### PR TITLE
Update spring.md

### DIFF
--- a/packages/docs/docs/spring.md
+++ b/packages/docs/docs/spring.md
@@ -50,13 +50,13 @@ _Default:_ `1`
 
 The weight of the spring. If you reduce the mass, the animation becomes faster!
 
-#### Damping
+#### damping
 
 _Default_: `10`
 
 How hard the animation decelerates.
 
-#### Stiffness
+#### stiffness
 
 _Default_: `100`
 


### PR DESCRIPTION
Small fix - the config keys got spring() are all lowercase. When copying them into my code, I was getting an error that the property did not exist in the type.