### PR TITLE
Update get-environment.ts

### DIFF
--- a/packages/core/src/get-environment.ts
+++ b/packages/core/src/get-environment.ts
@@ -13,14 +13,6 @@ export const getRemotionEnvironment = (): RemotionEnvironment => {
 		return 'rendering';
 	}
 
-	if (process.env.NODE_ENV === 'development') {
-		if (typeof window !== 'undefined' && window.remotion_isPlayer) {
-			return 'player-development';
-		}
-
-		return 'preview';
-	}
-
 	// The Jest framework sets NODE_ENV as test.
 	// Right now we don't need to treat it in a special
 	// way which is good - defaulting to `rendering`.
@@ -28,5 +20,9 @@ export const getRemotionEnvironment = (): RemotionEnvironment => {
 		return 'rendering';
 	}
 
-	throw new Error('Cannot determine Remotion environment');
+	if (typeof window !== 'undefined' && window.remotion_isPlayer) {
+		return 'player-development';
+	}
+
+	return 'preview';
 };


### PR DESCRIPTION
In ejected CRA apps, we cannot expect that process.env.NODE_ENV is set. Therefore we fall back to `development` and don't fail hard.

While rendering, we set it explicitly always.