### PR TITLE
fix example

### DIFF
--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -163,6 +163,7 @@ export const webpackConfig = ({
 				},
 				{
 					test: /\.jsx?$/,
+					exclude: /node_modules/,
 					use: [
 						{
 							loader: require.resolve('esbuild-loader'),


### PR DESCRIPTION
Fixes #453 

minor breaking change: it is expected that node modules are already compiled. we need to watch out for breakages but I think it's a good change, also speeds up bundling.