### PR TITLE
can render an audio with no inputs

### DIFF
--- a/packages/renderer/src/assets-to-ffmpeg-inputs.ts
+++ b/packages/renderer/src/assets-to-ffmpeg-inputs.ts
@@ -1,0 +1,21 @@
+export const assetsToFfmpegInputs = ({
+	assets,
+	isAudioOnly,
+	frameCount,
+	fps,
+}: {
+	assets: string[];
+	isAudioOnly: boolean;
+	frameCount: number;
+	fps: number;
+}): [string, string][] => {
+	if (isAudioOnly && assets.length === 0) {
+		return [
+			['-f', 'lavfi'],
+			['-i', 'anullsrc'],
+			['-t', (frameCount / fps).toFixed(4)],
+		];
+	}
+
+	return assets.map((path) => ['-i', path]);
+};

--- a/packages/renderer/src/stitcher.ts
+++ b/packages/renderer/src/stitcher.ts
@@ -7,6 +7,7 @@ import {
 	ProResProfile,
 	RenderAssetInfo,
 } from 'remotion';
+import {assetsToFfmpegInputs} from './assets-to-ffmpeg-inputs';
 import {calculateAssetPositions} from './assets/calculate-asset-positions';
 import {convertAssetsToFileUrls} from './assets/convert-assets-to-file-urls';
 import {markAllAssetsAsDownloaded} from './assets/download-and-map-assets-to-file';
@@ -104,11 +105,6 @@ export const stitchFramesToVideo = async (options: {
 	const assetPositions = calculateAssetPositions(fileUrlAssets);
 
 	const assetPaths = assetPositions.map((asset) => resolveAssetSrc(asset.src));
-	if (isAudioOnly && assetPaths.length === 0) {
-		throw new Error(
-			`Cannot render - you are trying to generate an audio file (${codec}) but your composition doesn't contain any audio.`
-		);
-	}
 
 	const assetAudioDetails = await getAssetAudioDetails({
 		assetPaths,
@@ -138,7 +134,12 @@ export const stitchFramesToVideo = async (options: {
 		frameInfo
 			? ['-i', `element-%0${frameInfo.numberLength}d.${imageFormat}`]
 			: null,
-		...assetPaths.map((path) => ['-i', path]),
+		...assetsToFfmpegInputs({
+			assets: assetPaths,
+			isAudioOnly,
+			fps: options.fps,
+			frameCount: options.assetsInfo.assets.length,
+		}),
 		encoderName
 			? // -c:v is the same as -vcodec as -codec:video
 			  // and specified the video codec.

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -272,10 +272,12 @@ test("Should fail to render an audio file that doesn't have any audio inputs", a
       reject: false,
     }
   );
-  expect(task.exitCode).toBe(process.platform === "win32" ? 0 : 1);
-  expect(task.stderr).toContain(
-    "Cannot render - you are trying to generate an audio file (mp3) but your composition doesn't contain any audio."
-  );
+  expect(task.exitCode).toBe(0);
+  const info = await execa("ffprobe", [out]);
+  const data = info.stderr;
+  expect(data).toContain("Duration: 00:00:00.37");
+  expect(data).toContain("Audio: mp3, 44100 Hz");
+  fs.unlinkSync(out);
 });
 
 test("Dynamic duration should work", async () => {


### PR DESCRIPTION
In lambda sometimes we need to generate a mp3 that has no sound. currently this is an error but it actually would make sense to support it.