### PR TITLE
Add emoji support to Dockerfile

### DIFF
--- a/packages/create-video/_template/Dockerfile
+++ b/packages/create-video/_template/Dockerfile
@@ -12,7 +12,8 @@ RUN apk add --no-cache \
   harfbuzz \
   ca-certificates \
   ttf-freefont \
-  ffmpeg
+  ffmpeg \
+  font-noto-emoji
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \


### PR DESCRIPTION
For context, there is only one emoji font supported by Alpine Linux: https://wiki.alpinelinux.org/wiki/Emojis
WIthout this change, emojis render as [?] characters.