### PR TITLE
chore: create font-display: swap issue demo

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,12 +4,18 @@ import {checkMultipleRemotionVersions} from './multiple-versions-warning';
 
 declare global {
 	interface Window {
-		ready: boolean;
 		getStaticCompositions: () => TCompMetadata[];
 		remotion_setFrame: (frame: number) => void;
 		remotion_collectAssets: () => TAsset[];
 		remotion_isPlayer: boolean;
 		remotion_imported: boolean;
+		remotion_handlesReady: boolean;
+		remotion_fontsReady: boolean;
+	}
+	interface Document {
+		fonts: {
+			ready: Promise<void>;
+		};
 	}
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,8 +13,8 @@ declare global {
 		remotion_fontsReady: boolean;
 	}
 	interface Document {
-		fonts: {
-			ready: Promise<void>;
+		fonts?: {
+			ready?: Promise<void>;
 		};
 	}
 }

--- a/packages/core/src/ready-manager.ts
+++ b/packages/core/src/ready-manager.ts
@@ -1,7 +1,16 @@
 import {getRemotionEnvironment} from './get-environment';
 
 if (typeof window !== 'undefined') {
-	window.ready = false;
+	window.remotion_handlesReady = false;
+	window.remotion_fontsReady = false;
+
+	document.fonts.ready
+		.then(() => {
+			window.remotion_fontsReady = true;
+		})
+		.catch(() => {
+			window.remotion_fontsReady = true;
+		});
 }
 
 let handles: number[] = [];
@@ -22,7 +31,7 @@ export const delayRender = (): number => {
 	}
 
 	if (typeof window !== 'undefined') {
-		window.ready = false;
+		window.remotion_handlesReady = false;
 	}
 
 	return handle;
@@ -41,6 +50,6 @@ export const continueRender = (handle: number): void => {
 		return true;
 	});
 	if (handles.length === 0 && typeof window !== 'undefined') {
-		window.ready = true;
+		window.remotion_handlesReady = true;
 	}
 };

--- a/packages/core/src/ready-manager.ts
+++ b/packages/core/src/ready-manager.ts
@@ -3,14 +3,20 @@ import {getRemotionEnvironment} from './get-environment';
 if (typeof window !== 'undefined') {
 	window.remotion_handlesReady = false;
 	window.remotion_fontsReady = false;
+}
 
-	document.fonts.ready
-		.then(() => {
-			window.remotion_fontsReady = true;
-		})
-		.catch(() => {
-			window.remotion_fontsReady = true;
-		});
+if (typeof document !== 'undefined') {
+	if (document.fonts?.ready) {
+		document.fonts.ready
+			.then(() => {
+				window.remotion_fontsReady = true;
+			})
+			.catch(() => {
+				window.remotion_fontsReady = true;
+			});
+	} else {
+		window.remotion_fontsReady = true;
+	}
 }
 
 let handles: number[] = [];

--- a/packages/core/src/test/ready-manager.test.ts
+++ b/packages/core/src/test/ready-manager.test.ts
@@ -3,25 +3,25 @@ import {continueRender, delayRender} from '../ready-manager';
 describe('Ready Manager tests', () => {
 	let handle: number;
 
-	test('delayRender sets window.ready to false', () => {
-		window.ready = true;
+	test('delayRender sets window.remotion_handlesReady to false', () => {
+		window.remotion_handlesReady = true;
 		handle = delayRender();
 		expect(typeof handle).toBe('number');
-		expect(window.ready).toBe(false);
+		expect(window.remotion_handlesReady).toBe(false);
 	});
 
-	test('continueRender sets window.ready to true', () => {
+	test('continueRender sets window.remotion_handlesReady to true', () => {
 		continueRender(handle);
-		expect(window.ready).toBe(true);
+		expect(window.remotion_handlesReady).toBe(true);
 	});
 
 	test('Render is only continued if all handles have been finished', () => {
 		handle = delayRender();
 		const handle2 = delayRender();
-		expect(window.ready).toBe(false);
+		expect(window.remotion_handlesReady).toBe(false);
 		continueRender(handle);
-		expect(window.ready).toBe(false);
+		expect(window.remotion_handlesReady).toBe(false);
 		continueRender(handle2);
-		expect(window.ready).toBe(true);
+		expect(window.remotion_handlesReady).toBe(true);
 	});
 });

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,7 +14,7 @@
 		"start-js": "remotion preview src/entry.jsx",
 		"test": "eslint src --ext ts,tsx,js,jsx",
 		"build": "tsc -d",
-		"render": "remotion render src/index.tsx react-svg video.mp4",
+		"render": "remotion render src/index.tsx beta-text video.mp4",
 		"render-js": "remotion render src/entry.jsx framer video.mp4",
 		"render-transparent": "remotion render src/index.tsx --image-format=png --pixel-format=yuva420p --codec=vp8 react-svg video.webm"
 	},

--- a/packages/example/remotion.config.ts
+++ b/packages/example/remotion.config.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import {Config, WebpackOverrideFn} from 'remotion';
 
 Config.Rendering.setConcurrency(os.cpus().length);
+Config.Rendering.setConcurrency(1);
 Config.Output.setOverwriteOutput(true);
 
 type Bundler = 'webpack' | 'esbuild';

--- a/packages/example/src/BetaText/font.css
+++ b/packages/example/src/BetaText/font.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css2?family=Bangers&display=swap');

--- a/packages/example/src/BetaText/index.tsx
+++ b/packages/example/src/BetaText/index.tsx
@@ -2,6 +2,7 @@ import {mix} from 'polished';
 import React from 'react';
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import styled from 'styled-components';
+import './font.css';
 
 const BRAND_GRADIENT = ['#5851db', '#405de6'];
 const solidBrand = mix(0.5, BRAND_GRADIENT[0], BRAND_GRADIENT[1]);
@@ -9,8 +10,7 @@ const Label = styled.span<{
 	outline: boolean;
 }>`
 	font-size: 120px;
-	font-family: ${(props) =>
-		props.outline ? 'Altero Outline' : 'Altero-Regular'};
+	font-family: Bangers;
 	text-align: center;
 	transform: scaleX(1);
 	line-height: 1em;

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -72,7 +72,9 @@ export const getCompositions = async (
 	});
 
 	await page.goto(`http://localhost:${port}/index.html?evaluation=true`);
-	await page.waitForFunction('window.ready === true');
+	await page.waitForFunction(
+		'window.remotion_handlesReady === true && window.remotion_fontsReady === true'
+	);
 	const result = await page.evaluate('window.getStaticCompositions()');
 
 	// Close web server and don't wait for it to finish,

--- a/packages/renderer/src/render.ts
+++ b/packages/renderer/src/render.ts
@@ -109,12 +109,26 @@ export const renderFrames = async ({
 			onError?.({error: err, frame: null});
 		};
 
+		await page.setCacheEnabled(false);
+		await page.setRequestInterception(true);
+		page.on('request', (request) => {
+			if (request.resourceType() !== 'font') {
+				request.continue();
+				return;
+			}
+
+			setTimeout(() => {
+				request.continue();
+			}, 3000);
+		});
 		page.on('pageerror', errorCallback);
 
 		await setPropsAndEnv({inputProps, envVariables, page, port});
 
 		const site = `http://localhost:${port}/index.html?composition=${compositionId}`;
 		await page.goto(site);
+		// Toggle the line below and render the video again
+		// await page.evaluateHandle('document.fonts.ready');
 		page.off('pageerror', errorCallback);
 		return page;
 	});

--- a/packages/renderer/src/seek-to-frame.ts
+++ b/packages/renderer/src/seek-to-frame.ts
@@ -7,9 +7,13 @@ export const seekToFrame = async ({
 	frame: number;
 	page: puppeteer.Page;
 }) => {
-	await page.waitForFunction('window.ready === true');
+	await page.waitForFunction(
+		'window.remotion_handlesReady === true && window.remotion_fontsReady === true'
+	);
 	await page.evaluate((f) => {
 		window.remotion_setFrame(f);
 	}, frame);
-	await page.waitForFunction('window.ready === true');
+	await page.waitForFunction(
+		'window.remotion_handlesReady === true && window.remotion_fontsReady === true'
+	);
 };

--- a/packages/renderer/src/test/get-assets-for-markup.tsx
+++ b/packages/renderer/src/test/get-assets-for-markup.tsx
@@ -16,7 +16,7 @@ const waitForWindowToBeReady = () => {
 	return new Promise<void>((resolve) => {
 		let interval: null | number | NodeJS.Timeout = null;
 		const check = () => {
-			if (window.ready) {
+			if (window.remotion_handlesReady) {
 				clearInterval(interval as number);
 				resolve();
 			}


### PR DESCRIPTION
Relates to [this comment](https://github.com/remotion-dev/remotion/issues/317#issuecomment-871690225).

## Steps to reproduce

- Clone this branch (arthurdenner:feat/wait-for-fonts)
- Run `npm run build -- --watch` in the `packages/renderer` folder
- Run `npm run render` in the `packages/example` folder

This will (hopefully) give you a video with a delayed font swapping, like the one below.
PS: You may need to run the `render` two times - maybe some cache in the build process?

<details><summary>Video</summary>

https://user-images.githubusercontent.com/13774309/124334814-9702ff00-db98-11eb-8a41-f64a572332a2.mp4

</details>

- Uncomment the `await page.evaluateHandle('document.fonts.ready');` line ([ref](https://github.com/arthurdenner/remotion/blob/feat/wait-for-fonts/packages/renderer/src/render.ts#L131));
- Verify the `npm run build -- --watch` output was updated just in case
- Run `npm run render` in the `packages/example` folder

This will (hopefully) give you a video *without* a delayed font swapping, like the one below, because we postpone rendering frames until fonts are ready.
PS: You may need to run the `render` two times - maybe some cache in the build process?

<details><summary>Video</summary>

https://user-images.githubusercontent.com/13774309/124334972-0e389300-db99-11eb-840e-f4cdf3696d0e.mp4

</details>

You can comment and uncomment the `await page.evaluateHandle('document.fonts.ready');` line a few times.
I was able to reproduce the bug and verify the proposed fix many times but sometimes I had to `npm run render` twice as mentioned above.