### PR TITLE
fix: await document.fonts.ready when rendering video

### DIFF
--- a/packages/renderer/src/render.ts
+++ b/packages/renderer/src/render.ts
@@ -115,6 +115,7 @@ export const renderFrames = async ({
 
 		const site = `http://localhost:${port}/index.html?composition=${compositionId}`;
 		await page.goto(site);
+		await page.evaluateHandle('document.fonts.ready');
 		page.off('pageerror', errorCallback);
 		return page;
 	});

--- a/packages/renderer/src/render.ts
+++ b/packages/renderer/src/render.ts
@@ -115,7 +115,6 @@ export const renderFrames = async ({
 
 		const site = `http://localhost:${port}/index.html?composition=${compositionId}`;
 		await page.goto(site);
-		await page.evaluateHandle('document.fonts.ready');
 		page.off('pageerror', errorCallback);
 		return page;
 	});

--- a/packages/renderer/src/seek-to-frame.ts
+++ b/packages/renderer/src/seek-to-frame.ts
@@ -12,4 +12,5 @@ export const seekToFrame = async ({
 		window.remotion_setFrame(f);
 	}, frame);
 	await page.waitForFunction('window.ready === true');
+	await page.evaluateHandle('document.fonts.ready');
 };


### PR DESCRIPTION
Closes #317. Some discussion and context can be found at #486.

`document.fonts.ready` is a Promise that resolves when all of the fonts of a page are loaded ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Document/fonts)).


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#317: [Idea] Detect/fix font-display: swap](https://issuehunt.io/repos/274495425/issues/317)
---
</details>
<!-- /Issuehunt content-->