### PR TITLE
Change reference from remotion.config.ts to remotion.config.js

### DIFF
--- a/packages/docs/docs/overwriting-webpack-config.md
+++ b/packages/docs/docs/overwriting-webpack-config.md
@@ -7,7 +7,7 @@ import Tabs from "@theme/Tabs";
 
 You can customize the Webpack configuration if you have at least Version 1.1 of Remotion.
 
-Create a config file called `remotion.config.ts` in the root of your project. As a confirmation, you should get a console message `Applied configuration from [configuration-file]`.
+Create a config file called `remotion.config.js` in the root of your project. As a confirmation, you should get a console message `Applied configuration from [configuration-file]`.
 
 ## Overriding the webpack config
 


### PR DESCRIPTION
I found that using `.ts` didn't pick up the config file, but `.js` worked.

