### PR TITLE
[Player] Space key press to toggle play and pause if the video element is focused.

### DIFF
--- a/packages/docs/docs/player.md
+++ b/packages/docs/docs/player.md
@@ -115,7 +115,7 @@ A boolean property defining whether you can go fullscreen and exit fullscreen in
 
 _optional_
 
-A boolean property defining whether you can play or pause a video using space key. If enabled, clicking on the video focus and subsequent space key actions play or pause the video. Default `true`.
+A boolean property defining whether you can play or pause a video using space key. If enabled, playing the video and subsequently pressing the space key pauses and resumes the video. Default `true`.
 
 ### `inputProps`
 

--- a/packages/docs/docs/player.md
+++ b/packages/docs/docs/player.md
@@ -111,7 +111,7 @@ _optional_
 
 A boolean property defining whether you can go fullscreen and exit fullscreen in the video with double click into the player. If enabled, clicking on the video once will delay pausing the video for 200ms to wait for a possible second click. Default `false`.
 
-### `spaceKeyPressPlayOrPause`
+### `spaceKeyToPlayOrPause`
 
 _optional_
 

--- a/packages/docs/docs/player.md
+++ b/packages/docs/docs/player.md
@@ -111,6 +111,12 @@ _optional_
 
 A boolean property defining whether you can go fullscreen and exit fullscreen in the video with double click into the player. If enabled, clicking on the video once will delay pausing the video for 200ms to wait for a possible second click. Default `false`.
 
+### `spaceKeyPressPlayOrPause`
+
+_optional_
+
+A boolean property defining whether you can play or pause a video using space key. If enabled, clicking on the video focus and subsequent space key actions play or pause the video. Default `true`.
+
 ### `inputProps`
 
 _optional_

--- a/packages/player-example/src/App.tsx
+++ b/packages/player-example/src/App.tsx
@@ -10,6 +10,7 @@ export default function App() {
 	const [doubleClickToFullscreen, setDoubleClickToFullscreen] = useState(true);
 	const [clickToPlay, setClickToPlay] = useState(true);
 	const [logs, setLogs] = useState<string[]>(() => []);
+	const [spaceKeyPressPlayOrPause, setSpaceKeyPressPlayOrPause] = useState(true);
 
 	const ref = useRef<PlayerRef>(null);
 
@@ -53,6 +54,7 @@ export default function App() {
 					bgColor: String(bgColor),
 					color: String(color),
 				}}
+				spaceKeyPressPlayOrPause={spaceKeyPressPlayOrPause}
 			/>
 			<div style={{paddingTop: '0.5rem'}}>
 				Enter Text{' '}
@@ -157,6 +159,12 @@ export default function App() {
 				}
 			>
 				log volume
+			</button>
+			<button
+				type="button"
+				onClick={() => setSpaceKeyPressPlayOrPause((l) => !l)}
+			>
+				spaceKeyPressPlayOrPause = {String(spaceKeyPressPlayOrPause)}
 			</button>
 			<br />
 			<br />

--- a/packages/player-example/src/App.tsx
+++ b/packages/player-example/src/App.tsx
@@ -10,8 +10,7 @@ export default function App() {
 	const [doubleClickToFullscreen, setDoubleClickToFullscreen] = useState(true);
 	const [clickToPlay, setClickToPlay] = useState(true);
 	const [logs, setLogs] = useState<string[]>(() => []);
-	const [spaceKeyPressPlayOrPause, setSpaceKeyPressPlayOrPause] =
-		useState(true);
+	const [spaceKeyToPlayOrPause, setspaceKeyToPlayOrPause] = useState(true);
 
 	const ref = useRef<PlayerRef>(null);
 
@@ -55,7 +54,7 @@ export default function App() {
 					bgColor: String(bgColor),
 					color: String(color),
 				}}
-				spaceKeyPressPlayOrPause={spaceKeyPressPlayOrPause}
+				spaceKeyToPlayOrPause={spaceKeyToPlayOrPause}
 			/>
 			<div style={{paddingTop: '0.5rem'}}>
 				Enter Text{' '}
@@ -161,11 +160,8 @@ export default function App() {
 			>
 				log volume
 			</button>
-			<button
-				type="button"
-				onClick={() => setSpaceKeyPressPlayOrPause((l) => !l)}
-			>
-				spaceKeyPressPlayOrPause = {String(spaceKeyPressPlayOrPause)}
+			<button type="button" onClick={() => setspaceKeyToPlayOrPause((l) => !l)}>
+				spaceKeyToPlayOrPause = {String(spaceKeyToPlayOrPause)}
 			</button>
 			<br />
 			<br />

--- a/packages/player-example/src/App.tsx
+++ b/packages/player-example/src/App.tsx
@@ -10,7 +10,8 @@ export default function App() {
 	const [doubleClickToFullscreen, setDoubleClickToFullscreen] = useState(true);
 	const [clickToPlay, setClickToPlay] = useState(true);
 	const [logs, setLogs] = useState<string[]>(() => []);
-	const [spaceKeyPressPlayOrPause, setSpaceKeyPressPlayOrPause] = useState(true);
+	const [spaceKeyPressPlayOrPause, setSpaceKeyPressPlayOrPause] =
+		useState(true);
 
 	const ref = useRef<PlayerRef>(null);
 

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -46,6 +46,7 @@ export type PlayerProps<T> = {
 	allowFullscreen?: boolean;
 	clickToPlay?: boolean;
 	doubleClickToFullscreen?: boolean;
+	spaceKeyPressPlayOrPause?: boolean;
 } & PropsIfHasProps<T> &
 	CompProps<T>;
 
@@ -68,6 +69,7 @@ export const PlayerFn = <T,>(
 		allowFullscreen = true,
 		clickToPlay,
 		doubleClickToFullscreen = false,
+		spaceKeyPressPlayOrPause = true,
 		...componentProps
 	}: PlayerProps<T>,
 	ref: MutableRefObject<PlayerRef>
@@ -162,6 +164,15 @@ export const PlayerFn = <T,>(
 	if (typeof clickToPlay !== 'boolean' && typeof clickToPlay !== 'undefined') {
 		throw new TypeError(
 			`'clickToPlay' must be a boolean or undefined but got '${typeof clickToPlay}' instead`
+		);
+	}
+
+	if (
+		typeof spaceKeyPressPlayOrPause !== 'boolean' &&
+		typeof spaceKeyPressPlayOrPause !== 'undefined'
+	) {
+		throw new TypeError(
+			`'spaceKeyPressPlayOrPause' must be a boolean or undefined but got '${typeof spaceKeyPressPlayOrPause}' instead`
 		);
 	}
 
@@ -277,6 +288,7 @@ export const PlayerFn = <T,>(
 									mediaMuted={mediaMuted}
 									doubleClickToFullscreen={Boolean(doubleClickToFullscreen)}
 									setMediaMuted={setMediaMuted}
+									spaceKeyPressPlayOrPause={Boolean(spaceKeyPressPlayOrPause)}
 								/>
 							</PlayerEventEmitterContext.Provider>
 						</Internals.SetMediaVolumeContext.Provider>

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -46,7 +46,7 @@ export type PlayerProps<T> = {
 	allowFullscreen?: boolean;
 	clickToPlay?: boolean;
 	doubleClickToFullscreen?: boolean;
-	spaceKeyPressPlayOrPause?: boolean;
+	spaceKeyToPlayOrPause?: boolean;
 } & PropsIfHasProps<T> &
 	CompProps<T>;
 
@@ -69,7 +69,7 @@ export const PlayerFn = <T,>(
 		allowFullscreen = true,
 		clickToPlay,
 		doubleClickToFullscreen = false,
-		spaceKeyPressPlayOrPause = true,
+		spaceKeyToPlayOrPause = true,
 		...componentProps
 	}: PlayerProps<T>,
 	ref: MutableRefObject<PlayerRef>
@@ -168,11 +168,11 @@ export const PlayerFn = <T,>(
 	}
 
 	if (
-		typeof spaceKeyPressPlayOrPause !== 'boolean' &&
-		typeof spaceKeyPressPlayOrPause !== 'undefined'
+		typeof spaceKeyToPlayOrPause !== 'boolean' &&
+		typeof spaceKeyToPlayOrPause !== 'undefined'
 	) {
 		throw new TypeError(
-			`'spaceKeyPressPlayOrPause' must be a boolean or undefined but got '${typeof spaceKeyPressPlayOrPause}' instead`
+			`'spaceKeyToPlayOrPause' must be a boolean or undefined but got '${typeof spaceKeyToPlayOrPause}' instead`
 		);
 	}
 
@@ -288,7 +288,7 @@ export const PlayerFn = <T,>(
 									mediaMuted={mediaMuted}
 									doubleClickToFullscreen={Boolean(doubleClickToFullscreen)}
 									setMediaMuted={setMediaMuted}
-									spaceKeyPressPlayOrPause={Boolean(spaceKeyPressPlayOrPause)}
+									spaceKeyToPlayOrPause={Boolean(spaceKeyToPlayOrPause)}
 								/>
 							</PlayerEventEmitterContext.Provider>
 						</Internals.SetMediaVolumeContext.Provider>

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -80,7 +80,7 @@ export const Controls: React.FC<{
 	isFullscreen: boolean;
 	allowFullscreen: boolean;
 	onExitFullscreenButtonClick: MouseEventHandler<HTMLButtonElement>;
-	spaceKeyPressPlayOrPause: boolean;
+	spaceKeyToPlayOrPause: boolean;
 }> = ({
 	durationInFrames,
 	hovered,
@@ -91,7 +91,7 @@ export const Controls: React.FC<{
 	onFullscreenButtonClick,
 	allowFullscreen,
 	onExitFullscreenButtonClick,
-	spaceKeyPressPlayOrPause,
+	spaceKeyToPlayOrPause,
 }) => {
 	const playButtonRef = useRef<HTMLButtonElement | null>(null);
 	const frame = Internals.Timeline.useTimelinePosition();
@@ -106,11 +106,11 @@ export const Controls: React.FC<{
 	}, [hovered, player.playing]);
 
 	useEffect(() => {
-		if (playButtonRef.current && spaceKeyPressPlayOrPause) {
+		if (playButtonRef.current && spaceKeyToPlayOrPause) {
 			// This switches focus to play button when player.playing flag changes
 			playButtonRef.current.focus();
 		}
-	}, [player.playing, spaceKeyPressPlayOrPause]);
+	}, [player.playing, spaceKeyToPlayOrPause]);
 
 	return (
 		<div style={containerCss}>

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -1,4 +1,6 @@
 import React, {MouseEventHandler, useMemo} from 'react';
+import { useEffect } from 'react';
+import { useRef } from 'react';
 import {Internals} from 'remotion';
 import {formatTime} from './format-time';
 import {FullscreenIcon, PauseIcon, PlayIcon} from './icons';
@@ -91,6 +93,7 @@ export const Controls: React.FC<{
 	allowFullscreen,
 	onExitFullscreenButtonClick,
 }) => {
+	const playButtonRef = useRef<HTMLButtonElement | null>(null);
 	const frame = Internals.Timeline.useTimelinePosition();
 
 	const containerCss: React.CSSProperties = useMemo(() => {
@@ -102,11 +105,19 @@ export const Controls: React.FC<{
 		};
 	}, [hovered, player.playing]);
 
+	useEffect(() => {
+		if(playButtonRef.current) {
+			// This switches focus to play button when player.playing flag changes
+			playButtonRef.current.focus();
+		}
+	}, [player.playing])
+
 	return (
 		<div style={containerCss}>
 			<div style={controlsRow}>
 				<div style={leftPartStyle}>
 					<button
+						ref={playButtonRef}
 						type="button"
 						style={buttonStyle}
 						onClick={player.playing ? player.pause : player.play}

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -80,6 +80,7 @@ export const Controls: React.FC<{
 	isFullscreen: boolean;
 	allowFullscreen: boolean;
 	onExitFullscreenButtonClick: MouseEventHandler<HTMLButtonElement>;
+	spaceKeyPressPlayOrPause: boolean;
 }> = ({
 	durationInFrames,
 	hovered,
@@ -90,6 +91,7 @@ export const Controls: React.FC<{
 	onFullscreenButtonClick,
 	allowFullscreen,
 	onExitFullscreenButtonClick,
+	spaceKeyPressPlayOrPause,
 }) => {
 	const playButtonRef = useRef<HTMLButtonElement | null>(null);
 	const frame = Internals.Timeline.useTimelinePosition();
@@ -104,11 +106,11 @@ export const Controls: React.FC<{
 	}, [hovered, player.playing]);
 
 	useEffect(() => {
-		if (playButtonRef.current) {
+		if (playButtonRef.current && spaceKeyPressPlayOrPause) {
 			// This switches focus to play button when player.playing flag changes
 			playButtonRef.current.focus();
 		}
-	}, [player.playing]);
+	}, [player.playing, spaceKeyPressPlayOrPause]);
 
 	return (
 		<div style={containerCss}>

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -1,6 +1,4 @@
-import React, {MouseEventHandler, useMemo} from 'react';
-import { useEffect } from 'react';
-import { useRef } from 'react';
+import React, {MouseEventHandler, useEffect, useMemo, useRef} from 'react';
 import {Internals} from 'remotion';
 import {formatTime} from './format-time';
 import {FullscreenIcon, PauseIcon, PlayIcon} from './icons';
@@ -106,11 +104,11 @@ export const Controls: React.FC<{
 	}, [hovered, player.playing]);
 
 	useEffect(() => {
-		if(playButtonRef.current) {
+		if (playButtonRef.current) {
 			// This switches focus to play button when player.playing flag changes
 			playButtonRef.current.focus();
 		}
-	}, [player.playing])
+	}, [player.playing]);
 
 	return (
 		<div style={containerCss}>

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -38,7 +38,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		style?: React.CSSProperties;
 		clickToPlay: boolean;
 		doubleClickToFullscreen: boolean;
-		spaceKeyPressPlayOrPause: boolean;
+		spaceKeyToPlayOrPause: boolean;
 		setMediaVolume: (v: number) => void;
 		setMediaMuted: (v: boolean) => void;
 		mediaVolume: number;
@@ -58,7 +58,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		doubleClickToFullscreen,
 		setMediaMuted,
 		setMediaVolume,
-		spaceKeyPressPlayOrPause,
+		spaceKeyToPlayOrPause,
 	},
 	ref
 ) => {
@@ -358,7 +358,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 					allowFullscreen={allowFullscreen}
 					showVolumeControls={showVolumeControls}
 					onExitFullscreenButtonClick={onExitFullscreenButtonClick}
-					spaceKeyPressPlayOrPause={spaceKeyPressPlayOrPause}
+					spaceKeyToPlayOrPause={spaceKeyToPlayOrPause}
 				/>
 			) : null}
 		</div>

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -318,21 +318,24 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		doubleClickToFullscreen
 	);
 
-	const onKeyPress = useCallback((e: React.KeyboardEvent<HTMLDivElement>): void => {
-		// Handle space key to pause / play the video
-		if (e.which === 32) {
-			if(!spaceKeyPressPlayOrPause) {
-				return;
-			}
+	const onKeyPress = useCallback(
+		(e: React.KeyboardEvent<HTMLDivElement>): void => {
+			// Handle space key to pause / play the video
+			if (e.which === 32) {
+				if (!spaceKeyPressPlayOrPause) {
+					return;
+				}
 
-			if(!player.playing) {
-				player.play();
-				return;
-			}
+				if (!player.playing) {
+					player.play();
+					return;
+				}
 
-			player.pause();
-    }
-	}, [spaceKeyPressPlayOrPause, player])
+				player.pause();
+			}
+		},
+		[spaceKeyPressPlayOrPause, player]
+	);
 
 	useEffect(() => {
 		if (shouldAutoplay) {

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -318,25 +318,6 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		doubleClickToFullscreen
 	);
 
-	const onKeyPress = useCallback(
-		(e: React.KeyboardEvent<HTMLDivElement>): void => {
-			// Handle space key to pause / play the video
-			if (e.which === 32) {
-				if (!spaceKeyPressPlayOrPause) {
-					return;
-				}
-
-				if (!player.playing) {
-					player.play();
-					return;
-				}
-
-				player.pause();
-			}
-		},
-		[spaceKeyPressPlayOrPause, player]
-	);
-
 	useEffect(() => {
 		if (shouldAutoplay) {
 			player.play();
@@ -351,7 +332,6 @@ const PlayerUI: React.ForwardRefRenderFunction<
 	const content = (
 		<div ref={container} style={outerStyle}>
 			<div
-				onKeyPress={onKeyPress}
 				style={outer}
 				onClick={clickToPlay ? handleClick : undefined}
 				onDoubleClick={doubleClickToFullscreen ? handleDoubleClick : undefined}
@@ -378,6 +358,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 					allowFullscreen={allowFullscreen}
 					showVolumeControls={showVolumeControls}
 					onExitFullscreenButtonClick={onExitFullscreenButtonClick}
+					spaceKeyPressPlayOrPause={spaceKeyPressPlayOrPause}
 				/>
 			) : null}
 		</div>

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -38,6 +38,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		style?: React.CSSProperties;
 		clickToPlay: boolean;
 		doubleClickToFullscreen: boolean;
+		spaceKeyPressPlayOrPause: boolean;
 		setMediaVolume: (v: number) => void;
 		setMediaMuted: (v: boolean) => void;
 		mediaVolume: number;
@@ -57,6 +58,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		doubleClickToFullscreen,
 		setMediaMuted,
 		setMediaVolume,
+		spaceKeyPressPlayOrPause,
 	},
 	ref
 ) => {
@@ -316,6 +318,22 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		doubleClickToFullscreen
 	);
 
+	const onKeyPress = useCallback((e: React.KeyboardEvent<HTMLDivElement>): void => {
+		// Handle space key to pause / play the video
+		if (e.which === 32) {
+			if(!spaceKeyPressPlayOrPause) {
+				return;
+			}
+
+			if(!player.playing) {
+				player.play();
+				return;
+			}
+
+			player.pause();
+    }
+	}, [spaceKeyPressPlayOrPause, player])
+
 	useEffect(() => {
 		if (shouldAutoplay) {
 			player.play();
@@ -330,6 +348,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 	const content = (
 		<div ref={container} style={outerStyle}>
 			<div
+				onKeyPress={onKeyPress}
 				style={outer}
 				onClick={clickToPlay ? handleClick : undefined}
 				onDoubleClick={doubleClickToFullscreen ? handleDoubleClick : undefined}


### PR DESCRIPTION
Fixes #342 

By default `onClick` event on `play/pause` control key is fired on keypress on space bar. Here we are now changing focus to `play/pause` controller button if `player.playing` status changes. So that this will `play/pause` the current video in focus. This behaviour can be enabled or disabled with `spaceKeyPressPlayOrPause` flag.


![Screen Cast 2021-07-11 at 6 34 21 PM](https://user-images.githubusercontent.com/10515204/125196232-b2e06200-e276-11eb-935b-19a86a501b5b.gif)

 
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
