### PR TITLE
[Docs] Updates Default From Argument Value To 0

### DIFF
--- a/packages/docs/docs/measure-spring.md
+++ b/packages/docs/docs/measure-spring.md
@@ -50,7 +50,7 @@ The spring configuration that you pass to [spring()](/docs/spring#config).
 
 ### `from?`
 
-_optional - default: `1`_
+_optional - default: `0`_
 
 The initial value of the animation.
 


### PR DESCRIPTION
I was reading the documentation and noticed that it says 1 for the default value for the `from` argument. 
Code has it as 0: https://github.com/remotion-dev/remotion/blob/main/packages/core/src/spring/measure-spring.ts#L8

Thanks for making Remotion!
