### PR TITLE
feat(💄): Add support for defaultProps in Composition

### DIFF
--- a/packages/core/src/Composition.tsx
+++ b/packages/core/src/Composition.tsx
@@ -12,24 +12,24 @@ import {validateDimension} from './validation/validate-dimensions';
 import {validateDurationInFrames} from './validation/validate-duration-in-frames';
 import {validateFps} from './validation/validate-fps';
 
-export type CompProps<T> =
+export type CompProps<C extends AnyComponent> =
 	| {
-			lazyComponent: () => Promise<{default: AnyComponent<T>}>;
+			lazyComponent: () => Promise<{default: C}>;
 	  }
 	| {
-			component: AnyComponent<T>;
+			component: C;
 	  };
 
-type Props<T> = {
+type Props<C extends AnyComponent> = {
 	width: number;
 	height: number;
 	fps: number;
 	durationInFrames: number;
 	id: string;
-	defaultProps?: T;
-} & CompProps<T>;
+        defaultProps?: Omit<P, keyof C["defaultProps"]>;
+} & CompProps<C>;
 
-export const Composition = <T,>({
+export const Composition = <C extends AnyComponent,>({
 	width,
 	height,
 	fps,
@@ -37,7 +37,7 @@ export const Composition = <T,>({
 	id,
 	defaultProps: props,
 	...compProps
-}: Props<T>) => {
+}: Props<C>) => {
 	const {registerComposition, unregisterComposition} = useContext(
 		CompositionManager
 	);


### PR DESCRIPTION
The goal of this PR is to add support for default props in Composition.

```tsx
interface HelloProps {
  hello: number;
  world: number;
}

const Hello = ({hello, world}: HelloProps) => (<p>{hello} {world}</p>);
Hello.defaultProps = {
  hello: "Hello"
};

      <Composition
        id="Main"
        component={Hello}
        durationInFrames={100}
        fps={30}
        width={3840}
        height={2160}
        defaultProps={{
          world: "Jonny 🙋🏼‍♂️"
        }}
      />
```