### PR TITLE
Prevent seekbar from loosing position after resizing browser window

### DIFF
--- a/packages/cli/src/editor/components/Canvas.tsx
+++ b/packages/cli/src/editor/components/Canvas.tsx
@@ -13,7 +13,7 @@ export const Container = styled.div`
 export const Canvas: React.FC = () => {
 	const ref = useRef<HTMLDivElement>(null);
 
-	const size = PlayerInternals.useElementSize(ref);
+	const size = PlayerInternals.useElementSize(ref, false);
 
 	return (
 		<Container ref={ref}>

--- a/packages/cli/src/editor/components/Canvas.tsx
+++ b/packages/cli/src/editor/components/Canvas.tsx
@@ -13,7 +13,9 @@ export const Container = styled.div`
 export const Canvas: React.FC = () => {
 	const ref = useRef<HTMLDivElement>(null);
 
-	const size = PlayerInternals.useElementSize(ref, false);
+	const size = PlayerInternals.useElementSize(ref, {
+		triggerOnWindowResize: false,
+	});
 
 	return (
 		<Container ref={ref}>

--- a/packages/cli/src/editor/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineDragHandler.tsx
@@ -40,7 +40,7 @@ const getFrameFromX = (
 };
 
 export const TimelineDragHandler: React.FC = ({children}) => {
-	const size = PlayerInternals.useElementSize(sliderAreaRef);
+	const size = PlayerInternals.useElementSize(sliderAreaRef, false);
 	const width = size?.width ?? 0;
 	const left = size?.left ?? 0;
 	const [dragging, setDragging] = useState<

--- a/packages/cli/src/editor/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineDragHandler.tsx
@@ -40,7 +40,9 @@ const getFrameFromX = (
 };
 
 export const TimelineDragHandler: React.FC = ({children}) => {
-	const size = PlayerInternals.useElementSize(sliderAreaRef, false);
+	const size = PlayerInternals.useElementSize(sliderAreaRef, {
+		triggerOnWindowResize: true,
+	});
 	const width = size?.width ?? 0;
 	const left = size?.left ?? 0;
 	const [dragging, setDragging] = useState<

--- a/packages/cli/src/editor/components/Timeline/TimelineSequence.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineSequence.tsx
@@ -20,7 +20,7 @@ export const TimelineSequence: React.FC<{
 	s: TSequence;
 	fps: number;
 }> = ({s, fps}) => {
-	const size = PlayerInternals.useElementSize(sliderAreaRef);
+	const size = PlayerInternals.useElementSize(sliderAreaRef, false);
 	const {richTimeline} = useContext(RichTimelineContext);
 
 	const windowWidth = size?.width ?? 0;

--- a/packages/cli/src/editor/components/Timeline/TimelineSequence.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineSequence.tsx
@@ -20,7 +20,9 @@ export const TimelineSequence: React.FC<{
 	s: TSequence;
 	fps: number;
 }> = ({s, fps}) => {
-	const size = PlayerInternals.useElementSize(sliderAreaRef, false);
+	const size = PlayerInternals.useElementSize(sliderAreaRef, {
+		triggerOnWindowResize: false,
+	});
 	const {richTimeline} = useContext(RichTimelineContext);
 
 	const windowWidth = size?.width ?? 0;

--- a/packages/cli/src/editor/components/Timeline/TimelineSlider.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineSlider.tsx
@@ -22,7 +22,7 @@ const Line = styled.div`
 export const TimelineSlider: React.FC = () => {
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const videoConfig = Internals.useUnsafeVideoConfig();
-	const size = PlayerInternals.useElementSize(sliderAreaRef);
+	const size = PlayerInternals.useElementSize(sliderAreaRef, false);
 	const width = size?.width ?? 0;
 
 	if (!videoConfig) {

--- a/packages/cli/src/editor/components/Timeline/TimelineSlider.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineSlider.tsx
@@ -22,7 +22,9 @@ const Line = styled.div`
 export const TimelineSlider: React.FC = () => {
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const videoConfig = Internals.useUnsafeVideoConfig();
-	const size = PlayerInternals.useElementSize(sliderAreaRef, false);
+	const size = PlayerInternals.useElementSize(sliderAreaRef, {
+		triggerOnWindowResize: false,
+	});
 	const width = size?.width ?? 0;
 
 	if (!videoConfig) {

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -65,7 +65,7 @@ export const MediaVolumeSlider: React.FC = () => {
 	const currentRef = useRef<HTMLDivElement>(null);
 	const iconDivRef = useRef<HTMLDivElement>(null);
 	const parentDivRef = useRef<HTMLDivElement>(null);
-	const size = useElementSize(currentRef);
+	const size = useElementSize(currentRef, false);
 	const hover = useHoverState(parentDivRef);
 
 	const hoverOrDragging = hover || dragging;

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -65,7 +65,7 @@ export const MediaVolumeSlider: React.FC = () => {
 	const currentRef = useRef<HTMLDivElement>(null);
 	const iconDivRef = useRef<HTMLDivElement>(null);
 	const parentDivRef = useRef<HTMLDivElement>(null);
-	const size = useElementSize(currentRef, false);
+	const size = useElementSize(currentRef, {triggerOnWindowResize: true});
 	const hover = useHoverState(parentDivRef);
 
 	const hoverOrDragging = hover || dragging;

--- a/packages/player/src/PlayerSeekBar.tsx
+++ b/packages/player/src/PlayerSeekBar.tsx
@@ -45,7 +45,7 @@ export const PlayerSeekBar: React.FC<{
 }> = ({durationInFrames}) => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const barHovered = useHoverState(containerRef);
-	const size = useElementSize(containerRef);
+	const size = useElementSize(containerRef, true);
 	const {seek, play, pause, playing} = usePlayer();
 	const frame = Internals.Timeline.useTimelinePosition();
 

--- a/packages/player/src/PlayerSeekBar.tsx
+++ b/packages/player/src/PlayerSeekBar.tsx
@@ -45,7 +45,7 @@ export const PlayerSeekBar: React.FC<{
 }> = ({durationInFrames}) => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const barHovered = useHoverState(containerRef);
-	const size = useElementSize(containerRef, true);
+	const size = useElementSize(containerRef, {triggerOnWindowResize: true});
 	const {seek, play, pause, playing} = usePlayer();
 	const frame = Internals.Timeline.useTimelinePosition();
 

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -66,7 +66,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 	const video = Internals.useVideo();
 	const container = useRef<HTMLDivElement>(null);
 	const hovered = useHoverState(container);
-	const canvasSize = useElementSize(container);
+	const canvasSize = useElementSize(container, false);
 
 	const [hasPausedToResume, setHasPausedToResume] = useState(false);
 	const [shouldAutoplay, setShouldAutoPlay] = useState(autoPlay);

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -66,7 +66,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 	const video = Internals.useVideo();
 	const container = useRef<HTMLDivElement>(null);
 	const hovered = useHoverState(container);
-	const canvasSize = useElementSize(container, false);
+	const canvasSize = useElementSize(container, {triggerOnWindowResize: false});
 
 	const [hasPausedToResume, setHasPausedToResume] = useState(false);
 	const [shouldAutoplay, setShouldAutoPlay] = useState(autoPlay);

--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -9,7 +9,7 @@ export type Size = {
 
 export const useElementSize = (
 	ref: React.RefObject<HTMLDivElement>,
-  triggerOnWindowResize: boolean
+	triggerOnWindowResize: boolean
 ): Size | null => {
 	const [size, setSize] = useState<Size | null>(null);
 	const observer = useMemo(() => {
@@ -55,23 +55,23 @@ export const useElementSize = (
 		if (!observer) {
 			return;
 		}
-        
+
 		updateSize();
 		const {current} = ref;
 		if (ref.current) {
 			observer.observe(ref.current);
 		}
 
-    if (triggerOnWindowResize) {
-      window.addEventListener("resize", updateSize);
-    }
+		if (triggerOnWindowResize) {
+			window.addEventListener('resize', updateSize);
+		}
 
 		return (): void => {
 			if (current) {
 				observer.unobserve(current);
-        if (triggerOnWindowResize) {
-          window.removeEventListener("resize", updateSize) 
-        }
+				if (triggerOnWindowResize) {
+					window.removeEventListener('resize', updateSize);
+				}
 			}
 		};
 	}, [observer, ref, updateSize, triggerOnWindowResize]);

--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -69,7 +69,7 @@ export const useElementSize = (
 				observer.unobserve(current);
 			}
 		};
-	}, [observer, ref, updateSize, options.triggerOnWindowResize]);
+	}, [observer, ref, updateSize]);
 
 	useEffect(() => {
 		if (!options.triggerOnWindowResize) {

--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -9,7 +9,9 @@ export type Size = {
 
 export const useElementSize = (
 	ref: React.RefObject<HTMLDivElement>,
-	triggerOnWindowResize: boolean
+	options: {
+		triggerOnWindowResize: boolean;
+	}
 ): Size | null => {
 	const [size, setSize] = useState<Size | null>(null);
 	const observer = useMemo(() => {
@@ -62,18 +64,18 @@ export const useElementSize = (
 			observer.observe(ref.current);
 		}
 
-		if (triggerOnWindowResize) {
+		if (options.triggerOnWindowResize) {
 			window.addEventListener('resize', updateSize);
 		}
 
 		return (): void => {
 			if (current) {
 				observer.unobserve(current);
-				if (triggerOnWindowResize) {
+				if (options.triggerOnWindowResize) {
 					window.removeEventListener('resize', updateSize);
 				}
 			}
 		};
-	}, [observer, ref, updateSize, triggerOnWindowResize]);
+	}, [observer, ref, updateSize, options.triggerOnWindowResize]);
 	return size;
 };

--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -8,7 +8,8 @@ export type Size = {
 };
 
 export const useElementSize = (
-	ref: React.RefObject<HTMLDivElement>
+	ref: React.RefObject<HTMLDivElement>,
+  triggerOnWindowResize: boolean
 ): Size | null => {
 	const [size, setSize] = useState<Size | null>(null);
 	const observer = useMemo(() => {
@@ -54,18 +55,25 @@ export const useElementSize = (
 		if (!observer) {
 			return;
 		}
-
+        
 		updateSize();
 		const {current} = ref;
 		if (ref.current) {
 			observer.observe(ref.current);
 		}
 
+    if (triggerOnWindowResize) {
+      window.addEventListener("resize", updateSize);
+    }
+
 		return (): void => {
 			if (current) {
 				observer.unobserve(current);
+        if (triggerOnWindowResize) {
+          window.removeEventListener("resize", updateSize) 
+        }
 			}
 		};
-	}, [observer, ref, updateSize]);
+	}, [observer, ref, updateSize, triggerOnWindowResize]);
 	return size;
 };

--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -64,18 +64,24 @@ export const useElementSize = (
 			observer.observe(ref.current);
 		}
 
-		if (options.triggerOnWindowResize) {
-			window.addEventListener('resize', updateSize);
-		}
-
 		return (): void => {
 			if (current) {
 				observer.unobserve(current);
-				if (options.triggerOnWindowResize) {
-					window.removeEventListener('resize', updateSize);
-				}
 			}
 		};
 	}, [observer, ref, updateSize, options.triggerOnWindowResize]);
+
+	useEffect(() => {
+		if (!options.triggerOnWindowResize) {
+			return;
+		}
+
+		window.addEventListener('resize', updateSize);
+
+		return () => {
+			window.removeEventListener('resize', updateSize);
+		};
+	}, [options.triggerOnWindowResize, updateSize]);
+
 	return size;
 };


### PR DESCRIPTION
When resizing the browser window after initial rendering of the player component the size variable (from useElementSize) does not get updatet resulting in the seekbar position no longer being in sync with the mouse pointer.

This PR adds an option to also trigger the useElemetSize hook when the browser window gets resized. It is optional to prevent unnecessaryre-renders when used in components that's not dependant on this event to function correctly.

There is probably a more elegant way to solve this but I am new to hooks and typescript in general so feel free to refactor.