### PR TITLE
feat(player): support volume control using keyboard

### DIFF
--- a/packages/player-example/src/CarSlideshow.tsx
+++ b/packages/player-example/src/CarSlideshow.tsx
@@ -2,15 +2,15 @@ import {interpolate, useCurrentFrame, useVideoConfig} from 'remotion';
 
 type Props = {
 	title: string;
-	bgColor: string,
-	color: string
+	bgColor: string;
+	color: string;
 };
 
 const CarSlideshow = ({title, bgColor, color}: Props) => {
 	const frame = useCurrentFrame();
 	const {width, height, durationInFrames} = useVideoConfig();
 	const left = interpolate(frame, [0, durationInFrames], [width, width * -1]);
-	console.log(bgColor, color)
+
 	return (
 		<div
 			style={{

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -1,12 +1,10 @@
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {Internals, interpolate} from 'remotion';
+import React, {useCallback, useRef, useState} from 'react';
+import {Internals} from 'remotion';
 import {ICON_SIZE, VolumeOffIcon, VolumeOnIcon} from './icons';
 import {useHoverState} from './use-hover-state';
-import {useElementSize} from './utils/use-element-size';
 
 const BAR_HEIGHT = 5;
-const KNOB_SIZE = 12;
-const VERTICAL_PADDING = 4;
+// const KNOB_SIZE = 12;
 const VOLUME_SLIDER_WIDTH = 100;
 
 const parentDivStyle: React.CSSProperties = {
@@ -19,36 +17,12 @@ const parentDivStyle: React.CSSProperties = {
 	touchAction: 'none',
 };
 
-const containerStyle: React.CSSProperties = {
-	userSelect: 'none',
-	paddingTop: VERTICAL_PADDING,
-	paddingBottom: VERTICAL_PADDING,
-	boxSizing: 'border-box',
-	cursor: 'pointer',
-	position: 'relative',
-};
-
 const barBackground: React.CSSProperties = {
 	height: BAR_HEIGHT,
 	backgroundColor: 'rgba(255, 255, 255, 0.5)',
 	width: VOLUME_SLIDER_WIDTH,
 	borderRadius: BAR_HEIGHT / 2,
-};
-
-const getVolumeFromX = (clientX: number, width: number) => {
-	const pos = clientX;
-	const volume =
-		width === 0
-			? 0
-			: interpolate(pos, [0, width], [0, 1], {
-					extrapolateLeft: 'clamp',
-					extrapolateRight: 'clamp',
-			  });
-	return volume;
-};
-
-const xSpacer: React.CSSProperties = {
-	width: 5,
+	marginLeft: 5,
 };
 
 const volumeContainer: React.CSSProperties = {
@@ -56,19 +30,34 @@ const volumeContainer: React.CSSProperties = {
 	width: ICON_SIZE,
 	height: ICON_SIZE,
 	cursor: 'pointer',
+	appearance: 'none',
+	background: 'none',
+	border: 'none',
+	padding: 0,
 };
 
 export const MediaVolumeSlider: React.FC = () => {
 	const [mediaMuted, setMediaMuted] = Internals.useMediaMutedState();
 	const [mediaVolume, setMediaVolume] = Internals.useMediaVolumeState();
-	const [dragging, setDragging] = useState<boolean>(false);
-	const currentRef = useRef<HTMLDivElement>(null);
-	const iconDivRef = useRef<HTMLDivElement>(null);
+	const [focused, setFocused] = useState<boolean>(false);
 	const parentDivRef = useRef<HTMLDivElement>(null);
-	const size = useElementSize(currentRef, {triggerOnWindowResize: true});
+	const inputRef = useRef<HTMLInputElement>(null);
 	const hover = useHoverState(parentDivRef);
+	const isMutedOrZero = mediaMuted || mediaVolume === 0;
 
-	const hoverOrDragging = hover || dragging;
+	const onVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setMediaVolume(parseFloat(e.target.value));
+	};
+
+	const onBlur = () => {
+		setTimeout(() => {
+			// We need a small delay to check which element was focused next,
+			// and if it wasn't the volume slider, we hide it
+			if (document.activeElement !== inputRef.current) {
+				setFocused(false);
+			}
+		}, 10);
+	};
 
 	const onClick = useCallback(() => {
 		if (mediaVolume === 0) {
@@ -80,118 +69,34 @@ export const MediaVolumeSlider: React.FC = () => {
 		setMediaMuted((mute) => !mute);
 	}, [mediaVolume, setMediaMuted, setMediaVolume]);
 
-	const onPointerDown = useCallback(
-		(e: React.PointerEvent<HTMLDivElement>) => {
-			if (!size) {
-				throw new Error('Player has no size');
-			}
-
-			const _volume = getVolumeFromX(
-				e.clientX - size.left - KNOB_SIZE / 2,
-				size.width - KNOB_SIZE
-			);
-			setMediaVolume(_volume);
-			if (_volume > 0) {
-				setMediaMuted(false);
-			}
-
-			setDragging(true);
-		},
-		[setMediaMuted, setMediaVolume, size]
-	);
-
-	const onPointerMove = useCallback(
-		(e: PointerEvent) => {
-			if (!size) {
-				throw new Error('Player has no size');
-			}
-
-			if (!dragging) return;
-
-			const _volume = getVolumeFromX(
-				e.clientX - size.left - KNOB_SIZE / 2,
-				size.width - KNOB_SIZE
-			);
-			setMediaVolume(_volume);
-			if (_volume > 0) {
-				setMediaMuted(false);
-			}
-		},
-		[dragging, setMediaMuted, setMediaVolume, size]
-	);
-
-	const onPointerUp = useCallback(() => {
-		setDragging(false);
-	}, []);
-
-	useEffect(() => {
-		if (!dragging) {
-			return;
-		}
-
-		window.addEventListener('pointermove', onPointerMove);
-		window.addEventListener('pointerup', onPointerUp);
-		return () => {
-			window.removeEventListener('pointermove', onPointerMove);
-			window.removeEventListener('pointerup', onPointerUp);
-		};
-	}, [currentRef, dragging, onPointerMove, onPointerUp, onPointerDown]);
-
-	const knobStyle: React.CSSProperties = useMemo(() => {
-		return {
-			height: KNOB_SIZE,
-			width: KNOB_SIZE,
-			borderRadius: KNOB_SIZE / 2,
-			position: 'absolute',
-			top: VERTICAL_PADDING - KNOB_SIZE / 2 + 5 / 2,
-			backgroundColor: 'white',
-			left: mediaMuted
-				? 0
-				: Math.max(0, mediaVolume * ((size?.width ?? 0) - KNOB_SIZE)),
-			boxShadow: '0 0 2px black',
-			opacity: Number(hoverOrDragging),
-		};
-	}, [hoverOrDragging, mediaMuted, mediaVolume, size?.width]);
-
-	const fillStyle: React.CSSProperties = useMemo(() => {
-		return {
-			height: BAR_HEIGHT,
-			backgroundColor: 'rgba(255, 255, 255, 1)',
-			width: mediaMuted ? 0 : (mediaVolume / 1) * 100 + '%',
-			borderRadius: BAR_HEIGHT / 2,
-		};
-	}, [mediaMuted, mediaVolume]);
-
-	const isMutedOrZero = mediaMuted || mediaVolume === 0;
-
 	return (
 		<div ref={parentDivRef} style={parentDivStyle}>
-			<div
-				ref={iconDivRef}
-				role="button"
+			<button
 				aria-label={isMutedOrZero ? 'Unmute sound' : 'Mute sound'}
 				title={isMutedOrZero ? 'Unmute sound' : 'Mute sound'}
 				onClick={onClick}
+				onBlur={onBlur}
+				onFocus={() => setFocused(true)}
 				style={volumeContainer}
+				type="button"
 			>
 				{isMutedOrZero ? <VolumeOffIcon /> : <VolumeOnIcon />}
-			</div>
-			<div style={xSpacer} />
+			</button>
 
-			<div
-				ref={currentRef}
-				onPointerDown={onPointerDown}
-				style={containerStyle}
-			>
-				{hoverOrDragging ? (
-					<>
-						<div style={barBackground}>
-							<div style={fillStyle} />
-						</div>
-						<div style={knobStyle} />
-					</>
-				) : null}
-			</div>
+			{(focused || hover) && !mediaMuted ? (
+				<input
+					ref={inputRef}
+					aria-label="Change volume"
+					max={1}
+					min={0}
+					onBlur={() => setFocused(false)}
+					onChange={onVolumeChange}
+					step={0.01}
+					style={barBackground}
+					type="range"
+					value={mediaVolume}
+				/>
+			) : null}
 		</div>
 	);
 };

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -1,11 +1,45 @@
 import React, {useCallback, useRef, useState} from 'react';
 import {Internals} from 'remotion';
 import {ICON_SIZE, VolumeOffIcon, VolumeOnIcon} from './icons';
+import {VOLUME_SLIDER_INPUT_CSS_CLASSNAME} from './player-css-classname';
 import {useHoverState} from './use-hover-state';
 
 const BAR_HEIGHT = 5;
-// const KNOB_SIZE = 12;
+const KNOB_SIZE = 12;
 const VOLUME_SLIDER_WIDTH = 100;
+
+const scope = `.${VOLUME_SLIDER_INPUT_CSS_CLASSNAME}`;
+const sliderStyle = `
+	${scope} {
+		-webkit-appearance: none;
+		background-color: rgba(255, 255, 255, 0.5);	
+		border-radius: ${BAR_HEIGHT / 2}px;
+		cursor: pointer;
+		height: ${BAR_HEIGHT}px;
+		margin-left: 5px;
+		width: ${VOLUME_SLIDER_WIDTH}px;
+	}
+
+	${scope}::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		background-color: white;
+		border-radius: ${KNOB_SIZE / 2}px;
+		box-shadow: 0 0 2px black;
+		height: ${KNOB_SIZE}px;
+		width: ${KNOB_SIZE}px;
+	}
+
+	${scope}::-moz-range-thumb {
+		-webkit-appearance: none;
+		background-color: white;
+		border-radius: ${KNOB_SIZE / 2}px;
+		box-shadow: 0 0 2px black;
+		height: ${KNOB_SIZE}px;
+		width: ${KNOB_SIZE}px;
+	}
+`;
+
+Internals.CSSUtils.injectCSS(sliderStyle);
 
 const parentDivStyle: React.CSSProperties = {
 	display: 'inline-flex',
@@ -15,14 +49,6 @@ const parentDivStyle: React.CSSProperties = {
 	justifyContent: 'center',
 	alignItems: 'center',
 	touchAction: 'none',
-};
-
-const barBackground: React.CSSProperties = {
-	height: BAR_HEIGHT,
-	backgroundColor: 'rgba(255, 255, 255, 0.5)',
-	width: VOLUME_SLIDER_WIDTH,
-	borderRadius: BAR_HEIGHT / 2,
-	marginLeft: 5,
 };
 
 const volumeContainer: React.CSSProperties = {
@@ -87,12 +113,12 @@ export const MediaVolumeSlider: React.FC = () => {
 				<input
 					ref={inputRef}
 					aria-label="Change volume"
+					className={VOLUME_SLIDER_INPUT_CSS_CLASSNAME}
 					max={1}
 					min={0}
 					onBlur={() => setFocused(false)}
 					onChange={onVolumeChange}
 					step={0.01}
-					style={barBackground}
 					type="range"
 					value={mediaVolume}
 				/>

--- a/packages/player/src/player-css-classname.ts
+++ b/packages/player/src/player-css-classname.ts
@@ -1,1 +1,4 @@
 export const PLAYER_CSS_CLASSNAME = '__remotion-player';
+export const VOLUME_SLIDER_INPUT_CSS_CLASSNAME = PLAYER_CSS_CLASSNAME.concat(
+	'_volume-slider-input'
+);


### PR DESCRIPTION
## Context

This PR adds support for controlling the volume using the keyboard.
Currently, one can't even reach it, it jumps from the play/pause button to the fullscreen button.

<details>
  <summary>Demo</summary>

https://user-images.githubusercontent.com/13774309/125946467-806148a5-1b54-4e63-a432-66e0e431e0f8.mp4

</details>

Leveraging the native `input[type="range"]` with some focus management, I got a more accessible result.

<details>
  <summary>Demo</summary>

From left to right: Firefox, Chrome and Edge

https://user-images.githubusercontent.com/13774309/125946852-52db0f9a-d580-4ee8-bce9-9cf735b37e1d.mp4

</details>

## Styling

Styling the slider is possible but requires some pseudo-selectors - [link on CSS Tricks](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/).

I reached to Remotion's internals based on Jonny's suggestion since the React `style` prop doesn't support pseudo-selectors and adding something like CSS modules or `styled-components` could interfere with outside the player.

I did not add all the pseudo-selectors from the CSS Tricks post because some target browsers like IE and I don't have access to them at the moment.
Let me know if we're interested in assuring the layout there and I can try to verify.
If you have access to something like [Browserstack](https://www.browserstack.com/), it can be helpful as well.

## Notes

As always, any feedback is appreciated.
