### PR TITLE
Revert "chore(docs): update Docusaurus and remove Babel plugin"

### DIFF
--- a/packages/docs/babel.config.js
+++ b/packages/docs/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: [require.resolve("@docusaurus/core/lib/babel/preset")],
+  plugins: ["@babel/plugin-transform-modules-commonjs"],
 };

--- a/packages/docs/package-lock.json
+++ b/packages/docs/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "docs",
-	"version": "2.2.4",
+	"version": "2.1.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"dependencies": {
-				"@docusaurus/core": "^2.0.0-beta.4",
-				"@docusaurus/module-type-aliases": "^2.0.0-beta.4",
-				"@docusaurus/preset-classic": "^2.0.0-beta.4",
+				"@babel/plugin-transform-modules-commonjs": "^7.14.0",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/module-type-aliases": "^2.0.0-beta.0",
+				"@docusaurus/preset-classic": "2.0.0-beta.0",
 				"@mdx-js/react": "^1.6.21",
 				"@splitbee/web": "^0.2.4",
 				"@tsconfig/docusaurus": "^1.0.2",
@@ -27,143 +28,143 @@
 			}
 		},
 		"node_modules/@algolia/autocomplete-core": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.2.1.tgz",
-			"integrity": "sha512-/SLS6636Wpl7eFiX7eEy0E3wBo60sUm1qRYybJBDt1fs8reiJ1+OSy+dZgrLBfLL4mSFqRIIUHXbVp25QdZ+iw==",
+			"version": "1.0.0-alpha.44",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.0.0-alpha.44.tgz",
+			"integrity": "sha512-2iMXthldMIDXtlbg9omRKLgg1bLo2ZzINAEqwhNjUeyj1ceEyL1ck6FY0VnJpf2LsjmNthHCz2BuFk+nYUeDNA==",
 			"dependencies": {
-				"@algolia/autocomplete-shared": "1.2.1"
+				"@algolia/autocomplete-shared": "1.0.0-alpha.44"
 			}
 		},
 		"node_modules/@algolia/autocomplete-preset-algolia": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.2.1.tgz",
-			"integrity": "sha512-Lf4PpPVgHNXm1ytrnVdrZYV7hAYSCpAI/TrebF8UC6xflPY6sKb1RL/2OfrO9On7SDjPBtNd+6MArSar5JmK0g==",
+			"version": "1.0.0-alpha.44",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.44.tgz",
+			"integrity": "sha512-DCHwo5ovzg9k2ejUolGNTLFnIA7GpsrkbNJTy1sFbMnYfBmeK8egZPZnEl7lBTr27OaZu7IkWpTepLVSztZyng==",
 			"dependencies": {
-				"@algolia/autocomplete-shared": "1.2.1"
+				"@algolia/autocomplete-shared": "1.0.0-alpha.44"
 			},
 			"peerDependencies": {
-				"@algolia/client-search": "^4.9.1",
-				"algoliasearch": "^4.9.1"
+				"@algolia/client-search": "^4.5.1",
+				"algoliasearch": "^4.5.1"
 			}
 		},
 		"node_modules/@algolia/autocomplete-shared": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.2.1.tgz",
-			"integrity": "sha512-RHCwcXAYFwDXTlomstjWRFIzOfyxtQ9KmViacPE5P5hxUSSjkmG3dAb77xdydift1PaZNbho5TNTCi5UZe0RpA=="
+			"version": "1.0.0-alpha.44",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.0.0-alpha.44.tgz",
+			"integrity": "sha512-2oQZPERYV+yNx/yoVWYjZZdOqsitJ5dfxXJjL18yczOXH6ujnsq+DTczSrX+RjzjQdVeJ1UAG053EJQF/FOiMg=="
 		},
 		"node_modules/@algolia/cache-browser-local-storage": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.3.tgz",
-			"integrity": "sha512-TD1N7zg5lb56/PLjjD4bBl2eccEvVHhC7yfgFu2r9k5tf+gvbGxEZ3NhRZVKu2MObUIcEy2VR4LVLxOQu45Hlg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.2.tgz",
+			"integrity": "sha512-B3NInwobEAim4J4Y0mgZermoi0DCXdTT/Q+4ehLamqUqxLw8To5zc9izjg7B8JaFSQsqflRdCeRmYEv2gYDY7g==",
 			"dependencies": {
-				"@algolia/cache-common": "4.10.3"
+				"@algolia/cache-common": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/cache-common": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.3.tgz",
-			"integrity": "sha512-q13cPPUmtf8a2suBC4kySSr97EyulSXuxUkn7l1tZUCX/k1y5KNheMp8npBy8Kc8gPPmHpacxddRSfOncjiKFw=="
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.2.tgz",
+			"integrity": "sha512-xcGbV0+6gLu2C7XoJdD+Pp6wWjROle6PNDsa6O21vS7fw1a03xb2bEnFdl1U31bs69P1z8IRy3h+8RVBouvhhw=="
 		},
 		"node_modules/@algolia/cache-in-memory": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.3.tgz",
-			"integrity": "sha512-JhPajhOXAjUP+TZrZTh6KJpF5VKTKyWK2aR1cD8NtrcVHwfGS7fTyfXfVm5BqBqkD9U0gVvufUt/mVyI80aZww==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.2.tgz",
+			"integrity": "sha512-zPIcxHQEJXy+M35A+v9Y5u5BAQOKR2aFK0kYpAdW/OrgxYcrFHtVCxwIWB/ZhGbkDtzCW8/8tJeddcD5YsHX9Q==",
 			"dependencies": {
-				"@algolia/cache-common": "4.10.3"
+				"@algolia/cache-common": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/client-account": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.3.tgz",
-			"integrity": "sha512-S/IsJB4s+e1xYctdpW3nAbwrR2y3pjSo9X21fJGoiGeIpTRdvQG7nydgsLkhnhcgAdLnmqBapYyAqMGmlcyOkg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.2.tgz",
+			"integrity": "sha512-iuIU+xUtjgR9p4Hpujlr8mePDPSrVIk3peg+RAUhxniLBDaI+OhgHyhP6Lmh9flWk+JfRg91Rhk46xuxMLqwfA==",
 			"dependencies": {
-				"@algolia/client-common": "4.10.3",
-				"@algolia/client-search": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/client-common": "4.10.2",
+				"@algolia/client-search": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/client-analytics": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.3.tgz",
-			"integrity": "sha512-vlHTbBqJktRgclh3v7bPQLfZvFIqY4erNFIZA5C7nisCj9oLeTgzefoUrr+R90+I+XjfoLxnmoeigS1Z1yg1vw==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.2.tgz",
+			"integrity": "sha512-u47J65NHs0fMryDrMeuLMGjXDOKt/muF9WlfbMslT2Cvdd7PZwl9KYnT7xMhnmBB8TDiDMmEQkDykhnCOnwVNw==",
 			"dependencies": {
-				"@algolia/client-common": "4.10.3",
-				"@algolia/client-search": "4.10.3",
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/client-common": "4.10.2",
+				"@algolia/client-search": "4.10.2",
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/client-common": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.3.tgz",
-			"integrity": "sha512-uFyP2Z14jG2hsFRbAoavna6oJf4NTXaSDAZgouZUZlHlBp5elM38sjNeA5HR9/D9J/GjwaB1SgB7iUiIWYBB4w==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.2.tgz",
+			"integrity": "sha512-sfgZCv9ha9aHbe3ErAYb1blg2qx4XTLvQqP1jq8asU75rrH9XBTtSzQQO43GlArwhtwCHLgcWquN3WgPlLzkiQ==",
 			"dependencies": {
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/client-personalization": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.3.tgz",
-			"integrity": "sha512-NS7Nx8EJ/nduGXT8CFo5z7kLF0jnFehTP3eC+z+GOEESH3rrs7uR12IZHxv5QhQswZa9vl925zCOZDcDVoENCg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.2.tgz",
+			"integrity": "sha512-2UhUNo/czfA/keOC3+vFyMnFGV/E1Zkm+ek9Fsk/9miS39UMhx2CmH5vKSIJ7jxLSin7zBaCwKt65phfYty1pg==",
 			"dependencies": {
-				"@algolia/client-common": "4.10.3",
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/client-common": "4.10.2",
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/client-search": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.3.tgz",
-			"integrity": "sha512-Zwnp2G94IrNFKWCG/k7epI5UswRkPvL9FCt7/slXe2bkjP2y/HA37gzRn+9tXoLVRwd7gBzrtOA4jFKIyjrtVw==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.2.tgz",
+			"integrity": "sha512-ZdOh6XS6Y9bcekfG4y0VhdoIYfsTounsgXX4Bt3X2RCcmY3uotgaq2EVY58E6q6nvfgBfPHW18+AZCHKTWHAAw==",
 			"dependencies": {
-				"@algolia/client-common": "4.10.3",
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/client-common": "4.10.2",
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/logger-common": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.3.tgz",
-			"integrity": "sha512-M6xi+qov2bkgg1H9e1Qtvq/E/eKsGcgz8RBbXNzqPIYoDGZNkv+b3b8YMo3dxd4Wd6M24HU1iqF3kmr1LaXndg=="
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.2.tgz",
+			"integrity": "sha512-UJaU6arzmW+FT5fCv5NIbxNMtEoGcf+UENmZxxu7k7UWPARR2XL4ljJ45Jv14Z5dlz32LXWtR1PRmNfkDMk22Q=="
 		},
 		"node_modules/@algolia/logger-console": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.3.tgz",
-			"integrity": "sha512-vVgRI7b4PHjgBdRkv/cRz490twvkLoGdpC4VYzIouSrKj8SIVLRhey3qgXk7oQXi3xoxVAv6NrklHfpO8Bpx0w==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.2.tgz",
+			"integrity": "sha512-JrCrZ7CGs/TsyNR2AWe9Vdd6rsuxfvfcpqbu+CY7LBUYEnV8GERkf7FnDNaKVNsFJqClILCGh3U8CzQ1G5L+kA==",
 			"dependencies": {
-				"@algolia/logger-common": "4.10.3"
+				"@algolia/logger-common": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/requester-browser-xhr": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.3.tgz",
-			"integrity": "sha512-4WIk1zreFbc1EF6+gsfBTQvwSNjWc20zJAAExRWql/Jq5yfVHmwOqi/CajA53/cXKFBqo80DAMRvOiwP+hOLYw==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.2.tgz",
+			"integrity": "sha512-LveaAp7/oCBotv1aZ4VHz8fCcJA7v/28ayh+Ljlm+hYXsxgs6NAYKz7iBpxGN7q5MV8GM+MThRYNFoT0cHTMxQ==",
 			"dependencies": {
-				"@algolia/requester-common": "4.10.3"
+				"@algolia/requester-common": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/requester-common": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.3.tgz",
-			"integrity": "sha512-PNfLHmg0Hujugs3rx55uz/ifv7b9HVdSFQDb2hj0O5xZaBEuQCNOXC6COrXR8+9VEfqp2swpg7zwgtqFxh+BtQ=="
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.2.tgz",
+			"integrity": "sha512-3J2W0fAaURLGK0lEGeNb8eWJnQcsu+oIcfJTCIYkYT5T9w21M65kUUyD9QSf/K137qQts3tzGniUR3LxfovlXA=="
 		},
 		"node_modules/@algolia/requester-node-http": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.3.tgz",
-			"integrity": "sha512-A9ZcGfEvgqf0luJApdNcIhsRh6MShn2zn2tbjwjGG1joF81w+HUY+BWuLZn56vGwAA9ZB9n00IoJJpxibbfofg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.2.tgz",
+			"integrity": "sha512-IBqsalCGgn0CrOP1PKRB5rufEOvHlrSQUFEGXZ8mxmE/zU8CLX2LKqdHbEFeNDLFl+l+8HW5BGVDGD2rvG+hSg==",
 			"dependencies": {
-				"@algolia/requester-common": "4.10.3"
+				"@algolia/requester-common": "4.10.2"
 			}
 		},
 		"node_modules/@algolia/transporter": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.3.tgz",
-			"integrity": "sha512-n1lRyKDbrckbMEgm7QXtj3nEWUuzA3aKLzVQ43/F/RCFib15j4IwtmYhXR6OIBRSc7+T0Hm48S0J6F+HeYCQkw==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.2.tgz",
+			"integrity": "sha512-I3QDRSookQtPSUEnxT2XCShhipCT4beJBpWhteNwMrWQF/SqTsveqSR6bX0G49lDh9MOmYrOlCegteuKuT/tEw==",
 			"dependencies": {
-				"@algolia/cache-common": "4.10.3",
-				"@algolia/logger-common": "4.10.3",
-				"@algolia/requester-common": "4.10.3"
+				"@algolia/cache-common": "4.10.2",
+				"@algolia/logger-common": "4.10.2",
+				"@algolia/requester-common": "4.10.2"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1908,18 +1909,18 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
 		},
 		"node_modules/@docsearch/css": {
-			"version": "3.0.0-alpha.39",
-			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.39.tgz",
-			"integrity": "sha512-lr10MFTgcR3NRea/FtJ7uNtIpQz0XVwYxbpO5wxykgfHu1sxZTr6zwkuPquRgFYXnccxsTvfoIiK3rMH0fLr/w=="
+			"version": "3.0.0-alpha.36",
+			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.36.tgz",
+			"integrity": "sha512-zSN2SXuZPDqQaSFzYa1kOwToukqzhLHG7c66iO+/PlmWb6/RZ5cjTkG6VCJynlohRWea7AqZKWS/ptm8kM2Dmg=="
 		},
 		"node_modules/@docsearch/react": {
-			"version": "3.0.0-alpha.39",
-			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0-alpha.39.tgz",
-			"integrity": "sha512-urTIt82tan6CU+D2kO6xXpWQom/r1DA7L/55m2JiCIK/3SLh2z15FJFVN2abeK7B4wl8pCfWunYOwCsSHhWDLA==",
+			"version": "3.0.0-alpha.36",
+			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0-alpha.36.tgz",
+			"integrity": "sha512-synYZDHalvMzesFiy7kK+uoz4oTdWSTbe2cU+iiUjwFMyQ+WWjWwGVnvcvk+cjj9pRCVaZo5y5WpqNXq1j8k9Q==",
 			"dependencies": {
-				"@algolia/autocomplete-core": "1.2.1",
-				"@algolia/autocomplete-preset-algolia": "1.2.1",
-				"@docsearch/css": "3.0.0-alpha.39",
+				"@algolia/autocomplete-core": "1.0.0-alpha.44",
+				"@algolia/autocomplete-preset-algolia": "1.0.0-alpha.44",
+				"@docsearch/css": "3.0.0-alpha.36",
 				"algoliasearch": "^4.0.0"
 			},
 			"peerDependencies": {
@@ -1929,9 +1930,9 @@
 			}
 		},
 		"node_modules/@docusaurus/core": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.4.tgz",
-			"integrity": "sha512-ITa976MPFl9KbYchMOWCCX6SU6EFDSdGeGOHtpaNcrJ9e9Sj7o77fKmMH/ciShwz1g8brTm3VxZ0FwleU8lTig==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.0.tgz",
+			"integrity": "sha512-xWwpuEwFRKJmZvNGOpr/dyRDnx/psckLPsozQTg2hu3u81Wqu9gigWgYK/C2fPlEjxMcVw0/2WH+zwpbyWmF2Q==",
 			"dependencies": {
 				"@babel/core": "^7.12.16",
 				"@babel/generator": "^7.12.15",
@@ -1943,49 +1944,47 @@
 				"@babel/runtime": "^7.12.5",
 				"@babel/runtime-corejs3": "^7.12.13",
 				"@babel/traverse": "^7.12.13",
-				"@docusaurus/cssnano-preset": "2.0.0-beta.4",
+				"@docusaurus/cssnano-preset": "2.0.0-beta.0",
 				"@docusaurus/react-loadable": "5.5.0",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-common": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
-				"@slorber/static-site-generator-webpack-plugin": "^4.0.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
+				"@endiliey/static-site-generator-webpack-plugin": "^4.0.0",
 				"@svgr/webpack": "^5.5.0",
 				"autoprefixer": "^10.2.5",
 				"babel-loader": "^8.2.2",
 				"babel-plugin-dynamic-import-node": "2.3.0",
-				"boxen": "^5.0.1",
-				"chalk": "^4.1.1",
+				"boxen": "^5.0.0",
+				"chalk": "^4.1.0",
 				"chokidar": "^3.5.1",
-				"clean-css": "^5.1.2",
+				"clean-css": "^5.1.1",
 				"commander": "^5.1.0",
-				"copy-webpack-plugin": "^9.0.0",
+				"copy-webpack-plugin": "^8.1.0",
 				"core-js": "^3.9.1",
 				"css-loader": "^5.1.1",
-				"css-minimizer-webpack-plugin": "^3.0.1",
-				"cssnano": "^5.0.4",
+				"css-minimizer-webpack-plugin": "^2.0.0",
+				"cssnano": "^5.0.1",
 				"del": "^6.0.0",
 				"detect-port": "^1.3.0",
-				"escape-html": "^1.0.3",
 				"eta": "^1.12.1",
 				"express": "^4.17.1",
 				"file-loader": "^6.2.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.1.0",
 				"github-slugger": "^1.3.0",
 				"globby": "^11.0.2",
 				"html-minifier-terser": "^5.1.1",
 				"html-tags": "^3.1.0",
-				"html-webpack-plugin": "^5.3.2",
+				"html-webpack-plugin": "^5.2.0",
 				"import-fresh": "^3.3.0",
 				"is-root": "^2.1.0",
 				"leven": "^3.1.0",
 				"lodash": "^4.17.20",
-				"mini-css-extract-plugin": "^1.6.0",
+				"mini-css-extract-plugin": "^1.4.0",
 				"module-alias": "^2.2.2",
 				"nprogress": "^0.2.0",
-				"postcss": "^8.2.15",
-				"postcss-loader": "^5.3.0",
-				"prompts": "^2.4.1",
+				"postcss": "^8.2.10",
+				"postcss-loader": "^5.2.0",
+				"prompts": "^2.4.0",
 				"react-dev-utils": "^11.0.1",
 				"react-error-overlay": "^6.0.9",
 				"react-helmet": "^6.1.0",
@@ -1995,21 +1994,21 @@
 				"react-router-config": "^5.1.1",
 				"react-router-dom": "^5.2.0",
 				"resolve-pathname": "^3.0.0",
-				"rtl-detect": "^1.0.3",
+				"rtl-detect": "^1.0.2",
 				"semver": "^7.3.4",
 				"serve-handler": "^6.1.3",
 				"shelljs": "^0.8.4",
 				"std-env": "^2.2.1",
 				"strip-ansi": "^6.0.0",
-				"terser-webpack-plugin": "^5.1.3",
-				"tslib": "^2.2.0",
+				"terser-webpack-plugin": "^5.1.1",
+				"tslib": "^2.1.0",
 				"update-notifier": "^5.1.0",
 				"url-loader": "^4.1.1",
-				"wait-on": "^5.3.0",
-				"webpack": "^5.40.0",
-				"webpack-bundle-analyzer": "^4.4.2",
+				"wait-on": "^5.2.1",
+				"webpack": "^5.28.0",
+				"webpack-bundle-analyzer": "^4.4.0",
 				"webpack-dev-server": "^3.11.2",
-				"webpack-merge": "^5.8.0",
+				"webpack-merge": "^5.7.3",
 				"webpackbar": "^5.0.0-3"
 			},
 			"bin": {
@@ -2032,38 +2031,37 @@
 			}
 		},
 		"node_modules/@docusaurus/cssnano-preset": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.4.tgz",
-			"integrity": "sha512-KsmFEob0ElffnFFbz93wcYH4IncU4LDnKBerdomU0Wdg/vXTLo3Q7no8df9yjbcBXVRaSX+/tNFapY9Iu/4Cew==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.0.tgz",
+			"integrity": "sha512-gqQHeQCDHZDd5NaiKZwDiyg75sBCqDyAsvmFukkDAty8xE7u9IhzbOQKvCAtwseuvzu2BNN41gnJ8bz7vZzQiw==",
 			"dependencies": {
-				"cssnano-preset-advanced": "^5.1.1",
-				"postcss": "^8.2.15",
-				"postcss-sort-media-queries": "^3.10.11"
+				"cssnano-preset-advanced": "^5.0.0",
+				"postcss": "^8.2.10",
+				"postcss-sort-media-queries": "^3.8.9"
 			}
 		},
 		"node_modules/@docusaurus/mdx-loader": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.4.tgz",
-			"integrity": "sha512-dwYKFKcsgiMB/TECoieKnwQemBAozd2a+cm4xzrWhDzElvwlQPo/j45OOUb6U/H8NJp7DnAynLBqSyKJ3YZb4g==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.0.tgz",
+			"integrity": "sha512-oQLS2ZeUnqw79CV37glglZpaYgFfA5Az5lT83m5tJfMUZjoK4ehG1XWBeUzWy8QQNI452yAID8jz8jihEQeCcw==",
 			"dependencies": {
 				"@babel/parser": "^7.12.16",
 				"@babel/traverse": "^7.12.13",
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
 				"@mdx-js/mdx": "^1.6.21",
 				"@mdx-js/react": "^1.6.21",
-				"chalk": "^4.1.1",
 				"escape-html": "^1.0.3",
 				"file-loader": "^6.2.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.1.0",
 				"github-slugger": "^1.3.0",
-				"gray-matter": "^4.0.3",
+				"gray-matter": "^4.0.2",
 				"mdast-util-to-string": "^2.0.0",
 				"remark-emoji": "^2.1.0",
 				"stringify-object": "^3.3.0",
 				"unist-util-visit": "^2.0.2",
 				"url-loader": "^4.1.1",
-				"webpack": "^5.40.0"
+				"webpack": "^5.28.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -2074,32 +2072,30 @@
 			}
 		},
 		"node_modules/@docusaurus/module-type-aliases": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.4.tgz",
-			"integrity": "sha512-FRAAOJMDbHcBNgFvH4ihPszxraTTCkS7kN3q8WIj67Uv8u3+T36XWpReWdFYmzfPA4QyFx9YK4u1bmF7pndBSw==",
-			"license": "MIT"
+			"version": "2.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.3.tgz",
+			"integrity": "sha512-vciejziDBu39cyfmdvbpn865YlvugJMUOeD2m/7Kg4RLUPIZzQTWns0ZGIMc/iToiwebHwkoJtRsHaHzj8FpnA=="
 		},
 		"node_modules/@docusaurus/plugin-content-blog": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.4.tgz",
-			"integrity": "sha512-NyLqoem/r/m8mNO3H1PbbPayA5KjgRTeB5T7j949uvGwlK34c+W6bSvr3OSRJdmFXqhFL4CG8E8wbSq7h+8WEA==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.0.tgz",
+			"integrity": "sha512-lz63i5k/23RJ3Rk/2fIsYAoD8Wua3b5b0AbH2JoOhQu1iAIQiV8m91Z3XALBSzA3nBtAOIweNI7yzWL+JFSTvw==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/mdx-loader": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
-				"chalk": "^4.1.1",
-				"escape-string-regexp": "^4.0.0",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/mdx-loader": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
+				"chalk": "^4.1.0",
 				"feed": "^4.2.2",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.1.0",
 				"globby": "^11.0.2",
 				"loader-utils": "^2.0.0",
 				"lodash": "^4.17.20",
 				"reading-time": "^1.3.0",
 				"remark-admonitions": "^1.2.1",
-				"tslib": "^2.2.0",
-				"webpack": "^5.40.0"
+				"tslib": "^2.1.0",
+				"webpack": "^5.28.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -2110,20 +2106,19 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-content-docs": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.4.tgz",
-			"integrity": "sha512-aVYycpOvtgPQ78a10jakCtrI7DEAffw+zVdZT6tgO8QIn5hNPcr5NB7Ms3kSZw83fMZwJqStHHGp0y13zt/gLw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.0.tgz",
+			"integrity": "sha512-WdDQUh2rRCbfJswVc0vY9EaAspxgziqpVEZja8+BmQR/TZh7HuLplT6GJbiFbE4RvwM3+PwG/jHMPglYDK60kw==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/mdx-loader": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
-				"chalk": "^4.1.1",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/mdx-loader": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
+				"chalk": "^4.1.0",
 				"combine-promises": "^1.1.0",
-				"escape-string-regexp": "^4.0.0",
 				"execa": "^5.0.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.1.0",
 				"globby": "^11.0.2",
 				"import-fresh": "^3.2.2",
 				"js-yaml": "^4.0.0",
@@ -2131,9 +2126,9 @@
 				"lodash": "^4.17.20",
 				"remark-admonitions": "^1.2.1",
 				"shelljs": "^0.8.4",
-				"tslib": "^2.2.0",
+				"tslib": "^2.1.0",
 				"utility-types": "^3.10.0",
-				"webpack": "^5.40.0"
+				"webpack": "^5.28.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -2168,20 +2163,22 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-content-pages": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.4.tgz",
-			"integrity": "sha512-VZ/iuxT1kgBh/1+W3Li88UZVjqHtHOt4TyFoVwHmf2p91BPHiF7zpiLb4hYL8s694/V+AdfWf4ostSyEoeMx8A==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.0.tgz",
+			"integrity": "sha512-mk5LVVSvn+HJPKBaAs/Pceq/hTGxF2LVBvJEquuQz0NMAW3QdBWaYRRpOrL9CO8v+ygn5RuLslXsyZBsDNuhww==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/mdx-loader": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/mdx-loader": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
 				"globby": "^11.0.2",
 				"lodash": "^4.17.20",
+				"minimatch": "^3.0.4",
 				"remark-admonitions": "^1.2.1",
+				"slash": "^3.0.0",
 				"tslib": "^2.1.0",
-				"webpack": "^5.40.0"
+				"webpack": "^5.28.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -2192,14 +2189,14 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-debug": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.4.tgz",
-			"integrity": "sha512-jc9o45NUuhVnFcoq6/6juxJQGgD2Q71IUokoOgw3sytHHOv1jv+eLWP1LDX71MHA1ElZ1MZTlz5mCd1wlzdCOw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.0.tgz",
+			"integrity": "sha512-m75sZdF8Yccxfih3qfdQg9DucMTrYBnmeTA8GNmdVaK701Ip8t50d1pDJchtu0FSEh6vzVB9C6D2YD5YgVFp8A==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"react-json-view": "^1.21.3",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"react-json-view": "^1.21.1",
 				"tslib": "^2.1.0"
 			},
 			"engines": {
@@ -2211,11 +2208,11 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-google-analytics": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.4.tgz",
-			"integrity": "sha512-mqMEnfMKIoR1UfIX+jiAcUolwYntqSNaW8Gg2tg8dlGvC3payT1gpNJaew6TWyrtE29vuZz6a830bIXBYm4uAA==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.0.tgz",
+			"integrity": "sha512-7lHrg1L+adc8VbiaLexa15i4fdq4MRPUTLMxRPAWz+QskhisW89Ryi2/gDmfMNqLblX84Qg2RASa+2gqO4wepw==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4"
+				"@docusaurus/core": "2.0.0-beta.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -2226,11 +2223,11 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-google-gtag": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.4.tgz",
-			"integrity": "sha512-MZ0Rr6LBZLKMVFXxV7Kr+l0U3Yz/Yn8L2E5z9DbgVi+9tyLn4xlMzuMPG3gN9TZ8kPcQ1ZWwv9crA+138UzIkw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.0.tgz",
+			"integrity": "sha512-V7zaYbhAMv0jexm5H/5sAnoM1GHibcn9QQk5UWC++x1kE0KRuLDZHV+9OyvW5wr0wWFajod/b88SpUpSMF5u+g==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4"
+				"@docusaurus/core": "2.0.0-beta.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -2241,18 +2238,17 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-sitemap": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.4.tgz",
-			"integrity": "sha512-0sU1aMQmMN7fE3TlSM2wBZN/gFsuvo79DYxw8TIVtNakA84oDxurH/rhDQHwJ34JQufm5CuWNC1ICHtyI3qyWw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.0.tgz",
+			"integrity": "sha512-dvmk8Sr+6pBkiKDb7Rjdp0GeFDWPUlayoJWK3fN3g0Fno6uxFfYhNZyXJ+ObyCA7HoW5rzeBMiO+uAja19JXTg==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-common": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
-				"fs-extra": "^10.0.0",
-				"sitemap": "^7.0.0",
-				"tslib": "^2.2.0"
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
+				"fs-extra": "^9.1.0",
+				"sitemap": "^6.3.6",
+				"tslib": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -2263,20 +2259,20 @@
 			}
 		},
 		"node_modules/@docusaurus/preset-classic": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.4.tgz",
-			"integrity": "sha512-fW8/iyGLJfBTtbCBQtnRcbDa+ZZMq6Ak20+8+ORB8mzjK4BNYmt9wIbfq0oV9/QBLyryQBYcsRimJoXpLZmWOg==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.0.tgz",
+			"integrity": "sha512-cFpR0UaAeUt5qVx1bpidhlar6tiRNITIQlxP4bOVsjbxVTZhZ/cNuIz7C+2zFPCuKIflGXdTIQOrucPmd7z51Q==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-blog": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-docs": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-pages": "2.0.0-beta.4",
-				"@docusaurus/plugin-debug": "2.0.0-beta.4",
-				"@docusaurus/plugin-google-analytics": "2.0.0-beta.4",
-				"@docusaurus/plugin-google-gtag": "2.0.0-beta.4",
-				"@docusaurus/plugin-sitemap": "2.0.0-beta.4",
-				"@docusaurus/theme-classic": "2.0.0-beta.4",
-				"@docusaurus/theme-search-algolia": "2.0.0-beta.4"
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-blog": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-docs": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-pages": "2.0.0-beta.0",
+				"@docusaurus/plugin-debug": "2.0.0-beta.0",
+				"@docusaurus/plugin-google-analytics": "2.0.0-beta.0",
+				"@docusaurus/plugin-google-gtag": "2.0.0-beta.0",
+				"@docusaurus/plugin-sitemap": "2.0.0-beta.0",
+				"@docusaurus/theme-classic": "2.0.0-beta.0",
+				"@docusaurus/theme-search-algolia": "2.0.0-beta.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -2298,31 +2294,30 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-classic": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.4.tgz",
-			"integrity": "sha512-gekEt/YuAEs7CLEJhBC5mE3AqXiDNL6U3WI9emokatpbPY7B12DLJ11QWJZ4mfKYWHuiTwPeybXkOySWMLuaaA==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.0.tgz",
+			"integrity": "sha512-cBNtwAyg3be7Gk41FazMtgyibAcfuYaGHhGHIDRsXfc/qp3RhbiGiei7tyh200QT0NgKZxiVQy/r4d0mtjC++Q==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-blog": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-docs": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-pages": "2.0.0-beta.4",
-				"@docusaurus/theme-common": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-common": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-blog": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-docs": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-pages": "2.0.0-beta.0",
+				"@docusaurus/theme-common": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
 				"@mdx-js/mdx": "^1.6.21",
 				"@mdx-js/react": "^1.6.21",
-				"chalk": "^4.1.1",
+				"chalk": "^4.1.0",
 				"clsx": "^1.1.1",
-				"copy-text-to-clipboard": "^3.0.1",
-				"fs-extra": "^10.0.0",
+				"copy-text-to-clipboard": "^3.0.0",
+				"fs-extra": "^9.1.0",
 				"globby": "^11.0.2",
-				"infima": "0.2.0-alpha.29",
+				"infima": "0.2.0-alpha.23",
 				"lodash": "^4.17.20",
 				"parse-numeric-range": "^1.2.0",
-				"postcss": "^8.2.15",
-				"prism-react-renderer": "^1.2.1",
+				"postcss": "^8.2.10",
+				"prism-react-renderer": "^1.1.1",
 				"prismjs": "^1.23.0",
 				"prop-types": "^15.7.2",
 				"react-router-dom": "^5.2.0",
@@ -2337,38 +2332,36 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-common": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.4.tgz",
-			"integrity": "sha512-RJ78rfb/K2dc/u/WDCZB8Q8mj19l7UtDx3F1yFC4WMwAd5tT8V5xlKc5UpHVJrKdc1c3Z4g+ki0wFm+LpCZj0w==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.0.tgz",
+			"integrity": "sha512-2rcVmQpvbdAgnzTWuM7Bfpu+2TQm928bhlvxn226jQy7IYz8ySRlIode63HhCtpx03hpdMCkrK6HxhfEcvHjQg==",
 			"dependencies": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-blog": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-docs": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-pages": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"clsx": "^1.1.1",
-				"fs-extra": "^10.0.0",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-blog": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-docs": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-pages": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
 				"tslib": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
 			},
 			"peerDependencies": {
-				"prism-react-renderer": "^1.2.1",
+				"prism-react-renderer": "^1.1.1",
 				"react": "^16.8.4 || ^17.0.0",
 				"react-dom": "^16.8.4 || ^17.0.0"
 			}
 		},
 		"node_modules/@docusaurus/theme-search-algolia": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.4.tgz",
-			"integrity": "sha512-W/DfGhlAe1Vl+IJiL9rCw8yswdUrX0lTyCMNRAFi749YN4vCWo2RoxylbUuWoV6lUKoIYfj3EGyotRT2OLqtZw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.0.tgz",
+			"integrity": "sha512-/GhgAm4yuwqTXWTsWnqpFYxpjTv+t45Wk8q/LmTVINa+A7b6jkMkch2lygagIt69/ufDm2Uw6eYhgrmF4DJqfQ==",
 			"dependencies": {
-				"@docsearch/react": "^3.0.0-alpha.39",
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/theme-common": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
+				"@docsearch/react": "^3.0.0-alpha.33",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/theme-common": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
 				"algoliasearch": "^4.8.4",
 				"algoliasearch-helper": "^3.3.4",
 				"clsx": "^1.1.1",
@@ -2384,62 +2377,60 @@
 			}
 		},
 		"node_modules/@docusaurus/types": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.4.tgz",
-			"integrity": "sha512-2aMCliUCBYhZO8UiiPIKpRu2KECtqt0nRu44EbN6rj1STf695AIOhJC1Zo5TiuW2WbiljSbkJTgG3XdBZ3FUBw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.0.tgz",
+			"integrity": "sha512-z9PI+GbtYwqTXnkX4/a/A6psDX2p8N2uWlN2f4ifrm8WY4WhR9yiTOh0uo0pIqqaUQQvkEq3o5hOXuXLECEs+w==",
 			"dependencies": {
 				"commander": "^5.1.0",
 				"joi": "^17.4.0",
 				"querystring": "0.2.0",
-				"webpack": "^5.40.0",
-				"webpack-merge": "^5.8.0"
+				"webpack": "^5.28.0",
+				"webpack-merge": "^5.7.3"
 			}
 		},
 		"node_modules/@docusaurus/utils": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.4.tgz",
-			"integrity": "sha512-6nI3ETBp0ZSt5yp5Fc5nthQjR1MmLgl2rXC3hcscrSUZx0QvzJFzTiRgD9EAIJtR/i2JkUK18eaFiBjMBoXEbQ==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.0.tgz",
+			"integrity": "sha512-bvrT1EQu0maavr0Hb/lke9jmpzgVL/9tn5VQtbyahf472eJFY0bQDExllDrHK+l784SUvucqX0iaQeg0q6ySUw==",
 			"dependencies": {
-				"@docusaurus/types": "2.0.0-beta.4",
+				"@docusaurus/types": "2.0.0-beta.0",
 				"@types/github-slugger": "^1.3.0",
-				"chalk": "^4.1.1",
+				"chalk": "^4.1.0",
 				"escape-string-regexp": "^4.0.0",
-				"fs-extra": "^10.0.0",
-				"globby": "^11.0.4",
-				"gray-matter": "^4.0.3",
+				"fs-extra": "^9.1.0",
+				"gray-matter": "^4.0.2",
 				"lodash": "^4.17.20",
-				"micromatch": "^4.0.4",
 				"resolve-pathname": "^3.0.0",
-				"tslib": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=12.13.0"
-			}
-		},
-		"node_modules/@docusaurus/utils-common": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.4.tgz",
-			"integrity": "sha512-QaKs96/95ztKgZqHMUS/vNl+GzZ/6vKVEPjBXWt7Fdhg2soT1Iu4cShnibEO5HaVlwSfnJbVmDLVm8phQRdr0A==",
-			"dependencies": {
-				"@docusaurus/types": "2.0.0-beta.4",
-				"tslib": "^2.2.0"
+				"tslib": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
 			}
 		},
 		"node_modules/@docusaurus/utils-validation": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.4.tgz",
-			"integrity": "sha512-t1sxSeyVU02NkcFhPvE7eQFA0CFUst68hTnie6ZS3ToY3nlzdbYRPOAZY5MPr3zRMwum6yFAXgqVA+5fnR0OGg==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.0.tgz",
+			"integrity": "sha512-ELl/FVJ6xBz35TisZ1NmJhjbiVXDeU++K531PEFPCPmwnQPh7S6hZXdPnR71/Kc3BmuN9X2ZkwGOqNKVfys2Bg==",
 			"dependencies": {
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"chalk": "^4.1.1",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"chalk": "^4.1.0",
 				"joi": "^17.4.0",
 				"tslib": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=12.13.0"
+			}
+		},
+		"node_modules/@endiliey/static-site-generator-webpack-plugin": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@endiliey/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.0.tgz",
+			"integrity": "sha512-3MBqYCs30qk1OBRC697NqhGouYbs71D1B8hrk/AFJC6GwF2QaJOQZtA1JYAaGSe650sZ8r5ppRTtCRXepDWlng==",
+			"dependencies": {
+				"bluebird": "^3.7.1",
+				"cheerio": "^0.22.0",
+				"eval": "^0.1.4",
+				"url": "^0.11.0",
+				"webpack-sources": "^1.4.3"
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -2662,12 +2653,39 @@
 				}
 			}
 		},
+		"node_modules/@jest/reporters/node_modules/jest-worker": {
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+			"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+			"dependencies": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
 		"node_modules/@jest/reporters/node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/@jest/source-map": {
@@ -2936,18 +2954,6 @@
 			"integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
 			"dependencies": {
 				"@sinonjs/commons": "^1.7.0"
-			}
-		},
-		"node_modules/@slorber/static-site-generator-webpack-plugin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.1.tgz",
-			"integrity": "sha512-PSv4RIVO1Y3kvHxjvqeVisk3E9XFoO04uwYBDWe217MFqKspplYswTuKLiJu0aLORQWzuQjfVsSlLPojwfYsLw==",
-			"dependencies": {
-				"bluebird": "^3.7.1",
-				"cheerio": "^0.22.0",
-				"eval": "^0.1.4",
-				"url": "^0.11.0",
-				"webpack-sources": "^1.4.3"
 			}
 		},
 		"node_modules/@splitbee/web": {
@@ -3271,9 +3277,9 @@
 			}
 		},
 		"node_modules/@types/hast": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.2.tgz",
-			"integrity": "sha512-Op5W7jYgZI7AWKY5wQ0/QNMzQM7dGQPyW1rXKNiymVCy5iTfdPuGu4HhYNOM2sIv8gUfIuIdcYlXmAepwaowow==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
+			"integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
 			"dependencies": {
 				"@types/unist": "*"
 			}
@@ -3315,9 +3321,9 @@
 			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
 		},
 		"node_modules/@types/mdast": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.7.tgz",
-			"integrity": "sha512-YwR7OK8aPmaBvMMUi+pZXBNoW2unbVbfok4YRqGMJBe1dpDlzpRkJrYEYmvjxgs5JhuQmKfDexrN98u941Zasg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
+			"integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
 			"dependencies": {
 				"@types/unist": "*"
 			}
@@ -3353,9 +3359,9 @@
 			"integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
 		},
 		"node_modules/@types/sax": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.3.tgz",
-			"integrity": "sha512-+QSw6Tqvs/KQpZX8DvIl3hZSjNFLW/OqE5nlyHXtTwODaJvioN2rOWpBNEWZp2HZUFhOh+VohmJku/WxEXU2XA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.1.tgz",
+			"integrity": "sha512-dqYdvN7Sbw8QT/0Ci5rhjE4/iCMJEM0Y9rHpCu+gGXD9Lwbz28t6HI2yegsB6BoV1sShRMU6lAmAcgRjmFy7LA==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -3366,9 +3372,9 @@
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
 		},
 		"node_modules/@types/unist": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.4.tgz",
+			"integrity": "sha512-zfyYsDTK1HTGYXU3fTiM76+om93HcFtsZd2M0bO/CL4DiETV7mSa/pIVN/6+G3esOqEMdg2An5cHHbK5t+9w+A=="
 		},
 		"node_modules/@types/yargs": {
 			"version": "16.0.4",
@@ -3384,9 +3390,9 @@
 			"integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
 		},
 		"node_modules/@typescript/twoslash": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@typescript/twoslash/-/twoslash-2.2.0.tgz",
-			"integrity": "sha512-Lkgrs9L/OIn1JZcIv2k4uy/CsQ+9dmurN64YzSWIHleTE3PkZlV2lZdq9xM7TnLh5zFy3tP8KuPtUxbIGV9sIw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript/twoslash/-/twoslash-2.1.0.tgz",
+			"integrity": "sha512-J72HH+zAMPA9udOuOgAxTXnzeRyz0t33Ww1jQ6CgNfjP3HtrOS4lNgG+m3u1H497U366zbcUOjNkIgNGqefd/A==",
 			"dependencies": {
 				"@typescript/vfs": "1.3.4",
 				"debug": "^4.1.1",
@@ -3661,30 +3667,30 @@
 			}
 		},
 		"node_modules/algoliasearch": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.3.tgz",
-			"integrity": "sha512-OLY0AWlPKGLbSaw14ivMB7BT5fPdp8VdzY4L8FtzZnqmLKsyes24cltGlf7/X96ACkYEcT390SReCDt/9SUIRg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.2.tgz",
+			"integrity": "sha512-BAYCe97XRfO15irJKBRjBnrp9tSqN0jppklLIXKdtUcXlibcPQtuAeGUP2cPiz6bJd3ISuoYzLFNt4/fQYtLMw==",
 			"dependencies": {
-				"@algolia/cache-browser-local-storage": "4.10.3",
-				"@algolia/cache-common": "4.10.3",
-				"@algolia/cache-in-memory": "4.10.3",
-				"@algolia/client-account": "4.10.3",
-				"@algolia/client-analytics": "4.10.3",
-				"@algolia/client-common": "4.10.3",
-				"@algolia/client-personalization": "4.10.3",
-				"@algolia/client-search": "4.10.3",
-				"@algolia/logger-common": "4.10.3",
-				"@algolia/logger-console": "4.10.3",
-				"@algolia/requester-browser-xhr": "4.10.3",
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/requester-node-http": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/cache-browser-local-storage": "4.10.2",
+				"@algolia/cache-common": "4.10.2",
+				"@algolia/cache-in-memory": "4.10.2",
+				"@algolia/client-account": "4.10.2",
+				"@algolia/client-analytics": "4.10.2",
+				"@algolia/client-common": "4.10.2",
+				"@algolia/client-personalization": "4.10.2",
+				"@algolia/client-search": "4.10.2",
+				"@algolia/logger-common": "4.10.2",
+				"@algolia/logger-console": "4.10.2",
+				"@algolia/requester-browser-xhr": "4.10.2",
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/requester-node-http": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"node_modules/algoliasearch-helper": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz",
-			"integrity": "sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.5.3.tgz",
+			"integrity": "sha512-DtSlOKAJ6TGkQD6u58g6/ABdMmHf3pAj6xVL5hJF+D4z9ldDRf/f5v6puNIxGOlJRwGVvFGyz34beYNqhLDUbQ==",
 			"dependencies": {
 				"events": "^1.1.1"
 			},
@@ -3927,6 +3933,14 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
+		"node_modules/at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -3939,12 +3953,12 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
-			"integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.6.tgz",
+			"integrity": "sha512-8lChSmdU6dCNMCQopIf4Pe5kipkAGj/fvTMslCsih0uHpOrXOPUEVOmYMMqmw3cekQkSD7EhIeuYl5y0BLdKqg==",
 			"dependencies": {
 				"browserslist": "^4.16.6",
-				"caniuse-lite": "^1.0.30001243",
+				"caniuse-lite": "^1.0.30001230",
 				"colorette": "^1.2.2",
 				"fraction.js": "^4.1.1",
 				"normalize-range": "^0.1.2",
@@ -4530,9 +4544,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001249",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-			"integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+			"version": "1.0.30001241",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+			"integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/browserslist"
@@ -4986,9 +5000,9 @@
 			}
 		},
 		"node_modules/colord": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/colord/-/colord-2.6.0.tgz",
-			"integrity": "sha512-8yMrtE20ZxH1YWvvSoeJFtvqY+GIAOfU+mZ3jx7ZSiEMasnAmNqD1BKUP3CuCWcy/XHgcXkLW6YU8C35nhOYVg=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.1.0.tgz",
+			"integrity": "sha512-H5sDP9XDk2uP+x/xSGkgB9SEFc1bojdI5DMKU0jmSXQtml2GIe48dj1DcSS0e53QQAHn+JKqUXbGeGX24xWD7w=="
 		},
 		"node_modules/colorette": {
 			"version": "1.2.2",
@@ -5184,20 +5198,20 @@
 			}
 		},
 		"node_modules/copy-webpack-plugin": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
-			"integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-8.1.1.tgz",
+			"integrity": "sha512-rYM2uzRxrLRpcyPqGceRBDpxxUV8vcDqIKxAUKfcnFpcrPxT5+XvhTxv7XLjo5AvEJFPdAE3zCogG2JVahqgSQ==",
 			"dependencies": {
 				"fast-glob": "^3.2.5",
-				"glob-parent": "^6.0.0",
+				"glob-parent": "^5.1.1",
 				"globby": "^11.0.3",
 				"normalize-path": "^3.0.0",
 				"p-limit": "^3.1.0",
 				"schema-utils": "^3.0.0",
-				"serialize-javascript": "^6.0.0"
+				"serialize-javascript": "^5.0.1"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 10.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5205,17 +5219,6 @@
 			},
 			"peerDependencies": {
 				"webpack": "^5.1.0"
-			}
-		},
-		"node_modules/copy-webpack-plugin/node_modules/glob-parent": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.1.tgz",
-			"integrity": "sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/core-js": {
@@ -5317,9 +5320,9 @@
 			}
 		},
 		"node_modules/css-declaration-sorter": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.1.tgz",
-			"integrity": "sha512-BZ1aOuif2Sb7tQYY1GeCjG7F++8ggnwUkH5Ictw0mrdpqpEd+zWmcPdstnH2TItlb74FqR0DrVEieon221T/1Q==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.0.3.tgz",
+			"integrity": "sha512-52P95mvW1SMzuRZegvpluT6yEv0FqQusydKQPZsNN5Q7hh8EwQvN8E2nwuJ16BBvNN6LcoIZXu/Bk58DAhrrxw==",
 			"dependencies": {
 				"timsort": "^0.3.0"
 			},
@@ -5358,20 +5361,20 @@
 			}
 		},
 		"node_modules/css-minimizer-webpack-plugin": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-3.0.2.tgz",
-			"integrity": "sha512-B3I5e17RwvKPJwsxjjWcdgpU/zqylzK1bPVghcmpFHRL48DXiBgrtqz1BJsn68+t/zzaLp9kYAaEDvQ7GyanFQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-2.0.0.tgz",
+			"integrity": "sha512-cG/uc94727tx5pBNtb1Sd7gvUPzwmcQi1lkpfqTpdkuNq75hJCw7bIVsCNijLm4dhDcr1atvuysl2rZqOG8Txw==",
 			"dependencies": {
-				"cssnano": "^5.0.6",
-				"jest-worker": "^27.0.2",
+				"cssnano": "^5.0.0",
+				"jest-worker": "^26.3.0",
 				"p-limit": "^3.0.2",
-				"postcss": "^8.3.5",
+				"postcss": "^8.2.9",
 				"schema-utils": "^3.0.0",
-				"serialize-javascript": "^6.0.0",
+				"serialize-javascript": "^5.0.1",
 				"source-map": "^0.6.1"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 10.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5453,14 +5456,13 @@
 			}
 		},
 		"node_modules/cssnano": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.7.tgz",
-			"integrity": "sha512-7C0tbb298hef3rq+TtBbMuezBQ9VrFtrQEsPNuBKNVgWny/67vdRsnq8EoNu7TRjAHURgYvWlRIpCUmcMZkRzw==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.6.tgz",
+			"integrity": "sha512-NiaLH/7yqGksFGsFNvSRe2IV/qmEBAeDE64dYeD8OBrgp6lE8YoMeQJMtsv5ijo6MPyhuoOvFhI94reahBRDkw==",
 			"dependencies": {
+				"cosmiconfig": "^7.0.0",
 				"cssnano-preset-default": "^5.1.3",
-				"is-resolvable": "^1.1.0",
-				"lilconfig": "^2.0.3",
-				"yaml": "^1.10.2"
+				"is-resolvable": "^1.1.0"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14.0"
@@ -6018,12 +6020,12 @@
 			}
 		},
 		"node_modules/docusaurus-preset-shiki-twoslash": {
-			"version": "1.1.23",
-			"resolved": "https://registry.npmjs.org/docusaurus-preset-shiki-twoslash/-/docusaurus-preset-shiki-twoslash-1.1.23.tgz",
-			"integrity": "sha512-MGeHX11/6IUwYKNnnka8FUSyiZwtgl2Q2SNLE/z8p7fnPrzLgQWxmE4/KC54YsjoP2j9ACRQavJ8oEOwDIWMZA==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/docusaurus-preset-shiki-twoslash/-/docusaurus-preset-shiki-twoslash-1.1.16.tgz",
+			"integrity": "sha512-tvwCOw6Xnvu9Id8AsWIASm5Asbqa9yExeo8v6Zt7tbbVxwiEnuWkuN9bjMBnNQecUZPJYWMaq7m2jzLk6u7irA==",
 			"dependencies": {
 				"copy-text-to-clipboard": "^3.0.1",
-				"remark-shiki-twoslash": "2.0.8",
+				"remark-shiki-twoslash": "2.0.1",
 				"typescript": ">3"
 			}
 		},
@@ -7306,16 +7308,17 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 			"dependencies": {
+				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -8318,9 +8321,9 @@
 			}
 		},
 		"node_modules/infima": {
-			"version": "0.2.0-alpha.29",
-			"resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.29.tgz",
-			"integrity": "sha512-b6XX4QJekAYBPz2Y0XcXrDRaX/+96V95/WKWedY4zAWZ6xlzdxCrnyUgNaC4575aHcA2bfarLlTsP8FHFhjZFQ==",
+			"version": "0.2.0-alpha.23",
+			"resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.23.tgz",
+			"integrity": "sha512-V0RTjB1otjpH3E2asbydx3gz7ovdSJsuV7r9JTdBggqRilnelTJUcXxLawBQQKsjQi5qPcRTjxnlaV8xyyKhhw==",
 			"engines": {
 				"node": ">=12"
 			}
@@ -9249,6 +9252,33 @@
 				"fsevents": "^2.3.2"
 			}
 		},
+		"node_modules/jest-haste-map/node_modules/jest-worker": {
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+			"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+			"dependencies": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/jest-haste-map/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
 		"node_modules/jest-jasmine2": {
 			"version": "27.0.6",
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
@@ -9422,6 +9452,33 @@
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
+		"node_modules/jest-runner/node_modules/jest-worker": {
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+			"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+			"dependencies": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
 		"node_modules/jest-runtime": {
 			"version": "27.0.6",
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.6.tgz",
@@ -9554,30 +9611,16 @@
 			}
 		},
 		"node_modules/jest-worker": {
-			"version": "27.0.6",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-			"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
+				"supports-color": "^7.0.0"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/jest-worker/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/joi": {
@@ -9767,14 +9810,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/lilconfig": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/lines-and-columns": {
@@ -13202,16 +13237,16 @@
 			}
 		},
 		"node_modules/remark-shiki-twoslash": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/remark-shiki-twoslash/-/remark-shiki-twoslash-2.0.8.tgz",
-			"integrity": "sha512-FQXBBiXkdCTKJ52/FzOuURv7t06dOop7ByyS4PUoq6FUFBihpiKlfv44H1G/UuEYt3s3SCB/f9DxGZl6V8J/pg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-shiki-twoslash/-/remark-shiki-twoslash-2.0.1.tgz",
+			"integrity": "sha512-Xj2pMArldasY6WvqjaVR/G7HJnqIGYGIQlpNCpeq2kGTaABU80nJ5lF7AiELUGbg1f5aK4tosE24zo2ChWi9Zg==",
 			"dependencies": {
-				"@typescript/twoslash": "2.2.0",
+				"@typescript/twoslash": "2.1.0",
 				"@typescript/vfs": "1.3.4",
 				"fenceparser": "^1.1.0",
 				"regenerator-runtime": "^0.13.7",
 				"shiki": "0.9.3",
-				"shiki-twoslash": "2.1.6",
+				"shiki-twoslash": "2.0.3",
 				"tslib": "2.1.0",
 				"typescript": ">3",
 				"unist-util-visit": "^2.0.0"
@@ -13531,9 +13566,9 @@
 			"integrity": "sha512-2sMcZO60tL9YDEFe24gqddg3hJ+xSmJFN8IExcQUxeHxQzydQrN6GHPL+yAWgzItXSI7es53hcZC9pJneuZDKA=="
 		},
 		"node_modules/rtlcss": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-3.3.0.tgz",
-			"integrity": "sha512-XZ2KEatH2nU5yPlts1Wu8SGIuZ3ndN025HQX5MqtUCUiOn5WkCDbcpJ2VJWjpuFmM2cUTQ1xtH21fhMCSseI5A==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-3.2.1.tgz",
+			"integrity": "sha512-S9bh35JXwPIhfun7nFu/HjlNrwELL5nvTJqA1suLfbnqY/mauIL5sBkrJNHziVppX9PA2rJ7NV82+RtzB71mJA==",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"find-up": "^5.0.0",
@@ -13796,9 +13831,9 @@
 			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+			"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -14024,11 +14059,11 @@
 			}
 		},
 		"node_modules/shiki-twoslash": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/shiki-twoslash/-/shiki-twoslash-2.1.6.tgz",
-			"integrity": "sha512-98Irtz/UIA4KE7ipeXIhN3+OvZqI0PYOE0Iamqmken6H5WEOgwDep45PjPWmuK1vSmlN/PWYg9EQu5v/ZN7eIg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/shiki-twoslash/-/shiki-twoslash-2.0.3.tgz",
+			"integrity": "sha512-tUeoek4e0pShUp0AnkfLXl4DCnvcC3iI1pDspPfdWKaBYY8hPW7J4iWxf9VXkdCA7wxwmT1bsiZ6e9h9Tndehg==",
 			"dependencies": {
-				"@typescript/twoslash": "2.2.0",
+				"@typescript/twoslash": "2.1.0",
 				"@typescript/vfs": "1.3.4",
 				"shiki": "0.9.3",
 				"typescript": ">3"
@@ -14069,11 +14104,11 @@
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
 		},
 		"node_modules/sitemap": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.0.0.tgz",
-			"integrity": "sha512-Ud0jrRQO2k7fEtPAM+cQkBKoMvxQyPKNXKDLn8tRVHxRCsdDQ2JZvw+aZ5IRYYQVAV9iGxEar6boTwZzev+x3g==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/sitemap/-/sitemap-6.4.0.tgz",
+			"integrity": "sha512-DoPKNc2/apQZTUnfiOONWctwq7s6dZVspxAZe2VPMNtoqNq7HgXRvlRnbIpKjf+8+piQdWncwcy+YhhTGY5USQ==",
 			"dependencies": {
-				"@types/node": "^15.0.1",
+				"@types/node": "^14.14.28",
 				"@types/sax": "^1.2.1",
 				"arg": "^5.0.0",
 				"sax": "^1.2.4"
@@ -14082,14 +14117,14 @@
 				"sitemap": "dist/cli.js"
 			},
 			"engines": {
-				"node": ">=12.0.0",
+				"node": ">=10.3.0",
 				"npm": ">=5.6.0"
 			}
 		},
 		"node_modules/sitemap/node_modules/@types/node": {
-			"version": "15.14.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.7.tgz",
-			"integrity": "sha512-FA45p37/mLhpebgbPWWCKfOisTjxGK9lwcHlJ6XVLfu3NgfcazOJHdYUZCWPMK8QX4LhNZdmfo6iMz9FqpUbaw=="
+			"version": "14.17.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
+			"integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A=="
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -14994,12 +15029,47 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
+		"node_modules/terser-webpack-plugin/node_modules/jest-worker": {
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+			"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+			"dependencies": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"dependencies": {
+				"randombytes": "^2.1.0"
+			}
+		},
 		"node_modules/terser-webpack-plugin/node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/terser-webpack-plugin/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/terser-webpack-plugin/node_modules/terser": {
@@ -17281,139 +17351,139 @@
 	},
 	"dependencies": {
 		"@algolia/autocomplete-core": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.2.1.tgz",
-			"integrity": "sha512-/SLS6636Wpl7eFiX7eEy0E3wBo60sUm1qRYybJBDt1fs8reiJ1+OSy+dZgrLBfLL4mSFqRIIUHXbVp25QdZ+iw==",
+			"version": "1.0.0-alpha.44",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.0.0-alpha.44.tgz",
+			"integrity": "sha512-2iMXthldMIDXtlbg9omRKLgg1bLo2ZzINAEqwhNjUeyj1ceEyL1ck6FY0VnJpf2LsjmNthHCz2BuFk+nYUeDNA==",
 			"requires": {
-				"@algolia/autocomplete-shared": "1.2.1"
+				"@algolia/autocomplete-shared": "1.0.0-alpha.44"
 			}
 		},
 		"@algolia/autocomplete-preset-algolia": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.2.1.tgz",
-			"integrity": "sha512-Lf4PpPVgHNXm1ytrnVdrZYV7hAYSCpAI/TrebF8UC6xflPY6sKb1RL/2OfrO9On7SDjPBtNd+6MArSar5JmK0g==",
+			"version": "1.0.0-alpha.44",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.44.tgz",
+			"integrity": "sha512-DCHwo5ovzg9k2ejUolGNTLFnIA7GpsrkbNJTy1sFbMnYfBmeK8egZPZnEl7lBTr27OaZu7IkWpTepLVSztZyng==",
 			"requires": {
-				"@algolia/autocomplete-shared": "1.2.1"
+				"@algolia/autocomplete-shared": "1.0.0-alpha.44"
 			}
 		},
 		"@algolia/autocomplete-shared": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.2.1.tgz",
-			"integrity": "sha512-RHCwcXAYFwDXTlomstjWRFIzOfyxtQ9KmViacPE5P5hxUSSjkmG3dAb77xdydift1PaZNbho5TNTCi5UZe0RpA=="
+			"version": "1.0.0-alpha.44",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.0.0-alpha.44.tgz",
+			"integrity": "sha512-2oQZPERYV+yNx/yoVWYjZZdOqsitJ5dfxXJjL18yczOXH6ujnsq+DTczSrX+RjzjQdVeJ1UAG053EJQF/FOiMg=="
 		},
 		"@algolia/cache-browser-local-storage": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.3.tgz",
-			"integrity": "sha512-TD1N7zg5lb56/PLjjD4bBl2eccEvVHhC7yfgFu2r9k5tf+gvbGxEZ3NhRZVKu2MObUIcEy2VR4LVLxOQu45Hlg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.2.tgz",
+			"integrity": "sha512-B3NInwobEAim4J4Y0mgZermoi0DCXdTT/Q+4ehLamqUqxLw8To5zc9izjg7B8JaFSQsqflRdCeRmYEv2gYDY7g==",
 			"requires": {
-				"@algolia/cache-common": "4.10.3"
+				"@algolia/cache-common": "4.10.2"
 			}
 		},
 		"@algolia/cache-common": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.3.tgz",
-			"integrity": "sha512-q13cPPUmtf8a2suBC4kySSr97EyulSXuxUkn7l1tZUCX/k1y5KNheMp8npBy8Kc8gPPmHpacxddRSfOncjiKFw=="
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.2.tgz",
+			"integrity": "sha512-xcGbV0+6gLu2C7XoJdD+Pp6wWjROle6PNDsa6O21vS7fw1a03xb2bEnFdl1U31bs69P1z8IRy3h+8RVBouvhhw=="
 		},
 		"@algolia/cache-in-memory": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.3.tgz",
-			"integrity": "sha512-JhPajhOXAjUP+TZrZTh6KJpF5VKTKyWK2aR1cD8NtrcVHwfGS7fTyfXfVm5BqBqkD9U0gVvufUt/mVyI80aZww==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.2.tgz",
+			"integrity": "sha512-zPIcxHQEJXy+M35A+v9Y5u5BAQOKR2aFK0kYpAdW/OrgxYcrFHtVCxwIWB/ZhGbkDtzCW8/8tJeddcD5YsHX9Q==",
 			"requires": {
-				"@algolia/cache-common": "4.10.3"
+				"@algolia/cache-common": "4.10.2"
 			}
 		},
 		"@algolia/client-account": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.3.tgz",
-			"integrity": "sha512-S/IsJB4s+e1xYctdpW3nAbwrR2y3pjSo9X21fJGoiGeIpTRdvQG7nydgsLkhnhcgAdLnmqBapYyAqMGmlcyOkg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.2.tgz",
+			"integrity": "sha512-iuIU+xUtjgR9p4Hpujlr8mePDPSrVIk3peg+RAUhxniLBDaI+OhgHyhP6Lmh9flWk+JfRg91Rhk46xuxMLqwfA==",
 			"requires": {
-				"@algolia/client-common": "4.10.3",
-				"@algolia/client-search": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/client-common": "4.10.2",
+				"@algolia/client-search": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"@algolia/client-analytics": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.3.tgz",
-			"integrity": "sha512-vlHTbBqJktRgclh3v7bPQLfZvFIqY4erNFIZA5C7nisCj9oLeTgzefoUrr+R90+I+XjfoLxnmoeigS1Z1yg1vw==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.2.tgz",
+			"integrity": "sha512-u47J65NHs0fMryDrMeuLMGjXDOKt/muF9WlfbMslT2Cvdd7PZwl9KYnT7xMhnmBB8TDiDMmEQkDykhnCOnwVNw==",
 			"requires": {
-				"@algolia/client-common": "4.10.3",
-				"@algolia/client-search": "4.10.3",
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/client-common": "4.10.2",
+				"@algolia/client-search": "4.10.2",
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"@algolia/client-common": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.3.tgz",
-			"integrity": "sha512-uFyP2Z14jG2hsFRbAoavna6oJf4NTXaSDAZgouZUZlHlBp5elM38sjNeA5HR9/D9J/GjwaB1SgB7iUiIWYBB4w==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.2.tgz",
+			"integrity": "sha512-sfgZCv9ha9aHbe3ErAYb1blg2qx4XTLvQqP1jq8asU75rrH9XBTtSzQQO43GlArwhtwCHLgcWquN3WgPlLzkiQ==",
 			"requires": {
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"@algolia/client-personalization": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.3.tgz",
-			"integrity": "sha512-NS7Nx8EJ/nduGXT8CFo5z7kLF0jnFehTP3eC+z+GOEESH3rrs7uR12IZHxv5QhQswZa9vl925zCOZDcDVoENCg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.2.tgz",
+			"integrity": "sha512-2UhUNo/czfA/keOC3+vFyMnFGV/E1Zkm+ek9Fsk/9miS39UMhx2CmH5vKSIJ7jxLSin7zBaCwKt65phfYty1pg==",
 			"requires": {
-				"@algolia/client-common": "4.10.3",
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/client-common": "4.10.2",
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"@algolia/client-search": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.3.tgz",
-			"integrity": "sha512-Zwnp2G94IrNFKWCG/k7epI5UswRkPvL9FCt7/slXe2bkjP2y/HA37gzRn+9tXoLVRwd7gBzrtOA4jFKIyjrtVw==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.2.tgz",
+			"integrity": "sha512-ZdOh6XS6Y9bcekfG4y0VhdoIYfsTounsgXX4Bt3X2RCcmY3uotgaq2EVY58E6q6nvfgBfPHW18+AZCHKTWHAAw==",
 			"requires": {
-				"@algolia/client-common": "4.10.3",
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/client-common": "4.10.2",
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"@algolia/logger-common": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.3.tgz",
-			"integrity": "sha512-M6xi+qov2bkgg1H9e1Qtvq/E/eKsGcgz8RBbXNzqPIYoDGZNkv+b3b8YMo3dxd4Wd6M24HU1iqF3kmr1LaXndg=="
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.2.tgz",
+			"integrity": "sha512-UJaU6arzmW+FT5fCv5NIbxNMtEoGcf+UENmZxxu7k7UWPARR2XL4ljJ45Jv14Z5dlz32LXWtR1PRmNfkDMk22Q=="
 		},
 		"@algolia/logger-console": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.3.tgz",
-			"integrity": "sha512-vVgRI7b4PHjgBdRkv/cRz490twvkLoGdpC4VYzIouSrKj8SIVLRhey3qgXk7oQXi3xoxVAv6NrklHfpO8Bpx0w==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.2.tgz",
+			"integrity": "sha512-JrCrZ7CGs/TsyNR2AWe9Vdd6rsuxfvfcpqbu+CY7LBUYEnV8GERkf7FnDNaKVNsFJqClILCGh3U8CzQ1G5L+kA==",
 			"requires": {
-				"@algolia/logger-common": "4.10.3"
+				"@algolia/logger-common": "4.10.2"
 			}
 		},
 		"@algolia/requester-browser-xhr": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.3.tgz",
-			"integrity": "sha512-4WIk1zreFbc1EF6+gsfBTQvwSNjWc20zJAAExRWql/Jq5yfVHmwOqi/CajA53/cXKFBqo80DAMRvOiwP+hOLYw==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.2.tgz",
+			"integrity": "sha512-LveaAp7/oCBotv1aZ4VHz8fCcJA7v/28ayh+Ljlm+hYXsxgs6NAYKz7iBpxGN7q5MV8GM+MThRYNFoT0cHTMxQ==",
 			"requires": {
-				"@algolia/requester-common": "4.10.3"
+				"@algolia/requester-common": "4.10.2"
 			}
 		},
 		"@algolia/requester-common": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.3.tgz",
-			"integrity": "sha512-PNfLHmg0Hujugs3rx55uz/ifv7b9HVdSFQDb2hj0O5xZaBEuQCNOXC6COrXR8+9VEfqp2swpg7zwgtqFxh+BtQ=="
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.2.tgz",
+			"integrity": "sha512-3J2W0fAaURLGK0lEGeNb8eWJnQcsu+oIcfJTCIYkYT5T9w21M65kUUyD9QSf/K137qQts3tzGniUR3LxfovlXA=="
 		},
 		"@algolia/requester-node-http": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.3.tgz",
-			"integrity": "sha512-A9ZcGfEvgqf0luJApdNcIhsRh6MShn2zn2tbjwjGG1joF81w+HUY+BWuLZn56vGwAA9ZB9n00IoJJpxibbfofg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.2.tgz",
+			"integrity": "sha512-IBqsalCGgn0CrOP1PKRB5rufEOvHlrSQUFEGXZ8mxmE/zU8CLX2LKqdHbEFeNDLFl+l+8HW5BGVDGD2rvG+hSg==",
 			"requires": {
-				"@algolia/requester-common": "4.10.3"
+				"@algolia/requester-common": "4.10.2"
 			}
 		},
 		"@algolia/transporter": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.3.tgz",
-			"integrity": "sha512-n1lRyKDbrckbMEgm7QXtj3nEWUuzA3aKLzVQ43/F/RCFib15j4IwtmYhXR6OIBRSc7+T0Hm48S0J6F+HeYCQkw==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.2.tgz",
+			"integrity": "sha512-I3QDRSookQtPSUEnxT2XCShhipCT4beJBpWhteNwMrWQF/SqTsveqSR6bX0G49lDh9MOmYrOlCegteuKuT/tEw==",
 			"requires": {
-				"@algolia/cache-common": "4.10.3",
-				"@algolia/logger-common": "4.10.3",
-				"@algolia/requester-common": "4.10.3"
+				"@algolia/cache-common": "4.10.2",
+				"@algolia/logger-common": "4.10.2",
+				"@algolia/requester-common": "4.10.2"
 			}
 		},
 		"@babel/code-frame": {
@@ -18599,25 +18669,25 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
 		},
 		"@docsearch/css": {
-			"version": "3.0.0-alpha.39",
-			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.39.tgz",
-			"integrity": "sha512-lr10MFTgcR3NRea/FtJ7uNtIpQz0XVwYxbpO5wxykgfHu1sxZTr6zwkuPquRgFYXnccxsTvfoIiK3rMH0fLr/w=="
+			"version": "3.0.0-alpha.36",
+			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.36.tgz",
+			"integrity": "sha512-zSN2SXuZPDqQaSFzYa1kOwToukqzhLHG7c66iO+/PlmWb6/RZ5cjTkG6VCJynlohRWea7AqZKWS/ptm8kM2Dmg=="
 		},
 		"@docsearch/react": {
-			"version": "3.0.0-alpha.39",
-			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0-alpha.39.tgz",
-			"integrity": "sha512-urTIt82tan6CU+D2kO6xXpWQom/r1DA7L/55m2JiCIK/3SLh2z15FJFVN2abeK7B4wl8pCfWunYOwCsSHhWDLA==",
+			"version": "3.0.0-alpha.36",
+			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0-alpha.36.tgz",
+			"integrity": "sha512-synYZDHalvMzesFiy7kK+uoz4oTdWSTbe2cU+iiUjwFMyQ+WWjWwGVnvcvk+cjj9pRCVaZo5y5WpqNXq1j8k9Q==",
 			"requires": {
-				"@algolia/autocomplete-core": "1.2.1",
-				"@algolia/autocomplete-preset-algolia": "1.2.1",
-				"@docsearch/css": "3.0.0-alpha.39",
+				"@algolia/autocomplete-core": "1.0.0-alpha.44",
+				"@algolia/autocomplete-preset-algolia": "1.0.0-alpha.44",
+				"@docsearch/css": "3.0.0-alpha.36",
 				"algoliasearch": "^4.0.0"
 			}
 		},
 		"@docusaurus/core": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.4.tgz",
-			"integrity": "sha512-ITa976MPFl9KbYchMOWCCX6SU6EFDSdGeGOHtpaNcrJ9e9Sj7o77fKmMH/ciShwz1g8brTm3VxZ0FwleU8lTig==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.0.tgz",
+			"integrity": "sha512-xWwpuEwFRKJmZvNGOpr/dyRDnx/psckLPsozQTg2hu3u81Wqu9gigWgYK/C2fPlEjxMcVw0/2WH+zwpbyWmF2Q==",
 			"requires": {
 				"@babel/core": "^7.12.16",
 				"@babel/generator": "^7.12.15",
@@ -18629,49 +18699,47 @@
 				"@babel/runtime": "^7.12.5",
 				"@babel/runtime-corejs3": "^7.12.13",
 				"@babel/traverse": "^7.12.13",
-				"@docusaurus/cssnano-preset": "2.0.0-beta.4",
+				"@docusaurus/cssnano-preset": "2.0.0-beta.0",
 				"@docusaurus/react-loadable": "5.5.0",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-common": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
-				"@slorber/static-site-generator-webpack-plugin": "^4.0.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
+				"@endiliey/static-site-generator-webpack-plugin": "^4.0.0",
 				"@svgr/webpack": "^5.5.0",
 				"autoprefixer": "^10.2.5",
 				"babel-loader": "^8.2.2",
 				"babel-plugin-dynamic-import-node": "2.3.0",
-				"boxen": "^5.0.1",
-				"chalk": "^4.1.1",
+				"boxen": "^5.0.0",
+				"chalk": "^4.1.0",
 				"chokidar": "^3.5.1",
-				"clean-css": "^5.1.2",
+				"clean-css": "^5.1.1",
 				"commander": "^5.1.0",
-				"copy-webpack-plugin": "^9.0.0",
+				"copy-webpack-plugin": "^8.1.0",
 				"core-js": "^3.9.1",
 				"css-loader": "^5.1.1",
-				"css-minimizer-webpack-plugin": "^3.0.1",
-				"cssnano": "^5.0.4",
+				"css-minimizer-webpack-plugin": "^2.0.0",
+				"cssnano": "^5.0.1",
 				"del": "^6.0.0",
 				"detect-port": "^1.3.0",
-				"escape-html": "^1.0.3",
 				"eta": "^1.12.1",
 				"express": "^4.17.1",
 				"file-loader": "^6.2.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.1.0",
 				"github-slugger": "^1.3.0",
 				"globby": "^11.0.2",
 				"html-minifier-terser": "^5.1.1",
 				"html-tags": "^3.1.0",
-				"html-webpack-plugin": "^5.3.2",
+				"html-webpack-plugin": "^5.2.0",
 				"import-fresh": "^3.3.0",
 				"is-root": "^2.1.0",
 				"leven": "^3.1.0",
 				"lodash": "^4.17.20",
-				"mini-css-extract-plugin": "^1.6.0",
+				"mini-css-extract-plugin": "^1.4.0",
 				"module-alias": "^2.2.2",
 				"nprogress": "^0.2.0",
-				"postcss": "^8.2.15",
-				"postcss-loader": "^5.3.0",
-				"prompts": "^2.4.1",
+				"postcss": "^8.2.10",
+				"postcss-loader": "^5.2.0",
+				"prompts": "^2.4.0",
 				"react-dev-utils": "^11.0.1",
 				"react-error-overlay": "^6.0.9",
 				"react-helmet": "^6.1.0",
@@ -18681,21 +18749,21 @@
 				"react-router-config": "^5.1.1",
 				"react-router-dom": "^5.2.0",
 				"resolve-pathname": "^3.0.0",
-				"rtl-detect": "^1.0.3",
+				"rtl-detect": "^1.0.2",
 				"semver": "^7.3.4",
 				"serve-handler": "^6.1.3",
 				"shelljs": "^0.8.4",
 				"std-env": "^2.2.1",
 				"strip-ansi": "^6.0.0",
-				"terser-webpack-plugin": "^5.1.3",
-				"tslib": "^2.2.0",
+				"terser-webpack-plugin": "^5.1.1",
+				"tslib": "^2.1.0",
 				"update-notifier": "^5.1.0",
 				"url-loader": "^4.1.1",
-				"wait-on": "^5.3.0",
-				"webpack": "^5.40.0",
-				"webpack-bundle-analyzer": "^4.4.2",
+				"wait-on": "^5.2.1",
+				"webpack": "^5.28.0",
+				"webpack-bundle-analyzer": "^4.4.0",
 				"webpack-dev-server": "^3.11.2",
-				"webpack-merge": "^5.8.0",
+				"webpack-merge": "^5.7.3",
 				"webpackbar": "^5.0.0-3"
 			},
 			"dependencies": {
@@ -18710,83 +18778,80 @@
 			}
 		},
 		"@docusaurus/cssnano-preset": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.4.tgz",
-			"integrity": "sha512-KsmFEob0ElffnFFbz93wcYH4IncU4LDnKBerdomU0Wdg/vXTLo3Q7no8df9yjbcBXVRaSX+/tNFapY9Iu/4Cew==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.0.tgz",
+			"integrity": "sha512-gqQHeQCDHZDd5NaiKZwDiyg75sBCqDyAsvmFukkDAty8xE7u9IhzbOQKvCAtwseuvzu2BNN41gnJ8bz7vZzQiw==",
 			"requires": {
-				"cssnano-preset-advanced": "^5.1.1",
-				"postcss": "^8.2.15",
-				"postcss-sort-media-queries": "^3.10.11"
+				"cssnano-preset-advanced": "^5.0.0",
+				"postcss": "^8.2.10",
+				"postcss-sort-media-queries": "^3.8.9"
 			}
 		},
 		"@docusaurus/mdx-loader": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.4.tgz",
-			"integrity": "sha512-dwYKFKcsgiMB/TECoieKnwQemBAozd2a+cm4xzrWhDzElvwlQPo/j45OOUb6U/H8NJp7DnAynLBqSyKJ3YZb4g==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.0.tgz",
+			"integrity": "sha512-oQLS2ZeUnqw79CV37glglZpaYgFfA5Az5lT83m5tJfMUZjoK4ehG1XWBeUzWy8QQNI452yAID8jz8jihEQeCcw==",
 			"requires": {
 				"@babel/parser": "^7.12.16",
 				"@babel/traverse": "^7.12.13",
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
 				"@mdx-js/mdx": "^1.6.21",
 				"@mdx-js/react": "^1.6.21",
-				"chalk": "^4.1.1",
 				"escape-html": "^1.0.3",
 				"file-loader": "^6.2.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.1.0",
 				"github-slugger": "^1.3.0",
-				"gray-matter": "^4.0.3",
+				"gray-matter": "^4.0.2",
 				"mdast-util-to-string": "^2.0.0",
 				"remark-emoji": "^2.1.0",
 				"stringify-object": "^3.3.0",
 				"unist-util-visit": "^2.0.2",
 				"url-loader": "^4.1.1",
-				"webpack": "^5.40.0"
+				"webpack": "^5.28.0"
 			}
 		},
 		"@docusaurus/module-type-aliases": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.4.tgz",
-			"integrity": "sha512-FRAAOJMDbHcBNgFvH4ihPszxraTTCkS7kN3q8WIj67Uv8u3+T36XWpReWdFYmzfPA4QyFx9YK4u1bmF7pndBSw=="
+			"version": "2.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.3.tgz",
+			"integrity": "sha512-vciejziDBu39cyfmdvbpn865YlvugJMUOeD2m/7Kg4RLUPIZzQTWns0ZGIMc/iToiwebHwkoJtRsHaHzj8FpnA=="
 		},
 		"@docusaurus/plugin-content-blog": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.4.tgz",
-			"integrity": "sha512-NyLqoem/r/m8mNO3H1PbbPayA5KjgRTeB5T7j949uvGwlK34c+W6bSvr3OSRJdmFXqhFL4CG8E8wbSq7h+8WEA==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.0.tgz",
+			"integrity": "sha512-lz63i5k/23RJ3Rk/2fIsYAoD8Wua3b5b0AbH2JoOhQu1iAIQiV8m91Z3XALBSzA3nBtAOIweNI7yzWL+JFSTvw==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/mdx-loader": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
-				"chalk": "^4.1.1",
-				"escape-string-regexp": "^4.0.0",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/mdx-loader": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
+				"chalk": "^4.1.0",
 				"feed": "^4.2.2",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.1.0",
 				"globby": "^11.0.2",
 				"loader-utils": "^2.0.0",
 				"lodash": "^4.17.20",
 				"reading-time": "^1.3.0",
 				"remark-admonitions": "^1.2.1",
-				"tslib": "^2.2.0",
-				"webpack": "^5.40.0"
+				"tslib": "^2.1.0",
+				"webpack": "^5.28.0"
 			}
 		},
 		"@docusaurus/plugin-content-docs": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.4.tgz",
-			"integrity": "sha512-aVYycpOvtgPQ78a10jakCtrI7DEAffw+zVdZT6tgO8QIn5hNPcr5NB7Ms3kSZw83fMZwJqStHHGp0y13zt/gLw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.0.tgz",
+			"integrity": "sha512-WdDQUh2rRCbfJswVc0vY9EaAspxgziqpVEZja8+BmQR/TZh7HuLplT6GJbiFbE4RvwM3+PwG/jHMPglYDK60kw==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/mdx-loader": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
-				"chalk": "^4.1.1",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/mdx-loader": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
+				"chalk": "^4.1.0",
 				"combine-promises": "^1.1.0",
-				"escape-string-regexp": "^4.0.0",
 				"execa": "^5.0.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.1.0",
 				"globby": "^11.0.2",
 				"import-fresh": "^3.2.2",
 				"js-yaml": "^4.0.0",
@@ -18794,9 +18859,9 @@
 				"lodash": "^4.17.20",
 				"remark-admonitions": "^1.2.1",
 				"shelljs": "^0.8.4",
-				"tslib": "^2.2.0",
+				"tslib": "^2.1.0",
 				"utility-types": "^3.10.0",
-				"webpack": "^5.40.0"
+				"webpack": "^5.28.0"
 			},
 			"dependencies": {
 				"json5": {
@@ -18820,80 +18885,81 @@
 			}
 		},
 		"@docusaurus/plugin-content-pages": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.4.tgz",
-			"integrity": "sha512-VZ/iuxT1kgBh/1+W3Li88UZVjqHtHOt4TyFoVwHmf2p91BPHiF7zpiLb4hYL8s694/V+AdfWf4ostSyEoeMx8A==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.0.tgz",
+			"integrity": "sha512-mk5LVVSvn+HJPKBaAs/Pceq/hTGxF2LVBvJEquuQz0NMAW3QdBWaYRRpOrL9CO8v+ygn5RuLslXsyZBsDNuhww==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/mdx-loader": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/mdx-loader": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
 				"globby": "^11.0.2",
 				"lodash": "^4.17.20",
+				"minimatch": "^3.0.4",
 				"remark-admonitions": "^1.2.1",
+				"slash": "^3.0.0",
 				"tslib": "^2.1.0",
-				"webpack": "^5.40.0"
+				"webpack": "^5.28.0"
 			}
 		},
 		"@docusaurus/plugin-debug": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.4.tgz",
-			"integrity": "sha512-jc9o45NUuhVnFcoq6/6juxJQGgD2Q71IUokoOgw3sytHHOv1jv+eLWP1LDX71MHA1ElZ1MZTlz5mCd1wlzdCOw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.0.tgz",
+			"integrity": "sha512-m75sZdF8Yccxfih3qfdQg9DucMTrYBnmeTA8GNmdVaK701Ip8t50d1pDJchtu0FSEh6vzVB9C6D2YD5YgVFp8A==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"react-json-view": "^1.21.3",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"react-json-view": "^1.21.1",
 				"tslib": "^2.1.0"
 			}
 		},
 		"@docusaurus/plugin-google-analytics": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.4.tgz",
-			"integrity": "sha512-mqMEnfMKIoR1UfIX+jiAcUolwYntqSNaW8Gg2tg8dlGvC3payT1gpNJaew6TWyrtE29vuZz6a830bIXBYm4uAA==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.0.tgz",
+			"integrity": "sha512-7lHrg1L+adc8VbiaLexa15i4fdq4MRPUTLMxRPAWz+QskhisW89Ryi2/gDmfMNqLblX84Qg2RASa+2gqO4wepw==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4"
+				"@docusaurus/core": "2.0.0-beta.0"
 			}
 		},
 		"@docusaurus/plugin-google-gtag": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.4.tgz",
-			"integrity": "sha512-MZ0Rr6LBZLKMVFXxV7Kr+l0U3Yz/Yn8L2E5z9DbgVi+9tyLn4xlMzuMPG3gN9TZ8kPcQ1ZWwv9crA+138UzIkw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.0.tgz",
+			"integrity": "sha512-V7zaYbhAMv0jexm5H/5sAnoM1GHibcn9QQk5UWC++x1kE0KRuLDZHV+9OyvW5wr0wWFajod/b88SpUpSMF5u+g==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4"
+				"@docusaurus/core": "2.0.0-beta.0"
 			}
 		},
 		"@docusaurus/plugin-sitemap": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.4.tgz",
-			"integrity": "sha512-0sU1aMQmMN7fE3TlSM2wBZN/gFsuvo79DYxw8TIVtNakA84oDxurH/rhDQHwJ34JQufm5CuWNC1ICHtyI3qyWw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.0.tgz",
+			"integrity": "sha512-dvmk8Sr+6pBkiKDb7Rjdp0GeFDWPUlayoJWK3fN3g0Fno6uxFfYhNZyXJ+ObyCA7HoW5rzeBMiO+uAja19JXTg==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-common": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
-				"fs-extra": "^10.0.0",
-				"sitemap": "^7.0.0",
-				"tslib": "^2.2.0"
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
+				"fs-extra": "^9.1.0",
+				"sitemap": "^6.3.6",
+				"tslib": "^2.1.0"
 			}
 		},
 		"@docusaurus/preset-classic": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.4.tgz",
-			"integrity": "sha512-fW8/iyGLJfBTtbCBQtnRcbDa+ZZMq6Ak20+8+ORB8mzjK4BNYmt9wIbfq0oV9/QBLyryQBYcsRimJoXpLZmWOg==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.0.tgz",
+			"integrity": "sha512-cFpR0UaAeUt5qVx1bpidhlar6tiRNITIQlxP4bOVsjbxVTZhZ/cNuIz7C+2zFPCuKIflGXdTIQOrucPmd7z51Q==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-blog": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-docs": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-pages": "2.0.0-beta.4",
-				"@docusaurus/plugin-debug": "2.0.0-beta.4",
-				"@docusaurus/plugin-google-analytics": "2.0.0-beta.4",
-				"@docusaurus/plugin-google-gtag": "2.0.0-beta.4",
-				"@docusaurus/plugin-sitemap": "2.0.0-beta.4",
-				"@docusaurus/theme-classic": "2.0.0-beta.4",
-				"@docusaurus/theme-search-algolia": "2.0.0-beta.4"
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-blog": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-docs": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-pages": "2.0.0-beta.0",
+				"@docusaurus/plugin-debug": "2.0.0-beta.0",
+				"@docusaurus/plugin-google-analytics": "2.0.0-beta.0",
+				"@docusaurus/plugin-google-gtag": "2.0.0-beta.0",
+				"@docusaurus/plugin-sitemap": "2.0.0-beta.0",
+				"@docusaurus/theme-classic": "2.0.0-beta.0",
+				"@docusaurus/theme-search-algolia": "2.0.0-beta.0"
 			}
 		},
 		"@docusaurus/react-loadable": {
@@ -18905,31 +18971,30 @@
 			}
 		},
 		"@docusaurus/theme-classic": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.4.tgz",
-			"integrity": "sha512-gekEt/YuAEs7CLEJhBC5mE3AqXiDNL6U3WI9emokatpbPY7B12DLJ11QWJZ4mfKYWHuiTwPeybXkOySWMLuaaA==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.0.tgz",
+			"integrity": "sha512-cBNtwAyg3be7Gk41FazMtgyibAcfuYaGHhGHIDRsXfc/qp3RhbiGiei7tyh200QT0NgKZxiVQy/r4d0mtjC++Q==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-blog": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-docs": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-pages": "2.0.0-beta.4",
-				"@docusaurus/theme-common": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-common": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-blog": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-docs": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-pages": "2.0.0-beta.0",
+				"@docusaurus/theme-common": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
 				"@mdx-js/mdx": "^1.6.21",
 				"@mdx-js/react": "^1.6.21",
-				"chalk": "^4.1.1",
+				"chalk": "^4.1.0",
 				"clsx": "^1.1.1",
-				"copy-text-to-clipboard": "^3.0.1",
-				"fs-extra": "^10.0.0",
+				"copy-text-to-clipboard": "^3.0.0",
+				"fs-extra": "^9.1.0",
 				"globby": "^11.0.2",
-				"infima": "0.2.0-alpha.29",
+				"infima": "0.2.0-alpha.23",
 				"lodash": "^4.17.20",
 				"parse-numeric-range": "^1.2.0",
-				"postcss": "^8.2.15",
-				"prism-react-renderer": "^1.2.1",
+				"postcss": "^8.2.10",
+				"prism-react-renderer": "^1.1.1",
 				"prismjs": "^1.23.0",
 				"prop-types": "^15.7.2",
 				"react-router-dom": "^5.2.0",
@@ -18937,30 +19002,28 @@
 			}
 		},
 		"@docusaurus/theme-common": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.4.tgz",
-			"integrity": "sha512-RJ78rfb/K2dc/u/WDCZB8Q8mj19l7UtDx3F1yFC4WMwAd5tT8V5xlKc5UpHVJrKdc1c3Z4g+ki0wFm+LpCZj0w==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.0.tgz",
+			"integrity": "sha512-2rcVmQpvbdAgnzTWuM7Bfpu+2TQm928bhlvxn226jQy7IYz8ySRlIode63HhCtpx03hpdMCkrK6HxhfEcvHjQg==",
 			"requires": {
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-blog": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-docs": "2.0.0-beta.4",
-				"@docusaurus/plugin-content-pages": "2.0.0-beta.4",
-				"@docusaurus/types": "2.0.0-beta.4",
-				"clsx": "^1.1.1",
-				"fs-extra": "^10.0.0",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-blog": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-docs": "2.0.0-beta.0",
+				"@docusaurus/plugin-content-pages": "2.0.0-beta.0",
+				"@docusaurus/types": "2.0.0-beta.0",
 				"tslib": "^2.1.0"
 			}
 		},
 		"@docusaurus/theme-search-algolia": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.4.tgz",
-			"integrity": "sha512-W/DfGhlAe1Vl+IJiL9rCw8yswdUrX0lTyCMNRAFi749YN4vCWo2RoxylbUuWoV6lUKoIYfj3EGyotRT2OLqtZw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.0.tgz",
+			"integrity": "sha512-/GhgAm4yuwqTXWTsWnqpFYxpjTv+t45Wk8q/LmTVINa+A7b6jkMkch2lygagIt69/ufDm2Uw6eYhgrmF4DJqfQ==",
 			"requires": {
-				"@docsearch/react": "^3.0.0-alpha.39",
-				"@docusaurus/core": "2.0.0-beta.4",
-				"@docusaurus/theme-common": "2.0.0-beta.4",
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"@docusaurus/utils-validation": "2.0.0-beta.4",
+				"@docsearch/react": "^3.0.0-alpha.33",
+				"@docusaurus/core": "2.0.0-beta.0",
+				"@docusaurus/theme-common": "2.0.0-beta.0",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"@docusaurus/utils-validation": "2.0.0-beta.0",
 				"algoliasearch": "^4.8.4",
 				"algoliasearch-helper": "^3.3.4",
 				"clsx": "^1.1.1",
@@ -18969,53 +19032,54 @@
 			}
 		},
 		"@docusaurus/types": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.4.tgz",
-			"integrity": "sha512-2aMCliUCBYhZO8UiiPIKpRu2KECtqt0nRu44EbN6rj1STf695AIOhJC1Zo5TiuW2WbiljSbkJTgG3XdBZ3FUBw==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.0.tgz",
+			"integrity": "sha512-z9PI+GbtYwqTXnkX4/a/A6psDX2p8N2uWlN2f4ifrm8WY4WhR9yiTOh0uo0pIqqaUQQvkEq3o5hOXuXLECEs+w==",
 			"requires": {
 				"commander": "^5.1.0",
 				"joi": "^17.4.0",
 				"querystring": "0.2.0",
-				"webpack": "^5.40.0",
-				"webpack-merge": "^5.8.0"
+				"webpack": "^5.28.0",
+				"webpack-merge": "^5.7.3"
 			}
 		},
 		"@docusaurus/utils": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.4.tgz",
-			"integrity": "sha512-6nI3ETBp0ZSt5yp5Fc5nthQjR1MmLgl2rXC3hcscrSUZx0QvzJFzTiRgD9EAIJtR/i2JkUK18eaFiBjMBoXEbQ==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.0.tgz",
+			"integrity": "sha512-bvrT1EQu0maavr0Hb/lke9jmpzgVL/9tn5VQtbyahf472eJFY0bQDExllDrHK+l784SUvucqX0iaQeg0q6ySUw==",
 			"requires": {
-				"@docusaurus/types": "2.0.0-beta.4",
+				"@docusaurus/types": "2.0.0-beta.0",
 				"@types/github-slugger": "^1.3.0",
-				"chalk": "^4.1.1",
+				"chalk": "^4.1.0",
 				"escape-string-regexp": "^4.0.0",
-				"fs-extra": "^10.0.0",
-				"globby": "^11.0.4",
-				"gray-matter": "^4.0.3",
+				"fs-extra": "^9.1.0",
+				"gray-matter": "^4.0.2",
 				"lodash": "^4.17.20",
-				"micromatch": "^4.0.4",
 				"resolve-pathname": "^3.0.0",
-				"tslib": "^2.2.0"
-			}
-		},
-		"@docusaurus/utils-common": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.4.tgz",
-			"integrity": "sha512-QaKs96/95ztKgZqHMUS/vNl+GzZ/6vKVEPjBXWt7Fdhg2soT1Iu4cShnibEO5HaVlwSfnJbVmDLVm8phQRdr0A==",
-			"requires": {
-				"@docusaurus/types": "2.0.0-beta.4",
-				"tslib": "^2.2.0"
+				"tslib": "^2.1.0"
 			}
 		},
 		"@docusaurus/utils-validation": {
-			"version": "2.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.4.tgz",
-			"integrity": "sha512-t1sxSeyVU02NkcFhPvE7eQFA0CFUst68hTnie6ZS3ToY3nlzdbYRPOAZY5MPr3zRMwum6yFAXgqVA+5fnR0OGg==",
+			"version": "2.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.0.tgz",
+			"integrity": "sha512-ELl/FVJ6xBz35TisZ1NmJhjbiVXDeU++K531PEFPCPmwnQPh7S6hZXdPnR71/Kc3BmuN9X2ZkwGOqNKVfys2Bg==",
 			"requires": {
-				"@docusaurus/utils": "2.0.0-beta.4",
-				"chalk": "^4.1.1",
+				"@docusaurus/utils": "2.0.0-beta.0",
+				"chalk": "^4.1.0",
 				"joi": "^17.4.0",
 				"tslib": "^2.1.0"
+			}
+		},
+		"@endiliey/static-site-generator-webpack-plugin": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@endiliey/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.0.tgz",
+			"integrity": "sha512-3MBqYCs30qk1OBRC697NqhGouYbs71D1B8hrk/AFJC6GwF2QaJOQZtA1JYAaGSe650sZ8r5ppRTtCRXepDWlng==",
+			"requires": {
+				"bluebird": "^3.7.1",
+				"cheerio": "^0.22.0",
+				"eval": "^0.1.4",
+				"url": "^0.11.0",
+				"webpack-sources": "^1.4.3"
 			}
 		},
 		"@hapi/hoek": {
@@ -19191,10 +19255,28 @@
 				"v8-to-istanbul": "^8.0.0"
 			},
 			"dependencies": {
+				"jest-worker": {
+					"version": "27.0.6",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+					"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+					"requires": {
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^8.0.0"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
@@ -19414,18 +19496,6 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
-		"@slorber/static-site-generator-webpack-plugin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.1.tgz",
-			"integrity": "sha512-PSv4RIVO1Y3kvHxjvqeVisk3E9XFoO04uwYBDWe217MFqKspplYswTuKLiJu0aLORQWzuQjfVsSlLPojwfYsLw==",
-			"requires": {
-				"bluebird": "^3.7.1",
-				"cheerio": "^0.22.0",
-				"eval": "^0.1.4",
-				"url": "^0.11.0",
-				"webpack-sources": "^1.4.3"
-			}
-		},
 		"@splitbee/web": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@splitbee/web/-/web-0.2.4.tgz",
@@ -19643,9 +19713,9 @@
 			}
 		},
 		"@types/hast": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.2.tgz",
-			"integrity": "sha512-Op5W7jYgZI7AWKY5wQ0/QNMzQM7dGQPyW1rXKNiymVCy5iTfdPuGu4HhYNOM2sIv8gUfIuIdcYlXmAepwaowow==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
+			"integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
 			"requires": {
 				"@types/unist": "*"
 			}
@@ -19687,9 +19757,9 @@
 			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
 		},
 		"@types/mdast": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.7.tgz",
-			"integrity": "sha512-YwR7OK8aPmaBvMMUi+pZXBNoW2unbVbfok4YRqGMJBe1dpDlzpRkJrYEYmvjxgs5JhuQmKfDexrN98u941Zasg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
+			"integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
 			"requires": {
 				"@types/unist": "*"
 			}
@@ -19725,9 +19795,9 @@
 			"integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
 		},
 		"@types/sax": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.3.tgz",
-			"integrity": "sha512-+QSw6Tqvs/KQpZX8DvIl3hZSjNFLW/OqE5nlyHXtTwODaJvioN2rOWpBNEWZp2HZUFhOh+VohmJku/WxEXU2XA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.1.tgz",
+			"integrity": "sha512-dqYdvN7Sbw8QT/0Ci5rhjE4/iCMJEM0Y9rHpCu+gGXD9Lwbz28t6HI2yegsB6BoV1sShRMU6lAmAcgRjmFy7LA==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -19738,9 +19808,9 @@
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
 		},
 		"@types/unist": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.4.tgz",
+			"integrity": "sha512-zfyYsDTK1HTGYXU3fTiM76+om93HcFtsZd2M0bO/CL4DiETV7mSa/pIVN/6+G3esOqEMdg2An5cHHbK5t+9w+A=="
 		},
 		"@types/yargs": {
 			"version": "16.0.4",
@@ -19756,9 +19826,9 @@
 			"integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
 		},
 		"@typescript/twoslash": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@typescript/twoslash/-/twoslash-2.2.0.tgz",
-			"integrity": "sha512-Lkgrs9L/OIn1JZcIv2k4uy/CsQ+9dmurN64YzSWIHleTE3PkZlV2lZdq9xM7TnLh5zFy3tP8KuPtUxbIGV9sIw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@typescript/twoslash/-/twoslash-2.1.0.tgz",
+			"integrity": "sha512-J72HH+zAMPA9udOuOgAxTXnzeRyz0t33Ww1jQ6CgNfjP3HtrOS4lNgG+m3u1H497U366zbcUOjNkIgNGqefd/A==",
 			"requires": {
 				"@typescript/vfs": "1.3.4",
 				"debug": "^4.1.1",
@@ -19998,30 +20068,30 @@
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
 		},
 		"algoliasearch": {
-			"version": "4.10.3",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.3.tgz",
-			"integrity": "sha512-OLY0AWlPKGLbSaw14ivMB7BT5fPdp8VdzY4L8FtzZnqmLKsyes24cltGlf7/X96ACkYEcT390SReCDt/9SUIRg==",
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.2.tgz",
+			"integrity": "sha512-BAYCe97XRfO15irJKBRjBnrp9tSqN0jppklLIXKdtUcXlibcPQtuAeGUP2cPiz6bJd3ISuoYzLFNt4/fQYtLMw==",
 			"requires": {
-				"@algolia/cache-browser-local-storage": "4.10.3",
-				"@algolia/cache-common": "4.10.3",
-				"@algolia/cache-in-memory": "4.10.3",
-				"@algolia/client-account": "4.10.3",
-				"@algolia/client-analytics": "4.10.3",
-				"@algolia/client-common": "4.10.3",
-				"@algolia/client-personalization": "4.10.3",
-				"@algolia/client-search": "4.10.3",
-				"@algolia/logger-common": "4.10.3",
-				"@algolia/logger-console": "4.10.3",
-				"@algolia/requester-browser-xhr": "4.10.3",
-				"@algolia/requester-common": "4.10.3",
-				"@algolia/requester-node-http": "4.10.3",
-				"@algolia/transporter": "4.10.3"
+				"@algolia/cache-browser-local-storage": "4.10.2",
+				"@algolia/cache-common": "4.10.2",
+				"@algolia/cache-in-memory": "4.10.2",
+				"@algolia/client-account": "4.10.2",
+				"@algolia/client-analytics": "4.10.2",
+				"@algolia/client-common": "4.10.2",
+				"@algolia/client-personalization": "4.10.2",
+				"@algolia/client-search": "4.10.2",
+				"@algolia/logger-common": "4.10.2",
+				"@algolia/logger-console": "4.10.2",
+				"@algolia/requester-browser-xhr": "4.10.2",
+				"@algolia/requester-common": "4.10.2",
+				"@algolia/requester-node-http": "4.10.2",
+				"@algolia/transporter": "4.10.2"
 			}
 		},
 		"algoliasearch-helper": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz",
-			"integrity": "sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.5.3.tgz",
+			"integrity": "sha512-DtSlOKAJ6TGkQD6u58g6/ABdMmHf3pAj6xVL5hJF+D4z9ldDRf/f5v6puNIxGOlJRwGVvFGyz34beYNqhLDUbQ==",
 			"requires": {
 				"events": "^1.1.1"
 			}
@@ -20199,18 +20269,23 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"autoprefixer": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
-			"integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.6.tgz",
+			"integrity": "sha512-8lChSmdU6dCNMCQopIf4Pe5kipkAGj/fvTMslCsih0uHpOrXOPUEVOmYMMqmw3cekQkSD7EhIeuYl5y0BLdKqg==",
 			"requires": {
 				"browserslist": "^4.16.6",
-				"caniuse-lite": "^1.0.30001243",
+				"caniuse-lite": "^1.0.30001230",
 				"colorette": "^1.2.2",
 				"fraction.js": "^4.1.1",
 				"normalize-range": "^0.1.2",
@@ -20671,9 +20746,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001249",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-			"integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw=="
+			"version": "1.0.30001241",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+			"integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ=="
 		},
 		"ccount": {
 			"version": "1.1.0",
@@ -21020,9 +21095,9 @@
 			}
 		},
 		"colord": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/colord/-/colord-2.6.0.tgz",
-			"integrity": "sha512-8yMrtE20ZxH1YWvvSoeJFtvqY+GIAOfU+mZ3jx7ZSiEMasnAmNqD1BKUP3CuCWcy/XHgcXkLW6YU8C35nhOYVg=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.1.0.tgz",
+			"integrity": "sha512-H5sDP9XDk2uP+x/xSGkgB9SEFc1bojdI5DMKU0jmSXQtml2GIe48dj1DcSS0e53QQAHn+JKqUXbGeGX24xWD7w=="
 		},
 		"colorette": {
 			"version": "1.2.2",
@@ -21174,27 +21249,17 @@
 			"integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q=="
 		},
 		"copy-webpack-plugin": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
-			"integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-8.1.1.tgz",
+			"integrity": "sha512-rYM2uzRxrLRpcyPqGceRBDpxxUV8vcDqIKxAUKfcnFpcrPxT5+XvhTxv7XLjo5AvEJFPdAE3zCogG2JVahqgSQ==",
 			"requires": {
 				"fast-glob": "^3.2.5",
-				"glob-parent": "^6.0.0",
+				"glob-parent": "^5.1.1",
 				"globby": "^11.0.3",
 				"normalize-path": "^3.0.0",
 				"p-limit": "^3.1.0",
 				"schema-utils": "^3.0.0",
-				"serialize-javascript": "^6.0.0"
-			},
-			"dependencies": {
-				"glob-parent": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.1.tgz",
-					"integrity": "sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==",
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				}
+				"serialize-javascript": "^5.0.1"
 			}
 		},
 		"core-js": {
@@ -21269,9 +21334,9 @@
 			"integrity": "sha512-/loXYOch1qU1biStIFsHH8SxTmOseh1IJqFvy8IujXOm1h+QjUdDhkzOrR5HG8K8mlxREj0yfi8ewCHx0eMxzA=="
 		},
 		"css-declaration-sorter": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.1.tgz",
-			"integrity": "sha512-BZ1aOuif2Sb7tQYY1GeCjG7F++8ggnwUkH5Ictw0mrdpqpEd+zWmcPdstnH2TItlb74FqR0DrVEieon221T/1Q==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.0.3.tgz",
+			"integrity": "sha512-52P95mvW1SMzuRZegvpluT6yEv0FqQusydKQPZsNN5Q7hh8EwQvN8E2nwuJ16BBvNN6LcoIZXu/Bk58DAhrrxw==",
 			"requires": {
 				"timsort": "^0.3.0"
 			}
@@ -21294,16 +21359,16 @@
 			}
 		},
 		"css-minimizer-webpack-plugin": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-3.0.2.tgz",
-			"integrity": "sha512-B3I5e17RwvKPJwsxjjWcdgpU/zqylzK1bPVghcmpFHRL48DXiBgrtqz1BJsn68+t/zzaLp9kYAaEDvQ7GyanFQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-2.0.0.tgz",
+			"integrity": "sha512-cG/uc94727tx5pBNtb1Sd7gvUPzwmcQi1lkpfqTpdkuNq75hJCw7bIVsCNijLm4dhDcr1atvuysl2rZqOG8Txw==",
 			"requires": {
-				"cssnano": "^5.0.6",
-				"jest-worker": "^27.0.2",
+				"cssnano": "^5.0.0",
+				"jest-worker": "^26.3.0",
 				"p-limit": "^3.0.2",
-				"postcss": "^8.3.5",
+				"postcss": "^8.2.9",
 				"schema-utils": "^3.0.0",
-				"serialize-javascript": "^6.0.0",
+				"serialize-javascript": "^5.0.1",
 				"source-map": "^0.6.1"
 			},
 			"dependencies": {
@@ -21357,14 +21422,13 @@
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
 		},
 		"cssnano": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.7.tgz",
-			"integrity": "sha512-7C0tbb298hef3rq+TtBbMuezBQ9VrFtrQEsPNuBKNVgWny/67vdRsnq8EoNu7TRjAHURgYvWlRIpCUmcMZkRzw==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.6.tgz",
+			"integrity": "sha512-NiaLH/7yqGksFGsFNvSRe2IV/qmEBAeDE64dYeD8OBrgp6lE8YoMeQJMtsv5ijo6MPyhuoOvFhI94reahBRDkw==",
 			"requires": {
+				"cosmiconfig": "^7.0.0",
 				"cssnano-preset-default": "^5.1.3",
-				"is-resolvable": "^1.1.0",
-				"lilconfig": "^2.0.3",
-				"yaml": "^1.10.2"
+				"is-resolvable": "^1.1.0"
 			}
 		},
 		"cssnano-preset-advanced": {
@@ -21788,12 +21852,12 @@
 			}
 		},
 		"docusaurus-preset-shiki-twoslash": {
-			"version": "1.1.23",
-			"resolved": "https://registry.npmjs.org/docusaurus-preset-shiki-twoslash/-/docusaurus-preset-shiki-twoslash-1.1.23.tgz",
-			"integrity": "sha512-MGeHX11/6IUwYKNnnka8FUSyiZwtgl2Q2SNLE/z8p7fnPrzLgQWxmE4/KC54YsjoP2j9ACRQavJ8oEOwDIWMZA==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/docusaurus-preset-shiki-twoslash/-/docusaurus-preset-shiki-twoslash-1.1.16.tgz",
+			"integrity": "sha512-tvwCOw6Xnvu9Id8AsWIASm5Asbqa9yExeo8v6Zt7tbbVxwiEnuWkuN9bjMBnNQecUZPJYWMaq7m2jzLk6u7irA==",
 			"requires": {
 				"copy-text-to-clipboard": "^3.0.1",
-				"remark-shiki-twoslash": "2.0.8",
+				"remark-shiki-twoslash": "2.0.1",
 				"typescript": ">3"
 			}
 		},
@@ -22807,10 +22871,11 @@
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"fs-extra": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 			"requires": {
+				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
@@ -23593,9 +23658,9 @@
 			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
 		},
 		"infima": {
-			"version": "0.2.0-alpha.29",
-			"resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.29.tgz",
-			"integrity": "sha512-b6XX4QJekAYBPz2Y0XcXrDRaX/+96V95/WKWedY4zAWZ6xlzdxCrnyUgNaC4575aHcA2bfarLlTsP8FHFhjZFQ=="
+			"version": "0.2.0-alpha.23",
+			"resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.23.tgz",
+			"integrity": "sha512-V0RTjB1otjpH3E2asbydx3gz7ovdSJsuV7r9JTdBggqRilnelTJUcXxLawBQQKsjQi5qPcRTjxnlaV8xyyKhhw=="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -24226,6 +24291,26 @@
 				"jest-worker": "^27.0.6",
 				"micromatch": "^4.0.4",
 				"walker": "^1.0.7"
+			},
+			"dependencies": {
+				"jest-worker": {
+					"version": "27.0.6",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+					"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+					"requires": {
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^8.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-jasmine2": {
@@ -24361,6 +24446,26 @@
 				"jest-worker": "^27.0.6",
 				"source-map-support": "^0.5.6",
 				"throat": "^6.0.1"
+			},
+			"dependencies": {
+				"jest-worker": {
+					"version": "27.0.6",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+					"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+					"requires": {
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^8.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-runtime": {
@@ -24477,23 +24582,13 @@
 			}
 		},
 		"jest-worker": {
-			"version": "27.0.6",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-			"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "8.1.1",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"supports-color": "^7.0.0"
 			}
 		},
 		"joi": {
@@ -24638,11 +24733,6 @@
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
 			}
-		},
-		"lilconfig": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg=="
 		},
 		"lines-and-columns": {
 			"version": "1.1.6",
@@ -27182,16 +27272,16 @@
 			}
 		},
 		"remark-shiki-twoslash": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/remark-shiki-twoslash/-/remark-shiki-twoslash-2.0.8.tgz",
-			"integrity": "sha512-FQXBBiXkdCTKJ52/FzOuURv7t06dOop7ByyS4PUoq6FUFBihpiKlfv44H1G/UuEYt3s3SCB/f9DxGZl6V8J/pg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-shiki-twoslash/-/remark-shiki-twoslash-2.0.1.tgz",
+			"integrity": "sha512-Xj2pMArldasY6WvqjaVR/G7HJnqIGYGIQlpNCpeq2kGTaABU80nJ5lF7AiELUGbg1f5aK4tosE24zo2ChWi9Zg==",
 			"requires": {
-				"@typescript/twoslash": "2.2.0",
+				"@typescript/twoslash": "2.1.0",
 				"@typescript/vfs": "1.3.4",
 				"fenceparser": "^1.1.0",
 				"regenerator-runtime": "^0.13.7",
 				"shiki": "0.9.3",
-				"shiki-twoslash": "2.1.6",
+				"shiki-twoslash": "2.0.3",
 				"tslib": "2.1.0",
 				"typescript": ">3",
 				"unist-util-visit": "^2.0.0"
@@ -27426,9 +27516,9 @@
 			"integrity": "sha512-2sMcZO60tL9YDEFe24gqddg3hJ+xSmJFN8IExcQUxeHxQzydQrN6GHPL+yAWgzItXSI7es53hcZC9pJneuZDKA=="
 		},
 		"rtlcss": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-3.3.0.tgz",
-			"integrity": "sha512-XZ2KEatH2nU5yPlts1Wu8SGIuZ3ndN025HQX5MqtUCUiOn5WkCDbcpJ2VJWjpuFmM2cUTQ1xtH21fhMCSseI5A==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-3.2.1.tgz",
+			"integrity": "sha512-S9bh35JXwPIhfun7nFu/HjlNrwELL5nvTJqA1suLfbnqY/mauIL5sBkrJNHziVppX9PA2rJ7NV82+RtzB71mJA==",
 			"requires": {
 				"chalk": "^4.1.0",
 				"find-up": "^5.0.0",
@@ -27626,9 +27716,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+			"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
 			"requires": {
 				"randombytes": "^2.1.0"
 			}
@@ -27816,11 +27906,11 @@
 			}
 		},
 		"shiki-twoslash": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/shiki-twoslash/-/shiki-twoslash-2.1.6.tgz",
-			"integrity": "sha512-98Irtz/UIA4KE7ipeXIhN3+OvZqI0PYOE0Iamqmken6H5WEOgwDep45PjPWmuK1vSmlN/PWYg9EQu5v/ZN7eIg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/shiki-twoslash/-/shiki-twoslash-2.0.3.tgz",
+			"integrity": "sha512-tUeoek4e0pShUp0AnkfLXl4DCnvcC3iI1pDspPfdWKaBYY8hPW7J4iWxf9VXkdCA7wxwmT1bsiZ6e9h9Tndehg==",
 			"requires": {
-				"@typescript/twoslash": "2.2.0",
+				"@typescript/twoslash": "2.1.0",
 				"@typescript/vfs": "1.3.4",
 				"shiki": "0.9.3",
 				"typescript": ">3"
@@ -27854,20 +27944,20 @@
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
 		},
 		"sitemap": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.0.0.tgz",
-			"integrity": "sha512-Ud0jrRQO2k7fEtPAM+cQkBKoMvxQyPKNXKDLn8tRVHxRCsdDQ2JZvw+aZ5IRYYQVAV9iGxEar6boTwZzev+x3g==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/sitemap/-/sitemap-6.4.0.tgz",
+			"integrity": "sha512-DoPKNc2/apQZTUnfiOONWctwq7s6dZVspxAZe2VPMNtoqNq7HgXRvlRnbIpKjf+8+piQdWncwcy+YhhTGY5USQ==",
 			"requires": {
-				"@types/node": "^15.0.1",
+				"@types/node": "^14.14.28",
 				"@types/sax": "^1.2.1",
 				"arg": "^5.0.0",
 				"sax": "^1.2.4"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "15.14.7",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.7.tgz",
-					"integrity": "sha512-FA45p37/mLhpebgbPWWCKfOisTjxGK9lwcHlJ6XVLfu3NgfcazOJHdYUZCWPMK8QX4LhNZdmfo6iMz9FqpUbaw=="
+					"version": "14.17.4",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
+					"integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A=="
 				}
 			}
 		},
@@ -28595,10 +28685,36 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 				},
+				"jest-worker": {
+					"version": "27.0.6",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+					"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+					"requires": {
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^8.0.0"
+					}
+				},
+				"serialize-javascript": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+					"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				},
 				"terser": {
 					"version": "5.7.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,8 +13,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-beta.4",
-    "@docusaurus/preset-classic": "^2.0.0-beta.4",
+    "@docusaurus/core": "2.0.0-beta.0",
+    "@docusaurus/preset-classic": "2.0.0-beta.0",
     "@mdx-js/react": "^1.6.21",
     "@remotion/babel-loader": "^2.2.4",
     "@remotion/bundler": "^2.2.4",
@@ -37,7 +37,8 @@
     "ts-jest": "^27.0.3"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.0-beta.4",
+    "@babel/plugin-transform-modules-commonjs": "^7.14.0",
+    "@docusaurus/module-type-aliases": "^2.0.0-beta.0",
     "@tsconfig/docusaurus": "^1.0.2",
     "@types/color-namer": "^1.3.0",
     "@types/hls.js": "^0.13.3"


### PR DESCRIPTION
This was a great PR but I noticed the showcase does not work anymore and it logs `exports is not defined`, reverting just for now until we figured it out