### PR TITLE
Component mounts at first frame rather than at frame 0

### DIFF
--- a/packages/bundler/src/setup-environment.ts
+++ b/packages/bundler/src/setup-environment.ts
@@ -1,3 +1,4 @@
 import {Internals} from 'remotion';
 
 Internals.setupEnvVariables();
+Internals.setupInitialFrame();

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -54,7 +54,7 @@ export const webpackConfig = ({
 			: false,
 		devtool: 'cheap-module-source-map',
 		entry: [
-			require.resolve('./setup-env-variables'),
+			require.resolve('./setup-environment'),
 			environment === 'development'
 				? require.resolve('webpack-hot-middleware/client') + '?overlay=true'
 				: null,

--- a/packages/core/src/RemotionRoot.tsx
+++ b/packages/core/src/RemotionRoot.tsx
@@ -32,7 +32,7 @@ export const RemotionRoot: React.FC = ({children}) => {
 	const [remotionRootId] = useState(() => String(random(null)));
 	const [sequences, setSequences] = useState<TSequence[]>([]);
 	const [assets, setAssets] = useState<TAsset[]>([]);
-	const [frame, setFrame] = useState<number>(0);
+	const [frame, setFrame] = useState<number>(window.remotion_initialFrame ?? 0);
 	const [playing, setPlaying] = useState<boolean>(false);
 	const [fastRefreshes, setFastRefreshes] = useState(0);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ declare global {
 		ready: boolean;
 		getStaticCompositions: () => TCompMetadata[];
 		remotion_setFrame: (frame: number) => void;
+		remotion_initialFrame: number;
 		remotion_collectAssets: () => TAsset[];
 		remotion_isPlayer: boolean;
 		remotion_imported: boolean;

--- a/packages/core/src/initial-frame.ts
+++ b/packages/core/src/initial-frame.ts
@@ -1,0 +1,10 @@
+export const INITIAL_FRAME_LOCAL_STORAGE_KEY = 'remotion.initialFrame';
+
+const getInitialFrame = (): number => {
+	const param = localStorage.getItem(INITIAL_FRAME_LOCAL_STORAGE_KEY);
+	return param ? Number(param) : 0;
+};
+
+export const setupInitialFrame = () => {
+	window.remotion_initialFrame = getInitialFrame();
+};

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -74,7 +74,9 @@ import {SequenceContext} from './sequencing';
 import {
 	ENV_VARIABLES_ENV_NAME,
 	ENV_VARIABLES_LOCAL_STORAGE_KEY,
+	INITIAL_FRAME_LOCAL_STORAGE_KEY,
 	setupEnvVariables,
+	setupInitialFrame,
 } from './setup-env-variables';
 import * as Timeline from './timeline-position-state';
 import {
@@ -151,8 +153,10 @@ export const Internals = {
 	isPlainIndex,
 	CSSUtils,
 	setupEnvVariables,
+	setupInitialFrame,
 	ENV_VARIABLES_ENV_NAME,
 	ENV_VARIABLES_LOCAL_STORAGE_KEY,
+	INITIAL_FRAME_LOCAL_STORAGE_KEY,
 	getDotEnvLocation,
 	getServerPort,
 	MediaVolumeContext,

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -61,6 +61,10 @@ import {
 import * as CSSUtils from './default-css';
 import {FEATURE_FLAG_FIREFOX_SUPPORT} from './feature-flags';
 import {getRemotionEnvironment, RemotionEnvironment} from './get-environment';
+import {
+	INITIAL_FRAME_LOCAL_STORAGE_KEY,
+	setupInitialFrame,
+} from './initial-frame';
 import {isAudioCodec} from './is-audio-codec';
 import * as perf from './perf';
 import {
@@ -74,9 +78,7 @@ import {SequenceContext} from './sequencing';
 import {
 	ENV_VARIABLES_ENV_NAME,
 	ENV_VARIABLES_LOCAL_STORAGE_KEY,
-	INITIAL_FRAME_LOCAL_STORAGE_KEY,
 	setupEnvVariables,
-	setupInitialFrame,
 } from './setup-env-variables';
 import * as Timeline from './timeline-position-state';
 import {

--- a/packages/core/src/setup-env-variables.ts
+++ b/packages/core/src/setup-env-variables.ts
@@ -1,7 +1,13 @@
 import {getRemotionEnvironment} from './get-environment';
 
 export const ENV_VARIABLES_LOCAL_STORAGE_KEY = 'remotion.envVariables';
+export const INITIAL_FRAME_LOCAL_STORAGE_KEY = 'remotion.initialFrame';
 export const ENV_VARIABLES_ENV_NAME = 'ENV_VARIABLES' as const;
+
+const getInitialFrame = (): number => {
+	const param = localStorage.getItem(INITIAL_FRAME_LOCAL_STORAGE_KEY);
+	return param ? Number(param) : 0;
+};
 
 const getEnvVariables = (): Record<string, string> => {
 	if (getRemotionEnvironment() === 'rendering') {
@@ -40,4 +46,8 @@ export const setupEnvVariables = () => {
 	Object.keys(env).forEach((key) => {
 		window.process.env[key] = env[key];
 	});
+};
+
+export const setupInitialFrame = () => {
+	window.remotion_initialFrame = getInitialFrame();
 };

--- a/packages/core/src/setup-env-variables.ts
+++ b/packages/core/src/setup-env-variables.ts
@@ -1,13 +1,7 @@
 import {getRemotionEnvironment} from './get-environment';
 
 export const ENV_VARIABLES_LOCAL_STORAGE_KEY = 'remotion.envVariables';
-export const INITIAL_FRAME_LOCAL_STORAGE_KEY = 'remotion.initialFrame';
 export const ENV_VARIABLES_ENV_NAME = 'ENV_VARIABLES' as const;
-
-const getInitialFrame = (): number => {
-	const param = localStorage.getItem(INITIAL_FRAME_LOCAL_STORAGE_KEY);
-	return param ? Number(param) : 0;
-};
 
 const getEnvVariables = (): Record<string, string> => {
 	if (getRemotionEnvironment() === 'rendering') {
@@ -46,8 +40,4 @@ export const setupEnvVariables = () => {
 	Object.keys(env).forEach((key) => {
 		window.process.env[key] = env[key];
 	});
-};
-
-export const setupInitialFrame = () => {
-	window.remotion_initialFrame = getInitialFrame();
 };

--- a/packages/example/src/SkipZeroFrame/index.tsx
+++ b/packages/example/src/SkipZeroFrame/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {useCurrentFrame} from 'remotion';
+
+// Try to render using:
+// npx remotion render src/index.tsx skip-zero-frame --frames=10-20 skip.mp4
+
+export const SkipZeroFrame: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	if (frame === 0 && process.env.NODE_ENV === 'production') {
+		throw new Error('should not render frame 0');
+	}
+
+	return <div>{frame}</div>;
+};

--- a/packages/example/src/Video.tsx
+++ b/packages/example/src/Video.tsx
@@ -5,6 +5,7 @@ import {ColorInterpolation} from './ColorInterpolation';
 import {Framer} from './Framer';
 import {MissingImg} from './MissingImg';
 import RemoteVideo from './RemoteVideo';
+import {SkipZeroFrame} from './SkipZeroFrame';
 import {TenFrameTester} from './TenFrameTester';
 import ThreeBasic from './ThreeBasic';
 import {VideoSpeed} from './VideoSpeed';
@@ -247,6 +248,14 @@ export const Index: React.FC = () => {
 			<Composition
 				id="video-speed"
 				component={VideoSpeed}
+				width={1280}
+				height={720}
+				fps={30}
+				durationInFrames={100}
+			/>
+			<Composition
+				id="skip-zero-frame"
+				component={SkipZeroFrame}
 				width={1280}
 				height={720}
 				fps={30}

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -69,6 +69,7 @@ export const getCompositions = async (
 		envVariables: config?.envVariables,
 		page,
 		port,
+		initialFrame: 0,
 	});
 
 	await page.goto(`http://localhost:${port}/index.html?evaluation=true`);

--- a/packages/renderer/src/render.ts
+++ b/packages/renderer/src/render.ts
@@ -111,7 +111,20 @@ export const renderFrames = async ({
 
 		page.on('pageerror', errorCallback);
 
-		await setPropsAndEnv({inputProps, envVariables, page, port});
+		const initialFrame =
+			typeof frameRange === 'number'
+				? frameCount
+				: frameRange === null || frameRange === undefined
+				? 0
+				: frameRange[0];
+
+		await setPropsAndEnv({
+			inputProps,
+			envVariables,
+			page,
+			port,
+			initialFrame,
+		});
 
 		const site = `http://localhost:${port}/index.html?composition=${compositionId}`;
 		await page.goto(site);

--- a/packages/renderer/src/render.ts
+++ b/packages/renderer/src/render.ts
@@ -113,7 +113,7 @@ export const renderFrames = async ({
 
 		const initialFrame =
 			typeof frameRange === 'number'
-				? frameCount
+				? frameRange
 				: frameRange === null || frameRange === undefined
 				? 0
 				: frameRange[0];

--- a/packages/renderer/src/set-props-and-env.ts
+++ b/packages/renderer/src/set-props-and-env.ts
@@ -6,11 +6,13 @@ export const setPropsAndEnv = async ({
 	envVariables,
 	page,
 	port,
+	initialFrame,
 }: {
 	inputProps: unknown;
 	envVariables: Record<string, string> | undefined;
 	page: Page;
 	port: number;
+	initialFrame: number;
 }) => {
 	if (inputProps || envVariables) {
 		await page.goto(`http://localhost:${port}/index.html`);
@@ -34,5 +36,13 @@ export const setPropsAndEnv = async ({
 				JSON.stringify(envVariables)
 			);
 		}
+
+		await page.evaluate(
+			(key, value) => {
+				window.localStorage.setItem(key, value);
+			},
+			Internals.INITIAL_FRAME_LOCAL_STORAGE_KEY,
+			initialFrame
+		);
 	}
 };


### PR DESCRIPTION
Consider the following render command:

```
npx remotion render src/index.tsx skip-zero-frame --frames=10-20 --log=verbose skip.mp4
```

Previously the component would be mounted at frame 0 and then changed to frame 10.

This PR makes the rendering process a bit more efficient by mounting the component at frame 10 initially. It's small breaking change but I think for the good!