### PR TITLE
fix: config is given higher priority than cli flags

### DIFF
--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -58,14 +58,14 @@ export const render = async () => {
 	const file = parsedCli._[1];
 	const fullPath = path.join(process.cwd(), file);
 
-	parseCommandLine();
 	const appliedName = loadConfig();
 	if (appliedName) {
 		Log.verbose(`Applied configuration from ${appliedName}.`);
 	} else {
 		Log.verbose('No config file loaded.');
 	}
-
+	
+	parseCommandLine();
 	const {
 		codec,
 		proResProfile,


### PR DESCRIPTION
While testing #527 found out that `remotion.config.ts` is given higher priority than remotion cli flags. 
This PR fixes that.
