### PR TITLE
allow to specify browser executable in renderFrames(), renderStill() and getCompositions()

### DIFF
--- a/packages/cli/src/get-cli-options.ts
+++ b/packages/cli/src/get-cli-options.ts
@@ -1,7 +1,13 @@
 import {RenderInternals} from '@remotion/renderer';
 import fs from 'fs';
 import path from 'path';
-import {Codec, FrameRange, Internals, PixelFormat} from 'remotion';
+import {
+	BrowserExecutable,
+	Codec,
+	FrameRange,
+	Internals,
+	PixelFormat,
+} from 'remotion';
 import {getEnvironmentVariables} from './get-env';
 import {getOutputFilename} from './get-filename';
 import {getInputProps} from './get-input-props';
@@ -149,10 +155,10 @@ const getAndValidateImageFormat = ({
 	return imageFormat;
 };
 
-const getAndValidateBrowser = async () => {
+const getAndValidateBrowser = async (browserExecutable: BrowserExecutable) => {
 	const browser = getBrowser();
 	try {
-		await RenderInternals.ensureLocalBrowser(browser);
+		await RenderInternals.ensureLocalBrowser(browser, browserExecutable);
 	} catch (err) {
 		Log.error('Could not download a browser for rendering frames.');
 		Log.error(err);
@@ -183,6 +189,7 @@ export const getCliOptions = async (type: 'still' | 'series') => {
 		pixelFormat,
 	});
 	const proResProfile = getAndValidateProResProfile(codec);
+	const browserExecutable = Internals.getBrowserExecutable();
 
 	return {
 		parallelism: Internals.getConcurrency(),
@@ -193,12 +200,13 @@ export const getCliOptions = async (type: 'still' | 'series') => {
 		inputProps: getInputProps(),
 		envVariables: await getEnvironmentVariables(),
 		quality: Internals.getQuality(),
-		browser: await getAndValidateBrowser(),
+		browser: await getAndValidateBrowser(browserExecutable),
 		absoluteOutputFile: getAndValidateAbsoluteOutputFile(outputFile, overwrite),
 		crf,
 		pixelFormat,
 		imageFormat,
 		proResProfile,
 		stillFrame: Internals.getStillFrame(),
+		browserExecutable,
 	};
 };

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -64,11 +64,13 @@ export const render = async () => {
 		crf,
 		pixelFormat,
 		imageFormat,
+		browserExecutable,
 	} = await getCliOptions('series');
 
 	await checkAndValidateFfmpegVersion();
 
 	const browserInstance = RenderInternals.openBrowser(browser, {
+		browserExecutable,
 		shouldDumpIo: Internals.Logging.isEqualOrBelowLogLevel('verbose'),
 	});
 	if (shouldOutputImageSequence) {

--- a/packages/cli/src/still.ts
+++ b/packages/cli/src/still.ts
@@ -47,6 +47,7 @@ export const still = async () => {
 		browser,
 		imageFormat,
 		stillFrame,
+		browserExecutable,
 	} = await getCliOptions('still');
 
 	if (imageFormat === 'none') {
@@ -73,6 +74,7 @@ export const still = async () => {
 	}
 
 	const browserInstance = RenderInternals.openBrowser(browser, {
+		browserExecutable,
 		shouldDumpIo: Internals.Logging.isEqualOrBelowLogLevel('verbose'),
 	});
 

--- a/packages/docs/docs/get-compositions.md
+++ b/packages/docs/docs/get-compositions.md
@@ -41,6 +41,12 @@ _optional_
 
 An already open Puppeteer [`Browser`](https://pptr.dev/#?product=Puppeteer&version=main&show=api-class-browser) instance. Reusing a browser across multiple function calls can speed up the rendering process. You are responsible for opening and closing the browser yourself. If you don't specify this option, a new browser will be opened and closed at the end.
 
+#### `browserExecutable?`
+
+_optional, available from v2.3.1_
+
+A string defining the absolute path on disk of the browser executable that should be used. By default Remotion will try to detect it automatically and download one if none is available. If `browserInstance` is defined, it will take precedence over `browserExecutable`.
+
 ## Return value
 
 Returns a promise that resolves to an array of available compositions. Example value:

--- a/packages/docs/docs/render-frames.md
+++ b/packages/docs/docs/render-frames.md
@@ -148,6 +148,12 @@ renderFrames({
 })
 ```
 
+### `browserExecutable?`
+
+_optional, available from v2.3.1_
+
+A string defining the absolute path on disk of the browser executable that should be used. By default Remotion will try to detect it automatically and download one if none is available. If `puppeteerInstance` is defined, it will take precedence over `browserExecutable`.
+
 ## Return value
 
 A promise resolving to an object containing the following properties:

--- a/packages/docs/docs/render-still.md
+++ b/packages/docs/docs/render-still.md
@@ -132,6 +132,12 @@ _optional - default `true`_
 
 Whether the file should be overwritten if the output already exists.
 
+### `browserExecutable?`
+
+_optional, available from v2.3.1_
+
+A string defining the absolute path on disk of the browser executable that should be used. By default Remotion will try to detect it automatically and download one if none is available. If `puppeteerInstance` is defined, it will take precedence over `browserExecutable`.
+
 ## Return value
 
 A promise with no value. If the render succeeded, the still has been saved to `output`. If the render failed, the promise rejects.

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -1,5 +1,5 @@
 import {Browser as PuppeteerBrowser, Page} from 'puppeteer-core';
-import {Browser, Internals, TCompMetadata} from 'remotion';
+import {Browser, BrowserExecutable, Internals, TCompMetadata} from 'remotion';
 import {openBrowser} from './open-browser';
 import {serveStatic} from './serve-static';
 import {setPropsAndEnv} from './set-props-and-env';
@@ -9,14 +9,17 @@ type GetCompositionsConfig = {
 	inputProps?: object | null;
 	envVariables?: Record<string, string>;
 	browserInstance?: PuppeteerBrowser;
+	browserExecutable?: BrowserExecutable;
 };
 
 const getPageAndCleanupFn = async ({
 	passedInInstance,
 	browser,
+	browserExecutable,
 }: {
 	passedInInstance: PuppeteerBrowser | undefined;
 	browser: Browser;
+	browserExecutable: BrowserExecutable | null;
 }): Promise<{
 	cleanup: () => void;
 	page: Page;
@@ -36,7 +39,10 @@ const getPageAndCleanupFn = async ({
 	}
 
 	const browserInstance = await openBrowser(
-		browser || Internals.DEFAULT_BROWSER
+		browser || Internals.DEFAULT_BROWSER,
+		{
+			browserExecutable,
+		}
 	);
 	const browserPage = await browserInstance.newPage();
 
@@ -58,6 +64,7 @@ export const getCompositions = async (
 	const {page, cleanup} = await getPageAndCleanupFn({
 		passedInInstance: config?.browserInstance,
 		browser: config?.browser ?? Internals.DEFAULT_BROWSER,
+		browserExecutable: config?.browserExecutable ?? null,
 	});
 
 	const {port, close} = await serveStatic(webpackBundle);

--- a/packages/renderer/src/get-local-browser-executable.ts
+++ b/packages/renderer/src/get-local-browser-executable.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import puppeteer, {Product, PuppeteerNode} from 'puppeteer-core';
 import {downloadBrowser} from 'puppeteer-core/lib/cjs/puppeteer/node/install';
 import {PUPPETEER_REVISIONS} from 'puppeteer-core/lib/cjs/puppeteer/revisions';
-import {Browser, Internals} from 'remotion';
+import {Browser, BrowserExecutable} from 'remotion';
 
 const getSearchPathsForProduct = (product: puppeteer.Product) => {
 	if (product === 'chrome') {
@@ -78,8 +78,10 @@ type BrowserStatus =
 			type: 'no-browser';
 	  };
 
-const getBrowserStatus = (product: puppeteer.Product): BrowserStatus => {
-	const browserExecutablePath = Internals.getBrowserExecutable();
+const getBrowserStatus = (
+	product: puppeteer.Product,
+	browserExecutablePath: BrowserExecutable
+): BrowserStatus => {
 	if (browserExecutablePath) {
 		if (!fs.existsSync(browserExecutablePath)) {
 			console.warn(
@@ -103,8 +105,14 @@ const getBrowserStatus = (product: puppeteer.Product): BrowserStatus => {
 	return {type: 'no-browser'};
 };
 
-export const ensureLocalBrowser = async (browser: Browser) => {
-	const status = getBrowserStatus(mapBrowserToProduct(browser));
+export const ensureLocalBrowser = async (
+	browser: Browser,
+	preferredBrowserExecutable: BrowserExecutable
+) => {
+	const status = getBrowserStatus(
+		mapBrowserToProduct(browser),
+		preferredBrowserExecutable
+	);
 	if (status.type === 'no-browser') {
 		console.log(
 			'No local browser could be found. Downloading one from the internet...'
@@ -114,9 +122,13 @@ export const ensureLocalBrowser = async (browser: Browser) => {
 };
 
 export const getLocalBrowserExecutable = async (
-	browser: Browser
+	browser: Browser,
+	preferredBrowserExecutable: BrowserExecutable
 ): Promise<string> => {
-	const status = getBrowserStatus(mapBrowserToProduct(browser));
+	const status = getBrowserStatus(
+		mapBrowserToProduct(browser),
+		preferredBrowserExecutable
+	);
 	if (status.type === 'no-browser') {
 		throw new TypeError(
 			'No browser found for rendering frames! Please open a GitHub issue and describe ' +

--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -9,6 +9,7 @@ export const openBrowser = async (
 	browser: Browser,
 	options?: {
 		shouldDumpIo?: boolean;
+		browserExecutable?: string | null;
 	}
 ): Promise<puppeteer.Browser> => {
 	if (browser === 'firefox' && !Internals.FEATURE_FLAG_FIREFOX_SUPPORT) {
@@ -17,9 +18,12 @@ export const openBrowser = async (
 		);
 	}
 
-	await ensureLocalBrowser(browser);
+	await ensureLocalBrowser(browser, options?.browserExecutable ?? null);
 
-	const executablePath = await getLocalBrowserExecutable(browser);
+	const executablePath = await getLocalBrowserExecutable(
+		browser,
+		options?.browserExecutable ?? null
+	);
 	const browserInstance = await puppeteer.launch({
 		executablePath,
 		product: browser,

--- a/packages/renderer/src/render-still.ts
+++ b/packages/renderer/src/render-still.ts
@@ -1,7 +1,7 @@
 import fs, {mkdirSync, statSync} from 'fs';
 import path from 'path';
 import {Browser as PuppeteerBrowser} from 'puppeteer-core';
-import {Browser, Internals, TCompMetadata} from 'remotion';
+import {Browser, BrowserExecutable, Internals, TCompMetadata} from 'remotion';
 import {openBrowser} from './open-browser';
 import {provideScreenshot} from './provide-screenshot';
 import {seekToFrame} from './seek-to-frame';
@@ -25,6 +25,7 @@ export const renderStill = async ({
 	output,
 	frame = 0,
 	overwrite = true,
+	browserExecutable,
 }: {
 	composition: TCompMetadata;
 	output: string;
@@ -39,6 +40,7 @@ export const renderStill = async ({
 	onError?: (err: Error) => void;
 	envVariables?: Record<string, string>;
 	overwrite?: boolean;
+	browserExecutable?: BrowserExecutable;
 }) => {
 	Internals.validateDimension(
 		composition.height,
@@ -99,6 +101,7 @@ export const renderStill = async ({
 		serveStatic(webpackBundle),
 		puppeteerInstance ??
 			openBrowser(browser, {
+				browserExecutable,
 				shouldDumpIo: dumpBrowserLogs,
 			}),
 	]);

--- a/packages/renderer/src/render.ts
+++ b/packages/renderer/src/render.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import {Browser as PuppeteerBrowser} from 'puppeteer-core';
 import {
 	Browser,
+	BrowserExecutable,
 	FrameRange,
 	ImageFormat,
 	Internals,
@@ -36,6 +37,7 @@ export const renderFrames = async ({
 	dumpBrowserLogs = false,
 	puppeteerInstance,
 	onError,
+	browserExecutable,
 }: {
 	config: VideoConfig;
 	compositionId: string;
@@ -52,6 +54,7 @@ export const renderFrames = async ({
 	frameRange?: FrameRange | null;
 	dumpBrowserLogs?: boolean;
 	puppeteerInstance?: PuppeteerBrowser;
+	browserExecutable?: BrowserExecutable;
 	onError?: (info: OnErrorInfo) => void;
 }): Promise<RenderFramesOutput> => {
 	Internals.validateDimension(
@@ -87,6 +90,7 @@ export const renderFrames = async ({
 		puppeteerInstance ??
 			openBrowser(browser, {
 				shouldDumpIo: dumpBrowserLogs,
+				browserExecutable,
 			}),
 	]);
 	const pages = new Array(actualParallelism).fill(true).map(async () => {


### PR DESCRIPTION
A feature that is available in config file, but missing in SSR still