### PR TITLE
feat: render video to out folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lerna-debug.log
 .DS_Store
 coverage
 packages/example/.env
+packages/example/out

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -166,6 +166,8 @@ export const render = async () => {
 		Internals.perf.logPerf();
 	}
 
+	let outputLocation = absoluteOutputFile
+
 	if (shouldOutputImageSequence) {
 		Log.info(chalk.green('\nYour image sequence is ready!'));
 	} else {
@@ -173,6 +175,15 @@ export const render = async () => {
 			throw new TypeError('CRF is unexpectedly not a number');
 		}
 
+		const outFolder = path.resolve(process.cwd(), './out');
+		outputLocation = absoluteOutputFile.replace(process.cwd(), outFolder)
+
+		if (!fs.existsSync(outFolder)) {
+				fs.mkdirSync(outFolder, {
+						recursive: true,
+				});
+		}
+	
 		const stitchingProgress = createProgressBar();
 
 		stitchingProgress.update(
@@ -189,7 +200,7 @@ export const render = async () => {
 			width: config.width,
 			height: config.height,
 			fps: config.fps,
-			outputLocation: absoluteOutputFile,
+			outputLocation,
 			force: overwrite,
 			imageFormat,
 			pixelFormat,
@@ -250,6 +261,6 @@ export const render = async () => {
 		].join(' ')
 	);
 	Log.info('-', 'Output can be found at:');
-	Log.info(chalk.cyan(`▶️ ${absoluteOutputFile}`));
+	Log.info(chalk.cyan(`▶️ ${outputLocation}`));
 	await closeBrowserPromise;
 };

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -177,9 +177,10 @@ export const render = async () => {
 
 		const outFolder = path.resolve(process.cwd(), './out');
 		outputLocation = absoluteOutputFile.replace(process.cwd(), outFolder)
+		const dirName = path.dirname(outputLocation)
 
-		if (!fs.existsSync(outFolder)) {
-				fs.mkdirSync(outFolder, {
+		if (!fs.existsSync(dirName)) {
+				fs.mkdirSync(dirName, {
 						recursive: true,
 				});
 		}

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -166,8 +166,6 @@ export const render = async () => {
 		Internals.perf.logPerf();
 	}
 
-	let outputLocation = absoluteOutputFile
-
 	if (shouldOutputImageSequence) {
 		Log.info(chalk.green('\nYour image sequence is ready!'));
 	} else {
@@ -175,9 +173,7 @@ export const render = async () => {
 			throw new TypeError('CRF is unexpectedly not a number');
 		}
 
-		const outFolder = path.resolve(process.cwd(), './out');
-		outputLocation = absoluteOutputFile.replace(process.cwd(), outFolder)
-		const dirName = path.dirname(outputLocation)
+		const dirName = path.dirname(absoluteOutputFile)
 
 		if (!fs.existsSync(dirName)) {
 				fs.mkdirSync(dirName, {
@@ -201,7 +197,7 @@ export const render = async () => {
 			width: config.width,
 			height: config.height,
 			fps: config.fps,
-			outputLocation,
+			outputLocation: absoluteOutputFile,
 			force: overwrite,
 			imageFormat,
 			pixelFormat,
@@ -262,6 +258,6 @@ export const render = async () => {
 		].join(' ')
 	);
 	Log.info('-', 'Output can be found at:');
-	Log.info(chalk.cyan(`▶️ ${outputLocation}`));
+	Log.info(chalk.cyan(`▶️ ${absoluteOutputFile}`));
 	await closeBrowserPromise;
 };

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -173,14 +173,14 @@ export const render = async () => {
 			throw new TypeError('CRF is unexpectedly not a number');
 		}
 
-		const dirName = path.dirname(absoluteOutputFile)
+		const dirName = path.dirname(absoluteOutputFile);
 
 		if (!fs.existsSync(dirName)) {
-				fs.mkdirSync(dirName, {
-						recursive: true,
-				});
+			fs.mkdirSync(dirName, {
+				recursive: true,
+			});
 		}
-	
+
 		const stitchingProgress = createProgressBar();
 
 		stitchingProgress.update(

--- a/packages/docs/docs/cli.md
+++ b/packages/docs/docs/cli.md
@@ -169,7 +169,7 @@ Print the list of available CLI commands and flags.
 ## Example command
 
 ```
-npx remotion render --codec=vp8 src/index.tsx HelloWorld video.webm
+npx remotion render --codec=vp8 src/index.tsx HelloWorld out/video.webm
 ```
 
 ## See also

--- a/packages/docs/docs/get-input-props.md
+++ b/packages/docs/docs/get-input-props.md
@@ -18,7 +18,7 @@ This method is not available when inside a Remotion Player. Instead, get the pro
 Pass in a [parseable](/docs/cli) JSON representation using the `--props` flag to either `remotion preview` or `remotion render`:
 
 ```bash
-npx remotion render --props='{"hello": "world"}' src/index.tsx my-composition out.mp4
+npx remotion render --props='{"hello": "world"}' src/index.tsx my-composition out/video.mp4
 ```
 
 You can then access the props in JavaScript:

--- a/packages/docs/docs/parametrized-rendering.md
+++ b/packages/docs/docs/parametrized-rendering.md
@@ -73,13 +73,13 @@ When rendering (for example using the `npm run build` script defined in `package
 **Using inline JSON**
 
 ```bash
-npx remotion render src/index.tsx HelloWorld helloworld.mp4 --props='{"propOne": "Hi", "propTwo": 10}'
+npx remotion render src/index.tsx HelloWorld out/helloworld.mp4 --props='{"propOne": "Hi", "propTwo": 10}'
 ```
 
 **Using a file path:**
 
 ```bash
-npx remotion render src/index.tsx HelloWorld helloworld.mp4 --props=./path/to/props.json
+npx remotion render src/index.tsx HelloWorld out/helloworld.mp4 --props=./path/to/props.json
 ```
 
 [See also: CLI flags](/docs/cli)

--- a/packages/docs/docs/render.md
+++ b/packages/docs/docs/render.md
@@ -12,7 +12,7 @@ npm run build
 The underlying command in package.json is defined as follows:
 
 ```bash
-npx remotion render src/index.tsx HelloWorld out.mp4
+npx remotion render src/index.tsx HelloWorld out/video.mp4
 ```
 
 Modify it to select a different video to render, or change its output location.

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,9 +14,9 @@
 		"start-js": "remotion preview src/entry.jsx",
 		"test": "eslint src --ext ts,tsx,js,jsx && jest",
 		"build": "tsc -d",
-		"render": "remotion render src/index.tsx react-svg video.mp4",
-		"render-js": "remotion render src/entry.jsx framer video.mp4",
-		"render-transparent": "remotion render src/index.tsx --image-format=png --pixel-format=yuva420p --codec=vp8 react-svg video.webm"
+		"render": "remotion render src/index.tsx react-svg out/video.mp4",
+		"render-js": "remotion render src/entry.jsx framer out/video.mp4",
+		"render-transparent": "remotion render src/index.tsx --image-format=png --pixel-format=yuva420p --codec=vp8 react-svg out/video.webm"
 	},
 	"dependencies": {
 		"@babel/plugin-syntax-jsx": "7.12.13",


### PR DESCRIPTION
## Description
Fixes https://github.com/remotion-dev/remotion/issues/518

## How to test?
- Build package
```bash
npm run build
```
- Go to example folder
```bash
cd packages/example
```
- Run render
```bash
../cli/remotion-cli.js render src/index.tsx react-svg video.mp4
```
- Render at sub folder
```bash
../cli/remotion-cli.js render src/index.tsx react-svg nested/video.mp4
```
