### PR TITLE
Add getContainerNode to PlayerRef methods

### DIFF
--- a/packages/docs/docs/player.md
+++ b/packages/docs/docs/player.md
@@ -198,6 +198,10 @@ Pauses the video if it's playing. Plays the video if it's paused.
 
 Gets the current postition expressed as the current frame. Divide by the `fps` you passed to get the time in seconds.
 
+### `getContainerNode()`
+
+Gets the container HTMLDivElement of the Remotion Player. This method is useful if you'd like to handle Player click events yourself with `addEventListener`.
+
 ### `mute()`
 
 Mutes the video.

--- a/packages/docs/docs/player.md
+++ b/packages/docs/docs/player.md
@@ -200,7 +200,33 @@ Gets the current postition expressed as the current frame. Divide by the `fps` y
 
 ### `getContainerNode()`
 
-Gets the container HTMLDivElement of the Remotion Player. This method is useful if you'd like to handle Player click events yourself with `addEventListener`.
+Gets the container `HTMLDivElement` of the player. Useful if you'd like to manually attach listeners to the player element.
+
+```tsx
+import {useRef, useEffect} from 'react'
+import {PlayerRef} from '@remotion/player'
+// ---cut---
+const playerRef = useRef<PlayerRef>(null);
+
+useEffect(() => {
+  if (!playerRef.current) {
+    return;
+  }
+  const container = playerRef.current.getContainerNode();
+  if (!container) {
+    return;
+  }
+  
+  const onClick = () => {
+    console.log('player got clicked');
+  };
+  
+  container.addEventListener('click', onClick)
+  return () => {
+    container.removeEventListener('click', onClick);
+  }
+}, []);
+```
 
 ### `mute()`
 

--- a/packages/docs/docs/player.md
+++ b/packages/docs/docs/player.md
@@ -200,9 +200,11 @@ Gets the current postition expressed as the current frame. Divide by the `fps` y
 
 ### `getContainerNode()`
 
+_Available from v2.4.2_
+
 Gets the container `HTMLDivElement` of the player. Useful if you'd like to manually attach listeners to the player element.
 
-```tsx
+```tsx twoslash
 import {useRef, useEffect} from 'react'
 import {PlayerRef} from '@remotion/player'
 // ---cut---
@@ -216,11 +218,11 @@ useEffect(() => {
   if (!container) {
     return;
   }
-  
+
   const onClick = () => {
     console.log('player got clicked');
   };
-  
+
   container.addEventListener('click', onClick)
   return () => {
     container.removeEventListener('click', onClick);

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -153,6 +153,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 				play: player.play,
 				pause: player.pause,
 				toggle,
+				getContainerNode: () => container.current,
 				getCurrentFrame: player.getCurrentFrame,
 				seekTo: (f) => {
 					if (player.isPlaying()) {

--- a/packages/player/src/player-methods.ts
+++ b/packages/player/src/player-methods.ts
@@ -6,6 +6,7 @@ export type PlayerMethods = {
 	pause: () => void;
 	toggle: () => void;
 	seekTo: (frame: number) => void;
+	getContainerNode: () => HTMLDivElement | null;
 	getCurrentFrame: () => number;
 	requestFullscreen: () => void;
 	exitFullscreen: () => void;


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Adds a `getContainerNode` method to any instance of a `PlayerRef`. This will allow consumers to retrieve the container `HTMLDivElement` and handle any interaction events they'd like to manually (ex. click, double click events).

I haven't added an example into the documentation (I can if you'd like), but it would look something like:

```tsx twoslash {15}
import {useEffect, useRef} from 'react'
import {Player, PlayerRef} from '@remotion/player'
import {MyComposition} from './MyComposition'

const MyComp: React.FC = () => {
  const playerRef = useRef<PlayerRef>(null);

  useEffect(() => {
    function listener() {
      console.log("I have been clicked");
    }

    if (playerRef.current) {
      const container = playerRef.current.getContainerNode();

      container.addEventListener("click", listener);

      return () => {
        container.removeEventListener("click", listener);
      };
    }
  }, []);

  return (
    <Player
      ref={playerRef}
      durationInFrames={30}
      compositionWidth={1080}
      compositionHeight={1080}
      fps={30}
      component={MyComposition}.
    />
  )
}
```

