### PR TITLE
Adding Fig.io section to the docs

### DIFF
--- a/packages/docs/docs/cli.md
+++ b/packages/docs/docs/cli.md
@@ -172,6 +172,10 @@ Print the list of available CLI commands and flags.
 npx remotion render --codec=vp8 src/index.tsx HelloWorld out/video.webm
 ```
 
+## Fig.io autocompletion
+
+Fig adds visual apps, shortcuts, and autocomplete to your existing Terminal. The remotion autocompletion is available on Fig, try i  with `npx remotion`, `remotion`, `yarn create video`. Useful if you have a memory lapse.
+
 ## See also
 
 - [Render your video](/docs/render)


### PR DESCRIPTION
This pull request add an informational section to the docs/cli page on the [remotion.dev](https://remotion.dev) website.

This PR is link to the Hacktoberfest issue https://github.com/remotion-dev/remotion/issues/614
