### PR TITLE
Fix code block theme

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -155,7 +155,7 @@ module.exports = {
     [
       "docusaurus-preset-shiki-twoslash",
       {
-        themes: ["min-light", "min-dark"],
+        themes: ["github-light", "github-dark"],
         defaultCompilerOptions: {
           types: ["node"],
         },

--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -51,11 +51,11 @@
 }
 
 /* Hide code blocks according to theme */
-[data-theme="light"] .shiki.min-dark {
+[data-theme="light"] .shiki.github-dark {
   display: none;
 }
 
-[data-theme="dark"] .shiki.min-light {
+[data-theme="dark"] .shiki.github-light {
   display: none;
 }
 


### PR DESCRIPTION
Resolve #612

This PR will fix diff code block not colored.

| Before | After |
| :----: | :---: |
| <img src="https://user-images.githubusercontent.com/2143364/135912535-ee8cbe7b-f865-4932-bc13-a999d0e7d672.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2143364/135912572-9a94a328-65db-4fae-b301-d5c0fc4cef0a.png" width="100%"> |
| <img src="https://user-images.githubusercontent.com/2143364/135912598-1358f2f9-e1aa-4d46-853e-f6f439c26571.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2143364/135912625-107490a2-2b2a-49c5-b830-136f69ceee84.png" width="100%"> |


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#612: ```diff blocks in Docs are not rendered](https://issuehunt.io/repos/274495425/issues/612)
---
</details>
<!-- /Issuehunt content-->