### PR TITLE
Update overwriting-webpack-config.md

### DIFF
--- a/packages/docs/docs/overwriting-webpack-config.md
+++ b/packages/docs/docs/overwriting-webpack-config.md
@@ -146,7 +146,7 @@ Config.Bundling.overrideWebpackConfig((currentConfiguration) => {
               loader: 'postcss-loader',
               options: {
                 postcssOptions: {
-                  plugins: ['postcss-preset-env', 'tailwindcss'],
+                  plugins: ['postcss-preset-env', 'tailwindcss', 'autoprefixer'],
                 },
               },
             },


### PR DESCRIPTION
`bg-clip-text` was being classed as an invalid property leading to the block gradient shown in this issue here https://github.com/tailwindlabs/tailwindcss/issues/2300. Simply adding autoprefixer to the plugins for postcss fixes this. Side note: I had to delete `node_modules/.cache` before the changes were then picked up!

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
