### PR TITLE
Fix ENOTEMPTY error when cleaning up

### DIFF
--- a/packages/cli/src/delete-directory.ts
+++ b/packages/cli/src/delete-directory.ts
@@ -1,0 +1,8 @@
+import execa from 'execa';
+
+export const deleteDirectory = async (directory: string) => {
+	// We use del before to remove all files inside the directories otherwise
+	// rmdir will throw an error.
+	await execa('cmd', ['/c', 'del', '/f', '/s', '/q', directory]);
+	await execa('cmd', ['/c', 'rmdir', '/s', '/q', directory]);
+};

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -7,11 +7,11 @@ import {
 	stitchFramesToVideo,
 } from '@remotion/renderer';
 import chalk from 'chalk';
-import execa from 'execa';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {Internals} from 'remotion';
+import {deleteDirectory} from './delete-directory';
 import {getCliOptions} from './get-cli-options';
 import {getCompositionId} from './get-composition-id';
 import {handleCommonError} from './handle-common-errors';
@@ -234,12 +234,9 @@ export const render = async () => {
 		Log.verbose('Cleaning up...');
 		try {
 			if (process.platform === 'win32') {
-				// Properly delete directories because Windows doesn't seem to like fs 
-				await execa('rmdir', ['/s', '/q', outputDir]);
-				// Bundled directory needs an additional 'del' command, otherwise rmdir
-				// will throw an error (directory not empty)
-				await execa('cmd', ['/c', 'del', '/f', '/s', '/q', bundled]);
-				await execa('rmdir', ['/s', '/q', bundled]);
+				// Properly delete directories because Windows doesn't seem to like fs.
+				await deleteDirectory(outputDir);
+				await deleteDirectory(bundled);
 			} else {
 				await Promise.all([
 					(fs.promises.rm ?? fs.promises.rmdir)(outputDir, {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
Resolve #334 

The issue seemed to appear when importing a local asset and using it in a `src` field.
Windows couldn't properly close the handle of the asset, making the `bundled` directory impossible to delete.

The workaround was to manually remove each file of the directory using `execa`, then using `fs`.

N.B. For now it seems like we got a [EPERM error instead](https://github.com/remotion-dev/remotion/pull/634/checks?check_run_id=3851621432#step:9:96), thinking if it's specific to actions or not (since my tests don't report anything).


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#334: Investigate windows / node v14 recursive bug](https://issuehunt.io/repos/274495425/issues/334)
---
</details>
<!-- /Issuehunt content-->