### PR TITLE
[#344] customize error ui

### DIFF
--- a/packages/docs/components/Experimental.tsx
+++ b/packages/docs/components/Experimental.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
-export const ExperimentalBadge: React.FC = () => {
+export const ExperimentalBadge: React.FC<{
+  message?: string;
+}> = ({
+  message = "This component may change in minor version updates. Monitor the documentation page to see breaking changes when upgrading.",
+}) => {
   return (
     <div
       style={{
@@ -24,10 +28,7 @@ export const ExperimentalBadge: React.FC = () => {
       >
         EXPERIMENTAL
       </div>
-      <div>
-        This component may change in minor version updates. Monitor the
-        documentation page to see breaking changes when upgrading.
-      </div>
+      <div>{message}</div>
     </div>
   );
 };

--- a/packages/docs/docs/player.md
+++ b/packages/docs/docs/player.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 import { PlayerExample } from "../components/Player.tsx";
 import { ExperimentalBadge } from "../components/Experimental.tsx";
 
-<ExperimentalBadge/>
+<ExperimentalBadge message="This player is currently in a beta state. We are done with the most important features we wanted to implement and will promote the Player to stable in the next version, if there is no feedback from users."/>
 
 Using the Remotion Player you can embed Remotion videos in any React app and customize the video content at runtime.
 
@@ -150,6 +150,12 @@ A number between -4 and 4 (excluding 0) for the speed that the Player will run t
 A `playbackRate` of `2` means the video plays twice as fast. A playbackRate of `0.5` means the video plays twice as slow. A playbackRate of `-1` means the video plays in reverse. Note that [`<Audio/>`](/docs/audio) and [`<Video/>`](/docs/video) tags cannot be played in reverse, this is a browser limitation.
 
 Default `1`.
+
+### `errorFallback`
+
+_optional_
+
+A callback for rendering a custom error message. See [Handling errors](#handling-errors) section for an example.
 
 ## `PlayerRef`
 
@@ -411,9 +417,48 @@ It is up to you to handle the error and to re-mount the video (for example by ch
 
 This feature is implemented using an [error boundary](https://reactjs.org/docs/error-boundaries.html), so only errors in the render function will be caught. Errors in event handlers and asynchronous code will not be reported and will not cause the video to unmount.
 
+You can customize the error message that is shown if a video crashes:
+
+```tsx twoslash
+import { Player, ErrorFallback } from "@remotion/player";
+import { useCallback } from "react";
+import { AbsoluteFill } from "remotion";
+
+const Component: React.FC = () => null;
+
+// ---cut---
+
+const MyApp: React.FC = () => {
+  // `ErrorFallback` type can be imported from "@remotion/player"
+  const errorFallback: ErrorFallback = useCallback(({ error }) => {
+    return (
+      <AbsoluteFill
+        style={{
+          backgroundColor: "yellow",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        Sorry about this! An error occurred: {error.message}
+      </AbsoluteFill>
+    );
+  }, []);
+
+  return (
+    <Player
+      fps={30}
+      component={Component}
+      durationInFrames={100}
+      compositionWidth={1080}
+      compositionHeight={1080}
+      errorFallback={errorFallback}
+    />
+  );
+};
+```
+
 ## Known issues
 
 Before we mark the player as stable, we are looking to improve in the following areas:
 
 - Better loading state than the current "Loading..." text.
-- Customize error UI

--- a/packages/player-example/src/App.tsx
+++ b/packages/player-example/src/App.tsx
@@ -1,6 +1,7 @@
 import {Player, PlayerRef} from '@remotion/player';
 import {useEffect, useRef, useState} from 'react';
-import CarSlideshow from './CarSlideshow';
+import {AbsoluteFill} from 'remotion';
+import CarSlideshow, {playerExampleComp} from './CarSlideshow';
 
 export default function App() {
 	const [title, setTitle] = useState('Hello World');
@@ -60,6 +61,19 @@ export default function App() {
 					title: String(title),
 					bgColor: String(bgColor),
 					color: String(color),
+				}}
+				errorFallback={({error}) => {
+					return (
+						<AbsoluteFill
+							style={{
+								backgroundColor: 'yellow',
+								justifyContent: 'center',
+								alignItems: 'center',
+							}}
+						>
+							Sorry about this! An error occurred: {error.message}
+						</AbsoluteFill>
+					);
 				}}
 				playbackRate={playbackRate}
 				spaceKeyToPlayOrPause={spaceKeyToPlayOrPause}
@@ -204,6 +218,14 @@ export default function App() {
 				}}
 			>
 				-1x speed
+			</button>
+			<button
+				type="button"
+				onClick={() => {
+					playerExampleComp.current?.triggerError();
+				}}
+			>
+				trigger error
 			</button>
 			<br />
 			<br />

--- a/packages/player-example/src/CarSlideshow.tsx
+++ b/packages/player-example/src/CarSlideshow.tsx
@@ -1,3 +1,4 @@
+import {createRef, useCallback, useImperativeHandle, useState} from 'react';
 import {interpolate, useCurrentFrame, useVideoConfig} from 'remotion';
 
 type Props = {
@@ -6,10 +7,35 @@ type Props = {
 	color: string;
 };
 
+export const playerExampleComp = createRef<{
+	triggerError: () => void;
+}>();
+
 const CarSlideshow = ({title, bgColor, color}: Props) => {
 	const frame = useCurrentFrame();
 	const {width, height, durationInFrames} = useVideoConfig();
 	const left = interpolate(frame, [0, durationInFrames], [width, width * -1]);
+
+	const [shouldThrowError, setThrowError] = useState(false);
+
+	const dummyText = useCallback(() => {
+		if (shouldThrowError) {
+			throw new Error('some error');
+		}
+		return '';
+	}, [shouldThrowError]);
+
+	useImperativeHandle(
+		playerExampleComp,
+		() => {
+			return {
+				triggerError: () => {
+					setThrowError(true);
+				},
+			};
+		},
+		[]
+	);
 
 	return (
 		<div
@@ -33,7 +59,7 @@ const CarSlideshow = ({title, bgColor, color}: Props) => {
 					whiteSpace: 'nowrap',
 				}}
 			>
-				{title}
+				{title} {dummyText()}
 			</h1>
 		</div>
 	);

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -35,6 +35,8 @@ type PropsIfHasProps<Props> = {} extends Props
 			inputProps: Props;
 	  };
 
+export type ErrorFallback = (info: {error: Error}) => React.ReactNode;
+
 export type PlayerProps<T> = {
 	durationInFrames: number;
 	compositionWidth: number;
@@ -42,7 +44,7 @@ export type PlayerProps<T> = {
 	fps: number;
 	showVolumeControls?: boolean;
 	controls?: boolean;
-	errorMessage: string;
+	errorFallback?: ErrorFallback;
 	style?: React.CSSProperties;
 	loop?: boolean;
 	autoPlay?: boolean;
@@ -77,7 +79,7 @@ export const PlayerFn = <T,>(
 		doubleClickToFullscreen = false,
 		spaceKeyToPlayOrPause = true,
 		numberOfSharedAudioTags = 5,
-		errorMessage = '⚠️',
+		errorFallback = () => '⚠️',
 		playbackRate = 1,
 		...componentProps
 	}: PlayerProps<T>,
@@ -310,7 +312,7 @@ export const PlayerFn = <T,>(
 										autoPlay={Boolean(autoPlay)}
 										loop={Boolean(loop)}
 										controls={Boolean(controls)}
-										errorMessage={errorMessage}
+										errorFallback={errorFallback}
 										style={style}
 										inputProps={passedInputProps}
 										allowFullscreen={Boolean(allowFullscreen)}

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -43,7 +43,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		setMediaVolume: (v: number) => void;
 		setMediaMuted: (v: boolean) => void;
 		mediaVolume: number;
-		errorMessage: string;
+		errorFallback: (info: {error: Error}) => React.ReactNode;
 		playbackRate: number;
 	}
 > = (
@@ -62,7 +62,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		setMediaMuted,
 		setMediaVolume,
 		spaceKeyToPlayOrPause,
-		errorMessage,
+		errorFallback,
 		playbackRate,
 	},
 	ref
@@ -366,7 +366,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 			>
 				<div style={containerStyle} className={PLAYER_CSS_CLASSNAME}>
 					{VideoComponent ? (
-						<ErrorBoundary onError={onError} errorMessage={errorMessage}>
+						<ErrorBoundary onError={onError} errorFallback={errorFallback}>
 							<VideoComponent
 								{...((video?.props as unknown as {}) ?? {})}
 								{...((inputProps as unknown as {}) ?? {})}

--- a/packages/player/src/error-boundary.tsx
+++ b/packages/player/src/error-boundary.tsx
@@ -12,14 +12,14 @@ const errorStyle: React.CSSProperties = {
 export class ErrorBoundary extends React.Component<
 	{
 		onError: (error: Error) => void;
-		errorMessage: string;
+		errorFallback: (info: {error: Error}) => React.ReactNode;
 	},
-	{hasError: boolean}
+	{hasError: Error | null}
 > {
-	state = {hasError: false};
-	static getDerivedStateFromError() {
+	state = {hasError: null};
+	static getDerivedStateFromError(error: Error) {
 		// Update state so the next render will show the fallback UI.
-		return {hasError: true};
+		return {hasError: error};
 	}
 
 	componentDidCatch(error: Error) {
@@ -29,7 +29,13 @@ export class ErrorBoundary extends React.Component<
 	render() {
 		if (this.state.hasError) {
 			// You can render any custom fallback UI
-			return <div style={errorStyle}>{this.props.errorMessage}</div>;
+			return (
+				<div style={errorStyle}>
+					{this.props.errorFallback({
+						error: this.state.hasError,
+					})}
+				</div>
+			);
 		}
 
 		return this.props.children;

--- a/packages/player/src/index.tsx
+++ b/packages/player/src/index.tsx
@@ -1,6 +1,7 @@
 import {calculateScale} from './calculate-scale';
 import {PlayerEventEmitterContext} from './emitter-context';
 import {PlayerEmitter} from './event-emitter';
+import {ErrorFallback} from './Player';
 import {useHoverState} from './use-hover-state';
 import {usePlayback} from './use-playback';
 import {usePlayer} from './use-player';
@@ -20,3 +21,5 @@ export const PlayerInternals = {
 	calculateScale,
 	useHoverState,
 };
+
+export type {ErrorFallback};

--- a/packages/player/src/test/validate-prop.test.tsx
+++ b/packages/player/src/test/validate-prop.test.tsx
@@ -7,7 +7,7 @@ test('no compositionWidth should give errors', () => {
 			<Player
 				// @ts-expect-error
 				compositionWidth={null}
-				errorMessage={'something went wrong'}
+				errorFallback={() => 'something went wrong'}
 				compositionHeight={400}
 				fps={30}
 				durationInFrames={500}
@@ -28,7 +28,7 @@ test('no compositionHeight should give errors', () => {
 		render(
 			<Player
 				compositionWidth={400}
-				errorMessage={'something went wrong'}
+				errorFallback={() => 'something went wrong'}
 				// @ts-expect-error
 				compositionHeight={undefined}
 				fps={30}
@@ -51,7 +51,7 @@ test('No fps should give errors', () => {
 			<Player
 				compositionWidth={500}
 				compositionHeight={400}
-				errorMessage={'something went wrong'}
+				errorFallback={() => 'something went wrong'}
 				// @ts-expect-error
 				fps={null}
 				durationInFrames={500}
@@ -71,7 +71,7 @@ test('No fps should give errors', () => {
 			<Player
 				compositionWidth={500}
 				compositionHeight={400}
-				errorMessage={'something went wrong'}
+				errorFallback={() => 'something went wrong'}
 				// @ts-expect-error
 				fps={undefined}
 				durationInFrames={500}
@@ -93,7 +93,7 @@ test('No durationInFrames should give errors', () => {
 			<Player
 				compositionWidth={500}
 				compositionHeight={400}
-				errorMessage={'something went wrong'}
+				errorFallback={() => 'something went wrong'}
 				fps={30}
 				// @ts-expect-error
 				durationInFrames={undefined}
@@ -204,7 +204,7 @@ test.each([
 			<Player
 				compositionWidth={500}
 				compositionHeight={400}
-				errorMessage={'something went wrong'}
+				errorFallback={() => 'something went wrong'}
 				fps={30}
 				durationInFrames={100}
 				component={HelloWorld}


### PR DESCRIPTION
closes #344 

- error message shown in the Error Boundary is customizable (the default is set to '⚠️')
- updated the test `validate-prop`