### PR TITLE
Enhancement: Update lambda upgrade docs and make removing lambda functions optional

### DIFF
--- a/packages/docs/docs/lambda-changelog.md
+++ b/packages/docs/docs/lambda-changelog.md
@@ -10,7 +10,7 @@ Keep track of changes to the APIs of Remotion Lambda here.
 
 1. Get the newest version from the `#lambda` Discord channel.
 1. Upgrade all packages to the newest version (`@remotion/lambda`, but also `remotion`, `@remotion/cli` etc.)
-1. (Optional) Remove all existing lambdas: `npx remotion-lambda functions ls` and then `npx remotion-lambda functions rm <function-name>`.
+1. (Optional) Remove all existing lambdas: `npx remotion-lambda functions ls` and then `npx remotion-lambda functions rm <function-name>`
 1. Redeploy your function: `npx remotion lambda functions deploy`
 1. Migrate according to the changelog below:
 

--- a/packages/docs/docs/lambda-changelog.md
+++ b/packages/docs/docs/lambda-changelog.md
@@ -10,7 +10,7 @@ Keep track of changes to the APIs of Remotion Lambda here.
 
 1. Get the newest version from the `#lambda` Discord channel.
 1. Upgrade all packages to the newest version (`@remotion/lambda`, but also `remotion`, `@remotion/cli` etc.)
-1. Remove all existing lambdas: `npx remotion-lambda functions ls` and then `npx remotion-lambda functions rm <function-name>`
+1. (Optional) Remove all existing lambdas: `npx remotion-lambda functions ls` and then `npx remotion-lambda functions rm <function-name>`.
 1. Redeploy your function: `npx remotion lambda functions deploy`
 1. Migrate according to the changelog below:
 


### PR DESCRIPTION
Small fix, but not sure if I need to extend the documentation or add additional reference to explain the rationale. For instance, adding this line after the step might help but also overcomplicate the upgrade process:

Refer to the second deploy exception in the [`FAQ`](/docs/lambda/faq#do-i-need-to-deploy-a-function-for-each-render) where one can run multiple lambda functions with different versions in the same region.

I thought maybe adding (optional) should be good enough, would appreciate some input regardless

