### PR TITLE
Fix asset types declaration

### DIFF
--- a/packages/core/src/asset-types.ts
+++ b/packages/core/src/asset-types.ts
@@ -63,8 +63,4 @@ declare module '*.woff2' {
 	export default src;
 }
 
-declare module '*.css' {
-	const src: string;
-	export default src;
-}
-
+declare module '*.css';

--- a/packages/core/src/asset-types.ts
+++ b/packages/core/src/asset-types.ts
@@ -1,14 +1,70 @@
-declare module '*.webm';
-declare module '*.png';
-declare module '*.mp4';
-declare module '*.mp3';
-declare module '*.wav';
-declare module '*.aac';
-declare module '*.svg';
-declare module '*.jpg';
-declare module '*.jpeg';
-declare module '*.bmp';
-declare module '*.gif';
-declare module '*.woff';
-declare module '*.woff2';
-declare module '*.css';
+declare module '*.webm' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.png' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.mp4' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.mp3' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.wav' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.aac' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.svg' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.jpg' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.jpeg' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.bmp' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.gif' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.woff' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.woff2' {
+	const src: string;
+	export default src;
+}
+
+declare module '*.css' {
+	const src: string;
+	export default src;
+}
+


### PR DESCRIPTION
Hello 👋

I started using Remotion, but noticed you overwrite asset types declarations (for imports).
Problem: the value type is set to `any`, which make some typescript-eslint rules break.

Example with the `no-unsafe-assignment` rule:

<img width="494" alt="issue-remotion" src="https://user-images.githubusercontent.com/1902323/145804485-60bc639d-2a7c-432c-bc04-b21bae0544b0.png">

This PR set the exported value to `string`, as the import returned value will be a `string` URL.