### PR TITLE
docs: fix dynamic-metadata example

### DIFF
--- a/packages/docs/docs/dynamic-metadata.md
+++ b/packages/docs/docs/dynamic-metadata.md
@@ -90,8 +90,10 @@ export const Index: React.FC = () => {
       })
       .catch((err) => {
         console.log(`Error fetching metadata: ${err}`);
-        continueRender(handle);
-      });
+			})
+			.finally(() => {
+				continueRender(handle);
+			});
   }, [handle]);
 
   return (

--- a/packages/docs/docs/dynamic-metadata.md
+++ b/packages/docs/docs/dynamic-metadata.md
@@ -90,10 +90,10 @@ export const Index: React.FC = () => {
       })
       .catch((err) => {
         console.log(`Error fetching metadata: ${err}`);
-			})
-			.finally(() => {
-				continueRender(handle);
-			});
+      })
+      .finally(() => {
+        continueRender(handle);
+      });
   }, [handle]);
 
   return (

--- a/packages/docs/docs/dynamic-metadata.md
+++ b/packages/docs/docs/dynamic-metadata.md
@@ -87,13 +87,11 @@ export const Index: React.FC = () => {
     )
       .then(({ durationInSeconds }) => {
         setDuration(Math.round(durationInSeconds * 30));
+        continueRender(handle);
       })
       .catch((err) => {
         console.log(`Error fetching metadata: ${err}`);
       })
-      .finally(() => {
-        continueRender(handle);
-      });
   }, [handle]);
 
   return (

--- a/packages/docs/docs/dynamic-metadata.md
+++ b/packages/docs/docs/dynamic-metadata.md
@@ -91,7 +91,7 @@ export const Index: React.FC = () => {
       })
       .catch((err) => {
         console.log(`Error fetching metadata: ${err}`);
-      })
+      });
   }, [handle]);
 
   return (


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
## Description

Running the [Change metadata based on asynchronous information​](https://www.remotion.dev/docs/dynamic-metadata#change-metadata-based-on-asynchronous-information) example from the documentation yields a timeout error when the `yarn build` command is run. It is because on successful metadata fetch `continueRender` is never executed.

<details>
<summary>Timeout error while running `yarn build` and using this example</summary>
<br>

```console
yarn run v1.22.17
$ remotion render src/index.tsx Empty out/video.mp4
📦 (1/3) [====================] Bundled code 709ms
[Error: Error: A delayRender was called but not cleared after 28000ms. See https://remotion.dev/docs/timeout for help. The delayRender was called: 
    at delayRender (http://localhost:3000/bundle.js:4455:32)
    at http://localhost:3000/bundle.js:6564:65
    at Object.Qh [as useState] (http://localhost:3000/bundle.js:971:102)
    at exports.useState (http://localhost:3000/bundle.js:1187:281)
    at Index (http://localhost:3000/bundle.js:6564:38)
    at Ch (http://localhost:3000/bundle.js:963:137)
    at ck (http://localhost:3000/bundle.js:1073:460)
    at bk (http://localhost:3000/bundle.js:1056:347)
    at ak (http://localhost:3000/bundle.js:1056:278)
    at Tj (http://localhost:3000/bundle.js:1056:138)
    at http://localhost:3000/bundle.js:4461:19]
```

</details>

## Changes

Moved `continueRender(handle)` to `Promise.finally()` to ensure `continueRender` is always executed.

