### PR TITLE
Fix static file in Next.JS SSR

### DIFF
--- a/packages/core/src/static-file.ts
+++ b/packages/core/src/static-file.ts
@@ -7,7 +7,7 @@ const trimLeadingSlash = (path: string) => {
 };
 
 const inner = (path: string): string => {
-	if (window.remotion_staticBase) {
+	if (typeof window !== 'undefined' && window.remotion_staticBase) {
 		return `${window.remotion_staticBase}/${trimLeadingSlash(path)}`;
 	}
 


### PR DESCRIPTION
`window` is not available, but the public folder will be available at the root path.
