### PR TITLE
docs: Clarification of Player.props.component

### DIFF
--- a/packages/docs/docs/player/api.md
+++ b/packages/docs/docs/player/api.md
@@ -11,6 +11,8 @@ A React component which takes the following props:
 
 Pass a React component in directly **or** pass a function that returns a dynamic import. Passing neither or both of the props is an error.
 
+:::info The component you pass in should not render the [`<Composition />`](/docs/composition) component, but rather your custom video component instead - the component you would pass into the `component` prop of the [`<Composition />`](/docs/composition) component. :::
+
 ### `durationInFrames`
 
 The duration of the video in frames. Must be an integer and greater than 0.

--- a/packages/docs/docs/player/api.md
+++ b/packages/docs/docs/player/api.md
@@ -11,7 +11,9 @@ A React component which takes the following props:
 
 Pass a React component in directly **or** pass a function that returns a dynamic import. Passing neither or both of the props is an error.
 
-:::info The component you pass in should not render the [`<Composition />`](/docs/composition) component, but rather your custom video component instead - the component you would pass into the `component` prop of the [`<Composition />`](/docs/composition) component. :::
+:::info
+The component you pass in should not render the [`<Composition />`](/docs/composition) component, but rather your custom video component instead - the component you would pass into the `component` prop of the [`<Composition />`](/docs/composition) component.
+:::
 
 ### `durationInFrames`
 


### PR DESCRIPTION
Small change to `@remotion/player` documentation to clarify that `Player.props.component` shouldn't take a `Composition` component, but the video component itself!

Spent the last 2 hours trying to work out why my video wasn't displaying, figured it could do with some clarification to prevent someone from doing the same!
