### PR TITLE
remove angle as default renderer

### DIFF
--- a/packages/core/src/config/chromium-flags.ts
+++ b/packages/core/src/config/chromium-flags.ts
@@ -3,11 +3,11 @@ import {
 	validateOpenGlRenderer,
 } from '../validation/validate-opengl-renderer';
 
-export const DEFAULT_OPENGL_RENDERER: OpenGlRenderer = 'angle';
+export const DEFAULT_OPENGL_RENDERER: OpenGlRenderer | null = null;
 
 let chromiumDisableWebSecurity = false;
 let ignoreCertificateErrors = false;
-let openGlRenderer: OpenGlRenderer = DEFAULT_OPENGL_RENDERER;
+let openGlRenderer: OpenGlRenderer | null = DEFAULT_OPENGL_RENDERER;
 let headlessMode = true;
 
 export const getChromiumDisableWebSecurity = () => chromiumDisableWebSecurity;

--- a/packages/core/src/validation/validate-opengl-renderer.ts
+++ b/packages/core/src/validation/validate-opengl-renderer.ts
@@ -3,8 +3,12 @@ const validRenderers = ['angle', 'egl', 'swiftshader'] as const;
 export type OpenGlRenderer = typeof validRenderers[number];
 
 export const validateOpenGlRenderer = (
-	option: OpenGlRenderer
-): OpenGlRenderer => {
+	option: OpenGlRenderer | null
+): OpenGlRenderer | null => {
+	if (option === null) {
+		return null;
+	}
+
 	if (!validRenderers.includes(option)) {
 		throw new TypeError(
 			`${option} is not a valid GL backend. Accepted values: ${validRenderers.join(

--- a/packages/docs/components/AngleChangelog.tsx
+++ b/packages/docs/components/AngleChangelog.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export const AngleChangelog: React.FC = () => {
+  return (
+    <details style={{ fontSize: "0.9em", marginBottom: "1em" }}>
+      <summary>Changelog</summary>
+      From Remotion v2.4.3 until v2.6.6, the default was <code>angle</code>,
+      however it turns out to have a memory leak.
+    </details>
+  );
+};

--- a/packages/docs/docs/chromium-flags.md
+++ b/packages/docs/docs/chromium-flags.md
@@ -3,6 +3,8 @@ id: chromium-flags
 title: Chromium flags
 ---
 
+import {AngleChangelog} from '../components/AngleChangelog';
+
 We allow you to set the following flags in Chromium and Google Chrome since Remotion 2.6.5:
 
 ## `--disable-web-security`
@@ -86,8 +88,9 @@ Config.Puppeteer.setChromiumHeadlessMode(false);
 ## `--gl`
 
 <!-- TODO: Update for lambda -->
+<AngleChangelog />
 
-Select the OpenGL renderer backend for Chromium. Accepted values: `angle`, `egl`, `swiftshader`. Default: `angle`.
+Select the OpenGL renderer backend for Chromium. Accepted values: `"angle"`, `"egl"`, `"swiftshader"` and `null`. `null` means Chromiums default. Default: `null`.
 
 ### Enabling in Node.JS APIs
 

--- a/packages/docs/docs/cli.md
+++ b/packages/docs/docs/cli.md
@@ -4,6 +4,8 @@ sidebar_label: CLI reference
 id: cli
 ---
 
+import {AngleChangelog} from '../components/AngleChangelog';
+
 ## Commands
 
 The following commands are available - you can always run them using `npx remotion` or even without the `npx` prefix if you put the command inside an npm script.
@@ -208,7 +210,10 @@ Available since v2.6.5.
 
 _available for `still`, `render` command_
 
-Select the OpenGL renderer backend for Chromium. Accepted values: `angle`, `egl`, `swiftshader`. Default: `angle`. Available since v2.6.5.
+<!-- TODO: Update for lambda -->
+<AngleChangelog />
+
+Select the OpenGL renderer backend for Chromium. Accepted values: `"angle"`, `"egl"`, `"swiftshader"` and `null`. `null` means Chromiums default. Default: `null`.
 
 ### `--help`
 

--- a/packages/docs/docs/get-compositions.md
+++ b/packages/docs/docs/get-compositions.md
@@ -3,6 +3,8 @@ title: getCompositions()
 id: get-compositions
 ---
 
+import {AngleChangelog} from '../components/AngleChangelog';
+
 _Part of the `@remotion/renderer` package._
 
 Gets the compositions defined in a Remotion project based on a webpack bundle. Spins up a browser with Puppeteer and evaluates the Remotion root.
@@ -83,7 +85,9 @@ _string_
 
 <!-- TODO: Update for lambda -->
 
-Select the OpenGL renderer backend for Chromium. Accepted values: `angle`, `egl`, `swiftshader`. Default: `angle`.
+<AngleChangelog />
+
+Select the OpenGL renderer backend for Chromium. Accepted values: `"angle"`, `"egl"`, `"swiftshader"` and `null`. `null` means Chromiums default. Default: `null`.
 
 ## Return value
 

--- a/packages/docs/docs/render-frames.md
+++ b/packages/docs/docs/render-frames.md
@@ -3,6 +3,8 @@ id: render-frames
 title: renderFrames()
 ---
 
+import {AngleChangelog} from '../components/AngleChangelog';
+
 _Part of the `@remotion/renderer` package._
 
 Renders a series of images using Puppeteer and computes information for mixing audio.
@@ -199,7 +201,9 @@ _string_
 
 <!-- TODO: Update for lambda -->
 
-Select the OpenGL renderer backend for Chromium. Accepted values: `angle`, `egl`, `swiftshader`. Default: `angle`.
+<AngleChangelog />
+
+Select the OpenGL renderer backend for Chromium. Accepted values: `"angle"`, `"egl"`, `"swiftshader"` and `null`. `null` means Chromiums default. Default: `null`.
 
 ## Return value
 

--- a/packages/docs/docs/render-still.md
+++ b/packages/docs/docs/render-still.md
@@ -3,6 +3,8 @@ id: render-still
 title: renderStill()
 ---
 
+import {AngleChangelog} from '../components/AngleChangelog';
+
 _Part of the `@remotion/renderer` package. Available from v2.3._
 
 Renders a single frame to an image and writes it to the specified output location.
@@ -181,8 +183,9 @@ If disabled, the render will open an actual Chrome window where you can see the 
 _string_
 
 <!-- TODO: Update for lambda -->
+<AngleChangelog />
 
-Select the OpenGL renderer backend for Chromium. Accepted values: `angle`, `egl`, `swiftshader`. Default: `angle`.
+Select the OpenGL renderer backend for Chromium. Accepted values: `"angle"`, `"egl"`, `"swiftshader"` and `null`. `null` means Chromiums default. Default: `null`.
 
 ## Return value
 

--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -15,11 +15,13 @@ type OpenGlRenderer = typeof validRenderers[number];
 export type ChromiumOptions = {
 	ignoreCertificateErrors?: boolean;
 	disableWebSecurity?: boolean;
-	gl?: OpenGlRenderer;
+	gl?: OpenGlRenderer | null;
 	headless?: boolean;
 };
 
-const getOpenGlRenderer = (option?: OpenGlRenderer): OpenGlRenderer => {
+const getOpenGlRenderer = (
+	option?: OpenGlRenderer | null
+): OpenGlRenderer | null => {
 	const renderer = option ?? Internals.DEFAULT_OPENGL_RENDERER;
 	Internals.validateOpenGlRenderer(renderer);
 	return renderer;
@@ -45,6 +47,11 @@ export const openBrowser = async (
 		browser,
 		options?.browserExecutable ?? null
 	);
+
+	const customGlRenderer = getOpenGlRenderer(
+		options?.chromiumOptions?.gl ?? null
+	);
+
 	const browserInstance = await puppeteer.launch({
 		executablePath,
 		product: browser,
@@ -54,7 +61,7 @@ export const openBrowser = async (
 			'--no-sandbox',
 			'--disable-setuid-sandbox',
 			'--disable-dev-shm-usage',
-			`--use-gl=${getOpenGlRenderer(options?.chromiumOptions?.gl)}`,
+			customGlRenderer ? `--use-gl=${customGlRenderer}` : null,
 			'--disable-background-media-suspend',
 			process.platform === 'linux' ? '--single-process' : null,
 			options?.chromiumOptions?.ignoreCertificateErrors


### PR DESCRIPTION
I found `angle` to be eating all the RAM when rendering a longer video.
The new default is `null`. With the `--gl` flag and equivalent Node.JS APIs, users may be able to specify `angle` again.

Fixes #442 
Fixes #821 