### PR TITLE
Docs: readable output

### DIFF
--- a/packages/docs/docs/animating-properties.md
+++ b/packages/docs/docs/animating-properties.md
@@ -20,8 +20,8 @@ export const MyVideo = () => {
     <div
       style={{
         flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
+        textAlign: "center",
+        fontSize: "7em",
         opacity: opacity,
       }}
     >
@@ -55,8 +55,8 @@ export const MyVideo = () => {
     <div
       style={{
         flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
+        textAlign: "center",
+        fontSize: "7em",
         opacity: opacity,
       }}
     >
@@ -90,8 +90,8 @@ export const MyVideo = () => {
     <div
       style={{
         flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
+        textAlign: "center",
+        fontSize: "7em",
       }}
     >
       <div style={{ transform: `scale(${scale})` }}>Hello World!</div>
@@ -104,6 +104,8 @@ You should see the text 'jump in'. The default spring configuration leads to a l
 
 ## Always animate using `useCurrentFrame()`
 
+:::caution
 Watch out for flickering issues during rendering that arise if you write animations that are not driven by [`useCurrentFrame()`](/docs/use-current-frame) - for example CSS transitions.
 
 [Read more about how Remotion's rendering works](/docs/flickering) - understanding it will help you avoid issues down the road.
+:::

--- a/packages/docs/docs/sequences.md
+++ b/packages/docs/docs/sequences.md
@@ -27,7 +27,13 @@ In order to make a title reusable, we first factor it out into it's own componen
 
 export const MyVideo = () => {
   return (
-    <div style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+    <div
+      style={{
+        flex: 1,
+        textAlign: "center",
+        fontSize: "7em",
+      }}
+    >
       <Title title="Hello World" />
     </div>
   );
@@ -46,8 +52,8 @@ export const MyVideo = () => {
     <div
       style={{
         flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
+        textAlign: "center",
+        fontSize: "7em",
         backgroundColor: "white",
       }}
     >

--- a/packages/docs/docs/the-fundamentals.md
+++ b/packages/docs/docs/the-fundamentals.md
@@ -13,8 +13,8 @@ export const MyVideo = () => {
     <div
       style={{
         flex: 1,
-        textAlign: 'center',
-        fontSize: '7em',
+        textAlign: "center",
+        fontSize: "em",
       }}
     >
       The current frame is {frame}.
@@ -52,8 +52,8 @@ export const MyVideo = () => {
     <div
       style={{
         flex: 1,
-        textAlign: 'center',
-        fontSize: '7em',
+        textAlign: "center",
+        fontSize: "7em",
        }}
       >
       This {width}px x {height}px video is {durationInFrames / fps} seconds long.

--- a/packages/docs/docs/the-fundamentals.md
+++ b/packages/docs/docs/the-fundamentals.md
@@ -14,7 +14,7 @@ export const MyVideo = () => {
       style={{
         flex: 1,
         textAlign: "center",
-        fontSize: "em",
+        fontSize: "7em",
       }}
     >
       The current frame is {frame}.

--- a/packages/docs/docs/the-fundamentals.md
+++ b/packages/docs/docs/the-fundamentals.md
@@ -50,12 +50,12 @@ export const MyVideo = () => {
 
   return (
     <div
-			style={{
-				flex: 1,
-				textAlign: 'center',
-				fontSize: '7em',
-			}}
-		>
+      style={{
+        flex: 1,
+        textAlign: 'center',
+        fontSize: '7em',
+       }}
+      >
       This {width}px x {height}px video is {durationInFrames / fps} seconds long.
     </div>
   );

--- a/packages/docs/docs/the-fundamentals.md
+++ b/packages/docs/docs/the-fundamentals.md
@@ -10,7 +10,13 @@ export const MyVideo = () => {
   const frame = useCurrentFrame();
 
   return (
-    <div style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+    <div
+			style={{
+				flex: 1,
+				textAlign: 'center',
+				fontSize: '7em',
+			}}
+		>
       The current frame is {frame}.
     </div>
   );
@@ -43,8 +49,14 @@ export const MyVideo = () => {
   const { fps, durationInFrames, width, height } = useVideoConfig();
 
   return (
-    <div style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-      This video is {durationInFrames / fps} seconds long.
+    <div
+			style={{
+				flex: 1,
+				textAlign: 'center',
+				fontSize: '7em',
+			}}
+		>
+      This {width}px x {height}px video is {durationInFrames / fps} seconds long.
     </div>
   );
 };

--- a/packages/docs/docs/the-fundamentals.md
+++ b/packages/docs/docs/the-fundamentals.md
@@ -11,12 +11,12 @@ export const MyVideo = () => {
 
   return (
     <div
-			style={{
-				flex: 1,
-				textAlign: 'center',
-				fontSize: '7em',
-			}}
-		>
+      style={{
+        flex: 1,
+        textAlign: 'center',
+        fontSize: '7em',
+      }}
+    >
       The current frame is {frame}.
     </div>
   );


### PR DESCRIPTION
I used the early examples to test out the `<Player>`, but they were unreadable:
![remotion-doc-example-old](https://user-images.githubusercontent.com/1308419/155885994-38d1c3ca-8e62-4aca-b3cb-df538fd910f5.JPG)

I got the text to properly center & increased fontsize:
![remotion-doc-example-new](https://user-images.githubusercontent.com/1308419/155886032-09b3cdec-7a54-456e-8d78-9679434a9397.JPG)

Some minor code reformatting, & added `:::caution` tag.
