### PR TITLE
chore: define bugs package.json configuration

### DIFF
--- a/packages/babel-loader/package.json
+++ b/packages/babel-loader/package.json
@@ -16,10 +16,10 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-    "bugs": {
-      "url": "https://github.com/remotion-dev/remotion/issues"
-    },
-    "dependencies": {
+	"bugs": {
+		"url": "https://github.com/remotion-dev/remotion/issues"
+	},
+	"dependencies": {
 		"@babel/core": "7.15.5",
 		"@babel/plugin-proposal-class-properties": "7.14.5",
 		"@babel/preset-env": "7.15.6",

--- a/packages/babel-loader/package.json
+++ b/packages/babel-loader/package.json
@@ -16,7 +16,10 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-	"dependencies": {
+    "bugs": {
+      "url": "https://github.com/remotion-dev/remotion/issues"
+    },
+    "dependencies": {
 		"@babel/core": "7.15.5",
 		"@babel/plugin-proposal-class-properties": "7.14.5",
 		"@babel/preset-env": "7.15.6",

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -7,9 +7,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-    "bugs": {
-      "url": "https://github.com/remotion-dev/remotion/issues"
-    },
+	"bugs": {
+		"url": "https://github.com/remotion-dev/remotion/issues"
+	},
 	"scripts": {
 		"lint": "eslint src --ext ts,tsx",
 		"test": "jest",

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -7,6 +7,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
+    "bugs": {
+      "url": "https://github.com/remotion-dev/remotion/issues"
+    },
 	"scripts": {
 		"lint": "eslint src --ext ts,tsx",
 		"test": "jest",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
+    "bugs": {
+      "url": "https://github.com/remotion-dev/remotion/issues"
+    },
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,9 +17,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-    "bugs": {
-      "url": "https://github.com/remotion-dev/remotion/issues"
-    },
+	"bugs": {
+		"url": "https://github.com/remotion-dev/remotion/issues"
+	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,9 +15,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-    "bugs": {
-      "url": "https://github.com/remotion-dev/remotion/issues"
-    },
+	"bugs": {
+		"url": "https://github.com/remotion-dev/remotion/issues"
+	},
 	"author": "",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
+    "bugs": {
+      "url": "https://github.com/remotion-dev/remotion/issues"
+    },
 	"author": "",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"peerDependencies": {

--- a/packages/gif/package.json
+++ b/packages/gif/package.json
@@ -6,6 +6,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
+    "bugs": {
+      "url": "https://github.com/remotion-dev/remotion/issues"
+    },
 	"license": "SEE LICENSE IN LICENSE.md",
 	"author": "",
 	"main": "dist/index.js",

--- a/packages/gif/package.json
+++ b/packages/gif/package.json
@@ -6,9 +6,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-    "bugs": {
-      "url": "https://github.com/remotion-dev/remotion/issues"
-    },
+	"bugs": {
+		"url": "https://github.com/remotion-dev/remotion/issues"
+	},
 	"license": "SEE LICENSE IN LICENSE.md",
 	"author": "",
 	"main": "dist/index.js",

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -14,9 +14,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-    "bugs": {
-      "url": "https://github.com/remotion-dev/remotion/issues"
-    },
+	"bugs": {
+		"url": "https://github.com/remotion-dev/remotion/issues"
+	},
 	"dependencies": {
 		"remotion": "2.6.11"
 	},

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -14,6 +14,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
+    "bugs": {
+      "url": "https://github.com/remotion-dev/remotion/issues"
+    },
 	"dependencies": {
 		"remotion": "2.6.11"
 	},

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -14,9 +14,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-    "bugs": {
-      "url": "https://github.com/remotion-dev/remotion/issues"
-    },
+	"bugs": {
+		"url": "https://github.com/remotion-dev/remotion/issues"
+	},
 	"files": [
 		"dist",
 		"README.md"

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -14,6 +14,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
+    "bugs": {
+      "url": "https://github.com/remotion-dev/remotion/issues"
+    },
 	"files": [
 		"dist",
 		"README.md"

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -16,9 +16,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-    "bugs": {
-      "url": "https://github.com/remotion-dev/remotion/issues"
-    },
+	"bugs": {
+		"url": "https://github.com/remotion-dev/remotion/issues"
+	},
 	"dependencies": {
 		"@remotion/bundler": "2.6.11",
 		"execa": "5.1.1",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -16,6 +16,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
+    "bugs": {
+      "url": "https://github.com/remotion-dev/remotion/issues"
+    },
 	"dependencies": {
 		"@remotion/bundler": "2.6.11",
 		"execa": "5.1.1",

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -16,9 +16,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
-    "bugs": {
-      "url": "https://github.com/remotion-dev/remotion/issues"
-    },
+	"bugs": {
+		"url": "https://github.com/remotion-dev/remotion/issues"
+	},
 	"dependencies": {
 		"remotion": "2.6.11"
 	},

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -16,6 +16,9 @@
 	"repository": {
 		"url": "https://github.com/remotion-dev/remotion"
 	},
+    "bugs": {
+      "url": "https://github.com/remotion-dev/remotion/issues"
+    },
 	"dependencies": {
 		"remotion": "2.6.11"
 	},


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Why

Some public and published packaged don't have the `bugs` attribute in their `package.json`.
This is documented feature of npm which is a good practice to define.
Here is the PR that make sure define it for all.

## TODO

- [ ] I don't really understand why my package.json format doesn't seems to be correct 😅 


## Another idea

Found out that packages does not have `keywords` define.
It could be really nice to add some of them for `remotion` visibility on NPM
