### PR TITLE
don't sanitize / in filename

### DIFF
--- a/packages/renderer/src/assets/sanitize-filename.ts
+++ b/packages/renderer/src/assets/sanitize-filename.ts
@@ -29,7 +29,7 @@ import {truncateUtf8Bytes} from './truncate-utf8-bytes';
  * @return {String}         Sanitized filename
  */
 
-const illegalRe = /[?<>\\:*|"]/g;
+const illegalRe = /[/?<>\\:*|"]/g;
 // eslint-disable-next-line no-control-regex
 const controlRe = /[\x00-\x1f\x80-\x9f]/g;
 const reservedRe = /^\.+$/;

--- a/packages/renderer/src/assets/sanitize-filename.ts
+++ b/packages/renderer/src/assets/sanitize-filename.ts
@@ -29,7 +29,7 @@ import {truncateUtf8Bytes} from './truncate-utf8-bytes';
  * @return {String}         Sanitized filename
  */
 
-const illegalRe = /[/?<>\\:*|"]/g;
+const illegalRe = /[?<>\\:*|"]/g;
 // eslint-disable-next-line no-control-regex
 const controlRe = /[\x00-\x1f\x80-\x9f]/g;
 const reservedRe = /^\.+$/;

--- a/packages/renderer/src/assets/sanitize-filepath.ts
+++ b/packages/renderer/src/assets/sanitize-filepath.ts
@@ -1,9 +1,11 @@
 import path from 'path';
 import {sanitizeFilename} from './sanitize-filename';
 
+const pathSeparators = /[/\\]/;
+
 export const sanitizeFilePath = (pathToSanitize: string) => {
 	return pathToSanitize
-		.split(path.sep)
+		.split(pathSeparators)
 		.map((s) => sanitizeFilename(s))
 		.join(path.sep);
 };

--- a/packages/renderer/src/test/sanitize-file-path.test.ts
+++ b/packages/renderer/src/test/sanitize-file-path.test.ts
@@ -4,6 +4,7 @@ test('sanitizeFilePath linux', () => {
 	if (process.platform === 'win32') {
 		return;
 	}
+
 	expect(sanitizeFilePath('/path/to/path')).toBe('/path/to/path');
 	expect(sanitizeFilePath('\\path\\to\\path')).toBe('/path/to/path');
 });
@@ -12,5 +13,6 @@ test('sanitizeFilePath windows', () => {
 	if (process.platform !== 'win32') {
 		return;
 	}
+
 	expect(sanitizeFilePath('/path/to/path')).toBe('\\path\\to\\path');
 });

--- a/packages/renderer/src/test/sanitize-file-path.test.ts
+++ b/packages/renderer/src/test/sanitize-file-path.test.ts
@@ -1,0 +1,16 @@
+import {sanitizeFilePath} from '../assets/sanitize-filepath';
+
+test('sanitizeFilePath linux', () => {
+	if (process.platform === 'win32') {
+		return;
+	}
+	expect(sanitizeFilePath('/path/to/path')).toBe('/path/to/path');
+	expect(sanitizeFilePath('\\path\\to\\path')).toBe('/path/to/path');
+});
+
+test('sanitizeFilePath windows', () => {
+	if (process.platform !== 'win32') {
+		return;
+	}
+	expect(sanitizeFilePath('/path/to/path')).toBe('\\path\\to\\path');
+});


### PR DESCRIPTION
Fixes the crash of the following code:

```ts
<Audio
   src={staticFile('/nested/sound1.mp3')}
/>
```