### PR TITLE
Webpack 5.72 + Asset modules instead of file-loader + More memory for the node process

### DIFF
--- a/packages/babel-loader/package.json
+++ b/packages/babel-loader/package.json
@@ -28,7 +28,7 @@
 		"@webhotelier/webpack-fast-refresh": "5.1.0",
 		"babel-loader": "8.2.2",
 		"react-refresh": "0.9.0",
-		"webpack": "5.60.0"
+		"webpack": "5.72.0"
 	},
 	"devDependencies": {
 		"@jonny/eslint-config": "3.0.259",

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -36,7 +36,7 @@
 		"source-map": "0.6.1",
 		"source-map-loader": "3.0.0",
 		"style-loader": "2.0.0",
-		"webpack": "5.60.0"
+		"webpack": "5.72.0"
 	},
 	"peerDependencies": {
 		"react": ">=16.8.0",

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -28,7 +28,6 @@
 		"esbuild": "0.14.19",
 		"execa": "5.1.1",
 		"express": "4.17.1",
-		"file-loader": "6.2.0",
 		"memfs": "3.4.0",
 		"mime-types": "2.1.34",
 		"react-refresh": "0.9.0",

--- a/packages/bundler/src/dev-middleware/index.ts
+++ b/packages/bundler/src/dev-middleware/index.ts
@@ -28,7 +28,7 @@ export const wdm = (compiler: webpack.Compiler): MiddleWare => {
 	if (context.compiler.watching) {
 		context.watching = context.compiler.watching;
 	} else {
-		const errorHandler = (error: Error | undefined) => {
+		const errorHandler = (error: Error | null | undefined) => {
 			if (error) {
 				context.logger.error(error);
 			}

--- a/packages/bundler/src/error-overlay/react-overlay/utils/get-source-map.ts
+++ b/packages/bundler/src/error-overlay/react-overlay/utils/get-source-map.ts
@@ -25,10 +25,7 @@ export const getOriginalPosition = (
 	return {line: result.line, column: result.column, source: result.source};
 };
 
-function extractSourceMapUrl(
-	fileUri: string,
-	fileContents: string
-): Promise<string> {
+function extractSourceMapUrl(fileContents: string): string | null {
 	const regex = /\/\/[#@] ?sourceMappingURL=([^\s'"]+)\s*$/gm;
 	let match = null;
 	for (;;) {
@@ -41,19 +38,21 @@ function extractSourceMapUrl(
 	}
 
 	if (!match?.[1]) {
-		return Promise.reject(
-			new Error(`Cannot find a source map directive for ${fileUri}.`)
-		);
+		return null;
 	}
 
-	return Promise.resolve(match[1].toString());
+	return match[1].toString();
 }
 
 export async function getSourceMap(
 	fileUri: string,
 	fileContents: string
-): Promise<SourceMapConsumer> {
-	const sm = await extractSourceMapUrl(fileUri, fileContents);
+): Promise<SourceMapConsumer | null> {
+	const sm = extractSourceMapUrl(fileContents);
+	if (sm === null) {
+		return null;
+	}
+
 	if (sm.indexOf('data:') === 0) {
 		const base64 = /^data:application\/json;([\w=:"-]+;)*base64,/;
 		const match2 = sm.match(base64);

--- a/packages/bundler/src/error-overlay/remotion-overlay/ErrorLoader.tsx
+++ b/packages/bundler/src/error-overlay/remotion-overlay/ErrorLoader.tsx
@@ -101,7 +101,9 @@ export const ErrorLoader: React.FC<{
 					name={error.name}
 					message={error.message}
 				/>
-				<div style={errorWhileErrorStyle}>Could not get a stack trace.</div>
+				<div style={errorWhileErrorStyle}>
+					Check the Terminal and browser console for error messages.
+				</div>
 			</div>
 		);
 	}

--- a/packages/bundler/src/start-server.ts
+++ b/packages/bundler/src/start-server.ts
@@ -52,7 +52,21 @@ export const startServer = async (
 
 	const hash = `/static-${crypto.randomBytes(6).toString('hex')}`;
 
-	app.use(hash, express.static(path.join(process.cwd(), 'public')));
+	app.use(
+		hash,
+		express.static(path.join(process.cwd(), 'public'), {
+			cacheControl: true,
+			dotfiles: 'allow',
+			etag: true,
+			extensions: false,
+			fallthrough: false,
+			immutable: false,
+			index: false,
+			lastModified: true,
+			maxAge: 0,
+			redirect: true,
+		})
+	);
 	app.use(wdm(compiler));
 	app.use(webpackHotMiddleware(compiler));
 

--- a/packages/bundler/src/static-preview.ts
+++ b/packages/bundler/src/static-preview.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+
 export const indexHtml = (
 	staticHash: string,
 	baseDir: string,

--- a/packages/bundler/src/webpack-cache.ts
+++ b/packages/bundler/src/webpack-cache.ts
@@ -80,12 +80,12 @@ export const getWebpackCacheName = (
 	// are changing, because they are injected using Webpack and if changed,
 	// it will get the cached version
 	if (environment === 'development') {
-		return `remotion-${environment}-${random(JSON.stringify(inputProps))}`;
+		return `remotion-v3-${environment}-${random(JSON.stringify(inputProps))}`;
 	}
 
 	// In production, the cache is independent from input props because
 	// they are passed over URL params. Speed is mostly important in production.
-	return `remotion-${environment}`;
+	return `remotion-v3-${environment}`;
 };
 
 export const cacheExists = (

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -124,7 +124,7 @@ export const webpackConfig = ({
 			path: outDir,
 			devtoolModuleFilenameTemplate: '[resource-path]',
 			assetModuleFilename:
-				environment === 'development' ? '[path][name].[ext]' : '[hash].[ext]',
+				environment === 'development' ? '[path][name][ext]' : '[hash][ext]',
 		},
 		devServer: {
 			contentBase: path.resolve(__dirname, '..', 'web'),
@@ -172,9 +172,6 @@ export const webpackConfig = ({
 				{
 					test: /\.(woff(2)?|otf|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
 					type: 'asset/resource',
-					generator: {
-						filename: 'static/[hash][ext][query]',
-					},
 				},
 				{
 					test: /\.jsx?$/,

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -123,6 +123,10 @@ export const webpackConfig = ({
 			filename: 'bundle.js',
 			path: outDir,
 			devtoolModuleFilenameTemplate: '[resource-path]',
+			assetModuleFilename:
+				environment === 'development'
+					? '[path][name].[ext]'
+					: '[md5:contenthash].[ext]',
 		},
 		devServer: {
 			contentBase: path.resolve(__dirname, '..', 'web'),
@@ -150,27 +154,7 @@ export const webpackConfig = ({
 				},
 				{
 					test: /\.(png|svg|jpg|jpeg|webp|gif|bmp|webm|mp4|mov|mp3|m4a|wav|aac)$/,
-					use: [
-						{
-							loader: require.resolve('file-loader'),
-							options: {
-								// default md4 not available in node17
-								hashType: 'md5',
-								// So you can do require('hi.png')
-								// instead of require('hi.png').default
-								esModule: false,
-								name: () => {
-									// Don't rename files in development
-									// so we can show the filename in the timeline
-									if (environment === 'development') {
-										return '[path][name].[ext]';
-									}
-
-									return '[md5:contenthash].[ext]';
-								},
-							},
-						},
-					],
+					type: 'asset/resource',
 				},
 				{
 					test: /\.tsx?$/,
@@ -188,16 +172,10 @@ export const webpackConfig = ({
 				},
 				{
 					test: /\.(woff(2)?|otf|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
-					use: [
-						{
-							loader: require.resolve('file-loader'),
-							options: {
-								// default md4 not available in node17
-								name: '[name].[ext]',
-								outputPath: 'fonts/',
-							},
-						},
-					],
+					type: 'asset/resource',
+					generator: {
+						filename: 'static/[hash][ext][query]',
+					},
 				},
 				{
 					test: /\.jsx?$/,

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -124,9 +124,7 @@ export const webpackConfig = ({
 			path: outDir,
 			devtoolModuleFilenameTemplate: '[resource-path]',
 			assetModuleFilename:
-				environment === 'development'
-					? '[path][name].[ext]'
-					: '[md5:contenthash].[ext]',
+				environment === 'development' ? '[path][name].[ext]' : '[hash].[ext]',
 		},
 		devServer: {
 			contentBase: path.resolve(__dirname, '..', 'web'),
@@ -151,6 +149,7 @@ export const webpackConfig = ({
 				{
 					test: /\.css$/i,
 					use: [require.resolve('style-loader'), require.resolve('css-loader')],
+					type: 'javascript/auto',
 				},
 				{
 					test: /\.(png|svg|jpg|jpeg|webp|gif|bmp|webm|mp4|mov|mp3|m4a|wav|aac)$/,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
 		"minimist": "1.2.6",
 		"remotion": "3.0.0",
 		"semver": "7.3.5",
-		"webpack": "5.60.0"
+		"webpack": "5.72.0"
 	},
 	"peerDependencies": {
 		"react": ">=16.8.0",

--- a/packages/cli/remotion-cli.js
+++ b/packages/cli/remotion-cli.js
@@ -1,8 +1,7 @@
-#! /usr/bin/env node
+#! /usr/bin/env node --max-old-space-size=10240
 const dotenv = require('dotenv');
 dotenv.config();
 const {cli} = require('./dist/index');
-
 
 cli()
 	.then(() => process.exit(0))

--- a/packages/cli/remotion-cli.js
+++ b/packages/cli/remotion-cli.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node --max-old-space-size=10240
+#!/usr/bin/env node
 const dotenv = require('dotenv');
 dotenv.config();
 const {cli} = require('./dist/index');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
 		"rimraf": "^3.0.2",
 		"ts-jest": "^27.0.5",
 		"typescript": "^4.5.5",
-		"webpack": "5.60.0"
+		"webpack": "5.72.0"
 	},
 	"keywords": [
 		"remotion",

--- a/packages/docs/docs/dynamic-import.md
+++ b/packages/docs/docs/dynamic-import.md
@@ -7,23 +7,7 @@ A common need in Remotion is to import assets from dynamic paths. This means tha
 
 This can become an unexpected hurdle in Webpack. On this page we collect some tips how to handle dynamic assets.
 
-## Write dynamic expressions correctly
-
-Consider you have a PNG sequence of images with the following file structure:
-
-```bash
-my-video/
-├─ src/
-│  ├─ assets/
-│  │  ├─ image0.png
-│  │  ├─ image1.png
-│  │  ├─ image2.png
-│  │  ├─ ...
-│  │  ├─ image99.png
-│  ├─ index.tsx
-```
-
-Note that the following pattern doesn't work:
+Take this scenario for an example:
 
 ```tsx twoslash
 import { Img, useCurrentFrame } from "remotion";
@@ -35,11 +19,26 @@ export const DynamicImports: React.FC = () => {
 };
 ```
 
+may result in:
+
 ```bash
 Error: Cannot find module './image0.png'
 ```
 
-However the following example **does** work:
+even if the file exists. This is because Webpack needs to figure out using static code analysis which assets it should bundle and cannot do so.
+
+## Recommended: Use `staticFile()` instead
+
+We recommend that you put the asset inside the `public/` folder and use `staticFile()` to reference it. This new way does not suffer from the underlying problem.
+
+- [Importing assets](/docs/assets)
+- [`staticFile()`](/docs/staticfile)
+
+## Write dynamic expressions correctly
+
+While the example at the top did not work, Webpck is smart enough to do so if you place your expression inside the `require()` or `import()` statement. In this case, Webpack will automatically bundle all `.png` files in the `assets/image` folder even if the asset is never used.
+
+The following **does** work:
 
 ```tsx twoslash
 import { Img, useCurrentFrame } from "remotion";
@@ -49,8 +48,6 @@ export const DynamicImports: React.FC = () => {
   return <Img src={require("./assets/image" + frame + ".png")} />;
 };
 ```
-
-Webpack needs to figure out which assets it should bundle and cannot do it in the first example. However, it is smart enough to do so if you place your expression inside the `require()` or `import()` statement. In this case, Webpack will automatically bundle all `.png` files in the `assets/image` folder even if the asset is never used. Therefore you have to be careful to not bundle too many assets.
 
 Please read [the Webpack documentation page](https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import) about this behavior if you would like to learn more.
 
@@ -77,51 +74,6 @@ const DynamicAsset: React.FC = () => {
   const inputProps = getInputProps(); // {"imageSrc": "img0.png"}
   // Works!
   return <Img src={require("./assets/" + inputProps.imageSrc)} />;
-};
-```
-
-## Adding assets after bundling
-
-If you server-side render your video using the Node.JS APIs, you might find yourself in a situation where you want to add new assets after you have already bundled the Remotion application. In this scenario, it is simply impossible for Webpack to interpret a `require()` statement correctly.
-
-You can use the following workaround that relies on the fact that Remotion creates a static web server while rendering:
-
-1. [`bundle()`](/docs/bundle) the video - the return value is a promise resolving to the folder where the bundle got saved.
-2. Copy a new asset into this folder.
-3. Rely on the fact that the asset is available via the static HTTP server. Since you only want this during rendering, use the `process.env.NODE_ENV === 'production'` statement to differentiate between development and rendering.
-
-```tsx twoslash
-import { getInputProps, Img } from "remotion";
-
-export const DynamicAsset: React.FC = () => {
-  const inputProps = getInputProps(); // {"imageSrc": "assets/img0.png"}
-  return (
-    <Img
-      src={
-        process.env.NODE_ENV === "production"
-          ? `/${inputProps.imageSrc}`
-          : require("./assets/default-asset.png")
-      }
-    />
-  );
-};
-```
-
-## Set up an HTTP server
-
-As a last resort, you can spin up your own static HTTP server and import the assets via HTTP:
-
-```sh
-# From any directory
-npx serve --cors ./src
-```
-
-```tsx twoslash
-import { getInputProps, Img } from "remotion";
-
-const HttpAsset: React.FC = () => {
-  const inputProps = getInputProps(); // {"imageSrc": "assets/img0.png"}
-  return <Img src={`http://localhost:5000/${inputProps.imageSrc}`} />;
 };
 ```
 

--- a/packages/docs/docs/importing-assets.md
+++ b/packages/docs/docs/importing-assets.md
@@ -3,19 +3,130 @@ id: assets
 title: Importing assets
 ---
 
-Remotion allows you to include several types of files in your project:
+To import assets in Remotion, create a `public/` folder in your project and use `staticFile()` to import it.
 
-- Images (`.png`, `.svg`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.bmp`)
-- Videos (`.webm`, `.mov`, `.mp4`)
-- Audio (`.mp3`, `.wav`, `.aac`)
-- [Webfonts - read the separate page for fonts](/docs/fonts)
-- Arbitrary files using the `staticFile()` API
+```txt
+my-video/
+├─ node_modules/
+├─ public/
+│  ├─ logo.png
+├─ src/
+│  ├─ MyComp.tsx
+│  ├─ Video.tsx
+│  ├─ index.tsx
+├─ package.json
+```
+
+```tsx twoslash title="src/MyComp.tsx"
+import { Img, staticFile } from "remotion";
+
+export const MyComp: React.FC = () => {
+  return <Img src={staticFile("logo.png")} />;
+};
+```
 
 ## Using images
 
-Require images using an `import` statement and pass them to the [`<Img/>`](/docs/img) tag.
+Use the [`<Img/>`](/docs/img) tag from Remotion.
+
+```tsx twoslash title="MyComp.tsx"
+import { Img, staticFile } from "remotion";
+
+export const MyComp: React.FC = () => {
+  return <Img src={staticFile("logo.png")} />;
+};
+```
+
+## Using image sequences
+
+If you have a series of images, for example exported from another program like After Effects or Rotato, you can interpolate the path to create a dynamic import.
+
+```txt
+my-video/
+├─ public/
+│  ├─ frame1.png
+│  ├─ frame2.png
+│  ├─ frame3.png
+├─ package.json
+```
 
 ```tsx twoslash
+import { Img, useCurrentFrame, staticFile } from "remotion";
+
+const MyComp: React.FC = () => {
+  const frame = useCurrentFrame();
+
+  return <Img src={staticFile(`/${frame}.png`)} />;
+};
+```
+
+## Using videos
+
+Use the [`<Video />`](/docs/video) component to keep the timeline and your video in sync.
+
+```tsx twoslash
+import { staticFile, Video } from "remotion";
+
+export const MyComp: React.FC = () => {
+  return <Video src={staticFile("vid.webm")} />;
+};
+```
+
+Be aware that if you are rendering using Chromium (as opposed to Chrome), the codec for MP4 videos is not included. Read the section on the [`<Video/ >`](/docs/video#codec-support) page for more information.
+
+## Using Audio
+
+Use the [`<Audio/ >`](/docs/audio) component.
+
+```tsx twoslash
+import { Audio, staticFile } from "remotion";
+
+export const MyComp: React.FC = () => {
+  return <Audio src={staticFile("tune.mp3")} />;
+};
+```
+
+See the [audio guide](/docs/using-audio) for guidance on including audio.
+
+## Using CSS
+
+Put the .css file alongside your JavaScript source files and use an `import` statement.
+
+```txt
+my-video/
+├─ node_modules/
+├─ src/
+│  ├─ style.css
+│  ├─ MyComp.tsx
+│  ├─ Video.tsx
+│  ├─ index.tsx
+├─ package.json
+```
+
+```tsx twoslash title="MyComp.tsx"
+import "./style.css";
+```
+
+:::note
+Want to use SASS, Tailwind or similar? [See examples on how to override the Webpack configuration](/docs/webpack).
+:::
+
+## Using Fonts
+
+[Read the separate page for fonts.](/docs/fonts)
+
+## `import` statements
+
+As an alternative way to import files, Remotion allows you to `import` or `require()` several types of files in your project:
+
+- Images (`.png`, `.svg`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.bmp`)
+- Videos (`.webm`, `.mov`, `.mp4`)
+- Audio (`.mp3`, `.wav`, `.aac`, `m4a`)
+- Fonts (`.woff`, `.woff2`, `otf`, `ttf`, `eot`)
+
+For example:
+
+```tsx twoslash title="MyComp.tsx"
 import { Img } from "remotion";
 import logo from "./logo.png";
 
@@ -24,68 +135,12 @@ export const MyComp: React.FC = () => {
 };
 ```
 
-## Using image sequences
+### Caveats
 
-If you have a series of images, for example exported from another program like After Effects or Rotato, you can use a dynamic `require` statement to import the images as they are needed.
+While this was previously the main way of importing files, we recommend against it because of the following reasons:
 
-```tsx twoslash
-import { useCurrentFrame } from "remotion";
+- Only the above listed file extensions are supported.
+- The maximum file size is 2GB.
+- Dynamic imports such as `require('img' + frame + '.png')` are [funky](/docs/webpack-dynamic-imports).
 
-/*
-  Assuming your file structure is:
-  assets/
-    frame1.png
-    frame2.png
-    frame3.png
-    ...
-*/
-
-const MyComp: React.FC = () => {
-  const frame = useCurrentFrame();
-  const src = require("./assets/frame" + frame + ".png");
-
-  return <img src={src} />;
-};
-```
-
-:::tip
-Avoid writing a require statement that requires a file that doesn't exist. If your project throws an error because your composition is longer than than your image sequence, clamp the file name using `Math.min()` or Remotion's `interpolate()`.
-:::
-
-## Using videos
-
-Import your files using an import statement. Use the [`<Video />`](/docs/video) component to keep the timeline and your video in sync.
-
-```tsx twoslash
-import { Video } from "remotion";
-import vid from "./vid.webm";
-
-export const MyComp: React.FC = () => {
-  return <Video src={vid} />;
-};
-```
-
-Be aware that if you are rendering using Chromium (as opposed to Chrome), the codec for MP4 videos is not included. Read the section on the [`<Video/ >`](/docs/video#codec-support) page for more information.
-
-## Using Audio
-
-Import your audio using an `import` statement and pass it to the [`<Audio/ >`](/docs/audio) component.
-
-```tsx twoslash
-import { Audio } from "remotion";
-import tune from "./tune.mp3";
-
-export const MyComp: React.FC = () => {
-  return <Audio src={tune} />;
-};
-```
-
-See the [audio guide](/docs/using-audio) for guidance on including audio.
-
-## Using fonts
-
-See the [dedicated page about fonts](/docs/fonts).
-
-## Importing arbitrary files
-
-Create a `public/` folder in your project and use the [`staticFile()`](/docs/staticfile) API to get a URL reference of the asset that you can load into your project.
+Prefer importing using `staticFile()` is possible.

--- a/packages/docs/docs/importing-assets.md
+++ b/packages/docs/docs/importing-assets.md
@@ -3,7 +3,7 @@ id: assets
 title: Importing assets
 ---
 
-To import assets in Remotion, create a `public/` folder in your project and use `staticFile()` to import it.
+To import assets in Remotion, create a `public/` folder in your project and use [`staticFile()`](/docs/staticfile) to import it.
 
 ```txt
 my-video/
@@ -177,4 +177,4 @@ While this was previously the main way of importing files, we now recommend agai
 - The maximum file size is 2GB.
 - Dynamic imports such as `require('img' + frame + '.png')` are [funky](/docs/webpack-dynamic-imports).
 
-Prefer importing using `staticFile()` is possible.
+Prefer importing using [`staticFile()`](/docs/staticfile) is possible.

--- a/packages/docs/docs/importing-assets.md
+++ b/packages/docs/docs/importing-assets.md
@@ -37,6 +37,16 @@ export const MyComp: React.FC = () => {
 };
 ```
 
+You can also pass a URL:
+
+```tsx twoslash title="MyComp.tsx"
+import { Img } from "remotion";
+
+export const MyComp: React.FC = () => {
+  return <Img src="https://picsum.photos/id/237/200/300" />;
+};
+```
+
 ## Using image sequences
 
 If you have a series of images, for example exported from another program like After Effects or Rotato, you can interpolate the path to create a dynamic import.
@@ -72,6 +82,18 @@ export const MyComp: React.FC = () => {
 };
 ```
 
+Loading videos via URL is also possible:
+
+```tsx twoslash
+import { Video } from "remotion";
+
+export const MyComp: React.FC = () => {
+  return (
+    <Video src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" />
+  );
+};
+```
+
 Be aware that if you are rendering using Chromium (as opposed to Chrome), the codec for MP4 videos is not included. Read the section on the [`<Video/ >`](/docs/video#codec-support) page for more information.
 
 ## Using Audio
@@ -83,6 +105,18 @@ import { Audio, staticFile } from "remotion";
 
 export const MyComp: React.FC = () => {
   return <Audio src={staticFile("tune.mp3")} />;
+};
+```
+
+Loading audio from an URL is also possible:
+
+```tsx twoslash
+import { Audio } from "remotion";
+
+export const MyComp: React.FC = () => {
+  return (
+    <Audio src="https://file-examples.com/wp-content/uploads/2017/11/file_example_MP3_700KB.mp3" />
+  );
 };
 ```
 
@@ -137,7 +171,7 @@ export const MyComp: React.FC = () => {
 
 ### Caveats
 
-While this was previously the main way of importing files, we recommend against it because of the following reasons:
+While this was previously the main way of importing files, we now recommend against it because of the following reasons:
 
 - Only the above listed file extensions are supported.
 - The maximum file size is 2GB.

--- a/packages/gif/package.json
+++ b/packages/gif/package.json
@@ -37,7 +37,7 @@
 		"react": "18.0.0",
 		"react-dom": "18.0.0",
 		"typescript": "^4.5.5",
-		"webpack": "5.60.0"
+		"webpack": "5.72.0"
 	},
 	"peerDependencies": {
 		"react": ">=16.8.0",

--- a/packages/lambda/remotion-lambda-cli.js
+++ b/packages/lambda/remotion-lambda-cli.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node --max-old-space-size=10240
+#!/usr/bin/env node
 const dotenv = require('dotenv');
 dotenv.config();
 const {cli} = require('./dist/cli/index');

--- a/packages/lambda/remotion-lambda-cli.js
+++ b/packages/lambda/remotion-lambda-cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#! /usr/bin/env node --max-old-space-size=10240
 const dotenv = require('dotenv');
 dotenv.config();
 const {cli} = require('./dist/cli/index');

--- a/packages/player-example/package.json
+++ b/packages/player-example/package.json
@@ -27,7 +27,7 @@
 		"react-refresh": "^0.11.0",
 		"remotion": "3.0.0",
 		"typescript": "^4.5.5",
-		"webpack": "5.60.0",
+		"webpack": "5.72.0",
 		"webpack-dev-server": "^4.6.0"
 	},
 	"scripts": {

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -50,7 +50,7 @@
 		"react-dom": "^18.0.0",
 		"ts-jest": "^27.0.5",
 		"typescript": "^4.5.5",
-		"webpack": "5.60.0"
+		"webpack": "5.72.0"
 	},
 	"keywords": [
 		"remotion",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,17 +30,17 @@ importers:
       react-refresh: 0.9.0
       remotion: 3.0.0
       typescript: ^4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
     dependencies:
       '@babel/core': 7.15.5
       '@babel/plugin-proposal-class-properties': 7.14.5_@babel+core@7.15.5
       '@babel/preset-env': 7.15.6_@babel+core@7.15.5
       '@babel/preset-react': 7.14.5_@babel+core@7.15.5
       '@babel/preset-typescript': 7.15.0_@babel+core@7.15.5
-      '@webhotelier/webpack-fast-refresh': 5.1.0_ac0f87342906ae3268ced85f94da75f3
-      babel-loader: 8.2.2_3912b4afc765b9767f10719d11e4a1b8
+      '@webhotelier/webpack-fast-refresh': 5.1.0_ad215394b92be37ab5bb82482aa97917
+      babel-loader: 8.2.2_020c178973d0b00481c828e00a554724
       react-refresh: 0.9.0
-      webpack: 5.60.0
+      webpack: 5.72.0
     devDependencies:
       '@jonny/eslint-config': 3.0.259_eslint@8.13.0+typescript@4.5.5
       '@types/node': 16.10.2
@@ -86,9 +86,9 @@ importers:
       style-loader: 2.0.0
       ts-jest: ^27.0.5
       typescript: ^4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
     dependencies:
-      css-loader: 5.2.7_webpack@5.60.0
+      css-loader: 5.2.7_webpack@5.72.0
       esbuild: 0.14.19
       execa: 5.1.1
       express: 4.17.1
@@ -98,9 +98,9 @@ importers:
       remotion: link:../core
       semver: 7.3.4
       source-map: 0.6.1
-      source-map-loader: 3.0.0_webpack@5.60.0
-      style-loader: 2.0.0_webpack@5.60.0
-      webpack: 5.60.0_esbuild@0.14.19
+      source-map-loader: 3.0.0_webpack@5.72.0
+      style-loader: 2.0.0_webpack@5.72.0
+      webpack: 5.72.0_esbuild@0.14.19
     devDependencies:
       '@jonny/eslint-config': 3.0.259_eslint@8.13.0+typescript@4.5.5
       '@types/express': 4.17.13
@@ -157,7 +157,7 @@ importers:
       semver: 7.3.5
       ts-jest: ^27.0.5
       typescript: ^4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
     dependencies:
       '@remotion/bundler': link:../bundler
       '@remotion/media-utils': link:../media-utils
@@ -170,7 +170,7 @@ importers:
       minimist: 1.2.6
       remotion: link:../core
       semver: 7.3.5
-      webpack: 5.60.0
+      webpack: 5.72.0
     devDependencies:
       '@jonny/eslint-config': 3.0.259_eslint@8.13.0+typescript@4.5.5
       '@types/jest': 27.4.0
@@ -211,7 +211,7 @@ importers:
       rimraf: ^3.0.2
       ts-jest: ^27.0.5
       typescript: ^4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
     devDependencies:
       '@jonny/eslint-config': 3.0.259_eslint@8.13.0+typescript@4.5.5
       '@testing-library/react': 13.1.1_react-dom@18.0.0+react@18.0.0
@@ -230,7 +230,7 @@ importers:
       rimraf: 3.0.2
       ts-jest: 27.0.5_c7c6851c09cd607ef678ccb9c9b11e0f
       typescript: 4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
 
   packages/create-video:
     specifiers:
@@ -493,7 +493,7 @@ importers:
       react-dom: 18.0.0
       remotion: 3.0.0
       typescript: ^4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
     dependencies:
       '@react-gifs/tools': 0.1.2_react-dom@18.0.0+react@18.0.0
       lru_map: 0.4.1
@@ -510,7 +510,7 @@ importers:
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
       typescript: 4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
 
   packages/it-tests:
     specifiers:
@@ -642,7 +642,7 @@ importers:
       remotion: 3.0.0
       ts-jest: ^27.0.5
       typescript: ^4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
     dependencies:
       remotion: link:../core
     devDependencies:
@@ -661,7 +661,7 @@ importers:
       react-dom: 18.0.0_react@18.0.0
       ts-jest: 27.0.5_c7c6851c09cd607ef678ccb9c9b11e0f
       typescript: 4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
 
   packages/player-example:
     specifiers:
@@ -684,10 +684,10 @@ importers:
       react-refresh: ^0.11.0
       remotion: 3.0.0
       typescript: ^4.5.5
-      webpack: 5.60.0
+      webpack: 5.72.0
       webpack-dev-server: ^4.6.0
     dependencies:
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.5_1f3ea81761345277e509a3c2c119b79d
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.5_71ded90fc5f197eeccab1f0382e7a4aa
       '@remotion/bundler': link:../bundler
       '@remotion/eslint-config': link:../eslint-config
       '@remotion/player': link:../player
@@ -699,15 +699,15 @@ importers:
       esbuild: 0.14.19
       eslint: 8.13.0
       fs-extra: 10.1.0
-      html-webpack-plugin: 5.5.0_webpack@5.60.0
+      html-webpack-plugin: 5.5.0_webpack@5.72.0
       react: 18.0.0
-      react-dev-utils: 12.0.1_5265adb70d7d43d0ecb83204172732f0
+      react-dev-utils: 12.0.1_ea896ea9b6534e6dc7369b23923d4d97
       react-dom: 18.0.0_react@18.0.0
       react-refresh: 0.11.0
       remotion: link:../core
       typescript: 4.5.5
-      webpack: 5.60.0_esbuild@0.14.19
-      webpack-dev-server: 4.8.1_webpack@5.60.0
+      webpack: 5.72.0_esbuild@0.14.19
+      webpack-dev-server: 4.8.1_webpack@5.72.0
 
   packages/renderer:
     specifiers:
@@ -6075,7 +6075,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jest-changed-files: 27.2.4
       jest-config: 27.2.4
       jest-haste-map: 27.2.4
@@ -6119,7 +6119,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jest-changed-files: 27.2.4
       jest-config: 27.2.4_ts-node@9.1.1
       jest-haste-map: 27.2.4
@@ -6191,7 +6191,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.0.1
       istanbul-lib-instrument: 4.0.3
       istanbul-lib-report: 3.0.0
@@ -6200,7 +6200,7 @@ packages:
       jest-haste-map: 27.2.4
       jest-resolve: 27.2.4
       jest-util: 27.2.4
-      jest-worker: 27.2.4
+      jest-worker: 27.5.1
       slash: 3.0.0
       source-map: 0.6.1
       string-length: 4.0.2
@@ -6214,7 +6214,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       source-map: 0.6.1
 
   /@jest/test-result/27.2.4:
@@ -6231,7 +6231,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/test-result': 27.2.4
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jest-haste-map: 27.2.4
       jest-runtime: 27.2.4
     transitivePeerDependencies:
@@ -6247,7 +6247,7 @@ packages:
       chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jest-haste-map: 27.2.4
       jest-regex-util: 27.0.6
       jest-util: 27.2.4
@@ -7230,7 +7230,7 @@ packages:
       '@octokit/openapi-types': 11.0.0
     dev: false
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.5_1f3ea81761345277e509a3c2c119b79d:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.5_71ded90fc5f197eeccab1f0382e7a4aa:
     resolution: {integrity: sha512-RbG7h6TuP6nFFYKJwbcToA1rjC1FyPg25NR2noAZ0vKI+la01KTSRPkuVPE+U88jXv7javx2JHglUcL1MHcshQ==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -7266,8 +7266,8 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.1
       source-map: 0.7.3
-      webpack: 5.60.0_esbuild@0.14.19
-      webpack-dev-server: 4.8.1_webpack@5.60.0
+      webpack: 5.72.0_esbuild@0.14.19
+      webpack-dev-server: 4.8.1_webpack@5.72.0
     dev: false
 
   /@polka/url/1.0.0-next.21:
@@ -7639,27 +7639,17 @@ packages:
     resolution: {integrity: sha512-CL7y71j2zaDmtPLD5Xq5S1Gv2dFoHl0/GBZm6s39Mj/ls28L3NzAOqf7H4H0/2TNVMgMjMVf9CAFYSjmXhi3bw==}
     dev: true
 
-  /@types/eslint-scope/3.7.1:
-    resolution: {integrity: sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==}
-    dependencies:
-      '@types/eslint': 7.28.0
-      '@types/estree': 0.0.50
-
   /@types/eslint-scope/3.7.3:
     resolution: {integrity: sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==}
     dependencies:
       '@types/eslint': 7.28.0
       '@types/estree': 0.0.51
-    dev: false
 
   /@types/eslint/7.28.0:
     resolution: {integrity: sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==}
     dependencies:
       '@types/estree': 0.0.51
       '@types/json-schema': 7.0.9
-
-  /@types/estree/0.0.50:
-    resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
 
   /@types/estree/0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
@@ -8323,7 +8313,7 @@ packages:
     resolution: {integrity: sha512-niT+Prh3Aff8Uf1MVBVUsaNjFj9rJAKDXuoHIKiQbB+6IUP/3J3JIhBNyZ7lDhytvXxw6ppgnwKZdDJ08UMj4Q==}
     dev: false
 
-  /@webhotelier/webpack-fast-refresh/5.1.0_ac0f87342906ae3268ced85f94da75f3:
+  /@webhotelier/webpack-fast-refresh/5.1.0_ad215394b92be37ab5bb82482aa97917:
     resolution: {integrity: sha512-GLe+NjtVaEBeK13RSJrBE4mnlYCxrfg2m1X/UALVpsjSYaIcrabbxBgOp1bGQ4VJoi2FfMN7BfjsLHrwQGaVZA==}
     peerDependencies:
       react-refresh: ^0.9.0-rc.2
@@ -8333,7 +8323,7 @@ packages:
       react-error-overlay: 7.0.0-next.117
       react-refresh: 0.9.0
       sockjs-client: 1.5.2
-      webpack: 5.60.0
+      webpack: 5.72.0
     dev: false
 
   /@webxr-input-profiles/motion-controllers/1.0.0:
@@ -8383,20 +8373,12 @@ packages:
       acorn: 7.4.1
       acorn-walk: 7.2.0
 
-  /acorn-import-assertions/1.8.0_acorn@8.5.0:
-    resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
-    peerDependencies:
-      acorn: ^8
-    dependencies:
-      acorn: 8.5.0
-
   /acorn-import-assertions/1.8.0_acorn@8.7.0:
     resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
     peerDependencies:
       acorn: ^8
     dependencies:
       acorn: 8.7.0
-    dev: false
 
   /acorn-jsx/5.3.2_acorn@8.7.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -8416,11 +8398,6 @@ packages:
 
   /acorn/7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  /acorn/8.5.0:
-    resolution: {integrity: sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -8793,7 +8770,7 @@ packages:
       babel-plugin-istanbul: 6.0.0
       babel-preset-jest: 27.2.0_@babel+core@7.15.5
       chalk: 4.1.2
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -8811,7 +8788,7 @@ packages:
       schema-utils: 2.7.1
     dev: false
 
-  /babel-loader/8.2.2_3912b4afc765b9767f10719d11e4a1b8:
+  /babel-loader/8.2.2_020c178973d0b00481c828e00a554724:
     resolution: {integrity: sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -8823,7 +8800,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.60.0
+      webpack: 5.72.0
     dev: false
 
   /babel-loader/8.2.4_acba72ea4bf9d339cdfcd8f55cdb7006:
@@ -10104,7 +10081,7 @@ packages:
       postcss: 8.4.12
     dev: false
 
-  /css-loader/5.2.7_webpack@5.60.0:
+  /css-loader/5.2.7_webpack@5.72.0:
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -10120,7 +10097,7 @@ packages:
       postcss-value-parser: 4.1.0
       schema-utils: 3.1.1
       semver: 7.3.5
-      webpack: 5.60.0_esbuild@0.14.19
+      webpack: 5.72.0_esbuild@0.14.19
     dev: false
 
   /css-loader/6.7.1_webpack@5.72.0:
@@ -10827,20 +10804,12 @@ packages:
     dependencies:
       once: 1.4.0
 
-  /enhanced-resolve/5.8.3:
-    resolution: {integrity: sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      graceful-fs: 4.2.8
-      tapable: 2.2.1
-
   /enhanced-resolve/5.9.3:
     resolution: {integrity: sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.10
       tapable: 2.2.1
-    dev: false
 
   /entities/1.1.2:
     resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
@@ -11818,38 +11787,6 @@ packages:
       worker-rpc: 0.1.1
     dev: false
 
-  /fork-ts-checker-webpack-plugin/6.5.1_5265adb70d7d43d0ecb83204172732f0:
-    resolution: {integrity: sha512-x1wumpHOEf4gDROmKTaB6i4/Q6H3LwmjVO7fIX47vBwlZbtPjU33hgoMuD/Q/y6SU8bnuYSoN6ZQOLshGp0T/g==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@types/json-schema': 7.0.9
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      cosmiconfig: 6.0.0
-      deepmerge: 4.2.2
-      eslint: 8.13.0
-      fs-extra: 9.1.0
-      glob: 7.2.0
-      memfs: 3.4.1
-      minimatch: 3.1.2
-      schema-utils: 2.7.0
-      semver: 7.3.5
-      tapable: 1.1.3
-      typescript: 4.5.5
-      webpack: 5.60.0_esbuild@0.14.19
-    dev: false
-
   /fork-ts-checker-webpack-plugin/6.5.1_ea896ea9b6534e6dc7369b23923d4d97:
     resolution: {integrity: sha512-x1wumpHOEf4gDROmKTaB6i4/Q6H3LwmjVO7fIX47vBwlZbtPjU33hgoMuD/Q/y6SU8bnuYSoN6ZQOLshGp0T/g==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
@@ -11879,7 +11816,7 @@ packages:
       semver: 7.3.5
       tapable: 1.1.3
       typescript: 4.5.5
-      webpack: 5.72.0
+      webpack: 5.72.0_esbuild@0.14.19
     dev: false
 
   /form-data/2.3.3:
@@ -11897,7 +11834,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.33
+      mime-types: 2.1.34
 
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -12258,10 +12195,10 @@ packages:
 
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: false
 
   /graceful-fs/4.2.8:
     resolution: {integrity: sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==}
+    dev: false
 
   /gray-matter/4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -12567,20 +12504,6 @@ packages:
     resolution: {integrity: sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==}
     dev: false
 
-  /html-webpack-plugin/5.5.0_webpack@5.60.0:
-    resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
-    engines: {node: '>=10.13.0'}
-    peerDependencies:
-      webpack: ^5.20.0
-    dependencies:
-      '@types/html-minifier-terser': 6.0.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.21
-      pretty-error: 4.0.0
-      tapable: 2.2.1
-      webpack: 5.60.0_esbuild@0.14.19
-    dev: false
-
   /html-webpack-plugin/5.5.0_webpack@5.72.0:
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
     engines: {node: '>=10.13.0'}
@@ -12592,7 +12515,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.72.0
+      webpack: 5.72.0_esbuild@0.14.19
     dev: false
 
   /htmlparser2/3.10.1:
@@ -13401,7 +13324,7 @@ packages:
       '@jest/types': 27.2.4
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       import-local: 3.0.3
       jest-config: 27.2.4
       jest-util: 27.2.4
@@ -13430,7 +13353,7 @@ packages:
       '@jest/types': 27.2.4
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       import-local: 3.0.3
       jest-config: 27.2.4_ts-node@9.1.1
       jest-util: 27.2.4
@@ -13461,7 +13384,7 @@ packages:
       chalk: 4.1.2
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       is-ci: 3.0.0
       jest-circus: 27.2.4
       jest-environment-jsdom: 27.2.4
@@ -13497,7 +13420,7 @@ packages:
       chalk: 4.1.2
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       is-ci: 3.0.0
       jest-circus: 27.2.4
       jest-environment-jsdom: 27.2.4
@@ -13585,11 +13508,11 @@ packages:
       '@types/node': 17.0.17
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jest-regex-util: 27.0.6
       jest-serializer: 27.0.6
       jest-util: 27.2.4
-      jest-worker: 27.2.4
+      jest-worker: 27.5.1
       micromatch: 4.0.4
       walker: 1.0.7
     optionalDependencies:
@@ -13644,7 +13567,7 @@ packages:
       '@jest/types': 27.2.4
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       micromatch: 4.0.4
       pretty-format: 27.2.4
       slash: 3.0.0
@@ -13689,7 +13612,7 @@ packages:
       '@jest/types': 27.2.4
       chalk: 4.1.2
       escalade: 3.1.1
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jest-haste-map: 27.2.4
       jest-pnp-resolver: 1.2.2_jest-resolve@27.2.4
       jest-util: 27.2.4
@@ -13710,7 +13633,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jest-docblock: 27.0.6
       jest-environment-jsdom: 27.2.4
       jest-environment-node: 27.2.4
@@ -13720,7 +13643,7 @@ packages:
       jest-resolve: 27.2.4
       jest-runtime: 27.2.4
       jest-util: 27.2.4
-      jest-worker: 27.2.4
+      jest-worker: 27.5.1
       source-map-support: 0.5.20
       throat: 6.0.1
     transitivePeerDependencies:
@@ -13748,7 +13671,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jest-haste-map: 27.2.4
       jest-message-util: 27.2.4
       jest-mock: 27.2.4
@@ -13768,7 +13691,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@types/node': 17.0.17
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
 
   /jest-snapshot/27.2.4:
     resolution: {integrity: sha512-5DFxK31rYS8X8C6WXsFx8XxrxW3PGa6+9IrUcZdTLg1aEyXDGIeiBh4jbwvh655bg/9vTETbEj/njfZicHTZZw==}
@@ -13787,7 +13710,7 @@ packages:
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.15.5
       chalk: 4.1.2
       expect: 27.2.4
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jest-diff: 27.2.4
       jest-get-type: 27.0.6
       jest-haste-map: 27.2.4
@@ -13808,7 +13731,7 @@ packages:
       '@jest/types': 27.2.4
       '@types/node': 17.0.17
       chalk: 4.1.2
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       is-ci: 3.0.0
       picomatch: 2.3.0
 
@@ -13842,6 +13765,7 @@ packages:
       '@types/node': 17.0.17
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: false
 
   /jest-worker/27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -13850,7 +13774,6 @@ packages:
       '@types/node': 17.0.17
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: false
 
   /jest/27.2.4:
     resolution: {integrity: sha512-h4uqb1EQLfPulWyUFFWv9e9Nn8sCqsJ/j3wk/KCY0p4s4s0ICCfP3iMf6hRf5hEhsDyvyrCgKiZXma63gMz16A==}
@@ -15558,6 +15481,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
+    dev: false
 
   /p-locate/2.0.0:
     resolution: {integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=}
@@ -16827,41 +16751,6 @@ packages:
       shell-quote: 1.7.2
       strip-ansi: 6.0.0
       text-table: 0.2.0
-    dev: false
-
-  /react-dev-utils/12.0.1_5265adb70d7d43d0ecb83204172732f0:
-    resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      address: 1.1.2
-      browserslist: 4.20.2
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      detect-port-alt: 1.1.6
-      escape-string-regexp: 4.0.0
-      filesize: 8.0.7
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.1_5265adb70d7d43d0ecb83204172732f0
-      global-modules: 2.0.0
-      globby: 11.1.0
-      gzip-size: 6.0.0
-      immer: 9.0.12
-      is-root: 2.1.0
-      loader-utils: 3.2.0
-      open: 8.4.0
-      pkg-up: 3.1.0
-      prompts: 2.4.2
-      react-error-overlay: 6.0.11
-      recursive-readdir: 2.2.2
-      shell-quote: 1.7.3
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - eslint
-      - typescript
-      - vue-template-compiler
-      - webpack
     dev: false
 
   /react-dev-utils/12.0.1_ea896ea9b6534e6dc7369b23923d4d97:
@@ -18243,7 +18132,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /source-map-loader/3.0.0_webpack@5.60.0:
+  /source-map-loader/3.0.0_webpack@5.72.0:
     resolution: {integrity: sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -18252,7 +18141,7 @@ packages:
       abab: 2.0.5
       iconv-lite: 0.6.3
       source-map-js: 0.6.2
-      webpack: 5.60.0_esbuild@0.14.19
+      webpack: 5.72.0_esbuild@0.14.19
     dev: false
 
   /source-map-resolve/0.5.3:
@@ -18597,7 +18486,7 @@ packages:
       through: 2.3.8
     dev: false
 
-  /style-loader/2.0.0_webpack@5.60.0:
+  /style-loader/2.0.0_webpack@5.72.0:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -18605,7 +18494,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 3.1.1
-      webpack: 5.60.0_esbuild@0.14.19
+      webpack: 5.72.0_esbuild@0.14.19
     dev: false
 
   /style-to-object/0.3.0:
@@ -18777,8 +18666,8 @@ packages:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.2.0
 
-  /terser-webpack-plugin/5.2.4_esbuild@0.14.19+webpack@5.60.0:
-    resolution: {integrity: sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==}
+  /terser-webpack-plugin/5.3.1_esbuild@0.14.19+webpack@5.72.0:
+    resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -18794,38 +18683,13 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.14.19
-      jest-worker: 27.2.4
-      p-limit: 3.1.0
+      jest-worker: 27.5.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       source-map: 0.6.1
-      terser: 5.9.0
-      webpack: 5.60.0_esbuild@0.14.19
+      terser: 5.12.1
+      webpack: 5.72.0_esbuild@0.14.19
     dev: false
-
-  /terser-webpack-plugin/5.2.4_webpack@5.60.0:
-    resolution: {integrity: sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      jest-worker: 27.2.4
-      p-limit: 3.1.0
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      source-map: 0.6.1
-      terser: 5.9.0
-      webpack: 5.60.0
 
   /terser-webpack-plugin/5.3.1_webpack@5.72.0:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -18849,7 +18713,6 @@ packages:
       source-map: 0.6.1
       terser: 5.12.1
       webpack: 5.72.0
-    dev: false
 
   /terser/5.12.1:
     resolution: {integrity: sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==}
@@ -18857,16 +18720,6 @@ packages:
     hasBin: true
     dependencies:
       acorn: 8.7.0
-      commander: 2.20.3
-      source-map: 0.7.3
-      source-map-support: 0.5.20
-    dev: false
-
-  /terser/5.9.0:
-    resolution: {integrity: sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
       commander: 2.20.3
       source-map: 0.7.3
       source-map-support: 0.5.20
@@ -20003,20 +19856,12 @@ packages:
     dependencies:
       makeerror: 1.0.11
 
-  /watchpack/2.2.0:
-    resolution: {integrity: sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.8
-
   /watchpack/2.3.1:
     resolution: {integrity: sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==}
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.10
-    dev: false
 
   /wbuf/1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
@@ -20073,20 +19918,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /webpack-dev-middleware/5.3.1_webpack@5.60.0:
-    resolution: {integrity: sha512-81EujCKkyles2wphtdrnPg/QqegC/AtqNH//mQkBYSMqwFVCQrxM6ktB2O/SPlZy7LqeEfTbV3cZARGQz6umhg==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      colorette: 2.0.16
-      memfs: 3.4.1
-      mime-types: 2.1.34
-      range-parser: 1.2.1
-      schema-utils: 4.0.0
-      webpack: 5.60.0_esbuild@0.14.19
-    dev: false
-
   /webpack-dev-middleware/5.3.1_webpack@5.72.0:
     resolution: {integrity: sha512-81EujCKkyles2wphtdrnPg/QqegC/AtqNH//mQkBYSMqwFVCQrxM6ktB2O/SPlZy7LqeEfTbV3cZARGQz6umhg==}
     engines: {node: '>= 12.13.0'}
@@ -20098,55 +19929,7 @@ packages:
       mime-types: 2.1.34
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.72.0
-    dev: false
-
-  /webpack-dev-server/4.8.1_webpack@5.60.0:
-    resolution: {integrity: sha512-dwld70gkgNJa33czmcj/PlKY/nOy/BimbrgZRaR9vDATBQAYgLzggR0nxDtPLJiLrMgZwbE6RRfJ5vnBBasTyg==}
-    engines: {node: '>= 12.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/bonjour': 3.5.10
-      '@types/connect-history-api-fallback': 1.3.5
-      '@types/express': 4.17.13
-      '@types/serve-index': 1.9.1
-      '@types/sockjs': 0.3.33
-      '@types/ws': 8.5.3
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.0.11
-      chokidar: 3.5.3
-      colorette: 2.0.16
-      compression: 1.7.4
-      connect-history-api-fallback: 1.6.0
-      default-gateway: 6.0.3
-      express: 4.17.3
-      graceful-fs: 4.2.8
-      html-entities: 2.3.3
-      http-proxy-middleware: 2.0.4_@types+express@4.17.13
-      ipaddr.js: 2.0.1
-      open: 8.4.0
-      p-retry: 4.6.1
-      portfinder: 1.0.28
-      rimraf: 3.0.2
-      schema-utils: 4.0.0
-      selfsigned: 2.0.1
-      serve-index: 1.9.1
-      sockjs: 0.3.21
-      spdy: 4.0.2
-      webpack: 5.60.0_esbuild@0.14.19
-      webpack-dev-middleware: 5.3.1_webpack@5.60.0
-      ws: 8.5.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
+      webpack: 5.72.0_esbuild@0.14.19
     dev: false
 
   /webpack-dev-server/4.8.1_webpack@5.72.0:
@@ -20187,7 +19970,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.21
       spdy: 4.0.2
-      webpack: 5.72.0
+      webpack: 5.72.0_esbuild@0.14.19
       webpack-dev-middleware: 5.3.1_webpack@5.72.0
       ws: 8.5.0
     transitivePeerDependencies:
@@ -20212,93 +19995,9 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /webpack-sources/3.2.1:
-    resolution: {integrity: sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==}
-    engines: {node: '>=10.13.0'}
-
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
-    dev: false
-
-  /webpack/5.60.0:
-    resolution: {integrity: sha512-OL5GDYi2dKxnwJPSOg2tODgzDxAffN0osgWkZaBo/l3ikCxDFP+tuJT3uF7GyBE3SDBpKML/+a8EobyWAQO3DQ==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.1
-      '@types/estree': 0.0.50
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/wasm-edit': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
-      acorn: 8.5.0
-      acorn-import-assertions: 1.8.0_acorn@8.5.0
-      browserslist: 4.20.2
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.8.3
-      es-module-lexer: 0.9.2
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.8
-      json-parse-better-errors: 1.0.2
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.1.1
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.2.4_webpack@5.60.0
-      watchpack: 2.2.0
-      webpack-sources: 3.2.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  /webpack/5.60.0_esbuild@0.14.19:
-    resolution: {integrity: sha512-OL5GDYi2dKxnwJPSOg2tODgzDxAffN0osgWkZaBo/l3ikCxDFP+tuJT3uF7GyBE3SDBpKML/+a8EobyWAQO3DQ==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.1
-      '@types/estree': 0.0.50
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/wasm-edit': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
-      acorn: 8.5.0
-      acorn-import-assertions: 1.8.0_acorn@8.5.0
-      browserslist: 4.20.2
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.8.3
-      es-module-lexer: 0.9.2
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.8
-      json-parse-better-errors: 1.0.2
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.1.1
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.2.4_esbuild@0.14.19+webpack@5.60.0
-      watchpack: 2.2.0
-      webpack-sources: 3.2.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: false
 
   /webpack/5.72.0:
     resolution: {integrity: sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==}
@@ -20332,6 +20031,45 @@ packages:
       schema-utils: 3.1.1
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.1_webpack@5.72.0
+      watchpack: 2.3.1
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  /webpack/5.72.0_esbuild@0.14.19:
+    resolution: {integrity: sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 0.0.51
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/wasm-edit': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
+      acorn: 8.7.0
+      acorn-import-assertions: 1.8.0_acorn@8.7.0
+      browserslist: 4.20.2
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.9.3
+      es-module-lexer: 0.9.2
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+      json-parse-better-errors: 1.0.2
+      loader-runner: 4.2.0
+      mime-types: 2.1.34
+      neo-async: 2.6.2
+      schema-utils: 3.1.1
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.1_esbuild@0.14.19+webpack@5.72.0
       watchpack: 2.3.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -20635,6 +20373,7 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: false
 
   /zip-lib/0.7.2:
     resolution: {integrity: sha512-yOHG2x9vrpeO1VYSfBmixNL3E2lo5RjGOapUmGeroRSosht4vsYlM8Ci8v5Sulv5hd9ZU2ILZrOtZ4xEYmhf0A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,6 @@ importers:
       eslint-plugin-react-hooks: 4.4.0
       execa: 5.1.1
       express: 4.17.1
-      file-loader: 6.2.0
       jest: ^27.2.4
       memfs: 3.4.0
       mime-types: 2.1.34
@@ -93,7 +92,6 @@ importers:
       esbuild: 0.14.19
       execa: 5.1.1
       express: 4.17.1
-      file-loader: 6.2.0_webpack@5.60.0
       memfs: 3.4.0
       mime-types: 2.1.34
       react-refresh: 0.9.0
@@ -11662,17 +11660,6 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       flat-cache: 3.0.4
-
-  /file-loader/6.2.0_webpack@5.60.0:
-    resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      loader-utils: 2.0.0
-      schema-utils: 3.1.1
-      webpack: 5.60.0_esbuild@0.14.19
-    dev: false
 
   /file-loader/6.2.0_webpack@5.72.0:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}


### PR DESCRIPTION
- Note limit of 2GB when using `import` statement and recommend `staticFile()` instead - fixes #937, fixes #938
- Non existing file in public/ folder now returns 404 instead of redirecting to preview HTML - fixes #935
- Emphasize `staticFile()` and remote URLs in "Importing assets" docs #901