### PR TITLE
refactor: alias method getAudioDuration to getAudioDurationInSeconds

### DIFF
--- a/packages/docs/blog/2021-04-15-remotion-2-0.md
+++ b/packages/docs/blog/2021-04-15-remotion-2-0.md
@@ -41,7 +41,7 @@ You can now also completely omit the video from the output and only emit an audi
   </video>
 </div>
 
-This is a new helper package which includes functions useful for dealing with audio. Besides audio visualization, you can also for example measure the duration of an audio or video source, which is really useful for making a composition duration dynamic. The functions included are [`getAudioData()`](/docs/get-audio-data), [`getAudioDuration()`](/docs/get-audio-duration), [`getVideoMetadata()`](/docs/get-video-metadata), [`getWaveformPortion()`](/docs/get-waveform-portion), [`visualizeAudio()`](/docs/visualize-audio) and [`useAudioData()`](/docs/use-audio-data).
+This is a new helper package which includes functions useful for dealing with audio. Besides audio visualization, you can also for example measure the duration of an audio or video source, which is really useful for making a composition duration dynamic. The functions included are [`getAudioData()`](/docs/get-audio-data), [`getAudioDuration()`](/docs/get-audio-duration-in-seconds), [`getVideoMetadata()`](/docs/get-video-metadata), [`getWaveformPortion()`](/docs/get-waveform-portion), [`visualizeAudio()`](/docs/visualize-audio) and [`useAudioData()`](/docs/use-audio-data).
 
 All of them except the last one are completely independent from the ideas of Remotion, so they might be a great fit for your other non-Remotion projects as well! This package is MIT-licensed, so you everybody can use it without obtaining a company license.
 
@@ -117,7 +117,11 @@ In the editor, you can now resize the timeline as well as the left sidebar. Than
 `interpolate()` now supports arrays with lengths bigger than 2. Really useful for a lot of scenarios - for example you can create a combined fade in/fade out transition with one line.
 
 ```tsx
-const opacity = interpolate(frame, [0, 10, durationInFrames - 10, durationInFrames], [0, 1, 1, 0])
+const opacity = interpolate(
+  frame,
+  [0, 10, durationInFrames - 10, durationInFrames],
+  [0, 1, 1, 0]
+);
 ```
 
 ## 170+ tests added

--- a/packages/docs/docs/get-audio-data.md
+++ b/packages/docs/docs/get-audio-data.md
@@ -67,7 +67,7 @@ If you pass in the same argument to `src` multiple times, it will return a cache
 
 ## Alternatives
 
-If you need only the duration, prefer [`getAudioDuration()`](/docs/get-audio-duration) which is faster because it doesn't need to read waveform data.
+If you need only the duration, prefer [`getAudioDurationInSeconds()`](/docs/get-audio-duration) which is faster because it doesn't need to read waveform data.
 
 Use the [`useAudioData()`](/docs/use-audio-data) helper hook to not have to do state management yourself and to wrap the call in [`delayRender()`](/docs/delay-render).
 

--- a/packages/docs/docs/get-audio-data.md
+++ b/packages/docs/docs/get-audio-data.md
@@ -67,7 +67,7 @@ If you pass in the same argument to `src` multiple times, it will return a cache
 
 ## Alternatives
 
-If you need only the duration, prefer [`getAudioDurationInSeconds()`](/docs/get-audio-duration) which is faster because it doesn't need to read waveform data.
+If you need only the duration, prefer [`getAudioDurationInSeconds()`](/docs/get-audio-duration-in-seconds) which is faster because it doesn't need to read waveform data.
 
 Use the [`useAudioData()`](/docs/use-audio-data) helper hook to not have to do state management yourself and to wrap the call in [`delayRender()`](/docs/delay-render).
 

--- a/packages/docs/docs/get-audio-duration-in-seconds.md
+++ b/packages/docs/docs/get-audio-duration-in-seconds.md
@@ -1,9 +1,11 @@
 ---
 title: getAudioDurationInSeconds()
-id: get-audio-duration
+id: get-audio-duration-in-seconds
 ---
 
 _Part of the `@remotion/media-utils` package of helper functions._
+
+_Previously `getAudioDuration()`_
 
 Gets the duration in seconds of an audio source. Remotion will create an invisible `<audio>` tag, load the audio and return the duration.
 
@@ -22,26 +24,27 @@ A string pointing to an audio asset
 ```tsx twoslash
 // @module: ESNext
 // @target: ESNext
-import {useCallback, useEffect} from "react";
-import {Audio, staticFile} from "remotion";
+import { useCallback, useEffect } from "react";
+import { Audio, staticFile } from "remotion";
 // ---cut---
-import {getAudioDurationInSeconds} from "@remotion/media-utils";
+import { getAudioDurationInSeconds } from "@remotion/media-utils";
 import music from "./music.mp3";
-import {getAudioDurationInSeconds} from "./get-audio-duration";
 
 const MyComp: React.FC = () => {
   const getDuration = useCallback(async () => {
     const imported = await getAudioDurationInSeconds(music); // 127.452
-    const publicFile = await getAudioDurationInSeconds(staticFile("voiceover.wav")); // 33.221
+    const publicFile = await getAudioDurationInSeconds(
+      staticFile("voiceover.wav")
+    ); // 33.221
     const remote = await getAudioDurationInSeconds(
       "https://example.com/remote-audio.aac"
     ); // 50.24
   }, []);
 
-    useEffect(() => {
-        getDuration();
-    }, []);
+  useEffect(() => {
+    getDuration();
+  }, []);
 
-    return null;
+  return null;
 };
 ```

--- a/packages/docs/docs/get-audio-duration-redirect.md
+++ b/packages/docs/docs/get-audio-duration-redirect.md
@@ -1,0 +1,10 @@
+---
+id: get-audio-duration
+title: getAudioDuration()
+---
+
+import Redirect from '../components/Redirect';
+
+This page has moved. Redirecting...
+
+<Redirect redirect="/docs/get-audio-duration-in-seconds"/>

--- a/packages/docs/docs/get-audio-duration.md
+++ b/packages/docs/docs/get-audio-duration.md
@@ -1,5 +1,5 @@
 ---
-title: getAudioDuration()
+title: getAudioDurationInSeconds()
 id: get-audio-duration
 ---
 
@@ -22,25 +22,26 @@ A string pointing to an audio asset
 ```tsx twoslash
 // @module: ESNext
 // @target: ESNext
-import { useCallback, useEffect } from "react";
-import { Audio, staticFile } from "remotion";
+import {useCallback, useEffect} from "react";
+import {Audio, staticFile} from "remotion";
 // ---cut---
-import { getAudioDuration } from "@remotion/media-utils";
+import {getAudioDurationInSeconds} from "@remotion/media-utils";
 import music from "./music.mp3";
+import {getAudioDurationInSeconds} from "./get-audio-duration";
 
 const MyComp: React.FC = () => {
   const getDuration = useCallback(async () => {
-    const imported = await getAudioDuration(music); // 127.452
-    const publicFile = await getAudioDuration(staticFile("voiceover.wav")); // 33.221
-    const remote = await getAudioDuration(
+    const imported = await getAudioDurationInSeconds(music); // 127.452
+    const publicFile = await getAudioDurationInSeconds(staticFile("voiceover.wav")); // 33.221
+    const remote = await getAudioDurationInSeconds(
       "https://example.com/remote-audio.aac"
     ); // 50.24
   }, []);
 
-  useEffect(() => {
-    getDuration();
-  }, []);
+    useEffect(() => {
+        getDuration();
+    }, []);
 
-  return null;
+    return null;
 };
 ```

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -196,7 +196,7 @@ module.exports = {
       items: [
         "audio-buffer-to-data-url",
         "get-audio-data",
-        "get-audio-duration",
+        "get-audio-duration-in-seconds",
         "get-video-metadata",
         "get-waveform-portion",
         "use-audio-data",

--- a/packages/media-utils/src/get-audio-duration.ts
+++ b/packages/media-utils/src/get-audio-duration.ts
@@ -1,4 +1,10 @@
-export const getAudioDuration = (src: string): Promise<number> => {
+/**
+ * Get the audio file passed in parameter duration in seconds
+ * @async
+ * @param src path to the audio file
+ * @return {number} duration of the audio file in seconds
+ */
+export const getAudioDurationInSeconds = (src: string): Promise<number> => {
 	const audio = document.createElement('audio');
 	audio.src = src;
 	return new Promise<number>((resolve, reject) => {

--- a/packages/media-utils/src/get-audio-duration.ts
+++ b/packages/media-utils/src/get-audio-duration.ts
@@ -27,3 +27,8 @@ export const getAudioDurationInSeconds = (src: string): Promise<number> => {
 		audio.addEventListener('error', onError, {once: true});
 	});
 };
+
+/**
+ * @deprecated Renamed to `getAudioDurationInSeconds`
+ */
+export const getAudioDuration = (src: string) => getAudioDurationInSeconds(src);

--- a/packages/media-utils/src/index.ts
+++ b/packages/media-utils/src/index.ts
@@ -1,5 +1,5 @@
 export {getAudioData} from './get-audio-data';
-export {getAudioDuration} from './get-audio-duration';
+export {getAudioDurationInSeconds as getAudioDuration,  getAudioDurationInSeconds} from './get-audio-duration';
 export {getVideoMetadata} from './get-video-metadata';
 export {getWaveformPortion} from './get-waveform-portion';
 export * from './types';

--- a/packages/media-utils/src/index.ts
+++ b/packages/media-utils/src/index.ts
@@ -1,5 +1,8 @@
 export {getAudioData} from './get-audio-data';
-export {getAudioDurationInSeconds as getAudioDuration,  getAudioDurationInSeconds} from './get-audio-duration';
+export {
+	getAudioDuration,
+	getAudioDurationInSeconds,
+} from './get-audio-duration';
 export {getVideoMetadata} from './get-video-metadata';
 export {getWaveformPortion} from './get-waveform-portion';
 export * from './types';


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
### Why

Close #940 

I did not want to include a breaking change here, so here is my proposition to just alias the method.

### How

- [x] update documentation
- [x] update examples


