### PR TITLE
chore: define a recommended eslint plugin config for remotion

### DIFF
--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -1,7 +1,7 @@
 import { autoImports } from "./auto-import-rules";
 import { allowESLintShareableConfig } from "./patch-eslint";
 
-const baseExtends = ["eslint:recommended"];
+const baseExtends = ["eslint:recommended", "plugin:@remotion/eslint-plugin/recommended"];
 
 const getRules = (typescript: boolean) => {
   return {
@@ -560,14 +560,6 @@ const getRules = (typescript: boolean) => {
         imports: autoImports,
       },
     ],
-    // Enable Remotion specific rules
-    "@remotion/no-mp4-import": "off",
-    "@remotion/warn-native-media-tag": "warn",
-    "@remotion/deterministic-randomness": "warn",
-    "@remotion/no-string-assets": "warn",
-    "@remotion/even-dimensions": "warn",
-    "@remotion/duration-in-frames": "warn",
-    "@remotion/volume-callback": "warn",
     "@typescript-eslint/explicit-module-boundary-types": "off",
   };
 };

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -18,4 +18,15 @@ const rules = {
 
 export = {
   rules,
+  config: {
+    recommended: {
+      "@remotion/no-mp4-import": "error",
+      "@remotion/warn-native-media-tag": "error",
+      "@remotion/deterministic-randomness": "error",
+      "@remotion/no-string-assets": "error",
+      "@remotion/even-dimensions": "error",
+      "@remotion/duration-in-frames": "error",
+      "@remotion/volume-callback": "error",
+    },
+  }
 };


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

**Not ready to merge**

As we discussed together @JonnyBurger , I tried to define a config within the eslint-plugin of remotion in order to list all the rules with a recommended configuration.
Sadly this seems not to work correctly.
`@remotion/eslint-config` can't succeed to load the configuration from the plugin


- [Eslint documentation about extending configuration](https://eslint.org/docs/user-guide/configuring/configuration-files#using-a-configuration-from-a-plugin)
- [React plugin recommended configuration](https://github.com/jsx-eslint/eslint-plugin-react) 
