### PR TITLE
Update 3-0-migration.md update section overrideWebpackConfig to fit code style

### DIFF
--- a/packages/docs/docs/3-0-migration.md
+++ b/packages/docs/docs/3-0-migration.md
@@ -209,18 +209,18 @@ To align the name with `renderStill()`, `renderFrames()` and `renderMedia()`, `b
 
 ### `overrideWebpackConfig()`: Config file option is removed
 
-```ts title="remotion.config.ts"
+The import `overrideWebpackConfig` was deprecated and now removed. Use `Config.Bundling.overrideWebpackConfig()` instead.
+
+**Upgrade path**: Change import in `remotion.config.ts`and use `overrideWebpackConfig()`.
+
+```tsx title="Previously"
 import { overrideWebpackConfig } from "@remotion/bundler";
 ```
 
-was deprecated and was now removed.
-
-Use
-
-```ts
+```tsx title="Now"
 import { Config } from "remotion";
 
 Config.Bundling.overrideWebpackConfig();
 ```
 
-instead.
+


### PR DESCRIPTION
change part of `overrideWebpackConfig` to align code style in document (Description / Upgrade Path / Previously example / Now example ).

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
