### PR TITLE
Fix: CRF range with a H264 codec

### DIFF
--- a/packages/docs/docs/config.md
+++ b/packages/docs/docs/config.md
@@ -400,7 +400,7 @@ The "Constant Rate Factor" (CRF) of the output. [Use this setting to tell FFMPEG
 
 Ranges for CRF scale, by codec:
 
-- `h264` crf range is 0-51 where crf 18 is _default_.
+- `h264` crf range is 1-51 where crf 18 is _default_.
 - `h265` crf range is 0-51 where crf 23 is _default_.
 - `vp8` crf range is 4-63 where crf 9 is _default_.
 - `vp9` crf range is 0-63 where crf 28 is _default_.


### PR DESCRIPTION
In fact, an error will be reported if CRF is set to 0 under H264:

```
An error occurred:
TypeError: Setting the CRF to 0 with a H264 codec is not supported anymore because of it's inconsistencies between platforms. Videos with CRF 0 cannot be played on iOS/macOS. 0 is a extreme value with inefficient settings which you probably want. Set CRF to a higher value to fix this error.
```

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
