### PR TITLE
fix: code highlights in documentation

### DIFF
--- a/packages/docs/docs/using-audio.md
+++ b/packages/docs/docs/using-audio.md
@@ -15,7 +15,7 @@ import audio from "./audio.mp3";
 
 You may add an [`<Audio/>`](/docs/audio) tag to your composition to add sound to it.
 
-```tsx twoslash {7}
+```tsx twoslash {8}
 import { Audio } from "remotion";
 import audio from "./audio.mp3";
 

--- a/packages/docs/docs/using-audio.md
+++ b/packages/docs/docs/using-audio.md
@@ -84,7 +84,7 @@ export const MyVideo = () => {
 You can use the `volume` prop to control the volume.
 **The simplest way is to pass a number between 0 and 1**. `1` is the maximum volume, values over 1 are allowed but will not increase the volume further. Volumes under 0 are not allowed.
 
-```tsx twoslash {7}
+```tsx twoslash {8}
 import { Audio } from "remotion";
 import audio from "./audio.mp3";
 
@@ -100,7 +100,7 @@ export const MyVideo = () => {
 
 You can also **change volume over time**, in this example we are using the [interpolate()](/docs/interpolate) function. Note that because values below 0 are not allowed, we need to set the `extrapolateLeft: 'clamp'` option to ensure no negative values.
 
-```tsx twoslash {11}
+```tsx twoslash {12-14}
 import { Audio, interpolate, useCurrentFrame } from "remotion";
 import audio from "./audio.mp3";
 
@@ -123,7 +123,7 @@ export const MyVideo = () => {
 
 You may also pass a **callback function** that returns the volume based an arbitrary frame number. This has the benefit that Remotion is able to **draw a volume curve in the timeline**!
 
-```tsx twoslash {9}
+```tsx twoslash {10-12}
 import { Audio, interpolate } from "remotion";
 import audio from "./audio.mp3";
 
@@ -148,7 +148,7 @@ Note that if you pass in a callback function, the first frame on which audio is 
 
 You may pass in the `muted` and it may change over time. When `muted` is true, audio will be omitted at that time. In the following example, we are muting the track between frame 40 and 60.
 
-```tsx twoslash {9}
+```tsx twoslash {10}
 import { Audio, useCurrentFrame } from "remotion";
 import audio from "./audio.mp3";
 

--- a/packages/docs/docs/using-audio.md
+++ b/packages/docs/docs/using-audio.md
@@ -40,7 +40,7 @@ You can mix multiple tracks together by adding more audio tags.
 You can use the [`<Sequence />`](/docs/sequence) API to cut and trim audio.
 As a convienience, the `<Audio />` tag supports the `startFrom` and `endAt` props.
 
-```tsx twoslash {9-10}
+```tsx twoslash {10-11}
 import { Audio } from "remotion";
 import audio from "./audio.mp3";
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

This PR fixes some code highlights in the documentation of the [use audio](https://www.remotion.dev/docs/using-audio) section
