### PR TITLE
Fix ffmpeg error with (32 <= audio files <= 64)

### DIFF
--- a/packages/example/src/ManyAudio/index.tsx
+++ b/packages/example/src/ManyAudio/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import {AbsoluteFill, Audio, staticFile} from 'remotion';
+
+export const ManyAudio: React.FC = () => {
+	return (
+		<AbsoluteFill>
+			{new Array(32).fill(true).map((_, i) => {
+				return <Audio src={staticFile('music.mp3?mus=' + i)} />;
+			})}
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/Video.tsx
+++ b/packages/example/src/Video.tsx
@@ -6,6 +6,7 @@ import {ColorInterpolation} from './ColorInterpolation';
 import {FontDemo} from './Fonts';
 import {Framer} from './Framer';
 import {FreezeExample} from './Freeze/FreezeExample';
+import {ManyAudio} from './ManyAudio';
 import {MissingImg} from './MissingImg';
 import {OffthreadRemoteVideo} from './OffthreadRemoteVideo/OffthreadRemoteVideo';
 import {OrbScene} from './Orb';
@@ -106,7 +107,6 @@ export const Index: React.FC = () => {
 					fps={30}
 					durationInFrames={100}
 				/>
-
 				<Composition
 					id="scripts"
 					component={Scripts}
@@ -114,6 +114,14 @@ export const Index: React.FC = () => {
 					height={720}
 					fps={30}
 					durationInFrames={100}
+				/>
+				<Composition
+					id="many-audio"
+					component={ManyAudio}
+					width={1280}
+					height={720}
+					fps={30}
+					durationInFrames={30}
 				/>
 			</Folder>
 			<Folder name="creatives">

--- a/packages/it-tests/src/rendering/many-audio-tracks.test.ts
+++ b/packages/it-tests/src/rendering/many-audio-tracks.test.ts
@@ -1,0 +1,18 @@
+import path from "path";
+import fs from "fs";
+import execa from "execa";
+
+test("Should be able to render if remotion.config.ts is not provided", async () => {
+  const outputPath = path.join(process.cwd(), "packages/example/out.mp3");
+
+  const task = await execa(
+    "pnpx",
+    ["remotion", "render", "src/index.tsx", "many-audio", outputPath],
+    {
+      cwd: path.join(process.cwd(), "..", "example"),
+    }
+  );
+
+  expect(task.exitCode).toBe(0);
+  fs.unlinkSync(outputPath);
+});

--- a/packages/renderer/src/merge-audio-track.ts
+++ b/packages/renderer/src/merge-audio-track.ts
@@ -39,8 +39,8 @@ const mergeAudioTrackUnlimited = async ({
 		return;
 	}
 
-	// FFMPEG has a limit of 64 tracks that can be merged at once
-	if (files.length > 64) {
+	// In FFMPEG, the total number of left and right tracks that can be merged at one time is limited to 64
+	if (files.length >= 32) {
 		const chunked = chunk(files, 10);
 		const tempPath = tmpDir('remotion-large-audio-mixing');
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

I am using this build of ffmpeg on Windows10.
```
ffmpeg version 4.4-full_build-www.gyan.dev Copyright (c) 2000-2021 the FFmpeg developers
  built with gcc 10.2.0 (Rev6, Built by MSYS2 project)
  configuration: --enable-gpl --enable-version3 --enable-shared --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-lzma --enable-libsnappy --enable-zlib --enable-librist --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-libbluray --enable-libcaca --enable-sdl2 --enable-libdav1d --enable-libzvbi --enable-librav1e --enable-libsvtav1 --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-libaom --enable-libopenjpeg --enable-libvpx --enable-libass --enable-frei0r --enable-libfreetype --enable-libfribidi --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-ffnvcodec --enable-nvdec --enable-nvenc --enable-d3d11va --enable-dxva2 --enable-libmfx --enable-libglslang --enable-vulkan --enable-opencl --enable-libcdio --enable-libgme --enable-libmodplug --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libshine --enable-libtheora --enable-libtwolame --enable-libvo-amrwbenc --enable-libilbc --enable-libgsm --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-ladspa --enable-libbs2b --enable-libflite --enable-libmysofa --enable-librubberband --enable-libsoxr --enable-chromaprint
  libavutil      56. 70.100 / 56. 70.100
  libavcodec     58.134.100 / 58.134.100
  libavformat    58. 76.100 / 58. 76.100
  libavdevice    58. 13.100 / 58. 13.100
  libavfilter     7.110.100 /  7.110.100
  libswscale      5.  9.100 /  5.  9.100
  libswresample   3.  9.100 /  3.  9.100
  libpostproc    55.  9.100 / 55.  9.100
```

I got the following error by ffmpeg while rendering a video with 52 files of audio.
```
(omitted)
[Parsed_pan_1 @ 00000156941e5340] Expected in channel name, got "c64+c66+"
[AVFilterGraph @ 000001569467bac0] Error initializing filter 'pan' with args 'stereo|c0=c0+c2+c4+c6+c8+c10+c12+c14+c16+c18+c20+c22+c24+c26+c28+c30+c32+c34+c36+c38+c40+c42+c44+c46+c48+c50+c52+c54+c56+c58+c60+c62+c64+c66+c68+c70+c72+c74+c76+c78+c80+c82+c84+c86+c88+c90+c92+c94+c96+c98+c100+c102+c104+c106+c108|c1=c1+c3+c5+c7+c9+c11+c13+c15+c17+c19+c21+c23+c25+c27+c29+c31+c33+c35+c37+c39+c41+c43+c45+c47+c49+c51+c53+c55+c57+c59+c61+c63+c65+c67+c69+c71+c73+c75+c77+c79+c81+c83+c85+c87+c89+c91+c93+c95+c97+c99+c101+c103+c105+c107+c109'
Error initializing complex filters.
(omitted)
```

And, following is with 32 files of audio.
```
(omitted)
[Parsed_amerge_0 @ 000001fa61e87880] No channel layout for input 1
[Parsed_amerge_0 @ 000001fa61e87880] Input channel layouts overlap: output layout will be determined by the number of distinct input channels
[Parsed_pan_1 @ 000001fa61e87680] af_pan supports a maximum of 64 channels. Feel free to ask for a higher limit.
[Parsed_pan_1 @ 000001fa61e87680] Failed to configure input pad on Parsed_pan_1
Error reinitializing filters!
(omitted)
```

This is probably due to the limitation of ffmpeg that it can only process 64 audios at the same time, that is the **sum of the two channels**.
Therefore, the audio mix is now done with a threshold of 32 instead of 64.
(I don't know why,) I got an error with 32 files of audio, so this change will make it work.