### PR TITLE
implement caching for offthread video last frames

### DIFF
--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -309,4 +309,13 @@ export const render = async () => {
 	}
 
 	Log.info(chalk.green('\nYour video is ready!'));
+
+	if (
+		Internals.Logging.isEqualOrBelowLogLevel(
+			Internals.Logging.getLogLevel(),
+			'verbose'
+		)
+	) {
+		Internals.perf.logPerf();
+	}
 };

--- a/packages/core/src/perf/index.ts
+++ b/packages/core/src/perf/index.ts
@@ -1,9 +1,16 @@
-type PerfId = 'activate-target' | 'capture' | 'save';
+type PerfId =
+	| 'activate-target'
+	| 'capture'
+	| 'save'
+	| 'extract-frame'
+	| 'piping';
 
 const perf: {[key in PerfId]: number[]} = {
 	'activate-target': [],
 	capture: [],
 	save: [],
+	'extract-frame': [],
+	piping: [],
 };
 
 const map: {

--- a/packages/renderer/src/extract-frame-from-video.ts
+++ b/packages/renderer/src/extract-frame-from-video.ts
@@ -18,7 +18,8 @@ export function streamToString(stream: Readable) {
 	});
 }
 
-const limit = pLimit(5);
+const lastFrameLimit = pLimit(5);
+const mainLimit = pLimit(5);
 
 const getLastFrameOfVideoUnlimited = async ({
 	ffmpegExecutable,
@@ -95,7 +96,7 @@ const getLastFrameOfVideo = async (
 		return fromCache;
 	}
 
-	const result = await limit(getLastFrameOfVideoUnlimited, options);
+	const result = await lastFrameLimit(getLastFrameOfVideoUnlimited, options);
 	setLastFrameInCache(options, result);
 
 	return result;
@@ -183,5 +184,5 @@ export const extractFrameFromVideoFn = async ({
 };
 
 export const extractFrameFromVideo = (options: Options) => {
-	return limit(extractFrameFromVideoFn, options);
+	return mainLimit(extractFrameFromVideoFn, options);
 };

--- a/packages/renderer/src/extract-frame-from-video.ts
+++ b/packages/renderer/src/extract-frame-from-video.ts
@@ -1,5 +1,5 @@
 import execa from 'execa';
-import {FfmpegExecutable} from 'remotion';
+import {FfmpegExecutable, Internals} from 'remotion';
 import {Readable} from 'stream';
 import {frameToFfmpegTimestamp} from './frame-to-ffmpeg-timestamp';
 import {
@@ -187,6 +187,9 @@ export const extractFrameFromVideoFn = async ({
 	return stdOut;
 };
 
-export const extractFrameFromVideo = (options: Options) => {
-	return mainLimit(extractFrameFromVideoFn, options);
+export const extractFrameFromVideo = async (options: Options) => {
+	const perf = Internals.perf.startPerfMeasure('extract-frame');
+	const res = await mainLimit(extractFrameFromVideoFn, options);
+	Internals.perf.stopPerfMeasure(perf);
+	return res;
 };

--- a/packages/renderer/src/extract-frame-from-video.ts
+++ b/packages/renderer/src/extract-frame-from-video.ts
@@ -82,7 +82,11 @@ const getLastFrameOfVideoUnlimited = async ({
 
 	const isEmpty = stdErr.includes('Output file is empty');
 	if (isEmpty) {
-		return getLastFrameOfVideo({ffmpegExecutable, offset: offset + 10, src});
+		return getLastFrameOfVideoUnlimited({
+			ffmpegExecutable,
+			offset: offset + 10,
+			src,
+		});
 	}
 
 	return stdoutBuffer;

--- a/packages/renderer/src/is-beyond-last-frame.ts
+++ b/packages/renderer/src/is-beyond-last-frame.ts
@@ -1,0 +1,9 @@
+const map: Record<string, number> = {};
+
+export const isBeyondLastFrame = (src: string, time: number) => {
+	return map[src] && time >= map[src];
+};
+
+export const markAsBeyondLastFrame = (src: string, time: number) => {
+	map[src] = time;
+};

--- a/packages/renderer/src/last-frame-from-video-cache.ts
+++ b/packages/renderer/src/last-frame-from-video-cache.ts
@@ -1,0 +1,71 @@
+// OffthreadVideo requires sometimes that the last frame of a video gets extracted, however, this can be slow. We allocate a cache for it but that can be garbage collected
+
+import {FfmpegExecutable} from 'remotion';
+
+export type LastFrameOptions = {
+	ffmpegExecutable: FfmpegExecutable;
+	offset: number;
+	src: string;
+};
+
+let map: Record<string, {lastAccessed: number; data: Buffer}> = {};
+
+const MAX_CACHE_SIZE = 50 * 1024 * 1024; // 50MB
+
+let bufferSize = 0;
+
+const makeLastFrameCacheKey = (options: LastFrameOptions) => {
+	return [options.ffmpegExecutable, options.offset, options.src].join('-');
+};
+
+export const setLastFrameInCache = (
+	options: LastFrameOptions,
+	data: Buffer
+) => {
+	const key = makeLastFrameCacheKey(options);
+	if (map[key]) {
+		bufferSize -= map[key].data.byteLength;
+	}
+
+	map[key] = {data, lastAccessed: Date.now()};
+	bufferSize += data.byteLength;
+	ensureMaxSize();
+};
+
+export const getLastFrameFromCache = (
+	options: LastFrameOptions
+): Buffer | null => {
+	const key = makeLastFrameCacheKey(options);
+
+	if (!map[key]) {
+		return null;
+	}
+
+	map[key].lastAccessed = Date.now();
+	return map[key].data ?? null;
+};
+
+export const removedLastFrameFromCache = (key: string) => {
+	if (!map[key]) {
+		return;
+	}
+
+	bufferSize -= map[key].data.byteLength;
+
+	delete map[key];
+};
+
+export const ensureMaxSize = () => {
+	// eslint-disable-next-line no-unmodified-loop-condition
+	while (bufferSize > MAX_CACHE_SIZE) {
+		const earliest = Object.entries(map).sort((a, b) => {
+			return a[1].lastAccessed - b[1].lastAccessed;
+		})[0];
+
+		removedLastFrameFromCache(earliest[0]);
+	}
+};
+
+export const clearLastFileCache = () => {
+	map = {};
+};

--- a/packages/renderer/src/provide-screenshot.ts
+++ b/packages/renderer/src/provide-screenshot.ts
@@ -2,7 +2,7 @@ import puppeteer from 'puppeteer-core';
 import {ImageFormat} from 'remotion';
 import {screenshotDOMElement} from './screenshot-dom-element';
 
-export const provideScreenshot = async ({
+export const provideScreenshot = ({
 	page,
 	imageFormat,
 	options,

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -251,6 +251,7 @@ const innerRenderFrames = ({
 
 				if (imageFormat !== 'none') {
 					if (onFrameBuffer) {
+						const id = Internals.perf.startPerfMeasure('save');
 						const buffer = await provideScreenshot({
 							page: freePage,
 							imageFormat,
@@ -260,6 +261,8 @@ const innerRenderFrames = ({
 								output: undefined,
 							},
 						});
+						Internals.perf.stopPerfMeasure(id);
+
 						onFrameBuffer(buffer, frame);
 					} else {
 						if (!outputDir) {

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -243,7 +243,9 @@ export const renderMedia = ({
 								return;
 							}
 
+							const id = Internals.perf.startPerfMeasure('piping');
 							stitcherFfmpeg?.stdin?.write(buffer);
+							Internals.perf.stopPerfMeasure(id);
 
 							setFrameToStitch(frame + 1);
 					  }

--- a/packages/renderer/src/test/last-frame-video-cache.test.ts
+++ b/packages/renderer/src/test/last-frame-video-cache.test.ts
@@ -1,0 +1,28 @@
+import crypto from 'crypto';
+import {
+	clearLastFileCache,
+	getLastFrameFromCache,
+	setLastFrameInCache,
+} from '../last-frame-from-video-cache';
+
+test('Last frame video cache', () => {
+	expect(getLastFrameFromCache('1')).toBe(null);
+
+	const buf = crypto.randomBytes(10 * 1024 * 1024);
+	setLastFrameInCache('1', buf);
+	expect(getLastFrameFromCache('1')?.byteLength).toBe(10 * 1024 * 1024);
+	setLastFrameInCache('2', buf);
+	setLastFrameInCache('3', buf);
+	setLastFrameInCache('4', buf);
+	setLastFrameInCache('5', buf);
+	setLastFrameInCache('6', buf);
+
+	expect(getLastFrameFromCache('1')?.byteLength ?? 0).toBe(0);
+	expect(getLastFrameFromCache('2')?.byteLength).toBe(10 * 1024 * 1024);
+	expect(getLastFrameFromCache('3')?.byteLength).toBe(10 * 1024 * 1024);
+	expect(getLastFrameFromCache('4')?.byteLength).toBe(10 * 1024 * 1024);
+	expect(getLastFrameFromCache('5')?.byteLength).toBe(10 * 1024 * 1024);
+	expect(getLastFrameFromCache('6')?.byteLength).toBe(10 * 1024 * 1024);
+
+	clearLastFileCache();
+});

--- a/packages/renderer/src/test/last-frame-video-cache.test.ts
+++ b/packages/renderer/src/test/last-frame-video-cache.test.ts
@@ -2,27 +2,48 @@ import crypto from 'crypto';
 import {
 	clearLastFileCache,
 	getLastFrameFromCache,
+	LastFrameOptions,
 	setLastFrameInCache,
 } from '../last-frame-from-video-cache';
 
+const makeKey = (id: string): LastFrameOptions => {
+	return {
+		ffmpegExecutable: null,
+		offset: 10,
+		src: id,
+	};
+};
+
 test('Last frame video cache', () => {
-	expect(getLastFrameFromCache('1')).toBe(null);
+	expect(getLastFrameFromCache(makeKey('1'))).toBe(null);
 
 	const buf = crypto.randomBytes(10 * 1024 * 1024);
-	setLastFrameInCache('1', buf);
-	expect(getLastFrameFromCache('1')?.byteLength).toBe(10 * 1024 * 1024);
-	setLastFrameInCache('2', buf);
-	setLastFrameInCache('3', buf);
-	setLastFrameInCache('4', buf);
-	setLastFrameInCache('5', buf);
-	setLastFrameInCache('6', buf);
+	setLastFrameInCache(makeKey('1'), buf);
+	expect(getLastFrameFromCache(makeKey('1'))?.byteLength).toBe(
+		10 * 1024 * 1024
+	);
+	setLastFrameInCache(makeKey('2'), buf);
+	setLastFrameInCache(makeKey('3'), buf);
+	setLastFrameInCache(makeKey('4'), buf);
+	setLastFrameInCache(makeKey('5'), buf);
+	setLastFrameInCache(makeKey('6'), buf);
 
-	expect(getLastFrameFromCache('1')?.byteLength ?? 0).toBe(0);
-	expect(getLastFrameFromCache('2')?.byteLength).toBe(10 * 1024 * 1024);
-	expect(getLastFrameFromCache('3')?.byteLength).toBe(10 * 1024 * 1024);
-	expect(getLastFrameFromCache('4')?.byteLength).toBe(10 * 1024 * 1024);
-	expect(getLastFrameFromCache('5')?.byteLength).toBe(10 * 1024 * 1024);
-	expect(getLastFrameFromCache('6')?.byteLength).toBe(10 * 1024 * 1024);
+	expect(getLastFrameFromCache(makeKey('1'))?.byteLength ?? 0).toBe(0);
+	expect(getLastFrameFromCache(makeKey('2'))?.byteLength).toBe(
+		10 * 1024 * 1024
+	);
+	expect(getLastFrameFromCache(makeKey('3'))?.byteLength).toBe(
+		10 * 1024 * 1024
+	);
+	expect(getLastFrameFromCache(makeKey('4'))?.byteLength).toBe(
+		10 * 1024 * 1024
+	);
+	expect(getLastFrameFromCache(makeKey('5'))?.byteLength).toBe(
+		10 * 1024 * 1024
+	);
+	expect(getLastFrameFromCache(makeKey('6'))?.byteLength).toBe(
+		10 * 1024 * 1024
+	);
 
 	clearLastFileCache();
 });


### PR DESCRIPTION
Getting the last frame of a video is very non-performant. This adds a cache for it