### PR TITLE
Fix typo in video documenation

### DIFF
--- a/packages/docs/docs/video.md
+++ b/packages/docs/docs/video.md
@@ -41,7 +41,7 @@ export const MyVideo = () => {
 ```
 
 :::note
-During render, Remotion will download the video to include it's audio in the output. If you don't need the audio, you can add the `muted` prop.
+During render, Remotion will download the video to include its audio in the output. If you don't need the audio, you can add the `muted` prop.
 :::
 
 ## Trim video


### PR DESCRIPTION
Fixes a small typo I spotted while browsing the docs.

---

rendered: https://remotion-git-fork-nmattia-nm-fix-typo-remotion.vercel.app/docs/video#remote-video
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
