### PR TITLE
add "object-fit: contain" to <OffthreadVideo> by default

### DIFF
--- a/packages/core/src/video/OffthreadVideoForRendering.tsx
+++ b/packages/core/src/video/OffthreadVideoForRendering.tsx
@@ -20,6 +20,7 @@ export const OffthreadVideoForRendering: React.FC<OffthreadVideoProps> = ({
 	playbackRate,
 	src,
 	muted,
+	style,
 	...props
 }) => {
 	const absoluteFrame = useAbsoluteCurrentFrame();
@@ -120,5 +121,12 @@ export const OffthreadVideoForRendering: React.FC<OffthreadVideoProps> = ({
 			[onError]
 		);
 
-	return <Img src={actualSrc} {...props} onError={onErr} />;
+	const actualStyle: React.CSSProperties = useMemo(() => {
+		return {
+			objectFit: 'contain',
+			...(style ?? {}),
+		};
+	}, [style]);
+
+	return <Img src={actualSrc} style={actualStyle} {...props} onError={onErr} />;
 };


### PR DESCRIPTION
This is the default for a `<video>` tag, it makes sense to put it into the underlying `<img>` tag so that the layout matches in preview and rendering.