### PR TITLE
docs: fix typo

### DIFF
--- a/packages/docs/docs/chromium-flags.md
+++ b/packages/docs/docs/chromium-flags.md
@@ -94,7 +94,7 @@ Accepted values:
 - `"egl"`,
 - `"swiftshader"`
 - `"swangle"`
-- `null` - Chromiums default
+- `null` - Chromium's default
 
 **Default for local rendering**: `null`.  
 **Default for Lambda rendering**: `"swangle"`.

--- a/packages/docs/docs/cli/render.md
+++ b/packages/docs/docs/cli/render.md
@@ -148,7 +148,7 @@ Accepted values:
 - `"egl"`,
 - `"swiftshader"`
 - `"swangle"`
-- `null` - Chromiums default
+- `null` - Chromium's default
 
 **Default for local rendering**: `null`.  
 **Default for Lambda rendering**: `"swangle"`.

--- a/packages/docs/docs/cli/still.md
+++ b/packages/docs/docs/cli/still.md
@@ -108,7 +108,7 @@ Accepted values:
 - `"egl"`,
 - `"swiftshader"`
 - `"swangle"`
-- `null` - Chromiums default
+- `null` - Chromium's default
 
 **Default for local rendering**: `null`.  
 **Default for Lambda rendering**: `"swangle"`.

--- a/packages/docs/docs/dynamic-import.md
+++ b/packages/docs/docs/dynamic-import.md
@@ -36,7 +36,7 @@ We recommend that you put the asset inside the `public/` folder and use `staticF
 
 ## Write dynamic expressions correctly
 
-While the example at the top did not work, Webpck is smart enough to do so if you place your expression inside the `require()` or `import()` statement. In this case, Webpack will automatically bundle all `.png` files in the `assets/image` folder even if the asset is never used.
+While the example at the top did not work, Webpack is smart enough to do so if you place your expression inside the `require()` or `import()` statement. In this case, Webpack will automatically bundle all `.png` files in the `assets/image` folder even if the asset is never used.
 
 The following **does** work:
 

--- a/packages/docs/docs/flickering.md
+++ b/packages/docs/docs/flickering.md
@@ -3,7 +3,7 @@ id: flickering
 title: Flickering
 ---
 
-If your video flickers or suffers from choppyness during rendering, it is an indication that you have a **multi-threading issue**.
+If your video flickers or suffers from choppiness during rendering, it is an indication that you have a **multi-threading issue**.
 
 The rendering process of Remotion works as follows:
 
@@ -28,7 +28,7 @@ Head over to [**the list of integrations**](/docs/third-party) to see if there i
 
 ## Bypass multithreading
 
-If your animation will not break if the frames are rendered in order, users often use the [`--concurrency=1`](/docs/cli/render#--concurrency) flag. This will fix flickering / choppyness in many cases and is a viable path if the effort of refactoring is too big. The drawback of this technique is that it is way slower and that the correct timing of the animations is still not guaranteed.
+If your animation will not break if the frames are rendered in order, users often use the [`--concurrency=1`](/docs/cli/render#--concurrency) flag. This will fix flickering / choppiness in many cases and is a viable path if the effort of refactoring is too big. The drawback of this technique is that it is way slower and that the correct timing of the animations is still not guaranteed.
 
 ## Why Remotion works this way
 

--- a/packages/docs/docs/media-playback-error.md
+++ b/packages/docs/docs/media-playback-error.md
@@ -26,7 +26,7 @@ Unlike Google Chrome, the Chromium Browser does not include proprietary codecs. 
 
 ## Invalid source
 
-Make sure you are trying to load a video that is either available locally or publicly on the internet. Typoing the `src` prop will lead to this error.
+Make sure you are trying to load a video that is either available locally or publicly on the internet. Typing the `src` prop will lead to this error.
 
 ## Other unsupported codecs
 

--- a/packages/docs/docs/player/api.md
+++ b/packages/docs/docs/player/api.md
@@ -228,7 +228,7 @@ If you play the video from a user gesture, pass the `SyntheticEvent` in as an ar
 
 ### `getCurrentFrame()`
 
-Gets the current postition expressed as the current frame. Divide by the `fps` you passed to get the time in seconds.
+Gets the current position expressed as the current frame. Divide by the `fps` you passed to get the time in seconds.
 
 ### `isPlaying()`
 

--- a/packages/docs/docs/player/autoplay.md
+++ b/packages/docs/docs/player/autoplay.md
@@ -45,7 +45,7 @@ export const App: React.FC = () => {
 
 ## Use the `numberOfSharedAudioTags` property
 
-If your audio does not enter the video immediately (say the few seconds of the video are silent, but then the audio fades in), it technically doesn't start based on an user interation. To combat this issue, you can use the [`numberOfSharedAudioTags`](/docs/player/api#numberofsharedaudiotags) property. This will play some silent audio on the first play with user interaction, and then reuse that tag to play your deferred audio playback.
+If your audio does not enter the video immediately (say the few seconds of the video are silent, but then the audio fades in), it technically doesn't start based on an user integration. To combat this issue, you can use the [`numberOfSharedAudioTags`](/docs/player/api#numberofsharedaudiotags) property. This will play some silent audio on the first play with user interaction, and then reuse that tag to play your deferred audio playback.
 
 You can have as many silent audio tags as you want. Set `numberOfSharedAudioTags={2}` to prepare two shared audio tags. Be mindful: If you set this props and you render more [`<Audio/>`](/docs/audio) than there are shared audio tags, an exception will be thrown.
 

--- a/packages/docs/docs/preload/preload-audio.md
+++ b/packages/docs/docs/preload/preload-audio.md
@@ -51,7 +51,7 @@ resolveRedirect(urlToLoad)
     urlToLoad = resolved;
   })
   .catch((err) => {
-    // Was unable to resolve redirect e.g. due to no CORS supoprt
+    // Was unable to resolve redirect e.g. due to no CORS support
     console.log("Could not resolve redirect", err);
   })
   .finally(() => {

--- a/packages/docs/docs/preload/preload-video.md
+++ b/packages/docs/docs/preload/preload-video.md
@@ -53,7 +53,7 @@ resolveRedirect(urlToLoad)
     urlToLoad = resolved;
   })
   .catch((err) => {
-    // Was unable to resolve redirect e.g. due to no CORS supoprt
+    // Was unable to resolve redirect e.g. due to no CORS support
     console.log("Could not resolve redirect", err);
   })
   .finally(() => {

--- a/packages/docs/docs/preload/resolve-redirect.md
+++ b/packages/docs/docs/preload/resolve-redirect.md
@@ -39,7 +39,7 @@ resolveRedirect(urlToLoad)
     urlToLoad = resolved;
   })
   .catch((err) => {
-    // Was unable to resolve redirect e.g. due to no CORS supoprt
+    // Was unable to resolve redirect e.g. due to no CORS support
     console.log("Could not resolve redirect", err);
   })
   .finally(() => {

--- a/packages/docs/docs/register-root.md
+++ b/packages/docs/docs/register-root.md
@@ -6,7 +6,7 @@ title: registerRoot()
 `registerRoot` is a function that registers the root component of the Remotion project. In the root component, one or multiple compositions should be returned (in the case of multiple compositions, they should be wrapped in a React Fragment).
 
 :::info
-`registerRoot()` should live in a file that is separarate from the list of compositions. This is because when using React Fast Refresh, all the code in the file that gets refreshed gets executed again, however, this function should only be called once.
+`registerRoot()` should live in a file that is separate from the list of compositions. This is because when using React Fast Refresh, all the code in the file that gets refreshed gets executed again, however, this function should only be called once.
 :::
 
 ## Example

--- a/packages/docs/docs/renderer/get-compositions.md
+++ b/packages/docs/docs/renderer/get-compositions.md
@@ -183,7 +183,7 @@ Accepted values:
 - `"egl"`,
 - `"swiftshader"`
 - `"swangle"`
-- `null` - Chromiums default
+- `null` - Chromium's default
 
 Default: `null`.
 

--- a/packages/docs/docs/renderer/render-media.md
+++ b/packages/docs/docs/renderer/render-media.md
@@ -58,7 +58,7 @@ Type `node -e "console.log(require('os').cpus().length)"` into your command line
 
 _number | null - optional_
 
-The constant rate factor, controlling the quality. See: [Controllsing quality using the CRF setting.](/docs/encoding/#controlling-quality-using-the-crf-setting)
+The constant rate factor, controlling the quality. See: [Controlling quality using the CRF setting.](/docs/encoding/#controlling-quality-using-the-crf-setting)
 
 ### `imageFormat`
 
@@ -295,7 +295,7 @@ Accepted values:
 - `"egl"`,
 - `"swiftshader"`
 - `"swangle"`
-- `null` - Chromiums default
+- `null` - Chromium's default
 
 **Default for local rendering**: `null`.  
 **Default for Lambda rendering**: `"swangle"`.

--- a/packages/docs/docs/still.md
+++ b/packages/docs/docs/still.md
@@ -3,7 +3,7 @@ id: still
 title: <Still>
 ---
 
-A `<Still />` is a [`<Composition />`](/docs/composition) that is only 1 frame long. It is a convienience component for defining a composition that is meant to be rendered an image rather than a video.
+A `<Still />` is a [`<Composition />`](/docs/composition) that is only 1 frame long. It is a convenience component for defining a composition that is meant to be rendered an image rather than a video.
 
 ## Example
 

--- a/packages/docs/docs/use-audio-data.md
+++ b/packages/docs/docs/use-audio-data.md
@@ -5,7 +5,7 @@ id: use-audio-data
 
 _Part of the `@remotion/media-utils` package of helper functions._
 
-This convienience function wraps the [`getAudioData()`](/docs/get-audio-data) function into a hook and does 3 things:
+This convenience function wraps the [`getAudioData()`](/docs/get-audio-data) function into a hook and does 3 things:
 
 - Keeps the audio data in a state
 - Wraps the function in a [`delayRender()` / `continueRender()`](/docs/data-fetching) pattern.

--- a/packages/docs/docs/using-audio.md
+++ b/packages/docs/docs/using-audio.md
@@ -38,7 +38,7 @@ You can mix multiple tracks together by adding more audio tags.
 ## Cutting or trimming the audio
 
 You can use the [`<Sequence />`](/docs/sequence) API to cut and trim audio.
-As a convienience, the `<Audio />` tag supports the `startFrom` and `endAt` props.
+As a convenience, the `<Audio />` tag supports the `startFrom` and `endAt` props.
 
 ```tsx twoslash {10-11}
 import { Audio } from "remotion";

--- a/packages/docs/docs/visualize-audio.md
+++ b/packages/docs/docs/visualize-audio.md
@@ -5,7 +5,7 @@ id: visualize-audio
 
 _Part of the `@remotion/media-utils` package of helper functions._
 
-This function takes in `AudioData` (preferrably fetched by the [`useAudioData()`](/docs/use-audio-data) hook) and processes it in a way that makes visualizing the audio that is playing at the current frame easy.
+This function takes in `AudioData` (preferably fetched by the [`useAudioData()`](/docs/use-audio-data) hook) and processes it in a way that makes visualizing the audio that is playing at the current frame easy.
 
 ## Arguments
 


### PR DESCRIPTION
1. Fixed "preferrably" to "preferably".
2. Fixed "convienience" to "convenience".
3. Fixed "separarate" to "separate".
4. Fixed "Typoing" to "Typing".
5. Fixed "choppyness" to "choppiness".
6. Fixed "Webpck" to "Webpack".
7. Fixed "Chromiums" to "Chromium's".
8. Fixed "Controllsing" to "Controlling".
9. Fixed "supoprt" to "support".
10. Fixed "postition" to "position".
11. Fixed "interation" to "integration".
