### PR TITLE
`downloadBehavior` attribute for renderMediaOnLambda() and renderStillOnLambda()

### DIFF
--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -157,6 +157,16 @@ _optional, available since v3.1_
 
 [Set the looping behavior.](/docs/config#setnumberofgifloops) This option may only be set when rendering GIFs. [See here for more details.](/docs/render-as-gif#changing-the-number-of-loops)
 
+### `downloadBehavior`
+
+_optional, available since v3.1.3_
+
+How the output file should behave when accessed through the S3 output link in the browser.  
+Either:
+
+- `{"type": "play-in-browser"}` - the default. The video will play in the browser.
+- `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposiion` header will be added which makes the browser download the file. You can optionally override the filename.
+
 #### `disableWebSecurity`
 
 _boolean - default `false`_

--- a/packages/docs/docs/lambda/renderstillonlambda.md
+++ b/packages/docs/docs/lambda/renderstillonlambda.md
@@ -114,6 +114,16 @@ It can either be:
 
 A number describing how long the render may take to resolve all `delayRender()` calls before it times out. Default: `30000`
 
+### `downloadBehavior`
+
+_optional, available since v3.1.3_
+
+How the output file should behave when accessed through the S3 output link in the browser.  
+Either:
+
+- `{"type": "play-in-browser"}` - the default. The video will play in the browser.
+- `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposiion` header will be added which makes the browser download the file. You can optionally override the filename.
+
 ### `chromiumOptions?`
 
 Allows you to set certain Chromium / Google Chrome flags. See: [Chromium flags](/docs/chromium-flags).

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -11,6 +11,7 @@ import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
 import type {OutNameInput, Privacy} from '../shared/constants';
 import {LambdaRoutines} from '../shared/constants';
+import type {DownloadBehavior} from '../shared/content-disposition-header';
 import {convertToServeUrl} from '../shared/convert-to-serve-url';
 import {validateFramesPerLambda} from '../shared/validate-frames-per-lambda';
 import type {LambdaCodec} from '../shared/validate-lambda-codec';
@@ -42,6 +43,7 @@ export type RenderMediaOnLambdaInput = {
 	everyNthFrame?: number;
 	numberOfGifLoops?: number | null;
 	concurrencyPerLambda?: number;
+	downloadBehavior?: DownloadBehavior | null;
 };
 
 export type RenderMediaOnLambdaOutput = {
@@ -93,6 +95,7 @@ export const renderMediaOnLambda = async ({
 	numberOfGifLoops,
 	everyNthFrame,
 	concurrencyPerLambda,
+	downloadBehavior,
 }: RenderMediaOnLambdaInput): Promise<RenderMediaOnLambdaOutput> => {
 	const actualCodec = validateLambdaCodec(codec);
 	validateServeUrl(serveUrl);
@@ -125,6 +128,7 @@ export const renderMediaOnLambda = async ({
 			everyNthFrame: everyNthFrame ?? 1,
 			numberOfGifLoops: numberOfGifLoops ?? 0,
 			concurrencyPerLambda: concurrencyPerLambda ?? 1,
+			downloadBehavior: downloadBehavior ?? {type: 'play-in-browser'},
 		},
 		region,
 	});

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -5,6 +5,7 @@ import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
 import type {CostsInfo, OutNameInput} from '../shared/constants';
 import {DEFAULT_MAX_RETRIES, LambdaRoutines} from '../shared/constants';
+import type {DownloadBehavior} from '../shared/content-disposition-header';
 import {convertToServeUrl} from '../shared/convert-to-serve-url';
 
 export type RenderStillOnLambdaInput = {
@@ -24,6 +25,7 @@ export type RenderStillOnLambdaInput = {
 	timeoutInMilliseconds?: number;
 	chromiumOptions?: ChromiumOptions;
 	scale?: number;
+	downloadBehavior?: DownloadBehavior;
 };
 
 export type RenderStillOnLambdaOutput = {
@@ -68,6 +70,7 @@ export const renderStillOnLambda = async ({
 	timeoutInMilliseconds,
 	chromiumOptions,
 	scale,
+	downloadBehavior,
 }: RenderStillOnLambdaInput): Promise<RenderStillOnLambdaOutput> => {
 	const realServeUrl = await convertToServeUrl(serveUrl, region);
 	const res = await callLambda({
@@ -90,6 +93,7 @@ export const renderStillOnLambda = async ({
 				timeoutInMilliseconds ?? Internals.DEFAULT_PUPPETEER_TIMEOUT,
 			chromiumOptions: chromiumOptions ?? {},
 			scale: scale ?? 1,
+			downloadBehavior: downloadBehavior ?? {type: 'play-in-browser'},
 		},
 		region,
 	});

--- a/packages/lambda/src/functions/chunk-optimization/s3-optimization-file.ts
+++ b/packages/lambda/src/functions/chunk-optimization/s3-optimization-file.ts
@@ -26,6 +26,7 @@ export const writeOptimization = async ({
 		region,
 		privacy: 'private',
 		expectedBucketOwner,
+		downloadBehavior: null,
 	});
 };
 

--- a/packages/lambda/src/functions/helpers/io.ts
+++ b/packages/lambda/src/functions/helpers/io.ts
@@ -1,9 +1,8 @@
-import type {
-	_Object} from '@aws-sdk/client-s3';
+import type {_Object} from '@aws-sdk/client-s3';
 import {
 	GetObjectCommand,
 	ListObjectsV2Command,
-	PutObjectCommand
+	PutObjectCommand,
 } from '@aws-sdk/client-s3';
 import type {ReadStream} from 'fs';
 import mimeTypes from 'mime-types';
@@ -11,6 +10,7 @@ import type {Readable} from 'stream';
 import type {AwsRegion} from '../../pricing/aws-regions';
 import {getS3Client} from '../../shared/aws-clients';
 import type {Privacy} from '../../shared/constants';
+import type {DownloadBehavior} from '../../shared/content-disposition-header';
 
 export type LambdaLSInput = {
 	bucketName: string;
@@ -87,6 +87,7 @@ export const lambdaWriteFile = async ({
 	region: AwsRegion;
 	privacy: Privacy;
 	expectedBucketOwner: string | null;
+	downloadBehavior: DownloadBehavior | null;
 }): Promise<void> => {
 	await getS3Client(region).send(
 		new PutObjectCommand({

--- a/packages/lambda/src/functions/helpers/write-lambda-error.ts
+++ b/packages/lambda/src/functions/helpers/write-lambda-error.ts
@@ -1,7 +1,7 @@
 import {getErrorFileName} from '../../shared/constants';
 import {getCurrentRegionInFunction} from './get-current-region';
 import type {FileNameAndSize} from './get-files-in-folder';
-import { getFolderFiles} from './get-files-in-folder';
+import {getFolderFiles} from './get-files-in-folder';
 import {lambdaWriteFile} from './io';
 import {errorIsOutOfSpaceError} from './is-enosp-err';
 
@@ -64,5 +64,6 @@ export const writeLambdaError = async ({
 		region: getCurrentRegionInFunction(),
 		privacy: 'private',
 		expectedBucketOwner,
+		downloadBehavior: null,
 	});
 };

--- a/packages/lambda/src/functions/helpers/write-post-render-data.ts
+++ b/packages/lambda/src/functions/helpers/write-post-render-data.ts
@@ -1,6 +1,6 @@
 import type {AwsRegion} from '../../pricing/aws-regions';
 import type {PostRenderData} from '../../shared/constants';
-import { postRenderDataKey} from '../../shared/constants';
+import {postRenderDataKey} from '../../shared/constants';
 import {lambdaWriteFile} from './io';
 
 export const writePostRenderData = async ({
@@ -23,5 +23,6 @@ export const writePostRenderData = async ({
 		body: JSON.stringify(postRenderData),
 		expectedBucketOwner,
 		region,
+		downloadBehavior: null,
 	});
 };

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -212,6 +212,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		region: getCurrentRegionInFunction(),
 		privacy: 'private',
 		expectedBucketOwner: options.expectedBucketOwner,
+		downloadBehavior: null,
 	});
 
 	await Promise.all(
@@ -263,6 +264,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 			region: getCurrentRegionInFunction(),
 			privacy: 'private',
 			expectedBucketOwner: options.expectedBucketOwner,
+			downloadBehavior: null,
 		}).catch((err) => {
 			writeLambdaError({
 				bucketName: params.bucketName,
@@ -319,6 +321,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		region: getCurrentRegionInFunction(),
 		privacy: params.privacy,
 		expectedBucketOwner: options.expectedBucketOwner,
+		downloadBehavior: params.downloadBehavior,
 	});
 
 	let chunkProm: Promise<unknown> = Promise.resolve();
@@ -385,6 +388,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		region: getCurrentRegionInFunction(),
 		privacy: 'private',
 		expectedBucketOwner: options.expectedBucketOwner,
+		downloadBehavior: null,
 	});
 
 	const errorExplanationsProm = inspectErrors({

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -132,6 +132,7 @@ const renderHandler = async (
 				}),
 				region: getCurrentRegionInFunction(),
 				expectedBucketOwner: options.expectedBucketOwner,
+				downloadBehavior: null,
 			});
 		},
 		puppeteerInstance: browserInstance,
@@ -185,6 +186,7 @@ const renderHandler = async (
 		region: getCurrentRegionInFunction(),
 		privacy: params.privacy,
 		expectedBucketOwner: options.expectedBucketOwner,
+		downloadBehavior: null,
 	});
 	await Promise.all([
 		fs.promises.rm(outputLocation, {recursive: true}),
@@ -192,15 +194,16 @@ const renderHandler = async (
 		lambdaWriteFile({
 			bucketName: params.bucketName,
 			body: JSON.stringify(condensedTimingData as ChunkTimingData, null, 2),
-			key: `${lambdaTimingsKey({
+			key: lambdaTimingsKey({
 				renderId: params.renderId,
 				chunk: params.chunk,
 				rendered: endRendered,
 				start,
-			})}`,
+			}),
 			region: getCurrentRegionInFunction(),
 			privacy: 'private',
 			expectedBucketOwner: options.expectedBucketOwner,
+			downloadBehavior: null,
 		}),
 	]);
 };

--- a/packages/lambda/src/functions/start.ts
+++ b/packages/lambda/src/functions/start.ts
@@ -43,6 +43,7 @@ export const startHandler = async (params: LambdaPayload) => {
 		numberOfGifLoops: params.numberOfGifLoops,
 		everyNthFrame: params.everyNthFrame,
 		concurrencyPerLambda: params.concurrencyPerLambda,
+		downloadBehavior: params.downloadBehavior,
 	};
 	await getLambdaClient(getCurrentRegionInFunction()).send(
 		new InvokeCommand({

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -110,6 +110,7 @@ const innerStillHandler = async (
 		region: getCurrentRegionInFunction(),
 		privacy: 'private',
 		expectedBucketOwner: options.expectedBucketOwner,
+		downloadBehavior: null,
 	});
 
 	await renderStill({
@@ -143,6 +144,7 @@ const innerStillHandler = async (
 		body: fs.createReadStream(outputPath),
 		expectedBucketOwner: options.expectedBucketOwner,
 		region: getCurrentRegionInFunction(),
+		downloadBehavior: lambdaParams.downloadBehavior,
 	});
 	await fs.promises.rm(outputPath, {recursive: true});
 

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -11,6 +11,7 @@ import type {
 import type {ChunkRetry} from '../functions/helpers/get-retry-stats';
 import type {EnhancedErrorInfo} from '../functions/helpers/write-lambda-error';
 import type {AwsRegion} from '../pricing/aws-regions';
+import type {DownloadBehavior} from './content-disposition-header';
 import type {ExpensiveChunk} from './get-most-expensive-chunks';
 import type {LambdaArchitecture} from './validate-architecture';
 import type {LambdaCodec} from './validate-lambda-codec';
@@ -198,6 +199,7 @@ export type LambdaPayloads = {
 		everyNthFrame: number;
 		numberOfGifLoops: number | null;
 		concurrencyPerLambda: number;
+		downloadBehavior: DownloadBehavior;
 	};
 	launch: {
 		type: LambdaRoutines.launch;
@@ -225,6 +227,7 @@ export type LambdaPayloads = {
 		everyNthFrame: number;
 		numberOfGifLoops: number | null;
 		concurrencyPerLambda: number;
+		downloadBehavior: DownloadBehavior;
 	};
 	status: {
 		type: LambdaRoutines.status;
@@ -278,6 +281,7 @@ export type LambdaPayloads = {
 		timeoutInMilliseconds: number;
 		chromiumOptions: ChromiumOptions;
 		scale: number;
+		downloadBehavior: DownloadBehavior | null;
 	};
 };
 

--- a/packages/lambda/src/shared/content-disposition-header.ts
+++ b/packages/lambda/src/shared/content-disposition-header.ts
@@ -1,0 +1,30 @@
+// By setting the Content-Disposition header in an S3 object,
+// you can control if the user downloads the item if you
+// visit the link
+
+export type DownloadBehavior =
+	| {
+			type: 'play-in-browser';
+	  }
+	| {
+			type: 'download';
+			fileName: string | null;
+	  };
+
+export const getContentDispositionHeader = (
+	behavior: DownloadBehavior | null
+): string | undefined => {
+	if (behavior === null) {
+		return undefined;
+	}
+
+	if (behavior.type === 'play-in-browser') {
+		return undefined;
+	}
+
+	if (behavior.fileName === null) {
+		return `attachment`;
+	}
+
+	return `attachment; filename="${behavior.fileName}"`;
+};

--- a/packages/lambda/src/shared/validate-download-behavior.ts
+++ b/packages/lambda/src/shared/validate-download-behavior.ts
@@ -1,0 +1,26 @@
+import type {DownloadBehavior} from './content-disposition-header';
+
+export const validateDownloadBehavior = (downloadBehavior: unknown) => {
+	if (downloadBehavior === null || downloadBehavior === undefined) {
+		return null;
+	}
+
+	if (typeof downloadBehavior !== 'object') {
+		throw new Error('downloadBehavior must be null or an object');
+	}
+
+	const behavior = downloadBehavior as DownloadBehavior;
+	if (behavior.type !== 'download' && behavior.type !== 'play-in-browser') {
+		throw new Error(
+			'Download behavior must be either "download" or "play-in-browser"'
+		);
+	}
+
+	if (behavior.type === 'download') {
+		if (typeof behavior.fileName !== 'string' && behavior.fileName !== null) {
+			throw new Error(
+				'If "downloadBehavior.type" is "download", then fileName must be "null" or a string'
+			);
+		}
+	}
+};

--- a/packages/lambda/src/test/integration/renders/gif.test.ts
+++ b/packages/lambda/src/test/integration/renders/gif.test.ts
@@ -55,6 +55,7 @@ test('Should make a distributed GIF', async () => {
 			numberOfGifLoops: null,
 			everyNthFrame: 2,
 			concurrencyPerLambda: 1,
+			downloadBehavior: {type: 'play-in-browser'},
 		},
 		extraContext
 	);

--- a/packages/lambda/src/test/integration/renders/old-version.test.ts
+++ b/packages/lambda/src/test/integration/renders/old-version.test.ts
@@ -51,6 +51,9 @@ test('Should be able to render to another bucket', async () => {
 			numberOfGifLoops: null,
 			everyNthFrame: 1,
 			concurrencyPerLambda: 1,
+			downloadBehavior: {
+				type: 'play-in-browser',
+			},
 		},
 		extraContext
 	);

--- a/packages/lambda/src/test/integration/renders/other-bucket.test.ts
+++ b/packages/lambda/src/test/integration/renders/other-bucket.test.ts
@@ -56,6 +56,9 @@ test('Should be able to render to another bucket', async () => {
 			numberOfGifLoops: null,
 			everyNthFrame: 1,
 			concurrencyPerLambda: 1,
+			downloadBehavior: {
+				type: 'play-in-browser',
+			},
 		},
 		extraContext
 	);

--- a/packages/lambda/src/test/integration/renders/silent-audio.test.ts
+++ b/packages/lambda/src/test/integration/renders/silent-audio.test.ts
@@ -53,6 +53,9 @@ test('Should add silent audio if there is no audio', async () => {
 			numberOfGifLoops: null,
 			everyNthFrame: 1,
 			concurrencyPerLambda: 1,
+			downloadBehavior: {
+				type: 'play-in-browser',
+			},
 		},
 		extraContext
 	);

--- a/packages/lambda/src/test/integration/renders/transparent-webm.test.ts
+++ b/packages/lambda/src/test/integration/renders/transparent-webm.test.ts
@@ -55,6 +55,9 @@ test('Should make a transparent video', async () => {
 			numberOfGifLoops: null,
 			everyNthFrame: 1,
 			concurrencyPerLambda: 1,
+			downloadBehavior: {
+				type: 'play-in-browser',
+			},
 		},
 		extraContext
 	);


### PR DESCRIPTION
_optional, available since v3.1.3_

How the output file should behave when accessed through the S3 output link in the browser.  
Either:

- `{"type": "play-in-browser"}` - the default. The video will play in the browser.
- `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposiion` header will be added which makes the browser download the file. You can optionally override the filename.
