### PR TITLE
Fix minor docs issues

### DIFF
--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -165,7 +165,7 @@ How the output file should behave when accessed through the S3 output link in th
 Either:
 
 - `{"type": "play-in-browser"}` - the default. The video will play in the browser.
-- `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposiion` header will be added which makes the browser download the file. You can optionally override the filename.
+- `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposition` header will be added which makes the browser download the file. You can optionally override the filename.
 
 ### `disableWebSecurity`
 

--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -167,19 +167,19 @@ Either:
 - `{"type": "play-in-browser"}` - the default. The video will play in the browser.
 - `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposition` header will be added which makes the browser download the file. You can optionally override the filename.
 
-### `disableWebSecurity`
+#### `disableWebSecurity`
 
 _boolean - default `false`_
 
 This will most notably disable CORS among other security features.
 
-### `ignoreCertificateErrors`
+#### `ignoreCertificateErrors`
 
 _boolean - default `false`_
 
 Results in invalid SSL certificates, such as self-signed ones, being ignored.
 
-### `gl`
+#### `gl`
 
 _string_
 

--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -157,7 +157,7 @@ _optional, available since v3.1_
 
 [Set the looping behavior.](/docs/config#setnumberofgifloops) This option may only be set when rendering GIFs. [See here for more details.](/docs/render-as-gif#changing-the-number-of-loops)
 
-### `downloadBehavior`
+### `downloadBehavior?`
 
 _optional, available since v3.1.3_
 
@@ -167,19 +167,19 @@ Either:
 - `{"type": "play-in-browser"}` - the default. The video will play in the browser.
 - `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposiion` header will be added which makes the browser download the file. You can optionally override the filename.
 
-#### `disableWebSecurity`
+### `disableWebSecurity`
 
 _boolean - default `false`_
 
 This will most notably disable CORS among other security features.
 
-#### `ignoreCertificateErrors`
+### `ignoreCertificateErrors`
 
 _boolean - default `false`_
 
 Results in invalid SSL certificates, such as self-signed ones, being ignored.
 
-#### `gl`
+### `gl`
 
 _string_
 

--- a/packages/docs/docs/lambda/renderstillonlambda.md
+++ b/packages/docs/docs/lambda/renderstillonlambda.md
@@ -114,7 +114,7 @@ It can either be:
 
 A number describing how long the render may take to resolve all `delayRender()` calls before it times out. Default: `30000`
 
-### `downloadBehavior`
+### `downloadBehavior`
 
 _optional, available since v3.1.3_
 
@@ -122,7 +122,7 @@ How the output file should behave when accessed through the S3 output link in th
 Either:
 
 - `{"type": "play-in-browser"}` - the default. The video will play in the browser.
-- `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposiion` header will be added which makes the browser download the file. You can optionally override the filename.
+- `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposition` header will be added which makes the browser download the file. You can optionally override the filename.
 
 ### `chromiumOptions?`
 


### PR DESCRIPTION
The markup was rendering incorrectly for the new `downloadBehavior`. I think the backticks were types before the hashes, which apparently confuses the parser.

Previous:
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/5115526/180478289-80a58488-e331-44d6-899c-67b746ba2f9e.png">

New:
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/5115526/180476824-cf59ffe1-50d5-4201-a4f1-24304c5b1992.png">

