### PR TITLE
remove requirement to have exactly as many launch files as expected

### DIFF
--- a/packages/lambda/src/functions/helpers/create-post-render-data.ts
+++ b/packages/lambda/src/functions/helpers/create-post-render-data.ts
@@ -1,12 +1,10 @@
 import type {_Object} from '@aws-sdk/client-s3';
 import {estimatePrice} from '../../api/estimate-price';
 import type {AwsRegion} from '../../pricing/aws-regions';
-import type {
-	PostRenderData,
-	RenderMetadata} from '../../shared/constants';
+import type {PostRenderData, RenderMetadata} from '../../shared/constants';
 import {
 	lambdaTimingsPrefix,
-	MAX_EPHEMERAL_STORAGE_IN_MB
+	MAX_EPHEMERAL_STORAGE_IN_MB,
 } from '../../shared/constants';
 import {
 	getMostExpensiveChunks,
@@ -89,7 +87,6 @@ export const createPostRenderData = ({
 	const {timeToInvokeLambdas} = getLambdasInvokedStats(
 		contents,
 		renderId,
-		renderMetadata?.estimatedRenderLambdaInvokations ?? null,
 		renderMetadata.startedDate
 	);
 	const retriesInfo = getRetryStats({contents, renderId});

--- a/packages/lambda/src/functions/helpers/get-lambdas-invoked-stats.ts
+++ b/packages/lambda/src/functions/helpers/get-lambdas-invoked-stats.ts
@@ -1,35 +1,28 @@
 import type {_Object} from '@aws-sdk/client-s3';
 import {lambdaInitializedPrefix} from '../../shared/constants';
-import {parseLambdaInitializedKey} from '../../shared/parse-lambda-initialized-key';
 import {max} from './min-max';
 
 export type LambdaInvokeStats = {
 	timeToInvokeLambdas: number | null;
-	allLambdasInvoked: boolean;
 	lambdasInvoked: number;
 };
 
 export const getLambdasInvokedStats = (
 	contents: _Object[],
 	renderId: string,
-	estimatedRenderLambdaInvokations: number | null,
 	startDate: number | null
 ): LambdaInvokeStats => {
-	const lambdasInvoked = contents
-		.filter((c) => c.Key?.startsWith(lambdaInitializedPrefix(renderId)))
-		.filter((c) => parseLambdaInitializedKey(c.Key as string).attempt === 1);
-	const allLambdasInvoked =
-		lambdasInvoked.length === estimatedRenderLambdaInvokations;
+	const lambdasInvoked = contents.filter((c) =>
+		c.Key?.startsWith(lambdaInitializedPrefix(renderId))
+	);
 
 	const timeToInvokeLambdas =
-		allLambdasInvoked && startDate
-			? max(lambdasInvoked.map((l) => l.LastModified?.getTime() as number)) -
-			  startDate
-			: null;
-
+		startDate === null
+			? null
+			: max(lambdasInvoked.map((l) => l.LastModified?.getTime() as number)) -
+			  startDate;
 	return {
 		timeToInvokeLambdas,
-		allLambdasInvoked,
 		lambdasInvoked: lambdasInvoked.length,
 	};
 };

--- a/packages/lambda/src/functions/helpers/get-progress.ts
+++ b/packages/lambda/src/functions/helpers/get-progress.ts
@@ -1,7 +1,6 @@
 import {Internals} from 'remotion';
 import type {AwsRegion} from '../../pricing/aws-regions';
-import type {
-	RenderProgress} from '../../shared/constants';
+import type {RenderProgress} from '../../shared/constants';
 import {
 	chunkKey,
 	encodingProgressKey,
@@ -181,7 +180,6 @@ export const getProgress = async ({
 	const lambdasInvokedStats = getLambdasInvokedStats(
 		contents,
 		renderId,
-		renderMetadata?.estimatedRenderLambdaInvokations ?? null,
 		renderMetadata?.startedDate ?? null
 	);
 

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -378,7 +378,6 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		timeToInvoke: getLambdasInvokedStats(
 			contents,
 			params.renderId,
-			renderMetadata.estimatedRenderLambdaInvokations,
 			renderMetadata.startedDate
 		).timeToInvokeLambdas,
 	};
@@ -412,7 +411,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		jobs,
 	});
 
-	const postRenderData = await createPostRenderData({
+	const postRenderData = createPostRenderData({
 		expectedBucketOwner: options.expectedBucketOwner,
 		region: getCurrentRegionInFunction(),
 		renderId: params.renderId,


### PR DESCRIPTION
It fails in production and is not critical. Also one can argue the cost calculation will be more accurate since it factors in retries