### PR TITLE
New ESLint rules for staticFile + GIFs

### DIFF
--- a/packages/cli/src/preview-server/error-overlay/remotion-overlay/Button.tsx
+++ b/packages/cli/src/preview-server/error-overlay/remotion-overlay/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {
 	INPUT_BACKGROUND,
 	INPUT_BORDER_COLOR_UNHOVERED,
@@ -25,9 +25,21 @@ export const Button: React.FC<{
 	onClick: () => void;
 	disabled?: boolean;
 	children: React.ReactNode;
-}> = ({children, onClick, disabled}) => {
+	style?: React.CSSProperties;
+}> = ({children, onClick, disabled, style}) => {
+	const combined = useMemo(() => {
+		return {
+			...button,
+			...(style ?? {}),
+		};
+	}, [style]);
 	return (
-		<button style={button} type="button" disabled={disabled} onClick={onClick}>
+		<button
+			style={combined}
+			type="button"
+			disabled={disabled}
+			onClick={onClick}
+		>
 			<div style={buttonContainer}>{children}</div>
 		</button>
 	);

--- a/packages/cli/src/preview-server/error-overlay/remotion-overlay/HelpLink.tsx
+++ b/packages/cli/src/preview-server/error-overlay/remotion-overlay/HelpLink.tsx
@@ -4,6 +4,11 @@ import {Button} from './Button';
 import type {THelpLink} from './get-help-link';
 import {ShortcutHint} from './ShortcutHint';
 
+const buttonStyle: React.CSSProperties = {
+	backgroundColor: 'var(--blue)',
+	color: 'white',
+};
+
 export const HelpLink: React.FC<{
 	canHaveKeyboardShortcuts: boolean;
 	link: THelpLink;
@@ -32,7 +37,7 @@ export const HelpLink: React.FC<{
 	}, [canHaveKeyboardShortcuts, openLink, registerKeybinding]);
 
 	return (
-		<Button onClick={openLink}>
+		<Button style={buttonStyle} onClick={openLink}>
 			Help: {'"'}
 			{link.title}
 			{'"'}

--- a/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
+++ b/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
@@ -36,5 +36,12 @@ export const getHelpLink = (message: string): THelpLink | null => {
 		};
 	}
 
+	if (message.includes('https://remotion.dev/docs/non-seekable-media')) {
+		return {
+			title: 'Non-seekable media',
+			url: 'https://remotion.dev/docs/non-seekable-media',
+		};
+	}
+
 	return null;
 };

--- a/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
+++ b/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
@@ -22,5 +22,12 @@ export const getHelpLink = (message: string): THelpLink | null => {
 		};
 	}
 
+	if (message.includes('https://remotion.dev/docs/staticfile-relative-paths')) {
+		return {
+			title: 'staticFile() relative paths',
+			url: 'https://remotion.dev/docs/staticfile-relative-paths',
+		};
+	}
+
 	return null;
 };

--- a/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
+++ b/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
@@ -29,5 +29,12 @@ export const getHelpLink = (message: string): THelpLink | null => {
 		};
 	}
 
+	if (message.includes('https://remotion.dev/docs/staticfile-remote-urls')) {
+		return {
+			title: 'staticFile() remote URLs',
+			url: 'https://remotion.dev/docs/staticfile-remote-urls',
+		};
+	}
+
 	return null;
 };

--- a/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
+++ b/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
@@ -43,5 +43,12 @@ export const getHelpLink = (message: string): THelpLink | null => {
 		};
 	}
 
+	if (message.includes('https://remotion.dev/docs/media-playback-error')) {
+		return {
+			title: 'Media playback error',
+			url: 'https://remotion.dev/docs/media-playback-error',
+		};
+	}
+
 	return null;
 };

--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -16,6 +16,12 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 > = ({onError, ...props}, ref) => {
 	const imageRef = useRef<HTMLImageElement>(null);
 
+	if (props.src?.endsWith('.gif')) {
+		throw new TypeError(
+			'The <Img> component does not support GIFs. Use the <Gif> instead: https://remotion.dev/docs/gif'
+		);
+	}
+
 	useImperativeHandle(ref, () => {
 		return imageRef.current as HTMLImageElement;
 	});

--- a/packages/core/src/audio/Audio.tsx
+++ b/packages/core/src/audio/Audio.tsx
@@ -19,7 +19,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 		(e) => {
 			console.log(e.currentTarget.error);
 			throw new Error(
-				`Could not play audio with src ${otherProps.src}: ${e.currentTarget.error}`
+				`Could not play audio with src ${otherProps.src}: ${e.currentTarget.error}. See https://remotion.dev/docs/media-playback-error for help.`
 			);
 		},
 		[otherProps.src]

--- a/packages/core/src/static-file.ts
+++ b/packages/core/src/static-file.ts
@@ -15,6 +15,12 @@ const inner = (path: string): string => {
 };
 
 export const staticFile = (path: string) => {
+	if (path.startsWith('http://') || path.startsWith('https://')) {
+		throw new TypeError(
+			`staticFile() does not support remote URLs - got "${path}". Instead, pass the URL without wrapping it in staticFile(). See: https://remotion.dev/docs/staticfile-remote-urls`
+		);
+	}
+
 	if (path.startsWith('..') || path.startsWith('./')) {
 		throw new TypeError(
 			`staticFile() does not support relative paths - got "${path}". Instead, pass the name of a file that is inside the public/ folder. See: https://remotion.dev/docs/staticfile-relative-paths`

--- a/packages/core/src/static-file.ts
+++ b/packages/core/src/static-file.ts
@@ -15,6 +15,12 @@ const inner = (path: string): string => {
 };
 
 export const staticFile = (path: string) => {
+	if (path.startsWith('..') || path.startsWith('./')) {
+		throw new TypeError(
+			`staticFile() does not support relative paths - got "${path}". Instead, pass the name of a file that is inside the public/ folder. See: https://remotion.dev/docs/staticfile-relative-paths`
+		);
+	}
+
 	const preparsed = inner(path);
 	if (!preparsed.startsWith('/')) {
 		return `/${preparsed}`;

--- a/packages/core/src/video/VideoForDevelopment.tsx
+++ b/packages/core/src/video/VideoForDevelopment.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, useImperativeHandle, useRef} from 'react';
+import React, {forwardRef, useEffect, useImperativeHandle, useRef} from 'react';
 import {useFrameForVolumeProp} from '../audio/use-audio-frame';
 import {useMediaInTimeline} from '../use-media-in-timeline';
 import {useMediaPlayback} from '../use-media-playback';
@@ -60,6 +60,29 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 	useImperativeHandle(ref, () => {
 		return videoRef.current as HTMLVideoElement;
 	});
+
+	useEffect(() => {
+		const {current} = videoRef;
+		if (!current) {
+			return;
+		}
+
+		const errorHandler = () => {
+			if (current?.error) {
+				console.error('Error occurred in video', current?.error);
+				throw new Error(
+					`The browser threw an error while playing the video: Code ${current.error.code} - ${current?.error?.message}. See https://remotion.dev/docs/media-playback-error for help`
+				);
+			} else {
+				throw new Error('The browser threw an error');
+			}
+		};
+
+		current.addEventListener('error', errorHandler, {once: true});
+		return () => {
+			current.removeEventListener('error', errorHandler);
+		};
+	}, []);
 
 	return (
 		<video

--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -101,7 +101,8 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 	});
 
 	useEffect(() => {
-		if (!videoRef.current) {
+		const {current} = videoRef;
+		if (!current) {
 			return;
 		}
 
@@ -121,67 +122,66 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 			return;
 		}
 
-		if (isApproximatelyTheSame(videoRef.current.currentTime, currentTime)) {
-			if (videoRef.current.readyState >= 2) {
+		if (isApproximatelyTheSame(current.currentTime, currentTime)) {
+			if (current.readyState >= 2) {
 				continueRender(handle);
 				return;
 			}
 
-			videoRef.current.addEventListener(
-				'loadeddata',
-				() => {
-					continueRender(handle);
-				},
-				{once: true}
-			);
-			return;
+			const loadedDataHandler = () => {
+				continueRender(handle);
+			};
+
+			current.addEventListener('loadeddata', loadedDataHandler, {once: true});
+			return () => {
+				current.removeEventListener('loadeddata', loadedDataHandler);
+			};
 		}
 
-		videoRef.current.currentTime = currentTime;
+		current.currentTime = currentTime;
 
-		videoRef.current.addEventListener(
-			'seeked',
-			() => {
-				warnAboutNonSeekableMedia(videoRef.current, 'exception');
+		const seekedHandler = () => {
+			warnAboutNonSeekableMedia(current, 'exception');
 
-				if (window.navigator.platform.startsWith('Mac')) {
-					// Improve me: This is ensures frame perfectness but slows down render.
-					// Please see this issue for context: https://github.com/remotion-dev/remotion/issues/200
+			if (window.navigator.platform.startsWith('Mac')) {
+				// Improve me: This is ensures frame perfectness but slows down render.
+				// Please see this issue for context: https://github.com/remotion-dev/remotion/issues/200
 
-					// Only affects macOS since it uses VideoToolbox decoding.
-					setTimeout(() => {
-						continueRender(handle);
-					}, 100);
-				} else {
+				// Only affects macOS since it uses VideoToolbox decoding.
+				setTimeout(() => {
 					continueRender(handle);
-				}
-			},
-			{once: true}
-		);
-		videoRef.current.addEventListener(
-			'ended',
-			() => {
+				}, 100);
+			} else {
 				continueRender(handle);
-			},
-			{once: true}
-		);
-		videoRef.current.addEventListener(
-			'error',
-			() => {
-				if (videoRef.current?.error) {
-					console.error('Error occurred in video', videoRef.current?.error);
-					throw new Error(
-						`The browser threw an error while playing the video: Code ${videoRef.current.error.code} - ${videoRef.current?.error?.message}`
-					);
-				} else {
-					throw new Error('The browser threw an error');
-				}
-			},
-			{once: true}
-		);
+			}
+		};
+
+		current.addEventListener('seeked', seekedHandler, {once: true});
+
+		const endedHandler = () => {
+			continueRender(handle);
+		};
+
+		current.addEventListener('ended', endedHandler, {once: true});
+
+		const errorHandler = () => {
+			if (current?.error) {
+				console.error('Error occurred in video', current?.error);
+				throw new Error(
+					`The browser threw an error while playing the video: Code ${current.error.code} - ${current?.error?.message}. See https://remotion.dev/docs/media-playback-error for help`
+				);
+			} else {
+				throw new Error('The browser threw an error');
+			}
+		};
+
+		current.addEventListener('error', errorHandler, {once: true});
 
 		// If video skips to another frame or unmounts, we clear the created handle
 		return () => {
+			current.removeEventListener('ended', endedHandler);
+			current.removeEventListener('error', errorHandler);
+			current.removeEventListener('seeked', seekedHandler);
 			continueRender(handle);
 		};
 	}, [

--- a/packages/docs/docs/media-playback-error.md
+++ b/packages/docs/docs/media-playback-error.md
@@ -7,13 +7,13 @@ sidebar_label: Media playback error
 The following error may occur in your Remotion project during development or while rendering:
 
 ```diff
-- Error: Could not play video with src [source]
+- Error: Could not play video with src [source] [object MediaError]
 ```
 
 or
 
 ```diff
-- Error: Could not play audio with src [source]
+- Error: Could not play audio with src [source] [object MediaError]
 ```
 
 This error happens when you are trying to embed a `<Video/>` or `<Audio/>` tag in your Remotion project but the browser is unable to load and play the media. Although the browser does not report the exact error, there are two common reasons for this error.
@@ -22,11 +22,25 @@ This error happens when you are trying to embed a `<Video/>` or `<Audio/>` tag i
 
 Unlike Google Chrome, the Chromium Browser does not include proprietary codecs. This means you cannot play MP4/H.264 videos and some audio codecs (more codecs may not be supported).
 
-**Workaround**: Convert videos to WebM or [use Chrome instead of Chromium](/docs/config#setbrowserexecutable).
+**Workaround**: Convert videos to WebM, [use Chrome instead of Chromium](/docs/config#setbrowserexecutable), or use [`<OffthreadVideo>`](/docs/offthreadvideo).
 
 ## Invalid source
 
-Make sure you are trying to load a video that is either available locally or publicly on the internet. Typing the `src` prop will lead to this error.
+Make sure you are trying to load a video that is either available locally or publicly on the internet. Open the DevTools, go to the Network tab, track the asset being loaded, and open it in a new tab. Does it actually start playing?
+
+## Wrong headers or status code
+
+In order for the browser being able to play the media, it should be loaded with:
+
+- a 200 status code
+- a suitable `Content-Type` header
+- A `Content-Range` header in order to support seeking.
+
+Open the DevTools and go to the network tab to validate that this is the case.
+
+## Internet Download Manager
+
+[Internet Download Manager](https://www.internetdownloadmanager.com/) is known to manipulate the network traffic causing problems for the browser to load media. Disable it if you have it.
 
 ## Other unsupported codecs
 

--- a/packages/docs/docs/static-file-relative-paths.md
+++ b/packages/docs/docs/static-file-relative-paths.md
@@ -1,0 +1,34 @@
+---
+id: staticfile-relative-paths
+title: staticFile() does not support relative paths
+sidebar_label: staticFile() relative paths
+---
+
+If you got the following error message:
+
+```
+staticFile() does not support relative paths. Instead, pass the name of a file that is inside the public/ folder.
+```
+
+You have tried to pass a relative path to `staticFile()`:
+
+```tsx twoslash title="❌ Relative path"
+import { staticFile } from "remotion";
+staticFile("../public/image.png");
+```
+
+```tsx twoslash title="❌ File should not have ./ prefix"
+import { staticFile } from "remotion";
+staticFile("./image.png");
+```
+
+Instead, pass the name of the file that is inside the public folder directly:
+
+```tsx twoslash title="✅ Filename"
+import { staticFile } from "remotion";
+staticFile("image.png");
+```
+
+## See also
+
+- [`staticFile()`](/docs/staticfile)

--- a/packages/docs/docs/static-file-remote-urls.md
+++ b/packages/docs/docs/static-file-remote-urls.md
@@ -1,0 +1,35 @@
+---
+id: staticfile-remote-urls
+title: staticFile() does not support remote URLs
+sidebar_label: staticFile() remote URLs
+---
+
+If you got the following error message:
+
+```
+staticFile() does not support remote URLs. Instead, pass the URL without wrapping it in staticFile().
+```
+
+You have tried to pass a remote URL to `staticFile()`. You don't need to wrap the path in `staticFile`, you can pass it directly:
+
+```tsx twoslash title="❌ Remote URL inside staticFile()"
+import { Img, staticFile } from "remotion";
+
+const MyComp = () => {
+  return <Img src={staticFile("https://example.com/image.png")} />;
+};
+```
+
+Instead, :
+
+```tsx twoslash title="✅ Remote URL passed directly"
+import { Img } from "remotion";
+
+const MyComp = () => {
+  return <Img src={"https://example.com/image.png"} />;
+};
+```
+
+## See also
+
+- [`staticFile()`](/docs/staticfile)

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -272,6 +272,7 @@ module.exports = {
         "enametoolong",
         "slow-method-to-extract-frame",
         "wrong-composition-mount",
+        "staticfile-relative-paths",
       ],
     },
     {

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -273,6 +273,7 @@ module.exports = {
         "slow-method-to-extract-frame",
         "wrong-composition-mount",
         "staticfile-relative-paths",
+        "staticfile-remote-urls",
       ],
     },
     {

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -3,6 +3,7 @@ import evenDimensions from "./rules/even-dimensions";
 import durationInFrames from "./rules/no-duration-frames-infinity";
 import nomp4Import from "./rules/no-mp4-import";
 import noStringAssets from "./rules/no-string-assets";
+import staticFileNoRelative from "./rules/staticfile-no-relative";
 import useGifComponent from "./rules/use-gif-component";
 import volumeCallback from "./rules/volume-callback";
 import warnNativeMediaTag from "./rules/warn-native-media-tag";
@@ -16,6 +17,7 @@ const rules = {
   "duration-in-frames": durationInFrames,
   "volume-callback": volumeCallback,
   "use-gif-component": useGifComponent,
+  "staticfile-no-relative": staticFileNoRelative,
 };
 
 export = {
@@ -31,6 +33,7 @@ export = {
         "@remotion/duration-in-frames": "error",
         "@remotion/volume-callback": "error",
         "@remotion/use-gif-component": "error",
+        "@remotion/staticfile-no-relative": "error",
       },
     },
   },

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,10 +1,11 @@
 import deterministicRandomness from "./rules/deterministic-randomness";
 import evenDimensions from "./rules/even-dimensions";
+import durationInFrames from "./rules/no-duration-frames-infinity";
 import nomp4Import from "./rules/no-mp4-import";
 import noStringAssets from "./rules/no-string-assets";
-import warnNativeMediaTag from "./rules/warn-native-media-tag";
-import durationInFrames from "./rules/no-duration-frames-infinity";
+import useGifComponent from "./rules/use-gif-component";
 import volumeCallback from "./rules/volume-callback";
+import warnNativeMediaTag from "./rules/warn-native-media-tag";
 
 const rules = {
   "no-mp4-import": nomp4Import,
@@ -14,6 +15,7 @@ const rules = {
   "even-dimensions": evenDimensions,
   "duration-in-frames": durationInFrames,
   "volume-callback": volumeCallback,
+  "use-gif-component": useGifComponent,
 };
 
 export = {
@@ -28,6 +30,7 @@ export = {
         "@remotion/even-dimensions": "error",
         "@remotion/duration-in-frames": "error",
         "@remotion/volume-callback": "error",
+        "@remotion/use-gif-component": "error",
       },
     },
   },

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -4,6 +4,7 @@ import durationInFrames from "./rules/no-duration-frames-infinity";
 import nomp4Import from "./rules/no-mp4-import";
 import noStringAssets from "./rules/no-string-assets";
 import staticFileNoRelative from "./rules/staticfile-no-relative";
+import staticFileNoRemote from "./rules/staticfile-no-remote";
 import useGifComponent from "./rules/use-gif-component";
 import volumeCallback from "./rules/volume-callback";
 import warnNativeMediaTag from "./rules/warn-native-media-tag";
@@ -18,6 +19,7 @@ const rules = {
   "volume-callback": volumeCallback,
   "use-gif-component": useGifComponent,
   "staticfile-no-relative": staticFileNoRelative,
+  "staticfile-no-remote": staticFileNoRemote,
 };
 
 export = {
@@ -34,6 +36,7 @@ export = {
         "@remotion/volume-callback": "error",
         "@remotion/use-gif-component": "error",
         "@remotion/staticfile-no-relative": "error",
+        "@remotion/staticfile-no-remote": "error",
       },
     },
   },

--- a/packages/eslint-plugin/src/rules/staticfile-no-relative.ts
+++ b/packages/eslint-plugin/src/rules/staticfile-no-relative.ts
@@ -1,0 +1,74 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(() => {
+  return `https://remotion.dev/docs/staticfile-relative-paths`;
+});
+
+type Options = [];
+
+type MessageIds = "RelativePathStaticFile";
+
+const RelativePathStaticFile = [
+  "Don't pass a relative path to staticFile().",
+  "See: https://remotion.dev/docs/staticfile-relative-paths",
+].join("\n");
+
+export default createRule<Options, MessageIds>({
+  name: "staticfile-no-relative",
+  meta: {
+    type: "problem",
+    docs: {
+      description: RelativePathStaticFile,
+      recommended: "warn",
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      RelativePathStaticFile: RelativePathStaticFile,
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      CallExpression: (node) => {
+        const value = node;
+        // src={"some string"}
+        if (!value) {
+          return;
+        }
+
+        if (
+          node.type === "CallExpression" &&
+          node.callee.type === "Identifier" &&
+          node.callee.name === "staticFile"
+        ) {
+          const args = node.arguments;
+          if (args.length === 0) {
+            return;
+          }
+
+          const firstArg = args[0];
+
+          if (firstArg.type === "Literal") {
+            const value = firstArg.value;
+            if (typeof value !== "string") {
+              return;
+            }
+            if (value.startsWith("./")) {
+              context.report({
+                messageId: "RelativePathStaticFile",
+                node,
+              });
+            }
+            if (value.startsWith("../")) {
+              context.report({
+                messageId: "RelativePathStaticFile",
+                node,
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/staticfile-no-remote.ts
+++ b/packages/eslint-plugin/src/rules/staticfile-no-remote.ts
@@ -1,0 +1,74 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(() => {
+  return `https://remotion.dev/docs/staticfile-remote-urls`;
+});
+
+type Options = [];
+
+type MessageIds = "RelativePathStaticFile";
+
+const RelativePathStaticFile = [
+  "Don't pass a remote URL to staticFile().",
+  "See: https://remotion.dev/docs/staticfile-remote-urls",
+].join("\n");
+
+export default createRule<Options, MessageIds>({
+  name: "staticfile-no-remote",
+  meta: {
+    type: "problem",
+    docs: {
+      description: RelativePathStaticFile,
+      recommended: "warn",
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      RelativePathStaticFile: RelativePathStaticFile,
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      CallExpression: (node) => {
+        const value = node;
+        // src={"some string"}
+        if (!value) {
+          return;
+        }
+
+        if (
+          node.type === "CallExpression" &&
+          node.callee.type === "Identifier" &&
+          node.callee.name === "staticFile"
+        ) {
+          const args = node.arguments;
+          if (args.length === 0) {
+            return;
+          }
+
+          const firstArg = args[0];
+
+          if (firstArg.type === "Literal") {
+            const value = firstArg.value;
+            if (typeof value !== "string") {
+              return;
+            }
+            if (value.startsWith("http://")) {
+              context.report({
+                messageId: "RelativePathStaticFile",
+                node,
+              });
+            }
+            if (value.startsWith("https://")) {
+              context.report({
+                messageId: "RelativePathStaticFile",
+                node,
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/use-gif-component.ts
+++ b/packages/eslint-plugin/src/rules/use-gif-component.ts
@@ -1,0 +1,84 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(() => {
+  return `https://github.com/remotion-dev/remotion`;
+});
+
+type Options = [];
+
+type MessageIds = "UseGifComponent";
+
+const UseGifComponent = [
+  "Use the <Gif> component for animated GIFs instead.",
+  "See: https://www.remotion.dev/docs/gif",
+].join("\n");
+
+export default createRule<Options, MessageIds>({
+  name: "use-gif-component",
+  meta: {
+    type: "problem",
+    docs: {
+      description: UseGifComponent,
+      recommended: "warn",
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      UseGifComponent: UseGifComponent,
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      JSXAttribute: (node) => {
+        if (node.type !== "JSXAttribute") {
+          return;
+        }
+        if (node.name.name !== "src") {
+          return;
+        }
+        const value = node.value;
+        // src={"some string"}
+        const insideCurlyBraces =
+          value &&
+          value.type === "JSXExpressionContainer" &&
+          value.expression.type === "Literal";
+        if (!value || (value.type !== "Literal" && !insideCurlyBraces)) {
+          return;
+        }
+        const stringValue =
+          value &&
+          value.type === "JSXExpressionContainer" &&
+          value.expression.type === "Literal"
+            ? value.expression.value
+            : value.type === "Literal"
+            ? value.value
+            : null;
+        if (typeof stringValue !== "string") {
+          return;
+        }
+
+        const parent = node.parent;
+        if (!parent) {
+          return;
+        }
+        if (parent.type !== "JSXOpeningElement") {
+          return;
+        }
+        const name = parent.name;
+        if (name.type !== "JSXIdentifier") {
+          return;
+        }
+        if (name.name === "Img" || name.name === "img") {
+          // Network and inline URLs are okay
+          if (stringValue.includes(".gif")) {
+            context.report({
+              messageId: "UseGifComponent",
+              node,
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/tests/staticfile-no-relative.test.ts
+++ b/packages/eslint-plugin/src/tests/staticfile-no-relative.test.ts
@@ -1,0 +1,39 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+import rule from "../rules/staticfile-no-relative";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run("staticfile-no-relative", rule, {
+  valid: [
+    `
+import {Img, staticFile} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Img src={staticFile("image.png")} />
+  );
+}
+          `,
+  ],
+  invalid: [
+    {
+      code: `
+import {staticFile} from 'remotion';
+
+staticFile("./relative.png")
+      `,
+      errors: [
+        {
+          messageId: "RelativePathStaticFile",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/tests/staticfile-no-remote.test.ts
+++ b/packages/eslint-plugin/src/tests/staticfile-no-remote.test.ts
@@ -1,0 +1,51 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+import rule from "../rules/staticfile-no-remote";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run("staticfile-no-remote", rule, {
+  valid: [
+    `
+import {Img, staticFile} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Img src={staticFile("image.png")} />
+  );
+}
+          `,
+  ],
+  invalid: [
+    {
+      code: `
+import {staticFile} from 'remotion';
+
+staticFile("http://relative.png")
+      `,
+      errors: [
+        {
+          messageId: "RelativePathStaticFile",
+        },
+      ],
+    },
+    {
+      code: `
+import {staticFile} from 'remotion';
+
+staticFile("https://relative.png")
+      `,
+      errors: [
+        {
+          messageId: "RelativePathStaticFile",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/tests/use-gif-component.test.ts
+++ b/packages/eslint-plugin/src/tests/use-gif-component.test.ts
@@ -23,6 +23,15 @@ export const Re = () => {
 }
           `,
     `
+import {Img, staticFile} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Img src={staticFile("image.png")} />
+  );
+}
+          `,
+    `
 import {Img} from 'remotion';
 
 export const Re = () => {

--- a/packages/eslint-plugin/src/tests/use-gif-component.test.ts
+++ b/packages/eslint-plugin/src/tests/use-gif-component.test.ts
@@ -1,0 +1,69 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+import rule from "../rules/use-gif-component";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run("use-gif-component", rule, {
+  valid: [
+    // Network image should be allowed
+    `
+import {Img} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Img src="https://google.com/favicon.png" />
+  );
+}
+          `,
+    `
+import {Img} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Img src="data:image/png;base64,
+    iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAALGP
+    C/xhBQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9YGARc5KB0XV+IA
+    AAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAF1J
+    REFUGNO9zL0NglAAxPEfdLTs4BZM4DIO4C7OwQg2JoQ9LE1exdlYvBBeZ7jq
+    ch9//q1uH4TLzw4d6+ErXMMcXuHWxId3KOETnnXXV6MJpcq2MLaI97CER3N0
+    vr4MkhoXe0rZigAAAABJRU5ErkJggg==" />
+  );
+}
+          `,
+    `
+import {Img} from 'remotion';
+import img from './img.png';
+
+export const Re = () => {
+  return (
+    <Img src={img} />
+  );
+}
+                `,
+  ],
+  invalid: [
+    {
+      code: `
+import {Img} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Img src="https://reddit.com/image.gif" />
+  );
+}
+      `,
+      errors: [
+        {
+          messageId: "UseGifComponent",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/example/src/Freeze/FreezeExample.tsx
+++ b/packages/example/src/Freeze/FreezeExample.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Freeze, Series, staticFile, Video} from 'remotion';
 
 export const FreezeExample: React.FC = () => {
-	const video = staticFile('./framermp4withoutfileextension');
+	const video = staticFile('framermp4withoutfileextension');
 
 	return (
 		<Series>

--- a/packages/example/src/VideoTesting/index.tsx
+++ b/packages/example/src/VideoTesting/index.tsx
@@ -11,8 +11,8 @@ export const VideoTesting: React.FC<{
 	offthread: boolean;
 }> = ({codec, offthread}) => {
 	const {durationInFrames} = useVideoConfig();
-	const videoMp4 = staticFile('./framermp4withoutfileextension');
-	const videoWebm = staticFile('./framer.webm');
+	const videoMp4 = staticFile('framermp4withoutfileextension');
+	const videoWebm = staticFile('framer.webm');
 
 	const Comp = offthread ? OffthreadVideo : Video;
 


### PR DESCRIPTION
- Disallow passing `./relativeUrls` into staticFile + ESLint rule + Help page
- Disallow passing `http://remoteurls.com` into staticFile() + ESLint rule + Help page
- Disallow passing a file ending in .gif into the `<Img>` component
- Better error handling for MediaError's

Fixes #1138