### PR TITLE
Don't throw an error anymore if passing `.gif` to an `<Img>` to allow non-animated GIF

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -16,12 +16,6 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 > = ({onError, ...props}, ref) => {
 	const imageRef = useRef<HTMLImageElement>(null);
 
-	if (props.src?.endsWith('.gif')) {
-		throw new TypeError(
-			'The <Img> component does not support GIFs. Use the <Gif> instead: https://remotion.dev/docs/gif'
-		);
-	}
-
 	useImperativeHandle(ref, () => {
 		return imageRef.current as HTMLImageElement;
 	});

--- a/packages/eslint-plugin/src/rules/use-gif-component.ts
+++ b/packages/eslint-plugin/src/rules/use-gif-component.ts
@@ -9,8 +9,9 @@ type Options = [];
 type MessageIds = "UseGifComponent";
 
 const UseGifComponent = [
-  "Use the <Gif> component for animated GIFs instead.",
-  "See: https://www.remotion.dev/docs/gif",
+  "Use the <Gif> component animated GIFs.",
+  "See: https://www.remotion.dev/docs/gif.",
+  "Ignore this message if this is a non-animated GIF.",
 ].join("\n");
 
 export default createRule<Options, MessageIds>({


### PR DESCRIPTION
The previous change was too strict, could not embed non-animated GIF anymore.