### PR TITLE
Fix Lambda + OffthreadVideo performance problem - ignore OPTIONS request from chrome

### DIFF
--- a/packages/cli/src/preview-server/live-events.ts
+++ b/packages/cli/src/preview-server/live-events.ts
@@ -26,6 +26,10 @@ export const makeLiveEventsRouter = (): LiveEventsServer => {
 		};
 
 		response.writeHead(200, headers);
+		if (request.method === 'OPTIONS') {
+			response.end();
+			return;
+		}
 
 		response.write(serializeMessage({type: 'init'}));
 

--- a/packages/cli/src/preview-server/routes.ts
+++ b/packages/cli/src/preview-server/routes.ts
@@ -181,7 +181,6 @@ export const handleRoutes = ({
 	liveEventsServer,
 	getCurrentInputProps,
 	remotionRoot,
-	method,
 }: {
 	hash: string;
 	hashPrefix: string;
@@ -190,7 +189,6 @@ export const handleRoutes = ({
 	liveEventsServer: LiveEventsServer;
 	getCurrentInputProps: () => object;
 	remotionRoot: string;
-	method: string;
 }) => {
 	const url = new URL(request.url as string, 'http://localhost');
 
@@ -206,7 +204,7 @@ export const handleRoutes = ({
 		return handleFileSource({
 			remotionRoot,
 			search: url.search,
-			method,
+			method: request.method as string,
 			response,
 		});
 	}

--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -83,6 +83,7 @@ export const startOffthreadVideoServer = ({
 			res.end();
 			return;
 		}
+
 		downloadAsset({src, onDownload, downloadMap})
 			.then((to) => {
 				return extractFrameFromVideo({

--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -74,6 +74,15 @@ export const startOffthreadVideoServer = ({
 			`image/${imageFormat === 'jpeg' ? 'jpg' : 'png'}`
 		);
 
+		if (req.method === 'OPTIONS') {
+			res.statusCode = 200;
+			if (req.headers['access-control-request-private-network']) {
+				res.setHeader('Access-Control-Allow-Private-Network', 'true');
+			}
+
+			res.end();
+			return;
+		}
 		downloadAsset({src, onDownload, downloadMap})
 			.then((to) => {
 				return extractFrameFromVideo({

--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -74,6 +74,9 @@ export const startOffthreadVideoServer = ({
 			`image/${imageFormat === 'jpeg' ? 'jpg' : 'png'}`
 		);
 
+		// Handling this case on Lambda:
+		// https://support.google.com/chrome/a/answer/7679408?hl=en
+		// Chrome sends Private Network Access preflights for subresources
 		if (req.method === 'OPTIONS') {
 			res.statusCode = 200;
 			if (req.headers['access-control-request-private-network']) {


### PR DESCRIPTION
> Chrome 104 sends a CORS preflight request ahead of any [private network requests](https://developer.chrome.com/blog/private-network-access-preflight/#what-is-private-network-access-pna) for subresources, asking for explicit permission from the target server. This request carries a new Access-Control-Request-Private-Network: true header. In this initial phase, this request is sent, but no response is required from network devices. If no response is received, or it does not carry a matching Access-Control-Allow-Private-Network: true header, a warning is shown in DevTools, see here for [more details](https://developer.chrome.com/blog/private-network-access-preflight/#how-to-know-if-your-website-is-affected)).
> In Chrome 107 at the earliest, the warnings will turn into errors and affected requests will fail. You can disable Private Network Access checks using the [InsecurePrivateNetworkRequestsAllowed](https://chromeenterprise.google/policies/#InsecurePrivateNetworkRequestsAllowed) and [InsecurePrivateNetworkRequestsAllowedForUrls](https://chromeenterprise.google/policies/#InsecurePrivateNetworkRequestsAllowedForUrls) enterprise policies.
> If you want to test this feature in advance, you can enable warnings using chrome://flags/#private-network-access-send-preflights. If you want to test how it behaves once warnings turn into errors, you can enable chrome://flags/#private-network-access-respect-preflight-results.
> To learn more about mitigating this change proactively, see details on [what to do if your site is affected](https://developer.chrome.com/blog/private-network-access-preflight/#what-to-do-if-your-website-is-affected). Read the [whole blog post](https://developer.chrome.com/blog/private-network-access-preflight/) for a more general discussion about Private Network Access preflights.

https://support.google.com/chrome/a/answer/7679408?hl=en

This lead to images from <OffthreadVideo> being calculated twice and being slow. Fixing this by handling the new Chrome request as they want it to be.