### PR TITLE
docs: add links to W3C spec

### DIFF
--- a/packages/docs/docs/visualize-audio.md
+++ b/packages/docs/docs/visualize-audio.md
@@ -93,9 +93,10 @@ const params = {
 // ---cut---
 /**
  * This postprocessing step will match the values with what you'd
- * get from WebAudio's AnalyserNode.
+ * get from WebAudio's `AnalyserNode.getByteFrequencyData()`.
  *
- * https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode
+ * MDN: https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode
+ * W3C Spec: https://www.w3.org/TR/webaudio/#AnalyserNode-methods
  */
 
 // get the frequency data

--- a/packages/docs/docs/visualize-audio.md
+++ b/packages/docs/docs/visualize-audio.md
@@ -95,7 +95,7 @@ const params = {
  * This postprocessing step will match the values with what you'd
  * get from WebAudio's `AnalyserNode.getByteFrequencyData()`.
  *
- * MDN: https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode
+ * MDN: https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getByteFrequencyData
  * W3C Spec: https://www.w3.org/TR/webaudio/#AnalyserNode-methods
  */
 


### PR DESCRIPTION
This just adds a link to the specific place in the W3C where the `getByteFrequencyData()` algorithm is explained.
