### PR TITLE
Stricter and simpler version checks for Remotion + Remotion Lambda

### DIFF
--- a/packages/bundler/src/renderEntry.tsx
+++ b/packages/bundler/src/renderEntry.tsx
@@ -6,9 +6,7 @@ import type {render, unmountComponentAtNode} from 'react-dom';
 // hence why we import the right thing all the time but need to differentiate here
 import ReactDOM from 'react-dom/client';
 import type {BundleState, TCompMetadata, TComposition} from 'remotion';
-import {continueRender, delayRender, Internals} from 'remotion';
-// In webpack, importing from remotion/version is not supported
-import {VERSION} from 'remotion/dist/version';
+import {continueRender, delayRender, Internals, VERSION} from 'remotion';
 import {getBundleMode, setBundleMode} from './bundle-mode';
 import {Homepage} from './homepage/homepage';
 

--- a/packages/bundler/src/renderEntry.tsx
+++ b/packages/bundler/src/renderEntry.tsx
@@ -223,5 +223,6 @@ if (typeof window !== 'undefined') {
 	};
 
 	window.siteVersion = '4';
+	window.remotion_version = Internals.VERSION;
 	window.setBundleMode = setBundleModeAndUpdate;
 }

--- a/packages/bundler/src/renderEntry.tsx
+++ b/packages/bundler/src/renderEntry.tsx
@@ -7,7 +7,8 @@ import type {render, unmountComponentAtNode} from 'react-dom';
 import ReactDOM from 'react-dom/client';
 import type {BundleState, TCompMetadata, TComposition} from 'remotion';
 import {continueRender, delayRender, Internals} from 'remotion';
-import {VERSION} from 'remotion/version';
+// In webpack, importing from remotion/version is not supported
+import {VERSION} from 'remotion/dist/version';
 import {getBundleMode, setBundleMode} from './bundle-mode';
 import {Homepage} from './homepage/homepage';
 

--- a/packages/bundler/src/renderEntry.tsx
+++ b/packages/bundler/src/renderEntry.tsx
@@ -7,6 +7,7 @@ import type {render, unmountComponentAtNode} from 'react-dom';
 import ReactDOM from 'react-dom/client';
 import type {BundleState, TCompMetadata, TComposition} from 'remotion';
 import {continueRender, delayRender, Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {getBundleMode, setBundleMode} from './bundle-mode';
 import {Homepage} from './homepage/homepage';
 
@@ -223,6 +224,6 @@ if (typeof window !== 'undefined') {
 	};
 
 	window.siteVersion = '4';
-	window.remotion_version = Internals.VERSION;
+	window.remotion_version = VERSION;
 	window.setBundleMode = setBundleModeAndUpdate;
 }

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -129,7 +129,6 @@ export const webpackConfig = ({
 					? require.resolve('react-dom/client')
 					: require.resolve('react-dom'),
 				remotion: require.resolve('remotion'),
-				'remotion/version': require.resolve('remotion/version'),
 				'react-native$': 'react-native-web',
 			},
 		},

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -129,6 +129,7 @@ export const webpackConfig = ({
 					? require.resolve('react-dom/client')
 					: require.resolve('react-dom'),
 				remotion: require.resolve('remotion'),
+				'remotion/version': require.resolve('remotion/version'),
 				'react-native$': 'react-native-web',
 			},
 		},

--- a/packages/core/ensure-correct-version.js
+++ b/packages/core/ensure-correct-version.js
@@ -21,4 +21,4 @@ if (!distFile.includes(version)) {
 	process.exit(1);
 }
 
-console.log('Updated version to v3.2.5');
+console.log('Updated version to v' + version);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,7 +26,7 @@ declare global {
 		remotion_finishedBuilding: undefined | (() => void);
 		siteVersion: '4';
 		remotion_version: string;
-		remotion_imported: boolean;
+		remotion_imported: string | boolean;
 	}
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,5 +70,6 @@ export * from './Still';
 export type {PlayableMediaTag} from './timeline-position-state';
 export {useCurrentFrame} from './use-current-frame';
 export * from './use-video-config';
+export * from './version';
 export * from './video';
 export * from './video-config';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ declare global {
 		remotion_isBuilding: undefined | (() => void);
 		remotion_finishedBuilding: undefined | (() => void);
 		siteVersion: '4';
+		remotion_version: string;
 		remotion_imported: boolean;
 	}
 }

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -45,7 +45,6 @@ import {validateDimension} from './validation/validate-dimensions';
 import {validateDurationInFrames} from './validation/validate-duration-in-frames';
 import {validateFps} from './validation/validate-fps';
 import {validateOffthreadVideoImageFormat} from './validation/validate-offthreadvideo-image-format';
-import {VERSION} from './version';
 import type {
 	MediaVolumeContextValue,
 	SetMediaVolumeContextValue,
@@ -100,7 +99,6 @@ export const Internals = {
 	CanUseRemotionHooksProvider,
 	CanUseRemotionHooks,
 	enableLegacyRemotionConfig,
-	VERSION,
 };
 
 type WebpackConfiguration = Configuration;

--- a/packages/core/src/multiple-versions-warning.ts
+++ b/packages/core/src/multiple-versions-warning.ts
@@ -1,19 +1,32 @@
+import {truthy} from './truthy';
+import {VERSION} from './version';
+
 export const checkMultipleRemotionVersions = () => {
 	if (typeof globalThis === 'undefined') {
 		return;
 	}
 
-	if (
+	const alreadyImported =
 		(globalThis as unknown as Window).remotion_imported ||
-		(typeof window !== 'undefined' && window.remotion_imported)
-	) {
+		(typeof window !== 'undefined' && window.remotion_imported);
+
+	if (alreadyImported) {
 		throw new TypeError(
-			'🚨 Multiple versions of Remotion detected. This will cause things to break in an unexpected way.\nCheck that all your Remotion packages are on the same version. You can also run `npx remotion versions` from your terminal to see which versions are mismatching.'
+			`🚨 Multiple versions of Remotion detected: ${[
+				VERSION,
+				typeof alreadyImported === 'string'
+					? alreadyImported
+					: 'an older version',
+			]
+				.filter(truthy)
+				.join(
+					' and '
+				)}. This will cause things to break in an unexpected way.\nCheck that all your Remotion packages are on the same version. If your dependencies depend on Remotion, make them peer dependencies. You can also run \`npx remotion versions\` from your terminal to see which versions are mismatching.`
 		);
 	}
 
 	(globalThis as unknown as Window).remotion_imported = true;
 	if (typeof window !== 'undefined') {
-		window.remotion_imported = true;
+		window.remotion_imported = VERSION;
 	}
 };

--- a/packages/core/version.d.ts
+++ b/packages/core/version.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/version';

--- a/packages/core/version.js
+++ b/packages/core/version.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/version');

--- a/packages/docs/components/PrereleaseVersion.tsx
+++ b/packages/docs/components/PrereleaseVersion.tsx
@@ -38,11 +38,11 @@ export const Prerelease: React.FC<{
           return (
             <div key={r}>
               <span style={{ color: "#e13238" }}>
-                - &quot;{r}&quot;: &quot;{"^3.0.0"}&quot;
+                - &quot;{r}&quot;: &quot;{"3.0.0"}&quot;
               </span>
               {"\n"}
               <span style={{ color: "#009400" }}>
-                + &quot;{r}&quot;: &quot;^{version}&quot;
+                + &quot;{r}&quot;: &quot;{version}&quot;
               </span>
               {"\n"}
             </div>

--- a/packages/docs/docs/lambda/setup.md
+++ b/packages/docs/docs/lambda/setup.md
@@ -151,7 +151,7 @@ The function name is returned which you'll need for rendering.
 </TabItem>
 </Tabs>
 
-## 8. Deploy a website
+## 8. Deploy a site
 
 <Tabs
 defaultValue="cli"
@@ -165,10 +165,12 @@ values={[
 Run the following command to deploy your Remotion project to an S3 bucket. Pass as the last argument the entry file of the project - this is the file where [`registerRoot()`](/docs/register-root) is called.
 
 ```bash
-npx remotion lambda sites create src/index.tsx
+npx remotion lambda sites create src/index.tsx --site-name=my-video
 ```
 
-A URL will be printed pointing to the deployed project.
+A `serveUrl` will be printed pointing to the deployed project.
+
+When you update your Remotion video in the future, redeploy your site. Pass the same [`--site-name`](/docs/lambda/cli/sites#--site-name) to overwrite the previous deploy. If you don't pass [`--site-name`](/docs/lambda/cli/sites#--site-name), a unique URL will be generated on every deploy.
 
 </TabItem>
 <TabItem value="node">
@@ -202,10 +204,11 @@ const { serveUrl } = await deploySite({
   bucketName,
   entryPoint: path.resolve(process.cwd(), "src/index.tsx"),
   region: "us-east-1",
+  siteName: "my-video",
 });
 ```
 
-You are now ready to render a video.
+When you update your Remotion video in the future, redeploy your site. Pass the same [`siteName`](/docs/lambda/deploysite#sitename) to overwrite the previous deploy. If you don't pass [`siteName`](/docs/lambda/deploysite#sitename), a unique URL will be generated on every deploy.
 
 </TabItem>
 </Tabs>

--- a/packages/docs/docs/lambda/upgrading.md
+++ b/packages/docs/docs/lambda/upgrading.md
@@ -1,6 +1,6 @@
 ---
 id: upgrading
-title: Upgrading
+title: Upgrading Lambda
 slug: /lambda/upgrading
 ---
 
@@ -27,10 +27,26 @@ npx remotion lambda functions rmall -y
 npx remotion lambda functions deploy
 ```
 
+- Update the site:
+
+```
+npx remotion sites create src/index.ts --site-name=my-name
+```
+
+:::info
+
+Pass `--site-name` with the name of an existing site to update it. The URL will stay the same but older functions may not be able to render the updated site.
+
+If you don't pass `--site-name` a new site URL will be generated. You'll need to update the [`serveUrl`](/docs/lambda/rendermediaonlambda#serveurl) parameter in your [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda) calls. Old deployed functions can still render by specifying the old serve URL.
+:::
+
 ## Separating production and testing environments
 
-If you already shipped Remotion Lambda to production, you can upgrade without incurring any downtime. Each version of Remotion Lambda has a schema identifier (in the format of `2021-08-12`) that will increment whenever a breaking change is introduced.
+If you already shipped Remotion Lambda to production, you can upgrade without incurring any downtime:
 
-If you have Remotion Lambda in production and are testing locally, upgrading Remotion Lambda in your project locally and then rendering a video will yield an error message that the versions are mismatching. Simply deploy a new function `npx remotion lambda functions deploy` and your local environment will talk to the new function, while production will talk to the older function.
+- Each deployed function has a version (see them using `npx remotion lambda functions ls`).  
+  Use the same version of the `@remotion/lambda` package to invoke the function.
 
-If everything works and you commit and deploy the change to production, it will start talking to the new version and you can safely remove the old function.
+- You can have multiple functions with different versions deployed. Use the [`compatibleOnly`](/docs/lambda/getfunctions#compatibleonly) parameter to find functions that match the version of the `@remotion/lambda` package.
+
+- Sites/`serveUrl`'s also are version-dependant. Create them with the same version of Remotion that you render them with. Remotion will tolerate mismatches if there are no incompatibilities, but will issue a warning that you might not have all the newest features and bugfixes in the bundled site.

--- a/packages/example/updatelambda.sh
+++ b/packages/example/updatelambda.sh
@@ -1,7 +1,0 @@
-cd ..
-cd lambda
-npm run buildlambda
-cd ..
-cd example
-npx remotion lambda functions rmall -f
-npx remotion lambda functions deploy --memory=2500

--- a/packages/lambda/src/admin/make-layer-public.ts
+++ b/packages/lambda/src/admin/make-layer-public.ts
@@ -3,7 +3,7 @@ import {
 	PublishLayerVersionCommand,
 } from '@aws-sdk/client-lambda';
 import {lambda} from 'aws-policies';
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {getRegions} from '..';
 import {quit} from '../cli/helpers/quit';
 import {getLambdaClient} from '../shared/aws-clients';
@@ -61,7 +61,7 @@ const makeLayerPublic = async () => {
 								? 'Compiled from FFMPEG source. Read FFMPEG license: https://ffmpeg.org/legal.html'
 								: 'Contains Noto Sans font. Read Noto Sans License: https://fonts.google.com/noto/specimen/Noto+Sans/about',
 						CompatibleRuntimes: runtimes,
-						Description: Internals.VERSION,
+						Description: VERSION,
 					})
 				);
 				await getLambdaClient(region).send(

--- a/packages/lambda/src/admin/make-layer-public.ts
+++ b/packages/lambda/src/admin/make-layer-public.ts
@@ -3,10 +3,10 @@ import {
 	PublishLayerVersionCommand,
 } from '@aws-sdk/client-lambda';
 import {lambda} from 'aws-policies';
+import {Internals} from 'remotion';
 import {getRegions} from '..';
 import {quit} from '../cli/helpers/quit';
 import {getLambdaClient} from '../shared/aws-clients';
-import {CURRENT_VERSION} from '../shared/constants';
 import type {HostedLayers} from '../shared/hosted-layers';
 import type {LambdaArchitecture} from '../shared/validate-architecture';
 
@@ -61,7 +61,7 @@ const makeLayerPublic = async () => {
 								? 'Compiled from FFMPEG source. Read FFMPEG license: https://ffmpeg.org/legal.html'
 								: 'Contains Noto Sans font. Read Noto Sans License: https://fonts.google.com/noto/specimen/Noto+Sans/about',
 						CompatibleRuntimes: runtimes,
-						Description: CURRENT_VERSION,
+						Description: Internals.VERSION,
 					})
 				);
 				await getLambdaClient(region).send(

--- a/packages/lambda/src/api/__mocks__/create-function.ts
+++ b/packages/lambda/src/api/__mocks__/create-function.ts
@@ -1,5 +1,5 @@
+import {Internals} from 'remotion';
 import {
-	CURRENT_VERSION,
 	DEFAULT_EPHEMERAL_STORAGE_IN_MB,
 	DEFAULT_MEMORY_SIZE,
 } from '../../defaults';
@@ -13,7 +13,7 @@ export const createFunction: typeof original = (input) => {
 				functionName: input.functionName,
 				memorySizeInMb: DEFAULT_MEMORY_SIZE,
 				timeoutInSeconds: input.timeoutInSeconds,
-				version: CURRENT_VERSION,
+				version: Internals.VERSION,
 				diskSizeInMb: DEFAULT_EPHEMERAL_STORAGE_IN_MB,
 			},
 			input.region

--- a/packages/lambda/src/api/__mocks__/create-function.ts
+++ b/packages/lambda/src/api/__mocks__/create-function.ts
@@ -1,4 +1,4 @@
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {
 	DEFAULT_EPHEMERAL_STORAGE_IN_MB,
 	DEFAULT_MEMORY_SIZE,
@@ -13,7 +13,7 @@ export const createFunction: typeof original = (input) => {
 				functionName: input.functionName,
 				memorySizeInMb: DEFAULT_MEMORY_SIZE,
 				timeoutInSeconds: input.timeoutInSeconds,
-				version: Internals.VERSION,
+				version: VERSION,
 				diskSizeInMb: DEFAULT_EPHEMERAL_STORAGE_IN_MB,
 			},
 			input.region

--- a/packages/lambda/src/api/__mocks__/get-functions.ts
+++ b/packages/lambda/src/api/__mocks__/get-functions.ts
@@ -1,4 +1,4 @@
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import type {getFunctions as original} from '../get-functions';
 import {getAllMockFunctions} from '../mock-functions';
 
@@ -6,5 +6,5 @@ export const getFunctions: typeof original = async ({
 	region,
 	compatibleOnly,
 }) => {
-	return getAllMockFunctions(region, compatibleOnly ? Internals.VERSION : null);
+	return getAllMockFunctions(region, compatibleOnly ? VERSION : null);
 };

--- a/packages/lambda/src/api/__mocks__/get-functions.ts
+++ b/packages/lambda/src/api/__mocks__/get-functions.ts
@@ -1,4 +1,4 @@
-import {CURRENT_VERSION} from '../../defaults';
+import {Internals} from 'remotion';
 import type {getFunctions as original} from '../get-functions';
 import {getAllMockFunctions} from '../mock-functions';
 
@@ -6,5 +6,5 @@ export const getFunctions: typeof original = async ({
 	region,
 	compatibleOnly,
 }) => {
-	return getAllMockFunctions(region, compatibleOnly ? CURRENT_VERSION : null);
+	return getAllMockFunctions(region, compatibleOnly ? Internals.VERSION : null);
 };

--- a/packages/lambda/src/api/deploy-function.ts
+++ b/packages/lambda/src/api/deploy-function.ts
@@ -1,4 +1,4 @@
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {getFunctions} from '../api/get-functions';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {
@@ -60,7 +60,7 @@ export const deployFunction = async (
 	validateCustomRoleArn(options.customRoleArn);
 
 	const fnNameRender = [
-		`${RENDER_FN_PREFIX}${Internals.VERSION.replace(/\./g, '-')}`,
+		`${RENDER_FN_PREFIX}${VERSION.replace(/\./g, '-')}`,
 		`mem${options.memorySizeInMb}mb`,
 		`disk${diskSizeInMb}mb`,
 		`${options.timeoutInSeconds}sec`,
@@ -74,7 +74,7 @@ export const deployFunction = async (
 
 	const alreadyDeployed = fns.find(
 		(f) =>
-			f.version === Internals.VERSION &&
+			f.version === VERSION &&
 			f.memorySizeInMb === options.memorySizeInMb &&
 			f.timeoutInSeconds === options.timeoutInSeconds &&
 			f.diskSizeInMb === diskSizeInMb

--- a/packages/lambda/src/api/deploy-function.ts
+++ b/packages/lambda/src/api/deploy-function.ts
@@ -1,18 +1,15 @@
+import {Internals} from 'remotion';
 import {getFunctions} from '../api/get-functions';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {
-	CURRENT_VERSION,
 	DEFAULT_CLOUDWATCH_RETENTION_PERIOD,
 	DEFAULT_EPHEMERAL_STORAGE_IN_MB,
 	RENDER_FN_PREFIX,
 } from '../shared/constants';
 import {FUNCTION_ZIP} from '../shared/function-zip-path';
 import {getAccountId} from '../shared/get-account-id';
-import type {
-	LambdaArchitecture} from '../shared/validate-architecture';
-import {
-	validateArchitecture,
-} from '../shared/validate-architecture';
+import type {LambdaArchitecture} from '../shared/validate-architecture';
+import {validateArchitecture} from '../shared/validate-architecture';
 import {validateAwsRegion} from '../shared/validate-aws-region';
 import {validateCustomRoleArn} from '../shared/validate-custom-role-arn';
 import {validateDiskSizeInMb} from '../shared/validate-disk-size-in-mb';
@@ -63,7 +60,7 @@ export const deployFunction = async (
 	validateCustomRoleArn(options.customRoleArn);
 
 	const fnNameRender = [
-		`${RENDER_FN_PREFIX}${CURRENT_VERSION}`,
+		`${RENDER_FN_PREFIX}${Internals.VERSION.replace(/\./g, '-')}`,
 		`mem${options.memorySizeInMb}mb`,
 		`disk${diskSizeInMb}mb`,
 		`${options.timeoutInSeconds}sec`,
@@ -77,7 +74,7 @@ export const deployFunction = async (
 
 	const alreadyDeployed = fns.find(
 		(f) =>
-			f.version === CURRENT_VERSION &&
+			f.version === Internals.VERSION &&
 			f.memorySizeInMb === options.memorySizeInMb &&
 			f.timeoutInSeconds === options.timeoutInSeconds &&
 			f.diskSizeInMb === diskSizeInMb

--- a/packages/lambda/src/api/get-function-info.ts
+++ b/packages/lambda/src/api/get-function-info.ts
@@ -1,11 +1,7 @@
 import {GetFunctionCommand} from '@aws-sdk/client-lambda';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {getLambdaClient} from '../shared/aws-clients';
-import type {
-	LambdaVersions} from '../shared/constants';
-import {
-	DEFAULT_EPHEMERAL_STORAGE_IN_MB
-} from '../shared/constants';
+import {DEFAULT_EPHEMERAL_STORAGE_IN_MB} from '../shared/constants';
 import {getFunctionVersion} from '../shared/get-function-version';
 import {validateAwsRegion} from '../shared/validate-aws-region';
 
@@ -13,7 +9,7 @@ export type FunctionInfo = {
 	functionName: string;
 	timeoutInSeconds: number;
 	memorySizeInMb: number;
-	version: LambdaVersions | null;
+	version: string | null;
 	diskSizeInMb: number;
 };
 

--- a/packages/lambda/src/api/get-functions.ts
+++ b/packages/lambda/src/api/get-functions.ts
@@ -1,6 +1,6 @@
 import type {FunctionConfiguration} from '@aws-sdk/client-lambda';
 import {ListFunctionsCommand} from '@aws-sdk/client-lambda';
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {getLambdaClient} from '../shared/aws-clients';
 import {
@@ -104,6 +104,6 @@ export const getFunctions = async (
 			return true;
 		}
 
-		return l.version === Internals.VERSION;
+		return l.version === VERSION;
 	});
 };

--- a/packages/lambda/src/api/get-functions.ts
+++ b/packages/lambda/src/api/get-functions.ts
@@ -1,12 +1,9 @@
-import type {
-	FunctionConfiguration} from '@aws-sdk/client-lambda';
-import {
-	ListFunctionsCommand,
-} from '@aws-sdk/client-lambda';
+import type {FunctionConfiguration} from '@aws-sdk/client-lambda';
+import {ListFunctionsCommand} from '@aws-sdk/client-lambda';
+import {Internals} from 'remotion';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {getLambdaClient} from '../shared/aws-clients';
 import {
-	CURRENT_VERSION,
 	DEFAULT_EPHEMERAL_STORAGE_IN_MB,
 	RENDER_FN_PREFIX,
 } from '../shared/constants';
@@ -107,6 +104,6 @@ export const getFunctions = async (
 			return true;
 		}
 
-		return l.version === CURRENT_VERSION;
+		return l.version === Internals.VERSION;
 	});
 };

--- a/packages/lambda/src/api/get-render-progress.ts
+++ b/packages/lambda/src/api/get-render-progress.ts
@@ -1,6 +1,7 @@
+import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
-import type { RenderProgress} from '../shared/constants';
+import type {RenderProgress} from '../shared/constants';
 import {LambdaRoutines} from '../shared/constants';
 
 export type GetRenderInput = {
@@ -31,6 +32,7 @@ export const getRenderProgress = async ({
 		payload: {
 			bucketName,
 			renderId,
+			version: VERSION,
 		},
 		region,
 	});

--- a/packages/lambda/src/api/mock-functions.ts
+++ b/packages/lambda/src/api/mock-functions.ts
@@ -1,17 +1,16 @@
 import type {AwsRegion} from '../pricing/aws-regions';
-import type {LambdaVersions} from '../shared/constants';
 import type {FunctionInfo} from './get-function-info';
 
 export let mockFunctionsStore: (FunctionInfo & {
 	region: AwsRegion;
-	version: LambdaVersions;
+	version: string;
 })[] = [];
 
 export const addFunction = (fn: FunctionInfo, region: AwsRegion) => {
 	mockFunctionsStore.push({
 		...fn,
 		region,
-		version: fn.version as LambdaVersions,
+		version: fn.version as string,
 	});
 };
 
@@ -27,10 +26,7 @@ export const findFunction = (name: string, region: string) => {
 	);
 };
 
-export const getAllMockFunctions = (
-	region: string,
-	version: LambdaVersions | null
-) => {
+export const getAllMockFunctions = (region: string, version: string | null) => {
 	return mockFunctionsStore.filter(
 		(f) => f.region === region && (version ? f.version === version : true)
 	);

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -6,7 +6,7 @@ import type {
 	PixelFormat,
 	ProResProfile,
 } from '@remotion/renderer';
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
 import type {OutNameInput, Privacy} from '../shared/constants';
@@ -134,7 +134,7 @@ export const renderMediaOnLambda = async ({
 				concurrencyPerLambda: concurrencyPerLambda ?? 1,
 				downloadBehavior: downloadBehavior ?? {type: 'play-in-browser'},
 				muted: muted ?? false,
-				version: Internals.VERSION,
+				version: VERSION,
 			},
 			region,
 		});

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -6,6 +6,7 @@ import type {
 	PixelFormat,
 	ProResProfile,
 } from '@remotion/renderer';
+import {Internals} from 'remotion';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
 import type {OutNameInput, Privacy} from '../shared/constants';
@@ -133,6 +134,7 @@ export const renderMediaOnLambda = async ({
 				concurrencyPerLambda: concurrencyPerLambda ?? 1,
 				downloadBehavior: downloadBehavior ?? {type: 'play-in-browser'},
 				muted: muted ?? false,
+				version: Internals.VERSION,
 			},
 			region,
 		});

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -3,7 +3,7 @@ import type {
 	LogLevel,
 	StillImageFormat,
 } from '@remotion/renderer';
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
 import type {CostsInfo, OutNameInput, Privacy} from '../shared/constants';
@@ -97,7 +97,7 @@ export const renderStillOnLambda = async ({
 				chromiumOptions: chromiumOptions ?? {},
 				scale: scale ?? 1,
 				downloadBehavior: downloadBehavior ?? {type: 'play-in-browser'},
-				version: Internals.VERSION,
+				version: VERSION,
 			},
 			region,
 		});

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -3,6 +3,7 @@ import type {
 	LogLevel,
 	StillImageFormat,
 } from '@remotion/renderer';
+import {Internals} from 'remotion';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
 import type {CostsInfo, OutNameInput, Privacy} from '../shared/constants';
@@ -96,6 +97,7 @@ export const renderStillOnLambda = async ({
 				chromiumOptions: chromiumOptions ?? {},
 				scale: scale ?? 1,
 				downloadBehavior: downloadBehavior ?? {type: 'play-in-browser'},
+				version: Internals.VERSION,
 			},
 			region,
 		});

--- a/packages/lambda/src/cli/commands/functions/deploy.ts
+++ b/packages/lambda/src/cli/commands/functions/deploy.ts
@@ -1,8 +1,8 @@
 import {CliInternals} from '@remotion/cli';
 import {Log} from '@remotion/cli/dist/log';
+import {Internals} from 'remotion';
 import {deployFunction} from '../../../api/deploy-function';
 import {
-	CURRENT_VERSION,
 	DEFAULT_ARCHITECTURE,
 	DEFAULT_CLOUDWATCH_RETENTION_PERIOD,
 	DEFAULT_EPHEMERAL_STORAGE_IN_MB,
@@ -43,7 +43,7 @@ Region = ${region}
 Memory = ${memorySizeInMb}MB
 Disk size = ${diskSizeInMb}MB
 Timeout = ${timeoutInSeconds}sec
-Version = ${CURRENT_VERSION}
+Version = ${Internals.VERSION}
 Architecture = ${architecture}
 CloudWatch Logging Enabled = ${createCloudWatchLogGroup}
 CloudWatch Retention Period = ${cloudWatchLogRetentionPeriodInDays} days

--- a/packages/lambda/src/cli/commands/functions/deploy.ts
+++ b/packages/lambda/src/cli/commands/functions/deploy.ts
@@ -1,6 +1,6 @@
 import {CliInternals} from '@remotion/cli';
 import {Log} from '@remotion/cli/dist/log';
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {deployFunction} from '../../../api/deploy-function';
 import {
 	DEFAULT_ARCHITECTURE,
@@ -43,7 +43,7 @@ Region = ${region}
 Memory = ${memorySizeInMb}MB
 Disk size = ${diskSizeInMb}MB
 Timeout = ${timeoutInSeconds}sec
-Version = ${Internals.VERSION}
+Version = ${VERSION}
 Architecture = ${architecture}
 CloudWatch Logging Enabled = ${createCloudWatchLogGroup}
 CloudWatch Retention Period = ${cloudWatchLogRetentionPeriodInDays} days

--- a/packages/lambda/src/cli/helpers/find-function-name.ts
+++ b/packages/lambda/src/cli/helpers/find-function-name.ts
@@ -1,4 +1,4 @@
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {getFunctions} from '../../api/get-functions';
 import {BINARY_NAME} from '../../shared/constants';
 import {FUNCTIONS_COMMAND} from '../commands/functions';
@@ -15,12 +15,12 @@ export const findFunctionName = async () => {
 		compatibleOnly: false,
 	});
 	const lambdasWithMatchingVersion = remotionLambdas.filter(
-		(l) => l.version === Internals.VERSION
+		(l) => l.version === VERSION
 	);
 
 	if (lambdasWithMatchingVersion.length === 0) {
 		Log.error(
-			`No lambda functions with version ${Internals.VERSION} found in your account.`
+			`No lambda functions with version ${VERSION} found in your account.`
 		);
 		if (remotionLambdas.length > 0) {
 			Log.error(

--- a/packages/lambda/src/cli/helpers/find-function-name.ts
+++ b/packages/lambda/src/cli/helpers/find-function-name.ts
@@ -1,5 +1,6 @@
+import {Internals} from 'remotion';
 import {getFunctions} from '../../api/get-functions';
-import {BINARY_NAME, CURRENT_VERSION} from '../../shared/constants';
+import {BINARY_NAME} from '../../shared/constants';
 import {FUNCTIONS_COMMAND} from '../commands/functions';
 import {FUNCTIONS_DEPLOY_SUBCOMMAND} from '../commands/functions/deploy';
 import {FUNCTIONS_LS_SUBCOMMAND} from '../commands/functions/ls';
@@ -14,12 +15,12 @@ export const findFunctionName = async () => {
 		compatibleOnly: false,
 	});
 	const lambdasWithMatchingVersion = remotionLambdas.filter(
-		(l) => l.version === CURRENT_VERSION
+		(l) => l.version === Internals.VERSION
 	);
 
 	if (lambdasWithMatchingVersion.length === 0) {
 		Log.error(
-			`No lambda functions with version ${CURRENT_VERSION} found in your account.`
+			`No lambda functions with version ${Internals.VERSION} found in your account.`
 		);
 		if (remotionLambdas.length > 0) {
 			Log.error(

--- a/packages/lambda/src/functions/chunk-optimization/can-use-optimization.ts
+++ b/packages/lambda/src/functions/chunk-optimization/can-use-optimization.ts
@@ -1,4 +1,4 @@
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import type {OptimizationProfile} from './types';
 
 export const canUseOptimization = ({
@@ -18,7 +18,7 @@ export const canUseOptimization = ({
 		return false;
 	}
 
-	if (optimization.lambdaVersion !== Internals.VERSION) {
+	if (optimization.lambdaVersion !== VERSION) {
 		return false;
 	}
 

--- a/packages/lambda/src/functions/chunk-optimization/can-use-optimization.ts
+++ b/packages/lambda/src/functions/chunk-optimization/can-use-optimization.ts
@@ -1,4 +1,4 @@
-import {CURRENT_VERSION} from '../../defaults';
+import {Internals} from 'remotion';
 import type {OptimizationProfile} from './types';
 
 export const canUseOptimization = ({
@@ -18,7 +18,7 @@ export const canUseOptimization = ({
 		return false;
 	}
 
-	if (optimization.lambdaVersion !== CURRENT_VERSION) {
+	if (optimization.lambdaVersion !== Internals.VERSION) {
 		return false;
 	}
 

--- a/packages/lambda/src/functions/chunk-optimization/types.ts
+++ b/packages/lambda/src/functions/chunk-optimization/types.ts
@@ -1,5 +1,3 @@
-import type {LambdaVersions} from '../../shared/constants';
-
 export type ObjectChunkTimingData = {
 	chunk: number;
 	frameRange: [number, number];
@@ -22,6 +20,6 @@ export type OptimizationProfile = {
 	newTiming: number;
 	createdFromRenderId: string;
 	framesPerLambda: number;
-	lambdaVersion: LambdaVersions;
+	lambdaVersion: string;
 	everyNthFrame: number;
 };

--- a/packages/lambda/src/functions/info.ts
+++ b/packages/lambda/src/functions/info.ts
@@ -1,4 +1,4 @@
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import type {LambdaPayload} from '../shared/constants';
 import {LambdaRoutines} from '../shared/constants';
 
@@ -7,10 +7,8 @@ export const infoHandler = (lambdaParams: LambdaPayload) => {
 		throw new TypeError('Expected info type');
 	}
 
-	const returnValue: {
-		version: string;
-	} = {
-		version: Internals.VERSION,
+	const returnValue = {
+		version: VERSION,
 	};
 
 	return Promise.resolve(returnValue);

--- a/packages/lambda/src/functions/info.ts
+++ b/packages/lambda/src/functions/info.ts
@@ -1,10 +1,6 @@
-import type {
-	LambdaPayload,
-	LambdaVersions} from '../shared/constants';
-import {
-	CURRENT_VERSION,
-	LambdaRoutines
-} from '../shared/constants';
+import {Internals} from 'remotion';
+import type {LambdaPayload} from '../shared/constants';
+import {LambdaRoutines} from '../shared/constants';
 
 export const infoHandler = (lambdaParams: LambdaPayload) => {
 	if (lambdaParams.type !== LambdaRoutines.info) {
@@ -12,9 +8,9 @@ export const infoHandler = (lambdaParams: LambdaPayload) => {
 	}
 
 	const returnValue: {
-		version: LambdaVersions;
+		version: string;
 	} = {
-		version: CURRENT_VERSION,
+		version: Internals.VERSION,
 	};
 
 	return Promise.resolve(returnValue);

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -2,6 +2,7 @@ import {InvokeCommand} from '@aws-sdk/client-lambda';
 import {RenderInternals} from '@remotion/renderer';
 import fs from 'fs';
 import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {getLambdaClient} from '../shared/aws-clients';
 import type {
 	EncodingProgress,
@@ -229,7 +230,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		type: 'video',
 		imageFormat: params.imageFormat,
 		inputProps: params.inputProps,
-		lambdaVersion: Internals.VERSION,
+		lambdaVersion: VERSION,
 		framesPerLambda,
 		memorySizeInMb: Number(process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE),
 		region: getCurrentRegionInFunction(),
@@ -373,7 +374,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 						newTiming: getProfileDuration(optimizedProfile),
 						createdFromRenderId: params.renderId,
 						framesPerLambda,
-						lambdaVersion: Internals.VERSION,
+						lambdaVersion: VERSION,
 						frameRange: realFrameRange,
 						everyNthFrame: params.everyNthFrame,
 					},

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -9,7 +9,6 @@ import type {
 	RenderMetadata,
 } from '../shared/constants';
 import {
-	CURRENT_VERSION,
 	encodingProgressKey,
 	LambdaRoutines,
 	MAX_FUNCTIONS_PER_RENDER,
@@ -230,7 +229,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		type: 'video',
 		imageFormat: params.imageFormat,
 		inputProps: params.inputProps,
-		lambdaVersion: CURRENT_VERSION,
+		lambdaVersion: Internals.VERSION,
 		framesPerLambda,
 		memorySizeInMb: Number(process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE),
 		region: getCurrentRegionInFunction(),
@@ -374,7 +373,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 						newTiming: getProfileDuration(optimizedProfile),
 						createdFromRenderId: params.renderId,
 						framesPerLambda,
-						lambdaVersion: CURRENT_VERSION,
+						lambdaVersion: Internals.VERSION,
 						frameRange: realFrameRange,
 						everyNthFrame: params.everyNthFrame,
 					},

--- a/packages/lambda/src/functions/progress.ts
+++ b/packages/lambda/src/functions/progress.ts
@@ -1,9 +1,6 @@
-import type {
-	LambdaPayload,
-	RenderProgress} from '../shared/constants';
-import {
-	LambdaRoutines
-} from '../shared/constants';
+import {VERSION} from 'remotion/version';
+import type {LambdaPayload, RenderProgress} from '../shared/constants';
+import {LambdaRoutines} from '../shared/constants';
 import {getCurrentRegionInFunction} from './helpers/get-current-region';
 import {getProgress} from './helpers/get-progress';
 
@@ -18,6 +15,18 @@ export const progressHandler = (
 ): Promise<RenderProgress> => {
 	if (lambdaParams.type !== LambdaRoutines.status) {
 		throw new TypeError('Expected status type');
+	}
+
+	if (lambdaParams.version !== VERSION) {
+		if (!lambdaParams.version) {
+			throw new Error(
+				`Version mismatch: When calling getRenderProgress(), the deployed Lambda function had version ${VERSION} but the @remotion/lambda package is an older version. Align the versions.`
+			);
+		}
+
+		throw new Error(
+			`Version mismatch: When calling getRenderProgress(), get deployed Lambda function had version ${VERSION} and the @remotion/lambda package has version ${lambdaParams.version}. Align the versions.`
+		);
 	}
 
 	return getProgress({

--- a/packages/lambda/src/functions/start.ts
+++ b/packages/lambda/src/functions/start.ts
@@ -1,5 +1,5 @@
 import {InvokeCommand} from '@aws-sdk/client-lambda';
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {getOrCreateBucket} from '../api/get-or-create-bucket';
 import {getLambdaClient} from '../shared/aws-clients';
 import type {LambdaPayload} from '../shared/constants';
@@ -12,15 +12,15 @@ export const startHandler = async (params: LambdaPayload) => {
 		throw new TypeError('Expected type start');
 	}
 
-	if (params.version !== Internals.VERSION) {
+	if (params.version !== VERSION) {
 		if (!params.version) {
 			throw new Error(
-				`Version mismatch: A Lambda function with version ${Internals.VERSION} was called using the @remotion/lambda package with an older version.`
+				`Version mismatch: A Lambda function with version ${VERSION} was called using the @remotion/lambda package with an older version.`
 			);
 		}
 
 		throw new Error(
-			`Version mismatch: A Lambda function with version ${Internals.VERSION} was called using the @remotion/lambda package with version ${params.version}`
+			`Version mismatch: A Lambda function with version ${VERSION} was called using the @remotion/lambda package with version ${params.version}`
 		);
 	}
 

--- a/packages/lambda/src/functions/start.ts
+++ b/packages/lambda/src/functions/start.ts
@@ -1,4 +1,5 @@
 import {InvokeCommand} from '@aws-sdk/client-lambda';
+import {Internals} from 'remotion';
 import {getOrCreateBucket} from '../api/get-or-create-bucket';
 import {getLambdaClient} from '../shared/aws-clients';
 import type {LambdaPayload} from '../shared/constants';
@@ -9,6 +10,18 @@ import {getCurrentRegionInFunction} from './helpers/get-current-region';
 export const startHandler = async (params: LambdaPayload) => {
 	if (params.type !== LambdaRoutines.start) {
 		throw new TypeError('Expected type start');
+	}
+
+	if (params.version !== Internals.VERSION) {
+		if (!params.version) {
+			throw new Error(
+				`Version mismatch: A Lambda function with version ${Internals.VERSION} was called using the @remotion/lambda package with an older version.`
+			);
+		}
+
+		throw new Error(
+			`Version mismatch: A Lambda function with version ${Internals.VERSION} was called using the @remotion/lambda package with version ${params.version}`
+		);
 	}
 
 	const {bucketName} = await getOrCreateBucket({

--- a/packages/lambda/src/functions/start.ts
+++ b/packages/lambda/src/functions/start.ts
@@ -15,12 +15,12 @@ export const startHandler = async (params: LambdaPayload) => {
 	if (params.version !== VERSION) {
 		if (!params.version) {
 			throw new Error(
-				`Version mismatch: A Lambda function with version ${VERSION} was called using the @remotion/lambda package with an older version.`
+				`Version mismatch: When calling renderMediaOnLambda(), the deployed Lambda function had version ${VERSION} but the @remotion/lambda package is an older version. Align the versions.`
 			);
 		}
 
 		throw new Error(
-			`Version mismatch: A Lambda function with version ${VERSION} was called using the @remotion/lambda package with version ${params.version}`
+			`Version mismatch: When calling renderMediaOnLambda(), get deployed Lambda function had version ${VERSION} and the @remotion/lambda package has version ${params.version}. Align the versions.`
 		);
 	}
 

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -48,6 +48,18 @@ const innerStillHandler = async (
 		throw new TypeError('Expected still type');
 	}
 
+	if (lambdaParams.version !== Internals.VERSION) {
+		if (!lambdaParams.version) {
+			throw new Error(
+				`Version mismatch: A Lambda function with version ${Internals.VERSION} was called using the @remotion/lambda package with an older version.`
+			);
+		}
+
+		throw new Error(
+			`Version mismatch: A Lambda function with version ${Internals.VERSION} was called using the @remotion/lambda package with version ${lambdaParams.version}`
+		);
+	}
+
 	validateDownloadBehavior(lambdaParams.downloadBehavior);
 	validatePrivacy(lambdaParams.privacy);
 	validateOutname(lambdaParams.outName);

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -3,6 +3,7 @@ import type {StillImageFormat} from '@remotion/renderer';
 import {RenderInternals, renderStill} from '@remotion/renderer';
 import fs from 'fs';
 import path from 'path';
+import {Internals} from 'remotion';
 import {estimatePrice} from '../api/estimate-price';
 import {getOrCreateBucket} from '../api/get-or-create-bucket';
 import {getLambdaClient} from '../shared/aws-clients';
@@ -12,7 +13,6 @@ import type {
 	RenderMetadata,
 } from '../shared/constants';
 import {
-	CURRENT_VERSION,
 	LambdaRoutines,
 	MAX_EPHEMERAL_STORAGE_IN_MB,
 	renderMetadataKey,
@@ -96,7 +96,7 @@ const innerStillHandler = async (
 		usesOptimizationProfile: false,
 		imageFormat: lambdaParams.imageFormat,
 		inputProps: lambdaParams.inputProps,
-		lambdaVersion: CURRENT_VERSION,
+		lambdaVersion: Internals.VERSION,
 		framesPerLambda: 1,
 		memorySizeInMb: Number(process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE),
 		region: getCurrentRegionInFunction(),

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -3,7 +3,7 @@ import type {StillImageFormat} from '@remotion/renderer';
 import {RenderInternals, renderStill} from '@remotion/renderer';
 import fs from 'fs';
 import path from 'path';
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {estimatePrice} from '../api/estimate-price';
 import {getOrCreateBucket} from '../api/get-or-create-bucket';
 import {getLambdaClient} from '../shared/aws-clients';
@@ -48,15 +48,15 @@ const innerStillHandler = async (
 		throw new TypeError('Expected still type');
 	}
 
-	if (lambdaParams.version !== Internals.VERSION) {
+	if (lambdaParams.version !== VERSION) {
 		if (!lambdaParams.version) {
 			throw new Error(
-				`Version mismatch: A Lambda function with version ${Internals.VERSION} was called using the @remotion/lambda package with an older version.`
+				`Version mismatch: A Lambda function with version ${VERSION} was called using the @remotion/lambda package with an older version.`
 			);
 		}
 
 		throw new Error(
-			`Version mismatch: A Lambda function with version ${Internals.VERSION} was called using the @remotion/lambda package with version ${lambdaParams.version}`
+			`Version mismatch: A Lambda function with version ${VERSION} was called using the @remotion/lambda package with version ${lambdaParams.version}`
 		);
 	}
 
@@ -108,7 +108,7 @@ const innerStillHandler = async (
 		usesOptimizationProfile: false,
 		imageFormat: lambdaParams.imageFormat,
 		inputProps: lambdaParams.inputProps,
-		lambdaVersion: Internals.VERSION,
+		lambdaVersion: VERSION,
 		framesPerLambda: 1,
 		memorySizeInMb: Number(process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE),
 		region: getCurrentRegionInFunction(),

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -51,12 +51,12 @@ const innerStillHandler = async (
 	if (lambdaParams.version !== VERSION) {
 		if (!lambdaParams.version) {
 			throw new Error(
-				`Version mismatch: A Lambda function with version ${VERSION} was called using the @remotion/lambda package with an older version.`
+				`Version mismatch: When calling renderStillOnLambda(), the deployed Lambda function had version ${VERSION} but the @remotion/lambda package is an older version. Align the versions.`
 			);
 		}
 
 		throw new Error(
-			`Version mismatch: A Lambda function with version ${VERSION} was called using the @remotion/lambda package with version ${lambdaParams.version}`
+			`Version mismatch: When calling renderStillOnLambda(), get deployed Lambda function had version ${VERSION} and the @remotion/lambda package has version ${lambdaParams.version}. Align the versions.`
 		);
 	}
 

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -312,15 +312,11 @@ export type RenderMetadata = {
 	inputProps: unknown;
 	framesPerLambda: number;
 	memorySizeInMb: number;
-	lambdaVersion: LambdaVersions;
+	lambdaVersion: string;
 	region: AwsRegion;
 	renderId: string;
 	outName: OutNameInput | undefined;
 };
-
-export type LambdaVersions = '2022-08-16' | 'n/a';
-
-export const CURRENT_VERSION: LambdaVersions = '2022-08-16';
 
 export type PostRenderData = {
 	cost: {

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -236,6 +236,7 @@ export type LambdaPayloads = {
 		type: LambdaRoutines.status;
 		bucketName: string;
 		renderId: string;
+		version: string;
 	};
 	renderer: {
 		concurrencyPerLambda: number;

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -201,6 +201,7 @@ export type LambdaPayloads = {
 		concurrencyPerLambda: number;
 		downloadBehavior: DownloadBehavior;
 		muted: boolean;
+		version: string;
 	};
 	launch: {
 		type: LambdaRoutines.launch;
@@ -285,6 +286,7 @@ export type LambdaPayloads = {
 		chromiumOptions: ChromiumOptions;
 		scale: number;
 		downloadBehavior: DownloadBehavior | null;
+		version: string;
 	};
 };
 

--- a/packages/lambda/src/shared/get-function-version.ts
+++ b/packages/lambda/src/shared/get-function-version.ts
@@ -1,6 +1,5 @@
 import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from './call-lambda';
-import type { LambdaVersions} from './constants';
 import {COMMAND_NOT_FOUND, LambdaRoutines} from './constants';
 
 export const getFunctionVersion = async ({
@@ -9,7 +8,7 @@ export const getFunctionVersion = async ({
 }: {
 	functionName: string;
 	region: AwsRegion;
-}): Promise<LambdaVersions> => {
+}): Promise<string> => {
 	try {
 		const result = await callLambda({
 			functionName,

--- a/packages/lambda/src/test/integration/cli.test.ts
+++ b/packages/lambda/src/test/integration/cli.test.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import {CliInternals} from '@remotion/cli';
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {
 	DEFAULT_EPHEMERAL_STORAGE_IN_MB,
 	DEFAULT_MEMORY_SIZE,
@@ -12,7 +12,7 @@ import {getProcessWriteOutput} from './console-hooks';
 test('Deploy function', async () => {
 	await LambdaInternals.executeCommand(['functions', 'deploy']);
 	expect(getProcessWriteOutput()).toContain(
-		`Deployed as remotion-render-${Internals.VERSION.replace(
+		`Deployed as remotion-render-${VERSION.replace(
 			/\./g,
 			'-'
 		)}-mem${DEFAULT_MEMORY_SIZE}mb-disk${DEFAULT_EPHEMERAL_STORAGE_IN_MB}mb-${DEFAULT_TIMEOUT}sec\n`

--- a/packages/lambda/src/test/integration/cli.test.ts
+++ b/packages/lambda/src/test/integration/cli.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {CliInternals} from '@remotion/cli';
+import {Internals} from 'remotion';
 import {
-	CURRENT_VERSION,
 	DEFAULT_EPHEMERAL_STORAGE_IN_MB,
 	DEFAULT_MEMORY_SIZE,
 	DEFAULT_TIMEOUT,
@@ -12,7 +12,10 @@ import {getProcessWriteOutput} from './console-hooks';
 test('Deploy function', async () => {
 	await LambdaInternals.executeCommand(['functions', 'deploy']);
 	expect(getProcessWriteOutput()).toContain(
-		`Deployed as remotion-render-${CURRENT_VERSION}-mem${DEFAULT_MEMORY_SIZE}mb-disk${DEFAULT_EPHEMERAL_STORAGE_IN_MB}mb-${DEFAULT_TIMEOUT}sec\n`
+		`Deployed as remotion-render-${Internals.VERSION.replace(
+			/\./g,
+			'-'
+		)}-mem${DEFAULT_MEMORY_SIZE}mb-disk${DEFAULT_EPHEMERAL_STORAGE_IN_MB}mb-${DEFAULT_TIMEOUT}sec\n`
 	);
 });
 

--- a/packages/lambda/src/test/integration/deploy-function.test.ts
+++ b/packages/lambda/src/test/integration/deploy-function.test.ts
@@ -1,3 +1,4 @@
+import {Internals} from 'remotion';
 import {deleteFunction} from '../../api/delete-function';
 import {deployFunction} from '../../api/deploy-function';
 import {getFunctions} from '../../api/get-functions';
@@ -5,13 +6,13 @@ import {
 	cleanFnStore,
 	markFunctionAsIncompatible,
 } from '../../api/mock-functions';
-import {
-	CURRENT_VERSION,
-	DEFAULT_EPHEMERAL_STORAGE_IN_MB,
-} from '../../shared/constants';
+import {DEFAULT_EPHEMERAL_STORAGE_IN_MB} from '../../shared/constants';
 
 const expectedFunctionName = (memory: number, timeout: number, disk: number) =>
-	`remotion-render-${CURRENT_VERSION}-mem${memory}mb-disk${disk}mb-${timeout}sec`;
+	`remotion-render-${Internals.VERSION.replace(
+		/\./g,
+		'-'
+	)}-mem${memory}mb-disk${disk}mb-${timeout}sec`;
 
 test('Should be able to deploy function', async () => {
 	const {functionName} = await deployFunction({
@@ -52,7 +53,7 @@ test('Should be able to get the function afterwards', async () => {
 			),
 			memorySizeInMb: 2048,
 			timeoutInSeconds: 120,
-			version: CURRENT_VERSION,
+			version: Internals.VERSION,
 			region: 'us-east-1',
 			diskSizeInMb: 2048,
 		},
@@ -118,7 +119,7 @@ test('Should be able to get the function afterwards', async () => {
 			),
 			memorySizeInMb: 2048,
 			timeoutInSeconds: 120,
-			version: CURRENT_VERSION,
+			version: Internals.VERSION,
 			region: 'us-east-1',
 			diskSizeInMb: 2048,
 		},

--- a/packages/lambda/src/test/integration/deploy-function.test.ts
+++ b/packages/lambda/src/test/integration/deploy-function.test.ts
@@ -1,4 +1,4 @@
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {deleteFunction} from '../../api/delete-function';
 import {deployFunction} from '../../api/deploy-function';
 import {getFunctions} from '../../api/get-functions';
@@ -9,7 +9,7 @@ import {
 import {DEFAULT_EPHEMERAL_STORAGE_IN_MB} from '../../shared/constants';
 
 const expectedFunctionName = (memory: number, timeout: number, disk: number) =>
-	`remotion-render-${Internals.VERSION.replace(
+	`remotion-render-${VERSION.replace(
 		/\./g,
 		'-'
 	)}-mem${memory}mb-disk${disk}mb-${timeout}sec`;
@@ -53,7 +53,7 @@ test('Should be able to get the function afterwards', async () => {
 			),
 			memorySizeInMb: 2048,
 			timeoutInSeconds: 120,
-			version: Internals.VERSION,
+			version: VERSION,
 			region: 'us-east-1',
 			diskSizeInMb: 2048,
 		},
@@ -119,7 +119,7 @@ test('Should be able to get the function afterwards', async () => {
 			),
 			memorySizeInMb: 2048,
 			timeoutInSeconds: 120,
-			version: Internals.VERSION,
+			version: VERSION,
 			region: 'us-east-1',
 			diskSizeInMb: 2048,
 		},

--- a/packages/lambda/src/test/integration/handlers.test.ts
+++ b/packages/lambda/src/test/integration/handlers.test.ts
@@ -1,4 +1,5 @@
-import {CURRENT_VERSION, LambdaRoutines} from '../../defaults';
+import {VERSION} from 'remotion/src/version';
+import {LambdaRoutines} from '../../defaults';
 import {handler} from '../../functions/index';
 
 test('Call function locally', async () => {
@@ -10,5 +11,5 @@ test('Call function locally', async () => {
 				getRemainingTimeInMillis: () => 1000,
 			}
 		)
-	).toEqual({version: CURRENT_VERSION});
+	).toEqual({version: VERSION});
 });

--- a/packages/lambda/src/test/integration/renders/gif.test.ts
+++ b/packages/lambda/src/test/integration/renders/gif.test.ts
@@ -1,5 +1,6 @@
 import {RenderInternals} from '@remotion/renderer';
 import {createWriteStream} from 'fs';
+import {VERSION} from 'remotion/version';
 import {LambdaRoutines} from '../../../defaults';
 import {handler} from '../../../functions';
 import {lambdaReadFile} from '../../../functions/helpers/io';
@@ -56,6 +57,7 @@ test('Should make a distributed GIF', async () => {
 			concurrencyPerLambda: 1,
 			downloadBehavior: {type: 'play-in-browser'},
 			muted: false,
+			version: VERSION,
 		},
 		extraContext
 	);
@@ -66,6 +68,7 @@ test('Should make a distributed GIF', async () => {
 			type: LambdaRoutines.status,
 			bucketName: startRes.bucketName,
 			renderId: startRes.renderId,
+			version: VERSION,
 		},
 		extraContext
 	)) as Await<LambdaReturnValues[LambdaRoutines.status]>;

--- a/packages/lambda/src/test/integration/renders/old-version.test.ts
+++ b/packages/lambda/src/test/integration/renders/old-version.test.ts
@@ -1,4 +1,5 @@
 import {RenderInternals} from '@remotion/renderer';
+import {VERSION} from 'remotion/version';
 import {LambdaRoutines} from '../../../defaults';
 import {handler} from '../../../functions';
 import type {LambdaReturnValues} from '../../../shared/return-values';
@@ -55,6 +56,7 @@ test('Should fail when using an incompatible version', async () => {
 				type: 'play-in-browser',
 			},
 			muted: false,
+			version: VERSION,
 		},
 		extraContext
 	);
@@ -65,6 +67,7 @@ test('Should fail when using an incompatible version', async () => {
 			type: LambdaRoutines.status,
 			bucketName: startRes.bucketName,
 			renderId: startRes.renderId,
+			version: VERSION,
 		},
 		extraContext
 	)) as Await<LambdaReturnValues[LambdaRoutines.status]>;

--- a/packages/lambda/src/test/integration/renders/other-bucket.test.ts
+++ b/packages/lambda/src/test/integration/renders/other-bucket.test.ts
@@ -1,4 +1,5 @@
 import {RenderInternals} from '@remotion/renderer';
+import {VERSION} from 'remotion/version';
 import {LambdaRoutines} from '../../../defaults';
 import {handler} from '../../../functions';
 import {lambdaReadFile} from '../../../functions/helpers/io';
@@ -59,6 +60,7 @@ test('Should be able to render to another bucket', async () => {
 				type: 'play-in-browser',
 			},
 			muted: false,
+			version: VERSION,
 		},
 		extraContext
 	);
@@ -69,6 +71,7 @@ test('Should be able to render to another bucket', async () => {
 			type: LambdaRoutines.status,
 			bucketName: startRes.bucketName,
 			renderId: startRes.renderId,
+			version: VERSION,
 		},
 		extraContext
 	)) as Await<LambdaReturnValues[LambdaRoutines.status]>;

--- a/packages/lambda/src/test/integration/renders/silent-audio.test.ts
+++ b/packages/lambda/src/test/integration/renders/silent-audio.test.ts
@@ -1,4 +1,5 @@
 import {RenderInternals} from '@remotion/renderer';
+import {VERSION} from 'remotion/version';
 import {LambdaRoutines} from '../../../defaults';
 import {handler} from '../../../functions';
 import {lambdaReadFile} from '../../../functions/helpers/io';
@@ -56,6 +57,7 @@ test('Should add silent audio if there is no audio', async () => {
 				type: 'play-in-browser',
 			},
 			muted: false,
+			version: VERSION,
 		},
 		extraContext
 	);
@@ -66,6 +68,7 @@ test('Should add silent audio if there is no audio', async () => {
 			type: LambdaRoutines.status,
 			bucketName: startRes.bucketName,
 			renderId: startRes.renderId,
+			version: VERSION,
 		},
 		extraContext
 	)) as Await<LambdaReturnValues[LambdaRoutines.status]>;

--- a/packages/lambda/src/test/integration/renders/transparent-webm.test.ts
+++ b/packages/lambda/src/test/integration/renders/transparent-webm.test.ts
@@ -2,6 +2,7 @@ import {RenderInternals} from '@remotion/renderer';
 import fs, {createWriteStream} from 'fs';
 import os from 'os';
 import path from 'path';
+import {VERSION} from 'remotion/version';
 import {LambdaRoutines} from '../../../defaults';
 import {handler} from '../../../functions';
 import {lambdaReadFile} from '../../../functions/helpers/io';
@@ -58,6 +59,7 @@ test('Should make a transparent video', async () => {
 				type: 'play-in-browser',
 			},
 			muted: false,
+			version: VERSION,
 		},
 		extraContext
 	);
@@ -68,6 +70,7 @@ test('Should make a transparent video', async () => {
 			type: LambdaRoutines.status,
 			bucketName: startRes.bucketName,
 			renderId: startRes.renderId,
+			version: VERSION,
 		},
 		extraContext
 	)) as Await<LambdaReturnValues[LambdaRoutines.status]>;

--- a/packages/renderer/src/set-props-and-env.ts
+++ b/packages/renderer/src/set-props-and-env.ts
@@ -1,4 +1,4 @@
-import {Internals} from 'remotion';
+import {VERSION} from 'remotion/version';
 import type {Page} from './browser/BrowserPage';
 import {DEFAULT_TIMEOUT} from './browser/TimeoutSettings';
 import {normalizeServeUrl} from './normalize-serve-url';
@@ -154,14 +154,14 @@ export const setPropsAndEnv = async ({
 		);
 	}
 
-	if (remotionVersion !== Internals.VERSION) {
+	if (remotionVersion !== VERSION) {
 		if (remotionVersion) {
 			console.warn(
-				`The site was bundled with version ${remotionVersion} of @remotion/bundler, while @remotion/renderer is on version ${Internals.VERSION}. You may not have the newest bugfixes and features. Re-bundle the site to fix this issue.`
+				`The site was bundled with version ${remotionVersion} of @remotion/bundler, while @remotion/renderer is on version ${VERSION}. You may not have the newest bugfixes and features. Re-bundle the site to fix this issue.`
 			);
 		} else {
 			console.warn(
-				`The site was bundled with an old version of Remotion, while @remotion/renderer is on version ${Internals.VERSION}. You may not have the newest bugfixes and features. Re-bundle the site to fix this issue.`
+				`The site was bundled with an old version of Remotion, while @remotion/renderer is on version ${VERSION}. You may not have the newest bugfixes and features. Re-bundle the site to fix this issue.`
 			);
 		}
 	}

--- a/packages/renderer/src/set-props-and-env.ts
+++ b/packages/renderer/src/set-props-and-env.ts
@@ -1,3 +1,4 @@
+import {Internals} from 'remotion';
 import type {Page} from './browser/BrowserPage';
 import {DEFAULT_TIMEOUT} from './browser/TimeoutSettings';
 import {normalizeServeUrl} from './normalize-serve-url';
@@ -136,11 +137,32 @@ export const setPropsAndEnv = async ({
 		page,
 	});
 
+	const remotionVersion = await puppeteerEvaluateWithCatch<string>({
+		pageFunction: () => {
+			return window.remotion_version;
+		},
+		args: [],
+		frame: null,
+		page,
+	});
+
 	const requiredVersion = '4';
 
 	if (siteVersion !== requiredVersion) {
 		throw new Error(
 			`Incompatible site: When visiting ${urlToVisit}, a bundle was found, but one that is not compatible with this version of Remotion. Found version: ${siteVersion} - Required version: ${requiredVersion}. To resolve this error, please bundle and deploy again.`
 		);
+	}
+
+	if (remotionVersion !== Internals.VERSION) {
+		if (remotionVersion) {
+			console.warn(
+				`The site was bundled with version ${remotionVersion} of @remotion/bundler, while @remotion/renderer is on version ${Internals.VERSION}. You may not have the newest bugfixes and features. Re-bundle the site to fix this issue.`
+			);
+		} else {
+			console.warn(
+				`The site was bundled with an old version of Remotion, while @remotion/renderer is on version ${Internals.VERSION}. You may not have the newest bugfixes and features. Re-bundle the site to fix this issue.`
+			);
+		}
 	}
 };


### PR DESCRIPTION
- Simpler Remotion Lambda versions: No more versions in the format of `2022-08-23`, now it's the same version as the Remotion Lambda package itself (e.g. `3.2.5`)
- Warn when site was bundled with a different version
- Fail when multiple versions of Remotion are imported on a site and mention their versions
- Fail when functions are mismatching when calling `renderMediaOnLambda()` and `renderStillOnLambda()`
- Improve documentation when upgrading Remotion Lambda by suggesting to use `--site-name` and updating your site