### PR TITLE
Update get-audio-data.ts

### DIFF
--- a/packages/media-utils/src/get-audio-data.ts
+++ b/packages/media-utils/src/get-audio-data.ts
@@ -10,6 +10,7 @@ const fetchWithCorsCatch = async (src: string) => {
 	try {
 		const response = await fetch(src, {
 			mode: 'cors',
+			referrerPolicy: 'no-referrer-when-downgrade',
 		});
 		return response;
 	} catch (err) {


### PR DESCRIPTION
When setting this header, the `Origin` header gets set when a request gets made from HTTP -> HTTPS, which makes S3 add CORS headers.