### PR TITLE
take content-type into consideration when downloading an asset

### DIFF
--- a/packages/renderer/src/assets/download-and-map-assets-to-file.ts
+++ b/packages/renderer/src/assets/download-and-map-assets-to-file.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
-import path from 'path';
+import path, {extname} from 'path';
 import type {TAsset} from 'remotion';
 import {random} from 'remotion';
 import {isAssetCompressed} from '../compress-assets';
 import {ensureOutputDirectory} from '../ensure-output-directory';
+import {getExt} from '../mime-types';
 import {downloadFile} from './download-file';
 import type {DownloadMap} from './download-map';
 import {sanitizeFilePath} from './sanitize-filepath';
@@ -197,6 +198,7 @@ export const downloadAsset = async ({
 			contentDisposition: null,
 			downloadDir,
 			src,
+			contentType: null,
 		});
 		ensureOutputDirectory(output);
 		const [assetDetails, assetData] = src.substring('data:'.length).split(',');
@@ -226,8 +228,13 @@ export const downloadAsset = async ({
 		onProgress: (progress) => {
 			onProgress?.(progress);
 		},
-		to: (contentDisposition) =>
-			getSanitizedFilenameForAssetUrl({contentDisposition, downloadDir, src}),
+		to: (contentDisposition, contentType) =>
+			getSanitizedFilenameForAssetUrl({
+				contentDisposition,
+				downloadDir,
+				src,
+				contentType,
+			}),
 	});
 
 	notifyAssetIsDownloaded({src, downloadMap, downloadDir, to});
@@ -248,9 +255,11 @@ export const markAllAssetsAsDownloaded = (downloadMap: DownloadMap) => {
 const getFilename = ({
 	contentDisposition,
 	src,
+	contentType,
 }: {
 	src: string;
 	contentDisposition: string | null;
+	contentType: string | null;
 }): {pathname: string; search: string} => {
 	const filenameProbe = 'filename=';
 	if (contentDisposition?.includes(filenameProbe)) {
@@ -272,6 +281,18 @@ const getFilename = ({
 
 	const {pathname, search} = new URL(src);
 
+	const ext = extname(pathname);
+
+	if (!ext && contentType) {
+		const matchedExt = getExt(contentType);
+
+		return {
+			pathname: `${pathname}.${matchedExt}`,
+			search,
+		};
+		// Has no file extension, check if we can derive it from contentType
+	}
+
 	return {pathname, search};
 };
 
@@ -279,16 +300,22 @@ export const getSanitizedFilenameForAssetUrl = ({
 	src,
 	downloadDir,
 	contentDisposition,
+	contentType,
 }: {
 	src: string;
 	downloadDir: string;
 	contentDisposition: string | null;
+	contentType: string | null;
 }) => {
 	if (isAssetCompressed(src)) {
 		return src;
 	}
 
-	const {pathname, search} = getFilename({contentDisposition, src});
+	const {pathname, search} = getFilename({
+		contentDisposition,
+		contentType,
+		src,
+	});
 
 	const split = pathname.split('.');
 	const fileExtension =

--- a/packages/renderer/src/assets/download-and-map-assets-to-file.ts
+++ b/packages/renderer/src/assets/download-and-map-assets-to-file.ts
@@ -283,6 +283,7 @@ const getFilename = ({
 
 	const ext = extname(pathname);
 
+	// Has no file extension, check if we can derive it from contentType
 	if (!ext && contentType) {
 		const matchedExt = getExt(contentType);
 
@@ -290,7 +291,6 @@ const getFilename = ({
 			pathname: `${pathname}.${matchedExt}`,
 			search,
 		};
-		// Has no file extension, check if we can derive it from contentType
 	}
 
 	return {pathname, search};

--- a/packages/renderer/src/assets/download-file.ts
+++ b/packages/renderer/src/assets/download-file.ts
@@ -8,7 +8,7 @@ export const downloadFile = ({
 	to: toFn,
 }: {
 	url: string;
-	to: (contentDisposition: string | null) => string;
+	to: (contentDisposition: string | null, contentType: string | null) => string;
 	onProgress:
 		| ((progress: {
 				percent: number | null;
@@ -21,7 +21,8 @@ export const downloadFile = ({
 		readFile(url)
 			.then((res) => {
 				const contentDisposition = res.headers['content-disposition'] ?? null;
-				const to = toFn(contentDisposition);
+				const contentType = res.headers['content-type'] ?? null;
+				const to = toFn(contentDisposition, contentType);
 				ensureOutputDirectory(to);
 
 				const sizeHeader = res.headers['content-length'];

--- a/packages/renderer/src/guess-extension-for-media.ts
+++ b/packages/renderer/src/guess-extension-for-media.ts
@@ -24,6 +24,6 @@ export const guessExtensionForVideo = async (src: string) => {
 	}
 
 	throw new Error(
-		`A media file ${src} which has no file extension and whose format could not be guessed. Is this a valid media file?`
+		`The media file "${src}" has no file extension and the format could not be guessed. Tips: a) Ensure this is a valid video or audio file b) Add a file extension to the URL like ".mp4" c) Set a "Content-Type" or "Content-Disposition" header if possible.`
 	);
 };

--- a/packages/renderer/src/mime-types.ts
+++ b/packages/renderer/src/mime-types.ts
@@ -7,6 +7,10 @@ const types: Record<string, string> = {};
 // Populate the extensions/types maps
 populateMaps(extensions, {});
 
+export const getExt = (contentType: string): string | null => {
+	return mimeDb[contentType.toLowerCase()]?.extensions?.[0] ?? null;
+};
+
 export function mimeLookup(path: string) {
 	if (!path || typeof path !== 'string') {
 		return false;

--- a/packages/renderer/src/test/download-file.test.ts
+++ b/packages/renderer/src/test/download-file.test.ts
@@ -8,11 +8,12 @@ test('Should be able to download file', async () => {
 	const downloadDir = tmpdir();
 	const {to} = await downloadFile({
 		url: 'https://example.net/',
-		to: (contentDisposition) => {
+		to: (contentDisposition, contentType) => {
 			return getSanitizedFilenameForAssetUrl({
 				contentDisposition,
 				downloadDir,
 				src: 'https://example.net/',
+				contentType,
 			});
 		},
 		onProgress: () => undefined,
@@ -28,9 +29,10 @@ test('Should fail to download invalid files', async () => {
 	const downloadDir = tmpdir();
 	await expect(() =>
 		downloadFile({
-			to: (contentDisposition) => {
+			to: (contentDisposition, contentType) => {
 				return getSanitizedFilenameForAssetUrl({
 					contentDisposition,
+					contentType,
 					downloadDir,
 					src: 'https://thisdomain.doesnotexist',
 				});

--- a/packages/renderer/src/test/handle-weird-file-names.test.ts
+++ b/packages/renderer/src/test/handle-weird-file-names.test.ts
@@ -7,6 +7,7 @@ test('Should sanitize weird file names when downloading', () => {
 		src: 'http://gtts-api.miniggiodev.fr/Ici+Japon+Corp.?lang=ja',
 		downloadDir: '/var/tmp',
 		contentDisposition: null,
+		contentType: null,
 	});
 	expect(newSrc).toBe(
 		process.platform === 'win32'
@@ -20,16 +21,19 @@ test('Should give different file names based on different url query parameters',
 		src: 'https://gtts-api.miniggiodev.fr/Ici+Japon+Corp.mp4?hi=1',
 		downloadDir: '',
 		contentDisposition: null,
+		contentType: null,
 	});
 	const sameAgain = getSanitizedFilenameForAssetUrl({
 		src: 'https://gtts-api.miniggiodev.fr/Ici+Japon+Corp.mp4?hi=1',
 		downloadDir: '',
 		contentDisposition: null,
+		contentType: null,
 	});
 	const differentAsset = getSanitizedFilenameForAssetUrl({
 		src: 'https://gtts-api.miniggiodev.fr/Ici+Japon+Corp.mp4?hi=2',
 		downloadDir: '',
 		contentDisposition: null,
+		contentType: null,
 	});
 	expect(asset1).toEqual(sameAgain);
 	expect(asset1).not.toEqual(differentAsset);
@@ -41,6 +45,7 @@ test('Should give different file names based on different url query parameters',
 		downloadDir: 'dl',
 		contentDisposition:
 			'attachment; filename=notjacksondatiras_1656689770_musicaldown.com.mp4; otherstuff',
+		contentType: null,
 	});
 	expect(asset1).toEqual(`dl${path.sep}2276125883217901.mp4`);
 	const asset2 = getSanitizedFilenameForAssetUrl({
@@ -48,6 +53,17 @@ test('Should give different file names based on different url query parameters',
 		downloadDir: 'dl',
 		contentDisposition:
 			'attachment; filename=notjacksondatiras_1656689770_musicaldown.com.mp4',
+		contentType: null,
 	});
 	expect(asset2).toEqual(`dl${path.sep}2276125883217901.mp4`);
+});
+
+test('Should attach correct file extensions ', () => {
+	const asset = getSanitizedFilenameForAssetUrl({
+		src: 'https://gtts-api.miniggiodev.fr/aha',
+		downloadDir: 'dl',
+		contentDisposition: null,
+		contentType: 'video/mp4',
+	});
+	expect(asset).toEqual(`dl${path.sep}2627764018252492.mp4`);
 });

--- a/packages/renderer/src/test/mime-types.test.ts
+++ b/packages/renderer/src/test/mime-types.test.ts
@@ -1,7 +1,11 @@
 import {expect, test} from 'vitest';
-import {mimeLookup} from '../mime-types';
+import {getExt, mimeLookup} from '../mime-types';
 
 test('Should get mime types', () => {
 	expect(mimeLookup('hi.png')).toBe('image/png');
 	expect(mimeLookup('hi.svg')).toBe('image/svg+xml');
+});
+
+test('Should be able to get extension', () => {
+	expect(getExt('video/mp4')).toBe('mp4');
 });


### PR DESCRIPTION
If file has no extension but a `Content-Type: video/mp4` header, the video will be downloaded as a .mp4 video