### PR TITLE
renderMedia() allows relative output paths

### DIFF
--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -340,7 +340,6 @@ export const renderMedia = ({
 			callUpdate();
 
 			if (absoluteOutputLocation) {
-				console.log({outputLocation});
 				ensureOutputDirectory(absoluteOutputLocation);
 			}
 

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -139,6 +139,10 @@ export const renderMedia = ({
 		validateOutputFilename(codec, getExtensionOfFilename(outputLocation));
 	}
 
+	const absoluteOutputLocation = outputLocation
+		? path.resolve(process.cwd(), outputLocation)
+		: null;
+
 	validateScale(scale);
 
 	const everyNthFrame = options.everyNthFrame ?? 1;
@@ -335,8 +339,9 @@ export const renderMedia = ({
 			renderedDoneIn = Date.now() - renderStart;
 			callUpdate();
 
-			if (outputLocation) {
-				ensureOutputDirectory(outputLocation);
+			if (absoluteOutputLocation) {
+				console.log({outputLocation});
+				ensureOutputDirectory(absoluteOutputLocation);
 			}
 
 			const stitchStart = Date.now();
@@ -345,7 +350,7 @@ export const renderMedia = ({
 					width: composition.width * (scale ?? 1),
 					height: composition.height * (scale ?? 1),
 					fps,
-					outputLocation,
+					outputLocation: absoluteOutputLocation,
 					internalOptions: {
 						preEncodedFileLocation,
 						imageFormat,


### PR DESCRIPTION
`outputLocation: "out/video.mp4"` will be resolved against the current working directory.