### PR TITLE
Remove the second browserExecutable argument

### DIFF
--- a/packages/docs/docs/renderer/render-frames.md
+++ b/packages/docs/docs/renderer/render-frames.md
@@ -189,12 +189,6 @@ renderFrames({
 });
 ```
 
-### `browserExecutable?`
-
-_optional, available from v2.3.1_
-
-A string defining the absolute path on disk of the browser executable that should be used. By default Remotion will try to detect it automatically and download one if none is available. If `puppeteerInstance` is defined, it will take precedence over `browserExecutable`.
-
 ### `ffmpegExecutable?`
 
 _optional, available from v3.0.11_


### PR DESCRIPTION
By some reason there's two "browserExecutable" arguments in the arguments section. One of them should not be there??

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
