### PR TITLE
docs: add docs for smoothing option

### DIFF
--- a/packages/docs/docs/visualize-audio.md
+++ b/packages/docs/docs/visualize-audio.md
@@ -21,6 +21,9 @@ The only argument for this function is an object containing the following values
 
 - `numberOfSamples`: `number` - must be a power of two, such as `32`, `64`, `128`, etc. This parameter controls the length of the output array. A lower number will simplify the spectrum and is useful if you want to animate elements roughly based on the level of lows, mids and highs. A higher number will give the spectrum in more detail, which is useful for displaying a bar chart or waveform-style visualization of the audio.
 
+- `smoothing`: `boolean` - when set to `true` the returned values will be an average of the current, previous and next frames. The result is a smoother transition for quickly changing values. Default value is `true`.
+
+
 ## Return value
 
 `number[]` - An array of values describing the amplitude of each frequency range. Each value is between 0 and 1. The array is of length defined by the `numberOfSamples` parameter.


### PR DESCRIPTION
Issue: #650 

Description comes from inspecting the Remotion source code. I debated whether to describe how the smoothing works (that it's an average) but I ended up thinking if someone's interested in the property they're probably somewhat interested in how the smoothing happens.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#650: visualizeAudio - smoothing parameter is not documented](https://issuehunt.io/repos/274495425/issues/650)
---
</details>
<!-- /Issuehunt content-->