### PR TITLE
add publicDir and rootDir() options to deploySite and document them for bundle()

### DIFF
--- a/packages/docs/docs/bundle.md
+++ b/packages/docs/docs/bundle.md
@@ -91,7 +91,7 @@ The current working directory is the directory from which your program gets exec
 
 _Available from v3.2.13_
 
-TODO!!!
+Set the directory in which the files that can be loaded using [`staticFile()`](/docs/staticfile) are located. By default it is the folder `public/` located in the Remotion root folder.
 
 ## Return value
 

--- a/packages/docs/docs/lambda/deploysite.md
+++ b/packages/docs/docs/lambda/deploysite.md
@@ -99,6 +99,22 @@ _optional - default true_
 
 Whether webpack caching should be enabled. See [`bundle()` -> enableCaching](/docs/bundle#enablecaching) for more information.
 
+#### `publicDir?`
+
+_optional, available from v3.2.17_
+
+Set the directory in which the files that can be loaded using [`staticFile()`](/docs/staticfile) are located. By default it is the folder `public/` located in the Remotion root folder.
+
+#### `rootDir?`
+
+_optional, available from v3.2.17_
+
+The directory in which the Remotion project is rooted in. This should be set to the directory that contains the `package.json` which installs Remotion. By default, it is the current working directory.
+
+:::note
+The current working directory is the directory from which your program gets executed from. It is not the same as the file where bundle() gets called.
+:::
+
 ## Return value
 
 An object with the following values:

--- a/packages/lambda/src/api/deploy-site.ts
+++ b/packages/lambda/src/api/deploy-site.ts
@@ -24,6 +24,8 @@ export type DeploySiteInput = {
 		onUploadProgress?: (upload: UploadDirProgress) => void;
 		webpackOverride?: WebpackOverrideFn;
 		enableCaching?: boolean;
+		publicDir?: string | null;
+		rootDir?: string;
 	};
 };
 
@@ -77,6 +79,8 @@ export const deploySite = async ({
 			publicPath: `/${subFolder}/`,
 			webpackOverride: options?.webpackOverride ?? ((f) => f),
 			enableCaching: options?.enableCaching ?? true,
+			publicDir: options?.publicDir,
+			rootDir: options?.rootDir,
 		}
 	);
 


### PR DESCRIPTION
(Previously there was a TODO comment in the docs)