### PR TITLE
Allow Remotion Lambda artifact to be saved to another provider (e.g. DigitalOcean)

### DIFF
--- a/packages/docs/docs/lambda/custom-destination.md
+++ b/packages/docs/docs/lambda/custom-destination.md
@@ -46,7 +46,7 @@ const { bucketName, renderId } = await renderMediaOnLambda({
 
 If you like to use this feature:
 
-- You must extend the [default Remotion policy](/lambda/permissions) to allow read and write access to that bucket.
+- You must extend the [default Remotion policy](/docs/lambda/permissions) to allow read and write access to that bucket.
 - The bucket must be in the same region.
 - When calling APIs such as [`downloadMedia()`](/docs/lambda/downloadmedia) or [`getRenderProgress()`](/docs/lambda/getrenderprogress), you must pass the `bucketName` where the site resides in, not the bucket where the video gets saved.
 - The `key` must match `/^([0-9a-zA-Z-!_.*'()]+)$/g`

--- a/packages/docs/docs/lambda/custom-destination.md
+++ b/packages/docs/docs/lambda/custom-destination.md
@@ -46,7 +46,7 @@ const { bucketName, renderId } = await renderMediaOnLambda({
 
 If you like to use this feature:
 
-- You must extend the [default Remotion policy](/lambda/cli/permissions) to allow read and write access to that bucket.
+- You must extend the [default Remotion policy](/lambda/permissions) to allow read and write access to that bucket.
 - The bucket must be in the same region.
 - When calling APIs such as [`downloadMedia()`](/docs/lambda/downloadmedia) or [`getRenderProgress()`](/docs/lambda/getrenderprogress), you must pass the `bucketName` where the site resides in, not the bucket where the video gets saved.
 - The `key` must match `/^([0-9a-zA-Z-!_.*'()]+)$/g`

--- a/packages/docs/docs/lambda/custom-destination.md
+++ b/packages/docs/docs/lambda/custom-destination.md
@@ -4,13 +4,13 @@ sidebar_label: Custom output destination
 title: Customizing Lambda output destination
 ---
 
-By default a render artifact is saved into the S3 back under the key `renders/${renderId}/out.{extension}` (for example: `renders/hy0k2siao8/out.mp4`)
+By default a render artifact is saved into the same S3 bucket as where the site is located under the key `renders/${renderId}/out.{extension}` (for example: `renders/hy0k2siao8/out.mp4`)
 
 You can modify the output destination by passing a different filename, writing it into a different bucket or even upload it to a different S3-compatible provider.
 
 ## Customizing the output name
 
-To customize the output filename, pass `outName: "my-filename.mp4"` to [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda) or [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda).
+To customize the output filename, pass `outName: "my-filename.mp4"` to [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda#outname) or [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda#outname).
 
 On the CLI, use the [`--out-name`](/docs/lambda/cli/render#--out-name) flag.
 

--- a/packages/docs/docs/lambda/custom-destination.md
+++ b/packages/docs/docs/lambda/custom-destination.md
@@ -1,0 +1,103 @@
+---
+id: custom-destination
+sidebar_label: Custom output destination
+title: Customizing Lambda output destination
+---
+
+By default a render artifact is saved into the S3 back under the key `renders/${renderId}/out.{extension}` (for example: `renders/hy0k2siao8/out.mp4`)
+
+You can modify the output destination by passing a different filename, writing it into a different bucket or even upload it to a different S3-compatible provider.
+
+## Customizing the output name
+
+To customize the output filename, pass `outName: "my-filename.mp4"` to [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda) or [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda).
+
+On the CLI, use the [`--out-name`](/docs/lambda/cli/render#--out-name) flag.
+
+The output name must match `/^([0-9a-zA-Z-!_.*'()/]+)$/g`.
+
+## Customizing the output bucket
+
+To render into a different bucket, specify the `outName` option to [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda) or [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda) and pass an object with the `key` and `bucketName` values:
+
+```tsx twoslash {13-16}
+// @module: esnext
+// @target: es2017
+import { renderMediaOnLambda } from "@remotion/lambda";
+// ---cut---
+
+const { bucketName, renderId } = await renderMediaOnLambda({
+  region: "us-east-1",
+  functionName: "remotion-render-bds9aab",
+  composition: "MyVideo",
+  serveUrl:
+    "https://remotionlambda-qg35eyp1s1.s3.eu-central-1.amazonaws.com/sites/bf2jrbfkw",
+  inputProps: {},
+  codec: "h264",
+  imageFormat: "jpeg",
+  maxRetries: 1,
+  privacy: "public",
+  outName: {
+    key: "my-output",
+    bucketName: "output-bucket",
+  },
+});
+```
+
+If you like to use this feature:
+
+- You must extend the [default Remotion policy](/lambda/cli/permissions) to allow read and write access to that bucket.
+- The bucket must be in the same region.
+- When calling APIs such as [`downloadMedia()`](/docs/lambda/downloadmedia) or [`getRenderProgress()`](/docs/lambda/getrenderprogress), you must pass the `bucketName` where the site resides in, not the bucket where the video gets saved.
+- The `key` must match `/^([0-9a-zA-Z-!_.*'()]+)$/g`
+- The bucketName must match `/^(?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$)/`.
+
+This feature is not supported from the CLI.
+
+## Saving to another cloud
+
+_Available from v3.2.23_
+
+You can upload the file to another S3-compatible provider. You must pass an `outName` [as specified above](#customizing-the-output-bucket) and also provide an `s3OutputProvider` like in the example below.
+
+```tsx twoslash {13-21}
+// @module: esnext
+// @target: es2017
+import { renderMediaOnLambda } from "@remotion/lambda";
+// ---cut---
+
+const { bucketName, renderId } = await renderMediaOnLambda({
+  region: "us-east-1",
+  functionName: "remotion-render-bds9aab",
+  composition: "MyVideo",
+  serveUrl:
+    "https://remotionlambda-qg35eyp1s1.s3.eu-central-1.amazonaws.com/sites/bf2jrbfkw",
+  inputProps: {},
+  codec: "h264",
+  imageFormat: "jpeg",
+  maxRetries: 1,
+  privacy: "public",
+  outName: {
+    key: "my-output",
+    bucketName: "output-bucket",
+    s3OutputProvider: {
+      endpoint: "https://fra1.digitaloceanspaces.com",
+      accessKeyId: "<DIGITAL_OCEAN_ACCESS_KEY_ID>",
+      secretAccessKey: "<DIGITAL_OCEAN_SECRET_ACCESS_KEY>",
+    },
+  },
+});
+```
+
+In this example, the output file will be uploaded to DigitalOcean Spaces. The cloud provider will give you the endpoint and credentials.
+
+If you want to use this feature, note the following:
+
+- When calling [`downloadMedia()`](/docs/lambda/downloadmedia#bucketname) or [`getRenderProgress()`](/docs/lambda/getrenderprogress#bucketname), you must pass the AWS `bucketName` where the site resides in, not the bucket name of the foreign cloud.
+- When calling [`downloadMedia()`](/docs/lambda/downloadmedia#s3outputprovider) or [`getRenderProgress()`](/docs/lambda/getrenderprogress#s3outputprovider), you must provide the `s3OutputProvider` option with the same credentials again.
+
+This feature is not supported from the CLI.
+
+## See also
+
+- Customizing the filename when a file is downloaded using `downloadBehavior`: For [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda#downloadbehavior) and [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda#downloadbehavior)

--- a/packages/docs/docs/lambda/downloadmedia.md
+++ b/packages/docs/docs/lambda/downloadmedia.md
@@ -51,11 +51,19 @@ Where the video should be saved. Pass an absolute path, or it will be resolved r
 
 ### `onProgress`
 
+_optional_
+
 Callback function that gets called with the following properties:
 
 - `totalSize` in bytes
 - `downloaded` number of bytes downloaded
 - `percent` relative progress between 0 and 1
+
+### `customCredentials`
+
+_optional, available from v3.2.23_
+
+If the render was saved to a [different cloud](/docs/lambda/custom-destination#saving-to-another-cloud), pass an object with the same `endpoint`, `accessKeyId` and `secretAccessKey` as you passed to [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda#outname) or [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda#outname).
 
 ## Return value
 

--- a/packages/docs/docs/lambda/getawsclient.md
+++ b/packages/docs/docs/lambda/getawsclient.md
@@ -78,7 +78,7 @@ One of `lambda`, `cloudwatch`, `iam`, `servicequotas` and `s3`.
 
 _available from v3.2.23_
 
-Allows you to connect to another cloud provider, useful if you [render your output to a different cloud](/docs/lambda/custom-destination).
+Allows you to connect to another cloud provider, useful if you [render your output to a different cloud](/docs/lambda/custom-destination). The value must satisfy the following type:
 
 ```ts
 type CustomCredentials = {

--- a/packages/docs/docs/lambda/getawsclient.md
+++ b/packages/docs/docs/lambda/getawsclient.md
@@ -74,6 +74,20 @@ One of the [supported regions](/docs/lambda/region-selection) of Remotion Lambda
 
 One of `lambda`, `cloudwatch`, `iam`, `servicequotas` and `s3`.
 
+### `customCredentials`
+
+_available from v3.2.23_
+
+Allows you to connect to another cloud provider, useful if you [render your output to a different cloud](/docs/lambda/custom-destination).
+
+```ts
+type CustomCredentials = {
+  endpoint: string;
+  accessKeyId: string | null;
+  secretAccessKey: string | null;
+};
+```
+
 ## Return value
 
 An object with two properties:

--- a/packages/docs/docs/lambda/getrenderprogress.md
+++ b/packages/docs/docs/lambda/getrenderprogress.md
@@ -43,6 +43,12 @@ The region in which the Lambda function is located in.
 
 The name of the function that triggered the render.
 
+### `customCredentials`
+
+_optional, available from v3.2.23_
+
+If the render is going to be saved to a [different cloud](/docs/lambda/custom-destination#saving-to-another-cloud), pass an object with the same `endpoint`, `accessKeyId` and `secretAccessKey` as you passed to [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda#outname) or [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda#outname).
+
 ## Response
 
 Returns a promise resolving to an object with the following properties:

--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -135,13 +135,9 @@ The file name of the media output.
 
 It can either be:
 
-- `undefined` - it will default to `out` plus the appropriate file extension, for example: `renders/${renderId}/out.mp4`. The outName must match `/^([0-9a-zA-Z-!_.*'()/]+)$/g`.
+- `undefined` - it will default to `out` plus the appropriate file extension, for example: `renders/${renderId}/out.mp4`.
 - A `string` - it will get saved to the same S3 bucket as your site under the key `renders/{renderId}/{outName}`.
-- An object of shape `{ key: string; bucketName: string }`. This will save the render to an arbitrary bucket with an arbitrary key. Note the following restrictions:
-  - You must extend the default Remotion policy to allow read and write access to that bucket.
-  - The bucket must be in the same region.
-  - When calling APIs such as `downloadMedia()` or `getRenderProgress()`, you must pass the bucket name where the site resides in, not the bucket where the video gets saved.
-  - The `key` must match `/^([0-9a-zA-Z-!_.*'()]+)$/g` and the bucketName must match `/^(?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$)/`.
+- An object if you want to render to a different bucket or cloud provider - [see here for detailed instructions](/docs/lambda/custom-destination)
 
 ### `timeoutInMilliseconds?`
 

--- a/packages/docs/docs/lambda/renderstillonlambda.md
+++ b/packages/docs/docs/lambda/renderstillonlambda.md
@@ -108,17 +108,11 @@ Scales the output dimensions by a factor. See [Scaling](/docs/scaling) to learn 
 
 _optional_
 
-The file name of the media output.
-
 It can either be:
 
-- `undefined` - it will default to `out` plus the appropriate file extension, for example: `renders/${renderId}/out.mp4`. The outName must match `/^([0-9a-zA-Z-!_.*'()/]+)$/g`.
+- `undefined` - it will default to `out` plus the appropriate file extension, for example: `renders/${renderId}/out.mp4`.
 - A `string` - it will get saved to the same S3 bucket as your site under the key `renders/{renderId}/{outName}`.
-- An object of shape `{ key: string; bucketName: string }`. This will save the render to an arbitrary bucket with an arbitrary key. Note the following restrictions:
-  - You must extend the default Remotion policy to allow read and write access to that bucket.
-  - The bucket must be in the same region.
-  - When calling APIs such as `downloadMedia()` or `getRenderProgress()`, you must pass the bucket name where the site resides in, not the bucket where the video gets saved.
-  - The `key` must match `/^([0-9a-zA-Z-!_.*'()]+)$/g` and the bucketName must match `/^(?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$)/`.
+- An object if you want to render to a different bucket or cloud provider - [see here for detailed instructions](/docs/lambda/custom-destination)
 
 ### `timeoutInMilliseconds?`
 

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -310,6 +310,7 @@ module.exports = {
         "lambda/faq",
         "lambda/light-client",
         "lambda/custom-layers",
+        "lambda/custom-destination",
         "lambda/checklist",
         {
           type: "category",

--- a/packages/lambda/src/api/bucket-exists.ts
+++ b/packages/lambda/src/api/bucket-exists.ts
@@ -12,7 +12,7 @@ export const bucketExistsInRegion = async ({
 	expectedBucketOwner: string | null;
 }) => {
 	try {
-		const bucket = await getS3Client(region).send(
+		const bucket = await getS3Client(region, null).send(
 			new GetBucketLocationCommand({
 				Bucket: bucketName,
 				ExpectedBucketOwner: expectedBucketOwner ?? undefined,

--- a/packages/lambda/src/api/clean-items.ts
+++ b/packages/lambda/src/api/clean-items.ts
@@ -25,7 +25,7 @@ export const cleanItems = async ({
 					bucketName: bucket,
 					itemName: object,
 				});
-				await getS3Client(region).send(
+				await getS3Client(region, null).send(
 					new DeleteObjectCommand({
 						Bucket: bucket,
 						Key: object,

--- a/packages/lambda/src/api/create-bucket.ts
+++ b/packages/lambda/src/api/create-bucket.ts
@@ -9,7 +9,7 @@ export const createBucket = async ({
 	region: AwsRegion;
 	bucketName: string;
 }) => {
-	await getS3Client(region).send(
+	await getS3Client(region, null).send(
 		new CreateBucketCommand({
 			Bucket: bucketName,
 			ACL: 'public-read',

--- a/packages/lambda/src/api/download-media.ts
+++ b/packages/lambda/src/api/download-media.ts
@@ -1,12 +1,11 @@
 import {RenderInternals} from '@remotion/renderer';
 import path from 'path';
 import {getExpectedOutName} from '../functions/helpers/expected-out-name';
-import {getCustomOutName} from '../functions/helpers/get-custom-out-name';
 import {getRenderMetadata} from '../functions/helpers/get-render-metadata';
 import type {LambdaReadFileProgress} from '../functions/helpers/read-with-progress';
 import {lambdaDownloadFileWithProgress} from '../functions/helpers/read-with-progress';
 import type {AwsRegion} from '../pricing/aws-regions';
-import type {CustomCredentials} from '../shared/aws-clients';
+import type {CustomS3Credentials} from '../shared/aws-clients';
 import {getAccountId} from '../shared/get-account-id';
 
 export type DownloadMediaInput = {
@@ -15,7 +14,7 @@ export type DownloadMediaInput = {
 	renderId: string;
 	outPath: string;
 	onProgress?: LambdaReadFileProgress;
-	customCredentials?: CustomCredentials;
+	customCredentials?: CustomS3Credentials;
 };
 
 export type DownloadMediaOutput = {
@@ -42,10 +41,7 @@ export const downloadMedia = async (
 	const {key, renderBucketName, customCredentials} = getExpectedOutName(
 		renderMetadata,
 		input.bucketName,
-		getCustomOutName({
-			renderMetadata,
-			customCredentials: input.customCredentials ?? null,
-		})
+		input.customCredentials ?? null
 	);
 
 	const {sizeInBytes} = await lambdaDownloadFileWithProgress({

--- a/packages/lambda/src/api/download-media.ts
+++ b/packages/lambda/src/api/download-media.ts
@@ -22,6 +22,18 @@ export type DownloadMediaOutput = {
 	sizeInBytes: number;
 };
 
+/**
+ * @description Triggers a render on a lambda given a composition and a lambda function.
+ * @link https://remotion.dev/docs/lambda/downloadmedia
+ * @param params.region The AWS region in which the media resides.
+ * @param params.bucketName The `bucketName` that was specified during the render.
+ * @param params.renderId The `renderId` that was obtainer after triggering the render.
+ * @param params.outPath Where to save the media.
+ * @param params.onProgress Progress callback function - see docs for details.
+ * @param params.customCredentials If the file was saved to a foreign cloud, pass credentials for reading from it.
+ * @returns {Promise<RenderMediaOnLambdaOutput>} See documentation for detailed structure
+ */
+
 export const downloadMedia = async (
 	input: DownloadMediaInput
 ): Promise<DownloadMediaOutput> => {

--- a/packages/lambda/src/api/download-media.ts
+++ b/packages/lambda/src/api/download-media.ts
@@ -5,7 +5,7 @@ import {getRenderMetadata} from '../functions/helpers/get-render-metadata';
 import type {LambdaReadFileProgress} from '../functions/helpers/read-with-progress';
 import {lambdaDownloadFileWithProgress} from '../functions/helpers/read-with-progress';
 import type {AwsRegion} from '../pricing/aws-regions';
-import type {CustomS3Credentials} from '../shared/aws-clients';
+import type {CustomCredentials} from '../shared/aws-clients';
 import {getAccountId} from '../shared/get-account-id';
 
 export type DownloadMediaInput = {
@@ -14,7 +14,7 @@ export type DownloadMediaInput = {
 	renderId: string;
 	outPath: string;
 	onProgress?: LambdaReadFileProgress;
-	customCredentials?: CustomS3Credentials;
+	customCredentials?: CustomCredentials;
 };
 
 export type DownloadMediaOutput = {

--- a/packages/lambda/src/api/enable-s3-website.ts
+++ b/packages/lambda/src/api/enable-s3-website.ts
@@ -9,7 +9,7 @@ export const enableS3Website = async ({
 	region: AwsRegion;
 	bucketName: string;
 }) => {
-	await getS3Client(region).send(
+	await getS3Client(region, null).send(
 		new PutBucketWebsiteCommand({
 			Bucket: bucketName,
 			WebsiteConfiguration: {

--- a/packages/lambda/src/api/get-aws-client.ts
+++ b/packages/lambda/src/api/get-aws-client.ts
@@ -31,6 +31,7 @@ export type GetAwsClientOutput<T extends keyof ServiceMapping> = {
  * @link https://remotion.dev/docs/lambda/getawsclient
  * @param {AwsRegion} params.region The region in which the S3 bucket resides in.
  * @param {string} params.service One of `iam`, `s3`, `cloudwatch`, `iam` or `servicequotas`
+ * @param {CustomCredentials} params.customCredentials Pass endpoint and credentials if you want to connect to a different cloud for S3
  * @returns {GetAwsClientOutput<T>} Returns `client` and `sdk` of a AWS service
  */
 export const getAwsClient = <T extends keyof ServiceMapping>({

--- a/packages/lambda/src/api/get-aws-client.ts
+++ b/packages/lambda/src/api/get-aws-client.ts
@@ -4,12 +4,13 @@ import * as LambdaSDK from '@aws-sdk/client-lambda';
 import * as S3SDK from '@aws-sdk/client-s3';
 import * as ServiceQuotasSDK from '@aws-sdk/client-service-quotas';
 import type {AwsRegion} from '../client';
-import type { ServiceMapping} from '../shared/aws-clients';
+import type {CustomCredentials, ServiceMapping} from '../shared/aws-clients';
 import {getServiceClient} from '../shared/aws-clients';
 
 export type GetAwsClientInput<T extends keyof ServiceMapping> = {
 	region: AwsRegion;
 	service: T;
+	customCredentials?: CustomCredentials | null;
 };
 
 type SdkMapping = {
@@ -35,9 +36,14 @@ export type GetAwsClientOutput<T extends keyof ServiceMapping> = {
 export const getAwsClient = <T extends keyof ServiceMapping>({
 	region,
 	service,
+	customCredentials,
 }: GetAwsClientInput<T>): GetAwsClientOutput<T> => {
 	return {
-		client: getServiceClient(region, service),
+		client: getServiceClient({
+			region,
+			service,
+			customCredentials: customCredentials ?? null,
+		}),
 		sdk: {
 			lambda: LambdaSDK,
 			cloudwatch: CloudWatchSDK,

--- a/packages/lambda/src/api/get-aws-client.ts
+++ b/packages/lambda/src/api/get-aws-client.ts
@@ -4,13 +4,13 @@ import * as LambdaSDK from '@aws-sdk/client-lambda';
 import * as S3SDK from '@aws-sdk/client-s3';
 import * as ServiceQuotasSDK from '@aws-sdk/client-service-quotas';
 import type {AwsRegion} from '../client';
-import type {CustomS3Credentials, ServiceMapping} from '../shared/aws-clients';
+import type {CustomCredentials, ServiceMapping} from '../shared/aws-clients';
 import {getServiceClient} from '../shared/aws-clients';
 
 export type GetAwsClientInput<T extends keyof ServiceMapping> = {
 	region: AwsRegion;
 	service: T;
-	customCredentials?: CustomS3Credentials | null;
+	customCredentials?: CustomCredentials | null;
 };
 
 type SdkMapping = {

--- a/packages/lambda/src/api/get-aws-client.ts
+++ b/packages/lambda/src/api/get-aws-client.ts
@@ -4,13 +4,13 @@ import * as LambdaSDK from '@aws-sdk/client-lambda';
 import * as S3SDK from '@aws-sdk/client-s3';
 import * as ServiceQuotasSDK from '@aws-sdk/client-service-quotas';
 import type {AwsRegion} from '../client';
-import type {CustomCredentials, ServiceMapping} from '../shared/aws-clients';
+import type {CustomS3Credentials, ServiceMapping} from '../shared/aws-clients';
 import {getServiceClient} from '../shared/aws-clients';
 
 export type GetAwsClientInput<T extends keyof ServiceMapping> = {
 	region: AwsRegion;
 	service: T;
-	customCredentials?: CustomCredentials | null;
+	customCredentials?: CustomS3Credentials | null;
 };
 
 type SdkMapping = {

--- a/packages/lambda/src/api/get-buckets.ts
+++ b/packages/lambda/src/api/get-buckets.ts
@@ -14,7 +14,9 @@ export const getRemotionS3Buckets = async (
 ): Promise<{
 	remotionBuckets: BucketWithLocation[];
 }> => {
-	const {Buckets} = await getS3Client(region).send(new ListBucketsCommand({}));
+	const {Buckets} = await getS3Client(region, null).send(
+		new ListBucketsCommand({})
+	);
 	if (!Buckets) {
 		return {remotionBuckets: []};
 	}
@@ -25,7 +27,7 @@ export const getRemotionS3Buckets = async (
 
 	const locations = await Promise.all(
 		remotionBuckets.map((bucket) => {
-			return getS3Client(region).send(
+			return getS3Client(region, null).send(
 				new GetBucketLocationCommand({
 					Bucket: bucket.Name as string,
 				})

--- a/packages/lambda/src/api/get-render-progress.ts
+++ b/packages/lambda/src/api/get-render-progress.ts
@@ -1,6 +1,6 @@
 import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../pricing/aws-regions';
-import type {CustomCredentials} from '../shared/aws-clients';
+import type {CustomS3Credentials} from '../shared/aws-clients';
 import {callLambda} from '../shared/call-lambda';
 import type {RenderProgress} from '../shared/constants';
 import {LambdaRoutines} from '../shared/constants';
@@ -10,7 +10,7 @@ export type GetRenderInput = {
 	bucketName: string;
 	renderId: string;
 	region: AwsRegion;
-	customS3Implementation?: CustomCredentials;
+	s3OutputProvider?: CustomS3Credentials;
 };
 
 /**
@@ -20,6 +20,7 @@ export type GetRenderInput = {
  * @param {string} params.bucketName The name of the bucket that was used in the render.
  * @param {string} params.renderId The ID of the render that was returned by `renderMediaOnLambda()`.
  * @param {AwsRegion} params.region The region in which the render was triggered.
+ * @param {CustomS3Credentials} params.s3OutputProvider? Endpoint and credentials if the output file is stored outside of AWS.
  * @returns {Promise<RenderProgress>} See documentation for this function to see all properties on the return object.
  */
 export const getRenderProgress = async ({
@@ -27,7 +28,7 @@ export const getRenderProgress = async ({
 	bucketName,
 	renderId,
 	region,
-	customS3Implementation,
+	s3OutputProvider,
 }: GetRenderInput): Promise<RenderProgress> => {
 	const result = await callLambda({
 		functionName,
@@ -36,7 +37,7 @@ export const getRenderProgress = async ({
 			bucketName,
 			renderId,
 			version: VERSION,
-			customS3Implementation,
+			customS3Implementation: s3OutputProvider,
 		},
 		region,
 	});

--- a/packages/lambda/src/api/get-render-progress.ts
+++ b/packages/lambda/src/api/get-render-progress.ts
@@ -37,7 +37,7 @@ export const getRenderProgress = async ({
 			bucketName,
 			renderId,
 			version: VERSION,
-			customS3Implementation: s3OutputProvider,
+			s3OutputProvider,
 		},
 		region,
 	});

--- a/packages/lambda/src/api/get-render-progress.ts
+++ b/packages/lambda/src/api/get-render-progress.ts
@@ -1,6 +1,6 @@
 import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../pricing/aws-regions';
-import type {CustomS3Credentials} from '../shared/aws-clients';
+import type {CustomCredentials} from '../shared/aws-clients';
 import {callLambda} from '../shared/call-lambda';
 import type {RenderProgress} from '../shared/constants';
 import {LambdaRoutines} from '../shared/constants';
@@ -10,7 +10,7 @@ export type GetRenderInput = {
 	bucketName: string;
 	renderId: string;
 	region: AwsRegion;
-	s3OutputProvider?: CustomS3Credentials;
+	s3OutputProvider?: CustomCredentials;
 };
 
 /**
@@ -20,7 +20,7 @@ export type GetRenderInput = {
  * @param {string} params.bucketName The name of the bucket that was used in the render.
  * @param {string} params.renderId The ID of the render that was returned by `renderMediaOnLambda()`.
  * @param {AwsRegion} params.region The region in which the render was triggered.
- * @param {CustomS3Credentials} params.s3OutputProvider? Endpoint and credentials if the output file is stored outside of AWS.
+ * @param {CustomCredentials} params.s3OutputProvider? Endpoint and credentials if the output file is stored outside of AWS.
  * @returns {Promise<RenderProgress>} See documentation for this function to see all properties on the return object.
  */
 export const getRenderProgress = async ({

--- a/packages/lambda/src/api/get-render-progress.ts
+++ b/packages/lambda/src/api/get-render-progress.ts
@@ -1,5 +1,6 @@
 import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../pricing/aws-regions';
+import type {CustomCredentials} from '../shared/aws-clients';
 import {callLambda} from '../shared/call-lambda';
 import type {RenderProgress} from '../shared/constants';
 import {LambdaRoutines} from '../shared/constants';
@@ -9,6 +10,7 @@ export type GetRenderInput = {
 	bucketName: string;
 	renderId: string;
 	region: AwsRegion;
+	customS3Implementation?: CustomCredentials;
 };
 
 /**
@@ -25,6 +27,7 @@ export const getRenderProgress = async ({
 	bucketName,
 	renderId,
 	region,
+	customS3Implementation,
 }: GetRenderInput): Promise<RenderProgress> => {
 	const result = await callLambda({
 		functionName,
@@ -33,6 +36,7 @@ export const getRenderProgress = async ({
 			bucketName,
 			renderId,
 			version: VERSION,
+			customS3Implementation,
 		},
 		region,
 	});

--- a/packages/lambda/src/api/presign-url.ts
+++ b/packages/lambda/src/api/presign-url.ts
@@ -33,7 +33,7 @@ export const presignUrl = async ({
 	validateBucketName(bucketName, {mustStartWithRemotion: false});
 	validatePresignExpiration(expiresInSeconds);
 
-	const s3Client = getS3Client(region);
+	const s3Client = getS3Client(region, null);
 
 	if (checkIfObjectExists) {
 		try {

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -62,14 +62,14 @@ export type RenderMediaOnLambdaOutput = {
  * @param params.serveUrl The URL of the deployed project
  * @param params.composition The ID of the composition which should be rendered.
  * @param params.inputProps The input props that should be passed to the composition.
- * @param params.codec The video codec which should be used for encoding.
+ * @param params.codec The media codec which should be used for encoding.
  * @param params.imageFormat In which image format the frames should be rendered.
  * @param params.crf The constant rate factor to be used during encoding.
  * @param params.envVariables Object containing environment variables to be inserted into the video environment
  * @param params.proResProfile The ProRes profile if rendering a ProRes video
  * @param params.quality JPEG quality if JPEG was selected as the image format.
- * @param params.region The AWS region in which the video should be rendered.
- * @param params.maxRetries How often rendering a chunk may fail before the video render gets aborted.
+ * @param params.region The AWS region in which the media should be rendered.
+ * @param params.maxRetries How often rendering a chunk may fail before the media render gets aborted.
  * @param params.logLevel Level of logging that Lambda function should perform. Default "info".
  * @returns {Promise<RenderMediaOnLambdaOutput>} See documentation for detailed structure
  */

--- a/packages/lambda/src/api/upload-dir.ts
+++ b/packages/lambda/src/api/upload-dir.ts
@@ -71,7 +71,7 @@ export const uploadDir = async ({
 		progresses[file.name] = 0;
 	}
 
-	const client = getS3Client(region);
+	const client = getS3Client(region, null);
 
 	const uploads = files.map(async (filePath) => {
 		const Key = makeS3Key(folder, dir, filePath.name);

--- a/packages/lambda/src/cli/commands/quotas/increase.ts
+++ b/packages/lambda/src/cli/commands/quotas/increase.ts
@@ -20,19 +20,19 @@ export const quotasIncreaseCommand = async () => {
 
 	const [concurrencyLimit, defaultConcurrencyLimit, changes] =
 		await Promise.all([
-			getServiceQuotasClient(region, null).send(
+			getServiceQuotasClient(region).send(
 				new GetServiceQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region, null).send(
+			getServiceQuotasClient(region).send(
 				new GetAWSDefaultServiceQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region, null).send(
+			getServiceQuotasClient(region).send(
 				new ListRequestedServiceQuotaChangeHistoryByQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
@@ -71,7 +71,7 @@ export const quotasIncreaseCommand = async () => {
 		allowForceFlag: true,
 		delMessage: 'Send? (Y/n)',
 	});
-	await getServiceQuotasClient(region, null).send(
+	await getServiceQuotasClient(region).send(
 		new RequestServiceQuotaIncreaseCommand({
 			QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 			DesiredValue: newLimit,

--- a/packages/lambda/src/cli/commands/quotas/increase.ts
+++ b/packages/lambda/src/cli/commands/quotas/increase.ts
@@ -20,19 +20,19 @@ export const quotasIncreaseCommand = async () => {
 
 	const [concurrencyLimit, defaultConcurrencyLimit, changes] =
 		await Promise.all([
-			getServiceQuotasClient(region).send(
+			getServiceQuotasClient(region, null).send(
 				new GetServiceQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region).send(
+			getServiceQuotasClient(region, null).send(
 				new GetAWSDefaultServiceQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region).send(
+			getServiceQuotasClient(region, null).send(
 				new ListRequestedServiceQuotaChangeHistoryByQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
@@ -71,7 +71,7 @@ export const quotasIncreaseCommand = async () => {
 		allowForceFlag: true,
 		delMessage: 'Send? (Y/n)',
 	});
-	await getServiceQuotasClient(region).send(
+	await getServiceQuotasClient(region, null).send(
 		new RequestServiceQuotaIncreaseCommand({
 			QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 			DesiredValue: newLimit,

--- a/packages/lambda/src/cli/commands/quotas/list.ts
+++ b/packages/lambda/src/cli/commands/quotas/list.ts
@@ -21,25 +21,25 @@ export const quotasListCommand = async () => {
 	Log.info();
 	const [concurrencyLimit, defaultConcurrencyLimit, burstLimit, changes] =
 		await Promise.all([
-			getServiceQuotasClient(region, null).send(
+			getServiceQuotasClient(region).send(
 				new GetServiceQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region, null).send(
+			getServiceQuotasClient(region).send(
 				new GetAWSDefaultServiceQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region, null).send(
+			getServiceQuotasClient(region).send(
 				new GetAWSDefaultServiceQuotaCommand({
 					QuotaCode: LAMBDA_BURST_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region, null).send(
+			getServiceQuotasClient(region).send(
 				new ListRequestedServiceQuotaChangeHistoryByQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',

--- a/packages/lambda/src/cli/commands/quotas/list.ts
+++ b/packages/lambda/src/cli/commands/quotas/list.ts
@@ -21,25 +21,25 @@ export const quotasListCommand = async () => {
 	Log.info();
 	const [concurrencyLimit, defaultConcurrencyLimit, burstLimit, changes] =
 		await Promise.all([
-			getServiceQuotasClient(region).send(
+			getServiceQuotasClient(region, null).send(
 				new GetServiceQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region).send(
+			getServiceQuotasClient(region, null).send(
 				new GetAWSDefaultServiceQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region).send(
+			getServiceQuotasClient(region, null).send(
 				new GetAWSDefaultServiceQuotaCommand({
 					QuotaCode: LAMBDA_BURST_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				})
 			),
-			getServiceQuotasClient(region).send(
+			getServiceQuotasClient(region, null).send(
 				new ListRequestedServiceQuotaChangeHistoryByQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
 					ServiceCode: 'lambda',

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -101,7 +101,15 @@ export const renderCommand = async (args: string[]) => {
 		privacy,
 		logLevel,
 		frameRange: frameRange ?? undefined,
-		outName: parsedLambdaCli['out-name'],
+		outName: {
+			bucketName: 'remotion-lambda-target',
+			key: 'out-file.mp4',
+			customS3Implementation: {
+				endpoint: 'https://fra1.digitaloceanspaces.com',
+				accessKeyId: process.env.SPACES_ACCESS_KEY as string,
+				secretAccessKey: process.env.SPACES_ACCESS_SECRET as string,
+			},
+		},
 		timeoutInMilliseconds: puppeteerTimeout,
 		chromiumOptions,
 		scale,

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -101,15 +101,7 @@ export const renderCommand = async (args: string[]) => {
 		privacy,
 		logLevel,
 		frameRange: frameRange ?? undefined,
-		outName: {
-			bucketName: 'remotion-lambda-target',
-			key: 'out-file.mp4',
-			customS3Implementation: {
-				endpoint: 'https://fra1.digitaloceanspaces.com',
-				accessKeyId: process.env.SPACES_ACCESS_KEY as string,
-				secretAccessKey: process.env.SPACES_ACCESS_SECRET as string,
-			},
-		},
+		outName: parsedLambdaCli['out-name'],
 		timeoutInMilliseconds: puppeteerTimeout,
 		chromiumOptions,
 		scale,

--- a/packages/lambda/src/functions/chunk-optimization/s3-optimization-file.ts
+++ b/packages/lambda/src/functions/chunk-optimization/s3-optimization-file.ts
@@ -27,6 +27,7 @@ export const writeOptimization = async ({
 		privacy: 'private',
 		expectedBucketOwner,
 		downloadBehavior: null,
+		customCredentials: null,
 	});
 };
 

--- a/packages/lambda/src/functions/helpers/expected-out-name.ts
+++ b/packages/lambda/src/functions/helpers/expected-out-name.ts
@@ -2,13 +2,13 @@ import type {Codec} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import type {OutNameInput, OutNameOutput, RenderMetadata} from '../../defaults';
 import {customOutName, outName, outStillName} from '../../defaults';
-import type {CustomS3Credentials} from '../../shared/aws-clients';
+import type {CustomCredentials} from '../../shared/aws-clients';
 import {validateOutname} from '../../shared/validate-outname';
 import {getCustomOutName} from './get-custom-out-name';
 
 export const getCredentialsFromOutName = (
 	name: OutNameInput | null
-): CustomS3Credentials | null => {
+): CustomCredentials | null => {
 	if (typeof name === 'string') {
 		return null;
 	}
@@ -27,7 +27,7 @@ export const getCredentialsFromOutName = (
 export const getExpectedOutName = (
 	renderMetadata: RenderMetadata,
 	bucketName: string,
-	customCredentials: CustomS3Credentials | null
+	customCredentials: CustomCredentials | null
 ): OutNameOutput => {
 	const outNameValue = getCustomOutName({
 		customCredentials,

--- a/packages/lambda/src/functions/helpers/expected-out-name.ts
+++ b/packages/lambda/src/functions/helpers/expected-out-name.ts
@@ -21,7 +21,7 @@ export const getCredentialsFromOutName = (
 		return null;
 	}
 
-	return name.customS3Implementation ?? null;
+	return name.s3OutputProvider ?? null;
 };
 
 export const getExpectedOutName = (

--- a/packages/lambda/src/functions/helpers/expected-out-name.ts
+++ b/packages/lambda/src/functions/helpers/expected-out-name.ts
@@ -2,13 +2,37 @@ import type {Codec} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import type {OutNameInput, OutNameOutput, RenderMetadata} from '../../defaults';
 import {customOutName, outName, outStillName} from '../../defaults';
+import type {CustomS3Credentials} from '../../shared/aws-clients';
 import {validateOutname} from '../../shared/validate-outname';
+import {getCustomOutName} from './get-custom-out-name';
+
+export const getCredentialsFromOutName = (
+	name: OutNameInput | null
+): CustomS3Credentials | null => {
+	if (typeof name === 'string') {
+		return null;
+	}
+
+	if (name === null) {
+		return null;
+	}
+
+	if (typeof name === 'undefined') {
+		return null;
+	}
+
+	return name.customS3Implementation ?? null;
+};
 
 export const getExpectedOutName = (
 	renderMetadata: RenderMetadata,
 	bucketName: string,
-	outNameValue: OutNameInput | null
+	customCredentials: CustomS3Credentials | null
 ): OutNameOutput => {
+	const outNameValue = getCustomOutName({
+		customCredentials,
+		renderMetadata,
+	});
 	if (outNameValue) {
 		validateOutname(outNameValue);
 		return customOutName(renderMetadata.renderId, bucketName, outNameValue);

--- a/packages/lambda/src/functions/helpers/expected-out-name.ts
+++ b/packages/lambda/src/functions/helpers/expected-out-name.ts
@@ -21,6 +21,7 @@ export const getExpectedOutName = (
 		return {
 			renderBucketName: bucketName,
 			key: outStillName(renderMetadata.renderId, renderMetadata.imageFormat),
+			customCredentials: null,
 		};
 	}
 
@@ -34,6 +35,7 @@ export const getExpectedOutName = (
 					'final'
 				)
 			),
+			customCredentials: null,
 		};
 	}
 

--- a/packages/lambda/src/functions/helpers/expected-out-name.ts
+++ b/packages/lambda/src/functions/helpers/expected-out-name.ts
@@ -1,20 +1,17 @@
 import type {Codec} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
-import type {OutNameOutput, RenderMetadata} from '../../defaults';
+import type {OutNameInput, OutNameOutput, RenderMetadata} from '../../defaults';
 import {customOutName, outName, outStillName} from '../../defaults';
 import {validateOutname} from '../../shared/validate-outname';
 
 export const getExpectedOutName = (
 	renderMetadata: RenderMetadata,
-	bucketName: string
+	bucketName: string,
+	outNameValue: OutNameInput | null
 ): OutNameOutput => {
-	if (renderMetadata.outName) {
-		validateOutname(renderMetadata.outName);
-		return customOutName(
-			renderMetadata.renderId,
-			bucketName,
-			renderMetadata.outName
-		);
+	if (outNameValue) {
+		validateOutname(outNameValue);
+		return customOutName(renderMetadata.renderId, bucketName, outNameValue);
 	}
 
 	if (renderMetadata.type === 'still') {

--- a/packages/lambda/src/functions/helpers/find-output-file-in-bucket.ts
+++ b/packages/lambda/src/functions/helpers/find-output-file-in-bucket.ts
@@ -1,7 +1,7 @@
 import {HeadObjectCommand} from '@aws-sdk/client-s3';
 import type {AwsRegion} from '../..';
 import {ROLE_NAME} from '../../api/iam-validation/suggested-policy';
-import type {CustomS3Credentials} from '../../shared/aws-clients';
+import type {CustomCredentials} from '../../shared/aws-clients';
 import {getS3Client} from '../../shared/aws-clients';
 import type {RenderMetadata} from '../../shared/constants';
 import {getExpectedOutName} from './expected-out-name';
@@ -22,7 +22,7 @@ export const findOutputFileInBucket = async ({
 	region: AwsRegion;
 	renderMetadata: RenderMetadata;
 	bucketName: string;
-	customCredentials: CustomS3Credentials | null;
+	customCredentials: CustomCredentials | null;
 }): Promise<OutputFileMetadata | null> => {
 	if (!renderMetadata) {
 		throw new Error('unexpectedly did not get renderMetadata');

--- a/packages/lambda/src/functions/helpers/find-output-file-in-bucket.ts
+++ b/packages/lambda/src/functions/helpers/find-output-file-in-bucket.ts
@@ -28,7 +28,7 @@ export const findOutputFileInBucket = async ({
 	const expectedOutData = getExpectedOutName(renderMetadata, bucketName);
 
 	try {
-		const head = await getS3Client(region).send(
+		const head = await getS3Client(region, null).send(
 			new HeadObjectCommand({
 				Bucket: expectedOutData.renderBucketName,
 				Key: expectedOutData.key,

--- a/packages/lambda/src/functions/helpers/find-output-file-in-bucket.ts
+++ b/packages/lambda/src/functions/helpers/find-output-file-in-bucket.ts
@@ -1,8 +1,9 @@
 import {HeadObjectCommand} from '@aws-sdk/client-s3';
 import type {AwsRegion} from '../..';
 import {ROLE_NAME} from '../../api/iam-validation/suggested-policy';
+import type {CustomCredentials} from '../../shared/aws-clients';
 import {getS3Client} from '../../shared/aws-clients';
-import type {RenderMetadata} from '../../shared/constants';
+import type {OutNameInput, RenderMetadata} from '../../shared/constants';
 import {getExpectedOutName} from './expected-out-name';
 import {getOutputUrlFromMetadata} from './get-output-url-from-metadata';
 
@@ -16,28 +17,36 @@ export const findOutputFileInBucket = async ({
 	region,
 	renderMetadata,
 	bucketName,
+	customCredentials,
+	outNameValue,
 }: {
 	region: AwsRegion;
 	renderMetadata: RenderMetadata;
 	bucketName: string;
+	customCredentials: CustomCredentials | null;
+	outNameValue: OutNameInput | null;
 }): Promise<OutputFileMetadata | null> => {
 	if (!renderMetadata) {
 		throw new Error('unexpectedly did not get renderMetadata');
 	}
 
-	const expectedOutData = getExpectedOutName(renderMetadata, bucketName);
+	const {renderBucketName, key} = getExpectedOutName(
+		renderMetadata,
+		bucketName,
+		null
+	);
 
 	try {
-		const head = await getS3Client(region, null).send(
+		const head = await getS3Client(region, customCredentials).send(
 			new HeadObjectCommand({
-				Bucket: expectedOutData.renderBucketName,
-				Key: expectedOutData.key,
+				Bucket: renderBucketName,
+				Key: key,
 			})
 		);
 		return {
 			lastModified: head.LastModified?.getTime() as number,
 			size: head.ContentLength as number,
-			url: getOutputUrlFromMetadata(renderMetadata, bucketName),
+			url: getOutputUrlFromMetadata(renderMetadata, bucketName, outNameValue),
 		};
 	} catch (err) {
 		if ((err as Error).name === 'NotFound') {
@@ -50,7 +59,7 @@ export const findOutputFileInBucket = async ({
 				.httpStatusCode === 403
 		) {
 			throw new Error(
-				`Unable to access item "${expectedOutData.key}" from bucket "${expectedOutData.renderBucketName}". The "${ROLE_NAME}" role must have permission for both "s3:GetObject" and "s3:ListBucket" actions.`
+				`Unable to access item "${key}" from bucket "${renderBucketName}". The "${ROLE_NAME}" role must have permission for both "s3:GetObject" and "s3:ListBucket" actions.`
 			);
 		}
 

--- a/packages/lambda/src/functions/helpers/get-custom-out-name.ts
+++ b/packages/lambda/src/functions/helpers/get-custom-out-name.ts
@@ -1,12 +1,12 @@
 import type {OutNameInput, RenderMetadata} from '../../defaults';
-import type {CustomS3Credentials} from '../../shared/aws-clients';
+import type {CustomCredentials} from '../../shared/aws-clients';
 
 export const getCustomOutName = ({
 	renderMetadata,
 	customCredentials,
 }: {
 	renderMetadata: RenderMetadata;
-	customCredentials: CustomS3Credentials | null;
+	customCredentials: CustomCredentials | null;
 }): OutNameInput | null => {
 	if (!renderMetadata.outName) {
 		return null;

--- a/packages/lambda/src/functions/helpers/get-custom-out-name.ts
+++ b/packages/lambda/src/functions/helpers/get-custom-out-name.ts
@@ -16,7 +16,7 @@ export const getCustomOutName = ({
 		return renderMetadata.outName;
 	}
 
-	if (renderMetadata.outName.customS3Implementation) {
+	if (renderMetadata.outName.s3OutputProvider) {
 		if (!customCredentials && renderMetadata.privacy !== 'public') {
 			throw new TypeError(
 				`The file was rendered with a custom S3 implementation and is not public, but no custom credentials were passed to downloadMedia().`
@@ -26,8 +26,8 @@ export const getCustomOutName = ({
 		return {
 			bucketName: renderMetadata.outName.bucketName,
 			key: renderMetadata.outName.key,
-			customS3Implementation: {
-				endpoint: renderMetadata.outName.customS3Implementation.endpoint,
+			s3OutputProvider: {
+				endpoint: renderMetadata.outName.s3OutputProvider.endpoint,
 				accessKeyId: customCredentials?.accessKeyId ?? null,
 				secretAccessKey: customCredentials?.secretAccessKey ?? null,
 			},

--- a/packages/lambda/src/functions/helpers/get-custom-out-name.ts
+++ b/packages/lambda/src/functions/helpers/get-custom-out-name.ts
@@ -1,12 +1,12 @@
 import type {OutNameInput, RenderMetadata} from '../../defaults';
-import type {CustomCredentials} from '../../shared/aws-clients';
+import type {CustomS3Credentials} from '../../shared/aws-clients';
 
 export const getCustomOutName = ({
 	renderMetadata,
 	customCredentials,
 }: {
 	renderMetadata: RenderMetadata;
-	customCredentials: CustomCredentials | null;
+	customCredentials: CustomS3Credentials | null;
 }): OutNameInput | null => {
 	if (!renderMetadata.outName) {
 		return null;
@@ -19,7 +19,7 @@ export const getCustomOutName = ({
 	if (renderMetadata.outName.customS3Implementation) {
 		if (!customCredentials && renderMetadata.privacy !== 'public') {
 			throw new TypeError(
-				`The file was rendered with a custom S3 implementation and is not public, but no custom credentials were passed to the downloadMedia().`
+				`The file was rendered with a custom S3 implementation and is not public, but no custom credentials were passed to downloadMedia().`
 			);
 		}
 

--- a/packages/lambda/src/functions/helpers/get-custom-out-name.ts
+++ b/packages/lambda/src/functions/helpers/get-custom-out-name.ts
@@ -1,0 +1,41 @@
+import type {OutNameInput, RenderMetadata} from '../../defaults';
+import type {CustomCredentials} from '../../shared/aws-clients';
+
+export const getCustomOutName = ({
+	renderMetadata,
+	customCredentials,
+}: {
+	renderMetadata: RenderMetadata;
+	customCredentials: CustomCredentials | null;
+}): OutNameInput | null => {
+	if (!renderMetadata.outName) {
+		return null;
+	}
+
+	if (typeof renderMetadata.outName === 'string') {
+		return renderMetadata.outName;
+	}
+
+	if (renderMetadata.outName.customS3Implementation) {
+		if (!customCredentials && renderMetadata.privacy !== 'public') {
+			throw new TypeError(
+				`The file was rendered with a custom S3 implementation and is not public, but no custom credentials were passed to the downloadMedia().`
+			);
+		}
+
+		return {
+			bucketName: renderMetadata.outName.bucketName,
+			key: renderMetadata.outName.key,
+			customS3Implementation: {
+				endpoint: renderMetadata.outName.customS3Implementation.endpoint,
+				accessKeyId: customCredentials?.accessKeyId ?? null,
+				secretAccessKey: customCredentials?.secretAccessKey ?? null,
+			},
+		};
+	}
+
+	return {
+		bucketName: renderMetadata.outName.bucketName,
+		key: renderMetadata.outName.key,
+	};
+};

--- a/packages/lambda/src/functions/helpers/get-output-url-from-metadata.ts
+++ b/packages/lambda/src/functions/helpers/get-output-url-from-metadata.ts
@@ -1,12 +1,13 @@
-import type {RenderMetadata} from '../../defaults';
+import type {OutNameInput, RenderMetadata} from '../../defaults';
 import {getExpectedOutName} from './expected-out-name';
 import {getCurrentRegionInFunction} from './get-current-region';
 
 export const getOutputUrlFromMetadata = (
 	renderMetadata: RenderMetadata,
-	bucketName: string
+	bucketName: string,
+	outName: OutNameInput | null
 ) => {
-	const outname = getExpectedOutName(renderMetadata, bucketName);
+	const outname = getExpectedOutName(renderMetadata, bucketName, outName);
 	return `https://s3.${getCurrentRegionInFunction()}.amazonaws.com/${
 		outname.renderBucketName
 	}/${outname.key}`;

--- a/packages/lambda/src/functions/helpers/get-output-url-from-metadata.ts
+++ b/packages/lambda/src/functions/helpers/get-output-url-from-metadata.ts
@@ -1,13 +1,18 @@
-import type {OutNameInput, RenderMetadata} from '../../defaults';
+import type {RenderMetadata} from '../../defaults';
+import type {CustomS3Credentials} from '../../shared/aws-clients';
 import {getExpectedOutName} from './expected-out-name';
 import {getCurrentRegionInFunction} from './get-current-region';
 
 export const getOutputUrlFromMetadata = (
 	renderMetadata: RenderMetadata,
 	bucketName: string,
-	outName: OutNameInput | null
+	customCredentials: CustomS3Credentials | null
 ) => {
-	const outname = getExpectedOutName(renderMetadata, bucketName, outName);
+	const outname = getExpectedOutName(
+		renderMetadata,
+		bucketName,
+		customCredentials
+	);
 	return `https://s3.${getCurrentRegionInFunction()}.amazonaws.com/${
 		outname.renderBucketName
 	}/${outname.key}`;

--- a/packages/lambda/src/functions/helpers/get-output-url-from-metadata.ts
+++ b/packages/lambda/src/functions/helpers/get-output-url-from-metadata.ts
@@ -1,12 +1,12 @@
 import type {RenderMetadata} from '../../defaults';
-import type {CustomS3Credentials} from '../../shared/aws-clients';
+import type {CustomCredentials} from '../../shared/aws-clients';
 import {getExpectedOutName} from './expected-out-name';
 import {getCurrentRegionInFunction} from './get-current-region';
 
 export const getOutputUrlFromMetadata = (
 	renderMetadata: RenderMetadata,
 	bucketName: string,
-	customCredentials: CustomS3Credentials | null
+	customCredentials: CustomCredentials | null
 ) => {
 	const outname = getExpectedOutName(
 		renderMetadata,

--- a/packages/lambda/src/functions/helpers/get-progress.ts
+++ b/packages/lambda/src/functions/helpers/get-progress.ts
@@ -1,6 +1,6 @@
 import {Internals} from 'remotion';
 import type {AwsRegion} from '../../pricing/aws-regions';
-import type {CustomS3Credentials} from '../../shared/aws-clients';
+import type {CustomCredentials} from '../../shared/aws-clients';
 import type {RenderProgress} from '../../shared/constants';
 import {
 	chunkKey,
@@ -46,7 +46,7 @@ export const getProgress = async ({
 	region: AwsRegion;
 	memorySizeInMb: number;
 	timeoutInMiliseconds: number;
-	customCredentials: CustomS3Credentials | null;
+	customCredentials: CustomCredentials | null;
 }): Promise<RenderProgress> => {
 	const postRenderData = await getPostRenderData({
 		bucketName,

--- a/packages/lambda/src/functions/helpers/get-progress.ts
+++ b/packages/lambda/src/functions/helpers/get-progress.ts
@@ -1,6 +1,6 @@
 import {Internals} from 'remotion';
 import type {AwsRegion} from '../../pricing/aws-regions';
-import type {CustomCredentials} from '../../shared/aws-clients';
+import type {CustomS3Credentials} from '../../shared/aws-clients';
 import type {RenderProgress} from '../../shared/constants';
 import {
 	chunkKey,
@@ -19,7 +19,6 @@ import {formatCostsInfo} from './format-costs-info';
 import {getCleanupProgress} from './get-cleanup-progress';
 import {getCurrentArchitecture} from './get-current-architecture';
 import {getCurrentRegionInFunction} from './get-current-region';
-import {getCustomOutName} from './get-custom-out-name';
 import {getEncodingMetadata} from './get-encoding-metadata';
 import {getFinalEncodingStatus} from './get-final-encoding-status';
 import {getLambdasInvokedStats} from './get-lambdas-invoked-stats';
@@ -47,7 +46,7 @@ export const getProgress = async ({
 	region: AwsRegion;
 	memorySizeInMb: number;
 	timeoutInMiliseconds: number;
-	customCredentials: CustomCredentials | null;
+	customCredentials: CustomS3Credentials | null;
 }): Promise<RenderProgress> => {
 	const postRenderData = await getPostRenderData({
 		bucketName,
@@ -60,10 +59,7 @@ export const getProgress = async ({
 		const outData = getExpectedOutName(
 			postRenderData.renderMetadata,
 			bucketName,
-			getCustomOutName({
-				customCredentials,
-				renderMetadata: postRenderData.renderMetadata,
-			})
+			customCredentials
 		);
 		return {
 			bucket: bucketName,
@@ -165,7 +161,6 @@ export const getProgress = async ({
 				renderMetadata,
 				region,
 				customCredentials,
-				outNameValue: getCustomOutName({customCredentials, renderMetadata}),
 		  })
 		: null;
 
@@ -291,19 +286,12 @@ export const getProgress = async ({
 		retriesInfo,
 		outKey:
 			outputFile && renderMetadata
-				? getExpectedOutName(
-						renderMetadata,
-						bucketName,
-						getCustomOutName({customCredentials, renderMetadata})
-				  ).key
+				? getExpectedOutName(renderMetadata, bucketName, customCredentials).key
 				: null,
 		outBucket:
 			outputFile && renderMetadata
-				? getExpectedOutName(
-						renderMetadata,
-						bucketName,
-						getCustomOutName({customCredentials, renderMetadata})
-				  ).renderBucketName
+				? getExpectedOutName(renderMetadata, bucketName, customCredentials)
+						.renderBucketName
 				: null,
 		mostExpensiveFrameRanges: null,
 	};

--- a/packages/lambda/src/functions/helpers/io.ts
+++ b/packages/lambda/src/functions/helpers/io.ts
@@ -9,7 +9,7 @@ import type {ReadStream} from 'fs';
 import mimeTypes from 'mime-types';
 import type {Readable} from 'stream';
 import type {AwsRegion} from '../../pricing/aws-regions';
-import type {CustomS3Credentials} from '../../shared/aws-clients';
+import type {CustomCredentials} from '../../shared/aws-clients';
 import {getS3Client} from '../../shared/aws-clients';
 import type {Privacy} from '../../shared/constants';
 import type {DownloadBehavior} from '../../shared/content-disposition-header';
@@ -110,7 +110,7 @@ export const lambdaWriteFile = async ({
 	privacy: Privacy;
 	expectedBucketOwner: string | null;
 	downloadBehavior: DownloadBehavior | null;
-	customCredentials: CustomS3Credentials | null;
+	customCredentials: CustomCredentials | null;
 }): Promise<void> => {
 	await getS3Client(region, customCredentials).send(
 		new PutObjectCommand({

--- a/packages/lambda/src/functions/helpers/io.ts
+++ b/packages/lambda/src/functions/helpers/io.ts
@@ -9,7 +9,7 @@ import type {ReadStream} from 'fs';
 import mimeTypes from 'mime-types';
 import type {Readable} from 'stream';
 import type {AwsRegion} from '../../pricing/aws-regions';
-import type {CustomCredentials} from '../../shared/aws-clients';
+import type {CustomS3Credentials} from '../../shared/aws-clients';
 import {getS3Client} from '../../shared/aws-clients';
 import type {Privacy} from '../../shared/constants';
 import type {DownloadBehavior} from '../../shared/content-disposition-header';
@@ -110,7 +110,7 @@ export const lambdaWriteFile = async ({
 	privacy: Privacy;
 	expectedBucketOwner: string | null;
 	downloadBehavior: DownloadBehavior | null;
-	customCredentials: CustomCredentials | null;
+	customCredentials: CustomS3Credentials | null;
 }): Promise<void> => {
 	await getS3Client(region, customCredentials).send(
 		new PutObjectCommand({

--- a/packages/lambda/src/functions/helpers/read-with-progress.ts
+++ b/packages/lambda/src/functions/helpers/read-with-progress.ts
@@ -2,6 +2,7 @@ import {GetObjectCommand} from '@aws-sdk/client-s3';
 import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
 import {RenderInternals} from '@remotion/renderer';
 import type {AwsRegion} from '../../pricing/aws-regions';
+import type {CustomCredentials} from '../../shared/aws-clients';
 import {getS3Client} from '../../shared/aws-clients';
 
 export type LambdaReadFileProgress = (progress: {
@@ -17,6 +18,7 @@ export const lambdaDownloadFileWithProgress = async ({
 	expectedBucketOwner,
 	outputPath,
 	onProgress,
+	customCredentials,
 }: {
 	bucketName: string;
 	key: string;
@@ -24,8 +26,9 @@ export const lambdaDownloadFileWithProgress = async ({
 	expectedBucketOwner: string;
 	outputPath: string;
 	onProgress: LambdaReadFileProgress;
+	customCredentials: CustomCredentials | null;
 }): Promise<{sizeInBytes: number; to: string}> => {
-	const client = getS3Client(region, null);
+	const client = getS3Client(region, customCredentials);
 	const command = new GetObjectCommand({
 		Bucket: bucketName,
 		ExpectedBucketOwner: expectedBucketOwner,

--- a/packages/lambda/src/functions/helpers/read-with-progress.ts
+++ b/packages/lambda/src/functions/helpers/read-with-progress.ts
@@ -25,7 +25,7 @@ export const lambdaDownloadFileWithProgress = async ({
 	outputPath: string;
 	onProgress: LambdaReadFileProgress;
 }): Promise<{sizeInBytes: number; to: string}> => {
-	const client = getS3Client(region);
+	const client = getS3Client(region, null);
 	const command = new GetObjectCommand({
 		Bucket: bucketName,
 		ExpectedBucketOwner: expectedBucketOwner,

--- a/packages/lambda/src/functions/helpers/read-with-progress.ts
+++ b/packages/lambda/src/functions/helpers/read-with-progress.ts
@@ -2,7 +2,7 @@ import {GetObjectCommand} from '@aws-sdk/client-s3';
 import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
 import {RenderInternals} from '@remotion/renderer';
 import type {AwsRegion} from '../../pricing/aws-regions';
-import type {CustomS3Credentials} from '../../shared/aws-clients';
+import type {CustomCredentials} from '../../shared/aws-clients';
 import {getS3Client} from '../../shared/aws-clients';
 
 export type LambdaReadFileProgress = (progress: {
@@ -26,7 +26,7 @@ export const lambdaDownloadFileWithProgress = async ({
 	expectedBucketOwner: string;
 	outputPath: string;
 	onProgress: LambdaReadFileProgress;
-	customCredentials: CustomS3Credentials | null;
+	customCredentials: CustomCredentials | null;
 }): Promise<{sizeInBytes: number; to: string}> => {
 	const client = getS3Client(region, customCredentials);
 	const command = new GetObjectCommand({

--- a/packages/lambda/src/functions/helpers/read-with-progress.ts
+++ b/packages/lambda/src/functions/helpers/read-with-progress.ts
@@ -2,7 +2,7 @@ import {GetObjectCommand} from '@aws-sdk/client-s3';
 import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
 import {RenderInternals} from '@remotion/renderer';
 import type {AwsRegion} from '../../pricing/aws-regions';
-import type {CustomCredentials} from '../../shared/aws-clients';
+import type {CustomS3Credentials} from '../../shared/aws-clients';
 import {getS3Client} from '../../shared/aws-clients';
 
 export type LambdaReadFileProgress = (progress: {
@@ -26,7 +26,7 @@ export const lambdaDownloadFileWithProgress = async ({
 	expectedBucketOwner: string;
 	outputPath: string;
 	onProgress: LambdaReadFileProgress;
-	customCredentials: CustomCredentials | null;
+	customCredentials: CustomS3Credentials | null;
 }): Promise<{sizeInBytes: number; to: string}> => {
 	const client = getS3Client(region, customCredentials);
 	const command = new GetObjectCommand({

--- a/packages/lambda/src/functions/helpers/write-lambda-error.ts
+++ b/packages/lambda/src/functions/helpers/write-lambda-error.ts
@@ -65,5 +65,6 @@ export const writeLambdaError = async ({
 		privacy: 'private',
 		expectedBucketOwner,
 		downloadBehavior: null,
+		customCredentials: null,
 	});
 };

--- a/packages/lambda/src/functions/helpers/write-post-render-data.ts
+++ b/packages/lambda/src/functions/helpers/write-post-render-data.ts
@@ -24,5 +24,6 @@ export const writePostRenderData = async ({
 		expectedBucketOwner,
 		region,
 		downloadBehavior: null,
+		customCredentials: null,
 	});
 };

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -40,7 +40,6 @@ import {cleanupFiles} from './helpers/delete-chunks';
 import {getExpectedOutName} from './helpers/expected-out-name';
 import {getBrowserInstance} from './helpers/get-browser-instance';
 import {getCurrentRegionInFunction} from './helpers/get-current-region';
-import {getCustomOutName} from './helpers/get-custom-out-name';
 import {getFilesToDelete} from './helpers/get-files-to-delete';
 import {getLambdasInvokedStats} from './helpers/get-lambdas-invoked-stats';
 import {getOutputUrlFromMetadata} from './helpers/get-output-url-from-metadata';
@@ -343,7 +342,9 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 	const {key, renderBucketName, customCredentials} = getExpectedOutName(
 		renderMetadata,
 		params.bucketName,
-		params.outName
+		typeof params.outName === 'string' || typeof params.outName === 'undefined'
+			? null
+			: params.outName?.customS3Implementation ?? null
 	);
 
 	const outputSize = fs.statSync(outfile);
@@ -465,7 +466,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 			url: getOutputUrlFromMetadata(
 				renderMetadata,
 				params.bucketName,
-				getCustomOutName({renderMetadata, customCredentials})
+				customCredentials
 			),
 		},
 	});

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -250,6 +250,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		privacy: 'private',
 		expectedBucketOwner: options.expectedBucketOwner,
 		downloadBehavior: null,
+		customCredentials: null,
 	});
 
 	await Promise.all(
@@ -294,6 +295,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 			privacy: 'private',
 			expectedBucketOwner: options.expectedBucketOwner,
 			downloadBehavior: null,
+			customCredentials: null,
 		}).catch((err) => {
 			writeLambdaError({
 				bucketName: params.bucketName,
@@ -336,7 +338,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		encodingStop = Date.now();
 	}
 
-	const {key, renderBucketName} = getExpectedOutName(
+	const {key, renderBucketName, customCredentials} = getExpectedOutName(
 		renderMetadata,
 		params.bucketName
 	);
@@ -351,6 +353,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		privacy: params.privacy,
 		expectedBucketOwner: options.expectedBucketOwner,
 		downloadBehavior: params.downloadBehavior,
+		customCredentials,
 	});
 
 	let chunkProm: Promise<unknown> = Promise.resolve();
@@ -420,6 +423,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		privacy: 'private',
 		expectedBucketOwner: options.expectedBucketOwner,
 		downloadBehavior: null,
+		customCredentials: null,
 	});
 
 	const errorExplanationsProm = inspectErrors({

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -40,6 +40,7 @@ import {cleanupFiles} from './helpers/delete-chunks';
 import {getExpectedOutName} from './helpers/expected-out-name';
 import {getBrowserInstance} from './helpers/get-browser-instance';
 import {getCurrentRegionInFunction} from './helpers/get-current-region';
+import {getCustomOutName} from './helpers/get-custom-out-name';
 import {getFilesToDelete} from './helpers/get-files-to-delete';
 import {getLambdasInvokedStats} from './helpers/get-lambdas-invoked-stats';
 import {getOutputUrlFromMetadata} from './helpers/get-output-url-from-metadata';
@@ -240,6 +241,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		region: getCurrentRegionInFunction(),
 		renderId: params.renderId,
 		outName: params.outName ?? undefined,
+		privacy: params.privacy,
 	};
 
 	await lambdaWriteFile({
@@ -340,7 +342,8 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 
 	const {key, renderBucketName, customCredentials} = getExpectedOutName(
 		renderMetadata,
-		params.bucketName
+		params.bucketName,
+		params.outName
 	);
 
 	const outputSize = fs.statSync(outfile);
@@ -459,7 +462,11 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		outputFile: {
 			lastModified: Date.now(),
 			size: outputSize.size,
-			url: getOutputUrlFromMetadata(renderMetadata, params.bucketName),
+			url: getOutputUrlFromMetadata(
+				renderMetadata,
+				params.bucketName,
+				getCustomOutName({renderMetadata, customCredentials})
+			),
 		},
 	});
 	await finalEncodingProgressProm;

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -344,7 +344,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		params.bucketName,
 		typeof params.outName === 'string' || typeof params.outName === 'undefined'
 			? null
-			: params.outName?.customS3Implementation ?? null
+			: params.outName?.s3OutputProvider ?? null
 	);
 
 	const outputSize = fs.statSync(outfile);

--- a/packages/lambda/src/functions/progress.ts
+++ b/packages/lambda/src/functions/progress.ts
@@ -36,6 +36,6 @@ export const progressHandler = (
 		region: getCurrentRegionInFunction(),
 		memorySizeInMb: Number(process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE),
 		timeoutInMiliseconds: options.timeoutInMiliseconds,
-		customCredentials: lambdaParams.customS3Implementation ?? null,
+		customCredentials: lambdaParams.s3OutputProvider ?? null,
 	});
 };

--- a/packages/lambda/src/functions/progress.ts
+++ b/packages/lambda/src/functions/progress.ts
@@ -36,5 +36,6 @@ export const progressHandler = (
 		region: getCurrentRegionInFunction(),
 		memorySizeInMb: Number(process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE),
 		timeoutInMiliseconds: options.timeoutInMiliseconds,
+		customCredentials: lambdaParams.customS3Implementation ?? null,
 	});
 };

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -134,6 +134,7 @@ const renderHandler = async (
 					region: getCurrentRegionInFunction(),
 					expectedBucketOwner: options.expectedBucketOwner,
 					downloadBehavior: null,
+					customCredentials: null,
 				}).catch((err) => reject(err));
 			},
 			puppeteerInstance: browserInstance,
@@ -221,6 +222,7 @@ const renderHandler = async (
 		privacy: params.privacy,
 		expectedBucketOwner: options.expectedBucketOwner,
 		downloadBehavior: null,
+		customCredentials: null,
 	});
 	await Promise.all([
 		fs.promises.rm(outputLocation, {recursive: true}),
@@ -238,6 +240,7 @@ const renderHandler = async (
 			privacy: 'private',
 			expectedBucketOwner: options.expectedBucketOwner,
 			downloadBehavior: null,
+			customCredentials: null,
 		}),
 	]);
 };

--- a/packages/lambda/src/functions/start.ts
+++ b/packages/lambda/src/functions/start.ts
@@ -43,6 +43,7 @@ export const startHandler = async (params: LambdaPayload, options: Options) => {
 		expectedBucketOwner: options.expectedBucketOwner,
 		key: initalizedMetadataKey(renderId),
 		privacy: 'private',
+		customCredentials: null,
 	});
 
 	const payload: LambdaPayload = {

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -27,6 +27,7 @@ import {formatCostsInfo} from './helpers/format-costs-info';
 import {getBrowserInstance} from './helpers/get-browser-instance';
 import {getCurrentArchitecture} from './helpers/get-current-architecture';
 import {getCurrentRegionInFunction} from './helpers/get-current-region';
+import {getCustomOutName} from './helpers/get-custom-out-name';
 import {getOutputUrlFromMetadata} from './helpers/get-output-url-from-metadata';
 import {lambdaWriteFile} from './helpers/io';
 import {validateComposition} from './helpers/validate-composition';
@@ -114,6 +115,7 @@ const innerStillHandler = async (
 		region: getCurrentRegionInFunction(),
 		renderId,
 		outName: lambdaParams.outName ?? undefined,
+		privacy: lambdaParams.privacy,
 	};
 
 	await lambdaWriteFile({
@@ -147,7 +149,8 @@ const innerStillHandler = async (
 
 	const {key, renderBucketName, customCredentials} = getExpectedOutName(
 		renderMetadata,
-		bucketName
+		bucketName,
+		lambdaParams.outName
 	);
 
 	const {size} = await fs.promises.stat(outputPath);
@@ -176,7 +179,11 @@ const innerStillHandler = async (
 	});
 
 	return {
-		output: getOutputUrlFromMetadata(renderMetadata, bucketName),
+		output: getOutputUrlFromMetadata(
+			renderMetadata,
+			bucketName,
+			getCustomOutName({customCredentials, renderMetadata})
+		),
 		size,
 		bucketName,
 		estimatedPrice: formatCostsInfo(estimatedPrice),

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -22,12 +22,14 @@ import {randomHash} from '../shared/random-hash';
 import {validateDownloadBehavior} from '../shared/validate-download-behavior';
 import {validateOutname} from '../shared/validate-outname';
 import {validatePrivacy} from '../shared/validate-privacy';
-import {getExpectedOutName} from './helpers/expected-out-name';
+import {
+	getCredentialsFromOutName,
+	getExpectedOutName,
+} from './helpers/expected-out-name';
 import {formatCostsInfo} from './helpers/format-costs-info';
 import {getBrowserInstance} from './helpers/get-browser-instance';
 import {getCurrentArchitecture} from './helpers/get-current-architecture';
 import {getCurrentRegionInFunction} from './helpers/get-current-region';
-import {getCustomOutName} from './helpers/get-custom-out-name';
 import {getOutputUrlFromMetadata} from './helpers/get-output-url-from-metadata';
 import {lambdaWriteFile} from './helpers/io';
 import {validateComposition} from './helpers/validate-composition';
@@ -150,7 +152,7 @@ const innerStillHandler = async (
 	const {key, renderBucketName, customCredentials} = getExpectedOutName(
 		renderMetadata,
 		bucketName,
-		lambdaParams.outName
+		getCredentialsFromOutName(lambdaParams.outName)
 	);
 
 	const {size} = await fs.promises.stat(outputPath);
@@ -182,7 +184,7 @@ const innerStillHandler = async (
 		output: getOutputUrlFromMetadata(
 			renderMetadata,
 			bucketName,
-			getCustomOutName({customCredentials, renderMetadata})
+			customCredentials
 		),
 		size,
 		bucketName,

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -124,6 +124,7 @@ const innerStillHandler = async (
 		privacy: 'private',
 		expectedBucketOwner: options.expectedBucketOwner,
 		downloadBehavior: null,
+		customCredentials: null,
 	});
 
 	await renderStill({
@@ -144,7 +145,7 @@ const innerStillHandler = async (
 		downloadMap,
 	});
 
-	const {key, renderBucketName} = getExpectedOutName(
+	const {key, renderBucketName, customCredentials} = getExpectedOutName(
 		renderMetadata,
 		bucketName
 	);
@@ -159,6 +160,7 @@ const innerStillHandler = async (
 		expectedBucketOwner: options.expectedBucketOwner,
 		region: getCurrentRegionInFunction(),
 		downloadBehavior: lambdaParams.downloadBehavior,
+		customCredentials,
 	});
 	await fs.promises.rm(outputPath, {recursive: true});
 

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -1,55 +1,42 @@
-import type { DeleteFunctionInput} from './api/delete-function';
+import type {DeleteFunctionInput} from './api/delete-function';
 import {deleteFunction} from './api/delete-function';
-import type { DeleteSiteInput, DeleteSiteOutput} from './api/delete-site';
+import type {DeleteSiteInput, DeleteSiteOutput} from './api/delete-site';
 import {deleteSite} from './api/delete-site';
 import type {
 	DeployFunctionInput,
-	DeployFunctionOutput} from './api/deploy-function';
-import {
-	deployFunction
+	DeployFunctionOutput,
 } from './api/deploy-function';
-import type { DeploySiteInput, DeploySiteOutput} from './api/deploy-site';
+import {deployFunction} from './api/deploy-function';
+import type {DeploySiteInput, DeploySiteOutput} from './api/deploy-site';
 import {deploySite} from './api/deploy-site';
 import type {
 	DownloadMediaInput,
-	DownloadMediaOutput} from './api/download-media';
-import {
-	downloadMedia,
-	downloadVideo,
+	DownloadMediaOutput,
 } from './api/download-media';
-import type { EstimatePriceInput} from './api/estimate-price';
+import {downloadMedia, downloadVideo} from './api/download-media';
+import type {EstimatePriceInput} from './api/estimate-price';
 import {estimatePrice} from './api/estimate-price';
-import type {
-	GetAwsClientInput,
-	GetAwsClientOutput} from './api/get-aws-client';
-import {
-	getAwsClient
-} from './api/get-aws-client';
-import type {
-	FunctionInfo,
-	GetFunctionInfoInput} from './api/get-function-info';
-import {
-	getFunctionInfo
-} from './api/get-function-info';
-import type { GetFunctionsInput} from './api/get-functions';
+import type {GetAwsClientInput, GetAwsClientOutput} from './api/get-aws-client';
+import {getAwsClient} from './api/get-aws-client';
+import type {FunctionInfo, GetFunctionInfoInput} from './api/get-function-info';
+import {getFunctionInfo} from './api/get-function-info';
+import type {GetFunctionsInput} from './api/get-functions';
 import {getFunctions} from './api/get-functions';
 import type {
 	GetOrCreateBucketInput,
-	GetOrCreateBucketOutput} from './api/get-or-create-bucket';
-import {
-	getOrCreateBucket
+	GetOrCreateBucketOutput,
 } from './api/get-or-create-bucket';
+import {getOrCreateBucket} from './api/get-or-create-bucket';
 import {getRegions} from './api/get-regions';
 import type {GetRenderInput} from './api/get-render-progress';
-import { getRenderProgress} from './api/get-render-progress';
-import type { GetSitesInput, GetSitesOutput} from './api/get-sites';
+import {getRenderProgress} from './api/get-render-progress';
+import type {GetSitesInput, GetSitesOutput} from './api/get-sites';
 import {getSites} from './api/get-sites';
 import type {
 	SimulatePermissionsInput,
-	SimulatePermissionsOutput} from './api/iam-validation/simulate';
-import {
-	simulatePermissions
+	SimulatePermissionsOutput,
 } from './api/iam-validation/simulate';
+import {simulatePermissions} from './api/iam-validation/simulate';
 import {
 	getRolePolicy,
 	getUserPolicy,
@@ -57,20 +44,21 @@ import {
 import {presignUrl} from './api/presign-url';
 import type {
 	RenderMediaOnLambdaInput,
-	RenderMediaOnLambdaOutput} from './api/render-media-on-lambda';
+	RenderMediaOnLambdaOutput,
+} from './api/render-media-on-lambda';
 import {
 	renderMediaOnLambda,
 	renderVideoOnLambda,
 } from './api/render-media-on-lambda';
 import type {
 	RenderStillOnLambdaInput,
-	RenderStillOnLambdaOutput} from './api/render-still-on-lambda';
-import {
-	renderStillOnLambda
+	RenderStillOnLambdaOutput,
 } from './api/render-still-on-lambda';
+import {renderStillOnLambda} from './api/render-still-on-lambda';
 import type {LambdaLSInput, LambdaLsReturnType} from './functions/helpers/io';
 import {LambdaInternals} from './internals';
 import type {AwsRegion} from './pricing/aws-regions';
+import type {CustomS3Credentials} from './shared/aws-clients';
 import type {RenderProgress} from './shared/constants';
 import type {LambdaArchitecture} from './shared/validate-architecture';
 
@@ -130,4 +118,5 @@ export type {
 	GetAwsClientInput,
 	GetAwsClientOutput,
 	LambdaArchitecture,
+	CustomS3Credentials,
 };

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -58,7 +58,7 @@ import {renderStillOnLambda} from './api/render-still-on-lambda';
 import type {LambdaLSInput, LambdaLsReturnType} from './functions/helpers/io';
 import {LambdaInternals} from './internals';
 import type {AwsRegion} from './pricing/aws-regions';
-import type {CustomS3Credentials} from './shared/aws-clients';
+import type {CustomCredentials} from './shared/aws-clients';
 import type {RenderProgress} from './shared/constants';
 import type {LambdaArchitecture} from './shared/validate-architecture';
 
@@ -118,5 +118,5 @@ export type {
 	GetAwsClientInput,
 	GetAwsClientOutput,
 	LambdaArchitecture,
-	CustomS3Credentials,
+	CustomCredentials,
 };

--- a/packages/lambda/src/shared/aws-clients.ts
+++ b/packages/lambda/src/shared/aws-clients.ts
@@ -53,7 +53,7 @@ const getKey = ({
 }: {
 	credentials: CredentialPair | null;
 	region: AwsRegion;
-	customCredentials: CustomCredentials | null;
+	customCredentials: CustomS3Credentials | null;
 	service: keyof ServiceMapping;
 }) =>
 	[
@@ -78,7 +78,7 @@ export type CustomCredentialsWithoutSensitiveData = {
 	endpoint: string;
 };
 
-export type CustomCredentials = CustomCredentialsWithoutSensitiveData & {
+export type CustomS3Credentials = CustomCredentialsWithoutSensitiveData & {
 	accessKeyId: string | null;
 	secretAccessKey: string | null;
 };
@@ -90,7 +90,7 @@ export const getServiceClient = <T extends keyof ServiceMapping>({
 }: {
 	region: AwsRegion;
 	service: T;
-	customCredentials: CustomCredentials | null;
+	customCredentials: CustomS3Credentials | null;
 }): ServiceMapping[T] => {
 	const Client = (() => {
 		if (service === 'cloudwatch') {
@@ -161,7 +161,7 @@ export const getCloudWatchLogsClient = (
 
 export const getS3Client = (
 	region: AwsRegion,
-	customCredentials: CustomCredentials | null
+	customCredentials: CustomS3Credentials | null
 ): S3Client => {
 	return getServiceClient({region, service: 's3', customCredentials});
 };
@@ -180,7 +180,7 @@ export const getIamClient = (region: AwsRegion): IAMClient => {
 
 export const getServiceQuotasClient = (
 	region: AwsRegion,
-	customCredentials: CustomCredentials | null
+	customCredentials: CustomS3Credentials | null
 ): ServiceQuotasClient => {
 	return getServiceClient({
 		region,

--- a/packages/lambda/src/shared/aws-clients.ts
+++ b/packages/lambda/src/shared/aws-clients.ts
@@ -53,7 +53,7 @@ const getKey = ({
 }: {
 	credentials: CredentialPair | null;
 	region: AwsRegion;
-	customCredentials: CustomS3Credentials | null;
+	customCredentials: CustomCredentials | null;
 	service: keyof ServiceMapping;
 }) =>
 	[
@@ -78,7 +78,7 @@ export type CustomCredentialsWithoutSensitiveData = {
 	endpoint: string;
 };
 
-export type CustomS3Credentials = CustomCredentialsWithoutSensitiveData & {
+export type CustomCredentials = CustomCredentialsWithoutSensitiveData & {
 	accessKeyId: string | null;
 	secretAccessKey: string | null;
 };
@@ -90,7 +90,7 @@ export const getServiceClient = <T extends keyof ServiceMapping>({
 }: {
 	region: AwsRegion;
 	service: T;
-	customCredentials: CustomS3Credentials | null;
+	customCredentials: CustomCredentials | null;
 }): ServiceMapping[T] => {
 	const Client = (() => {
 		if (service === 'cloudwatch') {
@@ -161,7 +161,7 @@ export const getCloudWatchLogsClient = (
 
 export const getS3Client = (
 	region: AwsRegion,
-	customCredentials: CustomS3Credentials | null
+	customCredentials: CustomCredentials | null
 ): S3Client => {
 	return getServiceClient({region, service: 's3', customCredentials});
 };
@@ -180,7 +180,7 @@ export const getIamClient = (region: AwsRegion): IAMClient => {
 
 export const getServiceQuotasClient = (
 	region: AwsRegion,
-	customCredentials: CustomS3Credentials | null
+	customCredentials: CustomCredentials | null
 ): ServiceQuotasClient => {
 	return getServiceClient({
 		region,

--- a/packages/lambda/src/shared/aws-clients.ts
+++ b/packages/lambda/src/shared/aws-clients.ts
@@ -74,10 +74,13 @@ export type ServiceMapping = {
 	servicequotas: ServiceQuotasClient;
 };
 
-export type CustomCredentials = {
-	accessKeyId: string;
-	secretAccessKey: string;
+export type CustomCredentialsWithoutSensitiveData = {
 	endpoint: string;
+};
+
+export type CustomCredentials = CustomCredentialsWithoutSensitiveData & {
+	accessKeyId: string | null;
+	secretAccessKey: string | null;
 };
 
 export const getServiceClient = <T extends keyof ServiceMapping>({
@@ -125,11 +128,14 @@ export const getServiceClient = <T extends keyof ServiceMapping>({
 
 		if (customCredentials) {
 			_clients[key] = new Client({
-				region,
-				credentials: {
-					accessKeyId: customCredentials.accessKeyId,
-					secretAccessKey: customCredentials.secretAccessKey,
-				},
+				region: 'us-east-1',
+				credentials:
+					customCredentials.accessKeyId && customCredentials.secretAccessKey
+						? {
+								accessKeyId: customCredentials.accessKeyId,
+								secretAccessKey: customCredentials.secretAccessKey,
+						  }
+						: undefined,
 				endpoint: customCredentials.endpoint,
 			});
 		} else {

--- a/packages/lambda/src/shared/aws-clients.ts
+++ b/packages/lambda/src/shared/aws-clients.ts
@@ -179,12 +179,11 @@ export const getIamClient = (region: AwsRegion): IAMClient => {
 };
 
 export const getServiceQuotasClient = (
-	region: AwsRegion,
-	customCredentials: CustomCredentials | null
+	region: AwsRegion
 ): ServiceQuotasClient => {
 	return getServiceClient({
 		region,
 		service: 'servicequotas',
-		customCredentials,
+		customCredentials: null,
 	});
 };

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -11,7 +11,10 @@ import type {VideoConfig} from 'remotion';
 import type {ChunkRetry} from '../functions/helpers/get-retry-stats';
 import type {EnhancedErrorInfo} from '../functions/helpers/write-lambda-error';
 import type {AwsRegion} from '../pricing/aws-regions';
-import type {CustomCredentials} from './aws-clients';
+import type {
+	CustomCredentials,
+	CustomCredentialsWithoutSensitiveData,
+} from './aws-clients';
 import type {DownloadBehavior} from './content-disposition-header';
 import type {ExpensiveChunk} from './get-most-expensive-chunks';
 import type {LambdaArchitecture} from './validate-architecture';
@@ -132,6 +135,14 @@ export type OutNameInput =
 			customS3Implementation?: CustomCredentials;
 	  };
 
+export type OutNameInputWithoutCredentials =
+	| string
+	| {
+			bucketName: string;
+			key: string;
+			customS3Implementation?: CustomCredentialsWithoutSensitiveData;
+	  };
+
 export type OutNameOutput = {
 	renderBucketName: string;
 	key: string;
@@ -249,6 +260,7 @@ export type LambdaPayloads = {
 		bucketName: string;
 		renderId: string;
 		version: string;
+		customS3Implementation?: CustomCredentials;
 	};
 	renderer: {
 		concurrencyPerLambda: number;
@@ -330,7 +342,8 @@ export type RenderMetadata = {
 	lambdaVersion: string;
 	region: AwsRegion;
 	renderId: string;
-	outName: OutNameInput | undefined;
+	outName: OutNameInputWithoutCredentials | undefined;
+	privacy: Privacy;
 };
 
 export type PostRenderData = {

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -12,8 +12,8 @@ import type {ChunkRetry} from '../functions/helpers/get-retry-stats';
 import type {EnhancedErrorInfo} from '../functions/helpers/write-lambda-error';
 import type {AwsRegion} from '../pricing/aws-regions';
 import type {
-	CustomCredentials,
 	CustomCredentialsWithoutSensitiveData,
+	CustomS3Credentials,
 } from './aws-clients';
 import type {DownloadBehavior} from './content-disposition-header';
 import type {ExpensiveChunk} from './get-most-expensive-chunks';
@@ -132,7 +132,7 @@ export type OutNameInput =
 	| {
 			bucketName: string;
 			key: string;
-			customS3Implementation?: CustomCredentials;
+			customS3Implementation?: CustomS3Credentials;
 	  };
 
 export type OutNameInputWithoutCredentials =
@@ -146,7 +146,7 @@ export type OutNameInputWithoutCredentials =
 export type OutNameOutput = {
 	renderBucketName: string;
 	key: string;
-	customCredentials: CustomCredentials | null;
+	customCredentials: CustomS3Credentials | null;
 };
 
 export const optimizationProfile = (siteId: string, compositionId: string) =>
@@ -260,7 +260,7 @@ export type LambdaPayloads = {
 		bucketName: string;
 		renderId: string;
 		version: string;
-		customS3Implementation?: CustomCredentials;
+		customS3Implementation?: CustomS3Credentials;
 	};
 	renderer: {
 		concurrencyPerLambda: number;

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -132,7 +132,7 @@ export type OutNameInput =
 	| {
 			bucketName: string;
 			key: string;
-			customS3Implementation?: CustomS3Credentials;
+			s3OutputProvider?: CustomS3Credentials;
 	  };
 
 export type OutNameInputWithoutCredentials =
@@ -140,7 +140,7 @@ export type OutNameInputWithoutCredentials =
 	| {
 			bucketName: string;
 			key: string;
-			customS3Implementation?: CustomCredentialsWithoutSensitiveData;
+			s3OutputProvider?: CustomCredentialsWithoutSensitiveData;
 	  };
 
 export type OutNameOutput = {
@@ -172,7 +172,7 @@ export const customOutName = (
 	return {
 		key: name.key,
 		renderBucketName: name.bucketName,
-		customCredentials: name.customS3Implementation ?? null,
+		customCredentials: name.s3OutputProvider ?? null,
 	};
 };
 
@@ -260,7 +260,7 @@ export type LambdaPayloads = {
 		bucketName: string;
 		renderId: string;
 		version: string;
-		customS3Implementation?: CustomS3Credentials;
+		s3OutputProvider?: CustomS3Credentials;
 	};
 	renderer: {
 		concurrencyPerLambda: number;

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -12,8 +12,8 @@ import type {ChunkRetry} from '../functions/helpers/get-retry-stats';
 import type {EnhancedErrorInfo} from '../functions/helpers/write-lambda-error';
 import type {AwsRegion} from '../pricing/aws-regions';
 import type {
+	CustomCredentials,
 	CustomCredentialsWithoutSensitiveData,
-	CustomS3Credentials,
 } from './aws-clients';
 import type {DownloadBehavior} from './content-disposition-header';
 import type {ExpensiveChunk} from './get-most-expensive-chunks';
@@ -132,7 +132,7 @@ export type OutNameInput =
 	| {
 			bucketName: string;
 			key: string;
-			s3OutputProvider?: CustomS3Credentials;
+			s3OutputProvider?: CustomCredentials;
 	  };
 
 export type OutNameInputWithoutCredentials =
@@ -146,7 +146,7 @@ export type OutNameInputWithoutCredentials =
 export type OutNameOutput = {
 	renderBucketName: string;
 	key: string;
-	customCredentials: CustomS3Credentials | null;
+	customCredentials: CustomCredentials | null;
 };
 
 export const optimizationProfile = (siteId: string, compositionId: string) =>
@@ -260,7 +260,7 @@ export type LambdaPayloads = {
 		bucketName: string;
 		renderId: string;
 		version: string;
-		s3OutputProvider?: CustomS3Credentials;
+		s3OutputProvider?: CustomCredentials;
 	};
 	renderer: {
 		concurrencyPerLambda: number;

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -11,6 +11,7 @@ import type {VideoConfig} from 'remotion';
 import type {ChunkRetry} from '../functions/helpers/get-retry-stats';
 import type {EnhancedErrorInfo} from '../functions/helpers/write-lambda-error';
 import type {AwsRegion} from '../pricing/aws-regions';
+import type {CustomCredentials} from './aws-clients';
 import type {DownloadBehavior} from './content-disposition-header';
 import type {ExpensiveChunk} from './get-most-expensive-chunks';
 import type {LambdaArchitecture} from './validate-architecture';
@@ -128,11 +129,13 @@ export type OutNameInput =
 	| {
 			bucketName: string;
 			key: string;
+			customS3Implementation?: CustomCredentials;
 	  };
 
 export type OutNameOutput = {
 	renderBucketName: string;
 	key: string;
+	customCredentials: CustomCredentials | null;
 };
 
 export const optimizationProfile = (siteId: string, compositionId: string) =>
@@ -151,10 +154,15 @@ export const customOutName = (
 		return {
 			renderBucketName: bucketName,
 			key: `${rendersPrefix(renderId)}/${name}`,
+			customCredentials: null,
 		};
 	}
 
-	return {key: name.key, renderBucketName: name.bucketName};
+	return {
+		key: name.key,
+		renderBucketName: name.bucketName,
+		customCredentials: name.customS3Implementation ?? null,
+	};
 };
 
 export const postRenderDataKey = (renderId: string) => {

--- a/packages/lambda/src/shared/validate-outname.ts
+++ b/packages/lambda/src/shared/validate-outname.ts
@@ -1,4 +1,4 @@
-import type {OutNameInput} from './constants';
+import type {OutNameInputWithoutCredentials} from './constants';
 import {validateBucketName} from './validate-bucketname';
 
 const validateS3Key = (s3Key: string) => {
@@ -17,7 +17,9 @@ const validateS3Key = (s3Key: string) => {
 	}
 };
 
-export const validateOutname = (outName: OutNameInput | undefined | null) => {
+export const validateOutname = (
+	outName: OutNameInputWithoutCredentials | undefined | null
+) => {
 	if (typeof outName === 'undefined' || outName === null) {
 		return;
 	}

--- a/packages/lambda/src/test/unit/expected-out-name.test.ts
+++ b/packages/lambda/src/test/unit/expected-out-name.test.ts
@@ -34,6 +34,7 @@ const testRenderMetadata: RenderMetadata = {
 
 test('Should get a custom outname', () => {
 	expect(getExpectedOutName(testRenderMetadata, bucketName)).toEqual({
+		customCredentials: null,
 		renderBucketName: 'remotionlambda-98fsduf',
 		key: 'renders/9n8dsfafs/out.mp4',
 	});
@@ -48,6 +49,7 @@ test('Should save to a different outname', () => {
 		},
 	};
 	expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+		customCredentials: null,
 		renderBucketName: 'my-bucket',
 		key: 'my-key',
 	});
@@ -59,6 +61,7 @@ test('For stills', () => {
 		type: 'still',
 	};
 	expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+		customCredentials: null,
 		renderBucketName: 'remotionlambda-98fsduf',
 		key: 'renders/9n8dsfafs/out.png',
 	});
@@ -70,6 +73,7 @@ test('Just a custom name', () => {
 		outName: 'justaname.jpeg',
 	};
 	expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+		customCredentials: null,
 		renderBucketName: 'remotionlambda-98fsduf',
 		key: 'renders/9n8dsfafs/justaname.jpeg',
 	});
@@ -82,6 +86,7 @@ test('Should throw on invalid names', () => {
 	};
 	expectToThrow(() => {
 		expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+			customCredentials: null,
 			renderBucketName: 'remotionlambda-98fsduf',
 			key: 'renders/9n8dsfafs/justaname.jpeg',
 		});
@@ -93,6 +98,7 @@ test('Should allow outName an outname with a slash', () => {
 		outName: 'justa/name.jpeg',
 	};
 	expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+		customCredentials: null,
 		key: 'renders/9n8dsfafs/justa/name.jpeg',
 		renderBucketName: 'remotionlambda-98fsduf',
 	});

--- a/packages/lambda/src/test/unit/expected-out-name.test.ts
+++ b/packages/lambda/src/test/unit/expected-out-name.test.ts
@@ -30,10 +30,11 @@ const testRenderMetadata: RenderMetadata = {
 		id: 'react-svg',
 		width: 1080,
 	},
+	privacy: 'public',
 };
 
 test('Should get a custom outname', () => {
-	expect(getExpectedOutName(testRenderMetadata, bucketName)).toEqual({
+	expect(getExpectedOutName(testRenderMetadata, bucketName, null)).toEqual({
 		customCredentials: null,
 		renderBucketName: 'remotionlambda-98fsduf',
 		key: 'renders/9n8dsfafs/out.mp4',
@@ -48,7 +49,7 @@ test('Should save to a different outname', () => {
 			key: 'my-key',
 		},
 	};
-	expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+	expect(getExpectedOutName(newRenderMetadata, bucketName, null)).toEqual({
 		customCredentials: null,
 		renderBucketName: 'my-bucket',
 		key: 'my-key',
@@ -60,7 +61,7 @@ test('For stills', () => {
 		...testRenderMetadata,
 		type: 'still',
 	};
-	expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+	expect(getExpectedOutName(newRenderMetadata, bucketName, null)).toEqual({
 		customCredentials: null,
 		renderBucketName: 'remotionlambda-98fsduf',
 		key: 'renders/9n8dsfafs/out.png',
@@ -72,7 +73,7 @@ test('Just a custom name', () => {
 		...testRenderMetadata,
 		outName: 'justaname.jpeg',
 	};
-	expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+	expect(getExpectedOutName(newRenderMetadata, bucketName, null)).toEqual({
 		customCredentials: null,
 		renderBucketName: 'remotionlambda-98fsduf',
 		key: 'renders/9n8dsfafs/justaname.jpeg',
@@ -85,19 +86,32 @@ test('Should throw on invalid names', () => {
 		outName: '👺.jpeg',
 	};
 	expectToThrow(() => {
-		expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+		expect(getExpectedOutName(newRenderMetadata, bucketName, null)).toEqual({
 			customCredentials: null,
 			renderBucketName: 'remotionlambda-98fsduf',
 			key: 'renders/9n8dsfafs/justaname.jpeg',
 		});
 	}, /The S3 Key must match the RegExp/);
 });
+
 test('Should allow outName an outname with a slash', () => {
 	const newRenderMetadata: RenderMetadata = {
 		...testRenderMetadata,
 		outName: 'justa/name.jpeg',
 	};
-	expect(getExpectedOutName(newRenderMetadata, bucketName)).toEqual({
+	expect(getExpectedOutName(newRenderMetadata, bucketName, null)).toEqual({
+		customCredentials: null,
+		key: 'renders/9n8dsfafs/justa/name.jpeg',
+		renderBucketName: 'remotionlambda-98fsduf',
+	});
+});
+
+test('Should allow to ', () => {
+	const newRenderMetadata: RenderMetadata = {
+		...testRenderMetadata,
+		outName: 'justa/name.jpeg',
+	};
+	expect(getExpectedOutName(newRenderMetadata, bucketName, null)).toEqual({
 		customCredentials: null,
 		key: 'renders/9n8dsfafs/justa/name.jpeg',
 		renderBucketName: 'remotionlambda-98fsduf',

--- a/packages/lambda/src/test/unit/expected-out-name.test.ts
+++ b/packages/lambda/src/test/unit/expected-out-name.test.ts
@@ -105,15 +105,3 @@ test('Should allow outName an outname with a slash', () => {
 		renderBucketName: 'remotionlambda-98fsduf',
 	});
 });
-
-test('Should allow to ', () => {
-	const newRenderMetadata: RenderMetadata = {
-		...testRenderMetadata,
-		outName: 'justa/name.jpeg',
-	};
-	expect(getExpectedOutName(newRenderMetadata, bucketName, null)).toEqual({
-		customCredentials: null,
-		key: 'renders/9n8dsfafs/justa/name.jpeg',
-		renderBucketName: 'remotionlambda-98fsduf',
-	});
-});

--- a/packages/lambda/src/test/unit/price-calculation.test.ts
+++ b/packages/lambda/src/test/unit/price-calculation.test.ts
@@ -40,6 +40,7 @@ test('Should not throw while calculating prices when time shifts occur', () => {
 				defaultProps: {},
 			},
 			outName: 'out.mp4',
+			privacy: 'public',
 		},
 		outputFileMetadata: {
 			url: 'out.mp4',


### PR DESCRIPTION
TODO:

- [x] `downloadFile()` should support it
- [x] document getAwsClient() addition
- [x] document new option for renderMediaOnLambda()
- [x] document new option for renderStillOnLambda()
- [x] Fix AWS client caching
- [x] Don't save credentials to preRenderMetadata()
- [x] Don't save credentials to postRenderMetadata()
- [x] Same name for customS3Implementation and customCredentials