### PR TITLE
Player: getScale() and initially show controls before fading out

### DIFF
--- a/packages/docs/docs/player/api.md
+++ b/packages/docs/docs/player/api.md
@@ -281,6 +281,12 @@ _optional, available from v3.2.15_
 
 Limit playback to only play before a certain frame. The video will end at this frame and move to the beginning once it has ended. Must be an integer, not smaller than `1`, not smaller than [`inFrame`](#inframe) and not bigger than `durationInFrames - 1`. Default `null`, which means the end of the video.
 
+### `initiallyShowControls`
+
+_optional, available from v3.2.24_
+
+If true, the controls flash when the player enters the scene. After 2 seconds without hover, the controls fade out. This is similar to how YouTube does it, and signals to the user that the player is in fact controllable. You can also pass a `number`, with which you can customize the duration in milliseconds. Default `true` since `v3.2.24`, before that unsupported.
+
 ## `PlayerRef`
 
 You may attach a ref to the player and control it in an imperative manner.

--- a/packages/docs/docs/player/api.md
+++ b/packages/docs/docs/player/api.md
@@ -438,6 +438,12 @@ Requests the video to go to fullscreen. This method throws if the `allowFullscre
 
 Exit fullscreen mode.
 
+### `getScale()`
+
+_available since v3.2.24_
+
+Returns a number which says how much the content is scaled down compared to the natural composition size. For example, if the composition is `1920x1080`, but the player is 960px in width, this method would return `0.5`.
+
 ### `addEventListener()`
 
 Start listening to an event. See the [Events](#events) section to see the function signature and the available events.

--- a/packages/player-example/src/index.tsx
+++ b/packages/player-example/src/index.tsx
@@ -2,7 +2,6 @@ import React, {ComponentType} from 'react';
 import {createRoot} from 'react-dom/client';
 import App from './App';
 import CarSlideshow from './CarSlideshow';
-import {MyAudio} from './MyAudio';
 import {VideoautoplayDemo} from './VideoAutoplay';
 
 const rootElement = document.getElementById('root');
@@ -28,7 +27,6 @@ createRoot(rootElement as HTMLElement).render(
 		}}
 	>
 		<React.StrictMode>
-			<MyAudio />
 			<App lazyComponent={Car} durationInFrames={500} />
 			<App component={VideoautoplayDemo} durationInFrames={2700} />
 		</React.StrictMode>

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -67,6 +67,7 @@ export type PlayerProps<T> = {
 	showPosterWhenUnplayed?: boolean;
 	inFrame?: number | null;
 	outFrame?: number | null;
+	initiallyShowControls?: number | boolean;
 } & PropsIfHasProps<T> &
 	CompProps<T>;
 
@@ -109,6 +110,7 @@ export const PlayerFn = <T,>(
 		renderPoster,
 		inFrame,
 		outFrame,
+		initiallyShowControls,
 		...componentProps
 	}: PlayerProps<T>,
 	ref: MutableRefObject<PlayerRef>
@@ -428,6 +430,7 @@ export const PlayerFn = <T,>(
 												renderPoster={renderPoster}
 												inFrame={inFrame ?? null}
 												outFrame={outFrame ?? null}
+												initiallyShowControls={initiallyShowControls ?? true}
 											/>
 										</Internals.PrefetchProvider>
 									</PlayerEventEmitterContext.Provider>

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -115,15 +115,16 @@ export const Controls: React.FC<{
 	const playButtonRef = useRef<HTMLButtonElement | null>(null);
 	const frame = Internals.Timeline.useTimelinePosition();
 	const [supportsFullscreen, setSupportsFullscreen] = useState(false);
+	const [initiallyShowControls, setInitiallyShowControls] = useState(true);
 
 	const containerCss: React.CSSProperties = useMemo(() => {
 		// Hide if playing and mouse outside
-		const shouldShow = hovered || !player.playing;
+		const shouldShow = hovered || !player.playing || initiallyShowControls;
 		return {
 			...containerStyle,
 			opacity: Number(shouldShow),
 		};
-	}, [hovered, player.playing]);
+	}, [hovered, initiallyShowControls, player.playing]);
 
 	useEffect(() => {
 		if (playButtonRef.current && spaceKeyToPlayOrPause) {
@@ -141,6 +142,16 @@ export const Controls: React.FC<{
 				(document.fullscreenEnabled || document.webkitFullscreenEnabled)) ??
 				false
 		);
+	}, []);
+
+	useEffect(() => {
+		const timeout = setTimeout(() => {
+			setInitiallyShowControls(false);
+		}, 2000);
+
+		return () => {
+			clearInterval(timeout);
+		};
 	}, []);
 
 	return (

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -146,7 +146,7 @@ export const Controls: React.FC<{
 			return initiallyShowControls;
 		}
 
-		return true;
+		throw new TypeError('initiallyShowControls must be a number or a boolean');
 	});
 
 	const containerCss: React.CSSProperties = useMemo(() => {

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -67,6 +67,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		showPosterWhenUnplayed: boolean;
 		inFrame: number | null;
 		outFrame: number | null;
+		initiallyShowControls: number | boolean;
 	}
 > = (
 	{
@@ -95,6 +96,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		showPosterWhenPaused,
 		inFrame,
 		outFrame,
+		initiallyShowControls,
 	},
 	ref
 ) => {
@@ -514,6 +516,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 					onSeekStart={onSeekStart}
 					inFrame={inFrame}
 					outFrame={outFrame}
+					initiallyShowControls={initiallyShowControls}
 				/>
 			) : null}
 		</>

--- a/packages/player/src/player-methods.ts
+++ b/packages/player/src/player-methods.ts
@@ -17,6 +17,7 @@ export type PlayerMethods = {
 	isPlaying: () => boolean;
 	mute: () => void;
 	unmute: () => void;
+	getScale: () => number;
 };
 
 export type PlayerRef = PlayerEmitter & PlayerMethods;

--- a/packages/player/src/use-hover-state.ts
+++ b/packages/player/src/use-hover-state.ts
@@ -1,13 +1,7 @@
 import {useEffect, useState} from 'react';
 
 export const useHoverState = (ref: React.RefObject<HTMLDivElement>) => {
-	const [hovered, stetHovered] = useState(() => {
-		if (ref.current) {
-			return ref.current.matches(':hover');
-		}
-
-		return false;
-	});
+	const [hovered, stetHovered] = useState(false);
 
 	useEffect(() => {
 		const {current} = ref;

--- a/packages/player/src/use-hover-state.ts
+++ b/packages/player/src/use-hover-state.ts
@@ -1,7 +1,13 @@
 import {useEffect, useState} from 'react';
 
 export const useHoverState = (ref: React.RefObject<HTMLDivElement>) => {
-	const [hovered, stetHovered] = useState(false);
+	const [hovered, stetHovered] = useState(() => {
+		if (ref.current) {
+			return ref.current.matches(':hover');
+		}
+
+		return false;
+	});
 
 	useEffect(() => {
 		const {current} = ref;


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
