### PR TITLE
Clean temporary image frames when rendering ends or fails

### DIFF
--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -458,6 +458,11 @@ export const renderMedia = ({
 			if (!options?.downloadMap) {
 				cleanDownloadMap(downloadMap);
 			}
+
+			// Clean temporary image frames when rendering ends or fails
+			if (outputDir && fs.existsSync(outputDir)) {
+				deleteDirectory(outputDir);
+			}
 		});
 
 	return Promise.race([


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
Clean temporary image frames when rendering ends or fails
