### PR TITLE
`imageFormat`, `maxRetries`, `privacy` are optional for renderMediaOnMedia

### DIFF
--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -40,7 +40,7 @@ In which region your Lambda function is deployed. It's highly recommended that y
 
 ### `privacy`
 
-_optional from v3.2.26_
+_optional since v3.2.26_
 
 One of:
 
@@ -118,7 +118,7 @@ See [`renderMedia() -> quality`](/docs/renderer/render-media#quality).
 
 ### `maxRetries`
 
-_optional from v3.2.26, default `1`_
+_optional since v3.2.26, default `1`_
 
 How often a chunk may be retried to render in case the render fails.
 If a rendering of a chunk is failed, the error will be reported in the [`getRenderProgress()`](/docs/lambda/getrenderprogress) object and retried up to as many times as you specify using this option.

--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -40,7 +40,7 @@ In which region your Lambda function is deployed. It's highly recommended that y
 
 ### `privacy`
 
-_optional_
+_optional from v3.2.26_
 
 One of:
 
@@ -118,7 +118,7 @@ See [`renderMedia() -> quality`](/docs/renderer/render-media#quality).
 
 ### `maxRetries`
 
-_optional, default `1`_
+_optional from v3.2.26, default `1`_
 
 How often a chunk may be retried to render in case the render fails.
 If a rendering of a chunk is failed, the error will be reported in the [`getRenderProgress()`](/docs/lambda/getrenderprogress) object and retried up to as many times as you specify using this option.

--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -19,14 +19,9 @@ const { bucketName, renderId } = await renderMediaOnLambda({
   region: "us-east-1",
   functionName: "remotion-render-bds9aab",
   composition: "MyVideo",
-  framesPerLambda: 20,
   serveUrl:
     "https://remotionlambda-qg35eyp1s1.s3.eu-central-1.amazonaws.com/sites/bf2jrbfkw",
-  inputProps: {},
   codec: "h264",
-  imageFormat: "jpeg",
-  maxRetries: 1,
-  privacy: "public",
 });
 ```
 
@@ -76,6 +71,8 @@ The `id` of the [composition](/docs/composition) you want to render.
 
 ### `inputProps`
 
+_optional since v3.2.26_
+
 React props that are passed to your composition. You define the shape of the props that the component accepts.
 
 ### `codec`
@@ -93,6 +90,8 @@ See also [`renderMedia() -> codec`](/docs/renderer/render-media#codec).
 Disables audio output. See also [`renderMedia() -> muted`](/docs/renderer/render-media#muted).
 
 ### `imageFormat`
+
+_optional since v3.2.26_
 
 See [`renderMedia() -> imageFormat`](/docs/renderer/render-media#imageformat).
 

--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -40,6 +40,8 @@ In which region your Lambda function is deployed. It's highly recommended that y
 
 ### `privacy`
 
+_optional_
+
 One of:
 
 - `"public"` (_default_): The rendered media is publicly accessible under the S3 URL.

--- a/packages/docs/docs/renderer/render-media.md
+++ b/packages/docs/docs/renderer/render-media.md
@@ -65,7 +65,7 @@ The constant rate factor, controlling the quality. See: [Controlling quality usi
 
 ### `imageFormat?`
 
-_"jpeg" (default) | "png" | "none" - optional from v3.2.26_
+_"jpeg" (default) | "png" | "none" - optional since v3.2.26_
 
 In which image format the frames should be rendered.
 

--- a/packages/docs/docs/renderer/render-media.md
+++ b/packages/docs/docs/renderer/render-media.md
@@ -65,7 +65,7 @@ The constant rate factor, controlling the quality. See: [Controlling quality usi
 
 ### `imageFormat?`
 
-_"jpeg" (default) | "png" | "none" - optional_
+_"jpeg" (default) | "png" | "none" - optional from v3.2.26_
 
 In which image format the frames should be rendered.
 

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -27,14 +27,14 @@ export type RenderMediaOnLambdaInput = {
 	composition: string;
 	inputProps: unknown;
 	codec: LambdaCodec;
-	imageFormat: ImageFormat;
+	imageFormat?: ImageFormat;
 	crf?: number | undefined;
 	envVariables?: Record<string, string>;
 	pixelFormat?: PixelFormat;
 	proResProfile?: ProResProfile;
-	privacy: Privacy;
+	privacy?: Privacy;
 	quality?: number;
-	maxRetries: number;
+	maxRetries?: number;
 	framesPerLambda?: number;
 	logLevel?: LogLevel;
 	frameRange?: FrameRange;
@@ -64,13 +64,13 @@ export type RenderMediaOnLambdaOutput = {
  * @param params.composition The ID of the composition which should be rendered.
  * @param params.inputProps The input props that should be passed to the composition.
  * @param params.codec The media codec which should be used for encoding.
- * @param params.imageFormat In which image format the frames should be rendered.
+ * @param params.imageFormat In which image format the frames should be rendered. Default "jpeg"
  * @param params.crf The constant rate factor to be used during encoding.
  * @param params.envVariables Object containing environment variables to be inserted into the video environment
  * @param params.proResProfile The ProRes profile if rendering a ProRes video
  * @param params.quality JPEG quality if JPEG was selected as the image format.
  * @param params.region The AWS region in which the media should be rendered.
- * @param params.maxRetries How often rendering a chunk may fail before the media render gets aborted.
+ * @param params.maxRetries How often rendering a chunk may fail before the media render gets aborted. Default "1"
  * @param params.logLevel Level of logging that Lambda function should perform. Default "info".
  * @returns {Promise<RenderMediaOnLambdaOutput>} See documentation for detailed structure
  */
@@ -122,14 +122,14 @@ export const renderMediaOnLambda = async ({
 				serveUrl: realServeUrl,
 				inputProps,
 				codec: actualCodec,
-				imageFormat,
+				imageFormat: imageFormat ?? 'jpeg',
 				crf,
 				envVariables,
 				pixelFormat,
 				proResProfile,
 				quality,
-				maxRetries,
-				privacy,
+				maxRetries: maxRetries ?? 1,
+				privacy: privacy ?? 'public',
 				logLevel: logLevel ?? 'info',
 				frameRange: frameRange ?? null,
 				outName: outName ?? null,

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -25,7 +25,7 @@ export type RenderMediaOnLambdaInput = {
 	functionName: string;
 	serveUrl: string;
 	composition: string;
-	inputProps: unknown;
+	inputProps?: unknown;
 	codec: LambdaCodec;
 	imageFormat?: ImageFormat;
 	crf?: number | undefined;
@@ -120,7 +120,7 @@ export const renderMediaOnLambda = async ({
 				framesPerLambda: framesPerLambda ?? null,
 				composition,
 				serveUrl: realServeUrl,
-				inputProps,
+				inputProps: inputProps ?? {},
 				codec: actualCodec,
 				imageFormat: imageFormat ?? 'jpeg',
 				crf,


### PR DESCRIPTION
This PR makes `imageFormat`, `maxRetries`, `privacy` optional for renderMediaOnMedia. Fixes #1348 

I have also added "optional" in the relevant documentation for the parameters.

Default values for these params are: 
- imageFormat : 'jpeg'
- maxRetries: 1,
- privacy: 'public'


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1348: `imageFormat`, `maxRetries`, `privacy` should not be mandatory for renderMediaOnLambda()](https://issuehunt.io/repos/274495425/issues/1348)
---
</details>
<!-- /Issuehunt content-->