### PR TITLE
feat: make volume slider responsive according to player size

### DIFF
--- a/packages/core/src/default-css.ts
+++ b/packages/core/src/default-css.ts
@@ -19,6 +19,23 @@ export const injectCSS = (css: string) => {
 	injected[css] = true;
 };
 
+export const removeCSS = (css: string) => {
+	if (typeof document === 'undefined') {
+		return;
+	}
+
+	if (injected[css]) {
+		const head = document.head || document.getElementsByTagName('head')[0];
+		head.childNodes.forEach((node) => {
+			if (node.textContent === css) {
+				head.removeChild(node);
+			}
+		});
+	}
+
+	injected[css] = false;
+};
+
 export const OFFTHREAD_VIDEO_CLASS_NAME = '__remotion_offthreadvideo';
 
 export const makeDefaultCSS = (

--- a/packages/core/src/default-css.ts
+++ b/packages/core/src/default-css.ts
@@ -19,23 +19,6 @@ export const injectCSS = (css: string) => {
 	injected[css] = true;
 };
 
-export const removeCSS = (css: string) => {
-	if (typeof document === 'undefined') {
-		return;
-	}
-
-	if (injected[css]) {
-		const head = document.head || document.getElementsByTagName('head')[0];
-		head.childNodes.forEach((node) => {
-			if (node.textContent === css) {
-				head.removeChild(node);
-			}
-		});
-	}
-
-	injected[css] = false;
-};
-
 export const OFFTHREAD_VIDEO_CLASS_NAME = '__remotion_offthreadvideo';
 
 export const makeDefaultCSS = (

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -1,13 +1,12 @@
 import React, {useCallback, useLayoutEffect, useRef, useState} from 'react';
-import {Internals, useVideoConfig} from 'remotion';
+import {Internals} from 'remotion';
 import {ICON_SIZE, VolumeOffIcon, VolumeOnIcon} from './icons';
 import {VOLUME_SLIDER_INPUT_CSS_CLASSNAME} from './player-css-classname';
 import {useHoverState} from './use-hover-state';
 
 const BAR_HEIGHT = 5;
 const KNOB_SIZE = 12;
-const VOLUME_SLIDER_WIDTH = 100;
-const MAX_MOBILE_WIDTH = 480;
+export const VOLUME_SLIDER_WIDTH = 100;
 
 const scope = `.${VOLUME_SLIDER_INPUT_CSS_CLASSNAME}`;
 const sliderStyle = `
@@ -49,7 +48,9 @@ ${scope} {
 }
 `;
 
-const parentDivStyle = (width: Number): React.CSSProperties => ({
+const parentDivStyle = (
+	displayVerticalVolumeSlider: Boolean
+): React.CSSProperties => ({
 	display: 'inline-flex',
 	background: 'none',
 	border: 'none',
@@ -57,10 +58,12 @@ const parentDivStyle = (width: Number): React.CSSProperties => ({
 	justifyContent: 'center',
 	alignItems: 'center',
 	touchAction: 'none',
-	...(width <= MAX_MOBILE_WIDTH && {position: 'relative'}),
+	...(displayVerticalVolumeSlider && {position: 'relative'}),
 });
 
-const volumeContainer = (width: Number): React.CSSProperties => ({
+const volumeContainer = (
+	displayVerticalVolumeSlider: Boolean
+): React.CSSProperties => ({
 	display: 'inline',
 	width: ICON_SIZE,
 	height: ICON_SIZE,
@@ -69,17 +72,14 @@ const volumeContainer = (width: Number): React.CSSProperties => ({
 	background: 'none',
 	border: 'none',
 	padding: 0,
-	...(width <= MAX_MOBILE_WIDTH && {position: 'absolute'}),
+	...(displayVerticalVolumeSlider && {position: 'absolute'}),
 });
 
 export const MediaVolumeSlider: React.FC<{
-	isFullscreen: Boolean;
-}> = ({isFullscreen}) => {
+	displayVerticalVolumeSlider: Boolean;
+}> = ({displayVerticalVolumeSlider}) => {
 	const [mediaMuted, setMediaMuted] = Internals.useMediaMutedState();
 	const [mediaVolume, setMediaVolume] = Internals.useMediaVolumeState();
-	const {width} = useVideoConfig();
-	const playerWidth = isFullscreen ? window.innerWidth : width;
-	const isPlayerWidthSmall = playerWidth < MAX_MOBILE_WIDTH;
 	const [focused, setFocused] = useState<boolean>(false);
 	const parentDivRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -87,14 +87,14 @@ export const MediaVolumeSlider: React.FC<{
 	const isMutedOrZero = mediaMuted || mediaVolume === 0;
 
 	useLayoutEffect(() => {
-		if (isPlayerWidthSmall) {
+		if (displayVerticalVolumeSlider) {
 			Internals.CSSUtils.removeCSS(sliderStyle);
 			Internals.CSSUtils.injectCSS(sliderStyleVertical);
 		} else {
 			Internals.CSSUtils.removeCSS(sliderStyleVertical);
 			Internals.CSSUtils.injectCSS(sliderStyle);
 		}
-	}, [isFullscreen, width]);
+	}, [displayVerticalVolumeSlider]);
 
 	const onVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setMediaVolume(parseFloat(e.target.value));
@@ -121,14 +121,14 @@ export const MediaVolumeSlider: React.FC<{
 	}, [mediaVolume, setMediaMuted, setMediaVolume]);
 
 	return (
-		<div ref={parentDivRef} style={parentDivStyle(playerWidth)}>
+		<div ref={parentDivRef} style={parentDivStyle(displayVerticalVolumeSlider)}>
 			<button
 				aria-label={isMutedOrZero ? 'Unmute sound' : 'Mute sound'}
 				title={isMutedOrZero ? 'Unmute sound' : 'Mute sound'}
 				onClick={onClick}
 				onBlur={onBlur}
 				onFocus={() => setFocused(true)}
-				style={volumeContainer(playerWidth)}
+				style={volumeContainer(displayVerticalVolumeSlider)}
 				type="button"
 			>
 				{isMutedOrZero ? <VolumeOffIcon /> : <VolumeOnIcon />}

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -1,10 +1,4 @@
-import React, {
-	useCallback,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {Internals} from 'remotion';
 import {ICON_SIZE, VolumeOffIcon, VolumeOnIcon} from './icons';
 import {VOLUME_SLIDER_INPUT_CSS_CLASSNAME} from './player-css-classname';
@@ -35,15 +29,7 @@ const sliderStyle = `
 	}
 `;
 
-const sliderStyleVertical = `
-${sliderStyle}
-${scope} {
-	position: absolute;
-  bottom: ${ICON_SIZE / 2 + 4}px;
-	height: ${VOLUME_SLIDER_WIDTH}px;
-	width: ${BAR_HEIGHT}px;
-}
-`;
+Internals.CSSUtils.injectCSS(sliderStyle);
 
 export const MediaVolumeSlider: React.FC<{
 	displayVerticalVolumeSlider: Boolean;
@@ -55,16 +41,6 @@ export const MediaVolumeSlider: React.FC<{
 	const inputRef = useRef<HTMLInputElement>(null);
 	const hover = useHoverState(parentDivRef);
 	const isMutedOrZero = mediaMuted || mediaVolume === 0;
-
-	useLayoutEffect(() => {
-		if (displayVerticalVolumeSlider) {
-			Internals.CSSUtils.removeCSS(sliderStyle);
-			Internals.CSSUtils.injectCSS(sliderStyleVertical);
-		} else {
-			Internals.CSSUtils.removeCSS(sliderStyleVertical);
-			Internals.CSSUtils.injectCSS(sliderStyle);
-		}
-	}, [displayVerticalVolumeSlider]);
 
 	const onVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setMediaVolume(parseFloat(e.target.value));
@@ -122,21 +98,21 @@ export const MediaVolumeSlider: React.FC<{
 			backgroundColor: 'rgba(255, 255, 255, 0.5)',
 			borderRadius: BAR_HEIGHT / 2,
 			cursor: 'pointer',
+			height: BAR_HEIGHT,
+			width: VOLUME_SLIDER_WIDTH,
 		};
 		if (displayVerticalVolumeSlider) {
 			return {
 				...commonStyle,
-				width: BAR_HEIGHT,
-				height: VOLUME_SLIDER_WIDTH,
+				transform: `rotate(-90deg)`,
+				position: 'absolute',
+				bottom: ICON_SIZE + VOLUME_SLIDER_WIDTH / 2 + 5,
 			};
 		}
 
 		return {
 			...commonStyle,
-			WebkitAppearance: 'slider-vertical',
-			height: BAR_HEIGHT,
 			marginLeft: 5,
-			width: VOLUME_SLIDER_WIDTH,
 		};
 	}, [displayVerticalVolumeSlider]);
 
@@ -153,7 +129,6 @@ export const MediaVolumeSlider: React.FC<{
 			>
 				{isMutedOrZero ? <VolumeOffIcon /> : <VolumeOnIcon />}
 			</button>
-
 			{(focused || hover) && !mediaMuted ? (
 				<input
 					ref={inputRef}

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -1,4 +1,10 @@
-import React, {useCallback, useLayoutEffect, useRef, useState} from 'react';
+import React, {
+	useCallback,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {Internals} from 'remotion';
 import {ICON_SIZE, VolumeOffIcon, VolumeOnIcon} from './icons';
 import {VOLUME_SLIDER_INPUT_CSS_CLASSNAME} from './player-css-classname';
@@ -48,33 +54,6 @@ ${scope} {
 }
 `;
 
-const parentDivStyle = (
-	displayVerticalVolumeSlider: Boolean
-): React.CSSProperties => ({
-	display: 'inline-flex',
-	background: 'none',
-	border: 'none',
-	padding: '6px',
-	justifyContent: 'center',
-	alignItems: 'center',
-	touchAction: 'none',
-	...(displayVerticalVolumeSlider && {position: 'relative'}),
-});
-
-const volumeContainer = (
-	displayVerticalVolumeSlider: Boolean
-): React.CSSProperties => ({
-	display: 'inline',
-	width: ICON_SIZE,
-	height: ICON_SIZE,
-	cursor: 'pointer',
-	appearance: 'none',
-	background: 'none',
-	border: 'none',
-	padding: 0,
-	...(displayVerticalVolumeSlider && {position: 'absolute'}),
-});
-
 export const MediaVolumeSlider: React.FC<{
 	displayVerticalVolumeSlider: Boolean;
 }> = ({displayVerticalVolumeSlider}) => {
@@ -120,15 +99,42 @@ export const MediaVolumeSlider: React.FC<{
 		setMediaMuted((mute) => !mute);
 	}, [mediaVolume, setMediaMuted, setMediaVolume]);
 
+	const parentDivStyle: React.CSSProperties = useMemo(() => {
+		return {
+			display: 'inline-flex',
+			background: 'none',
+			border: 'none',
+			padding: '6px',
+			justifyContent: 'center',
+			alignItems: 'center',
+			touchAction: 'none',
+			...(displayVerticalVolumeSlider && {position: 'relative' as const}),
+		};
+	}, [displayVerticalVolumeSlider]);
+
+	const volumeContainer: React.CSSProperties = useMemo(() => {
+		return {
+			display: 'inline',
+			width: ICON_SIZE,
+			height: ICON_SIZE,
+			cursor: 'pointer',
+			appearance: 'none',
+			background: 'none',
+			border: 'none',
+			padding: 0,
+			...(displayVerticalVolumeSlider && {position: 'absolute'}),
+		};
+	}, [displayVerticalVolumeSlider]);
+
 	return (
-		<div ref={parentDivRef} style={parentDivStyle(displayVerticalVolumeSlider)}>
+		<div ref={parentDivRef} style={parentDivStyle}>
 			<button
 				aria-label={isMutedOrZero ? 'Unmute sound' : 'Mute sound'}
 				title={isMutedOrZero ? 'Unmute sound' : 'Mute sound'}
 				onClick={onClick}
 				onBlur={onBlur}
 				onFocus={() => setFocused(true)}
-				style={volumeContainer(displayVerticalVolumeSlider)}
+				style={volumeContainer}
 				type="button"
 			>
 				{isMutedOrZero ? <VolumeOffIcon /> : <VolumeOnIcon />}

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -1,35 +1,11 @@
 import React, {useCallback, useMemo, useRef, useState} from 'react';
-import {Internals} from 'remotion';
+import {Internals, random} from 'remotion';
 import {ICON_SIZE, VolumeOffIcon, VolumeOnIcon} from './icons';
-import {VOLUME_SLIDER_INPUT_CSS_CLASSNAME} from './player-css-classname';
 import {useHoverState} from './use-hover-state';
 
 const BAR_HEIGHT = 5;
 const KNOB_SIZE = 12;
 export const VOLUME_SLIDER_WIDTH = 100;
-
-const scope = `.${VOLUME_SLIDER_INPUT_CSS_CLASSNAME}`;
-const sliderStyle = `
-	${scope}::-webkit-slider-thumb {
-		-webkit-appearance: none;
-		background-color: white;
-		border-radius: ${KNOB_SIZE / 2}px;
-		box-shadow: 0 0 2px black;
-		height: ${KNOB_SIZE}px;
-		width: ${KNOB_SIZE}px;
-	}
-
-	${scope}::-moz-range-thumb {
-		-webkit-appearance: none;
-		background-color: white;
-		border-radius: ${KNOB_SIZE / 2}px;
-		box-shadow: 0 0 2px black;
-		height: ${KNOB_SIZE}px;
-		width: ${KNOB_SIZE}px;
-	}
-`;
-
-Internals.CSSUtils.injectCSS(sliderStyle);
 
 export const MediaVolumeSlider: React.FC<{
 	displayVerticalVolumeSlider: Boolean;
@@ -40,6 +16,9 @@ export const MediaVolumeSlider: React.FC<{
 	const parentDivRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
 	const hover = useHoverState(parentDivRef);
+	const [randomClass] = useState(() =>
+		`slider-${random(null)}`.replace('.', '')
+	);
 	const isMutedOrZero = mediaMuted || mediaVolume === 0;
 
 	const onVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -116,8 +95,40 @@ export const MediaVolumeSlider: React.FC<{
 		};
 	}, [displayVerticalVolumeSlider]);
 
+	const sliderStyle = `
+	.${randomClass}::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		background-color: white;
+		border-radius: ${KNOB_SIZE / 2}px;
+		box-shadow: 0 0 2px black;
+		height: ${KNOB_SIZE}px;
+		width: ${KNOB_SIZE}px;
+	}
+	.${randomClass} {
+		background-image: linear-gradient(
+			to right,
+			white ${mediaVolume * 100}%, rgba(255, 255, 255, 0) ${mediaVolume * 100}%
+		);
+	}
+
+	.${randomClass}::-moz-range-thumb {
+		-webkit-appearance: none;
+		background-color: white;
+		border-radius: ${KNOB_SIZE / 2}px;
+		box-shadow: 0 0 2px black;
+		height: ${KNOB_SIZE}px;
+		width: ${KNOB_SIZE}px;
+	}
+`;
+
 	return (
 		<div ref={parentDivRef} style={parentDivStyle}>
+			<style
+				// eslint-disable-next-line react/no-danger
+				dangerouslySetInnerHTML={{
+					__html: sliderStyle,
+				}}
+			/>
 			<button
 				aria-label={isMutedOrZero ? 'Unmute sound' : 'Mute sound'}
 				title={isMutedOrZero ? 'Unmute sound' : 'Mute sound'}
@@ -133,7 +144,7 @@ export const MediaVolumeSlider: React.FC<{
 				<input
 					ref={inputRef}
 					aria-label="Change volume"
-					className={VOLUME_SLIDER_INPUT_CSS_CLASSNAME}
+					className={randomClass}
 					max={1}
 					min={0}
 					onBlur={() => setFocused(false)}

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -94,7 +94,7 @@ export const MediaVolumeSlider: React.FC<{
 			Internals.CSSUtils.removeCSS(sliderStyleVertical);
 			Internals.CSSUtils.injectCSS(sliderStyle);
 		}
-	}, [isFullscreen]);
+	}, [isFullscreen, width]);
 
 	const onVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setMediaVolume(parseFloat(e.target.value));

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -44,7 +44,7 @@ const sliderStyleVertical = `
 ${sliderStyle}
 ${scope} {
 	position: absolute;
-  bottom: ${VOLUME_SLIDER_WIDTH / 2 + ICON_SIZE / 2}px;
+  bottom: ${VOLUME_SLIDER_WIDTH / 2 + ICON_SIZE / 2 + 4}px;
   transform: rotate(-90deg);
 }
 `;

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -16,16 +16,6 @@ export const VOLUME_SLIDER_WIDTH = 100;
 
 const scope = `.${VOLUME_SLIDER_INPUT_CSS_CLASSNAME}`;
 const sliderStyle = `
-	${scope} {
-		-webkit-appearance: none;
-		background-color: rgba(255, 255, 255, 0.5);	
-		border-radius: ${BAR_HEIGHT / 2}px;
-		cursor: pointer;
-		height: ${BAR_HEIGHT}px;
-		margin-left: 5px;
-		width: ${VOLUME_SLIDER_WIDTH}px;
-	}
-
 	${scope}::-webkit-slider-thumb {
 		-webkit-appearance: none;
 		background-color: white;
@@ -49,8 +39,9 @@ const sliderStyleVertical = `
 ${sliderStyle}
 ${scope} {
 	position: absolute;
-  bottom: ${VOLUME_SLIDER_WIDTH / 2 + ICON_SIZE / 2 + 4}px;
-  transform: rotate(-90deg);
+  bottom: ${ICON_SIZE / 2 + 4}px;
+	height: ${VOLUME_SLIDER_WIDTH}px;
+	width: ${BAR_HEIGHT}px;
 }
 `;
 
@@ -122,7 +113,30 @@ export const MediaVolumeSlider: React.FC<{
 			background: 'none',
 			border: 'none',
 			padding: 0,
-			...(displayVerticalVolumeSlider && {position: 'absolute'}),
+		};
+	}, []);
+
+	const inputStyle = useMemo((): React.CSSProperties => {
+		const commonStyle: React.CSSProperties = {
+			WebkitAppearance: 'none',
+			backgroundColor: 'rgba(255, 255, 255, 0.5)',
+			borderRadius: BAR_HEIGHT / 2,
+			cursor: 'pointer',
+		};
+		if (displayVerticalVolumeSlider) {
+			return {
+				...commonStyle,
+				width: BAR_HEIGHT,
+				height: VOLUME_SLIDER_WIDTH,
+			};
+		}
+
+		return {
+			...commonStyle,
+			WebkitAppearance: 'slider-vertical',
+			height: BAR_HEIGHT,
+			marginLeft: 5,
+			width: VOLUME_SLIDER_WIDTH,
 		};
 	}, [displayVerticalVolumeSlider]);
 
@@ -152,6 +166,7 @@ export const MediaVolumeSlider: React.FC<{
 					step={0.01}
 					type="range"
 					value={mediaVolume}
+					style={inputStyle}
 				/>
 			) : null}
 		</div>

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -208,7 +208,7 @@ export const Controls: React.FC<{
 					{showVolumeControls ? (
 						<>
 							<div style={xSpacer} />
-							<MediaVolumeSlider />
+							<MediaVolumeSlider isFullscreen={isFullscreen} />
 						</>
 					) : null}
 					<div style={xSpacer} />

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -104,6 +104,7 @@ export const Controls: React.FC<{
 	inFrame: number | null;
 	outFrame: number | null;
 	initiallyShowControls: number | boolean;
+	playerWidth: number;
 }> = ({
 	durationInFrames,
 	hovered,
@@ -120,13 +121,14 @@ export const Controls: React.FC<{
 	inFrame,
 	outFrame,
 	initiallyShowControls,
+	playerWidth,
 }) => {
 	const playButtonRef = useRef<HTMLButtonElement | null>(null);
 	const frame = Internals.Timeline.useTimelinePosition();
 	const [supportsFullscreen, setSupportsFullscreen] = useState(false);
 
 	const {maxTimeLabelWidth, displayVerticalVolumeSlider} =
-		useVideoControlsResize(isFullscreen, allowFullscreen);
+		useVideoControlsResize({allowFullscreen, playerWidth});
 	const [shouldShowInitially, setInitiallyShowControls] = useState<
 		boolean | number
 	>(() => {

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -9,6 +9,7 @@ import type {usePlayer} from './use-player';
 import {useVideoControlsResize} from './use-video-controls-resize';
 
 export const X_SPACER = 10;
+export const X_PADDING = 12;
 
 const containerStyle: React.CSSProperties = {
 	boxSizing: 'border-box',
@@ -19,8 +20,8 @@ const containerStyle: React.CSSProperties = {
 	paddingBottom: 10,
 	background: 'linear-gradient(transparent, rgba(0, 0, 0, 0.4))',
 	display: 'flex',
-	paddingRight: 12,
-	paddingLeft: 12,
+	paddingRight: X_PADDING,
+	paddingLeft: X_PADDING,
 	flexDirection: 'column',
 	transition: 'opacity 0.3s',
 };

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -68,15 +68,6 @@ const flex1: React.CSSProperties = {
 
 const fullscreen: React.CSSProperties = {};
 
-const timeLabel = (maxWidth: number): React.CSSProperties => ({
-	color: 'white',
-	fontFamily: 'sans-serif',
-	fontSize: 14,
-	maxWidth,
-	overflow: 'hidden',
-	textOverflow: 'ellipsis',
-});
-
 declare global {
 	interface Document {
 		webkitFullscreenEnabled?: boolean;
@@ -203,6 +194,17 @@ export const Controls: React.FC<{
 		};
 	}, [shouldShowInitially]);
 
+	const timeLabel: React.CSSProperties = useMemo(() => {
+		return {
+			color: 'white',
+			fontFamily: 'sans-serif',
+			fontSize: 14,
+			maxWidth: maxTimeLabelWidth,
+			overflow: 'hidden',
+			textOverflow: 'ellipsis',
+		};
+	}, [maxTimeLabelWidth]);
+
 	return (
 		<div style={containerCss}>
 			<div style={controlsRow}>
@@ -226,7 +228,7 @@ export const Controls: React.FC<{
 						</>
 					) : null}
 					<div style={xSpacer} />
-					<div style={timeLabel(maxTimeLabelWidth)}>
+					<div style={timeLabel}>
 						{formatTime(frame / fps)} / {formatTime(durationInFrames / fps)}
 					</div>
 					<div style={xSpacer} />

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -6,6 +6,9 @@ import {FullscreenIcon, PauseIcon, PlayIcon} from './icons';
 import {MediaVolumeSlider} from './MediaVolumeSlider';
 import {PlayerSeekBar} from './PlayerSeekBar';
 import type {usePlayer} from './use-player';
+import {useVideoControlsResize} from './use-video-controls-resize';
+
+export const X_SPACER = 10;
 
 const containerStyle: React.CSSProperties = {
 	boxSizing: 'border-box',
@@ -64,11 +67,14 @@ const flex1: React.CSSProperties = {
 
 const fullscreen: React.CSSProperties = {};
 
-const timeLabel: React.CSSProperties = {
+const timeLabel = (maxWidth: number): React.CSSProperties => ({
 	color: 'white',
 	fontFamily: 'sans-serif',
 	fontSize: 14,
-};
+	maxWidth,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+});
 
 declare global {
 	interface Document {
@@ -117,6 +123,9 @@ export const Controls: React.FC<{
 	const playButtonRef = useRef<HTMLButtonElement | null>(null);
 	const frame = Internals.Timeline.useTimelinePosition();
 	const [supportsFullscreen, setSupportsFullscreen] = useState(false);
+
+	const {maxTimeLabelWidth, displayVerticalVolumeSlider} =
+		useVideoControlsResize(isFullscreen, allowFullscreen);
 	const [shouldShowInitially, setInitiallyShowControls] = useState<
 		boolean | number
 	>(() => {
@@ -208,11 +217,13 @@ export const Controls: React.FC<{
 					{showVolumeControls ? (
 						<>
 							<div style={xSpacer} />
-							<MediaVolumeSlider isFullscreen={isFullscreen} />
+							<MediaVolumeSlider
+								displayVerticalVolumeSlider={displayVerticalVolumeSlider}
+							/>
 						</>
 					) : null}
 					<div style={xSpacer} />
-					<div style={timeLabel}>
+					<div style={timeLabel(maxTimeLabelWidth)}>
 						{formatTime(frame / fps)} / {formatTime(durationInFrames / fps)}
 					</div>
 					<div style={xSpacer} />

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -517,6 +517,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 					inFrame={inFrame}
 					outFrame={outFrame}
 					initiallyShowControls={initiallyShowControls}
+					playerWidth={canvasSize?.width ?? 0}
 				/>
 			) : null}
 		</>

--- a/packages/player/src/icons.tsx
+++ b/packages/player/src/icons.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const ICON_SIZE = 25;
-const fullscreenIconSize = 16;
+export const fullscreenIconSize = 16;
 
 const rotate: React.CSSProperties = {
 	transform: `rotate(90deg)`,

--- a/packages/player/src/player-css-classname.ts
+++ b/packages/player/src/player-css-classname.ts
@@ -1,4 +1,1 @@
 export const PLAYER_CSS_CLASSNAME = '__remotion-player';
-export const VOLUME_SLIDER_INPUT_CSS_CLASSNAME = PLAYER_CSS_CLASSNAME.concat(
-	'_volume-slider-input'
-);

--- a/packages/player/src/use-video-controls-resize.ts
+++ b/packages/player/src/use-video-controls-resize.ts
@@ -20,16 +20,19 @@ export const useVideoControlsResize = ({
 		const playPauseIconSize = ICON_SIZE;
 		const volumeIconSize = ICON_SIZE;
 		const _fullscreenIconSize = allowFullScreen ? fullscreenIconSize : 0;
-		const maxTimeLabelWidth =
-			playerWidth -
-			volumeIconSize -
-			playPauseIconSize -
-			_fullscreenIconSize -
-			X_PADDING * 2 -
+		const elementsSize =
+			volumeIconSize +
+			playPauseIconSize +
+			_fullscreenIconSize +
+			X_PADDING * 2 +
 			X_SPACER * 2;
 
-		const maxTimeLabelWidthWithoutNegativeValue =
-			maxTimeLabelWidth > 0 ? maxTimeLabelWidth : 0;
+		const maxTimeLabelWidth = playerWidth - elementsSize;
+
+		const maxTimeLabelWidthWithoutNegativeValue = Math.max(
+			maxTimeLabelWidth,
+			0
+		);
 
 		const availableTimeLabelWidthIfVolumeOpen =
 			maxTimeLabelWidthWithoutNegativeValue - VOLUME_SLIDER_WIDTH;
@@ -42,13 +45,7 @@ export const useVideoControlsResize = ({
 				? maxTimeLabelWidthWithoutNegativeValue
 				: availableTimeLabelWidthIfVolumeOpen;
 		const minWidthForHorizontalDisplay =
-			computedLabelWidth +
-			volumeIconSize +
-			VOLUME_SLIDER_WIDTH +
-			playPauseIconSize +
-			_fullscreenIconSize +
-			X_PADDING * 2 +
-			X_SPACER * 2;
+			computedLabelWidth + elementsSize + VOLUME_SLIDER_WIDTH;
 
 		const displayVerticalVolumeSlider =
 			playerWidth < minWidthForHorizontalDisplay;

--- a/packages/player/src/use-video-controls-resize.ts
+++ b/packages/player/src/use-video-controls-resize.ts
@@ -1,0 +1,67 @@
+import {useMemo} from 'react';
+import {useVideoConfig} from 'remotion';
+import {fullscreenIconSize, ICON_SIZE} from './icons';
+import {VOLUME_SLIDER_WIDTH} from './MediaVolumeSlider';
+import {X_SPACER} from './PlayerControls';
+
+export const useVideoControlsResize = (
+	isFullscreen: Boolean,
+	allowFullScreen: Boolean
+): {
+	maxTimeLabelWidth: number;
+	displayVerticalVolumeSlider: Boolean;
+} => {
+	const {width} = useVideoConfig();
+
+	const {maxTimeLabelWidth, displayVerticalVolumeSlider} = useMemo((): {
+		maxTimeLabelWidth: number;
+		displayVerticalVolumeSlider: Boolean;
+	} => {
+		const playerWidth = isFullscreen ? window.innerWidth : width;
+		const playPauseIconSize = ICON_SIZE;
+		const volumeIconSize = ICON_SIZE;
+		const _fullscreenIconSize = allowFullScreen ? fullscreenIconSize : 0;
+		const xPadding = 12 * 2;
+		const maxTimeLabelWidth =
+			playerWidth -
+			volumeIconSize -
+			playPauseIconSize -
+			xPadding -
+			_fullscreenIconSize -
+			X_SPACER * 2;
+
+		const maxTimeLabelWidthWithoutNegativeValue =
+			maxTimeLabelWidth > 0 ? maxTimeLabelWidth : 0;
+
+		const availableTimeLabelWidthIfVolumeOpen =
+			maxTimeLabelWidthWithoutNegativeValue - VOLUME_SLIDER_WIDTH;
+
+		// If max label width is lower than the volume width
+		// then it means we need to take it's width as the max label width
+		// otherwise we took the available width when volume open
+		const computedLabelWidth =
+			availableTimeLabelWidthIfVolumeOpen < VOLUME_SLIDER_WIDTH
+				? maxTimeLabelWidthWithoutNegativeValue
+				: availableTimeLabelWidthIfVolumeOpen;
+		const minWidthForHorizontalDisplay =
+			computedLabelWidth +
+			volumeIconSize +
+			VOLUME_SLIDER_WIDTH +
+			playPauseIconSize +
+			_fullscreenIconSize +
+			xPadding +
+			X_SPACER * 2;
+
+		const displayVerticalVolumeSlider =
+			playerWidth < minWidthForHorizontalDisplay;
+		return {
+			maxTimeLabelWidth: maxTimeLabelWidthWithoutNegativeValue,
+			displayVerticalVolumeSlider,
+		};
+	}, [width, isFullscreen, allowFullScreen]);
+
+	return {
+		maxTimeLabelWidth,
+		displayVerticalVolumeSlider,
+	};
+};

--- a/packages/player/src/use-video-controls-resize.ts
+++ b/packages/player/src/use-video-controls-resize.ts
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 import {useVideoConfig} from 'remotion';
 import {fullscreenIconSize, ICON_SIZE} from './icons';
 import {VOLUME_SLIDER_WIDTH} from './MediaVolumeSlider';
-import {X_SPACER} from './PlayerControls';
+import {X_PADDING, X_SPACER} from './PlayerControls';
 
 export const useVideoControlsResize = (
 	isFullscreen: Boolean,
@@ -13,7 +13,7 @@ export const useVideoControlsResize = (
 } => {
 	const {width} = useVideoConfig();
 
-	const {maxTimeLabelWidth, displayVerticalVolumeSlider} = useMemo((): {
+	const resizeInfo = useMemo((): {
 		maxTimeLabelWidth: number;
 		displayVerticalVolumeSlider: Boolean;
 	} => {
@@ -21,13 +21,12 @@ export const useVideoControlsResize = (
 		const playPauseIconSize = ICON_SIZE;
 		const volumeIconSize = ICON_SIZE;
 		const _fullscreenIconSize = allowFullScreen ? fullscreenIconSize : 0;
-		const xPadding = 12 * 2;
 		const maxTimeLabelWidth =
 			playerWidth -
 			volumeIconSize -
 			playPauseIconSize -
-			xPadding -
 			_fullscreenIconSize -
+			X_PADDING * 2 -
 			X_SPACER * 2;
 
 		const maxTimeLabelWidthWithoutNegativeValue =
@@ -49,7 +48,7 @@ export const useVideoControlsResize = (
 			VOLUME_SLIDER_WIDTH +
 			playPauseIconSize +
 			_fullscreenIconSize +
-			xPadding +
+			X_PADDING * 2 +
 			X_SPACER * 2;
 
 		const displayVerticalVolumeSlider =
@@ -60,8 +59,5 @@ export const useVideoControlsResize = (
 		};
 	}, [width, isFullscreen, allowFullScreen]);
 
-	return {
-		maxTimeLabelWidth,
-		displayVerticalVolumeSlider,
-	};
+	return resizeInfo;
 };

--- a/packages/player/src/use-video-controls-resize.ts
+++ b/packages/player/src/use-video-controls-resize.ts
@@ -1,23 +1,22 @@
 import {useMemo} from 'react';
-import {useVideoConfig} from 'remotion';
 import {fullscreenIconSize, ICON_SIZE} from './icons';
 import {VOLUME_SLIDER_WIDTH} from './MediaVolumeSlider';
 import {X_PADDING, X_SPACER} from './PlayerControls';
 
-export const useVideoControlsResize = (
-	isFullscreen: Boolean,
-	allowFullScreen: Boolean
-): {
+export const useVideoControlsResize = ({
+	allowFullscreen: allowFullScreen,
+	playerWidth,
+}: {
+	allowFullscreen: boolean;
+	playerWidth: number;
+}): {
 	maxTimeLabelWidth: number;
-	displayVerticalVolumeSlider: Boolean;
+	displayVerticalVolumeSlider: boolean;
 } => {
-	const {width} = useVideoConfig();
-
 	const resizeInfo = useMemo((): {
 		maxTimeLabelWidth: number;
-		displayVerticalVolumeSlider: Boolean;
+		displayVerticalVolumeSlider: boolean;
 	} => {
-		const playerWidth = isFullscreen ? window.innerWidth : width;
 		const playPauseIconSize = ICON_SIZE;
 		const volumeIconSize = ICON_SIZE;
 		const _fullscreenIconSize = allowFullScreen ? fullscreenIconSize : 0;
@@ -53,11 +52,12 @@ export const useVideoControlsResize = (
 
 		const displayVerticalVolumeSlider =
 			playerWidth < minWidthForHorizontalDisplay;
+
 		return {
 			maxTimeLabelWidth: maxTimeLabelWidthWithoutNegativeValue,
 			displayVerticalVolumeSlider,
 		};
-	}, [width, isFullscreen, allowFullScreen]);
+	}, [allowFullScreen, playerWidth]);
 
 	return resizeInfo;
 };


### PR DESCRIPTION
#1352

As mention in the bug report, the volume is not responsive if the player has a small width.

#### Integration
![volumeSliderVertical](https://user-images.githubusercontent.com/7658097/193391291-c88551d1-1382-411c-a151-efafc44ef420.gif)

Under 480px, I considerer that the width is small (we can change this value by changing the MAX_MOBILE_WIDTH value)

According to the case, there was two possible width :
- Width configured on the player
- window.innerWidth

If the fullScreen is enabled, then I check the innerWidth, otherwise I rely on the width that was configure on the player.

If the player is small, then I delete the injectedCSS for the horizontal display and inject the one for the vertical.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1352: volume component of Player is not responsively designed](https://issuehunt.io/repos/274495425/issues/1352)
---
</details>
<!-- /Issuehunt content-->