### PR TITLE
Report slowest frames

### DIFF
--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -322,6 +322,7 @@ export const render = async (remotionRoot: string) => {
 		onDownload,
 		downloadMap,
 		onSlowestFrames: (slowestFrames) => {
+			Log.verbose();
 			Log.verbose(`Slowest frames:`);
 			slowestFrames.forEach(({frame, time}) => {
 				Log.verbose(`Frame ${frame} (${time.toFixed(3)}ms)`);

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -308,7 +308,7 @@ export const render = async (remotionRoot: string) => {
 		codec,
 	});
 
-	const ret = await renderMedia({
+	await renderMedia({
 		...options,
 		onProgress: (update) => {
 			encodedDoneIn = update.encodedDoneIn;
@@ -321,18 +321,16 @@ export const render = async (remotionRoot: string) => {
 		puppeteerInstance,
 		onDownload,
 		downloadMap,
+		onSlowestFrames: (slowestFrames) => {
+			Log.verbose(`Slowest frames:`);
+			slowestFrames.forEach(({frame, time}) => {
+				Log.verbose(`Frame ${frame} (${time.toFixed(3)}ms)`);
+			});
+		},
 	});
 
 	Log.info();
 	Log.info();
-	if (ret) {
-		Log.verbose(
-			`Following ${ret.slowestFrames.length} frames were slowest to render, consider optimizing them:`
-		);
-		ret.slowestFrames.forEach(({index, time}) => {
-			Log.verbose(`Frame Number : ${index}, Time Taken : ${time.toFixed(3)}`);
-		});
-	}
 
 	const seconds = Math.round((Date.now() - startTime) / 1000);
 	Log.info(

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -308,7 +308,7 @@ export const render = async (remotionRoot: string) => {
 		codec,
 	});
 
-	await renderMedia({
+	const ret = await renderMedia({
 		...options,
 		onProgress: (update) => {
 			encodedDoneIn = update.encodedDoneIn;
@@ -325,6 +325,15 @@ export const render = async (remotionRoot: string) => {
 
 	Log.info();
 	Log.info();
+	if (ret) {
+		Log.verbose(
+			`Following ${ret.slowestFrames.length} frames were slowest to render, consider optimizing them:`
+		);
+		ret.slowestFrames.forEach(({index, time}) => {
+			Log.verbose(`Frame Number : ${index}, Time Taken : ${time.toFixed(3)}`);
+		});
+	}
+
 	const seconds = Math.round((Date.now() - startTime) / 1000);
 	Log.info(
 		[

--- a/packages/docs/docs/renderer/render-frames.md
+++ b/packages/docs/docs/renderer/render-frames.md
@@ -39,11 +39,25 @@ const onStart = () => {
 
 ### `onFrameUpdate`
 
-A callback function that gets called whenever a frame finished rendering. An argument is passed containing how many frames have been rendered (not the frame number of the rendered frame). Example value
+A callback function that gets called whenever a frame finished rendering. An argument is passed containing how many frames have been rendered (not the frame number of the rendered frame).
+
+In `v3.0.0`, a second argument was added: `frame`, returning the frame number that was just rendered.
+
+In `v3.2.30`, a third argument was rendered: `timeToRenderInMilliseconds`, describing the time it took to render that frame in milliseconds.
 
 ```ts twoslash
-const onFrameUpdate = (frame: number) => {
-  console.log(`${frame} frames rendered.`);
+const onFrameUpdate = (
+  framesRendered: number,
+  frame: number,
+  timeToRenderInMilliseconds: number
+) => {
+  console.log(`${framesRendered} frames rendered.`);
+
+  // From v3.0.0
+  console.log(`${frame} was just rendered.`);
+
+  // From v3.2.30
+  console.log(`It took ${timeToRenderInMilliseconds}ms to render that frame.`);
 };
 ```
 

--- a/packages/docs/docs/renderer/render-media.md
+++ b/packages/docs/docs/renderer/render-media.md
@@ -368,6 +368,8 @@ Before you use this hack, reach out to the Remotion team on [Discord](https://re
 
 ## Return Value
 
+_Available since 3.2.29_
+
 Returns a promise that resolves to an object with keys `buffer` and `slowestFrames`. `slowestFrames` is an array of 10 slowest frames in form of `{index:<Frame number>, time:<Time to render frame ms>}`. You can use this information to optimise your render times.
 
 ## See also

--- a/packages/docs/docs/renderer/render-media.md
+++ b/packages/docs/docs/renderer/render-media.md
@@ -366,11 +366,29 @@ Using this feature is discouraged. Before using it, we want to make you aware of
 Before you use this hack, reach out to the Remotion team on [Discord](https://remotion.dev/discord) and ask us if we are open to implement the feature you need in a clean way - we often do implement new features quickly based on users feedback.
 :::
 
+### `onSlowestFrames?`
+
+_available from v3.2.29_
+
+Callback function that gets called right before `renderMedia()` resolves.  
+The only argument `slowestFrames` is an array of the 10 slowest frames in the shape of `{frame:<Frame number>, time:<Time to render frame ms>}`. You can use this information to optimise your render times.
+
+```tsx twoslash
+import type { OnSlowestFrames } from "@remotion/renderer";
+
+const onSlowestFrames: OnSlowestFrames = (slowestFrames) => {
+  console.log("The slowest 10 frames are:");
+  for (const slowFrame of slowestFrames) {
+    console.log(`Frame ${slowFrame.frame} (${slowFrame.time}ms)`);
+  }
+};
+```
+
 ## Return Value
 
-_Available since 3.2.29_
+_since v3.0.26_
 
-Returns a promise that resolves to an object with keys `buffer` and `slowestFrames`. `slowestFrames` is an array of 10 slowest frames in form of `{index:<Frame number>, time:<Time to render frame ms>}`. You can use this information to optimise your render times.
+If `outputLocation` is not specified or `null`, the return value is a Promise that resolves a `Buffer`. If an output location is specified, the return value is a Promise that resolves no value.
 
 ## See also
 

--- a/packages/docs/docs/renderer/render-media.md
+++ b/packages/docs/docs/renderer/render-media.md
@@ -366,6 +366,10 @@ Using this feature is discouraged. Before using it, we want to make you aware of
 Before you use this hack, reach out to the Remotion team on [Discord](https://remotion.dev/discord) and ask us if we are open to implement the feature you need in a clean way - we often do implement new features quickly based on users feedback.
 :::
 
+## Return Value
+
+Returns a promise that resolves to an object with keys `buffer` and `slowestFrames`. `slowestFrames` is an array of 10 slowest frames in form of `{index:<Frame number>, time:<Time to render frame ms>}`. You can use this information to optimise your render times.
+
 ## See also
 
 - [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/renderer/src/render-media.ts)

--- a/packages/it-tests/src/ssr/render-media.test.ts
+++ b/packages/it-tests/src/ssr/render-media.test.ts
@@ -111,5 +111,5 @@ test("Render video to a buffer", async () => {
     frameRange: [0, 2],
   });
 
-  expect(buffer?.buffer?.length).toBeGreaterThan(2000);
+  expect(buffer?.length).toBeGreaterThan(2000);
 });

--- a/packages/it-tests/src/ssr/render-media.test.ts
+++ b/packages/it-tests/src/ssr/render-media.test.ts
@@ -111,5 +111,5 @@ test("Render video to a buffer", async () => {
     frameRange: [0, 2],
   });
 
-  expect(buffer?.length).toBeGreaterThan(2000);
+  expect(buffer?.buffer?.length).toBeGreaterThan(2000);
 });

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -199,22 +199,14 @@ const renderHandler = async (
 			downloadMap,
 			muted: params.muted,
 			enforceAudioTrack: true,
-		})
-			.then((ret) => {
-				if (ret && params.logLevel === 'verbose') {
-					console.log(
-						`Following ${ret.slowestFrames.length} frames were slowest to render, consider optimizing them:`
-					);
-					ret.slowestFrames.forEach(({index, time}) => {
-						console.log(
-							`Frame Number : ${index}, Time Taken : ${time.toFixed(3)}`
-						);
-					});
-				}
-
-				resolve();
-			})
-			.catch((err) => reject(err));
+			onSlowestFrames: (slowestFrames) => {
+				console.log();
+				console.log(`Slowest frames:`);
+				slowestFrames.forEach(({frame, time}) => {
+					console.log(`Frame ${frame} (${time.toFixed(3)}ms)`);
+				});
+			},
+		}).catch((err) => reject(err));
 	});
 
 	const endRendered = Date.now();

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -200,7 +200,20 @@ const renderHandler = async (
 			muted: params.muted,
 			enforceAudioTrack: true,
 		})
-			.then(() => resolve())
+			.then((ret) => {
+				if (ret && params.logLevel === 'verbose') {
+					console.log(
+						`Following ${ret.slowestFrames.length} frames were slowest to render, consider optimizing them:`
+					);
+					ret.slowestFrames.forEach(({index, time}) => {
+						console.log(
+							`Frame Number : ${index}, Time Taken : ${time.toFixed(3)}`
+						);
+					});
+				}
+
+				resolve();
+			})
 			.catch((err) => reject(err));
 	});
 

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -206,7 +206,9 @@ const renderHandler = async (
 					console.log(`Frame ${frame} (${time.toFixed(3)}ms)`);
 				});
 			},
-		}).catch((err) => reject(err));
+		})
+			.then(() => resolve())
+			.catch((err) => reject(err));
 	});
 
 	const endRendered = Date.now();

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -95,9 +95,11 @@ export {PixelFormat} from './pixel-format';
 export {ProResProfile} from './prores-profile';
 export {renderFrames} from './render-frames';
 export {
+	OnSlowestFrames,
 	renderMedia,
 	RenderMediaOnProgress,
 	RenderMediaOptions,
+	SlowFrame,
 	StitchingState,
 } from './render-media';
 export {renderStill, RenderStillOptions} from './render-still';

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import {performance} from 'perf_hooks';
 import type {SmallTCompMetadata, TAsset} from 'remotion';
 import {Internals} from 'remotion';
 import type {RenderMediaOnDownload} from './assets/download-and-map-assets-to-file';
@@ -68,7 +69,11 @@ type ConcurrencyOrParallelism =
 
 type RenderFramesOptions = {
 	onStart: (data: OnStartData) => void;
-	onFrameUpdate: (framesRendered: number, frameIndex: number) => void;
+	onFrameUpdate: (
+		framesRendered: number,
+		frameIndex: number,
+		timeToRenderInMilliseconds: number
+	) => void;
 	outputDir: string | null;
 	inputProps: unknown;
 	envVariables?: Record<string, string>;
@@ -290,6 +295,8 @@ const innerRenderFrames = ({
 				throw new Error('Render was stopped');
 			}
 
+			const startTime = performance.now();
+
 			const errorCallbackOnFrame = (err: Error) => {
 				onError(err);
 			};
@@ -372,7 +379,7 @@ const innerRenderFrames = ({
 			});
 			pool.release(freePage);
 			framesRendered++;
-			onFrameUpdate(framesRendered, frame);
+			onFrameUpdate(framesRendered, frame, performance.now() - startTime);
 			cleanupPageError();
 			freePage.off('error', errorCallbackOnFrame);
 			return compressedAssets;

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -53,11 +53,6 @@ const SLOWEST_FRAME_COUNT = 10;
 
 export type FrameTime = {index: number; time: number};
 
-export type RenderMediaResult = Promise<{
-	buffer: Buffer | null;
-	slowestFrames: FrameTime[];
-} | null>;
-
 export type RenderMediaOnProgress = (progress: {
 	renderedFrames: number;
 	encodedFrames: number;
@@ -166,7 +161,7 @@ export const renderMedia = ({
 	enforceAudioTrack,
 	ffmpegOverride,
 	...options
-}: RenderMediaOptions): RenderMediaResult => {
+}: RenderMediaOptions): Promise<Buffer | null> => {
 	validateQuality(options.quality);
 	if (typeof crf !== 'undefined' && crf !== null) {
 		validateSelectedCrfAndCodecCombination(crf, codec);
@@ -470,7 +465,7 @@ export const renderMedia = ({
 			encodedFrames = getFramesToRender(realFrameRange, everyNthFrame).length;
 			encodedDoneIn = Date.now() - stitchStart;
 			callUpdate();
-			return {buffer, slowestFrames};
+			return buffer;
 		})
 		.catch((err) => {
 			/**
@@ -517,7 +512,7 @@ export const renderMedia = ({
 
 	return Promise.race([
 		happyPath,
-		new Promise<RenderMediaResult>((_resolve, reject) => {
+		new Promise<Buffer | null>((_resolve, reject) => {
 			cancelSignal?.(() => {
 				reject(new Error('renderMedia() got cancelled'));
 			});

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -2,7 +2,6 @@ import type {ExecaChildProcess} from 'execa';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import {performance} from 'perf_hooks';
 import type {SmallTCompMetadata} from 'remotion';
 import {Internals} from 'remotion';
 import type {RenderMediaOnDownload} from './assets/download-and-map-assets-to-file';
@@ -332,17 +331,8 @@ export const renderMedia = ({
 	const slowestFrames: SlowFrame[] = [];
 	let maxTime = 0;
 	let minTime = 0;
-	let startTime = performance.now();
 
-	const recordFrameTime = (frameIndex: number) => {
-		const time = performance.now() - startTime;
-		startTime = performance.now();
-
-		// ignore first frame
-		if (frameIndex <= 1) {
-			return;
-		}
-
+	const recordFrameTime = (frameIndex: number, time: number) => {
 		const frameTime: SlowFrame = {frame: frameIndex, time};
 
 		if (time < minTime && slowestFrames.length === SLOWEST_FRAME_COUNT) {
@@ -372,10 +362,14 @@ export const renderMedia = ({
 		.then(() => {
 			const renderFramesProc = renderFrames({
 				config: composition,
-				onFrameUpdate: (frame: number, frameIndex: number) => {
+				onFrameUpdate: (
+					frame: number,
+					frameIndex: number,
+					timeToRenderInMilliseconds
+				) => {
 					renderedFrames = frame;
 					callUpdate();
-					recordFrameTime(frameIndex);
+					recordFrameTime(frameIndex, timeToRenderInMilliseconds);
 				},
 				concurrency,
 				outputDir,

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -359,7 +359,7 @@ export const renderMedia = ({
 			slowestFrames.pop();
 		}
 
-		minTime = slowestFrames.at(-1)?.time ?? minTime;
+		minTime = slowestFrames[slowestFrames.length - 1]?.time ?? minTime;
 	};
 
 	const happyPath = createPrestitcherIfNecessary()

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -2,6 +2,7 @@ import type {ExecaChildProcess} from 'execa';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import {performance} from 'perf_hooks';
 import type {SmallTCompMetadata} from 'remotion';
 import {Internals} from 'remotion';
 import type {RenderMediaOnDownload} from './assets/download-and-map-assets-to-file';

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -476,6 +476,7 @@ export const renderMedia = ({
 			encodedFrames = getFramesToRender(realFrameRange, everyNthFrame).length;
 			encodedDoneIn = Date.now() - stitchStart;
 			callUpdate();
+			slowestFrames.sort((a, b) => b.time - a.time);
 			onSlowestFrames?.(slowestFrames);
 			return buffer;
 		})


### PR DESCRIPTION
Fixes #1344 

`renderMedia` returns array of 10 slowest frames with frame indexes for user to optimise them. 

Tasks: 
- [x] Report in cli in verbose mode
- [x] Log slowest frames in lambda
- [x] Update docs
- [x] CI build pass (or fix tests)?


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1344: Report slowest frames of renderMedia()](https://issuehunt.io/repos/274495425/issues/1344)
---
</details>
<!-- /Issuehunt content-->