### PR TITLE
throw if undefined variable is passed to registerRoot()

### DIFF
--- a/packages/core/src/register-root.ts
+++ b/packages/core/src/register-root.ts
@@ -5,6 +5,14 @@ let Root: React.FC | null = null;
 let listeners: ((comp: React.FC) => void)[] = [];
 
 export const registerRoot = (comp: React.FC) => {
+	if (!comp) {
+		throw new Error(
+			`You must pass a React component to registerRoot(), but ${JSON.stringify(
+				comp
+			)} was passed.`
+		);
+	}
+
 	if (Root) {
 		throw new Error('registerRoot() was called more than once.');
 	}


### PR DESCRIPTION
Previously if you rendered, you would get "minified react error"