### PR TITLE
resolve the public dir relative to the directory of the entry point

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -113,13 +113,13 @@ const convertArgumentsIntoOptions = (args: Arguments): BundleOptions => {
 
 const recursionLimit = 5;
 
-const findClosestPackageJson = (currentDir: string): string | null => {
+const findClosestPackageJsonFolder = (currentDir: string): string | null => {
 	let possiblePackageJson = '';
 	for (let i = 0; i < recursionLimit; i++) {
 		possiblePackageJson = path.join(currentDir, 'package.json');
 		const exists = fs.existsSync(possiblePackageJson);
 		if (exists) {
-			return possiblePackageJson;
+			return path.dirname(possiblePackageJson);
 		}
 
 		currentDir = path.dirname(currentDir);
@@ -132,7 +132,7 @@ export async function bundle(...args: Arguments): Promise<string> {
 	const actualArgs = convertArgumentsIntoOptions(args);
 	const resolvedRemotionRoot =
 		actualArgs?.rootDir ??
-		findClosestPackageJson(actualArgs.entryPoint) ??
+		findClosestPackageJsonFolder(actualArgs.entryPoint) ??
 		process.cwd();
 
 	const outDir = await prepareOutDir(actualArgs?.outDir ?? null);

--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -111,9 +111,29 @@ const convertArgumentsIntoOptions = (args: Arguments): BundleOptions => {
 	return firstArg;
 };
 
+const recursionLimit = 5;
+
+const findClosestPackageJson = (currentDir: string): string | null => {
+	let possiblePackageJson = '';
+	for (let i = 0; i < recursionLimit; i++) {
+		possiblePackageJson = path.join(currentDir, 'package.json');
+		const exists = fs.existsSync(possiblePackageJson);
+		if (exists) {
+			return possiblePackageJson;
+		}
+
+		currentDir = path.dirname(currentDir);
+	}
+
+	return null;
+};
+
 export async function bundle(...args: Arguments): Promise<string> {
 	const actualArgs = convertArgumentsIntoOptions(args);
-	const resolvedRemotionRoot = actualArgs?.rootDir ?? process.cwd();
+	const resolvedRemotionRoot =
+		actualArgs?.rootDir ??
+		findClosestPackageJson(actualArgs.entryPoint) ??
+		process.cwd();
 
 	const outDir = await prepareOutDir(actualArgs?.outDir ?? null);
 


### PR DESCRIPTION
Assuming a project structure like this:

```
renderer
│   ├── package.json
│   ├── public
│   │   └── fonts
│   │       ├── cc.ttf
│   │       ├── mb.ttf
│   │       └── mc.ttf
│   ├── README.md
│   ├── remotion.config.ts
│   ├── src
│   │   ├── components
│   │   │   └── Title.tsx
│   │   ├── index.tsx
│   │   ├── Subtitle.tsx
│   │   ├── util
│   │   │   ├── Font.ts
│   │   └── Video.tsx
│   ├── tsconfig.json
│   ├── yarn-error.log
│   └── yarn.lock
server
├── package.json
└── utils
    ├── Render.ts
├── tsconfig.json
└── yarn.lock
```

It would make sense to look for the public dir in the renderer folder, not the server folder when the entry point is in the renderer folder. Making this change to fix it, since it was undefined behavior before I think it is fine to change the behavior