### PR TITLE
Rename MotionBlur to Trail and add CameraMotionBlur component

### DIFF
--- a/packages/motion-blur/src/MotionBlur.tsx
+++ b/packages/motion-blur/src/MotionBlur.tsx
@@ -72,7 +72,6 @@ export const MotionBlur: React.FC<MotionBlurProps> = ({
 					</AbsoluteFill>
 				);
 			})}
-			{children}
 		</AbsoluteFill>
 	);
 };


### PR DESCRIPTION
~~MotionBlur works by making `n` copies of `children` and assigning each child an opacity to give an experienced trailing effect similar to motion blur.~~

~~This PR removes the `{children}` adjacent to those "onion skin" copies. The component should render only the "onion skin" layers, and not an extra original on top of everything.~~

This PR is waiting on the outcome of the discussion below to determine its future.