### PR TITLE
Make the from prop of <Sequence> optional

### DIFF
--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -35,7 +35,7 @@ type LayoutAndStyle =
 
 export type SequenceProps = {
 	children: React.ReactNode;
-	from: number;
+	from?: number;
 	durationInFrames?: number;
 	name?: string;
 	showInTimeline?: boolean;
@@ -47,7 +47,7 @@ const SequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 	SequenceProps
 > = (
 	{
-		from,
+		from = 0,
 		durationInFrames = Infinity,
 		children,
 		name,

--- a/packages/docs/components/SequenceExamples/SequenceForward.tsx
+++ b/packages/docs/components/SequenceExamples/SequenceForward.tsx
@@ -45,15 +45,15 @@ const BlueSquare: React.FC = () => {
 
 const DelayExample: React.FC = () => {
   return (
-    <Sequence from={30} >
-      <BlueSquare/>
+    <Sequence from={30}>
+      <BlueSquare />
     </Sequence>
   );
 };
 
 const TrimStartExample: React.FC = () => {
   return (
-    <Sequence from={-15} >
+    <Sequence from={-15}>
       <BlueSquare />
     </Sequence>
   );
@@ -61,8 +61,8 @@ const TrimStartExample: React.FC = () => {
 
 const TrimAndDelayExample: React.FC = () => {
   return (
-    <Sequence from={30} >
-      <Sequence from={-15} >
+    <Sequence from={30}>
+      <Sequence from={-15}>
         <BlueSquare />
       </Sequence>
     </Sequence>
@@ -120,7 +120,7 @@ export const SequenceForwardExample: React.FC<{
           width: "100%",
         }}
         loop
-       />
+      />
     </div>
   );
 };

--- a/packages/docs/docs/sequence.md
+++ b/packages/docs/docs/sequence.md
@@ -50,9 +50,10 @@ The Sequence component is a high order component and accepts, besides children, 
 
 ### `from`
 
-_required_
+_optional_ (From v3.2.36, _required_ in previous versions)
 
 At which frame it's children should assume the video starts. When the sequence is at `frame`, it's children are at frame `0`.
+From v3.2.36 onwards, this prop will be optional; by default, it will be 0.
 
 ### `durationInFrames`
 

--- a/packages/docs/docs/sequence.md
+++ b/packages/docs/docs/sequence.md
@@ -24,7 +24,7 @@ export const Outro = () => <></>;
 const MyTrailer = () => {
   return (
     <>
-      <Sequence from={0} durationInFrames={10}>
+      <Sequence durationInFrames={10}>
         <Intro />
       </Sequence>
       <Sequence from={10}>
@@ -123,7 +123,7 @@ const MyVideo = () => {
 ### Trim end
 
 We can clip some content so it only stays visible for a certain time by specifying a non-finite `durationInFrames` number.
-In this example, we wrap the square in `<Sequence from={0} durationInFrames={45}>` and as you can see, it disappears after 45 frames.
+In this example, we wrap the square in `<Sequence durationInFrames={45}>` and as you can see, it disappears after 45 frames.
 
 <SequenceForwardExample type="clip" />
 <br />

--- a/packages/docs/docs/sequences.md
+++ b/packages/docs/docs/sequences.md
@@ -57,7 +57,7 @@ export const MyVideo = () => {
         backgroundColor: "white",
       }}
     >
-      <Sequence from={0} durationInFrames={40}>
+      <Sequence durationInFrames={40}>
         <Title title="Hello" />
       </Sequence>
       <Sequence from={40}>

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import deterministicRandomness from "./rules/deterministic-randomness";
 import evenDimensions from "./rules/even-dimensions";
 import durationInFrames from "./rules/no-duration-frames-infinity";
+import noFrom0 from "./rules/no-from-0";
 import nomp4Import from "./rules/no-mp4-import";
 import noStringAssets from "./rules/no-string-assets";
 import staticFileNoRelative from "./rules/staticfile-no-relative";
@@ -16,6 +17,7 @@ const rules = {
   "no-string-assets": noStringAssets,
   "even-dimensions": evenDimensions,
   "duration-in-frames": durationInFrames,
+  "from-0": noFrom0,
   "volume-callback": volumeCallback,
   "use-gif-component": useGifComponent,
   "staticfile-no-relative": staticFileNoRelative,
@@ -33,6 +35,7 @@ export = {
         "@remotion/no-string-assets": "error",
         "@remotion/even-dimensions": "error",
         "@remotion/duration-in-frames": "error",
+        "@remotion/from-0": "error",
         "@remotion/volume-callback": "error",
         "@remotion/use-gif-component": "error",
         "@remotion/staticfile-no-relative": "error",

--- a/packages/eslint-plugin/src/rules/no-from-0.ts
+++ b/packages/eslint-plugin/src/rules/no-from-0.ts
@@ -6,22 +6,22 @@ const createRule = ESLintUtils.RuleCreator(() => {
 
 type Options = [];
 
-type MessageIds = "From";
+type MessageIds = "From0";
 
-const From = "0 is now the default, so you can remove the prop.";
+const From0 = "0 is now the default, so you can remove the prop.";
 
 export default createRule<Options, MessageIds>({
   name: "from",
   meta: {
     type: "problem",
     docs: {
-      description: From,
+      description: From0,
       recommended: "warn",
     },
     fixable: "code",
     schema: [],
     messages: {
-      From,
+      From0,
     },
   },
   defaultOptions: [],
@@ -41,12 +41,13 @@ export default createRule<Options, MessageIds>({
         }
 
         const expression = value.expression;
-        if (!expression || expression.type !== "Identifier") {
+        if (!expression || expression.type !== "Literal") {
           return;
         }
 
-        const stringValue = expression.name;
-        if (typeof stringValue !== "string") {
+        const stringValue = expression.value;
+
+        if (stringValue !== 0) {
           return;
         }
 
@@ -66,9 +67,9 @@ export default createRule<Options, MessageIds>({
         if (name.name !== "Sequence") {
           return;
         }
-        if (stringValue === "0") {
+        if (stringValue === 0) {
           context.report({
-            messageId: "From",
+            messageId: "From0",
             node,
             fix: (fixer) => {
               return fixer.removeRange([node.name.range[0], value.range[1]]);

--- a/packages/eslint-plugin/src/rules/no-from-0.ts
+++ b/packages/eslint-plugin/src/rules/no-from-0.ts
@@ -1,0 +1,81 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(() => {
+  return `https://github.com/remotion-dev/remotion`;
+});
+
+type Options = [];
+
+type MessageIds = "From";
+
+const From = "0 is now the default, so you can remove the prop.";
+
+export default createRule<Options, MessageIds>({
+  name: "from",
+  meta: {
+    type: "problem",
+    docs: {
+      description: From,
+      recommended: "warn",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      From,
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      JSXAttribute: (node) => {
+        if (node.type !== "JSXAttribute") {
+          return;
+        }
+
+        if (node.name.name !== "from") {
+          return;
+        }
+        const value = node.value;
+        if (!value || value.type !== "JSXExpressionContainer") {
+          return;
+        }
+
+        const expression = value.expression;
+        if (!expression || expression.type !== "Identifier") {
+          return;
+        }
+
+        const stringValue = expression.name;
+        if (typeof stringValue !== "string") {
+          return;
+        }
+
+        const parent = node.parent;
+        if (!parent) {
+          return;
+        }
+
+        if (parent.type !== "JSXOpeningElement") {
+          return;
+        }
+
+        const name = parent.name;
+        if (name.type !== "JSXIdentifier") {
+          return;
+        }
+        if (name.name !== "Sequence") {
+          return;
+        }
+        if (stringValue === "0") {
+          context.report({
+            messageId: "From",
+            node,
+            fix: (fixer) => {
+              return fixer.removeRange([node.name.range[0], value.range[1]]);
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/tests/no-from-0.test.ts
+++ b/packages/eslint-plugin/src/tests/no-from-0.test.ts
@@ -1,5 +1,5 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
-import rule from "../rules/no-duration-frames-infinity";
+import rule from "../rules/no-from-0";
 
 const ruleTester = new ESLintUtils.RuleTester({
   parser: "@typescript-eslint/parser",
@@ -17,7 +17,7 @@ ruleTester.run("no-duration-frames-infinity", rule, {
 
       export const Re = () => {
         return (
-          <Sequence durationInFrames={1}>
+          <Sequence durationInFrames={1} from={1}>
             Hi
           </Sequence>
         );
@@ -27,18 +27,18 @@ ruleTester.run("no-duration-frames-infinity", rule, {
   invalid: [
     {
       code: `
-        import {Composition} from 'remotion';
+        import {Composition, Sequence} from 'remotion';
 
         export const Re = () => {
           return (
-            <Sequence durationInFrames={Infinity}>
+            <Sequence from={0}>
               Hi
             </Sequence>
           );
         }
       `,
       output: `
-        import {Composition} from 'remotion';
+        import {Composition, Sequence} from 'remotion';
 
         export const Re = () => {
           return (
@@ -50,7 +50,7 @@ ruleTester.run("no-duration-frames-infinity", rule, {
       `,
       errors: [
         {
-          messageId: "DurationInFrames",
+          messageId: "From0",
         },
       ],
     },

--- a/packages/example/src/GifTest/fill-modes.tsx
+++ b/packages/example/src/GifTest/fill-modes.tsx
@@ -10,7 +10,7 @@ const GifTest: React.FC = () => {
 				display: 'flex',
 			}}
 		>
-			<Sequence from={0} durationInFrames={30}>
+			<Sequence durationInFrames={30}>
 				<Gif
 					fit="contain"
 					style={{

--- a/packages/example/src/GifTest/index.tsx
+++ b/packages/example/src/GifTest/index.tsx
@@ -7,7 +7,7 @@ const GifTest: React.FC = () => {
 
 	return (
 		<div style={{flex: 1, backgroundColor: 'black'}}>
-			<Sequence from={0} durationInFrames={50}>
+			<Sequence durationInFrames={50}>
 				<Gif src={giphy} width={width} height={height} fit="fill" />
 			</Sequence>
 

--- a/packages/example/src/Lottie/Halloween/Balloons.tsx
+++ b/packages/example/src/Lottie/Halloween/Balloons.tsx
@@ -59,7 +59,7 @@ const LottieBalloons: React.FC = () => {
 
 	return (
 		<div className="container" style={{height, width}}>
-			<Sequence from={0}>
+			<Sequence>
 				<Balloons />
 			</Sequence>
 			<Sequence from={10}>

--- a/packages/example/src/Lottie/Halloween/Pumpkin.tsx
+++ b/packages/example/src/Lottie/Halloween/Pumpkin.tsx
@@ -53,7 +53,7 @@ const LottiePumpkin: React.FC = () => {
 
 	return (
 		<div className="container" style={{height, width}}>
-			<Sequence from={0} durationInFrames={durationInFrames}>
+			<Sequence durationInFrames={durationInFrames}>
 				<Pumpkin />
 			</Sequence>
 			<Sequence from={30}>

--- a/packages/example/src/VideoTesting/index.tsx
+++ b/packages/example/src/VideoTesting/index.tsx
@@ -18,7 +18,7 @@ export const VideoTesting: React.FC<{
 
 	return (
 		<div>
-			<Sequence from={0} durationInFrames={durationInFrames}>
+			<Sequence durationInFrames={durationInFrames}>
 				<Comp src={codec === 'mp4' ? videoMp4 : videoWebm} />
 			</Sequence>
 		</div>


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
References #1431 
- Made the `from` prop optional and set a default value of `0`.
- Updated the `sequence.md` docs to state that the `from` prop is optional from `v3.2.36` onwards.
- Removed all occurrences of `from={0}` from the docs.
- Added ESLint Rule `no-from-0.ts` that automatically removes `from={0}`.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1431: Make the `from` prop of `<Sequence>` optional](https://issuehunt.io/repos/274495425/issues/1431)
---
</details>
<!-- /Issuehunt content-->