### PR TITLE
simplex-noise@4.0.1

### DIFF
--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"remotion": "3.2.35",
-		"simplex-noise": "4.0.0"
+		"simplex-noise": "4.0.1"
 	},
 	"devDependencies": {
 		"@jonny/eslint-config": "^3.0.266",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,12 +682,12 @@ importers:
       prettier: ^2.7.1
       prettier-plugin-organize-imports: ^2.3.4
       remotion: 3.2.35
-      simplex-noise: 4.0.0
+      simplex-noise: 4.0.1
       typescript: ^4.7.0
       vitest: 0.24.3
     dependencies:
       remotion: link:../core
-      simplex-noise: 4.0.0
+      simplex-noise: 4.0.1
     devDependencies:
       '@jonny/eslint-config': 3.0.266_t54va6jeo5lf3vtqih5uiyrm5e
       '@types/node': 16.10.2
@@ -19575,8 +19575,8 @@ packages:
       is-arrayish: 0.3.2
     dev: true
 
-  /simplex-noise/4.0.0:
-    resolution: {integrity: sha512-ciRAxJnRdQhFhZ7+yZKxk8bQJoIq2J2UPO2pbzy1vcrWFq70P4hNCCmcCTkBKDCIeXZVd/yKjL8Fmh8Aeu5+6g==}
+  /simplex-noise/4.0.1:
+    resolution: {integrity: sha512-zl/+bdSqW7HJOQ0oDbxrNYaF4F5ik0i7M6YOYmEoIJNtg16NpvWaTTM1Y7oV/7T0jFljawLgYPS81Uu2rsfo1A==}
     dev: false
 
   /sirv/1.0.17:


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Small fix of `simplex-noise`'s TSDoc and return type of `createNoise4D` function, so consumers won't get confused in case of looking at `node_modules` for example.

Diff between 4.0.0 and 4.0.1: https://github.com/jwagner/simplex-noise.js/compare/4.0.0...4.0.1