### PR TITLE
lottie add frame overload value

### DIFF
--- a/packages/lottie/src/Lottie.tsx
+++ b/packages/lottie/src/Lottie.tsx
@@ -13,6 +13,7 @@ export const Lottie = ({
 	direction,
 	loop,
 	playbackRate,
+	animationFrame,
 	style,
 	onAnimationLoaded,
 }: LottieProps) => {
@@ -87,7 +88,7 @@ export const Lottie = ({
 
 		const {totalFrames} = animationRef.current;
 		const nextFrame = getNextFrame({
-			currentFrame: frame * (playbackRate ?? 1),
+			currentFrame: animationFrame ?? frame * (playbackRate ?? 1),
 			direction,
 			loop,
 			totalFrames,
@@ -117,7 +118,7 @@ export const Lottie = ({
 				img.href.baseVal as string
 			);
 		});
-	}, [direction, frame, loop, playbackRate]);
+	}, [direction, frame, loop, playbackRate, animationFrame]);
 
 	return <div ref={containerRef} className={className} style={style} />;
 };

--- a/packages/lottie/src/types.ts
+++ b/packages/lottie/src/types.ts
@@ -30,6 +30,10 @@ export type LottieProps = {
 	 */
 	playbackRate?: number;
 	/**
+	 * Overload the frame number of the animation.
+	 */
+	animationFrame?: number;
+	/**
 	 * CSS properties to apply to the container of the animation.
 	 */
 	style?: CSSProperties;


### PR DESCRIPTION
This PR add a optional value _**animationFrame**_ in the props of Lottie to override the frame calculation.
So the playback can be maipulated from the outside of Lottie.

