### PR TITLE
docs: remove misleading info

### DIFF
--- a/packages/docs/docs/miscellaneous/snippets/player-in-iframe.md
+++ b/packages/docs/docs/miscellaneous/snippets/player-in-iframe.md
@@ -6,7 +6,7 @@ title: "Embedding a <Player> into an <iframe>"
 Credit to [@marcusstenbeck](https://twitter.com/marcusstenbeck) for creating this snippet.
 :::
 
-This snippet is useful if you want to isolate the global styles of your homepage from the global styles of the [`<Player>`](/docs/player), for example if you are using TailwindCSS.
+This snippet is useful if you want to isolate the global styles of your homepage from the global styles of the [`<Player>`](/docs/player).
 
 ```diff title="Usage"
 - import { Player } from '@remotion/player';


### PR DESCRIPTION
Since *any* global styles from the enclosing webpage will be applied it's better to not mention any CSS frameworks. Anyone trying to embed the `<Player />` component into a website will experience "style leaking". Whether this is an issue or not is up to the person in question.
