### PR TITLE
remove -shortest flag on lambda / don't cleanup lambda render when passing --log=verbose / print bucket link on lambda when adding --verbose

### DIFF
--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -283,7 +283,7 @@ _available from v3.2.10_
 
 A link to CloudWatch (if you haven't disabled it) that you can visit to see the logs for the render.
 
-### `renderFolder`
+### `folderInS3Console`
 
 _available from v3.2.43_
 

--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -283,6 +283,12 @@ _available from v3.2.10_
 
 A link to CloudWatch (if you haven't disabled it) that you can visit to see the logs for the render.
 
+### `renderFolder`
+
+_available from v3.2.43_
+
+A link to the folder in the AWS console where each chunk and render is located.
+
 ## See also
 
 - [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/lambda/src/api/render-media-on-lambda.ts)

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -13,7 +13,7 @@ import type {OutNameInput, Privacy} from '../shared/constants';
 import {LambdaRoutines} from '../shared/constants';
 import type {DownloadBehavior} from '../shared/content-disposition-header';
 import {convertToServeUrl} from '../shared/convert-to-serve-url';
-import {getCloudwatchStreamUrl} from '../shared/get-cloudwatch-stream-url';
+import {getCloudwatchStreamUrl, getS3RenderUrl} from '../shared/get-aws-urls';
 import {serializeInputProps} from '../shared/serialize-input-props';
 import {validateDownloadBehavior} from '../shared/validate-download-behavior';
 import {validateFramesPerLambda} from '../shared/validate-frames-per-lambda';
@@ -63,6 +63,7 @@ export type RenderMediaOnLambdaOutput = {
 	renderId: string;
 	bucketName: string;
 	cloudWatchLogs: string;
+	renderFolder: string;
 };
 
 /**
@@ -182,6 +183,11 @@ export const renderMediaOnLambda = async ({
 				method: LambdaRoutines.renderer,
 				region,
 				renderId: res.renderId,
+			}),
+			renderFolder: getS3RenderUrl({
+				bucketName: res.bucketName,
+				renderId: res.renderId,
+				region,
 			}),
 		};
 	} catch (err) {

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -63,7 +63,7 @@ export type RenderMediaOnLambdaOutput = {
 	renderId: string;
 	bucketName: string;
 	cloudWatchLogs: string;
-	renderFolder: string;
+	folderInS3Console: string;
 };
 
 /**
@@ -184,7 +184,7 @@ export const renderMediaOnLambda = async ({
 				region,
 				renderId: res.renderId,
 			}),
-			renderFolder: getS3RenderUrl({
+			folderInS3Console: getS3RenderUrl({
 				bucketName: res.bucketName,
 				renderId: res.renderId,
 				region,

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -10,7 +10,7 @@ import type {CostsInfo, OutNameInput, Privacy} from '../shared/constants';
 import {DEFAULT_MAX_RETRIES, LambdaRoutines} from '../shared/constants';
 import type {DownloadBehavior} from '../shared/content-disposition-header';
 import {convertToServeUrl} from '../shared/convert-to-serve-url';
-import {getCloudwatchStreamUrl} from '../shared/get-cloudwatch-stream-url';
+import {getCloudwatchStreamUrl} from '../shared/get-aws-urls';
 import {serializeInputProps} from '../shared/serialize-input-props';
 
 export type RenderStillOnLambdaInput = {

--- a/packages/lambda/src/cli/commands/render/progress.ts
+++ b/packages/lambda/src/cli/commands/render/progress.ts
@@ -107,10 +107,21 @@ const makeEncodingProgress = ({
 
 const makeCleanupProgress = (
 	cleanupInfo: CleanupInfo | null,
-	totalSteps: number
+	totalSteps: number,
+	skipped: boolean
 ) => {
 	if (!cleanupInfo) {
 		return '';
+	}
+
+	if (skipped) {
+		return [
+			'🪣 ',
+			`(4/${totalSteps})`,
+			CliInternals.chalk.blueBright(
+				`Not cleaning up because --log=verbose was set`
+			),
+		].join(' ');
 	}
 
 	const {doneIn, filesDeleted, minFilesToDelete} = cleanupInfo;
@@ -188,11 +199,13 @@ export const makeProgressString = ({
 	steps,
 	downloadInfo,
 	retriesInfo,
+	verbose,
 }: {
 	progress: MultiRenderProgress;
 	steps: number;
 	downloadInfo: DownloadedInfo | null;
 	retriesInfo: ChunkRetry[];
+	verbose: boolean;
 }) => {
 	return [
 		makeInvokeProgress(progress.lambdaInvokeProgress, steps, retriesInfo),
@@ -206,7 +219,7 @@ export const makeProgressString = ({
 			chunkProgress: progress.chunkProgress,
 			totalSteps: steps,
 		}),
-		makeCleanupProgress(progress.cleanupInfo, steps),
+		makeCleanupProgress(progress.cleanupInfo, steps, verbose),
 		downloadInfo ? makeDownloadProgress(downloadInfo, steps) : null,
 	]
 		.filter(Internals.truthy)

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -157,7 +157,7 @@ export const renderCommand = async (args: string[]) => {
 	);
 
 	Log.verbose(`CloudWatch logs (if enabled): ${res.cloudWatchLogs}`);
-	Log.verbose(`Render folder: ${res.renderFolder}`);
+	Log.verbose(`Render folder: ${res.folderInS3Console}`);
 	const status = await getRenderProgress({
 		functionName,
 		bucketName: res.bucketName,

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -1,4 +1,4 @@
-import {CliInternals} from '@remotion/cli';
+import {CliInternals, ConfigInternals} from '@remotion/cli';
 import {getCompositions, RenderInternals} from '@remotion/renderer';
 import {downloadMedia} from '../../../api/download-media';
 import {getRenderProgress} from '../../../api/get-render-progress';
@@ -151,7 +151,13 @@ export const renderCommand = async (args: string[]) => {
 			`renderId = ${res.renderId}, codec = ${codec} (${reason})`
 		)
 	);
+	const verbose = RenderInternals.isEqualOrBelowLogLevel(
+		ConfigInternals.Logging.getLogLevel(),
+		'verbose'
+	);
+
 	Log.verbose(`CloudWatch logs (if enabled): ${res.cloudWatchLogs}`);
+	Log.verbose(`Render folder: ${res.renderFolder}`);
 	const status = await getRenderProgress({
 		functionName,
 		bucketName: res.bucketName,
@@ -165,6 +171,7 @@ export const renderCommand = async (args: string[]) => {
 			steps: totalSteps,
 			downloadInfo: null,
 			retriesInfo: status.retriesInfo,
+			verbose,
 		})
 	);
 
@@ -184,6 +191,7 @@ export const renderCommand = async (args: string[]) => {
 				steps: totalSteps,
 				retriesInfo: newStatus.retriesInfo,
 				downloadInfo: null,
+				verbose,
 			})
 		);
 
@@ -194,6 +202,7 @@ export const renderCommand = async (args: string[]) => {
 					steps: totalSteps,
 					downloadInfo: null,
 					retriesInfo: newStatus.retriesInfo,
+					verbose,
 				})
 			);
 			if (downloadName) {
@@ -214,6 +223,7 @@ export const renderCommand = async (args: string[]) => {
 									downloaded,
 									totalSize,
 								},
+								verbose,
 							})
 						);
 					},
@@ -228,6 +238,7 @@ export const renderCommand = async (args: string[]) => {
 							downloaded: sizeInBytes,
 							totalSize: sizeInBytes,
 						},
+						verbose,
 					})
 				);
 				Log.info();

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -95,6 +95,10 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 			1000
 		)} before it times out`
 	);
+	const verbose = RenderInternals.isEqualOrBelowLogLevel(
+		params.logLevel,
+		'verbose'
+	);
 	const webhookDueToTimeout = setTimeout(async () => {
 		if (params.webhook && !webhookInvoked) {
 			try {
@@ -139,7 +143,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 	}, Math.max(options.getRemainingTimeInMillis() - 1000, 1000));
 
 	const browserInstance = await getBrowserInstance(
-		RenderInternals.isEqualOrBelowLogLevel(params.logLevel, 'verbose'),
+		verbose,
 		params.chromiumOptions
 	);
 
@@ -508,12 +512,14 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 		renderId: params.renderId,
 	});
 
-	const deletProm = cleanupFiles({
-		region: getCurrentRegionInFunction(),
-		bucket: params.bucketName,
-		contents,
-		jobs,
-	});
+	const deletProm = verbose
+		? Promise.resolve(0)
+		: cleanupFiles({
+				region: getCurrentRegionInFunction(),
+				bucket: params.bucketName,
+				contents,
+				jobs,
+		  });
 
 	const cleanupSerializedInputPropsProm = cleanupSerializedInputProps({
 		bucketName: params.bucketName,

--- a/packages/lambda/src/shared/get-aws-urls.ts
+++ b/packages/lambda/src/shared/get-aws-urls.ts
@@ -14,3 +14,15 @@ export const getCloudwatchStreamUrl = ({
 }) => {
 	return `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logsV2:log-groups/log-group/$252Faws$252Flambda$252F${functionName}/log-events$3FfilterPattern$3D$2522method$253D${method}$252CrenderId$253D${renderId}$2522`;
 };
+
+export const getS3RenderUrl = ({
+	renderId,
+	region,
+	bucketName,
+}: {
+	renderId: string;
+	region: AwsRegion;
+	bucketName: string;
+}) => {
+	return `https://s3.console.aws.amazon.com/s3/buckets/${bucketName}?region=${region}&prefix=renders/${renderId}/`;
+};

--- a/packages/renderer/src/combine-videos.ts
+++ b/packages/renderer/src/combine-videos.ts
@@ -60,7 +60,6 @@ export const combineVideos = async ({
 				'512K',
 				codec === 'h264' ? '-movflags' : null,
 				codec === 'h264' ? 'faststart' : null,
-				'-shortest',
 				'-y',
 				output,
 			].filter(truthy)

--- a/packages/renderer/src/get-extension-from-codec.ts
+++ b/packages/renderer/src/get-extension-from-codec.ts
@@ -1,9 +1,18 @@
 import type {Codec} from './codec';
+import {validCodecs} from './codec';
 
 export const getFileExtensionFromCodec = (
 	codec: Codec,
 	type: 'chunk' | 'final'
 ) => {
+	if (!validCodecs.includes(codec)) {
+		throw new Error(
+			`Codec must be one of the following: ${validCodecs.join(
+				', '
+			)}, but got ${codec}`
+		);
+	}
+
 	switch (codec) {
 		case 'aac':
 			return 'aac';

--- a/packages/renderer/src/merge-audio-track.ts
+++ b/packages/renderer/src/merge-audio-track.ts
@@ -26,7 +26,6 @@ const mergeAudioTrackUnlimited = async ({
 	numberOfSeconds,
 	downloadMap,
 }: Options): Promise<void> => {
-	console.log('MERGING AUDIO TRACKS', files.length);
 	if (files.length === 0) {
 		await createSilentAudio({
 			outName,

--- a/packages/renderer/src/merge-audio-track.ts
+++ b/packages/renderer/src/merge-audio-track.ts
@@ -26,6 +26,7 @@ const mergeAudioTrackUnlimited = async ({
 	numberOfSeconds,
 	downloadMap,
 }: Options): Promise<void> => {
+	console.log('MERGING AUDIO TRACKS', files.length);
 	if (files.length === 0) {
 		await createSilentAudio({
 			outName,

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -211,6 +211,14 @@ const spawnFfmpeg = async (options: StitcherOptions): Promise<ReturnType> => {
 		(options.assetsInfo.assets.flat(1).length > 0 ||
 			options.enforceAudioTrack) &&
 		!options.muted;
+
+	console.log({
+		shouldRenderAudio,
+		audio: mediaSupport.audio,
+		assets: options.assetsInfo.assets.flat(1).length,
+		enforce: options.enforceAudioTrack,
+		muted: options.muted,
+	});
 	const shouldRenderVideo = mediaSupport.video;
 
 	if (!shouldRenderAudio && !shouldRenderVideo) {

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -212,13 +212,6 @@ const spawnFfmpeg = async (options: StitcherOptions): Promise<ReturnType> => {
 			options.enforceAudioTrack) &&
 		!options.muted;
 
-	console.log({
-		shouldRenderAudio,
-		audio: mediaSupport.audio,
-		assets: options.assetsInfo.assets.flat(1).length,
-		enforce: options.enforceAudioTrack,
-		muted: options.muted,
-	});
 	const shouldRenderVideo = mediaSupport.video;
 
 	if (!shouldRenderAudio && !shouldRenderVideo) {


### PR DESCRIPTION
When rendering a WebM video on Lambda, the opus audio codec will force the video to be shorter. Repro demo reference: webwalrus