### PR TITLE
[FIX][Expert page] Social link occupies full width

### DIFF
--- a/packages/docs/src/components/ExpertPage.tsx
+++ b/packages/docs/src/components/ExpertPage.tsx
@@ -81,11 +81,14 @@ const socialIconContainer: React.CSSProperties = {
   alignItems: "center",
 };
 
+const socialLink: React.CSSProperties = {
+  display: 'inline-block'
+}
+
 const socialRow: React.CSSProperties = {
   flexDirection: "row",
   display: "flex",
   alignItems: "center",
-  marginTop: 10,
   marginBottom: 10,
 };
 
@@ -173,7 +176,7 @@ export default () => {
         <h3>About me</h3>
         <p style={description}>{expert.description}</p>
         <h3>Socials</h3>
-        <a href={`mailto:${expert.email}`} target={"_blank"}>
+        <a style={socialLink} href={`mailto:${expert.email}`} target={"_blank"}>
           <div style={socialRow}>
             <div style={socialIconContainer}>
               <svg
@@ -191,7 +194,7 @@ export default () => {
           </div>
         </a>
         {expert.github ? (
-          <a href={`https://github.com/${expert.github}`} target={"_blank"}>
+          <a style={socialLink} href={`https://github.com/${expert.github}`} target={"_blank"}>
             <div style={socialRow}>
               <div style={socialIconContainer}>
                 <svg
@@ -210,7 +213,7 @@ export default () => {
           </a>
         ) : null}
         {expert.twitter ? (
-          <a href={`https://twitter.com/${expert.twitter}`} target={"_blank"}>
+          <a style={socialLink} href={`https://twitter.com/${expert.twitter}`} target={"_blank"}>
             <div style={socialRow}>
               <div style={socialIconContainer}>
                 <svg
@@ -229,7 +232,7 @@ export default () => {
           </a>
         ) : null}
         {expert.linkedin ? (
-          <a href={`https://linkedin.com/${expert.linkedin}`} target={"_blank"}>
+          <a style={socialLink} href={`https://linkedin.com/${expert.linkedin}`} target={"_blank"}>
             <div style={socialRow}>
               <div style={socialIconContainer}>
                 <svg

--- a/packages/docs/src/components/ExpertPage.tsx
+++ b/packages/docs/src/components/ExpertPage.tsx
@@ -82,7 +82,8 @@ const socialIconContainer: React.CSSProperties = {
 };
 
 const socialLink: React.CSSProperties = {
-  display: 'inline-block'
+  display: 'block',
+  maxWidth: 'fit-content',
 }
 
 const socialRow: React.CSSProperties = {


### PR DESCRIPTION
Social link occupies full-width, so users can click it even if it's hovered way far from the right side

<img width="759" alt="image" src="https://user-images.githubusercontent.com/20585619/201490287-afbeae40-d84e-405f-a4a5-5d9987a03947.png">

This change fixes it ⚙️ 