### PR TITLE
fix: small typo error in docs

### DIFF
--- a/packages/docs/docs/renderer/ensure-ffmpeg.md
+++ b/packages/docs/docs/renderer/ensure-ffmpeg.md
@@ -29,7 +29,7 @@ Optionally, you can pass an object and pass the following options:
 
 _string_
 
-The directory in which your `node_modules` is locted.
+The directory in which your `node_modules` is located.
 
 ## Return value
 

--- a/packages/docs/docs/renderer/ensure-ffprobe.md
+++ b/packages/docs/docs/renderer/ensure-ffprobe.md
@@ -29,7 +29,7 @@ Optionally, you can pass an object and pass the following options:
 
 _string_
 
-The directory in which your `node_modules` is locted.
+The directory in which your `node_modules` is located.
 
 ## Return value
 


### PR DESCRIPTION
I fixed a small typo error in the docs for v3.3.0