### PR TITLE
make old node versions throw an error message

### DIFF
--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -1,6 +1,5 @@
 import execa from 'execa';
-import fs from 'fs';
-import {readFile} from 'fs/promises';
+import fs, {promises} from 'fs';
 import path from 'path';
 import type {TAsset} from 'remotion';
 import {Internals} from 'remotion';
@@ -319,7 +318,8 @@ export const spawnFfmpeg = async (
 
 		const file = await new Promise<Buffer | null>((resolve, reject) => {
 			if (tempFile) {
-				readFile(tempFile)
+				promises
+					.readFile(tempFile)
 					.then((f) => {
 						return resolve(f);
 					})

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -452,7 +452,8 @@ export const spawnFfmpeg = async (
 				return null;
 			}
 
-			return readFile(tempFile)
+			return promises
+				.readFile(tempFile)
 				.then((file) => {
 					return Promise.all([
 						file,


### PR DESCRIPTION
Old node versions would not get the error message because fs/promises is undefined in old versions