### PR TITLE
Expose `style` and `ref` in `Series.Sequence`

### DIFF
--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -24,7 +24,7 @@ export type SequenceContextType = {
 
 export const SequenceContext = createContext<SequenceContextType | null>(null);
 
-type LayoutAndStyle =
+export type LayoutAndStyle =
 	| {
 			layout: 'none';
 	  }

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -1,6 +1,6 @@
 import type {FC, PropsWithChildren} from 'react';
-import {Children, useMemo} from 'react';
-import type {SequenceProps} from '../Sequence';
+import {Children, forwardRef, useMemo} from 'react';
+import type {SequenceProps, LayoutAndStyle} from '../Sequence';
 import {Sequence} from '../Sequence';
 import {validateDurationInFrames} from '../validation/validate-duration-in-frames';
 import {flattenChildren} from './flatten-children';
@@ -9,13 +9,18 @@ type SeriesSequenceProps = PropsWithChildren<
 	{
 		durationInFrames: number;
 		offset?: number;
-	} & Pick<SequenceProps, 'layout' | 'name'>
+	} & Pick<SequenceProps, 'layout' | 'name'> & LayoutAndStyle
 >;
 
-const SeriesSequence = ({children}: SeriesSequenceProps) => {
+const SeriesSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
+HTMLDivElement,
+SeriesSequenceProps
+> = ({children}) => {
 	// eslint-disable-next-line react/jsx-no-useless-fragment
 	return <>{children}</>;
 };
+
+const SeriesSequence = forwardRef(SeriesSequenceRefForwardingFunction)
 
 const Series: FC<{
 	children: React.ReactNode;
@@ -29,6 +34,7 @@ const Series: FC<{
 				| {
 						props: SeriesSequenceProps;
 						type: typeof SeriesSequence;
+						ref: React.MutableRefObject<HTMLDivElement>;
 				  }
 				| string;
 			if (typeof castedChild === 'string') {
@@ -92,6 +98,7 @@ const Series: FC<{
 					from={currentStartFrame}
 					durationInFrames={durationInFramesProp}
 					{...passedProps}
+					ref={castedChild.ref}
 				>
 					{child}
 				</Sequence>

--- a/packages/docs/docs/series.md
+++ b/packages/docs/docs/series.md
@@ -63,6 +63,33 @@ This component is a high order component, and accepts, besides it's children, th
 
 - `layout`: _(optional)_: Either `"absolute-fill"` _(default)_ or `"none"` By default, your sequences will be absolutely positioned, so they will overlay each other. If you would like to opt out of it and handle layouting yourself, pass `layout="none"`.
 
+- `style`: _(optional)_: CSS styles to be applied to the container. If `layout` is set to `none`, there is no container and setting this style is not allowed.
+
+- `ref`: _(optional)_: You can add a [React ref](https://reactjs.org/docs/refs-and-the-dom.html) to a `<Series.Sequence>`. If you use TypeScript, you need to type it with `HTMLDivElement`:
+
+```tsx
+import { useRef } from "react";
+import { Series } from "remotion";
+
+const Example: React.FC = () => {
+  const first = useRef<HTMLDivElement>(null);
+  const second = useRef<HTMLDivElement>(null);
+  return (
+    <Series>
+      <Series.Sequence durationInFrames={40} ref={first}>
+        <Square color={"#3498db"} />
+      </Series.Sequence>
+      <Series.Sequence durationInFrames={20} ref="second">
+        <Square color={"#5ff332"} />
+      </Series.Sequence>
+      <Series.Sequence durationInFrames={70}>
+        <Square color={"#fdc321"} />
+      </Series.Sequence>
+    </Series>
+  );
+};
+```
+
 ## See also
 
 - [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/core/src/series/index.tsx)


### PR DESCRIPTION
Adresses #1475 

- [x] Similar to how you can now add a style to a <Sequence>: https://github.com/remotion-dev/remotion/blob/main/packages/core/src/Sequence.tsx, the same should be possible for <Series.Sequence>
- [ ]  and `<Loop>`

- [x] You should be able to add a ref to <Series.Sequence> using forwardRef, also analogue to how it is possible with <Sequence>

- [ ] Documentation should be added for both, mentioning the possibility in the same style as the documentation for <Sequence>
