### PR TITLE
feat: add packageManager to app scaffold #1520

### DIFF
--- a/packages/create-video/package.json
+++ b/packages/create-video/package.json
@@ -12,7 +12,8 @@
 	"scripts": {
 		"build": "tsc -d",
 		"watch": "tsc -w",
-		"lint": "eslint src --ext ts,tsx"
+		"lint": "eslint src --ext ts,tsx",
+		"test": "vitest --run"
 	},
 	"author": "",
 	"license": "SEE LICENSE IN LICENSE.md",

--- a/packages/create-video/src/init.ts
+++ b/packages/create-video/src/init.ts
@@ -8,7 +8,7 @@ import {patchPackageJson} from './patch-package-json';
 import {patchReadmeMd} from './patch-readme';
 import {
 	getDevCommand,
-	getPackageManagerVersion,
+	getPackageManagerVersionOrNull,
 	getRenderCommandForTemplate,
 	selectPackageManager,
 } from './pkg-managers';
@@ -55,7 +55,7 @@ export const init = async () => {
 	const selectedTemplate = await selectTemplate();
 
 	const pkgManager = selectPackageManager();
-	const pkgManagerVersion = await getPackageManagerVersion(pkgManager);
+	const pkgManagerVersion = await getPackageManagerVersionOrNull(pkgManager);
 
 	try {
 		await degit({
@@ -69,7 +69,9 @@ export const init = async () => {
 			projectRoot,
 			projectName: folderName,
 			latestRemotionVersion: latestVersion,
-			packageManager: `${pkgManager}@${pkgManagerVersion}`
+			packageManager: pkgManagerVersion
+				? `${pkgManager}@${pkgManagerVersion}`
+				: null,
 		});
 	} catch (e) {
 		Log.error(e);

--- a/packages/create-video/src/init.ts
+++ b/packages/create-video/src/init.ts
@@ -8,6 +8,7 @@ import {patchPackageJson} from './patch-package-json';
 import {patchReadmeMd} from './patch-readme';
 import {
 	getDevCommand,
+	getPackageManagerVersion,
 	getRenderCommandForTemplate,
 	selectPackageManager,
 } from './pkg-managers';
@@ -54,6 +55,7 @@ export const init = async () => {
 	const selectedTemplate = await selectTemplate();
 
 	const pkgManager = selectPackageManager();
+	const pkgManagerVersion = await getPackageManagerVersion(pkgManager);
 
 	try {
 		await degit({
@@ -67,6 +69,7 @@ export const init = async () => {
 			projectRoot,
 			projectName: folderName,
 			latestRemotionVersion: latestVersion,
+			packageManager: `${pkgManager}@${pkgManagerVersion}`
 		});
 	} catch (e) {
 		Log.error(e);

--- a/packages/create-video/src/patch-package-json.ts
+++ b/packages/create-video/src/patch-package-json.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import type {PackageManager} from './pkg-managers';
 
 export const listOfRemotionPackages = [
 	'@remotion/bundler',
@@ -22,18 +23,27 @@ export const listOfRemotionPackages = [
 	'remotion',
 ];
 
-export const patchPackageJson = ({
-	projectRoot,
-	projectName,
-	latestRemotionVersion,
-}: {
-	projectRoot: string;
-	projectName: string;
-	latestRemotionVersion: string;
-}) => {
+export const patchPackageJson = (
+	{
+		projectRoot,
+		projectName,
+		latestRemotionVersion,
+		packageManager,
+	}: {
+		projectRoot: string;
+		projectName: string;
+		latestRemotionVersion: string;
+		packageManager: `${PackageManager}@${string}`;
+	},
+	{
+		getPackageJson = (filename: string) => fs.readFileSync(filename, 'utf-8'),
+		setPackageJson = (filename: string, content: string) =>
+			fs.writeFileSync(filename, content),
+	} = {}
+) => {
 	const fileName = path.join(projectRoot, 'package.json');
 
-	const contents = fs.readFileSync(fileName, 'utf-8');
+	const contents = getPackageJson(fileName);
 	const packageJson = JSON.parse(contents);
 
 	const {name, dependencies, ...others} = packageJson;
@@ -55,10 +65,11 @@ export const patchPackageJson = ({
 			name: projectName,
 			...others,
 			dependencies: newDependencies,
+			packageManager,
 		},
 		undefined,
 		2
 	);
 
-	fs.writeFileSync(fileName, newPackageJson);
+	setPackageJson(fileName, newPackageJson);
 };

--- a/packages/create-video/src/patch-package-json.ts
+++ b/packages/create-video/src/patch-package-json.ts
@@ -33,7 +33,7 @@ export const patchPackageJson = (
 		projectRoot: string;
 		projectName: string;
 		latestRemotionVersion: string;
-		packageManager: `${PackageManager}@${string}`;
+		packageManager: `${PackageManager}@${string}` | null;
 	},
 	{
 		getPackageJson = (filename: string) => fs.readFileSync(filename, 'utf-8'),
@@ -65,7 +65,7 @@ export const patchPackageJson = (
 			name: projectName,
 			...others,
 			dependencies: newDependencies,
-			packageManager,
+			...(packageManager ? {packageManager} : {}),
 		},
 		undefined,
 		2

--- a/packages/create-video/src/pkg-managers.ts
+++ b/packages/create-video/src/pkg-managers.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import {exec} from 'child_process';
 import path from 'path';
 import type {Template} from './templates';
 
@@ -121,22 +121,36 @@ export const getRunCommand = (manager: PackageManager) => {
 	throw new TypeError('unknown package manager');
 };
 
-export const getPackageManagerVersion = (manager: PackageManager): Promise<string> => {
-	const cmd: `${PackageManager} -v` = `${manager} -v`
-	
+export const getPackageManagerVersion = (
+	manager: PackageManager
+): Promise<string> => {
+	const cmd: `${PackageManager} -v` = `${manager} -v`;
+
 	return new Promise((resolve, reject) => {
 		exec(cmd, (error, stdout, stderr) => {
 			if (error) {
 				reject(error);
 				return;
 			}
-		
+
 			if (stderr) {
 				reject(stderr);
 				return;
 			}
-			
+
 			resolve(stdout.trim());
 		});
-	})
-}
+	});
+};
+
+export const getPackageManagerVersionOrNull = async (
+	manager: PackageManager
+): Promise<string | null> => {
+	try {
+		const version = await getPackageManagerVersion(manager);
+		return version;
+	} catch (err) {
+		console.warn(`Could not determine the version of ${manager}.`);
+		return null;
+	}
+};

--- a/packages/create-video/src/pkg-managers.ts
+++ b/packages/create-video/src/pkg-managers.ts
@@ -122,14 +122,7 @@ export const getRunCommand = (manager: PackageManager) => {
 };
 
 export const getPackageManagerVersion = (manager: PackageManager): Promise<string> => {
-	const cmd = {
-		npm: `npm -v`,
-		yarn: `yarn -v`,
-		pnpm: `pnpm -v`
-	}[manager];
-	if (!cmd) {
-		throw new TypeError('unknown package manager');
-	}
+	const cmd: `${PackageManager} -v` = `${manager} -v`
 	
 	return new Promise((resolve, reject) => {
 		exec(cmd, (error, stdout, stderr) => {

--- a/packages/create-video/src/pkg-managers.ts
+++ b/packages/create-video/src/pkg-managers.ts
@@ -1,3 +1,4 @@
+import { exec } from 'child_process';
 import path from 'path';
 import type {Template} from './templates';
 
@@ -119,3 +120,30 @@ export const getRunCommand = (manager: PackageManager) => {
 
 	throw new TypeError('unknown package manager');
 };
+
+export const getPackageManagerVersion = (manager: PackageManager): Promise<string> => {
+	const cmd = {
+		npm: `npm -v`,
+		yarn: `yarn -v`,
+		pnpm: `pnpm -v`
+	}[manager];
+	if (!cmd) {
+		throw new TypeError('unknown package manager');
+	}
+	
+	return new Promise((resolve, reject) => {
+		exec(cmd, (error, stdout, stderr) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+		
+			if (stderr) {
+				reject(stderr);
+				return;
+			}
+			
+			resolve(stdout.trim());
+		});
+	})
+}

--- a/packages/create-video/src/test/patch-package-json.test.ts
+++ b/packages/create-video/src/test/patch-package-json.test.ts
@@ -1,0 +1,52 @@
+import {expect, test} from 'vitest';
+import {patchPackageJson} from '../patch-package-json';
+import type {PackageManager} from '../pkg-managers';
+
+const packageManagers: PackageManager[] = ['npm', 'pnpm', 'yarn'];
+
+for (const packageManager of packageManagers) {
+	test(`Using ${packageManager} package manager provides the correct "packageManager" entry in package.json`, () => {
+		const latestRemotionVersion = '1.0.0';
+		const packageManagerVersion = '1.22.19';
+		const packageJson = {
+			name: 'my-video',
+			version: '1.0.0',
+			description: 'My Remotion video',
+			scripts: {
+				start: 'remotion preview',
+			},
+			dependencies: {
+				'@remotion/cli': 'stale-remotion-version',
+				react: '^18.0.0',
+				remotion: 'stale-remotion-version',
+			},
+			devDependencies: {
+				'@types/react': '^18.0.6',
+			},
+		};
+		let newPackageJson: typeof packageJson | null = null;
+		patchPackageJson(
+			{
+				projectRoot: '/path/to/project',
+				latestRemotionVersion,
+				packageManager: `${packageManager}@${packageManagerVersion}`,
+				projectName: 'my-video',
+			},
+			{
+				getPackageJson: () => JSON.stringify(packageJson),
+				setPackageJson: (_: string, content: string) => {
+					newPackageJson = JSON.parse(content);
+				},
+			}
+		);
+		expect(newPackageJson).to.deep.equal({
+			...packageJson,
+			dependencies: {
+				...packageJson.dependencies,
+				'@remotion/cli': latestRemotionVersion,
+				remotion: latestRemotionVersion,
+			},
+			packageManager: `${packageManager}@${packageManagerVersion}`
+		});
+	});
+}

--- a/packages/create-video/src/test/validate-templates.test.ts
+++ b/packages/create-video/src/test/validate-templates.test.ts
@@ -17,7 +17,10 @@ for (const template of FEATURED_TEMPLATES) {
 		expect(res.statusCode).toBe(200);
 		const body = JSON.parse(res.body);
 
-		if (!template.shortName.includes('Remix')) {
+		if (
+			!template.shortName.includes('Remix') &&
+			!template.shortName.includes('Still')
+		) {
 			expect(body.scripts.build).toMatch(/render/);
 			expect(body.scripts.build).not.toContain('index');
 		}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

#1520

# Implementation Strategy

The [selectPackageManager](https://github.com/remotion-dev/remotion/blob/main/packages/create-video/src/pkg-managers.ts#L30-L40) function already does a good job of telling us which package manager is responsible for running `npm init video`, so I had to 

1. Get the version of the package manager, which `child_process.exec` is great for.
2. Pass the package manager version to the `patchPackageJson` function, which passes it to the rendered package json.

## Tests

I noticed the create-video package does not have a `test` script in its package.json, but I wanted to add tests anyway for the `patchPackageJson` function, so I took the liberty of adding an abstraction for its `fs.readFileSync` and `fs.writeFileSync` dependencies. 

If this is not acceptable, I am happy to revert this.

## Results

When I run `create-video` locally, with the `Hello World` template, I get:

```json
{
  "name": "my-video",
  "version": "1.0.0",
  "description": "My Remotion video",
  "scripts": {
    // ...
  },
  "repository": {},
  "license": "UNLICENSED",
  "devDependencies": {
    // ...
  },
  "dependencies": {
    // ...
  },
  "packageManager": "npm@8.1.2"
}
```

If I have missed something, please let me know and I'll get to it.