### PR TITLE
fix suspense loader for newer versions of R3F and react

### DIFF
--- a/packages/three/src/SuspenseLoader.tsx
+++ b/packages/three/src/SuspenseLoader.tsx
@@ -1,15 +1,19 @@
-import React, {Suspense, useEffect, useState} from 'react';
+import React, {Suspense, useLayoutEffect} from 'react';
 import {continueRender, delayRender} from 'remotion';
 
 const Unblocker: React.FC = () => {
-	const [handle] = useState(() =>
-		delayRender(`Waiting for <Suspense /> of <ThreeCanvas /> to resolve`)
-	);
-	useEffect(() => {
-		return () => {
-			continueRender(handle);
-		};
-	}, [handle]);
+	if (typeof document !== 'undefined') {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		useLayoutEffect(() => {
+			const handle = delayRender(
+				`Waiting for <Suspense /> of <ThreeCanvas /> to resolve`
+			);
+			return () => {
+				continueRender(handle);
+			};
+		}, []);
+	}
+
 	return null;
 };
 


### PR DESCRIPTION
interestingly, this did not work if two <ThreeCanvas> were rendered. the component rendered but no useEffect() was executed. porting over the same waiting strategy that <Img> has

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
