### PR TITLE
Refresh timeout whenever data appears

### DIFF
--- a/packages/renderer/src/assets/download-file.ts
+++ b/packages/renderer/src/assets/download-file.ts
@@ -96,6 +96,7 @@ export const downloadFile = ({
 				res.pipe(writeStream).on('error', (err) => rejectAndFlag(err));
 				res.on('data', (d) => {
 					downloaded += d.length;
+					refreshTimeout();
 					onProgress?.({
 						downloaded,
 						percent: totalSize === null ? null : downloaded / totalSize,

--- a/packages/renderer/src/assets/download-file.ts
+++ b/packages/renderer/src/assets/download-file.ts
@@ -95,8 +95,8 @@ export const downloadFile = ({
 				res.on('error', (err) => rejectAndFlag(err));
 				res.pipe(writeStream).on('error', (err) => rejectAndFlag(err));
 				res.on('data', (d) => {
-					downloaded += d.length;
 					refreshTimeout();
+					downloaded += d.length;
 					onProgress?.({
 						downloaded,
 						percent: totalSize === null ? null : downloaded / totalSize,


### PR DESCRIPTION
Fix getting a timeout if a download takes longer than 20 seconds.