### PR TITLE
don't give ESLint error on `<Gif src={staticFile("gif.gif")}>`

### DIFF
--- a/packages/eslint-plugin/src/rules/use-gif-component.ts
+++ b/packages/eslint-plugin/src/rules/use-gif-component.ts
@@ -38,6 +38,21 @@ export default createRule<Options, MessageIds>({
         if (node.name.name !== "src") {
           return;
         }
+        const parent = node.parent;
+        if (!parent) {
+          return;
+        }
+        if (parent.type !== "JSXOpeningElement") {
+          return;
+        }
+        const name = parent.name;
+        if (name.type !== "JSXIdentifier") {
+          return;
+        }
+        if (name.name !== "Img" && name.name !== "img") {
+          return;
+        }
+
         const value = node.value;
         // src={"some string"}
         if (!value) {
@@ -53,25 +68,12 @@ export default createRule<Options, MessageIds>({
             : null;
         // src="image.gif"
         if (typeof stringValue === "string") {
-          const parent = node.parent;
-          if (!parent) {
-            return;
-          }
-          if (parent.type !== "JSXOpeningElement") {
-            return;
-          }
-          const name = parent.name;
-          if (name.type !== "JSXIdentifier") {
-            return;
-          }
-          if (name.name === "Img" || name.name === "img") {
-            // Network and inline URLs are okay
-            if (stringValue.includes(".gif")) {
-              context.report({
-                messageId: "UseGifComponent",
-                node,
-              });
-            }
+          // Network and inline URLs are okay
+          if (stringValue.includes(".gif")) {
+            context.report({
+              messageId: "UseGifComponent",
+              node,
+            });
           }
         }
 

--- a/packages/eslint-plugin/src/tests/use-gif-component.test.ts
+++ b/packages/eslint-plugin/src/tests/use-gif-component.test.ts
@@ -56,6 +56,16 @@ export const Re = () => {
   );
 }
                 `,
+    `
+import {Gif} from '@remotion/gif';
+import {staticFile} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Gif src={staticFile('gif.gif')} />
+  );
+}
+                `,
   ],
   invalid: [
     {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
