### PR TITLE
remove --enable-extensions flag

### DIFF
--- a/packages/cli/src/config/chromium-flags.ts
+++ b/packages/cli/src/config/chromium-flags.ts
@@ -6,7 +6,6 @@ let ignoreCertificateErrors = false;
 let openGlRenderer: OpenGlRenderer | null =
 	RenderInternals.DEFAULT_OPENGL_RENDERER;
 let headlessMode = true;
-let enableExtensions = false;
 
 export const getChromiumDisableWebSecurity = () => chromiumDisableWebSecurity;
 export const setChromiumDisableWebSecurity = (should: boolean) => {
@@ -27,9 +26,4 @@ export const setChromiumOpenGlRenderer = (renderer: OpenGlRenderer) => {
 export const getChromiumHeadlessMode = () => headlessMode;
 export const setChromiumHeadlessMode = (should: boolean) => {
 	headlessMode = should;
-};
-
-export const getChromiumEnableExtensions = () => enableExtensions;
-export const setEnableChromiumExtensions = (should: boolean) => {
-	enableExtensions = should;
 };

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -4,11 +4,9 @@ import {getBrowser} from './browser';
 import {getBrowserExecutable} from './browser-executable';
 import {
 	getChromiumDisableWebSecurity,
-	getChromiumEnableExtensions,
 	getChromiumHeadlessMode,
 	getChromiumOpenGlRenderer,
 	getIgnoreCertificateErrors,
-	setEnableChromiumExtensions,
 } from './chromium-flags';
 import {getOutputCodecOrUndefined} from './codec';
 import {getConcurrency} from './concurrency';
@@ -123,7 +121,6 @@ export const Config: ConfigType = {
 		setChromiumDisableWebSecurity,
 		setChromiumIgnoreCertificateErrors,
 		setChromiumHeadlessMode,
-		setEnableChromiumExtensions,
 		setChromiumOpenGlRenderer,
 	},
 	Rendering: {
@@ -177,7 +174,6 @@ export const ConfigInternals = {
 	getIgnoreCertificateErrors,
 	getChromiumHeadlessMode,
 	getChromiumOpenGlRenderer,
-	getChromiumEnableExtensions,
 	getEveryNthFrame,
 	getConcurrency,
 	getCurrentPuppeteerTimeout,

--- a/packages/cli/src/get-cli-options.ts
+++ b/packages/cli/src/get-cli-options.ts
@@ -203,7 +203,6 @@ export const getCliOptions = async (options: {
 		gl:
 			ConfigInternals.getChromiumOpenGlRenderer() ??
 			RenderInternals.DEFAULT_OPENGL_RENDERER,
-		enableExtensions: ConfigInternals.getChromiumEnableExtensions(),
 	};
 	const everyNthFrame = ConfigInternals.getEveryNthFrame();
 	const numberOfGifLoops = ConfigInternals.getNumberOfGifLoops();

--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -51,7 +51,6 @@ export type CommandLineOptions = {
 	port: number;
 	frame: string | number;
 	['disable-headless']: boolean;
-	['enable-extensions']: boolean;
 	['disable-keyboard-shortcuts']: boolean;
 	muted: boolean;
 	height: number;
@@ -136,10 +135,6 @@ export const parseCommandLine = () => {
 
 	if (parsedCli['disable-headless']) {
 		Config.Puppeteer.setChromiumHeadlessMode(false);
-	}
-
-	if (parsedCli['enable-extensions']) {
-		Config.Puppeteer.setEnableChromiumExtensions(true);
 	}
 
 	if (parsedCli.log) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -126,11 +126,6 @@ export type ConfigType = {
 		 */
 		readonly setChromiumHeadlessMode: (should: boolean) => void;
 		/**
-		 * If true, your installed Chrome extensions will be enabled.
-		 * Default: false
-		 */
-		readonly setEnableChromiumExtensions: (should: boolean) => void;
-		/**
 		 * Set the OpenGL rendering backend for Chrome. Possible values: 'egl', 'angle', 'swiftshader' and 'swangle'.
 		 * Default: 'swangle' in Lambda, null elsewhere.
 		 */

--- a/packages/docs/docs/chromium-flags.md
+++ b/packages/docs/docs/chromium-flags.md
@@ -25,18 +25,6 @@ In [`getCompositions()`](/docs/renderer/get-compositions#disablewebsecurity), [`
 
 Pass [`--disable-web-security`](/docs/cli/render#--disable-web-security) in one of the following commands: `remotion render`, `remotion still`, `remotion lambda render`, `remotion lambda still`.
 
-## `--enable-extensions`
-
-This will enable your installed Chrome extensions during render.
-
-### Via Node.JS APIs
-
-In [`getCompositions()`](/docs/renderer/get-compositions#enableextensions), [`renderStill()`](/docs/renderer/render-still#enableextensions), [`renderMedia()`](/docs/renderer/render-media#enableextensions) and [`renderFrames()`](/docs/renderer/render-frames#enableextensions), you can pass [`chromiumOptions.disableWebSecurity`](/docs/renderer/render-still#enableextensions).
-
-### Via CLI flag
-
-Pass [`--disable-web-security`](/docs/cli/render#--disable-web-security) in one of the following commands: `remotion render`, `remotion still`, `remotion lambda render`, `remotion lambda still`.
-
 ### Via config file
 
 Use [setChromiumDisableWebSecurity()](/docs/config#setchromiumdisablewebsecurity).

--- a/packages/docs/docs/cli/benchmark.md
+++ b/packages/docs/docs/cli/benchmark.md
@@ -109,12 +109,6 @@ _optional_
 
 Inherited from [`npx remotion render`](/docs/cli/render#--disable-web-security)
 
-### `--enable-extensions`
-
-_optional_
-
-Inherited from [`npx remotion render`](/docs/cli/render#--enable-extensions)
-
 ### `--disable-headless`
 
 _optional_

--- a/packages/docs/docs/cli/compositions.md
+++ b/packages/docs/docs/cli/compositions.md
@@ -85,12 +85,6 @@ _available since v2.6.5_
 
 This will most notably disable CORS in Chrome among other security features.
 
-### `--enable-extensions`
-
-_available since v3.3.10_
-
-If set, your Chrome extensions will be enabled while rendering.
-
 ### `--disable-headless`
 
 Opens an actual browser to observe the composition fetching.

--- a/packages/docs/docs/cli/render.md
+++ b/packages/docs/docs/cli/render.md
@@ -194,12 +194,6 @@ _available since v2.6.5_
 
 This will most notably disable CORS in Chrome among other security features.
 
-### `--enable-extensions`
-
-_available since v3.3.10_
-
-If set, your Chrome extensions will be enabled while rendering.
-
 ### `--disable-headless`
 
 _available since v2.6.5_

--- a/packages/docs/docs/cli/still.md
+++ b/packages/docs/docs/cli/still.md
@@ -105,12 +105,6 @@ _Available since v2.6.5_
 
 This will most notably disable CORS in Chrome among other security features.
 
-### `--enable-extensions`
-
-_available since v3.3.10_
-
-If set, your Chrome extensions will be enabled while rendering.
-
 ### `--disable-headless`
 
 _Available since v2.6.5_

--- a/packages/docs/docs/config.md
+++ b/packages/docs/docs/config.md
@@ -230,22 +230,6 @@ Config.Puppeteer.setChromiumDisableWebSecurity(true);
 
 The [command line flag](/docs/cli/render#--disable-web-security) `--disable-web-security` will take precedence over this option.
 
-### setEnableChromiumExtensions()
-
-_Available from Version 3.3.11._
-
-If set to true, you installed Chrome extensions will be enabled.
-
-```tsx twoslash
-import { Config } from "remotion";
-
-// ---cut---
-
-Config.Puppeteer.setEnableChromiumExtensions(true);
-```
-
-The [command line flag](/docs/cli/render#--enable-extensions) `--enable-extensions` will take precedence over this option.
-
 ### setChromiumIgnoreCertificateErrors()
 
 _Available from Version 2.6.5._

--- a/packages/lambda/src/api/get-compositions-on-lambda.ts
+++ b/packages/lambda/src/api/get-compositions-on-lambda.ts
@@ -1,5 +1,5 @@
 import type {LogLevel} from '@remotion/renderer';
-import type {LambdaChromiumOptions} from '@remotion/renderer/src/open-browser';
+import type {ChromiumOptions} from '@remotion/renderer/src/open-browser';
 import type {TCompMetadata} from 'remotion';
 import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../client';
@@ -9,7 +9,7 @@ import {convertToServeUrl} from '../shared/convert-to-serve-url';
 import {serializeInputProps} from '../shared/serialize-input-props';
 
 export type GetCompositionsOnLambdaInput = {
-	chromiumOptions?: LambdaChromiumOptions;
+	chromiumOptions?: ChromiumOptions;
 	region: AwsRegion;
 	inputProps: unknown;
 	functionName: string;

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -5,7 +5,7 @@ import type {
 	PixelFormat,
 	ProResProfile,
 } from '@remotion/renderer';
-import type {LambdaChromiumOptions} from '@remotion/renderer/src/open-browser';
+import type {ChromiumOptions} from '@remotion/renderer/src/open-browser';
 import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
@@ -41,7 +41,7 @@ export type RenderMediaOnLambdaInput = {
 	frameRange?: FrameRange;
 	outName?: OutNameInput;
 	timeoutInMilliseconds?: number;
-	chromiumOptions?: LambdaChromiumOptions;
+	chromiumOptions?: ChromiumOptions;
 	scale?: number;
 	everyNthFrame?: number;
 	numberOfGifLoops?: number | null;

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -1,5 +1,5 @@
 import type {LogLevel, StillImageFormat} from '@remotion/renderer';
-import type {LambdaChromiumOptions} from '@remotion/renderer/src/open-browser';
+import type {ChromiumOptions} from '@remotion/renderer/src/open-browser';
 import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
@@ -25,7 +25,7 @@ export type RenderStillOnLambdaInput = {
 	logLevel?: LogLevel;
 	outName?: OutNameInput;
 	timeoutInMilliseconds?: number;
-	chromiumOptions?: LambdaChromiumOptions;
+	chromiumOptions?: ChromiumOptions;
 	scale?: number;
 	downloadBehavior?: DownloadBehavior;
 	forceWidth?: number | null;

--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -16,15 +16,11 @@ const validRenderers = ['swangle', 'angle', 'egl', 'swiftshader'] as const;
 
 type OpenGlRenderer = typeof validRenderers[number];
 
-export type LambdaChromiumOptions = {
+export type ChromiumOptions = {
 	ignoreCertificateErrors?: boolean;
 	disableWebSecurity?: boolean;
 	gl?: OpenGlRenderer | null;
 	headless?: boolean;
-};
-
-export type ChromiumOptions = LambdaChromiumOptions & {
-	enableExtensions?: boolean;
 };
 
 const getOpenGlRenderer = (option?: OpenGlRenderer | null): string[] => {
@@ -94,13 +90,11 @@ export const openBrowser = async (
 			'--disable-component-extensions-with-background-pages',
 			'--disable-default-apps',
 			'--disable-dev-shm-usage',
-			options?.chromiumOptions?.enableExtensions
-				? null
-				: '--disable-extensions',
 			'--no-proxy-server',
 			"--proxy-server='direct://'",
 			'--proxy-bypass-list=*',
 			'--disable-hang-monitor',
+			'--disable-extensions',
 			'--disable-ipc-flooding-protection',
 			'--disable-popup-blocking',
 			'--disable-prompt-on-repost',


### PR DESCRIPTION
It turns out that the flag was non-functional since Chrome does not allow extensions unless in headless=chrome mode which we do not support.