### PR TITLE
remove one getOrCreateBucket() call

### DIFF
--- a/packages/lambda/src/api/get-compositions-on-lambda.ts
+++ b/packages/lambda/src/api/get-compositions-on-lambda.ts
@@ -5,7 +5,6 @@ import {VERSION} from 'remotion/version';
 import type {AwsRegion} from '../client';
 import {LambdaRoutines} from '../defaults';
 import {callLambda} from '../shared/call-lambda';
-import {convertToServeUrl} from '../shared/convert-to-serve-url';
 import {serializeInputProps} from '../shared/serialize-input-props';
 
 export type GetCompositionsOnLambdaInput = {
@@ -44,8 +43,6 @@ export const getCompositionsOnLambda = async ({
 	logLevel,
 	timeoutInMilliseconds,
 }: GetCompositionsOnLambdaInput): Promise<GetCompositionsOnLambdaOutput> => {
-	const realServeUrl = await convertToServeUrl(serveUrl, region);
-
 	const serializedInputProps = await serializeInputProps({
 		inputProps,
 		region,
@@ -58,7 +55,7 @@ export const getCompositionsOnLambda = async ({
 			type: LambdaRoutines.compositions,
 			payload: {
 				chromiumOptions: chromiumOptions ?? {},
-				serveUrl: realServeUrl,
+				serveUrl,
 				envVariables,
 				inputProps: serializedInputProps,
 				logLevel: logLevel ?? 'info',

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -12,7 +12,6 @@ import {callLambda} from '../shared/call-lambda';
 import type {OutNameInput, Privacy} from '../shared/constants';
 import {LambdaRoutines} from '../shared/constants';
 import type {DownloadBehavior} from '../shared/content-disposition-header';
-import {convertToServeUrl} from '../shared/convert-to-serve-url';
 import {getCloudwatchStreamUrl, getS3RenderUrl} from '../shared/get-aws-urls';
 import {serializeInputProps} from '../shared/serialize-input-props';
 import {validateDownloadBehavior} from '../shared/validate-download-behavior';
@@ -128,14 +127,11 @@ export const renderMediaOnLambda = async ({
 	});
 	validateDownloadBehavior(downloadBehavior);
 
-	const [realServeUrl, serializedInputProps] = await Promise.all([
-		convertToServeUrl(serveUrl, region),
-		serializeInputProps({
-			inputProps,
-			region,
-			type: 'video-or-audio',
-		}),
-	]);
+	const serializedInputProps = await serializeInputProps({
+		inputProps,
+		region,
+		type: 'video-or-audio',
+	});
 	try {
 		const res = await callLambda({
 			functionName,
@@ -143,7 +139,7 @@ export const renderMediaOnLambda = async ({
 			payload: {
 				framesPerLambda: framesPerLambda ?? null,
 				composition,
-				serveUrl: realServeUrl,
+				serveUrl,
 				inputProps: serializedInputProps,
 				codec: actualCodec,
 				imageFormat: imageFormat ?? 'jpeg',

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -6,7 +6,6 @@ import {callLambda} from '../shared/call-lambda';
 import type {CostsInfo, OutNameInput, Privacy} from '../shared/constants';
 import {DEFAULT_MAX_RETRIES, LambdaRoutines} from '../shared/constants';
 import type {DownloadBehavior} from '../shared/content-disposition-header';
-import {convertToServeUrl} from '../shared/convert-to-serve-url';
 import {getCloudwatchStreamUrl} from '../shared/get-aws-urls';
 import {serializeInputProps} from '../shared/serialize-input-props';
 
@@ -79,8 +78,6 @@ export const renderStillOnLambda = async ({
 	forceHeight,
 	forceWidth,
 }: RenderStillOnLambdaInput): Promise<RenderStillOnLambdaOutput> => {
-	const realServeUrl = await convertToServeUrl(serveUrl, region);
-
 	const serializedInputProps = await serializeInputProps({
 		inputProps,
 		region,
@@ -93,7 +90,7 @@ export const renderStillOnLambda = async ({
 			type: LambdaRoutines.still,
 			payload: {
 				composition,
-				serveUrl: realServeUrl,
+				serveUrl,
 				inputProps: serializedInputProps,
 				imageFormat,
 				envVariables,

--- a/packages/lambda/src/cli/commands/compositions/index.ts
+++ b/packages/lambda/src/cli/commands/compositions/index.ts
@@ -1,7 +1,6 @@
 import {CliInternals} from '@remotion/cli';
 import {getCompositionsOnLambda} from '../../..';
 import {BINARY_NAME} from '../../../shared/constants';
-import {convertToServeUrl} from '../../../shared/convert-to-serve-url';
 import {validateServeUrl} from '../../../shared/validate-serveurl';
 import {getAwsRegion} from '../../get-aws-region';
 import {findFunctionName} from '../../helpers/find-function-name';
@@ -42,10 +41,9 @@ export const compositionsCommand = async (
 	validateServeUrl(serveUrl);
 	const functionName = await findFunctionName();
 
-	const realServeUrl = await convertToServeUrl(serveUrl, region);
 	const comps = await getCompositionsOnLambda({
 		functionName,
-		serveUrl: realServeUrl,
+		serveUrl,
 		inputProps,
 		region,
 		chromiumOptions,

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -9,7 +9,6 @@ import {
 	DEFAULT_MAX_RETRIES,
 	DEFAULT_OUTPUT_PRIVACY,
 } from '../../../shared/constants';
-import {convertToServeUrl} from '../../../shared/convert-to-serve-url';
 import {sleep} from '../../../shared/sleep';
 import {validateFramesPerLambda} from '../../../shared/validate-frames-per-lambda';
 import type {LambdaCodec} from '../../../shared/validate-lambda-codec';
@@ -46,8 +45,7 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 		Log.info('No compositions passed. Fetching compositions...');
 
 		validateServeUrl(serveUrl);
-		const realServeUrl = await convertToServeUrl(serveUrl, region);
-		const comps = await getCompositions(realServeUrl);
+		const comps = await getCompositions(serveUrl);
 		const {compositionId} = await CliInternals.selectComposition(comps);
 		composition = compositionId;
 	}

--- a/packages/lambda/src/cli/commands/still.ts
+++ b/packages/lambda/src/cli/commands/still.ts
@@ -7,7 +7,6 @@ import {
 	DEFAULT_MAX_RETRIES,
 	DEFAULT_OUTPUT_PRIVACY,
 } from '../../shared/constants';
-import {convertToServeUrl} from '../../shared/convert-to-serve-url';
 import {validatePrivacy} from '../../shared/validate-privacy';
 import {validateMaxRetries} from '../../shared/validate-retries';
 import {validateServeUrl} from '../../shared/validate-serveurl';
@@ -37,15 +36,12 @@ export const stillCommand = async (args: string[], remotionRoot: string) => {
 	const region = getAwsRegion();
 	let composition = args[1];
 	if (!composition) {
-		if (!composition) {
-			Log.info('No compositions passed. Fetching compositions...');
+		Log.info('No compositions passed. Fetching compositions...');
 
-			validateServeUrl(serveUrl);
-			const realServeUrl = await convertToServeUrl(serveUrl, region);
-			const comps = await getCompositions(realServeUrl);
-			const {compositionId} = await CliInternals.selectComposition(comps);
-			composition = compositionId;
-		}
+		validateServeUrl(serveUrl);
+		const comps = await getCompositions(serveUrl);
+		const {compositionId} = await CliInternals.selectComposition(comps);
+		composition = compositionId;
 	}
 
 	const downloadName = args[2] ?? null;

--- a/packages/lambda/src/functions/start.ts
+++ b/packages/lambda/src/functions/start.ts
@@ -4,6 +4,7 @@ import {getOrCreateBucket} from '../api/get-or-create-bucket';
 import {getLambdaClient} from '../shared/aws-clients';
 import type {LambdaPayload} from '../shared/constants';
 import {initalizedMetadataKey, LambdaRoutines} from '../shared/constants';
+import {convertToServeUrl} from '../shared/convert-to-serve-url';
 import {randomHash} from '../shared/random-hash';
 import {getCurrentRegionInFunction} from './helpers/get-current-region';
 import {lambdaWriteFile} from './helpers/io';
@@ -29,8 +30,14 @@ export const startHandler = async (params: LambdaPayload, options: Options) => {
 		);
 	}
 
+	const region = getCurrentRegionInFunction();
 	const {bucketName} = await getOrCreateBucket({
 		region: getCurrentRegionInFunction(),
+	});
+	const realServeUrl = convertToServeUrl({
+		urlOrId: params.serveUrl,
+		region,
+		bucketName,
 	});
 
 	const renderId = randomHash({randomInTests: true});
@@ -38,7 +45,7 @@ export const startHandler = async (params: LambdaPayload, options: Options) => {
 	const initialFile = lambdaWriteFile({
 		bucketName,
 		downloadBehavior: null,
-		region: getCurrentRegionInFunction(),
+		region,
 		body: 'Render was initialized',
 		expectedBucketOwner: options.expectedBucketOwner,
 		key: initalizedMetadataKey(renderId),
@@ -50,7 +57,7 @@ export const startHandler = async (params: LambdaPayload, options: Options) => {
 		type: LambdaRoutines.launch,
 		framesPerLambda: params.framesPerLambda,
 		composition: params.composition,
-		serveUrl: params.serveUrl,
+		serveUrl: realServeUrl,
 		inputProps: params.inputProps,
 		bucketName,
 		renderId,

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -18,6 +18,7 @@ import {
 	MAX_EPHEMERAL_STORAGE_IN_MB,
 	renderMetadataKey,
 } from '../shared/constants';
+import {convertToServeUrl} from '../shared/convert-to-serve-url';
 import {deserializeInputProps} from '../shared/deserialize-input-props';
 import {getServeUrlHash} from '../shared/make-s3-url';
 import {randomHash} from '../shared/random-hash';
@@ -87,15 +88,22 @@ const innerStillHandler = async (
 
 	const downloadMap = RenderInternals.makeDownloadMap();
 
+	const region = getCurrentRegionInFunction();
 	const inputProps = await deserializeInputProps({
 		bucketName,
 		expectedBucketOwner: options.expectedBucketOwner,
-		region: getCurrentRegionInFunction(),
+		region,
 		serialized: lambdaParams.inputProps,
 	});
 
+	const serveUrl = convertToServeUrl({
+		urlOrId: lambdaParams.serveUrl,
+		region,
+		bucketName,
+	});
+
 	const composition = await validateComposition({
-		serveUrl: lambdaParams.serveUrl,
+		serveUrl,
 		browserInstance,
 		composition: lambdaParams.composition,
 		inputProps,
@@ -117,7 +125,7 @@ const innerStillHandler = async (
 		compositionId: lambdaParams.composition,
 		estimatedTotalLambdaInvokations: 1,
 		estimatedRenderLambdaInvokations: 1,
-		siteId: getServeUrlHash(lambdaParams.serveUrl),
+		siteId: getServeUrlHash(serveUrl),
 		totalChunks: 1,
 		type: 'still',
 		imageFormat: lambdaParams.imageFormat,
@@ -147,7 +155,7 @@ const innerStillHandler = async (
 	await renderStill({
 		composition,
 		output: outputPath,
-		serveUrl: lambdaParams.serveUrl,
+		serveUrl,
 		dumpBrowserLogs: false,
 		envVariables: lambdaParams.envVariables,
 		frame: RenderInternals.convertToPositiveFrameIndex({

--- a/packages/lambda/src/shared/convert-to-serve-url.ts
+++ b/packages/lambda/src/shared/convert-to-serve-url.ts
@@ -1,8 +1,15 @@
-import {getOrCreateBucket} from '../api/get-or-create-bucket';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {DOCS_URL} from './docs-url';
 
-export const convertToServeUrl = async (urlOrId: string, region: AwsRegion) => {
+export const convertToServeUrl = ({
+	urlOrId,
+	region,
+	bucketName,
+}: {
+	urlOrId: string;
+	region: AwsRegion;
+	bucketName: string;
+}) => {
 	if (urlOrId.startsWith('src/')) {
 		throw new Error(
 			`Remotion Lambda can only render based on a URL in the cloud. It seems like you passed a local file: ${urlOrId}. Read the setup guide for Remotion Lambda ${DOCS_URL}/docs/lambda/setup`
@@ -12,10 +19,6 @@ export const convertToServeUrl = async (urlOrId: string, region: AwsRegion) => {
 	if (urlOrId.startsWith('http://') || urlOrId.startsWith('https://')) {
 		return urlOrId;
 	}
-
-	const {bucketName} = await getOrCreateBucket({
-		region,
-	});
 
 	return `https://${bucketName}.s3.${region}.amazonaws.com/sites/${urlOrId}/index.html`;
 };

--- a/packages/lambda/src/shared/deserialize-input-props.ts
+++ b/packages/lambda/src/shared/deserialize-input-props.ts
@@ -14,7 +14,7 @@ export const deserializeInputProps = async ({
 	region: AwsRegion;
 	bucketName: string;
 	expectedBucketOwner: string;
-}): Promise<unknown> => {
+}): Promise<object> => {
 	if (serialized.type === 'payload') {
 		return JSON.parse(serialized.payload as string);
 	}
@@ -32,6 +32,10 @@ export const deserializeInputProps = async ({
 
 		return payload;
 	} catch (err) {
-		throw new Error('Failed to parse input props that were');
+		throw new Error(
+			`Failed to parse input props that were serialized: ${
+				(err as Error).stack
+			}`
+		);
 	}
 };


### PR DESCRIPTION
We don't need to do it in the client and inside the function. We can do it just once in the function! This will make triggering the render faster.