### PR TITLE
docs: add `deploySite` webpack override example

### DIFF
--- a/packages/docs/docs/overwriting-webpack-config.md
+++ b/packages/docs/docs/overwriting-webpack-config.md
@@ -43,6 +43,7 @@ When using the Node.JS APIs - [`bundle()`](/docs/bundle) for SSR or [`deploySite
 
 ```ts twoslash title="src/webpack-override.ts"
 import { WebpackOverrideFn } from "remotion";
+
 export const webpackOverride: WebpackOverrideFn = (currentConfiguration) => {
   return {
     ...currentConfiguration,
@@ -59,6 +60,7 @@ export const webpackOverride: WebpackOverrideFn = (c) => c;
 // ---cut---
 import { Config } from "remotion";
 import { webpackOverride } from "./src/webpack-override";
+
 Config.Bundling.overrideWebpackConfig(webpackOverride);
 ```
 
@@ -73,6 +75,7 @@ export const webpackOverride: WebpackOverrideFn = (c) => c;
 // ---cut---
 import { bundle } from "@remotion/bundler";
 import { webpackOverride } from "./src/webpack-override";
+
 await bundle({
   entryPoint: require.resolve("./src/index.ts"),
   webpackOverride,
@@ -90,6 +93,7 @@ export const webpackOverride: WebpackOverrideFn = (c) => c;
 // ---cut---
 import { deploySite } from "@remotion/lambda";
 import { webpackOverride } from "./src/webpack-override";
+
 await deploySite({
   entryPoint: require.resolve("./src/index.ts"),
   options: {

--- a/packages/docs/docs/overwriting-webpack-config.md
+++ b/packages/docs/docs/overwriting-webpack-config.md
@@ -96,8 +96,10 @@ import { webpackOverride } from "./src/webpack-override";
 
 await deploySite({
   entryPoint: require.resolve("./src/index.ts"),
+  region: "us-east-1",
+  bucketName: "remotionlambda-c7fsl3d",
   options: {
-    webpackOverride
+    webpackOverride,
   },
   // ...other parameters
 });

--- a/packages/docs/docs/overwriting-webpack-config.md
+++ b/packages/docs/docs/overwriting-webpack-config.md
@@ -43,7 +43,6 @@ When using the Node.JS APIs - [`bundle()`](/docs/bundle) for SSR or [`deploySite
 
 ```ts twoslash title="src/webpack-override.ts"
 import { WebpackOverrideFn } from "remotion";
-
 export const webpackOverride: WebpackOverrideFn = (currentConfiguration) => {
   return {
     ...currentConfiguration,
@@ -60,9 +59,10 @@ export const webpackOverride: WebpackOverrideFn = (c) => c;
 // ---cut---
 import { Config } from "remotion";
 import { webpackOverride } from "./src/webpack-override";
-
 Config.Bundling.overrideWebpackConfig(webpackOverride);
 ```
+
+With `bundle`:
 
 ```ts twoslash title="my-script.js"
 // @filename: ./src/webpack-override.ts
@@ -73,10 +73,29 @@ export const webpackOverride: WebpackOverrideFn = (c) => c;
 // ---cut---
 import { bundle } from "@remotion/bundler";
 import { webpackOverride } from "./src/webpack-override";
-
 await bundle({
   entryPoint: require.resolve("./src/index.ts"),
   webpackOverride,
+});
+```
+
+Or while using with `deploySite`:
+
+```ts twoslash title="my-script.js"
+// @filename: ./src/webpack-override.ts
+import { WebpackOverrideFn } from "remotion";
+export const webpackOverride: WebpackOverrideFn = (c) => c;
+// @filename: remotion.config.ts
+// @target: esnext
+// ---cut---
+import { deploySite } from "@remotion/lambda";
+import { webpackOverride } from "./src/webpack-override";
+await deploySite({
+  entryPoint: require.resolve("./src/index.ts"),
+  options: {
+    webpackOverride
+  },
+  // ...other parameters
 });
 ```
 


### PR DESCRIPTION
Added 'webpackOverride' example for `deploySite`. 

People might have to figure this out themselves, and since the title says 

> When using `bundle()` and `deploySite()`

I believe an example for both would be expected :)

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
