### PR TITLE
prevent devs from import renderMediaOnLambda from `@remotion/lambda` 

### DIFF
--- a/packages/docs/docs/lambda/getcompositionsonlambda.md
+++ b/packages/docs/docs/lambda/getcompositionsonlambda.md
@@ -19,7 +19,7 @@ You should use `getCompositionsOnLambda()` if you cannot use [`getCompositions()
 ```tsx twoslash
 // @module: esnext
 // @target: es2017
-import { getCompositionsOnLambda } from "@remotion/lambda";
+import { getCompositionsOnLambda } from "@remotion/lambda/client";
 
 const compositions = await getCompositionsOnLambda({
   region: "us-east-1",
@@ -31,6 +31,10 @@ const compositions = await getCompositionsOnLambda({
 
 console.log(compositions); // See below for an example value
 ```
+
+:::note
+Preferrably import this function from `@remotion/lambda/client` to avoid problems [inside serverless functions](/docs/lambda/light-client).
+:::
 
 ## Arguments
 

--- a/packages/docs/docs/lambda/getfunctions.md
+++ b/packages/docs/docs/lambda/getfunctions.md
@@ -18,7 +18,7 @@ To get information about only a single function, use [`getFunctionInfo()`](/docs
 // @module: esnext
 // @target: es2017
 
-import { getFunctions } from "@remotion/lambda";
+import { getFunctions } from "@remotion/lambda/client";
 
 const info = await getFunctions({
   region: "eu-central-1",
@@ -33,6 +33,10 @@ for (const fn of info) {
   console.log(fn.version); // "2021-07-25"
 }
 ```
+
+:::note
+Preferrably import this function from `@remotion/lambda/client` to avoid problems [inside serverless functions](/docs/lambda/light-client).
+:::
 
 ## Argument
 

--- a/packages/docs/docs/lambda/getrenderprogress.md
+++ b/packages/docs/docs/lambda/getrenderprogress.md
@@ -13,9 +13,8 @@ Gets the current status of a render originally triggered via [`renderMediaOnLamb
 ```tsx twoslash
 // @module: esnext
 // @target: es2017
-import { getRenderProgress } from "@remotion/lambda";
 
-// ---cut---
+import { getRenderProgress } from "@remotion/lambda/client";
 
 const progress = await getRenderProgress({
   renderId: "d7nlc2y",
@@ -24,6 +23,10 @@ const progress = await getRenderProgress({
   region: "us-east-1",
 });
 ```
+
+:::note
+Preferrably import this function from `@remotion/lambda/client` to avoid problems [inside serverless functions](/docs/lambda/light-client).
+:::
 
 ## API
 

--- a/packages/docs/docs/lambda/light-client.md
+++ b/packages/docs/docs/lambda/light-client.md
@@ -8,7 +8,19 @@ crumb: "Lambda"
 The following methods and types can be imported from `@remotion/lambda/client`:
 
 ```tsx twoslash
-
+// organize-imports-ignore
+// ---cut---
+import {
+  renderMediaOnLambda,
+  renderStillOnLambda,
+  getRenderProgress,
+  getCompositionsOnLambda,
+  getFunctions,
+  AwsRegion,
+  RenderProgress,
+  validateWebhookSignature,
+  WebhookPayload,
+} from "@remotion/lambda/client";
 ```
 
 These functions don't have any Node.JS dependencies and can be bundled with a bundler such as Webpack or ESBuild.

--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -14,8 +14,8 @@ Triggers a render on a lambda given a composition and a lambda function.
 ```tsx twoslash
 // @module: esnext
 // @target: es2017
-import { renderMediaOnLambda } from "@remotion/lambda";
 // ---cut---
+import { renderMediaOnLambda } from "@remotion/lambda/client";
 
 const { bucketName, renderId } = await renderMediaOnLambda({
   region: "us-east-1",
@@ -26,6 +26,10 @@ const { bucketName, renderId } = await renderMediaOnLambda({
   codec: "h264",
 });
 ```
+
+:::note
+Preferrably import this function from `@remotion/lambda/client` to avoid problems [inside serverless functions](/docs/lambda/light-client).
+:::
 
 ## Arguments
 

--- a/packages/docs/docs/lambda/renderstillonlambda.md
+++ b/packages/docs/docs/lambda/renderstillonlambda.md
@@ -17,8 +17,7 @@ If you want to render a still locally instead, use [`renderStill()`](/docs/rende
 ```tsx twoslash
 // @module: esnext
 // @target: es2017
-import { renderStillOnLambda } from "@remotion/lambda";
-// ---cut---
+import { renderStillOnLambda } from "@remotion/lambda/client";
 
 const { estimatedPrice, url, sizeInBytes } = await renderStillOnLambda({
   region: "us-east-1",
@@ -34,6 +33,10 @@ const { estimatedPrice, url, sizeInBytes } = await renderStillOnLambda({
   frame: 10,
 });
 ```
+
+:::note
+Preferrably import this function from `@remotion/lambda/client` to avoid problems [inside serverless functions](/docs/lambda/light-client).
+:::
 
 ## Arguments
 

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -54,14 +54,14 @@ import type {
 	RenderMediaOnLambdaOutput,
 } from './api/render-media-on-lambda';
 import {
-	renderMediaOnLambda,
+	renderMediaOnLambda as deprecatedRenderMediaOnLambda,
 	renderVideoOnLambda,
 } from './api/render-media-on-lambda';
 import type {
 	RenderStillOnLambdaInput,
 	RenderStillOnLambdaOutput,
 } from './api/render-still-on-lambda';
-import {renderStillOnLambda} from './api/render-still-on-lambda';
+import {renderStillOnLambda as deprecatedRenderStillOnLambda} from './api/render-still-on-lambda';
 import {validateWebhookSignature} from './api/validate-webhook-signature';
 import type {LambdaLSInput, LambdaLsReturnType} from './functions/helpers/io';
 import type {
@@ -74,6 +74,16 @@ import type {CustomCredentials} from './shared/aws-clients';
 import type {RenderProgress} from './shared/constants';
 import type {WebhookPayload} from './shared/invoke-webhook';
 import type {LambdaArchitecture} from './shared/validate-architecture';
+
+/**
+ * @deprecated Import this from `@remotion/lambda/client` instead
+ */
+const renderMediaOnLambda = deprecatedRenderMediaOnLambda;
+
+/**
+ * @deprecated Import this from `@remotion/lambda/client` instead
+ */
+const renderStillOnLambda = deprecatedRenderStillOnLambda;
 
 export {
 	deleteSite,


### PR DESCRIPTION
From `@remotion/lambda/client` is better