### PR TITLE
Fix "Changing the temporary directory" docs to actually have an effect on macOS

### DIFF
--- a/packages/docs/docs/miscellaneous/changing-temp-dir.md
+++ b/packages/docs/docs/miscellaneous/changing-temp-dir.md
@@ -16,7 +16,7 @@ TMPDIR=/var/tmp npx remotion render
 ```
 
 Remotion will make a new temporary directory in the path that you have specified.
-This is because Remotion uses the the Node.JS [`os.tmpdir()`][tmpdir] API, which checks for these environment variables in priority order:
+This is because Remotion uses the the Node.JS [`os.tmpdir()`][tmpdir] API, which checks for environment variables in the following order:
 
 * `TMPDIR`, `TMP`, `TEMP` on non-Windows platforms
 * `TEMP` and `TMP` on Windows platforms

--- a/packages/docs/docs/miscellaneous/changing-temp-dir.md
+++ b/packages/docs/docs/miscellaneous/changing-temp-dir.md
@@ -7,12 +7,18 @@ crumb: "Advanced configuration"
 
 During rendering, Remotion will write items into the temporary directory of the system. This includes rendered frames, uncompressed audio and other artifacts.
 
-If you want to customize the directory that Remotion uses, you can set the `TEMP` environment variable to specify a directory to your liking.
+Changing the temporary directory may be useful if the default temporary directory is on a disk that has limited space available.
+
+If you want to customize the directory that Remotion uses, you can set the `TMPDIR` (Linux, macOS) or `TEMP` (Windows) environment variable to specify a directory to your liking.
 
 ```bash
-TEMP=/var/tmp npx remotion render
+TMPDIR=/var/tmp npx remotion render
 ```
 
-Remotion will make a new temporary directory in the path that you have specified. This is because the Node.JS API [`os.tmpdir()`](https://github.com/nodejs/node/blob/58431c0e6bb1829b6ccafc5cf6340226c15da790/lib/os.js#L181) is called by Remotion which is checking for environment variables.
+Remotion will make a new temporary directory in the path that you have specified.
+This is because Remotion uses the the Node.JS [`os.tmpdir()`][tmpdir] API, which checks for these environment variables in priority order:
 
-Changing the temporary directory may be useful if the default temporary directory is on a disk that has limited space available.
+* `TMPDIR`, `TMP`, `TEMP` on non-Windows platforms
+* `TEMP` and `TMP` on Windows platforms
+
+[tmpdir]: https://github.com/nodejs/node/blob/58431c0e6bb1829b6ccafc5cf6340226c15da790/lib/os.js#L181


### PR DESCRIPTION
macOS sets `TMPDIR` by default, so setting `TEMP` has no effect.

Setting `TMPDIR` on non-Windows platforms is the priority, as evident from the code linked in the doc.
