### PR TITLE
Fix `--sequence` output folder that starts with a `./`

### DIFF
--- a/packages/renderer/src/get-extension-of-filename.ts
+++ b/packages/renderer/src/get-extension-of-filename.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 export const getExtensionOfFilename = (
 	filename: string | null
 ): string | null => {
@@ -5,7 +7,7 @@ export const getExtensionOfFilename = (
 		return null;
 	}
 
-	const filenameArr = filename.split('.');
+	const filenameArr = path.normalize(filename).split('.');
 
 	const hasExtension = filenameArr.length >= 2;
 	const filenameArrLength = filenameArr.length;

--- a/packages/renderer/src/test/file-extension.test.ts
+++ b/packages/renderer/src/test/file-extension.test.ts
@@ -1,0 +1,14 @@
+import {expect, test} from 'vitest';
+import {getExtensionOfFilename} from '../get-extension-of-filename';
+
+test('Get extension of filename', () => {
+	const filename = './test.mp4';
+	const extension = getExtensionOfFilename(filename);
+	expect(extension).toBe('mp4');
+});
+
+test('Dot slash should not count', () => {
+	const filename = './out';
+	const extension = getExtensionOfFilename(filename);
+	expect(extension).toBe(null);
+});


### PR DESCRIPTION
Fixes #1651 