### PR TITLE
warn about using <Sequence> inside <ThreeCanvas>

### DIFF
--- a/packages/cli/src/preview-server/error-overlay/react-overlay/utils/get-stack-frames.ts
+++ b/packages/cli/src/preview-server/error-overlay/react-overlay/utils/get-stack-frames.ts
@@ -22,12 +22,7 @@ export const getStackFrames = async (
 	if (
 		enhancedFrames
 			.map((f) => f.originalFileName)
-			.filter(
-				(f_1) =>
-					f_1 !== null &&
-					f_1 !== undefined &&
-					f_1.indexOf('node_modules') === -1
-			).length === 0
+			.filter((f_1) => f_1 !== null && f_1 !== undefined).length === 0
 	) {
 		return null;
 	}

--- a/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
+++ b/packages/cli/src/preview-server/error-overlay/remotion-overlay/get-help-link.ts
@@ -50,5 +50,12 @@ export const getHelpLink = (message: string): THelpLink | null => {
 		};
 	}
 
+	if (message.includes('Div is not part of the THREE')) {
+		return {
+			title: '<Sequence> inside <ThreeCanvas>',
+			url: 'https://remotion.dev/docs/sequence#note-for-remotionthree',
+		};
+	}
+
 	return null;
 };

--- a/packages/docs/docs/sequence.md
+++ b/packages/docs/docs/sequence.md
@@ -184,6 +184,10 @@ const MyComp = () => {
 };
 ```
 
+## Note for `@remotion/three`
+
+A `<Sequence>` by default will return a `<div>` component which is not allows inside a [`<ThreeCanvas>`](/docs/three-canvas). To avoid an error, pass `layout="none"` to `<Sequence>`.
+
 ## See also
 
 - [Source code for this component](https://github.com/remotion-dev/remotion/blob/main/packages/core/src/Sequence.tsx)

--- a/packages/docs/docs/three-canvas.md
+++ b/packages/docs/docs/three-canvas.md
@@ -58,6 +58,10 @@ const ThreeBasic: React.FC = () => {
 export default ThreeBasic;
 ```
 
+## Note on `<Sequence>`
+
+A [`<Sequence>`](/docs/sequence) by default will return a `<div>` component which is not allows inside a `<ThreeCanvas>`. To avoid an error, pass `layout="none"` to `<Sequence>`.
+
 ## See also
 
 - [Source code for this component](https://github.com/remotion-dev/remotion/blob/main/packages/three/src/ThreeCanvas.tsx)

--- a/packages/docs/docs/three.md
+++ b/packages/docs/docs/three.md
@@ -63,6 +63,10 @@ pnpm i three @react-three/fiber @remotion/three @types/three
 
 You are now set up and can render a [`<ThreeCanvas />`](/docs/three-canvas) in your project.
 
+## Note on `<Sequence>`
+
+A [`<Sequence>`](/docs/sequence) by default will return a `<div>` component which is not allows inside a `<ThreeCanvas>`. To avoid an error, pass `layout="none"` to `<Sequence>`.
+
 ## Thanks
 
 Big thanks to [Björn Zeutzheim](https://github.com/olee) for researching and discovering the techniques needed for React Three Fiber integration and for doing the initial implementation of the @remotion/three APIs.


### PR DESCRIPTION
It will render a `<div>` which by default will break.
So the error message is confusing