### PR TITLE
remove combineVideos() from regular exports

### DIFF
--- a/packages/example/src/simulate-lambda.ts
+++ b/packages/example/src/simulate-lambda.ts
@@ -1,6 +1,5 @@
 import {bundle} from '@remotion/bundler';
 import {
-	combineVideos,
 	getCompositions,
 	RenderInternals,
 	renderMedia,
@@ -37,7 +36,7 @@ const start = async () => {
 		console.log({i});
 	}
 
-	await combineVideos({
+	await RenderInternals.combineVideos({
 		codec: 'h264',
 		filelistDir,
 		files: new Array(dur / framesPerLambda).fill(true).map((_, i) => {

--- a/packages/lambda/src/functions/helpers/concat-videos.ts
+++ b/packages/lambda/src/functions/helpers/concat-videos.ts
@@ -1,5 +1,5 @@
 import type {Codec, FfmpegExecutable} from '@remotion/renderer';
-import {combineVideos, RenderInternals} from '@remotion/renderer';
+import {RenderInternals} from '@remotion/renderer';
 import fs, {createWriteStream, promises} from 'fs';
 import path, {join} from 'path';
 import type {AwsRegion} from '../../pricing/aws-regions';
@@ -200,7 +200,7 @@ export const concatVideosS3 = async ({
 	const filelistDir = RenderInternals.tmpDir(REMOTION_FILELIST_TOKEN);
 	const codecForCombining: Codec = codec === 'h264-mkv' ? 'h264' : codec;
 
-	await combineVideos({
+	await RenderInternals.combineVideos({
 		files,
 		filelistDir,
 		output: outfile,

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -6,6 +6,7 @@ import {DEFAULT_TIMEOUT} from './browser/TimeoutSettings';
 import {canUseParallelEncoding} from './can-use-parallel-encoding';
 import {checkNodeVersionAndWarnAboutRosetta} from './check-apple-silicon';
 import {DEFAULT_CODEC, validCodecs} from './codec';
+import {combineVideos} from './combine-videos';
 import {convertToPositiveFrameIndex} from './convert-to-positive-frame-index';
 import {deleteDirectory} from './delete-directory';
 import {ensureOutputDirectory} from './ensure-output-directory';
@@ -58,7 +59,6 @@ export {Browser} from './browser';
 export {BrowserExecutable} from './browser-executable';
 export {BrowserLog} from './browser-log';
 export {Codec, CodecOrUndefined} from './codec';
-export {combineVideos} from './combine-videos';
 export {Crf} from './crf';
 export {
 	ensureFfmpeg,
@@ -153,6 +153,7 @@ export const RenderInternals = {
 	getExecutableBinary,
 	validateBitrate,
 	getFfmpegVersion,
+	combineVideos,
 };
 
 // Warn of potential performance issues with Apple Silicon (M1 chip under Rosetta)


### PR DESCRIPTION
Previously it was possible to do `import {combineVideos} from "@remotion/renderer"`.
However this was never intended to be a public API and wasn't documented.

Moving it to `import {RenderInternals} from "@remotion/renderer"; const combineVideos = RenderInternals.combineVideos` if someone wants to use this unstable API.