### PR TITLE
Fix `setPort()` being ignored in preview command

### DIFF
--- a/packages/cli/src/preview.ts
+++ b/packages/cli/src/preview.ts
@@ -67,8 +67,9 @@ const getPort = () => {
 		return parsedCli.port;
 	}
 
-	if (ConfigInternals.getServerPort()) {
-		return ConfigInternals.getServerPort();
+	const serverPort = ConfigInternals.getServerPort();
+	if (serverPort) {
+		return serverPort;
 	}
 
 	return null;

--- a/packages/cli/src/preview.ts
+++ b/packages/cli/src/preview.ts
@@ -62,6 +62,18 @@ const getShouldOpenBrowser = (): {
 	return {shouldOpenBrowser: true, reasonForBrowserDecision: 'default'};
 };
 
+const getPort = () => {
+	if (parsedCli.port) {
+		return parsedCli.port;
+	}
+
+	if (ConfigInternals.getServerPort()) {
+		return ConfigInternals.getServerPort();
+	}
+
+	return null;
+};
+
 export const previewCommand = async (remotionRoot: string, args: string[]) => {
 	const {file, reason} = findEntryPoint(args, remotionRoot);
 
@@ -78,7 +90,7 @@ export const previewCommand = async (remotionRoot: string, args: string[]) => {
 		process.exit(1);
 	}
 
-	const {port: desiredPort} = parsedCli;
+	const desiredPort = getPort();
 	const fullPath = path.join(process.cwd(), file);
 
 	let inputProps = getInputProps((newProps) => {

--- a/packages/example/remotion.config.ts
+++ b/packages/example/remotion.config.ts
@@ -3,3 +3,4 @@ import {webpackOverride} from './src/webpack-override';
 
 Config.Output.setOverwriteOutput(true);
 Config.Bundling.overrideWebpackConfig(webpackOverride);
+Config.Bundling.setPort(8080);


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
