### PR TITLE
docs: fix typo in noise package

### DIFF
--- a/packages/docs/docs/noise/noise-2d.md
+++ b/packages/docs/docs/noise/noise-2d.md
@@ -14,7 +14,7 @@ The function takes three arguments:
 
 ### `seed`
 
-Pass any _string_ or _number_. If the seed is the same, you will get the same result for same `x` and `y` values. Change the seed to to get different results for your `x` and `y` values.
+Pass any _string_ or _number_. If the seed is the same, you will get the same result for same `x` and `y` values. Change the seed to get different results for your `x` and `y` values.
 
 ### `x`
 

--- a/packages/docs/docs/noise/noise-3d.md
+++ b/packages/docs/docs/noise/noise-3d.md
@@ -14,7 +14,7 @@ The function takes four arguments:
 
 ### `seed`
 
-Pass any _string_ or _number_. If the seed is the same, you will get the same result for same `x`, `y` and `z` values. Change the seed to to get different results for your `x`, `y` and `z` values.
+Pass any _string_ or _number_. If the seed is the same, you will get the same result for same `x`, `y` and `z` values. Change the seed to get different results for your `x`, `y` and `z` values.
 
 ### `x`
 

--- a/packages/docs/docs/noise/noise-4d.md
+++ b/packages/docs/docs/noise/noise-4d.md
@@ -14,7 +14,7 @@ The function takes five arguments:
 
 ### `seed`
 
-Pass any _string_ or _number_. If the seed is the same, you will get the same result for same `x`, `y`, `z` and `w` values. Change the seed to to get different results for your `x`, `y`, `z`, `w` values.
+Pass any _string_ or _number_. If the seed is the same, you will get the same result for same `x`, `y`, `z` and `w` values. Change the seed to get different results for your `x`, `y`, `z`, `w` values.
 
 ### `x`
 


### PR DESCRIPTION
I only fixed a copy paste error in docs.
