### PR TITLE
Recalc ComboBox layout before mounting

### DIFF
--- a/packages/cli/src/editor/components/NewComposition/ComboBox.tsx
+++ b/packages/cli/src/editor/components/NewComposition/ComboBox.tsx
@@ -68,6 +68,8 @@ export const Combobox: React.FC<{
 		shouldApplyCssTransforms: true,
 	});
 
+	const refresh = size?.refresh;
+
 	const onHide = useCallback(() => {
 		setOpened(false);
 	}, []);
@@ -82,7 +84,13 @@ export const Combobox: React.FC<{
 		const onMouseLeave = () => setIsHovered(false);
 		const onClick = (e: MouseEvent) => {
 			e.stopPropagation();
-			return setOpened((o) => !o);
+			return setOpened((o) => {
+				if (!o) {
+					refresh?.();
+				}
+
+				return !o;
+			});
 		};
 
 		current.addEventListener('mouseenter', onMouseEnter);
@@ -94,7 +102,7 @@ export const Combobox: React.FC<{
 			current.removeEventListener('mouseleave', onMouseLeave);
 			current.removeEventListener('click', onClick);
 		};
-	}, []);
+	}, [refresh]);
 
 	const portalStyle = useMemo((): React.CSSProperties | null => {
 		if (!opened || !size) {
@@ -114,7 +122,6 @@ export const Combobox: React.FC<{
 				  }
 				: {
 						...menuContainerTowardsTop,
-
 						bottom: size.windowSize.height - size.top,
 				  }),
 			left: size.left,

--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -9,6 +9,7 @@ export type Size = {
 		width: number;
 		height: number;
 	};
+	refresh: () => void;
 };
 
 // If a pane has been moved, it will cause a layout shift without
@@ -32,7 +33,8 @@ export const useElementSize = (
 		shouldApplyCssTransforms: boolean;
 	}
 ): Size | null => {
-	const [size, setSize] = useState<Size | null>(null);
+	const [size, setSize] = useState<Omit<Size, 'refresh'> | null>(null);
+
 	const observer = useMemo(() => {
 		if (typeof ResizeObserver === 'undefined') {
 			return null;
@@ -70,6 +72,7 @@ export const useElementSize = (
 			});
 		});
 	}, [options.shouldApplyCssTransforms]);
+
 	const updateSize = useCallback(() => {
 		if (!ref.current) {
 			return;
@@ -131,5 +134,5 @@ export const useElementSize = (
 		};
 	}, [updateSize]);
 
-	return size;
+	return size ? {...size, refresh: updateSize} : null;
 };


### PR DESCRIPTION
Good if there are natural layout shifts occurring without resizing