### PR TITLE
`@remotion/three`: Fix `useVideoTexture()` in Create React App

### DIFF
--- a/packages/three/src/use-video-texture.ts
+++ b/packages/three/src/use-video-texture.ts
@@ -1,7 +1,7 @@
 import React, {useCallback, useState} from 'react';
 import type {Video} from 'remotion';
 import {continueRender, delayRender, useCurrentFrame} from 'remotion';
-import {VideoTexture} from 'three';
+import {VideoTexture} from 'three/src/textures/VideoTexture';
 
 export type UseVideoTextureOptions = React.ComponentProps<typeof Video>;
 


### PR DESCRIPTION
Having this in CRA breaks it lol:

```
const three = require('three')

console.log(three)
```

returns a string