### PR TITLE
more reliable lambda upload

### DIFF
--- a/packages/lambda/src/api/upload-dir.ts
+++ b/packages/lambda/src/api/upload-dir.ts
@@ -95,7 +95,7 @@ export const uploadDir = async ({
 
 	const client = getS3Client(region, null);
 
-	const uploads = files.map(async (filePath) => {
+	const uploads = files.map((filePath) => {
 		const Key = makeS3Key(keyPrefix, localDir, filePath.name);
 		const Body = createReadStream(filePath.name);
 		const ContentType = mimeTypes.lookup(Key) || 'application/octet-stream';


### PR DESCRIPTION
Fixing the folllowing user report:

> Hi! I often get the following error when running npx remotion lambda create sites ... with any regions, like 3 out of 5 times.
> 
> RequestTimeout: Your socket connection to the server was not read from or written to within the timeout period. Idle connections will be closed.
> 
> 
> If I use the upload command (in @aws-sdk/lib-storage) instead of the put object command for all files, it works fine in seconds (100%).
> I changed the line in node_modules to do this temporarily...
> https://github.com/remotion-dev/remotion/blob/f1ad1f7f1360f05cedccf93bd146dcf766be870e/packages/lambda/src/api/upload-dir.ts#L109
> 5 * 1024 * 1024 -> 0
> 
> Do you know anything about this?
> Is there a reason for using PutObjectCommand instead of the upload command?