### PR TITLE
Disable Yarn PnP when creating a project with Yarn2/3

### DIFF
--- a/packages/create-video/src/add-yarn2-support.ts
+++ b/packages/create-video/src/add-yarn2-support.ts
@@ -1,0 +1,37 @@
+import {writeFileSync} from 'fs';
+import path from 'path';
+import {Log} from './log';
+import type {PackageManager} from './pkg-managers';
+
+export const createYarnYmlFile = ({
+	projectRoot,
+	pkgManagerVersion,
+	pkgManager,
+}: {
+	projectRoot: string;
+	pkgManagerVersion: string | null;
+	pkgManager: PackageManager;
+}) => {
+	if (pkgManager !== 'yarn') {
+		return;
+	}
+
+	if (!pkgManagerVersion) {
+		return;
+	}
+
+	const majorVersion = pkgManagerVersion[0] as string;
+	const majorVersionNumber = Number(majorVersion);
+
+	if (majorVersionNumber < 2) {
+		return;
+	}
+
+	Log.info(
+		'Remotion has no support for automatically installing the Yarn PnP modules yet.'
+	);
+	Log.info('Creating .yarnrc.yml file to disable Yarn PnP.');
+
+	const yarnrcYml = `nodeLinker: node-modules\n`;
+	writeFileSync(path.join(projectRoot, '.yarnrc.yml'), yarnrcYml);
+};

--- a/packages/create-video/src/init.ts
+++ b/packages/create-video/src/init.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import execa from 'execa';
 import os from 'os';
+import {createYarnYmlFile} from './add-yarn2-support';
 import {degit} from './degit';
 import {getLatestRemotionVersion} from './latest-remotion-version';
 import {Log} from './log';
@@ -128,6 +129,12 @@ export const init = async () => {
 			selectedTemplate.shortName
 		)} to ${chalk.blueBright(folderName)}. Installing dependencies...`
 	);
+
+	createYarnYmlFile({
+		pkgManager,
+		pkgManagerVersion,
+		projectRoot,
+	});
 
 	if (pkgManager === 'yarn') {
 		Log.info('> yarn');


### PR DESCRIPTION
Yarn does not support TypeScript for example if you don't know to install specific Editor integrations.
Users are very confused, so let's revert back to `node_modules`