### PR TITLE
docs: change confusing statement in sequence documentation

### DIFF
--- a/packages/docs/docs/sequences.md
+++ b/packages/docs/docs/sequences.md
@@ -70,8 +70,7 @@ export const MyVideo = () => {
 };
 ```
 
-You should see two titles appearing after each other. Titles which are not shown during a frame are unmounted.
-This is why the layout did not shift (as it does in HTML) when you added a second title. If you want the titles to overlap in time, use absolute positioning if necessary.
+You should see two titles appearing after each other. Note that titles which are not shown during a frame are unmounted.
 
 ## See also
 

--- a/packages/docs/docs/sequences.md
+++ b/packages/docs/docs/sequences.md
@@ -70,7 +70,8 @@ export const MyVideo = () => {
 };
 ```
 
-You should see two titles appearing after each other. Note that titles which are not shown during a frame are unmounted.
+You should see two titles appearing after each other. Sequences which are not shown during a frame are unmounted.  
+Sequences by default are absolutely positioned - you can use [`layout="none"`](/docs/sequence#layout) to disable that.
 
 ## See also
 


### PR DESCRIPTION
## 🤔 Why ?

Related to #1779

## 💻 How ?

Just a small correction in the documentation on a part that is a bit confusing, on the positioning of sequences what was said is actually wrong because a `<Sequence>` by default is already in `position: absolute`, so the layout would not shift anyway, I think that this part is no longer useful in the doc and that just with this we understand 😊

