### PR TITLE
Add layers export

### DIFF
--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -68,7 +68,8 @@
 		"./defaults": "./dist/defaults.js",
 		"./regions": "./dist/regions.js",
 		"./policies": "./dist/api/iam-validation/suggested-policy.js",
-		"./client": "./dist/client.js"
+		"./client": "./dist/client.js",
+		"./layers": "./dist/shared/hosted-layers.js"
 	},
 	"typesVersions": {
 		">=1.0": {

--- a/packages/lambda/src/api/create-function.ts
+++ b/packages/lambda/src/api/create-function.ts
@@ -12,7 +12,7 @@ import {readFileSync} from 'fs';
 import {LOG_GROUP_PREFIX} from '../defaults';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {getCloudWatchLogsClient, getLambdaClient} from '../shared/aws-clients';
-import {hostedLayers} from '../shared/hosted-layers';
+import {__internal_doNotUsehostedLayers} from '../shared/hosted-layers';
 import type {LambdaArchitecture} from '../shared/validate-architecture';
 import {ROLE_NAME} from './iam-validation/suggested-policy';
 
@@ -82,7 +82,7 @@ export const createFunction = async ({
 			Description: 'Renders a Remotion video.',
 			MemorySize: memorySizeInMb,
 			Timeout: timeoutInSeconds,
-			Layers: hostedLayers[architecture][region].map(
+			Layers: __internal_doNotUsehostedLayers[architecture][region].map(
 				({layerArn, version}) => `${layerArn}:${version}`
 			),
 			Architectures: [architecture],

--- a/packages/lambda/src/shared/hosted-layers.ts
+++ b/packages/lambda/src/shared/hosted-layers.ts
@@ -9,366 +9,368 @@ export type HostedLayers = {
 	};
 };
 
-export const hostedLayers: HostedLayers = {
-	arm64: {
-		'ap-northeast-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 4,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 8,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 8,
-			},
-		],
-		'ap-south-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 4,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 8,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 8,
-			},
-		],
-		'ap-southeast-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 4,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 8,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 8,
-			},
-		],
-		'ap-southeast-2': [
-			{
-				layerArn:
-					'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 4,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 8,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 8,
-			},
-		],
-		'eu-central-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 4,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 8,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 8,
-			},
-		],
-		'eu-west-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 4,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 8,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 8,
-			},
-		],
-		'eu-west-2': [
-			{
-				layerArn:
-					'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 4,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 8,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 8,
-			},
-		],
-		'us-east-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 9,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 17,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 17,
-			},
-		],
-		'us-east-2': [
-			{
-				layerArn:
-					'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 4,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 8,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 8,
-			},
-		],
-		'us-west-2': [
-			{
-				layerArn:
-					'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 4,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 8,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 8,
-			},
-		],
-		'af-south-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'ap-east-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'ap-northeast-2': [
-			{
-				layerArn:
-					'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'ap-northeast-3': [
-			{
-				layerArn:
-					'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'ca-central-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'eu-north-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'eu-south-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'eu-west-3': [
-			{
-				layerArn:
-					'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'me-south-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'sa-east-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-		'us-west-1': [
-			{
-				layerArn:
-					'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-fonts-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
-				version: 1,
-			},
-			{
-				layerArn:
-					'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-chromium-arm64',
-				version: 1,
-			},
-		],
-	},
+export const hostedLayers = {
+	'ap-northeast-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 4,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 8,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 8,
+		},
+	],
+	'ap-south-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 4,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 8,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 8,
+		},
+	],
+	'ap-southeast-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 4,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 8,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 8,
+		},
+	],
+	'ap-southeast-2': [
+		{
+			layerArn:
+				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 4,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 8,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 8,
+		},
+	],
+	'eu-central-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 4,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 8,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 8,
+		},
+	],
+	'eu-west-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 4,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 8,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 8,
+		},
+	],
+	'eu-west-2': [
+		{
+			layerArn:
+				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 4,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 8,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 8,
+		},
+	],
+	'us-east-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 9,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 17,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 17,
+		},
+	],
+	'us-east-2': [
+		{
+			layerArn:
+				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 4,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 8,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 8,
+		},
+	],
+	'us-west-2': [
+		{
+			layerArn:
+				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 4,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 8,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 8,
+		},
+	],
+	'af-south-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'ap-east-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'ap-northeast-2': [
+		{
+			layerArn:
+				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'ap-northeast-3': [
+		{
+			layerArn:
+				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'ca-central-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'eu-north-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'eu-south-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'eu-west-3': [
+		{
+			layerArn:
+				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'me-south-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'sa-east-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+	'us-west-1': [
+		{
+			layerArn:
+				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-fonts-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-ffmpeg-arm64',
+			version: 1,
+		},
+		{
+			layerArn:
+				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-chromium-arm64',
+			version: 1,
+		},
+	],
+};
+
+export const __internal_doNotUsehostedLayers: HostedLayers = {
+	arm64: hostedLayers,
 	x86_64: {
 		'ap-northeast-1': [
 			{

--- a/packages/lambda/src/test/unit/hosted-layers-match.test.ts
+++ b/packages/lambda/src/test/unit/hosted-layers-match.test.ts
@@ -1,13 +1,15 @@
 import {expect, test} from 'vitest';
 import type {LambdaArchitecture} from '../..';
 import {
-	hostedLayers,
 	REMOTION_HOSTED_LAYER_ARN,
+	__internal_doNotUsehostedLayers,
 } from '../../shared/hosted-layers';
 
 test('All hosted layers should match ARN', () => {
-	Object.keys(hostedLayers).forEach((arch) => {
-		Object.values(hostedLayers[arch as LambdaArchitecture]).forEach((h) => {
+	Object.keys(__internal_doNotUsehostedLayers).forEach((arch) => {
+		Object.values(
+			__internal_doNotUsehostedLayers[arch as LambdaArchitecture]
+		).forEach((h) => {
 			h.forEach(({layerArn}) => {
 				expect(layerArn).toMatch(
 					new RegExp(REMOTION_HOSTED_LAYER_ARN.replace(/\*/g, '(.*)'))


### PR DESCRIPTION
Hi Jonny,

First, I'm experimenting with Remotion and love it so far! I'm deploying it on Lambda, but as all my infra is defined in CDK, I don't want to use the Remotion CLI function to deploy/update the Lambda functions. I have successfully set up my project in a way that deploys the Lambda function as part of my CDK setup and am working on a blog post to document the process. I did, however, have to patch Remotion to add an export for the lambda layers definition. Would you consider adding this export to your package.json? This little detail was the only thing I needed to patch to make it work, so I think it could be a great alternative approach for running Remotion on Lambda!

Benedikt