### PR TITLE
Mix instead of merge audio

### DIFF
--- a/packages/renderer/src/create-ffmpeg-merge-filter.ts
+++ b/packages/renderer/src/create-ffmpeg-merge-filter.ts
@@ -1,17 +1,3 @@
-import {truthy} from './truthy';
-
 export const createFfmpegMergeFilter = (inputs: number) => {
-	const leftChannel = new Array(inputs * 2)
-		.fill(true)
-		.map((_, i) => (i % 2 === 0 ? `c${i}` : null))
-		.filter(truthy)
-		.join('+');
-
-	const rightChannel = new Array(inputs * 2)
-		.fill(true)
-		.map((_, i) => (i % 2 === 1 ? `c${i}` : null))
-		.filter(truthy)
-		.join('+');
-
-	return `[0:a][1:a]amerge=inputs=${inputs},pan=stereo|c0=${leftChannel}|c1=${rightChannel}[a]`;
+	return `[0:a][1:a]amix=inputs=${inputs},pan=stereo[a]`;
 };

--- a/packages/renderer/src/test/ffmpeg-merge-filter.test.ts
+++ b/packages/renderer/src/test/ffmpeg-merge-filter.test.ts
@@ -3,12 +3,12 @@ import {createFfmpegMergeFilter} from '../create-ffmpeg-merge-filter';
 
 test('FFMPEG merge filters', () => {
 	expect(createFfmpegMergeFilter(2)).toBe(
-		'[0:a][1:a]amerge=inputs=2,pan=stereo|c0=c0+c2|c1=c1+c3[a]'
+		'[0:a][1:a]amix=inputs=2,pan=stereo[a]'
 	);
 	expect(createFfmpegMergeFilter(3)).toBe(
-		'[0:a][1:a]amerge=inputs=3,pan=stereo|c0=c0+c2+c4|c1=c1+c3+c5[a]'
+		'[0:a][1:a]amix=inputs=3,pan=stereo[a]'
 	);
 	expect(createFfmpegMergeFilter(4)).toBe(
-		'[0:a][1:a]amerge=inputs=4,pan=stereo|c0=c0+c2+c4+c6|c1=c1+c3+c5+c7[a]'
+		'[0:a][1:a]amix=inputs=4,pan=stereo[a]'
 	);
 });


### PR DESCRIPTION
FFmpeg would swallow a clip at the end when merging the audio - for repro, concat these 4 files using mix instead of merge:

[merge-audio-failure.zip](https://github.com/remotion-dev/remotion/files/10872477/merge-audio-failure.zip)
