### PR TITLE
docs: tailwindcss install missing deps; npm dev only install

### DIFF
--- a/packages/docs/docs/tailwind.md
+++ b/packages/docs/docs/tailwind.md
@@ -60,7 +60,7 @@ values={[
 <TabItem value="npm">
 
 ```bash
-npm i postcss-loader postcss postcss-preset-env tailwindcss autoprefixer
+npm i -D postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-loader style-loader
 ```
 
   </TabItem>
@@ -68,14 +68,14 @@ npm i postcss-loader postcss postcss-preset-env tailwindcss autoprefixer
   <TabItem value="yarn">
 
 ```bash
-yarn add postcss-loader postcss postcss-preset-env tailwindcss autoprefixer
+yarn add -D postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-loader style-loader
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```bash
-pnpm i postcss-loader postcss postcss-preset-env tailwindcss autoprefixer
+pnpm i -D postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-loader style-loader
 ```
 
   </TabItem>


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Setting up tailwindcss in existing projects always resulted in errors and I usually brute-forced my way into making it work. But today I tried to track what changes I made to make it work.

Turns out the docs were missing key dependencies, so added those.

Gist of the PR:

- Converted npm install to npm dev dependency installs, just like how they were in the tailwindcss starter template
- Added missing deps which caused errors