### PR TITLE
revert moving webpackoverridefn to bundler

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -1,13 +1,13 @@
 import fs, {promises} from 'fs';
 import os from 'os';
 import path from 'path';
+import type {WebpackOverrideFn} from 'remotion';
 import {promisify} from 'util';
 import webpack from 'webpack';
 import {isMainThread} from 'worker_threads';
 import {copyDir} from './copy-dir';
 import {indexHtml} from './index-html';
 import {readRecursively} from './read-recursively';
-import type {WebpackOverrideFn} from './types';
 import {webpackConfig} from './webpack-config';
 
 const promisified = promisify(webpack);

--- a/packages/bundler/src/index.ts
+++ b/packages/bundler/src/index.ts
@@ -1,7 +1,6 @@
 import {getConfig} from './bundle';
 import {indexHtml} from './index-html';
 import {readRecursively} from './read-recursively';
-import type {WebpackOverrideFn} from './types';
 import {cacheExists, clearCache} from './webpack-cache';
 import {webpackConfig} from './webpack-config';
 import esbuild = require('esbuild');
@@ -17,12 +16,6 @@ export const BundlerInternals = {
 	readRecursively,
 };
 
+export {WebpackConfiguration, WebpackOverrideFn} from 'remotion';
 export {bundle, BundleOptions, LegacyBundleOptions} from './bundle';
-export {WebpackConfiguration, WebpackOverrideFn} from './types';
 export {webpack};
-
-declare global {
-	interface RemotionBundlingOptions {
-		readonly overrideWebpackConfig: (f: WebpackOverrideFn) => void;
-	}
-}

--- a/packages/bundler/src/types.ts
+++ b/packages/bundler/src/types.ts
@@ -1,7 +1,0 @@
-import webpack = require('webpack');
-
-export type WebpackConfiguration = webpack.Configuration;
-
-export type WebpackOverrideFn = (
-	currentConfiguration: WebpackConfiguration
-) => WebpackConfiguration;

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -1,11 +1,11 @@
 import {createHash} from 'crypto';
 import ReactDOM from 'react-dom';
+import type {WebpackConfiguration, WebpackOverrideFn} from 'remotion';
 import {Internals} from 'remotion';
 import webpack, {ProgressPlugin} from 'webpack';
 import type {LoaderOptions} from './esbuild-loader/interfaces';
 import {ReactFreshWebpackPlugin} from './fast-refresh';
 import {jsonStringifyWithCircularReferences} from './stringify-with-circular-references';
-import type {WebpackConfiguration, WebpackOverrideFn} from './types';
 import {getWebpackCacheName} from './webpack-cache';
 import esbuild = require('esbuild');
 
@@ -63,7 +63,7 @@ export const webpackConfig = ({
 	remotionRoot: string;
 	poll: number | null;
 }): [string, WebpackConfiguration] => {
-	const conf: webpack.Configuration = webpackOverride({
+	const conf: WebpackConfiguration = webpackOverride({
 		optimization: {
 			minimize: false,
 		},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
 		"rimraf": "^3.0.2",
 		"rollup": "^2.70.1",
 		"typescript": "^4.7.0",
+		"webpack": "5.74.0",
 		"vitest": "0.24.3"
 	},
 	"keywords": [

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,6 +2,7 @@
  * The configuration has moved to @remotion/cli.
  * For the moment the type definitions are going to stay here
  */
+import type {Configuration} from 'webpack';
 
 type Concurrency = number | null;
 type BrowserExecutable = string | null;
@@ -21,6 +22,12 @@ type CodecOrUndefined =
 	| 'gif'
 	| undefined;
 type Crf = number | undefined;
+
+export type WebpackConfiguration = Configuration;
+
+export type WebpackOverrideFn = (
+	currentConfiguration: WebpackConfiguration
+) => WebpackConfiguration;
 
 // New config format: Add new options only here.
 type FlatConfig = RemotionConfigObject['Bundling'] &
@@ -61,6 +68,8 @@ declare global {
 		 * You can set an absolute path or a relative path that will be resolved from the closest package.json location.
 		 */
 		readonly setPublicDir: (publicDir: string | null) => void;
+
+		readonly overrideWebpackConfig: (f: WebpackOverrideFn) => void;
 	}
 	// Legacy config format: New options to not need to be added here.
 	interface RemotionConfigObject {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,7 +67,12 @@ export {
 	TAsset,
 	TCompMetadata,
 } from './CompositionManager.js';
-export {Config, ConfigType} from './config.js';
+export {
+	Config,
+	ConfigType,
+	WebpackConfiguration,
+	WebpackOverrideFn,
+} from './config.js';
 export {getInputProps} from './config/input-props.js';
 export {continueRender, delayRender} from './delay-render.js';
 export * from './easing.js';
@@ -109,6 +114,3 @@ export const Experimental = {
 	Null,
 	useIsPlayer,
 };
-
-export type WebpackOverrideFn =
-	"The 'WebpackOverrideFn' has been moved to '@remotion/bundler'. Update your imports and install '@remotion/bundler' if necessary.";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,7 @@ importers:
       rollup: ^2.70.1
       typescript: ^4.7.0
       vitest: 0.24.3
+      webpack: 5.74.0
     devDependencies:
       '@jonny/eslint-config': 3.0.273_t54va6jeo5lf3vtqih5uiyrm5e
       '@rollup/plugin-typescript': 8.5.0_2s5nfqwcf62746iqzotp3mpuy4
@@ -260,6 +261,7 @@ importers:
       rollup: 2.76.0
       typescript: 4.7.2
       vitest: 0.24.3_jsdom@21.1.0
+      webpack: 5.74.0
 
   packages/create-video:
     specifiers:
@@ -9480,12 +9482,12 @@ packages:
     resolution: {integrity: sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==}
     dependencies:
       '@types/eslint': 7.28.0
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.0
 
   /@types/eslint/7.28.0:
     resolution: {integrity: sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==}
     dependencies:
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.0
       '@types/json-schema': 7.0.9
 
   /@types/estree/0.0.39:
@@ -9497,7 +9499,6 @@ packages:
 
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
-    dev: false
 
   /@types/express-serve-static-core/4.17.24:
     resolution: {integrity: sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==}
@@ -10650,13 +10651,6 @@ packages:
       acorn: 8.8.1
       acorn-walk: 8.2.0
     dev: true
-
-  /acorn-import-assertions/1.8.0_acorn@8.8.0:
-    resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
-    peerDependencies:
-      acorn: ^8
-    dependencies:
-      acorn: 8.8.0
 
   /acorn-import-assertions/1.8.0_acorn@8.8.1:
     resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
@@ -24914,8 +24908,8 @@ packages:
       '@webassemblyjs/ast': 1.11.1
       '@webassemblyjs/wasm-edit': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
-      acorn: 8.8.0
-      acorn-import-assertions: 1.8.0_acorn@8.8.0
+      acorn: 8.8.1
+      acorn-import-assertions: 1.8.0_acorn@8.8.1
       browserslist: 4.21.4
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.10.0


### PR DESCRIPTION
It causes breakage. Reverting and reconsidering for V4