### PR TITLE
fix(shapes): fix shape radius on triangle and rectangle

### DIFF
--- a/packages/shapes/src/test/make-rect.test.ts
+++ b/packages/shapes/src/test/make-rect.test.ts
@@ -18,3 +18,16 @@ test('Should be able to make a rect path', () => {
 		],
 	});
 });
+
+
+test('Should handle rectangle path with radius', () => {
+	const rect = makeRect({width: 100, height: 100, cornerRadius: 20})
+
+	expect(rect).toEqual({
+		height: 100,
+		width: 100,
+		path: 'M 20 0 L 80 0 a 20 20 0 0 1 20 20 L 100 80 a 20 20 0 0 1 -20 20 L 20 100 a 20 20 0 0 1 -20 -20 L 0 20 a 20 20 0 0 1 20 -20 Z',
+		transformOrigin: '50 50',
+		instructions: expect.any(Array),
+	});
+});

--- a/packages/shapes/src/test/make-triangle.test.ts
+++ b/packages/shapes/src/test/make-triangle.test.ts
@@ -21,3 +21,38 @@ test('Should be able to make a triangle path', () => {
 		],
 	});
 });
+
+test.only('Should handle triangle path with radius', () => {
+	const rightTriangle = makeTriangle({
+		length: 100,
+		direction: 'right',
+		cornerRadius: 60
+	});
+
+	expect(rightTriangle).toEqual(
+		{
+			height: 100,
+			path: "M 0 40 L 0 40 C 0 100 0 100 51.96152422706631 70 L 34.64101615137755 80 C 86.60254037844386 50 86.60254037844386 50 34.64101615137755 20 L 51.96152422706631 30 C 0 0 0 0 0 60 Z",
+			transformOrigin: "28.867513459481287 50",
+			instructions: expect.any(Array),
+			width: 86.60254037844386,
+		});
+})
+
+
+test.only('Should handle triangle path with radius with direction up', () => {
+	const upTriangle = makeTriangle({
+		length: 100,
+		direction: 'up',
+		cornerRadius: 60
+	});
+
+	expect(upTriangle).toEqual(
+		{
+			height: 86.60254037844386,
+			instructions: expect.any(Array),
+			path: "M 30 34.64101615137755 L 30 34.64101615137755 C 0 86.60254037844386 0 86.60254037844386 60 86.60254037844386 L 40 86.60254037844386 C 100 86.60254037844386 100 86.60254037844386 70 34.64101615137755 L 80 51.96152422706631 C 50 0 50 0 20 51.96152422706631 Z",
+			transformOrigin: "50 57.735026918962575",
+			width: 100,
+		});
+})

--- a/packages/shapes/src/utils/join-points.ts
+++ b/packages/shapes/src/utils/join-points.ts
@@ -52,11 +52,12 @@ export const joinPoints = (
 					];
 				}
 
+				const shorten = shortenVector(nextPoint, cornerRadius)
 				return [
 					{
 						type: 'M',
-						x,
-						y,
+						x: shorten[0],
+						y: shorten[1],
 					},
 				];
 			}
@@ -82,7 +83,7 @@ export const joinPoints = (
 				}
 
 				const prevVectorMinusRadius = shortenVector(prevVector, cornerRadius);
-				const prevVectorLenght = scaleVectorToLength(prevVector, cornerRadius);
+				const prevVectorLength = scaleVectorToLength(prevVector, cornerRadius);
 				const nextVectorMinusRadius = scaleVectorToLength(
 					nextVector,
 					cornerRadius
@@ -105,17 +106,17 @@ export const joinPoints = (
 								rx: cornerRadius,
 								ry: cornerRadius,
 								xAxisRotation: 0,
-								dx: prevVectorLenght[0] + nextVectorMinusRadius[0],
-								dy: prevVectorLenght[1] + nextVectorMinusRadius[1],
+								dx: prevVectorLength[0] + nextVectorMinusRadius[0],
+								dy: prevVectorLength[1] + nextVectorMinusRadius[1],
 								largeArcFlag: false,
 								sweepFlag: true,
 						  }
 						: {
 								type: 'C',
 								x:
-									firstDraw[0] + prevVectorLenght[0] + nextVectorMinusRadius[0],
+									firstDraw[0] + prevVectorLength[0] + nextVectorMinusRadius[0],
 								y:
-									firstDraw[1] + prevVectorLenght[1] + nextVectorMinusRadius[1],
+									firstDraw[1] + prevVectorLength[1] + nextVectorMinusRadius[1],
 								cp1x: x,
 								cp1y: y,
 								cp2x: x,

--- a/packages/shapes/src/utils/make-rect.ts
+++ b/packages/shapes/src/utils/make-rect.ts
@@ -28,7 +28,7 @@ export const makeRect = ({
 	const instructions: Instruction[] = [
 		...joinPoints(
 			[
-				[0, 0],
+				[cornerRadius, 0],
 				[width, 0],
 				[width, height],
 				[0, height],


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Fix #1766 issue.

## Why

Border radius on shapes does not seem to work nicely with triangle and rectangle
I tried to add some unit test to make it more stable.

## How

- fixup typo in joinPoints function
- fixup Rectangle radius shapes on initial point
- fixup Triangle on right orientation.

⚠️ Triangle are not completely fixed, I may need your help on that @JonnyBurger because I don't really see what I miss to find any orientation fix for triangle.
