### PR TITLE
Allow more special characters in S3 keys

### DIFF
--- a/packages/lambda/src/shared/validate-outname.ts
+++ b/packages/lambda/src/shared/validate-outname.ts
@@ -10,9 +10,9 @@ const validateS3Key = (s3Key: string) => {
 		);
 	}
 
-	if (!s3Key.match(/^([0-9a-zA-Z-!_.*'()/]+)$/g)) {
+	if (!s3Key.match(/^([0-9a-zA-Z-!_.*'()/:]+)$/g)) {
 		throw new Error(
-			"The S3 Key must match the RegExp `/([0-9a-zA-Z-!_.*'()/]+)/g`. You passed: " +
+			"The S3 Key must match the RegExp `/([0-9a-zA-Z-!_.*'()/:]+)/g`. You passed: " +
 				s3Key +
 				'. Check for invalid characters.'
 		);

--- a/packages/lambda/src/shared/validate-outname.ts
+++ b/packages/lambda/src/shared/validate-outname.ts
@@ -10,6 +10,7 @@ const validateS3Key = (s3Key: string) => {
 		);
 	}
 
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
 	if (!s3Key.match(/^([0-9a-zA-Z-!_.*'()/:&$@=;+,?]+)/g)) {
 		throw new Error(
 			"The S3 Key must match the RegExp `/^([0-9a-zA-Z-!_.*'()/:&$@=;+,?]+)/g`. You passed: " +

--- a/packages/lambda/src/shared/validate-outname.ts
+++ b/packages/lambda/src/shared/validate-outname.ts
@@ -10,9 +10,9 @@ const validateS3Key = (s3Key: string) => {
 		);
 	}
 
-	if (!s3Key.match(/^([0-9a-zA-Z-!_.*'()/:]+)$/g)) {
+	if (!s3Key.match(/^([0-9a-zA-Z-!_.*'()/:&$@=;+,?]+)/g)) {
 		throw new Error(
-			"The S3 Key must match the RegExp `/([0-9a-zA-Z-!_.*'()/:]+)/g`. You passed: " +
+			"The S3 Key must match the RegExp `/^([0-9a-zA-Z-!_.*'()/:&$@=;+,?]+)/g`. You passed: " +
 				s3Key +
 				'. Check for invalid characters.'
 		);

--- a/packages/lambda/src/test/unit/expected-out-name.test.ts
+++ b/packages/lambda/src/test/unit/expected-out-name.test.ts
@@ -113,3 +113,18 @@ test('Should allow outName an outname with a slash', () => {
 		renderBucketName: 'remotionlambda-98fsduf',
 	});
 });
+
+test('Should allow outName an outname with colon', () => {
+	const newRenderMetadata: RenderMetadata = {
+		...testRenderMetadata,
+		codec: null,
+		audioCodec: null,
+		type: 'still',
+		outName: 'ap-east-1:xxxxxx/video/XXXXX-0b9ba84XXXX.mp4',
+	};
+	expect(getExpectedOutName(newRenderMetadata, bucketName, null)).toEqual({
+		customCredentials: null,
+		key: 'renders/9n8dsfafs/ap-east-1:xxxxxx/video/XXXXX-0b9ba84XXXX.mp4',
+		renderBucketName: 'remotionlambda-98fsduf',
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12305,8 +12305,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
 ### Background
I've been working with [AWS Amplify](https://docs.amplify.aws/lib/storage/download/q/platform/js/) specifically on storage functionality. To enhance the security of the application, it should only authorise users to access and download their own rendered videos, which the remotion lambda will move the file to user s3 directory.

### Problem
For some reason, Amplify user identity id is in this format, **ap-east-1:xxxxxxm** notice that there is a colon in between or after the aws region. I've noticed that their is a function that validates the s3 keys.
```{

  type: 'error',
  renderId: 'XXXXXXX',
  expectedBucketOwner: 'XXXXXXX',
  bucketName: 'XXXXXXX',
  errors: [
    {
      message: "The S3 Key must match the RegExp `/([0-9a-zA-Z-!_.*'()/]+)/g`. You passed: **ap-southeast-2:510e9b30-a747-4225-XXXXXXXXXprivate/xxxxxxxxxxx4e.mp4.** Check for invalid characters.",
      name: 'Error',
      stack: "Error: The S3 Key must match the RegExp `/([0-9a-zA-Z-!_.*'()/]+)/g`. You passed: ap-southeast-2:510e9b30-a747-4225-bc75-4835c2314344/private/0d267014-f0ec-4e84-9980-731af28ac8e5/video/b6c30ce5-a0db-43a4-8bac-0b9ba84bbb4e.mp4. Check for invalid characters.\n" +
        '    at validateS3Key (/var/task/index.js:186608:11)\n' +
        '    at validateOutname (/var/task/index.js:186629:3)\n' +
        '    at innerLaunchHandler (/var/task/index.js:188727:3)\n' +
        '    at processTicksAndRejections (internal/process/task_queues.js:95:5)\n' +
        '    at async launchHandler (/var/task/index.js:189084:5)'
    }
  ]
}
```



### Solution
I propose to fix the issue by allowing colon or : , in the list of allowed characters for the s3 key. The fix is contained in the merge request.

