### PR TITLE
docs: add font awesome and other sources in contributing guide

### DIFF
--- a/packages/docs/docs/contributing/feature.md
+++ b/packages/docs/docs/contributing/feature.md
@@ -13,10 +13,10 @@ See the [CONTRIBUTING.md](https://github.com/remotion-dev/remotion/blob/main/CON
 ## Third party services Remotion uses
 
 Remotion uses third services for various things, such as icons.
+If you are implementing a feature that uses one of these services, try accessing the service yourself or reach out if you need help with access.
 
 - [Font Awesome](https://fontawesome.com/) v(?@JonnyBurger) - We use font awesome for icons in the remotion previewer UI.
 
-If you are implementing a feature that uses one of these services, try accessing the service yourself or reach out if you need help with access.
 
 ## What's important to us
 

--- a/packages/docs/docs/contributing/feature.md
+++ b/packages/docs/docs/contributing/feature.md
@@ -13,10 +13,10 @@ See the [CONTRIBUTING.md](https://github.com/remotion-dev/remotion/blob/main/CON
 ## Third party services Remotion uses
 
 Remotion uses third services for various things, such as icons.
-If you are implementing a feature that uses one of these services, try accessing the service yourself or reach out if you need help with access.
 
 - [Font Awesome](https://fontawesome.com/) v(?@JonnyBurger) - We use font awesome for icons in the remotion previewer UI.
 
+If you are implementing a feature that uses one of these services, try accessing the service yourself or reach out if you need help with access.
 
 ## What's important to us
 

--- a/packages/docs/docs/contributing/feature.md
+++ b/packages/docs/docs/contributing/feature.md
@@ -10,6 +10,14 @@ We are happy to accept contributions to the Remotion project that implement new 
 
 See the [CONTRIBUTING.md](https://github.com/remotion-dev/remotion/blob/main/CONTRIBUTING.md) file for instructions on how to set up the project.
 
+## Third party services Remotion uses
+
+Remotion uses third services for various things, such as icons.
+
+- [Font Awesome](https://fontawesome.com/) v(?@JonnyBurger) - We use font awesome for icons in the remotion previewer UI.
+
+If you are implementing a feature that uses one of these services, try accessing the service yourself or reach out if you need help with access.
+
 ## What's important to us
 
 - **Planning**: Signal beforehand that you would like to propose the feature by opening an issue and mentioning that you would like to work on it.  


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

While implementing the toggle for disabling panning, I needed to add a disable-panning icon in the toolbar in the remotion previewer. However, the docs didn't indicate where the icons would be sourced from. Even though the icon didn't make it to the final PR, adding info about 3p sources remotion uses would be helpful for contributors and would save just a few messages on discord 😊