### PR TITLE
fix: clip looped tracks that are too wide

### DIFF
--- a/packages/cli/src/editor/components/Timeline/TimelineTracks.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineTracks.tsx
@@ -32,6 +32,8 @@ export const TimelineTracks: React.FC<{
 	const inner: React.CSSProperties = useMemo(() => {
 		return {
 			height: TIMELINE_LAYER_HEIGHT + TIMELINE_BORDER * 2,
+			position: 'relative',
+			overflow: 'hidden',
 		};
 	}, []);
 

--- a/packages/cli/src/editor/components/Timeline/TimelineTracks.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineTracks.tsx
@@ -32,8 +32,6 @@ export const TimelineTracks: React.FC<{
 	const inner: React.CSSProperties = useMemo(() => {
 		return {
 			height: TIMELINE_LAYER_HEIGHT + TIMELINE_BORDER * 2,
-			position: 'relative',
-			overflow: 'hidden',
 		};
 	}, []);
 

--- a/packages/cli/src/editor/helpers/get-timeline-sequence-layout.ts
+++ b/packages/cli/src/editor/helpers/get-timeline-sequence-layout.ts
@@ -21,6 +21,7 @@ const getWidthOfTrack = ({
 		durationInFrames === Infinity || lastFrame === 0
 			? fullWidth
 			: (spatialDuration / lastFrame) * fullWidth;
+
 	return base - SEQUENCE_BORDER_WIDTH + nonNegativeMarginLeft;
 };
 
@@ -41,12 +42,13 @@ export const getTimelineSequenceLayout = ({
 }) => {
 	const maxMediaSequenceDuration =
 		(maxMediaDuration ?? Infinity) - startFromMedia;
+	const lastFrame = (video.durationInFrames ?? 1) - 1;
 	let spatialDuration = Math.min(
 		maxMediaSequenceDuration,
-		durationInFrames - 1
+		durationInFrames - 1,
+		lastFrame - startFrom
 	);
 
-	const lastFrame = (video.durationInFrames ?? 1) - 1;
 	const shouldAddHalfAFrameAtEnd = startFrom + durationInFrames < lastFrame;
 	const shouldAddHalfAFrameAtStart = startFrom > 0;
 	if (shouldAddHalfAFrameAtEnd) {


### PR DESCRIPTION
Using Remotion 3.3.77

Using the [technique for looping an offthread video](https://www.remotion.dev/docs/offthreadvideo#looping-a-video) produces a slightly annoying bug as seen in the video.

https://user-images.githubusercontent.com/616906/225666205-05ac4dc0-66a3-45c5-9cc7-f392005ed901.mp4

The PR contains a fix that solves the problem, but very little work has been done to ensure it doesn't interact in some non-desirable way with other timeline track components.