### PR TITLE
chore: handle Minified React error #306

### DIFF
--- a/packages/cli/src/handle-common-errors.ts
+++ b/packages/cli/src/handle-common-errors.ts
@@ -49,4 +49,13 @@ export const handleCommonError = async (err: Error) => {
 			)
 		);
 	}
+
+	if (err.message.includes("Minified React error #306")) {
+		const componentName = err.message.match(/<\w+>/)?.[0] || ""
+		const errorMsg = `Error: Failed to render ${componentName}. Please check that it is imported correctly.`
+		Log.error(errorMsg)
+		Log.info(
+			'💡 You can try taking a look at the path of the component that you are referencing. It could be the cause of this error.'
+		)
+	}
 };

--- a/packages/cli/src/handle-common-errors.ts
+++ b/packages/cli/src/handle-common-errors.ts
@@ -1,6 +1,7 @@
 import {chalk} from './chalk';
 import {Log} from './log';
 import {printError} from './print-error';
+import {truthy} from './truthy';
 
 export const handleCommonError = async (err: Error) => {
 	await printError(err);
@@ -50,12 +51,27 @@ export const handleCommonError = async (err: Error) => {
 		);
 	}
 
-	if (err.message.includes("Minified React error #306")) {
-		const componentName = err.message.match(/<\w+>/)?.[0] || ""
-		const errorMsg = `Error: Failed to render ${componentName}. Please check that it is imported correctly.`
-		Log.error(errorMsg)
+	if (err.message.includes('Minified React error #306')) {
+		const componentName = err.message.match(/<\w+>/)?.[0];
 		Log.info(
-			'💡 You can try taking a look at the path of the component that you are referencing. It could be the cause of this error.'
-		)
+			[
+				'💡 This error indicates that the component',
+				componentName ? `(${componentName})` : null,
+				'you are trying to render is not imported correctly.',
+			]
+				.filter(truthy)
+				.join(' ')
+		);
+
+		Log.info();
+		Log.info(
+			'   Check the root file and ensure that the component is not undefined.'
+		);
+		Log.info(
+			'   Oftentimes, this happens if the component is missing the `export` keyword'
+		);
+		Log.info(
+			'   or if the component was renamed and the import statement not properly adjusted.'
+		);
 	}
 };


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

@JonnyBurger, is there a way I can test this?

I added a little change to the error handling to make it more intuitive though. I copied some RegEx somewhere 😃 that will match the component name by checking if there's any `<` or `/>` in the error message and it extracts the text in between it &mdash; which sorta translates to the component name.

```ts
const componentName = err.message.match(/<\w+>/)?.[0] || ""
const errorMsg = `Error: Failed to render ${componentName}. Please check that it is imported correctly.`
```

Please review and let me know If you'd love me to make any change.