### PR TITLE
Updated setup links for code sharing

### DIFF
--- a/packages/docs/docs/brownfield-installation.md
+++ b/packages/docs/docs/brownfield-installation.md
@@ -9,7 +9,7 @@ crumb: "Brownfield integration"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Remotion can be installed into any Node.JS based project, such as Create React App, Next.JS apps as well as server-only projects such as an Express API. Get started by adding the following packages:
+Remotion can be installed into existing projects, such as [Next.JS](https://nextjs.org/), [Remix](https://remix.run/), [Vite](https://vitejs.dev/guide/) or [Create React App](https://create-react-app.dev/), as well as server-only projects that run on Node.JS. Get started by adding the following packages:
 
 <Tabs
 defaultValue="npm"

--- a/packages/docs/docs/player/player-integration.md
+++ b/packages/docs/docs/player/player-integration.md
@@ -16,7 +16,11 @@ Remotion and your React app use a different Webpack config. Therefore, if you wa
 
 ## Setup
 
-Set up a React project with your preferred setup, such as [Create React App](https://reactjs.org/docs/create-a-new-react-app.html) or [Next.JS](https://nextjs.org/learn/basics/create-nextjs-app/setup).
+Set up a React project with your preferred setup from the [Official React docs](https://react.dev/learn/start-a-new-react-project), such as [Next.js](https://nextjs.org/learn/basics/create-nextjs-app/setup) or [Remix](https://remix.run/docs/en/main/tutorials/blog).
+
+:::info
+While you can still use [Create React App](https://create-react-app.dev), it is not being actively recommended by the React team anymore.
+:::
 
 When your project is setup, add the necessary Remotion dependencies:
 

--- a/packages/docs/docs/player/player-integration.md
+++ b/packages/docs/docs/player/player-integration.md
@@ -16,9 +16,13 @@ Remotion and your React app use a different Webpack config. Therefore, if you wa
 
 ## Setup
 
-Set up a React project with your preferred setup from the [Official React docs](https://react.dev/learn/start-a-new-react-project), such as [Next.js](https://nextjs.org/learn/basics/create-nextjs-app/setup) or [Remix](https://remix.run/docs/en/main/tutorials/blog).
+Set up a React project with your preferred setup from the [Official React docs](https://react.dev/learn/start-a-new-react-project). Popular choices are:
 
-:::info
+- [Next.js](https://nextjs.org/learn/basics/create-nextjs-app/setup)
+- [Remix](https://remix.run/docs/en/main/tutorials/blog)
+- [Vite](https://vitejs.dev/guide/)
+
+:::note
 While you can still use [Create React App](https://create-react-app.dev), it is not being actively recommended by the React team anymore.
 :::
 


### PR DESCRIPTION
This PR updates the docs page at https://www.remotion.dev/docs/player/integration

The [create-react-app](https://reactjs.org/docs/create-a-new-react-app.html) link mentioned in the above docs now redirects to the new React docs, which recommend using a framework for a new React project, instead of CRA. So Next.js and Remix are mentioned, while still keeping a note for create-react-app users with the updated link.

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
