### PR TITLE
remove "runtime" from @babel/preset-typescript config

### DIFF
--- a/packages/babel-loader/src/index.ts
+++ b/packages/babel-loader/src/index.ts
@@ -46,7 +46,6 @@ export const replaceLoadersWithBabel = (
 										[
 											require.resolve('@babel/preset-typescript'),
 											{
-												runtime: 'automatic',
 												isTSX: true,
 												allExtensions: true,
 											},


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
Babel's maintainer here. The `runtime` option is invalid and never supported in `@babel/preset-typescript` ([docs](https://babel.dev/docs/babel-preset-typescript) here). Currently Babel 7 allows unrecognized option name in presets, in Babel 8 we will throw on invalid usage. Hence removed the option here so we can be future-proof.