### PR TITLE
`@remotion/lambda`: `dumpBrowserLogs` option for renderMediaOnLambda(), renderStillOnLambda() and getCompositionsOnLambda()

### DIFF
--- a/packages/docs/docs/lambda/getcompositionsonlambda.md
+++ b/packages/docs/docs/lambda/getcompositionsonlambda.md
@@ -106,6 +106,16 @@ _available from v3.3.42_
 
 Specify a specific bucket name to be used. [This is not recommended](/docs/lambda/multiple-buckets), instead let Remotion discover the right bucket automatically.
 
+### `logLevel?`
+
+One of `verbose`, `info`, `warn`, `error`. Determines how much is being logged inside the Lambda function. Logs can be read through the CloudWatch URL that this function returns.
+
+If the `logLevel` is set to `verbose`, the `dumpBrowserLogs` flag will also be enabled.
+
+### `dumpBrowserLogs?` <AvailableFrom v="3.3.83" />
+
+If set to true, all `console` statements from the headless browser will be forwarded to the CloudWatch logs.
+
 ## Return value
 
 Returns a promise that resolves to an array of available compositions. Example value:

--- a/packages/docs/docs/lambda/php.md
+++ b/packages/docs/docs/lambda/php.md
@@ -98,6 +98,7 @@ $params = array(
     "bucketName" => null,
     "audioCodec" => null,
     "forceBucketName" => $bucketName,
+    "dumpBrowserLogs" => false,
 );
 
 try {

--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -304,6 +304,18 @@ Specify a specific bucket name to be used. [This is not recommended](/docs/lambd
 
 [See here for detailed instructions on how to set up your webhook](/docs/lambda/webhooks).
 
+### `logLevel?`
+
+One of `verbose`, `info`, `warn`, `error`. Determines how much is being logged inside the Lambda function. Logs can be read through the CloudWatch URL that this function returns.
+
+If the `logLevel` is set to `verbose`, the Lambda function will not clean up artifacts, to aid debugging. Do not use it unless you are debugging a problem.
+
+If the `logLevel` is set to `verbose`, the `dumpBrowserLogs` flag will also be enabled.
+
+### `dumpBrowserLogs?` <AvailableFrom v="3.3.83" />
+
+If set to true, all `console` statements from the headless browser will be forwarded to the CloudWatch logs.
+
 ## Return value
 
 Returns a promise resolving to an object containing two properties: `renderId`, `bucketName`, `cloudWatchLogs`. Those are useful for passing to `getRenderProgress()`

--- a/packages/docs/docs/lambda/renderstillonlambda.md
+++ b/packages/docs/docs/lambda/renderstillonlambda.md
@@ -180,11 +180,21 @@ Accepted values:
 The default for Lambda is `"swangle"`, but `null` elsewhere.
 :::
 
-### `forceBucketName`
+### `forceBucketName?` <AvailableFrom v="3.3.42" />
 
-_optional, available from v3.3.42_
+_optional_
 
 Specify a specific bucket name to be used. [This is not recommended](/docs/lambda/multiple-buckets), instead let Remotion discover the right bucket automatically.
+
+### `logLevel?`
+
+One of `verbose`, `info`, `warn`, `error`. Determines how much is being logged inside the Lambda function. Logs can be read through the CloudWatch URL that this function returns.
+
+If the `logLevel` is set to `verbose`, the `dumpBrowserLogs` flag will also be enabled.
+
+### `dumpBrowserLogs?` <AvailableFrom v="3.3.83" />
+
+If set to true, all `console` statements from the headless browser will be forwarded to the CloudWatch logs.
 
 ## Return value
 

--- a/packages/lambda/src/api/get-compositions-on-lambda.ts
+++ b/packages/lambda/src/api/get-compositions-on-lambda.ts
@@ -16,6 +16,7 @@ export type GetCompositionsOnLambdaInput = {
 	logLevel?: LogLevel;
 	timeoutInMilliseconds?: number;
 	forceBucketName?: string;
+	dumpBrowserLogs?: boolean;
 };
 
 export type GetCompositionsOnLambdaOutput = TCompMetadata[];
@@ -31,6 +32,7 @@ export type GetCompositionsOnLambdaOutput = TCompMetadata[];
  * @param params.logLevel The log level of the Lambda function
  * @param params.timeoutInMilliseconds The timeout of the Lambda function
  * @param params.chromiumOptions The options to pass to Chromium
+ * @param params.dumpBrowserLogs Whether to print browser logs to CloudWatch
  * @returns The compositions
  */
 export const getCompositionsOnLambda = async ({
@@ -43,6 +45,7 @@ export const getCompositionsOnLambda = async ({
 	logLevel,
 	timeoutInMilliseconds,
 	forceBucketName: bucketName,
+	dumpBrowserLogs,
 }: GetCompositionsOnLambdaInput): Promise<GetCompositionsOnLambdaOutput> => {
 	const serializedInputProps = await serializeInputProps({
 		inputProps,
@@ -64,6 +67,7 @@ export const getCompositionsOnLambda = async ({
 				timeoutInMilliseconds: timeoutInMilliseconds ?? 30000,
 				version: VERSION,
 				bucketName: bucketName ?? null,
+				dumpBrowserLogs: dumpBrowserLogs ?? false,
 			},
 			region,
 		});

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -60,6 +60,7 @@ export type RenderMediaOnLambdaInput = {
 	rendererFunctionName?: string | null;
 	forceBucketName?: string;
 	audioCodec?: AudioCodec | null;
+	dumpBrowserLogs?: boolean;
 };
 
 export type RenderMediaOnLambdaOutput = {
@@ -125,6 +126,7 @@ export const renderMediaOnLambda = async ({
 	rendererFunctionName,
 	forceBucketName: bucketName,
 	audioCodec,
+	dumpBrowserLogs,
 }: RenderMediaOnLambdaInput): Promise<RenderMediaOnLambdaOutput> => {
 	const actualCodec = validateLambdaCodec(codec);
 	validateServeUrl(serveUrl);
@@ -179,6 +181,7 @@ export const renderMediaOnLambda = async ({
 				forceWidth: forceWidth ?? null,
 				bucketName: bucketName ?? null,
 				audioCodec: audioCodec ?? null,
+				dumpBrowserLogs: dumpBrowserLogs ?? false,
 			},
 			region,
 		});

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -87,6 +87,7 @@ export type RenderMediaOnLambdaOutput = {
  * @param params.maxRetries How often rendering a chunk may fail before the media render gets aborted. Default "1"
  * @param params.logLevel Level of logging that Lambda function should perform. Default "info".
  * @param params.webhook Configuration for webhook called upon completion or timeout of the render.
+ * @param params.dumpBrowserLogs Whether to print browser logs to CloudWatch
  * @returns {Promise<RenderMediaOnLambdaOutput>} See documentation for detailed structure
  */
 

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -59,6 +59,7 @@ export type RenderStillOnLambdaOutput = {
  * @param params.maxRetries How often rendering a chunk may fail before the video render gets aborted.
  * @param params.frame Which frame should be used for the still image. Default 0.
  * @param params.privacy Whether the item in the S3 bucket should be public. Possible values: `"private"` and `"public"`
+ * @param params.dumpBrowserLogs Whether to print browser logs to CloudWatch.
  * @returns {Promise<RenderStillOnLambdaOutput>} See documentation for exact response structure.
  */
 

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -33,6 +33,7 @@ export type RenderStillOnLambdaInput = {
 	forceWidth?: number | null;
 	forceHeight?: number | null;
 	forceBucketName?: string;
+	dumpBrowserLogs?: boolean;
 };
 
 export type RenderStillOnLambdaOutput = {
@@ -82,6 +83,7 @@ export const renderStillOnLambda = async ({
 	forceHeight,
 	forceWidth,
 	forceBucketName,
+	dumpBrowserLogs,
 }: RenderStillOnLambdaInput): Promise<RenderStillOnLambdaOutput> => {
 	const serializedInputProps = await serializeInputProps({
 		inputProps,
@@ -115,6 +117,7 @@ export const renderStillOnLambda = async ({
 				forceHeight: forceHeight ?? null,
 				forceWidth: forceWidth ?? null,
 				bucketName: forceBucketName ?? null,
+				dumpBrowserLogs: dumpBrowserLogs ?? false,
 			},
 			region,
 		});

--- a/packages/lambda/src/functions/compositions.ts
+++ b/packages/lambda/src/functions/compositions.ts
@@ -40,7 +40,11 @@ export const compositionsHandler = async (
 				region,
 			}).then((b) => b.bucketName),
 		getBrowserInstance(
-			RenderInternals.isEqualOrBelowLogLevel(lambdaParams.logLevel, 'verbose'),
+			lambdaParams.dumpBrowserLogs ??
+				RenderInternals.isEqualOrBelowLogLevel(
+					lambdaParams.logLevel,
+					'verbose'
+				),
 			lambdaParams.chromiumOptions ?? {}
 		),
 	]);

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -279,6 +279,7 @@ const innerLaunchHandler = async (params: LambdaPayload, options: Options) => {
 			launchFunctionConfig: {
 				version: VERSION,
 			},
+			dumpBrowserLogs: params.dumpBrowserLogs,
 		};
 		return payload;
 	});

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -159,10 +159,9 @@ const renderHandler = async (
 			serveUrl: params.serveUrl,
 			quality: params.quality,
 			envVariables: params.envVariables,
-			dumpBrowserLogs: RenderInternals.isEqualOrBelowLogLevel(
-				params.logLevel,
-				'verbose'
-			),
+			dumpBrowserLogs:
+				params.dumpBrowserLogs ??
+				RenderInternals.isEqualOrBelowLogLevel(params.logLevel, 'verbose'),
 			verbose: RenderInternals.isEqualOrBelowLogLevel(
 				params.logLevel,
 				'verbose'

--- a/packages/lambda/src/functions/start.ts
+++ b/packages/lambda/src/functions/start.ts
@@ -93,6 +93,7 @@ export const startHandler = async (params: LambdaPayload, options: Options) => {
 		forceWidth: params.forceWidth,
 		rendererFunctionName: params.rendererFunctionName,
 		audioCodec: params.audioCodec,
+		dumpBrowserLogs: params.dumpBrowserLogs,
 	};
 	await getLambdaClient(getCurrentRegionInFunction()).send(
 		new InvokeCommand({

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -159,7 +159,9 @@ const innerStillHandler = async (
 		composition,
 		output: outputPath,
 		serveUrl,
-		dumpBrowserLogs: false,
+		dumpBrowserLogs:
+			lambdaParams.dumpBrowserLogs ??
+			RenderInternals.isEqualOrBelowLogLevel(lambdaParams.logLevel, 'verbose'),
 		envVariables: lambdaParams.envVariables,
 		frame: RenderInternals.convertToPositiveFrameIndex({
 			frame: lambdaParams.frame,

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -255,6 +255,7 @@ export type LambdaPayloads = {
 		forceHeight: number | null;
 		forceWidth: number | null;
 		bucketName: string | null;
+		dumpBrowserLogs: boolean;
 	};
 	launch: {
 		rendererFunctionName: string | null;
@@ -292,6 +293,7 @@ export type LambdaPayloads = {
 		webhook: WebhookOption;
 		forceHeight: number | null;
 		forceWidth: number | null;
+		dumpBrowserLogs: boolean;
 	};
 	status: {
 		type: LambdaRoutines.status;
@@ -335,6 +337,7 @@ export type LambdaPayloads = {
 		launchFunctionConfig: {
 			version: string;
 		};
+		dumpBrowserLogs: boolean;
 	};
 	still: {
 		type: LambdaRoutines.still;
@@ -358,6 +361,7 @@ export type LambdaPayloads = {
 		forceHeight: number | null;
 		forceWidth: number | null;
 		bucketName: string | null;
+		dumpBrowserLogs: boolean;
 	};
 	compositions: {
 		type: LambdaRoutines.compositions;

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -373,6 +373,7 @@ export type LambdaPayloads = {
 		timeoutInMilliseconds: number;
 		serveUrl: string;
 		bucketName: string | null;
+		dumpBrowserLogs: boolean;
 	};
 };
 

--- a/packages/lambda/src/test/integration/renders/gif.test.ts
+++ b/packages/lambda/src/test/integration/renders/gif.test.ts
@@ -69,6 +69,7 @@ test('Should make a distributed GIF', async () => {
 			rendererFunctionName: null,
 			bucketName: null,
 			audioCodec: null,
+			dumpBrowserLogs: false,
 		},
 		extraContext
 	);

--- a/packages/lambda/src/test/integration/renders/old-version.test.ts
+++ b/packages/lambda/src/test/integration/renders/old-version.test.ts
@@ -66,6 +66,7 @@ test('Should fail when using an incompatible version', async () => {
 				rendererFunctionName: null,
 				bucketName: null,
 				audioCodec: null,
+				dumpBrowserLogs: false,
 			},
 			extraContext
 		)

--- a/packages/lambda/src/test/integration/renders/other-bucket.test.ts
+++ b/packages/lambda/src/test/integration/renders/other-bucket.test.ts
@@ -72,6 +72,7 @@ test('Should be able to render to another bucket', async () => {
 			rendererFunctionName: null,
 			bucketName: null,
 			audioCodec: null,
+			dumpBrowserLogs: false,
 		},
 		extraContext
 	);

--- a/packages/lambda/src/test/integration/renders/silent-audio.test.ts
+++ b/packages/lambda/src/test/integration/renders/silent-audio.test.ts
@@ -69,6 +69,7 @@ test('Should add silent audio if there is no audio', async () => {
 			rendererFunctionName: null,
 			bucketName: null,
 			audioCodec: null,
+			dumpBrowserLogs: false,
 		},
 		extraContext
 	);

--- a/packages/lambda/src/test/integration/renders/transparent-webm.test.ts
+++ b/packages/lambda/src/test/integration/renders/transparent-webm.test.ts
@@ -71,6 +71,7 @@ test('Should make a transparent video', async () => {
 			rendererFunctionName: null,
 			bucketName: null,
 			audioCodec: null,
+			dumpBrowserLogs: false,
 		},
 		extraContext
 	);

--- a/packages/lambda/src/test/integration/webhooks.test.ts
+++ b/packages/lambda/src/test/integration/webhooks.test.ts
@@ -108,6 +108,7 @@ describe('Webhooks', () => {
 				rendererFunctionName: null,
 				bucketName: null,
 				audioCodec: null,
+				dumpBrowserLogs: false,
 			},
 			extraContext
 		);
@@ -186,6 +187,7 @@ describe('Webhooks', () => {
 				forceWidth: null,
 				rendererFunctionName: null,
 				audioCodec: null,
+				dumpBrowserLogs: false,
 			},
 			{
 				...extraContext,


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
