### PR TITLE
Fix frame accuracy regression in Chrome 112

### DIFF
--- a/packages/core/src/video/get-current-time.ts
+++ b/packages/core/src/video/get-current-time.ts
@@ -39,7 +39,9 @@ export const getMediaTime = ({
 		startFrom,
 	});
 
-	const isChrome = window.navigator.userAgent.match(/Chrome\/([0-9]+)/);
+	const isChrome =
+		typeof window !== 'undefined' &&
+		window.navigator.userAgent.match(/Chrome\/([0-9]+)/);
 	if (
 		isChrome &&
 		Number(isChrome[1]) < 112 &&

--- a/packages/core/src/video/get-current-time.ts
+++ b/packages/core/src/video/get-current-time.ts
@@ -39,20 +39,21 @@ export const getMediaTime = ({
 		startFrom,
 	});
 
-	if (src.endsWith('webm')) {
-		// For WebM videos, we need to add a little bit of shift to get the right frame.
-		const msPerFrame = 1000 / fps;
-		const msShift = msPerFrame / 2;
-		return (expectedFrame * msPerFrame + msShift) / 1000;
-	}
-
-	if (mediaType === 'video') {
+	const isChrome = window.navigator.userAgent.match(/Chrome\/([0-9]+)/);
+	if (
+		isChrome &&
+		Number(isChrome[1]) < 112 &&
+		mediaType === 'video' &&
+		src.endsWith('.mp4')
+	) {
 		// In Chrome, for MP4s, if 30fps, the first frame is still displayed at 0.033333
 		// even though after that it increases by 0.033333333 each.
 		// So frame = 0 in Remotion is like frame = 1 for the browser
 		return (expectedFrame + 1) / fps;
 	}
 
-	// For audio, we don't do any shift correction
-	return expectedFrame / fps;
+	// For WebM videos, we need to add a little bit of shift to get the right frame.
+	const msPerFrame = 1000 / fps;
+	const msShift = msPerFrame / 2;
+	return (expectedFrame * msPerFrame + msShift) / 1000;
 };

--- a/packages/lambda/src/functions/start.ts
+++ b/packages/lambda/src/functions/start.ts
@@ -94,6 +94,7 @@ export const startHandler = async (params: LambdaPayload, options: Options) => {
 		rendererFunctionName: params.rendererFunctionName,
 		audioCodec: params.audioCodec,
 	};
+	console.log('invoking lambda', payload);
 	await getLambdaClient(getCurrentRegionInFunction()).send(
 		new InvokeCommand({
 			FunctionName: process.env.AWS_LAMBDA_FUNCTION_NAME,

--- a/packages/renderer/src/assets/download-and-map-assets-to-file.ts
+++ b/packages/renderer/src/assets/download-and-map-assets-to-file.ts
@@ -29,6 +29,7 @@ const waitForAssetToBeDownloaded = ({
 	downloadDir: string;
 	downloadMap: DownloadMap;
 }): Promise<string> => {
+	console.log('waiting for asset to be downloaded', src);
 	if (downloadMap.hasBeenDownloadedMap[src]?.[downloadDir]) {
 		return Promise.resolve(
 			downloadMap.hasBeenDownloadedMap[src]?.[downloadDir] as string
@@ -190,6 +191,8 @@ export const downloadAsset = async ({
 			[downloadDir: string]: boolean;
 		}
 	)[downloadDir] = true;
+
+	console.log('Actually downloading asset', src);
 
 	const onProgress = onDownload(src);
 


### PR DESCRIPTION
Seeking for `<Video>` works differently since the Chrome 112 upgrade