### PR TITLE
fixes: expert page buttons #2012

### DIFF
--- a/packages/docs/src/pages/experts/index.tsx
+++ b/packages/docs/src/pages/experts/index.tsx
@@ -78,13 +78,15 @@ const Experts: React.FC = () => {
           <br />
           {expertsInRandomOrder.map((e) => {
             return (
-              <Link key={e.name} style={link} href={`/experts/${e.slug}`}>
-                <div className={styles.card}>
+              <div key={e.name} className={styles.card}>
+                <Link style={link} href={`/experts/${e.slug}`}>
                   <img className={styles.profile} src={e.image} />
                   <div className={styles.spacer} />
                   <div className={styles.right}>
                     <div className={styles.title}>{e.name}</div>
                     <p>{e.description}</p>
+                  </div>
+                </Link>
                     <div
                       style={{
                         display: "flex",
@@ -166,9 +168,7 @@ const Experts: React.FC = () => {
                     </div>
 
                     <br />
-                  </div>
-                </div>
-              </Link>
+              </div>   
             );
           })}
         </div>


### PR DESCRIPTION
Fixes the issue-

Experts page: Clicking any button does take you to the detail page instead of the profile #2012

Also, I think I messed up somewhere in the CSS styles. Ready to improvise based on the review.

Thank You.


<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
