### PR TITLE
fix(cli): fix design of long timeline sequence name

### DIFF
--- a/packages/cli/src/editor/components/Splitter/SplitterElement.tsx
+++ b/packages/cli/src/editor/components/Splitter/SplitterElement.tsx
@@ -15,6 +15,7 @@ export const SplitterElement: React.FC<{
 			display: 'flex',
 			position: 'relative',
 			overflow: 'hidden',
+			flexDirection: 'column',
 		};
 	}, [context.flexValue, type]);
 

--- a/packages/cli/src/editor/components/TimeValue.tsx
+++ b/packages/cli/src/editor/components/TimeValue.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Internals, useCurrentFrame} from 'remotion';
 import {useIsStill} from '../helpers/is-current-selected-still';
 import {renderFrame} from '../state/render-frame';
-import {SPACING_UNIT} from './layout';
+import {Spacing} from './layout';
 
 const text: React.CSSProperties = {
 	color: 'white',
@@ -17,16 +17,14 @@ const text: React.CSSProperties = {
 const time: React.CSSProperties = {
 	display: 'inline-block',
 	fontSize: 18,
+	lineHeight: 1,
 };
 
 const frameStyle: React.CSSProperties = {
 	color: '#ccc',
 	fontSize: 10,
 	fontWeight: 500,
-};
-
-const spacer: React.CSSProperties = {
-	width: SPACING_UNIT,
+	lineHeight: 1,
 };
 
 export const TimeValue: React.FC = () => {
@@ -44,8 +42,7 @@ export const TimeValue: React.FC = () => {
 
 	return (
 		<div style={text}>
-			<div style={time}>{renderFrame(frame, config.fps)}</div>{' '}
-			<div style={spacer} />
+			<div style={time}>{renderFrame(frame, config.fps)}</div> <Spacing x={1} />
 			<div style={frameStyle}>
 				{frame} <span style={frameStyle}>({config.fps} fps)</span>
 			</div>

--- a/packages/cli/src/editor/components/Timeline/TimelineListItem.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineListItem.tsx
@@ -6,6 +6,7 @@ import {
 	TIMELINE_PADDING,
 } from '../../helpers/timeline-layout';
 import {useZIndex} from '../../state/z-index';
+import {Spacing} from '../layout';
 import type {TimelineActionState} from './timeline-state-reducer';
 import {TimelineCollapseToggle} from './TimelineCollapseToggle';
 import {TimelineSequenceFrame} from './TimelineSequenceFrame';
@@ -23,14 +24,9 @@ export const TOTAL_TIMELINE_LAYER_LEFT_PADDING =
 
 const textStyle: React.CSSProperties = {
 	fontSize: 13,
-};
-
-const truncateText : React.CSSProperties = {
-	overflow: 'hidden',
-	fontSize: 13,
-	height: 20,
 	whiteSpace: 'nowrap',
 	textOverflow: 'ellipsis',
+	overflow: 'hidden',
 };
 
 const outer: React.CSSProperties = {
@@ -62,16 +58,20 @@ const hook: React.CSSProperties = {
 
 const space: React.CSSProperties = {
 	width: SPACING,
+	flexShrink: 0,
 };
 
 const smallSpace: React.CSSProperties = {
 	width: SPACING * 0.5,
+
+	flexShrink: 0,
 };
 
 const collapser: React.CSSProperties = {
 	width: TIMELINE_COLLAPSER_WIDTH,
 	userSelect: 'none',
 	marginRight: TIMELINE_COLLAPSER_MARGIN_RIGHT,
+	flexShrink: 0,
 };
 
 const collapserButton: React.CSSProperties = {
@@ -112,6 +112,7 @@ export const TimelineListItem: React.FC<{
 	const padder = useMemo((): React.CSSProperties => {
 		return {
 			width: leftOffset * nestedDepth,
+			flexShrink: 0,
 		};
 	}, [leftOffset, nestedDepth]);
 
@@ -157,15 +158,14 @@ export const TimelineListItem: React.FC<{
 					<div style={space} />
 				</>
 			) : null}
-			<div style={textStyle}>
-				<div style={truncateText}>
-					{text || 'Untitled'}
-				</div>
+			<div title={text || 'Untitled'} style={textStyle}>
+				{text || 'Untitled'}
 				<TimelineSequenceFrame
 					duration={sequence.duration}
 					from={sequence.from}
 				/>
 			</div>
+			<Spacing x={1} />
 		</div>
 	);
 };

--- a/packages/cli/src/editor/components/Timeline/TimelineListItem.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineListItem.tsx
@@ -25,6 +25,14 @@ const textStyle: React.CSSProperties = {
 	fontSize: 13,
 };
 
+const truncateText : React.CSSProperties = {
+	overflow: 'hidden',
+	fontSize: 13,
+	height: 20,
+	whiteSpace: 'nowrap',
+	textOverflow: 'ellipsis',
+};
+
 const outer: React.CSSProperties = {
 	height: TIMELINE_LAYER_HEIGHT + TIMELINE_BORDER * 2,
 	color: 'white',
@@ -150,7 +158,9 @@ export const TimelineListItem: React.FC<{
 				</>
 			) : null}
 			<div style={textStyle}>
-				{text || 'Untitled'}
+				<div style={truncateText}>
+					{text || 'Untitled'}
+				</div>
 				<TimelineSequenceFrame
 					duration={sequence.duration}
 					from={sequence.from}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Why

Fix #2016 

## How

In order to fix the bug I took the possibility of truncating the title of the sequence with overflow.
Sequence name will be limited by 1 line and won't wrap.

But, as the TimelineListItem is a flexible container with `flex: 200 1 0%` which allow timeline name to overflow from the container, the ellispsis don't really work.
This would mean a big refactor of the left navigation in order to to use a `flex-grow` of 200.

Maybe @JonnyBurger you have an opinion on that.

## How to validate

You can modify `packages/example/src/VideoTesting/index.tsx` sequence name to check that overflow in handled correctly.


