### PR TITLE
better error message if a bucket was created but incorrectly configured before

### DIFF
--- a/packages/lambda/src/api/create-bucket.ts
+++ b/packages/lambda/src/api/create-bucket.ts
@@ -52,10 +52,20 @@ export const createBucket = async ({
 		throw err;
 	}
 
-	await getS3Client(region, null).send(
-		new PutBucketAclCommand({
-			Bucket: bucketName,
-			ACL: 'public-read',
-		})
-	);
+	try {
+		await getS3Client(region, null).send(
+			new PutBucketAclCommand({
+				Bucket: bucketName,
+				ACL: 'public-read',
+			})
+		);
+	} catch (err) {
+		if ((err as Error).message.includes('The bucket does not allow ACLs')) {
+			throw new Error(
+				`Could not add an ACL to the bucket. This might have happened because the bucket was already successfully created before but then failed to configure correctly. We recommend to delete the bucket (${bucketName}) if it is empty and start over to fix the problem.`
+			);
+		}
+
+		throw err;
+	}
 };


### PR DESCRIPTION

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
