### PR TITLE
Gif: Add ref forwarding

### DIFF
--- a/packages/docs/docs/gif/gif.md
+++ b/packages/docs/docs/gif/gif.md
@@ -71,7 +71,7 @@ The looping behavior of the GIF. Can be one of these values:
 - `'pause-after-finish'`: The GIF will play once and then show the last frame.
 - `'unmount-after-finish'`: The GIF will play once and then unmount. Note that if you attach a `ref`, it will become `null` after the GIF has finished playing.
 
-### `ref` <AvailableFrom v="3.4.88" />
+### `ref` <AvailableFrom v="3.3.88" />
 
 You can add a [React ref](https://reactjs.org/docs/refs-and-the-dom.html) to `<Gif>`. If you use TypeScript, you need to type it with `HTMLCanvasElement`.
 

--- a/packages/docs/docs/gif/gif.md
+++ b/packages/docs/docs/gif/gif.md
@@ -71,18 +71,25 @@ The looping behavior of the GIF. Can be one of these values:
 - `'pause-after-finish'`: The GIF will play once and then show the last frame.
 - `'unmount-after-finish'`: The GIF will play once and then unmount. Note that if you attach a `ref`, it will become `null` after the GIF has finished playing.
 
+### `ref` <AvailableFrom v="3.4.88" />
+
+You can add a [React ref](https://reactjs.org/docs/refs-and-the-dom.html) to `<Gif>`. If you use TypeScript, you need to type it with `HTMLCanvasElement`.
+
 ## Example
 
 ```tsx twoslash
+import { useRef } from "react";
 import { useVideoConfig } from "remotion";
 // ---cut---
 import { Gif } from "@remotion/gif";
 
 export const MyComponent: React.FC = () => {
   const { width, height } = useVideoConfig();
+  const ref = useRef<HTMLCanvasElement>(null);
 
   return (
     <Gif
+      ref={ref}
       src="https://media.giphy.com/media/3o72F7YT6s0EMFI0Za/giphy.gif"
       width={width}
       height={height}

--- a/packages/example/src/GifTest/index.tsx
+++ b/packages/example/src/GifTest/index.tsx
@@ -1,18 +1,35 @@
 import {Gif} from '@remotion/gif';
-import {Sequence, staticFile, useVideoConfig} from 'remotion';
+import {useEffect, useRef} from 'react';
+import {Sequence, staticFile, useCurrentFrame, useVideoConfig} from 'remotion';
 
 const GifTest: React.FC = () => {
 	const {width, height} = useVideoConfig();
 	const giphy = staticFile('giphy.gif');
+	const ref1 = useRef<HTMLCanvasElement>(null);
+	const ref2 = useRef<HTMLCanvasElement>(null);
+	const ref3 = useRef<HTMLCanvasElement>(null);
+	const ref4 = useRef<HTMLCanvasElement>(null);
+	const frame = useCurrentFrame();
+
+	useEffect(() => {
+		console.log(
+			frame,
+			ref1.current?.tagName ?? 'Not rendered',
+			ref2.current?.tagName ?? 'Not rendered',
+			ref3.current?.tagName ?? 'Not rendered',
+			ref4.current?.tagName ?? 'Not rendered'
+		);
+	}, [frame]);
 
 	return (
 		<div style={{flex: 1, backgroundColor: 'black'}}>
 			<Sequence durationInFrames={50}>
-				<Gif src={giphy} width={width} height={height} fit="fill" />
+				<Gif ref={ref1} src={giphy} width={width} height={height} fit="fill" />
 			</Sequence>
 
 			<Sequence from={50} durationInFrames={50}>
 				<Gif
+					ref={ref2}
 					src="https://media.giphy.com/media/xT0GqH01ZyKwd3aT3G/giphy.gif"
 					width={width}
 					height={height}
@@ -22,6 +39,7 @@ const GifTest: React.FC = () => {
 
 			<Sequence from={100} durationInFrames={50}>
 				<Gif
+					ref={ref3}
 					src="https://media.giphy.com/media/3o72F7YT6s0EMFI0Za/giphy.gif"
 					width={width}
 					height={height}
@@ -36,6 +54,7 @@ const GifTest: React.FC = () => {
 				}}
 			>
 				<Gif
+					ref={ref4}
 					src={staticFile('disposal-type-3.gif')}
 					width={width}
 					height={height}

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -1,3 +1,4 @@
+import {forwardRef} from 'react';
 import {Internals} from 'remotion';
 import {GifForDevelopment} from './GifForDevelopment';
 import {GifForRendering} from './GifForRendering';
@@ -7,11 +8,13 @@ import type {RemotionGifProps} from './props';
  * @description Displays a GIF that synchronizes with Remotions useCurrentFrame().
  * @see [Documentation](https://www.remotion.dev/docs/gif/gif)
  */
-export const Gif = (props: RemotionGifProps) => {
-	const env = Internals.useRemotionEnvironment();
-	if (env === 'rendering') {
-		return <GifForRendering {...props} />;
-	}
+export const Gif = forwardRef<HTMLCanvasElement, RemotionGifProps>(
+	(props, ref) => {
+		const env = Internals.useRemotionEnvironment();
+		if (env === 'rendering') {
+			return <GifForRendering {...props} ref={ref} />;
+		}
 
-	return <GifForDevelopment {...props} />;
-};
+		return <GifForDevelopment {...props} ref={ref} />;
+	}
+);


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->


GitForRendering and GifForDevelopment already accepted refs, so we just needed to add `forwardRefs` to the core Gif component with this PR.

I've tested this with some tweaks to `packages/example/src/GifTest/index.tsx`, which `console.log` each frame alongside what element each Gif is being rendered as. Playing the video or scrubbing through the timeline shows which Gif is currently rendered on each frame:

```txt
[Log] 19 – "CANVAS" – "Not rendered" – "Not rendered" – "Not rendered" (src_GifTest_index_tsx.bundle.js, line 32)
[Log] 43 – "CANVAS" – "Not rendered" – "Not rendered" – "Not rendered" (src_GifTest_index_tsx.bundle.js, line 32)
[Log] 60 – "Not rendered" – "CANVAS" – "Not rendered" – "Not rendered" (src_GifTest_index_tsx.bundle.js, line 32)
[Log] 96 – "Not rendered" – "CANVAS" – "Not rendered" – "Not rendered" (src_GifTest_index_tsx.bundle.js, line 32)
[Log] 104 – "Not rendered" – "Not rendered" – "CANVAS" – "Not rendered" (src_GifTest_index_tsx.bundle.js, line 32)
[Log] 146 – "Not rendered" – "Not rendered" – "CANVAS" – "Not rendered" (src_GifTest_index_tsx.bundle.js, line 32)
[Log] 157 – "Not rendered" – "Not rendered" – "Not rendered" – "CANVAS" (src_GifTest_index_tsx.bundle.js, line 32)
[Log] 195 – "Not rendered" – "Not rendered" – "Not rendered" – "CANVAS" (src_GifTest_index_tsx.bundle.js, line 32)
```

I've speculatively set the `<AvailableFrom ... />` version in the documentation page. This might need updating depending on release schedule & plan at merge time.

Solves #2176 
/claim #2176