### PR TITLE
Update series fragment test to cover nested fragments

### DIFF
--- a/packages/core/src/test/series.test.tsx
+++ b/packages/core/src/test/series.test.tsx
@@ -26,6 +26,11 @@ const Third = () => {
 	return <div>{'third ' + frame}</div>;
 };
 
+const Fourth = () => {
+	const frame = useCurrentFrame();
+	return <div>{'fourth ' + frame}</div>;
+};
+
 const renderForFrame = (frame: number, markup: React.ReactNode) => {
 	return renderToString(
 		<CanUseRemotionHooksProvider>
@@ -84,9 +89,14 @@ test('Should support fragments', () => {
 					<Series.Sequence key="0" durationInFrames={5}>
 						<Second />
 					</Series.Sequence>
-					<Series.Sequence key="1" durationInFrames={5}>
-						<Third />
-					</Series.Sequence>
+					<>
+						<Series.Sequence key="1" durationInFrames={5}>
+							<Third />
+						</Series.Sequence>
+						<Series.Sequence key="2" durationInFrames={5}>
+							<Fourth />
+						</Series.Sequence>
+					</>
 				</>
 			</Series>
 		</WrapSequenceContext>


### PR DESCRIPTION
As mentioned in the comments on the issue, the Series already support React Fragments.

The underlying code flattens all children given to Series, and we had an existing test verifying that behaviour with a single layer of fragments.

This PR expands the test to verify that nested fragments are parsed properly. This feels like a very silly test and use-case, but the code does support nested fragments so we ought to make sure they're tested too.

Solves #2129
/claim #2129