### PR TITLE
Update validate-privacy.ts public-read error

### DIFF
--- a/packages/lambda/src/shared/validate-privacy.ts
+++ b/packages/lambda/src/shared/validate-privacy.ts
@@ -7,7 +7,7 @@ export function validatePrivacy(privacy: unknown): asserts privacy is Privacy {
 
 	if (privacy !== 'private' && privacy !== 'public' && privacy !== 'no-acl') {
 		throw new TypeError(
-			'Privacy must be either "private", "public-read" or "no-acl"'
+			'Privacy must be either "private", "public" or "no-acl"'
 		);
 	}
 }


### PR DESCRIPTION
If you set privacy to `public-read`, as the error message says you should, you would end up with the same error 😅
