### PR TITLE
CLI command `remotion lambda regions` required AWS creds

### DIFF
--- a/packages/lambda/src/cli/index.ts
+++ b/packages/lambda/src/cli/index.ts
@@ -32,10 +32,10 @@ const requiresCredentials = (args: string[]) => {
 		if (args[1] === ROLE_SUBCOMMAND) {
 			return false;
 		}
+	}
 
-		if (args[1] === REGIONS_COMMAND) {
-			return false;
-		}
+	if (args[0] === REGIONS_COMMAND) {
+		return false;
 	}
 
 	return true;


### PR DESCRIPTION
Fetching the available regions shouldn't need AWS env variables.

I think this had been accounted for, but incorrectly, by placing it under the Policies CLI command along with USER_SUBCOMMAND and ROLE_SUBCOMMAND.

Before:
![image](https://user-images.githubusercontent.com/22192773/236721078-392b7b61-7209-4954-a4a6-428a3794a35a.png)

After:
![image](https://user-images.githubusercontent.com/22192773/236721129-60897e71-f13b-4b8c-a613-a02b51b8ad17.png)

