### PR TITLE
no globalobject in webpack config

### DIFF
--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -118,7 +118,6 @@ export const webpackConfig = ({
 				  ],
 		output: {
 			hashFunction: 'xxhash64',
-			globalObject: 'this',
 			filename: 'bundle.js',
 			devtoolModuleFilenameTemplate: '[resource-path]',
 			assetModuleFilename:


### PR DESCRIPTION
Added in: https://github.com/remotion-dev/remotion/commit/f5945130dec6e16219dae70d07cab5a59d12f6a1

Let's see if CI passes without it