### PR TITLE
#2210 Add option for rendering a spring animation

### DIFF
--- a/packages/core/src/spring/index.ts
+++ b/packages/core/src/spring/index.ts
@@ -10,6 +10,7 @@ import {springCalculation} from './spring-utils.js';
  * @see [Documentation](https://www.remotion.dev/docs/spring)
  * @param {number} frame The current time value. Most of the time you want to pass in the return value of useCurrentFrame.
  * @param {number} fps The framerate at which the animation runs. Pass in the value obtained by `useVideoConfig()`.
+ * @param {?boolean} reverse Whether the animation plays in reverse or not. Default `false`.
  * @param {?Object} config optional object that allows you to customize the physical properties of the animation.
  * @param {number} [config.mass=1] The weight of the spring. If you reduce the mass, the animation becomes faster!
  * @param {number} [config.damping=10] How hard the animation decelerates.
@@ -30,6 +31,7 @@ export function spring({
 	durationInFrames,
 	durationRestThreshold,
 	delay = 0,
+	reverse = false
 }: {
 	frame: number;
 	fps: number;
@@ -39,6 +41,7 @@ export function spring({
 	durationInFrames?: number;
 	durationRestThreshold?: number;
 	delay?: number;
+	reverse?: boolean;
 }): number {
 	validateSpringDuration(durationInFrames);
 	validateFrame({
@@ -48,20 +51,25 @@ export function spring({
 	});
 	validateFps(fps, 'to spring()', false);
 
-	const durationRatio =
-		durationInFrames === undefined
-			? 1
-			: durationInFrames /
-			  measureSpring({
-					fps,
-					config,
-					from,
-					to,
-					threshold: durationRestThreshold,
-			  });
+	const duration = measureSpring({
+		fps,
+		config,
+		from,
+		to,
+		threshold: durationRestThreshold,
+	});
+	if (durationInFrames === undefined) {
+		durationInFrames = duration;
+	}
+
+	const durationRatio = durationInFrames / duration;
 
 	// Delay the spring by telling the calculation we're at an earlier frame.
-	const frame = passedFrame - delay;
+	let frame = passedFrame - delay;
+
+	if (reverse) {
+		frame = durationInFrames - frame;
+	}
 
 	const spr = springCalculation({
 		fps,

--- a/packages/core/src/test/spring.test.ts
+++ b/packages/core/src/test/spring.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, test} from 'vitest';
 import {isApproximatelyTheSame} from '../is-approximately-the-same.js';
 import {spring} from '../spring/index.js';
+import {measureSpring} from '../spring/measure-spring.js';
 
 test('Basic spring to equal 0', () => {
 	expect(
@@ -53,6 +54,50 @@ test('Should be able to set duration for spring', () => {
 	).toBeCloseTo(1);
 });
 
+// Reverse tests
+test('Should be able to set duration for spring when in reverse', () => {
+	expect(
+		spring({
+			fps: 30,
+			frame: 5,
+			durationInFrames: 5,
+			reverse: true
+		})
+	).toBeCloseTo(0);
+});
+
+test('Should be able to set duration for spring when in reverse', () => {
+	expect(
+		spring({
+			fps: 30,
+			frame: 0,
+			durationInFrames: 5,
+			reverse: true
+		})
+	).toBeCloseTo(1);
+});
+
+// This is the reverse of one of the first tests
+test('Should be approxmiately the same when in reverse', () => {
+	expect(
+		spring({
+			fps: 30,
+			// duration - 1
+			frame: measureSpring({fps: 30}) - 1,
+			reverse: true
+		}),
+	).toBeCloseTo(0.04941510804510185);
+});
+
+test('Should be close to 0 when in reverse', () => {
+	expect(
+		spring({
+			fps: 30,
+			frame: 100,
+			reverse: true
+		})
+	).toBeCloseTo(0);
+});
 
 describe('Should be able to delay a spring', () => {
 	test('Should clamp all frames before the delay to zero', () => {

--- a/packages/docs/docs/spring.md
+++ b/packages/docs/docs/spring.md
@@ -46,6 +46,12 @@ The end value of the animation. Note that depending on the parameters, spring an
 
 For how many frames per second the spring animation should be calculated. This should always be the `fps` property of the return value of [`useVideoConfig()`](/docs/use-video-config).
 
+### reverse
+
+_Default:_ `false`
+
+Render the animation in reverse. When this option is enabled, passing a `frame` is like passing `duration - frame`.
+
 ### config
 
 An optional object that allows you to customize the physical properties of the animation.

--- a/packages/docs/docs/spring.md
+++ b/packages/docs/docs/spring.md
@@ -9,7 +9,7 @@ A physics-based animation primitive.
 
 Example:
 
-```tsx twoslash
+```tsx twoslash title="spring-example.ts"
 import { spring, useCurrentFrame, useVideoConfig } from "remotion";
 // ---cut---
 const frame = useCurrentFrame();
@@ -26,33 +26,33 @@ const value = spring({
 
 ## Parameters
 
-### frame
+### `frame`
 
 The current time value. Most of the time you want to pass in the return value of [`useCurrentFrame()`](/docs/use-current-frame). The spring animation starts at frame 0, so if you would like to delay the animation, you can pass a different value like `frame - 20`.
 
-### from
+### `from`
 
 _Default:_ `0`
 
 The initial value of the animation.
 
-### to
+### `to`
 
 _Default:_ `1`
 
 The end value of the animation. Note that depending on the parameters, spring animations may overshoot the target a bit, before they bounce back to their final target.
 
-### fps
+### `fps`
 
 For how many frames per second the spring animation should be calculated. This should always be the `fps` property of the return value of [`useVideoConfig()`](/docs/use-video-config).
 
-### reverse
+### `reverse` <AvailableFrom v="3.3.92" />
 
 _Default:_ `false`
 
-Render the animation in reverse. When this option is enabled, passing a `frame` is like passing `duration - frame`.
+Render the animation in reverse. See: [Order or operations](#order-of-operations)
 
-### config
+### `config`
 
 An optional object that allows you to customize the physical properties of the animation.
 
@@ -80,13 +80,13 @@ _Default_: `false`
 
 Determines whether the animation can shoot over the `to` value. If set to true, if the animation goes over `to`, it will just return the value of `to`.
 
-### durationInFrames <AvailableFrom v="3.0.27" />
+### `durationInFrames` <AvailableFrom v="3.0.27" />
 
 _optional_
 
 Stretches the animation curve so it is exactly as long as you specify.
 
-```tsx twoslash
+```tsx twoslash title="spring-example.ts"
 import { spring, useCurrentFrame, useVideoConfig } from "remotion";
 // ---cut---
 const frame = useCurrentFrame();
@@ -102,6 +102,8 @@ const value = spring({
 });
 ```
 
+See also: [Order or operations](#order-of-operations)
+
 ### `durationRestThreshold` <AvailableFrom v="3.0.27" />
 
 _optional_
@@ -116,13 +118,15 @@ _optional_
 
 How many frames to delay the animation for.
 
-For example, if a `delay` of `25` is given frames 0-24 will return the initial value, and the animation will effectively start from frame 25.
+For example, if a `delay` of `25` is given frames 0-24 will return the initial value, and the animation will effectively start from frame 25. See also: [Order or operations](#order-of-operations)
 
-## YouTube video
+## Order of operations
 
-Want to understand the different properties like `mass`, `stiffness`, `damping` etc.? We made a video trying to make sense of all the parameters!
+Here is the order of which the `durationInFrames`, `reverse` and `delay` operations are applied:
 
-Watch: **[The perfect spring animation](https://www.youtube.com/watch?v=GE8ZqrKqE5g)**
+<Step>1</Step> First the spring animation is stretched to the duration that you pass using <a href="#durationinframes"><code>durationInFrames</code></a>, if you pass a duration.<br/>
+<Step>2</Step> Then the animation is reversed if you pass <a href="#reverse-"><code>reverse: true</code></a>.<br/>
+<Step>3</Step> Then the animation is delayed if you pass <a href="#delay-"><code>delay</code></a>.
 
 ## Credit
 


### PR DESCRIPTION
This PR implements the `reverse` option for the spring animation rendering. I added tests and updated the documentation where necessary. The implementation is very close to the one discussed in the [original issue](https://github.com/remotion-dev/remotion/issues/2210).

I am looking forward to implementing any feedback from the review process to things for which I may have blind spots.

/claim #2210