### PR TITLE
remove bucketName input from lambda GetSitesInput type

### DIFF
--- a/packages/lambda/src/api/get-sites.ts
+++ b/packages/lambda/src/api/get-sites.ts
@@ -16,7 +16,6 @@ type Site = {
 
 export type GetSitesInput = {
 	region: AwsRegion;
-	bucketName?: string;
 };
 
 export type GetSitesOutput = {


### PR DESCRIPTION
This input is not used in the code.

Not sure if you want to retain the GetSitesInput or put the type declaration inline?  
Removing the exported GetSitesInput type would mean removing it from `packages/lambda/src/index.ts` as well. I couldn't see that it was used anywhere else, so it would probably be a good thing to clean up - let me know if you want me to do this.

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
