### PR TITLE
docs-fix: link to `getPointAtLength` method docs

### DIFF
--- a/packages/docs/components/TableOfContents/paths.tsx
+++ b/packages/docs/components/TableOfContents/paths.tsx
@@ -10,7 +10,7 @@ export const TableOfContents: React.FC = () => {
           <strong>getLength()</strong>
           <div>Obtain length of an SVG path</div>
         </TOCItem>
-        <TOCItem link="/docs/paths/get-tangent-at-length">
+        <TOCItem link="/docs/paths/get-point-at-length">
           <strong>getPointAtLength()</strong>
           <div>Get coordinates at a certain point of an SVG path</div>
         </TOCItem>


### PR DESCRIPTION
On [@remotion/paths](https://www.remotion.dev/docs/paths/) page, `getPointAtLength` method link was taking user to `getTangentAtLength` method docs
