### PR TITLE
lambda region-selection.md improved wording

### DIFF
--- a/packages/docs/docs/lambda/region-selection.md
+++ b/packages/docs/docs/lambda/region-selection.md
@@ -70,9 +70,9 @@ see [here]
 
 ## Other considerations
 
-- The function and S3 bucket must be in the same region to eliminate latency across datacenters. Rendering with functions and buckets that ahave mismatching regions is not supported
+- The function and S3 bucket must be in the same region to eliminate latency across datacenters. Rendering with functions and buckets that have mismatching regions is not supported
 
-- You may deploy your whole architecture to different regions to further increase the amount of renders you can make concurrently. The tradeoff is higher redundancy, and not being able to benefit less from already warm functions.
+- You may deploy your whole architecture to different regions to further increase the amount of renders you can make concurrently. This has the advantage of higher redundancy, but a potential drawback of hitting a non-warm function.
 
 - Some regions are more expensive than others (for example `af-south-1`).
   Consult the [Lambda Pricing page](https://aws.amazon.com/lambda/pricing/) from AWS.


### PR DESCRIPTION
There was a slight typo, which I fixed, and IMO it is worded a little more clearly now.

I won't be offended if you disagree my rewording 😅 but there is definitely an error with the original;
> not being able to benefit less from already warm functions