### PR TITLE
Update legacy link

### DIFF
--- a/packages/bundler/src/fast-refresh/runtime.ts
+++ b/packages/bundler/src/fast-refresh/runtime.ts
@@ -64,7 +64,6 @@ self.$RefreshInterceptModuleExecution$ = function (webpackModuleId: unknown) {
 	self.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
 
 	// Modeled after `useEffect` cleanup pattern:
-	// https://reactjs.org/docs/hooks-effect.html#effects-with-cleanup
 	return () => {
 		self.$RefreshReg$ = prevRefreshReg;
 		self.$RefreshSig$ = prevRefreshSig;

--- a/packages/docs/docs/absolute-fill.md
+++ b/packages/docs/docs/absolute-fill.md
@@ -24,7 +24,7 @@ const style: React.CSSProperties = {
 
 ## Adding a ref
 
-You can add a [React ref](https://reactjs.org/docs/refs-and-the-dom.html) to an `<AbsoluteFill>` from version `v3.2.13` on. If you use TypeScript, you need to type it with `HTMLDivElement`:
+You can add a [React ref](https://react.dev/learn/manipulating-the-dom-with-refs) to an `<AbsoluteFill>` from version `v3.2.13` on. If you use TypeScript, you need to type it with `HTMLDivElement`:
 
 ```tsx twoslash
 import { useRef } from "react";

--- a/packages/docs/docs/data-fetching.md
+++ b/packages/docs/docs/data-fetching.md
@@ -7,7 +7,7 @@ crumb: "How to"
 
 One of the coolest things about Remotion is that you can fetch data from an API.
 
-It works almost like you are used to: You can use the [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API to load data in a [`useEffect()`](https://reactjs.org/docs/hooks-effect.html) call and set a state.
+It works almost like you are used to: You can use the [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API to load data in a [`useEffect()`](https://react.dev/reference/react/useEffect) call and set a state.
 
 ## Telling Remotion to wait until the data is loaded
 

--- a/packages/docs/docs/gif/gif.md
+++ b/packages/docs/docs/gif/gif.md
@@ -73,7 +73,7 @@ The looping behavior of the GIF. Can be one of these values:
 
 ### `ref` <AvailableFrom v="3.3.88" />
 
-You can add a [React ref](https://reactjs.org/docs/refs-and-the-dom.html) to `<Gif>`. If you use TypeScript, you need to type it with `HTMLCanvasElement`.
+You can add a [React ref](https://react.dev/learn/manipulating-the-dom-with-refs) to `<Gif>`. If you use TypeScript, you need to type it with `HTMLCanvasElement`.
 
 ## Example
 

--- a/packages/docs/docs/player/api.md
+++ b/packages/docs/docs/player/api.md
@@ -758,7 +758,7 @@ When a video throws an exception, you may handle the error using the [`error` ev
 The video will unmount and show an error UI, but the host application (The React app which is embedding the player) will not crash.
 It is up to you to handle the error and to re-mount the video (for example by changing the `key` prop in React).
 
-This feature is implemented using an [error boundary](https://reactjs.org/docs/error-boundaries.html), so only errors in the render function will be caught. Errors in event handlers and asynchronous code will not be reported and will not cause the video to unmount.
+This feature is implemented using an [error boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary), so only errors in the render function will be caught. Errors in event handlers and asynchronous code will not be reported and will not cause the video to unmount.
 
 You can customize the error message that is shown if a video crashes:
 

--- a/packages/docs/docs/player/preloading.md
+++ b/packages/docs/docs/player/preloading.md
@@ -15,7 +15,7 @@ Two ways of preloading are supported:
 ## Preloading videos using `@remotion/preload`
 
 By preloading, a `<link type='preload'>` tag is placed on the page, signaling to the browser that it may start loading the media.  
-For videos, use [`preloadVideo()`](/docs/preload/preload-video) API, for audio use [`preloadAudio()`](/docs/preload/preload-audio), for images use [`preloadImage()`](/docs/preload/preload-image). Perform the preload outside a component or inside an [`useEffect()`](https://reactjs.org/docs/hooks-effect.html).
+For videos, use [`preloadVideo()`](/docs/preload/preload-video) API, for audio use [`preloadAudio()`](/docs/preload/preload-audio), for images use [`preloadImage()`](/docs/preload/preload-image). Perform the preload outside a component or inside an [`useEffect()`](https://react.dev/reference/react/useEffect).
 
 ```tsx twoslash
 import { preloadAudio, preloadVideo } from "@remotion/preload";

--- a/packages/docs/docs/sequence.md
+++ b/packages/docs/docs/sequence.md
@@ -172,7 +172,7 @@ See the [`<Series />`](/docs/series) helper component, which helps you calculate
 
 ## Adding a ref
 
-You can add a [React ref](https://reactjs.org/docs/refs-and-the-dom.html) to an `<Sequence>` from version `v3.2.13` on. If you use TypeScript, you need to type it with `HTMLDivElement`:
+You can add a [React ref](https://react.dev/learn/manipulating-the-dom-with-refs) to an `<Sequence>` from version `v3.2.13` on. If you use TypeScript, you need to type it with `HTMLDivElement`:
 
 ```tsx twoslash
 import { useRef } from "react";

--- a/packages/docs/docs/series.md
+++ b/packages/docs/docs/series.md
@@ -91,7 +91,7 @@ A class name to be applied to the container. If `layout` is set to `none`, there
 
 _optional_
 
-You can add a [React ref](https://reactjs.org/docs/refs-and-the-dom.html) to a `<Series.Sequence>`. If you use TypeScript, you need to type it with `HTMLDivElement`:
+You can add a [React ref](https://react.dev/learn/manipulating-the-dom-with-refs) to a `<Series.Sequence>`. If you use TypeScript, you need to type it with `HTMLDivElement`:
 
 ```tsx twoslash title="src/Example.tsx"
 const Square: React.FC<{

--- a/packages/docs/docs/the-fundamentals.md
+++ b/packages/docs/docs/the-fundamentals.md
@@ -27,7 +27,7 @@ export const MyComposition = () => {
 // - MyComposition
 ```
 
-The basic idea behind Remotion is that we'll give you a frame number and a blank canvas, and the freedom to render anything you want using [React](https://reactjs.org).
+The basic idea behind Remotion is that we'll give you a frame number and a blank canvas, and the freedom to render anything you want using [React](https://react.dev).
 
 ```tsx twoslash
 // @include: example-MyComposition


### PR DESCRIPTION
Reactjs.org docs are no longer maintained, so linked to the new docs instead. I guess it may be time to update all react links to the new docs 🤔

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
