### PR TITLE
add "use client" directive to @remotion/player bundle

### DIFF
--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -61,6 +61,7 @@
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0",
 		"rollup": "^2.70.1",
+		"rollup-plugin-banner2": "^1.2.2",
 		"typescript": "^4.7.0",
 		"vitest": "0.24.3",
 		"webpack": "5.76.1"

--- a/packages/player/rollup.config.js
+++ b/packages/player/rollup.config.js
@@ -1,5 +1,6 @@
 // rollup.config.js
 import typescript from '@rollup/plugin-typescript';
+import banner2 from 'rollup-plugin-banner2';
 
 export default [
 	{
@@ -18,6 +19,9 @@ export default [
 				sourceMap: false,
 				outputToFilesystem: true,
 			}),
+			// Adds "use client;" on top of the bundle instructing React to treat the <Player />
+			// and all other exported components as a client component as opposed to a server component.
+			banner2(() => `"use client";\n`),
 		],
 	},
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,6 +918,7 @@ importers:
       react-dom: ^18.0.0
       remotion: workspace:*
       rollup: ^2.70.1
+      rollup-plugin-banner2: ^1.2.2
       typescript: ^4.7.0
       vitest: 0.24.3
       webpack: 5.76.1
@@ -940,6 +941,7 @@ importers:
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
       rollup: 2.76.0
+      rollup-plugin-banner2: 1.2.2
       typescript: 4.7.2
       vitest: 0.24.3_jsdom@20.0.1
       webpack: 5.76.1
@@ -16233,6 +16235,12 @@ packages:
     resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
     hasBin: true
 
+  /magic-string/0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+
   /magic-string/0.26.2:
     resolution: {integrity: sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==}
     engines: {node: '>=12'}
@@ -19860,6 +19868,13 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.0
+
+  /rollup-plugin-banner2/1.2.2:
+    resolution: {integrity: sha512-ShlyRFlJfh7fxHT0rkmIxBv+lIWfdvaWcZmra7xAQFGAHHnd7f93zoa0wdDWHrguR9vR+BxWKToabR6DJQHC9g==}
+    engines: {node: '>=12.13.0'}
+    dependencies:
+      magic-string: 0.25.9
+    dev: true
 
   /rollup/2.76.0:
     resolution: {integrity: sha512-9jwRIEY1jOzKLj3nsY/yot41r19ITdQrhs+q3ggNWhr9TQgduHqANvPpS32RNpzGklJu3G1AJfvlZLi/6wFgWA==}


### PR DESCRIPTION
This PR adds a `use client` directive to @remotion/player. I have used `rollup-plugin-banner2` to add the directive to the ESM bundle. Note, this marks all components exported by @remotion/player as client components. I believe it isn't a problem in our case.

/claim #2313