### PR TITLE
Consistent indication of optional props - renderstillonlambda.md

### DIFF
--- a/packages/docs/docs/lambda/renderstillonlambda.md
+++ b/packages/docs/docs/lambda/renderstillonlambda.md
@@ -71,7 +71,7 @@ One of:
 - `"private"`: The rendered still is not publicly available, but signed links can be created using [presignUrl()](/docs/lambda/presignurl).
 - `"no-acl"` (_available from v.3.1.7_): The ACL option is not being set at all, this option is useful if you are writing to another bucket that does not support ACL using [`outName`](#outname).
 
-### `frame`
+### `frame?`
 
 _optional - default `0`_
 
@@ -105,25 +105,25 @@ _optional - default `{}`_
 
 See [`renderMedia() -> envVariables`](/docs/renderer/render-media#envvariables).
 
-### `forceHeight`
+### `forceHeight?`
 
 _optional, available from v3.2.40_
 
 Overrides the default composition height.
 
-### `forceWidth`
+### `forceWidth?`
 
 _optional, available from v3.2.40_
 
 Overrides the default composition width.
 
-### `scale`
+### `scale?`
 
 _optional_
 
 Scales the output dimensions by a factor. See [Scaling](/docs/scaling) to learn more about this feature.
 
-### `outName`
+### `outName?`
 
 _optional_
 
@@ -135,9 +135,11 @@ It can either be:
 
 ### `timeoutInMilliseconds?`
 
+_optional_
+
 A number describing how long the render may take to resolve all [`delayRender()`](/docs/delay-render) calls [before it times out](/docs/timeout). Default: `30000`
 
-### `downloadBehavior`
+### `downloadBehavior?`
 
 _optional, available since v3.1.5_
 
@@ -148,6 +150,8 @@ Either:
 - `{"type": "download", fileName: null}` or `{"type": "download", fileName: "download.mp4"}` - a `Content-Disposition` header will be added which makes the browser download the file. You can optionally override the filename.
 
 ### `chromiumOptions?`
+
+_optional_
 
 Allows you to set certain Chromium / Google Chrome flags. See: [Chromium flags](/docs/chromium-flags).
 
@@ -192,11 +196,15 @@ Specify a specific bucket name to be used. [This is not recommended](/docs/lambd
 
 ### `logLevel?`
 
+_optional_
+
 One of `verbose`, `info`, `warn`, `error`. Determines how much is being logged inside the Lambda function. Logs can be read through the CloudWatch URL that this function returns.
 
 If the `logLevel` is set to `verbose`, the `dumpBrowserLogs` flag will also be enabled.
 
-### `dumpBrowserLogs?`<AvailableFrom v="3.3.83" />
+### `dumpBrowserLogs?`
+
+_optional, available since v3.3.83_
 
 If set to true, all `console` statements from the headless browser will be forwarded to the CloudWatch logs.
 


### PR DESCRIPTION
Some of the props are optional in the code, yet they weren't marked as optional in the docs.
Some props has the optional subheading, but were missing the question mark.
dumpBrowserLogs was using the AvailableFrom component but no other headings were.