### PR TITLE
Update getorcreatebucket.md

### DIFF
--- a/packages/docs/docs/lambda/getorcreatebucket.md
+++ b/packages/docs/docs/lambda/getorcreatebucket.md
@@ -36,7 +36,7 @@ Allows to pass a callback after the bucket was created and before the S3 website
 
 ## Return value
 
-A promise resolving to an object with the following property:
+A promise resolving to an object with the following properties:
 
 ### `bucketName`
 
@@ -44,7 +44,8 @@ The name of your bucket that was found or created.
 
 ### `alreadyExisted`
 
-<AvailableFrom v="v3.3.78" />
+_available from v3.3.78_
+
 A boolean indicating whether the bucket already existed or was newly created.
 
 ## See also


### PR DESCRIPTION
Changed property to properties.

Not certain of whether you want `<AvailableFrom v="v3.3.78" />` or `_available from v3.3.78_`, but I do think the component was non-obvious:

![image](https://github.com/remotion-dev/remotion/assets/22192773/86fa9b50-de55-4dcf-bafe-2f5db63cbad9)


If you want to stick with the component approach, I can make a PR that changes all the `_available from_` text across the docs. I'll also make sure the component sits next to the heading, as opposed to underneath. Just let me know! 😁