### PR TITLE
it's vs its - grammar correction

### DIFF
--- a/packages/docs/docs/lambda/cli/sites.md
+++ b/packages/docs/docs/lambda/cli/sites.md
@@ -131,7 +131,7 @@ pr6fwglz05 testbed<br/>
 
 ## rm
 
-Removes a site (or multiple) from S3 by it's ID.
+Removes a site (or multiple) from S3 by its ID.
 
 ```bash
 npx remotion lambda sites rm abcdef

--- a/packages/docs/docs/lambda/deletefunction.md
+++ b/packages/docs/docs/lambda/deletefunction.md
@@ -6,7 +6,7 @@ slug: /lambda/deletefunction
 crumb: "Lambda API"
 ---
 
-Deletes a deployed Lambda function based on it's name.
+Deletes a deployed Lambda function based on its name.
 
 To retrieve a list of functions, call [`getFunctions()`](/docs/lambda/getfunctions) first.
 

--- a/packages/docs/docs/lambda/deleterender.md
+++ b/packages/docs/docs/lambda/deleterender.md
@@ -6,7 +6,7 @@ slug: /lambda/deleterender
 crumb: "Lambda API"
 ---
 
-Deletes a rendered video, audio or still and it's associated metada.
+Deletes a rendered video, audio or still and its associated metada.
 
 ```ts twoslash
 // @module: ESNext

--- a/packages/docs/docs/lambda/getfunctioninfo.md
+++ b/packages/docs/docs/lambda/getfunctioninfo.md
@@ -6,7 +6,7 @@ slug: /lambda/getfunctioninfo
 crumb: "Lambda API"
 ---
 
-Gets information about a function given it's name and region.
+Gets information about a function given its name and region.
 
 To get a list of deployed functions, use [`getFunctions()`](/docs/lambda/getfunctions).
 

--- a/packages/docs/docs/lambda/webhooks.md
+++ b/packages/docs/docs/lambda/webhooks.md
@@ -202,7 +202,7 @@ router.post("/my-remotion-webhook-endpoint", jsonParser, (req, res) => {
 
 Similary, here is an example endpoint in Next.JS.
 
-Since this endpoint is going to be executed in an AWS Lambda function on it's own, you want to import the Remotion functions from [`@remotion/lambda/client`](/docs/lambda/light-client).
+Since this endpoint is going to be executed in an AWS Lambda function on its own, you want to import the Remotion functions from [`@remotion/lambda/client`](/docs/lambda/light-client).
 
 ```tsx twoslash title="pages/api/webhook.ts"
 type NextApiRequest = {


### PR DESCRIPTION
Something I had noticed whlie being in the docs 😁. From [grammarly.com](https://www.grammarly.com/blog/its-vs-its/);
> its (without an apostrophe) is a possessive pronoun, like his or her, for nouns that don’t have a defined gender. In contrast, it’s (with an apostrophe) is the shortened form, or contraction, of it is or it has.
