### PR TITLE
Add `mutechange` event to Player

### DIFF
--- a/packages/docs/docs/player/api.md
+++ b/packages/docs/docs/player/api.md
@@ -597,6 +597,10 @@ useEffect(() => {
     console.log("scalechange", e.detail.scale);
   };
 
+  const onMuteChange: CallbackListener<"mutechange"> = (e) => {
+    console.log("mutechange", e.detail.isMuted);
+  };
+
   playerRef.current.addEventListener("play", onPlay);
   playerRef.current.addEventListener("ratechange", onRateChange);
   playerRef.current.addEventListener("volumechange", onVolumeChange);
@@ -605,6 +609,7 @@ useEffect(() => {
   playerRef.current.addEventListener("error", onError);
   playerRef.current.addEventListener("fullscreenchange", onFullscreenChange);
   playerRef.current.addEventListener("scalechange", onScaleChange);
+  playerRef.current.addEventListener("mutechange", onMuteChange);
 
   // See below for difference between `seeked` and `timeupdate`
   playerRef.current.addEventListener("seeked", onSeeked);
@@ -624,6 +629,7 @@ useEffect(() => {
         onFullscreenChange
       );
       playerRef.current.removeEventListener("scalechange", onScaleChange);
+      playerRef.current.removeEventListener("mutechange", onMuteChange);
       playerRef.current.removeEventListener("seeked", onSeeked);
       playerRef.current.removeEventListener("timeupdate", onTimeupdate);
     }
@@ -732,6 +738,23 @@ if (!playerRef.current) {
 // ---cut---
 playerRef.current.addEventListener("fullscreenchange", (e) => {
   console.log("is fullscreen" + e.detail.isFullscreen); // is fullscreen true
+});
+```
+
+### `mutechange`<AvailableFrom v="3.3.98" />
+
+Fires when the player's audio is muted or not. Also returned by [`isMuted()`](#ismuted).
+
+```tsx twoslash
+import { PlayerRef } from "@remotion/player";
+import { useRef } from "react";
+const playerRef = useRef<PlayerRef>(null);
+if (!playerRef.current) {
+  throw new Error();
+}
+// ---cut---
+playerRef.current.addEventListener("mutechange", (e) => {
+  console.log("is mute" + e.detail.isMuted); // is mute true
 });
 ```
 

--- a/packages/player-example/src/App.tsx
+++ b/packages/player-example/src/App.tsx
@@ -155,6 +155,24 @@ const ControlsOnly: React.FC<{
 			]);
 		};
 
+		const volumechangeCallbackListener: CallbackListener<
+			'volumechange'
+		> = (e) => {
+			setLogs((l) => [
+				...l,
+				'volumechange ' + e.detail.volume + ' ' + Date.now(),
+			]);
+		};
+
+		const mutechangeCallbackListener: CallbackListener<
+			'mutechange'
+		> = (e) => {
+			setLogs((l) => [
+				...l,
+				'mutechange ' + e.detail.isMuted + ' ' + Date.now(),
+			]);
+		};
+
 		const {current} = ref;
 		if (!current) {
 			return;
@@ -169,6 +187,8 @@ const ControlsOnly: React.FC<{
 		current.addEventListener('frameupdate', frameupdateCallbackListener);
 		current.addEventListener('ratechange', ratechangeCallbackListener);
 		current.addEventListener('scalechange', scalechangeCallbackListener);
+		current.addEventListener('volumechange', volumechangeCallbackListener);
+		current.addEventListener('mutechange', mutechangeCallbackListener);
 		current.addEventListener(
 			'fullscreenchange',
 			fullscreenChangeCallbackListener
@@ -184,6 +204,8 @@ const ControlsOnly: React.FC<{
 			current.removeEventListener('frameupdate', frameupdateCallbackListener);
 			current.removeEventListener('ratechange', ratechangeCallbackListener);
 			current.removeEventListener('scalechange', scalechangeCallbackListener);
+			current.removeEventListener('volumechange', volumechangeCallbackListener);
+			current.removeEventListener('mutechange', mutechangeCallbackListener);
 			current.removeEventListener(
 				'fullscreenchange',
 				fullscreenChangeCallbackListener

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -264,6 +264,10 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		Internals.SetMediaVolumeContext
 	);
 	const {mediaMuted, mediaVolume} = useContext(Internals.MediaVolumeContext);
+	useEffect(() => {
+		player.emitter.dispatchVolumeChange(mediaVolume);
+	}, [player.emitter, mediaVolume])
+
 	const isMuted = mediaMuted || mediaVolume === 0;
 	useEffect(() => {
 		player.emitter.dispatchMuteChange({
@@ -327,7 +331,6 @@ const PlayerUI: React.ForwardRefRenderFunction<
 					}
 
 					setMediaVolume(vol);
-					player.emitter.dispatchVolumeChange(vol);
 				},
 				isMuted: () => isMuted,
 				mute: () => {

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -264,6 +264,13 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		Internals.SetMediaVolumeContext
 	);
 	const {mediaMuted, mediaVolume} = useContext(Internals.MediaVolumeContext);
+	const isMuted = mediaMuted || mediaVolume === 0;
+	useEffect(() => {
+		player.emitter.dispatchMuteChange({
+			isMuted
+		})
+	},
+	[player.emitter, isMuted]);
 
 	useImperativeHandle(
 		ref,
@@ -322,7 +329,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 					setMediaVolume(vol);
 					player.emitter.dispatchVolumeChange(vol);
 				},
-				isMuted: () => mediaMuted || mediaVolume === 0,
+				isMuted: () => isMuted,
 				mute: () => {
 					setMediaMuted(true);
 				},
@@ -339,6 +346,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 			isFullscreen,
 			loop,
 			mediaMuted,
+			isMuted,
 			mediaVolume,
 			player,
 			requestFullscreen,

--- a/packages/player/src/event-emitter.ts
+++ b/packages/player/src/event-emitter.ts
@@ -30,6 +30,10 @@ type FullscreenChangeEventPayload = {
 	isFullscreen: boolean;
 };
 
+type MuteChangeEventPayload = {
+	isMuted: boolean;
+}
+
 type PlayerStateEventMap = {
 	seeked: SeekPayload;
 	pause: undefined;
@@ -42,6 +46,7 @@ type PlayerStateEventMap = {
 	timeupdate: TimeUpdateEventPayload;
 	frameupdate: FrameUpdateEventPayload;
 	fullscreenchange: FullscreenChangeEventPayload;
+	mutechange: MuteChangeEventPayload;
 };
 
 type ThumbnailStateEventMap = {
@@ -76,6 +81,7 @@ export class PlayerEmitter {
 		frameupdate: [],
 		fullscreenchange: [],
 		volumechange: [],
+		mutechange: [],
 	};
 
 	addEventListener<Q extends PlayerEventTypes>(
@@ -157,6 +163,10 @@ export class PlayerEmitter {
 
 	dispatchFullscreenChange(event: FullscreenChangeEventPayload) {
 		this.dispatchEvent('fullscreenchange', event);
+	}
+
+	dispatchMuteChange(event: MuteChangeEventPayload) {
+		this.dispatchEvent('mutechange', event)
 	}
 }
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

This PR adds a new `mutechange` event emitter for Player.

It's implemented the same as the `isMuted()` method, where the player is considered muted if the mute button is pressed or the volume is currently set to zero.

Alongside this PR I have included a fix for the `volumechange` event, to make sure it is emitted every time the volume changes. Previously it was only emitting were programmatically changed via the `setVolume()` method, which means it was not emitting when the volume slider was changed.

To test this change I have expanded the `packages/player-example`. When running this example with:

```sh
cd packages/player-example
pnpm dev
```

And interacting with the mute button or volume slider, you can see the mutechange and fixed volumechange events being logged.

In the following screenshot, the left player shows mute being directly toggled, whereas the right shows the volume slider going down to zero and back up.

![image](https://github.com/remotion-dev/remotion/assets/602850/da3363d4-ce54-4511-95b5-378af91403ea)

The Player API reference docs have been updated to note the new event:

![image](https://github.com/remotion-dev/remotion/assets/602850/9fe61958-e3d0-4a5a-b1b8-1e30b9fa5831)


Solves #2376
/claim #2376