### PR TITLE
Hide TTS template

### DIFF
--- a/packages/create-video/src/select-template.ts
+++ b/packages/create-video/src/select-template.ts
@@ -5,6 +5,8 @@ import {stripAnsi} from './strip-ansi';
 import type {Template} from './templates';
 import {FEATURED_TEMPLATES} from './templates';
 
+const SHOWN_TEMPLATES = FEATURED_TEMPLATES.filter((t) => t.listed);
+
 const parsed = minimist(process.argv.slice(2), {
 	boolean: FEATURED_TEMPLATES.map((f) => f.cliId),
 });
@@ -17,7 +19,7 @@ function padEnd(str: string, width: number): string {
 
 const descriptionColumn =
 	Math.max(
-		...FEATURED_TEMPLATES.map((t) =>
+		...SHOWN_TEMPLATES.map((t) =>
 			typeof t === 'object' ? t.shortName.length : 0
 		)
 	) + 2;
@@ -35,7 +37,7 @@ export const selectTemplate = async () => {
 		{
 			message: 'Choose a template:',
 			optionsPerPage: 20,
-			choices: FEATURED_TEMPLATES.map((template) => {
+			choices: SHOWN_TEMPLATES.map((template) => {
 				if (typeof template === 'string') {
 					return prompts.separator(template);
 				}

--- a/packages/create-video/src/templates.tsx
+++ b/packages/create-video/src/templates.tsx
@@ -38,6 +38,7 @@ export type Template = {
 		| 'tailwind'
 		| 'overlay';
 	defaultBranch: string;
+	listed: boolean;
 } & DynamicTemplate;
 
 type Truthy<T> = T extends false | '' | 0 | null | undefined ? never : T;
@@ -65,6 +66,7 @@ const nextTemplate: Template = {
 	cliId: 'next',
 	type: 'image',
 	defaultBranch: 'main',
+	listed: true,
 };
 
 // Note that this page is statically analyzed by extract-articles.mjs
@@ -85,6 +87,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'hello-world' as const,
 		type: 'video' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 	ENABLE_NEXT ? nextTemplate : null,
 	{
@@ -103,6 +106,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'blank' as const,
 		type: 'video' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 	{
 		homePageLabel: 'JavaScript',
@@ -120,6 +124,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'javascript' as const,
 		type: 'video' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 	{
 		homePageLabel: 'Remix',
@@ -137,6 +142,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'remix' as const,
 		type: 'image' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 	{
 		homePageLabel: '3D',
@@ -154,6 +160,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'three' as const,
 		type: 'video' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 	{
 		homePageLabel: 'Stills',
@@ -171,6 +178,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'still' as const,
 		type: 'video' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 	{
 		homePageLabel: 'Text-To-Speech',
@@ -188,6 +196,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'tts' as const,
 		type: 'video' as const,
 		defaultBranch: 'master',
+		listed: false,
 	},
 	{
 		homePageLabel: 'Audiogram',
@@ -205,6 +214,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'audiogram' as const,
 		type: 'video' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 	{
 		homePageLabel: 'Skia',
@@ -221,6 +231,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'skia' as const,
 		type: 'video' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 	{
 		homePageLabel: 'Tailwind',
@@ -238,6 +249,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'tailwind' as const,
 		type: 'video' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 
 	{
@@ -261,5 +273,6 @@ export const FEATURED_TEMPLATES: Template[] = [
 		cliId: 'overlay' as const,
 		type: 'video' as const,
 		defaultBranch: 'main',
+		listed: true,
 	},
 ].filter(truthy);

--- a/packages/docs/src/pages/templates/index.tsx
+++ b/packages/docs/src/pages/templates/index.tsx
@@ -47,23 +47,25 @@ export default () => {
           Jumpstart your project with a template that fits your usecase.
         </p>
         <div className={styles.grid}>
-          {CreateVideoInternals.FEATURED_TEMPLATES.map((template) => {
-            return (
-              <Link
-                key={template.cliId}
-                className={styles.item}
-                style={outer}
-                to={`/templates/${template.cliId}`}
-              >
-                <Item
-                  label={template.homePageLabel}
-                  description={template.description}
+          {CreateVideoInternals.FEATURED_TEMPLATES.filter((f) => f.listed).map(
+            (template) => {
+              return (
+                <Link
+                  key={template.cliId}
+                  className={styles.item}
+                  style={outer}
+                  to={`/templates/${template.cliId}`}
                 >
-                  <IconForTemplate scale={0.7} template={template} />
-                </Item>
-              </Link>
-            );
-          })}
+                  <Item
+                    label={template.homePageLabel}
+                    description={template.description}
+                  >
+                    <IconForTemplate scale={0.7} template={template} />
+                  </Item>
+                </Link>
+              );
+            }
+          )}
         </div>
         <br />
         <p style={lowerpara}>


### PR DESCRIPTION
I cannot use the TTS template anymore, the Azure service is just responding anymore. This is after another report we have received https://github.com/remotion-dev/remotion/issues/2153.

It is currently not clear whether this is a problem with our accounts or the API does not work generally anymore. Until it is clear what the problem is, we are hiding the template because people might have a bad experience with it.

