### PR TITLE
Fix env variable hot reloading

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -74,8 +74,6 @@ export const getConfig = ({
 		onProgress,
 		enableCaching: options?.enableCaching ?? true,
 		maxTimelineTracks: 15,
-		// For production, the variables are set dynamically
-		envVariables: {},
 		entryPoints: [],
 		remotionRoot: resolvedRemotionRoot,
 		keyboardShortcutsEnabled: false,

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -1,7 +1,6 @@
 import {createHash} from 'crypto';
 import ReactDOM from 'react-dom';
 import type {WebpackConfiguration, WebpackOverrideFn} from 'remotion';
-import {Internals} from 'remotion';
 import webpack, {ProgressPlugin} from 'webpack';
 import type {LoaderOptions} from './esbuild-loader/interfaces';
 import {ReactFreshWebpackPlugin} from './fast-refresh';
@@ -43,7 +42,6 @@ export const webpackConfig = ({
 	webpackOverride = (f) => f,
 	onProgress,
 	enableCaching = true,
-	envVariables,
 	maxTimelineTracks,
 	entryPoints,
 	remotionRoot,
@@ -57,7 +55,6 @@ export const webpackConfig = ({
 	webpackOverride: WebpackOverrideFn;
 	onProgress?: (f: number) => void;
 	enableCaching?: boolean;
-	envVariables: Record<string, string>;
 	maxTimelineTracks: number;
 	keyboardShortcutsEnabled: boolean;
 	entryPoints: string[];
@@ -106,8 +103,6 @@ export const webpackConfig = ({
 							'process.env.MAX_TIMELINE_TRACKS': maxTimelineTracks,
 							'process.env.KEYBOARD_SHORTCUTS_ENABLED':
 								keyboardShortcutsEnabled,
-							[`process.env.${Internals.ENV_VARIABLES_ENV_NAME}`]:
-								JSON.stringify(envVariables),
 						}),
 						new AllowOptionalDependenciesPlugin(),
 				  ]

--- a/packages/cli/src/preview-server/start-server.ts
+++ b/packages/cli/src/preview-server/start-server.ts
@@ -36,7 +36,6 @@ export const startServer = async (options: {
 		environment: 'development',
 		webpackOverride:
 			options?.webpackOverride ?? ConfigInternals.getWebpackOverrideFn(),
-		envVariables: options?.getEnvVariables() ?? {},
 		maxTimelineTracks: options?.maxTimelineTracks ?? 15,
 		entryPoints: [
 			require.resolve('./hot-middleware/client'),

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -32,10 +32,7 @@ import {usePreload} from './prefetch.js';
 import {getRoot, waitForRoot} from './register-root.js';
 import {RemotionRoot} from './RemotionRoot.js';
 import {SequenceContext} from './SequenceContext.js';
-import {
-	ENV_VARIABLES_ENV_NAME,
-	setupEnvVariables,
-} from './setup-env-variables.js';
+import {setupEnvVariables} from './setup-env-variables.js';
 import type {
 	SetTimelineContextValue,
 	TimelineContextValue,
@@ -89,7 +86,6 @@ export const Internals = {
 	RemotionContextProvider,
 	CSSUtils,
 	setupEnvVariables,
-	ENV_VARIABLES_ENV_NAME,
 	MediaVolumeContext,
 	SetMediaVolumeContext,
 	validateDurationInFrames,

--- a/packages/core/src/setup-env-variables.ts
+++ b/packages/core/src/setup-env-variables.ts
@@ -1,7 +1,5 @@
 import {getRemotionEnvironment} from './get-environment.js';
 
-export const ENV_VARIABLES_ENV_NAME = 'ENV_VARIABLES' as const;
-
 const getEnvVariables = (): Record<string, string> => {
 	if (getRemotionEnvironment() === 'rendering') {
 		const param = window.remotion_envVariables;
@@ -13,11 +11,10 @@ const getEnvVariables = (): Record<string, string> => {
 	}
 
 	if (getRemotionEnvironment() === 'preview') {
-		// Webpack will convert this to an object at compile time.
-		// Don't convert this syntax to a computed property.
+		// For the Preview, we already set the environment variables in index-html.ts.
+		// We just add NODE_ENV here.
 		return {
-			...(process.env.ENV_VARIABLES as unknown as Record<string, string>),
-			NODE_ENV: process.env.NODE_ENV as string,
+			NODE_ENV: 'development',
 		};
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,12 +776,6 @@ importers:
     devDependencies:
       remotion: link:../core
 
-  packages/lambda-php-example/vendor/remotion/lambda:
-    specifiers:
-      remotion: workspace:*
-    devDependencies:
-      remotion: link:../../../../core
-
   packages/lottie:
     specifiers:
       '@jonny/eslint-config': 3.0.266


### PR DESCRIPTION
There is some extra logic that is not necessary anymore and actually breaks env variable hot reloading in the Preview.