### PR TITLE
`@remotion/lambda`: Don't delete sites with the same prefix as a side effect

### DIFF
--- a/packages/lambda/src/api/delete-site.ts
+++ b/packages/lambda/src/api/delete-site.ts
@@ -35,7 +35,8 @@ export const deleteSite = async ({
 
 	let files = await lambdaLs({
 		bucketName,
-		prefix: getSitesKey(siteName),
+		// The `/` is important to not accidentially delete sites with the same name but containing a suffix.
+		prefix: `${getSitesKey(siteName)}/`,
 		region,
 		expectedBucketOwner: accountId,
 	});
@@ -55,7 +56,8 @@ export const deleteSite = async ({
 		});
 		files = await lambdaLs({
 			bucketName,
-			prefix: getSitesKey(siteName),
+			// The `/` is important to not accidentially delete sites with the same name but containing a suffix.
+			prefix: `${getSitesKey(siteName)}/`,
 			region,
 			expectedBucketOwner: accountId,
 		});

--- a/packages/lambda/src/api/deploy-site.ts
+++ b/packages/lambda/src/api/deploy-site.ts
@@ -89,7 +89,8 @@ export const deploySite = async ({
 			bucketName,
 			expectedBucketOwner: accountId,
 			region,
-			prefix: subFolder,
+			// The `/` is important to not accidentially delete sites with the same name but containing a suffix.
+			prefix: `${subFolder}/`,
 		}),
 		bundleSite({
 			publicPath: `/${subFolder}/`,


### PR DESCRIPTION
Fixes bug: When deleting or overwriting site `my-site`, it would also delete `my-site-staging` because it has the same prefix.