### PR TITLE
add Geologica font to @remotion/google-fonts

### DIFF
--- a/packages/google-fonts/package.json
+++ b/packages/google-fonts/package.json
@@ -1382,6 +1382,9 @@
       "Geo": [
         "dist/esm/Geo.d.ts"
       ],
+      "Geologica": [
+        "dist/esm/Geologica.d.ts"
+      ],
       "Georama": [
         "dist/esm/Georama.d.ts"
       ],
@@ -7202,6 +7205,12 @@
       "module": "./dist/esm/Geo.mjs",
       "import": "./dist/esm/Geo.mjs",
       "types": "./dist/cjs/Geo.d.ts"
+    },
+    "./Geologica": {
+      "require": "./dist/cjs/Geologica.cjs",
+      "module": "./dist/esm/Geologica.mjs",
+      "import": "./dist/esm/Geologica.mjs",
+      "types": "./dist/cjs/Geologica.d.ts"
     },
     "./Georama": {
       "require": "./dist/cjs/Georama.cjs",

--- a/packages/google-fonts/scripts/google-fonts.ts
+++ b/packages/google-fonts/scripts/google-fonts.ts
@@ -4706,6 +4706,24 @@ export const googleFonts: Font[] = [
     category: "sans-serif",
   },
   {
+    family: "Geologica",
+    variants: [
+      "100",
+      "200",
+      "300",
+      "regular",
+      "500",
+      "600",
+      "700",
+      "800",
+      "900",
+    ],
+    subsets: ["cyrillic", "cyrillic-ext", "latin", "latin-ext", "vietnamese"],
+    version: "v1",
+    lastModified: "2023-04-12",
+    category: "sans-serif",
+  },
+  {
     family: "Georama",
     variants: [
       "100",


### PR DESCRIPTION
This PR adds support for the [Geologica font](https://fonts.google.com/specimen/Geologica) to `@remotion/google-fonts`.

Not entirely sure I did this correctly but I followed the patterns from #1851 so 🤞 