### PR TITLE
fix: #2421. Propagate --force-bucket-name in rm.ts and get-sites.ts

### DIFF
--- a/packages/docs/docs/lambda/getsites.md
+++ b/packages/docs/docs/lambda/getsites.md
@@ -50,9 +50,11 @@ An object with the following properties:
 
 The [AWS region](/docs/lambda/region-selection) which you want to query.
 
-### `forced?`
+### `forceBucketName?`<AvailableFrom v="3.3.102"/>
 
-Whether the bucket name is forced or not. Forcing overrides the default prefix (`REMOTION_BUCKET_PREFIX`, which is currently `'remotionlambda-'`).
+_optional_
+
+Specify a specific bucket name to be used. [This is not recommended](/docs/lambda/multiple-buckets), instead let Remotion discover the right bucket automatically.
 
 ## Return value
 

--- a/packages/docs/docs/lambda/getsites.md
+++ b/packages/docs/docs/lambda/getsites.md
@@ -50,6 +50,10 @@ An object with the following properties:
 
 The [AWS region](/docs/lambda/region-selection) which you want to query.
 
+### `forced?`
+
+Whether the bucket name is forced or not. Forcing overrides the default prefix (`REMOTION_BUCKET_PREFIX`, which is currently `'remotionlambda-'`).
+
 ## Return value
 
 A promise resolving to an object with the following properties:

--- a/packages/lambda/src/api/get-buckets.ts
+++ b/packages/lambda/src/api/get-buckets.ts
@@ -11,7 +11,7 @@ export type BucketWithLocation = {
 };
 
 export const getRemotionS3Buckets = async (
-	region: AwsRegion
+	region: AwsRegion, bucketPrefix: string = REMOTION_BUCKET_PREFIX
 ): Promise<{
 	remotionBuckets: BucketWithLocation[];
 }> => {
@@ -23,7 +23,7 @@ export const getRemotionS3Buckets = async (
 	}
 
 	const remotionBuckets = Buckets.filter((b) =>
-		b.Name?.startsWith(REMOTION_BUCKET_PREFIX)
+		b.Name?.startsWith(bucketPrefix)
 	);
 
 	const locations = await Promise.all(

--- a/packages/lambda/src/api/get-buckets.ts
+++ b/packages/lambda/src/api/get-buckets.ts
@@ -1,7 +1,7 @@
 import {GetBucketLocationCommand, ListBucketsCommand} from '@aws-sdk/client-s3';
+import {REMOTION_BUCKET_PREFIX} from '../defaults';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {getS3Client} from '../shared/aws-clients';
-import {REMOTION_BUCKET_PREFIX} from '../shared/constants';
 import {parseBucketName} from '../shared/validate-bucketname';
 
 export type BucketWithLocation = {
@@ -11,7 +11,8 @@ export type BucketWithLocation = {
 };
 
 export const getRemotionS3Buckets = async (
-	region: AwsRegion, bucketPrefix: string = REMOTION_BUCKET_PREFIX
+	region: AwsRegion,
+	forceBucketName?: string
 ): Promise<{
 	remotionBuckets: BucketWithLocation[];
 }> => {
@@ -22,9 +23,13 @@ export const getRemotionS3Buckets = async (
 		return {remotionBuckets: []};
 	}
 
-	const remotionBuckets = Buckets.filter((b) =>
-		b.Name?.startsWith(bucketPrefix)
-	);
+	const remotionBuckets = Buckets.filter((b) => {
+		if (forceBucketName) {
+			return b.Name === forceBucketName;
+		}
+
+		return b.Name?.startsWith(REMOTION_BUCKET_PREFIX);
+	});
 
 	const locations = await Promise.all(
 		remotionBuckets.map(async (bucket) => {

--- a/packages/lambda/src/api/get-sites.ts
+++ b/packages/lambda/src/api/get-sites.ts
@@ -31,7 +31,7 @@ export type GetSitesOutput = {
  */
 export const getSites = async ({
 	region,
-}: GetSitesInput, forced: boolean): Promise<GetSitesOutput> => {
+}: GetSitesInput, forced?: boolean): Promise<GetSitesOutput> => {
 	const {remotionBuckets} = forced ? await getRemotionS3Buckets(region) : await getRemotionS3Buckets(region, "");
 	const accountId = await getAccountId({region});
 

--- a/packages/lambda/src/api/get-sites.ts
+++ b/packages/lambda/src/api/get-sites.ts
@@ -16,6 +16,7 @@ type Site = {
 
 export type GetSitesInput = {
 	region: AwsRegion;
+	forceBucketName?: string;
 };
 
 export type GetSitesOutput = {
@@ -31,8 +32,11 @@ export type GetSitesOutput = {
  */
 export const getSites = async ({
 	region,
-}: GetSitesInput, forced?: boolean): Promise<GetSitesOutput> => {
-	const {remotionBuckets} = forced ? await getRemotionS3Buckets(region) : await getRemotionS3Buckets(region, "");
+	forceBucketName,
+}: GetSitesInput): Promise<GetSitesOutput> => {
+	const {remotionBuckets} = forceBucketName
+		? await getRemotionS3Buckets(region, forceBucketName)
+		: await getRemotionS3Buckets(region);
 	const accountId = await getAccountId({region});
 
 	const sites: {[key: string]: Site} = {};

--- a/packages/lambda/src/api/get-sites.ts
+++ b/packages/lambda/src/api/get-sites.ts
@@ -31,8 +31,8 @@ export type GetSitesOutput = {
  */
 export const getSites = async ({
 	region,
-}: GetSitesInput): Promise<GetSitesOutput> => {
-	const {remotionBuckets} = await getRemotionS3Buckets(region);
+}: GetSitesInput, forced: boolean): Promise<GetSitesOutput> => {
+	const {remotionBuckets} = forced ? await getRemotionS3Buckets(region) : await getRemotionS3Buckets(region, "");
 	const accountId = await getAccountId({region});
 
 	const sites: {[key: string]: Site} = {};

--- a/packages/lambda/src/cli/commands/sites/create.ts
+++ b/packages/lambda/src/cli/commands/sites/create.ts
@@ -124,6 +124,7 @@ export const sitesCreateSubcommand = async (
 			},
 			enableCaching: ConfigInternals.getWebpackCaching(),
 			webpackOverride: ConfigInternals.getWebpackOverrideFn() ?? ((f) => f),
+			bypassBucketNameValidation: Boolean(parsedLambdaCli['force-bucket-name']),
 		},
 		region: getAwsRegion(),
 		privacy: parsedLambdaCli.privacy as Exclude<Privacy, 'private'> | undefined,

--- a/packages/lambda/src/cli/commands/sites/rm.ts
+++ b/packages/lambda/src/cli/commands/sites/rm.ts
@@ -25,7 +25,7 @@ export const sitesRmSubcommand = async (args: string[]) => {
 	const region = getAwsRegion();
 	const deployedSites = await getSites({
 		region,
-	});
+	}, Boolean(parsedLambdaCli['force-bucket-name']));
 
 	for (const siteName of args) {
 		const bucketName =

--- a/packages/lambda/src/cli/commands/sites/rm.ts
+++ b/packages/lambda/src/cli/commands/sites/rm.ts
@@ -25,13 +25,14 @@ export const sitesRmSubcommand = async (args: string[]) => {
 	const region = getAwsRegion();
 	const deployedSites = await getSites({
 		region,
-	}, Boolean(parsedLambdaCli['force-bucket-name']));
+		forceBucketName: parsedLambdaCli['force-bucket-name'],
+	});
+
+	const bucketName =
+		parsedLambdaCli['force-bucket-name'] ??
+		(await getOrCreateBucket({region})).bucketName;
 
 	for (const siteName of args) {
-		const bucketName =
-			parsedLambdaCli['force-bucket-name'] ??
-			(await getOrCreateBucket({region})).bucketName;
-
 		const site = deployedSites.sites.find((s) => s.id === siteName.trim());
 		if (!site) {
 			Log.error(

--- a/packages/lambda/src/test/integration/get-sites.test.ts
+++ b/packages/lambda/src/test/integration/get-sites.test.ts
@@ -7,8 +7,7 @@ test('Should have no buckets at first', async () => {
 	expect(
 		await getSites({
 			region: 'us-east-1',
-		},
-		false)
+		})
 	).toEqual({buckets: [], sites: []});
 });
 
@@ -33,7 +32,7 @@ test('Should have a site after deploying', async () => {
 			uploadedFiles: 2,
 		},
 	});
-	expect(await getSites({region: 'eu-central-1'}, false)).toEqual({
+	expect(await getSites({region: 'eu-central-1'})).toEqual({
 		buckets: [
 			{
 				creationDate: 0,

--- a/packages/lambda/src/test/integration/get-sites.test.ts
+++ b/packages/lambda/src/test/integration/get-sites.test.ts
@@ -7,7 +7,8 @@ test('Should have no buckets at first', async () => {
 	expect(
 		await getSites({
 			region: 'us-east-1',
-		})
+		},
+		false)
 	).toEqual({buckets: [], sites: []});
 });
 
@@ -32,7 +33,7 @@ test('Should have a site after deploying', async () => {
 			uploadedFiles: 2,
 		},
 	});
-	expect(await getSites({region: 'eu-central-1'})).toEqual({
+	expect(await getSites({region: 'eu-central-1'}, false)).toEqual({
 		buckets: [
 			{
 				creationDate: 0,


### PR DESCRIPTION
Solves #2421.

There was a bug where `--forced-bucket-name` was not propagated properly.

/claim #2421
