### PR TITLE
feat(docs): Lottie TableOfContents

### DIFF
--- a/packages/docs/components/TableOfContents/lottie.tsx
+++ b/packages/docs/components/TableOfContents/lottie.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Grid } from "./Grid";
+import { TOCItem } from "./TOCItem";
+
+export const TableOfContents = () => {
+  return (
+    <div>
+      <Grid>
+        <h1>Functions</h1>
+        <TOCItem link="/docs/lottie/getlottiemetadata">
+          <strong>getLottieMetadata()</strong>
+          <div>Get metadata of a Lottie animation</div>
+        </TOCItem>
+        <TOCItem link="/docs/staticfile">
+          <strong>staticFile()</strong>
+          <div>Load Lottie animations from a static file</div>
+        </TOCItem>
+        <TOCItem link="/docs/lottie/remote">
+          <div>Loading Lottie animations from a remote URL</div>
+        </TOCItem>
+        <TOCItem link="/docs/lottie/lottiefiles">
+          <div>Where to find Lottie files</div>
+        </TOCItem>
+      </Grid>
+    </div>
+  );
+};

--- a/packages/docs/components/TableOfContents/lottie.tsx
+++ b/packages/docs/components/TableOfContents/lottie.tsx
@@ -6,11 +6,15 @@ export const TableOfContents = () => {
   return (
     <div>
       <Grid>
+        <TOCItem link="/docs/lottie/lottie">
+          <strong>{"<Lottie>"}</strong>
+          <div>Embed a Lottie animation in Remotion</div>
+        </TOCItem>
         <TOCItem link="/docs/lottie/getlottiemetadata">
           <strong>getLottieMetadata()</strong>
           <div>Get metadata of a Lottie animation</div>
         </TOCItem>
-        <TOCItem link="/docs/staticfile">
+        <TOCItem link="/docs/lottie/staticfile">
           <strong>staticFile()</strong>
           <div>Load Lottie animations from a static file</div>
         </TOCItem>

--- a/packages/docs/components/TableOfContents/lottie.tsx
+++ b/packages/docs/components/TableOfContents/lottie.tsx
@@ -6,7 +6,6 @@ export const TableOfContents = () => {
   return (
     <div>
       <Grid>
-        <h1>Functions</h1>
         <TOCItem link="/docs/lottie/getlottiemetadata">
           <strong>getLottieMetadata()</strong>
           <div>Get metadata of a Lottie animation</div>

--- a/packages/docs/docs/lottie/index.md
+++ b/packages/docs/docs/lottie/index.md
@@ -7,6 +7,7 @@ title: "@remotion/lottie"
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import {TableOfContents} from "../../components/TableOfContents/lottie"
 
 This package provides a component for displaying [Lottie](http://airbnb.io/lottie/) animations in Remotion.
 
@@ -69,3 +70,11 @@ You can now start using the [`<Lottie>`](/docs/lottie/lottie) component in your 
 ## APIs
 
 - [`<Lottie>`](/docs/lottie/lottie)
+
+## Functions
+
+<TableOfContents />
+
+## License
+
+MIT

--- a/packages/docs/docs/lottie/index.md
+++ b/packages/docs/docs/lottie/index.md
@@ -67,14 +67,10 @@ You can now start using the [`<Lottie>`](/docs/lottie/lottie) component in your 
 [Open an issue](https://remotion.dev/issue) if you want to request a currently unsupported feature.
 :::
 
-## APIs
-
-- [`<Lottie>`](/docs/lottie/lottie)
-
-## Functions
+## Table of contents
 
 <TableOfContents />
 
 ## License
 
-MIT
+[Remotion License](https://remotion.dev/license)


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

@JonnyBurger, Kindly review this. 

After a second look at all APIs, I found out that most of them have the TOC component. The ones that do not have them include a "See more" text that redirects people to these resource(s) respectively. 

I think that works. So there won't be any need for me to add a TOC component. Let me know what you think when you get this.
