### PR TITLE
`remotion`: staticFile() does not encode `/` anymore

### DIFF
--- a/packages/core/src/static-file.ts
+++ b/packages/core/src/static-file.ts
@@ -67,6 +67,16 @@ const inner = (path: string): string => {
 	return `/${trimLeadingSlash(path)}`;
 };
 
+const encodeBySplitting = (path: string): string => {
+	const splitBySlash = path.split('/');
+
+	const encodedArray = splitBySlash.map((element) => {
+		return encodeURIComponent(element);
+	});
+	const merged = encodedArray.join('/');
+	return merged;
+};
+
 /**
  * @description Reference a file from the public/ folder. If the file does not appear in the autocomplete, type the path manually.
  * @see [Documentation](https://www.remotion.dev/docs/staticfile)
@@ -113,7 +123,8 @@ export const staticFile = (path: string) => {
 		);
 	}
 
-	const preparsed = inner(encodeURIComponent(path));
+	const preprocessed = encodeBySplitting(path);
+	const preparsed = inner(preprocessed);
 
 	if (!preparsed.startsWith('/')) {
 		return `/${preparsed}`;

--- a/packages/core/src/test/static-file-safe-uri.test.ts
+++ b/packages/core/src/test/static-file-safe-uri.test.ts
@@ -20,3 +20,13 @@ test('staticFile() should encode all problematic characters except slashes', () 
 	const nameWithSlashes = '/test/#example/$word';
 	expect(staticFile(nameWithSlashes)).toBe('/test/%23example/%24word');
 });
+
+test('if no leading slash exists, one should be added', () => {
+	const nameWithSlashes = 'test/example';
+	expect(staticFile(nameWithSlashes)).toBe('/test/example');
+});
+
+test('problematic character at the beginning should be encoded correctly', () => {
+	const problematicStart = '#test/example';
+	expect(staticFile(problematicStart)).toBe('/%23test/example');
+});

--- a/packages/core/src/test/static-file-safe-uri.test.ts
+++ b/packages/core/src/test/static-file-safe-uri.test.ts
@@ -3,10 +3,20 @@ import {staticFile} from '../static-file.js';
 
 test('staticFile() should convert # into %23', () => {
 	const unsafeName = 'test/example#music';
-	expect(staticFile(unsafeName)).toBe('/test%2Fexample%23music');
+	expect(staticFile(unsafeName)).toBe('/test/example%23music');
 });
 
 test('staticFile() passing already encoded path should give warning', () => {
 	const unsafeName = '/test%2Fexample%23music';
-	expect(staticFile(unsafeName)).toBe('/%2Ftest%252Fexample%2523music');
+	expect(staticFile(unsafeName)).toBe('/test%252Fexample%2523music');
+});
+
+test('staticFile() should not encode slashes', () => {
+	const nameWithSlashes = '/test/example/word';
+	expect(staticFile(nameWithSlashes)).toBe(nameWithSlashes);
+});
+
+test('staticFile() should encode all problematic characters except slashes', () => {
+	const nameWithSlashes = '/test/#example/$word';
+	expect(staticFile(nameWithSlashes)).toBe('/test/%23example/%24word');
 });


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
