### PR TITLE
`@remotion/cli`: Fixing some layout regressions

### DIFF
--- a/packages/cli/src/editor/components/CopyButton.tsx
+++ b/packages/cli/src/editor/components/CopyButton.tsx
@@ -7,7 +7,11 @@ const iconStyle: React.CSSProperties = {
 	width: 16,
 	height: 16,
 	color: 'white',
-	verticalAlign: 'sub',
+};
+
+const buttonContainerStyle: React.CSSProperties = {
+	display: 'flex',
+	minWidth: '114px',
 };
 
 const copyIcon = (
@@ -55,7 +59,11 @@ export const CopyButton: React.FC<{
 	}, [copied]);
 
 	return (
-		<Button onClick={onClick}>
+		<Button
+			onClick={onClick}
+			style={{}}
+			buttonContainerStyle={buttonContainerStyle}
+		>
 			{copyIcon}
 			<Spacing x={1.5} />{' '}
 			<span style={labelStyle}>{copied ? labelWhenCopied : label}</span>

--- a/packages/cli/src/editor/components/OpenEditorButton.tsx
+++ b/packages/cli/src/editor/components/OpenEditorButton.tsx
@@ -10,8 +10,11 @@ const svgStyle: React.CSSProperties = {
 
 const buttonStyle: React.CSSProperties = {
 	border: 'none',
-	width: '25px',
-	height: '25px',
+	width: '20px',
+	height: '20px',
+	display: 'flex',
+	justifyContent: 'center',
+	alignItems: 'center',
 };
 export const OpenEditorButton: React.FC<{}> = () => {
 	const [hovered, setHovered] = useState<boolean>(false);

--- a/packages/cli/src/preview-server/error-overlay/remotion-overlay/Button.tsx
+++ b/packages/cli/src/preview-server/error-overlay/remotion-overlay/Button.tsx
@@ -13,6 +13,7 @@ const button: React.CSSProperties = {
 	fontSize: 14,
 	color: 'white',
 	flexDirection: 'row',
+	display: 'flex',
 };
 
 const ButtonRefForwardFunction: React.ForwardRefRenderFunction<
@@ -46,7 +47,6 @@ const ButtonRefForwardFunction: React.ForwardRefRenderFunction<
 			...(style ?? {}),
 		};
 	}, [style]);
-
 	const buttonContainer: React.CSSProperties = useMemo(() => {
 		return {
 			padding: 10,


### PR DESCRIPTION
CopyButton and OpenInEditorButton layout fixed 

close #2467 