### PR TITLE
`@remotion/renderer`: Filter out mixed content warnings for localhost frames

### DIFF
--- a/packages/renderer/src/browser/BrowserPage.ts
+++ b/packages/renderer/src/browser/BrowserPage.ts
@@ -63,6 +63,18 @@ interface WaitForOptions {
 	timeout?: number;
 }
 
+// Mixed Content warnings caused by localhost should not be displayed
+const filteredOut = (log: ConsoleMessage) => {
+	if (
+		log.text.includes('Mixed Content:') &&
+		log.text.includes('http://localhost:')
+	) {
+		return true;
+	}
+
+	return false;
+};
+
 export const enum PageEmittedEvents {
 	Console = 'console',
 	Error = 'error',
@@ -180,6 +192,11 @@ export class Page extends EventEmitter {
 
 		this.on('console', (log) => {
 			const {url, columnNumber, lineNumber} = log.location();
+
+			if (filteredOut(log)) {
+				return;
+			}
+
 			if (
 				url?.endsWith(Internals.bundleName) &&
 				lineNumber &&

--- a/packages/renderer/src/browser/BrowserPage.ts
+++ b/packages/renderer/src/browser/BrowserPage.ts
@@ -63,8 +63,8 @@ interface WaitForOptions {
 	timeout?: number;
 }
 
-// Mixed Content warnings caused by localhost should not be displayed
-const filteredOut = (log: ConsoleMessage) => {
+const shouldHideWarning = (log: ConsoleMessage) => {
+	// Mixed Content warnings caused by localhost should not be displayed
 	if (
 		log.text.includes('Mixed Content:') &&
 		log.text.includes('http://localhost:')
@@ -193,7 +193,7 @@ export class Page extends EventEmitter {
 		this.on('console', (log) => {
 			const {url, columnNumber, lineNumber} = log.location();
 
-			if (filteredOut(log)) {
+			if (shouldHideWarning(log)) {
 				return;
 			}
 

--- a/packages/renderer/src/browser/should-log-message.ts
+++ b/packages/renderer/src/browser/should-log-message.ts
@@ -23,6 +23,28 @@ export const shouldLogBrowserMessage = (message: string) => {
 		return false;
 	}
 
+	// Lambda function accessing resources from localhost
+	if (
+		message.includes('Mixed Content:') &&
+		message.includes('http://localhost:')
+	) {
+		return false;
+	}
+
+	if (
+		message.includes(
+			'CreatePlatformSocket() failed: Address family not supported by protocol (97)'
+		)
+	) {
+		return false;
+	}
+
+	if (
+		message.includes('[chrome] Fontconfig error: No writable cache directories')
+	) {
+		return false;
+	}
+
 	return true;
 };
 

--- a/packages/renderer/src/browser/should-log-message.ts
+++ b/packages/renderer/src/browser/should-log-message.ts
@@ -25,14 +25,14 @@ export const shouldLogBrowserMessage = (message: string) => {
 
 	if (
 		message.includes(
-			'CreatePlatformSocket() failed: Address family not supported by protocol (97)'
+			'CreatePlatformSocket() failed: Address family not supported by protocol'
 		)
 	) {
 		return false;
 	}
 
 	if (
-		message.includes('[chrome] Fontconfig error: No writable cache directories')
+		message.includes('Fontconfig error: No writable cache directories')
 	) {
 		return false;
 	}

--- a/packages/renderer/src/browser/should-log-message.ts
+++ b/packages/renderer/src/browser/should-log-message.ts
@@ -23,14 +23,6 @@ export const shouldLogBrowserMessage = (message: string) => {
 		return false;
 	}
 
-	// Lambda function accessing resources from localhost
-	if (
-		message.includes('Mixed Content:') &&
-		message.includes('http://localhost:')
-	) {
-		return false;
-	}
-
 	if (
 		message.includes(
 			'CreatePlatformSocket() failed: Address family not supported by protocol (97)'

--- a/packages/renderer/src/browser/should-log-message.ts
+++ b/packages/renderer/src/browser/should-log-message.ts
@@ -31,9 +31,7 @@ export const shouldLogBrowserMessage = (message: string) => {
 		return false;
 	}
 
-	if (
-		message.includes('Fontconfig error: No writable cache directories')
-	) {
+	if (message.includes('Fontconfig error: No writable cache directories')) {
 		return false;
 	}
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
