### PR TITLE
Document breaking change: The props of a composition must be a `type`, not an `interface`

### DIFF
--- a/packages/docs/docs/4-0-migration.md
+++ b/packages/docs/docs/4-0-migration.md
@@ -280,6 +280,39 @@ You can now remove your re-encoding logic!
 
 Since the input props are passed to a React component, they must not explicitly be objects (`{}`). You can still use other data structures such as arrays, but they must be wrapped in an object.
 
+## Cannot use an `interface` for props
+
+The following code now gives a type error:
+
+```tsx
+interface MyProps {
+  title: string;
+}
+
+const Hi = (props: MyProps) => {
+  return <div>{props.title}</div>;
+};
+
+<Still
+  component={Hi}
+  id="interface-props"
+  defaultProps={{ title: "hi" }}
+  height={1080}
+  width={1080}
+/>;
+```
+
+This is because props must now be an object and satisfy the shape `Record<string, unknown>`.  
+`interface`'s do not satisfy this shape, so you must use a `type` instead:
+
+```tsx
+type MyProps = {
+  title: string;
+};
+```
+
+See also: [Input props must be an object](/docs/4-0-migration#input-props-must-be-an-object)
+
 ## `defaultProps` is required if the component has props
 
 If you register a composition with a component that requires some props, you now are required to provide a `defaultProps` object.

--- a/packages/docs/docs/composition.md
+++ b/packages/docs/docs/composition.md
@@ -81,6 +81,10 @@ Type your components using the `React.FC<{}>` type and the `defaultProps` prop w
 Passing huge objects to `defaultProps` can be slow. [Learn how to avoid it.](/docs/troubleshooting/defaultprops-too-big)
 :::
 
+:::note
+Use a `type`, not an `interface` to type your `defaultProps`. [Learn why](/docs/4-0-migration#cannot-use-an-interface-for-props)
+:::
+
 ### `calculateMetadata`
 
 See: [`calculateMetadata()`](/docs/calculate-metadata)


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
