### PR TITLE
Fix typo in pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
   - "packages/**"
-  - "packages/lambda-php-example/vendor/remotion/lambda"
+  - "!packages/lambda-php-example/vendor/remotion/lambda"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
   - "packages/**"
-  - "packges/lambda-php-example/vendor/remotion/lambda"
+  - "packages/lambda-php-example/vendor/remotion/lambda"


### PR DESCRIPTION
Spotted a typo in the pnpm workspace file while browsing the source; might be intentional in which case feel free to close
