### PR TITLE
fix selectComposition return type

### DIFF
--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -766,7 +766,7 @@ export const renderMedia = ({
 		serializedResolvedPropsWithCustomSchema: Internals.serializeJSONWithDate({
 			indent: undefined,
 			staticBase: null,
-			data: composition.props,
+			data: composition.props ?? {},
 		}).serializedString,
 	});
 };

--- a/packages/renderer/src/select-composition.ts
+++ b/packages/renderer/src/select-composition.ts
@@ -262,7 +262,7 @@ export const internalSelectComposition = async (
  */
 export const selectComposition = async (
 	options: SelectCompositionOptions
-): Promise<Omit<VideoConfig, 'defaultProps'>> => {
+): Promise<VideoConfig> => {
 	const {
 		id,
 		serveUrl,
@@ -276,6 +276,7 @@ export const selectComposition = async (
 		timeoutInMilliseconds,
 		verbose,
 	} = options;
+
 	const data = await internalSelectComposition({
 		id,
 		serveUrl,

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,11 @@
       "outputMode": "new-only"
     },
     "docs": {
-      "outputs": ["build/**", ".docusaurus"]
+      "outputs": [
+        "build/**",
+        ".docusaurus",
+        "../../node_modules/.cache/twoslash"
+      ]
     },
     "test": {
       "dependsOn": ["^build", "build"],


### PR DESCRIPTION
Also we add twoslash output as the outputs in turborepo, to hopefully bust the cache and fix cache issues in our docs