### PR TITLE
`@remotion/renderer`: Fix support for older TypeScript versions by not using `const[]`

### DIFF
--- a/packages/cli/src/editor/components/RenderModal/RenderModal.tsx
+++ b/packages/cli/src/editor/components/RenderModal/RenderModal.tsx
@@ -498,7 +498,9 @@ const RenderModal: React.FC<
 			if (
 				passedAudioCodec !== null &&
 				(
-					BrowserSafeApis.supportedAudioCodecs[passedVideoCodec] as AudioCodec[]
+					BrowserSafeApis.supportedAudioCodecs[
+						passedVideoCodec
+					] as readonly AudioCodec[]
 				).includes(passedAudioCodec)
 			) {
 				return passedAudioCodec;

--- a/packages/renderer/src/audio-codec.ts
+++ b/packages/renderer/src/audio-codec.ts
@@ -8,7 +8,7 @@ export const supportedAudioCodecs = {
 	h264: ['aac', 'pcm-16'] as const,
 	'h264-mkv': ['pcm-16'] as const,
 	aac: ['aac', 'pcm-16'] as const,
-	gif: [] as const[],
+	gif: [] as const,
 	h265: ['aac', 'pcm-16'] as const,
 	mp3: ['mp3', 'pcm-16'] as const,
 	prores: ['aac', 'pcm-16'] as const,


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
