### PR TITLE
Docs: Fix factual error: Remotion requires at least libc 2.35

### DIFF
--- a/packages/cli/src/handle-common-errors.ts
+++ b/packages/cli/src/handle-common-errors.ts
@@ -77,7 +77,7 @@ export const handleCommonError = async (err: Error, logLevel: LogLevel) => {
 	}
 
 	if (err.message.includes('GLIBC_')) {
-		Log.info('💡 Remotion requires at least Libc 2.34.');
+		Log.info('💡 Remotion requires at least Libc 2.35.');
 		Log.info(
 			'💡 Get help for this issue: https://github.com/remotion-dev/remotion/issues/2439'
 		);

--- a/packages/docs/docs/4-0-migration.md
+++ b/packages/docs/docs/4-0-migration.md
@@ -35,7 +35,7 @@ The minimum Node version is now 16.0.0.
 
 Only the following platforms are supported: Windows (x64 only), macOS, Linux.
 
-Linux distros with glibc need to have at least version 2.34. [See here](https://github.com/remotion-dev/remotion/issues/2439) for more information.
+Linux distros with glibc need to have at least version 2.35. [See here](https://github.com/remotion-dev/remotion/issues/2439) for more information.
 
 ## Config file changes
 

--- a/packages/docs/docs/getting-started.md
+++ b/packages/docs/docs/getting-started.md
@@ -95,7 +95,7 @@ Watch out for `apt` wanting to uninstall critical packages (e.g the Desktop) in 
 
 </Tabs>
 
-Linux distros that use libc need at least version 2.34 of it. [Check here](https://github.com/remotion-dev/remotion/issues/2439) if your distro has it.
+Linux distros that use libc need at least version 2.35 of it. [Check here](https://github.com/remotion-dev/remotion/issues/2439) if your distro has it.
 
 Got instructions for more Linux distributions? [Add them to this page](https://github.com/remotion-dev/remotion/edit/main/packages/docs/docs/getting-started.md)!
 


### PR DESCRIPTION
Not 2.34