### PR TITLE
fix: "Jump to Beginning" button should jump to "Mark In" frame if active

### DIFF
--- a/packages/cli/src/editor/components/PlayPause.tsx
+++ b/packages/cli/src/editor/components/PlayPause.tsx
@@ -153,12 +153,12 @@ export const PlayPause: React.FC<{
 	}, [frameForward]);
 
 	const jumpToStart = useCallback(() => {
-		seek(0);
-	}, [seek]);
+		seek(inFrame ?? 0);
+	}, [seek, inFrame]);
 
 	const jumpToEnd = useCallback(() => {
-		seek(getCurrentDuration() - 1);
-	}, [seek]);
+		seek(outFrame ?? getCurrentDuration() - 1);
+	}, [seek, outFrame]);
 
 	const keybindings = useKeybinding();
 


### PR DESCRIPTION
This PR solves #2573. When the user presses on "Jump to Beginning" Button or presses "a" key, the pointer jumps to the "Mark In" frame if it is active instead of the first frame of the composition. Similarly, when the user presses "e" key, the pointer moves to the "Mark Out" frame if it is active instead of the last frame of the composition.
 
video - https://jam.dev/c/6dd9913a-0d57-4d50-8eee-6889ad3c5c81

