### PR TITLE
Add redirection for booking

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -28,6 +28,11 @@
       "permanent": false
     },
     {
+      "source": "/booking",
+      "destination": "https://cal.com/remotion",
+      "permanent": false
+    },
+    {
       "source": "/coc",
       "destination": "https://github.com/remotion-dev/remotion/blob/main/CODE-OF-CONDUCT.md",
       "permanent": false


### PR DESCRIPTION
Instead of using "cal.com/remotion", let's also have "remotion.dev/booking". I would like to use it on our Google Search profile.
