### PR TITLE
`@remotion/renderer`: Give better error message if a React component takes a long time to compute

### DIFF
--- a/packages/renderer/src/browser/BrowserPage.ts
+++ b/packages/renderer/src/browser/BrowserPage.ts
@@ -149,7 +149,7 @@ export class Page extends EventEmitter {
 		super();
 		this.#client = client;
 		this.#target = target;
-		this.#frameManager = new FrameManager(client, this, this.#timeoutSettings);
+		this.#frameManager = new FrameManager(client, this);
 		this.screenshotTaskQueue = new TaskQueue();
 		this.browser = browser;
 		this.id = String(Math.random());
@@ -487,11 +487,16 @@ export class Page extends EventEmitter {
 		return this.mainFrame().url();
 	}
 
-	goto(
-		url: string,
-		options: WaitForOptions & {referer?: string} = {}
-	): Promise<HTTPResponse | null> {
-		return this.#frameManager.mainFrame().goto(url, options);
+	goto({
+		url,
+		timeout,
+		options = {},
+	}: {
+		url: string;
+		timeout: number;
+		options?: WaitForOptions & {referer?: string};
+	}): Promise<HTTPResponse | null> {
+		return this.#frameManager.mainFrame().goto(url, timeout, options);
 	}
 
 	async bringToFront(): Promise<void> {

--- a/packages/renderer/src/browser/FrameManager.ts
+++ b/packages/renderer/src/browser/FrameManager.ts
@@ -577,8 +577,8 @@ export class Frame {
 
 	goto(
 		url: string,
-		timeout: number
-,		options: {
+		timeout: number,
+		options: {
 			referer?: string;
 			waitUntil?: PuppeteerLifeCycleEvent;
 		} = {}

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -105,7 +105,7 @@ const innerGetCompositions = async ({
 		args: [],
 	});
 
-	await waitForReady(page);
+	await waitForReady({page, timeoutInMilliseconds, frame: null});
 	const {value: result} = await puppeteerEvaluateWithCatch({
 		pageFunction: () => {
 			return window.getStaticCompositions();

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -368,7 +368,12 @@ const innerRenderFrames = async ({
 
 		const startSeeking = Date.now();
 
-		await seekToFrame({frame, page: freePage, composition: compId});
+		await seekToFrame({
+			frame,
+			page: freePage,
+			composition: compId,
+			timeoutInMilliseconds,
+		});
 
 		const timeToSeek = Date.now() - startSeeking;
 		if (timeToSeek > 1000) {

--- a/packages/renderer/src/render-still.ts
+++ b/packages/renderer/src/render-still.ts
@@ -297,7 +297,12 @@ const innerRenderStill = async ({
 		frame: null,
 		page,
 	});
-	await seekToFrame({frame: stillFrame, page, composition: composition.id});
+	await seekToFrame({
+		frame: stillFrame,
+		page,
+		composition: composition.id,
+		timeoutInMilliseconds,
+	});
 
 	const {buffer} = await takeFrameAndCompose({
 		frame: stillFrame,

--- a/packages/renderer/src/select-composition.ts
+++ b/packages/renderer/src/select-composition.ts
@@ -107,7 +107,7 @@ const innerSelectComposition = async ({
 		args: [],
 	});
 
-	await waitForReady(page);
+	await waitForReady({page, timeoutInMilliseconds, frame: null});
 
 	Log.verboseAdvanced(
 		{

--- a/packages/renderer/src/set-props-and-env.ts
+++ b/packages/renderer/src/set-props-and-env.ts
@@ -74,7 +74,7 @@ const innerSetPropsAndEnv = async ({
 		window.remotion_videoEnabled = enabled;
 	}, videoEnabled);
 
-	const pageRes = await page.goto(urlToVisit);
+	const pageRes = await page.goto({url: urlToVisit, timeout: actualTimeout});
 
 	if (pageRes === null) {
 		throw new Error(`Visited "${urlToVisit}" but got no response.`);


### PR DESCRIPTION
In that case the error message describes it, and gives the frame at which it happens

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
