### PR TITLE
`@remotion/renderer`: surface original source if it fails to extract a frame

### DIFF
--- a/packages/renderer/rust/commands/mod.rs
+++ b/packages/renderer/rust/commands/mod.rs
@@ -9,7 +9,12 @@ use std::io::ErrorKind;
 pub fn execute_command(opts: CliInputCommandPayload) -> Result<Vec<u8>, ErrorWithBacktrace> {
     match opts {
         CliInputCommandPayload::ExtractFrame(command) => {
-            let res = ffmpeg::extract_frame(command.input, command.time, command.transparent)?;
+            let res = ffmpeg::extract_frame(
+                command.src,
+                command.original_src,
+                command.time,
+                command.transparent,
+            )?;
             Ok(res)
         }
         CliInputCommandPayload::GetOpenVideoStats(_) => {

--- a/packages/renderer/rust/ffmpeg.rs
+++ b/packages/renderer/rust/ffmpeg.rs
@@ -37,11 +37,12 @@ pub fn keep_only_latest_frames(frames: usize) -> Result<(), ErrorWithBacktrace> 
 
 pub fn extract_frame(
     src: String,
+    original_src: String,
     time: f64,
     transparent: bool,
 ) -> Result<Vec<u8>, ErrorWithBacktrace> {
     let manager = OpenedVideoManager::get_instance();
-    let video_locked = manager.get_video(&src, transparent)?;
+    let video_locked = manager.get_video(&src, &original_src, transparent)?;
     let mut vid = video_locked.lock()?;
 
     // The requested position in the video.

--- a/packages/renderer/rust/frame_cache.rs
+++ b/packages/renderer/rust/frame_cache.rs
@@ -27,6 +27,7 @@ pub struct FrameCacheReference {
     pub id: usize,
     pub last_used: u128,
     pub src: String,
+    pub original_src: String,
     pub transparent: bool,
 }
 
@@ -47,6 +48,7 @@ impl FrameCache {
     pub fn get_references(
         &self,
         src: String,
+        original_src: String,
         transparent: bool,
     ) -> Result<Vec<FrameCacheReference>, ErrorWithBacktrace> {
         let mut references: Vec<FrameCacheReference> = Vec::new();
@@ -55,6 +57,7 @@ impl FrameCache {
                 id: item.id,
                 last_used: item.last_used,
                 src: src.clone(),
+                original_src: original_src.clone(),
                 transparent,
             });
         }

--- a/packages/renderer/rust/opened_stream.rs
+++ b/packages/renderer/rust/opened_stream.rs
@@ -26,6 +26,7 @@ pub struct OpenedStream {
     pub format: Pixel,
     pub video: remotionffmpeg::codec::decoder::Video,
     pub src: String,
+    pub original_src: String,
     pub input: remotionffmpeg::format::context::Input,
     pub last_position: i64,
     pub duration_or_zero: i64,
@@ -306,8 +307,8 @@ impl OpenedStream {
             return Err(std::io::Error::new(
                 ErrorKind::Other,
                 format!(
-                    "No frame found at position {} for source {}",
-                    position, self.src
+                    "No frame found at position {} for source {} (original source = {})",
+                    position, self.src, self.original_src
                 ),
             ))?;
         }
@@ -338,6 +339,7 @@ pub fn get_display_aspect_ratio(mut_stream: &StreamMut) -> Rational {
 
 pub fn open_stream(
     src: &str,
+    original_src: &str,
     transparent: bool,
 ) -> Result<(OpenedStream, Rational, Rational), ErrorWithBacktrace> {
     let mut dictionary = Dictionary::new();
@@ -450,6 +452,7 @@ pub fn open_stream(
         reached_eof: false,
         transparent,
         rotation: rotate,
+        original_src: original_src.to_string(),
     };
 
     Ok((opened_stream, fps, time_base))

--- a/packages/renderer/rust/opened_video.rs
+++ b/packages/renderer/rust/opened_video.rs
@@ -16,10 +16,16 @@ pub struct OpenedVideo {
     pub fps: Rational,
     pub time_base: Rational,
     pub src: String,
+    pub original_src: String,
 }
 
-pub fn open_video(src: &str, transparent: bool) -> Result<OpenedVideo, ErrorWithBacktrace> {
-    let (opened_stream, fps, time_base) = opened_stream::open_stream(src, transparent)?;
+pub fn open_video(
+    src: &str,
+    original_src: &str,
+    transparent: bool,
+) -> Result<OpenedVideo, ErrorWithBacktrace> {
+    let (opened_stream, fps, time_base) =
+        opened_stream::open_stream(src, original_src, transparent)?;
 
     let opened_video = OpenedVideo {
         opened_streams: vec![(Arc::new(Mutex::new(opened_stream)))],
@@ -28,6 +34,7 @@ pub fn open_video(src: &str, transparent: bool) -> Result<OpenedVideo, ErrorWith
         fps,
         time_base,
         src: src.to_string(),
+        original_src: original_src.to_string(),
     };
 
     _print_verbose(&format!(
@@ -45,7 +52,8 @@ impl OpenedVideo {
         Ok(())
     }
     pub fn open_new_stream(&mut self, transparent: bool) -> Result<usize, ErrorWithBacktrace> {
-        let (opened_stream, _, _) = opened_stream::open_stream(&self.src, transparent)?;
+        let (opened_stream, _, _) =
+            opened_stream::open_stream(&self.src, &self.original_src, transparent)?;
         let arc_mutex = Arc::new(Mutex::new(opened_stream));
         self.opened_streams.push(arc_mutex);
         return Ok(self.opened_streams.len() - 1);

--- a/packages/renderer/rust/payloads.rs
+++ b/packages/renderer/rust/payloads.rs
@@ -56,7 +56,8 @@ pub mod payloads {
 
     #[derive(Serialize, Deserialize, Debug)]
     pub struct ExtractFrameCommand {
-        pub input: String,
+        pub src: String,
+        pub original_src: String,
         pub time: f64,
         pub transparent: bool,
     }

--- a/packages/renderer/src/compositor/payloads.ts
+++ b/packages/renderer/src/compositor/payloads.ts
@@ -52,7 +52,8 @@ export type CompositorCommand = {
 		output_format: CompositorImageFormat;
 	};
 	ExtractFrame: {
-		input: string;
+		src: string;
+		original_src: string;
 		time: number;
 		transparent: boolean;
 	};

--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -123,7 +123,8 @@ export const startOffthreadVideoServer = ({
 						extractStart = Date.now();
 						resolve(
 							compositor.executeCommand('ExtractFrame', {
-								input: to,
+								src: to,
+								original_src: src,
 								time,
 								transparent,
 							})

--- a/packages/renderer/src/test/extract-frame-rust.test.ts
+++ b/packages/renderer/src/test/extract-frame-rust.test.ts
@@ -18,14 +18,16 @@ test(
 		);
 
 		const data = await compositor.executeCommand('ExtractFrame', {
-			input: exampleVideos.bigBuckBunny,
+			src: exampleVideos.bigBuckBunny,
+			original_src: exampleVideos.bigBuckBunny,
 			time: 40,
 			transparent: false,
 		});
 		expect(data.length).toBe(1280 * 720 * 3 + BMP_HEADER_SIZE);
 
 		const data2 = await compositor.executeCommand('ExtractFrame', {
-			input: exampleVideos.bigBuckBunny,
+			src: exampleVideos.bigBuckBunny,
+			original_src: exampleVideos.bigBuckBunny,
 			time: 40.4,
 			transparent: false,
 		});
@@ -49,7 +51,8 @@ test(
 		);
 
 		const data = await compositor.executeCommand('ExtractFrame', {
-			input: exampleVideos.transparentWebm,
+			src: exampleVideos.transparentWebm,
+			original_src: exampleVideos.transparentWebm,
 			time: 1,
 			transparent: true,
 		});
@@ -88,12 +91,14 @@ test('Should be able to start two compositors', async () => {
 	);
 
 	await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.bigBuckBunny,
+		src: exampleVideos.bigBuckBunny,
+		original_src: exampleVideos.bigBuckBunny,
 		time: 40,
 		transparent: false,
 	});
 	await compositor2.executeCommand('ExtractFrame', {
-		input: exampleVideos.bigBuckBunny,
+		src: exampleVideos.bigBuckBunny,
+		original_src: exampleVideos.bigBuckBunny,
 		time: 40,
 		transparent: false,
 	});
@@ -107,13 +112,15 @@ test('Should be able to seek backwards', async () => {
 	);
 
 	const data = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.bigBuckBunny,
+		src: exampleVideos.bigBuckBunny,
+		original_src: exampleVideos.bigBuckBunny,
 		time: 40,
 		transparent: false,
 	});
 	expect(data.length).toBe(2764854);
 	const data2 = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.bigBuckBunny,
+		src: exampleVideos.bigBuckBunny,
+		original_src: exampleVideos.bigBuckBunny,
 		time: 35,
 		transparent: false,
 	});
@@ -133,7 +140,8 @@ test(
 		);
 
 		const data = await compositor.executeCommand('ExtractFrame', {
-			input: exampleVideos.framerWithoutFileExtension,
+			src: exampleVideos.framerWithoutFileExtension,
+			original_src: exampleVideos.framerWithoutFileExtension,
 			time: 0.04,
 			transparent: false,
 		});
@@ -155,7 +163,8 @@ test(
 		);
 
 		const data = await compositor.executeCommand('ExtractFrame', {
-			input: exampleVideos.framerWithoutFileExtension,
+			src: exampleVideos.framerWithoutFileExtension,
+			original_src: exampleVideos.framerWithoutFileExtension,
 			time: 3.33,
 			transparent: false,
 		});
@@ -186,7 +195,8 @@ test(
 		);
 
 		const data = await compositor.executeCommand('ExtractFrame', {
-			input: exampleVideos.corrupted,
+			src: exampleVideos.corrupted,
+			original_src: exampleVideos.corrupted,
 			time: 100,
 			transparent: false,
 		});
@@ -211,7 +221,8 @@ test('Should be able to extract a frame with abnormal DAR', async () => {
 	);
 
 	const data = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.customDar,
+		src: exampleVideos.customDar,
+		original_src: exampleVideos.customDar,
 		time: 3.33,
 		transparent: false,
 	});
@@ -243,7 +254,8 @@ test('Should be able to extract the frames in reverse order', async () => {
 
 	for (let i = 30; i > 0; i -= 2) {
 		const data = await compositor.executeCommand('ExtractFrame', {
-			input: exampleVideos.bigBuckBunny,
+			src: exampleVideos.bigBuckBunny,
+			original_src: exampleVideos.bigBuckBunny,
 			time: i,
 			transparent: false,
 		});
@@ -285,7 +297,8 @@ test('Last frame should be fast', async () => {
 	const time = Date.now();
 
 	const data = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.framerWithoutFileExtension,
+		src: exampleVideos.framerWithoutFileExtension,
+		original_src: exampleVideos.framerWithoutFileExtension,
 		time: 3.333,
 		transparent: false,
 	});
@@ -295,7 +308,8 @@ test('Last frame should be fast', async () => {
 
 	const time2 = Date.now();
 	const data2 = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.framerWithoutFileExtension,
+		src: exampleVideos.framerWithoutFileExtension,
+		original_src: exampleVideos.framerWithoutFileExtension,
 		time: 3.333,
 		transparent: false,
 	});
@@ -307,7 +321,8 @@ test('Last frame should be fast', async () => {
 
 	const time3 = Date.now();
 	const data3 = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.framerWithoutFileExtension,
+		src: exampleVideos.framerWithoutFileExtension,
+		original_src: exampleVideos.framerWithoutFileExtension,
 		time: 100,
 		transparent: false,
 	});
@@ -320,7 +335,8 @@ test('Last frame should be fast', async () => {
 	// Transparent frame should be different, so it should take a lot more time
 	const time4 = Date.now();
 	const data4 = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.framerWithoutFileExtension,
+		src: exampleVideos.framerWithoutFileExtension,
+		original_src: exampleVideos.framerWithoutFileExtension,
 		time: 100,
 		transparent: true,
 	});
@@ -341,7 +357,8 @@ test('Should get from a screen recording', async () => {
 	);
 
 	const data = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.screenrecording,
+		src: exampleVideos.screenrecording,
+		original_src: exampleVideos.screenrecording,
 		time: 0.5,
 		transparent: false,
 	});
@@ -360,7 +377,8 @@ test('Should get from video with no fps', async () => {
 	);
 
 	const data = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.nofps,
+		src: exampleVideos.nofps,
+		original_src: exampleVideos.nofps,
 		time: 0.5,
 		transparent: false,
 	});
@@ -379,7 +397,8 @@ test('Should get from broken webcam video', async () => {
 	);
 
 	const data = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.webcam,
+		src: exampleVideos.webcam,
+		original_src: exampleVideos.webcam,
 		time: 0,
 		transparent: false,
 	});
@@ -398,7 +417,8 @@ test('Should get from iPhone video', async () => {
 	);
 
 	const data = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.iphonevideo,
+		src: exampleVideos.iphonevideo,
+		original_src: exampleVideos.iphonevideo,
 		time: 3,
 		transparent: false,
 	});
@@ -417,7 +437,8 @@ test('Should get from AV1 video', async () => {
 	);
 
 	const data = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.av1,
+		src: exampleVideos.av1,
+		original_src: exampleVideos.av1,
 		time: 0.5,
 		transparent: false,
 	});
@@ -436,7 +457,8 @@ test('Two different starting times should not result in big seeking', async () =
 	for (let i = 0; i < 10; i++) {
 		const time = i + (i % 2 === 0 ? 60 : 0);
 		const data = await compositor.executeCommand('ExtractFrame', {
-			input: exampleVideos.bigBuckBunny,
+			src: exampleVideos.bigBuckBunny,
+			original_src: exampleVideos.bigBuckBunny,
 			time,
 			transparent: false,
 		});
@@ -534,13 +556,15 @@ test('Should not duplicate frames for iphoneVideo', async () => {
 	const compositor = startLongRunningCompositor(500, 'info', false);
 
 	const firstFrame = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.iphonevideo,
+		src: exampleVideos.iphonevideo,
+		original_src: exampleVideos.iphonevideo,
 		time: frame30,
 		transparent: false,
 	});
 
 	const secondFrame = await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.iphonevideo,
+		src: exampleVideos.iphonevideo,
+		original_src: exampleVideos.iphonevideo,
 		time: frame31,
 		transparent: false,
 	});

--- a/packages/renderer/src/test/rust-errors.test.ts
+++ b/packages/renderer/src/test/rust-errors.test.ts
@@ -15,7 +15,8 @@ test('Should get Rust errors in a good way', async () => {
 
 	try {
 		await compositor.executeCommand('ExtractFrame', {
-			input: 'invlaid',
+			src: 'invlaid',
+			original_src: 'invlaid',
 			time: 1,
 			transparent: false,
 		});
@@ -81,7 +82,8 @@ test('Non-long running task panics should be handled', async () => {
 
 test('Long running task failures should be handled', async () => {
 	const command = serializeCommand('ExtractFrame', {
-		input: 'fsdfds',
+		src: 'fsdfds',
+		original_src: 'fsdfds',
 		time: 1,
 		transparent: false,
 	});
@@ -101,7 +103,8 @@ test('Long running task failures should be handled', async () => {
 test('Invalid payloads will be handled', async () => {
 	// @ts-expect-error
 	const command = serializeCommand('ExtractFrame', {
-		input: 'fsdfds',
+		src: 'fsdfds',
+		original_src: 'fsdfds',
 	});
 	try {
 		await callCompositor(JSON.stringify(command));

--- a/packages/renderer/src/test/rust-memory-usage.test.ts
+++ b/packages/renderer/src/test/rust-memory-usage.test.ts
@@ -15,7 +15,8 @@ test('Memory usage should be determined ', async () => {
 	).toBeLessThan(10 * 1024 * 1024);
 
 	await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.bigBuckBunny,
+		src: exampleVideos.bigBuckBunny,
+		original_src: exampleVideos.bigBuckBunny,
 		time: 3.333,
 		transparent: false,
 	});
@@ -29,7 +30,8 @@ test('Memory usage should be determined ', async () => {
 	});
 
 	await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.framerWithoutFileExtension,
+		src: exampleVideos.framerWithoutFileExtension,
+		original_src: exampleVideos.framerWithoutFileExtension,
 		time: 3.333,
 		transparent: false,
 	});
@@ -82,7 +84,8 @@ test('Memory usage should be determined ', async () => {
 	).toBeLessThan(40 * 1024 * 1024);
 
 	await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.framerWithoutFileExtension,
+		src: exampleVideos.framerWithoutFileExtension,
+		original_src: exampleVideos.framerWithoutFileExtension,
 		time: 3.333,
 		transparent: false,
 	});
@@ -92,7 +95,8 @@ test('Should respect the maximum frame cache limit', async () => {
 	const compositor = startLongRunningCompositor(50, 'info', false);
 
 	await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.bigBuckBunny,
+		src: exampleVideos.bigBuckBunny,
+		original_src: exampleVideos.bigBuckBunny,
 		time: 3.333,
 		transparent: false,
 	});
@@ -118,7 +122,8 @@ test('Should be able to take commands for freeing up memory', async () => {
 	).toBeLessThan(10 * 1024 * 1024);
 
 	await compositor.executeCommand('ExtractFrame', {
-		input: exampleVideos.bigBuckBunny,
+		src: exampleVideos.bigBuckBunny,
+		original_src: exampleVideos.bigBuckBunny,
 		time: 3.333,
 		transparent: false,
 	});


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
