### PR TITLE
`remotion`: Fix `src` of getStaticFiles() not being properly encoded in case of sub-folders

### DIFF
--- a/packages/bundler/src/read-recursively.ts
+++ b/packages/bundler/src/read-recursively.ts
@@ -2,6 +2,17 @@ import fs, {statSync} from 'node:fs';
 import path from 'node:path';
 import type {StaticFile} from 'remotion';
 
+const encodeBySplitting = (p: string): string => {
+	// Intentional: split by path.sep, then join by /
+	const splitBySlash = p.split(path.sep);
+
+	const encodedArray = splitBySlash.map((element) => {
+		return encodeURIComponent(element);
+	});
+	const merged = encodedArray.join('/');
+	return merged;
+};
+
 export const readRecursively = ({
 	folder,
 	output = [],
@@ -46,7 +57,7 @@ export const readRecursively = ({
 				name: path.join(folder, file),
 				lastModified: Math.floor(stat.mtimeMs),
 				sizeInBytes: stat.size,
-				src: staticHash + '/' + encodeURIComponent(path.join(folder, file)),
+				src: staticHash + '/' + encodeBySplitting(path.join(folder, file)),
 			});
 		} else if (stat.isSymbolicLink()) {
 			const realpath = fs.realpathSync(path.join(folder, file));
@@ -56,7 +67,7 @@ export const readRecursively = ({
 					name: realpath,
 					lastModified: Math.floor(realStat.mtimeMs),
 					sizeInBytes: realStat.size,
-					src: staticHash + '/' + encodeURIComponent(realpath),
+					src: staticHash + '/' + encodeBySplitting(realpath),
 				});
 			}
 		}


### PR DESCRIPTION


<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
