### PR TITLE
Remotion Studio: Fix incorrect saving icon for `z.nullable()` types

### DIFF
--- a/packages/cli/src/editor/components/RenderModal/SchemaEditor/ZodOrNullishEditor.tsx
+++ b/packages/cli/src/editor/components/RenderModal/SchemaEditor/ZodOrNullishEditor.tsx
@@ -113,7 +113,7 @@ export const ZodOrNullishEditor: React.FC<{
 					setValue={setLocalValue}
 					jsonPath={jsonPath}
 					schema={innerSchema}
-					defaultValue={value}
+					defaultValue={defaultValue}
 					onSave={onSave}
 					showSaveButton={showSaveButton}
 					onRemove={onRemove}


### PR DESCRIPTION
Fixes #2566