### PR TITLE
`@remotion/lambda`: Simplify Lambda streaming response

### DIFF
--- a/packages/lambda/src/shared/call-lambda.ts
+++ b/packages/lambda/src/shared/call-lambda.ts
@@ -31,7 +31,7 @@ export const callLambda = async <T extends LambdaRoutines>({
 
 	const events =
 		res.EventStream as AsyncIterable<InvokeWithResponseStreamResponseEvent>;
-	let responsePayload: Uint8Array = new Uint8Array();
+	let responsePayload = '';
 
 	for await (const event of events) {
 		// There are two types of events you can get on a stream.
@@ -50,7 +50,7 @@ export const callLambda = async <T extends LambdaRoutines>({
 				continue;
 			}
 
-			responsePayload = Buffer.concat([responsePayload, Buffer.from(decoded)]);
+			responsePayload += decoded;
 		}
 
 		if (event.InvokeComplete) {
@@ -69,8 +69,7 @@ export const callLambda = async <T extends LambdaRoutines>({
 		}
 	}
 
-	const string = Buffer.from(responsePayload).toString();
-	const json = parseJson<T>(string);
+	const json = parseJson<T>(responsePayload.trim());
 
 	return json;
 };


### PR DESCRIPTION
No need to use UInt8Array and buffers if it is just about streaming

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
