### PR TITLE
`@remotion/renderer`: Allow to use MP3 as an audio codec for .mp4 videos

### DIFF
--- a/packages/docs/docs/lambda/speed.md
+++ b/packages/docs/docs/lambda/speed.md
@@ -31,6 +31,10 @@ If you have a Remotion version before December 2022, then your bucket name might
 
 [See this article for more information](/docs/lambda/bucket-naming#aws-region-in-the-name). Consider renaming your bucket or re-setting up Remotion Lambda to gain speed. This especially applies if you are having many Remotion buckets across regions.
 
+## Use MP3 as an audio codec<AvailableFrom v="4.0.16">
+
+By default, a video renders with the `h264` codec and the `aac` audio codec. Setting the [`audioCodec`](/docs/encoding/#audio-codec) to `mp3` will make "Combining videos" stage a lot faster, as the MP3 codec is much faster to encode than AAC. However, **the audio will not play in QuickTime Player and the file size is minimally higher**.
+
 ## Optimizing render performance
 
 See the [general performance tips](/docs/performance) which also apply to Lambda.

--- a/packages/renderer/src/audio-codec.ts
+++ b/packages/renderer/src/audio-codec.ts
@@ -5,8 +5,8 @@ export const validAudioCodecs = ['pcm-16', 'aac', 'mp3', 'opus'] as const;
 export type AudioCodec = typeof validAudioCodecs[number];
 
 export const supportedAudioCodecs = {
-	h264: ['aac', 'pcm-16'] as const,
-	'h264-mkv': ['pcm-16'] as const,
+	h264: ['aac', 'pcm-16', 'mp3'] as const,
+	'h264-mkv': ['pcm-16', 'mp3'] as const,
 	aac: ['aac', 'pcm-16'] as const,
 	gif: [] as const,
 	h265: ['aac', 'pcm-16'] as const,

--- a/packages/renderer/src/combine-videos.ts
+++ b/packages/renderer/src/combine-videos.ts
@@ -46,39 +46,40 @@ export const combineVideos = async (options: Options) => {
 	const resolvedAudioCodec =
 		audioCodec ?? getDefaultAudioCodec({codec, preferLossless: false});
 
+	const command = [
+		isAudioCodec(codec) ? null : '-r',
+		isAudioCodec(codec) ? null : String(fps),
+		'-f',
+		'concat',
+		'-safe',
+		'0',
+		'-i',
+		fileListTxt,
+		numberOfGifLoops === null ? null : '-loop',
+		numberOfGifLoops === null
+			? null
+			: typeof numberOfGifLoops === 'number'
+			? String(numberOfGifLoops)
+			: '-1',
+		isAudioCodec(codec) ? null : '-c:v',
+		isAudioCodec(codec) ? null : codec === 'gif' ? 'gif' : 'copy',
+		resolvedAudioCodec ? '-c:a' : null,
+		resolvedAudioCodec
+			? mapAudioCodecToFfmpegAudioCodecName(resolvedAudioCodec)
+			: null,
+		// Set max bitrate up to 512kbps, will choose lower if that's too much
+		'-b:a',
+		'512K',
+		codec === 'h264' ? '-movflags' : null,
+		codec === 'h264' ? 'faststart' : null,
+		'-y',
+		output,
+	].filter(truthy);
+
+	Log.verbose('Combining command: ', command);
+
 	try {
-		const task = callFf(
-			'ffmpeg',
-			[
-				isAudioCodec(codec) ? null : '-r',
-				isAudioCodec(codec) ? null : String(fps),
-				'-f',
-				'concat',
-				'-safe',
-				'0',
-				'-i',
-				fileListTxt,
-				numberOfGifLoops === null ? null : '-loop',
-				numberOfGifLoops === null
-					? null
-					: typeof numberOfGifLoops === 'number'
-					? String(numberOfGifLoops)
-					: '-1',
-				isAudioCodec(codec) ? null : '-c:v',
-				isAudioCodec(codec) ? null : codec === 'gif' ? 'gif' : 'copy',
-				resolvedAudioCodec ? '-c:a' : null,
-				resolvedAudioCodec
-					? mapAudioCodecToFfmpegAudioCodecName(resolvedAudioCodec)
-					: null,
-				// Set max bitrate up to 512kbps, will choose lower if that's too much
-				'-b:a',
-				'512K',
-				codec === 'h264' ? '-movflags' : null,
-				codec === 'h264' ? 'faststart' : null,
-				'-y',
-				output,
-			].filter(truthy)
-		);
+		const task = callFf('ffmpeg', command);
 		task.stderr?.on('data', (data: Buffer) => {
 			if (onProgress) {
 				const parsed = parseFfmpegProgress(data.toString('utf8'));

--- a/packages/renderer/src/file-extensions.ts
+++ b/packages/renderer/src/file-extensions.ts
@@ -33,6 +33,7 @@ export const defaultFileExtensionMap: {
 		default: 'mkv',
 		forAudioCodec: {
 			'pcm-16': {possible: ['mkv'], default: 'mkv'},
+			mp3: {possible: ['mkv'], default: 'mkv'},
 		},
 	},
 	aac: {
@@ -57,6 +58,7 @@ export const defaultFileExtensionMap: {
 		forAudioCodec: {
 			'pcm-16': {possible: ['mkv', 'mov'], default: 'mkv'},
 			aac: {possible: ['mp4', 'mkv', 'mov'], default: 'mp4'},
+			mp3: {possible: ['mp4', 'mkv', 'mov'], default: 'mp4'},
 		},
 	},
 	h265: {


### PR DESCRIPTION
Does make Lambda renders much faster but QuickTime Player will not play the audio