### PR TITLE
`remotion`: Fix a case where props calculated with `calculateMetadata()` do not correctly get applied

### DIFF
--- a/packages/cli/src/get-input-props.ts
+++ b/packages/cli/src/get-input-props.ts
@@ -35,7 +35,8 @@ export const getInputProps = (
 		return JSON.parse(parsedCli.props);
 	} catch (err) {
 		Log.error(
-			'You passed --props but it was neither valid JSON nor a file path to a valid JSON file.'
+			'You passed --props but it was neither valid JSON nor a file path to a valid JSON file. Provided value: ' +
+				parsedCli.props
 		);
 		Log.info('Got the following value:', parsedCli.props);
 		Log.error(

--- a/packages/core/src/resolve-video-config.ts
+++ b/packages/core/src/resolve-video-config.ts
@@ -32,6 +32,11 @@ export const resolveVideoConfig = ({
 		  })
 		: null;
 
+	const fallbackProps = {
+		...(composition.defaultProps ?? {}),
+		...(inputProps ?? {}),
+	};
+
 	if (
 		calculatedProm !== null &&
 		typeof calculatedProm === 'object' &&
@@ -49,7 +54,7 @@ export const resolveVideoConfig = ({
 				durationInFrames,
 				id: composition.id,
 				defaultProps: composition.defaultProps ?? {},
-				props: c.props ?? composition.defaultProps ?? {},
+				props: c.props ?? fallbackProps,
 			};
 		});
 	}
@@ -64,10 +69,7 @@ export const resolveVideoConfig = ({
 			...data,
 			id: composition.id,
 			defaultProps: composition.defaultProps ?? {},
-			props: {
-				...(composition.defaultProps ?? {}),
-				...(inputProps ?? {}),
-			},
+			props: fallbackProps,
 		};
 	}
 

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -593,6 +593,10 @@ export const Index: React.FC = () => {
 					component={StaticDemo}
 					width={1000}
 					height={1000}
+					defaultProps={{flag: false}}
+					calculateMetadata={async () => {
+						return {};
+					}}
 				/>
 				<Still id="font-demo" component={FontDemo} width={1000} height={1000} />
 				<Composition

--- a/packages/example/src/StaticServer/index.tsx
+++ b/packages/example/src/StaticServer/index.tsx
@@ -1,7 +1,13 @@
 import React, {useState} from 'react';
 import {continueRender, delayRender, Img, staticFile} from 'remotion';
 
-export const StaticDemo: React.FC = () => {
+export const StaticDemo: React.FC<{
+	flag: boolean;
+}> = ({flag}) => {
+	if (!flag) {
+		throw new Error('`flag` must be true (this only works during rendering)');
+	}
+
 	const [handle1] = useState(() => delayRender('handle1'));
 	const [handle2] = useState(() => delayRender('handle2'));
 

--- a/packages/it-tests/src/rendering/rendering.test.ts
+++ b/packages/it-tests/src/rendering/rendering.test.ts
@@ -299,11 +299,19 @@ test("Should succeed to render an audio file that doesn't have any audio inputs"
   fs.unlinkSync(out);
 });
 
-test("Should render a still that uses the staticFile() API", async () => {
+test("Should render a still that uses the staticFile() API and should apply props", async () => {
   const out = outputPath.replace(".mp4", ".png");
   const task = await execa(
     "pnpm",
-    ["exec", "remotion", "still", "static-demo", out, "--log=verbose"],
+    [
+      "exec",
+      "remotion",
+      "still",
+      "static-demo",
+      out,
+      "--log=verbose",
+      `--props={\"flag\": true}`,
+    ],
     {
       cwd: path.join(process.cwd(), "..", "example"),
       reject: false,


### PR DESCRIPTION
This would happen if:

- `calculateMetadata()` is used and is an asynchronous function
- Data comes from `inputProps`
- No transformation of props happens in `calculateMetadata()`

Fixes #2672