### PR TITLE
`@remotion/lambda`: Retry getRenderProgress() on JSON failure

### DIFF
--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -186,6 +186,10 @@ _optional since v3.2.27, default `1`_
 How often a chunk may be retried to render in case the render fails.
 If a rendering of a chunk is failed, the error will be reported in the [`getRenderProgress()`](/docs/lambda/getrenderprogress) object and retried up to as many times as you specify using this option.
 
+:::note
+A retry only gets executed if a the error is in the [list of flaky errors](https://github.com/remotion-dev/remotion/blob/main/packages/lambda/src/shared/is-flaky-error.ts).
+:::
+
 ### `scale?`
 
 _optional_

--- a/packages/docs/docs/lambda/renderstillonlambda.md
+++ b/packages/docs/docs/lambda/renderstillonlambda.md
@@ -145,6 +145,10 @@ _optional - default `1`_
 
 How often a frame render may be retried until it fails.
 
+:::note
+A retry only gets executed if a the error is in the [list of flaky errors](https://github.com/remotion-dev/remotion/blob/main/packages/lambda/src/shared/is-flaky-error.ts).
+:::
+
 ### `envVariables?`
 
 _optional - default `{}`_

--- a/packages/lambda/src/api/get-compositions-on-lambda.ts
+++ b/packages/lambda/src/api/get-compositions-on-lambda.ts
@@ -82,6 +82,7 @@ export const getCompositionsOnLambda = async ({
 			region,
 			receivedStreamingPayload: () => undefined,
 			timeoutInTest: 120000,
+			retriesRemaining: 0,
 		});
 		return res.compositions;
 	} catch (err) {

--- a/packages/lambda/src/api/get-render-progress.ts
+++ b/packages/lambda/src/api/get-render-progress.ts
@@ -33,6 +33,7 @@ export const getRenderProgress = async (
 		region: input.region,
 		receivedStreamingPayload: () => undefined,
 		timeoutInTest: 120000,
+		retriesRemaining: 2,
 	});
 	return result;
 };

--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -105,6 +105,7 @@ export const renderMediaOnLambda = async (
 			region,
 			receivedStreamingPayload: () => undefined,
 			timeoutInTest: 120000,
+			retriesRemaining: 0,
 		});
 		return {
 			renderId: res.renderId,

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -157,6 +157,7 @@ export const renderStillOnLambda = async ({
 				}
 			},
 			timeoutInTest: 120000,
+			retriesRemaining: 0,
 		});
 
 		return {

--- a/packages/lambda/src/shared/get-function-version.ts
+++ b/packages/lambda/src/shared/get-function-version.ts
@@ -19,6 +19,7 @@ export const getFunctionVersion = async ({
 			type: LambdaRoutines.info,
 			receivedStreamingPayload: () => undefined,
 			timeoutInTest: 120000,
+			retriesRemaining: 0,
 		});
 		return result.version;
 	} catch (err) {

--- a/packages/lambda/src/shared/is-flaky-error.ts
+++ b/packages/lambda/src/shared/is-flaky-error.ts
@@ -1,0 +1,12 @@
+export const isFlakyError = (err: Error): boolean => {
+	const {message} = err;
+
+	return (
+		message.includes('FATAL:zygote_communication_linux.cc') ||
+		message.includes('error while loading shared libraries: libnss3.so') ||
+		message.includes('but the server sent no data') ||
+		message.includes('Compositor panicked') ||
+		(message.includes('Compositor exited') && !message.includes('SIGSEGV')) ||
+		message.includes('Timed out while setting up the headless browser')
+	);
+};

--- a/packages/lambda/src/shared/is-flaky-error.ts
+++ b/packages/lambda/src/shared/is-flaky-error.ts
@@ -1,12 +1,37 @@
 export const isFlakyError = (err: Error): boolean => {
 	const {message} = err;
 
-	return (
-		message.includes('FATAL:zygote_communication_linux.cc') ||
-		message.includes('error while loading shared libraries: libnss3.so') ||
-		message.includes('but the server sent no data') ||
-		message.includes('Compositor panicked') ||
-		(message.includes('Compositor exited') && !message.includes('SIGSEGV')) ||
-		message.includes('Timed out while setting up the headless browser')
-	);
+	// storage.googleapis.com sometimes returns 500s, and Video does not have retry on its own
+	if (
+		message.includes('Format error') &&
+		message.includes('storage.googleapis.com')
+	) {
+		return true;
+	}
+
+	if (message.includes('FATAL:zygote_communication_linux.cc')) {
+		return true;
+	}
+
+	if (message.includes('error while loading shared libraries: libnss3.so')) {
+		return true;
+	}
+
+	if (message.includes('but the server sent no data')) {
+		return true;
+	}
+
+	if (message.includes('Compositor panicked')) {
+		return true;
+	}
+
+	if (message.includes('Compositor exited') && !message.includes('SIGSEGV')) {
+		return true;
+	}
+
+	if (message.includes('Timed out while setting up the headless browser')) {
+		return true;
+	}
+
+	return false;
 };

--- a/packages/lambda/src/test/integration/handlers.test.ts
+++ b/packages/lambda/src/test/integration/handlers.test.ts
@@ -12,6 +12,7 @@ test('Call function locally', async () => {
 			region: 'us-east-1',
 			receivedStreamingPayload: () => undefined,
 			timeoutInTest: 120000,
+			retriesRemaining: 0,
 		})
 	).toEqual({type: 'success', version: VERSION});
 });

--- a/packages/lambda/src/test/integration/renders/gif.test.ts
+++ b/packages/lambda/src/test/integration/renders/gif.test.ts
@@ -67,6 +67,7 @@ test('Should make a distributed GIF', async () => {
 		receivedStreamingPayload: () => undefined,
 		region: 'eu-central-1',
 		timeoutInTest: 120000,
+		retriesRemaining: 0,
 	});
 
 	const progress = await callLambda({
@@ -80,6 +81,7 @@ test('Should make a distributed GIF', async () => {
 		receivedStreamingPayload: () => undefined,
 		region: 'eu-central-1',
 		timeoutInTest: 120000,
+		retriesRemaining: 0,
 	});
 
 	const file = await lambdaReadFile({

--- a/packages/lambda/src/test/integration/renders/old-version.test.ts
+++ b/packages/lambda/src/test/integration/renders/old-version.test.ts
@@ -65,6 +65,7 @@ test('Should fail when using an incompatible version', async () => {
 			receivedStreamingPayload: () => undefined,
 			region: 'us-east-1',
 			timeoutInTest: 120000,
+			retriesRemaining: 0,
 		});
 		console.log(aha);
 		throw new Error('Should not reach this');

--- a/packages/lambda/src/test/integration/renders/other-bucket.test.ts
+++ b/packages/lambda/src/test/integration/renders/other-bucket.test.ts
@@ -70,6 +70,7 @@ test('Should be able to render to another bucket', async () => {
 		receivedStreamingPayload: () => undefined,
 		region: 'eu-central-1',
 		timeoutInTest: 120000,
+		retriesRemaining: 0,
 	});
 
 	const progress = await callLambda({
@@ -83,6 +84,7 @@ test('Should be able to render to another bucket', async () => {
 		receivedStreamingPayload: () => undefined,
 		region: 'eu-central-1',
 		timeoutInTest: 120000,
+		retriesRemaining: 0,
 	});
 
 	const file = await lambdaReadFile({

--- a/packages/lambda/src/test/integration/renders/silent-audio.test.ts
+++ b/packages/lambda/src/test/integration/renders/silent-audio.test.ts
@@ -67,6 +67,7 @@ test('Should add silent audio if there is no audio', async () => {
 		region: 'eu-central-1',
 		type: LambdaRoutines.start,
 		timeoutInTest: 120000,
+		retriesRemaining: 0,
 	});
 
 	const progress = await callLambda({
@@ -80,6 +81,7 @@ test('Should add silent audio if there is no audio', async () => {
 		region: 'eu-central-1',
 		type: LambdaRoutines.status,
 		timeoutInTest: 120000,
+		retriesRemaining: 0,
 	});
 
 	const file = await lambdaReadFile({

--- a/packages/lambda/src/test/integration/renders/transparent-webm.test.ts
+++ b/packages/lambda/src/test/integration/renders/transparent-webm.test.ts
@@ -70,6 +70,7 @@ test('Should make a transparent video', async () => {
 		receivedStreamingPayload: () => undefined,
 		region: 'eu-central-1',
 		timeoutInTest: 120000,
+		retriesRemaining: 0,
 	});
 
 	const progress = await callLambda({
@@ -83,6 +84,7 @@ test('Should make a transparent video', async () => {
 		receivedStreamingPayload: () => undefined,
 		region: 'eu-central-1',
 		timeoutInTest: 120000,
+		retriesRemaining: 0,
 	});
 
 	const file = await lambdaReadFile({

--- a/packages/lambda/src/test/integration/webhooks.test.ts
+++ b/packages/lambda/src/test/integration/webhooks.test.ts
@@ -106,6 +106,7 @@ describe('Webhooks', () => {
 			receivedStreamingPayload: () => undefined,
 			region: 'us-east-1',
 			timeoutInTest: 120000,
+			retriesRemaining: 0,
 		});
 		const parsed = res;
 
@@ -120,6 +121,7 @@ describe('Webhooks', () => {
 			receivedStreamingPayload: () => undefined,
 			region: 'us-east-1',
 			timeoutInTest: 120000,
+			retriesRemaining: 0,
 		});
 
 		expect(mockableHttpClients.http).toHaveBeenCalledTimes(1);
@@ -191,6 +193,7 @@ describe('Webhooks', () => {
 				audioCodec: null,
 			},
 			timeoutInTest: 1000,
+			retriesRemaining: 0,
 		});
 
 		await new Promise((resolve) => {

--- a/packages/lambda/src/test/unit/handlers.test.ts
+++ b/packages/lambda/src/test/unit/handlers.test.ts
@@ -10,6 +10,7 @@ test('Info handler should return version', async () => {
 		receivedStreamingPayload: () => undefined,
 		region: 'us-east-1',
 		timeoutInTest: 120000,
+		retriesRemaining: 0,
 	});
 
 	expect(typeof response.version === 'string').toBe(true);


### PR DESCRIPTION
- Retry `callLambda()` if Lambda streaming fails (we suspect AWS bug) @jmaguirrei 
- Clarify when a retry gets executed
- Update list of flaky errors @jmaguirrei 