### PR TITLE
`remotion`: Error gets thrown when `staticFile()` is nested inside itself

### DIFF
--- a/packages/core/src/static-file.ts
+++ b/packages/core/src/static-file.ts
@@ -61,8 +61,10 @@ const trimLeadingSlash = (path: string): string => {
 
 const inner = (path: string): string => {
 	if (typeof window !== 'undefined' && window.remotion_staticBase) {
-		if (path.includes(window.remotion_staticBase)) {
-			throw new Error("You can't nest staticFile() inside of staticFile()");
+		if (path.startsWith(window.remotion_staticBase)) {
+			throw new Error(
+				`The value "${path}" is already prefixed with the static base ${window.remotion_staticBase}. You don't need to call staticFile() on it.`
+			);
 		}
 
 		return `${window.remotion_staticBase}/${trimLeadingSlash(path)}`;

--- a/packages/core/src/static-file.ts
+++ b/packages/core/src/static-file.ts
@@ -61,6 +61,10 @@ const trimLeadingSlash = (path: string): string => {
 
 const inner = (path: string): string => {
 	if (typeof window !== 'undefined' && window.remotion_staticBase) {
+		if (path.includes(window.remotion_staticBase)) {
+			throw new Error("You can't nest staticFile() inside of staticFile()");
+		}
+
 		return `${window.remotion_staticBase}/${trimLeadingSlash(path)}`;
 	}
 

--- a/packages/core/src/test/static-file-errors.test.ts
+++ b/packages/core/src/test/static-file-errors.test.ts
@@ -1,0 +1,22 @@
+import {expect, test} from 'vitest';
+import {staticFile} from '../static-file.js';
+
+test('duplicate staticFile() should throw a warning', () => {
+	global.window = {
+		remotion_staticBase: '/static-abcdef',
+	};
+	expect(() => staticFile(staticFile('file.mp3'))).toThrow(
+		"You can't nest staticFile() inside of staticFile()"
+	);
+});
+
+test('"https//" in staticFile() should throw an error', () => {
+	expect(() => staticFile(staticFile('https://'))).toThrow(
+		'staticFile() does not support remote URLs - got "https://". Instead, pass the URL without wrapping it in staticFile(). See: https://remotion.dev/docs/staticfile-remote-urls'
+	);
+});
+
+test('Single use of staticFile should not thrown an error', () => {
+	const staticBase = window.remotion_staticBase;
+	expect(staticFile('file.mp3')).toBe(staticBase + '/file.mp3');
+});

--- a/packages/core/src/test/static-file-errors.test.ts
+++ b/packages/core/src/test/static-file-errors.test.ts
@@ -7,7 +7,7 @@ test('duplicate staticFile() should throw a warning', () => {
 		remotion_staticBase: '/static-abcdef',
 	};
 	expect(() => staticFile(staticFile('file.mp3'))).toThrow(
-		"You can't nest staticFile() inside of staticFile()"
+		'The value "/static-abcdef/file.mp3" is already prefixed with the static base /static-abcdef. You don\'t need to call staticFile() on it.'
 	);
 });
 

--- a/packages/core/src/test/static-file-errors.test.ts
+++ b/packages/core/src/test/static-file-errors.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'vitest';
 import {staticFile} from '../static-file.js';
 
 test('duplicate staticFile() should throw a warning', () => {
+	// @ts-expect-error
 	global.window = {
 		remotion_staticBase: '/static-abcdef',
 	};


### PR DESCRIPTION
fix #2551