### PR TITLE
`@remotion/renderer`: `getSilentParts()` - Don't allow negative values

### DIFF
--- a/packages/renderer/rust/get_silent_parts.rs
+++ b/packages/renderer/rust/get_silent_parts.rs
@@ -215,7 +215,7 @@ pub fn get_silent_parts(
             if last_occurrence == LastOccurrence::Start {
                 silent_parts.push(SilentParts {
                     endInSeconds: end,
-                    startInSeconds: start,
+                    startInSeconds: start.max(0.0),
                 });
             }
 
@@ -226,7 +226,7 @@ pub fn get_silent_parts(
     if last_occurrence == LastOccurrence::Start {
         silent_parts.push(SilentParts {
             endInSeconds: duration,
-            startInSeconds: start,
+            startInSeconds: start.max(0.0),
         });
     }
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
