### PR TITLE
`@remotion/bundler`: Align `getStaticFiles()` forward slashes on Windows for dev/prod parity

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -253,6 +253,11 @@ export async function bundle(...args: Arguments): Promise<string> {
 			startPath: from,
 			staticHash,
 			limit: 1000,
+		}).map((f) => {
+			return {
+				...f,
+				name: f.name.split(path.sep).join('/'),
+			};
 		}),
 		includeFavicon: false,
 		title: 'Remotion Bundle',


### PR DESCRIPTION
Always forward slash