### PR TITLE
`@remotion/lambda`: Don't hash serve URL

### DIFF
--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -33,7 +33,6 @@ import {
 } from '../shared/constants';
 import {DOCS_URL} from '../shared/docs-url';
 import {invokeWebhook} from '../shared/invoke-webhook';
-import {getServeUrlHash} from '../shared/make-s3-url';
 import {validateFramesPerLambda} from '../shared/validate-frames-per-lambda';
 import {validateOutname} from '../shared/validate-outname';
 import {validatePrivacy} from '../shared/validate-privacy';
@@ -290,7 +289,7 @@ const innerLaunchHandler = async (
 		].reduce((a, b) => a + b, 0),
 		estimatedRenderLambdaInvokations: chunks.length,
 		compositionId: comp.id,
-		siteId: getServeUrlHash(params.serveUrl),
+		siteId: params.serveUrl,
 		codec: params.codec,
 		type: 'video',
 		imageFormat: params.imageFormat,

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -22,7 +22,6 @@ import {
 } from '../shared/constants';
 import {convertToServeUrl} from '../shared/convert-to-serve-url';
 import {isFlakyError} from '../shared/is-flaky-error';
-import {getServeUrlHash} from '../shared/make-s3-url';
 import {validateDownloadBehavior} from '../shared/validate-download-behavior';
 import {validateOutname} from '../shared/validate-outname';
 import {validatePrivacy} from '../shared/validate-privacy';
@@ -138,7 +137,7 @@ const innerStillHandler = async ({
 		compositionId: lambdaParams.composition,
 		estimatedTotalLambdaInvokations: 1,
 		estimatedRenderLambdaInvokations: 1,
-		siteId: getServeUrlHash(serveUrl),
+		siteId: serveUrl,
 		totalChunks: 1,
 		type: 'still',
 		imageFormat: lambdaParams.imageFormat,

--- a/packages/lambda/src/shared/make-s3-url.ts
+++ b/packages/lambda/src/shared/make-s3-url.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import type {AwsRegion} from '../pricing/aws-regions';
 
 export const makeS3ServeUrl = ({
@@ -11,18 +10,4 @@ export const makeS3ServeUrl = ({
 	region: AwsRegion;
 }): string => {
 	return `https://${bucketName}.s3.${region}.amazonaws.com/${subFolder}/index.html`;
-};
-
-const hashCache: {[key: string]: string} = {};
-
-export const getServeUrlHash = (url: string) => {
-	if (hashCache[url]) {
-		return hashCache[url];
-	}
-
-	const hash = crypto.createHash('md5').update(url).digest('hex');
-
-	hashCache[url] = hash;
-
-	return hash;
 };


### PR DESCRIPTION
✅ This was never used except for a feature we did not ship
✅ This removes a dependency on `node:crypto` which makes it more likely we can use vercel edge functions