### PR TITLE
`@remotion/lambda` + `@remotion/cloudrun`: Correctly handle omitting the composition name

### DIFF
--- a/packages/cloudrun/src/cli/commands/render/index.ts
+++ b/packages/cloudrun/src/cli/commands/render/index.ts
@@ -72,6 +72,12 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 
 		validateServeUrl(serveUrl);
 
+		if (!serveUrl.startsWith('https://') && !serveUrl.startsWith('http://')) {
+			throw Error(
+				'Passing the shorthand serve URL without composition name is currently not supported.\n Make sure to pass a composition name after the shorthand serve URL or pass the complete serveURL without composition name to get to choose between all compositions.'
+			);
+		}
+
 		const server = RenderInternals.prepareServer({
 			concurrency: 1,
 			indent: false,

--- a/packages/cloudrun/src/cli/commands/render/index.ts
+++ b/packages/cloudrun/src/cli/commands/render/index.ts
@@ -67,7 +67,6 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 	});
 
 	let composition: string = args[1];
-
 	if (!composition) {
 		Log.info('No compositions passed. Fetching compositions...');
 
@@ -84,7 +83,7 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 
 		const {compositionId} =
 			await CliInternals.getCompositionWithDimensionOverride({
-				args,
+				args: args.slice(1),
 				compositionIdFromUi: null,
 				browserExecutable,
 				chromiumOptions,

--- a/packages/cloudrun/src/cli/commands/still.ts
+++ b/packages/cloudrun/src/cli/commands/still.ts
@@ -45,6 +45,13 @@ export const stillCommand = async (args: string[], remotionRoot: string) => {
 		Log.info('No compositions passed. Fetching compositions...');
 
 		validateServeUrl(serveUrl);
+
+		if (!serveUrl.startsWith('https://') && !serveUrl.startsWith('http://')) {
+			throw Error(
+				'Passing the shorthand serve URL without composition name is currently not supported.\n Make sure to pass a composition name after the shorthand serve URL or pass the complete serveURL without composition name to get to choose between all compositions.'
+			);
+		}
+
 		const server = RenderInternals.prepareServer({
 			concurrency: 1,
 			indent: false,

--- a/packages/cloudrun/src/cli/commands/still.ts
+++ b/packages/cloudrun/src/cli/commands/still.ts
@@ -56,7 +56,7 @@ export const stillCommand = async (args: string[], remotionRoot: string) => {
 
 		const {compositionId} =
 			await CliInternals.getCompositionWithDimensionOverride({
-				args,
+				args: args.slice(1),
 				compositionIdFromUi: null,
 				indent: false,
 				serveUrlOrWebpackUrl: serveUrl,

--- a/packages/cloudrun/src/shared/validate-serveurl.ts
+++ b/packages/cloudrun/src/shared/validate-serveurl.ts
@@ -24,13 +24,7 @@ export const validateServeUrl = async (serveUrl: unknown) => {
 
 		if (!exists) {
 			throw new Error(
-				'serveURL ERROR. File "' +
-					fileName +
-					'" not found in bucket "' +
-					bucketName +
-					'". Is your site name correct - "' +
-					siteName +
-					'"?'
+				`serveURL ERROR. File "${fileName}" not found in bucket "${bucketName}". Is your site name correct - "${siteName}"?`
 			);
 		}
 	}

--- a/packages/docs/docs/lambda/cli/render.md
+++ b/packages/docs/docs/lambda/cli/render.md
@@ -42,6 +42,10 @@ Using the shorthand serve URL:
 npx remotion lambda render testbed my-comp
 ```
 
+:::info
+If you are using the shorthand serve URL, you have to pass a composition ID. Available compositions can only be fetched if a complete serve URL is passed.
+:::
+
 Passing in input props:
 
 ```

--- a/packages/docs/docs/lambda/cli/still.md
+++ b/packages/docs/docs/lambda/cli/still.md
@@ -33,6 +33,10 @@ Rendering using the serve URL shorthand:
 npx remotion lambda still testbed my-comp
 ```
 
+:::info
+If you are using the shorthand serve URL, you have to pass a composition ID. Available compositions can only be fetched if a complete serve URL is passed.
+:::
+
 Rendering the 10th frame of a composition:
 
 ```

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -89,6 +89,7 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 		const {compositionId} =
 			await CliInternals.getCompositionWithDimensionOverride({
 				args,
+				args: args.slice(1),
 				compositionIdFromUi: null,
 				browserExecutable,
 				chromiumOptions,

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -82,6 +82,7 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 				'Passing the shorthand serve URL without composition name is currently not supported.\n Make sure to pass a composition name after the shorthand serve URL or pass the complete serveURL without composition name to get to choose between all compositions.'
 			);
 		}
+
 		const server = await RenderInternals.prepareServer({
 			concurrency: 1,
 			indent: false,

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -79,7 +79,7 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 
 		if (!serveUrl.startsWith('https://')) {
 			throw Error(
-				'Passing the short-hand serveURL without composition name is currently not supported.\n Make sure to pass a composition name after the short-hand serveURL or pass the complete serveURL without composition name to get to choose between all compositions.'
+				'Passing the shorthand serve URL without composition name is currently not supported.\n Make sure to pass a composition name after the shorthand serve URL or pass the complete serveURL without composition name to get to choose between all compositions.'
 			);
 		}
 		const server = await RenderInternals.prepareServer({

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -77,6 +77,11 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 
 		validateServeUrl(serveUrl);
 
+		if (!serveUrl.startsWith('https://')) {
+			throw Error(
+				'Passing the short-hand serveURL without composition name is currently not supported.\n Make sure to pass a composition name after the short-hand serveURL or pass the complete serveURL without composition name to get to choose between all compositions.'
+			);
+		}
 		const server = await RenderInternals.prepareServer({
 			concurrency: 1,
 			indent: false,

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -93,7 +93,6 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 
 		const {compositionId} =
 			await CliInternals.getCompositionWithDimensionOverride({
-				args,
 				args: args.slice(1),
 				compositionIdFromUi: null,
 				browserExecutable,

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -77,7 +77,7 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 
 		validateServeUrl(serveUrl);
 
-		if (!serveUrl.startsWith('https://')) {
+		if (!serveUrl.startsWith('https://') && !serveUrl.startsWith('http://')) {
 			throw Error(
 				'Passing the shorthand serve URL without composition name is currently not supported.\n Make sure to pass a composition name after the shorthand serve URL or pass the complete serveURL without composition name to get to choose between all compositions.'
 			);

--- a/packages/lambda/src/cli/commands/still.ts
+++ b/packages/lambda/src/cli/commands/still.ts
@@ -63,7 +63,7 @@ export const stillCommand = async (args: string[], remotionRoot: string) => {
 
 		if (!serveUrl.startsWith('https://')) {
 			throw Error(
-				'Passing the short-hand serveURL without composition name is currently not supported.\n Make sure to pass a composition name after the short-hand serveURL or pass the complete serveURL without composition name to get to choose between all compositions.'
+				'Passing the shorthand serveURL without composition name is currently not supported.\n Make sure to pass a composition name after the short-hand serveURL or pass the complete serveURL without composition name to get to choose between all compositions.'
 			);
 		}
 

--- a/packages/lambda/src/cli/commands/still.ts
+++ b/packages/lambda/src/cli/commands/still.ts
@@ -63,7 +63,7 @@ export const stillCommand = async (args: string[], remotionRoot: string) => {
 
 		if (!serveUrl.startsWith('https://')) {
 			throw Error(
-				'Passing the shorthand serveURL without composition name is currently not supported.\n Make sure to pass a composition name after the short-hand serveURL or pass the complete serveURL without composition name to get to choose between all compositions.'
+				'Passing the shorthand serve URL without composition name is currently not supported.\n Make sure to pass a composition name after the shorthand serve URL or pass the complete serveURL without composition name to get to choose between all compositions.'
 			);
 		}
 

--- a/packages/lambda/src/cli/commands/still.ts
+++ b/packages/lambda/src/cli/commands/still.ts
@@ -61,7 +61,7 @@ export const stillCommand = async (args: string[], remotionRoot: string) => {
 
 		validateServeUrl(serveUrl);
 
-		if (!serveUrl.startsWith('https://')) {
+		if (!serveUrl.startsWith('https://') && !serveUrl.startsWith('http://')) {
 			throw Error(
 				'Passing the shorthand serve URL without composition name is currently not supported.\n Make sure to pass a composition name after the shorthand serve URL or pass the complete serveURL without composition name to get to choose between all compositions.'
 			);

--- a/packages/lambda/src/cli/commands/still.ts
+++ b/packages/lambda/src/cli/commands/still.ts
@@ -60,6 +60,13 @@ export const stillCommand = async (args: string[], remotionRoot: string) => {
 		Log.info('No compositions passed. Fetching compositions...');
 
 		validateServeUrl(serveUrl);
+
+		if (!serveUrl.startsWith('https://')) {
+			throw Error(
+				'Passing the short-hand serveURL without composition name is currently not supported.\n Make sure to pass a composition name after the short-hand serveURL or pass the complete serveURL without composition name to get to choose between all compositions.'
+			);
+		}
+
 		const server = await RenderInternals.prepareServer({
 			concurrency: 1,
 			indent: false,
@@ -71,7 +78,7 @@ export const stillCommand = async (args: string[], remotionRoot: string) => {
 
 		const {compositionId} =
 			await CliInternals.getCompositionWithDimensionOverride({
-				args,
+				args: args.slice(1),
 				compositionIdFromUi: null,
 				indent: false,
 				serveUrlOrWebpackUrl: serveUrl,


### PR DESCRIPTION
Maybe the info box in the docs could be formulated better...?

#2425
