### PR TITLE
`@remotion/cloudrun`: Same download behavior as for Lambda

### DIFF
--- a/packages/cloudrun/src/api/download-file.ts
+++ b/packages/cloudrun/src/api/download-file.ts
@@ -1,4 +1,5 @@
-import fs from 'fs';
+import {RenderInternals} from '@remotion/renderer';
+import path from 'node:path';
 import {getCloudStorageClient} from './helpers/get-cloud-storage-client';
 
 /**
@@ -21,16 +22,12 @@ export const downloadFile = async ({
 
 	const fileName = gsutilURI.replace(`gs://${bucketName}/`, '');
 
-	// check if out folder exists, if not, create it
-	if (!fs.existsSync('out')) {
-		fs.mkdirSync('out');
-	}
-
-	const destination = `out/${downloadName}`;
+	const outputPath = path.resolve(process.cwd(), downloadName);
+	RenderInternals.ensureOutputDirectory(outputPath);
 
 	await cloudStorageClient.bucket(bucketName).file(fileName).download({
-		destination,
+		destination: outputPath,
 	});
 
-	return destination;
+	return {outputPath};
 };

--- a/packages/cloudrun/src/cli/commands/render/index.ts
+++ b/packages/cloudrun/src/cli/commands/render/index.ts
@@ -296,7 +296,7 @@ Codec = ${codec} (${codecReason})
 			Log.info('');
 			Log.info('downloading file...');
 
-			const destination = await downloadFile({
+			const {outputPath: destination} = await downloadFile({
 				bucketName: res.bucketName,
 				gsutilURI: res.cloudStorageUri,
 				downloadName,

--- a/packages/cloudrun/src/cli/commands/still.ts
+++ b/packages/cloudrun/src/cli/commands/still.ts
@@ -169,7 +169,7 @@ ${downloadName ? `    Downloaded File = ${downloadName}` : ''}
 		Log.info('');
 		Log.info('downloading file...');
 
-		const destination = await downloadFile({
+		const {outputPath: destination} = await downloadFile({
 			bucketName: res.bucketName,
 			gsutilURI: res.cloudStorageUri,
 			downloadName,


### PR DESCRIPTION
- Fixes absolute paths
- Relative paths don't get prefixed with `out` anymore