### PR TITLE
`@remotion/lambda` + `@remotion/cloudrun`: Site create time starts after bundle is complete

### DIFF
--- a/packages/cloudrun/src/cli/commands/sites/create.ts
+++ b/packages/cloudrun/src/cli/commands/sites/create.ts
@@ -116,6 +116,7 @@ export const sitesCreateSubcommand = async (
 	updateProgress();
 
 	const bundleStart = Date.now();
+	let uploadStart = Date.now();
 
 	const {serveUrl, siteName, stats} = await deploySite({
 		entryPoint: file,
@@ -127,6 +128,9 @@ export const sitesCreateSubcommand = async (
 					progress,
 					doneIn: progress === 100 ? Date.now() - bundleStart : null,
 				};
+				if (progress === 100) {
+					uploadStart = Date.now();
+				}
 			},
 			onUploadProgress: (p) => {
 				multiProgress.deployProgress = {
@@ -144,9 +148,8 @@ export const sitesCreateSubcommand = async (
 
 	updateProgress();
 
-	const uploadStart = Date.now();
-
 	const uploadDuration = Date.now() - uploadStart;
+
 	multiProgress.deployProgress = {
 		sizeUploaded: 1,
 		totalSize: 1,

--- a/packages/lambda/src/cli/commands/sites/create.ts
+++ b/packages/lambda/src/cli/commands/sites/create.ts
@@ -102,7 +102,7 @@ export const sitesCreateSubcommand = async (
 	updateProgress();
 
 	const bundleStart = Date.now();
-	const uploadStart = Date.now();
+	let uploadStart = Date.now();
 
 	const {serveUrl, siteName, stats} = await deploySite({
 		entryPoint: file,
@@ -114,6 +114,9 @@ export const sitesCreateSubcommand = async (
 					progress,
 					doneIn: progress === 100 ? Date.now() - bundleStart : null,
 				};
+				if (progress === 100) {
+					uploadStart = Date.now();
+				}
 			},
 			onUploadProgress: (p) => {
 				multiProgress.deployProgress = {


### PR DESCRIPTION
Resolving cloud run bug - when creating site, the upload time is always 0ms.
https://github.com/orgs/remotion-dev/projects/7/views/1?pane=issue&itemId=35893546

Noticed that the lambda implementation was starting the upload time at the same time as the bundle time. This meant that upload time always included a portion of bundle time. Have fixed this for both lambda and cloud run packages, so that upload start time is set once bundle has reached 100% progress.