### PR TITLE
`@remotion/lambda`: Display accured costs until an error was thrown

### DIFF
--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -371,13 +371,12 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 				await CliInternals.handleCommonError(errorWithStackFrame, logLevel);
 			}
 
-			Log.info(
-				'\n\nAccured costs until the error was thrown: ',
-				newStatus.costs.accruedSoFar.toString(),
-				'USD. '
+			Log.info();
+			Log.verbose(
+				`Accrued costs until error was thrown: ${newStatus.costs.displayCost}.`
 			);
 			Log.info(
-				'This is only an estimate and does not include charges for other AWS services! \n\n'
+				'This is an estimate and continuing Lambda functions may incur additional costs.'
 			);
 			quit(1);
 		}

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -371,6 +371,14 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 				await CliInternals.handleCommonError(errorWithStackFrame, logLevel);
 			}
 
+			Log.info(
+				'\n\nAccured costs until the error was thrown: ',
+				newStatus.costs.accruedSoFar.toString(),
+				'USD. '
+			);
+			Log.info(
+				'This is only an estimate and does not include charges for other AWS services! \n\n'
+			);
 			quit(1);
 		}
 	}


### PR DESCRIPTION
close #2725


