### PR TITLE
fix typo in durationInMiliseconds

### DIFF
--- a/packages/docs/docs/lambda/changelog.md
+++ b/packages/docs/docs/lambda/changelog.md
@@ -293,7 +293,7 @@ Lambda version: '2021-12-16'
 
 Stability and ease of use improvements that we implemented from our learnings from https://githubwrapped.com!
 
-- Fixed an error `Parameter 'durationInMiliseconds' must be over 0 but is [negative number]`
+- Fixed an error `Parameter 'durationInMilliseconds' must be over 0 but is [negative number]`
 - The function name of a deployed function is not random anymore. Instead it has the format of `remotion-render-2021-12-16-2048mb-120sec`
 - More CLI commands support the `-q` (quiet) flag.
 - Calling `npx remotion lambda functions deploy` if a suitable function already exists will not throw an error anymore but log the existing function.

--- a/packages/docs/docs/lambda/estimateprice.md
+++ b/packages/docs/docs/lambda/estimateprice.md
@@ -27,7 +27,7 @@ import { estimatePrice } from "@remotion/lambda";
 console.log(
   estimatePrice({
     region: "us-east-1",
-    durationInMiliseconds: 20000,
+    durationInMilliseconds: 20000,
     memorySizeInMb: 2048,
     diskSizeInMb: 2048,
     lambdasInvoked: 1,
@@ -47,9 +47,9 @@ The region in which the Lambda function is executed in. [Pricing varies across r
 
 The amount of memory that has been given to the Lambda function. May be received with [`getFunctionInfo()`](/docs/lambda/getfunctioninfo).
 
-### `durationInMiliseconds`
+### `durationInMilliseconds`
 
-The estimated total execution duration in miliseconds of all Lambdas combined. See the top of this page for a guide on how to approximate the duration.
+The estimated total execution duration in Milliseconds of all Lambdas combined. See the top of this page for a guide on how to approximate the duration.
 
 ### `lambdasInvoked`
 

--- a/packages/lambda/src/api/estimate-price.ts
+++ b/packages/lambda/src/api/estimate-price.ts
@@ -8,7 +8,7 @@ import {validateMemorySize} from '../shared/validate-memory-size';
 type Miliseconds =
 	| {
 			/**
-			 * @deprecated Typo in property name. Use `durationInMiliseconds` instead.
+			 * @deprecated Typo in property name. Use `durationInMilliseconds` instead.
 			 */
 			durationInMiliseconds: number;
 	  }

--- a/packages/lambda/src/api/estimate-price.ts
+++ b/packages/lambda/src/api/estimate-price.ts
@@ -7,7 +7,7 @@ import {validateMemorySize} from '../shared/validate-memory-size';
 
 export type EstimatePriceInput = {
 	region: AwsRegion;
-	durationInMiliseconds: number;
+	durationInMilliseconds: number;
 	memorySizeInMb: number;
 	diskSizeInMb: number;
 	lambdasInvoked: number;
@@ -20,7 +20,7 @@ export type EstimatePriceInput = {
  */
 export const estimatePrice = ({
 	region,
-	durationInMiliseconds,
+	durationInMilliseconds,
 	memorySizeInMb,
 	diskSizeInMb,
 	lambdasInvoked,
@@ -28,27 +28,27 @@ export const estimatePrice = ({
 	validateMemorySize(memorySizeInMb);
 	validateAwsRegion(region);
 	validateDiskSizeInMb(diskSizeInMb);
-	if (typeof durationInMiliseconds !== 'number') {
+	if (typeof durationInMilliseconds !== 'number') {
 		throw new TypeError(
-			`Parameter 'durationInMiliseconds' must be a number but got ${typeof durationInMiliseconds}`
+			`Parameter 'durationInMilliseconds' must be a number but got ${typeof durationInMilliseconds}`
 		);
 	}
 
-	if (Number.isNaN(durationInMiliseconds)) {
+	if (Number.isNaN(durationInMilliseconds)) {
 		throw new TypeError(
-			`Parameter 'durationInMiliseconds' must not be NaN but it is.`
+			`Parameter 'durationInMilliseconds' must not be NaN but it is.`
 		);
 	}
 
-	if (!Number.isFinite(durationInMiliseconds)) {
+	if (!Number.isFinite(durationInMilliseconds)) {
 		throw new TypeError(
-			`Parameter 'durationInMiliseconds' must be finite but it is ${durationInMiliseconds}`
+			`Parameter 'durationInMilliseconds' must be finite but it is ${durationInMilliseconds}`
 		);
 	}
 
-	if (durationInMiliseconds < 0) {
+	if (durationInMilliseconds < 0) {
 		throw new TypeError(
-			`Parameter 'durationInMiliseconds' must be over 0 but it is ${durationInMiliseconds}.`
+			`Parameter 'durationInMilliseconds' must be over 0 but it is ${durationInMilliseconds}.`
 		);
 	}
 
@@ -57,7 +57,7 @@ export const estimatePrice = ({
 	// In GB-second
 	const timeCostDollars =
 		Number(durationPrice) *
-		((memorySizeInMb * durationInMiliseconds) / 1000 / 1024);
+		((memorySizeInMb * durationInMilliseconds) / 1000 / 1024);
 
 	const diskSizePrice = pricing[region]['Lambda Storage-Duration-ARM'].price;
 
@@ -69,7 +69,7 @@ export const estimatePrice = ({
 	const diskSizeDollars =
 		chargedDiskSize *
 		Number(diskSizePrice) *
-		(durationInMiliseconds / 1000 / 1024);
+		(durationInMilliseconds / 1000 / 1024);
 
 	const invocationCost =
 		Number(pricing[region]['Lambda Requests'].price) * lambdasInvoked;

--- a/packages/lambda/src/api/estimate-price.ts
+++ b/packages/lambda/src/api/estimate-price.ts
@@ -5,17 +5,24 @@ import {validateAwsRegion} from '../shared/validate-aws-region';
 import {validateDiskSizeInMb} from '../shared/validate-disk-size-in-mb';
 import {validateMemorySize} from '../shared/validate-memory-size';
 
+type Miliseconds =
+	| {
+			/**
+			 * @deprecated Typo in property name. Use `durationInMiliseconds` instead.
+			 */
+			durationInMiliseconds: number;
+	  }
+	| {
+			durationInMilliseconds: number;
+	  };
+
 export type EstimatePriceInput = {
 	region: AwsRegion;
-	durationInMilliseconds: number;
-	/**
-	 * @deprecated Typo in property name. Use `durationInMiliseconds` instead.
-	 */
-	durationInMiliseconds: number;
 	memorySizeInMb: number;
 	diskSizeInMb: number;
 	lambdasInvoked: number;
-};
+} & Miliseconds;
+
 /**
  *
  * @description Calculates the AWS costs incurred for AWS Lambda given the region, execution duration and memory size.
@@ -24,18 +31,19 @@ export type EstimatePriceInput = {
  */
 export const estimatePrice = ({
 	region,
-	durationInMilliseconds: durationInMillisecondsFixed,
-	durationInMiliseconds: durationInMillisecondsTypo,
 	memorySizeInMb,
 	diskSizeInMb,
 	lambdasInvoked,
+	...other
 }: EstimatePriceInput): number => {
 	validateMemorySize(memorySizeInMb);
 	validateAwsRegion(region);
 	validateDiskSizeInMb(diskSizeInMb);
 
 	const durationInMilliseconds =
-		durationInMillisecondsFixed ?? durationInMillisecondsTypo;
+		'durationInMiliseconds' in other
+			? other.durationInMiliseconds
+			: other.durationInMilliseconds;
 
 	if (typeof durationInMilliseconds !== 'number') {
 		throw new TypeError(

--- a/packages/lambda/src/api/estimate-price.ts
+++ b/packages/lambda/src/api/estimate-price.ts
@@ -8,6 +8,10 @@ import {validateMemorySize} from '../shared/validate-memory-size';
 export type EstimatePriceInput = {
 	region: AwsRegion;
 	durationInMilliseconds: number;
+	/**
+	 * @deprecated Typo in property name. Use `durationInMiliseconds` instead.
+	 */
+	durationInMiliseconds: number;
 	memorySizeInMb: number;
 	diskSizeInMb: number;
 	lambdasInvoked: number;
@@ -20,7 +24,8 @@ export type EstimatePriceInput = {
  */
 export const estimatePrice = ({
 	region,
-	durationInMilliseconds,
+	durationInMilliseconds: durationInMillisecondsFixed,
+	durationInMiliseconds: durationInMillisecondsTypo,
 	memorySizeInMb,
 	diskSizeInMb,
 	lambdasInvoked,
@@ -28,6 +33,10 @@ export const estimatePrice = ({
 	validateMemorySize(memorySizeInMb);
 	validateAwsRegion(region);
 	validateDiskSizeInMb(diskSizeInMb);
+
+	const durationInMilliseconds =
+		durationInMillisecondsFixed ?? durationInMillisecondsTypo;
+
 	if (typeof durationInMilliseconds !== 'number') {
 		throw new TypeError(
 			`Parameter 'durationInMilliseconds' must be a number but got ${typeof durationInMilliseconds}`

--- a/packages/lambda/src/functions/helpers/calculate-price-from-bucket.ts
+++ b/packages/lambda/src/functions/helpers/calculate-price-from-bucket.ts
@@ -55,7 +55,7 @@ export const estimatePriceFromBucket = ({
 	const accruedSoFar = Number(
 		estimatePrice({
 			region: getCurrentRegionInFunction(),
-			durationInMiliseconds:
+			durationInMilliseconds:
 				calculateChunkTimes({
 					contents,
 					renderId: renderMetadata.renderId,

--- a/packages/lambda/src/functions/helpers/create-post-render-data.ts
+++ b/packages/lambda/src/functions/helpers/create-post-render-data.ts
@@ -53,7 +53,7 @@ export const createPostRenderData = ({
 		.reduce((a, b) => a + b);
 
 	const cost = estimatePrice({
-		durationInMiliseconds: times,
+		durationInMilliseconds: times,
 		memorySizeInMb,
 		region,
 		lambdasInvoked: renderMetadata.estimatedTotalLambdaInvokations,

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -227,7 +227,7 @@ const innerStillHandler = async ({
 	]);
 
 	const estimatedPrice = estimatePrice({
-		durationInMiliseconds: Date.now() - start + 100,
+		durationInMilliseconds: Date.now() - start + 100,
 		memorySizeInMb: Number(process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE),
 		region: getCurrentRegionInFunction(),
 		lambdasInvoked: 1,

--- a/packages/lambda/src/test/unit/pricing.test.ts
+++ b/packages/lambda/src/test/unit/pricing.test.ts
@@ -14,7 +14,7 @@ test('Should calculate costs accurately', () => {
 	expect(
 		estimatePrice({
 			region: 'us-east-1',
-			durationInMiliseconds: 20000000,
+			durationInMilliseconds: 20000000,
 			memorySizeInMb: 2048,
 			diskSizeInMb: 10240,
 			lambdasInvoked: 1,


### PR DESCRIPTION
durationInMiliseconds is missing the second `l`

I wasn't 100% certain if you would want the changelog updated, as the spelling is correct for the changelog date 🤷🏻 