### PR TITLE
`@remotion/player`: use preload="auto" for video on desktop

### DIFF
--- a/packages/core/src/video/VideoForDevelopment.tsx
+++ b/packages/core/src/video/VideoForDevelopment.tsx
@@ -22,7 +22,7 @@ import {
 	useMediaVolumeState,
 } from '../volume-position-state.js';
 import type {RemotionVideoProps} from './props.js';
-import {useAppendVideoFragment} from './video-fragment.js';
+import {isIosSafari, useAppendVideoFragment} from './video-fragment.js';
 
 type VideoForDevelopmentProps = RemotionVideoProps & {
 	onlyWarnForMediaSeekingError: boolean;
@@ -170,7 +170,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 			// Without this, on iOS Safari, the video cannot be seeked.
 			// if a seek is triggered before `loadedmetadata` is fired,
 			// the video will not seek, even if `loadedmetadata` is fired afterwards.
-			preload="metadata"
+			preload={isIosSafari() ? 'metadata' : 'auto'}
 			muted={muted || mediaMuted}
 			playsInline
 			src={actualSrc}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
