### PR TITLE
`@remotion/renderer`: Include signal in error message when compositor is quitting

### DIFF
--- a/packages/renderer/src/test/rust-errors.test.ts
+++ b/packages/renderer/src/test/rust-errors.test.ts
@@ -57,14 +57,14 @@ test('Handle panics', async () => {
 		compositor.finishCommands();
 		throw new Error('should not be reached');
 	} catch (err) {
-		expect((err as Error).message).toContain('Compositor already quit');
+		expect((err as Error).message).toContain('Compositor quit');
 	}
 
 	try {
 		await compositor.waitForDone();
 		throw new Error('should not be reached');
 	} catch (err) {
-		expect((err as Error).message).toContain('Compositor already quit');
+		expect((err as Error).message).toContain('Compositor quit');
 	}
 });
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
