### PR TITLE
`remotion`: 🪲 Fix another timeline infinite loop

### DIFF
--- a/packages/core/src/test/wrap-sequence-context.tsx
+++ b/packages/core/src/test/wrap-sequence-context.tsx
@@ -26,11 +26,9 @@ export const mockCompositionContext: CompositionManagerContext = {
 	],
 	currentComposition: 'my-comp',
 	folders: [],
-	registerRenderAsset: () => undefined,
 	registerComposition: () => undefined,
 	registerFolder: () => undefined,
 	setCurrentComposition: () => undefined,
-	unregisterAsset: () => undefined,
 	unregisterComposition: () => undefined,
 	unregisterFolder: () => undefined,
 };

--- a/packages/core/src/use-media-in-timeline.ts
+++ b/packages/core/src/use-media-in-timeline.ts
@@ -57,8 +57,6 @@ export const useMediaInTimeline = ({
 		: videoConfig.durationInFrames;
 	const doesVolumeChange = typeof volume === 'function';
 
-	const environment = getRemotionEnvironment();
-
 	const volumes: string | number = useMemo(() => {
 		if (typeof volume === 'number') {
 			return volume;
@@ -94,7 +92,7 @@ export const useMediaInTimeline = ({
 			throw new Error('No src passed');
 		}
 
-		if (!environment.isStudio && process.env.NODE_ENV !== 'test') {
+		if (!getRemotionEnvironment().isStudio && process.env.NODE_ENV !== 'test') {
 			return;
 		}
 
@@ -135,7 +133,6 @@ export const useMediaInTimeline = ({
 		mediaType,
 		startsAt,
 		playbackRate,
-		environment,
 	]);
 
 	useEffect(() => {

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -69,7 +69,6 @@ export const SharedPlayerContexts: React.FC<{
 			unregisterComposition: () => undefined,
 			unregisterSequence: () => undefined,
 			registerRenderAsset: () => undefined,
-			unregisterAsset: () => undefined,
 			currentCompositionMetadata: null,
 			setCurrentCompositionMetadata: () => undefined,
 			assets: [],


### PR DESCRIPTION
Fixes #2799 