### PR TITLE
`@remotion/cli`: Don't validate concurrency for remote renders

### DIFF
--- a/packages/cli/src/get-cli-options.ts
+++ b/packages/cli/src/get-cli-options.ts
@@ -133,7 +133,11 @@ export const getCliOptions = async (options: {
 	const height = ConfigInternals.getHeight();
 	const width = ConfigInternals.getWidth();
 
-	RenderInternals.validateConcurrency(concurrency, 'concurrency');
+	RenderInternals.validateConcurrency({
+		value: concurrency,
+		setting: 'concurrency',
+		checkIfValidForCurrentMachine: false,
+	});
 
 	return {
 		puppeteerTimeout: ConfigInternals.getCurrentPuppeteerTimeout(),

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -170,10 +170,11 @@ const innerLaunchHandler = async (
 	RenderInternals.validateBitrate(params.audioBitrate, 'audioBitrate');
 	RenderInternals.validateBitrate(params.videoBitrate, 'videoBitrate');
 
-	RenderInternals.validateConcurrency(
-		params.concurrencyPerLambda,
-		'concurrencyPerLambda',
-	);
+	RenderInternals.validateConcurrency({
+		value: params.concurrencyPerLambda,
+		setting: 'concurrencyPerLambda',
+		checkIfValidForCurrentMachine: true,
+	});
 
 	const realFrameRange = RenderInternals.getRealFrameRange(
 		comp.durationInFrames,

--- a/packages/renderer/src/test/validate-concurrency.test.ts
+++ b/packages/renderer/src/test/validate-concurrency.test.ts
@@ -49,8 +49,8 @@ test('setConcurrency should throw if concurrency is too high', () => {
 	expect(
 		validateConcurrency({
 			checkIfValidForCurrentMachine: false,
-			setting: '50%',
-			value: 'concurrency',
+			value: '50%',
+			setting: 'concurrency',
 		}),
 	).toBe(undefined);
 });

--- a/packages/renderer/src/test/validate-concurrency.test.ts
+++ b/packages/renderer/src/test/validate-concurrency.test.ts
@@ -5,26 +5,52 @@ const invalidConcurrency: String = 'invalidConcurrency';
 
 test('setConcurrency should throw if concurrency is not a number or percentage', () => {
 	expect(() =>
-		validateConcurrency(invalidConcurrency, 'concurrencyPerLambda'),
+		validateConcurrency({
+			value: invalidConcurrency,
+			setting: 'concurrencyPerLambda',
+			checkIfValidForCurrentMachine: false,
+		}),
 	).toThrow(/concurrencyPerLambda must be a number or percentage, but is/);
 });
 
 test('setConcurrency should NOT throw if concurrency is a number', () => {
-	expect(() => validateConcurrency(2, 'concurrencyPerLambda')).not.toThrow();
+	expect(() =>
+		validateConcurrency({
+			value: 2,
+			setting: 'concurrencyPerLambda',
+			checkIfValidForCurrentMachine: false,
+		}),
+	).not.toThrow();
 });
 
 test('setConcurrency should throw if concurrency is too high', () => {
-	expect(() => validateConcurrency(50, 'concurrencyPerLambda')).toThrow(
+	expect(() =>
+		validateConcurrency({
+			checkIfValidForCurrentMachine: true,
+			value: 50,
+			setting: 'concurrencyPerLambda',
+		}),
+	).toThrow(
 		/concurrencyPerLambda is set higher than the amount of CPU cores available/,
 	);
 });
 
-test('setConcurrency should throw if concurrency is too high', () => {
-	expect(() => validateConcurrency('0', 'concurrency')).toThrow(
-		/concurrency must be a number or percentage, but is "0"/,
-	);
+test('setConcurrency should throw if concurrency is string 0', () => {
+	expect(() =>
+		validateConcurrency({
+			value: '0',
+			checkIfValidForCurrentMachine: false,
+			setting: 'concurrency',
+		}),
+	).toThrow(/concurrency must be a number or percentage, but is "0"/);
 });
 
 test('setConcurrency should throw if concurrency is too high', () => {
-	expect(validateConcurrency('50%', 'concurrency')).toBe(undefined);
+	expect(
+		validateConcurrency({
+			checkIfValidForCurrentMachine: false,
+			setting: '50%',
+			value: 'concurrency',
+		}),
+	).toBe(undefined);
 });

--- a/packages/renderer/src/validate-concurrency.ts
+++ b/packages/renderer/src/validate-concurrency.ts
@@ -1,4 +1,12 @@
-export const validateConcurrency = (value: unknown, setting: string) => {
+export const validateConcurrency = ({
+	setting,
+	value,
+	checkIfValidForCurrentMachine,
+}: {
+	value: unknown;
+	setting: string;
+	checkIfValidForCurrentMachine: boolean;
+}) => {
 	if (typeof value === 'undefined') {
 		return;
 	}
@@ -16,18 +24,20 @@ export const validateConcurrency = (value: unknown, setting: string) => {
 			throw new Error(setting + ' must be an integer, but is ' + value);
 		}
 
-		if (value < getMinConcurrency()) {
-			throw new Error(
-				`${setting} must be at least ${getMinConcurrency()}, but is ${JSON.stringify(
-					value,
-				)}`,
-			);
-		}
+		if (checkIfValidForCurrentMachine) {
+			if (value < getMinConcurrency()) {
+				throw new Error(
+					`${setting} must be at least ${getMinConcurrency()}, but is ${JSON.stringify(
+						value,
+					)}`,
+				);
+			}
 
-		if (value > getMaxConcurrency()) {
-			throw new Error(
-				`${setting} is set higher than the amount of CPU cores available. Available CPU cores: ${getMaxConcurrency()}, value set: ${value}`,
-			);
+			if (value > getMaxConcurrency()) {
+				throw new Error(
+					`${setting} is set higher than the amount of CPU cores available. Available CPU cores: ${getMaxConcurrency()}, value set: ${value}`,
+				);
+			}
 		}
 	} else if (!/^\d+(\.\d+)?%$/.test(value)) {
 		throw new Error(


### PR DESCRIPTION
E.g. triggering a cloud run render with 8x concurrency but the local available concurrency is only 2x will not trigger an error anymore