### PR TITLE
`@remotion/player`: Calling `.pause()` immediately after `.seek()` will behave correctly

### DIFF
--- a/packages/player-example/src/App.tsx
+++ b/packages/player-example/src/App.tsx
@@ -257,8 +257,14 @@ const ControlsOnly: React.FC<{
 			<button type="button" onClick={() => ref.current?.toggle()}>
 				⏯️ Toggle
 			</button>
-			<button type="button" onClick={() => ref.current?.seekTo(10)}>
-				seekTo 10
+			<button
+				type="button"
+				onClick={() => {
+					ref.current?.seekTo(10);
+					ref.current?.pause();
+				}}
+			>
+				seekTo 10 and pause
 			</button>
 			<button type="button" onClick={() => ref.current?.seekTo(50)}>
 				seekTo 50

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -280,7 +280,11 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		() => {
 			const methods: PlayerMethods = {
 				play: player.play,
-				pause: player.pause,
+				pause: () => {
+					// If, after .seek()-ing, the player was explicitly paused, we don't resume
+					setHasPausedToResume(false);
+					player.pause();
+				},
 				toggle,
 				getContainerNode: () => container.current,
 				getCurrentFrame: player.getCurrentFrame,
@@ -288,6 +292,8 @@ const PlayerUI: React.ForwardRefRenderFunction<
 				seekTo: (f) => {
 					const lastFrame = durationInFrames - 1;
 					const frameToSeekTo = Math.max(0, Math.min(lastFrame, f));
+
+					// continue playing after seeking if the player was playing before
 					if (player.isPlaying()) {
 						const pauseToResume = frameToSeekTo !== lastFrame || loop;
 						setHasPausedToResume(pauseToResume);


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
