### PR TITLE
`@remotion/renderer`: Fix videos with holes / sparsly populated frames

### DIFF
--- a/packages/renderer/rust/frame_cache.rs
+++ b/packages/renderer/rust/frame_cache.rs
@@ -3,7 +3,9 @@ extern crate ffmpeg_next as remotionffmpeg;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{
-    errors::ErrorWithBacktrace, global_printer::_print_debug, opened_stream::get_time,
+    errors::ErrorWithBacktrace,
+    global_printer::{_print_debug, _print_verbose},
+    opened_stream::get_time,
     scalable_frame::ScalableFrame,
 };
 
@@ -14,6 +16,7 @@ pub fn get_frame_cache_id() -> usize {
 
 pub struct FrameCacheItem {
     pub resolved_pts: i64,
+    pub previous_pts: Option<i64>,
     pub asked_time: i64,
     pub frame: ScalableFrame,
     pub id: usize,
@@ -194,6 +197,7 @@ impl FrameCache {
 
         if best_distance > threshold {
             let has_no_items_before = self.items.iter().all(|item| item.resolved_pts > time);
+
             if has_no_items_before {
                 let has_asked_time_before = self
                     .items
@@ -213,7 +217,58 @@ impl FrameCache {
                     return Ok(None);
                 }
             } else {
-                return Ok(None);
+                let closest_item_after_this = self
+                    .items
+                    .iter()
+                    .filter(|item| item.resolved_pts >= time)
+                    .min_by_key(|item| item.resolved_pts);
+
+                let is_inbetween_next_frame = match closest_item_after_this {
+                    Some(closest_item_after_this) => {
+                        // Comparing DTS and PTS - not perfect but that is the assumption for variable videos
+                        closest_item_after_this.resolved_pts > time
+                            && closest_item_after_this.previous_pts.is_some()
+                            && closest_item_after_this.previous_pts.unwrap() < time
+                    }
+                    None => false,
+                };
+
+                let is_inbetween_and_after = best_item.is_some()
+                    && self.items[best_item.unwrap()].previous_pts.is_some()
+                    && self.items[best_item.unwrap()].previous_pts.unwrap() < time
+                    && self.items[best_item.unwrap()].resolved_pts > time;
+
+                if is_inbetween_next_frame {
+                    _print_verbose(&format!(
+                        "Found timestamp with too much threshold, but will let it pass because it is the best match and there is a frame after the current one that follows one with a lower timestamp. threshold = {}, after this pts = {} after this previous pts = {:?}",
+                         threshold,
+                         closest_item_after_this.unwrap().resolved_pts,
+                        closest_item_after_this.unwrap().previous_pts,
+                    ))?;
+                    // Fall through to success
+                } else if is_inbetween_and_after {
+                    _print_verbose(&format!(
+                        "Found timestamp with too much threshold, but will let it pass because it is inbetween frames. threshold = {}",
+                         threshold
+                    ))?;
+                    // Fall through to success
+                } else {
+                    if best_item.is_some() {
+                        _print_verbose(&format!(
+                            "none found current: {} previous: {:?}",
+                            self.items[best_item.unwrap()].resolved_pts,
+                            self.items[best_item.unwrap()].previous_pts
+                        ))?;
+                    }
+                    if closest_item_after_this.is_some() {
+                        _print_verbose(&format!(
+                            "also next one: {} previous: {:?}",
+                            closest_item_after_this.unwrap().resolved_pts,
+                            closest_item_after_this.unwrap().previous_pts
+                        ))?;
+                    }
+                    return Ok(None);
+                }
             }
         }
 

--- a/packages/renderer/rust/frame_cache.rs
+++ b/packages/renderer/rust/frame_cache.rs
@@ -253,20 +253,6 @@ impl FrameCache {
                     ))?;
                     // Fall through to success
                 } else {
-                    if best_item.is_some() {
-                        _print_verbose(&format!(
-                            "none found current: {} previous: {:?}",
-                            self.items[best_item.unwrap()].resolved_pts,
-                            self.items[best_item.unwrap()].previous_pts
-                        ))?;
-                    }
-                    if closest_item_after_this.is_some() {
-                        _print_verbose(&format!(
-                            "also next one: {} previous: {:?}",
-                            closest_item_after_this.unwrap().resolved_pts,
-                            closest_item_after_this.unwrap().previous_pts
-                        ))?;
-                    }
                     return Ok(None);
                 }
             }

--- a/packages/renderer/rust/opened_stream.rs
+++ b/packages/renderer/rust/opened_stream.rs
@@ -316,7 +316,7 @@ impl OpenedStream {
             return Err(std::io::Error::new(
                 ErrorKind::Other,
                 format!(
-                    "No frame found at position {} for source {} (original source = {})",
+                    "No frame found at position {} for source {} (original source = {}). If you think this should work, file an issue at https://remotion.dev/issue or post it in https://remotion.dev/discord. Post the problematic video and the output of `npx remotion versions`.",
                     position, self.src, self.original_src
                 ),
             ))?;

--- a/packages/renderer/rust/opened_stream.rs
+++ b/packages/renderer/rust/opened_stream.rs
@@ -34,6 +34,7 @@ pub struct OpenedStream {
     pub rotation: Rotate,
 }
 
+#[derive(Clone, Copy)]
 pub struct LastFrameInfo {
     index: usize,
     pts: i64,
@@ -76,10 +77,12 @@ impl OpenedStream {
         position: i64,
         frame_cache: &Arc<Mutex<FrameCache>>,
         one_frame_in_time_base: i64,
+        previous_pts: Option<i64>,
     ) -> Result<Option<LastFrameInfo>, ErrorWithBacktrace> {
         self.video.send_eof()?;
 
         let mut latest_frame: Option<LastFrameInfo> = None;
+        let mut looped_pts = previous_pts;
         let mut offset = 0;
 
         loop {
@@ -117,7 +120,10 @@ impl OpenedStream {
                         id: frame_cache_id,
                         asked_time: position,
                         last_used: get_time(),
+                        previous_pts: looped_pts,
                     };
+
+                    looped_pts = video.pts();
 
                     frame_cache.lock()?.add_item(item);
                     latest_frame = Some(LastFrameInfo {
@@ -183,7 +189,15 @@ impl OpenedStream {
 
             let (stream, packet) = match self.input.get_next_packet() {
                 Err(remotionffmpeg::Error::Eof) => {
-                    let data = self.handle_eof(position, frame_cache, one_frame_in_time_base)?;
+                    let data = self.handle_eof(
+                        position,
+                        frame_cache,
+                        one_frame_in_time_base,
+                        match freshly_seeked || self.last_position == 0 {
+                            true => None,
+                            false => Some(self.last_position),
+                        },
+                    )?;
                     if data.is_some() {
                         last_frame_received = data;
 
@@ -233,76 +247,74 @@ impl OpenedStream {
                 }
             }
 
-            loop {
-                self.video.send_packet(&packet)?;
-                let result = self.receive_frame();
+            self.video.send_packet(&packet)?;
+            let result = self.receive_frame();
 
-                match result {
-                    Ok(Some(video)) => unsafe {
-                        let linesize = (*video.as_ptr()).linesize;
-                        let frame_cache_id = get_frame_cache_id();
+            match result {
+                Ok(Some(video)) => unsafe {
+                    let linesize = (*video.as_ptr()).linesize;
+                    let frame_cache_id = get_frame_cache_id();
 
-                        let amount_of_planes = video.planes();
-                        let mut planes = Vec::with_capacity(amount_of_planes);
-                        for i in 0..amount_of_planes {
-                            planes.push(video.data(i).to_vec());
-                        }
+                    let amount_of_planes = video.planes();
+                    let mut planes = Vec::with_capacity(amount_of_planes);
+                    for i in 0..amount_of_planes {
+                        planes.push(video.data(i).to_vec());
+                    }
 
-                        let frame = NotRgbFrame {
-                            linesizes: linesize,
-                            planes,
-                            format: video.format(),
-                            original_height: self.original_height,
-                            original_width: self.original_width,
-                            scaled_height: self.scaled_height,
-                            scaled_width: self.scaled_width,
-                            rotate: self.rotation,
-                            original_src: self.original_src.clone(),
-                        };
+                    let frame = NotRgbFrame {
+                        linesizes: linesize,
+                        planes,
+                        format: video.format(),
+                        original_height: self.original_height,
+                        original_width: self.original_width,
+                        scaled_height: self.scaled_height,
+                        scaled_width: self.scaled_width,
+                        rotate: self.rotation,
+                        original_src: self.original_src.clone(),
+                    };
 
-                        self.last_position = video.pts().expect("expected pts");
+                    let item = FrameCacheItem {
+                        resolved_pts: video.pts().expect("expected pts"),
+                        frame: ScalableFrame::new(frame, self.transparent),
+                        id: frame_cache_id,
+                        asked_time: position,
+                        last_used: get_time(),
+                        previous_pts: match freshly_seeked || self.last_position == 0 {
+                            true => None,
+                            false => Some(self.last_position),
+                        },
+                    };
 
-                        let item = FrameCacheItem {
-                            resolved_pts: video.pts().expect("expected pts"),
-                            frame: ScalableFrame::new(frame, self.transparent),
-                            id: frame_cache_id,
-                            asked_time: position,
-                            last_used: get_time(),
-                        };
+                    self.last_position = video.pts().expect("expected pts");
+                    freshly_seeked = false;
 
-                        frame_cache.lock().unwrap().add_item(item);
+                    frame_cache.lock().unwrap().add_item(item);
 
-                        _print_verbose(&format!("received frame {}", video.pts().expect("pts"),))?;
+                    _print_verbose(&format!("received frame {}", video.pts().expect("pts"),))?;
 
-                        match stop_after_n_diverging_pts {
-                            Some(stop) => match last_frame_received {
-                                Some(last_frame) => {
-                                    let prev_difference = (last_frame.pts - position).abs();
-                                    let new_difference =
-                                        (video.pts().expect("pts") - position).abs();
+                    match stop_after_n_diverging_pts {
+                        Some(stop) => match last_frame_received {
+                            Some(last_frame) => {
+                                let prev_difference = (last_frame.pts - position).abs();
+                                let new_difference = (video.pts().expect("pts") - position).abs();
 
-                                    if new_difference > prev_difference {
-                                        stop_after_n_diverging_pts = Some(stop - 1);
-                                    }
+                                if new_difference > prev_difference {
+                                    stop_after_n_diverging_pts = Some(stop - 1);
                                 }
-                                None => {}
-                            },
+                            }
                             None => {}
-                        }
-
-                        last_frame_received = Some(LastFrameInfo {
-                            index: frame_cache_id,
-                            pts: video.pts().expect("pts"),
-                        });
-
-                        break;
-                    },
-                    Ok(None) => {
-                        break;
+                        },
+                        None => {}
                     }
-                    Err(err) => {
-                        return Err(err);
-                    }
+
+                    last_frame_received = Some(LastFrameInfo {
+                        index: frame_cache_id,
+                        pts: video.pts().expect("pts"),
+                    });
+                },
+                Ok(None) => {}
+                Err(err) => {
+                    return Err(err);
                 }
             }
         }

--- a/packages/renderer/src/test/extract-frame-rust.test.ts
+++ b/packages/renderer/src/test/extract-frame-rust.test.ts
@@ -1,3 +1,4 @@
+import {writeFileSync} from 'fs';
 import {interpolate} from 'remotion';
 import {expect, test} from 'vitest';
 import {
@@ -515,6 +516,8 @@ test('Two different starting times should not result in big seeking', async () =
 			time,
 			transparent: false,
 		});
+
+		writeFileSync('data' + i + '.bmp', data);
 
 		const expectedLength = BMP_HEADER_SIZE + 1280 * 720 * 3;
 		const centerLeftPixelR =

--- a/packages/renderer/src/test/extract-frame-rust.test.ts
+++ b/packages/renderer/src/test/extract-frame-rust.test.ts
@@ -1,4 +1,3 @@
-import {writeFileSync} from 'fs';
 import {interpolate} from 'remotion';
 import {expect, test} from 'vitest';
 import {
@@ -516,8 +515,6 @@ test('Two different starting times should not result in big seeking', async () =
 			time,
 			transparent: false,
 		});
-
-		writeFileSync('data' + i + '.bmp', data);
 
 		const expectedLength = BMP_HEADER_SIZE + 1280 * 720 * 3;
 		const centerLeftPixelR =


### PR DESCRIPTION
Fixes demo1.mp4 and demo2.mp4, filed in my Bear notes