### PR TITLE
`@remotion/renderer`: Fix having an unnecessary second pass when using parallel encoding

### DIFF
--- a/packages/renderer/src/ffmpeg-args.ts
+++ b/packages/renderer/src/ffmpeg-args.ts
@@ -79,7 +79,7 @@ export const generateFfmpegArgs = ({
 			: [];
 
 	return [
-		['-c:v', encoderName],
+		['-c:v', hasPreencoded ? 'copy' : encoderName],
 		// -c:v is the same as -vcodec as -codec:video
 		// and specified the video codec.
 		...colorSpaceOptions,


### PR DESCRIPTION
Fixes an unintentional second pass when "parallel encoding" was enabled

- Makes rendering faster, especially on Lambda, where parallel encoding is used very often
- Fixes the `crf` parameter being ignored
- Increases the bitrate correctly now if `crf` is set. If you see a higher filesize, this is why.