### PR TITLE
Update brownfield-installation.md

### DIFF
--- a/packages/docs/docs/brownfield-installation.md
+++ b/packages/docs/docs/brownfield-installation.md
@@ -119,6 +119,10 @@ registerRoot(RemotionRoot);
 
 The file that calls [`registerRoot()`](/docs/register-root) is now your Remotion **entrypoint**.
 
+:::note
+Watch out for import aliases in your `tsconfig.json` that will resolve `import {...} from "remotion"` to the `remotion` folder. We recommend to not use `paths` without a prefix.
+:::
+
 ## Starting the Studio
 
 Start the Remotion Studio using the following command:

--- a/packages/docs/docs/brownfield-installation.md
+++ b/packages/docs/docs/brownfield-installation.md
@@ -50,15 +50,15 @@ yarn add @remotion/cli remotion
 
 ## Setting up the folder structure
 
-Create a new folder for the Remotion files. It can be anywhere and assume any name, in this example we name it `video` and put it in the root of our project. Inside the folder you created, create 3 files:
+Create a new folder for the Remotion files. It can be anywhere and assume any name, in this example we name it `remotion` and put it in the root of our project. Inside the folder you created, create 3 files:
 
-```tsx twoslash title="video/Composition.tsx"
+```tsx twoslash title="remotion/Composition.tsx"
 export const MyComposition = () => {
   return null;
 };
 ```
 
-```tsx twoslash title="video/Root.tsx"
+```tsx twoslash title="remotion/Root.tsx"
 // @filename: Composition.tsx
 export const MyComposition: React.FC = () => {
   return null;
@@ -85,7 +85,7 @@ export const RemotionRoot: React.FC = () => {
 };
 ```
 
-```ts twoslash title="video/index.ts"
+```ts twoslash title="remotion/index.ts"
 // @filename: Composition.tsx
 export const MyComposition: React.FC = () => {
   return null;
@@ -124,17 +124,17 @@ The file that calls [`registerRoot()`](/docs/register-root) is now your Remotion
 Start the Remotion Studio using the following command:
 
 ```
-npx remotion studio video/index.ts
+npx remotion studio remotion/index.ts
 ```
 
-Replace `video/index.ts` with your entrypoint if necessary.
+Replace `remotion/index.ts` with your entrypoint if necessary.
 
 ## Render a video
 
 Render our a video using
 
 ```
-npx remotion render video/index.ts MyComp out.mp4
+npx remotion render remotion/index.ts MyComp out.mp4
 ```
 
 Replace the entrypoint, composition name and output filename with the values that correspond to your usecase.

--- a/packages/docs/docs/brownfield-installation.md
+++ b/packages/docs/docs/brownfield-installation.md
@@ -50,15 +50,15 @@ yarn add @remotion/cli remotion
 
 ## Setting up the folder structure
 
-Create a new folder for the Remotion files. It can be anywhere and assume any name, in this example we name it `remotion` and put it in the root of our project. Inside the folder you created, create 3 files:
+Create a new folder for the Remotion files. It can be anywhere and assume any name, in this example we name it `video` and put it in the root of our project. Inside the folder you created, create 3 files:
 
-```tsx twoslash title="remotion/Composition.tsx"
+```tsx twoslash title="video/Composition.tsx"
 export const MyComposition = () => {
   return null;
 };
 ```
 
-```tsx twoslash title="remotion/Root.tsx"
+```tsx twoslash title="video/Root.tsx"
 // @filename: Composition.tsx
 export const MyComposition: React.FC = () => {
   return null;
@@ -85,7 +85,7 @@ export const RemotionRoot: React.FC = () => {
 };
 ```
 
-```ts twoslash title="remotion/index.ts"
+```ts twoslash title="video/index.ts"
 // @filename: Composition.tsx
 export const MyComposition: React.FC = () => {
   return null;
@@ -124,17 +124,17 @@ The file that calls [`registerRoot()`](/docs/register-root) is now your Remotion
 Start the Remotion Studio using the following command:
 
 ```
-npx remotion studio remotion/index.ts
+npx remotion studio video/index.ts
 ```
 
-Replace `remotion/index.ts` with your entrypoint if necessary.
+Replace `video/index.ts` with your entrypoint if necessary.
 
 ## Render a video
 
 Render our a video using
 
 ```
-npx remotion render remotion/index.ts MyComp out.mp4
+npx remotion render video/index.ts MyComp out.mp4
 ```
 
 Replace the entrypoint, composition name and output filename with the values that correspond to your usecase.


### PR DESCRIPTION
Using remotion as the folder name causes ```Module has no exported member``` errors as it is looking into that folder instead of node_modules/remotion folder.

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
