### PR TITLE
Update incorrect 'see also' links in compositions.md

### DIFF
--- a/packages/docs/docs/cli/compositions.md
+++ b/packages/docs/docs/cli/compositions.md
@@ -105,7 +105,6 @@ _removed in v4.0_
 
 ## See also
 
-- [`getCompositions()`](/docs/cli/compositions)
-- [`npx remotion compositions`](/docs/cli/compositions)
+- [`getCompositions()`](/docs/renderer/get-compositions)
 - [`getCompositionsOnLambda()`](/docs/lambda/getcompositionsonlambda)
 - [`npx remotion lambda compositions`](/docs/lambda/cli/compositions)


### PR DESCRIPTION
One of the links was for the parent page, and the other link was incorrect
