### PR TITLE
fix: account for `startFrom` and `endAt` when using `loop` for Audio

### DIFF
--- a/packages/core/src/audio/Audio.tsx
+++ b/packages/core/src/audio/Audio.tsx
@@ -1,5 +1,6 @@
 import React, {forwardRef, useCallback, useContext} from 'react';
 import {getAbsoluteSrc} from '../absolute-src.js';
+import {calculateLoopDuration} from '../calculate-loop.js';
 import {cancelRender} from '../cancel-render.js';
 import {getRemotionEnvironment} from '../get-remotion-environment.js';
 import {Loop} from '../loop/index.js';
@@ -58,23 +59,18 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 	);
 
 	if (loop && props.src && durations[getAbsoluteSrc(props.src)] !== undefined) {
-		let duration = Math.floor(durations[getAbsoluteSrc(props.src)] * fps);
-
-		// Account for endAt
-		if (typeof endAt !== 'undefined') {
-			duration = endAt;
-		}
-		
-		// Account for startFrom
-		if (typeof startFrom !== 'undefined') {
-			duration -= startFrom;
-		}
-
-		const playbackRate = props.playbackRate ?? 1;
-		const actualDuration = duration / playbackRate;
+		const duration = Math.floor(durations[getAbsoluteSrc(props.src)] * fps);
 
 		return (
-			<Loop layout="none" durationInFrames={Math.floor(actualDuration)}>
+			<Loop
+				layout="none"
+				durationInFrames={calculateLoopDuration({
+					endAt,
+					mediaDuration: duration,
+					playbackRate: props.playbackRate ?? 1,
+					startFrom,
+				})}
+			>
 				<Audio {...propsOtherThanLoop} ref={ref} />
 			</Loop>
 		);

--- a/packages/core/src/audio/Audio.tsx
+++ b/packages/core/src/audio/Audio.tsx
@@ -38,7 +38,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 			console.log(e.currentTarget.error);
 
 			// If there is no `loop` property, we don't need to get the duration
-			// and thsi does not need to be a fatal error
+			// and this does not need to be a fatal error
 			const errMessage = `Could not play audio with src ${otherProps.src}: ${e.currentTarget.error}. See https://remotion.dev/docs/media-playback-error for help.`;
 
 			if (loop) {
@@ -58,7 +58,18 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 	);
 
 	if (loop && props.src && durations[getAbsoluteSrc(props.src)] !== undefined) {
-		const duration = Math.floor(durations[getAbsoluteSrc(props.src)] * fps);
+		let duration = Math.floor(durations[getAbsoluteSrc(props.src)] * fps);
+
+		// Account for endAt
+		if (typeof endAt !== 'undefined') {
+			duration = endAt;
+		}
+		
+		// Account for startFrom
+		if (typeof startFrom !== 'undefined') {
+			duration -= startFrom;
+		}
+
 		const playbackRate = props.playbackRate ?? 1;
 		const actualDuration = duration / playbackRate;
 

--- a/packages/core/src/calculate-loop.ts
+++ b/packages/core/src/calculate-loop.ts
@@ -1,0 +1,27 @@
+export const calculateLoopDuration = ({
+	endAt,
+	mediaDuration,
+	playbackRate,
+	startFrom,
+}: {
+	mediaDuration: number;
+	playbackRate: number;
+	startFrom: number | undefined;
+	endAt: number | undefined;
+}) => {
+	let duration = mediaDuration;
+
+	// Account for endAt
+	if (typeof endAt !== 'undefined') {
+		duration = endAt;
+	}
+
+	// Account for startFrom
+	if (typeof startFrom !== 'undefined') {
+		duration -= startFrom;
+	}
+
+	const actualDuration = duration / playbackRate;
+
+	return Math.floor(actualDuration);
+};

--- a/packages/core/src/test/audio.test.tsx
+++ b/packages/core/src/test/audio.test.tsx
@@ -46,4 +46,14 @@ describe('Render correctly with props', () => {
 			),
 		).not.toThrow();
 	});
+	
+	test('It should render Audio with loop, startFrom and endAt props', () => {
+		expect(() =>
+			render(
+				<WrapSequenceContext>
+					<Audio src="test" volume={1} startFrom={10} endAt={20} loop/>
+				</WrapSequenceContext>,
+			),
+		).not.toThrow();
+	});
 });

--- a/packages/core/src/test/audio.test.tsx
+++ b/packages/core/src/test/audio.test.tsx
@@ -46,12 +46,12 @@ describe('Render correctly with props', () => {
 			),
 		).not.toThrow();
 	});
-	
+
 	test('It should render Audio with loop, startFrom and endAt props', () => {
 		expect(() =>
 			render(
 				<WrapSequenceContext>
-					<Audio src="test" volume={1} startFrom={10} endAt={20} loop/>
+					<Audio src="test" volume={1} startFrom={10} endAt={20} loop />
 				</WrapSequenceContext>,
 			),
 		).not.toThrow();

--- a/packages/core/src/video/Video.tsx
+++ b/packages/core/src/video/Video.tsx
@@ -1,5 +1,6 @@
 import React, {forwardRef, useCallback, useContext} from 'react';
 import {getAbsoluteSrc} from '../absolute-src.js';
+import {calculateLoopDuration} from '../calculate-loop.js';
 import {getRemotionEnvironment} from '../get-remotion-environment.js';
 import {Loop} from '../loop/index.js';
 import {Sequence} from '../Sequence.js';
@@ -42,12 +43,17 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 	);
 
 	if (loop && props.src && durations[getAbsoluteSrc(props.src)] !== undefined) {
-		const naturalDuration = durations[getAbsoluteSrc(props.src)] * fps;
-		const playbackRate = props.playbackRate ?? 1;
-		const durationInFrames = Math.floor(naturalDuration / playbackRate);
+		const mediaDuration = durations[getAbsoluteSrc(props.src)] * fps;
 
 		return (
-			<Loop durationInFrames={durationInFrames}>
+			<Loop
+				durationInFrames={calculateLoopDuration({
+					endAt,
+					mediaDuration,
+					playbackRate: props.playbackRate ?? 1,
+					startFrom,
+				})}
+			>
 				<Video {...propsOtherThanLoop} ref={ref} />
 			</Loop>
 		);

--- a/packages/example/src/LoopTrimmedAudio/index.tsx
+++ b/packages/example/src/LoopTrimmedAudio/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import {Audio, staticFile} from 'remotion';
+
+const LoopedTrimmedAudio: React.FC = () => {
+	return <Audio loop src={staticFile('music.mp3')} startFrom={125} endAt={370}/>;
+};
+
+export default LoopedTrimmedAudio;

--- a/packages/example/src/LoopTrimmedAudio/index.tsx
+++ b/packages/example/src/LoopTrimmedAudio/index.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import {Audio, staticFile} from 'remotion';
 
 const LoopedTrimmedAudio: React.FC = () => {
-	return <Audio loop src={staticFile('music.mp3')} startFrom={125} endAt={370}/>;
+	return (
+		<Audio loop src={staticFile('music.mp3')} startFrom={125} endAt={370} />
+	);
 };
 
 export default LoopedTrimmedAudio;

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -696,6 +696,14 @@ export const Index: React.FC = () => {
 					fps={30}
 					durationInFrames={180 * 30}
 				/>
+				<Composition
+					id="loop-trimmed-audio"
+					lazyComponent={() => import('./LoopTrimmedAudio')}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={180 * 30}
+				/>
 			</Folder>
 			<Folder name="three">
 				<Still id="Orb" component={OrbScene} width={2000} height={2000} />


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
Fixes #2823.

When using `loop` with either `startFrom` or `endAt` props, the audio should loop right after it completes playing.
