### PR TITLE
`@remotion/renderer`: Prioritize Remotion .dll files over system-installed ones

### DIFF
--- a/packages/renderer/src/call-ffmpeg.ts
+++ b/packages/renderer/src/call-ffmpeg.ts
@@ -16,7 +16,7 @@ export const dynamicLibraryPathOptions = () => {
 				  }
 				: process.platform === 'win32'
 				? {
-						PATH: `${process.env.PATH};${lib}`,
+						PATH: `${lib};${process.env.PATH}`,
 				  }
 				: {
 						LD_LIBRARY_PATH: lib,


### PR DESCRIPTION
Other installations of FFmpeg might previously take precedence. 

ChatGPT:


> In Windows, when you execute a command without providing its full path, the operating system uses the PATH environment variable to determine where to look for the executable.
> 
> Windows searches the directories in the PATH environment variable in the order they are listed. So, if there are multiple matches for a binary, Windows will use the one that appears in the first directory listed in the PATH that contains the matching binary.
> 
> For example, consider the following hypothetical PATH:
> 
> mathematica
> Copy code
> C:\Directory1;C:\Directory2;C:\Directory3
> If executable.exe is present in both Directory1 and Directory2, and you just type executable at the command prompt, Windows will execute the one in Directory1 because it searches Directory1 before Directory2.