### PR TITLE
`@remotion/renderer`: Free up memory if system memory is critically low

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -432,9 +432,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -562,6 +562,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -821,6 +830,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "sysinfo",
 ]
 
 [[package]]
@@ -916,6 +926,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.29.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d0e9cc2273cc8d31377bdd638d72e3ac3e5607b18621062b169d02787f1bab"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -15,8 +15,9 @@ jpeg-decoder = "0.3"
 jpeg-encoder = "0.5.1"
 lazy_static = "1.4"
 rayon = "1.7.0"
-image = "0.23.14"
+image = "0.23.7"
 arboard = "3.2.0"
+sysinfo = "0.29.9"
 mp4 = {git = "https://github.com/jonnyburger/mp4-rust", rev = "92ba375738cc2f05a4d754e1f968cf2e97d06641"}
 ffmpeg-next = {git = "https://github.com/remotion-dev/rust-ffmpeg", rev ="d94f32c1a6a8af15c11eb7cf52cd75259326569c"}
 

--- a/packages/renderer/rust/ffmpeg.rs
+++ b/packages/renderer/rust/ffmpeg.rs
@@ -1,4 +1,5 @@
 use crate::errors::ErrorWithBacktrace;
+use crate::global_printer::_print_verbose;
 use crate::opened_stream::calc_position;
 use crate::opened_video_manager::OpenedVideoManager;
 use crate::payloads::payloads::{KnownCodecs, KnownColorSpaces, OpenVideoStats, VideoMetadata};
@@ -32,7 +33,18 @@ pub fn keep_only_latest_frames(
 ) -> Result<(), ErrorWithBacktrace> {
     let manager = OpenedVideoManager::get_instance();
 
-    manager.only_keep_n_frames(maximum_frame_cache_size_in_bytes)?;
+    manager.prune_oldest(maximum_frame_cache_size_in_bytes)?;
+
+    Ok(())
+}
+
+pub fn emergency_memory_free_up(
+    maximum_frame_cache_size_in_bytes: u128,
+) -> Result<(), ErrorWithBacktrace> {
+    let manager = OpenedVideoManager::get_instance();
+
+    _print_verbose("System is about to run out of memory, freeing up memory.")?;
+    manager.halfen_cache_size(maximum_frame_cache_size_in_bytes)?;
 
     Ok(())
 }

--- a/packages/renderer/rust/main.rs
+++ b/packages/renderer/rust/main.rs
@@ -8,6 +8,7 @@ mod get_silent_parts;
 mod global_printer;
 mod image;
 mod logger;
+mod memory;
 mod opened_stream;
 mod opened_video;
 mod opened_video_manager;
@@ -17,6 +18,7 @@ mod scalable_frame;
 use commands::execute_command;
 use errors::{error_to_json, ErrorWithBacktrace};
 use global_printer::{_print_verbose, set_verbose_logging};
+use memory::is_about_to_run_out_of_memory;
 use std::env;
 
 use payloads::payloads::{parse_cli, CliInputCommand, CliInputCommandPayload};
@@ -39,6 +41,11 @@ fn mainfn() -> Result<(), ErrorWithBacktrace> {
     match opts.payload {
         CliInputCommandPayload::StartLongRunningProcess(payload) => {
             set_verbose_logging(payload.verbose);
+
+            let memory = memory::get_available_memory();
+
+            _print_verbose(&format!("available memory {}", memory))?;
+
             _print_verbose(&format!(
                 "Starting Rust process. Max video cache size: {}MB, max concurrency = {}",
                 payload.maximum_frame_cache_size_in_bytes / 1024 / 1024,
@@ -96,6 +103,9 @@ fn start_long_running_process(
                 )
                 .unwrap(),
             };
+            if is_about_to_run_out_of_memory() {
+                ffmpeg::emergency_memory_free_up(maximum_frame_cache_size_in_bytes).unwrap();
+            }
             ffmpeg::keep_only_latest_frames(maximum_frame_cache_size_in_bytes).unwrap();
         });
     }

--- a/packages/renderer/rust/memory.rs
+++ b/packages/renderer/rust/memory.rs
@@ -1,0 +1,16 @@
+use sysinfo::{System, SystemExt};
+
+pub fn get_available_memory() -> u64 {
+    let mut sys = System::new();
+    sys.refresh_memory();
+    return sys.free_memory();
+}
+
+// Is there less than 100MB of memory left?
+pub fn is_about_to_run_out_of_memory() -> bool {
+    let mut sys = System::new();
+    sys.refresh_memory();
+
+    let free_memory_and_swap = sys.free_memory() + sys.free_swap();
+    return free_memory_and_swap < 100 * 1024 * 1024;
+}

--- a/packages/renderer/rust/opened_video_manager.rs
+++ b/packages/renderer/rust/opened_video_manager.rs
@@ -74,18 +74,19 @@ impl OpenedVideoManager {
         return Ok(total_size);
     }
 
-    pub fn only_keep_n_frames(
+    pub fn prune_oldest(
         &self,
         maximum_frame_cache_size_in_bytes: u128,
     ) -> Result<(), ErrorWithBacktrace> {
         self.prune(maximum_frame_cache_size_in_bytes)
     }
 
-    pub fn prune_oldest(
+    // Should be called if system is about to run out of memory
+    pub fn halfen_cache_size(
         &self,
         maximum_frame_cache_size_in_bytes: u128,
     ) -> Result<(), ErrorWithBacktrace> {
-        self.prune(maximum_frame_cache_size_in_bytes)
+        self.prune(maximum_frame_cache_size_in_bytes / 2)
     }
 
     pub fn prune(&self, maximum_frame_cache_size_in_bytes: u128) -> Result<(), ErrorWithBacktrace> {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
