### PR TITLE
add internalRenderMediaOnCloudrun

### DIFF
--- a/packages/cloudrun/src/api/render-media-on-cloudrun.ts
+++ b/packages/cloudrun/src/api/render-media-on-cloudrun.ts
@@ -68,7 +68,7 @@ type InternalRenderMediaOnCloudrun = {
 	enforceAudioTrack: boolean | undefined;
 	preferLossless: boolean | undefined;
 	colorSpace: ColorSpace | undefined;
-} & Partial<ToOptions<typeof BrowserSafeApis.optionsMap.renderMediaOnLambda>>;
+} & Partial<ToOptions<typeof BrowserSafeApis.optionsMap.renderMediaOnCloudRun>>;
 
 export type RenderMediaOnCloudrunInput = {
 	cloudRunUrl?: string;
@@ -106,7 +106,7 @@ export type RenderMediaOnCloudrunInput = {
 	enforceAudioTrack?: boolean;
 	preferLossless?: boolean;
 	colorSpace?: ColorSpace;
-} & Partial<ToOptions<typeof BrowserSafeApis.optionsMap.renderMediaOnLambda>>;
+} & Partial<ToOptions<typeof BrowserSafeApis.optionsMap.renderMediaOnCloudRun>>;
 
 const internalRenderMediaOnCloudrunRaw = async ({
 	cloudRunUrl,

--- a/packages/cloudrun/src/api/render-media-on-cloudrun.ts
+++ b/packages/cloudrun/src/api/render-media-on-cloudrun.ts
@@ -211,12 +211,6 @@ const internalRenderMediaOnCloudrunRaw = async ({
 		responseType: 'stream',
 	});
 
-	console.log('2~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~2');
-	console.log({jpegQuality});
-	console.log({crf});
-	console.log({x264Preset});
-	console.log('2~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~2');
-
 	const renderResponse = await new Promise<
 		RenderMediaOnCloudrunOutput | CloudRunCrashResponse
 	>((resolve, reject) => {

--- a/packages/cloudrun/src/api/render-media-on-cloudrun.ts
+++ b/packages/cloudrun/src/api/render-media-on-cloudrun.ts
@@ -2,6 +2,7 @@ import type {
 	AudioCodec,
 	ChromiumOptions,
 	ColorSpace,
+	Crf,
 	FrameRange,
 	LogLevel,
 	PixelFormat,
@@ -9,7 +10,6 @@ import type {
 	ToOptions,
 	VideoImageFormat,
 	X264Preset,
-	Crf
 } from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import type {BrowserSafeApis} from '@remotion/renderer/client';
@@ -40,7 +40,9 @@ type InternalRenderMediaOnCloudrun = {
 	privacy: 'public' | 'private' | undefined;
 	forceBucketName: string | undefined;
 	outName: string | undefined;
-	updateRenderProgress: ((progress: number, error?: boolean) => void) | undefined;
+	updateRenderProgress:
+		| ((progress: number, error?: boolean) => void)
+		| undefined;
 	codec: CloudrunCodec;
 	audioCodec: AudioCodec | undefined;
 	jpegQuality: number | undefined;
@@ -209,6 +211,12 @@ const internalRenderMediaOnCloudrunRaw = async ({
 		responseType: 'stream',
 	});
 
+	console.log('2~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~2');
+	console.log({jpegQuality});
+	console.log({crf});
+	console.log({x264Preset});
+	console.log('2~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~2');
+
 	const renderResponse = await new Promise<
 		RenderMediaOnCloudrunOutput | CloudRunCrashResponse
 	>((resolve, reject) => {
@@ -284,7 +292,6 @@ export const internalRenderMediaOnCloudrun = PureJSAPIs.wrapWithErrorHandling(
 	internalRenderMediaOnCloudrunRaw,
 ) as typeof internalRenderMediaOnCloudrunRaw;
 
-
 /**
  * @description Triggers a render on a GCP Cloud Run service given a composition and a Cloud Run URL.
  * @see [Documentation](https://remotion.dev/docs/cloudrun/renderMediaOnGcp)
@@ -324,7 +331,7 @@ export const internalRenderMediaOnCloudrun = PureJSAPIs.wrapWithErrorHandling(
  * @param params.preferLossless Uses a lossless audio codec, if one is available for the codec. If you set audioCodec, it takes priority over preferLossless.
  * @returns {Promise<RenderMediaOnCloudrunOutput>} See documentation for detailed structure
  */
-export const renderMediaOnCloudrun  = ({
+export const renderMediaOnCloudrun = ({
 	cloudRunUrl,
 	serviceName,
 	region,
@@ -362,7 +369,7 @@ export const renderMediaOnCloudrun  = ({
 	offthreadVideoCacheSizeInBytes,
 	colorSpace,
 }: RenderMediaOnCloudrunInput): Promise<
-RenderMediaOnCloudrunOutput | CloudRunCrashResponse
+	RenderMediaOnCloudrunOutput | CloudRunCrashResponse
 > => {
 	return internalRenderMediaOnCloudrun({
 		cloudRunUrl: cloudRunUrl ?? undefined,
@@ -395,11 +402,12 @@ RenderMediaOnCloudrunOutput | CloudRunCrashResponse
 		forceWidth: forceWidth ?? null,
 		forceHeight: forceHeight ?? null,
 		logLevel: logLevel ?? undefined,
-		delayRenderTimeoutInMilliseconds: delayRenderTimeoutInMilliseconds ?? undefined,
+		delayRenderTimeoutInMilliseconds:
+			delayRenderTimeoutInMilliseconds ?? undefined,
 		concurrency: concurrency ?? null,
 		enforceAudioTrack: enforceAudioTrack ?? undefined,
 		preferLossless: preferLossless ?? undefined,
 		offthreadVideoCacheSizeInBytes: offthreadVideoCacheSizeInBytes ?? undefined,
 		colorSpace: colorSpace ?? undefined,
-	})
-}
+	});
+};

--- a/packages/cloudrun/src/cli/commands/render/index.ts
+++ b/packages/cloudrun/src/cli/commands/render/index.ts
@@ -207,6 +207,7 @@ ${downloadName ? `		Downloaded File = ${downloadName}` : ''}
 		delayRenderTimeoutInMilliseconds: puppeteerTimeout,
 		enforceAudioTrack,
 		preferLossless: false,
+		offthreadVideoCacheSizeInBytes
 	});
 
 	if (res.type === 'crash') {

--- a/packages/cloudrun/src/cli/commands/render/index.ts
+++ b/packages/cloudrun/src/cli/commands/render/index.ts
@@ -3,7 +3,7 @@ import {ConfigInternals} from '@remotion/cli/config';
 import {RenderInternals} from '@remotion/renderer';
 import {Internals} from 'remotion';
 import {downloadFile} from '../../../api/download-file';
-import {renderMediaOnCloudrun} from '../../../api/render-media-on-cloudrun';
+import {internalRenderMediaOnCloudrun} from '../../../api/render-media-on-cloudrun';
 import type {CloudrunCodec} from '../../../shared/validate-gcp-codec';
 import {validateServeUrl} from '../../../shared/validate-serveurl';
 import {parsedCloudrunCli} from '../../args';
@@ -46,6 +46,7 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 		puppeteerTimeout,
 		pixelFormat,
 		proResProfile,
+		x264Preset,
 		jpegQuality,
 		scale,
 		everyNthFrame,
@@ -59,6 +60,7 @@ export const renderCommand = async (args: string[], remotionRoot: string) => {
 		port,
 		enforceAudioTrack,
 		offthreadVideoCacheSizeInBytes,
+		colorSpace,
 	} = await CliInternals.getCliOptions({
 		type: 'series',
 		isLambda: true,
@@ -172,42 +174,45 @@ ${downloadName ? `		Downloaded File = ${downloadName}` : ''}
 		}
 	};
 
-	const res = await renderMediaOnCloudrun({
+	const res = await internalRenderMediaOnCloudrun({
 		cloudRunUrl,
-		serveUrl,
+		serviceName: undefined,
 		region,
+		serveUrl,
+		composition,
 		inputProps,
 		codec: codec as CloudrunCodec,
-		imageFormat,
-		crf: crf ?? undefined,
-		envVariables,
-		pixelFormat,
-		proResProfile,
-		jpegQuality,
-		composition,
+		forceBucketName,
 		privacy,
-		frameRange: frameRange ?? undefined,
 		outName,
-		chromiumOptions,
-		scale,
-		numberOfGifLoops,
-		everyNthFrame,
-		muted,
+		updateRenderProgress,
+		jpegQuality,
+		audioCodec,
 		audioBitrate,
 		videoBitrate,
-		forceHeight: height,
+		proResProfile,
+		x264Preset,
+		crf,
+		pixelFormat,
+		imageFormat,
+		scale,
+		everyNthFrame,
+		numberOfGifLoops,
+		frameRange: frameRange ?? undefined,
+		envVariables,
+		chromiumOptions,
+		muted,
 		forceWidth: width,
-		audioCodec,
-		forceBucketName,
-		updateRenderProgress,
+		forceHeight: height,
 		logLevel: ConfigInternals.Logging.getLogLevel(),
+		delayRenderTimeoutInMilliseconds: puppeteerTimeout,
 		// Special case: Should not use default local concurrency, or from
 		// config file, just when explicitly set
 		concurrency: CliInternals.parsedCli.concurrency ?? null,
-		delayRenderTimeoutInMilliseconds: puppeteerTimeout,
 		enforceAudioTrack,
 		preferLossless: false,
-		offthreadVideoCacheSizeInBytes
+		offthreadVideoCacheSizeInBytes,
+		colorSpace,
 	});
 
 	if (res.type === 'crash') {


### PR DESCRIPTION
By creating internalRenderMediaOnCloudrun, found that these attributes were missing:

- colorSpace
- offthreadVideoCacheSizeInBytes
- x264Preset

Should be more reliable to add/remove properties in the future!