### PR TITLE
`@remotion/cloudrun`: Deleting a site will not delete other sites with the same prefix

### DIFF
--- a/packages/cloudrun/src/api/delete-site.ts
+++ b/packages/cloudrun/src/api/delete-site.ts
@@ -22,7 +22,8 @@ export const deleteSite = ({
 
 		cloudStorageClient.bucket(bucketName).deleteFiles(
 			{
-				prefix: `sites/${siteName}`,
+				// The `/` is important to not accidentially delete sites with the same name but containing a suffix.
+				prefix: `sites/${siteName}/`,
 			},
 			(err) => {
 				if (err) {


### PR DESCRIPTION
Fixes #2801 