### PR TITLE
`@remotion/lambda`: Make compressed input + resolved props private

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -139,7 +139,7 @@ jobs:
           - os: macos-latest
             node_version: 16
           - os: ubuntu-latest
-            node_version: 20
+            node_version: 20.5
     steps:
       - name: Uninstall Chrome on Windows because it does not include proprietary codecs
         run: |

--- a/packages/lambda/src/shared/compress-props.ts
+++ b/packages/lambda/src/shared/compress-props.ts
@@ -86,7 +86,7 @@ export const compressInputProps = async ({
 			downloadBehavior: null,
 			expectedBucketOwner: null,
 			key: makeKey(propsType, hash),
-			privacy: 'public',
+			privacy: 'private',
 		});
 
 		return {


### PR DESCRIPTION
Could fix bugs with `no-acl`