### PR TITLE
`@remotion/renderer`: Fix video with zigzag timestamps

### DIFF
--- a/packages/renderer/rust/opened_stream.rs
+++ b/packages/renderer/rust/opened_stream.rs
@@ -308,6 +308,9 @@ impl OpenedStream {
 
                                 if new_difference > prev_difference {
                                     stop_after_n_diverging_pts = Some(stop - 1);
+                                } else if prev_difference > new_difference {
+                                    // Fixing test video crazy1.mp4, frames 240-259
+                                    stop_after_n_diverging_pts = Some(stop + 1);
                                 }
                             }
                             None => {}

--- a/packages/renderer/src/test/rust-memory-usage.test.ts
+++ b/packages/renderer/src/test/rust-memory-usage.test.ts
@@ -27,9 +27,7 @@ test('Memory usage should be determined ', async () => {
 
 	const stats = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson = JSON.parse(stats.toString('utf-8'));
-	expect(
-		statsJson.frames_in_cache === 84 || statsJson.frames_in_cache === 85,
-	).toBe(true);
+	expect(statsJson.frames_in_cache).toBe(164);
 	expect(statsJson.open_streams).toBe(1);
 	expect(statsJson.open_videos).toBe(1);
 
@@ -42,9 +40,8 @@ test('Memory usage should be determined ', async () => {
 
 	const stats2 = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson2 = JSON.parse(stats2.toString('utf-8'));
-	expect(
-		statsJson2.frames_in_cache === 185 || statsJson2.frames_in_cache === 184,
-	).toBe(true);
+
+	expect(statsJson2.frames_in_cache).toBe(264);
 	expect(statsJson2.open_streams).toBe(2);
 	expect(statsJson2.open_videos).toBe(2);
 
@@ -54,7 +51,7 @@ test('Memory usage should be determined ', async () => {
 
 	const stats3 = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson3 = JSON.parse(stats3.toString('utf-8'));
-	expect(statsJson3.frames_in_cache).toBe(184);
+	expect(statsJson3.frames_in_cache).toBe(264);
 
 	await compositor.executeCommand('FreeUpMemory', {
 		remaining_bytes: 100 * 24 * 1024 * 1024,
@@ -63,7 +60,7 @@ test('Memory usage should be determined ', async () => {
 	const stats4 = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson4 = JSON.parse(stats4.toString('utf-8'));
 	expect(statsJson4).toEqual({
-		frames_in_cache: 184,
+		frames_in_cache: 264,
 		open_streams: 2,
 		open_videos: 2,
 	});
@@ -112,7 +109,7 @@ test('Should respect the maximum frame cache limit', async () => {
 	const stats = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson = JSON.parse(stats.toString('utf-8'));
 	expect(statsJson).toEqual({
-		frames_in_cache: 84,
+		frames_in_cache: 164,
 		open_streams: 1,
 		open_videos: 1,
 	});


### PR DESCRIPTION
Fixes crazy1.mp4
frames=240-59

in our video library of edge cases