### PR TITLE
`@remotion/renderer`: Clamp max diverging frames

### DIFF
--- a/packages/renderer/rust/opened_stream.rs
+++ b/packages/renderer/rust/opened_stream.rs
@@ -51,6 +51,8 @@ pub fn get_time() -> u128 {
         .as_millis()
 }
 
+const MAX_DIVERGING_SEEK: u8 = 3;
+
 impl OpenedStream {
     pub fn receive_frame(&mut self) -> Result<Option<Video>, ErrorWithBacktrace> {
         let mut frame = Video::empty();
@@ -182,7 +184,7 @@ impl OpenedStream {
             match last_frame_received {
                 Some(_) => {
                     if stop_after_n_diverging_pts.is_none() {
-                        stop_after_n_diverging_pts = Some(3);
+                        stop_after_n_diverging_pts = Some(MAX_DIVERGING_SEEK);
                     }
                 }
                 None => {}
@@ -310,7 +312,8 @@ impl OpenedStream {
                                     stop_after_n_diverging_pts = Some(stop - 1);
                                 } else if prev_difference > new_difference {
                                     // Fixing test video crazy1.mp4, frames 240-259
-                                    stop_after_n_diverging_pts = Some(stop + 1);
+                                    stop_after_n_diverging_pts =
+                                        Some((stop + 1).min(MAX_DIVERGING_SEEK));
                                 }
                             }
                             None => {}

--- a/packages/renderer/src/test/rust-memory-usage.test.ts
+++ b/packages/renderer/src/test/rust-memory-usage.test.ts
@@ -41,7 +41,9 @@ test('Memory usage should be determined ', async () => {
 	const stats2 = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson2 = JSON.parse(stats2.toString('utf-8'));
 
-	expect(statsJson2.frames_in_cache).toBe(264);
+	expect(
+		statsJson2.frames_in_cache === 185 || statsJson2.frames_in_cache === 184,
+	).toBe(true);
 	expect(statsJson2.open_streams).toBe(2);
 	expect(statsJson2.open_videos).toBe(2);
 
@@ -51,7 +53,7 @@ test('Memory usage should be determined ', async () => {
 
 	const stats3 = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson3 = JSON.parse(stats3.toString('utf-8'));
-	expect(statsJson3.frames_in_cache).toBe(264);
+	expect(statsJson3.frames_in_cache).toBe(184);
 
 	await compositor.executeCommand('FreeUpMemory', {
 		remaining_bytes: 100 * 24 * 1024 * 1024,
@@ -60,7 +62,7 @@ test('Memory usage should be determined ', async () => {
 	const stats4 = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson4 = JSON.parse(stats4.toString('utf-8'));
 	expect(statsJson4).toEqual({
-		frames_in_cache: 264,
+		frames_in_cache: 184,
 		open_streams: 2,
 		open_videos: 2,
 	});
@@ -109,7 +111,7 @@ test('Should respect the maximum frame cache limit', async () => {
 	const stats = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson = JSON.parse(stats.toString('utf-8'));
 	expect(statsJson).toEqual({
-		frames_in_cache: 164,
+		frames_in_cache: 84,
 		open_streams: 1,
 		open_videos: 1,
 	});

--- a/packages/renderer/src/test/rust-memory-usage.test.ts
+++ b/packages/renderer/src/test/rust-memory-usage.test.ts
@@ -27,7 +27,7 @@ test('Memory usage should be determined ', async () => {
 
 	const stats = await compositor.executeCommand('GetOpenVideoStats', {});
 	const statsJson = JSON.parse(stats.toString('utf-8'));
-	expect(statsJson.frames_in_cache).toBe(164);
+	expect(statsJson.frames_in_cache).toBe(84);
 	expect(statsJson.open_streams).toBe(1);
 	expect(statsJson.open_videos).toBe(1);
 


### PR DESCRIPTION
Fixes a video `max-diverging.mp4` that previously worked.