### PR TITLE
`@remotion/player`: Don't show volume slider on iOS Safari

### DIFF
--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -74,6 +74,7 @@ import {validateDimension} from './validation/validate-dimensions.js';
 import {validateDurationInFrames} from './validation/validate-duration-in-frames.js';
 import {validateFps} from './validation/validate-fps.js';
 import {DurationsContextProvider} from './video/duration-state.js';
+import {isIosSafari} from './video/video-fragment.js';
 import type {
 	MediaVolumeContextValue,
 	SetMediaVolumeContextValue,
@@ -153,6 +154,7 @@ export const Internals = {
 	DATE_TOKEN,
 	NativeLayersProvider,
 	ClipComposition,
+	isIosSafari,
 } as const;
 
 export type {

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -141,7 +141,7 @@ export const MediaVolumeSlider: React.FC<{
 			>
 				{isMutedOrZero ? <VolumeOffIcon /> : <VolumeOnIcon />}
 			</button>
-			{(focused || hover) && !mediaMuted ? (
+			{(focused || hover) && !mediaMuted && !Internals.isIosSafari() ? (
 				<input
 					ref={inputRef}
 					aria-label="Change volume"


### PR DESCRIPTION
Because iOS Safari does not support changing volume