### PR TITLE
Remotion Studio: Don't throw on odd dimensions when rendering image sequences

### DIFF
--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -298,6 +298,7 @@ export const renderVideoFlow = async ({
 		height: config.height,
 		codec,
 		scale,
+		wantsImageSequence: shouldOutputImageSequence,
 	});
 
 	const relativeOutputLocation = getOutputFilename({

--- a/packages/renderer/src/prespawn-ffmpeg.ts
+++ b/packages/renderer/src/prespawn-ffmpeg.ts
@@ -72,6 +72,7 @@ export const prespawnFfmpeg = (options: PreStitcherOptions) => {
 		height: options.height,
 		codec,
 		scale: 1,
+		wantsImageSequence: false,
 	});
 	const pixelFormat = options.pixelFormat ?? DEFAULT_PIXEL_FORMAT;
 

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -383,6 +383,7 @@ const internalRenderMediaRaw = ({
 		height: composition.height,
 		scale,
 		width: composition.width,
+		wantsImageSequence: false,
 	});
 
 	const realFrameRange = getRealFrameRange(

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -236,6 +236,7 @@ const innerStitchFramesToVideo = async (
 		height,
 		codec,
 		scale: 1,
+		wantsImageSequence: false,
 	});
 	validateSelectedCodecAndProResCombination({
 		codec,

--- a/packages/renderer/src/validate-even-dimensions-with-codec.ts
+++ b/packages/renderer/src/validate-even-dimensions-with-codec.ts
@@ -6,12 +6,18 @@ export const validateEvenDimensionsWithCodec = ({
 	height,
 	codec,
 	scale,
+	wantsImageSequence,
 }: {
 	width: number;
 	height: number;
 	scale: number;
 	codec: Codec;
+	wantsImageSequence: boolean;
 }) => {
+	if (wantsImageSequence) {
+		return;
+	}
+
 	if (codec !== 'h264-mkv' && codec !== 'h264' && codec !== 'h265') {
 		return;
 	}


### PR DESCRIPTION

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
