### PR TITLE
`@remotion/renderer`: Add HLS decoder and asetrate filter to FFmpeg binary

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "ffmpeg-next"
 version = "6.0.0"
-source = "git+https://github.com/remotion-dev/rust-ffmpeg?rev=d94f32c1a6a8af15c11eb7cf52cd75259326569c#d94f32c1a6a8af15c11eb7cf52cd75259326569c"
+source = "git+https://github.com/remotion-dev/rust-ffmpeg?rev=98f1b3311325e925403f3cd804359d93ddcc42fb#98f1b3311325e925403f3cd804359d93ddcc42fb"
 dependencies = [
  "bitflags",
  "ffmpeg-sys-next",
@@ -270,7 +270,7 @@ dependencies = [
 [[package]]
 name = "ffmpeg-sys-next"
 version = "6.0.1"
-source = "git+https://github.com/remotion-dev/rust-ffmpeg-sys?rev=7c1d470bcac793e98849d03a25922719989a8657#7c1d470bcac793e98849d03a25922719989a8657"
+source = "git+https://github.com/remotion-dev/rust-ffmpeg-sys?rev=41f18a31d1c0b03afdcde4c838c1409b51a784a9#41f18a31d1c0b03afdcde4c838c1409b51a784a9"
 dependencies = [
  "bindgen",
  "cc",

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -19,7 +19,7 @@ image = "0.23.7"
 arboard = "3.2.0"
 sysinfo = "0.29.9"
 mp4 = {git = "https://github.com/jonnyburger/mp4-rust", rev = "92ba375738cc2f05a4d754e1f968cf2e97d06641"}
-ffmpeg-next = {git = "https://github.com/remotion-dev/rust-ffmpeg", rev ="d94f32c1a6a8af15c11eb7cf52cd75259326569c"}
+ffmpeg-next = {git = "https://github.com/remotion-dev/rust-ffmpeg", rev ="98f1b3311325e925403f3cd804359d93ddcc42fb"}
 
 [[bin]]
 name = "compositor"


### PR DESCRIPTION
Useful for #2930 and #2932 