### PR TITLE
`@remotion/eslint-config`: Disable "no-unreachable" rule in TypeScript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,7 @@
 {
   "editor.tabSize": 2,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false,
-    "source.fixAll": true
+    "source.organizeImports": false
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[rust]": {

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -162,7 +162,8 @@ const getRules = (typescript: boolean) => {
     "no-setter-return": "error",
     "no-sparse-arrays": "error",
     "no-template-curly-in-string": "error",
-    "no-unreachable": "error",
+    // TypeScript handles this
+    "no-unreachable": typescript ? "off" : "error",
     "no-unreachable-loop": "error",
     "no-unsafe-finally": "error",
     "no-unsafe-negation": "error",


### PR DESCRIPTION
Because TypeScript takes care of this already

https://eslint.org/docs/latest/rules/no-unreachable#handled_by_typescript