### PR TITLE
`@remotion/player`: Fix `<Sequence>`'s in `<Thumbnail>`

### DIFF
--- a/packages/astro-example/tsconfig.json
+++ b/packages/astro-example/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "astro/tsconfigs/strictest",
   "compilerOptions": {
     "jsx": "react-jsx"
-  }
+  },
+  "references": [{ "path": "../player" }, { "path": "../core" }]
 }

--- a/packages/bugs/api/[v].ts
+++ b/packages/bugs/api/[v].ts
@@ -21,6 +21,13 @@ const bugs: Bug[] = [
     link: "https://github.com/remotion-dev/remotion/pull/2882",
     versions: ["4.0.33", "4.0.34", "4.0.35", "4.0.36"],
   },
+  {
+    title: "<Thumbnail> component would crash",
+    description:
+      "<Thumbnail> component in a React app would crash if a <Sequence> was used.",
+    link: "https://github.com/remotion-dev/remotion/pull/2944",
+    versions: ["4.0.43", "4.0.42"],
+  },
 ];
 
 const getVersionBugs = (version: string) => {

--- a/packages/core/src/RenderAssetManager.tsx
+++ b/packages/core/src/RenderAssetManager.tsx
@@ -14,6 +14,7 @@ export type RenderAssetManagerContext = {
 };
 
 export const RenderAssetManager = createContext<RenderAssetManagerContext>({
+	// Must be undefined, otherwise error in Player
 	registerRenderAsset: () => undefined,
 	unregisterRenderAsset: () => undefined,
 	renderAssets: [],

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -49,7 +49,7 @@ import {
 	useResolvedVideoConfig,
 } from './ResolveCompositionConfig.js';
 import {SequenceContext} from './SequenceContext.js';
-import {SequenceManager} from './SequenceManager.js';
+import {SequenceManager, SequenceManagerProvider} from './SequenceManager.js';
 import {setupEnvVariables} from './setup-env-variables.js';
 import type {
 	SetTimelineContextValue,
@@ -98,6 +98,7 @@ export const Internals = {
 	Timeline,
 	CompositionManager,
 	SequenceManager,
+	SequenceManagerProvider,
 	RemotionRoot,
 	useVideo,
 	getRoot,

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -49,7 +49,7 @@ import {
 	useResolvedVideoConfig,
 } from './ResolveCompositionConfig.js';
 import {SequenceContext} from './SequenceContext.js';
-import {SequenceManager, SequenceManagerProvider} from './SequenceManager.js';
+import {SequenceManager} from './SequenceManager.js';
 import {setupEnvVariables} from './setup-env-variables.js';
 import type {
 	SetTimelineContextValue,
@@ -98,7 +98,6 @@ export const Internals = {
 	Timeline,
 	CompositionManager,
 	SequenceManager,
-	SequenceManagerProvider,
 	RemotionRoot,
 	useVideo,
 	getRoot,

--- a/packages/player-example/src/CarSlideshow.tsx
+++ b/packages/player-example/src/CarSlideshow.tsx
@@ -58,19 +58,21 @@ const CarSlideshow = ({title, bgColor, color}: Props) => {
 			}}
 		>
 			<Experimental.Clipper height={100} width={100} x={0} y={0} />
-			<h1
-				style={{
-					fontSize: '5em',
-					fontWeight: 'bold',
-					position: 'absolute',
-					top: height / 2 - 100,
-					left,
-					color,
-					whiteSpace: 'nowrap',
-				}}
-			>
-				{title} {dummyText()}
-			</h1>
+			<Sequence>
+				<h1
+					style={{
+						fontSize: '5em',
+						fontWeight: 'bold',
+						position: 'absolute',
+						top: height / 2 - 100,
+						left,
+						color,
+						whiteSpace: 'nowrap',
+					}}
+				>
+					{title} {dummyText()}
+				</h1>
+			</Sequence>
 			<Img
 				src={staticFile('/logo.png')}
 				style={{

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -293,14 +293,11 @@ const PlayerFn = <Schema extends AnyZodObject, Props>(
 
 	useImperativeHandle(ref, () => rootRef.current as PlayerRef, []);
 
-	const timelineContextValue = useMemo((): TimelineContextValue & {
-		shouldRegisterSequences: boolean;
-	} => {
+	const timelineContextValue = useMemo((): TimelineContextValue => {
 		return {
 			frame,
 			playing,
 			rootId,
-			shouldRegisterSequences: false,
 			playbackRate: currentPlaybackRate,
 			imperativePlaying,
 			setPlaybackRate: (rate) => {

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -317,10 +317,6 @@ const PlayerFn = <Schema extends AnyZodObject, Props>(
 		};
 	}, [setFrame]);
 
-	const passedInputProps = useMemo(() => {
-		return inputProps ?? {};
-	}, [inputProps]);
-
 	if (typeof window !== 'undefined') {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		useLayoutEffect(() => {
@@ -342,7 +338,6 @@ const PlayerFn = <Schema extends AnyZodObject, Props>(
 				compositionWidth={compositionWidth}
 				durationInFrames={durationInFrames}
 				fps={fps}
-				inputProps={actualInputProps}
 				numberOfSharedAudioTags={numberOfSharedAudioTags}
 				initiallyMuted={initiallyMuted}
 			>
@@ -358,7 +353,7 @@ const PlayerFn = <Schema extends AnyZodObject, Props>(
 							controls={Boolean(controls)}
 							errorFallback={errorFallback}
 							style={style}
-							inputProps={passedInputProps}
+							inputProps={actualInputProps}
 							allowFullscreen={Boolean(allowFullscreen)}
 							moveToBeginningWhenEnded={Boolean(moveToBeginningWhenEnded)}
 							clickToPlay={

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -96,30 +96,28 @@ export const SharedPlayerContexts: React.FC<{
 				<Internals.CompositionManager.Provider
 					value={compositionManagerContext}
 				>
-					<Internals.SequenceManagerProvider>
-						<Internals.ResolveCompositionConfig>
-							<Internals.PrefetchProvider>
-								<Internals.DurationsContextProvider>
-									<Internals.MediaVolumeContext.Provider
-										value={mediaVolumeContextValue}
-									>
-										<Internals.NativeLayersProvider>
-											<Internals.SetMediaVolumeContext.Provider
-												value={setMediaVolumeContextValue}
+					<Internals.ResolveCompositionConfig>
+						<Internals.PrefetchProvider>
+							<Internals.DurationsContextProvider>
+								<Internals.MediaVolumeContext.Provider
+									value={mediaVolumeContextValue}
+								>
+									<Internals.NativeLayersProvider>
+										<Internals.SetMediaVolumeContext.Provider
+											value={setMediaVolumeContextValue}
+										>
+											<Internals.SharedAudioContextProvider
+												numberOfAudioTags={numberOfSharedAudioTags}
+												component={component}
 											>
-												<Internals.SharedAudioContextProvider
-													numberOfAudioTags={numberOfSharedAudioTags}
-													component={component}
-												>
-													{children}
-												</Internals.SharedAudioContextProvider>
-											</Internals.SetMediaVolumeContext.Provider>
-										</Internals.NativeLayersProvider>
-									</Internals.MediaVolumeContext.Provider>
-								</Internals.DurationsContextProvider>
-							</Internals.PrefetchProvider>
-						</Internals.ResolveCompositionConfig>
-					</Internals.SequenceManagerProvider>
+												{children}
+											</Internals.SharedAudioContextProvider>
+										</Internals.SetMediaVolumeContext.Provider>
+									</Internals.NativeLayersProvider>
+								</Internals.MediaVolumeContext.Provider>
+							</Internals.DurationsContextProvider>
+						</Internals.PrefetchProvider>
+					</Internals.ResolveCompositionConfig>
 				</Internals.CompositionManager.Provider>
 			</Internals.Timeline.TimelineContext.Provider>
 		</Internals.CanUseRemotionHooksProvider>

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -16,7 +16,6 @@ export const PLAYER_COMP_ID = 'player-comp';
 export const SharedPlayerContexts: React.FC<{
 	children: React.ReactNode;
 	timelineContext: TimelineContextValue;
-	inputProps?: Record<string, unknown>;
 	fps: number;
 	compositionWidth: number;
 	compositionHeight: number;
@@ -27,7 +26,6 @@ export const SharedPlayerContexts: React.FC<{
 }> = ({
 	children,
 	timelineContext,
-	inputProps,
 	fps,
 	compositionHeight,
 	compositionWidth,
@@ -37,7 +35,7 @@ export const SharedPlayerContexts: React.FC<{
 	initiallyMuted,
 }) => {
 	const compositionManagerContext: CompositionManagerContext = useMemo(() => {
-		return {
+		const context: CompositionManagerContext = {
 			compositions: [
 				{
 					component: component as React.LazyExoticComponent<
@@ -48,11 +46,8 @@ export const SharedPlayerContexts: React.FC<{
 					width: compositionWidth,
 					fps,
 					id: PLAYER_COMP_ID,
-					props: inputProps as unknown,
 					nonce: 777,
-					scale: 1,
 					folderName: null,
-					defaultProps: undefined,
 					parentFolderName: null,
 					schema: null,
 					calculateMetadata: null,
@@ -63,26 +58,13 @@ export const SharedPlayerContexts: React.FC<{
 			unregisterFolder: () => undefined,
 			currentComposition: 'player-comp',
 			registerComposition: () => undefined,
-			registerSequence: () => undefined,
-			sequences: [],
 			setCurrentComposition: () => undefined,
 			unregisterComposition: () => undefined,
-			unregisterSequence: () => undefined,
-			registerRenderAsset: () => undefined,
 			currentCompositionMetadata: null,
 			setCurrentCompositionMetadata: () => undefined,
-			assets: [],
-			setClipRegion: () => undefined,
-			resolved: null,
 		};
-	}, [
-		component,
-		durationInFrames,
-		compositionHeight,
-		compositionWidth,
-		fps,
-		inputProps,
-	]);
+		return context;
+	}, [component, durationInFrames, compositionHeight, compositionWidth, fps]);
 
 	const [mediaMuted, setMediaMuted] = useState<boolean>(() => initiallyMuted);
 	const [mediaVolume, setMediaVolume] = useState<number>(() =>
@@ -114,28 +96,30 @@ export const SharedPlayerContexts: React.FC<{
 				<Internals.CompositionManager.Provider
 					value={compositionManagerContext}
 				>
-					<Internals.ResolveCompositionConfig>
-						<Internals.PrefetchProvider>
-							<Internals.DurationsContextProvider>
-								<Internals.MediaVolumeContext.Provider
-									value={mediaVolumeContextValue}
-								>
-									<Internals.NativeLayersProvider>
-										<Internals.SetMediaVolumeContext.Provider
-											value={setMediaVolumeContextValue}
-										>
-											<Internals.SharedAudioContextProvider
-												numberOfAudioTags={numberOfSharedAudioTags}
-												component={component}
+					<Internals.SequenceManagerProvider>
+						<Internals.ResolveCompositionConfig>
+							<Internals.PrefetchProvider>
+								<Internals.DurationsContextProvider>
+									<Internals.MediaVolumeContext.Provider
+										value={mediaVolumeContextValue}
+									>
+										<Internals.NativeLayersProvider>
+											<Internals.SetMediaVolumeContext.Provider
+												value={setMediaVolumeContextValue}
 											>
-												{children}
-											</Internals.SharedAudioContextProvider>
-										</Internals.SetMediaVolumeContext.Provider>
-									</Internals.NativeLayersProvider>
-								</Internals.MediaVolumeContext.Provider>
-							</Internals.DurationsContextProvider>
-						</Internals.PrefetchProvider>
-					</Internals.ResolveCompositionConfig>
+												<Internals.SharedAudioContextProvider
+													numberOfAudioTags={numberOfSharedAudioTags}
+													component={component}
+												>
+													{children}
+												</Internals.SharedAudioContextProvider>
+											</Internals.SetMediaVolumeContext.Provider>
+										</Internals.NativeLayersProvider>
+									</Internals.MediaVolumeContext.Provider>
+								</Internals.DurationsContextProvider>
+							</Internals.PrefetchProvider>
+						</Internals.ResolveCompositionConfig>
+					</Internals.SequenceManagerProvider>
 				</Internals.CompositionManager.Provider>
 			</Internals.Timeline.TimelineContext.Provider>
 		</Internals.CanUseRemotionHooksProvider>

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -99,7 +99,6 @@ export const ThumbnailFn = <
 				compositionWidth={compositionWidth}
 				durationInFrames={durationInFrames}
 				fps={fps}
-				inputProps={passedInputProps}
 				numberOfSharedAudioTags={0}
 				initiallyMuted
 			>

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -7,6 +7,7 @@ import type {
 import {
 	forwardRef,
 	useImperativeHandle,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -57,11 +58,18 @@ export const ThumbnailFn = <
 	}: ThumbnailProps<Schema, Props>,
 	ref: MutableRefObject<ThumbnailMethods>,
 ) => {
+	if (typeof window !== 'undefined') {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		useLayoutEffect(() => {
+			window.remotion_isPlayer = true;
+		}, []);
+	}
+
 	const [thumbnailId] = useState(() => String(random(null)));
 	const rootRef = useRef<ThumbnailMethods>(null);
 
 	const timelineState: TimelineContextValue = useMemo(() => {
-		return {
+		const value: TimelineContextValue = {
 			playing: false,
 			frame: {
 				[PLAYER_COMP_ID]: frameToDisplay,
@@ -76,6 +84,8 @@ export const ThumbnailFn = <
 			},
 			audioAndVideoTags: {current: []},
 		};
+
+		return value;
 	}, [frameToDisplay, thumbnailId]);
 
 	useImperativeHandle(ref, () => rootRef.current as ThumbnailMethods, []);


### PR DESCRIPTION
If only a `<Thumbnail>` is rendered, then `window.remotion_isPlayer` is not set, and `getRemotionEnvironment()` would think you are in the Studio.