### PR TITLE
#2942 Added playbackRate Prop to Gif Component #

### DIFF
--- a/packages/docs/docs/gif/gif.md
+++ b/packages/docs/docs/gif/gif.md
@@ -75,6 +75,19 @@ The looping behavior of the GIF. Can be one of these values:
 
 You can add a [React ref](https://react.dev/learn/manipulating-the-dom-with-refs) to `<Gif>`. If you use TypeScript, you need to type it with `HTMLCanvasElement`.
 
+### playbackRate
+
+Controls the playback speed of the GIF. This prop allows you to adjust how fast or slow the GIF animation plays within your Remotion video.
+
+Type: number
+Default: 1.0 (Normal speed)
+Values:
+- `1.0`: Plays the GIF at normal speed.
+- `< 1.0`: Slows down the GIF animation (e.g., 0.5 plays it at half speed).
+- `> 1.0:` Speeds up the GIF animation (e.g., 2.0 plays it at double speed).
+
+Use this prop when you need precise control over the timing of the GIF animation to synchronize it with your video content. Here's an example of how to use it to adjust the playback speed:
+
 ## Example
 
 ```tsx twoslash
@@ -94,6 +107,8 @@ export const MyComponent: React.FC = () => {
       width={width}
       height={height}
       fit="fill"
+      playbackRate={0.5} {/* Play the GIF at half speed */}
+
     />
   );
 };

--- a/packages/gif/src/GifForDevelopment.tsx
+++ b/packages/gif/src/GifForDevelopment.tsx
@@ -21,6 +21,7 @@ export const GifForDevelopment = forwardRef<
 			loopBehavior = 'loop',
 			onLoad,
 			fit = 'fill',
+			playbackRate = 1,
 			...props
 		},
 		ref,
@@ -104,7 +105,7 @@ export const GifForDevelopment = forwardRef<
 			);
 		}
 
-		const index = useCurrentGifIndex(state.delays, loopBehavior);
+		const index = useCurrentGifIndex(state.delays, loopBehavior, playbackRate);
 
 		if (index === -1) {
 			return null;

--- a/packages/gif/src/GifForRendering.tsx
+++ b/packages/gif/src/GifForRendering.tsx
@@ -18,6 +18,7 @@ export const GifForRendering = forwardRef<HTMLCanvasElement, RemotionGifProps>(
 			onError,
 			loopBehavior = 'loop',
 			fit = 'fill',
+			playbackRate = 1,
 			...props
 		},
 		ref,
@@ -49,7 +50,7 @@ export const GifForRendering = forwardRef<HTMLCanvasElement, RemotionGifProps>(
 			};
 		}, [id]);
 
-		const index = useCurrentGifIndex(state.delays, loopBehavior);
+		const index = useCurrentGifIndex(state.delays, loopBehavior, playbackRate);
 		const currentOnLoad = useRef(onLoad);
 		const currentOnError = useRef(onError);
 		currentOnLoad.current = onLoad;

--- a/packages/gif/src/props.ts
+++ b/packages/gif/src/props.ts
@@ -18,6 +18,7 @@ export type RemotionGifProps = {
 	style?: React.CSSProperties;
 	loopBehavior?: GifLoopBehavior;
 	id?: string;
+	playbackRate?: number; // Added playbackRate prop
 };
 
 export type GifState = {

--- a/packages/gif/src/useCurrentGifIndex.tsx
+++ b/packages/gif/src/useCurrentGifIndex.tsx
@@ -5,6 +5,7 @@ import type {GifLoopBehavior} from './props';
 export function useCurrentGifIndex(
 	delays: number[],
 	loopBehavior: GifLoopBehavior,
+	playbackRate = 1, //  playbackRate default value of 1
 ): number {
 	const currentFrame = useCurrentFrame();
 	const videoConfig = useVideoConfig();
@@ -24,7 +25,9 @@ export function useCurrentGifIndex(
 		return 0;
 	}
 
-	const time = (currentFrame / videoConfig.fps) * 1000;
+	const correctedPlaybackRate = playbackRate === 0 ? 1 : playbackRate; // Check if playbackRate is 0, if so, default it to 1
+
+	const time = (currentFrame / correctedPlaybackRate / videoConfig.fps) * 1000;
 
 	if (loopBehavior === 'pause-after-finish' && time >= duration) {
 		return delays.length - 1;


### PR DESCRIPTION
Introduced a playbackRate prop in the Gif component to adjust GIF speed. Updated the useCurrentGifIndex hook to reflect this chang

test vid : https://www.loom.com/share/90ee6687f10b4ae9963f45bf9b1b9016

fix: https://github.com/remotion-dev/remotion/issues/2942
/claim https://github.com/remotion-dev/remotion/issues/2942

