### PR TITLE
Add bounty cards

### DIFF
--- a/packages/docs/components/Bounties.tsx
+++ b/packages/docs/components/Bounties.tsx
@@ -1,0 +1,78 @@
+import { algora, type AlgoraOutput } from "@algora/sdk";
+import React, { useEffect, useState } from "react";
+
+import { useColorMode } from "@docusaurus/theme-common";
+import "./bounties.css";
+
+const org = "remotion";
+const limit = 3;
+
+type RemoteData<T> =
+  | { _tag: "loading" }
+  | { _tag: "failure"; error: Error }
+  | { _tag: "success"; data: T };
+
+type Bounty = AlgoraOutput["bounty"]["list"]["items"][number];
+
+export const Bounties = () => {
+  const { colorMode } = useColorMode();
+
+  const [bounties, setBounties] = useState<RemoteData<Bounty[]>>({
+    _tag: "loading",
+  });
+
+  useEffect(() => {
+    const ac = new AbortController();
+
+    algora.bounty.list
+      .query({ org, limit, status: "active" }, { signal: ac.signal })
+      .then(({ items: data }) => setBounties({ _tag: "success", data }))
+      .catch((error) => setBounties({ _tag: "failure", error }));
+
+    return () => ac.abort();
+  }, []);
+
+  return (
+    <div className={`bounty-grid ${colorMode}`}>
+      {bounties._tag === "success" &&
+        bounties.data.map((bounty) => (
+          <div key={bounty.id}>
+            <BountyCard bounty={bounty} />
+          </div>
+        ))}
+      {bounties._tag === "loading" &&
+        [...Array(limit).keys()].map((i) => (
+          <div key={i}>
+            <BountyCardSkeleton />
+          </div>
+        ))}
+    </div>
+  );
+};
+
+const BountyCard = (props: { bounty: Bounty }) => (
+  <a
+    href={props.bounty.task.url}
+    target="_blank"
+    rel="noopener"
+    className="bounty-card"
+  >
+    <div className="bounty-content">
+      <div className="bounty-reward">{props.bounty.reward_formatted}</div>
+      <div className="bounty-issue">
+        {props.bounty.task.repo_name}#{props.bounty.task.number}
+      </div>
+      <div className="bounty-title">{props.bounty.task.title}</div>
+    </div>
+  </a>
+);
+
+const BountyCardSkeleton = () => (
+  <div className="bounty-skeleton">
+    <div className="bounty-content">
+      <div className="bounty-reward" />
+      <div className="bounty-issue" />
+      <div className="bounty-title" />
+    </div>
+  </div>
+);

--- a/packages/docs/components/Bounties.tsx
+++ b/packages/docs/components/Bounties.tsx
@@ -33,7 +33,7 @@ export const Bounties = () => {
   }, []);
 
   return (
-    <div className={`bounty-grid ${colorMode}`}>
+    <div className={`${colorMode} bounty-grid`}>
       {bounties._tag === "success" &&
         bounties.data.map((bounty) => (
           <div key={bounty.id}>

--- a/packages/docs/components/Bounties.tsx
+++ b/packages/docs/components/Bounties.tsx
@@ -1,7 +1,8 @@
 import { algora, type AlgoraOutput } from "@algora/sdk";
+import { useColorMode } from "@docusaurus/theme-common";
+import clsx from "clsx";
 import React, { useEffect, useState } from "react";
 
-import { useColorMode } from "@docusaurus/theme-common";
 import "./bounties.css";
 
 const org = "remotion";
@@ -15,7 +16,7 @@ type RemoteData<T> =
 type Bounty = AlgoraOutput["bounty"]["list"]["items"][number];
 
 export const Bounties = () => {
-  const { colorMode } = useColorMode();
+  const { isDarkTheme } = useColorMode();
 
   const [bounties, setBounties] = useState<RemoteData<Bounty[]>>({
     _tag: "loading",
@@ -33,7 +34,7 @@ export const Bounties = () => {
   }, []);
 
   return (
-    <div className={`${colorMode} bounty-grid`}>
+    <div className={clsx("bounty-grid", isDarkTheme && "dark")}>
       {bounties._tag === "success" &&
         bounties.data.map((bounty) => (
           <div key={bounty.id}>

--- a/packages/docs/components/bounties.css
+++ b/packages/docs/components/bounties.css
@@ -1,0 +1,222 @@
+.bounty-grid {
+  --gray-50: 248, 250, 252;
+  --gray-100: 241, 245, 249;
+  --gray-200: 226, 232, 240;
+  --gray-300: 203, 213, 225;
+  --gray-400: 148, 163, 184;
+  --gray-500: 100, 116, 139;
+  --gray-600: 71, 85, 105;
+  --gray-700: 51, 65, 85;
+  --gray-800: 30, 41, 59;
+  --gray-900: 15, 23, 42;
+  --gray-950: 2, 6, 23;
+
+  --accent-50: 239, 246, 255;
+  --accent-100: 219, 234, 254;
+  --accent-200: 191, 219, 254;
+  --accent-300: 147, 197, 253;
+  --accent-400: 96, 165, 250;
+  --accent-500: 59, 130, 246;
+  --accent-600: 37, 99, 235;
+  --accent-700: 29, 78, 216;
+  --accent-800: 30, 64, 175;
+  --accent-900: 30, 58, 138;
+  --accent-950: 23, 37, 84;
+
+  --green-50: 236, 253, 245;
+  --green-100: 209, 250, 229;
+  --green-200: 167, 243, 208;
+  --green-300: 110, 231, 183;
+  --green-400: 52, 211, 153;
+  --green-500: 16, 185, 129;
+  --green-600: 5, 150, 105;
+  --green-700: 4, 120, 87;
+  --green-800: 6, 95, 70;
+  --green-900: 6, 78, 59;
+  --green-950: 2, 44, 34;
+}
+
+.bounty-grid {
+  display: none;
+}
+
+@media (min-width: 640px) {
+  .bounty-grid {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@keyframes bounty-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.bounty-grid {
+  --gradient-to: rgba(var(--accent-400), 0.4);
+  --gradient-from: rgba(var(--accent-400), 0.2);
+  --gradient-stops: var(--gradient-from), rgba(var(--accent-400), 0.3),
+    var(--gradient-to);
+}
+
+.bounty-grid.dark {
+  --gradient-to: rgba(var(--accent-600), 0.2);
+  --gradient-from: rgba(var(--accent-600), 0.3);
+  --gradient-stops: var(--gradient-from), rgba(var(--accent-600), 0.4),
+    var(--gradient-to);
+}
+
+.bounty-grid .bounty-card {
+  text-decoration-line: none;
+  display: block;
+  position: relative;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  height: 100%;
+  background-image: linear-gradient(to bottom right, var(--gradient-stops));
+}
+
+.bounty-grid .bounty-card *,
+.bounty-grid .bounty-skeleton * {
+  transition-property: background-color, color, border-color;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
+}
+
+.bounty-grid .bounty-card:hover {
+  border-color: rgb(var(--gray-400));
+}
+
+.bounty-grid .bounty-card .bounty-content {
+  position: relative;
+  padding: 1rem;
+  height: 100%;
+}
+
+.bounty-grid .bounty-card .bounty-reward {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 700;
+  color: rgb(var(--green-500));
+}
+
+.bounty-grid .bounty-card .bounty-issue {
+  margin-top: 0.125rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: rgb(var(--gray-700));
+}
+
+.bounty-grid .bounty-card .bounty-title {
+  margin-top: 0.75rem;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-weight: 500;
+  line-height: 1.25;
+  color: rgb(var(--gray-800));
+  overflow-wrap: break-word;
+}
+
+.bounty-grid.dark .bounty-card .bounty-reward {
+  color: rgb(var(--green-400));
+}
+
+.bounty-grid.dark .bounty-card .bounty-issue {
+  color: rgb(var(--accent-200));
+}
+
+.bounty-grid.dark .bounty-card .bounty-title {
+  color: rgb(var(--accent-50));
+}
+
+.bounty-grid .bounty-card:hover {
+  background-color: rgba(var(--gray-300), 0.1);
+  border-color: rgb(var(--gray-400));
+}
+
+.bounty-grid .bounty-card:hover .bounty-reward {
+  color: rgb(var(--green-600));
+}
+
+.bounty-grid .bounty-card:hover .bounty-issue {
+  color: rgb(var(--gray-800));
+}
+
+.bounty-grid .bounty-card:hover .bounty-title {
+  color: rgb(var(--gray-900));
+}
+
+.bounty-grid.dark .bounty-card:hover {
+  background-color: rgba(var(--gray-600), 0.05);
+  border-color: rgb(var(--accent-500));
+}
+
+.bounty-grid.dark .bounty-card:hover .bounty-reward {
+  color: rgb(var(--green-300));
+}
+
+.bounty-grid.dark .bounty-card:hover .bounty-issue {
+  color: rgb(var(--accent-100));
+}
+
+.bounty-grid.dark .bounty-card:hover .bounty-title {
+  color: white;
+}
+
+.bounty-grid .bounty-skeleton {
+  border-radius: 0.5rem;
+  background-color: rgb(var(--gray-200));
+  animation: bounty-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  height: 122px;
+}
+
+.bounty-grid.dark .bounty-skeleton {
+  background-color: rgb(var(--gray-800));
+}
+
+.bounty-grid .bounty-skeleton .bounty-content {
+  position: relative;
+  padding: 1rem;
+  height: 100%;
+}
+
+.bounty-grid .bounty-skeleton .bounty-reward {
+  margin-top: 0.25rem;
+  border-radius: 0.375rem;
+  height: 25px;
+  width: 59px;
+  background-color: rgb(var(--gray-300));
+}
+
+.bounty-grid .bounty-skeleton .bounty-issue {
+  margin-top: 0.625rem;
+  border-radius: 0.375rem;
+  height: 14px;
+  width: 86px;
+  background-color: rgb(var(--gray-300));
+}
+
+.bounty-grid .bounty-skeleton .bounty-title {
+  margin-top: 1rem;
+  border-radius: 0.375rem;
+  height: 20px;
+  background-color: rgb(var(--gray-300));
+}
+
+.bounty-grid.dark .bounty-skeleton .bounty-reward {
+  background-color: rgb(var(--gray-700));
+}
+
+.bounty-grid.dark .bounty-skeleton .bounty-issue {
+  background-color: rgb(var(--gray-700));
+}
+
+.bounty-grid.dark .bounty-skeleton .bounty-title {
+  background-color: rgb(var(--gray-700));
+}

--- a/packages/docs/components/bounties.css
+++ b/packages/docs/components/bounties.css
@@ -41,7 +41,7 @@
   gap: 0.5rem;
 }
 
-.bounty-grid > *:not(:first-child) {
+.bounty-grid.bounty-grid-clamp > *:not(:first-child) {
   display: none;
 }
 
@@ -49,7 +49,7 @@
   .bounty-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-  .bounty-grid > *:nth-child(-n + 2) {
+  .bounty-grid.bounty-grid-clamp > *:nth-child(-n + 2) {
     display: block;
   }
 }
@@ -58,7 +58,7 @@
   .bounty-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-  .bounty-grid > *:nth-child(-n + 3) {
+  .bounty-grid.bounty-grid-clamp > *:nth-child(-n + 3) {
     display: block;
   }
 }

--- a/packages/docs/components/bounties.css
+++ b/packages/docs/components/bounties.css
@@ -120,7 +120,11 @@
   font-weight: 500;
   line-height: 1.25;
   color: rgb(var(--gray-800));
-  overflow-wrap: break-word;
+  word-break: break-all;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .bounty-grid.dark .bounty-card .bounty-reward {

--- a/packages/docs/components/bounties.css
+++ b/packages/docs/components/bounties.css
@@ -37,14 +37,29 @@
 }
 
 .bounty-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.bounty-grid > *:not(:first-child) {
   display: none;
 }
 
 @media (min-width: 640px) {
   .bounty-grid {
-    display: grid;
-    gap: 0.5rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .bounty-grid > *:nth-child(-n + 2) {
+    display: block;
+  }
+}
+
+@media (min-width: 768px) {
+  .bounty-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .bounty-grid > *:nth-child(-n + 3) {
+    display: block;
   }
 }
 

--- a/packages/docs/docs/contributing/bounty.md
+++ b/packages/docs/docs/contributing/bounty.md
@@ -5,7 +5,11 @@ sidebar_label: Bounty issues
 crumb: Contributing
 ---
 
+import { Bounties } from "../../components/Bounties.tsx";
+
 Some issues carry cash bounties that you can earn by solving them.
+
+<Bounties />
 
 ## Find bounties
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -18,6 +18,7 @@
     "remotion": "remotion studio src/remotion/entry.ts"
   },
   "dependencies": {
+    "@algora/sdk": "^0.1.2",
     "@aws-sdk/s3-request-presigner": "3.215.0",
     "@babel/plugin-transform-modules-commonjs": "^7.15.4",
     "@docusaurus/core": "2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 0.9.0
       webpack:
         specifier: 5.83.1
-        version: 5.83.1(@swc/core@1.3.27)
+        version: 5.83.1
     devDependencies:
       '@jonny/eslint-config':
         specifier: 3.0.266
@@ -448,7 +448,7 @@ importers:
         version: 0.31.1(jsdom@21.1.0)
       webpack:
         specifier: 5.83.1
-        version: 5.83.1(@swc/core@1.3.27)
+        version: 5.83.1
       zod:
         specifier: 3.21.4
         version: 3.21.4
@@ -516,6 +516,9 @@ importers:
 
   packages/docs:
     dependencies:
+      '@algora/sdk':
+        specifier: ^0.1.2
+        version: 0.1.2
       '@aws-sdk/s3-request-presigner':
         specifier: 3.215.0
         version: 3.215.0
@@ -1383,7 +1386,7 @@ importers:
         version: 0.31.1(jsdom@20.0.1)
       webpack:
         specifier: 5.83.1
-        version: 5.83.1(@swc/core@1.3.27)
+        version: 5.83.1
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -1905,6 +1908,14 @@ packages:
       '@algolia/cache-common': 4.14.2
       '@algolia/logger-common': 4.14.2
       '@algolia/requester-common': 4.14.2
+    dev: false
+
+  /@algora/sdk@0.1.2:
+    resolution: {integrity: sha512-NgApYU88IaS8PSgTBV9PsqRWU+y6lNNgCV9vav1wTJVP/UdX9ToTIY7dNP+glGKQd+7MzAq3QCMLHCZEhta8GQ==}
+    dependencies:
+      '@trpc/client': 10.38.5(@trpc/server@10.38.5)
+      '@trpc/server': 10.38.5
+      superjson: 1.13.3
     dev: false
 
   /@alloc/quick-lru@5.2.0:
@@ -7539,7 +7550,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.3.0
       source-map: 0.7.3
-      webpack: 5.83.1(@swc/core@1.3.27)
+      webpack: 5.83.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8807,6 +8818,18 @@ packages:
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
+
+  /@trpc/client@10.38.5(@trpc/server@10.38.5):
+    resolution: {integrity: sha512-tpGUsoAP+3CD/1KRqMdWZ+zebvB68/86SaVPAYHaEDozTFLQdNqTe98DS/T0S4hfh7WCKbMSObj40SCzE8amKQ==}
+    peerDependencies:
+      '@trpc/server': 10.38.5
+    dependencies:
+      '@trpc/server': 10.38.5
+    dev: false
+
+  /@trpc/server@10.38.5:
+    resolution: {integrity: sha512-J0d2Y3Gpt2bMohOshPBfuzDqVrPaE3OKEDtJYgTmLk5t1pZy3kXHQep4rP2LEIr+ELbmkelhcrSvvFLA+4/w/Q==}
+    dev: false
 
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -10116,7 +10139,7 @@ packages:
       react-error-overlay: 7.0.0-next.117
       react-refresh: 0.9.0
       sockjs-client: 1.5.2
-      webpack: 5.83.1(@swc/core@1.3.27)
+      webpack: 5.83.1
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -10619,7 +10642,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.83.1(@swc/core@1.3.27)
+      webpack: 5.83.1
     dev: false
 
   /babel-loader@8.2.5(@babel/core@7.18.6)(webpack@5.83.1):
@@ -11584,6 +11607,13 @@ packages:
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.15
     dev: false
 
   /copy-descriptor@0.1.1:
@@ -13701,7 +13731,7 @@ packages:
       semver: 5.7.1
       tapable: 1.1.3
       typescript: 4.9.5
-      webpack: 5.83.1(@swc/core@1.3.27)
+      webpack: 5.83.1
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
@@ -15196,6 +15226,11 @@ packages:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
       call-bind: 1.0.2
+
+  /is-what@4.1.15:
+    resolution: {integrity: sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==}
+    engines: {node: '>=12.13'}
+    dev: false
 
   /is-whitespace-character@1.0.4:
     resolution: {integrity: sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==}
@@ -17835,7 +17870,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.21
       semver: 7.5.3
-      webpack: 5.83.1(@swc/core@1.3.27)
+      webpack: 5.83.1
     dev: false
 
   /postcss-logical@6.2.0(postcss@8.4.21):
@@ -19004,7 +19039,7 @@ packages:
       strip-ansi: 6.0.0
       text-table: 0.2.0
       typescript: 4.9.5
-      webpack: 5.83.1(@swc/core@1.3.27)
+      webpack: 5.83.1
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -20743,6 +20778,13 @@ packages:
       s.color: 0.0.15
     dev: false
 
+  /superjson@1.13.3:
+    resolution: {integrity: sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==}
+    engines: {node: '>=10'}
+    dependencies:
+      copy-anything: 3.0.5
+    dev: false
+
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -20951,6 +20993,29 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.17.5
       webpack: 5.83.1(esbuild@0.18.6)
+
+  /terser-webpack-plugin@5.3.9(webpack@5.83.1):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.18
+      jest-worker: 27.5.1
+      schema-utils: 3.1.2
+      serialize-javascript: 6.0.1
+      terser: 5.17.5
+      webpack: 5.83.1
 
   /terser@5.17.5:
     resolution: {integrity: sha512-NqFkzBX34WExkCbk3K5urmNCpEWqMPZnwGI1pMHwqvJ/zDlXC75u3NI7BrzoR8/pryy8Abx2e1i8ChrWkhH1Hg==}
@@ -22467,6 +22532,45 @@ packages:
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+
+  /webpack@5.83.1:
+    resolution: {integrity: sha512-TNsG9jDScbNuB+Lb/3+vYolPplCS3bbEaJf+Bj0Gw4DhP3ioAflBb1flcRt9zsWITyvOhM96wMQNRWlSX52DgA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 1.0.0
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.8.2
+      acorn-import-assertions: 1.8.0(acorn@8.8.2)
+      browserslist: 4.21.5
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.14.0
+      es-module-lexer: 1.2.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.2.0
+      mime-types: 2.1.34
+      neo-async: 2.6.2
+      schema-utils: 3.1.2
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(webpack@5.83.1)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   /webpack@5.83.1(@swc/core@1.3.27):
     resolution: {integrity: sha512-TNsG9jDScbNuB+Lb/3+vYolPplCS3bbEaJf+Bj0Gw4DhP3ioAflBb1flcRt9zsWITyvOhM96wMQNRWlSX52DgA==}


### PR DESCRIPTION
Added a grid of cards displaying all open bounties using the [Algora SDK](https://algora.io/sdk)

Dark | Light
:-----:|:-----:
![](https://github.com/remotion-dev/remotion/assets/17045339/c663d81c-e658-4b6c-a3c8-8b06dfa60019) | ![](https://github.com/remotion-dev/remotion/assets/17045339/84657037-5fc5-4214-809f-f72b2cffe5a5)

If you'd like to truncate the grid at a single row, you can add `bounty-grid-clamp` on the container:

```tsx
<div className={clsx("bounty-grid bounty-grid-clamp", isDarkTheme && "dark")}>
```