### PR TITLE
`remotion`: fix `loop` changing the layout

### DIFF
--- a/packages/core/src/video/Video.tsx
+++ b/packages/core/src/video/Video.tsx
@@ -53,6 +53,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 					playbackRate: props.playbackRate ?? 1,
 					startFrom,
 				})}
+				layout="none"
 			>
 				<Video {...propsOtherThanLoop} ref={ref} />
 			</Loop>


### PR DESCRIPTION
We did not intend for a video to adopt an absolute style when adding the `loop` attribute. Considering this a bug and fixing this, if you want to restore the previous behavior, then wrap the video tag in an AbsoluteFill.