### PR TITLE
Change the Pitch using a FFmpef filter

### DIFF
--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -133,6 +133,7 @@ export type TRenderAsset = {
 	mediaFrame: number;
 	playbackRate: number;
 	allowAmplificationDuringRender: boolean;
+	toneFrequency: number | null;
 };
 
 export const compositionsRef = React.createRef<{

--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -124,6 +124,17 @@ export type TSequence = {
 	loopDisplay: LoopDisplay | undefined;
 } & EnhancedTSequenceData;
 
+
+type ToneFrequencyConstraints = {
+	min: number;
+	max: number;
+};
+
+const TONE_FREQUENCY_CONSTRAINTS: ToneFrequencyConstraints = {
+	min: 0,  // Minimum allowed value for toneFrequency
+	max: 1, // Maximum allowed value for toneFrequency
+};
+
 export type TRenderAsset = {
 	type: 'audio' | 'video';
 	src: string;
@@ -134,6 +145,13 @@ export type TRenderAsset = {
 	playbackRate: number;
 	allowAmplificationDuringRender: boolean;
 	toneFrequency: number | null;
+};
+export const validateToneFrequency = (toneFrequency?: number | null): boolean => {
+	if (toneFrequency === undefined || toneFrequency === null) {
+			return true; // toneFrequency is optional, so it's valid if undefined or null
+	}
+	
+	return toneFrequency >= TONE_FREQUENCY_CONSTRAINTS.min && toneFrequency <= TONE_FREQUENCY_CONSTRAINTS.max;
 };
 
 export const compositionsRef = React.createRef<{

--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -143,11 +143,10 @@ export type TRenderAsset = {
 	mediaFrame: number;
 	playbackRate: number;
 	allowAmplificationDuringRender: boolean;
-	toneFrequency?: number | null;
+	toneFrequency?: number;
+	ffmpegFilter?: string;
 };
-export const validateToneFrequency = (
-	toneFrequency?: number | null,
-): boolean => {
+export const validateToneFrequency = (toneFrequency?: number): boolean => {
 	if (toneFrequency === undefined || toneFrequency === null) {
 		return true; // toneFrequency is optional, so it's valid if undefined or null
 	}

--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -124,14 +124,13 @@ export type TSequence = {
 	loopDisplay: LoopDisplay | undefined;
 } & EnhancedTSequenceData;
 
-
 type ToneFrequencyConstraints = {
 	min: number;
 	max: number;
 };
 
 const TONE_FREQUENCY_CONSTRAINTS: ToneFrequencyConstraints = {
-	min: 0,  // Minimum allowed value for toneFrequency
+	min: 0, // Minimum allowed value for toneFrequency
 	max: 1, // Maximum allowed value for toneFrequency
 };
 
@@ -146,12 +145,17 @@ export type TRenderAsset = {
 	allowAmplificationDuringRender: boolean;
 	toneFrequency?: number | null;
 };
-export const validateToneFrequency = (toneFrequency?: number | null): boolean => {
+export const validateToneFrequency = (
+	toneFrequency?: number | null,
+): boolean => {
 	if (toneFrequency === undefined || toneFrequency === null) {
-			return true; // toneFrequency is optional, so it's valid if undefined or null
+		return true; // toneFrequency is optional, so it's valid if undefined or null
 	}
-	
-	return toneFrequency >= TONE_FREQUENCY_CONSTRAINTS.min && toneFrequency <= TONE_FREQUENCY_CONSTRAINTS.max;
+
+	return (
+		toneFrequency >= TONE_FREQUENCY_CONSTRAINTS.min &&
+		toneFrequency <= TONE_FREQUENCY_CONSTRAINTS.max
+	);
 };
 
 export const compositionsRef = React.createRef<{

--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -144,7 +144,7 @@ export type TRenderAsset = {
 	mediaFrame: number;
 	playbackRate: number;
 	allowAmplificationDuringRender: boolean;
-	toneFrequency: number | null;
+	toneFrequency?: number | null;
 };
 export const validateToneFrequency = (toneFrequency?: number | null): boolean => {
 	if (toneFrequency === undefined || toneFrequency === null) {

--- a/packages/core/src/audio/AudioForRendering.tsx
+++ b/packages/core/src/audio/AudioForRendering.tsx
@@ -21,6 +21,7 @@ import {useFrameForVolumeProp} from './use-audio-frame.js';
 
 type AudioForRenderingProps = RemotionAudioProps & {
 	onDuration: (src: string, durationInSeconds: number) => void;
+	ffmpegFilter?: string; // Add the ffmpegFilter property
 };
 
 const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
@@ -97,7 +98,8 @@ const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
 			mediaFrame: frame,
 			playbackRate: props.playbackRate ?? 1,
 			allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
-			toneFrequency: null,
+			toneFrequency: 0,
+			ffmpegFilter: '',
 		});
 		return () => unregisterRenderAsset(id);
 	}, [

--- a/packages/core/src/audio/AudioForRendering.tsx
+++ b/packages/core/src/audio/AudioForRendering.tsx
@@ -97,6 +97,7 @@ const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
 			mediaFrame: frame,
 			playbackRate: props.playbackRate ?? 1,
 			allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
+			toneFrequency: null
 		});
 		return () => unregisterRenderAsset(id);
 	}, [

--- a/packages/core/src/audio/AudioForRendering.tsx
+++ b/packages/core/src/audio/AudioForRendering.tsx
@@ -97,7 +97,7 @@ const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
 			mediaFrame: frame,
 			playbackRate: props.playbackRate ?? 1,
 			allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
-			toneFrequency: null
+			toneFrequency: null,
 		});
 		return () => unregisterRenderAsset(id);
 	}, [

--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -1,4 +1,3 @@
-
 import type {ForwardRefExoticComponent, RefAttributes} from 'react';
 import React, {
 	forwardRef,

--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -29,6 +29,7 @@ import type {RemotionVideoProps} from './props.js';
 
 type VideoForRenderingProps = RemotionVideoProps & {
 	onDuration: (src: string, durationInSeconds: number) => void;
+	toneFrequency?: number;
 };
 
 const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
@@ -41,6 +42,7 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 		allowAmplificationDuringRender,
 		playbackRate,
 		onDuration,
+		
 		...props
 	},
 	ref,
@@ -110,7 +112,6 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 			mediaFrame: frame,
 			playbackRate: playbackRate ?? 1,
 			allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
-			toneFrequency: null,
 		});
 
 		return () => unregisterRenderAsset(id);

--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -1,3 +1,4 @@
+
 import type {ForwardRefExoticComponent, RefAttributes} from 'react';
 import React, {
 	forwardRef,
@@ -110,6 +111,7 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 			mediaFrame: frame,
 			playbackRate: playbackRate ?? 1,
 			allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
+			toneFrequency: null,
 		});
 
 		return () => unregisterRenderAsset(id);

--- a/packages/docs/docs/audio.md
+++ b/packages/docs/docs/audio.md
@@ -125,7 +125,8 @@ export const MyVideo = () => {
 };
 ```
 
-### `toneFrequency`<AvailableFrom v="4.0.45"/> 
+### `toneFrequency`<AvailableFrom v="4.0.45"/>
+
 //update the version
 
 The `toneFrequency` prop allows you to adjust the pitch of the audio. It accepts a number between 0 and 1, where 0 represents the lowest pitch and 1 represents the highest pitch. For example, a toneFrequency of 0.5 would lower the pitch by half. The valid range for toneFrequency is from 0 (lowest pitch) to 1 (highest pitch).
@@ -147,7 +148,7 @@ In the [Remotion Studio](/docs/terminology#remotion-studio) or in the [Remotion 
 
 ## `allowAmplificationDuringRender`<AvailableFrom v="3.3.17"/>
 
-Make values for [`volume`](#volume) greater than `1` result in amplification during renders.  
+Make values for [`volume`](#volume) greater than `1` result in amplification during renders.
 In the Remotion Studio, the volume will be limited to `1`, since the browser cannot amplify audio.
 
 ## See also
@@ -156,3 +157,4 @@ In the Remotion Studio, the volume will be limited to `1`, since the browser can
 - [Using audio](/docs/using-audio)
 - [Audio visualization](/docs/audio-visualization)
 - [`<Video />`](/docs/video)
+```

--- a/packages/docs/docs/audio.md
+++ b/packages/docs/docs/audio.md
@@ -125,6 +125,22 @@ export const MyVideo = () => {
 };
 ```
 
+### `toneFrequency`<AvailableFrom v="4.0.45"/> 
+//update the version
+
+The `toneFrequency` prop allows you to adjust the pitch of the audio. It accepts a number between 0 and 1, where 0 represents the lowest pitch and 1 represents the highest pitch. For example, a toneFrequency of 0.5 would lower the pitch by half. The valid range for toneFrequency is from 0 (lowest pitch) to 1 (highest pitch).
+
+```tsx twoslash
+import { AbsoluteFill, Audio, staticFile } from "remotion";
+
+export const MyVideo = () => {
+  return (
+    <AbsoluteFill>
+      <Audio src={staticFile("audio.mp3")} toneFrequency={0.5} />
+    </AbsoluteFill>
+  );
+};
+
 ## `acceptableTimeShiftInSeconds`<AvailableFrom v="3.2.42"/>
 
 In the [Remotion Studio](/docs/terminology#remotion-studio) or in the [Remotion Player](/docs/player), Remotion will seek the audio if it gets too much out of sync with Remotion's internal time - be it due to the audio loading or the page being too slow to keep up in real-time. By default, a seek is triggered if `0.45` seconds of time shift is encountered. Using this prop, you can customize the threshold.

--- a/packages/renderer/src/preprocess-audio-track.ts
+++ b/packages/renderer/src/preprocess-audio-track.ts
@@ -15,7 +15,7 @@ type Options = {
   expectedFrames: number;
   fps: number;
   downloadMap: DownloadMap;
-  toneFrequency: number | null; // Add toneFrequency parameter
+  toneFrequency?: number | null; // Add toneFrequency parameter
 };
 
 export type PreprocessedAudioTrack = {

--- a/packages/renderer/src/preprocess-audio-track.ts
+++ b/packages/renderer/src/preprocess-audio-track.ts
@@ -1,70 +1,76 @@
-import type {DownloadMap} from './assets/download-map';
-import {getAudioChannelsAndDuration} from './assets/get-audio-channels';
-import type {MediaAsset} from './assets/types';
-import {calculateFfmpegFilter} from './calculate-ffmpeg-filters';
-import {callFf} from './call-ffmpeg';
-import {makeFfmpegFilterFile} from './ffmpeg-filter-file';
-import {pLimit} from './p-limit';
-import {resolveAssetSrc} from './resolve-asset-src';
-import {DEFAULT_SAMPLE_RATE} from './sample-rate';
-import type {ProcessedTrack} from './stringify-ffmpeg-filter';
+import type { DownloadMap } from './assets/download-map';
+import { getAudioChannelsAndDuration } from './assets/get-audio-channels';
+import type { MediaAsset } from './assets/types';
+import { calculateFfmpegFilter } from './calculate-ffmpeg-filters';
+import { callFf } from './call-ffmpeg';
+import { makeFfmpegFilterFile } from './ffmpeg-filter-file';
+import { pLimit } from './p-limit';
+import { resolveAssetSrc } from './resolve-asset-src';
+import { DEFAULT_SAMPLE_RATE } from './sample-rate';
+import type { ProcessedTrack } from './stringify-ffmpeg-filter';
 
 type Options = {
-	outName: string;
-	asset: MediaAsset;
-	expectedFrames: number;
-	fps: number;
-	downloadMap: DownloadMap;
+  outName: string;
+  asset: MediaAsset;
+  expectedFrames: number;
+  fps: number;
+  downloadMap: DownloadMap;
+  toneFrequency: number; // Add toneFrequency parameter
 };
 
 export type PreprocessedAudioTrack = {
-	outName: string;
-	filter: ProcessedTrack;
+  outName: string;
+  filter: ProcessedTrack;
 };
 
 const preprocessAudioTrackUnlimited = async ({
-	outName,
-	asset,
-	expectedFrames,
-	fps,
-	downloadMap,
+  outName,
+  asset,
+  expectedFrames,
+  fps,
+  downloadMap,
+  toneFrequency, // Receive toneFrequency from options
 }: Options): Promise<PreprocessedAudioTrack | null> => {
-	const {channels, duration} = await getAudioChannelsAndDuration(
-		downloadMap,
-		resolveAssetSrc(asset.src),
-	);
+  const { channels, duration } = await getAudioChannelsAndDuration(
+    downloadMap,
+    resolveAssetSrc(asset.src),
+  );
 
-	const filter = calculateFfmpegFilter({
-		asset,
-		durationInFrames: expectedFrames,
-		fps,
-		channels,
-		assetDuration: duration,
-	});
+  // Calculate the FFmpeg filter for pitch adjustment based on tone frequency
+  const ffmpegFilter = `asetrate=44100*${toneFrequency},aresample=44100,atempo=1/${toneFrequency}`;
 
-	if (filter === null) {
-		return null;
-	}
+  const filter = calculateFfmpegFilter({
+    asset,
+    durationInFrames: expectedFrames,
+    fps,
+    channels,
+    assetDuration: duration,
+  });
 
-	const {cleanup, file} = await makeFfmpegFilterFile(filter, downloadMap);
+  if (filter === null) {
+    return null;
+  }
 
-	const args = [
-		['-i', resolveAssetSrc(asset.src)],
-		['-ac', '2'],
-		['-filter_script:a', file],
-		['-c:a', 'pcm_s16le'],
-		['-ar', String(DEFAULT_SAMPLE_RATE)],
-		['-y', outName],
-	].flat(2);
+  const { cleanup, file } = await makeFfmpegFilterFile(filter, downloadMap);
 
-	await callFf('ffmpeg', args);
+  const args = [
+    '-i', resolveAssetSrc(asset.src),
+    '-ac', '2',
+    '-filter_script:a', file,
+    '-c:a', 'pcm_s16le',
+    '-ar', String(DEFAULT_SAMPLE_RATE),
+    '-af', ffmpegFilter, // Apply the FFmpeg filter for pitch adjustment
+    '-y', outName,
+  ].flat(2);;
 
-	cleanup();
-	return {outName, filter};
+  await callFf('ffmpeg', args);
+
+  cleanup();
+  return { outName, filter };
 };
 
 const limit = pLimit(2);
 
 export const preprocessAudioTrack = (options: Options) => {
-	return limit(preprocessAudioTrackUnlimited, options);
+  return limit(preprocessAudioTrackUnlimited, options);
 };

--- a/packages/renderer/src/preprocess-audio-track.ts
+++ b/packages/renderer/src/preprocess-audio-track.ts
@@ -1,76 +1,83 @@
-import type { DownloadMap } from './assets/download-map';
-import { getAudioChannelsAndDuration } from './assets/get-audio-channels';
-import type { MediaAsset } from './assets/types';
-import { calculateFfmpegFilter } from './calculate-ffmpeg-filters';
-import { callFf } from './call-ffmpeg';
-import { makeFfmpegFilterFile } from './ffmpeg-filter-file';
-import { pLimit } from './p-limit';
-import { resolveAssetSrc } from './resolve-asset-src';
-import { DEFAULT_SAMPLE_RATE } from './sample-rate';
-import type { ProcessedTrack } from './stringify-ffmpeg-filter';
+import type {DownloadMap} from './assets/download-map';
+import {getAudioChannelsAndDuration} from './assets/get-audio-channels';
+import type {MediaAsset} from './assets/types';
+import {calculateFfmpegFilter} from './calculate-ffmpeg-filters';
+import {callFf} from './call-ffmpeg';
+import {makeFfmpegFilterFile} from './ffmpeg-filter-file';
+import {pLimit} from './p-limit';
+import {resolveAssetSrc} from './resolve-asset-src';
+import {DEFAULT_SAMPLE_RATE} from './sample-rate';
+import type {ProcessedTrack} from './stringify-ffmpeg-filter';
 
 type Options = {
-  outName: string;
-  asset: MediaAsset;
-  expectedFrames: number;
-  fps: number;
-  downloadMap: DownloadMap;
-  toneFrequency?: number | null; // Add toneFrequency parameter
+	outName: string;
+	asset: MediaAsset;
+	expectedFrames: number;
+	fps: number;
+	downloadMap: DownloadMap;
+	toneFrequency?: number; // Add toneFrequency parameter
 };
 
 export type PreprocessedAudioTrack = {
-  outName: string;
-  filter: ProcessedTrack;
+	outName: string;
+	filter: ProcessedTrack;
 };
 
 const preprocessAudioTrackUnlimited = async ({
-  outName,
-  asset,
-  expectedFrames,
-  fps,
-  downloadMap,
-  toneFrequency, // Receive toneFrequency from options
+	outName,
+	asset,
+	expectedFrames,
+	fps,
+	downloadMap,
+	toneFrequency, // Receive toneFrequency from options
 }: Options): Promise<PreprocessedAudioTrack | null> => {
-  const { channels, duration } = await getAudioChannelsAndDuration(
-    downloadMap,
-    resolveAssetSrc(asset.src),
-  );
+	const {channels, duration} = await getAudioChannelsAndDuration(
+		downloadMap,
+		resolveAssetSrc(asset.src),
+	);
 
-  // Calculate the FFmpeg filter for pitch adjustment based on tone frequency
-  const ffmpegFilter = `asetrate=44100*${toneFrequency},aresample=44100,atempo=1/${toneFrequency}`;
+	// Calculate the FFmpeg filter for pitch adjustment based on tone frequency
+	const ffmpegFilter = `asetrate=44100*${toneFrequency},aresample=44100,atempo=1/${toneFrequency}`;
 
-  const filter = calculateFfmpegFilter({
-    asset,
-    durationInFrames: expectedFrames,
-    fps,
-    channels,
-    assetDuration: duration,
-  });
+	const filter = calculateFfmpegFilter({
+		asset,
+		durationInFrames: expectedFrames,
+		fps,
+		channels,
+		assetDuration: duration,
+	});
 
-  if (filter === null) {
-    return null;
-  }
+	if (filter === null) {
+		return null;
+	}
 
-  const { cleanup, file } = await makeFfmpegFilterFile(filter, downloadMap);
+	const {cleanup, file} = await makeFfmpegFilterFile(filter, downloadMap);
 
-  const args = [
-    '-i', resolveAssetSrc(asset.src),
-    '-ac', '2',
-    '-filter_script:a', file,
-    '-c:a', 'pcm_s16le',
-    '-ar', String(DEFAULT_SAMPLE_RATE),
-    '-af', ffmpegFilter, // Apply the FFmpeg filter for pitch adjustment
-    '-y', outName,
-  ].flat(2);;
+	const args = [
+		'-i',
+		resolveAssetSrc(asset.src),
+		'-ac',
+		'2',
+		'-filter_script:a',
+		file,
+		'-c:a',
+		'pcm_s16le',
+		'-ar',
+		String(DEFAULT_SAMPLE_RATE),
+		'-af',
+		ffmpegFilter, // Apply the FFmpeg filter for pitch adjustment
+		'-y',
+		outName,
+	].flat(2);
 
-  await callFf('ffmpeg', args);
+	await callFf('ffmpeg', args);
 
-  cleanup();
-  return { outName, filter };
+	cleanup();
+	return {outName, filter};
 };
 
 const limit = pLimit(2);
 
 export const preprocessAudioTrack = (options: Options) => {
-  return limit(preprocessAudioTrackUnlimited, options);
+	return limit(preprocessAudioTrackUnlimited, options);
 };

--- a/packages/renderer/src/preprocess-audio-track.ts
+++ b/packages/renderer/src/preprocess-audio-track.ts
@@ -15,7 +15,7 @@ type Options = {
   expectedFrames: number;
   fps: number;
   downloadMap: DownloadMap;
-  toneFrequency: number; // Add toneFrequency parameter
+  toneFrequency: number | null; // Add toneFrequency parameter
 };
 
 export type PreprocessedAudioTrack = {

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -169,7 +169,7 @@ const getAssetsData = async ({
 					expectedFrames,
 					fps,
 					downloadMap,
-					toneFrequency:0.9,
+					toneFrequency:null,
 				});
 				preprocessProgress[index] = 1;
 				updateProgress();

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -169,6 +169,7 @@ const getAssetsData = async ({
 					expectedFrames,
 					fps,
 					downloadMap,
+					toneFrequency:0.9,
 				});
 				preprocessProgress[index] = 1;
 				updateProgress();


### PR DESCRIPTION


### Issue

Fixes #2932

### Description

This PR addresses issue #2932 by introducing the `toneFrequency` prop to the `<Audio>` component. The `toneFrequency` prop allows users to specify the pitch adjustment for audio playback, with a valid range from 0 to 1. This feature enables precise control over audio pitch during rendering.

### Changes Made

- Added `toneFrequency` prop to the `<Audio>` component, allowing users to control pitch adjustment during audio playback.
- Updated documentation to include information about the `toneFrequency` prop, specifying its usage and valid range.
- Ensured that the test suite passes with the new changes.
- Documented potential tradeoffs, if any, related to the implementation of the `toneFrequency` prop.

### Tradeoffs Considered

Did not seem at first but cannot say for future

### How to Test

Please refer to the <Audio> documentation.

