### PR TITLE
Fix `chromiumOptions` in PHP package

### DIFF
--- a/packages/lambda-php/src/RenderParams.php
+++ b/packages/lambda-php/src/RenderParams.php
@@ -91,7 +91,7 @@ class RenderParams
         ?string $frameRange = null,
         ?string $outName = null,
         ?int $timeoutInMilliseconds = 30000,
-        ?object $chromiumOptions = new stdClass(), 
+        ?object $chromiumOptions = null, 
         ?int $scale = 1, 
         ?int $everyNthFrame = 1, 
         ?int $numberOfGifLoops = 0, 

--- a/packages/lambda-php/src/RenderParams.php
+++ b/packages/lambda-php/src/RenderParams.php
@@ -114,6 +114,11 @@ class RenderParams
         ?string $deleteAfter = null
         )
     {
+        if ($chromiumOptions === null) {
+            $this->chromiumOptions = new stdClass();
+        } else {
+            $this->chromiumOptions = $chromiumOptions;
+        }
         $this->data = $data;
         $this->composition = $composition;
         $this->codec = $codec;
@@ -129,7 +134,6 @@ class RenderParams
         $this->frameRange = $frameRange;
         $this->outName = $outName;
         $this->timeoutInMilliseconds = $timeoutInMilliseconds;
-        $this->chromiumOptions = $chromiumOptions;
         $this->scale = $scale;
         $this->everyNthFrame = $everyNthFrame;
         $this->numberOfGifLoops = $numberOfGifLoops;


### PR DESCRIPTION
> Also for the fix you mentiond. default to stdClass that was what cased the issue. Apparently it was not possible to default to std class since it is not possible to initialize a class property with a non-constant stdClass class,  is not allowed as a default property value.
