### PR TITLE
PHP: Extract GetRenderProgressResponse into separate file

### DIFF
--- a/packages/lambda-php/src/GetRenderProgressResponse.php
+++ b/packages/lambda-php/src/GetRenderProgressResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+class GetRenderProgressResponse
+{
+    public int $chunks;
+    public bool $done;
+    public float $overallProgress;
+    public string $type;
+    public ?string $outputFile;
+    public int $lambdasInvoked;
+    public int $renderSize;
+    public int $currentTime;
+    public bool $fatalErrorEncountered;
+    public ?int $timeToFinish;
+    public ?string $outBucket;
+    public ?string $outKey;
+    public ?string $bucket;
+}

--- a/packages/lambda-php/src/PHPClient.php
+++ b/packages/lambda-php/src/PHPClient.php
@@ -4,6 +4,7 @@ namespace Remotion\LambdaPhp;
 use Aws\Credentials\CredentialProvider;
 use Aws\Lambda\LambdaClient;
 use Exception;
+use GetRenderProgressResponse;
 use stdClass;
 
 require_once __DIR__ . '/Version.php';

--- a/packages/lambda-php/src/RenderParams.php
+++ b/packages/lambda-php/src/RenderParams.php
@@ -12,22 +12,6 @@ class RenderMediaOnLambdaResponse
     public string $renderId;
 }
 
-class GetRenderProgressResponse
-{
-    public int $chunks;
-    public bool $done;
-    public float $overallProgress;
-    public string $type;
-    public ?string $outputFile;
-    public int $lambdasInvoked;
-    public int $renderSize;
-    public int $currentTime;
-    public bool $fatalErrorEncountered;
-    public ?int $timeToFinish;
-    public ?string $outBucket;
-    public ?string $outKey;
-    public ?string $bucket;
-}
 
 class RenderParams
 {


### PR DESCRIPTION
Might solve an issue with Laravel:

> It could have to do with that or it could be that Laravel and other php frameworks are more strict in this while plain php is fine.
> I also recommend moving "GetRenderProgressResponse" out to its own file to not mess with frameworks namespaces
At least that solved the issues for me.