### PR TITLE
Docs: Update Lambda claims

### DIFF
--- a/packages/docs/docs/lambda.md
+++ b/packages/docs/docs/lambda.md
@@ -20,11 +20,11 @@ import {LambdaRegionList} from '../components/lambda/regions.tsx';
 
 ## When should I use it?
 
-- You are rendering less than 1 hour of video per minute. <sub>([AWS Lambda Concurrency Limit / Burst Limit constraint](/docs/lambda/troubleshooting/rate-limit))</sub>
-- Your videos are less than 2 hours long. <sub>([AWS Lambda storage constraint](/docs/lambda/disk-size))</sub>
+- Your videos are less than 30 minutes long at Full HD. <sub>approximately until the 15min AWS Timeout limit is hit</sub>
+- You stay within the ([AWS Lambda Concurrency Limit](/docs/lambda/troubleshooting/rate-limit)) or you are requesting an [increase from AWS](/docs/lambda/troubleshooting/rate-limit).
 - You are fine with using Amazon Web Services in one of the [supported regions](/docs/lambda/region-selection).
 
-If one of those constraints is a dealbreaker for you, resort to normal [server-side rendering](/docs/ssr).
+If one of those constraints is a dealbreaker for you, resort to normal [server-side rendering](/docs/ssr) or consider using [Cloud Run](/docs/cloudrun).
 
 ## How it works
 


### PR DESCRIPTION
- I'm giving up on supporting up to 2 hours of videos. The proper AAC encoding we introduced later makes the renders slower and therefore not suitable for such long videos. Therefore we need to update our claim.
- People think that Lambda is limited to 3000 concurrent Lambdas, but you can increase it. Lambda can scale pretty high actually. Let's not make it sound like this is a limitation
- Mention Cloud Run as an alternative