### PR TITLE
`@remotion/lambda`: Faster renders when using warm starts

### DIFF
--- a/packages/example/runlambda.sh
+++ b/packages/example/runlambda.sh
@@ -4,7 +4,7 @@ cd lambda
 npm run buildlambda
 cd ..
 cd example
-pnpm exec remotion lambda functions rmall -f
-pnpm exec remotion lambda functions deploy --memory=4000 --timeout=900 --disk=10000
-pnpm exec remotion lambda sites create --site-name=testbed-v6 --log=verbose --enable-folder-expiry
-# pnpm exec remotion lambda render testbed-v6 OffthreadRemoteVideo --log=verbose --delete-after="1-day"
+bunx remotion lambda functions rmall -f
+bunx remotion lambda functions deploy --memory=3000 --disk=10000
+bunx remotion lambda sites create --site-name=testbed-v6 --log=verbose --enable-folder-expiry
+bunx remotion lambda render testbed-v6 OffthreadRemoteVideo --log=verbose --delete-after="1-day"

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -496,7 +496,7 @@ export const Index: React.FC = () => {
 					width={1920}
 					height={1080}
 					fps={30}
-					durationInFrames={30 * 60 * 60}
+					durationInFrames={30 * 60}
 				/>
 				<Composition
 					id="video-testing-webm"

--- a/packages/lambda/src/functions/compositions.ts
+++ b/packages/lambda/src/functions/compositions.ts
@@ -41,11 +41,7 @@ export const compositionsHandler = async (
 				enableFolderExpiry: null,
 				customCredentials: null,
 			}).then((b) => b.bucketName),
-		getBrowserInstance(
-			lambdaParams.logLevel,
-			false,
-			lambdaParams.chromiumOptions ?? {},
-		),
+		getBrowserInstance(lambdaParams.chromiumOptions),
 	]);
 
 	const serializedInputPropsWithCustomSchema = await decompressInputProps({
@@ -77,6 +73,8 @@ export const compositionsHandler = async (
 		onBrowserLog: null,
 		offthreadVideoCacheSizeInBytes: lambdaParams.offthreadVideoCacheSizeInBytes,
 	});
+
+	browserInstance.close(true, lambdaParams.logLevel, false);
 
 	return Promise.resolve({
 		compositions,

--- a/packages/lambda/src/functions/compositions.ts
+++ b/packages/lambda/src/functions/compositions.ts
@@ -64,7 +64,7 @@ export const compositionsHandler = async (
 
 	const compositions = await RenderInternals.internalGetCompositions({
 		serveUrlOrWebpackUrl: realServeUrl,
-		puppeteerInstance: await browserInstancePromise,
+		puppeteerInstance: (await browserInstancePromise).instance,
 		serializedInputPropsWithCustomSchema,
 		envVariables: lambdaParams.envVariables ?? {},
 		timeoutInMilliseconds: lambdaParams.timeoutInMilliseconds,
@@ -78,7 +78,7 @@ export const compositionsHandler = async (
 		offthreadVideoCacheSizeInBytes: lambdaParams.offthreadVideoCacheSizeInBytes,
 	});
 
-	(await browserInstancePromise).forgetEventLoop();
+	(await browserInstancePromise).instance.forgetEventLoop();
 
 	return Promise.resolve({
 		compositions,

--- a/packages/lambda/src/functions/compositions.ts
+++ b/packages/lambda/src/functions/compositions.ts
@@ -41,7 +41,11 @@ export const compositionsHandler = async (
 				enableFolderExpiry: null,
 				customCredentials: null,
 			}).then((b) => b.bucketName),
-		getBrowserInstance(lambdaParams.chromiumOptions),
+		getBrowserInstance(
+			lambdaParams.logLevel,
+			false,
+			lambdaParams.chromiumOptions,
+		),
 	]);
 
 	const serializedInputPropsWithCustomSchema = await decompressInputProps({

--- a/packages/lambda/src/functions/compositions.ts
+++ b/packages/lambda/src/functions/compositions.ts
@@ -78,7 +78,7 @@ export const compositionsHandler = async (
 		offthreadVideoCacheSizeInBytes: lambdaParams.offthreadVideoCacheSizeInBytes,
 	});
 
-	(await browserInstancePromise).close(true, lambdaParams.logLevel, false);
+	(await browserInstancePromise).forgetEventLoop();
 
 	return Promise.resolve({
 		compositions,

--- a/packages/lambda/src/functions/helpers/__mocks__/get-browser-instance.ts
+++ b/packages/lambda/src/functions/helpers/__mocks__/get-browser-instance.ts
@@ -6,5 +6,5 @@ let _browserInstance: Await<ReturnType<typeof openBrowser>> | null;
 
 export const getBrowserInstance: typeof original = async () => {
 	_browserInstance = await openBrowser('chrome');
-	return _browserInstance;
+	return {instance: _browserInstance, configurationString: 'chrome'};
 };

--- a/packages/lambda/src/functions/helpers/get-browser-instance.ts
+++ b/packages/lambda/src/functions/helpers/get-browser-instance.ts
@@ -38,6 +38,8 @@ export const getBrowserInstance = async (
 	}
 
 	if (_browserInstance) {
+		RenderInternals.Log.info('Warm Lambda function, reusing browser instance');
+		_browserInstance.rememberEventLoop();
 		return _browserInstance;
 	}
 

--- a/packages/lambda/src/functions/helpers/get-browser-instance.ts
+++ b/packages/lambda/src/functions/helpers/get-browser-instance.ts
@@ -1,10 +1,48 @@
-import type {ChromiumOptions} from '@remotion/renderer';
-import {openBrowser} from '@remotion/renderer';
+import type {ChromiumOptions, LogLevel, openBrowser} from '@remotion/renderer';
+import {RenderInternals} from '@remotion/renderer';
+import type {Await} from '../../shared/await';
 import {executablePath} from './get-chromium-executable-path';
 
+let _browserInstance: Await<ReturnType<typeof openBrowser>> | null;
+
+let launching = false;
+
+const waitForLaunched = () => {
+	return new Promise<void>((resolve, reject) => {
+		const check = () =>
+			setTimeout(() => {
+				if (launching) {
+					resolve();
+				} else {
+					check();
+				}
+			}, 16);
+
+		setTimeout(() => reject(new Error('Timeout launching browser')), 5000);
+		check();
+	});
+};
+
 export const getBrowserInstance = async (
+	logLevel: LogLevel,
+	indent: boolean,
 	chromiumOptions: ChromiumOptions,
 ): ReturnType<typeof openBrowser> => {
+	if (launching) {
+		await waitForLaunched();
+		if (!_browserInstance) {
+			throw new Error('expected to launch');
+		}
+
+		return _browserInstance;
+	}
+
+	if (_browserInstance) {
+		return _browserInstance;
+	}
+
+	launching = true;
+
 	const execPath = executablePath();
 
 	const actualChromiumOptions: ChromiumOptions = {
@@ -13,11 +51,20 @@ export const getBrowserInstance = async (
 		gl: chromiumOptions.gl ?? 'swangle',
 	};
 
-	const _browserInstance = await openBrowser('chrome', {
+	_browserInstance = await RenderInternals.internalOpenBrowser({
+		browser: 'chrome',
 		browserExecutable: execPath,
 		chromiumOptions: actualChromiumOptions,
 		forceDeviceScaleFactor: undefined,
+		indent: false,
+		viewport: null,
+		logLevel,
 	});
-
+	_browserInstance.on('disconnected', () => {
+		console.log('Browser disconnected / crashed');
+		_browserInstance?.close(true, logLevel, indent).catch(() => undefined);
+		_browserInstance = null;
+	});
+	launching = false;
 	return _browserInstance;
 };

--- a/packages/lambda/src/functions/helpers/get-browser-instance.ts
+++ b/packages/lambda/src/functions/helpers/get-browser-instance.ts
@@ -3,7 +3,27 @@ import {RenderInternals} from '@remotion/renderer';
 import type {Await} from '../../shared/await';
 import {executablePath} from './get-chromium-executable-path';
 
-let _browserInstance: Await<ReturnType<typeof openBrowser>> | null;
+type LaunchedBrowser = {
+	instance: Await<ReturnType<typeof openBrowser>>;
+	configurationString: string;
+};
+
+const makeConfigurationString = (
+	options: ChromiumOptions,
+	logLevel: LogLevel,
+): string => {
+	return [
+		`web-security-${Boolean(options.disableWebSecurity)}`,
+		`multi-process-${Boolean(options.enableMultiProcessOnLinux)}`,
+		`ignore-certificate-errors-${Boolean(options.ignoreCertificateErrors)}`,
+		`log-level-${logLevel}`,
+		`gl-${options.gl ?? null}`,
+		`userAgent-${options.userAgent ?? null}`,
+		`headless-${options.headless ?? false}`,
+	].join('/');
+};
+
+let _browserInstance: LaunchedBrowser | null;
 
 let launching = false;
 
@@ -27,46 +47,70 @@ export const getBrowserInstance = async (
 	logLevel: LogLevel,
 	indent: boolean,
 	chromiumOptions: ChromiumOptions,
-): ReturnType<typeof openBrowser> => {
-	if (launching) {
-		await waitForLaunched();
-		if (!_browserInstance) {
-			throw new Error('expected to launch');
-		}
-
-		return _browserInstance;
-	}
-
-	if (_browserInstance) {
-		RenderInternals.Log.info('Warm Lambda function, reusing browser instance');
-		_browserInstance.rememberEventLoop();
-		return _browserInstance;
-	}
-
-	launching = true;
-
-	const execPath = executablePath();
-
+): Promise<LaunchedBrowser> => {
 	const actualChromiumOptions: ChromiumOptions = {
 		...chromiumOptions,
 		// Override the `null` value, which might come from CLI with swANGLE
 		gl: chromiumOptions.gl ?? 'swangle',
 	};
 
-	_browserInstance = await RenderInternals.internalOpenBrowser({
-		browser: 'chrome',
-		browserExecutable: execPath,
-		chromiumOptions: actualChromiumOptions,
-		forceDeviceScaleFactor: undefined,
-		indent: false,
-		viewport: null,
+	if (launching) {
+		RenderInternals.Log.info('Already waiting for browser launch...');
+		await waitForLaunched();
+		if (!_browserInstance) {
+			throw new Error('expected to launch');
+		}
+	}
+
+	const configurationString = makeConfigurationString(
+		actualChromiumOptions,
 		logLevel,
-	});
-	_browserInstance.on('disconnected', () => {
-		console.log('Browser disconnected / crashed');
-		_browserInstance?.close(true, logLevel, indent).catch(() => undefined);
+	);
+
+	if (!_browserInstance) {
+		RenderInternals.Log.info(
+			'Cold Lambda function, launching new Lambda function',
+		);
+		launching = true;
+
+		const execPath = executablePath();
+
+		const instance = await RenderInternals.internalOpenBrowser({
+			browser: 'chrome',
+			browserExecutable: execPath,
+			chromiumOptions: actualChromiumOptions,
+			forceDeviceScaleFactor: undefined,
+			indent: false,
+			viewport: null,
+			logLevel,
+		});
+		instance.on('disconnected', () => {
+			console.log('Browser disconnected / crashed');
+			_browserInstance?.instance
+				?.close(true, logLevel, indent)
+				.catch(() => undefined);
+			_browserInstance = null;
+		});
+		_browserInstance = {
+			instance,
+			configurationString,
+		};
+
+		launching = false;
+		return _browserInstance;
+	}
+
+	if (_browserInstance.configurationString !== configurationString) {
+		RenderInternals.Log.info(
+			'Warm Lambda function, but Browser configuration changed. Killing old browser instance.',
+		);
+		_browserInstance.instance.rememberEventLoop();
+		await _browserInstance.instance.close(true, logLevel, indent);
 		_browserInstance = null;
-	});
-	launching = false;
+		return getBrowserInstance(logLevel, indent, chromiumOptions);
+	}
+
+	RenderInternals.Log.info('Warm Lambda function, reusing browser instance');
+	_browserInstance.instance.rememberEventLoop();
 	return _browserInstance;
 };

--- a/packages/lambda/src/functions/helpers/get-browser-instance.ts
+++ b/packages/lambda/src/functions/helpers/get-browser-instance.ts
@@ -1,48 +1,10 @@
-import type {ChromiumOptions, LogLevel, openBrowser} from '@remotion/renderer';
-import {RenderInternals} from '@remotion/renderer';
-import type {Await} from '../../shared/await';
+import type {ChromiumOptions} from '@remotion/renderer';
+import {openBrowser} from '@remotion/renderer';
 import {executablePath} from './get-chromium-executable-path';
 
-let _browserInstance: Await<ReturnType<typeof openBrowser>> | null;
-
-let launching = false;
-
-const waitForLaunched = () => {
-	return new Promise<void>((resolve, reject) => {
-		const check = () =>
-			setTimeout(() => {
-				if (launching) {
-					resolve();
-				} else {
-					check();
-				}
-			}, 16);
-
-		setTimeout(() => reject(new Error('Timeout launching browser')), 5000);
-		check();
-	});
-};
-
 export const getBrowserInstance = async (
-	logLevel: LogLevel,
-	indent: boolean,
 	chromiumOptions: ChromiumOptions,
 ): ReturnType<typeof openBrowser> => {
-	if (launching) {
-		await waitForLaunched();
-		if (!_browserInstance) {
-			throw new Error('expected to launch');
-		}
-
-		return _browserInstance;
-	}
-
-	if (_browserInstance) {
-		return _browserInstance;
-	}
-
-	launching = true;
-
 	const execPath = executablePath();
 
 	const actualChromiumOptions: ChromiumOptions = {
@@ -51,20 +13,11 @@ export const getBrowserInstance = async (
 		gl: chromiumOptions.gl ?? 'swangle',
 	};
 
-	_browserInstance = await RenderInternals.internalOpenBrowser({
-		browser: 'chrome',
+	const _browserInstance = await openBrowser('chrome', {
 		browserExecutable: execPath,
 		chromiumOptions: actualChromiumOptions,
 		forceDeviceScaleFactor: undefined,
-		indent: false,
-		viewport: null,
-		logLevel,
 	});
-	_browserInstance.on('disconnected', () => {
-		console.log('Browser disconnected / crashed');
-		_browserInstance?.close(true, logLevel, indent).catch(() => undefined);
-		_browserInstance = null;
-	});
-	launching = false;
+
 	return _browserInstance;
 };

--- a/packages/lambda/src/functions/index.ts
+++ b/packages/lambda/src/functions/index.ts
@@ -209,12 +209,6 @@ const routine = async (
 
 		responseStream.write(JSON.stringify(res));
 		responseStream.end();
-	} finally {
-		responseStream.on('close', () => {
-			if (!process.env.VITEST) {
-				process.exit(0);
-			}
-		});
 	}
 };
 

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -133,7 +133,7 @@ const innerLaunchHandler = async ({
 	const comp = await validateComposition({
 		serveUrl: params.serveUrl,
 		composition: params.composition,
-		browserInstance: await browserInstance,
+		browserInstance: (await browserInstance).instance,
 		serializedInputPropsWithCustomSchema,
 		envVariables: params.envVariables ?? {},
 		timeoutInMilliseconds: params.timeoutInMilliseconds,
@@ -355,7 +355,7 @@ const innerLaunchHandler = async ({
 	);
 
 	reqSend.end();
-	(await browserInstance).forgetEventLoop();
+	(await browserInstance).instance.forgetEventLoop();
 
 	const fps = comp.fps / params.everyNthFrame;
 	const postRenderData = await mergeChunksAndFinishRender({

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -111,11 +111,7 @@ const innerLaunchHandler = async ({
 
 	const startedDate = Date.now();
 
-	const browserInstance = await getBrowserInstance(
-		params.logLevel,
-		false,
-		params.chromiumOptions,
-	);
+	const browserInstance = await getBrowserInstance(params.chromiumOptions);
 
 	const inputPropsPromise = decompressInputProps({
 		bucketName: params.bucketName,
@@ -355,6 +351,10 @@ const innerLaunchHandler = async ({
 	);
 
 	reqSend.end();
+	browserInstance.close(true, params.logLevel, verbose).catch((err) => {
+		RenderInternals.Log.error('Failed to close browser instance:');
+		RenderInternals.Log.error(err);
+	});
 
 	const fps = comp.fps / params.everyNthFrame;
 	const postRenderData = await mergeChunksAndFinishRender({

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -111,7 +111,7 @@ const innerLaunchHandler = async ({
 
 	const startedDate = Date.now();
 
-	const browserInstance = await getBrowserInstance(params.chromiumOptions);
+	const browserInstance = getBrowserInstance(params.chromiumOptions);
 
 	const inputPropsPromise = decompressInputProps({
 		bucketName: params.bucketName,
@@ -129,7 +129,7 @@ const innerLaunchHandler = async ({
 	const comp = await validateComposition({
 		serveUrl: params.serveUrl,
 		composition: params.composition,
-		browserInstance,
+		browserInstance: await browserInstance,
 		serializedInputPropsWithCustomSchema,
 		envVariables: params.envVariables ?? {},
 		timeoutInMilliseconds: params.timeoutInMilliseconds,
@@ -351,7 +351,7 @@ const innerLaunchHandler = async ({
 	);
 
 	reqSend.end();
-	browserInstance.close(true, params.logLevel, verbose).catch((err) => {
+	(await browserInstance).close(true, params.logLevel, verbose).catch((err) => {
 		RenderInternals.Log.error('Failed to close browser instance:');
 		RenderInternals.Log.error(err);
 	});

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -355,10 +355,7 @@ const innerLaunchHandler = async ({
 	);
 
 	reqSend.end();
-	(await browserInstance).close(true, params.logLevel, verbose).catch((err) => {
-		RenderInternals.Log.error('Failed to close browser instance:');
-		RenderInternals.Log.error(err);
-	});
+	(await browserInstance).forgetEventLoop();
 
 	const fps = comp.fps / params.everyNthFrame;
 	const postRenderData = await mergeChunksAndFinishRender({

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -111,7 +111,11 @@ const innerLaunchHandler = async ({
 
 	const startedDate = Date.now();
 
-	const browserInstance = getBrowserInstance(params.chromiumOptions);
+	const browserInstance = getBrowserInstance(
+		params.logLevel,
+		false,
+		params.chromiumOptions,
+	);
 
 	const inputPropsPromise = decompressInputProps({
 		bucketName: params.bucketName,

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -268,9 +268,7 @@ const renderHandler = async (
 			downloadBehavior: null,
 			customCredentials: null,
 		}),
-		browserInstance.close(true, params.logLevel, false).catch((err) => {
-			console.log('Could not close browser instance', err);
-		}),
+		browserInstance.forgetEventLoop(),
 	]);
 	RenderInternals.Log.verbose('Done!');
 	return {};

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -64,11 +64,7 @@ const renderHandler = async (
 		propsType: 'resolved-props',
 	});
 
-	const browserInstance = await getBrowserInstance(
-		params.logLevel,
-		false,
-		params.chromiumOptions ?? {},
-	);
+	const browserInstance = await getBrowserInstance(params.chromiumOptions);
 
 	const outputPath = RenderInternals.tmpDir('remotion-render-');
 
@@ -268,7 +264,11 @@ const renderHandler = async (
 			downloadBehavior: null,
 			customCredentials: null,
 		}),
+		browserInstance.close(true, params.logLevel, false).catch((err) => {
+			console.log('Could not close browser instance', err);
+		}),
 	]);
+	RenderInternals.Log.verbose('Done!');
 	return {};
 };
 

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -64,7 +64,11 @@ const renderHandler = async (
 		propsType: 'resolved-props',
 	});
 
-	const browserInstance = await getBrowserInstance(params.chromiumOptions);
+	const browserInstance = await getBrowserInstance(
+		params.logLevel,
+		false,
+		params.chromiumOptions,
+	);
 
 	const outputPath = RenderInternals.tmpDir('remotion-render-');
 

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -172,7 +172,7 @@ const renderHandler = async (
 					renderId: params.renderId,
 				}).catch((err) => reject(err));
 			},
-			puppeteerInstance: browserInstance,
+			puppeteerInstance: browserInstance.instance,
 			serveUrl: params.serveUrl,
 			jpegQuality: params.jpegQuality ?? RenderInternals.DEFAULT_JPEG_QUALITY,
 			envVariables: params.envVariables ?? {},
@@ -269,7 +269,7 @@ const renderHandler = async (
 			customCredentials: null,
 		}),
 	]);
-	browserInstance.forgetEventLoop();
+	browserInstance.instance.forgetEventLoop();
 	RenderInternals.Log.verbose('Done!');
 	return {};
 };

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -268,8 +268,8 @@ const renderHandler = async (
 			downloadBehavior: null,
 			customCredentials: null,
 		}),
-		browserInstance.forgetEventLoop(),
 	]);
+	browserInstance.forgetEventLoop();
 	RenderInternals.Log.verbose('Done!');
 	return {};
 };

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -121,7 +121,7 @@ const innerStillHandler = async ({
 	const browserInstance = await browserInstancePromise;
 	const composition = await validateComposition({
 		serveUrl,
-		browserInstance,
+		browserInstance: browserInstance.instance,
 		composition: lambdaParams.composition,
 		serializedInputPropsWithCustomSchema,
 		envVariables: lambdaParams.envVariables ?? {},
@@ -185,7 +185,7 @@ const innerStillHandler = async ({
 		imageFormat: lambdaParams.imageFormat as StillImageFormat,
 		serializedInputPropsWithCustomSchema,
 		overwrite: false,
-		puppeteerInstance: browserInstance,
+		puppeteerInstance: browserInstance.instance,
 		jpegQuality:
 			lambdaParams.jpegQuality ?? RenderInternals.DEFAULT_JPEG_QUALITY,
 		chromiumOptions: lambdaParams.chromiumOptions,
@@ -246,7 +246,7 @@ const innerStillHandler = async ({
 		diskSizeInMb: MAX_EPHEMERAL_STORAGE_IN_MB,
 	});
 
-	browserInstance.forgetEventLoop();
+	browserInstance.instance.forgetEventLoop();
 
 	return {
 		type: 'success' as const,

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -75,21 +75,23 @@ const innerStillHandler = async ({
 
 	const start = Date.now();
 
-	const [bucketName, browserInstance] = await Promise.all([
+	const browserInstancePromise = getBrowserInstance(
+		lambdaParams.chromiumOptions,
+	);
+	const bucketNamePromise =
 		lambdaParams.bucketName ??
-			internalGetOrCreateBucket({
-				region: getCurrentRegionInFunction(),
-				enableFolderExpiry: null,
-				customCredentials: null,
-			}).then((b) => b.bucketName),
-		getBrowserInstance(lambdaParams.chromiumOptions),
-	]);
+		internalGetOrCreateBucket({
+			region: getCurrentRegionInFunction(),
+			enableFolderExpiry: null,
+			customCredentials: null,
+		}).then((b) => b.bucketName);
 
 	const outputDir = RenderInternals.tmpDir('remotion-render-');
 
 	const outputPath = path.join(outputDir, 'output');
 
 	const region = getCurrentRegionInFunction();
+	const bucketName = await bucketNamePromise;
 	const serializedInputPropsWithCustomSchema = await decompressInputProps({
 		bucketName,
 		expectedBucketOwner,
@@ -114,6 +116,7 @@ const innerStillHandler = async ({
 		offthreadVideoCacheSizeInBytes: lambdaParams.offthreadVideoCacheSizeInBytes,
 	});
 
+	const browserInstance = await browserInstancePromise;
 	const composition = await validateComposition({
 		serveUrl,
 		browserInstance,

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -76,6 +76,8 @@ const innerStillHandler = async ({
 	const start = Date.now();
 
 	const browserInstancePromise = getBrowserInstance(
+		lambdaParams.logLevel,
+		false,
 		lambdaParams.chromiumOptions,
 	);
 	const bucketNamePromise =

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -82,11 +82,7 @@ const innerStillHandler = async ({
 				enableFolderExpiry: null,
 				customCredentials: null,
 			}).then((b) => b.bucketName),
-		getBrowserInstance(
-			lambdaParams.logLevel,
-			false,
-			lambdaParams.chromiumOptions ?? {},
-		),
+		getBrowserInstance(lambdaParams.chromiumOptions),
 	]);
 
 	const outputDir = RenderInternals.tmpDir('remotion-render-');
@@ -243,6 +239,10 @@ const innerStillHandler = async ({
 		// We cannot determine the ephemeral storage size, so we
 		// overestimate the price, but will only have a miniscule effect (~0.2%)
 		diskSizeInMb: MAX_EPHEMERAL_STORAGE_IN_MB,
+	});
+
+	browserInstance.close(true, lambdaParams.logLevel, false).catch((err) => {
+		console.error('Failed to close browser instance', err);
 	});
 
 	return {

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -246,9 +246,7 @@ const innerStillHandler = async ({
 		diskSizeInMb: MAX_EPHEMERAL_STORAGE_IN_MB,
 	});
 
-	browserInstance.close(true, lambdaParams.logLevel, false).catch((err) => {
-		console.error('Failed to close browser instance', err);
-	});
+	browserInstance.forgetEventLoop();
 
 	return {
 		type: 'success' as const,

--- a/packages/renderer/src/browser/Browser.ts
+++ b/packages/renderer/src/browser/Browser.ts
@@ -72,16 +72,12 @@ export class HeadlessBrowser extends EventEmitter {
 	constructor(
 		connection: Connection,
 		defaultViewport: Viewport,
-		closeCallback?: BrowserCloseCallback,
+		closeCallback: BrowserCloseCallback,
 	) {
 		super();
 		this.#defaultViewport = defaultViewport;
 		this.connection = connection;
-		this.#closeCallback =
-			closeCallback ||
-			function () {
-				return undefined;
-			};
+		this.#closeCallback = closeCallback;
 
 		this.#defaultContext = new BrowserContext(this);
 		this.#contexts = new Map();

--- a/packages/renderer/src/browser/Browser.ts
+++ b/packages/renderer/src/browser/Browser.ts
@@ -44,16 +44,22 @@ export class HeadlessBrowser extends EventEmitter {
 		connection,
 		defaultViewport,
 		closeCallback,
+		forgetEventLoop,
+		rememberEventLoop,
 	}: {
 		connection: Connection;
 		defaultViewport: Viewport;
 		closeCallback: BrowserCloseCallback;
+		forgetEventLoop: () => void;
+		rememberEventLoop: () => void;
 	}): Promise<HeadlessBrowser> {
-		const browser = new HeadlessBrowser(
+		const browser = new HeadlessBrowser({
 			connection,
 			defaultViewport,
 			closeCallback,
-		);
+			forgetEventLoop,
+			rememberEventLoop,
+		});
 		await connection.send('Target.setDiscoverTargets', {discover: true});
 		return browser;
 	}
@@ -65,15 +71,26 @@ export class HeadlessBrowser extends EventEmitter {
 	#contexts: Map<string, BrowserContext>;
 	#targets: Map<string, Target>;
 
+	forgetEventLoop: () => void;
+	rememberEventLoop: () => void;
+
 	get _targets(): Map<string, Target> {
 		return this.#targets;
 	}
 
-	constructor(
-		connection: Connection,
-		defaultViewport: Viewport,
-		closeCallback: BrowserCloseCallback,
-	) {
+	constructor({
+		closeCallback,
+		connection,
+		defaultViewport,
+		forgetEventLoop,
+		rememberEventLoop,
+	}: {
+		connection: Connection;
+		defaultViewport: Viewport;
+		closeCallback: BrowserCloseCallback;
+		forgetEventLoop: () => void;
+		rememberEventLoop: () => void;
+	}) {
 		super();
 		this.#defaultViewport = defaultViewport;
 		this.connection = connection;
@@ -92,6 +109,8 @@ export class HeadlessBrowser extends EventEmitter {
 			'Target.targetInfoChanged',
 			this.#targetInfoChanged.bind(this),
 		);
+		this.forgetEventLoop = forgetEventLoop;
+		this.rememberEventLoop = rememberEventLoop;
 	}
 
 	browserContexts(): BrowserContext[] {

--- a/packages/renderer/src/browser/BrowserRunner.ts
+++ b/packages/renderer/src/browser/BrowserRunner.ts
@@ -169,11 +169,23 @@ export class BrowserRunner {
 	forgetEventLoop(): void {
 		assert(this.proc, 'BrowserRunner not started.');
 		this.proc.unref();
+		// @ts-expect-error
+		this.proc.stdout?.unref();
+		// @ts-expect-error
+		this.proc.stderr?.unref();
+		assert(this.connection, 'BrowserRunner not connected.');
+		this.connection.transport.forgetEventLoop();
 	}
 
 	rememberEventLoop(): void {
 		assert(this.proc, 'BrowserRunner not started.');
 		this.proc.ref();
+		// @ts-expect-error
+		this.proc.stdout?.ref();
+		// @ts-expect-error
+		this.proc.stderr?.ref();
+		assert(this.connection, 'BrowserRunner not connected.');
+		this.connection.transport.rememberEventLoop();
 	}
 
 	kill(): void {

--- a/packages/renderer/src/browser/BrowserRunner.ts
+++ b/packages/renderer/src/browser/BrowserRunner.ts
@@ -166,6 +166,16 @@ export class BrowserRunner {
 		return this.#processClosing;
 	}
 
+	forgetEventLoop(): void {
+		assert(this.proc, 'BrowserRunner not started.');
+		this.proc.unref();
+	}
+
+	rememberEventLoop(): void {
+		assert(this.proc, 'BrowserRunner not started.');
+		this.proc.ref();
+	}
+
 	kill(): void {
 		// If the process failed to launch (for example if the browser executable path
 		// is invalid), then the process does not get a pid assigned. A call to

--- a/packages/renderer/src/browser/Connection.ts
+++ b/packages/renderer/src/browser/Connection.ts
@@ -33,7 +33,7 @@ const ConnectionEmittedEvents = {
 } as const;
 
 export class Connection extends EventEmitter {
-	#transport: NodeWebSocketTransport;
+	transport: NodeWebSocketTransport;
 	#lastId = 0;
 	#sessions: Map<string, CDPSession> = new Map();
 	#closed = false;
@@ -42,9 +42,9 @@ export class Connection extends EventEmitter {
 	constructor(transport: NodeWebSocketTransport) {
 		super();
 
-		this.#transport = transport;
-		this.#transport.onmessage = this.#onMessage.bind(this);
-		this.#transport.onclose = this.#onClose.bind(this);
+		this.transport = transport;
+		this.transport.onmessage = this.#onMessage.bind(this);
+		this.transport.onclose = this.#onClose.bind(this);
 	}
 
 	static fromSession(session: CDPSession): Connection | undefined {
@@ -82,7 +82,7 @@ export class Connection extends EventEmitter {
 	_rawSend(message: Record<string, unknown>): number {
 		const id = ++this.#lastId;
 		const stringifiedMessage = JSON.stringify({...message, id});
-		this.#transport.send(stringifiedMessage);
+		this.transport.send(stringifiedMessage);
 		return id;
 	}
 
@@ -142,8 +142,8 @@ export class Connection extends EventEmitter {
 			return;
 		}
 
-		this.#transport.onmessage = undefined;
-		this.#transport.onclose = undefined;
+		this.transport.onmessage = undefined;
+		this.transport.onclose = undefined;
 		for (const callback of this.#callbacks.values()) {
 			callback.reject(
 				rewriteError(
@@ -164,7 +164,7 @@ export class Connection extends EventEmitter {
 
 	dispose(): void {
 		this.#onClose();
-		this.#transport.close();
+		this.transport.close();
 	}
 
 	/**

--- a/packages/renderer/src/browser/Launcher.ts
+++ b/packages/renderer/src/browser/Launcher.ts
@@ -94,6 +94,8 @@ export class ChromeLauncher implements ProductLauncher {
 				connection,
 				defaultViewport,
 				closeCallback: runner.close.bind(runner),
+				forgetEventLoop: runner.forgetEventLoop.bind(runner),
+				rememberEventLoop: runner.rememberEventLoop.bind(runner),
 			});
 		} catch (error) {
 			runner.kill();

--- a/packages/renderer/src/browser/NodeWebSocketTransport.ts
+++ b/packages/renderer/src/browser/NodeWebSocketTransport.ts
@@ -57,31 +57,41 @@ export class NodeWebSocketTransport implements ConnectionTransport {
 		});
 	}
 
-	#ws: WS;
+	websocket: WS;
 	onmessage?: (message: string) => void;
 	onclose?: () => void;
 
 	constructor(ws: WS) {
-		this.#ws = ws;
-		this.#ws.addEventListener('message', (event) => {
+		this.websocket = ws;
+		this.websocket.addEventListener('message', (event) => {
 			if (this.onmessage) {
 				this.onmessage.call(null, event.data as string);
 			}
 		});
-		this.#ws.addEventListener('close', () => {
+		this.websocket.addEventListener('close', () => {
 			if (this.onclose) {
 				this.onclose.call(null);
 			}
 		});
 		// Silently ignore all errors - we don't know what to do with them.
-		this.#ws.addEventListener('error', () => undefined);
+		this.websocket.addEventListener('error', () => undefined);
 	}
 
 	send(message: string): void {
-		this.#ws.send(message);
+		this.websocket.send(message);
 	}
 
 	close(): void {
-		this.#ws.close();
+		this.websocket.close();
+	}
+
+	forgetEventLoop(): void {
+		// @ts-expect-error
+		this.websocket._socket.unref();
+	}
+
+	rememberEventLoop(): void {
+		// @ts-expect-error
+		this.websocket._socket.ref();
 	}
 }

--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -23,6 +23,7 @@ const validRenderers = [
 
 type OpenGlRenderer = (typeof validRenderers)[number];
 
+// ⚠️ When adding new options, also add them to the hash in lambda/get-browser-instance.ts!
 export type ChromiumOptions = {
 	ignoreCertificateErrors?: boolean;
 	disableWebSecurity?: boolean;


### PR DESCRIPTION
- We don't call `process.exit(0)` anymore after a render, since the event loop leaks have been cleaned up.
- When possible, we re-use opened Chrome instances, and `unref` them so the Lambda shuts down correctly
- When the configuration changes (e.g. different `gl` value), we restart the browser

Finally solved all the tradeoffs!