### PR TITLE
`@remotion/renderer`: Use IPv6 for port binding

### DIFF
--- a/packages/cli/src/preview-server/start-server.ts
+++ b/packages/cli/src/preview-server/start-server.ts
@@ -111,7 +111,7 @@ export const startServer = async (options: {
 	const maxTries = 5;
 
 	// Default Node.js host, but explicity
-	const host = '0.0.0.0';
+	const host = '::';
 
 	for (let i = 0; i < maxTries; i++) {
 		try {
@@ -120,7 +120,7 @@ export const startServer = async (options: {
 					desiredPort,
 					from: 3000,
 					to: 3100,
-					hostsToTry: ['127.0.0.1', '0.0.0.0'],
+					hostsToTry: ['::1', '::'],
 				})
 					.then(({port, didUsePort}) => {
 						server.listen({

--- a/packages/renderer/src/get-port.ts
+++ b/packages/renderer/src/get-port.ts
@@ -98,7 +98,7 @@ export const getDesiredPort = async ({
 		typeof desiredPort !== 'undefined' &&
 		(await testPortAvailableOnMultipleHosts({
 			port: desiredPort,
-			hosts: ['0.0.0.0', '127.0.0.1'],
+			hosts: ['::', '::1'],
 		})) === 'available'
 	) {
 		return {port: desiredPort, didUsePort};

--- a/packages/renderer/src/serve-static.ts
+++ b/packages/renderer/src/serve-static.ts
@@ -72,7 +72,7 @@ export const serveStatic = async (
 	const maxTries = 5;
 
 	// Default Node.js host, but explicity
-	const host = '0.0.0.0';
+	const host = '::';
 	for (let i = 0; i < maxTries; i++) {
 		try {
 			selectedPort = await new Promise<number>((resolve, reject) => {
@@ -80,7 +80,7 @@ export const serveStatic = async (
 					desiredPort: options?.port ?? undefined,
 					from: 3000,
 					to: 3100,
-					hostsToTry: ['0.0.0.0', '127.0.0.1'],
+					hostsToTry: ['::', '::1'],
 				})
 					.then(({port, didUsePort}) => {
 						server.listen({port, host});

--- a/packages/renderer/src/test/port-selection.test.ts
+++ b/packages/renderer/src/test/port-selection.test.ts
@@ -8,13 +8,13 @@ test('Port selection should only be freed once the previous result has been used
 		desiredPort: undefined,
 		from: 3100,
 		to: 3200,
-		hostsToTry: ['0.0.0.0', '127.0.0.1'],
+		hostsToTry: ['::', '::1'],
 	});
 	const secondPort = getDesiredPort({
 		desiredPort: port,
 		from: 3100,
 		to: 3200,
-		hostsToTry: ['0.0.0.0', '127.0.0.1'],
+		hostsToTry: ['::', '::1'],
 	}).then(() => ports++);
 
 	await new Promise<void>((resolve) => {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
