### PR TITLE
`@remotion/renderer`: Only bind to IPv6 port if IPv6 network interface is available + Print original stack if symbolicated error did not yield stack frames

### DIFF
--- a/packages/bugs/api/[v].ts
+++ b/packages/bugs/api/[v].ts
@@ -9,8 +9,8 @@ type Bug = {
 const bugs: Bug[] = [
   {
     title: "Broken Lambda",
-    description: "Lambda rendering fails due to no IPv6 support on Lambda.",
-    link: "https://github.com/remotion-dev/remotion/issues/3018",
+    description: "Lambda rendering fails witg no IPv6 error.",
+    link: "https://github.com/remotion-dev/remotion/pull/3019",
     versions: ["4.0.49"],
   },
   {

--- a/packages/bugs/api/[v].ts
+++ b/packages/bugs/api/[v].ts
@@ -9,7 +9,7 @@ type Bug = {
 const bugs: Bug[] = [
   {
     title: "Broken Lambda",
-    description: "Lambda rendering fails witg no IPv6 error.",
+    description: "Lambda rendering fails with IPv6 error.",
     link: "https://github.com/remotion-dev/remotion/pull/3019",
     versions: ["4.0.49"],
   },

--- a/packages/cli/src/preview-server/start-server.ts
+++ b/packages/cli/src/preview-server/start-server.ts
@@ -110,8 +110,10 @@ export const startServer = async (options: {
 
 	const maxTries = 5;
 
-	// Default Node.js host, but explicity
-	const host = '::';
+	const host = RenderInternals.isIpV6Supported() ? '::' : '0.0.0.0';
+	const hostsToTry = RenderInternals.isIpV6Supported()
+		? ['::', '::1']
+		: ['0.0.0.0', '127.0.0.1'];
 
 	for (let i = 0; i < maxTries; i++) {
 		try {
@@ -120,7 +122,7 @@ export const startServer = async (options: {
 					desiredPort,
 					from: 3000,
 					to: 3100,
-					hostsToTry: ['::1', '::'],
+					hostsToTry,
 				})
 					.then(({port, didUsePort}) => {
 						server.listen({

--- a/packages/renderer/src/error-handling/handle-javascript-exception.ts
+++ b/packages/renderer/src/error-handling/handle-javascript-exception.ts
@@ -17,18 +17,22 @@ export class ErrorWithStackFrame extends Error {
 		frame,
 		name,
 		delayRenderCall,
+		stack,
 	}: {
 		message: string;
 		symbolicatedStackFrames: SymbolicatedStackFrame[] | null;
 		frame: number | null;
 		name: string;
 		delayRenderCall: SymbolicatedStackFrame[] | null;
+		stack: string | undefined;
 	}) {
 		super(message);
 		this.symbolicatedStackFrames = symbolicatedStackFrames;
 		this.frame = frame;
 		this.name = name;
 		this.delayRenderCall = delayRenderCall;
+		// If error symbolication did not yield any stack frames, we print the original stack
+		this.stack = stack;
 	}
 }
 

--- a/packages/renderer/src/error-handling/symbolicate-error.ts
+++ b/packages/renderer/src/error-handling/symbolicate-error.ts
@@ -23,6 +23,7 @@ export const symbolicateError = async (
 		frame: symbolicateableError.frame,
 		name: symbolicateableError.name,
 		delayRenderCall: delayRenderFrames,
+		stack: symbolicateableError.stack,
 	});
 
 	return symbolicatedErr;

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -45,6 +45,7 @@ import {
 	validVideoImageFormats,
 } from './image-format';
 import {isAudioCodec} from './is-audio-codec';
+import {isIpV6Supported} from './is-ipv6-supported';
 import {isServeUrl} from './is-serve-url';
 import {DEFAULT_JPEG_QUALITY, validateJpegQuality} from './jpeg-quality';
 import {isEqualOrBelowLogLevel, isValidLogLevel, logLevels} from './log-level';
@@ -215,6 +216,7 @@ export const RenderInternals = {
 	internalRenderMedia,
 	validOpenGlRenderers,
 	copyImageToClipboard,
+	isIpV6Supported,
 };
 
 // Warn of potential performance issues with Apple Silicon (M1 chip under Rosetta)

--- a/packages/renderer/src/is-ipv6-supported.ts
+++ b/packages/renderer/src/is-ipv6-supported.ts
@@ -1,6 +1,8 @@
 import os from 'os';
 
-export const isIpV6Supported = (): boolean => {
+let cache: null | boolean = null;
+
+const calculate = (): boolean => {
 	const interfaces = os.networkInterfaces();
 
 	for (const iface in interfaces) {
@@ -14,4 +16,12 @@ export const isIpV6Supported = (): boolean => {
 	}
 
 	return false;
+};
+
+export const isIpV6Supported = (): boolean => {
+	if (cache === null) {
+		cache = calculate();
+	}
+
+	return cache;
 };

--- a/packages/renderer/src/is-ipv6-supported.ts
+++ b/packages/renderer/src/is-ipv6-supported.ts
@@ -1,0 +1,17 @@
+import os from 'os';
+
+export const isIpV6Supported = (): boolean => {
+	const interfaces = os.networkInterfaces();
+
+	for (const iface in interfaces) {
+		for (const configuration of interfaces[
+			iface
+		] as os.NetworkInterfaceInfo[]) {
+			if (configuration.family === 'IPv6' && !configuration.internal) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+};


### PR DESCRIPTION
Accidentially put two features into one PR:

`@remotion/renderer`: Print original stack if symbolicated error did not yield stack frames
`@remotion/renderer`: Only bind to IPv6 port if IPv6 network interface is available - fixes a Lambda issue in v4.0...49