### PR TITLE
`@remotion/preload`: use preload="metadata" on ios safari for `preloadVideo()` and `preloadAudio()`

### DIFF
--- a/packages/preload/src/preload-asset.ts
+++ b/packages/preload/src/preload-asset.ts
@@ -2,6 +2,13 @@ import {resolveRedirect} from './resolve-redirect';
 
 const typesAllowed = ['video', 'audio', 'image', 'font'] as const;
 
+export const isIosSafari = () => {
+	return typeof window === 'undefined'
+		? false
+		: /iP(ad|od|hone)/i.test(window.navigator.userAgent) &&
+				Boolean(navigator.userAgent.match(/Version\/[\d.]+.*Safari/));
+};
+
 export const preloadAsset = (
 	src: string,
 	elemType: (typeof typesAllowed)[number],
@@ -52,7 +59,10 @@ export const preloadAsset = (
 	}
 
 	const elem = document.createElement(elemType);
-	elem.preload = 'auto';
+	elem.preload =
+		(elemType === 'video' || elemType === 'audio') && isIosSafari()
+			? 'metadata'
+			: 'auto';
 	elem.controls = true;
 
 	elem.style.display = 'none';


### PR DESCRIPTION
We now know this better and Mobile Safari will not preload a video with `preload="auto"`, but with `preload="metadata"`