### PR TITLE
@remotion/lambda: Add Remotion + Version tag when deploying function

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -145,10 +145,6 @@ jobs:
         run: |
           choco install mingw --version=11.2.0 --allow-downgrade
         if: matrix.os == 'windows-latest'
-      - name: Downgrade Rust
-        run: |
-          rustup install 1.72
-          rustup default 1.72
       - uses: actions/checkout@main
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -145,6 +145,10 @@ jobs:
         run: |
           choco install mingw --version=11.2.0 --allow-downgrade
         if: matrix.os == 'windows-latest'
+      - name: Downgrade Rust
+        run: |
+          rustup install 1.72
+          rustup default 1.72
       - uses: actions/checkout@main
       - uses: actions/setup-node@v3
         with:

--- a/packages/docs/docs/lambda/permissions.md
+++ b/packages/docs/docs/lambda/permissions.md
@@ -150,17 +150,19 @@ The following table is a breakdown of why Remotion Lambda requires the permissio
   </tr>
   <tr>
     <td>
-      <code>logs:InvokeAsync</code> <br/>
-      <code>logs:InvokeFunction</code> <br/>
-      <code>logs:DeleteFunction</code> <br/>
-      <code>logs:PutFunctionEventInvokeConfig</code> <br/>
-      <code>logs:CreateFunction</code> <br/>
+      <code>lambda:InvokeAsync</code> <br/>
+      <code>lambda:InvokeFunction</code> <br/>
+      <code>lambda:DeleteFunction</code> <br/>
+      <code>lambda:PutFunctionEventInvokeConfig</code> <br/>
+      <code>lambda:CreateFunction</code> <br/>
+      <code>lambda:PutRuntimeManagementConfig</code> <br/>
+      <code>lambda:TagResource</code> <br/>
     </td>
     <td>
       <code>{"arn:aws:lambda:*:*:function:remotion-render-*"}</code>
     </td>
     <td>
-    Allows to create, delete, invoke and configure functions (such as disabling automatic retries). Used by the CLI and the Node.JS APIS to set up, execute and teardown the infrastructure.
+    Allows to create, delete, invoke and configure functions (such as disabling automatic retries). Used by the CLI and the Node.JS APIS to set up, execute and teardown the infrastructure. <code>lambda:TagResource</code> will optionally tag the functions 
     </td>
   </tr>
   <tr>

--- a/packages/lambda/src/api/create-function.ts
+++ b/packages/lambda/src/api/create-function.ts
@@ -99,6 +99,9 @@ export const createFunction = async ({
 				Tags: {
 					'remotion-lambda': 'true',
 					'remotion-version': VERSION,
+					'remotion-memory-in-mb': String(memorySizeInMb),
+					'remotion-timeout-in-seconds': String(timeoutInSeconds),
+					'remotion-ephemereal-storage-in-mb': String(ephemerealStorageInMb),
 				},
 			}),
 		);

--- a/packages/lambda/src/api/iam-validation/user-permissions.ts
+++ b/packages/lambda/src/api/iam-validation/user-permissions.ts
@@ -75,6 +75,7 @@ export const requiredPermissions: {
 			lambda.DeleteFunction,
 			lambda.PutFunctionEventInvokeConfig,
 			'lambda:PutRuntimeManagementConfig',
+			lambda.TagResource,
 		],
 		resource: [`arn:aws:lambda:*:*:function:${RENDER_FN_PREFIX}*`],
 	},


### PR DESCRIPTION
This is optional, needs `lambda:TagResource` permission