### PR TITLE
Change ANGLE backend to gl-egl

### DIFF
--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -31,7 +31,7 @@ const getOpenGlRenderer = (option?: OpenGlRenderer | null): string[] => {
 	}
 
 	if (renderer === 'angle-egl') {
-		return [`--use-gl=angle`, `--use-angle=egl`];
+		return [`--use-gl=angle`, `--use-angle=gl-egl`];
 	}
 
 	if (renderer === 'vulkan') {


### PR DESCRIPTION
The headless GPU rendering was broken, we did some research and testing and were initially able to make `Chrome/Chromium` run in headless mode. We figured out that only `ANGLE` with `OpenGL (GL)` backed with `EGL` for rendering works in headless mode. So we decided to use `--use-gl=angle` and `--use-angle=gl-egl` in combination. 

This pull request updates `--use-angle` flag to `--use-angle=gl-egl`. The change has been tested on AWS `g4dn.xlarge` instance.

The detailed instructions to setup AWS Instance to execute GPU workload are mentioned in the documentation at
[Using the GPU in the cloud](https://remotion-git-gpu-on-ec2-remotion.vercel.app/docs/miscellaneous/cloud-gpu#launch-an-ec2-instance)