### PR TITLE
Remotion Studio: Fix crash with @remotion/transitions

### DIFF
--- a/packages/cli/src/editor/components/Timeline/is-collapsed.ts
+++ b/packages/cli/src/editor/components/Timeline/is-collapsed.ts
@@ -25,6 +25,12 @@ export const isTrackHidden = (
 		(t) => t.sequence.id === track.sequence.parent,
 	) as TrackWithHash;
 
+	// Due to effects and conditional `showInTimeline`, a parent
+	// may not exist in the `allTracks` array.
+	if (!parent) {
+		return true;
+	}
+
 	if (isTrackCollapsed(parent.hash, viewState)) {
 		return true;
 	}

--- a/packages/cli/src/editor/helpers/get-timeline-sequence-sort-key.ts
+++ b/packages/cli/src/editor/helpers/get-timeline-sequence-sort-key.ts
@@ -33,7 +33,9 @@ export const getTimelineSequenceSequenceSortKey = (
 
 	const parent = tracks.find((t) => t.sequence.id === track.sequence.parent);
 	if (!parent) {
-		throw new Error('Cannot find parent');
+		// Due to effects and conditional `showInTimeline`, a parent
+		// may not exist in the `allTracks` array.
+		return id;
 	}
 
 	const firstParentWithSameHash = tracks.find((a) => {


### PR DESCRIPTION
`showInTimeline` will hide a sequence, but registerSequence / unregisterSequence is asynchronous, so the state is sometimes wrong 