### PR TITLE
check if process.report is undefined with bun

### DIFF
--- a/packages/renderer/src/compositor/get-executable-path.ts
+++ b/packages/renderer/src/compositor/get-executable-path.ts
@@ -7,7 +7,7 @@ let warned = false;
 
 function isMusl({indent, logLevel}: {indent: boolean; logLevel: LogLevel}) {
 	// @ts-expect-error bun no types
-	if (process.report && typeof Bun !== 'undefined') {
+	if (!process.report && typeof Bun !== 'undefined') {
 		if (!warned) {
 			Log.warnAdvanced(
 				{indent, logLevel},


### PR DESCRIPTION
Related to #3062
Just a small fix on the changes at #3063 to check if process.report is undefined in case of using Bun.