### PR TITLE
Better docs for getWaveformPortion() and getAudioData()

### DIFF
--- a/packages/docs/docs/get-audio-data.md
+++ b/packages/docs/docs/get-audio-data.md
@@ -36,14 +36,43 @@ A string pointing to an audio asset.
 
 ## Return value
 
-`Promise<AudioData>` - object with information about the audio data:
+_`Promise<AudioData>`_
 
-- `channelWaveforms`: `Float32Array[]` an array with waveform information for each channel.
-- `sampleRate`: `number` How many samples per second each waveform contains.
-- `durationInSeconds`: `number` The duration of the audio in seconds.
-- `numberOfChannels`: `number` The number of channels contained in the audio file. This corresponds to the length of the `channelWaveforms` array.
-- `resultId`: `string` Unique identifier of this audio data fetching call. Other functions can cache expensive operations if they get called with the same resultId multiple times.
-- `isRemote`: `boolean` Whether the audio was imported locally or from a different origin.
+An object with information about the audio data:
+
+### `channelWaveforms`
+
+_Float32Array[]_
+
+An array with waveform information for each channel.
+
+### `sampleRate`
+
+_number_
+
+How many samples per second each waveform contains.
+
+### `durationInSeconds`
+
+_number_
+
+The duration of the audio in seconds.
+
+### `numberOfChannels`
+
+_number_
+
+The number of channels contained in the audio file. This corresponds to the length of the `channelWaveforms` array.
+
+### `resultId`
+
+_string_ Unique identifier of this audio data fetching call. Other functions can cache expensive operations if they get called with the same resultId multiple times.
+
+### `isRemote`
+
+_boolean_
+
+Whether the audio was imported locally or from a different origin.
 
 ## Example
 
@@ -81,10 +110,18 @@ await getAudioData(staticFile("my-file.wav")); /* {
 } */
 ```
 
+## Errors
+
+If you pass in a file that has no audio track, this function will throw an error you need to handle.
+
+To determine if a file has an audio track, you may use the [`getVideoMetadata()`](/docs/renderer/get-video-metadata#audiocodec) function on the server to reject a file if it has no audio track. To do so, check if the `audioCodec` field is `null`.
+
 ## Caching behavior
 
 This function is memoizing the results it returns.
-If you pass in the same argument to `src` multiple times, it will return a cached version from the second time on, regardless of if the file has changed. To clear the cache, you have to reload the page.
+
+If you pass in the same argument to `src` multiple times, it will return a cached version from the second time on, regardless of if the file has changed.  
+To clear the cache, you have to reload the page.
 
 ## Alternatives
 

--- a/packages/docs/docs/get-waveform-portion.md
+++ b/packages/docs/docs/get-waveform-portion.md
@@ -11,21 +11,47 @@ Takes bulky waveform data (for example fetched by [`getAudioData()`](/docs/get-a
 
 ## Arguments
 
-### `options`
-
 An object with the following arguments:
 
-- `audioData`: `AudioData` - information about the audio. Use [`getAudioData()`](/docs/get-audio-data) to fetch it.
-- `startTimeInSeconds`: `number` - trim the waveform to exclude all data before `startTimeInSeconds`.
-- `durationInSeconds`: `number` - trim the waveform to exclude all data after `startTimeInSeconds + durationInSeconds`.
-- `numberOfSamples`: `number` - how big you want the result array to be. The function will compress the waveform to fit in `numberOfSamples` data points.
+### `audioData`
+
+_AudioData_
+
+Information about the audio. Use [`getAudioData()`](/docs/get-audio-data) to fetch it.
+
+### `startTimeInSeconds`
+
+_number_
+
+Trim the waveform to exclude all data before `startTimeInSeconds`.
+
+### `durationInSeconds`
+
+_number_
+
+trim the waveform to exclude all data after `startTimeInSeconds + durationInSeconds`.
+
+### `numberOfSamples`
+
+_number_
+
+How big you want the result array to be. The function will compress the waveform to fit in `numberOfSamples` data points.
 
 ## Return value
 
 `Bar[]` - An array of objects with the following properties:
 
-- `index`: `number` - the index of the datapoint, starting at 0. Useful for specifying as React `key` attribute without getting a warning.
-- `amplitude`: `number` - a value describing the amplitude / volume / loudness of the audio.
+### `index`
+
+_number_
+
+The index of the datapoint, starting at 0. Useful for specifying as React `key` attribute without getting a warning.
+
+### `amplitude`
+
+_number_
+
+A value describing the amplitude / volume / loudness of the audio. Values range between 0 and 1.
 
 ## Example
 
@@ -52,7 +78,7 @@ const waveformPortion = await getWaveformPortion({
   startTimeInSeconds: 20,
   durationInSeconds: 20,
   numberOfSamples: 10,
-}); // [{index: 0, amplitude: 1.2203}, ... {index: 9, amplitude: 3.2211}]
+}); // [{index: 0, amplitude: 0.14}, ... {index: 9, amplitude: 0.79}]
 
 console.log(waveformPortion.length); // 10
 ```

--- a/packages/docs/docs/renderer/extract-audio.md
+++ b/packages/docs/docs/renderer/extract-audio.md
@@ -5,7 +5,7 @@ title: extractAudio()
 crumb: "@remotion/renderer"
 ---
 
-# extractAudio()`<AvailableFrom v="4.0.49" />`
+# extractAudio()<AvailableFrom v="4.0.49" />
 
 :::note
 This function is meant to be used **in Node.js applications**. It cannot run in the browser.

--- a/packages/docs/docs/use-audio-data.md
+++ b/packages/docs/docs/use-audio-data.md
@@ -62,6 +62,14 @@ export const MyComponent: React.FC = () => {
 };
 ```
 
+## Errors
+
+If you pass in a file that has no audio track, this hook will throw an error.
+
+To determine if a file has an audio track, you may use the [`getVideoMetadata()`](/docs/renderer/get-video-metadata#audiocodec) function on the server to reject a file if it has no audio track. To do so, check if the `audioCodec` field is `null`.
+
+If you want to catch the error in the component, you need to make your own inline hook by taking the source code from the bottom of this page.
+
 ## See also
 
 - [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/media-utils/src/use-audio-data.ts)

--- a/packages/example/src/DropDots/DropDots.tsx
+++ b/packages/example/src/DropDots/DropDots.tsx
@@ -146,7 +146,7 @@ const DropDots: React.FC<{
 									marginLeft: d.size * 0.05,
 									opacity: 0.55,
 								}}
-								src="https://github.com/remotion-dev/logo/blob/main/monochromatic/element-0.png?raw=true"
+								src="https://github.com/remotion-dev/brand/blob/main/withouttitle/element-0.png?raw=true"
 							/>
 						</div>
 					</div>


### PR DESCRIPTION
- Mistake in getWaveformPortion(): The returned data is is normalized to be inbetween 0 and 1.
- Mention that getAudioData() may throw an error if the asset has no audio track