### PR TITLE
`@remotion/renderer`: Support the case of stride != width * 3 when rotating a video file

### DIFF
--- a/packages/renderer/rust/scalable_frame.rs
+++ b/packages/renderer/rust/scalable_frame.rs
@@ -183,11 +183,13 @@ pub fn scale_and_make_bitmap(
             scaled.data(0),
             native_frame.scaled_width,
             native_frame.scaled_height,
+            scaled.stride(0),
         ),
         Rotate::Rotate180 => rotate_180(
             scaled.data(0),
             native_frame.scaled_width,
             native_frame.scaled_height,
+            scaled.stride(0),
         ),
         Rotate::Rotate270 => rotate_270(
             scaled.data(0),
@@ -255,34 +257,45 @@ pub fn rotate_270(
     (new_data, height, width, new_stride)
 }
 
-pub fn rotate_180(data: &[u8], width: u32, height: u32) -> (Vec<u8>, u32, u32, usize) {
-    let mut new_data: Vec<u8> = vec![0; data.len()];
+pub fn rotate_180(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    stride: usize,
+) -> (Vec<u8>, u32, u32, usize) {
+    let mut new_data: Vec<u8> = vec![0; stride * height as usize];
 
     for y in 0..height {
         for x in 0..width {
             let new_x = width - x - 1;
             let new_y = height - y - 1;
-            let new_index = (new_y * width + new_x) as usize * 3;
-            let old_index = (y * width + x) as usize * 3;
+            let new_index = (new_y as usize * stride) + (new_x as usize * 3);
+            let old_index = (y as usize * stride) + (x as usize * 3);
             new_data[new_index..new_index + 3].copy_from_slice(&data[old_index..old_index + 3]);
         }
     }
 
-    (new_data, width, height, width as usize * 3)
+    (new_data, width, height, stride)
 }
 
-pub fn rotate_90(data: &[u8], width: u32, height: u32) -> (Vec<u8>, u32, u32, usize) {
-    let mut new_data: Vec<u8> = vec![0; data.len()];
+pub fn rotate_90(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    stride: usize,
+) -> (Vec<u8>, u32, u32, usize) {
+    let new_stride = (height as usize * 3 + 3) & !3; // This ensures the new stride is a multiple of 4 for alignment
+    let mut new_data: Vec<u8> = vec![0; new_stride * width as usize];
 
     for y in 0..height {
         for x in 0..width {
             let new_x = height - y - 1;
             let new_y = x;
-            let new_index = (new_y * height + new_x) as usize * 3;
-            let old_index = (y * width + x) as usize * 3;
+            let new_index = (new_y as usize * new_stride) + (new_x as usize * 3);
+            let old_index = (y as usize * stride) + (x as usize * 3);
             new_data[new_index..new_index + 3].copy_from_slice(&data[old_index..old_index + 3]);
         }
     }
 
-    (new_data, height, width, height as usize * 3)
+    (new_data, height, width, new_stride)
 }

--- a/packages/renderer/rust/scalable_frame.rs
+++ b/packages/renderer/rust/scalable_frame.rs
@@ -193,6 +193,7 @@ pub fn scale_and_make_bitmap(
             scaled.data(0),
             native_frame.scaled_width,
             native_frame.scaled_height,
+            scaled.stride(0),
         ),
         Rotate::Rotate0 => (
             scaled.data(0).to_vec(),
@@ -232,20 +233,26 @@ pub fn scale_and_make_bitmap(
     ))
 }
 
-pub fn rotate_270(data: &[u8], width: u32, height: u32) -> (Vec<u8>, u32, u32, usize) {
-    let mut new_data: Vec<u8> = vec![0; data.len()];
+pub fn rotate_270(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    stride: usize,
+) -> (Vec<u8>, u32, u32, usize) {
+    let new_stride = (height as usize * 3 + 3) & !3; // This ensures the new stride is a multiple of 4 for alignment
+    let mut new_data: Vec<u8> = vec![0; new_stride * width as usize];
 
     for y in 0..height {
         for x in 0..width {
             let new_x = y;
             let new_y = width - x - 1;
             let new_index = (new_y * height + new_x) as usize * 3;
-            let old_index = (y * width + x) as usize * 3;
+            let old_index = y as usize * stride + x as usize * 3;
             new_data[new_index..new_index + 3].copy_from_slice(&data[old_index..old_index + 3]);
         }
     }
 
-    (new_data, height, width, height as usize * 3)
+    (new_data, height, width, new_stride)
 }
 
 pub fn rotate_180(data: &[u8], width: u32, height: u32) -> (Vec<u8>, u32, u32, usize) {


### PR DESCRIPTION
Fixes customstride.mov in testbed