### PR TITLE
Added a callback function to mimic the  property of the High-level API

### DIFF
--- a/packages/docs/docs/rive/remotionrivecanvas.md
+++ b/packages/docs/docs/rive/remotionrivecanvas.md
@@ -33,7 +33,7 @@ Either a `string` specifying the animation name, a `number` specifying the anima
 
 ### `onLoad?`<AvailableFrom v="4.0.58" />
 
-A callback function that will be executed when the Rive Runtime is loaded. The argument callback is an object of type `RiveCanvas`
+A callback function that will be executed when the Rive Runtime is loaded. The argument callback is an object of type Rive `File`
 
 ## Basic Example
 
@@ -52,12 +52,12 @@ more information about Text Runs on Rive.
 
 ```tsx twoslash
 import { RemotionRiveCanvas } from "@remotion/rive";
-import { RiveCanvas } from "@rive-app/canvas-advanced";
+import { File } from "@rive-app/canvas-advanced";
 import { useCallback } from "react";
 
 // Make sure to wrap your onLoad handler on `useCallback` to avoid re-rendering this component every single time
-const onLoadHandler = useCallback((rive: RiveCanvas) => {
-  const artboard = rive.defaultArtboard();
+const onLoadHandler = useCallback((file: File) => {
+  const artboard = file.defaultArtboard();
   const textRun = artboard.textRun("city");
   textRun.text = "Tokyo";
 }, []);

--- a/packages/docs/docs/rive/remotionrivecanvas.md
+++ b/packages/docs/docs/rive/remotionrivecanvas.md
@@ -31,13 +31,39 @@ Either a `string` specifying the artboard name, a `number` specifying the artboa
 
 Either a `string` specifying the animation name, a `number` specifying the animation index, otherwise the default animation is being used.
 
-## Example
+### `onLoad?`
+
+A callback function that will be executed when the Rive Runtime is loaded. The argument callback is an object of type `RiveCanvas`
+
+## Basic Example
 
 ```tsx twoslash
 import { RemotionRiveCanvas } from "@remotion/rive";
 
 function App() {
   return <RemotionRiveCanvas src="https://example.com/myAnimation.riv" />;
+}
+```
+
+## Set Text Run at Runtime Example
+
+This example assumes that your Rive animation has a text run named "city". See [here](https://help.rive.app/runtimes/text#low-level-api-usage) for
+more information about Text Runs on Rive.
+
+```tsx twoslash
+import { useCallback } from 'react';
+import { RemotionRiveCanvas } from "@remotion/rive";
+import { RiveCanvas } from "@rive-app/canvas-advanced";
+
+// Make sure to wrap your onLoad handler on `useCallback` to avoid re-rendering this component every single time
+const onLoadHandler = useCallback((rive: RiveCanvas) => {
+  const artboard = rive.defaultArtboard()
+  const textRun = artboard.textRun("city")
+  textRun.text = "Tokyo"
+}, [])
+
+function App() {
+  return <RemotionRiveCanvas src="https://example.com/myAnimation.riv" onLoad={onLoadHandler} />;
 }
 ```
 

--- a/packages/docs/docs/rive/remotionrivecanvas.md
+++ b/packages/docs/docs/rive/remotionrivecanvas.md
@@ -31,7 +31,7 @@ Either a `string` specifying the artboard name, a `number` specifying the artboa
 
 Either a `string` specifying the animation name, a `number` specifying the animation index, otherwise the default animation is being used.
 
-### `onLoad?`
+### `onLoad?`<AvailableFrom v="4.0.58" />
 
 A callback function that will be executed when the Rive Runtime is loaded. The argument callback is an object of type `RiveCanvas`
 
@@ -51,19 +51,24 @@ This example assumes that your Rive animation has a text run named "city". See [
 more information about Text Runs on Rive.
 
 ```tsx twoslash
-import { useCallback } from 'react';
 import { RemotionRiveCanvas } from "@remotion/rive";
 import { RiveCanvas } from "@rive-app/canvas-advanced";
+import { useCallback } from "react";
 
 // Make sure to wrap your onLoad handler on `useCallback` to avoid re-rendering this component every single time
 const onLoadHandler = useCallback((rive: RiveCanvas) => {
-  const artboard = rive.defaultArtboard()
-  const textRun = artboard.textRun("city")
-  textRun.text = "Tokyo"
-}, [])
+  const artboard = rive.defaultArtboard();
+  const textRun = artboard.textRun("city");
+  textRun.text = "Tokyo";
+}, []);
 
 function App() {
-  return <RemotionRiveCanvas src="https://example.com/myAnimation.riv" onLoad={onLoadHandler} />;
+  return (
+    <RemotionRiveCanvas
+      src="https://example.com/myAnimation.riv"
+      onLoad={onLoadHandler}
+    />
+  );
 }
 ```
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -50,6 +50,7 @@
     "@remotion/transitions": "workspace:*",
     "@remotion/three": "workspace:*",
     "@remotion/layout-utils": "workspace:*",
+    "@rive-app/canvas-advanced": "2.3.0",
     "@shopify/react-native-skia": "^0.1.191",
     "@swc/core": "^1.3.80",
     "@types/uuid": "^8.3.4",

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -1,6 +1,7 @@
 import type {
 	Artboard,
 	CanvasRenderer,
+	File,
 	LinearAnimationInstance,
 	RiveCanvas,
 } from '@rive-app/canvas-advanced';
@@ -18,7 +19,7 @@ import type {
 } from './map-enums.js';
 import {mapToAlignment, mapToFit} from './map-enums.js';
 
-type onLoadCallback = (rive: RiveCanvas) => void;
+type onLoadCallback = (file: File) => void;
 
 interface RiveProps {
 	src: string;
@@ -101,7 +102,7 @@ export const RemotionRiveCanvas: React.FC<RiveProps> = ({
 						renderer,
 					});
 					if (onLoad) {
-						onLoad(riveCanvasInstance);
+						onLoad(file);
 					}
 				});
 			})

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -18,7 +18,7 @@ import type {
 } from './map-enums.js';
 import {mapToAlignment, mapToFit} from './map-enums.js';
 
-type onLoadCallback = (rive: RiveCanvas) => void
+type onLoadCallback = (rive: RiveCanvas) => void;
 
 interface RiveProps {
 	src: string;
@@ -28,8 +28,6 @@ interface RiveProps {
 	animation?: string | number;
 	onLoad?: onLoadCallback | null;
 }
-
-
 
 export const RemotionRiveCanvas: React.FC<RiveProps> = ({
 	src,

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -18,13 +18,18 @@ import type {
 } from './map-enums.js';
 import {mapToAlignment, mapToFit} from './map-enums.js';
 
+type onLoadCallback = (rive: RiveCanvas) => void
+
 interface RiveProps {
 	src: string;
 	fit?: RemotionRiveCanvasFit;
 	alignment?: RemotionRiveCanvasAlignment;
 	artboard?: string | number;
 	animation?: string | number;
+	onLoad?: onLoadCallback | null;
 }
+
+
 
 export const RemotionRiveCanvas: React.FC<RiveProps> = ({
 	src,
@@ -32,6 +37,7 @@ export const RemotionRiveCanvas: React.FC<RiveProps> = ({
 	alignment = 'center',
 	artboard: artboardName,
 	animation: animationIndex,
+	onLoad = null,
 }) => {
 	const {width, fps, height} = useVideoConfig();
 	const frame = useCurrentFrame();
@@ -96,12 +102,15 @@ export const RemotionRiveCanvas: React.FC<RiveProps> = ({
 						artboard,
 						renderer,
 					});
+					if (onLoad) {
+						onLoad(riveCanvasInstance);
+					}
 				});
 			})
 			.catch((newErr) => {
 				setError(newErr);
 			});
-	}, [animationIndex, artboardName, riveCanvasInstance, src]);
+	}, [animationIndex, artboardName, riveCanvasInstance, src, onLoad]);
 
 	React.useEffect(() => {
 		if (!riveCanvasInstance) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -612,6 +612,9 @@ importers:
       '@remotion/transitions':
         specifier: workspace:*
         version: link:../transitions
+      '@rive-app/canvas-advanced':
+        specifier: 2.3.0
+        version: 2.3.0
       '@shopify/react-native-skia':
         specifier: ^0.1.191
         version: 0.1.191(react@18.0.0)


### PR DESCRIPTION
Rive provides ways multiple ways to programatically change their animations by using State Machines and Text Runs. Being able to hook into the underlying RiveCanvas would be nice to change these programatically. By adding a `onLoad` callback to the props for this component we can mimic the behaviour of the High-Level API provided by Rive.
