### PR TITLE
`@remotion/renderer`: Test for ipv4 and ipv6 when binding a port

### DIFF
--- a/packages/cli/src/preview-server/start-server.ts
+++ b/packages/cli/src/preview-server/start-server.ts
@@ -113,10 +113,7 @@ export const startServer = async (options: {
 
 	const maxTries = 5;
 
-	const host = RenderInternals.isIpV6Supported() ? '::' : '0.0.0.0';
-	const hostsToTry = RenderInternals.isIpV6Supported()
-		? ['::', '::1']
-		: ['0.0.0.0', '127.0.0.1'];
+	const portConfig = RenderInternals.getPortConfig();
 
 	for (let i = 0; i < maxTries; i++) {
 		try {
@@ -125,12 +122,12 @@ export const startServer = async (options: {
 					desiredPort,
 					from: 3000,
 					to: 3100,
-					hostsToTry,
+					hostsToTry: portConfig.hostsToTry,
 				})
 					.then(({port, didUsePort}) => {
 						server.listen({
 							port,
-							host,
+							host: portConfig.host,
 						});
 						server.on('listening', () => {
 							resolve(port);

--- a/packages/renderer/src/get-port.ts
+++ b/packages/renderer/src/get-port.ts
@@ -1,4 +1,5 @@
 import net from 'net';
+import {isIpV6Supported} from './is-ipv6-supported';
 import {createLock} from './locks';
 
 type PortStatus = 'available' | 'unavailable';
@@ -80,6 +81,15 @@ const getPort = async ({
 
 const portLocks = createLock({timeout: 10000});
 
+export const getPortConfig = () => {
+	const host = isIpV6Supported() ? '::' : '0.0.0.0';
+	const hostsToTry = isIpV6Supported()
+		? ['::', '::1', '0.0.0.0', '127.0.0.1']
+		: ['0.0.0.0', '127.0.0.1'];
+
+	return {host, hostsToTry};
+};
+
 export const getDesiredPort = async ({
 	desiredPort,
 	from,
@@ -98,7 +108,7 @@ export const getDesiredPort = async ({
 		typeof desiredPort !== 'undefined' &&
 		(await testPortAvailableOnMultipleHosts({
 			port: desiredPort,
-			hosts: ['::', '::1'],
+			hosts: hostsToTry,
 		})) === 'available'
 	) {
 		return {port: desiredPort, didUsePort};

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -37,7 +37,7 @@ import {
 import {getExtensionOfFilename} from './get-extension-of-filename';
 import {getRealFrameRange} from './get-frame-to-render';
 import {ensureLocalBrowser} from './get-local-browser-executable';
-import {getDesiredPort} from './get-port';
+import {getDesiredPort, getPortConfig} from './get-port';
 import {
 	DEFAULT_STILL_IMAGE_FORMAT,
 	DEFAULT_VIDEO_IMAGE_FORMAT,
@@ -220,6 +220,7 @@ export const RenderInternals = {
 	copyImageToClipboard,
 	isIpV6Supported,
 	getChromiumGpuInformation,
+	getPortConfig,
 };
 
 // Warn of potential performance issues with Apple Silicon (M1 chip under Rosetta)

--- a/packages/renderer/src/serve-static.ts
+++ b/packages/renderer/src/serve-static.ts
@@ -2,8 +2,7 @@ import type {Socket} from 'net';
 import http from 'node:http';
 import type {DownloadMap} from './assets/download-map';
 import type {Compositor} from './compositor/compositor';
-import {getDesiredPort} from './get-port';
-import {isIpV6Supported} from './is-ipv6-supported';
+import {getDesiredPort, getPortConfig} from './get-port';
 import type {LogLevel} from './log-level';
 import {startOffthreadVideoServer} from './offthread-video-server';
 import {serveHandler} from './serve-handler';
@@ -72,10 +71,7 @@ export const serveStatic = async (
 
 	const maxTries = 5;
 
-	const host = isIpV6Supported() ? '::' : '0.0.0.0';
-	const hostsToTry = isIpV6Supported()
-		? ['::', '::1']
-		: ['0.0.0.0', '127.0.0.1'];
+	const portConfig = getPortConfig();
 
 	for (let i = 0; i < maxTries; i++) {
 		try {
@@ -84,10 +80,10 @@ export const serveStatic = async (
 					desiredPort: options?.port ?? undefined,
 					from: 3000,
 					to: 3100,
-					hostsToTry,
+					hostsToTry: portConfig.hostsToTry,
 				})
 					.then(({port, didUsePort}) => {
-						server.listen({port, host});
+						server.listen({port, host: portConfig.host});
 						server.on('listening', () => {
 							resolve(port);
 							return didUsePort();


### PR DESCRIPTION
Could potentially fix #3084 and also with Docusaurus server running at the same time