### PR TITLE
`@remotion/renderer`: Properly clean up WaitTasks for error listeners

### DIFF
--- a/packages/renderer/src/browser/DOMWorld.ts
+++ b/packages/renderer/src/browser/DOMWorld.ts
@@ -127,7 +127,7 @@ export class DOMWorld {
 		timeout: number | null;
 		pageFunction: Function | string;
 		title: string;
-	}): Promise<JSHandle> {
+	}): WaitTask {
 		return new WaitTask({
 			domWorld: this,
 			predicateBody: pageFunction,
@@ -135,12 +135,6 @@ export class DOMWorld {
 			timeout,
 			args: [],
 			browser,
-		}).promise;
-	}
-
-	title(): Promise<string> {
-		return this.evaluate(() => {
-			return document.title;
 		});
 	}
 }

--- a/packages/renderer/src/browser/DOMWorld.ts
+++ b/packages/renderer/src/browser/DOMWorld.ts
@@ -330,6 +330,10 @@ class WaitTask {
 			this.onBrowserCloseSilent,
 		);
 
+		if (this.#domWorld._waitTasks.size > 100) {
+			throw new Error('Leak detected: Too many WaitTasks');
+		}
+
 		this.#domWorld._waitTasks.delete(this);
 	}
 }

--- a/packages/renderer/src/browser/JSHandle.ts
+++ b/packages/renderer/src/browser/JSHandle.ts
@@ -90,7 +90,7 @@ export class JSHandle {
 			return 'JSHandle@' + type;
 		}
 
-		return 'JSHandle:' + valueFromRemoteObject(this.#remoteObject);
+		return valueFromRemoteObject(this.#remoteObject);
 	}
 }
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
