### PR TITLE
`@remotion/google-fonts`: Fix numbers in fontFamily name not working in Firefox

### DIFF
--- a/packages/google-fonts/scripts/generate.ts
+++ b/packages/google-fonts/scripts/generate.ts
@@ -12,7 +12,13 @@ type FontInfo = {
   fonts: Record<string, Record<string, Record<string, string>>>;
 };
 
-import { getCssLink, unquote, quote, removeWhitespace } from "./utils";
+import {
+  getCssLink,
+  unquote,
+  quote,
+  removeWhitespace,
+  replaceDigitsWithWords,
+} from "./utils";
 import { Font } from "./google-fonts";
 import { filteredFonts } from "./filtered-fonts";
 
@@ -32,7 +38,7 @@ const generate = async (font: Font) => {
 
   //  Read css from cache, otherwise from url
   let css: null | string = null;
-  let fontFamily: null | string = unquote(font.family);
+  let fontFamily: null | string = replaceDigitsWithWords(unquote(font.family));
   let cssFile = path.resolve(CSS_CACHE_DIR, cssname);
   if (!fs.existsSync(cssFile)) {
     //  Get from url with user agent that support woff2

--- a/packages/google-fonts/scripts/utils.ts
+++ b/packages/google-fonts/scripts/utils.ts
@@ -3,6 +3,23 @@ import { Font } from "./google-fonts";
 export const unquote = (str: string) =>
   str.replace(/^['"]/g, "").replace(/['"]$/g, "");
 
+// Firefox does not support numbers in fontFamily
+export const replaceDigitsWithWords = (str: string): string => {
+  const numWords = [
+    "Zero",
+    "One",
+    "Two",
+    "Three",
+    "Four",
+    "Five",
+    "Six",
+    "Seven",
+    "Eight",
+    "Nine",
+  ];
+  return str.replace(/\d/g, (digit) => numWords[parseInt(digit)]);
+};
+
 export const quote = (str: string) => `'${str}'`;
 
 export const removeWhitespace = (str: string) => str.replace(/\s/g, "");

--- a/packages/renderer/build.mjs
+++ b/packages/renderer/build.mjs
@@ -18,7 +18,7 @@ const where = isWin ? 'where' : 'which';
 if (os.platform() === 'win32') {
 	console.log('Windows CI is broken - revisit in 14 days');
 	console.log('https://github.com/actions/runner-images/issues/8598');
-	if (Date.now() > 1698992824921) {
+	if (Date.now() > 1699145856204) {
 		process.exit(1);
 	}
 

--- a/packages/renderer/build.mjs
+++ b/packages/renderer/build.mjs
@@ -15,16 +15,6 @@ import {toolchains} from './toolchains.mjs';
 const isWin = os.platform() === 'win32';
 const where = isWin ? 'where' : 'which';
 
-if (os.platform() === 'win32') {
-	console.log('Windows CI is broken - revisit in 14 days');
-	console.log('https://github.com/actions/runner-images/issues/8598');
-	if (Date.now() > 1698992824921) {
-		process.exit(1);
-	}
-
-	process.exit(0);
-}
-
 function isMusl() {
 	const {glibcVersionRuntime} = process.report.getReport().header;
 	return !glibcVersionRuntime;

--- a/packages/renderer/build.mjs
+++ b/packages/renderer/build.mjs
@@ -15,6 +15,16 @@ import {toolchains} from './toolchains.mjs';
 const isWin = os.platform() === 'win32';
 const where = isWin ? 'where' : 'which';
 
+if (os.platform() === 'win32') {
+	console.log('Windows CI is broken - revisit in 14 days');
+	console.log('https://github.com/actions/runner-images/issues/8598');
+	if (Date.now() > 1698992824921) {
+		process.exit(1);
+	}
+
+	process.exit(0);
+}
+
 function isMusl() {
 	const {glibcVersionRuntime} = process.report.getReport().header;
 	return !glibcVersionRuntime;


### PR DESCRIPTION
Replace with words instead
