### PR TITLE
docs(visual-editing): add zTextarea on implemented controls

### DIFF
--- a/packages/docs/docs/visual-editing.md
+++ b/packages/docs/docs/visual-editing.md
@@ -41,6 +41,7 @@ Controls are implemented for:
 - `z.nullable()`
 - `z.enum()`
 - [`zColor()`](/docs/zod-types/z-color) (from `@remotion/zod-types`)
+- [`zTextarea()`](/docs/zod-types/z-textarea) (from `@remotion/zod-types`)
 - [`staticFile()`](/docs/staticfile) assets by typing as `z.string()` and using `staticFile()` in your code
 - `.default()`
 


### PR DESCRIPTION
In the PR https://github.com/remotion-dev/remotion/pull/3010 I think an addition to the 'visual-editing' doc has been forgotten 😊