### PR TITLE
`remotion`: Increase maximum files returned by `getStaticFiles()` to 10000

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -252,7 +252,7 @@ export async function bundle(...args: Arguments): Promise<string> {
 			folder: '.',
 			startPath: from,
 			staticHash,
-			limit: 1000,
+			limit: 10000,
 		}).map((f) => {
 			return {
 				...f,

--- a/packages/cli/src/preview-server/public-folder.ts
+++ b/packages/cli/src/preview-server/public-folder.ts
@@ -31,7 +31,7 @@ export const fetchFolder = ({
 		folder: '.',
 		startPath: publicDir,
 		staticHash,
-		limit: 1000,
+		limit: 10000,
 	}).map((f) => {
 		return {
 			...f,

--- a/packages/docs/docs/get-static-files.md
+++ b/packages/docs/docs/get-static-files.md
@@ -68,7 +68,11 @@ Takes no arguments and returns an array of object, each of which have four entri
 
 ## Maximum files
 
-For performance, only the first 1000 items are fetched and displayed.
+For performance, only the first 10000 items are fetched and displayed.
+
+**Changelog**
+
+Before v4.0.64, only the first 1000 items were displayed.
 
 ## See also
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
