### PR TITLE
`remotion`: fix spring ending too early + add tests

### DIFF
--- a/packages/core/src/spring/index.ts
+++ b/packages/core/src/spring/index.ts
@@ -87,7 +87,7 @@ export function spring({
 			? delayProcessed
 			: delayProcessed / (passedDurationInFrames / naturalDurationGetter.get());
 
-	if (passedDurationInFrames && durationProcessed > passedDurationInFrames) {
+	if (passedDurationInFrames && delayProcessed > passedDurationInFrames) {
 		return to;
 	}
 

--- a/packages/core/src/test/spring.test.ts
+++ b/packages/core/src/test/spring.test.ts
@@ -200,3 +200,26 @@ test('weird case', () => {
 
 	expect(val2).toBeCloseTo(0);
 });
+
+test('spring should not end too early', () => {
+	expect(
+		spring({
+			fps: 30,
+			frame: 9,
+			config: {
+				damping: 200,
+			},
+			durationInFrames: 10,
+		}),
+	).toBeLessThan(1);
+	expect(
+		spring({
+			fps: 30,
+			frame: 10,
+			config: {
+				damping: 200,
+			},
+			durationInFrames: 10,
+		}),
+	).toBeCloseTo(1);
+});


### PR DESCRIPTION
Affects `spring()`s with a set duration