### PR TITLE
🪲 `@remotion/renderer`: Fix the cleanup of cycling browser tabs after a render

### DIFF
--- a/packages/lambda/src/functions/helpers/get-browser-instance.ts
+++ b/packages/lambda/src/functions/helpers/get-browser-instance.ts
@@ -76,7 +76,7 @@ export const getBrowserInstance = async (
 
 	if (!_browserInstance) {
 		RenderInternals.Log.info(
-			'Cold Lambda function, launching new Lambda function',
+			'Cold Lambda function, launching new browser instance',
 		);
 		launching = true;
 
@@ -92,10 +92,11 @@ export const getBrowserInstance = async (
 			logLevel,
 		});
 		instance.on('disconnected', () => {
-			console.log('Browser disconnected / crashed');
-			_browserInstance?.instance
-				?.close(true, logLevel, indent)
-				.catch(() => undefined);
+			RenderInternals.Log.info('Browser disconnected or crashed.');
+			forgetBrowserEventLoop(logLevel);
+			_browserInstance?.instance?.close(true, logLevel, indent).catch((err) => {
+				RenderInternals.Log.info('Could not close browser instance', err);
+			});
 			_browserInstance = null;
 		});
 		_browserInstance = {

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -260,10 +260,7 @@ const renderHandler = async (
 	});
 	RenderInternals.Log.verbose(
 		{indent: false, logLevel: params.logLevel},
-		'Wrote chunk to S3',
-		{
-			time: Date.now() - writeStart,
-		},
+		`Wrote chunk to S3 (${Date.now() - writeStart}ms)`,
 	);
 	RenderInternals.Log.verbose(
 		{indent: false, logLevel: params.logLevel},

--- a/packages/renderer/src/cycle-browser-tabs.ts
+++ b/packages/renderer/src/cycle-browser-tabs.ts
@@ -41,7 +41,9 @@ export const cycleBrowserTabs = (
 
 				.catch((err) => console.log(err))
 				.finally(() => {
-					set();
+					if (!stopped) {
+						set();
+					}
 				});
 		}, 200);
 	};
@@ -56,7 +58,7 @@ export const cycleBrowserTabs = (
 
 			stopped = true;
 
-			return clearInterval(interval);
+			return clearTimeout(interval);
 		},
 	};
 };


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
