### PR TITLE
`@remotion/renderer`: Also unlock port selection lock after an error

### DIFF
--- a/packages/cli/src/preview-server/start-server.ts
+++ b/packages/cli/src/preview-server/start-server.ts
@@ -124,14 +124,14 @@ export const startServer = async (options: {
 					to: 3100,
 					hostsToTry: portConfig.hostsToTry,
 				})
-					.then(({port, didUsePort}) => {
+					.then(({port, unlockPort}) => {
 						server.listen({
 							port,
 							host: portConfig.host,
 						});
 						server.on('listening', () => {
 							resolve(port);
-							return didUsePort();
+							return unlockPort();
 						});
 						server.on('error', (err) => {
 							reject(err);

--- a/packages/renderer/src/get-port.ts
+++ b/packages/renderer/src/get-port.ts
@@ -93,7 +93,8 @@ export const getDesiredPort = async ({
 }) => {
 	await portLocks.waitForAllToBeDone();
 	const lockPortSelection = portLocks.lock();
-	const didUsePort = () => portLocks.unlock(lockPortSelection);
+	const unlockPort = portLocks.unlock(lockPortSelection);
+
 	if (
 		typeof desiredPort !== 'undefined' &&
 		(await testPortAvailableOnMultipleHosts({
@@ -101,7 +102,7 @@ export const getDesiredPort = async ({
 			hosts: hostsToTry,
 		})) === 'available'
 	) {
-		return {port: desiredPort, didUsePort};
+		return {port: desiredPort, unlockPort};
 	}
 
 	const actualPort = await getPort({from, to, hostsToTest: hostsToTry});
@@ -113,7 +114,7 @@ export const getDesiredPort = async ({
 		);
 	}
 
-	return {port: actualPort, didUsePort};
+	return {port: actualPort, unlockPort};
 };
 
 const makeRange = (from: number, to: number): number[] => {

--- a/packages/renderer/src/get-port.ts
+++ b/packages/renderer/src/get-port.ts
@@ -93,7 +93,7 @@ export const getDesiredPort = async ({
 }) => {
 	await portLocks.waitForAllToBeDone();
 	const lockPortSelection = portLocks.lock();
-	const unlockPort = portLocks.unlock(lockPortSelection);
+	const unlockPort = () => portLocks.unlock(lockPortSelection);
 
 	if (
 		typeof desiredPort !== 'undefined' &&

--- a/packages/renderer/src/test/port-selection.test.ts
+++ b/packages/renderer/src/test/port-selection.test.ts
@@ -4,7 +4,7 @@ import {getDesiredPort} from '../get-port';
 test('Port selection should only be freed once the previous result has been used', async () => {
 	let ports = 0;
 
-	const {port, didUsePort} = await getDesiredPort({
+	const {port, unlockPort} = await getDesiredPort({
 		desiredPort: undefined,
 		from: 3100,
 		to: 3200,
@@ -22,7 +22,7 @@ test('Port selection should only be freed once the previous result has been used
 	});
 
 	expect(ports).toBe(0);
-	didUsePort();
+	unlockPort();
 	await secondPort;
 	expect(ports).toBe(1);
 });


### PR DESCRIPTION
Otherwise it slows down parallel renders by 10 seconds due to timeout