### PR TITLE
fix: Update resources links

### DIFF
--- a/packages/docs/docs/resources.md
+++ b/packages/docs/docs/resources.md
@@ -54,7 +54,7 @@ This list tries to compile all templates, libraries, building blocks and example
 
 - [GitHub Unwrapped 2022](https://github.com/remotion-dev/github-unwrapped-2022)
 - [GitHub Unwrapped 2021](https://github.com/remotion-dev/github-unwrapped-2021)
-- [Podcast Maker](https://github.com/remotion-dev/podcast-maker)
+- [Podcast Maker](https://github.com/FelippeChemello/podcast-maker)
 - [Stargazer](https://github.com/pomber/stargazer)
 - [MapSnap](https://remotion.pro) _(exclusive for Company License subscribers)_
 - [Mockoops](https://github.com/Just-Moh-it/Mockoops)

--- a/packages/docs/docs/resources.md
+++ b/packages/docs/docs/resources.md
@@ -103,7 +103,6 @@ See the [Showcase](/showcase) for videos made with Remotion.
 - [Formula 1 Graphics](https://www.youtube.com/watch?v=sA-X0Bw_7Gg&t=146s)
 - [Remotion Skia Tutorial](https://www.youtube.com/watch?v=-7MOoWN2_nk)
 - [Fireship: Remotion Tutorial](https://www.youtube.com/watch?v=deg8bOoziaE&t=3s)
-- [A soft introduction to Remotion](https://www.youtube.com/watch?v=szh2Qgo9SVE&t=847s)
 - [CRT effect](https://www.youtube.com/watch?v=-7MOoWN2_nk)
 - ["Create videos with Code" by Prismic](https://prismic.io/blog/create-videos-with-code-remotion-tutorial)
 - [Integrate GreenSock with Remotion](https://archive.ph/dGQ19)


### PR DESCRIPTION
# 1. Podcast-maker
https://github.com/remotion-dev/podcast-maker is a 404.
And I think it was supposed to be https://github.com/FelippeChemello/podcast-maker 🤔

# 2. Tutorials > [A soft introduction to Remotion](https://www.youtube.com/watch?v=szh2Qgo9SVE&t=847s)

This video no longer exists