### PR TITLE
`remotion`: Buttons in props editor properly usable via keyboard

### DIFF
--- a/packages/cli/src/editor/components/AssetSelectorItem.tsx
+++ b/packages/cli/src/editor/components/AssetSelectorItem.tsx
@@ -241,7 +241,7 @@ export const AssetSelectorItem: React.FC<{
 		return <ClipboardIcon style={revealIconStyle} color={color} />;
 	}, []);
 
-	const revealInExplorer: React.MouseEventHandler<HTMLAnchorElement> =
+	const revealInExplorer: React.MouseEventHandler<HTMLButtonElement> =
 		React.useCallback(
 			(e) => {
 				e.stopPropagation();
@@ -259,7 +259,7 @@ export const AssetSelectorItem: React.FC<{
 			[item.name, parentFolder],
 		);
 
-	const copyToClipboard: React.MouseEventHandler<HTMLAnchorElement> =
+	const copyToClipboard: React.MouseEventHandler<HTMLButtonElement> =
 		useCallback(
 			(e) => {
 				e.stopPropagation();

--- a/packages/cli/src/editor/components/InlineAction.tsx
+++ b/packages/cli/src/editor/components/InlineAction.tsx
@@ -5,7 +5,7 @@ import {useZIndex} from '../state/z-index';
 export type RenderInlineAction = (color: string) => React.ReactNode;
 
 export const InlineAction: React.FC<{
-	onClick: React.MouseEventHandler<HTMLAnchorElement>;
+	onClick: React.MouseEventHandler<HTMLButtonElement>;
 	disabled?: boolean;
 	renderAction: RenderInlineAction;
 	title?: string;
@@ -39,7 +39,7 @@ export const InlineAction: React.FC<{
 	}, [disabled, hovered]);
 
 	return (
-		<a
+		<button
 			type="button"
 			onPointerEnter={onPointerEnter}
 			onPointerLeave={onPointerLeave}
@@ -49,6 +49,6 @@ export const InlineAction: React.FC<{
 			title={title}
 		>
 			{renderAction(hovered ? 'white' : LIGHT_TEXT)}
-		</a>
+		</button>
 	);
 };

--- a/packages/cli/src/editor/components/SidebarRenderButton.tsx
+++ b/packages/cli/src/editor/components/SidebarRenderButton.tsx
@@ -35,7 +35,7 @@ export const SidebarRenderButton: React.FC<{
 	const connectionStatus = useContext(StudioServerConnectionCtx).type;
 	const {props} = useContext(Internals.EditorPropsContext);
 
-	const onClick: React.MouseEventHandler<HTMLAnchorElement> = useCallback(
+	const onClick: React.MouseEventHandler<HTMLButtonElement> = useCallback(
 		(e) => {
 			const defaults = window.remotion_renderDefaults;
 			if (!defaults) {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
