### PR TITLE
Python SDK: Prevent usage of `input_props`

### DIFF
--- a/packages/docs/docs/lambda/python.md
+++ b/packages/docs/docs/lambda/python.md
@@ -49,6 +49,7 @@ client = RemotionClient(region=REMOTION_APP_REGION,
 # Set render request
 render_params = RenderParams(
     composition="react-svg",
+    # Note: In Python, you pass input props using `data`, not `input_props`
     data={
         'hi': 'there'
     },

--- a/packages/lambda-python/remotion_lambda/models.py
+++ b/packages/lambda-python/remotion_lambda/models.py
@@ -18,7 +18,7 @@ class RenderParams:
     composition: str = ""
     serve_url: str = ""
     frames_per_lambda: Optional[int] = None
-    input_props: Optional[Dict] = None
+    private_serialized_input_props: Optional[Dict] = None
     codec: str = 'h264'
     version: str = ""
     image_format: str = 'jpeg'
@@ -62,7 +62,7 @@ class RenderParams:
             'framesPerLambda': self.frames_per_lambda,
             'composition': self.composition,
             'serveUrl': self.serve_url,
-            'inputProps': self.input_props,
+            'inputProps': self.private_serialized_input_props,
             'codec': self.codec,
             'imageFormat': self.image_format,
             'maxRetries': self.max_retries,

--- a/packages/lambda-python/remotion_lambda/remotionclient.py
+++ b/packages/lambda-python/remotion_lambda/remotionclient.py
@@ -100,7 +100,7 @@ class RemotionClient:
         render_params.serve_url = self.serve_url
         render_params.region = self.region
         render_params.function_name = self.function_name
-        render_params.input_props = self._serialize_input_props(
+        render_params.private_serialized_input_props = self._serialize_input_props(
             input_props=render_params.data,
             render_type="video-or-audio"
         )


### PR DESCRIPTION
Update docs and remove `input_props` from autocomplete. It's `data` in Python instead