### PR TITLE
`@remotion/lambda` Disable Lambda leak detection slowing down renders

### DIFF
--- a/packages/bugs/api/[v].ts
+++ b/packages/bugs/api/[v].ts
@@ -8,9 +8,9 @@ type Bug = {
 
 const bugs: Bug[] = [
   {
-    title: "Subsequence Lambda renders are slow",
-    description: "A warm Lambda function would get slower over time",
-    link: "",
+    title: "Subsequent Lambda renders become slow",
+    description: "A warm Lambda function would get slower over time.",
+    link: "https://github.com/remotion-dev/remotion/pull/3184",
     versions: ["4.0.66", "4.0.67", "4.0.68", "4.0.69", "4.0.70"],
   },
   {

--- a/packages/bugs/api/[v].ts
+++ b/packages/bugs/api/[v].ts
@@ -8,6 +8,12 @@ type Bug = {
 
 const bugs: Bug[] = [
   {
+    title: "Subsequence Lambda renders are slow",
+    description: "A warm Lambda function would get slower over time",
+    link: "",
+    versions: ["4.0.66", "4.0.67", "4.0.68", "4.0.69", "4.0.70"],
+  },
+  {
     title: "<Player> does not render",
     description: "The <Player> component does not render anything.",
     link: "https://github.com/remotion-dev/remotion/issues/3128",

--- a/packages/example/testlambda.mjs
+++ b/packages/example/testlambda.mjs
@@ -47,3 +47,4 @@ execSync(
 );
 
 await import('./testlambdaintegrations.mjs');
+await import('./testlambdaperformance.mjs');

--- a/packages/example/testlambdaperformance.mjs
+++ b/packages/example/testlambdaperformance.mjs
@@ -1,0 +1,51 @@
+import {
+	getFunctions,
+	getRenderProgress,
+	renderMediaOnLambda,
+} from '@remotion/lambda/client';
+import assert from 'assert';
+import {config} from 'dotenv';
+
+config();
+
+const [{functionName}] = await getFunctions({
+	compatibleOnly: true,
+	region: 'eu-central-1',
+});
+
+const timings = [];
+
+for (let i = 0; i < 5; i++) {
+	const startRender = Date.now();
+	const {bucketName, renderId} = await renderMediaOnLambda({
+		functionName,
+		codec: 'h264',
+		composition: 'OffthreadRemoteVideo',
+		serveUrl: 'testbed-v6',
+		region: 'eu-central-1',
+	});
+
+	let done = false;
+	while (!done) {
+		const progress = await getRenderProgress({
+			bucketName,
+			functionName,
+			region: 'eu-central-1',
+			renderId,
+		});
+		done = progress.done;
+		console.log(progress.overallProgress);
+		if (progress.fatalErrorEncountered) {
+			console.log(progress.errors);
+		}
+		if (progress.done) {
+			console.log(progress.outputFile);
+		}
+	}
+
+	const end = Date.now();
+	const time = end - startRender;
+	timings.push(time);
+	assert(time < 1000 * 45, `Render took too long (${time})`);
+}
+console.log('Times for 5 renders', timings);

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -292,6 +292,8 @@ const renderHandler = async (
 	return {};
 };
 
+export const ENABLE_SLOW_LEAK_DETECTION = false;
+
 export const rendererHandler = async (
 	params: LambdaPayload,
 	options: Options,
@@ -305,7 +307,7 @@ export const rendererHandler = async (
 
 	const logs: BrowserLog[] = [];
 
-	const leakDetection = enableNodeIntrospection();
+	const leakDetection = enableNodeIntrospection(ENABLE_SLOW_LEAK_DETECTION);
 
 	try {
 		await renderHandler(params, options, logs);

--- a/packages/lambda/src/shared/why-is-node-running.ts
+++ b/packages/lambda/src/shared/why-is-node-running.ts
@@ -12,12 +12,21 @@ type Resource = {
 };
 
 export type NodeIntrospection = {
-	hook: asyncHooks.AsyncHook;
+	hook: asyncHooks.AsyncHook | null;
 	active: Map<number, Resource>;
 };
 
-export const enableNodeIntrospection = (): NodeIntrospection => {
+export const enableNodeIntrospection = (
+	enabled: boolean,
+): NodeIntrospection => {
 	const active = new Map<number, Resource>();
+	if (!enabled) {
+		return {
+			active,
+			hook: null,
+		};
+	}
+
 	const hook = asyncHooks.createHook({
 		init(asyncId, type, _triggerAsyncId, resource) {
 			if (type === 'TIMERWRAP' || type === 'PROMISE') return;
@@ -37,6 +46,10 @@ export const enableNodeIntrospection = (): NodeIntrospection => {
 };
 
 export function whyIsNodeRunning({active, hook}: NodeIntrospection) {
+	if (!hook) {
+		return;
+	}
+
 	hook.disable();
 	const activeResources = [...active.values()].filter((r) => {
 		if (typeof r.resource.hasRef === 'function' && !r.resource.hasRef())


### PR DESCRIPTION
In this bug which appeared from v4.0.66-4.0.70, a leak from an improperly called Node.js async_hooks listener would lead do slowdown in downloads, which would get worse with every new render on Lambda.

If not on the "latest stable release" (v4.0.43 at time of writing), we recommend upgrading to v4.0.71.