### PR TITLE
`@remotion/player`: better way to apply preload="metadata"

### DIFF
--- a/packages/core/src/video/VideoForDevelopment.tsx
+++ b/packages/core/src/video/VideoForDevelopment.tsx
@@ -178,6 +178,9 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		// if a seek is triggered before `loadedmetadata` is fired,
 		// the video will not seek, even if `loadedmetadata` is fired afterwards.
 
+		// Also, this needs to happen in a useEffect, because otherwise
+		// the SSR props will be applied.
+
 		if (isIosSafari()) {
 			current.preload = 'metadata';
 		} else {

--- a/packages/core/src/video/VideoForDevelopment.tsx
+++ b/packages/core/src/video/VideoForDevelopment.tsx
@@ -167,13 +167,27 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		};
 	}, [src]);
 
+	useEffect(() => {
+		const {current} = videoRef;
+
+		if (!current) {
+			return;
+		}
+
+		// Without this, on iOS Safari, the video cannot be seeked.
+		// if a seek is triggered before `loadedmetadata` is fired,
+		// the video will not seek, even if `loadedmetadata` is fired afterwards.
+
+		if (isIosSafari()) {
+			current.preload = 'metadata';
+		} else {
+			current.preload = 'auto';
+		}
+	}, []);
+
 	return (
 		<video
 			ref={videoRef}
-			// Without this, on iOS Safari, the video cannot be seeked.
-			// if a seek is triggered before `loadedmetadata` is fired,
-			// the video will not seek, even if `loadedmetadata` is fired afterwards.
-			preload={isIosSafari() ? 'metadata' : 'auto'}
 			muted={muted || mediaMuted}
 			playsInline
 			src={actualSrc}

--- a/packages/core/src/video/video-fragment.ts
+++ b/packages/core/src/video/video-fragment.ts
@@ -4,21 +4,16 @@ const toSeconds = (time: number, fps: number) => {
 	return Math.round((time / fps) * 100) / 100;
 };
 
+export const isIosSafari = () => {
+	return typeof window === 'undefined'
+		? false
+		: /iP(ad|od|hone)/i.test(window.navigator.userAgent) &&
+				Boolean(navigator.userAgent.match(/Version\/[\d.]+.*Safari/));
+};
+
 // https://github.com/remotion-dev/remotion/issues/1655
-const isIOSSafariCase = (actualSrc: string) => {
-	if (typeof window === 'undefined') {
-		return false;
-	}
-
-	const isIpadIPodIPhone = /iP(ad|od|hone)/i.test(window.navigator.userAgent);
-	const isSafari = Boolean(
-		navigator.userAgent.match(/Version\/[\d.]+.*Safari/),
-	);
-	const isChrome = Boolean(navigator.userAgent.match(/CriOS\//));
-
-	return (
-		isIpadIPodIPhone && (isSafari || isChrome) && actualSrc.startsWith('blob:')
-	);
+const isIOSSafariAndBlob = (actualSrc: string) => {
+	return isIosSafari() && actualSrc.startsWith('blob:');
 };
 
 export const appendVideoFragment = ({
@@ -32,7 +27,7 @@ export const appendVideoFragment = ({
 	duration: number;
 	fps: number;
 }): string => {
-	if (isIOSSafariCase(actualSrc)) {
+	if (isIOSSafariAndBlob(actualSrc)) {
 		return actualSrc;
 	}
 
@@ -108,11 +103,4 @@ export const useAppendVideoFragment = ({
 	});
 
 	return appended;
-};
-
-export const isIosSafari = () => {
-	return typeof window === 'undefined'
-		? false
-		: /iP(ad|od|hone)/i.test(window.navigator.userAgent) &&
-				Boolean(navigator.userAgent.match(/Version\/[\d.]+.*Safari/));
 };

--- a/packages/preload/src/preload-asset.ts
+++ b/packages/preload/src/preload-asset.ts
@@ -3,10 +3,16 @@ import {resolveRedirect} from './resolve-redirect';
 const typesAllowed = ['video', 'audio', 'image', 'font'] as const;
 
 export const isIosSafari = () => {
-	return typeof window === 'undefined'
-		? false
-		: /iP(ad|od|hone)/i.test(window.navigator.userAgent) &&
-				Boolean(navigator.userAgent.match(/Version\/[\d.]+.*Safari/));
+	if (typeof window === 'undefined') {
+		return false;
+	}
+
+	const isIpadIPodIPhone = /iP(ad|od|hone)/i.test(window.navigator.userAgent);
+	const isSafari = Boolean(
+		navigator.userAgent.match(/Version\/[\d.]+.*Safari/),
+	);
+	const isChrome = Boolean(navigator.userAgent.match(/CriOS\//));
+	return isIpadIPodIPhone && (isSafari || isChrome);
 };
 
 export const preloadAsset = (


### PR DESCRIPTION
In Next.js, the markup from the server renders `preload="auto"`, but on the client it must be `preload="metadata"`. 
This will result in a mismatch which we cannot see because Safari DevTools currently seem broken and do not show console.logs.

What will eventually be applied is preload="auto" which Safari does not respect, and the video will not actually be preloaded.
To fix this, we are applying the prop during runtime.