### PR TITLE
`@remotion/renderer`: ffmpeg 6.1 + enable paletteuse and palettegen filters

### DIFF
--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -19,7 +19,7 @@ image = "0.23.7"
 arboard = "3.2.0"
 sysinfo = "0.29.9"
 mp4 = {git = "https://github.com/jonnyburger/mp4-rust", rev = "92ba375738cc2f05a4d754e1f968cf2e97d06641"}
-ffmpeg-next = {git = "https://github.com/remotion-dev/rust-ffmpeg", rev ="ebddf9713f988a21e9f12d62c1878bd06ebaf1a0"}
+ffmpeg-next = {git = "https://github.com/remotion-dev/rust-ffmpeg", rev ="aa1f7ab87680f10a74a95368eec0448869a78589"}
 
 [[bin]]
 name = "compositor"


### PR DESCRIPTION
This will allow for higher quality GIF exports