### PR TITLE
`@remotion/renderer`: transparent GIFs can be rendered 

### DIFF
--- a/packages/renderer/src/ffmpeg-args.ts
+++ b/packages/renderer/src/ffmpeg-args.ts
@@ -23,7 +23,7 @@ const firstEncodingStepOnly = ({
 	codec: Codec;
 	videoBitrate: string | null | undefined;
 }): string[][] => {
-	if (hasPreencoded) {
+	if (hasPreencoded || codec === 'gif') {
 		return [];
 	}
 

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -417,6 +417,9 @@ const innerStitchFramesToVideo = async (
 					['-s', `${width}x${height}`],
 					['-start_number', String(assetsInfo.firstFrameIndex)],
 					['-i', assetsInfo.imageSequenceName],
+					codec === 'gif'
+						? ['-filter_complex', 'split[v],palettegen,[v]paletteuse']
+						: null,
 			  ]),
 		audio ? ['-i', audio] : null,
 		numberOfGifLoops === null


### PR DESCRIPTION
close #1276

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
