### PR TITLE
Remotion Studio: Fix codec resetting to default when retrying a render

### DIFF
--- a/packages/cli/src/preview-server/render-queue/make-retry-payload.ts
+++ b/packages/cli/src/preview-server/render-queue/make-retry-payload.ts
@@ -138,7 +138,7 @@ export const makeRetryPayload = (job: RenderJob): RenderModalState => {
 			initialOffthreadVideoCacheSizeInBytes: job.offthreadVideoCacheSizeInBytes,
 			initialColorSpace: job.colorSpace,
 			initialMultiProcessOnLinux: job.multiProcessOnLinux,
-			defaultConfigurationVideoCodec: defaults.codec as Codec,
+			defaultConfigurationVideoCodec: job.codec,
 			defaultConfigurationAudioCodec: job.audioCodec,
 		};
 	}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
