### PR TITLE
`remotion`: Better error behavior for useAudioData()

### DIFF
--- a/packages/core/src/audio/AudioForRendering.tsx
+++ b/packages/core/src/audio/AudioForRendering.tsx
@@ -61,6 +61,7 @@ const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
 		_remotionInternalNativeLoopPassed,
 		acceptableTimeShiftInSeconds,
 		name,
+		onError,
 		...nativeProps
 	} = props;
 

--- a/packages/docs/docs/use-audio-data.md
+++ b/packages/docs/docs/use-audio-data.md
@@ -64,7 +64,7 @@ export const MyComponent: React.FC = () => {
 
 ## Errors
 
-If you pass in a file that has no audio track, this hook will throw an error.
+If you pass in a file that has no audio track, this hook will throw an error (_from v4.0.75_) or lead to an unhandled rejection (_until v4.0.74_).
 
 To determine if a file has an audio track, you may use the [`getVideoMetadata()`](/docs/renderer/get-video-metadata#audiocodec) function on the server to reject a file if it has no audio track. To do so, check if the `audioCodec` field is `null`.
 

--- a/packages/media-utils/src/use-audio-data.ts
+++ b/packages/media-utils/src/use-audio-data.ts
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
-import {continueRender, delayRender} from 'remotion';
+import {cancelRender, continueRender, delayRender} from 'remotion';
 import {getAudioData} from './get-audio-data';
 import type {AudioData} from './types';
 
@@ -31,9 +31,14 @@ export const useAudioData = (src: string): AudioData | null => {
 		const handle = delayRender(
 			`Waiting for audio metadata with src="${src}" to be loaded`,
 		);
-		const data = await getAudioData(src);
-		if (mountState.current.isMounted) {
-			setMetadata(data);
+
+		try {
+			const data = await getAudioData(src);
+			if (mountState.current.isMounted) {
+				setMetadata(data);
+			}
+		} catch (err) {
+			cancelRender(err);
 		}
 
 		continueRender(handle);


### PR DESCRIPTION
In case of an error, it will not anymore be an unhandled reject, but a hard error cancelling the render.

If you want different error behavior, use `getAudioData()` directly.