### PR TITLE
`@remotion/renderer`: Fix FPS in getVideoMetadata() when FPS is fract…

### DIFF
--- a/packages/renderer/rust/ffmpeg.rs
+++ b/packages/renderer/rust/ffmpeg.rs
@@ -288,7 +288,8 @@ pub fn get_video_metadata(file_path: &str) -> Result<VideoMetadata, ErrorWithBac
     };
 
     // Get the frame rate
-    let fps: i32 = video_stream.avg_frame_rate().numerator();
+    let fps = (video_stream.avg_frame_rate().numerator() as f32)
+        / (video_stream.avg_frame_rate().denominator() as f32);
 
     // Get the codec
     let codec = remotionffmpeg::codec::context::Context::from_parameters(video_stream.parameters())

--- a/packages/renderer/rust/payloads.rs
+++ b/packages/renderer/rust/payloads.rs
@@ -217,7 +217,7 @@ pub mod payloads {
     #[derive(Serialize, Deserialize, Debug)]
     #[allow(non_snake_case)]
     pub struct VideoMetadata {
-        pub fps: i32,
+        pub fps: f32,
         pub width: u32,
         pub height: u32,
         pub durationInSeconds: f64,


### PR DESCRIPTION
…ional

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
