### PR TITLE
`@remotion/cloudrun`:  By default, use 50% concurrency, not 100%

### DIFF
--- a/packages/cloudrun/container/package.json
+++ b/packages/cloudrun/container/package.json
@@ -1,13 +1,13 @@
 {
-	"name": "cloud-run-render",
-	"version": "4.0.17",
-	"description": "Render media and stills on GCP Cloud Run",
-	"main": "dist/index.js",
-	"scripts": {
-		"start": "functions-framework --target=renderOnCloudRun"
-	},
-	"dependencies": {
-		"@google-cloud/functions-framework": "^3.1.3"
-	},
-	"private": true
+  "name": "cloud-run-render",
+  "version": "4.0.75",
+  "description": "Render media and stills on GCP Cloud Run",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "functions-framework --target=renderOnCloudRun"
+  },
+  "dependencies": {
+    "@google-cloud/functions-framework": "^3.1.3"
+  },
+  "private": true
 }

--- a/packages/cloudrun/src/functions/render-media-single-thread.ts
+++ b/packages/cloudrun/src/functions/render-media-single-thread.ts
@@ -84,7 +84,7 @@ export const renderMediaSingleThread = async (
 			browserExecutable: null,
 			timeoutInMilliseconds: body.delayRenderTimeoutInMilliseconds,
 			cancelSignal: undefined,
-			concurrency: body.concurrency ?? '100%',
+			concurrency: body.concurrency ?? null,
 			disallowParallelEncoding: false,
 			enforceAudioTrack: body.enforceAudioTrack,
 			ffmpegOverride: undefined,

--- a/packages/example/testcloudrun.sh
+++ b/packages/example/testcloudrun.sh
@@ -13,4 +13,4 @@ cd example
 pnpm exec remotion cloudrun services rmall -f
 pnpm exec remotion cloudrun sites create --site-name=testbed
 ARTIFACT_REGISTRY_ENV=development pnpm exec remotion cloudrun services deploy --cpuLimit=4.0
-pnpm exec remotion cloudrun render testbed react-svg --log=verbose
+pnpm exec remotion cloudrun render testbed OffthreadRemoteVideo --log=verbose

--- a/set-version.mjs
+++ b/set-version.mjs
@@ -27,7 +27,7 @@ const dirs = readdirSync("packages")
     existsSync(path.join(process.cwd(), "packages", dir, "package.json"))
   );
 
-for (const dir of dirs) {
+for (const dir of [path.join("cloudrun", "container"), ...dirs]) {
   const packageJsonPath = path.join(
     process.cwd(),
     "packages",


### PR DESCRIPTION
Aligning with Lambda and renderMedia() in general.