### PR TITLE
Upgrade Thorium to the latest version on all platforms

### DIFF
--- a/packages/renderer/src/browser/BrowserFetcher.ts
+++ b/packages/renderer/src/browser/BrowserFetcher.ts
@@ -31,12 +31,12 @@ import {getDownloadsCacheDir} from './get-download-destination';
 
 const downloadURLs: Record<Platform, string> = {
 	linux:
-		'https://github.com/Alex313031/thorium/releases/download/M114.0.5735.205/thorium-browser_114.0.5735.205_amd64.zip',
-	mac: 'https://github.com/Alex313031/Thorium-Special/releases/download/M114.0.5735.205-1/Thorium_MacOS_X64.dmg',
+		'https://github.com/Alex313031/thorium/releases/download/M117.0.5938.157/thorium-browser_117.0.5938.157_amd64.zip',
+	mac: 'https://github.com/Alex313031/Thorium-MacOS/releases/download/M116.0.5845.169/Thorium_MacOS_X64.dmg',
 	mac_arm:
-		'https://github.com/Alex313031/Thorium-Special/releases/download/M114.0.5735.205-1/Thorium_MacOS_ARM.dmg',
+		'https://github.com/Alex313031/Thorium-MacOS/releases/download/M116.0.5845.169/Thorium_MacOS_ARM.dmg',
 	win64:
-		'https://github.com/Alex313031/Thorium-Win/releases/download/M114.0.5735.205/Thorium_114.0.5735.205.zip',
+		'https://github.com/Alex313031/Thorium-Win/releases/download/M117.0.5938.157/Thorium_117.0.5938.157.zip',
 };
 
 type Platform = 'linux' | 'mac' | 'mac_arm' | 'win64';


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

This fixes #3241 for me. [My original message from Discord](https://discord.com/channels/809501355504959528/817306238811111454/1180102532106829835).

I encountered flickering issues while using Remotion to render videos. The problem occurred due to the older version of Thorium [M114.0.5735.205](https://github.com/Alex313031/Thorium-Win/releases/tag/M114.0.5735.205) that Remotion was using for rendering. However, I was able to resolve the issue by downloading the latest version of Thorium from https://github.com/Alex313031/Thorium-Win/releases/tag/M117.0.5938.157 and setting the browser executable path in `remotion.config.ts` to the newly downloaded Thorium on my Windows machine. 

It appears that the issue was caused by a bug in the older version of Thorium, which has now been fixed in the latest update. Therefore, I updated the download URLs to the latest version on all platforms. I can confirm that the `win64` version matches the version on my host machine, where I was able to render the video without any flickering issues.

The parent issue can be fixed by installing the latest build of Thorium / Chrome.