### PR TITLE
`remotion`: don't warn when prefetching assets with `image/*` content type

### DIFF
--- a/packages/core/src/prefetch.ts
+++ b/packages/core/src/prefetch.ts
@@ -86,6 +86,7 @@ export const prefetch = (
 			if (
 				!buf.type.startsWith('video/') &&
 				!buf.type.startsWith('audio/') &&
+				!buf.type.startsWith('image/') &&
 				!options?.contentType
 			) {
 				// eslint-disable-next-line no-console


### PR DESCRIPTION
Which is actually proper