### PR TITLE
Docs: Fix wipe presentation source code link

### DIFF
--- a/packages/docs/docs/transitions/presentations/wipe.mdx
+++ b/packages/docs/docs/transitions/presentations/wipe.mdx
@@ -70,5 +70,5 @@ const wipeDirection: WipeDirection = "from-left";
 
 ## See also
 
-- [Source code for this presentation](https://github.com/remotion-dev/remotion/blob/main/packages/transitions/src/presentations/slide.tsx)
+- [Source code for this presentation](https://github.com/remotion-dev/remotion/blob/main/packages/transitions/src/presentations/wipe.tsx)
 - [Presentations](/docs/transitions/presentations)


### PR DESCRIPTION
Fixes small typo where the wipe docs were linking to the slide source code

https://www.remotion.dev/docs/transitions/presentations/wipe#see-also

