### PR TITLE
Zod: use `input` and `output` instead of `infer`

### DIFF
--- a/packages/core/src/Composition.tsx
+++ b/packages/core/src/Composition.tsx
@@ -193,7 +193,7 @@ export const Composition = <
 			id,
 			folderName,
 			component: lazy,
-			defaultProps: defaultProps as z.infer<Schema> & Props,
+			defaultProps: defaultProps as z.output<Schema> & Props,
 			nonce,
 			parentFolderName: parentName,
 			schema: schema ?? null,

--- a/packages/core/src/props-if-has-props.ts
+++ b/packages/core/src/props-if-has-props.ts
@@ -33,6 +33,6 @@ export type InferProps<
 		  Props
 	: {} extends Props
 	? // Only schema specified
-	  z.infer<Schema>
+	  z.input<Schema>
 	: // Props and schema specified
-	  z.infer<Schema> & Props;
+	  z.input<Schema> & Props;

--- a/packages/player/src/utils/props-if-has-props.ts
+++ b/packages/player/src/utils/props-if-has-props.ts
@@ -7,7 +7,7 @@ export type PropsIfHasProps<
 	? {} extends Props
 		? {
 				// Neither props nor schema specified
-				inputProps?: z.infer<Schema> & Props;
+				inputProps?: z.input<Schema> & Props;
 		  }
 		: {
 				// Only props specified
@@ -16,9 +16,9 @@ export type PropsIfHasProps<
 	: {} extends Props
 	? {
 			// Only schema specified
-			inputProps: z.infer<Schema>;
+			inputProps: z.input<Schema>;
 	  }
 	: {
 			// Props and schema specified
-			inputProps: z.infer<Schema> & Props;
+			inputProps: z.input<Schema> & Props;
 	  };


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
