### PR TITLE
`@remotion/renderer`: Support bt2020 colorspace

### DIFF
--- a/packages/renderer/src/ffmpeg-args.ts
+++ b/packages/renderer/src/ffmpeg-args.ts
@@ -87,27 +87,17 @@ export const generateFfmpegArgs = ({
 					['-color_range', 'tv'],
 					hasPreencoded ? [] : ['-vf', 'zscale=m=709:min=709:r=limited'],
 				]
-			: colorSpace === 'bt2020-cl'
+			: colorSpace === 'bt2020-ncl'
 				? [
-						['-colorspace:v', 'bt2020cl'],
+						['-colorspace:v', 'bt2020nc'],
 						['-color_primaries:v', 'bt2020'],
 						['-color_trc:v', 'arib-std-b67'],
 						['-color_range', 'tv'],
 						hasPreencoded
 							? []
-							: ['-vf', 'zscale=m=2020_cl:min=2020_cl:r=limited'],
+							: ['-vf', 'zscale=m=2020_ncl:min=2020_ncl:r=limited'],
 					]
-				: colorSpace === 'bt2020-ncl'
-					? [
-							['-colorspace:v', 'bt2020nc'],
-							['-color_primaries:v', 'bt2020'],
-							['-color_trc:v', 'arib-std-b67'],
-							['-color_range', 'tv'],
-							hasPreencoded
-								? []
-								: ['-vf', 'zscale=m=2020_ncl:min=2020_ncl:r=limited'],
-						]
-					: [];
+				: [];
 
 	return [
 		['-c:v', hasPreencoded ? 'copy' : encoderName],

--- a/packages/renderer/src/ffmpeg-args.ts
+++ b/packages/renderer/src/ffmpeg-args.ts
@@ -87,7 +87,27 @@ export const generateFfmpegArgs = ({
 					['-color_range', 'tv'],
 					hasPreencoded ? [] : ['-vf', 'zscale=m=709:min=709:r=limited'],
 				]
-			: [];
+			: colorSpace === 'bt2020-cl'
+				? [
+						['-colorspace:v', 'bt2020cl'],
+						['-color_primaries:v', 'bt2020'],
+						['-color_trc:v', 'arib-std-b67'],
+						['-color_range', 'tv'],
+						hasPreencoded
+							? []
+							: ['-vf', 'zscale=m=2020_cl:min=2020_cl:r=limited'],
+					]
+				: colorSpace === 'bt2020-ncl'
+					? [
+							['-colorspace:v', 'bt2020nc'],
+							['-color_primaries:v', 'bt2020'],
+							['-color_trc:v', 'arib-std-b67'],
+							['-color_range', 'tv'],
+							hasPreencoded
+								? []
+								: ['-vf', 'zscale=m=2020_ncl:min=2020_ncl:r=limited'],
+						]
+					: [];
 
 	return [
 		['-c:v', hasPreencoded ? 'copy' : encoderName],

--- a/packages/renderer/src/options/color-space.tsx
+++ b/packages/renderer/src/options/color-space.tsx
@@ -1,11 +1,6 @@
 import type {AnyRemotionOption} from './option';
 
-export const validColorSpaces = [
-	'default',
-	'bt709',
-	'bt2020-ncl',
-	'bt2020-cl',
-] as const;
+export const validColorSpaces = ['default', 'bt709', 'bt2020-ncl'] as const;
 
 export type ColorSpace = (typeof validColorSpaces)[number];
 

--- a/packages/renderer/src/options/color-space.tsx
+++ b/packages/renderer/src/options/color-space.tsx
@@ -1,6 +1,11 @@
 import type {AnyRemotionOption} from './option';
 
-export const validColorSpaces = ['default', 'bt709'] as const;
+export const validColorSpaces = [
+	'default',
+	'bt709',
+	'bt2020-ncl',
+	'bt2020-cl',
+] as const;
 
 export type ColorSpace = (typeof validColorSpaces)[number];
 
@@ -16,13 +21,17 @@ export const colorSpaceOption = {
 			,{' '}
 			<code>
 				{'"'}bt709{'"'}
-			</code>
-			.<br />
-			If{' '}
-			<code>
-				{'"'}bt709{'"'}
 			</code>{' '}
-			is used, it is recommended to also use{' '}
+			(since v4.0.28),{' '}
+			<code>
+				{'"'}bt2020-ncl{'"'}
+			</code>{' '}
+			(since v4.0.88),{' '}
+			<code>
+				{'"'}bt2020-cl{'"'}
+			</code>{' '}
+			(since v4.0.88), .<br />
+			If a non-default colorspace is used, it is recommended to also use{' '}
 			<code>
 				{'"'}png{'"'}
 			</code>{' '}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
