### PR TITLE
`@remotion/renderer`: better error message when not specifying a serv…

### DIFF
--- a/packages/it-tests/src/rendering/get-compositions.test.ts
+++ b/packages/it-tests/src/rendering/get-compositions.test.ts
@@ -1,0 +1,9 @@
+import { getCompositions } from "@remotion/renderer";
+import { expect, test } from "vitest";
+
+test("getCompositions() should give a good error message if there is no compositions file", async () => {
+  // @ts-expect-error
+  expect(() => getCompositions()).toThrow(
+    "No serve URL or webpack bundle directory was passed to getCompositions()."
+  );
+});

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -251,6 +251,12 @@ export const getCompositions = (
 	serveUrlOrWebpackUrl: string,
 	config?: GetCompositionsOptions,
 ): Promise<VideoConfig[]> => {
+	if (!serveUrlOrWebpackUrl) {
+		throw new Error(
+			'No serve URL or webpack bundle directory was passed to getCompositions().',
+		);
+	}
+
 	const {
 		browserExecutable,
 		chromiumOptions,


### PR DESCRIPTION
…eURL getCompositions()

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
