### PR TITLE
docs: add behavior for single number passed as `frameRange` to `renderMediaOnLambda`

### DIFF
--- a/packages/docs/docs/lambda/rendermediaonlambda.md
+++ b/packages/docs/docs/lambda/rendermediaonlambda.md
@@ -72,9 +72,9 @@ The `framesPerLambda` parameter cannot result in more than 200 functions being s
 
 ### `frameRange?`
 
-_optional_
+_number | [number, number] - optional_
 
-Render a subset of a video. Example: `[0, 9]` to select the first 10 frames. To render a still, use [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda).
+Specify a single frame (passing a `number`) or a range of frames (passing a tuple `[number, number]`) to render a subset of a video. Example: `[0, 9]` to select the first 10 frames. By passing `null` (default) all frames of a composition get rendered. To render a still, use [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda).
 
 ### `serveUrl`
 


### PR DESCRIPTION
Had to go into the source code to see the single-frame behavior... while creating this pr, realized there were docs on the behavior for a single number being passed to the `frameRange`, just for `renderMedia` though... this change might help 😎

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
