### PR TITLE
`@remotion/renderer`: If compositor quits, always include the signal

### DIFF
--- a/packages/renderer/src/compositor/compositor.ts
+++ b/packages/renderer/src/compositor/compositor.ts
@@ -334,7 +334,11 @@ export const startCompositor = <T extends keyof CompositorCommand>(
 			}
 
 			if (runningStatus.type === 'quit-with-error') {
-				throw new Error(`Compositor quit: ${runningStatus.error}`);
+				throw new Error(
+					`Compositor quit${
+						runningStatus.signal ? ` with signal ${runningStatus.signal}` : ''
+					}: ${runningStatus.error}`,
+				);
 			}
 
 			return new Promise<Buffer>((_resolve, _reject) => {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
