### PR TITLE
`remotion`: Wait longer if <Video> frame is late

### DIFF
--- a/packages/core/src/video/seek-until-right.ts
+++ b/packages/core/src/video/seek-until-right.ts
@@ -14,7 +14,7 @@ export const seekToTime = (element: HTMLVideoElement, desiredTime: number) => {
 
 			setTimeout(() => {
 				resolve(metadata.mediaTime);
-			}, displayIn + 50);
+			}, displayIn + 150);
 		});
 	});
 


### PR DESCRIPTION
the current 50ms does not yet seem to solve the issue in a satisfactory fashion

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
