### PR TITLE
`@remotion/shapes`: Use transform-origin for React versions 18.2.0, and transformOrigin for canary versions after February 2023

### DIFF
--- a/packages/docs/components/demos/control.tsx
+++ b/packages/docs/components/demos/control.tsx
@@ -37,7 +37,7 @@ export const Control = ({
       flexDirection: "row",
       alignItems: "center",
     }),
-    []
+    [],
   );
 
   const inputStyle = useMemo<React.CSSProperties>(
@@ -45,7 +45,7 @@ export const Control = ({
       width: 80,
       marginRight: 2,
     }),
-    []
+    [],
   );
 
   return (
@@ -67,7 +67,7 @@ export const Control = ({
         )}
         {`${option.name}`}
       </div>
-      {option.type === "numeric" ? (
+      {option.type === "numeric" && enabled ? (
         <input
           type="range"
           min={option.min}
@@ -75,7 +75,6 @@ export const Control = ({
           step={option.step}
           value={value as number}
           style={inputStyle}
-          disabled={!enabled}
           onChange={(e) => setValue(Number(e.target.value))}
         />
       ) : null}

--- a/packages/shapes/package.json
+++ b/packages/shapes/package.json
@@ -20,6 +20,7 @@
 		"url": "https://github.com/remotion-dev/remotion/issues"
 	},
 	"devDependencies": {
+		"@types/react-dom": "18.0.11",
 		"@jonny/eslint-config": "3.0.276",
 		"@testing-library/react": "^13.4.0",
 		"@types/node": "18.14.6",

--- a/packages/shapes/src/components/render-svg.tsx
+++ b/packages/shapes/src/components/render-svg.tsx
@@ -1,5 +1,7 @@
 import type {Instruction} from '@remotion/paths';
 import React, {useMemo} from 'react';
+import {version} from 'react-dom';
+import {doesReactSupportTransformOriginProperty} from '../utils/does-react-support-canary';
 
 export type AllShapesProps = Omit<
 	React.SVGProps<SVGPathElement>,
@@ -40,6 +42,9 @@ export const RenderSvg = ({
 		};
 	}, [pathStyle]);
 
+	const reactSupportsTransformOrigin =
+		doesReactSupportTransformOriginProperty(version);
+
 	return (
 		<svg
 			width={width}
@@ -50,7 +55,13 @@ export const RenderSvg = ({
 		>
 			<path
 				// eslint-disable-next-line react/no-unknown-property
-				transform-origin={transformOrigin}
+				transform-origin={
+					reactSupportsTransformOrigin ? undefined : transformOrigin
+				}
+				// @ts-expect-error
+				transformOrigin={
+					reactSupportsTransformOrigin ? transformOrigin : undefined
+				}
 				d={path}
 				style={actualPathStyle}
 				{...props}

--- a/packages/shapes/src/test/react-canary.test.ts
+++ b/packages/shapes/src/test/react-canary.test.ts
@@ -1,0 +1,12 @@
+import {expect, test} from 'vitest';
+import {doesReactSupportTransformOriginProperty} from '../utils/does-react-support-canary';
+
+test('Does React support transform-origin', () => {
+	expect(
+		doesReactSupportTransformOriginProperty('18.3.0-canary-2c338b16f-20231116'),
+	).toBe(true);
+	expect(
+		doesReactSupportTransformOriginProperty('18.3.0-canary-2c338b16f-20230116'),
+	).toBe(false);
+	expect(doesReactSupportTransformOriginProperty('18.2.0')).toBe(false);
+});

--- a/packages/shapes/src/utils/does-react-support-canary.ts
+++ b/packages/shapes/src/utils/does-react-support-canary.ts
@@ -1,0 +1,9 @@
+export const doesReactSupportTransformOriginProperty = (version: string) => {
+	if (version.includes('canary') || version.includes('experimental')) {
+		const last8Chars = parseInt(version.slice(-8), 10);
+		return last8Chars > 20230209;
+	}
+
+	const [major, minor] = version.split('.').map(Number);
+	return major > 18 || (major === 18 && minor >= 3);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1688,6 +1688,9 @@ importers:
       '@types/react':
         specifier: 18.0.26
         version: 18.0.26
+      '@types/react-dom':
+        specifier: 18.0.11
+        version: 18.0.11
       '@vitejs/plugin-react':
         specifier: ^2.0.0
         version: 2.0.0(vite@3.0.0)


### PR DESCRIPTION
In old mode, the property is not recognized and you needed to write transform-origin to write it to the DOM as a custom attribute.

In new mode, the property is recognized and if you write transform-origin to the DOM, it warns and says you should use transformOrigin instead -> this PR now does this