### PR TITLE
⚠️ `@remotion/cloudrun`: Enforce the same version of the service and the @remotion/cloudrun package (Breaking change)

### DIFF
--- a/packages/cloudrun/src/api/render-media-on-cloudrun.ts
+++ b/packages/cloudrun/src/api/render-media-on-cloudrun.ts
@@ -14,6 +14,7 @@ import type {
 import type {BrowserSafeApis} from '@remotion/renderer/client';
 import {NoReactAPIs} from '@remotion/renderer/pure';
 import {NoReactInternals} from 'remotion/no-react';
+import {VERSION} from 'remotion/version';
 import type {
 	CloudRunCrashResponse,
 	CloudRunPayloadType,
@@ -205,6 +206,7 @@ const internalRenderMediaOnCloudrunRaw = async ({
 		preferLossless: preferLossless ?? false,
 		offthreadVideoCacheSizeInBytes: offthreadVideoCacheSizeInBytes ?? null,
 		colorSpace: colorSpace ?? 'default',
+		clientVersion: VERSION,
 	};
 
 	const client = await getAuthClientForUrl(cloudRunEndpoint);

--- a/packages/cloudrun/src/api/render-still-on-cloudrun.ts
+++ b/packages/cloudrun/src/api/render-still-on-cloudrun.ts
@@ -7,6 +7,7 @@ import type {
 import {BrowserSafeApis} from '@remotion/renderer/client';
 import {NoReactAPIs} from '@remotion/renderer/pure';
 import {NoReactInternals} from 'remotion/no-react';
+import {VERSION} from 'remotion/version';
 import type {
 	CloudRunCrashResponse,
 	CloudRunPayloadType,
@@ -128,6 +129,7 @@ const renderStillOnCloudrunRaw = async ({
 		delayRenderTimeoutInMilliseconds:
 			delayRenderTimeoutInMilliseconds ?? BrowserSafeApis.DEFAULT_TIMEOUT,
 		offthreadVideoCacheSizeInBytes: offthreadVideoCacheSizeInBytes ?? null,
+		clientVersion: VERSION,
 	};
 
 	const client = await getAuthClientForUrl(cloudRunEndpoint);

--- a/packages/cloudrun/src/functions/helpers/payloads.ts
+++ b/packages/cloudrun/src/functions/helpers/payloads.ts
@@ -54,6 +54,7 @@ export const CloudRunPayload = z.discriminatedUnion('type', [
 		preferLossless: z.boolean(),
 		offthreadVideoCacheSizeInBytes: z.number().nullable(),
 		colorSpace: z.enum(BrowserSafeApis.validColorSpaces),
+		clientVersion: z.string(),
 	}),
 	z.object({
 		type: z.literal('still'),
@@ -74,6 +75,7 @@ export const CloudRunPayload = z.discriminatedUnion('type', [
 		delayRenderTimeoutInMilliseconds: z.number(),
 		logLevel,
 		offthreadVideoCacheSizeInBytes: z.number().nullable(),
+		clientVersion: z.string(),
 	}),
 ]);
 

--- a/packages/cloudrun/src/functions/render-media-single-thread.ts
+++ b/packages/cloudrun/src/functions/render-media-single-thread.ts
@@ -3,6 +3,7 @@ import {Storage} from '@google-cloud/storage';
 import type {ChromiumOptions, RenderMediaOnProgress} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import {NoReactInternals} from 'remotion/no-react';
+import {VERSION} from 'remotion/version';
 import {randomHash} from '../shared/random-hash';
 import {getCompositionFromBody} from './helpers/get-composition-from-body';
 import type {
@@ -17,6 +18,18 @@ export const renderMediaSingleThread = async (
 ) => {
 	if (body.type !== 'media') {
 		throw new Error('expected type media');
+	}
+
+	if (body.clientVersion !== VERSION) {
+		if (!body.clientVersion) {
+			throw new Error(
+				`Version mismatch: When calling renderMediaOnCloudRun(), you called a service which has the version ${VERSION} but the @remotion/cloudrun package is an older version. Deploy a new service with matchin version and use it to call renderMediaOnCloudRun().`,
+			);
+		}
+
+		throw new Error(
+			`Version mismatch: When calling renderMediaOnCloudRun(), you called a service, which has the version ${VERSION}, but the @remotion/cloudrun package you used to invoke the function has version ${VERSION}. Deploy a new service and use it to call renderMediaOnCloudrun().`,
+		);
 	}
 
 	const renderId = randomHash({randomInTests: true});

--- a/packages/cloudrun/src/functions/render-still-single-thread.ts
+++ b/packages/cloudrun/src/functions/render-still-single-thread.ts
@@ -3,6 +3,7 @@ import {Storage} from '@google-cloud/storage';
 import type {ChromiumOptions} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import {NoReactInternals} from 'remotion/no-react';
+import {VERSION} from 'remotion/version';
 import {Log} from '../cli/log';
 import {randomHash} from '../shared/random-hash';
 import {getCompositionFromBody} from './helpers/get-composition-from-body';
@@ -18,6 +19,18 @@ export const renderStillSingleThread = async (
 ) => {
 	if (body.type !== 'still') {
 		throw new Error('expected type still');
+	}
+
+	if (body.clientVersion !== VERSION) {
+		if (!body.clientVersion) {
+			throw new Error(
+				`Version mismatch: When calling renderMediaOnCloudRun(), you called a service which has the version ${VERSION} but the @remotion/cloudrun package is an older version. Deploy a new service with matchin version and use it to call renderMediaOnCloudRun().`,
+			);
+		}
+
+		throw new Error(
+			`Version mismatch: When calling renderMediaOnCloudRun(), you called a service, which has the version ${VERSION}, but the @remotion/cloudrun package you used to invoke the function has version ${VERSION}. Deploy a new service and use it to call renderMediaOnCloudrun().`,
+		);
 	}
 
 	const renderId = randomHash({randomInTests: true});


### PR DESCRIPTION
There is no stability in the protocol when using different versions and weird bugs can occur.

Solution is to always have a service that matches the version of @remotion/cloudrun.

Since Cloud Run is in alpha, this breaking change is pushed in a patch version.