### PR TITLE
docs: remove unused arg in use-current-player-frame convinience-hook

### DIFF
--- a/packages/docs/docs/player/current-time.md
+++ b/packages/docs/docs/player/current-time.md
@@ -25,13 +25,13 @@ import { useCallback, useSyncExternalStore } from "react";
 
 export const useCurrentPlayerFrame = (ref: React.RefObject<PlayerRef>) => {
   const subscribe = useCallback(
-    (onStoreChange: (newVal: number) => void) => {
+    (onStoreChange: () => void) => {
       const { current } = ref;
       if (!current) {
         return () => undefined;
       }
       const updater: CallbackListener<"frameupdate"> = ({ detail }) => {
-        onStoreChange(detail.frame);
+        onStoreChange();
       };
       current.addEventListener("frameupdate", updater);
       return () => {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

I refer to this doc often since i implement custom remotion playback controls a lot, and since `useSyncExternalStore` isn't used very often, it takes some time to understand how the `useCurrentPlayerFrame` hook works. But every time I do, I can't help but notice and end up being left confused for a while after I read the callback function and see the frame is being fed in from two locations, but only one of those is actually returned by the hook.

Doesn't change any functionality, but might help understand this hook for people who don't use `useSyncExternalStore` a lot.