### PR TITLE
`@remotion/shapes`: Fix transform-origin warning in React 18.2

### DIFF
--- a/packages/shapes/src/components/render-svg.tsx
+++ b/packages/shapes/src/components/render-svg.tsx
@@ -58,10 +58,11 @@ export const RenderSvg = ({
 				transform-origin={
 					reactSupportsTransformOrigin ? undefined : transformOrigin
 				}
-				// @ts-expect-error
-				transformOrigin={
-					reactSupportsTransformOrigin ? transformOrigin : undefined
-				}
+				{...(reactSupportsTransformOrigin
+					? {
+							transformOrigin,
+						}
+					: {})}
 				d={path}
 				style={actualPathStyle}
 				{...props}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
