### PR TITLE
`@remotion/cli`: Give no warning if Remotion CLI is installed globally

### DIFF
--- a/packages/cli/src/versions.ts
+++ b/packages/cli/src/versions.ts
@@ -136,6 +136,12 @@ export const versionsCommand = async (
 		Log.info();
 	}
 
+	if (installedVersions.length === 0) {
+		Log.info('No Remotion packages found.');
+		Log.info('Maybe @remotion/cli is installed globally.');
+		process.exit(1);
+	}
+
 	if (installedVersions.length === 1) {
 		Log.info(`✅ Great! All packages have the same version.`);
 	} else {

--- a/packages/cli/src/versions.ts
+++ b/packages/cli/src/versions.ts
@@ -139,6 +139,10 @@ export const versionsCommand = async (
 	if (installedVersions.length === 0) {
 		Log.info('No Remotion packages found.');
 		Log.info('Maybe @remotion/cli is installed globally.');
+
+		Log.info(
+			'If you try to render a video that was bundled with a different version, you will get a warning.',
+		);
 		process.exit(1);
 	}
 

--- a/packages/cli/src/versions.ts
+++ b/packages/cli/src/versions.ts
@@ -62,6 +62,12 @@ export const validateVersionsBeforeCommand = async (
 		return;
 	}
 
+	// Could be a global install of @remotion/cli.
+	// If you render a bundle with a different version, it will give a warning accordingly.
+	if (installedVersions.length === 0) {
+		return;
+	}
+
 	const logOptions: LogOptions = {indent: false, logLevel};
 	Log.warn(logOptions, '-------------');
 	Log.warn(logOptions, 'Version mismatch:');


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
