### PR TITLE
`@remotion/renderer`: Suppress calling alert() and confirm() during a render

### DIFF
--- a/packages/renderer/src/set-props-and-env.ts
+++ b/packages/renderer/src/set-props-and-env.ts
@@ -77,26 +77,28 @@ const innerSetPropsAndEnv = async ({
 	await page.evaluateOnNewDocument(() => {
 		window.alert = (message) => {
 			if (message) {
-				throw new Error(
+				window.window.remotion_cancelledError = new Error(
 					`alert("${message}") was called. It cannot be called in a headless browser.`,
-				);
+				).stack;
 			} else {
-				throw new Error(
+				window.window.remotion_cancelledError = new Error(
 					'alert() was called. It cannot be called in a headless browser.',
-				);
+				).stack;
 			}
 		};
 
 		window.confirm = (message) => {
 			if (message) {
-				throw new Error(
+				window.remotion_cancelledError = new Error(
 					`confirm("${message}") was called. It cannot be called in a headless browser.`,
-				);
+				).stack;
 			} else {
-				throw new Error(
+				window.remotion_cancelledError = new Error(
 					'confirm() was called. It cannot be called in a headless browser.',
-				);
+				).stack;
 			}
+
+			return false;
 		};
 	});
 

--- a/packages/renderer/src/set-props-and-env.ts
+++ b/packages/renderer/src/set-props-and-env.ts
@@ -74,6 +74,30 @@ const innerSetPropsAndEnv = async ({
 		window.remotion_videoEnabled = enabled;
 	}, videoEnabled);
 
+	await page.evaluateOnNewDocument(() => {
+		window.alert = (message) => {
+			if (message) {
+				console.error(
+					`alert("${message}") was called and suppressed by Remotion.`,
+				);
+			} else {
+				console.error('alert() was called and suppressed by Remotion.');
+			}
+		};
+
+		window.confirm = (message) => {
+			if (message) {
+				console.error(
+					`confirm("${message}") was called and suppressed by Remotion.`,
+				);
+			} else {
+				console.error('confirm() was called and suppressed by Remotion.');
+			}
+
+			return false;
+		};
+	});
+
 	const pageRes = await page.goto({url: urlToVisit, timeout: actualTimeout});
 
 	if (pageRes === null) {

--- a/packages/renderer/src/set-props-and-env.ts
+++ b/packages/renderer/src/set-props-and-env.ts
@@ -77,24 +77,26 @@ const innerSetPropsAndEnv = async ({
 	await page.evaluateOnNewDocument(() => {
 		window.alert = (message) => {
 			if (message) {
-				console.error(
-					`alert("${message}") was called and suppressed by Remotion.`,
+				throw new Error(
+					`alert("${message}") was called. It cannot be called in a headless browser.`,
 				);
 			} else {
-				console.error('alert() was called and suppressed by Remotion.');
+				throw new Error(
+					'alert() was called. It cannot be called in a headless browser.',
+				);
 			}
 		};
 
 		window.confirm = (message) => {
 			if (message) {
-				console.error(
-					`confirm("${message}") was called and suppressed by Remotion.`,
+				throw new Error(
+					`confirm("${message}") was called. It cannot be called in a headless browser.`,
 				);
 			} else {
-				console.error('confirm() was called and suppressed by Remotion.');
+				throw new Error(
+					'confirm() was called. It cannot be called in a headless browser.',
+				);
 			}
-
-			return false;
 		};
 	});
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
