### PR TITLE
`@remotion/shapes`: Fix transform-origin in Next.js

### DIFF
--- a/packages/shapes/src/components/render-svg.tsx
+++ b/packages/shapes/src/components/render-svg.tsx
@@ -54,15 +54,13 @@ export const RenderSvg = ({
 			style={actualStyle}
 		>
 			<path
-				// eslint-disable-next-line react/no-unknown-property
-				transform-origin={
-					reactSupportsTransformOrigin ? undefined : transformOrigin
-				}
 				{...(reactSupportsTransformOrigin
 					? {
 							transformOrigin,
 						}
-					: {})}
+					: {
+							'transform-origin': transformOrigin,
+						})}
 				d={path}
 				style={actualPathStyle}
 				{...props}


### PR DESCRIPTION
Even with undefined it gives the error as empirically seens