### PR TITLE
`@remotion/lottie`: Support `renderer` and `preserveAspectRatio` options

### DIFF
--- a/packages/docs/docs/lottie/lottie-comp.md
+++ b/packages/docs/docs/lottie/lottie-comp.md
@@ -67,16 +67,14 @@ CSS properties to be applied to the `<div>` that contains the animation.
 
 _"svg"_ | _"canvas"_ | _"html"_
 
-Set the renderer for the Lotti files.
-[`Supported Features`](https://github.com/airbnb/lottie-web/wiki/Features)
+Set the renderer for the Lottie files. Default `svg`. See: [`renderer` option](https://github.com/airbnb/lottie-web/wiki/Usage#getting-started), [Supported Features](https://github.com/airbnb/lottie-web/wiki/Features)
 
 ### `preserveAspectRatio`<AvailableFrom v="4.0.105" />
 
-_string_ 
+_optional, string_
 
-Set the aspect ratio of the Lotti file. 
-[`preserveAspectRatio`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio)
-
+Set how aspect ratios should be handled in the Lottie file.
+See [`preserveAspectRatio`](https://github.com/airbnb/lottie-web/wiki/Renderer-Settings#preserveaspectratio)
 
 ### `onAnimationLoaded`<AvailableFrom v="3.2.29" />
 

--- a/packages/docs/docs/lottie/lottie-comp.md
+++ b/packages/docs/docs/lottie/lottie-comp.md
@@ -63,6 +63,21 @@ The speed of the animation. A higher number is faster. Default: `1`.
 
 CSS properties to be applied to the `<div>` that contains the animation.
 
+### `renderer`<AvailableFrom v="4.0.105" />
+
+_"svg"_ | _"canvas"_ | _"html"_
+
+Set the renderer for the Lotti files.
+[`Supported Features`](https://github.com/airbnb/lottie-web/wiki/Features)
+
+### `preserveAspectRatio`<AvailableFrom v="4.0.105" />
+
+_string_ 
+
+Set the aspect ratio of the Lotti file. 
+[`preserveAspectRatio`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio)
+
+
 ### `onAnimationLoaded`<AvailableFrom v="3.2.29" />
 
 _optional_

--- a/packages/lottie/src/Lottie.tsx
+++ b/packages/lottie/src/Lottie.tsx
@@ -55,7 +55,7 @@ export const Lottie = ({
 			animationData,
 			renderer: renderer ?? 'svg',
 			rendererSettings: {
-				preserveAspectRatio: preserveAspectRatio ?? 'xMidYMid meet',
+				preserveAspectRatio: preserveAspectRatio ?? undefined,
 			},
 		});
 

--- a/packages/lottie/src/Lottie.tsx
+++ b/packages/lottie/src/Lottie.tsx
@@ -19,6 +19,8 @@ export const Lottie = ({
 	playbackRate,
 	style,
 	onAnimationLoaded,
+	renderer,
+	preserveAspectRatio,
 }: LottieProps) => {
 	if (typeof animationData !== 'object') {
 		throw new Error(
@@ -51,6 +53,10 @@ export const Lottie = ({
 			container: containerRef.current,
 			autoplay: false,
 			animationData,
+			renderer: renderer ?? 'svg',
+			rendererSettings: {
+				preserveAspectRatio: preserveAspectRatio ?? 'xMidYMid meet',
+			},
 		});
 
 		const {current: animation} = animationRef;

--- a/packages/lottie/src/types.ts
+++ b/packages/lottie/src/types.ts
@@ -8,6 +8,17 @@ export type LottieAnimationData = {
 	op: number;
 } & Record<string | number | symbol, unknown>;
 
+export type AspectRatioConstraint =
+	| 'none'
+	| 'xMinYMin'
+	| 'xMidYMin'
+	| 'xMaxYMin'
+	| 'xMinYMid'
+	| 'xMidYMid'
+	| 'xMaxYMid'
+	| 'xMinYMax'
+	| 'xMidYMax';
+
 export type LottieProps = {
 	/**
 	 * JSON object with the animation data.
@@ -33,6 +44,18 @@ export type LottieProps = {
 	 * CSS properties to apply to the container of the animation.
 	 */
 	style?: CSSProperties;
+	/**
+	 * The render engine of the Lotti files.
+	 */
+	renderer?: 'svg' | 'canvas' | 'html';
+	/**
+	 * for svg and canvas renderer it simulates the behavior of the preserveAspectRatio property on svgs.
+	 * https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
+	 */
+
+	preserveAspectRatio:
+		| AspectRatioConstraint
+		| `${AspectRatioConstraint} ${'slice' | 'meet'}`;
 	/**
 	 * Callback that gets invoked when new animation data has been initialized
 	 */

--- a/packages/lottie/src/types.ts
+++ b/packages/lottie/src/types.ts
@@ -53,7 +53,7 @@ export type LottieProps = {
 	 * https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
 	 */
 
-	preserveAspectRatio:
+	preserveAspectRatio?:
 		| AspectRatioConstraint
 		| `${AspectRatioConstraint} ${'slice' | 'meet'}`;
 	/**


### PR DESCRIPTION

  - added documentation
  - 2 new props for Lotti files: renderer & preserveAspectRatio
