### PR TITLE
`@remotion/renderer`: Fix "classic" way of SSR with renderFrames() + stitchFramesToMedia()

### DIFF
--- a/packages/it-tests/src/ssr/render-frames.test.ts
+++ b/packages/it-tests/src/ssr/render-frames.test.ts
@@ -10,7 +10,7 @@ import {
 import { expect, test } from "bun:test";
 import { RenderInternals } from "@remotion/renderer";
 
-test.only("Legacy SSR way of rendering videos should still work", async () => {
+test("Legacy SSR way of rendering videos should still work", async () => {
   const puppeteerInstance = await openBrowser("chrome");
   const compositions = await getCompositions(
     "https://65c0a612d164b60f65becedd--fluffy-bubblegum-1ed385.netlify.app/",

--- a/packages/it-tests/src/ssr/render-frames.test.ts
+++ b/packages/it-tests/src/ssr/render-frames.test.ts
@@ -10,16 +10,16 @@ import {
 import { expect, test } from "bun:test";
 import { RenderInternals } from "@remotion/renderer";
 
-test("Legacy SSR way of rendering videos should still work", async () => {
+test.only("Legacy SSR way of rendering videos should still work", async () => {
   const puppeteerInstance = await openBrowser("chrome");
   const compositions = await getCompositions(
-    "https://64d3734a6bb69052c34d3616--spiffy-kelpie-71657b.netlify.app/",
+    "https://65c0a612d164b60f65becedd--fluffy-bubblegum-1ed385.netlify.app/",
     {
       puppeteerInstance,
     }
   );
 
-  const reactSvg = compositions.find((c) => c.id === "react-svg");
+  const reactSvg = compositions.find((c) => c.id === "22khz");
 
   if (!reactSvg) {
     throw new Error("not found");
@@ -40,13 +40,12 @@ test("Legacy SSR way of rendering videos should still work", async () => {
     inputProps: {},
     onFrameUpdate: () => undefined,
     serveUrl:
-      "https://64d3734a6bb69052c34d3616--spiffy-kelpie-71657b.netlify.app/",
+      "https://65c0a612d164b60f65becedd--fluffy-bubblegum-1ed385.netlify.app/",
     concurrency: null,
     frameRange: [0, 10],
     outputDir: framesDir,
     onStart: () => undefined,
   });
-
   await stitchFramesToVideo({
     assetsInfo,
     force: true,

--- a/packages/renderer/src/assets/download-and-map-assets-to-file.ts
+++ b/packages/renderer/src/assets/download-and-map-assets-to-file.ts
@@ -30,10 +30,6 @@ const waitForAssetToBeDownloaded = ({
 	downloadDir: string;
 	downloadMap: DownloadMap;
 }): Promise<string> => {
-	if (process.env.NODE_ENV === 'test') {
-		console.log('waiting for asset to be downloaded', src);
-	}
-
 	if (downloadMap.hasBeenDownloadedMap[src]?.[downloadDir]) {
 		return Promise.resolve(
 			downloadMap.hasBeenDownloadedMap[src]?.[downloadDir] as string,
@@ -197,10 +193,6 @@ export const downloadAsset = async ({
 			[downloadDir: string]: boolean;
 		}
 	)[downloadDir] = true;
-
-	if (process.env.NODE_ENV === 'test') {
-		console.log('Actually downloading asset', src);
-	}
 
 	downloadMap.emitter.dispatchDownload(src);
 

--- a/packages/renderer/src/assets/download-map.ts
+++ b/packages/renderer/src/assets/download-map.ts
@@ -40,6 +40,9 @@ export type DownloadMap = {
 	assetDir: string;
 	compositingDir: string;
 	compositorCache: {[key: string]: string};
+	preventCleanup: () => void;
+	allowCleanup: () => void;
+	isPreventedFromCleanup: () => boolean;
 };
 
 export type RenderAssetInfo = {
@@ -68,6 +71,8 @@ export const makeDownloadMap = (): DownloadMap => {
 			: 'remotion-assets',
 	);
 
+	let prevented = false;
+
 	return {
 		isDownloadingMap: {},
 		hasBeenDownloadedMap: {},
@@ -85,10 +90,23 @@ export const makeDownloadMap = (): DownloadMap => {
 		compositingDir: makeAndReturn(dir, 'remotion-compositing-temp-dir'),
 		compositorCache: {},
 		emitter: new OffthreadVideoServerEmitter(),
+		preventCleanup: () => {
+			prevented = true;
+		},
+		allowCleanup: () => {
+			prevented = false;
+		},
+		isPreventedFromCleanup: () => {
+			return prevented;
+		},
 	};
 };
 
 export const cleanDownloadMap = (downloadMap: DownloadMap) => {
+	if (downloadMap.isPreventedFromCleanup()) {
+		return;
+	}
+
 	deleteDirectory(downloadMap.downloadDir);
 	deleteDirectory(downloadMap.complexFilter);
 	deleteDirectory(downloadMap.compositingDir);

--- a/packages/renderer/src/call-ffmpeg.ts
+++ b/packages/renderer/src/call-ffmpeg.ts
@@ -1,4 +1,6 @@
 import execa from 'execa';
+import type {SpawnOptionsWithoutStdio} from 'node:child_process';
+import {spawn} from 'node:child_process';
 import {chmodSync} from 'node:fs';
 import path from 'path';
 import {getExecutablePath} from './compositor/get-executable-path';
@@ -24,6 +26,30 @@ export const callFf = ({
 	}
 
 	return execa(executablePath, args.filter(truthy), {
+		cwd: path.dirname(executablePath),
+		...options,
+	});
+};
+
+export const callFfNative = ({
+	args,
+	bin,
+	indent,
+	logLevel,
+	options,
+}: {
+	bin: 'ffmpeg' | 'ffprobe';
+	args: (string | null)[];
+	indent: boolean;
+	logLevel: LogLevel;
+	options?: SpawnOptionsWithoutStdio;
+}) => {
+	const executablePath = getExecutablePath(bin, indent, logLevel);
+	if (!process.env.READ_ONLY_FS) {
+		chmodSync(executablePath, 0o755);
+	}
+
+	return spawn(executablePath, args.filter(truthy), {
 		cwd: path.dirname(executablePath),
 		...options,
 	});

--- a/packages/renderer/src/prepare-server.ts
+++ b/packages/renderer/src/prepare-server.ts
@@ -129,6 +129,7 @@ export const prepareServer = async ({
 
 	const {
 		port: serverPort,
+		host,
 		close,
 		compositor,
 	} = await serveStatic(webpackConfigOrServeUrl, {
@@ -152,7 +153,9 @@ export const prepareServer = async ({
 
 			return close();
 		},
-		serveUrl: `http://localhost:${serverPort}`,
+		serveUrl: `http://${
+			host.startsWith(':') ? `[${host}]` : host
+		}:${serverPort}`,
 		offthreadPort: serverPort,
 		compositor,
 		sourceMap: () => localSourceMap,

--- a/packages/renderer/src/prepare-server.ts
+++ b/packages/renderer/src/prepare-server.ts
@@ -129,7 +129,6 @@ export const prepareServer = async ({
 
 	const {
 		port: serverPort,
-		host,
 		close,
 		compositor,
 	} = await serveStatic(webpackConfigOrServeUrl, {
@@ -153,9 +152,9 @@ export const prepareServer = async ({
 
 			return close();
 		},
-		serveUrl: `http://${
-			host.startsWith(':') ? `[${host}]` : host
-		}:${serverPort}`,
+		// This should be kept localhost, even if the server is bound to ::1,
+		// to prevent "Failed to load resource: net::ERR_FAILED  Access to image at 'http://localhost:3000/proxy?src=http%3A%2F%2F%5B%3A%3A%5D%3A3000%2Fpublic%2Fframer.webm&time=0&transparent=false' from origin 'http://[::]:3000' has been blocked by CORS policy: The request client is not a secure context and the resource is in more-private address space `local`".
+		serveUrl: `http://localhost:${serverPort}`,
 		offthreadPort: serverPort,
 		compositor,
 		sourceMap: () => localSourceMap,

--- a/packages/renderer/src/serve-static.ts
+++ b/packages/renderer/src/serve-static.ts
@@ -21,6 +21,7 @@ export const serveStatic = async (
 	},
 ): Promise<{
 	port: number;
+	host: string;
 	close: () => Promise<void>;
 	compositor: Compositor;
 }> => {
@@ -138,7 +139,7 @@ export const serveStatic = async (
 				]);
 			};
 
-			return {port: selectedPort, close, compositor};
+			return {port: selectedPort, close, compositor, host: portConfig.host};
 		} catch (err) {
 			if (!(err instanceof Error)) {
 				throw err;

--- a/packages/renderer/src/serve-static.ts
+++ b/packages/renderer/src/serve-static.ts
@@ -21,7 +21,6 @@ export const serveStatic = async (
 	},
 ): Promise<{
 	port: number;
-	host: string;
 	close: () => Promise<void>;
 	compositor: Compositor;
 }> => {
@@ -139,7 +138,7 @@ export const serveStatic = async (
 				]);
 			};
 
-			return {port: selectedPort, close, compositor, host: portConfig.host};
+			return {port: selectedPort, close, compositor};
 		} catch (err) {
 			if (!(err instanceof Error)) {
 				throw err;

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -15,7 +15,7 @@ import {
 	getDefaultAudioCodec,
 	mapAudioCodecToFfmpegAudioCodecName,
 } from './audio-codec';
-import {callFf} from './call-ffmpeg';
+import {callFf, callFfNative} from './call-ffmpeg';
 import type {Codec} from './codec';
 import {DEFAULT_CODEC} from './codec';
 import {codecSupportsMedia} from './codec-supports-media';
@@ -107,10 +107,7 @@ export type StitchFramesToVideoOptions = {
 	colorSpace?: ColorSpace;
 };
 
-type ReturnType = {
-	task: Promise<Buffer | null>;
-	getLogs: () => string;
-};
+type ReturnType = Promise<Buffer | null>;
 
 const getAssetsData = async ({
 	assets,
@@ -405,10 +402,7 @@ const innerStitchFramesToVideo = async (
 		});
 		deleteDirectory(assetsInfo.downloadMap.stitchFrames);
 
-		return {
-			getLogs: () => '',
-			task: Promise.resolve(file),
-		};
+		return Promise.resolve(file);
 	}
 
 	const ffmpegArgs = [
@@ -476,7 +470,7 @@ const innerStitchFramesToVideo = async (
 		finalFfmpegString.join(' '),
 	);
 
-	const task = callFf({
+	const task = callFfNative({
 		bin: 'ffmpeg',
 		args: finalFfmpegString,
 		indent,
@@ -485,11 +479,12 @@ const innerStitchFramesToVideo = async (
 	cancelSignal?.(() => {
 		task.kill();
 	});
-	let ffmpegOutput = '';
+	let ffmpegStderr = '';
 	let isFinished = false;
+
 	task.stderr?.on('data', (data: Buffer) => {
 		const str = data.toString();
-		ffmpegOutput += str;
+		ffmpegStderr += str;
 		if (onProgress) {
 			const parsed = parseFfmpegProgress(str);
 			// FFMPEG bug: In some cases, FFMPEG does hang after it is finished with it's job
@@ -509,35 +504,48 @@ const innerStitchFramesToVideo = async (
 		}
 	});
 
-	return {
-		task: task.then(() => {
-			assetsInfo.downloadMap.allowCleanup();
+	return new Promise<Buffer | null>((resolve, reject) => {
+		task.once('close', (code, signal) => {
+			if (code === 0) {
+				assetsInfo.downloadMap.allowCleanup();
 
-			if (tempFile === null) {
-				cleanDownloadMap(assetsInfo.downloadMap);
-				return null;
+				if (tempFile === null) {
+					cleanDownloadMap(assetsInfo.downloadMap);
+					return resolve(null);
+				}
+
+				promises
+					.readFile(tempFile)
+					.then((f) => {
+						resolve(f);
+					})
+					.catch((e) => {
+						reject(e);
+					})
+					.finally(() => {
+						cleanDownloadMap(assetsInfo.downloadMap);
+					});
+			} else {
+				reject(
+					new Error(
+						`FFmpeg quit with code ${code} ${
+							signal ? `(${signal})` : ''
+						} The FFmpeg output was ${ffmpegStderr}`,
+					),
+				);
 			}
-
-			return promises.readFile(tempFile).finally(() => {
-				cleanDownloadMap(assetsInfo.downloadMap);
-			});
-		}),
-		getLogs: () => ffmpegOutput,
-	};
+		});
+	});
 };
 
 export const internalStitchFramesToVideo = async (
 	options: InternalStitchFramesToVideoOptions,
 ): Promise<Buffer | null> => {
 	const remotionRoot = findRemotionRoot();
-	const {task, getLogs} = await innerStitchFramesToVideo(options, remotionRoot);
-
-	const happyPath = task.catch(() => {
-		throw new Error(getLogs());
-	});
+	const task = await innerStitchFramesToVideo(options, remotionRoot);
 
 	return Promise.race([
-		happyPath,
+		task,
 		new Promise<Buffer | null>((_resolve, reject) => {
 			options.cancelSignal?.(() => {
 				reject(new Error(cancelErrorMessages.stitchFramesToVideo));

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -512,18 +512,15 @@ const innerStitchFramesToVideo = async (
 	return {
 		task: task.then(() => {
 			assetsInfo.downloadMap.allowCleanup();
-			cleanDownloadMap(assetsInfo.downloadMap);
 
 			if (tempFile === null) {
+				cleanDownloadMap(assetsInfo.downloadMap);
 				return null;
 			}
 
-			return promises
-				.readFile(tempFile)
-				.then((file) => {
-					return Promise.all([file, deleteDirectory(path.dirname(tempFile))]);
-				})
-				.then(([file]) => file);
+			return promises.readFile(tempFile).finally(() => {
+				cleanDownloadMap(assetsInfo.downloadMap);
+			});
 		}),
 		getLogs: () => ffmpegOutput,
 	};


### PR DESCRIPTION
Audio would clean up too early for this