### PR TITLE
Removed --save-exact option from pnpm command

### DIFF
--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -18,7 +18,7 @@ const getUpgradeCommand = ({
 	const pkgList = packages.map((p) => `${p}@${version}`);
 	const commands: {[key in PackageManager]: string[]} = {
 		npm: ['i', '--save-exact', '--no-fund', '--no-audit', ...pkgList],
-		pnpm: ['i', '--save-exact', ...pkgList],
+		pnpm: ['i', ...pkgList],
 		yarn: ['add', '--exact', ...pkgList],
 		bun: ['i', ...pkgList],
 	};


### PR DESCRIPTION
`--save-exact` option does not exist on `pnpm install` command.

It only exists on `pnpm add`

Running `pnpm exec remotion upgrade` in a pnpm project results in an error: `--save-exact` option does not exist.

https://pnpm.io/cli/install#options