### PR TITLE
`@remotion/lambda`: Set `optimizeForSpeed` to true

### DIFF
--- a/packages/renderer/src/screenshot-task.ts
+++ b/packages/renderer/src/screenshot-task.ts
@@ -75,7 +75,7 @@ export const screenshotTask = async ({
 								width,
 							},
 				captureBeyondViewport: true,
-				optimizeForSpeed: false,
+				optimizeForSpeed: true,
 				// We find that there is a 0.1% framedrop when rendering under memory pressure
 				// which can be circumvented by disabling this option on Lambda.
 				// To be determined: Is this a problem with Lambda, or the Chrome version


### PR DESCRIPTION
This was set to false a few versions ago but led to performance regressions

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
