### PR TITLE
docs: New solution to background-image flickering.

### DIFF
--- a/packages/docs/docs/troubleshooting/background-image.md
+++ b/packages/docs/docs/troubleshooting/background-image.md
@@ -1,7 +1,7 @@
 ---
 image: /generated/articles-docs-troubleshooting-background-image.png
 sidebar_label: Flickering with background-image
-title: Flickering when using background-image
+title: Flickering when using background-image or mask-image
 crumb: "Common mistakes"
 ---
 
@@ -27,7 +27,35 @@ Remotion has no way of knowing when the image is finished loading because it is 
 
 ## Solution
 
-Include an [`<Img>`](/docs/img) tag that renders the same src on that frame hide with CSS:
+Use the [`<Img>`](/docs/img) tag instead and place it in an [`<AbsoluteFill>`](/docs/absolute-fill):
+
+```tsx twoslash title="✅ Do this"
+const src = "abc";
+// ---cut---
+import { AbsoluteFill, Img } from "remotion";
+
+const myMarkup = (
+  <AbsoluteFill>
+    <AbsoluteFill>
+      <Img
+        style={{
+          width: "100%",
+        }}
+        src={src}
+      />
+    </AbsoluteFill>
+    <AbsoluteFill>
+      <p>Hello World</p>
+    </AbsoluteFill>
+  </AbsoluteFill>
+);
+```
+
+The next will be placed on top of the image and will not flicker.
+
+## Workaround
+
+If you cannot use an [`<Img>`](/docs/img) tag, for example because you need to use `mask-image()`, render an adjacent `<Img>` tag that renders the same src and place it outside the viewport:
 
 ```tsx twoslash title="✅ Do this"
 const src = "abc";
@@ -36,14 +64,17 @@ import { Img } from "remotion";
 
 const myMarkup = (
   <>
-    <Img src={src} style={{
-      opacity: 0,
-      position: "absolute",
-      left: "-100%",
-    }} />
+    <Img
+      src={src}
+      style={{
+        opacity: 0,
+        position: "absolute",
+        left: "-100%",
+      }}
+    />
     <div
       style={{
-        backgroundImage: `url(${src})`,
+        maskImage: `url(${src})`,
       }}
     >
       <p>Hello World</p>

--- a/packages/docs/docs/troubleshooting/background-image.md
+++ b/packages/docs/docs/troubleshooting/background-image.md
@@ -23,33 +23,36 @@ const myMarkup = (
 
 ## Problem
 
-Remotion has no way of knowing when the image is finished loading because it is impossible to determine so when loading an image through `background-image`. This will lead to Remotion not waiting for the image to be loaded during rendering and cause visible flickers.
+Remotion has no way of knowing when the image is finished loading because it is impossible to determine so when loading an image through `background-image`, `mask-image`, or other CSS properties. This will lead to Remotion not waiting for the image to be loaded during rendering and cause visible flickers.
 
 ## Solution
 
-Use the [`<Img>`](/docs/img) tag instead and place it in an [`<AbsoluteFill>`](/docs/absolute-fill):
+Include an [`<Img>`](/docs/img) tag that renders the same src on that frame hide with CSS:
 
 ```tsx twoslash title="✅ Do this"
 const src = "abc";
 // ---cut---
-import { AbsoluteFill, Img } from "remotion";
+import { Img } from "remotion";
 
 const myMarkup = (
-  <AbsoluteFill>
-    <AbsoluteFill>
-      <Img
-        style={{
-          width: "100%",
-        }}
-        src={src}
-      />
-    </AbsoluteFill>
-    <AbsoluteFill>
+  <>
+    <Img src={src} style={{
+      opacity: 0,
+      position: "absolute",
+      left: "-100%",
+    }} />
+    <div
+      style={{
+        backgroundImage: `url(${src})`,
+      }}
+    >
       <p>Hello World</p>
-    </AbsoluteFill>
-  </AbsoluteFill>
+    </div>
+  </>
 );
 ```
+
+The hidden `<Img>` tag ensures the image will download completely which allows the `background-image` will fully render.
 
 ## See also
 


### PR DESCRIPTION
The existing solution works for `background-image`, but not for `mask-image`. The solution proposed in the commit works for both, and in some cases might be simpler to implement.
