### PR TITLE
`@remotion/renderer`: Fix combining videos progress report

### DIFF
--- a/packages/renderer/src/combine-videos.ts
+++ b/packages/renderer/src/combine-videos.ts
@@ -97,7 +97,7 @@ export const combineVideos = async (options: Options) => {
 		});
 		task.stderr?.on('data', (data: Buffer) => {
 			if (onProgress) {
-				const parsed = parseFfmpegProgress(data.toString('utf8'));
+				const parsed = parseFfmpegProgress(data.toString('utf8'), fps);
 				if (parsed === undefined) {
 					Log.verbose({indent, logLevel}, data.toString('utf8'));
 				} else {

--- a/packages/renderer/src/parse-ffmpeg-progress.ts
+++ b/packages/renderer/src/parse-ffmpeg-progress.ts
@@ -1,8 +1,20 @@
-export const parseFfmpegProgress = (input: string): number | undefined => {
+export const parseFfmpegProgress = (
+	input: string,
+	fps: number,
+): number | undefined => {
 	const match = input.match(/frame=(\s+)?([0-9]+)\s/);
-	if (!match) {
-		return undefined;
+	if (match) {
+		return Number(match[2]);
 	}
 
-	return Number(match[2]);
+	const match2 = input.match(/time=(\d+):(\d+):(\d+).(\d+)\s/);
+	if (match2) {
+		const [, hours, minutes, seconds, hundreds] = match2;
+		return (
+			(Number(hundreds) / 100) * fps +
+			Number(seconds) * fps +
+			Number(minutes) * fps * 60 +
+			Number(hours) * fps * 60 * 60
+		);
+	}
 };

--- a/packages/renderer/src/prespawn-ffmpeg.ts
+++ b/packages/renderer/src/prespawn-ffmpeg.ts
@@ -147,7 +147,7 @@ export const prespawnFfmpeg = (options: PreStitcherOptions) => {
 		const str = data.toString();
 		ffmpegOutput += str;
 		if (options.onProgress) {
-			const parsed = parseFfmpegProgress(str);
+			const parsed = parseFfmpegProgress(str, options.fps);
 			if (parsed !== undefined) {
 				options.onProgress(parsed);
 			}

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -486,7 +486,7 @@ const innerStitchFramesToVideo = async (
 		const str = data.toString();
 		ffmpegStderr += str;
 		if (onProgress) {
-			const parsed = parseFfmpegProgress(str);
+			const parsed = parseFfmpegProgress(str, fps);
 			// FFMPEG bug: In some cases, FFMPEG does hang after it is finished with it's job
 			// Example repo: https://github.com/JonnyBurger/ffmpeg-repro (access can be given upon request)
 			if (parsed !== undefined) {

--- a/packages/renderer/src/test/parse-ffmpeg-progress.test.ts
+++ b/packages/renderer/src/test/parse-ffmpeg-progress.test.ts
@@ -2,11 +2,12 @@ import {expect, test} from 'vitest';
 import {parseFfmpegProgress} from '../parse-ffmpeg-progress';
 
 test('Should be able to parse FFMPEG progress', () => {
-	const result = parseFfmpegProgress('anything');
+	const result = parseFfmpegProgress('anything', 30);
 	expect(result).toBe(undefined);
 	expect(
 		parseFfmpegProgress(
 			'frame=   34 fps=5.7 q=0.0 size=       0kB time=00:00:00.15 bitrate=  27.0kbits/s speed=0.0253x',
+			30,
 		),
 	).toBe(34);
 });
@@ -14,6 +15,7 @@ test('Should be able to parse 5 digits progress', () => {
 	expect(
 		parseFfmpegProgress(
 			'frame=10234 fps=5.7 q=0.0 size=       0kB time=00:00:00.15 bitrate=  27.0kbits/s speed=0.0253x',
+			30,
 		),
 	).toBe(10234);
 });
@@ -22,6 +24,16 @@ test('another failure', () => {
 	expect(
 		parseFfmpegProgress(
 			'frame= 3188 fps=104 q=-1.0 size=   11776kB time=00:01:46.19 bitrate= 908.4kbits/s speed=3.46x',
+			30,
 		),
 	).toBe(3188);
+});
+
+test('New "time" output', () => {
+	expect(
+		parseFfmpegProgress(
+			'size= 130048kB time=00:02:37.70 bitrate=6755.6kbits/s speed=7.14x',
+			30,
+		),
+	).toBe(4731);
 });


### PR DESCRIPTION
New FFmpeg versions have different way of progress reporting