### PR TITLE
With custom credentials, use provided region for S3 endpoint

### DIFF
--- a/packages/docs/docs/lambda/custom-destination.mdx
+++ b/packages/docs/docs/lambda/custom-destination.mdx
@@ -106,6 +106,24 @@ If you want to use this feature, note the following:
 
 This feature is not supported from the CLI.
 
+### Adding a custom region to the S3 output provider<AvailableFrom v="4.0.112">
+
+If you plan on saving to another bucket on AWS S3 and would like to use different credentials, you can specify the `region` in the `s3OutputProvider` object.
+
+```json
+{
+  "s3OutputProvider": {
+    "endpoint": "https://s3.us-west-1.amazonaws.com",
+    "accessKeyId": "<DIGITAL_OCEAN_ACCESS_KEY_ID>",
+    "secretAccessKey": "<DIGITAL_OCEAN_SECRET_ACCESS_KEY>",
+    "region": "us-west-1"
+  }
+}
+```
+
+Note that it is not necessary to provide a custom `s3OutputProvider` if you want to use the same role as you already gave to the Lambda.  
+You may need to extend your [role policy](/docs/lambda/setup#2-create-role-policy) to allow writing to this bucket.
+
 ## See also
 
 - Customizing the filename when a file is downloaded using `downloadBehavior`: For [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda#downloadbehavior) and [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda#downloadbehavior)

--- a/packages/docs/docs/lambda/custom-destination.mdx
+++ b/packages/docs/docs/lambda/custom-destination.mdx
@@ -106,7 +106,7 @@ If you want to use this feature, note the following:
 
 This feature is not supported from the CLI.
 
-### Adding a custom region to the S3 output provider<AvailableFrom v="4.0.112">
+### Adding a custom region to the S3 output provider<AvailableFrom v="4.0.112"/>
 
 If you plan on saving to another bucket on AWS S3 and would like to use different credentials, you can specify the `region` in the `s3OutputProvider` object.
 

--- a/packages/lambda/src/shared/aws-clients.ts
+++ b/packages/lambda/src/shared/aws-clients.ts
@@ -203,7 +203,7 @@ export const getServiceClient = <T extends keyof ServiceMapping>({
 
 		if (customCredentials) {
 			_clients[key] = new Client({
-				region: 'us-east-1',
+				region: customCredentials.endpoint.endsWith('amazonaws.com') ? region: 'us-east-1',
 				credentials:
 					customCredentials.accessKeyId && customCredentials.secretAccessKey
 						? {

--- a/packages/lambda/src/shared/aws-clients.ts
+++ b/packages/lambda/src/shared/aws-clients.ts
@@ -153,6 +153,7 @@ export type CustomCredentialsWithoutSensitiveData = {
 export type CustomCredentials = CustomCredentialsWithoutSensitiveData & {
 	accessKeyId: string | null;
 	secretAccessKey: string | null;
+	region: AwsRegion | undefined;
 };
 
 export const getServiceClient = <T extends keyof ServiceMapping>({
@@ -203,7 +204,7 @@ export const getServiceClient = <T extends keyof ServiceMapping>({
 
 		if (customCredentials) {
 			_clients[key] = new Client({
-				region: customCredentials.endpoint.endsWith('amazonaws.com') ? region: 'us-east-1',
+				region: customCredentials.region ?? 'us-east-1',
 				credentials:
 					customCredentials.accessKeyId && customCredentials.secretAccessKey
 						? {

--- a/packages/lambda/src/shared/aws-clients.ts
+++ b/packages/lambda/src/shared/aws-clients.ts
@@ -153,7 +153,7 @@ export type CustomCredentialsWithoutSensitiveData = {
 export type CustomCredentials = CustomCredentialsWithoutSensitiveData & {
 	accessKeyId: string | null;
 	secretAccessKey: string | null;
-	region: AwsRegion | undefined;
+	region?: AwsRegion;
 };
 
 export const getServiceClient = <T extends keyof ServiceMapping>({


### PR DESCRIPTION
Closes #3474

Read the original issue for context on the problem.

This fix allows user to specify a custom `region` to `CustomCredentials` for constructing a Client.