### PR TITLE
Update overwriting-webpack-config.md

### DIFF
--- a/packages/docs/docs/overwriting-webpack-config.md
+++ b/packages/docs/docs/overwriting-webpack-config.md
@@ -210,14 +210,14 @@ values={[
 <TabItem value="npm">
 
 ```bash
-npm i sass sass-loader
+npm i sass style-loader css-loader sass-loader
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```bash
-pnpm i sass sass-loader
+pnpm i sass style-loader css-loader sass-loader
 ```
 
   </TabItem>
@@ -225,7 +225,7 @@ pnpm i sass sass-loader
   <TabItem value="yarn">
 
 ```bash
-yarn add sass sass-loader
+yarn add sass style-loader css-loader sass-loader
 ```
 
   </TabItem>


### PR DESCRIPTION
I'm fumbling my way through sass, but I couldn't get this to work without installing these other packages. Are they required? They are listed in the webpack config;

```
...
use: [
   { loader: "style-loader" },
   { loader: "css-loader" },
   { loader: "sass-loader", options: { sourceMap: true } },
],
```