### PR TITLE
`@remotion/bundler`: Allow a webpack override to be async

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -192,7 +192,7 @@ export async function bundle(...args: Arguments): Promise<string> {
 	}
 
 	const {onProgress, ...options} = actualArgs;
-	const [, config] = getConfig({
+	const [, config] = await getConfig({
 		outDir,
 		entryPoint,
 		resolvedRemotionRoot,

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -14,7 +14,7 @@ export type WebpackConfiguration = Configuration;
 
 export type WebpackOverrideFn = (
 	currentConfiguration: WebpackConfiguration,
-) => WebpackConfiguration;
+) => WebpackConfiguration | Promise<WebpackConfiguration>;
 
 if (!ReactDOM?.version) {
 	throw new Error('Could not find "react-dom" package. Did you install it?');
@@ -41,7 +41,7 @@ function truthy<T>(value: T): value is Truthy<T> {
 	return Boolean(value);
 }
 
-export const webpackConfig = ({
+export const webpackConfig = async ({
 	entry,
 	userDefinedComponent,
 	outDir,
@@ -67,7 +67,7 @@ export const webpackConfig = ({
 	bufferStateDelayInMilliseconds: number | null;
 	remotionRoot: string;
 	poll: number | null;
-}): [string, WebpackConfiguration] => {
+}): Promise<[string, WebpackConfiguration]> => {
 	let lastProgress = 0;
 
 	const isBun = typeof Bun !== 'undefined';
@@ -79,7 +79,7 @@ export const webpackConfig = ({
 			bufferStateDelayInMilliseconds,
 	});
 
-	const conf: WebpackConfiguration = webpackOverride({
+	const conf: WebpackConfiguration = await webpackOverride({
 		optimization: {
 			minimize: false,
 		},

--- a/packages/cli/src/config/override-webpack.ts
+++ b/packages/cli/src/config/override-webpack.ts
@@ -2,7 +2,7 @@ import type {WebpackConfiguration} from '@remotion/bundler';
 
 export type WebpackOverrideFn = (
 	currentConfiguration: WebpackConfiguration,
-) => WebpackConfiguration;
+) => WebpackConfiguration | Promise<WebpackConfiguration>;
 
 export const defaultOverrideFunction: WebpackOverrideFn = (config) => config;
 let overrideFn: WebpackOverrideFn = defaultOverrideFunction;

--- a/packages/cli/src/setup-cache.ts
+++ b/packages/cli/src/setup-cache.ts
@@ -195,7 +195,7 @@ export const bundleOnCli = async ({
 		onSymlinkDetected,
 	};
 
-	const [hash] = BundlerInternals.getConfig({
+	const [hash] = await BundlerInternals.getConfig({
 		outDir: '',
 		entryPoint: fullPath,
 		onProgress,

--- a/packages/docs/docs/config.md
+++ b/packages/docs/docs/config.md
@@ -25,26 +25,6 @@ Config.setPixelFormat("yuv444p");
 Config.setCodec("h265");
 ```
 
-## Old config file format
-
-In v3.3.39, a new config file format was introduced which flattens the options so they can more easily be discovered using TypeScript autocompletion.
-
-Previously, each config option was two levels deep:
-
-```ts title="remotion.config.ts"
-Config.Bundling.setCachingEnabled(false);
-```
-
-From v3.3.39 on, all options can be accessed directly from the `Config` object.
-
-```ts twoslash title="remotion.config.ts"
-import { Config } from "@remotion/cli/config";
-// ---cut---
-Config.setCachingEnabled(false);
-```
-
-The old way is deprecated, but will work for the foreseeable future.
-
 ## overrideWebpackConfig()<AvailableFrom v="1.1.0" />
 
 Allows you to insert your custom Webpack config. [See the page about custom Webpack configs](/docs/webpack) for more information.
@@ -866,6 +846,45 @@ Config.setPort(3003);
 ```
 
 The [command line flag](/docs/cli/render#--port) `--port` will take precedence over this option. If set on `npx remotion studio`, it will set the Studio port, otherwise the renderer port.
+
+## Importing ES Modules
+
+The [config file](/docs/config) gets executed in a CommonJS environment. If you want to import ES modules to override the Webpack config, you can pass an async function to `Config.overrideWebpackConfig()`:
+
+```ts twoslash title="remotion.config.ts"
+// @filename: src/enable-sass.ts
+import { WebpackOverrideFn } from "@remotion/bundler";
+export const enableSass: WebpackOverrideFn = (c) => c;
+
+// @filename: remotion.config.ts
+// ---cut---
+import { Config } from "@remotion/cli/config";
+
+Config.overrideWebpackConfig(async (currentConfiguration) => {
+  const { enableSass } = await import("./src/enable-sass");
+  return enableSass(currentConfiguration);
+});
+```
+
+## Old config file format
+
+In v3.3.39, a new config file format was introduced which flattens the options so they can more easily be discovered using TypeScript autocompletion.
+
+Previously, each config option was two levels deep:
+
+```ts title="remotion.config.ts"
+Config.Bundling.setCachingEnabled(false);
+```
+
+From v3.3.39 on, all options can be accessed directly from the `Config` object.
+
+```ts twoslash title="remotion.config.ts"
+import { Config } from "@remotion/cli/config";
+// ---cut---
+Config.setCachingEnabled(false);
+```
+
+The old way is deprecated, but will work for the foreseeable future.
 
 ## See also
 

--- a/packages/docs/docs/overwriting-webpack-config.mdx
+++ b/packages/docs/docs/overwriting-webpack-config.mdx
@@ -6,7 +6,7 @@ crumb: "How To"
 ---
 
 import Tabs from "@theme/Tabs";
-import TabItem from '@theme/TabItem';
+import TabItem from "@theme/TabItem";
 
 Remotion ships with [it's own Webpack configuration](https://github.com/remotion-dev/remotion/blob/main/packages/bundler/src/webpack-config.ts).
 
@@ -14,7 +14,7 @@ You can override it reducer-style by creating a function that takes the previous
 
 ## When rendering using the command line
 
-In your `remotion.config.ts` file, you can call `Config.Bundler.overrideWebpackConfig()` from `remotion`.
+In your [`remotion.config.ts`](/docs/config) file, you can call [`Config.overrideWebpackConfig()`](/docs/config#overridewebpackconfig) from `@remotion/cli/config`.
 
 ```ts twoslash title="remotion.config.ts"
 import { Config } from "@remotion/cli/config";
@@ -420,6 +420,25 @@ See [TypeScript aliases](/docs/typescript-aliases).
 ## Customizing configuration file location
 
 You can pass a `--config` option to the command line to specify a custom location for your configuration file.
+
+## Importing ES Modules in remotion.config.ts<AvailableFrom v="4.0.117"/>
+
+The [config file](/docs/config) gets executed in a CommonJS environment. If you want to import ES modules, you can pass an async function to `Config.overrideWebpackConfig`:
+
+```ts twoslash title="remotion.config.ts"
+// @filename: src/enable-sass.ts
+import { WebpackOverrideFn } from "@remotion/bundler";
+export const enableSass: WebpackOverrideFn = (c) => c;
+
+// @filename: remotion.config.ts
+// ---cut---
+import { Config } from "@remotion/cli/config";
+
+Config.overrideWebpackConfig(async (currentConfiguration) => {
+  const { enableSass } = await import("./src/enable-sass");
+  return enableSass(currentConfiguration);
+});
+```
 
 ## See also
 

--- a/packages/example/remotion.config.ts
+++ b/packages/example/remotion.config.ts
@@ -1,5 +1,11 @@
 import {Config} from '@remotion/cli/config';
+
 import {webpackOverride} from './src/webpack-override.mjs';
 
 Config.setOverwriteOutput(true);
-Config.overrideWebpackConfig(webpackOverride);
+Config.overrideWebpackConfig(async (config) => {
+	await new Promise((resolve) => {
+		setTimeout(resolve, 10);
+	});
+	return webpackOverride(config);
+});

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -44,7 +44,7 @@ export const startServer = async (options: {
 	port: number;
 	liveEventsServer: LiveEventsServer;
 }> => {
-	const [, config] = BundlerInternals.webpackConfig({
+	const [, config] = await BundlerInternals.webpackConfig({
 		entry: options.entry,
 		userDefinedComponent: options.userDefinedComponent,
 		outDir: null,


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
