### PR TITLE
`remotion`: Fix native buffering state when using startFrom and endAt props

### DIFF
--- a/packages/core/src/audio/Audio.tsx
+++ b/packages/core/src/audio/Audio.tsx
@@ -112,6 +112,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 			>
 				<Audio
 					_remotionInternalNeedsDurationCalculation={Boolean(loop)}
+					pauseWhenBuffering={pauseWhenBuffering ?? false}
 					{...otherProps}
 					ref={ref}
 				/>

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -47,7 +47,10 @@ export const OffthreadVideo: React.FC<OffthreadVideoProps> = (props) => {
 				durationInFrames={endAtFrameNo}
 				name={name}
 			>
-				<OffthreadVideo {...otherProps} />
+				<OffthreadVideo
+					pauseWhenBuffering={pauseWhenBuffering ?? false}
+					{...otherProps}
+				/>
 			</Sequence>
 		);
 	}

--- a/packages/core/src/video/Video.tsx
+++ b/packages/core/src/video/Video.tsx
@@ -101,7 +101,11 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 				durationInFrames={endAtFrameNo}
 				name={name}
 			>
-				<Video {...otherProps} ref={ref} />
+				<Video
+					pauseWhenBuffering={pauseWhenBuffering ?? false}
+					{...otherProps}
+					ref={ref}
+				/>
 			</Sequence>
 		);
 	}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
