### PR TITLE
`@remotion/renderer`: Fix video wrongly being tone mapped

### DIFF
--- a/packages/bugs/api/[v].ts
+++ b/packages/bugs/api/[v].ts
@@ -8,6 +8,13 @@ type Bug = {
 
 const bugs: Bug[] = [
   {
+    title: "Videos have bad colors during rendering",
+    description:
+      "Videos could become too dark when rendering by being tone-mapped when they should not. Upgrade to 4.0.118.",
+    link: "https://github.com/remotion-dev/remotion/pull/3518",
+    versions: ["4.0.117"],
+  },
+  {
     title: "Every render now by default emits a repro.zip",
     description:
       "This was unintentional and has been removed. Upgrade to 4.0.116.",

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -61,7 +61,7 @@ export const OffthreadVideo: React.FC<OffthreadVideoProps> = (props) => {
 		return <OffthreadVideoForRendering {...otherProps} />;
 	}
 
-	const {transparent, ...withoutTransparent} = otherProps;
+	const {transparent, toneMapped, ...withoutTransparent} = otherProps;
 
 	return (
 		<VideoForPreview

--- a/packages/renderer/rust/tone_map.rs
+++ b/packages/renderer/rust/tone_map.rs
@@ -65,7 +65,11 @@ pub fn make_tone_map_filtergraph(
         _ => "input",
     };
 
-    let is_bt_601 = matrix_in == "input" && transfer_in == "input" && primaries == "input";
+    let matrix_is_target = matrix_in == "input" || matrix_in == "709";
+    let transfer_is_target = transfer_in == "input" || transfer_in == "709";
+    let primaries_is_target = primaries == "input" || primaries == "709";
+
+    let is_bt_601 = matrix_is_target && transfer_is_target && primaries_is_target;
 
     let filter_string  = match  is_bt_601 {
         false => format!(


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
