### PR TITLE
`@remotion/renderer`: Fix browser tab cycling

### DIFF
--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -698,13 +698,14 @@ const internalRenderFramesRaw = ({
 
 				const browserReplacer = handleBrowserCrash(pInstance, logLevel, indent);
 
+				const cycle = cycleBrowserTabs(
+					browserReplacer,
+					actualConcurrency,
+					logLevel,
+					indent,
+				);
 				cleanup.push(() => {
-					cycleBrowserTabs(
-						browserReplacer,
-						actualConcurrency,
-						logLevel,
-						indent,
-					).stopCycling();
+					cycle.stopCycling();
 					return Promise.resolve();
 				});
 				cleanup.push(() => cleanupServer(false));


### PR DESCRIPTION
Was broken in 4.0.103, might have hindered multithreaded rendering