### PR TITLE
`@remotion/media-utils`: Consistent sample rate across devices

### DIFF
--- a/packages/docs/docs/get-audio-data.md
+++ b/packages/docs/docs/get-audio-data.md
@@ -34,6 +34,14 @@ You can <a href="/docs/chromium-flags#--disable-web-security">disable CORS</a> d
 
 A string pointing to an audio asset.
 
+### `options?`<AvailableFrom v="4.0.121"/>
+
+#### `sampleRate?`<AvailableFrom v="4.0.121"/>
+
+The `sampleRate` that should be passed into the [`AudioContext`](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext) constructor. If not provided, the default value is `48000`.
+
+In versions before 4.0.121, the default value was `undefined`, leading to undeterministic behavior across devices rendering.
+
 ## Return value
 
 _`Promise<AudioData>`_
@@ -50,7 +58,11 @@ An array with waveform information for each channel.
 
 _number_
 
-How many samples per second each waveform contains.
+The sample rate of the generated `AudioContext`. This will be the same as the `sampleRate` input option if passed, `48000` otherwise, and in version previous to 4.0.121, the sample rate of the device's preferred output device.
+
+:::note
+Previously, this documentation stated that this is the sample rate of the audio file. This is incorrect. [The sample rate of the audio file is not exposed to the browser's JavaScript environment.](https://github.com/WebAudio/web-audio-api/issues/30)
+:::
 
 ### `durationInSeconds`
 

--- a/packages/media-utils/src/get-audio-data.ts
+++ b/packages/media-utils/src/get-audio-data.ts
@@ -32,7 +32,11 @@ const fetchWithCorsCatch = async (src: string) => {
 	}
 };
 
-const fn = async (src: string): Promise<AudioData> => {
+type Options = {
+	sampleRate?: number;
+};
+
+const fn = async (src: string, options?: Options): Promise<AudioData> => {
 	if (metadataCache[src]) {
 		return metadataCache[src];
 	}
@@ -41,7 +45,9 @@ const fn = async (src: string): Promise<AudioData> => {
 		throw new Error('getAudioData() is only available in the browser.');
 	}
 
-	const audioContext = new AudioContext();
+	const audioContext = new AudioContext({
+		sampleRate: options?.sampleRate ?? 48000,
+	});
 
 	const response = await fetchWithCorsCatch(src);
 	const arrayBuffer = await response.arrayBuffer();
@@ -56,7 +62,7 @@ const fn = async (src: string): Promise<AudioData> => {
 
 	const metadata: AudioData = {
 		channelWaveforms,
-		sampleRate: audioContext.sampleRate,
+		sampleRate: wave.sampleRate,
 		durationInSeconds: wave.duration,
 		numberOfChannels: wave.numberOfChannels,
 		resultId: String(Math.random()),
@@ -70,6 +76,6 @@ const fn = async (src: string): Promise<AudioData> => {
  * @description Takes an audio src, loads it and returns data and metadata for the specified source.
  * @see [Documentation](https://www.remotion.dev/docs/get-audio-data)
  */
-export const getAudioData = (src: string) => {
-	return limit(fn, src);
+export const getAudioData = (src: string, options?: Options) => {
+	return limit(fn, src, options);
 };


### PR DESCRIPTION
- Give a default sample rate to make the waveform appear consistent across devices. Fixes #3528
- Acknowledge that the output of `getAudioData()` is wrong and the docs are wrong, and document why. It cannot be fixed, so closes #1370