### PR TITLE
Remove dotenv usage in remotionb-cli.js

### DIFF
--- a/packages/cli/remotionb-cli.js
+++ b/packages/cli/remotionb-cli.js
@@ -1,6 +1,4 @@
 #!/usr/bin/env bun
-const dotenv = require('dotenv');
-dotenv.config();
 const {cli} = require('./dist/index');
 
 // Just like "remotion", but it uses Bun


### PR DESCRIPTION
Bun doesn't need dotenv. It automatically loads env variables
