### PR TITLE
fix: increase minimum value for shutterAngle slider

### DIFF
--- a/packages/docs/components/CameraMotionBlurExample/CameraMotionBlurExample.tsx
+++ b/packages/docs/components/CameraMotionBlurExample/CameraMotionBlurExample.tsx
@@ -132,7 +132,7 @@ export const CameraMotionBlurExample: React.FC = () => {
         <label style={row}>
           <input
             type="range"
-            min={0}
+            min={1}
             max={360}
             step={1}
             value={shutterAngle}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

In Camera Motion Blur example, the player crashes when shutterAngle is zero.
![image](https://github.com/remotion-dev/remotion/assets/38887390/1e755391-ecd6-46a7-95b6-4d19ee3da21b)

