### PR TITLE
`@remotion/renderer`: Get rid of READ_ONLY_FS

### DIFF
--- a/packages/cli/src/ffmpeg.ts
+++ b/packages/cli/src/ffmpeg.ts
@@ -2,7 +2,6 @@ import type {LogLevel} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import {BrowserSafeApis} from '@remotion/renderer/client';
 import {spawnSync} from 'node:child_process';
-import {chmodSync} from 'node:fs';
 import path from 'node:path';
 import {parsedCli} from './parse-command-line';
 
@@ -52,9 +51,7 @@ export const ffmpegCommand = (
 		logLevel,
 		binariesDirectory,
 	});
-	if (!process.env.READ_ONLY_FS) {
-		chmodSync(binary, 0o755);
-	}
+	RenderInternals.makeFileExecutableIfItIsNot(binary);
 
 	const done = spawnSync(binary, args, {
 		stdio: 'inherit',
@@ -78,9 +75,7 @@ export const ffprobeCommand = (
 		logLevel,
 		binariesDirectory,
 	});
-	if (!process.env.READ_ONLY_FS) {
-		chmodSync(binary, 0o755);
-	}
+	RenderInternals.makeFileExecutableIfItIsNot(binary);
 
 	const done = spawnSync(binary, args, {
 		cwd: path.dirname(binary),

--- a/packages/lambda/src/functions/helpers/get-chromium-executable-path.ts
+++ b/packages/lambda/src/functions/helpers/get-chromium-executable-path.ts
@@ -5,7 +5,6 @@ if (
 	process.env.FONTCONFIG_PATH = '/opt';
 	process.env.FONTCONFIG_FILE = '/opt/fonts.conf';
 
-	process.env.READ_ONLY_FS = '1';
 	process.env.DISABLE_FROM_SURFACE = '1';
 	process.env.NO_COLOR = '1';
 }

--- a/packages/renderer/src/call-ffmpeg.ts
+++ b/packages/renderer/src/call-ffmpeg.ts
@@ -1,9 +1,9 @@
 import execa from 'execa';
 import type {SpawnOptionsWithoutStdio} from 'node:child_process';
 import {spawn} from 'node:child_process';
-import {chmodSync} from 'node:fs';
 import path from 'path';
 import {getExecutablePath} from './compositor/get-executable-path';
+import {makeFileExecutableIfItIsNot} from './compositor/make-file-executable';
 import type {LogLevel} from './log-level';
 import {truthy} from './truthy';
 
@@ -28,9 +28,7 @@ export const callFf = ({
 		logLevel,
 		binariesDirectory,
 	});
-	if (!process.env.READ_ONLY_FS) {
-		chmodSync(executablePath, 0o755);
-	}
+	makeFileExecutableIfItIsNot(executablePath);
 
 	return execa(executablePath, args.filter(truthy), {
 		cwd: path.dirname(executablePath),
@@ -59,9 +57,7 @@ export const callFfNative = ({
 		logLevel,
 		binariesDirectory,
 	});
-	if (!process.env.READ_ONLY_FS) {
-		chmodSync(executablePath, 0o755);
-	}
+	makeFileExecutableIfItIsNot(executablePath);
 
 	return spawn(executablePath, args.filter(truthy), {
 		cwd: path.dirname(executablePath),

--- a/packages/renderer/src/compositor/compose.ts
+++ b/packages/renderer/src/compositor/compose.ts
@@ -1,12 +1,12 @@
 import {spawn} from 'node:child_process';
 import {createHash} from 'node:crypto';
-import {chmodSync} from 'node:fs';
 import {copyFile} from 'node:fs/promises';
 import path from 'node:path';
 import type {DownloadMap} from '../assets/download-map';
 import type {LogLevel} from '../log-level';
 import type {Compositor} from './compositor';
 import {getExecutablePath} from './get-executable-path';
+import {makeFileExecutableIfItIsNot} from './make-file-executable';
 import {makeNonce} from './make-nonce';
 import type {
 	CompositorCommand,
@@ -108,9 +108,7 @@ export const callCompositor = (
 			logLevel,
 			binariesDirectory,
 		});
-		if (!process.env.READ_ONLY_FS) {
-			chmodSync(execPath, 0o755);
-		}
+		makeFileExecutableIfItIsNot(execPath);
 
 		const child = spawn(execPath, [payload], {
 			cwd: path.dirname(execPath),

--- a/packages/renderer/src/compositor/compositor.ts
+++ b/packages/renderer/src/compositor/compositor.ts
@@ -1,5 +1,4 @@
 import {spawn} from 'node:child_process';
-import {chmodSync} from 'node:fs';
 import path from 'node:path';
 import {getActualConcurrency} from '../get-concurrency';
 import type {LogLevel} from '../log-level';
@@ -7,6 +6,7 @@ import {isEqualOrBelowLogLevel} from '../log-level';
 import {Log} from '../logger';
 import {serializeCommand} from './compose';
 import {getExecutablePath} from './get-executable-path';
+import {makeFileExecutableIfItIsNot} from './make-file-executable';
 import {makeNonce} from './make-nonce';
 import type {
 	CompositorCommand,
@@ -86,9 +86,7 @@ export const startCompositor = <T extends keyof CompositorCommand>({
 		logLevel,
 		binariesDirectory,
 	});
-	if (!process.env.READ_ONLY_FS) {
-		chmodSync(bin, 0o755);
-	}
+	makeFileExecutableIfItIsNot(bin);
 
 	const fullCommand: CompositorCommandSerialized<T> = serializeCommand(
 		type,

--- a/packages/renderer/src/compositor/make-file-executable.ts
+++ b/packages/renderer/src/compositor/make-file-executable.ts
@@ -1,0 +1,10 @@
+/* eslint-disable no-bitwise */
+import {accessSync, chmodSync, constants} from 'node:fs';
+
+export const makeFileExecutableIfItIsNot = (path: string) => {
+	try {
+		accessSync(path, constants.X_OK);
+	} catch (err) {
+		chmodSync(path, 0o755);
+	}
+};

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -134,6 +134,7 @@ export {OnStartData, RenderFramesOutput} from './types';
 export {validateOutputFilename} from './validate-output-filename';
 
 import {makeDownloadMap} from './assets/download-map';
+import {makeFileExecutableIfItIsNot} from './compositor/make-file-executable';
 import {validatePuppeteerTimeout} from './validate-puppeteer-timeout';
 import {validateBitrate} from './validate-videobitrate';
 import {
@@ -222,6 +223,7 @@ export const RenderInternals = {
 	getChromiumGpuInformation,
 	getPortConfig,
 	makeDownloadMap,
+	makeFileExecutableIfItIsNot,
 };
 
 // Warn of potential performance issues with Apple Silicon (M1 chip under Rosetta)


### PR DESCRIPTION
No need if we check if file is already executable