### PR TITLE
`@remotion/renderer`: Fix seeking video backwards moving the PTS forward

### DIFF
--- a/packages/renderer/rust/opened_stream.rs
+++ b/packages/renderer/rust/opened_stream.rs
@@ -183,6 +183,7 @@ impl OpenedStream {
                 "Seeking to {} from dts = {:?}, duration = {}",
                 position, self.last_position, self.duration_or_zero
             ))?;
+            self.video.flush();
             self.input
                 .seek(self.stream_index as i32, 0, position, last_seek_position, 0)?;
             freshly_seeked = true


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
