### PR TITLE
Allow wrapping in interpolate extrapolation

### DIFF
--- a/packages/animation-utils/src/transformation-helpers/interpolate-styles/index.tsx
+++ b/packages/animation-utils/src/transformation-helpers/interpolate-styles/index.tsx
@@ -1,4 +1,4 @@
-import type {InterpolateOptions} from 'remotion';
+import type {ExtrapolateType, InterpolateOptions} from 'remotion';
 import {interpolate, interpolateColors} from 'remotion';
 import type {
 	CSSPropertiesKey,
@@ -7,8 +7,6 @@ import type {
 	UnitNumberAndFunction,
 } from '../../type';
 import {breakDownValueIntoUnitNumberAndFunctions} from './utils';
-
-type ExtrapolateType = 'extend' | 'identity' | 'clamp';
 
 const interpolatedPropertyPart = ({
 	inputValue,

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -1,6 +1,6 @@
 // Taken from https://github.com/facebook/react-native/blob/0b9ea60b4fee8cacc36e7160e31b91fc114dbc0d/Libraries/Animated/src/nodes/AnimatedInterpolation.js
 
-export type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+export type ExtrapolateType = 'extend' | 'identity' | 'clamp' | 'wrap';
 
 /**
  * @description This function allows you to map a range of values to another with a conside syntax
@@ -21,7 +21,7 @@ function interpolateFunction(
 	outputRange: [number, number],
 	options: Required<InterpolateOptions>,
 ): number {
-	const {extrapolateLeft, extrapolateRight, easing} = options;
+	const { extrapolateLeft, extrapolateRight, easing } = options;
 
 	let result = input;
 	const [inputMin, inputMax] = inputRange;
@@ -34,8 +34,13 @@ function interpolateFunction(
 
 		if (extrapolateLeft === 'clamp') {
 			result = inputMin;
-		} else if (extrapolateLeft === 'extend') {
-			// noop
+		}
+		else if (extrapolateLeft === 'wrap') {
+			const range = inputMax - inputMin + 1;
+			result = ((result - inputMin) % range + range) % range + inputMin;
+		}
+		else if (extrapolateLeft === 'extend') {
+			// Noop
 		}
 	}
 
@@ -46,8 +51,13 @@ function interpolateFunction(
 
 		if (extrapolateRight === 'clamp') {
 			result = inputMax;
-		} else if (extrapolateRight === 'extend') {
-			// noop
+		}
+		else if (extrapolateRight === 'wrap') {
+			const range = inputMax - inputMin + 1;
+			result = ((result - inputMin) % range + range) % range + inputMin;
+		}
+		else if (extrapolateRight === 'extend') {
+			// Noop
 		}
 	}
 
@@ -140,10 +150,10 @@ export function interpolate(
 	if (inputRange.length !== outputRange.length) {
 		throw new Error(
 			'inputRange (' +
-				inputRange.length +
-				') and outputRange (' +
-				outputRange.length +
-				') must have the same length',
+			inputRange.length +
+			') and outputRange (' +
+			outputRange.length +
+			') must have the same length',
 		);
 	}
 

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -21,7 +21,7 @@ function interpolateFunction(
 	outputRange: [number, number],
 	options: Required<InterpolateOptions>,
 ): number {
-	const { extrapolateLeft, extrapolateRight, easing } = options;
+	const {extrapolateLeft, extrapolateRight, easing} = options;
 
 	let result = input;
 	const [inputMin, inputMax] = inputRange;
@@ -34,12 +34,10 @@ function interpolateFunction(
 
 		if (extrapolateLeft === 'clamp') {
 			result = inputMin;
-		}
-		else if (extrapolateLeft === 'wrap') {
+		} else if (extrapolateLeft === 'wrap') {
 			const range = inputMax - inputMin + 1;
-			result = ((result - inputMin) % range + range) % range + inputMin;
-		}
-		else if (extrapolateLeft === 'extend') {
+			result = ((((result - inputMin) % range) + range) % range) + inputMin;
+		} else if (extrapolateLeft === 'extend') {
 			// Noop
 		}
 	}
@@ -51,12 +49,10 @@ function interpolateFunction(
 
 		if (extrapolateRight === 'clamp') {
 			result = inputMax;
-		}
-		else if (extrapolateRight === 'wrap') {
+		} else if (extrapolateRight === 'wrap') {
 			const range = inputMax - inputMin + 1;
-			result = ((result - inputMin) % range + range) % range + inputMin;
-		}
-		else if (extrapolateRight === 'extend') {
+			result = ((((result - inputMin) % range) + range) % range) + inputMin;
+		} else if (extrapolateRight === 'extend') {
 			// Noop
 		}
 	}
@@ -150,10 +146,10 @@ export function interpolate(
 	if (inputRange.length !== outputRange.length) {
 		throw new Error(
 			'inputRange (' +
-			inputRange.length +
-			') and outputRange (' +
-			outputRange.length +
-			') must have the same length',
+				inputRange.length +
+				') and outputRange (' +
+				outputRange.length +
+				') must have the same length',
 		);
 	}
 

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -35,7 +35,7 @@ function interpolateFunction(
 		if (extrapolateLeft === 'clamp') {
 			result = inputMin;
 		} else if (extrapolateLeft === 'wrap') {
-			const range = inputMax - inputMin + 1;
+			const range = inputMax - inputMin;
 			result = ((((result - inputMin) % range) + range) % range) + inputMin;
 		} else if (extrapolateLeft === 'extend') {
 			// Noop
@@ -50,7 +50,7 @@ function interpolateFunction(
 		if (extrapolateRight === 'clamp') {
 			result = inputMax;
 		} else if (extrapolateRight === 'wrap') {
-			const range = inputMax - inputMin + 1;
+			const range = inputMax - inputMin;
 			result = ((((result - inputMin) % range) + range) % range) + inputMin;
 		} else if (extrapolateRight === 'extend') {
 			// Noop

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -211,4 +211,5 @@ test('Handle bad types', () => {
 
 test('wrap option', () => {
 	expect(interpolate(1.5, [0, 1], [0, 2], {extrapolateRight: 'wrap'})).toBe(1);
+	expect(interpolate(-0.5, [0, 1], [0, 2], {extrapolateLeft: 'wrap'})).toBe(1);
 });

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -208,3 +208,7 @@ test('Handle bad types', () => {
 		/inputRange can not be undefined/,
 	);
 });
+
+test('wrap option', () => {
+	expect(interpolate(1.5, [0, 1], [0, 2], {extrapolateRight: 'wrap'})).toBe(1);
+});

--- a/packages/docs/docs/interpolate.md
+++ b/packages/docs/docs/interpolate.md
@@ -133,6 +133,7 @@ What should happen if the input value is outside left the input range:
 
 - `extend`: Interpolate nonetheless, even if outside output range.
 - `clamp`: Return the closest value inside the range instead
+- `wrap`: Loops the value change.
 - `identity`: Return the input value instead.
 
 #### extrapolateRight
@@ -149,6 +150,7 @@ import { interpolate } from "remotion";
 interpolate(1.5, [0, 1], [0, 2], { extrapolateRight: "extend" }); // 3
 interpolate(1.5, [0, 1], [0, 2], { extrapolateRight: "clamp" }); // 2
 interpolate(1.5, [0, 1], [0, 2], { extrapolateRight: "identity" }); // 1.5
+interpolate(1.5, [0, 1], [0, 2], { extrapolateRight: "wrap" }); // 1
 ```
 
 #### easing


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Sorry for not documenting this in an issue, i just stumbled across the need to use a wrapping feature and figured i could implement it quickly (its a very small change).

Now when you call interpolate, you can use `'wrap'` in `extrapolateLeft` or `extrapolateRight`

Meaning that if you have

`interpolate(frame, [0,5], [0,50], {extrapolateRight:'wrap'})`

then

`interpolate(6, [0,5], [0,50], {extrapolateRight:'wrap'}) //yields 0`
`interpolate(7, [0,5], [0,50], {extrapolateRight:'wrap'}) //yields 10`
`interpolate(11, [0,5], [0,50], {extrapolateRight:'wrap'}) //yields 50`

and so on, wrapping arround your outputRange so that it loops on the intended values forever. A great example usecase would be a forever scrolling background, that instead of forever expanding, just returns to your initial x position.
