### PR TITLE
`@remotion/layout-utils`: Allow strings for measureText()

### DIFF
--- a/packages/docs/docs/layout-utils/measure-text.md
+++ b/packages/docs/docs/layout-utils/measure-text.md
@@ -28,9 +28,9 @@ Same as CSS style `font-family`
 
 ### `fontSize`
 
-_Required_ _number_
+_Required_ _number_ / _string_
 
-Same as CSS style `font-size`. Only _numbers_ allowed, unit `px`
+Same as CSS style `font-size`. Since v4.0.125, strings are allowed too, before only numbers.
 
 ### `fontWeight`
 

--- a/packages/layout-utils/src/layouts/measure-text.ts
+++ b/packages/layout-utils/src/layouts/measure-text.ts
@@ -6,7 +6,7 @@ type Dimensions = {
 export type Word = {
 	text: string;
 	fontFamily: string;
-	fontSize: number;
+	fontSize: number | string;
 	fontWeight?: number | string;
 	letterSpacing?: string;
 	fontVariantNumeric?: string;
@@ -35,7 +35,8 @@ export const measureText = ({
 	node.style.position = 'absolute';
 	node.style.top = `-10000px`;
 	node.style.whiteSpace = 'pre';
-	node.style.fontSize = `${fontSize}px`;
+	node.style.fontSize =
+		typeof fontSize === 'string' ? fontSize : `${fontSize}px`;
 
 	if (fontWeight) {
 		node.style.fontWeight = fontWeight.toString();


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
