### PR TITLE
`@remotion/studio-server`: Print which hostname is being used

### DIFF
--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -141,6 +141,10 @@ export const startServer = async (options: {
 					hostsToTry: portConfig.hostsToTry,
 				})
 					.then(({port, unlockPort}) => {
+						RenderInternals.Log.verbose(
+							{indent: false, logLevel: options.logLevel},
+							`Binding server to host ${portConfig.host}, port ${port}`,
+						);
 						server.listen({
 							port,
 							host: portConfig.host,


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
