### PR TITLE
`@remotion/cloudrun`: Point more prominently towards light client

### DIFF
--- a/packages/cloudrun/src/index.ts
+++ b/packages/cloudrun/src/index.ts
@@ -10,15 +10,30 @@ import {getOrCreateBucket} from './api/get-or-create-bucket';
 import {getRegions} from './api/get-regions';
 import {getServiceInfo} from './api/get-service-info';
 import {getServices} from './api/get-services';
-import {getSites} from './api/get-sites';
+import {getSites as deprecatedGetSites} from './api/get-sites';
 import {testPermissions} from './api/iam-validation/testPermissions';
 import type {RenderMediaOnCloudrunInput} from './api/render-media-on-cloudrun';
-import {renderMediaOnCloudrun} from './api/render-media-on-cloudrun';
-import {renderStillOnCloudrun} from './api/render-still-on-cloudrun';
+import {renderMediaOnCloudrun as deprecatedRenderMediaOnCloudrun} from './api/render-media-on-cloudrun';
+import {renderStillOnCloudrun as deprecatedRenderStillOnCloudrun} from './api/render-still-on-cloudrun';
 import {speculateServiceName} from './api/speculate-service-name';
 import type {RenderMediaOnCloudrunOutput} from './functions/helpers/payloads';
 import {CloudrunInternals} from './internals';
 import type {GcpRegion} from './pricing/gcp-regions';
+
+/**
+ * @deprecated  Import this from `@remotion/cloudrun/client` instead
+ */
+const renderMediaOnCloudrun = deprecatedRenderMediaOnCloudrun;
+
+/**
+ * @deprecated  Import this from `@remotion/cloudrun/client` instead
+ */
+const renderStillOnCloudrun = deprecatedRenderStillOnCloudrun;
+
+/**
+ * @deprecated Import this from `@remotion/lambda/client` instead
+ */
+const getSites = deprecatedGetSites;
 
 export {
 	CloudrunInternals,

--- a/packages/docs/docs/cloudrun/getServiceinfo.md
+++ b/packages/docs/docs/cloudrun/getServiceinfo.md
@@ -22,7 +22,7 @@ To deploy a service, use [`deployService()`](/docs/cloudrun/deployservice).
 // @module: esnext
 // @target: es2017
 
-import { getServiceInfo } from "@remotion/cloudrun";
+import { getServiceInfo } from "@remotion/cloudrun/client";
 
 const info = await getServiceInfo({
   region: "us-east1",
@@ -37,6 +37,10 @@ console.log(info.uri); // "https://remotion--3-3-82--mem512mi--cpu1-0--t-500-1a2
 console.log(info.region); // "us-east1"
 console.log(info.consoleUrl); // "https://console.cloud.google.com/run/detail/us-east1/remotion--3-3-82--mem512mi--cpu1-0--t-500/logs"
 ```
+
+:::note
+Import from [`@remotion/cloudrun/client`](/docs/cloudrun/light-client) to not import the whole renderer, which cannot be bundled.
+:::
 
 ## Arguments
 

--- a/packages/docs/docs/cloudrun/getregions.md
+++ b/packages/docs/docs/cloudrun/getregions.md
@@ -16,13 +16,17 @@ Gets an array of all supported GCP regions of this release of Remotion Cloud Run
 ```tsx twoslash
 // @module: esnext
 // @target: es2017
-import { getRegions } from "@remotion/cloudrun";
+import { getRegions } from "@remotion/cloudrun/client";
 
 // ---cut---
 
 const regions = getRegions();
 // ["asia-east1", "us-east1"]
 ```
+
+:::note
+Import from [`@remotion/cloudrun/client`](/docs/cloudrun/light-client) to not import the whole renderer, which cannot be bundled.
+:::
 
 ## Return value
 

--- a/packages/docs/docs/cloudrun/getservices.md
+++ b/packages/docs/docs/cloudrun/getservices.md
@@ -28,7 +28,7 @@ If you are sure that a service exists, you can also guess the name of it using [
 // @module: esnext
 // @target: es2017
 
-import { getServices } from "@remotion/cloudrun";
+import { getServices } from "@remotion/cloudrun/client";
 
 const info = await getServices({
   region: "us-east1",
@@ -46,6 +46,10 @@ for (const service of info) {
   console.log(service.consoleUrl); // "https://console.cloud.google.com/run/detail/us-east1/remotion--3-3-82--mem512mi--cpu1-0--t-300/logs"
 }
 ```
+
+:::note
+Import from [`@remotion/cloudrun/client`](/docs/cloudrun/light-client) to not import the whole renderer, which cannot be bundled.
+:::
 
 ## Argument
 

--- a/packages/docs/docs/cloudrun/rendermediaoncloudrun.md
+++ b/packages/docs/docs/cloudrun/rendermediaoncloudrun.md
@@ -20,7 +20,7 @@ A [site](/docs/cloudrun/deploysite) or a [Serve URL](/docs/terminology/serve-url
 // @module: esnext
 // @target: es2017
 // ---cut---
-import { renderMediaOnCloudrun } from "@remotion/cloudrun";
+import { renderMediaOnCloudrun } from "@remotion/cloudrun/client";
 
 const result = await renderMediaOnCloudrun({
   region: "us-east1",
@@ -30,11 +30,16 @@ const result = await renderMediaOnCloudrun({
     "https://storage.googleapis.com/remotioncloudrun-123asd321/sites/abcdefgh",
   codec: "h264",
 });
+
 if (result.type === "success") {
   console.log(result.bucketName);
   console.log(result.renderId);
 }
 ```
+
+:::note
+Import from [`@remotion/cloudrun/client`](/docs/cloudrun/light-client) to not import the whole renderer, which cannot be bundled.
+:::
 
 ## Arguments
 

--- a/packages/docs/docs/cloudrun/renderstilloncloudrun.md
+++ b/packages/docs/docs/cloudrun/renderstilloncloudrun.md
@@ -20,7 +20,7 @@ A [site](/docs/cloudrun/deploysite) or a [Serve URL](/docs/terminology/serve-url
 // @module: esnext
 // @target: es2017
 // ---cut---
-import { renderStillOnCloudrun } from "@remotion/cloudrun";
+import { renderStillOnCloudrun } from "@remotion/cloudrun/client";
 
 const result = await renderStillOnCloudrun({
   region: "us-east1",
@@ -36,6 +36,10 @@ if (result.type === "success") {
   console.log(result.renderId);
 }
 ```
+
+:::note
+Import from [`@remotion/cloudrun/client`](/docs/cloudrun/light-client) to not import the whole renderer, which cannot be bundled.
+:::
 
 ## Arguments
 

--- a/packages/docs/docs/cloudrun/setup.md
+++ b/packages/docs/docs/cloudrun/setup.md
@@ -295,7 +295,7 @@ You already have the service name from a previous step. But since you only need 
 ```ts twoslash
 // @module: ESNext
 // @target: ESNext
-import { getServices, renderMediaOnCloudrun } from "@remotion/cloudrun";
+import { getServices, renderMediaOnCloudrun } from "@remotion/cloudrun/client";
 
 const services = await getServices({
   region: "us-east1",
@@ -310,8 +310,8 @@ We can now trigger a render of a video using the [`renderMediaOnCloudrun()`](/do
 ```ts twoslash
 // @module: ESNext
 // @target: ESNext
-import { renderMediaOnCloudrun } from "@remotion/cloudrun";
 
+import { renderMediaOnCloudrun } from "@remotion/cloudrun/client";
 const url = "string";
 const serviceName = "string";
 const updateRenderProgress = (progress: number) => {};
@@ -332,6 +332,10 @@ if (result.type === "success") {
   console.log(result.renderId);
 }
 ```
+
+:::note
+Import from [`@remotion/cloudrun/client`](/docs/cloudrun/light-client) to not import the whole renderer, which cannot be bundled.
+:::
 
 The render will now run and after a while the video will be available in your cloud storage bucket. You can keep track of the render progress by passing a function to the [updateRenderProgress](/docs/cloudrun/rendermediaoncloudrun#updaterenderprogress) attribute, to receive progress as a number.
 
@@ -359,7 +363,7 @@ We can now trigger a render of a still using the [`renderStillOnCloudrun()`](/do
 ```ts twoslash
 // @module: ESNext
 // @target: ESNext
-import { renderStillOnCloudrun } from "@remotion/cloudrun";
+import { renderStillOnCloudrun } from "@remotion/cloudrun/client";
 
 const url = "string";
 const serviceName = "string";
@@ -379,6 +383,10 @@ if (result.type === "success") {
   console.log(result.renderId);
 }
 ```
+
+:::note
+Import from [`@remotion/cloudrun/client`](/docs/cloudrun/light-client) to not import the whole renderer, which cannot be bundled.
+:::
 
 The render will now run and after a while the image will be available in your cloud storage bucket.
 

--- a/packages/docs/docs/studio/deploy-static.mdx
+++ b/packages/docs/docs/studio/deploy-static.mdx
@@ -150,7 +150,7 @@ npx remotion cloudrun render https://remotion-helloworld.vercel.app HelloWorld -
 // @module: esnext
 // @target: es2017
 // ---cut---
-import { renderMediaOnCloudrun } from "@remotion/cloudrun";
+import { renderMediaOnCloudrun } from "@remotion/cloudrun/client";
 
 const result = await renderMediaOnCloudrun({
   region: "us-east1",


### PR DESCRIPTION
Troublesome if trying to import Google Cloud Run APIs in Next.js