### PR TITLE
`@remotion/cli`: Allow `--public-path` for `npx remotion bundle`

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -41,16 +41,18 @@ const trimTrailingSlash = (p: string): string => {
 	return p;
 };
 
-export type LegacyBundleOptions = {
-	webpackOverride?: WebpackOverrideFn;
-	outDir?: string;
-	enableCaching?: boolean;
-	publicPath?: string;
-	rootDir?: string;
-	publicDir?: string | null;
-	onPublicDirCopyProgress?: (bytes: number) => void;
-	onSymlinkDetected?: (path: string) => void;
+export type MandatoryLegacyBundleOptions = {
+	webpackOverride: WebpackOverrideFn;
+	outDir: string | null;
+	enableCaching: boolean;
+	publicPath: string | null;
+	rootDir: string | null;
+	publicDir: string | null;
+	onPublicDirCopyProgress: (bytes: number) => void;
+	onSymlinkDetected: (path: string) => void;
 };
+
+export type LegacyBundleOptions = Partial<MandatoryLegacyBundleOptions>;
 
 export const getConfig = ({
 	entryPoint,
@@ -87,15 +89,25 @@ export const getConfig = ({
 	});
 };
 
+type NewBundleOptions = {
+	entryPoint: string;
+	onProgress: (progress: number) => void;
+	ignoreRegisterRootWarning: boolean;
+	onDirectoryCreated: (dir: string) => void;
+	gitSource: GitSource | null;
+	maxTimelineTracks: number | null;
+	bufferStateDelayInMilliseconds: number | null;
+};
+
+type MandatoryBundleOptions = {
+	entryPoint: string;
+} & NewBundleOptions &
+	MandatoryLegacyBundleOptions;
+
 export type BundleOptions = {
 	entryPoint: string;
-	onProgress?: (progress: number) => void;
-	ignoreRegisterRootWarning?: boolean;
-	onDirectoryCreated?: (dir: string) => void;
-	gitSource?: GitSource | null;
-	maxTimelineTracks?: number;
-	bufferStateDelayInMilliseconds?: number;
-} & LegacyBundleOptions;
+} & Partial<NewBundleOptions> &
+	LegacyBundleOptions;
 
 type Arguments =
 	| [options: BundleOptions]
@@ -164,12 +176,9 @@ const validateEntryPoint = async (entryPoint: string) => {
 	}
 };
 
-/**
- * @description The method bundles a Remotion project using Webpack and prepares it for rendering using renderMedia()
- * @see [Documentation](https://www.remotion.dev/docs/bundle)
- */
-export async function bundle(...args: Arguments): Promise<string> {
-	const actualArgs = convertArgumentsIntoOptions(args);
+export const internalBundle = async (
+	actualArgs: MandatoryBundleOptions,
+): Promise<string> => {
 	const entryPoint = path.resolve(process.cwd(), actualArgs.entryPoint);
 	const resolvedRemotionRoot =
 		actualArgs?.rootDir ??
@@ -301,4 +310,31 @@ export async function bundle(...args: Arguments): Promise<string> {
 		path.join(outDir, SOURCE_MAP_ENDPOINT.replace('/', '')),
 	);
 	return outDir;
+};
+
+/**
+ * @description The method bundles a Remotion project using Webpack and prepares it for rendering.
+ * @see [Documentation](https://www.remotion.dev/docs/bundle)
+ */
+export async function bundle(...args: Arguments): Promise<string> {
+	const actualArgs = convertArgumentsIntoOptions(args);
+	const result = await internalBundle({
+		bufferStateDelayInMilliseconds:
+			actualArgs.bufferStateDelayInMilliseconds ?? null,
+		enableCaching: actualArgs.enableCaching ?? true,
+		entryPoint: actualArgs.entryPoint,
+		gitSource: actualArgs.gitSource ?? null,
+		ignoreRegisterRootWarning: actualArgs.ignoreRegisterRootWarning ?? false,
+		maxTimelineTracks: actualArgs.maxTimelineTracks ?? null,
+		onDirectoryCreated: actualArgs.onDirectoryCreated ?? (() => {}),
+		onProgress: actualArgs.onProgress ?? (() => {}),
+		onPublicDirCopyProgress: actualArgs.onPublicDirCopyProgress ?? (() => {}),
+		onSymlinkDetected: actualArgs.onSymlinkDetected ?? (() => {}),
+		outDir: actualArgs.outDir ?? null,
+		publicDir: actualArgs.publicDir ?? null,
+		publicPath: actualArgs.publicPath ?? null,
+		rootDir: actualArgs.rootDir ?? null,
+		webpackOverride: actualArgs.webpackOverride ?? ((f) => f),
+	});
+	return result;
 }

--- a/packages/bundler/src/index.ts
+++ b/packages/bundler/src/index.ts
@@ -1,4 +1,4 @@
-import {findClosestFolderWithItem, getConfig} from './bundle';
+import {findClosestFolderWithItem, getConfig, internalBundle} from './bundle';
 import {indexHtml} from './index-html';
 import {readRecursively} from './read-recursively';
 import {cacheExists, clearCache} from './webpack-cache';
@@ -15,9 +15,15 @@ export const BundlerInternals = {
 	getConfig,
 	readRecursively,
 	findClosestFolderWithItem,
+	internalBundle,
 };
 
 export type {GitSource} from '@remotion/studio';
-export {bundle, BundleOptions, LegacyBundleOptions} from './bundle';
+export {
+	bundle,
+	BundleOptions,
+	LegacyBundleOptions,
+	MandatoryLegacyBundleOptions,
+} from './bundle';
 export {WebpackConfiguration, WebpackOverrideFn} from './webpack-config';
 export {webpack};

--- a/packages/cli/src/benchmark.ts
+++ b/packages/cli/src/benchmark.ts
@@ -48,6 +48,7 @@ const {
 	binariesDirectoryOption,
 	forSeamlessAacConcatenationOption,
 	publicPathOption,
+	publicDirOption,
 } = BrowserSafeApis.options;
 
 const getValidConcurrency = (cliConcurrency: number | string | null) => {
@@ -188,7 +189,6 @@ export const benchmarkCommand = async (
 		inputProps,
 		envVariables,
 		browserExecutable,
-		publicDir,
 		proResProfile,
 		frameRange: defaultFrameRange,
 		pixelFormat,
@@ -220,6 +220,7 @@ export const benchmarkCommand = async (
 	const gl = glOption.getValue({commandLine: parsedCli}).value;
 	const headless = headlessOption.getValue({commandLine: parsedCli}).value;
 	const publicPath = publicPathOption.getValue({commandLine: parsedCli}).value;
+	const publicDir = publicDirOption.getValue({commandLine: parsedCli}).value;
 
 	const chromiumOptions: ChromiumOptions = {
 		disableWebSecurity,

--- a/packages/cli/src/benchmark.ts
+++ b/packages/cli/src/benchmark.ts
@@ -47,6 +47,7 @@ const {
 	overwriteOption,
 	binariesDirectoryOption,
 	forSeamlessAacConcatenationOption,
+	publicPathOption,
 } = BrowserSafeApis.options;
 
 const getValidConcurrency = (cliConcurrency: number | string | null) => {
@@ -218,6 +219,7 @@ export const benchmarkCommand = async (
 	}).value;
 	const gl = glOption.getValue({commandLine: parsedCli}).value;
 	const headless = headlessOption.getValue({commandLine: parsedCli}).value;
+	const publicPath = publicPathOption.getValue({commandLine: parsedCli}).value;
 
 	const chromiumOptions: ChromiumOptions = {
 		disableWebSecurity,
@@ -258,6 +260,7 @@ export const benchmarkCommand = async (
 			gitSource: null,
 			bufferStateDelayInMilliseconds: null,
 			maxTimelineTracks: null,
+			publicPath,
 		});
 
 	registerCleanupJob(() => cleanupBundle());

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -6,7 +6,6 @@ import {existsSync, readdirSync, readFileSync, rmSync, writeFileSync} from 'fs';
 import path from 'path';
 import {chalk} from './chalk';
 import {findEntryPoint} from './entry-point';
-import {getCliOptions} from './get-cli-options';
 import {getGitSource} from './get-github-repository';
 import {Log} from './log';
 import {parsedCli, quietFlagProvided} from './parse-command-line';
@@ -14,7 +13,7 @@ import {bundleOnCli} from './setup-cache';
 import {shouldUseNonOverlayingLogger} from './should-use-non-overlaying-logger';
 import {yesOrNo} from './yes-or-no';
 
-const {publicPathOption} = BrowserSafeApis.options;
+const {publicPathOption, publicDirOption} = BrowserSafeApis.options;
 
 export const bundleCommand = async (
 	remotionRoot: string,
@@ -53,12 +52,8 @@ export const bundleCommand = async (
 		process.exit(1);
 	}
 
-	const {publicDir} = getCliOptions({
-		isStill: false,
-		logLevel,
-	});
-
 	const publicPath = publicPathOption.getValue({commandLine: parsedCli}).value;
+	const publicDir = publicDirOption.getValue({commandLine: parsedCli}).value;
 
 	const outputPath = parsedCli['out-dir']
 		? path.resolve(process.cwd(), parsedCli['out-dir'])

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -1,5 +1,6 @@
 import {BundlerInternals} from '@remotion/bundler';
 import type {LogLevel} from '@remotion/renderer';
+import {BrowserSafeApis} from '@remotion/renderer/client';
 import {StudioServerInternals} from '@remotion/studio-server';
 import {existsSync, readdirSync, readFileSync, rmSync, writeFileSync} from 'fs';
 import path from 'path';
@@ -12,6 +13,8 @@ import {parsedCli, quietFlagProvided} from './parse-command-line';
 import {bundleOnCli} from './setup-cache';
 import {shouldUseNonOverlayingLogger} from './should-use-non-overlaying-logger';
 import {yesOrNo} from './yes-or-no';
+
+const {publicPathOption} = BrowserSafeApis.options;
 
 export const bundleCommand = async (
 	remotionRoot: string,
@@ -54,6 +57,8 @@ export const bundleCommand = async (
 		isStill: false,
 		logLevel,
 	});
+
+	const publicPath = publicPathOption.getValue({commandLine: parsedCli}).value;
 
 	const outputPath = parsedCli['out-dir']
 		? path.resolve(process.cwd(), parsedCli['out-dir'])
@@ -122,6 +127,7 @@ export const bundleCommand = async (
 		gitSource,
 		bufferStateDelayInMilliseconds: null,
 		maxTimelineTracks: null,
+		publicPath,
 	});
 
 	Log.info(

--- a/packages/cli/src/compositions.ts
+++ b/packages/cli/src/compositions.ts
@@ -18,6 +18,7 @@ const {
 	headlessOption,
 	delayRenderTimeoutInMillisecondsOption,
 	binariesDirectoryOption,
+	publicPathOption,
 } = BrowserSafeApis.options;
 
 export const listCompositionsCommand = async (
@@ -75,6 +76,20 @@ export const listCompositionsCommand = async (
 		userAgent,
 	};
 
+	const publicPath = publicPathOption.getValue({commandLine: parsedCli}).value;
+	const timeoutInMilliseconds = delayRenderTimeoutInMillisecondsOption.getValue(
+		{
+			commandLine: parsedCli,
+		},
+	).value;
+	const binariesDirectory = binariesDirectoryOption.getValue({
+		commandLine: parsedCli,
+	}).value;
+	const offthreadVideoCacheSizeInBytes =
+		offthreadVideoCacheSizeInBytesOption.getValue({
+			commandLine: parsedCli,
+		}).value;
+
 	const {urlOrBundle: bundled, cleanup: cleanupBundle} =
 		await bundleOnCliOrTakeServeUrl({
 			remotionRoot,
@@ -95,6 +110,7 @@ export const listCompositionsCommand = async (
 			gitSource: null,
 			bufferStateDelayInMilliseconds: null,
 			maxTimelineTracks: null,
+			publicPath,
 		});
 
 	registerCleanupJob(() => cleanupBundle());
@@ -110,22 +126,15 @@ export const listCompositionsCommand = async (
 				staticBase: null,
 				indent: undefined,
 			}).serializedString,
-		timeoutInMilliseconds: delayRenderTimeoutInMillisecondsOption.getValue({
-			commandLine: parsedCli,
-		}).value,
+		timeoutInMilliseconds,
 		port: getRendererPortFromConfigFileAndCliFlag(),
 		indent: false,
 		onBrowserLog: null,
 		puppeteerInstance: undefined,
 		logLevel,
 		server: undefined,
-		offthreadVideoCacheSizeInBytes:
-			offthreadVideoCacheSizeInBytesOption.getValue({
-				commandLine: parsedCli,
-			}).value,
-		binariesDirectory: binariesDirectoryOption.getValue({
-			commandLine: parsedCli,
-		}).value,
+		offthreadVideoCacheSizeInBytes,
+		binariesDirectory,
 	});
 
 	printCompositions(compositions, logLevel);

--- a/packages/cli/src/compositions.ts
+++ b/packages/cli/src/compositions.ts
@@ -19,6 +19,7 @@ const {
 	delayRenderTimeoutInMillisecondsOption,
 	binariesDirectoryOption,
 	publicPathOption,
+	publicDirOption,
 } = BrowserSafeApis.options;
 
 export const listCompositionsCommand = async (
@@ -56,7 +57,6 @@ export const listCompositionsCommand = async (
 		browserExecutable,
 		envVariables,
 		inputProps,
-		publicDir,
 		ignoreCertificateErrors,
 		userAgent,
 		disableWebSecurity,
@@ -89,6 +89,7 @@ export const listCompositionsCommand = async (
 		offthreadVideoCacheSizeInBytesOption.getValue({
 			commandLine: parsedCli,
 		}).value;
+	const publicDir = publicDirOption.getValue({commandLine: parsedCli}).value;
 
 	const {urlOrBundle: bundled, cleanup: cleanupBundle} =
 		await bundleOnCliOrTakeServeUrl({

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -117,6 +117,7 @@ const {
 	preferLosslessOption,
 	forSeamlessAacConcatenationOption,
 	audioCodecOption,
+	publicPathOption,
 } = BrowserSafeApis.options;
 
 declare global {
@@ -472,6 +473,10 @@ declare global {
 		 * Prefer lossless audio encoding. Default: false
 		 */
 		readonly setPreferLosslessAudio: (lossless: boolean) => void;
+		/**
+		 * Prefer lossless audio encoding. Default: false
+		 */
+		readonly setPublicPath: (publicPath: string | null) => void;
 	}
 }
 
@@ -627,6 +632,7 @@ export const Config: FlatConfig = {
 	setLambdaInsights: enableLambdaInsights.setConfig,
 	setBinariesDirectory: binariesDirectoryOption.setConfig,
 	setPreferLosslessAudio: preferLosslessOption.setConfig,
+	setPublicPath: publicPathOption.setConfig,
 };
 
 export const ConfigInternals = {

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -76,7 +76,6 @@ import {overrideWebpackConfig} from './override-webpack';
 import {setPixelFormat} from './pixel-format';
 import {setPort, setRendererPort, setStudioPort} from './preview-server';
 import {setProResProfile} from './prores-profile';
-import {getPublicDir, setPublicDir} from './public-dir';
 import {getChromiumUserAgent, setChromiumUserAgent} from './user-agent';
 import {setWebpackCaching} from './webpack-caching';
 import {
@@ -113,6 +112,7 @@ const {
 	enableLambdaInsights,
 	logLevelOption,
 	delayRenderTimeoutInMillisecondsOption,
+	publicDirOption,
 	binariesDirectoryOption,
 	preferLosslessOption,
 	forSeamlessAacConcatenationOption,
@@ -570,7 +570,7 @@ export const Config: FlatConfig = {
 	setPort,
 	setStudioPort,
 	setRendererPort,
-	setPublicDir,
+	setPublicDir: publicDirOption.setConfig,
 	setEntryPoint,
 	setLevel: logLevelOption.setConfig,
 	setBrowserExecutable,
@@ -661,7 +661,6 @@ export const ConfigInternals = {
 	getMaxTimelineTracks: StudioServerInternals.getMaxTimelineTracks,
 	defaultOverrideFunction,
 	getKeyboardShortcutsEnabled,
-	getPublicDir,
 	getFfmpegOverrideFunction,
 	getHeight,
 	getWidth,

--- a/packages/cli/src/config/public-dir.ts
+++ b/packages/cli/src/config/public-dir.ts
@@ -1,9 +1,0 @@
-let publicDir: string | null = null;
-
-export const getPublicDir = () => {
-	return publicDir;
-};
-
-export const setPublicDir = (dir: string | null) => {
-	publicDir = dir;
-};

--- a/packages/cli/src/get-cli-options.ts
+++ b/packages/cli/src/get-cli-options.ts
@@ -98,7 +98,6 @@ export const getCliOptions = (options: {
 		userAgent,
 		disableWebSecurity,
 		ignoreCertificateErrors,
-		publicDir: ConfigInternals.getPublicDir(),
 		ffmpegOverride: ConfigInternals.getFfmpegOverrideFunction(),
 		height,
 		width,

--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -145,10 +145,6 @@ export const parsedCli = minimist<CommandLineOptions>(process.argv.slice(2), {
 };
 
 export const parseCommandLine = () => {
-	if (parsedCli.repro) {
-		Config.setRepro(true);
-	}
-
 	if (parsedCli['pixel-format']) {
 		Config.setPixelFormat(parsedCli['pixel-format']);
 	}
@@ -237,18 +233,6 @@ export const parseCommandLine = () => {
 
 	if (typeof parsedCli['webpack-poll'] !== 'undefined') {
 		Config.setWebpackPollingInMilliseconds(parsedCli['webpack-poll']);
-	}
-
-	if (typeof parsedCli['audio-bitrate'] !== 'undefined') {
-		Config.setAudioBitrate(parsedCli['audio-bitrate']);
-	}
-
-	if (typeof parsedCli['video-bitrate'] !== 'undefined') {
-		Config.setVideoBitrate(parsedCli['video-bitrate']);
-	}
-
-	if (typeof parsedCli['buffer-size'] !== 'undefined') {
-		Config.setEncodingBufferSize(parsedCli['buffer-size']);
 	}
 };
 

--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -227,10 +227,6 @@ export const parseCommandLine = () => {
 		);
 	}
 
-	if (typeof parsedCli['public-dir'] !== 'undefined') {
-		Config.setPublicDir(parsedCli['public-dir']);
-	}
-
 	if (typeof parsedCli['webpack-poll'] !== 'undefined') {
 		Config.setWebpackPollingInMilliseconds(parsedCli['webpack-poll']);
 	}

--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -30,6 +30,7 @@ const {
 	audioBitrateOption,
 	videoBitrateOption,
 	audioCodecOption,
+	publicPathOption,
 } = BrowserSafeApis.options;
 
 type CommandLineOptions = {
@@ -63,6 +64,7 @@ type CommandLineOptions = {
 	>;
 	[encodingMaxRateOption.cliFlag]: TypeOfOption<typeof encodingMaxRateOption>;
 	[audioCodecOption.cliFlag]: AudioCodec;
+	[publicPathOption.cliFlag]: string;
 	crf: number;
 	force: boolean;
 	output: string;

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -103,6 +103,7 @@ export const renderVideoFlow = async ({
 	binariesDirectory,
 	forSeamlessAacConcatenation,
 	separateAudioTo,
+	publicPath,
 }: {
 	remotionRoot: string;
 	fullEntryPoint: string;
@@ -155,6 +156,7 @@ export const renderVideoFlow = async ({
 	binariesDirectory: string | null;
 	forSeamlessAacConcatenation: boolean;
 	separateAudioTo: string | null;
+	publicPath: string | null;
 }) => {
 	const downloads: DownloadProgress[] = [];
 
@@ -248,6 +250,7 @@ export const renderVideoFlow = async ({
 			gitSource: null,
 			bufferStateDelayInMilliseconds: null,
 			maxTimelineTracks: null,
+			publicPath,
 		},
 	);
 

--- a/packages/cli/src/render-flows/still.ts
+++ b/packages/cli/src/render-flows/still.ts
@@ -308,7 +308,7 @@ export const renderStillFlow = async ({
 		onDownload,
 		port,
 		puppeteerInstance,
-		server: await server,
+		server,
 		cancelSignal,
 		indent,
 		onBrowserLog: null,

--- a/packages/cli/src/render-flows/still.ts
+++ b/packages/cli/src/render-flows/still.ts
@@ -70,6 +70,7 @@ export const renderStillFlow = async ({
 	outputLocationFromUi,
 	offthreadVideoCacheSizeInBytes,
 	binariesDirectory,
+	publicPath,
 }: {
 	remotionRoot: string;
 	fullEntryPoint: string;
@@ -99,6 +100,7 @@ export const renderStillFlow = async ({
 	outputLocationFromUi: string | null;
 	offthreadVideoCacheSizeInBytes: number | null;
 	binariesDirectory: string | null;
+	publicPath: string | null;
 }) => {
 	const aggregate: AggregateRenderProgress = initialAggregateRenderProgress();
 	const updatesDontOverwrite = shouldUseNonOverlayingLogger({logLevel});
@@ -177,6 +179,7 @@ export const renderStillFlow = async ({
 			gitSource: null,
 			bufferStateDelayInMilliseconds: null,
 			maxTimelineTracks: null,
+			publicPath,
 		},
 	);
 

--- a/packages/cli/src/render-queue/process-still.ts
+++ b/packages/cli/src/render-queue/process-still.ts
@@ -58,5 +58,6 @@ export const processStill = async ({
 		outputLocationFromUi: job.outName,
 		offthreadVideoCacheSizeInBytes: job.offthreadVideoCacheSizeInBytes,
 		binariesDirectory: job.binariesDirectory,
+		publicPath: null,
 	});
 };

--- a/packages/cli/src/render-queue/process-still.ts
+++ b/packages/cli/src/render-queue/process-still.ts
@@ -1,8 +1,12 @@
+import {BrowserSafeApis} from '@remotion/renderer/client';
 import type {JobProgressCallback, RenderJob} from '@remotion/studio-server';
 import {getRendererPortFromConfigFile} from '../config/preview-server';
 import {convertEntryPointToServeUrl} from '../convert-entry-point-to-serve-url';
 import {getCliOptions} from '../get-cli-options';
+import {parsedCli} from '../parse-command-line';
 import {renderStillFlow} from '../render-flows/still';
+
+const {publicDirOption} = BrowserSafeApis.options;
 
 export const processStill = async ({
 	job,
@@ -21,10 +25,14 @@ export const processStill = async ({
 		throw new Error('Expected still job');
 	}
 
-	const {publicDir, browserExecutable} = getCliOptions({
+	const {browserExecutable} = getCliOptions({
 		isStill: true,
 		logLevel: job.logLevel,
 	});
+
+	const publicDir = publicDirOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 
 	const fullEntryPoint = convertEntryPointToServeUrl(entryPoint);
 

--- a/packages/cli/src/render-queue/process-video.ts
+++ b/packages/cli/src/render-queue/process-video.ts
@@ -1,9 +1,13 @@
 import type {LogLevel} from '@remotion/renderer';
+import {BrowserSafeApis} from '@remotion/renderer/client';
 import type {JobProgressCallback, RenderJob} from '@remotion/studio-server';
 import {getRendererPortFromConfigFile} from '../config/preview-server';
 import {convertEntryPointToServeUrl} from '../convert-entry-point-to-serve-url';
 import {getCliOptions} from '../get-cli-options';
+import {parsedCli} from '../parse-command-line';
 import {renderVideoFlow} from '../render-flows/render';
+
+const {publicDirOption} = BrowserSafeApis.options;
 
 export const processVideoJob = async ({
 	job,
@@ -24,7 +28,11 @@ export const processVideoJob = async ({
 		throw new Error('Expected video job');
 	}
 
-	const {publicDir, browserExecutable, ffmpegOverride} = getCliOptions({
+	const publicDir = publicDirOption.getValue({
+		commandLine: parsedCli,
+	}).value;
+
+	const {browserExecutable, ffmpegOverride} = getCliOptions({
 		isStill: true,
 		logLevel,
 	});

--- a/packages/cli/src/render-queue/process-video.ts
+++ b/packages/cli/src/render-queue/process-video.ts
@@ -85,5 +85,6 @@ export const processVideoJob = async ({
 		forSeamlessAacConcatenation:
 			job.type === 'video' ? job.forSeamlessAacConcatenation : false,
 		separateAudioTo: job.type === 'video' ? job.separateAudioTo : null,
+		publicPath: null,
 	});
 };

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -35,6 +35,7 @@ const {
 	forSeamlessAacConcatenationOption,
 	separateAudioOption,
 	audioCodecOption,
+	publicPathOption,
 } = BrowserSafeApis.options;
 
 export const render = async (
@@ -160,6 +161,7 @@ export const render = async (
 	const separateAudioTo = separateAudioOption.getValue({
 		commandLine: parsedCli,
 	}).value;
+	const publicPath = publicPathOption.getValue({commandLine: parsedCli}).value;
 
 	const chromiumOptions: ChromiumOptions = {
 		disableWebSecurity,
@@ -231,5 +233,6 @@ export const render = async (
 		binariesDirectory,
 		forSeamlessAacConcatenation,
 		separateAudioTo,
+		publicPath,
 	});
 };

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -36,6 +36,7 @@ const {
 	separateAudioOption,
 	audioCodecOption,
 	publicPathOption,
+	publicDirOption,
 } = BrowserSafeApis.options;
 
 export const render = async (
@@ -86,7 +87,6 @@ export const render = async (
 		userAgent,
 		disableWebSecurity,
 		ignoreCertificateErrors,
-		publicDir,
 		height,
 		width,
 		ffmpegOverride,
@@ -173,6 +173,7 @@ export const render = async (
 	};
 
 	const audioCodec = audioCodecOption.getValue({commandLine: parsedCli}).value;
+	const publicDir = publicDirOption.getValue({commandLine: parsedCli}).value;
 
 	await renderVideoFlow({
 		fullEntryPoint,

--- a/packages/cli/src/setup-cache.ts
+++ b/packages/cli/src/setup-cache.ts
@@ -193,6 +193,7 @@ export const bundleOnCli = async ({
 		publicDir,
 		onPublicDirCopyProgress,
 		onSymlinkDetected,
+		publicPath: './',
 	};
 
 	const [hash] = await BundlerInternals.getConfig({

--- a/packages/cli/src/still.ts
+++ b/packages/cli/src/still.ts
@@ -20,6 +20,7 @@ const {
 	headlessOption,
 	overwriteOption,
 	binariesDirectoryOption,
+	publicPathOption,
 } = BrowserSafeApis.options;
 
 export const still = async (
@@ -102,6 +103,9 @@ export const still = async (
 	const binariesDirectory = binariesDirectoryOption.getValue({
 		commandLine: parsedCli,
 	}).value;
+	const publicPath = publicPathOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 
 	const chromiumOptions: ChromiumOptions = {
 		disableWebSecurity,
@@ -148,5 +152,6 @@ export const still = async (
 		outputLocationFromUi: null,
 		offthreadVideoCacheSizeInBytes,
 		binariesDirectory,
+		publicPath,
 	});
 };

--- a/packages/cli/src/still.ts
+++ b/packages/cli/src/still.ts
@@ -21,6 +21,7 @@ const {
 	overwriteOption,
 	binariesDirectoryOption,
 	publicPathOption,
+	publicDirOption,
 } = BrowserSafeApis.options;
 
 export const still = async (
@@ -65,7 +66,6 @@ export const still = async (
 		envVariables,
 		height,
 		inputProps,
-		publicDir,
 		stillFrame,
 		width,
 		disableWebSecurity,
@@ -104,6 +104,9 @@ export const still = async (
 		commandLine: parsedCli,
 	}).value;
 	const publicPath = publicPathOption.getValue({
+		commandLine: parsedCli,
+	}).value;
+	const publicDir = publicDirOption.getValue({
 		commandLine: parsedCli,
 	}).value;
 

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -31,6 +31,8 @@ const getPort = () => {
 	return null;
 };
 
+const {binariesDirectoryOption, publicDirOption} = BrowserSafeApis.options;
+
 export const studioCommand = async (
 	remotionRoot: string,
 	args: string[],
@@ -91,10 +93,13 @@ export const studioCommand = async (
 
 	const gitSource = getGitSource(remotionRoot);
 
-	const binariesDirectory =
-		BrowserSafeApis.options.binariesDirectoryOption.getValue({
-			commandLine: parsedCli,
-		}).value;
+	const binariesDirectory = binariesDirectoryOption.getValue({
+		commandLine: parsedCli,
+	}).value;
+
+	const relativePublicDir = publicDirOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 
 	await StudioServerInternals.startStudio({
 		previewEntry: require.resolve('@remotion/studio/entry'),
@@ -109,7 +114,7 @@ export const studioCommand = async (
 		keyboardShortcutsEnabled,
 		maxTimelineTracks: ConfigInternals.getMaxTimelineTracks(),
 		remotionRoot,
-		userPassedPublicDir: ConfigInternals.getPublicDir(),
+		relativePublicDir,
 		webpackOverride: ConfigInternals.getWebpackOverrideFn(),
 		poll: ConfigInternals.getWebpackPolling(),
 		getRenderDefaults,

--- a/packages/docs/docs/bundle.md
+++ b/packages/docs/docs/bundle.md
@@ -7,26 +7,24 @@ crumb: "@remotion/bundler"
 
 _Part of the `@remotion/bundler` package._
 
-Bundles a Remotion project using Webpack and prepares it for rendering using [`renderMedia()`](/docs/renderer/render-media).
+Bundles a Remotion project using Webpack and prepares it for rendering using [`renderMedia()`](/docs/renderer/render-media). [See a full server-side rendering example.](/docs/ssr-node)
 
 You only need to call this function when the source code changes. You can render multiple videos from the same bundle and parametrize them using [input props](/docs/passing-props).
 
 Calling `bundle()` for every video that you render is an anti-pattern.  
 `bundle()` cannot be called in a serverless function, see: [Calling bundle() in bundled code](/docs/troubleshooting/bundling-bundle).
 
-```ts title="Function signature"
-const bundle: (options?: {
-  entryPoint: string;
-  onProgress?: (progress: number) => void;
-  webpackOverride?: WebpackOverrideFn;
-  outDir?: string;
-  enableCaching?: boolean;
-  publicPath?: string;
-  rootDir?: string;
-  publicDir?: string | null;
-  onPublicDirCopyProgress?: (bytes: number) => void;
-  onSymlinkDetected?: (path: string) => void;
-}) => Promise<string>;
+## Example
+
+```tsx twoslash title="render.mjs"
+import path from "path";
+// @module: ESNext
+// @target: ESNext
+import { bundle } from "@remotion/bundler";
+
+const serveUrl = await bundle({
+  entryPoint: path.join(process.cwd(), "./src/index.ts"),
+});
 ```
 
 ## Arguments
@@ -78,7 +76,7 @@ A `boolean` specifying whether Webpack caching should be enabled. Default `true`
 
 _optional_
 
-The path of the URL where the bundle is going to be hosted. By default it is `/`, meaning that the bundle is going to be hosted at the root of the domain (e.g. `https://localhost:3000/`). In some cases like rendering on Lambda, the public path might be a subdirectory.
+<Options id="public-path"/>
 
 ### `rootDir?`<AvailableFrom v="3.1.6" />
 

--- a/packages/docs/docs/cli/bundle.md
+++ b/packages/docs/docs/cli/bundle.md
@@ -24,7 +24,7 @@ Specify a location for the Remotion config file.
 
 ### `--log`
 
-[Set the log level](/docs/config#setlevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
+<Options id="log" />
 
 ### `--public-dir`
 
@@ -33,3 +33,7 @@ Specify a location for the Remotion config file.
 ### `--out-dir`
 
 Define the location of the resulting bundle. By default it is a folder called `./build`, adjacent to the [Remotion Root](/docs/terminology/remotion-root).
+
+### `--public-path`<AvailableFrom v="4.0.127"/>
+
+<Options id="public-path" />

--- a/packages/docs/docs/cli/bundle.md
+++ b/packages/docs/docs/cli/bundle.md
@@ -28,7 +28,7 @@ Specify a location for the Remotion config file.
 
 ### `--public-dir`
 
-[Define the location of the `public/` directory.](/docs/config#setpublicdir). If not defined, Remotion will assume the location is the `public` folder in your Remotion root.
+<Options id="public-dir" />
 
 ### `--out-dir`
 

--- a/packages/docs/docs/cli/compositions.md
+++ b/packages/docs/docs/cli/compositions.md
@@ -51,7 +51,7 @@ If you don't feel like passing command line flags every time, consider creating 
 
 ### `--public-dir`<AvailableFrom v="3.2.13" />
 
-[Define the location of the `public/` directory.](/docs/config#setpublicdir). If not defined, Remotion will assume the location is the `public` folder in your Remotion root.
+<Options id="public-path" />
 
 ### `--timeout`
 

--- a/packages/docs/docs/cli/render.md
+++ b/packages/docs/docs/cli/render.md
@@ -158,7 +158,7 @@ For example only every second frame, every third frame and so on. Only works for
 
 ### `--public-dir`<AvailableFrom v="3.2.13" />
 
-[Define the location of the `public/` directory.](/docs/config#setpublicdir). If not defined, Remotion will assume the location is the `public` folder in your Remotion root.
+<Options id="public-path" />
 
 ### `--timeout`
 

--- a/packages/docs/docs/cli/still.md
+++ b/packages/docs/docs/cli/still.md
@@ -85,7 +85,7 @@ From v3.2.27, negative values are allowed, with `-1` being the last frame.
 
 ### `--public-dir`<AvailableFrom v="3.2.13" />
 
-[Define the location of the `public/` directory.](/docs/config#setpublicdir). If not defined, Remotion will assume the location is the `public` folder in your Remotion root.
+<Options id="public-path" />
 
 ### `--timeout`
 

--- a/packages/docs/docs/cli/studio.md
+++ b/packages/docs/docs/cli/studio.md
@@ -43,7 +43,7 @@ Specify a location for a dotenv file - Default `.env`. [Read about how environme
 
 ### `--public-dir`<AvailableFrom v="3.2.13" />
 
-[Define the location of the `public/` directory.](/docs/config#setpublicdir). If not defined, Remotion will assume the location is the `public` folder in your Remotion root.
+<Options id="public-path" />
 
 ### `--disable-keyboard-shortcuts`<AvailableFrom v="3.2.11" />
 

--- a/packages/docs/docs/config.md
+++ b/packages/docs/docs/config.md
@@ -79,14 +79,12 @@ The [command line flag](/docs/cli/render#--port) `--port` will take precedence o
 
 ## setPublicDir()<AvailableFrom v="3.2.13" />
 
-Define the location of the `public/` directory.  
-By default it is a folder named "public" inside the current working directory.  
-You can either set an absolute path, or a relative path that will be resolved from the closest package.json location.
+<Options id="public-dir"  />
 
 ```ts twoslash title="remotion.config.ts"
 import { Config } from "@remotion/cli/config";
 // ---cut---
-Config.setPublicDir("./publico");
+Config.setPublicDir("./custom-public-dir");
 ```
 
 The [command line flag](/docs/cli/render#--public-dir) `--public-dir` will take precedence over this option.

--- a/packages/renderer/src/options/index.tsx
+++ b/packages/renderer/src/options/index.tsx
@@ -22,6 +22,7 @@ import {offthreadVideoCacheSizeInBytesOption} from './offthreadvideo-cache-size'
 import type {AnyRemotionOption} from './option';
 import {overwriteOption} from './overwrite';
 import {preferLosslessAudioOption} from './prefer-lossless';
+import {publicPathOption} from './public-path';
 import {reproOption} from './repro';
 import {scaleOption} from './scale';
 import {separateAudioOption} from './separate-audio';
@@ -63,6 +64,7 @@ export const allOptions = {
 	binariesDirectoryOption,
 	forSeamlessAacConcatenationOption,
 	separateAudioOption,
+	publicPathOption,
 };
 
 export type AvailableOptions = keyof typeof allOptions;

--- a/packages/renderer/src/options/index.tsx
+++ b/packages/renderer/src/options/index.tsx
@@ -22,6 +22,7 @@ import {offthreadVideoCacheSizeInBytesOption} from './offthreadvideo-cache-size'
 import type {AnyRemotionOption} from './option';
 import {overwriteOption} from './overwrite';
 import {preferLosslessAudioOption} from './prefer-lossless';
+import {publicDirOption} from './public-dir';
 import {publicPathOption} from './public-path';
 import {reproOption} from './repro';
 import {scaleOption} from './scale';
@@ -65,6 +66,7 @@ export const allOptions = {
 	forSeamlessAacConcatenationOption,
 	separateAudioOption,
 	publicPathOption,
+	publicDirOption,
 };
 
 export type AvailableOptions = keyof typeof allOptions;

--- a/packages/renderer/src/options/public-dir.tsx
+++ b/packages/renderer/src/options/public-dir.tsx
@@ -1,0 +1,48 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'public-dir' as const;
+
+let currentPublicDir: string | null = null;
+
+export const publicDirOption = {
+	name: 'Public Directory',
+	cliFlag,
+	description: () => {
+		return (
+			<>
+				Define the location of the{' '}
+				<a href="/docs/terminology/public-dir">
+					<code>public/ directory</code>
+				</a>
+				. If not defined, Remotion will assume the location is the `public`
+				folder in your Remotion root.
+			</>
+		);
+	},
+	ssrName: 'publicDir' as const,
+	docLink: 'https://www.remotion.dev/docs/terminology/public-dir',
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {
+				source: 'cli',
+				value: commandLine[cliFlag] as string,
+			};
+		}
+
+		if (currentPublicDir !== null) {
+			return {
+				source: 'config',
+				value: currentPublicDir,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: null,
+		};
+	},
+	setConfig: (value: string | null) => {
+		currentPublicDir = value;
+	},
+	type: '' as string | null,
+} satisfies AnyRemotionOption<string | null>;

--- a/packages/renderer/src/options/public-path.tsx
+++ b/packages/renderer/src/options/public-path.tsx
@@ -1,0 +1,47 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'public-path' as const;
+
+let currentPublicPath: string | null = null;
+
+export const publicPathOption = {
+	name: 'Public Path',
+	cliFlag,
+	description: () => {
+		return (
+			<>
+				The path of the URL where the bundle is going to be hosted. By default
+				it is <code>/</code>, meaning that the bundle is going to be hosted at
+				the root of the domain (e.g. <code>https://localhost:3000/</code>). If
+				you are deploying to a subdirectory (e.g. <code>/sites/my-site/</code>),
+				you should set this to the subdirectory.
+			</>
+		);
+	},
+	ssrName: 'publicPath' as const,
+	docLink: 'https://www.remotion.dev/docs/renderer',
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {
+				source: 'cli',
+				value: commandLine[cliFlag] as string,
+			};
+		}
+
+		if (currentPublicPath !== null) {
+			return {
+				source: 'config',
+				value: currentPublicPath,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: null,
+		};
+	},
+	setConfig: (value: string | null) => {
+		currentPublicPath = value;
+	},
+	type: '' as string | null,
+} satisfies AnyRemotionOption<string | null>;

--- a/packages/studio-server/src/preview-server/get-absolute-public-dir.ts
+++ b/packages/studio-server/src/preview-server/get-absolute-public-dir.ts
@@ -1,15 +1,13 @@
 import path from 'node:path';
 
 export const getAbsolutePublicDir = ({
-	userPassedPublicDir,
+	relativePublicDir,
 	remotionRoot,
 }: {
-	userPassedPublicDir: string | null;
+	relativePublicDir: string | null;
 	remotionRoot: string;
 }) => {
-	const publicDir = userPassedPublicDir
-		? path.resolve(remotionRoot, userPassedPublicDir)
+	return relativePublicDir
+		? path.resolve(remotionRoot, relativePublicDir)
 		: path.join(remotionRoot, 'public');
-
-	return publicDir;
 };

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -28,7 +28,6 @@ export const startServer = async (options: {
 	remotionRoot: string;
 	keyboardShortcutsEnabled: boolean;
 	publicDir: string;
-	userPassedPublicDir: string | null;
 	poll: number | null;
 	staticHash: string;
 	staticHashPrefix: string;

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -67,7 +67,7 @@ export const startStudio = async ({
 	maxTimelineTracks,
 	remotionRoot,
 	keyboardShortcutsEnabled,
-	userPassedPublicDir,
+	relativePublicDir,
 	webpackOverride,
 	poll,
 	getRenderDefaults,
@@ -93,7 +93,7 @@ export const startStudio = async ({
 	bufferStateDelayInMilliseconds: number | null;
 	remotionRoot: string;
 	keyboardShortcutsEnabled: boolean;
-	userPassedPublicDir: string | null;
+	relativePublicDir: string | null;
 	webpackOverride: WebpackOverrideFn;
 	poll: number | null;
 	getRenderDefaults: () => RenderDefaults;
@@ -108,7 +108,7 @@ export const startStudio = async ({
 }) => {
 	watchRootFile(remotionRoot);
 	const publicDir = getAbsolutePublicDir({
-		userPassedPublicDir,
+		relativePublicDir,
 		remotionRoot,
 	});
 	const hash = crypto.randomBytes(6).toString('hex');
@@ -152,7 +152,6 @@ export const startStudio = async ({
 		publicDir,
 		webpackOverride,
 		poll,
-		userPassedPublicDir,
 		staticHash,
 		staticHashPrefix,
 		outputHash,


### PR DESCRIPTION
Now we can host the bundled studio on GitHub pages as a preview for the code. Previously it wanted to load [username].github.io/bundle.js (from the root of the url)

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
