### PR TITLE
Docs: Better indentation for Remotion Studio deployment

### DIFF
--- a/packages/docs/docs/render.md
+++ b/packages/docs/docs/render.md
@@ -12,6 +12,10 @@ There are various ways to render your video.
 To render a video, click the "<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" style={{height: 16, verticalAlign: "text-bottom"}}><path d="M117.8 128H207C286.9-3.7 409.5-8.5 483.9 5.3c11.6 2.2 20.7 11.2 22.8 22.8c13.8 74.4 9 197-122.7 276.9v89.3c0 25.4-13.4 49-35.3 61.9l-88.5 52.5c-7.4 4.4-16.6 4.5-24.1 .2s-12.1-12.2-12.1-20.9l0-114.7c0-22.6-9-44.3-25-60.3s-37.7-25-60.3-25H24c-8.6 0-16.6-4.6-20.9-12.1s-4.2-16.7 .2-24.1l52.5-88.5c13-21.9 36.5-35.3 61.9-35.3zM424 128a40 40 0 1 0 -80 0 40 40 0 1 0 80 0zM166.5 470C132.3 504.3 66 511 28.3 511.9c-16 .4-28.6-12.2-28.2-28.2C1 446 7.7 379.7 42 345.5c34.4-34.4 90.1-34.4 124.5 0s34.4 90.1 0 124.5zm-46.7-36.4c11.4-11.4 11.4-30 0-41.4s-30-11.4-41.4 0c-10.1 10.1-13 28.5-13.7 41.3c-.5 8 5.9 14.3 13.9 13.9c12.8-.7 31.2-3.7 41.3-13.7z"/></svg> Render" button.  
 Choose your preferred settings, then confirm using the `Render video` button.
 
+### Remotion Studio deployment
+
+It’s possible to deploy the Remotion Studio onto a long-running server in the cloud, which can then be accessed by your non-technical team members using just a URL. Check out the [Deploy the Remotion Studio](/docs/studio/deploy-server) guide to learn how to do this.
+
 ## CLI
 
 Render a video using [`render` CLI command](/docs/cli/render):
@@ -43,10 +47,6 @@ You can also render a [video using a GitHub Action.](/docs/ssr#render-using-gith
 ## Google Cloud Run
 
 An official Remotion package for Cloud Run is in development. Register your interest in [Discord](https://remotion.dev/discord) if you want to be a beta tester.
-
-### Remotion Studio deployment
-
-It’s possible to deploy the Remotion Studio onto a long-running server in the cloud, which can then be accessed by your non-technical team members using just a URL. Check out the [Deploy the Remotion Studio](/docs/studio/deploy-server) guide to learn how to do this.
 
 ## Variants
 


### PR DESCRIPTION
Currently, the side panel shows this on the [Render page](https://www.remotion.dev/docs/render)
![image](https://github.com/remotion-dev/remotion/assets/22192773/0fc39e4e-7f50-4ecc-bc7d-3f3a141f31ef)


I've moved Remotion Studio deployment to be a subheading under Remotion Studio 