### PR TITLE
`remotion`: Fix Apple WebKit detection

### DIFF
--- a/packages/core/src/video/video-fragment.ts
+++ b/packages/core/src/video/video-fragment.ts
@@ -5,10 +5,14 @@ const toSeconds = (time: number, fps: number) => {
 };
 
 export const isIosSafari = () => {
-	return typeof window === 'undefined'
-		? false
-		: /iP(ad|od|hone)/i.test(window.navigator.userAgent) &&
-				Boolean(navigator.userAgent.match(/Version\/[\d.]+.*Safari/));
+	if (typeof window === 'undefined') {
+		return false;
+	}
+
+	const isIpadIPodIPhone = /iP(ad|od|hone)/i.test(window.navigator.userAgent);
+	const isAppleWebKit = /AppleWebKit/.test(window.navigator.userAgent);
+
+	return isIpadIPodIPhone && isAppleWebKit;
 };
 
 // https://github.com/remotion-dev/remotion/issues/1655


### PR DESCRIPTION
Previously, it would not trigger on third party browsers like Chrome.

Now testing for AppleWebkit to also cover more third-party browsers