### PR TITLE
feat:add-generics-to-getInputProps

### DIFF
--- a/packages/core/src/config/input-props.ts
+++ b/packages/core/src/config/input-props.ts
@@ -19,7 +19,9 @@ const warnOnceSSRImport = () => {
 	console.warn("  typeof window === 'undefined' ? {} : getInputProps()");
 };
 
-export const getInputProps = <T extends Record<string, any> = Record<string, unknown>>(): T => {
+export const getInputProps = <
+	T extends Record<string, unknown> = Record<string, unknown>,
+>(): T => {
 	if (typeof window === 'undefined') {
 		warnOnceSSRImport();
 		return {} as T;

--- a/packages/core/src/config/input-props.ts
+++ b/packages/core/src/config/input-props.ts
@@ -19,10 +19,10 @@ const warnOnceSSRImport = () => {
 	console.warn("  typeof window === 'undefined' ? {} : getInputProps()");
 };
 
-export const getInputProps = () => {
+export const getInputProps = <T extends Record<string, any> = Record<string, unknown>>(): T => {
 	if (typeof window === 'undefined') {
 		warnOnceSSRImport();
-		return {};
+		return {} as T;
 	}
 
 	if (getRemotionEnvironment().isPlayer) {
@@ -33,9 +33,9 @@ export const getInputProps = () => {
 
 	const param = window.remotion_inputProps;
 	if (!param) {
-		return {};
+		return {} as T;
 	}
 
-	const parsed = deserializeJSONWithCustomFields(param);
+	const parsed = deserializeJSONWithCustomFields<T>(param);
 	return parsed;
 };

--- a/packages/core/src/input-props-serialization.ts
+++ b/packages/core/src/input-props-serialization.ts
@@ -63,9 +63,9 @@ export const serializeJSONWithDate = ({
 	return {serializedString, customDateUsed, customFileUsed, mapUsed, setUsed};
 };
 
-export const deserializeJSONWithCustomFields = (
+export const deserializeJSONWithCustomFields = <T = Record<string, unknown>>(
 	data: string,
-): Record<string, unknown> => {
+): T => {
 	return JSON.parse(data, (_, value) => {
 		if (typeof value === 'string' && value.startsWith(DATE_TOKEN)) {
 			return new Date(value.replace(DATE_TOKEN, ''));


### PR DESCRIPTION
Add a generic to getInputProps, allowing it to accept a more specific return type rather than Record<string, unknown>.