### PR TITLE
feat: add nextjs app dir tailwindcss template

### DIFF
--- a/packages/create-video/src/pkg-managers.ts
+++ b/packages/create-video/src/pkg-managers.ts
@@ -133,6 +133,7 @@ export const getDevCommand = (manager: PackageManager, template: Template) => {
 	if (
 		template.cliId === 'remix' ||
 		template.cliId === 'next' ||
+		template.cliId === 'next-tailwind' ||
 		template.cliId === 'next-pages-dir'
 	) {
 		return `${getRunCommand(manager)} dev`;

--- a/packages/create-video/src/templates.tsx
+++ b/packages/create-video/src/templates.tsx
@@ -30,6 +30,7 @@ export type Template = {
 		| 'javascript'
 		| 'blank'
 		| 'next'
+		| 'next-tailwind'
 		| 'next-pages-dir'
 		| 'remix'
 		| 'three'
@@ -89,6 +90,24 @@ export const FEATURED_TEMPLATES: Template[] = [
 		type: 'video' as const,
 		defaultBranch: 'main',
 		featuredOnHomePage: 'Next.js',
+	},
+	{
+		homePageLabel: 'Next.js (App dir + TailwindCSS)',
+		shortName: 'Next.js (App dir/TailwindCSS)',
+		org: 'remotion-dev',
+		repoName: 'template-next-app-dir-tailwind',
+		description: 'SaaS template for video generation apps',
+		longerDescription:
+			'A SaaS starter kit which has the Remotion Player and rendering via Remotion Lambda built-in. Our recommended choice for people who want to build an app that can generate videos.',
+		promoVideo: {
+			width: 1280,
+			height: 720,
+			muxId: 'RufnZIJZh6L1MAaeG02jnXuM9pK96tNuHRxmXHbWqCBI',
+		},
+		cliId: 'next-tailwind' as const,
+		type: 'video' as const,
+		defaultBranch: 'main',
+		featuredOnHomePage: null,
 	},
 	{
 		homePageLabel: 'Next.js (Pages dir)',

--- a/packages/create-video/src/templates.tsx
+++ b/packages/create-video/src/templates.tsx
@@ -93,7 +93,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 	},
 	{
 		homePageLabel: 'Next.js (App dir + TailwindCSS)',
-		shortName: 'Next.js (App dir/TailwindCSS)',
+		shortName: 'Next.js (App dir + TailwindCSS)',
 		org: 'remotion-dev',
 		repoName: 'template-next-app-dir-tailwind',
 		description: 'SaaS template for video generation apps',

--- a/packages/docs/docs/player/index.md
+++ b/packages/docs/docs/player/index.md
@@ -13,6 +13,7 @@ Using the Remotion Player you can embed Remotion videos in any React app and cus
 The following templates include the Player and Lambda rendering and are a good starting point for building a video app:
 
 - [Next.js (App dir)](/templates/next)
+- [Next.js (App dir + TailwindCSS)](/templates/next-tailwind)
 - [Next.js (Pages dir)](/templates/next-pages-dir)
 - [Remix](/templates/remix)
 

--- a/packages/docs/docs/player/player-integration.md
+++ b/packages/docs/docs/player/player-integration.md
@@ -19,6 +19,7 @@ Remotion and your React app use a different Webpack config. Therefore, if you wa
 Use one of our starter templates:
 
 - [Next.js (App dir)](/templates/next)
+- [Next.js (App dir + TailwindCSS)](/templates/next-tailwind)
 - [Next.js (Pages dir)](/templates/next-pages-dir)
 - [Remix](/templates/remix)
 

--- a/packages/docs/src/components/IconForTemplate.tsx
+++ b/packages/docs/src/components/IconForTemplate.tsx
@@ -134,7 +134,11 @@ export const IconForTemplate: React.FC<{
     return <OverlayIcon style={{ height: scale * 42 }} />;
   }
 
-  if (template.cliId === "next" || template.cliId === "next-pages-dir") {
+  if (
+    template.cliId === "next" ||
+    template.cliId === "next-tailwind" ||
+    template.cliId === "next-pages-dir"
+  ) {
     return <NextIcon style={{ height: scale * 36 }} />;
   }
 

--- a/packages/docs/src/pages/templates/index.tsx
+++ b/packages/docs/src/pages/templates/index.tsx
@@ -5,6 +5,7 @@ import Layout from "@theme/Layout";
 import { CreateVideoInternals } from "create-video";
 import React from "react";
 import { IconForTemplate } from "../../components/IconForTemplate";
+import { SkiaIcon } from "../../components/icons/skia";
 import { Seo } from "../../components/Seo";
 import styles from "./styles.module.css";
 
@@ -94,6 +95,7 @@ export default () => {
         <p style={para}>
           Jumpstart your project with a template that fits your usecase.
         </p>
+        <h3>Free templates</h3>
         <div className={styles.grid}>
           {CreateVideoInternals.FEATURED_TEMPLATES.map((template) => {
             return (
@@ -113,6 +115,47 @@ export default () => {
             );
           })}
         </div>
+        <br />
+        <br />
+        <h3>Paid templates</h3>
+        <div className={styles.grid}>
+          <Link
+            key={"map"}
+            className={styles.item}
+            style={outer}
+            to={`https://www.remotion.pro/mapbox-globe`}
+          >
+            <Item
+              label={"Mapbox Globe"}
+              description={"A rotateable and zoomeable 3D Globe"}
+            >
+              <svg style={{ height: 0.7 * 36 }} viewBox="0 0 512 512">
+                <path
+                  fill="currentcolor"
+                  d="M256 464c7.4 0 27-7.2 47.6-48.4c8.8-17.7 16.4-39.2 22-63.6H186.4c5.6 24.4 13.2 45.9 22 63.6C229 456.8 248.6 464 256 464zM178.5 304h155c1.6-15.3 2.5-31.4 2.5-48s-.9-32.7-2.5-48h-155c-1.6 15.3-2.5 31.4-2.5 48s.9 32.7 2.5 48zm7.9-144H325.6c-5.6-24.4-13.2-45.9-22-63.6C283 55.2 263.4 48 256 48s-27 7.2-47.6 48.4c-8.8 17.7-16.4 39.2-22 63.6zm195.3 48c1.5 15.5 2.2 31.6 2.2 48s-.8 32.5-2.2 48h76.7c3.6-15.4 5.6-31.5 5.6-48s-1.9-32.6-5.6-48H381.8zm58.8-48c-21.4-41.1-56.1-74.1-98.4-93.4c14.1 25.6 25.3 57.5 32.6 93.4h65.9zm-303.3 0c7.3-35.9 18.5-67.7 32.6-93.4c-42.3 19.3-77 52.3-98.4 93.4h65.9zM53.6 208c-3.6 15.4-5.6 31.5-5.6 48s1.9 32.6 5.6 48h76.7c-1.5-15.5-2.2-31.6-2.2-48s.8-32.5 2.2-48H53.6zM342.1 445.4c42.3-19.3 77-52.3 98.4-93.4H374.7c-7.3 35.9-18.5 67.7-32.6 93.4zm-172.2 0c-14.1-25.6-25.3-57.5-32.6-93.4H71.4c21.4 41.1 56.1 74.1 98.4 93.4zM256 512A256 256 0 1 1 256 0a256 256 0 1 1 0 512z"
+                />
+              </svg>
+            </Item>
+          </Link>
+          <Link
+            key={"map"}
+            className={styles.item}
+            style={outer}
+            to={`https://www.remotion.pro/mapbox-globe`}
+          >
+            <Item
+              label={"Watercolor Map"}
+              description={"A beautiful 2D map for travel videos"}
+            >
+              <SkiaIcon
+                style={{
+                  height: 0.7 * 32,
+                }}
+              />
+            </Item>
+          </Link>
+        </div>
+
         <br />
         <p style={lowerpara}>
           {"Couldn't"} find what you need? Check out the list of{" "}

--- a/packages/docs/src/remotion/Template.tsx
+++ b/packages/docs/src/remotion/Template.tsx
@@ -68,6 +68,7 @@ export const TemplateComp: React.FC<{
             }}
           >
             {template.cliId === "next" ||
+            template.cliId === "next-tailwind" ||
             template.cliId === "next-pages-dir" ? null : (
               <>
                 <IconForTemplate scale={1.6} template={template} />{" "}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Closes #3316 

Was working on a new remotion project and since i use tailwindcss for all projects, it's quite a bit of work to get remotion configured... took some time out to fork the existing nextjs template, convert it over to tailwindcss with its best practices applied 🙃 Hope this would be helpful for people using tailwind with nextjs... 

@JonnyBurger the pr assumes [`Just-Moh-it/template-next-app-dir-tailwind`](https://github.com/Just-Moh-it/template-next-app-dir-tailwind) has been transferred over to `remotion-dev/template-next-app-dir-tailwind`. Since I don't have create repo access on the org, I created a transfer request to your personal github account instead, just like we did for the turborepo template... feel free to accept the transfer and make your modifications :)