### PR TITLE
`@remotion/renderer`: Render frames in order

### DIFF
--- a/packages/renderer/src/get-extra-frames-to-capture.ts
+++ b/packages/renderer/src/get-extra-frames-to-capture.ts
@@ -5,7 +5,8 @@ import {getClosestAlignedTime} from './combine-audio';
 import {DEFAULT_SAMPLE_RATE} from './sample-rate';
 
 type ReturnType = {
-	extraFramesToCaptureAssets: number[];
+	extraFramesToCaptureAssetsFrontend: number[];
+	extraFramesToCaptureAssetsBackend: number[];
 	trimLeftOffset: number;
 	trimRightOffset: number;
 	chunkLengthInSeconds: number;
@@ -28,7 +29,8 @@ export const getExtraFramesToCapture = ({
 	// If the feature is disabled, don't capture extra frames.
 	if (!forSeamlessAacConcatenation) {
 		return {
-			extraFramesToCaptureAssets: [],
+			extraFramesToCaptureAssetsBackend: [],
+			extraFramesToCaptureAssetsFrontend: [],
 			chunkLengthInSeconds: (realFrameRange[1] - realFrameRange[0] + 1) / fps,
 			trimLeftOffset: 0,
 			trimRightOffset: 0,
@@ -89,10 +91,8 @@ export const getExtraFramesToCapture = ({
 	const chunkLengthInSeconds = aacAdjustedRightEnd - aacAdjustedLeftEnd;
 
 	return {
-		extraFramesToCaptureAssets: [
-			...extraFramesToCaptureAudioOnlyFrontend,
-			...extraFramesToCaptureAudioOnlyBackend,
-		],
+		extraFramesToCaptureAssetsFrontend: extraFramesToCaptureAudioOnlyFrontend,
+		extraFramesToCaptureAssetsBackend: extraFramesToCaptureAudioOnlyBackend,
 		chunkLengthInSeconds,
 		trimLeftOffset,
 		trimRightOffset,

--- a/packages/renderer/src/test/extra-frames-to-capture.test.ts
+++ b/packages/renderer/src/test/extra-frames-to-capture.test.ts
@@ -2,41 +2,61 @@ import {expect, test} from 'vitest';
 import {getExtraFramesToCapture} from '../get-extra-frames-to-capture';
 
 test('Extra frames to capture 0', () => {
-	const {extraFramesToCaptureAssets} = getExtraFramesToCapture({
+	const {
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
+	} = getExtraFramesToCapture({
 		fps: 30,
 		compositionStart: 0,
 		realFrameRange: [0, 30],
 		forSeamlessAacConcatenation: true,
 	});
 
-	expect(extraFramesToCaptureAssets).toEqual([31]);
+	expect([
+		...extraFramesToCaptureAssetsFrontend,
+		...extraFramesToCaptureAssetsBackend,
+	]).toEqual([31]);
 });
 
 test('Extra frames to capture 1', () => {
-	const {extraFramesToCaptureAssets} = getExtraFramesToCapture({
+	const {
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
+	} = getExtraFramesToCapture({
 		fps: 30,
 		compositionStart: 100,
 		realFrameRange: [100, 116],
 		forSeamlessAacConcatenation: true,
 	});
 
-	expect(extraFramesToCaptureAssets).toEqual([117, 118]);
+	expect([
+		...extraFramesToCaptureAssetsFrontend,
+		...extraFramesToCaptureAssetsBackend,
+	]).toEqual([117, 118]);
 });
 
 test('Extra frames to capture 2', () => {
-	const {extraFramesToCaptureAssets} = getExtraFramesToCapture({
+	const {
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
+	} = getExtraFramesToCapture({
 		fps: 30,
 		compositionStart: 100,
 		realFrameRange: [151, 167],
 		forSeamlessAacConcatenation: true,
 	});
 
-	expect(extraFramesToCaptureAssets).toEqual([149, 150, 168, 169]);
+	expect([
+		...extraFramesToCaptureAssetsFrontend,
+		...extraFramesToCaptureAssetsBackend,
+	]).toEqual([149, 150, 168, 169]);
 });
 
 test('Extra frames to capture 3', () => {
 	const {
-		extraFramesToCaptureAssets,
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
+
 		trimLeftOffset,
 		trimRightOffset,
 		chunkLengthInSeconds,
@@ -47,7 +67,10 @@ test('Extra frames to capture 3', () => {
 		forSeamlessAacConcatenation: true,
 	});
 
-	expect(extraFramesToCaptureAssets).toEqual([132, 133, 151, 152]);
+	expect([
+		...extraFramesToCaptureAssetsFrontend,
+		...extraFramesToCaptureAssetsBackend,
+	]).toEqual([132, 133, 151, 152]);
 	expect(trimLeftOffset).toEqual(0.021333333333333114);
 	expect(trimRightOffset).toEqual(-0.017333333333333437);
 	expect(chunkLengthInSeconds).toEqual(0.6613333333333333);
@@ -55,7 +78,8 @@ test('Extra frames to capture 3', () => {
 
 test('Extra frames to capture 4', () => {
 	const {
-		extraFramesToCaptureAssets,
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
 		trimLeftOffset,
 		trimRightOffset,
 		chunkLengthInSeconds,
@@ -66,7 +90,10 @@ test('Extra frames to capture 4', () => {
 		forSeamlessAacConcatenation: true,
 	});
 
-	expect(extraFramesToCaptureAssets).toEqual([116, 134, 135]);
+	expect([
+		...extraFramesToCaptureAssetsFrontend,
+		...extraFramesToCaptureAssetsBackend,
+	]).toEqual([116, 134, 135]);
 	expect(trimLeftOffset).toEqual(0);
 	expect(trimRightOffset).toEqual(-0.026666666666666807);
 	expect(chunkLengthInSeconds).toEqual(0.6399999999999998);

--- a/packages/renderer/src/test/ffmpeg-filters.test.ts
+++ b/packages/renderer/src/test/ffmpeg-filters.test.ts
@@ -59,7 +59,8 @@ test('Trim the end', () => {
 		chunkLengthInSeconds,
 		trimLeftOffset,
 		trimRightOffset,
-		extraFramesToCaptureAssets,
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
 	} = getExtraFramesToCapture({
 		compositionStart: 0,
 		forSeamlessAacConcatenation: true,
@@ -76,7 +77,13 @@ test('Trim the end', () => {
 	expect(
 		calculateFfmpegFilter({
 			fps: 30,
-			asset: expandAsset({extraFramesToCaptureAssets, base: baseAsset}),
+			asset: expandAsset({
+				extraFramesToCaptureAssets: [
+					...extraFramesToCaptureAssetsFrontend,
+					...extraFramesToCaptureAssetsBackend,
+				],
+				base: baseAsset,
+			}),
 			channels: 1,
 			assetDuration: 100,
 			chunkLengthInSeconds,
@@ -97,7 +104,8 @@ test('Should handle trim correctly', () => {
 		chunkLengthInSeconds,
 		trimLeftOffset,
 		trimRightOffset,
-		extraFramesToCaptureAssets,
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
 	} = getExtraFramesToCapture({
 		compositionStart: 0,
 		forSeamlessAacConcatenation: true,
@@ -116,7 +124,10 @@ test('Should handle trim correctly', () => {
 					...baseAsset,
 					trimLeft: 10,
 				},
-				extraFramesToCaptureAssets,
+				extraFramesToCaptureAssets: [
+					...extraFramesToCaptureAssetsFrontend,
+					...extraFramesToCaptureAssetsBackend,
+				],
 			}),
 			channels: 1,
 			assetDuration: 10,
@@ -170,7 +181,8 @@ test('Should handle delay correctly', () => {
 		chunkLengthInSeconds,
 		trimLeftOffset,
 		trimRightOffset,
-		extraFramesToCaptureAssets,
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
 	} = getExtraFramesToCapture({
 		compositionStart: 0,
 		forSeamlessAacConcatenation: true,
@@ -187,7 +199,10 @@ test('Should handle delay correctly', () => {
 					trimLeft: 10,
 					startInVideo: 80,
 				},
-				extraFramesToCaptureAssets,
+				extraFramesToCaptureAssets: [
+					...extraFramesToCaptureAssetsFrontend,
+					...extraFramesToCaptureAssetsBackend,
+				],
 			}),
 			channels: 1,
 			assetDuration: 1,
@@ -209,7 +224,8 @@ test('Should offset multiple channels', () => {
 		chunkLengthInSeconds,
 		trimLeftOffset,
 		trimRightOffset,
-		extraFramesToCaptureAssets,
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
 	} = getExtraFramesToCapture({
 		compositionStart: 0,
 		forSeamlessAacConcatenation: true,
@@ -226,7 +242,10 @@ test('Should offset multiple channels', () => {
 					trimLeft: 10,
 					startInVideo: 80,
 				},
-				extraFramesToCaptureAssets,
+				extraFramesToCaptureAssets: [
+					...extraFramesToCaptureAssetsFrontend,
+					...extraFramesToCaptureAssetsBackend,
+				],
 			}),
 			channels: 3,
 			assetDuration: 1,
@@ -252,7 +271,8 @@ test('Should calculate pad correctly with a lot of playbackRate', () => {
 		chunkLengthInSeconds,
 		trimLeftOffset,
 		trimRightOffset,
-		extraFramesToCaptureAssets,
+		extraFramesToCaptureAssetsBackend,
+		extraFramesToCaptureAssetsFrontend,
 	} = getExtraFramesToCapture({
 		compositionStart: 0,
 		forSeamlessAacConcatenation: false,
@@ -276,7 +296,10 @@ test('Should calculate pad correctly with a lot of playbackRate', () => {
 					allowAmplificationDuringRender: false,
 					toneFrequency: null,
 				},
-				extraFramesToCaptureAssets,
+				extraFramesToCaptureAssets: [
+					...extraFramesToCaptureAssetsFrontend,
+					...extraFramesToCaptureAssetsBackend,
+				],
 			}),
 			channels: 1,
 			assetDuration: 33.333333,


### PR DESCRIPTION
While the order technically doesn't matter, components such as `<Video>` are not always frame perfect and give a flicker. We reduce the chance of flicker by rendering the frames in order.
