### PR TITLE
`@remotion/renderer`: Handle problematic tone mapping video (tone_mapping_bt2020_no_transferin_metadata.mp4)

### DIFF
--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -207,7 +207,6 @@ export const startOffthreadVideoServer = ({
 						!err.message.includes('EPIPE')
 					) {
 						downloadMap.emitter.dispatchError(err);
-						console.log('Error occurred', err);
 					}
 				});
 		},


### PR DESCRIPTION
Reported by z0w0 on Discord  
Added it to our internal problematic video database