### PR TITLE
`@remotion/lambda`: Disable seamless concatenation if framesPerLambda <= 4

### DIFF
--- a/packages/lambda/src/functions/helpers/can-concat-seamlessly.ts
+++ b/packages/lambda/src/functions/helpers/can-concat-seamlessly.ts
@@ -2,7 +2,16 @@ import type {AudioCodec} from '@remotion/renderer';
 
 // Cannot do WAV yet, because currently assumes AAC in+outpoint
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const canConcatAudioSeamlessly = (audioCodec: AudioCodec | null) => {
+export const canConcatAudioSeamlessly = (
+	audioCodec: AudioCodec | null,
+	chunkDurationInFrames: number,
+) => {
+	// Rendering a chunk that is too small generates too much overhead
+	// and is currently buggy
+	if (chunkDurationInFrames <= 4) {
+		return false;
+	}
+
 	return audioCodec === 'aac';
 };
 

--- a/packages/lambda/src/functions/helpers/concat-videos.ts
+++ b/packages/lambda/src/functions/helpers/concat-videos.ts
@@ -238,7 +238,10 @@ export const concatVideosS3 = async ({
 		separateAudioTo: null,
 	});
 
-	const seamlessAudio = canConcatAudioSeamlessly(resolvedAudioCodec);
+	const seamlessAudio = canConcatAudioSeamlessly(
+		resolvedAudioCodec,
+		framesPerLambda,
+	);
 	const seamlessVideo = canConcatVideoSeamlessly(codec);
 
 	await RenderInternals.combineVideos({

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -289,6 +289,7 @@ const innerLaunchHandler = async ({
 			colorSpace: params.colorSpace,
 			preferLossless: params.preferLossless,
 			compositionStart: realFrameRange[0],
+			framesPerLambda,
 		};
 		return payload;
 	});

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -112,7 +112,10 @@ const renderHandler = async (
 		preferLossless: params.preferLossless,
 	});
 
-	const seamlessAudio = canConcatAudioSeamlessly(defaultAudioCodec);
+	const seamlessAudio = canConcatAudioSeamlessly(
+		defaultAudioCodec,
+		params.framesPerLambda,
+	);
 	const seamlessVideo = canConcatVideoSeamlessly(params.codec);
 
 	RenderInternals.Log.verbose(

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -389,6 +389,7 @@ export type LambdaPayloads = {
 		deleteAfter: DeleteAfter | null;
 		colorSpace: ColorSpace;
 		compositionStart: number;
+		framesPerLambda: number;
 	};
 	still: {
 		type: LambdaRoutines.still;


### PR DESCRIPTION
It is buggy currently due to padding being bigger than the actual chunk