### PR TITLE
Fix Docusaurus Vercel URL

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -6,10 +6,7 @@
 const config = (mode) => ({
   title: "Remotion | Make videos programmatically in React",
   tagline: "Make videos programmatically",
-  url:
-    process.env.VERCEL_ENV && process.env.VERCEL_ENV !== "production"
-      ? `https://${process.env.VERCEL_URL}`
-      : "https://www.remotion.dev",
+  url: "https://www.remotion.dev",
   baseUrl: "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",


### PR DESCRIPTION
The env variables do not seem to work as you expect, and this is harmful for Remotion site SEO which has bad canonical urls.

Page metadata: 

```html
<link data-rh="true" rel="canonical" href="https://remotion-ebgrex03y-remotion.vercel.app/blog/faster-lambda">
```

RSS feed: https://www.remotion.dev/blog/rss.xml

![CleanShot 2024-03-25 at 18 39 26](https://github.com/remotion-dev/remotion/assets/749374/5e34c196-f092-4448-8ddd-74aed2fcb2f3)

IMHO it is preferable to harcode the URL. This way if Google ever tries to index a deploy preview, Google will consider that the deploy preview is a "copy" and only consider your prod website as the canonical source of content without penalizing it.