### PR TITLE
Fix minor typo in studio.mdx:

### DIFF
--- a/packages/docs/docs/studio/studio.mdx
+++ b/packages/docs/docs/studio/studio.mdx
@@ -46,7 +46,8 @@ yarn add @remotion/cli
 ```
 
   </TabItem>
-  <TabItem value="yarn">
+
+  <TabItem value="bun">
 
 ```bash
 bun i @remotion/cli


### PR DESCRIPTION
The `bun` tab was misconfigured as `yarn`.