### PR TITLE
`@remotion/renderer`: Use `--headless=old` to force using old headless

### DIFF
--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -158,7 +158,7 @@ export const internalOpenBrowser = async ({
 			'--enable-blink-features=IdleDetection',
 			'--export-tagged-pdf',
 			'--intensive-wake-up-throttling-policy=0',
-			chromiumOptions.headless ?? true ? '--headless' : null,
+			chromiumOptions.headless ?? true ? '--headless=old' : null,
 			'--no-sandbox',
 			'--disable-setuid-sandbox',
 			...customGlRenderer,


### PR DESCRIPTION
Equivalent of https://developer.chrome.com/blog/chrome-headless-shell