### PR TITLE
`@remotion/lambda`: Remove burst limit from `npx remotion lambda quotas`

### DIFF
--- a/packages/lambda/src/cli/commands/quotas/list.ts
+++ b/packages/lambda/src/cli/commands/quotas/list.ts
@@ -6,11 +6,7 @@ import {
 import {CliInternals} from '@remotion/cli';
 import type {LogLevel} from '@remotion/renderer';
 import {QUOTAS_COMMAND} from '.';
-import {
-	BINARY_NAME,
-	LAMBDA_BURST_LIMIT_QUOTA,
-	LAMBDA_CONCURRENCY_LIMIT_QUOTA,
-} from '../../../defaults';
+import {BINARY_NAME, LAMBDA_CONCURRENCY_LIMIT_QUOTA} from '../../../defaults';
 import {getServiceQuotasClient} from '../../../shared/aws-clients';
 import {getAwsRegion} from '../../get-aws-region';
 import {Log} from '../../log';
@@ -23,7 +19,7 @@ export const quotasListCommand = async (logLevel: LogLevel) => {
 		CliInternals.chalk.gray(`Region = ${region}`),
 	);
 	Log.info({indent: false, logLevel});
-	const [concurrencyLimit, defaultConcurrencyLimit, burstLimit, changes] =
+	const [concurrencyLimit, defaultConcurrencyLimit, changes] =
 		await Promise.all([
 			getServiceQuotasClient(region).send(
 				new GetServiceQuotaCommand({
@@ -34,12 +30,6 @@ export const quotasListCommand = async (logLevel: LogLevel) => {
 			getServiceQuotasClient(region).send(
 				new GetAWSDefaultServiceQuotaCommand({
 					QuotaCode: LAMBDA_CONCURRENCY_LIMIT_QUOTA,
-					ServiceCode: 'lambda',
-				}),
-			),
-			getServiceQuotasClient(region).send(
-				new GetAWSDefaultServiceQuotaCommand({
-					QuotaCode: LAMBDA_BURST_LIMIT_QUOTA,
 					ServiceCode: 'lambda',
 				}),
 			),
@@ -57,10 +47,8 @@ export const quotasListCommand = async (logLevel: LogLevel) => {
 
 	const concurrencyCurrent = concurrencyLimit.Quota?.Value as number;
 	const defaultConcurrency = defaultConcurrencyLimit.Quota?.Value as number;
-	const burstDefault = burstLimit.Quota?.Value as number;
 
 	const increaseRecommended = concurrencyCurrent <= defaultConcurrency;
-	const effectiveBurstConcurrency = Math.min(burstDefault, defaultConcurrency);
 
 	if (increaseRecommended) {
 		Log.info(
@@ -102,15 +90,6 @@ export const quotasListCommand = async (logLevel: LogLevel) => {
 		),
 	);
 	Log.info({indent: false, logLevel});
-
-	if (effectiveBurstConcurrency === burstDefault) {
-		Log.info({indent: false, logLevel}, `Burst concurrency: ${burstDefault}`);
-	} else {
-		Log.info(
-			{indent: false, logLevel},
-			`Burst concurrency: ${burstDefault}, but only ${effectiveBurstConcurrency} effective because of concurrency limit`,
-		);
-	}
 
 	Log.info(
 		{indent: false, logLevel},

--- a/packages/lambda/src/shared/constants.ts
+++ b/packages/lambda/src/shared/constants.ts
@@ -558,4 +558,3 @@ export type RenderProgress = {
 export type Privacy = 'public' | 'private' | 'no-acl';
 
 export const LAMBDA_CONCURRENCY_LIMIT_QUOTA = 'L-B99A9384';
-export const LAMBDA_BURST_LIMIT_QUOTA = 'L-548AE339';


### PR DESCRIPTION
AWS has removed the burst limit