### PR TITLE
fix(docs): wrong watercolor template url in templates

### DIFF
--- a/packages/docs/src/pages/templates/index.tsx
+++ b/packages/docs/src/pages/templates/index.tsx
@@ -141,7 +141,7 @@ export default () => {
             key={"map"}
             className={styles.item}
             style={outer}
-            to={`https://www.remotion.pro/mapbox-globe`}
+            to={`https://www.remotion.pro/watercolor-map`}
           >
             <Item
               label={"Watercolor Map"}


### PR DESCRIPTION
fix(docs): Wrong watercolor template URL

In `https://www.remotion.dev/templates/`, the WaterColor Map is redirecting to `https://www.remotion.pro/mapbox-globe`. It should redirect to `https://www.remotion.pro/mapbox-globe`.
