### PR TITLE
feat: `additionalElementStyles` prop on `fitText` and `measureText`

### DIFF
--- a/packages/docs/docs/layout-utils/fill-text-box.md
+++ b/packages/docs/docs/layout-utils/fill-text-box.md
@@ -80,7 +80,7 @@ _string_
 
 Same as CSS style `font-variant-numeric`.
 
-### `textTransform`<AvailableFrom v="4.0.140"/>
+#### `textTransform`<AvailableFrom v="4.0.140"/>
 
 _string_
 
@@ -91,6 +91,12 @@ Same as CSS style `text-transform`.
 _boolean_
 
 If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
+
+#### `additionalStyles`<AvailableFrom v="4.0.140"/>
+
+_object, optional_
+
+Additional CSS properties that affect the layout of the text.
 
 ### Return value
 

--- a/packages/docs/docs/layout-utils/fill-text-box.md
+++ b/packages/docs/docs/layout-utils/fill-text-box.md
@@ -80,6 +80,12 @@ _string_
 
 Same as CSS style `font-variant-numeric`.
 
+### `textTransform`<AvailableFrom v="4.0.140"/>
+
+_string_
+
+Same as CSS style `text-transform`.
+
 #### `validateFontIsLoaded?`<AvailableFrom v="4.0.136"/>
 
 _boolean_

--- a/packages/docs/docs/layout-utils/fit-text.md
+++ b/packages/docs/docs/layout-utils/fit-text.md
@@ -21,9 +21,7 @@ const { fontSize } = fitText({
   withinWidth: width,
   fontFamily: fontFamily,
   fontWeight: fontWeight,
-  additionalElementStyles: {
-    textTransform: "uppercase",
-  },
+  textTransform: "uppercase",
 });
 
 // Example markup:
@@ -90,13 +88,19 @@ _string, optional_
 
 Pass this option if you are going to assign a `font-variant-numeric` CSS property to the text.
 
+### `textTransform`<AvailableFrom v="4.0.140"/>
+
+_string_
+
+Same as CSS style `text-transform`.
+
 ### `validateFontIsLoaded?`<AvailableFrom v="4.0.136"/>
 
 _boolean_
 
 If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
-### `additionalElementStyles`<AvailableFrom v="4.0.140"/>
+### `additionalStyles`<AvailableFrom v="4.0.140"/>
 
 _object, optional_
 

--- a/packages/docs/docs/layout-utils/fit-text.md
+++ b/packages/docs/docs/layout-utils/fit-text.md
@@ -21,10 +21,23 @@ const { fontSize } = fitText({
   withinWidth: width,
   fontFamily: fontFamily,
   fontWeight: fontWeight,
+  additionalElementStyles: {
+    textTransform: "uppercase",
+  },
 });
 
 // Example markup:
-<div style={{ fontSize, width, fontFamily, fontWeight }}>{text}</div>;
+<div
+  style={{
+    fontSize,
+    width,
+    fontFamily,
+    fontWeight,
+    textTransform: "uppercase",
+  }}
+>
+  {text}
+</div>;
 ```
 
 ## API
@@ -82,6 +95,12 @@ Pass this option if you are going to assign a `font-variant-numeric` CSS propert
 _boolean_
 
 If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
+
+### `additionalElementStyles`
+
+_object, optional_
+
+Pass this option if you want to add additional CSS properties to the text that should affect the resulting font size.
 
 ## Return value
 

--- a/packages/docs/docs/layout-utils/fit-text.md
+++ b/packages/docs/docs/layout-utils/fit-text.md
@@ -96,7 +96,7 @@ _boolean_
 
 If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
-### `additionalElementStyles`
+### `additionalElementStyles`<AvailableFrom v="4.0.140"/>
 
 _object, optional_
 

--- a/packages/docs/docs/layout-utils/fit-text.md
+++ b/packages/docs/docs/layout-utils/fit-text.md
@@ -104,7 +104,7 @@ If set to `true`, will take a second measurement with the fallback font and if i
 
 _object, optional_
 
-Pass this option if you want to add additional CSS properties to the text that should affect the resulting font size.
+Additional CSS properties that affect the layout of the text.
 
 ## Return value
 

--- a/packages/docs/docs/layout-utils/measure-text.md
+++ b/packages/docs/docs/layout-utils/measure-text.md
@@ -76,7 +76,7 @@ _boolean_
 
 If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
-### `additionalElementStyles`
+### `additionalElementStyles`<AvailableFrom v="4.0.140"/>
 
 _object, optional_
 

--- a/packages/docs/docs/layout-utils/measure-text.md
+++ b/packages/docs/docs/layout-utils/measure-text.md
@@ -70,13 +70,19 @@ _string_
 
 Same as CSS style `font-variant-numeric`.
 
+### `textTransform`<AvailableFrom v="4.0.140"/>
+
+_string_
+
+Same as CSS style `text-transform`.
+
 ### `validateFontIsLoaded?`<AvailableFrom v="4.0.136"/>
 
 _boolean_
 
 If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
-### `additionalElementStyles`<AvailableFrom v="4.0.140"/>
+### `additionalStyles`<AvailableFrom v="4.0.140"/>
 
 _object, optional_
 

--- a/packages/docs/docs/layout-utils/measure-text.md
+++ b/packages/docs/docs/layout-utils/measure-text.md
@@ -76,6 +76,12 @@ _boolean_
 
 If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
+### `additionalElementStyles`
+
+_object, optional_
+
+Pass this option if you want to add additional CSS properties to the text element that could affect the resulting size.
+
 ## Return value
 
 An object with `height` and `width`

--- a/packages/docs/docs/layout-utils/measure-text.md
+++ b/packages/docs/docs/layout-utils/measure-text.md
@@ -86,7 +86,7 @@ If set to `true`, will take a second measurement with the fallback font and if i
 
 _object, optional_
 
-Pass this option if you want to add additional CSS properties to the text element that could affect the resulting size.
+Additional CSS properties that affect the layout of the text.
 
 ## Return value
 

--- a/packages/example/src/Title/FitText.tsx
+++ b/packages/example/src/Title/FitText.tsx
@@ -20,6 +20,9 @@ export const FitText: React.FC<z.infer<typeof fitTextSchema>> = ({line}) => {
 			text: line,
 			withinWidth: boxWidth,
 			fontWeight,
+			additionalElementStyles: {
+				textTransform: 'uppercase',
+			},
 		}).fontSize,
 	);
 

--- a/packages/example/src/Title/FitText.tsx
+++ b/packages/example/src/Title/FitText.tsx
@@ -46,6 +46,7 @@ export const FitText: React.FC<z.infer<typeof fitTextSchema>> = ({line}) => {
 						display: 'flex',
 						alignItems: 'center',
 						color: 'white',
+						textTransform: 'uppercase',
 					}}
 				>
 					{line}

--- a/packages/example/src/Title/FitText.tsx
+++ b/packages/example/src/Title/FitText.tsx
@@ -20,9 +20,7 @@ export const FitText: React.FC<z.infer<typeof fitTextSchema>> = ({line}) => {
 			text: line,
 			withinWidth: boxWidth,
 			fontWeight,
-			additionalElementStyles: {
-				textTransform: 'uppercase',
-			},
+			textTransform: 'uppercase',
 		}).fontSize,
 	);
 

--- a/packages/layout-utils/src/layouts/fill-text-box.ts
+++ b/packages/layout-utils/src/layouts/fill-text-box.ts
@@ -18,6 +18,8 @@ export const fillTextBox = ({
 			letterSpacing,
 			fontVariantNumeric,
 			validateFontIsLoaded,
+			textTransform,
+			additionalStyles,
 		}: Word): {
 			exceedsBox: boolean;
 			newLine: boolean;
@@ -42,6 +44,8 @@ export const fillTextBox = ({
 					letterSpacing,
 					fontVariantNumeric,
 					validateFontIsLoaded,
+					textTransform,
+					additionalStyles,
 				},
 			];
 

--- a/packages/layout-utils/src/layouts/fit-text.ts
+++ b/packages/layout-utils/src/layouts/fit-text.ts
@@ -1,4 +1,7 @@
-import type {ModifyableCSSProperties} from '../layouts/measure-text';
+import type {
+	ModifyableCSSProperties,
+	TextTransform,
+} from '../layouts/measure-text';
 import {measureText} from '../layouts/measure-text';
 
 const sampleSize = 100;
@@ -11,7 +14,8 @@ export const fitText = ({
 	fontWeight,
 	letterSpacing,
 	validateFontIsLoaded,
-	additionalElementStyles,
+	additionalStyles,
+	textTransform,
 }: {
 	text: string;
 	withinWidth: number;
@@ -20,7 +24,8 @@ export const fitText = ({
 	letterSpacing?: string;
 	fontVariantNumeric?: string;
 	validateFontIsLoaded?: boolean;
-	additionalElementStyles?: ModifyableCSSProperties;
+	textTransform?: TextTransform;
+	additionalStyles?: ModifyableCSSProperties;
 }) => {
 	const estimate = measureText({
 		text,
@@ -30,7 +35,9 @@ export const fitText = ({
 		fontVariantNumeric,
 		letterSpacing,
 		validateFontIsLoaded,
-		additionalElementStyles,
+		textTransform,
+		additionalStyles,
 	});
+
 	return {fontSize: (withinWidth / estimate.width) * sampleSize};
 };

--- a/packages/layout-utils/src/layouts/fit-text.ts
+++ b/packages/layout-utils/src/layouts/fit-text.ts
@@ -30,6 +30,7 @@ export const fitText = ({
 		fontVariantNumeric,
 		letterSpacing,
 		validateFontIsLoaded,
+		additionalElementStyles,
 	});
 	return {fontSize: (withinWidth / estimate.width) * sampleSize};
 };

--- a/packages/layout-utils/src/layouts/fit-text.ts
+++ b/packages/layout-utils/src/layouts/fit-text.ts
@@ -1,3 +1,4 @@
+import type {ModifyableCSSProperties} from '../layouts/measure-text';
 import {measureText} from '../layouts/measure-text';
 
 const sampleSize = 100;

--- a/packages/layout-utils/src/layouts/fit-text.ts
+++ b/packages/layout-utils/src/layouts/fit-text.ts
@@ -11,6 +11,7 @@ export const fitText = ({
 	fontWeight,
 	letterSpacing,
 	validateFontIsLoaded,
+	additionalElementStyles,
 }: {
 	text: string;
 	withinWidth: number;
@@ -19,6 +20,7 @@ export const fitText = ({
 	letterSpacing?: string;
 	fontVariantNumeric?: string;
 	validateFontIsLoaded?: boolean;
+	additionalElementStyles?: ModifyableCSSProperties;
 }) => {
 	const estimate = measureText({
 		text,

--- a/packages/layout-utils/src/layouts/measure-text.ts
+++ b/packages/layout-utils/src/layouts/measure-text.ts
@@ -36,6 +36,7 @@ const takeMeasurement = ({
 	fontWeight,
 	letterSpacing,
 	fontVariantNumeric,
+	additionalElementStyles,
 }: Omit<Word, 'fontFamily'> & {fontFamily: string | null}): {
 	boundingBox: DOMRect;
 	computedFontFamily: string;

--- a/packages/layout-utils/src/layouts/measure-text.ts
+++ b/packages/layout-utils/src/layouts/measure-text.ts
@@ -3,8 +3,15 @@ export type Dimensions = {
 	height: number;
 };
 
-export type Word = {
-	text: string;
+export type ModifyableCSSProperties<T = Partial<CSSStyleDeclaration>> = {
+	[P in keyof T as P extends 'length'
+		? never
+		: P extends keyof CSSPropertiesOnWord
+			? never
+			: T[P] extends string | number
+				? P
+				: never]: T[P];
+};
 	fontFamily: string;
 	fontSize: number | string;
 	fontWeight?: number | string;

--- a/packages/layout-utils/src/layouts/measure-text.ts
+++ b/packages/layout-utils/src/layouts/measure-text.ts
@@ -20,8 +20,12 @@ type CSSPropertiesOnWord = {
 	letterSpacing?: string;
 	fontVariantNumeric?: string;
 };
+
+export type Word = {
+	text: string;
 	validateFontIsLoaded?: boolean;
-};
+	additionalElementStyles?: ModifyableCSSProperties;
+} & CSSPropertiesOnWord;
 
 const wordCache = new Map<string, Dimensions>();
 

--- a/packages/layout-utils/src/layouts/measure-text.ts
+++ b/packages/layout-utils/src/layouts/measure-text.ts
@@ -99,6 +99,7 @@ export const measureText = ({
 	letterSpacing,
 	fontVariantNumeric,
 	validateFontIsLoaded,
+	additionalElementStyles,
 }: Word): Dimensions => {
 	const key = `${text}-${fontFamily}-${fontWeight}-${fontSize}-${letterSpacing}`;
 
@@ -113,6 +114,7 @@ export const measureText = ({
 		fontVariantNumeric,
 		fontWeight,
 		letterSpacing,
+		additionalElementStyles,
 	});
 
 	if (validateFontIsLoaded) {
@@ -126,6 +128,7 @@ export const measureText = ({
 			fontVariantNumeric,
 			fontWeight,
 			letterSpacing,
+			additionalElementStyles,
 		});
 
 		const sameAsFallbackFont =

--- a/packages/layout-utils/src/layouts/measure-text.ts
+++ b/packages/layout-utils/src/layouts/measure-text.ts
@@ -13,18 +13,33 @@ export type ModifyableCSSProperties<T = Partial<CSSStyleDeclaration>> = {
 				: never]: T[P];
 };
 
+export type TextTransform =
+	| '-moz-initial'
+	| 'inherit'
+	| 'initial'
+	| 'revert'
+	| 'revert-layer'
+	| 'unset'
+	| 'none'
+	| 'capitalize'
+	| 'full-size-kana'
+	| 'full-width'
+	| 'lowercase'
+	| 'uppercase';
+
 type CSSPropertiesOnWord = {
 	fontFamily: string;
 	fontSize: number | string;
 	fontWeight?: number | string;
 	letterSpacing?: string;
 	fontVariantNumeric?: string;
+	textTransform?: TextTransform;
 };
 
 export type Word = {
 	text: string;
 	validateFontIsLoaded?: boolean;
-	additionalElementStyles?: ModifyableCSSProperties;
+	additionalStyles?: ModifyableCSSProperties;
 } & CSSPropertiesOnWord;
 
 const wordCache = new Map<string, Dimensions>();
@@ -36,7 +51,8 @@ const takeMeasurement = ({
 	fontWeight,
 	letterSpacing,
 	fontVariantNumeric,
-	additionalElementStyles,
+	additionalStyles,
+	textTransform,
 }: Omit<Word, 'fontFamily'> & {fontFamily: string | null}): {
 	boundingBox: DOMRect;
 	computedFontFamily: string;
@@ -58,11 +74,11 @@ const takeMeasurement = ({
 	node.style.fontSize =
 		typeof fontSize === 'string' ? fontSize : `${fontSize}px`;
 
-	if (additionalElementStyles) {
+	if (additionalStyles) {
 		for (const key of Object.keys(
-			additionalElementStyles,
-		) as (keyof typeof additionalElementStyles)[]) {
-			node.style[key] = additionalElementStyles[key];
+			additionalStyles,
+		) as (keyof typeof additionalStyles)[]) {
+			node.style[key] = additionalStyles[key];
 		}
 	}
 
@@ -76,6 +92,10 @@ const takeMeasurement = ({
 
 	if (fontVariantNumeric) {
 		node.style.fontVariantNumeric = fontVariantNumeric;
+	}
+
+	if (textTransform) {
+		node.style.textTransform = textTransform;
 	}
 
 	node.innerText = text;
@@ -99,7 +119,7 @@ export const measureText = ({
 	letterSpacing,
 	fontVariantNumeric,
 	validateFontIsLoaded,
-	additionalElementStyles,
+	additionalStyles,
 }: Word): Dimensions => {
 	const key = `${text}-${fontFamily}-${fontWeight}-${fontSize}-${letterSpacing}`;
 
@@ -114,7 +134,7 @@ export const measureText = ({
 		fontVariantNumeric,
 		fontWeight,
 		letterSpacing,
-		additionalElementStyles,
+		additionalStyles,
 	});
 
 	if (validateFontIsLoaded) {
@@ -128,7 +148,7 @@ export const measureText = ({
 			fontVariantNumeric,
 			fontWeight,
 			letterSpacing,
-			additionalElementStyles,
+			additionalStyles,
 		});
 
 		const sameAsFallbackFont =

--- a/packages/layout-utils/src/layouts/measure-text.ts
+++ b/packages/layout-utils/src/layouts/measure-text.ts
@@ -12,11 +12,14 @@ export type ModifyableCSSProperties<T = Partial<CSSStyleDeclaration>> = {
 				? P
 				: never]: T[P];
 };
+
+type CSSPropertiesOnWord = {
 	fontFamily: string;
 	fontSize: number | string;
 	fontWeight?: number | string;
 	letterSpacing?: string;
 	fontVariantNumeric?: string;
+};
 	validateFontIsLoaded?: boolean;
 };
 

--- a/packages/layout-utils/src/layouts/measure-text.ts
+++ b/packages/layout-utils/src/layouts/measure-text.ts
@@ -58,6 +58,14 @@ const takeMeasurement = ({
 	node.style.fontSize =
 		typeof fontSize === 'string' ? fontSize : `${fontSize}px`;
 
+	if (additionalElementStyles) {
+		for (const key of Object.keys(
+			additionalElementStyles,
+		) as (keyof typeof additionalElementStyles)[]) {
+			node.style[key] = additionalElementStyles[key];
+		}
+	}
+
 	if (fontWeight) {
 		node.style.fontWeight = fontWeight.toString();
 	}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

With all the existing inputs `fitText` and `measureText` expose, it's not possible to use these functions for more complex inputs where you need more control over the underlying `<span>` element that gets created to measure the text

## Example

### Before the addition

Adding a property like this:

<img width="835" alt="Screenshot 2024-04-08 at 11 15 35 PM" src="https://github.com/remotion-dev/remotion/assets/48997634/3952fd65-a081-4c8c-afd1-11a47fa17d5d">

Would make the fitText and measureText break and wrap the output.

<img width="1723" alt="image" src="https://github.com/remotion-dev/remotion/assets/48997634/da19b2bc-5bf7-4808-af44-9fae1546d21f">

<hr />

### After the addition,

<img width="671" alt="Screenshot 2024-04-08 at 11 17 04 PM" src="https://github.com/remotion-dev/remotion/assets/48997634/c16a87bb-4bb1-47ba-bc9f-7284055fd5d7">

It properly fits the text in now!

<img width="1728" alt="Screenshot 2024-04-08 at 11 18 25 PM" src="https://github.com/remotion-dev/remotion/assets/48997634/4c86ce04-428a-4f5f-ab7d-8f3131f57d9e">

## Why not just expose `textTransform` in as an input instead of creating a totally new `additionalElementStyles`

I use this function in a project that uses this function in a complex text element inside a editor that supports various font properties on an element, like textTransform, transform, etc., which I don't think would make sense to have as explicit inputs to this function.

As for the risk of specifying fontFamily or fontSize, or any other property through `additionalElementStyles`, I've excluded them from the type for this property, hence leaving no scope of accidentally specifying the same property twice, once through the direct function params, and again through `additionalElementStyles`.

## What could be improved

- I think the name `additionalElementStyles` is not the best and could be better. It says `element` in the name, whereas the docs don't specify what the `element` actually is. Unless someone digs through the source code and finds out the `measureText` function actually creates an invisible text element in the DOM, they won't know this abstraction exists. Feels like it exposes parts of the abstraction that haven't been documented.
- Naturally, the second would be 'how it works' section on `fitText` docs, which says something like "it uses `measureText` under the hood to calculate the size of the text with a standard fontSize, then uses the ratio of the resulting element's width to proportionally find the fontSize that would fit into the passed in `withinWidth` property. This property exposes the styles on the underlying invisible span element that is created", and something similar on `measureText` as well.