### PR TITLE
Add parameter maxLength to transcribe

### DIFF
--- a/packages/docs/docs/install-whisper-cpp/transcribe.mdx
+++ b/packages/docs/docs/install-whisper-cpp/transcribe.mdx
@@ -95,6 +95,18 @@ We recommend using at least the `medium` model to get satisfactory results when 
 
 Whether to print the output of the transcription process to the console. Defaults to `true`.
 
+### `maxLength?`<AvailableFrom v="4.0.141" />
+
+_optional - default: `1`_
+
+The maximum amount of tokens included in each transcription item.
+
+Set this flag to `null`, to use `whisper.cpp`'s default token grouping (useful for generating a movie-style transcription).
+
+:::info
+`maxLength` can only be set when `tokenLevelTimestamps` is set to `false`.
+:::
+
 ## Return value
 
 ### `TranscriptionJson`

--- a/packages/docs/docs/install-whisper-cpp/transcribe.mdx
+++ b/packages/docs/docs/install-whisper-cpp/transcribe.mdx
@@ -95,7 +95,7 @@ We recommend using at least the `medium` model to get satisfactory results when 
 
 Whether to print the output of the transcription process to the console. Defaults to `true`.
 
-### `maxLength?`<AvailableFrom v="4.0.141" />
+### `tokensPerItem?`<AvailableFrom v="4.0.141" />
 
 _optional - default: `1`_
 
@@ -104,7 +104,7 @@ The maximum amount of tokens included in each transcription item.
 Set this flag to `null`, to use `whisper.cpp`'s default token grouping (useful for generating a movie-style transcription).
 
 :::info
-`maxLength` can only be set when `tokenLevelTimestamps` is set to `false`.
+`tokensPerItem` can only be set when `tokenLevelTimestamps` is set to `false`.
 :::
 
 ## Return value

--- a/packages/install-whisper-cpp/src/transcribe.ts
+++ b/packages/install-whisper-cpp/src/transcribe.ts
@@ -97,6 +97,7 @@ const transcribeToTempJSON = async ({
 	translate,
 	tokenLevelTimestamps,
 	printOutput,
+	maxLength,
 }: {
 	fileToTranscribe: string;
 	whisperPath: string;
@@ -106,6 +107,7 @@ const transcribeToTempJSON = async ({
 	translate: boolean;
 	tokenLevelTimestamps: boolean;
 	printOutput: boolean;
+	maxLength: number | null;
 }): Promise<{
 	outputPath: string;
 }> => {
@@ -127,8 +129,7 @@ const transcribeToTempJSON = async ({
 		'--output-file',
 		tmpJSONPath,
 		'--output-json',
-		'--max-len',
-		'1',
+		maxLength ? ['--max-len', maxLength] : null,
 		'-ojf', // Output full JSON
 		tokenLevelTimestamps ? ['--dtw', model] : null,
 		model ? [`-m`, `${modelPath}`] : null,
@@ -207,6 +208,7 @@ export const transcribe = async <HasTokenLevelTimestamps extends boolean>({
 	translateToEnglish = false,
 	tokenLevelTimestamps,
 	printOutput = true,
+	maxLength,
 }: {
 	inputPath: string;
 	whisperPath: string;
@@ -215,6 +217,7 @@ export const transcribe = async <HasTokenLevelTimestamps extends boolean>({
 	modelFolder?: string;
 	translateToEnglish?: boolean;
 	printOutput?: boolean;
+	maxLength?: true extends HasTokenLevelTimestamps ? never : number | null;
 }): Promise<TranscriptionJson<HasTokenLevelTimestamps>> => {
 	if (!existsSync(whisperPath)) {
 		throw new Error(
@@ -243,6 +246,7 @@ export const transcribe = async <HasTokenLevelTimestamps extends boolean>({
 		translate: translateToEnglish,
 		tokenLevelTimestamps,
 		printOutput,
+		maxLength: tokenLevelTimestamps ? 1 : maxLength ?? 1,
 	});
 
 	const json = (await readJson(

--- a/packages/install-whisper-cpp/src/transcribe.ts
+++ b/packages/install-whisper-cpp/src/transcribe.ts
@@ -97,7 +97,7 @@ const transcribeToTempJSON = async ({
 	translate,
 	tokenLevelTimestamps,
 	printOutput,
-	maxLength,
+	tokensPerItem,
 }: {
 	fileToTranscribe: string;
 	whisperPath: string;
@@ -107,7 +107,7 @@ const transcribeToTempJSON = async ({
 	translate: boolean;
 	tokenLevelTimestamps: boolean;
 	printOutput: boolean;
-	maxLength: number | null;
+	tokensPerItem: number | null;
 }): Promise<{
 	outputPath: string;
 }> => {
@@ -129,7 +129,7 @@ const transcribeToTempJSON = async ({
 		'--output-file',
 		tmpJSONPath,
 		'--output-json',
-		maxLength ? ['--max-len', maxLength] : null,
+		tokensPerItem ? ['--max-len', tokensPerItem] : null,
 		'-ojf', // Output full JSON
 		tokenLevelTimestamps ? ['--dtw', model] : null,
 		model ? [`-m`, `${modelPath}`] : null,
@@ -208,7 +208,7 @@ export const transcribe = async <HasTokenLevelTimestamps extends boolean>({
 	translateToEnglish = false,
 	tokenLevelTimestamps,
 	printOutput = true,
-	maxLength,
+	tokensPerItem,
 }: {
 	inputPath: string;
 	whisperPath: string;
@@ -217,7 +217,7 @@ export const transcribe = async <HasTokenLevelTimestamps extends boolean>({
 	modelFolder?: string;
 	translateToEnglish?: boolean;
 	printOutput?: boolean;
-	maxLength?: true extends HasTokenLevelTimestamps ? never : number | null;
+	tokensPerItem?: true extends HasTokenLevelTimestamps ? never : number | null;
 }): Promise<TranscriptionJson<HasTokenLevelTimestamps>> => {
 	if (!existsSync(whisperPath)) {
 		throw new Error(
@@ -246,7 +246,7 @@ export const transcribe = async <HasTokenLevelTimestamps extends boolean>({
 		translate: translateToEnglish,
 		tokenLevelTimestamps,
 		printOutput,
-		maxLength: tokenLevelTimestamps ? 1 : maxLength ?? 1,
+		tokensPerItem: tokenLevelTimestamps ? 1 : tokensPerItem ?? 1,
 	});
 
 	const json = (await readJson(


### PR DESCRIPTION
Fixes #3688

This PR adds the possibility to configure the `max-length` parameter that is passed to whisper.cpp (previously hard coded to 1).

The function `transcribe` now also accepts a parameter `maxLength`. 

The parameter can only be also be set to null, to use `whisper.cpp`'s default token grouping (useful for generating a movie-style transcription).

## Backwards compatibility

The function is backward compatible. If `maxLength` is not provided, a default value of 1 is used (same behaviour as before)

## Note
Since `convertToCaptions` groups the transcription-items and not the tokens, the parameter `maxLength` can now only be used when `tokenLevelTimestamps` is set false.

Question: Would `tokensPerTranscriptionItem` be a batter/more accurate name?




/claim 3688