### PR TITLE
`@remotion/lambda`: fix bad timeoutInMilliseconds value for renderStillOnLambda()

### DIFF
--- a/packages/cloudrun/src/api/render-still-on-cloudrun.ts
+++ b/packages/cloudrun/src/api/render-still-on-cloudrun.ts
@@ -7,7 +7,6 @@ import {BrowserSafeApis} from '@remotion/renderer/client';
 import {NoReactAPIs} from '@remotion/renderer/pure';
 import {NoReactInternals} from 'remotion/no-react';
 import {VERSION} from 'remotion/version';
-import {DEFAULT_TIMEOUT} from '../defaults';
 import type {
 	CloudRunCrashResponse,
 	CloudRunPayloadType,
@@ -219,7 +218,7 @@ export const renderStillOnCloudrun = (options: RenderStillOnCloudrunInput) => {
 		cloudRunUrl: options.cloudRunUrl ?? null,
 		composition: options.composition,
 		delayRenderTimeoutInMilliseconds:
-			options.delayRenderTimeoutInMilliseconds ?? DEFAULT_TIMEOUT,
+			options.delayRenderTimeoutInMilliseconds ?? 30000,
 		envVariables: options.envVariables ?? {},
 		forceBucketName: options.forceBucketName ?? null,
 		forceHeight: options.forceHeight ?? null,

--- a/packages/lambda/src/api/render-still-on-lambda.ts
+++ b/packages/lambda/src/api/render-still-on-lambda.ts
@@ -8,11 +8,7 @@ import {NoReactAPIs} from '@remotion/renderer/pure';
 import type {AwsRegion} from '../pricing/aws-regions';
 import {callLambda} from '../shared/call-lambda';
 import type {CostsInfo, OutNameInput, Privacy} from '../shared/constants';
-import {
-	DEFAULT_MAX_RETRIES,
-	DEFAULT_TIMEOUT,
-	LambdaRoutines,
-} from '../shared/constants';
+import {DEFAULT_MAX_RETRIES, LambdaRoutines} from '../shared/constants';
 import type {DownloadBehavior} from '../shared/content-disposition-header';
 import {
 	getCloudwatchMethodUrl,
@@ -177,7 +173,7 @@ export const renderStillOnLambda = (input: RenderStillOnLambdaInput) => {
 		offthreadVideoCacheSizeInBytes:
 			input.offthreadVideoCacheSizeInBytes ?? null,
 		scale: input.scale ?? 1,
-		timeoutInMilliseconds: input.timeoutInMilliseconds ?? DEFAULT_TIMEOUT,
+		timeoutInMilliseconds: input.timeoutInMilliseconds ?? 30000,
 		dumpBrowserLogs: false,
 	});
 };


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
