### PR TITLE
`remotion`: Fix bad `#t=` start value for a video

### DIFF
--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -122,9 +122,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		isPremounting: Boolean(parentSequence?.premounting),
 	});
 
-	const actualFrom = parentSequence
-		? parentSequence.relativeFrom + parentSequence.cumulatedFrom
-		: 0;
+	const actualFrom = parentSequence ? parentSequence.relativeFrom : 0;
 	const duration = parentSequence
 		? Math.min(parentSequence.durationInFrames, durationInFrames)
 		: durationInFrames;


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
