### PR TITLE
`remotion`: Move `sequenceContext?.premounting` out of the useEffect dependency array

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -128,6 +128,7 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 	);
 
 	if (typeof window !== 'undefined') {
+		const isPremounting = Boolean(sequenceContext?.premounting);
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		useLayoutEffect(() => {
 			if (process.env.NODE_ENV === 'test') {
@@ -139,7 +140,7 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 				timeoutInMilliseconds: delayRenderTimeoutInMilliseconds ?? undefined,
 			});
 			const unblock =
-				pauseWhenLoading && !sequenceContext?.premounting
+				pauseWhenLoading && !isPremounting
 					? delayPlayback().unblock
 					: () => undefined;
 			const {current} = imageRef;
@@ -182,7 +183,7 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 			delayRenderRetries,
 			delayRenderTimeoutInMilliseconds,
 			pauseWhenLoading,
-			sequenceContext?.premounting,
+			isPremounting,
 		]);
 	}
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
