### PR TITLE
`@remotion/lambda`: Encode `fileName` in `downloadBehavior if necessary`

### DIFF
--- a/packages/lambda/src/shared/content-disposition-header.ts
+++ b/packages/lambda/src/shared/content-disposition-header.ts
@@ -47,16 +47,6 @@ const includesHexOfUnsafeChar = (path: string): HexInfo => {
 	return {containsHex: false};
 };
 
-const encodeUriComponentBySplitting = (path: string): string => {
-	const splitBySlash = path.split('/');
-
-	const encodedArray = splitBySlash.map((element) => {
-		return encodeURIComponent(element);
-	});
-	const merged = encodedArray.join('/');
-	return merged;
-};
-
 export const getContentDispositionHeader = (
 	behavior: DownloadBehavior | null,
 ): string | undefined => {
@@ -77,5 +67,5 @@ export const getContentDispositionHeader = (
 		return `attachment; filename="${behavior.fileName}"`;
 	}
 
-	return `attachment; filename="${encodeUriComponentBySplitting(behavior.fileName)}"`;
+	return `attachment; filename="${encodeURIComponent(behavior.fileName)}"`;
 };

--- a/packages/lambda/src/shared/content-disposition-header.ts
+++ b/packages/lambda/src/shared/content-disposition-header.ts
@@ -11,6 +11,52 @@ export type DownloadBehavior =
 			fileName: string | null;
 	  };
 
+const problematicCharacters = {
+	'%3A': ':',
+	'%2F': '/',
+	'%3F': '?',
+	'%23': '#',
+	'%5B': '[',
+	'%5D': ']',
+	'%40': '@',
+	'%21': '!',
+	'%24': '$',
+	'%26': '&',
+	'%27': "'",
+	'%28': '(',
+	'%29': ')',
+	'%2A': '*',
+	'%2B': '+',
+	'%2C': ',',
+	'%3B': ';',
+};
+
+export type HexInfo = {
+	containsHex: boolean;
+};
+
+const includesHexOfUnsafeChar = (path: string): HexInfo => {
+	for (const key of Object.keys(
+		problematicCharacters,
+	) as (keyof typeof problematicCharacters)[]) {
+		if (path.includes(key)) {
+			return {containsHex: true};
+		}
+	}
+
+	return {containsHex: false};
+};
+
+const encodeUriComponentBySplitting = (path: string): string => {
+	const splitBySlash = path.split('/');
+
+	const encodedArray = splitBySlash.map((element) => {
+		return encodeURIComponent(element);
+	});
+	const merged = encodedArray.join('/');
+	return merged;
+};
+
 export const getContentDispositionHeader = (
 	behavior: DownloadBehavior | null,
 ): string | undefined => {
@@ -26,5 +72,10 @@ export const getContentDispositionHeader = (
 		return `attachment`;
 	}
 
-	return `attachment; filename="${behavior.fileName}"`;
+	const {containsHex} = includesHexOfUnsafeChar(behavior.fileName);
+	if (containsHex) {
+		return `attachment; filename="${behavior.fileName}"`;
+	}
+
+	return `attachment; filename="${encodeUriComponentBySplitting(behavior.fileName)}"`;
 };


### PR DESCRIPTION
Already successfully using this logic for `staticFile()`.  
Should handle both encoded and unencoded versions.

Fixs #3607