### PR TITLE
Remotion 5.0: Drop support for rendering without `ReactDOM.render`

### DIFF
--- a/packages/bundler/renderEntry.tsx
+++ b/packages/bundler/renderEntry.tsx
@@ -208,15 +208,21 @@ const getRootForElement = () => {
 };
 
 const renderToDOM = (content: React.ReactElement) => {
-	// @ts-expect-error
-	if (ReactDOM.createRoot) {
-		getRootForElement().render(content);
-	} else {
+	if (!ReactDOM.createRoot) {
+		if (NoReactInternals.ENABLE_V5_BREAKING_CHANGES) {
+			throw new Error(
+				'Remotion 5.0 does only support React 18+. However, ReactDOM.createRoot() is undefined.',
+			);
+		}
+
 		(ReactDOM as unknown as {render: typeof render}).render(
 			content,
 			videoContainer,
 		);
+		return;
 	}
+
+	getRootForElement().render(content);
 };
 
 const renderContent = (Root: React.FC) => {
@@ -255,8 +261,8 @@ const renderContent = (Root: React.FC) => {
 			</div>,
 		);
 		import('@remotion/studio')
-			.then(({Studio}) => {
-				renderToDOM(<Studio readOnly rootComponent={Root} />);
+			.then(({StudioInternals}) => {
+				renderToDOM(<StudioInternals.Studio readOnly rootComponent={Root} />);
 			})
 			.catch((err) => {
 				renderToDOM(<div>Failed to load Remotion Studio: {err.message}</div>);

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -28,7 +28,9 @@ if (reactDomVersion === '0') {
 	);
 }
 
-const shouldUseReactDomClient = parseInt(reactDomVersion, 10) >= 18;
+const shouldUseReactDomClient = NoReactInternals.ENABLE_V5_BREAKING_CHANGES
+	? true
+	: parseInt(reactDomVersion, 10) >= 18;
 
 const esbuildLoaderOptions: LoaderOptions = {
 	target: 'chrome85',

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -1,2 +1,7 @@
+import {Studio} from './Studio';
+
 export type {GitSource, RenderDefaults} from '@remotion/studio-shared';
-export {Studio} from './Studio';
+
+export const StudioInternals = {
+	Studio,
+};

--- a/packages/studio/src/previewEntry.tsx
+++ b/packages/studio/src/previewEntry.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type {render} from 'react-dom';
 import ReactDOM from 'react-dom/client';
 import {Internals} from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
 import {Studio} from './Studio';
 import {NoRegisterRoot} from './components/NoRegisterRoot';
 import {startErrorOverlay} from './error-overlay/entry-basic';
@@ -23,15 +24,21 @@ const getRootForElement = () => {
 };
 
 const renderToDOM = (content: React.ReactElement) => {
-	// @ts-expect-error
-	if (ReactDOM.createRoot) {
-		getRootForElement().render(content);
-	} else {
+	if (!ReactDOM.createRoot) {
+		if (NoReactInternals.ENABLE_V5_BREAKING_CHANGES) {
+			throw new Error(
+				'Remotion 5.0 does only support React 18+. However, ReactDOM.createRoot() is undefined.',
+			);
+		}
+
 		(ReactDOM as unknown as {render: typeof render}).render(
 			content,
 			Internals.getPreviewDomElement(),
 		);
+		return;
 	}
+
+	getRootForElement().render(content);
 };
 
 renderToDOM(<NoRegisterRoot />);


### PR DESCRIPTION
Require `React.createRoot()`