### PR TITLE
Update Templates page

### DIFF
--- a/packages/create-video/src/templates.tsx
+++ b/packages/create-video/src/templates.tsx
@@ -313,6 +313,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		type: 'video' as const,
 		defaultBranch: 'main',
 		featuredOnHomePage: null,
+		previewURL: 'https://template-tailwind-remotion.vercel.app/?/MyComp',
 	},
 	{
 		homePageLabel: 'Overlay',
@@ -336,7 +337,6 @@ export const FEATURED_TEMPLATES: Template[] = [
 		type: 'video' as const,
 		defaultBranch: 'main',
 		featuredOnHomePage: null,
-		previewURL: 'https://template-tailwind-remotion.vercel.app/?/MyComp',
 	},
 	{
 		homePageLabel: 'Stargazer',


### PR DESCRIPTION
When I added the Remotion Studio preview links to the templates, I mixed it up for one template. Should be fixed.
