### PR TITLE
`remotion`: Avoid unnecessary state updates at the beginning of the render

### DIFF
--- a/packages/core/src/RemotionRoot.tsx
+++ b/packages/core/src/RemotionRoot.tsx
@@ -52,11 +52,26 @@ export const RemotionRoot: React.FC<{
 			window.remotion_setFrame = (f: number, composition: string, attempt) => {
 				window.remotion_attempt = attempt;
 				const id = delayRender(`Setting the current frame to ${f}`);
-				setFrame((s) => ({
-					...s,
-					[composition]: f,
-				}));
-				requestAnimationFrame(() => continueRender(id));
+
+				let avoidUpdate = false;
+
+				setFrame((s) => {
+					const currentFrame = s[composition] ?? window.remotion_initialFrame;
+					// Avoid cloning the object
+					if (currentFrame === f) {
+						avoidUpdate = true;
+						continueRender(id);
+						return s;
+					}
+
+					return {
+						...s,
+						[composition]: f,
+					};
+				});
+				if (!avoidUpdate) {
+					requestAnimationFrame(() => continueRender(id));
+				}
 			};
 
 			window.remotion_isPlayer = false;

--- a/packages/core/src/RemotionRoot.tsx
+++ b/packages/core/src/RemotionRoot.tsx
@@ -53,14 +53,13 @@ export const RemotionRoot: React.FC<{
 				window.remotion_attempt = attempt;
 				const id = delayRender(`Setting the current frame to ${f}`);
 
-				let avoidUpdate = false;
+				let asyncUpdate = true;
 
 				setFrame((s) => {
 					const currentFrame = s[composition] ?? window.remotion_initialFrame;
 					// Avoid cloning the object
 					if (currentFrame === f) {
-						avoidUpdate = true;
-						continueRender(id);
+						asyncUpdate = false;
 						return s;
 					}
 
@@ -69,8 +68,12 @@ export const RemotionRoot: React.FC<{
 						[composition]: f,
 					};
 				});
-				if (!avoidUpdate) {
+
+				// After setting the state, need to wait until it is applied in the next cycle
+				if (asyncUpdate) {
 					requestAnimationFrame(() => continueRender(id));
+				} else {
+					continueRender(id);
 				}
 			};
 

--- a/packages/core/src/timeline-position-state.ts
+++ b/packages/core/src/timeline-position-state.ts
@@ -1,5 +1,6 @@
 import type {MutableRefObject} from 'react';
 import {createContext, useContext, useMemo} from 'react';
+import {getRemotionEnvironment} from './get-remotion-environment.js';
 import {useVideo} from './use-video.js';
 
 export type PlayableMediaTag = {
@@ -65,10 +66,15 @@ export const getFrameForComposition = (composition: string) => {
 	const item = localStorage.getItem(makeKey()) ?? '{}';
 	const obj: CurrentTimePerComposition = JSON.parse(item);
 
-	return obj[composition]
-		? Number(obj[composition])
-		: (typeof window === 'undefined' ? 0 : window.remotion_initialFrame ?? 0) ??
-				0;
+	if (obj[composition] !== undefined) {
+		return Number(obj[composition]);
+	}
+
+	if (typeof window === 'undefined') {
+		return 0;
+	}
+
+	return window.remotion_initialFrame ?? 0;
 };
 
 export const useTimelinePosition = (): number => {
@@ -83,7 +89,7 @@ export const useTimelinePosition = (): number => {
 
 	const unclamped =
 		state.frame[videoConfig.id] ??
-		(typeof window !== 'undefined' && window.remotion_isPlayer
+		(getRemotionEnvironment().isPlayer
 			? 0
 			: getFrameForComposition(videoConfig.id));
 

--- a/packages/core/src/use-current-frame.ts
+++ b/packages/core/src/use-current-frame.ts
@@ -1,6 +1,7 @@
 import {useContext} from 'react';
 import {CanUseRemotionHooks} from './CanUseRemotionHooks.js';
 import {SequenceContext} from './SequenceContext.js';
+import {getRemotionEnvironment} from './get-remotion-environment.js';
 import {useTimelinePosition} from './timeline-position-state.js';
 
 /**
@@ -10,7 +11,7 @@ import {useTimelinePosition} from './timeline-position-state.js';
 export const useCurrentFrame = (): number => {
 	const canUseRemotionHooks = useContext(CanUseRemotionHooks);
 	if (!canUseRemotionHooks) {
-		if (typeof window !== 'undefined' && window.remotion_isPlayer) {
+		if (getRemotionEnvironment().isPlayer) {
 			throw new Error(
 				`useCurrentFrame can only be called inside a component that was passed to <Player>. See: https://www.remotion.dev/docs/player/examples`,
 			);


### PR DESCRIPTION
…ender

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
