### PR TITLE
`@remotion/renderer`: Don't allow for negative audio start frame

### DIFF
--- a/packages/core/src/audio/AudioForRendering.tsx
+++ b/packages/core/src/audio/AudioForRendering.tsx
@@ -112,7 +112,7 @@ const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
 			playbackRate: props.playbackRate ?? 1,
 			allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
 			toneFrequency: toneFrequency ?? null,
-			audioStartFrame: -(sequenceContext?.relativeFrom ?? 0),
+			audioStartFrame: Math.max(0, -(sequenceContext?.relativeFrom ?? 0)),
 		});
 		return () => unregisterRenderAsset(id);
 	}, [

--- a/packages/core/src/video/OffthreadVideoForRendering.tsx
+++ b/packages/core/src/video/OffthreadVideoForRendering.tsx
@@ -103,7 +103,7 @@ export const OffthreadVideoForRendering: React.FC<OffthreadVideoProps> = ({
 			playbackRate: playbackRate ?? 1,
 			allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
 			toneFrequency: toneFrequency ?? null,
-			audioStartFrame: -(sequenceContext?.relativeFrom ?? 0),
+			audioStartFrame: Math.max(0, -(sequenceContext?.relativeFrom ?? 0)),
 		});
 
 		return () => unregisterRenderAsset(id);

--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -119,7 +119,7 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 			playbackRate: playbackRate ?? 1,
 			allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
 			toneFrequency: toneFrequency ?? null,
-			audioStartFrame: -(sequenceContext?.relativeFrom ?? 0),
+			audioStartFrame: Math.max(0, -(sequenceContext?.relativeFrom ?? 0)),
 		});
 
 		return () => unregisterRenderAsset(id);

--- a/packages/renderer/src/test/asset-calculation.test.tsx
+++ b/packages/renderer/src/test/asset-calculation.test.tsx
@@ -42,7 +42,7 @@ test('Should be able to collect assets', async () => {
 		playbackRate: 1,
 		allowAmplificationDuringRender: false,
 		toneFrequency: null,
-		audioStartFrame: -0,
+		audioStartFrame: 0,
 	});
 });
 
@@ -64,7 +64,7 @@ test('Should get multiple assets', async () => {
 		playbackRate: 1,
 		allowAmplificationDuringRender: false,
 		toneFrequency: null,
-		audioStartFrame: -0,
+		audioStartFrame: 0,
 	});
 	expect(withoutId(assetPositions[1])).toEqual({
 		type: 'audio',
@@ -76,7 +76,7 @@ test('Should get multiple assets', async () => {
 		playbackRate: 1,
 		allowAmplificationDuringRender: false,
 		toneFrequency: null,
-		audioStartFrame: -0,
+		audioStartFrame: 0,
 	});
 });
 
@@ -102,7 +102,7 @@ test('Should handle jumps inbetween', async () => {
 		playbackRate: 1,
 		allowAmplificationDuringRender: false,
 		toneFrequency: null,
-		audioStartFrame: -0,
+		audioStartFrame: 0,
 	});
 	expect(withoutId(assetPositions[1])).toEqual({
 		type: 'video',
@@ -114,7 +114,7 @@ test('Should handle jumps inbetween', async () => {
 		playbackRate: 1,
 		allowAmplificationDuringRender: false,
 		toneFrequency: null,
-		audioStartFrame: -0,
+		audioStartFrame: 0,
 	});
 });
 
@@ -170,7 +170,7 @@ test('Should calculate volumes correctly', async () => {
 			.filter((f) => f > 0),
 		allowAmplificationDuringRender: false,
 		toneFrequency: null,
-		audioStartFrame: -0,
+		audioStartFrame: 0,
 	});
 });
 


### PR DESCRIPTION
This will lead to incorrect audio positioning, and bad-sounding audio if combined with playbackRate