### PR TITLE
`@remotion/cloudrun`: Implement ETag diffing when deploying a site

### DIFF
--- a/packages/cloudrun/src/shared/base64-to-hash.ts
+++ b/packages/cloudrun/src/shared/base64-to-hash.ts
@@ -1,0 +1,12 @@
+export function base64ToHex(str: string): string {
+	// Decode the base64 string to a buffer containing the binary data
+	const raw = Buffer.from(str, 'base64');
+
+	// Convert the buffer to a hexadecimal string
+	let hex = '';
+	for (const byte of raw) {
+		hex += byte.toString(16).padStart(2, '0'); // Ensure two digits per byte
+	}
+
+	return hex;
+}

--- a/packages/cloudrun/src/shared/get-etag.ts
+++ b/packages/cloudrun/src/shared/get-etag.ts
@@ -1,23 +1,10 @@
 import crypto from 'crypto';
 import fs from 'fs';
 
-const chunk = 1024 * 1024 * 5; // 5MB
-
 const md5 = (data: Buffer) =>
 	crypto.createHash('md5').update(data).digest('hex');
 
 export const getEtagOfFile = async (filePath: string) => {
 	const stream = await fs.promises.readFile(filePath);
-	if (stream.length <= chunk) {
-		return `"${md5(stream)}"`;
-	}
-
-	const md5Chunks = [];
-	const chunksNumber = Math.ceil(stream.length / chunk);
-	for (let i = 0; i < chunksNumber; i++) {
-		const chunkStream = stream.slice(i * chunk, (i + 1) * chunk);
-		md5Chunks.push(md5(chunkStream));
-	}
-
-	return `"${md5(Buffer.from(md5Chunks.join(''), 'hex'))}-${chunksNumber}"`;
+	return `${md5(stream)}`;
 };

--- a/packages/cloudrun/src/shared/get-storage-operations.ts
+++ b/packages/cloudrun/src/shared/get-storage-operations.ts
@@ -1,5 +1,10 @@
 import type {File} from '@google-cloud/storage';
+import {base64ToHex} from './base64-to-hash';
 import {readDirectory} from './read-dir';
+
+const stripPrefix = (file: string, prefix: string) => {
+	return file.substring(prefix.length + 1);
+};
 
 export const getStorageDiffOperations = async ({
 	objects,
@@ -16,20 +21,25 @@ export const getStorageDiffOperations = async ({
 		originalDir: bundle,
 	});
 
-	const filesOnStorageButNotLocal = objects.filter((fileOnStorage) => {
-		const key = fileOnStorage.name?.substring(prefix.length) as string;
+	const hashMap: Record<string, string> = {};
+	for (const object of objects) {
+		hashMap[object.name] = base64ToHex(object.metadata.md5Hash);
+	}
+
+	const filesOnStorageButNotLocal = objects.filter((o) => {
+		const key = stripPrefix(o.name, prefix);
 		return !dir[key];
 	});
 	const localFilesNotOnStorage = Object.keys(dir).filter((d) => {
 		return !objects.find((o) => {
-			const key = o.name?.substring(prefix.length) as string;
-			return key === d && o.metadata.etag === dir[d];
+			const key = stripPrefix(o.name, prefix);
+			return key === d && hashMap[o.name] === dir[d];
 		});
 	});
 	const existing = Object.keys(dir).filter((d) => {
 		return objects.find((o) => {
-			const key = o.name?.substring(prefix.length) as string;
-			return key === d && o.metadata.etag === dir[d];
+			const key = stripPrefix(o.name, prefix);
+			return key === d && hashMap[o.name] === dir[d];
 		});
 	});
 


### PR DESCRIPTION
Previously it just copied the Lambda code and did not work