### PR TITLE
`@remotion/renderer`: Stop potential massive computation when a lot of packets with same timestamp are in a video

### DIFF
--- a/packages/renderer/rust/opened_stream.rs
+++ b/packages/renderer/rust/opened_stream.rs
@@ -368,7 +368,7 @@ impl OpenedStream {
                                 let new_difference =
                                     (unfiltered.pts().expect("pts") - position).abs();
 
-                                if new_difference > prev_difference {
+                                if new_difference >= prev_difference {
                                     stop_after_n_diverging_pts = Some(stop - 1);
                                 } else if prev_difference > new_difference {
                                     // Fixing test video crazy1.mp4, frames 240-259


### PR DESCRIPTION
Sample submitted here https://discord.com/channels/809501355504959528/1197447378828021830/1234690815901827094