### PR TITLE
`@remotion/cli`: Error out when using --log with npm run

### DIFF
--- a/packages/cli/src/check-for-npm-run-flag-pass.ts
+++ b/packages/cli/src/check-for-npm-run-flag-pass.ts
@@ -1,0 +1,68 @@
+// If someone passes --log=verbose to npm run render
+// We don't receive it.
+
+import type {LogLevel} from '@remotion/renderer';
+import {Log} from './log';
+
+export const checkForNpmRunFlagPass = ({
+	indent,
+	logLevel,
+}: {
+	indent: boolean;
+	logLevel: LogLevel;
+}) => {
+	if (!process.env.npm_config_log) {
+		return;
+	}
+
+	Log.error(
+		{indent, logLevel},
+		`The environment variable "npm_config_log" is set to "${process.env.npm_config_log}".`,
+	);
+	Log.error({indent, logLevel}, `This indicates a likely mistake:`);
+	Log.error(
+		{
+			indent,
+			logLevel,
+		},
+		`--log gets passed to the npm command, however npm has no "log" configuration option.`,
+	);
+	Log.error(
+		{
+			indent,
+			logLevel,
+		},
+		`You most likely wanted to pass --log to the Remotion CLI.`,
+	);
+	Log.error(
+		{
+			indent,
+			logLevel,
+		},
+		`However, arguments passed to "npm run" don't get received by the script, in this case Remotion.`,
+	);
+	Log.error(
+		{
+			indent,
+			logLevel,
+		},
+		`Edit the npm script and pass Remotion flags to "remotion" command instead. Example:`,
+	);
+	Log.error({
+		indent,
+		logLevel,
+	});
+	Log.error(
+		{
+			indent,
+			logLevel,
+		},
+		`  "render": "remotion render --log=verbose"`,
+	);
+	Log.error({
+		indent,
+		logLevel,
+	});
+
+	process.exit(1);
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import {BROWSER_COMMAND, browserCommand} from './browser';
 import {defaultBrowserDownloadProgress} from './browser-download-bar';
 import {bundleCommand} from './bundle';
 import {chalk} from './chalk';
+import {checkForNpmRunFlagPass} from './check-for-npm-run-flag-pass';
 import {cleanupBeforeQuit, handleCtrlC} from './cleanup-before-quit';
 import {cloudrunCommand} from './cloudrun-command';
 import {listCompositionsCommand} from './compositions';
@@ -83,6 +84,7 @@ export const cli = async () => {
 		: RenderInternals.registerErrorSymbolicationLock();
 
 	handleCtrlC({indent: false, logLevel});
+	checkForNpmRunFlagPass({indent: false, logLevel});
 
 	try {
 		if (command === 'bundle') {


### PR DESCRIPTION
Common mistake: `npm run remotion --log=verbose` does not invoke verbose mode, because npm run flags don't get forwarded.

We could parse it, but it could conflict with npm flags
And would encourage people to continue believing this works generally