### PR TITLE
`@remotion/studio`: Fix rounding issues of timeline layers

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -21,8 +21,8 @@ const timelineContent: React.CSSProperties = {
 };
 
 export const TimelineTracks: React.FC<{
-	timeline: TrackWithHash[];
-	hasBeenCut: boolean;
+	readonly timeline: TrackWithHash[];
+	readonly hasBeenCut: boolean;
 }> = ({timeline, hasBeenCut}) => {
 	const inner: React.CSSProperties = useMemo(() => {
 		return {

--- a/packages/studio/src/helpers/get-timeline-sequence-layout.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-layout.ts
@@ -74,30 +74,26 @@ export const getTimelineSequenceLayout = ({
 
 	const nonNegativeMarginLeft = Math.min(marginLeft, 0);
 
-	const width = Math.floor(
-		getWidthOfTrack({
-			durationInFrames,
-			lastFrame,
-			nonNegativeMarginLeft,
-			spatialDuration,
-			windowWidth,
-		}),
-	);
+	const width = getWidthOfTrack({
+		durationInFrames,
+		lastFrame,
+		nonNegativeMarginLeft,
+		spatialDuration,
+		windowWidth,
+	});
 
 	const premountWidth = premountDisplay
-		? Math.floor(
-				getWidthOfTrack({
-					durationInFrames: premountDisplay,
-					lastFrame,
-					nonNegativeMarginLeft,
-					spatialDuration: premountDisplay,
-					windowWidth,
-				}),
-			)
+		? getWidthOfTrack({
+				durationInFrames: premountDisplay,
+				lastFrame,
+				nonNegativeMarginLeft,
+				spatialDuration: premountDisplay,
+				windowWidth,
+			})
 		: null;
 
 	return {
-		marginLeft: Math.round(Math.max(marginLeft, 0)) - (premountWidth ?? 0),
+		marginLeft: Math.max(marginLeft, 0) - (premountWidth ?? 0),
 		width: width + (premountWidth ?? 0),
 		premountWidth,
 	};

--- a/packages/studio/src/test/timeline-sequence-layout.test.ts
+++ b/packages/studio/src/test/timeline-sequence-layout.test.ts
@@ -26,9 +26,9 @@ test('Should test timeline sequence layout without max media duration', () => {
 			windowWidth: 1414.203125,
 		}),
 	).toEqual({
-		marginLeft: 1154,
+		marginLeft: 1154.2137986426505,
 		premountWidth: null,
-		width: 226,
+		width: 226.9893263573493,
 	});
 });
 test('Should test timeline sequence layout with max media duration', () => {
@@ -56,8 +56,8 @@ test('Should test timeline sequence layout with max media duration', () => {
 			windowWidth: 1414.203125,
 		}),
 	).toEqual({
-		marginLeft: 1154,
+		marginLeft: 1154.2137986426505,
 		premountWidth: null,
-		width: 221,
+		width: 221.8531462892238,
 	});
 });


### PR DESCRIPTION
Seems like we always rounding but it is not actually necessary