### PR TITLE
Add Light-leak Transition to Resources

### DIFF
--- a/packages/docs/blog/2024-03-05-deployable-studio.md
+++ b/packages/docs/blog/2024-03-05-deployable-studio.md
@@ -77,6 +77,7 @@ Our templates and examples are deployed as a Studio:
 - Jump cuts without re-mounting ([Source code](https://github.com/remotion-dev/video-with-jump-cuts), [Preview](https://video-with-jump-cuts.vercel.app/))
 - CSS animations ([Source code](https://github.com/remotion-dev/css-animation-play-state), [Preview](https://css-animation-play-state.vercel.app/))
 - Measuring the size of a DOM node ([Source code](https://github.com/remotion-dev/measure-item), [Preview](https://measure-item.vercel.app/))
+- Light-leak Transition ([Source code](https://github.com/remotion-dev/light-leak-example), [Preview](https://light-leak-example.vercel.app/))
 
 ## Deploy the Studio to a server
 

--- a/packages/docs/docs/resources.md
+++ b/packages/docs/docs/resources.md
@@ -103,6 +103,7 @@ This list tries to compile all templates, libraries, building blocks and example
 - CSS animations ([Source code](https://github.com/remotion-dev/css-animation-play-state), [Preview](https://css-animation-play-state.vercel.app/))
 - Globe.gl example ([Source code](https://github.com/alexfernandez803/remotion-globegl))
 - Measuring the size of a DOM node ([Source code](https://github.com/remotion-dev/measure-item), [Preview](https://measure-item.vercel.app/))
+- Light-leak Transition ([Source code](https://github.com/remotion-dev/light-leak-example), [Preview](https://light-leak-example.vercel.app/))
 
 ## Videos
 


### PR DESCRIPTION
I added the following repo as an Example to the Resources page: https://github.com/remotion-dev/light-leak-example