### PR TITLE
`remotion`: Several buffering state fixes

### DIFF
--- a/packages/studio/src/components/Editor.tsx
+++ b/packages/studio/src/components/Editor.tsx
@@ -24,7 +24,8 @@ const background: React.CSSProperties = {
 const DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS = 300;
 
 export const BUFFER_STATE_DELAY_IN_MILLISECONDS =
-	typeof process.env.BUFFER_STATE_DELAY_IN_MILLISECONDS === 'undefined'
+	typeof process.env.BUFFER_STATE_DELAY_IN_MILLISECONDS === 'undefined' ||
+	process.env.BUFFER_STATE_DELAY_IN_MILLISECONDS === null
 		? DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS
 		: Number(process.env.BUFFER_STATE_DELAY_IN_MILLISECONDS);
 

--- a/packages/studio/src/components/PlayPause.tsx
+++ b/packages/studio/src/components/PlayPause.tsx
@@ -258,6 +258,7 @@ export const PlayPause: React.FC<{
 
 		const onBuffer = () => {
 			requestAnimationFrame(() => {
+				stopped = false;
 				timeout = setTimeout(() => {
 					if (!stopped) {
 						setShowBufferState(true);

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -53,11 +53,11 @@ export const useResponsiveSidebarStatus = (): 'collapsed' | 'expanded' => {
 };
 
 export const TopPanel: React.FC<{
-	readOnlyStudio: boolean;
-	onMounted: () => void;
-	size: Size | null;
-	drawRef: React.RefObject<HTMLDivElement>;
-	bufferStateDelayInMilliseconds: number;
+	readonly readOnlyStudio: boolean;
+	readonly onMounted: () => void;
+	readonly size: Size | null;
+	readonly drawRef: React.RefObject<HTMLDivElement>;
+	readonly bufferStateDelayInMilliseconds: number;
 }> = ({
 	readOnlyStudio,
 	onMounted,


### PR DESCRIPTION
Bugs we had before:

- Resume and buffering callbacks would fire twice
- In Studio, buffering indicator would only show once
- delay was set to 0 by default instead of 300 in the Studio
- Improper cleanup in listeners leading to unexpected behaviors