### PR TITLE
`@remotion/renderer`: Fix audio being cut too short with playback rate higher than 1 + non-seamless chunk rendering

### DIFF
--- a/packages/renderer/src/stringify-ffmpeg-filter.ts
+++ b/packages/renderer/src/stringify-ffmpeg-filter.ts
@@ -202,17 +202,6 @@ export const stringifyFfmpegFilter = ({
 
 		const wouldBeSilent = trimLeft >= maxDuration;
 		if (wouldBeSilent) {
-			console.log({
-				assetDuration,
-				playbackRate,
-				trimLeft: getActualTrimLeft({
-					asset,
-					fps,
-					trimLeftOffset,
-					seamless: forSeamlessAacConcatenation,
-				}),
-			});
-
 			return null;
 		}
 	}

--- a/packages/renderer/src/stringify-ffmpeg-filter.ts
+++ b/packages/renderer/src/stringify-ffmpeg-filter.ts
@@ -188,17 +188,33 @@ export const stringifyFfmpegFilter = ({
 
 	const startInVideoSeconds = startInVideo / fps;
 
-	if (
-		assetDuration &&
-		getActualTrimLeft({
+	if (assetDuration) {
+		const maxDuration = forSeamlessAacConcatenation
+			? assetDuration / playbackRate
+			: assetDuration;
+
+		const trimLeft = getActualTrimLeft({
 			asset,
 			fps,
 			trimLeftOffset,
 			seamless: forSeamlessAacConcatenation,
-		}) >=
-			assetDuration / playbackRate
-	) {
-		return null;
+		});
+
+		const wouldBeSilent = trimLeft >= maxDuration;
+		if (wouldBeSilent) {
+			console.log({
+				assetDuration,
+				playbackRate,
+				trimLeft: getActualTrimLeft({
+					asset,
+					fps,
+					trimLeftOffset,
+					seamless: forSeamlessAacConcatenation,
+				}),
+			});
+
+			return null;
+		}
 	}
 
 	if (toneFrequency !== null && (toneFrequency <= 0 || toneFrequency > 2)) {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
