### PR TITLE
`@remotion/renderer`: Clear up `outputBuffer` rust memory after a render

### DIFF
--- a/packages/renderer/src/compositor/compositor.ts
+++ b/packages/renderer/src/compositor/compositor.ts
@@ -97,7 +97,7 @@ export const startCompositor = <T extends keyof CompositorCommand>({
 		cwd: path.dirname(bin),
 	});
 
-	const stderrChunks: Buffer[] = [];
+	let stderrChunks: Buffer[] = [];
 	let outputBuffer = Buffer.from('');
 
 	const separator = Buffer.from('remotion_buffer:');
@@ -277,6 +277,10 @@ export const startCompositor = <T extends keyof CompositorCommand>({
 
 			reject?.(error);
 		}
+
+		// Need to manually free up memory
+		outputBuffer = Buffer.from('');
+		stderrChunks = [];
 	});
 
 	return {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
