### PR TITLE
`@remotion/renderer`: Always use adjacent FFmpeg libraries

### DIFF
--- a/packages/renderer/src/compositor/compositor.ts
+++ b/packages/renderer/src/compositor/compositor.ts
@@ -104,7 +104,7 @@ export const startCompositor = <T extends keyof CompositorCommand>({
 						// https://github.com/remotion-dev/remotion/issues/3862
 						DYLD_LIBRARY_PATH: cwd,
 					}
-				: {},
+				: undefined,
 	});
 
 	let stderrChunks: Buffer[] = [];

--- a/packages/renderer/src/compositor/compositor.ts
+++ b/packages/renderer/src/compositor/compositor.ts
@@ -93,8 +93,18 @@ export const startCompositor = <T extends keyof CompositorCommand>({
 		payload,
 	);
 
+	const cwd = path.dirname(bin);
+
 	const child = spawn(bin, [JSON.stringify(fullCommand)], {
-		cwd: path.dirname(bin),
+		cwd,
+		env:
+			process.platform === 'darwin'
+				? {
+						// Should work out of the box, but sometimes it doesn't
+						// https://github.com/remotion-dev/remotion/issues/3862
+						DYLD_LIBRARY_PATH: cwd,
+					}
+				: {},
 	});
 
 	let stderrChunks: Buffer[] = [];


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
