### PR TITLE
`remotion`: Fix `spring()` from / to interpolation

### DIFF
--- a/packages/core/src/spring/index.ts
+++ b/packages/core/src/spring/index.ts
@@ -59,8 +59,6 @@ export function spring({
 		? measureSpring({
 				fps,
 				config,
-				from,
-				to,
 				threshold: durationRestThreshold,
 			})
 		: undefined;

--- a/packages/core/src/spring/measure-spring.ts
+++ b/packages/core/src/spring/measure-spring.ts
@@ -12,8 +12,6 @@ export function measureSpring({
 	fps,
 	config = {},
 	threshold = 0.005,
-	from = 0,
-	to = 1,
 }: {
 	fps: number;
 	config?: Partial<SpringConfig>;
@@ -53,8 +51,6 @@ export function measureSpring({
 		config.mass,
 		config.overshootClamping,
 		config.stiffness,
-		from,
-		to,
 		threshold,
 	].join('-');
 	if (cache.has(cacheKey)) {
@@ -63,7 +59,6 @@ export function measureSpring({
 
 	validateFps(fps, 'to the measureSpring() function', false);
 
-	const range = Math.abs(from - to);
 	let frame = 0;
 	let finishedFrame = 0;
 	const calc = () => {
@@ -76,10 +71,7 @@ export function measureSpring({
 
 	let animation = calc();
 	const calcDifference = () => {
-		return (
-			Math.abs(animation.current - animation.toValue) /
-			(range === 0 ? 1 : range)
-		);
+		return Math.abs(animation.current - animation.toValue);
 	};
 
 	let difference = calcDifference();

--- a/packages/core/src/spring/measure-spring.ts
+++ b/packages/core/src/spring/measure-spring.ts
@@ -1,8 +1,20 @@
+import type {ENABLE_V5_BREAKING_CHANGES} from '../v5-flag.js';
 import {validateFps} from '../validation/validate-fps.js';
 import type {SpringConfig} from './spring-utils';
 import {springCalculation} from './spring-utils.js';
 
 const cache = new Map<string, number>();
+
+type V4Props = {
+	from?: number;
+	to?: number;
+};
+
+type MeasureSpringProps = {
+	fps: number;
+	config?: Partial<SpringConfig>;
+	threshold?: number;
+} & (false extends typeof ENABLE_V5_BREAKING_CHANGES ? V4Props : {});
 
 /**
  * @description The function returns how long it takes for a spring animation to settle
@@ -12,13 +24,7 @@ export function measureSpring({
 	fps,
 	config = {},
 	threshold = 0.005,
-}: {
-	fps: number;
-	config?: Partial<SpringConfig>;
-	threshold?: number;
-	from?: number;
-	to?: number;
-}): number {
+}: MeasureSpringProps): number {
 	if (typeof threshold !== 'number') {
 		throw new TypeError(
 			`threshold must be a number, got ${threshold} of type ${typeof threshold}`,

--- a/packages/core/src/test/spring.test.ts
+++ b/packages/core/src/test/spring.test.ts
@@ -223,3 +223,17 @@ test('spring should not end too early', () => {
 		}),
 	).toBeCloseTo(1);
 });
+
+test('from / to', () => {
+	expect(
+		spring({
+			fps: 30,
+			frame: 10,
+			from: 0,
+			to: 200,
+			config: {
+				damping: 200,
+			},
+		}),
+	).toBeCloseTo(169.082);
+});


### PR DESCRIPTION
We will remove from / to in Remotion v5, it does not influence the duration at all!

We have to yet document this