### PR TITLE
`@remotion/renderer`: Cleanup headless browsers inbetween renders

### DIFF
--- a/packages/renderer/src/browser-instances.ts
+++ b/packages/renderer/src/browser-instances.ts
@@ -1,0 +1,19 @@
+import type {HeadlessBrowser} from './browser/Browser';
+
+const browserInstances: HeadlessBrowser[] = [];
+
+export const killAllBrowsers = async () => {
+	for (const browser of browserInstances) {
+		try {
+			await browser.close(true, 'info', false);
+		} catch (err) {}
+	}
+};
+
+export const addHeadlessBrowser = (browser: HeadlessBrowser) => {
+	browserInstances.push(browser);
+};
+
+export const removeHeadlessBrowser = (browser: HeadlessBrowser) => {
+	browserInstances.splice(browserInstances.indexOf(browser), 1);
+};

--- a/packages/renderer/src/browser/Browser.ts
+++ b/packages/renderer/src/browser/Browser.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {removeHeadlessBrowser} from '../browser-instances';
 import type {LogLevel} from '../log-level';
 import {assert} from './assert';
 import type {Page} from './BrowserPage';
@@ -278,6 +279,7 @@ export class HeadlessBrowser extends EventEmitter {
 		this.emit(
 			silent ? BrowserEmittedEvents.ClosedSilent : BrowserEmittedEvents.Closed,
 		);
+		removeHeadlessBrowser(this);
 	}
 
 	disconnect(): void {

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -43,7 +43,7 @@ import {DEFAULT_JPEG_QUALITY, validateJpegQuality} from './jpeg-quality';
 import {isEqualOrBelowLogLevel, isValidLogLevel, logLevels} from './log-level';
 import {INDENT_TOKEN, Log} from './logger';
 import {mimeContentType, mimeLookup} from './mime-types';
-import {internalOpenBrowser, killAllBrowsers} from './open-browser';
+import {internalOpenBrowser} from './open-browser';
 import {
 	DEFAULT_OPENGL_RENDERER,
 	validOpenGlRenderers,
@@ -132,6 +132,7 @@ export {validateOutputFilename} from './validate-output-filename';
 export type {AudioCodec};
 
 import {makeDownloadMap} from './assets/download-map';
+import {killAllBrowsers} from './browser-instances';
 import {codecSupportsMedia} from './codec-supports-media';
 import {makeFileExecutableIfItIsNot} from './compositor/make-file-executable';
 import {internalEnsureBrowser} from './ensure-browser';

--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -1,4 +1,5 @@
 import type {Browser} from './browser';
+import {addHeadlessBrowser} from './browser-instances';
 import type {HeadlessBrowser} from './browser/Browser';
 import {defaultBrowserDownloadProgress} from './browser/browser-download-progress-bar';
 import {puppeteer} from './browser/node';
@@ -50,16 +51,6 @@ const getOpenGlRenderer = (option?: OpenGlRenderer | null): string[] => {
 	}
 
 	return [`--use-gl=${renderer}`];
-};
-
-const browserInstances: HeadlessBrowser[] = [];
-
-export const killAllBrowsers = async () => {
-	for (const browser of browserInstances) {
-		try {
-			await browser.close(true, 'info', false);
-		} catch (err) {}
-	}
 };
 
 type InternalOpenBrowserOptions = {
@@ -207,7 +198,7 @@ export const internalOpenBrowser = async ({
 	const pages = await browserInstance.pages(logLevel, indent);
 	await pages[0].close();
 
-	browserInstances.push(browserInstance);
+	addHeadlessBrowser(browserInstance);
 	return browserInstance;
 };
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
