### PR TITLE
`@remotion/renderer`: Fix x264 preset not working on Lambda H.264 anymore

### DIFF
--- a/packages/cli-autocomplete/src/source.ts
+++ b/packages/cli-autocomplete/src/source.ts
@@ -276,6 +276,7 @@ const renderOptions: Fig.Option[] = [
         { name: "wav" },
         { name: "prores" },
         { name: "h264-mkv" },
+        { name: "h264-ts" },
       ],
     },
   },

--- a/packages/renderer/src/crf.ts
+++ b/packages/renderer/src/crf.ts
@@ -105,7 +105,10 @@ export const validateQualitySettings = ({
 	}
 
 	const range = getValidCrfRanges(codec);
-	if (crf === 0 && (codec === 'h264' || codec === 'h264-mkv')) {
+	if (
+		crf === 0 &&
+		(codec === 'h264' || codec === 'h264-mkv' || codec === 'h264-ts')
+	) {
 		throw new TypeError(
 			"Setting the CRF to 0 with a H264 codec is not supported anymore because of it's inconsistencies between platforms. Videos with CRF 0 cannot be played on iOS/macOS. 0 is a extreme value with inefficient settings which you probably do not want. Set CRF to a higher value to fix this error.",
 		);

--- a/packages/renderer/src/options/x264-preset.tsx
+++ b/packages/renderer/src/options/x264-preset.tsx
@@ -25,7 +25,12 @@ export const validateSelectedCodecAndPresetCombination = ({
 	codec: Codec;
 	x264Preset: X264Preset | null;
 }) => {
-	if (x264Preset !== null && codec !== 'h264' && codec !== 'h264-mkv') {
+	if (
+		x264Preset !== null &&
+		codec !== 'h264' &&
+		codec !== 'h264-mkv' &&
+		codec !== 'h264-ts'
+	) {
 		throw new TypeError(
 			`You have set a x264 preset but the codec is "${codec}". Set the codec to "h264" or remove the Preset profile.`,
 		);

--- a/packages/renderer/src/validate-even-dimensions-with-codec.ts
+++ b/packages/renderer/src/validate-even-dimensions-with-codec.ts
@@ -18,7 +18,12 @@ export const validateEvenDimensionsWithCodec = ({
 		return;
 	}
 
-	if (codec !== 'h264-mkv' && codec !== 'h264' && codec !== 'h265') {
+	if (
+		codec !== 'h264-mkv' &&
+		codec !== 'h264' &&
+		codec !== 'h265' &&
+		codec !== 'h264-ts'
+	) {
 		return;
 	}
 


### PR DESCRIPTION
Among some other places we did not treat h264-ts the same as h264