### PR TITLE
`@remotion/renderer`: Explicit DYLD_LIBRARY_PATH to ensure FFmpeg gets executed

### DIFF
--- a/packages/renderer/src/call-ffmpeg.ts
+++ b/packages/renderer/src/call-ffmpeg.ts
@@ -3,6 +3,7 @@ import type {SpawnOptionsWithoutStdio} from 'node:child_process';
 import {spawn} from 'node:child_process';
 import path from 'path';
 import {getExecutablePath} from './compositor/get-executable-path';
+import {getExplicitEnv} from './compositor/get-explicit-env';
 import {makeFileExecutableIfItIsNot} from './compositor/make-file-executable';
 import type {LogLevel} from './log-level';
 import type {CancelSignal} from './make-cancel-signal';
@@ -33,8 +34,11 @@ export const callFf = ({
 	});
 	makeFileExecutableIfItIsNot(executablePath);
 
+	const cwd = path.dirname(executablePath);
+
 	const task = execa(executablePath, args.filter(truthy), {
-		cwd: path.dirname(executablePath),
+		cwd,
+		env: getExplicitEnv(cwd),
 		...options,
 	});
 
@@ -70,8 +74,11 @@ export const callFfNative = ({
 	});
 	makeFileExecutableIfItIsNot(executablePath);
 
+	const cwd = path.dirname(executablePath);
+
 	const task = spawn(executablePath, args.filter(truthy), {
-		cwd: path.dirname(executablePath),
+		cwd,
+		env: getExplicitEnv(cwd),
 		...options,
 	});
 

--- a/packages/renderer/src/compositor/get-explicit-env.ts
+++ b/packages/renderer/src/compositor/get-explicit-env.ts
@@ -1,0 +1,9 @@
+export const getExplicitEnv = (cwd: string) => {
+	return process.platform === 'darwin'
+		? {
+				// Should work out of the box, but sometimes it doesn't
+				// https://github.com/remotion-dev/remotion/issues/3862
+				DYLD_LIBRARY_PATH: cwd,
+			}
+		: undefined;
+};


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
