### PR TITLE
`remotion`: Don't call .load() on Firefox when using buffering state

### DIFF
--- a/packages/core/src/use-media-buffering.ts
+++ b/packages/core/src/use-media-buffering.ts
@@ -77,7 +77,11 @@ export const useMediaBuffering = ({
 				// reset if a video is already playing.
 				// Therefore only calling it after checking if the video
 				// has no future data.
-				current.load();
+
+				// Breaks on Firefox though: https://github.com/remotion-dev/remotion/issues/3915
+				if (!navigator.userAgent.includes('Firefox/')) {
+					current.load();
+				}
 			} else {
 				current.addEventListener('waiting', onWaiting);
 				cleanupFns.push(() => {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
