### PR TITLE
`@remotion/renderer`: Better retrying of asset downloading

### DIFF
--- a/packages/renderer/src/assets/download-file.ts
+++ b/packages/renderer/src/assets/download-file.ts
@@ -138,7 +138,7 @@ export const downloadFile = async (
 		const {message} = err as Error;
 		if (
 			message === 'aborted' ||
-			message === 'ECONNRESET' ||
+			message.includes('ECONNRESET') ||
 			message.includes(incorrectContentLengthToken) ||
 			// Try again if hitting internal errors
 			message.includes('503') ||

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -508,8 +508,13 @@ const innerRenderFrames = async ({
 				indent,
 				logLevel,
 			}).catch((err) => {
+				const truncateWithEllipsis =
+					renderAsset.src.substring(0, 1000) +
+					(renderAsset.src.length > 1000 ? '...' : '');
 				onError(
-					new Error(`Error while downloading asset: ${(err as Error).stack}`),
+					new Error(
+						`Error while downloading ${truncateWithEllipsis}: ${(err as Error).stack}`,
+					),
 				);
 			});
 		});


### PR DESCRIPTION
- Show URL in error message
- `read ECONNRESET` was not properly retried