### PR TITLE
`@remotion/studio`: Fix reevaluateComposition `props` object

### DIFF
--- a/packages/core/src/ResolveCompositionConfig.tsx
+++ b/packages/core/src/ResolveCompositionConfig.tsx
@@ -247,6 +247,7 @@ export const ResolveCompositionConfig: React.FC<
 					};
 
 					const props = {
+						...defaultProps,
 						...(inputProps ?? {}),
 					};
 


### PR DESCRIPTION
Would not give the same props as in the original calculateMetadata