### PR TITLE
`@remotion/player`: Better handling of pointer events

### DIFF
--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -1,4 +1,4 @@
-import type {MouseEventHandler, ReactNode} from 'react';
+import type {MouseEventHandler, ReactNode, SyntheticEvent} from 'react';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Internals} from 'remotion';
 import {DefaultPlayPauseButton} from './DefaultPlayPauseButton.js';
@@ -122,7 +122,9 @@ export const Controls: React.FC<{
 	readonly containerRef: React.RefObject<HTMLDivElement>;
 	readonly buffering: boolean;
 	readonly hideControlsWhenPointerDoesntMove: boolean | number;
-	readonly onPointerUp: React.PointerEventHandler<HTMLDivElement> | undefined;
+	readonly onPointerDown:
+		| ((ev: PointerEvent | SyntheticEvent) => void)
+		| undefined;
 	readonly onDoubleClick: MouseEventHandler<HTMLDivElement> | undefined;
 }> = ({
 	durationInFrames,
@@ -147,7 +149,7 @@ export const Controls: React.FC<{
 	containerRef,
 	buffering,
 	hideControlsWhenPointerDoesntMove,
-	onPointerUp,
+	onPointerDown,
 	onDoubleClick,
 }) => {
 	const playButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -278,16 +280,17 @@ export const Controls: React.FC<{
 	const ref = useRef<HTMLDivElement | null>(null);
 	const flexRef = useRef<HTMLDivElement | null>(null);
 
-	const onPointerUpIfContainer: React.PointerEventHandler<HTMLDivElement> =
+	const onPointerDownIfContainer: React.PointerEventHandler<HTMLDivElement> =
 		useCallback(
 			(e) => {
 				// Only if pressing the container
 				if (e.target === ref.current || e.target === flexRef.current) {
-					onPointerUp?.(e);
+					onPointerDown?.(e);
 				}
 			},
-			[onPointerUp],
+			[onPointerDown],
 		);
+
 	const onDoubleClickIfContainer: MouseEventHandler<HTMLDivElement> =
 		useCallback(
 			(e) => {
@@ -303,7 +306,7 @@ export const Controls: React.FC<{
 		<div
 			ref={ref}
 			style={containerCss}
-			onPointerUp={onPointerUpIfContainer}
+			onPointerDown={onPointerDownIfContainer}
 			onDoubleClick={onDoubleClickIfContainer}
 		>
 			<div ref={flexRef} style={controlsRow}>

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -186,7 +186,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 	}, []);
 
 	const toggle = useCallback(
-		(e?: SyntheticEvent) => {
+		(e?: SyntheticEvent | PointerEvent) => {
 			if (player.isPlaying()) {
 				player.pause();
 			} else {
@@ -484,7 +484,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		);
 
 	const onSingleClick = useCallback(
-		(e: SyntheticEvent) => {
+		(e: SyntheticEvent | PointerEvent) => {
 			toggle(e);
 		},
 		[toggle],
@@ -506,11 +506,12 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		}
 	}, [exitFullscreen, isFullscreen, requestFullscreen]);
 
-	const [handleClick, handleDoubleClick] = useClickPreventionOnDoubleClick(
-		onSingleClick,
-		onDoubleClick,
-		doubleClickToFullscreen && allowFullscreen && supportsFullScreen,
-	);
+	const {handlePointerDown, handleDoubleClick} =
+		useClickPreventionOnDoubleClick(
+			onSingleClick,
+			onDoubleClick,
+			doubleClickToFullscreen && allowFullscreen && supportsFullScreen,
+		);
 
 	useEffect(() => {
 		if (shouldAutoplay) {
@@ -575,7 +576,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		<>
 			<div
 				style={outer}
-				onPointerUp={clickToPlay ? handleClick : undefined}
+				onPointerDown={clickToPlay ? handlePointerDown : undefined}
 				onDoubleClick={doubleClickToFullscreen ? handleDoubleClick : undefined}
 			>
 				<div style={containerStyle} className={PLAYER_CSS_CLASSNAME}>
@@ -598,7 +599,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 								width: config.width,
 								height: config.height,
 							}}
-							onPointerUp={clickToPlay ? handleClick : undefined}
+							onPointerDown={clickToPlay ? handlePointerDown : undefined}
 							onDoubleClick={
 								doubleClickToFullscreen ? handleDoubleClick : undefined
 							}
@@ -611,7 +612,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 			{shouldShowPoster && posterFillMode === 'player-size' ? (
 				<div
 					style={outer}
-					onPointerUp={clickToPlay ? handleClick : undefined}
+					onPointerDown={clickToPlay ? handlePointerDown : undefined}
 					onDoubleClick={
 						doubleClickToFullscreen ? handleDoubleClick : undefined
 					}
@@ -646,7 +647,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 					onDoubleClick={
 						doubleClickToFullscreen ? handleDoubleClick : undefined
 					}
-					onPointerUp={clickToPlay ? handleClick : undefined}
+					onPointerDown={clickToPlay ? handlePointerDown : undefined}
 				/>
 			) : null}
 		</>

--- a/packages/player/src/use-player.ts
+++ b/packages/player/src/use-player.ts
@@ -11,7 +11,7 @@ type UsePlayerMethods = {
 	isFirstFrame: boolean;
 	emitter: PlayerEmitter;
 	playing: boolean;
-	play: (e?: SyntheticEvent) => void;
+	play: (e?: SyntheticEvent | PointerEvent) => void;
 	pause: () => void;
 	pauseAndReturnToPlayStart: () => void;
 	seek: (newFrame: number) => void;
@@ -74,7 +74,7 @@ export const usePlayer = (): UsePlayerMethods => {
 	);
 
 	const play = useCallback(
-		(e?: SyntheticEvent) => {
+		(e?: SyntheticEvent | PointerEvent) => {
 			if (imperativePlaying.current) {
 				return;
 			}

--- a/packages/player/src/utils/use-click-prevention-on-double-click.ts
+++ b/packages/player/src/utils/use-click-prevention-on-double-click.ts
@@ -4,17 +4,26 @@ import {cancellablePromise} from './cancellable-promise.js';
 import {delay} from './delay.js';
 import {useCancellablePromises} from './use-cancellable-promises.js';
 
+type ReturnVal = {
+	handlePointerDown: (e: SyntheticEvent | PointerEvent) => void;
+	handleDoubleClick: () => void;
+};
+
 const useClickPreventionOnDoubleClick = (
-	onClick: (e: SyntheticEvent) => void,
+	onClick: (e: PointerEvent | SyntheticEvent) => void,
 	onDoubleClick: () => void,
 	doubleClickToFullscreen: boolean,
-): [(e: SyntheticEvent) => void, () => void] => {
+): ReturnVal => {
 	const api = useCancellablePromises();
 
 	const handleClick = useCallback(
-		async (e: SyntheticEvent) => {
+		async (e: SyntheticEvent | PointerEvent) => {
 			// UnSupported double click on touch.(mobile)
-			if ((e.nativeEvent as PointerEvent).pointerType === 'touch') {
+			if (
+				e instanceof PointerEvent
+					? e.pointerType === 'touch'
+					: (e.nativeEvent as PointerEvent).pointerType === 'touch'
+			) {
 				onClick(e);
 				return;
 			}
@@ -39,18 +48,30 @@ const useClickPreventionOnDoubleClick = (
 		[api, onClick],
 	);
 
+	const handlePointerDown = useCallback(() => {
+		document.addEventListener(
+			'pointerup',
+			(newEvt) => {
+				handleClick(newEvt);
+			},
+			{
+				once: true,
+			},
+		);
+	}, [handleClick]);
+
 	const handleDoubleClick = useCallback(() => {
 		api.clearPendingPromises();
 		onDoubleClick();
 	}, [api, onDoubleClick]);
 
-	const returnValue = useMemo((): [(e: SyntheticEvent) => void, () => void] => {
+	const returnValue = useMemo((): ReturnVal => {
 		if (!doubleClickToFullscreen) {
-			return [onClick, () => undefined];
+			return {handlePointerDown: onClick, handleDoubleClick: () => undefined};
 		}
 
-		return [handleClick, handleDoubleClick];
-	}, [doubleClickToFullscreen, handleClick, handleDoubleClick, onClick]);
+		return {handlePointerDown, handleDoubleClick};
+	}, [doubleClickToFullscreen, handleDoubleClick, handlePointerDown, onClick]);
 
 	return returnValue;
 };


### PR DESCRIPTION
When dragging the seek bar and releasing the mouse over the video, it would pause before.

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
