### PR TITLE
`@remotion/lambda`: Disable slow leak detection

### DIFF
--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -442,6 +442,8 @@ export const rendererHandler = async (
 	} finally {
 		forgetBrowserEventLoop(params.logLevel);
 
-		startLeakDetection(leakDetection, requestContext.awsRequestId);
+		if (ENABLE_SLOW_LEAK_DETECTION) {
+			startLeakDetection(leakDetection, requestContext.awsRequestId);
+		}
 	}
 };


### PR DESCRIPTION
Previously it was partially disabled, but still it can lead to a unfortunate race condition if another Lambda function is launched exactly 10 seconds after the previous one.

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
