### PR TITLE
`remotion`: Fix crash if using `<Composition lazyComponent={undefined}>`

### DIFF
--- a/packages/core/src/use-lazy-component.ts
+++ b/packages/core/src/use-lazy-component.ts
@@ -17,7 +17,10 @@ export const useLazyComponent = <Props>(
 	compProps: CompProps<Props>,
 ): LazyExoticComponent<ComponentType<Props>> => {
 	const lazy = useMemo(() => {
-		if ('lazyComponent' in compProps) {
+		if (
+			'lazyComponent' in compProps &&
+			typeof compProps.lazyComponent !== 'undefined'
+		) {
 			return React.lazy(
 				compProps.lazyComponent as () => Promise<{
 					default: ComponentType<Props>;

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -806,6 +806,7 @@ export const Index: React.FC = () => {
 					height={1080}
 					fps={30}
 					durationInFrames={720}
+					lazyComponent={undefined}
 				/>
 				<Composition
 					id="22khz"


### PR DESCRIPTION
Creative way to break remotion 🤣

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
