### PR TITLE
`@remotion/renderer`: Fix unnecessary colorspace conversion

### DIFF
--- a/packages/renderer/rust/scalable_frame.rs
+++ b/packages/renderer/rust/scalable_frame.rs
@@ -214,15 +214,6 @@ pub fn scale_and_make_bitmap(
         )?;
     }
 
-    scaler.set_colorspace_details(
-        native_frame.colorspace,
-        native_frame.src_range,
-        color::Range::JPEG,
-        0,
-        1 << 16,
-        1 << 16,
-    )?;
-
     let mut data: Vec<*const u8> = Vec::with_capacity(planes.len());
 
     for i in 0..planes.len() {

--- a/packages/renderer/src/test/extract-frame-rust.test.ts
+++ b/packages/renderer/src/test/extract-frame-rust.test.ts
@@ -289,9 +289,9 @@ test('Should be able to extract a frame with abnormal DAR', async () => {
 	expect(Buffer.from([...header.subarray(18, 22)]).readInt32LE(0)).toBe(1280);
 	expect(Buffer.from([...header.subarray(22, 26)]).readInt32LE(0)).toBe(2276);
 
-	expect(data[0x00169915]).toBeCloseTo(232, 2);
-	expect(data[0x0012dd58]).toBeCloseTo(231, 2);
-	expect(data[0x00019108]).toBeCloseTo(231, 2);
+	expect(data[0x00169915]).toBeCloseTo(250, 2);
+	expect(data[0x0012dd58]).toBeCloseTo(249, 2);
+	expect(data[0x00019108]).toBeCloseTo(249, 2);
 
 	await compositor.finishCommands();
 	await compositor.waitForDone();
@@ -610,40 +610,40 @@ test('Two different starting times should not result in big seeking', async () =
 		expected.push([centerLeftPixelR, centerLeftPixelG, centerLeftPixelB]);
 	}
 
-	expect(expected[0][0] / 100).toBeCloseTo(1.48, 1);
-	expect(expected[0][1] / 100).toBeCloseTo(1.77, 1);
-	expect(expected[0][2] / 100).toBeCloseTo(2.11, 1);
+	expect(expected[0][0] / 100).toBeCloseTo(1.53, 1);
+	expect(expected[0][1] / 100).toBeCloseTo(1.86, 1);
+	expect(expected[0][2] / 100).toBeCloseTo(2.24, 1);
 
-	expect(expected[1][0] / 100).toBeCloseTo(0.77, 1);
-	expect(expected[1][1] / 100).toBeCloseTo(0.78, 1);
-	expect(expected[1][2] / 100).toBeCloseTo(0.76, 1);
+	expect(expected[1][0] / 100).toBeCloseTo(0.69, 1);
+	expect(expected[1][1] / 100).toBeCloseTo(0.7, 1);
+	expect(expected[1][2] / 100).toBeCloseTo(0.68, 1);
 
-	expect(expected[2][0] / 100).toBeCloseTo(1.48, 1);
-	expect(expected[2][1] / 100).toBeCloseTo(1.77, 1);
-	expect(expected[2][2] / 100).toBeCloseTo(2.11, 1);
+	expect(expected[2][0] / 100).toBeCloseTo(1.53, 1);
+	expect(expected[2][1] / 100).toBeCloseTo(1.86, 1);
+	expect(expected[2][2] / 100).toBeCloseTo(2.24, 1);
 
-	expect(expected[3][0] / 100).toBeCloseTo(2.34, 1);
-	expect(expected[3][1] / 100).toBeCloseTo(2.33, 1);
-	expect(expected[3][2] / 100).toBeCloseTo(2.28, 1);
+	expect(expected[3][0] / 100).toBeCloseTo(2.52, 1);
+	expect(expected[3][1] / 100).toBeCloseTo(2.51, 1);
+	expect(expected[3][2] / 100).toBeCloseTo(2.45, 1);
 
 	expect(expected[4][0] / 100).toBeCloseTo(1.5, 1);
-	expect(expected[4][1] / 100).toBeCloseTo(1.77, 1);
-	expect(expected[4][2] / 100).toBeCloseTo(2.11, 1);
+	expect(expected[4][1] / 100).toBeCloseTo(1.86, 1);
+	expect(expected[4][2] / 100).toBeCloseTo(2.24, 1);
 
 	expect(expected[5][0] / 100).toBeCloseTo(1.32, 1);
 	expect(expected[5][2] / 100).toBeCloseTo(1.2, 1);
 
-	expect(expected[6][0] / 100).toBeCloseTo(1.48, 1);
-	expect(expected[6][1] / 100).toBeCloseTo(1.77, 1);
-	expect(expected[6][2] / 100).toBeCloseTo(2.11, 1);
+	expect(expected[6][0] / 100).toBeCloseTo(1.53, 1);
+	expect(expected[6][1] / 100).toBeCloseTo(1.86, 1);
+	expect(expected[6][2] / 100).toBeCloseTo(2.24, 1);
 
 	expect(expected[7][0] / 100).toBeCloseTo(1.38, 1);
 	expect(expected[7][1] / 100).toBeCloseTo(1.41, 1);
 	expect(expected[7][2] / 100).toBeCloseTo(1.07, 1);
 
-	expect(expected[8][0] / 100).toBeCloseTo(1.48, 1);
-	expect(expected[8][1] / 100).toBeCloseTo(1.77, 1);
-	expect(expected[8][2] / 100).toBeCloseTo(2.11, 1);
+	expect(expected[8][0] / 100).toBeCloseTo(1.53, 1);
+	expect(expected[8][1] / 100).toBeCloseTo(1.86, 1);
+	expect(expected[8][2] / 100).toBeCloseTo(2.24, 1);
 
 	expect(expected[9][0] / 100).toBeCloseTo(1.27, 1);
 	expect(expected[9][1] / 100).toBeCloseTo(1.47, 1);

--- a/packages/renderer/src/test/extract-frame-rust.test.ts
+++ b/packages/renderer/src/test/extract-frame-rust.test.ts
@@ -290,7 +290,7 @@ test('Should be able to extract a frame with abnormal DAR', async () => {
 	expect(Buffer.from([...header.subarray(22, 26)]).readInt32LE(0)).toBe(2276);
 
 	expect(data[0x00169915] / 100).toBeCloseTo(2.5, 1);
-	expect(data[0x0012dd58]).toBeCloseTo(249, 2);
+	expect(data[0x0012dd58] / 100).toBeCloseTo(2.5, 1);
 	expect(data[0x00019108]).toBeCloseTo(249, 2);
 
 	await compositor.finishCommands();

--- a/packages/renderer/src/test/extract-frame-rust.test.ts
+++ b/packages/renderer/src/test/extract-frame-rust.test.ts
@@ -289,7 +289,7 @@ test('Should be able to extract a frame with abnormal DAR', async () => {
 	expect(Buffer.from([...header.subarray(18, 22)]).readInt32LE(0)).toBe(1280);
 	expect(Buffer.from([...header.subarray(22, 26)]).readInt32LE(0)).toBe(2276);
 
-	expect(data[0x00169915]).toBeCloseTo(250, 2);
+	expect(data[0x00169915] / 100).toBeCloseTo(2.5, 1);
 	expect(data[0x0012dd58]).toBeCloseTo(249, 2);
 	expect(data[0x00019108]).toBeCloseTo(249, 2);
 

--- a/packages/renderer/src/test/extract-frame-rust.test.ts
+++ b/packages/renderer/src/test/extract-frame-rust.test.ts
@@ -291,7 +291,7 @@ test('Should be able to extract a frame with abnormal DAR', async () => {
 
 	expect(data[0x00169915] / 100).toBeCloseTo(2.5, 1);
 	expect(data[0x0012dd58] / 100).toBeCloseTo(2.5, 1);
-	expect(data[0x00019108]).toBeCloseTo(249, 2);
+	expect(data[0x00019108] / 100).toBeCloseTo(2.5, 1);
 
 	await compositor.finishCommands();
 	await compositor.waitForDone();


### PR DESCRIPTION
This is a regression of 4.0.158 https://github.com/remotion-dev/remotion/commit/0d231ec50a463a9e3ff9771bcadb3ade93c4dc5b