### PR TITLE
`@remotion/renderer`: Get audio channels immediately after downloading and validate early

### DIFF
--- a/packages/example/src/MediaErrorHandling/HandleAudioRenderError.tsx
+++ b/packages/example/src/MediaErrorHandling/HandleAudioRenderError.tsx
@@ -1,0 +1,5 @@
+import {Audio, staticFile} from 'remotion';
+
+export const HandleAudioRenderError = () => {
+	return <Audio src={staticFile('balloons.json')} />;
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -31,6 +31,7 @@ import {HlsDemo} from './Hls/HlsDemo';
 import {HugePayload, hugePayloadSchema} from './HugePayload';
 import {Layers} from './Layers';
 import {ManyAudio} from './ManyAudio';
+import {HandleAudioRenderError} from './MediaErrorHandling/HandleAudioRenderError';
 import {MissingImg} from './MissingImg';
 import {
 	OffthreadRemoteVideo,
@@ -94,6 +95,7 @@ import {WarpDemoOuter} from './WarpText';
 import {WarpDemo2} from './WarpText/demo2';
 import './style.css';
 import {WatchStaticDemo} from './watch-static';
+
 if (alias !== 'alias') {
 	throw new Error('should support TS aliases');
 }
@@ -1377,6 +1379,16 @@ export const Index: React.FC = () => {
 					height={1000}
 					width={1000}
 					durationInFrames={10}
+				/>
+			</Folder>
+			<Folder name="MediaErrorHandling">
+				<Composition
+					id="AudioError"
+					component={HandleAudioRenderError}
+					fps={30}
+					height={1080}
+					width={1080}
+					durationInFrames={10_000}
 				/>
 			</Folder>
 		</>

--- a/packages/renderer/src/assets/convert-assets-to-file-urls.ts
+++ b/packages/renderer/src/assets/convert-assets-to-file-urls.ts
@@ -19,12 +19,14 @@ export const convertAssetsToFileUrls = async ({
 	downloadMap,
 	indent,
 	logLevel,
+	binariesDirectory,
 }: {
 	assets: FrameAndAssets[];
 	onDownload: RenderMediaOnDownload;
 	downloadMap: DownloadMap;
 	indent: boolean;
 	logLevel: LogLevel;
+	binariesDirectory: string | null;
 }): Promise<AudioOrVideoAsset[][]> => {
 	const chunks = chunk(assets, 1000);
 	const results: AudioOrVideoAsset[][][] = [];
@@ -38,6 +40,9 @@ export const convertAssetsToFileUrls = async ({
 					downloadMap,
 					indent,
 					logLevel,
+					binariesDirectory,
+					cancelSignalForAudioAnalysis: undefined,
+					shouldAnalyzeAudioImmediately: true,
 				});
 			});
 			return Promise.all(frameAssetPromises);

--- a/packages/renderer/src/assets/download-and-map-assets-to-file.ts
+++ b/packages/renderer/src/assets/download-and-map-assets-to-file.ts
@@ -261,7 +261,7 @@ export const downloadAsset = async ({
 		await getAudioChannelsAndDuration({
 			binariesDirectory,
 			downloadMap,
-			src,
+			src: to,
 			indent,
 			logLevel,
 			cancelSignal: cancelSignalForAudioAnalysis,

--- a/packages/renderer/src/assets/get-audio-channels.ts
+++ b/packages/renderer/src/assets/get-audio-channels.ts
@@ -51,7 +51,7 @@ export const getAudioChannelsAndDurationWithoutCache = async ({
 	} catch (err) {
 		if (
 			(err as Error).message.includes(
-				'Invalid data found when processing input',
+				'This file cannot be read by `ffprobe`. Is it a valid multimedia file?',
 			)
 		) {
 			throw new Error(

--- a/packages/renderer/src/assets/get-audio-channels.ts
+++ b/packages/renderer/src/assets/get-audio-channels.ts
@@ -31,23 +31,36 @@ export const getAudioChannelsAndDurationWithoutCache = async ({
 		.reduce<(string | null)[]>((acc, val) => acc.concat(val), [])
 		.filter(Boolean) as string[];
 
-	const task = await callFf({
-		bin: 'ffprobe',
-		args,
-		indent,
-		logLevel,
-		binariesDirectory,
-		cancelSignal,
-	});
+	try {
+		const task = await callFf({
+			bin: 'ffprobe',
+			args,
+			indent,
+			logLevel,
+			binariesDirectory,
+			cancelSignal,
+		});
+		const channels = task.stdout.match(/channels=([0-9]+)/);
+		const duration = task.stdout.match(/duration=([0-9.]+)/);
 
-	const channels = task.stdout.match(/channels=([0-9]+)/);
-	const duration = task.stdout.match(/duration=([0-9.]+)/);
+		const result: AudioChannelsAndDurationResultCache = {
+			channels: channels ? parseInt(channels[1], 10) : 0,
+			duration: duration ? parseFloat(duration[1]) : null,
+		};
+		return result;
+	} catch (err) {
+		if (
+			(err as Error).message.includes(
+				'Invalid data found when processing input',
+			)
+		) {
+			throw new Error(
+				'This file cannot be read by `ffprobe`. Is it a valid multimedia file?',
+			);
+		}
 
-	const result: AudioChannelsAndDurationResultCache = {
-		channels: channels ? parseInt(channels[1], 10) : 0,
-		duration: duration ? parseFloat(duration[1]) : null,
-	};
-	return result;
+		throw err;
+	}
 };
 
 async function getAudioChannelsAndDurationUnlimited({

--- a/packages/renderer/src/create-audio.ts
+++ b/packages/renderer/src/create-audio.ts
@@ -64,6 +64,7 @@ export const createAudio = async ({
 		downloadMap,
 		indent,
 		logLevel,
+		binariesDirectory,
 	});
 
 	markAllAssetsAsDownloaded(downloadMap);

--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -135,7 +135,15 @@ export const startOffthreadVideoServer = ({
 			});
 
 			let extractStart = Date.now();
-			downloadAsset({src, downloadMap, indent, logLevel})
+			downloadAsset({
+				src,
+				downloadMap,
+				indent,
+				logLevel,
+				binariesDirectory,
+				cancelSignalForAudioAnalysis: undefined,
+				shouldAnalyzeAudioImmediately: true,
+			})
 				.then((to) => {
 					return new Promise<Uint8Array>((resolve, reject) => {
 						if (closed) {

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -145,6 +145,7 @@ type InnerRenderFramesOptions = {
 	serializedResolvedPropsWithCustomSchema: string;
 	parallelEncodingEnabled: boolean;
 	compositionStart: number;
+	binariesDirectory: string | null;
 } & ToOptions<typeof optionsMap.renderFrames>;
 
 type ArtifactWithoutContent = {
@@ -235,6 +236,7 @@ const innerRenderFrames = async ({
 	compositionStart,
 	forSeamlessAacConcatenation,
 	onArtifact,
+	binariesDirectory,
 }: Omit<
 	InnerRenderFramesOptions,
 	'offthreadVideoCacheSizeInBytes'
@@ -550,6 +552,9 @@ const innerRenderFrames = async ({
 				downloadMap,
 				indent,
 				logLevel,
+				binariesDirectory,
+				cancelSignalForAudioAnalysis: cancelSignal,
+				shouldAnalyzeAudioImmediately: true,
 			}).catch((err) => {
 				const truncateWithEllipsis =
 					renderAsset.src.substring(0, 1000) +


### PR DESCRIPTION
Not only in the end

Also give a better error message