### PR TITLE
`@remotion/player`: Don't overwrite global TypeScript Types

### DIFF
--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -90,17 +90,6 @@ const flex1: React.CSSProperties = {
 
 const fullscreen: React.CSSProperties = {};
 
-declare global {
-	interface Document {
-		webkitFullscreenEnabled?: boolean;
-		webkitFullscreenElement?: Element;
-		webkitExitFullscreen?: Document['exitFullscreen'];
-	}
-	interface HTMLDivElement {
-		webkitRequestFullScreen: HTMLDivElement['requestFullscreen'];
-	}
-}
-
 export const Controls: React.FC<{
 	readonly fps: number;
 	readonly durationInFrames: number;
@@ -222,7 +211,9 @@ export const Controls: React.FC<{
 		// Must be handled client-side to avoid SSR hydration mismatch
 		setSupportsFullscreen(
 			(typeof document !== 'undefined' &&
-				(document.fullscreenEnabled || document.webkitFullscreenEnabled)) ??
+				(document.fullscreenEnabled ||
+					// @ts-expect-error Types not defined
+					document.webkitFullscreenEnabled)) ??
 				false,
 		);
 	}, []);

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -139,7 +139,9 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		}
 
 		return Boolean(
-			document.fullscreenEnabled || document.webkitFullscreenEnabled,
+			document.fullscreenEnabled ||
+				// @ts-expect-error Types not defined
+				document.webkitFullscreenEnabled,
 		);
 	}, []);
 
@@ -170,6 +172,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		const onFullscreenChange = () => {
 			setIsFullscreen(
 				document.fullscreenElement === current ||
+					// @ts-expect-error Types not defined
 					document.webkitFullscreenElement === current,
 			);
 		};
@@ -209,7 +212,9 @@ const PlayerUI: React.ForwardRefRenderFunction<
 			throw new Error('No player ref found');
 		}
 
+		// @ts-expect-error Types not defined
 		if (container.current.webkitRequestFullScreen) {
+			// @ts-expect-error Types not defined
 			container.current.webkitRequestFullScreen();
 		} else {
 			container.current.requestFullscreen();
@@ -217,7 +222,9 @@ const PlayerUI: React.ForwardRefRenderFunction<
 	}, [allowFullscreen, supportsFullScreen]);
 
 	const exitFullscreen = useCallback(() => {
+		// @ts-expect-error Types not defined
 		if (document.webkitExitFullscreen) {
+			// @ts-expect-error Types not defined
 			document.webkitExitFullscreen();
 		} else {
 			document.exitFullscreen();
@@ -232,7 +239,10 @@ const PlayerUI: React.ForwardRefRenderFunction<
 
 		const fullscreenChange = () => {
 			const element =
-				document.webkitFullscreenElement ?? document.fullscreenElement;
+				// @ts-expect-error Types not defined
+				document.webkitFullscreenElement ??
+				// defined
+				document.fullscreenElement;
 
 			if (element && element === container.current) {
 				player.emitter.dispatchFullscreenChange({

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -1,5 +1,6 @@
 import React, {useContext, useState} from 'react';
 import {Internals} from 'remotion';
+import {checkFullscreenSupport} from '../helpers/check-fullscreen-support';
 import {BACKGROUND} from '../helpers/colors';
 import {
 	useIsStill,
@@ -60,8 +61,7 @@ export const PreviewToolbar: React.FC<{
 
 	const [loop, setLoop] = useState(loadLoopOption());
 
-	const isFullscreenSupported =
-		document.fullscreenEnabled || document.webkitFullscreenEnabled;
+	const isFullscreenSupported = checkFullscreenSupport();
 
 	return (
 		<div style={container} className="css-reset">

--- a/packages/studio/src/helpers/check-fullscreen-support.ts
+++ b/packages/studio/src/helpers/check-fullscreen-support.ts
@@ -1,0 +1,7 @@
+export const checkFullscreenSupport = () => {
+	return (
+		document.fullscreenEnabled ||
+		// @ts-expect-error Types not defined
+		document.webkitFullscreenEnabled
+	);
+};

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -23,6 +23,7 @@ import type {ModalState} from '../state/modals';
 import {ModalsContext} from '../state/modals';
 import type {SidebarCollapsedState} from '../state/sidebar';
 import {SidebarContext} from '../state/sidebar';
+import {checkFullscreenSupport} from './check-fullscreen-support';
 import {StudioServerConnectionCtx} from './client-id';
 import {getGitMenuItem} from './get-git-menu-item';
 import {useMobileLayout} from './mobile-layout';
@@ -161,8 +162,7 @@ export const useMenuStructure = (
 	} = useContext(SidebarContext);
 	const sizes = getUniqueSizes(size);
 
-	const isFullscreenSupported =
-		document.fullscreenEnabled || document.webkitFullscreenEnabled;
+	const isFullscreenSupported = checkFullscreenSupport();
 
 	const mobileLayout = useMobileLayout();
 	const structure = useMemo((): Structure => {


### PR DESCRIPTION
> Somewhat related question: it appears that PlayerControls.d.ts from @remotion/player is mutating the global namespace to add full screen support to HTMLDivElement, but that causes other libraries like Material UI to report TypeScript errors, since they don’t have the same implementation. 
