### PR TITLE
`@remotion/renderer`: Fix initial frame being set wrong

### DIFF
--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -360,7 +360,7 @@ const innerRenderFrames = async ({
 	const getPool = async (context: SourceMapGetter) => {
 		const pages = new Array(concurrencyOrFramesToRender)
 			.fill(true)
-			.map((_, i) => makePage(context, realFrameRange[i]));
+			.map((_, i) => makePage(context, framesToRender[i]));
 		const puppeteerPages = await Promise.all(pages);
 		const pool = new Pool(puppeteerPages);
 		return pool;


### PR DESCRIPTION
It would seek to the last frame of the composition instead for 1 tab, which could cause a lot of seeks