### PR TITLE
fix: Resolve the issue where CJK-named composition IDs are not automatically reselected after page refresh in Remotion Studio.

### DIFF
--- a/packages/studio/src/components/ZoomPersistor.tsx
+++ b/packages/studio/src/components/ZoomPersistor.tsx
@@ -18,6 +18,21 @@ export const getZoomFromLocalStorage = (): Record<string, number> => {
 	return zoom ? JSON.parse(zoom) : {};
 };
 
+function decodeIfNeeded(str: string) {
+	const needsDecode = /%[0-9A-Fa-f]{2}/.test(str);
+
+	if (needsDecode) {
+		try {
+			return decodeURIComponent(str);
+		} catch (e) {
+			// console.warn("Failed to decode string:", str);
+			return str;
+		}
+	}
+
+	return str;
+}
+
 export const deriveCanvasContentFromUrl = (): CanvasContent | null => {
 	const substrings = getRoute().split('/').filter(Boolean);
 
@@ -40,7 +55,8 @@ export const deriveCanvasContentFromUrl = (): CanvasContent | null => {
 	if (lastPart) {
 		return {
 			type: 'composition',
-			compositionId: lastPart,
+			// CJK-named composition IDs are not automatically reselected after page refresh
+			compositionId: decodeIfNeeded(lastPart),
 		};
 	}
 


### PR DESCRIPTION
Resolve the issue where CJK-named composition IDs are not automatically reselected after page refresh in Remotion Studio.

![image](https://github.com/remotion-dev/remotion/assets/5625783/1e46e7b0-c84d-4352-8611-9b0d109dc85e)
