### PR TITLE
`@remotion/lambda`: `npx remotion still` does not log `null` when there are no artifacts

### DIFF
--- a/packages/lambda/src/cli/commands/still.ts
+++ b/packages/lambda/src/cli/commands/still.ts
@@ -271,13 +271,16 @@ export const stillCommand = async (
 		),
 	);
 
-	Log.info(
-		{
-			indent: false,
-			logLevel,
-		},
-		makeArtifactProgress(res.artifacts),
-	);
+	const artifactProgress = makeArtifactProgress(res.artifacts);
+	if (artifactProgress) {
+		Log.info(
+			{
+				indent: false,
+				logLevel,
+			},
+			makeArtifactProgress(res.artifacts),
+		);
+	}
 
 	Log.info(
 		{indent: false, logLevel},


### PR DESCRIPTION
This was a bug previously