### PR TITLE
`@remotion/renderer`: Add `resolvedConcurrency` field to `onStart` callback

### DIFF
--- a/packages/cli/src/benchmark.ts
+++ b/packages/cli/src/benchmark.ts
@@ -56,7 +56,7 @@ const getValidConcurrency = (cliConcurrency: number | string | null) => {
 	const {concurrencies} = parsedCli;
 
 	if (!concurrencies) {
-		return [RenderInternals.getActualConcurrency(cliConcurrency)];
+		return [RenderInternals.resolveConcurrency(cliConcurrency)];
 	}
 
 	return (concurrencies as string)

--- a/packages/cli/src/get-render-defaults.ts
+++ b/packages/cli/src/get-render-defaults.ts
@@ -34,7 +34,7 @@ export const getRenderDefaults = (): RenderDefaults => {
 	}).value;
 	const logLevel = logLevelOption.getValue({commandLine: parsedCli}).value;
 	const defaultCodec = ConfigInternals.getOutputCodecOrUndefined();
-	const concurrency = RenderInternals.getActualConcurrency(
+	const concurrency = RenderInternals.resolveConcurrency(
 		ConfigInternals.getConcurrency(),
 	);
 	const pixelFormat = ConfigInternals.getPixelFormat();

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -290,9 +290,9 @@ export const renderVideoFlow = async ({
 	const puppeteerInstance = await browserInstance;
 	addCleanupCallback(() => puppeteerInstance.close(false, logLevel, indent));
 
-	const actualConcurrency = RenderInternals.getActualConcurrency(concurrency);
+	const resolvedConcurrency = RenderInternals.resolveConcurrency(concurrency);
 	const server = await RenderInternals.prepareServer({
-		concurrency: actualConcurrency,
+		concurrency: resolvedConcurrency,
 		indent,
 		port,
 		remotionRoot,
@@ -406,7 +406,7 @@ export const renderVideoFlow = async ({
 		logLevel,
 		left: 'Concurrency',
 		link: 'https://www.remotion.dev/docs/terminology/concurrency',
-		right: `${actualConcurrency}x`,
+		right: `${resolvedConcurrency}x`,
 		color: 'gray',
 	});
 
@@ -479,7 +479,7 @@ export const renderVideoFlow = async ({
 			everyNthFrame,
 			envVariables,
 			frameRange,
-			concurrency: actualConcurrency,
+			concurrency: resolvedConcurrency,
 			puppeteerInstance,
 			jpegQuality: jpegQuality ?? RenderInternals.DEFAULT_JPEG_QUALITY,
 			timeoutInMilliseconds: puppeteerTimeout,

--- a/packages/docs/docs/renderer/render-frames.mdx
+++ b/packages/docs/docs/renderer/render-frames.mdx
@@ -2,10 +2,10 @@
 image: /generated/articles-docs-renderer-render-frames.png
 id: render-frames
 title: renderFrames()
-crumb: "@remotion/renderer"
+crumb: '@remotion/renderer'
 ---
 
-import { AngleChangelog } from "../../components/AngleChangelog";
+import {AngleChangelog} from '../../components/AngleChangelog';
 
 _Part of the `@remotion/renderer` package._
 
@@ -34,11 +34,23 @@ Call [`selectComposition()`](/docs/renderer/select-composition) or [`getComposit
 
 ### `onStart`
 
-A callback that fires after the setup process (validation, browser launch) has finished. Example value
+Callback function that gets called once the renderer has prepared to start rendering and has calculated the amount of frames that are going to be rendered:
 
-```ts twoslash
-const onStart = () => {
-  console.log("Starting rendering...");
+```tsx twoslash
+import {OnStartData} from '@remotion/renderer';
+
+const onStart = ({
+  frameCount,
+  parallelEncoding, // available from v4.0.52
+  resolvedConcurrency, // available from v4.0.180
+}: OnStartData) => {
+  console.log(`Beginning to render ${frameCount}.`);
+
+  if (parallelEncoding) {
+    console.log('Parallel encoding is enabled.');
+  }
+
+  console.log(`Using concurrency: ${resolvedConcurrency}`);
 };
 ```
 
@@ -178,25 +190,25 @@ type BrowserLog = {
   text: string;
   stackTrace: ConsoleMessageLocation[];
   type:
-    | "log"
-    | "debug"
-    | "info"
-    | "error"
-    | "warning"
-    | "dir"
-    | "dirxml"
-    | "table"
-    | "trace"
-    | "clear"
-    | "startGroup"
-    | "startGroupCollapsed"
-    | "endGroup"
-    | "assert"
-    | "profile"
-    | "profileEnd"
-    | "count"
-    | "timeEnd"
-    | "verbose";
+    | 'log'
+    | 'debug'
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'dir'
+    | 'dirxml'
+    | 'table'
+    | 'trace'
+    | 'clear'
+    | 'startGroup'
+    | 'startGroupCollapsed'
+    | 'endGroup'
+    | 'assert'
+    | 'profile'
+    | 'profileEnd'
+    | 'count'
+    | 'timeEnd'
+    | 'verbose';
 };
 
 const renderFrames = (options: {
@@ -211,7 +223,7 @@ renderFrames({
         .map((stack) => {
           return `  ${stack.url}:${stack.lineNumber}:${stack.columnNumber}`;
         })
-        .join("\n"),
+        .join('\n'),
     );
   },
 });

--- a/packages/docs/docs/renderer/render-media.mdx
+++ b/packages/docs/docs/renderer/render-media.mdx
@@ -2,7 +2,7 @@
 image: /generated/articles-docs-renderer-render-media.png
 id: render-media
 title: renderMedia()
-crumb: "@remotion/renderer"
+crumb: '@remotion/renderer'
 ---
 
 _Available since v3.0 - Part of the `@remotion/renderer` package._
@@ -12,18 +12,18 @@ Render a video or an audio programmatically.
 ```tsx twoslash title="render.mjs"
 // @module: esnext
 // @target: es2017
-const serveUrl = "/path/to/bundle";
-const outputLocation = "/path/to/frames";
+const serveUrl = '/path/to/bundle';
+const outputLocation = '/path/to/frames';
 
-import { renderMedia, selectComposition } from "@remotion/renderer";
+import {renderMedia, selectComposition} from '@remotion/renderer';
 
 const inputProps = {
-  titleText: "Hello World",
+  titleText: 'Hello World',
 };
 
 const composition = await selectComposition({
   serveUrl,
-  id: "my-video",
+  id: 'my-video',
   inputProps,
 });
 
@@ -32,7 +32,7 @@ const composition = await selectComposition({
 await renderMedia({
   composition,
   serveUrl,
-  codec: "h264",
+  codec: 'h264',
   outputLocation,
   inputProps,
 });
@@ -228,14 +228,20 @@ _function_ - optional
 Callback function that gets called once the renderer has prepared to start rendering and has calculated the amount of frames that are going to be rendered:
 
 ```tsx twoslash
-import { OnStartData } from "@remotion/renderer";
+import {OnStartData} from '@remotion/renderer';
 
-const onStart = ({ frameCount, parallelEncoding }: OnStartData) => {
+const onStart = ({
+  frameCount,
+  parallelEncoding, // available from v4.0.52
+  resolvedConcurrency, // available from v4.0.180
+}: OnStartData) => {
   console.log(`Beginning to render ${frameCount}.`);
-  // From Remotion v4.0.52
+
   if (parallelEncoding) {
-    console.log("Parallel encoding is enabled.");
+    console.log('Parallel encoding is enabled.');
   }
+
+  console.log(`Using concurrency: ${resolvedConcurrency}`);
 };
 ```
 
@@ -246,15 +252,15 @@ _function - optional_
 React to render progress. The following callback function is similar to how Remotion displays render progress on it's CLI:
 
 ```tsx twoslash title="Simple example - Log overall progress"
-import { RenderMediaOnProgress } from "@remotion/renderer";
+import {RenderMediaOnProgress} from '@remotion/renderer';
 
-const onProgress: RenderMediaOnProgress = ({ progress }) => {
+const onProgress: RenderMediaOnProgress = ({progress}) => {
   console.log(`Rendering is ${progress * 100}% complete`);
 };
 ```
 
 ```tsx twoslash title="Advanced example - Fine-grained progress values"
-import { RenderMediaOnProgress } from "@remotion/renderer";
+import {RenderMediaOnProgress} from '@remotion/renderer';
 
 const onProgress: RenderMediaOnProgress = ({
   renderedFrames,
@@ -263,12 +269,12 @@ const onProgress: RenderMediaOnProgress = ({
   renderedDoneIn,
   stitchStage,
 }) => {
-  if (stitchStage === "encoding") {
+  if (stitchStage === 'encoding') {
     // First pass, parallel rendering of frames and encoding into video
-    console.log("Encoding...");
-  } else if (stitchStage === "muxing") {
+    console.log('Encoding...');
+  } else if (stitchStage === 'muxing') {
     // Second pass, adding audio to the video
-    console.log("Muxing audio...");
+    console.log('Muxing audio...');
   }
   // Amount of frames rendered into images
   console.log(`${renderedFrames} rendered`);
@@ -296,11 +302,11 @@ _function - optional_
 If an audio (or a video with sound) is included in your project, Remotion needs to download it in order to use it's audio in the output file. You can use this callback to react to a download happening and progressing.
 
 ```tsx twoslash
-import { RenderMediaOnDownload } from "@remotion/renderer";
+import {RenderMediaOnDownload} from '@remotion/renderer';
 
 const onDownload: RenderMediaOnDownload = (src) => {
   console.log(`Downloading ${src}...`);
-  return ({ percent, downloaded, totalSize }) => {
+  return ({percent, downloaded, totalSize}) => {
     // percent and totalSize can be `null` if the downloaded resource
     // does not have a `Content-Length` header
     if (percent === null) {
@@ -331,7 +337,7 @@ _function - optional_
 Catch a console message being printed. Example:
 
 ```tsx twoslash
-import { BrowserLog } from "@remotion/renderer";
+import {BrowserLog} from '@remotion/renderer';
 
 const onBrowserLog = (log: BrowserLog) => {
   // `type` is the console.* method: `log`, `warn`, `error`, etc.
@@ -400,11 +406,11 @@ _function - optional_
 Modifies the FFMPEG command that Remotion uses under the hood. It works reducer-style, meaning that you pass a function that takes a command as an argument and returns a new command.
 
 ```tsx twoslash
-import type { FfmpegOverrideFn } from "@remotion/renderer";
+import type {FfmpegOverrideFn} from '@remotion/renderer';
 
-const ffmpegOverride: FfmpegOverrideFn = ({ type, args }) => {
+const ffmpegOverride: FfmpegOverrideFn = ({type, args}) => {
   console.log(type); // "stitcher" | "pre-stitcher
-  return [...args, "-vf", "eq=brightness=0:saturation=1"];
+  return [...args, '-vf', 'eq=brightness=0:saturation=1'];
 };
 ```
 

--- a/packages/renderer/src/compositor/compositor.ts
+++ b/packages/renderer/src/compositor/compositor.ts
@@ -1,6 +1,6 @@
 import {spawn} from 'node:child_process';
 import path from 'node:path';
-import {getActualConcurrency} from '../get-concurrency';
+import {resolveConcurrency} from '../get-concurrency';
 import type {LogLevel} from '../log-level';
 import {isEqualOrBelowLogLevel} from '../log-level';
 import {Log} from '../logger';
@@ -44,7 +44,7 @@ export const startLongRunningCompositor = ({
 	return startCompositor({
 		type: 'StartLongRunningProcess',
 		payload: {
-			concurrency: getActualConcurrency(null),
+			concurrency: resolveConcurrency(null),
 			maximum_frame_cache_size_in_bytes: maximumFrameCacheItemsInBytes,
 			verbose: isEqualOrBelowLogLevel(logLevel, 'verbose'),
 		},

--- a/packages/renderer/src/get-concurrency.ts
+++ b/packages/renderer/src/get-concurrency.ts
@@ -1,8 +1,6 @@
 import {getCpuCount} from './get-cpu-count';
 
-export const getActualConcurrency = (
-	userPreference: number | string | null,
-) => {
+export const resolveConcurrency = (userPreference: number | string | null) => {
 	const maxCpus = getCpuCount();
 
 	if (userPreference === null) {

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -21,7 +21,7 @@ import {defaultFileExtensionMap} from './file-extensions';
 import {findRemotionRoot} from './find-closest-package-json';
 import {validateFrameRange} from './frame-range';
 import {internalGetCompositions} from './get-compositions';
-import {getActualConcurrency} from './get-concurrency';
+import {resolveConcurrency} from './get-concurrency';
 import {getFramesToRender} from './get-duration-from-frame-range';
 
 import {
@@ -155,7 +155,7 @@ import {
 } from './wait-for-symbolication-error-to-be-done';
 
 export const RenderInternals = {
-	getActualConcurrency,
+	resolveConcurrency,
 	serveStatic,
 	validateEvenDimensionsWithCodec,
 	getFileExtensionFromCodec,

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -20,7 +20,7 @@ import {ensureOutputDirectory} from './ensure-output-directory';
 import type {FfmpegOverrideFn} from './ffmpeg-override';
 import {findRemotionRoot} from './find-closest-package-json';
 import type {FrameRange} from './frame-range';
-import {getActualConcurrency} from './get-concurrency';
+import {resolveConcurrency} from './get-concurrency';
 import {getFramesToRender} from './get-duration-from-frame-range';
 import {getFileExtensionFromCodec} from './get-extension-from-codec';
 import {getExtensionOfFilename} from './get-extension-of-filename';
@@ -336,7 +336,7 @@ const internalRenderMediaRaw = ({
 		'Estimated usage parallel encoding',
 		estimatedUsage,
 	);
-	const actualConcurrency = getActualConcurrency(concurrency);
+	const resolvedConcurrency = resolveConcurrency(concurrency);
 	Log.verbose(
 		{
 			indent,
@@ -344,7 +344,7 @@ const internalRenderMediaRaw = ({
 			tag: 'renderMedia()',
 		},
 		'Using concurrency:',
-		actualConcurrency,
+		resolvedConcurrency,
 	);
 	Log.verbose(
 		{
@@ -551,7 +551,7 @@ const internalRenderMediaRaw = ({
 				return makeOrReuseServer(
 					reusedServer,
 					{
-						concurrency: actualConcurrency,
+						concurrency: resolvedConcurrency,
 						indent,
 						port,
 						remotionRoot: findRemotionRoot(),

--- a/packages/renderer/src/test/actual-concurrency.test.ts
+++ b/packages/renderer/src/test/actual-concurrency.test.ts
@@ -1,29 +1,29 @@
 import {expect, test} from 'bun:test';
-import {getActualConcurrency} from '../get-concurrency';
+import {resolveConcurrency} from '../get-concurrency';
 import {getCpuCount} from '../get-cpu-count';
 
 test('Actual concurrency null should choose a good result', () => {
-	expect(getActualConcurrency(null)).toBe(
+	expect(resolveConcurrency(null)).toBe(
 		Math.round(Math.min(8, Math.max(1, (getCpuCount() as number) / 2))),
 	);
 });
 
 test('50% should yield half the cores', () => {
-	expect(getActualConcurrency('50%')).toBe(
+	expect(resolveConcurrency('50%')).toBe(
 		Math.floor(Math.min(8, Math.max(1, (getCpuCount() as number) / 2))),
 	);
 });
 
 test('75% should be 3/4 of the cores', () => {
-	expect(getActualConcurrency('75%')).toBe(
+	expect(resolveConcurrency('75%')).toBe(
 		Math.floor((getCpuCount() as number) * 0.75),
 	);
 });
 
 test('Slightly over 100% is ok as long as it is rounded', () => {
-	expect(getActualConcurrency('100.2%')).toBe(getCpuCount() as number);
+	expect(resolveConcurrency('100.2%')).toBe(getCpuCount() as number);
 });
 
 test('Should also accept integers', () => {
-	expect(getActualConcurrency(1)).toBe(1);
+	expect(resolveConcurrency(1)).toBe(1);
 });

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -8,4 +8,5 @@ export type RenderFramesOutput = {
 export type OnStartData = {
 	frameCount: number;
 	parallelEncoding: boolean;
+	resolvedConcurrency: number;
 };


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
