### PR TITLE
feat: add warning when override specified more than once

### DIFF
--- a/packages/cli/src/config/override-webpack.ts
+++ b/packages/cli/src/config/override-webpack.ts
@@ -12,15 +12,15 @@ export const getWebpackOverrideFn = () => {
 	return overrideFn;
 };
 
-//to warn the user if overrideWebpackConfig is invoked more than once
+//	to warn the user if overrideWebpackConfig is invoked more than once
 let invocations = 0;
-let warned = false
 
 export const overrideWebpackConfig = (fn: WebpackOverrideFn) => {
-	if(invocations > 0 && !warned){
-		console.error('You specified the overrideWebpackConfig() multiple times which is incorrect, in such a case, only the function passed in the latest override will be considered. If you want to call more than one functions, pass a single function and then call other functions from inside. Read More: https://www.remotion.dev/docs/config#overridewebpackconfig   https://github.com/remotion-dev/remotion/issues/4063  \n')
-		warned = true
+	if(invocations > 0){
+		throw new Error('You specified the overrideWebpackConfig() multiple times which is incorrect, in such a case, only the function passed in the latest override will be considered. If you want to call more than one functions, pass a single function and then call other functions from inside. Read More: https://www.remotion.dev/docs/config#overridewebpackconfig   https://github.com/remotion-dev/remotion/issues/4063  \n')
+	
 	}
+	
 	invocations++
 	overrideFn = fn;
 };

--- a/packages/cli/src/config/override-webpack.ts
+++ b/packages/cli/src/config/override-webpack.ts
@@ -4,6 +4,7 @@ export type WebpackOverrideFn = (
 	currentConfiguration: WebpackConfiguration,
 ) => WebpackConfiguration | Promise<WebpackConfiguration>;
 
+
 export const defaultOverrideFunction: WebpackOverrideFn = (config) => config;
 let overrideFn: WebpackOverrideFn = defaultOverrideFunction;
 
@@ -11,6 +12,15 @@ export const getWebpackOverrideFn = () => {
 	return overrideFn;
 };
 
+//to warn the user if overrideWebpackConfig is invoked more than once
+let invocations = 0;
+let warned = false
+
 export const overrideWebpackConfig = (fn: WebpackOverrideFn) => {
+	if(invocations > 0 && !warned){
+		console.error('You specified the overrideWebpackConfig() multiple times which is incorrect, in such a case, only the function passed in the latest override will be considered. If you want to call more than one functions, pass a single function and then call other functions from inside. Read More: https://www.remotion.dev/docs/config#overridewebpackconfig   https://github.com/remotion-dev/remotion/issues/4063  \n')
+		warned = true
+	}
+	invocations++
 	overrideFn = fn;
 };

--- a/packages/cli/src/config/override-webpack.ts
+++ b/packages/cli/src/config/override-webpack.ts
@@ -4,7 +4,6 @@ export type WebpackOverrideFn = (
 	currentConfiguration: WebpackConfiguration,
 ) => WebpackConfiguration | Promise<WebpackConfiguration>;
 
-
 export const defaultOverrideFunction: WebpackOverrideFn = (config) => config;
 let overrideFn: WebpackOverrideFn = defaultOverrideFunction;
 
@@ -16,11 +15,12 @@ export const getWebpackOverrideFn = () => {
 let invocations = 0;
 
 export const overrideWebpackConfig = (fn: WebpackOverrideFn) => {
-	if(invocations > 0){
-		throw new Error('You specified the overrideWebpackConfig() multiple times which is incorrect, in such a case, only the function passed in the latest override will be considered. If you want to call more than one functions, pass a single function and then call other functions from inside. Read More: https://www.remotion.dev/docs/config#overridewebpackconfig   https://github.com/remotion-dev/remotion/issues/4063  \n')
-	
+	if (invocations > 0) {
+		throw new Error(
+			'You specified the overrideWebpackConfig() multiple times which is incorrect, in such a case, only the function passed in the latest override will be considered. If you want to call more than one functions, pass a single function and then call other functions from inside. Read More: https://www.remotion.dev/docs/config#overridewebpackconfig   https://github.com/remotion-dev/remotion/issues/4063  \n',
+		);
 	}
-	
-	invocations++
+
+	invocations++;
 	overrideFn = fn;
 };

--- a/packages/cli/src/config/override-webpack.ts
+++ b/packages/cli/src/config/override-webpack.ts
@@ -16,9 +16,29 @@ let invocations = 0;
 
 export const overrideWebpackConfig = (fn: WebpackOverrideFn) => {
 	if (invocations > 0) {
-		throw new Error(
-			'You specified the overrideWebpackConfig() multiple times which is incorrect, in such a case, only the function passed in the latest override will be considered. If you want to call more than one functions, pass a single function and then call other functions from inside. Read More: https://www.remotion.dev/docs/config#overridewebpackconfig   https://github.com/remotion-dev/remotion/issues/4063  \n',
-		);
+		const err = [
+			'You specified the Config.overrideWebpackConfig() multiple times, which is not supported.',
+			'Combine all Webpack overrides into a single one.',
+			'You can curry multiple overrides:',
+			'',
+			'Instead of:',
+			'',
+			'  Config.overrideWebpackConfig((currentConfiguration) => {',
+			'    return enableScss(currentConfiguration);',
+			'  });',
+			'  Config.overrideWebpackConfig((currentConfiguration) => {',
+			'    return enableTailwind(currentConfiguration);',
+			'  });',
+			'',
+			'Do this:',
+			'',
+			'  Config.overrideWebpackConfig((currentConfiguration) => {',
+			'    return enableScss(enableTailwind(currentConfiguration));',
+			'  });',
+			'',
+			'Read more: https://www.remotion.dev/docs/config#overridewebpackconfig',
+		];
+		throw new Error(err.join('\n'));
 	}
 
 	invocations++;


### PR DESCRIPTION
/claim #4063 
fixes #4063 
added the code to check if `overrideWebpackConfig` is specified multiple times, and give a suitable error message with links the docs and the issue.

[Screencast from 10-07-2024 23:05:18.webm](https://github.com/remotion-dev/remotion/assets/89797440/2dc62295-16b7-43c9-ab74-8ff812b1bc3b)

