### PR TITLE
`@remotion/rive`:  Bump Rive to `2.19.3` and add new `assetLoader` prop

### DIFF
--- a/packages/docs/docs/rive/remotionrivecanvas.mdx
+++ b/packages/docs/docs/rive/remotionrivecanvas.mdx
@@ -45,6 +45,19 @@ Either a `string` specifying the animation name, a `number` specifying the anima
 
 A callback function that will be executed when the Rive Runtime is loaded. The argument callback is an object of type Rive `File`
 
+### `enableRiveAssetCdn?`<AvailableFrom v="4.0.181" />
+
+Whether to enable the Rive Asset CDN. Default is `true`.
+
+### `assetLoader?`<AvailableFrom v="4.0.181" />
+
+A custom asset loader. See [here](https://rive.app/community/doc/loading-assets/doct4wVHGPgC#handling-assets) for more information.
+
+:::note
+Memoize the assetLoader function using `useCallback`.  
+You can type the function using `FileAssetLoader` from `@remotion/rive` (re-exported from `@rive-app/canvas-advanced`).
+:::
+
 ## Ref<AvailableFrom v="4.0.180" />
 
 You can attach a ref to the component to access the Rive Canvas instance.

--- a/packages/rive/package.json
+++ b/packages/rive/package.json
@@ -20,7 +20,7 @@
 	"author": "Caleb Ojo, Jonny Burger",
 	"license": "See LICENSE.md",
 	"dependencies": {
-		"@rive-app/canvas-advanced": "2.3.0",
+		"@rive-app/canvas-advanced": "2.19.3",
 		"remotion": "workspace:*"
 	},
 	"peerDependencies": {

--- a/packages/rive/src/index.ts
+++ b/packages/rive/src/index.ts
@@ -1,1 +1,2 @@
+export type {FileAssetLoader} from '@rive-app/canvas-advanced';
 export {RemotionRiveCanvas, RiveCanvasRef} from './RemotionRiveCanvas.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1291,8 +1291,8 @@ importers:
   packages/rive:
     dependencies:
       '@rive-app/canvas-advanced':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.19.3
+        version: 2.19.3
       remotion:
         specifier: workspace:*
         version: link:../core
@@ -8116,6 +8116,10 @@ packages:
       suspend-react: 0.1.3(react@18.3.1)
       three: 0.158.0
       zustand: 3.7.2(react@18.3.1)
+
+  /@rive-app/canvas-advanced@2.19.3:
+    resolution: {integrity: sha512-AcUsPH8ve7pV6QABN0ekwSpIJN0Fudjp+bqYxFUwbtXnE2wvoA0d2yzAtJeVwNQtFKboyfHovNgPIQ9tEdB4VA==}
+    dev: false
 
   /@rive-app/canvas-advanced@2.3.0:
     resolution: {integrity: sha512-JzgY8aSvWbuigoJ+8x1lHW8or0syQz8hxpRdPijkCCp/GJYRPvBstYdJPbHk2nbv5+BV+8Rv4zRw96wKFVsvKQ==}


### PR DESCRIPTION
Fixes #4081
