### PR TITLE
`@remotion/google-fonts`: Eliminate loading race condition

### DIFF
--- a/packages/google-fonts/src/base.ts
+++ b/packages/google-fonts/src/base.ts
@@ -1,14 +1,14 @@
-import type {} from "css-font-loading-module";
-import { continueRender, delayRender } from "remotion";
+import {continueRender, delayRender} from 'remotion';
 
-const loadedFonts: { [key: string]: boolean } = {};
+const loadedFonts: Record<string, Promise<void> | undefined> = {};
+
 export type FontInfo = {
-  fontFamily: string;
-  importName: string;
-  version: string;
-  url: string;
-  unicodeRanges: Record<string, string>;
-  fonts: Record<string, Record<string, Record<string, string>>>;
+	fontFamily: string;
+	importName: string;
+	version: string;
+	url: string;
+	unicodeRanges: Record<string, string>;
+	fonts: Record<string, Record<string, Record<string, string>>>;
 };
 
 /**
@@ -20,102 +20,104 @@ export type FontInfo = {
  * @see [Documentation](https://www.remotion.dev/docs/google-fonts/load-font)
  */
 export const loadFonts = (
-  meta: FontInfo,
-  style?: string,
-  options?: {
-    weights?: string[];
-    subsets?: string[];
-    document?: Document;
-  }
+	meta: FontInfo,
+	style?: string,
+	options?: {
+		weights?: string[];
+		subsets?: string[];
+		document?: Document;
+	},
 ): {
-  fontFamily: FontInfo["fontFamily"];
-  fonts: FontInfo["fonts"];
-  unicodeRanges: FontInfo["unicodeRanges"];
-  waitUntilDone: () => Promise<undefined>;
+	fontFamily: FontInfo['fontFamily'];
+	fonts: FontInfo['fonts'];
+	unicodeRanges: FontInfo['unicodeRanges'];
+	waitUntilDone: () => Promise<undefined>;
 } => {
-  const promises: Promise<void>[] = [];
-  const styles = style ? [style] : Object.keys(meta.fonts);
-  for (const style of styles) {
-    // Don't load fonts on server
-    if (typeof FontFace === "undefined") {
-      continue;
-    }
+	const promises: Promise<void>[] = [];
+	const styles = style ? [style] : Object.keys(meta.fonts);
+	for (const style of styles) {
+		// Don't load fonts on server
+		if (typeof FontFace === 'undefined') {
+			continue;
+		}
 
-    if (!meta.fonts[style]) {
-      throw new Error(
-        `The font ${meta.fontFamily} does not have a style ${style}`
-      );
-    }
-    const weights = options?.weights ?? Object.keys(meta.fonts[style]);
-    for (const weight of weights) {
-      if (!meta.fonts[style][weight]) {
-        throw new Error(
-          `The font ${meta.fontFamily} does not  have a weight ${weight} in style ${style}`
-        );
-      }
-      const subsets =
-        options?.subsets ?? Object.keys(meta.fonts[style][weight]);
-      for (const subset of subsets) {
-        //  Get font url from meta
-        let font = meta.fonts[style]?.[weight]?.[subset];
+		if (!meta.fonts[style]) {
+			throw new Error(
+				`The font ${meta.fontFamily} does not have a style ${style}`,
+			);
+		}
+		const weights = options?.weights ?? Object.keys(meta.fonts[style]);
+		for (const weight of weights) {
+			if (!meta.fonts[style][weight]) {
+				throw new Error(
+					`The font ${meta.fontFamily} does not  have a weight ${weight} in style ${style}`,
+				);
+			}
+			const subsets =
+				options?.subsets ?? Object.keys(meta.fonts[style][weight]);
+			for (const subset of subsets) {
+				//  Get font url from meta
+				let font = meta.fonts[style]?.[weight]?.[subset];
 
-        //  Check is font available in meta
-        if (!font) {
-          throw new Error(
-            `weight: ${weight} subset: ${subset} is not available for '${meta.fontFamily}'`
-          );
-        }
+				//  Check is font available in meta
+				if (!font) {
+					throw new Error(
+						`weight: ${weight} subset: ${subset} is not available for '${meta.fontFamily}'`,
+					);
+				}
 
-        //  Check is font already loaded
-        let fontKey = `${meta.fontFamily}-${style}-${weight}-${subset}`;
-        if (loadedFonts[fontKey]) {
-          continue;
-        }
+				//  Check is font already loaded
+				let fontKey = `${meta.fontFamily}-${style}-${weight}-${subset}`;
+				const previousPromise = loadedFonts[fontKey];
+				if (previousPromise) {
+					promises.push(previousPromise);
+					continue;
+				}
 
-        //  Mark font as loaded
-        loadedFonts[fontKey] = true;
+				const handle = delayRender(
+					`Fetching ${meta.fontFamily} font ${JSON.stringify({
+						style,
+						weight,
+						subset,
+					})}`,
+				);
 
-        const handle = delayRender(
-          `Fetching ${meta.fontFamily} font ${JSON.stringify({
-            style,
-            weight,
-            subset,
-          })}`
-        );
+				//  Create font-face
+				const fontFace = new FontFace(
+					meta.fontFamily,
+					`url(${font}) format('woff2')`,
+					{
+						weight: weight,
+						style: style,
+						unicodeRange: meta.unicodeRanges[subset],
+					},
+				);
 
-        //  Create font-face
-        const fontFace = new FontFace(
-          meta.fontFamily,
-          `url(${font}) format('woff2')`,
-          {
-            weight: weight,
-            style: style,
-            unicodeRange: meta.unicodeRanges[subset],
-          }
-        );
+				//  Load font-face
+				const promise = fontFace
+					.load()
+					.then(() => {
+						(options?.document ?? document).fonts.add(fontFace);
+						continueRender(handle);
+					})
+					.catch((err) => {
+						//  Mark font as not loaded
+						loadedFonts[fontKey] = undefined;
+						throw err;
+					});
 
-        //  Load font-face
-        const promise = fontFace
-          .load()
-          .then(() => {
-            (options?.document ?? document).fonts.add(fontFace);
-            continueRender(handle);
-          })
-          .catch((err) => {
-            //  Mark font as not loaded
-            loadedFonts[fontKey] = false;
-            throw err;
-          });
+				//  Mark font as loaded
+				loadedFonts[fontKey] = promise;
 
-        promises.push(promise);
-      }
-    }
-  }
+				promises.push(promise);
+			}
+		}
+	}
 
-  return {
-    fontFamily: meta.fontFamily,
-    fonts: meta.fonts,
-    unicodeRanges: meta.unicodeRanges,
-    waitUntilDone: () => Promise.all<void>(promises).then(() => undefined),
-  };
+	return {
+		fontFamily: meta.fontFamily,
+		fonts: meta.fonts,
+		unicodeRanges: meta.unicodeRanges,
+		waitUntilDone: () => Promise.all<void>(promises).then(() => undefined),
+	};
 };

--- a/packages/google-fonts/src/base.ts
+++ b/packages/google-fonts/src/base.ts
@@ -3,12 +3,12 @@ import {continueRender, delayRender} from 'remotion';
 const loadedFonts: Record<string, Promise<void> | undefined> = {};
 
 export type FontInfo = {
-	fontFamily: string;
-	importName: string;
-	version: string;
-	url: string;
-	unicodeRanges: Record<string, string>;
-	fonts: Record<string, Record<string, Record<string, string>>>;
+  fontFamily: string;
+  importName: string;
+  version: string;
+  url: string;
+  unicodeRanges: Record<string, string>;
+  fonts: Record<string, Record<string, Record<string, string>>>;
 };
 
 /**
@@ -20,104 +20,104 @@ export type FontInfo = {
  * @see [Documentation](https://www.remotion.dev/docs/google-fonts/load-font)
  */
 export const loadFonts = (
-	meta: FontInfo,
-	style?: string,
-	options?: {
-		weights?: string[];
-		subsets?: string[];
-		document?: Document;
-	},
+  meta: FontInfo,
+  style?: string,
+  options?: {
+    weights?: string[];
+    subsets?: string[];
+    document?: Document;
+  },
 ): {
-	fontFamily: FontInfo['fontFamily'];
-	fonts: FontInfo['fonts'];
-	unicodeRanges: FontInfo['unicodeRanges'];
-	waitUntilDone: () => Promise<undefined>;
+  fontFamily: FontInfo['fontFamily'];
+  fonts: FontInfo['fonts'];
+  unicodeRanges: FontInfo['unicodeRanges'];
+  waitUntilDone: () => Promise<undefined>;
 } => {
-	const promises: Promise<void>[] = [];
-	const styles = style ? [style] : Object.keys(meta.fonts);
-	for (const style of styles) {
-		// Don't load fonts on server
-		if (typeof FontFace === 'undefined') {
-			continue;
-		}
+  const promises: Promise<void>[] = [];
+  const styles = style ? [style] : Object.keys(meta.fonts);
+  for (const style of styles) {
+    // Don't load fonts on server
+    if (typeof FontFace === 'undefined') {
+      continue;
+    }
 
-		if (!meta.fonts[style]) {
-			throw new Error(
-				`The font ${meta.fontFamily} does not have a style ${style}`,
-			);
-		}
-		const weights = options?.weights ?? Object.keys(meta.fonts[style]);
-		for (const weight of weights) {
-			if (!meta.fonts[style][weight]) {
-				throw new Error(
-					`The font ${meta.fontFamily} does not  have a weight ${weight} in style ${style}`,
-				);
-			}
-			const subsets =
-				options?.subsets ?? Object.keys(meta.fonts[style][weight]);
-			for (const subset of subsets) {
-				//  Get font url from meta
-				let font = meta.fonts[style]?.[weight]?.[subset];
+    if (!meta.fonts[style]) {
+      throw new Error(
+        `The font ${meta.fontFamily} does not have a style ${style}`,
+      );
+    }
+    const weights = options?.weights ?? Object.keys(meta.fonts[style]);
+    for (const weight of weights) {
+      if (!meta.fonts[style][weight]) {
+        throw new Error(
+          `The font ${meta.fontFamily} does not  have a weight ${weight} in style ${style}`,
+        );
+      }
+      const subsets =
+        options?.subsets ?? Object.keys(meta.fonts[style][weight]);
+      for (const subset of subsets) {
+        //  Get font url from meta
+        let font = meta.fonts[style]?.[weight]?.[subset];
 
-				//  Check is font available in meta
-				if (!font) {
-					throw new Error(
-						`weight: ${weight} subset: ${subset} is not available for '${meta.fontFamily}'`,
-					);
-				}
+        //  Check is font available in meta
+        if (!font) {
+          throw new Error(
+            `weight: ${weight} subset: ${subset} is not available for '${meta.fontFamily}'`,
+          );
+        }
 
-				//  Check is font already loaded
-				let fontKey = `${meta.fontFamily}-${style}-${weight}-${subset}`;
-				const previousPromise = loadedFonts[fontKey];
-				if (previousPromise) {
-					promises.push(previousPromise);
-					continue;
-				}
+        //  Check is font already loaded
+        let fontKey = `${meta.fontFamily}-${style}-${weight}-${subset}`;
+        const previousPromise = loadedFonts[fontKey];
+        if (previousPromise) {
+          promises.push(previousPromise);
+          continue;
+        }
 
-				const handle = delayRender(
-					`Fetching ${meta.fontFamily} font ${JSON.stringify({
-						style,
-						weight,
-						subset,
-					})}`,
-				);
+        const handle = delayRender(
+          `Fetching ${meta.fontFamily} font ${JSON.stringify({
+            style,
+            weight,
+            subset,
+          })}`,
+        );
 
-				//  Create font-face
-				const fontFace = new FontFace(
-					meta.fontFamily,
-					`url(${font}) format('woff2')`,
-					{
-						weight: weight,
-						style: style,
-						unicodeRange: meta.unicodeRanges[subset],
-					},
-				);
+        //  Create font-face
+        const fontFace = new FontFace(
+          meta.fontFamily,
+          `url(${font}) format('woff2')`,
+          {
+            weight: weight,
+            style: style,
+            unicodeRange: meta.unicodeRanges[subset],
+          },
+        );
 
-				//  Load font-face
-				const promise = fontFace
-					.load()
-					.then(() => {
-						(options?.document ?? document).fonts.add(fontFace);
-						continueRender(handle);
-					})
-					.catch((err) => {
-						//  Mark font as not loaded
-						loadedFonts[fontKey] = undefined;
-						throw err;
-					});
+        //  Load font-face
+        const promise = fontFace
+          .load()
+          .then(() => {
+            (options?.document ?? document).fonts.add(fontFace);
+            continueRender(handle);
+          })
+          .catch((err) => {
+            //  Mark font as not loaded
+            loadedFonts[fontKey] = undefined;
+            throw err;
+          });
 
-				//  Mark font as loaded
-				loadedFonts[fontKey] = promise;
+        //  Mark font as loaded
+        loadedFonts[fontKey] = promise;
 
-				promises.push(promise);
-			}
-		}
-	}
+        promises.push(promise);
+      }
+    }
+  }
 
-	return {
-		fontFamily: meta.fontFamily,
-		fonts: meta.fonts,
-		unicodeRanges: meta.unicodeRanges,
-		waitUntilDone: () => Promise.all<void>(promises).then(() => undefined),
-	};
+  return {
+    fontFamily: meta.fontFamily,
+    fonts: meta.fonts,
+    unicodeRanges: meta.unicodeRanges,
+    waitUntilDone: () => Promise.all<void>(promises).then(() => undefined),
+  };
 };


### PR DESCRIPTION
If loadFont() is called multiple times, the second invocation resolves waitUntilReady() too early.

This is a problem in React Strict Mode, because one might set a `fontLoaded` flag to true on any of the two calls.