### PR TITLE
`remotion`: Allow to handle error in `<OffthreadVideo>` using the `onError` props

### DIFF
--- a/packages/core/src/video/OffthreadVideoForRendering.tsx
+++ b/packages/core/src/video/OffthreadVideoForRendering.tsx
@@ -1,14 +1,22 @@
-import React, {useCallback, useContext, useEffect, useMemo} from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
 import {Img} from '../Img.js';
 import {RenderAssetManager} from '../RenderAssetManager.js';
 import {SequenceContext} from '../SequenceContext.js';
 import {getAbsoluteSrc} from '../absolute-src.js';
 import {
-	useFrameForVolumeProp,
-	useMediaStartsAt,
+  useFrameForVolumeProp,
+  useMediaStartsAt,
 } from '../audio/use-audio-frame.js';
 import {cancelRender} from '../cancel-render.js';
 import {OFFTHREAD_VIDEO_CLASS_NAME} from '../default-css.js';
+import {continueRender, delayRender} from '../delay-render.js';
 import {random} from '../random.js';
 import {useTimelinePosition} from '../timeline-position-state.js';
 import {truthy} from '../truthy.js';
@@ -20,143 +28,205 @@ import {getOffthreadVideoSource} from './offthread-video-source.js';
 import type {OffthreadVideoProps} from './props.js';
 
 export const OffthreadVideoForRendering: React.FC<OffthreadVideoProps> = ({
-	onError,
-	volume: volumeProp,
-	playbackRate,
-	src,
-	muted,
-	allowAmplificationDuringRender,
-	transparent = false,
-	toneMapped = true,
-	toneFrequency,
-	name,
-	loopVolumeCurveBehavior,
-	...props
+  onError,
+  volume: volumeProp,
+  playbackRate,
+  src,
+  muted,
+  allowAmplificationDuringRender,
+  transparent = false,
+  toneMapped = true,
+  toneFrequency,
+  name,
+  loopVolumeCurveBehavior,
+  delayRenderRetries,
+  delayRenderTimeoutInMilliseconds,
+  ...props
 }) => {
-	const absoluteFrame = useTimelinePosition();
+  const absoluteFrame = useTimelinePosition();
 
-	const frame = useCurrentFrame();
-	const volumePropsFrame = useFrameForVolumeProp(
-		loopVolumeCurveBehavior ?? 'repeat',
-	);
-	const videoConfig = useUnsafeVideoConfig();
-	const sequenceContext = useContext(SequenceContext);
-	const mediaStartsAt = useMediaStartsAt();
+  const frame = useCurrentFrame();
+  const volumePropsFrame = useFrameForVolumeProp(
+    loopVolumeCurveBehavior ?? 'repeat',
+  );
+  const videoConfig = useUnsafeVideoConfig();
+  const sequenceContext = useContext(SequenceContext);
+  const mediaStartsAt = useMediaStartsAt();
 
-	const {registerRenderAsset, unregisterRenderAsset} =
-		useContext(RenderAssetManager);
+  const {registerRenderAsset, unregisterRenderAsset} =
+    useContext(RenderAssetManager);
 
-	if (!src) {
-		throw new TypeError('No `src` was passed to <OffthreadVideo>.');
-	}
+  if (!src) {
+    throw new TypeError('No `src` was passed to <OffthreadVideo>.');
+  }
 
-	// Generate a string that's as unique as possible for this asset
-	// but at the same time the same on all threads
-	const id = useMemo(
-		() =>
-			`offthreadvideo-${random(
-				src ?? '',
-			)}-${sequenceContext?.cumulatedFrom}-${sequenceContext?.relativeFrom}-${sequenceContext?.durationInFrames}`,
-		[
-			src,
-			sequenceContext?.cumulatedFrom,
-			sequenceContext?.relativeFrom,
-			sequenceContext?.durationInFrames,
-		],
-	);
+  // Generate a string that's as unique as possible for this asset
+  // but at the same time the same on all threads
+  const id = useMemo(
+    () =>
+      `offthreadvideo-${random(
+        src ?? '',
+      )}-${sequenceContext?.cumulatedFrom}-${sequenceContext?.relativeFrom}-${sequenceContext?.durationInFrames}`,
+    [
+      src,
+      sequenceContext?.cumulatedFrom,
+      sequenceContext?.relativeFrom,
+      sequenceContext?.durationInFrames,
+    ],
+  );
 
-	if (!videoConfig) {
-		throw new Error('No video config found');
-	}
+  if (!videoConfig) {
+    throw new Error('No video config found');
+  }
 
-	const volume = evaluateVolume({
-		volume: volumeProp,
-		frame: volumePropsFrame,
-		mediaVolume: 1,
-		allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
-	});
+  const volume = evaluateVolume({
+    volume: volumeProp,
+    frame: volumePropsFrame,
+    mediaVolume: 1,
+    allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
+  });
 
-	useEffect(() => {
-		if (!src) {
-			throw new Error('No src passed');
-		}
+  useEffect(() => {
+    if (!src) {
+      throw new Error('No src passed');
+    }
 
-		if (!window.remotion_audioEnabled) {
-			return;
-		}
+    if (!window.remotion_audioEnabled) {
+      return;
+    }
 
-		if (muted) {
-			return;
-		}
+    if (muted) {
+      return;
+    }
 
-		if (volume <= 0) {
-			return;
-		}
+    if (volume <= 0) {
+      return;
+    }
 
-		registerRenderAsset({
-			type: 'video',
-			src: getAbsoluteSrc(src),
-			id,
-			frame: absoluteFrame,
-			volume,
-			mediaFrame: frame,
-			playbackRate: playbackRate ?? 1,
-			allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
-			toneFrequency: toneFrequency ?? null,
-			audioStartFrame: Math.max(0, -(sequenceContext?.relativeFrom ?? 0)),
-		});
+    registerRenderAsset({
+      type: 'video',
+      src: getAbsoluteSrc(src),
+      id,
+      frame: absoluteFrame,
+      volume,
+      mediaFrame: frame,
+      playbackRate: playbackRate ?? 1,
+      allowAmplificationDuringRender: allowAmplificationDuringRender ?? false,
+      toneFrequency: toneFrequency ?? null,
+      audioStartFrame: Math.max(0, -(sequenceContext?.relativeFrom ?? 0)),
+    });
 
-		return () => unregisterRenderAsset(id);
-	}, [
-		muted,
-		src,
-		registerRenderAsset,
-		id,
-		unregisterRenderAsset,
-		volume,
-		frame,
-		absoluteFrame,
-		playbackRate,
-		allowAmplificationDuringRender,
-		toneFrequency,
-		sequenceContext?.relativeFrom,
-	]);
+    return () => unregisterRenderAsset(id);
+  }, [
+    muted,
+    src,
+    registerRenderAsset,
+    id,
+    unregisterRenderAsset,
+    volume,
+    frame,
+    absoluteFrame,
+    playbackRate,
+    allowAmplificationDuringRender,
+    toneFrequency,
+    sequenceContext?.relativeFrom,
+  ]);
 
-	const currentTime = useMemo(() => {
-		return (
-			getExpectedMediaFrameUncorrected({
-				frame,
-				playbackRate: playbackRate || 1,
-				startFrom: -mediaStartsAt,
-			}) / videoConfig.fps
-		);
-	}, [frame, mediaStartsAt, playbackRate, videoConfig.fps]);
+  const currentTime = useMemo(() => {
+    return (
+      getExpectedMediaFrameUncorrected({
+        frame,
+        playbackRate: playbackRate || 1,
+        startFrom: -mediaStartsAt,
+      }) / videoConfig.fps
+    );
+  }, [frame, mediaStartsAt, playbackRate, videoConfig.fps]);
 
-	const actualSrc = useMemo(() => {
-		return getOffthreadVideoSource({
-			src,
-			currentTime,
-			transparent,
-			toneMapped,
-		});
-	}, [toneMapped, currentTime, src, transparent]);
+  const actualSrc = useMemo(() => {
+    return getOffthreadVideoSource({
+      src,
+      currentTime,
+      transparent,
+      toneMapped,
+    });
+  }, [toneMapped, currentTime, src, transparent]);
 
-	const onErr: React.ReactEventHandler<HTMLVideoElement | HTMLImageElement> =
-		useCallback(() => {
-			if (onError) {
-				onError?.(new Error('Failed to load image with src ' + actualSrc));
-			} else {
-				cancelRender('Failed to load image with src ' + actualSrc);
-			}
-		}, [actualSrc, onError]);
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
 
-	const className = useMemo(() => {
-		return [OFFTHREAD_VIDEO_CLASS_NAME, props.className]
-			.filter(truthy)
-			.join(' ');
-	}, [props.className]);
+  useLayoutEffect(() => {
+    const cleanup: Function[] = [];
 
-	return (
-		<Img src={actualSrc} className={className} {...props} onError={onErr} />
-	);
+    setImageSrc(null);
+    const controller = new AbortController();
+
+    const newHandle = delayRender('Fetching ' + actualSrc + 'from server', {
+      retries: delayRenderRetries ?? undefined,
+      timeoutInMilliseconds: delayRenderTimeoutInMilliseconds ?? undefined,
+    });
+
+    fetch(actualSrc, {
+      signal: controller.signal,
+    })
+      .then((res) => res.blob())
+      .then((blob) => {
+        const url = URL.createObjectURL(blob);
+        cleanup.push(() => URL.revokeObjectURL(url));
+        setImageSrc(url);
+        continueRender(newHandle);
+      })
+      .catch((err) => {
+        if (onError) {
+          onError(err);
+        } else {
+          cancelRender(err);
+        }
+      });
+
+    cleanup.push(() => {
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      controller.abort();
+    });
+
+    return () => {
+      cleanup.forEach((c) => c());
+    };
+  }, [
+    actualSrc,
+    delayRenderRetries,
+    delayRenderTimeoutInMilliseconds,
+    onError,
+  ]);
+
+  const onErr: React.ReactEventHandler<HTMLVideoElement | HTMLImageElement> =
+    useCallback(() => {
+      if (onError) {
+        onError?.(new Error('Failed to load image with src ' + actualSrc));
+      } else {
+        cancelRender('Failed to load image with src ' + actualSrc);
+      }
+    }, [actualSrc, onError]);
+
+  const className = useMemo(() => {
+    return [OFFTHREAD_VIDEO_CLASS_NAME, props.className]
+      .filter(truthy)
+      .join(' ');
+  }, [props.className]);
+
+  if (!imageSrc) {
+    return null;
+  }
+
+  return (
+    <Img
+      src={imageSrc}
+      className={className}
+      delayRenderRetries={delayRenderRetries}
+      delayRenderTimeoutInMilliseconds={delayRenderTimeoutInMilliseconds}
+      {...props}
+      onError={onErr}
+    />
+  );
 };

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -4,9 +4,9 @@ import {
 	CalculateMetadataFunction,
 	Composition,
 	Folder,
-	Still,
 	getInputProps,
 	staticFile,
+	Still,
 } from 'remotion';
 import {z} from 'zod';
 import {TwentyTwoKHzAudio} from './22KhzAudio';
@@ -34,8 +34,8 @@ import {ManyAudio} from './ManyAudio';
 import {HandleAudioRenderError} from './MediaErrorHandling/HandleAudioRenderError';
 import {MissingImg} from './MissingImg';
 import {
-	OffthreadRemoteVideo,
 	calculateMetadataFn,
+	OffthreadRemoteVideo,
 } from './OffthreadRemoteVideo/OffthreadRemoteVideo';
 import {OrbScene} from './Orb';
 import {ShapesMorph} from './Paths/ShapesMorph';
@@ -49,8 +49,8 @@ import RiveVehicle from './Rive/RiveExample';
 import {ScalePath} from './ScalePath';
 import {
 	ArrayTest,
-	SchemaTest,
 	schemaArrayTestSchema,
+	SchemaTest,
 	schemaTestSchema,
 } from './SchemaTest';
 import {Scripts} from './Scripts';
@@ -76,6 +76,7 @@ import {
 } from './StudioApis/SaveDefaultProps';
 import {TriggerCalculateMetadata} from './StudioApis/TriggerCalculateMetadata';
 import {WriteStaticFile} from './StudioApis/WriteStaticFile';
+import './style.css';
 import {SubtitleArtifact} from './SubtitleArtifact/SubtitleArtifact';
 import {Tailwind} from './Tailwind';
 import {TenFrameTester} from './TenFrameTester';
@@ -93,7 +94,6 @@ import {VideoSpeed} from './VideoSpeed';
 import {VideoTesting} from './VideoTesting';
 import {WarpDemoOuter} from './WarpText';
 import {WarpDemo2} from './WarpText/demo2';
-import './style.css';
 import {WatchStaticDemo} from './watch-static';
 
 if (alias !== 'alias') {
@@ -104,7 +104,7 @@ const INCLUDE_COMP_BREAKING_GET_COMPOSITIONS = false;
 
 // @ts-expect-error no types
 import styles from './styles.module.scss';
-import { ThreeHtml } from './ThreeHtml/ThreeHtml';
+import {ThreeHtml} from './ThreeHtml/ThreeHtml';
 
 class Vector2 {
 	readonly x: number;

--- a/packages/example/src/ThreeHtml/ThreeHtml.tsx
+++ b/packages/example/src/ThreeHtml/ThreeHtml.tsx
@@ -1,6 +1,6 @@
 import {Html} from '@react-three/drei';
 import {ThreeCanvas} from '@remotion/three';
-import {useRef} from 'react';
+import React, {useRef} from 'react';
 import {
   Internals,
   interpolate,
@@ -12,7 +12,9 @@ const Content = () => {
   return <h1>{useCurrentFrame()}</h1>;
 };
 
-const Box = ({portalTarget}) => {
+const Box: React.FC<{
+  portalTarget: React.MutableRefObject<HTMLDivElement>;
+}> = ({portalTarget}) => {
   const frame = useCurrentFrame();
   const rotation = interpolate(frame, [0, 1_000], [0, -5], {
     extrapolateRight: 'clamp',
@@ -38,7 +40,8 @@ const Box = ({portalTarget}) => {
 };
 
 export const ThreeHtml = () => {
-  const portalRef = useRef(null);
+  const portalRef =
+    useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
 
   const {width, height} = useVideoConfig();
 

--- a/packages/example/src/ThreeHtml/ThreeHtml.tsx
+++ b/packages/example/src/ThreeHtml/ThreeHtml.tsx
@@ -2,60 +2,60 @@ import {Html} from '@react-three/drei';
 import {ThreeCanvas} from '@remotion/three';
 import React, {useRef} from 'react';
 import {
-  Internals,
-  interpolate,
-  useCurrentFrame,
-  useVideoConfig,
+	Internals,
+	interpolate,
+	useCurrentFrame,
+	useVideoConfig,
 } from 'remotion';
 
 const Content = () => {
-  return <h1>{useCurrentFrame()}</h1>;
+	return <h1>{useCurrentFrame()}</h1>;
 };
 
 const Box: React.FC<{
-  portalTarget: React.MutableRefObject<HTMLDivElement>;
+	portalTarget: React.MutableRefObject<HTMLDivElement>;
 }> = ({portalTarget}) => {
-  const frame = useCurrentFrame();
-  const rotation = interpolate(frame, [0, 1_000], [0, -5], {
-    extrapolateRight: 'clamp',
-    extrapolateLeft: 'clamp',
-  });
+	const frame = useCurrentFrame();
+	const rotation = interpolate(frame, [0, 1_000], [0, -5], {
+		extrapolateRight: 'clamp',
+		extrapolateLeft: 'clamp',
+	});
 
-  const contexts = Internals.useRemotionContexts();
+	const contexts = Internals.useRemotionContexts();
 
-  return (
-    <group position={[0, 0.05, -0.75]} rotation={[0, rotation, 0]}>
-      <mesh position={[0, 0.05, -0.7]}>
-        <boxGeometry args={[2, 2, 0.1]} />
-        <meshStandardMaterial color="#f00" />
+	return (
+		<group position={[0, 0.05, -0.75]} rotation={[0, rotation, 0]}>
+			<mesh position={[0, 0.05, -0.7]}>
+				<boxGeometry args={[2, 2, 0.1]} />
+				<meshStandardMaterial color="#f00" />
 
-        <Html transform portal={portalTarget}>
-          <Internals.RemotionContextProvider contexts={contexts}>
-            <Content />
-          </Internals.RemotionContextProvider>
-        </Html>
-      </mesh>
-    </group>
-  );
+				<Html transform portal={portalTarget}>
+					<Internals.RemotionContextProvider contexts={contexts}>
+						<Content />
+					</Internals.RemotionContextProvider>
+				</Html>
+			</mesh>
+		</group>
+	);
 };
 
 export const ThreeHtml = () => {
-  const portalRef =
-    useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
+	const portalRef =
+		useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
 
-  const {width, height} = useVideoConfig();
+	const {width, height} = useVideoConfig();
 
-  return (
-    <div style={{background: 'rgba(0, 0, 0, 0.5)'}}>
-      <div ref={portalRef} data-portal />
-      <ThreeCanvas
-        camera={{position: [0, 2, 5], fov: 50}}
-        width={width}
-        height={height}
-      >
-        <pointLight position={[10, 10, 10]} />
-        <Box portalTarget={portalRef} />
-      </ThreeCanvas>
-    </div>
-  );
+	return (
+		<div style={{background: 'rgba(0, 0, 0, 0.5)'}}>
+			<div ref={portalRef} data-portal />
+			<ThreeCanvas
+				camera={{position: [0, 2, 5], fov: 50}}
+				width={width}
+				height={height}
+			>
+				<pointLight position={[10, 10, 10]} />
+				<Box portalTarget={portalRef} />
+			</ThreeCanvas>
+		</div>
+	);
 };

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -202,7 +202,6 @@ const internalGetCompositionsRaw = async ({
 			},
 			{
 				onDownload: () => undefined,
-				onError,
 			},
 		)
 			.then(({server: {serveUrl, offthreadPort, sourceMap}, cleanupServer}) => {

--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -219,17 +219,10 @@ export const startOffthreadVideoServer = ({
 				.catch((err) => {
 					if (!response.headersSent) {
 						response.writeHead(500);
+						response.write(JSON.stringify({error: err.stack}));
 					}
 
 					response.end();
-
-					// Any errors occurred due to the render being aborted don't need to be logged.
-					if (
-						err.message !== REQUEST_CLOSED_TOKEN &&
-						!err.message.includes('EPIPE')
-					) {
-						downloadMap.emitter.dispatchError(err);
-					}
 				});
 		},
 		compositor,
@@ -247,13 +240,8 @@ type ProgressEventPayload = {
 	src: string;
 };
 
-type ErrorEventPayload = {
-	error: Error;
-};
-
 type EventMap = {
 	progress: ProgressEventPayload;
-	error: ErrorEventPayload;
 	download: DownloadEventPayload;
 };
 
@@ -269,7 +257,6 @@ type Listeners = {
 
 export class OffthreadVideoServerEmitter {
 	listeners: Listeners = {
-		error: [],
 		progress: [],
 		download: [],
 	};
@@ -303,12 +290,6 @@ export class OffthreadVideoServerEmitter {
 				callback({detail: context});
 			},
 		);
-	}
-
-	dispatchError(error: Error) {
-		this.dispatchEvent('error', {
-			error,
-		});
 	}
 
 	dispatchDownloadProgress(

--- a/packages/renderer/src/prepare-server.ts
+++ b/packages/renderer/src/prepare-server.ts
@@ -175,9 +175,7 @@ export const makeOrReuseServer = async (
 	config: PrepareServerOptions,
 	{
 		onDownload,
-		onError,
 	}: {
-		onError: (err: Error) => void;
 		onDownload: RenderMediaOnDownload | null;
 	},
 ): Promise<{
@@ -190,18 +188,10 @@ export const makeOrReuseServer = async (
 			onDownload,
 		);
 
-		const cleanupError = server.downloadMap.emitter.addEventListener(
-			'error',
-			({detail: {error}}) => {
-				onError(error);
-			},
-		);
-
 		return {
 			server,
 			cleanupServer: () => {
 				cleanupOnDownload();
-				cleanupError();
 				return Promise.resolve();
 			},
 		};
@@ -214,18 +204,10 @@ export const makeOrReuseServer = async (
 		onDownload,
 	);
 
-	const cleanupErrorNew = newServer.downloadMap.emitter.addEventListener(
-		'error',
-		({detail: {error}}) => {
-			onError(error);
-		},
-	);
-
 	return {
 		server: newServer,
 		cleanupServer: (force: boolean) => {
 			cleanupOnDownloadNew();
-			cleanupErrorNew();
 			return Promise.all([newServer.closeServer(force)]);
 		},
 	};

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -877,7 +877,6 @@ const internalRenderFramesRaw = ({
 					},
 					{
 						onDownload,
-						onError,
 					},
 				),
 				browserInstance,

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -942,7 +942,10 @@ const internalRenderFramesRaw = ({
 				server?.compositor
 					.executeCommand('CloseAllVideos', {})
 					.then(() => {
-						Log.verbose({indent, logLevel}, 'Freed memory from compositor');
+						Log.verbose(
+							{indent, logLevel, tag: 'compositor'},
+							'Freed memory from compositor',
+						);
 					})
 					.catch((err) => {
 						Log.verbose({indent, logLevel}, 'Could not close compositor', err);

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -564,7 +564,6 @@ const internalRenderMediaRaw = ({
 					},
 					{
 						onDownload,
-						onError: (err) => reject(err),
 					},
 				);
 			})

--- a/packages/renderer/src/render-still.ts
+++ b/packages/renderer/src/render-still.ts
@@ -381,7 +381,6 @@ const internalRenderStillRaw = (
 			},
 			{
 				onDownload: options.onDownload,
-				onError,
 			},
 		)
 			.then(({server, cleanupServer}) => {

--- a/packages/renderer/src/select-composition.ts
+++ b/packages/renderer/src/select-composition.ts
@@ -240,7 +240,6 @@ export const internalSelectCompositionRaw = async (
 			},
 			{
 				onDownload: () => undefined,
-				onError,
 			},
 		)
 			.then(({server: {serveUrl, offthreadPort, sourceMap}, cleanupServer}) => {


### PR DESCRIPTION
Previously the compositor would crash, with no option to recover.

Now the error gets sent to the frontend and by default will call cancelRender()

Unless the `onError` prop is set for the component