### PR TITLE
Fix: save media to another bucket (python)

### DIFF
--- a/packages/lambda-python/remotion_lambda/models.py
+++ b/packages/lambda-python/remotion_lambda/models.py
@@ -128,7 +128,7 @@ class OutNameInputObject:
         s3_output_provider (Optional[CustomCredentials]):
              Optional custom credentials for the S3 output provider.
     """
-    bucket_name: str
+    bucketName: str
     key: str
     s3_output_provider: Optional[CustomCredentials] = None
 

--- a/packages/lambda-python/remotion_lambda/models.py
+++ b/packages/lambda-python/remotion_lambda/models.py
@@ -251,7 +251,7 @@ class RenderMediaParams:
     input_props: Optional[List] = None
     bucket_name: Optional[str] = None
     region: Optional[str] = None
-    out_name: Optional[str] = None
+    out_name: Optional[Union[str, OutNameInputObject]] = None
     prefer_lossless: Optional[bool] = False
     composition: str = ""
     serve_url: str = ""

--- a/packages/lambda-python/remotion_lambda/models.py
+++ b/packages/lambda-python/remotion_lambda/models.py
@@ -35,6 +35,7 @@ class Privacy(str, Enum):
     """
     PUBLIC: str = 'public'
     PRIVATE: str = 'private'
+    NO_ACL: str = 'no-acl'
 
 
 class LogLevel(str, Enum):

--- a/packages/lambda-python/remotion_lambda/models.py
+++ b/packages/lambda-python/remotion_lambda/models.py
@@ -124,7 +124,7 @@ class OutNameInputObject:
     Defines output naming and storage options.
 
     Attributes:
-        bucket_name (str): The name of the S3 bucket for output storage.
+        bucketName (str): The name of the S3 bucket for output storage.
         key (str): The key name within the S3 bucket.
         s3_output_provider (Optional[CustomCredentials]):
              Optional custom credentials for the S3 output provider.


### PR DESCRIPTION
- RenderMediaParams to be able to pass OutNameInputObject and follow the same naming 
- add "no-acl" privacy