### PR TITLE
`@remotion/lambda`: Fix `--function-name` flag

### DIFF
--- a/packages/lambda/src/cli/helpers/find-function-name.ts
+++ b/packages/lambda/src/cli/helpers/find-function-name.ts
@@ -52,9 +52,9 @@ export const findFunctionName = async (logLevel: LogLevel) => {
 					'Prefer using one of those functions by passing their name to  `--function-name` or removing it entirely.',
 				);
 			}
-
-			return cliFlag;
 		}
+
+		return cliFlag;
 	}
 
 	if (lambdasWithMatchingVersion.length === 0) {


### PR DESCRIPTION
It was meant to allow any function name, but the return statement was in the wrong branch