### PR TITLE
`@remotion/rive`: Ensure `ref` is available before calling `onLoad`

### DIFF
--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -79,6 +79,7 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 		animation: LinearAnimationInstance;
 		renderer: CanvasRenderer;
 		artboard: Artboard;
+		file: File;
 	} | null>(null);
 
 	useImperativeHandle(
@@ -148,10 +149,8 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 							animation,
 							artboard,
 							renderer,
+							file,
 						});
-						if (onLoad) {
-							onLoad(file);
-						}
 					});
 			})
 			.catch((newErr) => {
@@ -166,6 +165,12 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 		assetLoader,
 		enableRiveAssetCdn,
 	]);
+
+	useEffect(() => {
+		if (onLoad && rive) {
+			onLoad(rive.file);
+		}
+	}, [onLoad, rive]);
 
 	React.useEffect(() => {
 		if (!riveCanvasInstance) {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
