### PR TITLE
`@remotion/renderer`: More efficient seeking, `@remotion/lambda`: Print progress.json to console

### DIFF
--- a/packages/lambda/src/api/render-media-on-lambda.ts
+++ b/packages/lambda/src/api/render-media-on-lambda.ts
@@ -18,6 +18,7 @@ import {
 	getCloudwatchMethodUrl,
 	getCloudwatchRendererUrl,
 	getLambdaInsightsUrl,
+	getProgressJsonUrl,
 	getS3RenderUrl,
 } from '../shared/get-aws-urls';
 import type {LambdaCodec} from '../shared/validate-lambda-codec';
@@ -71,6 +72,7 @@ export type RenderMediaOnLambdaOutput = {
 	cloudWatchMainLogs: string;
 	lambdaInsightsLogs: string;
 	folderInS3Console: string;
+	progressJsonInConsole: string;
 };
 
 export const internalRenderMediaOnLambdaRaw = async (
@@ -111,6 +113,11 @@ export const internalRenderMediaOnLambdaRaw = async (
 			}),
 			lambdaInsightsLogs: getLambdaInsightsUrl({
 				functionName,
+				region,
+			}),
+			progressJsonInConsole: getProgressJsonUrl({
+				bucketName: res.bucketName,
+				renderId: res.renderId,
 				region,
 			}),
 		};

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -347,6 +347,18 @@ export const renderCommand = async (
 		),
 	);
 	Log.info(
+		{indent: false, logLevel},
+		CliInternals.chalk.gray(
+			`progress.json: ${CliInternals.makeHyperlink({
+				text: (clickInstruction) => {
+					return `${clickInstruction} to view`;
+				},
+				fallback: res.progressJsonInConsole,
+				url: res.progressJsonInConsole,
+			})}`,
+		),
+	);
+	Log.info(
 		{
 			indent: false,
 			logLevel,

--- a/packages/lambda/src/shared/get-aws-urls.ts
+++ b/packages/lambda/src/shared/get-aws-urls.ts
@@ -77,3 +77,15 @@ export const getS3RenderUrl = ({
 }) => {
 	return `https://s3.console.aws.amazon.com/s3/buckets/${bucketName}?region=${region}&prefix=renders/${renderId}/`;
 };
+
+export const getProgressJsonUrl = ({
+	region,
+	bucketName,
+	renderId,
+}: {
+	region: AwsRegion;
+	bucketName: string;
+	renderId: string;
+}) => {
+	return `https://${region}.console.aws.amazon.com/s3/object/${bucketName}?region=${region}&bucketType=general&prefix=renders/${renderId}/progress.json`;
+};

--- a/packages/renderer/Cargo.lock
+++ b/packages/renderer/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "ffmpeg-next"
 version = "6.0.0"
-source = "git+https://github.com/remotion-dev/rust-ffmpeg?rev=675dd103871633dd0ad8a3a2ca7f12e9a42edec1#675dd103871633dd0ad8a3a2ca7f12e9a42edec1"
+source = "git+https://github.com/remotion-dev/rust-ffmpeg?rev=4027d3764d54c6c71ab72ff076764ae7abe91428#4027d3764d54c6c71ab72ff076764ae7abe91428"
 dependencies = [
  "bitflags",
  "ffmpeg-sys-next",

--- a/packages/renderer/Cargo.toml
+++ b/packages/renderer/Cargo.toml
@@ -19,7 +19,7 @@ image = "0.24.7"
 arboard = "3.2.0"
 sysinfo = "0.30.7"
 mp4 = {git = "https://github.com/jonnyburger/mp4-rust", rev = "92ba375738cc2f05a4d754e1f968cf2e97d06641"}
-ffmpeg-next = {git = "https://github.com/remotion-dev/rust-ffmpeg", rev ="675dd103871633dd0ad8a3a2ca7f12e9a42edec1"}
+ffmpeg-next = {git = "https://github.com/remotion-dev/rust-ffmpeg", rev ="4027d3764d54c6c71ab72ff076764ae7abe91428"}
 
 [[bin]]
 name = "remotion"

--- a/packages/renderer/rust/main.rs
+++ b/packages/renderer/rust/main.rs
@@ -21,10 +21,7 @@ use commands::execute_command;
 use errors::{error_to_json, ErrorWithBacktrace};
 use global_printer::{_print_verbose, set_verbose_logging};
 use memory::{get_ideal_maximum_frame_cache_size, is_about_to_run_out_of_memory};
-use std::{
-    env, thread,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{ env, thread};
 
 use payloads::payloads::{parse_cli, CliInputCommand, CliInputCommandPayload};
 

--- a/packages/renderer/rust/opened_stream.rs
+++ b/packages/renderer/rust/opened_stream.rs
@@ -177,10 +177,8 @@ impl OpenedStream {
          target_position < self.last_position.unwrap_or(0)
             || 
             // Less than 3 seconds before the position we want to be
-            self.last_position.unwrap_or(0) < calc_position(time - 3.0, time_base)
-            || 
-            // Never seeked before
-            self.last_position.is_none()
+            self.last_position.unwrap_or(0) < calc_position(time - 1.0, time_base)
+            
             ;
 
         if should_seek {


### PR DESCRIPTION
- Before, it would not seek if extracting a time between 0.0 and 3.0, now it will allow a seek if none has happened
- Fixes a Rust overflow bug causing a video to crash
- Lambda CLI prints progress.json link to console