### PR TITLE
`remotion`: Accept Exceptions that the browser generates

### DIFF
--- a/packages/core/src/cancel-render.ts
+++ b/packages/core/src/cancel-render.ts
@@ -1,4 +1,8 @@
 const isErrorLike = (err: unknown): boolean => {
+	if (err instanceof Error) {
+		return true;
+	}
+
 	if (err === null) {
 		return false;
 	}
@@ -39,6 +43,9 @@ export function cancelRender(err: unknown): never {
 
 	if (isErrorLike(err)) {
 		error = err as Error;
+		if (!error.stack) {
+			error.stack = new Error(error.message).stack;
+		}
 	} else if (typeof err === 'string') {
 		error = Error(err);
 	} else {


### PR DESCRIPTION
If running into a CORS issue using loadFont(), then an error is thrown which was not handled well