### PR TITLE
`@remotion/renderer`: Log error if frame should not be extracted

### DIFF
--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -217,6 +217,11 @@ export const startOffthreadVideoServer = ({
 					});
 				})
 				.catch((err) => {
+					Log.error(
+						{indent, logLevel},
+						'Could not extract frame from compositor',
+						err,
+					);
 					if (!response.headersSent) {
 						response.writeHead(500);
 						response.write(JSON.stringify({error: err.stack}));


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
