### PR TITLE
`@remotion/tailwind`: Allow for a custom config location

### DIFF
--- a/packages/docs/docs/tailwind/enable-tailwind.mdx
+++ b/packages/docs/docs/tailwind/enable-tailwind.mdx
@@ -1,27 +1,30 @@
 ---
 image: /generated/articles-docs-tailwind-enable-tailwind.png
 title: enableTailwind()
-crumb: "@remotion/tailwind"
+crumb: '@remotion/tailwind'
 ---
 
 _available from v3.3.95_
 
 A function that modifies the default Webpack configuration to make the necessary changes to support TailwindCSS.
+See the [setup](/docs/tailwind) to see full instructions on how to setup TailwindCSS in Remotion.
 
 ```ts twoslash title="remotion.config.ts"
-import { Config } from "@remotion/cli/config";
-import { enableTailwind } from "@remotion/tailwind";
+import {Config} from '@remotion/cli/config';
+import {enableTailwind} from '@remotion/tailwind';
 
 Config.overrideWebpackConfig((currentConfiguration) => {
   return enableTailwind(currentConfiguration);
 });
 ```
 
+## Multiple Webpack changes
+
 If you want to make other configuration changes, you can do so by doing them reducer-style:
 
 ```ts twoslash title="remotion.config.ts"
-import { Config } from "@remotion/cli/config";
-import { enableTailwind } from "@remotion/tailwind";
+import {Config} from '@remotion/cli/config';
+import {enableTailwind} from '@remotion/tailwind';
 
 Config.overrideWebpackConfig((currentConfiguration) => {
   return enableTailwind({
@@ -32,4 +35,21 @@ Config.overrideWebpackConfig((currentConfiguration) => {
 });
 ```
 
-See the [setup](/docs/tailwind) to see full instructions on how to setup TailwindCSS in Remotion.
+## Custom Tailwind config location<AvailableFrom v="4.0.187" />
+
+By default, TailwindCSS will search for a file called `tailwind.config.js` in the current working directory where you executed the Remotion CLI.  
+This is not in line with Remotion which resolves files relative to the [Remotion Root](/docs/terminology/remotion-root).
+
+This mean if you execute the Remotion CLI from a different directory, Tailwind will not be able to find the config file.  
+To fix this, you can pass the path to the config file as the second argument to `enableTailwind()`:
+
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+import {enableTailwind} from '@remotion/tailwind';
+
+Config.overrideWebpackConfig((currentConfiguration) => {
+  return enableTailwind(currentConfiguration, {
+    configLocation: path.join(__dirname, 'tailwind.config.js'),
+  });
+});
+```

--- a/packages/docs/docs/tailwind/enable-tailwind.mdx
+++ b/packages/docs/docs/tailwind/enable-tailwind.mdx
@@ -44,6 +44,7 @@ This mean if you execute the Remotion CLI from a different directory, Tailwind w
 To fix this, you can pass the path to the config file as the second argument to `enableTailwind()`:
 
 ```ts twoslash title="remotion.config.ts"
+import path from 'node:path';
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind';
 

--- a/packages/tailwind/src/enable.ts
+++ b/packages/tailwind/src/enable.ts
@@ -1,10 +1,15 @@
-import type {WebpackOverrideFn} from '@remotion/bundler';
+import type {WebpackConfiguration, WebpackOverrideFn} from '@remotion/bundler';
 
 /**
  * @description A function that modifies the default Webpack configuration to make the necessary changes to support Tailwind.
  * @see [Documentation](https://www.remotion.dev/docs/tailwind/enable-tailwind)
  */
-export const enableTailwind: WebpackOverrideFn = (currentConfiguration) => {
+export const enableTailwind = ((
+	currentConfiguration: WebpackConfiguration,
+	options?: {
+		configLocation?: string;
+	},
+): WebpackConfiguration => {
 	return {
 		...currentConfiguration,
 		module: {
@@ -27,7 +32,12 @@ export const enableTailwind: WebpackOverrideFn = (currentConfiguration) => {
 								postcssOptions: {
 									plugins: [
 										require.resolve('postcss-preset-env'),
-										require.resolve('tailwindcss'),
+										[
+											require.resolve('tailwindcss'),
+											options?.configLocation
+												? {config: options.configLocation}
+												: {},
+										],
 										require.resolve('autoprefixer'),
 									],
 								},
@@ -38,4 +48,4 @@ export const enableTailwind: WebpackOverrideFn = (currentConfiguration) => {
 			],
 		},
 	};
-};
+}) satisfies WebpackOverrideFn;


### PR DESCRIPTION
Fixes #4097