### PR TITLE
`remotion`: Don't cancel render if fetch is aborted

### DIFF
--- a/packages/core/src/video/OffthreadVideoForRendering.tsx
+++ b/packages/core/src/video/OffthreadVideoForRendering.tsx
@@ -201,6 +201,15 @@ export const OffthreadVideoForRendering: React.FC<OffthreadVideoProps> = ({
 					handle: newHandle,
 				});
 			} catch (err) {
+				// If component is unmounted, we should not throw
+				if ((err as Error).message.includes('aborted')) {
+					return;
+				}
+
+				if (controller.signal.aborted) {
+					return;
+				}
+
 				if (onError) {
 					onError(err as Error);
 				} else {


### PR DESCRIPTION
Fixes #4124