### PR TITLE
`remotion`: Handle being imported in a React Server Component

### DIFF
--- a/packages/core/src/_check-rsc.ts
+++ b/packages/core/src/_check-rsc.ts
@@ -1,0 +1,17 @@
+import {createContext} from 'react';
+
+if (typeof createContext !== 'function') {
+	const err = [
+		'Remotion requires React.createContext, but it is "undefined".',
+		'If you are in a React Server Component, turn it into a client component by adding "use client" at the top of the file.',
+		'',
+		'Before:',
+		'  import {useCurrentFrame} from "remotion";',
+		'',
+		'After:',
+		'  "use client";',
+		'  import {useCurrentFrame} from "remotion";',
+	];
+
+	throw new Error(err.join('\n'));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+import './_check-rsc.js';
 import './asset-types.js';
 import {Clipper} from './Clipper.js';
 import type {Codec} from './codec.js';

--- a/packages/player/src/_check-rsc.ts
+++ b/packages/player/src/_check-rsc.ts
@@ -1,0 +1,17 @@
+import {createContext} from 'react';
+
+if (typeof createContext !== 'function') {
+	const err = [
+		'Remotion requires React.createContext, but it is "undefined".',
+		'If you are in a React Server Component, turn it into a client component by adding "use client" at the top of the file.',
+		'',
+		'Before:',
+		'  import {useCurrentFrame} from "remotion";',
+		'',
+		'After:',
+		'  "use client";',
+		'  import {useCurrentFrame} from "remotion";',
+	];
+
+	throw new Error(err.join('\n'));
+}

--- a/packages/player/src/_check-rsc.ts
+++ b/packages/player/src/_check-rsc.ts
@@ -6,11 +6,11 @@ if (typeof createContext !== 'function') {
 		'If you are in a React Server Component, turn it into a client component by adding "use client" at the top of the file.',
 		'',
 		'Before:',
-		'  import {useCurrentFrame} from "remotion";',
+		'  import {Player} from "@remotion/player";',
 		'',
 		'After:',
 		'  "use client";',
-		'  import {useCurrentFrame} from "remotion";',
+		'  import {Player} from "@remotion/player";',
 	];
 
 	throw new Error(err.join('\n'));

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1,3 +1,4 @@
+import './_check-rsc.js';
 import {BufferingIndicator} from './BufferingIndicator.js';
 import {calculateCanvasTransformation} from './calculate-scale.js';
 import {PlayerEventEmitterContext} from './emitter-context.js';


### PR DESCRIPTION
Next.js might throw an esoteric error when importing Remotion Player in a React Server Component:


```
TypeError: (0 , react__WEBPACK_IMPORTED_MODULE_0__.createContext) is not a function
    at __webpack_require__ (C:\Users\Yuvraj\Desktop\saas\.next\server\webpack-runtime.js:33:42)
    at eval (./components/VideoPlayer.tsx:7:66)
    at (rsc)/./components/VideoPlayer.tsx (C:\Users\Yuvraj\Desktop\saas\.next\server\app\page.js:239:1)
    at __webpack_require__ (C:\Users\Yuvraj\Desktop\saas\.next\server\webpack-runtime.js:33:42)
```

Improving the DX and suggesting to add "use client" to the top