### PR TITLE
`@remotion/renderer`: Don't use the ThreadPool if using only 1 thread

### DIFF
--- a/packages/renderer/rust/main.rs
+++ b/packages/renderer/rust/main.rs
@@ -9,6 +9,7 @@ mod get_silent_parts;
 mod global_printer;
 mod image;
 mod logger;
+mod max_cache_size;
 mod memory;
 mod opened_stream;
 mod opened_video;
@@ -17,11 +18,12 @@ mod payloads;
 mod rotation;
 mod scalable_frame;
 mod tone_map;
+
 use commands::execute_command;
 use errors::{error_to_json, ErrorWithBacktrace};
 use global_printer::{_print_verbose, set_verbose_logging};
-use memory::{get_ideal_maximum_frame_cache_size, is_about_to_run_out_of_memory};
-use std::{ env, thread};
+use memory::get_ideal_maximum_frame_cache_size;
+use std::{env, thread};
 
 use payloads::payloads::{parse_cli, CliInputCommand, CliInputCommandPayload};
 
@@ -57,7 +59,7 @@ fn mainfn() -> Result<(), ErrorWithBacktrace> {
             start_long_running_process(payload.concurrency, max_video_cache_size)?;
         }
         _ => {
-            let data = execute_command(opts.payload, None)?;
+            let data = execute_command(opts.payload)?;
             global_printer::synchronized_write_buf(0, &opts.nonce, &data)?;
         }
     }
@@ -79,6 +81,11 @@ fn start_long_running_process(
         .num_threads(threads)
         .build()?;
 
+    max_cache_size::get_instance()
+        .lock()
+        .unwrap()
+        .set_value(Some(maximum_frame_cache_size_in_bytes));
+
     loop {
         let mut input = String::new();
         let matched = match std::io::stdin().read_line(&mut input) {
@@ -94,33 +101,35 @@ fn start_long_running_process(
         }
         let opts: CliInputCommand = parse_cli(&input)?;
 
-        let mut current_maximum_cache_size = maximum_frame_cache_size_in_bytes;
+        if threads > 1 {
+            pool.install(move || {
+                let handle = thread::spawn(move || {
+                    match execute_command(opts.payload) {
+                        Ok(res) => {
+                            global_printer::synchronized_write_buf(0, &opts.nonce, &res).unwrap()
+                        }
+                        Err(err) => global_printer::synchronized_write_buf(
+                            1,
+                            &opts.nonce,
+                            &error_to_json(err).unwrap().as_bytes(),
+                        )
+                        .unwrap(),
+                    };
+                });
 
-        pool.install(move || {
-            let handle = thread::spawn(move || {
-                if is_about_to_run_out_of_memory() {
-                    ffmpeg::emergency_memory_free_up().unwrap();
-                    current_maximum_cache_size = current_maximum_cache_size / 2;
-                }
-
-                match execute_command(opts.payload, Some(current_maximum_cache_size)) {
-                    Ok(res) => {
-                        global_printer::synchronized_write_buf(0, &opts.nonce, &res).unwrap()
-                    }
-                    Err(err) => global_printer::synchronized_write_buf(
-                        1,
-                        &opts.nonce,
-                        &error_to_json(err).unwrap().as_bytes(),
-                    )
-                    .unwrap(),
-                };
-
-                ffmpeg::keep_only_latest_frames_and_close_videos(current_maximum_cache_size)
-                    .unwrap();
+                handle.join().unwrap();
             });
-
-            handle.join().unwrap();
-        });
+        } else {
+            match execute_command(opts.payload) {
+                Ok(res) => global_printer::synchronized_write_buf(0, &opts.nonce, &res).unwrap(),
+                Err(err) => global_printer::synchronized_write_buf(
+                    1,
+                    &opts.nonce,
+                    &error_to_json(err).unwrap().as_bytes(),
+                )
+                .unwrap(),
+            };
+        }
     }
 
     Ok(())

--- a/packages/renderer/rust/max_cache_size.rs
+++ b/packages/renderer/rust/max_cache_size.rs
@@ -1,0 +1,33 @@
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+
+pub struct MaxCacheSize {
+    value: Option<u128>,
+}
+
+impl MaxCacheSize {
+    // Private constructor
+    fn new() -> Self {
+        MaxCacheSize { value: None }
+    }
+
+    // Getter for the value
+    pub fn get_value(&self) -> Option<u128> {
+        self.value
+    }
+
+    // Setter for the value
+    pub fn set_value(&mut self, value: Option<u128>) {
+        self.value = value;
+    }
+}
+
+// Global static instance of MaxCacheSize
+lazy_static! {
+    static ref INSTANCE: Mutex<MaxCacheSize> = Mutex::new(MaxCacheSize::new());
+}
+
+// Function to access the global singleton instance
+pub fn get_instance() -> &'static Mutex<MaxCacheSize> {
+    &INSTANCE
+}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
