### PR TITLE
`@remotion/player`: Fix `isPlaying()` and `isFullscreen()` methods not immediately updating

### DIFF
--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -372,7 +372,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 				toggle,
 				getContainerNode: () => container.current,
 				getCurrentFrame: player.getCurrentFrame,
-				isPlaying: () => player.playing,
+				isPlaying: player.isPlaying,
 				seekTo: (f) => {
 					const lastFrame = durationInFrames - 1;
 					const frameToSeekTo = Math.max(0, Math.min(lastFrame, f));

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -397,12 +397,11 @@ const PlayerUI: React.ForwardRefRenderFunction<
 						return false;
 					}
 
-					const newValue =
+					return (
 						document.fullscreenElement === current ||
 						// @ts-expect-error Types not defined
-						document.webkitFullscreenElement === current;
-
-					return newValue;
+						document.webkitFullscreenElement === current
+					);
 				},
 				requestFullscreen,
 				exitFullscreen,

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -176,11 +176,12 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		}
 
 		const onFullscreenChange = () => {
-			setIsFullscreen(
+			const newValue =
 				document.fullscreenElement === current ||
-					// @ts-expect-error Types not defined
-					document.webkitFullscreenElement === current,
-			);
+				// @ts-expect-error Types not defined
+				document.webkitFullscreenElement === current;
+
+			setIsFullscreen(newValue);
 		};
 
 		document.addEventListener('fullscreenchange', onFullscreenChange);
@@ -390,7 +391,19 @@ const PlayerUI: React.ForwardRefRenderFunction<
 
 					player.seek(frameToSeekTo);
 				},
-				isFullscreen: () => isFullscreen,
+				isFullscreen: () => {
+					const {current} = container;
+					if (!current) {
+						return false;
+					}
+
+					const newValue =
+						document.fullscreenElement === current ||
+						// @ts-expect-error Types not defined
+						document.webkitFullscreenElement === current;
+
+					return newValue;
+				},
 				requestFullscreen,
 				exitFullscreen,
 				getVolume: () => {
@@ -438,7 +451,6 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		[
 			durationInFrames,
 			exitFullscreen,
-			isFullscreen,
 			loop,
 			mediaMuted,
 			isMuted,


### PR DESCRIPTION
They were using the React state instead of the imperative state