### PR TITLE
`@remotion/media-utils`: `useAudioData()` should use useLayoutEffect

### DIFF
--- a/packages/media-utils/src/use-audio-data.ts
+++ b/packages/media-utils/src/use-audio-data.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {cancelRender, continueRender, delayRender} from 'remotion';
 import {getAudioData} from './get-audio-data';
 import type {AudioData} from './types';
@@ -44,7 +44,7 @@ export const useAudioData = (src: string): AudioData | null => {
 		continueRender(handle);
 	}, [src]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		fetchMetadata();
 	}, [fetchMetadata]);
 


### PR DESCRIPTION
Calling delayRender() in an useEffect() can in some rare cases lead to flickering