### PR TITLE
`@remotion/media-parser`: Throw if runtime does not support ArrayBuffer.resize

### DIFF
--- a/packages/media-parser/src/buffer-iterator.ts
+++ b/packages/media-parser/src/buffer-iterator.ts
@@ -55,6 +55,12 @@ export const getArrayBufferIterator = (
 	const buf = new ArrayBuffer(initialData.byteLength, {
 		maxByteLength: maxBytes ?? 1_000_000_000,
 	});
+	if (!buf.resize) {
+		throw new Error(
+			'`ArrayBuffer.resize` is not supported in this Runtime. Use at least Node.js 20 or Bun.',
+		);
+	}
+
 	let data = new Uint8Array(buf);
 	data.set(initialData);
 


### PR DESCRIPTION
…er.resize

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
