### PR TITLE
`remotion`: Better error message if OffthreadVideoForRendering fails with "Failed to fetch"

### DIFF
--- a/packages/cli/src/print-error.ts
+++ b/packages/cli/src/print-error.ts
@@ -47,6 +47,7 @@ export const printError = async (err: Error, logLevel: LogLevel) => {
 			}
 
 			printCodeFrameAndStack(symbolicated, logLevel);
+			RenderInternals.printUsefulErrorMessage(err, logLevel, false);
 		} catch (e) {
 			output.update(chalk.red(''), true);
 			Log.error({indent: false, logLevel});

--- a/packages/core/src/video/OffthreadVideoForRendering.tsx
+++ b/packages/core/src/video/OffthreadVideoForRendering.tsx
@@ -211,6 +211,14 @@ export const OffthreadVideoForRendering: React.FC<OffthreadVideoProps> = ({
 					return;
 				}
 
+				if ((err as Error).message.includes('Failed to fetch')) {
+					// eslint-disable-next-line no-ex-assign
+					err = new Error(
+						`Failed to fetch ${actualSrc}. This could be caused by Chrome rejecting the request because the disk space is low. Consider increasing the disk size of your environment.`,
+						{cause: err},
+					);
+				}
+
 				if (onError) {
 					onError(err as Error);
 				} else {

--- a/packages/renderer/src/browser/NetworkManager.ts
+++ b/packages/renderer/src/browser/NetworkManager.ts
@@ -350,6 +350,24 @@ export class NetworkManager extends EventEmitter {
 				{indent: this.#indent, logLevel: this.#logLevel},
 				`Browser failed to load ${request._url} (${event.type}): ${event.errorText}`,
 			);
+			if (
+				event.errorText === 'net::ERR_FAILED' &&
+				event.type === 'Fetch' &&
+				request._url?.includes('/proxy')
+			) {
+				Log.warn(
+					{indent: this.#indent, logLevel: this.#logLevel},
+					'This could be caused by Chrome rejecting the request because the disk space is low.',
+				);
+				Log.warn(
+					{indent: this.#indent, logLevel: this.#logLevel},
+					'This could be caused by Chrome rejecting the request because the disk space is low.',
+				);
+				Log.warn(
+					{indent: this.#indent, logLevel: this.#logLevel},
+					'Consider increasing the disk size of your Lambda function.',
+				);
+			}
 		}
 
 		this.#forgetRequest(request, true);

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -146,6 +146,7 @@ import {
 	resolveAudioCodec,
 	supportedAudioCodecs,
 } from './options/audio-codec';
+import {printUsefulErrorMessage} from './print-useful-error-message';
 import {getShouldRenderAudio} from './render-has-audio';
 import {toMegabytes} from './to-megabytes';
 import {validatePuppeteerTimeout} from './validate-puppeteer-timeout';
@@ -242,6 +243,7 @@ export const RenderInternals = {
 	toMegabytes,
 	internalEnsureBrowser,
 	exampleVideos,
+	printUsefulErrorMessage,
 };
 
 // Warn of potential performance issues with Apple Silicon (M1 chip under Rosetta)

--- a/packages/renderer/src/print-useful-error-message.ts
+++ b/packages/renderer/src/print-useful-error-message.ts
@@ -158,4 +158,15 @@ export const printUsefulErrorMessage = (
 			'   https://github.com/remotion-dev/remotion/issues/3864',
 		);
 	}
+
+	if (err.message.includes('Failed to fetch')) {
+		Log.info(
+			{indent, logLevel},
+			'💡 On Lambda, one reason this could happen is that Chrome is rejecting an asset to be loaded when it is running low on disk space.',
+		);
+		Log.info(
+			{indent, logLevel},
+			'Try increasing the disk size of your Lambda function.',
+		);
+	}
 };


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
