### PR TITLE
`@remotion/renderer`: Fix getting open handles when timing out the component

### DIFF
--- a/packages/renderer/src/error-handling/handle-javascript-exception.ts
+++ b/packages/renderer/src/error-handling/handle-javascript-exception.ts
@@ -110,7 +110,6 @@ export const handleJavascriptException = ({
 
 		const errorType = exception.exceptionDetails.exception?.className as string;
 
-		page.close();
 		const symbolicatedErr = new SymbolicateableError({
 			message: removeDelayRenderStack(cleanErrorMessage),
 			stackFrame: (

--- a/packages/renderer/src/seek-to-frame.ts
+++ b/packages/renderer/src/seek-to-frame.ts
@@ -119,8 +119,8 @@ export const waitForReady = ({
 						.then((res) => {
 							reject(
 								new Error(
-									`Timeout exceeded rendering the component${
-										frame ? ' at frame ' + frame : ''
+									`Timeout (${timeoutInMilliseconds}ms) exceeded rendering the component${
+										frame ? ' at frame ' + frame : ' initially'
 									}. ${
 										res.value ? `Open delayRender() handles: ${res.value}` : ''
 									}`,


### PR DESCRIPTION
…mponent

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
