### PR TITLE
`@remotion/media-parser`: Default timescale is 1_000_000

### DIFF
--- a/packages/media-parser/src/parser-state.ts
+++ b/packages/media-parser/src/parser-state.ts
@@ -49,8 +49,10 @@ export const makeParserState = ({
 	let timescale: number | null = null;
 
 	const getTimescale = () => {
+		// https://www.matroska.org/technical/notes.html
+		// When using the default value of TimestampScale of “1,000,000”, one Segment Tick represents one millisecond.
 		if (timescale === null) {
-			throw new Error('Timescale not set');
+			return 1_000_000;
 		}
 
 		return timescale;


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
