### PR TITLE
`@remotion/media-parser`: Support `largesize` and `co64` conventions

### DIFF
--- a/packages/media-parser/src/boxes/iso-base-media/mdat/mdat.ts
+++ b/packages/media-parser/src/boxes/iso-base-media/mdat/mdat.ts
@@ -26,7 +26,7 @@ export const parseMdat = async ({
 }): Promise<MdatBox> => {
 	const alreadyHas = hasTracks(existingBoxes);
 	if (!alreadyHas) {
-		data.discard(size - data.counter.getOffset() - fileOffset);
+		data.discard(size - (data.counter.getOffset() - fileOffset));
 		return Promise.resolve({
 			type: 'mdat-box',
 			boxSize: size,

--- a/packages/media-parser/src/boxes/iso-base-media/mdat/mdat.ts
+++ b/packages/media-parser/src/boxes/iso-base-media/mdat/mdat.ts
@@ -26,7 +26,7 @@ export const parseMdat = async ({
 }): Promise<MdatBox> => {
 	const alreadyHas = hasTracks(existingBoxes);
 	if (!alreadyHas) {
-		data.discard(size - 8);
+		data.discard(size - data.counter.getOffset() - fileOffset);
 		return Promise.resolve({
 			type: 'mdat-box',
 			boxSize: size,

--- a/packages/media-parser/src/boxes/iso-base-media/stsd/stco.ts
+++ b/packages/media-parser/src/boxes/iso-base-media/stsd/stco.ts
@@ -6,17 +6,19 @@ export interface StcoBox extends BaseBox {
 	version: number;
 	flags: number[];
 	entryCount: number;
-	entries: number[];
+	entries: (number | bigint)[];
 }
 
 export const parseStco = ({
 	iterator,
 	offset,
 	size,
+	mode64Bit,
 }: {
 	iterator: BufferIterator;
 	offset: number;
 	size: number;
+	mode64Bit: boolean;
 }): StcoBox => {
 	const version = iterator.getUint8();
 	if (version !== 0) {
@@ -26,14 +28,14 @@ export const parseStco = ({
 	const flags = iterator.getSlice(3);
 	const entryCount = iterator.getUint32();
 
-	const entries: number[] = [];
+	const entries: (number | bigint)[] = [];
 	for (let i = 0; i < entryCount; i++) {
 		const bytesRemaining = size - (iterator.counter.getOffset() - offset);
 		if (bytesRemaining < 4) {
 			break;
 		}
 
-		entries.push(iterator.getUint32());
+		entries.push(mode64Bit ? iterator.getUint64() : iterator.getUint32());
 	}
 
 	iterator.discard(size - (iterator.counter.getOffset() - offset));

--- a/packages/media-parser/src/buffer-iterator.ts
+++ b/packages/media-parser/src/buffer-iterator.ts
@@ -96,6 +96,41 @@ export const getArrayBufferIterator = (
 		return val;
 	};
 
+	const getEightByteNumber = (littleEndian = false) => {
+		if (littleEndian) {
+			const one = getUint8();
+			const two = getUint8();
+			const three = getUint8();
+			const four = getUint8();
+			const five = getUint8();
+			const six = getUint8();
+			const seven = getUint8();
+			const eight = getUint8();
+
+			return (
+				(eight << 56) |
+				(seven << 48) |
+				(six << 40) |
+				(five << 32) |
+				(four << 24) |
+				(three << 16) |
+				(two << 8) |
+				one
+			);
+		}
+
+		return (
+			(getUint8() << 56) |
+			(getUint8() << 48) |
+			(getUint8() << 40) |
+			(getUint8() << 32) |
+			(getUint8() << 24) |
+			(getUint8() << 16) |
+			(getUint8() << 8) |
+			getUint8()
+		);
+	};
+
 	const getFourByteNumber = (littleEndian = false) => {
 		if (littleEndian) {
 			const one = getUint8();
@@ -122,6 +157,12 @@ export const getArrayBufferIterator = (
 	const getUint32 = (littleEndian = false) => {
 		const val = view.getUint32(counter.getDiscardedOffset(), littleEndian);
 		counter.increment(4);
+		return val;
+	};
+
+	const getUint64 = (littleEndian = false) => {
+		const val = view.getBigUint64(counter.getDiscardedOffset(), littleEndian);
+		counter.increment(8);
 		return val;
 	};
 
@@ -294,6 +335,7 @@ export const getArrayBufferIterator = (
 		discard: (length: number) => {
 			counter.increment(length);
 		},
+		getEightByteNumber,
 		getFourByteNumber,
 		getSlice,
 		getAtom: () => {
@@ -416,6 +458,7 @@ export const getArrayBufferIterator = (
 			return val;
 		},
 		getUint32,
+		getUint64,
 		// https://developer.apple.com/documentation/quicktime-file-format/sound_sample_description_version_1
 		// A 32-bit unsigned fixed-point number (16.16) that indicates the rate at which the sound samples were obtained.
 		getFixedPointUnsigned1616Number: () => {

--- a/packages/media-parser/src/get-sample-positions.ts
+++ b/packages/media-parser/src/get-sample-positions.ts
@@ -77,7 +77,7 @@ export const getSamplePositions = ({
 			const cts = dts + ctsOffset;
 
 			samples.push({
-				offset: chunks[i] + offsetInThisChunk,
+				offset: Number(chunks[i]) + offsetInThisChunk,
 				size,
 				isKeyframe,
 				dts,

--- a/packages/media-parser/src/test/parse-stco.test.ts
+++ b/packages/media-parser/src/test/parse-stco.test.ts
@@ -18,6 +18,7 @@ test('Parse stco box', () => {
 		iterator,
 		size: buf.length - 8,
 		offset: 0,
+		mode64Bit: false,
 	});
 	expect(result).toEqual({
 		type: 'stco-box',
@@ -46,6 +47,7 @@ test('Parse stco box with empty chunk', () => {
 		iterator,
 		size: buf.length - 8,
 		offset: 0,
+		mode64Bit: false,
 	});
 	expect(result).toEqual({
 		type: 'stco-box',


### PR DESCRIPTION
Larger ISO BM FF media files have two special cases:

- `mdat` atom might have size 1, in which case the size is encoded in 8 bytes after the atom name
- Instead of `stco` atom, there is a `co64` atom for 64-bit chunk offsets