### PR TITLE
`@remotion/media-parser`: Handle very large files (> 4GB)

### DIFF
--- a/packages/media-parser/src/boxes/iso-base-media/mdat/mdat.ts
+++ b/packages/media-parser/src/boxes/iso-base-media/mdat/mdat.ts
@@ -116,6 +116,7 @@ export const parseMdat = async ({
 		}
 
 		const remaining = size - (data.counter.getOffset() - fileOffset);
+		data.removeBytesRead();
 		if (remaining === 0) {
 			break;
 		}

--- a/packages/media-parser/src/boxes/iso-base-media/process-box.ts
+++ b/packages/media-parser/src/boxes/iso-base-media/process-box.ts
@@ -676,7 +676,7 @@ export const parseBoxes = async ({
 			};
 		}
 
-		iterator.discardFirstBytes();
+		iterator.removeBytesRead();
 	}
 
 	const mdatState = hasSkippedMdatProcessing(boxes);


### PR DESCRIPTION
- Correctly read length from header
- Discard found packets