### PR TITLE
Remove unused `path` import

### DIFF
--- a/packages/docs/docs/miscellaneous/ts-aliases.mdx
+++ b/packages/docs/docs/miscellaneous/ts-aliases.mdx
@@ -59,7 +59,6 @@ Remember that in Node.JS APIs, the config file does not apply, so you need to ad
 To not duplicate the aliases in your Webpack override and in your `tsconfig.json`, you can install `tsconfig-paths-webpack-plugin` and use it:
 
 ```ts
-import path from "path";
 import { Config } from "@remotion/cli/config";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

The `path` import is not used in the example.
I think it can be removed safely.