### PR TITLE
Docs: Corrected typo in <ThreeCanvas>

### DIFF
--- a/packages/docs/docs/three-canvas.mdx
+++ b/packages/docs/docs/three-canvas.mdx
@@ -60,7 +60,7 @@ export default ThreeBasic;
 
 ## Note on `<Sequence>`
 
-A [`<Sequence>`](/docs/sequence) by default will return a `<div>` component which is not allows inside a `<ThreeCanvas>`. To avoid an error, pass `layout="none"` to `<Sequence>`.
+A [`<Sequence>`](/docs/sequence) by default will return a `<div>` component which is not allowed inside a `<ThreeCanvas>`. To avoid an error, pass `layout="none"` to `<Sequence>`.
 
 ## See also
 


### PR DESCRIPTION
Corrected typo "is not allows" to "is not allowed".