### PR TITLE
fix(lambda): Always parse arguments as string

### DIFF
--- a/packages/cli/src/benchmark.ts
+++ b/packages/cli/src/benchmark.ts
@@ -320,7 +320,7 @@ export const benchmarkCommand = async (
 
 	const ids = (
 		remainingArgs[0]
-			? remainingArgs[0]
+			? String(remainingArgs[0])
 					.split(',')
 					.map((c) => c.trim())
 					.filter(truthy)

--- a/packages/cli/src/entry-point.ts
+++ b/packages/cli/src/entry-point.ts
@@ -36,13 +36,13 @@ export const findEntryPoint = ({
 	remotionRoot,
 	allowDirectory,
 }: {
-	args: string[];
+	args: (string | number)[];
 	remotionRoot: string;
 	logLevel: LogLevel;
 	allowDirectory: boolean;
 }): {
 	file: string | null;
-	remainingArgs: string[];
+	remainingArgs: (string | number)[];
 	reason: FoundReason;
 } => {
 	const result = findEntryPointInner(args, remotionRoot, logLevel);
@@ -74,17 +74,17 @@ const isBundledCode = (p: string) => {
 };
 
 const findEntryPointInner = (
-	args: string[],
+	args: (string | number)[],
 	remotionRoot: string,
 	logLevel: LogLevel,
 ): {
 	file: string | null;
 	isDirectory: boolean;
-	remainingArgs: string[];
+	remainingArgs: (string | number)[];
 	reason: FoundReason;
 } => {
 	// 1st priority: Explicitly passed entry point
-	let file: string | null = args[0];
+	let file: string | null = args[0] ? args[0].toString() : null;
 	if (file) {
 		Log.verbose(
 			{indent: false, logLevel},

--- a/packages/cli/src/get-composition-id.ts
+++ b/packages/cli/src/get-composition-id.ts
@@ -16,11 +16,11 @@ const getCompName = ({
 	cliArgs,
 	compositionIdFromUi,
 }: {
-	cliArgs: string[];
+	cliArgs: (string | number)[];
 	compositionIdFromUi: string | null;
 }): {
 	compName: string;
-	remainingArgs: string[];
+	remainingArgs: (string | number)[];
 	reason: string;
 } => {
 	if (compositionIdFromUi) {
@@ -33,7 +33,11 @@ const getCompName = ({
 
 	const [compName, ...remainingArgs] = cliArgs;
 
-	return {compName, remainingArgs, reason: 'Passed as argument'};
+	return {
+		compName: String(compName),
+		remainingArgs,
+		reason: 'Passed as argument',
+	};
 };
 
 export const getCompositionId = async ({
@@ -54,7 +58,7 @@ export const getCompositionId = async ({
 	binariesDirectory,
 	onBrowserDownload,
 }: {
-	args: string[];
+	args: (string | number)[];
 	compositionIdFromUi: string | null;
 	serializedInputPropsWithCustomSchema: string;
 	puppeteerInstance: HeadlessBrowser | undefined;
@@ -74,7 +78,7 @@ export const getCompositionId = async ({
 	compositionId: string;
 	reason: string;
 	config: VideoConfig;
-	argsAfterComposition: string[];
+	argsAfterComposition: (string | number)[];
 }> => {
 	const {
 		compName,

--- a/packages/cli/src/get-composition-with-dimension-override.ts
+++ b/packages/cli/src/get-composition-with-dimension-override.ts
@@ -31,7 +31,7 @@ export const getCompositionWithDimensionOverride = async ({
 }: {
 	height: number | null;
 	width: number | null;
-	args: string[];
+	args: (string | number)[];
 	compositionIdFromUi: string | null;
 	timeoutInMilliseconds: number;
 	puppeteerInstance: HeadlessBrowser | undefined;
@@ -51,7 +51,7 @@ export const getCompositionWithDimensionOverride = async ({
 	compositionId: string;
 	reason: string;
 	config: VideoConfig;
-	argsAfterComposition: string[];
+	argsAfterComposition: (string | number)[];
 }> => {
 	const returnValue = await getCompositionId({
 		args,

--- a/packages/cli/src/get-filename.ts
+++ b/packages/cli/src/get-filename.ts
@@ -15,7 +15,7 @@ export const getOutputFilename = ({
 	imageSequence: boolean;
 	compositionName: string;
 	defaultExtension: string;
-	args: string[];
+	args: (string | number)[];
 	fromUi: string | null;
 	indent: boolean;
 	logLevel: LogLevel;
@@ -32,7 +32,7 @@ export const getOutputFilename = ({
 		outputLocationFromUi: null,
 	});
 
-	const extension = RenderInternals.getExtensionOfFilename(filename);
+	const extension = RenderInternals.getExtensionOfFilename(String(filename));
 	if (imageSequence) {
 		if (extension !== null) {
 			throw new Error(
@@ -41,7 +41,7 @@ export const getOutputFilename = ({
 			);
 		}
 
-		return filename;
+		return String(filename);
 	}
 
 	if (extension === null && !imageSequence) {
@@ -52,5 +52,5 @@ export const getOutputFilename = ({
 		return `${filename}.${defaultExtension}`;
 	}
 
-	return filename;
+	return String(filename);
 };

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -127,7 +127,7 @@ export const renderVideoFlow = async ({
 	port: number | null;
 	height: number | null;
 	width: number | null;
-	remainingArgs: string[];
+	remainingArgs: (string | number)[];
 	compositionIdFromUi: string | null;
 	outputLocationFromUI: string | null;
 	overwrite: boolean;

--- a/packages/cli/src/render-flows/still.ts
+++ b/packages/cli/src/render-flows/still.ts
@@ -79,7 +79,7 @@ export const renderStillFlow = async ({
 	remotionRoot: string;
 	fullEntryPoint: string;
 	entryPointReason: string;
-	remainingArgs: string[];
+	remainingArgs: (string | number)[];
 	serializedInputPropsWithCustomSchema: string;
 	envVariables: Record<string, string>;
 	jpegQuality: number;

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -41,7 +41,7 @@ const {
 
 export const render = async (
 	remotionRoot: string,
-	args: string[],
+	args: (string | number)[],
 	logLevel: LogLevel,
 ) => {
 	const {

--- a/packages/cli/src/user-passed-output-location.ts
+++ b/packages/cli/src/user-passed-output-location.ts
@@ -3,7 +3,7 @@ import {ConfigInternals} from './config';
 import {parsedCli} from './parsed-cli';
 
 export const getUserPassedOutputLocation = (
-	args: string[],
+	args: (string | number)[],
 	uiPassedOutName: string | null,
 ) => {
 	const filename =
@@ -12,7 +12,7 @@ export const getUserPassedOutputLocation = (
 		parsedCli.output ??
 		ConfigInternals.getOutputLocation();
 
-	return filename;
+	return String(filename);
 };
 
 export const getOutputLocation = ({
@@ -25,7 +25,7 @@ export const getOutputLocation = ({
 	compositionId: string;
 	outputLocationFromUi: string | null;
 	defaultExtension: string;
-	args: string[];
+	args: (string | number)[];
 	type: 'asset' | 'sequence';
 }) => {
 	if (

--- a/packages/cloudrun/src/cli/args.ts
+++ b/packages/cloudrun/src/cli/args.ts
@@ -21,6 +21,7 @@ type servicesCommandLineOptions = {
 export const parsedCloudrunCli =
 	CliInternals.minimist<servicesCommandLineOptions>(process.argv.slice(2), {
 		boolean: CliInternals.BooleanFlags,
+		string: ['_']
 	});
 
 export const forceFlagProvided =

--- a/packages/cloudrun/src/cli/args.ts
+++ b/packages/cloudrun/src/cli/args.ts
@@ -21,7 +21,7 @@ type servicesCommandLineOptions = {
 export const parsedCloudrunCli =
 	CliInternals.minimist<servicesCommandLineOptions>(process.argv.slice(2), {
 		boolean: CliInternals.BooleanFlags,
-		string: ['_']
+		string: ['_'],
 	});
 
 export const forceFlagProvided =

--- a/packages/lambda/src/cli/args.ts
+++ b/packages/lambda/src/cli/args.ts
@@ -48,7 +48,7 @@ export const parsedLambdaCli = CliInternals.minimist<LambdaCommandLineOptions>(
 	process.argv.slice(2),
 	{
 		boolean: CliInternals.BooleanFlags,
-		string: ['_']
+		string: ['_'],
 	},
 );
 

--- a/packages/lambda/src/cli/args.ts
+++ b/packages/lambda/src/cli/args.ts
@@ -48,6 +48,7 @@ export const parsedLambdaCli = CliInternals.minimist<LambdaCommandLineOptions>(
 	process.argv.slice(2),
 	{
 		boolean: CliInternals.BooleanFlags,
+		string: ['_']
 	},
 );
 


### PR DESCRIPTION
This PR fixes the fact that minimist is parsing numeric arguments as numbers. Remotion expects strings (in internal TS types).
I've found this fix while passing numeric ids like `1` to `npx remotion lambda render <SITE_URL> 1`.
This results in `Error: Could not find composition with ID 1. Available compositions: 1, 2`

Based on docs of minimist (https://github.com/minimistjs/minimist):
```
Numeric-looking arguments will be returned as numbers unless opts.string or opts.boolean contains that argument name. To disable numeric conversion for non-option arguments, add '_' to opts.string.
```

This PR disables implicit type conversion of numeric arguments to javascript number type.

Please test if this really fixes the issue, i'm not familiar enough with remotion to test this myself