### PR TITLE
enable word for word flag from whisper

### DIFF
--- a/packages/docs/docs/install-whisper-cpp/transcribe.mdx
+++ b/packages/docs/docs/install-whisper-cpp/transcribe.mdx
@@ -63,7 +63,7 @@ Set to `false` if you use an older version of Whisper.cpp.
 
 ### `model?`
 
-_optional - default: `base.en`_
+_default: `base.en`_
 
 Specify a specific Whisper model for the transcription.
 
@@ -73,7 +73,7 @@ Make sure the model you want to use exists in your `whisper.cpp/models` folder. 
 
 ### `modelFolder?`
 
-_optional - default: whisperPath/models_
+_default: whisperPath/models_
 
 If you saved Whisper models to a specific folder, pass its path here.
 
@@ -81,7 +81,7 @@ Uses the `whisper.cpp/models` folder at the location defined through `whisperPat
 
 ### `translateToEnglish?`
 
-_optional - default: false_
+_default: false_
 
 Set this boolean flag to `true` if you want to get a translated transcription of the provided file in English.
 Make sure to not use a \*.en model, as they will not be able to translate a foreign language to english.
@@ -96,7 +96,7 @@ Whether to print the output of the transcription process to the console. Default
 
 ### `tokensPerItem?`<AvailableFrom v="4.0.141" />
 
-_optional - default: `1`_
+_default: `1`_
 
 The maximum amount of tokens included in each transcription item.
 
@@ -106,9 +106,13 @@ Set this flag to `null`, to use `whisper.cpp`'s default token grouping (useful f
 `tokensPerItem` can only be set when `tokenLevelTimestamps` is set to `false`.
 :::
 
+### `splitOnWord?`<AvailableFrom v="4.0.208" />
+
+[Adds the `--split-on-word` flag to Whisper.cpp](https://github.com/remotion-dev/remotion/pull/4257) for cleaner word-for-word output.
+
 ### `language?`<AvailableFrom v="4.0.142" />
 
-_optional - default: null_
+_default: null_
 
 Passes the `-l` flag to Whisper.cpp to specific spoken language of the audio file.
 

--- a/packages/install-whisper-cpp/src/transcribe.ts
+++ b/packages/install-whisper-cpp/src/transcribe.ts
@@ -120,6 +120,7 @@ const transcribeToTemporaryFile = async ({
 	printOutput,
 	tokensPerItem,
 	language,
+	splitOnWord,
 	signal,
 	onProgress,
 }: {
@@ -133,6 +134,7 @@ const transcribeToTemporaryFile = async ({
 	printOutput: boolean;
 	tokensPerItem: number | null;
 	language: Language | null;
+	splitOnWord: boolean | null;
 	signal: AbortSignal | null;
 	onProgress: TranscribeOnProgress | null;
 }): Promise<{
@@ -163,6 +165,7 @@ const transcribeToTemporaryFile = async ({
 		['-pp'], // print progress
 		translate ? '-tr' : null,
 		language ? ['-l', language.toLowerCase()] : null,
+		splitOnWord ? ['--split-on-word', splitOnWord] : null,
 	]
 		.flat(1)
 		.filter(Boolean) as string[];
@@ -247,6 +250,7 @@ export const transcribe = async <HasTokenLevelTimestamps extends boolean>({
 	printOutput = true,
 	tokensPerItem,
 	language,
+	splitOnWord,
 	signal,
 	onProgress,
 }: {
@@ -259,6 +263,7 @@ export const transcribe = async <HasTokenLevelTimestamps extends boolean>({
 	printOutput?: boolean;
 	tokensPerItem?: true extends HasTokenLevelTimestamps ? never : number | null;
 	language?: Language | null;
+	splitOnWord?: boolean;
 	signal?: AbortSignal;
 	onProgress?: TranscribeOnProgress;
 }): Promise<TranscriptionJson<HasTokenLevelTimestamps>> => {
@@ -292,6 +297,7 @@ export const transcribe = async <HasTokenLevelTimestamps extends boolean>({
 		tokensPerItem: tokenLevelTimestamps ? 1 : tokensPerItem ?? 1,
 		language: language ?? null,
 		signal: signal ?? null,
+		splitOnWord: splitOnWord ?? null,
 		onProgress: onProgress ?? null,
 	});
 


### PR DESCRIPTION
Enable `--split-on-word` flag for cleaner word for word output.
https://github.com/ggerganov/whisper.cpp/issues/49

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->


