### PR TITLE
`remotion`: Remove `onVideoFrame` from `<Video>`

### DIFF
--- a/packages/core/src/video/Video.tsx
+++ b/packages/core/src/video/Video.tsx
@@ -34,7 +34,6 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 		_remotionInternalNativeLoopPassed,
 		showInTimeline,
 		onAutoPlayError,
-		onVideoFrame,
 		crossOrigin,
 		...otherProps
 	} = props;
@@ -65,6 +64,8 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 		[setDurations],
 	);
 
+	const onVideoFrame = useCallback(() => {}, []);
+
 	const durationFetched =
 		durations[getAbsoluteSrc(preloadedSrc)] ??
 		durations[getAbsoluteSrc(props.src)];
@@ -86,7 +87,6 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 				<Video
 					{...propsOtherThanLoop}
 					ref={ref}
-					onVideoFrame={onVideoFrame}
 					_remotionInternalNativeLoopPassed
 				/>
 			</Loop>
@@ -108,7 +108,6 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			>
 				<Video
 					pauseWhenBuffering={pauseWhenBuffering ?? false}
-					onVideoFrame={onVideoFrame}
 					{...otherProps}
 					ref={ref}
 				/>
@@ -134,7 +133,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			onlyWarnForMediaSeekingError={false}
 			{...otherProps}
 			ref={ref}
-			onVideoFrame={onVideoFrame ?? null}
+			onVideoFrame={null}
 			// Proposal: Make this default to true in v5
 			pauseWhenBuffering={pauseWhenBuffering ?? false}
 			onDuration={onDuration}

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -10,7 +10,6 @@ export type RemotionMainVideoProps = {
 	 */
 	_remotionInternalNativeLoopPassed?: boolean;
 	_remotionDebugSeeking?: boolean;
-	onVideoFrame?: OnVideoFrame;
 };
 
 export type RemotionVideoProps = Omit<

--- a/packages/docs/docs/video.mdx
+++ b/packages/docs/docs/video.mdx
@@ -250,13 +250,6 @@ If you don't pass a callback, the video will be muted and be retried once.
 This prop is useful if you want to handle the error yourself, e.g. for pausing the Player.  
 Read more here about [autoplay restrictions](/docs/player/autoplay).
 
-### `onVideoFrame?`<AvailableFrom v="4.0.190" />
-
-A callback function that gets called when a frame is extracted from the video.  
-Useful for [video manipulation](/docs/video-manipulation).  
-The callback is called with a [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource) object.  
-When you use the `<Video>` tag, it is always a `HTMLVideoElement` object.
-
 ### `crossOrigin?`<AvailableFrom v="4.0.190" />
 
 Corresponds to the [`crossOrigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-crossorigin) attribute of the `<video>` element.  


### PR DESCRIPTION
It was meant to only be added to `<OffthreadVideo>`.  
If drawing a `<Video>` to a canvas, the old method may continue to be used.

During rendering, `onVideoFrame` on a `<Video>` did not work at all, therefore I feel it is same to assume this will not break any production workflows.