### PR TITLE
Brownout: Download Chrome Headless Shell instead of using installed Chrome

### DIFF
--- a/packages/cli/src/browser-download-bar.ts
+++ b/packages/cli/src/browser-download-bar.ts
@@ -3,7 +3,7 @@ import {RenderInternals} from '@remotion/renderer';
 import {chalk} from './chalk';
 import {Log} from './log';
 import {makeProgressBar} from './make-progress-bar';
-import {createOverwriteableCliOutput} from './progress-bar';
+import {LABEL_WIDTH, createOverwriteableCliOutput} from './progress-bar';
 import {shouldUseNonOverlayingLogger} from './should-use-non-overlaying-logger';
 import {truthy} from './truthy';
 
@@ -19,9 +19,8 @@ const makeDownloadProgress = ({
 	const progress = bytesDownloaded / totalBytes;
 
 	return [
-		`    +`,
+		`${doneIn ? 'Got' : 'Getting'} Headless Shell`.padEnd(LABEL_WIDTH, ' '),
 		makeProgressBar(progress, false),
-		`${doneIn ? 'Got' : 'Getting'} Headless Shell`,
 		doneIn === null
 			? (progress * 100).toFixed(0) + '%'
 			: chalk.gray(`${doneIn}ms`),
@@ -42,7 +41,9 @@ export const defaultBrowserDownloadProgress = ({
 	return () => {
 		Log.info(
 			{indent, logLevel},
-			'Downloading Chrome Headless Shell https://www.remotion.dev/chrome-headless-shell',
+			chalk.gray(
+				'Downloading Chrome Headless Shell https://www.remotion.dev/chrome-headless-shell',
+			),
 		);
 
 		const updatesDontOverwrite = shouldUseNonOverlayingLogger({logLevel});

--- a/packages/cli/src/browser-download-bar.ts
+++ b/packages/cli/src/browser-download-bar.ts
@@ -40,7 +40,6 @@ export const defaultBrowserDownloadProgress = ({
 	quiet: boolean;
 }): OnBrowserDownload => {
 	return () => {
-		Log.info({indent, logLevel}, 'No local browser could be found.');
 		Log.info(
 			{indent, logLevel},
 			'Downloading Chrome Headless Shell https://www.remotion.dev/chrome-headless-shell',

--- a/packages/docs/docs/chromium-flags.mdx
+++ b/packages/docs/docs/chromium-flags.mdx
@@ -67,7 +67,7 @@ Config.setChromiumIgnoreCertificateErrors(true);
 Prior to `v3.3.39`, the option was called `Config.Puppeteer.setChromiumIgnoreCertificateErrors()`.
 :::
 
-## `--disable-headless`
+## ~`--disable-headless`~
 
 <Options id="disable-headless" />
 

--- a/packages/docs/docs/cli/benchmark.mdx
+++ b/packages/docs/docs/cli/benchmark.mdx
@@ -109,7 +109,7 @@ _optional_
 
 Inherited from [`npx remotion render`](/docs/cli/render#--disable-web-security)
 
-### `--disable-headless?`
+### ~`--disable-headless?`~
 
 _optional_
 

--- a/packages/docs/docs/cli/compositions.mdx
+++ b/packages/docs/docs/cli/compositions.mdx
@@ -74,7 +74,7 @@ _available since v2.6.5_
 
 This will most notably disable CORS in Chrome among other security features.
 
-### `--disable-headless?`
+### ~`--disable-headless?`~
 
 <Options id="disable-headless"  />
 

--- a/packages/docs/docs/cli/render.mdx
+++ b/packages/docs/docs/cli/render.mdx
@@ -177,9 +177,9 @@ Results in invalid SSL certificates in Chrome, such as self-signed ones, being i
 
 This will most notably disable CORS in Chrome among other security features.
 
-### `--disable-headless`<AvailableFrom v="2.6.5" />
+### ~`--disable-headless`~<AvailableFrom v="2.6.5" />
 
-Opens an actual browser during rendering to observe the render.
+<Options id="disable-headless"  />
 
 ### `--gl`
 

--- a/packages/docs/docs/cli/still.mdx
+++ b/packages/docs/docs/cli/still.mdx
@@ -104,9 +104,9 @@ Results in invalid SSL certificates in Chrome, such as self-signed ones, being i
 
 This will most notably disable CORS in Chrome among other security features.
 
-### `--disable-headless`<AvailableFrom v="2.6.5" />
+### ~`--disable-headless`~<AvailableFrom v="2.6.5" />
 
-Opens an actual browser during rendering to observe the render.
+<Options id="disable-headless"  />
 
 ### `--gl`
 

--- a/packages/docs/docs/lambda/cli/compositions.mdx
+++ b/packages/docs/docs/lambda/cli/compositions.mdx
@@ -107,9 +107,9 @@ Results in invalid SSL certificates in Chrome, such as self-signed ones, being i
 
 This will most notably disable CORS in Chrome among other security features.
 
-### `--disable-headless`
+### ~`--disable-headless`~
 
-Opens an actual browser to observe the composition fetching.
+<Options id="disable-headless"  />
 
 ### `--quiet`, `--q`
 

--- a/packages/docs/docs/miscellaneous/chrome-headless-shell.mdx
+++ b/packages/docs/docs/miscellaneous/chrome-headless-shell.mdx
@@ -60,6 +60,21 @@ An executable `./chrome-headless-shell` (`.\chrome-headless-shell.exe` on Window
 Remotion previously used the desktop version of Chrome that many users had already installed.  
 This workflow is bound to break at some point, which is why Remotion is not picking up the desktop version of Chrome anymore.
 
+## Best practices
+
+To ensure your project does not get disrupted by an upcoming Chrome change, you should use the Remotion mechanisms which uses and pins the version of Chrome Headless Shell.  
+
+- Use Remotion v4.0.208 or later to not pick up an externally installed browser.
+- Use [`npx remotion browser ensure`](/docs/cli/browser/ensure) to ensure Chrome Headless Shell is available.
+- Do not download Chrome in your Dockerfile, but do install [Linux dependencies](/docs/miscellaneous/linux-dependencies) if you use Linux.
+- Do not use `--browser-executable`, `browserExecutable` or `setBrowserExecutable()` options to override the Headless Shell with an incompatible Chrome version.
+
+:::warning
+Note: Most Linux distros do not allow you to pin a Chrome package.  
+If you use a Remotion version below v4.0.208, you are at risk of Chrome automatically being upgraded to a version that does not ship with a headless mode.  
+:::
+
+
 ## What is Chrome Headless Shell?
 
 Chrome used to ship with a `--headless` flag, which Remotion would use.
@@ -83,13 +98,16 @@ Upgrades may happen in a patch release and will be listed here.
 
 If you are using [Remotion Lambda](/docs/lambda) or [Cloud Run](/docs/cloudrun), you don't need to worry about installing a browser - it is included in the runtime already.
 
-## Thorium (v4.0.18 - v4.0.135)
+
+## Previous changes
+
+### Thorium (v4.0.18 - v4.0.135)
 
 In these versions, if no local browser can be found, an instance of [Thorium](https://thorium.rocks/) is downloaded.
 
 Thorium is a free and open-source browser forked off Chromium, which includes the codecs needed to render videos.
 
-## Chromium (before v4.0.18)
+### Chromium (before v4.0.18)
 
 In previous versions, Remotion would download the free version of Chromium, which would not include codecs for the proprietary H.264 and H.265 codecs.
 This would often lead to problems when using the [`<Video>`](/docs/video) tag.

--- a/packages/docs/docs/miscellaneous/chrome-headless-shell.mdx
+++ b/packages/docs/docs/miscellaneous/chrome-headless-shell.mdx
@@ -5,26 +5,29 @@ title: Chrome Headless Shell
 crumb: "FAQ"
 ---
 
-# Chrome Headless Shell<AvailableFrom v="4.0.137"/>
+# Chrome Headless Shell<AvailableFrom v="4.0.208"/>
 
-Remotion will download [Chrome Headless Shell](https://developer.chrome.com/blog/chrome-headless-shell) if no local browser can be found and an API for rendering videos is used.
+From v4.0.208, Remotion will download [Chrome Headless Shell](https://developer.chrome.com/blog/chrome-headless-shell) before the first render.  
+This will future-proof your Remotion project, because headless mode will be removed in a future version of Chrome.  
 
 ## Supported platforms
 
 The following platforms are supported:
 
-- Linux (x64)
-- Windows (x64)
 - macOS (x64 and arm64)
+- Windows (x64)
+- Linux (x64 and arm64) - [install the Linux dependencies](/docs/miscellaneous/linux-dependencies)
 
-:::note
-[Remotion Lambda](/docs/lambda) is also support despite being arm64 on Linux.
-:::
 
-## Ensure a local browser is found
+## Ensure Headless Shell is available
 
-Use [`ensureBrowser()`](/docs/renderer/ensure-browser) or [`npx remotion browser ensure`](/docs/cli/browser/ensure) to ensure a local browser is found.  
-This function will download Chrome Headless Shell if no local browser is found.
+There are two ways to ensure Chrome Headless Shell is available:
+
+- [`npx remotion browser ensure`](/docs/cli/browser/ensure) on the command line
+- [`ensureBrowser()`](/docs/renderer/ensure-browser) as a Node.js / Bun API
+
+It is recommended use call these functions if you do server-side rendering.  
+That way, if a request comes in wanting to render a video, the browser is already downloaded and ready to go.
 
 ## Bring your own binary
 
@@ -47,12 +50,17 @@ Chrome Headless Shell will download to
 node_modules/.remotion/chrome-headless-shell/[platform]/chrome-headless-shell-[platform]
 ```
 
-`platform` can be one of `mac-arm64`, `mac-x64`, `linux64` or `win64`.
+`platform` can be one of `mac-arm64`, `mac-x64`, `linux64`, `linux-arm64` or `win64`.
 
 At this path, a folder with the necessary files will be created.  
 An executable `./chrome-headless-shell` (`.\chrome-headless-shell.exe` on Windows) will be created.
 
-## Chrome vs. Chrome Headless Shell
+## Why this change?
+
+Remotion previously used the desktop version of Chrome that many users had already installed.  
+This workflow is bound to break at some point, which is why Remotion is not picking up the desktop version of Chrome anymore.
+
+## What is Chrome Headless Shell?
 
 Chrome used to ship with a `--headless` flag, which Remotion would use.
 
@@ -66,16 +74,14 @@ The old headless mode is being extracted into "Chrome Headless Shell".
 
 Hence we encourage you to use Chrome Headless Shell to future-proof your Remotion application.
 
-## Chrome vs. Chromium
+## Version
 
-Chromium is the open-source project that Chrome is based on. Some versions of Chromium don't the necessary codecs for the [`<Video >`](/docs/video) tag as well as for functions in [`@remotion/media-utils`](/docs/media-utils).
+Remotion will download a well-tested Chrome version from the `123.0.6312` release line.  
+Upgrades may happen in a patch release and will be listed here.
 
-This is why we recommend Chrome over Chromium.
+## On Lambda and Cloud Run
 
-## Changes in Remotion v5.0
-
-Remotion 5.0 will not recognize your regular Chrome browser anymore.  
-You will need to use Chrome Headless Shell, because Chrome is [discontinuing the `--headless=old`](#chrome-vs-chrome-headless-shell) mode.
+If you are using [Remotion Lambda](/docs/lambda) or [Cloud Run](/docs/cloudrun), you don't need to worry about installing a browser - it is included in the runtime already.
 
 ## Thorium (v4.0.18 - v4.0.135)
 

--- a/packages/docs/docs/renderer/render-media.mdx
+++ b/packages/docs/docs/renderer/render-media.mdx
@@ -387,7 +387,7 @@ _boolean - default `false`_
 
 Results in invalid SSL certificates, such as self-signed ones, being ignored.
 
-#### `headless?`
+#### ~`headless?`~
 
 <Options id="disable-headless" />
 

--- a/packages/docs/docs/renderer/render-still.mdx
+++ b/packages/docs/docs/renderer/render-still.mdx
@@ -185,7 +185,7 @@ _boolean - default `false`_
 
 Results in invalid SSL certificates, such as self-signed ones, being ignored.
 
-#### `headless?`
+#### ~`headless?`~
 
 <Options id="disable-headless" />
 

--- a/packages/lambda/src/test/integration/webhooks.test.ts
+++ b/packages/lambda/src/test/integration/webhooks.test.ts
@@ -1,4 +1,4 @@
-import {RenderInternals} from '@remotion/renderer';
+import {RenderInternals, ensureBrowser} from '@remotion/renderer';
 import {ServerlessRoutines} from '@remotion/serverless/client';
 import path from 'path';
 import {VERSION} from 'remotion/version';
@@ -29,7 +29,8 @@ beforeEach(() => {
 	};
 });
 
-beforeAll(() => {
+beforeAll(async () => {
+	await ensureBrowser();
 	return async () => {
 		await RenderInternals.killAllBrowsers();
 	};

--- a/packages/renderer/src/browser/browser-download-progress-bar.ts
+++ b/packages/renderer/src/browser/browser-download-progress-bar.ts
@@ -14,7 +14,6 @@ export const defaultBrowserDownloadProgress =
 		api: string;
 	}): OnBrowserDownload =>
 	() => {
-		Log.info({indent, logLevel}, 'No local browser could be found.');
 		Log.info(
 			{indent, logLevel},
 			'Downloading Chrome Headless Shell https://www.remotion.dev/docs/miscellaneous/chrome-headless-shell',

--- a/packages/renderer/src/get-local-browser.ts
+++ b/packages/renderer/src/get-local-browser.ts
@@ -1,43 +1,7 @@
 import fs from 'fs';
-import {homedir} from 'node:os';
-import {NoReactInternals} from 'remotion/no-react';
 
 const getSearchPathsForProduct = () => {
-	if (NoReactInternals.ENABLE_V5_BREAKING_CHANGES) {
-		return [];
-	}
-
-	return [
-		process.env.PUPPETEER_EXECUTABLE_PATH ?? null,
-		process.platform === 'darwin'
-			? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-			: null,
-		process.platform === 'linux' ? '/usr/bin/google-chrome' : null,
-		process.platform === 'linux' ? '/usr/bin/chromium-browser' : null,
-		process.platform === 'linux' ? '/usr/bin/chromium' : null, // Debian
-		process.platform === 'linux'
-			? '/app/.apt/usr/bin/google-chrome-stable'
-			: null,
-		process.platform === 'win32'
-			? 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'
-			: null,
-		process.platform === 'win32'
-			? 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe'
-			: null,
-		process.platform === 'win32'
-			? homedir() + '\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe'
-			: null,
-		process.platform === 'win32'
-			? 'C:\\Program Files\\Google\\Chrome SxS\\Application\\chrome.exe'
-			: null,
-		process.platform === 'win32'
-			? 'C:\\Program Files (x86)\\Google\\Chrome SxS\\Application\\chrome.exe'
-			: null,
-		process.platform === 'win32'
-			? homedir() +
-				'\\AppData\\Local\\Google\\Chrome SxS\\Application\\chrome.exe'
-			: null,
-	].filter(Boolean) as string[];
+	return [];
 };
 
 export const getLocalBrowser = () => {

--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -20,6 +20,10 @@ type OnlyV4Options =
 	typeof NoReactInternals.ENABLE_V5_BREAKING_CHANGES extends true
 		? {}
 		: {
+				/**
+				 * @deprecated - Will be removed in v5.
+				 * Chrome Headless shell does not allow disabling headless mode anymore.
+				 */
 				headless?: boolean;
 			};
 

--- a/packages/renderer/src/options/headless.tsx
+++ b/packages/renderer/src/options/headless.tsx
@@ -10,8 +10,14 @@ export const headlessOption = {
 	cliFlag,
 	description: () => (
 		<>
-			If disabled, the render will open an actual Chrome window where you can
-			see the render happen. The default is headless mode.
+			Deprecated - will be removed in 5.0.0. With the migration to{' '}
+			<a href="/docs/miscellaneous/chrome-headless-shell">
+				Chrome Headless Shell
+			</a>
+			, this option is not functional anymore.
+			<br />
+			<br /> If disabled, the render will open an actual Chrome window where you
+			can see the render happen. The default is headless mode.
 		</>
 	),
 	ssrName: 'headless',

--- a/packages/renderer/src/test/render-still.test.ts
+++ b/packages/renderer/src/test/render-still.test.ts
@@ -1,5 +1,10 @@
-import {expect, test} from 'bun:test';
+import {beforeAll, expect, test} from 'bun:test';
+import {ensureBrowser} from '../ensure-browser';
 import {renderStill} from '../render-still';
+
+beforeAll(async () => {
+	await ensureBrowser();
+});
 
 test(
 	'Need to pass valid metadata',


### PR DESCRIPTION
We'll stop picking up the default browser in this version and instead download Chrome Headless Shell.  
Hope it all goes well, but maybe we need to backpeddle