### PR TITLE
`@remotion/lambda`: Show missing chunks instead of existing ones

### DIFF
--- a/packages/lambda/src/functions/helpers/get-progress.ts
+++ b/packages/lambda/src/functions/helpers/get-progress.ts
@@ -179,7 +179,7 @@ export const getProgress = async <Provider extends CloudProvider>({
 				.map((_, i) => i)
 				.filter((index) => {
 					return (
-						typeof (overallProgress.chunks ?? []).find((c) => c === index) !==
+						typeof (overallProgress.chunks ?? []).find((c) => c === index) ===
 						'undefined'
 					);
 				})


### PR DESCRIPTION
Fixes a regression from about 2 weeks ago