### PR TITLE
`@remotion/media-parser`: Not looking for children of EBML with size 0

### DIFF
--- a/packages/media-parser/src/boxes/webm/parse-ebml.ts
+++ b/packages/media-parser/src/boxes/webm/parse-ebml.ts
@@ -110,6 +110,10 @@ export const parseEbml = async (
 
 		// eslint-disable-next-line no-constant-condition
 		while (true) {
+			if (size === 0) {
+				break;
+			}
+
 			const offset = iterator.counter.getOffset();
 			const value = await parseEbml(iterator, parserContext);
 			const remapped = await postprocessEbml({


### PR DESCRIPTION
Thanks @kittygiraudel for reporting this