### PR TITLE
`@remotion/media-parser`: Correctly treat EBML size of -1

### DIFF
--- a/packages/media-parser/src/buffer-iterator.ts
+++ b/packages/media-parser/src/buffer-iterator.ts
@@ -459,6 +459,13 @@ export const getArrayBufferIterator = (
 				value = (value << 8) | d[i];
 			}
 
+			// Livestreamed segments sometimes have a Cluster length of 0xFFFFFFFFFFFFFF
+			// which we parse as -1
+			// this should be treated as Infinity
+			if (value === -1) {
+				return Infinity;
+			}
+
 			return value;
 		},
 		getUint8,

--- a/packages/media-parser/src/readers/from-fetch.ts
+++ b/packages/media-parser/src/readers/from-fetch.ts
@@ -18,7 +18,7 @@ export const fetchReader: ReaderInterface = {
 			return Promise.reject(
 				new Error(
 					resolvedUrl +
-						' is not a URL - needs to start with http:// or https://. If you want to read a local file, pass `nodeReader` to parseMedia().',
+						' is not a URL - needs to start with http:// or https://. If you want to read a local file, pass `reader: nodeReader` to parseMedia().',
 				),
 			);
 		}


### PR DESCRIPTION
It means that no more segments will follow after this.

This is possible if the video is being encoded while streaming