### PR TITLE
`@remotion/media-parser`: Detect `twos` audio codec

### DIFF
--- a/packages/media-parser/src/get-audio-codec.ts
+++ b/packages/media-parser/src/get-audio-codec.ts
@@ -195,7 +195,13 @@ export const getAudioCodecStringFromTrak = (
 	};
 };
 
-const getAudioCodecFromAudioCodecInfo = (codec: AudioCodecInfo) => {
+const getAudioCodecFromAudioCodecInfo = (
+	codec: AudioCodecInfo,
+): MediaParserAudioCodec => {
+	if (codec.format === 'twos') {
+		return 'pcm-s16';
+	}
+
 	if (codec.format === 'sowt') {
 		return 'aiff';
 	}
@@ -216,7 +222,7 @@ const getAudioCodecFromAudioCodecInfo = (codec: AudioCodecInfo) => {
 		throw new Error('Unknown mp4a codec: ' + codec.primarySpecificator);
 	}
 
-	throw new Error('Unknown audio format: ' + codec.format);
+	throw new Error(`Unknown audio format: ${codec.format}`);
 };
 
 export const getAudioCodecFromTrack = (track: TrakBox) => {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
