### PR TITLE
In Img, wait for decode() before continueRender().

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -147,7 +147,14 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 					: () => undefined;
 			const {current} = imageRef;
 
+			let unmounted = false;
+
 			const onComplete = () => {
+				// the decode() promise isn't cancelable -- it may still resolve after unmounting
+				if (unmounted) {
+					return;
+				}
+
 				if ((errors.current[imageRef.current?.src as string] ?? 0) > 0) {
 					delete errors.current[imageRef.current?.src as string];
 					// eslint-disable-next-line no-console
@@ -159,6 +166,8 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 				}
 
 				if (current) {
+					current.src = actualSrc;
+
 					onImageFrame?.(current);
 				}
 
@@ -166,21 +175,29 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 				continueRender(newHandle);
 			};
 
-			const didLoad = () => {
-				onComplete();
-			};
+			const newImg = new Image();
+			newImg.src = actualSrc;
 
-			if (current?.complete) {
-				onComplete();
-			} else {
-				current?.addEventListener('load', didLoad, {once: true});
-			}
+			newImg
+				.decode()
+				.then(onComplete)
+				.catch((err) => {
+					// fall back to onload event if decode() fails
+					// eslint-disable-next-line no-console
+					console.warn(err);
+
+					if (newImg.complete) {
+						onComplete();
+					} else {
+						newImg.addEventListener('load', onComplete);
+					}
+				});
 
 			// If tag gets unmounted, clear pending handles because image is not going to load
 			return () => {
-				current?.removeEventListener('load', didLoad);
+				unmounted = true;
+				newImg.removeEventListener('load', onComplete);
 				unblock();
-
 				continueRender(newHandle);
 			};
 		}, [
@@ -194,9 +211,8 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 		]);
 	}
 
-	return (
-		<img {...props} ref={imageRef} src={actualSrc} onError={didGetError} />
-	);
+	// src gets set once we've loaded and decoded the image.
+	return <img {...props} ref={imageRef} onError={didGetError} />;
 };
 
 /**


### PR DESCRIPTION
This PR aims to ensure that images are fully decoded before we capture a frame. This is to see if we can avoid the issue where occasionally OffthreadVideo renders a transparent frame.

Notes:

- I originally tried just waiting on `current.decode()`, but it would throw a decoding exception every time. Seems like maybe it was from calling it on elements that were already in the process of decoding? Hard to tell exactly, but I couldn't reproduce the error when using `new Image()`.
- Related, [there are some bug reports](https://issues.chromium.org/issues/40792189) that Chrome sometimes throws decoding errors unexpectedly. So I set it up to fall back to the old "load"/complete logic if that happens.
- I removed the didLoad function since it didn't seem to serve a purpose.
- I only assign the rendered img src once it has decoded from `newImg`. This is to avoid double-decoding. I was able to test and debug this by using the Performance tab in Chrome, checking "Enable advanced paint instrumentation (slow)", and then looking for "Image Decode" bars in the Thread Pool area. If the src was assigned in the JSX, there was an extra decode. (This can technically be accomplished by modifying certain styles like display:none, too, but this change seemed to have the fewest complexity trade-offs.)

I didn't add an onload or decode() for the `current` img. I think that should be okay because of this from [the spec section 4.8.4.3.5 Updating the image data](https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data) in bullet 7.4.4:

> 7. If the [list of available images](https://html.spec.whatwg.org/multipage/images.html#list-of-available-images) contains an entry for key, then:
> ...
> 7.4. Let [current request](https://html.spec.whatwg.org/multipage/images.html#current-request) be a new [image request](https://html.spec.whatwg.org/multipage/images.html#image-request) whose [image data](https://html.spec.whatwg.org/multipage/images.html#img-req-data) is that of the entry and whose [state](https://html.spec.whatwg.org/multipage/images.html#img-req-state) is [completely available](https://html.spec.whatwg.org/multipage/images.html#img-all).
> 7.5 [Prepare current request for presentation](https://html.spec.whatwg.org/multipage/images.html#prepare-an-image-for-presentation) given img.
> ...

One thing I'm worried about with this PR is that, in the browser, it seems like `decode()` takes significantly longer to resolve than when listening for the "load" event. If this slows things down by a lot, it might be a non-starter. On the other hand, I compared the render speed of the "OffthreadRemoteVideo" example composition locally, and it seemed to be about the same or faster.

Is it possible to do an OffthreadVideo benchmark comparison to see if it causes a noticeable speed regression?