### PR TITLE
Add missing full-stop

### DIFF
--- a/packages/docs/docs/sequence.mdx
+++ b/packages/docs/docs/sequence.mdx
@@ -244,7 +244,7 @@ You can give your sequence a name and it will be shown as the label of the seque
 
 _optional_
 
-Either `"absolute-fill"` _(default)_ or `"none"` By default, your sequences will be absolutely positioned, so they will overlay each other. If you would like to opt out of it and handle layouting yourself, pass `layout="none"`. Available since v1.4.
+Either `"absolute-fill"` _(default)_ or `"none"`. By default, your sequences will be absolutely positioned, so they will overlay each other. If you would like to opt out of it and handle layouting yourself, pass `layout="none"`. Available since v1.4.
 
 ### `style`<AvailableFrom v="3.0.27"/>
 


### PR DESCRIPTION
The sentence was a bit confusing without the full-stop, I thought it was contradicting what the default was :)