### PR TITLE
`@remotion/renderer`: show HTTP status code and headers of failed resources

### DIFF
--- a/packages/renderer/src/browser/handle-failed-resource.ts
+++ b/packages/renderer/src/browser/handle-failed-resource.ts
@@ -1,0 +1,59 @@
+import type {LogLevel} from '../log-level';
+import {Log} from '../logger';
+import type {HTTPRequest} from './HTTPRequest';
+import type {
+	LoadingFailedEvent,
+	ResponseReceivedExtraInfoEvent,
+} from './devtools-types';
+
+export const handleFailedResource = ({
+	extraInfo,
+	logLevel,
+	indent,
+	request,
+	event,
+}: {
+	extraInfo: ResponseReceivedExtraInfoEvent[];
+	logLevel: LogLevel;
+	indent: boolean;
+	request: HTTPRequest;
+	event: LoadingFailedEvent;
+}) => {
+	const firstExtraInfo = extraInfo[0] ?? null;
+
+	Log.warn(
+		{indent, logLevel},
+		`Browser failed to load ${request._url} (${event.type}): ${event.errorText}`,
+	);
+	if (firstExtraInfo) {
+		Log.warn(
+			{indent, logLevel},
+			'Status code:',
+			firstExtraInfo.statusCode,
+			', headers:',
+		);
+		Log.warn(
+			{indent, logLevel},
+			JSON.stringify(firstExtraInfo.headers, null, 2),
+		);
+	}
+
+	if (
+		event.errorText === 'net::ERR_FAILED' &&
+		event.type === 'Fetch' &&
+		request._url?.includes('/proxy')
+	) {
+		Log.warn(
+			{indent, logLevel},
+			'This could be caused by Chrome rejecting the request because the disk space is low.',
+		);
+		Log.warn(
+			{indent, logLevel},
+			'This could be caused by Chrome rejecting the request because the disk space is low.',
+		);
+		Log.warn(
+			{indent, logLevel},
+			'Consider increasing the disk size of your Lambda function.',
+		);
+	}
+};

--- a/packages/renderer/src/browser/handle-failed-resource.ts
+++ b/packages/renderer/src/browser/handle-failed-resource.ts
@@ -28,9 +28,7 @@ export const handleFailedResource = ({
 	if (firstExtraInfo) {
 		Log.warn(
 			{indent, logLevel},
-			'Status code:',
-			firstExtraInfo.statusCode,
-			', headers:',
+			`HTTP status code: ${firstExtraInfo.statusCode}, headers:`,
 		);
 		Log.warn(
 			{indent, logLevel},


### PR DESCRIPTION
Useful for debugging

![image](https://github.com/user-attachments/assets/bc8fb5fb-3a0a-4b4c-8968-40779066cbea)
