### PR TITLE
`@remotion/renderer`: Correctly use setMuted() as default

### DIFF
--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -37,6 +37,7 @@ export const parsedCli = minimist<CommandLineOptions>(process.argv.slice(2), {
 	boolean: BooleanFlags,
 	default: {
 		overwrite: true,
+		muted: null,
 	},
 }) as CommandLineOptions & {
 	_: string[];

--- a/packages/renderer/src/options/mute.tsx
+++ b/packages/renderer/src/options/mute.tsx
@@ -14,7 +14,8 @@ export const mutedOption = {
 	docLink: 'https://www.remotion.dev/docs/using-audio/#muted-property',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		// we set in minimist `muted` default as null
+		if (commandLine[cliFlag] !== null) {
 			return {
 				source: 'cli',
 				value: commandLine[cliFlag] as boolean,


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
