### PR TITLE
`@remotion/renderer`: disallow chrome to cache

### DIFF
--- a/packages/renderer/src/serve-handler/index.ts
+++ b/packages/renderer/src/serve-handler/index.ts
@@ -265,6 +265,8 @@ export const serveHandler = async (
 		headers['Content-Length'] = String(streamOpts.end - streamOpts.start + 1);
 	}
 
+	headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
+
 	response.writeHead(response.statusCode || 200, headers);
 	stream.pipe(response);
 };


### PR DESCRIPTION
Having this in the disk cache leads to some problems like `net::ERR_CACHE_WRITE_FAILURE`, but also some that people face on Lambda