### PR TITLE
`@remotion/cli`: Explain where version conflict is coming from

### DIFF
--- a/packages/cli/src/versions.ts
+++ b/packages/cli/src/versions.ts
@@ -1,33 +1,45 @@
 import type {LogLevel, LogOptions} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import fs from 'node:fs';
+import path from 'node:path';
+import {chalk} from './chalk';
 import {listOfRemotionPackages} from './list-of-remotion-packages';
 import {Log} from './log';
 import {parseCommandLine} from './parse-command-line';
 import {resolveFrom} from './resolve-from';
 
+export type VersionAndPath = {version: string; path: string};
+
 const getVersion = async (
 	remotionRoot: string,
 	p: string,
-): Promise<string | null> => {
+): Promise<VersionAndPath | null> => {
 	try {
 		const remotionPkgJson = resolveFrom(remotionRoot, `${p}/package.json`);
 		const file = await fs.promises.readFile(remotionPkgJson, 'utf-8');
 		const packageJson = JSON.parse(file);
-		return packageJson.version;
+		return {version: packageJson.version, path: remotionPkgJson};
 	} catch (err) {
 		return null;
 	}
 };
 
-const groupBy = (vals: [string, string][]) => {
-	const groups: {[key: string]: string[]} = {};
+type Val = {
+	pkg: string;
+	versionAndPath: VersionAndPath;
+};
+
+const groupBy = (vals: [string, VersionAndPath][]) => {
+	const groups: {[key: string]: Val[]} = {};
 	for (const [pkg, version] of vals) {
-		if (!groups[version]) {
-			groups[version] = [];
+		if (!groups[version.version]) {
+			groups[version.version] = [];
 		}
 
-		(groups[version] as string[]).push(pkg);
+		(groups[version.version] as Val[]).push({
+			pkg,
+			versionAndPath: version,
+		});
 	}
 
 	return groups;
@@ -35,11 +47,12 @@ const groupBy = (vals: [string, string][]) => {
 
 const getAllVersions = async (
 	remotionRoot: string,
-): Promise<[string, string][]> => {
+): Promise<[string, VersionAndPath][]> => {
 	return (
 		await Promise.all(
 			listOfRemotionPackages.map(
-				async (p) => [p, await getVersion(remotionRoot, p)] as [string, string],
+				async (p) =>
+					[p, await getVersion(remotionRoot, p)] as [string, VersionAndPath],
 			),
 		)
 	).filter(([, version]) => version);
@@ -73,7 +86,10 @@ export const validateVersionsBeforeCommand = async (
 	for (const version of installedVersions) {
 		Log.warn(logOptions, `- On version: ${version}`);
 		for (const pkg of grouped[version] ?? []) {
-			Log.warn(logOptions, `  - ${pkg}`);
+			Log.warn(
+				logOptions,
+				`  - ${pkg.pkg} ${chalk.gray(path.relative(remotionRoot, pkg.versionAndPath.path))}`,
+			);
 		}
 
 		Log.info({indent: false, logLevel});


### PR DESCRIPTION
I had a version conflict because there was a node_modules folder in the parent of my project.
I didn't realize but with this I now understand!

![image](https://github.com/user-attachments/assets/72c0b838-7cf1-4678-81d1-e22b03779f19)
