### PR TITLE
`@remotion/lambda`: Better guidance for TooManyRequestsException

### DIFF
--- a/packages/docs/docs/lambda/troubleshooting/rate-limit.mdx
+++ b/packages/docs/docs/lambda/troubleshooting/rate-limit.mdx
@@ -1,9 +1,9 @@
 ---
 image: /generated/articles-docs-lambda-troubleshooting-rate-limit.png
 id: rate-limit
-sidebar_label: Rate Limit
+sidebar_label: TooManyRequestsException
 title: AWS Rate Limit Troubleshooting
-crumb: "Lambda Troubleshooting"
+crumb: 'Lambda Troubleshooting'
 ---
 
 If you get an error message:
@@ -21,9 +21,17 @@ while calling a Lambda function, it means your concurrency limit has been reache
 
 By default, the concurrency limit is 1000 functions per region, however in some regions the burst limit is only 500, somewhat limiting the scale you can use.
 
-## Exception: New accounts using AWS Lambda
+## New accounts using AWS Lambda
 
 According to AWS, "some accounts" which are new to AWS Lambda might get a very low concurrency limit such as 10 when they first start with AWS Lambda. In that case, increase the limit via the AWS console or the Remotion CLI (see below).
+
+### Workaround
+
+If you want to test Remotion Lambda while you are waiting for AWS to approve a higher concurrency limit, you can pass a higher number to [`framesPerLambda`](/docs/lambda/rendermediaonlambda#framesperlambda).
+
+For example: If your account currently has a concurrency limit of 10 and you want to render a composition with 900 frames, you can set `framesPerLambda` to `100`.  
+9 Lambda renderer functions will be spawned: `900 / 100 = 9`.  
+An additional Lambda function will be spawned for orchestration, meaning a total of 10 Lambda functions will be used, keeping yourself within your limit.
 
 ## See your limits
 

--- a/packages/lambda/src/shared/call-lambda.ts
+++ b/packages/lambda/src/shared/call-lambda.ts
@@ -80,6 +80,12 @@ export const callLambdaWithStreaming = async <
 		// Do not remove this await
 		await callLambdaWithStreamingWithoutRetry<T, Provider>(options);
 	} catch (err) {
+		if ((err as Error).message.includes('TooManyRequestsException')) {
+			throw new Error(
+				`AWS Concurrency limit reached (Original Error: ${(err as Error).message}). See https://www.remotion.dev/docs/lambda/troubleshooting/rate-limit for tips to fix this.`,
+			);
+		}
+
 		if (
 			!(err as Error).message.includes(INVALID_JSON_MESSAGE) &&
 			!(err as Error).message.includes(LAMBDA_STREAM_STALL) &&


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
