### PR TITLE
fix: signal is aborted without reason

### DIFF
--- a/packages/core/src/prefetch.ts
+++ b/packages/core/src/prefetch.ts
@@ -202,7 +202,7 @@ export const prefetch = (
 				canceled = true;
 				if (canBeAborted) {
 					try {
-						controller.abort();
+						controller.abort('free() called');
 					} catch (e) {}
 				}
 			}

--- a/packages/core/src/prefetch.ts
+++ b/packages/core/src/prefetch.ts
@@ -202,7 +202,7 @@ export const prefetch = (
 				canceled = true;
 				if (canBeAborted) {
 					try {
-						controller.abort('free() called');
+						controller.abort(new Error('free() called'));
 					} catch (e) {}
 				}
 			}


### PR DESCRIPTION
Fixes issue when `free()` is called inside different `useEffect`

![CleanShot 2024-09-27 at 10 59 43](https://github.com/user-attachments/assets/3b9d1c6a-1167-4fb7-8401-a174fe77c97b)

