### PR TITLE
`@remotion/renderer`: Parallelize creating server and opening browser for `selectComposition()`

### DIFF
--- a/packages/renderer/src/get-browser-instance.ts
+++ b/packages/renderer/src/get-browser-instance.ts
@@ -24,14 +24,14 @@ export const getPageAndCleanupFn = async ({
 	logLevel: LogLevel;
 	onBrowserDownload: OnBrowserDownload;
 }): Promise<{
-	cleanup: () => Promise<void>;
+	cleanupPage: () => Promise<void>;
 	page: Page;
 }> => {
 	if (passedInInstance) {
 		const page = await passedInInstance.newPage(() => null, logLevel, indent);
 		return {
 			page,
-			cleanup: () => {
+			cleanupPage: () => {
 				// Close puppeteer page and don't wait for it to finish.
 				// Keep browser open.
 				page.close().catch((err) => {
@@ -62,7 +62,7 @@ export const getPageAndCleanupFn = async ({
 
 	return {
 		page: browserPage,
-		cleanup: () => {
+		cleanupPage: () => {
 			// Close whole browser that was just created and don't wait for it to finish.
 			browserInstance.close(true, logLevel, indent).catch((err) => {
 				if (!(err as Error).message.includes('Target closed')) {

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -164,7 +164,7 @@ const internalGetCompositionsRaw = async ({
 	binariesDirectory,
 	onBrowserDownload,
 }: InternalGetCompositionsOptions) => {
-	const {page, cleanup: cleanupPage} = await getPageAndCleanupFn({
+	const {page, cleanupPage} = await getPageAndCleanupFn({
 		passedInInstance: puppeteerInstance,
 		browserExecutable,
 		chromiumOptions,

--- a/packages/renderer/src/select-composition.ts
+++ b/packages/renderer/src/select-composition.ts
@@ -203,28 +203,16 @@ export const internalSelectCompositionRaw = async (
 		onServeUrlVisited,
 	} = options;
 
-	const {page, cleanup: cleanupPage} = await getPageAndCleanupFn({
-		passedInInstance: puppeteerInstance,
-		browserExecutable,
-		chromiumOptions,
-		forceDeviceScaleFactor: undefined,
-		indent,
-		logLevel,
-		onBrowserDownload,
-	});
-	cleanup.push(() => cleanupPage());
-
-	return new Promise<InternalReturnType>((resolve, reject) => {
-		const onError = (err: Error) => reject(err);
-
-		cleanup.push(
-			handleJavascriptException({
-				page,
-				frame: null,
-				onError,
-			}),
-		);
-
+	const [{page, cleanupPage}, serverUsed] = await Promise.all([
+		getPageAndCleanupFn({
+			passedInInstance: puppeteerInstance,
+			browserExecutable,
+			chromiumOptions,
+			forceDeviceScaleFactor: undefined,
+			indent,
+			logLevel,
+			onBrowserDownload,
+		}),
 		makeOrReuseServer(
 			options.server,
 			{
@@ -241,33 +229,45 @@ export const internalSelectCompositionRaw = async (
 			{
 				onDownload: () => undefined,
 			},
-		)
-			.then(({server: {serveUrl, offthreadPort, sourceMap}, cleanupServer}) => {
-				page.setBrowserSourceMapGetter(sourceMap);
-				cleanup.push(() => cleanupServer(true));
+		).then((result) => {
+			cleanup.push(() => result.cleanupServer(true));
+			return result;
+		}),
+	]);
+	cleanup.push(() => cleanupPage());
 
-				return innerSelectComposition({
-					serveUrl,
-					page,
-					port: offthreadPort,
-					browserExecutable,
-					chromiumOptions,
-					envVariables,
-					id,
-					serializedInputPropsWithCustomSchema,
-					onBrowserLog,
-					timeoutInMilliseconds,
-					logLevel,
-					indent,
-					puppeteerInstance,
-					server,
-					offthreadVideoCacheSizeInBytes,
-					binariesDirectory,
-					onBrowserDownload,
-					onServeUrlVisited,
-				});
-			})
+	return new Promise<InternalReturnType>((resolve, reject) => {
+		const onError = (err: Error) => reject(err);
 
+		cleanup.push(
+			handleJavascriptException({
+				page,
+				frame: null,
+				onError,
+			}),
+		);
+		page.setBrowserSourceMapGetter(serverUsed.server.sourceMap);
+
+		innerSelectComposition({
+			serveUrl: serverUsed.server.serveUrl,
+			page,
+			port: serverUsed.server.offthreadPort,
+			browserExecutable,
+			chromiumOptions,
+			envVariables,
+			id,
+			serializedInputPropsWithCustomSchema,
+			onBrowserLog,
+			timeoutInMilliseconds,
+			logLevel,
+			indent,
+			puppeteerInstance,
+			server,
+			offthreadVideoCacheSizeInBytes,
+			binariesDirectory,
+			onBrowserDownload,
+			onServeUrlVisited,
+		})
 			.then((data) => {
 				return resolve(data);
 			})

--- a/packages/renderer/src/test-gpu.ts
+++ b/packages/renderer/src/test-gpu.ts
@@ -25,7 +25,7 @@ export const getChromiumGpuInformation = async ({
 	timeoutInMilliseconds: number;
 	onBrowserDownload: OnBrowserDownload;
 }) => {
-	const {page, cleanup} = await getPageAndCleanupFn({
+	const {page, cleanupPage: cleanup} = await getPageAndCleanupFn({
 		passedInInstance: undefined,
 		browserExecutable,
 		chromiumOptions,


### PR DESCRIPTION


<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
