### PR TITLE
Fix crossOrigin prop not being passed to VideoForPreview.

### DIFF
--- a/packages/core/src/video/Video.tsx
+++ b/packages/core/src/video/Video.tsx
@@ -34,7 +34,6 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 		_remotionInternalNativeLoopPassed,
 		showInTimeline,
 		onAutoPlayError,
-		crossOrigin,
 		...otherProps
 	} = props;
 	const {loop, _remotionDebugSeeking, ...propsOtherThanLoop} = props;
@@ -144,7 +143,6 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			_remotionDebugSeeking={_remotionDebugSeeking ?? false}
 			showInTimeline={showInTimeline ?? true}
 			onAutoPlayError={onAutoPlayError ?? undefined}
-			crossOrigin={crossOrigin}
 		/>
 	);
 };

--- a/packages/core/src/video/Video.tsx
+++ b/packages/core/src/video/Video.tsx
@@ -25,6 +25,18 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			readonly stack?: string;
 		}
 > = (props, ref) => {
+	const {
+		startFrom,
+		endAt,
+		name,
+		pauseWhenBuffering,
+		stack,
+		_remotionInternalNativeLoopPassed,
+		showInTimeline,
+		onAutoPlayError,
+		...otherProps
+	} = props;
+	const {loop, _remotionDebugSeeking, ...propsOtherThanLoop} = props;
 	const {fps} = useVideoConfig();
 	const environment = getRemotionEnvironment();
 
@@ -57,15 +69,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 		durations[getAbsoluteSrc(preloadedSrc)] ??
 		durations[getAbsoluteSrc(props.src)];
 
-	if (props.loop && durationFetched !== undefined) {
-		const {
-			startFrom,
-			endAt,
-			name,
-			loop: __omitLoop,
-			_remotionDebugSeeking: __omitRemotionDebugSeeking,
-			...loopedVideoProps
-		} = props;
+	if (loop && durationFetched !== undefined) {
 		const mediaDuration = durationFetched * fps;
 
 		return (
@@ -80,7 +84,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 				name={name}
 			>
 				<Video
-					{...loopedVideoProps}
+					{...propsOtherThanLoop}
 					ref={ref}
 					_remotionInternalNativeLoopPassed
 				/>
@@ -88,11 +92,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 		);
 	}
 
-	if (
-		typeof props.startFrom !== 'undefined' ||
-		typeof props.endAt !== 'undefined'
-	) {
-		const {startFrom, endAt, name, ...sequencedVideoProps} = props;
+	if (typeof startFrom !== 'undefined' || typeof endAt !== 'undefined') {
 		validateStartFromProps(startFrom, endAt);
 
 		const startFromFrameNo = startFrom ?? 0;
@@ -105,7 +105,11 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 				durationInFrames={endAtFrameNo}
 				name={name}
 			>
-				<Video {...sequencedVideoProps} ref={ref} />
+				<Video
+					pauseWhenBuffering={pauseWhenBuffering ?? false}
+					{...otherProps}
+					ref={ref}
+				/>
 			</Sequence>
 		);
 	}
@@ -113,36 +117,20 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 	validateMediaProps(props, 'Video');
 
 	if (environment.isRendering) {
-		const {
-			startFrom: __omitStartFrom,
-			endAt: __omitEndAt,
-			pauseWhenBuffering: __omitPauseWhenBuffering,
-			...renderedVideoProps
-		} = props;
 		return (
 			<VideoForRendering
 				onDuration={onDuration}
 				onVideoFrame={onVideoFrame ?? null}
-				{...renderedVideoProps}
+				{...otherProps}
 				ref={ref}
 			/>
 		);
 	}
 
-	const {
-		crossOrigin,
-		pauseWhenBuffering,
-		showInTimeline,
-		stack,
-		_remotionInternalNativeLoopPassed,
-		_remotionDebugSeeking,
-		...videoForPreviewProps
-	} = props;
-
 	return (
 		<VideoForPreview
 			onlyWarnForMediaSeekingError={false}
-			{...videoForPreviewProps}
+			{...otherProps}
 			ref={ref}
 			onVideoFrame={null}
 			// Proposal: Make this default to true in v5
@@ -154,7 +142,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			}
 			_remotionDebugSeeking={_remotionDebugSeeking ?? false}
 			showInTimeline={showInTimeline ?? true}
-			crossOrigin={crossOrigin ?? undefined}
+			onAutoPlayError={onAutoPlayError ?? undefined}
 		/>
 	);
 };

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -36,7 +36,7 @@ type VideoForPreviewProps = RemotionVideoProps & {
 	readonly _remotionDebugSeeking: boolean;
 	readonly showInTimeline: boolean;
 	readonly onVideoFrame: null | OnVideoFrame;
-	readonly crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined;
+	readonly crossOrigin?: '' | 'anonymous' | 'use-credentials';
 };
 
 const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -36,7 +36,7 @@ type VideoForPreviewProps = RemotionVideoProps & {
 	readonly _remotionDebugSeeking: boolean;
 	readonly showInTimeline: boolean;
 	readonly onVideoFrame: null | OnVideoFrame;
-	readonly crossOrigin?: '' | 'anonymous' | 'use-credentials';
+	readonly crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined;
 };
 
 const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<


### PR DESCRIPTION
resolves https://github.com/remotion-dev/remotion/issues/4355

this pr ensures that the `crossOrigin` prop will always make it to the underlying video element.
Currently if passing either the `startFrom` or `endAt` props the `crossOrigin` prop will be dropped along with the `showInTimeline` and `onAutoPlayError` props.

I also made a second commit to propose a refactor to make the prop destructuring in this file easier to read. The first commit only fixes the `crossOrigin` prop being dropped but is a much smaller and less risky change.