### PR TITLE
`@remotion/cli`: Make `npx remotion ffmpeg` and `npx remotion ffprobe` inherit the CWD

### DIFF
--- a/packages/cli/src/ffmpeg.ts
+++ b/packages/cli/src/ffmpeg.ts
@@ -35,11 +35,7 @@ export const dynamicLibEnv = (
 	};
 };
 
-export const ffmpegCommand = (
-	_root: string,
-	args: string[],
-	logLevel: LogLevel,
-) => {
+export const ffmpegCommand = (args: string[], logLevel: LogLevel) => {
 	const {value: binariesDirectory} =
 		BrowserSafeApis.options.binariesDirectoryOption.getValue({
 			commandLine: parsedCli,
@@ -56,15 +52,12 @@ export const ffmpegCommand = (
 	const done = spawnSync(binary, args, {
 		stdio: 'inherit',
 		env: dynamicLibEnv(false, logLevel, binariesDirectory),
+		cwd: process.cwd(),
 	});
 	process.exit(done.status as number);
 };
 
-export const ffprobeCommand = (
-	_root: string,
-	args: string[],
-	logLevel: LogLevel,
-) => {
+export const ffprobeCommand = (args: string[], logLevel: LogLevel) => {
 	const {value: binariesDirectory} =
 		BrowserSafeApis.options.binariesDirectoryOption.getValue({
 			commandLine: parsedCli,
@@ -78,7 +71,7 @@ export const ffprobeCommand = (
 	RenderInternals.makeFileExecutableIfItIsNot(binary);
 
 	const done = spawnSync(binary, args, {
-		cwd: path.dirname(binary),
+		cwd: process.cwd(),
 		stdio: 'inherit',
 		env: dynamicLibEnv(false, logLevel, binariesDirectory),
 	});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -105,11 +105,11 @@ export const cli = async () => {
 		} else if (command === 'still') {
 			await still(remotionRoot, args, logLevel);
 		} else if (command === 'ffmpeg') {
-			ffmpegCommand(remotionRoot, process.argv.slice(3), logLevel);
+			ffmpegCommand(process.argv.slice(3), logLevel);
 		} else if (command === 'gpu') {
 			await gpuCommand(logLevel);
 		} else if (command === 'ffprobe') {
-			ffprobeCommand(remotionRoot, process.argv.slice(3), logLevel);
+			ffprobeCommand(process.argv.slice(3), logLevel);
 		} else if (command === 'upgrade') {
 			await upgrade(
 				remotionRoot,

--- a/packages/docs/docs/cli/ffmpeg.mdx
+++ b/packages/docs/docs/cli/ffmpeg.mdx
@@ -2,15 +2,15 @@
 image: /generated/articles-docs-cli-ffmpeg.png
 id: ffmpeg
 title: npx remotion ffmpeg
-crumb: "@remotion/cli"
-sidebar_label: "ffmpeg"
+crumb: '@remotion/cli'
+sidebar_label: 'ffmpeg'
 ---
 
 _available since v4.0_
 
 In order to use `ffmpeg` without having to directly install it, Remotion provides it via `npx remotion ffmpeg`.
 
-Note that in order to keep the binary size small, the FFmpeg binary only understand the codecs that Remotion itself supports: H.264, H.265, VP8, VP9 and ProRes. A binary from the 6.0 release line of FFmpeg is used.
+Note that in order to keep the binary size small, the FFmpeg binary only understand the codecs that Remotion itself supports: H.264, H.265, VP8, VP9 and ProRes. A binary from the 7.1 release line of FFmpeg is used.
 
 # Example
 

--- a/packages/docs/docs/cli/ffprobe.mdx
+++ b/packages/docs/docs/cli/ffprobe.mdx
@@ -2,15 +2,15 @@
 image: /generated/articles-docs-cli-ffprobe.png
 id: ffprobe
 title: npx remotion ffprobe
-crumb: "@remotion/cli"
-sidebar_label: "ffprobe"
+crumb: '@remotion/cli'
+sidebar_label: 'ffprobe'
 ---
 
 _available since v4.0_
 
 In order to use `ffprobe` without having to directly install it, Remotion provides it via `npx remotion ffprobe`.
 
-Note that in order to keep the binary size small, the FFprobe binary only understand the codecs that Remotion itself supports: H.264, H.265, VP8, VP9 and ProRes. A binary from the 6.0 release line of FFprobe is used.
+Note that in order to keep the binary size small, the FFprobe binary only understand the codecs that Remotion itself supports: H.264, H.265, VP8, VP9 and ProRes. A binary from the 7.1 release line of FFprobe is used.
 
 # Example
 


### PR DESCRIPTION
This is so much more intuitive and previously was broken without complaints.

So I'm going to allow myself making this breaking change!