### PR TITLE
`@remotion/lambda`: Allow passing `skipLambdaInvocation` to `getRenderProgress`

### DIFF
--- a/packages/cli/src/image-formats.ts
+++ b/packages/cli/src/image-formats.ts
@@ -1,5 +1,6 @@
 import type {VideoImageFormat} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
+import {NoReactAPIs} from '@remotion/renderer/pure';
 import {ConfigInternals} from './config';
 import {parsedCli} from './parsed-cli';
 
@@ -32,7 +33,7 @@ export const getVideoImageFormat = ({
 		return configFileOption;
 	}
 
-	if (RenderInternals.isAudioCodec(codec)) {
+	if (NoReactAPIs.isAudioCodec(codec)) {
 		return 'none';
 	}
 

--- a/packages/cli/src/progress-bar.ts
+++ b/packages/cli/src/progress-bar.ts
@@ -1,5 +1,6 @@
 import type {CancelSignal, LogLevel} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
+import {NoReactAPIs} from '@remotion/renderer/pure';
 import type {
 	AggregateRenderProgress,
 	BundlingState,
@@ -233,7 +234,7 @@ const makeStitchingProgress = ({
 	const mediaType =
 		codec === 'gif'
 			? 'GIF'
-			: RenderInternals.isAudioCodec(codec)
+			: NoReactAPIs.isAudioCodec(codec)
 				? 'audio'
 				: 'video';
 

--- a/packages/docs/docs/lambda/getrenderprogress.mdx
+++ b/packages/docs/docs/lambda/getrenderprogress.mdx
@@ -6,7 +6,10 @@ slug: /lambda/getrenderprogress
 crumb: 'Lambda API'
 ---
 
-Gets the current status of a non-[still](https://www.remotion.dev/docs/lambda/renderstillonlambda) render originally triggered via [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda).
+Gets the current status of a render initiated via [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda).  
+Calling this function results in a Lambda invocation.
+
+For renders initiated via [`renderStillOnLambda()`](/docs/lambda/renderstillonlambda), do not use this function. Instead, the result is returned immediately.
 
 ## Example
 
@@ -59,7 +62,6 @@ If the render is going to be saved to a [different cloud](/docs/lambda/custom-de
 ### `forcePathStyle?`<AvailableFrom v="4.0.202" />
 
 Passes `forcePathStyle` to the AWS S3 client. If you don't know what this is, you probably don't need it.
-
 
 ## Response
 

--- a/packages/docs/docs/lambda/getrenderprogress.mdx
+++ b/packages/docs/docs/lambda/getrenderprogress.mdx
@@ -63,6 +63,11 @@ If the render is going to be saved to a [different cloud](/docs/lambda/custom-de
 
 Passes `forcePathStyle` to the AWS S3 client. If you don't know what this is, you probably don't need it.
 
+### `skipLambdaInvocation?`<AvailableFrom v="4.0.218" />
+
+Instead of calling a Lambda function which will get the progress from S3, make the S3 call directly.  
+This is cheaper and faster, but the function name must follow [the function name convention](/docs/lambda/naming-convention#see-also).
+
 ## Response
 
 Returns a promise resolving to an object with the following properties:

--- a/packages/docs/docs/lambda/speculateFunctionName.mdx
+++ b/packages/docs/docs/lambda/speculateFunctionName.mdx
@@ -3,7 +3,7 @@ image: /generated/articles-docs-lambda-speculateFunctionName.png
 id: speculatefunctionname
 title: speculateFunctionName()
 slug: /lambda/speculatefunctionname
-crumb: "Lambda API"
+crumb: 'Lambda API'
 ---
 
 _available from v3.3.75_
@@ -35,7 +35,7 @@ remotion-render-3-3-63-mem2048mb-disk2048mb-240sec
 // @module: esnext
 // @target: es2017
 
-import { speculateFunctionName } from "@remotion/lambda/client";
+import {speculateFunctionName} from '@remotion/lambda/client';
 
 const speculatedFunctionName = speculateFunctionName({
   memorySizeInMb: 2048,
@@ -69,5 +69,6 @@ A string with the name of the function that will be created.
 ## See also
 
 - [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/lambda/src/api/speculate-function-name.ts)
-- [deployFunction()](/docs/lambda/deployfunction)
+- [Function name convention](/docs/lambda/naming-convention)
+- [`deployFunction()`](/docs/lambda/deployfunction)
 - CLI version of `deployFunction()`: [`npx remotion lambda functions deploy`](/docs/lambda/cli/functions#deploy)

--- a/packages/it-tests/src/ssr/cancel-renderframes.test.ts
+++ b/packages/it-tests/src/ssr/cancel-renderframes.test.ts
@@ -1,5 +1,13 @@
-import {makeCancelSignal, renderFrames} from '@remotion/renderer';
-import {expect, test} from 'bun:test';
+import {
+	ensureBrowser,
+	makeCancelSignal,
+	renderFrames,
+} from '@remotion/renderer';
+import {beforeAll, expect, test} from 'bun:test';
+
+beforeAll(async () => {
+	await ensureBrowser();
+});
 
 test('Should be able to cancel render', async () => {
 	try {

--- a/packages/it-tests/src/ssr/render-still.test.ts
+++ b/packages/it-tests/src/ssr/render-still.test.ts
@@ -1,13 +1,18 @@
 import {
+	ensureBrowser,
 	getCompositions,
 	openBrowser,
 	RenderInternals,
 	renderStill,
 } from '@remotion/renderer';
-import {afterEach, expect, test} from 'bun:test';
+import {afterEach, beforeAll, expect, test} from 'bun:test';
 import {existsSync} from 'fs';
 import os from 'os';
 import path from 'path';
+
+beforeAll(async () => {
+	await ensureBrowser();
+});
 
 afterEach(async () => {
 	await RenderInternals.killAllBrowsers();

--- a/packages/lambda/src/api/get-render-progress.ts
+++ b/packages/lambda/src/api/get-render-progress.ts
@@ -1,7 +1,12 @@
 import type {LogLevel} from '@remotion/renderer';
 import type {CustomCredentials} from '@remotion/serverless/client';
 import {ServerlessRoutines} from '@remotion/serverless/client';
-import type {AwsProvider} from '../functions/aws-implementation';
+import {
+	awsImplementation,
+	type AwsProvider,
+} from '../functions/aws-implementation';
+import {getProgress} from '../functions/helpers/get-progress';
+import {parseFunctionName} from '../functions/helpers/parse-function-name';
 import type {AwsRegion} from '../regions';
 import {callLambda} from '../shared/call-lambda';
 import type {RenderProgress} from '../shared/constants';
@@ -15,6 +20,7 @@ export type GetRenderProgressInput = {
 	logLevel?: LogLevel;
 	s3OutputProvider?: CustomCredentials<AwsProvider>;
 	forcePathStyle?: boolean;
+	skipLambdaInvocation?: boolean;
 };
 
 /**
@@ -30,6 +36,31 @@ export type GetRenderProgressInput = {
 export const getRenderProgress = async (
 	input: GetRenderProgressInput,
 ): Promise<RenderProgress> => {
+	if (input.skipLambdaInvocation) {
+		const parsed = parseFunctionName(input.functionName);
+		if (!parsed) {
+			throw new Error(
+				[
+					`The function name ${input.functionName} does not adhere to the function name convention (https://www.remotion.dev/docs/lambda/naming-convention).`,
+					'Cannot determine memory and disk size from the function name.',
+					'You must call getRenderProgress with `skipLambdaInvocation` set to false.',
+				].join('\n'),
+			);
+		}
+
+		return getProgress<AwsProvider>({
+			bucketName: input.bucketName,
+			renderId: input.renderId,
+			region: input.region,
+			forcePathStyle: input.forcePathStyle ?? false,
+			customCredentials: input.s3OutputProvider ?? null,
+			expectedBucketOwner: null,
+			providerSpecifics: awsImplementation,
+			memorySizeInMb: parsed.memorySizeInMb,
+			timeoutInMilliseconds: parsed.timeoutInSeconds * 1000,
+		});
+	}
+
 	const result = await callLambda<AwsProvider, ServerlessRoutines.status>({
 		functionName: input.functionName,
 		type: ServerlessRoutines.status,

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -12,6 +12,7 @@ import {internalRenderMediaOnLambdaRaw} from '../../../api/render-media-on-lambd
 import type {EnhancedErrorInfo, ProviderSpecifics} from '@remotion/serverless';
 import type {ServerlessCodec} from '@remotion/serverless/client';
 import type {AwsProvider} from '../../../functions/aws-implementation';
+import {parseFunctionName} from '../../../functions/helpers/parse-function-name';
 import {
 	BINARY_NAME,
 	DEFAULT_MAX_RETRIES,
@@ -415,12 +416,15 @@ export const renderCommand = async (
 		);
 	}
 
+	const adheresToFunctionNameConvention = parseFunctionName(functionName);
+
 	const status = await getRenderProgress({
 		functionName,
 		bucketName: res.bucketName,
 		renderId: res.renderId,
 		region: getAwsRegion(),
 		logLevel,
+		skipLambdaInvocation: Boolean(adheresToFunctionNameConvention),
 	});
 	progressBar.update(
 		makeProgressString({

--- a/packages/lambda/src/functions/helpers/get-overall-progress-s3.ts
+++ b/packages/lambda/src/functions/helpers/get-overall-progress-s3.ts
@@ -11,7 +11,7 @@ export const getOverallProgressS3 = async <Provider extends CloudProvider>({
 	forcePathStyle,
 }: {
 	renderId: string;
-	expectedBucketOwner: string;
+	expectedBucketOwner: string | null;
 	bucketName: string;
 	region: Provider['region'];
 	providerSpecifics: ProviderSpecifics<Provider>;

--- a/packages/lambda/src/functions/helpers/get-progress.ts
+++ b/packages/lambda/src/functions/helpers/get-progress.ts
@@ -58,19 +58,22 @@ export const getProgress = async <Provider extends CloudProvider>({
 			);
 		}
 
+		if (overallProgress.renderMetadata.type === 'still') {
+			throw new Error(
+				"You don't need to call getRenderProgress() on a still render. Once you have obtained the `renderId`, the render is already done! 😉",
+			);
+		}
+
 		const outData = getExpectedOutName(
 			overallProgress.renderMetadata,
 			bucketName,
 			customCredentials,
 		);
 
-		const totalFrameCount =
-			overallProgress.renderMetadata.type === 'still'
-				? 1
-				: RenderInternals.getFramesToRender(
-						overallProgress.renderMetadata.frameRange,
-						overallProgress.renderMetadata.everyNthFrame,
-					).length;
+		const totalFrameCount = RenderInternals.getFramesToRender(
+			overallProgress.renderMetadata.frameRange,
+			overallProgress.renderMetadata.everyNthFrame,
+		).length;
 
 		return {
 			framesRendered: totalFrameCount,
@@ -131,26 +134,11 @@ export const getProgress = async <Provider extends CloudProvider>({
 		errors: overallProgress.errors,
 	});
 
-	if (renderMetadata && renderMetadata.type === 'still') {
-		throw new Error(
-			"You don't need to call getRenderProgress() on a still render. Once you have obtained the `renderId`, the render is already done! 😉",
-		);
-	}
-
-	const priceFromBucket = estimatePriceFromBucket({
-		renderMetadata,
-		memorySizeInMb,
-		lambdasInvoked: renderMetadata?.estimatedRenderLambdaInvokations ?? 0,
-		// We cannot determine the ephemeral storage size, so we
-		// overestimate the price, but will only have a miniscule effect (~0.2%)
-		diskSizeInMb: MAX_EPHEMERAL_STORAGE_IN_MB,
-		timings: overallProgress.timings ?? [],
-		providerSpecifics,
-	});
-
 	const {hasAudio, hasVideo} = renderMetadata
 		? lambdaRenderHasAudioVideo(renderMetadata)
 		: {hasAudio: false, hasVideo: false};
+
+	const chunkCount = overallProgress.chunks.length ?? 0;
 
 	const cleanup: CleanupInfo = {
 		doneIn: null,
@@ -158,45 +146,106 @@ export const getProgress = async <Provider extends CloudProvider>({
 		filesDeleted: 0,
 	};
 
+	if (renderMetadata === null) {
+		return {
+			framesRendered: overallProgress.framesRendered ?? 0,
+			chunks: chunkCount,
+			done: false,
+			encodingStatus: {
+				framesEncoded: overallProgress.framesEncoded,
+				combinedFrames: overallProgress.combinedFrames,
+				timeToCombine: overallProgress.timeToCombine,
+			},
+			timeToRenderFrames: overallProgress.timeToRenderFrames,
+			costs: formatCostsInfo(0),
+			renderId,
+			renderMetadata,
+			bucket: bucketName,
+			outputFile: null,
+			timeToFinish: null,
+			errors: errorExplanations,
+			fatalErrorEncountered: errorExplanations.some(
+				(f) => f.isFatal && !f.willRetry,
+			),
+			currentTime: Date.now(),
+			renderSize: 0,
+			lambdasInvoked: overallProgress.lambdasInvoked ?? 0,
+			cleanup,
+			timeToFinishChunks: null,
+			overallProgress: getOverallProgress({
+				encoding: 0,
+				invoking: 0,
+				frames: 0,
+				gotComposition: overallProgress.compositionValidated,
+				visitedServeUrl: overallProgress.serveUrlOpened,
+				invokedLambda: overallProgress.lambdasInvoked,
+				combining: 0,
+			}),
+			retriesInfo: overallProgress.retries ?? [],
+			outKey: null,
+			outBucket: null,
+			mostExpensiveFrameRanges: null,
+			timeToEncode: overallProgress.timeToEncode,
+			outputSizeInBytes: null,
+			estimatedBillingDurationInMilliseconds: null,
+			combinedFrames: overallProgress.combinedFrames ?? 0,
+			timeToCombine: overallProgress.timeToCombine ?? null,
+			timeoutTimestamp: overallProgress.timeoutTimestamp,
+			type: 'success',
+			compositionValidated: overallProgress.compositionValidated,
+			functionLaunched: overallProgress.functionLaunched,
+			serveUrlOpened: overallProgress.serveUrlOpened,
+			artifacts: overallProgress.receivedArtifact,
+		};
+	}
+
+	const priceFromBucket = estimatePriceFromBucket({
+		renderMetadata,
+		memorySizeInMb,
+		lambdasInvoked: renderMetadata.estimatedRenderLambdaInvokations ?? 0,
+		// We cannot determine the ephemeral storage size, so we
+		// overestimate the price, but will only have a miniscule effect (~0.2%)
+		diskSizeInMb: MAX_EPHEMERAL_STORAGE_IN_MB,
+		timings: overallProgress.timings ?? [],
+		providerSpecifics,
+	});
+
 	const chunkMultiplier = [hasAudio, hasVideo].filter(truthy).length;
+
+	if (renderMetadata.type === 'still') {
+		throw new Error(
+			"You don't need to call getRenderProgress() on a still render. Once you have obtained the `renderId`, the render is already done! 😉",
+		);
+	}
 
 	const allChunks =
 		(overallProgress.chunks ?? []).length / chunkMultiplier ===
-		(renderMetadata?.totalChunks ?? Infinity);
+		(renderMetadata.totalChunks ?? Infinity);
 
-	const frameCount = renderMetadata
-		? RenderInternals.getFramesToRender(
-				renderMetadata.frameRange,
-				renderMetadata.everyNthFrame,
-			).length
-		: null;
+	const frameCount = RenderInternals.getFramesToRender(
+		renderMetadata.frameRange,
+		renderMetadata.everyNthFrame,
+	).length;
 
-	const chunkCount = overallProgress.chunks.length ?? 0;
-
-	const missingChunks = renderMetadata
-		? new Array(renderMetadata.totalChunks)
-				.fill(true)
-				.map((_, i) => i)
-				.filter((index) => {
-					return (
-						typeof (overallProgress.chunks ?? []).find((c) => c === index) ===
-						'undefined'
-					);
-				})
-		: null;
-
+	const missingChunks = new Array(renderMetadata.totalChunks)
+		.fill(true)
+		.map((_, i) => i)
+		.filter((index) => {
+			return (
+				typeof (overallProgress.chunks ?? []).find((c) => c === index) ===
+				'undefined'
+			);
+		});
 	// We add a 20 second buffer for it, since AWS timeshifts can be quite a lot. Once it's 20sec over the limit, we consider it timed out
 
 	// 1. If we have missing chunks, we consider it timed out
 	const isBeyondTimeoutAndMissingChunks =
-		renderMetadata &&
 		Date.now() > renderMetadata.startedDate + timeoutInMilliseconds + 20000 &&
 		missingChunks &&
 		missingChunks.length > 0;
 
 	// 2. If we have no missing chunks, but the encoding is not done, even after the additional `merge` function has been spawned, we consider it timed out
 	const isBeyondTimeoutAndHasStitchTimeout =
-		renderMetadata &&
 		Date.now() > renderMetadata.startedDate + timeoutInMilliseconds * 2 + 20000;
 
 	const allErrors: EnhancedErrorInfo[] = [
@@ -244,14 +293,12 @@ export const getProgress = async <Provider extends CloudProvider>({
 					})
 				: null,
 		overallProgress: getOverallProgress({
-			encoding:
-				renderMetadata && frameCount
-					? (overallProgress.framesEncoded ?? 0) / frameCount
-					: 0,
-			invoking: renderMetadata
-				? (overallProgress.lambdasInvoked ?? 0) /
-					renderMetadata.estimatedRenderLambdaInvokations
+			encoding: frameCount
+				? (overallProgress.framesEncoded ?? 0) / frameCount
 				: 0,
+			invoking:
+				(overallProgress.lambdasInvoked ?? 0) /
+				renderMetadata.estimatedRenderLambdaInvokations,
 			frames: (overallProgress.framesRendered ?? 0) / (frameCount ?? 1),
 			gotComposition: overallProgress.compositionValidated,
 			visitedServeUrl: overallProgress.serveUrlOpened,

--- a/packages/lambda/src/functions/helpers/get-progress.ts
+++ b/packages/lambda/src/functions/helpers/get-progress.ts
@@ -1,4 +1,4 @@
-import {BrowserSafeApis} from '@remotion/renderer/client';
+import {NoReactAPIs} from '@remotion/renderer/pure';
 import type {
 	CloudProvider,
 	EnhancedErrorInfo,
@@ -70,7 +70,7 @@ export const getProgress = async <Provider extends CloudProvider>({
 			customCredentials,
 		);
 
-		const totalFrameCount = BrowserSafeApis.getFramesToRender(
+		const totalFrameCount = NoReactAPIs.getFramesToRender(
 			overallProgress.renderMetadata.frameRange,
 			overallProgress.renderMetadata.everyNthFrame,
 		).length;
@@ -222,7 +222,7 @@ export const getProgress = async <Provider extends CloudProvider>({
 		(overallProgress.chunks ?? []).length / chunkMultiplier ===
 		(renderMetadata.totalChunks ?? Infinity);
 
-	const frameCount = BrowserSafeApis.getFramesToRender(
+	const frameCount = NoReactAPIs.getFramesToRender(
 		renderMetadata.frameRange,
 		renderMetadata.everyNthFrame,
 	).length;

--- a/packages/lambda/src/functions/helpers/get-progress.ts
+++ b/packages/lambda/src/functions/helpers/get-progress.ts
@@ -1,4 +1,4 @@
-import {RenderInternals} from '@remotion/renderer';
+import {BrowserSafeApis} from '@remotion/renderer/client';
 import type {
 	CloudProvider,
 	EnhancedErrorInfo,
@@ -34,7 +34,7 @@ export const getProgress = async <Provider extends CloudProvider>({
 }: {
 	bucketName: string;
 	renderId: string;
-	expectedBucketOwner: string;
+	expectedBucketOwner: string | null;
 	region: Provider['region'];
 	memorySizeInMb: number;
 	timeoutInMilliseconds: number;
@@ -70,7 +70,7 @@ export const getProgress = async <Provider extends CloudProvider>({
 			customCredentials,
 		);
 
-		const totalFrameCount = RenderInternals.getFramesToRender(
+		const totalFrameCount = BrowserSafeApis.getFramesToRender(
 			overallProgress.renderMetadata.frameRange,
 			overallProgress.renderMetadata.everyNthFrame,
 		).length;
@@ -222,7 +222,7 @@ export const getProgress = async <Provider extends CloudProvider>({
 		(overallProgress.chunks ?? []).length / chunkMultiplier ===
 		(renderMetadata.totalChunks ?? Infinity);
 
-	const frameCount = RenderInternals.getFramesToRender(
+	const frameCount = BrowserSafeApis.getFramesToRender(
 		renderMetadata.frameRange,
 		renderMetadata.everyNthFrame,
 	).length;

--- a/packages/lambda/src/functions/helpers/inspect-errors.ts
+++ b/packages/lambda/src/functions/helpers/inspect-errors.ts
@@ -1,10 +1,9 @@
+import type {EnhancedErrorInfo, LambdaErrorInfo} from '@remotion/serverless';
 import {
 	errorIsOutOfSpaceError,
 	isBrowserCrashedError,
 	isErrInsufficientResourcesErr,
-	type EnhancedErrorInfo,
-	type LambdaErrorInfo,
-} from '@remotion/serverless';
+} from '@remotion/serverless/client';
 
 import {DOCS_URL} from '../../shared/docs-url';
 

--- a/packages/lambda/src/functions/helpers/parse-function-name.ts
+++ b/packages/lambda/src/functions/helpers/parse-function-name.ts
@@ -1,0 +1,24 @@
+import {RENDER_FN_PREFIX} from '../../defaults';
+
+type ReturnType = {
+	version: string;
+	memorySizeInMb: number;
+	diskSizeInMb: number;
+	timeoutInSeconds: number;
+};
+
+export const parseFunctionName = (functionName: string): ReturnType | null => {
+	const match = functionName.match(
+		new RegExp(RENDER_FN_PREFIX + '(.*)-mem(\\d+)mb-disk(\\d+)mb-(\\d+)sec$'),
+	);
+	if (!match) {
+		return null;
+	}
+
+	return {
+		version: match[1],
+		memorySizeInMb: parseInt(match[2], 10),
+		diskSizeInMb: parseInt(match[3], 10),
+		timeoutInSeconds: parseInt(match[4], 10),
+	};
+};

--- a/packages/lambda/src/functions/helpers/render-has-audio-video.ts
+++ b/packages/lambda/src/functions/helpers/render-has-audio-video.ts
@@ -1,4 +1,4 @@
-import {BrowserSafeApis} from '@remotion/renderer/client';
+import {NoReactAPIs} from '@remotion/renderer/pure';
 import type {CloudProvider} from '@remotion/serverless';
 import type {RenderMetadata} from '@remotion/serverless/client';
 
@@ -12,10 +12,10 @@ export const lambdaRenderHasAudioVideo = <Provider extends CloudProvider>(
 		throw new Error('Cannot merge stills');
 	}
 
-	const support = BrowserSafeApis.codecSupportsMedia(renderMetadata.codec);
+	const support = NoReactAPIs.codecSupportsMedia(renderMetadata.codec);
 
 	const hasVideo = renderMetadata
-		? !BrowserSafeApis.isAudioCodec(renderMetadata.codec)
+		? !NoReactAPIs.isAudioCodec(renderMetadata.codec)
 		: false;
 	const hasAudio = renderMetadata
 		? !renderMetadata.muted && support.audio

--- a/packages/lambda/src/functions/helpers/render-has-audio-video.ts
+++ b/packages/lambda/src/functions/helpers/render-has-audio-video.ts
@@ -1,4 +1,4 @@
-import {RenderInternals} from '@remotion/renderer';
+import {BrowserSafeApis} from '@remotion/renderer/client';
 import type {CloudProvider} from '@remotion/serverless';
 import type {RenderMetadata} from '@remotion/serverless/client';
 
@@ -12,10 +12,10 @@ export const lambdaRenderHasAudioVideo = <Provider extends CloudProvider>(
 		throw new Error('Cannot merge stills');
 	}
 
-	const support = RenderInternals.codecSupportsMedia(renderMetadata.codec);
+	const support = BrowserSafeApis.codecSupportsMedia(renderMetadata.codec);
 
 	const hasVideo = renderMetadata
-		? !RenderInternals.isAudioCodec(renderMetadata.codec)
+		? !BrowserSafeApis.isAudioCodec(renderMetadata.codec)
 		: false;
 	const hasAudio = renderMetadata
 		? !renderMetadata.muted && support.audio

--- a/packages/lambda/src/functions/renderer.ts
+++ b/packages/lambda/src/functions/renderer.ts
@@ -5,6 +5,7 @@ import type {
 	OnArtifact,
 } from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
+import {NoReactAPIs} from '@remotion/renderer/pure';
 import type {
 	CloudProvider,
 	OnStream,
@@ -175,7 +176,7 @@ const renderHandler = async <Provider extends CloudProvider>({
 	const audioOutputLocation =
 		willRenderAudioEval === 'no'
 			? null
-			: RenderInternals.isAudioCodec(params.codec)
+			: NoReactAPIs.isAudioCodec(params.codec)
 				? null
 				: audioExtension
 					? path.join(outdir, `${chunk}.${audioExtension}`)
@@ -358,7 +359,7 @@ const renderHandler = async <Provider extends CloudProvider>({
 	if (videoOutputLocation) {
 		const videoChunkTimer = timer('Sending main chunk', params.logLevel);
 		await onStream({
-			type: RenderInternals.isAudioCodec(params.codec)
+			type: NoReactAPIs.isAudioCodec(params.codec)
 				? 'audio-chunk-rendered'
 				: 'video-chunk-rendered',
 			payload: fs.readFileSync(videoOutputLocation),

--- a/packages/lambda/src/io/read-file.ts
+++ b/packages/lambda/src/io/read-file.ts
@@ -13,7 +13,7 @@ export const lambdaReadFileImplementation = async ({
 	bucketName: string;
 	key: string;
 	region: AwsRegion;
-	expectedBucketOwner: string;
+	expectedBucketOwner: string | null;
 	forcePathStyle: boolean;
 }): Promise<Readable> => {
 	const {Body} = await getS3Client({
@@ -24,7 +24,7 @@ export const lambdaReadFileImplementation = async ({
 		new GetObjectCommand({
 			Bucket: bucketName,
 			Key: key,
-			ExpectedBucketOwner: expectedBucketOwner,
+			ExpectedBucketOwner: expectedBucketOwner ?? undefined,
 		}),
 	);
 	return Body as Readable;

--- a/packages/renderer/src/can-use-parallel-encoding.ts
+++ b/packages/renderer/src/can-use-parallel-encoding.ts
@@ -1,5 +1,5 @@
 import type {Codec} from './codec';
-import {isAudioCodec} from './options/audio-codec';
+import {isAudioCodec} from './is-audio-codec';
 
 export const canUseParallelEncoding = (codec: Codec) => {
 	if (isAudioCodec(codec)) {

--- a/packages/renderer/src/client.ts
+++ b/packages/renderer/src/client.ts
@@ -2,10 +2,12 @@ import {DEFAULT_TIMEOUT} from './browser/TimeoutSettings';
 import {validCodecs} from './codec';
 import {
 	codecSupportsCrf,
+	codecSupportsMedia,
 	codecSupportsVideoBitrate,
 } from './codec-supports-media';
 import {getDefaultCrfForCodec, getValidCrfRanges} from './crf';
 import {defaultFileExtensionMap} from './file-extensions';
+import {getFramesToRender} from './get-duration-from-frame-range';
 import {
 	defaultCodecsForFileExtension,
 	getFileExtensionFromCodec,
@@ -66,4 +68,6 @@ export const BrowserSafeApis = {
 	logLevels,
 	getOutputCodecOrUndefined,
 	getExtensionFromAudioCodec,
+	codecSupportsMedia,
+	getFramesToRender,
 };

--- a/packages/renderer/src/client.ts
+++ b/packages/renderer/src/client.ts
@@ -19,7 +19,6 @@ import {allOptions} from './options';
 import {
 	defaultAudioCodecs,
 	getExtensionFromAudioCodec,
-	isAudioCodec,
 	supportedAudioCodecs,
 	validAudioCodecs,
 } from './options/audio-codec';
@@ -43,7 +42,6 @@ export const BrowserSafeApis = {
 	validAudioCodecs,
 	getDefaultCrfForCodec,
 	getValidCrfRanges,
-	isAudioCodec,
 	proResProfileOptions,
 	x264PresetOptions,
 	validPixelFormats,

--- a/packages/renderer/src/client.ts
+++ b/packages/renderer/src/client.ts
@@ -2,12 +2,10 @@ import {DEFAULT_TIMEOUT} from './browser/TimeoutSettings';
 import {validCodecs} from './codec';
 import {
 	codecSupportsCrf,
-	codecSupportsMedia,
 	codecSupportsVideoBitrate,
 } from './codec-supports-media';
 import {getDefaultCrfForCodec, getValidCrfRanges} from './crf';
 import {defaultFileExtensionMap} from './file-extensions';
-import {getFramesToRender} from './get-duration-from-frame-range';
 import {
 	defaultCodecsForFileExtension,
 	getFileExtensionFromCodec,
@@ -66,6 +64,4 @@ export const BrowserSafeApis = {
 	logLevels,
 	getOutputCodecOrUndefined,
 	getExtensionFromAudioCodec,
-	codecSupportsMedia,
-	getFramesToRender,
 };

--- a/packages/renderer/src/combine-videos.ts
+++ b/packages/renderer/src/combine-videos.ts
@@ -7,12 +7,13 @@ import {createCombinedAudio} from './combine-audio';
 import {combineVideoStreams} from './combine-video-streams';
 import {combineVideoStreamsSeamlessly} from './combine-video-streams-seamlessly';
 import {getFileExtensionFromCodec} from './get-extension-from-codec';
+import {isAudioCodec} from './is-audio-codec';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
 import type {CancelSignal} from './make-cancel-signal';
 import {muxVideoAndAudio} from './mux-video-and-audio';
 import type {AudioCodec} from './options/audio-codec';
-import {getExtensionFromAudioCodec, isAudioCodec} from './options/audio-codec';
+import {getExtensionFromAudioCodec} from './options/audio-codec';
 import {truthy} from './truthy';
 
 type Options = {

--- a/packages/renderer/src/crf.ts
+++ b/packages/renderer/src/crf.ts
@@ -1,5 +1,5 @@
 import type {Codec} from './codec';
-import {isAudioCodec} from './options/audio-codec';
+import {isAudioCodec} from './is-audio-codec';
 
 export type Crf = number | undefined;
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -142,7 +142,6 @@ import type {AudioCodec} from './options/audio-codec';
 import {
 	getDefaultAudioCodec,
 	getExtensionFromAudioCodec,
-	isAudioCodec,
 	resolveAudioCodec,
 	supportedAudioCodecs,
 } from './options/audio-codec';
@@ -193,7 +192,6 @@ export const RenderInternals = {
 	validateJpegQuality,
 	DEFAULT_TIMEOUT,
 	DEFAULT_CODEC,
-	isAudioCodec,
 	logLevels,
 	isEqualOrBelowLogLevel,
 	isValidLogLevel,

--- a/packages/renderer/src/is-audio-codec.ts
+++ b/packages/renderer/src/is-audio-codec.ts
@@ -1,0 +1,5 @@
+import type {Codec} from './codec';
+
+export const isAudioCodec = (codec: Codec | undefined | null) => {
+	return codec === 'mp3' || codec === 'aac' || codec === 'wav';
+};

--- a/packages/renderer/src/options/audio-codec.tsx
+++ b/packages/renderer/src/options/audio-codec.tsx
@@ -6,10 +6,6 @@ export const validAudioCodecs = ['pcm-16', 'aac', 'mp3', 'opus'] as const;
 
 export type AudioCodec = (typeof validAudioCodecs)[number];
 
-export const isAudioCodec = (codec: Codec | undefined | null) => {
-	return codec === 'mp3' || codec === 'aac' || codec === 'wav';
-};
-
 export const supportedAudioCodecs = {
 	h264: ['aac', 'pcm-16', 'mp3'] as const,
 	'h264-mkv': ['pcm-16', 'mp3'] as const,

--- a/packages/renderer/src/pure.ts
+++ b/packages/renderer/src/pure.ts
@@ -1,9 +1,15 @@
+import {codecSupportsMedia} from './codec-supports-media';
+import {getFramesToRender} from './get-duration-from-frame-range';
 import {getFileExtensionFromCodec} from './get-extension-from-codec';
 import {getExtensionOfFilename} from './get-extension-of-filename';
+import {isAudioCodec} from './is-audio-codec';
 import {validateOutputFilename} from './validate-output-filename';
 
 export const NoReactAPIs = {
 	getExtensionOfFilename,
 	getFileExtensionFromCodec,
 	validateOutputFilename,
+	getFramesToRender,
+	codecSupportsMedia,
+	isAudioCodec,
 };

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -30,12 +30,12 @@ import {
 	DEFAULT_VIDEO_IMAGE_FORMAT,
 	validateSelectedPixelFormatAndImageFormatCombination,
 } from './image-format';
+import {isAudioCodec} from './is-audio-codec';
 import {DEFAULT_JPEG_QUALITY, validateJpegQuality} from './jpeg-quality';
 import {Log} from './logger';
 import type {CancelSignal} from './make-cancel-signal';
 import {cancelErrorMessages, makeCancelSignal} from './make-cancel-signal';
 import type {ChromiumOptions} from './open-browser';
-import {isAudioCodec} from './options/audio-codec';
 import {DEFAULT_COLOR_SPACE, type ColorSpace} from './options/color-space';
 import type {ToOptions} from './options/option';
 import type {optionsMap} from './options/options-map';

--- a/packages/serverless/src/client.ts
+++ b/packages/serverless/src/client.ts
@@ -38,6 +38,12 @@ export {
 	internalGetOrCreateBucket,
 } from './get-or-create-bucket';
 
+export {
+	errorIsOutOfSpaceError,
+	isBrowserCrashedError,
+	isErrInsufficientResourcesErr,
+} from './error-category';
+
 export {getExpectedOutName} from './expected-out-name';
 export {FileNameAndSize, GetFolderFiles} from './get-files-in-folder';
 export {inputPropsKey, resolvedPropsKey} from './input-props-keys';

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -1,9 +1,5 @@
 export {compositionsHandler} from './compositions';
-export {
-	errorIsOutOfSpaceError,
-	isBrowserCrashedError,
-	isErrInsufficientResourcesErr,
-} from './error-category';
+
 export {getCredentialsFromOutName} from './expected-out-name';
 export {
 	forgetBrowserEventLoop,

--- a/packages/serverless/src/provider-implementation.ts
+++ b/packages/serverless/src/provider-implementation.ts
@@ -65,7 +65,7 @@ type ReadFile<Provider extends CloudProvider> = (params: {
 	bucketName: string;
 	key: string;
 	region: Provider['region'];
-	expectedBucketOwner: string;
+	expectedBucketOwner: string | null;
 	forcePathStyle: boolean;
 }) => Promise<Readable>;
 

--- a/packages/studio/bundle.ts
+++ b/packages/studio/bundle.ts
@@ -42,6 +42,7 @@ const [enableFile] = internalsModule.outputs;
 const internalsText = (await enableFile.text())
 	.replace(/jsxDEV/g, 'jsx')
 	.replace(/@remotion\/renderer\/client/g, '@remotion/renderer/client.js')
+	.replace(/@remotion\/renderer\/pure/g, '@remotion/renderer/pure.js')
 	.replace(/react\/jsx-dev-runtime/g, 'react/jsx-runtime');
 
 await Bun.write('dist/esm/internals.mjs', internalsText);

--- a/packages/studio/bundle.ts
+++ b/packages/studio/bundle.ts
@@ -30,6 +30,8 @@ const internalsModule = await build({
 		'@remotion/renderer',
 		'@remotion/player',
 		'@remotion/renderer/client',
+		'@remotion/renderer/pure',
+		'@remotion/renderer/error-handling',
 		'source-map',
 		'zod',
 		'remotion/no-react',

--- a/packages/studio/src/components/RenderModal/RenderModalBasic.tsx
+++ b/packages/studio/src/components/RenderModal/RenderModalBasic.tsx
@@ -1,5 +1,6 @@
 import type {Codec, ProResProfile} from '@remotion/renderer';
 import {BrowserSafeApis} from '@remotion/renderer/client';
+import {NoReactAPIs} from '@remotion/renderer/pure';
 import React, {useCallback, useMemo} from 'react';
 import type {VideoConfig} from 'remotion';
 import {labelProResProfile} from '../../helpers/prores-labels';
@@ -62,7 +63,7 @@ export const RenderModalBasic: React.FC<{
 	const videoCodecOptions = useMemo((): ComboboxValue[] => {
 		return BrowserSafeApis.validCodecs
 			.filter((c) => {
-				return BrowserSafeApis.isAudioCodec(c) === (renderMode === 'audio');
+				return NoReactAPIs.isAudioCodec(c) === (renderMode === 'audio');
 			})
 			.map((codecOption) => {
 				return {

--- a/packages/studio/src/components/RenderModal/get-default-codecs.ts
+++ b/packages/studio/src/components/RenderModal/get-default-codecs.ts
@@ -1,5 +1,6 @@
 import type {AudioCodec, Codec} from '@remotion/renderer';
 import {BrowserSafeApis} from '@remotion/renderer/client';
+import {NoReactAPIs} from '@remotion/renderer/pure';
 import type {RenderType} from './RenderModalAdvanced';
 
 export const getDefaultCodecs = ({
@@ -34,7 +35,7 @@ export const getDefaultCodecs = ({
 							? 'mp3'
 							: 'aac';
 
-	const isVideoCodecAnAudioCodec = BrowserSafeApis.isAudioCodec(
+	const isVideoCodecAnAudioCodec = NoReactAPIs.isAudioCodec(
 		userPreferredVideoCodec,
 	);
 
@@ -44,7 +45,7 @@ export const getDefaultCodecs = ({
 			initialRenderType: 'audio',
 			initialVideoCodec: userPreferredVideoCodec as Codec,
 			initialVideoCodecForAudioTab: userPreferredVideoCodecForAudioTab,
-			initialVideoCodecForVideoTab: BrowserSafeApis.isAudioCodec(
+			initialVideoCodecForVideoTab: NoReactAPIs.isAudioCodec(
 				defaultConfigurationVideoCodec,
 			)
 				? 'h264'

--- a/turbo.json
+++ b/turbo.json
@@ -71,7 +71,7 @@
 		},
 
 		"@remotion/it-tests#test": {
-			"dependsOn": ["^make", "@remotion/example#test", "@remotion/example#make"]
+			"dependsOn": ["//#ts-build", "^make", "@remotion/example#test", "@remotion/example#make"]
 		},
 		"@remotion/media-parser#build": {
 			"dependsOn": ["//#ts-build"],

--- a/turbo.json
+++ b/turbo.json
@@ -71,7 +71,13 @@
 		},
 
 		"@remotion/it-tests#test": {
-			"dependsOn": ["//#ts-build", "^make", "@remotion/example#test", "@remotion/example#make"]
+			"dependsOn": [
+				"//#ts-build",
+				"^make",
+				"@remotion/example#test",
+				"@remotion/example#make",
+				"@remotion/studio#make"
+			]
 		},
 		"@remotion/media-parser#build": {
 			"dependsOn": ["//#ts-build"],


### PR DESCRIPTION
This gets the render progress directly from S3 instead of invoking a Lambda function that calls S3.  
This is faster, but it only works if you didn't rename the function name and if the user is allowed to access the S3 file (previously the role was accessing the file)