### PR TITLE
`remotion`: Fix bad double-seeking behavior

### DIFF
--- a/packages/core/src/buffer-until-first-frame.ts
+++ b/packages/core/src/buffer-until-first-frame.ts
@@ -52,7 +52,7 @@ export const useBufferUntilFirstFrame = ({
 				bufferingRef.current = false;
 			};
 
-			const onEndedOrPause = () => {
+			const onEndedOrPauseOrCanPlay = () => {
 				unblock();
 			};
 
@@ -64,15 +64,14 @@ export const useBufferUntilFirstFrame = ({
 					onVariableFpsVideoDetected();
 				}
 
-				// Safari often seeks and then stalls.
-				// This makes sure that the video actually starts playing.
-				current.requestVideoFrameCallback(() => {
-					unblock();
-				});
+				unblock();
 			});
 
-			current.addEventListener('ended', onEndedOrPause, {once: true});
-			current.addEventListener('pause', onEndedOrPause, {once: true});
+			current.addEventListener('ended', onEndedOrPauseOrCanPlay, {once: true});
+			current.addEventListener('pause', onEndedOrPauseOrCanPlay, {once: true});
+			current.addEventListener('canplay', onEndedOrPauseOrCanPlay, {
+				once: true,
+			});
 		},
 		[
 			delayPlayback,


### PR DESCRIPTION
I got submitted a video that in the end has only 1 frame with a long duration.

https://discord.com/channels/809501355504959528/919965306171052143/1293534844906897431

It trips up our behavior that waits for 2 new frames before it unblocks the buffer state. With testing on Chrome and Safari, it seems like we are doing better by just not doing this at all and unblock as soon as a new frame is received.

The long-term fix this is to combine it with parseMedia() so that we know all the frames before hand and know when a frame is expected or not.