### PR TITLE
`@remotion/renderer`: Fix race condition when calling `ensureBrowser()` while other `ensureBrowser()` call is already downloading a browser

### DIFF
--- a/packages/renderer/src/ensure-browser.ts
+++ b/packages/renderer/src/ensure-browser.ts
@@ -34,7 +34,9 @@ export type EnsureBrowserOptions = Partial<
 	} & ToOptions<typeof BrowserSafeApis.optionsMap.ensureBrowser>
 >;
 
-export const internalEnsureBrowser = async ({
+let currentEnsureBrowserOperation: Promise<unknown> = Promise.resolve();
+
+const internalEnsureBrowserUncapped = async ({
 	indent,
 	logLevel,
 	browserExecutable,
@@ -49,6 +51,15 @@ export const internalEnsureBrowser = async ({
 
 	const newStatus = getBrowserStatus(browserExecutable);
 	return newStatus;
+};
+
+export const internalEnsureBrowser = (
+	options: InternalEnsureBrowserOptions,
+): Promise<BrowserStatus> => {
+	currentEnsureBrowserOperation = currentEnsureBrowserOperation.then(() =>
+		internalEnsureBrowserUncapped(options),
+	);
+	return currentEnsureBrowserOperation as Promise<BrowserStatus>;
 };
 
 const getBrowserStatus = (


### PR DESCRIPTION


Very nuanced

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
