### PR TITLE
`@remotion/studio`: Don't allow APIs to be called in a read-only Studio

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,7 @@ declare global {
 		remotion_getClipRegion: () => ClipRegion | null;
 		remotion_isPlayer: boolean;
 		remotion_isStudio: boolean;
+		remotion_isReadOnlyStudio: boolean;
 		remotion_isBuilding: undefined | (() => void);
 		remotion_finishedBuilding: undefined | (() => void);
 		siteVersion: '11';

--- a/packages/studio/src/Studio.tsx
+++ b/packages/studio/src/Studio.tsx
@@ -16,10 +16,12 @@ export const Studio: React.FC<{
 }> = ({rootComponent, readOnly}) => {
 	useLayoutEffect(() => {
 		window.remotion_isStudio = true;
+		window.remotion_isReadOnlyStudio = true;
 		Internals.enableSequenceStackTraces();
 
 		return () => {
 			window.remotion_isStudio = false;
+			window.remotion_isReadOnlyStudio = false;
 		};
 	}, []);
 

--- a/packages/studio/src/api/delete-static-file.ts
+++ b/packages/studio/src/api/delete-static-file.ts
@@ -9,6 +9,10 @@ export const deleteStaticFile = async (
 		throw new Error('deleteStaticFile() is only available in the Studio');
 	}
 
+	if (window.remotion_isReadOnlyStudio) {
+		throw new Error('deleteStaticFile() is not available in Read-Only Studio');
+	}
+
 	if (relativePath.startsWith(window.remotion_staticBase)) {
 		relativePath = relativePath.substring(
 			window.remotion_staticBase.length + 1,

--- a/packages/studio/src/api/install-package.ts
+++ b/packages/studio/src/api/install-package.ts
@@ -2,10 +2,19 @@ import type {
 	InstallPackageResponse,
 	InstallablePackage,
 } from '@remotion/studio-shared';
+import {getRemotionEnvironment} from 'remotion';
 import {callApi} from '../components/call-api';
 
 export const installPackages = (
 	packageNames: InstallablePackage[],
 ): Promise<InstallPackageResponse> => {
+	if (!getRemotionEnvironment().isStudio) {
+		throw new Error('installPackages() is only available in the Studio');
+	}
+
+	if (window.remotion_isReadOnlyStudio) {
+		throw new Error('installPackages() is not available in Read-Only Studio');
+	}
+
 	return callApi('/api/install-package', {packageNames});
 };

--- a/packages/studio/src/api/restart-studio.ts
+++ b/packages/studio/src/api/restart-studio.ts
@@ -4,8 +4,17 @@
  */
 
 import type {RestartStudioResponse} from '@remotion/studio-shared';
+import {getRemotionEnvironment} from 'remotion';
 import {callApi} from '../components/call-api';
 
 export const restartStudio = (): Promise<RestartStudioResponse> => {
+	if (!getRemotionEnvironment().isStudio) {
+		throw new Error('restartStudio() is only available in the Studio');
+	}
+
+	if (window.remotion_isReadOnlyStudio) {
+		throw new Error('restartStudio() is not available in read-only Studio');
+	}
+
 	return callApi('/api/restart-studio', {});
 };

--- a/packages/studio/src/api/save-default-props.ts
+++ b/packages/studio/src/api/save-default-props.ts
@@ -1,3 +1,4 @@
+import {getRemotionEnvironment} from 'remotion';
 import {extractEnumJsonPaths} from '../components/RenderModal/SchemaEditor/extract-enum-json-paths';
 import {callUpdateDefaultPropsApi} from '../components/RenderQueue/actions';
 import type {UpdateDefaultPropsFunction} from './helpers/calc-new-props';
@@ -15,6 +16,14 @@ export const saveDefaultProps = async ({
 	compositionId: string;
 	defaultProps: UpdateDefaultPropsFunction;
 }) => {
+	if (!getRemotionEnvironment().isStudio) {
+		throw new Error('saveDefaultProps() is only available in the Studio');
+	}
+
+	if (window.remotion_isReadOnlyStudio) {
+		throw new Error('saveDefaultProps() is not available in read-only Studio');
+	}
+
 	try {
 		await import('zod');
 	} catch {

--- a/packages/studio/src/api/watch-public-folder.ts
+++ b/packages/studio/src/api/watch-public-folder.ts
@@ -20,6 +20,10 @@ export const watchPublicFolder = (
 		return {cancel: () => undefined};
 	}
 
+	if (window.remotion_isReadOnlyStudio) {
+		throw new Error('watchPublicFolder() is not available in read-only Studio');
+	}
+
 	const emitUpdate = () => {
 		callback(getStaticFiles());
 	};

--- a/packages/studio/src/api/watch-static-file.ts
+++ b/packages/studio/src/api/watch-static-file.ts
@@ -21,7 +21,17 @@ export const watchStaticFile = (
 ): {cancel: () => void} => {
 	if (!getRemotionEnvironment().isStudio) {
 		// eslint-disable-next-line no-console
-		console.warn('The API is only available while using the Remotion Studio.');
+		console.warn(
+			'watchStaticFile() is only available while using the Remotion Studio.',
+		);
+		return {cancel: () => undefined};
+	}
+
+	if (window.remotion_isReadOnlyStudio) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'watchStaticFile() is only available in an interactive Studio.',
+		);
 		return {cancel: () => undefined};
 	}
 

--- a/packages/studio/src/api/write-static-file.ts
+++ b/packages/studio/src/api/write-static-file.ts
@@ -5,6 +5,10 @@ export const writeStaticFile = async ({
 	contents: string | ArrayBuffer;
 	filePath: string;
 }): Promise<void> => {
+	if (window.remotion_isReadOnlyStudio) {
+		throw new Error('writeStaticFile() is not available in read-only Studio');
+	}
+
 	const url = new URL('/api/add-asset', window.location.origin);
 
 	if (filePath.includes('\\')) {


### PR DESCRIPTION
Fixes #3782