### PR TITLE
`@remotion/lambda`: Add dimensions to `RenderMetadata`

### DIFF
--- a/packages/docs/docs/lambda/getrenderprogress.mdx
+++ b/packages/docs/docs/lambda/getrenderprogress.mdx
@@ -103,6 +103,7 @@ Contains the following information about the render:
 - `estimatedRenderLambdaInvokations`: The estimated amount of Lambdas that will render chunks of the video.
 - `compositionId`: The ID of the composition that is being rendered.
 - `codec`: The selected codec into which the video gets encoded.
+- `dimensions`: The dimensions, with any `scale` applied, of the output video. (Available from v4.0.222)
 
 ### `bucket`
 

--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -327,6 +327,10 @@ const innerLaunchHandler = async <Provider extends CloudProvider>({
 		muted: params.muted,
 		metadata: params.metadata,
 		functionName: process.env.AWS_LAMBDA_FUNCTION_NAME as string,
+		dimensions: {
+			width: comp.width * (params.scale ?? 1),
+			height: comp.height * (params.scale ?? 1),
+		},
 	};
 
 	const {key, renderBucketName, customCredentials} = getExpectedOutName(

--- a/packages/lambda/src/functions/still.ts
+++ b/packages/lambda/src/functions/still.ts
@@ -196,6 +196,10 @@ const innerStillHandler = async <Provider extends CloudProvider>(
 		audioBitrate: null,
 		metadata: null,
 		functionName: process.env.AWS_LAMBDA_FUNCTION_NAME as string,
+		dimensions: {
+			height: composition.height * (lambdaParams.scale ?? 1),
+			width: composition.width * (lambdaParams.scale ?? 1),
+		},
 	};
 
 	const still = makeInitialOverallRenderProgress(timeoutInMilliseconds);

--- a/packages/lambda/src/test/unit/price-calculation.test.ts
+++ b/packages/lambda/src/test/unit/price-calculation.test.ts
@@ -40,6 +40,10 @@ test('Should not throw while calculating prices when time shifts occur', () => {
 			muted: false,
 			metadata: {Author: 'Lunar'},
 			functionName: 'remotion-render-la8ffw',
+			dimensions: {
+				height: 1080,
+				width: 1920,
+			},
 		},
 		diskSizeInMb: 512,
 		lambdasInvoked: 1,

--- a/packages/serverless/src/render-metadata.ts
+++ b/packages/serverless/src/render-metadata.ts
@@ -28,6 +28,11 @@ type Discriminated =
 			codec: ServerlessCodec;
 	  };
 
+type Dimensions = {
+	width: number;
+	height: number;
+};
+
 export type RenderMetadata<Provider extends CloudProvider> = Discriminated & {
 	siteId: string;
 	startedDate: number;
@@ -50,4 +55,5 @@ export type RenderMetadata<Provider extends CloudProvider> = Discriminated & {
 	audioBitrate: string | null;
 	downloadBehavior: DownloadBehavior;
 	metadata: Record<string, string> | null;
+	dimensions: Dimensions;
 };

--- a/packages/serverless/src/test/expected-out-name.test.ts
+++ b/packages/serverless/src/test/expected-out-name.test.ts
@@ -44,6 +44,10 @@ const testRenderMetadata: RenderMetadata<MockProvider> = {
 	muted: false,
 	metadata: null,
 	codec: 'h264',
+	dimensions: {
+		width: 1920,
+		height: 1080,
+	},
 };
 
 test('Should get a custom outname', () => {


### PR DESCRIPTION
Useful for displaying the dimensions after a render