### PR TITLE
Building a Timeline: Fix the dependency array in useMemo hook

### DIFF
--- a/packages/docs/docs/building-a-timeline.mdx
+++ b/packages/docs/docs/building-a-timeline.mdx
@@ -209,7 +209,7 @@ export const Editor = () => {
     return {
       tracks,
     };
-  }, []);
+  }, [tracks]);
 
   return (
     <>
@@ -264,7 +264,7 @@ const Editor: React.FC = () => {
     return {
       tracks,
     };
-  }, []);
+  }, [tracks]);
 
   return (
     <>


### PR DESCRIPTION
Without the dependency, the callback will never return the updated tracks.
