### PR TITLE
`@remotion/lambda`: Correct retry for `aborted` error on Lambda

### DIFF
--- a/packages/lambda/src/functions/helpers/stream-renderer.ts
+++ b/packages/lambda/src/functions/helpers/stream-renderer.ts
@@ -174,7 +174,7 @@ const streamRenderer = <Provider extends CloudProvider>({
 			})
 			.catch((err) => {
 				const shouldRetry =
-					(err as Error).message?.includes('Error: aborted') ?? false;
+					(err as Error).stack?.includes('Error: aborted') ?? false;
 
 				resolve({
 					type: 'error',


### PR DESCRIPTION
`new Error('aborted').message` does not include the string, but `new Error('aborted').stack` does¨