### PR TITLE
fix cjs export of google fonts

### DIFF
--- a/packages/google-fonts/package.json
+++ b/packages/google-fonts/package.json
@@ -4764,19 +4764,19 @@
 		"./*": {
 			"module": "./dist/esm/*.mjs",
 			"import": "./dist/esm/*.mjs",
-			"require": "./dist/cjs/*.cjs",
+			"require": "./dist/cjs/*.js",
 			"types": "./dist/cjs/*.d.ts"
 		},
 		"./index": {
 			"module": "./dist/esm/index.mjs",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.cjs",
+			"require": "./dist/cjs/index.js",
 			"types": "./dist/cjs/index.d.ts"
 		},
 		".": {
 			"module": "./dist/esm/index.mjs",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.cjs",
+			"require": "./dist/cjs/index.js",
 			"types": "./dist/cjs/index.d.ts"
 		}
 	},


### PR DESCRIPTION
I'm requiring a google font package from node in common js and I get this error:

```
Error: Cannot find module '/blabla/node_modules/@remotion/google-fonts/dist/cjs/WorkSans.cjs'
```

It's because the `cjs` files don't exist and are `.js` instead.

A quick look into the repo shows that it's the only place where we have this issue https://github.com/search?q=repo%3Aremotion-dev%2Fremotion%20%22*.cjs%22&type=code

I hope that's the correct fix because I know how much publishing for ESM/CJS is a nightmare 😱