### PR TITLE
`remotion`: New `credentials` options for `prefetch()`

### DIFF
--- a/packages/core/src/prefetch.ts
+++ b/packages/core/src/prefetch.ts
@@ -85,6 +85,7 @@ export const prefetch = (
 		method?: 'blob-url' | 'base64';
 		contentType?: string;
 		onProgress?: PrefetchOnProgress;
+		credentials?: RequestCredentials;
 	},
 ): FetchAndPreload => {
 	const method = options?.method ?? 'blob-url';
@@ -111,6 +112,7 @@ export const prefetch = (
 
 	fetch(src, {
 		signal: controller.signal,
+		credentials: options?.credentials ?? undefined,
 	})
 		.then((res) => {
 			canBeAborted = false;

--- a/packages/docs/docs/prefetch.mdx
+++ b/packages/docs/docs/prefetch.mdx
@@ -74,6 +74,10 @@ Read below for which option is suitable for you.
 
 Set a content type for the blob. By default, the content type from the HTTP response is taken. We recommend setting an appropriate content type for the media, e.g `video/mp4` only if the HTTP resource does not contain the right one by default.
 
+#### `credentials?`<AvailableFrom v="4.0.229" />
+
+Set a value for [`credentials`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#including_credentials) when calling `fetch()`.
+
 #### `onProgress?`<AvailableFrom v="4.0.85" />
 
 Callback for progress events.


### PR DESCRIPTION
Same as in fetch()