### PR TITLE
docs: fix link to X264 preset CLI option doc

### DIFF
--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -540,7 +540,7 @@ import {Config} from '@remotion/cli/config';
 Config.setX264Preset('fast');
 ```
 
-The [command line flag](/docs/cli/render#--prores-profile) `--prores-profile` will take precedence over this option.
+The [command line flag](/docs/cli/render#--x264-preset) `--x264-preset` will take precedence over this option.
 
 **See also**: [Encoding guide](/docs/encoding), [Transparent videos](/docs/transparent-videos)
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
This PR fixes an incorrect internal link I noticed while reading the docs.
