### PR TITLE
Fix typo in API overview doc

### DIFF
--- a/packages/docs/components/TableOfContents/remotion.tsx
+++ b/packages/docs/components/TableOfContents/remotion.tsx
@@ -42,7 +42,7 @@ export const TableOfContents: React.FC = () => {
 					<strong>interpolateColors()</strong>
 					<div>Map a range of values to colors</div>
 				</TOCItem>
-				<TOCItem link="/docs/interpolate-colors">
+				<TOCItem link="/docs/measure-spring">
 					<strong>measureSpring()</strong>
 					<div>Determine the duration of a spring</div>
 				</TOCItem>


### PR DESCRIPTION
Hello :) 

Just fixing a small typo in a link.

Thanks for the library :) 