### PR TITLE
`@remotion/bundler`: ESBuild loader picks up right tsconfig.json

### DIFF
--- a/packages/bundler/src/esbuild-loader/index.ts
+++ b/packages/bundler/src/esbuild-loader/index.ts
@@ -19,11 +19,10 @@ async function ESBuildLoader(
 	source: string,
 ): Promise<void> {
 	const done = this.async();
-	this.getOptions();
 	const options: LoaderOptions = this.getOptions();
-	const {implementation, ...esbuildTransformOptions} = options;
+	const {implementation, remotionRoot, ...esbuildTransformOptions} = options;
 
-	const tsConfigPath = path.join(this.context, 'tsconfig.json');
+	const tsConfigPath = path.join(remotionRoot, 'tsconfig.json');
 
 	if (implementation && typeof implementation.transform !== 'function') {
 		done(

--- a/packages/bundler/src/esbuild-loader/interfaces.ts
+++ b/packages/bundler/src/esbuild-loader/interfaces.ts
@@ -15,4 +15,5 @@ export type LoaderOptions = Except<
 	'sourcemap' | 'sourcefile'
 > & {
 	implementation: Implementation;
+	remotionRoot: string;
 };

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -33,12 +33,6 @@ const shouldUseReactDomClient = NoReactInternals.ENABLE_V5_BREAKING_CHANGES
 	? true
 	: parseInt(reactDomVersion, 10) >= 18;
 
-const esbuildLoaderOptions: LoaderOptions = {
-	target: 'chrome85',
-	loader: 'tsx',
-	implementation: esbuild,
-};
-
 type Truthy<T> = T extends false | '' | 0 | null | undefined ? never : T;
 
 function truthy<T>(value: T): value is Truthy<T> {
@@ -72,6 +66,13 @@ export const webpackConfig = async ({
 	remotionRoot: string;
 	poll: number | null;
 }): Promise<[string, WebpackConfiguration]> => {
+	const esbuildLoaderOptions: LoaderOptions = {
+		target: 'chrome85',
+		loader: 'tsx',
+		implementation: esbuild,
+		remotionRoot,
+	};
+
 	let lastProgress = 0;
 
 	const isBun = typeof Bun !== 'undefined';


### PR DESCRIPTION
It would pick up a tsconfig that is adjacent to the source file, but I think it makes more sense to pick it up adjacent from remotion root

e.g. File `./src/comp/Component.ts` should pick it up from `./tsconfig.json`, not from `./src/comp/tsconfig.json`