### PR TITLE
`@remotion/webcodecs`: Override Chrome audio config

### DIFF
--- a/packages/media-parser/src/boxes/iso-base-media/esds/decoder-specific-config.ts
+++ b/packages/media-parser/src/boxes/iso-base-media/esds/decoder-specific-config.ts
@@ -56,9 +56,9 @@ export const parseDecoderSpecificConfig = (
 
 	let patchedBytes = bytes;
 
-	if (bytes[0] === 18 && bytes[1] === 16) {
+	if (bytes[0] === 18 && bytes[1] === 8) {
 		// riverside_use_cursor_.mp4
-		patchedBytes = new Uint8Array([18, 8]);
+		patchedBytes = new Uint8Array([18, 16]);
 		Log.warn(
 			logLevel,
 			'Chrome has a bug and might not be able to decode this audio. It will be fixed, see: https://issues.chromium.org/issues/360083330',

--- a/packages/media-parser/src/boxes/iso-base-media/esds/decoder-specific-config.ts
+++ b/packages/media-parser/src/boxes/iso-base-media/esds/decoder-specific-config.ts
@@ -54,7 +54,19 @@ export const parseDecoderSpecificConfig = (
 		iterator.discard(layerSize - read);
 	}
 
+	let patchedBytes = bytes;
+
+	if (bytes[0] === 18 && bytes[1] === 16) {
+		// riverside_use_cursor_.mp4
+		patchedBytes = new Uint8Array([18, 8]);
+		Log.warn(
+			logLevel,
+			'Chrome has a bug and might not be able to decode this audio. It will be fixed, see: https://issues.chromium.org/issues/360083330',
+		);
+	}
+
 	if (bytes.byteLength === 2 && bytes[0] === 17 && bytes[1] === 136) {
+		patchedBytes = new Uint8Array([18, 144]);
 		Log.warn(
 			logLevel,
 			'Chrome has a bug and might not be able to decode this audio. It will be fixed, see: https://issues.chromium.org/issues/360083330',
@@ -66,6 +78,6 @@ export const parseDecoderSpecificConfig = (
 		audioObjectType,
 		samplingFrequencyIndex,
 		channelConfiguration,
-		asBytes: bytes,
+		asBytes: patchedBytes,
 	};
 };

--- a/packages/media-parser/src/create/matroska/cluster.ts
+++ b/packages/media-parser/src/create/matroska/cluster.ts
@@ -34,7 +34,9 @@ export const canFitInCluster = ({
 		timestampToClusterTimestamp(clusterStartTimestamp, timescale);
 
 	if (timecodeRelativeToCluster < 0) {
-		throw new Error(`timecodeRelativeToCluster is negative`);
+		throw new Error(
+			`timecodeRelativeToCluster is negative, tried to add ${chunk.timestamp} to ${clusterStartTimestamp}`,
+		);
 	}
 
 	return timecodeRelativeToCluster <= maxClusterTimestamp;


### PR DESCRIPTION
Aiming to fix #4565 