### PR TITLE
add quote around paths to take into account if there are spaces in file paths

### DIFF
--- a/packages/template-tiktok/sub.mjs
+++ b/packages/template-tiktok/sub.mjs
@@ -24,7 +24,7 @@ import {
 const extractToTempAudioFile = (fileToTranscribe, tempOutFile) => {
   // Extracting audio from mp4 and save it as 16khz wav file
   execSync(
-    `npx remotion ffmpeg -i ${fileToTranscribe} -ar 16000 ${tempOutFile} -y`,
+    `npx remotion ffmpeg -i "${fileToTranscribe}" -ar 16000 "${tempOutFile}" -y`,
     { stdio: ["ignore", "inherit"] },
   );
 };


### PR DESCRIPTION
Just tried the tiktok template. I have a space in my path where the project is installed so when i ran sub.mjs i got an error. Adding a quote around it will avoid this issue


