### PR TITLE
`@remotion/player`: allow overriding `__remotion-player` className

### DIFF
--- a/packages/docs/docs/player/api.mdx
+++ b/packages/docs/docs/player/api.mdx
@@ -539,6 +539,12 @@ Makes the Player render things outside of the canvas. Useful if you have interac
 Controls what happens when the user presses the Play/Pause button on their keyboard or uses other controls such as Chromes built-in controls.  
 See [Media Keys Behavior](/docs/player/media-keys) for more information.
 
+### `overrideInternalClassName`<AvailableFrom v="4.0.233" />
+
+_optional_
+
+A HTML class name to be used in place of the default `__remotion-player`.
+
 ## `PlayerRef`
 
 You may attach a ref to the player and control it in an imperative manner.

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -87,6 +87,7 @@ export type PlayerProps<
 	readonly hideControlsWhenPointerDoesntMove?: boolean | number;
 	readonly overflowVisible?: boolean;
 	readonly browserMediaControlsBehavior?: BrowserMediaControlsBehavior;
+	readonly overrideInternalClassName?: string;
 } & CompProps<Props> &
 	PropsIfHasProps<Schema, Props>;
 
@@ -149,6 +150,7 @@ const PlayerFn = <
 		overflowVisible = false,
 		renderMuteButton,
 		browserMediaControlsBehavior: passedBrowserMediaControlsBehavior,
+		overrideInternalClassName,
 		...componentProps
 	}: PlayerProps<Schema, Props>,
 	ref: MutableRefObject<PlayerRef>,
@@ -342,7 +344,7 @@ const PlayerFn = <
 			// Inject CSS only on client, and also only after the Player has hydrated
 			Internals.CSSUtils.injectCSS(
 				Internals.CSSUtils.makeDefaultPreviewCSS(
-					`.${PLAYER_CSS_CLASSNAME}`,
+					`.${PLAYER_CSS_CLASSNAME(overrideInternalClassName)}`,
 					'#fff',
 				),
 			);
@@ -420,6 +422,7 @@ const PlayerFn = <
 							}
 							overflowVisible={overflowVisible}
 							browserMediaControlsBehavior={browserMediaControlsBehavior}
+							overrideInternalClassName={overrideInternalClassName ?? undefined}
 						/>
 					</PlayerEmitterProvider>
 				</Internals.Timeline.SetTimelineContext.Provider>

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -89,6 +89,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		readonly hideControlsWhenPointerDoesntMove: boolean | number;
 		readonly overflowVisible: boolean;
 		readonly browserMediaControlsBehavior: BrowserMediaControlsBehavior;
+		readonly overrideInternalClassName: string | undefined;
 	}
 > = (
 	{
@@ -126,6 +127,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		hideControlsWhenPointerDoesntMove,
 		overflowVisible,
 		browserMediaControlsBehavior,
+		overrideInternalClassName,
 	},
 	ref,
 ) => {
@@ -618,7 +620,10 @@ const PlayerUI: React.ForwardRefRenderFunction<
 				onPointerDown={clickToPlay ? handlePointerDown : undefined}
 				onDoubleClick={doubleClickToFullscreen ? handleDoubleClick : undefined}
 			>
-				<div style={containerStyle} className={PLAYER_CSS_CLASSNAME}>
+				<div
+					style={containerStyle}
+					className={PLAYER_CSS_CLASSNAME(overrideInternalClassName)}
+				>
 					{VideoComponent ? (
 						<ErrorBoundary onError={onError} errorFallback={errorFallback}>
 							<Internals.CurrentScaleContext.Provider value={currentScale}>

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -38,6 +38,7 @@ export type ThumbnailProps<
 		readonly errorFallback?: ErrorFallback;
 		readonly renderLoading?: RenderLoading;
 		readonly className?: string;
+		readonly overrideInternalClassName?: string;
 	};
 
 export type ThumbnailPropsWithoutZod<Props extends Record<string, unknown>> =
@@ -59,6 +60,7 @@ const ThumbnailFn = <
 		errorFallback = () => '⚠️',
 		renderLoading,
 		overflowVisible = false,
+		overrideInternalClassName,
 		...componentProps
 	}: ThumbnailProps<Schema, Props>,
 	ref: MutableRefObject<ThumbnailMethods>,
@@ -126,6 +128,7 @@ const ThumbnailFn = <
 						renderLoading={renderLoading}
 						style={style}
 						overflowVisible={overflowVisible}
+						overrideInternalClassName={overrideInternalClassName}
 					/>
 				</ThumbnailEmitterContext.Provider>
 			</SharedPlayerContexts>

--- a/packages/player/src/ThumbnailUI.tsx
+++ b/packages/player/src/ThumbnailUI.tsx
@@ -41,9 +41,18 @@ const ThumbnailUI: React.ForwardRefRenderFunction<
 		readonly renderLoading: RenderLoading | undefined;
 		readonly className: string | undefined;
 		readonly overflowVisible: boolean;
+		readonly overrideInternalClassName: string | undefined;
 	}
 > = (
-	{style, inputProps, errorFallback, renderLoading, className, overflowVisible},
+	{
+		style,
+		inputProps,
+		errorFallback,
+		renderLoading,
+		className,
+		overflowVisible,
+		overrideInternalClassName,
+	},
 	ref,
 ) => {
 	const config = Internals.useUnsafeVideoConfig();
@@ -137,7 +146,10 @@ const ThumbnailUI: React.ForwardRefRenderFunction<
 
 	const content = (
 		<div style={outer}>
-			<div style={containerStyle} className={PLAYER_CSS_CLASSNAME}>
+			<div
+				style={containerStyle}
+				className={PLAYER_CSS_CLASSNAME(overrideInternalClassName)}
+			>
 				{VideoComponent ? (
 					<ErrorBoundary onError={onError} errorFallback={errorFallback}>
 						<Internals.CurrentScaleContext.Provider value={currentScaleContext}>

--- a/packages/player/src/player-css-classname.ts
+++ b/packages/player/src/player-css-classname.ts
@@ -1,1 +1,3 @@
-export const PLAYER_CSS_CLASSNAME = '__remotion-player';
+export const PLAYER_CSS_CLASSNAME = (override?: string): string => {
+	return override ?? '__remotion-player';
+};


### PR DESCRIPTION
In an effort to obfuscate that Remotion is the technology being used within an app, this PR makes it possible to pass a different className to be used in place of `__remotion-player`

![image](https://github.com/user-attachments/assets/597d543e-fa61-4807-af02-2abf804959d0)