### PR TITLE
`@remotion/media-utils`: Don't draw NaN height bars if audio is completely silent

### DIFF
--- a/packages/media-utils/src/get-wave-form-samples.ts
+++ b/packages/media-utils/src/get-wave-form-samples.ts
@@ -19,7 +19,8 @@ const filterData = (audioBuffer: Float32Array, samples: number) => {
 };
 
 const normalizeData = (filteredData: number[]) => {
-	const multiplier = Math.max(...filteredData) ** -1;
+	const max = Math.max(...filteredData);
+	const multiplier = max === 0 ? 0 : max ** -1;
 	return filteredData.map((n) => n * multiplier);
 };
 


### PR DESCRIPTION
…etely silent

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
