### PR TITLE
`@remotion/player`: Show banner on sites that do not respect license

### DIFF
--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -26,6 +26,7 @@ import {
 	calculateOuterStyle,
 } from './calculate-scale.js';
 import {ErrorBoundary} from './error-boundary.js';
+import {RenderWarningIfBlacklist} from './license-blacklist.js';
 import {playerCssClassname} from './player-css-classname.js';
 import type {PlayerMethods, PlayerRef} from './player-methods.js';
 import type {RenderVolumeSlider} from './render-volume-slider.js';
@@ -650,6 +651,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 						</div>
 					) : null}
 				</div>
+				<RenderWarningIfBlacklist />
 			</div>
 			{shouldShowPoster && posterFillMode === 'player-size' ? (
 				<div

--- a/packages/player/src/license-blacklist.tsx
+++ b/packages/player/src/license-blacklist.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 
 export const getHashOfDomain = async (): Promise<string | null> => {
 	if (typeof window === 'undefined') {
@@ -34,6 +34,48 @@ const style: React.CSSProperties = {
 	fontFamily: 'Arial',
 };
 
+const DOMAIN_BLACKLIST = [
+	'28d262b44cc61fa750f1686b16ad0604dabfe193fbc263eec05c89b7ad4c2cd6',
+	'4db1b0a94be33165dfefcb3ba03d04c7a2666dd27c496d3dc9fa41858e94925e',
+	'fbc48530bbf245da790f63675e84e06bab38c3b114fab07eb350025119922bdc',
+	'7baf10a8932757b1b3a22b3fce10a048747ac2f8eaf638603487e3705b07eb83',
+	'8a6c21a598d8c667272b5207c051b85997bf5b45d5fb712378be3f27cd72c6a6',
+	'a2f7aaac9c50a9255e7fc376110c4e0bfe153722dc66ed3c5d3bf2a135f65518',
+];
+
+let ran = false;
+
 export const RenderWarningIfBlacklist: React.FC = () => {
-	return <div style={style}>Remotion Unlicensed – Contact hi@remotion.dev</div>;
+	const [unlicensed, setUnlicensed] = React.useState(false);
+
+	useEffect(() => {
+		// Prevent firing twice in strict mode
+		if (ran) {
+			return;
+		}
+
+		ran = true;
+		getHashOfDomain()
+			.then((hash) => {
+				if (hash && DOMAIN_BLACKLIST.includes(hash)) {
+					setUnlicensed(true);
+				}
+			})
+			.catch(() => {});
+	}, []);
+
+	if (!unlicensed) {
+		return null;
+	}
+
+	return (
+		<div style={style}>
+			<a
+				style={{color: 'white'}}
+				href="https://github.com/remotion-dev/remotion/pull/4589"
+			>
+				Remotion Unlicensed – Contact hi@remotion.dev
+			</a>
+		</div>
+	);
 };

--- a/packages/player/src/license-blacklist.tsx
+++ b/packages/player/src/license-blacklist.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export const getHashOfDomain = async (): Promise<string | null> => {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+
+	if (typeof window.crypto === 'undefined') {
+		return null;
+	}
+
+	if (typeof window.crypto.subtle === 'undefined') {
+		return null;
+	}
+
+	try {
+		const hashBuffer = await crypto.subtle.digest(
+			'SHA-256',
+			new TextEncoder().encode(window.location.hostname),
+		);
+
+		return Array.from(new Uint8Array(hashBuffer))
+			.map((b) => b.toString(16).padStart(2, '0'))
+			.join('');
+	} catch {
+		return null;
+	}
+};
+
+const style: React.CSSProperties = {
+	backgroundColor: 'red',
+	position: 'absolute',
+	padding: 12,
+	fontFamily: 'Arial',
+};
+
+export const RenderWarningIfBlacklist: React.FC = () => {
+	return <div style={style}>Remotion Unlicensed – Contact hi@remotion.dev</div>;
+};


### PR DESCRIPTION
If one gets to see this banner, it means that:

- [ ] The Remotion Player is running on a website that evidently belongs to a website with a team greater than 4
- [ ] The company has not purchased a [company license](https://remotion.pro/license)
- [ ] The company has been contacted by Remotion but we have been unsuccessful to sell them a [company license](https://remotion.pro/license), or we are unable to contact them.

This means an unauthorized use of Remotion according to our [license](https://remotion.dev/license).

Only in rare cases we add domains to this list after our efforts to solve the situation amicably fail.

We hash the domains in order to protect the identity of the companies.
The hash is generated using the following code:

```ts
await Array.from(new Uint8Array(await crypto.subtle.digest(
	'SHA-256',
	new TextEncoder().encode(window.location.origin),
)))
	.map((b) => b.toString(16).padStart(2, '0'))
	.join('')
```

We keep a list of hashes here, but only the Remotion team is able to see it: https://docs.google.com/spreadsheets/d/1mcIdtdNUGc6EBir5P1rbSjgfLZZLuVRhsXqk_VUZp68/edit?gid=0#gid=0

If you get to see such a message on your site, contact hi@remotion.dev