### PR TITLE
`@remotion/renderer`: Support hardware accelerated encoding for H.264, H.265 and ProRes on macOS

### DIFF
--- a/packages/docs/docs/hardware-acceleration.mdx
+++ b/packages/docs/docs/hardware-acceleration.mdx
@@ -13,7 +13,7 @@ From Remotion v4.0.228, Remotion supports hardware-accelerated encoding in some 
 Since encoding is platform- and codec-specific, only a few scenarios are supported at the moment.
 
 - Currently, only macOS is supported (Acceleration using VideoToolbox)
-- Only ProRes is supported
+- ProRes is supported from v4.0.228, H.264 and H.265 are supported from v4.0.236
 
 ## Enable hardware accelerated encoding
 
@@ -80,6 +80,13 @@ Config.setHardwareAcceleration('if-possible');
 ### In Remotion Lambda and Cloud Run
 
 These options are not supported in Remotion Lambda and Cloud Run, because those cloud services do not support hardware acceleration.
+
+## File size
+
+Note that the file size is significantly larger by default when using hardware acceleration, likely because less compression is applied.  
+We recommend that you use the `--video-bitrate` flag to control the file size.
+
+We find that `--video-bitrate=8M` achieves a similar file size than software encoding when exporting a H.264 Full HD video.
 
 ## Tell if hardware acceleration is being used
 

--- a/packages/renderer/src/ffmpeg-args.ts
+++ b/packages/renderer/src/ffmpeg-args.ts
@@ -84,11 +84,15 @@ export const generateFfmpegArgs = ({
 	indent: boolean;
 	logLevel: LogLevel;
 }): string[][] => {
-	const encoderSettings = getCodecName(
+	const encoderSettings = getCodecName({
 		codec,
-		hardwareAcceleration === 'required' ||
-			hardwareAcceleration === 'if-possible',
-	);
+		encodingMaxRate,
+		encodingBufferSize,
+		crf,
+		hardwareAcceleration,
+		indent,
+		logLevel,
+	});
 
 	if (encoderSettings === null) {
 		throw new TypeError(

--- a/packages/renderer/src/get-codec-name.ts
+++ b/packages/renderer/src/get-codec-name.ts
@@ -1,27 +1,119 @@
 import type {Codec} from './codec';
+import type {LogLevel} from './log-level';
+import {Log} from './logger';
+import type {HardwareAccelerationOption} from './options/hardware-acceleration';
 
 export type CodecSettings = {
 	encoderName: string;
 	hardwareAccelerated: boolean;
 };
 
-export const getCodecName = (
-	codec: Codec,
-	preferredHwAcceleration: boolean,
-): CodecSettings | null => {
+export const hasSpecifiedUnsupportedHardwareQualifySettings = ({
+	encodingMaxRate,
+	encodingBufferSize,
+	crf,
+}: {
+	encodingMaxRate: string | null;
+	encodingBufferSize: string | null;
+	crf: unknown;
+}) => {
+	if (encodingBufferSize !== null) {
+		return 'encodingBufferSize';
+	}
+
+	if (encodingMaxRate !== null) {
+		return 'encodingMaxRate';
+	}
+
+	if (crf !== null && typeof crf !== 'undefined') {
+		return 'crf';
+	}
+
+	return null;
+};
+
+export const getCodecName = ({
+	codec,
+	encodingMaxRate,
+	encodingBufferSize,
+	crf,
+	hardwareAcceleration,
+	logLevel,
+	indent,
+}: {
+	codec: Codec;
+	hardwareAcceleration: HardwareAccelerationOption;
+	encodingMaxRate: string | null;
+	encodingBufferSize: string | null;
+	crf: unknown;
+	logLevel: LogLevel;
+	indent: boolean;
+}): CodecSettings | null => {
+	const preferredHwAcceleration =
+		hardwareAcceleration === 'required' ||
+		hardwareAcceleration === 'if-possible';
+
+	const unsupportedQualityOption =
+		hasSpecifiedUnsupportedHardwareQualifySettings({
+			encodingMaxRate,
+			encodingBufferSize,
+			crf,
+		});
+
+	if (hardwareAcceleration === 'required' && unsupportedQualityOption) {
+		throw new Error(
+			`When using hardware accelerated encoding, the option "${unsupportedQualityOption}" with hardware acceleration is not supported. Disable hardware accelerated encoding or use "if-possible" instead.`,
+		);
+	}
+
+	const warnAboutDisabledHardwareAcceleration = () => {
+		if (hardwareAcceleration === 'if-possible' && unsupportedQualityOption) {
+			Log.warn(
+				{indent, logLevel},
+				`${indent ? '' : '\n'}Hardware accelerated encoding disabled - "${unsupportedQualityOption}" option is not supported with hardware acceleration`,
+			);
+		}
+	};
+
 	if (codec === 'prores') {
-		if (preferredHwAcceleration && process.platform === 'darwin') {
+		if (
+			preferredHwAcceleration &&
+			process.platform === 'darwin' &&
+			!unsupportedQualityOption
+		) {
 			return {encoderName: 'prores_videotoolbox', hardwareAccelerated: true};
 		}
+
+		warnAboutDisabledHardwareAcceleration();
 
 		return {encoderName: 'prores_ks', hardwareAccelerated: false};
 	}
 
 	if (codec === 'h264') {
+		if (
+			preferredHwAcceleration &&
+			process.platform === 'darwin' &&
+			!unsupportedQualityOption
+		) {
+			return {encoderName: 'h264_videotoolbox', hardwareAccelerated: true};
+		}
+
+		warnAboutDisabledHardwareAcceleration();
+
 		return {encoderName: 'libx264', hardwareAccelerated: false};
 	}
 
 	if (codec === 'h265') {
+		if (
+			preferredHwAcceleration &&
+			process.platform === 'darwin' &&
+			!unsupportedQualityOption
+		) {
+			return {encoderName: 'hevc_videotoolbox', hardwareAccelerated: true};
+		}
+
+		warnAboutDisabledHardwareAcceleration();
+
 		return {encoderName: 'libx265', hardwareAccelerated: false};
 	}
 


### PR DESCRIPTION
https://remotion.dev/docs/hardware-acceleration