### PR TITLE
@remotion/studio: ability to edit tuple-schemas

### DIFF
--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -1276,6 +1276,7 @@ export const Index: React.FC = () => {
 							{type: 'b' as const, b: {b: 'hi'}},
 						],
 						discriminatedUnion: {type: 'auto'},
+						tuple: ['foo', 42, {a: 'hi'}],
 					}}
 				/>
 				{/**

--- a/packages/example/src/SchemaTest/index.tsx
+++ b/packages/example/src/SchemaTest/index.tsx
@@ -31,6 +31,7 @@ export const schemaTestSchema = z.object({
 			value: z.number().min(1080),
 		}),
 	]),
+	tuple: z.tuple([z.string(), z.number(), z.object({a: z.string()})]),
 });
 
 export const schemaArrayTestSchema = z.array(z.number());

--- a/packages/studio/src/components/RenderModal/SchemaEditor/SchemaSeparationLine.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/SchemaSeparationLine.tsx
@@ -25,6 +25,7 @@ const arraySeparationLine: React.CSSProperties = {
 	marginTop: -VERTICAL_GUIDE_HEIGHT / 2,
 	pointerEvents: 'none',
 	width: '100%',
+	flexBasis: '100%',
 };
 
 export const SchemaArrayItemSeparationLine: React.FC<{
@@ -35,8 +36,9 @@ export const SchemaArrayItemSeparationLine: React.FC<{
 	) => void;
 	readonly index: number;
 	readonly schema: z.ZodTypeAny;
+	readonly showAddButton: boolean;
 	readonly isLast: boolean;
-}> = ({onChange, index, schema, isLast}) => {
+}> = ({onChange, index, schema, isLast, showAddButton}) => {
 	const [outerHovered, setOuterHovered] = useState(false);
 	const [innerHovered, setInnerHovered] = useState(false);
 
@@ -68,8 +70,10 @@ export const SchemaArrayItemSeparationLine: React.FC<{
 			justifyContent: 'center',
 			height: VERTICAL_GUIDE_HEIGHT,
 			opacity: outerHovered || isLast ? 1 : 0,
-			position: 'relative',
-			marginTop: -4,
+			position: 'absolute',
+			top: '50%',
+			left: '50%',
+			transform: 'translate(-50%, -50%)',
 		};
 	}, [isLast, outerHovered]);
 
@@ -98,25 +102,41 @@ export const SchemaArrayItemSeparationLine: React.FC<{
 	}, []);
 
 	return (
-		<div style={{display: 'flex', flexDirection: 'row'}}>
-			<div style={{flex: 1}}>
-				<div
-					style={dynamicAddButtonStyle}
-					onMouseEnter={onOuterMouseEnter}
-					onMouseLeave={onOuterMouseLeave}
-				>
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'row',
+				height: VERTICAL_GUIDE_HEIGHT,
+			}}
+		>
+			<div
+				style={{
+					flex: 1,
+					position: 'relative',
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'flex-end',
+				}}
+			>
+				{showAddButton && (
 					<div
-						onClick={onAdd}
-						style={inner}
-						onMouseEnter={onInnerMouseEnter}
-						onMouseLeave={onInnerMouseLeave}
+						style={dynamicAddButtonStyle}
+						onMouseEnter={onOuterMouseEnter}
+						onMouseLeave={onOuterMouseLeave}
 					>
-						<Plus
-							color={innerHovered ? 'white' : LIGHT_TEXT}
-							style={{height: VERTICAL_GUIDE_HEIGHT / 2}}
-						/>
+						<div
+							onClick={onAdd}
+							style={inner}
+							onMouseEnter={onInnerMouseEnter}
+							onMouseLeave={onInnerMouseLeave}
+						>
+							<Plus
+								color={innerHovered ? 'white' : LIGHT_TEXT}
+								style={{height: VERTICAL_GUIDE_HEIGHT / 2}}
+							/>
+						</div>
 					</div>
-				</div>
+				)}
 				<div style={arraySeparationLine} />
 			</div>
 			{isLast ? (

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodArrayEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodArrayEditor.tsx
@@ -124,6 +124,7 @@ export const ZodArrayEditor: React.FC<{
 										index={i}
 										onChange={onChange}
 										isLast={i === localValue.value.length - 1}
+										showAddButton
 									/>
 								</React.Fragment>
 							);
@@ -134,6 +135,7 @@ export const ZodArrayEditor: React.FC<{
 								index={0}
 								onChange={onChange}
 								isLast
+								showAddButton
 							/>
 						) : null}
 					</SchemaVerticalGuide>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodSwitch.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodSwitch.tsx
@@ -20,6 +20,7 @@ import {ZodOptionalEditor} from './ZodOptionalEditor';
 import {ZodStaticFileEditor} from './ZodStaticFileEditor';
 import {ZodStringEditor} from './ZodStringEditor';
 import {ZodTextareaEditor} from './ZodTextareaEditor';
+import {ZodTupleEditor} from './ZodTupleEditor';
 import {ZodUnionEditor} from './ZodUnionEditor';
 import type {JSONPath} from './zod-types';
 
@@ -415,6 +416,24 @@ export const ZodSwitch: React.FC<{
 				saving={saving}
 				saveDisabledByParent={saveDisabledByParent}
 				showSaveButton={showSaveButton}
+			/>
+		);
+	}
+
+	if (typeName === z.ZodFirstPartyTypeKind.ZodTuple) {
+		return (
+			<ZodTupleEditor
+				setValue={setValue as UpdaterFunction<unknown[]>}
+				value={value as unknown[]}
+				jsonPath={jsonPath}
+				schema={schema}
+				defaultValue={defaultValue as unknown[]}
+				onSave={onSave as UpdaterFunction<unknown[]>}
+				showSaveButton={showSaveButton}
+				onRemove={onRemove}
+				saving={saving}
+				saveDisabledByParent={saveDisabledByParent}
+				mayPad={mayPad}
 			/>
 		);
 	}

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodTupleEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodTupleEditor.tsx
@@ -1,0 +1,146 @@
+import React, {useMemo, useState} from 'react';
+import type {z} from 'zod';
+import {
+	useZodIfPossible,
+	useZodTypesIfPossible,
+} from '../../get-zod-if-possible';
+import {createZodValues} from './create-zod-values';
+import {deepEqual} from './deep-equal';
+import {Fieldset} from './Fieldset';
+import {useLocalState} from './local-state';
+import {SchemaLabel} from './SchemaLabel';
+import {SchemaArrayItemSeparationLine} from './SchemaSeparationLine';
+import {SchemaVerticalGuide} from './SchemaVerticalGuide';
+import type {JSONPath} from './zod-types';
+import {ZodFieldValidation} from './ZodFieldValidation';
+import type {UpdaterFunction} from './ZodSwitch';
+import {ZodTupleItemEditor} from './ZodTupleItemEditor';
+
+export const ZodTupleEditor: React.FC<{
+	readonly schema: z.ZodTypeAny;
+	readonly jsonPath: JSONPath;
+	readonly value: unknown[];
+	readonly defaultValue: unknown[];
+	readonly setValue: UpdaterFunction<unknown[]>;
+	readonly onSave: UpdaterFunction<unknown[]>;
+	readonly showSaveButton: boolean;
+	readonly onRemove: null | (() => void);
+	readonly saving: boolean;
+	readonly saveDisabledByParent: boolean;
+	readonly mayPad: boolean;
+}> = ({
+	schema,
+	jsonPath,
+	setValue,
+	defaultValue,
+	value,
+	onSave,
+	showSaveButton,
+	onRemove,
+	saving,
+	saveDisabledByParent,
+	mayPad,
+}) => {
+	const {localValue, onChange, RevisionContextProvider, reset} = useLocalState({
+		unsavedValue: value,
+		schema,
+		setValue,
+		savedValue: defaultValue,
+	});
+	const [expanded, setExpanded] = useState(true);
+
+	const def = schema._def as z.ZodTupleDef;
+
+	const suffix = useMemo(() => {
+		return expanded ? ' [' : ' [...] ';
+	}, [expanded]);
+	const z = useZodIfPossible();
+	if (!z) {
+		throw new Error('expected zod');
+	}
+
+	const zodTypes = useZodTypesIfPossible();
+
+	const typeName = def.typeName as z.ZodFirstPartyTypeKind;
+	if (typeName !== z.ZodFirstPartyTypeKind.ZodTuple) {
+		throw new Error('expected object');
+	}
+
+	const isDefaultValue = useMemo(() => {
+		return deepEqual(localValue.value, defaultValue);
+	}, [defaultValue, localValue]);
+
+	return (
+		<Fieldset shouldPad={mayPad} success={localValue.zodValidation.success}>
+			<div
+				style={{
+					display: 'flex',
+					flexDirection: 'row',
+				}}
+			>
+				<SchemaLabel
+					onReset={reset}
+					isDefaultValue={isDefaultValue}
+					jsonPath={jsonPath}
+					onRemove={onRemove}
+					suffix={suffix}
+					onSave={() => {
+						onSave(() => localValue.value, false, false);
+					}}
+					saveDisabledByParent={saveDisabledByParent}
+					saving={saving}
+					showSaveButton={showSaveButton}
+					valid={localValue.zodValidation.success}
+					handleClick={() => setExpanded(!expanded)}
+				/>
+			</div>
+
+			{expanded ? (
+				<RevisionContextProvider>
+					<SchemaVerticalGuide isRoot={false}>
+						{localValue.value.map((child, i) => {
+							return (
+								// eslint-disable-next-line react/no-array-index-key
+								<React.Fragment key={`${i}${localValue.keyStabilityRevision}`}>
+									<ZodTupleItemEditor
+										onChange={onChange}
+										value={child}
+										def={def}
+										index={i}
+										jsonPath={jsonPath}
+										defaultValue={
+											defaultValue?.[i] ??
+											createZodValues(def.items[i], z, zodTypes)
+										}
+										onSave={onSave}
+										showSaveButton={showSaveButton}
+										saving={saving}
+										saveDisabledByParent={saveDisabledByParent}
+										mayPad={mayPad}
+									/>
+									<SchemaArrayItemSeparationLine
+										schema={schema}
+										index={i}
+										onChange={onChange}
+										isLast={i === localValue.value.length - 1}
+										showAddButton={false}
+									/>
+								</React.Fragment>
+							);
+						})}
+						{value.length === 0 ? (
+							<SchemaArrayItemSeparationLine
+								schema={schema}
+								index={0}
+								onChange={onChange}
+								isLast
+								showAddButton={false}
+							/>
+						) : null}
+					</SchemaVerticalGuide>
+				</RevisionContextProvider>
+			) : null}
+			<ZodFieldValidation path={jsonPath} localValue={localValue} />
+		</Fieldset>
+	);
+};

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodTupleItemEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodTupleItemEditor.tsx
@@ -1,0 +1,87 @@
+import {useCallback, useMemo} from 'react';
+import {useZodIfPossible} from '../../get-zod-if-possible';
+import type {UpdaterFunction} from './ZodSwitch';
+import {ZodSwitch} from './ZodSwitch';
+import type {JSONPath} from './zod-types';
+
+export const ZodTupleItemEditor: React.FC<{
+	jsonPath: JSONPath;
+	onChange: UpdaterFunction<unknown[]>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	def: any;
+	index: number;
+	value: unknown;
+	defaultValue: unknown;
+	onSave: UpdaterFunction<unknown[]>;
+	showSaveButton: boolean;
+	saving: boolean;
+	saveDisabledByParent: boolean;
+	mayPad: boolean;
+}> = ({
+	def,
+	onChange,
+	jsonPath,
+	index,
+	value,
+	defaultValue,
+	onSave: onSaveObject,
+	showSaveButton,
+	saving,
+	saveDisabledByParent,
+	mayPad,
+}) => {
+	const z = useZodIfPossible();
+	if (!z) {
+		throw new Error('expected zod');
+	}
+
+	const setValue = useCallback(
+		(val: ((newV: unknown) => unknown) | unknown) => {
+			onChange(
+				(oldV) => [
+					...oldV.slice(0, index),
+					typeof val === 'function' ? val(oldV[index]) : val,
+					...oldV.slice(index + 1),
+				],
+				false,
+				false,
+			);
+		},
+		[index, onChange],
+	);
+
+	const newJsonPath = useMemo(() => [...jsonPath, index], [index, jsonPath]);
+
+	const onSave = useCallback(
+		(updater: (oldState: unknown) => unknown) => {
+			onSaveObject(
+				(oldV) => [
+					...oldV.slice(0, index),
+					updater(oldV[index]),
+					...oldV.slice(index + 1),
+				],
+				false,
+				false,
+			);
+		},
+		[index, onSaveObject],
+	);
+
+	return (
+		<div>
+			<ZodSwitch
+				jsonPath={newJsonPath}
+				schema={def.items[index]}
+				value={value}
+				setValue={setValue}
+				defaultValue={defaultValue}
+				onSave={onSave}
+				showSaveButton={showSaveButton}
+				onRemove={null}
+				saving={saving}
+				saveDisabledByParent={saveDisabledByParent}
+				mayPad={mayPad}
+			/>
+		</div>
+	);
+};


### PR DESCRIPTION
This PR adds the ability to edit tuple-schemas in the editor.

To achieve this, the following changes have been made:

1. The `SchemaArrayItemSeparationLine` has been refactored with a new `showAddButton` property. If set to `false`, the add-button will be omitted.
2. Analogous to the `ZodArrayEditor`, a new `ZodTupleEditor`-element has been introduced. This element uses `ZodTupleItemEditor`-elements for a tuple’s items. Following [zod’s rules on tuples](https://zod.dev/?id=tuples), the ZodTupleEditor does not allow tuples to be removed or added.
3. Lastly, the SchemaTest composition has been updated to show the ability to edit tuples.