### PR TITLE
`@remotion/bundler`: No preconnect to fonts.gstatic.com

### DIFF
--- a/packages/bundler/src/index-html.ts
+++ b/packages/bundler/src/index-html.ts
@@ -53,7 +53,6 @@ export const indexHtml = ({
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" />
 		${
 			includeFavicon
 				? `<link id="__remotion_favicon" rel="icon" type="image/png" href="${publicPath}favicon.ico" />`


### PR DESCRIPTION
This is a relict of Remotion 1.0

It leads to a console message every time in Safari

Probably it is not necessary for most cases, sometimes doing unnecessary work

It is not documented

It can also be trivially added in userland

