### PR TITLE
`remotion`: Add `isReadOnlyStudio` field to `getRemotionEnvironment()`

### DIFF
--- a/packages/core/src/get-remotion-environment.ts
+++ b/packages/core/src/get-remotion-environment.ts
@@ -2,6 +2,7 @@ export type RemotionEnvironment = {
 	isStudio: boolean;
 	isRendering: boolean;
 	isPlayer: boolean;
+	isReadOnlyStudio: boolean;
 };
 
 // Avoid VITE obfuscation
@@ -28,10 +29,13 @@ export const getRemotionEnvironment = (): RemotionEnvironment => {
 				typeof window !== 'undefined' &&
 				typeof window.remotion_puppeteerTimeout !== 'undefined'));
 	const isStudio = typeof window !== 'undefined' && window.remotion_isStudio;
+	const isReadOnlyStudio =
+		typeof window !== 'undefined' && window.remotion_isReadOnlyStudio;
 
 	return {
 		isStudio,
 		isRendering,
 		isPlayer,
+		isReadOnlyStudio,
 	};
 };

--- a/packages/docs/docs/get-remotion-environment.mdx
+++ b/packages/docs/docs/get-remotion-environment.mdx
@@ -2,7 +2,7 @@
 image: /generated/articles-docs-get-remotion-environment.png
 title: getRemotionEnvironment()
 id: get-remotion-environment
-crumb: "API"
+crumb: 'API'
 ---
 
 # getRemotionEnvironment()<AvailableFrom v="4.0.25" />
@@ -13,17 +13,18 @@ It returns an object with the following properties:
 - `isStudio`: Whether the function got called in the [Remotion Studio](/docs/cli/studio).
 - `isRendering`: Whether the function got called in a render.
 - `isPlayer`: Whether a [`<Player>`](/docs/player) is mounted on the current page.
+- `isReadOnlyStudio`: Whether in a [statically deployed studio](https://www.remotion.dev/docs/studio/deploy-static), where the [`@remotion/studio`](/docs/studio/api) APIs cannot be used (_available from v4.0.238_)
 
 This can be useful if you want components or functions to behave differently depending on the environment.
 
 ### Example
 
 ```tsx twoslash
-import React from "react";
-import { getRemotionEnvironment } from "remotion";
+import React from 'react';
+import {getRemotionEnvironment} from 'remotion';
 
 export const MyComp: React.FC = () => {
-  const { isStudio, isPlayer, isRendering } = getRemotionEnvironment();
+  const {isStudio, isPlayer, isRendering} = getRemotionEnvironment();
 
   if (isStudio) {
     return <div>I'm in the Studio!</div>;

--- a/packages/template-code-hike/src/ReloadOnCodeChange.tsx
+++ b/packages/template-code-hike/src/ReloadOnCodeChange.tsx
@@ -2,6 +2,7 @@ import { getStaticFiles, reevaluateComposition } from "@remotion/studio";
 import { useState } from "react";
 import React, { useEffect } from "react";
 import { watchPublicFolder } from "@remotion/studio";
+import { getRemotionEnvironment } from "remotion";
 
 const getCurrentHash = () => {
   const files = getStaticFiles();
@@ -14,6 +15,10 @@ export const RefreshOnCodeChange: React.FC = () => {
   const [files, setFiles] = useState(getCurrentHash());
 
   useEffect(() => {
+    if (getRemotionEnvironment().isReadOnlyStudio) {
+      return;
+    }
+
     const { cancel } = watchPublicFolder(() => {
       const hash = getCurrentHash();
       if (hash !== files) {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
