### PR TITLE
`remotion`: OffthreadVideo – Don't pass through `delayRenderTimeoutInMilliseconds` and `delayRenderRetries` to DOM 

### DIFF
--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -75,7 +75,9 @@ export const OffthreadVideo: React.FC<OffthreadVideoProps> = (props) => {
 		onAutoPlayError,
 		onVideoFrame,
 		crossOrigin,
-		...withoutTransparent
+		delayRenderRetries,
+		delayRenderTimeoutInMilliseconds,
+		...propsForPreview
 	} = otherProps;
 
 	return (
@@ -90,7 +92,7 @@ export const OffthreadVideo: React.FC<OffthreadVideoProps> = (props) => {
 			onAutoPlayError={onAutoPlayError ?? undefined}
 			onVideoFrame={onVideoFrame ?? null}
 			crossOrigin={crossOrigin}
-			{...withoutTransparent}
+			{...propsForPreview}
 		/>
 	);
 };

--- a/packages/example-without-zod/src/MyComposition.tsx
+++ b/packages/example-without-zod/src/MyComposition.tsx
@@ -1,3 +1,10 @@
+import {OffthreadVideo} from 'remotion';
+
 export const MyComposition = () => {
-	return null;
+	return (
+		<OffthreadVideo
+			src="https://www.w3schools.com/html"
+			delayRenderRetries={2}
+		/>
+	);
 };


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
