### PR TITLE
`@remotion/lambda`: Validate concurrency only in launch function if no `rendererFunctionName` is passed

### DIFF
--- a/packages/lambda/src/functions/launch.ts
+++ b/packages/lambda/src/functions/launch.ts
@@ -154,7 +154,8 @@ const innerLaunchHandler = async <Provider extends CloudProvider>({
 	RenderInternals.validateConcurrency({
 		value: params.concurrencyPerLambda,
 		setting: 'concurrencyPerLambda',
-		checkIfValidForCurrentMachine: true,
+		checkIfValidForCurrentMachine:
+			(params.rendererFunctionName ?? null) === null,
 	});
 
 	const realFrameRange = RenderInternals.getRealFrameRange(


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
