### PR TITLE
Tests: Fix Windows shakiness

### DIFF
--- a/packages/example/src/StaticServer/index.tsx
+++ b/packages/example/src/StaticServer/index.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
-import {continueRender, delayRender, Img, staticFile} from 'remotion';
+import React from 'react';
+import {Img, staticFile} from 'remotion';
 
 export const StaticDemo: React.FC<{
 	readonly flag: boolean;
@@ -8,19 +8,10 @@ export const StaticDemo: React.FC<{
 		throw new Error('`flag` must be true (this only works during rendering)');
 	}
 
-	const [handle1] = useState(() => delayRender('handle1'));
-	const [handle2] = useState(() => delayRender('handle2'));
-
 	return (
 		<>
-			<Img
-				src={staticFile('nested/logö.png')}
-				onLoad={() => continueRender(handle1)}
-			/>
-			<Img
-				src={staticFile('/nested/mp4.png')}
-				onLoad={() => continueRender(handle2)}
-			/>
+			<Img src={staticFile('nested/logö.png')} />
+			<Img src={staticFile('/nested/mp4.png')} />
 		</>
 	);
 };


### PR DESCRIPTION
In our tests, we check if img onload is working.
However, this is completely a browser behavior for which's weirdness we cannot take responsibility for.
It should not lead to a test failure