### PR TITLE
More flexible upgrading experience

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,7 +40,7 @@ import {render} from './render';
 import {shouldUseNonOverlayingLogger} from './should-use-non-overlaying-logger';
 import {still} from './still';
 import {studioCommand} from './studio';
-import {upgrade} from './upgrade';
+import {upgradeCommand} from './upgrade';
 import {
 	VERSIONS_COMMAND,
 	validateVersionsBeforeCommand,
@@ -111,12 +111,13 @@ export const cli = async () => {
 		} else if (command === 'ffprobe') {
 			ffprobeCommand(process.argv.slice(3), logLevel);
 		} else if (command === 'upgrade') {
-			await upgrade(
+			await upgradeCommand({
 				remotionRoot,
-				parsedCli['package-manager'],
-				parsedCli.version,
+				packageManager: parsedCli['package-manager'],
+				version: parsedCli.version,
 				logLevel,
-			);
+				args,
+			});
 		} else if (command === VERSIONS_COMMAND) {
 			await versionsCommand(remotionRoot, logLevel);
 		} else if (command === BROWSER_COMMAND) {

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -1,15 +1,23 @@
 import {RenderInternals, type LogLevel} from '@remotion/renderer';
 import {StudioServerInternals} from '@remotion/studio-server';
 import {spawn} from 'node:child_process';
+import {chalk} from './chalk';
 import {listOfRemotionPackages} from './list-of-remotion-packages';
 import {Log} from './log';
 
-export const upgrade = async (
-	remotionRoot: string,
-	packageManager: string | undefined,
-	version: string | undefined,
-	logLevel: LogLevel,
-) => {
+export const upgradeCommand = async ({
+	remotionRoot,
+	packageManager,
+	version,
+	logLevel,
+	args,
+}: {
+	remotionRoot: string;
+	packageManager: string | undefined;
+	version: string | undefined;
+	logLevel: LogLevel;
+	args: string[];
+}) => {
 	const {
 		dependencies,
 		devDependencies,
@@ -55,27 +63,38 @@ export const upgrade = async (
 			peerDependencies.includes(u),
 	);
 
-	const task = spawn(
-		manager.manager,
-		StudioServerInternals.getInstallCommand({
-			manager: manager.manager,
-			packages: toUpgrade,
-			version: targetVersion,
-		}),
-		{
-			env: {
-				...process.env,
-				ADBLOCK: '1',
-				DISABLE_OPENCOLLECTIVE: '1',
-			},
-			stdio: RenderInternals.isEqualOrBelowLogLevel(logLevel, 'info')
-				? 'inherit'
-				: 'ignore',
+	const command = StudioServerInternals.getInstallCommand({
+		manager: manager.manager,
+		packages: toUpgrade,
+		version: targetVersion,
+		additionalArgs: args,
+	});
+
+	Log.info({indent: false, logLevel}, chalk.gray(`$ ${command.join(' ')}`));
+
+	const task = spawn(manager.manager, command, {
+		env: {
+			...process.env,
+			ADBLOCK: '1',
+			DISABLE_OPENCOLLECTIVE: '1',
 		},
-	);
+		stdio: RenderInternals.isEqualOrBelowLogLevel(logLevel, 'info')
+			? 'inherit'
+			: 'ignore',
+	});
 
 	await new Promise<void>((resolve) => {
-		task.on('close', resolve);
+		task.on('close', (code) => {
+			if (code === 0) {
+				resolve();
+			} else if (RenderInternals.isEqualOrBelowLogLevel(logLevel, 'info')) {
+				throw new Error('Failed to upgrade Remotion, see logs above');
+			} else {
+				throw new Error(
+					'Failed to upgrade Remotion, run with --log=info info to see logs',
+				);
+			}
+		});
 	});
 
 	Log.info({indent: false, logLevel}, '⏫ Remotion has been upgraded!');

--- a/packages/docs/babel.config.js
+++ b/packages/docs/babel.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  presets: [require.resolve("@docusaurus/core/lib/babel/preset")],
-  plugins: ["@babel/plugin-transform-modules-commonjs"],
-};

--- a/packages/docs/docs/cli/upgrade.mdx
+++ b/packages/docs/docs/cli/upgrade.mdx
@@ -29,6 +29,11 @@ Install a specific version. Also enables downgrading to an older version.
 
 `npm`, `yarn` and `pnpm` are all supported.
 
+## Additional arguments
+
+Any additional arguments you pass to this command will be forwarded as flags to the package manager, before the list of packages.  
+Before v4.0.246, additional arguments were ignored.
+
 ## Difference to `npm update`, `yarn upgrade`, `pnpm up`
 
 These commands, when executed without arguments will upgrade all dependencies in your project. We recommend against it because you may unintentionally break other parts of your project when you only wanted to upgrade Remotion.

--- a/packages/docs/docs/upgrading.mdx
+++ b/packages/docs/docs/upgrading.mdx
@@ -1,11 +1,12 @@
 ---
 image: /generated/articles-docs-upgrading.png
 title: Upgrading Remotion
-crumb: "upgrade remotion"
+crumb: 'upgrade remotion'
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import {VERSION} from 'remotion/version';
 
 The easiest way to do this is to run the following command in the root of your project:
 
@@ -57,10 +58,58 @@ You need the `@remotion/cli` package installed for this.
 
 ## Manually upgrading Remotion
 
-To upgrade Remotion to the latest version, all `@remotion/*` packages and `remotion` must be updated to the same version.
+<Step>1</Step> Edit the version number of all `@remotion/*` packages and
+`remotion` in your `package.json` for all packages. The current version is {
+  VERSION
+}
+.
 
-Edit the version number in your `package.json` for all packages.
-Delete the `^` in front of the version number in your `package.json` in order to force the exact version you specified.
+<Step>2</Step> Delete the `^` in front of the version number in your
+`package.json` in order to force the exact version you specified.{' '}
+
+<Step>3</Step> Run the install command of your package manager:{' '}
+
+<Tabs
+defaultValue="npm"
+values={[
+{ label: 'npm', value: 'npm', },
+{ label: 'pnpm', value: 'pnpm', },
+{ label: 'yarn', value: 'yarn', },
+{ label: 'bun', value: 'bun', },
+]
+}>
+<TabItem value="npm">
+
+```bash
+npm i
+```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+```bash
+pnpm i
+```
+
+  </TabItem>
+
+  <TabItem value="yarn">
+
+```bash
+yarn
+```
+
+  </TabItem>
+
+  <TabItem value="bun">
+
+```bash
+bun i
+```
+
+  </TabItem>
+</Tabs>
 
 ## Breaking changes
 

--- a/packages/studio-server/src/helpers/get-installed-dependencies.ts
+++ b/packages/studio-server/src/helpers/get-installed-dependencies.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 export const getInstalledDependencies = (remotionRoot: string) => {
 	const packageJsonFilePath = path.join(remotionRoot, 'package.json');
 	const packageJson = JSON.parse(fs.readFileSync(packageJsonFilePath, 'utf-8'));
-	const dependencies = Object.keys(packageJson.dependencies);
+	const dependencies = Object.keys(packageJson.dependencies ?? {});
 	const devDependencies = Object.keys(packageJson.devDependencies ?? {});
 	const optionalDependencies = Object.keys(
 		packageJson.optionalDependencies ?? {},

--- a/packages/studio-server/src/helpers/install-command.ts
+++ b/packages/studio-server/src/helpers/install-command.ts
@@ -1,0 +1,31 @@
+import type {PackageManager} from '@remotion/studio-shared';
+
+export const getInstallCommand = ({
+	manager,
+	packages,
+	version,
+	additionalArgs,
+}: {
+	manager: PackageManager;
+	packages: string[];
+	version: string;
+	additionalArgs: string[];
+}): string[] => {
+	const pkgList = packages.map((p) => `${p}@${version}`);
+
+	const commands: {[key in PackageManager]: string[]} = {
+		npm: [
+			'i',
+			'--save-exact',
+			'--no-fund',
+			'--no-audit',
+			...additionalArgs,
+			...pkgList,
+		],
+		pnpm: ['i', ...additionalArgs, ...pkgList],
+		yarn: ['add', '--exact', ...additionalArgs, ...pkgList],
+		bun: ['i', ...additionalArgs, ...pkgList],
+	};
+
+	return commands[manager];
+};

--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -29,6 +29,7 @@ import {parseAndApplyCodemod} from './codemods/duplicate-composition';
 import {installFileWatcher} from './file-watcher';
 import {getLatestRemotionVersion} from './get-latest-remotion-version';
 import {getInstalledDependencies} from './helpers/get-installed-dependencies';
+import {getInstallCommand} from './helpers/install-command';
 import {
 	getMaxTimelineTracks,
 	setMaxTimelineTracks,
@@ -38,7 +39,6 @@ import {
 	lockFilePaths,
 } from './preview-server/get-package-manager';
 import {waitForLiveEventsListener} from './preview-server/live-events';
-import {getInstallCommand} from './preview-server/routes/install-dependency';
 import {getRemotionVersion} from './preview-server/update-available';
 import {startStudio} from './start-studio';
 

--- a/packages/studio-server/src/preview-server/routes/install-dependency.ts
+++ b/packages/studio-server/src/preview-server/routes/install-dependency.ts
@@ -3,33 +3,12 @@ import {
 	listOfInstallableRemotionPackages,
 	type InstallPackageRequest,
 	type InstallPackageResponse,
-	type PackageManager,
 } from '@remotion/studio-shared';
 import {spawn} from 'node:child_process';
 import {VERSION} from 'remotion/version';
+import {getInstallCommand} from '../../helpers/install-command';
 import type {ApiHandler} from '../api-types';
 import {getPackageManager, lockFilePaths} from '../get-package-manager';
-
-export const getInstallCommand = ({
-	manager,
-	packages,
-	version,
-}: {
-	manager: PackageManager;
-	packages: string[];
-	version: string;
-}): string[] => {
-	const pkgList = packages.map((p) => `${p}@${version}`);
-
-	const commands: {[key in PackageManager]: string[]} = {
-		npm: ['i', '--save-exact', '--no-fund', '--no-audit', ...pkgList],
-		pnpm: ['i', ...pkgList],
-		yarn: ['add', '--exact', ...pkgList],
-		bun: ['i', ...pkgList],
-	};
-
-	return commands[manager];
-};
 
 export const handleInstallPackage: ApiHandler<
 	InstallPackageRequest,
@@ -56,6 +35,7 @@ export const handleInstallPackage: ApiHandler<
 		manager: manager.manager,
 		packages: packageNames,
 		version: VERSION,
+		additionalArgs: [],
 	});
 
 	RenderInternals.Log.info(


### PR DESCRIPTION
- Don't fail if package.json has no `dependencies` field
- Pass any additional arguments of `npx remotion upgrade` to the package manger.
- Improve the documentation of how to upgrade Remotion manually