### PR TITLE
Docs: Prefer `slowDurationInSeconds` in `calculateMetadata()`

### DIFF
--- a/packages/docs/docs/dynamic-metadata.mdx
+++ b/packages/docs/docs/dynamic-metadata.mdx
@@ -40,16 +40,13 @@ export const Root: React.FC = () => {
         src: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
       }}
       calculateMetadata={async ({props}) => {
-        const {durationInSeconds} = await parseMedia({
+        const {slowDurationInSeconds} = await parseMedia({
           src: props.src,
-          fields: {durationInSeconds: true},
+          fields: {slowDurationInSeconds: true},
         });
-        if (durationInSeconds === null) {
-          throw new Error('Could not read duration of video');
-        }
 
         return {
-          durationInFrames: Math.floor(durationInSeconds * 30),
+          durationInFrames: Math.floor(slowDurationInSeconds * 30),
         };
       }}
     />
@@ -85,15 +82,11 @@ export const Index: React.FC = () => {
     parseMedia({
       src: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
       fields: {
-        durationInSeconds: true,
+        slowDurationInSeconds: true,
       },
     })
-      .then(({durationInSeconds}) => {
-        if (durationInSeconds === null) {
-          throw new Error('Could not read duration of video');
-        }
-
-        setDuration(Math.round(durationInSeconds * 30));
+      .then(({slowDurationInSeconds}) => {
+        setDuration(Math.round(slowDurationInSeconds * 30));
         continueRender(handle);
       })
       .catch((err) => {
@@ -163,15 +156,11 @@ export const Index: React.FC = () => {
     parseMedia({
       src: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
       fields: {
-        durationInSeconds: true,
+        slowDurationInSeconds: true,
       },
     })
-      .then(({durationInSeconds}) => {
-        if (durationInSeconds === null) {
-          throw new Error('Could not read duration of video');
-        }
-
-        setDuration(Math.round(durationInSeconds * 30));
+      .then(({slowDurationInSeconds}) => {
+        setDuration(Math.round(slowDurationInSeconds * 30));
       })
       .catch((err) => {
         console.log(`Error fetching metadata: ${err}`);

--- a/packages/docs/docs/miscellaneous/snippets/align-duration.mdx
+++ b/packages/docs/docs/miscellaneous/snippets/align-duration.mdx
@@ -47,22 +47,18 @@ import {parseMedia} from '@remotion/media-parser';
 export const calculateMetadata: CalculateMetadataFunction<
   MyCompProps
 > = async ({props}) => {
-  const {durationInSeconds, dimensions} = await parseMedia({
+  const {slowDurationInSeconds, dimensions} = await parseMedia({
     src: props.src,
     fields: {
-      durationInSeconds: true,
+      slowDurationInSeconds: true,
       dimensions: true,
     },
   });
 
-  if (durationInSeconds === null) {
-    throw new Error('Could not get video duration');
-  }
-
   const fps = 30;
 
   return {
-    durationInFrames: Math.floor(durationInSeconds * fps),
+    durationInFrames: Math.floor(slowDurationInSeconds * fps),
     fps,
     width: dimensions.width,
     height: dimensions.height,

--- a/packages/docs/docs/videos/sequence.mdx
+++ b/packages/docs/docs/videos/sequence.mdx
@@ -87,19 +87,15 @@ export const calculateMetadata: CalculateMetadataFunction<Props> = async ({
   const fps = 30;
   const videos = await Promise.all([
     ...props.videos.map(async (video): Promise<VideoToEmbed> => {
-      const {durationInSeconds} = await parseMedia({
+      const {slowDurationInSeconds} = await parseMedia({
         src: video.src,
         fields: {
-          durationInSeconds: true,
+          slowDurationInSeconds: true,
         },
       });
 
-      if (durationInSeconds === null) {
-        throw new Error(`Could not get video duration of ${durationInSeconds}`);
-      }
-
       return {
-        durationInFrames: Math.floor(durationInSeconds * fps),
+        durationInFrames: Math.floor(slowDurationInSeconds * fps),
         src: video.src,
       };
     }),
@@ -149,19 +145,15 @@ export const calculateMetadata: CalculateMetadataFunction<Props> = async ({
   const fps = 30;
   const videos = await Promise.all([
     ...props.videos.map(async (video): Promise<VideoToEmbed> => {
-      const {durationInSeconds} = await parseMedia({
+      const {slowDurationInSeconds} = await parseMedia({
         src: video.src,
         fields: {
-          durationInSeconds: true,
+          slowDurationInSeconds: true,
         },
       });
 
-      if (durationInSeconds === null) {
-        throw new Error(`Could not get video duration of ${durationInSeconds}`);
-      }
-
       return {
-        durationInFrames: Math.floor(durationInSeconds * fps),
+        durationInFrames: Math.floor(slowDurationInSeconds * fps),
         src: video.src,
       };
     }),


### PR DESCRIPTION
Makes more sense since you **need** a duration