### PR TITLE
`remotion`: Handle animated AVIF in Firefox better

### DIFF
--- a/packages/core/src/animated-image/decode-image.ts
+++ b/packages/core/src/animated-image/decode-image.ts
@@ -145,7 +145,8 @@ export const decodeImage = async ({
 			}
 
 			if (!f.frame.duration) {
-				throw new Error('Frame has no duration');
+				// non-animated, or AVIF in firefox
+				break;
 			}
 
 			if (i === selectedTrack.frameCount && durationFound === null) {


### PR DESCRIPTION
In `<AnimatedImage>` component