### PR TITLE
`@remotion/renderer`: Add `--disable-vulkan-surface`

### DIFF
--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -73,6 +73,7 @@ const getOpenGlRenderer = (option?: OpenGlRenderer | null): string[] => {
 			'--use-angle=vulkan',
 			'--use-vulkan=native',
 			'--disable-vulkan-fallback-to-gl-for-testing',
+			'--disable-vulkan-surface',
 			'--ignore-gpu-blocklist',
 			'--enable-gpu',
 		];


### PR DESCRIPTION
Although this makes it slower with `--gl=vulkan`, we have not yet found a Vulkan accelerated use case.

Without this flag, Chrome tries to initialize the GPU, making startup slower and throwing errors