### PR TITLE
`@remotion/renderer`: Ignore `startTime` from MP3 files

### DIFF
--- a/packages/renderer/src/assets/get-audio-channels.ts
+++ b/packages/renderer/src/assets/get-audio-channels.ts
@@ -25,7 +25,10 @@ export const getAudioChannelsAndDurationWithoutCache = async ({
 	const args = [
 		['-v', 'error'],
 		['-select_streams', 'a:0'],
-		['-show_entries', 'stream=channels:stream=start_time:format=duration'],
+		[
+			'-show_entries',
+			'stream=channels:stream=start_time:format=duration:format=format_name',
+		],
 		['-of', 'default=nw=1'],
 		[src],
 	]
@@ -44,11 +47,16 @@ export const getAudioChannelsAndDurationWithoutCache = async ({
 		const channels = task.stdout.match(/channels=([0-9]+)/);
 		const duration = task.stdout.match(/duration=([0-9.]+)/);
 		const startTime = task.stdout.match(/start_time=([0-9.]+)/);
+		const container = task.stdout.match(/format_name=([a-zA-Z0-9.]+)/);
+
+		const isMP3 = container ? container[1] === 'mp3' : false;
 
 		const result: AudioChannelsAndDurationResultCache = {
 			channels: channels ? parseInt(channels[1], 10) : 0,
 			duration: duration ? parseFloat(duration[1]) : null,
-			startTime: startTime ? parseFloat(startTime[1]) : null,
+			// We ignore the start time for MP3 because that is an inherent encoder thing
+			// not in the sense that we want
+			startTime: startTime ? (isMP3 ? 0 : parseFloat(startTime[1])) : null,
 		};
 		return result;
 	} catch (err) {

--- a/packages/renderer/src/create-ffmpeg-complex-filter.ts
+++ b/packages/renderer/src/create-ffmpeg-complex-filter.ts
@@ -12,9 +12,14 @@ export const createFfmpegComplexFilter = async ({
 }): Promise<{
 	complexFilterFlag: [string, string] | null;
 	cleanup: () => void;
+	complexFilter: string | null;
 }> => {
 	if (filters.length === 0) {
-		return {complexFilterFlag: null, cleanup: () => undefined};
+		return {
+			complexFilterFlag: null,
+			cleanup: () => undefined,
+			complexFilter: null,
+		};
 	}
 
 	const complexFilter = createFfmpegMergeFilter({
@@ -29,5 +34,6 @@ export const createFfmpegComplexFilter = async ({
 	return {
 		complexFilterFlag: ['-filter_complex_script', file],
 		cleanup,
+		complexFilter,
 	};
 };

--- a/packages/renderer/src/merge-audio-track.ts
+++ b/packages/renderer/src/merge-audio-track.ts
@@ -7,6 +7,7 @@ import {OUTPUT_FILTER_NAME} from './create-ffmpeg-merge-filter';
 import {createSilentAudio} from './create-silent-audio';
 import {deleteDirectory} from './delete-directory';
 import type {LogLevel} from './log-level';
+import {Log} from './logger';
 import type {CancelSignal} from './make-cancel-signal';
 import {pLimit} from './p-limit';
 import {parseFfmpegProgress} from './parse-ffmpeg-progress';
@@ -124,11 +125,14 @@ const mergeAudioTrackUnlimited = async ({
 		}
 	}
 
-	const {complexFilterFlag: mergeFilter, cleanup} =
-		await createFfmpegComplexFilter({
-			filters: files,
-			downloadMap,
-		});
+	const {
+		complexFilterFlag: mergeFilter,
+		cleanup,
+		complexFilter,
+	} = await createFfmpegComplexFilter({
+		filters: files,
+		downloadMap,
+	});
 
 	const args = [
 		['-hide_banner'],
@@ -140,6 +144,15 @@ const mergeAudioTrackUnlimited = async ({
 	]
 		.filter(truthy)
 		.flat(2);
+
+	Log.verbose(
+		{indent, logLevel},
+		`Merging audio tracks`,
+		'Command:',
+		`ffmpeg ${args.join(' ')}`,
+		'Complex filter script:',
+		complexFilter,
+	);
 
 	const task = callFf({
 		bin: 'ffmpeg',

--- a/packages/renderer/src/test/get-audio-channels.test.ts
+++ b/packages/renderer/src/test/get-audio-channels.test.ts
@@ -53,7 +53,7 @@ test('Get audio channels for video without music', async () => {
 	expect(channels.duration).toBeCloseTo(3.334, 2);
 }, 90000);
 
-test('Get audio channels for video with music', async () => {
+test('Get audio channels for mp3', async () => {
 	const downloadMap = makeDownloadMap();
 	const audio = path.join(
 		__dirname,
@@ -79,7 +79,7 @@ test('Get audio channels for video with music', async () => {
 	expect(channels).toEqual({
 		channels: 2,
 		duration: 56.52898,
-		startTime: 0.011995,
+		startTime: 0,
 	});
 }, 90000);
 


### PR DESCRIPTION
MP3 files don't have metadata to shift the start, but FFprobe reports that.

Ignore it if it comes from FFprobe.