### PR TITLE
`@remotion/lambda`: Use renderer function to calculate price of render

### DIFF
--- a/packages/lambda/src/functions/aws-implementation.ts
+++ b/packages/lambda/src/functions/aws-implementation.ts
@@ -31,6 +31,7 @@ import {getCurrentRegionInFunctionImplementation} from './helpers/get-current-re
 import {getFolderFiles} from './helpers/get-folder-files';
 import {getOutputUrlFromMetadata} from './helpers/get-output-url-from-metadata';
 import {makeAwsArtifact} from './helpers/make-aws-artifact';
+import {parseFunctionName} from './helpers/parse-function-name';
 
 if (
 	/^AWS_Lambda_nodejs(?:18|20)[.]x$/.test(
@@ -135,4 +136,5 @@ export const awsImplementation: ProviderSpecifics<AwsProvider> = {
 	getAccountId: getAccountIdImplementation,
 	deleteFunction,
 	getFunctions,
+	parseFunctionName,
 };

--- a/packages/lambda/src/test/mock-implementation.ts
+++ b/packages/lambda/src/test/mock-implementation.ts
@@ -10,6 +10,7 @@ import {estimatePrice} from '../api/estimate-price';
 import {speculateFunctionName} from '../api/speculate-function-name';
 import {MAX_EPHEMERAL_STORAGE_IN_MB} from '../defaults';
 import type {AwsProvider} from '../functions/aws-implementation';
+import {parseFunctionName} from '../functions/helpers/parse-function-name';
 import {convertToServeUrlImplementation} from '../shared/convert-to-serve-url';
 import {
 	getCloudwatchMethodUrl,
@@ -177,6 +178,7 @@ export const mockImplementation: ProviderSpecifics<AwsProvider> = {
 	isFlakyError,
 	deleteFunction: deleteMockFunction,
 	getFunctions: getAllMockFunctions,
+	parseFunctionName,
 };
 
 export const mockServerImplementation: InsideFunctionSpecifics = {

--- a/packages/lambda/src/test/unit/price-calculation.test.ts
+++ b/packages/lambda/src/test/unit/price-calculation.test.ts
@@ -39,6 +39,7 @@ test('Should not throw while calculating prices when time shifts occur', () => {
 			muted: false,
 			metadata: {Author: 'Lunar'},
 			functionName: 'remotion-render-la8ffw',
+			rendererFunctionName: 'remotion-render-la8ffw',
 			dimensions: {
 				height: 1080,
 				width: 1920,

--- a/packages/renderer/src/test/get-audio-channels.test.ts
+++ b/packages/renderer/src/test/get-audio-channels.test.ts
@@ -53,7 +53,7 @@ test('Get audio channels for video without music', async () => {
 	expect(channels.duration).toBeCloseTo(3.334, 2);
 }, 90000);
 
-test('Get audio channels for video with music', async () => {
+test('Get audio channels for mp3', async () => {
 	const downloadMap = makeDownloadMap();
 	const audio = path.join(
 		__dirname,
@@ -79,7 +79,7 @@ test('Get audio channels for video with music', async () => {
 	expect(channels).toEqual({
 		channels: 2,
 		duration: 56.52898,
-		startTime: 0.011995,
+		startTime: 0,
 	});
 }, 90000);
 

--- a/packages/serverless/src/create-post-render-data.ts
+++ b/packages/serverless/src/create-post-render-data.ts
@@ -44,7 +44,9 @@ export const createPostRenderData = <Provider extends CloudProvider>({
 
 	const cost = providerSpecifics.estimatePrice({
 		durationInMilliseconds: estimatedBillingDurationInMilliseconds,
-		memorySizeInMb,
+		memorySizeInMb:
+			providerSpecifics.parseFunctionName(renderMetadata.rendererFunctionName)
+				?.memorySizeInMb ?? memorySizeInMb,
 		region,
 		lambdasInvoked: renderMetadata.estimatedTotalLambdaInvokations,
 		diskSizeInMb: providerSpecifics.getEphemeralStorageForPriceCalculation(),

--- a/packages/serverless/src/handlers/launch.ts
+++ b/packages/serverless/src/handlers/launch.ts
@@ -50,7 +50,6 @@ type Options = {
 };
 
 const innerLaunchHandler = async <Provider extends CloudProvider>({
-	functionName,
 	params,
 	options,
 	overallProgress,
@@ -58,7 +57,6 @@ const innerLaunchHandler = async <Provider extends CloudProvider>({
 	providerSpecifics,
 	insideFunctionSpecifics,
 }: {
-	functionName: string;
 	params: ServerlessPayload<Provider>;
 	options: Options;
 	overallProgress: OverallProgressHelper<Provider>;
@@ -289,6 +287,10 @@ const innerLaunchHandler = async <Provider extends CloudProvider>({
 		chunks.map((c, i) => `Chunk ${i} (Frames ${c[0]} - ${c[1]})`).join(', '),
 	);
 
+	const rendererFunctionName =
+		params.rendererFunctionName ??
+		insideFunctionSpecifics.getCurrentFunctionName();
+
 	const renderMetadata: RenderMetadata<Provider> = {
 		startedDate,
 		totalChunks: chunks.length,
@@ -326,6 +328,9 @@ const innerLaunchHandler = async <Provider extends CloudProvider>({
 			width: comp.width * (params.scale ?? 1),
 			height: comp.height * (params.scale ?? 1),
 		},
+		rendererFunctionName:
+			params.rendererFunctionName ??
+			insideFunctionSpecifics.getCurrentFunctionName(),
 	};
 
 	const {key, renderBucketName, customCredentials} = getExpectedOutName(
@@ -444,7 +449,7 @@ const innerLaunchHandler = async <Provider extends CloudProvider>({
 		lambdaPayloads.map(async (payload) => {
 			await streamRendererFunctionWithRetry({
 				files,
-				functionName,
+				functionName: rendererFunctionName,
 				outdir,
 				overallProgress,
 				payload,
@@ -511,10 +516,6 @@ export const launchHandler = async <Provider extends CloudProvider>({
 	if (params.type !== ServerlessRoutines.launch) {
 		throw new Error('Expected launch type');
 	}
-
-	const functionName =
-		params.rendererFunctionName ??
-		insideFunctionSpecifics.getCurrentFunctionName();
 
 	const logOptions: LogOptions = {
 		indent: false,
@@ -669,7 +670,6 @@ export const launchHandler = async <Provider extends CloudProvider>({
 
 	try {
 		const postRenderData = await innerLaunchHandler({
-			functionName,
 			params,
 			options,
 			overallProgress,

--- a/packages/serverless/src/handlers/still.ts
+++ b/packages/serverless/src/handlers/still.ts
@@ -189,6 +189,7 @@ const innerStillHandler = async <Provider extends CloudProvider>(
 		audioBitrate: null,
 		metadata: null,
 		functionName: insideFunctionSpecifics.getCurrentFunctionName(),
+		rendererFunctionName: insideFunctionSpecifics.getCurrentFunctionName(),
 		dimensions: {
 			height: composition.height * (params.scale ?? 1),
 			width: composition.width * (params.scale ?? 1),

--- a/packages/serverless/src/progress.ts
+++ b/packages/serverless/src/progress.ts
@@ -199,7 +199,9 @@ export const getProgress = async <Provider extends CloudProvider>({
 
 	const priceFromBucket = estimatePriceFromMetadata({
 		renderMetadata,
-		memorySizeInMb,
+		memorySizeInMb:
+			providerSpecifics.parseFunctionName(renderMetadata.rendererFunctionName)
+				?.memorySizeInMb ?? memorySizeInMb,
 		functionsInvoked: renderMetadata.estimatedRenderLambdaInvokations ?? 0,
 		diskSizeInMb: providerSpecifics.getEphemeralStorageForPriceCalculation(),
 		timings: overallProgress.timings ?? [],

--- a/packages/serverless/src/provider-implementation.ts
+++ b/packages/serverless/src/provider-implementation.ts
@@ -313,6 +313,13 @@ export type CreateFunction<Provider extends CloudProvider> = (
 	options: CreateFunctionOptions<Provider>,
 ) => Promise<{FunctionName: string}>;
 
+export type ParseFunctionName = (functionName: string) => {
+	version: string;
+	memorySizeInMb: number;
+	diskSizeInMb: number;
+	timeoutInSeconds: number;
+} | null;
+
 export type InsideFunctionSpecifics = {
 	getBrowserInstance: GetBrowserInstance;
 	forgetBrowserEventLoop: ForgetBrowserEventLoop;
@@ -365,4 +372,5 @@ export type ProviderSpecifics<Provider extends CloudProvider> = {
 	getAccountId: GetAccountId<Provider>;
 	deleteFunction: DeleteFunction<Provider>;
 	getFunctions: GetFunctions<Provider>;
+	parseFunctionName: ParseFunctionName;
 };

--- a/packages/serverless/src/render-metadata.ts
+++ b/packages/serverless/src/render-metadata.ts
@@ -45,6 +45,7 @@ export type RenderMetadata<Provider extends CloudProvider> = Discriminated & {
 	framesPerLambda: number;
 	memorySizeInMb: number;
 	functionName: string;
+	rendererFunctionName: string;
 	lambdaVersion: string;
 	region: Provider['region'];
 	renderId: string;

--- a/packages/serverless/src/test/expected-out-name.test.ts
+++ b/packages/serverless/src/test/expected-out-name.test.ts
@@ -28,6 +28,7 @@ const testRenderMetadata: RenderMetadata<MockProvider> = {
 	lambdaVersion: '2022-02-14',
 	memorySizeInMb: 2048,
 	functionName: 'remotion-render-4-0-187-mem3000mb-disk10000mb-120sec',
+	rendererFunctionName: 'remotion-render-4-0-187-mem3000mb-disk10000mb-120sec',
 	outName: undefined,
 	region: 'eu-central',
 	renderId: '9n8dsfafs',


### PR DESCRIPTION
Instead of current function name