### PR TITLE
`@remotion/media-parser`: `sampleRate` and `numberOfAudioChannels` fields

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           pnpm build
       - name: Test Lambda IT
+        timeout-minutes: 12
         run: |
           pnpm run testlambda
   ssr-tests:

--- a/packages/docs/docs/media-parser/fast-and-slow.mdx
+++ b/packages/docs/docs/media-parser/fast-and-slow.mdx
@@ -48,6 +48,8 @@ The following [`fields`](/docs/media-parser#fields) require only the metadata se
 - [`rotation`](/docs/media-parser/parse-media#rotation)
 - [`location`](/docs/media-parser/parse-media#location)
 - [`keyframes`](/docs/media-parser/parse-media#keyframes)
+- [`sampleRate`](/docs/media-parser/parse-media#sampleRate)
+- [`numberOfAudioChannels`](/docs/media-parser/parse-media#numberofaudiochannels)
 
 Also, if an [`onVideoTrack`](/docs/media-parser/parse-media#onvideotrack) or [`onAudioTrack`](/docs/media-parser/parse-media#onvideotrack) handler is passed, only the parsing of the metadata section is required if `null` is returned from the handler function.
 

--- a/packages/docs/docs/media-parser/parse-media.mdx
+++ b/packages/docs/docs/media-parser/parse-media.mdx
@@ -63,164 +63,9 @@ If you pass a `File` object, you must also pass [`webFileReader`](/docs/media-pa
 ### `fields?`
 
 An object specifying which fields you'd like to receive.  
-If you like to receive the field, pass `true` as the value.  
-Possible fields are:
+If you like to receive the field, pass `true` as the value.
 
-#### `dimensions`
-
-_`{width: number, height: number} | null`_
-
-The dimensions of the video.  
-Any rotation is already applied - the dimensions are like a media player would show them.  
-Use `unrotatedDimensions` to get the dimensions before rotation.
-
-If the media passed is an audio file, this will return `null`.
-
-#### `durationInSeconds`
-
-_number | null_
-
-The duration of the video in seconds.  
-Only returns a non-null value if the duration is stored in the metadata.
-
-#### `slowDurationInSeconds`
-
-_number_
-
-The duration of the video in seconds, but it is guaranteed to return a value.  
-If needed, the entire video file is read to determine the duration.
-
-#### `name`
-
-_string_
-
-The name of the file.
-
-#### `container`
-
-_"mp4" | "webm" | "avi" | "transport-stream" | "mp3" | "aac" | "wav" | "flac"_
-
-The container of the file.
-
-#### `size`
-
-_number | null_
-
-The size of the input in bytes.
-
-#### `mimeType`
-
-_string | null_
-
-The MIME type of the file that was returned when the file was fetched.  
-Only available if using the `fetchReader` or `webFileReader`.
-
-#### `structure`
-
-The internal structure of the video. Unstable, internal data structure, refer to the TypeScript types to see what's inside.
-
-#### `fps`
-
-_number | null_
-
-The frame rate of the video.  
-Only returns a non-null value if the frame rate is stored in the metadata.
-
-#### `slowFps`
-
-_number_
-
-The frame rate of the video, but it is guaranteed to return a value.  
-If needed, the entire video file is read to determine the frame rate.
-
-#### `videoCodec`
-
-The video codec of the file.  
-If multiple video tracks are present, this will be the first video track.  
-One of `"h264"`, `"h265"`, `"vp8"`, `"vp9"`, `"av1"`, `"prores"` or `null` (in case of an unknown codec).
-
-#### `audioCodec`
-
-The audio codec of the file.  
-If multiple audio tracks are present, this will be the first audio track.  
-One of `'aac'`, `'mp3'`, `'aiff'`, `'opus'`, `'pcm'`, `'flac'`, `'unknown'` (audio is there but not recognized) or `null` (in case of no audio detected).
-
-#### `metadata`
-
-Metadata fields such as ID3 tags or EXIF data.  
-See [metadata](/docs/media-parser/tags) for more information.
-
-#### `location`
-
-The location of the video was shot. Either `null` if not available or:
-
-- `latitude`: The latitude of the location
-- `longitude`: The longitude of the location
-- `altitude`: The altitude of the location (can be `null`)
-- `horizontalAccuracy`: The horizontal accuracy of the location (can be `null`)
-
-#### `tracks`
-
-Returns an object of two two arrays `videoTracks` and `audioTracks`.  
-The data structure of them is not yet stable.
-
-#### `keyframes`
-
-Return type: <TsType type="MediaParserKeyframe[] | null" source="@remotion/media-parser" />
-
-An array of keyframes. Each keyframe has the following structure:
-
-- `presentationTimeInSeconds`: The time in seconds when the keyframe should be presented
-- `decodingTimeInSeconds`: The time in seconds when the keyframe should be decoded
-- `positionInBytes`: The position in bytes where the keyframe is located in the file
-- `sizeInBytes`: The size of the keyframe in bytes
-- `trackId`: The ID of the track the frame belongs to
-
-Only being returned if the keyframe information are stored in the metadata, otherwise `null`.
-
-#### `slowKeyframes`
-
-Return type: <TsType type="MediaParserKeyframe[]" source="@remotion/media-parser" />
-
-An array of keyframes, same as [`keyframes`](#keyframes), but it is guaranteed to return a value.
-
-Will read the entire video file to determine the keyframes.
-
-#### `slowNumberOfFrames`
-
-_number_
-
-The number of video frames in the media.  
-Will read the entire video file to determine the number of frames.
-
-#### `unrotatedDimensions`
-
-_`{width: number, height: number}`_
-
-The dimensions of the video before rotation.
-
-#### `isHdr`
-
-_`boolean`_
-
-Whether the video is in HDR (High dynamic range).
-
-#### `rotation`
-
-_number_
-
-The rotation of the video in degrees (e.g. `-90` for a 90° counter-clockwise rotation).
-
-#### `images`
-
-Return type: <TsType type="MediaParserEmbeddedImage[]" source="@remotion/media-parser" />
-
-Embedded images in the file, for example an album cover inside an MP3.  
-Each array element has the following fields:
-
-- `mimeType`: The MIME type of the image, or `null`
-- `description`: A description of the image, or `null`
-- `data`: The image data as a `Uint8Array`
+See [Available Fields](#available-fields) for a list of available fields.
 
 ### `reader?`
 
@@ -307,7 +152,179 @@ Default value: `"info"`, which logs only important information.
 An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) instance.  
 If the signal is aborted, the parser will stop reading the media and stop the decoding process and throw an error.
 
-### Callbacks
+## Available fields
+
+The following fields are queryable:
+
+### `dimensions`
+
+_`{width: number, height: number} | null`_
+
+The dimensions of the video.  
+Any rotation is already applied - the dimensions are like a media player would show them.  
+Use `unrotatedDimensions` to get the dimensions before rotation.
+
+If the media passed is an audio file, this will return `null`.
+
+### `durationInSeconds`
+
+_number | null_
+
+The duration of the video in seconds.  
+Only returns a non-null value if the duration is stored in the metadata.
+
+### `slowDurationInSeconds`
+
+_number_
+
+The duration of the video in seconds, but it is guaranteed to return a value.  
+If needed, the entire video file is read to determine the duration.
+
+### `name`
+
+_string_
+
+The name of the file.
+
+### `container`
+
+_"mp4" | "webm" | "avi" | "transport-stream" | "mp3" | "aac" | "wav" | "flac"_
+
+The container of the file.
+
+### `size`
+
+_number | null_
+
+The size of the input in bytes.
+
+### `mimeType`
+
+_string | null_
+
+The MIME type of the file that was returned when the file was fetched.  
+Only available if using the `fetchReader` or `webFileReader`.
+
+### `structure`
+
+The internal structure of the video. Unstable, internal data structure, refer to the TypeScript types to see what's inside.
+
+### `fps`
+
+_number | null_
+
+The frame rate of the video.  
+Only returns a non-null value if the frame rate is stored in the metadata.
+
+### `slowFps`
+
+_number_
+
+The frame rate of the video, but it is guaranteed to return a value.  
+If needed, the entire video file is read to determine the frame rate.
+
+### `videoCodec`
+
+The video codec of the file.  
+If multiple video tracks are present, this will be the first video track.  
+One of `"h264"`, `"h265"`, `"vp8"`, `"vp9"`, `"av1"`, `"prores"` or `null` (in case of an unknown codec).
+
+### `audioCodec`
+
+The audio codec of the file.  
+If multiple audio tracks are present, this will be the first audio track.  
+One of `'aac'`, `'mp3'`, `'aiff'`, `'opus'`, `'pcm'`, `'flac'`, `'unknown'` (audio is there but not recognized) or `null` (in case of no audio detected).
+
+### `metadata`
+
+Metadata fields such as ID3 tags or EXIF data.  
+See [metadata](/docs/media-parser/tags) for more information.
+
+### `location`
+
+The location of the video was shot. Either `null` if not available or:
+
+- `latitude`: The latitude of the location
+- `longitude`: The longitude of the location
+- `altitude`: The altitude of the location (can be `null`)
+- `horizontalAccuracy`: The horizontal accuracy of the location (can be `null`)
+
+### `tracks`
+
+Returns an object of two two arrays `videoTracks` and `audioTracks`.  
+The data structure of them is not yet stable.
+
+### `keyframes`
+
+Return type: <TsType type="MediaParserKeyframe[] | null" source="@remotion/media-parser" />
+
+An array of keyframes. Each keyframe has the following structure:
+
+- `presentationTimeInSeconds`: The time in seconds when the keyframe should be presented
+- `decodingTimeInSeconds`: The time in seconds when the keyframe should be decoded
+- `positionInBytes`: The position in bytes where the keyframe is located in the file
+- `sizeInBytes`: The size of the keyframe in bytes
+- `trackId`: The ID of the track the frame belongs to
+
+Only being returned if the keyframe information are stored in the metadata, otherwise `null`.
+
+### `slowKeyframes`
+
+Return type: <TsType type="MediaParserKeyframe[]" source="@remotion/media-parser" />
+
+An array of keyframes, same as [`keyframes`](#keyframes), but it is guaranteed to return a value.
+
+Will read the entire video file to determine the keyframes.
+
+### `slowNumberOfFrames`
+
+_number_
+
+The number of video frames in the media.  
+Will read the entire video file to determine the number of frames.
+
+### `unrotatedDimensions`
+
+_`{width: number, height: number}`_
+
+The dimensions of the video before rotation.
+
+### `isHdr`
+
+_`boolean`_
+
+Whether the video is in HDR (High dynamic range).
+
+### `rotation`
+
+_number_
+
+The rotation of the video in degrees (e.g. `-90` for a 90° counter-clockwise rotation).
+
+### `images`
+
+Return type: <TsType type="MediaParserEmbeddedImage[]" source="@remotion/media-parser" />
+
+Embedded images in the file, for example an album cover inside an MP3.  
+Each array element has the following fields:
+
+- `mimeType`: The MIME type of the image, or `null`
+- `description`: A description of the image, or `null`
+- `data`: The image data as a `Uint8Array`
+
+### `sampleRate`
+
+_number | null_
+
+The audio sample rate, if there is an audio track.
+
+### `numberOfAudioChannels`
+
+_number | null_
+
+The number of audio channels, if there is an audio track.
+
+## Callbacks
 
 Each field also has a callback that allows you to retrieve the value as soon as it is obtained without waiting for the function to resolve.
 

--- a/packages/media-parser/src/boxes/riff/get-duration.ts
+++ b/packages/media-parser/src/boxes/riff/get-duration.ts
@@ -1,0 +1,38 @@
+import type {RiffStructure} from './riff-box';
+import {getStrhBox, getStrlBoxes} from './traversal';
+
+export const getDurationFromAvi = (structure: RiffStructure) => {
+	const strl = getStrlBoxes(structure);
+
+	const lengths: number[] = [];
+	for (const s of strl) {
+		const strh = getStrhBox(s.children);
+		if (!strh) {
+			throw new Error('No strh box');
+		}
+
+		const samplesPerSecond = strh.rate / strh.scale;
+
+		const streamLength = strh.length / samplesPerSecond;
+		lengths.push(streamLength);
+	}
+
+	return Math.max(...lengths);
+};
+
+export const getSampleRateFromAvi = (structure: RiffStructure) => {
+	const strl = getStrlBoxes(structure);
+
+	for (const s of strl) {
+		const strh = getStrhBox(s.children);
+		if (!strh) {
+			throw new Error('No strh box');
+		}
+
+		if (strh.strf.type === 'strf-box-audio') {
+			return strh.strf.sampleRate;
+		}
+	}
+
+	return null;
+};

--- a/packages/media-parser/src/emit-available-info.ts
+++ b/packages/media-parser/src/emit-available-info.ts
@@ -7,6 +7,8 @@ import {getFps} from './get-fps';
 import {getIsHdr} from './get-is-hdr';
 import {getKeyframes} from './get-keyframes';
 import {getLocation} from './get-location';
+import {getNumberOfAudioChannels} from './get-number-of-audio-channels';
+import {getSampleRate} from './get-sample-rate';
 import {getTracks} from './get-tracks';
 import {getVideoCodec} from './get-video-codec';
 import {getMetadata} from './metadata/get-metadata';
@@ -447,6 +449,38 @@ export const emitAvailableInfo = ({
 				}
 
 				emittedFields.images = true;
+			}
+
+			continue;
+		}
+
+		if (key === 'sampleRate') {
+			if (!emittedFields.sampleRate && hasInfo.sampleRate && parseResult) {
+				const sampleRate = getSampleRate(state);
+				callbacks.onSampleRate?.(sampleRate);
+				if (fieldsInReturnValue.sampleRate) {
+					returnValue.sampleRate = sampleRate;
+				}
+
+				emittedFields.sampleRate = true;
+			}
+
+			continue;
+		}
+
+		if (key === 'numberOfAudioChannels') {
+			if (
+				!emittedFields.numberOfAudioChannels &&
+				hasInfo.numberOfAudioChannels &&
+				parseResult
+			) {
+				const numberOfAudioChannels = getNumberOfAudioChannels(state);
+				callbacks.onNumberOfAudioChannels?.(numberOfAudioChannels);
+				if (fieldsInReturnValue.numberOfAudioChannels) {
+					returnValue.numberOfAudioChannels = numberOfAudioChannels;
+				}
+
+				emittedFields.numberOfAudioChannels = true;
 			}
 
 			continue;

--- a/packages/media-parser/src/get-duration.ts
+++ b/packages/media-parser/src/get-duration.ts
@@ -7,8 +7,7 @@ import {
 	getMvhdBox,
 } from './boxes/iso-base-media/traversal';
 import {getDurationFromMp3} from './boxes/mp3/get-duration';
-import type {RiffStructure} from './boxes/riff/riff-box';
-import {getStrhBox, getStrlBoxes} from './boxes/riff/traversal';
+import {getDurationFromAvi} from './boxes/riff/get-duration';
 import {getDurationFromWav} from './boxes/wav/get-duration-from-wav';
 import type {DurationSegment} from './boxes/webm/segments/all-segments';
 import {getHasTracks, getTracks} from './get-tracks';
@@ -101,25 +100,6 @@ const getDurationFromIsoBaseMedia = (
 	});
 	const highestTimestamp = Math.max(...allSamples);
 	return highestTimestamp;
-};
-
-const getDurationFromAvi = (structure: RiffStructure) => {
-	const strl = getStrlBoxes(structure);
-
-	const lengths: number[] = [];
-	for (const s of strl) {
-		const strh = getStrhBox(s.children);
-		if (!strh) {
-			throw new Error('No strh box');
-		}
-
-		const samplesPerSecond = strh.rate / strh.scale;
-
-		const streamLength = strh.length / samplesPerSecond;
-		lengths.push(streamLength);
-	}
-
-	return Math.max(...lengths);
 };
 
 export const getDuration = (

--- a/packages/media-parser/src/get-fields-from-callbacks.ts
+++ b/packages/media-parser/src/get-fields-from-callbacks.ts
@@ -36,6 +36,8 @@ export const getFieldsFromCallback = <F extends Options<ParseMediaFields>>({
 		slowNumberOfFrames: Boolean(callbacks.onSlowNumberOfFrames),
 		keyframes: Boolean(callbacks.onKeyframes),
 		images: Boolean(callbacks.onImages),
+		numberOfAudioChannels: Boolean(callbacks.onNumberOfAudioChannels),
+		sampleRate: Boolean(callbacks.onSampleRate),
 		...fields,
 	};
 	return newFields;

--- a/packages/media-parser/src/get-number-of-audio-channels.ts
+++ b/packages/media-parser/src/get-number-of-audio-channels.ts
@@ -1,0 +1,13 @@
+import type {ParserState} from './state/parser-state';
+
+export const getNumberOfAudioChannels = (state: ParserState) => {
+	return (
+		state.callbacks.tracks.getTracks().find((track) => {
+			return track.type === 'audio';
+		})?.numberOfChannels ?? null
+	);
+};
+
+export const hasNumberOfAudioChannels = (state: ParserState) => {
+	return state.callbacks.tracks.hasAllTracks();
+};

--- a/packages/media-parser/src/get-sample-rate.ts
+++ b/packages/media-parser/src/get-sample-rate.ts
@@ -1,0 +1,13 @@
+import type {ParserState} from './state/parser-state';
+
+export const getSampleRate = (state: ParserState) => {
+	return (
+		state.callbacks.tracks.getTracks().find((track) => {
+			return track.type === 'audio';
+		})?.sampleRate ?? null
+	);
+};
+
+export const hasSampleRate = (state: ParserState) => {
+	return state.callbacks.tracks.hasAllTracks();
+};

--- a/packages/media-parser/src/has-all-info.ts
+++ b/packages/media-parser/src/has-all-info.ts
@@ -5,6 +5,8 @@ import {hasDuration, hasSlowDuration} from './get-duration';
 import {hasFps, hasFpsSuitedForSlowFps} from './get-fps';
 import {hasHdr} from './get-is-hdr';
 import {hasKeyframes} from './get-keyframes';
+import {hasNumberOfAudioChannels} from './get-number-of-audio-channels';
+import {hasSampleRate} from './get-sample-rate';
 import {getHasTracks} from './get-tracks';
 import {hasVideoCodec} from './get-video-codec';
 import {maySkipVideoData} from './may-skip-video-data/may-skip-video-data';
@@ -107,6 +109,14 @@ export const getAvailableInfo = ({
 
 		if (key === 'slowNumberOfFrames') {
 			return false;
+		}
+
+		if (key === 'numberOfAudioChannels') {
+			return hasNumberOfAudioChannels(state);
+		}
+
+		if (key === 'sampleRate') {
+			return hasSampleRate(state);
 		}
 
 		throw new Error(`Unknown key: ${key satisfies never}`);

--- a/packages/media-parser/src/may-skip-video-data/need-samples-for-fields.ts
+++ b/packages/media-parser/src/may-skip-video-data/need-samples-for-fields.ts
@@ -24,6 +24,8 @@ const needsSamples: Record<keyof Options<ParseMediaFields>, boolean> = {
 	mimeType: false,
 	keyframes: false,
 	images: false,
+	numberOfAudioChannels: false,
+	sampleRate: false,
 };
 
 export const needsToIterateOverSamples = ({

--- a/packages/media-parser/src/options.ts
+++ b/packages/media-parser/src/options.ts
@@ -47,6 +47,8 @@ export type ParseMediaFields = {
 	slowKeyframes: boolean;
 	slowNumberOfFrames: boolean;
 	images: boolean;
+	sampleRate: boolean;
+	numberOfAudioChannels: boolean;
 };
 
 export type AllParseMediaFields = {
@@ -73,6 +75,8 @@ export type AllParseMediaFields = {
 	keyframes: true;
 	slowKeyframes: true;
 	images: true;
+	sampleRate: true;
+	numberOfAudioChannels: true;
 };
 
 export type AllOptions<Fields extends ParseMediaFields> = {
@@ -99,6 +103,8 @@ export type AllOptions<Fields extends ParseMediaFields> = {
 	slowKeyframes: Fields['slowKeyframes'];
 	slowNumberOfFrames: Fields['slowNumberOfFrames'];
 	images: Fields['images'];
+	sampleRate: Fields['sampleRate'];
+	numberOfAudioChannels: Fields['numberOfAudioChannels'];
 };
 
 export type Options<Fields extends ParseMediaFields> = Partial<
@@ -152,6 +158,8 @@ export interface ParseMediaCallbacks {
 	onSlowKeyframes?: (keyframes: MediaParserKeyframe[]) => void;
 	onSlowNumberOfFrames?: (samples: number) => void;
 	onImages?: (images: MediaParserEmbeddedImage[]) => void;
+	onSampleRate?: (sampleRate: number | null) => void;
+	onNumberOfAudioChannels?: (numberOfChannels: number | null) => void;
 }
 
 export interface ParseMediaData {
@@ -178,6 +186,8 @@ export interface ParseMediaData {
 	slowKeyframes: MediaParserKeyframe[];
 	slowNumberOfFrames: number;
 	images: MediaParserEmbeddedImage[];
+	sampleRate: number | null;
+	numberOfAudioChannels: number | null;
 }
 
 export type ParseMediaResult<T extends Partial<ParseMediaFields>> = {

--- a/packages/media-parser/src/state/can-skip-tracks.ts
+++ b/packages/media-parser/src/state/can-skip-tracks.ts
@@ -34,7 +34,9 @@ export const needsTracksForField = ({
 		field === 'slowKeyframes' ||
 		field === 'slowNumberOfFrames' ||
 		field === 'keyframes' ||
-		field === 'images'
+		field === 'images' ||
+		field === 'sampleRate' ||
+		field === 'numberOfAudioChannels'
 	) {
 		return true;
 	}

--- a/packages/media-parser/src/state/emitted-fields.ts
+++ b/packages/media-parser/src/state/emitted-fields.ts
@@ -25,6 +25,8 @@ export const emittedState = () => {
 		slowNumberOfFrames: false,
 		keyframes: false,
 		images: false,
+		numberOfAudioChannels: false,
+		sampleRate: false,
 	};
 
 	return emittedFields;

--- a/packages/media-parser/src/test/flac.test.ts
+++ b/packages/media-parser/src/test/flac.test.ts
@@ -29,6 +29,8 @@ test('parse flac', async () => {
 		slowNumberOfFrames,
 		structure,
 		unrotatedDimensions,
+		numberOfAudioChannels,
+		sampleRate,
 	} = await parseMedia({
 		src: exampleVideos.flac,
 		reader: nodeReader,
@@ -56,6 +58,8 @@ test('parse flac', async () => {
 			slowNumberOfFrames: true,
 			structure: true,
 			unrotatedDimensions: true,
+			numberOfAudioChannels: true,
+			sampleRate: true,
 		},
 		onAudioTrack: () => {
 			return () => {
@@ -203,6 +207,8 @@ test('parse flac', async () => {
 		],
 	});
 	expect(unrotatedDimensions).toBe(null);
+	expect(sampleRate).toBe(44100);
+	expect(numberOfAudioChannels).toBe(2);
 });
 
 test('parse flac minimal seek', async () => {

--- a/packages/media-parser/src/test/iso-base-media.test.ts
+++ b/packages/media-parser/src/test/iso-base-media.test.ts
@@ -21,6 +21,8 @@ if (process.platform !== 'win32') {
 				dimensions: true,
 				rotation: true,
 				unrotatedDimensions: true,
+				numberOfAudioChannels: true,
+				sampleRate: true,
 			},
 			reader: nodeReader,
 			onVideoTrack: ({track}) => {
@@ -52,6 +54,8 @@ if (process.platform !== 'win32') {
 			height: 2160,
 			width: 3840,
 		});
+		expect(result.sampleRate).toBe(44100);
+		expect(result.numberOfAudioChannels).toBe(2);
 		expect(videoTracks).toBe(1);
 		expect(audioTracks).toBe(1);
 		expect(videoSamples).toBe(377);

--- a/packages/media-parser/src/test/matroska.test.ts
+++ b/packages/media-parser/src/test/matroska.test.ts
@@ -13,6 +13,8 @@ test('Should get duration of AV1 video', async () => {
 			fps: true,
 			slowFps: true,
 			slowNumberOfFrames: true,
+			numberOfAudioChannels: true,
+			sampleRate: true,
 		},
 		reader: nodeReader,
 	});
@@ -25,6 +27,8 @@ test('Should get duration of AV1 video', async () => {
 		width: 1920,
 		height: 1080,
 	});
+	expect(parsed.numberOfAudioChannels).toBe(null);
+	expect(parsed.sampleRate).toBe(null);
 
 	expect(parsed.structure.boxes).toEqual([
 		{

--- a/packages/media-parser/src/test/parse-aac.test.ts
+++ b/packages/media-parser/src/test/parse-aac.test.ts
@@ -29,6 +29,8 @@ test('should be able to parse aac', async () => {
 		tracks,
 		unrotatedDimensions,
 		videoCodec,
+		numberOfAudioChannels,
+		sampleRate,
 	} = await parseMedia({
 		src: exampleVideos.aac,
 		reader: nodeReader,
@@ -56,6 +58,8 @@ test('should be able to parse aac', async () => {
 			structure: true,
 			tracks: true,
 			unrotatedDimensions: true,
+			numberOfAudioChannels: true,
+			sampleRate: true,
 		},
 		onAudioTrack: ({track}) => {
 			expect(track).toEqual({
@@ -107,9 +111,11 @@ test('should be able to parse aac', async () => {
 	});
 	expect(tracks.audioTracks.length).toBe(1);
 	expect(tracks.videoTracks.length).toBe(0);
+	expect(numberOfAudioChannels).toBe(2);
+	expect(sampleRate).toBe(44100);
 });
 
-test.only('should be able to get basics without parsing all', async () => {
+test('should be able to get basics without parsing all', async () => {
 	const audioSamples = 0;
 	const {
 		durationInSeconds,

--- a/packages/media-parser/src/test/parse-avi-file.test.ts
+++ b/packages/media-parser/src/test/parse-avi-file.test.ts
@@ -20,6 +20,8 @@ test('AVI file', async () => {
 		name,
 		rotation,
 		videoCodec,
+		numberOfAudioChannels,
+		sampleRate,
 	} = await parseMedia({
 		src: exampleVideos.avi,
 		reader: nodeReader,
@@ -35,6 +37,8 @@ test('AVI file', async () => {
 			name: true,
 			rotation: true,
 			videoCodec: true,
+			sampleRate: true,
+			numberOfAudioChannels: true,
 		},
 		onAudioTrack: () => {
 			audioTrackCount++;
@@ -297,4 +301,6 @@ test('AVI file', async () => {
 			},
 		],
 	});
+	expect(sampleRate).toBe(48000);
+	expect(numberOfAudioChannels).toBe(2);
 });

--- a/packages/media-parser/src/test/parse-mp3.test.ts
+++ b/packages/media-parser/src/test/parse-mp3.test.ts
@@ -28,6 +28,8 @@ test('should read MP3 file', async () => {
 		structure,
 		unrotatedDimensions,
 		videoCodec,
+		numberOfAudioChannels,
+		sampleRate,
 	} = await parseMedia({
 		src: exampleVideos.music,
 		reader: nodeReader,
@@ -54,6 +56,8 @@ test('should read MP3 file', async () => {
 			structure: true,
 			unrotatedDimensions: true,
 			videoCodec: true,
+			numberOfAudioChannels: true,
+			sampleRate: true,
 		},
 		onAudioTrack: () => {
 			let lastSample = -1;
@@ -158,6 +162,8 @@ test('should read MP3 file', async () => {
 	expect(slowNumberOfFrames).toBe(0);
 	expect(structure.boxes.length).toEqual(1);
 	expect(unrotatedDimensions).toBe(null);
+	expect(numberOfAudioChannels).toBe(2);
+	expect(sampleRate).toBe(44100);
 });
 
 test('should read only metadata', async () => {

--- a/packages/media-parser/src/test/parse-transport-stream-partially.test.ts
+++ b/packages/media-parser/src/test/parse-transport-stream-partially.test.ts
@@ -32,6 +32,8 @@ test('Should be able to parse only tracks of Transport Stream', async () => {
 			tracks: true,
 			durationInSeconds: true,
 			fps: true,
+			sampleRate: true,
+			numberOfAudioChannels: true,
 		},
 		reader: nodeReader,
 	});
@@ -41,4 +43,6 @@ test('Should be able to parse only tracks of Transport Stream', async () => {
 		finalCursorOffset: 80652,
 		skippedBytes: 1832812,
 	});
+	expect(parsed.sampleRate).toBe(48000);
+	expect(parsed.numberOfAudioChannels).toBe(2);
 });

--- a/packages/media-parser/src/test/parse-webm-partially.test.ts
+++ b/packages/media-parser/src/test/parse-webm-partially.test.ts
@@ -22,11 +22,13 @@ test('Parse only header of WebM', async () => {
 });
 
 test('Parse WebM partially', async () => {
-	const {internalStats} = await parseMedia({
+	const {internalStats, numberOfAudioChannels, sampleRate} = await parseMedia({
 		src: exampleVideos.stretchedVp8,
 		fields: {
 			tracks: true,
 			internalStats: true,
+			sampleRate: true,
+			numberOfAudioChannels: true,
 		},
 		reader: nodeReader,
 	});
@@ -35,6 +37,8 @@ test('Parse WebM partially', async () => {
 		finalCursorOffset: 4540,
 		skippedBytes: 13190819,
 	});
+	expect(numberOfAudioChannels).toBe(2);
+	expect(sampleRate).toBe(44100);
 });
 
 test('Parse WebM fully', async () => {

--- a/packages/media-parser/src/test/wav.test.ts
+++ b/packages/media-parser/src/test/wav.test.ts
@@ -28,6 +28,8 @@ test('parse full wav', async () => {
 		structure,
 		unrotatedDimensions,
 		videoCodec,
+		numberOfAudioChannels,
+		sampleRate,
 	} = await parseMedia({
 		src: exampleVideos.chirp,
 		reader: nodeReader,
@@ -55,6 +57,8 @@ test('parse full wav', async () => {
 			structure: true,
 			unrotatedDimensions: true,
 			videoCodec: true,
+			sampleRate: true,
+			numberOfAudioChannels: true,
 		},
 	});
 	expect(dimensions).toBe(null);
@@ -136,6 +140,8 @@ test('parse full wav', async () => {
 	});
 	expect(unrotatedDimensions).toBe(null);
 	expect(videoCodec).toBe(null);
+	expect(numberOfAudioChannels).toBe(1);
+	expect(sampleRate).toBe(44100);
 });
 
 test('should be fast to only get duration', async () => {


### PR DESCRIPTION
Cool