### PR TITLE
`@remotion/renderer`: Fix swallowing the error in `ensureBrowser()`

### DIFF
--- a/packages/renderer/src/browser/BrowserFetcher.ts
+++ b/packages/renderer/src/browser/BrowserFetcher.ts
@@ -187,6 +187,8 @@ export const downloadBrowser = async ({
 				path.join(outputPath, 'chrome-headless-shell-linux-arm64'),
 			);
 		}
+	} catch (err) {
+		return Promise.reject(err);
 	} finally {
 		if (await existsAsync(archivePath)) {
 			await unlinkAsync(archivePath);


### PR DESCRIPTION
Fixes #4759