### PR TITLE
Monorepo: Don't run Rust build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,9 +25,6 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.2.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "packages/compositor -> target"
       - name: Install
         run: pnpm i --frozen-lockfile
       - name: Cache turbo build setup
@@ -156,9 +153,6 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.2.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "packages/compositor -> target"
       - name: Install
         run: pnpm i --frozen-lockfile
       - name: Build & Test

--- a/packages/compositor/package.json
+++ b/packages/compositor/package.json
@@ -7,7 +7,6 @@
 	"description": "Rust binary for Remotion",
 	"sideEffects": false,
 	"scripts": {
-		"make": "bun build.ts --debug",
 		"build-all": "bun build.ts --all"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",

--- a/packages/docs/docs/contributing/rust.mdx
+++ b/packages/docs/docs/contributing/rust.mdx
@@ -24,7 +24,7 @@ To build the Rust parts for your operating system, run:
 
 ```sh
 cd packages/compositor
-bun build.ts
+bun build.ts --debug
 ```
 
 ## Building for all platforms
@@ -35,13 +35,13 @@ To build the Rust binaries for all supported platforms, you need to install thei
 
 ```sh
 cd packages/compositor
-node install-toolchains.mjs
+node install-toolchain.ts
 ```
 
 You can then build all binaries with:
 
 ```
-pnpm build-all
+bun run build-all
 ```
 
 The resulting artifacts should be checked into Git.


### PR DESCRIPTION
Files are committed anyway

Slows down CI a lot, as well as `pnpm watch`

I'll just build all architectures whenever I change it from now on which is not all that often