### PR TITLE
`@remotion/renderer`: Use `new URL` to avoid deprecation warning

### DIFF
--- a/packages/renderer/src/serve-handler/index.ts
+++ b/packages/renderer/src/serve-handler/index.ts
@@ -3,7 +3,6 @@ import type {Stats} from 'node:fs';
 import {createReadStream, promises} from 'node:fs';
 import type {IncomingMessage, ServerResponse} from 'node:http';
 import path from 'node:path';
-import url from 'node:url';
 import {mimeContentType} from '../mime-types';
 // Packages
 import {isPathInside} from './is-path-inside';
@@ -112,9 +111,11 @@ export const serveHandler = async (
 	let relativePath = null;
 
 	try {
-		relativePath = decodeURIComponent(
-			url.parse(request.url as string).pathname as string,
+		const parsedUrl = new URL(
+			request.url as string,
+			`http://${request.headers.host}`,
 		);
+		relativePath = decodeURIComponent(parsedUrl.pathname);
 	} catch {
 		return sendError('/', response, {
 			statusCode: 400,


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
