### PR TITLE
`@remotion/renderer`: `--force-gpu-mem-available-mb=4096`

### DIFF
--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -182,6 +182,7 @@ export const internalOpenBrowser = async ({
 			'--no-proxy-server',
 			"--proxy-server='direct://'",
 			'--proxy-bypass-list=*',
+			'--force-gpu-mem-available-mb=4096',
 			'--disable-hang-monitor',
 			'--disable-extensions',
 			'--allow-chrome-scheme-url',


### PR DESCRIPTION
Based on https://github.com/puppeteer/puppeteer/issues/5530
and https://discord.com/channels/809501355504959528/1331059097625165834/1331613743389474881

this seems to help against Chrome not rendering all tiles