### PR TITLE
`@remotion/player`: `acknowledgeRemotionLicense` prop

### DIFF
--- a/packages/docs/docs/player/api.mdx
+++ b/packages/docs/docs/player/api.mdx
@@ -472,6 +472,10 @@ A HTML class name to be used in place of the default `__remotion-player`.
 
 <Options id="log" />
 
+### `acknowledgeRemotionLicense?`<AvailableFrom v="4.0.253" />
+
+Acknowledge the [Remotion License](/docs/license) to make the console message disappear.
+
 ## `PlayerRef`
 
 You may attach a ref to the player and control it in an imperative manner.

--- a/packages/player-example/src/App.tsx
+++ b/packages/player-example/src/App.tsx
@@ -634,6 +634,7 @@ const PlayerOnly: React.FC<
 		<Player
 			ref={playerRef}
 			controls
+			acknowledgeRemotionLicense
 			showVolumeControls={showVolumeControls}
 			compositionWidth={1920}
 			compositionHeight={1080}

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -30,6 +30,7 @@ import type {BrowserMediaControlsBehavior} from './browser-mediasession.js';
 import {playerCssClassname} from './player-css-classname.js';
 import type {PlayerRef} from './player-methods.js';
 import type {RenderVolumeSlider} from './render-volume-slider.js';
+import {acknowledgeRemotionLicenseMessage} from './use-remotion-license-acknowledge.js';
 import type {PropsIfHasProps} from './utils/props-if-has-props.js';
 import {validateInOutFrames} from './utils/validate-in-out-frame.js';
 import {validateInitialFrame} from './utils/validate-initial-frame.js';
@@ -90,6 +91,7 @@ export type PlayerProps<
 	readonly browserMediaControlsBehavior?: BrowserMediaControlsBehavior;
 	readonly overrideInternalClassName?: string;
 	readonly logLevel?: LogLevel;
+	readonly acknowledgeRemotionLicense?: boolean;
 } & CompProps<Props> &
 	PropsIfHasProps<Schema, Props>;
 
@@ -154,6 +156,7 @@ const PlayerFn = <
 		browserMediaControlsBehavior: passedBrowserMediaControlsBehavior,
 		overrideInternalClassName,
 		logLevel = 'info',
+		acknowledgeRemotionLicense,
 		...componentProps
 	}: PlayerProps<Schema, Props>,
 	ref: MutableRefObject<PlayerRef>,
@@ -188,6 +191,13 @@ const PlayerFn = <
 			`'component' must not be the 'Composition' component. Pass your own React component directly, and set the duration, fps and dimensions as separate props. See https://www.remotion.dev/docs/player/examples for an example.`,
 		);
 	}
+
+	useState(() =>
+		acknowledgeRemotionLicenseMessage(
+			Boolean(acknowledgeRemotionLicense),
+			logLevel,
+		),
+	);
 
 	const component = Internals.useLazyComponent(
 		componentProps,

--- a/packages/player/src/use-remotion-license-acknowledge.ts
+++ b/packages/player/src/use-remotion-license-acknowledge.ts
@@ -1,0 +1,27 @@
+import type {LogLevel} from 'remotion';
+import {Internals} from 'remotion';
+
+let warningShown = false;
+
+export const acknowledgeRemotionLicenseMessage = (
+	acknowledge: boolean,
+	logLevel: LogLevel,
+) => {
+	if (acknowledge) {
+		return;
+	}
+
+	if (warningShown) {
+		return;
+	}
+
+	warningShown = true;
+	Internals.Log.warn(
+		logLevel,
+		'Note: Some companies are required to obtain a license to use Remotion. See: https://remotion.dev/license',
+	);
+	Internals.Log.warn(
+		logLevel,
+		'Pass the `acknowledgeRemotionLicense` prop to `<Player />` function to make this message disappear.',
+	);
+};


### PR DESCRIPTION
More people are coming to Remotion through AI or through a template.

With it, it becomes easier to oversee our license.

This is a gentle information for the user that they should at least read the license once before the first use of the Player.