### PR TITLE
handle quiet audio waves

### DIFF
--- a/packages/media-utils/src/get-wave-form-samples.ts
+++ b/packages/media-utils/src/get-wave-form-samples.ts
@@ -18,10 +18,18 @@ const filterData = (audioBuffer: Float32Array, samples: number) => {
 	return filteredData;
 };
 
-const normalizeData = (filteredData: number[]) => {
-	const max = Math.max(...filteredData);
-	const multiplier = max === 0 ? 0 : max ** -1;
-	return filteredData.map((n) => n * multiplier);
+const normalizeData = (filteredData) => {
+    const max = Math.max(...filteredData);
+    
+    // If the maximum amplitude is below this threshold, treat it as silence
+    const MINIMUM_AMPLITUDE_THRESHOLD = 0.001;
+    
+    if (max < MINIMUM_AMPLITUDE_THRESHOLD) {
+        return new Array(filteredData.length).fill(0);
+    }
+    
+    const multiplier = max ** -1;
+    return filteredData.map((n) => n * multiplier);
 };
 
 export const getWaveformSamples = (


### PR DESCRIPTION

When processing extremely quiet audio (max amplitude < 0.001), the waveform visualization would over-amplify the noise due to normalization. This would make silent or near-silent sections appear as prominent waves.

For example, when I'm splitting this audio out into individual stems, it is common that one of the instruments is not present. In this screenshot, there is no piano:
![image](https://github.com/user-attachments/assets/a17761e4-c661-47a9-8085-e39448d7f193)


This now treats audio below this threshold as silence by returning zeros instead of normalizing. Here are what the stems look like now:
![image](https://github.com/user-attachments/assets/be9aad79-de4d-46a6-b45d-cec60b95857f)

Note that I still place a dot for the waveform when amplitude is zero, but that is in the canvas logic.