### PR TITLE
`@remotion/renderer`: Split up into multiple functions

### DIFF
--- a/packages/renderer/src/cycle-browser-tabs.ts
+++ b/packages/renderer/src/cycle-browser-tabs.ts
@@ -2,12 +2,17 @@ import type {LogLevel} from './log-level';
 import {Log} from './logger';
 import type {BrowserReplacer} from './replace-browser';
 
-export const cycleBrowserTabs = (
-	puppeteerInstance: BrowserReplacer,
-	concurrency: number,
-	logLevel: LogLevel,
-	indent: boolean,
-): {
+export const cycleBrowserTabs = ({
+	puppeteerInstance,
+	concurrency,
+	logLevel,
+	indent,
+}: {
+	puppeteerInstance: BrowserReplacer;
+	concurrency: number;
+	logLevel: LogLevel;
+	indent: boolean;
+}): {
 	stopCycling: () => void;
 } => {
 	if (concurrency <= 1) {

--- a/packages/renderer/src/make-page.ts
+++ b/packages/renderer/src/make-page.ts
@@ -1,0 +1,127 @@
+import type {VideoConfig} from 'remotion';
+import type {BrowserLog} from './browser-log';
+import type {Page} from './browser/BrowserPage';
+import type {ConsoleMessage} from './browser/ConsoleMessage';
+import type {SourceMapGetter} from './browser/source-map-getter';
+import type {Codec} from './codec';
+import type {VideoImageFormat} from './image-format';
+import type {LogLevel} from './log-level';
+import {puppeteerEvaluateWithCatch} from './puppeteer-evaluate';
+import type {BrowserReplacer} from './replace-browser';
+import {setPropsAndEnv} from './set-props-and-env';
+
+export const makePage = async ({
+	context,
+	initialFrame,
+	browserReplacer,
+	logLevel,
+	indent,
+	pagesArray,
+	onBrowserLog,
+	scale,
+	timeoutInMilliseconds,
+	composition,
+	proxyPort,
+	serveUrl,
+	muted,
+	envVariables,
+	serializedInputPropsWithCustomSchema,
+	imageFormat,
+	serializedResolvedPropsWithCustomSchema,
+}: {
+	context: SourceMapGetter;
+	initialFrame: number;
+	browserReplacer: BrowserReplacer;
+	logLevel: LogLevel;
+	indent: boolean;
+	pagesArray: Page[];
+	onBrowserLog: ((log: BrowserLog) => void) | undefined | null;
+	scale: number;
+	timeoutInMilliseconds: number;
+	composition: Omit<VideoConfig, 'defaultProps' | 'props'>;
+	proxyPort: number;
+	serveUrl: string;
+	muted: boolean;
+	envVariables: Record<string, string>;
+	serializedInputPropsWithCustomSchema: string;
+	serializedResolvedPropsWithCustomSchema: string;
+	imageFormat: VideoImageFormat;
+}) => {
+	const page = await browserReplacer
+		.getBrowser()
+		.newPage(context, logLevel, indent);
+	pagesArray.push(page);
+	await page.setViewport({
+		width: composition.width,
+		height: composition.height,
+		deviceScaleFactor: scale,
+	});
+
+	const logCallback = (log: ConsoleMessage) => {
+		onBrowserLog?.({
+			stackTrace: log.stackTrace(),
+			text: log.text,
+			type: log.type,
+		});
+	};
+
+	if (onBrowserLog) {
+		page.on('console', logCallback);
+	}
+
+	await setPropsAndEnv({
+		serializedInputPropsWithCustomSchema,
+		envVariables,
+		page,
+		serveUrl,
+		initialFrame,
+		timeoutInMilliseconds,
+		proxyPort,
+		retriesRemaining: 2,
+		audioEnabled: !muted,
+		videoEnabled: imageFormat !== 'none',
+		indent,
+		logLevel,
+		onServeUrlVisited: () => undefined,
+	});
+
+	await puppeteerEvaluateWithCatch({
+		// eslint-disable-next-line max-params
+		pageFunction: (
+			id: string,
+			props: string,
+			durationInFrames: number,
+			fps: number,
+			height: number,
+			width: number,
+			defaultCodec: Codec,
+		) => {
+			window.remotion_setBundleMode({
+				type: 'composition',
+				compositionName: id,
+				serializedResolvedPropsWithSchema: props,
+				compositionDurationInFrames: durationInFrames,
+				compositionFps: fps,
+				compositionHeight: height,
+				compositionWidth: width,
+				compositionDefaultCodec: defaultCodec,
+			});
+		},
+		args: [
+			composition.id,
+			serializedResolvedPropsWithCustomSchema,
+			composition.durationInFrames,
+			composition.fps,
+			composition.height,
+			composition.width,
+			composition.defaultCodec,
+		],
+		frame: null,
+		page,
+		timeoutInMilliseconds,
+	});
+
+	page.off('console', logCallback);
+
+	return page;
+};

--- a/packages/renderer/src/render-frame-with-option-to-reject.ts
+++ b/packages/renderer/src/render-frame-with-option-to-reject.ts
@@ -1,0 +1,237 @@
+import path from 'path';
+import type {RenderMediaOnDownload} from './assets/download-and-map-assets-to-file';
+import {downloadAndMapAssetsToFileUrl} from './assets/download-and-map-assets-to-file';
+import type {DownloadMap} from './assets/download-map';
+import type {Page} from './browser/BrowserPage';
+import {compressAsset} from './compress-assets';
+import {handleJavascriptException} from './error-handling/handle-javascript-exception';
+import {onlyArtifact, onlyAudioAndVideoAssets} from './filter-asset-types';
+import type {CountType} from './get-frame-padded-index';
+import {getFrameOutputFileName} from './get-frame-padded-index';
+import type {VideoImageFormat} from './image-format';
+import type {LogLevel} from './log-level';
+import {Log} from './logger';
+import type {CancelSignal} from './make-cancel-signal';
+import {startPerfMeasure, stopPerfMeasure} from './perf';
+import type {Pool} from './pool';
+import type {FrameAndAssets, OnArtifact} from './render-frames';
+import {seekToFrame} from './seek-to-frame';
+import {takeFrame} from './take-frame';
+import {truthy} from './truthy';
+
+export const renderFrameWithOptionToReject = async ({
+	frame,
+	index,
+	reject,
+	width,
+	height,
+	compId,
+	assetsOnly,
+	attempt,
+	poolPromise,
+	stoppedSignal,
+	indent,
+	logLevel,
+	timeoutInMilliseconds,
+	outputDir,
+	onFrameBuffer,
+	imageFormat,
+	onError,
+	lastFrame,
+	jpegQuality,
+	frameDir,
+	scale,
+	countType,
+	assets,
+	framesToRender,
+	onArtifact,
+	onDownload,
+	downloadMap,
+	binariesDirectory,
+	cancelSignal,
+}: {
+	frame: number;
+	index: number | null;
+	reject: (err: Error) => void;
+	width: number;
+	height: number;
+	compId: string;
+	assetsOnly: boolean;
+	attempt: number;
+	poolPromise: Promise<Pool<Page>>;
+	stoppedSignal: {stopped: boolean};
+	timeoutInMilliseconds: number;
+	indent: boolean;
+	logLevel: LogLevel;
+	outputDir: string | null;
+	onFrameBuffer: null | ((buffer: Buffer, frame: number) => void) | undefined;
+	imageFormat: VideoImageFormat;
+	onError: (err: Error) => void;
+	lastFrame: number;
+	jpegQuality: number;
+	frameDir: string;
+	scale: number;
+	countType: CountType;
+	assets: FrameAndAssets[];
+	framesToRender: number[];
+	onArtifact: OnArtifact | null;
+	onDownload: RenderMediaOnDownload | null;
+	downloadMap: DownloadMap;
+	binariesDirectory: string | null;
+	cancelSignal: CancelSignal | undefined;
+}) => {
+	const pool = await poolPromise;
+	const freePage = await pool.acquire();
+
+	if (stoppedSignal.stopped) {
+		return reject(new Error('Render was stopped'));
+	}
+
+	const errorCallbackOnFrame = (err: Error) => {
+		reject(err);
+	};
+
+	const cleanupPageError = handleJavascriptException({
+		page: freePage,
+		onError: errorCallbackOnFrame,
+		frame,
+	});
+	freePage.on('error', errorCallbackOnFrame);
+
+	const startSeeking = Date.now();
+
+	await seekToFrame({
+		frame,
+		page: freePage,
+		composition: compId,
+		timeoutInMilliseconds,
+		indent,
+		logLevel,
+		attempt,
+	});
+
+	const timeToSeek = Date.now() - startSeeking;
+	if (timeToSeek > 1000) {
+		Log.verbose(
+			{indent, logLevel},
+			`Seeking to frame ${frame} took ${timeToSeek}ms`,
+		);
+	}
+
+	if (!outputDir && !onFrameBuffer && imageFormat !== 'none') {
+		throw new Error(
+			'Called renderFrames() without specifying either `outputDir` or `onFrameBuffer`',
+		);
+	}
+
+	if (outputDir && onFrameBuffer && imageFormat !== 'none') {
+		throw new Error(
+			'Pass either `outputDir` or `onFrameBuffer` to renderFrames(), not both.',
+		);
+	}
+
+	const id = startPerfMeasure('save');
+
+	const {buffer, collectedAssets} = await takeFrame({
+		frame,
+		freePage,
+		height,
+		imageFormat: assetsOnly ? 'none' : imageFormat,
+		output:
+			index === null
+				? null
+				: path.join(
+						frameDir,
+						getFrameOutputFileName({
+							frame,
+							imageFormat,
+							index,
+							countType,
+							lastFrame,
+							totalFrames: framesToRender.length,
+						}),
+					),
+		jpegQuality,
+		width,
+		scale,
+		wantsBuffer: Boolean(onFrameBuffer),
+		timeoutInMilliseconds,
+	});
+	if (onFrameBuffer && !assetsOnly) {
+		if (!buffer) {
+			throw new Error('unexpected null buffer');
+		}
+
+		onFrameBuffer(buffer, frame);
+	}
+
+	stopPerfMeasure(id);
+
+	const previousAudioRenderAssets = assets
+		.filter(truthy)
+		.map((a) => a.audioAndVideoAssets)
+		.flat(2);
+
+	const previousArtifactAssets = assets
+		.filter(truthy)
+		.map((a) => a.artifactAssets)
+		.flat(2);
+
+	const audioAndVideoAssets = onlyAudioAndVideoAssets(collectedAssets);
+	const artifactAssets = onlyArtifact(collectedAssets);
+
+	for (const artifact of artifactAssets) {
+		for (const previousArtifact of previousArtifactAssets) {
+			if (artifact.filename === previousArtifact.filename) {
+				reject(
+					new Error(
+						`An artifact with output "${artifact.filename}" was already registered at frame ${previousArtifact.frame}, but now registered again at frame ${artifact.frame}. Artifacts must have unique names. https://remotion.dev/docs/artifacts`,
+					),
+				);
+				return;
+			}
+		}
+
+		onArtifact?.(artifact);
+	}
+
+	const compressedAssets = audioAndVideoAssets.map((asset) => {
+		return compressAsset(previousAudioRenderAssets, asset);
+	});
+
+	assets.push({
+		audioAndVideoAssets: compressedAssets,
+		frame,
+		artifactAssets: artifactAssets.map((a) => {
+			return {
+				frame: a.frame,
+				filename: a.filename,
+			};
+		}),
+	});
+	for (const renderAsset of compressedAssets) {
+		downloadAndMapAssetsToFileUrl({
+			renderAsset,
+			onDownload,
+			downloadMap,
+			indent,
+			logLevel,
+			binariesDirectory,
+			cancelSignalForAudioAnalysis: cancelSignal,
+			shouldAnalyzeAudioImmediately: true,
+		}).catch((err) => {
+			const truncateWithEllipsis =
+				renderAsset.src.substring(0, 1000) +
+				(renderAsset.src.length > 1000 ? '...' : '');
+			onError(
+				new Error(
+					`Error while downloading ${truncateWithEllipsis}: ${(err as Error).stack}`,
+				),
+			);
+		});
+	}
+
+	cleanupPageError();
+	freePage.off('error', errorCallbackOnFrame);
+	pool.release(freePage);
+};

--- a/packages/renderer/src/render-frame.ts
+++ b/packages/renderer/src/render-frame.ts
@@ -1,73 +1,55 @@
-import path from 'path';
+import type {VideoConfig} from 'remotion/no-react';
 import type {RenderMediaOnDownload} from './assets/download-and-map-assets-to-file';
-import {downloadAndMapAssetsToFileUrl} from './assets/download-and-map-assets-to-file';
 import type {DownloadMap} from './assets/download-map';
 import type {Page} from './browser/BrowserPage';
-import {compressAsset} from './compress-assets';
-import {handleJavascriptException} from './error-handling/handle-javascript-exception';
-import {onlyArtifact, onlyAudioAndVideoAssets} from './filter-asset-types';
 import type {CountType} from './get-frame-padded-index';
-import {getFrameOutputFileName} from './get-frame-padded-index';
 import type {VideoImageFormat} from './image-format';
 import type {LogLevel} from './log-level';
-import {Log} from './logger';
 import type {CancelSignal} from './make-cancel-signal';
-import {startPerfMeasure, stopPerfMeasure} from './perf';
 import type {Pool} from './pool';
+import {renderFrameWithOptionToReject} from './render-frame-with-option-to-reject';
 import type {FrameAndAssets, OnArtifact} from './render-frames';
-import {seekToFrame} from './seek-to-frame';
-import {takeFrame} from './take-frame';
-import {truthy} from './truthy';
 
-export const renderFrameWithOptionToReject = async ({
+export const renderFrame = ({
 	frame,
 	index,
-	reject,
-	width,
-	height,
-	compId,
 	assetsOnly,
 	attempt,
-	poolPromise,
-	stoppedSignal,
-	indent,
-	logLevel,
-	timeoutInMilliseconds,
-	outputDir,
-	onFrameBuffer,
-	imageFormat,
-	onError,
-	lastFrame,
-	jpegQuality,
-	frameDir,
-	scale,
-	countType,
-	assets,
-	framesToRender,
-	onArtifact,
-	onDownload,
-	downloadMap,
 	binariesDirectory,
 	cancelSignal,
+	imageFormat,
+	indent,
+	logLevel,
+	poolPromise,
+	assets,
+	countType,
+	downloadMap,
+	frameDir,
+	framesToRender,
+	jpegQuality,
+	onArtifact,
+	onDownload,
+	scale,
+	composition,
+	onError,
+	outputDir,
+	stoppedSignal,
+	timeoutInMilliseconds,
+	lastFrame,
+	onFrameBuffer,
+	onFrameUpdate,
+	framesRenderedObj,
 }: {
 	frame: number;
 	index: number | null;
-	reject: (err: Error) => void;
-	width: number;
-	height: number;
-	compId: string;
 	assetsOnly: boolean;
 	attempt: number;
-	poolPromise: Promise<Pool<Page>>;
-	stoppedSignal: {stopped: boolean};
-	timeoutInMilliseconds: number;
 	indent: boolean;
 	logLevel: LogLevel;
-	outputDir: string | null;
-	onFrameBuffer: null | ((buffer: Buffer, frame: number) => void) | undefined;
 	imageFormat: VideoImageFormat;
-	onError: (err: Error) => void;
-	lastFrame: number;
+	cancelSignal: CancelSignal | undefined;
+	binariesDirectory: string | null;
+	poolPromise: Promise<Pool<Page>>;
 	jpegQuality: number;
 	frameDir: string;
 	scale: number;
@@ -77,161 +59,70 @@ export const renderFrameWithOptionToReject = async ({
 	onArtifact: OnArtifact | null;
 	onDownload: RenderMediaOnDownload | null;
 	downloadMap: DownloadMap;
-	binariesDirectory: string | null;
-	cancelSignal: CancelSignal | undefined;
+	composition: Omit<VideoConfig, 'defaultProps' | 'props'>;
+	onError: (err: Error) => void;
+	stoppedSignal: {stopped: boolean};
+	timeoutInMilliseconds: number;
+	outputDir: string | null;
+	onFrameBuffer: null | ((buffer: Buffer, frame: number) => void) | undefined;
+	lastFrame: number;
+	onFrameUpdate:
+		| null
+		| ((
+				framesRendered: number,
+				frameIndex: number,
+				timeToRenderInMilliseconds: number,
+		  ) => void);
+	framesRenderedObj: {count: number};
 }) => {
-	const pool = await poolPromise;
-	const freePage = await pool.acquire();
+	return new Promise<void>((resolve, reject) => {
+		const startTime = performance.now();
 
-	if (stoppedSignal.stopped) {
-		return reject(new Error('Render was stopped'));
-	}
-
-	const errorCallbackOnFrame = (err: Error) => {
-		reject(err);
-	};
-
-	const cleanupPageError = handleJavascriptException({
-		page: freePage,
-		onError: errorCallbackOnFrame,
-		frame,
-	});
-	freePage.on('error', errorCallbackOnFrame);
-
-	const startSeeking = Date.now();
-
-	await seekToFrame({
-		frame,
-		page: freePage,
-		composition: compId,
-		timeoutInMilliseconds,
-		indent,
-		logLevel,
-		attempt,
-	});
-
-	const timeToSeek = Date.now() - startSeeking;
-	if (timeToSeek > 1000) {
-		Log.verbose(
-			{indent, logLevel},
-			`Seeking to frame ${frame} took ${timeToSeek}ms`,
-		);
-	}
-
-	if (!outputDir && !onFrameBuffer && imageFormat !== 'none') {
-		throw new Error(
-			'Called renderFrames() without specifying either `outputDir` or `onFrameBuffer`',
-		);
-	}
-
-	if (outputDir && onFrameBuffer && imageFormat !== 'none') {
-		throw new Error(
-			'Pass either `outputDir` or `onFrameBuffer` to renderFrames(), not both.',
-		);
-	}
-
-	const id = startPerfMeasure('save');
-
-	const {buffer, collectedAssets} = await takeFrame({
-		frame,
-		freePage,
-		height,
-		imageFormat: assetsOnly ? 'none' : imageFormat,
-		output:
-			index === null
-				? null
-				: path.join(
-						frameDir,
-						getFrameOutputFileName({
-							frame,
-							imageFormat,
-							index,
-							countType,
-							lastFrame,
-							totalFrames: framesToRender.length,
-						}),
-					),
-		jpegQuality,
-		width,
-		scale,
-		wantsBuffer: Boolean(onFrameBuffer),
-		timeoutInMilliseconds,
-	});
-	if (onFrameBuffer && !assetsOnly) {
-		if (!buffer) {
-			throw new Error('unexpected null buffer');
-		}
-
-		onFrameBuffer(buffer, frame);
-	}
-
-	stopPerfMeasure(id);
-
-	const previousAudioRenderAssets = assets
-		.filter(truthy)
-		.map((a) => a.audioAndVideoAssets)
-		.flat(2);
-
-	const previousArtifactAssets = assets
-		.filter(truthy)
-		.map((a) => a.artifactAssets)
-		.flat(2);
-
-	const audioAndVideoAssets = onlyAudioAndVideoAssets(collectedAssets);
-	const artifactAssets = onlyArtifact(collectedAssets);
-
-	for (const artifact of artifactAssets) {
-		for (const previousArtifact of previousArtifactAssets) {
-			if (artifact.filename === previousArtifact.filename) {
-				reject(
-					new Error(
-						`An artifact with output "${artifact.filename}" was already registered at frame ${previousArtifact.frame}, but now registered again at frame ${artifact.frame}. Artifacts must have unique names. https://remotion.dev/docs/artifacts`,
-					),
-				);
-				return;
-			}
-		}
-
-		onArtifact?.(artifact);
-	}
-
-	const compressedAssets = audioAndVideoAssets.map((asset) => {
-		return compressAsset(previousAudioRenderAssets, asset);
-	});
-
-	assets.push({
-		audioAndVideoAssets: compressedAssets,
-		frame,
-		artifactAssets: artifactAssets.map((a) => {
-			return {
-				frame: a.frame,
-				filename: a.filename,
-			};
-		}),
-	});
-	for (const renderAsset of compressedAssets) {
-		downloadAndMapAssetsToFileUrl({
-			renderAsset,
-			onDownload,
-			downloadMap,
+		renderFrameWithOptionToReject({
+			frame,
+			index,
+			reject,
+			width: composition.width,
+			height: composition.height,
+			compId: composition.id,
+			assetsOnly,
+			attempt,
 			indent,
 			logLevel,
+			poolPromise,
+			stoppedSignal,
+			timeoutInMilliseconds,
+			imageFormat,
+			onFrameBuffer,
+			outputDir,
+			assets,
 			binariesDirectory,
-			cancelSignalForAudioAnalysis: cancelSignal,
-			shouldAnalyzeAudioImmediately: true,
-		}).catch((err) => {
-			const truncateWithEllipsis =
-				renderAsset.src.substring(0, 1000) +
-				(renderAsset.src.length > 1000 ? '...' : '');
-			onError(
-				new Error(
-					`Error while downloading ${truncateWithEllipsis}: ${(err as Error).stack}`,
-				),
-			);
-		});
-	}
+			cancelSignal,
+			countType,
+			downloadMap,
+			frameDir,
+			framesToRender,
+			jpegQuality,
+			lastFrame,
+			onArtifact,
+			onDownload,
+			onError,
+			scale,
+		})
+			.then(() => {
+				if (!assetsOnly) {
+					framesRenderedObj.count++;
+					onFrameUpdate?.(
+						framesRenderedObj.count,
+						frame,
+						performance.now() - startTime,
+					);
+				}
 
-	cleanupPageError();
-	freePage.off('error', errorCallbackOnFrame);
-	pool.release(freePage);
+				resolve();
+			})
+			.catch((err) => {
+				reject(err);
+			});
+	});
 };

--- a/packages/renderer/src/render-frame.ts
+++ b/packages/renderer/src/render-frame.ts
@@ -1,0 +1,237 @@
+import path from 'path';
+import type {RenderMediaOnDownload} from './assets/download-and-map-assets-to-file';
+import {downloadAndMapAssetsToFileUrl} from './assets/download-and-map-assets-to-file';
+import type {DownloadMap} from './assets/download-map';
+import type {Page} from './browser/BrowserPage';
+import {compressAsset} from './compress-assets';
+import {handleJavascriptException} from './error-handling/handle-javascript-exception';
+import {onlyArtifact, onlyAudioAndVideoAssets} from './filter-asset-types';
+import type {CountType} from './get-frame-padded-index';
+import {getFrameOutputFileName} from './get-frame-padded-index';
+import type {VideoImageFormat} from './image-format';
+import type {LogLevel} from './log-level';
+import {Log} from './logger';
+import type {CancelSignal} from './make-cancel-signal';
+import {startPerfMeasure, stopPerfMeasure} from './perf';
+import type {Pool} from './pool';
+import type {FrameAndAssets, OnArtifact} from './render-frames';
+import {seekToFrame} from './seek-to-frame';
+import {takeFrame} from './take-frame';
+import {truthy} from './truthy';
+
+export const renderFrameWithOptionToReject = async ({
+	frame,
+	index,
+	reject,
+	width,
+	height,
+	compId,
+	assetsOnly,
+	attempt,
+	poolPromise,
+	stoppedSignal,
+	indent,
+	logLevel,
+	timeoutInMilliseconds,
+	outputDir,
+	onFrameBuffer,
+	imageFormat,
+	onError,
+	lastFrame,
+	jpegQuality,
+	frameDir,
+	scale,
+	countType,
+	assets,
+	framesToRender,
+	onArtifact,
+	onDownload,
+	downloadMap,
+	binariesDirectory,
+	cancelSignal,
+}: {
+	frame: number;
+	index: number | null;
+	reject: (err: Error) => void;
+	width: number;
+	height: number;
+	compId: string;
+	assetsOnly: boolean;
+	attempt: number;
+	poolPromise: Promise<Pool<Page>>;
+	stoppedSignal: {stopped: boolean};
+	timeoutInMilliseconds: number;
+	indent: boolean;
+	logLevel: LogLevel;
+	outputDir: string | null;
+	onFrameBuffer: null | ((buffer: Buffer, frame: number) => void) | undefined;
+	imageFormat: VideoImageFormat;
+	onError: (err: Error) => void;
+	lastFrame: number;
+	jpegQuality: number;
+	frameDir: string;
+	scale: number;
+	countType: CountType;
+	assets: FrameAndAssets[];
+	framesToRender: number[];
+	onArtifact: OnArtifact | null;
+	onDownload: RenderMediaOnDownload | null;
+	downloadMap: DownloadMap;
+	binariesDirectory: string | null;
+	cancelSignal: CancelSignal | undefined;
+}) => {
+	const pool = await poolPromise;
+	const freePage = await pool.acquire();
+
+	if (stoppedSignal.stopped) {
+		return reject(new Error('Render was stopped'));
+	}
+
+	const errorCallbackOnFrame = (err: Error) => {
+		reject(err);
+	};
+
+	const cleanupPageError = handleJavascriptException({
+		page: freePage,
+		onError: errorCallbackOnFrame,
+		frame,
+	});
+	freePage.on('error', errorCallbackOnFrame);
+
+	const startSeeking = Date.now();
+
+	await seekToFrame({
+		frame,
+		page: freePage,
+		composition: compId,
+		timeoutInMilliseconds,
+		indent,
+		logLevel,
+		attempt,
+	});
+
+	const timeToSeek = Date.now() - startSeeking;
+	if (timeToSeek > 1000) {
+		Log.verbose(
+			{indent, logLevel},
+			`Seeking to frame ${frame} took ${timeToSeek}ms`,
+		);
+	}
+
+	if (!outputDir && !onFrameBuffer && imageFormat !== 'none') {
+		throw new Error(
+			'Called renderFrames() without specifying either `outputDir` or `onFrameBuffer`',
+		);
+	}
+
+	if (outputDir && onFrameBuffer && imageFormat !== 'none') {
+		throw new Error(
+			'Pass either `outputDir` or `onFrameBuffer` to renderFrames(), not both.',
+		);
+	}
+
+	const id = startPerfMeasure('save');
+
+	const {buffer, collectedAssets} = await takeFrame({
+		frame,
+		freePage,
+		height,
+		imageFormat: assetsOnly ? 'none' : imageFormat,
+		output:
+			index === null
+				? null
+				: path.join(
+						frameDir,
+						getFrameOutputFileName({
+							frame,
+							imageFormat,
+							index,
+							countType,
+							lastFrame,
+							totalFrames: framesToRender.length,
+						}),
+					),
+		jpegQuality,
+		width,
+		scale,
+		wantsBuffer: Boolean(onFrameBuffer),
+		timeoutInMilliseconds,
+	});
+	if (onFrameBuffer && !assetsOnly) {
+		if (!buffer) {
+			throw new Error('unexpected null buffer');
+		}
+
+		onFrameBuffer(buffer, frame);
+	}
+
+	stopPerfMeasure(id);
+
+	const previousAudioRenderAssets = assets
+		.filter(truthy)
+		.map((a) => a.audioAndVideoAssets)
+		.flat(2);
+
+	const previousArtifactAssets = assets
+		.filter(truthy)
+		.map((a) => a.artifactAssets)
+		.flat(2);
+
+	const audioAndVideoAssets = onlyAudioAndVideoAssets(collectedAssets);
+	const artifactAssets = onlyArtifact(collectedAssets);
+
+	for (const artifact of artifactAssets) {
+		for (const previousArtifact of previousArtifactAssets) {
+			if (artifact.filename === previousArtifact.filename) {
+				reject(
+					new Error(
+						`An artifact with output "${artifact.filename}" was already registered at frame ${previousArtifact.frame}, but now registered again at frame ${artifact.frame}. Artifacts must have unique names. https://remotion.dev/docs/artifacts`,
+					),
+				);
+				return;
+			}
+		}
+
+		onArtifact?.(artifact);
+	}
+
+	const compressedAssets = audioAndVideoAssets.map((asset) => {
+		return compressAsset(previousAudioRenderAssets, asset);
+	});
+
+	assets.push({
+		audioAndVideoAssets: compressedAssets,
+		frame,
+		artifactAssets: artifactAssets.map((a) => {
+			return {
+				frame: a.frame,
+				filename: a.filename,
+			};
+		}),
+	});
+	for (const renderAsset of compressedAssets) {
+		downloadAndMapAssetsToFileUrl({
+			renderAsset,
+			onDownload,
+			downloadMap,
+			indent,
+			logLevel,
+			binariesDirectory,
+			cancelSignalForAudioAnalysis: cancelSignal,
+			shouldAnalyzeAudioImmediately: true,
+		}).catch((err) => {
+			const truncateWithEllipsis =
+				renderAsset.src.substring(0, 1000) +
+				(renderAsset.src.length > 1000 ? '...' : '');
+			onError(
+				new Error(
+					`Error while downloading ${truncateWithEllipsis}: ${(err as Error).stack}`,
+				),
+			);
+		});
+	}
+
+	cleanupPageError();
+	freePage.off('error', errorCallbackOnFrame);
+	pool.release(freePage);
+};


### PR DESCRIPTION
Will make the next refactor easier