### PR TITLE
`@remotion/cli`: Don't print Git error when getting Git source

### DIFF
--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -95,7 +95,7 @@ export const bundleCommand = async (
 		rmSync(outputPath, {recursive: true});
 	}
 
-	const gitSource = getGitSource({remotionRoot, disableGitSource});
+	const gitSource = getGitSource({remotionRoot, disableGitSource, logLevel});
 
 	const output = await bundleOnCli({
 		fullPath: file,

--- a/packages/cli/src/get-github-repository.ts
+++ b/packages/cli/src/get-github-repository.ts
@@ -1,8 +1,10 @@
 import {BundlerInternals} from '@remotion/bundler';
+import type {LogLevel} from '@remotion/renderer';
 import type {GitSource} from '@remotion/studio-shared';
 import {execSync} from 'child_process';
 import {existsSync, readFileSync} from 'fs';
 import path from 'path';
+import {Log} from './log';
 
 export type ParsedGitRemote = {
 	type: 'github';
@@ -96,10 +98,16 @@ export const normalizeGitRemoteUrl = (url: string): ParsedGitRemote | null => {
 	return null;
 };
 
-export const getGifRef = (): string | null => {
+export const getGifRef = (logLevel: LogLevel): string | null => {
 	try {
-		return execSync('git rev-parse --abbrev-ref HEAD').toString('utf-8').trim();
-	} catch {
+		const ret = execSync('git rev-parse --abbrev-ref HEAD', {
+			stdio: ['ignore', 'pipe', 'ignore'],
+		})
+			.toString('utf-8')
+			.trim();
+		return ret;
+	} catch (err) {
+		Log.verbose({logLevel, indent: false}, 'Could not get git ref', err);
 		return null;
 	}
 };
@@ -132,9 +140,11 @@ const getFromEnvVariables = (): GitSource | null => {
 export const getGitSource = ({
 	remotionRoot,
 	disableGitSource,
+	logLevel,
 }: {
 	remotionRoot: string;
 	disableGitSource: boolean;
+	logLevel: LogLevel;
 }): GitSource | null => {
 	if (disableGitSource) {
 		return null;
@@ -145,7 +155,7 @@ export const getGitSource = ({
 		return getFromEnvVariables();
 	}
 
-	const ref = getGifRef();
+	const ref = getGifRef(logLevel);
 	if (!ref) {
 		return null;
 	}

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -109,7 +109,7 @@ export const studioCommand = async (
 		commandLine: parsedCli,
 	}).value;
 
-	const gitSource = getGitSource({remotionRoot, disableGitSource});
+	const gitSource = getGitSource({remotionRoot, disableGitSource, logLevel});
 
 	await StudioServerInternals.startStudio({
 		previewEntry: require.resolve('@remotion/studio/entry'),

--- a/packages/cli/src/test/get-github-repo.test.ts
+++ b/packages/cli/src/test/get-github-repo.test.ts
@@ -49,13 +49,14 @@ test('Should normalize HTTPS URLs without .git', () => {
 });
 
 test('Should get Gif Ref', () => {
-	expect(typeof getGifRef() === 'string').toBe(true);
+	expect(typeof getGifRef('info') === 'string').toBe(true);
 });
 
 test('Should get Git Source', () => {
 	const git = getGitSource({
 		remotionRoot: process.cwd(),
 		disableGitSource: false,
+		logLevel: 'info',
 	});
 	expect(git).not.toBeNull();
 	expect(git?.relativeFromGitRoot).toBe(`packages${path.sep}cli`);
@@ -70,6 +71,7 @@ test('Should recognize VERCEL', () => {
 	const source = getGitSource({
 		remotionRoot: 'dontmatter',
 		disableGitSource: false,
+		logLevel: 'info',
 	});
 	expect(source).not.toBeNull();
 	expect(source?.name).toBe('remotion');

--- a/packages/cloudrun/src/cli/commands/sites/create.ts
+++ b/packages/cloudrun/src/cli/commands/sites/create.ts
@@ -143,7 +143,11 @@ export const sitesCreateSubcommand = async (
 			commandLine: CliInternals.parsedCli,
 		}).value;
 
-	const gitSource = CliInternals.getGitSource({remotionRoot, disableGitSource});
+	const gitSource = CliInternals.getGitSource({
+		remotionRoot,
+		disableGitSource,
+		logLevel,
+	});
 
 	const {serveUrl, siteName, stats} = await internalDeploySiteRaw({
 		entryPoint: file,

--- a/packages/lambda/src/cli/commands/sites/create.ts
+++ b/packages/lambda/src/cli/commands/sites/create.ts
@@ -163,7 +163,11 @@ export const sitesCreateSubcommand = async (
 		commandLine: CliInternals.parsedCli,
 	}).value;
 
-	const gitSource = CliInternals.getGitSource({remotionRoot, disableGitSource});
+	const gitSource = CliInternals.getGitSource({
+		remotionRoot,
+		disableGitSource,
+		logLevel,
+	});
 
 	const {serveUrl, siteName, stats} = await LambdaInternals.internalDeploySite({
 		entryPoint: file,


### PR DESCRIPTION
This would print a warning in StackBlitz