### PR TITLE
Make timeline controls accessible on mobile

### DIFF
--- a/packages/studio/src/components/FpsCounter.tsx
+++ b/packages/studio/src/components/FpsCounter.tsx
@@ -11,6 +11,7 @@ const label: React.CSSProperties = {
 	color: 'white',
 	fontSize: 15,
 	fontFamily: 'Arial, Helvetica, sans-serif',
+	whiteSpace: 'nowrap',
 };
 
 const pushWithMaxSize = (

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -1,7 +1,7 @@
-import React, {useContext, useState} from 'react';
+import React, {useContext, useEffect, useRef, useState} from 'react';
 import {Internals} from 'remotion';
 import {checkFullscreenSupport} from '../helpers/check-fullscreen-support';
-import {BACKGROUND} from '../helpers/colors';
+import {BACKGROUND, BACKGROUND__TRANSPARENT} from '../helpers/colors';
 import {
 	useIsStill,
 	useIsVideoComposition,
@@ -37,8 +37,30 @@ const container: React.CSSProperties = {
 
 const mobileContainer: React.CSSProperties = {
 	...container,
+	position: 'relative',
 	overflowY: 'auto',
 	justifyContent: 'flex-start',
+};
+const scrollIndicatorLeft: React.CSSProperties = {
+	position: 'fixed',
+	display: 'none',
+	top: 0,
+	left: 0,
+	width: 40,
+	height: '100%',
+	pointerEvents: 'none',
+	background: `linear-gradient(to right, ${BACKGROUND}, ${BACKGROUND__TRANSPARENT})`,
+};
+
+const scrollIndicatorRight: React.CSSProperties = {
+	position: 'fixed',
+	display: 'none',
+	top: 0,
+	right: 0,
+	width: 40,
+	height: '100%',
+	pointerEvents: 'none',
+	background: `linear-gradient(to left, ${BACKGROUND}, ${BACKGROUND__TRANSPARENT})`,
 };
 
 const sideContainer: React.CSSProperties = {
@@ -64,6 +86,10 @@ export const PreviewToolbar: React.FC<{
 	const {mediaMuted} = useContext(Internals.MediaVolumeContext);
 	const {setMediaMuted} = useContext(Internals.SetMediaVolumeContext);
 	const isVideoComposition = useIsVideoComposition();
+	const previewToolbarRef = useRef<HTMLDivElement | null>(null);
+	const leftScrollIndicatorRef = useRef<HTMLDivElement | null>(null);
+	const rightScrollIndicatorRef = useRef<HTMLDivElement | null>(null);
+
 	const isStill = useIsStill();
 
 	const [loop, setLoop] = useState(loadLoopOption());
@@ -72,11 +98,67 @@ export const PreviewToolbar: React.FC<{
 
 	const isMobileLayout = useMobileLayout();
 
+	useEffect(() => {
+		if (isMobileLayout && previewToolbarRef.current) {
+			const updateScrollableIndicatorProps = (target: HTMLDivElement) => {
+				const boundingBox = target.getBoundingClientRect();
+				const {scrollLeft, scrollWidth, clientWidth} = target;
+				const scrollRight = scrollWidth - clientWidth - scrollLeft;
+				if (
+					!leftScrollIndicatorRef.current ||
+					!rightScrollIndicatorRef.current
+				) {
+					return;
+				}
+
+				if (scrollLeft !== 0) {
+					Object.assign(leftScrollIndicatorRef.current.style, {
+						display: 'block',
+						height: `${boundingBox.height}px`,
+						top: `${boundingBox.top}px`,
+						left: `${boundingBox.left}px`,
+					});
+				} else {
+					Object.assign(leftScrollIndicatorRef.current.style, {
+						display: 'none',
+					});
+				}
+
+				if (scrollRight !== 0) {
+					const itemWidth = rightScrollIndicatorRef.current?.clientWidth || 0;
+					Object.assign(rightScrollIndicatorRef.current.style, {
+						display: 'block',
+						height: `${boundingBox.height}px`,
+						top: `${boundingBox.top}px`,
+						left: `${boundingBox.left + boundingBox.width - itemWidth}px`,
+					});
+				} else {
+					Object.assign(rightScrollIndicatorRef.current.style, {
+						display: 'none',
+					});
+				}
+			};
+
+			const previewToolbar = previewToolbarRef.current;
+			const scrollHandler = () => {
+				updateScrollableIndicatorProps(previewToolbar);
+			};
+
+			previewToolbar.addEventListener('scroll', scrollHandler);
+			scrollHandler();
+			return () => {
+				previewToolbar.removeEventListener('scroll', scrollHandler);
+			};
+		}
+	});
+
 	return (
 		<div
+			ref={previewToolbarRef}
 			style={isMobileLayout ? mobileContainer : container}
 			className="css-reset"
 		>
+			<div ref={leftScrollIndicatorRef} style={scrollIndicatorLeft} />
 			{isMobileLayout ? null : (
 				<>
 					<div style={sideContainer}>
@@ -136,6 +218,7 @@ export const PreviewToolbar: React.FC<{
 			</div>
 			<PlaybackKeyboardShortcutsManager setPlaybackRate={setPlaybackRate} />
 			<PlaybackRatePersistor />
+			<div ref={rightScrollIndicatorRef} style={scrollIndicatorRight} />
 		</div>
 	);
 };

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -6,6 +6,7 @@ import {
 	useIsStill,
 	useIsVideoComposition,
 } from '../helpers/is-current-selected-still';
+import {useMobileLayout} from '../helpers/mobile-layout';
 import {TIMELINE_PADDING} from '../helpers/timeline-layout';
 import {loadLoopOption} from '../state/loop';
 import {CheckboardToggle} from './CheckboardToggle';
@@ -32,6 +33,12 @@ const container: React.CSSProperties = {
 	alignItems: 'center',
 	flexDirection: 'row',
 	background: BACKGROUND,
+};
+
+const mobileContainer: React.CSSProperties = {
+	...container,
+	overflow: 'auto',
+	justifyContent: 'flex-start',
 };
 
 const sideContainer: React.CSSProperties = {
@@ -63,20 +70,30 @@ export const PreviewToolbar: React.FC<{
 
 	const isFullscreenSupported = checkFullscreenSupport();
 
+	const isMobileLayout = useMobileLayout();
+
 	return (
-		<div style={container} className="css-reset">
-			<div style={sideContainer}>
-				<div style={padding} />
-				<TimelineZoomControls />
-			</div>
-			<Flex />
-			<SizeSelector />
-			{isStill || isVideoComposition ? (
-				<PlaybackRateSelector
-					setPlaybackRate={setPlaybackRate}
-					playbackRate={playbackRate}
-				/>
-			) : null}
+		<div
+			style={isMobileLayout ? mobileContainer : container}
+			className="css-reset"
+		>
+			{isMobileLayout ? null : (
+				<>
+					<div style={sideContainer}>
+						<div style={padding} />
+						<TimelineZoomControls />
+					</div>
+					<Flex />
+					<SizeSelector />
+					{isStill || isVideoComposition ? (
+						<PlaybackRateSelector
+							setPlaybackRate={setPlaybackRate}
+							playbackRate={playbackRate}
+						/>
+					) : null}
+				</>
+			)}
+
 			{isVideoComposition ? (
 				<>
 					<Spacing x={2} />
@@ -85,7 +102,7 @@ export const PreviewToolbar: React.FC<{
 						loop={loop}
 						playbackRate={playbackRate}
 					/>
-					<Spacing x={2} />
+					<Spacing x={isMobileLayout ? 12 : 2} />
 					<LoopToggle loop={loop} setLoop={setLoop} />
 					<MuteToggle muted={mediaMuted} setMuted={setMediaMuted} />
 					<Spacing x={2} />
@@ -93,10 +110,23 @@ export const PreviewToolbar: React.FC<{
 					<Spacing x={2} />
 				</>
 			) : null}
+
 			<CheckboardToggle />
 			<Spacing x={1} />
 			{isFullscreenSupported && <FullScreenToggle />}
 			<Flex />
+			{isMobileLayout && (
+				<>
+					<Flex />
+					<SizeSelector />
+					{isStill || isVideoComposition ? (
+						<PlaybackRateSelector
+							setPlaybackRate={setPlaybackRate}
+							playbackRate={playbackRate}
+						/>
+					) : null}
+				</>
+			)}
 			<div style={sideContainer}>
 				<Flex />
 				<FpsCounter playbackSpeed={playbackRate} />

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -37,7 +37,7 @@ const container: React.CSSProperties = {
 
 const mobileContainer: React.CSSProperties = {
 	...container,
-	overflow: 'auto',
+	overflowY: 'auto',
 	justifyContent: 'flex-start',
 };
 
@@ -102,7 +102,7 @@ export const PreviewToolbar: React.FC<{
 						loop={loop}
 						playbackRate={playbackRate}
 					/>
-					<Spacing x={isMobileLayout ? 12 : 2} />
+					<Spacing x={2} />
 					<LoopToggle loop={loop} setLoop={setLoop} />
 					<MuteToggle muted={mediaMuted} setMuted={setMediaMuted} />
 					<Spacing x={2} />
@@ -129,7 +129,7 @@ export const PreviewToolbar: React.FC<{
 			)}
 			<div style={sideContainer}>
 				<Flex />
-				<FpsCounter playbackSpeed={playbackRate} />
+				{!isMobileLayout && <FpsCounter playbackSpeed={playbackRate} />}
 				<Spacing x={2} />
 				{readOnlyStudio ? null : <RenderButton />}
 				<Spacing x={1.5} />


### PR DESCRIPTION
UI update

Old UI 

<img width="380" alt="Screenshot 2025-02-07 at 11 55 04 PM" src="https://github.com/user-attachments/assets/0c4113a1-9d1b-4bda-9840-9640beccd746" />


New UI
<img width="366" alt="Screenshot 2025-02-07 at 11 34 43 PM" src="https://github.com/user-attachments/assets/4a2a280d-6713-4193-a95d-763e13df9133" />
<img width="391" alt="Screenshot 2025-02-07 at 11 34 47 PM" src="https://github.com/user-attachments/assets/02b94271-bad2-41a2-8861-3580eb8875fe" />


Changes
1. Remove Timeline Zoom Slider in mobile
2. Show playback control on left.
3. Move all other controls to the right and make the control panel scrollable.
