### PR TITLE
`@remotion/renderer`: Be more lenient with floating point-based rounding issues when using `scale` parameter

### DIFF
--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -374,6 +374,8 @@ export const renderVideoFlow = async ({
 		codec,
 		scale,
 		wantsImageSequence: shouldOutputImageSequence,
+		indent,
+		logLevel,
 	});
 
 	const relativeOutputLocation = getOutputFilename({

--- a/packages/renderer/src/prespawn-ffmpeg.ts
+++ b/packages/renderer/src/prespawn-ffmpeg.ts
@@ -78,6 +78,8 @@ export const prespawnFfmpeg = (options: PreStitcherOptions) => {
 		codec,
 		scale: 1,
 		wantsImageSequence: false,
+		indent: options.indent,
+		logLevel: options.logLevel,
 	});
 	const pixelFormat = options.pixelFormat ?? DEFAULT_PIXEL_FORMAT;
 

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -431,6 +431,8 @@ const internalRenderMediaRaw = ({
 		scale,
 		width: composition.width,
 		wantsImageSequence: false,
+		indent,
+		logLevel,
 	});
 
 	const realFrameRange = getRealFrameRange(

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -150,6 +150,8 @@ const innerStitchFramesToVideo = async (
 		codec,
 		scale: 1,
 		wantsImageSequence: false,
+		indent,
+		logLevel,
 	});
 	validateSelectedCodecAndProResCombination({
 		codec,

--- a/packages/renderer/src/validate-even-dimensions-with-codec.ts
+++ b/packages/renderer/src/validate-even-dimensions-with-codec.ts
@@ -1,4 +1,6 @@
 import type {Codec} from './codec';
+import type {LogLevel} from './log-level';
+import {Log} from './logger';
 import {truthy} from './truthy';
 
 export const validateEvenDimensionsWithCodec = ({
@@ -7,12 +9,16 @@ export const validateEvenDimensionsWithCodec = ({
 	codec,
 	scale,
 	wantsImageSequence,
+	indent,
+	logLevel,
 }: {
 	width: number;
 	height: number;
 	scale: number;
 	codec: Codec;
 	wantsImageSequence: boolean;
+	indent: boolean;
+	logLevel: LogLevel;
 }) => {
 	if (wantsImageSequence) {
 		return;
@@ -27,8 +33,29 @@ export const validateEvenDimensionsWithCodec = ({
 		return;
 	}
 
-	const actualWidth = width * scale;
-	const actualHeight = height * scale;
+	let actualWidth = width * scale;
+	let actualHeight = height * scale;
+	if (
+		actualWidth % 1 !== 0 &&
+		(actualWidth % 1 < 0.005 || actualWidth % 1 > 0.005)
+	) {
+		Log.verbose(
+			{indent, logLevel},
+			`Rounding width to an even number from ${actualWidth} to ${Math.round(actualWidth)}`,
+		);
+		actualWidth = Math.round(actualWidth);
+	}
+
+	if (
+		actualHeight % 1 !== 0 &&
+		(actualHeight % 1 < 0.005 || actualHeight % 1 > 0.005)
+	) {
+		Log.verbose(
+			{indent, logLevel},
+			`Rounding height to an even number from ${actualHeight} to ${Math.round(actualHeight)}`,
+		);
+		actualHeight = Math.round(actualHeight);
+	}
 
 	const displayName = codec === 'h265' ? 'H265' : 'H264';
 


### PR DESCRIPTION
`@remotion/renderer`: Be more lenient with floating point-based rounding issues when using `scale` parameter