### PR TITLE
`@remotion/lambda`: Validate the input of `speculateFunctionName()`

### DIFF
--- a/packages/lambda-client/src/index.ts
+++ b/packages/lambda-client/src/index.ts
@@ -49,6 +49,7 @@ import {
 	renderMediaOnLambdaOptionalToRequired,
 } from './render-media-on-lambda';
 import {runtimePreferenceOptions} from './runtime-preference';
+import {innerSpeculateFunctionName} from './speculate-function-name';
 import {validateAwsRegion} from './validate-aws-region';
 import {parseBucketName} from './validate-bucketname';
 import {validateDiskSizeInMb} from './validate-disk-size-in-mb';
@@ -144,4 +145,5 @@ export const LambdaClientInternals = {
 	cleanItems,
 	makeLambdaRenderStillPayload,
 	getRenderProgressPayload,
+	innerSpeculateFunctionName,
 };

--- a/packages/lambda-client/src/speculate-function-name.ts
+++ b/packages/lambda-client/src/speculate-function-name.ts
@@ -7,6 +7,20 @@ export type SpeculateFunctionNameInput = {
 	timeoutInSeconds: string | number;
 };
 
+export const innerSpeculateFunctionName = ({
+	diskSizeInMb,
+	memorySizeInMb,
+	timeoutInSeconds,
+}: SpeculateFunctionNameInput) => {
+	// No validation here, used in find-function-name.ts
+	return [
+		`${RENDER_FN_PREFIX}${LAMBDA_VERSION_STRING}`,
+		`mem${memorySizeInMb}mb`,
+		`disk${diskSizeInMb}mb`,
+		`${timeoutInSeconds}sec`,
+	].join('-');
+};
+
 /*
  * @description Speculate the name of the Lambda function that will be created by `deployFunction()` or its CLI equivalent, based on the function configuration.
  * @see [Documentation](https://remotion.dev/docs/lambda/speculatefunctionname)
@@ -16,12 +30,31 @@ export const speculateFunctionName = ({
 	diskSizeInMb,
 	timeoutInSeconds,
 }: SpeculateFunctionNameInput) => {
-	// find-function-name.ts uses this for templating
-	// consider this before adding any validation here
-	return [
-		`${RENDER_FN_PREFIX}${LAMBDA_VERSION_STRING}`,
-		`mem${memorySizeInMb}mb`,
-		`disk${diskSizeInMb}mb`,
-		`${timeoutInSeconds}sec`,
-	].join('-');
+	const memorySize = Number(memorySizeInMb);
+	const diskSize = Number(diskSizeInMb);
+	const timeout = Number(timeoutInSeconds);
+
+	if (!Number.isInteger(memorySize) || memorySize <= 0) {
+		throw new Error(
+			`Memory size must be a positive integer. Received: ${memorySizeInMb}`,
+		);
+	}
+
+	if (!Number.isInteger(diskSize) || diskSize <= 0) {
+		throw new Error(
+			`Disk size must be a positive integer. Received: ${diskSizeInMb}`,
+		);
+	}
+
+	if (!Number.isInteger(timeout) || timeout <= 0) {
+		throw new Error(
+			`Timeout must be a positive integer. Received: ${timeoutInSeconds}`,
+		);
+	}
+
+	return innerSpeculateFunctionName({
+		diskSizeInMb,
+		memorySizeInMb,
+		timeoutInSeconds,
+	});
 };

--- a/packages/lambda/src/cli/helpers/find-function-name.ts
+++ b/packages/lambda/src/cli/helpers/find-function-name.ts
@@ -1,4 +1,4 @@
-import {AwsProvider, speculateFunctionName} from '@remotion/lambda-client';
+import {AwsProvider, LambdaClientInternals} from '@remotion/lambda-client';
 import type {LogLevel, LogOptions} from '@remotion/renderer';
 import {ProviderSpecifics} from '@remotion/serverless';
 import {VERSION} from 'remotion/version';
@@ -40,7 +40,7 @@ export const findFunctionName = async ({
 		if (!compatibleFunctionExists) {
 			Log.warn(
 				{indent: false, logLevel},
-				`Function "${cliFlag}" does not match naming convention ${speculateFunctionName({diskSizeInMb: '[disk]', memorySizeInMb: '[memory]', timeoutInSeconds: '[timeout]'})}.`,
+				`Function "${cliFlag}" does not match naming convention ${LambdaClientInternals.innerSpeculateFunctionName({diskSizeInMb: '[disk]', memorySizeInMb: '[memory]', timeoutInSeconds: '[timeout]'})}.`,
 			);
 			Log.warn(
 				{indent: false, logLevel},


### PR DESCRIPTION
`@remotion/lambda`: Validate the input of `speculateFunctionName()`