### PR TITLE
Next.js templates: Fix importing TIMEOUT from wrong location

### DIFF
--- a/packages/template-next-app-tailwind/src/app/api/lambda/progress/route.ts
+++ b/packages/template-next-app-tailwind/src/app/api/lambda/progress/route.ts
@@ -3,8 +3,7 @@ import {
   AwsRegion,
   getRenderProgress,
 } from "@remotion/lambda/client";
-import { TIMEOUT } from "dns";
-import { DISK, RAM, REGION } from "../../../../../config.mjs";
+import { DISK, RAM, REGION, TIMEOUT } from "../../../../../config.mjs";
 import { ProgressResponse, ProgressRequest } from "../../../../../types/schema";
 import { executeApi } from "../../../../helpers/api-response";
 

--- a/packages/template-next-app/src/app/api/lambda/render/route.ts
+++ b/packages/template-next-app/src/app/api/lambda/render/route.ts
@@ -4,8 +4,13 @@ import {
   speculateFunctionName,
 } from "@remotion/lambda/client";
 import { executeApi } from "../../../../helpers/api-response";
-import { TIMEOUT } from "dns";
-import { DISK, RAM, REGION, SITE_NAME } from "../../../../../config.mjs";
+import {
+  DISK,
+  RAM,
+  REGION,
+  SITE_NAME,
+  TIMEOUT,
+} from "../../../../../config.mjs";
 import { RenderRequest } from "../../../../types/schema";
 
 export const POST = executeApi<RenderMediaOnLambdaOutput, typeof RenderRequest>(


### PR DESCRIPTION
Next.js templates: Fix importing TIMEOUT from wrong location