### PR TITLE
`@remotion/media-parser`: Don't add `bytes=x-` header if x = 0

### DIFF
--- a/packages/media-parser/src/readers/from-fetch.ts
+++ b/packages/media-parser/src/readers/from-fetch.ts
@@ -105,9 +105,11 @@ export const fetchReader: ReaderInterface = {
 		const res = await fetch(resolvedUrl, {
 			headers:
 				typeof actualRange === 'number'
-					? {
-							Range: `bytes=${actualRange}-`,
-						}
+					? actualRange === 0
+						? {}
+						: {
+								Range: `bytes=${actualRange}-`,
+							}
 					: {
 							Range: `bytes=${`${actualRange[0]}-${actualRange[1]}`}`,
 						},


### PR DESCRIPTION
S3 does not support that