### PR TITLE
Separate types exports from regular exports, bun was failing because of them.

### DIFF
--- a/packages/media-parser/src/index.ts
+++ b/packages/media-parser/src/index.ts
@@ -14,8 +14,8 @@ import {internalParseMedia} from './internal-parse-media';
 import type {LogLevel} from './log';
 import {Log} from './log';
 import {makeParserState} from './state/parser-state';
-export {MatroskaSegment} from './containers/webm/segments';
-export {MatroskaElement} from './containers/webm/segments/all-segments';
+export type {MatroskaSegment} from './containers/webm/segments';
+export type {MatroskaElement} from './containers/webm/segments/all-segments';
 export {
 	hasBeenAborted,
 	IsAGifError,
@@ -26,7 +26,7 @@ export {
 	MediaParserAbortError,
 } from './errors';
 export type {SamplePosition} from './get-sample-positions';
-export {
+export type {
 	AudioTrack,
 	MediaParserAudioCodec,
 	MediaParserVideoCodec,
@@ -35,8 +35,8 @@ export {
 	VideoTrack,
 	VideoTrackColorParams,
 } from './get-tracks';
-export {MetadataEntry} from './metadata/get-metadata';
-export {MediaParserKeyframe, ParseMediaSrc} from './options';
+export type {MetadataEntry} from './metadata/get-metadata';
+export type {MediaParserKeyframe, ParseMediaSrc} from './options';
 export type {MediaParserEmbeddedImage} from './state/images';
 
 export {downloadAndParseMedia} from './download-and-parse-media';
@@ -52,7 +52,7 @@ export type {
 	TracksField,
 } from './options';
 export {parseMedia} from './parse-media';
-export {
+export type {
 	AudioOrVideoSample,
 	OnAudioSample,
 	OnAudioTrack,
@@ -60,8 +60,8 @@ export {
 	OnVideoTrack,
 } from './webcodec-sample-types';
 
-export {Dimensions} from './get-dimensions';
-export {MediaParserLocation} from './get-location';
+export type {Dimensions} from './get-dimensions';
+export type {MediaParserLocation} from './get-location';
 export type {ReaderInterface} from './readers/reader';
 
 export type {CreateContent, Writer, WriterInterface} from './writers/writer';
@@ -94,8 +94,6 @@ export type {
 } from './containers/webm/segments/all-segments';
 export type {LogLevel};
 
-export {
-	mediaParserController,
-	MediaParserController,
-} from './media-parser-controller';
+export {mediaParserController} from './media-parser-controller';
+export type {MediaParserController} from './media-parser-controller';
 export {VERSION} from './version';

--- a/packages/webcodecs/src/index.ts
+++ b/packages/webcodecs/src/index.ts
@@ -5,14 +5,16 @@ import {
 import {calculateNewDimensionsFromRotateAndScale} from './rotation';
 import {setRemotionImported} from './set-remotion-imported';
 
-export {createAudioDecoder, WebCodecsAudioDecoder} from './audio-decoder';
-export {createAudioEncoder, WebCodecsAudioEncoder} from './audio-encoder';
+export {createAudioDecoder} from './audio-decoder';
+export type {WebCodecsAudioDecoder} from './audio-decoder';
+export {createAudioEncoder} from './audio-encoder';
+export type {WebCodecsAudioEncoder} from './audio-encoder';
 export {canCopyAudioTrack} from './can-copy-audio-track';
 export {canCopyVideoTrack} from './can-copy-video-track';
 export {canReencodeAudioTrack} from './can-reencode-audio-track';
 export {canReencodeVideoTrack} from './can-reencode-video-track';
-export {
-	convertMedia,
+export {convertMedia} from './convert-media';
+export type {
 	ConvertMediaOnAudioData,
 	ConvertMediaOnProgress,
 	ConvertMediaOnVideoFrame,
@@ -21,32 +23,29 @@ export {
 } from './convert-media';
 export {defaultOnAudioTrackHandler} from './default-on-audio-track-handler';
 export {defaultOnVideoTrackHandler} from './default-on-video-track-handler';
-export {
-	ConvertMediaAudioCodec,
-	getAvailableAudioCodecs,
-} from './get-available-audio-codecs';
-export {
-	ConvertMediaContainer,
-	getAvailableContainers,
-} from './get-available-containers';
-export {
-	ConvertMediaVideoCodec,
-	getAvailableVideoCodecs,
-} from './get-available-video-codecs';
+export {getAvailableAudioCodecs} from './get-available-audio-codecs';
+export type {ConvertMediaAudioCodec} from './get-available-audio-codecs';
+export {getAvailableContainers} from './get-available-containers';
+export type {ConvertMediaContainer} from './get-available-containers';
+export {getAvailableVideoCodecs} from './get-available-video-codecs';
+export type {ConvertMediaVideoCodec} from './get-available-video-codecs';
 export {getDefaultAudioCodec} from './get-default-audio-codec';
 export {getDefaultVideoCodec} from './get-default-video-codec';
-export {
+export type {
 	AudioOperation,
 	ConvertMediaOnAudioTrackHandler,
 } from './on-audio-track-handler';
-export {
+export type {
 	ConvertMediaOnVideoTrackHandler,
 	VideoOperation,
 } from './on-video-track-handler';
 export type {ResizeOperation} from './resizing/mode';
-export {createVideoDecoder, WebCodecsVideoDecoder} from './video-decoder';
-export {createVideoEncoder, WebCodecsVideoEncoder} from './video-encoder';
-export {webcodecsController, WebCodecsController} from './webcodecs-controller';
+export {createVideoDecoder} from './video-decoder';
+export type {WebCodecsVideoDecoder} from './video-decoder';
+export {createVideoEncoder} from './video-encoder';
+export type {WebCodecsVideoEncoder} from './video-encoder';
+export {webcodecsController} from './webcodecs-controller';
+export type {WebCodecsController} from './webcodecs-controller';
 
 export const WebCodecsInternals = {
 	rotateAndResizeVideoFrame,


### PR DESCRIPTION
Bun was failing on the types exports not being marked with `type`, so I fixed that for media-parser and webcodecs package, I can do it for others if you want, was just not using those yet.

Verified that `pnpm build` still works.