### PR TITLE
`@remotion/renderer`: Explain how to increase timeout

### DIFF
--- a/packages/renderer/src/seek-to-frame.ts
+++ b/packages/renderer/src/seek-to-frame.ts
@@ -123,7 +123,7 @@ export const waitForReady = ({
 										frame ? ' at frame ' + frame : ' initially'
 									}. ${
 										res.value ? `Open delayRender() handles: ${res.value}` : ''
-									}`,
+									}. You can increase the timeout using the "timeoutInMilliseconds" / "--timeout" option of the function or command you used to trigger this render.`,
 								),
 							);
 						})


### PR DESCRIPTION
`@remotion/renderer`: Explain how to increase timeout