### PR TITLE
`@remotion/renderer`: Mark frame as unrendered before retrying it

### DIFF
--- a/packages/renderer/src/next-frame-to-render.ts
+++ b/packages/renderer/src/next-frame-to-render.ts
@@ -23,6 +23,9 @@ export const nextFrameToRenderState = ({
 			rendered.set(nextFrame, true);
 			return nextFrame;
 		},
+		returnFrame: (frame: number) => {
+			rendered.delete(frame);
+		},
 	};
 };
 
@@ -41,6 +44,11 @@ export const partitionedNextFrameToRenderState: Fn = ({
 	return {
 		getNextFrame: (pageIndex) => {
 			return partitions.getNextFrame(pageIndex);
+		},
+		returnFrame: () => {
+			throw new Error(
+				'retrying failed frames for partitioned rendering is not supported. Disable partitioned rendering.',
+			);
 		},
 	};
 };

--- a/packages/renderer/src/render-frame-and-retry-target-close.ts
+++ b/packages/renderer/src/render-frame-and-retry-target-close.ts
@@ -228,6 +228,9 @@ export const renderFrameAndRetryTargetClose = async ({
 				pool.release(newPage);
 			}
 		});
+
+		nextFrameToRender.returnFrame(frame);
+
 		await renderFrameAndRetryTargetClose({
 			retriesLeft: retriesLeft - 1,
 			attempt: attempt + 1,


### PR DESCRIPTION
Fixes #4898