### PR TITLE
fix city display in temperature card on promo page

### DIFF
--- a/packages/promo-pages/src/components/homepage/Demo/Cards.tsx
+++ b/packages/promo-pages/src/components/homepage/Demo/Cards.tsx
@@ -91,7 +91,7 @@ export const Cards: React.FC<{
 						<TrendingRepos trending={trending} theme={theme} />
 					) : index === 1 ? (
 						<Temperature
-							city={location?.city ?? null}
+							city={location?.city ? decodeURIComponent(location?.city) : null}
 							theme={theme}
 							temperatureInCelsius={trending?.temperatureInCelsius ?? null}
 						/>


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

I noticed that the city name in the Temperature card of the promo page was displayed incorrectly when the city name has some special characters. We can use a simple `decodeURIComponent` to fix this


Production:

![CleanShot 2025-02-21 at 10 56 27@2x](https://github.com/user-attachments/assets/a55cf86c-2961-4f7a-ad31-9b617e6d7b9f)


Local:

![CleanShot 2025-02-21 at 10 56 55@2x](https://github.com/user-attachments/assets/51ca2582-f0de-43e1-82cf-53e07cf33dab)


