### PR TITLE
`@remotion/webcodecs`: Don't flush on a keyframe

### DIFF
--- a/packages/media-parser/src/internal-parse-media.ts
+++ b/packages/media-parser/src/internal-parse-media.ts
@@ -63,7 +63,7 @@ export const internalParseMedia: InternalParseMedia = async function <
 
 	if (contentLength === null) {
 		throw new Error(
-			'Cannot read media without a content length. This is currently not supported. Ensure the media has a "Content-Length" HTTP header.',
+			`Cannot read media ${src} without a content length. This is currently not supported. Ensure the media has a "Content-Length" HTTP header.`,
 		);
 	}
 

--- a/packages/webcodecs/src/video-decoder.ts
+++ b/packages/webcodecs/src/video-decoder.ts
@@ -113,9 +113,12 @@ export const createVideoDecoder = ({
 			minimumProgress: sample.timestamp - 10_000_000,
 			controller,
 		});
-		if (sample.type === 'key') {
-			await videoDecoder.flush();
-		}
+
+		// Don't flush here.
+		// We manually keep track of the memory with the IO synchornizer.
+
+		// Example of flushing breaking things:
+		// IMG_2310.MOV has B-frames, and if we flush on a keyframe, we discard some frames that are yet to come.
 
 		videoDecoder.decode(new EncodedVideoChunk(sample));
 


### PR DESCRIPTION
As described, also tested and ensured the memory usage does not go up