### PR TITLE
`@remotion/transitions`: Remove rounding for sequences

### DIFF
--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -121,6 +121,7 @@ import {AnimatedImages} from './AnimatedImage/Avif';
 import {ParseAndDownloadMedia} from './ParseAndDownloadMedia';
 import {SmoothTextTransition} from './SmoothTextTransition';
 import {Seek} from './StudioApis/Seek';
+import {TransitionRounding} from './TransitionRounding';
 import {VoiceVisualization} from './voice-visualization';
 
 class Vector2 {
@@ -404,6 +405,14 @@ export const Index: React.FC = () => {
 				<Composition
 					id="missing-img"
 					component={MissingImg}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={10}
+				/>
+				<Composition
+					id="transition-rounding"
+					component={TransitionRounding}
 					width={1080}
 					height={1080}
 					fps={30}

--- a/packages/example/src/TransitionRounding.tsx
+++ b/packages/example/src/TransitionRounding.tsx
@@ -1,0 +1,36 @@
+import {TransitionSeries} from '@remotion/transitions';
+import {AbsoluteFill, useCurrentFrame} from 'remotion';
+
+const durations: number[] = [3.000002, 4];
+
+// this should never show 2 sequences at once
+// https://github.com/remotion-dev/remotion/issues/4922
+export const TransitionRounding: React.FC = () => {
+	const currentFrame = useCurrentFrame();
+	return (
+		<AbsoluteFill style={{backgroundColor: 'white'}}>
+			<TransitionSeries>
+				{durations.map((duration, index) => (
+					<TransitionSeries.Sequence durationInFrames={duration}>
+						<AbsoluteFill
+							style={{
+								display: 'flex',
+								justifyContent: 'center',
+								alignItems: 'center',
+							}}
+						>
+							<h1
+								style={{
+									fontSize: 100,
+									marginTop: index * 150,
+								}}
+							>
+								Sequence {index}, Frame {currentFrame}
+							</h1>
+						</AbsoluteFill>
+					</TransitionSeries.Sequence>
+				))}
+			</TransitionSeries>
+		</AbsoluteFill>
+	);
+};

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -243,7 +243,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					<Sequence
 						// eslint-disable-next-line react/no-array-index-key
 						key={i}
-						from={Math.floor(actualStartFrame)}
+						from={actualStartFrame}
 						durationInFrames={durationInFramesProp}
 						{...passedProps}
 						name={passedProps.name || '<TS.Sequence>'}
@@ -286,7 +286,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					<Sequence
 						// eslint-disable-next-line react/no-array-index-key
 						key={i}
-						from={Math.floor(actualStartFrame)}
+						from={actualStartFrame}
 						durationInFrames={durationInFramesProp}
 						{...passedProps}
 						name={passedProps.name || '<TS.Sequence>'}
@@ -318,7 +318,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					<Sequence
 						// eslint-disable-next-line react/no-array-index-key
 						key={i}
-						from={Math.floor(actualStartFrame)}
+						from={actualStartFrame}
 						durationInFrames={durationInFramesProp}
 						{...passedProps}
 						name={passedProps.name || '<TS.Sequence>'}
@@ -343,7 +343,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 				<Sequence
 					// eslint-disable-next-line react/no-array-index-key
 					key={i}
-					from={Math.floor(actualStartFrame)}
+					from={actualStartFrame}
 					durationInFrames={durationInFramesProp}
 					{...passedProps}
 					name={passedProps.name || '<TS.Sequence>'}


### PR DESCRIPTION
Since `<Sequence>` now supports floats, we don't need this anymore

Fixes #4922