### PR TITLE
`@remotion/media-utils`: Support dataOffsetInSeconds for `visualizeAudioWaveform()`

### DIFF
--- a/packages/docs/docs/media-utils/visualize-audio-waveform.mdx
+++ b/packages/docs/docs/media-utils/visualize-audio-waveform.mdx
@@ -69,6 +69,10 @@ Must be a power of two, such as `32`, `64`, `128`, etc. This parameter controls 
 Time in seconds (can be float) which represents the duration for which you want to see the audio waveform.  
 Example: Your video has an `fps` of 30, and you pass 15 as the `frame` on `visualizeAudioWaveform` and 0.25 as `windowInSeconds` then output will have audio waveform data from (15/30) - .125 = 0.375 sec to (15/30) +0.125 = 0.625 sec.
 
+### `dataOffsetInSeconds`<AvailableFrom v="4.0.268" />
+
+The amount of seconds the audio is offset, pass this parameter if you are using [`useWindowedAudioData()`](/docs/use-windowed-audio-data).
+
 ## Return value
 
 `number[]`

--- a/packages/docs/docs/visualize-audio.mdx
+++ b/packages/docs/docs/visualize-audio.mdx
@@ -49,6 +49,10 @@ _`"accuracy" | "speed"`_
 
 Default `"accuracy"`. When set to `"speed"`, a faster Fast Fourier transform is used. Recommended for Remotion Lambda and when using a high number of samples. Read [user](https://discord.com/channels/809501355504959528/1189048518988550264/1190228606287360030) [experiences](https://discord.com/channels/809501355504959528/1155110845488046111/1155111360481480725) [here](https://github.com/remotion-dev/remotion/issues/2925).
 
+### `dataOffsetInSeconds`<AvailableFrom v="4.0.268" />
+
+The amount of seconds the audio is offset, pass this parameter if you are using [`useWindowedAudioData()`](/docs/use-windowed-audio-data).
+
 ## Return value
 
 `number[]`

--- a/packages/media-utils/src/get-waveform-portion.ts
+++ b/packages/media-utils/src/get-waveform-portion.ts
@@ -33,6 +33,7 @@ export type GetWaveformPortion = {
 	numberOfSamples: number;
 	channel?: number;
 	outputRange?: SampleOutputRange;
+	dataOffsetInSeconds?: number;
 };
 
 /*
@@ -46,17 +47,18 @@ export const getWaveformPortion = ({
 	numberOfSamples,
 	channel = 0,
 	outputRange = 'zero-to-one',
+	dataOffsetInSeconds,
 }: GetWaveformPortion): Bar[] => {
 	validateChannel(channel, audioData.numberOfChannels);
 
 	const waveform = audioData.channelWaveforms[channel];
 
 	const startSample = Math.floor(
-		(startTimeInSeconds / audioData.durationInSeconds) * waveform.length,
+		(startTimeInSeconds - (dataOffsetInSeconds ?? 0)) * audioData.sampleRate,
 	);
 	const endSample = Math.floor(
-		((startTimeInSeconds + durationInSeconds) / audioData.durationInSeconds) *
-			waveform.length,
+		(startTimeInSeconds - (dataOffsetInSeconds ?? 0) + durationInSeconds) *
+			audioData.sampleRate,
 	);
 
 	const samplesBeforeStart = 0 - startSample;

--- a/packages/media-utils/src/visualize-audio-waveform.ts
+++ b/packages/media-utils/src/visualize-audio-waveform.ts
@@ -11,6 +11,7 @@ export type VisualizeAudioWaveformOptions = {
 	windowInSeconds: number;
 	numberOfSamples: number;
 	channel?: number;
+	dataOffsetInSeconds?: number;
 };
 
 const visualizeAudioWaveformFrame = ({
@@ -20,6 +21,7 @@ const visualizeAudioWaveformFrame = ({
 	numberOfSamples,
 	windowInSeconds,
 	channel,
+	dataOffsetInSeconds,
 }: VisualizeAudioWaveformOptions) => {
 	if (windowInSeconds * audioData.sampleRate < numberOfSamples) {
 		throw new TypeError(
@@ -31,7 +33,12 @@ const visualizeAudioWaveformFrame = ({
 	}
 
 	const cacheKey =
-		audioData.resultId + frame + fps + numberOfSamples + 'waveform';
+		audioData.resultId +
+		frame +
+		fps +
+		numberOfSamples +
+		'waveform' +
+		dataOffsetInSeconds;
 	if (cache[cacheKey]) {
 		return cache[cacheKey];
 	}
@@ -47,12 +54,13 @@ const visualizeAudioWaveformFrame = ({
 		numberOfSamples,
 		outputRange: 'minus-one-to-one',
 		channel,
+		dataOffsetInSeconds,
 	});
 };
 
-export const visualizeAudioWaveform = ({
-	...parameters
-}: VisualizeAudioWaveformOptions) => {
+export const visualizeAudioWaveform = (
+	parameters: VisualizeAudioWaveformOptions,
+) => {
 	const data = visualizeAudioWaveformFrame(parameters);
 	return data.map((value) => value.amplitude);
 };


### PR DESCRIPTION
`@remotion/media-utils`: Support dataOffsetInSeconds for `visualizeAudioWaveform()`