### PR TITLE
`@remotion/serverless`: Close browsers in tests

### DIFF
--- a/packages/lambda/src/test/mock-implementation.ts
+++ b/packages/lambda/src/test/mock-implementation.ts
@@ -15,18 +15,16 @@ import {mockCreateFunction} from './mocks/mock-create-function';
 import {mockReadDirectory} from './mocks/mock-read-dir';
 import {mockUploadDir} from './mocks/upload-dir';
 
-type Await<T> = T extends PromiseLike<infer U> ? U : T;
-let _browserInstance: Await<ReturnType<typeof openBrowser>> | null;
-
 export const getBrowserInstance: GetBrowserInstance = async () => {
-	_browserInstance = await openBrowser('chrome');
-	return {instance: _browserInstance, configurationString: 'chrome'};
+	return {instance: await openBrowser('chrome'), configurationString: 'chrome'};
 };
 
 const paramsArray: InvokeWebhookParams[] = [];
 
 export const mockServerImplementation: InsideFunctionSpecifics<AwsProvider> = {
-	forgetBrowserEventLoop: () => {},
+	forgetBrowserEventLoop: ({launchedBrowser}) => {
+		launchedBrowser.instance.close({silent: false});
+	},
 	getCurrentRegionInFunction: () => 'eu-central-1',
 	getBrowserInstance,
 	timer: () => ({

--- a/packages/serverless/src/get-browser-instance.ts
+++ b/packages/serverless/src/get-browser-instance.ts
@@ -7,6 +7,7 @@ import type {
 } from '@remotion/serverless-client';
 import {VERSION} from '@remotion/serverless-client';
 import type {
+	ForgetBrowserEventLoop,
 	GetBrowserInstance,
 	InsideFunctionSpecifics,
 } from './provider-implementation';
@@ -51,13 +52,16 @@ const waitForLaunched = () => {
 	});
 };
 
-export const forgetBrowserEventLoopImplementation = (logLevel: LogLevel) => {
+export const forgetBrowserEventLoopImplementation: ForgetBrowserEventLoop = ({
+	logLevel,
+	launchedBrowser,
+}) => {
 	RenderInternals.Log.info(
 		{indent: false, logLevel},
 		'Keeping browser open for next invocation',
 	);
-	_browserInstance?.instance.runner.forgetEventLoop();
-	_browserInstance?.instance.runner.deleteBrowserCaches();
+	launchedBrowser.instance.runner.forgetEventLoop();
+	launchedBrowser.instance.runner.deleteBrowserCaches();
 };
 
 export const getBrowserInstanceImplementation: GetBrowserInstance = async <
@@ -128,7 +132,10 @@ export const getBrowserInstanceImplementation: GetBrowserInstance = async <
 				{indent: false, logLevel},
 				'Browser disconnected or crashed.',
 			);
-			insideFunctionSpecifics.forgetBrowserEventLoop(logLevel);
+			insideFunctionSpecifics.forgetBrowserEventLoop({
+				logLevel,
+				launchedBrowser: _browserInstance as LaunchedBrowser,
+			});
 			_browserInstance?.instance?.close({silent: true}).catch((err) => {
 				RenderInternals.Log.info(
 					{indent: false, logLevel},

--- a/packages/serverless/src/handlers/renderer.ts
+++ b/packages/serverless/src/handlers/renderer.ts
@@ -28,6 +28,7 @@ import {
 	canConcatAudioSeamlessly,
 	canConcatVideoSeamlessly,
 } from '../can-concat-seamlessly';
+import type {LaunchedBrowser} from '../get-browser-instance';
 import {getTmpDirStateIfENoSp} from '../get-tmp-dir';
 import {startLeakDetection} from '../leak-detection';
 import {onDownloadsHelper} from '../on-downloads-helpers';
@@ -52,6 +53,7 @@ const renderHandler = async <Provider extends CloudProvider>({
 	onStream,
 	providerSpecifics,
 	insideFunctionSpecifics,
+	onBrowserInstance,
 }: {
 	params: ServerlessPayload<Provider>;
 	options: Options;
@@ -59,6 +61,7 @@ const renderHandler = async <Provider extends CloudProvider>({
 	onStream: OnStream<Provider>;
 	providerSpecifics: ProviderSpecifics<Provider>;
 	insideFunctionSpecifics: InsideFunctionSpecifics<Provider>;
+	onBrowserInstance: (browserInstance: LaunchedBrowser) => void;
 }): Promise<{}> => {
 	if (params.type !== ServerlessRoutines.renderer) {
 		throw new Error('Params must be renderer');
@@ -97,6 +100,8 @@ const renderHandler = async <Provider extends CloudProvider>({
 		providerSpecifics,
 		insideFunctionSpecifics,
 	});
+
+	onBrowserInstance(browserInstance);
 
 	const outputPath = RenderInternals.tmpDir('remotion-render-');
 
@@ -442,6 +447,7 @@ export const rendererHandler = async <Provider extends CloudProvider>({
 
 	const leakDetection = enableNodeIntrospection(ENABLE_SLOW_LEAK_DETECTION);
 	let shouldKeepBrowserOpen = true;
+	let instance: LaunchedBrowser | undefined;
 
 	try {
 		await renderHandler({
@@ -451,6 +457,9 @@ export const rendererHandler = async <Provider extends CloudProvider>({
 			onStream,
 			providerSpecifics,
 			insideFunctionSpecifics,
+			onBrowserInstance: (browserInstance) => {
+				instance = browserInstance;
+			},
 		});
 		return {
 			type: 'success',
@@ -509,8 +518,11 @@ export const rendererHandler = async <Provider extends CloudProvider>({
 
 		throw err;
 	} finally {
-		if (shouldKeepBrowserOpen) {
-			insideFunctionSpecifics.forgetBrowserEventLoop(params.logLevel);
+		if (shouldKeepBrowserOpen && instance) {
+			insideFunctionSpecifics.forgetBrowserEventLoop({
+				logLevel: params.logLevel,
+				launchedBrowser: instance,
+			});
 		} else {
 			RenderInternals.Log.info(
 				{indent: false, logLevel: params.logLevel},

--- a/packages/serverless/src/handlers/still.ts
+++ b/packages/serverless/src/handlers/still.ts
@@ -87,6 +87,19 @@ const innerStillHandler = async <Provider extends CloudProvider>(
 		providerSpecifics,
 		insideFunctionSpecifics,
 	});
+
+	browserInstancePromise.then((instance) => {
+		cleanup.push(() => {
+			insideFunctionSpecifics.forgetBrowserEventLoop({
+				logLevel:
+					params.type === ServerlessRoutines.still ? params.logLevel : 'error',
+				launchedBrowser: instance,
+			});
+
+			return Promise.resolve();
+		});
+	});
+
 	const bucketNamePromise =
 		params.bucketName ??
 		internalGetOrCreateBucket({
@@ -446,12 +459,6 @@ export const stillHandler = async <Provider extends CloudProvider>(
 			stack: (err as Error).stack as string,
 		};
 	} finally {
-		options.insideFunctionSpecifics.forgetBrowserEventLoop(
-			options.params.type === ServerlessRoutines.still
-				? options.params.logLevel
-				: 'error',
-		);
-
 		cleanUpFn.forEach((c) => c());
 	}
 };

--- a/packages/serverless/src/provider-implementation.ts
+++ b/packages/serverless/src/provider-implementation.ts
@@ -43,7 +43,10 @@ export type GetBrowserInstance = <Provider extends CloudProvider>({
 	insideFunctionSpecifics: InsideFunctionSpecifics<Provider>;
 }) => Promise<LaunchedBrowser>;
 
-export type ForgetBrowserEventLoop = (logLevel: LogLevel) => void;
+export type ForgetBrowserEventLoop = (options: {
+	logLevel: LogLevel;
+	launchedBrowser: LaunchedBrowser;
+}) => void;
 
 export type GenerateRenderId = (options: {
 	deleteAfter: DeleteAfter | null;


### PR DESCRIPTION
This made tests unreliable before
No changes to actual runtime