### PR TITLE
Retries and timeouts for `useOffthreadVideoTexture`

### DIFF
--- a/packages/docs/docs/use-offthread-video-texture.mdx
+++ b/packages/docs/docs/use-offthread-video-texture.mdx
@@ -31,34 +31,20 @@ const My3DVideo = () => {
 
   return (
     <ThreeCanvas width={width} height={height}>
-      <mesh>
-        {videoTexture ? <meshBasicMaterial map={videoTexture} /> : null}
-      </mesh>
+      <mesh>{videoTexture ? <meshBasicMaterial map={videoTexture} /> : null}</mesh>
     </ThreeCanvas>
   );
 };
 ```
 
 ```tsx twoslash title="Use useVideoTexture() only during rendering"
-import {
-  ThreeCanvas,
-  useOffthreadVideoTexture,
-  useVideoTexture,
-} from '@remotion/three';
+import {ThreeCanvas, useOffthreadVideoTexture, useVideoTexture} from '@remotion/three';
 import {useRef} from 'react';
-import {
-  getRemotionEnvironment,
-  staticFile,
-  useVideoConfig,
-  Video,
-} from 'remotion';
+import {getRemotionEnvironment, staticFile, useVideoConfig, Video} from 'remotion';
 
 const videoSrc = staticFile('/vid.mp4');
 
-const useVideoOrOffthreadVideoTexture = (
-  videoSrc: string,
-  videoRef: React.RefObject<HTMLVideoElement | null>,
-) => {
+const useVideoOrOffthreadVideoTexture = (videoSrc: string, videoRef: React.RefObject<HTMLVideoElement | null>) => {
   if (getRemotionEnvironment().isRendering) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useOffthreadVideoTexture({src: videoSrc});
@@ -76,17 +62,9 @@ const My3DVideo = () => {
 
   return (
     <>
-      {getRemotionEnvironment().isRendering ? null : (
-        <Video
-          ref={videoRef}
-          src={videoSrc}
-          style={{position: 'absolute', opacity: 0}}
-        />
-      )}
+      {getRemotionEnvironment().isRendering ? null : <Video ref={videoRef} src={videoSrc} style={{position: 'absolute', opacity: 0}} />}
       <ThreeCanvas width={width} height={height}>
-        <mesh>
-          {videoTexture ? <meshBasicMaterial map={videoTexture} /> : null}
-        </mesh>
+        <mesh>{videoTexture ? <meshBasicMaterial map={videoTexture} /> : null}</mesh>
       </ThreeCanvas>
     </>
   );
@@ -122,11 +100,11 @@ Disabling tone mapping will speed up rendering, but may result in less vibrant c
 
 Prior to Remotion 4.0.117, tone mapping was always disabled, and the `toneMapped` prop was not available.
 
-### `delayRenderTimeoutInMilliseconds`<AvailableFrom v="4.0.270" />
+### `delayRenderTimeoutInMilliseconds`<AvailableFrom v="4.0.271" />
 
 Customize the [timeout](/docs/delay-render#modifying-the-timeout) of the [`delayRender()`](/docs/delay-render) call that this hook makes.
 
-### `delayRenderRetries`<AvailableFrom v="4.0.270" />
+### `delayRenderRetries`<AvailableFrom v="4.0.271" />
 
 Customize the [number of retries](/docs/delay-render#retrying) of the [`delayRender()`](/docs/delay-render) call that this hook makes.
 

--- a/packages/docs/docs/use-offthread-video-texture.mdx
+++ b/packages/docs/docs/use-offthread-video-texture.mdx
@@ -122,6 +122,14 @@ Disabling tone mapping will speed up rendering, but may result in less vibrant c
 
 Prior to Remotion 4.0.117, tone mapping was always disabled, and the `toneMapped` prop was not available.
 
+### `delayRenderTimeoutInMilliseconds`<AvailableFrom v="4.0.270" />
+
+Customize the [timeout](/docs/delay-render#modifying-the-timeout) of the [`delayRender()`](/docs/delay-render) call that this hook makes.
+
+### `delayRenderRetries`<AvailableFrom v="4.0.270" />
+
+Customize the [number of retries](/docs/delay-render#retrying) of the [`delayRender()`](/docs/delay-render) call that this hook makes.
+
 ## Looping a texture
 
 Like `<OffthreadVideo>`, looping a video [is not supported out of the box](/docs/offthreadvideo#looping-a-video) but can be achieved with the `<Loop>` component.

--- a/packages/three/src/use-offthread-video-texture.ts
+++ b/packages/three/src/use-offthread-video-texture.ts
@@ -16,6 +16,8 @@ export type UseOffthreadVideoTextureOptions = {
 	playbackRate?: number;
 	transparent?: boolean;
 	toneMapped?: boolean;
+	delayRenderRetries?: number;
+	delayRenderTimeoutInMilliseconds?: number;
 };
 
 export const useInnerVideoTexture = ({
@@ -23,11 +25,15 @@ export const useInnerVideoTexture = ({
 	src,
 	transparent,
 	toneMapped,
+	delayRenderRetries,
+	delayRenderTimeoutInMilliseconds,
 }: {
 	playbackRate: number;
 	src: string;
 	transparent: boolean;
 	toneMapped: boolean;
+	delayRenderRetries?: number;
+	delayRenderTimeoutInMilliseconds?: number;
 }) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
@@ -59,7 +65,10 @@ export const useInnerVideoTexture = ({
 	const [imageTexture, setImageTexture] = useState<Texture | null>(null);
 
 	const fetchTexture = useCallback(() => {
-		const imageTextureHandle = delayRender('fetch offthread video frame');
+		const imageTextureHandle = delayRender('fetch offthread video frame', {
+			retries: delayRenderRetries ?? undefined,
+			timeoutInMilliseconds: delayRenderTimeoutInMilliseconds ?? undefined,
+		});
 
 		let textureLoaded: Texture | null = null;
 		let cleanedUp = false;
@@ -86,7 +95,7 @@ export const useInnerVideoTexture = ({
 			textureLoaded?.dispose();
 			continueRender(imageTextureHandle);
 		};
-	}, [offthreadVideoFrameSrc, textLoaderPromise]);
+	}, [offthreadVideoFrameSrc, textLoaderPromise, delayRenderRetries, delayRenderTimeoutInMilliseconds]);
 
 	useLayoutEffect(() => {
 		const cleanup = fetchTexture();
@@ -108,6 +117,8 @@ export function useOffthreadVideoTexture({
 	playbackRate = 1,
 	transparent = false,
 	toneMapped = true,
+	delayRenderRetries,
+	delayRenderTimeoutInMilliseconds,
 }: UseOffthreadVideoTextureOptions) {
 	if (!src) {
 		throw new Error('src must be provided to useOffthreadVideoTexture');
@@ -120,5 +131,12 @@ export function useOffthreadVideoTexture({
 		);
 	}
 
-	return useInnerVideoTexture({playbackRate, src, transparent, toneMapped});
+	return useInnerVideoTexture({
+		playbackRate,
+		src,
+		transparent,
+		toneMapped,
+		delayRenderRetries,
+		delayRenderTimeoutInMilliseconds,
+	});
 }

--- a/packages/three/src/use-offthread-video-texture.ts
+++ b/packages/three/src/use-offthread-video-texture.ts
@@ -95,7 +95,12 @@ export const useInnerVideoTexture = ({
 			textureLoaded?.dispose();
 			continueRender(imageTextureHandle);
 		};
-	}, [offthreadVideoFrameSrc, textLoaderPromise, delayRenderRetries, delayRenderTimeoutInMilliseconds]);
+	}, [
+		offthreadVideoFrameSrc,
+		textLoaderPromise,
+		delayRenderRetries,
+		delayRenderTimeoutInMilliseconds,
+	]);
 
 	useLayoutEffect(() => {
 		const cleanup = fetchTexture();


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Improvement

- `delayRenderRetries` and `delayRenderTimeoutInMilliseconds` for `useOffthreadVideoTexture` hook!

So it works the same fashion as `<Audio>`, `<Video>`, `<IFrame>`, etc.