### PR TITLE
`@remotion/webcodecs`: Support creating MP4 files bigger than 4GB

### DIFF
--- a/packages/webcodecs/src/create/iso-base-media/primitives.ts
+++ b/packages/webcodecs/src/create/iso-base-media/primitives.ts
@@ -13,6 +13,20 @@ export const numberTo32BitUIntOrInt = (num: number) => {
 	]);
 };
 
+export const numberTo64BitUIntOrInt = (num: number | bigint) => {
+	const bigNum = BigInt(num);
+	return new Uint8Array([
+		Number((bigNum >> 56n) & 0xffn),
+		Number((bigNum >> 48n) & 0xffn),
+		Number((bigNum >> 40n) & 0xffn),
+		Number((bigNum >> 32n) & 0xffn),
+		Number((bigNum >> 24n) & 0xffn),
+		Number((bigNum >> 16n) & 0xffn),
+		Number((bigNum >> 8n) & 0xffn),
+		Number(bigNum & 0xffn),
+	]);
+};
+
 export const numberTo32BitUIntOrIntLeading128 = (num: number) => {
 	const arr = [
 		(num >> 24) & 0xff,

--- a/packages/webcodecs/src/create/iso-base-media/trak/mdia/minf/stbl/create-stco.ts
+++ b/packages/webcodecs/src/create/iso-base-media/trak/mdia/minf/stbl/create-stco.ts
@@ -3,15 +3,22 @@ import {combineUint8Arrays} from '../../../../../matroska/matroska-utils';
 import {
 	addSize,
 	numberTo32BitUIntOrInt,
+	numberTo64BitUIntOrInt,
 	stringsToUint8Array,
 } from '../../../../primitives';
 
 export const createStcoAtom = (samplePositions: SamplePosition[]) => {
 	const chunkOffsets = [];
 	let lastChunk;
+	let needs64Bit = false;
+
 	for (const sample of samplePositions) {
 		if (lastChunk !== sample.chunk) {
 			chunkOffsets.push(sample.offset);
+		}
+
+		if (sample.offset > 2 ** 32) {
+			needs64Bit = true;
 		}
 
 		lastChunk = sample.chunk;
@@ -20,7 +27,7 @@ export const createStcoAtom = (samplePositions: SamplePosition[]) => {
 	return addSize(
 		combineUint8Arrays([
 			// type
-			stringsToUint8Array('stco'),
+			stringsToUint8Array(needs64Bit ? 'co64' : 'stco'),
 			// version
 			new Uint8Array([0]),
 			// flags
@@ -28,7 +35,13 @@ export const createStcoAtom = (samplePositions: SamplePosition[]) => {
 			// number of entries
 			numberTo32BitUIntOrInt(chunkOffsets.length),
 			// chunk offsets
-			...chunkOffsets.map((offset) => numberTo32BitUIntOrInt(offset)),
+			combineUint8Arrays(
+				chunkOffsets.map((offset) =>
+					needs64Bit
+						? numberTo64BitUIntOrInt(offset)
+						: numberTo32BitUIntOrInt(offset),
+				),
+			),
 		]),
 	);
 };

--- a/packages/webcodecs/tsconfig.json
+++ b/packages/webcodecs/tsconfig.json
@@ -4,7 +4,8 @@
 		"rootDir": "src",
 		"outDir": "dist",
 		"jsx": "react-jsx",
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"target": "ES2020"
 	},
 	"include": ["src"],
 	"references": [


### PR DESCRIPTION
`@remotion/webcodecs`: Support creating MP4 files bigger than 4GB