### PR TITLE
Move Media Parser Worker APIs to `@remotion/media-parser/worker`

### DIFF
--- a/packages/convert/app/components/use-probe.ts
+++ b/packages/convert/app/components/use-probe.ts
@@ -12,10 +12,8 @@ import type {
 	MediaParserVideoCodec,
 	ParseMediaOnProgress,
 } from '@remotion/media-parser';
-import {
-	mediaParserController,
-	parseMediaOnWebWorker,
-} from '@remotion/media-parser';
+import {mediaParserController} from '@remotion/media-parser';
+import {parseMediaOnWebWorker} from '@remotion/media-parser/worker';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import type {Source} from '~/lib/convert-state';
 

--- a/packages/convert/app/lib/use-thumbnail.ts
+++ b/packages/convert/app/lib/use-thumbnail.ts
@@ -1,8 +1,6 @@
 import type {LogLevel} from '@remotion/media-parser';
-import {
-	mediaParserController,
-	parseMediaOnWebWorker,
-} from '@remotion/media-parser';
+import {mediaParserController} from '@remotion/media-parser';
+import {parseMediaOnWebWorker} from '@remotion/media-parser/worker';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import type {Source} from './convert-state';
 import {makeWaveformVisualizer} from './waveform-visualizer';

--- a/packages/docs/docs/media-parser/parse-media-on-server-worker.mdx
+++ b/packages/docs/docs/media-parser/parse-media-on-server-worker.mdx
@@ -22,7 +22,7 @@ We do not test against Deno's `Worker` implementation.
 :::
 
 ```tsx twoslash title="Parsing a video on a Bun Worker"
-import {parseMediaOnServerWorker} from '@remotion/media-parser';
+import {parseMediaOnServerWorker} from '@remotion/media-parser/worker';
 
 const result = await parseMediaOnServerWorker({
   src: '/tmp/video.mp4',

--- a/packages/docs/docs/media-parser/parse-media-on-web-worker.mdx
+++ b/packages/docs/docs/media-parser/parse-media-on-web-worker.mdx
@@ -20,7 +20,7 @@ This API abstracts the communication between the main thread and the worker with
 The only difference in API is that the [`reader`](/docs/media-parser/parse-media#reader) option is not available. This is because you cannot pass a function to a Web Worker.
 
 ```tsx twoslash title="Parsing a video on a Web Worker"
-import {parseMediaOnWebWorker} from '@remotion/media-parser';
+import {parseMediaOnWebWorker} from '@remotion/media-parser/worker';
 
 const result = await parseMediaOnWebWorker({
   src: 'https://example.com/my-video.mp4',

--- a/packages/docs/docs/media-parser/workers.mdx
+++ b/packages/docs/docs/media-parser/workers.mdx
@@ -21,7 +21,7 @@ The API takes care of exchanging messages between the main thread and the Web Wo
 ## Example
 
 ```tsx twoslash title="Parsing a video on a Web Worker"
-import {parseMediaOnWebWorker} from '@remotion/media-parser';
+import {parseMediaOnWebWorker} from '@remotion/media-parser/worker';
 
 const result = await parseMediaOnWebWorker({
   src: 'https://example.com/my-video.mp4',
@@ -41,7 +41,7 @@ console.log(result.dimensions); // {width: 1920, height: 1080}
 To use it, you can use the [`parseMediaOnServerWorker()`](/docs/media-parser/parse-media-on-server-worker) API.
 
 ```tsx twoslash title="Parsing a video on a Web Worker on Bun"
-import {parseMediaOnServerWorker} from '@remotion/media-parser';
+import {parseMediaOnServerWorker} from '@remotion/media-parser/worker';
 
 const result = await parseMediaOnServerWorker({
   src: '/tmp/video.mp4',

--- a/packages/media-parser/bundle.ts
+++ b/packages/media-parser/bundle.ts
@@ -34,6 +34,10 @@ await buildPackage({
 			path: 'src/worker-server-entry.ts',
 			target: 'node',
 		},
+		{
+			path: 'src/worker.ts',
+			target: 'browser',
+		},
 	],
 	external: ['stream'],
 });

--- a/packages/media-parser/package.json
+++ b/packages/media-parser/package.json
@@ -69,6 +69,12 @@
 			"require": "./dist/worker-server-entry.js",
 			"module": "./dist/esm/worker-server-entry.mjs",
 			"import": "./dist/esm/worker-server-entry.mjs"
+		},
+		"./worker": {
+			"types": "./dist/worker.d.ts",
+			"require": "./dist/worker.js",
+			"module": "./dist/esm/worker.mjs",
+			"import": "./dist/esm/worker.mjs"
 		}
 	},
 	"typesVersions": {
@@ -90,6 +96,9 @@
 			],
 			"worker-server-entry": [
 				"dist/worker-server-entry.d.ts"
+			],
+			"worker": [
+				"dist/worker.d.ts"
 			]
 		}
 	},

--- a/packages/media-parser/src/index.ts
+++ b/packages/media-parser/src/index.ts
@@ -36,8 +36,6 @@ export type {
 } from './get-tracks';
 export type {MediaParserMetadataEntry} from './metadata/get-metadata';
 export type {MediaParserKeyframe, ParseMediaSrc} from './options';
-export {parseMediaOnServerWorker} from './parse-media-on-server-worker';
-export {parseMediaOnWebWorker} from './parse-media-on-web-worker';
 export type {MediaParserEmbeddedImage} from './state/images';
 
 export {downloadAndParseMedia} from './download-and-parse-media';

--- a/packages/media-parser/src/worker.ts
+++ b/packages/media-parser/src/worker.ts
@@ -1,0 +1,3 @@
+export type {ParseMediaOnWorker, ParseMediaOnWorkerOptions} from './options';
+export {parseMediaOnServerWorker} from './parse-media-on-server-worker';
+export {parseMediaOnWebWorker} from './parse-media-on-web-worker';


### PR DESCRIPTION
I reckon that otherwise you will load the library twice