### PR TITLE
`@remotion/renderer`: Remove playback rate optimization

### DIFF
--- a/packages/renderer/src/stringify-ffmpeg-filter.ts
+++ b/packages/renderer/src/stringify-ffmpeg-filter.ts
@@ -29,7 +29,8 @@ const cleanUpFloatingPointError = (value: number) => {
 };
 
 const stringifyTrim = (trim: number) => {
-	const value = trim * 1_000_000;
+	const value = cleanUpFloatingPointError(trim * 1_000_000);
+
 	const asString = `${value}us`;
 
 	// Handle very small values such as `"6e-7us"`, those are essentially rounding errors to 0
@@ -81,7 +82,6 @@ export const getActualTrimLeft = ({
 };
 
 const trimAndSetTempo = ({
-	forSeamlessAacConcatenation,
 	assetDuration,
 	asset,
 	trimLeftOffset,
@@ -90,7 +90,6 @@ const trimAndSetTempo = ({
 	indent,
 	logLevel,
 }: {
-	forSeamlessAacConcatenation: boolean;
 	assetDuration: number | null;
 	trimLeftOffset: number;
 	trimRightOffset: number;
@@ -103,80 +102,46 @@ const trimAndSetTempo = ({
 	filter: (string | null)[];
 	audibleDuration: number;
 } => {
-	// If we need seamless AAC stitching, we need to apply the tempo filter first
-	// because the atempo filter is not frame-perfect. It creates a small offset
-	// and the offset needs to be the same for all audio tracks, before processing it further.
+	// We need to apply the tempo filter first
+	// because the atempo filter is not frame-perfect.
+	// It creates a small offset and the offset needs to be the same for all audio tracks, before processing it further.
 	// This also affects the trimLeft and trimRight values, as they need to be adjusted.
-	if (forSeamlessAacConcatenation) {
-		const {trimLeft, maxTrim} = getActualTrimLeft({
-			asset,
-			fps,
-			trimLeftOffset,
-			seamless: true,
-			assetDuration,
-		});
-		const trimRight =
-			trimLeft + asset.duration / fps - trimLeftOffset + trimRightOffset;
+	const {trimLeft, maxTrim} = getActualTrimLeft({
+		asset,
+		fps,
+		trimLeftOffset,
+		seamless: true,
+		assetDuration,
+	});
+	const trimRight =
+		trimLeft + asset.duration / fps - trimLeftOffset + trimRightOffset;
 
-		let trimRightOrAssetDuration = maxTrim
-			? Math.min(trimRight, maxTrim)
-			: trimRight;
+	let trimRightOrAssetDuration = maxTrim
+		? Math.min(trimRight, maxTrim)
+		: trimRight;
 
-		if (trimRightOrAssetDuration < trimLeft) {
-			Log.warn(
-				{indent, logLevel},
-				'trimRightOrAssetDuration < trimLeft: ' +
-					JSON.stringify({
-						trimRight,
-						trimLeft,
-						assetDuration,
-						assetTrimLeft: asset.trimLeft,
-					}),
-			);
-			trimRightOrAssetDuration = trimLeft;
-		}
-
-		return {
-			filter: [
-				calculateATempo(asset.playbackRate),
-				`atrim=${stringifyTrim(trimLeft)}:${stringifyTrim(trimRightOrAssetDuration)}`,
-			],
-			actualTrimLeft: trimLeft,
-			audibleDuration: trimRightOrAssetDuration - trimLeft,
-		};
+	if (trimRightOrAssetDuration < trimLeft) {
+		Log.warn(
+			{indent, logLevel},
+			'trimRightOrAssetDuration < trimLeft: ' +
+				JSON.stringify({
+					trimRight,
+					trimLeft,
+					assetDuration,
+					assetTrimLeft: asset.trimLeft,
+				}),
+		);
+		trimRightOrAssetDuration = trimLeft;
 	}
 
-	// Otherwise, we first trim and then apply playback rate, as then the atempo
-	// filter needs to do less work.
-	if (!forSeamlessAacConcatenation) {
-		const {trimLeft: actualTrimLeft, maxTrim} = getActualTrimLeft({
-			asset,
-			fps,
-			trimLeftOffset,
-			seamless: false,
-			assetDuration,
-		});
-		const trimRight =
-			actualTrimLeft + (asset.duration / fps) * asset.playbackRate;
-
-		const trimRightOrAssetDuration = maxTrim
-			? Math.min(trimRight, maxTrim)
-			: trimRight;
-
-		return {
-			filter: [
-				`atrim=${stringifyTrim(actualTrimLeft)}:${stringifyTrim(
-					trimRightOrAssetDuration,
-				)}`,
-				calculateATempo(asset.playbackRate),
-			],
-			actualTrimLeft,
-			audibleDuration:
-				(trimRightOrAssetDuration - actualTrimLeft) / asset.playbackRate,
-		};
-	}
-
-	throw new Error('This should never happen');
+	return {
+		filter: [
+			calculateATempo(asset.playbackRate),
+			`atrim=${stringifyTrim(trimLeft)}:${stringifyTrim(trimRightOrAssetDuration)}`,
+		],
+		actualTrimLeft: trimLeft,
+		audibleDuration: trimRightOrAssetDuration - trimLeft,
+	};
 };
 
 export const stringifyFfmpegFilter = ({
@@ -237,7 +202,6 @@ export const stringifyFfmpegFilter = ({
 		audibleDuration,
 		filter: trimAndTempoFilter,
 	} = trimAndSetTempo({
-		forSeamlessAacConcatenation,
 		assetDuration,
 		trimLeftOffset,
 		trimRightOffset,

--- a/packages/renderer/src/test/ffmpeg-filters.test.ts
+++ b/packages/renderer/src/test/ffmpeg-filters.test.ts
@@ -105,7 +105,7 @@ test('Trim the end', () => {
 	).toEqual({
 		actualTrimLeft: 0,
 		filter:
-			'[0:a]aformat=sample_fmts=s32:sample_rates=48000,atrim=0us:704000.0000000001us[a0]',
+			'[0:a]aformat=sample_fmts=s32:sample_rates=48000,atrim=0us:704000us[a0]',
 		pad_end: 'apad=pad_len=' + padding,
 		pad_start: null,
 	});
@@ -348,7 +348,7 @@ test('Should calculate pad correctly with a lot of playbackRate', () => {
 	).toEqual({
 		actualTrimLeft: 0,
 		filter:
-			'[0:a]aformat=sample_fmts=s32:sample_rates=48000,atrim=0us:33333333.000000004us,atempo=2.00000,atempo=2.00000,atempo=2.00000,atempo=2.00000[a0]',
+			'[0:a]aformat=sample_fmts=s32:sample_rates=48000,atempo=2.00000,atempo=2.00000,atempo=2.00000,atempo=2.00000,atrim=0us:2083333.3125000002us[a0]',
 		pad_end: `apad=pad_len=${expectedPadLength}`,
 		pad_start: null,
 	});


### PR DESCRIPTION
The said optimization unfortunately broke renders like https://discord.com/channels/@me/1127949286789881897/1347606294810460191 (private link for our reference)

The said bug in FFmpeg is described here https://pietrasiak.com/debugging-%22multi-issue-bugs%22 and affects exports in MP3 format