### PR TITLE
`@remotion/eslint-config-flat`: Fix hardcoded paths in ESM output

### DIFF
--- a/packages/.monorepo/builder.ts
+++ b/packages/.monorepo/builder.ts
@@ -8,16 +8,38 @@ if (process.env.NODE_ENV !== 'production') {
 
 type Format = 'esm' | 'cjs';
 
+const getPackageJson = () => {
+	return require(path.join(process.cwd(), 'package.json'));
+};
+
+const getDependenciesAndPeerAndOptionalDependencies = () => {
+	const packageJson = getPackageJson();
+
+	return {
+		...(packageJson.dependencies ?? {}),
+		...(packageJson.optionalDependencies ?? {}),
+		...(packageJson.peerDependencies ?? {}),
+	};
+};
+
 const getExternal = (deps: string[] | 'dependencies'): string[] => {
 	if (deps === 'dependencies') {
-		const packageJson = require(path.join(process.cwd(), 'package.json'));
-		return Object.keys({
-			...(packageJson.dependencies ?? {}),
-			...(packageJson.optionalDependencies ?? {}),
-		});
+		return Object.keys(getDependenciesAndPeerAndOptionalDependencies());
 	}
 
 	return deps;
+};
+
+const validateExternal = (external: string[]) => {
+	const packageJson = Object.keys(
+		getDependenciesAndPeerAndOptionalDependencies(),
+	);
+
+	if (external.some((dep) => !packageJson.includes(dep))) {
+		throw new Error(
+			`External dependency ${external} not found in package.json`,
+		);
+	}
 };
 
 const sortObject = (obj: Record<string, string>) => {
@@ -70,10 +92,12 @@ export const buildPackage = async ({
 		} else if (action === 'use-tsc') {
 		} else if (action === 'build') {
 			for (const {path: p, target} of entrypoints) {
+				const externalFinal = filterExternal(getExternal(external));
+				validateExternal(externalFinal);
 				const output = await build({
 					entrypoints: [p],
 					naming: `[name].${format === 'esm' ? 'mjs' : 'js'}`,
-					external: filterExternal(getExternal(external)),
+					external: externalFinal,
 					target,
 					format,
 				});

--- a/packages/eslint-config-flat/bundle.ts
+++ b/packages/eslint-config-flat/bundle.ts
@@ -1,20 +1,10 @@
-import {build} from 'bun';
+import {buildPackage} from '../.monorepo/builder';
 
-if (process.env.NODE_ENV !== 'production') {
-	throw new Error('This script must be run using NODE_ENV=production');
-}
-
-const output = await build({
-	entrypoints: ['src/index.ts'],
-	naming: '[name].mjs',
-	target: 'node',
-	external: [],
+await buildPackage({
+	entrypoints: [{path: 'src/index.ts', target: 'node'}],
+	formats: {
+		cjs: 'use-tsc',
+		esm: 'build',
+	},
+	external: ['eslint', 'typescript-eslint'],
 });
-
-const [file] = output.outputs;
-const text = await file.text();
-
-await Bun.write('dist/esm/index.mjs', text);
-
-export {};
-console.log('Generated.');

--- a/packages/eslint-config-flat/package.json
+++ b/packages/eslint-config-flat/package.json
@@ -20,13 +20,14 @@
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"license": "ISC",
-	"dependencies": {},
+	"dependencies": {
+		"typescript-eslint": "8.21.0"
+	},
 	"peerDependencies": {
 		"eslint": ">=9"
 	},
 	"devDependencies": {
 		"@remotion/eslint-plugin": "workspace:*",
-		"typescript-eslint": "8.21.0",
 		"@eslint/js": "9.19.0",
 		"eslint-plugin-react": "7.37.4",
 		"eslint-plugin-react-hooks": "5.2.0",
@@ -43,9 +44,9 @@
 		"./package.json": "./package.json",
 		".": {
 			"types": "./dist/index.d.ts",
+			"require": "./dist/index.js",
 			"module": "./dist/esm/index.mjs",
-			"import": "./dist/esm/index.mjs",
-			"require": "./dist/index.js"
+			"import": "./dist/esm/index.mjs"
 		}
 	},
 	"publishConfig": {


### PR DESCRIPTION
`@remotion/eslint-config-flat`: Fix hardcoded paths in ESM output