### PR TITLE
`@remotion/webcodecs`: canUseWebFsWriter() catches Firefox Private Window Exception

### DIFF
--- a/packages/webcodecs/src/writers/web-fs.ts
+++ b/packages/webcodecs/src/writers/web-fs.ts
@@ -83,14 +83,18 @@ export const canUseWebFsWriter = async () => {
 		return false;
 	}
 
-	const directoryHandle = await navigator.storage.getDirectory();
-	const fileHandle = await directoryHandle.getFileHandle(
-		'remotion-probe-web-fs-support',
-		{
-			create: true,
-		},
-	);
+	try {
+		const directoryHandle = await navigator.storage.getDirectory();
+		const fileHandle = await directoryHandle.getFileHandle(
+			'remotion-probe-web-fs-support',
+			{
+				create: true,
+			},
+		);
 
-	const canUse = fileHandle.createWritable !== undefined;
-	return canUse;
+		const canUse = fileHandle.createWritable !== undefined;
+		return canUse;
+	} catch {
+		return false;
+	}
 };


### PR DESCRIPTION
Calling .getDirectory() is not available in Firefox Private Window Mode