### PR TITLE
`@remotion/media-utils`: Log status code if it is not 206 in `getPartialWaveData()`

### DIFF
--- a/packages/media-utils/src/get-partial-wave-data.ts
+++ b/packages/media-utils/src/get-partial-wave-data.ts
@@ -40,7 +40,7 @@ export const getPartialWaveData = async ({
 
 	if (response.status !== 206) {
 		throw new Error(
-			`Tried to read bytes ${startByte}-${endByte} from ${src}, but the response status code was not 206. This means the server might not support returning a partial response.`,
+			`Tried to read bytes ${startByte}-${endByte} from ${src}, but the response status code was ${response.status} (expected was 206). This means the server might not support returning a partial response.`,
 		);
 	}
 

--- a/packages/media-utils/src/probe-wave-file.ts
+++ b/packages/media-utils/src/probe-wave-file.ts
@@ -55,7 +55,7 @@ export const probeWaveFile = async (src: string): Promise<WaveProbe> => {
 	});
 	if (response.status !== 206) {
 		throw new Error(
-			`Tried to read bytes 0-256 from ${src}, but the response status code was not 206. This means the server might not support returning a partial response.`,
+			`Tried to read bytes 0-256 from ${src}, but the response status code was ${response.status} (expected was 206). This means the server might not support returning a partial response.`,
 		);
 	}
 


### PR DESCRIPTION
`@remotion/media-utils`: Log status code if it is not 206 in getPartialWaveData)()