### PR TITLE
`@remotion/media-parser`: Not counting samples twice if seeking has happened

### DIFF
--- a/packages/media-parser/src/iterator/buffer-manager.ts
+++ b/packages/media-parser/src/iterator/buffer-manager.ts
@@ -100,8 +100,7 @@ export const bufferManager = ({
 		uintArray = new Uint8Array(buf);
 		uintArray.set(newData);
 		view = new DataView(uintArray.buffer);
-		// no more dicarded bytes
-		counter.setDiscardedOffset(0);
+		counter.setDiscardedOffset(seekTo);
 		// reset counter to 0
 		counter.decrement(counter.getOffset());
 		// seek to the new position

--- a/packages/media-parser/src/test/seeking/no-samples-twice.test.ts
+++ b/packages/media-parser/src/test/seeking/no-samples-twice.test.ts
@@ -1,0 +1,35 @@
+import {exampleVideos} from '@remotion/example-videos';
+import {expect, test} from 'bun:test';
+import {mediaParserController} from '../../media-parser-controller';
+import {nodeReader} from '../../node';
+import {parseMedia} from '../../parse-media';
+
+test('should not count samples twice', async () => {
+	const controller = mediaParserController();
+
+	let samples = 0;
+
+	const {slowNumberOfFrames} = await parseMedia({
+		src: exampleVideos.framer24fps,
+		controller,
+		reader: nodeReader,
+		fields: {
+			slowNumberOfFrames: true,
+		},
+		onVideoTrack: () => {
+			return () => {
+				samples++;
+				if (samples === 100) {
+					controller._experimentalSeek({
+						type: 'keyframe-before-time-in-seconds',
+						time: 0,
+					});
+				}
+			};
+		},
+		acknowledgeRemotionLicense: true,
+	});
+
+	expect(slowNumberOfFrames).toBe(100);
+	expect(samples).toBe(200);
+});

--- a/packages/media-parser/src/test/seeking/seek-todos.test.ts
+++ b/packages/media-parser/src/test/seeking/seek-todos.test.ts
@@ -1,6 +1,5 @@
 import {test} from 'bun:test';
 
-test.todo('should not count samples twice');
 test.todo(
 	'should not calculate slow fps, slow duration, slow keyframes etc. if there was seeking inbetween',
 );

--- a/packages/media-parser/src/test/transportstream.test.ts
+++ b/packages/media-parser/src/test/transportstream.test.ts
@@ -191,7 +191,7 @@ test('Transport stream', async () => {
 	expect(audioCodec).toBe('aac');
 	expect(fps).toBe(null);
 	expect(slowFps).toBe(59.999999999999986);
-	expect(slowDurationInSeconds).toBe(4.966666666666668);
+	expect(slowDurationInSeconds).toBe(5.119999999999999);
 	expect(isHdr).toBe(true);
 	expect(videoCodec).toBe('h264');
 	expect(videoSamples).toBe(298);


### PR DESCRIPTION
`@remotion/media-parser`: Not counting samples twice if seeking has happened