### PR TITLE
fix: select composition logLevel is not passed correctly

### DIFF
--- a/packages/renderer/src/select-composition.ts
+++ b/packages/renderer/src/select-composition.ts
@@ -313,7 +313,7 @@ export const selectComposition = async (
 	} = options;
 
 	const indent = false;
-	const logLevel = (passedLogLevel ?? verbose) ? 'verbose' : 'info';
+	const logLevel = passedLogLevel ?? (verbose ? 'verbose' : 'info');
 
 	const data = await internalSelectComposition({
 		id,


### PR DESCRIPTION
I noticed that `selectComposition` will not respect the passed `logLevel`. Inspected the code and find out this issue!