### PR TITLE
Templates: Load less fonts

### DIFF
--- a/packages/template-code-hike/src/font.ts
+++ b/packages/template-code-hike/src/font.ts
@@ -1,6 +1,9 @@
 import { loadFont } from "@remotion/google-fonts/RobotoMono";
 
-export const { fontFamily, waitUntilDone } = loadFont();
+export const { fontFamily, waitUntilDone } = loadFont("normal", {
+  subsets: ["latin"],
+  weights: ["400", "700"],
+});
 export const fontSize = 40;
 export const tabSize = 3;
 export const horizontalPadding = 60;

--- a/packages/template-next-app-tailwind/src/remotion/MyComp/Main.tsx
+++ b/packages/template-next-app-tailwind/src/remotion/MyComp/Main.tsx
@@ -13,8 +13,10 @@ import React from "react";
 import { Rings } from "./Rings";
 import { TextFade } from "./TextFade";
 
-loadFont();
-
+loadFont("normal", {
+  subsets: ["latin"],
+  weights: ["400", "700"],
+});
 export const Main = ({ title }: z.infer<typeof CompositionProps>) => {
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();

--- a/packages/template-next-app/src/remotion/MyComp/Main.tsx
+++ b/packages/template-next-app/src/remotion/MyComp/Main.tsx
@@ -13,7 +13,10 @@ import { Rings } from "./Rings";
 import { TextFade } from "./TextFade";
 import { CompositionProps } from "../../types/constants";
 
-loadFont();
+loadFont("normal", {
+  subsets: ["latin"],
+  weights: ["400", "700"],
+});
 
 const container: React.CSSProperties = {
   backgroundColor: "white",

--- a/packages/template-next-pages/src/remotion/MyComp/Main.tsx
+++ b/packages/template-next-pages/src/remotion/MyComp/Main.tsx
@@ -13,7 +13,10 @@ import { Rings } from "./Rings";
 import { TextFade } from "./TextFade";
 import { CompositionProps } from "../../../types/constants";
 
-loadFont();
+loadFont("normal", {
+  subsets: ["latin"],
+  weights: ["400", "700"],
+});
 
 const container: React.CSSProperties = {
   backgroundColor: "white",

--- a/packages/template-overlay/src/Overlay.tsx
+++ b/packages/template-overlay/src/Overlay.tsx
@@ -8,7 +8,10 @@ import {
 import React, { useMemo } from "react";
 import { loadFont } from "@remotion/google-fonts/Roboto";
 
-const { fontFamily } = loadFont();
+const { fontFamily } = loadFont("normal", {
+  subsets: ["latin"],
+  weights: ["400", "700"],
+});
 
 const title: React.CSSProperties = {
   fontFamily,


### PR DESCRIPTION
Loading Inter would make a lot of network requests.
By default, load less fonts. This will also solve errors like #5071.