### PR TITLE
`@remotion/studio`: Fix Timeline Visibility Toggler shrinking when toggling it if there is a long name

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"watch": "turbo watch make --concurrency=2 --experimental-write-cache",
 		"watchwebcodecs": "turbo watch make --experimental-write-cache --filter='@remotion/media-parser' --filter='@remotion/webcodecs'",
 		"watchcore": "turbo watch make --experimental-write-cache --filter='remotion'",
+		"watchstudio": "turbo watch make --experimental-write-cache --filter='remotion/studio'",
 		"watchserverless": "turbo watch make --experimental-write-cache --filter='@remotion/lambda' --filter='@remotion/serverless' --filter='@remotion/streaming'",
 		"release-alpha": "pnpm recursive publish --tag=alpha --no-git-checks && pnpm recursive run --sequential publishprivate",
 		"release": "pnpm recursive publish && pnpm recursive run --sequential publishprivate && git push --tags && git push",

--- a/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
+++ b/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
@@ -23,6 +23,7 @@ const container: React.CSSProperties = {
 	justifyContent: 'center',
 	alignItems: 'center',
 	marginRight: 6,
+	flexShrink: 0,
 };
 
 let layerPointedDown: null | 'enable' | 'disable' = null;


### PR DESCRIPTION
`@remotion/studio`: Fix Timeline Visibility Toggler shrinking when toggling it if there is a long name