### PR TITLE
Create "Font loading error" section in troubleshooting docs

### DIFF
--- a/packages/docs/docs/google-fonts/index.mdx
+++ b/packages/docs/docs/google-fonts/index.mdx
@@ -144,6 +144,12 @@ console.log(getAvailableFonts());
 
 <TableOfContents />
 
+## Troubleshooting
+
+Known issues:
+
+- [delayRender timeout when fetching fonts](/docs/troubleshooting/font-loading-errors#render-timeout-when-loading-google-fonts)
+
 ## Credits
 
 Implemented by [Hidayatullah](https://github.com/ayatkyo).

--- a/packages/docs/docs/troubleshooting/font-loading-errors.mdx
+++ b/packages/docs/docs/troubleshooting/font-loading-errors.mdx
@@ -1,0 +1,36 @@
+---
+image: /generated/articles-docs-troubleshooting-font-loading-errors.png
+id: font-loading-errors
+title: 'Font loading errors'
+sidebar_label: Font loading errors
+crumb: 'Troubleshooting'
+---
+
+## Render timeout when loading Google Fonts
+
+When using `@remotion/google-fonts`, you may encounter timeout errors like:
+
+```diff
+- A delayRender() "Fetching Inter font {"style":"normal","weight":"100","subset":"cyrillic-ext"}" was called but not cleared after 58000ms.
+```
+
+### Problem
+
+By default, `loadFont()` attempts to load all available font weights and character subsets, which can cause timeouts.
+
+### Solution
+
+Only load the specific font weights and character subsets that your project needs:
+
+```tsx
+import {loadFont} from '@remotion/google-fonts/Inter';
+
+// ❌ Avoid: Loading all weights and subsets
+loadFont();
+
+// ✅ Recommended: Load only required weights and subsets
+loadFont('normal', {
+  subsets: ['latin'],
+  weights: ['400', '700'], // Only load regular (400) and bold (700)
+});
+```

--- a/packages/docs/docs/troubleshooting/render-stuck.mdx
+++ b/packages/docs/docs/troubleshooting/render-stuck.mdx
@@ -18,7 +18,7 @@ If the `delayRender()` timeout is bigger than the Lambda function timeout, the L
 To debug the issue:
 
 - Set the `delayRender()` timeout value to a smaller value, so that if it does not resolve, an error message is shown.
-- Always sse [`cancelRender()`](/docs/cancel-render) to handle any error that prevents you from calling `continueRender()`.
+- Always use [`cancelRender()`](/docs/cancel-render) to handle any error that prevents you from calling `continueRender()`.
 
 ## Enable verbose logging
 

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -1118,6 +1118,7 @@ module.exports = {
 				'troubleshooting/could-not-find-executable-to-run',
 				'troubleshooting/stuck-render',
 				'troubleshooting/no-frame-found-at-position',
+				'troubleshooting/font-loading-errors',
 			],
 		},
 		{

--- a/packages/google-fonts/src/base.ts
+++ b/packages/google-fonts/src/base.ts
@@ -93,14 +93,20 @@ export const loadFonts = (
 					continue;
 				}
 
-				const handle = delayRender(
-					`Fetching ${meta.fontFamily} font ${JSON.stringify({
-						style,
-						weight,
-						subset,
-					})}`,
-					{timeoutInMilliseconds: 60000},
-				);
+				const weightsAndSubsetsAreSpecified =
+					options?.weights && options?.subsets;
+
+				const baseLabel = `Fetching ${meta.fontFamily} font ${JSON.stringify({
+					style,
+					weight,
+					subset,
+				})}`;
+
+				const label = weightsAndSubsetsAreSpecified
+					? baseLabel
+					: `${baseLabel}. This might be caused by loading too many font variations. Read more: https://www.remotion.dev/docs/troubleshooting/font-loading-errors#render-timeout-when-loading-google-fonts`;
+
+				const handle = delayRender(label, {timeoutInMilliseconds: 60000});
 				fontsLoaded++;
 
 				//  Create font-face


### PR DESCRIPTION
- Create a "Font loading error" section in troubleshooting docs
- Reference the doc in `@remotion/google-fonts`
- Reference the error in `loadFont()` if the user hasn't specified `weights` and `subsets` fields