### PR TITLE
Upgrade runner image in Discord notify action

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -4,7 +4,7 @@ on: [push, pull_request_target]
 
 jobs:
   notify_discord:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: always() && github.repository == 'remotion-dev/remotion' && (github.event_name == 'pull_request_target' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
 
     steps:


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Discord notification action is failing in latest PRs because of this:
https://github.com/actions/runner-images/issues/11101

Let's upgrade this to `ubuntu-24.04`