### PR TITLE
`@remotion/media-parser`: Disable some seeking hints for now

### DIFF
--- a/packages/media-parser/src/containers/iso-base-media/get-keyframes.ts
+++ b/packages/media-parser/src/containers/iso-base-media/get-keyframes.ts
@@ -8,7 +8,7 @@ import {getMoofBoxes, getTfraBoxes} from './traversal';
 export const getKeyframesFromIsoBaseMedia = (
 	state: ParserState,
 ): MediaParserKeyframe[] => {
-	const {videoTracks} = getTracksFromIsoBaseMedia(state);
+	const {videoTracks} = getTracksFromIsoBaseMedia(state, true);
 	const structure = state.structure.getIsoStructure();
 
 	const moofBoxes = getMoofBoxes(structure.boxes);

--- a/packages/media-parser/src/containers/iso-base-media/mdat/mdat.ts
+++ b/packages/media-parser/src/containers/iso-base-media/mdat/mdat.ts
@@ -28,7 +28,6 @@ export const parseMdatSection = async (
 		return makeSkip(endOfMdat);
 	}
 
-	const alreadyHasParsedMdat = getHasTracks(state, false);
 	const alreadyHasMoov = getHasTracks(state, true);
 
 	if (!alreadyHasMoov) {

--- a/packages/media-parser/src/containers/iso-base-media/mdat/mdat.ts
+++ b/packages/media-parser/src/containers/iso-base-media/mdat/mdat.ts
@@ -28,7 +28,7 @@ export const parseMdatSection = async (
 		return makeSkip(endOfMdat);
 	}
 
-	const alreadyHas = getHasTracks(state);
+	const alreadyHas = getHasTracks(state, false);
 
 	if (!alreadyHas) {
 		const moov = await getMoovAtom({

--- a/packages/media-parser/src/containers/iso-base-media/mdat/mdat.ts
+++ b/packages/media-parser/src/containers/iso-base-media/mdat/mdat.ts
@@ -28,9 +28,10 @@ export const parseMdatSection = async (
 		return makeSkip(endOfMdat);
 	}
 
-	const alreadyHas = getHasTracks(state, false);
+	const alreadyHasParsedMdat = getHasTracks(state, false);
+	const alreadyHasMoov = getHasTracks(state, true);
 
-	if (!alreadyHas) {
+	if (!alreadyHasMoov) {
 		const moov = await getMoovAtom({
 			endOfMdat,
 			state,
@@ -40,8 +41,8 @@ export const parseMdatSection = async (
 			precomputed: false,
 		});
 		state.callbacks.tracks.setIsDone(state.logLevel);
-		state.structure.getIsoStructure().boxes.push(moov);
 
+		state.structure.getIsoStructure().boxes.push(moov);
 		return parseMdatSection(state);
 	}
 

--- a/packages/media-parser/src/containers/iso-base-media/seeking-hints.ts
+++ b/packages/media-parser/src/containers/iso-base-media/seeking-hints.ts
@@ -24,6 +24,7 @@ export const getSeekingHintsFromMp4 = ({
 		isoState,
 		mp4HeaderSegment,
 		structureState,
+		mayUsePrecomputed: true,
 	});
 	const moofBoxes = deduplicateMoofBoxesByOffset([
 		...isoState.moof.getMoofBoxes(),

--- a/packages/media-parser/src/containers/iso-base-media/seeking-hints.ts
+++ b/packages/media-parser/src/containers/iso-base-media/seeking-hints.ts
@@ -60,11 +60,15 @@ export const setSeekingHintsForMp4 = ({
 		moovBox: hints.moovBox,
 		precomputed: true,
 	});
-	state.iso.mfra.setFromSeekingHints(hints);
-	state.iso.moof.setMoofBoxes(hints.moofBoxes);
-	state.iso.tfra.setTfraBoxes(hints.tfraBoxes);
+	// 	state.iso.mfra.setFromSeekingHints(hints);
+	// state.iso.moof.setMoofBoxes(hints.moofBoxes);
+
+	// TODO: Make use of these seeking hints and make tests pass
+	/*
+	//	state.iso.tfra.setTfraBoxes(hints.tfraBoxes);
 
 	for (const mediaSection of hints.mediaSections) {
-		state.mediaSection.addMediaSection(mediaSection);
+		// state.mediaSection.addMediaSection(mediaSection);
 	}
+	*/
 };

--- a/packages/media-parser/src/containers/iso-base-media/traversal.ts
+++ b/packages/media-parser/src/containers/iso-base-media/traversal.ts
@@ -46,14 +46,16 @@ export const getMoovBoxFromState = ({
 	structureState,
 	isoState,
 	mp4HeaderSegment,
+	mayUsePrecomputed,
 }: {
 	structureState: StructureState;
 	isoState: IsoBaseMediaState;
 	mp4HeaderSegment: IsoBaseMediaStructure | null;
+	mayUsePrecomputed: boolean;
 }): MoovBox | null => {
 	const got = isoState.moov.getMoovBoxAndPrecomputed();
 
-	if (got) {
+	if (got && (mayUsePrecomputed || !got.precomputed)) {
 		return got.moovBox;
 	}
 

--- a/packages/media-parser/src/containers/riff/parse-video-section.ts
+++ b/packages/media-parser/src/containers/riff/parse-video-section.ts
@@ -8,7 +8,7 @@ export const parseMediaSection = async (state: ParserState): Promise<void> => {
 		state,
 	});
 
-	const tracks = getTracks(state);
+	const tracks = getTracks(state, false);
 	if (
 		!tracks.videoTracks.some((t) => t.codec === TO_BE_OVERRIDDEN_LATER) &&
 		!state.callbacks.tracks.getIsDone()

--- a/packages/media-parser/src/emit-available-info.ts
+++ b/packages/media-parser/src/emit-available-info.ts
@@ -221,7 +221,7 @@ export const emitAvailableInfo = async ({
 
 		if (key === 'tracks') {
 			if (!emittedFields.tracks && hasInfo.tracks) {
-				const {videoTracks, audioTracks} = getTracks(state);
+				const {videoTracks, audioTracks} = getTracks(state, true);
 				await callbackFunctions.onTracks?.({videoTracks, audioTracks});
 				if (fieldsInReturnValue.tracks) {
 					returnValue.tracks = {videoTracks, audioTracks};

--- a/packages/media-parser/src/get-audio-codec.ts
+++ b/packages/media-parser/src/get-audio-codec.ts
@@ -15,7 +15,7 @@ import type {ParserState} from './state/parser-state';
 export const getAudioCodec = (
 	parserState: ParserState,
 ): MediaParserAudioCodec | null => {
-	const tracks = getTracks(parserState);
+	const tracks = getTracks(parserState, true);
 	const allTracks =
 		tracks.audioTracks.length +
 		tracks.otherTracks.length +
@@ -38,7 +38,7 @@ export const getAudioCodec = (
 };
 
 export const hasAudioCodec = (state: ParserState): boolean => {
-	return getHasTracks(state);
+	return getHasTracks(state, true);
 };
 
 const getCodecSpecificatorFromEsdsBox = ({

--- a/packages/media-parser/src/get-dimensions.ts
+++ b/packages/media-parser/src/get-dimensions.ts
@@ -21,7 +21,7 @@ export const getDimensions = (
 		return null;
 	}
 
-	const {videoTracks} = getTracks(state);
+	const {videoTracks} = getTracks(state, true);
 	if (!videoTracks.length) {
 		return null;
 	}

--- a/packages/media-parser/src/get-duration.ts
+++ b/packages/media-parser/src/get-duration.ts
@@ -61,6 +61,7 @@ const getDurationFromIsoBaseMedia = (parserState: ParserState) => {
 		structureState: parserState.structure,
 		isoState: parserState.iso,
 		mp4HeaderSegment: parserState.mp4HeaderSegment,
+		mayUsePrecomputed: true,
 	});
 	if (!moovBox) {
 		return null;
@@ -82,7 +83,7 @@ const getDurationFromIsoBaseMedia = (parserState: ParserState) => {
 		return mvhdBox.durationInSeconds;
 	}
 
-	const tracks = getTracks(parserState);
+	const tracks = getTracks(parserState, true);
 	const allTracks = [
 		...tracks.videoTracks,
 		...tracks.audioTracks,
@@ -169,7 +170,7 @@ export const hasDuration = (parserState: ParserState): boolean => {
 		return false;
 	}
 
-	return getHasTracks(parserState);
+	return getHasTracks(parserState, true);
 };
 
 // `slowDuration` goes through everything, and therefore is false

--- a/packages/media-parser/src/get-fps.ts
+++ b/packages/media-parser/src/get-fps.ts
@@ -104,6 +104,7 @@ const getFpsFromIsoMaseMedia = (state: ParserState) => {
 		structureState: state.structure,
 		isoState: state.iso,
 		mp4HeaderSegment: state.mp4HeaderSegment,
+		mayUsePrecomputed: true,
 	});
 	if (!moovBox) {
 		return null;

--- a/packages/media-parser/src/get-is-hdr.ts
+++ b/packages/media-parser/src/get-is-hdr.ts
@@ -11,11 +11,11 @@ const isVideoTrackHdr = (track: VideoTrack) => {
 };
 
 export const getIsHdr = (state: ParserState): boolean => {
-	const {videoTracks} = getTracks(state);
+	const {videoTracks} = getTracks(state, true);
 
 	return videoTracks.some((track) => isVideoTrackHdr(track));
 };
 
 export const hasHdr = (state: ParserState): boolean => {
-	return getHasTracks(state);
+	return getHasTracks(state, true);
 };

--- a/packages/media-parser/src/get-keyframes.ts
+++ b/packages/media-parser/src/get-keyframes.ts
@@ -18,7 +18,7 @@ export const getKeyframes = (
 export const hasKeyframes = (parserState: ParserState) => {
 	const structure = parserState.structure.getStructure();
 	if (structure.type === 'iso-base-media') {
-		return getHasTracks(parserState);
+		return getHasTracks(parserState, true);
 	}
 
 	// Has, but will be null

--- a/packages/media-parser/src/get-seeking-byte.ts
+++ b/packages/media-parser/src/get-seeking-byte.ts
@@ -2,9 +2,11 @@ import {getSeekingByteFromIsoBaseMedia} from './containers/iso-base-media/get-se
 import {getSeekingByteFromWav} from './containers/wav/get-seeking-byte';
 import {getSeekingByteFromMatroska} from './containers/webm/seek/get-seeking-byte';
 import type {LogLevel} from './log';
+import type {IsoBaseMediaStructure} from './parse-result';
 import type {SeekingHints} from './seeking-hints';
 import type {IsoBaseMediaState} from './state/iso-base-media/iso-state';
 import type {WebmState} from './state/matroska/webm';
+import type {StructureState} from './state/structure';
 import {getLastKeyFrameBeforeTimeInSeconds} from './state/transport-stream/observed-pes-header';
 import type {TransportStreamState} from './state/transport-stream/transport-stream';
 import type {MediaSectionState} from './state/video-section';
@@ -19,6 +21,8 @@ export const getSeekingByte = ({
 	transportStream,
 	webmState,
 	mediaSection,
+	mp4HeaderSegment,
+	structure,
 }: {
 	info: SeekingHints;
 	time: number;
@@ -28,6 +32,8 @@ export const getSeekingByte = ({
 	transportStream: TransportStreamState;
 	webmState: WebmState;
 	mediaSection: MediaSectionState;
+	structure: StructureState;
+	mp4HeaderSegment: IsoBaseMediaStructure | null;
 }): Promise<SeekResolution> => {
 	if (info.type === 'iso-base-media-seeking-hints') {
 		return getSeekingByteFromIsoBaseMedia({
@@ -36,6 +42,8 @@ export const getSeekingByte = ({
 			logLevel,
 			currentPosition,
 			isoState,
+			mp4HeaderSegment,
+			structure,
 		});
 	}
 

--- a/packages/media-parser/src/get-tracks.ts
+++ b/packages/media-parser/src/get-tracks.ts
@@ -113,17 +113,24 @@ export const getNumberOfTracks = (moovBox: MoovBox): number => {
 	return mvHdBox.nextTrackId - 1;
 };
 
-export const isoBaseMediaHasTracks = (state: ParserState) => {
+export const isoBaseMediaHasTracks = (
+	state: ParserState,
+	mayUsePrecomputed: boolean,
+) => {
 	return Boolean(
 		getMoovBoxFromState({
 			structureState: state.structure,
 			isoState: state.iso,
 			mp4HeaderSegment: state.mp4HeaderSegment,
+			mayUsePrecomputed,
 		}),
 	);
 };
 
-export const getHasTracks = (state: ParserState): boolean => {
+export const getHasTracks = (
+	state: ParserState,
+	mayUsePrecomputed: boolean,
+): boolean => {
 	const structure = state.structure.getStructure();
 	if (structure.type === 'matroska') {
 		return matroskaHasTracks({
@@ -133,7 +140,7 @@ export const getHasTracks = (state: ParserState): boolean => {
 	}
 
 	if (structure.type === 'iso-base-media') {
-		return isoBaseMediaHasTracks(state);
+		return isoBaseMediaHasTracks(state, mayUsePrecomputed);
 	}
 
 	if (structure.type === 'riff') {
@@ -222,11 +229,15 @@ export const getTracksFromMoovBox = (moovBox: MoovBox) => {
 	};
 };
 
-export const getTracksFromIsoBaseMedia = (state: ParserState) => {
+export const getTracksFromIsoBaseMedia = (
+	state: ParserState,
+	mayUsePrecomputed: boolean,
+) => {
 	const moovBox = getMoovBoxFromState({
 		structureState: state.structure,
 		isoState: state.iso,
 		mp4HeaderSegment: state.mp4HeaderSegment,
+		mayUsePrecomputed,
 	});
 	if (!moovBox) {
 		return {
@@ -261,14 +272,17 @@ export const defaultHasallTracks = (parserState: ParserState): boolean => {
 	}
 };
 
-export const getTracks = (state: ParserState): AllTracks => {
+export const getTracks = (
+	state: ParserState,
+	mayUsePrecomputed: boolean,
+): AllTracks => {
 	const structure = state.structure.getStructure();
 	if (structure.type === 'matroska') {
 		return getCategorizedTracksFromMatroska(state);
 	}
 
 	if (structure.type === 'iso-base-media') {
-		return getTracksFromIsoBaseMedia(state);
+		return getTracksFromIsoBaseMedia(state, mayUsePrecomputed);
 	}
 
 	if (structure.type === 'riff') {

--- a/packages/media-parser/src/get-video-codec.ts
+++ b/packages/media-parser/src/get-video-codec.ts
@@ -23,12 +23,12 @@ import type {ParserState} from './state/parser-state';
 export const getVideoCodec = (
 	state: ParserState,
 ): MediaParserVideoCodec | null => {
-	const track = getTracks(state);
+	const track = getTracks(state, true);
 	return track.videoTracks[0]?.codecWithoutConfig ?? null;
 };
 
 export const hasVideoCodec = (state: ParserState): boolean => {
-	return getHasTracks(state);
+	return getHasTracks(state, true);
 };
 
 export const getVideoPrivateData = (trakBox: TrakBox): Uint8Array | null => {

--- a/packages/media-parser/src/has-all-info.ts
+++ b/packages/media-parser/src/has-all-info.ts
@@ -72,7 +72,7 @@ export const getAvailableInfo = ({
 		}
 
 		if (key === 'tracks') {
-			return Boolean(structure && getHasTracks(state));
+			return Boolean(structure && getHasTracks(state, true));
 		}
 
 		if (key === 'keyframes') {

--- a/packages/media-parser/src/metadata/metadata-from-iso.ts
+++ b/packages/media-parser/src/metadata/metadata-from-iso.ts
@@ -154,6 +154,7 @@ export const getMetadataFromIsoBase = (
 		structureState: state.structure,
 		isoState: state.iso,
 		mp4HeaderSegment: state.mp4HeaderSegment,
+		mayUsePrecomputed: true,
 	});
 	if (!moov) {
 		return [];

--- a/packages/media-parser/src/state/iso-base-media/cached-sample-positions.ts
+++ b/packages/media-parser/src/state/iso-base-media/cached-sample-positions.ts
@@ -15,7 +15,7 @@ export type FlatSample = {
 };
 
 export const calculateFlatSamples = (state: ParserState) => {
-	const tracks = getTracks(state);
+	const tracks = getTracks(state, true);
 	const allTracks = [
 		...tracks.videoTracks,
 		...tracks.audioTracks,

--- a/packages/media-parser/src/test/seeking/seek-moof.test.ts
+++ b/packages/media-parser/src/test/seeking/seek-moof.test.ts
@@ -143,8 +143,8 @@ test('should use seeking hints from previous parse', async () => {
 		controller2._internals.performedSeeksSignal.getPerformedSeeks();
 	// Wow, jumping straight ahead
 	expect(performedSeeks[0]).toEqual({
-		from: 0,
-		to: 1215224,
+		from: 2052,
+		to: 1214780,
 		type: 'user-initiated',
 	});
 });

--- a/packages/media-parser/src/work-on-seek-request.ts
+++ b/packages/media-parser/src/work-on-seek-request.ts
@@ -88,6 +88,8 @@ const turnSeekIntoByte = async ({
 			transportStream,
 			webmState,
 			mediaSection: mediaSectionState,
+			mp4HeaderSegment,
+			structure: structureState,
 		});
 
 		return seekingByte;


### PR DESCRIPTION
`@remotion/media-parser`: Fix MP4 seeking hints preventing conversion