### PR TITLE
Remove specifics on Cloud Rendering Units

### DIFF
--- a/packages/docs/docs/cloudrun.mdx
+++ b/packages/docs/docs/cloudrun.mdx
@@ -7,7 +7,13 @@ title: '@remotion/cloudrun'
 
 <ExperimentalBadge>
   <p>
-    Cloud Run is in <a href="/docs/cloudrun-alpha">Alpha</a>, which means APIs may change in any version and documentation is not yet finished. See the{' '}<a href="https://remotion.dev/changelog">changelog to stay up to date with breaking changes</a>.
+    Cloud Run is in <a href="/docs/cloudrun-alpha">Alpha</a>, which means APIs
+    may change in any version and documentation is not yet finished. See the{' '}
+    <a href="https://remotion.dev/changelog">
+      {' '}
+      changelog to stay up to date with breaking changes
+    </a>
+    .
   </p>
 </ExperimentalBadge>
 
@@ -83,9 +89,9 @@ Everything you can do using the CLI, you can also control using Node.JS APIs. Se
 
 ## License
 
-The standard Remotion license applies. https://github.com/remotion-dev/remotion/blob/main/LICENSE.md
+The standard Remotion license applies: https://github.com/remotion-dev/remotion/blob/main/LICENSE.md
 
-Companies need to buy 1 cloud rendering seat per 2000 renders per month - see https://remotion.pro
+Companies needing a license and using cloud rendering must set it up with Cloud Rendering Units. Please visit: https://remotion.pro/license.
 
 ## Uninstalling
 

--- a/packages/docs/docs/cloudrun.mdx
+++ b/packages/docs/docs/cloudrun.mdx
@@ -91,7 +91,7 @@ Everything you can do using the CLI, you can also control using Node.JS APIs. Se
 
 The standard Remotion license applies: https://github.com/remotion-dev/remotion/blob/main/LICENSE.md
 
-Companies needing a license and using cloud rendering must set it up with Cloud Rendering Units. Please visit: https://remotion.pro/license.
+Companies needing a license and using cloud rendering must set it up with Cloud Rendering Units. Please visit: https://remotion.pro/license
 
 ## Uninstalling
 

--- a/packages/docs/docs/lambda.mdx
+++ b/packages/docs/docs/lambda.mdx
@@ -85,7 +85,7 @@ Everything you can do using the CLI, you can also control using Node.JS APIs. Se
 
 The standard Remotion license applies: https://github.com/remotion-dev/remotion/blob/main/LICENSE.md
 
-Companies needing a license and using cloud rendering must set it up with Cloud Rendering Units. Please visit: https://remotion.pro/license.
+Companies needing a license and using cloud rendering must set it up with Cloud Rendering Units. Please visit: https://remotion.pro/license
 
 ## Uninstalling
 

--- a/packages/docs/docs/lambda.mdx
+++ b/packages/docs/docs/lambda.mdx
@@ -83,9 +83,9 @@ Everything you can do using the CLI, you can also control using Node.JS APIs. Se
 
 ## License
 
-The standard Remotion license applies. https://github.com/remotion-dev/remotion/blob/main/LICENSE.md
+The standard Remotion license applies: https://github.com/remotion-dev/remotion/blob/main/LICENSE.md
 
-Companies need to buy 1 cloud rendering seat per 2000 renders per month - see https://remotion.pro
+Companies needing a license and using cloud rendering must set it up with Cloud Rendering Units. Please visit: https://remotion.pro/license.
 
 ## Uninstalling
 


### PR DESCRIPTION
We had on old license specification, which makes it complicated and confusing once the terms change.


