### PR TITLE
`remotion`: Call the internal type the same as the external type

### DIFF
--- a/packages/core/src/validate-media-props.ts
+++ b/packages/core/src/validate-media-props.ts
@@ -1,9 +1,9 @@
 import type {RemotionAudioProps} from './audio/index.js';
 import type {RemotionVideoProps} from './video/index.js';
-import type {OffthreadVideoProps} from './video/props.js';
+import type {RemotionOffthreadVideoProps} from './video/props.js';
 
 export const validateMediaProps = (
-	props: RemotionVideoProps | RemotionAudioProps | OffthreadVideoProps,
+	props: RemotionVideoProps | RemotionAudioProps | RemotionOffthreadVideoProps,
 	component: 'Video' | 'Audio',
 ) => {
 	if (

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -5,13 +5,15 @@ import {validateMediaProps} from '../validate-media-props.js';
 import {validateStartFromProps} from '../validate-start-from-props.js';
 import {OffthreadVideoForRendering} from './OffthreadVideoForRendering.js';
 import {VideoForPreview} from './VideoForPreview.js';
-import type {OffthreadVideoProps} from './props.js';
+import type {RemotionOffthreadVideoProps} from './props.js';
 
 /*
  * @description This method imports and displays a video, similar to <Video />. During rendering, it extracts the exact frame from the video and displays it in an <img> tag
  * @see [Documentation](https://www.remotion.dev/docs/offthreadvideo)
  */
-export const OffthreadVideo: React.FC<OffthreadVideoProps> = (props) => {
+export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = (
+	props,
+) => {
 	// Should only destruct `startFrom` and `endAt` from props,
 	// rest gets drilled down
 	const {

--- a/packages/core/src/video/OffthreadVideoForRendering.tsx
+++ b/packages/core/src/video/OffthreadVideoForRendering.tsx
@@ -25,14 +25,16 @@ import {useUnsafeVideoConfig} from '../use-unsafe-video-config.js';
 import {evaluateVolume} from '../volume-prop.js';
 import {getExpectedMediaFrameUncorrected} from './get-current-time.js';
 import {getOffthreadVideoSource} from './offthread-video-source.js';
-import type {OffthreadVideoProps} from './props.js';
+import type {RemotionOffthreadVideoProps} from './props.js';
 
 type SrcAndHandle = {
 	src: string;
 	handle: ReturnType<typeof delayRender>;
 };
 
-export const OffthreadVideoForRendering: React.FC<OffthreadVideoProps> = ({
+export const OffthreadVideoForRendering: React.FC<
+	RemotionOffthreadVideoProps
+> = ({
 	onError,
 	volume: volumeProp,
 	playbackRate,

--- a/packages/core/src/video/index.ts
+++ b/packages/core/src/video/index.ts
@@ -1,7 +1,8 @@
 export {OffthreadVideo} from './OffthreadVideo.js';
 export type {
+	RemotionOffthreadVideoProps as OffthreadVideoProps,
 	RemotionMainVideoProps,
-	OffthreadVideoProps as RemotionOffthreadVideoProps,
+	RemotionOffthreadVideoProps,
 	RemotionVideoProps,
 } from './props';
 export {Video} from './Video.js';

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -45,7 +45,7 @@ type DeprecatedOffthreadVideoProps = {
 	imageFormat?: never;
 };
 
-export type OffthreadVideoProps = {
+export type RemotionOffthreadVideoProps = {
 	src: string;
 	className?: string;
 	name?: string;

--- a/packages/docs/docs/player/api.mdx
+++ b/packages/docs/docs/player/api.mdx
@@ -854,7 +854,7 @@ playerRef.current.addEventListener('mutechange', (e) => {
 
 ### `error`
 
-Fires when an error or uncaught exception has happened in the video.
+Fires when an error or uncaught exception has happened in the React component.
 
 You may get the error by reading the `e.detail.error` value:
 


### PR DESCRIPTION
with alias to not have breakage