### PR TITLE
`remotion`: Remain `#x=y` hashes when combining prefetching and custom hashes

### DIFF
--- a/packages/core/src/prefetch.ts
+++ b/packages/core/src/prefetch.ts
@@ -5,10 +5,38 @@ import {Log} from './log.js';
 import {playbackLogging} from './playback-logging.js';
 import {PreloadContext, setPreloads} from './prefetch-state.js';
 
+export const removeAndGetHashFragment = (src: string) => {
+	const hashIndex = src.indexOf('#');
+	if (hashIndex === -1) {
+		return null;
+	}
+
+	return hashIndex;
+};
+
+export const getSrcWithoutHash = (src: string) => {
+	const hashIndex = removeAndGetHashFragment(src);
+	if (hashIndex === null) {
+		return src;
+	}
+
+	return src.slice(0, hashIndex);
+};
+
 export const usePreload = (src: string): string => {
 	const preloads = useContext(PreloadContext);
+	const hashFragmentIndex = removeAndGetHashFragment(src);
+	const withoutHashFragment = getSrcWithoutHash(src);
 
-	return preloads[src] ?? src;
+	if (!preloads[withoutHashFragment]) {
+		return src;
+	}
+
+	if (hashFragmentIndex !== null) {
+		return preloads[withoutHashFragment] + src.slice(hashFragmentIndex);
+	}
+
+	return preloads[withoutHashFragment];
 };
 
 type FetchAndPreload = {
@@ -94,15 +122,16 @@ export const prefetch = (
 ): FetchAndPreload => {
 	const method = options?.method ?? 'blob-url';
 	const logLevel = options?.logLevel ?? 'info';
+	const srcWithoutHash = getSrcWithoutHash(src);
 
 	if (getRemotionEnvironment().isRendering) {
 		return {
 			free: () => undefined,
-			waitUntilDone: () => Promise.resolve(src),
+			waitUntilDone: () => Promise.resolve(srcWithoutHash),
 		};
 	}
 
-	Log.verbose(logLevel, `[prefetch] Starting prefetch ${src}`);
+	Log.verbose(logLevel, `[prefetch] Starting prefetch ${srcWithoutHash}`);
 
 	let canceled = false;
 	let objectUrl: string | null = null;
@@ -117,7 +146,7 @@ export const prefetch = (
 	const controller = new AbortController();
 	let canBeAborted = true;
 
-	fetch(src, {
+	fetch(srcWithoutHash, {
 		signal: controller.signal,
 		credentials: options?.credentials ?? undefined,
 	})
@@ -143,12 +172,12 @@ export const prefetch = (
 			if (!hasProperContentType) {
 				// eslint-disable-next-line no-console
 				console.warn(
-					`Called prefetch() on ${src} which returned a "Content-Type" of ${headerContentType}. Prefetched content should have a proper content type (video/... or audio/...) or a contentType passed the options of prefetch(). Otherwise, prefetching will not work properly in all browsers.`,
+					`Called prefetch() on ${srcWithoutHash} which returned a "Content-Type" of ${headerContentType}. Prefetched content should have a proper content type (video/... or audio/...) or a contentType passed the options of prefetch(). Otherwise, prefetching will not work properly in all browsers.`,
 				);
 			}
 
 			if (!res.body) {
-				throw new Error(`HTTP response of ${src} has no body`);
+				throw new Error(`HTTP response of ${srcWithoutHash} has no body`);
 			}
 
 			const reader = res.body.getReader();
@@ -185,7 +214,7 @@ export const prefetch = (
 			playbackLogging({
 				logLevel,
 				tag: 'prefetch',
-				message: `Finished prefetch ${src} with method ${method}`,
+				message: `Finished prefetch ${srcWithoutHash} with method ${method}`,
 				mountTime: null,
 			});
 
@@ -193,7 +222,7 @@ export const prefetch = (
 
 			setPreloads((p) => ({
 				...p,
-				[src]: objectUrl as string,
+				[srcWithoutHash]: objectUrl as string,
 			}));
 			resolve(objectUrl);
 		})
@@ -210,7 +239,7 @@ export const prefetch = (
 			playbackLogging({
 				logLevel,
 				tag: 'prefetch',
-				message: `Freeing ${src}`,
+				message: `Freeing ${srcWithoutHash}`,
 				mountTime: null,
 			});
 			if (objectUrl) {
@@ -220,7 +249,7 @@ export const prefetch = (
 
 				setPreloads((p) => {
 					const copy = {...p};
-					delete copy[src];
+					delete copy[srcWithoutHash];
 					return copy;
 				});
 			} else {

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -143,8 +143,10 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		? Math.min(parentSequence.durationInFrames, durationInFrames)
 		: durationInFrames;
 
+	const preloadedSrc = usePreload(src as string);
+
 	const actualSrc = useAppendVideoFragment({
-		actualSrc: usePreload(src as string),
+		actualSrc: preloadedSrc,
 		actualFrom,
 		duration,
 		fps,

--- a/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteVideo.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteVideo.tsx
@@ -4,12 +4,15 @@ import {
 	AbsoluteFill,
 	CalculateMetadataFunction,
 	OffthreadVideo,
+	prefetch,
 	staticFile,
 	useCurrentFrame,
 } from 'remotion';
 
 const fps = 30;
-const src = staticFile('bigbuckbunny.mp4');
+const src = staticFile('bigbuckbunny.mp4') + '#t=lol';
+
+prefetch(src);
 
 export const calculateMetadataFn: CalculateMetadataFunction<
 	Record<string, unknown>


### PR DESCRIPTION
`remotion`: Remain `#x=y` hashes when combining prefetching and custom hashes