### PR TITLE
`@remotion/media-parser`: Fix a video converting to MP4, and disable some broken seeking hints for now

### DIFF
--- a/packages/media-parser/src/containers/iso-base-media/process-box.ts
+++ b/packages/media-parser/src/containers/iso-base-media/process-box.ts
@@ -277,6 +277,7 @@ export const processBox = async ({
 			logLevel,
 		});
 		const transformedTrack = makeBaseMediaTrack(box);
+
 		if (transformedTrack && transformedTrack.type === 'video') {
 			await registerVideoTrack({
 				track: transformedTrack,

--- a/packages/media-parser/src/containers/iso-base-media/seeking-hints.ts
+++ b/packages/media-parser/src/containers/iso-base-media/seeking-hints.ts
@@ -49,20 +49,17 @@ export const getSeekingHintsFromMp4 = ({
 	};
 };
 
-export const setSeekingHintsForMp4 = ({
-	hints,
-	state,
-}: {
+// eslint-disable-next-line no-empty-pattern
+export const setSeekingHintsForMp4 = ({}: {
 	hints: IsoBaseMediaSeekingHints;
 	state: ParserState;
 }) => {
-	state.iso.moov.setMoovBox({
-		moovBox: hints.moovBox,
-		precomputed: true,
-	});
+	// state.iso.moov.setMoovBox({
+	//	moovBox: hints.moovBox,
+	//	precomputed: true,
+	// });
 	// 	state.iso.mfra.setFromSeekingHints(hints);
 	// state.iso.moof.setMoofBoxes(hints.moofBoxes);
-
 	// TODO: Make use of these seeking hints and make tests pass
 	/*
 	//	state.iso.tfra.setTfraBoxes(hints.tfraBoxes);

--- a/packages/webcodecs/src/create/iso-base-media/codec-specific/create-codec-specific-data.ts
+++ b/packages/webcodecs/src/create/iso-base-media/codec-specific/create-codec-specific-data.ts
@@ -46,6 +46,11 @@ export const createCodecSpecificData = (
 ) => {
 	if (track.type === 'video') {
 		if (track.codec === 'h264') {
+			// May not have it initially
+			if (!track.codecPrivate) {
+				return new Uint8Array([]);
+			}
+
 			return createAvc1Data({
 				avccBox: createAvccBox(track.codecPrivate),
 				compressorName: 'WebCodecs',
@@ -60,6 +65,11 @@ export const createCodecSpecificData = (
 		}
 
 		if (track.codec === 'h265') {
+			// May not have it initially
+			if (!track.codecPrivate) {
+				return new Uint8Array([]);
+			}
+
 			return createHvc1Data({
 				hvccBox: createHvccBox(track.codecPrivate),
 				compressorName: 'WebCodecs',

--- a/packages/webcodecs/src/create/matroska/create-matroska-media.ts
+++ b/packages/webcodecs/src/create/matroska/create-matroska-media.ts
@@ -243,7 +243,7 @@ export const createMatroskaMedia = async ({
 				}
 			});
 		},
-		getBlob: async () => {
+		getBlob: () => {
 			return w.getBlob();
 		},
 		remove: async () => {


### PR DESCRIPTION
`@remotion/media-parser`: Fix a video converting to MP4, and disable some broken seeking hints for now