### PR TITLE
`@remotion/serverless`: Don't throw error on launch routine to cause a retry

### DIFF
--- a/packages/serverless/src/handlers/launch.ts
+++ b/packages/serverless/src/handlers/launch.ts
@@ -523,9 +523,7 @@ export const launchHandler = async <Provider extends CloudProvider>({
 	options: Options;
 	providerSpecifics: ProviderSpecifics<Provider>;
 	insideFunctionSpecifics: InsideFunctionSpecifics<Provider>;
-}): Promise<{
-	type: 'success';
-}> => {
+}): Promise<void> => {
 	if (params.type !== ServerlessRoutines.launch) {
 		throw new Error('Expected launch type');
 	}
@@ -697,9 +695,7 @@ export const launchHandler = async <Provider extends CloudProvider>({
 		sendTelemetryEvent(params.apiKey ?? null, params.logLevel);
 
 		if (!params.webhook || webhookInvoked) {
-			return {
-				type: 'success',
-			};
+			return;
 		}
 
 		try {
@@ -754,10 +750,6 @@ export const launchHandler = async <Provider extends CloudProvider>({
 		}
 
 		runCleanupTasks();
-
-		return {
-			type: 'success',
-		};
 	} catch (err) {
 		if (process.env.NODE_ENV === 'test') {
 			throw err;

--- a/packages/serverless/src/handlers/launch.ts
+++ b/packages/serverless/src/handlers/launch.ts
@@ -846,8 +846,6 @@ export const launchHandler = async <Provider extends CloudProvider>({
 				);
 			}
 		}
-
-		throw err;
 	} finally {
 		if (instance) {
 			insideFunctionSpecifics.forgetBrowserEventLoop({

--- a/packages/serverless/src/handlers/renderer.ts
+++ b/packages/serverless/src/handlers/renderer.ts
@@ -432,9 +432,7 @@ export const rendererHandler = async <Provider extends CloudProvider>({
 	requestContext: RequestContext;
 	providerSpecifics: ProviderSpecifics<Provider>;
 	insideFunctionSpecifics: InsideFunctionSpecifics<Provider>;
-}): Promise<{
-	type: 'success';
-}> => {
+}): Promise<void> => {
 	if (params.type !== ServerlessRoutines.renderer) {
 		throw new Error('Params must be renderer');
 	}
@@ -457,9 +455,6 @@ export const rendererHandler = async <Provider extends CloudProvider>({
 				instance = browserInstance;
 			},
 		});
-		return {
-			type: 'success',
-		};
 	} catch (err) {
 		if (process.env.NODE_ENV === 'test') {
 			// eslint-disable-next-line no-console
@@ -511,8 +506,6 @@ export const rendererHandler = async <Provider extends CloudProvider>({
 				},
 			},
 		});
-
-		throw err;
 	} finally {
 		if (shouldKeepBrowserOpen && instance) {
 			insideFunctionSpecifics.forgetBrowserEventLoop({

--- a/packages/serverless/src/inner-routine.ts
+++ b/packages/serverless/src/inner-routine.ts
@@ -203,7 +203,7 @@ export const innerHandler = async <Provider extends CloudProvider>({
 			);
 		}
 
-		const response = await launchHandler({
+		await launchHandler({
 			params,
 			options: {
 				expectedBucketOwner: currentUserId,
@@ -213,9 +213,7 @@ export const innerHandler = async <Provider extends CloudProvider>({
 			insideFunctionSpecifics,
 		});
 
-		await responseWriter.write(
-			new TextEncoder().encode(JSON.stringify(response)),
-		);
+		await responseWriter.write(new TextEncoder().encode(JSON.stringify({})));
 		await responseWriter.end();
 		return;
 	}


### PR DESCRIPTION
Lambda will re-invoke the function for some reason otherwise