### PR TITLE
`remotion`: Playback improvements

### DIFF
--- a/packages/core/src/buffer-until-first-frame.ts
+++ b/packages/core/src/buffer-until-first-frame.ts
@@ -3,9 +3,11 @@ import type {LogLevel} from './log';
 import {playbackLogging} from './playback-logging';
 import {useBufferState} from './use-buffer-state';
 
-const isWebkit = () => {
-	const isAppleWebKit = /AppleWebKit/.test(window.navigator.userAgent);
-	return isAppleWebKit;
+const isSafariWebkit = () => {
+	const isSafari = /^((?!chrome|android).)*safari/i.test(
+		window.navigator.userAgent,
+	);
+	return isSafari;
 };
 
 export const useBufferUntilFirstFrame = ({
@@ -42,18 +44,23 @@ export const useBufferUntilFirstFrame = ({
 				return;
 			}
 
-			playbackLogging({
-				logLevel,
-				message: `Checking if should buffer until first frame, ${current.readyState}`,
-				mountTime,
-				tag: 'buffer',
-			});
-
-			if (current.readyState >= current.HAVE_ENOUGH_DATA && !isWebkit()) {
+			if (current.readyState >= current.HAVE_ENOUGH_DATA && !isSafariWebkit()) {
+				playbackLogging({
+					logLevel,
+					message: `Not using buffer until first frame, because readyState is ${current.readyState} and is not Safari`,
+					mountTime,
+					tag: 'buffer',
+				});
 				return;
 			}
 
 			if (!current.requestVideoFrameCallback) {
+				playbackLogging({
+					logLevel,
+					message: `Not using buffer until first frame, because requestVideoFrameCallback is not supported`,
+					mountTime,
+					tag: 'buffer',
+				});
 				return;
 			}
 

--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -2,6 +2,7 @@ import React, {
 	useCallback,
 	useContext,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -110,7 +111,7 @@ const useBufferManager = (
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [blocks]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (blocks.length === 0) {
 			onResumeCallbacks.forEach((c) => c());
 			playbackLogging({

--- a/packages/core/src/use-media-playback.ts
+++ b/packages/core/src/use-media-playback.ts
@@ -152,7 +152,8 @@ export const useMediaPlayback = ({
 
 		const isMediaTagBufferingOrStalled = isMediaTagBuffering || isBuffering();
 
-		if (isPlayerBuffering && !isMediaTagBufferingOrStalled) {
+		const playerBufferingNotStateButLive = buffering.buffering.current;
+		if (playerBufferingNotStateButLive && !isMediaTagBufferingOrStalled) {
 			playbackLogging({
 				logLevel,
 				tag: 'pause',
@@ -164,6 +165,7 @@ export const useMediaPlayback = ({
 	}, [
 		isBuffering,
 		isMediaTagBuffering,
+		buffering,
 		isPlayerBuffering,
 		isPremounting,
 		logLevel,

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -160,7 +160,9 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 	useState(() =>
 		playbackLogging({
 			logLevel,
-			message: `Mounting video with source = ${actualSrc}, v=${VERSION}, user agent=${window.navigator.userAgent}`,
+			message: `Mounting video with source = ${actualSrc}, v=${VERSION}, user agent=${
+				typeof navigator === 'undefined' ? 'server' : navigator.userAgent
+			}`,
 			tag: 'video',
 			mountTime,
 		}),

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -18,6 +18,7 @@ import {useMediaInTimeline} from '../use-media-in-timeline.js';
 import {useMediaPlayback} from '../use-media-playback.js';
 import {useSyncVolumeWithMediaTag} from '../use-sync-volume-with-media-tag.js';
 import {useVideoConfig} from '../use-video-config.js';
+import {VERSION} from '../version.js';
 import {
 	useMediaMutedState,
 	useMediaVolumeState,
@@ -159,7 +160,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 	useState(() =>
 		playbackLogging({
 			logLevel,
-			message: `Mounting video with source = ${actualSrc}`,
+			message: `Mounting video with source = ${actualSrc}, v=${VERSION}, user agent=${window.navigator.userAgent}`,
 			tag: 'video',
 			mountTime,
 		}),

--- a/packages/docs/docs/player/playback-issues.mdx
+++ b/packages/docs/docs/player/playback-issues.mdx
@@ -73,7 +73,7 @@ We have implemented exact logging of relevant events so in order to improve how 
 We are encouraging you to file feedback. If you would like to report feedback, please:
 
 <div>
-  <Step>1</Step> <span>Ensure you are at least on v4.0.273 of Remotion. Previous versions had known bugs.</span>
+  <Step>1</Step> <span>Ensure you are at least on v4.0.288 of Remotion. Previous versions had known bugs.</span>
 </div>
 <div>
   <Step>2</Step>{' '}


### PR DESCRIPTION
- Fixing the WebKit detection to only trigger Chrome
- Better logging
- Unblocking buffers earlier in the render cycle
- Using live value not stale value to detect whether to block