### PR TITLE
`@remotion/layout-utils`: use textTransform inside measureText

### DIFF
--- a/packages/layout-utils/src/layouts/measure-text.ts
+++ b/packages/layout-utils/src/layouts/measure-text.ts
@@ -124,8 +124,9 @@ export const measureText = ({
 	fontVariantNumeric,
 	validateFontIsLoaded,
 	additionalStyles,
+	textTransform,
 }: Word): Dimensions => {
-	const key = `${text}-${fontFamily}-${fontWeight}-${fontSize}-${letterSpacing}-${JSON.stringify(additionalStyles)}`;
+	const key = `${text}-${fontFamily}-${fontWeight}-${fontSize}-${letterSpacing}-${textTransform}-${JSON.stringify(additionalStyles)}`;
 
 	if (wordCache.has(key)) {
 		return wordCache.get(key) as Dimensions;
@@ -139,6 +140,7 @@ export const measureText = ({
 		fontWeight,
 		letterSpacing,
 		additionalStyles,
+		textTransform,
 	});
 
 	if (validateFontIsLoaded && text.trim().length > 0) {
@@ -153,6 +155,7 @@ export const measureText = ({
 			fontWeight,
 			letterSpacing,
 			additionalStyles,
+			textTransform,
 		});
 
 		const sameAsFallbackFont =


### PR DESCRIPTION
I noticed that `takeMeasurement` (used by `measureText`) accepts `textTransform` as a parameter, but it was never passed to the function. 
This caused `measureText` to return the same size for uppercase and lowercase texts. It also influenced the fontSize returned by `fitText`.