### PR TITLE
`@remotion/google-fonts`: Remove `Promise.withResolvers` usage to fix for Node 16

### DIFF
--- a/packages/google-fonts/src/base.ts
+++ b/packages/google-fonts/src/base.ts
@@ -12,8 +12,25 @@ export type FontInfo = {
 	fonts: Record<string, Record<string, Record<string, string>>>;
 };
 
+interface WithResolvers<T> {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	reject: (reason?: any) => void;
+}
+
+export const withResolvers = function <T>() {
+	let resolve: WithResolvers<T>['resolve'];
+	let reject: WithResolvers<T>['reject'];
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return {promise, resolve: resolve!, reject: reject!};
+};
+
 const loadFontFaceOrTimeoutAfter20Seconds = (fontFace: FontFace) => {
-	const timeout = Promise.withResolvers();
+	const timeout = withResolvers();
 
 	const int = setTimeout(() => {
 		timeout.reject(new Error('Timed out loading Google Font'));


### PR DESCRIPTION
`@remotion/google-fonts`: Remove `Promise.withResolvers` usage to fix for Node 16