### PR TITLE
Typo/grammar in offthreadvideo-threads docs

### DIFF
--- a/packages/renderer/src/options/offthreadvideo-threads.tsx
+++ b/packages/renderer/src/options/offthreadvideo-threads.tsx
@@ -17,9 +17,9 @@ export const offthreadVideoThreadsOption = {
 			<a href="https://remotion.dev/docs/offthreadvideo">
 				<code>&lt;OffthreadVideo&gt;</code>
 			</a>{' '}
-			can start to extract frames. frames. The default is{' '}
+			can start to extract frames. The default is{' '}
 			{DEFAULT_RENDER_FRAMES_OFFTHREAD_VIDEO_THREADS}. Increase carefully, as
-			too much threads may cause instability.
+			too many threads may cause instability.
 		</>
 	),
 	ssrName: 'offthreadVideoThreads' as const,


### PR DESCRIPTION
Fixing this repeated word, and updating minor grammar error, changing 'much' to 'many'

![image](https://github.com/user-attachments/assets/6b716147-a6cf-40da-bd95-1e6ed579a88d)