### PR TITLE
`@remotion/renderer`: Calculate CPU count only once

### DIFF
--- a/packages/renderer/src/get-cpu-count.ts
+++ b/packages/renderer/src/get-cpu-count.ts
@@ -5,10 +5,21 @@
 import {execSync} from 'node:child_process';
 import {cpus} from 'node:os';
 
+let nprocCount: number | null | undefined;
+
 // We also get it from nproc and use the minimum of the two.
 export const getConcurrencyFromNProc = (): number | null => {
+	if (nprocCount !== undefined) {
+		return nprocCount;
+	}
+
 	try {
-		return parseInt(execSync('nproc', {stdio: 'pipe'}).toString().trim(), 10);
+		const count = parseInt(
+			execSync('nproc', {stdio: 'pipe'}).toString().trim(),
+			10,
+		);
+		nprocCount = count;
+		return count;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
It seems sensible to cache it

We had a flaky Lambda test with this one hanging