### PR TITLE
`@remotion/studio`: Don't reset unsaved props if code has been saved but props have not been updated

### DIFF
--- a/packages/core/src/Composition.tsx
+++ b/packages/core/src/Composition.tsx
@@ -8,7 +8,10 @@ import {
 } from './CanUseRemotionHooks.js';
 import {CompositionSetters} from './CompositionManagerContext.js';
 import {FolderContext} from './Folder.js';
-import {useResolvedVideoConfig} from './ResolveCompositionConfig.js';
+import {
+	PROPS_UPDATED_EXTERNALLY,
+	useResolvedVideoConfig,
+} from './ResolveCompositionConfig.js';
 import type {Codec} from './codec.js';
 import {continueRender, delayRender} from './delay-render.js';
 import {getRemotionEnvironment} from './get-remotion-environment.js';
@@ -168,6 +171,7 @@ const InnerComposition = <
 
 		validateCompositionId(id);
 		validateDefaultAndInputProps(defaultProps, 'defaultProps', id);
+
 		registerComposition<Schema, Props>({
 			durationInFrames: durationInFrames ?? undefined,
 			fps: fps ?? undefined,
@@ -204,6 +208,16 @@ const InnerComposition = <
 		registerComposition,
 		unregisterComposition,
 	]);
+
+	useEffect(() => {
+		window.dispatchEvent(
+			new CustomEvent<{resetUnsaved: string | null}>(PROPS_UPDATED_EXTERNALLY, {
+				detail: {
+					resetUnsaved: id,
+				},
+			}),
+		);
+	}, [defaultProps, id]);
 
 	const resolved = useResolvedVideoConfig(id);
 

--- a/packages/core/src/EditorProps.tsx
+++ b/packages/core/src/EditorProps.tsx
@@ -18,7 +18,7 @@ export type EditorPropsContextType = {
 			| Record<string, unknown>
 			| ((oldProps: Record<string, unknown>) => Record<string, unknown>);
 	}) => void;
-	resetUnsaved: () => void;
+	resetUnsaved: (compositionId: string) => void;
 };
 
 export const EditorPropsContext = createContext<EditorPropsContextType>({
@@ -72,8 +72,16 @@ export const EditorPropsProvider: React.FC<{
 		[],
 	);
 
-	const resetUnsaved = useCallback(() => {
-		setProps({});
+	const resetUnsaved = useCallback((compositionId: string) => {
+		setProps((prev) => {
+			if (prev[compositionId]) {
+				const newProps = {...prev};
+				delete newProps[compositionId];
+				return newProps;
+			}
+
+			return prev;
+		});
 	}, []);
 
 	useImperativeHandle(editorPropsProviderRef, () => {

--- a/packages/core/src/ResolveCompositionConfig.tsx
+++ b/packages/core/src/ResolveCompositionConfig.tsx
@@ -345,23 +345,6 @@ export const ResolveCompositionConfig: React.FC<
 	]);
 
 	useEffect(() => {
-		if (shouldIgnoreUpdate) {
-			// We already have the current state, we just saved it back
-			// to the file
-			return;
-		}
-
-		window.dispatchEvent(
-			new CustomEvent<{resetUnsaved: boolean}>(PROPS_UPDATED_EXTERNALLY, {
-				detail: {
-					resetUnsaved: true,
-				},
-			}),
-		);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [fastRefreshes]);
-
-	useEffect(() => {
 		if (renderModalComposition && !isTheSame) {
 			const combinedProps = {
 				...(renderModalComposition.defaultProps ?? {}),

--- a/packages/studio/src/api/update-default-props.ts
+++ b/packages/studio/src/api/update-default-props.ts
@@ -29,11 +29,11 @@ export const updateDefaultProps = ({
 	});
 
 	window.dispatchEvent(
-		new CustomEvent<{resetUnsaved: boolean}>(
+		new CustomEvent<{resetUnsaved: string | null}>(
 			Internals.PROPS_UPDATED_EXTERNALLY,
 			{
 				detail: {
-					resetUnsaved: false,
+					resetUnsaved: null,
 				},
 			},
 		),

--- a/packages/studio/src/components/GlobalPropsEditorUpdateButton.tsx
+++ b/packages/studio/src/components/GlobalPropsEditorUpdateButton.tsx
@@ -37,16 +37,16 @@ export const GlobalPropsEditorUpdateButton: React.FC<{
 	const onReset = useCallback(() => {
 		window.remotion_ignoreFastRefreshUpdate = null;
 		window.dispatchEvent(
-			new CustomEvent<{resetUnsaved: boolean}>(
+			new CustomEvent<{resetUnsaved: string | null}>(
 				Internals.PROPS_UPDATED_EXTERNALLY,
 				{
 					detail: {
-						resetUnsaved: true,
+						resetUnsaved: compositionId,
 					},
 				},
 			),
 		);
-	}, []);
+	}, [compositionId]);
 
 	return (
 		<div style={container}>

--- a/packages/studio/src/components/OptionsPanel.tsx
+++ b/packages/studio/src/components/OptionsPanel.tsx
@@ -151,7 +151,7 @@ export const OptionsPanel: React.FC<{
 	const reset = useCallback(
 		(e: Event) => {
 			if ((e as CustomEvent).detail.resetUnsaved) {
-				resetUnsaved();
+				resetUnsaved((e as CustomEvent).detail.resetUnsaved);
 			}
 		},
 		[resetUnsaved],


### PR DESCRIPTION
Actually fixes #5095, this was very annoying for a long time