### PR TITLE
`@remotion/media-parser`: Officially support + test short-circuiting

### DIFF
--- a/packages/docs/docs/media-parser/fields.mdx
+++ b/packages/docs/docs/media-parser/fields.mdx
@@ -29,8 +29,10 @@ Only returns a non-null value if the duration is stored in the metadata.
 
 _number_
 
-The duration of the video in seconds, but it is guaranteed to return a value.  
-If needed, the entire video file is read to determine the duration.
+The duration of the media in seconds, but it is guaranteed to return a value.
+
+If needed, the entire video file is read to determine the duration.  
+However, if the duration is stored in the metadata, it will be used, so it will not read the entire file.
 
 ### `name`
 
@@ -72,8 +74,10 @@ Only returns a non-null value if the frame rate is stored in the metadata.
 
 _number_
 
-The frame rate of the video, but it is guaranteed to return a value.  
+The frame rate of the video, but it is guaranteed to return a value.
+
 If needed, the entire video file is read to determine the frame rate.
+However, if the frame rate is stored in the metadata, it will be used, so it will not read the entire file.
 
 ### `videoCodec`
 

--- a/packages/media-parser/src/emit-available-info.ts
+++ b/packages/media-parser/src/emit-available-info.ts
@@ -120,7 +120,7 @@ export const emitAvailableInfo = async ({
 		// must be handled after fps
 		if (key === 'slowFps') {
 			if (hasInfo.slowFps && !emittedFields.slowFps) {
-				const slowFps = state.samplesObserved.getFps();
+				const slowFps = getFps(state) ?? state.samplesObserved.getFps();
 				await callbackFunctions.onSlowFps?.(slowFps);
 				if (fieldsInReturnValue.slowFps) {
 					returnValue.slowFps = slowFps;

--- a/packages/media-parser/src/state/current-reader.ts
+++ b/packages/media-parser/src/state/current-reader.ts
@@ -5,6 +5,7 @@ export const currentReader = (initialReader: Reader) => {
 	return {
 		getCurrent: () => current,
 		setCurrent: (newReader: Reader) => {
+			current.abort();
 			current = newReader;
 		},
 	};

--- a/packages/media-parser/src/test/slow-shortcircuit.test.ts
+++ b/packages/media-parser/src/test/slow-shortcircuit.test.ts
@@ -23,10 +23,12 @@ test('if metadata is available, it should not use duration from metadata even in
 	expect(slowDurationInSeconds).toBe(22947.121);
 	expect(internalStats.skippedBytes).toBe(152932);
 	expect(internalStats.finalCursorOffset).toBe(18436532);
-});
 
-test('if metadata is available, it should not use duration from metadata even in case of using the "slow" fields', async () => {
-	const {durationInSeconds, internalStats, fps} = await parseMedia({
+	const {
+		durationInSeconds,
+		internalStats: internalStats2,
+		fps,
+	} = await parseMedia({
 		src: await getRemoteExampleVideo('largeStsd'),
 		acknowledgeRemotionLicense: true,
 		fields: {
@@ -39,6 +41,6 @@ test('if metadata is available, it should not use duration from metadata even in
 
 	expect(durationInSeconds).toBe(22947.121);
 	expect(fps).toBe(23.976024846723483);
-	expect(internalStats.skippedBytes).toBe(152940);
-	expect(internalStats.finalCursorOffset).toBe(18436524);
+	expect(internalStats2.skippedBytes).toBe(152940);
+	expect(internalStats2.finalCursorOffset).toBe(18436524);
 });

--- a/packages/media-parser/src/test/slow-shortcircuit.test.ts
+++ b/packages/media-parser/src/test/slow-shortcircuit.test.ts
@@ -1,0 +1,44 @@
+import {getRemoteExampleVideo} from '@remotion/example-videos';
+import {beforeAll, expect, test} from 'bun:test';
+import {nodeReader} from '../node';
+import {parseMedia} from '../parse-media';
+
+beforeAll(async () => {
+	await getRemoteExampleVideo('largeStsd');
+});
+
+test('if metadata is available, it should not use duration from metadata even in case of using the "slow" fields', async () => {
+	const {slowFps, slowDurationInSeconds, internalStats} = await parseMedia({
+		src: await getRemoteExampleVideo('largeStsd'),
+		acknowledgeRemotionLicense: true,
+		fields: {
+			slowDurationInSeconds: true,
+			slowFps: true,
+			internalStats: true,
+		},
+		reader: nodeReader,
+	});
+
+	expect(slowFps).toBe(23.976024846723483);
+	expect(slowDurationInSeconds).toBe(22947.121);
+	expect(internalStats.skippedBytes).toBe(152932);
+	expect(internalStats.finalCursorOffset).toBe(18436532);
+});
+
+test('if metadata is available, it should not use duration from metadata even in case of using the "slow" fields', async () => {
+	const {durationInSeconds, internalStats, fps} = await parseMedia({
+		src: await getRemoteExampleVideo('largeStsd'),
+		acknowledgeRemotionLicense: true,
+		fields: {
+			durationInSeconds: true,
+			internalStats: true,
+			fps: true,
+		},
+		reader: nodeReader,
+	});
+
+	expect(durationInSeconds).toBe(22947.121);
+	expect(fps).toBe(23.976024846723483);
+	expect(internalStats.skippedBytes).toBe(152940);
+	expect(internalStats.finalCursorOffset).toBe(18436524);
+});


### PR DESCRIPTION
Short circuiting: If `slowFps` or `slowDurationInFrames` is being queried, but the data can be gotten from the metadata, then the fast data is being preferred