### PR TITLE
docs: Updated create-tiktok-style-captions.mdx for better understanding

### DIFF
--- a/packages/docs/docs/captions/create-tiktok-style-captions.mdx
+++ b/packages/docs/docs/captions/create-tiktok-style-captions.mdx
@@ -14,7 +14,7 @@ A high value for `combineTokensWithinMilliseconds` will fit many words on 1 page
 This function is safe to use in the browser, Node.js and Bun.
 
 :::note
-This API expects the whitespace to be included in the `text` field **before each word**.
+This API expects the whitespace to be included in the `text` field **before each word. Spaces are used as delimiters, and omitting them will cause the entire text to merge into a single line or page, resulting in poorly formatted captions.**.
 :::
 
 ```tsx twoslash title="Create pages from captions"


### PR DESCRIPTION
Explicit mention of how a custom dataset json for caption generation should be ( including spaces )

Personal Note: I was breaking my head over why my video was not rendering with a custom subtitle, but then after getting into the source code of createTikTokStyleCaptions. I understood that the spaces are a delimiter and modified the captions json file and voila it worked. I wish the next person not to undergo the same headache, as the current Note is not very explanatory and easy to scroll past it. 

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
