### PR TITLE
`@remotion/studio`: Move Ask AI shortcut to Cmd+I

### DIFF
--- a/packages/docs/docs/ai/chatbot.mdx
+++ b/packages/docs/docs/ai/chatbot.mdx
@@ -13,7 +13,7 @@ You can invoke it either by:
 
 - Clicking on the "Ask AI" button anywhere on our docs
 - Visiting [remotion.ai](https://remotion.ai)
-- Pressing <kbd>⌘/Ctrl</kbd> + <kbd>J</kbd> while in the [Studio](/docs/studio)
+- Pressing <kbd>⌘/Ctrl</kbd> + <kbd>I</kbd> while in the [Studio](/docs/studio)
 
 For more complicated questions, you can ask human intelligence.  
 Join us on our [Discord](https://remotion.dev/discord) where you can get help.

--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -284,7 +284,7 @@ Pause and return to where playback started
     <td>
       <kbd>⌘/Ctrl</kbd>
       <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>J</kbd>
+      <kbd>I</kbd>
     </td>
     <td>Ask AI</td>
   </tr>

--- a/packages/docs/src/pages/ai-embed.tsx
+++ b/packages/docs/src/pages/ai-embed.tsx
@@ -12,12 +12,12 @@ export default () => {
 				if (json.type === 'keydown') {
 					// CrawlChat sends Cmd+shift+k event
 					if (
-						(json.data.key === 'j' && json.data.metaKey) ||
+						(json.data.key === 'i' && json.data.metaKey) ||
 						json.data.key === 'Escape'
 					) {
 						window.parent.postMessage(
 							{
-								type: 'cmd-j',
+								type: 'cmd-i',
 							},
 							'*',
 						);

--- a/packages/studio/src/components/AskAiModal.tsx
+++ b/packages/studio/src/components/AskAiModal.tsx
@@ -51,7 +51,7 @@ export const AskAiModal: React.FC = () => {
 		const onMessage = (event: MessageEvent) => {
 			const json =
 				typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
-			if (json.type === 'cmd-j') {
+			if (json.type === 'cmd-i') {
 				askAiModalRef.current?.toggle();
 			}
 		};

--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -41,9 +41,9 @@ export const GlobalKeybindings: React.FC = () => {
 			commandCtrlKey: true,
 			preventDefault: true,
 		});
-		const cmdJKey = keybindings.registerKeybinding({
+		const cmdIKey = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'j',
+			key: 'i',
 			callback: () => {
 				askAiModalRef.current?.toggle();
 			},
@@ -85,7 +85,7 @@ export const GlobalKeybindings: React.FC = () => {
 			cKey.unregister();
 			questionMark.unregister();
 			cmdKKey.unregister();
-			cmdJKey.unregister();
+			cmdIKey.unregister();
 		};
 	}, [keybindings, setCheckerboard, setSelectedModal]);
 

--- a/packages/studio/src/components/KeyboardShortcutsExplainer.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsExplainer.tsx
@@ -292,7 +292,7 @@ export const KeyboardShortcutsExplainer: React.FC = () => {
 						<div style={left}>
 							<kbd style={key}>{cmdOrCtrlCharacter}</kbd>
 							<Spacing x={0.3} />
-							<kbd style={key}>J</kbd>
+							<kbd style={key}>I</kbd>
 						</div>
 						<div style={right}>Ask AI</div>
 					</Row>

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -633,7 +633,7 @@ export const useMenuStructure = (
 							askAiModalRef.current?.toggle();
 						},
 						leftItem: null,
-						keyHint: `${cmdOrCtrlCharacter}+J`,
+						keyHint: `${cmdOrCtrlCharacter}+I`,
 						subMenu: null,
 						type: 'item' as const,
 						quickSwitcherLabel: 'Ask AI',


### PR DESCRIPTION
Unfortunately this will trigger the info tab on Firefox on the second trigger, but I don't know any other shortcut which is not reserved