### PR TITLE
`@remotion/serverless`: Custom output destination provider: Surface original error when getting a 403

### DIFF
--- a/packages/serverless/src/find-output-file-in-bucket.ts
+++ b/packages/serverless/src/find-output-file-in-bucket.ts
@@ -69,7 +69,8 @@ export const findOutputFileInBucket = async <Provider extends CloudProvider>({
 					customCredentials?.endpoint
 						? `(S3 Endpoint = ${customCredentials?.endpoint})`
 						: ''
-				}. The Lambda role must have permission for both "s3:GetObject" and "s3:ListBucket" actions.`,
+				} - got a 403 error when heading the file. Check your credentials and permissions. The Lambda role must have permission for both "s3:GetObject" and "s3:ListBucket" actions.`,
+				{cause: err},
 			);
 		}
 


### PR DESCRIPTION
`@remotion/serverless`: Custom output destination provider: Surface original error when getting a 403