### PR TITLE
docs: Updated setup.mdx

### DIFF
--- a/packages/docs/docs/lambda/setup.mdx
+++ b/packages/docs/docs/lambda/setup.mdx
@@ -21,8 +21,8 @@ import TabItem from '@theme/TabItem';
 - Click on "Create policy"
 - Click on JSON
 - In your project, type `npx remotion lambda policies role` in the command line and copy it into the "JSON" field on AWS.
-- Click next. On the tags page, you don't need to fill in anything. Click next again.
-- Give the policy **exactly** the name `remotion-lambda-policy`. The other fields can be left as they are.
+- Click next. Give the policy **exactly** the name `remotion-lambda-policy`. The other fields can be left as they are.
+- On the tags page, you don't need to fill in anything. Click next again.
 
 ## 3. Create a role
 


### PR DESCRIPTION
Swapped the 2 to maintain logical hierarchy since giving name is the 1st task in the page after clicking next and followed by ignoring the tags page.

AWS beginners like me would get confused.
because I created a policy with a different policy after reading the final instruction had to recreate a new policy with the given name remotion-lambda-policy.

QoL improvement

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
