### PR TITLE
Update contributing doc about testing

### DIFF
--- a/packages/docs/docs/contributing/index.mdx
+++ b/packages/docs/docs/contributing/index.mdx
@@ -102,7 +102,7 @@ cd packages/player-example
 pnpm run dev
 ```
 
-For information about testing, please consult [TESTING.md](https://github.com/remotion-dev/remotion/blob/main/TESTING.md). Issues and pull requests of all sorts are welcome!
+For information about testing Remotion components, please consult the [Testing Remotion components](/docs/testing) page. Issues and pull requests of all sorts are welcome!
 
 ## Running documentation
 


### PR DESCRIPTION
`TESTING.md` is absent and is 404 now, so the most relevant resource in this case is `/docs/testing` page.

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
