### PR TITLE
`@remotion/media-parser`: Fix return type if no `fields` are passed

### DIFF
--- a/packages/media-parser/src/options.ts
+++ b/packages/media-parser/src/options.ts
@@ -194,13 +194,15 @@ export interface ParseMediaData {
 	m3uStreams: M3uStream[] | null;
 }
 
-export type ParseMediaResult<T extends Partial<ParseMediaFields>> = {
-	[K in keyof T]: T[K] extends true
-		? K extends keyof ParseMediaData
-			? ParseMediaData[K]
-			: never
-		: never;
-};
+export type ParseMediaResult<T extends Partial<ParseMediaFields>> = {} extends T
+	? Record<never, never>
+	: {
+			[K in keyof T]: T[K] extends true
+				? K extends keyof ParseMediaData
+					? ParseMediaData[K]
+					: never
+				: never;
+		};
 
 export type ParseMediaProgress = {
 	bytes: number;

--- a/packages/media-parser/src/test/no-fields.test.ts
+++ b/packages/media-parser/src/test/no-fields.test.ts
@@ -1,0 +1,43 @@
+import {exampleVideos} from '@remotion/example-videos';
+import {expect, test} from 'bun:test';
+import {nodeReader} from '../node';
+import {parseMedia} from '../parse-media';
+
+test('should return immediately with no fields and not return any fields', async () => {
+	// @ts-expect-error these fields are not available in the container
+	const {audioCodec} = await parseMedia({
+		src: exampleVideos.aac,
+		acknowledgeRemotionLicense: true,
+		reader: nodeReader,
+		logLevel: 'error',
+	});
+
+	expect(audioCodec).toBeUndefined();
+
+	// @ts-expect-error these fields are not available in the container
+	const {container} = await parseMedia({
+		src: exampleVideos.aac,
+		acknowledgeRemotionLicense: true,
+		fields: {},
+		reader: nodeReader,
+		logLevel: 'error',
+	});
+
+	expect(container).toBeUndefined();
+
+	const {container: cont} = await parseMedia({
+		src: exampleVideos.aac,
+		acknowledgeRemotionLicense: true,
+		fields: {
+			container: false,
+		},
+		reader: nodeReader,
+		logLevel: 'error',
+	});
+
+	try {
+		// @ts-expect-error `cont` should be never
+		expect(cont.toString() === 'mp4').toBe(false);
+		throw new Error('should not happen');
+	} catch {}
+});


### PR DESCRIPTION
`@remotion/media-parser`: Fix return type if no `fields` are passed