### PR TITLE
`@remotion/media-parser`: Make sure reading metadata from Matroska does not read whole file

### DIFF
--- a/packages/media-parser/src/containers/webm/parse-webm-header.ts
+++ b/packages/media-parser/src/containers/webm/parse-webm-header.ts
@@ -1,4 +1,6 @@
 import type {ParseResult} from '../../parse-result';
+import {makeSkip} from '../../skip';
+import {maySkipVideoData} from '../../state/may-skip-video-data';
 import type {ParserState} from '../../state/parser-state';
 import {getByteForSeek} from './get-byte-for-cues';
 import {expectSegment} from './segments';
@@ -33,6 +35,15 @@ export const parseWebm = async (state: ParserState): Promise<ParseResult> => {
 	}
 
 	if (isInsideCluster) {
+		if (maySkipVideoData({state})) {
+			return makeSkip(
+				Math.min(
+					state.contentLength,
+					isInsideCluster.size + isInsideCluster.start,
+				),
+			);
+		}
+
 		const segments = structure.boxes.filter((box) => box.type === 'Segment');
 		const segment = segments[isInsideCluster.segment];
 		if (!segment) {

--- a/packages/media-parser/src/containers/webm/segments.ts
+++ b/packages/media-parser/src/containers/webm/segments.ts
@@ -98,7 +98,7 @@ export const expectSegment = async ({
 
 		statesForProcessing.webmState.addCluster({
 			start: offset,
-			size,
+			size: size + (offsetAfterVInt - offset),
 			segment: isInsideSegment.index,
 		});
 

--- a/packages/media-parser/src/containers/webm/traversal.ts
+++ b/packages/media-parser/src/containers/webm/traversal.ts
@@ -24,7 +24,8 @@ import type {
 export const getMainSegment = (
 	segments: MatroskaSegment[],
 ): MainSegment | null => {
-	return segments.find((s) => s.type === 'Segment') as MainSegment | null;
+	return (segments.find((s) => s.type === 'Segment') ??
+		null) as MainSegment | null;
 };
 
 export const getTrackNumber = (track: TrackEntry) => {

--- a/packages/media-parser/src/metadata/get-metadata.ts
+++ b/packages/media-parser/src/metadata/get-metadata.ts
@@ -68,7 +68,13 @@ export const hasMetadata = (
 		return getMetadataFromWav(structure) !== null;
 	}
 
-	if (structure.type === 'm3u' || structure.type === 'transport-stream') {
+	// M3U, Transport Stream, AAC cannot store any metadata
+
+	if (
+		structure.type === 'm3u' ||
+		structure.type === 'transport-stream' ||
+		structure.type === 'aac'
+	) {
 		return true;
 	}
 
@@ -76,6 +82,8 @@ export const hasMetadata = (
 		return getMetadataFromFlac(structure) !== null;
 	}
 
+	// The following containers (MP4, Matroska, AVI) all have mechanisms
+	// to skip over video sections, and tests for it in read-metadata.test.ts
 	if (structure.type === 'iso-base-media') {
 		return false;
 	}
@@ -86,10 +94,6 @@ export const hasMetadata = (
 
 	if (structure.type === 'riff') {
 		return false;
-	}
-
-	if (structure.type === 'aac') {
-		return true;
 	}
 
 	throw new Error('Unknown container ' + (structure as never));

--- a/packages/media-parser/src/state/matroska/webm.ts
+++ b/packages/media-parser/src/state/matroska/webm.ts
@@ -183,7 +183,7 @@ export const webmState = ({
 		},
 		isInsideCluster: (offset: number): ClusterSection | null => {
 			for (const cluster of clusters) {
-				if (offset >= cluster.start && offset <= cluster.start + cluster.size) {
+				if (offset >= cluster.start && offset < cluster.start + cluster.size) {
 					return cluster;
 				}
 			}

--- a/packages/media-parser/src/test/read-metadata.test.ts
+++ b/packages/media-parser/src/test/read-metadata.test.ts
@@ -114,15 +114,22 @@ test('AVI metadata', async () => {
 });
 
 test('Metadata from Matroska', async () => {
-	const {metadata} = await parseMedia({
+	const {metadata, internalStats} = await parseMedia({
 		src: exampleVideos.matroskaPcm16,
 		fields: {
 			metadata: true,
 			structure: true,
+			internalStats: true,
 		},
 		acknowledgeRemotionLicense: true,
 		reader: nodeReader,
 	});
+
+	expect(internalStats).toEqual({
+		finalCursorOffset: 75328,
+		skippedBytes: 74506,
+	});
+
 	expect(metadata).toEqual([
 		{
 			key: 'comment',

--- a/packages/media-parser/src/test/read-metadata.test.ts
+++ b/packages/media-parser/src/test/read-metadata.test.ts
@@ -4,15 +4,21 @@ import {parseMedia} from '../parse-media';
 import {nodeReader} from '../readers/from-node';
 
 test('iPhone metadata', async () => {
-	const {structure, metadata, location} = await parseMedia({
+	const {structure, metadata, location, internalStats} = await parseMedia({
 		src: exampleVideos.iphonelivefoto,
 		fields: {
 			structure: true,
 			metadata: true,
 			location: true,
+			internalStats: true,
 		},
 		acknowledgeRemotionLicense: true,
 		reader: nodeReader,
+	});
+
+	expect(internalStats).toEqual({
+		skippedBytes: 3862190,
+		finalCursorOffset: 3868807,
 	});
 
 	if (structure.type !== 'iso-base-media') {
@@ -96,13 +102,18 @@ test('iPhone metadata', async () => {
 });
 
 test('AVI metadata', async () => {
-	const {metadata} = await parseMedia({
+	const {metadata, internalStats} = await parseMedia({
 		src: exampleVideos.avi,
 		fields: {
 			metadata: true,
+			internalStats: true,
 		},
 		acknowledgeRemotionLicense: true,
 		reader: nodeReader,
+	});
+	expect(internalStats).toEqual({
+		skippedBytes: 690502,
+		finalCursorOffset: 742478,
 	});
 	expect(metadata).toEqual([
 		{


### PR DESCRIPTION
`@remotion/media-parser`: Make sure reading metadata from Matroska does not read whole file

This is fixing a case where metadata: true would unexpectedly read more than it needed to, now it is consistent that all fields starting with *slow* can read the whole file