### PR TITLE
`@remotion/studio`: Fix whole studio being loaded during rendering + add test for it

### DIFF
--- a/packages/.monorepo/builder.ts
+++ b/packages/.monorepo/builder.ts
@@ -72,6 +72,7 @@ type FormatAction = 'do-nothing' | 'build' | 'use-tsc';
 type EntryPoint = {
 	target: 'node' | 'browser';
 	path: string;
+	splitting?: boolean;
 };
 
 export const buildPackage = async ({
@@ -108,7 +109,7 @@ export const buildPackage = async ({
 			continue;
 		} else if (action === 'use-tsc') {
 		} else if (action === 'build') {
-			for (const {path: p, target} of entrypoints) {
+			for (const {path: p, target, splitting} of entrypoints) {
 				const externalFinal = filterExternal(getExternal(external));
 				validateExternal(externalFinal);
 				const output = await build({
@@ -117,6 +118,7 @@ export const buildPackage = async ({
 					external: externalFinal,
 					target,
 					format,
+					splitting: splitting ?? false,
 				});
 
 				for (const file of output.outputs) {

--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -72,7 +72,12 @@ export const getConfig = ({
 	options?: LegacyBundleOptions;
 }) => {
 	return webpackConfig({
-		entry: require.resolve('@remotion/studio/renderEntry'),
+		entry: path.join(
+			require.resolve('@remotion/studio/renderEntry'),
+			'..',
+			'esm',
+			'renderEntry.mjs',
+		),
 		userDefinedComponent: entryPoint,
 		outDir,
 		environment: 'production',

--- a/packages/it-tests/src/bundle/bundle-studio.test.ts
+++ b/packages/it-tests/src/bundle/bundle-studio.test.ts
@@ -1,55 +1,68 @@
 import {RenderInternals, openBrowser} from '@remotion/renderer';
 import {expect, test} from 'bun:test';
-import {existsSync} from 'fs';
+import {existsSync, readFileSync} from 'fs';
 import path from 'path';
 
-test('Bundle studio', async () => {
-	const browser = openBrowser('chrome');
+test(
+	'Bundle studio',
+	async () => {
+		const browser = openBrowser('chrome');
 
-	const tab = await (
-		await browser
-	).newPage({
-		context: () => null,
-		logLevel: 'info',
-		indent: false,
-		pageIndex: 0,
-		onBrowserLog: null,
-	});
-	const folder = path.join(process.cwd(), '..', 'example', 'build');
-	const indexHtmlExists = existsSync(path.join(folder, 'index.html'));
-	if (!indexHtmlExists) {
-		throw new Error('index.html does not exist in the build folder');
-	}
-
-	const {port, close} = await RenderInternals.serveStatic(
-		path.join(process.cwd(), '..', 'example', 'build'),
-		{
-			port: null,
-			offthreadVideoThreads: 1,
-			downloadMap: RenderInternals.makeDownloadMap(),
-			indent: false,
+		const tab = await (
+			await browser
+		).newPage({
+			context: () => null,
 			logLevel: 'info',
-			offthreadVideoCacheSizeInBytes: null,
-			remotionRoot: path.join(process.cwd(), '..', 'example'),
-			binariesDirectory: null,
-			forceIPv4: false,
-		},
-	);
-	await tab.goto({
-		url: `http://localhost:${port}`,
-		timeout: 10000,
-		options: {},
-	});
-	await new Promise((resolve) => {
-		setTimeout(() => {
-			resolve(null);
-		}, 3000);
-	});
-	const result = await tab.evaluateHandle(() => {
-		return document.querySelectorAll('.css-reset').length;
-	});
-	expect(result.toString()).toBeGreaterThan(1);
+			indent: false,
+			pageIndex: 0,
+			onBrowserLog: null,
+		});
+		const folder = path.join(process.cwd(), '..', 'example', 'build');
+		const indexHtmlExists = existsSync(path.join(folder, 'index.html'));
+		if (!indexHtmlExists) {
+			throw new Error('index.html does not exist in the build folder');
+		}
 
-	await (await browser).close({silent: false});
-	await close();
-});
+		const bundleJs = existsSync(path.join(folder, 'bundle.js'));
+		if (!bundleJs) {
+			throw new Error('bundle.js does not exist in the build folder');
+		}
+		const contents = readFileSync(path.join(folder, 'bundle.js'), 'utf-8');
+		if (contents.includes('PreviewToolbar') || contents.includes('TopPanel')) {
+			throw new Error('Studio was bundled');
+		}
+
+		const {port, close} = await RenderInternals.serveStatic(
+			path.join(process.cwd(), '..', 'example', 'build'),
+			{
+				port: null,
+				offthreadVideoThreads: 1,
+				downloadMap: RenderInternals.makeDownloadMap(),
+				indent: false,
+				logLevel: 'info',
+				offthreadVideoCacheSizeInBytes: null,
+				remotionRoot: path.join(process.cwd(), '..', 'example'),
+				binariesDirectory: null,
+				forceIPv4: false,
+			},
+		);
+		await tab.goto({
+			url: `http://localhost:${port}`,
+			timeout: 10000,
+			options: {},
+		});
+		await new Promise((resolve) => {
+			setTimeout(() => {
+				resolve(null);
+			}, 3000);
+		});
+		const result = await tab.evaluateHandle(() => {
+			return document.querySelectorAll('.css-reset').length;
+		});
+		expect(result.toString()).toBeGreaterThan(1);
+
+		await (await browser).close({silent: false});
+		await close();
+	},
+	{timeout: 20000},
+);

--- a/packages/studio/bundle.ts
+++ b/packages/studio/bundle.ts
@@ -33,6 +33,7 @@ await buildPackage({
 		{
 			path: 'src/renderEntry.tsx',
 			target: 'browser',
+			splitting: true,
 		},
 		{
 			path: 'src/internals.ts',


### PR DESCRIPTION
The 2MB Studio was loaded even during rendering. Fixing this now and adding a test to avoid regressions