### PR TITLE
Three.js template: use `useOffthreadVideoTexture()` instead of `useVideoTexture()`

### DIFF
--- a/packages/template-three/src/Phone.tsx
+++ b/packages/template-three/src/Phone.tsx
@@ -1,7 +1,7 @@
 import { useThree } from "@react-three/fiber";
 import React, { useEffect, useMemo } from "react";
 import { interpolate, spring, useCurrentFrame, useVideoConfig } from "remotion";
-import { VideoTexture } from "three";
+import { Texture } from "three";
 import {
   CAMERA_DISTANCE,
   getPhoneLayout,
@@ -12,7 +12,7 @@ import { roundedRect } from "./helpers/rounded-rectangle";
 import { RoundedBox } from "./RoundedBox";
 
 export const Phone: React.FC<{
-  readonly videoTexture: VideoTexture | null;
+  readonly videoTexture: Texture | null;
   readonly aspectRatio: number;
   readonly baseScale: number;
   readonly phoneColor: string;

--- a/packages/template-three/src/Scene.tsx
+++ b/packages/template-three/src/Scene.tsx
@@ -1,11 +1,12 @@
 import { staticFile } from "remotion";
 import { getVideoMetadata, VideoMetadata } from "@remotion/media-utils";
-import { ThreeCanvas, useVideoTexture } from "@remotion/three";
+import { ThreeCanvas } from "@remotion/three";
 import React, { useEffect, useRef, useState } from "react";
 import { AbsoluteFill, useVideoConfig, Video } from "remotion";
 import { Phone } from "./Phone";
 import { z } from "zod";
 import { zColor } from "@remotion/zod-types";
+import { useTexture } from "./use-texture";
 
 const container: React.CSSProperties = {
   backgroundColor: "white",
@@ -41,7 +42,8 @@ export const Scene: React.FC<
       .catch((err) => console.log(err));
   }, [videoSrc]);
 
-  const texture = useVideoTexture(videoRef);
+  const texture = useTexture(videoSrc, videoRef);
+
   return (
     <AbsoluteFill style={container}>
       <Video ref={videoRef} src={videoSrc} style={videoStyle} />

--- a/packages/template-three/src/use-texture.ts
+++ b/packages/template-three/src/use-texture.ts
@@ -1,0 +1,16 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useOffthreadVideoTexture, useVideoTexture } from "@remotion/three";
+import { getRemotionEnvironment } from "remotion";
+
+export const useTexture = (
+  src: string,
+  videoRef: React.RefObject<HTMLVideoElement | null>,
+) => {
+  if (getRemotionEnvironment().isRendering) {
+    return useOffthreadVideoTexture({
+      src,
+    });
+  }
+
+  return useVideoTexture(videoRef);
+};


### PR DESCRIPTION
Fixes hangs with higher concurrency

Fixes #13