### PR TITLE
`remotion`: Use more recent timestamp to determine if there is a timeshift

### DIFF
--- a/packages/core/src/media-tag-current-time-timestamp.ts
+++ b/packages/core/src/media-tag-current-time-timestamp.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export const useCurrentTimeOfMediaTagWithUpdateTimeStamp = (
+	mediaRef: React.RefObject<HTMLVideoElement | HTMLAudioElement | null>,
+) => {
+	const lastUpdate: React.RefObject<{
+		time: number;
+		lastUpdate: number;
+	}> = React.useRef({
+		time: mediaRef.current?.currentTime ?? 0,
+		lastUpdate: performance.now(),
+	});
+
+	const nowCurrentTime = mediaRef.current?.currentTime ?? null;
+	if (nowCurrentTime !== null) {
+		if (lastUpdate.current.time !== nowCurrentTime) {
+			lastUpdate.current.time = nowCurrentTime;
+			lastUpdate.current.lastUpdate = performance.now();
+		}
+	}
+
+	return lastUpdate;
+};

--- a/packages/core/src/use-request-video-callback-time.ts
+++ b/packages/core/src/use-request-video-callback-time.ts
@@ -12,12 +12,18 @@ export const useRequestVideoCallbackTime = ({
 	lastSeek: React.MutableRefObject<number | null>;
 	onVariableFpsVideoDetected: () => void;
 }) => {
-	const currentTime = useRef<number | null>(null);
+	const currentTime = useRef<{
+		time: number;
+		lastUpdate: number;
+	} | null>(null);
 
 	useEffect(() => {
 		const {current} = mediaRef;
 		if (current) {
-			currentTime.current = current.currentTime;
+			currentTime.current = {
+				time: current.currentTime,
+				lastUpdate: performance.now(),
+			};
 		} else {
 			currentTime.current = null;
 			return;
@@ -43,7 +49,9 @@ export const useRequestVideoCallbackTime = ({
 
 			const cb = videoTag.requestVideoFrameCallback((_, info) => {
 				if (currentTime.current !== null) {
-					const difference = Math.abs(currentTime.current - info.mediaTime);
+					const difference = Math.abs(
+						currentTime.current.time - info.mediaTime,
+					);
 					const differenceToLastSeek = Math.abs(
 						lastSeek.current === null
 							? Infinity
@@ -56,13 +64,16 @@ export const useRequestVideoCallbackTime = ({
 					if (
 						difference > 0.5 &&
 						differenceToLastSeek > 0.5 &&
-						info.mediaTime > currentTime.current
+						info.mediaTime > currentTime.current.time
 					) {
 						onVariableFpsVideoDetected();
 					}
 				}
 
-				currentTime.current = info.mediaTime;
+				currentTime.current = {
+					time: info.mediaTime,
+					lastUpdate: performance.now(),
+				};
 				request();
 			});
 


### PR DESCRIPTION
Between `videoRef.currentTime` and the timestamp we get from requestVideoFrameCallback, we take the more recent timestamp 

Resolves a bug discussed in internal chat: https://discord.com/channels/@me/1314232261008162876/1371392111584350208