### PR TITLE
`@remotion/three`: 30% rendering performance gains with frameloop=demand in rendering

### DIFF
--- a/packages/three/src/ThreeCanvas.tsx
+++ b/packages/three/src/ThreeCanvas.tsx
@@ -86,9 +86,9 @@ export const ThreeCanvas = (props: ThreeCanvasProps) => {
 				frameloop={shouldUseFrameloopDemand ? 'demand' : 'always'}
 				onCreated={remotion_onCreated}
 			>
-				{shouldUseFrameloopDemand && <FiberFrameInvalidator />}
 				<Scale width={width} height={height} />
 				<Internals.RemotionContextProvider contexts={contexts}>
+					{shouldUseFrameloopDemand && <FiberFrameInvalidator />}
 					{children}
 				</Internals.RemotionContextProvider>
 			</Canvas>

--- a/packages/three/src/ThreeCanvas.tsx
+++ b/packages/three/src/ThreeCanvas.tsx
@@ -1,7 +1,13 @@
 import type {RootState} from '@react-three/fiber';
 import {Canvas, useThree} from '@react-three/fiber';
-import React, {useCallback, useLayoutEffect, useState} from 'react';
-import {Internals, continueRender, delayRender} from 'remotion';
+import React, {useCallback, useEffect, useLayoutEffect, useState} from 'react';
+import {
+	Internals,
+	continueRender,
+	delayRender,
+	getRemotionEnvironment,
+	useCurrentFrame,
+} from 'remotion';
 import {SuspenseLoader} from './SuspenseLoader';
 import {validateDimension} from './validate';
 
@@ -27,6 +33,23 @@ const Scale = ({
 	}, [setSize, width, height, set]);
 	return null;
 };
+
+const FiberFrameInvalidator = () => {
+	const {invalidate} = useThree();
+
+	const frame = useCurrentFrame();
+
+	useEffect(() => {
+		invalidate();
+	}, [frame, invalidate]);
+
+	return null;
+};
+
+const {isRendering} = getRemotionEnvironment();
+
+// https://r3f.docs.pmnd.rs/advanced/scaling-performance#on-demand-rendering
+const shouldUseFrameloopDemand = isRendering;
 
 /*
  * @description A wrapper for React Three Fiber's <Canvas /> which synchronizes with Remotion's useCurrentFrame().
@@ -57,7 +80,13 @@ export const ThreeCanvas = (props: ThreeCanvasProps) => {
 
 	return (
 		<SuspenseLoader>
-			<Canvas style={actualStyle} {...rest} onCreated={remotion_onCreated}>
+			<Canvas
+				style={actualStyle}
+				{...rest}
+				frameloop={shouldUseFrameloopDemand ? 'demand' : 'always'}
+				onCreated={remotion_onCreated}
+			>
+				{shouldUseFrameloopDemand && <FiberFrameInvalidator />}
 				<Scale width={width} height={height} />
 				<Internals.RemotionContextProvider contexts={contexts}>
 					{children}


### PR DESCRIPTION
This change stops R3F's `<Canvas>` from automatically using requestAnimationFrame for rendering. Instead, we now manually trigger updates using the `invalidate()` function during rendering.

By doing this, we significantly improve concurrent rendering performance—especially for complex scenes—since it prevents each browser tab from running the Three.js frame loop at 60 FPS for every Remotion frame.

https://r3f.docs.pmnd.rs/advanced/scaling-performance#on-demand-rendering

Also, tested in production on banger.show, for 300 videos that were rendered, the output is consistent. We see 30-40% faster renders after implementing this change in January.