### PR TITLE
`remotion`: Don't buffer if readyState === HAVE_FUTURE_DATA

### DIFF
--- a/packages/core/src/buffer-until-first-frame.ts
+++ b/packages/core/src/buffer-until-first-frame.ts
@@ -51,7 +51,7 @@ export const useBufferUntilFirstFrame = ({
 			}
 
 			if (
-				current.readyState >= current.HAVE_ENOUGH_DATA &&
+				current.readyState >= current.HAVE_FUTURE_DATA &&
 				!isSafariWebkit() &&
 				// In Desktop Chrome, the video might switch to playing
 				// but does not play due to Bluetooth headphones


### PR DESCRIPTION
Previously we were looking for HAVE_ENOUGH_DATA