### PR TITLE
`@remotion/studio`: New option for setting custom audioLatencyHint

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -102,7 +102,7 @@ type NewBundleOptions = {
 	gitSource: GitSource | null;
 	maxTimelineTracks: number | null;
 	bufferStateDelayInMilliseconds: number | null;
-	audioLatencyHint: AudioContextLatencyCategory;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 };
 
 type MandatoryBundleOptions = {
@@ -350,7 +350,7 @@ export async function bundle(...args: Arguments): Promise<string> {
 		publicPath: actualArgs.publicPath ?? null,
 		rootDir: actualArgs.rootDir ?? null,
 		webpackOverride: actualArgs.webpackOverride ?? ((f) => f),
-		audioLatencyHint: actualArgs.audioLatencyHint ?? 'interactive',
+		audioLatencyHint: actualArgs.audioLatencyHint ?? null,
 	});
 	return result;
 }

--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -102,6 +102,7 @@ type NewBundleOptions = {
 	gitSource: GitSource | null;
 	maxTimelineTracks: number | null;
 	bufferStateDelayInMilliseconds: number | null;
+	audioLatencyHint: AudioContextLatencyCategory;
 };
 
 type MandatoryBundleOptions = {
@@ -311,6 +312,7 @@ export const internalBundle = async (
 		// Actual log level is set in setPropsAndEnv()
 		logLevel: 'info',
 		mode: 'bundle',
+		audioLatencyHint: actualArgs.audioLatencyHint ?? 'interactive',
 	});
 
 	fs.writeFileSync(path.join(outDir, 'index.html'), html);
@@ -348,6 +350,7 @@ export async function bundle(...args: Arguments): Promise<string> {
 		publicPath: actualArgs.publicPath ?? null,
 		rootDir: actualArgs.rootDir ?? null,
 		webpackOverride: actualArgs.webpackOverride ?? ((f) => f),
+		audioLatencyHint: actualArgs.audioLatencyHint ?? 'interactive',
 	});
 	return result;
 }

--- a/packages/bundler/src/index-html.ts
+++ b/packages/bundler/src/index-html.ts
@@ -25,6 +25,7 @@ export const indexHtml = ({
 	projectName,
 	installedDependencies,
 	packageManager,
+	audioLatencyHint,
 	logLevel,
 	mode,
 }: {
@@ -37,6 +38,7 @@ export const indexHtml = ({
 	studioServerCommand: string | null;
 	renderQueue: unknown | null;
 	numberOfAudioTags: number;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 	publicFiles: StaticFile[];
 	publicFolderExists: string | null;
 	includeFavicon: boolean;
@@ -65,6 +67,7 @@ export const indexHtml = ({
 	</head>
 	<body>
 		<script>window.remotion_numberOfAudioTags = ${numberOfAudioTags};</script>
+		<script>window.remotion_audioLatencyHint = ${audioLatencyHint};</script>
 		${mode === 'dev' ? `<script>window.remotion_logLevel = "${logLevel}";</script>` : ''}
 		<script>window.remotion_staticBase = "${staticHash}";</script>
 		${

--- a/packages/bundler/src/index-html.ts
+++ b/packages/bundler/src/index-html.ts
@@ -38,7 +38,7 @@ export const indexHtml = ({
 	studioServerCommand: string | null;
 	renderQueue: unknown | null;
 	numberOfAudioTags: number;
-	audioLatencyHint: AudioContextLatencyCategory | null;
+	audioLatencyHint: AudioContextLatencyCategory;
 	publicFiles: StaticFile[];
 	publicFolderExists: string | null;
 	includeFavicon: boolean;
@@ -67,7 +67,7 @@ export const indexHtml = ({
 	</head>
 	<body>
 		<script>window.remotion_numberOfAudioTags = ${numberOfAudioTags};</script>
-		<script>window.remotion_audioLatencyHint = ${audioLatencyHint};</script>
+		<script>window.remotion_audioLatencyHint = "${audioLatencyHint}";</script>
 		${mode === 'dev' ? `<script>window.remotion_logLevel = "${logLevel}";</script>` : ''}
 		<script>window.remotion_staticBase = "${staticHash}";</script>
 		${

--- a/packages/cli/src/benchmark.ts
+++ b/packages/cli/src/benchmark.ts
@@ -288,7 +288,7 @@ export const benchmarkCommand = async (
 			bufferStateDelayInMilliseconds: null,
 			maxTimelineTracks: null,
 			publicPath,
-			audioLatencyHint: 'interactive',
+			audioLatencyHint: null,
 		});
 
 	registerCleanupJob(`Deleting bundle`, () => cleanupBundle());

--- a/packages/cli/src/benchmark.ts
+++ b/packages/cli/src/benchmark.ts
@@ -288,6 +288,7 @@ export const benchmarkCommand = async (
 			bufferStateDelayInMilliseconds: null,
 			maxTimelineTracks: null,
 			publicPath,
+			audioLatencyHint: 'interactive',
 		});
 
 	registerCleanupJob(`Deleting bundle`, () => cleanupBundle());

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -13,8 +13,12 @@ import {bundleOnCli} from './setup-cache';
 import {shouldUseNonOverlayingLogger} from './should-use-non-overlaying-logger';
 import {yesOrNo} from './yes-or-no';
 
-const {publicPathOption, publicDirOption, disableGitSourceOption} =
-	BrowserSafeApis.options;
+const {
+	publicPathOption,
+	publicDirOption,
+	disableGitSourceOption,
+	audioLatencyHintOption,
+} = BrowserSafeApis.options;
 
 export const bundleCommand = async (
 	remotionRoot: string,
@@ -61,6 +65,9 @@ export const bundleCommand = async (
 	const publicPath = publicPathOption.getValue({commandLine: parsedCli}).value;
 	const publicDir = publicDirOption.getValue({commandLine: parsedCli}).value;
 	const disableGitSource = disableGitSourceOption.getValue({
+		commandLine: parsedCli,
+	}).value;
+	const audioLatencyHint = audioLatencyHintOption.getValue({
 		commandLine: parsedCli,
 	}).value;
 
@@ -130,6 +137,7 @@ export const bundleCommand = async (
 		bufferStateDelayInMilliseconds: null,
 		maxTimelineTracks: null,
 		publicPath,
+		audioLatencyHint,
 	});
 
 	Log.info(

--- a/packages/cli/src/compositions.ts
+++ b/packages/cli/src/compositions.ts
@@ -23,6 +23,7 @@ const {
 	publicPathOption,
 	publicDirOption,
 	chromeModeOption,
+	audioLatencyHintOption,
 } = BrowserSafeApis.options;
 
 export const listCompositionsCommand = async (
@@ -105,6 +106,9 @@ export const listCompositionsCommand = async (
 	const chromeMode = chromeModeOption.getValue({
 		commandLine: parsedCli,
 	}).value;
+	const audioLatencyHint = audioLatencyHintOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 
 	const {urlOrBundle: bundled, cleanup: cleanupBundle} =
 		await bundleOnCliOrTakeServeUrl({
@@ -127,6 +131,7 @@ export const listCompositionsCommand = async (
 			bufferStateDelayInMilliseconds: null,
 			maxTimelineTracks: null,
 			publicPath,
+			audioLatencyHint,
 		});
 
 	registerCleanupJob(`Cleanup bundle`, () => cleanupBundle());

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -123,6 +123,7 @@ const {
 	audioCodecOption,
 	publicPathOption,
 	hardwareAccelerationOption,
+	audioLatencyHintOption,
 } = BrowserSafeApis.options;
 
 declare global {
@@ -436,6 +437,15 @@ declare global {
 		readonly setVideoBitrate: (bitrate: string | null) => void;
 
 		/**
+		 * Set the audio latency hint that the Studio will
+		 * use when playing back audio
+		 * Default: 'interactive'
+		 */
+		readonly setAudioLatencyHint: (
+			audioLatencyHint: AudioContextLatencyCategory | null,
+		) => void;
+
+		/**
 		 * Set a maximum bitrate to be passed to FFmpeg.
 		 */
 		readonly setEncodingMaxRate: (bitrate: string | null) => void;
@@ -638,6 +648,7 @@ export const Config: FlatConfig = {
 	setX264Preset: x264Option.setConfig,
 	setAudioBitrate: audioBitrateOption.setConfig,
 	setVideoBitrate: videoBitrateOption.setConfig,
+	setAudioLatencyHint: audioLatencyHintOption.setConfig,
 	setForSeamlessAacConcatenation: forSeamlessAacConcatenationOption.setConfig,
 	overrideHeight,
 	overrideWidth,

--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -31,6 +31,7 @@ const {
 	videoBitrateOption,
 	audioCodecOption,
 	publicPathOption,
+	audioLatencyHintOption,
 } = BrowserSafeApis.options;
 
 export type CommandLineOptions = {
@@ -98,6 +99,7 @@ export type CommandLineOptions = {
 	['browser-args']: string;
 	['user-agent']: string;
 	['out-dir']: string;
+	[audioLatencyHintOption.cliFlag]: AudioContextLatencyCategory;
 	ipv4: boolean;
 	[deleteAfterOption.cliFlag]: TypeOfOption<typeof deleteAfterOption>;
 	[folderExpiryOption.cliFlag]: TypeOfOption<typeof folderExpiryOption>;

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -115,6 +115,7 @@ export const renderVideoFlow = async ({
 	metadata,
 	hardwareAcceleration,
 	chromeMode,
+	audioLatencyHint,
 }: {
 	remotionRoot: string;
 	fullEntryPoint: string;
@@ -172,6 +173,7 @@ export const renderVideoFlow = async ({
 	metadata: Record<string, string> | null;
 	hardwareAcceleration: HardwareAccelerationOption;
 	chromeMode: ChromeMode;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 }) => {
 	const isVerbose = RenderInternals.isEqualOrBelowLogLevel(logLevel, 'verbose');
 
@@ -287,6 +289,7 @@ export const renderVideoFlow = async ({
 			bufferStateDelayInMilliseconds: null,
 			maxTimelineTracks: null,
 			publicPath,
+			audioLatencyHint,
 		},
 	);
 

--- a/packages/cli/src/render-flows/still.ts
+++ b/packages/cli/src/render-flows/still.ts
@@ -78,6 +78,7 @@ export const renderStillFlow = async ({
 	publicPath,
 	chromeMode,
 	offthreadVideoThreads,
+	audioLatencyHint,
 }: {
 	remotionRoot: string;
 	fullEntryPoint: string;
@@ -110,6 +111,7 @@ export const renderStillFlow = async ({
 	binariesDirectory: string | null;
 	publicPath: string | null;
 	chromeMode: ChromeMode;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 }) => {
 	const isVerbose = RenderInternals.isEqualOrBelowLogLevel(logLevel, 'verbose');
 	Log.verbose(
@@ -199,6 +201,7 @@ export const renderStillFlow = async ({
 			bufferStateDelayInMilliseconds: null,
 			maxTimelineTracks: null,
 			publicPath,
+			audioLatencyHint,
 		},
 	);
 

--- a/packages/cli/src/render-queue/process-still.ts
+++ b/packages/cli/src/render-queue/process-still.ts
@@ -70,5 +70,6 @@ export const processStill = async ({
 		binariesDirectory: job.binariesDirectory,
 		publicPath: null,
 		chromeMode: job.chromeMode,
+		audioLatencyHint: 'interactive',
 	});
 };

--- a/packages/cli/src/render-queue/process-still.ts
+++ b/packages/cli/src/render-queue/process-still.ts
@@ -70,6 +70,6 @@ export const processStill = async ({
 		binariesDirectory: job.binariesDirectory,
 		publicPath: null,
 		chromeMode: job.chromeMode,
-		audioLatencyHint: 'interactive',
+		audioLatencyHint: null,
 	});
 };

--- a/packages/cli/src/render-queue/process-video.ts
+++ b/packages/cli/src/render-queue/process-video.ts
@@ -100,5 +100,6 @@ export const processVideoJob = async ({
 			job.type === 'video' ? job.hardwareAcceleration : 'disable',
 		chromeMode: job.chromeMode,
 		offthreadVideoThreads: job.offthreadVideoThreads,
+		audioLatencyHint: 'interactive',
 	});
 };

--- a/packages/cli/src/render-queue/process-video.ts
+++ b/packages/cli/src/render-queue/process-video.ts
@@ -100,6 +100,6 @@ export const processVideoJob = async ({
 			job.type === 'video' ? job.hardwareAcceleration : 'disable',
 		chromeMode: job.chromeMode,
 		offthreadVideoThreads: job.offthreadVideoThreads,
-		audioLatencyHint: 'interactive',
+		audioLatencyHint: null,
 	});
 };

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -40,6 +40,7 @@ const {
 	hardwareAccelerationOption,
 	chromeModeOption,
 	offthreadVideoThreadsOption,
+	audioLatencyHintOption,
 } = BrowserSafeApis.options;
 
 export const render = async (
@@ -185,6 +186,9 @@ export const render = async (
 	const hardwareAcceleration = hardwareAccelerationOption.getValue({
 		commandLine: parsedCli,
 	}).value;
+	const audioLatencyHint = audioLatencyHintOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 
 	await renderVideoFlow({
 		fullEntryPoint,
@@ -250,5 +254,6 @@ export const render = async (
 		hardwareAcceleration,
 		chromeMode,
 		offthreadVideoThreads,
+		audioLatencyHint,
 	});
 };

--- a/packages/cli/src/setup-cache.ts
+++ b/packages/cli/src/setup-cache.ts
@@ -253,7 +253,7 @@ export const bundleOnCli = async ({
 		ignoreRegisterRootWarning: false,
 		maxTimelineTracks,
 		bufferStateDelayInMilliseconds,
-		audioLatencyHint: audioLatencyHint ?? 'interactive',
+		audioLatencyHint,
 	});
 
 	bundlingState = {

--- a/packages/cli/src/setup-cache.ts
+++ b/packages/cli/src/setup-cache.ts
@@ -30,6 +30,7 @@ export const bundleOnCliOrTakeServeUrl = async ({
 	bufferStateDelayInMilliseconds,
 	maxTimelineTracks,
 	publicPath,
+	audioLatencyHint,
 }: {
 	fullPath: string;
 	remotionRoot: string;
@@ -48,6 +49,7 @@ export const bundleOnCliOrTakeServeUrl = async ({
 	bufferStateDelayInMilliseconds: number | null;
 	maxTimelineTracks: number | null;
 	publicPath: string | null;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 }): Promise<{
 	urlOrBundle: string;
 	cleanup: () => void;
@@ -87,6 +89,7 @@ export const bundleOnCliOrTakeServeUrl = async ({
 		bufferStateDelayInMilliseconds,
 		maxTimelineTracks,
 		publicPath,
+		audioLatencyHint,
 	});
 
 	return {
@@ -110,6 +113,7 @@ export const bundleOnCli = async ({
 	maxTimelineTracks,
 	bufferStateDelayInMilliseconds,
 	publicPath,
+	audioLatencyHint,
 }: {
 	fullPath: string;
 	remotionRoot: string;
@@ -128,6 +132,7 @@ export const bundleOnCli = async ({
 	maxTimelineTracks: number | null;
 	bufferStateDelayInMilliseconds: number | null;
 	publicPath: string | null;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 }) => {
 	const shouldCache = ConfigInternals.getWebpackCaching();
 
@@ -248,6 +253,7 @@ export const bundleOnCli = async ({
 		ignoreRegisterRootWarning: false,
 		maxTimelineTracks,
 		bufferStateDelayInMilliseconds,
+		audioLatencyHint: audioLatencyHint ?? 'interactive',
 	});
 
 	bundlingState = {

--- a/packages/cli/src/still.ts
+++ b/packages/cli/src/still.ts
@@ -24,6 +24,7 @@ const {
 	publicDirOption,
 	chromeModeOption,
 	offthreadVideoThreadsOption,
+	audioLatencyHintOption,
 } = BrowserSafeApis.options;
 
 export const still = async (
@@ -118,6 +119,9 @@ export const still = async (
 	const chromeMode = chromeModeOption.getValue({
 		commandLine: parsedCli,
 	}).value;
+	const audioLatencyHint = audioLatencyHintOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 
 	const chromiumOptions: ChromiumOptions = {
 		disableWebSecurity,
@@ -167,5 +171,6 @@ export const still = async (
 		binariesDirectory,
 		publicPath,
 		chromeMode,
+		audioLatencyHint,
 	});
 };

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -144,6 +144,7 @@ export const studioCommand = async (
 			ConfigInternals.getBufferStateDelayInMilliseconds(),
 		binariesDirectory,
 		forceIPv4: parsedCli.ipv4,
+		audioLatencyHint: parsedCli['audio-latency-hint'],
 	});
 
 	// If the server is restarted through the UI, let's do the whole thing again.

--- a/packages/cloudrun/src/api/deploy-site.ts
+++ b/packages/cloudrun/src/api/deploy-site.ts
@@ -101,7 +101,7 @@ export const internalDeploySiteRaw = async ({
 			onPublicDirCopyProgress: () => undefined,
 			onSymlinkDetected: () => undefined,
 			outDir: null,
-			audioLatencyHint: 'interactive',
+			audioLatencyHint: null,
 		}),
 	]);
 

--- a/packages/cloudrun/src/api/deploy-site.ts
+++ b/packages/cloudrun/src/api/deploy-site.ts
@@ -101,6 +101,7 @@ export const internalDeploySiteRaw = async ({
 			onPublicDirCopyProgress: () => undefined,
 			onSymlinkDetected: () => undefined,
 			outDir: null,
+			audioLatencyHint: 'interactive',
 		}),
 	]);
 

--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -166,11 +166,13 @@ export const CompositionManagerProvider: React.FC<{
 	readonly numberOfAudioTags: number;
 	readonly onlyRenderComposition: string | null;
 	readonly currentCompositionMetadata: BaseMetadata | null;
+	readonly audioLatencyHint: AudioContextLatencyCategory;
 }> = ({
 	children,
 	numberOfAudioTags,
 	onlyRenderComposition,
 	currentCompositionMetadata,
+	audioLatencyHint,
 }) => {
 	// Wontfix, expected to have
 	const [compositions, setCompositions] = useState<AnyComposition[]>([]);
@@ -310,6 +312,7 @@ export const CompositionManagerProvider: React.FC<{
 							<SharedAudioContextProvider
 								numberOfAudioTags={numberOfAudioTags}
 								component={composition?.component ?? null}
+								audioLatencyHint={audioLatencyHint}
 							>
 								{children}
 							</SharedAudioContextProvider>

--- a/packages/core/src/RemotionRoot.tsx
+++ b/packages/core/src/RemotionRoot.tsx
@@ -41,12 +41,14 @@ export const RemotionRoot: React.FC<{
 	readonly logLevel: LogLevel;
 	readonly onlyRenderComposition: string | null;
 	readonly currentCompositionMetadata: BaseMetadata | null;
+	readonly audioLatencyHint: AudioContextLatencyCategory;
 }> = ({
 	children,
 	numberOfAudioTags,
 	logLevel,
 	onlyRenderComposition,
 	currentCompositionMetadata,
+	audioLatencyHint,
 }) => {
 	const [remotionRootId] = useState(() => String(random(null)));
 	const [frame, setFrame] = useState<Record<string, number>>(() =>
@@ -158,6 +160,7 @@ export const RemotionRoot: React.FC<{
 										numberOfAudioTags={numberOfAudioTags}
 										onlyRenderComposition={onlyRenderComposition}
 										currentCompositionMetadata={currentCompositionMetadata}
+										audioLatencyHint={audioLatencyHint}
 									>
 										<DurationsContextProvider>
 											<BufferingProvider>{children}</BufferingProvider>

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -105,7 +105,8 @@ export const SharedAudioContextProvider: React.FC<{
 	readonly component: LazyExoticComponent<
 		ComponentType<Record<string, unknown>>
 	> | null;
-}> = ({children, numberOfAudioTags, component}) => {
+	readonly audioLatencyHint: AudioContextLatencyCategory;
+}> = ({children, numberOfAudioTags, component, audioLatencyHint}) => {
 	const audios = useRef<AudioElem[]>([]);
 	const [initialNumberOfAudioTags] = useState(numberOfAudioTags);
 
@@ -126,7 +127,7 @@ export const SharedAudioContextProvider: React.FC<{
 	);
 
 	const logLevel = useLogLevel();
-	const audioContext = useSingletonAudioContext(logLevel);
+	const audioContext = useSingletonAudioContext(logLevel, audioLatencyHint);
 
 	const rerenderAudios = useCallback(() => {
 		refs.forEach(({ref, id}) => {

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -17,7 +17,10 @@ const warnOnce = (logLevel: LogLevel) => {
 	}
 };
 
-export const useSingletonAudioContext = (logLevel: LogLevel) => {
+export const useSingletonAudioContext = (
+	logLevel: LogLevel,
+	latencyHint: AudioContextLatencyCategory,
+) => {
 	const audioContext = useMemo(() => {
 		if (typeof AudioContext === 'undefined') {
 			warnOnce(logLevel);
@@ -25,9 +28,9 @@ export const useSingletonAudioContext = (logLevel: LogLevel) => {
 		}
 
 		return new AudioContext({
-			latencyHint: 'interactive',
+			latencyHint,
 		});
-	}, [logLevel]);
+	}, [logLevel, latencyHint]);
 
 	useEffect(() => {
 		return () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ declare global {
 		remotion_editorName: string | null;
 		remotion_ignoreFastRefreshUpdate: number | null;
 		remotion_numberOfAudioTags: number;
+		remotion_audioLatencyHint: AudioContextLatencyCategory | undefined;
 		remotion_logLevel: LogLevel;
 		remotion_projectName: string;
 		remotion_cwd: string;

--- a/packages/core/src/test/composition-rules.test.tsx
+++ b/packages/core/src/test/composition-rules.test.tsx
@@ -55,6 +55,7 @@ describe('Render composition-rules should throw with invalid props', () => {
 						logLevel="info"
 						onlyRenderComposition={null}
 						currentCompositionMetadata={null}
+						audioLatencyHint="interactive"
 					>
 						<Composition
 							lazyComponent={() => Promise.resolve({default: AnyComp})}

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -674,7 +674,7 @@ Config.setAudioBitrate('128K');
 
 The [command line flag](/docs/cli/render#--audio-bitrate) `--audio-bitrate` will take precedence over this option.
 
-## `setAudioLatencyHint()`<AvailableFrom v="4.0.302" />
+## `setAudioLatencyHint()`<AvailableFrom v="4.0.303" />
 
 <Options id="audio-latency-hint" />
 <br />

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -674,10 +674,23 @@ Config.setAudioBitrate('128K');
 
 The [command line flag](/docs/cli/render#--audio-bitrate) `--audio-bitrate` will take precedence over this option.
 
+## `setAudioLatencyHint()`<AvailableFrom v="4.0.302" />
+
+<Options id="audio-latency-hint" />
+<br />
+<br />
+
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+// ---cut---
+Config.setAudioLatencyHint('interactive');
+```
+
+The [command line flag](/docs/cli/render#--audio-latency-hint) `--audio-latency-hint` will take precedence over this option.
+
 ## `setEnableFolderExpiry()`<AvailableFrom v="4.0.32" />
 
 <Options id="enable-folder-expiry" />
-<br />
 <br />
 
 ```ts twoslash title="remotion.config.ts"

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -94,6 +94,7 @@ export type PlayerProps<
 	readonly logLevel?: LogLevel;
 	readonly noSuspense?: boolean;
 	readonly acknowledgeRemotionLicense?: boolean;
+	readonly audioLatencyHint?: AudioContextLatencyCategory;
 } & CompProps<Props> &
 	PropsIfHasProps<Schema, Props>;
 
@@ -161,6 +162,7 @@ const PlayerFn = <
 		logLevel = 'info',
 		noSuspense,
 		acknowledgeRemotionLicense,
+		audioLatencyHint = 'interactive',
 		...componentProps
 	}: PlayerProps<Schema, Props>,
 	ref: MutableRefObject<PlayerRef>,
@@ -404,6 +406,7 @@ const PlayerFn = <
 				numberOfSharedAudioTags={numberOfSharedAudioTags}
 				initiallyMuted={initiallyMuted}
 				logLevel={logLevel}
+				audioLatencyHint={audioLatencyHint}
 			>
 				<Internals.Timeline.SetTimelineContext.Provider
 					value={setTimelineContextValue}

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -26,6 +26,7 @@ export const SharedPlayerContexts: React.FC<{
 	readonly numberOfSharedAudioTags: number;
 	readonly initiallyMuted: boolean;
 	readonly logLevel: LogLevel;
+	readonly audioLatencyHint: AudioContextLatencyCategory;
 }> = ({
 	children,
 	timelineContext,
@@ -37,6 +38,7 @@ export const SharedPlayerContexts: React.FC<{
 	numberOfSharedAudioTags,
 	initiallyMuted,
 	logLevel,
+	audioLatencyHint,
 }) => {
 	const compositionManagerContext: CompositionManagerContext = useMemo(() => {
 		const context: CompositionManagerContext = {
@@ -117,6 +119,7 @@ export const SharedPlayerContexts: React.FC<{
 											<Internals.SharedAudioContextProvider
 												numberOfAudioTags={numberOfSharedAudioTags}
 												component={component}
+												audioLatencyHint={audioLatencyHint}
 											>
 												<Internals.BufferingProvider>
 													{children}

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -125,6 +125,7 @@ const ThumbnailFn = <
 				numberOfSharedAudioTags={0}
 				initiallyMuted
 				logLevel={logLevel}
+				audioLatencyHint="playback"
 			>
 				<ThumbnailEmitterContext.Provider value={emitter}>
 					<ThumbnailUI

--- a/packages/renderer/src/options/index.tsx
+++ b/packages/renderer/src/options/index.tsx
@@ -19,6 +19,7 @@ import {glOption} from './gl';
 import {hardwareAccelerationOption} from './hardware-acceleration';
 import {headlessOption} from './headless';
 import {jpegQualityOption} from './jpeg-quality';
+import {audioLatencyHintOption} from './latency-hint';
 import {logLevelOption} from './log-level';
 import {metadataOption} from './metadata';
 import {mutedOption} from './mute';
@@ -83,6 +84,7 @@ export const allOptions = {
 	hardwareAccelerationOption,
 	chromeModeOption,
 	apiKeyOption,
+	audioLatencyHintOption,
 };
 
 export type AvailableOptions = keyof typeof allOptions;

--- a/packages/renderer/src/options/latency-hint.tsx
+++ b/packages/renderer/src/options/latency-hint.tsx
@@ -1,0 +1,37 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'audio-latency-hint' as const;
+
+let value: AudioContextLatencyCategory | null = null;
+
+export const audioLatencyHintOption = {
+	name: 'Audio Latency Hint',
+	cliFlag,
+	description: () => (
+		<>
+			Sets the audio latency hint for the AudioContext that Remotion uses to
+			play audio.
+			<br />
+			Possible values: <code>interactive</code>, <code>balanced</code>,{' '}
+			<code>playback</code>
+		</>
+	),
+	ssrName: 'audioLatencyHint' as const,
+	docLink: 'https://www.remotion.dev/docs/renderer/render-media',
+	type: 'interactive' as AudioContextLatencyCategory,
+	getValue: ({commandLine}) => {
+		const val = commandLine[cliFlag];
+		if (typeof val !== 'undefined') {
+			return {value: val as AudioContextLatencyCategory, source: 'cli'};
+		}
+
+		if (value !== null) {
+			return {value, source: 'config'};
+		}
+
+		return {value: null, source: 'default'};
+	},
+	setConfig: (profile: AudioContextLatencyCategory | null) => {
+		value = profile;
+	},
+} satisfies AnyRemotionOption<AudioContextLatencyCategory | null>;

--- a/packages/renderer/src/options/latency-hint.tsx
+++ b/packages/renderer/src/options/latency-hint.tsx
@@ -9,8 +9,12 @@ export const audioLatencyHintOption = {
 	cliFlag,
 	description: () => (
 		<>
-			Sets the audio latency hint for the AudioContext that Remotion uses to
-			play audio.
+			Sets the{' '}
+			<a href="https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext">
+				audio latency
+			</a>{' '}
+			hint for the global <code>AudioContext</code> context that Remotion uses
+			to play audio.
 			<br />
 			Possible values: <code>interactive</code>, <code>balanced</code>,{' '}
 			<code>playback</code>

--- a/packages/renderer/src/test/get-assets-for-markup.tsx
+++ b/packages/renderer/src/test/get-assets-for-markup.tsx
@@ -112,6 +112,7 @@ export const getAssetsForMarkup = async (
 					logLevel="info"
 					onlyRenderComposition={null}
 					currentCompositionMetadata={null}
+					audioLatencyHint="interactive"
 				>
 					<Internals.CompositionManager.Provider value={value}>
 						<Internals.RenderAssetManager.Provider value={assetContext}>

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -41,6 +41,7 @@ export const startServer = async (options: {
 	gitSource: GitSource | null;
 	binariesDirectory: string | null;
 	forceIPv4: boolean;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 }): Promise<{
 	port: number;
 	liveEventsServer: LiveEventsServer;
@@ -100,6 +101,7 @@ export const startServer = async (options: {
 					queueMethods: options.queueMethods,
 					gitSource: options.gitSource,
 					binariesDirectory: options.binariesDirectory,
+					audioLatencyHint: options.audioLatencyHint,
 				});
 			})
 			.catch((err) => {

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -112,7 +112,7 @@ const handleFallback = async ({
 				packageManager === 'unknown' ? 'unknown' : packageManager.manager,
 			logLevel,
 			mode: 'dev',
-			audioLatencyHint,
+			audioLatencyHint: audioLatencyHint ?? 'interactive',
 		}),
 	);
 };

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -57,6 +57,7 @@ const handleFallback = async ({
 	getRenderQueue,
 	getRenderDefaults,
 	numberOfAudioTags,
+	audioLatencyHint,
 	gitSource,
 	logLevel,
 }: {
@@ -69,6 +70,7 @@ const handleFallback = async ({
 	getRenderQueue: () => RenderJob[];
 	getRenderDefaults: () => RenderDefaults;
 	numberOfAudioTags: number;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 	gitSource: GitSource | null;
 	logLevel: LogLevel;
 }) => {
@@ -110,6 +112,7 @@ const handleFallback = async ({
 				packageManager === 'unknown' ? 'unknown' : packageManager.manager,
 			logLevel,
 			mode: 'dev',
+			audioLatencyHint,
 		}),
 	);
 };
@@ -317,6 +320,7 @@ export const handleRoutes = ({
 	queueMethods: methods,
 	gitSource,
 	binariesDirectory,
+	audioLatencyHint,
 }: {
 	staticHash: string;
 	staticHashPrefix: string;
@@ -337,6 +341,7 @@ export const handleRoutes = ({
 	queueMethods: QueueMethods;
 	gitSource: GitSource | null;
 	binariesDirectory: string | null;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 }): Promise<void> => {
 	const url = new URL(request.url as string, 'http://localhost');
 
@@ -449,5 +454,6 @@ export const handleRoutes = ({
 		numberOfAudioTags,
 		gitSource,
 		logLevel,
+		audioLatencyHint,
 	});
 };

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -79,6 +79,7 @@ export const startStudio = async ({
 	bufferStateDelayInMilliseconds,
 	binariesDirectory,
 	forceIPv4,
+	audioLatencyHint,
 }: {
 	browserArgs: string;
 	browserFlag: string;
@@ -98,6 +99,7 @@ export const startStudio = async ({
 	getRenderDefaults: () => RenderDefaults;
 	getRenderQueue: () => RenderJob[];
 	numberOfAudioTags: number;
+	audioLatencyHint: AudioContextLatencyCategory | null;
 	queueMethods: QueueMethods;
 	parsedCliOpen: boolean;
 	previewEntry: string;
@@ -174,6 +176,7 @@ export const startStudio = async ({
 		bufferStateDelayInMilliseconds,
 		binariesDirectory,
 		forceIPv4,
+		audioLatencyHint,
 	});
 
 	const cleanupLiveEventsListener = setLiveEventsListener(liveEventsServer);

--- a/packages/studio/src/Studio.tsx
+++ b/packages/studio/src/Studio.tsx
@@ -35,6 +35,7 @@ export const Studio: React.FC<{
 			numberOfAudioTags={window.remotion_numberOfAudioTags}
 			onlyRenderComposition={null}
 			currentCompositionMetadata={null}
+			audioLatencyHint={window.remotion_audioLatencyHint ?? 'interactive'}
 		>
 			<EditorContexts readOnlyStudio={readOnly}>
 				<Editor readOnlyStudio={readOnly} Root={rootComponent} />

--- a/packages/studio/src/renderEntry.tsx
+++ b/packages/studio/src/renderEntry.tsx
@@ -224,6 +224,7 @@ const renderContent = (Root: React.FC) => {
 			<Internals.RemotionRoot
 				logLevel={window.remotion_logLevel}
 				numberOfAudioTags={0}
+				audioLatencyHint={window.remotion_audioLatencyHint ?? 'interactive'}
 				onlyRenderComposition={bundleMode.compositionName}
 				currentCompositionMetadata={{
 					props: NoReactInternals.deserializeJSONWithSpecialTypes(
@@ -252,6 +253,7 @@ const renderContent = (Root: React.FC) => {
 				numberOfAudioTags={0}
 				onlyRenderComposition={null}
 				currentCompositionMetadata={null}
+				audioLatencyHint={window.remotion_audioLatencyHint ?? 'interactive'}
 			>
 				<Root />
 			</Internals.RemotionRoot>


### PR DESCRIPTION
Allow customizing the `latencyHint` that we pass to our global AudioContext