### PR TITLE
`remotion`: Always find best cross-origin value

### DIFF
--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import {SequenceContext} from '../SequenceContext.js';
 import {SequenceVisibilityToggleContext} from '../SequenceManager.js';
+import {getCrossOriginValue} from '../get-cross-origin-value.js';
 import {useLogLevel} from '../log-level-context.js';
 import {usePreload} from '../prefetch.js';
 import {random} from '../random.js';
@@ -66,6 +67,7 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		showInTimeline,
 		loopVolumeCurveBehavior,
 		stack,
+		crossOrigin,
 		...nativeProps
 	} = props;
 
@@ -213,7 +215,19 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		return null;
 	}
 
-	return <audio ref={audioRef} preload="metadata" {...propsToPass} />;
+	const crossOriginValue = getCrossOriginValue({
+		crossOrigin,
+		requestsVideoFrame: false,
+	});
+
+	return (
+		<audio
+			ref={audioRef}
+			preload="metadata"
+			crossOrigin={crossOriginValue}
+			{...propsToPass}
+		/>
+	);
 };
 
 export const AudioForPreview = forwardRef(

--- a/packages/core/src/get-cross-origin-value.ts
+++ b/packages/core/src/get-cross-origin-value.ts
@@ -1,0 +1,37 @@
+import {getRemotionEnvironment} from './get-remotion-environment';
+
+export const getCrossOriginValue = ({
+	crossOrigin,
+	requestsVideoFrame,
+}: {
+	crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined;
+	requestsVideoFrame: boolean;
+}) => {
+	// If user specifies a value explicitly, use that
+	if (crossOrigin !== undefined && crossOrigin !== null) {
+		return crossOrigin;
+	}
+
+	// We need to set anonymous because otherwise we are not allowed
+	// to get frames
+	if (requestsVideoFrame) {
+		return 'anonymous';
+	}
+
+	// If we are in preview mode, we need to set anonymous
+	// because we use Web Audio API and otherwise it would
+	// zero out
+	// See issue: https://github.com/remotion-dev/remotion/issues/5274
+	// Second reason: In Studio, window.crossOriginIsolated is set,
+	// and you cannot play media from CORS at all.
+
+	if (!getRemotionEnvironment().isRendering) {
+		return 'anonymous';
+	}
+
+	// During rendering, we opt out of the crossOrigin value
+	// because it may lead to flickering
+
+	// https://discord.com/channels/809501355504959528/1275726814790025271/1278375651153547264
+	return undefined;
+};

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -12,6 +12,7 @@ import {SequenceVisibilityToggleContext} from '../SequenceManager.js';
 import {SharedAudioContext} from '../audio/shared-audio-tags.js';
 import {makeSharedElementSourceNode} from '../audio/shared-element-source-node.js';
 import {useFrameForVolumeProp} from '../audio/use-audio-frame.js';
+import {getCrossOriginValue} from '../get-cross-origin-value.js';
 import {useLogLevel, useMountTime} from '../log-level-context.js';
 import {playbackLogging} from '../playback-logging.js';
 import {usePreload} from '../prefetch.js';
@@ -277,8 +278,10 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		};
 	}, [isSequenceHidden, style]);
 
-	const crossOriginValue =
-		crossOrigin ?? (onVideoFrame ? 'anonymous' : undefined);
+	const crossOriginValue = getCrossOriginValue({
+		crossOrigin,
+		requestsVideoFrame: Boolean(onVideoFrame),
+	});
 
 	return (
 		<video


### PR DESCRIPTION
Fixes #5274