### PR TITLE
`@remotion/media-parser`: Correct return timestamp of .avi files with more than 1 audio channel

### DIFF
--- a/packages/media-parser/src/containers/riff/parse-movi.ts
+++ b/packages/media-parser/src/containers/riff/parse-movi.ts
@@ -61,7 +61,7 @@ export const handleChunk = async ({
 				cts: timestamp,
 				dts: timestamp,
 				data,
-				duration: undefined,
+				duration: 1 / samplesPerSecond,
 				timestamp,
 				trackId,
 				type: keyOrDelta,
@@ -84,7 +84,12 @@ export const handleChunk = async ({
 		const trackId = parseInt(audioChunk[1], 10);
 		const strh = getStrhForIndex(state.structure.getRiffStructure(), trackId);
 
-		const samplesPerSecond = strh.rate / strh.scale;
+		const {strf} = strh;
+		if (strf.type !== 'strf-box-audio') {
+			throw new Error('audio');
+		}
+
+		const samplesPerSecond = (strh.rate / strh.scale) * strf.numberOfChannels;
 		const nthSample = state.riff.sampleCounter.getSamplesForTrack(trackId);
 		const timeInSec = nthSample / samplesPerSecond;
 		const timestamp = timeInSec;

--- a/packages/media-parser/src/test/parse-avi-file.test.ts
+++ b/packages/media-parser/src/test/parse-avi-file.test.ts
@@ -42,7 +42,12 @@ test('AVI file', async () => {
 		},
 		onAudioTrack: () => {
 			audioTrackCount++;
-			return () => {
+			return (sample) => {
+				const time = sample.timestamp / sample.timescale;
+				if (time > 31) {
+					throw new Error('time higher than duration');
+				}
+
 				audioSamples++;
 			};
 		},
@@ -52,7 +57,12 @@ test('AVI file', async () => {
 			}
 
 			videoTrackCount++;
-			return () => {
+			return (sample) => {
+				const time = sample.timestamp / sample.timescale;
+				if (time > 31) {
+					throw new Error('time higher than duration');
+				}
+
 				videoSamples++;
 			};
 		},


### PR DESCRIPTION
`@remotion/media-parser`: Correct return timestamp of .avi files with more than 1 audio channel