### PR TITLE
`@remotion/media-parser`: Fix the timestamps of ouf-of-order AVC samples

### DIFF
--- a/packages/media-parser/src/check-if-done.ts
+++ b/packages/media-parser/src/check-if-done.ts
@@ -26,6 +26,11 @@ export const checkIfDone = async (state: ParserState) => {
 			return false;
 		}
 
+		state.riff.queuedBFrames.flush();
+		if (state.riff.queuedBFrames.hasReleasedFrames()) {
+			return false;
+		}
+
 		Log.verbose(state.logLevel, 'Reached end of file');
 		await state.discardReadBytes(true);
 

--- a/packages/media-parser/src/containers/avc/key.ts
+++ b/packages/media-parser/src/containers/avc/key.ts
@@ -1,6 +1,8 @@
 import type {AvcInfo} from './parse-avc';
 
-export const getKeyFrameOrDeltaFromAvcInfo = (infos: AvcInfo[]) => {
+export const getKeyFrameOrDeltaFromAvcInfo = (
+	infos: AvcInfo[],
+): 'key' | 'delta' | 'bidirectional' => {
 	const keyOrDelta = infos.find(
 		(i) => i.type === 'keyframe' || i.type === 'delta-frame',
 	);
@@ -8,5 +10,9 @@ export const getKeyFrameOrDeltaFromAvcInfo = (infos: AvcInfo[]) => {
 		throw new Error('expected avc to contain info about key or delta');
 	}
 
-	return keyOrDelta.type === 'keyframe' ? 'key' : 'delta';
+	return keyOrDelta.type === 'keyframe'
+		? 'key'
+		: keyOrDelta.isBidirectionalFrame
+			? 'bidirectional'
+			: 'delta';
 };

--- a/packages/media-parser/src/containers/avc/max-buffer-size.ts
+++ b/packages/media-parser/src/containers/avc/max-buffer-size.ts
@@ -1,0 +1,36 @@
+import type {SpsInfo} from './parse-avc';
+
+const maxMacroblocksByLevel: Record<number, number> = {
+	0x0a: 396,
+	0x0b: 396,
+	0x0c: 900,
+	0x0d: 2376,
+	0x0e: 2376,
+	0x15: 2376,
+	0x16: 4752,
+	0x1e: 8118,
+	0x20: 8100,
+	0x28: 18000,
+	0x29: 20480,
+	0x32: 32768,
+	0x33: 32768,
+	0x3c: 34816,
+	0x42: 110400,
+	0x4d: 184320,
+	0x50: 184320,
+};
+
+export const macroBlocksPerFrame = (sps: SpsInfo) => {
+	const {pic_width_in_mbs_minus1, pic_height_in_map_units_minus1} = sps;
+	return (pic_width_in_mbs_minus1 + 1) * (pic_height_in_map_units_minus1 + 1);
+};
+
+export const maxMacroblockBufferSize = (sps: SpsInfo) => {
+	const {level} = sps;
+	const maxMacroblocks = maxMacroblocksByLevel[level];
+	if (maxMacroblocks === undefined) {
+		throw new Error(`Unsupported level: ${level.toString(16)}`);
+	}
+
+	return maxMacroblocks;
+};

--- a/packages/media-parser/src/containers/avc/parse-avc.ts
+++ b/packages/media-parser/src/containers/avc/parse-avc.ts
@@ -3,6 +3,11 @@
 
 import type {BufferIterator} from '../../iterator/buffer-iterator';
 import {getArrayBufferIterator} from '../../iterator/buffer-iterator';
+import type {AvcState} from '../../state/avc/avc-state';
+import type {
+	MediaParserAvcDeltaFrameInfo,
+	MediaParserAvcKeyframeInfo,
+} from '../../webcodec-sample-types';
 
 const Extended_SAR = 255;
 
@@ -17,6 +22,45 @@ type VuiParameters = {
 	matrix_coefficients: number | null;
 	chroma_sample_loc_type_top_field: number | null;
 	chroma_sample_loc_type_bottom_field: number | null;
+};
+
+const getPoc = (iterator: BufferIterator, sps: SpsInfo, avcState: AvcState) => {
+	const {pic_order_cnt_type, log2_max_pic_order_cnt_lsb_minus4} = sps;
+	if (pic_order_cnt_type !== 0) {
+		return null;
+	}
+
+	const prevPicOrderCntLsb = avcState.getPrevPicOrderCntLsb();
+	const prevPicOrderCntMsb = avcState.getPrevPicOrderCntMsb();
+
+	if (log2_max_pic_order_cnt_lsb_minus4 === null) {
+		throw new Error('log2_max_pic_order_cnt_lsb_minus4 is null');
+	}
+
+	const max_pic_order_cnt_lsb = 2 ** (log2_max_pic_order_cnt_lsb_minus4 + 4);
+	const pic_order_cnt_lsb = iterator.getBits(
+		log2_max_pic_order_cnt_lsb_minus4 + 4,
+	);
+	let picOrderCntMsb;
+	if (
+		pic_order_cnt_lsb < prevPicOrderCntLsb &&
+		prevPicOrderCntLsb >= max_pic_order_cnt_lsb / 2
+	) {
+		picOrderCntMsb = prevPicOrderCntMsb + max_pic_order_cnt_lsb;
+	} else if (
+		pic_order_cnt_lsb > prevPicOrderCntLsb &&
+		pic_order_cnt_lsb - prevPicOrderCntLsb > max_pic_order_cnt_lsb / 2
+	) {
+		picOrderCntMsb = prevPicOrderCntMsb - max_pic_order_cnt_lsb;
+	} else {
+		picOrderCntMsb = prevPicOrderCntMsb;
+	}
+
+	const poc = picOrderCntMsb + pic_order_cnt_lsb;
+	avcState.setPrevPicOrderCntLsb(pic_order_cnt_lsb);
+	avcState.setPrevPicOrderCntMsb(picOrderCntMsb);
+
+	return poc;
 };
 
 const readVuiParameters = (iterator: BufferIterator): VuiParameters => {
@@ -86,7 +130,7 @@ export type SpsInfo = {
 	bit_depth_luma_minus8: number | null;
 	bit_depth_chroma_minus8: number | null;
 	qpprime_y_zero_transform_bypass_flag: number | null;
-	log2_max_frame_num_minus4: number | null;
+	log2_max_frame_num_minus4: number;
 	log2_max_pic_order_cnt_lsb_minus4: number | null;
 	max_num_ref_frames: number | null;
 	gaps_in_frame_num_value_allowed_flag: number | null;
@@ -99,6 +143,7 @@ export type SpsInfo = {
 	frame_crop_top_offset: number | null;
 	frame_crop_bottom_offset: number | null;
 	vui_parameters: VuiParameters | null;
+	pic_order_cnt_type: number;
 };
 
 const readSps = (iterator: BufferIterator): SpsInfo => {
@@ -222,6 +267,7 @@ const readSps = (iterator: BufferIterator): SpsInfo => {
 		frame_crop_top_offset,
 		mb_adaptive_frame_field_flag,
 		vui_parameters,
+		pic_order_cnt_type,
 	};
 };
 
@@ -239,12 +285,8 @@ export type AvcPPs = {
 export type AvcInfo =
 	| AvcProfileInfo
 	| AvcPPs
-	| {
-			type: 'keyframe';
-	  }
-	| {
-			type: 'delta-frame';
-	  };
+	| MediaParserAvcKeyframeInfo
+	| MediaParserAvcDeltaFrameInfo;
 
 const findEnd = (buffer: Uint8Array) => {
 	let zeroesInARow = 0;
@@ -266,17 +308,21 @@ const findEnd = (buffer: Uint8Array) => {
 	return null;
 };
 
-const inspect = (buffer: Uint8Array): AvcInfo | null => {
+const inspect = (buffer: Uint8Array, avcState: AvcState): AvcInfo | null => {
 	const iterator = getArrayBufferIterator(buffer, buffer.byteLength);
 	iterator.startReadingBits();
-	iterator.getBits(1);
-	iterator.getBits(2);
-	const type = iterator.getBits(5);
-	iterator.stopReadingBits();
+	iterator.getBits(1); // forbidden_zero_bit
+	iterator.getBits(2); // nal_ref_idc
+	const type = iterator.getBits(5); // nal_unit_type
 	if (type === 7) {
+		iterator.stopReadingBits();
+
 		const end = findEnd(buffer);
 		const data = readSps(iterator);
 		const sps = buffer.slice(0, end === null ? Infinity : end);
+		avcState.setSps(data);
+		avcState.setPrevPicOrderCntLsb(0);
+		avcState.setPrevPicOrderCntMsb(0);
 
 		return {
 			spsData: data,
@@ -286,15 +332,40 @@ const inspect = (buffer: Uint8Array): AvcInfo | null => {
 	}
 
 	if (type === 5) {
+		avcState.setPrevPicOrderCntLsb(0);
+		avcState.setPrevPicOrderCntMsb(0);
+		iterator.readExpGolomb(); // ignore first_mb_in_slice
+		iterator.readExpGolomb(); // slice_type
+		iterator.readExpGolomb(); // pic_parameter_set_id
+		const sps = avcState.getSps();
+		if (!sps) {
+			throw new Error('SPS not found');
+		}
+
+		const numberOfBitsForFrameNum = sps.log2_max_frame_num_minus4 + 4;
+		iterator.getBits(numberOfBitsForFrameNum); // frame_num
+		iterator.readExpGolomb(); // idr_pic_id
+
+		const {pic_order_cnt_type} = sps;
+
+		let poc: number | null = null;
+		if (pic_order_cnt_type === 0) {
+			poc = getPoc(iterator, sps, avcState);
+		}
+
+		iterator.stopReadingBits();
+
 		return {
 			type: 'keyframe',
+			poc,
 		};
 	}
 
 	if (type === 8) {
+		iterator.stopReadingBits();
+
 		const end = findEnd(buffer);
 		const pps = buffer.slice(0, end === null ? Infinity : end);
-
 		return {
 			type: 'avc-pps',
 			pps,
@@ -302,8 +373,30 @@ const inspect = (buffer: Uint8Array): AvcInfo | null => {
 	}
 
 	if (type === 1) {
+		iterator.readExpGolomb(); // ignore first_mb_in_slice
+		const slice_type = iterator.readExpGolomb();
+		const isBidirectionalFrame = slice_type === 6;
+		iterator.readExpGolomb(); // pic_parameter_set_id
+		const sps = avcState.getSps();
+		if (!sps) {
+			throw new Error('SPS not found');
+		}
+
+		const numberOfBitsForFrameNum = sps.log2_max_frame_num_minus4 + 4;
+		iterator.getBits(numberOfBitsForFrameNum); // frame_num
+		const {pic_order_cnt_type} = sps;
+
+		let poc: number | null = null;
+		if (pic_order_cnt_type === 0) {
+			poc = getPoc(iterator, sps, avcState);
+		}
+
+		iterator.stopReadingBits();
+
 		return {
 			type: 'delta-frame',
+			isBidirectionalFrame,
+			poc,
 		};
 	}
 
@@ -312,7 +405,7 @@ const inspect = (buffer: Uint8Array): AvcInfo | null => {
 };
 
 // https://stackoverflow.com/questions/24884827/possible-locations-for-sequence-picture-parameter-sets-for-h-264-stream
-export const parseAvc = (buffer: Uint8Array): AvcInfo[] => {
+export const parseAvc = (buffer: Uint8Array, avcState: AvcState): AvcInfo[] => {
 	let zeroesInARow = 0;
 	const infos: AvcInfo[] = [];
 
@@ -326,7 +419,7 @@ export const parseAvc = (buffer: Uint8Array): AvcInfo[] => {
 
 		if (zeroesInARow >= 2 && val === 1) {
 			zeroesInARow = 0;
-			const info = inspect(buffer.slice(i + 1, i + 100));
+			const info = inspect(buffer.slice(i + 1, i + 100), avcState);
 			if (info) {
 				infos.push(info);
 				if (info.type === 'keyframe' || info.type === 'delta-frame') {

--- a/packages/media-parser/src/containers/riff/convert-queued-sample-to-mediaparser-sample.ts
+++ b/packages/media-parser/src/containers/riff/convert-queued-sample-to-mediaparser-sample.ts
@@ -1,0 +1,31 @@
+import {convertAudioOrVideoSampleToWebCodecsTimestamps} from '../../convert-audio-or-video-sample';
+import type {ParserState} from '../../state/parser-state';
+import type {QueuedVideoSample} from '../../state/riff/queued-frames';
+import {getStrhForIndex} from './get-strh-for-index';
+
+export const convertQueuedSampleToMediaParserSample = (
+	sample: QueuedVideoSample,
+	state: ParserState,
+) => {
+	const strh = getStrhForIndex(
+		state.structure.getRiffStructure(),
+		sample.trackId,
+	);
+
+	const samplesPerSecond = strh.rate / strh.scale;
+
+	const nthSample = state.riff.sampleCounter.getSamplesForTrack(sample.trackId);
+	const timeInSec = nthSample / samplesPerSecond;
+	const timestamp = timeInSec;
+	const videoSample = convertAudioOrVideoSampleToWebCodecsTimestamps({
+		sample: {
+			...sample,
+			timestamp,
+			cts: timestamp,
+			dts: timestamp,
+		},
+		timescale: 1,
+	});
+
+	return videoSample;
+};

--- a/packages/media-parser/src/containers/riff/get-seeking-byte.ts
+++ b/packages/media-parser/src/containers/riff/get-seeking-byte.ts
@@ -1,4 +1,5 @@
 import {findLastKeyframe} from '../../find-last-keyframe';
+import type {AvcState} from '../../state/avc/avc-state';
 import type {RiffState} from '../../state/riff';
 import type {SeekResolution} from '../../work-on-seek-request';
 import type {Idx1Entry} from './riff-box';
@@ -8,10 +9,12 @@ export const getSeekingByteForRiff = async ({
 	info,
 	time,
 	riffState,
+	avcState,
 }: {
 	info: RiffSeekingHints;
 	time: number;
 	riffState: RiffState;
+	avcState: AvcState;
 }): Promise<SeekResolution> => {
 	const idx1Entries = await (info.hasIndex
 		? riffState.lazyIdx1.waitForLoaded()
@@ -30,6 +33,8 @@ export const getSeekingByteForRiff = async ({
 		}
 
 		riffState.sampleCounter.setSamplesFromSeek(lastKeyframe.sampleCounts);
+		riffState.queuedBFrames.clear();
+		avcState.clear();
 
 		return {
 			type: 'do-seek',

--- a/packages/media-parser/src/containers/riff/get-strh-for-index.ts
+++ b/packages/media-parser/src/containers/riff/get-strh-for-index.ts
@@ -1,0 +1,20 @@
+import type {RiffStructure, StrhBox} from './riff-box';
+import {getStrhBox, getStrlBoxes} from './traversal';
+
+export const getStrhForIndex = (
+	structure: RiffStructure,
+	trackId: number,
+): StrhBox => {
+	const boxes = getStrlBoxes(structure);
+	const box = boxes[trackId];
+	if (!box) {
+		throw new Error('Expected box');
+	}
+
+	const strh = getStrhBox(box.children);
+	if (!strh) {
+		throw new Error('strh');
+	}
+
+	return strh;
+};

--- a/packages/media-parser/src/containers/riff/parse-movi.ts
+++ b/packages/media-parser/src/containers/riff/parse-movi.ts
@@ -1,27 +1,9 @@
 import {convertAudioOrVideoSampleToWebCodecsTimestamps} from '../../convert-audio-or-video-sample';
 import type {ParserState} from '../../state/parser-state';
+import type {QueuedVideoSample} from '../../state/riff/queued-frames';
 import {getKeyFrameOrDeltaFromAvcInfo} from '../avc/key';
 import {parseAvc} from '../avc/parse-avc';
-import type {RiffStructure, StrhBox} from './riff-box';
-import {getStrhBox, getStrlBoxes} from './traversal';
-
-const getStrhForIndex = (
-	structure: RiffStructure,
-	trackId: number,
-): StrhBox => {
-	const boxes = getStrlBoxes(structure);
-	const box = boxes[trackId];
-	if (!box) {
-		throw new Error('Expected box');
-	}
-
-	const strh = getStrhBox(box.children);
-	if (!strh) {
-		throw new Error('strh');
-	}
-
-	return strh;
-};
+import {getStrhForIndex} from './get-strh-for-index';
 
 export const handleChunk = async ({
 	state,
@@ -41,13 +23,13 @@ export const handleChunk = async ({
 		const strh = getStrhForIndex(state.structure.getRiffStructure(), trackId);
 
 		const samplesPerSecond = strh.rate / strh.scale;
-		const nthSample = state.riff.sampleCounter.getSamplesForTrack(trackId);
-		const timeInSec = nthSample / samplesPerSecond;
-		const timestamp = timeInSec;
 
 		const data = iterator.getSlice(ckSize);
-		const infos = parseAvc(data);
+		const infos = parseAvc(data, state.avc);
 		const keyOrDelta = getKeyFrameOrDeltaFromAvcInfo(infos);
+		const info = infos.find(
+			(i) => i.type === 'keyframe' || i.type === 'delta-frame',
+		);
 
 		const avcProfile = infos.find((i) => i.type === 'avc-profile');
 		const ppsProfile = infos.find((i) => i.type === 'avc-pps');
@@ -56,25 +38,43 @@ export const handleChunk = async ({
 			state.callbacks.tracks.setIsDone(state.logLevel);
 		}
 
-		const videoSample = convertAudioOrVideoSampleToWebCodecsTimestamps({
-			sample: {
-				cts: timestamp,
-				dts: timestamp,
-				data,
-				duration: 1 / samplesPerSecond,
-				timestamp,
-				trackId,
-				type: keyOrDelta,
-				offset,
-				timescale: samplesPerSecond,
-			},
-			timescale: 1,
-		});
-		state.riff.sampleCounter.onVideoSample(trackId, videoSample);
-		// We must also NOT pass a duration because if the the next sample is 0,
-		// this sample would be longer. Chrome will pad it with silence.
-		// If we'd pass a duration instead, it would shift the audio and we think that audio is not finished
-		await state.callbacks.onVideoSample(trackId, videoSample);
+		const rawSample: QueuedVideoSample = {
+			data,
+			// We must also NOT pass a duration because if the the next sample is 0,
+			// this sample would be longer. Chrome will pad it with silence.
+			// If we'd pass a duration instead, it would shift the audio and we think that audio is not finished
+			duration: 1 / samplesPerSecond,
+			trackId,
+			type: keyOrDelta === 'bidirectional' ? 'delta' : keyOrDelta,
+			offset,
+			timescale: samplesPerSecond,
+			avc: info,
+		};
+
+		const maxFramesInBuffer = state.avc.getMaxFramesInBuffer();
+		if (maxFramesInBuffer === null) {
+			throw new Error('maxFramesInBuffer is null');
+		}
+
+		state.riff.queuedBFrames.addFrame(rawSample, maxFramesInBuffer);
+		const releasedFrame = state.riff.queuedBFrames.getReleasedFrame();
+		if (releasedFrame) {
+			const nthSample = state.riff.sampleCounter.getSamplesForTrack(trackId);
+			const timeInSec = nthSample / samplesPerSecond;
+			const timestamp = timeInSec;
+			const videoSample = convertAudioOrVideoSampleToWebCodecsTimestamps({
+				sample: {
+					...releasedFrame,
+					timestamp,
+					cts: timestamp,
+					dts: timestamp,
+				},
+				timescale: 1,
+			});
+
+			state.riff.sampleCounter.onVideoSample(trackId, videoSample);
+			await state.callbacks.onVideoSample(trackId, videoSample);
+		}
 
 		return;
 	}
@@ -100,7 +100,10 @@ export const handleChunk = async ({
 			sample: {
 				cts: timestamp,
 				dts: timestamp,
-				data,
+				data, // We must also NOT pass a duration because if the the next sample is 0,
+				// this sample would be longer. Chrome will pad it with silence.
+				// If we'd pass a duration instead, it would shift the audio and we think that audio is not finished
+
 				duration: undefined,
 				timestamp,
 				trackId,
@@ -114,10 +117,6 @@ export const handleChunk = async ({
 
 		// In example.avi, we have samples with 0 data
 		// Chrome fails on these
-
-		// We must also NOT pass a duration because if the the next sample is 0,
-		// this sample would be longer. Chrome will pad it with silence.
-		// If we'd pass a duration instead, it would shift the audio and we think that audio is not finished
 
 		await state.callbacks.onAudioSample(trackId, audioSample);
 	}

--- a/packages/media-parser/src/containers/riff/parse-riff-body.ts
+++ b/packages/media-parser/src/containers/riff/parse-riff-body.ts
@@ -3,12 +3,22 @@ import {makeSkip} from '../../skip';
 import {maySkipVideoData} from '../../state/may-skip-video-data';
 import type {ParserState} from '../../state/parser-state';
 import {getCurrentMediaSection} from '../../state/video-section';
+import {convertQueuedSampleToMediaParserSample} from './convert-queued-sample-to-mediaparser-sample';
 import {expectRiffBox, postProcessRiffBox} from './expect-riff-box';
 import {parseMediaSection} from './parse-video-section';
 
 export const parseRiffBody = async (
 	state: ParserState,
 ): Promise<ParseResult> => {
+	const releasedFrame = state.riff.queuedBFrames.getReleasedFrame();
+	if (releasedFrame) {
+		await state.callbacks.onVideoSample(
+			releasedFrame.trackId,
+			convertQueuedSampleToMediaParserSample(releasedFrame, state),
+		);
+		return null;
+	}
+
 	if (
 		state.mediaSection.isCurrentByteInMediaSection(state.iterator) ===
 		'in-section'

--- a/packages/media-parser/src/containers/transport-stream/handle-avc-packet.ts
+++ b/packages/media-parser/src/containers/transport-stream/handle-avc-packet.ts
@@ -2,6 +2,7 @@ import {convertAudioOrVideoSampleToWebCodecsTimestamps} from '../../convert-audi
 import type {MediaParserTrack} from '../../get-tracks';
 import type {MediaParserLogLevel} from '../../log';
 import {registerVideoTrack} from '../../register-track';
+import type {AvcState} from '../../state/avc/avc-state';
 import type {CallbacksState} from '../../state/sample-callbacks';
 import type {TransportStreamState} from '../../state/transport-stream/transport-stream';
 import type {
@@ -32,6 +33,7 @@ export const handleAvcPacket = async ({
 	onVideoTrack,
 	transportStream,
 	makeSamplesStartAtZero,
+	avcState,
 }: {
 	streamBuffer: TransportStreamPacketBuffer;
 	programId: number;
@@ -41,8 +43,9 @@ export const handleAvcPacket = async ({
 	onVideoTrack: MediaParserOnVideoTrack | null;
 	transportStream: TransportStreamState;
 	makeSamplesStartAtZero: boolean;
+	avcState: AvcState;
 }) => {
-	const avc = parseAvc(streamBuffer.getBuffer());
+	const avc = parseAvc(streamBuffer.getBuffer(), avcState);
 	const isTrackRegistered = sampleCallbacks.tracks.getTracks().find((t) => {
 		return t.trackId === programId;
 	});
@@ -122,7 +125,7 @@ export const handleAvcPacket = async ({
 		duration: undefined,
 		data: streamBuffer.getBuffer(),
 		trackId: programId,
-		type,
+		type: type === 'bidirectional' ? 'delta' : type,
 		offset,
 		timescale: MPEG_TIMESCALE,
 	};

--- a/packages/media-parser/src/containers/transport-stream/parse-transport-stream.ts
+++ b/packages/media-parser/src/containers/transport-stream/parse-transport-stream.ts
@@ -40,6 +40,7 @@ export const parseTransportStream = async (
 			onAudioTrack: state.onAudioTrack,
 			onVideoTrack: state.onVideoTrack,
 			makeSamplesStartAtZero: state.makeSamplesStartAtZero,
+			avcState: state.avc,
 		});
 	}
 

--- a/packages/media-parser/src/containers/transport-stream/process-audio.ts
+++ b/packages/media-parser/src/containers/transport-stream/process-audio.ts
@@ -1,5 +1,6 @@
 import type {MediaParserLogLevel} from '../../log';
 import type {TransportStreamStructure} from '../../parse-result';
+import type {AvcState} from '../../state/avc/avc-state';
 import type {CallbacksState} from '../../state/sample-callbacks';
 import type {TransportStreamState} from '../../state/transport-stream/transport-stream';
 import type {
@@ -43,6 +44,7 @@ export const processAudio = async ({
 	onVideoTrack,
 	transportStream,
 	makeSamplesStartAtZero,
+	avcState,
 }: {
 	transportStreamEntry: TransportStreamEntry;
 	structure: TransportStreamStructure;
@@ -53,6 +55,7 @@ export const processAudio = async ({
 	transportStream: TransportStreamState;
 	offset: number;
 	makeSamplesStartAtZero: boolean;
+	avcState: AvcState;
 }): Promise<void> => {
 	const {streamBuffers, nextPesHeaderStore: nextPesHeader} = transportStream;
 	const streamBuffer = streamBuffers.get(transportStreamEntry.pid);
@@ -85,6 +88,7 @@ export const processAudio = async ({
 		onVideoTrack,
 		transportStream,
 		makeSamplesStartAtZero,
+		avcState,
 	});
 
 	const rest = streamBuffer.getBuffer().slice(expectedLength);

--- a/packages/media-parser/src/containers/transport-stream/process-sample-if-possible.ts
+++ b/packages/media-parser/src/containers/transport-stream/process-sample-if-possible.ts
@@ -30,6 +30,7 @@ export const processSampleIfPossible = async (state: ParserState) => {
 					onVideoTrack: state.onVideoTrack,
 					transportStream: state.transportStream,
 					makeSamplesStartAtZero: state.makeSamplesStartAtZero,
+					avcState: state.avc,
 				});
 				state.transportStream.streamBuffers.delete(stream.pid);
 
@@ -59,6 +60,7 @@ export const processSampleIfPossible = async (state: ParserState) => {
 					transportStream: state.transportStream,
 					makeSamplesStartAtZero: state.makeSamplesStartAtZero,
 					transportStreamEntry: stream,
+					avcState: state.avc,
 				});
 				processed = true;
 				break;

--- a/packages/media-parser/src/containers/transport-stream/process-stream-buffers.ts
+++ b/packages/media-parser/src/containers/transport-stream/process-stream-buffers.ts
@@ -1,6 +1,7 @@
 import {combineUint8Arrays} from '../../combine-uint8-arrays';
 import type {MediaParserLogLevel} from '../../log';
 import type {TransportStreamStructure} from '../../parse-result';
+import type {AvcState} from '../../state/avc/avc-state';
 import type {CallbacksState} from '../../state/sample-callbacks';
 import type {TransportStreamState} from '../../state/transport-stream/transport-stream';
 import type {
@@ -93,6 +94,7 @@ export const processStreamBuffer = async ({
 	onVideoTrack,
 	transportStream,
 	makeSamplesStartAtZero,
+	avcState,
 }: {
 	streamBuffer: TransportStreamPacketBuffer;
 	programId: number;
@@ -103,6 +105,7 @@ export const processStreamBuffer = async ({
 	onVideoTrack: MediaParserOnVideoTrack | null;
 	transportStream: TransportStreamState;
 	makeSamplesStartAtZero: boolean;
+	avcState: AvcState;
 }) => {
 	const stream = getStreamForId(structure, programId);
 	if (!stream) {
@@ -125,6 +128,7 @@ export const processStreamBuffer = async ({
 			offset: streamBuffer.offset,
 			transportStream,
 			makeSamplesStartAtZero,
+			avcState,
 		});
 	}
 	// 15 = AAC / ADTS
@@ -158,6 +162,7 @@ export const processFinalStreamBuffers = async ({
 	onVideoTrack,
 	transportStream,
 	makeSamplesStartAtZero,
+	avcState,
 }: {
 	structure: TransportStreamStructure;
 	sampleCallbacks: CallbacksState;
@@ -166,6 +171,7 @@ export const processFinalStreamBuffers = async ({
 	onVideoTrack: MediaParserOnVideoTrack | null;
 	transportStream: TransportStreamState;
 	makeSamplesStartAtZero: boolean;
+	avcState: AvcState;
 }) => {
 	for (const [programId, buffer] of transportStream.streamBuffers) {
 		if (buffer.getBuffer().byteLength > 0) {
@@ -179,6 +185,7 @@ export const processFinalStreamBuffers = async ({
 				onVideoTrack,
 				transportStream,
 				makeSamplesStartAtZero,
+				avcState,
 			});
 			transportStream.streamBuffers.delete(programId);
 		}

--- a/packages/media-parser/src/containers/transport-stream/process-video.ts
+++ b/packages/media-parser/src/containers/transport-stream/process-video.ts
@@ -1,5 +1,6 @@
 import type {MediaParserLogLevel} from '../../log';
 import type {TransportStreamStructure} from '../../parse-result';
+import type {AvcState} from '../../state/avc/avc-state';
 import type {CallbacksState} from '../../state/sample-callbacks';
 import type {TransportStreamState} from '../../state/transport-stream/transport-stream';
 import type {
@@ -36,6 +37,7 @@ export const processVideo = async ({
 	onVideoTrack,
 	transportStream,
 	makeSamplesStartAtZero,
+	avcState,
 }: {
 	programId: number;
 	structure: TransportStreamStructure;
@@ -46,6 +48,7 @@ export const processVideo = async ({
 	onVideoTrack: MediaParserOnVideoTrack | null;
 	transportStream: TransportStreamState;
 	makeSamplesStartAtZero: boolean;
+	avcState: AvcState;
 }): Promise<Uint8Array> => {
 	const indexOfSeparator = streamBuffer.get2ndSubArrayIndex();
 
@@ -72,6 +75,7 @@ export const processVideo = async ({
 		onVideoTrack,
 		transportStream,
 		makeSamplesStartAtZero,
+		avcState,
 	});
 	return rest;
 };

--- a/packages/media-parser/src/containers/webm/parse-ebml.ts
+++ b/packages/media-parser/src/containers/webm/parse-ebml.ts
@@ -160,6 +160,7 @@ export const postprocessEbml = async ({
 		onAudioTrack,
 		onVideoTrack,
 		structureState,
+		avcState,
 	},
 }: {
 	offset: number;
@@ -220,6 +221,7 @@ export const postprocessEbml = async ({
 			callbacks,
 			logLevel,
 			onVideoTrack,
+			avcState,
 		});
 
 		if (sample.type === 'video-sample') {
@@ -285,6 +287,7 @@ export const postprocessEbml = async ({
 						callbacks,
 						logLevel,
 						onVideoTrack,
+						avcState,
 					});
 
 		if (sample && sample.type === 'partial-video-sample') {

--- a/packages/media-parser/src/containers/webm/state-for-processing.ts
+++ b/packages/media-parser/src/containers/webm/state-for-processing.ts
@@ -1,4 +1,5 @@
 import type {MediaParserLogLevel} from '../../log';
+import type {AvcState} from '../../state/avc/avc-state';
 import type {WebmState} from '../../state/matroska/webm';
 import type {ParserState} from '../../state/parser-state';
 import type {CallbacksState} from '../../state/sample-callbacks';
@@ -7,7 +8,6 @@ import type {
 	MediaParserOnAudioTrack,
 	MediaParserOnVideoTrack,
 } from '../../webcodec-sample-types';
-
 export type WebmRequiredStatesForProcessing = {
 	webmState: WebmState;
 	callbacks: CallbacksState;
@@ -15,6 +15,7 @@ export type WebmRequiredStatesForProcessing = {
 	onAudioTrack: MediaParserOnAudioTrack | null;
 	onVideoTrack: MediaParserOnVideoTrack | null;
 	structureState: StructureState;
+	avcState: AvcState;
 };
 
 export const selectStatesForProcessing = ({
@@ -24,6 +25,7 @@ export const selectStatesForProcessing = ({
 	onVideoTrack,
 	structure,
 	webm,
+	avc,
 }: ParserState): WebmRequiredStatesForProcessing => {
 	return {
 		webmState: webm,
@@ -32,5 +34,6 @@ export const selectStatesForProcessing = ({
 		onAudioTrack,
 		onVideoTrack,
 		structureState: structure,
+		avcState: avc,
 	};
 };

--- a/packages/media-parser/src/convert-audio-or-video-sample.ts
+++ b/packages/media-parser/src/convert-audio-or-video-sample.ts
@@ -45,5 +45,6 @@ export const convertAudioOrVideoSampleToWebCodecsTimestamps = <
 		type: sample.type,
 		offset: sample.offset,
 		timescale: TARGET_TIMESCALE,
+		...('avc' in sample ? {avc: sample.avc} : {}),
 	} as T;
 };

--- a/packages/media-parser/src/get-seeking-byte.ts
+++ b/packages/media-parser/src/get-seeking-byte.ts
@@ -9,6 +9,7 @@ import {getSeekingByteFromMatroska} from './containers/webm/seek/get-seeking-byt
 import type {MediaParserLogLevel} from './log';
 import type {M3uPlaylistContext} from './options';
 import type {SeekingHints} from './seeking-hints';
+import type {AvcState} from './state/avc/avc-state';
 import type {IsoBaseMediaState} from './state/iso-base-media/iso-state';
 import type {M3uState} from './state/m3u-state';
 import type {WebmState} from './state/matroska/webm';
@@ -32,6 +33,7 @@ export const getSeekingByte = ({
 	structure,
 	riffState,
 	m3uState,
+	avcState,
 }: {
 	info: SeekingHints;
 	time: number;
@@ -45,6 +47,7 @@ export const getSeekingByte = ({
 	m3uPlaylistContext: M3uPlaylistContext | null;
 	riffState: RiffState;
 	m3uState: M3uState;
+	avcState: AvcState;
 }): Promise<SeekResolution> => {
 	if (info.type === 'iso-base-media-seeking-hints') {
 		return getSeekingByteFromIsoBaseMedia({
@@ -113,6 +116,7 @@ export const getSeekingByte = ({
 			info,
 			time,
 			riffState,
+			avcState,
 		});
 	}
 

--- a/packages/media-parser/src/run-parse-iteration.ts
+++ b/packages/media-parser/src/run-parse-iteration.ts
@@ -22,10 +22,6 @@ export const runParseIteration = async ({
 		return parseM3u({state});
 	}
 
-	if (state.iterator.bytesRemaining() === 0) {
-		return Promise.reject(new Error('no bytes'));
-	}
-
 	if (structure === null) {
 		await initVideo({
 			state,

--- a/packages/media-parser/src/state/avc/avc-state.ts
+++ b/packages/media-parser/src/state/avc/avc-state.ts
@@ -1,0 +1,51 @@
+import {
+	macroBlocksPerFrame,
+	maxMacroblockBufferSize,
+} from '../../containers/avc/max-buffer-size';
+import type {SpsInfo} from '../../containers/avc/parse-avc';
+
+export const avcState = () => {
+	let prevPicOrderCntLsb = 0;
+	let prevPicOrderCntMsb = 0;
+	let sps: SpsInfo | null = null;
+	let maxFramesInBuffer: number | null = null;
+
+	return {
+		getPrevPicOrderCntLsb() {
+			return prevPicOrderCntLsb;
+		},
+		getPrevPicOrderCntMsb() {
+			return prevPicOrderCntMsb;
+		},
+		setPrevPicOrderCntLsb(value: number) {
+			prevPicOrderCntLsb = value;
+		},
+		setPrevPicOrderCntMsb(value: number) {
+			prevPicOrderCntMsb = value;
+		},
+		setSps(value: SpsInfo) {
+			const macroblockBufferSize = macroBlocksPerFrame(value);
+			const maxBufferSize = maxMacroblockBufferSize(value);
+			const maxFrames = Math.min(
+				16,
+				Math.floor(maxBufferSize / macroblockBufferSize),
+			);
+			maxFramesInBuffer = maxFrames;
+			sps = value;
+		},
+		getSps() {
+			return sps;
+		},
+		getMaxFramesInBuffer() {
+			return maxFramesInBuffer;
+		},
+		clear() {
+			maxFramesInBuffer = null;
+			sps = null;
+			prevPicOrderCntLsb = 0;
+			prevPicOrderCntMsb = 0;
+		},
+	};
+};
+
+export type AvcState = ReturnType<typeof avcState>;

--- a/packages/media-parser/src/state/parser-state.ts
+++ b/packages/media-parser/src/state/parser-state.ts
@@ -27,6 +27,7 @@ import type {
 	MediaParserOnVideoTrack,
 } from '../webcodec-sample-types';
 import {aacState} from './aac-state';
+import {avcState} from './avc/avc-state';
 import {currentReader} from './current-reader';
 import {emittedState} from './emitted-fields';
 import {flacState} from './flac-state';
@@ -122,7 +123,7 @@ export const makeParserState = ({
 	const timings = timingsState();
 	const seekInfiniteLoop = seekInfiniteLoopDetectionState();
 	const currentReaderState = currentReader(initialReaderInstance);
-
+	const avc = avcState();
 	const errored: Error | null = null;
 
 	const discardReadBytes = async (force: boolean) => {
@@ -222,6 +223,7 @@ export const makeParserState = ({
 		seekInfiniteLoop,
 		makeSamplesStartAtZero,
 		prefetchCache,
+		avc,
 	};
 };
 

--- a/packages/media-parser/src/state/riff.ts
+++ b/packages/media-parser/src/state/riff.ts
@@ -5,6 +5,7 @@ import type {ParseMediaSrc} from '../options';
 import type {MediaParserReaderInterface} from '../readers/reader';
 import type {SpsAndPps} from './parser-state';
 import {lazyIdx1Fetch} from './riff/lazy-idx1-fetch';
+import {queuedBFramesState} from './riff/queued-frames';
 import {riffSampleCounter} from './riff/sample-counter';
 
 type AvcProfileInfoCallback = (profile: SpsAndPps) => Promise<void>;
@@ -49,6 +50,7 @@ export const riffSpecificState = ({
 	});
 
 	const sampleCounter = riffSampleCounter();
+	const queuedBFrames = queuedBFramesState();
 
 	return {
 		getAvcProfile: () => {
@@ -59,6 +61,7 @@ export const riffSpecificState = ({
 		getNextTrackIndex: () => {
 			return nextTrackIndex;
 		},
+		queuedBFrames,
 		incrementNextTrackIndex: () => {
 			nextTrackIndex++;
 		},

--- a/packages/media-parser/src/state/riff/queued-frames.ts
+++ b/packages/media-parser/src/state/riff/queued-frames.ts
@@ -1,0 +1,59 @@
+import type {MediaParserVideoSample} from '../../webcodec-sample-types';
+
+export type QueuedVideoSample = Omit<
+	MediaParserVideoSample,
+	'cts' | 'dts' | 'timestamp'
+>;
+
+export const queuedBFramesState = () => {
+	const queuedFrames: QueuedVideoSample[] = [];
+	const releasedFrames: QueuedVideoSample[] = [];
+
+	const sortFrames = () => {
+		queuedFrames.sort((a, b) => {
+			if (!a.avc || !b.avc || a.avc.poc === null || b.avc.poc === null) {
+				throw new Error('Invalid frame');
+			}
+
+			return a.avc.poc - b.avc.poc;
+		});
+	};
+
+	const flush = () => {
+		sortFrames();
+
+		releasedFrames.push(...queuedFrames);
+		queuedFrames.length = 0;
+	};
+
+	return {
+		addFrame: (frame: QueuedVideoSample, maxFramesInBuffer: number) => {
+			if (frame.type === 'key') {
+				flush();
+			}
+
+			queuedFrames.push(frame);
+
+			if (queuedFrames.length > maxFramesInBuffer) {
+				sortFrames();
+
+				releasedFrames.push(queuedFrames.shift()!);
+			}
+		},
+		flush,
+		getReleasedFrame: (): QueuedVideoSample | null => {
+			if (releasedFrames.length === 0) {
+				return null;
+			}
+
+			return releasedFrames.shift()!;
+		},
+		hasReleasedFrames: () => {
+			return releasedFrames.length > 0;
+		},
+		clear: () => {
+			releasedFrames.length = 0;
+			queuedFrames.length = 0;
+		},
+	};
+};

--- a/packages/media-parser/src/test/parse-avi-file.test.ts
+++ b/packages/media-parser/src/test/parse-avi-file.test.ts
@@ -8,6 +8,9 @@ test('AVI file', async () => {
 	let videoTrackCount = 0;
 	let audioSamples = 0;
 	let videoSamples = 0;
+
+	let lastPoc = -1;
+
 	const {
 		slowStructure,
 		tracks,
@@ -59,6 +62,15 @@ test('AVI file', async () => {
 			videoTrackCount++;
 			return (sample) => {
 				const time = sample.timestamp / sample.timescale;
+				if (sample.type === 'key') {
+					lastPoc = -1;
+				}
+
+				if ((sample.avc?.poc ?? 0) < lastPoc) {
+					throw new Error('poc lower than last poc');
+				}
+
+				lastPoc = sample.avc?.poc as number;
 				if (time > 31) {
 					throw new Error('time higher than duration');
 				}

--- a/packages/media-parser/src/webcodec-sample-types.ts
+++ b/packages/media-parser/src/webcodec-sample-types.ts
@@ -41,6 +41,21 @@ export type MediaParserAudioSample = {
 	timescale: number;
 };
 
+export type MediaParserAvcKeyframeInfo = {
+	type: 'keyframe';
+	poc: number | null;
+};
+
+export type MediaParserAvcDeltaFrameInfo = {
+	type: 'delta-frame';
+	isBidirectionalFrame: boolean;
+	poc: number | null;
+};
+
+export type MediaParserAvcExtraInfo =
+	| MediaParserAvcKeyframeInfo
+	| MediaParserAvcDeltaFrameInfo;
+
 export type MediaParserVideoSample = {
 	data: Uint8Array;
 	timestamp: number;
@@ -51,4 +66,5 @@ export type MediaParserVideoSample = {
 	dts: number;
 	offset: number;
 	timescale: number;
+	avc?: MediaParserAvcExtraInfo;
 };

--- a/packages/media-parser/src/work-on-seek-request.ts
+++ b/packages/media-parser/src/work-on-seek-request.ts
@@ -14,6 +14,7 @@ import type {
 import {performSeek} from './perform-seek';
 import type {MediaParserReaderInterface} from './readers/reader';
 import type {AacState} from './state/aac-state';
+import type {AvcState} from './state/avc/avc-state';
 import type {CurrentReader} from './state/current-reader';
 import type {FlacState} from './state/flac-state';
 import type {TracksState} from './state/has-tracks-section';
@@ -49,6 +50,7 @@ const turnSeekIntoByte = async ({
 	contentLength,
 	aacState,
 	m3uState,
+	avcState,
 }: {
 	seek: number;
 	mediaSectionState: MediaSectionState;
@@ -68,6 +70,7 @@ const turnSeekIntoByte = async ({
 	aacState: AacState;
 	contentLength: number;
 	m3uState: M3uState;
+	avcState: AvcState;
 }): Promise<SeekResolution> => {
 	const mediaSections = mediaSectionState.getMediaSections();
 
@@ -119,6 +122,7 @@ const turnSeekIntoByte = async ({
 		structure: structureState,
 		riffState,
 		m3uState,
+		avcState,
 	});
 
 	return seekingByte;
@@ -151,6 +155,7 @@ export type WorkOnSeekRequestOptions = {
 	aacState: AacState;
 	m3uState: M3uState;
 	prefetchCache: PrefetchCache;
+	avcState: AvcState;
 };
 
 export const getWorkOnSeekRequestOptions = (
@@ -183,6 +188,7 @@ export const getWorkOnSeekRequestOptions = (
 		aacState: state.aac,
 		m3uState: state.m3u,
 		prefetchCache: state.prefetchCache,
+		avcState: state.avc,
 	};
 };
 
@@ -214,6 +220,7 @@ export const workOnSeekRequest = async (options: WorkOnSeekRequestOptions) => {
 		aacState,
 		prefetchCache,
 		m3uState,
+		avcState,
 	} = options;
 	const seek = controller._internals.seekSignal.getSeek();
 	if (seek === null) {
@@ -240,6 +247,7 @@ export const workOnSeekRequest = async (options: WorkOnSeekRequestOptions) => {
 		contentLength,
 		aacState,
 		m3uState,
+		avcState,
 	});
 	Log.trace(logLevel, `Seek action: ${JSON.stringify(resolution)}`);
 


### PR DESCRIPTION
`@remotion/media-parser`: Fix the timestamps of ouf-of-order AVC samples