### PR TITLE
`remotion`: Prevent props being passed to Remotion DOM node

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -12,8 +12,8 @@ import {continueRender, delayRender} from './delay-render.js';
 import {usePreload} from './prefetch.js';
 import {useBufferState} from './use-buffer-state.js';
 
-import {getCrossOriginValue} from './get-cross-origin-value.js';
 import type {IsExact} from './audio/props.js';
+import {getCrossOriginValue} from './get-cross-origin-value.js';
 
 function exponentialBackoff(errorCount: number): number {
 	return 1000 * 2 ** (errorCount - 1);

--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -12,17 +12,22 @@ import {continueRender, delayRender} from './delay-render.js';
 import {usePreload} from './prefetch.js';
 import {useBufferState} from './use-buffer-state.js';
 
+import {getCrossOriginValue} from './get-cross-origin-value.js';
+import type {IsExact} from './audio/props.js';
+
 function exponentialBackoff(errorCount: number): number {
 	return 1000 * 2 ** (errorCount - 1);
 }
 
-export type ImgProps = Omit<
+type NativeImgProps = Omit<
 	React.DetailedHTMLProps<
 		React.ImgHTMLAttributes<HTMLImageElement>,
 		HTMLImageElement
 	>,
 	'src'
-> & {
+>;
+
+export type ImgProps = NativeImgProps & {
 	readonly maxRetries?: number;
 	readonly pauseWhenLoading?: boolean;
 	readonly delayRenderRetries?: number;
@@ -30,6 +35,8 @@ export type ImgProps = Omit<
 	readonly onImageFrame?: (imgelement: HTMLImageElement) => void;
 	readonly src: string;
 };
+
+type Expected = Omit<NativeImgProps, 'onError' | 'src' | 'crossOrigin'>;
 
 const ImgRefForwarding: React.ForwardRefRenderFunction<
 	HTMLImageElement,
@@ -43,6 +50,7 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
 		onImageFrame,
+		crossOrigin,
 		...props
 	},
 	ref,
@@ -54,6 +62,12 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 
 	if (!src) {
 		throw new Error('No "src" prop was passed to <Img>.');
+	}
+
+	const _propsValid: IsExact<typeof props, Expected> = true;
+
+	if (!_propsValid) {
+		throw new Error('typecheck error');
 	}
 
 	useImperativeHandle(ref, () => {
@@ -222,7 +236,17 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 	}
 
 	// src gets set once we've loaded and decoded the image.
-	return <img {...props} ref={imageRef} onError={didGetError} />;
+	return (
+		<img
+			{...props}
+			ref={imageRef}
+			crossOrigin={getCrossOriginValue({
+				crossOrigin,
+				requestsVideoFrame: false,
+			})}
+			onError={didGetError}
+		/>
+	);
 };
 
 /*

--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -21,7 +21,7 @@ import {
 	useMediaVolumeState,
 } from '../volume-position-state.js';
 import {evaluateVolume} from '../volume-prop.js';
-import type {RemotionAudioProps} from './props.js';
+import type {IsExact, NativeAudioProps, RemotionAudioProps} from './props.js';
 import {SharedAudioContext, useSharedAudio} from './shared-audio-tags.js';
 import {useFrameForVolumeProp} from './use-audio-frame.js';
 
@@ -68,8 +68,21 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		loopVolumeCurveBehavior,
 		stack,
 		crossOrigin,
+		delayRenderRetries,
+		delayRenderTimeoutInMilliseconds,
+		toneFrequency,
 		...nativeProps
 	} = props;
+
+	// Typecheck that we are not accidentially passing unrecognized props
+	// to the DOM
+	const _propsValid: IsExact<
+		typeof nativeProps,
+		Omit<NativeAudioProps, 'crossOrigin' | 'src' | 'name' | 'muted'>
+	> = true;
+	if (!_propsValid) {
+		throw new Error('typecheck error');
+	}
 
 	const [mediaVolume] = useMediaVolumeState();
 	const [mediaMuted] = useMediaMutedState();

--- a/packages/core/src/audio/props.ts
+++ b/packages/core/src/audio/props.ts
@@ -6,13 +6,15 @@ export type RemotionMainAudioProps = {
 	endAt?: number;
 };
 
-export type RemotionAudioProps = Omit<
+export type NativeAudioProps = Omit<
 	React.DetailedHTMLProps<
 		React.AudioHTMLAttributes<HTMLAudioElement>,
 		HTMLAudioElement
 	>,
 	'autoPlay' | 'controls' | 'onEnded' | 'nonce' | 'onResize' | 'onResizeCapture'
-> & {
+>;
+
+export type RemotionAudioProps = NativeAudioProps & {
 	name?: string;
 	volume?: VolumeProp;
 	playbackRate?: number;
@@ -30,3 +32,14 @@ export type RemotionAudioProps = Omit<
 	delayRenderRetries?: number;
 	loopVolumeCurveBehavior?: LoopVolumeCurveBehavior;
 };
+
+type IsNever<T> = [T] extends [never] ? true : false;
+
+export type IsExact<T, U> =
+	(<G>() => G extends T ? 1 : 2) extends <G>() => G extends U ? 1 : 2
+		? IsNever<Exclude<keyof T, keyof U>> extends true
+			? IsNever<Exclude<keyof U, keyof T>> extends true
+				? true
+				: false
+			: false
+		: false;

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -27,8 +27,9 @@ import {
 } from '../volume-position-state.js';
 import {evaluateVolume} from '../volume-prop.js';
 import {useEmitVideoFrame} from './emit-video-frame.js';
-import type {OnVideoFrame, RemotionVideoProps} from './props';
+import type {NativeVideoProps, OnVideoFrame, RemotionVideoProps} from './props';
 import {isIosSafari, useAppendVideoFragment} from './video-fragment.js';
+import type {IsExact} from '../audio/props.js';
 
 type VideoForPreviewProps = RemotionVideoProps & {
 	readonly onlyWarnForMediaSeekingError: boolean;
@@ -40,6 +41,11 @@ type VideoForPreviewProps = RemotionVideoProps & {
 	readonly onVideoFrame: null | OnVideoFrame;
 	readonly crossOrigin?: '' | 'anonymous' | 'use-credentials';
 };
+
+type Expected = Omit<
+	NativeVideoProps,
+	'crossOrigin' | 'src' | 'name' | 'muted' | 'style'
+>;
 
 const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 	HTMLVideoElement,
@@ -84,8 +90,17 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		onAutoPlayError,
 		onVideoFrame,
 		crossOrigin,
+		delayRenderRetries,
+		delayRenderTimeoutInMilliseconds,
+		allowAmplificationDuringRender,
 		...nativeProps
 	} = props;
+
+	const _propsValid: IsExact<typeof nativeProps, Expected> = true;
+
+	if (!_propsValid) {
+		throw new Error('typecheck error');
+	}
 
 	const volumePropFrame = useFrameForVolumeProp(
 		loopVolumeCurveBehavior ?? 'repeat',

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import {SequenceContext} from '../SequenceContext.js';
 import {SequenceVisibilityToggleContext} from '../SequenceManager.js';
+import type {IsExact} from '../audio/props.js';
 import {SharedAudioContext} from '../audio/shared-audio-tags.js';
 import {makeSharedElementSourceNode} from '../audio/shared-element-source-node.js';
 import {useFrameForVolumeProp} from '../audio/use-audio-frame.js';
@@ -29,7 +30,6 @@ import {evaluateVolume} from '../volume-prop.js';
 import {useEmitVideoFrame} from './emit-video-frame.js';
 import type {NativeVideoProps, OnVideoFrame, RemotionVideoProps} from './props';
 import {isIosSafari, useAppendVideoFragment} from './video-fragment.js';
-import type {IsExact} from '../audio/props.js';
 
 type VideoForPreviewProps = RemotionVideoProps & {
 	readonly onlyWarnForMediaSeekingError: boolean;

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -11,7 +11,7 @@ export type RemotionMainVideoProps = {
 	_remotionInternalNativeLoopPassed?: boolean;
 };
 
-export type RemotionVideoProps = Omit<
+export type NativeVideoProps = Omit<
 	React.DetailedHTMLProps<
 		React.VideoHTMLAttributes<HTMLVideoElement>,
 		HTMLVideoElement
@@ -22,7 +22,9 @@ export type RemotionVideoProps = Omit<
 	| 'nonce'
 	| 'onError'
 	| 'disableRemotePlayback'
-> & {
+>;
+
+export type RemotionVideoProps = NativeVideoProps & {
 	name?: string;
 	volume?: VolumeProp;
 	playbackRate?: number;


### PR DESCRIPTION
`remotion`: Prevent props being passed to Remotion DOM node