### PR TITLE
Update AudioForPreview.tsx so that crossOrigin is sent to useSharedAudio

### DIFF
--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -111,12 +111,18 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		mediaVolume,
 	});
 
+	const crossOriginValue = getCrossOriginValue({
+		crossOrigin,
+		requestsVideoFrame: false,
+	});
+
 	const propsToPass = useMemo((): RemotionAudioProps => {
 		return {
 			muted:
 				muted || mediaMuted || isSequenceHidden || userPreferredVolume <= 0,
 			src: preloadedSrc,
 			loop: _remotionInternalNativeLoopPassed,
+			crossOrigin: crossOriginValue,
 			...nativeProps,
 		};
 	}, [
@@ -127,6 +133,7 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		nativeProps,
 		preloadedSrc,
 		userPreferredVolume,
+		crossOriginValue,
 	]);
 	// Generate a string that's as unique as possible for this asset
 	// but at the same time deterministic. We use it to combat strict mode issues.
@@ -226,11 +233,6 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 	if (initialShouldPreMountAudioElements) {
 		return null;
 	}
-
-	const crossOriginValue = getCrossOriginValue({
-		crossOrigin,
-		requestsVideoFrame: false,
-	});
 
 	return (
 		<audio


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
https://github.com/remotion-dev/remotion/issues/5307

because we destructure props and crossOrigin is not part of nativeProps, it does not get passed to the audio tag generated in useSharedAudio https://github.com/remotion-dev/remotion/blob/main/packages/core/src/audio/AudioForPreview.tsx#L70