### PR TITLE
`remotion`: Disable use of Web Audio API by default again - reverting change of v4.0.302

### DIFF
--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -71,6 +71,7 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
 		toneFrequency,
+		useWebAudioApi,
 		...nativeProps
 	} = props;
 
@@ -199,6 +200,7 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		mediaRef: audioRef,
 		source: mediaElementSourceNode,
 		volume: userPreferredVolume,
+		shouldUseWebAudioApi: useWebAudioApi ?? false,
 	});
 
 	useImperativeHandle(ref, () => {

--- a/packages/core/src/audio/props.ts
+++ b/packages/core/src/audio/props.ts
@@ -26,6 +26,7 @@ export type RemotionAudioProps = NativeAudioProps & {
 	_remotionInternalNeedsDurationCalculation?: boolean;
 	_remotionInternalNativeLoopPassed?: boolean;
 	toneFrequency?: number;
+	useWebAudioApi?: boolean;
 	pauseWhenBuffering?: boolean;
 	showInTimeline?: boolean;
 	delayRenderTimeoutInMilliseconds?: number;

--- a/packages/core/src/get-cross-origin-value.ts
+++ b/packages/core/src/get-cross-origin-value.ts
@@ -1,5 +1,3 @@
-import {getRemotionEnvironment} from './get-remotion-environment';
-
 export const getCrossOriginValue = ({
 	crossOrigin,
 	requestsVideoFrame,
@@ -18,16 +16,15 @@ export const getCrossOriginValue = ({
 		return 'anonymous';
 	}
 
-	// If we are in preview mode, we need to set anonymous
-	// because we use Web Audio API and otherwise it would
-	// zero out
-	// See issue: https://github.com/remotion-dev/remotion/issues/5274
-	// Second reason: In Studio, window.crossOriginIsolated is set,
-	// and you cannot play media from CORS at all.
+	// If we are in preview mode, we could set
+	// "anonymous" to prevent Web Audio API from
+	// zeroing out the volume.
+	// But this requires CORS, so we cannot default to that.
 
-	if (!getRemotionEnvironment().isRendering) {
-		return 'anonymous';
-	}
+	// DONT DO THIS:
+	// if (!getRemotionEnvironment().isRendering) {
+	// 	return 'anonymous';
+	// }
 
 	// During rendering, we opt out of the crossOrigin value
 	// because it may lead to flickering

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -93,6 +93,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
 		allowAmplificationDuringRender,
+		useWebAudioApi,
 		...nativeProps
 	} = props;
 
@@ -164,6 +165,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		mediaRef: videoRef,
 		volume: userPreferredVolume,
 		source: sharedSource,
+		shouldUseWebAudioApi: useWebAudioApi ?? false,
 	});
 
 	const actualFrom = parentSequence ? parentSequence.relativeFrom : 0;

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -30,6 +30,7 @@ export type RemotionVideoProps = NativeVideoProps & {
 	playbackRate?: number;
 	acceptableTimeShiftInSeconds?: number;
 	allowAmplificationDuringRender?: boolean;
+	useWebAudioApi?: boolean;
 	toneFrequency?: number;
 	pauseWhenBuffering?: boolean;
 	showInTimeline?: boolean;
@@ -66,6 +67,7 @@ export type RemotionOffthreadVideoProps = {
 	loopVolumeCurveBehavior?: LoopVolumeCurveBehavior;
 	delayRenderTimeoutInMilliseconds?: number;
 	delayRenderRetries?: number;
+	useWebAudioApi?: boolean;
 	/**
 	 * @deprecated For internal use only
 	 */

--- a/packages/docs/docs/audio.mdx
+++ b/packages/docs/docs/audio.mdx
@@ -25,7 +25,7 @@ export const MyVideo = () => {
 };
 ```
 
-### `volume`
+### `volume?`
 
 The component also accepts a `volume` props which allows you to control the volume of the audio in it's entirety or frame by frame. Read the page on [using audio](/docs/using-audio) to learn more.
 
@@ -53,27 +53,16 @@ export const MyVideo = () => {
 };
 ```
 
-:::note
-Since v4.0.302, it is now possible to:
+By default, volumes between 0 and 1 are supported, where in iOS Safari, the volume is always 1.  
+See [Volume Limitations](/docs/audio/volume#limitations) for more information.
 
-- Set the volume to a value higher than 1
-- In iOS Safari, set the volume to a value lower than 1
-
-Now arbitrary volumes are supported on all platforms, but there is 1 caveat on Safari:
-`volume` and `playbackRate` cannot be set at the same time, and if both are set,
-
-- on Desktop Safari, the volume will only be applied if it is 1 or lower
-- on iOS Safari, the volume will be ignored and set to 1
-
-:::
-
-### `loopVolumeCurveBehavior`<AvailableFrom v="4.0.142" />
+### `loopVolumeCurveBehavior?`<AvailableFrom v="4.0.142" />
 
 Controls the `frame` which is returned when using the [`volume`](#volume) callback function and adding the [`loop`](#loop) attribute.
 
 Can be either `"repeat"` (default, start from 0 on each iteration) or `"extend"` (keep increasing frames).
 
-### `startFrom` / `endAt`
+### `startFrom?` / `endAt?`
 
 `<Audio>` has two more helper props you can use:
 
@@ -99,7 +88,7 @@ export const MyVideo = () => {
 };
 ```
 
-### `playbackRate`<AvailableFrom v="2.2.0"/>
+### `playbackRate?`<AvailableFrom v="2.2.0"/>
 
 You can use the `playbackRate` prop to control the speed of the audio. `1` is the default and means regular speed, `0.5` slows down the audio so it's twice as long and `2` speeds up the audio so it's twice as fast.
 
@@ -117,7 +106,7 @@ export const MyVideo = () => {
 };
 ```
 
-### `muted`<AvailableFrom v="2.0.0"/>
+### `muted?`<AvailableFrom v="2.0.0"/>
 
 The `muted` prop will be respected. It will lead to no audio being played while still keeping the audio tag mounted. It's value may change over time, for example to only mute a certain section of the audio.
 
@@ -134,13 +123,13 @@ export const MyVideo = () => {
 };
 ```
 
-### `name`<AvailableFrom v="4.0.71"/>
+### `name?`<AvailableFrom v="4.0.71"/>
 
 _optional_
 
 A name and that will be shown as the label of the sequence in the timeline of the Remotion Studio. This property is purely for helping you keep track of items in the timeline.
 
-### `loop`<AvailableFrom v="3.2.29"/>
+### `loop?`<AvailableFrom v="3.2.29"/>
 
 You can use the `loop` prop to loop audio.
 
@@ -157,7 +146,7 @@ export const MyVideo = () => {
 };
 ```
 
-### `toneFrequency`<AvailableFrom v="4.0.47"/>
+### `toneFrequency?`<AvailableFrom v="4.0.47"/>
 
 Adjust the pitch of the audio - will only be applied during rendering.
 
@@ -165,25 +154,29 @@ Accepts a number between `0.01` and `2`, where `1` represents the original pitch
 
 A `toneFrequency` of 0.5 would lower the pitch by half, and a `toneFrequency` of `1.5` would increase the pitch by 50%.
 
-### `acceptableTimeShiftInSeconds`<AvailableFrom v="3.2.42"/>
+### `acceptableTimeShiftInSeconds?`<AvailableFrom v="3.2.42"/>
 
 In the [Remotion Studio](/docs/terminology/studio) or in the [Remotion Player](/docs/player), Remotion will seek the audio if it gets too much out of sync with Remotion's internal time - be it due to the audio loading or the page being too slow to keep up in real-time. By default, a seek is triggered if `0.45` seconds of time shift is encountered. Using this prop, you can customize the threshold.
 
-### `pauseWhenBuffering`<AvailableFrom v="4.0.111"/>
+### `pauseWhenBuffering?`<AvailableFrom v="4.0.111"/>
 
 If set to `true` and the audio is buffering, the Player will enter into the [native buffering state](/docs/player/buffer-state). The default is `false`, but will become `true` in Remotion 5.0.
 
-### `showInTimeline`<AvailableFrom v="4.0.122"/>
+### `showInTimeline?`<AvailableFrom v="4.0.122"/>
 
 If set to `false`, no layer will be shown in the timeline of the Remotion Studio. The default is `true`.
 
-### `delayRenderTimeoutInMilliseconds`<AvailableFrom v="4.0.140" />
+### `delayRenderTimeoutInMilliseconds?`<AvailableFrom v="4.0.140" />
 
 Customize the [timeout](/docs/delay-render#modifying-the-timeout) of the [`delayRender()`](/docs/delay-render) call that this component makes.
 
-### `delayRenderRetries`<AvailableFrom v="4.0.140" />
+### `delayRenderRetries?`<AvailableFrom v="4.0.140" />
 
 Customize the [number of retries](/docs/delay-render#retrying) of the [`delayRender()`](/docs/delay-render) call that this component makes.
+
+### `useWebAudioApi?`<AvailableFrom v="4.0.306" />
+
+Enable the [Web Audio API](/docs/volume#limitations) for the audio tag.
 
 ### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
 

--- a/packages/docs/docs/audio.mdx
+++ b/packages/docs/docs/audio.mdx
@@ -176,7 +176,7 @@ Customize the [number of retries](/docs/delay-render#retrying) of the [`delayRen
 
 ### `useWebAudioApi?`<AvailableFrom v="4.0.306" />
 
-Enable the [Web Audio API](/docs/volume#limitations) for the audio tag.
+Enable the [Web Audio API](/docs/audio/volume#limitations) for the audio tag.
 
 ### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
 

--- a/packages/docs/docs/audio/volume.mdx
+++ b/packages/docs/docs/audio/volume.mdx
@@ -53,14 +53,26 @@ It is not the same as the value of [`useCurrentFrame()`](/docs/use-current-frame
 
 Prefer using a callback function if the volume is changing. This will enable Remotion to draw a volume curve in the [Studio](/docs/studio) and is more performant.
 
-## Volume on iOS Safari
+## Limitations<AvailableFrom v="4.0.306" />
 
-Note that Mobile Safari [does not support the `volume` property](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html#//apple_ref/doc/uid/TP40009523-CH5-SW11). Currently, the volume will always be 1. We plan on in the future support to provide a workaround using the Web Audio API (see below).
+By default, you'll face 2 limitations by default regarding volume:
 
-## Increasing the volume to above 1<AvailableFrom v="4.0.279" />
+<div>
+<div><Step>1</Step> It is not possible to set the volume to a value higher than 1.</div>
+<div><Step>2</Step> On iOS Safari, the volume will be set to 1.</div>
+</div><br/>
+You can work around these limitations by enabling the Web Audio API for your [`<Audio>`](/docs/audio#usewebaudioapi), [`<Video>`](/docs/video#usewebaudioapi) and [`<OffthreadVideo>`](/docs/offthreadvideo#usewebaudioapi) tags.
 
-It is possible to set volumes above 1, but some things need your attention.
+```tsx twoslash
+import {Audio, staticFile, AbsoluteFill} from 'remotion';
+// ---cut---
 
-Remotion will use the Web Audio API to amplify the audio.
+<Audio src="https://parser.media/audio.wav" volume={2} useWebAudioApi crossOrigin="anonymous" />;
+```
 
-For remote audio that does not support [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS-enabled), you need to also add `crossOrigin="anonymous"` to your media tags, otherwise the audio will be fully muted.
+However, this comes with two caveats:
+
+<div>
+<div><Step error>1</Step> You must set the `crossOrigin` prop to `anonymous` and the audio must support CORS.</div>
+<div><Step error>2</Step> On Safari, you cannot combine it with [`playbackRate`](/docs/audio#playbackrate). If you do, the volume will be ignored.</div>
+</div><br/>

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -247,7 +247,7 @@ Default: `"anonymous"` if `onVideoFrame` is specified, `undefined`, otherwise.
 
 ### `useWebAudioApi?`<AvailableFrom v="4.0.306" />
 
-Enable the [Web Audio API](/docs/volume#limitations) for the video tag.
+Enable the [Web Audio API](/docs/audio/volume#limitations) for the video tag.
 
 ### ~~`imageFormat` <AvailableFrom v="3.0.22" />~~
 

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -111,19 +111,8 @@ export const MyComposition = () => {
 };
 ```
 
-:::note
-Since v4.0.302, it is now possible to:
-
-- Set the volume to a value higher than 1
-- In iOS Safari, set the volume to a value lower than 1
-
-Now arbitrary volumes are supported on all platforms, but there is 1 caveat on Safari:
-`volume` and `playbackRate` cannot be set at the same time, and if both are set,
-
-- on Desktop Safari, the volume will only be applied if it is 1 or lower
-- on iOS Safari, the volume will be ignored and set to 1
-
-:::
+By default, volumes between 0 and 1 are supported, where in iOS Safari, the volume is always 1.  
+See [Volume Limitations](/docs/audio/volume#limitations) for more information.
 
 ### `loopVolumeCurveBehavior?`<AvailableFrom v="4.0.142" />
 
@@ -255,6 +244,10 @@ During preview, this is a `HTMLVideoElement` object, during rendering, it is an 
 Corresponds to the [`crossOrigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-crossorigin) attribute of the `<video>` element.  
 One of `"anonymous"`, `"use-credentials"` or `undefined`.  
 Default: `"anonymous"` if `onVideoFrame` is specified, `undefined`, otherwise.
+
+### `useWebAudioApi?`<AvailableFrom v="4.0.306" />
+
+Enable the [Web Audio API](/docs/volume#limitations) for the video tag.
 
 ### ~~`imageFormat` <AvailableFrom v="3.0.22" />~~
 

--- a/packages/docs/docs/video.mdx
+++ b/packages/docs/docs/video.mdx
@@ -239,7 +239,7 @@ Default: `"anonymous"` if `onVideoFrame` is specified, `undefined`, otherwise.
 
 ### `useWebAudioApi?`<AvailableFrom v="4.0.306" />
 
-Enable the [Web Audio API](/docs/volume#limitations) for the video tag.
+Enable the [Web Audio API](/docs/audio/volume#limitations) for the video tag.
 
 ### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
 

--- a/packages/docs/docs/video.mdx
+++ b/packages/docs/docs/video.mdx
@@ -126,19 +126,8 @@ export const MyComposition = () => {
 };
 ```
 
-:::note
-Since v4.0.302, it is now possible to:
-
-- Set the volume to a value higher than 1
-- In iOS Safari, set the volume to a value lower than 1
-
-Now arbitrary volumes are supported on all platforms, but there is 1 caveat on Safari:
-`volume` and `playbackRate` cannot be set at the same time, and if both are set,
-
-- on Desktop Safari, the volume will only be applied if it is 1 or lower
-- on iOS Safari, the volume will be ignored and set to 1
-
-:::
+By default, volumes between 0 and 1 are supported, where in iOS Safari, the volume is always 1.  
+See [Volume Limitations](/docs/audio/volume#limitations) for more information.
 
 ### `loopVolumeCurveBehavior?`<AvailableFrom v="4.0.142" />
 
@@ -247,6 +236,10 @@ Read more here about [autoplay restrictions](/docs/player/autoplay).
 Corresponds to the [`crossOrigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-crossorigin) attribute of the `<video>` element.  
 One of `"anonymous"`, `"use-credentials"` or `undefined`.  
 Default: `"anonymous"` if `onVideoFrame` is specified, `undefined`, otherwise.
+
+### `useWebAudioApi?`<AvailableFrom v="4.0.306" />
+
+Enable the [Web Audio API](/docs/volume#limitations) for the video tag.
 
 ### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
 


### PR DESCRIPTION
This led to some breakage, so we are making it opt-in instead. New prop `useWebAudioApi` for `Audio`, `Video` and `OffthreadVideo`