### PR TITLE
Docs: Use AWS keys for s3OutputProvider instead of DIGITAL_OCEAN

### DIFF
--- a/packages/docs/docs/lambda/custom-destination.mdx
+++ b/packages/docs/docs/lambda/custom-destination.mdx
@@ -124,8 +124,8 @@ If you plan on saving to another bucket on AWS S3 and would like to use differen
 {
   "s3OutputProvider": {
     "endpoint": "https://s3.us-west-1.amazonaws.com",
-    "accessKeyId": "<DIGITAL_OCEAN_ACCESS_KEY_ID>",
-    "secretAccessKey": "<DIGITAL_OCEAN_SECRET_ACCESS_KEY>",
+    "accessKeyId": "<AWS_ACCESS_KEY_ID>",
+    "secretAccessKey": "<AWS_SECRET_ACCESS_KEY>",
     "region": "us-west-1"
   }
 }


### PR DESCRIPTION
In the example configuration to `Saving to another AWS region`, Use of `DIGITAL_OCEAN_ACCESS_KEY_ID` was suggested instead of `AWS_ACCESS_KEY_ID`.

Original change was added in #3476 

This PR aims to correct the related docs to suggest using `AWS Keys`.