### PR TITLE
remotion: Fix shell command built from environment values `open-in-editor`

### DIFF
--- a/packages/studio-server/src/helpers/open-in-editor.ts
+++ b/packages/studio-server/src/helpers/open-in-editor.ts
@@ -582,7 +582,7 @@ export async function launchEditor({
 			return;
 		}
 
-		child_process.exec(`${where} "${editor.command}"`, (err) => {
+		child_process.execFile(where, [editor.command], (err) => {
 			if (err) {
 				resolve(editor.process);
 			} else {
@@ -597,12 +597,13 @@ export async function launchEditor({
 			// launch .exe files.
 			_childProcess = child_process.spawn(
 				'cmd.exe',
-				['/C', binaryToUse].concat(args),
+				['/C', binaryToUse, ...args],
 				{stdio: 'inherit', detached: true},
 			);
 		} else {
 			_childProcess = child_process.spawn(binaryToUse, args, {
 				stdio: 'inherit',
+				shell: false, // Disable shell interpretation
 			});
 		}
 


### PR DESCRIPTION
https://github.com/remotion-dev/remotion/blob/5fbbbb026f7e2d1cbbc30dcd4b3bf645713fffe1/packages/studio-server/src/helpers/open-in-editor.ts#L585-L600

https://github.com/remotion-dev/remotion/blob/5fbbbb026f7e2d1cbbc30dcd4b3bf645713fffe1/packages/studio-server/src/helpers/open-in-editor.ts#L598-L602


Fix the issue will replace the use of `child_process.exec` and `child_process.spawn` with safer alternatives. Specifically:
1. Use `child_process.spawn` with separate arguments instead of dynamically constructing the command string.
2. Ensure that all inputs (e.g., `binaryToUse`, `args`, and `fileName`) are properly sanitized or validated before being passed to the `spawn` function.
3. Replace the `child_process.exec` call used to resolve `binaryToUse` with `child_process.execFile`, which avoids shell interpretation of the command and its arguments.

These changes will ensure that special characters in environment values or user inputs do not alter the behavior of the shell command unexpectedly.

---


