### PR TITLE
Update jumpcuts.mdx

### DIFF
--- a/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
+++ b/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
@@ -60,7 +60,7 @@ export const JumpCuts: React.FC<Props> = ({sections}) => {
     let summedUpDurations = 0;
     for (const section of sections) {
       summedUpDurations += section.endAt - section.startFrom;
-      if (summedUpDurations > frame) {
+      if (summedUpDurations >= frame) {
         return section.endAt - summedUpDurations;
       }
     }


### PR DESCRIPTION
Without this, you can sometimes see a single-frame gap between jump cuts

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
