### PR TITLE
`@remotion/media-parser`: Use smaller buffer on Cloudflare Worker

### DIFF
--- a/packages/media-parser/src/iterator/buffer-iterator.ts
+++ b/packages/media-parser/src/iterator/buffer-iterator.ts
@@ -11,7 +11,7 @@ import {makeOffsetCounter} from './offset-counter';
 
 export const getArrayBufferIterator = (
 	initialData: Uint8Array,
-	maxBytes: number | null,
+	maxBytes: number,
 ) => {
 	const counter = makeOffsetCounter(0);
 	const {

--- a/packages/media-parser/src/test/mvhd.test.ts
+++ b/packages/media-parser/src/test/mvhd.test.ts
@@ -64,7 +64,7 @@ test('Should be able to parse a MVHD box correctly', () => {
 		0, 0, 0, 2,
 	]);
 
-	const iterator = getArrayBufferIterator(buffer, null);
+	const iterator = getArrayBufferIterator(buffer, buffer.length);
 	iterator.discard(8);
 
 	const mvhd = parseMvhd({

--- a/packages/media-parser/src/test/parse-esds.test.ts
+++ b/packages/media-parser/src/test/parse-esds.test.ts
@@ -11,7 +11,7 @@ test('Parse ESDS box', () => {
 		0, 0, 0, 4, 226, 0, 0, 4, 226, 0, 6, 128, 128, 128, 1, 2,
 	]);
 
-	const iter = getArrayBufferIterator(buf, null);
+	const iter = getArrayBufferIterator(buf, buf.length);
 	iter.counter.increment(8);
 
 	expect(
@@ -54,7 +54,7 @@ test('Parse two ESDS', () => {
 		226, 0, 5, 2, 17, 144, 6, 1, 2, 0, 0, 0, 24, 115, 116, 116, 115,
 	]);
 
-	const iter = getArrayBufferIterator(buf, null);
+	const iter = getArrayBufferIterator(buf, buf.length);
 	iter.counter.increment(8);
 
 	expect(

--- a/packages/media-parser/src/test/parse-stco.test.ts
+++ b/packages/media-parser/src/test/parse-stco.test.ts
@@ -12,7 +12,7 @@ test('Parse stco box', () => {
 		246,
 	]);
 
-	const iterator = getArrayBufferIterator(buf, null);
+	const iterator = getArrayBufferIterator(buf, buf.length);
 	iterator.counter.increment(8);
 	const result = parseStco({
 		iterator,
@@ -41,7 +41,7 @@ test('Parse stco box with empty chunk', () => {
 		172,
 	]);
 
-	const iterator = getArrayBufferIterator(buf, null);
+	const iterator = getArrayBufferIterator(buf, buf.length);
 	iterator.counter.increment(8);
 	const result = parseStco({
 		iterator,

--- a/packages/media-parser/src/test/parse-stsc.test.ts
+++ b/packages/media-parser/src/test/parse-stsc.test.ts
@@ -11,7 +11,7 @@ test('Parse stsc box', () => {
 		0, 0, 1, 0, 0, 0, 1,
 	]);
 
-	const iterator = getArrayBufferIterator(buffer, null);
+	const iterator = getArrayBufferIterator(buffer, buffer.length);
 	iterator.counter.increment(8);
 	const result = parseStsc({
 		iterator,
@@ -45,7 +45,7 @@ test('Parse stsc box 2', () => {
 		0, 0, 0, 1,
 	]);
 
-	const iterator = getArrayBufferIterator(buffer, null);
+	const iterator = getArrayBufferIterator(buffer, buffer.length);
 	iterator.counter.increment(8);
 	const result = parseStsc({
 		iterator,

--- a/packages/media-parser/src/test/parse-stsz.test.ts
+++ b/packages/media-parser/src/test/parse-stsz.test.ts
@@ -11,7 +11,7 @@ test('parse stsz box 1', () => {
 		186, 0, 0, 2, 83, 0, 0, 2, 36, 0, 0, 2, 99, 0, 0, 2, 189, 0, 0, 2, 23, 0, 0,
 		3, 8, 0, 0, 2, 74, 0, 0, 0, 52, 115, 116, 99, 111,
 	]);
-	const iterator = getArrayBufferIterator(buf, null);
+	const iterator = getArrayBufferIterator(buf, buf.length);
 	iterator.counter.increment(8);
 	const result = parseStsz({
 		iterator,
@@ -37,7 +37,7 @@ test('parse stsz box 2', () => {
 		// actual box
 		0, 0, 0, 0, 0, 0, 3, 192, 0, 0, 0, 15, 0, 0, 0, 52, 115, 116, 99, 111,
 	]);
-	const iterator = getArrayBufferIterator(buf, null);
+	const iterator = getArrayBufferIterator(buf, buf.length);
 	iterator.counter.increment(8);
 	const result = parseStsz({
 		iterator,

--- a/packages/media-parser/src/test/parse-stts.test.ts
+++ b/packages/media-parser/src/test/parse-stts.test.ts
@@ -11,7 +11,7 @@ const buffer = new Uint8Array([
 ]);
 
 test('Should parse stts box', () => {
-	const iterator = getArrayBufferIterator(buffer, null);
+	const iterator = getArrayBufferIterator(buffer, buffer.length);
 	iterator.counter.increment(8);
 	const result = parseStts({
 		data: iterator,

--- a/packages/webcodecs/src/test/create-ftyp.test.ts
+++ b/packages/webcodecs/src/test/create-ftyp.test.ts
@@ -20,7 +20,10 @@ const input = new Uint8Array([
 ]);
 
 test('Create ftyp box', () => {
-	const iterator = MediaParserInternals.getArrayBufferIterator(input, null);
+	const iterator = MediaParserInternals.getArrayBufferIterator(
+		input,
+		input.length,
+	);
 	const size = iterator.getFourByteNumber();
 	iterator.discard(4);
 

--- a/packages/webcodecs/src/test/create-mvhd.test.ts
+++ b/packages/webcodecs/src/test/create-mvhd.test.ts
@@ -65,7 +65,10 @@ const input = new Uint8Array([
 ]);
 
 test('Create mvhd box', () => {
-	const iterator = MediaParserInternals.getArrayBufferIterator(input, null);
+	const iterator = MediaParserInternals.getArrayBufferIterator(
+		input,
+		input.length,
+	);
 	const size = iterator.getFourByteNumber();
 	iterator.discard(4);
 

--- a/packages/webcodecs/src/test/tkhd.test.ts
+++ b/packages/webcodecs/src/test/tkhd.test.ts
@@ -62,7 +62,10 @@ const buffer = Uint8Array.from([
 ]);
 
 test('Should be able to parse a TKHD box', () => {
-	const iterator = MediaParserInternals.getArrayBufferIterator(buffer, null);
+	const iterator = MediaParserInternals.getArrayBufferIterator(
+		buffer,
+		buffer.length,
+	);
 	iterator.discard(8);
 	const mvhd = MediaParserInternals.parseTkhd({
 		iterator,
@@ -123,7 +126,10 @@ const buffer2 = new Uint8Array([
 ]);
 
 test('Should be able to parse a TKHD box 2', () => {
-	const iterator = MediaParserInternals.getArrayBufferIterator(buffer2, null);
+	const iterator = MediaParserInternals.getArrayBufferIterator(
+		buffer2,
+		buffer2.length,
+	);
 	iterator.discard(8);
 	const mvhd = MediaParserInternals.parseTkhd({
 		iterator,


### PR DESCRIPTION
On Cloudflare workers, you get the following error if you run new ArrayBuffer(0, {maxByteLength: 2 ** 27 + 1}):

RangeError: Invalid array buffer max length

Working around this