### PR TITLE
Update getAbsoluteSrc to check for absoluteness of the URL too

### DIFF
--- a/packages/core/src/absolute-src.ts
+++ b/packages/core/src/absolute-src.ts
@@ -3,5 +3,9 @@ export const getAbsoluteSrc = (relativeSrc: string) => {
 		return relativeSrc;
 	}
 
+	if (relativeSrc.startsWith('http://') || relativeSrc.startsWith('https://')) {
+		return relativeSrc;
+	}
+
 	return new URL(relativeSrc, window.origin).href;
 };

--- a/packages/core/src/absolute-src.ts
+++ b/packages/core/src/absolute-src.ts
@@ -3,7 +3,14 @@ export const getAbsoluteSrc = (relativeSrc: string) => {
 		return relativeSrc;
 	}
 
-	if (relativeSrc.startsWith('http://') || relativeSrc.startsWith('https://')) {
+	// https://github.com/remotion-dev/remotion/issues/5359
+	if (
+		relativeSrc.startsWith('http://') ||
+		relativeSrc.startsWith('https://') ||
+		relativeSrc.startsWith('file://') ||
+		relativeSrc.startsWith('blob:') ||
+		relativeSrc.startsWith('data:')
+	) {
 		return relativeSrc;
 	}
 

--- a/packages/core/src/test/absolute-src.test.ts
+++ b/packages/core/src/test/absolute-src.test.ts
@@ -4,7 +4,7 @@ import {getAbsoluteSrc} from '../absolute-src.js';
 describe('Absolute src should behave as expected', () => {
 	test('Get localhost:8080', () => {
 		expect(getAbsoluteSrc('http://localhost:8080')).toBe(
-			'http://localhost:8080/',
+			'http://localhost:8080',
 		);
 	});
 	test('Get localhost/hi', () => {
@@ -13,6 +13,11 @@ describe('Absolute src should behave as expected', () => {
 	test('Get data:base64', () => {
 		expect(getAbsoluteSrc('data:base64,image/png,abc')).toBe(
 			'data:base64,image/png,abc',
+		);
+	});
+	test('Get blob URL', () => {
+		expect(getAbsoluteSrc('blob:http://localhost:3000/abc123')).toBe(
+			'blob:http://localhost:3000/abc123',
 		);
 	});
 });


### PR DESCRIPTION
This PR fixes #5359 (getAbsoluteSrc is not respecting real absolute URLs).

Currently, getAbsoluteSrc is looking only at the `window` property to determine whether the given URL is absolute or not. This PR adds the check for the protocol too as described in the issue.