### PR TITLE
`@remotion/cli` + `@remotion/studio`: Use the correct term "encoding"

### DIFF
--- a/packages/cli/src/progress-bar.ts
+++ b/packages/cli/src/progress-bar.ts
@@ -351,7 +351,7 @@ const getGuiProgressSubtitle = (progress: AggregateRenderProgress): string => {
 		return `Rendered ${progress.rendering.frames}/${progress.rendering.totalFrames}${etaString}`;
 	}
 
-	return `Stitched ${progress.stitching.frames}/${progress.stitching.totalFrames}`;
+	return `Encoded ${progress.stitching.frames}/${progress.stitching.totalFrames}`;
 };
 
 export const printFact =

--- a/packages/docs/docs/lambda/getrenderprogress.mdx
+++ b/packages/docs/docs/lambda/getrenderprogress.mdx
@@ -83,7 +83,7 @@ How many chunks have been fully rendered so far.
 
 ### `encodingStatus`
 
-Either `null` if not all chunks have been rendered yet or an object with the signature `{framesEncoded: number}` that tells how many frames have been stitched together so far in the concatenation process.
+Either `null` if not all chunks have been rendered yet or an object with the signature `{framesEncoded: number}` that tells how many frames have been encoded so far in the encoding process.
 
 ### `renderId`
 

--- a/packages/studio/src/components/RenderModal/GuiRenderStatus.tsx
+++ b/packages/studio/src/components/RenderModal/GuiRenderStatus.tsx
@@ -86,8 +86,8 @@ const StitchingProgress: React.FC<{
 			<Spacing x={1} />
 			<div style={label}>
 				{progress.doneIn
-					? `Stitched ${progress.totalFrames} frames`
-					: `Stitching ${progress.frames} / ${progress.totalFrames} frames`}
+					? `Encoded ${progress.totalFrames} frames`
+					: `Encoding ${progress.frames} / ${progress.totalFrames} frames`}
 			</div>
 			{progress.doneIn ? <div style={right}>{progress.doneIn}ms</div> : null}
 		</div>


### PR DESCRIPTION
PR