### PR TITLE
Fix lambda-python type hints

### DIFF
--- a/packages/lambda-python/remotion_lambda/models.py
+++ b/packages/lambda-python/remotion_lambda/models.py
@@ -8,6 +8,7 @@ from .version import VERSION
 
 # pylint: disable=too-many-instance-attributes
 
+RenderType = Union[Literal["video-or-audio"], Literal["still"]]
 
 class ValidStillImageFormats(str, Enum):
     """
@@ -19,10 +20,10 @@ class ValidStillImageFormats(str, Enum):
         PDF: Represents the PDF format for images.
         WEBP: Represents the WEBP image format.
     """
-    PNG: str = 'png'
-    JPEG: str = 'jpeg'
-    PDF: str = 'pdf'
-    WEBP: str = 'webp'
+    PNG = 'png'
+    JPEG = 'jpeg'
+    PDF = 'pdf'
+    WEBP = 'webp'
 
 
 class Privacy(str, Enum):
@@ -33,9 +34,9 @@ class Privacy(str, Enum):
         PUBLIC: Indicates a public setting.
         PRIVATE: Indicates a private setting.
     """
-    PUBLIC: str = 'public'
-    PRIVATE: str = 'private'
-    NO_ACL: str = 'no-acl'
+    PUBLIC = 'public'
+    PRIVATE = 'private'
+    NO_ACL = 'no-acl'
 
 
 class LogLevel(str, Enum):
@@ -65,11 +66,11 @@ class OpenGlRenderer(str, Enum):
         SWIFTSHADER: Represents the SWIFTSHADER OpenGL renderer.
         VULKAN: Represents the VULKAN OpenGL renderer.
     """
-    SWANGLE: str = 'swangle'
-    ANGLE: str = 'angle'
-    EGL: str = 'egl'
-    SWIFTSHADER: str = 'swiftshader'
-    VULKAN: str = 'vulkan'
+    SWANGLE = 'swangle'
+    ANGLE = 'angle'
+    EGL = 'egl'
+    SWIFTSHADER = 'swiftshader'
+    VULKAN = 'vulkan'
 
 
 @dataclass
@@ -203,7 +204,7 @@ class RenderProgressParams:
         """
         Convert instance attributes to a dictionary for serialization.
         """
-        parameters = {
+        parameters: dict[str, Any] = {
             'renderId': self.render_id,
             'bucketName': self.bucket_name,
             'type': 'status',
@@ -301,7 +302,7 @@ class RenderMediaParams:
     number_of_gif_loops: Optional[int] = 0
     concurrency_per_lambda: Optional[int] = 1
     download_behavior: Optional[Union[PlayInBrowser, ShouldDownload]] = field(
-        default_factory=lambda: {'type': 'play-in-browser'})
+        default_factory=lambda: PlayInBrowser(type='play-in-browser'))
     muted: bool = False
     overwrite: bool = False
     force_path_style: Optional[bool] = None

--- a/packages/lambda-python/remotion_lambda/remotionclient.py
+++ b/packages/lambda-python/remotion_lambda/remotionclient.py
@@ -4,7 +4,7 @@ import json
 from math import ceil
 from typing import Optional, Union
 from enum import Enum
-import boto3  # type: ignore
+import boto3
 from .models import (CostsInfo, CustomCredentials, RenderMediaParams, RenderMediaProgress,
                      RenderMediaResponse, RenderProgressParams, RenderStillResponse,
                      RenderStillParams, RenderType)
@@ -192,7 +192,7 @@ class RemotionClient:
         )
         return json.dumps(progress_params.serialize_params())
 
-    def render_media_on_lambda(self, render_params: RenderMediaParams) -> RenderMediaResponse | None:
+    def render_media_on_lambda(self, render_params: RenderMediaParams) -> Optional[RenderMediaResponse]:
         """
         Render media using AWS Lambda.
 
@@ -211,7 +211,7 @@ class RemotionClient:
 
         return None
 
-    def render_still_on_lambda(self, render_params: RenderStillParams) -> RenderStillResponse | None:
+    def render_still_on_lambda(self, render_params: RenderStillParams) -> Optional[RenderStillResponse]:
         """
         Render still using AWS Lambda.
 
@@ -249,7 +249,7 @@ class RemotionClient:
                             bucket_name: str,
                             log_level="info",
                             s3_output_provider: Optional[CustomCredentials] = None
-                            ) -> RenderMediaProgress | None:
+                            ) -> Optional[RenderMediaProgress]:
         """
         Get the progress of a render.
 

--- a/packages/lambda-python/remotion_lambda/remotionclient.py
+++ b/packages/lambda-python/remotion_lambda/remotionclient.py
@@ -2,12 +2,12 @@
 from dataclasses import asdict
 import json
 from math import ceil
-from typing import Optional, Union, Literal
+from typing import Optional, Union
 from enum import Enum
-import boto3
+import boto3  # type: ignore
 from .models import (CostsInfo, CustomCredentials, RenderMediaParams, RenderMediaProgress,
                      RenderMediaResponse, RenderProgressParams, RenderStillResponse,
-                     RenderStillParams)
+                     RenderStillParams, RenderType)
 
 
 class RemotionClient:
@@ -143,8 +143,7 @@ class RemotionClient:
         return asdict(obj)
 
     def construct_render_request(self, render_params: Union[RenderMediaParams, RenderStillParams],
-                                 render_type:
-                                 Union[Literal["video-or-audio"], Literal["still"]]) -> str:
+                                 render_type: RenderType) -> str:
         """
         Construct a render request in JSON format.
 
@@ -155,14 +154,17 @@ class RemotionClient:
             str: JSON representation of the render request.
         """
         render_params.serve_url = self.serve_url
-        render_params.region = self.region
-        render_params.function_name = self.function_name
-        render_params.type = render_type
+
+        payload = render_params.serialize_params()
         render_params.private_serialized_input_props = self._serialize_input_props(
             input_props=render_params.input_props,
             render_type=render_type
         )
-        return json.dumps(render_params.serialize_params(), default=self._custom_serializer)
+
+        payload['type'] = render_type
+        payload['region'] = self.region
+
+        return json.dumps(payload, default=self._custom_serializer)
 
     def construct_render_progress_request(self,
                                           render_id: str,
@@ -190,7 +192,7 @@ class RemotionClient:
         )
         return json.dumps(progress_params.serialize_params())
 
-    def render_media_on_lambda(self, render_params: RenderMediaParams) -> RenderMediaResponse:
+    def render_media_on_lambda(self, render_params: RenderMediaParams) -> RenderMediaResponse | None:
         """
         Render media using AWS Lambda.
 
@@ -209,7 +211,7 @@ class RemotionClient:
 
         return None
 
-    def render_still_on_lambda(self, render_params: RenderStillParams) -> RenderStillResponse:
+    def render_still_on_lambda(self, render_params: RenderStillParams) -> RenderStillResponse | None:
         """
         Render still using AWS Lambda.
 
@@ -247,7 +249,7 @@ class RemotionClient:
                             bucket_name: str,
                             log_level="info",
                             s3_output_provider: Optional[CustomCredentials] = None
-                            ) -> RenderMediaProgress:
+                            ) -> RenderMediaProgress | None:
         """
         Get the progress of a render.
 

--- a/packages/lambda-python/remotion_lambda/remotionclient.py
+++ b/packages/lambda-python/remotion_lambda/remotionclient.py
@@ -155,15 +155,12 @@ class RemotionClient:
         """
         render_params.serve_url = self.serve_url
 
-        payload = render_params.serialize_params()
         render_params.private_serialized_input_props = self._serialize_input_props(
             input_props=render_params.input_props,
             render_type=render_type
         )
 
-        payload['type'] = render_type
-        payload['region'] = self.region
-
+        payload = render_params.serialize_params()
         return json.dumps(payload, default=self._custom_serializer)
 
     def construct_render_progress_request(self,
@@ -192,7 +189,9 @@ class RemotionClient:
         )
         return json.dumps(progress_params.serialize_params())
 
-    def render_media_on_lambda(self, render_params: RenderMediaParams) -> Optional[RenderMediaResponse]:
+    def render_media_on_lambda(
+        self, render_params: RenderMediaParams
+    ) -> Optional[RenderMediaResponse]:
         """
         Render media using AWS Lambda.
 
@@ -211,7 +210,9 @@ class RemotionClient:
 
         return None
 
-    def render_still_on_lambda(self, render_params: RenderStillParams) -> Optional[RenderStillResponse]:
+    def render_still_on_lambda(
+        self, render_params: RenderStillParams
+    ) -> Optional[RenderStillResponse]:
         """
         Render still using AWS Lambda.
 


### PR DESCRIPTION
## Overview
Fixed typing so **mypy** checks pass.

## Changes
- removed string enum redundant types
- replaced download_behavior field default_factory value with typed object instead of dict
- fixed payload object construction in construct_render_request 
- fixed function result hints that return optional objects
- removed redundant var assignments that didn't result in any output