### PR TITLE
`@remotion/player`: Prevent case where Player measurer returns NaN

### DIFF
--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -72,7 +72,9 @@ export const useElementSize = (
 			}
 
 			const probableCssParentScale =
-				contentRect.width === 0 ? 1 : newSize[0].width / contentRect.width;
+				contentRect.width === 0 || contentRect.width === 0
+					? 1
+					: newSize[0].width / contentRect.width;
 
 			const width = options.shouldApplyCssTransforms
 				? newSize[0].width


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
