### PR TITLE
`@remotion/renderer`: Support different chrome modes on linux-arm64, resort to headless shell

### DIFF
--- a/packages/cli/src/browser-download-bar.ts
+++ b/packages/cli/src/browser-download-bar.ts
@@ -1,4 +1,4 @@
-import type {LogLevel, OnBrowserDownload} from '@remotion/renderer';
+import type {ChromeMode, LogLevel, OnBrowserDownload} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import {chalk} from './chalk';
 import {Log} from './log';
@@ -11,15 +11,21 @@ const makeDownloadProgress = ({
 	bytesDownloaded,
 	totalBytes,
 	doneIn,
+	chromeMode,
 }: {
 	totalBytes: number;
 	bytesDownloaded: number;
 	doneIn: number | null;
+	chromeMode: ChromeMode;
 }) => {
 	const progress = bytesDownloaded / totalBytes;
 
 	return [
-		`${doneIn ? 'Got' : 'Getting'} Headless Shell`.padEnd(LABEL_WIDTH, ' '),
+		`${doneIn ? 'Got' : 'Getting'} ${
+			chromeMode === 'chrome-for-testing'
+				? 'Chrome for Testing'
+				: 'Headless Shell'
+		}`.padEnd(LABEL_WIDTH, ' '),
 		makeProgressBar(progress, false),
 		doneIn === null
 			? (progress * 100).toFixed(0) + '%'
@@ -107,6 +113,7 @@ export const defaultBrowserDownloadProgress = ({
 						doneIn,
 						bytesDownloaded: progress.downloadedBytes,
 						totalBytes: progress.totalSizeInBytes,
+						chromeMode,
 					}),
 					progress.percent === 1,
 				);

--- a/packages/renderer/src/browser/BrowserFetcher.ts
+++ b/packages/renderer/src/browser/BrowserFetcher.ts
@@ -46,6 +46,10 @@ function getChromeDownloadUrl({
 	chromeMode: ChromeMode;
 }): string {
 	if (platform === 'linux-arm64') {
+		if (chromeMode === 'chrome-for-testing') {
+			return `https://playwright.azureedge.net/builds/chromium/${version ?? PLAYWRIGHT_VERSION}/chromium-linux-arm64.zip`;
+		}
+
 		return `https://playwright.azureedge.net/builds/chromium/${version ?? PLAYWRIGHT_VERSION}/chromium-headless-shell-linux-arm64.zip`;
 	}
 


### PR DESCRIPTION
PR