### PR TITLE
`@remotion/media-parser`: Support track done callback also in workers

### DIFF
--- a/packages/media-parser/src/worker-server.ts
+++ b/packages/media-parser/src/worker-server.ts
@@ -401,11 +401,26 @@ const startParsing = async (
 						}
 
 						return async (sample) => {
-							await executeCallback({
+							const audioSampleRes = await executeCallback({
 								callbackType: 'on-audio-sample',
 								value: sample,
 								trackId: params.track.trackId,
 							});
+
+							if (audioSampleRes.payloadType !== 'on-sample-response') {
+								throw new Error('Invalid response from callback');
+							}
+
+							if (!audioSampleRes.registeredTrackDoneCallback) {
+								return;
+							}
+
+							return async () => {
+								await executeCallback({
+									callbackType: 'track-done',
+									trackId: params.track.trackId,
+								});
+							};
 						};
 					}
 				: null,
@@ -425,11 +440,26 @@ const startParsing = async (
 						}
 
 						return async (sample) => {
-							await executeCallback({
+							const videoSampleRes = await executeCallback({
 								callbackType: 'on-video-sample',
 								value: sample,
 								trackId: params.track.trackId,
 							});
+
+							if (videoSampleRes.payloadType !== 'on-sample-response') {
+								throw new Error('Invalid response from callback');
+							}
+
+							if (!videoSampleRes.registeredTrackDoneCallback) {
+								return;
+							}
+
+							return async () => {
+								await executeCallback({
+									callbackType: 'track-done',
+									trackId: params.track.trackId,
+								});
+							};
 						};
 					}
 				: null,

--- a/packages/media-parser/src/worker/worker-types.ts
+++ b/packages/media-parser/src/worker/worker-types.ts
@@ -333,6 +333,10 @@ export type ResponseCallbackPayload =
 			trackId: number;
 	  }
 	| {
+			callbackType: 'track-done';
+			trackId: number;
+	  }
+	| {
 			callbackType: 'm3u-associated-playlists-selection';
 			value: SelectM3uAssociatedPlaylistsFnOptions;
 	  };
@@ -362,6 +366,10 @@ export type AcknowledgePayload =
 	| {
 			payloadType: 'on-video-track-response';
 			registeredCallback: boolean;
+	  }
+	| {
+			payloadType: 'on-sample-response';
+			registeredTrackDoneCallback: boolean;
 	  };
 
 export type AcknowledgeCallback = {

--- a/packages/webcodecs/src/extract-frames.ts
+++ b/packages/webcodecs/src/extract-frames.ts
@@ -135,6 +135,10 @@ const internalExtractFrames = ({
 						controller.abort();
 					}
 				}
+
+				return async () => {
+					await decoder.flush();
+				};
 			};
 		},
 	})


### PR DESCRIPTION
In an oversight, this was not supported