### PR TITLE
@remotion/lambda: expose getLayers

### DIFF
--- a/packages/lambda/src/internals.ts
+++ b/packages/lambda/src/internals.ts
@@ -1,9 +1,11 @@
 import {internalDeploySite} from './api/deploy-site';
 import {executeCommand} from './cli/index';
+import {getLayers} from './shared/get-layers';
 
 export const LambdaInternals = {
 	executeCommand,
 	internalDeploySite,
+	getLayers,
 };
 
 export type {OverallRenderProgress as _InternalOverallRenderProgress} from '@remotion/serverless';


### PR DESCRIPTION
Externally exposes the `getLayers` under `LambdaInternals`.

This does not advertise it as a public API, but does allow for an escape hatch to build a lambda manually with CDK (something we have been doing for a while).

Currently we copy the list of layers, but would like to use `getLayers` as a source of truth
![image](https://github.com/user-attachments/assets/675ffa96-bece-4863-80a5-c0c6d936b6c5)