### PR TITLE
doc: Fix incorrect method name in documentation (setStudioPort → setRendererPort)

### DIFF
--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -70,7 +70,7 @@ Set the port to be used to host the Webpack bundle.
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 // ---cut---
-Config.setStudioPort(3004);
+Config.setRendererPort(3004);
 ```
 
 The [command line flag](/docs/cli/render#--port) `--port` will take precedence over this option.


### PR DESCRIPTION
This PR fixes a documentation error in the Remotion config example.

Changes:
- Updated the code snippet to use `setRendererPort` instead of `setStudioPort` under the [setRendererPort()](https://www.remotion.dev/docs/config#setrendererport) section.