### PR TITLE
`@remotion/webcodecs`: Flush before the next keyframe

### DIFF
--- a/packages/webcodecs/src/extract-frames.ts
+++ b/packages/webcodecs/src/extract-frames.ts
@@ -107,6 +107,7 @@ const internalExtractFrames = ({
 				const nextTimestampWeWant = timestampTargets[0];
 
 				if (sample.type === 'key') {
+					await decoder.flush();
 					queued.length = 0;
 				}
 


### PR DESCRIPTION
PR