### PR TITLE
`@remotion/cli`: Fix not autimatically selecting the first composition when rendering in CI

### DIFF
--- a/packages/cli/src/get-composition-id.ts
+++ b/packages/cli/src/get-composition-id.ts
@@ -144,30 +144,41 @@ export const getCompositionId = async ({
 		};
 	}
 
+	const comps = await RenderInternals.internalGetCompositions({
+		puppeteerInstance,
+		envVariables,
+		timeoutInMilliseconds,
+		chromiumOptions,
+		port,
+		browserExecutable,
+		logLevel,
+		indent,
+		server,
+		serveUrlOrWebpackUrl,
+		onBrowserLog: null,
+		serializedInputPropsWithCustomSchema,
+		offthreadVideoCacheSizeInBytes,
+		offthreadVideoThreads,
+		binariesDirectory,
+		onBrowserDownload,
+		chromeMode,
+	});
+
+	if (comps.length === 1) {
+		return {
+			compositionId: comps[0]!.id,
+			reason: 'Only composition',
+			config: comps[0]!,
+			argsAfterComposition: args,
+		};
+	}
+
 	if (!process.env.CI) {
-		const comps = await RenderInternals.internalGetCompositions({
-			puppeteerInstance,
-			envVariables,
-			timeoutInMilliseconds,
-			chromiumOptions,
-			port,
-			browserExecutable,
-			logLevel,
-			indent,
-			server,
-			serveUrlOrWebpackUrl,
-			onBrowserLog: null,
-			serializedInputPropsWithCustomSchema,
-			offthreadVideoCacheSizeInBytes,
-			offthreadVideoThreads,
-			binariesDirectory,
-			onBrowserDownload,
-			chromeMode,
-		});
 		const {compositionId, reason} = await showSingleCompositionsPicker(
 			comps,
 			logLevel,
 		);
+
 		if (compositionId && typeof compositionId === 'string') {
 			return {
 				compositionId,

--- a/packages/cli/src/show-compositions-picker.ts
+++ b/packages/cli/src/show-compositions-picker.ts
@@ -8,16 +8,6 @@ export const showSingleCompositionsPicker = async (
 	validCompositions: Await<ReturnType<typeof getCompositions>>,
 	logLevel: LogLevel,
 ): Promise<{compositionId: string; reason: string}> => {
-	if (validCompositions.length === 1) {
-		const onlyComposition = validCompositions[0];
-		if (onlyComposition) {
-			return {
-				compositionId: onlyComposition.id,
-				reason: 'Only composition',
-			};
-		}
-	}
-
 	const selectedComposition = (await selectAsync(
 		{
 			message: 'Select composition:',


### PR DESCRIPTION
PR