### PR TITLE
`@remotion/renderer`: Validate the `maxRate` early

### DIFF
--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -280,6 +280,8 @@ const internalRenderMediaRaw = ({
 	});
 	validateBitrate(audioBitrate, 'audioBitrate');
 	validateBitrate(videoBitrate, 'videoBitrate');
+	validateBitrate(encodingMaxRate, 'encodingMaxRate');
+	validateBitrate(encodingBufferSize, 'encodingBufferSize');
 
 	validateSelectedCodecAndProResCombination({
 		codec,


### PR DESCRIPTION
Fixes #5514