### PR TITLE
`@remotion/serverless`: Validate codec in serverless function

### DIFF
--- a/packages/core/src/no-react.ts
+++ b/packages/core/src/no-react.ts
@@ -28,6 +28,7 @@ import {colorNames, processColor} from './interpolate-colors';
 import {truthy} from './truthy';
 import {ENABLE_V5_BREAKING_CHANGES} from './v5-flag';
 import {validateFrame} from './validate-frame';
+import {validateCodec} from './validation/validate-default-codec';
 import {validateDefaultAndInputProps} from './validation/validate-default-props';
 import {validateDimension} from './validation/validate-dimensions';
 import {validateDurationInFrames} from './validation/validate-duration-in-frames';
@@ -59,4 +60,5 @@ export const NoReactInternals = {
 	colorNames,
 	DATE_TOKEN,
 	FILE_TOKEN,
+	validateCodec,
 };

--- a/packages/core/src/resolve-video-config.ts
+++ b/packages/core/src/resolve-video-config.ts
@@ -5,7 +5,7 @@ import type {
 } from './Composition.js';
 import {serializeThenDeserializeInStudio} from './input-props-serialization.js';
 import type {InferProps} from './props-if-has-props.js';
-import {validateDefaultCodec} from './validation/validate-default-codec.js';
+import {validateCodec} from './validation/validate-default-codec.js';
 import {validateDimension} from './validation/validate-dimensions.js';
 import {validateDurationInFrames} from './validation/validate-duration-in-frames.js';
 import {validateFps} from './validation/validate-fps.js';
@@ -62,7 +62,7 @@ const validateCalculated = ({
 	});
 
 	const defaultCodec = calculated?.defaultCodec;
-	validateDefaultCodec(defaultCodec, calculateMetadataErrorLocation);
+	validateCodec(defaultCodec, calculateMetadataErrorLocation, 'defaultCodec');
 
 	const defaultOutName = calculated?.defaultOutName;
 	const defaultVideoImageFormat = calculated?.defaultVideoImageFormat;

--- a/packages/core/src/validation/validate-default-codec.ts
+++ b/packages/core/src/validation/validate-default-codec.ts
@@ -1,9 +1,10 @@
 import type {Codec, CodecOrUndefined} from '../codec';
 import {validCodecs} from '../codec';
 
-export function validateDefaultCodec(
+export function validateCodec(
 	defaultCodec: unknown,
 	location: string,
+	name: string,
 ): asserts defaultCodec is CodecOrUndefined {
 	if (typeof defaultCodec === 'undefined') {
 		return;
@@ -11,13 +12,13 @@ export function validateDefaultCodec(
 
 	if (typeof defaultCodec !== 'string') {
 		throw new TypeError(
-			`The "defaultCodec" prop ${location} must be a string, but you passed a value of type ${typeof defaultCodec}.`,
+			`The "${name}" prop ${location} must be a string, but you passed a value of type ${typeof defaultCodec}.`,
 		);
 	}
 
 	if (!validCodecs.includes(defaultCodec as Codec)) {
 		throw new Error(
-			`The "defaultCodec" prop ${location} must be one of ${validCodecs.join(
+			`The "${name}" prop ${location} must be one of ${validCodecs.join(
 				', ',
 			)}, but you passed ${defaultCodec}.`,
 		);

--- a/packages/serverless-client/src/index.ts
+++ b/packages/serverless-client/src/index.ts
@@ -121,4 +121,5 @@ export const {
 	validateFps,
 	validateDimension,
 	validateDurationInFrames,
+	validateCodec,
 } = NoReactInternals;

--- a/packages/serverless/src/handlers/launch.ts
+++ b/packages/serverless/src/handlers/launch.ts
@@ -2,7 +2,7 @@
 import type {EmittedArtifact, LogOptions} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 
-import {VERSION} from '@remotion/serverless-client';
+import {validateCodec, VERSION} from '@remotion/serverless-client';
 import {existsSync, mkdirSync, rmSync} from 'fs';
 import {type EventEmitter} from 'node:events';
 import {join} from 'path';
@@ -174,6 +174,7 @@ const innerLaunchHandler = async <Provider extends CloudProvider>({
 		separateAudioTo: null,
 		bucketNamePrefix: providerSpecifics.getBucketPrefix(),
 	});
+	validateCodec(params.codec, 'renderMediaOnLambda', 'codec');
 	validatePrivacy(params.privacy, true);
 	RenderInternals.validatePuppeteerTimeout(params.timeoutInMilliseconds);
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
