### PR TITLE
Docs: Update all references of startFrom / endAt with `trimBefore` and `trimAfter`

### DIFF
--- a/packages/docs/components/AcceleratedVideoPlayerExample.tsx
+++ b/packages/docs/components/AcceleratedVideoPlayerExample.tsx
@@ -32,7 +32,7 @@ const AcceleratedVideo: React.FC = () => {
 	return (
 		<Sequence from={frame}>
 			<Video
-				startFrom={Math.round(remappedFrame)}
+				trimBefore={Math.round(remappedFrame)}
 				playbackRate={speedFunction(frame)}
 				src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4#disable"
 			/>

--- a/packages/docs/components/GreenscreenExamples/index.tsx
+++ b/packages/docs/components/GreenscreenExamples/index.tsx
@@ -82,7 +82,7 @@ export const VideoOnCanvas: React.FC = () => {
 				<OffthreadVideo
 					onVideoFrame={onVideoFrame}
 					style={{opacity: 0}}
-					startFrom={300}
+					trimBefore={300}
 					src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
 				/>
 			</AbsoluteFill>

--- a/packages/docs/docs/audio.mdx
+++ b/packages/docs/docs/audio.mdx
@@ -94,30 +94,6 @@ export const MyVideo = () => {
 These props have been renamed to [`trimBefore`](#trimbefore--trimafter) and [`trimAfter`](#trimbefore--trimafter) in 4.0.319. They will continue to work but you cannot use them together with the new props.
 :::
 
-`<Audio>` has two helper props you can use:
-
-- `startFrom` will remove a portion of the audio at the beginning
-- `endAt` will remove a portion of the audio at the end
-
-In the following example, we assume that the [`fps`](/docs/composition#fps) of the composition is `30`.
-
-By passing `startFrom={60}`, the playback starts immediately, but with the first 2 seconds of the audio trimmed away.  
-By passing `endAt={120}`, any audio after the 4 second mark in the file will be trimmed away.
-
-The audio will play the range from `00:02:00` to `00:04:00`, meaning the audio will play for 2 seconds.
-
-```tsx twoslash
-import {AbsoluteFill, Audio, staticFile} from 'remotion';
-
-export const MyVideo = () => {
-  return (
-    <AbsoluteFill>
-      <Audio src={staticFile('audio.mp3')} startFrom={60} endAt={120} />
-    </AbsoluteFill>
-  );
-};
-```
-
 ### `playbackRate?`<AvailableFrom v="2.2.0"/>
 
 You can use the `playbackRate` prop to control the speed of the audio. `1` is the default and means regular speed, `0.5` slows down the audio so it's twice as long and `2` speeds up the audio so it's twice as fast.
@@ -210,7 +186,7 @@ Enable the [Web Audio API](/docs/audio/volume#limitations) for the audio tag.
 
 ### `onError?`<AvailableFrom v="4.0.326" />
 
-Handle an error playing the audio.  
+Handle an error playing the audio.
 
 ### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
 

--- a/packages/docs/docs/audio/order-of-operations.mdx
+++ b/packages/docs/docs/audio/order-of-operations.mdx
@@ -14,13 +14,13 @@ Before Remotion v4.0.141, it was not defined in which order audio and video oper
 
 Since Remotion v4.0.141, the order of operations is guaranteed to be the following:
 
-1. Trim audio (using [`startFrom`](/docs/audio#startfrom--endat)).
+1. Trim audio (using [`trimBefore`](/docs/audio##trimbefore--trimafter)).
 2. Offset audio (by putting it in a [`<Sequence>`](/docs/sequence)).
 3. Stretch audio (by adding a [`playbackRate`](/docs/audio#playbackrate)).
 
 Example for a 30 FPS composition which is 60 frames long:
 
-1. An [`<Audio>`](/docs/audio) tag has a [`startFrom`](/docs/audio#startfrom--endat) value of 45. The first 1.5 seconds of the audio get trimmed off.
+1. An [`<Audio>`](/docs/audio) tag has a [`trimBefore`](/docs/audio#trimbefore--trimafter) value of 45. The first 1.5 seconds of the audio get trimmed off.
 2. The [`<Audio>`](/docs/audio) tag is in a [`<Sequence>`](/docs/sequence) which starts at `30`. The audio only begins playing at the 1.0 second timeline mark at the 1.5 second audio position.
 3. The [`<Audio>`](/docs/audio) has a [`playbackRate`](/docs/audio#playbackrate) of `2`. The audio gets sped up by 2x, but the starting position and start offset is not affected.
 4. The composition is 60 frames long, so the audio must stop at the 3.5 second mark:

--- a/packages/docs/docs/audio/trimming.mdx
+++ b/packages/docs/docs/audio/trimming.mdx
@@ -31,5 +31,5 @@ This will result the audio to play the range from `00:02:00` to `00:04:00`, mean
 The audio will still play immediately at the beginning - to see how to shift the audio to appear later in the composition, see the [next article](/docs/audio/delaying).
 
 :::note Legacy props
-You can also use the deprecated [`startFrom`](/docs/audio#startfrom--endat) and [`endAt`](/docs/audio#startfrom--endat) props, but the new `trimBefore` and `trimAfter` props are preferred.
+You can also use the deprecated `startFrom` and `endAt` props, but the new `trimBefore` and `trimAfter` props are preferred.
 :::

--- a/packages/docs/docs/audiobuffertodataurl.mdx
+++ b/packages/docs/docs/audiobuffertodataurl.mdx
@@ -2,7 +2,7 @@
 image: /generated/articles-docs-audiobuffertodataurl.png
 id: audio-buffer-to-data-url
 title: audioBufferToDataUrl()
-crumb: "@remotion/media-utils"
+crumb: '@remotion/media-utils'
 ---
 
 _Part of the `@remotion/media-utils` package of helper functions. Available from v2.5.7._
@@ -12,9 +12,9 @@ This API takes an [`AudioBuffer`](https://developer.mozilla.org/en-US/docs/Web/A
 ## API Usage
 
 ```tsx twoslash
-const audioBuffer = new AudioBuffer({ length: 0, sampleRate: 44100 });
+const audioBuffer = new AudioBuffer({length: 0, sampleRate: 44100});
 // ---cut---
-import { audioBufferToDataUrl } from "@remotion/media-utils";
+import {audioBufferToDataUrl} from '@remotion/media-utils';
 
 const str = audioBufferToDataUrl(audioBuffer);
 ```
@@ -24,16 +24,9 @@ const str = audioBufferToDataUrl(audioBuffer);
 The following composition will render a sine tone with a C4 pitch.
 
 ```tsx twoslash
-import { audioBufferToDataUrl } from "@remotion/media-utils";
-import { useCallback, useEffect, useState } from "react";
-import {
-  Audio,
-  cancelRender,
-  continueRender,
-  delayRender,
-  interpolate,
-  useVideoConfig,
-} from "remotion";
+import {audioBufferToDataUrl} from '@remotion/media-utils';
+import {useCallback, useEffect, useState} from 'react';
+import {Audio, cancelRender, continueRender, delayRender, interpolate, useVideoConfig} from 'remotion';
 
 const C4_FREQUENCY = 261.63;
 const sampleRate = 44100;
@@ -41,7 +34,7 @@ const sampleRate = 44100;
 export const OfflineAudioBufferExample: React.FC = () => {
   const [handle] = useState(() => delayRender());
   const [audioBuffer, setAudioBuffer] = useState<string | null>(null);
-  const { fps, durationInFrames } = useVideoConfig();
+  const {fps, durationInFrames} = useVideoConfig();
   const lengthInSeconds = durationInFrames / fps;
 
   const renderAudio = useCallback(async () => {
@@ -56,10 +49,10 @@ export const OfflineAudioBufferExample: React.FC = () => {
     gainNode.connect(offlineContext.destination);
     gainNode.gain.setValueAtTime(0.5, offlineContext.currentTime);
 
-    oscillatorNode.type = "sine";
+    oscillatorNode.type = 'sine';
     oscillatorNode.frequency.value = C4_FREQUENCY;
 
-    const { currentTime } = offlineContext;
+    const {currentTime} = offlineContext;
     oscillatorNode.start(currentTime);
     oscillatorNode.stop(currentTime + lengthInSeconds);
 
@@ -76,12 +69,11 @@ export const OfflineAudioBufferExample: React.FC = () => {
   return audioBuffer ? (
     <Audio
       src={audioBuffer}
-      startFrom={0}
-      endAt={100}
+      trimAfter={100}
       volume={(f) =>
         interpolate(f, [0, 50, 100], [0, 1, 0], {
-          extrapolateLeft: "clamp",
-          extrapolateRight: "clamp",
+          extrapolateLeft: 'clamp',
+          extrapolateRight: 'clamp',
         })
       }
     />

--- a/packages/docs/docs/media-fragments.mdx
+++ b/packages/docs/docs/media-fragments.mdx
@@ -65,7 +65,7 @@ Anytime they change, the browser considers this a new source and re-loads the vi
 There are valid scenarios where we recommend disabling the media fragment hints:
 
 - Changing the `from` and `durationInFrames` values of a `<Sequence>` dynamically
-- Changing the `startFrom` and `endAt` values of a `<Video>` or `<OffthreadVideo>` dynamically
+- Changing the `trimBefore` and `trimAfter` values of a `<Video>` or `<OffthreadVideo>` dynamically
 - Changing the `playbackRate` of a `<Video>` over time.
 
 Normally you would not do this, but there are exceptions, like: [Changing the speed of a video over time](/docs/miscellaneous/snippets/accelerated-video)

--- a/packages/docs/docs/miscellaneous/snippets/accelerated-video.mdx
+++ b/packages/docs/docs/miscellaneous/snippets/accelerated-video.mdx
@@ -15,10 +15,7 @@ It is not as easy as interpolating the [`playbackRate`](/docs/video#playbackrate
 import {interpolate, OffthreadVideo} from 'remotion';
 let frame = 0;
 // ---cut---
-<OffthreadVideo
-  playbackRate={interpolate(frame, [0, 100], [1, 5])}
-  src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4#disable"
-/>;
+<OffthreadVideo playbackRate={interpolate(frame, [0, 100], [1, 5])} src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4#disable" />;
 ```
 
 This is because Remotion will evaluate each frame independently from the other frames. If `frame` is 100, the `playbackRate` evaluates as 5 and Remotion will render the 500th frame of the video, which is undesired because it does not take into account that the speed has been building up to 5 until now.
@@ -47,11 +44,7 @@ export const AcceleratedVideo: React.FC = () => {
 
   return (
     <Sequence from={frame}>
-      <OffthreadVideo
-        startFrom={Math.round(remappedFrame)}
-        playbackRate={speedFunction(frame)}
-        src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4#disable"
-      />
+      <OffthreadVideo trimBefore={Math.round(remappedFrame)} playbackRate={speedFunction(frame)} src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4#disable" />
     </Sequence>
   );
 };

--- a/packages/docs/docs/miscellaneous/snippets/different-segments-at-different-speeds.mdx
+++ b/packages/docs/docs/miscellaneous/snippets/different-segments-at-different-speeds.mdx
@@ -60,9 +60,7 @@ export const SpeedSegments = () => {
   const frame = useCurrentFrame();
   const accumulated = accumulateSegments();
 
-  const currentSegment = accumulated.find(
-    (segment) => frame > segment.start && frame <= segment.end,
-  );
+  const currentSegment = accumulated.find((segment) => frame > segment.start && frame <= segment.end);
 
   if (!currentSegment) {
     return;
@@ -72,9 +70,9 @@ export const SpeedSegments = () => {
     <Sequence from={currentSegment.start}>
       <OffthreadVideo
         pauseWhenBuffering
-        startFrom={currentSegment.passedVideoTime}
+        trimBefore={currentSegment.passedVideoTime}
         // Remotion will automatically add a time fragment to the end of the video URL
-        // based on `startFrom`. Opt out of this by adding one yourself.
+        // based on `trimBefore`. Opt out of this by adding one yourself.
         // https://www.remotion.dev/docs/media-fragments
         src={`${staticFile('bigbuckbunny.mp4')}#t=0,`}
         playbackRate={currentSegment.speed}

--- a/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
+++ b/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
@@ -10,29 +10,24 @@ Use the following snippet to skip certain sections of a video, without re-mounti
 
 ```tsx twoslash
 import React, {useMemo} from 'react';
-import {
-  CalculateMetadataFunction,
-  OffthreadVideo,
-  staticFile,
-  useCurrentFrame,
-} from 'remotion';
+import {CalculateMetadataFunction, OffthreadVideo, staticFile, useCurrentFrame} from 'remotion';
 
 const fps = 30;
 
 type Section = {
-  startFrom: number;
-  endAt: number;
+  trimBefore: number;
+  trimAfter: number;
 };
 
 export const SAMPLE_SECTIONS: Section[] = [
-  {startFrom: 0, endAt: 5 * fps},
+  {trimBefore: 0, trimAfter: 5 * fps},
   {
-    startFrom: 7 * fps,
-    endAt: 10 * fps,
+    trimBefore: 7 * fps,
+    trimAfter: 10 * fps,
   },
   {
-    startFrom: 13 * fps,
-    endAt: 18 * fps,
+    trimBefore: 13 * fps,
+    trimAfter: 18 * fps,
   },
 ];
 
@@ -40,11 +35,9 @@ type Props = {
   sections: Section[];
 };
 
-export const calculateMetadata: CalculateMetadataFunction<Props> = ({
-  props,
-}) => {
+export const calculateMetadata: CalculateMetadataFunction<Props> = ({props}) => {
   const durationInFrames = props.sections.reduce((acc, section) => {
-    return acc + section.endAt - section.startFrom;
+    return acc + section.trimAfter - section.trimBefore;
   }, 0);
 
   return {
@@ -56,28 +49,28 @@ export const calculateMetadata: CalculateMetadataFunction<Props> = ({
 export const JumpCuts: React.FC<Props> = ({sections}) => {
   const frame = useCurrentFrame();
 
-  const startFrom = useMemo(() => {
+  const trimBefore = useMemo(() => {
     let summedUpDurations = 0;
     for (const section of sections) {
-      summedUpDurations += section.endAt - section.startFrom;
+      summedUpDurations += section.trimAfter - section.trimBefore;
       if (summedUpDurations > frame) {
-        return section.endAt - summedUpDurations;
+        return section.trimAfter - summedUpDurations;
       }
     }
 
     return null;
   }, [frame, sections]);
 
-  if (startFrom === null) {
+  if (trimBefore === null) {
     return null;
   }
 
   return (
     <OffthreadVideo
       pauseWhenBuffering
-      startFrom={startFrom}
+      trimBefore={trimBefore}
       // Remotion will automatically add a time fragment to the end of the video URL
-      // based on `startFrom` and `endAt`. Opt out of this by adding one yourself.
+      // based on `trimBefore` and `trimAfter`. Opt out of this by adding one yourself.
       // https://www.remotion.dev/docs/media-fragments
       src={`${staticFile('time.mp4')}#t=0,`}
     />

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -81,37 +81,11 @@ Removes a portion of the video at the end (right side). See [`trimBefore`](/docs
 This prop has been renamed to [`trimBefore`](#trimbefore) in 4.0.319. It will continue to work but you cannot use it together with the new prop.
 :::
 
-Will remove a portion of the video at the beginning.
-
-In the following example, we assume that the [`fps`](/docs/composition#fps) of the composition is `30`.
-
-By passing `startFrom={60}`, the playback starts immediately, but with the first 2 seconds of the video trimmed away.  
-By passing `endAt={120}`, any video after the 4 second mark in the file will be trimmed away.
-
-The video will play the range from `00:02:00` to `00:04:00`, meaning the video will play for 2 seconds.
-
-For exact behavior, see: [Order of operations](/docs/audio/order-of-operations).
-
-```tsx twoslash
-import {AbsoluteFill, OffthreadVideo, staticFile} from 'remotion';
-
-// ---cut---
-export const MyComposition = () => {
-  return (
-    <AbsoluteFill>
-      <OffthreadVideo src={staticFile('video.webm')} startFrom={60} endAt={120} />
-    </AbsoluteFill>
-  );
-};
-```
-
 ### ~~`endAt?`~~
 
 :::note Deprecated
 This prop has been renamed to [`trimAfter`](#trimafter) in 4.0.319. It will continue to work but you cannot use it together with the new prop.
 :::
-
-Removes a portion of the video at the end. See [`startFrom`](/docs/offthreadvideo#startfrom) for an explanation.
 
 ### `transparent?`<AvailableFrom v="4.0.0" />
 

--- a/packages/docs/docs/video.mdx
+++ b/packages/docs/docs/video.mdx
@@ -85,37 +85,11 @@ Removes a portion of the video at the end (right side). See [`trimBefore`](/docs
 This prop has been renamed to [`trimBefore`](#trimbefore) in 4.0.319. It will continue to work but you cannot use it together with the new prop.
 :::
 
-Will remove a portion of the video at the beginning.
-
-In the following example, we assume that the [`fps`](/docs/composition#fps) of the composition is `30`.
-
-By passing `startFrom={60}`, the playback starts immediately, but with the first 2 seconds of the video trimmed away.  
-By passing `endAt={120}`, any video after the 4 second mark in the file will be trimmed away.
-
-The video will play the range from `00:02:00` to `00:04:00`, meaning the video will play for 2 seconds.
-
-For exact behavior, see: [Order of operations](/docs/audio/order-of-operations).
-
-```tsx twoslash
-import {AbsoluteFill, staticFile, Video} from 'remotion';
-
-// ---cut---
-export const MyComposition = () => {
-  return (
-    <AbsoluteFill>
-      <Video src={staticFile('video.webm')} startFrom={60} endAt={120} />
-    </AbsoluteFill>
-  );
-};
-```
-
 ### ~~`endAt?`~~
 
 :::note Deprecated
 This prop has been renamed to [`trimAfter`](#trimAfter) in 4.0.319. It will continue to work but you cannot use it together with the new prop.
 :::
-
-Removes a portion of the video at the end. See [`startFrom`](/docs/video#startfrom) for an explanation.
 
 ### `style?`
 

--- a/packages/docs/src/helpers/system-prompt.ts
+++ b/packages/docs/src/helpers/system-prompt.ts
@@ -81,8 +81,8 @@ export const MyComp: React.FC = () => {
 };
 \`\`\`
 
-OffthreadVideo has a "startFrom" prop that trims the left side of a video by a number of frames.
-OffthreadVideo has a "endAt" prop that limits how long a video is shown.
+OffthreadVideo has a "trimBefore" prop that trims the left side of a video by a number of frames.
+OffthreadVideo has a "trimAfter" prop that limits how long a video is shown.
 OffthreadVideo has a "volume" prop that sets the volume of the video. It accepts values between 0 and 1.
 
 If an non-animated image is included In the component it should use the "<Img>" tag.
@@ -131,8 +131,8 @@ export const MyComp: React.FC = () => {
 };
 \`\`\`
 
-Audio has a "startFrom" prop that trims the left side of a audio by a number of frames.
-Audio has a "endAt" prop that limits how long a audio is shown.
+Audio has a "trimBefore" prop that trims the left side of a audio by a number of frames.
+Audio has a "trimAfter" prop that limits how long a audio is shown.
 Audio has a "volume" prop that sets the volume of the audio. It accepts values between 0 and 1.
 
 If two elements should be rendered on top of each other, they should be layered using the "AbsoluteFill" component from "remotion".

--- a/packages/docs/static/llms.txt
+++ b/packages/docs/static/llms.txt
@@ -78,8 +78,8 @@ export const MyComp: React.FC = () => {
 };
 ```
 
-OffthreadVideo has a "startFrom" prop that trims the left side of a video by a number of frames.
-OffthreadVideo has a "endAt" prop that limits how long a video is shown.
+OffthreadVideo has a "trimBefoer" prop that trims the left side of a video by a number of frames.
+OffthreadVideo has a "trimAfter" prop that limits how long a video is shown.
 OffthreadVideo has a "volume" prop that sets the volume of the video. It accepts values between 0 and 1.
 
 If an non-animated image is included In the component it should use the "<Img>" tag.


### PR DESCRIPTION
Fixes #5505