### PR TITLE
`@remotion/media-parser`: Fix parser getting stuck when multiple samples have the same timestamp

### DIFF
--- a/packages/media-parser/src/containers/iso-base-media/mdat/calculate-jump-marks.ts
+++ b/packages/media-parser/src/containers/iso-base-media/mdat/calculate-jump-marks.ts
@@ -19,7 +19,7 @@ export type JumpMark = {
 };
 
 const getKey = (samplePositionTrack: MinimalFlatSampleForTesting) => {
-	return `${samplePositionTrack.track.trackId}-${samplePositionTrack.samplePosition.decodingTimestamp}`;
+	return `${samplePositionTrack.track.trackId}-${samplePositionTrack.samplePosition.decodingTimestamp}.${samplePositionTrack.samplePosition.offset}`;
 };
 
 const findBestJump = ({


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
