### PR TITLE
`@remotion/lambda`: Increase the minimum value for framesPerLambda to 5

### DIFF
--- a/packages/docs/docs/lambda/concurrency.mdx
+++ b/packages/docs/docs/lambda/concurrency.mdx
@@ -56,7 +56,7 @@ import {ConcurrencyCalculator} from '../../components/Concurrency';
 
 Ensure that you only set parameter within these limits to ensure the renders don't throw any errors:
 
-- Minimum `framesPerLambda`: 4
+- Minimum `framesPerLambda`: 5 (4 up until Remotion 4.0.331)
 - Maximum concurrency: 200
 
 The Remotion Lambda defaults will never go outside these bounds.

--- a/packages/serverless-client/src/constants.ts
+++ b/packages/serverless-client/src/constants.ts
@@ -396,7 +396,7 @@ export type AfterRenderCost = {
 
 export const CONCAT_FOLDER_TOKEN = 'remotion-concat';
 export const MAX_FUNCTIONS_PER_RENDER = 200;
-export const MINIMUM_FRAMES_PER_FUNCTIONS = 4;
+export const MINIMUM_FRAMES_PER_FUNCTION = 5;
 
 export const REMOTION_CONCATENATED_TOKEN = 'remotion-concatenated-token';
 

--- a/packages/serverless-client/src/index.ts
+++ b/packages/serverless-client/src/index.ts
@@ -4,7 +4,7 @@ export {
 	artifactName,
 	customOutName,
 	expiryDays,
-	MINIMUM_FRAMES_PER_FUNCTIONS,
+	MINIMUM_FRAMES_PER_FUNCTION,
 	outName,
 	outStillName,
 	overallProgressKey,

--- a/packages/serverless-client/src/validate-frames-per-function.ts
+++ b/packages/serverless-client/src/validate-frames-per-function.ts
@@ -1,7 +1,7 @@
 import {bestFramesPerFunctionParam} from './best-frames-per-function-param';
 import {
 	MAX_FUNCTIONS_PER_RENDER,
-	MINIMUM_FRAMES_PER_FUNCTIONS,
+	MINIMUM_FRAMES_PER_FUNCTION,
 } from './constants';
 
 export const validateFramesPerFunction = ({
@@ -20,7 +20,7 @@ export const validateFramesPerFunction = ({
 	}
 
 	const effectiveMinimum = Math.min(
-		MINIMUM_FRAMES_PER_FUNCTIONS,
+		MINIMUM_FRAMES_PER_FUNCTION,
 		durationInFrames,
 	);
 


### PR DESCRIPTION
Previously 4, but having such short chunks could lead to encoding issues with FFmpeg