### PR TITLE
`@remotion/webcodecs`: Fix `extractFrames()` emitting same frame twice

### DIFF
--- a/packages/webcodecs/src/internal-extract-frames.ts
+++ b/packages/webcodecs/src/internal-extract-frames.ts
@@ -11,7 +11,6 @@ import {
 	hasBeenAborted,
 	mediaParserController,
 } from '@remotion/media-parser';
-import type {ParseMediaOnWorker} from '@remotion/media-parser/worker';
 import {createVideoDecoder} from './create-video-decoder';
 import {withResolvers} from './create/with-resolvers';
 import {Log} from './log';
@@ -105,13 +104,14 @@ export const internalExtractFrames = ({
 					// A WebM might have a timestamp of 67000 but we request 66666
 					// See a test with this problem in it-tests/rendering/frame-accuracy.test.ts
 					// Solution: We allow a 10.000ms - 3.333ms = 6.667ms difference between the requested timestamp and the actual timestamp
-					if (expectedFrames[0] + 6667 < frame.timestamp && lastFrame) {
+					if (
+						expectedFrames[0] + 6667 < frame.timestamp &&
+						lastFrame &&
+						lastFrame !== lastFrameEmitted
+					) {
 						onFrame(lastFrame);
 						lastFrameEmitted = lastFrame;
 						expectedFrames.shift();
-						if (lastFrame) {
-							lastFrame.close();
-						}
 
 						lastFrame = frame;
 						return;

--- a/packages/webcodecs/src/internal-extract-frames.ts
+++ b/packages/webcodecs/src/internal-extract-frames.ts
@@ -11,6 +11,7 @@ import {
 	hasBeenAborted,
 	mediaParserController,
 } from '@remotion/media-parser';
+import type {ParseMediaOnWorker} from '@remotion/media-parser/worker';
 import {createVideoDecoder} from './create-video-decoder';
 import {withResolvers} from './create/with-resolvers';
 import {Log} from './log';

--- a/packages/webcodecs/src/it-tests/extract-frames.test.mts
+++ b/packages/webcodecs/src/it-tests/extract-frames.test.mts
@@ -32,6 +32,7 @@ test.describe('Vite app', () => {
 
 		await page.waitForFunction(() => (window as any).videoFrames?.length === 5);
 		const value = await page.evaluate(() => (window as any).videoFrames);
+		console.log(value);
 		expect(value[0]).toBe(0);
 		expect(value[1] === 1000000 || value[1] === 920000).toBe(true);
 		expect(value[2] === 2000000 || value[2] === 1880000).toBe(true);


### PR DESCRIPTION
PR