### PR TITLE
`@remotion/webcodecs`: Don't apply any rotation when using default options

### DIFF
--- a/packages/webcodecs/src/default-on-video-track-handler.ts
+++ b/packages/webcodecs/src/default-on-video-track-handler.ts
@@ -47,7 +47,8 @@ export const defaultOnVideoTrackHandler: ConvertMediaOnVideoTrackHandler =
 			return Promise.resolve({
 				type: 'reencode',
 				videoCodec: defaultVideoCodec,
-				rotate: rotate - track.rotation,
+				// By default, will remove rotation when re-encoding
+				rotate: undefined,
 				resize: resizeOperation,
 			});
 		}


### PR DESCRIPTION
Fixes #5509