### PR TITLE
Fix renderStill error when rendering negative frame index 

### DIFF
--- a/packages/renderer/src/convert-to-positive-frame-index.ts
+++ b/packages/renderer/src/convert-to-positive-frame-index.ts
@@ -6,5 +6,5 @@ export const convertToPositiveFrameIndex = ({
 	frame: number;
 	durationInFrames: number;
 }) => {
-	return frame < 0 ? durationInFrames - frame : frame;
+	return frame < 0 ? durationInFrames + frame : frame;
 };


### PR DESCRIPTION
Docs say rendering frame -1 will render the last frame
https://www.remotion.dev/docs/renderer/render-still

If you pass a negative number it will error as there is a small bug in that logic

```
durationInFrames: 100

renderStill({frame: -1}) = frame 101
```
