### PR TITLE
`@remotion/webcodecs`: Don't overrotate video frames

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
@@ -1,5 +1,6 @@
 import {hasBeenAborted, WEBCODECS_TIMESCALE} from '@remotion/media-parser';
-import {extractFrames, rotateAndResizeVideoFrame} from '@remotion/webcodecs';
+import {rotateAndResizeVideoFrame} from '@remotion/webcodecs';
+import {extractFramesOnWebWorker} from '@remotion/webcodecs/worker';
 import React, {useEffect, useRef, useState} from 'react';
 import {useVideoConfig} from 'remotion';
 import type {FrameDatabaseKey} from '../../helpers/frame-database';
@@ -333,7 +334,7 @@ export const TimelineVideoInfo: React.FC<{
 
 		clearOldFrames();
 
-		extractFrames({
+		extractFramesOnWebWorker({
 			acknowledgeRemotionLicense: true,
 			timestampsInSeconds: ({track}) => {
 				aspectRatio.current = track.width / track.height;

--- a/packages/webcodecs/src/reencode-video-track.ts
+++ b/packages/webcodecs/src/reencode-video-track.ts
@@ -52,7 +52,7 @@ export const reencodeVideoTrack = async ({
 		);
 	}
 
-	const rotation = (videoOperation.rotate ?? rotate) + track.rotation;
+	const rotation = videoOperation.rotate ?? rotate;
 
 	const {height: newHeight, width: newWidth} =
 		calculateNewDimensionsFromRotateAndScale({

--- a/packages/webcodecs/src/rotate-and-resize-video-frame.ts
+++ b/packages/webcodecs/src/rotate-and-resize-video-frame.ts
@@ -52,11 +52,7 @@ export const rotateAndResizeVideoFrame = ({
 		return frame;
 	}
 
-	// @ts-expect-error
-	const frameRotation: number = frame.rotation ?? 0;
-	const canvasRotationToApply = normalizeVideoRotation(
-		normalized - frameRotation,
-	);
+	const canvasRotationToApply = normalizeVideoRotation(normalized);
 
 	const {width, height} = calculateNewDimensionsFromRotateAndScale({
 		height: frame.displayHeight,


### PR DESCRIPTION
PR