### PR TITLE
Fix media parser not accepting MPEG 2.5 mp3 file

### DIFF
--- a/packages/media-parser/src/containers/mp3/parse-packet-header.ts
+++ b/packages/media-parser/src/containers/mp3/parse-packet-header.ts
@@ -185,7 +185,11 @@ const innerParseMp3PacketHeader = (iterator: BufferIterator) => {
      10 - MPEG Version 2 (ISO/IEC 13818-3)
      11 - MPEG Version 1 (ISO/IEC 11172-3)
    */
-	if (audioVersionId !== 0b11 && audioVersionId !== 0b10) {
+	if (
+		audioVersionId !== 0b11 &&
+		audioVersionId !== 0b10 &&
+		audioVersionId !== 0b00
+	) {
 		throw new Error('Expected MPEG Version 1 or 2');
 	}
 


### PR DESCRIPTION
Fixes `parseMedia` call with this mp3 file: [test-silence-enhanced.mp3](https://github.com/user-attachments/files/21903603/test-silence-enhanced.mp3)

Original issue in the Remotion Studio:

<img width="500" height="965" alt="image" src="https://github.com/user-attachments/assets/a6b6c8a1-d2fe-41a2-8296-fa0a2e81677e" />



<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
[test-silence-enhanced.mp3](https://github.com/user-attachments/files/21903596/test-silence-enhanced.mp3)

  - document potential tradeoffs in this PR.
-->
