### PR TITLE
`@remotion/serverless`: Retry render after `ETIMEDOUT`

### DIFF
--- a/packages/serverless/src/stream-renderer.ts
+++ b/packages/serverless/src/stream-renderer.ts
@@ -183,7 +183,9 @@ const streamRenderer = <Provider extends CloudProvider>({
 			})
 			.catch((err) => {
 				const shouldRetry =
-					(err as Error).stack?.includes('Error: aborted') ?? false;
+					(err as Error).stack?.includes('Error: aborted') ||
+					(err as Error).stack?.includes('ETIMEDOUT') ||
+					false;
 
 				resolve({
 					type: 'error',


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
