### PR TITLE
Bump Rive canvas to 2.31.2

### DIFF
--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -103,7 +103,7 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 	useEffect(() => {
 		riveCanvas({
 			locateFile: () =>
-				'https://unpkg.com/@rive-app/canvas-advanced@2.19.3/rive.wasm',
+				'https://unpkg.com/@rive-app/canvas-advanced@2.31.2/rive.wasm',
 		})
 			.then((riveInstance) => {
 				setRiveCanvas(riveInstance);


### PR DESCRIPTION
Bumping Rive version to latest. 

Used one (2.19.3) doesn't open files exported from current Rive editor that contain new features. 