### PR TITLE
`@remotion/serverless`: Don't store credentials in progress.json

### DIFF
--- a/packages/serverless/src/handlers/launch.ts
+++ b/packages/serverless/src/handlers/launch.ts
@@ -38,6 +38,7 @@ import {mergeChunksAndFinishRender} from '../merge-chunks';
 import type {OverallProgressHelper} from '../overall-render-progress';
 import {makeOverallRenderProgress} from '../overall-render-progress';
 import {planFrameRanges} from '../plan-frame-ranges';
+import {removeOutnameCredentials} from '../remove-outname-credentials';
 import {streamRendererFunctionWithRetry} from '../stream-renderer';
 import {validateComposition} from '../validate-composition';
 import {sendTelemetryEvent} from './send-telemetry-event';
@@ -321,7 +322,7 @@ const innerLaunchHandler = async <Provider extends CloudProvider>({
 		memorySizeInMb: insideFunctionSpecifics.getCurrentMemorySizeInMb(),
 		region: insideFunctionSpecifics.getCurrentRegionInFunction(),
 		renderId: params.renderId,
-		outName: params.outName ?? undefined,
+		outName: removeOutnameCredentials(params.outName ?? undefined),
 		privacy: params.privacy,
 		everyNthFrame: params.everyNthFrame,
 		frameRange: realFrameRange,

--- a/packages/serverless/src/handlers/still.ts
+++ b/packages/serverless/src/handlers/still.ts
@@ -32,6 +32,7 @@ import {getTmpDirStateIfENoSp} from '../get-tmp-dir';
 import {onDownloadsHelper} from '../on-downloads-helpers';
 import {makeInitialOverallRenderProgress} from '../overall-render-progress';
 import type {InsideFunctionSpecifics} from '../provider-implementation';
+import {removeOutnameCredentials} from '../remove-outname-credentials';
 import {validateComposition} from '../validate-composition';
 import {checkVersionMismatch} from './check-version-mismatch';
 import {sendTelemetryEvent} from './send-telemetry-event';
@@ -196,7 +197,7 @@ const innerStillHandler = async <Provider extends CloudProvider>(
 		memorySizeInMb: insideFunctionSpecifics.getCurrentMemorySizeInMb(),
 		region: insideFunctionSpecifics.getCurrentRegionInFunction(),
 		renderId,
-		outName: params.outName ?? undefined,
+		outName: removeOutnameCredentials(params.outName ?? undefined),
 		privacy: params.privacy,
 		audioCodec: null,
 		deleteAfter: params.deleteAfter,

--- a/packages/serverless/src/remove-outname-credentials.ts
+++ b/packages/serverless/src/remove-outname-credentials.ts
@@ -1,0 +1,27 @@
+import type {
+	CloudProvider,
+	OutNameInput,
+	OutNameInputWithoutCredentials,
+} from '@remotion/serverless-client';
+
+export const removeOutnameCredentials = <Provider extends CloudProvider>(
+	outname: OutNameInput<Provider> | undefined,
+): OutNameInputWithoutCredentials | undefined => {
+	if (outname === undefined) {
+		return undefined;
+	}
+
+	if (typeof outname === 'string') {
+		return outname;
+	}
+
+	return {
+		bucketName: outname.bucketName,
+		key: outname.key,
+		s3OutputProvider: outname.s3OutputProvider
+			? {
+					endpoint: outname.s3OutputProvider.endpoint,
+				}
+			: undefined,
+	};
+};


### PR DESCRIPTION
`progress.json` is a private file, so it is not as bad, but cleaner to remove credentials

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
