### PR TITLE
`calculateMetadata()`: add `isRendering` argument property

### DIFF
--- a/packages/core/src/Composition.tsx
+++ b/packages/core/src/Composition.tsx
@@ -55,6 +55,7 @@ export type CalculateMetadataFunction<T extends Record<string, unknown>> =
 		props: T;
 		abortSignal: AbortSignal;
 		compositionId: string;
+		isRendering: boolean;
 	}) => Promise<CalcMetadataReturnType<T>> | CalcMetadataReturnType<T>;
 
 type OptionalDimensions<

--- a/packages/core/src/resolve-video-config.ts
+++ b/packages/core/src/resolve-video-config.ts
@@ -3,6 +3,7 @@ import type {
 	CalcMetadataReturnType,
 	CalculateMetadataFunction,
 } from './Composition.js';
+import {getRemotionEnvironment} from './get-remotion-environment.js';
 import {serializeThenDeserializeInStudio} from './input-props-serialization.js';
 import type {InferProps} from './props-if-has-props.js';
 import {validateCodec} from './validation/validate-default-codec.js';
@@ -111,6 +112,7 @@ export const resolveVideoConfig = ({
 				props: originalProps,
 				abortSignal: signal,
 				compositionId,
+				isRendering: getRemotionEnvironment().isRendering,
 			})
 		: null;
 

--- a/packages/docs/docs/calculate-metadata.mdx
+++ b/packages/docs/docs/calculate-metadata.mdx
@@ -53,7 +53,7 @@ import React from 'react';
 import {CalculateMetadataFunction, Composition} from 'remotion';
 import {MyComponent, MyComponentProps} from './MyComp';
 
-const calculateMetadata: CalculateMetadataFunction<MyComponentProps> = ({props, defaultProps, abortSignal}) => {
+const calculateMetadata: CalculateMetadataFunction<MyComponentProps> = ({props, defaultProps, abortSignal, isRendering}) => {
   return {
     // Change the metadata
     durationInFrames: props.duration,
@@ -93,6 +93,7 @@ As argument, you get an object with the following properties:
 - `props`: The [resolved props](/docs/props-resolution), taking input props into account.
 - `abortSignal`: An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) which you can use to abort network requests if [the default props have been changed](/docs/data-fetching#aborting-stale-requests) in the meanwhile.
 - `compositionId` (_available from v4.0.98_): The ID of the current composition
+- `isRendering` (_available from v4.0.342_): A boolean indicating whether the function is being called during rendering (`true`) or in other contexts like the Studio (`false`)
 
 The function must return an pure JSON-serializable object, which can contain the following properties:
 

--- a/packages/docs/docs/get-remotion-environment.mdx
+++ b/packages/docs/docs/get-remotion-environment.mdx
@@ -15,7 +15,7 @@ Consider using the [`useRemotionEnvironment()`](/docs/use-remotion-environment) 
 It returns an object with the following properties:
 
 - `isStudio`: Whether the function got called in the [Remotion Studio](/docs/cli/studio).
-- `isRendering`: Whether the function got called in a render.
+- `isRendering`: Whether the function got called in a render. Also available in the [`calculateMetadata()`](/docs/calculate-metadata) function.
 - `isPlayer`: Whether a [`<Player>`](/docs/player) is mounted on the current page.
 - `isReadOnlyStudio`: Whether in a [statically deployed studio](https://www.remotion.dev/docs/studio/deploy-static), where the [`@remotion/studio`](/docs/studio/api) APIs cannot be used (_available from v4.0.238_)
 

--- a/packages/template-stargazer/src/Root.tsx
+++ b/packages/template-stargazer/src/Root.tsx
@@ -8,8 +8,11 @@ const FPS = 30;
 
 export const RemotionRoot = () => {
   const calculateMetadata: CalculateMetadataFunction<MainProps> = useCallback(
-    async ({ props, abortSignal }) => {
-      await waitForNoInput(abortSignal, 500);
+    async ({ props, abortSignal, isRendering }) => {
+      // don't debounce user input during rendering
+      if (!isRendering) {
+        await waitForNoInput(abortSignal, 500);
+      }
 
       const stargazers = await fetchStargazers({
         repoOrg: props.repoOrg,

--- a/packages/template-stargazer/src/wait-for-no-input.ts
+++ b/packages/template-stargazer/src/wait-for-no-input.ts
@@ -1,11 +1,4 @@
-import { getRemotionEnvironment } from "remotion";
-
 export const waitForNoInput = (signal: AbortSignal, ms: number) => {
-  // Don't wait during rendering
-  if (getRemotionEnvironment().isRendering) {
-    return Promise.resolve();
-  }
-
   if (signal.aborted) {
     return Promise.reject(new Error("stale"));
   }

--- a/packages/template-tts-azure/src/Root.tsx
+++ b/packages/template-tts-azure/src/Root.tsx
@@ -21,8 +21,12 @@ export const RemotionRoot: React.FC = () => {
           voice: "enUSWoman1" as const,
           displaySpeed: 10,
         }}
-        calculateMetadata={async ({ props, abortSignal }) => {
-          await waitForNoInput(abortSignal, 1000);
+        calculateMetadata={async ({ props, abortSignal, isRendering }) => {
+          // don't debounce user input during rendering
+          if (!isRendering) {
+            await waitForNoInput(abortSignal, 1000);
+          }
+
           const exists = await audioAlreadyExists({
             text: props.text,
             voice: props.voice,

--- a/packages/template-tts-azure/src/debounce.ts
+++ b/packages/template-tts-azure/src/debounce.ts
@@ -1,11 +1,4 @@
-import { getRemotionEnvironment } from "remotion";
-
 export const waitForNoInput = (signal: AbortSignal, ms: number) => {
-  // Don't wait during rendering
-  if (getRemotionEnvironment().isRendering) {
-    return Promise.resolve();
-  }
-
   if (signal.aborted) {
     return Promise.reject(new Error("stale"));
   }

--- a/packages/template-tts-google/src/Root.tsx
+++ b/packages/template-tts-google/src/Root.tsx
@@ -59,8 +59,12 @@ export const RemotionRoot: React.FC = () => {
         speakingRate: 1,
         audioUrl: null,
       }}
-      calculateMetadata={async ({ props, abortSignal }) => {
-        await waitForNoInput(abortSignal, 1000);
+      calculateMetadata={async ({ props, abortSignal, isRendering }) => {
+        // don't debounce user input during rendering
+        if (!isRendering) {
+          await waitForNoInput(abortSignal, 1000);
+        }
+
         const audioUrl = await getTTSFromServer({ ...props });
         const audioDurationInSeconds =
           await getAudioDurationInSeconds(audioUrl);

--- a/packages/template-tts-google/src/debounce.ts
+++ b/packages/template-tts-google/src/debounce.ts
@@ -1,11 +1,4 @@
-import { getRemotionEnvironment } from "remotion";
-
 export const waitForNoInput = (signal: AbortSignal, ms: number) => {
-  // Don't wait during rendering
-  if (getRemotionEnvironment().isRendering) {
-    return Promise.resolve();
-  }
-
   if (signal.aborted) {
     return Promise.reject(new Error("stale"));
   }


### PR DESCRIPTION
- **Add `isRendering` to `calculateMetadata` function args**
- **Remove usage of `getRemotionEnvironment` in 3 templates**

Fixes #5629
