### PR TITLE
`remotion`: Fix `useRemotionEnvironment().isStudio` detection

### DIFF
--- a/packages/studio/src/Studio.tsx
+++ b/packages/studio/src/Studio.tsx
@@ -15,17 +15,6 @@ export const Studio: React.FC<{
 	readonly readOnly: boolean;
 }> = ({rootComponent, readOnly}) => {
 	useLayoutEffect(() => {
-		window.remotion_isStudio = true;
-		window.remotion_isReadOnlyStudio = readOnly;
-		Internals.enableSequenceStackTraces();
-
-		return () => {
-			window.remotion_isStudio = false;
-			window.remotion_isReadOnlyStudio = false;
-		};
-	}, [readOnly]);
-
-	useLayoutEffect(() => {
 		injectCSS();
 	}, []);
 

--- a/packages/studio/src/previewEntry.tsx
+++ b/packages/studio/src/previewEntry.tsx
@@ -45,6 +45,10 @@ const renderToDOM = (content: React.ReactElement) => {
 renderToDOM(<NoRegisterRoot />);
 
 Internals.waitForRoot((NewRoot) => {
+	window.remotion_isStudio = true;
+	window.remotion_isReadOnlyStudio = false;
+	Internals.enableSequenceStackTraces();
+
 	renderToDOM(<Studio readOnly={false} rootComponent={NewRoot} />);
 });
 

--- a/packages/studio/src/renderEntry.tsx
+++ b/packages/studio/src/renderEntry.tsx
@@ -279,6 +279,10 @@ const renderContent = (Root: React.FC) => {
 		);
 		import('./internals')
 			.then(({StudioInternals}) => {
+				window.remotion_isStudio = true;
+				window.remotion_isReadOnlyStudio = true;
+
+				Internals.enableSequenceStackTraces();
 				renderToDOM(<StudioInternals.Studio readOnly rootComponent={Root} />);
 			})
 			.catch((err) => {


### PR DESCRIPTION
Would register too late