### PR TITLE
`@remotion/media`: Verify key packets

### DIFF
--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -55,7 +55,7 @@ export const getFramesSinceKeyframe = async ({
 	startPacket: EncodedPacket;
 }) => {
 	const nextKeyPacket = await packetSink.getNextKeyPacket(startPacket, {
-		verifyKeyPackets: false,
+		verifyKeyPackets: true,
 	});
 
 	const sampleIterator = videoSampleSink.samples(


### PR DESCRIPTION
To avoid errors such as "Timestamp is after end timestamp (requested: 325.26666666666665sec, end: 324.69103333333334)"

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
