### PR TITLE
`@remotion/renderer`: Allow a bit more threshold for inline audio mixing

### DIFF
--- a/packages/renderer/src/assets/inline-audio-mixing.ts
+++ b/packages/renderer/src/assets/inline-audio-mixing.ts
@@ -164,19 +164,19 @@ export const makeInlineAudioMixing = (dir: string) => {
 		const samplesToShaveFromEnd = trimRightOffset * DEFAULT_SAMPLE_RATE;
 		if (
 			Math.abs(Math.round(samplesToShaveFromEnd) - samplesToShaveFromEnd) >
-			0.00000001
+			0.0000001
 		) {
 			throw new Error(
-				'samplesToShaveFromEnd should be approximately an integer',
+				`samplesToShaveFromEnd should be approximately an integer, is${samplesToShaveFromEnd}`,
 			);
 		}
 
 		if (
 			Math.abs(Math.round(samplesToShaveFromStart) - samplesToShaveFromStart) >
-			0.00000001
+			0.0000001
 		) {
 			throw new Error(
-				'samplesToShaveFromStart should be approximately an integer',
+				`samplesToShaveFromStart should be approximately an integer, is ${samplesToShaveFromStart}`,
 			);
 		}
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
