### PR TITLE
`@remotion/renderer`: Fix audio mixing for `@remotion/media` tags with fractional FPS

### DIFF
--- a/packages/media/src/convert-audiodata/resample-audiodata.ts
+++ b/packages/media/src/convert-audiodata/resample-audiodata.ts
@@ -96,8 +96,9 @@ export const resampleAudioData = ({
 			const sl = getSourceValues(start, end, 3);
 			const sr = getSourceValues(start, end, 4);
 
-			const l2 = l + Math.sqrt(1 / 2) * (c + sl);
-			const r2 = r + Math.sqrt(1 / 2) * (c + sr);
+			const sq = Math.sqrt(1 / 2);
+			const l2 = l + sq * (c + sl);
+			const r2 = r + sq * (c + sr);
 
 			destination[newFrameIndex * 2 + 0] = l2;
 			destination[newFrameIndex * 2 + 1] = r2;

--- a/packages/renderer/src/assets/inline-audio-mixing.ts
+++ b/packages/renderer/src/assets/inline-audio-mixing.ts
@@ -196,12 +196,10 @@ export const makeInlineAudioMixing = (dir: string) => {
 		const positionInSeconds =
 			(asset.frame - firstFrame) / fps - (isFirst ? 0 : trimLeftOffset);
 
-		const position = Math.round(
-			positionInSeconds *
-				asset.numberOfChannels *
-				DEFAULT_SAMPLE_RATE *
-				BYTES_PER_SAMPLE,
-		);
+		const position =
+			Math.round(positionInSeconds * DEFAULT_SAMPLE_RATE) *
+			asset.numberOfChannels *
+			BYTES_PER_SAMPLE;
 
 		writeSync(
 			// fs


### PR DESCRIPTION
Audio position was not calculated correctly