### PR TITLE
`@remotion/renderer`: Fix FFmpeg crashing when scaling leads to uneven dimensions

### DIFF
--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -439,17 +439,23 @@ const internalRenderMediaRaw = ({
 		onCtrlCExit(`Delete ${workingDir}`, () => deleteDirectory(workingDir));
 	}
 
-	const {actualWidth: widthEvenDimensions, actualHeight: heightEvenDimensions} =
-		validateEvenDimensionsWithCodec({
-			codec,
-			height: compositionWithPossibleUnevenDimensions.height,
-			// Don't apply scale yet, only ensure even dimensions
-			scale: 1,
-			width: compositionWithPossibleUnevenDimensions.width,
-			wantsImageSequence: false,
-			indent,
-			logLevel,
-		});
+	const {
+		actualWidth: widthEvenDimensionsUndivided,
+		actualHeight: heightEvenDimensionsUndivided,
+	} = validateEvenDimensionsWithCodec({
+		codec,
+		height: compositionWithPossibleUnevenDimensions.height,
+		scale,
+		width: compositionWithPossibleUnevenDimensions.width,
+		wantsImageSequence: false,
+		indent,
+		logLevel,
+	});
+
+	const heightEvenDimensions = Math.round(
+		heightEvenDimensionsUndivided / scale,
+	);
+	const widthEvenDimensions = Math.round(widthEvenDimensionsUndivided / scale);
 
 	const {actualWidth, actualHeight} = validateEvenDimensionsWithCodec({
 		codec,


### PR DESCRIPTION
…n dimensions

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
