### PR TITLE
@remotion/lambda: Await async callbacks in appRouterWebhook to prevent premature termination

### DIFF
--- a/packages/docs/docs/lambda/webhooks.mdx
+++ b/packages/docs/docs/lambda/webhooks.mdx
@@ -139,7 +139,7 @@ Instead of validating the signature yourself, you can use the [`validateWebhookS
 
 ## Example webhook endpoint (Express)
 
-You can use any web framework and language to set up your webhook endpoint. The following example is written in JavaScript using the Express framework, we are using [expressWebhook()](/docs/lambda/expresswebhook) to simplify the process.
+You can use any web framework and language to set up your webhook endpoint. The following example is written in JavaScript using the Express framework, we are using [`expressWebhook()`](/docs/lambda/expresswebhook) to simplify the process.
 
 ```javascript twoslash title="server.js"
 const ENABLE_TESTING = false;

--- a/packages/lambda-client/src/app-router-webhook.ts
+++ b/packages/lambda-client/src/app-router-webhook.ts
@@ -51,12 +51,22 @@ export const appRouterWebhook = (
 
 		const payload = body as WebhookPayload;
 
-		if (payload.type === 'success' && onSuccess) {
-			await onSuccess(payload);
-		} else if (payload.type === 'timeout' && onTimeout) {
-			await onTimeout(payload);
-		} else if (payload.type === 'error' && onError) {
-			await onError(payload);
+		try {
+			if (payload.type === 'success' && onSuccess) {
+				await onSuccess(payload);
+			} else if (payload.type === 'timeout' && onTimeout) {
+				await onTimeout(payload);
+			} else if (payload.type === 'error' && onError) {
+				await onError(payload);
+			}
+		} catch (err) {
+			return new Response(
+				JSON.stringify({
+					success: false,
+					error: (err instanceof Error ? err.message : String(err)),
+				}),
+				{ status: 500, headers }
+			);
 		}
 
 		return new Response(JSON.stringify({success: true}), {headers});

--- a/packages/lambda-client/src/app-router-webhook.ts
+++ b/packages/lambda-client/src/app-router-webhook.ts
@@ -43,15 +43,14 @@ export const appRouterWebhook = (
 		// Parse the body properly
 		const body = await req.json();
 
-		validateWebhookSignature({
-			secret,
-			body,
-			signatureHeader: req.headers.get('X-Remotion-Signature') as string,
-		});
-
-		const payload = body as WebhookPayload;
-
 		try {
+			validateWebhookSignature({
+				secret,
+				body,
+				signatureHeader: req.headers.get('X-Remotion-Signature') as string,
+			});
+
+			const payload = body as WebhookPayload;
 			if (payload.type === 'success' && onSuccess) {
 				await onSuccess(payload);
 			} else if (payload.type === 'timeout' && onTimeout) {
@@ -63,9 +62,9 @@ export const appRouterWebhook = (
 			return new Response(
 				JSON.stringify({
 					success: false,
-					error: (err instanceof Error ? err.message : String(err)),
+					error: err instanceof Error ? err.message : String(err),
 				}),
-				{ status: 500, headers }
+				{status: 500, headers},
 			);
 		}
 

--- a/packages/lambda-client/src/app-router-webhook.ts
+++ b/packages/lambda-client/src/app-router-webhook.ts
@@ -10,9 +10,9 @@ export type NextWebhookArgs = {
 	testing?: boolean;
 	extraHeaders?: Record<string, string>;
 	secret: string;
-	onSuccess?: (payload: WebhookSuccessPayload) => void;
-	onTimeout?: (payload: WebhookTimeoutPayload) => void;
-	onError?: (payload: WebhookErrorPayload) => void;
+	onSuccess?: (payload: WebhookSuccessPayload) => void | Promise<void>;
+	onTimeout?: (payload: WebhookTimeoutPayload) => void | Promise<void>;
+	onError?: (payload: WebhookErrorPayload) => void | Promise<void>;
 };
 
 export const appRouterWebhook = (
@@ -52,11 +52,11 @@ export const appRouterWebhook = (
 		const payload = body as WebhookPayload;
 
 		if (payload.type === 'success' && onSuccess) {
-			onSuccess(payload);
+			await onSuccess(payload);
 		} else if (payload.type === 'timeout' && onTimeout) {
-			onTimeout(payload);
+			await onTimeout(payload);
 		} else if (payload.type === 'error' && onError) {
-			onError(payload);
+			await onError(payload);
 		}
 
 		return new Response(JSON.stringify({success: true}), {headers});

--- a/packages/lambda-client/src/pages-router-webhook.ts
+++ b/packages/lambda-client/src/pages-router-webhook.ts
@@ -35,24 +35,31 @@ export const pagesRouterWebhook = (options: NextWebhookArgs) => {
 			return;
 		}
 
-		validateWebhookSignature({
-			secret,
-			body: req.body,
-			signatureHeader: req.headers['x-remotion-signature'] as string,
-		});
+		try {
+			validateWebhookSignature({
+				secret,
+				body: req.body,
+				signatureHeader: req.headers['x-remotion-signature'] as string,
+			});
 
-		// If code reaches this path, the webhook is authentic.
-		const payload = req.body as WebhookPayload;
-		if (payload.type === 'success' && onSuccess) {
-			await onSuccess(payload);
-		} else if (payload.type === 'timeout' && onTimeout) {
-			await onTimeout(payload);
-		} else if (payload.type === 'error' && onError) {
-			await onError(payload);
+			// If code reaches this path, the webhook is authentic.
+			const payload = req.body as WebhookPayload;
+			if (payload.type === 'success' && onSuccess) {
+				await onSuccess(payload);
+			} else if (payload.type === 'timeout' && onTimeout) {
+				await onTimeout(payload);
+			} else if (payload.type === 'error' && onError) {
+				await onError(payload);
+			}
+
+			res.status(200).json({
+				success: true,
+			});
+		} catch (err) {
+			res.status(500).json({
+				success: false,
+				error: (err instanceof Error ? err.message : String(err)),
+			});
 		}
-
-		res.status(200).json({
-			success: true,
-		});
 	};
 };

--- a/packages/lambda-client/src/pages-router-webhook.ts
+++ b/packages/lambda-client/src/pages-router-webhook.ts
@@ -16,7 +16,10 @@ export const addHeaders = (
 export const pagesRouterWebhook = (options: NextWebhookArgs) => {
 	const {testing, extraHeaders, secret, onSuccess, onTimeout, onError} =
 		options;
-	return async function (req: NextApiRequest, res: NextApiResponse): Promise<void> {
+	return async function (
+		req: NextApiRequest,
+		res: NextApiResponse,
+	): Promise<void> {
 		addHeaders(res, extraHeaders || {});
 
 		if (testing) {
@@ -58,7 +61,7 @@ export const pagesRouterWebhook = (options: NextWebhookArgs) => {
 		} catch (err) {
 			res.status(500).json({
 				success: false,
-				error: (err instanceof Error ? err.message : String(err)),
+				error: err instanceof Error ? err.message : String(err),
 			});
 		}
 	};

--- a/packages/lambda-client/src/pages-router-webhook.ts
+++ b/packages/lambda-client/src/pages-router-webhook.ts
@@ -16,7 +16,7 @@ export const addHeaders = (
 export const pagesRouterWebhook = (options: NextWebhookArgs) => {
 	const {testing, extraHeaders, secret, onSuccess, onTimeout, onError} =
 		options;
-	return function (req: NextApiRequest, res: NextApiResponse): void {
+	return async function (req: NextApiRequest, res: NextApiResponse): Promise<void> {
 		addHeaders(res, extraHeaders || {});
 
 		if (testing) {
@@ -44,11 +44,11 @@ export const pagesRouterWebhook = (options: NextWebhookArgs) => {
 		// If code reaches this path, the webhook is authentic.
 		const payload = req.body as WebhookPayload;
 		if (payload.type === 'success' && onSuccess) {
-			onSuccess(payload);
+			await onSuccess(payload);
 		} else if (payload.type === 'timeout' && onTimeout) {
-			onTimeout(payload);
+			await onTimeout(payload);
 		} else if (payload.type === 'error' && onError) {
-			onError(payload);
+			await onError(payload);
 		}
 
 		res.status(200).json({


### PR DESCRIPTION
## Problem
The appRouterWebhook helper doesn't await the onSuccess, onError, and onTimeout callbacks before returning the response. This causes issues in serverless environments (Vercel, AWS Lambda, etc.) where:
The callback starts executing async operations (e.g., database updates)
The response is immediately returned
The serverless function terminates
Async operations are killed mid-execution
This results in database updates, credit consumption, and other async operations silently failing without errors.

## Real-World Impact
Users performing database updates or API calls in webhook callbacks experience:
* Database records not updating despite successful renders
* No error logs (operations silently fail)
* Credits/billing not being processed

## Solution
Change callback signatures to support Promise<void> and await them before returning the response.
