### PR TITLE
`@remotion/media`: Allow frames to be off by 1ms

### DIFF
--- a/packages/media/src/video-extraction/keyframe-bank.ts
+++ b/packages/media/src/video-extraction/keyframe-bank.ts
@@ -59,7 +59,7 @@ export const makeKeyframeBank = ({
 
 		return (
 			roundTo4Digits(lastFrame.timestamp + lastFrame.duration) >
-			roundTo4Digits(timestamp)
+			roundTo4Digits(timestamp) + 0.001
 		);
 	};
 
@@ -117,7 +117,11 @@ export const makeKeyframeBank = ({
 			}
 
 			if (
-				roundTo4Digits(sample.timestamp) <= roundTo4Digits(timestampInSeconds)
+				roundTo4Digits(sample.timestamp) <=
+					roundTo4Digits(timestampInSeconds) ||
+				// Match 0.3333333333 to 0.33355555
+				// this does not satisfy the previous condition, since one rounds up and one rounds down
+				Math.abs(sample.timestamp - timestampInSeconds) < 0.001
 			) {
 				return sample;
 			}


### PR DESCRIPTION
If a frame is in the future, but less than 1ms off the target timestamp, use it nonetheless

Now when matching 29.97fps in 30fps, a frame might still be duplicated, but not 1 duplicate + 1 missing, which could happen previously

 https://discord.com/channels/809501355504959528/809501355504959531/1425017654783250522 to 