### PR TITLE
`@remotion/media`: Don't use WeakRefs for holding keyframe banks

### DIFF
--- a/packages/media/src/get-sink-weak.ts
+++ b/packages/media/src/get-sink-weak.ts
@@ -8,27 +8,16 @@ export const sinkPromises: Record<string, Promise<GetSink>> = {};
 export const getSinkWeak = async (src: string, logLevel: LogLevel) => {
 	let promise = sinkPromises[src];
 	if (!promise) {
-		promise = getSinks(src);
-		sinkPromises[src] = promise;
-	}
-
-	let awaited = await promise;
-	let deferredValue = awaited.deref();
-
-	if (!deferredValue) {
 		Internals.Log.verbose(
 			{
 				logLevel,
 				tag: '@remotion/media',
 			},
-			`Sink for ${src} was garbage collected, creating new sink`,
+			`Sink for ${src} was not found, creating new sink`,
 		);
 		promise = getSinks(src);
 		sinkPromises[src] = promise;
-
-		awaited = await promise;
-		deferredValue = awaited.deref()!;
 	}
 
-	return deferredValue;
+	return promise;
 };

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -126,7 +126,7 @@ export const getSinks = async (src: string) => {
 		return audioSinksPromise[index];
 	};
 
-	return new WeakRef({
+	return {
 		getVideo: () => getVideoSinksPromise(),
 		getAudio: (index: number) => getAudioSinksPromise(index),
 		actualMatroskaTimestamps: rememberActualMatroskaTimestamps(isMatroska),
@@ -134,7 +134,7 @@ export const getSinks = async (src: string) => {
 		getDuration: () => {
 			return input.computeDuration();
 		},
-	});
+	};
 };
 
 export type GetSink = Awaited<ReturnType<typeof getSinks>>;


### PR DESCRIPTION
- Actually, they are being freed as soon as possible, not just when there is memory pressure
- This can lead to messages about frames being garbage collected, we should close VideoFrame's explicitly