### PR TITLE
`@remotion/media`: do not trigger buffer state at the end of the media

### DIFF
--- a/packages/media/src/video/timeout-utils.ts
+++ b/packages/media/src/video/timeout-utils.ts
@@ -2,6 +2,13 @@
 export const sleep = (ms: number) =>
 	new Promise((resolve) => setTimeout(resolve, ms));
 
+export class TimeoutError extends Error {
+	constructor(message: string = 'Operation timed out') {
+		super(message);
+		this.name = 'TimeoutError';
+	}
+}
+
 export function withTimeout<T>(
 	promise: Promise<T>,
 	timeoutMs: number,
@@ -11,7 +18,7 @@ export function withTimeout<T>(
 
 	const timeoutPromise = new Promise<never>((_, reject) => {
 		timeoutId = window.setTimeout(() => {
-			reject(new Error(errorMessage));
+			reject(new TimeoutError(errorMessage));
 		}, timeoutMs);
 	});
 


### PR DESCRIPTION
Fixes #5798
