### PR TITLE
Document the video tags behavior when media ends

### DIFF
--- a/packages/docs/docs/html5-video.mdx
+++ b/packages/docs/docs/html5-video.mdx
@@ -210,6 +210,11 @@ export const MyComposition = () => {
 };
 ```
 
+:::note
+When a video ends (and `loop` is not set), the last frame of the video remains visible by default.  
+This is because Remotion mounts a `<video>` tag and sets `ref.currentTime = frame / fps` to synchronize with the timeline. When `currentTime` is set to a value larger than the video's duration, the HTML5 `<video>` element displays the last frame.
+:::
+
 ### `acceptableTimeShiftInSeconds?`<AvailableFrom v="3.2.42" />
 
 In the [Studio](/docs/terminology/studio) or in the [Remotion Player](/docs/player), Remotion will seek the video if it gets too much out of sync with Remotion's internal time - be it due to the video loading or the page being too slow to keep up in real-time. By default, a seek is triggered if `0.45` seconds of time shift is encountered. Using this prop, you can customize the threshold.

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -201,6 +201,11 @@ export const MyComposition = () => {
 };
 ```
 
+:::note
+When a video ends (and `loop` is not set), the last frame of the video remains visible by default.  
+This matches the behavior of [`<Html5Video>`](/docs/html5-video#loop).
+:::
+
 ### `loopVolumeCurveBehavior?`<AvailableFrom v="4.0.354" />
 
 Controls the `frame` which is returned when using the [`volume`](#volume) callback function and adding the [`loop`](#loop) attribute.

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -320,6 +320,11 @@ If you don't care about color accuracy, you can set `toneMapped` to `false` as w
 Unlike [`<Html5Video>`](/docs/html5-video), `OffthreadVideo` does not implement the `loop` property.  
 Consider using [another video tag](/docs/video-tags) for looping.
 
+:::note
+When a video ends, the last frame of the video remains visible by default.  
+This matches the behavior of [`<Html5Video>`](/docs/html5-video#loop).
+:::
+
 You can use the following `<LoopableOffthreadVideo>` component that uses [`@remotion/media-parser`](/docs/media-parser/) to loop a video.
 
 ```tsx twoslash title="src/LoopableOffthreadVideo.tsx"


### PR DESCRIPTION
For these video tags in packages:
- `remotion`: Html5Video, OffthreadVideo
- `@remotion/media`: Video

Document the default behavior when video ends. 
It always will show the last frame by default.

Why? 

Because in preview we mount a HTML5 video tag, and then we set ref.currentTime = frame / fps.

In `@remotion/media`, we don't use HTML5 video. However, the new video tag will follow the same behavior as we advertise it as a drop-in-replacement.
