### PR TITLE
`@remotion/media`: fix race condition when seeking outside of the video bounds

### DIFF
--- a/packages/media/src/video/media-player.ts
+++ b/packages/media/src/video/media-player.ts
@@ -307,6 +307,9 @@ export class MediaPlayer {
 		});
 
 		if (newTime === null) {
+			// invalidate in-flight video operations
+			this.videoAsyncId++;
+			this.nextFrame = null;
 			this.clearCanvas();
 			await this.cleanAudioIteratorAndNodes();
 			return;


### PR DESCRIPTION
Fixes #5779
