### PR TITLE
Docs: Add shadcn/ui theme compatibility FAQ to Editor Starter docs

### DIFF
--- a/packages/docs/docs/editor-starter/faq.mdx
+++ b/packages/docs/docs/editor-starter/faq.mdx
@@ -36,6 +36,14 @@ We also provide copy-pasteable backend endpoints for Next.js.
 
 Read the [Setup](/docs/editor-starter/setup) and [Dependencies](/docs/editor-starter/dependencies) sections to get a better idea of how to integrate the Editor Starter into your existing project.
 
+## Will the Editor Starter conflict with my existing shadcn/ui theme?
+
+If your project already uses shadcn/ui with custom theme configuration, conflicts are unlikely unless you've made external modifications to your Tailwind theme.
+
+The Editor Starter uses some shadcn components but doesn't include a custom theme implementation. Since the Editor Starter has minimal CSS variables defined, integration should be relatively straightforward.
+
+Potential issues primarily arise only if you've customized Tailwind's theme configuration outside of standard approaches.
+
 ## Feature X is missing, can you add it?
 
 Don't assume that we will add features, even crucial ones, to the Editor Starter that are not listed in the [Features](/docs/editor-starter/features) section.  


### PR DESCRIPTION
Add FAQ entry clarifying that the Editor Starter uses shadcn components but doesn't include a custom theme, addressing potential theme conflicts when integrating with existing projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
