### PR TITLE
`@remotion/media`: Graduate to stable

### DIFF
--- a/packages/docs/docs/media/audio.mdx
+++ b/packages/docs/docs/media/audio.mdx
@@ -9,13 +9,6 @@ This is documentation for the new `<Audio>` tag.
 Not to be confused with the older [`<Html5Audio>` / `<Audio>`](/docs/html5-audio) tag from `remotion`.
 :::
 
-:::warning
-**Experimental**: This component is in beta.
-Use [`<Html5Audio />`](/docs/html5-audio) for the most stable experience, but give us feedback on this component.
-
-See the [progress of this component on our issue tracker](https://github.com/remotion-dev/remotion/issues/5650).
-:::
-
 This component imports and displays a video, similar to [`<Html5Audio />`](/docs/html5-audio) from `remotion` but during rendering, extracts the exact audio using [Mediabunny](/docs/mediabunny) instead of FFmpeg.
 
 ## Example

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -9,13 +9,6 @@ This is documentation for the new `<Video>` tag.
 Not to be confused with the older [`<Html5Video>` / `<Video>`](/docs/html5-video) tag from `remotion`.
 :::
 
-:::warning
-**Experimental**: This component is in beta.
-Use [`<OffthreadVideo />`](/docs/offthreadvideo) for the most stable experience, but give us feedback on this component.
-
-See the [progress of this component on our issue tracker](https://github.com/remotion-dev/remotion/issues/5650).
-:::
-
 This component imports and displays a video, similar to [`<OffthreadVideo/>`](/docs/offthreadvideo) but during rendering, extracts the exact frame from the video using [Mediabunny](/docs/mediabunny) and displays it in a `<canvas>` tag.
 
 This component has [native buffering support](/docs/player/buffer-state) enabled by default. When used in the Player, it automatically pauses playback when buffering and resumes when ready.


### PR DESCRIPTION
We now think this is pretty usable.

While we look for user feedback still, the API is stable and we think there are no dealbreaking issues.

https://www.remotion.dev/docs/media/video
https://www.remotion.dev/docs/media/audio