### PR TITLE
Find and handle YouTube embeds

### DIFF
--- a/packages/docs/blog/2022-11-09-seed-funding.mdx
+++ b/packages/docs/blog/2022-11-09-seed-funding.mdx
@@ -16,7 +16,7 @@ We are delighted to announce that we have raised 180'000 Swiss Francs from Remot
 <iframe style={{
   width: '100%',
   aspectRatio: '16 / 9'
-}} src="https://www.youtube.com/embed/AZinzRlATJo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+}} src="https://www.youtube.com/embed/AZinzRlATJo" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
 
 With our first funding, we will make it easier for you to programmatically create videos and video apps. We'll introduce new components, templates and tools to help you build more with less code.
 

--- a/packages/docs/blog/2023-07-03-remotion-4-0.mdx
+++ b/packages/docs/blog/2023-07-03-remotion-4-0.mdx
@@ -19,9 +19,8 @@ With Remotion 4.0, we offer significant improvements to every workflow.
   }}
   src="https://www.youtube.com/embed/S3C9wlPNhkQ"
   title="YouTube video player"
-  frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 ></iframe>
 
 <br />

--- a/packages/docs/blog/2025-05-20-media-parser.mdx
+++ b/packages/docs/blog/2025-05-20-media-parser.mdx
@@ -21,9 +21,8 @@ We're taking video even more seriously with our own multimedia library, designed
   }}
   src="https://www.youtube.com/embed/r3dUGdfVnkM"
   title="YouTube video player"
-  frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 <br />
 

--- a/packages/docs/blog/2025-08-21-editor-starter.mdx
+++ b/packages/docs/blog/2025-08-21-editor-starter.mdx
@@ -20,9 +20,8 @@ Today, we're launching the Editor Starter, a paid template for building your own
   }}
   src="https://www.youtube.com/embed/KwMMm1n3giU"
   title="YouTube video player"
-  frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 <br />
 <br />

--- a/packages/docs/docs/editor-starter/index.mdx
+++ b/packages/docs/docs/editor-starter/index.mdx
@@ -27,9 +27,8 @@ import {TableOfContents} from './TableOfContents';
   }}
   src="https://www.youtube.com/embed/KwMMm1n3giU"
   title="YouTube video player"
-  frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 <br />
 

--- a/packages/docs/docs/media-parser/index.mdx
+++ b/packages/docs/docs/media-parser/index.mdx
@@ -42,9 +42,8 @@ Design goals:
   }}
   src="https://www.youtube.com/embed/r3dUGdfVnkM"
   title="YouTube video player"
-  frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 <br />
 


### PR DESCRIPTION
Removed deprecated `frameborder` attribute and changed `allowfullscreen` to `allowFullScreen` (camelCase) in all YouTube iframe embeds across documentation.

This fixes issue #5883 by ensuring all iframe elements use proper React/JSX attribute naming conventions instead of legacy HTML attributes.

Changes:
- Removed `frameborder="0"` (deprecated HTML attribute)
- Changed `allowfullscreen` to `allowFullScreen` (React requires camelCase)

Affected files:
- packages/docs/docs/media-parser/index.mdx
- packages/docs/docs/editor-starter/index.mdx
- packages/docs/blog/2025-05-20-media-parser.mdx
- packages/docs/blog/2025-08-21-editor-starter.mdx
- packages/docs/blog/2023-07-03-remotion-4-0.mdx
- packages/docs/blog/2022-11-09-seed-funding.mdx

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
