### PR TITLE
`@remotion/media`: Fix buffer state triggering incorrectly during big and rapid seeks

### DIFF
--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -149,7 +149,7 @@ export const audioIteratorManager = ({
 			}
 		} catch (e) {
 			if (e instanceof InputDisposedError) {
-				// iterator was disposed by a newer startAudioIteerator call
+				// iterator was disposed by a newer startAudioIterator call
 				// this is expected during rapid seeking
 				return;
 			}


### PR DESCRIPTION
Fixes #5892
