### PR TITLE
return null for timestamp outside start and end bounds

### DIFF
--- a/packages/media/src/video-extraction/keyframe-bank.ts
+++ b/packages/media/src/video-extraction/keyframe-bank.ts
@@ -141,19 +141,11 @@ export const makeKeyframeBank = ({
 		lastUsed = Date.now();
 
 		if (timestampInSeconds < startTimestampInSeconds) {
-			return Promise.reject(
-				new Error(
-					`Timestamp is before start timestamp (requested: ${timestampInSeconds}sec, start: ${startTimestampInSeconds})`,
-				),
-			);
+			return null;
 		}
 
 		if (timestampInSeconds > endTimestampInSeconds) {
-			return Promise.reject(
-				new Error(
-					`Timestamp is after end timestamp (requested: ${timestampInSeconds}sec, end: ${endTimestampInSeconds})`,
-				),
-			);
+			return null;
 		}
 
 		await ensureEnoughFramesForTimestamp(timestampInSeconds);


### PR DESCRIPTION
Gracefully return `null` rather than throwing an error if timestamp input passed to `getFrameFromTimestamp` is outside the start and end bounds.

This addresses fatal errors of the following form, which are occurring over 10x per hour on our production site (app.videogen.io):

```
Timestamp is before start timestamp (requested: 1.5333333333333332sec, start: 1.5333333333333334)
    at getFrameFromTimestamp (https://remotionlambda-useast1-6078qr2mcj.s3.us-east-1.amazonaws.com/sites/videogen-prod/bundle.js:70883:29)
    at https://remotionlambda-useast1-6078qr2mcj.s3.us-east-1.amazonaws.com/sites/videogen-prod/bundle.js:70938:32
    at async extractFrameInternal (https://remotionlambda-useast1-6078qr2mcj.s3.us-east-1.amazonaws.com/sites/videogen-prod/bundle.js:71595:17)
```

Looks like the errors are always within a slight floating point error, so I could be open to change this to instead have a `1e-10` threshold. However, based on the return type and the behavior of the rest of the function, it does seem expected that it would return `null` for any value outside of the start and end bounds.