### PR TITLE
`@remotion/media`: fix choppy audio when unpausing playback

### DIFF
--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -339,19 +339,6 @@ export class MediaPlayer {
 			return;
 		}
 
-		if (!this.playing) {
-			const newAudioSyncAnchor =
-				this.sharedAudioContext.currentTime -
-				newTime / (this.playbackRate * this.globalPlaybackRate);
-			const diff = Math.abs(newAudioSyncAnchor - this.audioSyncAnchor);
-			if (diff > 0.04) {
-				this.setPlaybackTime(
-					newTime,
-					this.playbackRate * this.globalPlaybackRate,
-				);
-			}
-		}
-
 		await this.videoIteratorManager?.seek({
 			newTime,
 			nonce,


### PR DESCRIPTION
There was a drift correction mechanism in `seekTo()` that would reset the audioSyncAnchor when detecting >0.04s difference. This was causing a race 
condition when unpausing:

1. `play()` sets audioSyncAnchor for the current time
2. `seekTo()` gets called as frames advance (1-2 frames = 0.04-0.08s later)
3. Drift detection triggers and resets audioSyncAnchor again
4. This disrupts the already-scheduled audio chunks, causing glitches

The fix: Only apply drift correction when paused. During playback, the audioSyncAnchor set by `play()` should remain stable. The drift correction is still needed for scrubbing while paused, but not for normal frame 
advancement during playback

This fixes #5926 