### PR TITLE
`@remotion/web-renderer`: Prevent conflict between `<Player>` and web render

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2022,6 +2022,7 @@
       },
       "devDependencies": {
         "@remotion/eslint-config-internal": "workspace:*",
+        "@remotion/player": "workspace:*",
         "@vitejs/plugin-react": "^5.1.0",
         "@vitest/browser-webdriverio": "4.0.7",
         "eslint": "catalog:",

--- a/packages/core/src/RemotionRoot.tsx
+++ b/packages/core/src/RemotionRoot.tsx
@@ -1,7 +1,6 @@
 import React, {useEffect, useMemo, useState} from 'react';
 import {EditorPropsProvider} from './EditorProps.js';
 import {RenderAssetManagerProvider} from './RenderAssetManager.js';
-import {ResolveCompositionConfig} from './ResolveCompositionConfig.js';
 import {SequenceManagerProvider} from './SequenceManager.js';
 import {TimelineContextProvider} from './TimelineContext.js';
 import {SharedAudioContextProvider} from './audio/shared-audio-tags.js';
@@ -87,16 +86,14 @@ export const RemotionRoot: React.FC<{
 								<PrefetchProvider>
 									<SequenceManagerProvider>
 										<RenderAssetManagerProvider>
-											<ResolveCompositionConfig>
-												<SharedAudioContextProvider
-													numberOfAudioTags={numberOfAudioTags}
-													audioLatencyHint={audioLatencyHint}
-												>
-													<DurationsContextProvider>
-														<BufferingProvider>{children}</BufferingProvider>
-													</DurationsContextProvider>
-												</SharedAudioContextProvider>
-											</ResolveCompositionConfig>
+											<SharedAudioContextProvider
+												numberOfAudioTags={numberOfAudioTags}
+												audioLatencyHint={audioLatencyHint}
+											>
+												<DurationsContextProvider>
+													<BufferingProvider>{children}</BufferingProvider>
+												</DurationsContextProvider>
+											</SharedAudioContextProvider>
 										</RenderAssetManagerProvider>
 									</SequenceManagerProvider>
 								</PrefetchProvider>

--- a/packages/core/src/ResolveCompositionConfig.tsx
+++ b/packages/core/src/ResolveCompositionConfig.tsx
@@ -414,9 +414,7 @@ export const ResolveCompositionConfig: React.FC<
 export const useResolvedVideoConfig = (
 	preferredCompositionId: string | null,
 ): VideoConfigState | null => {
-	const context = useContext(
-		ResolveCompositionContext,
-	) as ResolveCompositionConfigContect;
+	const context = useContext(ResolveCompositionContext);
 	const {props: allEditorProps} = useContext(EditorPropsContext);
 
 	const {compositions, canvasContent, currentCompositionMetadata} =
@@ -494,7 +492,7 @@ export const useResolvedVideoConfig = (
 			};
 		}
 
-		if (!context[composition.id]) {
+		if (!context || !context[composition.id]) {
 			return null;
 		}
 

--- a/packages/core/src/test/composition-rules.test.tsx
+++ b/packages/core/src/test/composition-rules.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {Composition} from '../Composition.js';
 import {CompositionManagerProvider} from '../CompositionManagerProvider.js';
 import {RemotionRoot} from '../RemotionRoot.js';
+import {ResolveCompositionConfig} from '../ResolveCompositionConfig.js';
 import {expectToThrow} from './expect-to-throw.js';
 
 afterEach(() => {
@@ -65,22 +66,24 @@ describe('Render composition-rules should throw with invalid props', () => {
 							logLevel="info"
 							audioLatencyHint="interactive"
 						>
-							<Composition
-								lazyComponent={() => Promise.resolve({default: AnyComp})}
-								durationInFrames={100}
-								fps={30}
-								height={100}
-								width={100}
-								id="id"
-							/>
-							<Composition
-								lazyComponent={() => Promise.resolve({default: AnyComp})}
-								durationInFrames={100}
-								fps={30}
-								height={100}
-								width={100}
-								id="id"
-							/>
+							<ResolveCompositionConfig>
+								<Composition
+									lazyComponent={() => Promise.resolve({default: AnyComp})}
+									durationInFrames={100}
+									fps={30}
+									height={100}
+									width={100}
+									id="id"
+								/>
+								<Composition
+									lazyComponent={() => Promise.resolve({default: AnyComp})}
+									durationInFrames={100}
+									fps={30}
+									height={100}
+									width={100}
+									id="id"
+								/>
+							</ResolveCompositionConfig>
 						</RemotionRoot>
 					</CompositionManagerProvider>,
 				),

--- a/packages/renderer/src/test/get-assets-for-markup.tsx
+++ b/packages/renderer/src/test/get-assets-for-markup.tsx
@@ -122,13 +122,15 @@ export const getAssetsForMarkup = async (
 						logLevel="info"
 						audioLatencyHint="interactive"
 					>
-						<Internals.CompositionManager.Provider value={value}>
-							<Internals.RenderAssetManager.Provider value={assetContext}>
-								<Internals.ResolveCompositionConfig>
-									<Markup />
-								</Internals.ResolveCompositionConfig>
-							</Internals.RenderAssetManager.Provider>
-						</Internals.CompositionManager.Provider>
+						<Internals.ResolveCompositionConfig>
+							<Internals.CompositionManager.Provider value={value}>
+								<Internals.RenderAssetManager.Provider value={assetContext}>
+									<Internals.ResolveCompositionConfig>
+										<Markup />
+									</Internals.ResolveCompositionConfig>
+								</Internals.RenderAssetManager.Provider>
+							</Internals.CompositionManager.Provider>
+						</Internals.ResolveCompositionConfig>
 					</Internals.RemotionRoot>
 				</Internals.CompositionManagerProvider>
 			</Internals.CanUseRemotionHooksProvider>

--- a/packages/studio/src/Studio.tsx
+++ b/packages/studio/src/Studio.tsx
@@ -33,15 +33,17 @@ export const Studio: React.FC<{
 				numberOfAudioTags={window.remotion_numberOfAudioTags}
 				audioLatencyHint={window.remotion_audioLatencyHint ?? 'interactive'}
 			>
-				<EditorContexts readOnlyStudio={readOnly}>
-					<Editor readOnlyStudio={readOnly} Root={rootComponent} />
-					{readOnly
-						? null
-						: createPortal(
-								<ServerDisconnected />,
-								getServerDisconnectedDomElement() as HTMLElement,
-							)}
-				</EditorContexts>
+				<Internals.ResolveCompositionConfig>
+					<EditorContexts readOnlyStudio={readOnly}>
+						<Editor readOnlyStudio={readOnly} Root={rootComponent} />
+						{readOnly
+							? null
+							: createPortal(
+									<ServerDisconnected />,
+									getServerDisconnectedDomElement() as HTMLElement,
+								)}
+					</EditorContexts>
+				</Internals.ResolveCompositionConfig>
 			</Internals.RemotionRoot>
 		</Internals.CompositionManagerProvider>
 	);

--- a/packages/studio/src/renderEntry.tsx
+++ b/packages/studio/src/renderEntry.tsx
@@ -251,8 +251,10 @@ const renderContent = (Root: React.FC) => {
 					numberOfAudioTags={0}
 					audioLatencyHint={window.remotion_audioLatencyHint ?? 'interactive'}
 				>
-					<Root />
-					<GetVideoComposition state={bundleMode} />
+					<Internals.ResolveCompositionConfig>
+						<Root />
+						<GetVideoComposition state={bundleMode} />
+					</Internals.ResolveCompositionConfig>
 				</Internals.RemotionRoot>
 			</Internals.CompositionManagerProvider>
 		);
@@ -276,7 +278,9 @@ const renderContent = (Root: React.FC) => {
 					numberOfAudioTags={0}
 					audioLatencyHint={window.remotion_audioLatencyHint ?? 'interactive'}
 				>
-					<Root />
+					<Internals.ResolveCompositionConfig>
+						<Root />
+					</Internals.ResolveCompositionConfig>
 				</Internals.RemotionRoot>
 			</Internals.CompositionManagerProvider>
 		);

--- a/packages/web-renderer/package.json
+++ b/packages/web-renderer/package.json
@@ -19,6 +19,7 @@
 	},
 	"devDependencies": {
 		"@remotion/eslint-config-internal": "workspace:*",
+		"@remotion/player": "workspace:*",
 		"@vitejs/plugin-react": "^5.1.0",
 		"@vitest/browser-webdriverio": "4.0.7",
 		"eslint": "catalog:",

--- a/packages/web-renderer/src/render-still-on-web.tsx
+++ b/packages/web-renderer/src/render-still-on-web.tsx
@@ -60,6 +60,7 @@ const internalRenderStillOnWeb = async ({
 	// TODO: Env variables
 	// TODO: Input Props
 	// TODO: Default props
+	// TODO: getInputProps()
 	// TODO: calculateMetadata()
 	// TODO: getRemotionEnvironment()
 	// TODO: delayRender()
@@ -125,13 +126,10 @@ const internalRenderStillOnWeb = async ({
 					]}
 				>
 					<Internals.RemotionRoot
-						// TODO: Hardcoded
 						audioEnabled={false}
-						// TODO: Hardcoded
 						videoEnabled
 						logLevel={logLevel}
 						numberOfAudioTags={0}
-						// TODO: Hardcoded
 						audioLatencyHint="interactive"
 						frameState={{
 							[COMP_ID]: frame,
@@ -146,7 +144,6 @@ const internalRenderStillOnWeb = async ({
 		</Internals.RemotionEnvironmentContext>,
 	);
 
-	// TODO: Scope cancelRender()
 	await waitForReady(delayRenderTimeoutInMilliseconds, delayRenderScope);
 	const canvasElements = findCanvasElements(div);
 	const svgElements = findSvgElements(div);

--- a/packages/web-renderer/src/test/player-false-positive.test.tsx
+++ b/packages/web-renderer/src/test/player-false-positive.test.tsx
@@ -1,0 +1,54 @@
+import {Player} from '@remotion/player';
+import {flushSync} from 'react-dom';
+import {createRoot} from 'react-dom/client';
+import {useRemotionEnvironment} from 'remotion';
+import {test} from 'vitest';
+import {renderStillOnWeb} from '../render-still-on-web';
+
+const MustBePlayer: React.FC = () => {
+	const {isPlayer} = useRemotionEnvironment();
+	if (!isPlayer) {
+		throw new Error('isPlayer is false');
+	}
+
+	return null;
+};
+
+const MustNotBePlayer: React.FC<Record<string, unknown>> = () => {
+	const {isPlayer} = useRemotionEnvironment();
+	if (isPlayer) {
+		throw new Error('isPlayer is false');
+	}
+
+	return null;
+};
+
+test('should not give a false positive when the player is also mounted', async () => {
+	const player = (
+		<Player
+			acknowledgeRemotionLicense
+			component={MustBePlayer}
+			durationInFrames={30}
+			compositionWidth={100}
+			compositionHeight={100}
+			fps={30}
+			inputProps={{}}
+		/>
+	);
+
+	const div = document.createElement('div');
+	const root = createRoot(div);
+
+	flushSync(() => {
+		root.render(player);
+	});
+
+	await renderStillOnWeb({
+		Component: MustNotBePlayer,
+		width: 100,
+		height: 100,
+		fps: 30,
+		durationInFrames: 30,
+		frame: 20,
+	});
+});


### PR DESCRIPTION
By removing ResolveCompositionConfig
