### PR TITLE
Fixed URL which points to the source code of renderMediaOnLambda()

### DIFF
--- a/packages/docs/docs/lambda/rendermediaonlambda.mdx
+++ b/packages/docs/docs/lambda/rendermediaonlambda.mdx
@@ -430,5 +430,5 @@ A link to the folder in the AWS console where each chunk and render is located.
 
 ## See also
 
-- [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/lambda/src/api/render-media-on-lambda.ts)
+- [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/lambda-client/src/render-media-on-lambda.ts)
 - [getRenderProgress()](/docs/lambda/getrenderprogress)


### PR DESCRIPTION
renderMediaOnLambda comes from lambda/client, previously the GITHUB url was pointing to /lambda/

No issue is there for this in Issues.
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
