### PR TITLE
`@remotion/media`: proper single test for rendering first frame for videos starting after timestamp 0

### DIFF
--- a/packages/media/src/test/video-non-zero-start.test.ts
+++ b/packages/media/src/test/video-non-zero-start.test.ts
@@ -2,14 +2,13 @@ import {assert, expect, test} from 'vitest';
 import {getMaxVideoCacheSize, keyframeManager} from '../caches';
 import {extractFrame} from '../video-extraction/extract-frame';
 
-test('Video frame extraction at timestamp 0 when video starts at 0.15sec', async () => {
+test('Should render first frame for videos starting after timestamp 0', async () => {
 	await keyframeManager.clearAll('info');
 
 	// This video's first video frame is at 0.15 seconds (150ms)
-	// The old tolerance was 0.1 seconds (100ms), which would have thrown an error:
-	// "Timestamp is before start timestamp (requested: 0sec, start: 0.15sec, difference: 0.150sec exceeds tolerance of 0.1sec)"
-	// Now we remove the tolerance check entirely and clamp to the first available frame,
-	// matching Chrome's behavior of rendering the first frame rather than showing black.
+	// Requesting frame at 0sec should clamp to first available frame (0.15s)
+	// Previously would throw: "Timestamp is before start timestamp (requested: 0sec, start: 0.15sec, difference: 0.150sec exceeds tolerance of 0.1sec)"
+	// Now matches Chrome's behavior: render the first frame rather than showing black
 	const result = await extractFrame({
 		src: '/video-start-offset.mp4',
 		timeInSeconds: 0,
@@ -22,97 +21,24 @@ test('Video frame extraction at timestamp 0 when video starts at 0.15sec', async
 		maxCacheSize: getMaxVideoCacheSize('info'),
 	});
 
+	// Should successfully extract (no error thrown)
 	expect(result.type).toBe('success');
 	assert(result.type === 'success');
-
 	assert(result.frame, 'Frame should be returned');
 
+	// Frame should have valid dimensions
 	expect(result.frame.codedWidth).toBe(640);
 	expect(result.frame.codedHeight).toBe(480);
 
-	// IMPORTANT: Frame timestamp should be at video start (0.15s), NOT at requested time (0s)
+	// Frame timestamp should be at video start (0.15s), NOT at requested time (0s)
+	// This proves we're returning the first actual frame
 	expect(result.frame.timestamp).toBeCloseTo(0.15, 2);
 
-	await keyframeManager.clearAll('info');
-});
-
-test('Video frame extraction at exact start timestamp works', async () => {
-	await keyframeManager.clearAll('info');
-
-	const result = await extractFrame({
-		src: '/video-start-offset.mp4',
-		timeInSeconds: 0.15,
-		logLevel: 'info',
-		loop: false,
-		trimAfter: undefined,
-		trimBefore: undefined,
-		playbackRate: 1,
-		fps: 30,
-		maxCacheSize: getMaxVideoCacheSize('info'),
-	});
-
-	expect(result.type).toBe('success');
-	assert(result.type === 'success');
-	assert(result.frame);
-
-	expect(result.frame.timestamp).toBeCloseTo(0.15, 2);
-
-	await keyframeManager.clearAll('info');
-});
-
-test('Video frame extraction slightly before start clamps to first frame', async () => {
-	await keyframeManager.clearAll('info');
-
-	// Requesting at 0.1 (slightly before 0.15) should clamp to 0.15
-	const result = await extractFrame({
-		src: '/video-start-offset.mp4',
-		timeInSeconds: 0.1,
-		logLevel: 'info',
-		loop: false,
-		trimAfter: undefined,
-		trimBefore: undefined,
-		playbackRate: 1,
-		fps: 30,
-		maxCacheSize: getMaxVideoCacheSize('info'),
-	});
-
-	expect(result.type).toBe('success');
-	assert(result.type === 'success');
-	assert(result.frame);
-
-	// Should return first frame at 0.15, not an error
-	expect(result.frame.timestamp).toBeCloseTo(0.15, 2);
-
-	await keyframeManager.clearAll('info');
-});
-
-test('First frame has non-black pixel data', async () => {
-	await keyframeManager.clearAll('info');
-
-	const result = await extractFrame({
-		src: '/video-start-offset.mp4',
-		timeInSeconds: 0,
-		logLevel: 'info',
-		loop: false,
-		trimAfter: undefined,
-		trimBefore: undefined,
-		playbackRate: 1,
-		fps: 30,
-		maxCacheSize: getMaxVideoCacheSize('info'),
-	});
-
-	expect(result.type).toBe('success');
-	assert(result.type === 'success');
-	assert(result.frame);
-
-	// Sample pixel data from the frame to verify it's not completely black
-	// testsrc generates a test pattern with colors, gradients, and timestamp overlay
-	// For a 640x480 video, we need 640 * 480 * 4 bytes for RGBA
+	// Verify frame has pixel data (not completely black)
+	// testsrc generates a test pattern with colors and gradients
 	const bufferSize = result.frame.codedWidth * result.frame.codedHeight * 4;
 	const buffer = new Uint8Array(bufferSize);
 	await result.frame.copyTo(buffer);
-
-	// Check that not all pixels are zero (black)
 	const hasNonZeroPixels = buffer.some((byte) => byte > 0);
 	expect(hasNonZeroPixels).toBe(true);
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
