### PR TITLE
`remotion`: Fix noisy error messages during render (`sync_reader.cc`)

### DIFF
--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import type {LogLevel} from '../log';
 import {Log} from '../log';
+import {useRemotionEnvironment} from '../use-remotion-environment';
 
 let warned = false;
 
@@ -24,7 +25,13 @@ export const useSingletonAudioContext = (
 	logLevel: LogLevel,
 	latencyHint: AudioContextLatencyCategory,
 ) => {
+	const env = useRemotionEnvironment();
+
 	const audioContext = useMemo(() => {
+		if (env.isRendering) {
+			return null;
+		}
+
 		if (typeof AudioContext === 'undefined') {
 			warnOnce(logLevel);
 			return null;
@@ -33,7 +40,7 @@ export const useSingletonAudioContext = (
 		return new AudioContext({
 			latencyHint,
 		});
-	}, [logLevel, latencyHint]);
+	}, [logLevel, latencyHint, env.isRendering]);
 
 	return audioContext;
 };

--- a/packages/renderer/src/browser/should-log-message.ts
+++ b/packages/renderer/src/browser/should-log-message.ts
@@ -67,13 +67,6 @@ export const shouldLogBrowserMessage = (message: string) => {
 		return false;
 	}
 
-	// Noisy warning that appears even though we pass --mute-audio
-	// https://github.com/remotion-dev/remotion/issues/5974
-	// https://github.com/remotion-dev/remotion/issues/5769
-	if (message.includes('ASR: No room in socket buffer.')) {
-		return false;
-	}
-
 	return true;
 };
 


### PR DESCRIPTION
Fixes #5769
Fixes #5974