### PR TITLE
`@remotion/media`: Add `crossOrigin` to fallback props

### DIFF
--- a/packages/docs/docs/media/audio.mdx
+++ b/packages/docs/docs/media/audio.mdx
@@ -233,6 +233,10 @@ Maps to [`<Html5Audio />` -> `acceptableTimeShiftInSeconds`](/docs/html5-audio#a
 
 Maps to [`<Html5Audio />` -> `pauseWhenBuffering`](/docs/html5-audio#pausewhenbuffering)
 
+#### `crossOrigin?`
+
+Maps to [`<Html5Audio />` -> `crossOrigin`](/docs/html5-audio#crossorigin)
+
 ### `disallowFallbackToHtml5Audio?`<AvailableFrom v="3.0.356" />
 
 By default, if the video cannot be embedded using this tag, [a fallback to `<Html5Audio>` from `remotion`](/docs/media/fallback) will be attempted.

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -274,6 +274,10 @@ Maps to [`<OffthreadVideo />` -> `toneMapped`](/docs/offthreadvideo#tonemapped)
 
 Maps to [`<OffthreadVideo />` -> `onError`](/docs/offthreadvideo#onerror)
 
+#### `crossOrigin?`
+
+Maps to [`<OffthreadVideo />` -> `crossOrigin`](/docs/offthreadvideo#crossorigin)
+
 ### `disallowFallbackToOffthreadVideo?`<AvailableFrom v="3.0.356" />
 
 By default, if the video cannot be embedded using this tag, [a fallback to `<OffthreadVideo>`](/docs/media/fallback) will be attempted.

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -436,6 +436,7 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 				toneFrequency={toneFrequency}
 				audioStreamIndex={audioStreamIndex}
 				pauseWhenBuffering={fallbackHtml5AudioProps?.pauseWhenBuffering}
+				crossOrigin={fallbackHtml5AudioProps?.crossOrigin}
 				{...fallbackHtml5AudioProps}
 			/>
 		);

--- a/packages/media/src/audio/props.ts
+++ b/packages/media/src/audio/props.ts
@@ -1,6 +1,7 @@
 import type {LogLevel, LoopVolumeCurveBehavior, VolumeProp} from 'remotion';
 
 export type FallbackHtml5AudioProps = {
+	crossOrigin?: '' | 'anonymous' | 'use-credentials' | undefined;
 	onError?: (err: Error) => void;
 	useWebAudioApi?: boolean;
 	acceptableTimeShiftInSeconds?: number;

--- a/packages/media/src/video/props.ts
+++ b/packages/media/src/video/props.ts
@@ -10,6 +10,7 @@ export type FallbackOffthreadVideoProps = {
 	transparent?: boolean;
 	toneMapped?: boolean;
 	onError?: (err: Error) => void;
+	crossOrigin?: '' | 'anonymous' | 'use-credentials' | undefined;
 };
 
 type MandatoryVideoProps = {


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
