### PR TITLE
`remotion`: Prevent multiple compositions from being rendered

### DIFF
--- a/packages/core/src/Composition.tsx
+++ b/packages/core/src/Composition.tsx
@@ -235,7 +235,12 @@ const InnerComposition = <
 
 	const resolved = useResolvedVideoConfig(id);
 
-	if (environment.isStudio && video && video.component === lazy) {
+	if (
+		environment.isStudio &&
+		video &&
+		video.component === lazy &&
+		video.id === id
+	) {
 		const Comp = lazy;
 		if (
 			resolved === null ||
@@ -260,7 +265,12 @@ const InnerComposition = <
 		);
 	}
 
-	if (environment.isRendering && video && video.component === lazy) {
+	if (
+		environment.isRendering &&
+		video &&
+		video.component === lazy &&
+		video.id === id
+	) {
 		const Comp = lazy;
 		if (
 			resolved === null ||


### PR DESCRIPTION
Multiple compositions which refer to the same component now have the same `lazy` component.
We did not check if the `id` also matched which can result in multiple compositions being rendered.