### PR TITLE
`@remotion/lambda`: Mark as Remotion License under NPM

### DIFF
--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -17,7 +17,7 @@
 		"prepublishOnly": "bun build.ts && bun ensure-version-match.js"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
-	"license": "Remotion License",
+	"license": "SEE LICENSE IN LICENSE.md",
 	"dependencies": {
 		"@aws-sdk/s3-request-presigner": "catalog:",
 		"@aws-sdk/middleware-flexible-checksums": "catalog:",


### PR DESCRIPTION
It has been wrongly flagged as MIT when you visit the NPM page. 

On our docs, it was correct https://www.remotion.dev/docs/lambda#license and it only makes sense as it has a dependency on Remotion License packages and we use this in our pricing.