### PR TITLE
`@remotion/cli`: Correct output on new line when rendering an image sequence

### DIFF
--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -578,7 +578,16 @@ export const renderVideoFlow = async ({
 			onLog,
 		});
 
-		Log.info({indent, logLevel}, chalk.blue(`\n▶ ${absoluteOutputFile}`));
+		if (!updatesDontOverwrite) {
+			updateRenderProgress({newline: true, printToConsole: true});
+		}
+
+		Log.info(
+			{indent, logLevel},
+			chalk.blue(
+				`${(exists ? '○' : '+').padEnd(LABEL_WIDTH)} ${makeHyperlink({url: `file://${absoluteOutputFile}`, text: relativeOutputLocation, fallback: relativeOutputLocation})}`,
+			),
+		);
 		return;
 	}
 


### PR DESCRIPTION
Like when rendering a video