### PR TITLE
`@remotion/media`: Fix rapid block/unblock cycles during video seek

### DIFF
--- a/packages/media/src/test/video-iterator-manager.test.ts
+++ b/packages/media/src/test/video-iterator-manager.test.ts
@@ -1,0 +1,102 @@
+import {ALL_FORMATS, Input, UrlSource} from 'mediabunny';
+import {expect, test} from 'vitest';
+import {makeNonceManager} from '../nonce-manager';
+import {videoIteratorManager} from '../video-iterator-manager';
+
+const prepare = async () => {
+	const input = new Input({
+		source: new UrlSource('https://remotion.media/video.mp4'),
+		formats: ALL_FORMATS,
+	});
+	const videoTrack = await input.getPrimaryVideoTrack();
+	if (!videoTrack) {
+		throw new Error('No video track found');
+	}
+
+	return {videoTrack};
+};
+
+test('seek should not cause overlapping block/unblock cycles', async () => {
+	const {videoTrack} = await prepare();
+
+	let activeBlocks = 0;
+	let maxConcurrentBlocks = 0;
+
+	const manager = videoIteratorManager({
+		videoTrack,
+		delayPlaybackHandleIfNotPremounting: () => {
+			activeBlocks++;
+			maxConcurrentBlocks = Math.max(maxConcurrentBlocks, activeBlocks);
+			return {
+				unblock: () => {
+					activeBlocks--;
+				},
+			};
+		},
+		context: null,
+		canvas: null,
+		getOnVideoFrameCallback: () => null,
+		logLevel: 'error',
+		drawDebugOverlay: () => {},
+	});
+
+	const nonceManager = makeNonceManager();
+
+	// Initialize the iterator first
+	await manager.startVideoIterator(0, nonceManager.createAsyncOperation());
+
+	// Perform seeks that will trigger 'not-satisfied' (jumping around)
+	// These should NOT cause overlapping blocks
+	await manager.seek({newTime: 5, nonce: nonceManager.createAsyncOperation()});
+	await manager.seek({newTime: 0, nonce: nonceManager.createAsyncOperation()});
+	await manager.seek({newTime: 8, nonce: nonceManager.createAsyncOperation()});
+
+	// With the fix, max concurrent blocks should be 1
+	// Before the fix (fire-and-forget), it could be > 1
+	expect(maxConcurrentBlocks).toBe(1);
+	expect(activeBlocks).toBe(0); // All blocks should be released
+});
+
+test('rapid sequential seeks should not cause overlapping blocks', async () => {
+	const {videoTrack} = await prepare();
+
+	let activeBlocks = 0;
+	let maxConcurrentBlocks = 0;
+
+	const manager = videoIteratorManager({
+		videoTrack,
+		delayPlaybackHandleIfNotPremounting: () => {
+			activeBlocks++;
+			maxConcurrentBlocks = Math.max(maxConcurrentBlocks, activeBlocks);
+			return {
+				unblock: () => {
+					activeBlocks--;
+				},
+			};
+		},
+		context: null,
+		canvas: null,
+		getOnVideoFrameCallback: () => null,
+		logLevel: 'error',
+		drawDebugOverlay: () => {},
+	});
+
+	const nonceManager = makeNonceManager();
+
+	// Initialize the iterator first
+	await manager.startVideoIterator(0, nonceManager.createAsyncOperation());
+
+	// Perform many rapid seeks - simulating scrubbing through video
+	for (let i = 0; i < 10; i++) {
+		// Alternate between distant positions to force iterator recreation
+		const time = i % 2 === 0 ? i * 0.5 : 9 - i * 0.5;
+		await manager.seek({
+			newTime: time,
+			nonce: nonceManager.createAsyncOperation(),
+		});
+	}
+
+	// With the fix, max concurrent blocks should be 1
+	expect(maxConcurrentBlocks).toBe(1);
+	expect(activeBlocks).toBe(0);
+});


### PR DESCRIPTION
## Summary


- Fix spinner flickering caused by overlapping block/unblock cycles when seeking video 
- Move playback blocking logic from `startVideoIterator` to the `seek` level, ensuring only one block/unblock 
cycle per seek operation

## Problem

When seeking through video, if `tryToSatisfySeek` returned `'not-satisfied'`, `startVideoIterator` was called fire-and-forget with its own internal block/unblock. Multiple rapid seeks caused overlapping block/unblock cycles, resulting in spinner flickering.

## Solution

- Split `startVideoIterator` into `startVideoIteratorWithoutBlocking` (core logic) and `startVideoIterator` (with blocking wrapper)
- `seek` now manages blocking at its level - only blocks when a new iterator is actually needed
- No blocking when frame is already available (`'satisfied'` path)
## Testing

Added `video-iterator-manager.test.ts` with tests verifying `maxConcurrentBlocks === 1` during rapid seeking.
