### PR TITLE
`@remotion/media-utils`: Fix delayRender never unblocking in `useWindowedAudioData` when audio ends

### DIFF
--- a/packages/media-utils/src/use-windowed-audio-data.ts
+++ b/packages/media-utils/src/use-windowed-audio-data.ts
@@ -362,8 +362,16 @@ export const useWindowedAudioData = ({
 		};
 	}, [src, waveFormMap, audioUtils?.metadata, availableWindows]);
 
+	const isBeyondAudioDuration = audioUtils
+		? currentTime >= audioUtils.metadata.durationInSeconds
+		: false;
+
 	useLayoutEffect(() => {
 		if (currentAudioData) {
+			return;
+		}
+
+		if (isBeyondAudioDuration) {
 			return;
 		}
 
@@ -373,11 +381,13 @@ export const useWindowedAudioData = ({
 		return () => {
 			continueRender(handle);
 		};
-	}, [currentAudioData, src, delayRender, continueRender]);
-
-	const isBeyondAudioDuration = audioUtils
-		? currentTime >= audioUtils.metadata.durationInSeconds
-		: false;
+	}, [
+		currentAudioData,
+		src,
+		delayRender,
+		continueRender,
+		isBeyondAudioDuration,
+	]);
 
 	const audioData = isBeyondAudioDuration ? null : currentAudioData;
 


### PR DESCRIPTION
## Summary
- Fix `useWindowedAudioData` hanging indefinitely when `currentTime` exceeds audio duration
## Problem
When `currentTime >= audioUtils.metadata.durationInSeconds`, `currentAudioData` would be `null` (as expected), but `delayRender` was still being called. Since audio data is never going to load for a time beyond the audio's duration, `continueRender` was never called, causing the render to hang forever.
## Solution
Check if we're beyond the audio duration *before* calling `delayRender`. If `currentTime` is past the end of the audio, we skip the delay since there's no audio data to wait for.
