### PR TITLE
`@remotion/media`: Fix initial `trimBefore` value causing player to initialize twice

### DIFF
--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -360,6 +360,10 @@ export class MediaPlayer {
 	}
 
 	public async play(time: number): Promise<void> {
+		if (this.playing) {
+			return;
+		}
+
 		const newTime = getTimeInSeconds({
 			unloopedTimeInSeconds: time,
 			playbackRate: this.playbackRate,
@@ -403,6 +407,10 @@ export class MediaPlayer {
 	};
 
 	public pause(): void {
+		if (!this.playing) {
+			return;
+		}
+
 		this.playing = false;
 		this.audioIteratorManager?.pausePlayback();
 


### PR DESCRIPTION
…nitialize twice

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
