### PR TITLE
`@remotion/web-renderer`: Fix AudioData size mismatch for single audio sources

### DIFF
--- a/packages/web-renderer/src/audio.ts
+++ b/packages/web-renderer/src/audio.ts
@@ -10,6 +10,11 @@ function mixAudio(waves: Int16Array[], length: number) {
 
 	const mixed = new Int16Array(length);
 
+	if (waves.length === 1) {
+		mixed.set(waves[0].subarray(0, length));
+		return mixed;
+	}
+
 	for (let i = 0; i < length; i++) {
 		const sum = waves.reduce((acc, wave) => {
 			return acc + (wave[i] ?? 0);


### PR DESCRIPTION
## Summary
- Fix "Failed to construct 'AudioData': data is too small" error when rendering videos with single audio sources (e.g., WAV files)
## The Problem
When rendering with a single audio source, the `mixAudio` function in `audio.ts` had an optimization that returned the original input array directly. However, this bypassed length normalization, causing the `AudioData` constructor to fail when the extracted audio had slightly fewer samples than expected due to floating-point rounding during resampling.
## The Fix
Added a length check to the single-wave optimization path, ensuring we only return the original array when it already has the exact expected length. Otherwise, we create a properly-sized array with correct padding.
