### PR TITLE
`@remotion/player`: Revert PR #6087 (multiple frameRef fix)

### DIFF
--- a/packages/core/src/TimelineContext.tsx
+++ b/packages/core/src/TimelineContext.tsx
@@ -1,4 +1,4 @@
-import type {MutableRefObject, RefObject} from 'react';
+import type {MutableRefObject} from 'react';
 import React, {
 	createContext,
 	useLayoutEffect,
@@ -15,7 +15,6 @@ import {useDelayRender} from './use-delay-render';
 
 export type TimelineContextValue = {
 	frame: Record<string, number>;
-	frameRef: RefObject<number>;
 	playing: boolean;
 	rootId: string;
 	playbackRate: number;
@@ -40,7 +39,6 @@ export const SetTimelineContext = createContext<SetTimelineContextValue>({
 
 export const TimelineContext = createContext<TimelineContextValue>({
 	frame: {},
-	frameRef: {current: 0},
 	playing: false,
 	playbackRate: 1,
 	rootId: '',
@@ -68,7 +66,6 @@ export const TimelineContextProvider: React.FC<{
 	);
 
 	const frame = frameState ?? _frame;
-	const frameRef = useRef<number>(0);
 
 	const {delayRender, continueRender} = useDelayRender();
 
@@ -116,7 +113,6 @@ export const TimelineContextProvider: React.FC<{
 			playbackRate,
 			setPlaybackRate,
 			audioAndVideoTags,
-			frameRef,
 		};
 	}, [frame, playbackRate, playing, remotionRootId]);
 

--- a/packages/core/src/test/nested-sequences.test.tsx
+++ b/packages/core/src/test/nested-sequences.test.tsx
@@ -13,7 +13,6 @@ const getForFrame = (frame: number, content: React.ReactNode) => {
 		<WrapSequenceContext>
 			<TimelineContext.Provider
 				value={{
-					frameRef: {current: frame},
 					frame: {
 						'my-comp': frame,
 					},

--- a/packages/core/src/test/series.test.tsx
+++ b/packages/core/src/test/series.test.tsx
@@ -34,7 +34,6 @@ const renderForFrame = (frame: number, markup: React.ReactNode) => {
 		<CanUseRemotionHooksProvider>
 			<TimelineContext.Provider
 				value={{
-					frameRef: {current: frame},
 					rootId: '',
 					frame: {
 						'my-comp': frame,

--- a/packages/core/src/timeline-position-state.ts
+++ b/packages/core/src/timeline-position-state.ts
@@ -1,4 +1,4 @@
-import type {MutableRefObject, RefObject} from 'react';
+import type {MutableRefObject} from 'react';
 import {useContext, useMemo} from 'react';
 import {SetTimelineContext, TimelineContext} from './TimelineContext.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
@@ -56,11 +56,6 @@ export const useTimelinePosition = (): number => {
 		(env.isPlayer ? 0 : getFrameForComposition(videoConfig.id));
 
 	return Math.min(videoConfig.durationInFrames - 1, unclamped);
-};
-
-export const useTimelineFrameRef = (): RefObject<number> => {
-	const {frameRef} = useContext(TimelineContext);
-	return frameRef;
 };
 
 export const useTimelineSetFrame = (): ((

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -351,7 +351,6 @@ const PlayerFn = <
 	const timelineContextValue = useMemo((): TimelineContextValue => {
 		return {
 			frame,
-			frameRef: {current: frame[PLAYER_COMP_ID]},
 			playing,
 			rootId,
 			playbackRate: currentPlaybackRate,

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -81,7 +81,6 @@ const ThumbnailFn = <
 
 	const timelineState: TimelineContextValue = useMemo(() => {
 		const value: TimelineContextValue = {
-			frameRef: {current: frameToDisplay},
 			playing: false,
 			frame: {
 				[PLAYER_COMP_ID]: frameToDisplay,

--- a/packages/player/src/use-frame-imperative.ts
+++ b/packages/player/src/use-frame-imperative.ts
@@ -1,14 +1,17 @@
-import {useCallback} from 'react';
+import {useCallback, useRef} from 'react';
 import {Internals} from 'remotion';
 
 export type GetCurrentFrame = () => number;
 
 export const useFrameImperative = (): GetCurrentFrame => {
-	const frameRef = Internals.Timeline.useTimelineFrameRef();
+	const frame = Internals.Timeline.useTimelinePosition();
+
+	const frameRef = useRef<number>(frame);
+	frameRef.current = frame;
 
 	const getCurrentFrame = useCallback(() => {
 		return frameRef.current;
-	}, [frameRef]);
+	}, []);
 
 	return getCurrentFrame;
 };

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -27,7 +27,8 @@ export const usePlayback = ({
 }) => {
 	const config = Internals.useUnsafeVideoConfig();
 	const frame = Internals.Timeline.useTimelinePosition();
-	const {playing, pause, emitter, setFrameAndImperative} = usePlayer();
+	const {playing, pause, emitter} = usePlayer();
+	const setFrame = Internals.Timeline.useTimelineSetFrame();
 
 	// requestAnimationFrame() does not work if the tab is not active.
 	// This means that audio will keep playing even if it has ended.
@@ -116,7 +117,7 @@ export const usePlayback = ({
 				nextFrame !== getCurrentFrame() &&
 				(!hasEnded || moveToBeginningWhenEnded)
 			) {
-				setFrameAndImperative(nextFrame, config.id);
+				setFrame((c) => ({...c, [config.id]: nextFrame}));
 			}
 
 			if (hasEnded) {
@@ -176,7 +177,7 @@ export const usePlayback = ({
 		loop,
 		pause,
 		playing,
-		setFrameAndImperative,
+		setFrame,
 		emitter,
 		playbackRate,
 		inFrame,

--- a/packages/test-utils/src/timeline-context.ts
+++ b/packages/test-utils/src/timeline-context.ts
@@ -3,7 +3,6 @@ import {ID} from './id.js';
 
 export const makeTimelineContext = (frame: number): TimelineContextValue => {
 	return {
-		frameRef: {current: frame},
 		rootId: '',
 		frame: {
 			[ID]: frame,


### PR DESCRIPTION
## Summary
- Reverts PR #6087 which introduced a shared `frameRef` to fix multiple internal `frameRef` instances
- This change caused a regression where compositions run at degraded fps because the `frameRef` object was being recreated on every render, causing the playback loop to restart on each frame
Fixes the fps throttling issue reported by consumer apps.