### PR TITLE
`remotion`: Add crossOrigin="anonymous" when rendering an <Img> client-side

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -13,6 +13,7 @@ import {getCrossOriginValue} from './get-cross-origin-value.js';
 import {usePreload} from './prefetch.js';
 import {useBufferState} from './use-buffer-state.js';
 import {useDelayRender} from './use-delay-render.js';
+import {useRemotionEnvironment} from './use-remotion-environment.js';
 
 function exponentialBackoff(errorCount: number): number {
 	return 1000 * 2 ** (errorCount - 1);
@@ -237,9 +238,12 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 		]);
 	}
 
+	const {isClientSideRendering} = useRemotionEnvironment();
+
 	const crossOriginValue = getCrossOriginValue({
 		crossOrigin,
 		requestsVideoFrame: false,
+		isClientSideRendering,
 	});
 
 	// src gets set once we've loaded and decoded the image.

--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -124,6 +124,7 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 	const crossOriginValue = getCrossOriginValue({
 		crossOrigin,
 		requestsVideoFrame: false,
+		isClientSideRendering: false,
 	});
 
 	const propsToPass = useMemo((): AudioHTMLAttributes<HTMLAudioElement> => {

--- a/packages/core/src/get-cross-origin-value.ts
+++ b/packages/core/src/get-cross-origin-value.ts
@@ -1,13 +1,19 @@
 export const getCrossOriginValue = ({
 	crossOrigin,
 	requestsVideoFrame,
+	isClientSideRendering,
 }: {
 	crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined;
 	requestsVideoFrame: boolean;
+	isClientSideRendering: boolean;
 }) => {
 	// If user specifies a value explicitly, use that
 	if (crossOrigin !== undefined && crossOrigin !== null) {
 		return crossOrigin;
+	}
+
+	if (isClientSideRendering) {
+		return 'anonymous';
 	}
 
 	// We need to set anonymous because otherwise we are not allowed

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -312,6 +312,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 	const crossOriginValue = getCrossOriginValue({
 		crossOrigin,
 		requestsVideoFrame: Boolean(onVideoFrame),
+		isClientSideRendering: false,
 	});
 
 	return (


### PR DESCRIPTION
TODOs:

- [ ] Add a test for handling tainted images correctly
- [ ] Mention in docs that there is this difference
- [ ] Ensure good error handling for images which do not support CORS