### PR TITLE
`@remotion/web-renderer`: add `muted` prop to `renderMediaOnWeb`

### DIFF
--- a/packages/studio/src/components/RenderModal/WebRenderModal.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModal.tsx
@@ -10,6 +10,7 @@ import type {
 import {renderMediaOnWeb, renderStillOnWeb} from '@remotion/web-renderer';
 import {useCallback, useContext, useMemo, useState} from 'react';
 import {ShortcutHint} from '../../error-overlay/remotion-overlay/ShortcutHint';
+import {AudioIcon} from '../../icons/audio';
 import {DataIcon} from '../../icons/data';
 import {FileIcon} from '../../icons/file';
 import {PicIcon} from '../../icons/frame';
@@ -40,6 +41,7 @@ import {
 	ResolvedCompositionContext,
 } from './ResolveCompositionBeforeModal';
 import {WebRenderModalAdvanced} from './WebRenderModalAdvanced';
+import {WebRenderModalAudio} from './WebRenderModalAudio';
 import {WebRenderModalBasic} from './WebRenderModalBasic';
 import {WebRenderModalPicture} from './WebRenderModalPicture';
 
@@ -54,7 +56,7 @@ type WebRenderModalProps = {
 
 export type RenderType = 'still' | 'video';
 
-type TabType = 'general' | 'data' | 'picture' | 'advanced';
+type TabType = 'general' | 'data' | 'picture' | 'audio' | 'advanced';
 
 const invalidCharacters = ['?', '*', '+', ':', '%'];
 
@@ -184,6 +186,7 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 	const [renderProgress, setRenderProgress] =
 		useState<RenderMediaOnWebProgress | null>(null);
 	const [transparent, setTransparent] = useState(false);
+	const [muted, setMuted] = useState(false);
 
 	const finalEndFrame = useMemo(() => {
 		if (endFrame === null) {
@@ -451,6 +454,7 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 				setRenderProgress(progress);
 			},
 			transparent,
+			muted,
 			outputTarget: 'web-fs',
 		});
 
@@ -485,6 +489,7 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 		resolvedComposition.fps,
 		outName,
 		transparent,
+		muted,
 		resolvedComposition.defaultProps,
 		resolvedComposition.id,
 		unresolvedComposition.calculateMetadata,
@@ -551,6 +556,18 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 							Picture
 						</VerticalTab>
 					) : null}
+					{renderMode === 'video' ? (
+						<VerticalTab
+							style={horizontalTab}
+							selected={tab === 'audio'}
+							onClick={() => setTab('audio')}
+						>
+							<div style={iconContainer}>
+								<AudioIcon style={icon} />
+							</div>
+							Audio
+						</VerticalTab>
+					) : null}
 					<VerticalTab
 						style={horizontalTab}
 						selected={tab === 'advanced'}
@@ -609,6 +626,8 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 							transparent={transparent}
 							setTransparent={setTransparent}
 						/>
+					) : tab === 'audio' ? (
+						<WebRenderModalAudio muted={muted} setMuted={setMuted} />
 					) : (
 						<WebRenderModalAdvanced
 							renderMode={renderMode}

--- a/packages/studio/src/components/RenderModal/WebRenderModalAudio.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModalAudio.tsx
@@ -1,0 +1,23 @@
+import type React from 'react';
+import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
+import {MutedSetting} from './MutedSetting';
+
+const container: React.CSSProperties = {
+	flex: 1,
+	overflowY: 'auto',
+};
+
+export const WebRenderModalAudio: React.FC<{
+	readonly muted: boolean;
+	readonly setMuted: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({muted, setMuted}) => {
+	return (
+		<div style={container} className={VERTICAL_SCROLLBAR_CLASSNAME}>
+			<MutedSetting
+				enforceAudioTrack={false}
+				muted={muted}
+				setMuted={setMuted}
+			/>
+		</div>
+	);
+};


### PR DESCRIPTION
## Summary

- Add muted option to renderMediaOnWeb() that disables audio encoding
- Add "Audio" tab to the Studio's "Render on web" dialog with the muted checkbox

Fixes #6046 
