### PR TITLE
Test bun install --backend=hardlink on Windows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -160,7 +160,13 @@ jobs:
         with:
           bun-version: 1.3.3
       - name: Install
-        run: bun ci
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            bun ci --backend=hardlink
+          else
+            bun ci
+          fi
+        shell: bash
       - name: Build & Test
         timeout-minutes: 30
         run: |


### PR DESCRIPTION
## Summary

Test performance of `bun install` with `--backend=hardlink` on Windows runners.

This PR adds the `--backend=hardlink` flag to the `bun ci` command on Windows to benchmark installation performance compared to other backend options.

## Test plan

- [ ] Check CI performance on Windows runner
- [ ] Compare installation time with other backend options

🤖 Generated with [Claude Code](https://claude.com/claude-code)