### PR TITLE
Add Bun dependency caching for Windows runners

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -151,6 +151,8 @@ jobs:
             node_version: 16
           - os: macos-latest
             node_version: 25
+    env:
+      BUN_INSTALL_CACHE_DIR: ${{ matrix.os == 'windows-latest' && 'D:\.bun\install\cache' || '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -159,6 +161,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2.0.2
         with:
           bun-version: 1.3.3
+      - name: Cache Bun dependencies (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/cache@v4
+        with:
+          path: D:\.bun\install\cache
+          key: ${{ matrix.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ matrix.os }}-bun-
       - name: Install
         run: bun ci
       - name: Build & Test


### PR DESCRIPTION
## Summary

Add Windows-specific dependency caching to improve CI performance.

This PR implements caching for Bun dependencies on Windows runners, similar to the approach used in other projects:
- Cache path: `D:\.bun\install\cache` (using D: drive to avoid C: drive bottlenecks)
- Cache key based on OS and `bun.lock` hash
- Set `BUN_INSTALL_CACHE_DIR` environment variable to direct Bun to use the cache

## Expected benefits

- Faster `bun install` on Windows runners by reusing cached dependencies
- Reduced network usage and registry requests
- More consistent build times

## Test plan

- [ ] Check CI performance on Windows runner
- [ ] Verify cache is being created and restored correctly
- [ ] Compare installation time with baseline (no cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)