### PR TITLE
`@remotion/web-renderer`: do not report user-cancelled renders to telemetry

### DIFF
--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -464,17 +464,20 @@ const internalRenderMediaOnWeb = async <
 			internalState,
 		};
 	} catch (err) {
-		sendUsageEvent({
-			succeeded: false,
-			licenseKey: licenseKey ?? null,
-			apiName: 'renderMediaOnWeb',
-		}).catch((err2) => {
-			Internals.Log.error(
-				{logLevel: 'error', tag: 'web-renderer'},
-				'Failed to send usage event',
-				err2,
-			);
-		});
+		if (!signal?.aborted) {
+			sendUsageEvent({
+				succeeded: false,
+				licenseKey: licenseKey ?? null,
+				apiName: 'renderMediaOnWeb',
+			}).catch((err2) => {
+				Internals.Log.error(
+					{logLevel: 'error', tag: 'web-renderer'},
+					'Failed to send usage event',
+					err2,
+				);
+			});
+		}
+
 		throw err;
 	} finally {
 		cleanupFns.forEach((fn) => fn());

--- a/packages/web-renderer/src/render-still-on-web.tsx
+++ b/packages/web-renderer/src/render-still-on-web.tsx
@@ -154,17 +154,20 @@ async function internalRenderStillOnWeb<
 
 		return {blob: imageData, internalState};
 	} catch (err) {
-		sendUsageEvent({
-			succeeded: false,
-			licenseKey: licenseKey ?? null,
-			apiName: 'renderStillOnWeb',
-		}).catch((err2) => {
-			Internals.Log.error(
-				{logLevel: 'error', tag: 'web-renderer'},
-				'Failed to send usage event',
-				err2,
-			);
-		});
+		if (!signal?.aborted) {
+			sendUsageEvent({
+				succeeded: false,
+				licenseKey: licenseKey ?? null,
+				apiName: 'renderStillOnWeb',
+			}).catch((err2) => {
+				Internals.Log.error(
+					{logLevel: 'error', tag: 'web-renderer'},
+					'Failed to send usage event',
+					err2,
+				);
+			});
+		}
+
 		throw err;
 	}
 }

--- a/packages/web-renderer/src/test/abort-render.test.tsx
+++ b/packages/web-renderer/src/test/abort-render.test.tsx
@@ -1,7 +1,10 @@
-import {expect, test} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import {renderMediaOnWeb} from '../render-media-on-web';
 import {renderStillOnWeb} from '../render-still-on-web';
+import * as telemetry from '../send-telemetry-event';
 import '../symbol-dispose';
+
+vi.mock('../send-telemetry-event', {spy: true});
 
 test('should be able to cancel renderMediaOnWeb()', async (t) => {
 	if (t.task.file.projectName === 'webkit') {
@@ -62,4 +65,68 @@ test('should be able to cancel renderStillOnWeb()', async () => {
 
 	controller.abort();
 	await expect(prom).rejects.toThrow('renderStillOnWeb() was cancelled');
+});
+
+test('should not send failed telemetry when renderMediaOnWeb() is aborted', async () => {
+	vi.mocked(telemetry.sendUsageEvent).mockClear();
+
+	const Component: React.FC = () => {
+		return null;
+	};
+
+	const controller = new AbortController();
+
+	const prom = renderMediaOnWeb({
+		licenseKey: 'free-license',
+		composition: {
+			component: Component,
+			id: 'abort-telemetry-test',
+			width: 400,
+			height: 400,
+			fps: 30,
+			durationInFrames: 200,
+		},
+		signal: controller.signal,
+		inputProps: {},
+	});
+
+	await new Promise((resolve) => {
+		setTimeout(resolve, 200);
+	});
+
+	controller.abort();
+	await expect(prom).rejects.toThrow('renderMediaOnWeb() was cancelled');
+
+	expect(vi.mocked(telemetry.sendUsageEvent).mock.calls.length).toBe(0);
+});
+
+test('should not send failed telemetry when renderStillOnWeb() is aborted', async () => {
+	vi.mocked(telemetry.sendUsageEvent).mockClear();
+
+	const Component: React.FC = () => {
+		return null;
+	};
+
+	const controller = new AbortController();
+
+	const prom = renderStillOnWeb({
+		licenseKey: 'free-license',
+		frame: 0,
+		imageFormat: 'png',
+		composition: {
+			component: Component,
+			id: 'abort-telemetry-test',
+			width: 400,
+			height: 400,
+			fps: 30,
+			durationInFrames: 200,
+		},
+		signal: controller.signal,
+		inputProps: {},
+	});
+
+	controller.abort();
+	await expect(prom).rejects.toThrow('renderStillOnWeb() was cancelled');
+
+	expect(vi.mocked(telemetry.sendUsageEvent).mock.calls.length).toBe(0);
 });


### PR DESCRIPTION
If user has aborted the render using `AbortController`, we treated the exception as a failed render. Fixing this in the PR.
