### PR TITLE
`@remotion/renderer`: Log if frame extraction error cannot be propagated

### DIFF
--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -225,7 +225,12 @@ export const startOffthreadVideoServer = ({
 						'Could not extract frame from compositor',
 						err,
 					);
-					if (!response.headersSent) {
+					if (response.headersSent) {
+						Log.error(
+							{indent, logLevel},
+							'Cannot propagate error message to client because headers have already been sent',
+						);
+					} else {
 						response.writeHead(500);
 						response.write(JSON.stringify({error: err.stack}));
 					}


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
