### PR TITLE
`@remotion/mcp`: Remove outputSchema registerTool (Fixes `-32602` error)

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -21,9 +21,6 @@ server.registerTool(
 				message: 'The query to search for. Keep it short and concise.',
 			}),
 		},
-		outputSchema: {
-			content: z.array(z.object({type: z.literal('text'), text: z.string()})),
-		},
 	},
 	async ({query}: {query: string}) => {
 		const res = await fetch(


### PR DESCRIPTION
fixes #6275 

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
