### PR TITLE
Add headerpad linker flag for MacOS compositor Builds

### DIFF
--- a/packages/compositor/build.ts
+++ b/packages/compositor/build.ts
@@ -249,9 +249,13 @@ for (const arch of archs) {
 		? `-C link-args=-Wl,-rpath,'$ORIGIN'`
 		: '';
 
-	const optimizations = all
-		? `-C opt-level=3 -C lto=fat -C strip=debuginfo -C embed-bitcode=yes ${rPathOrigin}`
+	const macOSHeaderPad = arch.includes('darwin')
+		? `-C link-args=-Wl,-headerpad_max_install_names`
 		: '';
+
+	const optimizations = all
+		? `-C opt-level=3 -C lto=fat -C strip=debuginfo -C embed-bitcode=yes ${rPathOrigin} ${macOSHeaderPad}`
+		: macOSHeaderPad;
 
 	execSync(command, {
 		stdio: 'inherit',


### PR DESCRIPTION
Adds **-headerpad_max_install_names** linker flag when building compositor for macOS.

Enables macOS compositor to be bundled in Electron apps by adding headerpad linker flag for **install_name_tool** compatibility. Without enough header padding path rewriting fails when new path is longer than the original.   