### PR TITLE
Add dark mode support for the Prompt Gallery page.

### DIFF
--- a/packages/promo-pages/src/components/prompts/CardLikeButton.tsx
+++ b/packages/promo-pages/src/components/prompts/CardLikeButton.tsx
@@ -67,13 +67,13 @@ export const CardLikeButton: React.FC<{
 			<Heart
 				height={16}
 				fill={liked ? 'var(--color-brand)' : 'none'}
-				stroke={liked ? 'var(--color-brand)' : 'black'}
+				stroke={liked ? 'var(--color-brand)' : 'var(--text-color)'}
 				strokeWidth={2}
 				bottomRoundnessAdjustment={roundness}
 				style={{transform: `scale(${scale})`, marginTop: 2}}
 			/>
 			<span
-				className="font-brand font-medium data-[liked=true]:text-brand data-[liked=false]:text-black"
+				className="font-brand font-medium data-[liked=true]:text-brand data-[liked=false]:text-text"
 				data-liked={liked}
 				style={{marginLeft: 8, flex: 1}}
 			>

--- a/packages/promo-pages/src/components/prompts/LikeButton.tsx
+++ b/packages/promo-pages/src/components/prompts/LikeButton.tsx
@@ -65,7 +65,7 @@ export const LikeButton: React.FC<{
 				<Heart
 					height={14}
 					fill={liked ? 'white' : 'none'}
-					stroke={liked ? 'white' : 'black'}
+					stroke={liked ? 'white' : 'var(--text-color)'}
 					strokeWidth={2}
 					bottomRoundnessAdjustment={roundness}
 					style={{transform: `scale(${scale})`}}

--- a/packages/promo-pages/src/components/prompts/NewBackButton.tsx
+++ b/packages/promo-pages/src/components/prompts/NewBackButton.tsx
@@ -2,25 +2,22 @@ import {Button} from '@remotion/design';
 import React from 'react';
 
 export const NewBackButton: React.FC<{
-	readonly color: string;
 	readonly text: string;
 	readonly link: string;
-}> = ({color, text, link}) => {
+}> = ({text, link}) => {
 	return (
 		<a
 			href={link}
-			className="justify-center items-center font-medium no-underline mb-4 block"
+			className="justify-center items-center font-medium no-underline mb-4 block text-text"
 			style={{
 				fontFamily: 'GTPlanar',
 				fontWeight: 500,
-				color,
 			}}
 		>
 			<Button className="px-8 rounded-full text-sm h-10">
 				<div className="flex row items-center justify-start font-normal">
 					<svg
-						className="h-4 mr-[8px] inline-block"
-						style={{color}}
+						className="h-4 mr-[8px] inline-block text-text"
 						xmlns="http://www.w3.org/2000/svg"
 						viewBox="0 0 448 512"
 					>

--- a/packages/promo-pages/src/components/prompts/Page.tsx
+++ b/packages/promo-pages/src/components/prompts/Page.tsx
@@ -15,7 +15,7 @@ export const Page: React.FC<{
 			onDrop={onDrop}
 			onDragOver={onDragOver}
 			className={clsx(
-				'overflow-y-auto w-full bg-slate-50 min-h-screen',
+				'overflow-y-auto w-full bg-[var(--background)] min-h-screen',
 				className,
 			)}
 		>

--- a/packages/promo-pages/src/components/prompts/PromptsGallery.tsx
+++ b/packages/promo-pages/src/components/prompts/PromptsGallery.tsx
@@ -68,7 +68,7 @@ const SubmissionCard: React.FC<{readonly submission: Submission}> = ({
 									alt={`${getAuthorName(submission)}'s avatar`}
 								/>
 							)}
-							<span className="text-sm font-brand text-black">
+							<span className="text-sm font-brand text-text">
 								{getAuthorName(submission)}
 							</span>
 						</div>
@@ -128,7 +128,7 @@ export const PromptsGalleryPage: React.FC = () => {
 						With{' '}
 						<a
 							href="/docs/ai/skills"
-							className="underline hover:text-black underline-offset-4"
+							className="underline hover:text-text underline-offset-4"
 						>
 							Remotion Skills
 						</a>

--- a/packages/promo-pages/src/components/prompts/PromptsShow.tsx
+++ b/packages/promo-pages/src/components/prompts/PromptsShow.tsx
@@ -67,7 +67,7 @@ export const PromptsShowPage: React.FC = () => {
 	return (
 		<Page className="flex-col">
 			<div className="m-auto max-w-[800px] w-full px-4 py-12">
-				<NewBackButton color="black" text="Back to gallery" link="/prompts" />
+				<NewBackButton text="Back to gallery" link="/prompts" />
 				<div className="h-1" />
 				<h1 className="text-2xl font-brand font-black">{submission.title}</h1>
 				<div>

--- a/packages/promo-pages/src/components/prompts/PromptsSubmit.tsx
+++ b/packages/promo-pages/src/components/prompts/PromptsSubmit.tsx
@@ -219,13 +219,13 @@ export const PromptsSubmitPage: React.FC = () => {
 		<Page className="flex-col" onDrop={onPageDrop} onDragOver={onPageDragOver}>
 			<div className="m-auto max-w-[800px] w-full">
 				<div className="mx-4 px-8 py-8 pt-8">
-					<NewBackButton color="black" text="Back to gallery" link="/prompts" />
+					<NewBackButton text="Back to gallery" link="/prompts" />
 					<h1 className="text-3xl font-brand font-black">Submit a prompt</h1>
 					<p className="text-muted-foreground text-sm font-brand">
 						Submit a prompt to be featured in the{' '}
 						<a
 							href="/prompts"
-							className="underline hover:text-black underline-offset-4"
+							className="underline hover:text-text underline-offset-4"
 						>
 							prompt gallery.
 						</a>


### PR DESCRIPTION
Fixes #6437

  ## Summary
  - Replace hardcoded color values with CSS variables for theme support
  - Change `black` to `var(--text-color)` / `text-text` for text colors
  - Change `bg-slate-50` to `bg-[var(--background)]` for background
  - Remove unnecessary `color` prop from `NewBackButton` component