### PR TITLE
Update media playback error documentation

### DIFF
--- a/packages/docs/docs/media-playback-error.mdx
+++ b/packages/docs/docs/media-playback-error.mdx
@@ -22,7 +22,7 @@ This error happens when you are trying to embed a [`<Html5Video/>`](/docs/html5-
 
 ## Codec not supported by Chrome
 
-Chrome does not support all codecs for playback. For example: HEVC on Linux, `.avi`, `.flv`, `.m3u8`.  
+Chrome does not support all codecs for playback. For example: HEVC on Linux, `.avi`, `.flv`.  
 Convert the video to a format that is supported by Chrome.
 
 ## Invalid source


### PR DESCRIPTION
Removed mention of unsupported codec '.m3u8' in playback error documentation since Chrome does support this.

https://caniuse.com/?search=M3U8

<img width="1009" height="778" alt="image" src="https://github.com/user-attachments/assets/f803c572-2f41-4633-ac7c-06d24947af77" />
