### PR TITLE
Use mediaMuted as fallback for initialMuted

### DIFF
--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -158,13 +158,15 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 		);
 	}
 
+	const effectiveMuted = muted || mediaMuted || userPreferredVolume <= 0;
+
 	const isPlayerBuffering = Internals.useIsPlayerBuffering(bufferingContext);
 	const initialPlaying = useRef(playing && !isPlayerBuffering);
 	const initialIsPremounting = useRef(isPremounting);
 	const initialIsPostmounting = useRef(isPostmounting);
 	const initialGlobalPlaybackRate = useRef(globalPlaybackRate);
 	const initialPlaybackRate = useRef(playbackRate);
-	const initialMuted = useRef(muted || mediaMuted);
+	const initialMuted = useRef(effectiveMuted);
 
 	useEffect(() => {
 		if (!sharedAudioContext) return;
@@ -354,8 +356,6 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 
 		mediaPlayer.setTrimAfter(trimAfter, currentTimeRef.current);
 	}, [trimAfter, mediaPlayerReady]);
-
-	const effectiveMuted = muted || mediaMuted || userPreferredVolume <= 0;
 
 	useLayoutEffect(() => {
 		const audioPlayer = mediaPlayerRef.current;

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -168,13 +168,16 @@ const VideoForPreviewAssertedShowing: React.FC<VideoForPreviewProps> = ({
 		);
 	}
 
+	const effectiveMuted =
+		isSequenceHidden || muted || mediaMuted || userPreferredVolume <= 0;
+
 	const isPlayerBuffering = Internals.useIsPlayerBuffering(buffering);
 	const initialPlaying = useRef(playing && !isPlayerBuffering);
 	const initialIsPremounting = useRef(isPremounting);
 	const initialIsPostmounting = useRef(isPostmounting);
 	const initialGlobalPlaybackRate = useRef(globalPlaybackRate);
 	const initialPlaybackRate = useRef(playbackRate);
-	const initialMuted = useRef(muted || mediaMuted);
+	const initialMuted = useRef(effectiveMuted);
 
 	useEffect(() => {
 		if (!sharedAudioContext) return;
@@ -364,9 +367,6 @@ const VideoForPreviewAssertedShowing: React.FC<VideoForPreviewProps> = ({
 
 		mediaPlayer.setTrimAfter(trimAfter, currentTimeRef.current);
 	}, [trimAfter, mediaPlayerReady]);
-
-	const effectiveMuted =
-		isSequenceHidden || muted || mediaMuted || userPreferredVolume <= 0;
 
 	useLayoutEffect(() => {
 		const mediaPlayer = mediaPlayerRef.current;


### PR DESCRIPTION
fixes #6476

Ensure the initial muted state considers the global mediaMuted flag when the muted prop is not set. Update au and audio-forpreview.tsx and video-for-preview.tsx to initialize initialMuted with `muted || mediaMuted`, preventing inconsistent mute state on preview mount.

Files modified:
- packages/media/src/audio/audio-for-preview.tsx
- packages/media/src/video/video-for-preview.tsx


