### PR TITLE
`@remotion/renderer`: Fix floating point error in audio mixing

### DIFF
--- a/packages/renderer/src/print-useful-error-message.ts
+++ b/packages/renderer/src/print-useful-error-message.ts
@@ -112,7 +112,7 @@ export const printUsefulErrorMessage = (
 				indent,
 				logLevel,
 			},
-			'💡 You might need to set the OpenGL renderer to "angle-egl", "angle" (or "swangle" if rendering on lambda). Learn why at https://www.remotion.dev/docs/three',
+			'💡 You might need to set the OpenGL renderer to "angle". Learn why at https://www.remotion.dev/docs/three',
 		);
 		Log.warn(
 			{


### PR DESCRIPTION
## Summary
- Fix floating point precision error in `inline-audio-mixing.ts` that caused audio artifacts in the `browser-test` composition
- Simplify OpenGL renderer error message in `print-useful-error-message.ts`

Fixes #6451

## Test plan
- [ ] Verify `browser-test` composition no longer has audio imperfections
- [ ] Run renderer tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)