### PR TITLE
Update GitHub stars from 35k to 36k

### DIFF
--- a/packages/promo-pages/src/components/homepage/CommunityStatsItems.tsx
+++ b/packages/promo-pages/src/components/homepage/CommunityStatsItems.tsx
@@ -177,7 +177,7 @@ export const GitHubStars: React.FC = () => {
 					width="45px"
 				/>
 				<StatItemContent
-					content="35k"
+					content="36k"
 					width="80px"
 					fontSize="2.5rem"
 					fontWeight="bold"

--- a/packages/promo-pages/src/components/homepage/GitHubButton.tsx
+++ b/packages/promo-pages/src/components/homepage/GitHubButton.tsx
@@ -16,7 +16,7 @@ export const GithubButton: React.FC = () => {
 		<div className="flex flex-row items-center text-base">
 			<GithubIcon /> <span>GitHub</span>{' '}
 			<div className="text-xs inline-block ml-2 leading-none mt-[3px] self-center">
-				{'35k'}
+				{'36k'}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Updated GitHub star count from 35k to 36k (current: 36,045)
- Updated `CommunityStatsItems.tsx` and `GitHubButton.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)