### PR TITLE
#6493 Block AAC on Firefox

### DIFF
--- a/packages/web-renderer/src/resolve-audio-codec.ts
+++ b/packages/web-renderer/src/resolve-audio-codec.ts
@@ -40,32 +40,32 @@ export const resolveAudioCodec = async (options: {
 	const mediabunnyAudioCodec = audioCodecToMediabunnyAudioCodec(audioCodec);
 	const canEncode = await canEncodeAudio(mediabunnyAudioCodec, {bitrate});
 
-	if (canEncode) {
-		return {codec: audioCodec, issues};
-	}
-
-	if (userSpecifiedAudioCodec) {
-		issues.push({
-			type: 'audio-codec-unsupported',
-			message: `Audio codec "${audioCodec}" cannot be encoded by this browser. This is common for AAC on Firefox. Try using "opus" instead.`,
-			severity: 'error',
-		});
-
-		return {codec: null, issues};
-	}
-
 	// Firefox produces bad audio with AAC, even if it says it supports it.
 	const isFirefox =
 		typeof navigator !== 'undefined' &&
 		navigator.userAgent.toLowerCase().includes('firefox');
 	if (isFirefox && audioCodec === 'aac') {
+		if (userSpecifiedAudioCodec) {
+			issues.push({
+				type: 'audio-codec-unsupported',
+				message: `Audio codec "${audioCodec}" cannot be encoded by this browser. This is common for AAC on Firefox. Try using "opus" instead.`,
+				severity: 'error',
+			});
+
+			return {codec: null, issues};
+		}
+
 		issues.push({
 			type: 'audio-codec-unsupported',
-			message: `Audio codec "aac" is not supported on Firefox due to known quality issues. Automatically falling back to "opus".`,
+			message: `Falling back from audio codec "aac" to "opus" on Firefox due to known quality issues.`,
 			severity: 'warning',
 		});
 
 		return {codec: 'opus', issues};
+	}
+
+	if (canEncode) {
+		return {codec: audioCodec, issues};
 	}
 
 	for (const fallbackCodec of supportedAudioCodecs) {


### PR DESCRIPTION
<img width="1917" height="539" alt="image" src="https://github.com/user-attachments/assets/a7e9bfdb-731e-4ca1-bf3e-e18ae110a8ba" />
-->Root Cause
Firefox has a known bug where its AAC encoder produces corrupted/glitchy audio output, even though it claims to support AAC via `MediaRecorder` and WebCodecs API. The current fix (added in #6493) detects this combination and fails fast to prevent wasted renders.

However, this "fail fast" approach is too aggressive - we should automatically fall back to Opus (which works) instead of forcing the user to manually change their code.

--> Solution
Changed the severity from `'error'` to `'warning'` and automatically return `'opus'` as the fallback codec when Firefox + AAC is detected.