### PR TITLE
Docs: Fix `<ThreeCanvas>` video texture example to use `advance()` during rendering

### DIFF
--- a/packages/docs/docs/three-canvas.mdx
+++ b/packages/docs/docs/three-canvas.mdx
@@ -48,6 +48,12 @@ const ThreeBasic: React.FC = () => {
 export default ThreeBasic;
 ```
 
+## `frameloop` behavior during rendering
+
+During rendering, `<ThreeCanvas>` overrides the `frameloop` prop to `'never'` regardless of what you pass. This means the Three.js scene will not re-render on its own — it is only re-rendered on demand via `advance()`.
+
+If you update textures asynchronously (e.g. from a [`<Video>`](/docs/media/video) `onVideoFrame` callback), you must call `advance(performance.now())` instead of `invalidate()` to synchronously re-render the scene before the frame is captured. See [Using a video as a texture](/docs/videos/as-threejs-texture) for a full example.
+
 ## Note on `<Sequence>`
 
 A [`<Sequence>`](/docs/sequence) by default will return a `<div>` component which is not allowed inside a `<ThreeCanvas>`. To avoid an error, pass `layout="none"` to `<Sequence>`.

--- a/packages/docs/docs/videos/as-threejs-texture.mdx
+++ b/packages/docs/docs/videos/as-threejs-texture.mdx
@@ -16,7 +16,7 @@ import {useThree} from '@react-three/fiber';
 import {Video} from '@remotion/media';
 import {ThreeCanvas} from '@remotion/three';
 import React, {useCallback, useState} from 'react';
-import {useVideoConfig} from 'remotion';
+import {useRemotionEnvironment, useVideoConfig} from 'remotion';
 import {CanvasTexture} from 'three';
 
 const videoSrc = 'https://remotion.media/video.mp4';
@@ -36,19 +36,29 @@ const Inner: React.FC = () => {
     return {canvas, context, texture};
   });
 
-  const {invalidate} = useThree();
+  const {invalidate, advance} = useThree();
+  const {isRendering} = useRemotionEnvironment();
 
   const onVideoFrame = useCallback(
     (frame: CanvasImageSource) => {
       canvasStuff.context.drawImage(frame, 0, 0, videoWidth, videoHeight);
-      // This is needed during preview - the frame loop synchronizes with the monitor refresh rate
-      // By setting this, we signal that the texture has been updated
       canvasStuff.texture.needsUpdate = true;
-      // This is needed during rendering - the frame loop is only triggered on demand.
-      // We have to call "invalidate()" to trigger a new frame loop.
-      invalidate();
+      if (isRendering) {
+        // ThreeCanvas's ManualFrameRenderer already calls advance() in a
+        // useEffect on frame change, but video frame extraction is async
+        // (BroadcastChannel round-trip) and resolves after that useEffect.
+        // So by the time onVideoFrame fires, the scene was already rendered
+        // with the stale texture. We need a second advance() here to
+        // re-render the scene now that the texture is actually updated.
+        advance(performance.now());
+      } else {
+        // During preview with the default frameloop='always', the texture
+        // is picked up automatically. This is only needed if
+        // frameloop='demand' is passed to <ThreeCanvas>.
+        invalidate();
+      }
     },
-    [canvasStuff.context, canvasStuff.texture, invalidate],
+    [canvasStuff.context, canvasStuff.texture, invalidate, advance, isRendering],
   );
 
   return (
@@ -76,7 +86,8 @@ export const RemotionMediaVideoTexture: React.FC = () => {
 ### Notes
 
 - By using the [`headless`](/docs/media/video#headless) prop, nothing will be returned by the `<Video>` tag, so it can be mounted within a [`<ThreeCanvas>`](/docs/three-canvas) without affecting the rendering.
-- For preview and rendering, separate approaches are needed to invalida the texture when it is being updated. See
+- During rendering, [`<ThreeCanvas>`](/docs/three-canvas) sets `frameloop='never'`, which means the scene is only re-rendered on demand. Use `advance()` inside `onVideoFrame` to synchronously re-render the scene before the screenshot is taken. Using `invalidate()` would only schedule an asynchronous re-render, which can lead to stale frames — especially with concurrency greater than 1.
+- During preview, `invalidate()` is sufficient because the frame loop runs continuously.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Docs update after this change: #6335

- Use `advance()` instead of `invalidate()` in the `onVideoFrame` example during rendering. `invalidate()` only schedules an async `requestAnimationFrame`, which causes stale/stuttering video frames — especially with `concurrency > 1`.
- Document that `<ThreeCanvas>` overrides `frameloop` to `'never'` during rendering, which was previously undocumented.
- Fix an incomplete note in the texture docs (previously ended mid-sentence with a typo).

### Why a second `advance()` is needed

`ThreeCanvas`'s `ManualFrameRenderer` already calls `advance()` in a `useEffect` on frame change, but video frame extraction is async (BroadcastChannel round-trip) and resolves after that `useEffect`. So by the time `onVideoFrame` fires, the scene was already rendered with the stale texture. A second `advance()` in `onVideoFrame` re-renders the scene now that the texture is actually updated.

## Changes

- `packages/docs/docs/videos/as-threejs-texture.mdx` — Updated code example and notes
- `packages/docs/docs/three-canvas.mdx` — Added "`frameloop` behavior during rendering" section
- `packages/example/src/VideoTexture.tsx` — Updated testbed example to match