### PR TITLE
`@remotion/studio`: Sort render queue jobs by startedAt timestamp

### DIFF
--- a/packages/studio/src/components/RenderQueue/context.tsx
+++ b/packages/studio/src/components/RenderQueue/context.tsx
@@ -333,7 +333,9 @@ export const RenderQueueContextProvider: React.FC<{
 
 	const value: RenderQueueContextType = useMemo(() => {
 		return {
-			jobs: [...serverJobs, ...clientJobs],
+			jobs: [...serverJobs, ...clientJobs].sort(
+				(a, b) => a.startedAt - b.startedAt,
+			),
 			serverJobs,
 			clientJobs,
 			addClientStillJob,


### PR DESCRIPTION
## Summary

Fixes #6325

- Sort the merged `jobs` array in `RenderQueueContextProvider` by `startedAt` ascending, so server-side and client-side renders are interleaved chronologically instead of arbitrarily concatenated.

## Problem

The `useMemo` in `RenderQueueContextProvider` merged server and client render jobs by simple concatenation (`[...serverJobs, ...clientJobs]`), which meant the display order depended on which array came first rather than when the job was actually started.

## Fix

Replace the concatenation with a sorted merge using the `startedAt` timestamp field available on both `RenderJob` and `ClientRenderJob` types:

```ts
jobs: [...serverJobs, ...clientJobs].sort(
  (a, b) => a.startedAt - b.startedAt,
),
```

This ensures oldest jobs appear first and newest last, matching the UI's scroll-to-bottom behavior for new jobs.