### PR TITLE
`@remotion/web-renderer`: Add "Made with Remotion" metadata

### DIFF
--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -173,6 +173,13 @@ export const webpackConfig = async ({
 					'esm',
 					'no-react.mjs',
 				),
+				'remotion/version': path.resolve(
+					require.resolve('remotion'),
+					'..',
+					'..',
+					'esm',
+					'version.mjs',
+				),
 				remotion: path.resolve(
 					require.resolve('remotion'),
 					'..',

--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -1,6 +1,7 @@
 import {BufferTarget, StreamTarget} from 'mediabunny';
 import type {CalculateMetadataFunction} from 'remotion';
 import {Internals, type LogLevel} from 'remotion';
+import {VERSION} from 'remotion/version';
 import type {AnyZodObject, z} from 'zod';
 import {addAudioSample, addVideoSampleAndCloseFrame} from './add-sample';
 import {handleArtifacts, type WebRendererOnArtifact} from './artifact';
@@ -135,7 +136,6 @@ type InternalRenderMediaOnWebOptions<
 	InputPropsIfHasProps<Schema, Props>;
 
 // TODO: More containers
-// TODO: Metadata
 // TODO: Validating inputs
 // TODO: Apply defaultCodec
 
@@ -289,6 +289,10 @@ const internalRenderMediaOnWeb = async <
 	using outputWithCleanup = makeOutputWithCleanup({
 		format,
 		target,
+	});
+
+	outputWithCleanup.output.setMetadataTags({
+		comment: `Made with Remotion ${VERSION}`,
 	});
 
 	using throttledProgress = createThrottledProgressCallback(onProgress);

--- a/packages/web-renderer/src/test/render-media.test.tsx
+++ b/packages/web-renderer/src/test/render-media.test.tsx
@@ -1,4 +1,6 @@
+import {ALL_FORMATS, BlobSource, Input} from 'mediabunny';
 import {interpolateColors, useCurrentFrame} from 'remotion';
+import {VERSION} from 'remotion/version';
 import {expect, test} from 'vitest';
 import {renderMediaOnWeb} from '../render-media-on-web';
 import '../symbol-dispose';
@@ -97,6 +99,37 @@ test('should throttle onProgress callback to 250ms', {retry: 2}, async (t) => {
 			expect(timeDiff).toBeGreaterThanOrEqual(200);
 		}
 	}
+});
+
+test('should include "Made with Remotion" metadata', async (t) => {
+	if (t.task.file.projectName === 'webkit') {
+		t.skip();
+		return;
+	}
+
+	const Component: React.FC = () => null;
+
+	const result = await renderMediaOnWeb({
+		composition: {
+			component: Component,
+			id: 'metadata-test',
+			width: 100,
+			height: 100,
+			fps: 30,
+			durationInFrames: 5,
+		},
+		inputProps: {},
+	});
+
+	const blob = await result.getBlob();
+
+	using input = new Input({
+		formats: ALL_FORMATS,
+		source: new BlobSource(blob),
+	});
+
+	const tags = await input.getMetadataTags();
+	expect(tags.comment).toBe(`Made with Remotion ${VERSION}`);
 });
 
 test('should not fire stale progress callbacks after render completes', async (t) => {


### PR DESCRIPTION
## Summary

- Embeds `Made with Remotion <version>` metadata in videos rendered by the web renderer using mediabunny's `Output.setMetadataTags()` API
- Adds a `remotion/version` webpack alias in `@remotion/bundler` so the studio can resolve the subpath export (same pattern as `remotion/no-react`)
- Adds a test that renders a video and reads back metadata with mediabunny's `Input` class to verify the comment is present

<img width="633" height="397" alt="image" src="https://github.com/user-attachments/assets/744b9e20-c964-4927-b9c3-cf9fa6093f27" />


Closes #6308