### PR TITLE
`@remotion/studio`: Show only encoding progress in web renderer

### DIFF
--- a/packages/studio/src/components/RenderModal/ClientRenderProgress.tsx
+++ b/packages/studio/src/components/RenderModal/ClientRenderProgress.tsx
@@ -26,26 +26,6 @@ const right: React.CSSProperties = {
 	flex: 1,
 };
 
-const RenderingProgress: React.FC<{
-	readonly renderedFrames: number;
-	readonly totalFrames: number;
-}> = ({renderedFrames, totalFrames}) => {
-	const done = renderedFrames === totalFrames;
-	const progress = totalFrames > 0 ? renderedFrames / totalFrames : 0;
-
-	return (
-		<div style={progressItem}>
-			{done ? <SuccessIcon /> : <CircularProgress progress={progress} />}
-			<Spacing x={1} />
-			<div style={label}>
-				{done
-					? `Rendered ${totalFrames} frames`
-					: `Rendering ${renderedFrames} / ${totalFrames} frames`}
-			</div>
-		</div>
-	);
-};
-
 const EncodingProgress: React.FC<{
 	readonly encodedFrames: number;
 	readonly totalFrames: number;
@@ -112,15 +92,11 @@ export const ClientRenderProgress: React.FC<{
 		);
 	}
 
-	const {renderedFrames, encodedFrames, totalFrames} = job.progress;
+	const {encodedFrames, totalFrames} = job.progress;
 
 	return (
 		<div>
 			<Spacing y={0.5} />
-			<RenderingProgress
-				renderedFrames={renderedFrames}
-				totalFrames={totalFrames}
-			/>
 			{job.type === 'client-video' && (
 				<EncodingProgress
 					encodedFrames={encodedFrames}

--- a/packages/studio/src/components/RenderQueue/ClientRenderQueueProcessor.tsx
+++ b/packages/studio/src/components/RenderQueue/ClientRenderQueueProcessor.tsx
@@ -136,7 +136,6 @@ export const ClientRenderQueueProcessor: React.FC = () => {
 				signal,
 				onProgress: (progress) => {
 					onProgress(job.id, {
-						renderedFrames: progress.renderedFrames,
 						encodedFrames: progress.encodedFrames,
 						totalFrames,
 					});

--- a/packages/studio/src/components/RenderQueue/RenderQueueItemStatus.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueItemStatus.tsx
@@ -94,8 +94,8 @@ export const RenderQueueItemStatus: React.FC<{
 	if (job.status === 'running') {
 		let progressValue: number;
 		if (isClientJob) {
-			const {renderedFrames, totalFrames} = job.progress;
-			progressValue = totalFrames > 0 ? renderedFrames / totalFrames : 0;
+			const {encodedFrames, totalFrames} = job.progress;
+			progressValue = totalFrames > 0 ? encodedFrames / totalFrames : 0;
 		} else {
 			progressValue = job.progress.value;
 		}

--- a/packages/studio/src/components/RenderQueue/RenderQueueProgressMessage.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueProgressMessage.tsx
@@ -29,7 +29,9 @@ export const RenderQueueProgressMessage: React.FC<{
 	}, [job.id, setSelectedModal]);
 
 	const message = isClientJob
-		? `Rendering frame ${job.progress.renderedFrames}/${job.progress.totalFrames}`
+		? job.progress.totalFrames === 0
+			? 'Getting composition'
+			: `Encoding frame ${job.progress.encodedFrames}/${job.progress.totalFrames}`
 		: job.progress.message;
 
 	return (

--- a/packages/studio/src/components/RenderQueue/client-side-render-types.ts
+++ b/packages/studio/src/components/RenderQueue/client-side-render-types.ts
@@ -9,7 +9,6 @@ import type {
 import type {LogLevel} from 'remotion';
 
 export type ClientRenderJobProgress = {
-	renderedFrames: number;
 	encodedFrames: number;
 	totalFrames: number;
 };

--- a/packages/studio/src/components/RenderQueue/context.tsx
+++ b/packages/studio/src/components/RenderQueue/context.tsx
@@ -144,7 +144,7 @@ export const RenderQueueContextProvider: React.FC<{
 					? ({
 							...job,
 							status: 'running',
-							progress: {renderedFrames: 0, encodedFrames: 0, totalFrames: 0},
+							progress: {encodedFrames: 0, totalFrames: 0},
 						} as ClientRenderJob)
 					: job,
 			),

--- a/packages/studio/src/helpers/document-title.ts
+++ b/packages/studio/src/helpers/document-title.ts
@@ -70,9 +70,9 @@ const getProgressInBrackets = (
 
 	let progInPercent: number;
 	if (isClientRenderJob(currentRender)) {
-		const {renderedFrames, totalFrames} = currentRender.progress;
+		const {encodedFrames, totalFrames} = currentRender.progress;
 		progInPercent =
-			totalFrames > 0 ? Math.ceil((renderedFrames / totalFrames) * 100) : 0;
+			totalFrames > 0 ? Math.ceil((encodedFrames / totalFrames) * 100) : 0;
 	} else {
 		progInPercent = Math.ceil(currentRender.progress.value * 100);
 	}


### PR DESCRIPTION
## Summary

- Only show encoding progress (not rendering progress) in the web renderer studio UI, since parallel encoding with Mediabunny backpressure means they're always within 4-5 frames of each other (fixes #6320)
- Show "Getting composition" instead of "Encoding frame 0/0" when `totalFrames` is not yet known (fixes #6326)

## Changes

- Removed `renderedFrames` from `ClientRenderJobProgress` type
- Deleted the `RenderingProgress` sub-component from `ClientRenderProgress.tsx`
- Updated circular progress indicator, queue subtitle text, and browser tab title to use `encodedFrames`
- Added "Getting composition" fallback when `totalFrames === 0`


<img width="522" height="244" alt="image" src="https://github.com/user-attachments/assets/7711fa69-41a1-4432-b5e2-15eb5646264a" />
