### PR TITLE
`@remotion/serverless`: Retry on socket hang up and ECONNRESET errors

### DIFF
--- a/packages/serverless/src/stream-renderer.ts
+++ b/packages/serverless/src/stream-renderer.ts
@@ -185,6 +185,8 @@ const streamRenderer = <Provider extends CloudProvider>({
 				const shouldRetry =
 					(err as Error).stack?.includes('Error: aborted') ||
 					(err as Error).stack?.includes('ETIMEDOUT') ||
+					(err as Error).stack?.includes('socket hang up') ||
+					(err as Error).stack?.includes('ECONNRESET') ||
 					false;
 
 				resolve({


### PR DESCRIPTION
## Summary
- Adds `socket hang up` and `ECONNRESET` to the list of retryable errors in `streamRenderer`'s `callFunctionStreaming` catch handler
- Previously only `Error: aborted` and `ETIMEDOUT` were retried, causing transient connection failures to be treated as fatal

Closes #6127

## Test plan
- [ ] Verify that a `socket hang up` error during streaming now triggers a retry instead of failing immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)