### PR TITLE
@remotion/renderer: Add imageFormatOption

### DIFF
--- a/packages/cli/src/image-formats.ts
+++ b/packages/cli/src/image-formats.ts
@@ -1,8 +1,11 @@
 import type {VideoImageFormat} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
+import {BrowserSafeApis} from '@remotion/renderer/client';
 import {NoReactAPIs} from '@remotion/renderer/pure';
 import {ConfigInternals} from './config';
 import {parsedCli} from './parsed-cli';
+
+const {imageFormatOption} = BrowserSafeApis.options;
 
 export const getVideoImageFormat = ({
 	codec,
@@ -15,16 +18,20 @@ export const getVideoImageFormat = ({
 		return uiImageFormat;
 	}
 
-	if (typeof parsedCli['image-format'] !== 'undefined') {
+	const cliImageFormat = imageFormatOption.getValue({
+		commandLine: parsedCli,
+	}).value;
+
+	if (cliImageFormat !== null) {
 		if (
 			!(RenderInternals.validVideoImageFormats as readonly string[]).includes(
-				parsedCli['image-format'] as string,
+				cliImageFormat,
 			)
 		) {
-			throw new Error(`Invalid image format: ${parsedCli['image-format']}`);
+			throw new Error(`Invalid image format: ${cliImageFormat}`);
 		}
 
-		return parsedCli['image-format'] as VideoImageFormat;
+		return cliImageFormat as VideoImageFormat;
 	}
 
 	const configFileOption = ConfigInternals.getUserPreferredVideoImageFormat();

--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -4,8 +4,6 @@ import type {
 	Codec,
 	OpenGlRenderer,
 	PixelFormat,
-	StillImageFormat,
-	VideoImageFormat,
 } from '@remotion/renderer';
 import type {TypeOfOption} from '@remotion/renderer/client';
 import {BrowserSafeApis} from '@remotion/renderer/client';
@@ -38,12 +36,13 @@ const {
 	forceNewStudioOption,
 	numberOfSharedAudioTagsOption,
 	ipv4Option,
+	imageFormatOption,
 } = BrowserSafeApis.options;
 
 export type CommandLineOptions = {
 	['browser-executable']: BrowserExecutable;
 	['pixel-format']: PixelFormat;
-	['image-format']: VideoImageFormat | StillImageFormat;
+	[imageFormatOption.cliFlag]: TypeOfOption<typeof imageFormatOption>;
 	['prores-profile']: _InternalTypes['ProResProfile'];
 	[x264Option.cliFlag]: TypeOfOption<typeof x264Option>;
 	['bundle-cache']: string;

--- a/packages/cli/src/render-flows/still.ts
+++ b/packages/cli/src/render-flows/still.ts
@@ -9,8 +9,10 @@ import type {
 	LogLevel,
 	RenderMediaOnDownload,
 	StillImageFormat,
+	VideoImageFormat,
 } from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
+import {BrowserSafeApis} from '@remotion/renderer/client';
 import type {
 	AggregateRenderProgress,
 	JobProgressCallback,
@@ -276,8 +278,15 @@ export const renderStillFlow = async ({
 			mediaCacheSizeInBytes,
 		});
 
+	const {imageFormatOption} = BrowserSafeApis.options;
+	const cliImageFormat = imageFormatOption.getValue({
+		commandLine: parsedCli,
+	}).value;
+
 	const {format: imageFormat, source} = determineFinalStillImageFormat({
-		cliFlag: parsedCli['image-format'] ?? null,
+		cliFlag:
+			(cliImageFormat as StillImageFormat | VideoImageFormat | undefined) ??
+			null,
 		configImageFormat:
 			ConfigInternals.getUserPreferredStillImageFormat() ?? null,
 		downloadName: null,

--- a/packages/cloudrun/src/cli/commands/still.ts
+++ b/packages/cloudrun/src/cli/commands/still.ts
@@ -1,6 +1,11 @@
 import {CliInternals} from '@remotion/cli';
 import {ConfigInternals} from '@remotion/cli/config';
-import type {ChromiumOptions, LogLevel} from '@remotion/renderer';
+import type {
+	ChromiumOptions,
+	LogLevel,
+	StillImageFormat,
+	VideoImageFormat,
+} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import {BrowserSafeApis} from '@remotion/renderer/client';
 import {NoReactInternals} from 'remotion/no-react';
@@ -24,6 +29,7 @@ const {
 	binariesDirectoryOption,
 	mediaCacheSizeInBytesOption,
 	darkModeOption,
+	imageFormatOption,
 } = BrowserSafeApis.options;
 
 export const stillCommand = async (
@@ -158,11 +164,17 @@ export const stillCommand = async (
 		composition = compositionId;
 	}
 
+	const cliImageFormat = imageFormatOption.getValue({
+		commandLine: CliInternals.parsedCli,
+	}).value;
+
 	const {format: imageFormat, source: imageFormatReason} =
 		CliInternals.determineFinalStillImageFormat({
 			downloadName,
 			outName: outName ?? null,
-			cliFlag: CliInternals.parsedCli['image-format'] ?? null,
+			cliFlag:
+				(cliImageFormat as StillImageFormat | VideoImageFormat | undefined) ??
+				null,
 			isLambda: true,
 			fromUi: null,
 			configImageFormat:

--- a/packages/docs/docs/cli/render.mdx
+++ b/packages/docs/docs/cli/render.mdx
@@ -49,7 +49,7 @@ Inline JSON string isn't supported on Windows shells because it removes the `"` 
 
 ### `--image-format`<AvailableFrom v="1.4.0" />
 
-[`jpeg` or `png` - JPEG is faster, but doesn't support transparency.](/docs/config#setvideoimageformat) The default image format is `jpeg` since v1.1.
+<Options id="image-format" cli />
 
 ### `--image-sequence-pattern` <AvailableFrom v="4.0.313" />
 

--- a/packages/docs/docs/cli/still.mdx
+++ b/packages/docs/docs/cli/still.mdx
@@ -33,7 +33,7 @@ Inline JSON string isn't supported on Windows shells because it removes the `"` 
 
 ### `--image-format`
 
-`jpeg`, `png`, `webp` or `pdf`. The default is `png`.
+<Options id="image-format" cli />
 
 ### `--config`
 

--- a/packages/docs/docs/cloudrun/cli/render.mdx
+++ b/packages/docs/docs/cloudrun/cli/render.mdx
@@ -8,9 +8,12 @@ crumb: 'Cloud Run CLI Reference'
 ---
 
 <ExperimentalBadge>
-  <p>
-    Cloud Run is in <a href="/docs/cloudrun/status">Alpha status and not actively being developed.</a>
-  </p>
+	<p>
+		Cloud Run is in{' '}
+		<a href="/docs/cloudrun/status">
+			Alpha status and not actively being developed.
+		</a>
+	</p>
 </ExperimentalBadge>
 
 Using the `npx remotion cloudrun render` command, you can render a video on GCP.
@@ -87,7 +90,7 @@ Before v4.0.76, this was "100%" by default. It is now aligned to the other serve
 
 ### `--image-format`
 
-[`jpeg` or `png` - JPEG is faster, but doesn't support transparency.](/docs/config#setvideoimageformat) The default image format is `jpeg`.
+<Options id="image-format" cli />
 
 ### `--scale`
 
@@ -139,11 +142,11 @@ The webhook will receive a POST request with a JSON body containing:
 
 ```json
 {
-  "progress": 0.1,
-  "renderedFrames": 100,
-  "encodedFrames": 100,
-  "renderId": "1234567890",
-  "projectId": "1234567890"
+	"progress": 0.1,
+	"renderedFrames": 100,
+	"encodedFrames": 100,
+	"renderId": "1234567890",
+	"projectId": "1234567890"
 }
 ```
 

--- a/packages/docs/docs/cloudrun/cli/still.mdx
+++ b/packages/docs/docs/cloudrun/cli/still.mdx
@@ -8,9 +8,12 @@ crumb: 'Cloud Run CLI Reference'
 ---
 
 <ExperimentalBadge>
-  <p>
-    Cloud Run is in <a href="/docs/cloudrun/status">Alpha status and not actively being developed.</a>
-  </p>
+	<p>
+		Cloud Run is in{' '}
+		<a href="/docs/cloudrun/status">
+			Alpha status and not actively being developed.
+		</a>
+	</p>
 </ExperimentalBadge>
 
 Using the `npx remotion cloudrun still` command, you can render an image on GCP.
@@ -79,7 +82,7 @@ Specify a specific bucket name to be used for the output. The resulting Google C
 
 ### `--image-format`
 
-[`jpeg` or `png` - JPEG is faster, but doesn't support transparency.](/docs/config#setstillimageformat) The default image format is `jpeg`.
+<Options id="image-format" cli />
 
 ### `--scale`
 

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -31,11 +31,11 @@ Allows you to insert your custom Webpack config. [See the page about custom Webp
 import {Config} from '@remotion/cli/config';
 // ---cut---
 Config.overrideWebpackConfig((currentConfiguration) => {
-  // Return a new Webpack configuration
-  return {
-    ...currentConfiguration,
-    // new configuration
-  };
+	// Return a new Webpack configuration
+	return {
+		...currentConfiguration,
+		// new configuration
+	};
 });
 ```
 
@@ -324,11 +324,7 @@ Try to set your concurrency to `os.cpus().length` to all the threads available o
 
 ## `setVideoImageFormat()`<AvailableFrom v="4.0.0" />
 
-Determines which in which image format to render the frames. Either:
-
-- `jpeg` - the fastest option (default)
-- `png` - slower, but supports transparency
-- `none` - don't render images, just calculate audio information
+<Options id="image-format" />
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
@@ -336,20 +332,19 @@ import {Config} from '@remotion/cli/config';
 Config.setVideoImageFormat('png');
 ```
 
+The CLI flag `--image-format` takes precedence over this config option.
+
 ## `setStillImageFormat()`<AvailableFrom v="4.0.0" />
 
-Determines which in which image format to render the frames. Either:
-
-- `png` (default)
-- `jpeg`
-- `pdf`
-- `webp`
+<Options id="image-format" />
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 // ---cut---
 Config.setStillImageFormat('pdf');
 ```
+
+The CLI flag `--image-format` takes precedence over this config option.
 
 ## `setScale()`<AvailableFrom v="2.6.7" />
 
@@ -898,12 +893,23 @@ Modifies the FFmpeg command that Remotion uses under the hood. It works reducer-
 import {Config} from '@remotion/cli/config';
 // ---cut---
 Config.overrideFfmpegCommand(({args}) => {
-  // Define the custom FFmpeg options as an array of strings
-  const customFfmpegOptions = ['-profile:v', 'main', '-video_track_timescale', '90000', '-color_primaries', 'bt709', '-color_trc', 'bt709', '-strict', 'experimental'];
-  // The customFfmpegOptions are inserted before the last element to ensure
-  // they appear before the ffmpeg's output path
-  args.splice(args.length - 1, 0, ...customFfmpegOptions);
-  return args;
+	// Define the custom FFmpeg options as an array of strings
+	const customFfmpegOptions = [
+		'-profile:v',
+		'main',
+		'-video_track_timescale',
+		'90000',
+		'-color_primaries',
+		'bt709',
+		'-color_trc',
+		'bt709',
+		'-strict',
+		'experimental',
+	];
+	// The customFfmpegOptions are inserted before the last element to ensure
+	// they appear before the ffmpeg's output path
+	args.splice(args.length - 1, 0, ...customFfmpegOptions);
+	return args;
 });
 ```
 
@@ -1048,8 +1054,8 @@ export const enableSass: WebpackOverrideFn = (c) => c;
 import {Config} from '@remotion/cli/config';
 
 Config.overrideWebpackConfig(async (currentConfiguration) => {
-  const {enableSass} = await import('./src/enable-sass');
-  return enableSass(currentConfiguration);
+	const {enableSass} = await import('./src/enable-sass');
+	return enableSass(currentConfiguration);
 });
 ```
 

--- a/packages/docs/docs/lambda/cli/render.mdx
+++ b/packages/docs/docs/lambda/cli/render.mdx
@@ -178,7 +178,7 @@ Renamed to `jpegQuality` in `v4.0.0`.
 
 ### `--image-format`
 
-[`jpeg` or `png` - JPEG is faster, but doesn't support transparency.](/docs/config#setvideoimageformat) The default image format is `jpeg`.
+<Options id="image-format" cli />
 
 ### `--scale`
 

--- a/packages/lambda-go-example/go.mod
+++ b/packages/lambda-go-example/go.mod
@@ -1,5 +1,7 @@
 module main.go
 
+go 1.24.3
+
 require (
 	github.com/go-playground/validator/v10 v10.13.0
 	github.com/joho/godotenv v1.5.1

--- a/packages/lambda/src/cli/commands/still.ts
+++ b/packages/lambda/src/cli/commands/still.ts
@@ -6,7 +6,12 @@ import {
 	DEFAULT_MAX_RETRIES,
 	DEFAULT_OUTPUT_PRIVACY,
 } from '@remotion/lambda-client/constants';
-import type {ChromiumOptions, LogLevel} from '@remotion/renderer';
+import type {
+	ChromiumOptions,
+	LogLevel,
+	StillImageFormat,
+	VideoImageFormat,
+} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import {BrowserSafeApis} from '@remotion/renderer/client';
 import type {ProviderSpecifics} from '@remotion/serverless';
@@ -35,6 +40,7 @@ const {
 	binariesDirectoryOption,
 	mediaCacheSizeInBytesOption,
 	darkModeOption,
+	imageFormatOption,
 } = BrowserSafeApis.options;
 
 const {
@@ -206,11 +212,17 @@ export const stillCommand = async ({
 	const privacy = parsedLambdaCli.privacy ?? DEFAULT_OUTPUT_PRIVACY;
 	validatePrivacy(privacy, true);
 
+	const cliImageFormat = imageFormatOption.getValue({
+		commandLine: parsedCli,
+	}).value;
+
 	const {format: imageFormat, source: imageFormatReason} =
 		determineFinalStillImageFormat({
 			downloadName,
 			outName: outName ?? null,
-			cliFlag: parsedCli['image-format'] ?? null,
+			cliFlag:
+				(cliImageFormat as StillImageFormat | VideoImageFormat | undefined) ??
+				null,
 			isLambda: true,
 			fromUi: null,
 			configImageFormat:

--- a/packages/renderer/src/options/image-format-option.tsx
+++ b/packages/renderer/src/options/image-format-option.tsx
@@ -1,0 +1,35 @@
+import type {AnyRemotionOption} from './option';
+
+let imageFormat: string | null = null;
+
+const cliFlag = 'image-format' as const;
+
+export const imageFormatOption = {
+	name: 'Image Format',
+	cliFlag,
+	description: () => (
+		<>
+			Determines which in which image format to render. Can be either{' '}
+			<code>&quot;jpeg&quot;</code>, <code>&quot;png&quot;</code>,{' '}
+			<code>&quot;webp&quot;</code>, <code>&quot;pdf&quot;</code>, or{' '}
+			<code>&quot;none&quot;</code> depending on the render type.
+		</>
+	),
+	ssrName: 'imageFormat' as const,
+	docLink: 'https://www.remotion.dev/docs/config#setvideoimageformat',
+	type: null as string | null,
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {value: commandLine[cliFlag] as string, source: 'cli'};
+		}
+
+		if (imageFormat !== null) {
+			return {value: imageFormat, source: 'config'};
+		}
+
+		return {value: null, source: 'default'};
+	},
+	setConfig(value) {
+		imageFormat = value;
+	},
+} satisfies AnyRemotionOption<string | null>;

--- a/packages/renderer/src/options/index.tsx
+++ b/packages/renderer/src/options/index.tsx
@@ -24,6 +24,7 @@ import {forceNewStudioOption} from './force-new-studio';
 import {glOption} from './gl';
 import {hardwareAccelerationOption} from './hardware-acceleration';
 import {headlessOption} from './headless';
+import {imageFormatOption} from './image-format-option';
 import {imageSequencePatternOption} from './image-sequence-pattern';
 import {ipv4Option} from './ipv4';
 import {isProductionOption} from './is-production';
@@ -86,6 +87,7 @@ export const allOptions = {
 	logLevelOption,
 	delayRenderTimeoutInMillisecondsOption,
 	headlessOption,
+	imageFormatOption,
 	overwriteOption,
 	binariesDirectoryOption,
 	forSeamlessAacConcatenationOption,


### PR DESCRIPTION
## Summary
- Adds a new `imageFormatOption` to the renderer options system, following the same pattern as other options
- Migrates CLI, Lambda, and Cloud Run still commands to use `imageFormatOption.getValue()` instead of directly accessing `parsedCli['image-format']`
- Updates docs to use the `<Options>` component for image format documentation

## Test plan
- [ ] Verify `npx remotion still --image-format png` works correctly
- [ ] Verify `npx remotion render --image-format jpeg` works correctly
- [ ] Check docs pages render correctly with the `<Options>` component

🤖 Generated with [Claude Code](https://claude.com/claude-code)