### PR TITLE
`@remotion/design`: Fix icon alignment in Button rendered as anchor

### DIFF
--- a/packages/design/src/Button.tsx
+++ b/packages/design/src/Button.tsx
@@ -123,7 +123,7 @@ export const Button: React.FC<ButtonProps> = ({
 
 	const innerContent = (
 		<>
-			<div className={cn(loading && 'invisible', 'inline-flex')}>
+			<div className={cn(loading && 'invisible', 'inline-flex items-center')}>
 				{children}
 			</div>
 			{loading ? (


### PR DESCRIPTION
## Summary

- Adds `items-center` to the inner `inline-flex` wrapper in `<Button>` so that icons and text are vertically aligned when the button renders as an `<a>` element (i.e. when `href` is provided).
- Fixes the misaligned icon in the "Prompt a Video" button on the homepage (`GetStartedStrip.tsx`). Native `<button>` elements center content by default, but `<a>` elements do not, so the explicit `items-center` is needed.

## Test plan

- [ ] Verify the "Prompt a Video" button icon on the homepage is vertically centered
- [ ] Verify other anchor-style buttons (Docs, Discord, GitHub) still look correct
- [ ] Verify regular `<button>`-style buttons (e.g. the copy command button) are unaffected

Made with [Cursor](https://cursor.com)