### PR TITLE
`@remotion/it-tests`: Increase frame accuracy test timeout and limit concurrency

### DIFF
--- a/packages/it-tests/src/rendering/frame-accuracy.test.ts
+++ b/packages/it-tests/src/rendering/frame-accuracy.test.ts
@@ -8,7 +8,7 @@ test(
 		expect(missedFrames).toBeLessThanOrEqual(8);
 	},
 	{
-		timeout: 30000,
+		timeout: 60000,
 	},
 );
 
@@ -19,7 +19,7 @@ test(
 		expect(missedFrames).toBe(0);
 	},
 	{
-		timeout: 30000,
+		timeout: 60000,
 	},
 );
 
@@ -30,7 +30,7 @@ test(
 		expect(missedFrames).toBeLessThanOrEqual(8);
 	},
 	{
-		timeout: 30000,
+		timeout: 60000,
 	},
 );
 
@@ -41,6 +41,6 @@ test(
 		expect(missedFrames).toBe(0);
 	},
 	{
-		timeout: 30000,
+		timeout: 60000,
 	},
 );

--- a/packages/it-tests/src/rendering/test-utils.ts
+++ b/packages/it-tests/src/rendering/test-utils.ts
@@ -152,6 +152,8 @@ async function saveSequenceInTempDir(id: string) {
 			'--image-format',
 			'png',
 			'--sequence',
+			'--concurrency',
+			'2',
 		],
 		{
 			cwd: path.join(process.cwd(), '..', 'example'),


### PR DESCRIPTION
## Summary
- Add `--concurrency 2` flag to frame accuracy render commands to limit parallel work
- Increase test timeout from 30s to 60s to prevent flaky timeouts

## Test plan
- [ ] Frame accuracy tests pass without timing out