### PR TITLE
`@remotion/studio`: Fix hot reloading of Root.tsx

### DIFF
--- a/packages/core/src/register-root.ts
+++ b/packages/core/src/register-root.ts
@@ -18,6 +18,16 @@ export const registerRoot = (comp: React.FC) => {
 	}
 
 	if (Root) {
+		if (process.env.NODE_ENV !== 'production') {
+			// eslint-disable-next-line no-console
+			console.warn('registerRoot() was called more than once. Overwriting.');
+			Root = comp;
+			listeners.forEach((l) => {
+				l(comp);
+			});
+			return;
+		}
+
 		throw new Error('registerRoot() was called more than once.');
 	}
 


### PR DESCRIPTION
During HMR, the entry file is re-executed and registerRoot() may be called again. Previously this threw an error, which stopped hot reload from completing.This change allows registerRoot() to overwrite the existing root in development, notifies listeners with the new component, and lets Studio update normally without a full reload.
In production, the original strict behavior is preserved to avoid accidental double registration.

----------Optional changes:
if (Root !== comp) {
  console.warn(...)
}----------------