### PR TITLE
Docs: Add missing crossOrigin prop docs to Html5Audio

### DIFF
--- a/packages/docs/docs/html5-audio.mdx
+++ b/packages/docs/docs/html5-audio.mdx
@@ -223,6 +223,11 @@ Enable the [Web Audio API](/docs/audio/volume#limitations) for the audio tag.
 
 Handle an error playing the audio.
 
+### `crossOrigin?`
+
+Corresponds to the [`crossOrigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#attr-crossorigin) attribute of the `<audio>` element.
+One of `"anonymous"`, `"use-credentials"` or `undefined`.
+
 ### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
 
 Deprecated since v4.0.279: This prop intended to opt into setting the volume to a value higher than one, even though it would only apply during render.


### PR DESCRIPTION
## Summary
- Add missing `crossOrigin?` prop documentation to `<Html5Audio>` page, fixing broken anchor link from `/docs/media/audio` → `/docs/html5-audio#crossorigin`

## Test plan
- [ ] Run `docs:build-docs` and verify the broken anchor warning for `crossorigin` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)