### PR TITLE
Remove --experimental-cli flag from prettier

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -7,7 +7,7 @@ Ensure we are not on the main branch, make a branch if necessary.
 For all packages affected, run Prettier to format the code:
 
 ```
-bunx prettier --experimental-cli src --write
+bunx prettier src --write
 ```
 
 Commit the changes, use the following format:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ The **package name** for each folder is `@remotion/[folder-name]`, except for th
 
 - `bun` is the package manager for the project.
 - To build the project after you made changes, run `bunx turbo make --filter="[package-name]"` and only include the package you are working on. Refer to package naming convention above. For example, the command to build the package in `packages/shapes` is `bunx turbo make --filter="@remotion/shapes"`.
-- After making code changes, run `bunx prettier --experimental-cli src --write` to format the code. Do not run the formatted on the docs.
+- After making code changes, run `bunx prettier src --write` to format the code. Do not run the formatted on the docs.
 
 ## Documentation
 

--- a/packages/animated-emoji/package.json
+++ b/packages/animated-emoji/package.json
@@ -6,7 +6,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/animation-utils/package.json
+++ b/packages/animation-utils/package.json
@@ -13,7 +13,7 @@
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
 		"test": "bun test src"

--- a/packages/babel-loader/package.json
+++ b/packages/babel-loader/package.json
@@ -7,7 +7,7 @@
 	"description": "Babel loader for Remotion",
 	"main": "dist/index.js",
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d"
 	},

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/remotion-dev/remotion/issues"
 	},
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"make": "tsgo -d"

--- a/packages/captions/package.json
+++ b/packages/captions/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/remotion-dev/remotion/issues"
 	},
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"make": "tsgo -d"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
 		"remotiond": "remotiond-cli.js"
 	},
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"make": "tsgo -d"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
 	"types": "dist/cjs/index.d.ts",
 	"module": "dist/esm/index.mjs",
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"prepublishOnly": "bun ensure-correct-version.ts && cp ../../README.md .",
 		"lint": "eslint src",
 		"test": "bun test src/test",

--- a/packages/create-video/package.json
+++ b/packages/create-video/package.json
@@ -10,7 +10,7 @@
 		"create-video": "bin.js"
 	},
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -13,7 +13,7 @@
 		"url": "https://github.com/remotion-dev/remotion/issues"
 	},
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"watch": "tsgo -w",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -6,7 +6,7 @@
 	"private": true,
 	"version": "4.0.424",
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"docusaurus": "docusaurus",
 		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && docusaurus start --host 0.0.0.0",
 		"build-docs": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun prewarm-twoslash.ts && DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus build && bun copy-convert.ts && bun count-pages.ts",

--- a/packages/enable-scss/package.json
+++ b/packages/enable-scss/package.json
@@ -12,7 +12,7 @@
 	"scripts": {
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
-		"formatting": "prettier --experimental-cli src --check"
+		"formatting": "prettier src --check"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"contributors": [],

--- a/packages/eslint-config-flat/package.json
+++ b/packages/eslint-config-flat/package.json
@@ -12,7 +12,7 @@
 	],
 	"scripts": {
 		"lint": "eslint src",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},
 	"bugs": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -11,7 +11,7 @@
 	],
 	"scripts": {
 		"lint": "eslint src",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"make": "tsgo -d"
 	},
 	"bugs": {

--- a/packages/example-videos/package.json
+++ b/packages/example-videos/package.json
@@ -8,7 +8,7 @@
 	"types": "dist/index.d.ts",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d"
 	},

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -12,7 +12,7 @@
 		"dist"
 	],
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"dev": "remotion studio --props src/my-props.json",
 		"start-bun": "PATCH_BUN_DEVELOPMENT=true bun --bun remotion studio",
 		"start-js": "remotion preview src/entry.jsx",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/gif/package.json
+++ b/packages/gif/package.json
@@ -15,7 +15,7 @@
 	"types": "dist/cjs/index.d.ts",
 	"module": "dist/esm/index.mjs",
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && node build.mjs && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/google-fonts/package.json
+++ b/packages/google-fonts/package.json
@@ -10,7 +10,7 @@
 	"scripts": {
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
 		"generate": "bun --env-file=.env scripts/update-font-db.ts",
-		"formatting": "prettier --experimental-cli src --check"
+		"formatting": "prettier src --check"
 	},
 	"license": "SEE LICENSE IN LICENSE.md",
 	"dependencies": {

--- a/packages/google-fonts/scripts/update-font-db.ts
+++ b/packages/google-fonts/scripts/update-font-db.ts
@@ -27,14 +27,14 @@ export const googleFonts: Font[] = ${JSON.stringify(json.items, null, 2)};
 `.trimStart();
 
 await Bun.write(__dirname + '/google-fonts.ts', contents);
-await $`bunx prettier --experimental-cli --write ${__dirname}/google-fonts.ts`;
+await $`bunx prettier --write ${__dirname}/google-fonts.ts`;
 
 const packageJson = JSON.parse(await Bun.file('package.json').text());
 packageJson.typesVersions['>=1.0'] = {};
 await Bun.write('package.json', JSON.stringify(packageJson, null, 2));
 
 await $`bun scripts/generate.ts && bun scripts/generate-index.ts`;
-await $`bunx prettier --experimental-cli --write src`;
+await $`bunx prettier --write src`;
 await $`bun run make`;
 await $`bun ensure-generation.ts`;
 

--- a/packages/install-whisper-cpp/package.json
+++ b/packages/install-whisper-cpp/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/remotion-dev/remotion/issues"
 	},
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"make": "tsgo -d"

--- a/packages/it-tests/package.json
+++ b/packages/it-tests/package.json
@@ -10,7 +10,7 @@
 		"testssr": "bun test src/ssr src/bundle src/webcodecs src/templates src/monorepo --timeout 40000",
 		"testlambda": "exit 0",
 		"lint": "tsc -d",
-		"formatting": "prettier --experimental-cli src --check"
+		"formatting": "prettier src --check"
 	},
 	"private": true,
 	"devDependencies": {

--- a/packages/lambda-client/package.json
+++ b/packages/lambda-client/package.json
@@ -7,7 +7,7 @@
 	"main": "dist/cjs/index.js",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"test": "bun test src",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -8,7 +8,7 @@
 	"main": "dist/index.js",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"testlambda": "exit 0",
 		"test": "bun test src/test/unit",

--- a/packages/layout-utils/package.json
+++ b/packages/layout-utils/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/licensing/package.json
+++ b/packages/licensing/package.json
@@ -9,7 +9,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"lint": "eslint src",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
 		"test": "bun test src/test/prod-domain.test.ts src/test/register-usage-event-retry.test.ts"
 	},

--- a/packages/light-leaks/package.json
+++ b/packages/light-leaks/package.json
@@ -11,7 +11,7 @@
 	"sideEffects": false,
 	"type": "module",
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"watch": "tsgo -w",
 		"make": "tsgo && bun --env-file=../.env.bundle bundle.ts"

--- a/packages/lottie/package.json
+++ b/packages/lottie/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"

--- a/packages/media-parser/package.json
+++ b/packages/media-parser/package.json
@@ -7,7 +7,7 @@
 	"main": "dist/index.js",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"testwebcodecs": "bun test src/test --timeout=30000",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -8,7 +8,7 @@
 	"main": "dist/index.js",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d"
 	},

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -14,7 +14,7 @@
 	"type": "module",
 	"scripts": {
 		"if-node-18+": "node -e \"const [maj]=process.versions.node.split('.').map(Number); process.exit(maj>=18?0:1)\"",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"watch": "tsgo -w",
 		"test": "node src/test/execute.mjs",

--- a/packages/motion-blur/package.json
+++ b/packages/motion-blur/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
 		"test": "bun test src"

--- a/packages/openai-whisper/package.json
+++ b/packages/openai-whisper/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/remotion-dev/remotion/issues"
 	},
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"make": "tsgo -d"

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"

--- a/packages/player-example/package.json
+++ b/packages/player-example/package.json
@@ -28,7 +28,7 @@
 		"@types/node": "catalog:"
 	},
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"dev": "next dev",
 		"build-site": "next build"

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun ensure-correct-version.ts && bun --env-file=../.env.bundle bundle.ts",
 		"test": "bun test src",

--- a/packages/preload/package.json
+++ b/packages/preload/package.json
@@ -9,7 +9,7 @@
 	"types": "dist/index.d.ts",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d"
 	},

--- a/packages/react18-tests/package.json
+++ b/packages/react18-tests/package.json
@@ -7,7 +7,7 @@
 	"main": "dist/index.js",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d",
 		"testwebrenderer": "vitest src/test --browser --run",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -9,7 +9,7 @@
 	"types": "dist/index.d.ts",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"watch": "tsgo -w",

--- a/packages/rive/package.json
+++ b/packages/rive/package.json
@@ -9,7 +9,7 @@
 	"types": "dist/cjs/index.d.ts",
 	"module": "dist/esm/index.mjs",
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/rounded-text-box/package.json
+++ b/packages/rounded-text-box/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/serverless-client/package.json
+++ b/packages/serverless-client/package.json
@@ -8,7 +8,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"lint": "eslint src",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"test": "bun test src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -9,7 +9,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"lint": "eslint src",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"test": "bun test src",
 		"make": "tsgo -d"
 	},

--- a/packages/shapes/package.json
+++ b/packages/shapes/package.json
@@ -8,7 +8,7 @@
 	"main": "dist/index.js",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"

--- a/packages/skia/package.json
+++ b/packages/skia/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/streaming/package.json
+++ b/packages/streaming/package.json
@@ -9,7 +9,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"lint": "eslint src",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -10,7 +10,7 @@
 	"scripts": {
 		"lint": "eslint src",
 		"test": "bun test src",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"make": "tsgo -d"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",

--- a/packages/studio-shared/package.json
+++ b/packages/studio-shared/package.json
@@ -9,7 +9,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"lint": "eslint src",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"make": "tsgo -d"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -11,7 +11,7 @@
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
 		"test": "bun test src",
-		"formatting": "prettier --experimental-cli src --check"
+		"formatting": "prettier src --check"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"contributors": [],

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/transitions/package.json
+++ b/packages/transitions/package.json
@@ -12,7 +12,7 @@
 	"scripts": {
 		"test": "bun test src",
 		"lint": "eslint src",
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},
 	"author": "Jonny Burger",

--- a/packages/web-renderer/package.json
+++ b/packages/web-renderer/package.json
@@ -7,7 +7,7 @@
 	"main": "dist/index.js",
 	"type": "module",
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo && bun --env-file=../.env.bundle bundle.ts",
 		"watch": "tsgo -w",

--- a/packages/webcodecs/package.json
+++ b/packages/webcodecs/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/remotion-dev/remotion/issues"
 	},
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"test": "bun test src/test",
 		"testwebcodecs": "playwright test src/it-tests",

--- a/packages/whisper-web/package.json
+++ b/packages/whisper-web/package.json
@@ -7,7 +7,7 @@
 	"main": "dist/index.js",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},

--- a/packages/zod-types/package.json
+++ b/packages/zod-types/package.json
@@ -10,7 +10,7 @@
 	"module": "dist/esm/index.mjs",
 	"sideEffects": false,
 	"scripts": {
-		"formatting": "prettier --experimental-cli src --check",
+		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},


### PR DESCRIPTION
## Summary
- Removes the `--experimental-cli` flag from all prettier commands across the monorepo (57 files)
- The flag is no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)