### PR TITLE
Docs: Document loop prop behavior during fallback

### DIFF
--- a/packages/docs/docs/media/fallback.mdx
+++ b/packages/docs/docs/media/fallback.mdx
@@ -51,6 +51,22 @@ export const MyComp: React.FC = () => {
 
 If a fallback is prevented, the render will be cancelled instead.
 
+## Behavior of the `loop` prop during fallback
+
+The [`loop`](/docs/media/video#loop) prop of [`<Video>`](/docs/media/video) is handled differently depending on the environment:
+
+**During preview**, the fallback uses [`<Html5Video>`](/docs/html5-video), which natively supports the `loop` prop. Looping works as expected.
+
+**During rendering**, [`<OffthreadVideo>`](/docs/offthreadvideo) does not natively support looping. To work around this, `@remotion/media` attempts to determine the duration of the video and automatically wraps [`<OffthreadVideo>`](/docs/offthreadvideo) in a [`<Loop>`](/docs/loop) component.
+
+- In most cases, the duration can be extracted from the media container even if the codec is not supported.
+- If the duration **cannot** be determined (e.g. due to [CORS issues](/docs/cors-issues) or a broken container), the render will fail with an error.
+
+To ensure looping works reliably during rendering, make sure:
+
+- The video file is valid and not corrupted
+- There are no [CORS issues](/docs/cors-issues) preventing the file from being read
+
 ## Fallback is not possible in client-side rendering
 
 When using [`@remotion/web-renderer`](/docs/web-renderer) for client-side rendering, fallback to [`<OffthreadVideo>`](/docs/offthreadvideo) or [`<Html5Audio>`](/docs/html5-audio) is **not possible**.


### PR DESCRIPTION
## Summary

- Documents how the `loop` prop of `<Video>` from `@remotion/media` behaves when falling back to `<OffthreadVideo>`
- During preview, fallback uses `<Html5Video>` which natively supports `loop`
- During rendering, `@remotion/media` automatically wraps `<OffthreadVideo>` in a `<Loop>` by extracting the video duration from the container
- If duration cannot be determined (CORS issues, broken container), the render fails with an error

Closes #6583

## Test plan

- [ ] Verify the new section renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)