### PR TITLE
`@remotion/docusaurus-plugin`: Fix title fence not rendering in code blocks

### DIFF
--- a/packages/docusaurus-plugin/src/shiki.ts
+++ b/packages/docusaurus-plugin/src/shiki.ts
@@ -210,7 +210,7 @@ const remarkVisitor =
 
 		// Inject title bar if fence has a title attribute
 		if (fence.meta.title && typeof fence.meta.title === 'string') {
-			const title = fence.meta.title;
+			const {title} = fence.meta;
 			shikiHTML = shikiHTML.replace(
 				'<pre class="shiki',
 				'<pre class="shiki with-title',


### PR DESCRIPTION
## Summary
- Fixes #6591
- After PR #6560 upgraded from `shiki-twoslash` to Shiki v3's `codeToHtml()`, the `title=""` fence attribute in markdown code blocks stopped rendering
- The old `renderCodeToHTML()` from `shiki-twoslash` internally injected the `<div class="code-title">` element and `with-title` CSS class — this was lost in the migration
- Adds post-processing after `codeToHtml()` to inject the title bar HTML when `fence.meta.title` is present

## Test plan
- [ ] Verify code blocks with `title="filename.tsx"` render the title bar on docs pages (e.g. `/docs/vue`, `/docs/spline`)
- [ ] Verify code blocks without `title` are unaffected
- [ ] Verify twoslash code blocks with `title` also render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)