### PR TITLE
`@remotion/discord-poster`: Split changelog into chunks to avoid Discord 2000 char limit

### DIFF
--- a/packages/discord-poster/post.ts
+++ b/packages/discord-poster/post.ts
@@ -1,41 +1,68 @@
+const DISCORD_MAX_LENGTH = 2000;
+
 const latestRelease = await fetch(
-  "https://api.github.com/repos/remotion-dev/remotion/releases?per_page=1"
+	'https://api.github.com/repos/remotion-dev/remotion/releases?per_page=1',
 );
 
 const json = await latestRelease.json();
 
 const markdown = [
-  `${json[0].tag_name} has been released!`,
-  `<:merge:909914451447259177> ${json[0].html_url}`,
-  ...json[0].body.split("\n").map((s) => {
-    if (s.startsWith("## ")) {
-      return s.replace("## ", "**<:love:989990489824559104> ") + "**";
-    }
-    return s;
-  }),
+	`${json[0].tag_name} has been released!`,
+	`<:merge:909914451447259177> ${json[0].html_url}`,
+	...json[0].body.split('\n').map((s: string) => {
+		if (s.startsWith('## ')) {
+			return s.replace('## ', '**<:love:989990489824559104> ') + '**';
+		}
+		return s;
+	}),
 ]
-  .filter(Boolean)
-  .join("\n");
+	.filter(Boolean)
+	.join('\n');
 
-const res = await fetch(
-  `https://discord.com/api/channels/994527481598070815/messages`,
-  {
-    method: "post",
-    body: JSON.stringify({
-      content: markdown,
-      allowed_mentions: {},
-      flags: 1 << 2,
-    }),
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bot ${process.env.DISCORD_TOKEN}`,
-    },
-  }
-);
+const splitIntoChunks = (text: string): string[] => {
+	const chunks: string[] = [];
+	let remaining = text;
 
-if (res.status !== 200) {
-  console.log(await res.text());
-  process.exit(1);
+	while (remaining.length > 0) {
+		if (remaining.length <= DISCORD_MAX_LENGTH) {
+			chunks.push(remaining);
+			break;
+		}
+
+		const slice = remaining.slice(0, DISCORD_MAX_LENGTH);
+		const lastNewline = slice.lastIndexOf('\n');
+		const splitAt = lastNewline > 0 ? lastNewline : DISCORD_MAX_LENGTH;
+
+		chunks.push(remaining.slice(0, splitAt));
+		remaining = remaining.slice(splitAt).replace(/^\n/, '');
+	}
+
+	return chunks;
+};
+
+const chunks = splitIntoChunks(markdown);
+
+for (const chunk of chunks) {
+	const res = await fetch(
+		`https://discord.com/api/channels/994527481598070815/messages`,
+		{
+			method: 'post',
+			body: JSON.stringify({
+				content: chunk,
+				allowed_mentions: {},
+				flags: 1 << 2,
+			}),
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bot ${process.env.DISCORD_TOKEN}`,
+			},
+		},
+	);
+
+	if (res.status !== 200) {
+		console.log(await res.text());
+		process.exit(1);
+	}
 }
 
 export {};


### PR DESCRIPTION
## Summary
- Split Discord changelog messages into chunks of up to 2000 characters to avoid Discord's message length limit
- Chunks are split at newline boundaries to keep messages readable
- Each chunk is sent as a separate message sequentially

## Test plan
- [ ] Trigger a release with a changelog longer than 2000 characters and verify multiple messages are posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)