### PR TITLE
Docs: Use <Options> component for shared option descriptions

### DIFF
--- a/packages/docs/docs/bundle.mdx
+++ b/packages/docs/docs/bundle.mdx
@@ -68,11 +68,11 @@ Specify a desired output directory. If no passed, the webpack bundle will be cre
 
 ### `keyboardShortcutsEnabled?`
 
-A `boolean` specifying whether the Studio responds to the predefined keyboard shortcuts.. Default `true`.
+<Options id="disable-keyboard-shortcuts" />
 
 ### `enableCaching?`
 
-A `boolean` specifying whether Webpack caching should be enabled. Default `true`, it is recommended to leave caching enabled at all times since file changes should be recognized by Webpack nonetheless.
+<Options id="bundle-cache" />
 
 ### `publicPath?`
 
@@ -88,7 +88,7 @@ The current working directory is the directory from which your program gets exec
 
 ### `publicDir?`<AvailableFrom v="3.2.13" />
 
-Set the directory in which the files that can be loaded using [`staticFile()`](/docs/staticfile) are located. By default it is the folder `public/` located in the [Remotion Root](/docs/terminology/remotion-root). If you pass a relative path, it will be resolved against the [Remotion Root](/docs/terminology/remotion-root).
+<Options id="public-dir" />
 
 ### `onPublicDirCopyProgress?`<AvailableFrom v="3.3.3" />
 

--- a/packages/docs/docs/cloudrun/deploysite.mdx
+++ b/packages/docs/docs/cloudrun/deploysite.mdx
@@ -56,6 +56,10 @@ The bucket to where the website will be deployed. The bucket must have been crea
 
 Specify the subfolder in your Cloud Storage bucket that you want the site to deploy to. If you omit this property, a new subfolder with a random name will be created. If a site already exists with the name you passed, it will be overwritten. Can only contain the following characters: `0-9`, `a-z`, `A-Z`, `-`, `!`, `_`, `.`, `*`, `'`, `(`, `)`
 
+### `logLevel?`<AvailableFrom v="4.0.140"/>
+
+<Options id="log" />
+
 ### `options?`
 
 An object with the following properties:
@@ -79,11 +83,11 @@ Allows to pass a custom webpack override. See [`bundle()` -> webpackOverride](/d
 
 #### `enableCaching?`
 
-Whether webpack caching should be enabled. See [`bundle()` -> enableCaching](/docs/bundle#enablecaching) for more information.
+<Options id="bundle-cache" />
 
 #### `publicDir?`
 
-Set the directory in which the files that can be loaded using [`staticFile()`](/docs/staticfile) are located. By default it is the folder `public/` located in the [Remotion Root](/docs/terminology/remotion-root) folder. If you pass a relative path, it will be resolved against the [Remotion Root](/docs/terminology/remotion-root).
+<Options id="public-dir" />
 
 #### `rootDir?`
 
@@ -99,21 +103,15 @@ Ignore an error that gets thrown if you pass an entry point file which does not 
 
 #### `keyboardShortcutsEnabled?`<AvailableFrom v="4.0.407"/>
 
-_default: `true`_
-
-Whether keyboard shortcuts should be enabled in the Studio. See [Config.setKeyboardShortcutsEnabled()](/docs/config#setkeyboardshortcutsenabled) for more information.
+<Options id="disable-keyboard-shortcuts" />
 
 #### `askAIEnabled?`<AvailableFrom v="4.0.407"/>
 
-_default: `true`_
-
-Whether the Ask AI option should be enabled in the Studio. See [Config.setAskAIEnabled()](/docs/config#setaskaienabled) for more information.
+<Options id="disable-ask-ai" />
 
 #### `experimentalClientSideRenderingEnabled?`<AvailableFrom v="4.0.407"/>
 
-_default: `false`_
-
-Whether experimental client-side rendering should be enabled in the Studio. See [Config.setExperimentalClientSideRenderingEnabled()](/docs/config#setexperimentalclientsiderenderingenabled) for more information.
+<Options id="enable-experimental-client-side-rendering" />
 
 ## Return value
 

--- a/packages/docs/docs/lambda/deploysite.mdx
+++ b/packages/docs/docs/lambda/deploysite.mdx
@@ -82,13 +82,13 @@ Allows to pass a custom webpack override. See [`bundle()` -> webpackOverride](/d
 
 #### `enableCaching?`
 
-Whether webpack caching should be enabled. Default true. See [`bundle()` -> enableCaching](/docs/bundle#enablecaching) for more information.
+<Options id="bundle-cache" />
 
 #### `publicDir?`
 
 _available from v3.2.17_
 
-Set the directory in which the files that can be loaded using [`staticFile()`](/docs/staticfile) are located. By default it is the folder `public/` located in the [Remotion Root](/docs/terminology/remotion-root) folder. If you pass a relative path, it will be resolved against the [Remotion Root](/docs/terminology/remotion-root).
+<Options id="public-dir" />
 
 #### `rootDir?`
 
@@ -108,21 +108,15 @@ Ignore an error that gets thrown if you pass an entry point file which does not 
 
 #### `keyboardShortcutsEnabled?`<AvailableFrom v="4.0.407"/>
 
-_default: `true`_
-
-Whether keyboard shortcuts should be enabled in the Studio. See [Config.setKeyboardShortcutsEnabled()](/docs/config#setkeyboardshortcutsenabled) for more information.
+<Options id="disable-keyboard-shortcuts" />
 
 #### `askAIEnabled?`<AvailableFrom v="4.0.407"/>
 
-_default: `true`_
-
-Whether the Ask AI option should be enabled in the Studio. See [Config.setAskAIEnabled()](/docs/config#setaskaienabled) for more information.
+<Options id="disable-ask-ai" />
 
 #### `experimentalClientSideRenderingEnabled?`<AvailableFrom v="4.0.407"/>
 
-_default: `false`_
-
-Whether experimental client-side rendering should be enabled in the Studio. See [Config.setExperimentalClientSideRenderingEnabled()](/docs/config#setexperimentalclientsiderenderingenabled) for more information.
+<Options id="enable-experimental-client-side-rendering" />
 
 ### `privacy?`
 


### PR DESCRIPTION
## Summary
- Replace inline option descriptions with `<Options>` component in `cloudrun/deploysite.mdx`, `lambda/deploysite.mdx`, and `bundle.mdx`
- Options now use the single source of truth from `@remotion/renderer` options definitions
- Adds missing `logLevel` option to `cloudrun/deploySite`

### Options replaced:
- `enableCaching` → `<Options id="bundle-cache" />`
- `publicDir` → `<Options id="public-dir" />`
- `keyboardShortcutsEnabled` → `<Options id="disable-keyboard-shortcuts" />`
- `askAIEnabled` → `<Options id="disable-ask-ai" />`
- `experimentalClientSideRenderingEnabled` → `<Options id="enable-experimental-client-side-rendering" />`

## Test plan
- [ ] Verify docs pages render correctly for `bundle()`, `lambda/deploySite()`, and `cloudrun/deploySite()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)