### PR TITLE
`@remotion/renderer`: Rename mimeType to contentType

### DIFF
--- a/packages/docs/docs/renderer/render-media.mdx
+++ b/packages/docs/docs/renderer/render-media.mdx
@@ -549,7 +549,7 @@ The return value is an object with the following properties:
 
 - `buffer`: If `outputLocation` is not specified or `null`, contains a buffer, otherwise `null`.
 - `slowestFrames`: An array of the 10 slowest frames in the shape of `{frame:<Frame number>, time:<Time to render frame ms>}`. You can use this information to optimise your render times.
-- `mimeType`: <AvailableFrom v="4.0.426" inline /> The MIME type of the rendered output, e.g. `"video/mp4"`, `"video/webm"`, `"image/gif"`.
+- `contentType`: <AvailableFrom v="4.0.426" inline /> The content type of the rendered output, e.g. `"video/mp4"`, `"video/webm"`, `"image/gif"`.
 
 _**from v3.0.26**:_
 

--- a/packages/docs/docs/renderer/render-still.mdx
+++ b/packages/docs/docs/renderer/render-still.mdx
@@ -246,7 +246,7 @@ Renamed to `jpegQuality` in `v4.0.0`.
 The return value is a promise that resolves to an object with the following keys:
 
 - `buffer`: <AvailableFrom v="3.3.9" inline /> A `Buffer` that only exists if no `output` option was provided. Otherwise null.
-- `mimeType`: <AvailableFrom v="4.0.426" inline /> The MIME type of the rendered output, e.g. `"image/png"`, `"image/jpeg"`.
+- `contentType`: <AvailableFrom v="4.0.426" inline /> The content type of the rendered output, e.g. `"image/png"`, `"image/jpeg"`.
 
 ## Compatibility
 

--- a/packages/it-tests/src/ssr/render-media.test.ts
+++ b/packages/it-tests/src/ssr/render-media.test.ts
@@ -124,7 +124,7 @@ test('Render video to a buffer', async () => {
 		throw new Error('not found');
 	}
 
-	const {buffer, mimeType} = await renderMedia({
+	const {buffer, contentType} = await renderMedia({
 		codec: 'h264',
 		serveUrl:
 			'https://661808694cad562ef2f35be7--incomparable-dasik-a4482b.netlify.app/',
@@ -134,7 +134,7 @@ test('Render video to a buffer', async () => {
 	});
 
 	expect(buffer?.length).toBeGreaterThan(2000);
-	expect(mimeType).toBe('video/mp4');
+	expect(contentType).toBe('video/mp4');
 });
 
 test('Should fail invalid serve URL', async () => {

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -221,7 +221,7 @@ type Await<T> = T extends PromiseLike<infer U> ? U : T;
 type RenderMediaResult = {
 	buffer: Buffer | null;
 	slowestFrames: SlowFrame[];
-	mimeType: string;
+	contentType: string;
 };
 
 const internalRenderMediaRaw = ({
@@ -828,7 +828,7 @@ const internalRenderMediaRaw = ({
 				const result: RenderMediaResult = {
 					buffer,
 					slowestFrames,
-					mimeType:
+					contentType:
 						mimeLookup(
 							'file.' + getFileExtensionFromCodec(codec, audioCodec),
 						) || 'application/octet-stream',

--- a/packages/renderer/src/render-still.ts
+++ b/packages/renderer/src/render-still.ts
@@ -119,7 +119,7 @@ export type RenderStillOptions = {
 	};
 
 type CleanupFn = () => Promise<unknown>;
-type RenderStillReturnValue = {buffer: Buffer | null; mimeType: string};
+type RenderStillReturnValue = {buffer: Buffer | null; contentType: string};
 
 const innerRenderStill = async ({
 	composition,
@@ -387,7 +387,8 @@ const innerRenderStill = async ({
 
 	return {
 		buffer: output ? null : buffer,
-		mimeType: mimeLookup('file.' + imageFormat) || 'application/octet-stream',
+		contentType:
+			mimeLookup('file.' + imageFormat) || 'application/octet-stream',
 	};
 };
 

--- a/packages/renderer/src/test/render-still.test.ts
+++ b/packages/renderer/src/test/render-still.test.ts
@@ -41,7 +41,7 @@ test(
 	async () => {
 		await ensureBrowser();
 
-		const {buffer, mimeType} = await renderStill({
+		const {buffer, contentType} = await renderStill({
 			composition: {
 				width: 1000,
 				height: 1000,
@@ -62,7 +62,7 @@ test(
 			verbose: false,
 		});
 		expect(buffer?.length).toBeGreaterThan(1000);
-		expect(mimeType).toBe('image/png');
+		expect(contentType).toBe('image/png');
 	},
 	{
 		timeout: 30000,


### PR DESCRIPTION
## Summary
- Renames `mimeType` to `contentType` in the return values of `renderMedia()` and `renderStill()`
- Updates tests and docs accordingly

## Test plan
- [ ] Existing `contentType` assertions pass in render-media and render-still tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)