### PR TITLE
`@remotion/studio`: Hide "Open in Explorer" icon in read-only mode

### DIFF
--- a/packages/studio/src/components/AssetSelector.tsx
+++ b/packages/studio/src/components/AssetSelector.tsx
@@ -181,6 +181,7 @@ export const AssetSelector: React.FC<{
 						toggleFolder={toggleFolder}
 						dropLocation={dropLocation}
 						setDropLocation={setDropLocation}
+						readOnlyStudio={readOnlyStudio}
 					/>
 				</div>
 			)}

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -76,6 +76,7 @@ const AssetFolderItem: React.FC<{
 	) => void;
 	readonly dropLocation: string | null;
 	readonly setDropLocation: React.Dispatch<React.SetStateAction<string | null>>;
+	readonly readOnlyStudio: boolean;
 }> = ({
 	tabIndex,
 	item,
@@ -84,6 +85,7 @@ const AssetFolderItem: React.FC<{
 	toggleFolder,
 	dropLocation,
 	setDropLocation,
+	readOnlyStudio,
 }) => {
 	const [hovered, setHovered] = useState(false);
 	const openFolderTimerRef = useRef<number | null>(null);
@@ -170,6 +172,7 @@ const AssetFolderItem: React.FC<{
 					toggleFolder={toggleFolder}
 					dropLocation={dropLocation}
 					setDropLocation={setDropLocation}
+					readOnlyStudio={readOnlyStudio}
 				/>
 			) : null}
 		</div>
@@ -188,6 +191,7 @@ export const AssetFolderTree: React.FC<{
 	) => void;
 	readonly dropLocation: string | null;
 	readonly setDropLocation: React.Dispatch<React.SetStateAction<string | null>>;
+	readonly readOnlyStudio: boolean;
 }> = ({
 	item,
 	level,
@@ -197,6 +201,7 @@ export const AssetFolderTree: React.FC<{
 	tabIndex,
 	dropLocation,
 	setDropLocation,
+	readOnlyStudio,
 }) => {
 	const combinedParents = useMemo(() => {
 		return [parentFolder, name].filter(NoReactInternals.truthy).join('/');
@@ -214,6 +219,7 @@ export const AssetFolderTree: React.FC<{
 						toggleFolder={toggleFolder}
 						dropLocation={dropLocation}
 						setDropLocation={setDropLocation}
+						readOnlyStudio={readOnlyStudio}
 					/>
 				);
 			})}
@@ -225,6 +231,7 @@ export const AssetFolderTree: React.FC<{
 						tabIndex={tabIndex}
 						level={level}
 						parentFolder={combinedParents}
+						readOnlyStudio={readOnlyStudio}
 					/>
 				);
 			})}
@@ -237,7 +244,8 @@ const AssetSelectorItem: React.FC<{
 	readonly tabIndex: number;
 	readonly level: number;
 	readonly parentFolder: string;
-}> = ({item, tabIndex, level, parentFolder}) => {
+	readonly readOnlyStudio: boolean;
+}> = ({item, tabIndex, level, parentFolder, readOnlyStudio}) => {
 	const isMobileLayout = useMobileLayout();
 	const [hovered, setHovered] = useState(false);
 	const {setSidebarCollapsedState} = useContext(SidebarContext);
@@ -364,12 +372,16 @@ const AssetSelectorItem: React.FC<{
 							renderAction={renderCopyAction}
 							onClick={copyToClipboard}
 						/>
-						<Spacing x={0.5} />
-						<InlineAction
-							title="Open in Explorer"
-							renderAction={renderFileExplorerAction}
-							onClick={revealInExplorer}
-						/>
+						{readOnlyStudio ? null : (
+							<>
+								<Spacing x={0.5} />
+								<InlineAction
+									title="Open in Explorer"
+									renderAction={renderFileExplorerAction}
+									onClick={revealInExplorer}
+								/>
+							</>
+						)}
 					</>
 				) : null}
 			</div>


### PR DESCRIPTION
## Summary
- Hides the "Open in Explorer" inline action on asset items when the studio is in read-only mode
- Threads `readOnlyStudio` prop from `AssetSelector` → `AssetFolderTree` → `AssetFolderItem` / `AssetSelectorItem`
- The "Copy staticFile() name" action remains visible in read-only mode since it doesn't require file system access

Closes #6540

## Test plan
- [ ] Open a read-only studio instance and verify the "Open in Explorer" icon does not appear on asset hover
- [ ] Open a normal (non-read-only) studio and verify the "Open in Explorer" icon still appears on asset hover
- [ ] Verify the "Copy staticFile() name" icon still works in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)