### PR TITLE
`@remotion/studio`: Fix infinite loop when duplicating composition

### DIFF
--- a/packages/studio/src/components/NewComposition/CodemodFooter.tsx
+++ b/packages/studio/src/components/NewComposition/CodemodFooter.tsx
@@ -122,7 +122,7 @@ export const CodemodFooter: React.FC<{
 			aborted = true;
 			abortController.abort();
 		};
-	}, [codemodStatus, getCanApplyCodemod, setSelectedModal]);
+	}, [getCanApplyCodemod]);
 
 	const disabled =
 		!valid ||


### PR DESCRIPTION
## Summary
- Fixes #6620
- The `useEffect` that triggers the dry-run API call (`/api/apply-codemod`) had `codemodStatus` in its dependency array
- When the dry-run succeeded, it updated `codemodStatus` (new object reference), which re-triggered the effect, creating an infinite loop of API calls
- Removed `codemodStatus` from the dependency array since the effect only needs to re-run when the `codemod` input changes (captured via `getCanApplyCodemod`)

## Test plan
- [ ] Open Studio, right-click a composition → "Duplicate composition"
- [ ] Verify only one dry-run call is made to `/api/apply-codemod` (check Network tab)
- [ ] Change fields (ID, width, height, etc.) and verify a new dry-run is triggered per change
- [ ] Submit the duplication and verify it works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)