### PR TITLE
`remotion`: Inherit `stack` for better display in Studio

### DIFF
--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -205,6 +205,8 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	const env = useRemotionEnvironment();
 
+	const inheritedStack = (other as any)?.stack ?? null;
+
 	useEffect(() => {
 		if (!env.isStudio) {
 			return;
@@ -221,7 +223,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 			showInTimeline,
 			nonce,
 			loopDisplay,
-			stack: stack ?? null,
+			stack: stack ?? inheritedStack,
 			premountDisplay: premountDisplay ?? null,
 			postmountDisplay: postmountDisplay ?? null,
 		});
@@ -246,6 +248,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		premountDisplay,
 		postmountDisplay,
 		env.isStudio,
+		inheritedStack,
 	]);
 
 	// Ceil to support floats

--- a/packages/light-leaks/src/LightLeak.tsx
+++ b/packages/light-leaks/src/LightLeak.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {
 	AbsoluteFill,
+	Internals,
 	Sequence,
 	useCurrentFrame,
 	useDelayRender,
@@ -256,8 +257,14 @@ export const LightLeak: React.FC<LightLeakProps> = ({
 	}
 
 	return (
-		<Sequence durationInFrames={resolvedDuration} {...sequenceProps}>
+		<Sequence
+			durationInFrames={resolvedDuration}
+			name="<LightLeak>"
+			{...sequenceProps}
+		>
 			<LightLeakCanvas seed={seed} hueShift={hueShift} />
 		</Sequence>
 	);
 };
+
+Internals.addSequenceStackTraces(LightLeak);


### PR DESCRIPTION
This would be useful for example in the `<LightLeak>` component which is a wrapper around `<Sequence>`