### PR TITLE
`@remotion/studio-server`: Faster "Open In Editor" on macOS

### DIFF
--- a/packages/studio-server/src/helpers/open-in-editor-url-scheme.ts
+++ b/packages/studio-server/src/helpers/open-in-editor-url-scheme.ts
@@ -47,7 +47,8 @@ export const openInEditorViaUrlScheme = ({
 	}
 
 	const filePath = fileName.startsWith('/') ? fileName.substring(1) : fileName;
-	const url = `${urlScheme}://file/${filePath}:${lineNumber}:${colNumber}`;
+	const encodedPath = filePath.split('/').map(encodeURIComponent).join('/');
+	const url = `${urlScheme}://file/${encodedPath}:${lineNumber}:${colNumber}`;
 	return new Promise<boolean>((resolve) => {
 		const proc = child_process.spawn('open', [url], {
 			stdio: 'ignore',

--- a/packages/studio-server/src/helpers/open-in-editor.ts
+++ b/packages/studio-server/src/helpers/open-in-editor.ts
@@ -564,7 +564,10 @@ export async function launchEditor({
 			colNumber,
 		});
 		if (result) {
-			return result;
+			const opened = await result;
+			if (opened) {
+				return true;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- On macOS with VS Code derivatives (Cursor, VS Code, Windsurf, VSCodium, Code Insiders), use `open <scheme>://file/...` instead of spawning the CLI
- This skips the Node.js process startup and IPC handshake, making "open in editor" noticeably faster
- Falls back to the existing CLI spawn approach on other platforms or for non-VS-Code editors

## Test plan
- [x] Tested `open "cursor://file/..."` on macOS — opens file at correct line/column
- [ ] Verify fallback still works on Linux/Windows
- [ ] Verify `--new-window` still spawns via CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)