### PR TITLE
Add install and build steps to Pullfrog workflow

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -27,6 +27,18 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - uses: oven-sh/setup-bun@v2.1.2
+        with:
+          bun-version: 1.3.3
+      - name: Install
+        run: bun ci
+      - name: Cache Turbo
+        uses: rharkor/caching-for-turbo@v2.3.11
+      - name: Build
+        run: bun run build
       - name: Run agent
         uses: pullfrog/pullfrog@v0
         with:


### PR DESCRIPTION
## Summary
- Adds Node.js, Bun setup, `bun ci` install, Turbo cache, and `bun run build` steps to the Pullfrog workflow before the agent runs
- Matches the pattern used in `push.yml` for consistent CI setup

## Test plan
- [ ] Verify Pullfrog workflow runs successfully with the new setup steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)