### PR TITLE
`@remotion/bundler`: Fix rspack warnings and HMR breakage from whisper-web

### DIFF
--- a/packages/bundler/src/rspack-config.ts
+++ b/packages/bundler/src/rspack-config.ts
@@ -94,11 +94,11 @@ export const rspackConfig = async ({
 	// but the TypeScript types differ. Cast through `any` for the override.
 	const conf = (await webpackOverride({
 		...getBaseConfig(environment, poll),
-		ignoreWarnings: [
-			/Circular dependency between chunks with runtime/,
-			/Critical dependency: the request of a dependency is an expression/,
-			/"__dirname" is used and has been mocked/,
-		],
+		ignoreWarnings: [/"__dirname" is used and has been mocked/],
+		node: {
+			// Suppress the warning in `source-map`
+			__dirname: 'mock',
+		},
 		entry: [
 			require.resolve('./setup-environment'),
 			userDefinedComponent,


### PR DESCRIPTION
## Summary
- Suppress `__dirname` warning from `source-map` by setting `node.__dirname` to `"mock"` and adding `ignoreWarnings` pattern
- Fix circular chunk dependency that breaks HMR when `@remotion/whisper-web` is imported: Emscripten's `main.js` spawns Workers of itself via `new Worker(new URL('./main.js', import.meta.url))`, causing rspack to create a circular `em-pthread` ↔ `main` chunk dependency. Disable Worker detection for that file with `parser.worker: false`.

## Test plan
- [ ] Run `bunx remotion studio` in `packages/example` with `@remotion/whisper-web` imported
- [ ] Verify no `__dirname` warning
- [ ] Verify no circular chunk dependency warning
- [ ] Verify HMR works (edit a file and confirm hot reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)