### PR TITLE
`@remotion/bundler`: Add `process.env.EXPERIMENTAL_VISUAL_MODE_ENABLED` define plugin variable

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -67,12 +67,14 @@ export const getConfig = ({
 	bufferStateDelayInMilliseconds,
 	maxTimelineTracks,
 	experimentalClientSideRenderingEnabled,
+	experimentalVisualModeEnabled,
 }: {
 	outDir: string;
 	entryPoint: string;
 	resolvedRemotionRoot: string;
 	bufferStateDelayInMilliseconds: number | null;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 	maxTimelineTracks: number | null;
 	onProgress: (progress: number) => void;
 	options: MandatoryLegacyBundleOptions;
@@ -98,6 +100,7 @@ export const getConfig = ({
 		bufferStateDelayInMilliseconds,
 		poll: null,
 		experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled,
 		askAIEnabled: options?.askAIEnabled ?? true,
 	};
 
@@ -118,6 +121,7 @@ type NewBundleOptions = {
 	bufferStateDelayInMilliseconds: number | null;
 	audioLatencyHint: AudioContextLatencyCategory | null;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 	renderDefaults: RenderDefaults | null;
 };
 
@@ -235,6 +239,7 @@ export const internalBundle = async (
 		maxTimelineTracks: actualArgs.maxTimelineTracks,
 		experimentalClientSideRenderingEnabled:
 			actualArgs.experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled: actualArgs.experimentalVisualModeEnabled,
 	});
 
 	if (actualArgs.rspack) {
@@ -412,6 +417,8 @@ export async function bundle(...args: Arguments): Promise<string> {
 		audioLatencyHint: actualArgs.audioLatencyHint ?? null,
 		experimentalClientSideRenderingEnabled:
 			actualArgs.experimentalClientSideRenderingEnabled ?? false,
+		experimentalVisualModeEnabled:
+			actualArgs.experimentalVisualModeEnabled ?? false,
 		renderDefaults: actualArgs.renderDefaults ?? null,
 		askAIEnabled: actualArgs.askAIEnabled ?? true,
 		keyboardShortcutsEnabled: actualArgs.keyboardShortcutsEnabled ?? true,

--- a/packages/bundler/src/define-plugin-definitions.ts
+++ b/packages/bundler/src/define-plugin-definitions.ts
@@ -4,12 +4,14 @@ export const getDefinePluginDefinitions = ({
 	keyboardShortcutsEnabled,
 	bufferStateDelayInMilliseconds,
 	experimentalClientSideRenderingEnabled,
+	experimentalVisualModeEnabled,
 }: {
 	maxTimelineTracks: number | null;
 	askAIEnabled: boolean;
 	keyboardShortcutsEnabled: boolean;
 	bufferStateDelayInMilliseconds: number | null;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 }) => ({
 	'process.env.MAX_TIMELINE_TRACKS': maxTimelineTracks,
 	'process.env.ASK_AI_ENABLED': askAIEnabled,
@@ -18,4 +20,5 @@ export const getDefinePluginDefinitions = ({
 		bufferStateDelayInMilliseconds,
 	'process.env.EXPERIMENTAL_CLIENT_SIDE_RENDERING_ENABLED':
 		experimentalClientSideRenderingEnabled,
+	'process.env.EXPERIMENTAL_VISUAL_MODE_ENABLED': experimentalVisualModeEnabled,
 });

--- a/packages/bundler/src/rspack-config.ts
+++ b/packages/bundler/src/rspack-config.ts
@@ -27,6 +27,7 @@ export const rspackConfig = async ({
 	bufferStateDelayInMilliseconds,
 	poll,
 	experimentalClientSideRenderingEnabled,
+	experimentalVisualModeEnabled,
 	askAIEnabled,
 }: {
 	entry: string;
@@ -43,6 +44,7 @@ export const rspackConfig = async ({
 	poll: number | null;
 	askAIEnabled: boolean;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 }): Promise<[string, RspackConfiguration]> => {
 	let lastProgress = 0;
 
@@ -53,6 +55,7 @@ export const rspackConfig = async ({
 			keyboardShortcutsEnabled,
 			bufferStateDelayInMilliseconds,
 			experimentalClientSideRenderingEnabled,
+			experimentalVisualModeEnabled,
 		}) as unknown as Record<string, string>,
 	);
 

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -41,6 +41,7 @@ export const webpackConfig = async ({
 	bufferStateDelayInMilliseconds,
 	poll,
 	experimentalClientSideRenderingEnabled,
+	experimentalVisualModeEnabled,
 	askAIEnabled,
 }: {
 	entry: string;
@@ -57,6 +58,7 @@ export const webpackConfig = async ({
 	poll: number | null;
 	askAIEnabled: boolean;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 }): Promise<[string, WebpackConfiguration]> => {
 	const esbuildLoaderOptions: LoaderOptions = {
 		target: 'chrome85',
@@ -74,6 +76,7 @@ export const webpackConfig = async ({
 			keyboardShortcutsEnabled,
 			bufferStateDelayInMilliseconds,
 			experimentalClientSideRenderingEnabled,
+			experimentalVisualModeEnabled,
 		}),
 	);
 

--- a/packages/cli/src/benchmark.ts
+++ b/packages/cli/src/benchmark.ts
@@ -57,6 +57,7 @@ const {
 	darkModeOption,
 	askAIOption,
 	experimentalClientSideRenderingOption,
+	experimentalVisualModeOption,
 	keyboardShortcutsOption,
 	rspackOption,
 	pixelFormatOption,
@@ -277,6 +278,9 @@ export const benchmarkCommand = async (
 		experimentalClientSideRenderingOption.getValue({
 			commandLine: parsedCli,
 		}).value;
+	const experimentalVisualModeEnabled = experimentalVisualModeOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 	const askAIEnabled = askAIOption.getValue({commandLine: parsedCli}).value;
 	const keyboardShortcutsEnabled = keyboardShortcutsOption.getValue({
 		commandLine: parsedCli,
@@ -355,6 +359,7 @@ export const benchmarkCommand = async (
 			publicPath,
 			audioLatencyHint: null,
 			experimentalClientSideRenderingEnabled,
+			experimentalVisualModeEnabled,
 			askAIEnabled,
 			keyboardShortcutsEnabled,
 			rspack,

--- a/packages/cli/src/bundle.ts
+++ b/packages/cli/src/bundle.ts
@@ -20,6 +20,7 @@ const {
 	audioLatencyHintOption,
 	askAIOption,
 	experimentalClientSideRenderingOption,
+	experimentalVisualModeOption,
 	keyboardShortcutsOption,
 	rspackOption,
 	outDirOption,
@@ -72,6 +73,9 @@ export const bundleCommand = async (
 		experimentalClientSideRenderingOption.getValue({
 			commandLine: parsedCli,
 		}).value;
+	const experimentalVisualModeEnabled = experimentalVisualModeOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 	const askAIEnabled = askAIOption.getValue({commandLine: parsedCli}).value;
 	const keyboardShortcutsEnabled = keyboardShortcutsOption.getValue({
 		commandLine: parsedCli,
@@ -166,6 +170,7 @@ export const bundleCommand = async (
 		publicPath,
 		audioLatencyHint,
 		experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled,
 		askAIEnabled,
 		keyboardShortcutsEnabled,
 		rspack,

--- a/packages/cli/src/compositions.ts
+++ b/packages/cli/src/compositions.ts
@@ -28,6 +28,7 @@ const {
 	darkModeOption,
 	askAIOption,
 	experimentalClientSideRenderingOption,
+	experimentalVisualModeOption,
 	keyboardShortcutsOption,
 	rspackOption,
 	browserExecutableOption,
@@ -134,6 +135,9 @@ export const listCompositionsCommand = async (
 		experimentalClientSideRenderingOption.getValue({
 			commandLine: parsedCli,
 		}).value;
+	const experimentalVisualModeEnabled = experimentalVisualModeOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 	const keyboardShortcutsEnabled = keyboardShortcutsOption.getValue({
 		commandLine: parsedCli,
 	}).value;
@@ -172,6 +176,7 @@ export const listCompositionsCommand = async (
 			publicPath,
 			audioLatencyHint,
 			experimentalClientSideRenderingEnabled,
+			experimentalVisualModeEnabled,
 			askAIEnabled,
 			keyboardShortcutsEnabled,
 			rspack,

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -129,6 +129,7 @@ export const renderVideoFlow = async ({
 	rspack,
 	askAIEnabled,
 	experimentalClientSideRenderingEnabled,
+	experimentalVisualModeEnabled,
 	keyboardShortcutsEnabled,
 	shouldCache,
 }: {
@@ -196,6 +197,7 @@ export const renderVideoFlow = async ({
 	rspack: boolean;
 	askAIEnabled: boolean;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 	keyboardShortcutsEnabled: boolean;
 	shouldCache: boolean;
 }) => {
@@ -345,6 +347,7 @@ export const renderVideoFlow = async ({
 			publicPath,
 			audioLatencyHint,
 			experimentalClientSideRenderingEnabled,
+			experimentalVisualModeEnabled,
 			askAIEnabled,
 			keyboardShortcutsEnabled,
 			rspack,

--- a/packages/cli/src/render-flows/still.ts
+++ b/packages/cli/src/render-flows/still.ts
@@ -87,6 +87,7 @@ export const renderStillFlow = async ({
 	rspack,
 	askAIEnabled,
 	experimentalClientSideRenderingEnabled,
+	experimentalVisualModeEnabled,
 	keyboardShortcutsEnabled,
 	shouldCache,
 }: {
@@ -128,6 +129,7 @@ export const renderStillFlow = async ({
 	rspack: boolean;
 	askAIEnabled: boolean;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 	keyboardShortcutsEnabled: boolean;
 	shouldCache: boolean;
 }) => {
@@ -231,6 +233,7 @@ export const renderStillFlow = async ({
 			publicPath,
 			audioLatencyHint,
 			experimentalClientSideRenderingEnabled,
+			experimentalVisualModeEnabled,
 			askAIEnabled,
 			keyboardShortcutsEnabled,
 			rspack,

--- a/packages/cli/src/render-queue/process-still.ts
+++ b/packages/cli/src/render-queue/process-still.ts
@@ -9,6 +9,7 @@ const {
 	publicDirOption,
 	askAIOption,
 	experimentalClientSideRenderingOption,
+	experimentalVisualModeOption,
 	keyboardShortcutsOption,
 	rspackOption,
 	browserExecutableOption,
@@ -44,6 +45,9 @@ export const processStill = async ({
 		experimentalClientSideRenderingOption.getValue({
 			commandLine: parsedCli,
 		}).value;
+	const experimentalVisualModeEnabled = experimentalVisualModeOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 	const keyboardShortcutsEnabled = keyboardShortcutsOption.getValue({
 		commandLine: parsedCli,
 	}).value;
@@ -93,6 +97,7 @@ export const processStill = async ({
 		mediaCacheSizeInBytes: job.mediaCacheSizeInBytes,
 		askAIEnabled,
 		experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled,
 		keyboardShortcutsEnabled,
 		rspack,
 		shouldCache,

--- a/packages/cli/src/render-queue/process-video.ts
+++ b/packages/cli/src/render-queue/process-video.ts
@@ -11,6 +11,7 @@ const {
 	publicDirOption,
 	askAIOption,
 	experimentalClientSideRenderingOption,
+	experimentalVisualModeOption,
 	keyboardShortcutsOption,
 	rspackOption,
 	browserExecutableOption,
@@ -129,6 +130,9 @@ export const processVideoJob = async ({
 		experimentalClientSideRenderingEnabled:
 			experimentalClientSideRenderingOption.getValue({commandLine: parsedCli})
 				.value,
+		experimentalVisualModeEnabled: experimentalVisualModeOption.getValue({
+			commandLine: parsedCli,
+		}).value,
 		keyboardShortcutsEnabled,
 		rspack,
 		shouldCache,

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -47,6 +47,7 @@ const {
 	darkModeOption,
 	askAIOption,
 	experimentalClientSideRenderingOption,
+	experimentalVisualModeOption,
 	keyboardShortcutsOption,
 	rspackOption,
 	pixelFormatOption,
@@ -256,6 +257,9 @@ export const render = async (
 		experimentalClientSideRenderingOption.getValue({
 			commandLine: parsedCli,
 		}).value;
+	const experimentalVisualModeEnabled = experimentalVisualModeOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 
 	await renderVideoFlow({
 		fullEntryPoint,
@@ -328,6 +332,7 @@ export const render = async (
 		imageSequencePattern,
 		askAIEnabled,
 		experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled,
 		keyboardShortcutsEnabled,
 		rspack,
 		shouldCache,

--- a/packages/cli/src/setup-cache.ts
+++ b/packages/cli/src/setup-cache.ts
@@ -33,6 +33,7 @@ export const bundleOnCliOrTakeServeUrl = async ({
 	publicPath,
 	audioLatencyHint,
 	experimentalClientSideRenderingEnabled,
+	experimentalVisualModeEnabled,
 	askAIEnabled,
 	keyboardShortcutsEnabled,
 	rspack,
@@ -57,6 +58,7 @@ export const bundleOnCliOrTakeServeUrl = async ({
 	publicPath: string | null;
 	audioLatencyHint: AudioContextLatencyCategory | null;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 	askAIEnabled: boolean;
 	keyboardShortcutsEnabled: boolean;
 	rspack: boolean;
@@ -102,6 +104,7 @@ export const bundleOnCliOrTakeServeUrl = async ({
 		publicPath,
 		audioLatencyHint,
 		experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled,
 		askAIEnabled,
 		keyboardShortcutsEnabled,
 		rspack,
@@ -131,6 +134,7 @@ export const bundleOnCli = async ({
 	publicPath,
 	audioLatencyHint,
 	experimentalClientSideRenderingEnabled,
+	experimentalVisualModeEnabled,
 	askAIEnabled,
 	keyboardShortcutsEnabled,
 	rspack,
@@ -155,6 +159,7 @@ export const bundleOnCli = async ({
 	publicPath: string | null;
 	audioLatencyHint: AudioContextLatencyCategory | null;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 	keyboardShortcutsEnabled: boolean;
 	askAIEnabled: boolean;
 	rspack: boolean;
@@ -234,6 +239,7 @@ export const bundleOnCli = async ({
 		bufferStateDelayInMilliseconds,
 		maxTimelineTracks,
 		experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled,
 	});
 	const cacheExistedBefore = BundlerInternals.cacheExists(
 		remotionRoot,
@@ -283,6 +289,7 @@ export const bundleOnCli = async ({
 		bufferStateDelayInMilliseconds,
 		audioLatencyHint,
 		experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled,
 		renderDefaults: getRenderDefaults(),
 	});
 

--- a/packages/cli/src/still.ts
+++ b/packages/cli/src/still.ts
@@ -29,6 +29,7 @@ const {
 	darkModeOption,
 	askAIOption,
 	experimentalClientSideRenderingOption,
+	experimentalVisualModeOption,
 	keyboardShortcutsOption,
 	rspackOption,
 	browserExecutableOption,
@@ -218,6 +219,9 @@ export const still = async (
 		experimentalClientSideRenderingEnabled:
 			experimentalClientSideRenderingOption.getValue({commandLine: parsedCli})
 				.value,
+		experimentalVisualModeEnabled: experimentalVisualModeOption.getValue({
+			commandLine: parsedCli,
+		}).value,
 		keyboardShortcutsEnabled,
 		rspack,
 		shouldCache,

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -167,6 +167,7 @@ export const studioCommand = async (
 		desiredPort,
 		keyboardShortcutsEnabled,
 		experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled: useVisualMode,
 		maxTimelineTracks: ConfigInternals.getMaxTimelineTracks(),
 		remotionRoot,
 		relativePublicDir,

--- a/packages/cloudrun/src/api/deploy-site.ts
+++ b/packages/cloudrun/src/api/deploy-site.ts
@@ -31,6 +31,7 @@ type Options = {
 	keyboardShortcutsEnabled?: boolean;
 	askAIEnabled?: boolean;
 	experimentalClientSideRenderingEnabled?: boolean;
+	experimentalVisualModeEnabled?: boolean;
 	rspack?: boolean;
 };
 
@@ -108,6 +109,8 @@ export const internalDeploySiteRaw = async ({
 			audioLatencyHint: null,
 			experimentalClientSideRenderingEnabled:
 				options?.experimentalClientSideRenderingEnabled ?? false,
+			experimentalVisualModeEnabled:
+				options?.experimentalVisualModeEnabled ?? false,
 			renderDefaults: null,
 			askAIEnabled: options?.askAIEnabled ?? true,
 			keyboardShortcutsEnabled: options?.keyboardShortcutsEnabled ?? true,

--- a/packages/cloudrun/src/cli/commands/sites/create.ts
+++ b/packages/cloudrun/src/cli/commands/sites/create.ts
@@ -28,6 +28,7 @@ const {
 	disableGitSourceOption,
 	askAIOption,
 	experimentalClientSideRenderingOption,
+	experimentalVisualModeOption,
 	keyboardShortcutsOption,
 } = BrowserSafeApis.options;
 
@@ -162,6 +163,9 @@ export const sitesCreateSubcommand = async (
 		experimentalClientSideRenderingOption.getValue({
 			commandLine: CliInternals.parsedCli,
 		}).value;
+	const experimentalVisualModeEnabled = experimentalVisualModeOption.getValue({
+		commandLine: CliInternals.parsedCli,
+	}).value;
 	const keyboardShortcutsEnabled = keyboardShortcutsOption.getValue({
 		commandLine: CliInternals.parsedCli,
 	}).value;
@@ -200,6 +204,7 @@ export const sitesCreateSubcommand = async (
 			rootDir: remotionRoot,
 			askAIEnabled,
 			experimentalClientSideRenderingEnabled,
+			experimentalVisualModeEnabled,
 			keyboardShortcutsEnabled,
 		},
 		indent: false,

--- a/packages/lambda/src/api/deploy-site.ts
+++ b/packages/lambda/src/api/deploy-site.ts
@@ -40,6 +40,7 @@ type OptionalParameters = {
 		keyboardShortcutsEnabled?: boolean;
 		askAIEnabled?: boolean;
 		experimentalClientSideRenderingEnabled?: boolean;
+		experimentalVisualModeEnabled?: boolean;
 		rspack?: boolean;
 	};
 	privacy: 'public' | 'no-acl';
@@ -136,6 +137,8 @@ const mandatoryDeploySite = async ({
 			audioLatencyHint: null,
 			experimentalClientSideRenderingEnabled:
 				options?.experimentalClientSideRenderingEnabled ?? false,
+			experimentalVisualModeEnabled:
+				options?.experimentalVisualModeEnabled ?? false,
 			keyboardShortcutsEnabled: options?.keyboardShortcutsEnabled ?? true,
 			renderDefaults: null,
 			rspack: options?.rspack ?? false,

--- a/packages/lambda/src/cli/commands/sites/create.ts
+++ b/packages/lambda/src/cli/commands/sites/create.ts
@@ -37,6 +37,7 @@ const {
 	disableGitSourceOption,
 	askAIOption,
 	experimentalClientSideRenderingOption,
+	experimentalVisualModeOption,
 	keyboardShortcutsOption,
 } = BrowserSafeApis.options;
 
@@ -178,6 +179,9 @@ export const sitesCreateSubcommand = async (
 		experimentalClientSideRenderingOption.getValue({
 			commandLine: CliInternals.parsedCli,
 		}).value;
+	const experimentalVisualModeEnabled = experimentalVisualModeOption.getValue({
+		commandLine: CliInternals.parsedCli,
+	}).value;
 	const keyboardShortcutsEnabled = keyboardShortcutsOption.getValue({
 		commandLine: CliInternals.parsedCli,
 	}).value;
@@ -228,6 +232,7 @@ export const sitesCreateSubcommand = async (
 			bypassBucketNameValidation: Boolean(parsedLambdaCli['force-bucket-name']),
 			askAIEnabled,
 			experimentalClientSideRenderingEnabled,
+			experimentalVisualModeEnabled,
 			keyboardShortcutsEnabled,
 		},
 		region: getAwsRegion(),

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -41,6 +41,7 @@ export const startServer = async (options: {
 	remotionRoot: string;
 	keyboardShortcutsEnabled: boolean;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 	publicDir: string;
 	poll: number | null;
 	staticHash: string;
@@ -90,6 +91,7 @@ export const startServer = async (options: {
 		keyboardShortcutsEnabled: options.keyboardShortcutsEnabled,
 		experimentalClientSideRenderingEnabled:
 			options.experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled: options.experimentalVisualModeEnabled,
 		poll: options.poll,
 		bufferStateDelayInMilliseconds: options.bufferStateDelayInMilliseconds,
 		askAIEnabled: options.askAIEnabled,

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -38,6 +38,7 @@ export const startStudio = async ({
 	remotionRoot,
 	keyboardShortcutsEnabled,
 	experimentalClientSideRenderingEnabled,
+	experimentalVisualModeEnabled,
 	relativePublicDir,
 	webpackOverride,
 	poll,
@@ -69,6 +70,7 @@ export const startStudio = async ({
 	remotionRoot: string;
 	keyboardShortcutsEnabled: boolean;
 	experimentalClientSideRenderingEnabled: boolean;
+	experimentalVisualModeEnabled: boolean;
 	relativePublicDir: string | null;
 	webpackOverride: WebpackOverrideFn;
 	poll: number | null;
@@ -140,6 +142,7 @@ export const startStudio = async ({
 		remotionRoot,
 		keyboardShortcutsEnabled,
 		experimentalClientSideRenderingEnabled,
+		experimentalVisualModeEnabled,
 		publicDir,
 		webpackOverride,
 		poll,


### PR DESCRIPTION
## Summary
- Adds `process.env.EXPERIMENTAL_VISUAL_MODE_ENABLED` to the webpack/rspack define plugin definitions
- Threads the `experimentalVisualModeEnabled` boolean through the full option system (bundler, studio-server, CLI, Lambda, CloudRun) mirroring the existing `experimentalClientSideRenderingEnabled` pattern
- Connects the new env var to the existing `experimentalVisualModeOption` from `@remotion/renderer`

## Test plan
- [x] `bun run build` passes
- [x] TypeScript type-checking passes across all affected packages
- [ ] Verify `process.env.EXPERIMENTAL_VISUAL_MODE_ENABLED` is available at runtime when the option is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)