### PR TITLE
`docs`: Document that Vercel Blob Storage must be public

### DIFF
--- a/packages/docs/docs/vercel.mdx
+++ b/packages/docs/docs/vercel.mdx
@@ -16,6 +16,8 @@ You can quickly deploy your Remotion project to Vercel to offload rendering to a
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?demo-description=Render%20your%20Remotion%20videos%20on%20Vercel.&demo-image=%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F4pq2kfE4t05fMkDCKGsfqz%2F1444f1b559d50391052fdf5102502ac9%2FFlagsmith_Dark.png&demo-title=Remotion%20on%20Vercel&demo-url=https%3A%2F%2Ftemplate-vercel.remotion.dev%2F&from=templates&products=%255B%257B%2522type%2522%253A%2522blob%2522%257D%255D&project-name=Remotion%20on%20Vercel&project-names=Comma%20separated%20list%20of%20project%20names%2Cto%20match%20the%20root-directories&repository-name=remotion-on-vercel&repository-url=https%3A%2F%2Fgithub.com%2Fremotion-dev%2Ftemplate-vercel&root-directories=List%20of%20directory%20paths%20for%20the%20directories%20to%20clone%20into%20projects)
 
+> Note: You will be prompted to create a Blob Storage. It must be public.
+
 Vercel Sandbox allows you to render videos on-demand without managing Lambda or AWS infrastructure. Each render spawns an ephemeral Linux VM with full access to the Remotion renderer.
 
 See the dedicated [Vercel Sandbox](/docs/vercel-sandbox) page for full documentation.
@@ -116,6 +118,8 @@ npx remotion render https://remotion-helloworld.vercel.app HelloWorld
 Deploy the Vercel template:
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?demo-description=Render%20your%20Remotion%20videos%20on%20Vercel.&demo-image=%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F4pq2kfE4t05fMkDCKGsfqz%2F1444f1b559d50391052fdf5102502ac9%2FFlagsmith_Dark.png&demo-title=Remotion%20on%20Vercel&demo-url=https%3A%2F%2Ftemplate-vercel.remotion.dev%2F&from=templates&products=%255B%257B%2522type%2522%253A%2522blob%2522%257D%255D&project-name=Remotion%20on%20Vercel&project-names=Comma%20separated%20list%20of%20project%20names%2Cto%20match%20the%20root-directories&repository-name=remotion-on-vercel&repository-url=https%3A%2F%2Fgithub.com%2Fremotion-dev%2Ftemplate-vercel&root-directories=List%20of%20directory%20paths%20for%20the%20directories%20to%20clone%20into%20projects)
+
+> Note: You will be prompted to create a Blob Storage. It must be public.
 
 Rendering will be done inside a [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) and the render will be stored in [Vercel Blob](https://vercel.com/docs/vercel-blob).
 

--- a/packages/template-vercel/README.md
+++ b/packages/template-vercel/README.md
@@ -4,6 +4,8 @@
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?demo-description=Render%20your%20Remotion%20videos%20on%20Vercel.&demo-image=%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F4pq2kfE4t05fMkDCKGsfqz%2F1444f1b559d50391052fdf5102502ac9%2FFlagsmith_Dark.png&demo-title=Remotion%20on%20Vercel&demo-url=https%3A%2F%2Ftemplate-vercel.remotion.dev%2F&from=templates&products=%255B%257B%2522type%2522%253A%2522blob%2522%257D%255D&project-name=Remotion%20on%20Vercel&project-names=Comma%20separated%20list%20of%20project%20names%2Cto%20match%20the%20root-directories&repository-name=remotion-on-vercel&repository-url=https%3A%2F%2Fgithub.com%2Fremotion-dev%2Ftemplate-vercel&root-directories=List%20of%20directory%20paths%20for%20the%20directories%20to%20clone%20into%20projects)
 
+> Note: You will be prompted to create a Blob Storage. It must be public.
+
 This is a Next.js template for building programmatic video apps with [`@remotion/player`](https://remotion.dev/player) and rendering via [Vercel Sandbox](https://vercel.com/docs/functions/sandbox).
 
 This template uses the Next.js App directory with TailwindCSS. Videos are rendered in a Vercel Sandbox environment and stored in [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) storage.


### PR DESCRIPTION
## Summary
- Adds a note underneath all three Vercel deploy buttons (in `packages/docs/docs/vercel.mdx` and `packages/template-vercel/README.md`) informing users that the Blob Storage must be public.

Closes #6646

🤖 Generated with [Claude Code](https://claude.com/claude-code)