### PR TITLE
`@remotion/player`: Don't activate browser media session until playback starts

### DIFF
--- a/packages/player/src/browser-mediasession.ts
+++ b/packages/player/src/browser-mediasession.ts
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import type {VideoConfig} from 'remotion';
 import {usePlayer} from './use-player.js';
 
@@ -23,6 +23,13 @@ export const useBrowserMediaSession = ({
 	playbackRate: number;
 }) => {
 	const {playing, pause, play, emitter, getCurrentFrame, seek} = usePlayer();
+	const hasEverPlayed = useRef(false);
+
+	useEffect(() => {
+		if (playing) {
+			hasEverPlayed.current = true;
+		}
+	}, [playing]);
 
 	useEffect(() => {
 		if (!navigator.mediaSession) {
@@ -35,7 +42,7 @@ export const useBrowserMediaSession = ({
 
 		if (playing) {
 			navigator.mediaSession.playbackState = 'playing';
-		} else {
+		} else if (hasEverPlayed.current) {
 			navigator.mediaSession.playbackState = 'paused';
 		}
 	}, [browserMediaControlsBehavior.mode, playing]);


### PR DESCRIPTION
## Summary
- Previously, opening the Studio immediately set `navigator.mediaSession.playbackState = 'paused'`, which activates the browser's media session and interrupts other audio sources (e.g. AirPods music playing on iPhone)
- Now we track whether playback has ever started via a `hasEverPlayed` ref, and only set the `'paused'` state after the user has played at least once

Closes #5622

## Test plan
- [ ] Open Studio while music is playing on AirPods/iPhone — music should continue
- [ ] Press play in Studio, then pause — media session should now be active
- [ ] Media keys should still work after first play

🤖 Generated with [Claude Code](https://claude.com/claude-code)