### PR TITLE
`@remotion/studio`: Only call backend on drag end, deduplicate getOriginalLocationFromStack

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -14,6 +14,7 @@ import {RemotionInput, inputBaseStyle} from './RemInput';
 
 type Props = InputHTMLAttributes<HTMLInputElement> & {
 	readonly onValueChange: (newVal: number) => void;
+	readonly onValueChangeEnd?: (newVal: number) => void;
 	readonly onTextChange: (newVal: string) => void;
 	readonly status: RemInputStatus;
 	readonly formatter?: (str: number | string) => string;
@@ -30,6 +31,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 > = (
 	{
 		onValueChange,
+		onValueChangeEnd,
 		min: _min,
 		max: _max,
 		step: _step,
@@ -122,6 +124,8 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 				return;
 			}
 
+			let lastDragValue: number | null = null;
+
 			const moveListener = (ev: MouseEvent) => {
 				const xDistance = ev.pageX - pageX;
 				const distanceFromStart = Math.sqrt(
@@ -142,6 +146,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 				);
 				const newValue = Math.min(max, Math.max(min, Number(value) + diff));
 				const roundedToStep = roundToStep(newValue, step);
+				lastDragValue = roundedToStep;
 				onValueChange(roundedToStep);
 			};
 
@@ -150,6 +155,10 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 				'pointerup',
 				() => {
 					window.removeEventListener('mousemove', moveListener);
+					if (lastDragValue !== null && onValueChangeEnd) {
+						onValueChangeEnd(lastDragValue);
+					}
+
 					setTimeout(() => {
 						setClickLock(false);
 					}, 2);
@@ -159,7 +168,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 				},
 			);
 		},
-		[_step, _min, _max, value, onValueChange],
+		[_step, _min, _max, value, onValueChange, onValueChangeEnd],
 	);
 
 	useEffect(() => {

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -30,7 +30,11 @@ const TimelineNumberField: React.FC<{
 	readonly canUpdate: boolean | null;
 	readonly onSave: (key: string, value: unknown) => void;
 }> = ({field, canUpdate, onSave}) => {
-	const onValueChange = useCallback(
+	const onValueChange = useCallback((_newVal: number) => {
+		// No-op during drag; save happens on drag end
+	}, []);
+
+	const onValueChangeEnd = useCallback(
 		(newVal: number) => {
 			if (canUpdate) {
 				onSave(field.key, newVal);
@@ -58,6 +62,7 @@ const TimelineNumberField: React.FC<{
 			style={draggerStyle}
 			status="ok"
 			onValueChange={onValueChange}
+			onValueChangeEnd={onValueChangeEnd}
 			onTextChange={onTextChange}
 			min={getZodNumberMinimum(field.fieldSchema)}
 			max={getZodNumberMaximum(field.fieldSchema)}

--- a/packages/studio/src/components/Timeline/TimelineStack/index.tsx
+++ b/packages/studio/src/components/Timeline/TimelineStack/index.tsx
@@ -1,12 +1,6 @@
 import type {GitSource} from '@remotion/studio-shared';
 import {SOURCE_MAP_ENDPOINT} from '@remotion/studio-shared';
-import React, {
-	useCallback,
-	useContext,
-	useEffect,
-	useMemo,
-	useState,
-} from 'react';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
 import type {TSequence} from 'remotion';
 import {SourceMapConsumer} from 'source-map';
 import type {OriginalPosition} from '../../../error-overlay/react-overlay/utils/get-source-map';
@@ -23,7 +17,6 @@ import {useSelectAsset} from '../../InitialCompositionLoader';
 import {Spacing} from '../../layout';
 import {showNotification} from '../../Notifications/NotificationCenter';
 import {Spinner} from '../../Spinner';
-import {getOriginalLocationFromStack} from './get-stack';
 import {getOriginalSourceAttribution} from './source-attribution';
 
 const publicPath =
@@ -41,10 +34,8 @@ SourceMapConsumer.initialize({
 export const TimelineStack: React.FC<{
 	readonly isCompact: boolean;
 	readonly sequence: TSequence;
-}> = ({isCompact, sequence}) => {
-	const [originalLocation, setOriginalLocation] =
-		useState<OriginalPosition | null>(null);
-
+	readonly originalLocation: OriginalPosition | null;
+}> = ({isCompact, sequence, originalLocation}) => {
 	const [stackHovered, setStackHovered] = useState(false);
 	const [titleHovered, setTitleHovered] = useState(false);
 	const [opening, setOpening] = useState(false);
@@ -156,21 +147,6 @@ export const TimelineStack: React.FC<{
 			);
 		}
 	}, [canOpenInEditor, canOpenInGitHub, openEditor, originalLocation]);
-
-	useEffect(() => {
-		if (!sequence.stack) {
-			return;
-		}
-
-		getOriginalLocationFromStack(sequence.stack, 'sequence')
-			.then((frame) => {
-				setOriginalLocation(frame);
-			})
-			.catch((err) => {
-				// eslint-disable-next-line no-console
-				console.error('Could not get original location of Sequence', err);
-			});
-	}, [sequence.stack]);
 
 	const onStackPointerEnter = useCallback(() => {
 		setStackHovered(true);


### PR DESCRIPTION
## Summary
- **Only call backend on drag end**: Added `onValueChangeEnd` callback to `InputDragger` that fires on `pointerup`. `TimelineSchemaField` now saves to backend only on drag end (via `onValueChangeEnd`) and text confirm (via `onTextChange`), not on every mousemove during drag.
- **Deduplicate `getOriginalLocationFromStack`**: Moved the call from both `TimelineStack` and `TimelineExpandedSection` up to their shared parent `TimelineListItem`, passing the result down as a prop.

## Test plan
- [ ] Open Studio with visual mode enabled
- [ ] Expand a timeline track with schema fields
- [ ] Drag a number field — verify backend is only called once on release, not on every mousemove
- [ ] Verify text input (click, type, blur/enter) still saves correctly
- [ ] Verify source attribution and open-in-editor still work in timeline stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)