### PR TITLE
`@remotion/studio`: Hide checkerboard toggle for non-composition canvas

### DIFF
--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -84,6 +84,7 @@ export const PreviewToolbar: React.FC<{
 
 	const {mediaMuted} = useContext(Internals.MediaVolumeContext);
 	const {setMediaMuted} = useContext(Internals.SetMediaVolumeContext);
+	const {canvasContent} = useContext(Internals.CompositionManager);
 	const isVideoComposition = useIsVideoComposition();
 	const previewToolbarRef = useRef<HTMLDivElement | null>(null);
 	const leftScrollIndicatorRef = useRef<HTMLDivElement | null>(null);
@@ -192,7 +193,7 @@ export const PreviewToolbar: React.FC<{
 				</>
 			) : null}
 
-			<CheckboardToggle />
+			{canvasContent?.type === 'composition' ? <CheckboardToggle /> : null}
 			<Spacing x={1} />
 			{isFullscreenSupported && <FullScreenToggle />}
 			<Flex />


### PR DESCRIPTION
## Summary
- Only show the checkerboard transparency toggle when viewing a composition (still or video)
- Previously it was shown unconditionally, including when viewing assets or render outputs where it has no effect

## Test plan
- [ ] Open a composition in the studio → checkerboard toggle should be visible
- [ ] Click on a static file asset → checkerboard toggle should be hidden
- [ ] View a render output → checkerboard toggle should be hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)