### PR TITLE
`@remotion/design`: prevent Button from stretching to full width

### DIFF
--- a/packages/design/src/Button.tsx
+++ b/packages/design/src/Button.tsx
@@ -98,7 +98,7 @@ export const Button: React.FC<ButtonProps> = ({
 
 	const sharedClasses = cn(
 		'text-text',
-		'flex',
+		'inline-flex',
 		'justify-center',
 		'bg-button-bg',
 		'items-center',
@@ -112,7 +112,6 @@ export const Button: React.FC<ButtonProps> = ({
 		'cursor-pointer',
 		'px-4',
 		'h-12',
-		'flex',
 		'flex-row',
 		'items-center',
 		'relative',


### PR DESCRIPTION
## Summary
- Changed `display: flex` to `display: inline-flex` on the `<Button>` component so it sizes to its content instead of stretching to fill the parent container
- Removed a duplicate `flex` Tailwind class in the shared styles

Callers that need full-width buttons already pass `w-full` via `className` (e.g. `templates.tsx`, `GetStartedStrip.tsx`), so existing usage is unaffected.

## Test plan
- [ ] Verify buttons on `/templates` page still fill their grid cells (they pass `w-full`)
- [ ] Verify buttons elsewhere (e.g. GetStartedStrip, MoreTemplatesButton) no longer stretch unexpectedly

Fixes #6684