### PR TITLE
`remotion`: Add `bun run format` pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+bun run format

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
 		"publishtemplates": "cd packages/it-tests && bun src/templates/publish.ts",
 		"cleantypes": "rm -rf packages/**/tsconfig.tsbuildinfo && rm -f packages/tsconfig.tsbuildinfo",
 		"clean": "turbo run clean && rm -rf packages/**/dist && rm -rf .cache && rm -rf packages/**/tsconfig.tsbuildinfo && rm -f packages/tsconfig.tsbuildinfo && rm -rf packages/**/.turbo && rm -rf .turbo",
-		"cleanall": "turbo run clean && rm -rf packages/**/dist && rm -rf packages/**/node_modules && rm -rf node_modules && rm -rf .cache && rm -rf packages/**/tsconfig.tsbuildinfo && rm -f packages/tsconfig.tsbuildinfo && rm -rf packages/**/.turbo && rm -rf .turbo"
+		"cleanall": "turbo run clean && rm -rf packages/**/dist && rm -rf packages/**/node_modules && rm -rf node_modules && rm -rf .cache && rm -rf packages/**/tsconfig.tsbuildinfo && rm -f packages/tsconfig.tsbuildinfo && rm -rf packages/**/.turbo && rm -rf .turbo",
+		"prepare": "git config core.hooksPath .githooks"
 	},
 	"engines": {
 		"node": ">=16"


### PR DESCRIPTION
## Summary
- Adds a `.githooks/pre-commit` hook that runs `bun run format` before every commit
- Adds a `prepare` script to root `package.json` that sets `core.hooksPath` to `.githooks`, so the hook is automatically configured on `bun install`

## Test plan
- [x] Verified the hook runs `bun run format` on commit
- [ ] Run `bun install` in a fresh clone and verify `git config core.hooksPath` is set to `.githooks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)