### PR TITLE
`@remotion/studio`: Reduce InputDragger padding

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -51,6 +51,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 			...inputBaseStyle,
 			backgroundColor: 'transparent',
 			borderColor: 'transparent',
+			padding: '4px 6px',
 		};
 	}, []);
 


### PR DESCRIPTION
## Summary
- Reduced padding on the `<InputDragger>` button from `8px 10px` to `4px 6px` to make it less wide when dragging

## Test plan
- [ ] Open the Remotion Studio and verify InputDragger components (e.g. in composition settings) have tighter padding
- [ ] Verify dragging still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)