### PR TITLE
`@remotion/studio-server`: Deduplicate sequence props file watchers

### DIFF
--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -181,6 +181,40 @@ const findJsxElementAtLine = (
 	return found;
 };
 
+export const computeSequencePropsStatusFromAst = ({
+	ast,
+	line,
+	keys,
+}: {
+	ast: File;
+	line: number;
+	keys: string[];
+}): CanUpdateSequencePropsResponse => {
+	const jsxElement = findJsxElementAtLine(ast, line);
+
+	if (!jsxElement) {
+		return {
+			canUpdate: false as const,
+			reason: 'Could not find a JSX element at the specified location',
+		};
+	}
+
+	const allProps = getPropsStatus(jsxElement);
+	const filteredProps: Record<string, CanUpdatePropStatus> = {};
+	for (const key of keys) {
+		if (key in allProps) {
+			filteredProps[key] = allProps[key];
+		} else {
+			filteredProps[key] = {canUpdate: false, reason: 'not-set'};
+		}
+	}
+
+	return {
+		canUpdate: true as const,
+		props: filteredProps,
+	};
+};
+
 export const computeSequencePropsStatus = ({
 	fileName,
 	line,
@@ -202,26 +236,7 @@ export const computeSequencePropsStatus = ({
 		const fileContents = readFileSync(absolutePath, 'utf-8');
 		const ast = parseAst(fileContents);
 
-		const jsxElement = findJsxElementAtLine(ast, line);
-
-		if (!jsxElement) {
-			throw new Error('Could not find a JSX element at the specified location');
-		}
-
-		const allProps = getPropsStatus(jsxElement);
-		const filteredProps: Record<string, CanUpdatePropStatus> = {};
-		for (const key of keys) {
-			if (key in allProps) {
-				filteredProps[key] = allProps[key];
-			} else {
-				filteredProps[key] = {canUpdate: false, reason: 'not-set'};
-			}
-		}
-
-		return {
-			canUpdate: true as const,
-			props: filteredProps,
-		};
+		return computeSequencePropsStatusFromAst({ast, line, keys});
 	} catch (err) {
 		return {
 			canUpdate: false as const,

--- a/packages/studio-server/src/preview-server/sequence-props-watchers.ts
+++ b/packages/studio-server/src/preview-server/sequence-props-watchers.ts
@@ -1,14 +1,37 @@
+import {readFileSync} from 'node:fs';
 import path from 'node:path';
 import type {CanUpdateSequencePropsResponse} from '@remotion/studio-shared';
+import {parseAst} from '../codemods/parse-ast';
 import {installFileWatcher} from '../file-watcher';
 import {waitForLiveEventsListener} from './live-events';
-import {computeSequencePropsStatus} from './routes/can-update-sequence-props';
+import {
+	computeSequencePropsStatus,
+	computeSequencePropsStatusFromAst,
+} from './routes/can-update-sequence-props';
 
-type WatcherInfo = {
-	unwatch: () => void;
+type PositionInfo = {
+	fileName: string;
+	line: number;
+	column: number;
+	keys: string[];
+	remotionRoot: string;
+	absolutePath: string;
+	clientIds: Set<string>;
 };
 
-const sequencePropsWatchers: Record<string, Record<string, WatcherInfo>> = {};
+type FileWatcherInfo = {
+	unwatch: () => void;
+	watcherKeys: Set<string>;
+};
+
+// watcherKey (absolutePath:line:column) -> position info with subscribing clients
+const positions = new Map<string, PositionInfo>();
+
+// absolutePath -> single file watcher shared across all positions in that file
+const fileWatchers = new Map<string, FileWatcherInfo>();
+
+// clientId -> set of watcherKeys (for cleanup on disconnect)
+const clientToWatcherKeys = new Map<string, Set<string>>();
 
 const makeWatcherKey = ({
 	absolutePath,
@@ -20,6 +43,105 @@ const makeWatcherKey = ({
 	column: number;
 }): string => {
 	return `${absolutePath}:${line}:${column}`;
+};
+
+const ensureFileWatcher = (absolutePath: string): void => {
+	if (fileWatchers.has(absolutePath)) {
+		return;
+	}
+
+	const {unwatch} = installFileWatcher({
+		file: absolutePath,
+		onChange: (type) => {
+			if (type === 'deleted') {
+				return;
+			}
+
+			const watcherInfo = fileWatchers.get(absolutePath);
+			if (!watcherInfo) {
+				return;
+			}
+
+			let ast;
+			try {
+				const fileContents = readFileSync(absolutePath, 'utf-8');
+				ast = parseAst(fileContents);
+			} catch (err) {
+				for (const watcherKey of watcherInfo.watcherKeys) {
+					const posInfo = positions.get(watcherKey);
+					if (!posInfo) {
+						continue;
+					}
+
+					waitForLiveEventsListener().then((listener) => {
+						listener.sendEventToClient({
+							type: 'sequence-props-updated',
+							fileName: posInfo.fileName,
+							line: posInfo.line,
+							column: posInfo.column,
+							result: {
+								canUpdate: false as const,
+								reason: (err as Error).message,
+							},
+						});
+					});
+				}
+
+				return;
+			}
+
+			for (const watcherKey of watcherInfo.watcherKeys) {
+				const posInfo = positions.get(watcherKey);
+				if (!posInfo) {
+					continue;
+				}
+
+				const result = computeSequencePropsStatusFromAst({
+					ast,
+					line: posInfo.line,
+					keys: posInfo.keys,
+				});
+
+				waitForLiveEventsListener().then((listener) => {
+					listener.sendEventToClient({
+						type: 'sequence-props-updated',
+						fileName: posInfo.fileName,
+						line: posInfo.line,
+						column: posInfo.column,
+						result,
+					});
+				});
+			}
+		},
+	});
+
+	fileWatchers.set(absolutePath, {unwatch, watcherKeys: new Set()});
+};
+
+const removeClientFromPosition = (
+	clientId: string,
+	watcherKey: string,
+): void => {
+	const posInfo = positions.get(watcherKey);
+	if (!posInfo) {
+		return;
+	}
+
+	posInfo.clientIds.delete(clientId);
+
+	if (posInfo.clientIds.size === 0) {
+		positions.delete(watcherKey);
+
+		const fileInfo = fileWatchers.get(posInfo.absolutePath);
+		if (fileInfo) {
+			fileInfo.watcherKeys.delete(watcherKey);
+
+			if (fileInfo.watcherKeys.size === 0) {
+				fileInfo.unwatch();
+				fileWatchers.delete(posInfo.absolutePath);
+			}
+		}
+	}
 };
 
 export const subscribeToSequencePropsWatchers = ({
@@ -40,51 +162,39 @@ export const subscribeToSequencePropsWatchers = ({
 	const absolutePath = path.resolve(remotionRoot, fileName);
 	const watcherKey = makeWatcherKey({absolutePath, line, column});
 
-	// Unwatch any existing watcher for the same key
-	if (sequencePropsWatchers[clientId]?.[watcherKey]) {
-		sequencePropsWatchers[clientId][watcherKey].unwatch();
+	ensureFileWatcher(absolutePath);
+
+	let posInfo = positions.get(watcherKey);
+	if (!posInfo) {
+		posInfo = {
+			fileName,
+			line,
+			column,
+			keys,
+			remotionRoot,
+			absolutePath,
+			clientIds: new Set(),
+		};
+		positions.set(watcherKey, posInfo);
+		fileWatchers.get(absolutePath)!.watcherKeys.add(watcherKey);
+	} else {
+		posInfo.keys = keys;
 	}
 
-	const initialResult = computeSequencePropsStatus({
+	posInfo.clientIds.add(clientId);
+
+	if (!clientToWatcherKeys.has(clientId)) {
+		clientToWatcherKeys.set(clientId, new Set());
+	}
+
+	clientToWatcherKeys.get(clientId)!.add(watcherKey);
+
+	return computeSequencePropsStatus({
 		fileName,
 		line,
 		keys,
 		remotionRoot,
 	});
-
-	const {unwatch} = installFileWatcher({
-		file: absolutePath,
-		onChange: (type) => {
-			if (type === 'deleted') {
-				return;
-			}
-
-			const result = computeSequencePropsStatus({
-				fileName,
-				line,
-				keys,
-				remotionRoot,
-			});
-
-			waitForLiveEventsListener().then((listener) => {
-				listener.sendEventToClient({
-					type: 'sequence-props-updated',
-					fileName,
-					line,
-					column,
-					result,
-				});
-			});
-		},
-	});
-
-	if (!sequencePropsWatchers[clientId]) {
-		sequencePropsWatchers[clientId] = {};
-	}
-
-	sequencePropsWatchers[clientId][watcherKey] = {unwatch};
-
-	return initialResult;
 };
 
 export const unsubscribeFromSequencePropsWatchers = ({
@@ -103,22 +213,26 @@ export const unsubscribeFromSequencePropsWatchers = ({
 	const absolutePath = path.resolve(remotionRoot, fileName);
 	const watcherKey = makeWatcherKey({absolutePath, line, column});
 
-	if (!sequencePropsWatchers[clientId]) {
-		return;
-	}
+	removeClientFromPosition(clientId, watcherKey);
 
-	sequencePropsWatchers[clientId][watcherKey]?.unwatch();
-	delete sequencePropsWatchers[clientId][watcherKey];
+	const watcherKeys = clientToWatcherKeys.get(clientId);
+	if (watcherKeys) {
+		watcherKeys.delete(watcherKey);
+		if (watcherKeys.size === 0) {
+			clientToWatcherKeys.delete(clientId);
+		}
+	}
 };
 
 export const unsubscribeClientSequencePropsWatchers = (clientId: string) => {
-	if (!sequencePropsWatchers[clientId]) {
+	const watcherKeys = clientToWatcherKeys.get(clientId);
+	if (!watcherKeys) {
 		return;
 	}
 
-	Object.values(sequencePropsWatchers[clientId]).forEach((watcher) => {
-		watcher.unwatch();
-	});
+	for (const watcherKey of watcherKeys) {
+		removeClientFromPosition(clientId, watcherKey);
+	}
 
-	delete sequencePropsWatchers[clientId];
+	clientToWatcherKeys.delete(clientId);
 };


### PR DESCRIPTION
## Summary
- Deduplicate file watchers for sequence props: one `fs.watchFile` per file regardless of how many positions or clients are watching
- When a file changes, read and parse the AST once, then check all positions against the shared AST
- Clean up file watchers when the last client watching a file disconnects

## Test plan
- [ ] Open the Studio with multiple timeline sections expanded that reference the same file
- [ ] Verify that editing a source file still triggers prop updates in the timeline
- [ ] Verify that closing the browser tab cleans up watchers

🤖 Generated with [Claude Code](https://claude.com/claude-code)