### PR TITLE
`@remotion/studio`: Use Zod schema descriptions as timeline field labels

### DIFF
--- a/packages/light-leaks/src/LightLeak.tsx
+++ b/packages/light-leaks/src/LightLeak.tsx
@@ -232,13 +232,9 @@ const LightLeakCanvas: React.FC<{
  * @see [Documentation](https://www.remotion.dev/docs/light-leaks/light-leak)
  */
 const lightLeakSchema = z.object({
-	seed: z.number().describe('Random seed for the light leak pattern'),
-	hueShift: z
-		.number()
-		.min(0)
-		.max(360)
-		.describe('Hue rotation in degrees (0–360)'),
-	from: z.number().describe('Starting frame of the light leak'),
+	seed: z.number().describe('Seed'),
+	hueShift: z.number().min(0).max(360).describe('Hue Shift'),
+	from: z.number().default(0).describe('From'),
 });
 
 export const LightLeak: React.FC<LightLeakProps> = ({

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -508,8 +508,19 @@ type InnerAudioProps = {
 };
 
 const audioSchema = z.object({
-	volume: z.number().min(0).max(20).multipleOf(0.01).default(1),
-	playbackRate: z.number().min(0).multipleOf(0.01).default(1),
+	volume: z
+		.number()
+		.min(0)
+		.max(20)
+		.multipleOf(0.01)
+		.default(1)
+		.describe('Volume'),
+	playbackRate: z
+		.number()
+		.min(0)
+		.multipleOf(0.01)
+		.default(1)
+		.describe('Playback Rate'),
 	trimBefore: z.number().min(0).default(0),
 	trimAfter: z.number().min(0).default(0),
 });

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -529,8 +529,19 @@ const VideoForPreviewAssertedShowing: React.FC<
 };
 
 const videoSchema = z.object({
-	volume: z.number().min(0).max(20).multipleOf(0.01).default(1),
-	playbackRate: z.number().min(0).multipleOf(0.01).default(1),
+	volume: z
+		.number()
+		.min(0)
+		.max(20)
+		.multipleOf(0.01)
+		.default(1)
+		.describe('Volume'),
+	playbackRate: z
+		.number()
+		.min(0)
+		.multipleOf(0.01)
+		.default(1)
+		.describe('Playback Rate'),
 	trimBefore: z.number().min(0).default(0),
 	trimAfter: z.number().min(0).default(0),
 });

--- a/packages/studio/src/components/Timeline/TimelineExpandedSection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedSection.tsx
@@ -63,7 +63,7 @@ const TimelineFieldRow: React.FC<{
 	return (
 		<div style={{...fieldRow, height: field.rowHeight}}>
 			<div style={fieldLabelRow}>
-				<span style={fieldName}>{field.key}</span>
+				<span style={fieldName}>{field.description ?? field.key}</span>
 			</div>
 			<TimelineFieldValue
 				field={field}

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -2,6 +2,7 @@ import type {SequenceControls} from 'remotion';
 import type {AnyZodSchema} from '../components/RenderModal/SchemaEditor/zod-schema-type';
 import {
 	getObjectShape,
+	getZodSchemaDescription,
 	getZodSchemaType,
 } from '../components/RenderModal/SchemaEditor/zod-schema-type';
 
@@ -29,6 +30,7 @@ const SUPPORTED_SCHEMA_TYPES = new Set([
 
 export type SchemaFieldInfo = {
 	key: string;
+	description: string | undefined;
 	typeName: string;
 	supported: boolean;
 	rowHeight: number;
@@ -49,6 +51,7 @@ export const getSchemaFields = (
 		const supported = SUPPORTED_SCHEMA_TYPES.has(typeName);
 		return {
 			key,
+			description: getZodSchemaDescription(fieldSchema),
 			typeName,
 			supported,
 			rowHeight: supported


### PR DESCRIPTION
## Summary

- Display Zod `.describe()` labels as field names in the timeline expanded section, falling back to the property key when no description is set.
- Add `.describe()` labels and `.default()` values to audio, video, and light-leak schemas for better Studio UX.
- Import and use `getZodSchemaDescription` in `timeline-layout.ts` to populate a new `description` field on `SchemaFieldInfo`.

## Test plan

- [ ] Open the Studio and expand a track with schema fields (e.g., audio, video, light-leak)
- [ ] Verify fields display their `.describe()` label instead of the raw key name
- [ ] Verify fields without a description still fall back to the property key

Made with [Cursor](https://cursor.com)