### PR TITLE
`@remotion/studio`: Prevent timeline layer labels from wrapping

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequenceFrame.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceFrame.tsx
@@ -5,6 +5,7 @@ const relativeFrameStyle: React.CSSProperties = {
 	fontFamily: 'Arial, Helvetica, sans-serif',
 	color: 'white',
 	opacity: 0.5,
+	whiteSpace: 'nowrap',
 };
 
 export const TimelineSequenceFrame: React.FC<{


### PR DESCRIPTION
## Summary
- Adds `whiteSpace: 'nowrap'` to the timeline sequence frame label style to prevent "(Premounted)" and "(Postmounted)" text from wrapping to two lines in narrow timeline layers.

Closes #6709

## Test plan
- Open the Studio with a composition that has premounted sequences
- Verify the "(Premounted)" label stays on a single line in the timeline layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)