### PR TITLE
`@remotion/studio`: Align timeline layers with playhead

### DIFF
--- a/packages/studio/src/helpers/get-timeline-sequence-layout.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-layout.ts
@@ -48,39 +48,22 @@ export const getTimelineSequenceLayout = ({
 		(maxMediaDuration ?? Infinity) - startFromMedia;
 	const lastFrame = (video.durationInFrames ?? 1) - 1;
 
-	let spatialDuration = Math.min(
+	const spatialDuration = Math.min(
 		maxMediaSequenceDuration,
 		durationInFrames - 1,
 		lastFrame - startFrom,
 	);
 
 	// Unclipped spatial duration: without the lastFrame - startFrom constraint
-	let naturalSpatialDuration = Math.min(
+	const naturalSpatialDuration = Math.min(
 		maxMediaSequenceDuration,
 		durationInFrames - 1,
 	);
 
-	const shouldAddHalfAFrameAtEnd = startFrom + durationInFrames < lastFrame;
-	const shouldAddHalfAFrameAtStart = startFrom > 0;
-	if (shouldAddHalfAFrameAtEnd) {
-		spatialDuration += 0.5;
-		naturalSpatialDuration += 0.5;
-	}
-
-	if (shouldAddHalfAFrameAtStart) {
-		spatialDuration += 0.5;
-		naturalSpatialDuration += 0.5;
-	}
-
-	const startFromWithOffset = shouldAddHalfAFrameAtStart
-		? startFrom - 0.5
-		: startFrom;
-
 	const marginLeft =
 		lastFrame === 0
 			? 0
-			: (startFromWithOffset / lastFrame) *
-				(windowWidth - TIMELINE_PADDING * 2);
+			: (startFrom / lastFrame) * (windowWidth - TIMELINE_PADDING * 2);
 
 	const nonNegativeMarginLeft = Math.min(marginLeft, 0);
 

--- a/packages/studio/src/test/timeline-sequence-layout.test.ts
+++ b/packages/studio/src/test/timeline-sequence-layout.test.ts
@@ -41,11 +41,11 @@ test('Should test timeline sequence layout without max media duration', () => {
 			windowWidth: 1414.203125,
 		}),
 	).toEqual({
-		marginLeft: 1154.2137986426505,
+		marginLeft: 1154.4991419797689,
 		premountWidth: null,
 		postmountWidth: null,
-		width: 226.9893263573493,
-		naturalWidth: 226.9893263573493,
+		width: 226.70398302023122,
+		naturalWidth: 226.70398302023122,
 	});
 });
 test('Should test timeline sequence layout with max media duration', () => {
@@ -75,11 +75,11 @@ test('Should test timeline sequence layout with max media duration', () => {
 			windowWidth: 1414.203125,
 		}),
 	).toEqual({
-		marginLeft: 1154.2137986426505,
+		marginLeft: 1154.4991419797689,
 		premountWidth: null,
 		postmountWidth: null,
-		width: 221.8531462892238,
-		naturalWidth: 221.8531462892238,
+		width: 221.5678029521057,
+		naturalWidth: 221.5678029521057,
 	});
 });
 
@@ -165,7 +165,7 @@ test('naturalWidth is constrained by maxMediaDuration but not by timeline end', 
 	expect(clippedByBoth.naturalWidth).toBeGreaterThan(clippedByBoth.width);
 
 	// Same segment but not clipped by timeline end (starts earlier)
-	// Both should have the same half-frame behavior (shouldAddHalfAFrameAtEnd = true)
+	// Both should have the same behavior
 	const clippedByMediaOnly = getTimelineSequenceLayout({
 		durationInFrames: 200,
 		startFrom: 100,


### PR DESCRIPTION
## Summary
- Removes the 0.5 frame offset from timeline layer positioning so layers start at the same position as the playhead for that frame
- Previously, layers started "in between frames" which was unintuitive when zooming in

Closes #6715

## Test plan
- [x] Updated snapshot values in `timeline-sequence-layout.test.ts`
- [x] All 6 tests pass
- [x] `bun run build` succeeds
- [x] `bun run stylecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)