### PR TITLE
Migrate `timeout` and `force` CLI flags to option system

### DIFF
--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -66,6 +66,7 @@ const {
 	mutedOption,
 	headlessOption,
 	disableGitSourceOption,
+	delayRenderTimeoutInMillisecondsOption,
 	framesOption,
 	forSeamlessAacConcatenationOption,
 	isProductionOption,
@@ -109,7 +110,9 @@ export type CommandLineOptions = {
 	[versionFlagOption.cliFlag]: TypeOfOption<typeof versionFlagOption>;
 	[videoCodecOption.cliFlag]: TypeOfOption<typeof videoCodecOption>;
 	[concurrencyOption.cliFlag]: TypeOfOption<typeof concurrencyOption>;
-	timeout: number;
+	[delayRenderTimeoutInMillisecondsOption.cliFlag]: TypeOfOption<
+		typeof delayRenderTimeoutInMillisecondsOption
+	>;
 	[configOption.cliFlag]: TypeOfOption<typeof configOption>;
 	['public-dir']: string;
 	[audioBitrateOption.cliFlag]: TypeOfOption<typeof audioBitrateOption>;
@@ -121,7 +124,6 @@ export type CommandLineOptions = {
 	[audioCodecOption.cliFlag]: AudioCodec;
 	[publicPathOption.cliFlag]: string;
 	[crfOption.cliFlag]: TypeOfOption<typeof crfOption>;
-	force: boolean;
 	output: string | undefined;
 	[overwriteOption.cliFlag]: TypeOfOption<typeof overwriteOption>;
 	png: boolean;


### PR DESCRIPTION
## Summary
- Replace raw `timeout: number` type entry in `CommandLineOptions` with `[delayRenderTimeoutInMillisecondsOption.cliFlag]` — the option already existed and was read via `getValue()` everywhere
- Remove dead `force: boolean` type entry — never accessed anywhere in the codebase

Partially addresses #6605.

## Test plan
- [x] `tsc --noEmit` passes for `packages/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)