### PR TITLE
`@remotion/studio`: Fix timeline layers being 1 frame too short

### DIFF
--- a/packages/studio/src/helpers/get-timeline-sequence-layout.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-layout.ts
@@ -46,18 +46,18 @@ export const getTimelineSequenceLayout = ({
 }) => {
 	const maxMediaSequenceDuration =
 		(maxMediaDuration ?? Infinity) - startFromMedia;
-	const lastFrame = (video.durationInFrames ?? 1) - 1;
+	const lastFrame = video.durationInFrames ?? 1;
 
 	const spatialDuration = Math.min(
 		maxMediaSequenceDuration,
-		durationInFrames - 1,
+		durationInFrames,
 		lastFrame - startFrom,
 	);
 
 	// Unclipped spatial duration: without the lastFrame - startFrom constraint
 	const naturalSpatialDuration = Math.min(
 		maxMediaSequenceDuration,
-		durationInFrames - 1,
+		durationInFrames,
 	);
 
 	const marginLeft =

--- a/packages/studio/src/test/timeline-sequence-layout.test.ts
+++ b/packages/studio/src/test/timeline-sequence-layout.test.ts
@@ -41,11 +41,11 @@ test('Should test timeline sequence layout without max media duration', () => {
 			windowWidth: 1414.203125,
 		}),
 	).toEqual({
-		marginLeft: 1154.4991419797689,
+		marginLeft: 1154.0226668902187,
 		premountWidth: null,
 		postmountWidth: null,
-		width: 226.70398302023122,
-		naturalWidth: 226.70398302023122,
+		width: 227.18045810978126,
+		naturalWidth: 227.18045810978126,
 	});
 });
 test('Should test timeline sequence layout with max media duration', () => {
@@ -75,11 +75,11 @@ test('Should test timeline sequence layout with max media duration', () => {
 			windowWidth: 1414.203125,
 		}),
 	).toEqual({
-		marginLeft: 1154.4991419797689,
+		marginLeft: 1154.0226668902187,
 		premountWidth: null,
 		postmountWidth: null,
-		width: 221.5678029521057,
-		naturalWidth: 221.5678029521057,
+		width: 221.47594665703676,
+		naturalWidth: 221.47594665703676,
 	});
 });
 


### PR DESCRIPTION
## Summary
- Fixed off-by-one errors in `get-timeline-sequence-layout.ts` that caused each timeline layer to appear 1 frame too short
- Changed from point-based coordinates (`durationInFrames - 1`, `video.durationInFrames - 1`) to slot-based coordinates (`durationInFrames`, `video.durationInFrames`) so each frame occupies a visible slot in the timeline
- A sequence that spans the entire composition now fills the timeline exactly without overflow

## Test plan
- [x] All 6 existing `timeline-sequence-layout.test.ts` tests pass with updated snapshot values
- [ ] Visually verify in the Studio that layers now appear the correct width

🤖 Generated with [Claude Code](https://claude.com/claude-code)