### PR TITLE
Template Prompt-to-Motion-Graphics: Use TabPanel for code examples page

### DIFF
--- a/packages/template-prompt-to-motion-graphics/src/app/code-examples/page.tsx
+++ b/packages/template-prompt-to-motion-graphics/src/app/code-examples/page.tsx
@@ -14,6 +14,7 @@ import {
 import { AnimationPlayer } from "../../components/AnimationPlayer";
 import { CodeEditor } from "../../components/CodeEditor";
 import { Header } from "../../components/Header";
+import { TabPanel } from "../../components/TabPanel";
 import { examples, getExampleById } from "../../examples/code";
 import { useAnimationState } from "../../hooks/useAnimationState";
 
@@ -145,8 +146,8 @@ function DemoPageContent() {
         </div>
 
         {/* Main content */}
-        <div className="flex-1 flex flex-col min-w-0 pb-8">
-          <div className="mb-4 flex items-center gap-4">
+        <div className="flex-1 flex flex-col min-w-0 pb-8 overflow-hidden">
+          <div className="mb-4 flex items-center gap-4 shrink-0">
             <button
               onClick={() => setSidebarOpen(!sidebarOpen)}
               className="p-2 rounded-lg border border-border-dim bg-muted text-muted-foreground hover:text-foreground hover:border-border transition-colors"
@@ -168,26 +169,32 @@ function DemoPageContent() {
             </div>
           </div>
 
-          <div className="flex-1 flex flex-col lg:flex-row gap-8 overflow-auto lg:overflow-hidden">
-            <CodeEditor
-              code={code}
-              onChange={handleCodeChange}
-              isStreaming={false}
-              streamPhase="idle"
+          <div className="flex-1 min-h-0">
+            <TabPanel
+              codeContent={
+                <CodeEditor
+                  code={code}
+                  onChange={handleCodeChange}
+                  isStreaming={false}
+                  streamPhase="idle"
+                />
+              }
+              previewContent={
+                <div className="h-full max-w-4xl">
+                  <AnimationPlayer
+                    Component={Component}
+                    durationInFrames={durationInFrames}
+                    fps={fps}
+                    onDurationChange={setDurationInFrames}
+                    onFpsChange={setFps}
+                    isCompiling={isCompiling}
+                    isStreaming={false}
+                    error={error}
+                    code={code}
+                  />
+                </div>
+              }
             />
-            <div className="shrink-0 lg:shrink lg:flex-[2.5] lg:min-w-0 lg:h-full">
-              <AnimationPlayer
-                Component={Component}
-                durationInFrames={durationInFrames}
-                fps={fps}
-                onDurationChange={setDurationInFrames}
-                onFpsChange={setFps}
-                isCompiling={isCompiling}
-                isStreaming={false}
-                error={error}
-                code={code}
-              />
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Summary                                                                                                                                                
                                                                                                  
  - Replace side-by-side code editor / preview layout on the code examples page with the same TabPanel toggle already used on the generate page
  - Each view (Remotion Code / Video Preview) now gets the full content width instead of being squeezed into a 1:2.5 split
  - Video preview is constrained to max-w-4xl so the 16:9 aspect ratio doesn't overflow the viewport