### PR TITLE
Remove root .npmrc (unused with Bun)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,8 +1,0 @@
-# By adding 1 dependency, we remove the defaults
-# The default is: ['*types*', '*eslint*', '@prettier/plugin-*', '*prettier-plugin-*']
-# Is a devDependency of `three` and a dependency of docs. Need to hoist
-public-hoist-pattern[]=@react-three/fiber
-auto-install-peers=true
-strict-peer-dependencies=false
-publish-branch=main
-update-notifier=false


### PR DESCRIPTION
## Summary
- The root `.npmrc` contained pnpm/npm-only settings (`public-hoist-pattern`, `auto-install-peers`, `strict-peer-dependencies`, `publish-branch`, `update-notifier`) that have no effect since this repo uses Bun
- Template `.npmrc` files are kept since they serve end users who may use npm/pnpm

## Test plan
- [x] `bun install` still works without the file
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)