### PR TITLE
Improve browser launch error messages

### DIFF
--- a/packages/renderer/src/browser/BrowserRunner.ts
+++ b/packages/renderer/src/browser/BrowserRunner.ts
@@ -76,6 +76,7 @@ export const makeBrowserRunner = async ({
 		timeout,
 		indent,
 		logLevel,
+		executablePath,
 	});
 	const transport = await NodeWebSocketTransport.create(browserWSEndpoint);
 	const connection = new Connection(transport);
@@ -257,11 +258,13 @@ function waitForWSEndpoint({
 	timeout,
 	logLevel,
 	indent,
+	executablePath,
 }: {
 	browserProcess: childProcess.ChildProcess;
 	timeout: number;
 	logLevel: LogLevel;
 	indent: boolean;
+	executablePath: string;
 }): Promise<string> {
 	const browserStderr = browserProcess.stderr;
 	const browserStdout = browserProcess.stdout;
@@ -296,12 +299,31 @@ function waitForWSEndpoint({
 
 		function onClose(error?: Error) {
 			cleanup();
+
+			const errorDetails: string[] = [];
+			if (error) {
+				errorDetails.push(error.message);
+				if (isErrnoException(error)) {
+					if (error.code) {
+						errorDetails.push(`Error code: ${error.code}`);
+					}
+
+					if (error.syscall) {
+						errorDetails.push(
+							`Syscall: ${error.syscall}${error.path ? ` ${error.path}` : ''}`,
+						);
+					}
+				}
+			}
+
 			reject(
 				new Error(
 					[
 						'Failed to launch the browser process!',
-						error ? error.stack : null,
-						stdioString,
+						`Executable: ${executablePath}`,
+						`PID: ${browserProcess.pid ?? 'not assigned'}`,
+						...errorDetails,
+						stdioString ? `Browser output: ${stdioString}` : null,
 						'Troubleshooting: https://remotion.dev/docs/troubleshooting/browser-launch',
 					]
 						.filter(truthy)


### PR DESCRIPTION
## Summary
- Surface executable path, PID, error code (`ENOENT`, `EACCES`, etc.), and syscall details in browser launch errors
- Previously the error was just `"Failed to launch the browser process!\nTroubleshooting: ..."` with no actionable info
- Now includes: which binary was attempted, whether a PID was assigned, the system error code, and any browser stdout/stderr output

## Test plan
- [ ] Verify type-checks pass (`npx tsc --noEmit`)
- [ ] Trigger a browser launch failure and confirm the improved error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)