### PR TITLE
Re-stage formatted files and run lint in pre-commit hook

### DIFF
--- a/pre-commit.ts
+++ b/pre-commit.ts
@@ -4,15 +4,17 @@ import {$} from 'bun';
 
 const staged = await $`git diff --cached --name-only --diff-filter=ACMR`.text();
 const unstaged = await $`git diff --name-only`.text();
+const stagedFiles = staged.trim().split('\n').filter(Boolean);
 const changedFiles = [
-	...new Set([...staged.trim().split('\n'), ...unstaged.trim().split('\n')]),
+	...new Set([...stagedFiles, ...unstaged.trim().split('\n')]),
 ].filter(Boolean);
 
 if (changedFiles.length === 0) {
 	process.exit(0);
 }
 
-const packageNames = new Set<string>();
+const formatPackageNames = new Set<string>();
+const lintPackageNames = new Set<string>();
 
 for (const file of changedFiles) {
 	const match = file.match(/^packages\/([^/]+)\//);
@@ -29,17 +31,32 @@ for (const file of changedFiles) {
 
 	const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
 
-	if (!pkgJson.scripts?.format) {
-		continue;
+	if (pkgJson.scripts?.format) {
+		formatPackageNames.add(pkgJson.name);
 	}
 
-	packageNames.add(pkgJson.name);
+	if (pkgJson.scripts?.lint) {
+		lintPackageNames.add(pkgJson.name);
+	}
 }
 
-if (packageNames.size === 0) {
-	process.exit(0);
+if (formatPackageNames.size > 0) {
+	const formatFilters = [...formatPackageNames].flatMap((name) => [
+		'--filter',
+		name,
+	]);
+	await $`bun run ${formatFilters} format`;
+
+	// Re-stage originally staged files so formatting changes are included in this commit
+	if (stagedFiles.length > 0) {
+		await $`git add ${stagedFiles}`;
+	}
 }
 
-const filters = [...packageNames].flatMap((name) => ['--filter', name]);
-
-await $`bun run ${filters} format`;
+if (lintPackageNames.size > 0) {
+	const lintFilters = [...lintPackageNames].flatMap((name) => [
+		'--filter',
+		name,
+	]);
+	await $`bun run ${lintFilters} lint`;
+}


### PR DESCRIPTION
## Summary
- After running `format`, re-stage originally staged files with `git add` so formatting changes are included in the current commit instead of being left as unstaged changes
- Run `lint` for affected packages and fail the commit if lint exits non-zero

## Test plan
- [ ] Make a change in a package, stage it, and commit — verify formatting changes are included in the commit
- [ ] Introduce a lint error and verify the commit is aborted

🤖 Generated with [Claude Code](https://claude.com/claude-code)