### PR TITLE
Increase docs twoslash worker timeout to 8 minutes

### DIFF
--- a/packages/docs/prewarm-twoslash.ts
+++ b/packages/docs/prewarm-twoslash.ts
@@ -156,7 +156,7 @@ interface WorkerResult {
 	timings: TimingEntry[];
 }
 
-const WORKER_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes per worker
+const WORKER_TIMEOUT_MS = 8 * 60 * 1000; // 8 minutes per worker
 
 function runWorker(
 	workItems: TwoslashBlock[],


### PR DESCRIPTION
## Summary
- Increases the twoslash worker timeout from 5 minutes to 8 minutes to prevent timeouts during docs build

## Test plan
- Verify docs build completes without worker timeout errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)