### PR TITLE
`@remotion/lambda`: Fix size being exceeded when using Apple Emojis

### DIFF
--- a/packages/lambda/src/admin/make-layer-public.ts
+++ b/packages/lambda/src/admin/make-layer-public.ts
@@ -61,7 +61,7 @@ const makeLayerPublic = async () => {
 				new PublishLayerVersionCommand({
 					Content: {
 						S3Bucket: getBucketName(region),
-						S3Key: `remotion-layer-${layer}-v15-arm64.zip`,
+						S3Key: `remotion-layer-${layer}-v16-arm64.zip`,
 					},
 					LayerName: layerName,
 					LicenseInfo:

--- a/packages/lambda/src/shared/hosted-layers.ts
+++ b/packages/lambda/src/shared/hosted-layers.ts
@@ -16,648 +16,648 @@ export const hostedLayers: HostedLayers = {
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 27,
+			version: 28,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'ap-south-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 27,
+			version: 28,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'ap-southeast-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 27,
+			version: 28,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'ap-southeast-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 27,
+			version: 28,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'eu-central-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 59,
+			version: 60,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 59,
+			version: 60,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 21,
+			version: 22,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 21,
+			version: 22,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 21,
+			version: 22,
 		},
 	],
 	'eu-west-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 24,
+			version: 25,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 27,
+			version: 28,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'eu-west-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 27,
+			version: 28,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'us-east-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 28,
+			version: 29,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 36,
+			version: 37,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'us-east-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 27,
+			version: 28,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'us-west-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 27,
+			version: 28,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'af-south-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'ap-east-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'ap-northeast-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'ap-northeast-3': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'ca-central-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 19,
+			version: 20,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 19,
+			version: 20,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 10,
+			version: 11,
 		},
 	],
 	'eu-north-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'eu-south-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'eu-west-3': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'me-south-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 19,
+			version: 20,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 19,
+			version: 20,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 10,
+			version: 11,
 		},
 	],
 	'sa-east-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 19,
+			version: 20,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 19,
+			version: 20,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 10,
+			version: 11,
 		},
 	],
 	'us-west-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 20,
+			version: 21,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
+			version: 12,
 		},
 	],
 	'ap-southeast-4': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 8,
+			version: 9,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 8,
+			version: 9,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 7,
+			version: 8,
 		},
 	],
 	'ap-southeast-5': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 7,
+			version: 8,
 		},
 	],
 	'eu-central-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 7,
+			version: 8,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 7,
+			version: 8,
 		},
 	],
 };


### PR DESCRIPTION
Apple Emojis are now built with https://github.com/samuelngs/apple-emoji-ttf v2, but with a lower 64px resolution