### PR TITLE
`remotion-lambda`: Fix `numberOfGifLoops` default causing non-GIF renders to fail

### DIFF
--- a/packages/lambda-python/remotion_lambda/models.py
+++ b/packages/lambda-python/remotion_lambda/models.py
@@ -302,7 +302,7 @@ class RenderMediaParams:
     chromium_options: Optional[ChromiumOptions] = None
     scale: Optional[int] = 1
     every_nth_frame: Optional[int] = 1
-    number_of_gif_loops: Optional[int] = 0
+    number_of_gif_loops: Optional[int] = None
     concurrency_per_lambda: Optional[int] = 1
     concurrency: Optional[int] = None
     download_behavior: Optional[Union[PlayInBrowser, ShouldDownload]] = field(


### PR DESCRIPTION
## Summary

- Change default value of `number_of_gif_loops` from `0` to `None` in the Python SDK's `RenderMediaParams` so that `numberOfGifLoops` is serialized as `null` instead of `0` for non-GIF codecs
- Since v4.0.424, the Lambda stitcher validates that `numberOfGifLoops` can only be set when `codec` is `"gif"`, so always sending `0` caused every non-GIF render to fail with: `"numberOfGifLoops" can only be set if "codec" is set to "gif"`

Fixes #6749

## Test plan

- [ ] Render a video with `codec="h264"` (default) using the Python SDK — should no longer throw the `numberOfGifLoops` validation error
- [ ] Render a GIF with `number_of_gif_loops=0` — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)