### PR TITLE
`@remotion/web-renderer`: handle `<img>` in a broken state

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -7,7 +7,6 @@ import React, {
 	useRef,
 } from 'react';
 import type {IsExact} from './audio/props.js';
-import {cancelRender} from './cancel-render.js';
 import {getCrossOriginValue} from './get-cross-origin-value.js';
 import {usePreload} from './prefetch.js';
 import {SequenceContext} from './SequenceContext.js';
@@ -100,6 +99,8 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 		}, timeout);
 	}, []);
 
+	const {delayRender, continueRender, cancelRender} = useDelayRender();
+
 	const didGetError = useCallback(
 		(e: React.SyntheticEvent<HTMLImageElement, Event>) => {
 			if (!errors.current) {
@@ -133,14 +134,17 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 				return;
 			}
 
-			cancelRender(
-				'Error loading image with src: ' + (imageRef.current?.src as string),
-			);
+			try {
+				cancelRender(
+					'Error loading image with src: ' + (imageRef.current?.src as string),
+				);
+			} catch {
+				// cancelRender() intentionally throws after storing the error in scope.
+				// In async image callbacks, we rely on the stored error for renderer propagation.
+			}
 		},
-		[maxRetries, onError, retryIn],
+		[cancelRender, maxRetries, onError, retryIn],
 	);
-
-	const {delayRender, continueRender} = useDelayRender();
 
 	if (typeof window !== 'undefined') {
 		const isPremounting = Boolean(sequenceContext?.premounting);
@@ -210,7 +214,13 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 					// eslint-disable-next-line no-console
 					console.warn(err);
 
-					if (current.complete) {
+					// HTMLImageElement.complete is also true for broken images (e.g. 404),
+					// so only treat it as loaded if intrinsic dimensions are available.
+					if (
+						current.complete &&
+						current.naturalWidth > 0 &&
+						current.naturalHeight > 0
+					) {
 						onComplete();
 					} else {
 						current.addEventListener('load', onComplete);

--- a/packages/web-renderer/src/test/images.test.tsx
+++ b/packages/web-renderer/src/test/images.test.tsx
@@ -1,5 +1,5 @@
 import {AbsoluteFill, Img, staticFile} from 'remotion';
-import {test} from 'vitest';
+import {expect, test} from 'vitest';
 import {renderStillOnWeb} from '../render-still-on-web';
 import '../symbol-dispose';
 import {testImage} from './utils';
@@ -30,4 +30,33 @@ test('can display an image', async () => {
 	});
 
 	await testImage({blob, testId: 'img-tag'});
+});
+
+test('should cancel render for a broken image', async () => {
+	const Component: React.FC = () => {
+		return (
+			<AbsoluteFill>
+				<Img src={staticFile('missing-image.png')} maxRetries={0} />
+			</AbsoluteFill>
+		);
+	};
+
+	await expect(
+		renderStillOnWeb({
+			licenseKey: 'free-license',
+			composition: {
+				component: Component,
+				id: 'missing-image-test',
+				width: 100,
+				height: 100,
+				fps: 25,
+				durationInFrames: 1,
+				calculateMetadata: () => Promise.resolve({}),
+			},
+			frame: 0,
+			inputProps: {},
+			imageFormat: 'png',
+			delayRenderTimeoutInMilliseconds: 5000,
+		}),
+	).rejects.toThrow(/Error loading image with src:/);
 });

--- a/packages/web-renderer/src/test/tainted-image.test.tsx
+++ b/packages/web-renderer/src/test/tainted-image.test.tsx
@@ -49,7 +49,8 @@ test('should throw readable error when image fails to load or is blocked by CORS
 		const hasReadableError =
 			err.message.includes('CORS restrictions') ||
 			err.message.includes('broken state') ||
-			err.message.includes('Could not draw image');
+			err.message.includes('Could not draw image') ||
+			err.message.includes('Error loading image with src');
 		expect(hasReadableError).toBe(true);
 	}
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
Fixes #6246

This PR addresses an issue where the `<Img>` component could incorrectly treat a broken image as successfully loaded if `img.complete` was true after a `decode()` failure.

**What changed:**
*   `packages/core/src/Img.tsx`:
    *   Modified `onComplete()` logic to only consider an image loaded if it has intrinsic dimensions (`naturalWidth` and `naturalHeight` > 0) after a `decode()` failure.
    *   Switched from global `cancelRender` to the scoped `cancelRender` from `useDelayRender()` to ensure proper cancellation within the web renderer context.
    *   Wrapped `cancelRender()` in a `try/catch` to prevent uncaught async errors.
*   `packages/web-renderer/src/test/images.test.tsx`: Added a regression test (`should cancel render for a broken image`) to verify that missing images correctly reject rendering.
*   `packages/web-renderer/src/test/tainted-image.test.tsx`: Updated the error matcher to accommodate the new explicit error path for image loading failures.

---
<p><a href="https://cursor.com/agents/bc-5be9a536-b739-46d0-ab86-c6d15d21e146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5be9a536-b739-46d0-ab86-c6d15d21e146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->