### PR TITLE
`docs`: Improve Lambda upgrading guide

### DIFF
--- a/packages/docs/docs/lambda/upgrading.mdx
+++ b/packages/docs/docs/lambda/upgrading.mdx
@@ -53,10 +53,10 @@ Only do this once the old function is no longer being used in production.
 :::
 
 ```sh
-npx remotion lambda functions rmall -y
+npx remotion lambda functions rm <function-name>
 ```
 
-See [`npx remotion lambda functions rmall`](/docs/lambda/cli/functions/rmall).
+See [`npx remotion lambda functions rm`](/docs/lambda/cli/functions/rm).
 
 ## Zero-downtime upgrades
 


### PR DESCRIPTION
## Summary
- Make it explicit that updating the site is **required** when upgrading Lambda, with a warning callout explaining that version mismatches can cause render failures on protocol changes
- Reorder steps to a more natural flow (upgrade packages → deploy function → update site → optionally remove old functions)
- Replace "Separating environments" section with a clear "Zero-downtime upgrades" procedure
- Add "Useful commands" reference section including `sites ls`

Addresses https://discord.com/channels/809501355504959528/1478160459898290277/1478160459898290277

## Test plan
- [ ] Verify the page renders correctly on the docs site
- [ ] Check all internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)