### PR TITLE
`@remotion/studio`: Fire onValueChange during text input mode on every keystroke

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -98,7 +98,6 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 
 	const onInputChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
 		(e) => {
-		(e) => {
 			const parsed = Number(e.target.value);
 			if (e.target.value !== '' && !Number.isNaN(parsed)) {
 				onValueChange(parsed);


### PR DESCRIPTION
## Summary
- When the `InputDragger` is in text input mode, `onValueChange` now fires on every keystroke via an `onChange` handler
- Previously, value changes were only communicated on blur via `onTextChange`, meaning the preview didn't update live while typing

## Test plan
- Open the Studio, find a number field using `InputDragger` (e.g. in the timeline schema fields)
- Click to enter text input mode
- Type a new number value — the preview should update live as you type, not just on blur

🤖 Generated with [Claude Code](https://claude.com/claude-code)