### PR TITLE
`@remotion/gif`: Add schema, Sequence wrapper and displayName

### DIFF
--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -1,20 +1,127 @@
-import {forwardRef} from 'react';
-import {useRemotionEnvironment} from 'remotion';
+import React from 'react';
+import {
+	Internals,
+	Sequence,
+	useRemotionEnvironment,
+	useVideoConfig,
+	type SequenceControls,
+	type SequenceProps,
+	type SequenceSchema,
+} from 'remotion';
 import {GifForDevelopment} from './GifForDevelopment';
 import {GifForRendering} from './GifForRendering';
 import type {RemotionGifProps} from './props';
+
+export type GifProps = Omit<
+	SequenceProps,
+	'children' | 'durationInFrames' | 'layout'
+> &
+	RemotionGifProps & {
+		readonly durationInFrames?: number;
+	};
 
 /*
  * @description Displays a GIF that synchronizes with Remotions useCurrentFrame().
  * @see [Documentation](https://remotion.dev/docs/gif)
  */
-export const Gif = forwardRef<HTMLCanvasElement, RemotionGifProps>(
-	(props, ref) => {
-		const env = useRemotionEnvironment();
-		if (env.isRendering) {
-			return <GifForRendering {...props} ref={ref} />;
-		}
-
-		return <GifForDevelopment {...props} ref={ref} />;
+const gifSchema = {
+	playbackRate: {
+		type: 'number',
+		min: 0,
+		max: 10,
+		step: 0.1,
+		default: 1,
+		description: 'Playback Rate',
 	},
-);
+	'style.translate': {
+		type: 'translate',
+		step: 1,
+		default: '0px 0px',
+		description: 'Position',
+	},
+	'style.scale': {
+		type: 'number',
+		min: 0.05,
+		max: 100,
+		step: 0.01,
+		default: 1,
+		description: 'Scale',
+	},
+	'style.rotate': {
+		type: 'rotation',
+		step: 1,
+		default: '0deg',
+		description: 'Rotation',
+	},
+	'style.opacity': {
+		type: 'number',
+		min: 0,
+		max: 1,
+		step: 0.01,
+		default: 1,
+		description: 'Opacity',
+	},
+} as const satisfies SequenceSchema;
+
+const GifInner = ({
+	src,
+	width,
+	height,
+	onLoad,
+	onError,
+	fit,
+	playbackRate,
+	loopBehavior,
+	id,
+	delayRenderTimeoutInMilliseconds,
+	durationInFrames,
+	style,
+	controls,
+	ref,
+	...sequenceProps
+}: GifProps & {
+	readonly controls?: SequenceControls | undefined;
+	readonly ref?: React.Ref<HTMLCanvasElement>;
+}) => {
+	const env = useRemotionEnvironment();
+	const {durationInFrames: videoDuration} = useVideoConfig();
+	const resolvedDuration = durationInFrames ?? videoDuration;
+
+	const gifProps: RemotionGifProps = {
+		src,
+		width,
+		height,
+		onLoad,
+		onError,
+		fit,
+		playbackRate,
+		loopBehavior,
+		id,
+		delayRenderTimeoutInMilliseconds,
+		style,
+	};
+
+	const inner = env.isRendering ? (
+		<GifForRendering {...gifProps} ref={ref} />
+	) : (
+		<GifForDevelopment {...gifProps} ref={ref} />
+	);
+
+	return (
+		<Sequence
+			layout="none"
+			durationInFrames={resolvedDuration}
+			name="<Gif>"
+			controls={controls}
+			{...sequenceProps}
+		>
+			{inner}
+		</Sequence>
+	);
+};
+
+export const Gif = Internals.wrapInSchema(GifInner, gifSchema);
+
+Gif.displayName = 'Gif';
+
+Internals.addSequenceStackTraces(Gif);

--- a/packages/gif/src/index.ts
+++ b/packages/gif/src/index.ts
@@ -1,4 +1,4 @@
 export {getGifDurationInSeconds} from './get-gif-duration-in-seconds';
-export {Gif} from './Gif';
+export {Gif, type GifProps} from './Gif';
 export {preloadGif} from './preload-gif';
 export {GifFillMode, RemotionGifProps} from './props';


### PR DESCRIPTION
## Summary
- Added a `gifSchema` with `playbackRate` and style controls (position, scale, rotation, opacity) for visual mode
- Wrapped Gif in a `<Sequence layout="none">` with name `<Gif>`
- Added `displayName` and `addSequenceStackTraces`
- Exported new `GifProps` type

## Test plan
- [ ] Verify `<Gif>` renders correctly in development and rendering modes
- [ ] Verify the Sequence shows up in the timeline with the name `<Gif>`
- [ ] Verify schema controls work in visual mode
- [ ] Verify passing a `ref` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)