### PR TITLE
`docs`: Update "Render in browser" page and downgrade "Very experimental" to "Experimental"

### DIFF
--- a/packages/docs/docs/client-side-rendering/cancellation.mdx
+++ b/packages/docs/docs/client-side-rendering/cancellation.mdx
@@ -6,7 +6,7 @@ crumb: '@remotion/web-renderer'
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/client-side-rendering/how-it-works.mdx
+++ b/packages/docs/docs/client-side-rendering/how-it-works.mdx
@@ -6,7 +6,7 @@ title: How client-side rendering works
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/client-side-rendering/index.mdx
+++ b/packages/docs/docs/client-side-rendering/index.mdx
@@ -6,7 +6,7 @@ title: Client-side rendering
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/client-side-rendering/limitations.mdx
+++ b/packages/docs/docs/client-side-rendering/limitations.mdx
@@ -6,7 +6,7 @@ title: Limitations of client-side rendering
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/client-side-rendering/migration.mdx
+++ b/packages/docs/docs/client-side-rendering/migration.mdx
@@ -6,7 +6,7 @@ crumb: 'FAQ'
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/client-side-rendering/telemetry.mdx
+++ b/packages/docs/docs/client-side-rendering/telemetry.mdx
@@ -6,7 +6,7 @@ title: Telemetry in client-side rendering
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/miscellaneous/render-in-browser.mdx
+++ b/packages/docs/docs/miscellaneous/render-in-browser.mdx
@@ -5,16 +5,11 @@ title: Can I render videos in the browser?
 crumb: 'FAQ'
 ---
 
-Rendering videos in the browser is currently not supported.  
-In order to render videos, you need to hook up [server-side rendering](/docs/ssr), [Remotion Lambda](/docs/lambda), or [render videos locally](/docs/render).
+Yes! Remotion supports rendering videos directly in the browser using the [`@remotion/web-renderer`](/docs/web-renderer) package.
 
-## Our future plan
-
-**We are planning to add support for rendering videos in the browser in the future** - with some [limitations](/docs/client-side-rendering/limitations).  
-See [Client-side rendering](/docs/client-side-rendering) for an overview of the project.
-
-We hope to launch this mode in late 2025.
+See [Client-side rendering](/docs/client-side-rendering) for an overview, including [how it works](/docs/client-side-rendering/how-it-works) and [limitations](/docs/client-side-rendering/limitations).
 
 ## See also
 
-- [`<Player>`](/player): Displaying a Remotion video in the browser without encoding it
+- [Client-side rendering](/docs/client-side-rendering)
+- [`<Player>`](/docs/player): Displaying a Remotion video in the browser without encoding it

--- a/packages/docs/docs/stills.mdx
+++ b/packages/docs/docs/stills.mdx
@@ -38,7 +38,7 @@ You can use the [`renderStill()`](/docs/renderer/render-still) Node.JS API to re
 ## Rendering in the browser
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/web-renderer/can-render-media-on-web.mdx
+++ b/packages/docs/docs/web-renderer/can-render-media-on-web.mdx
@@ -6,7 +6,7 @@ crumb: '@remotion/web-renderer'
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/web-renderer/get-encodable-audio-codecs.mdx
+++ b/packages/docs/docs/web-renderer/get-encodable-audio-codecs.mdx
@@ -6,7 +6,7 @@ crumb: '@remotion/web-renderer'
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/web-renderer/get-encodable-video-codecs.mdx
+++ b/packages/docs/docs/web-renderer/get-encodable-video-codecs.mdx
@@ -6,7 +6,7 @@ crumb: '@remotion/web-renderer'
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/web-renderer/index.mdx
+++ b/packages/docs/docs/web-renderer/index.mdx
@@ -6,7 +6,7 @@ crumb: API
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/web-renderer/render-media-on-web.mdx
+++ b/packages/docs/docs/web-renderer/render-media-on-web.mdx
@@ -8,7 +8,7 @@ crumb: '@remotion/web-renderer'
 # renderMediaOnWeb()<AvailableFrom v="4.0.397" />
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/web-renderer/render-still-on-web.mdx
+++ b/packages/docs/docs/web-renderer/render-still-on-web.mdx
@@ -8,7 +8,7 @@ crumb: '@remotion/web-renderer'
 # renderStillOnWeb()<AvailableFrom v="4.0.397" />
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.  
+Experimental feature - expect bugs and breaking changes at any time.  
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 

--- a/packages/docs/docs/web-renderer/types.mdx
+++ b/packages/docs/docs/web-renderer/types.mdx
@@ -8,7 +8,7 @@ crumb: '@remotion/web-renderer'
 ---
 
 :::warning
-Very experimental feature - expect bugs and breaking changes at any time.
+Experimental feature - expect bugs and breaking changes at any time.
 [Track progress on GitHub](https://github.com/remotion-dev/remotion/issues/5913) and discuss in the [`#web-renderer`](https://remotion.dev/discord) channel on Discord.
 :::
 


### PR DESCRIPTION
## Summary
- Updated the "Can I render videos in the browser?" FAQ page to reflect that client-side rendering has shipped
- Downgraded "Very experimental" to "Experimental" across all `@remotion/web-renderer` and client-side rendering docs (14 files)

Closes #6818

🤖 Generated with [Claude Code](https://claude.com/claude-code)