### PR TITLE
`@remotion/lambda`: Add `compatibleOnly` support to `getSites()` and `sites ls`

### DIFF
--- a/packages/docs/docs/lambda/cli/sites/ls.mdx
+++ b/packages/docs/docs/lambda/cli/sites/ls.mdx
@@ -48,6 +48,10 @@ npx remotion lambda sites ls -q
   </pre>
 </details>
 
+## `--compatible-only`<AvailableFrom v="4.0.435" />
+
+If passed, only sites whose Remotion version matches the installed version of `@remotion/lambda` are returned.
+
 ## `--force-path-style`<AvailableFrom v="4.0.202" />
 
 Passes `forcePathStyle` to the AWS S3 client. If you don't know what this is, you probably don't need it.

--- a/packages/docs/docs/lambda/getsites.mdx
+++ b/packages/docs/docs/lambda/getsites.mdx
@@ -27,6 +27,7 @@ for (const site of sites) {
   console.log(site.lastModified); // A unix timestamp, but may also be null
   console.log(site.sizeInBytes); // Size of all contents in the folder
   console.log(site.serveUrl); // URL of the deployed site that you can pass to `renderMediaOnLambda()`
+  console.log(site.version); // The Remotion version of the site, or null
 }
 
 for (const bucket of buckets) {
@@ -51,6 +52,10 @@ The [AWS region](/docs/lambda/region-selection) which you want to query.
 ### `forceBucketName?`<AvailableFrom v="3.3.102"/>
 
 Specify a specific bucket name to be used. [This is not recommended](/docs/lambda/multiple-buckets), instead let Remotion discover the right bucket automatically.
+
+### `compatibleOnly?`<AvailableFrom v="4.0.435"/>
+
+If `true`, only sites whose Remotion version matches the installed version of `@remotion/lambda` are returned. If `false` or not provided, all sites are returned.
 
 ## Return value
 
@@ -81,6 +86,10 @@ The combined size of all files in that project.
 #### `serveUrl`
 
 URL of the deployed site. You can pass it into [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda) to render a video or audio.
+
+#### `version`<AvailableFrom v="4.0.435"/>
+
+The Remotion version of the site, or `null` if the version could not be determined.
 
 ### `buckets`
 

--- a/packages/it-tests/src/bundle/bundle-studio.test.ts
+++ b/packages/it-tests/src/bundle/bundle-studio.test.ts
@@ -2,6 +2,10 @@ import {expect, test} from 'bun:test';
 import {existsSync, readFileSync} from 'fs';
 import path from 'path';
 import {RenderInternals, openBrowser} from '@remotion/renderer';
+import {
+	getRemotionVersionFromIndexHtml,
+	VERSION,
+} from '@remotion/serverless-client';
 
 test(
 	'Bundle studio',
@@ -32,6 +36,13 @@ test(
 		if (contents.includes('PreviewToolbar') || contents.includes('TopPanel')) {
 			throw new Error('Studio was bundled');
 		}
+
+		const indexHtmlContent = readFileSync(
+			path.join(folder, 'index.html'),
+			'utf-8',
+		);
+		const version = getRemotionVersionFromIndexHtml(indexHtmlContent);
+		expect(version).toBe(VERSION);
 
 		const {port, close} = await RenderInternals.serveStatic(
 			path.join(process.cwd(), '..', 'example', 'build'),

--- a/packages/lambda-client/src/get-sites.ts
+++ b/packages/lambda-client/src/get-sites.ts
@@ -1,4 +1,9 @@
 import type {ProviderSpecifics} from '@remotion/serverless-client';
+import {
+	getRemotionVersionFromIndexHtml,
+	streamToString,
+	VERSION,
+} from '@remotion/serverless-client';
 import type {AwsProvider} from './aws-provider';
 import {awsImplementation} from './aws-provider';
 import {getSitesKey} from './constants';
@@ -13,6 +18,7 @@ type Site = {
 	bucketName: string;
 	id: string;
 	serveUrl: string;
+	version: string | null;
 };
 
 type MandatoryParameters = {
@@ -22,6 +28,7 @@ type MandatoryParameters = {
 type OptionalParameters = {
 	forceBucketName: string | null;
 	forcePathStyle: boolean;
+	compatibleOnly: boolean;
 	requestHandler: RequestHandler | null;
 };
 
@@ -38,6 +45,7 @@ export const internalGetSites = async ({
 	forceBucketName,
 	providerSpecifics,
 	forcePathStyle,
+	compatibleOnly,
 	requestHandler,
 }: GetSitesInternalInput & {
 	providerSpecifics: ProviderSpecifics<AwsProvider>;
@@ -91,6 +99,7 @@ export const internalGetSites = async ({
 						region,
 						subFolder: getSitesKey(siteId),
 					}),
+					version: null,
 				};
 			}
 
@@ -113,23 +122,49 @@ export const internalGetSites = async ({
 	const sitesArray: Site[] = Object.keys(sites).map((siteId) => {
 		return sites[siteId];
 	});
-	return {sites: sitesArray, buckets: remotionBuckets};
+
+	await Promise.all(
+		sitesArray.map(async (site) => {
+			try {
+				const body = await providerSpecifics.readFile({
+					bucketName: site.bucketName,
+					key: `${getSitesKey(site.id)}/index.html`,
+					region,
+					expectedBucketOwner: accountId,
+					forcePathStyle,
+					requestHandler,
+				});
+				const indexHtml = await streamToString(body);
+				site.version = getRemotionVersionFromIndexHtml(indexHtml);
+			} catch {
+				site.version = null;
+			}
+		}),
+	);
+
+	const filtered = compatibleOnly
+		? sitesArray.filter((s) => s.version === VERSION)
+		: sitesArray;
+
+	return {sites: filtered, buckets: remotionBuckets};
 };
 
 /*
- * @description Gets an array of Remotion projects in Cloud Storage, in your GCP project.
- * @see [Documentation](https://remotion.dev/docs/cloudrun/getsites)
+ * @description Gets an array of Remotion sites in your S3 bucket.
+ * @see [Documentation](https://remotion.dev/docs/lambda/getsites)
  */
 export const getSites = ({
 	region,
 	forceBucketName,
 	forcePathStyle,
+	compatibleOnly,
 	requestHandler,
 }: GetSitesInput): Promise<GetSitesOutput> => {
 	return internalGetSites({
 		region,
 		forceBucketName: forceBucketName ?? null,
 		forcePathStyle: forcePathStyle ?? false,
+		compatibleOnly: compatibleOnly ?? false,
 		providerSpecifics: awsImplementation,
 		requestHandler: requestHandler ?? null,
 	});

--- a/packages/lambda/src/cli/commands/sites/ls.ts
+++ b/packages/lambda/src/cli/commands/sites/ls.ts
@@ -1,25 +1,28 @@
 import {CliInternals} from '@remotion/cli';
 import {getSites} from '@remotion/lambda-client';
 import type {LogLevel} from '@remotion/renderer';
+import {parsedLambdaCli} from '../../args';
 import {getAwsRegion} from '../../get-aws-region';
 import {dateString} from '../../helpers/date-string';
 
 export const SITES_LS_SUBCOMMAND = 'ls';
 
-const COLS: [number, number, number, number] = [20, 30, 10, 15];
+const COLS: [number, number, number, number, number] = [20, 30, 10, 15, 15];
 
-const logRow = (data: [string, string, string, string]) => {
+const logRow = (data: [string, string, string, string, string]) => {
 	return [
 		data[0].padEnd(COLS[0], ' '),
 		data[1].padEnd(COLS[1], ' '),
 		data[2].padEnd(COLS[2], ' '),
 		String(data[3]).padEnd(COLS[3], ' '),
+		String(data[4]).padEnd(COLS[4], ' '),
 	].join('');
 };
 
 export const sitesLsSubcommand = async (logLevel: LogLevel) => {
 	const region = getAwsRegion();
-	const {sites, buckets} = await getSites({region});
+	const compatibleOnly = parsedLambdaCli['compatible-only'] || false;
+	const {sites, buckets} = await getSites({region, compatibleOnly});
 
 	if (buckets.length > 1 && !CliInternals.quietFlagProvided()) {
 		CliInternals.Log.warn(
@@ -52,7 +55,7 @@ export const sitesLsSubcommand = async (logLevel: LogLevel) => {
 	CliInternals.Log.info(
 		{indent: false, logLevel},
 		CliInternals.chalk.gray(
-			logRow(['Site Name', 'Bucket', 'Size', 'Last updated']),
+			logRow(['Site Name', 'Bucket', 'Size', 'Last updated', 'Version']),
 		),
 	);
 
@@ -64,6 +67,7 @@ export const sitesLsSubcommand = async (logLevel: LogLevel) => {
 				site.bucketName,
 				CliInternals.formatBytes(site.sizeInBytes),
 				site.lastModified ? dateString(new Date(site.lastModified)) : 'n/a',
+				site.version ?? 'n/a',
 			]),
 		);
 		CliInternals.Log.info({indent: false, logLevel}, site.serveUrl);

--- a/packages/lambda/src/test/integration/deploy-site.test.ts
+++ b/packages/lambda/src/test/integration/deploy-site.test.ts
@@ -107,7 +107,7 @@ test('Should apply name if given', async () => {
 		stats: {
 			deletedFiles: 0,
 			untouchedFiles: 0,
-			uploadedFiles: 2,
+			uploadedFiles: 3,
 		},
 	});
 });
@@ -147,7 +147,7 @@ test('Should overwrite site if given siteName is already taken', async () => {
 			'https://remotionlambda-apnortheast1-abcdef.s3.ap-northeast-1.amazonaws.com/sites/testing/index.html',
 		stats: {
 			deletedFiles: 0,
-			untouchedFiles: 2,
+			untouchedFiles: 3,
 			uploadedFiles: 0,
 		},
 	});

--- a/packages/lambda/src/test/integration/get-sites.test.ts
+++ b/packages/lambda/src/test/integration/get-sites.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
 import {LambdaClientInternals} from '@remotion/lambda-client';
 import {internalGetOrCreateBucket} from '@remotion/serverless';
+import {VERSION} from 'remotion/version';
 import {internalDeploySite} from '../../api/deploy-site';
 import {mockFullClientSpecifics} from '../mock-implementation';
 import {mockImplementation} from '../mocks/mock-implementation';
@@ -14,6 +15,7 @@ test('Should have no buckets at first', async () => {
 			providerSpecifics: mockImplementation,
 			forcePathStyle: false,
 			forceBucketName: null,
+			compatibleOnly: false,
 			requestHandler: null,
 		}),
 	).toEqual({buckets: [], sites: []});
@@ -55,7 +57,7 @@ test('Should have a site after deploying', async () => {
 		stats: {
 			deletedFiles: 0,
 			untouchedFiles: 0,
-			uploadedFiles: 2,
+			uploadedFiles: 3,
 		},
 	});
 	expect(
@@ -64,6 +66,7 @@ test('Should have a site after deploying', async () => {
 			providerSpecifics: mockImplementation,
 			forcePathStyle: false,
 			forceBucketName: null,
+			compatibleOnly: false,
 			requestHandler: null,
 		}),
 	).toEqual({
@@ -79,10 +82,53 @@ test('Should have a site after deploying', async () => {
 				bucketName: 'remotionlambda-eucentral1-abcdef',
 				id: 'testing',
 				lastModified: 0,
-				sizeInBytes: 48,
+				sizeInBytes: expect.any(Number),
 				serveUrl:
 					'https://remotionlambda-eucentral1-abcdef.s3.eu-central-1.amazonaws.com/sites/testing/index.html',
+				version: VERSION,
 			},
 		],
 	});
+});
+
+test('Should filter sites by compatibleOnly', async () => {
+	resetMockStore();
+	await internalGetOrCreateBucket({
+		region: 'eu-central-1',
+		providerSpecifics: mockImplementation,
+		customCredentials: null,
+		enableFolderExpiry: null,
+		forcePathStyle: false,
+		skipPutAcl: false,
+		requestHandler: null,
+		logLevel: 'info',
+	});
+	await internalDeploySite({
+		bucketName: 'remotionlambda-eucentral1-abcdef',
+		entryPoint: 'first',
+		region: 'eu-central-1',
+		siteName: 'testing',
+		gitSource: null,
+		logLevel: 'info',
+		indent: false,
+		providerSpecifics: mockImplementation,
+		privacy: 'public',
+		throwIfSiteExists: true,
+		options: {},
+		forcePathStyle: false,
+		fullClientSpecifics: mockFullClientSpecifics,
+		requestHandler: null,
+	});
+
+	const {sites} = await LambdaClientInternals.internalGetSites({
+		region: 'eu-central-1',
+		providerSpecifics: mockImplementation,
+		forcePathStyle: false,
+		forceBucketName: null,
+		compatibleOnly: true,
+		requestHandler: null,
+	});
+
+	expect(sites.length).toBe(1);
+	expect(sites[0].version).toBe(VERSION);
 });

--- a/packages/lambda/src/test/mocks/upload-dir.ts
+++ b/packages/lambda/src/test/mocks/upload-dir.ts
@@ -1,9 +1,25 @@
+import {VERSION} from 'remotion/version';
 import type {MockFile, uploadDir as original} from '../../api/upload-dir';
 import {writeMockS3File} from './mock-store';
+
+const mockIndexHtml = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Test</title></head>
+<body>
+<script>
+	window.siteVersion = '11';
+	window.remotion_version = '${VERSION}';
+</script>
+</body>
+</html>`;
 
 export const getDirFiles = (dir: string): MockFile[] => {
 	if (dir === '/path/to/bundle-1') {
 		return [
+			{
+				name: 'index.html',
+				content: mockIndexHtml,
+			},
 			{
 				name: 'bundle.js',
 				content: 'console.log("Hello World")',
@@ -17,6 +33,10 @@ export const getDirFiles = (dir: string): MockFile[] => {
 
 	if (dir === '/path/to/bundle-2') {
 		return [
+			{
+				name: 'index.html',
+				content: mockIndexHtml,
+			},
 			{
 				name: 'bundle.js',
 				content: 'console.log("Hello World")',

--- a/packages/serverless-client/src/get-remotion-version-from-index-html.ts
+++ b/packages/serverless-client/src/get-remotion-version-from-index-html.ts
@@ -1,0 +1,8 @@
+export const getRemotionVersionFromIndexHtml = (
+	indexHtmlContent: string,
+): string | null => {
+	const match = indexHtmlContent.match(
+		/window\.remotion_version\s*=\s*'([^']+)'/,
+	);
+	return match ? match[1] : null;
+};

--- a/packages/serverless-client/src/index.ts
+++ b/packages/serverless-client/src/index.ts
@@ -82,6 +82,7 @@ export {
 	internalGetOrCreateBucket,
 } from './get-or-create-bucket';
 export {getOverallProgressFromStorage} from './get-overall-progress-from-storage';
+export {getRemotionVersionFromIndexHtml} from './get-remotion-version-from-index-html';
 export {inputPropsKey, resolvedPropsKey} from './input-props-keys';
 export {inspectErrors} from './inspect-error';
 export {makeBucketName} from './make-bucket-name';


### PR DESCRIPTION
## Summary
- Add `compatibleOnly` option to `getSites()` API and `--compatible-only` flag to `npx remotion lambda sites ls` CLI command, matching the existing pattern from `getFunctions()`
- Each site now includes a `version` field extracted from the bundle's `index.html` (`window.remotion_version`), displayed in the `sites ls` table output
- Add `getRemotionVersionFromIndexHtml()` utility in `@remotion/serverless-client` for parsing the Remotion version from bundled HTML

Closes #6786

## Test plan
- [x] Updated existing `get-sites.test.ts` to verify `version` field is returned
- [x] Added new test case: "Should filter sites by compatibleOnly"
- [x] Updated `deploy-site.test.ts` expectations for new mock file count
- [x] Added assertion in `bundle-studio.test.ts` that bundled `index.html` contains correct Remotion version
- [x] All 11 site-related integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)