### PR TITLE
Fix deprecated link in getAudioDurationInSeconds docs

### DIFF
--- a/packages/docs/docs/get-audio-duration-in-seconds.mdx
+++ b/packages/docs/docs/get-audio-duration-in-seconds.mdx
@@ -6,7 +6,7 @@ crumb: '@remotion/media-utils'
 ---
 
 :::warning Deprecated
-This function has been deprecated. Use [`parseMedia()`](/docs/media-parser/parse-media) instead, which is faster and supports more formats.
+This function has been deprecated. Use [`getMediaMetadata()`](/docs/mediabunny/metadata) instead, which is faster and supports more formats.
 :::
 
 _Part of the `@remotion/media-utils` package of helper functions._


### PR DESCRIPTION
## Summary
- Update deprecation notice in `getAudioDurationInSeconds` docs to point to `getMediaMetadata()` instead of `parseMedia()`

## Test plan
- [ ] Verify the link `/docs/mediabunny/metadata` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)