### PR TITLE
test: add regression test for premountFor cascading in nested Sequences

### DIFF
--- a/packages/transitions/src/test/with-premounting.test.tsx
+++ b/packages/transitions/src/test/with-premounting.test.tsx
@@ -143,3 +143,34 @@ test('should correctly render against report #6027', () => {
 	const outerHTML = renderForFrame(138, <BugReport6027 />);
 	expect(outerHTML).toContain('<div>0</div>');
 });
+
+// Regression test for https://github.com/remotion-dev/remotion/issues/6727
+// premountFor should not cascade from parent to child Sequences
+const BugReport6727: React.FC = () => {
+	return (
+		<Sequence from={15} premountFor={15}>
+			{Array.from({length: 10}, (_, i) => (
+				<Sequence key={i} from={i * 3} durationInFrames={3} premountFor={15}>
+					<div data-child-id={i} />
+				</Sequence>
+			))}
+		</Sequence>
+	);
+};
+
+test('Should not cascade premountFor in nested Sequences - issue #6727', () => {
+	// Parent starts at abs frame 15 with premountFor=15 (premounts from frame 0).
+	// Each child has premountFor=15, so child i premounts when the absolute frame
+	// is in [abs_start - 15, abs_start - 1] = [i*3, 15 + i*3 - 1].
+	//
+	// At frame 0: only child 0 (abs start=15, window [0,14]) should be premounted.
+	// Before the fix, 6 children were premounted due to cascading.
+	const frame0HTML = renderForFrame(0, <BugReport6727 />);
+	const premountedAt0 = (frame0HTML.match(/data-child-id/g) ?? []).length;
+	expect(premountedAt0).toBe(1);
+
+	// At frame 3: children 0 (window [0,14]) and 1 (window [3,17]) should be premounted.
+	const frame3HTML = renderForFrame(3, <BugReport6727 />);
+	const premountedAt3 = (frame3HTML.match(/data-child-id/g) ?? []).length;
+	expect(premountedAt3).toBe(2);
+});


### PR DESCRIPTION
## Summary

Adds a regression test for the `premountFor` cascading bug reported in #6727.

The actual fix was already applied in commit `7644abe` ("fix premounting being cascading"), which corrected `PremountedPostmountedSequenceRefForwardingFunction` in `packages/core/src/Sequence.tsx`. However, no test was added to prevent future regressions.

## Root Cause (from commit 7644abe)

In `PremountedPostmountedSequenceRefForwardingFunction`, the frame used to decide whether premounting should be active was not accounting for the parent's `premountFramesRemaining`. As a result, when a parent `<Sequence premountFor={15}>` was active, its children saw an artificially shifted (frozen) frame from `useCurrentFrame()`, making them think they were within their own premount window when they were not.

The fix adjusts the frame check: `frame = useCurrentFrame() - parentPremountContext.premountFramesRemaining`, so each child sequence evaluates its premount window against the actual (un-shifted) timeline position.

## Changes

- `packages/transitions/src/test/with-premounting.test.tsx`: Added `BugReport6727` component and test that reproduces the exact scenario from the issue (parent `from={15} premountFor={15}` with 10 children `from={i*3} durationInFrames={3} premountFor={15}`). Verifies only 1 child premounts at frame 0 (not 6), and only 2 children premount at frame 3.

## Testing

The test directly replicates the scenario from issue #6727:
- At frame 0: only child 0 (absolute start=15, premount window [0,14]) should be premounted — **not 6** as was the case before the fix.
- At frame 3: children 0 and 1 (windows [0,14] and [3,17]) should be premounted.

Fixes #6727
