### PR TITLE
feat: indicate development vs production render in client-side render modal

### DIFF
--- a/packages/studio/src/components/RenderModal/WebRenderModal.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModal.tsx
@@ -1,5 +1,6 @@
 import type {LogLevel} from '@remotion/renderer';
 import {getDefaultOutLocation} from '@remotion/studio-shared';
+import {WARNING_COLOR} from '../../helpers/colors';
 import type {
 	RenderStillOnWebImageFormat,
 	WebRendererAudioCodec,
@@ -161,6 +162,53 @@ const validateOutnameForStill = ({
 	} catch (err) {
 		return {valid: false, error: err as Error};
 	}
+};
+
+const isLocalhostRender = (): boolean => {
+	if (typeof window === 'undefined') {
+		return false;
+	}
+
+	return (
+		window.location.hostname === 'localhost' ||
+		window.location.hostname === '127.0.0.1'
+	);
+};
+
+const devBadgeStyle: React.CSSProperties = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	fontSize: 12,
+	fontFamily: 'sans-serif',
+	padding: '2px 8px',
+	borderRadius: 4,
+	backgroundColor: 'rgba(46, 204, 113, 0.15)',
+	color: '#2ecc71',
+	fontWeight: 'bold',
+	flexShrink: 0,
+};
+
+const prodBadgeStyle: React.CSSProperties = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	fontSize: 12,
+	fontFamily: 'sans-serif',
+	padding: '2px 8px',
+	borderRadius: 4,
+	backgroundColor: 'rgba(241, 196, 15, 0.15)',
+	color: WARNING_COLOR,
+	fontWeight: 'bold',
+	flexShrink: 0,
+};
+
+const RenderEnvironmentBadge: React.FC = () => {
+	if (isLocalhostRender()) {
+		return <div style={devBadgeStyle}>Development render · Not charged</div>;
+	}
+
+	return (
+		<div style={prodBadgeStyle}>Production render · Usage will be billed</div>
+	);
 };
 
 // TODO: Switch to server-side rendering
@@ -629,6 +677,8 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 			</div>
 			<div style={containerStyle}>
 				<WebRendererExperimentalBadge />
+				<div style={flexer} />
+				<RenderEnvironmentBadge />
 			</div>
 			<div style={horizontalLayout}>
 				<div style={leftSidebar}>


### PR DESCRIPTION
## Summary

Adds a visual indicator in the client-side render modal (`WebRenderModal`) to show whether the current render is a **development render** (localhost, not charged) or a **production render** (deployed host, billed).

## Changes

- Added `isLocalhostRender()` helper that checks `window.location.hostname` for `localhost` / `127.0.0.1`
- Added `RenderEnvironmentBadge` component displayed in the modal header bar alongside the existing experimental warning badge
- On **localhost**: shows a green badge `Development render · Not charged`
- On **production hosts**: shows an orange/yellow badge `Production render · Usage will be billed`
- Styles match the existing Studio design system (dark background, same font-family/size pattern as `WebRendererExperimentalBadge`)

## Before / After

**Before:** The modal had no indication of whether the render would be charged.

**After:** A colored badge appears in the info bar below the render controls:
- 🟢 `Development render · Not charged` (localhost)
- 🟡 `Production render · Usage will be billed` (deployed)

Fixes #6169