### PR TITLE
feat: warn on unknown CLI flags, migrate remaining flags to AnyRemotionOption

### DIFF
--- a/packages/cli/src/initialize-cli.ts
+++ b/packages/cli/src/initialize-cli.ts
@@ -4,7 +4,7 @@ import {BrowserSafeApis} from '@remotion/renderer/client';
 import {loadConfig} from './get-config-file-name';
 import {makeHyperlink} from './hyperlinks/make-link';
 import {Log} from './log';
-import {parseCommandLine} from './parse-command-line';
+import {parseCommandLine, warnAboutUnknownFlags} from './parse-command-line';
 import {parsedCli} from './parsed-cli';
 
 export const initializeCli = async (
@@ -16,6 +16,7 @@ export const initializeCli = async (
 	const logLevel = BrowserSafeApis.options.logLevelOption.getValue({
 		commandLine: parsedCli,
 	}).value;
+	warnAboutUnknownFlags(logLevel);
 	// Only now Log.verbose is available
 	Log.verbose(
 		{indent: false, logLevel},

--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -1,17 +1,53 @@
+import type {LogLevel} from '@remotion/renderer';
+import {BrowserSafeApis} from '@remotion/renderer/client';
 import {Config} from './config';
+import {Log} from './log';
 import {parsedCli} from './parsed-cli';
 
+/**
+ * Returns the set of all known CLI flag names, derived from the AnyRemotionOption
+ * registry plus a small set of aliases that minimist expands for us.
+ */
+const getKnownCliFlags = (): Set<string> => {
+	const flags = new Set<string>(
+		Object.values(BrowserSafeApis.options).map(
+			(opt) => (opt as {cliFlag: string}).cliFlag,
+		),
+	);
+
+	// `-q` is a single-letter alias for `--quiet` recognised by minimist.
+	// It is not its own AnyRemotionOption entry, so we add it explicitly.
+	flags.add('q');
+
+	return flags;
+};
+
+export const warnAboutUnknownFlags = (logLevel: LogLevel) => {
+	const knownFlags = getKnownCliFlags();
+
+	const unknownFlags = Object.keys(parsedCli)
+		// `_` holds positional arguments, not flags
+		.filter((key) => key !== '_')
+		.filter((key) => !knownFlags.has(key));
+
+	for (const flag of unknownFlags) {
+		Log.warn(
+			{indent: false, logLevel},
+			`Warning: Unknown CLI flag "--${flag}" was passed and will be ignored. Check for typos.`,
+		);
+	}
+};
+
 export const parseCommandLine = () => {
-	if (parsedCli.png) {
+	if (parsedCli[BrowserSafeApis.options.pngOption.cliFlag]) {
 		throw new Error(
 			'The --png flag has been removed. Use --sequence --image-format=png from now on.',
 		);
 	}
 
-	if (
-		parsedCli['license-key'] &&
-		parsedCli['license-key'].startsWith('rm_pub_')
-	) {
-		Config.setPublicLicenseKey(parsedCli['license-key']);
+	const licenseKey =
+		parsedCli[BrowserSafeApis.options.licenseKeyOption.cliFlag];
+	if (licenseKey && licenseKey.startsWith('rm_pub_')) {
+		Config.setPublicLicenseKey(licenseKey);
 	}
 };

--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -76,6 +76,14 @@ const {
 	propsOption,
 	configOption,
 	browserOption,
+	outputOption,
+	quietOption,
+	helpOption,
+	forceOption,
+	browserArgsOption,
+	pngOption,
+	qualityOption,
+	licenseKeyOption,
 } = BrowserSafeApis.options;
 
 export type CommandLineOptions = {
@@ -125,19 +133,19 @@ export type CommandLineOptions = {
 	[audioCodecOption.cliFlag]: AudioCodec;
 	[publicPathOption.cliFlag]: string;
 	[crfOption.cliFlag]: TypeOfOption<typeof crfOption>;
-	output: string | undefined;
+	[outputOption.cliFlag]: TypeOfOption<typeof outputOption>;
 	[overwriteOption.cliFlag]: TypeOfOption<typeof overwriteOption>;
-	png: boolean;
+	[pngOption.cliFlag]: TypeOfOption<typeof pngOption>;
 	[propsOption.cliFlag]: TypeOfOption<typeof propsOption>;
-	quality: number;
+	[qualityOption.cliFlag]: TypeOfOption<typeof qualityOption>;
 	[jpegQualityOption.cliFlag]: TypeOfOption<typeof jpegQualityOption>;
 	[framesOption.cliFlag]: string | number;
 	[scaleOption.cliFlag]: TypeOfOption<typeof scaleOption>;
 	[imageSequenceOption.cliFlag]: TypeOfOption<typeof imageSequenceOption>;
-	quiet: boolean;
+	[quietOption.cliFlag]: TypeOfOption<typeof quietOption>;
 	q: boolean;
 	[logLevelOption.cliFlag]: TypeOfOption<typeof logLevelOption>;
-	help: boolean;
+	[helpOption.cliFlag]: TypeOfOption<typeof helpOption>;
 	[portOption.cliFlag]: TypeOfOption<typeof portOption>;
 	[stillFrameOption.cliFlag]: TypeOfOption<typeof stillFrameOption>;
 	[headlessOption.cliFlag]: TypeOfOption<typeof headlessOption>;
@@ -165,7 +173,7 @@ export type CommandLineOptions = {
 	[webpackPollOption.cliFlag]: TypeOfOption<typeof webpackPollOption>;
 	[noOpenOption.cliFlag]: TypeOfOption<typeof noOpenOption>;
 	[browserOption.cliFlag]: TypeOfOption<typeof browserOption>;
-	['browser-args']: string;
+	[browserArgsOption.cliFlag]: TypeOfOption<typeof browserArgsOption>;
 	[userAgentOption.cliFlag]: TypeOfOption<typeof userAgentOption>;
 	[outDirOption.cliFlag]: TypeOfOption<typeof outDirOption>;
 	[audioLatencyHintOption.cliFlag]: AudioContextLatencyCategory;
@@ -179,7 +187,7 @@ export type CommandLineOptions = {
 	[imageSequencePatternOption.cliFlag]: TypeOfOption<
 		typeof imageSequencePatternOption
 	>;
-	'license-key': string;
+	[licenseKeyOption.cliFlag]: TypeOfOption<typeof licenseKeyOption>;
 	[publicLicenseKeyOption.cliFlag]: string;
 	[forceNewStudioOption.cliFlag]: TypeOfOption<typeof forceNewStudioOption>;
 };
@@ -187,9 +195,11 @@ export type CommandLineOptions = {
 export const BooleanFlags = [
 	overwriteOption.cliFlag,
 	imageSequenceOption.cliFlag,
-	'help',
-	'quiet',
+	helpOption.cliFlag,
+	quietOption.cliFlag,
 	'q',
+	forceOption.cliFlag,
+	pngOption.cliFlag,
 	mutedOption.cliFlag,
 	enforceAudioOption.cliFlag,
 	disableWebSecurityOption.cliFlag,

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -157,7 +157,7 @@ export const studioCommand = async (
 
 	const result = await StudioServerInternals.startStudio({
 		previewEntry: require.resolve('@remotion/studio/previewEntry'),
-		browserArgs: parsedCli['browser-args'],
+		browserArgs: parsedCli['browser-args'] ?? '',
 		browserFlag: browserOption.getValue({commandLine: parsedCli}).value ?? '',
 		logLevel,
 		shouldOpenBrowser: !noOpenOption.getValue({commandLine: parsedCli}).value,

--- a/packages/renderer/src/options/browser-args.tsx
+++ b/packages/renderer/src/options/browser-args.tsx
@@ -1,0 +1,36 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'browser-args' as const;
+
+export const browserArgsOption = {
+	name: 'Browser arguments',
+	cliFlag,
+	description: () => (
+		<>
+			A JSON array of additional Chromium CLI flags to pass when launching the
+			browser. Example: <code>--browser-args=&quot;[&quot;--disable-gpu&quot;]&quot;</code>
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/cli/render#--browser-args',
+	type: null as string | null,
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {
+				source: 'cli',
+				value: commandLine[cliFlag] as string,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: null,
+		};
+	},
+	setConfig: () => {
+		throw new Error(
+			'Cannot set browser args via config file. Use chromiumOptions.args instead.',
+		);
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<string | null>;

--- a/packages/renderer/src/options/force.tsx
+++ b/packages/renderer/src/options/force.tsx
@@ -1,0 +1,33 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'force' as const;
+
+export const forceOption = {
+	name: 'Force',
+	cliFlag,
+	description: () => (
+		<>
+			Force the render to proceed even if there are warnings.
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/cli',
+	type: false as boolean,
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {
+				source: 'cli',
+				value: commandLine[cliFlag] as boolean,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: false,
+		};
+	},
+	setConfig: () => {
+		throw new Error('Cannot set force flag via config file');
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<boolean>;

--- a/packages/renderer/src/options/help.tsx
+++ b/packages/renderer/src/options/help.tsx
@@ -1,0 +1,33 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'help' as const;
+
+export const helpOption = {
+	name: 'Help',
+	cliFlag,
+	description: () => (
+		<>
+			Prints the list of available CLI commands and options.
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/cli',
+	type: false as boolean,
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {
+				source: 'cli',
+				value: commandLine[cliFlag] as boolean,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: false,
+		};
+	},
+	setConfig: () => {
+		throw new Error('Cannot set help flag via config file');
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<boolean>;

--- a/packages/renderer/src/options/index.tsx
+++ b/packages/renderer/src/options/index.tsx
@@ -30,8 +30,11 @@ import {experimentalClientSideRenderingOption} from './experimental-client-side-
 import {experimentalVisualModeOption} from './experimental-visual-mode';
 import {folderExpiryOption} from './folder-expiry';
 import {forSeamlessAacConcatenationOption} from './for-seamless-aac-concatenation';
+import {browserArgsOption} from './browser-args';
+import {forceOption} from './force';
 import {forceNewStudioOption} from './force-new-studio';
 import {framesOption} from './frames';
+import {helpOption} from './help';
 import {glOption} from './gl';
 import {hardwareAccelerationOption} from './hardware-acceleration';
 import {headlessOption} from './headless';
@@ -55,6 +58,7 @@ import {offthreadVideoThreadsOption} from './offthreadvideo-threads';
 import {onBrowserDownloadOption} from './on-browser-download';
 import type {AnyRemotionOption} from './option';
 import {outDirOption} from './out-dir';
+import {outputOption} from './output';
 import {overrideDurationOption} from './override-duration';
 import {overrideFpsOption} from './override-fps';
 import {overrideHeightOption} from './override-height';
@@ -62,10 +66,13 @@ import {overrideWidthOption} from './override-width';
 import {overwriteOption} from './overwrite';
 import {packageManagerOption} from './package-manager';
 import {pixelFormatOption} from './pixel-format';
+import {pngOption} from './png';
 import {portOption} from './port';
 import {preferLosslessAudioOption} from './prefer-lossless';
 import {propsOption} from './props';
 import {proResProfileOption} from './prores-profile';
+import {qualityOption} from './quality';
+import {quietOption} from './quiet';
 import {publicDirOption} from './public-dir';
 import {publicLicenseKeyOption} from './public-license-key';
 import {publicPathOption} from './public-path';
@@ -177,7 +184,15 @@ export const allOptions = {
 	propsOption,
 	configOption,
 	browserOption,
+	outputOption,
+	quietOption,
+	helpOption,
+	forceOption,
+	browserArgsOption,
+	pngOption,
+	qualityOption,
 };
+
 
 export type AvailableOptions = keyof typeof allOptions;
 export type TypeOfOption<Type> =

--- a/packages/renderer/src/options/output.tsx
+++ b/packages/renderer/src/options/output.tsx
@@ -1,0 +1,34 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'output' as const;
+
+export const outputOption = {
+	name: 'Output location',
+	cliFlag,
+	description: () => (
+		<>
+			Where to save the output to. Can be a file path or a directory. If not
+			specified, the output will be saved to the default location.
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/cli/render#--output',
+	type: undefined as string | undefined,
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {
+				source: 'cli',
+				value: commandLine[cliFlag] as string,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: undefined,
+		};
+	},
+	setConfig: () => {
+		throw new Error('Cannot set output via config file. Use setOutputLocation()');
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<string | undefined>;

--- a/packages/renderer/src/options/png.tsx
+++ b/packages/renderer/src/options/png.tsx
@@ -1,0 +1,36 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'png' as const;
+
+export const pngOption = {
+	name: 'PNG (deprecated)',
+	cliFlag,
+	description: () => (
+		<>
+			<strong>Deprecated.</strong> Use <code>--sequence --image-format=png</code>{' '}
+			instead.
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/cli/render',
+	type: false as boolean,
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {
+				source: 'cli',
+				value: commandLine[cliFlag] as boolean,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: false,
+		};
+	},
+	setConfig: () => {
+		throw new Error(
+			'The --png flag has been removed. Use --sequence --image-format=png from now on.',
+		);
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<boolean>;

--- a/packages/renderer/src/options/quality.tsx
+++ b/packages/renderer/src/options/quality.tsx
@@ -1,0 +1,35 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'quality' as const;
+
+export const qualityOption = {
+	name: 'Quality (deprecated)',
+	cliFlag,
+	description: () => (
+		<>
+			<strong>Deprecated alias.</strong> Use <code>--jpeg-quality</code> instead.
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/cli/render',
+	type: 0 as number,
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {
+				source: 'cli',
+				value: commandLine[cliFlag] as number,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: 0,
+		};
+	},
+	setConfig: () => {
+		throw new Error(
+			'The --quality flag is deprecated. Use --jpeg-quality or Config.setJpegQuality() instead.',
+		);
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<number>;

--- a/packages/renderer/src/options/quiet.tsx
+++ b/packages/renderer/src/options/quiet.tsx
@@ -1,0 +1,34 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'quiet' as const;
+
+export const quietOption = {
+	name: 'Quiet mode',
+	cliFlag,
+	description: () => (
+		<>
+			If set, Remotion will only print errors to the console. Also available as{' '}
+			<code>-q</code>.
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/cli',
+	type: false as boolean,
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {
+				source: 'cli',
+				value: commandLine[cliFlag] as boolean,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: false,
+		};
+	},
+	setConfig: () => {
+		throw new Error('Cannot set quiet mode via config file');
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<boolean>;


### PR DESCRIPTION
## Summary

Completes the migration of remaining CLI flags to the `AnyRemotionOption` system and adds unknown-flag detection as requested in #6605.

## Flags Migrated

The following flags were not yet in the `AnyRemotionOption` system and have been added by creating dedicated option files in `packages/renderer/src/options/`:

- `--output` → `outputOption` (new `output.tsx`)
- `--quiet` → `quietOption` (new `quiet.tsx`)
- `--help` → `helpOption` (new `help.tsx`)
- `--force` → `forceOption` (new `force.tsx`)
- `--browser-args` → `browserArgsOption` (new `browser-args.tsx`)
- `--png` (deprecated, throws error) → `pngOption` (new `png.tsx`)
- `--quality` (deprecated alias) → `qualityOption` (new `quality.tsx`)

The following flags were **already migrated** in earlier work and are not changed:
- `--frames` (`framesOption`)
- `--timeout` (`delayRenderTimeoutInMillisecondsOption`)
- `--concurrencies` (`benchmarkConcurrenciesOption`)
- `--license-key` (`licenseKeyOption`)
- `--image-format` (`stillImageFormatOption` / `videoImageFormatOption`)

## Unknown Flag Detection

`warnAboutUnknownFlags()` is called in `initializeCli()` after the log level is determined. It:

1. Collects all known `cliFlag` values from `BrowserSafeApis.options` (the `allOptions` registry)
2. Adds `"q"` explicitly as the short-form alias for `--quiet` (minimist expands `-q` to a separate `q` key)
3. Compares every key in `parsedCli` (excluding `_` for positional args) against the known set
4. Emits a `Log.warn` for any unrecognised flag, helping users catch typos early

## Type System Updates

`CommandLineOptions` in `parsed-cli.ts` now uses `[option.cliFlag]` computed property syntax for the newly migrated flags, replacing hardcoded string keys. `BooleanFlags` likewise uses `option.cliFlag` references for `help`, `quiet`, `force`, and `png`.

Fixes #6605