### PR TITLE
Recorder: Stop recording when tab sharing ends

### DIFF
--- a/packages/template-recorder/src/RecordButton.tsx
+++ b/packages/template-recorder/src/RecordButton.tsx
@@ -128,10 +128,34 @@ export const RecordButton: React.FC<{
   }, [recordingStatus, setRecordingStatus]);
 
   useEffect(() => {
+    if (recordingStatus.type !== "recording") {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    for (const rec of recordingStatus.ongoing.recorders) {
+      for (const track of rec.recorder.stream.getTracks()) {
+        track.addEventListener(
+          "ended",
+          () => {
+            onStop();
+          },
+          { once: true, signal: controller.signal },
+        );
+      }
+    }
+
+    return () => {
+      controller.abort();
+    };
+  }, [recordingStatus, onStop]);
+
+  useEffect(() => {
     return () => {
       if (recordingStatus.type === "recording") {
         recordingStatus.ongoing.recorders.forEach((r) => {
-          r.recorder.stop();
+          r.stopAndWaitUntilDone();
         });
       }
     };

--- a/packages/template-recorder/src/helpers/start-media-recorder.ts
+++ b/packages/template-recorder/src/helpers/start-media-recorder.ts
@@ -67,13 +67,19 @@ export const startMediaRecorder = async ({
     },
   );
 
-  const stopAndWaitUntilDone = () => {
+  let stoppedPromise: Promise<FinishedRecording> | null = null;
+
+  const stopRecorder = (): Promise<FinishedRecording> => {
+    if (stoppedPromise) {
+      return stoppedPromise;
+    }
+
     periodicSaveController.abort();
     const { resolve, reject, promise } =
       Promise.withResolvers<FinishedRecording>();
+    stoppedPromise = promise;
     const controller = new AbortController();
 
-    recorder.stop();
     recorder.addEventListener(
       "error",
       (event) => {
@@ -112,13 +118,27 @@ export const startMediaRecorder = async ({
       },
     );
 
+    recorder.stop();
+
     promise.finally(() => controller.abort());
 
     return promise;
   };
 
+  // Stop the recorder immediately when any track ends to prevent
+  // corrupt timestamps in the output file
+  for (const track of source.stream.getTracks()) {
+    track.addEventListener(
+      "ended",
+      () => {
+        stopRecorder();
+      },
+      { once: true },
+    );
+  }
+
   // Trigger a save every 10 seconds
   recorder.start(10_000);
 
-  return { recorder, stopAndWaitUntilDone, mimeType };
+  return { recorder, stopAndWaitUntilDone: stopRecorder, mimeType };
 };


### PR DESCRIPTION
## Summary
- Fixes #6844: If "Stop Sharing Tab" is clicked in Chrome during a recording, the recording now automatically stops
- The `MediaRecorder` is stopped **immediately** in the track `ended` event handler (inside `startMediaRecorder`) to prevent corrupt timestamps in the output file
- `stopAndWaitUntilDone` is now idempotent — multiple calls return the same promise, so the React state transition in `RecordButton` works cleanly even though the recorder is already stopped

## Test plan
- [ ] Start a recording that includes a shared tab (with audio)
- [ ] Click "Stop Sharing Tab" on the shared tab in Chrome
- [ ] Verify the recording stops automatically and produces a valid video
- [ ] Verify normal stop-recording flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)