### PR TITLE
`docs`: Add /templates link to Resources menu and footer

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -78,6 +78,7 @@ const config: Config = {
 						{to: 'https://remotion.dev/convert', label: 'Convert a video'},
 						{to: 'https://remotion.dev/timing-editor', label: 'Timing Editor'},
 						{to: '/docs/support', label: 'Support'},
+						{to: '/templates', label: 'Templates'},
 					],
 				},
 				{
@@ -124,6 +125,10 @@ const config: Config = {
 						{
 							label: 'Getting started',
 							to: '/docs/',
+						},
+						{
+							label: 'Templates',
+							to: '/templates',
 						},
 						{
 							label: 'API Reference',


### PR DESCRIPTION
## Summary
- Added `/templates` link to the Resources dropdown menu in the navbar
- Added `/templates` link to the "Remotion" (Getting Started) section in the footer

## Test plan
- [ ] Verify `/templates` appears in the Resources dropdown nav menu
- [ ] Verify `/templates` appears in the footer under the Remotion column

🤖 Generated with [Claude Code](https://claude.com/claude-code)