### PR TITLE
`@remotion/studio-server`: Fix AppleScript tab focus not triggering for studio

### DIFF
--- a/packages/studio-server/src/better-opn/index.ts
+++ b/packages/studio-server/src/better-opn/index.ts
@@ -33,9 +33,7 @@ const startBrowserProcess = async ({
 	const shouldTryOpenChromiumWithAppleScript =
 		process.platform === 'darwin' &&
 		!tryNewInstance &&
-		(typeof browser !== 'string' ||
-			browser === 'google chrome' ||
-			browser === 'chrome');
+		(!browser || browser === 'google chrome' || browser === 'chrome');
 
 	if (shouldTryOpenChromiumWithAppleScript) {
 		let appleScriptDenied = false;
@@ -86,11 +84,7 @@ const startBrowserProcess = async ({
   
   on run argv
     set theURL to "${encodeURI(url)}"
-    set matchURL to "${
-			process.env.OPEN_MATCH_HOST_ONLY === 'true'
-				? encodeURI(normalizeURLToMatch(url))
-				: encodeURI(url)
-		}"
+    set matchURL to "${encodeURI(normalizeURLToMatch(url))}"
     
     using terms from application "Google Chrome"
       tell application theProgram


### PR DESCRIPTION
## Summary
- `browserFlag` defaults to `''` which caused the AppleScript tab-reuse guard (`typeof browser !== 'string'`) to always be false — AppleScript was never attempted. Fixed by using `!browser` instead.
- `matchURL` used the full URL including path, so an existing tab on `/my-comp` wouldn't match when opening `/`. Now always matches by origin, since the AppleScript uses `contains`.

## Test plan
- [ ] Run `npx remotion studio` with Chrome open — should focus existing tab instead of opening new one
- [ ] Verify it works when tab is on a different composition path (e.g. `/dynamic-length`)
- [ ] Verify new tab is created when no matching tab exists


🤖 Generated with [Claude Code](https://claude.com/claude-code)