### PR TITLE
`@remotion/media`: Handle audio scheduling past trim end gracefully

### DIFF
--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -660,7 +660,7 @@ export class MediaPlayer {
 		const timeInSeconds = globalTime - this.sequenceOffset;
 		const localTime = this.getTrimmedTime(timeInSeconds);
 		if (localTime === null) {
-			throw new Error('hmm, should not render!');
+			return {type: 'not-started'};
 		}
 
 		const targetTime =


### PR DESCRIPTION
## Summary
- When `getTrimmedTime()` returns `null` (current time is past the trimmed media duration), `scheduleAudioNode` was throwing `"hmm, should not render!"` instead of handling the edge case gracefully
- Now returns `{type: 'not-started'}` which is the standard way to indicate an audio node wasn't scheduled

Closes #6872

## Test plan
- [ ] Play a trimmed audio/video and verify no error is thrown during concurrent rendering
- [ ] Verify audio still plays correctly within the trimmed range

🤖 Generated with [Claude Code](https://claude.com/claude-code)