### PR TITLE
`@remotion/studio`: Account for expanded tracks in timeline height calculation

### DIFF
--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -1,12 +1,15 @@
 import React, {useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {calculateTimeline} from '../../helpers/calculate-timeline';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {BACKGROUND} from '../../helpers/colors';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
 import {
+	getExpandedTrackHeight,
 	getTimelineLayerHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
 } from '../../helpers/timeline-layout';
+import {ExpandedTracksContext} from '../ExpandedTracksProvider';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {SplitterContainer} from '../Splitter/SplitterContainer';
 import {SplitterElement} from '../Splitter/SplitterElement';
@@ -44,6 +47,11 @@ const noop = () => undefined;
 
 const TimelineInner: React.FC = () => {
 	const {sequences} = useContext(Internals.SequenceManager);
+	const {expandedTracks} = useContext(ExpandedTracksContext);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const visualModeEnabled =
+		Boolean(process.env.EXPERIMENTAL_VISUAL_MODE_ENABLED) &&
+		previewServerState.type === 'connected';
 	const videoConfig = Internals.useUnsafeVideoConfig();
 
 	const timeline = useMemo((): TrackWithHash[] => {
@@ -76,12 +84,18 @@ const TimelineInner: React.FC = () => {
 		return {
 			height:
 				shown.reduce((acc, track) => {
+					const isExpanded =
+						visualModeEnabled && (expandedTracks[track.sequence.id] ?? false);
 					return (
 						acc +
 						getTimelineLayerHeight(
 							track.sequence.type === 'video' ? 'video' : 'other',
 						) +
-						Number(TIMELINE_ITEM_BORDER_BOTTOM)
+						Number(TIMELINE_ITEM_BORDER_BOTTOM) +
+						(isExpanded
+							? getExpandedTrackHeight(track.sequence.controls) +
+								TIMELINE_ITEM_BORDER_BOTTOM
+							: 0)
 					);
 				}, 0) +
 				TIMELINE_ITEM_BORDER_BOTTOM +
@@ -92,7 +106,7 @@ const TimelineInner: React.FC = () => {
 			minHeight: '100%',
 			overflowX: 'hidden',
 		};
-	}, [hasBeenCut, shown]);
+	}, [hasBeenCut, shown, expandedTracks, visualModeEnabled]);
 
 	return (
 		<div


### PR DESCRIPTION
## Summary
- The timeline container height calculation did not account for expanded timeline tracks, causing the container to be too short when tracks are expanded in visual mode.
- Added `expandedTracks` and `visualModeEnabled` to the height computation so each expanded track contributes its expanded height (via `getExpandedTrackHeight`) to the total.

## Test plan
- [ ] Open the studio with `EXPERIMENTAL_VISUAL_MODE_ENABLED` set
- [ ] Expand a timeline track with controls and verify the timeline container height adjusts correctly
- [ ] Verify scrolling works properly with multiple expanded tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)