### PR TITLE
`@remotion/transitions`: Forward stack traces for TransitionSeries.Overlay

### DIFF
--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -209,6 +209,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					halfDuration,
 					children: overlayProps.children,
 					index: i,
+					stack: overlayProps.stack,
 				} as unknown as React.ReactNode);
 
 				return null;
@@ -508,6 +509,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 				durationInFrames: number;
 				children: React.ReactNode;
 				index: number;
+				stack: string | undefined;
 			};
 
 			return (
@@ -517,6 +519,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					durationInFrames={info.durationInFrames}
 					name="<TS.Overlay>"
 					layout="absolute-fill"
+					{...(info.stack ? {stack: info.stack} : {})}
 				>
 					{info.children}
 				</Sequence>

--- a/packages/transitions/src/types.ts
+++ b/packages/transitions/src/types.ts
@@ -39,4 +39,8 @@ export type TransitionSeriesOverlayProps = {
 	readonly durationInFrames: number;
 	readonly offset?: number;
 	readonly children: React.ReactNode;
+	/**
+	 * @deprecated For internal use only
+	 */
+	readonly stack?: string;
 };


### PR DESCRIPTION
## Summary
- Add `stack` prop to `TransitionSeriesOverlayProps` so the sequence stack trace proxy can inject it
- Forward the `stack` prop through the overlay render path to the `<Sequence>` component
- Fixes stack traces not appearing for `<TransitionSeries.Overlay>` in the Studio timeline

## Test plan
- [ ] Verify that `<TransitionSeries.Overlay>` now shows stack traces in the Studio timeline
- [ ] Verify that `<TransitionSeries.Sequence>` stack traces still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)