### PR TITLE
`@remotion/skills`: Remove .mp4 from defaultOutName example

### DIFF
--- a/packages/skills/skills/remotion/rules/calculate-metadata.md
+++ b/packages/skills/skills/remotion/rules/calculate-metadata.md
@@ -93,7 +93,7 @@ const calculateMetadata: CalculateMetadataFunction<Props> = async ({
   props,
 }) => {
   return {
-    defaultOutName: `video-${props.id}.mp4`,
+    defaultOutName: `video-${props.id}`, // .mp4 is added automatically
   };
 };
 ```


### PR DESCRIPTION
## Summary
- Update `calculateMetadata` example to omit `.mp4` extension from `defaultOutName` since it is added automatically

## Test plan
- [ ] Verify docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)