### PR TITLE
`@remotion/bundler`: Handle webpack cache corruption on low-memory machines

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -320,6 +320,7 @@ export const internalBundle = async (
 			await runWebpack();
 		} catch (err) {
 			if (looksLikeCacheCorruption(err) && actualArgs.enableCaching !== false) {
+				// eslint-disable-next-line no-console
 				console.warn(
 					'Webpack cache appears to be corrupted. Clearing cache and retrying...',
 				);


### PR DESCRIPTION
## Summary
- Automatically detect and recover from webpack filesystem cache corruption during bundling
- When a cache corruption error is detected (e.g. `wasm-hash` TypeError), the cache is cleared and bundling is retried once
- Previously, users had to manually delete `node_modules/.cache/webpack` to recover

Closes #6865

## Test plan
- [ ] Verify normal bundling still works with caching enabled
- [ ] Verify normal bundling works with caching disabled (`enableCaching: false`)
- [ ] Verify that a corrupted cache file in `node_modules/.cache/webpack` triggers automatic recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)