### PR TITLE
`create-video`: Respect npm registry config for corporate proxy support

### DIFF
--- a/packages/create-video/src/latest-remotion-version.ts
+++ b/packages/create-video/src/latest-remotion-version.ts
@@ -1,9 +1,35 @@
-import http from 'https';
+import {execSync} from 'node:child_process';
+import http from 'node:http';
+import https from 'node:https';
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+
+const getRegistry = (): string => {
+	try {
+		const registry = execSync('npm config get registry', {
+			encoding: 'utf-8',
+			timeout: 10_000,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		}).trim();
+
+		if (registry && registry !== 'undefined') {
+			return registry.replace(/\/$/, '');
+		}
+	} catch {
+		// Fall through to default
+	}
+
+	return DEFAULT_REGISTRY;
+};
 
 const getPackageJsonForRemotion = (): Promise<string> => {
+	const registry = getRegistry();
+	const url = `${registry}/remotion`;
+	const client = url.startsWith('https') ? https : http;
+
 	return new Promise<string>((resolve, reject) => {
-		const req = http.get(
-			'https://registry.npmjs.org/remotion',
+		const req = client.get(
+			url,
 			{
 				headers: {
 					accept:
@@ -31,5 +57,15 @@ const getPackageJsonForRemotion = (): Promise<string> => {
 
 export const getLatestRemotionVersion = async () => {
 	const pkgJson = await getPackageJsonForRemotion();
-	return JSON.parse(pkgJson)['dist-tags'].latest;
+	try {
+		return JSON.parse(pkgJson)['dist-tags'].latest;
+	} catch {
+		const registry = getRegistry();
+		throw new Error(
+			`Failed to fetch the latest Remotion version from ${registry}. ` +
+				`The response was not valid JSON. ` +
+				`If you are behind a corporate proxy, make sure your npm registry is configured correctly ` +
+				`(npm config set registry <your-registry-url>).`,
+		);
+	}
 };


### PR DESCRIPTION
## Summary

- Read the user's configured npm registry via `npm config get registry` instead of hardcoding `registry.npmjs.org`
- Falls back to the default public registry if the config command fails
- Handles both `http` and `https` registry URLs
- Adds a clear error message when the registry returns non-JSON responses (e.g. corporate proxy HTML pages)

Closes #6888

## Test plan

- [ ] `npm config set registry https://registry.npmjs.org` → `npx create-video` works as before
- [ ] `npm config set registry http://localhost:4873` (Verdaccio) → uses the local registry
- [ ] With an unreachable registry → shows the new descriptive error message instead of `SyntaxError: Unexpected token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)