### PR TITLE
`create-video`: Strip control characters from directory name input

### DIFF
--- a/packages/create-video/src/resolve-project-root.ts
+++ b/packages/create-video/src/resolve-project-root.ts
@@ -56,9 +56,12 @@ export const resolveProjectRoot = async (options?: {
 	let projectName = '';
 	let directlyCreateInCurrentDir = false;
 
+	// eslint-disable-next-line no-control-regex
+	const stripControlChars = (s: string) => s.replace(/[\x00-\x1f\x7f]/g, '');
+
 	// If a directory argument was provided, use it directly
 	if (options?.directoryArgument) {
-		projectName = options.directoryArgument;
+		projectName = stripControlChars(options.directoryArgument).trim();
 	} else {
 		// Print selected template info before prompting for directory
 		if (options?.selectedTemplate && isFlagSelected) {
@@ -98,10 +101,7 @@ export const resolveProjectRoot = async (options?: {
 				});
 
 				if (typeof answer === 'string') {
-					// Strip control characters (U+0000–U+001F, U+007F) that terminal
-					// emulators may inject via readline shortcuts (e.g. Ctrl+U → U+0015)
-					// eslint-disable-next-line no-control-regex
-					projectName = answer.replace(/[\x00-\x1f\x7f]/g, '').trim();
+					projectName = stripControlChars(answer).trim();
 				}
 			}
 		} catch (error) {


### PR DESCRIPTION
## Summary

- Strip C0 control characters (U+0000–U+001F) and DEL (U+007F) from directory name input
- Fixes the issue where Ctrl+U in some terminal emulators injects U+0015 (NAK) into the input, causing the project to be created in a phantom directory like `^UDownloads/my-video`

Closes #6859

## Test plan

- [ ] Enter a directory name normally → works as before
- [ ] Paste a string containing control characters (e.g. `\x15Downloads/my-video`) → control chars are stripped, project created at `Downloads/my-video`

🤖 Generated with [Claude Code](https://claude.com/claude-code)