### PR TITLE
`@remotion/bundler`: Render `window.remotion_logLevel` in bundle mode

### DIFF
--- a/packages/bundler/src/index-html.ts
+++ b/packages/bundler/src/index-html.ts
@@ -70,7 +70,7 @@ export const indexHtml = ({
 	<body>
 		<script>window.remotion_numberOfAudioTags = ${numberOfAudioTags};</script>
 		<script>window.remotion_audioLatencyHint = "${audioLatencyHint}";</script>
-		${mode === 'dev' ? `<script>window.remotion_logLevel = "${logLevel}";</script>` : ''}
+		<script>window.remotion_logLevel = "${logLevel}";</script>
 		<script>window.remotion_staticBase = "${staticHash}";</script>
 		${
 			editorName


### PR DESCRIPTION
## Summary
- `window.remotion_logLevel` was only rendered in `dev` mode but not in `bundle` mode
- Removed the `mode === 'dev'` condition so the log level is always set in the HTML output

## Test plan
- [ ] Verify `window.remotion_logLevel` is present in the HTML when bundling

🤖 Generated with [Claude Code](https://claude.com/claude-code)