### PR TITLE
`@remotion/bundler`: Revert rendering `window.remotion_logLevel` in bundle mode, use fallback instead

### DIFF
--- a/packages/bundler/src/index-html.ts
+++ b/packages/bundler/src/index-html.ts
@@ -70,7 +70,7 @@ export const indexHtml = ({
 	<body>
 		<script>window.remotion_numberOfAudioTags = ${numberOfAudioTags};</script>
 		<script>window.remotion_audioLatencyHint = "${audioLatencyHint}";</script>
-		<script>window.remotion_logLevel = "${logLevel}";</script>
+		${mode === 'dev' ? `<script>window.remotion_logLevel = "${logLevel}";</script>` : ''}
 		<script>window.remotion_staticBase = "${staticHash}";</script>
 		${
 			editorName

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,7 +63,7 @@ declare global {
 		remotion_ignoreFastRefreshUpdate: number | null;
 		remotion_numberOfAudioTags: number;
 		remotion_audioLatencyHint: AudioContextLatencyCategory | undefined;
-		remotion_logLevel: LogLevel;
+		remotion_logLevel: LogLevel | undefined;
 		remotion_projectName: string;
 		remotion_cwd: string;
 		remotion_studioServerCommand: string;

--- a/packages/studio/src/Studio.tsx
+++ b/packages/studio/src/Studio.tsx
@@ -30,7 +30,7 @@ const StudioInner: React.FC<{
 				frameState={null}
 				audioEnabled={window.remotion_audioEnabled}
 				videoEnabled={window.remotion_videoEnabled}
-				logLevel={window.remotion_logLevel}
+				logLevel={window.remotion_logLevel ?? 'info'}
 				numberOfAudioTags={window.remotion_numberOfAudioTags}
 				audioLatencyHint={window.remotion_audioLatencyHint ?? 'interactive'}
 			>

--- a/packages/studio/src/renderEntry.tsx
+++ b/packages/studio/src/renderEntry.tsx
@@ -247,7 +247,7 @@ const renderContent = (Root: React.FC) => {
 					frameState={null}
 					audioEnabled={window.remotion_audioEnabled}
 					videoEnabled={window.remotion_videoEnabled}
-					logLevel={window.remotion_logLevel}
+					logLevel={window.remotion_logLevel ?? 'info'}
 					numberOfAudioTags={0}
 					audioLatencyHint={window.remotion_audioLatencyHint ?? 'interactive'}
 					visualModeEnabled={false}
@@ -275,7 +275,7 @@ const renderContent = (Root: React.FC) => {
 					frameState={null}
 					audioEnabled={window.remotion_audioEnabled}
 					videoEnabled={window.remotion_videoEnabled}
-					logLevel={window.remotion_logLevel}
+					logLevel={window.remotion_logLevel ?? 'info'}
 					numberOfAudioTags={0}
 					audioLatencyHint={window.remotion_audioLatencyHint ?? 'interactive'}
 					visualModeEnabled={false}
@@ -355,11 +355,11 @@ if (typeof window !== 'undefined') {
 		const canSerializeDefaultProps = getCanSerializeDefaultProps(compositions);
 		if (!canSerializeDefaultProps) {
 			Internals.Log.warn(
-				{logLevel: window.remotion_logLevel, tag: null},
+				{logLevel: window.remotion_logLevel ?? 'info', tag: null},
 				'defaultProps are too big to serialize - trying to find the problematic composition...',
 			);
 			Internals.Log.warn(
-				{logLevel: window.remotion_logLevel, tag: null},
+				{logLevel: window.remotion_logLevel ?? 'info', tag: null},
 				'Serialization:',
 				compositions,
 			);
@@ -372,7 +372,7 @@ if (typeof window !== 'undefined') {
 			}
 
 			Internals.Log.warn(
-				{logLevel: window.remotion_logLevel, tag: null},
+				{logLevel: window.remotion_logLevel ?? 'info', tag: null},
 				'Could not single out a problematic composition -  The composition list as a whole is too big to serialize.',
 			);
 


### PR DESCRIPTION
## Summary
- Reverts #6902 which rendered `window.remotion_logLevel` in bundle mode, causing it to override the value set by `setPropsAndEnv()` via `evaluateOnNewDocument`
- Instead, makes `window.remotion_logLevel` type `LogLevel | undefined` and adds `?? 'info'` fallback at every read site
- In dev mode, the inline script still sets it; in bundle mode, `setPropsAndEnv()` sets it before the page loads, and if neither sets it, it falls back to `'info'`

## Test plan
- [ ] Verify that log level passed to rendering functions is respected in bundle mode
- [ ] Verify that Studio still works correctly in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)