### PR TITLE
`@remotion/renderer`: Fix imprecise FPS when combining chunks

### DIFF
--- a/packages/renderer/src/mux-video-and-audio.ts
+++ b/packages/renderer/src/mux-video-and-audio.ts
@@ -47,6 +47,11 @@ export const muxVideoAndAudio = async ({
 		videoOutput ? 'copy' : null,
 		audioOutput ? '-c:a' : null,
 		audioOutput ? 'copy' : null,
+		// Set the exact output framerate to prevent drift when combining chunks.
+		// Without this, ffmpeg infers the framerate from the stream which can
+		// result in slightly imprecise values like 95940000/3197999 instead of 30/1.
+		videoOutput ? '-r' : null,
+		videoOutput ? String(fps) : null,
 		numberOfGifLoops === null ? null : '-loop',
 		numberOfGifLoops === null
 			? null


### PR DESCRIPTION
## Summary
- When combining chunks in distributed rendering (Lambda), the mux step did not specify an explicit framerate (`-r`), causing ffmpeg to infer a slightly imprecise value from the concatenated stream (e.g. `95940000/3197999` instead of `30/1`)
- Added `-r <fps>` to the mux command in `mux-video-and-audio.ts` to force the exact output framerate in the container metadata
- No re-encoding occurs — with `-c:v copy`, the `-r` flag only sets the mp4 container header timing values

## Test plan
- [x] Rendered locally — FPS is `30/1`
- [x] Rendered on Lambda with distributed rendering — FPS is now `30/1` (was `95940000/3197999` before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)