### PR TITLE
fix: handle InputDisposedError in useWindowedAudioData to ensure prop…

### DIFF
--- a/packages/media-utils/src/use-windowed-audio-data.ts
+++ b/packages/media-utils/src/use-windowed-audio-data.ts
@@ -155,6 +155,11 @@ export const useWindowedAudioData = ({
 
 				continueRender(handle);
 			} catch (err) {
+				if (err instanceof InputDisposedError) {
+					continueRender(handle);
+					return;
+				}
+
 				cancelRender(err);
 			} finally {
 				signal.removeEventListener('abort', cont);


### PR DESCRIPTION
When the src changes, or the component unmounts, the metadata AbortController disposes the mediabunny Input while computeDuration() may still be running. That correctly throws InputDisposedError, but the catch path called cancelRender(err), which rethrows and produced an unhandled rejection because fetchMetadata is not awaited.

Treat InputDisposedError like the waveform path and useMaxMediaDuration: call continueRender(handle) and return; keep cancelRender for real failures.

Fixes #6894.
