### PR TITLE
`@remotion/media`: Prevent MediaPlayer reinit on Sequence durationInFrames change

### DIFF
--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -182,6 +182,7 @@ const AudioForPreviewAssertedShowing: React.FC<
 	const initialGlobalPlaybackRate = useRef(globalPlaybackRate);
 	const initialPlaybackRate = useRef(playbackRate);
 	const initialMuted = useRef(effectiveMuted);
+	const initialDurationInFrames = useRef(videoConfig.durationInFrames);
 	const initialSequenceOffset = useRef(sequenceOffset);
 
 	useCommonEffects({
@@ -235,7 +236,7 @@ const AudioForPreviewAssertedShowing: React.FC<
 				isPostmounting: initialIsPostmounting.current,
 				isPremounting: initialIsPremounting.current,
 				globalPlaybackRate: initialGlobalPlaybackRate.current,
-				durationInFrames: videoConfig.durationInFrames,
+				durationInFrames: initialDurationInFrames.current,
 				onVideoFrameCallback: null,
 				playing: initialPlaying.current,
 				sequenceOffset: initialSequenceOffset.current,
@@ -375,7 +376,6 @@ const AudioForPreviewAssertedShowing: React.FC<
 		debugAudioScheduling,
 		buffer,
 		onError,
-		videoConfig.durationInFrames,
 		credentials,
 	]);
 

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -200,6 +200,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 	const initialGlobalPlaybackRate = useRef(globalPlaybackRate);
 	const initialPlaybackRate = useRef(playbackRate);
 	const initialMuted = useRef(effectiveMuted);
+	const initialDurationInFrames = useRef(videoConfig.durationInFrames);
 	const initialSequenceOffset = useRef(sequenceOffset);
 
 	useEffect(() => {
@@ -227,7 +228,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 				isPremounting: initialIsPremounting.current,
 				isPostmounting: initialIsPostmounting.current,
 				globalPlaybackRate: initialGlobalPlaybackRate.current,
-				durationInFrames: videoConfig.durationInFrames,
+				durationInFrames: initialDurationInFrames.current,
 				onVideoFrameCallback: initialOnVideoFrameRef.current ?? null,
 				playing: initialPlaying.current,
 				sequenceOffset: initialSequenceOffset.current,
@@ -363,7 +364,6 @@ const VideoForPreviewAssertedShowing: React.FC<
 		sharedAudioContext,
 		videoConfig.fps,
 		onError,
-		videoConfig.durationInFrames,
 		credentials,
 	]);
 


### PR DESCRIPTION
## Summary
- When a parent `<Sequence>`'s `durationInFrames` changes, `videoConfig.durationInFrames` (derived from `SequenceContext`) was in the `useEffect` dependency array that creates the `MediaPlayer` instance, causing a full dispose + recreate and a visible blink in preview
- `useCommonEffects` already handles `durationInFrames` updates via `mediaPlayer.setDurationInFrames()` in a `useLayoutEffect`, so full reinit is unnecessary
- Use a ref (`initialDurationInFrames`) for the constructor's initial value (consistent with `trimAfter`, `trimBefore`, `playbackRate`, etc.) and remove `videoConfig.durationInFrames` from the `useEffect` dep array
- Applied to both `VideoForPreviewAssertedShowing` and `AudioForPreviewAssertedShowing`

## Test plan
- [ ] Verify in preview: change parent `<Sequence>` `durationInFrames` — `<Video>` should update smoothly without blinking
- [ ] Verify audio continues playing without interruption when parent sequence duration changes
- [ ] Verify initial render still works correctly (ref captures correct initial value)
- [ ] Verify `setDurationInFrames()` in `useCommonEffects` keeps MediaPlayer in sync after duration changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)