### PR TITLE
`@remotion/studio`: Don't show empty layer when there are no sequences

### DIFF
--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -53,17 +53,17 @@ const TimelineInner: React.FC = () => {
 		Boolean(process.env.EXPERIMENTAL_VISUAL_MODE_ENABLED) &&
 		previewServerState.type === 'connected';
 	const videoConfig = Internals.useUnsafeVideoConfig();
+	const videoConfigIsNull = videoConfig === null;
 
 	const timeline = useMemo((): TrackWithHash[] => {
-		if (!videoConfig) {
+		if (videoConfigIsNull) {
 			return [];
 		}
 
 		return calculateTimeline({
 			sequences,
-			sequenceDuration: videoConfig.durationInFrames,
 		});
-	}, [sequences, videoConfig]);
+	}, [sequences, videoConfigIsNull]);
 
 	const durationInFrames = videoConfig?.durationInFrames ?? 0;
 

--- a/packages/studio/src/helpers/calculate-timeline.ts
+++ b/packages/studio/src/helpers/calculate-timeline.ts
@@ -15,37 +15,14 @@ import {sortItemsByNonceHistory} from './sort-by-nonce-history';
 
 export const calculateTimeline = ({
 	sequences,
-	sequenceDuration,
 }: {
 	sequences: TSequence[];
-	sequenceDuration: number;
 }): TrackWithHash[] => {
 	const sortedSequences = sortItemsByNonceHistory(sequences);
 	const tracks: TrackWithHashAndOriginalTimings[] = [];
 
 	if (sortedSequences.length === 0) {
-		return [
-			{
-				sequence: {
-					displayName: '',
-					duration: sequenceDuration,
-					from: 0,
-					id: 'seq',
-					parent: null,
-					type: 'sequence',
-					rootId: '-',
-					showInTimeline: true,
-					nonce: [[0, 0]],
-					loopDisplay: undefined,
-					stack: null,
-					premountDisplay: null,
-					postmountDisplay: null,
-					controls: null,
-				},
-				depth: 0,
-				hash: '-',
-			},
-		];
+		return [];
 	}
 
 	const sameHashes: {[hash: string]: string[]} = {};

--- a/packages/studio/src/test/big-timeline.test.ts
+++ b/packages/studio/src/test/big-timeline.test.ts
@@ -5,7 +5,6 @@ import {calculateTimeline} from '../helpers/calculate-timeline';
 test('Should calculate timeline as expected', () => {
 	const timeline = calculateTimeline({
 		sequences,
-		sequenceDuration: 2422,
 	});
 	expect(timeline).toEqual([
 		{

--- a/packages/studio/src/test/sequenced-timeline.test.ts
+++ b/packages/studio/src/test/sequenced-timeline.test.ts
@@ -5,7 +5,6 @@ import {calculateTimeline} from '../helpers/calculate-timeline';
 test('Should calculate sequences correctly', () => {
 	const timeline = calculateTimeline({
 		sequences,
-		sequenceDuration: 1000,
 	});
 
 	expect(timeline).toEqual([

--- a/packages/studio/src/test/timeline.test.ts
+++ b/packages/studio/src/test/timeline.test.ts
@@ -4,30 +4,8 @@ import {calculateTimeline} from '../helpers/calculate-timeline';
 test('Should calculate timeline with no sequences', () => {
 	const calculated = calculateTimeline({
 		sequences: [],
-		sequenceDuration: 100,
 	});
-	expect(calculated).toEqual([
-		{
-			sequence: {
-				displayName: '',
-				duration: 100,
-				from: 0,
-				id: 'seq',
-				parent: null,
-				type: 'sequence',
-				rootId: '-',
-				showInTimeline: true,
-				nonce: [[0, 0]],
-				premountDisplay: null,
-				postmountDisplay: null,
-				controls: null,
-				loopDisplay: undefined,
-				stack: null,
-			},
-			depth: 0,
-			hash: '-',
-		},
-	]);
+	expect(calculated).toEqual([]);
 });
 
 test('Should calculate a basic timeline', () => {
@@ -50,7 +28,6 @@ test('Should calculate a basic timeline', () => {
 				loopDisplay: undefined,
 			},
 		],
-		sequenceDuration: 100,
 	});
 	expect(calculated).toEqual([
 		{
@@ -112,7 +89,6 @@ test('Should follow order of nesting', () => {
 				stack: null,
 			},
 		],
-		sequenceDuration: 100,
 	});
 	expect(calculated).toEqual([
 		{


### PR DESCRIPTION
## Summary
- Remove the placeholder layer that was shown when no sequences exist
- `calculateTimeline()` now returns `[]` instead of a synthetic empty sequence
- Remove the now-unused `sequenceDuration` parameter from `calculateTimeline()`
- Update tests to match new behavior

## Test plan
- [ ] Open a composition with no sequences — timeline should be empty (no phantom layer)
- [ ] Open a composition with sequences — timeline renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)