### PR TITLE
`@remotion/design`: Add theme defaults to register CSS

### DIFF
--- a/packages/design/index.css
+++ b/packages/design/index.css
@@ -1,1 +1,14 @@
 @source "./dist/esm/index.mjs";
+
+@theme {
+	--font-brand: 'GTPlanar', sans-serif;
+	--color-brand: #0b84f3;
+	--color-warn: #ff3232;
+	--color-text: black;
+	--color-button-bg: white;
+	--color-card-bg: white;
+}
+
+@theme inline {
+	--font-brand--font-feature-settings: 'ss03' 1;
+}


### PR DESCRIPTION
## Summary
- The `@remotion/design/register` entry point only had a `@source` directive for Tailwind class scanning
- Consumers who import it still needed to manually define `--color-card-bg`, `--color-text`, `--color-button-bg`, etc. in their own `@theme` for design system utilities to resolve
- Add `@theme` defaults to the register CSS so components like Card, Button, and Switch work out of the box

## Test plan
- [ ] Verify `@remotion/design` components render correctly in consumers using `@import '@remotion/design/register'`
- [ ] Verify promo-pages still works (its own `@theme` overrides these defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)