### PR TITLE
`@remotion/studio`: Use `server.listen()` for port availability checks

### DIFF
--- a/packages/renderer/src/get-port.ts
+++ b/packages/renderer/src/get-port.ts
@@ -31,13 +31,14 @@ export const testPortAvailableOnMultipleHosts = async ({
 	port: number;
 	hosts: string[];
 }): Promise<PortStatus> => {
-	const results = await Promise.all(
-		hosts.map((host) => {
-			return isPortAvailableOnHost({portToTry: port, host});
-		}),
-	);
+	for (const host of hosts) {
+		const result = await isPortAvailableOnHost({portToTry: port, host});
+		if (result === 'unavailable') {
+			return 'unavailable';
+		}
+	}
 
-	return results.every((r) => r === 'available') ? 'available' : 'unavailable';
+	return 'available';
 };
 
 const getPort = async ({


### PR DESCRIPTION
## Summary
- Switch back from `socket.connect()` to `server.listen()` for port availability detection
- Fixes Remotion Studio failing to start on WSL2 with "No available ports found"

## History

The original implementation used `server.listen()` to check port availability — the most direct way to test if a port is bindable.

In **v3.0.13** (`000d42195b`), this was changed to `socket.connect()` to fix a port selection issue ([#1023](https://github.com/remotion-dev/remotion/issues/1023)). The renderer was synced to match in **v3.0.18** (`fe00816c25`).

However, the `connect()`-based approach has a fundamental flaw on WSL2: Windows' port forwarding proxy accepts TCP connections on `127.0.0.1` and `0.0.0.0` across a large port range (~1024–41000), even when nothing inside WSL is actually listening. This makes every port in the 3000–3100 scan range appear "occupied", so the studio HTTP server never starts.

`server.listen()` is the correct fix because it directly tests bindability rather than inferring availability from a failed connection attempt.

## Context
- Original bug report about WSL2: [#4315](https://github.com/remotion-dev/remotion/issues/4315)
- The issue that prompted the original switch to `connect()`: [#1023](https://github.com/remotion-dev/remotion/issues/1023) — this turned out to be a timeout handling bug in the `connect()`-based code itself, not a problem with the `listen()` approach

## Test plan
- [ ] Test studio starts correctly on macOS/Linux
- [ ] Test studio starts correctly on WSL2
- [ ] Test that if port 3000 is already in use, the next available port is selected

Closes #4315

🤖 Generated with [Claude Code](https://claude.com/claude-code)