### PR TITLE
`@remotion/design`: Remove box-content from Switch inner element

### DIFF
--- a/packages/design/src/Switch.tsx
+++ b/packages/design/src/Switch.tsx
@@ -12,7 +12,7 @@ export const Switch: React.FC<{
 		>
 			<div
 				data-active={active}
-				className="h-[20px] w-[20px] box-content left-[4px] top-[4px] transition-all rounded-full bg-white border-2 border-black absolute data-[active=true]:left-[calc(100%-24px)]"
+				className="h-[20px] w-[20px] left-[4px] top-[4px] transition-all rounded-full bg-white border-2 border-black absolute data-[active=true]:left-[calc(100%-24px)]"
 			/>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- The Switch inner slider circle used `box-content` which made its total rendered size 24x24 (20px content + 4px borders), filling the entire track height with no visible gap
- Remove `box-content` so it uses the default `border-box` from Tailwind's base reset, making the circle 20x20 total with symmetric 4px gaps on all sides
- The existing position values (`left-[4px]` inactive, `left-[calc(100%-24px)]` active) produce correct symmetric spacing with border-box

## Test plan
- [ ] Verify Switch toggle circle has visible gap around it in the track
- [ ] Verify Switch slides correctly between inactive and active positions
- [ ] Verify on remotion.dev pricing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)