### PR TITLE
`@remotion/studio`: Parse rotation values directly to preserve angles beyond 360°

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineRotationField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRotationField.tsx
@@ -4,6 +4,28 @@ import {InputDragger} from '../NewComposition/InputDragger';
 import {draggerStyle, getDecimalPlaces} from './timeline-field-utils';
 
 const parseCssRotationToDegrees = (value: string): number => {
+	const trimmed = value.trim();
+
+	const degMatch = trimmed.match(/^(-?\d+(?:\.\d+)?)deg$/);
+	if (degMatch) {
+		return Number(degMatch[1]);
+	}
+
+	const radMatch = trimmed.match(/^(-?\d+(?:\.\d+)?)rad$/);
+	if (radMatch) {
+		return Number(radMatch[1]) * (180 / Math.PI);
+	}
+
+	const turnMatch = trimmed.match(/^(-?\d+(?:\.\d+)?)turn$/);
+	if (turnMatch) {
+		return Number(turnMatch[1]) * 360;
+	}
+
+	const gradMatch = trimmed.match(/^(-?\d+(?:\.\d+)?)grad$/);
+	if (gradMatch) {
+		return Number(gradMatch[1]) * (360 / 400);
+	}
+
 	try {
 		const m = new DOMMatrix(`rotate(${value})`);
 		return Math.round(Math.atan2(m.b, m.a) * (180 / Math.PI) * 1e6) / 1e6;


### PR DESCRIPTION
## Summary
- The timeline rotation field was wrapping 360° back to 0° because it used `DOMMatrix` + `atan2` to parse rotation values, which loses information about full rotations
- Now parses `deg`, `rad`, `turn`, and `grad` unit strings directly to preserve the original numeric value
- Falls back to the `DOMMatrix` approach for unrecognized formats

## Test plan
- [ ] Set a rotation to 360°, 720°, or other multiples — verify the field displays the correct value instead of wrapping to 0°
- [ ] Verify negative rotations still work correctly
- [ ] Verify `rad`, `turn`, `grad` units parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)