### PR TITLE
`remotion`: Add schema support for `<Img>` tag

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -1,5 +1,4 @@
 import React, {
-	forwardRef,
 	useCallback,
 	useContext,
 	useImperativeHandle,
@@ -8,14 +7,17 @@ import React, {
 	useState,
 } from 'react';
 import type {IsExact} from './audio/props.js';
+import type {SequenceControls} from './CompositionManager.js';
 import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
 import {getCrossOriginValue} from './get-cross-origin-value.js';
 import {usePreload} from './prefetch.js';
+import type {SequenceSchema} from './sequence-field-schema.js';
 import {SequenceContext} from './SequenceContext.js';
 import {useBufferState} from './use-buffer-state.js';
 import {useDelayRender} from './use-delay-render.js';
 import {useImageInTimeline} from './use-media-in-timeline.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
+import {wrapInSchema} from './wrap-in-schema.js';
 
 function exponentialBackoff(errorCount: number): number {
 	return 1000 * 2 ** (errorCount - 1);
@@ -44,28 +46,59 @@ export type ImgProps = NativeImgProps & {
 	readonly stack?: string;
 };
 
-type Expected = Omit<NativeImgProps, 'onError' | 'src' | 'crossOrigin'>;
+type Expected = Omit<NativeImgProps, 'onError' | 'src' | 'crossOrigin' | 'ref'>;
 
-const ImgRefForwarding: React.ForwardRefRenderFunction<
-	HTMLImageElement,
-	ImgProps
-> = (
-	{
-		onError,
-		maxRetries = 2,
-		src,
-		pauseWhenLoading,
-		delayRenderRetries,
-		delayRenderTimeoutInMilliseconds,
-		onImageFrame,
-		crossOrigin,
-		showInTimeline,
-		name,
-		stack,
-		...props
+const imgSchema = {
+	'style.translate': {
+		type: 'translate',
+		step: 1,
+		default: '0px 0px',
+		description: 'Position',
 	},
+	'style.scale': {
+		type: 'number',
+		min: 0.05,
+		max: 100,
+		step: 0.01,
+		default: 1,
+		description: 'Scale',
+	},
+	'style.rotate': {
+		type: 'rotation',
+		step: 1,
+		default: '0deg',
+		description: 'Rotation',
+	},
+	'style.opacity': {
+		type: 'number',
+		min: 0,
+		max: 1,
+		step: 0.01,
+		default: 1,
+		description: 'Opacity',
+	},
+} as const satisfies SequenceSchema;
+
+const ImgInner: React.FC<
+	ImgProps & {
+		readonly controls: SequenceControls | undefined;
+	}
+> = ({
+	onError,
+	maxRetries = 2,
+	src,
+	pauseWhenLoading,
+	delayRenderRetries,
+	delayRenderTimeoutInMilliseconds,
+	onImageFrame,
+	crossOrigin,
+	showInTimeline,
+	name,
+	stack,
 	ref,
-) => {
+	controls,
+	...props
+}) => {
 	const imageRef = useRef<HTMLImageElement>(null);
 	const errors = useRef<Record<string, number>>({});
 	const {delayPlayback} = useBufferState();
@@ -95,6 +128,7 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 		premountDisplay: sequenceContext?.premountDisplay ?? null,
 		postmountDisplay: sequenceContext?.postmountDisplay ?? null,
 		loopDisplay: undefined,
+		controls: controls ?? null,
 	});
 
 	const actualSrc = usePreload(src as string);
@@ -296,5 +330,5 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
  * @description Works just like a regular HTML img tag. When you use the <Img> tag, Remotion will ensure that the image is loaded before rendering the frame.
  * @see [Documentation](https://remotion.dev/docs/img)
  */
-export const Img = forwardRef(ImgRefForwarding);
+export const Img = wrapInSchema(ImgInner, imgSchema);
 addSequenceStackTraces(Img);

--- a/packages/core/src/use-media-in-timeline.ts
+++ b/packages/core/src/use-media-in-timeline.ts
@@ -1,7 +1,7 @@
 import {useContext, useEffect, useMemo, useState} from 'react';
 import {useMediaStartsAt} from './audio/use-audio-frame.js';
 import {calculateMediaDuration} from './calculate-media-duration.js';
-import type {LoopDisplay} from './CompositionManager.js';
+import type {LoopDisplay, SequenceControls} from './CompositionManager.js';
 import {getAssetDisplayName} from './get-asset-file-name.js';
 import {useNonce} from './nonce.js';
 import {SequenceContext} from './SequenceContext.js';
@@ -114,6 +114,7 @@ export const useImageInTimeline = ({
 	premountDisplay,
 	postmountDisplay,
 	loopDisplay,
+	controls,
 }: {
 	src: string | undefined;
 	displayName: string | null;
@@ -123,6 +124,7 @@ export const useImageInTimeline = ({
 	premountDisplay: number | null;
 	postmountDisplay: number | null;
 	loopDisplay: LoopDisplay | undefined;
+	controls: SequenceControls | null;
 }) => {
 	const parentSequence = useContext(SequenceContext);
 	const {registerSequence, unregisterSequence} = useContext(SequenceManager);
@@ -167,7 +169,7 @@ export const useImageInTimeline = ({
 			stack,
 			premountDisplay,
 			postmountDisplay,
-			controls: null,
+			controls,
 		});
 
 		return () => {
@@ -189,6 +191,7 @@ export const useImageInTimeline = ({
 		loopDisplay,
 		rootId,
 		finalDisplayName,
+		controls,
 	]);
 };
 


### PR DESCRIPTION
## Summary
- Adds an `imgSchema` with visual controls (Position, Scale, Rotation, Opacity) to the `<Img>` component, mirroring the `<Video>` tag's schema support
- Threads `controls` from `wrapInSchema` through `useImageInTimeline` to `registerSequence` so the schema is registered with the sequence

## Test plan
- [ ] Verify `<Img>` shows schema controls in the Studio visual mode
- [ ] Verify Position, Scale, Rotation, Opacity controls work on `<Img>`
- [ ] Verify ref forwarding still works on `<Img>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)