### PR TITLE
`@remotion/studio`: Fix 1px gaps between timeline video thumbnails

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
@@ -139,15 +139,15 @@ const drawSlot = ({
 
 	const relativeTimestamp = timestamp - fromSeconds * WEBCODECS_TIMESCALE;
 	const frameIndex = relativeTimestamp / durationOfOneFrame;
-	const left = Math.floor(
-		(frameIndex * frame.displayWidth) / window.devicePixelRatio,
-	); // round to avoid antialiasing
+	const thumbnailWidth = frame.displayWidth / window.devicePixelRatio;
+	const left = Math.floor(frameIndex * thumbnailWidth);
+	const right = Math.ceil((frameIndex + 1) * thumbnailWidth);
 
 	ctx.drawImage(
 		frame,
 		left,
 		0,
-		frame.displayWidth / window.devicePixelRatio,
+		right - left,
 		frame.displayHeight / window.devicePixelRatio,
 	);
 	filledSlots.set(timestamp, frame.timestamp);


### PR DESCRIPTION
## Summary
- Compute left and right edges of each timeline thumbnail slot with `Math.floor`/`Math.ceil` respectively, so adjacent frames always touch or slightly overlap instead of leaving subpixel gaps

## Test plan
- [ ] Open a composition with a `<Video>` tag in the Studio timeline
- [ ] Verify no visible 1px gaps appear between video thumbnails at various zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)