### PR TITLE
`@remotion/web-renderer`: Validate container and codec for transparent videos

### DIFF
--- a/packages/docs/docs/web-renderer/render-media-on-web.mdx
+++ b/packages/docs/docs/web-renderer/render-media-on-web.mdx
@@ -154,8 +154,10 @@ Default is `5`.
 
 _boolean_
 
-If set to `true`, the video will be encoded with an alpha channel, allowing for transparent backgrounds.  
+If set to `true`, the video will be encoded with an alpha channel, allowing for transparent backgrounds.
 The composition must render with a transparent background for this to work.
+
+Only the `"webm"` and `"mkv"` containers support transparency. Only the `"vp8"` and `"vp9"` codecs support transparency. An error will be thrown if an incompatible container or codec is used.
 
 Default is `false`.
 

--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -206,6 +206,24 @@ const internalRenderMediaOnWeb = async <
 		);
 	}
 
+	if (transparent) {
+		if (container !== 'webm' && container !== 'mkv') {
+			return Promise.reject(
+				new Error(
+					`Transparent videos are only supported with the "webm" and "mkv" containers, but you specified "${container}". Change the \`container\` option to "webm" or "mkv".`,
+				),
+			);
+		}
+
+		if (codec && codec !== 'vp8' && codec !== 'vp9') {
+			return Promise.reject(
+				new Error(
+					`Transparent videos are only supported with the "vp8" and "vp9" codecs, but you specified "${codec}". Change the \`videoCodec\` option to "vp8" or "vp9", or remove it to use the default.`,
+				),
+			);
+		}
+	}
+
 	const resolvedAudioBitrate =
 		typeof audioBitrate === 'number'
 			? audioBitrate


### PR DESCRIPTION
## Summary
- Throw an error if `transparent: true` is used with a container other than `"webm"` or `"mkv"`
- Throw an error if `transparent: true` is used with a codec other than `"vp8"` or `"vp9"`
- Updated docs for the `transparent` option to document supported containers and codecs

## Test plan
- [ ] Verify `renderMediaOnWeb({ transparent: true, container: 'webm' })` works
- [ ] Verify `renderMediaOnWeb({ transparent: true, container: 'mp4' })` throws
- [ ] Verify `renderMediaOnWeb({ transparent: true, videoCodec: 'h264', container: 'mkv' })` throws
- [ ] Verify `renderMediaOnWeb({ transparent: true, videoCodec: 'vp9', container: 'webm' })` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)