### PR TITLE
`@remotion/studio`: Fix JSON editor error state being immediately cleared

### DIFF
--- a/packages/studio/src/components/RenderModal/RenderModalJSONPropsEditor.tsx
+++ b/packages/studio/src/components/RenderModal/RenderModalJSONPropsEditor.tsx
@@ -109,12 +109,14 @@ export const RenderModalJSONPropsEditor: React.FC<{
 	}, [subscribeToEvent, compositionId, schema]);
 
 	useEffect(() => {
-		if (localValue.validJSON && deepEqual(value, localValue.value)) {
-			return;
-		}
+		setLocalValue((prev) => {
+			if (prev.validJSON && deepEqual(value, prev.value)) {
+				return prev;
+			}
 
-		setLocalValue(parseJS(value as Record<string, unknown>, schema));
-	}, [value, schema, localValue]);
+			return parseJS(value as Record<string, unknown>, schema);
+		});
+	}, [value, schema]);
 
 	const onPretty = useCallback(() => {
 		if (!localValue.validJSON) {


### PR DESCRIPTION
## Summary
- Fix flaky JSON editor e2e tests by removing `localValue` from the `useEffect` dependency array in `RenderModalJSONPropsEditor`
- The `useEffect` that syncs local state with the parent `value` had `localValue` as a dependency, causing a feedback loop: typing invalid JSON would trigger the effect, which would overwrite the error state with the parent's last-known-good value
- Uses a functional state updater (`setLocalValue((prev) => ...)`) to access previous state without needing `localValue` as a dependency

## Test plan
- [ ] Verify `json-editor.test.mts` e2e tests pass consistently (no longer flaky)
- [ ] Verify JSON editor still syncs correctly when props change externally

🤖 Generated with [Claude Code](https://claude.com/claude-code)