### PR TITLE
`@remotion/serverless-client`: Fix cost estimate increasing after fatal error

### DIFF
--- a/packages/lambda-client/src/test/price-calculation.test.ts
+++ b/packages/lambda-client/src/test/price-calculation.test.ts
@@ -57,6 +57,7 @@ test('Should not throw while calculating prices when time shifts occur', () => {
 		],
 		region: 'eu-central-1',
 		providerSpecifics: awsImplementation,
+		fatalErrorTimestamp: null,
 	});
 	expect(price?.accruedSoFar).toBeGreaterThanOrEqual(0);
 });

--- a/packages/serverless-client/src/estimate-price-from-bucket.ts
+++ b/packages/serverless-client/src/estimate-price-from-bucket.ts
@@ -11,6 +11,7 @@ export const estimatePriceFromMetadata = <Provider extends CloudProvider>({
 	timings,
 	region,
 	providerSpecifics,
+	fatalErrorTimestamp,
 }: {
 	renderMetadata: RenderMetadata<Provider> | null;
 	memorySizeInMb: number;
@@ -19,15 +20,14 @@ export const estimatePriceFromMetadata = <Provider extends CloudProvider>({
 	timings: ParsedTiming[];
 	region: Provider['region'];
 	providerSpecifics: ProviderSpecifics<Provider>;
+	fatalErrorTimestamp: number | null;
 }) => {
 	if (!renderMetadata) {
 		return null;
 	}
 
-	const elapsedTime = Math.max(
-		0,
-		Date.now() - (renderMetadata?.startedDate ?? 0),
-	);
+	const now = fatalErrorTimestamp ?? Date.now();
+	const elapsedTime = Math.max(0, now - (renderMetadata?.startedDate ?? 0));
 	const unfinished = Math.max(
 		0,
 		(renderMetadata?.totalChunks ?? 0) - timings.length,

--- a/packages/serverless-client/src/overall-render-progress.ts
+++ b/packages/serverless-client/src/overall-render-progress.ts
@@ -22,6 +22,7 @@ export type OverallRenderProgress<Provider extends CloudProvider> = {
 	timings: ParsedTiming[];
 	renderMetadata: RenderMetadata<Provider> | null;
 	errors: FunctionErrorInfo[];
+	fatalErrorTimestamp: number | null;
 	timeoutTimestamp: number;
 	functionLaunched: number;
 	serveUrlOpened: number | null;

--- a/packages/serverless-client/src/progress.ts
+++ b/packages/serverless-client/src/progress.ts
@@ -209,6 +209,7 @@ export const getProgress = async <Provider extends CloudProvider>({
 		timings: overallProgress.timings ?? [],
 		region,
 		providerSpecifics,
+		fatalErrorTimestamp: overallProgress.fatalErrorTimestamp ?? null,
 	});
 
 	const chunkMultiplier = [hasAudio, hasVideo].filter(truthy).length;

--- a/packages/serverless/src/overall-render-progress.ts
+++ b/packages/serverless/src/overall-render-progress.ts
@@ -62,6 +62,7 @@ export const makeInitialOverallRenderProgress = <
 		timings: [],
 		renderMetadata: null,
 		errors: [],
+		fatalErrorTimestamp: null,
 		timeToRenderFrames: null,
 		timeoutTimestamp,
 		functionLaunched: Date.now(),
@@ -267,6 +268,9 @@ export const makeOverallRenderProgress = <Provider extends CloudProvider>({
 		},
 		addErrorWithoutUpload: (errorInfo) => {
 			renderProgress.errors.push(errorInfo);
+			if (errorInfo.isFatal && renderProgress.fatalErrorTimestamp === null) {
+				renderProgress.fatalErrorTimestamp = Date.now();
+			}
 		},
 		setExpectedChunks: (expectedChunks) => {
 			framesRendered = new Array(expectedChunks).fill(0);


### PR DESCRIPTION
## Summary
- When a Lambda render hits a fatal error, the cost estimate returned by `getRenderProgress()` kept increasing on every call, even though no Lambda functions were running
- Root cause: unfinished chunks used `Date.now()` to estimate their duration, so the cost grew linearly with wall-clock time
- Fix: store a `fatalErrorTimestamp` when a fatal error is recorded and use it to cap the elapsed time calculation

## Test plan
- [x] Existing `price-calculation.test.ts` passes
- [x] `bun run build` succeeds
- [ ] Trigger a Lambda render with a fatal error and verify `getRenderProgress()` returns stable cost values after the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)