### PR TITLE
Skills: Teach AI how it can look at the output

### DIFF
--- a/packages/skills/skills/remotion/SKILL.md
+++ b/packages/skills/skills/remotion/SKILL.md
@@ -11,7 +11,8 @@ Use this skills whenever you are dealing with Remotion code to obtain the domain
 
 ## Optional: one-frame render check
 
-You can render a single frame with the CLI to sanity-check layout, colors, or timing when **you** judge that helpful—for example after larger visual edits or when you cannot rely on Remotion Studio. This is **not** a default or required step; skip it for trivial edits, pure refactors, or when you already have enough confidence from Studio or prior renders.
+You can render a single frame with the CLI to sanity-check layout, colors, or timing.  
+Skip it for trivial edits, pure refactors, or when you already have enough confidence from Studio or prior renders.
 
 ```bash
 npx remotion still [composition-id] --scale=0.25 --frame=30


### PR DESCRIPTION
Some projects extend the `remotion-best-practices` skill with a `remotion still` step so agents double-check visual output. That reads like a mandatory loop when it sits in the main flow without qualification.

This PR documents the same technique in upstream, but explicitly as an **optional** check the agent chooses when it helps—not part of the default workflow.

Relates to teams (e.g. birthday-bash) that found the unqualified wording too heavy-handed.

Made with [Cursor](https://cursor.com)