### PR TITLE
@remotion/player: Fix typo - rename persistance to persistence

### DIFF
--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -12,7 +12,7 @@ import type {
 	TimelineContextValue,
 } from 'remotion';
 import {Internals} from 'remotion';
-import {getPreferredVolume, persistVolume} from './volume-persistance.js';
+import {getPreferredVolume, persistVolume} from './volume-persistence.js';
 
 export const PLAYER_COMP_ID = 'player-comp';
 

--- a/packages/player/src/volume-persistence.ts
+++ b/packages/player/src/volume-persistence.ts
@@ -1,6 +1,6 @@
 import {Internals, type LogLevel} from 'remotion';
 
-const DEFAULT_VOLUME_PERSISTANCE_KEY = 'remotion.volumePreference';
+const DEFAULT_VOLUME_PERSISTENCE_KEY = 'remotion.volumePreference';
 
 export const persistVolume = (
 	volume: number,
@@ -13,7 +13,7 @@ export const persistVolume = (
 
 	try {
 		window.localStorage.setItem(
-			volumePersistenceKey ?? DEFAULT_VOLUME_PERSISTANCE_KEY,
+			volumePersistenceKey ?? DEFAULT_VOLUME_PERSISTENCE_KEY,
 			String(volume),
 		);
 	} catch (e) {
@@ -33,7 +33,7 @@ export const getPreferredVolume = (
 
 	try {
 		const val = window.localStorage.getItem(
-			volumePersistenceKey ?? DEFAULT_VOLUME_PERSISTANCE_KEY,
+			volumePersistenceKey ?? DEFAULT_VOLUME_PERSISTENCE_KEY,
 		);
 		return val ? Number(val) : 1;
 	} catch {


### PR DESCRIPTION
Fixes spelling typo in volume-persistance.ts by renaming to volume-persistence.ts and updating the constant DEFAULT_VOLUME_PERSISTANCE_KEY to DEFAULT_VOLUME_PERSISTENCE_KEY.

This is a non-breaking internal change that improves code consistency with the already-correct volumePersistenceKey parameter names used throughout the codebase.

- Renamed: volume-persistance.ts → volume-persistence.ts
- Updated: DEFAULT_VOLUME_PERSISTANCE_KEY → DEFAULT_VOLUME_PERSISTENCE_KEY
- Updated: import statement in SharedPlayerContext.tsx

All tests pass and formatting checks succeed.

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->
