### PR TITLE
`@remotion/studio`: Accept `z.discriminatedUnion()` as top-level composition schema

### DIFF
--- a/packages/example/src/DiscriminatedUnionSchemaTest/index.tsx
+++ b/packages/example/src/DiscriminatedUnionSchemaTest/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+import {z} from 'zod';
+
+export const discriminatedUnionRootSchema = z.discriminatedUnion('preset', [
+	z.object({
+		preset: z.literal('Simple'),
+		track: z.string(),
+		fontSize: z.number().default(48),
+	}),
+	z.object({
+		preset: z.literal('Fancy'),
+		track: z.string(),
+		fontSize: z.number().default(48),
+		outline: z.boolean().default(false),
+	}),
+]);
+
+export const DiscriminatedUnionSchemaTest: React.FC<
+	z.infer<typeof discriminatedUnionRootSchema>
+> = (props) => {
+	return (
+		<AbsoluteFill
+			style={{
+				justifyContent: 'center',
+				alignItems: 'center',
+				fontSize: props.fontSize,
+				background: '#222',
+				color: '#fff',
+			}}
+		>
+			<div>
+				<div>Preset: {props.preset}</div>
+				<div>Track: {props.track}</div>
+				{props.preset === 'Fancy' && (
+					<div>Outline: {String(props.outline)}</div>
+				)}
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -24,6 +24,10 @@ import CorruptVideo from './CorruptVideo';
 import {CssLoaderTest} from './CssLoaderTest';
 import {DarkModeTest} from './DarkModeTest';
 import {DecoderDemo} from './DecoderDemo';
+import {
+	DiscriminatedUnionSchemaTest,
+	discriminatedUnionRootSchema,
+} from './DiscriminatedUnionSchemaTest';
 import {DynamicDuration, dynamicDurationSchema} from './DynamicDuration';
 import {EmojiTestbed} from './Emoji';
 import {ErrorOnFrame10} from './ErrorOnFrame10';
@@ -1537,6 +1541,21 @@ export const Index: React.FC = () => {
 						items: [{label: 'alpha!', value: 1}],
 						mode: 'light' as const,
 						nested: {a: 'asdfadsf', b: 99},
+					}}
+				/>
+
+				<Composition
+					id="discriminated-union-root"
+					component={DiscriminatedUnionSchemaTest}
+					width={1920}
+					height={1080}
+					fps={30}
+					durationInFrames={150}
+					schema={discriminatedUnionRootSchema}
+					defaultProps={{
+						preset: 'Simple' as const,
+						track: 'Main audio',
+						fontSize: 48,
 					}}
 				/>
 			</Folder>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/SchemaEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/SchemaEditor.tsx
@@ -5,6 +5,7 @@ import {TopLevelZodValue} from './SchemaErrorMessages';
 import {defaultPropsEditorScrollableAreaRef} from './scroll-to-default-props-path';
 import type {AnyZodSchema} from './zod-schema-type';
 import {getZodSchemaType} from './zod-schema-type';
+import {ZodDiscriminatedUnionEditor} from './ZodDiscriminatedUnionEditor';
 import {ZodObjectEditor} from './ZodObjectEditor';
 import type {UpdaterFunction} from './ZodSwitch';
 
@@ -26,8 +27,27 @@ export const SchemaEditor: React.FC<{
 
 	const typeName = getZodSchemaType(schema);
 
-	if (typeName !== 'object') {
+	if (typeName !== 'object' && typeName !== 'discriminatedUnion') {
 		return <TopLevelZodValue typeReceived={typeName} />;
+	}
+
+	if (typeName === 'discriminatedUnion') {
+		return (
+			<div
+				ref={defaultPropsEditorScrollableAreaRef}
+				style={scrollable}
+				className={VERTICAL_SCROLLBAR_CLASSNAME}
+			>
+				<ZodDiscriminatedUnionEditor
+					schema={schema}
+					setValue={setValue}
+					value={value}
+					mayPad
+					jsonPath={[]}
+					onRemove={null}
+				/>
+			</div>
+		);
 	}
 
 	return (

--- a/packages/studio/src/components/RenderModal/SchemaEditor/SchemaErrorMessages.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/SchemaErrorMessages.tsx
@@ -134,13 +134,15 @@ export const TopLevelZodValue: React.FC<{
 	return (
 		<div style={explainer}>
 			<div style={errorExplanation}>
-				The top-level type of the schema must be a pure{' '}
-				<code style={codeSnippet}>z.object</code>. Instead got a schema of type{' '}
-				<code style={codeSnippet}>{typeReceived}</code>
+				The top-level type of the schema must be{' '}
+				<code style={codeSnippet}>z.object()</code> or{' '}
+				<code style={codeSnippet}>z.discriminatedUnion()</code>. Instead got a
+				schema of type <code style={codeSnippet}>{typeReceived}</code>
 			</div>
 			<Spacing y={1} />
 			<div style={errorExplanation}>
-				Fix the schema by changing the top-level Zod type to an object.
+				Fix the schema by changing the top-level Zod type to an object or
+				discriminated union.
 			</div>
 			<Spacing y={2} block />
 			<Button onClick={openDocs}>Learn more</Button>


### PR DESCRIPTION
## Summary

- Accept `z.discriminatedUnion()` as the top-level composition schema type in Remotion Studio, in addition to `z.object()`
- Renders `ZodDiscriminatedUnionEditor` at the root when the schema is a discriminated union, providing a dropdown to switch between union variants
- Updates the error message to mention `z.discriminatedUnion()` as a valid option

Closes #6976

## Test plan

- [x] `bun run build` passes
- [x] `bun run stylecheck` passes  
- [x] Existing schema tests pass (`create-zod-values.test.ts`, `extract-zod-enums.test.ts`)
- [ ] Open Remotion Studio (`cd packages/example && bun run dev`), navigate to Schema > `discriminated-union-root` composition, verify the discriminator dropdown works and switching between "Simple" and "Fancy" correctly shows/hides the `outline` field


Made with [Cursor](https://cursor.com)