### PR TITLE
`@remotion/studio-server`: Fix getCompositionDefaultPropsLine ast-types visitor

### DIFF
--- a/packages/studio-server/src/codemods/update-default-props.ts
+++ b/packages/studio-server/src/codemods/update-default-props.ts
@@ -256,6 +256,7 @@ export const getCompositionDefaultPropsLine = ({
 
 			found = true;
 			line = openingElement.loc?.start.line ?? path.node.loc?.start.line ?? 1;
+			this.traverse(path);
 		},
 	});
 

--- a/packages/studio-server/src/test/update-default-props.test.ts
+++ b/packages/studio-server/src/test/update-default-props.test.ts
@@ -1,7 +1,10 @@
 import {expect, test} from 'bun:test';
 import {readFileSync} from 'node:fs';
 import path from 'node:path';
-import {updateDefaultProps} from '../codemods/update-default-props';
+import {
+	getCompositionDefaultPropsLine,
+	updateDefaultProps,
+} from '../codemods/update-default-props';
 
 test('Should be able to update default props', async () => {
 	const file = readFileSync(
@@ -21,6 +24,20 @@ test('Should be able to update default props', async () => {
 	});
 
 	expect(output).toBe(expected);
+});
+
+test('getCompositionDefaultPropsLine returns the opening tag line (ast-types visitor must traverse)', () => {
+	const file = readFileSync(
+		path.join(__dirname, 'snapshots', 'root-before.tsx'),
+		'utf-8',
+	);
+
+	expect(
+		getCompositionDefaultPropsLine({
+			input: file,
+			compositionId: 'Comp3',
+		}),
+	).toBe(27);
 });
 
 test('Should be able to update default props', async () => {


### PR DESCRIPTION
## Summary

`getCompositionDefaultPropsLine` (added for path:line logging in default-props updates) used an ast-types `visitJSXElement` handler that did not call `this.traverse(path)` or `return false` after finding the matching `<Composition>` / `<Still>`. That violates ast-types’ visitor contract and caused every `/api/update-default-props` request to fail with:

`Must either call this.traverse or return false in visitJSXElement`

## Changes

- Call `this.traverse(path)` after resolving the line number.
- Add a unit test that exercises `getCompositionDefaultPropsLine` on the existing snapshot fixture.

## Testing

- `bun test packages/studio-server/src/test/update-default-props.test.ts`
- `packages/example/e2e/suppress-rebuild.test.mts` (POST to update-default-props API)

Made with [Cursor](https://cursor.com)