### PR TITLE
Skills: clarify defaultOutName must omit file extension

### DIFF
--- a/packages/skills/skills/remotion/rules/calculate-metadata.md
+++ b/packages/skills/skills/remotion/rules/calculate-metadata.md
@@ -86,14 +86,14 @@ const calculateMetadata: CalculateMetadataFunction<Props> = async ({
 
 ## Setting a default outName
 
-Set the default output filename based on props:
+Set the default output filename based on props. Omit the file extension: Remotion appends the correct extension for the selected codec (for example `.mp4` or `.mov`), so including one yourself produces names like `video.mp4.mp4`.
 
 ```tsx
 const calculateMetadata: CalculateMetadataFunction<Props> = async ({
   props,
 }) => {
   return {
-    defaultOutName: `video-${props.id}`, // .mp4 is added automatically
+    defaultOutName: `video-${props.id}`, // extension added automatically
   };
 };
 ```
@@ -130,5 +130,5 @@ All fields are optional. Returned values override the `<Composition>` props:
 - `height`: Composition height in pixels
 - `fps`: Frames per second
 - `props`: Transformed props passed to the component
-- `defaultOutName`: Default output filename
+- `defaultOutName`: Default output base name (no extension; the renderer appends it)
 - `defaultCodec`: Default codec for rendering


### PR DESCRIPTION
## Summary

The agent skill for `calculateMetadata` showed `defaultOutName` without an extension in the code sample, but the prose and return-value list did not explain that the renderer appends the codec extension (see `getDefaultOutLocation` in `@remotion/studio-shared`). Including `.mp4` or `.mov` in `defaultOutName` produces paths like `Caption-First.mov.mov`.

## Changes

- Document that the file extension must be omitted and why.
- Clarify the `defaultOutName` bullet in the return value section.

Made with [Cursor](https://cursor.com)