### PR TITLE
`@remotion/studio`: Scroll selected asset and composition into view in sidebar

### DIFF
--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -1,4 +1,11 @@
-import React, {useCallback, useContext, useMemo, useRef, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {Internals, type StaticFile} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {
@@ -272,6 +279,13 @@ const AssetSelectorItem: React.FC<{
 		setHovered(false);
 	}, []);
 
+	const rowRef = useRef<HTMLDivElement>(null);
+	useLayoutEffect(() => {
+		if (selected) {
+			rowRef.current?.scrollIntoView({block: 'center', behavior: 'auto'});
+		}
+	}, [selected]);
+
 	const onClick = useCallback(() => {
 		setCanvasContent({type: 'asset', asset: relativePath});
 		pushUrl(`/assets/${relativePath}`);
@@ -352,6 +366,7 @@ const AssetSelectorItem: React.FC<{
 	return (
 		<Row align="center">
 			<div
+				ref={rowRef}
 				style={style}
 				onPointerEnter={onPointerEnter}
 				onPointerLeave={onPointerLeave}

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -1,5 +1,12 @@
 import type {KeyboardEvent, MouseEvent} from 'react';
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {type _InternalTypes} from 'remotion';
 import {
 	BACKGROUND,
@@ -106,6 +113,16 @@ export const CompositionSelectorItem: React.FC<{
 	const onPointerLeave = useCallback(() => {
 		setHovered(false);
 	}, []);
+
+	const compositionRowRef = useRef<HTMLAnchorElement>(null);
+	useLayoutEffect(() => {
+		if (item.type === 'composition' && selected) {
+			compositionRowRef.current?.scrollIntoView({
+				block: 'center',
+				behavior: 'auto',
+			});
+		}
+	}, [item.type, selected]);
 
 	const style: React.CSSProperties = useMemo(() => {
 		return {
@@ -282,6 +299,7 @@ export const CompositionSelectorItem: React.FC<{
 		<ContextMenu values={contextMenu}>
 			<Row align="center">
 				<a
+					ref={compositionRowRef}
 					style={style}
 					onPointerEnter={onPointerEnter}
 					onPointerLeave={onPointerLeave}

--- a/packages/studio/src/components/InitialCompositionLoader.tsx
+++ b/packages/studio/src/components/InitialCompositionLoader.tsx
@@ -16,25 +16,28 @@ export const useSelectAsset = () => {
 	const {setCanvasContent} = useContext(Internals.CompositionSetters);
 	const {setAssetFoldersExpanded} = useContext(FolderContext);
 
-	return (asset: string) => {
-		setCanvasContent({type: 'asset', asset});
-		explorerSidebarTabs.current?.selectAssetsPanel();
-		setAssetFoldersExpanded((ex) => {
-			const split = asset.split('/');
+	return useCallback(
+		(asset: string) => {
+			setCanvasContent({type: 'asset', asset});
+			explorerSidebarTabs.current?.selectAssetsPanel();
+			setAssetFoldersExpanded((ex) => {
+				const split = asset.split('/');
 
-			const keysToExpand = split.map((_, i) => {
-				return split.slice(0, i).join('/');
+				const keysToExpand = split.map((_, i) => {
+					return split.slice(0, i).join('/');
+				});
+				const newState: ExpandedFoldersState = {
+					...ex,
+				};
+				for (const key of keysToExpand) {
+					newState[key] = true;
+				}
+
+				return newState;
 			});
-			const newState: ExpandedFoldersState = {
-				...ex,
-			};
-			for (const key of keysToExpand) {
-				newState[key] = true;
-			}
-
-			return newState;
-		});
-	};
+		},
+		[setAssetFoldersExpanded, setCanvasContent],
+	);
 };
 
 export const useSelectComposition = () => {
@@ -165,7 +168,7 @@ export const InitialCompositionLoader: React.FC = () => {
 				});
 
 				if (exists) {
-					setCanvasContent(newCanvas);
+					selectAsset(newCanvas.asset);
 				}
 
 				return;
@@ -177,7 +180,13 @@ export const InitialCompositionLoader: React.FC = () => {
 		window.addEventListener('popstate', onchange);
 
 		return () => window.removeEventListener('popstate', onchange);
-	}, [compositions, selectComposition, setCanvasContent, staticFiles]);
+	}, [
+		compositions,
+		selectAsset,
+		selectComposition,
+		setCanvasContent,
+		staticFiles,
+	]);
 
 	return null;
 };


### PR DESCRIPTION
When navigating to an asset or composition URL, scroll the sidebar tree so the selected item is centered in the viewport without animation.

- `scrollIntoView({ block: 'center', behavior: 'auto', })` in `useLayoutEffect` on selected asset and composition rows.
- On `popstate` for asset URLs, call `selectAsset` so folders expand and the Assets tab is shown.
- Memoize `useSelectAsset` with `useCallback`.