### PR TITLE
`@remotion/studio`: Fix calculateMetadata copy on render errors

### DIFF
--- a/packages/studio/src/components/CanvasOrLoading.tsx
+++ b/packages/studio/src/components/CanvasOrLoading.tsx
@@ -55,7 +55,9 @@ export const CanvasOrLoading: React.FC<{
 	}, [resolved, setZoom]);
 
 	if (renderError) {
-		return <ErrorLoading error={renderError} />;
+		return (
+			<ErrorLoading error={renderError} calculateMetadataContext={false} />
+		);
 	}
 
 	if (!canvasContent) {
@@ -98,7 +100,7 @@ export const CanvasOrLoading: React.FC<{
 	}
 
 	if (resolved.type === 'error') {
-		return <ErrorLoading error={resolved.error} />;
+		return <ErrorLoading error={resolved.error} calculateMetadataContext />;
 	}
 
 	return (
@@ -119,7 +121,8 @@ const loaderContainer: React.CSSProperties = {
 
 const ErrorLoading: React.FC<{
 	readonly error: Error;
-}> = ({error}) => {
+	readonly calculateMetadataContext: boolean;
+}> = ({error, calculateMetadataContext}) => {
 	return (
 		<div style={loaderContainer} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 			<ErrorLoader
@@ -130,7 +133,7 @@ const ErrorLoading: React.FC<{
 				onRetry={() =>
 					Internals.resolveCompositionsRef.current?.reloadCurrentlySelectedComposition()
 				}
-				calculateMetadata
+				calculateMetadata={calculateMetadataContext}
 			/>
 		</div>
 	);

--- a/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
@@ -123,7 +123,10 @@ export const ErrorDisplay: React.FC<{
 			{onRetry ? (
 				<>
 					<div style={spacer} />
-					<RetryButton onClick={onRetry} />
+					<RetryButton
+						onClick={onRetry}
+						label={calculateMetadata ? 'Retry calculateMetadata()' : 'Retry'}
+					/>
 				</>
 			) : null}
 			{calculateMetadata ? (

--- a/packages/studio/src/error-overlay/remotion-overlay/Retry.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/Retry.tsx
@@ -2,6 +2,7 @@ import {Button} from '../../components/Button';
 
 export const RetryButton: React.FC<{
 	onClick: () => void;
-}> = ({onClick}) => {
-	return <Button onClick={onClick}>Retry calculateMetadata()</Button>;
+	readonly label?: string;
+}> = ({onClick, label = 'Retry'}) => {
+	return <Button onClick={onClick}>{label}</Button>;
 };


### PR DESCRIPTION
## Summary

- **Root cause:** `CanvasOrLoading` always passed `calculateMetadata` to `ErrorLoader` for both (a) **render** errors from `RenderErrorContext` and (b) **composition resolution** failures (`resolved.type === 'error'`). Only (b) is from `calculateMetadata()`.
- **Retry button:** `RetryButton` always said `Retry calculateMetadata()` even when the error was not from metadata calculation (e.g. render errors).

## Changes

- Pass `calculateMetadataContext={false}` for render errors and `true` only when showing resolution errors from `calculateMetadata`.
- `RetryButton` accepts an optional `label` (default `Retry`). `ErrorDisplay` sets `Retry calculateMetadata()` only when `calculateMetadata` is true.

## Related

- Independent of #6997 (sidebar scroll + asset metadata errors in canvas).