### PR TITLE
remotion.dev/convert: Fall back to in-memory target if Web FS is not available

### DIFF
--- a/packages/convert/app/lib/web-fs-target.ts
+++ b/packages/convert/app/lib/web-fs-target.ts
@@ -1,6 +1,32 @@
 import type {StreamTargetChunk} from 'mediabunny';
 
-export const makeWebFsTarget = async (filename: string) => {
+const canUseCreateWritable = async (): Promise<boolean> => {
+	if (!('storage' in navigator)) {
+		return false;
+	}
+
+	if (!('getDirectory' in navigator.storage)) {
+		return false;
+	}
+
+	try {
+		const directoryHandle = await navigator.storage.getDirectory();
+		const fileHandle = await directoryHandle.getFileHandle(
+			'remotion-probe-web-fs-support',
+			{
+				create: true,
+			},
+		);
+
+		const writable = await fileHandle.createWritable();
+		await writable.close();
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const makeWebFsTargetWithFs = async (filename: string) => {
 	const directoryHandle = await navigator.storage.getDirectory();
 	const actualFilename = `__remotion_convert:${filename}`;
 
@@ -43,4 +69,61 @@ export const makeWebFsTarget = async (filename: string) => {
 		getWrittenByteCount: () => written,
 		close: () => writable.close(),
 	};
+};
+
+const makeWebFsTargetInMemory = (filename: string) => {
+	let buffer = new Uint8Array(1024 * 1024);
+	let length = 0;
+	let written = 0;
+
+	const ensureCapacity = (needed: number) => {
+		if (needed <= buffer.byteLength) {
+			return;
+		}
+
+		let newSize = buffer.byteLength;
+		while (newSize < needed) {
+			newSize *= 2;
+		}
+
+		const newBuffer = new Uint8Array(newSize);
+		newBuffer.set(buffer);
+		buffer = newBuffer;
+	};
+
+	const writableStream = new WritableStream({
+		write(chunk: StreamTargetChunk) {
+			const end = chunk.position + chunk.data.byteLength;
+			ensureCapacity(end);
+			buffer.set(new Uint8Array(chunk.data), chunk.position);
+			if (end > length) {
+				length = end;
+			}
+
+			written += chunk.data.byteLength;
+		},
+	});
+
+	const getBlob = (): Promise<File> =>
+		Promise.resolve(
+			new File([buffer.slice(0, length)], filename, {
+				lastModified: Date.now(),
+			}),
+		);
+
+	return {
+		stream: writableStream,
+		getBlob,
+		getWrittenByteCount: () => written,
+		close: () => {},
+	};
+};
+
+export const makeWebFsTarget = async (filename: string) => {
+	const canUse = await canUseCreateWritable();
+	if (canUse) {
+		return makeWebFsTargetWithFs(filename);
+	}
+
+	return makeWebFsTargetInMemory(filename);
 };


### PR DESCRIPTION
## Summary

- Fixes the `canUseWebFsWriter` check across `@remotion/webcodecs`, `@remotion/web-renderer`, and `@remotion/template-recorder` to actually try calling `fileHandle.createWritable()` instead of just checking `!== undefined`. Safari partially supports OPFS but `createWritable()` is not functional, causing the old check to incorrectly return `true`.
- Adds an in-memory buffer fallback to `@remotion/convert` so conversions work in Safari and other browsers that lack `createWritable()` support.

Closes #7003

## Test plan

- [x] Verified the check now catches the case where `createWritable` exists on the prototype but throws when called
- [ ] Test in Safari: conversion should fall back to in-memory buffer instead of crashing
- [ ] Test in Chrome: conversion should continue to use the Web FS API as before

Made with [Cursor](https://cursor.com)