### PR TITLE
docs: Point license key copy to License keys page instead of Usage tab

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -556,7 +556,7 @@ declare global {
 		readonly setImageSequencePattern: (pattern: string | null) => void;
 		/**
 		 * Set the public license key for your company license.
-		 * Obtain it from the "Usage" tab on https://remotion.pro
+		 * Obtain it from https://remotion.pro (License keys page)
 		 * Pass "free-license" if you are eligible for the free license.
 		 */
 		readonly setPublicLicenseKey: (key: string | null) => void;

--- a/packages/docs/docs/client-side-rendering/telemetry.mdx
+++ b/packages/docs/docs/client-side-rendering/telemetry.mdx
@@ -62,7 +62,7 @@ await renderMediaOnWeb({
 });
 ```
 
-If you have a Remotion Company License or Enterprise License, go to [remotion.pro](https://remotion.pro) and get your license key from the "Usage" tab.
+If you have a Remotion Company License or Enterprise License, go to [remotion.pro](https://remotion.pro) and get your license key from the License keys page.
 
 ```tsx twoslash title="Set a license key" {6}
 import React from 'react';

--- a/packages/docs/docs/licensing/index.mdx
+++ b/packages/docs/docs/licensing/index.mdx
@@ -28,7 +28,7 @@ Not directly - pass the `licenseKey` option in the renderer package you use.
 - [`@remotion/webcodecs`](/docs/webcodecs): Telemetry was removed in v4.0.399 because this package is no longer monetized.
 </details>
 
-On your Company License dashboard on [remotion.pro](https://remotion.pro), you can find your license keys under the "Usage" tab.
+On your Company License dashboard on [remotion.pro](https://remotion.pro), you can find your license keys on the License keys page.
 
 ### Do I need to use this package?
 

--- a/packages/renderer/src/options/public-license-key.tsx
+++ b/packages/renderer/src/options/public-license-key.tsx
@@ -9,9 +9,9 @@ export const publicLicenseKeyOption = {
 	cliFlag,
 	description: () => (
 		<>
-			The public license key for your company license, obtained from the "Usage"
-			tab on <a href="https://remotion.pro/dashboard">remotion.pro</a>. If you
-			are eligible for the free license, pass "free-license".
+			The public license key for your company license, obtained from the License
+			keys page on <a href="https://remotion.pro/dashboard">remotion.pro</a>. If
+			you are eligible for the free license, pass "free-license".
 		</>
 	),
 	ssrName: 'publicLicenseKey' as const,


### PR DESCRIPTION
Updates references that said license keys were under the Usage tab on remotion.pro so they now describe the License keys page.

**Changed**
- `packages/docs/docs/licensing/index.mdx` — overview
- `packages/docs/docs/client-side-rendering/telemetry.mdx` — company license key instructions
- `packages/renderer/src/options/public-license-key.tsx` — option description (docs UI)
- `packages/cli/src/config/index.ts` — `setPublicLicenseKey` JSDoc

**Unchanged**
- `get-usage` / `register-usage-event` API docs (dashboard-only wording)
- Studio render modal link (still `remotion.pro/dashboard`)
- Telemetry paragraph about tracking usage on the Usage tab

Made with [Cursor](https://cursor.com)