### PR TITLE
`@remotion/media`: Pre-decode and schedule at most 2 seconds ahead

### DIFF
--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -12,7 +12,7 @@ import {makePrewarmedAudioIteratorCache} from './prewarm-iterator-for-looping';
 import {ALLOWED_GLOBAL_TIME_ANCHOR_SHIFT} from './set-global-time-anchor';
 import type {SharedAudioContextForMediaPlayer} from './shared-audio-context-for-media-player';
 
-const MAX_BUFFER_AHEAD_SECONDS = 8;
+const MAX_BUFFER_AHEAD_SECONDS = 2;
 
 type ScheduleAudioNode = (
 	node: AudioBufferSourceNode,

--- a/packages/media/src/make-iterator-with-priming.ts
+++ b/packages/media/src/make-iterator-with-priming.ts
@@ -1,7 +1,7 @@
 import type {AudioBufferSink, WrappedAudioBuffer} from 'mediabunny';
 
 const AUDIO_PRIMING_SECONDS = 0.5;
-const PREDECODE_AHEAD_SECONDS = 8;
+const PREDECODE_AHEAD_SECONDS = 2;
 
 function makePredecodingIterator(
 	inner: AsyncGenerator<WrappedAudioBuffer, void, unknown>,


### PR DESCRIPTION
Issue: When there are multiple media tags, there is no priority mechanism.
Video tags that come later can already decode and schedule audio nodes even though there are more urgent audio nodes.

We will later optimize this, but as an immediate remedy, limiting how far into the future we schedule.