### PR TITLE
`remotion`: Truncate very long data URLs to avoid polluting logs

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -23,6 +23,16 @@ function exponentialBackoff(errorCount: number): number {
 	return 1000 * 2 ** (errorCount - 1);
 }
 
+// Data URLs like the ones from canvas.toDataURL() can be many megabytes, which makes the delayRender() label
+// unreadable and bloats log output
+export function truncateSrcForLabel(src: string): string {
+	if (src.startsWith('data:') && src.length > 100) {
+		return src.slice(0, 60) + '...[' + src.length + ' chars total]';
+	}
+
+	return src;
+}
+
 type NativeImgProps = Omit<
 	React.DetailedHTMLProps<
 		React.ImgHTMLAttributes<HTMLImageElement>,
@@ -183,9 +193,9 @@ const ImgInner: React.FC<
 				);
 				// eslint-disable-next-line no-console
 				console.warn(
-					`Could not load image with source ${
-						imageRef.current?.src as string
-					}, retrying again in ${backoff}ms`,
+					`Could not load image with source ${truncateSrcForLabel(
+						imageRef.current?.src as string,
+					)}, retrying again in ${backoff}ms`,
 				);
 
 				retryIn(backoff);
@@ -194,7 +204,8 @@ const ImgInner: React.FC<
 
 			try {
 				cancelRender(
-					'Error loading image with src: ' + (imageRef.current?.src as string),
+					'Error loading image with src: ' +
+						truncateSrcForLabel(imageRef.current?.src as string),
 				);
 			} catch {
 				// cancelRender() intentionally throws after storing the error in scope.
@@ -222,10 +233,13 @@ const ImgInner: React.FC<
 				return;
 			}
 
-			const newHandle = delayRender('Loading <Img> with src=' + actualSrc, {
-				retries: delayRenderRetries ?? undefined,
-				timeoutInMilliseconds: delayRenderTimeoutInMilliseconds ?? undefined,
-			});
+			const newHandle = delayRender(
+				'Loading <Img> with src=' + truncateSrcForLabel(actualSrc),
+				{
+					retries: delayRenderRetries ?? undefined,
+					timeoutInMilliseconds: delayRenderTimeoutInMilliseconds ?? undefined,
+				},
+			);
 			const unblock =
 				pauseWhenLoading && !isPremounting && !isPostmounting
 					? delayPlayback().unblock
@@ -244,9 +258,9 @@ const ImgInner: React.FC<
 					delete errors.current[imageRef.current?.src as string];
 					// eslint-disable-next-line no-console
 					console.info(
-						`Retry successful - ${
-							imageRef.current?.src as string
-						} is now loaded`,
+						`Retry successful - ${truncateSrcForLabel(
+							imageRef.current?.src as string,
+						)} is now loaded`,
 					);
 				}
 

--- a/packages/core/src/test/truncate-src-for-label.test.ts
+++ b/packages/core/src/test/truncate-src-for-label.test.ts
@@ -1,0 +1,28 @@
+import {expect, test} from 'bun:test';
+import {truncateSrcForLabel} from '../Img.js';
+
+test('leaves http URLs untouched', () => {
+	const src = 'https://example.com/images/hero.png';
+	expect(truncateSrcForLabel(src)).toBe(src);
+});
+
+test('leaves file:// URLs untouched', () => {
+	const src = 'file:///tmp/foo.jpg';
+	expect(truncateSrcForLabel(src)).toBe(src);
+});
+
+test('leaves short data URLs untouched', () => {
+	const src =
+		'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+	expect(src.length).toBeLessThanOrEqual(100);
+	expect(truncateSrcForLabel(src)).toBe(src);
+});
+
+test('truncates large data URLs', () => {
+	const huge = 'data:image/png;base64,' + 'A'.repeat(2_000_000);
+	const result = truncateSrcForLabel(huge);
+
+	expect(result.length).toBeLessThan(200);
+	expect(result.startsWith('data:image/png;base64,')).toBe(true);
+	expect(result).toContain('[' + huge.length + ' chars total]');
+});


### PR DESCRIPTION
We've been working with large images as `<Img>` sources in our compositions and have had >10MB base64'd data URLs appear in our logs when something goes wrong (usually from memory pressure), which makes debugging difficult. This truncates those blobs.

The threshold length I chose is fairly arbitrary, so I'm happy to change it to something else. My working assumption is that showing the first part of the data URL is enough to help track down which image is being shown.

Example:
```
 Tab 0, delayRender()  "Loading <Img> with src=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAADwAAAAhwCAYAAA...[truncated 10635270 chars]" handle was cleared after 236ms
```