### PR TITLE
`template-prompt-to-video`: Add Typecast TTS as alternative provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1976,6 +1976,7 @@
       },
       "devDependencies": {
         "@elevenlabs/elevenlabs-js": "^2.20.0",
+        "@neosapience/typecast-js": "^0.1.8",
         "@remotion/eslint-config-flat": "workspace:*",
         "@types/prompts": "^2.4.9",
         "@types/react": "19.2.7",
@@ -1985,6 +1986,7 @@
         "chalk": "^5.6.2",
         "dotenv": "17.3.1",
         "eslint": "9.19.0",
+        "openai": "^4.0.0",
         "ora": "^9.0.0",
         "prettier": "3.8.1",
         "prompts": "^2.4.2",
@@ -3445,6 +3447,8 @@
     "@mux/upchunk": ["@mux/upchunk@3.5.0", "", { "dependencies": { "event-target-shim": "^6.0.2", "xhr": "^2.6.0" } }, "sha512-D+TtvlujlZQjh5I+vFzJ31h5E1uVpEaLdR8M3BNaCFbVLnFMZs8J/L/fYSUyVGnyHT/yDtPHn/IHKdo3G6oSjA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.7", "", { "dependencies": { "@emnapi/core": "^1.5.0", "@emnapi/runtime": "^1.5.0", "@tybys/wasm-util": "^0.10.1" } }, "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw=="],
+
+    "@neosapience/typecast-js": ["@neosapience/typecast-js@0.1.8", "", {}, "sha512-HpLr6XUQZq4H1AEm8/gcaqClXNoc1u+onrmSCZijnmfrwq7V+hpizgzUU/hjNM9AjMy8pi7RXDGmpiJCsFnEBQ=="],
 
     "@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
 

--- a/packages/template-prompt-to-video/cli/cli.ts
+++ b/packages/template-prompt-to-video/cli/cli.ts
@@ -9,6 +9,7 @@ import * as dotenv from "dotenv";
 import {
   generateAiImage,
   generateVoice,
+  generateVoiceTypecast,
   getGenerateImageDescriptionPrompt,
   getGenerateStoryPrompt,
   openaiStructuredCompletion,
@@ -28,9 +29,14 @@ import { createTimeLineFromStoryWithDetails } from "./timeline";
 
 dotenv.config({ quiet: true });
 
+type TtsProvider = "elevenlabs" | "typecast";
+
 interface GenerateOptions {
   apiKey?: string;
+  ttsProvider?: TtsProvider;
   elevenlabsApiKey?: string;
+  typecastApiKey?: string;
+  voiceId?: string;
   title?: string;
   topic?: string;
 }
@@ -87,8 +93,12 @@ class ContentFS {
 async function generateStory(options: GenerateOptions) {
   try {
     let apiKey = options.apiKey || process.env.OPENAI_API_KEY;
+    const ttsProvider: TtsProvider = options.ttsProvider || "elevenlabs";
     let elevenlabsApiKey =
       options.elevenlabsApiKey || process.env.ELEVENLABS_API_KEY;
+    let typecastApiKey =
+      options.typecastApiKey || process.env.TYPECAST_API_KEY;
+    const voiceId = options.voiceId;
 
     if (!apiKey) {
       const response = await prompts({
@@ -106,7 +116,7 @@ async function generateStory(options: GenerateOptions) {
       apiKey = response.apiKey;
     }
 
-    if (!elevenlabsApiKey) {
+    if (ttsProvider === "elevenlabs" && !elevenlabsApiKey) {
       const response = await prompts({
         type: "password",
         name: "elevenlabsApiKey",
@@ -121,6 +131,23 @@ async function generateStory(options: GenerateOptions) {
       }
 
       elevenlabsApiKey = response.elevenlabsApiKey;
+    }
+
+    if (ttsProvider === "typecast" && !typecastApiKey) {
+      const response = await prompts({
+        type: "password",
+        name: "typecastApiKey",
+        message: "Enter your Typecast API key:",
+        validate: (value) =>
+          value.length > 0 || "Typecast API key is required",
+      });
+
+      if (!response.typecastApiKey) {
+        console.log(chalk.red("API key is required. Exiting..."));
+        process.exit(1);
+      }
+
+      typecastApiKey = response.typecastApiKey;
     }
 
     let { title, topic } = options;
@@ -180,11 +207,15 @@ async function generateStory(options: GenerateOptions) {
         text: item.text,
         imageDescription: item.imageDescription,
         uid: uuidv4(),
-        audioTimestamps: {
-          characters: [],
-          characterStartTimesSeconds: [],
-          characterEndTimesSeconds: [],
-        },
+        ...(ttsProvider === "elevenlabs"
+          ? {
+              audioTimestamps: {
+                characters: [],
+                characterStartTimesSeconds: [],
+                characterEndTimesSeconds: [],
+              },
+            }
+          : { wordTimestamps: [] }),
       };
 
       storyWithDetails.content.push(contentWithDetails);
@@ -205,12 +236,23 @@ async function generateStory(options: GenerateOptions) {
         },
       });
       imagesSpinner.text = `[${i * 2 + 2}/${storyWithDetails.content.length * 2}] Generating voice for ${storyItem.text}`;
-      const timings = await generateVoice(
-        storyItem.text,
-        elevenlabsApiKey!,
-        contentFs.getAudioPath(storyItem.uid),
-      );
-      storyItem.audioTimestamps = timings;
+      if (ttsProvider === "typecast") {
+        const wordTimestamps = await generateVoiceTypecast(
+          storyItem.text,
+          typecastApiKey!,
+          voiceId,
+          contentFs.getAudioPath(storyItem.uid),
+        );
+        storyItem.wordTimestamps = wordTimestamps;
+      } else {
+        const timings = await generateVoice(
+          storyItem.text,
+          elevenlabsApiKey!,
+          voiceId,
+          contentFs.getAudioPath(storyItem.uid),
+        );
+        storyItem.audioTimestamps = timings;
+      }
     }
     contentFs.saveDescriptor(storyWithDetails);
     imagesSpinner.succeed(chalk.green("Images generated!"));
@@ -241,6 +283,20 @@ yargs(hideBin(process.argv))
           type: "string",
           description: "OpenAI API key",
         })
+        .option("tts-provider", {
+          type: "string",
+          choices: ["elevenlabs", "typecast"] as const,
+          default: "elevenlabs",
+          description: "TTS provider to use",
+        })
+        .option("typecast-api-key", {
+          type: "string",
+          description: "Typecast API key (required when --tts-provider=typecast)",
+        })
+        .option("voice-id", {
+          type: "string",
+          description: "TTS voice ID (defaults per provider)",
+        })
         .option("title", {
           alias: "t",
           type: "string",
@@ -256,6 +312,9 @@ yargs(hideBin(process.argv))
     async (argv) => {
       await generateStory({
         apiKey: argv["api-key"],
+        ttsProvider: argv["tts-provider"] as TtsProvider,
+        typecastApiKey: argv["typecast-api-key"],
+        voiceId: argv["voice-id"],
         title: argv.title,
         topic: argv.topic,
       });
@@ -271,6 +330,20 @@ yargs(hideBin(process.argv))
           type: "string",
           description: "OpenAI API key",
         })
+        .option("tts-provider", {
+          type: "string",
+          choices: ["elevenlabs", "typecast"] as const,
+          default: "elevenlabs",
+          description: "TTS provider to use",
+        })
+        .option("typecast-api-key", {
+          type: "string",
+          description: "Typecast API key (required when --tts-provider=typecast)",
+        })
+        .option("voice-id", {
+          type: "string",
+          description: "TTS voice ID (defaults per provider)",
+        })
         .option("title", {
           alias: "t",
           type: "string",
@@ -286,6 +359,9 @@ yargs(hideBin(process.argv))
     async (argv) => {
       await generateStory({
         apiKey: argv["api-key"],
+        ttsProvider: argv["tts-provider"] as TtsProvider,
+        typecastApiKey: argv["typecast-api-key"],
+        voiceId: argv["voice-id"],
         title: argv.title,
         topic: argv.topic,
       });

--- a/packages/template-prompt-to-video/cli/service.ts
+++ b/packages/template-prompt-to-video/cli/service.ts
@@ -1,8 +1,9 @@
 import z from "zod";
 import * as fs from "fs";
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
-import { CharacterAlignmentResponseModel } from "@elevenlabs/elevenlabs-js/api";
+import type { CharacterAlignmentResponseModel } from "@elevenlabs/elevenlabs-js/api";
 import { IMAGE_HEIGHT, IMAGE_WIDTH } from "../src/lib/constants";
+import type { WordTimestamp } from "../src/lib/types";
 
 let apiKey: string | null = null;
 
@@ -150,17 +151,18 @@ const saveBase64ToMp3 = (data: string, path: string) => {
   fs.writeFileSync(path, buffer as Uint8Array);
 };
 
+const DEFAULT_ELEVENLABS_VOICE_ID = "21m00Tcm4TlvDq8ikWAM";
+
 export const generateVoice = async (
   text: string,
   apiKey: string,
+  voiceId = DEFAULT_ELEVENLABS_VOICE_ID,
   path: string,
 ): Promise<CharacterAlignmentResponseModel> => {
   const client = new ElevenLabsClient({
     environment: "https://api.elevenlabs.io",
     apiKey,
   });
-
-  const voiceId = "21m00Tcm4TlvDq8ikWAM";
 
   const data = await client.textToSpeech.convertWithTimestamps(voiceId, {
     text,
@@ -172,4 +174,41 @@ export const generateVoice = async (
 
   saveBase64ToMp3(data.audioBase64, path);
   return data.alignment;
+};
+
+const DEFAULT_TYPECAST_VOICE_ID = "tc_67512e5af2b6dbabce63f92a";
+
+export const generateVoiceTypecast = async (
+  text: string,
+  typecastApiKey: string,
+  voiceId = DEFAULT_TYPECAST_VOICE_ID,
+  path: string,
+): Promise<WordTimestamp[]> => {
+  const { TypecastClient } = await import("@neosapience/typecast-js");
+  const typecast = new TypecastClient({ apiKey: typecastApiKey });
+
+  const audio = await typecast.textToSpeech({
+    text,
+    voice_id: voiceId,
+    model: "ssfm-v30",
+    output: { audio_format: "mp3" },
+  });
+
+  await fs.promises.writeFile(path, new Uint8Array(audio.audioData));
+
+  const OpenAI = (await import("openai")).default;
+  const openai = new OpenAI({ apiKey: apiKey! });
+  const transcription = await openai.audio.transcriptions.create({
+    file: fs.createReadStream(path),
+    model: "whisper-1",
+    response_format: "verbose_json",
+    timestamp_granularities: ["word"],
+  });
+
+  const words = (transcription as unknown as { words?: WordTimestamp[] }).words;
+  if (!words || words.length === 0) {
+    throw new Error("Whisper did not return word-level timestamps");
+  }
+
+  return words;
 };

--- a/packages/template-prompt-to-video/cli/timeline.ts
+++ b/packages/template-prompt-to-video/cli/timeline.ts
@@ -22,86 +22,149 @@ export const createTimeLineFromStoryWithDetails = (
   for (let i = 0; i < storyWithDetails.content.length; i++) {
     const content = storyWithDetails.content[i];
 
-    const lenMs = Math.ceil(
-      content.audioTimestamps.characterEndTimesSeconds[
-        content.audioTimestamps.characterEndTimesSeconds.length - 1
-      ] * 1000,
-    );
+    if (content.audioTimestamps) {
+      // ElevenLabs character-level timestamps
+      const {
+        characterStartTimesSeconds: charStarts,
+        characterEndTimesSeconds: charEnds,
+      } = content.audioTimestamps;
 
-    const bgElem: BackgroundElement = {
-      startMs: durationMs,
-      endMs: durationMs + lenMs,
-      imageUrl: content.uid,
-      enterTransition: "blur",
-      exitTransition: "blur",
-      animations: getBgAnimations(lenMs, zoomIn),
-    };
+      const lenMs = Math.ceil(charEnds[charEnds.length - 1] * 1000);
 
-    timeline.elements.push(bgElem);
-    timeline.audio.push({
-      startMs: durationMs,
-      endMs: durationMs + lenMs,
-      audioUrl: content.uid,
-    });
+      const bgElem: BackgroundElement = {
+        startMs: durationMs,
+        endMs: durationMs + lenMs,
+        imageUrl: content.uid,
+        enterTransition: "blur",
+        exitTransition: "blur",
+        animations: getBgAnimations(lenMs, zoomIn),
+      };
 
-    // hadnle text word by word
-    const words = content.text.split(" ");
-    const {
-      characterStartTimesSeconds: character_start_times_seconds,
-      characterEndTimesSeconds: character_end_times_seconds,
-    } = content.audioTimestamps;
+      timeline.elements.push(bgElem);
+      timeline.audio.push({
+        startMs: durationMs,
+        endMs: durationMs + lenMs,
+        audioUrl: content.uid,
+      });
 
-    const MaxSentenseSizeChars = 14;
+      const words = content.text.split(" ");
+      const MaxSentenseSizeChars = 14;
 
-    let currentText = "";
-    let currentStartMs = character_start_times_seconds[0] * 1000 + durationMs;
-    let currentEndMs = durationMs;
-    let currentCharIndex = 0;
+      let currentText = "";
+      let currentStartMs = charStarts[0] * 1000 + durationMs;
+      let currentEndMs = durationMs;
+      let currentCharIndex = 0;
 
-    for (const word of words) {
-      if ((currentText + word).length > MaxSentenseSizeChars) {
+      for (const word of words) {
+        if ((currentText + word).length > MaxSentenseSizeChars) {
+          const textElem: TextElement = {
+            startMs: currentStartMs,
+            endMs: currentEndMs,
+            text: currentText.trim(),
+            position: "center",
+            animations: getTextAnimations(),
+          };
+
+          timeline.text.push(textElem);
+
+          currentText = "";
+          currentStartMs = currentEndMs;
+        }
+
+        currentText += `${word} `;
+        for (let j = 0; j < word.length; j++) {
+          currentEndMs = charEnds[currentCharIndex] * 1000 + durationMs;
+          currentCharIndex++;
+        }
+
+        currentEndMs = charEnds[currentCharIndex] * 1000 + durationMs;
+        currentCharIndex++;
+      }
+
+      if (currentText.trim().length > 0) {
         const textElem: TextElement = {
           startMs: currentStartMs,
-          endMs: currentEndMs,
+          endMs: charEnds[charEnds.length - 1] * 1000 + durationMs,
           text: currentText.trim(),
           position: "center",
           animations: getTextAnimations(),
         };
 
         timeline.text.push(textElem);
-
-        currentText = "";
-        currentStartMs = currentEndMs;
       }
 
-      currentText += `${word} `;
-      for (let i = 0; i < word.length; i++) {
-        currentEndMs =
-          character_end_times_seconds[currentCharIndex] * 1000 + durationMs;
-        currentCharIndex++;
-      }
+      durationMs += lenMs;
+    } else if (content.wordTimestamps) {
+      // Typecast word-level timestamps (via Whisper)
+      const { wordTimestamps } = content;
 
-      currentEndMs =
-        character_end_times_seconds[currentCharIndex] * 1000 + durationMs;
-      currentCharIndex++;
-    }
+      const lenMs = Math.ceil(
+        wordTimestamps[wordTimestamps.length - 1].end * 1000,
+      );
 
-    if (currentText.trim().length > 0) {
-      const textElem: TextElement = {
-        startMs: currentStartMs,
-        endMs:
-          character_end_times_seconds[character_end_times_seconds.length - 1] *
-            1000 +
-          durationMs,
-        text: currentText.trim(),
-        position: "center",
-        animations: getTextAnimations(),
+      const bgElem: BackgroundElement = {
+        startMs: durationMs,
+        endMs: durationMs + lenMs,
+        imageUrl: content.uid,
+        enterTransition: "blur",
+        exitTransition: "blur",
+        animations: getBgAnimations(lenMs, zoomIn),
       };
 
-      timeline.text.push(textElem);
-    }
+      timeline.elements.push(bgElem);
+      timeline.audio.push({
+        startMs: durationMs,
+        endMs: durationMs + lenMs,
+        audioUrl: content.uid,
+      });
 
-    durationMs += lenMs;
+      const MaxSentenseSizeChars = 14;
+      let currentWords: string[] = [];
+      let currentStartMs = wordTimestamps[0].start * 1000 + durationMs;
+      let currentEndMs = durationMs;
+
+      for (const wordTs of wordTimestamps) {
+        const candidateText = [...currentWords, wordTs.word].join(" ");
+
+        if (
+          candidateText.length > MaxSentenseSizeChars &&
+          currentWords.length > 0
+        ) {
+          const endMs = Math.max(currentEndMs, currentStartMs + 100);
+          const textElem: TextElement = {
+            startMs: currentStartMs,
+            endMs,
+            text: currentWords.join(" "),
+            position: "center",
+            animations: getTextAnimations(),
+          };
+
+          timeline.text.push(textElem);
+
+          currentWords = [];
+          currentStartMs = endMs;
+        }
+
+        currentWords.push(wordTs.word);
+        currentEndMs = wordTs.end * 1000 + durationMs;
+      }
+
+      if (currentWords.length > 0) {
+        const lastEndMs =
+          wordTimestamps[wordTimestamps.length - 1].end * 1000 + durationMs;
+        const textElem: TextElement = {
+          startMs: currentStartMs,
+          endMs: Math.max(lastEndMs, currentStartMs + 100),
+          text: currentWords.join(" "),
+          position: "center",
+          animations: getTextAnimations(),
+        };
+
+        timeline.text.push(textElem);
+      }
+
+      durationMs += lenMs;
+    }
 
     zoomIn = !zoomIn;
   }

--- a/packages/template-prompt-to-video/package.json
+++ b/packages/template-prompt-to-video/package.json
@@ -25,6 +25,8 @@
   },
   "devDependencies": {
     "@elevenlabs/elevenlabs-js": "^2.20.0",
+    "@neosapience/typecast-js": "^0.1.8",
+    "openai": "^4.0.0",
     "@remotion/eslint-config-flat": "workspace:*",
     "@types/prompts": "^2.4.9",
     "@types/react": "19.2.7",

--- a/packages/template-prompt-to-video/src/lib/types.ts
+++ b/packages/template-prompt-to-video/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { CharacterAlignmentResponseModel } from "@elevenlabs/elevenlabs-js/api";
+import type { CharacterAlignmentResponseModel } from "@elevenlabs/elevenlabs-js/api";
 import { z } from "zod";
 
 const BackgroundTransitionTypeSchema = z.union([
@@ -92,9 +92,16 @@ export interface StoryMetadataWithDetails {
   content: ContentItemWithDetails[];
 }
 
+export interface WordTimestamp {
+  word: string;
+  start: number;
+  end: number;
+}
+
 export interface ContentItemWithDetails {
   text: string;
   imageDescription: string;
   uid: string;
-  audioTimestamps: CharacterAlignmentResponseModel;
+  audioTimestamps?: CharacterAlignmentResponseModel;
+  wordTimestamps?: WordTimestamp[];
 }


### PR DESCRIPTION
## Summary
- Add `--tts-provider` CLI option (`elevenlabs` | `typecast`) to support Typecast TTS alongside existing ElevenLabs integration
- When using Typecast, word-level timestamps are extracted via OpenAI Whisper
- ElevenLabs remains the default — existing behavior is completely unchanged
- Add `--voice-id` option to override the default voice for either provider

## Changes
- `cli.ts`: Add `--tts-provider`, `--typecast-api-key`, `--voice-id` options with provider-specific API key prompts
- `service.ts`: Add `generateVoiceTypecast()` using `@neosapience/typecast-js` + Whisper for timestamps
- `timeline.ts`: Handle both character-level (ElevenLabs) and word-level (Typecast) timestamps
- `types.ts`: Add `WordTimestamp` type, make timestamp fields optional to support both formats
- `package.json`: Add `@neosapience/typecast-js` and `openai` as devDependencies

## Usage
```bash
# ElevenLabs (default, unchanged)
bun cli/cli.ts generate

# Typecast
bun cli/cli.ts generate --tts-provider typecast

# Custom voice ID
bun cli/cli.ts generate --voice-id <id>
```

## Test plan
- [x] `--tts-provider typecast` generates story with Typecast TTS + Whisper timestamps
- [x] Default (no `--tts-provider`) uses ElevenLabs as before
- [x] `--voice-id` override works for both providers
- [x] TypeScript compiles with no errors
- [x] Generated videos render correctly in Remotion Studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)