### PR TITLE
`@remotion/promo-pages`: strip CSS Modules :global() from video-player.css for Turbopack consumers

### DIFF
--- a/packages/promo-pages/src/components/homepage/video-player.css
+++ b/packages/promo-pages/src/components/homepage/video-player.css
@@ -1,9 +1,9 @@
-:global(:root) {
+:root {
 	--plyr-color-main: #1b1b1b;
 	--plyr-range-fill-background: #ccc;
 }
-:global(.plyr__controls button),
-:global(.plyr__controls input) {
+.plyr__controls button,
+.plyr__controls input {
 	cursor: pointer;
 }
 .video-container {
@@ -11,7 +11,7 @@
 	margin-top: 40px;
 	border-radius: 30px;
 }
-:global(.plyr:fullscreen video) {
+.plyr:fullscreen video {
 	max-width: initial;
 	max-height: initial;
 	width: 100%;


### PR DESCRIPTION
## Summary

`packages/promo-pages/src/components/homepage/video-player.css` uses CSS Modules `:global()` selector syntax in a plain `.css` file. webpack's `css-loader` historically silently accepted this as a no-op, but Turbopack's CSS parser correctly rejects `:global()` outside of CSS Modules context — breaking consumer apps that build with `next build --turbopack` (beta in Next.js 15.5+, default in Next.js 16).

This PR strips the 4 `:global()` wrappers. The change is **semantically a no-op for browsers** because plain CSS is already global by default — the `:global()` wrappers were dead syntactic sugar. After this PR the file is valid both as plain CSS (Turbopack-friendly) and as it always was at runtime (webpack-friendly).

## The error this fixes

```
./node_modules/@remotion/promo-pages/dist/Homepage.css:2:9
Parsing CSS source code failed
 1 | /* src/components/homepage/video-player.css */
 2 | :global(:root) {
   |         ^
 3 |   --plyr-color-main: #1b1b1b;
 4 |   --plyr-range-fill-background: #ccc;
 5 | }

'global' is not recognized as a valid pseudo-class.
```

## Diff

```diff
-:global(:root) {
+:root {
 	--plyr-color-main: #1b1b1b;
 	--plyr-range-fill-background: #ccc;
 }
-:global(.plyr__controls button),
-:global(.plyr__controls input) {
+.plyr__controls button,
+.plyr__controls input {
 	cursor: pointer;
 }
 .video-container {
 	margin-bottom: 40px;
 	margin-top: 40px;
 	border-radius: 30px;
 }
-:global(.plyr:fullscreen video) {
+.plyr:fullscreen video {
 	max-width: initial;
 	max-height: initial;
 	width: 100%;
 	height: 100%;
 }
```

4 lines changed. Pure selector cleanup. No JS, no TS, no tests, no docs.

## Verification

- `bun run lint` (in `packages/promo-pages`): no new errors. The 16 pre-existing TypeScript/ESLint errors in the package are unrelated to this CSS change (they're about missing workspace deps and pre-existing implicit-`any` annotations) and identical before vs after this commit.
- Browser semantics: identical before and after — plain CSS selectors are global by default, so `:global(.plyr__controls button)` and `.plyr__controls button` produce the exact same matched element set.

## Why this matters

Tracked in #7057. Blocks the Turbopack migration of [remotion-dev/pro](https://github.com/remotion-dev/pro) (see [remotion-dev/pro#467](https://github.com/remotion-dev/pro/issues/467)). After this lands and a new `@remotion/promo-pages` is published, the consumer app needs only a one-line dep bump to unblock its Turbopack build.

The same fix benefits any other future Turbopack consumer of `@remotion/promo-pages/dist/Homepage.css`.

## Alternatives considered

- **`bun patch` stopgap downstream** — fragile, leaks node_modules patches into consumer repos
- **Inline the Pricing component into the consumer** — would require vendoring ~614 lines across 5 files with manual sync forever
- **Rename the CSS file to `Homepage.module.css`** — would require changing the package's public API and breaking all consumers' import paths

This upstream fix is the smallest, cleanest, and most consumer-friendly path.

Closes #7057.