### PR TITLE
Add Banger.Show skill documentation

### DIFF
--- a/.claude/skills/banger-show/SKILL.md
+++ b/.claude/skills/banger-show/SKILL.md
@@ -3,131 +3,176 @@ name: banger-show
 description: Create music videos and audio-reactive visuals using Banger.Show. Use when helping users build projects on the Banger.Show platform — lyric videos, audio visualizers, 3D visuals, camera animations, and exporting for YouTube, Spotify Canvas, and social media.
 ---
 
-# Banger.Show
+# Creating with Banger.Show
 
-Banger.Show (https://banger.show) is an online music video creation platform for musicians and artists. It renders audio-reactive 3D visuals, lyric videos, and music visualizers using a timeline-based editor. Videos can be exported for YouTube, Spotify Canvas, and social media.
+Banger.Show (https://banger.show) is a browser-based music video editor. When this skill is invoked, guide the user through creating their video step by step — gathering what they need, walking through each part of the editor, and ending with an exported file.
 
-Banger.Show uses Remotion internally for its cloud rendering pipeline.
+---
 
-## Getting Started
+## Step 1: Understand the goal
 
-1. Go to https://banger.show and sign in
-2. Create a new project and **upload your audio track** (MP3, WAV, or AAC)
-3. Choose a **template** or start from a blank canvas
-4. Customize visuals using the Clips panel, Timeline, and property editors
-5. Preview in real-time, then **render and export**
+Ask the user:
 
-## Lyric Videos
+1. **What type of video?**
+   - Lyric video (animated text synced to the track)
+   - Audio visualizer (shapes/shaders that react to the music)
+   - Spotify Canvas (3–8 second looping clip, 9:16)
+   - General music video with 3D objects
+   - Multiple types combined
 
-Create animated text synchronized to your track.
+2. **What platform?** — determines aspect ratio and resolution:
+   - YouTube → 16:9, 1080p or 4K
+   - Spotify Canvas → 9:16, max 8 seconds, must loop
+   - Instagram Reel / TikTok → 9:16, 1080×1920
+   - Instagram Post → 1:1, 1080×1080
 
-1. **Add a Text clip** from the Clips panel
-2. Type or paste your lyrics into the text editor
-3. **Set in/out points** on the timeline for each lyric line — scrub to the right moment and trim
-4. **Choose an entrance/exit animation**: fade, slide, typewriter, scale, etc.
-5. **Style the text**: font family, size, color, gradient, letter spacing, 3D depth
-6. Repeat for each lyric line, stacking clips in the timeline
+3. **What assets do they have ready?**
+   - Audio file (MP3, WAV, or AAC) — required
+   - Lyrics or lyric SRT file — for lyric videos
+   - Artwork, logo, or photos — for 3D images or logo extrusion
+   - 3D model (GLB/GLTF) — optional
 
-**Tips:**
-- Work verse-by-verse — add all clips for a section before moving to the next
-- Use the snap-to-playhead feature for precise timing
-- Duplicate clips to reuse styling across multiple lines
+4. **What visual vibe?** — dark/moody, bright/colorful, minimal, glitchy/VHS, futuristic
 
-## Audio Reactivity
+---
 
-Link visual properties to your music so they pulse and react automatically.
+## Step 2: Open Banger.Show and create a project
 
-1. **Select a clip** in the timeline or canvas
-2. Open the **Audio Reactivity panel** in the properties sidebar
-3. **Choose a property** to animate: scale, opacity, position X/Y, rotation, blur, etc.
-4. **Choose a frequency band**:
-   - **Bass** (20–250 Hz) — kick drums, bass lines; gives punchy, heavy reactions
-   - **Mid** (250 Hz–2 kHz) — melody, vocals; good for sustained movement
-   - **High** (2–20 kHz) — hi-hats, cymbals; creates fast, subtle shimmer
-   - **Overall loudness** — reacts to the full mix energy
-5. **Adjust sensitivity** (how strongly the audio drives the property) and **multiplier** (scales the effect range)
-6. Preview with the play button; tweak until it feels right
+1. Go to **https://banger.show** and sign in
+2. Click **New Project**
+3. **Upload the audio file** (from device or Dropbox)
+4. Select the portion of the track to use (drag the trim handles) — for Spotify Canvas, keep it 3–8 seconds
+5. Choose a **starting template** that matches the vibe, or start blank
 
-**Built-in visualizers** (add from the Clips panel):
-- Waveform, Spectre, Oscilloscope, Ferro Fluid, Pulsar, Circle
+> At this point the timeline is set to the track duration. Everything from here is adding and adjusting clips.
 
-## Camera Movements
+---
 
-Add cinematic motion to your 3D scene.
+## Step 3: Build the scene
+
+Follow the sub-guide for whichever type was chosen in Step 1.
+
+### 3A — Lyric Video
+
+1. **Add a Text clip**: Clips panel → Text → drag onto the timeline at the right time position
+2. Type the first lyric line into the text editor
+3. **Trim the clip** so it covers exactly when that line is sung — drag the clip edges in the timeline
+4. **Animate the entrance**: in clip properties, set an entrance animation (fade, slide up, typewriter, scale)
+5. **Style**: font, size, color/gradient, letter spacing, 3D depth
+6. Repeat for each lyric line — use **Duplicate** (Cmd/Ctrl+D) to copy styling across lines
+7. Suggested background: add an audio-reactive background clip (Spectre or Waveform) behind the text, or upload the album artwork as a 3D image
+
+### 3B — Audio Visualizer
+
+1. **Add a visualizer clip**: Clips panel → Visualizers → choose one:
+   - **Waveform** — classic wave; reacts to full spectrum
+   - **Spectre** — frequency bars; shows bass vs. treble separation
+   - **Oscilloscope** — raw waveform trace; precise and technical
+   - **Ferro Fluid** — organic blob that pulses; great for dark/moody
+   - **Pulsar** — radial rings; energetic
+   - **Circle** — circular waveform; minimal and clean
+2. Drag the visualizer clip across the full timeline
+3. In clip properties, set **colors** to match the artwork/brand palette
+4. Add album artwork or logo as a 3D image in the center of the scene (Clips panel → Image → select file)
+
+### 3C — Spotify Canvas
+
+- Keep the total duration **3–8 seconds** (already set at trim step)
+- Use a looping-friendly visualizer (Pulsar or Circle loop naturally)
+- Set aspect ratio to **9:16** in project settings
+- Make sure the last frame transitions cleanly into the first — preview on loop before rendering
+
+### 3D — 3D Objects
+
+1. **Upload a 3D model**: Clips panel → 3D Model → Upload (GLB/GLTF)
+   — or — browse **Sketchfab** from inside the editor to find a free CC-licensed model
+   — or — use **Logo to 3D**: provide a PNG with transparent background; the tool extrudes it
+2. Drag the model clip onto the timeline
+3. In clip properties, adjust **position, rotation, scale** and set **material** (color, roughness, metalness, emissive glow)
+4. Drag & drop the model onto the timeline like a video clip to set its duration
+
+---
+
+## Step 4: Add audio reactivity
+
+For any clip (text, 3D object, image, visualizer):
+
+1. Select the clip in the timeline
+2. Open **Audio Reactivity** panel
+3. Choose a **property** to animate: scale, opacity, position X/Y/Z, rotation, blur
+4. Choose a **frequency band**:
+   - **Bass** (20–250 Hz) — kick and bass; heavy, punchy reactions
+   - **Mid** (250 Hz–2 kHz) — melody, vocals; sustained movement
+   - **High** (2–20 kHz) — hi-hats, cymbals; fast shimmer
+   - **Loudness** — overall energy; follows the mix
+5. Adjust **sensitivity** and **multiplier** — preview in real-time to tune it
+
+**Typical setups by vibe:**
+- Heavy bass drop: scale or Z-position on Bass, high multiplier
+- Vocal glow: opacity or emissive on Mid
+- Hi-hat shimmer: rotation or blur on High, low multiplier
+
+---
+
+## Step 5: Camera movement
 
 1. Open the **Camera panel**
-2. Choose a movement approach:
-   - **Pre-defined animations** — pan, zoom, orbit, dolly; pick and apply directly
-   - **Keyframe animation** — position the camera manually at a frame, click "Add Keyframe", move to another frame, reposition, repeat
-   - **Bass-reactive bumping** — camera shakes or pulses in sync with low frequencies; configure intensity and direction
-3. Adjust **easing** between keyframes: linear, ease-in, ease-out, ease-in-out
-4. Use **orbit mode** to rotate around a central subject automatically
+2. To navigate the scene: use **WASD** keys (first-person fly mode)
+3. Choose a movement type:
+   - **Pre-defined**: pick a preset (pan, orbit, dolly, zoom) — it animates the whole timeline automatically
+   - **Keyframe**: fly to a position → click **Add Keyframe** → scrub to another time → reposition → repeat
+   - **Bass-reactive bumping**: in Camera panel, enable bump → link to Bass frequency → set intensity
+4. Adjust easing between keyframes (linear, ease-in-out)
 
 **Tips:**
-- Subtle slow camera drift reads well on loop videos (Spotify Canvas)
-- Bass bumping on the Z axis (push/pull) creates an impactful drop effect
-- Lock camera Y position to avoid unwanted vertical drift on simple pans
+- A slow orbit around a 3D logo works well for Spotify Canvas loops
+- Bass-bump on Z axis (push toward camera) gives a strong drop effect
+- Keep camera movement subtle for lyric videos so text stays readable
 
-## Clips and Timeline
+---
 
-The timeline is the core editing surface.
+## Step 6: Add post-processing effects
 
-- **Add clips**: open the Clips panel → drag onto the timeline or click to insert at playhead
-- **Clip types**: 3D objects, images, text, video, audio-reactive backgrounds (GLSL shaders), effects overlays
-- **Trim**: drag the left or right edge of a clip to adjust its start/end
-- **Move**: drag the clip body to shift its position in time
-- **Layer order**: clips higher in the stack appear in front; drag to reorder
-- **Transitions**: right-click the boundary between two clips to add a transition (fade, wipe, dissolve)
-- **Duplicate**: Cmd/Ctrl+D to copy a clip with all its settings
+Add from the **Effects panel** (applied globally):
 
-## 3D Objects
+| Goal | Effect to use |
+|------|--------------|
+| Dreamy glow | Bloom |
+| Vintage / retro | VHS + Scanline + Film Grain |
+| Color grade to match artwork | Hue/Saturation + Color Grading |
+| Cinematic depth | Autofocus (depth of field) + Vignette |
+| Glitchy / cyberpunk | Chromatic Aberration + Noise |
 
-- **Upload your own model**: GLB or GLTF format; drag into the editor or use File → Import
-- **Browse Sketchfab**: search thousands of free CC-licensed 3D models from inside the editor
-- **Logo to 3D**: use the built-in tool to extrude your artist logo (PNG with transparent background) into a 3D object
-- **Images and text** are automatically given 3D depth — adjust extrusion depth in the properties panel
-- **Materials**: change color, roughness, metalness, and emissive glow on any 3D object
+Stack multiple effects — order matters, they apply top to bottom.
 
-## Post-Processing Effects
+---
 
-Effects are applied globally to the scene. Add them from the Effects panel.
+## Step 7: Preview and adjust
 
-| Category   | Effects |
-|------------|---------|
-| Color      | Hue/Saturation, Color Grading, Bloom |
-| Distortion | VHS, Chromatic Aberration, Scanline |
-| Depth      | Autofocus (depth of field), Vignette |
-| Texture    | Noise, Film Grain |
+1. Press **Play** to preview the full video with audio
+2. Check that:
+   - Audio reactivity feels right (not too subtle, not too jittery)
+   - Lyrics appear and disappear at the right moments
+   - Camera movement doesn't distract from the main visual focus
+   - The loop point is clean (for Spotify Canvas)
+3. Tweak anything that feels off
 
-Stack multiple effects; order matters — effects are applied top to bottom.
+---
 
-## Export Settings
+## Step 8: Render and export
 
-Open **File → Export** to configure your render.
+1. **File → Export**
+2. Set **resolution** and **format**:
+   - YouTube: 1080p or 4K, H.264 or H.265, 30fps
+   - Spotify Canvas: 1080×1920 (9:16), H.264, 30fps, 3–8 seconds
+   - Instagram/TikTok: 1080×1920 (9:16) or 1080×1080 (1:1), H.264, 30fps
+3. Click **Render** — typically takes about a minute
+4. Preview the result, then **Download**
+5. To share: copy the project link from **File → Share** to let others view or collaborate
 
-| Setting    | Options |
-|------------|---------|
-| Resolution | 720p, 1080p, 1440p, 4K (3840×2160) |
-| Format     | MP4 (H.264 or H.265) |
-| HDR        | Available for supported bundles |
-| Frame rate | 24, 30, 60 fps |
-
-**Platform presets:**
-
-| Platform        | Aspect Ratio | Max Duration | Notes |
-|-----------------|--------------|--------------|-------|
-| YouTube         | 16:9         | Full track   | 1080p or 4K recommended |
-| Spotify Canvas  | 9:16         | 3–8 seconds  | Must loop cleanly |
-| Instagram Reel  | 9:16         | Up to 90s    | 1080×1920 |
-| Instagram Post  | 1:1          | Up to 60s    | 1080×1080 |
-| TikTok          | 9:16         | Up to 10 min | 1080×1920 |
-
-**Tips:**
-- For Spotify Canvas: trim the project to exactly 3–8 seconds and ensure the last frame blends into the first for a seamless loop
-- H.265 produces smaller files at the same quality; use H.264 for broadest compatibility
-- Render at 1080p for social; 4K for official YouTube releases
+---
 
 ## Reference
 
 - Guides: https://banger.show/guides
-- Homepage: https://banger.show
+- Discord (help & feedback): linked from the Banger.Show site

--- a/.claude/skills/banger-show/SKILL.md
+++ b/.claude/skills/banger-show/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: banger-show
+description: Create music videos and audio-reactive visuals using Banger.Show. Use when helping users build projects on the Banger.Show platform — lyric videos, audio visualizers, 3D visuals, camera animations, and exporting for YouTube, Spotify Canvas, and social media.
+---
+
+# Banger.Show
+
+Banger.Show (https://banger.show) is an online music video creation platform for musicians and artists. It renders audio-reactive 3D visuals, lyric videos, and music visualizers using a timeline-based editor. Videos can be exported for YouTube, Spotify Canvas, and social media.
+
+Banger.Show uses Remotion internally for its cloud rendering pipeline.
+
+## Getting Started
+
+1. Go to https://banger.show and sign in
+2. Create a new project and **upload your audio track** (MP3, WAV, or AAC)
+3. Choose a **template** or start from a blank canvas
+4. Customize visuals using the Clips panel, Timeline, and property editors
+5. Preview in real-time, then **render and export**
+
+## Lyric Videos
+
+Create animated text synchronized to your track.
+
+1. **Add a Text clip** from the Clips panel
+2. Type or paste your lyrics into the text editor
+3. **Set in/out points** on the timeline for each lyric line — scrub to the right moment and trim
+4. **Choose an entrance/exit animation**: fade, slide, typewriter, scale, etc.
+5. **Style the text**: font family, size, color, gradient, letter spacing, 3D depth
+6. Repeat for each lyric line, stacking clips in the timeline
+
+**Tips:**
+- Work verse-by-verse — add all clips for a section before moving to the next
+- Use the snap-to-playhead feature for precise timing
+- Duplicate clips to reuse styling across multiple lines
+
+## Audio Reactivity
+
+Link visual properties to your music so they pulse and react automatically.
+
+1. **Select a clip** in the timeline or canvas
+2. Open the **Audio Reactivity panel** in the properties sidebar
+3. **Choose a property** to animate: scale, opacity, position X/Y, rotation, blur, etc.
+4. **Choose a frequency band**:
+   - **Bass** (20–250 Hz) — kick drums, bass lines; gives punchy, heavy reactions
+   - **Mid** (250 Hz–2 kHz) — melody, vocals; good for sustained movement
+   - **High** (2–20 kHz) — hi-hats, cymbals; creates fast, subtle shimmer
+   - **Overall loudness** — reacts to the full mix energy
+5. **Adjust sensitivity** (how strongly the audio drives the property) and **multiplier** (scales the effect range)
+6. Preview with the play button; tweak until it feels right
+
+**Built-in visualizers** (add from the Clips panel):
+- Waveform, Spectre, Oscilloscope, Ferro Fluid, Pulsar, Circle
+
+## Camera Movements
+
+Add cinematic motion to your 3D scene.
+
+1. Open the **Camera panel**
+2. Choose a movement approach:
+   - **Pre-defined animations** — pan, zoom, orbit, dolly; pick and apply directly
+   - **Keyframe animation** — position the camera manually at a frame, click "Add Keyframe", move to another frame, reposition, repeat
+   - **Bass-reactive bumping** — camera shakes or pulses in sync with low frequencies; configure intensity and direction
+3. Adjust **easing** between keyframes: linear, ease-in, ease-out, ease-in-out
+4. Use **orbit mode** to rotate around a central subject automatically
+
+**Tips:**
+- Subtle slow camera drift reads well on loop videos (Spotify Canvas)
+- Bass bumping on the Z axis (push/pull) creates an impactful drop effect
+- Lock camera Y position to avoid unwanted vertical drift on simple pans
+
+## Clips and Timeline
+
+The timeline is the core editing surface.
+
+- **Add clips**: open the Clips panel → drag onto the timeline or click to insert at playhead
+- **Clip types**: 3D objects, images, text, video, audio-reactive backgrounds (GLSL shaders), effects overlays
+- **Trim**: drag the left or right edge of a clip to adjust its start/end
+- **Move**: drag the clip body to shift its position in time
+- **Layer order**: clips higher in the stack appear in front; drag to reorder
+- **Transitions**: right-click the boundary between two clips to add a transition (fade, wipe, dissolve)
+- **Duplicate**: Cmd/Ctrl+D to copy a clip with all its settings
+
+## 3D Objects
+
+- **Upload your own model**: GLB or GLTF format; drag into the editor or use File → Import
+- **Browse Sketchfab**: search thousands of free CC-licensed 3D models from inside the editor
+- **Logo to 3D**: use the built-in tool to extrude your artist logo (PNG with transparent background) into a 3D object
+- **Images and text** are automatically given 3D depth — adjust extrusion depth in the properties panel
+- **Materials**: change color, roughness, metalness, and emissive glow on any 3D object
+
+## Post-Processing Effects
+
+Effects are applied globally to the scene. Add them from the Effects panel.
+
+| Category   | Effects |
+|------------|---------|
+| Color      | Hue/Saturation, Color Grading, Bloom |
+| Distortion | VHS, Chromatic Aberration, Scanline |
+| Depth      | Autofocus (depth of field), Vignette |
+| Texture    | Noise, Film Grain |
+
+Stack multiple effects; order matters — effects are applied top to bottom.
+
+## Export Settings
+
+Open **File → Export** to configure your render.
+
+| Setting    | Options |
+|------------|---------|
+| Resolution | 720p, 1080p, 1440p, 4K (3840×2160) |
+| Format     | MP4 (H.264 or H.265) |
+| HDR        | Available for supported bundles |
+| Frame rate | 24, 30, 60 fps |
+
+**Platform presets:**
+
+| Platform        | Aspect Ratio | Max Duration | Notes |
+|-----------------|--------------|--------------|-------|
+| YouTube         | 16:9         | Full track   | 1080p or 4K recommended |
+| Spotify Canvas  | 9:16         | 3–8 seconds  | Must loop cleanly |
+| Instagram Reel  | 9:16         | Up to 90s    | 1080×1920 |
+| Instagram Post  | 1:1          | Up to 60s    | 1080×1080 |
+| TikTok          | 9:16         | Up to 10 min | 1080×1920 |
+
+**Tips:**
+- For Spotify Canvas: trim the project to exactly 3–8 seconds and ensure the last frame blends into the first for a seamless loop
+- H.265 produces smaller files at the same quality; use H.264 for broadest compatibility
+- Render at 1080p for social; 4K for official YouTube releases
+
+## Reference
+
+- Guides: https://banger.show/guides
+- Homepage: https://banger.show


### PR DESCRIPTION
## Description

Adds a new Claude skill for Banger.Show, an online music video creation platform. This skill documentation enables Claude to help users build projects on Banger.Show, including lyric videos, audio visualizers, 3D visuals, camera animations, and exporting for YouTube, Spotify Canvas, and social media.

## Changes

- Added `.claude/skills/banger-show/SKILL.md` with comprehensive documentation covering:
  - Platform overview and getting started guide
  - Lyric video creation workflow
  - Audio reactivity configuration (frequency bands, sensitivity, multipliers)
  - Camera movement techniques (keyframes, pre-defined animations, bass-reactive effects)
  - Timeline and clips management
  - 3D object handling (uploads, Sketchfab integration, logo extrusion)
  - Post-processing effects (color, distortion, depth, texture)
  - Export settings and platform-specific presets (YouTube, Spotify Canvas, Instagram, TikTok)
  - Tips and best practices throughout

## Test Plan

N/A - Documentation only. The skill file follows the established format and can be validated by the skill loading system.

https://claude.ai/code/session_01JgcpegZAqUyitZF8Zu3wXu