### PR TITLE
feat(renderer): add optional bitsPerMb for ProRes encoding

### DIFF
--- a/packages/renderer/src/ffmpeg-args.ts
+++ b/packages/renderer/src/ffmpeg-args.ts
@@ -20,6 +20,7 @@ const firstEncodingStepOnly = ({
 	encodingMaxRate,
 	encodingBufferSize,
 	hardwareAcceleration,
+	bitsPerMb,
 }: {
 	hasPreencoded: boolean;
 	proResProfileName: string | null;
@@ -31,6 +32,7 @@ const firstEncodingStepOnly = ({
 	encodingMaxRate: string | null;
 	encodingBufferSize: string | null;
 	hardwareAcceleration: HardwareAccelerationOption;
+	bitsPerMb: number | undefined;
 }): string[][] => {
 	if (hasPreencoded || codec === 'gif') {
 		return [];
@@ -55,6 +57,7 @@ const firstEncodingStepOnly = ({
 			encodingBufferSize,
 			hardwareAcceleration,
 		}),
+		bitsPerMb !== undefined ? ['-bits_per_mb', String(bitsPerMb)] : null,
 	].filter(truthy);
 };
 
@@ -72,6 +75,7 @@ export const generateFfmpegArgs = ({
 	hardwareAcceleration,
 	indent,
 	logLevel,
+	bitsPerMb,
 }: {
 	hasPreencoded: boolean;
 	proResProfileName: string | null;
@@ -86,6 +90,7 @@ export const generateFfmpegArgs = ({
 	hardwareAcceleration: HardwareAccelerationOption;
 	indent: boolean;
 	logLevel: LogLevel;
+	bitsPerMb?: number | undefined;
 }): string[][] => {
 	const encoderSettings = getCodecName({
 		codec,
@@ -164,6 +169,7 @@ export const generateFfmpegArgs = ({
 			encodingBufferSize,
 			x264Preset,
 			hardwareAcceleration,
+			bitsPerMb,
 		}),
 	].filter(truthy);
 };

--- a/packages/renderer/src/prespawn-ffmpeg.ts
+++ b/packages/renderer/src/prespawn-ffmpeg.ts
@@ -58,6 +58,7 @@ type PreStitcherOptions = {
 	colorSpace: ColorSpace | null;
 	binariesDirectory: string | null;
 	hardwareAcceleration: HardwareAccelerationOption;
+	bitsPerMb?: number | undefined;
 };
 
 export const prespawnFfmpeg = (options: PreStitcherOptions) => {
@@ -112,6 +113,7 @@ export const prespawnFfmpeg = (options: PreStitcherOptions) => {
 			hardwareAcceleration: options.hardwareAcceleration,
 			indent: options.indent,
 			logLevel: options.logLevel,
+			bitsPerMb: options.bitsPerMb,
 		}),
 
 		'-y',

--- a/packages/renderer/src/prores-profile.ts
+++ b/packages/renderer/src/prores-profile.ts
@@ -2,6 +2,48 @@ import {type _InternalTypes} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import type {Codec} from './codec';
 
+export const validateSelectedCodecAndBitsPerMbCombination = ({
+	codec,
+	bitsPerMb,
+}: {
+	codec: Codec;
+	bitsPerMb: number | undefined;
+}) => {
+	if (bitsPerMb === undefined) {
+		return;
+	}
+
+	if (codec !== 'prores') {
+		throw new TypeError(
+			`"bitsPerMb" is only supported when using the "prores" codec. You have set the codec to "${codec}".`,
+		);
+	}
+
+	if (typeof bitsPerMb !== 'number' || Number.isNaN(bitsPerMb)) {
+		throw new TypeError(
+			`"bitsPerMb" must be a number, but got ${JSON.stringify(bitsPerMb)}.`,
+		);
+	}
+
+	if (!Number.isInteger(bitsPerMb)) {
+		throw new TypeError(
+			`"bitsPerMb" must be an integer, but got ${bitsPerMb}.`,
+		);
+	}
+
+	if (bitsPerMb < 128) {
+		throw new TypeError(
+			`"bitsPerMb" must be at least 128, but got ${bitsPerMb}. The prores_ks encoder requires at least 128 bits per macroblock.`,
+		);
+	}
+
+	if (bitsPerMb > 8192) {
+		throw new TypeError(
+			`"bitsPerMb" must be at most 8192, but got ${bitsPerMb}.`,
+		);
+	}
+};
+
 export const validateSelectedCodecAndProResCombination = ({
 	codec,
 	proResProfile,

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -136,7 +136,7 @@ export type InternalRenderMediaOptions = {
 	onProgress: RenderMediaOnProgress;
 	onDownload: RenderMediaOnDownload;
 	proResProfile: _InternalTypes['ProResProfile'] | undefined;
-	bitsPerMb: number | undefined;
+	bitsPerMb?: number | undefined;
 	onBrowserLog: ((log: BrowserLog) => void) | null;
 	onStart: (data: OnStartData) => void;
 	chromiumOptions: ChromiumOptions;

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -58,7 +58,10 @@ import type {RemotionServer} from './prepare-server';
 import {makeOrReuseServer} from './prepare-server';
 import {prespawnFfmpeg} from './prespawn-ffmpeg';
 import {shouldUseParallelEncoding} from './prestitcher-memory-usage';
-import {validateSelectedCodecAndProResCombination} from './prores-profile';
+import {
+	validateSelectedCodecAndBitsPerMbCombination,
+	validateSelectedCodecAndProResCombination,
+} from './prores-profile';
 import type {OnArtifact} from './render-frames';
 import {internalRenderFrames} from './render-frames';
 import {
@@ -133,6 +136,7 @@ export type InternalRenderMediaOptions = {
 	onProgress: RenderMediaOnProgress;
 	onDownload: RenderMediaOnDownload;
 	proResProfile: _InternalTypes['ProResProfile'] | undefined;
+	bitsPerMb: number | undefined;
 	onBrowserLog: ((log: BrowserLog) => void) | null;
 	onStart: (data: OnStartData) => void;
 	chromiumOptions: ChromiumOptions;
@@ -183,6 +187,7 @@ export type RenderMediaOptions = Prettify<{
 	onProgress?: RenderMediaOnProgress;
 	onDownload?: RenderMediaOnDownload;
 	proResProfile?: _InternalTypes['ProResProfile'];
+	bitsPerMb?: number;
 	/**
 	 * @deprecated Use "logLevel": "verbose" instead
 	 */
@@ -228,6 +233,7 @@ type RenderMediaResult = {
 
 const internalRenderMediaRaw = ({
 	proResProfile,
+	bitsPerMb,
 	x264Preset,
 	crf,
 	composition: compositionWithPossibleUnevenDimensions,
@@ -322,6 +328,10 @@ const internalRenderMediaRaw = ({
 	validateSelectedCodecAndProResCombination({
 		codec,
 		proResProfile,
+	});
+	validateSelectedCodecAndBitsPerMbCombination({
+		codec,
+		bitsPerMb,
 	});
 
 	validateSelectedCodecAndPresetCombination({
@@ -562,6 +572,7 @@ const internalRenderMediaRaw = ({
 				colorSpace,
 				binariesDirectory,
 				hardwareAcceleration,
+				bitsPerMb,
 			});
 			stitcherFfmpeg = preStitcher.task;
 		}
@@ -822,6 +833,7 @@ const internalRenderMediaRaw = ({
 					metadata,
 					hardwareAcceleration,
 					sampleRate,
+					bitsPerMb,
 				});
 			})
 			.then((buffer) => {
@@ -954,6 +966,7 @@ export const internalRenderMedia = wrapWithErrorHandling(
  */
 export const renderMedia = ({
 	proResProfile,
+	bitsPerMb,
 	x264Preset,
 	crf,
 	composition,
@@ -1031,6 +1044,7 @@ export const renderMedia = ({
 
 	return internalRenderMedia({
 		proResProfile: proResProfile ?? undefined,
+		bitsPerMb,
 		x264Preset: x264Preset ?? null,
 		codec,
 		composition,

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -34,7 +34,10 @@ import {
 	DEFAULT_PIXEL_FORMAT,
 	validateSelectedPixelFormatAndCodecCombination,
 } from './pixel-format';
-import {validateSelectedCodecAndProResCombination} from './prores-profile';
+import {
+	validateSelectedCodecAndBitsPerMbCombination,
+	validateSelectedCodecAndProResCombination,
+} from './prores-profile';
 import {getShouldRenderAudio} from './render-has-audio';
 import {validateDimension, validateFps} from './validate';
 import {validateEvenDimensionsWithCodec} from './validate-even-dimensions-with-codec';
@@ -72,6 +75,7 @@ type InternalStitchFramesToVideoOptions = {
 	binariesDirectory: string | null;
 	metadata: Record<string, string> | null;
 	sampleRate: number;
+	bitsPerMb: number | undefined;
 } & ToOptions<typeof optionsMap.stitchFramesToVideo>;
 
 export type StitchFramesToVideoOptions = {
@@ -103,6 +107,7 @@ export type StitchFramesToVideoOptions = {
 	binariesDirectory?: string | null;
 	metadata?: Record<string, string> | null;
 	sampleRate?: number;
+	bitsPerMb?: number;
 } & Partial<ToOptions<typeof optionsMap.stitchFramesToVideo>>;
 
 type ReturnType = Promise<Buffer | null>;
@@ -142,6 +147,7 @@ const innerStitchFramesToVideo = async (
 		metadata,
 		hardwareAcceleration,
 		sampleRate,
+		bitsPerMb,
 	}: InternalStitchFramesToVideoOptions,
 	remotionRoot: string,
 ): Promise<ReturnType> => {
@@ -159,6 +165,10 @@ const innerStitchFramesToVideo = async (
 	validateSelectedCodecAndProResCombination({
 		codec,
 		proResProfile,
+	});
+	validateSelectedCodecAndBitsPerMbCombination({
+		codec,
+		bitsPerMb,
 	});
 
 	validateBitrate(audioBitrate, 'audioBitrate');
@@ -373,6 +383,7 @@ const innerStitchFramesToVideo = async (
 			hardwareAcceleration,
 			indent,
 			logLevel,
+			bitsPerMb,
 		}),
 		codec === 'h264' ? ['-movflags', 'faststart'] : null,
 		// Ignore metadata that may come from remote media
@@ -537,6 +548,7 @@ export const stitchFramesToVideo = ({
 	metadata,
 	hardwareAcceleration,
 	sampleRate,
+	bitsPerMb,
 }: StitchFramesToVideoOptions): Promise<Buffer | null> => {
 	return internalStitchFramesToVideo({
 		assetsInfo,
@@ -572,5 +584,6 @@ export const stitchFramesToVideo = ({
 		separateAudioTo: separateAudioTo ?? null,
 		hardwareAcceleration: hardwareAcceleration ?? 'disable',
 		sampleRate: sampleRate ?? 48000,
+		bitsPerMb,
 	});
 };

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -75,7 +75,7 @@ type InternalStitchFramesToVideoOptions = {
 	binariesDirectory: string | null;
 	metadata: Record<string, string> | null;
 	sampleRate: number;
-	bitsPerMb: number | undefined;
+	bitsPerMb?: number | undefined;
 } & ToOptions<typeof optionsMap.stitchFramesToVideo>;
 
 export type StitchFramesToVideoOptions = {


### PR DESCRIPTION
## Summary

- Adds optional `bitsPerMb` parameter to `renderMedia()` and `stitchFramesToVideo()` that maps to FFmpeg's `-bits_per_mb` flag for the `prores_ks` encoder
- Validates range 128-8192 (matching `prores_ks` encoder limits) and ensures it's only used with the `prores` codec
- Plumbed through all encoding paths: `generateFfmpegArgs`, `prespawnFfmpeg`, `internalStitchFramesToVideo`, and `internalRenderMedia`

## Test plan

- [ ] Render a ProRes video with `bitsPerMb: 128` and verify smaller output than default
- [ ] Render a ProRes video with `bitsPerMb: 8192` and verify output matches default quality
- [ ] Verify `bitsPerMb` with non-ProRes codec throws a clear error
- [ ] Verify `bitsPerMb` below 128 or above 8192 throws a clear error
- [ ] Verify omitting `bitsPerMb` preserves existing default behavior

Fixes #7031