### PR TITLE
fix: remove CSS Modules :global() syntax from plain CSS in promo-pages

### DIFF
--- a/packages/docs/src/components/video-player.css
+++ b/packages/docs/src/components/video-player.css
@@ -1,9 +1,9 @@
-:global(:root) {
+:root {
 	--plyr-color-main: #1b1b1b;
 	--plyr-range-fill-background: #ccc;
 }
-:global(.plyr__controls button),
-:global(.plyr__controls input) {
+.plyr__controls button,
+.plyr__controls input {
 	cursor: pointer;
 }
 .video-container {
@@ -11,7 +11,7 @@
 	margin-top: 40px;
 	border-radius: 30px;
 }
-:global(.plyr:fullscreen video) {
+.plyr:fullscreen video {
 	max-width: initial;
 	max-height: initial;
 	width: 100%;

--- a/packages/promo-pages/src/components/homepage/video-player.css
+++ b/packages/promo-pages/src/components/homepage/video-player.css
@@ -1,9 +1,9 @@
-:global(:root) {
+:root {
 	--plyr-color-main: #1b1b1b;
 	--plyr-range-fill-background: #ccc;
 }
-:global(.plyr__controls button),
-:global(.plyr__controls input) {
+.plyr__controls button,
+.plyr__controls input {
 	cursor: pointer;
 }
 .video-container {
@@ -11,7 +11,7 @@
 	margin-top: 40px;
 	border-radius: 30px;
 }
-:global(.plyr:fullscreen video) {
+.plyr:fullscreen video {
 	max-width: initial;
 	max-height: initial;
 	width: 100%;


### PR DESCRIPTION
## Summary
- Remove `:global()` wrappers from plain CSS files in `@remotion/promo-pages` and `docs`
- These are not CSS Modules, so `:global()` is invalid and breaks Turbopack builds
- Inner selectors are preserved as-is

## Test plan
- Verify CSS still applies correctly (selectors unchanged, only wrapper removed)
- Turbopack build should no longer fail on these files

Fixes #7057