### PR TITLE
Fix typo: occured -> occurred in CalculateMetadataErrorExplainer

### DIFF
--- a/packages/studio/src/error-overlay/remotion-overlay/CalculateMetadataErrorExplainer.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/CalculateMetadataErrorExplainer.tsx
@@ -5,7 +5,7 @@ import {BORDER_COLOR} from '../../helpers/colors';
 export const CalculateMetadataErrorExplainer: React.FC<{}> = () => {
 	return (
 		<div style={style}>
-			This error occured while calling{' '}
+			This error occurred while calling{' '}
 			<code style={inlineCodeSnippet}>calculateMetadata()</code>.
 		</div>
 	);


### PR DESCRIPTION
Fixes a small typo in the user-facing error message shown when `calculateMetadata()` throws.

Before: *This error occured while calling calculateMetadata().*
After: *This error occurred while calling calculateMetadata().*