### PR TITLE
`@remotion/vercel`: Fix `sampleRate` being `undefined` in FFmpeg command

### DIFF
--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -15,7 +15,7 @@
 		"format": "oxfmt src",
 		"lint": "eslint src",
 		"watch": "tsgo -w",
-		"make": "bun --env-file=../.env.bundle bundle.ts && tsgo"
+		"make": "bun --env-file=../.env.bundle bundle.ts && tsgo && tsgo -p tsconfig.scripts.json"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"contributors": [],

--- a/packages/vercel/src/render-media-on-vercel.ts
+++ b/packages/vercel/src/render-media-on-vercel.ts
@@ -57,6 +57,7 @@ export async function renderMediaOnVercel({
 	offthreadVideoCacheSizeInBytes,
 	mediaCacheSizeInBytes,
 	offthreadVideoThreads,
+	sampleRate,
 }: {
 	sandbox: Sandbox;
 	compositionId: string;
@@ -97,6 +98,7 @@ export async function renderMediaOnVercel({
 	offthreadVideoCacheSizeInBytes?: number | null;
 	mediaCacheSizeInBytes?: number | null;
 	offthreadVideoThreads?: number | null;
+	sampleRate?: number;
 }): Promise<{sandboxFilePath: string; contentType: string}> {
 	const serveUrl = `/vercel/sandbox/${REMOTION_SANDBOX_BUNDLE_DIR}`;
 
@@ -143,6 +145,7 @@ export async function renderMediaOnVercel({
 		browserExecutable: null,
 		binariesDirectory: null,
 		repro: false,
+		sampleRate: sampleRate ?? 48000,
 	};
 
 	const renderCmd = await sandbox.runCommand({

--- a/packages/vercel/src/scripts/render-video.ts
+++ b/packages/vercel/src/scripts/render-video.ts
@@ -48,6 +48,7 @@ type RenderVideoConfig = {
 	mediaCacheSizeInBytes: InternalRenderMediaOptions['mediaCacheSizeInBytes'];
 	offthreadVideoThreads: InternalRenderMediaOptions['offthreadVideoThreads'];
 	repro: InternalRenderMediaOptions['repro'];
+	sampleRate: InternalRenderMediaOptions['sampleRate'];
 };
 
 const config: RenderVideoConfig = JSON.parse(process.argv[2]);
@@ -161,6 +162,7 @@ try {
 		mediaCacheSizeInBytes: config.mediaCacheSizeInBytes,
 		offthreadVideoThreads: config.offthreadVideoThreads,
 		repro: config.repro,
+		sampleRate: config.sampleRate,
 		// Non-serializable fields with defaults
 		puppeteerInstance: browser,
 		onProgress: (progress) => {

--- a/packages/vercel/tsconfig.scripts.json
+++ b/packages/vercel/tsconfig.scripts.json
@@ -1,0 +1,14 @@
+{
+	"extends": "../tsconfig.settings.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"skipLibCheck": true,
+		"target": "ES2022",
+		"module": "es2022",
+		"moduleResolution": "bundler",
+		"noEmit": true,
+		"composite": false,
+		"declaration": false
+	},
+	"include": ["src/scripts"]
+}


### PR DESCRIPTION
Fixes #7071

## Problem

When using `renderMediaOnVercel`, any render that required a silent audio track would crash with:

anullsrc=r=undefined -ar undefined Unable to parse option value "undefined" Error opening input file anullsrc=r=undefined


## Root Cause

`renderMediaOnVercel` never accepted a `sampleRate` option, so it was never included in the JSON config serialized and passed to the render subprocess (`render-video.ts`). When `internalRenderMedia` then called `createSilentAudio` (e.g. for compositions with no audio tracks), `sampleRate` was `undefined` and got string-interpolated directly into the FFmpeg command.

## Fix

- **`packages/vercel/src/render-media-on-vercel.ts`**: Added optional `sampleRate?: number` parameter. It is forwarded into the render config with a fallback of `48000` (`sampleRate ?? 48000`).
- **`packages/vercel/src/scripts/render-video.ts`**: Added `sampleRate` to the `RenderVideoConfig` type and passed `config.sampleRate` through to `internalRenderMedia`.

Before this fix it crashed on every render involving audio. After this fix the default 48 kHz sample rate is used correctly.