### PR TITLE
`docs`: Mention that HTML-in-canvas removes CSS limitations

### DIFF
--- a/packages/docs/docs/client-side-rendering/limitations.mdx
+++ b/packages/docs/docs/client-side-rendering/limitations.mdx
@@ -16,6 +16,10 @@ Unlike server-side rendering, where a full screenshot it taken, in client-side r
 
 It is not feasible to support all CSS properties and factors affecting the visual style of a page, so only the most important styling primitives are supported.
 
+:::info
+If the [HTML-in-canvas](/docs/client-side-rendering/html-in-canvas) flag is enabled and active, these CSS limitations don't apply because a full screenshot is taken instead.
+:::
+
 ## Supported CSS styles
 
 ### Positioning and layouting properties


### PR DESCRIPTION
## Summary
- Adds an info admonition to the client-side rendering limitations page noting that when the HTML-in-canvas flag is enabled and active, the CSS limitations don't apply because a full screenshot is taken instead.
- Links to the existing HTML-in-canvas documentation page.

## Test plan
- [ ] Verify the docs site builds: `bun run build-docs`
- [ ] Check that the info box renders correctly on the limitations page

Made with [Cursor](https://cursor.com)