### PR TITLE
`@remotion/transitions`: Fix pointer events on SVG clip path wrappers

### DIFF
--- a/packages/transitions/src/presentations/clock-wipe.tsx
+++ b/packages/transitions/src/presentations/clock-wipe.tsx
@@ -16,6 +16,8 @@ export type ClockWipeProps = {
 	innerExitStyle?: React.CSSProperties;
 };
 
+const svgContainerStyle: React.CSSProperties = {pointerEvents: 'none'};
+
 const ClockWipePresentation: React.FC<
 	TransitionPresentationComponentProps<ClockWipeProps>
 > = ({children, presentationDirection, presentationProgress, passedProps}) => {
@@ -65,7 +67,7 @@ const ClockWipePresentation: React.FC<
 		<AbsoluteFill style={outerStyle}>
 			<AbsoluteFill style={style}>{children}</AbsoluteFill>
 			{presentationDirection === 'exiting' ? null : (
-				<AbsoluteFill>
+				<AbsoluteFill style={svgContainerStyle}>
 					<svg>
 						<defs>
 							<clipPath id={clipId}>

--- a/packages/transitions/src/presentations/iris.tsx
+++ b/packages/transitions/src/presentations/iris.tsx
@@ -16,6 +16,8 @@ export type IrisProps = {
 	innerExitStyle?: React.CSSProperties;
 };
 
+const svgContainerStyle: React.CSSProperties = {pointerEvents: 'none'};
+
 const IrisPresentation: React.FC<
 	TransitionPresentationComponentProps<IrisProps>
 > = ({children, presentationDirection, presentationProgress, passedProps}) => {
@@ -75,7 +77,7 @@ const IrisPresentation: React.FC<
 		<AbsoluteFill style={outerStyle}>
 			<AbsoluteFill style={style}>{children}</AbsoluteFill>
 			{presentationDirection === 'exiting' ? null : (
-				<AbsoluteFill>
+				<AbsoluteFill style={svgContainerStyle}>
 					<svg>
 						<defs>
 							<clipPath id={clipId}>

--- a/packages/transitions/src/presentations/wipe.tsx
+++ b/packages/transitions/src/presentations/wipe.tsx
@@ -157,6 +157,8 @@ Z`;
 	}
 };
 
+const svgContainerStyle: React.CSSProperties = {pointerEvents: 'none'};
+
 const WipePresentation: React.FC<
 	TransitionPresentationComponentProps<WipeProps>
 > = ({
@@ -213,7 +215,7 @@ const WipePresentation: React.FC<
 	return (
 		<AbsoluteFill style={outerStyle}>
 			<AbsoluteFill style={style}>{children}</AbsoluteFill>
-			<AbsoluteFill>
+			<AbsoluteFill style={svgContainerStyle}>
 				<svg viewBox="0 0 1 1" style={svgStyle}>
 					<defs>
 						<clipPath id={clipId} clipPathUnits="objectBoundingBox">


### PR DESCRIPTION
## Summary

- Adds `pointerEvents: 'none'` to the `<AbsoluteFill>` wrapping the SVG `<clipPath>` definition in `wipe`, `clockWipe`, and `iris` transition presentations
- Fixes #7082: the empty SVG wrapper was absorbing all clicks, making layers underneath the transition unselectable in Player/Studio

## Test plan

- Use `<TransitionSeries>` with `wipe`, `clockWipe`, or `iris` as the presentation in `@remotion/player`
- Verify clickable layers (e.g. `<div onClick>`) inside scenes are now interactive during transitions


Made with [Cursor](https://cursor.com)