### PR TITLE
Docs: Fix broken anchors in documentation

### DIFF
--- a/packages/docs/docs/cli/render.mdx
+++ b/packages/docs/docs/cli/render.mdx
@@ -56,7 +56,7 @@ Inline JSON string isn't supported on Windows shells because it removes the `"` 
 
 <Options id="video-image-format" />
 
-### `--image-sequence-pattern` <AvailableFrom v="4.0.313" />
+### `--image-sequence-pattern`<AvailableFrom v="4.0.313" />
 
 <Options id="image-sequence-pattern" />
 

--- a/packages/docs/docs/cli/studio.mdx
+++ b/packages/docs/docs/cli/studio.mdx
@@ -142,3 +142,11 @@ npx remotion studio --force-new
 ```sh
 npx remotion studio --public-license-key="your-license-key"
 ```
+
+### `--experimental-visual-mode`<AvailableFrom v="4.0.428" />
+
+<Options id="experimental-visual-mode" />
+
+```sh
+npx remotion studio --experimental-visual-mode
+```

--- a/packages/docs/docs/spring.mdx
+++ b/packages/docs/docs/spring.mdx
@@ -142,7 +142,7 @@ This function was taken from [Reanimated 2](https://github.com/software-mansion/
 
 ## See also
 
-- [Spring animation example](/docs/animating-properties#using-spring-animations)
+- [Spring animation example](/docs/animating-properties#using-spring)
 - [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/core/src/spring/index.ts)
 - [`interpolate()`](/docs/interpolate)
 - [`measureSpring()`](/docs/measure-spring)

--- a/packages/docs/docs/vercel/types.mdx
+++ b/packages/docs/docs/vercel/types.mdx
@@ -49,6 +49,10 @@ Every variant includes `overallProgress` — a number from `0` to `1` representi
 
 Used as the `onProgress` callback type for [`renderMediaOnVercel()`](/docs/vercel/render-media-on-vercel).
 
+## `RenderMediaProgress`
+
+See [`RenderMediaOnProgress`](/docs/renderer/types#rendermediaonprogress) in `@remotion/renderer`.
+
 ## `RenderStillOnVercelProgress`
 
 ```ts twoslash

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
 	url: 'https://www.remotion.dev',
 	baseUrl: '/',
 	onBrokenLinks: 'throw',
+	onBrokenAnchors: 'throw',
 	markdown: {
 		hooks: {
 			onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
## Summary
- Add missing `--experimental-visual-mode` CLI flag documentation to the Studio CLI page
- Fix heading format for `--image-sequence-pattern` in render CLI page (remove space before `<AvailableFrom>`)
- Fix broken anchor link in spring.mdx (`#using-spring-animations` → `#using-spring`)
- Add missing `RenderMediaProgress` section to vercel/types.mdx

## Test plan
- [x] `bun run build-docs` passes without broken anchor warnings


Made with [Cursor](https://cursor.com)