### PR TITLE
Docs: Add canonical tags and enforce no trailing slashes

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
 	tagline: 'Make videos programmatically',
 	url: 'https://www.remotion.dev',
 	baseUrl: '/',
+	trailingSlash: false,
 	onBrokenLinks: 'throw',
 	onBrokenAnchors: 'throw',
 	markdown: {

--- a/packages/docs/vercel.ts
+++ b/packages/docs/vercel.ts
@@ -1,6 +1,8 @@
 import {routes, type VercelConfig} from '@vercel/config/v1';
 
 export const config: VercelConfig = {
+	trailingSlash: false,
+	cleanUrls: true,
 	headers: [
 		routes.cacheControl('/assets/(.*)', {
 			public: true,


### PR DESCRIPTION
## Summary

- Adds `trailingSlash: false` to the Docusaurus config so every page emits a `<link rel="canonical">` tag without a trailing slash
- Adds `trailingSlash: false` and `cleanUrls: true` to the Vercel config so trailing-slash URLs get a 308 redirect to the canonical form

Closes #7076

## Test plan

- [x] Built the docs site with `docusaurus build` and verified canonical tags appear on all sampled pages (`/`, `/docs`, `/docs/the-fundamentals`, `/learn`, `/blog`)
- [x] Served the production build locally and confirmed `/docs/` returns a 301 redirect to `/docs`, while `/docs` returns 200 directly

Made with [Cursor](https://cursor.com)