### PR TITLE
fix-dependabot skill: Use \`git add -u\` instead of explicit globs

### DIFF
--- a/.claude/skills/fix-dependabot/SKILL.md
+++ b/.claude/skills/fix-dependabot/SKILL.md
@@ -31,7 +31,7 @@ Update every match to the new version. Preserve the prefix style (`^`, `~`, or e
 6. **Commit and push**:
 
 ```bash
-git add bun.lock packages/*/package.json
+git add -u
 git commit -m "Update <dependency> to <version> across all monorepo packages"
 git push
 ```


### PR DESCRIPTION
## Summary
- Addresses review feedback from #7087: the `git add bun.lock packages/*/package.json` glob missed the root `package.json` and any package.json not under `packages/*/`
- Replaced with `git add -u` which stages all tracked modified files, relying on the existing verify step to catch unexpected modifications

## Test plan
- [x] Reviewed the skill file reads correctly after the change


Made with [Cursor](https://cursor.com)