### PR TITLE
Docs: Remove outdated Spline tutorial from sidebar

### DIFF
--- a/packages/docs/docs/spline.mdx
+++ b/packages/docs/docs/spline.mdx
@@ -6,6 +6,10 @@ crumb: 'Integrations'
 
 import {SplineVideo} from '../components/SplineVideo';
 
+:::warning
+This tutorial has been reported as out of date. The Spline export workflow may have changed since this was written. Proceed with caution.
+:::
+
 _Authors: [Dhroov Makwana](https://github.com/pabloescoder) and [Jonny Burger](https://twitter.com/JNYBGR)_
 
 [Spline](https://app.spline.design/) allows to design 3D models on the web. It allows exporting these models as React Three Fiber code, meaning that can be directly used and animated in Remotion.

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -1296,7 +1296,6 @@ const sidebars: SidebarsConfig = {
 				'miscellaneous/typescript-aliases',
 				'testing',
 				'figma',
-				'spline',
 				'after-effects',
 			],
 		},


### PR DESCRIPTION
Closes #7080

The Spline tutorial has been reported as out of date. This removes it from the sidebar while keeping the page accessible via direct link, with an added warning note.

Made with [Cursor](https://cursor.com)