### PR TITLE
`create-video`: Remove JSX syntax from HTML template description

### DIFF
--- a/packages/create-video/src/templates.ts
+++ b/packages/create-video/src/templates.ts
@@ -506,7 +506,7 @@ export const FEATURED_TEMPLATES: Template[] = [
 		longerDescription: `
 			<span>
 				A starter template to create overlays to use in conventional video
-				editing software.{' '}
+				editing software.
 				<a href="/docs/overlay">Read more about creating overlays.</a>
 			</span>
 			`,


### PR DESCRIPTION
## Summary
- The overlay template's `longerDescription` contained `{' '}` (JSX syntax for a space), but this field is rendered as raw HTML via `dangerouslySetInnerHTML`, causing the literal text `{' '}` to appear on the template detail page instead of a space.
- Removed the `{' '}` — the existing whitespace between the sentence and the `<a>` tag already produces a space in HTML.
- Audited all other `longerDescription` values; no other templates were affected.

## Test plan
- [ ] Visit `/templates/overlay` and verify the description renders cleanly without literal `{' '}` text

Made with [Cursor](https://cursor.com)