### PR TITLE
`@remotion/bundler`: Fix null props crash in setup-sequence-stack-traces

### DIFF
--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -21,7 +21,7 @@ const enableProxy = <
 		apply(target, thisArg, argArray) {
 			if (componentsToAddStacksTo.includes(argArray[0])) {
 				const [first, props, ...rest] = argArray;
-				const newProps = props.stack
+				const newProps = props?.stack
 					? props
 					: {
 							...(props ?? {}),


### PR DESCRIPTION
## Summary

- Fixes a `TypeError: Cannot read properties of null (reading 'stack')` crash in Remotion Studio when `React.createElement(Component, null)` is called for components tracked by `componentsToAddStacksTo` (e.g. `TransitionSeries`).
- Adds optional chaining (`props?.stack` instead of `props.stack`) so the null guard on line 27 can take effect instead of crashing on line 24.

Fixes #7103

## Test plan

- Open Remotion Studio with a project using `TransitionSeries` — compositions should no longer crash.

Made with [Cursor](https://cursor.com)