### PR TITLE
Docs: Revert "Add canonical tags and enforce no trailing slashes"

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -6,7 +6,6 @@ const config: Config = {
 	tagline: 'Make videos programmatically',
 	url: 'https://www.remotion.dev',
 	baseUrl: '/',
-	trailingSlash: false,
 	onBrokenLinks: 'throw',
 	onBrokenAnchors: 'throw',
 	markdown: {

--- a/packages/docs/vercel.ts
+++ b/packages/docs/vercel.ts
@@ -1,8 +1,6 @@
 import {routes, type VercelConfig} from '@vercel/config/v1';
 
 export const config: VercelConfig = {
-	trailingSlash: false,
-	cleanUrls: true,
 	headers: [
 		routes.cacheControl('/assets/(.*)', {
 			public: true,


### PR DESCRIPTION
## Summary

- Reverts #7086 which caused 404 "Page Not Found" errors on the docs site
- Reopens #7076

## Why it broke

The `trailingSlash: false` Docusaurus config setting changes the build output format from `page/index.html` (directory-based) to `page.html` (file-based). On Vercel, the existing routing expected directory-based output, so pages became unreachable — resulting in 404 errors for visitors.

Even though `cleanUrls: true` was added to the Vercel config to compensate, it wasn't sufficient to handle all existing URL patterns, particularly those without `.html` extensions that relied on the `index.html` convention.

Made with [Cursor](https://cursor.com)