### PR TITLE
`@remotion/design`: Add `asChild` API to `Button`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -380,6 +380,7 @@
       "version": "4.0.450",
       "dependencies": {
         "@radix-ui/react-select": "2.1.1",
+        "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.0",
         "@remotion/paths": "workspace:*",
         "@remotion/shapes": "workspace:*",

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -20,14 +20,15 @@
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},
 	"dependencies": {
+		"@radix-ui/react-select": "2.1.1",
+		"@radix-ui/react-slot": "^1.2.4",
+		"@radix-ui/react-tabs": "^1.1.0",
 		"@remotion/paths": "workspace:*",
 		"@remotion/shapes": "workspace:*",
 		"@remotion/svg-3d-engine": "workspace:*",
 		"clsx": "^2.1.1",
-		"remotion": "workspace:*",
-		"@radix-ui/react-select": "2.1.1",
-		"@radix-ui/react-tabs": "^1.1.0",
-		"lucide-react": "0.439.0"
+		"lucide-react": "0.439.0",
+		"remotion": "workspace:*"
 	},
 	"peerDependencies": {
 		"react": ">=16.8.0",

--- a/packages/design/src/Button.tsx
+++ b/packages/design/src/Button.tsx
@@ -151,6 +151,21 @@ export const Button: React.FC<ButtonProps> = ({
 		</div>
 	) : null;
 
+	const slottableChild = asChild
+		? React.cloneElement(
+				children as React.ReactElement<{children?: React.ReactNode}>,
+				undefined,
+				<span
+					className={cn(loading && 'invisible', 'inline-flex items-center')}
+				>
+					{
+						(children as React.ReactElement<{children?: React.ReactNode}>).props
+							.children
+					}
+				</span>,
+			)
+		: null;
+
 	const content = asChild ? (
 		<Slot
 			{...(rest as React.ComponentPropsWithoutRef<typeof Slot>)}
@@ -159,7 +174,7 @@ export const Button: React.FC<ButtonProps> = ({
 			tabIndex={isDisabled ? -1 : undefined}
 			onClickCapture={isDisabled ? preventInteraction : undefined}
 		>
-			<Slottable>{children}</Slottable>
+			<Slottable>{slottableChild}</Slottable>
 			{spinnerOverlay}
 		</Slot>
 	) : isAnchor ? (

--- a/packages/design/src/Button.tsx
+++ b/packages/design/src/Button.tsx
@@ -1,3 +1,4 @@
+import {Slot, Slottable} from '@radix-ui/react-slot';
 import React, {useCallback, useRef, useState} from 'react';
 import {cn} from './helpers/cn';
 import {useHoverTransforms} from './helpers/hover-transforms';
@@ -13,16 +14,29 @@ type CommonProps = {
 type ButtonAsButton = CommonProps &
 	Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'href' | 'disabled'> & {
 		readonly href?: undefined;
+		readonly asChild?: false;
 	};
 
 type ButtonAsAnchor = CommonProps &
 	Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'type'> & {
 		readonly href: string;
+		readonly asChild?: false;
 	};
 
-export type ButtonProps = ButtonAsButton | ButtonAsAnchor;
+type ButtonAsChild = CommonProps &
+	Omit<
+		React.ComponentPropsWithoutRef<typeof Slot>,
+		'children' | 'disabled' | 'href'
+	> & {
+		readonly asChild: true;
+		readonly href?: never;
+		readonly children: React.ReactElement;
+	};
+
+export type ButtonProps = ButtonAsButton | ButtonAsAnchor | ButtonAsChild;
 
 export const Button: React.FC<ButtonProps> = ({
+	asChild = false,
 	children,
 	className,
 	disabled,
@@ -95,6 +109,7 @@ export const Button: React.FC<ButtonProps> = ({
 	);
 
 	const isDisabled = disabled || loading;
+	const isAnchor = !asChild && 'href' in rest && rest.href !== undefined;
 
 	const sharedClasses = cn(
 		'text-text',
@@ -120,40 +135,45 @@ export const Button: React.FC<ButtonProps> = ({
 		className,
 	);
 
-	const innerContent = (
-		<>
-			<div className={cn(loading && 'invisible', 'inline-flex items-center')}>
-				{children}
-			</div>
-			{loading ? (
-				<div
-					className={cn(
-						'absolute w-full h-full flex inset-0 items-center justify-center text-inherit bg-inherit',
-					)}
-				>
-					<Spinner size={20} duration={1} />
-				</div>
-			) : null}
-		</>
-	);
+	const preventInteraction = useCallback((e: React.MouseEvent<HTMLElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+	}, []);
 
-	const isAnchor = 'href' in rest && rest.href !== undefined;
+	const spinnerOverlay = loading ? (
+		<div
+			data-button-spinner
+			className={cn(
+				'absolute w-full h-full flex inset-0 items-center justify-center text-inherit bg-inherit',
+			)}
+		>
+			<Spinner size={20} duration={1} />
+		</div>
+	) : null;
 
-	const content = isAnchor ? (
+	const content = asChild ? (
+		<Slot
+			{...(rest as React.ComponentPropsWithoutRef<typeof Slot>)}
+			className={cn('no-underline text-inherit', sharedClasses)}
+			aria-disabled={isDisabled || undefined}
+			tabIndex={isDisabled ? -1 : undefined}
+			onClickCapture={isDisabled ? preventInteraction : undefined}
+		>
+			<Slottable>{children}</Slottable>
+			{spinnerOverlay}
+		</Slot>
+	) : isAnchor ? (
 		<a
 			{...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
 			className={cn('no-underline text-inherit', sharedClasses)}
 			aria-disabled={isDisabled || undefined}
 			tabIndex={isDisabled ? -1 : undefined}
-			onClick={
-				isDisabled
-					? (e: React.MouseEvent<HTMLAnchorElement>) => {
-							e.preventDefault();
-						}
-					: (rest as React.AnchorHTMLAttributes<HTMLAnchorElement>).onClick
-			}
+			onClickCapture={isDisabled ? preventInteraction : undefined}
 		>
-			{innerContent}
+			<div className={cn(loading && 'invisible', 'inline-flex items-center')}>
+				{children}
+			</div>
+			{spinnerOverlay}
 		</a>
 	) : (
 		<button
@@ -162,7 +182,10 @@ export const Button: React.FC<ButtonProps> = ({
 			className={sharedClasses}
 			{...(rest as React.ButtonHTMLAttributes<HTMLButtonElement>)}
 		>
-			{innerContent}
+			<div className={cn(loading && 'invisible', 'inline-flex items-center')}>
+				{children}
+			</div>
+			{spinnerOverlay}
 		</button>
 	);
 


### PR DESCRIPTION
## Motivation
Allow framework routers to compose with `@remotion/design`'s `Button` without falling back to plain anchors and full page navigations, while keeping the existing `href` API working.

## Changes
- add an `asChild` composition mode to `Button`
- make `href` and `asChild` mutually exclusive in the component types
- preserve loading and disabled behavior for slotted link-like children
- add `@radix-ui/react-slot` to `@remotion/design`

## Testing
- [x] Run `bun run lint && bun run make` in `packages/design`
- [x] Manually verify `<Button asChild><Link ... /></Button>` in a downstream app
- [x] Manually verify existing `<Button href="..." />` usage remains unchanged