### PR TITLE
`@remotion/studio`: Revert timeline width useLayoutEffect fix

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
@@ -1,6 +1,5 @@
 import {PlayerInternals} from '@remotion/player';
-import {createContext, useContext, useLayoutEffect, useState} from 'react';
-import {TimelineZoomCtx} from '../../state/timeline-zoom';
+import {createContext} from 'react';
 import {sliderAreaRef} from './timeline-refs';
 
 type TimelineWidthContextType = number | null;
@@ -15,22 +14,9 @@ export const TimelineWidthProvider: React.FC<{
 		triggerOnWindowResize: false,
 		shouldApplyCssTransforms: true,
 	});
-	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
-	const [widthOverride, setWidthOverride] = useState<number | null>(null);
-
-	const observedWidth = size?.width ?? null;
-
-	useLayoutEffect(() => {
-		const actual = sliderAreaRef.current?.clientWidth ?? null;
-		if (actual !== null && actual !== observedWidth) {
-			setWidthOverride(actual);
-		} else {
-			setWidthOverride(null);
-		}
-	}, [observedWidth, zoomMap]);
 
 	return (
-		<TimelineWidthContext.Provider value={widthOverride ?? observedWidth}>
+		<TimelineWidthContext.Provider value={size?.width ?? null}>
 			{children}
 		</TimelineWidthContext.Provider>
 	);


### PR DESCRIPTION
## Summary
- Reverts the `useLayoutEffect` + `setState` width override added in #6935
- The fix was causing performance regressions: `setState` inside `useLayoutEffect` forced synchronous re-renders on every zoom change, and the `zoomMap` dependency caused a triple-render cascade (zoom state → layout effect override → ResizeObserver correction)
- The timeline now uses `ResizeObserver` width directly via `useElementSize`, as it did before #6935

Re-opens #7118

## Test plan
- [ ] Open studio, verify timeline playback performance is improved
- [ ] Zoom in/out on the timeline — confirm no major regressions beyond the original minor flicker

Made with [Cursor](https://cursor.com)