### PR TITLE
`@remotion/player`: Increase playbackRate limit to 10

### DIFF
--- a/packages/docs/docs/player/api.mdx
+++ b/packages/docs/docs/player/api.mdx
@@ -126,9 +126,11 @@ Once you have set this prop, you cannot change it anymore or an error will be th
 
 ### `playbackRate?`
 
-A number between -4 and 4 (excluding 0) for the speed that the Player will run the media.
+A number between -10 and 10 (excluding 0) for the speed that the Player will run the media.
 
 A `playbackRate` of `2` means the video plays twice as fast. A playbackRate of `0.5` means the video plays twice as slow. A playbackRate of `-1` means the video plays in reverse. Note that the media tags ([`<Audio>`](/docs/media/audio), [`<Video>`](/docs/media/video), [`<Html5Audio>`](/docs/html5-audio), [`<Html5Video>`](/docs/html5-video), [`<OffthreadVideo>`](/docs/offthreadvideo)) cannot be played in reverse, this is a browser limitation.
+
+Until `v4.0.451`, the allowed range was -4 to 4.
 
 Default `1`.
 

--- a/packages/player/src/test/validate-prop.test.tsx
+++ b/packages/player/src/test/validate-prop.test.tsx
@@ -123,13 +123,13 @@ test('Invalid playbackRate should give error', () => {
 				component={HelloWorld}
 				controls
 				showVolumeControls
-				playbackRate={-5}
+				playbackRate={11}
 				inputProps={{}}
 			/>,
 		);
 	} catch (e) {
 		expect((e as Error).message).toMatch(
-			/The lowest possible playback rate is -4. You passed: -5/,
+			/The highest possible playback rate is 10. You passed: 11/,
 		);
 	}
 });

--- a/packages/player/src/utils/validate-playbackrate.ts
+++ b/packages/player/src/utils/validate-playbackrate.ts
@@ -3,15 +3,15 @@ export const validatePlaybackRate = (playbackRate: number | undefined) => {
 		return;
 	}
 
-	if (playbackRate > 4) {
+	if (playbackRate > 10) {
 		throw new Error(
-			`The highest possible playback rate is 4. You passed: ${playbackRate}`,
+			`The highest possible playback rate is 10. You passed: ${playbackRate}`,
 		);
 	}
 
-	if (playbackRate < -4) {
+	if (playbackRate < -10) {
 		throw new Error(
-			`The lowest possible playback rate is -4. You passed: ${playbackRate}`,
+			`The lowest possible playback rate is -10. You passed: ${playbackRate}`,
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Increases the maximum supported `playbackRate` in the Remotion Player from ±4 to ±10
- Updates validation, tests, and documentation
- Adds a version note in docs that until `v4.0.451`, the allowed range was -4 to 4

Closes #7096


Made with [Cursor](https://cursor.com)