### PR TITLE
`@remotion/studio`: Use scheduler.postTask() for waveform drawing

### DIFF
--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -5,6 +5,20 @@ import {TIMELINE_BORDER} from '../helpers/timeline-layout';
 import {drawBars} from './draw-peaks';
 import {loadWaveformPeaks, TARGET_SAMPLE_RATE} from './load-waveform-peaks';
 
+type SchedulerPostTask = (
+	callback: () => void,
+	options?: {
+		priority?: 'user-blocking' | 'user-visible' | 'background';
+		signal?: AbortSignal;
+	},
+) => Promise<void>;
+
+const getSchedulerPostTask = (): SchedulerPostTask | null => {
+	const s = (globalThis as {scheduler?: {postTask?: SchedulerPostTask}})
+		.scheduler;
+	return s?.postTask ? s.postTask.bind(s) : null;
+};
+
 const container: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'row',
@@ -116,7 +130,23 @@ export const AudioWaveform: React.FC<{
 		canvasElement.height = h;
 
 		const vol = typeof volume === 'number' ? volume : 1;
-		drawBars(canvasElement, portionPeaks, 'rgba(255, 255, 255, 0.6)', vol, w);
+		const draw = () => {
+			drawBars(canvasElement, portionPeaks, 'rgba(255, 255, 255, 0.6)', vol, w);
+		};
+
+		const postTask = getSchedulerPostTask();
+		if (postTask) {
+			const controller = new AbortController();
+			postTask(draw, {
+				priority: 'background',
+				signal: controller.signal,
+			}).catch(() => {
+				// Task was aborted
+			});
+			return () => controller.abort();
+		}
+
+		draw();
 	}, [portionPeaks, visualizationWidth, volume]);
 
 	useEffect(() => {

--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -140,8 +140,12 @@ export const AudioWaveform: React.FC<{
 			postTask(draw, {
 				priority: 'background',
 				signal: controller.signal,
-			}).catch(() => {
-				// Task was aborted
+			}).catch((err) => {
+				if (err instanceof DOMException && err.name === 'AbortError') {
+					return;
+				}
+
+				throw err;
 			});
 			return () => controller.abort();
 		}


### PR DESCRIPTION
## Summary
- Wraps the `drawBars()` call in the timeline waveform component with `scheduler.postTask({priority: 'background'})` so urgent updates (scrubbing, input, playback controls) can preempt the pixel-by-pixel waveform drawing
- Adds an `AbortController` in the effect cleanup to cancel pending tasks when inputs change before drawing completes
- Falls back to synchronous drawing when `scheduler.postTask` is not available in the browser

Closes #7123

## Test plan
- [ ] Open Remotion Studio with a composition containing audio
- [ ] Verify waveforms still render correctly in the timeline
- [ ] Verify that scrubbing and playback controls remain responsive while waveforms are drawing
- [ ] Verify in a browser without `scheduler.postTask` support (e.g. Firefox) that waveforms still render via the synchronous fallback

Made with [Cursor](https://cursor.com)