### PR TITLE
`@remotion/vercel`: Add `timeoutInMilliseconds` option to `createSandbox()`

### DIFF
--- a/packages/docs/docs/vercel/create-sandbox.mdx
+++ b/packages/docs/docs/vercel/create-sandbox.mdx
@@ -71,6 +71,12 @@ const sandbox = await createSandbox({
 
 Default: `{vcpus: 4}`.
 
+### `timeoutInMilliseconds?`
+
+The maximum time allowed for the sandbox to be created, in milliseconds. If exceeded, sandbox creation is aborted.
+
+Default: `300000` (5 minutes).
+
 ## Return value
 
 A [`VercelSandbox`](/docs/vercel/types#vercelsandbox) object (a [`Sandbox`](https://vercel.com/docs/vercel-sandbox/sdk-reference#sandbox-class) with `AsyncDisposable` support).

--- a/packages/vercel/src/create-sandbox.ts
+++ b/packages/vercel/src/create-sandbox.ts
@@ -18,9 +18,11 @@ export const SANDBOX_CREATING_TIMEOUT = 5 * 60 * 1000;
 export async function createSandbox({
 	onProgress,
 	resources = {vcpus: 4},
+	timeoutInMilliseconds = SANDBOX_CREATING_TIMEOUT,
 }: {
 	onProgress?: CreateSandboxOnProgress;
 	resources?: CreateSandboxResources;
+	timeoutInMilliseconds?: number;
 } = {}): Promise<VercelSandbox> {
 	const report = async (progress: number, message: string) => {
 		await onProgress?.({progress, message});
@@ -29,7 +31,7 @@ export async function createSandbox({
 	const sandbox = await createDisposableSandbox({
 		runtime: 'node24',
 		resources,
-		timeout: SANDBOX_CREATING_TIMEOUT,
+		timeout: timeoutInMilliseconds,
 	});
 
 	// Preparation has 2 stages with weights:


### PR DESCRIPTION
## Motivation

My builds were failing because the `create-snapshot` step (which calls `createSandbox()`) was timing out. The hard-coded 5-minute `SANDBOX_CREATING_TIMEOUT` wasn't enough for my workload (larger resource class, slower cold-start), and there was no way to raise it without forking the function. Conversely, other users with tight CI budgets may want to lower it for fail-fast behavior. An optional override is the minimal idiomatic fix.

## Summary

- Adds an optional `timeoutInMilliseconds` parameter to `createSandbox()` in `@remotion/vercel`, letting callers override the 5-minute sandbox creation timeout (`SANDBOX_CREATING_TIMEOUT`) without forking the function.
- Defaults to `SANDBOX_CREATING_TIMEOUT`, so existing callers see no behavior change.
- Follows the repo's naming convention of including units in variable names (per `packages/docs/docs/contributing/feature.mdx`, which names `timeoutInMilliseconds` as the canonical example).

## Files changed

- `packages/vercel/src/create-sandbox.ts` — new optional field on the options object, threaded into `createDisposableSandbox`.
- `packages/docs/docs/vercel/create-sandbox.mdx` — new `### timeoutInMilliseconds?` entry under Arguments.

## Test plan

- [ ] `bunx turbo run lint --filter=@remotion/vercel` passes
- [ ] `bunx oxfmt packages/vercel/src packages/docs/docs/vercel --check` passes
- [ ] Existing call sites in `packages/template-vercel` still compile unchanged (field is optional)
- [ ] Manually verify passing `timeoutInMilliseconds: 1000` triggers early timeout, and omitting it preserves the 5-minute default

🤖 Generated with [Claude Code](https://claude.com/claude-code)