### PR TITLE
`@remotion/vercel`: Add `<AvailableFrom>` tag to `timeoutInMilliseconds`

### DIFF
--- a/packages/docs/docs/vercel/create-sandbox.mdx
+++ b/packages/docs/docs/vercel/create-sandbox.mdx
@@ -71,7 +71,7 @@ const sandbox = await createSandbox({
 
 Default: `{vcpus: 4}`.
 
-### `timeoutInMilliseconds?`
+### `timeoutInMilliseconds?`<AvailableFrom v="4.0.452" />
 
 The maximum time allowed for the sandbox to be created, in milliseconds. If exceeded, sandbox creation is aborted.
 


### PR DESCRIPTION
## Summary
- Adds `<AvailableFrom v="4.0.452" />` to the `timeoutInMilliseconds` option heading in the `createSandbox()` docs, following the convention used throughout the docs.
- Follow-up to #7130.

Made with [Cursor](https://cursor.com)