### PR TITLE
`@remotion/renderer`: Enable HTML-in-canvas during rendering

### DIFF
--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -44,7 +44,11 @@ export type ChromiumOptions = {
 const featuresToEnable = (option?: OpenGlRenderer | null) => {
 	const renderer = option ?? DEFAULT_OPENGL_RENDERER;
 
-	const enableAlways = ['NetworkService', 'NetworkServiceInProcess'];
+	const enableAlways = [
+		'NetworkService',
+		'NetworkServiceInProcess',
+		'CanvasDrawElement',
+	];
 
 	if (renderer === 'vulkan') {
 		return [...enableAlways, 'Vulkan', 'UseSkiaRenderer'];


### PR DESCRIPTION
## Summary
- Add `CanvasDrawElement` to the list of always-enabled Chrome features when launching the browser

## Test plan
- Verify that Chrome launches successfully with the new feature flag

Made with [Cursor](https://cursor.com)