### PR TITLE
`@remotion/fonts`: Add validation for loadFont() arguments

### DIFF
--- a/packages/fonts/src/get-font-format.ts
+++ b/packages/fonts/src/get-font-format.ts
@@ -1,6 +1,12 @@
 export type FontFormat = 'woff2' | 'woff' | 'opentype' | 'truetype';
 
 export const getFontFormat = (url: string): FontFormat => {
+	if (typeof url !== 'string') {
+		throw new TypeError(
+			`Expected a URL string but received ${url === undefined ? 'undefined' : typeof url}. Make sure to pass a "url" field in the options object of loadFont().`,
+		);
+	}
+
 	const ext = url.split('.').pop()?.toLowerCase();
 	switch (ext) {
 		case 'woff2':

--- a/packages/fonts/src/load-font.ts
+++ b/packages/fonts/src/load-font.ts
@@ -18,21 +18,35 @@ export type LoadFontOptions = {
 	format?: FontFormat;
 };
 
-export const loadFont = async ({
-	family,
-	url,
-	ascentOverride,
-	descentOverride,
-	display,
-	featureSettings,
-	lineGapOverride,
-	stretch,
-	style,
-	unicodeRange,
-	weight,
-	format,
-	variant,
-}: LoadFontOptions): Promise<void> => {
+export const loadFont = async (options: LoadFontOptions): Promise<void> => {
+	if (typeof options !== 'object' || options === null) {
+		throw new TypeError(
+			`loadFont() requires an object as its argument, but received ${typeof options === 'string' ? `"${options}"` : typeof options}. If you want to load a Google Font, use the @remotion/google-fonts package instead. See: https://www.remotion.dev/docs/google-fonts/load-font`,
+		);
+	}
+
+	const {
+		family,
+		url,
+		ascentOverride,
+		descentOverride,
+		display,
+		featureSettings,
+		lineGapOverride,
+		stretch,
+		style,
+		unicodeRange,
+		weight,
+		format,
+		variant,
+	} = options;
+
+	if (typeof url !== 'string') {
+		throw new TypeError(
+			`loadFont() requires a "url" field in the options object, but received ${url === undefined ? 'undefined' : JSON.stringify(url)}. If you want to load a Google Font, use the @remotion/google-fonts package instead. See: https://www.remotion.dev/docs/google-fonts/load-font`,
+		);
+	}
+
 	const waitForFont = delayRender(
 		`Loading font ${family} (url: ${url}, format: ${format}, weight: ${weight}, style: ${style}, variant: ${variant}, ascentOverride: ${ascentOverride}, descentOverride: ${descentOverride}, display: ${display}, featureSettings: ${featureSettings}, lineGapOverride: ${lineGapOverride}, stretch: ${stretch}, unicodeRange: ${unicodeRange})`,
 	);


### PR DESCRIPTION
## Summary

Fixes #7133.

- When `loadFont()` from `@remotion/fonts` is called with incorrect arguments (e.g. a string like `"google"` instead of an options object), `getFontFormat()` crashes with **"Cannot read properties of undefined (reading 'split')"** because `url` is `undefined`.
- Adds runtime validation to `loadFont()` to check that the argument is an object and that `url` is a string, throwing a helpful error that suggests using `@remotion/google-fonts` if appropriate.
- Adds a defensive guard in `getFontFormat()` for non-string `url` inputs.

## Test plan

- [x] `bunx turbo run make --filter='@remotion/fonts'` builds successfully
- [x] `bun run formatting` passes
- [x] `bun run lint` passes


Made with [Cursor](https://cursor.com)