### PR TITLE
`remotion/lambda`: Fix `numberOfGifLoops` default causing non-GIF renders to fail in PHP SDK

### DIFF
--- a/packages/it-tests/src/monorepo/php-package.test.ts
+++ b/packages/it-tests/src/monorepo/php-package.test.ts
@@ -106,7 +106,7 @@ class Semantic
 				logLevel: 'info',
 				maxRetries: 1,
 				muted: false,
-				numberOfGifLoops: 0,
+				numberOfGifLoops: null,
 				offthreadVideoCacheSizeInBytes: null,
 				offthreadVideoThreads: null,
 				outName: null,

--- a/packages/lambda-php/src/RenderParams.php
+++ b/packages/lambda-php/src/RenderParams.php
@@ -30,7 +30,7 @@ class RenderParams
     protected $chromiumOptions = null;
     protected $scale = 1;
     protected $everyNthFrame = 1;
-    protected $numberOfGifLoops = 0;
+    protected $numberOfGifLoops = null;
     protected $concurrencyPerLambda = 1;
     protected $concurrency = null;
     protected $downloadBehavior = [
@@ -82,7 +82,7 @@ class RenderParams
         ?object $chromiumOptions = null,
         ?int    $scale = 1,
         ?int    $everyNthFrame = 1,
-        ?int    $numberOfGifLoops = 0,
+        ?int    $numberOfGifLoops = null,
         ?int    $concurrencyPerLambda = 1,
         ?int    $concurrency = null,
         ?array  $downloadBehavior = null,


### PR DESCRIPTION
## Summary

- Fixes the PHP SDK (`remotion/lambda`) sending `numberOfGifLoops: 0` by default for all codecs, which causes non-GIF Lambda renders to fail with validation error since v4.0.424
- Changes the default from `0` to `null` in both the property declaration and constructor parameter, mirroring the Python SDK fix from #6751

Closes #7136

## Test plan

- [ ] Verify that non-GIF renders (e.g. `h264`) no longer fail with `"numberOfGifLoops" can only be set if "codec" is set to "gif"` error
- [ ] Verify that GIF renders still work when `numberOfGifLoops` is explicitly set

Made with [Cursor](https://cursor.com)