### PR TITLE
Docs: Highlight Chrome Canary requirement for HTML-in-canvas

### DIFF
--- a/packages/docs/docs/client-side-rendering/html-in-canvas.mdx
+++ b/packages/docs/docs/client-side-rendering/html-in-canvas.mdx
@@ -14,6 +14,10 @@ Experimental feature - expect bugs and breaking changes at any time.
 
 On supported Chromium-based browsers, [`@remotion/web-renderer`](/docs/web-renderer) can optionally capture full frames using the experimental [HTML-in-canvas](https://github.com/WICG/html-in-canvas) APIs.
 
+:::info
+As of April 2026, this feature requires [Chrome Canary](https://www.google.com/chrome/canary/). Regular Chrome has partial support (`drawElementImage`) but is missing `canvas.requestPaint()`, which can cause rendering issues such as frames being repeated. See [Compatibility](#compatibility) for details.
+:::
+
 Enabling the option does not guarantee that this path runs. If the browser does not have HTML-in-canvas enabled, it falls back to the [default frame capturing mechanism](/docs/client-side-rendering/how-it-works).
 
 ## Enabling
@@ -95,6 +99,8 @@ If HTML-in-canvas is not available, or not allowed, no warning will be printed.
 />
 
 HTML-in-canvas depends on Chromium flag `chrome://flags/#canvas-draw-element` which needs to be explicitly enabled as of time of writing in April 2026.
+
+As of April 2026, [Chrome Canary](https://www.google.com/chrome/canary/) is required for full support. Regular Chrome exposes `drawElementImage` when the flag is enabled, but does not yet ship `canvas.requestPaint()`. Without `requestPaint()`, the renderer cannot synchronize paint operations, which can lead to repeated or incorrect frames.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Adds a prominent info box near the top of the HTML-in-canvas docs page noting that Chrome Canary is required for full support
- Expands the Compatibility section to explain that regular Chrome is missing `canvas.requestPaint()`, which can cause repeated or incorrect frames

## Test plan
- [ ] Verify the docs page renders correctly with `cd packages/docs && bun run start`


Made with [Cursor](https://cursor.com)