### PR TITLE
`@remotion/player`: Fix `timeupdate` event not firing in Firefox

### DIFF
--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -35,7 +35,7 @@ export const usePlayback = ({
 	// In that case, we use setTimeout() instead.
 	const isBackgroundedRef = useIsBackgrounded();
 
-	const lastTimeUpdateEvent = useRef<number | null>(null);
+	const lastTimeUpdateTimestamp = useRef<number>(0);
 
 	const context = useContext(Internals.BufferingContextReact);
 	if (!context) {
@@ -194,17 +194,22 @@ export const usePlayback = ({
 	]);
 
 	useEffect(() => {
-		const interval = setInterval(() => {
-			if (lastTimeUpdateEvent.current === getCurrentFrame()) {
-				return;
-			}
+		const now = performance.now();
+		const timeSinceLastUpdate = now - lastTimeUpdateTimestamp.current;
 
-			emitter.dispatchTimeUpdate({frame: getCurrentFrame()});
-			lastTimeUpdateEvent.current = getCurrentFrame();
-		}, 250);
+		if (timeSinceLastUpdate >= 250) {
+			emitter.dispatchTimeUpdate({frame});
+			lastTimeUpdateTimestamp.current = now;
+			return;
+		}
 
-		return () => clearInterval(interval);
-	}, [emitter, getCurrentFrame]);
+		const timeoutId = setTimeout(() => {
+			emitter.dispatchTimeUpdate({frame});
+			lastTimeUpdateTimestamp.current = performance.now();
+		}, 250 - timeSinceLastUpdate);
+
+		return () => clearTimeout(timeoutId);
+	}, [emitter, frame]);
 
 	useEffect(() => {
 		emitter.dispatchFrameUpdate({frame});


### PR DESCRIPTION
## Summary

- Fixes a Firefox-specific bug where the `timeupdate` event only fires on pause/resume, not during active playback (#7144)
- Replaces `setInterval`-based polling with a throttled React `useEffect` driven by `frame` state changes — the same mechanism that makes `frameupdate` work reliably across all browsers
- Preserves the 250ms throttle interval using leading + trailing edge dispatch via `setTimeout`

## Why

The previous implementation used `setInterval` to poll `getCurrentFrame()` every 250ms. Firefox does not reliably fire `setInterval` callbacks during active `requestAnimationFrame` playback loops. The new approach ties `timeupdate` dispatch to the React render cycle (triggered by frame state changes), which works consistently across browsers.

## Test plan

- [ ] Verify `timeupdate` fires regularly (~every 250ms) during playback in Firefox
- [ ] Verify `timeupdate` fires regularly during playback in Chrome (no regression)
- [ ] Verify `timeupdate` fires on seek while paused
- [ ] Verify `timeupdate` reports the final frame position when playback stops
- [ ] Verify `frameupdate` still works correctly (no changes to that codepath)


Made with [Cursor](https://cursor.com)