### PR TITLE
CI: Upgrade Bun to 1.3.13 and run `bun ci --verbose`

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@main
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Push changelog
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 20
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Cache turbo build setup
         uses: actions/cache@v5
         with:

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: 25
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Install
         run: bun ci
       - name: Cache Turbo

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,9 +20,9 @@ jobs:
           node-version: 25
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Install
-        run: bun ci
+        run: bun ci --verbose
       - name: Cache Turbo
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Test Lambda IT
@@ -46,9 +46,9 @@ jobs:
           node-version: 25
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Install
-        run: bun ci
+        run: bun ci --verbose
       - name: Cache Turbo
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Test Lambda IT
@@ -68,9 +68,9 @@ jobs:
           node-version: 25
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Install
-        run: bun ci
+        run: bun ci --verbose
       - name: Install deps
         run: cd packages/webcodecs && bunx playwright install --with-deps
       - name: Cache Turbo
@@ -93,9 +93,9 @@ jobs:
           node-version: 25
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Install
-        run: bun ci
+        run: bun ci --verbose
       - name: Install deps
         run: cd packages/web-renderer && bunx playwright install --with-deps && cd ../media && bunx playwright install --with-deps
       - name: Cache Turbo
@@ -113,9 +113,9 @@ jobs:
           node-version: 16
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Install
-        run: bun ci
+        run: bun ci --verbose
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -152,7 +152,7 @@ jobs:
           node-version: 25
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Check if template tests are affected
         id: check
         run: |
@@ -192,7 +192,7 @@ jobs:
           node-version: 25
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Cache Bun dependencies (Windows)
         if: matrix.os == 'windows-latest'
         uses: actions/cache@v5
@@ -202,7 +202,7 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-bun-
       - name: Install
-        run: bun ci
+        run: bun ci --verbose
       - name: Cache Turbo
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Test templates
@@ -219,9 +219,9 @@ jobs:
           node-version: 25
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Install
-        run: bun ci
+        run: bun ci --verbose
         env:
           CI: true
       - name: Cache Turbo
@@ -252,7 +252,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
       - uses: oven-sh/setup-bun@v2.1.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.13
       - name: Cache Bun dependencies (Windows)
         if: matrix.os == 'windows-latest'
         uses: actions/cache@v5
@@ -262,7 +262,7 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-bun-
       - name: Install
-        run: bun ci
+        run: bun ci --verbose
       - name: Cache Turbo
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Build & Test

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"turbo": "2.9.3",
 		"@typescript/native-preview": "catalog:"
 	},
-	"packageManager": "bun@1.3.3",
+	"packageManager": "bun@1.3.13",
 	"overrides": {
 		"caniuse-lite": "1.0.30001766",
 		"@rspack/core": "1.7.6"


### PR DESCRIPTION
## Why

Since 2026-04-24, every `Install and Test` run on `ubuntu-latest` / `macos-latest` hangs at the `bun ci` step right after `Resolved, downloaded and extracted [N]`, until the job times out. Windows is unaffected because the workflow already maintains an `actions/cache@v5` of the bun install cache.

The previous attempt to work around this by forcing IPv4 on the runner (#7147) did not help.

## What

- Bump Bun from `1.3.3` → `1.3.13` everywhere it is pinned (workflows + `package.json` `packageManager`).
- Switch `bun ci` → `bun ci --verbose` so that the next CI failure tells us *which* package or network call hangs, instead of leaving us with a silent stall.

## Rationale

- Bun 1.3.11 shipped explicit "bun install hang fixes" in its release notes.
- Bun 1.3.13 rewrote the install path to stream tarballs to disk instead of buffering them in memory before extraction — this is the most plausible fix if the hang is in Bun's HTTP/extract pipeline rather than purely in network routing.
- Running with `--verbose` on Linux/macOS gives us actionable logs even if 1.3.13 also hangs.

## Test plan

- [ ] Linux + macOS jobs complete `bun ci` within normal time (~30 s) instead of hanging.
- [ ] If they still hang, the `--verbose` output identifies the specific package or step that is stuck.
- [ ] Windows job continues to pass.

Made with [Cursor](https://cursor.com)