### PR TITLE
CI: Drop `--frozen-lockfile` from install (use `bun install --verbose`)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           bun-version: 1.3.3
       - name: Install
-        run: bun ci
+        run: bun install --verbose
       - name: Cache Turbo
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Test Lambda IT
@@ -48,7 +48,7 @@ jobs:
         with:
           bun-version: 1.3.3
       - name: Install
-        run: bun ci
+        run: bun install --verbose
       - name: Cache Turbo
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Test Lambda IT
@@ -70,7 +70,7 @@ jobs:
         with:
           bun-version: 1.3.3
       - name: Install
-        run: bun ci
+        run: bun install --verbose
       - name: Install deps
         run: cd packages/webcodecs && bunx playwright install --with-deps
       - name: Cache Turbo
@@ -95,7 +95,7 @@ jobs:
         with:
           bun-version: 1.3.3
       - name: Install
-        run: bun ci
+        run: bun install --verbose
       - name: Install deps
         run: cd packages/web-renderer && bunx playwright install --with-deps && cd ../media && bunx playwright install --with-deps
       - name: Cache Turbo
@@ -115,7 +115,7 @@ jobs:
         with:
           bun-version: 1.3.3
       - name: Install
-        run: bun ci
+        run: bun install --verbose
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -202,7 +202,7 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-bun-
       - name: Install
-        run: bun ci
+        run: bun install --verbose
       - name: Cache Turbo
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Test templates
@@ -221,7 +221,7 @@ jobs:
         with:
           bun-version: 1.3.3
       - name: Install
-        run: bun ci
+        run: bun install --verbose
         env:
           CI: true
       - name: Cache Turbo
@@ -262,7 +262,7 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-bun-
       - name: Install
-        run: bun ci
+        run: bun install --verbose
       - name: Cache Turbo
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Build & Test


### PR DESCRIPTION
## Why

Since 2026-04-24, every `Install and Test` run on `ubuntu-latest` / `macos-latest` hangs at the `bun ci` step right after `Resolved, downloaded and extracted [N]`, until the job times out. Windows is unaffected because the workflow already maintains an `actions/cache@v5` of the bun install cache.

The previous attempt to work around this by forcing IPv4 on the runner (#7147) did not help.

## What

- Replace `bun ci` (which is `bun install --frozen-lockfile`) with `bun install --verbose` in every `Install and Test` job.

## Rationale

`bun ci` enables `--frozen-lockfile`, which forces Bun down a code path that does extra integrity / lockfile reconciliation work. Multiple upstream reports (e.g. [oven-sh/bun#29516](https://github.com/oven-sh/bun/issues/29516)) describe hangs that only manifest under `--frozen-lockfile` because Bun detects state it cannot reconcile (a postinstall mutated a package.json, an integrity mismatch, etc.) and instead of erroring it just stalls.

Running plain `bun install` lets us isolate whether the hang is in that code path. `--verbose` ensures that if it still hangs, we get actionable logs telling us which package or step stalled, instead of a silent stop after `Resolved, downloaded and extracted [N]`.

This is a temporary diagnostic change for CI only — `bun ci` should be restored once the root cause is understood.

## Test plan

- [ ] Linux + macOS jobs complete `bun install` within normal time (~30 s) instead of hanging.
- [ ] If they still hang, the `--verbose` output identifies the specific package or step that is stuck.
- [ ] Windows job continues to pass.

Made with [Cursor](https://cursor.com)