### PR TITLE
remotion: Ramp up gain on AudioContext resume to avoid click/pop

### DIFF
--- a/packages/core/src/audio/audio-ramp.ts
+++ b/packages/core/src/audio/audio-ramp.ts
@@ -1,0 +1,14 @@
+// Short enough to be imperceptible to the ear, long enough to avoid a click.
+// See https://github.com/remotion-dev/remotion/issues/7140.
+const RAMP_DURATION_SECONDS = 0.02;
+
+export const resumeAudioContextWithRamp = (
+	audioContext: AudioContext,
+	masterGain: GainNode,
+): Promise<void> => {
+	const now = audioContext.currentTime;
+	masterGain.gain.cancelScheduledValues(now);
+	masterGain.gain.setValueAtTime(0, now);
+	masterGain.gain.linearRampToValueAtTime(1, now + RAMP_DURATION_SECONDS);
+	return audioContext.resume();
+};

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -12,6 +12,7 @@ import {useLogLevel, useMountTime} from '../log-level-context.js';
 import {Log} from '../log.js';
 import {playAndHandleNotAllowedError} from '../play-and-handle-not-allowed-error.js';
 import {useRemotionEnvironment} from '../use-remotion-environment.js';
+import {resumeAudioContextWithRamp} from './audio-ramp.js';
 import type {SharedElementSourceNode} from './shared-element-source-node.js';
 import {makeSharedElementSourceNode} from './shared-element-source-node.js';
 import {useSingletonAudioContext} from './use-audio-context.js';
@@ -80,6 +81,7 @@ type SharedContext = {
 	playAllAudios: () => void;
 	numberOfAudioTags: number;
 	audioContext: AudioContext | null;
+	masterGain: GainNode | null;
 	audioSyncAnchor: {value: number};
 	scheduleAudioNode: (
 		options: ScheduleAudioNodeOptions,
@@ -155,11 +157,13 @@ export const SharedAudioContextProvider: React.FC<{
 	}
 
 	const logLevel = useLogLevel();
-	const audioContext = useSingletonAudioContext({
+	const singleton = useSingletonAudioContext({
 		logLevel,
 		latencyHint: audioLatencyHint,
 		audioEnabled,
 	});
+	const audioContext = singleton?.audioContext ?? null;
+	const masterGain = singleton?.masterGain ?? null;
 
 	const audioSyncAnchor = useMemo(() => ({value: 0}), []);
 
@@ -493,8 +497,10 @@ export const SharedAudioContextProvider: React.FC<{
 				isPlayer: env.isPlayer,
 			});
 		});
-		audioContext?.resume();
-	}, [audioContext, logLevel, mountTime, refs, env.isPlayer]);
+		if (audioContext && masterGain) {
+			resumeAudioContextWithRamp(audioContext, masterGain);
+		}
+	}, [audioContext, masterGain, logLevel, mountTime, refs, env.isPlayer]);
 
 	const value: SharedContext = useMemo(() => {
 		return {
@@ -504,6 +510,7 @@ export const SharedAudioContextProvider: React.FC<{
 			playAllAudios,
 			numberOfAudioTags,
 			audioContext,
+			masterGain,
 			audioSyncAnchor,
 			scheduleAudioNode,
 		};
@@ -514,6 +521,7 @@ export const SharedAudioContextProvider: React.FC<{
 		unregisterAudio,
 		updateAudio,
 		audioContext,
+		masterGain,
 		audioSyncAnchor,
 		scheduleAudioNode,
 	]);

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -21,6 +21,14 @@ const warnOnce = (logLevel: LogLevel) => {
 	}
 };
 
+export type SingletonAudioContext = {
+	audioContext: AudioContext;
+	// Master gain node sitting between all sources and `audioContext.destination`.
+	// Used to ramp output up/down on resume() so we don't get a click/pop.
+	// See https://github.com/remotion-dev/remotion/issues/7140.
+	masterGain: GainNode;
+};
+
 export const useSingletonAudioContext = ({
 	logLevel,
 	latencyHint,
@@ -29,10 +37,10 @@ export const useSingletonAudioContext = ({
 	logLevel: LogLevel;
 	latencyHint: AudioContextLatencyCategory;
 	audioEnabled: boolean;
-}) => {
+}): SingletonAudioContext | null => {
 	const env = useRemotionEnvironment();
 
-	const audioContext = useMemo(() => {
+	const singleton = useMemo<SingletonAudioContext | null>(() => {
 		if (env.isRendering) {
 			return null;
 		}
@@ -46,14 +54,17 @@ export const useSingletonAudioContext = ({
 			return null;
 		}
 
-		return new AudioContext({
+		const audioContext = new AudioContext({
 			latencyHint,
 			// By default, this can end up being 44100Hz.
 			// Playing a 48000Hz file in a 44100Hz context, such as https://remotion.media/video.mp4 in a @remotion/media tag
 			// we observe some issues that seem to go away when we set the sample rate to 48000 with Sony LinkBuds Bluetooth headphones.
 			sampleRate: 48000,
 		});
+		const masterGain = audioContext.createGain();
+		masterGain.connect(audioContext.destination);
+		return {audioContext, masterGain};
 	}, [logLevel, latencyHint, env.isRendering, audioEnabled]);
 
-	return audioContext;
+	return singleton;
 };

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -1,5 +1,6 @@
 import {createRef} from 'react';
 import {getAbsoluteSrc} from './absolute-src.js';
+import {resumeAudioContextWithRamp} from './audio/audio-ramp.js';
 import {AudioForPreview} from './audio/AudioForPreview.js';
 import type {ScheduleAudioNodeResult} from './audio/shared-audio-tags.js';
 import {
@@ -279,6 +280,7 @@ export const Internals = {
 	RenderAssetManagerProvider,
 	getEffectiveVisualModeValue,
 	CompositionRenderErrorContext,
+	resumeAudioContextWithRamp,
 } as const;
 
 export type {

--- a/packages/core/src/use-amplification.ts
+++ b/packages/core/src/use-amplification.ts
@@ -62,7 +62,7 @@ export const useVolume = ({
 		);
 	}
 
-	const {audioContext} = sharedAudioContext;
+	const {audioContext, masterGain} = sharedAudioContext;
 
 	if (typeof window !== 'undefined') {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -95,7 +95,7 @@ export const useVolume = ({
 
 			source.attemptToConnect();
 			source.get().connect(gainNode);
-			gainNode.connect(audioContext.destination);
+			gainNode.connect(masterGain ?? audioContext.destination);
 			audioStuffRef.current = {
 				gainNode,
 			};
@@ -110,7 +110,7 @@ export const useVolume = ({
 				gainNode.disconnect();
 				source.get().disconnect();
 			};
-		}, [logLevel, mediaRef, audioContext, source, shouldUseWebAudioApi]);
+		}, [logLevel, mediaRef, audioContext, masterGain, source, shouldUseWebAudioApi]);
 	}
 
 	if (audioStuffRef.current) {

--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -42,7 +42,7 @@ export const audioIteratorManager = ({
 	let currentVolume = 1;
 
 	const gainNode = sharedAudioContext.audioContext.createGain();
-	gainNode.connect(sharedAudioContext.audioContext.destination);
+	gainNode.connect(sharedAudioContext.masterGain);
 
 	const audioSink = new AudioBufferSink(audioTrack);
 	const prewarmedAudioIteratorCache =

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -214,15 +214,21 @@ const AudioForPreviewAssertedShowing: React.FC<
 	useEffect(() => {
 		if (!sharedAudioContext) return;
 		if (!sharedAudioContext.audioContext) return;
+		if (!sharedAudioContext.masterGain) return;
 
-		const {audioContext, audioSyncAnchor, scheduleAudioNode} =
+		const {audioContext, masterGain, audioSyncAnchor, scheduleAudioNode} =
 			sharedAudioContext;
 
 		try {
 			const player = new MediaPlayer({
 				src: preloadedSrc,
 				logLevel,
-				sharedAudioContext: {audioContext, audioSyncAnchor, scheduleAudioNode},
+				sharedAudioContext: {
+					audioContext,
+					masterGain,
+					audioSyncAnchor,
+					scheduleAudioNode,
+				},
 				loop,
 				trimAfter: initialTrimAfterRef.current,
 				trimBefore: initialTrimBeforeRef.current,

--- a/packages/media/src/shared-audio-context-for-media-player.ts
+++ b/packages/media/src/shared-audio-context-for-media-player.ts
@@ -2,6 +2,7 @@ import type {ScheduleAudioNodeOptions, ScheduleAudioNodeResult} from 'remotion';
 
 export type SharedAudioContextForMediaPlayer = {
 	audioContext: AudioContext;
+	masterGain: GainNode;
 	audioSyncAnchor: {value: number};
 	scheduleAudioNode: (
 		options: ScheduleAudioNodeOptions,

--- a/packages/media/src/test/audio-cleanup-on-seek.test.ts
+++ b/packages/media/src/test/audio-cleanup-on-seek.test.ts
@@ -51,6 +51,7 @@ const makeMockSharedAudioContext = ({
 			currentTime,
 			getOutputTimestamp: () => ({contextTime: currentTime}),
 		} as unknown as AudioContext,
+		masterGain: {} as unknown as GainNode,
 		audioSyncAnchor: {value: anchorValue},
 		scheduleAudioNode: () => ({type: 'started', scheduledTime: 0}),
 	};

--- a/packages/media/src/test/audio-iterator.test.ts
+++ b/packages/media/src/test/audio-iterator.test.ts
@@ -24,6 +24,7 @@ const prepare = async () => {
 		}),
 		sharedAudioContext: {
 			audioContext,
+			masterGain: audioContext.createGain(),
 			audioSyncAnchor: {value: 0},
 			scheduleAudioNode: () => ({
 				type: 'started',
@@ -238,6 +239,7 @@ test('should not schedule duplicate chunks with playbackRate=0.5', async () => {
 		}),
 		sharedAudioContext: {
 			audioContext,
+			masterGain: audioContext.createGain(),
 			audioSyncAnchor: {value: 0},
 			scheduleAudioNode: () => ({
 				type: 'started',
@@ -314,6 +316,7 @@ test('should not decode + schedule audio chunks beyond the end time', async () =
 		}),
 		sharedAudioContext: {
 			audioContext,
+			masterGain: audioContext.createGain(),
 			audioSyncAnchor: {value: 0},
 			scheduleAudioNode: () => ({
 				type: 'started',

--- a/packages/media/src/test/media-player.test.ts
+++ b/packages/media/src/test/media-player.test.ts
@@ -23,8 +23,11 @@ test('dispose should immediately unblock playback delays', async () => {
 	};
 
 	const audioContext = new AudioContext();
+	const masterGain = audioContext.createGain();
+	masterGain.connect(audioContext.destination);
 	const sharedAudioContext: SharedAudioContextForMediaPlayer = {
 		audioContext,
+		masterGain,
 		audioSyncAnchor: {value: 0},
 		scheduleAudioNode: () => ({
 			type: 'started',

--- a/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
+++ b/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
@@ -89,14 +89,18 @@ test('same goes for audio', async () => {
 			unblock: () => {},
 			[Symbol.dispose]: () => {},
 		}),
-		sharedAudioContext: {
-			audioContext: new AudioContext(),
-			audioSyncAnchor: {value: 0},
-			scheduleAudioNode: () => ({
-				type: 'started',
-				scheduledTime: 0,
-			}),
-		},
+		sharedAudioContext: (() => {
+			const ctx = new AudioContext();
+			return {
+				audioContext: ctx,
+				masterGain: ctx.createGain(),
+				audioSyncAnchor: {value: 0},
+				scheduleAudioNode: () => ({
+					type: 'started',
+					scheduledTime: 0,
+				}),
+			};
+		})(),
 		getIsLooping: () => false,
 		getEndTime: () => Infinity,
 		getStartTime: () => 0,

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -263,8 +263,9 @@ const VideoForPreviewAssertedShowing: React.FC<
 	useEffect(() => {
 		if (!sharedAudioContext) return;
 		if (!sharedAudioContext.audioContext) return;
+		if (!sharedAudioContext.masterGain) return;
 
-		const {audioContext, audioSyncAnchor, scheduleAudioNode} =
+		const {audioContext, masterGain, audioSyncAnchor, scheduleAudioNode} =
 			sharedAudioContext;
 
 		try {
@@ -272,7 +273,12 @@ const VideoForPreviewAssertedShowing: React.FC<
 				canvas: canvasRef.current,
 				src: preloadedSrc,
 				logLevel,
-				sharedAudioContext: {audioContext, audioSyncAnchor, scheduleAudioNode},
+				sharedAudioContext: {
+					audioContext,
+					masterGain,
+					audioSyncAnchor,
+					scheduleAudioNode,
+				},
 				loop,
 				trimAfter: initialTrimAfterRef.current,
 				trimBefore: initialTrimBeforeRef.current,

--- a/packages/player/src/use-player.ts
+++ b/packages/player/src/use-player.ts
@@ -82,7 +82,12 @@ export const usePlayer = (): UsePlayerMethods => {
 				seek(0);
 			}
 
-			audioContext?.audioContext?.resume();
+			if (audioContext?.audioContext && audioContext.masterGain) {
+				Internals.resumeAudioContextWithRamp(
+					audioContext.audioContext,
+					audioContext.masterGain,
+				);
+			}
 
 			/**
 			 * Play silent audio tags to warm them up for autoplay


### PR DESCRIPTION
Closes #7140.

## Summary

Resuming an `AudioContext` after a user-initiated pause currently produces an audible click/pop, because audio output starts abruptly at full volume the moment the context transitions back to `running`.

This PR introduces a master `GainNode` between every audio source and `audioContext.destination`, and ramps that gain from `0` → `1` over 20 ms whenever the context is resumed — short enough to be imperceptible, long enough to eliminate the discontinuity.

## Changes

**New helper**
- `packages/core/src/audio/audio-ramp.ts` — `resumeAudioContextWithRamp(audioContext, masterGain)` schedules `setValueAtTime(0)` + `linearRampToValueAtTime(1, +0.02s)` on the master gain, then calls `audioContext.resume()`.

**Routing**
- `useSingletonAudioContext` now also creates a `masterGain` node and connects it to `destination`. Returned as `{audioContext, masterGain}`.
- `SharedAudioContext` (core) and `SharedAudioContextForMediaPlayer` (media) expose `masterGain`.
- `useAmplification` (core) and `audioIteratorManager` (media) connect each per-source `GainNode` to `masterGain` instead of `audioContext.destination`.

**Resume call sites**
- `playAllAudios()` in `shared-audio-tags.tsx` and `play()` in `@remotion/player`'s `use-player.ts` now use `resumeAudioContextWithRamp(...)` instead of `audioContext.resume()`.

**Tests**
- Updated 4 test files in `@remotion/media` that construct `SharedAudioContextForMediaPlayer` to include the new `masterGain` field.

## Test plan

- [ ] `bun run build` passes
- [ ] `bun run stylecheck` passes
- [ ] `bun test` in `packages/core` and `packages/media` pass
- [ ] Manual: in `packages/player-example`, pause and resume playback of a composition with audio — verify the click/pop is gone and audio still sounds at the user's set volume
- [ ] Manual: verify per-track volume control (`volume` prop on `<Audio>` / `<Video>`) still works (per-source gain is preserved; only master is ramped)

## Notes

- The master gain stays at `1` outside of resume ramps, so existing per-source volume behavior is unchanged.
- 20 ms is the documented sweet spot in the issue; not exposed as a tunable to keep surface area minimal.
- Ramp-down on `suspend()` is a logical follow-up but intentionally out of scope — the issue title focuses on resume, and pause-time clicks are less common in practice.
