### PR TITLE
`@remotion/media`: Skip video decoding when used in `<Audio>` tag

### DIFF
--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -251,6 +251,7 @@ const AudioForPreviewAssertedShowing: React.FC<
 				playing: initialPlaying.current,
 				sequenceOffset: initialSequenceOffset.current,
 				credentials,
+				tagType: 'audio',
 			});
 
 			mediaPlayerRef.current = player;

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -30,6 +30,7 @@ export type MediaPlayerInitResult =
 	| {type: 'disposed'};
 
 export class MediaPlayer {
+	private tagType: 'audio' | 'video';
 	private canvas: HTMLCanvasElement | OffscreenCanvas | null;
 	private context:
 		| OffscreenCanvasRenderingContext2D
@@ -94,6 +95,7 @@ export class MediaPlayer {
 		playing,
 		sequenceOffset,
 		credentials,
+		tagType,
 	}: {
 		canvas: HTMLCanvasElement | OffscreenCanvas | null;
 		src: string;
@@ -115,6 +117,7 @@ export class MediaPlayer {
 		playing: boolean;
 		sequenceOffset: number;
 		credentials: RequestCredentials | undefined;
+		tagType: 'audio' | 'video';
 	}) {
 		this.canvas = canvas ?? null;
 		this.src = src;
@@ -147,6 +150,7 @@ export class MediaPlayer {
 			),
 			formats: ALL_FORMATS,
 		});
+		this.tagType = tagType;
 
 		if (canvas) {
 			const context = canvas.getContext('2d', {
@@ -263,7 +267,7 @@ export class MediaPlayer {
 				return {type: 'no-tracks'};
 			}
 
-			if (videoTrack) {
+			if (videoTrack && this.tagType === 'video') {
 				const canDecode = await videoTrack.canDecode();
 
 				if (!canDecode) {

--- a/packages/media/src/test/media-player.test.ts
+++ b/packages/media/src/test/media-player.test.ts
@@ -55,6 +55,7 @@ test('dispose should immediately unblock playback delays', async () => {
 		playing: false,
 		sequenceOffset: 0,
 		credentials: undefined,
+		tagType: 'video',
 	});
 
 	await player.initialize(0, false);

--- a/packages/media/src/test/trim-change-seek.test.ts
+++ b/packages/media/src/test/trim-change-seek.test.ts
@@ -23,6 +23,7 @@ test('setTrimBefore and setTrimAfter should update frame when paused', async () 
 		playing: false,
 		sequenceOffset: 0,
 		credentials: undefined,
+		tagType: 'video',
 	});
 
 	await player.initialize(0, false);

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -302,6 +302,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 				playing: initialPlaying.current,
 				sequenceOffset: initialSequenceOffset.current,
 				credentials,
+				tagType: 'video',
 			});
 
 			mediaPlayerRef.current = player;


### PR DESCRIPTION
😳