### PR TITLE
`@remotion/media`: Decode 1 frame ahead of time

### DIFF
--- a/packages/media/src/canvas-ahead-of-time.ts
+++ b/packages/media/src/canvas-ahead-of-time.ts
@@ -1,0 +1,88 @@
+import type {CanvasSink, WrappedCanvas} from 'mediabunny';
+
+export type CanvasAheadOfTimeNext =
+	| {type: 'ready'; frame: WrappedCanvas | null}
+	| {type: 'pending'; wait: () => Promise<WrappedCanvas | null>};
+
+export const canvasesAheadOfTime = (
+	videoSink: CanvasSink,
+	startTimestamp?: number,
+) => {
+	const iterator = videoSink.canvases(startTimestamp);
+
+	let inFlight: Promise<IteratorResult<WrappedCanvas, void>> = iterator.next();
+	let resolved: IteratorResult<WrappedCanvas, void> | null = null;
+
+	const trackResolution = () => {
+		const captured = inFlight;
+		captured.then(
+			(result) => {
+				if (captured === inFlight) {
+					resolved = result;
+				}
+			},
+			() => undefined,
+		);
+	};
+
+	trackResolution();
+
+	const advance = () => {
+		inFlight = iterator.next();
+		resolved = null;
+		trackResolution();
+	};
+
+	const next = (): CanvasAheadOfTimeNext => {
+		if (resolved) {
+			if (resolved.done) {
+				return {type: 'ready', frame: null};
+			}
+
+			const frame = resolved.value;
+			advance();
+			return {type: 'ready', frame};
+		}
+
+		const captured = inFlight;
+		return {
+			type: 'pending',
+			wait: async () => {
+				const result = await captured;
+				if (captured === inFlight && !result.done) {
+					advance();
+				}
+
+				return result.done ? null : result.value;
+			},
+		};
+	};
+
+	const closeFrame = (frame: WrappedCanvas) => {
+		(frame as unknown as {close?: () => void}).close?.();
+	};
+
+	const closeIterator = async () => {
+		if (resolved) {
+			if (!resolved.done) {
+				closeFrame(resolved.value);
+			}
+		} else {
+			const captured = inFlight;
+			captured.then(
+				(result) => {
+					if (!result.done) {
+						closeFrame(result.value);
+					}
+				},
+				() => undefined,
+			);
+		}
+
+		await iterator.return();
+	};
+
+	return {next, closeIterator};
+};
+
+export type CanvasAheadOfTimeIterator = ReturnType<typeof canvasesAheadOfTime>;

--- a/packages/media/src/prewarm-iterator-for-looping.ts
+++ b/packages/media/src/prewarm-iterator-for-looping.ts
@@ -1,14 +1,17 @@
-import type {CanvasSink, WrappedCanvas} from 'mediabunny';
+import type {CanvasSink} from 'mediabunny';
+import type {CanvasAheadOfTimeIterator} from './canvas-ahead-of-time';
+import {canvasesAheadOfTime} from './canvas-ahead-of-time';
 
 export const makePrewarmedVideoIteratorCache = (videoSink: CanvasSink) => {
-	const prewarmedVideoIterators: Map<
-		number,
-		AsyncGenerator<WrappedCanvas, void, unknown>
-	> = new Map();
+	const prewarmedVideoIterators: Map<number, CanvasAheadOfTimeIterator> =
+		new Map();
 
 	const prewarmIteratorForLooping = ({timeToSeek}: {timeToSeek: number}) => {
 		if (!prewarmedVideoIterators.has(timeToSeek)) {
-			prewarmedVideoIterators.set(timeToSeek, videoSink.canvases(timeToSeek));
+			prewarmedVideoIterators.set(
+				timeToSeek,
+				canvasesAheadOfTime(videoSink, timeToSeek),
+			);
 		}
 	};
 
@@ -19,13 +22,12 @@ export const makePrewarmedVideoIteratorCache = (videoSink: CanvasSink) => {
 			return prewarmedIterator;
 		}
 
-		const iterator = videoSink.canvases(timeToSeek);
-		return iterator;
+		return canvasesAheadOfTime(videoSink, timeToSeek);
 	};
 
 	const destroy = () => {
 		for (const iterator of prewarmedVideoIterators.values()) {
-			iterator.return();
+			iterator.closeIterator();
 		}
 
 		prewarmedVideoIterators.clear();

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -126,8 +126,7 @@ export const videoIteratorManager = ({
 			}
 		}
 
-		const videoSatisfyResult =
-			await videoFrameIterator.tryToSatisfySeek(newTime);
+		const videoSatisfyResult = videoFrameIterator.tryToSatisfySeek(newTime);
 
 		// Doing this before the staleness check, because
 		// frame might be better than what we currently have

--- a/packages/media/src/video/video-preview-iterator.ts
+++ b/packages/media/src/video/video-preview-iterator.ts
@@ -10,55 +10,53 @@ export const createVideoIterator = async (
 	const iterator = cache.makeIteratorOrUsePrewarmed(timeToSeek);
 	let iteratorEnded = false;
 
-	const initialFrame = (await iterator.next())?.value ?? null;
+	const firstAwait = iterator.next();
+	const initialFrame =
+		firstAwait && firstAwait.type === 'ready'
+			? firstAwait.frame
+			: await firstAwait.wait();
 	let lastReturnedFrame = initialFrame;
 
-	const getNextOrNullIfNotAvailable = async () => {
+	const getNextOrNullIfNotAvailable = () => {
 		const next = iterator.next();
-		const result = await Promise.race([
-			next,
-			new Promise<void>((resolve) => {
-				Promise.resolve().then(() => resolve());
-			}),
-		]);
 
-		if (!result) {
+		if (next.type === 'pending') {
 			return {
 				type: 'need-to-wait-for-it' as const,
 				waitPromise: async () => {
-					const res = await next;
-					if (res.value) {
-						lastReturnedFrame = res.value;
+					const res = await next.wait();
+					if (res) {
+						lastReturnedFrame = res;
 					} else {
 						iteratorEnded = true;
 					}
 
-					return res.value;
+					return res;
 				},
 			};
 		}
 
-		if (result.value) {
-			lastReturnedFrame = result.value;
+		if (next.frame) {
+			lastReturnedFrame = next.frame;
 		} else {
 			iteratorEnded = true;
 		}
 
 		return {
 			type: 'got-frame-or-end' as const,
-			frame: result.value ?? null,
+			frame: next.frame ?? null,
 		};
 	};
 
 	const destroy = () => {
 		destroyed = true;
 		lastReturnedFrame = null;
-		iterator.return().catch(() => undefined);
+		iterator.closeIterator().catch(() => undefined);
 	};
 
-	const tryToSatisfySeek = async (
+	const tryToSatisfySeek = (
 		time: number,
-	): Promise<
+	):
 		| {
 				type: 'not-satisfied';
 				reason: string;
@@ -66,8 +64,7 @@ export const createVideoIterator = async (
 		| {
 				type: 'satisfied';
 				frame: WrappedCanvas;
-		  }
-	> => {
+		  } => {
 		if (lastReturnedFrame) {
 			const frameTimestamp = roundTo4Digits(lastReturnedFrame.timestamp);
 
@@ -117,7 +114,7 @@ export const createVideoIterator = async (
 		}
 
 		while (true) {
-			const frame = await getNextOrNullIfNotAvailable();
+			const frame = getNextOrNullIfNotAvailable();
 			if (frame.type === 'need-to-wait-for-it') {
 				return {
 					type: 'not-satisfied' as const,


### PR DESCRIPTION
## Summary
- Adds `canvasesAheadOfTime()` wrapper around `CanvasSink.canvases()` that always keeps one `.next()` call in flight, so a frame can be yielded synchronously when it is already decoded.
- Replaces the `Promise.race`-based "is the next frame ready?" hack in the video preview iterator with the new typed `{type: 'ready'} | {type: 'pending'}` API.
- `closeIterator()` releases any prefetched/in-flight `WrappedCanvas` before returning the underlying iterator to avoid leaking a slot in the canvas pool.

## Test plan
- [ ] Existing media playback tests pass
- [ ] Looping playback still pre-warms iterators correctly