### PR TITLE
`@remotion/renderer`: Fix ENOENT crash when uncompressing assets with duplicate id and frame

### DIFF
--- a/packages/renderer/src/assets/types.ts
+++ b/packages/renderer/src/assets/types.ts
@@ -39,7 +39,8 @@ export const uncompressMediaAsset = (
 	const [, id, frame] = isCompressed;
 
 	const assetToFill = allRenderAssets.find(
-		(a) => a.id === id && String(a.frame) === frame,
+		(a) =>
+			a.id === id && String(a.frame) === frame && !a.src.startsWith('same-as'),
 	);
 	if (!assetToFill) {
 		console.log('List of assets:');

--- a/packages/renderer/src/test/asset-compression.test.ts
+++ b/packages/renderer/src/test/asset-compression.test.ts
@@ -1,6 +1,8 @@
 import {expect, test} from 'bun:test';
 import type {TRenderAsset} from 'remotion';
+import type {AudioOrVideoAsset} from 'remotion/no-react';
 import {calculateAssetPositions} from '../assets/calculate-asset-positions';
+import {uncompressMediaAsset} from '../assets/types';
 import {compressAsset} from '../compress-assets';
 import {onlyAudioAndVideoAssets} from '../filter-asset-types';
 
@@ -61,4 +63,61 @@ test('Should compress and uncompress assets', () => {
 			audioStreamIndex: 0,
 		},
 	]);
+});
+
+test('Should uncompress correctly when multiple assets share the same id and frame', () => {
+	const longSrc = String('x').repeat(1000);
+
+	const assets: AudioOrVideoAsset[] = [
+		{
+			frame: 187,
+			id: 'offthreadvideo-0.123',
+			src: longSrc,
+			mediaFrame: 0,
+			playbackRate: 1,
+			type: 'video' as const,
+			volume: 1,
+			toneFrequency: 1,
+			audioStartFrame: 0,
+			audioStreamIndex: 0,
+		},
+		{
+			frame: 187,
+			id: 'offthreadvideo-0.123',
+			src: longSrc,
+			mediaFrame: 1,
+			playbackRate: 1,
+			type: 'video' as const,
+			volume: 1,
+			toneFrequency: 1,
+			audioStartFrame: 0,
+			audioStreamIndex: 0,
+		},
+		{
+			frame: 187,
+			id: 'offthreadvideo-0.123',
+			src: longSrc,
+			mediaFrame: 2,
+			playbackRate: 1,
+			type: 'video' as const,
+			volume: 1,
+			toneFrequency: 1,
+			audioStartFrame: 0,
+			audioStreamIndex: 0,
+		},
+	];
+
+	const compressed = assets.map((asset, i) => {
+		return compressAsset(assets.slice(0, i), asset);
+	});
+
+	expect(compressed[0].src).toBe(longSrc);
+	expect(compressed[1].src).toBe('same-as-offthreadvideo-0.123-187');
+	expect(compressed[2].src).toBe('same-as-offthreadvideo-0.123-187');
+
+	const uncompressed1 = uncompressMediaAsset(compressed, compressed[1]);
+	expect(uncompressed1.src).toBe(longSrc);
+
+	const uncompressed2 = uncompressMediaAsset(compressed, compressed[2]);
+	expect(uncompressed2.src).toBe(longSrc);
 });


### PR DESCRIPTION
## Summary

Fixes an intermittent `ENOENT` crash in `renderMedia()` when using multiple `<OffthreadVideo>` clips with transitions.

### The problem

To save memory, Remotion compresses long asset `src` strings (e.g. base64-encoded data) into short `same-as-{id}-{frame}` references pointing back to the first occurrence. When it's time to resolve those references, `uncompressMediaAsset()` calls `find()` on the full asset list looking for a match on `id` and `frame`.

`<OffthreadVideo>` registers every frame of a clip with the **same `frame` property** (the clip's start frame). So a 153-frame video starting at frame 187 produces 153 asset entries all with `frame: 187`. After compression, all but the first become `same-as-offthreadvideo-...-187`. The problem is that `find()` matches on `id` and `frame` alone — it can return **another compressed reference** instead of the original uncompressed entry, since they all share the same key. This causes ffprobe to receive a `same-as-...` string as a file path, resulting in `ENOENT`.

### The fix

Add `!a.src.startsWith('same-as')` to the `find()` predicate in `uncompressMediaAsset()`, ensuring it always resolves to the original uncompressed asset and skips over other compressed references.

## Test plan

- Added a test case that reproduces the exact scenario: three assets with the same `id` and `frame`, where the second and third get compressed, verifying that uncompression resolves both back to the real `src`
- Existing `asset-compression` test continues to pass


Made with [Cursor](https://cursor.com)