### PR TITLE
`@remotion/example`: Fix loop trimmed audio volume callback

### DIFF
--- a/packages/example/src/LoopTrimmedAudio/index.tsx
+++ b/packages/example/src/LoopTrimmedAudio/index.tsx
@@ -8,7 +8,7 @@ const LoopedTrimmedAudio: React.FC = () => {
 			src={staticFile('music.mp3')}
 			startFrom={125}
 			endAt={370}
-			volume={(v) => v}
+			volume={(v) => Math.min(1, v / 30)}
 		/>
 	);
 };


### PR DESCRIPTION
## Summary
- Fix the LoopTrimmedAudio example so the volume callback returns a normalized 0-1 volume value.
- Prevent Studio seeking from tripping the high-volume safeguard when the callback frame reaches 100+.

## Test plan
- bunx oxfmt src --write
- ReadLints on packages/example/src/LoopTrimmedAudio/index.tsx