### PR TITLE
`@remotion/serverless-client`: Resolve workspace imports from source during ESM bundling

### DIFF
--- a/packages/.monorepo/builder.ts
+++ b/packages/.monorepo/builder.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import type {BunPlugin} from 'bun';
 import {build} from 'bun';
 import {Exports, validateExports} from './validate-exports';
 
@@ -82,6 +83,7 @@ export const buildPackage = async ({
 	formats,
 	external,
 	entrypoints,
+	plugins = [],
 	filterExternal = (external) => external,
 }: {
 	formats: {
@@ -89,6 +91,7 @@ export const buildPackage = async ({
 		cjs: FormatAction;
 	};
 	external: 'dependencies' | string[];
+	plugins?: BunPlugin[];
 	filterExternal?: (external: string[]) => string[];
 	entrypoints: EntryPoint[];
 }) => {
@@ -122,6 +125,7 @@ export const buildPackage = async ({
 					target,
 					format,
 					splitting: splitting ?? false,
+					plugins,
 				});
 
 				for (const file of output.outputs) {

--- a/packages/serverless-client/bundle.ts
+++ b/packages/serverless-client/bundle.ts
@@ -1,4 +1,31 @@
+import path from 'path';
+import type {BunPlugin} from 'bun';
 import {buildPackage} from '../.monorepo/builder';
+
+const resolveWorkspaceSourcesPlugin: BunPlugin = {
+	name: 'resolve-workspace-sources',
+	setup(build) {
+		const mappings: Record<string, string> = {
+			'@remotion/renderer/error-handling': path.resolve(
+				'../renderer/src/error-handling.ts',
+			),
+			'@remotion/renderer/pure': path.resolve('../renderer/src/pure.ts'),
+			'@remotion/renderer/client': path.resolve('../renderer/src/client.ts'),
+			'@remotion/streaming': path.resolve('../streaming/src/index.ts'),
+			'remotion/no-react': path.resolve('../core/src/no-react.ts'),
+			'remotion/version': path.resolve('../core/src/version.ts'),
+		};
+
+		build.onResolve({filter: /^(@remotion\/|remotion\/)/}, (args) => {
+			const resolved = mappings[args.path];
+			if (resolved) {
+				return {path: resolved};
+			}
+
+			return undefined;
+		});
+	},
+};
 
 await buildPackage({
 	formats: {
@@ -6,6 +33,7 @@ await buildPackage({
 		esm: 'build',
 	},
 	external: [],
+	plugins: [resolveWorkspaceSourcesPlugin],
 	entrypoints: [
 		{
 			path: 'src/index.ts',


### PR DESCRIPTION
## Summary
- Fixes the monorepo build failure on Bun v1.3.13 where `@remotion/serverless-client`'s ESM bundle step failed with `"wrapWithErrorHandling" is not declared in this file` (and similar errors for `@remotion/streaming` exports)
- The root cause is that `Bun.build()` with `external: []` tries to re-bundle pre-built `.mjs` artifacts from workspace packages, which newer Bun versions handle incorrectly
- Adds a Bun build plugin to `serverless-client/bundle.ts` that resolves workspace package imports (`@remotion/renderer/*`, `@remotion/streaming`, `remotion/*`) directly to their TypeScript source entry points, bypassing the pre-built `.mjs` files entirely
- Extends the shared builder (`packages/.monorepo/builder.ts`) with an optional `plugins` parameter passed through to `Bun.build()`

Closes #7109

## Test plan
- [x] Verified `Bun.build()` succeeds with the plugin and produces correct output (101KB bundle with all exports present)
- [x] Verified no absolute paths leak into the bundle output
- [x] Verified formatting passes (`oxfmt --check`)
- [ ] Full `bun run build` on Bun v1.3.13

Made with [Cursor](https://cursor.com)