### PR TITLE
`@remotion/player`: Compensate per-axis CSS scale in useElementSize

### DIFF
--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -61,17 +61,10 @@ export const useElementSize = (
 		}
 
 		return new ResizeObserver((entries) => {
-			// `contentRect` is the element's pre-transform content box (CSS layout
-			// width/height). `getClientRects()` is the post-transform AABB. We want
-			// the layout box; we recover it by dividing each AABB axis by the
-			// per-axis ratio between AABB and content box, which cancels the
-			// parent's CSS transform whether it is uniform or not.
-			//
-			// Computing one scalar from the X-axis ratio and applying it to both
-			// dimensions only works under uniform 2D scale. Under non-uniform
-			// transforms (`scale(X, Y)` with different factors, `rotateX/Y`,
-			// `perspective`, `matrix3d`) the X- and Y-axis AABB grow at different
-			// rates and the height comes out wrong.
+			// `contentRect` is the element's pre-transform content box.
+			// `getClientRects()` is the post-transform AABB. Dividing each AABB
+			// axis by its content-box counterpart cancels the parent CSS transform
+			// whether it is uniform or not.
 			const {contentRect, target} = entries[0];
 			const newSize = target.getClientRects();
 

--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -61,9 +61,18 @@ export const useElementSize = (
 		}
 
 		return new ResizeObserver((entries) => {
-			// The contentRect returns the width without any `scale()`'s being applied. The height is wrong
+			// `contentRect` is the element's pre-transform content box (CSS layout
+			// width/height). `getClientRects()` is the post-transform AABB. We want
+			// the layout box; we recover it by dividing each AABB axis by the
+			// per-axis ratio between AABB and content box, which cancels the
+			// parent's CSS transform whether it is uniform or not.
+			//
+			// Computing one scalar from the X-axis ratio and applying it to both
+			// dimensions only works under uniform 2D scale. Under non-uniform
+			// transforms (`scale(X, Y)` with different factors, `rotateX/Y`,
+			// `perspective`, `matrix3d`) the X- and Y-axis AABB grow at different
+			// rates and the height comes out wrong.
 			const {contentRect, target} = entries[0];
-			// The clientRect returns the size with `scale()` being applied.
 			const newSize = target.getClientRects();
 
 			if (!newSize?.[0]) {
@@ -71,17 +80,19 @@ export const useElementSize = (
 				return;
 			}
 
-			const probableCssParentScale =
+			const probableCssParentScaleX =
 				contentRect.width === 0 ? 1 : newSize[0].width / contentRect.width;
+			const probableCssParentScaleY =
+				contentRect.height === 0 ? 1 : newSize[0].height / contentRect.height;
 
 			const width =
-				options.shouldApplyCssTransforms || probableCssParentScale === 0
+				options.shouldApplyCssTransforms || probableCssParentScaleX === 0
 					? newSize[0].width
-					: newSize[0].width * (1 / probableCssParentScale);
+					: newSize[0].width * (1 / probableCssParentScaleX);
 			const height =
-				options.shouldApplyCssTransforms || probableCssParentScale === 0
+				options.shouldApplyCssTransforms || probableCssParentScaleY === 0
 					? newSize[0].height
-					: newSize[0].height * (1 / probableCssParentScale);
+					: newSize[0].height * (1 / probableCssParentScaleY);
 
 			setSize((prevState) => {
 				const isSame =


### PR DESCRIPTION
Fixes the `ResizeObserver` branch of `useElementSize` so it produces a correct height under non-uniform parent CSS transforms.

Refs #7183 (full reproduction, numerical trace, and analysis). This is the **minimal-diff** of two PRs offered for that issue — the **broader** alternative is #7185, which reads `el.offsetWidth` / `el.offsetHeight` directly across all three measurement paths. Maintainers can pick whichever shape they prefer; the two PRs are mutually exclusive.

## Background

The `ResizeObserver` callback in `useElementSize` recovers the element's CSS layout box from the post-transform AABB by dividing each AABB axis by the parent's CSS scale, which it estimates as:

```ts
const probableCssParentScale =
  contentRect.width === 0 ? 1 : newSize[0].width / contentRect.width;
```

— and applies the same scalar to both width and height. That works for `transform: scale(N)` (uniform 2D scale, `scaleX === scaleY`). It produces a wrong height under any non-uniform CSS transform — `scale(X, Y)` with different factors, `rotateX/Y`, `rotate3d`, `perspective`, `matrix3d` — because the X- and Y-axis AABB grow at different rates.

When the recovered height is wrong, `calculateCanvasTransformation` emits a non-zero `centerY`, which `calculateOuter` writes as `top` on the composition outer. The composition is rendered at the right scale but **vertically offset** inside its container (empty top portion of the plate, composition bottom spilling below).

## What this PR does

Computes the parent CSS scale **per axis**:

```ts
const probableCssParentScaleX =
  contentRect.width === 0 ? 1 : newSize[0].width / contentRect.width;
const probableCssParentScaleY =
  contentRect.height === 0 ? 1 : newSize[0].height / contentRect.height;
```

…and divides each axis of the AABB by its own scalar, cancelling the parent transform whether it is uniform or not.

- **Uniform 2D scale** (`scaleX === scaleY`): identical output to the previous code.
- **Non-uniform 2D scale, 3D rotation, perspective:** each axis is recovered correctly.

Also replaces the inline comment that claimed `contentRect.height` is unreliable (we use it now and have not seen it return wrong values on modern Chrome / Safari / Firefox).

## Scope

This PR fixes only the `ResizeObserver` callback. The initial `useState` and `updateSize` paths use raw `getClientRects()` with no scale compensation at all — they are also affected by the same family of transforms but were not the headline bug in #7183. The companion PR #7185 covers all three paths via `offsetWidth`/`offsetHeight`. Pick whichever you prefer.

## Test plan

`useElementSize` is a hook that depends on `ResizeObserver` and DOM measurement, which the existing `bun:test` suite under `packages/player/src/test/` does not currently exercise — every test there is on pure utilities. I'd be happy to add a `jsdom` or Playwright-driven regression that asserts:

1. `transform: scale(2)` parent → correct width AND height (current code passes).
2. `transform: scaleX(2) scaleY(3)` parent → correct height (current code fails, this PR passes).
3. `transform: rotateY(45deg)` + `transform-style: preserve-3d` parent → correct height (current code fails, this PR passes).

…if you'd like that as part of this PR. Let me know if you have a preferred test harness for hooks like this.
