### PR TITLE
@remotion/player: Read offsetWidth/offsetHeight in useElementSize (fixes all 3 measurement paths)

### DIFF
--- a/packages/player-example/pages/use-element-size-testbed.tsx
+++ b/packages/player-example/pages/use-element-size-testbed.tsx
@@ -1,0 +1,139 @@
+import {Player} from '@remotion/player';
+import React from 'react';
+import {UseElementSizeTestbedComposition} from '../src/UseElementSizeTestbedComposition';
+
+/**
+ * Manual testbed for GitHub issue #7183 and PRs #7184 / #7185 (useElementSize
+ * under transformed ancestors).
+ *
+ * Run from repo root: `bunx turbo run dev --filter=@remotion/player-example`
+ * Open: http://localhost:3000/use-element-size-testbed
+ *
+ * Compare before/after: checkout `main` vs the PR branch and reload. After the
+ * fix, the 3D plate should stay visually filled (TOP/BOTTOM bands flush with the
+ * plate); before, the composition shifts vertically inside the plate.
+ */
+const plate: React.CSSProperties = {
+	width: 320,
+	height: 180,
+	border: '2px solid #666',
+	boxSizing: 'border-box',
+	backgroundColor: '#222',
+};
+
+const playerCommon = {
+	component: UseElementSizeTestbedComposition,
+	compositionWidth: 1920,
+	compositionHeight: 1080,
+	durationInFrames: 300,
+	fps: 30,
+	acknowledgeRemotionLicense: true as const,
+	controls: true,
+	style: {width: '100%', height: '100%'} as const,
+};
+
+const UseElementSizeTestbedPage: React.FC = () => {
+	return (
+		<div
+			style={{
+				padding: 24,
+				fontFamily: 'system-ui, sans-serif',
+				maxWidth: 900,
+				lineHeight: 1.5,
+			}}
+		>
+			<h1 style={{marginTop: 0}}>useElementSize / #7183 testbed</h1>
+			<p>
+				Reproduction from{' '}
+				<a href="https://github.com/remotion-dev/remotion/issues/7183">
+					issue #7183
+				</a>
+				: Player inside a 320×180 plate with 3D rotation. Before the fix,
+				<code> useElementSize </code>
+				can report an inflated height (post-transform AABB), which drives a
+				non-zero <code>centerY</code> and vertical letterboxing. Red/green
+				stripes should sit flush with the top and bottom of each outlined plate
+				when sizing is correct.
+			</p>
+			<p style={{color: '#555', fontSize: 14}}>
+				Tip: toggle between <code>main</code> and the PR branch (
+				<a href="https://github.com/remotion-dev/remotion/pull/7185">#7185</a>
+				) to compare before and after.
+			</p>
+
+			<h2>Control — no parent transform</h2>
+			<p style={{marginTop: 0, fontSize: 14, color: '#444'}}>
+				Expected: TOP/BOTTOM bands align with the plate; no empty strip above
+				the composition.
+			</p>
+			<div style={plate}>
+				<Player {...playerCommon} />
+			</div>
+
+			<h2>Original repro — rotateY + rotateX + preserve-3d</h2>
+			<p style={{marginTop: 0, fontSize: 14, color: '#444'}}>
+				Same as the snippet in #7183. Before fix: wrong vertical centering
+				inside the plate.
+			</p>
+			<div
+				style={{
+					...plate,
+					transform: 'rotateY(45deg) rotateX(-15deg)',
+					transformStyle: 'preserve-3d',
+				}}
+			>
+				<Player {...playerCommon} />
+			</div>
+
+			<h2>Extra: non-uniform 2D scale</h2>
+			<p style={{marginTop: 0, fontSize: 14, color: '#444'}}>
+				<code>scaleX(2) scaleY(3)</code> — also called out in the PR behaviour
+				matrix. The transformed bounds are large; scroll the dashed area if
+				needed.
+			</p>
+			<div
+				style={{
+					overflow: 'auto',
+					maxWidth: '100%',
+					padding: 24,
+					border: '1px dashed #bbb',
+				}}
+			>
+				<div
+					style={{
+						...plate,
+						transform: 'scaleX(2) scaleY(3)',
+						transformOrigin: 'center center',
+					}}
+				>
+					<Player {...playerCommon} />
+				</div>
+			</div>
+
+			<h2>Extra: perspective + rotateX</h2>
+			<p style={{marginTop: 0, fontSize: 14, color: '#444'}}>
+				Matches the “perspective + rotateX” case from the PR write-up.
+			</p>
+			<div
+				style={{
+					...plate,
+					perspective: '1000px',
+					transformStyle: 'preserve-3d',
+				}}
+			>
+				<div
+					style={{
+						width: '100%',
+						height: '100%',
+						transform: 'rotateX(15deg)',
+						transformStyle: 'preserve-3d',
+					}}
+				>
+					<Player {...playerCommon} />
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default UseElementSizeTestbedPage;

--- a/packages/player-example/src/UseElementSizeTestbedComposition.tsx
+++ b/packages/player-example/src/UseElementSizeTestbedComposition.tsx
@@ -1,0 +1,49 @@
+import {AbsoluteFill} from 'remotion';
+
+/**
+ * 16:9 composition with strong top/bottom bands. When `useElementSize` reports a
+ * wrong height under transformed ancestors (#7183), the Player letterboxes and
+ * these bands no longer align with the plate edges.
+ */
+export const UseElementSizeTestbedComposition = () => {
+	return (
+		<AbsoluteFill style={{backgroundColor: '#16213e'}}>
+			<div
+				style={{
+					position: 'absolute',
+					top: 0,
+					left: 0,
+					right: 0,
+					height: 48,
+					backgroundColor: '#e94560',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					color: '#fff',
+					fontSize: 28,
+					fontFamily: 'system-ui, sans-serif',
+				}}
+			>
+				TOP
+			</div>
+			<div
+				style={{
+					position: 'absolute',
+					bottom: 0,
+					left: 0,
+					right: 0,
+					height: 48,
+					backgroundColor: '#0f3460',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					color: '#fff',
+					fontSize: 28,
+					fontFamily: 'system-ui, sans-serif',
+				}}
+			>
+				BOTTOM
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -26,6 +26,46 @@ export const updateAllElementsSizes = () => {
 	}
 };
 
+// `el.offsetWidth` / `el.offsetHeight` is the element's CSS layout box —
+// the pre-transform width and height the browser allocates during layout.
+// Reading those is robust against ALL ancestor CSS transforms (uniform 2D
+// scale, asymmetric 2D scale, 3D rotation, perspective, matrix3d) which
+// `getClientRects()` cannot recover from with a single scalar.
+//
+// `getClientRects()[0]` is still used for the (x, y) corner since
+// `offsetLeft` / `offsetTop` are relative to the offset parent (not the
+// viewport), and consumers like the controls layer want viewport coords.
+//
+// Callers that explicitly want the post-transform AABB pass
+// `shouldApplyCssTransforms: true` (used by `PlayerSeekBar` to track the
+// transformed scrubber). For those, we keep the current `getClientRects()`
+// behaviour for both axes.
+const measureElement = (
+	el: HTMLElement,
+	shouldApplyCssTransforms: boolean,
+): {width: number; height: number; left: number; top: number} | null => {
+	const rect = el.getClientRects();
+	if (!rect[0]) {
+		return null;
+	}
+
+	if (shouldApplyCssTransforms) {
+		return {
+			width: rect[0].width,
+			height: rect[0].height,
+			left: rect[0].x,
+			top: rect[0].y,
+		};
+	}
+
+	return {
+		width: el.offsetWidth || rect[0].width,
+		height: el.offsetHeight || rect[0].height,
+		left: rect[0].x,
+		top: rect[0].y,
+	};
+};
+
 export const useElementSize = (
 	ref: React.RefObject<HTMLElement | null>,
 	options: {
@@ -38,16 +78,16 @@ export const useElementSize = (
 			return null;
 		}
 
-		const rect = ref.current.getClientRects();
-		if (!rect[0]) {
+		const measured = measureElement(
+			ref.current,
+			options.shouldApplyCssTransforms,
+		);
+		if (!measured) {
 			return null;
 		}
 
 		return {
-			width: rect[0].width as number,
-			height: rect[0].height as number,
-			left: rect[0].x as number,
-			top: rect[0].y as number,
+			...measured,
 			windowSize: {
 				height: window.innerHeight,
 				width: window.innerWidth,
@@ -61,35 +101,24 @@ export const useElementSize = (
 		}
 
 		return new ResizeObserver((entries) => {
-			// The contentRect returns the width without any `scale()`'s being applied. The height is wrong
-			const {contentRect, target} = entries[0];
-			// The clientRect returns the size with `scale()` being applied.
-			const newSize = target.getClientRects();
+			const {target} = entries[0];
+			const measured = measureElement(
+				target as HTMLElement,
+				options.shouldApplyCssTransforms,
+			);
 
-			if (!newSize?.[0]) {
+			if (!measured) {
 				setSize(null);
 				return;
 			}
 
-			const probableCssParentScale =
-				contentRect.width === 0 ? 1 : newSize[0].width / contentRect.width;
-
-			const width =
-				options.shouldApplyCssTransforms || probableCssParentScale === 0
-					? newSize[0].width
-					: newSize[0].width * (1 / probableCssParentScale);
-			const height =
-				options.shouldApplyCssTransforms || probableCssParentScale === 0
-					? newSize[0].height
-					: newSize[0].height * (1 / probableCssParentScale);
-
 			setSize((prevState) => {
 				const isSame =
 					prevState &&
-					prevState.width === width &&
-					prevState.height === height &&
-					prevState.left === newSize[0].x &&
-					prevState.top === newSize[0].y &&
+					prevState.width === measured.width &&
+					prevState.height === measured.height &&
+					prevState.left === measured.left &&
+					prevState.top === measured.top &&
 					prevState.windowSize.height === window.innerHeight &&
 					prevState.windowSize.width === window.innerWidth;
 				if (isSame) {
@@ -97,10 +126,7 @@ export const useElementSize = (
 				}
 
 				return {
-					width,
-					height,
-					left: newSize[0].x,
-					top: newSize[0].y,
+					...measured,
 					windowSize: {
 						height: window.innerHeight,
 						width: window.innerWidth,
@@ -115,8 +141,11 @@ export const useElementSize = (
 			return;
 		}
 
-		const rect = ref.current.getClientRects();
-		if (!rect[0]) {
+		const measured = measureElement(
+			ref.current,
+			options.shouldApplyCssTransforms,
+		);
+		if (!measured) {
 			setSize(null);
 			return;
 		}
@@ -124,10 +153,10 @@ export const useElementSize = (
 		setSize((prevState) => {
 			const isSame =
 				prevState &&
-				prevState.width === rect[0].width &&
-				prevState.height === rect[0].height &&
-				prevState.left === rect[0].x &&
-				prevState.top === rect[0].y &&
+				prevState.width === measured.width &&
+				prevState.height === measured.height &&
+				prevState.left === measured.left &&
+				prevState.top === measured.top &&
 				prevState.windowSize.height === window.innerHeight &&
 				prevState.windowSize.width === window.innerWidth;
 			if (isSame) {
@@ -135,17 +164,14 @@ export const useElementSize = (
 			}
 
 			return {
-				width: rect[0].width as number,
-				height: rect[0].height as number,
-				left: rect[0].x as number,
-				top: rect[0].y as number,
+				...measured,
 				windowSize: {
 					height: window.innerHeight,
 					width: window.innerWidth,
 				},
 			};
 		});
-	}, [ref]);
+	}, [ref, options.shouldApplyCssTransforms]);
 
 	useEffect(() => {
 		if (!observer) {


### PR DESCRIPTION
Fixes `useElementSize` so all three of its measurement paths return the element's CSS layout box, robust against all ancestor CSS transforms.

Refs #7183 (full reproduction, numerical trace, and analysis). This is the **broader** of two PRs offered for that issue — the **minimal-diff** alternative is #7184, which fixes only the `ResizeObserver` path with a per-axis scale compensation. Maintainers can pick whichever shape they prefer; the two PRs are mutually exclusive.

## Background

`useElementSize` reads its target with `getClientRects()` in three places:

1. The initial `useState` initializer.
2. The `ResizeObserver` callback.
3. The `updateSize` callback (window-resize + `updateAllElementsSizes`).

`getClientRects()` returns the **post-transform AABB**, which is not what consumers want — they want the layout box. Today, only path (2) tries to recover the layout box, by dividing the AABB by `newSize.width / contentRect.width` (the X-axis ratio) **on both axes**. That recovery is correct under uniform 2D scale (`transform: scale(N)`) but wrong under any non-uniform transform (`scale(X, Y)`, `rotateX/Y`, `rotate3d`, `perspective`, `matrix3d`) because the X- and Y-axis AABB grow at different rates. Paths (1) and (3) don't compensate at all — they return the raw AABB, which is wrong under every transform.

## What this PR does

Introduces a `measureElement(el, shouldApplyCssTransforms)` helper that returns `{width, height, left, top}`:

- `width` / `height` come from `el.offsetWidth` / `el.offsetHeight` — the element's pre-transform content + padding box, exactly what the existing recovery was trying to compute. Reading from the layout engine directly is robust against all ancestor transforms (uniform 2D scale, asymmetric 2D scale, 3D rotation, perspective, `matrix3d`) without depending on `contentRect.width / height` reliability.
- `left` / `top` continue to come from `getClientRects()[0]` because consumers want **viewport-relative** coordinates, and `offsetLeft` / `offsetTop` are relative to the offset parent (not the viewport).
- When the caller passes `shouldApplyCssTransforms: true` (used by `PlayerSeekBar` for the transformed scrubber), the helper returns `getClientRects()` width/height unchanged — preserving the post-transform behaviour for callers that explicitly want it.

All three callsites use the helper. Net change: `+68 / -42` lines, all in `packages/player/src/utils/use-element-size.ts`.

## Behaviour matrix

| Parent transform | Old code | This PR |
|---|---|---|
| None | ✅ correct | ✅ correct |
| `transform: scale(2)` (uniform 2D) | ✅ correct in `ResizeObserver`, ❌ wrong in initial `useState` and `updateSize` | ✅ correct everywhere |
| `transform: scaleX(2) scaleY(3)` | ❌ wrong height | ✅ correct |
| `transform: rotateY(45deg)` + `transform-style: preserve-3d` | ❌ wrong height | ✅ correct |
| `perspective: 1000px` + `transform: rotateX(15deg)` | ❌ wrong height | ✅ correct |
| `shouldApplyCssTransforms: true` (callers wanting AABB) | ✅ AABB returned | ✅ AABB returned (unchanged) |

## Why this approach

The PR description for the minimal-diff alternative (#7184) preserves the existing "compensate via division" intent and only fixes the per-axis bug in the `ResizeObserver` callback. That PR is correct but has two limitations:

1. It leaves paths (1) and (3) returning the raw AABB. Initial measurements before the first `ResizeObserver` callback fires, and any `updateSize` triggered by a window-resize, will still be wrong under any transform.
2. It depends on `contentRect.height` being reliable — the existing inline comment in `useElementSize` claims it is not (`The contentRect returns the width without any \`scale()\`'s being applied. The height is wrong`), and the PR effectively decides the comment is outdated. We've found `contentRect` to be reliable on modern Chrome / Firefox / Safari, but if there's a known-bad browser, this PR (which never reads `contentRect`) sidesteps the question entirely.

This PR removes the recovery round-trip and gets the layout box directly from the property the layout engine populates for exactly this purpose.

## Test plan

`useElementSize` is a hook depending on `ResizeObserver` and DOM measurement; the `bun:test` suite under `packages/player/src/test/` is currently pure-utility-only. I'd be happy to add a `jsdom` or Playwright regression that asserts:

1. `transform: scale(2)` parent → correct width AND height (this PR passes; current `ResizeObserver` passes; current `useState`/`updateSize` fails).
2. `transform: scaleX(2) scaleY(3)` parent → correct height (current code fails everywhere; this PR passes).
3. `transform: rotateY(45deg)` + `transform-style: preserve-3d` parent → correct height (current code fails everywhere; this PR passes).
4. Callers passing `shouldApplyCssTransforms: true` get post-transform AABB unchanged.

Let me know if you have a preferred test harness for hooks like this.
