### PR TITLE
`@remotion/player`: Add `initialVolume` prop

### DIFF
--- a/packages/docs/docs/player/api.mdx
+++ b/packages/docs/docs/player/api.mdx
@@ -436,6 +436,8 @@ By default, Remotion uses the key `"remotion.volumePreference"`.
 
 This prop is useful if you would like to scope the volume preference to a specific Player instance.
 
+To set a fixed initial volume and **not** use `localStorage` at all, use [`initialVolume`](#initialvolume) instead of this prop.
+
 **Example:**
 
 ```tsx
@@ -443,6 +445,22 @@ This prop is useful if you would like to scope the volume preference to a specif
   component={MyVideo}
   // ... other props
   volumePersistenceKey="my-app-volume-preference"
+/>
+```
+
+### `initialVolume?`<AvailableFrom v="4.0.453" />
+
+A number between `0` and `1` that sets the volume when the Player mounts (same range as the volume slider).
+
+If you pass this prop, the Player **does not** read the starting volume from `localStorage` or write volume changes back to `localStorage`. Omit it to keep the default behavior: load and save using [`volumePersistenceKey`](#volumepersistencekey) (or the default key).
+
+**Example:**
+
+```tsx
+<Player
+  component={MyVideo}
+  // ... other props
+  initialVolume={0.8}
 />
 ```
 

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -97,6 +97,7 @@ export type PlayerProps<
 	readonly acknowledgeRemotionLicense?: boolean;
 	readonly audioLatencyHint?: AudioContextLatencyCategory;
 	readonly volumePersistenceKey?: string;
+	readonly initialVolume?: number;
 } & CompProps<Props> &
 	PropsIfHasProps<Schema, Props>;
 
@@ -167,6 +168,7 @@ const PlayerFn = <
 		acknowledgeRemotionLicense,
 		audioLatencyHint = 'playback',
 		volumePersistenceKey,
+		initialVolume,
 		...componentProps
 	}: PlayerProps<Schema, Props>,
 	ref: MutableRefObject<PlayerRef>,
@@ -320,6 +322,27 @@ const PlayerFn = <
 	}
 
 	if (
+		typeof initialVolume !== 'undefined' &&
+		typeof initialVolume !== 'number'
+	) {
+		throw new TypeError(
+			`'initialVolume' must be a number or undefined but got '${typeof initialVolume}' instead`,
+		);
+	}
+
+	if (
+		typeof initialVolume === 'number' &&
+		(!Number.isFinite(initialVolume) ||
+			Number.isNaN(initialVolume) ||
+			initialVolume < 0 ||
+			initialVolume > 1)
+	) {
+		throw new TypeError(
+			`'initialVolume' must be between 0 and 1 but got '${initialVolume}' instead`,
+		);
+	}
+
+	if (
 		typeof numberOfSharedAudioTags !== 'number' ||
 		numberOfSharedAudioTags % 1 !== 0 ||
 		!Number.isFinite(numberOfSharedAudioTags) ||
@@ -409,6 +432,7 @@ const PlayerFn = <
 				logLevel={logLevel}
 				audioLatencyHint={audioLatencyHint}
 				volumePersistenceKey={volumePersistenceKey}
+				initialVolume={initialVolume}
 				inputProps={actualInputProps}
 				audioEnabled
 			>

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -29,6 +29,7 @@ export const SharedPlayerContexts: React.FC<{
 	readonly logLevel: LogLevel;
 	readonly audioLatencyHint: AudioContextLatencyCategory;
 	readonly volumePersistenceKey?: string;
+	readonly initialVolume?: number;
 	readonly inputProps: Record<string, unknown>;
 	readonly audioEnabled: boolean;
 }> = ({
@@ -44,9 +45,11 @@ export const SharedPlayerContexts: React.FC<{
 	logLevel,
 	audioLatencyHint,
 	volumePersistenceKey,
+	initialVolume,
 	inputProps,
 	audioEnabled,
 }) => {
+	const persistVolumeToStorage = initialVolume === undefined;
 	const compositionManagerContext: CompositionManagerContext = useMemo(() => {
 		const context: CompositionManagerContext = {
 			compositions: [
@@ -95,7 +98,9 @@ export const SharedPlayerContexts: React.FC<{
 
 	const [mediaMuted, setMediaMuted] = useState<boolean>(() => initiallyMuted);
 	const [mediaVolume, setMediaVolume] = useState<number>(() =>
-		getPreferredVolume(volumePersistenceKey ?? null),
+		persistVolumeToStorage
+			? getPreferredVolume(volumePersistenceKey ?? null)
+			: initialVolume,
 	);
 
 	const mediaVolumeContextValue = useMemo((): MediaVolumeContextValue => {
@@ -108,9 +113,11 @@ export const SharedPlayerContexts: React.FC<{
 	const setMediaVolumeAndPersist = useCallback(
 		(vol: number) => {
 			setMediaVolume(vol);
-			persistVolume(vol, logLevel, volumePersistenceKey ?? null);
+			if (persistVolumeToStorage) {
+				persistVolume(vol, logLevel, volumePersistenceKey ?? null);
+			}
 		},
-		[logLevel, volumePersistenceKey],
+		[persistVolumeToStorage, logLevel, volumePersistenceKey],
 	);
 
 	const setMediaVolumeContextValue = useMemo((): SetMediaVolumeContextValue => {

--- a/packages/player/src/test/validate-prop.test.tsx
+++ b/packages/player/src/test/validate-prop.test.tsx
@@ -208,6 +208,59 @@ test('volumePersistenceKey of string should be okay', () => {
 	expect(true).toBe(true);
 });
 
+test('initialVolume should be okay', () => {
+	render(
+		<Player
+			compositionWidth={500}
+			compositionHeight={400}
+			fps={30}
+			durationInFrames={500}
+			component={HelloWorld}
+			controls
+			showVolumeControls
+			initialVolume={0.75}
+		/>,
+	);
+	expect(true).toBe(true);
+});
+
+test('invalid initialVolume type should give errors', () => {
+	expect(() => {
+		render(
+			<Player
+				compositionWidth={500}
+				compositionHeight={400}
+				fps={30}
+				durationInFrames={500}
+				component={HelloWorld}
+				controls
+				showVolumeControls
+				// @ts-expect-error
+				initialVolume="loud"
+			/>,
+		);
+	}).toThrow(
+		/'initialVolume' must be a number or undefined but got 'string' instead/,
+	);
+});
+
+test('initialVolume out of range should give errors', () => {
+	expect(() => {
+		render(
+			<Player
+				compositionWidth={500}
+				compositionHeight={400}
+				fps={30}
+				durationInFrames={500}
+				component={HelloWorld}
+				controls
+				showVolumeControls
+				initialVolume={2}
+			/>,
+		);
+	}).toThrow(/'initialVolume' must be between 0 and 1 but got '2' instead/);
+});
+
 test('passing in <Composition /> instance should not be possible', () => {
 	expect(() => {
 		render(


### PR DESCRIPTION
## Summary

Closes https://github.com/remotion-dev/remotion/issues/7182

Adds `initialVolume` to `<Player />` (optional number, `0`–`1`).

- **If set:** that value is used as the volume on mount, and the Player does **not** read from or write to `localStorage` (persistence is off; `volumePersistenceKey` is not used for load/save).
- **If omitted:** existing behavior is unchanged: load and save the user’s volume via `localStorage` (using `volumePersistenceKey` or the default key).

To get full volume without persistence, use `initialVolume={1}`.

## Changes

- `SharedPlayerContext`: when `initialVolume` is defined, use it for initial state; otherwise `getPreferredVolume`. Call `persistVolume` only when `initialVolume` is omitted.
- `Player`: new optional prop, validation (type and `0`–`1` range).
- Docs: `api.mdx` (`initialVolume`, `AvailableFrom`, cross-link with `volumePersistenceKey`).
- Tests: valid `initialVolume`, wrong type, out of range.

