### PR TITLE
`@remotion/lambda`:  Remove support for `me-south-1`

### DIFF
--- a/packages/docs/docs/lambda/changelog.mdx
+++ b/packages/docs/docs/lambda/changelog.mdx
@@ -365,7 +365,7 @@ Lambda version: '2021-11-24'
 
 - **Breaking**: Migrated to **ARM architecture**! This means 34% better cost/performance ratio. However, only the following 10 regions support ARM architectures: `eu-central-1`, `eu-west-1`, `eu-west-2`, `us-east-1`, `us-east-2`, `us-west-2`, `ap-south-1`, `ap-southeast-1`, `ap-southeast-2`, `ap-northeast-1`.
 
-That means that the previously supported regions `us-west-1`, `af-south-1`, `ap-east-1`, `ap-northeast-2`, `ap-northeast-3`, `ca-central-1`, `eu-west-1`, `eu-west-2`, `eu-south-1`, `eu-west-3`, `eu-north-1`, `me-south-1`, `sa-east-1` are not supported anymore.
+That means that the previously supported regions `us-west-1`, `af-south-1`, `ap-east-1`, `ap-northeast-2`, `ap-northeast-3`, `ca-central-1`, `eu-west-1`, `eu-west-2`, `eu-south-1`, `eu-west-3`, `eu-north-1`, `sa-east-1` are not supported anymore.
 
 We will add those regions back again once AWS adds support for Lambda.
 

--- a/packages/docs/docs/lambda/cli/regions.mdx
+++ b/packages/docs/docs/lambda/cli/regions.mdx
@@ -14,7 +14,7 @@ npx remotion lambda regions
 
 <details>
   <summary>Show output</summary>
-  <pre>eu-central-1 eu-west-1 eu-west-2 eu-west-3 eu-south-1 eu-north-1 us-east-1 us-east-2 us-west-1 us-west-2 af-south-1 ap-south-1 ap-east-1 ap-southeast-1 ap-southeast-2 ap-northeast-3 ap-northeast-1 ap-northeast-2 ca-central-1 me-south-1 sa-east-1</pre>
+  <pre>eu-central-1 eu-west-1 eu-west-2 eu-west-3 eu-south-1 eu-north-1 us-east-1 us-east-2 us-west-1 us-west-2 af-south-1 ap-south-1 ap-east-1 ap-southeast-1 ap-southeast-2 ap-northeast-3 ap-northeast-1 ap-northeast-2 ca-central-1 sa-east-1</pre>
 </details>
 
 ## Flags

--- a/packages/docs/docs/lambda/region-selection.mdx
+++ b/packages/docs/docs/lambda/region-selection.mdx
@@ -21,7 +21,7 @@ The following AWS regions are available:
 You can call [`getRegions()`](/docs/lambda/getregions) or type [`npx remotion lambda regions`](/docs/lambda/cli/regions) to get this list programmatically.
 
 :::note
-Support for regions `eu-west-3`, `eu-south-1`, `eu-north-1`, `us-west-1`, `af-south-1`, `ap-east-1`, `ap-northeast-2`, `ap-northeast-3`, `ca-central-1`, `me-south-1`, `sa-east-1` has been added in v3.3.7.
+Support for regions `eu-west-3`, `eu-south-1`, `eu-north-1`, `us-west-1`, `af-south-1`, `ap-east-1`, `ap-northeast-2`, `ap-northeast-3`, `ca-central-1`, `sa-east-1` has been added in v3.3.7.
 :::
 
 ## Default region
@@ -58,7 +58,6 @@ Data may be out of date, please consult the [AWS Lambda Pricing page](https://aw
 | -------------- | ------------------- |
 | ap-east-1      | 0.0000183000        |
 | af-south-1     | 0.0000176800        |
-| me-south-1     | 0.0000165334        |
 | eu-south-1     | 0.0000156138        |
 | ap-south-1     | 0.0000133334        |
 | ap-northeast-3 | 0.0000133334        |

--- a/packages/lambda-client/src/price-per-1s.ts
+++ b/packages/lambda-client/src/price-per-1s.ts
@@ -617,40 +617,6 @@ export const pricing: {
 			price: '0.0000133334',
 		},
 	},
-	'me-south-1': {
-		'Lambda Duration-Provisioned': {
-			rateCode: '55WKNBUF5TE92NZJ.JRTCKXETXF.6YS6EN2CT7',
-			price: '0.0000119251',
-		},
-		'Lambda Provisioned-Concurrency': {
-			rateCode: 'RPTP77J75VAKQZD9.JRTCKXETXF.6YS6EN2CT7',
-			price: '0.0000051108',
-		},
-		'Lambda Requests': {
-			rateCode: 'EMZ8YZDPGWMDYZNK.JRTCKXETXF.6YS6EN2CT7',
-			price: '0.0000002500',
-		},
-		'Lambda Requests-ARM': {
-			rateCode: 'KY96C7U4EB95UXGK.JRTCKXETXF.6YS6EN2CT7',
-			price: '0.0000002500',
-		},
-		'Lambda Storage-Duration': {
-			rateCode: 'DBA83XQ3BXSW7T3A.JRTCKXETXF.6YS6EN2CT7',
-			price: '0.0000000374',
-		},
-		'Lambda Storage-Duration-ARM': {
-			rateCode: '9PH9MHPV4V4MQNRH.JRTCKXETXF.6YS6EN2CT7',
-			price: '0.0000000374',
-		},
-		'Lambda Duration': {
-			rateCode: 'N7S38YMSMVSPHNAH.JRTCKXETXF.CUKFZ388N3',
-			price: '0.0000206667',
-		},
-		'Lambda Duration-ARM': {
-			rateCode: 'R3C6YVZV7TF52KUE.JRTCKXETXF.6NBUNBXSC3',
-			price: '0.0000165334',
-		},
-	},
 	'sa-east-1': {
 		'Lambda Duration-Provisioned': {
 			rateCode: 'VENWZ787B7TGFR3E.JRTCKXETXF.6YS6EN2CT7',

--- a/packages/lambda-client/src/regions.ts
+++ b/packages/lambda-client/src/regions.ts
@@ -41,7 +41,6 @@ export const AWS_REGIONS = [
 	'ap-southeast-4',
 	'ap-southeast-5',
 	'ca-central-1',
-	'me-south-1',
 	'sa-east-1',
 ] as const;
 

--- a/packages/lambda/src/admin/make-layer-public.ts
+++ b/packages/lambda/src/admin/make-layer-public.ts
@@ -28,7 +28,6 @@ const layerInfo: HostedLayers = {
 	'eu-north-1': [],
 	'eu-south-1': [],
 	'eu-west-3': [],
-	'me-south-1': [],
 	'sa-east-1': [],
 	'us-west-1': [],
 	'ap-southeast-4': [],

--- a/packages/lambda/src/shared/hosted-layers.ts
+++ b/packages/lambda/src/shared/hosted-layers.ts
@@ -498,33 +498,6 @@ export const hostedLayers: HostedLayers = {
 			version: 14,
 		},
 	],
-	'me-south-1': [
-		{
-			layerArn:
-				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 20,
-		},
-		{
-			layerArn:
-				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 20,
-		},
-		{
-			layerArn:
-				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 11,
-		},
-		{
-			layerArn:
-				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 11,
-		},
-		{
-			layerArn:
-				'arn:aws:lambda:me-south-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 11,
-		},
-	],
 	'sa-east-1': [
 		{
 			layerArn:

--- a/packages/lambda/src/shared/lambda-insights-extensions.ts
+++ b/packages/lambda/src/shared/lambda-insights-extensions.ts
@@ -40,8 +40,6 @@ export const lambdaInsightsExtensions: {[region in AwsRegion]: string | null} =
 			'arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension-Arm64:3',
 		'eu-north-1':
 			'arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension-Arm64:3',
-		'me-south-1':
-			'arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension-Arm64:2',
 		'sa-east-1':
 			'arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension-Arm64:3',
 		'ap-southeast-4': null,


### PR DESCRIPTION
The region is down and does not seem to come back anytime soon

Closes https://github.com/remotion-dev/remotion/issues/7166

Made with [Cursor](https://cursor.com)