### PR TITLE
`@remotion/design`: Fix bundled client directives

### DIFF
--- a/packages/design/bundle.ts
+++ b/packages/design/bundle.ts
@@ -33,7 +33,9 @@ if (!output.success) {
 }
 
 for (const file of output.outputs) {
-	const str = await file.text();
+	// Work around Bun preserving nested directives when bundling dependencies:
+	// https://github.com/oven-sh/bun/issues/6854
+	const str = (await file.text()).replace(/^\s*['"]use client['"];\n?/gm, '');
 	const out = path.join('dist', 'esm', file.path);
 
 	await Bun.write(out, str);


### PR DESCRIPTION
## Summary
- Strip nested `use client` directives from the Bun-generated design ESM bundle.
- Link the workaround to the upstream Bun directive preservation issue.
- Issue link: https://github.com/oven-sh/bun/issues/6854

## Test plan
- `bunx oxfmt src --write` in `packages/design`
- `bunx oxfmt bundle.ts --write` in `packages/design`
- `bunx turbo run make --filter='@remotion/design' --force`