### PR TITLE
`@remotion/media`: Fix audio-only `<Audio>` falling back to `<Html5Audio>` (#7210)

### DIFF
--- a/packages/media/src/helpers/resolve-audio-track.ts
+++ b/packages/media/src/helpers/resolve-audio-track.ts
@@ -1,0 +1,27 @@
+import type {InputAudioTrack, InputVideoTrack} from 'mediabunny';
+
+// Resolves which audio track to use given the user's `audioStreamIndex` prop:
+// - When the user explicitly picks a stream, honor that index.
+// - When unset and a video track is present, pair it with the matching audio
+//   track (preserves multi-track behavior introduced in #7094).
+// - When unset and the file is audio-only, fall back to the first audio track
+//   so that audio-only files (e.g. .m4a) keep working (regression fix for #7210).
+export const resolveAudioTrack = async ({
+	videoTrack,
+	audioTracks,
+	audioStreamIndex,
+}: {
+	videoTrack: InputVideoTrack | null;
+	audioTracks: InputAudioTrack[];
+	audioStreamIndex: number | null;
+}): Promise<InputAudioTrack | null> => {
+	if (audioStreamIndex !== null) {
+		return audioTracks[audioStreamIndex] ?? null;
+	}
+
+	if (videoTrack) {
+		return (await videoTrack.getPrimaryPairableAudioTrack()) ?? null;
+	}
+
+	return audioTracks[0] ?? null;
+};

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -15,6 +15,7 @@ import {drawPreviewOverlay} from './debug-overlay/preview-overlay';
 import type {DelayPlaybackIfNotPremounting} from './delay-playback-if-not-premounting';
 import {getDurationOrCompute} from './get-duration-or-compute';
 import {calculateEndTime, getTimeInSeconds} from './get-time-in-seconds';
+import {resolveAudioTrack} from './helpers/resolve-audio-track';
 import {isNetworkError} from './is-type-of-error';
 import type {Nonce, NonceManager} from './nonce-manager';
 import {makeNonceManager} from './nonce-manager';
@@ -262,9 +263,11 @@ export class MediaPlayer {
 
 			this.totalDuration = durationInSeconds;
 
-			const audioTrack = await (this.audioStreamIndex === null
-				? videoTrack?.getPrimaryPairableAudioTrack()
-				: (audioTracks[this.audioStreamIndex] ?? null));
+			const audioTrack = await resolveAudioTrack({
+				videoTrack,
+				audioTracks,
+				audioStreamIndex: this.audioStreamIndex,
+			});
 
 			if (!videoTrack && !audioTrack) {
 				return {type: 'no-tracks'};

--- a/packages/media/src/test/media-player.test.ts
+++ b/packages/media/src/test/media-player.test.ts
@@ -2,6 +2,69 @@ import {expect, test} from 'vitest';
 import {MediaPlayer} from '../media-player';
 import type {SharedAudioContextForMediaPlayer} from '../shared-audio-context-for-media-player';
 
+const makeBufferState = () => {
+	const noopBufferState = {
+		delayPlayback: () => {
+			let unblocked = false;
+			return {
+				unblock: () => {
+					if (!unblocked) {
+						unblocked = true;
+					}
+				},
+			};
+		},
+	};
+
+	return noopBufferState;
+};
+
+const makeSharedAudioContext = (): SharedAudioContextForMediaPlayer => {
+	const audioContext = new AudioContext();
+	return {
+		audioContext,
+		gainNode: audioContext.createGain(),
+		audioSyncAnchor: {value: 0},
+		scheduleAudioNode: () => ({
+			type: 'started',
+			scheduledTime: 0,
+		}),
+		unscheduleAudioNode: () => {},
+	};
+};
+
+test('audio-only file should initialize without `audioStreamIndex` (regression for #7210)', async () => {
+	const player = new MediaPlayer({
+		canvas: null,
+		src: '/voice-note.m4a',
+		logLevel: 'error',
+		sharedAudioContext: makeSharedAudioContext(),
+		loop: false,
+		trimBefore: undefined,
+		trimAfter: undefined,
+		playbackRate: 1,
+		globalPlaybackRate: 1,
+		audioStreamIndex: null,
+		fps: 30,
+		debugOverlay: false,
+		bufferState: makeBufferState(),
+		isPremounting: false,
+		isPostmounting: false,
+		durationInFrames: 300,
+		onVideoFrameCallback: null,
+		playing: false,
+		sequenceOffset: 0,
+		credentials: undefined,
+		tagType: 'audio',
+	});
+
+	const result = await player.initialize(0, false);
+
+	expect(result.type).toBe('success');
+
+	await player.dispose();
+});
+
 test('dispose should immediately unblock playback delays', async () => {
 	let activeBlocks = 0;
 	let delayPlaybackCalled: () => void = () => {};

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -11,6 +11,7 @@ import {
 } from 'mediabunny';
 import {canBrowserUseWebGl2} from '../browser-can-use-webgl2';
 import {getDurationOrCompute} from '../get-duration-or-compute';
+import {resolveAudioTrack} from '../helpers/resolve-audio-track';
 import {isNetworkError} from '../is-type-of-error';
 import {rememberActualMatroskaTimestamps} from './remember-actual-matroska-timestamps';
 
@@ -150,14 +151,16 @@ export const getSinks = async (
 			return 'network-error';
 		}
 
-		const videoTrack = await input.getPrimaryVideoTrack();
+		const [videoTrack, audioTracks] = await Promise.all([
+			input.getPrimaryVideoTrack(),
+			input.getAudioTracks(),
+		]);
 
-		const audioTrack =
-			videoTrack === null
-				? (await input.getAudioTracks())[index ?? 0]
-				: await (index === null
-						? videoTrack?.getPrimaryPairableAudioTrack()
-						: ((await input.getAudioTracks())[index] ?? null));
+		const audioTrack = await resolveAudioTrack({
+			videoTrack,
+			audioTracks,
+			audioStreamIndex: index,
+		});
 
 		if (!audioTrack) {
 			return 'no-audio-track';


### PR DESCRIPTION
## Summary

Fixes #7210.

#7094 changed `MediaPlayer._initialize` to route the unset `audioStreamIndex` case through `videoTrack?.getPrimaryPairableAudioTrack()`. For audio-only files (e.g. `.m4a`, `.flac`, `.wav`), `videoTrack` is `null`, so the optional chain short-circuits to `undefined`, the player returns `no-tracks`, and `<Audio>` wrongly falls back to `<Html5Audio>` in 4.0.454.

This restores the pre-4.0.454 behavior by selecting the first audio track when there's no video track and `audioStreamIndex` isn't set, while preserving the new HLS pairable-audio-track logic when a video track is present. Thanks @andreibarabas for the precise diagnosis!

The same pattern was already implemented manually in `getSinks` (`get-frames-since-keyframe.ts`), so this PR also DRYs both call sites by extracting a single `resolveAudioTrack` helper.

## Test plan

- [x] Adds a regression test in `media-player.test.ts` that initializes `MediaPlayer` against an audio-only `.m4a` with `audioStreamIndex: null` and asserts `result.type === 'success'`.
- [x] `bun run lint` passes.
- [x] `tsgo --noEmit` passes.

Made with [Cursor](https://cursor.com)