### PR TITLE
`@remotion/studio`: Remove misleading Cmd+T shortcut from Copy Stacktrace

### DIFF
--- a/packages/studio/src/error-overlay/remotion-overlay/CopyStackTrace.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/CopyStackTrace.tsx
@@ -1,12 +1,9 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import {Button} from '../../components/Button';
-import {useKeybinding} from '../../helpers/use-keybinding';
-import {ShortcutHint} from './ShortcutHint';
 
 export const CopyStackTrace: React.FC<{
-	readonly canHaveKeyboardShortcuts: boolean;
 	readonly errorText: string;
-}> = ({canHaveKeyboardShortcuts, errorText}) => {
+}> = ({errorText}) => {
 	const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>(
 		'idle',
 	);
@@ -24,26 +21,6 @@ export const CopyStackTrace: React.FC<{
 			});
 	}, [errorText]);
 
-	const {registerKeybinding} = useKeybinding();
-
-	useEffect(() => {
-		if (!canHaveKeyboardShortcuts) {
-			return;
-		}
-
-		const {unregister} = registerKeybinding({
-			event: 'keydown',
-			key: 't',
-			callback: handleCopyToClipboard,
-			commandCtrlKey: true,
-			preventDefault: true,
-			triggerIfInputFieldFocused: false,
-			keepRegisteredWhenNotHighestContext: false,
-		});
-
-		return () => unregister();
-	}, [canHaveKeyboardShortcuts, handleCopyToClipboard, registerKeybinding]);
-
 	const label = useMemo(() => {
 		if (copyState === 'copied') {
 			return 'Copied!';
@@ -56,12 +33,5 @@ export const CopyStackTrace: React.FC<{
 		return 'Copy Stacktrace';
 	}, [copyState]);
 
-	return (
-		<Button onClick={handleCopyToClipboard}>
-			{label}{' '}
-			{copyState === 'idle' && canHaveKeyboardShortcuts ? (
-				<ShortcutHint cmdOrCtrl keyToPress="t" />
-			) : null}
-		</Button>
-	);
+	return <Button onClick={handleCopyToClipboard}>{label}</Button>;
 };

--- a/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
@@ -109,10 +109,7 @@ export const ErrorDisplay: React.FC<{
 					<div style={spacer} />
 				</>
 			) : null}
-			<CopyStackTrace
-				canHaveKeyboardShortcuts={keyboardShortcuts}
-				errorText={errorTextForCopy}
-			/>
+			<CopyStackTrace errorText={errorTextForCopy} />
 			<div style={spacer} />
 			<SearchGithubIssues
 				canHaveKeyboardShortcuts={keyboardShortcuts}


### PR DESCRIPTION
## Summary

- Removed the keyboard shortcut registration and UI hint for copying the stack trace from the error overlay.
- **Reason:** `Cmd+T` / `Ctrl+T` is reserved by browsers for “new tab”, so the advertised shortcut could not work as shown ([issue #7203](https://github.com/remotion-dev/remotion/issues/7203)).

Copy stack trace remains available via the button click.

## Test plan

- [ ] Open Remotion Studio, trigger an error overlay, confirm “Copy Stacktrace” works on click and no shortcut hint is shown.

Made with [Cursor](https://cursor.com)