### PR TITLE
`@remotion/studio`: Make symbolicated stack file paths open in editor

### DIFF
--- a/packages/studio/src/error-overlay/remotion-overlay/StackFrame.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/StackFrame.tsx
@@ -1,6 +1,7 @@
 import type {SymbolicatedStackFrame} from '@remotion/studio-shared';
 import React, {useCallback, useState} from 'react';
 import {Button} from '../../components/Button';
+import {openInEditor} from '../../helpers/open-in-editor';
 import {CaretDown, CaretRight} from './carets';
 import {CodeFrame} from './CodeFrame';
 import {formatLocation} from './format-location';
@@ -46,6 +47,19 @@ export const StackElement: React.FC<{
 				!s.originalFileName?.startsWith('webpack/')) ||
 			isFirst,
 	);
+	const [locationHovered, setLocationHovered] = useState(false);
+	const canOpenFileLocation = Boolean(
+		window.remotion_editorName && s.originalFileName,
+	);
+	const onOpenFileLocation = useCallback(() => {
+		if (!canOpenFileLocation) {
+			return;
+		}
+
+		openInEditor(s).catch((err: unknown) => {
+			console.log('Could not open in editor', err);
+		});
+	}, [canOpenFileLocation, s]);
 	const toggleCodeFrame = useCallback(() => {
 		setShowCodeFrame((f) => !f);
 	}, []);
@@ -58,8 +72,31 @@ export const StackElement: React.FC<{
 					</div>
 					{s.originalFileName ? (
 						<div style={location}>
-							{formatLocation(s.originalFileName as string)}:
-							{s.originalLineNumber}
+							{canOpenFileLocation ? (
+								<span
+									onClick={onOpenFileLocation}
+									onPointerEnter={() => {
+										setLocationHovered(true);
+									}}
+									onPointerLeave={() => {
+										setLocationHovered(false);
+									}}
+									style={{
+										...location,
+										cursor: 'pointer',
+										textDecoration: locationHovered ? 'underline' : 'none',
+										textUnderlineOffset: locationHovered ? 4 : undefined,
+									}}
+								>
+									{formatLocation(s.originalFileName as string)}:
+									{s.originalLineNumber}
+								</span>
+							) : (
+								<>
+									{formatLocation(s.originalFileName as string)}:
+									{s.originalLineNumber}
+								</>
+							)}
 						</div>
 					) : null}
 				</div>

--- a/packages/studio/src/error-overlay/remotion-overlay/StackFrame.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/StackFrame.tsx
@@ -57,6 +57,7 @@ export const StackElement: React.FC<{
 		}
 
 		openInEditor(s).catch((err: unknown) => {
+			// eslint-disable-next-line no-console
 			console.log('Could not open in editor', err);
 		});
 	}, [canOpenFileLocation, s]);


### PR DESCRIPTION
Fixes https://github.com/remotion-dev/remotion/issues/7194

When an editor is connected (`window.remotion_editorName`), each symbolicated frame path in the error overlay is clickable and opens that frame in the editor via the existing `/api/open-in-editor` flow.

The interactive span repeats the location typography inline so `.css-reset` does not strip monospace/color. Hover shows an underline with a small offset.

Made with [Cursor](https://cursor.com)