### PR TITLE
`create-video`: Exit when CLI target directory is not empty

### DIFF
--- a/packages/create-video/src/resolve-project-root.ts
+++ b/packages/create-video/src/resolve-project-root.ts
@@ -122,6 +122,12 @@ export const resolveProjectRoot = async (options?: {
 	}
 
 	if (assertFolderEmptyAsync(projectRoot).exists) {
+		// When the folder name came from the CLI, prompting again would reuse the same
+		// argument and recurse forever (see https://github.com/remotion-dev/remotion/issues/7219).
+		if (options?.directoryArgument) {
+			process.exit(1);
+		}
+
 		return resolveProjectRoot(options);
 	}
 

--- a/packages/create-video/src/test/resolve-project-root.test.ts
+++ b/packages/create-video/src/test/resolve-project-root.test.ts
@@ -1,0 +1,28 @@
+import {expect, spyOn, test} from 'bun:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {resolveProjectRoot} from '../resolve-project-root';
+
+test('CLI directory argument: exits when target folder is not empty', async () => {
+	const dir = await fs.mkdtemp(
+		path.join(os.tmpdir(), 'create-video-nonempty-'),
+	);
+	await fs.writeFile(path.join(dir, 'existing.txt'), 'x');
+
+	const exitSpy = spyOn(process, 'exit').mockImplementation(((
+		code?: number,
+	) => {
+		throw new Error(`EXIT:${code ?? 0}`);
+	}) as typeof process.exit);
+
+	try {
+		await expect(resolveProjectRoot({directoryArgument: dir})).rejects.toThrow(
+			'EXIT:1',
+		);
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	} finally {
+		exitSpy.mockRestore();
+		await fs.rm(dir, {recursive: true, force: true});
+	}
+});


### PR DESCRIPTION
## Summary

Fixes https://github.com/remotion-dev/remotion/issues/7219.

When `create-video` was invoked with a positional directory name (e.g. `npx create-video@latest north-korea`) and that path already existed with files, `resolveProjectRoot` recursively called itself with the same options forever. That repeated the error message and eventually overflowed the stack.

## Change

If the target folder is not empty **and** the folder name came from the CLI (`directoryArgument`), call `process.exit(1)` after the existing log output instead of recursing. Interactive flows (prompted directory name) keep the previous retry behavior.

## Test

Added a unit test that stubs `process.exit` and asserts exit code `1` when `directoryArgument` points at a non-empty directory.

Made with [Cursor](https://cursor.com)