### PR TITLE
`@remotion/studio`: Expand composition folders when navigating via URL

### DIFF
--- a/packages/studio/src/components/CompSelectorRef.tsx
+++ b/packages/studio/src/components/CompSelectorRef.tsx
@@ -1,37 +1,31 @@
 import type React from 'react';
-import {
-	useCallback,
-	useContext,
-	useImperativeHandle,
-	useMemo,
-	useState,
-} from 'react';
+import {useCallback, useContext, useImperativeHandle, useMemo} from 'react';
 import {Internals} from 'remotion';
+import {getKeysToExpand} from '../helpers/create-folder-tree';
 import type {
 	ExpandedFoldersRef,
 	ExpandedFoldersState,
 } from '../helpers/persist-open-folders';
 import {
 	ExpandedFoldersContext,
-	loadExpandedFolders,
 	openFolderKey,
 	persistExpandedFolders,
 } from '../helpers/persist-open-folders';
+import {FolderContext} from '../state/folders';
 import {useSelectComposition} from './InitialCompositionLoader';
 
 export const CompSelectorRef: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
 	const {compositions} = useContext(Internals.CompositionManager);
-	const [foldersExpanded, setFoldersExpanded] = useState<ExpandedFoldersState>(
-		loadExpandedFolders('compositions'),
-	);
+	const {compositionFoldersExpanded, setCompositionFoldersExpanded} =
+		useContext(FolderContext);
 
 	const selectComposition = useSelectComposition();
 
 	const toggleFolder = useCallback(
 		(folderName: string, parentName: string | null) => {
-			setFoldersExpanded((p) => {
+			setCompositionFoldersExpanded((p) => {
 				const key = openFolderKey({folderName, parentName});
 				const prev = p[key] ?? false;
 				const foldersExpandedState: ExpandedFoldersState = {
@@ -42,7 +36,7 @@ export const CompSelectorRef: React.FC<{
 				return foldersExpandedState;
 			});
 		},
-		[],
+		[setCompositionFoldersExpanded],
 	);
 
 	useImperativeHandle(
@@ -62,28 +56,13 @@ export const CompSelectorRef: React.FC<{
 						return;
 					}
 
-					setFoldersExpanded((previousState) => {
+					setCompositionFoldersExpanded((previousState) => {
+						const keysToExpand = getKeysToExpand(folderName, parentFolderName);
 						const foldersExpandedState: ExpandedFoldersState = {
 							...previousState,
 						};
-
-						const currentFolder: string | null = folderName;
-						const currentParentName: string | null = parentFolderName;
-						const key = openFolderKey({
-							folderName: currentFolder,
-							parentName: currentParentName,
-						});
-
-						const splitted = key.split('/');
-						for (let i = 0; i < splitted.length - 1; i++) {
-							const allExceptLast =
-								i === 0
-									? openFolderKey({
-											folderName: splitted.filter((s) => s !== 'no-parent')[0],
-											parentName: null,
-										})
-									: splitted.slice(0, i + 1).join('/');
-							foldersExpandedState[allExceptLast] = true;
+						for (const key of keysToExpand) {
+							foldersExpandedState[key] = true;
 						}
 
 						persistExpandedFolders('compositions', foldersExpandedState);
@@ -104,16 +83,24 @@ export const CompSelectorRef: React.FC<{
 				},
 			};
 		},
-		[compositions, selectComposition, toggleFolder],
+		[
+			compositions,
+			selectComposition,
+			setCompositionFoldersExpanded,
+			toggleFolder,
+		],
 	);
 
 	const contextValue: ExpandedFoldersRef = useMemo(() => {
 		return {
-			foldersExpanded,
-			setFoldersExpanded,
+			foldersExpanded: compositionFoldersExpanded,
+			setFoldersExpanded: (foldersExpanded) => {
+				setCompositionFoldersExpanded(foldersExpanded);
+				persistExpandedFolders('compositions', foldersExpanded);
+			},
 			toggleFolder,
 		};
-	}, [foldersExpanded, setFoldersExpanded, toggleFolder]);
+	}, [compositionFoldersExpanded, setCompositionFoldersExpanded, toggleFolder]);
 
 	return (
 		<ExpandedFoldersContext.Provider value={contextValue}>

--- a/packages/studio/src/components/CompositionSelector.tsx
+++ b/packages/studio/src/components/CompositionSelector.tsx
@@ -2,14 +2,8 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
 import {BACKGROUND, BORDER_COLOR, LIGHT_TEXT} from '../helpers/colors';
-import {
-	createFolderTree,
-	splitParentIntoNameAndParent,
-} from '../helpers/create-folder-tree';
-import {
-	ExpandedFoldersContext,
-	openFolderKey,
-} from '../helpers/persist-open-folders';
+import {createFolderTree} from '../helpers/create-folder-tree';
+import {ExpandedFoldersContext} from '../helpers/persist-open-folders';
 import {sortItemsByNonceHistory} from '../helpers/sort-by-nonce-history';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
 import {ModalsContext} from '../state/modals';
@@ -112,26 +106,6 @@ const quickSwitcherTrigger: React.CSSProperties = {
 const shortcutLabel: React.CSSProperties = {
 	fontSize: 11,
 	opacity: 0.6,
-};
-
-export const getKeysToExpand = (
-	initialFolderName: string,
-	parentFolderName: string | null,
-	initial: string[] = [],
-): string[] => {
-	initial.push(
-		openFolderKey({
-			folderName: initialFolderName,
-			parentName: parentFolderName,
-		}),
-	);
-
-	const {name, parent} = splitParentIntoNameAndParent(parentFolderName);
-	if (!name) {
-		return initial;
-	}
-
-	return getKeysToExpand(name, parent, initial);
 };
 
 export const CompositionSelector: React.FC = () => {

--- a/packages/studio/src/components/InitialCompositionLoader.tsx
+++ b/packages/studio/src/components/InitialCompositionLoader.tsx
@@ -2,12 +2,13 @@ import type React from 'react';
 import {useCallback, useContext, useEffect} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
+import {getKeysToExpand} from '../helpers/create-folder-tree';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import type {ExpandedFoldersState} from '../helpers/persist-open-folders';
+import {persistExpandedFolders} from '../helpers/persist-open-folders';
 import {getRoute, pushUrl} from '../helpers/url-state';
 import {FolderContext} from '../state/folders';
 import {SidebarContext} from '../state/sidebar';
-import {getKeysToExpand} from './CompositionSelector';
 import {explorerSidebarTabs} from './ExplorerPanel';
 import {deriveCanvasContentFromUrl} from './load-canvas-content-from-url';
 import {useStaticFiles} from './use-static-files';
@@ -67,6 +68,8 @@ export const useSelectComposition = () => {
 					for (const key of keysToExpand) {
 						newState[key] = true;
 					}
+
+					persistExpandedFolders('compositions', newState);
 
 					return newState;
 				});

--- a/packages/studio/src/helpers/create-folder-tree.ts
+++ b/packages/studio/src/helpers/create-folder-tree.ts
@@ -79,6 +79,30 @@ export const splitParentIntoNameAndParent = (
 	};
 };
 
+/**
+ * Returns storage keys for the composition folder and each ancestor, so the
+ * tree can be expanded when navigating to a nested composition.
+ */
+export const getKeysToExpand = (
+	initialFolderName: string,
+	parentFolderName: string | null,
+	initial: string[] = [],
+): string[] => {
+	initial.push(
+		openFolderKey({
+			folderName: initialFolderName,
+			parentName: parentFolderName,
+		}),
+	);
+
+	const {name, parent} = splitParentIntoNameAndParent(parentFolderName);
+	if (!name) {
+		return initial;
+	}
+
+	return getKeysToExpand(name, parent, initial);
+};
+
 const doesFolderExist = (
 	items: CompositionSelectorItemType[],
 	folderName: string,

--- a/packages/studio/src/test/folder-tree.test.ts
+++ b/packages/studio/src/test/folder-tree.test.ts
@@ -2,7 +2,7 @@ import {expect, test} from 'bun:test';
 import type {ComponentType} from 'react';
 import React from 'react';
 import {getZodIfPossible} from '../components/get-zod-if-possible';
-import {createFolderTree} from '../helpers/create-folder-tree';
+import {createFolderTree, getKeysToExpand} from '../helpers/create-folder-tree';
 
 const SampleComp: React.FC<{}> = () => null;
 const component = React.lazy(() =>
@@ -205,6 +205,23 @@ test('Should handle nested folders well', async () => {
 			],
 			type: 'folder',
 		},
+	]);
+});
+
+test('getKeysToExpand lists nested folder keys from leaf to root', () => {
+	expect(
+		getKeysToExpand('my-folder', 'my-third-folder/my-second-folder'),
+	).toEqual([
+		'my-third-folder/my-second-folder/my-folder',
+		'my-third-folder/my-second-folder',
+		'no-parent/my-third-folder',
+	]);
+});
+
+test('getKeysToExpand lists direct child folder and root folder', () => {
+	expect(getKeysToExpand('html-in-canvas', 'video-tests')).toEqual([
+		'video-tests/html-in-canvas',
+		'no-parent/video-tests',
 	]);
 });
 


### PR DESCRIPTION
## Summary

- **Root cause:** `useSelectComposition` updated `FolderContext` expanded-folder state, while `CompositionSelector` read `ExpandedFoldersContext`, which was backed by a **separate** `useState` in `CompSelectorRef`. URL-driven selection never updated the state the sidebar renders.
- **Fix:** `CompSelectorRef` now uses `FolderContext` (`compositionFoldersExpanded` / `setCompositionFoldersExpanded`) as the single source of truth; toggles and the imperative API persist to `localStorage` like before.
- **Also:** `getKeysToExpand` lives next to `createFolderTree`; `expandComposition` uses the same recursive keys as URL navigation; `persistExpandedFolders` runs when expanding from `useSelectComposition`.
- **Tests:** Added expectations for nested and one-level folder key paths.

## Test plan

- [ ] Open Studio with all composition folders collapsed, navigate to a nested composition URL (e.g. `/html-in-canvas-compose-async-bitmap`) — parent folders should expand and the composition stay visible in the list.
- [ ] Toggle folders manually — still persists and updates the tree.

Made with [Cursor](https://cursor.com)