### PR TITLE
`remotion`: forbid nesting HtmlInCanvas

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -522,7 +522,9 @@ const HtmlInCanvasInner = forwardRef<
 		}, [width, height, style]);
 
 		if (isInsideAncestorHtmlInCanvas) {
-			throw new Error('<HtmlInCanvas> effects cannot be nested together');
+			throw new Error(
+				'<HtmlInCanvas> effects cannot be nested together. Chrome will only display the outer effect. Consider merging the effects into one if you can.',
+			);
 		}
 
 		return (

--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -1,6 +1,8 @@
 import React, {
+	createContext,
 	forwardRef,
 	useCallback,
+	useContext,
 	useLayoutEffect,
 	useMemo,
 	useRef,
@@ -261,6 +263,8 @@ export type HtmlInCanvasProps = Omit<
 	};
 /* eslint-enable react/require-default-props */
 
+const HtmlInCanvasAncestorContext = createContext(false);
+
 const htmlInCanvasSchema = {
 	'style.translate': {
 		type: 'translate',
@@ -313,6 +317,10 @@ const HtmlInCanvasInner = forwardRef<
 		},
 		ref,
 	) => {
+		const isInsideAncestorHtmlInCanvas = useContext(
+			HtmlInCanvasAncestorContext,
+		);
+
 		assertHtmlInCanvasDimensions(width, height);
 		const {continueRender, cancelRender} = useDelayRender();
 
@@ -513,6 +521,10 @@ const HtmlInCanvasInner = forwardRef<
 			};
 		}, [width, height, style]);
 
+		if (isInsideAncestorHtmlInCanvas) {
+			throw new Error('<HtmlInCanvas> effects cannot be nested together');
+		}
+
 		return (
 			<Sequence
 				durationInFrames={resolvedDuration}
@@ -521,11 +533,13 @@ const HtmlInCanvasInner = forwardRef<
 				layout="none"
 				{...sequenceProps}
 			>
-				<canvas ref={setLayoutCanvasRef} width={width} height={height}>
-					<div ref={divRef} style={innerStyle}>
-						{children}
-					</div>
-				</canvas>
+				<HtmlInCanvasAncestorContext.Provider value>
+					<canvas ref={setLayoutCanvasRef} width={width} height={height}>
+						<div ref={divRef} style={innerStyle}>
+							{children}
+						</div>
+					</canvas>
+				</HtmlInCanvasAncestorContext.Provider>
 			</Sequence>
 		);
 	},

--- a/packages/docs/docs/remotion/html-in-canvas.mdx
+++ b/packages/docs/docs/remotion/html-in-canvas.mdx
@@ -40,6 +40,26 @@ if (HtmlInCanvas.isHtmlInCanvasSupported()) {
 }
 ```
 
+## Video and the ANGLE renderer
+
+If your composition includes **video** (for example [`<Video>`](/docs/media/video) from `@remotion/media`) and you use `<HtmlInCanvas>`, video will only render when Chromium uses the **ANGLE** OpenGL backend.
+
+From the CLI:
+
+```bash
+npx remotion render --gl=angle
+```
+
+It is advised to set the default in `remotion.config.ts` so Studio and CLI renders pick it up:
+
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+// ---cut---
+Config.setChromiumOpenGlRenderer('angle');
+```
+
+See [`Config.setChromiumOpenGlRenderer()`](/docs/config#setchromiumopenglrenderer).
+
 ## API
 
 ### `width`

--- a/packages/docs/docs/remotion/html-in-canvas.mdx
+++ b/packages/docs/docs/remotion/html-in-canvas.mdx
@@ -58,7 +58,7 @@ Children will be wrapped in a `<div>` with the given `width` and `height`.
 Do not nest `<HtmlInCanvas>` inside another `<HtmlInCanvas>`. Nesting is not supported and throws:
 
 ```
-<HtmlInCanvas> effects cannot be nested together
+<HtmlInCanvas> effects cannot be nested together. Chrome will only display the outer effect. Consider merging the effects into one if you can.
 ```
 
 ### `onPaint?`

--- a/packages/docs/docs/remotion/html-in-canvas.mdx
+++ b/packages/docs/docs/remotion/html-in-canvas.mdx
@@ -55,6 +55,12 @@ Height of the canvas and the inner layout area, in pixels. Must be a positive in
 Children to draw to the canvas.  
 Children will be wrapped in a `<div>` with the given `width` and `height`.
 
+Do not nest `<HtmlInCanvas>` inside another `<HtmlInCanvas>`. Nesting is not supported and throws:
+
+```
+<HtmlInCanvas> effects cannot be nested together
+```
+
 ### `onPaint?`
 
 Called when the children are updated and can be painted onto the canvas.  

--- a/packages/skills/skills/remotion/rules/html-in-canvas.md
+++ b/packages/skills/skills/remotion/rules/html-in-canvas.md
@@ -31,8 +31,6 @@ import { Config } from "@remotion/cli/config";
 Config.setChromiumOpenGlRenderer("angle");
 ```
 
-See https://remotion.dev/docs/config#setchromiumopenglrenderer
-
 ## Basic usage
 
 By default, draws to canvas with no effect applied:

--- a/packages/skills/skills/remotion/rules/html-in-canvas.md
+++ b/packages/skills/skills/remotion/rules/html-in-canvas.md
@@ -5,6 +5,34 @@ Renders children into a `<canvas>` so you can post-process them with the Canvas 
 Only works in Chrome 149+ with the `chrome://flags/#canvas-draw-element` flag enabled.  
 Give the user a notice.
 
+## Nesting
+
+Do not nest `<HtmlInCanvas>` inside another `<HtmlInCanvas>`. Remotion throws:
+
+```
+<HtmlInCanvas> effects cannot be nested together. Chrome will only display the outer effect. Consider merging the effects into one if you can.
+```
+
+## Video and the ANGLE renderer
+
+If the composition includes **video** (for example `<Video>` from `@remotion/media`) and you use `<HtmlInCanvas>`, rendering only works when Chromium uses the **ANGLE** OpenGL backend.
+
+From the CLI:
+
+```bash
+npx remotion render --gl=angle
+```
+
+Set it as the default for Studio and CLI (advised):
+
+```ts
+import { Config } from "@remotion/cli/config";
+
+Config.setChromiumOpenGlRenderer("angle");
+```
+
+See https://remotion.dev/docs/config#setchromiumopenglrenderer
+
 ## Basic usage
 
 By default, draws to canvas with no effect applied:


### PR DESCRIPTION
## Summary

- Add `HtmlInCanvasAncestorContext` so any `<HtmlInCanvas>` rendered inside another instance throws: `<HtmlInCanvas> effects cannot be nested together`.
- Document the constraint under the `children` section on [`/docs/remotion/html-in-canvas`](/docs/remotion/html-in-canvas).

## Notes

The check runs after hooks (same pattern as other invariant throws) and wraps `children` with the context provider so nesting is detected reliably.

Made with [Cursor](https://cursor.com)