### PR TITLE
`@remotion/renderer`: Close inline WAV before tone-frequency replace (fix #7242)

### DIFF
--- a/packages/renderer/src/assets/inline-audio-mixing.ts
+++ b/packages/renderer/src/assets/inline-audio-mixing.ts
@@ -57,7 +57,8 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 	};
 
 	const getListOfAssets = () => {
-		return Object.keys(openFiles);
+		// Use writtenHeaders so paths stay listed after finish() closes descriptors for tone processing.
+		return Object.keys(writtenHeaders);
 	};
 
 	const getFilePath = (asset: InlineAudioAsset) => {
@@ -162,12 +163,21 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 		cancelSignal: CancelSignal | undefined;
 		sampleRate: number;
 	}) => {
-		for (const fd of Object.keys(openFiles)) {
-			const frequency = toneFrequencies[fd];
+		// Snapshot paths: finish() may delete keys from openFiles while iterating.
+		const filePaths = Object.keys(openFiles);
+		for (const filePath of filePaths) {
+			const frequency = toneFrequencies[filePath];
 			if (frequency !== 1) {
-				const tmpFile = fd.replace(/.wav$/, '-tmp.wav');
+				// Windows returns EPERM if we rename over a path still open for writing; close first.
+				const descriptor = openFiles[filePath];
+				if (descriptor !== undefined) {
+					fs.closeSync(descriptor);
+					delete openFiles[filePath];
+				}
+
+				const tmpFile = filePath.replace(/.wav$/, '-tmp.wav');
 				await applyToneFrequencyUsingFfmpeg({
-					input: fd,
+					input: filePath,
 					output: tmpFile,
 					toneFrequency: frequency,
 					indent,
@@ -176,7 +186,7 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 					cancelSignal,
 					sampleRate: finishSampleRate,
 				});
-				fs.renameSync(tmpFile, fd);
+				fs.renameSync(tmpFile, filePath);
 			}
 		}
 	};


### PR DESCRIPTION
## Summary
Fixes https://github.com/remotion-dev/remotion/issues/7242

On Windows, `fs.renameSync(\*-tmp.wav, target.wav)` failed with `EPERM` when inline audio mixing applied `toneFrequency` because the target path was still open for writing in `openFiles`.

## Changes
- In `makeInlineAudioMixing().finish()`, `fs.closeSync` the descriptor and remove the path from `openFiles` before `applyToneFrequencyUsingFfmpeg` and `renameSync`.
- `getListOfAssets()` now lists paths from `writtenHeaders` so inlined WAVs that were closed for tone processing are still passed to the merge step (`create-audio.ts`).

## Testing
- `bunx turbo run make --filter=@remotion/renderer`
- `bun run lint` in `packages/renderer` (pre-existing warnings only)


Made with [Cursor](https://cursor.com)