### PR TITLE
Docs: add SwiftClip to resources list

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -23,6 +23,7 @@ This list tries to compile all templates, libraries, building blocks and example
 - Video Editor & Timeline Component (Next.js, Tailwind CSS) ([Source Code](https://github.com/sambowenhughes/a-react-video-editor), [Preview](https://www.reactvideoeditor.com/open-source?utm_source=remotion))
 - [Free Remotion Components](https://www.clippkit.com/)
 - [Remotion Bits - Ready-made blocks to use for you and your agents](https://remotion-bits.dev/)
+- [SwiftClip - 30 production-ready Remotion templates](https://swift-clip.vercel.app/) ([Source code](https://github.com/zz41354899/SwiftClip))
 - Docker Build & Render ([Source code](https://github.com/scotthavird/remotion-docker-template))
 - [Template for deploying Remotion on Railway](https://railway.com/deploy/remotion-on-rails) ([Blog](https://medium.com/@viveknathani/remotion-on-rails-0852acc9595e))
 - [Multiple shared Remotion components in a Monorepo template](https://github.com/Takamasa045/remotion-studio-monorepo)


### PR DESCRIPTION
## What is this PR?

Adds [SwiftClip](https://swift-clip.vercel.app/) to the resources list under Templates.

SwiftClip is an open-source library of 30 copy-paste Remotion video composition templates built with React & TypeScript. Templates cover Marketing, Social, Data Viz, Broadcast, AI, and more categories.

- **Live site:** https://swift-clip.vercel.app/
- **Source code:** https://github.com/zz41354899/SwiftClip
- **License:** MIT