### PR TITLE
`remotion`: Split playback rate out of timeline context

### DIFF
--- a/packages/bundler/src/index-html.ts
+++ b/packages/bundler/src/index-html.ts
@@ -66,11 +66,6 @@ export const indexHtml = ({
 				: ''
 		}
 		<title>${title}</title>
-		${
-			mode === 'dev'
-				? '<script crossOrigin="anonymous" src="//unpkg.com/react-scan/dist/auto.global.js"></script>'
-				: ''
-		}
 	</head>
 	<body>
 		<script>window.remotion_numberOfAudioTags = ${numberOfAudioTags};</script>

--- a/packages/bundler/src/index-html.ts
+++ b/packages/bundler/src/index-html.ts
@@ -66,6 +66,11 @@ export const indexHtml = ({
 				: ''
 		}
 		<title>${title}</title>
+		${
+			mode === 'dev'
+				? '<script crossOrigin="anonymous" src="//unpkg.com/react-scan/dist/auto.global.js"></script>'
+				: ''
+		}
 	</head>
 	<body>
 		<script>window.remotion_numberOfAudioTags = ${numberOfAudioTags};</script>

--- a/packages/core/src/TimelineContext.tsx
+++ b/packages/core/src/TimelineContext.tsx
@@ -23,6 +23,11 @@ export type TimelineContextValue = {
 	audioAndVideoTags: MutableRefObject<PlayableMediaTag[]>;
 };
 
+export type PlaybackRateContextValue = {
+	playbackRate: number;
+	setPlaybackRate: (u: React.SetStateAction<number>) => void;
+};
+
 export type SetTimelineContextValue = {
 	setFrame: (u: React.SetStateAction<Record<string, number>>) => void;
 	setPlaying: (u: React.SetStateAction<boolean>) => void;
@@ -38,6 +43,9 @@ export const SetTimelineContext = createContext<SetTimelineContextValue>({
 });
 
 export const TimelineContext = createContext<TimelineContextValue | null>(null);
+
+export const PlaybackRateContext =
+	createContext<PlaybackRateContextValue | null>(null);
 
 export const AbsoluteTimeContext = createContext<TimelineContextValue | null>(
 	null,
@@ -108,6 +116,13 @@ export const TimelineContextProvider: React.FC<{
 		};
 	}, [frame, playbackRate, playing, remotionRootId]);
 
+	const playbackRateContextValue = useMemo((): PlaybackRateContextValue => {
+		return {
+			playbackRate,
+			setPlaybackRate,
+		};
+	}, [playbackRate]);
+
 	const setTimelineContextValue = useMemo((): SetTimelineContextValue => {
 		return {
 			setFrame,
@@ -117,11 +132,13 @@ export const TimelineContextProvider: React.FC<{
 
 	return (
 		<AbsoluteTimeContext.Provider value={timelineContextValue}>
-			<TimelineContext.Provider value={timelineContextValue}>
-				<SetTimelineContext.Provider value={setTimelineContextValue}>
-					{children}
-				</SetTimelineContext.Provider>
-			</TimelineContext.Provider>
+			<PlaybackRateContext.Provider value={playbackRateContextValue}>
+				<TimelineContext.Provider value={timelineContextValue}>
+					<SetTimelineContext.Provider value={setTimelineContextValue}>
+						{children}
+					</SetTimelineContext.Provider>
+				</TimelineContext.Provider>
+			</PlaybackRateContext.Provider>
 		</AbsoluteTimeContext.Provider>
 	);
 };

--- a/packages/core/src/TimelineContext.tsx
+++ b/packages/core/src/TimelineContext.tsx
@@ -17,9 +17,7 @@ export type TimelineContextValue = {
 	frame: Record<string, number>;
 	playing: boolean;
 	rootId: string;
-	playbackRate: number;
 	imperativePlaying: MutableRefObject<boolean>;
-	setPlaybackRate: (u: React.SetStateAction<number>) => void;
 	audioAndVideoTags: MutableRefObject<PlayableMediaTag[]>;
 };
 
@@ -110,11 +108,9 @@ export const TimelineContextProvider: React.FC<{
 			playing,
 			imperativePlaying,
 			rootId: remotionRootId,
-			playbackRate,
-			setPlaybackRate,
 			audioAndVideoTags,
 		};
-	}, [frame, playbackRate, playing, remotionRootId]);
+	}, [frame, playing, remotionRootId]);
 
 	const playbackRateContextValue = useMemo((): PlaybackRateContextValue => {
 		return {

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -109,13 +109,16 @@ import {setupEnvVariables} from './setup-env-variables.js';
 import * as TimelinePosition from './timeline-position-state.js';
 import {
 	persistCurrentFrame,
+	usePlaybackRate,
 	useTimelineContext,
 	useTimelineSetFrame,
 } from './timeline-position-state.js';
 import {
 	AbsoluteTimeContext,
+	PlaybackRateContext,
 	SetTimelineContext,
 	TimelineContext,
+	type PlaybackRateContextValue,
 	type SetTimelineContextValue,
 	type TimelineContextValue,
 } from './TimelineContext.js';
@@ -251,6 +254,7 @@ export const Internals = {
 	REMOTION_STUDIO_CONTAINER_ELEMENT,
 	RenderAssetManager,
 	persistCurrentFrame,
+	usePlaybackRate,
 	useTimelineContext,
 	useTimelineSetFrame,
 	isIosSafari,
@@ -284,6 +288,7 @@ export const Internals = {
 	TimelinePosition,
 	DelayRenderContextType,
 	TimelineContext,
+	PlaybackRateContext,
 	AbsoluteTimeContext,
 	RenderAssetManagerProvider,
 	getEffectiveVisualModeValue,
@@ -307,6 +312,7 @@ export type {
 	SerializedJSONWithCustomFields,
 	SetMediaVolumeContextValue,
 	SetTimelineContextValue,
+	PlaybackRateContextValue,
 	TCompMetadata,
 	TComposition,
 	TimelineContextValue,

--- a/packages/core/src/test/nested-sequences.test.tsx
+++ b/packages/core/src/test/nested-sequences.test.tsx
@@ -21,10 +21,6 @@ const getForFrame = (frame: number, content: React.ReactNode) => {
 					imperativePlaying: {
 						current: false,
 					},
-					playbackRate: 1,
-					setPlaybackRate: () => {
-						throw new Error('playback rate');
-					},
 					audioAndVideoTags: {
 						current: [],
 					},

--- a/packages/core/src/test/series.test.tsx
+++ b/packages/core/src/test/series.test.tsx
@@ -43,10 +43,6 @@ const renderForFrame = (frame: number, markup: React.ReactNode) => {
 		imperativePlaying: {
 			current: false,
 		},
-		playbackRate: 1,
-		setPlaybackRate: () => {
-			throw new Error('playback rate');
-		},
 		audioAndVideoTags: {current: []},
 	};
 

--- a/packages/core/src/test/wrap-sequence-context.tsx
+++ b/packages/core/src/test/wrap-sequence-context.tsx
@@ -6,8 +6,15 @@ import {CompositionManager} from '../CompositionManagerContext.js';
 import type {LoggingContextValue} from '../log-level-context.js';
 import {LogLevelContext} from '../log-level-context.js';
 import {SequenceManagerProvider} from '../SequenceManager.js';
-import type {TimelineContextValue} from '../TimelineContext.js';
-import {AbsoluteTimeContext, TimelineContext} from '../TimelineContext.js';
+import type {
+	PlaybackRateContextValue,
+	TimelineContextValue,
+} from '../TimelineContext.js';
+import {
+	AbsoluteTimeContext,
+	PlaybackRateContext,
+	TimelineContext,
+} from '../TimelineContext.js';
 
 const Comp: React.FC = () => null;
 
@@ -54,13 +61,16 @@ const logContext: LoggingContextValue = {
 const mockTimelineContext: TimelineContextValue = {
 	frame: {},
 	playing: false,
-	playbackRate: 1,
 	rootId: 'test-root',
 	imperativePlaying: {current: false},
+	audioAndVideoTags: {current: []},
+};
+
+const mockPlaybackRateContext: PlaybackRateContextValue = {
+	playbackRate: 1,
 	setPlaybackRate: () => {
 		throw new Error('not implemented');
 	},
-	audioAndVideoTags: {current: []},
 };
 
 const MaybeTimelineProvider: React.FC<{
@@ -81,6 +91,22 @@ const MaybeTimelineProvider: React.FC<{
 	);
 };
 
+const MaybePlaybackRateProvider: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	const existing = useContext(PlaybackRateContext);
+	if (existing !== null) {
+		// eslint-disable-next-line react/jsx-no-useless-fragment
+		return <>{children}</>;
+	}
+
+	return (
+		<PlaybackRateContext.Provider value={mockPlaybackRateContext}>
+			{children}
+		</PlaybackRateContext.Provider>
+	);
+};
+
 export const WrapSequenceContext: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
@@ -89,11 +115,13 @@ export const WrapSequenceContext: React.FC<{
 			<BufferingProvider>
 				<CanUseRemotionHooksProvider>
 					<MaybeTimelineProvider>
-						<SequenceManagerProvider visualModeEnabled={false}>
-							<CompositionManager.Provider value={mockCompositionContext}>
-								{children}
-							</CompositionManager.Provider>
-						</SequenceManagerProvider>
+						<MaybePlaybackRateProvider>
+							<SequenceManagerProvider visualModeEnabled={false}>
+								<CompositionManager.Provider value={mockCompositionContext}>
+									{children}
+								</CompositionManager.Provider>
+							</SequenceManagerProvider>
+						</MaybePlaybackRateProvider>
 					</MaybeTimelineProvider>
 				</CanUseRemotionHooksProvider>
 			</BufferingProvider>

--- a/packages/core/src/timeline-position-state.ts
+++ b/packages/core/src/timeline-position-state.ts
@@ -2,8 +2,10 @@ import type {MutableRefObject} from 'react';
 import {useContext, useMemo} from 'react';
 import {
 	AbsoluteTimeContext,
+	PlaybackRateContext,
 	SetTimelineContext,
 	TimelineContext,
+	type PlaybackRateContextValue,
 	type TimelineContextValue,
 } from './TimelineContext.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
@@ -69,6 +71,17 @@ export const useTimelineContext = (): TimelineContextValue => {
 	if (state === null) {
 		throw new Error(
 			'TimelineContext is not available. This hook must be used inside a <Player> or the Remotion Studio.',
+		);
+	}
+
+	return state;
+};
+
+export const usePlaybackRate = (): PlaybackRateContextValue => {
+	const state = useContext(PlaybackRateContext);
+	if (state === null) {
+		throw new Error(
+			'PlaybackRateContext is not available. This hook must be used inside a <Player> or the Remotion Studio.',
 		);
 	}
 

--- a/packages/core/src/use-media-playback.ts
+++ b/packages/core/src/use-media-playback.ts
@@ -17,7 +17,7 @@ import {playbackLogging} from './playback-logging.js';
 import {seek} from './seek.js';
 import {
 	usePlayingState,
-	useTimelineContext,
+	usePlaybackRate,
 	useTimelinePosition,
 } from './timeline-position-state.js';
 import {useCurrentFrame} from './use-current-frame.js';
@@ -51,7 +51,7 @@ export const useMediaPlayback = ({
 	isPostmounting: boolean;
 	onAutoPlayError: null | (() => void);
 }) => {
-	const {playbackRate: globalPlaybackRate} = useTimelineContext();
+	const {playbackRate: globalPlaybackRate} = usePlaybackRate();
 	const frame = useCurrentFrame();
 	const absoluteFrame = useTimelinePosition();
 	const [playing] = usePlayingState();

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -80,8 +80,7 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 		useState(false);
 
 	const [playing] = Timeline.usePlayingState();
-	const timelineContext = Internals.useTimelineContext();
-	const globalPlaybackRate = timelineContext.playbackRate;
+	const {playbackRate: globalPlaybackRate} = Internals.usePlaybackRate();
 	const sharedAudioContext = useContext(SharedAudioContext);
 	const buffer = useBufferState();
 

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -116,8 +116,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 		useState(false);
 
 	const [playing] = Timeline.usePlayingState();
-	const timelineContext = Internals.useTimelineContext();
-	const globalPlaybackRate = timelineContext.playbackRate;
+	const {playbackRate: globalPlaybackRate} = Internals.usePlaybackRate();
 	const sharedAudioContext = useContext(SharedAudioContext);
 	const buffer = useBufferState();
 

--- a/packages/player/src/PlaybackrateControl.tsx
+++ b/packages/player/src/PlaybackrateControl.tsx
@@ -101,7 +101,7 @@ const PlaybackPopup: React.FC<{
 	readonly playbackRates: number[];
 	readonly canvasSize: Size;
 }> = ({setIsComponentVisible, playbackRates, canvasSize}) => {
-	const {setPlaybackRate, playbackRate} = Internals.useTimelineContext();
+	const {setPlaybackRate, playbackRate} = Internals.usePlaybackRate();
 
 	const [keyboardSelectedRate, setKeyboardSelectedRate] =
 		useState<number>(playbackRate);
@@ -232,7 +232,7 @@ export const PlaybackrateControl: React.FC<{
 }> = ({playbackRates, canvasSize}) => {
 	const {ref, isComponentVisible, setIsComponentVisible} =
 		useComponentVisible(false);
-	const {playbackRate} = Internals.useTimelineContext();
+	const {playbackRate} = Internals.usePlaybackRate();
 
 	const onClick: React.MouseEventHandler<HTMLButtonElement> = useCallback(
 		(e) => {

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -12,6 +12,7 @@ import type {
 	AnyZodObject,
 	CompProps,
 	LogLevel,
+	PlaybackRateContextValue,
 	PlayableMediaTag,
 	SetTimelineContextValue,
 	TimelineContextValue,
@@ -378,12 +379,17 @@ const PlayerFn = <
 			frame,
 			playing,
 			rootId,
-			playbackRate: currentPlaybackRate,
 			imperativePlaying,
-			setPlaybackRate: setCurrentPlaybackRate,
 			audioAndVideoTags,
 		};
-	}, [frame, currentPlaybackRate, playing, rootId]);
+	}, [frame, playing, rootId]);
+
+	const playbackRateContextValue = useMemo((): PlaybackRateContextValue => {
+		return {
+			playbackRate: currentPlaybackRate,
+			setPlaybackRate: setCurrentPlaybackRate,
+		};
+	}, [currentPlaybackRate]);
 
 	const setTimelineContextValue = useMemo((): SetTimelineContextValue => {
 		return {
@@ -420,6 +426,7 @@ const PlayerFn = <
 		<Internals.IsPlayerContextProvider>
 			<SharedPlayerContexts
 				timelineContext={timelineContextValue}
+				playbackRateContext={playbackRateContextValue}
 				component={component}
 				compositionHeight={compositionHeight}
 				compositionWidth={compositionWidth}

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -380,9 +380,7 @@ const PlayerFn = <
 			rootId,
 			playbackRate: currentPlaybackRate,
 			imperativePlaying,
-			setPlaybackRate: (rate) => {
-				setCurrentPlaybackRate(rate);
-			},
+			setPlaybackRate: setCurrentPlaybackRate,
 			audioAndVideoTags,
 		};
 	}, [frame, currentPlaybackRate, playing, rootId]);

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -7,6 +7,7 @@ import type {
 	LoggingContextValue,
 	LogLevel,
 	MediaVolumeContextValue,
+	PlaybackRateContextValue,
 	RemotionEnvironment,
 	SetMediaVolumeContextValue,
 	TimelineContextValue,
@@ -19,6 +20,7 @@ export const PLAYER_COMP_ID = 'player-comp';
 export const SharedPlayerContexts: React.FC<{
 	readonly children: React.ReactNode;
 	readonly timelineContext: TimelineContextValue;
+	readonly playbackRateContext: PlaybackRateContextValue;
 	readonly fps: number;
 	readonly compositionWidth: number;
 	readonly compositionHeight: number;
@@ -35,6 +37,7 @@ export const SharedPlayerContexts: React.FC<{
 }> = ({
 	children,
 	timelineContext,
+	playbackRateContext,
 	fps,
 	compositionHeight,
 	compositionWidth,
@@ -143,13 +146,6 @@ export const SharedPlayerContexts: React.FC<{
 			isReadOnlyStudio: false,
 		};
 	}, []);
-
-	const playbackRateContext = useMemo(() => {
-		return {
-			playbackRate: timelineContext.playbackRate,
-			setPlaybackRate: timelineContext.setPlaybackRate,
-		};
-	}, [timelineContext.playbackRate, timelineContext.setPlaybackRate]);
 
 	return (
 		<Internals.RemotionEnvironmentContext.Provider value={env}>

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -144,41 +144,50 @@ export const SharedPlayerContexts: React.FC<{
 		};
 	}, []);
 
+	const playbackRateContext = useMemo(() => {
+		return {
+			playbackRate: timelineContext.playbackRate,
+			setPlaybackRate: timelineContext.setPlaybackRate,
+		};
+	}, [timelineContext.playbackRate, timelineContext.setPlaybackRate]);
+
 	return (
 		<Internals.RemotionEnvironmentContext.Provider value={env}>
 			<Internals.LogLevelContext.Provider value={logLevelContext}>
 				<Internals.CanUseRemotionHooksProvider>
 					<Internals.AbsoluteTimeContext.Provider value={timelineContext}>
-						<Internals.TimelineContext.Provider value={timelineContext}>
-							<Internals.CompositionManager.Provider
-								value={compositionManagerContext}
-							>
-								<Internals.PrefetchProvider>
-									<Internals.DurationsContextProvider>
-										<Internals.MediaVolumeContext.Provider
-											value={mediaVolumeContextValue}
-										>
-											<Internals.SetMediaVolumeContext.Provider
-												value={setMediaVolumeContextValue}
+						<Internals.PlaybackRateContext.Provider value={playbackRateContext}>
+							<Internals.TimelineContext.Provider value={timelineContext}>
+								<Internals.CompositionManager.Provider
+									value={compositionManagerContext}
+								>
+									<Internals.PrefetchProvider>
+										<Internals.DurationsContextProvider>
+											<Internals.MediaVolumeContext.Provider
+												value={mediaVolumeContextValue}
 											>
-												<Internals.BufferingProvider>
-													<Internals.SharedAudioContextProvider
-														audioLatencyHint={audioLatencyHint}
-														audioEnabled={audioEnabled}
-													>
-														<Internals.SharedAudioTagsContextProvider
-															numberOfAudioTags={numberOfSharedAudioTags}
+												<Internals.SetMediaVolumeContext.Provider
+													value={setMediaVolumeContextValue}
+												>
+													<Internals.BufferingProvider>
+														<Internals.SharedAudioContextProvider
+															audioLatencyHint={audioLatencyHint}
+															audioEnabled={audioEnabled}
 														>
-															{children}
-														</Internals.SharedAudioTagsContextProvider>
-													</Internals.SharedAudioContextProvider>
-												</Internals.BufferingProvider>
-											</Internals.SetMediaVolumeContext.Provider>
-										</Internals.MediaVolumeContext.Provider>
-									</Internals.DurationsContextProvider>
-								</Internals.PrefetchProvider>
-							</Internals.CompositionManager.Provider>
-						</Internals.TimelineContext.Provider>
+															<Internals.SharedAudioTagsContextProvider
+																numberOfAudioTags={numberOfSharedAudioTags}
+															>
+																{children}
+															</Internals.SharedAudioTagsContextProvider>
+														</Internals.SharedAudioContextProvider>
+													</Internals.BufferingProvider>
+												</Internals.SetMediaVolumeContext.Provider>
+											</Internals.MediaVolumeContext.Provider>
+										</Internals.DurationsContextProvider>
+									</Internals.PrefetchProvider>
+								</Internals.CompositionManager.Provider>
+							</Internals.TimelineContext.Provider>
+						</Internals.PlaybackRateContext.Provider>
 					</Internals.AbsoluteTimeContext.Provider>
 				</Internals.CanUseRemotionHooksProvider>
 			</Internals.LogLevelContext.Provider>

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -16,6 +16,7 @@ import type {
 	AnyZodObject,
 	CompProps,
 	LogLevel,
+	PlaybackRateContextValue,
 	TimelineContextValue,
 } from 'remotion';
 import {Internals, random} from 'remotion';
@@ -93,15 +94,20 @@ const ThumbnailFn = <
 			imperativePlaying: {
 				current: false,
 			},
-			playbackRate: 1,
-			setPlaybackRate: () => {
-				throw new Error('thumbnail');
-			},
 			audioAndVideoTags: {current: []},
 		};
 
 		return value;
 	}, [frameToDisplay, thumbnailId]);
+
+	const playbackRateContext: PlaybackRateContextValue = useMemo(() => {
+		return {
+			playbackRate: 1,
+			setPlaybackRate: () => {
+				throw new Error('thumbnail');
+			},
+		};
+	}, []);
 
 	useImperativeHandle(ref, () => rootRef.current as ThumbnailMethods, []);
 
@@ -121,6 +127,7 @@ const ThumbnailFn = <
 		<Internals.IsPlayerContextProvider>
 			<SharedPlayerContexts
 				timelineContext={timelineState}
+				playbackRateContext={playbackRateContext}
 				component={Component}
 				compositionHeight={compositionHeight}
 				compositionWidth={compositionWidth}

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -35,7 +35,6 @@ export const usePlayback = ({
 	const setFrame = Internals.Timeline.useTimelineSetFrame();
 	const sharedAudioContext = useContext(Internals.SharedAudioContext);
 	const logLevel = Internals.useLogLevel();
-	const timelineContext = Internals.useTimelineContext();
 
 	// requestAnimationFrame() does not work if the tab is not active.
 	// This means that audio will keep playing even if it has ended.
@@ -74,19 +73,13 @@ export const usePlayback = ({
 			audioContext: sharedAudioContext.audioContext,
 			audioSyncAnchor: sharedAudioContext.audioSyncAnchor,
 			absoluteTimeInSeconds: frame / config.fps,
-			globalPlaybackRate: timelineContext.playbackRate,
+			globalPlaybackRate: playbackRate,
 			logLevel,
 		});
 		if (changed) {
 			sharedAudioContext.audioSyncAnchorEmitter.dispatch('changed');
 		}
-	}, [
-		config,
-		frame,
-		logLevel,
-		sharedAudioContext,
-		timelineContext.playbackRate,
-	]);
+	}, [config, frame, logLevel, playbackRate, sharedAudioContext]);
 
 	useEffect(() => {
 		if (!config) {
@@ -197,7 +190,7 @@ export const usePlayback = ({
 						audioContext: sharedAudioContext.audioContext,
 						audioSyncAnchor: sharedAudioContext.audioSyncAnchor,
 						absoluteTimeInSeconds: getCurrentFrame() / config.fps,
-						globalPlaybackRate: timelineContext.playbackRate,
+						globalPlaybackRate: playbackRate,
 						logLevel,
 					});
 					startedTime = performance.now();
@@ -266,7 +259,6 @@ export const usePlayback = ({
 		context,
 		isPlaying,
 		sharedAudioContext,
-		timelineContext.playbackRate,
 		logLevel,
 		muted,
 	]);

--- a/packages/studio/src/components/FramePersistor.tsx
+++ b/packages/studio/src/components/FramePersistor.tsx
@@ -11,7 +11,7 @@ export const FramePersistor: React.FC = () => {
 	useEffect(() => {
 		if (!playing) {
 			setFrame((f) => {
-				const newObj = {...f, [config.id]: frame};
+				const newObj = f[config.id] === frame ? f : {...f, [config.id]: frame};
 				Internals.persistCurrentFrame(newObj);
 				return newObj;
 			});

--- a/packages/studio/src/components/PlaybackRatePersistor.tsx
+++ b/packages/studio/src/components/PlaybackRatePersistor.tsx
@@ -4,7 +4,7 @@ import {Internals} from 'remotion';
 import {loadPlaybackRate, persistPlaybackRate} from '../state/playbackrate';
 
 export const PlaybackRatePersistor: React.FC = () => {
-	const {setPlaybackRate, playbackRate} = Internals.useTimelineContext();
+	const {setPlaybackRate, playbackRate} = Internals.usePlaybackRate();
 
 	useEffect(() => {
 		setPlaybackRate(loadPlaybackRate());

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -82,7 +82,7 @@ export const PreviewToolbar: React.FC<{
 	readonly readOnlyStudio: boolean;
 	readonly bufferStateDelayInMilliseconds: number;
 }> = ({readOnlyStudio, bufferStateDelayInMilliseconds}) => {
-	const {playbackRate, setPlaybackRate} = Internals.useTimelineContext();
+	const {playbackRate, setPlaybackRate} = Internals.usePlaybackRate();
 
 	const {mediaMuted} = useContext(Internals.MediaVolumeContext);
 	const {setMediaMuted} = useContext(Internals.SetMediaVolumeContext);

--- a/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
@@ -30,8 +30,9 @@ let lastTimelinePositionWhileScrolling: TimelinePosition | null = null;
 
 export const TimelinePlayCursorSyncer: React.FC = () => {
 	const video = Internals.useVideo();
-	const timelineContext = Internals.useTimelineContext();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const [playing] = Internals.Timeline.usePlayingState();
+	const {playbackRate} = Internals.usePlaybackRate();
 	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
 
@@ -50,8 +51,6 @@ export const TimelinePlayCursorSyncer: React.FC = () => {
 		setCurrentFps(video.fps);
 	}
 
-	const playing = timelineContext.playing ?? false;
-
 	/**
 	 * While playing (forwards or backwards), jump one viewport width to the left or right when the cursor goes out of the viewport.
 	 */
@@ -65,11 +64,11 @@ export const TimelinePlayCursorSyncer: React.FC = () => {
 		}
 
 		ensureFrameIsInViewport({
-			direction: timelineContext.playbackRate > 0 ? 'page-right' : 'page-left',
+			direction: playbackRate > 0 ? 'page-right' : 'page-left',
 			durationInFrames: video.durationInFrames,
 			frame: timelinePosition,
 		});
-	}, [playing, timelineContext, timelinePosition, video]);
+	}, [playbackRate, playing, timelinePosition, video]);
 
 	/**
 	 * Restore state if `enter` is being pressed

--- a/packages/test-utils/src/timeline-context.ts
+++ b/packages/test-utils/src/timeline-context.ts
@@ -11,10 +11,6 @@ export const makeTimelineContext = (frame: number): TimelineContextValue => {
 		imperativePlaying: {
 			current: false,
 		},
-		playbackRate: 1,
-		setPlaybackRate: () => {
-			throw new Error('playback rate');
-		},
 		audioAndVideoTags: {current: []},
 	};
 };


### PR DESCRIPTION
## Summary
- Addresses #7178 by adding a dedicated playback-rate context so playback-rate consumers do not subscribe to frame updates through `TimelineContext`.
- Remove playback rate from `TimelineContextValue` entirely, keeping playback-rate reads and writes on the narrow context only.
- Update Studio, Player, media preview, and core media playback consumers to use the narrow playback-rate hook or explicit playback-rate props.
- Avoid a duplicate Studio frame-context update by preserving the existing frame object in `FramePersistor` when the frame is already current.

## Test plan
- `bunx turbo run lint formatting --filter='remotion' --filter='@remotion/player' --filter='@remotion/studio'`
- `bunx turbo run make --filter='remotion' --filter='@remotion/player' --filter='@remotion/studio'`
- `bunx turbo run test --filter='remotion' --filter='@remotion/player' --filter='@remotion/studio'`
- `bunx oxfmt packages/studio/src/components/FramePersistor.tsx --check`
- `ReadLints`: `packages/player/src/Player.tsx`
- `bunx turbo run lint formatting --filter='remotion' --filter='@remotion/player' --filter='@remotion/media' --filter='@remotion/studio' --filter='@remotion/test-utils'`
- `bunx turbo run make --filter='remotion' --filter='@remotion/player' --filter='@remotion/media' --filter='@remotion/studio' --filter='@remotion/test-utils'`
- `bunx turbo run test --filter='remotion' --filter='@remotion/player' --filter='@remotion/media' --filter='@remotion/studio' --filter='@remotion/test-utils'`
- React Scan smoke test in Studio: PreviewToolbar no longer appears during playback/scrubbing; right-arrow frame stepping no longer triggers a duplicate structurally-identical frame context update.