### PR TITLE
`@remotion/google-fonts`: Fix CJK subset loading

### DIFF
--- a/packages/example/src/GoogleFontsCjk/GoogleFontsCjk.tsx
+++ b/packages/example/src/GoogleFontsCjk/GoogleFontsCjk.tsx
@@ -1,0 +1,38 @@
+import {loadFont} from '@remotion/google-fonts/NotoSansSC';
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+const {fontFamily} = loadFont('normal', {
+	weights: ['400'],
+	subsets: ['latin', 'chinese-simplified'],
+	ignoreTooManyRequestsWarning: true,
+});
+
+/**
+ * Regression cover for #7258: named CJK subsets must resolve to numbered Google Fonts chunks.
+ * Loads many files on purpose — open only when validating CJK loading.
+ */
+export const GoogleFontsCjk: React.FC = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				justifyContent: 'center',
+				alignItems: 'center',
+				backgroundColor: '#ffffff',
+			}}
+		>
+			<div
+				style={{
+					fontFamily,
+					fontSize: 80,
+					textAlign: 'center',
+					lineHeight: 1.35,
+					padding: 48,
+					color: '#111',
+				}}
+			>
+				你好 · 日本語 · 한글
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -37,6 +37,7 @@ import {FontDemo} from './Fonts';
 import {Framer} from './Framer';
 import {FreezeExample} from './Freeze/FreezeExample';
 import {FreezePortion} from './FreezePortion/FreezePortion';
+import {GoogleFontsCjk} from './GoogleFontsCjk/GoogleFontsCjk';
 import {Green} from './Green';
 import {HlsDemo} from './Hls/HlsDemo';
 import {
@@ -1215,6 +1216,12 @@ export const Index: React.FC = () => {
 					defaultProps={{flag: false}}
 				/>
 				<Still id="font-demo" component={FontDemo} width={1000} height={1000} />
+				<Still
+					id="google-fonts-cjk"
+					component={GoogleFontsCjk}
+					width={1920}
+					height={1080}
+				/>
 				<Composition
 					id="dynamic-duration"
 					component={VideoTesting}

--- a/packages/google-fonts/package.json
+++ b/packages/google-fonts/package.json
@@ -10,6 +10,7 @@
 	"scripts": {
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
 		"generate": "bun --env-file=.env scripts/update-font-db.ts",
+		"test": "bun test test",
 		"formatting": "oxfmt src --check",
 		"format": "oxfmt src"
 	},

--- a/packages/google-fonts/src/BigShouldersDisplay.ts
+++ b/packages/google-fonts/src/BigShouldersDisplay.ts
@@ -89,6 +89,7 @@ export const getInfo = () => ({
 			},
 		},
 	},
+	subsets: ['latin', 'latin-ext', 'vietnamese'],
 });
 
 export const fontFamily = 'Big Shoulders Display' as const;

--- a/packages/google-fonts/src/BigShouldersInlineDisplay.ts
+++ b/packages/google-fonts/src/BigShouldersInlineDisplay.ts
@@ -89,6 +89,7 @@ export const getInfo = () => ({
 			},
 		},
 	},
+	subsets: ['latin', 'latin-ext', 'vietnamese'],
 });
 
 export const fontFamily = 'Big Shoulders Inline Display' as const;

--- a/packages/google-fonts/src/BigShouldersInlineText.ts
+++ b/packages/google-fonts/src/BigShouldersInlineText.ts
@@ -89,6 +89,7 @@ export const getInfo = () => ({
 			},
 		},
 	},
+	subsets: ['latin', 'latin-ext', 'vietnamese'],
 });
 
 export const fontFamily = 'Big Shoulders Inline Text' as const;

--- a/packages/google-fonts/src/BigShouldersStencilDisplay.ts
+++ b/packages/google-fonts/src/BigShouldersStencilDisplay.ts
@@ -89,6 +89,7 @@ export const getInfo = () => ({
 			},
 		},
 	},
+	subsets: ['latin', 'latin-ext', 'vietnamese'],
 });
 
 export const fontFamily = 'Big Shoulders Stencil Display' as const;

--- a/packages/google-fonts/src/BigShouldersStencilText.ts
+++ b/packages/google-fonts/src/BigShouldersStencilText.ts
@@ -89,6 +89,7 @@ export const getInfo = () => ({
 			},
 		},
 	},
+	subsets: ['latin', 'latin-ext', 'vietnamese'],
 });
 
 export const fontFamily = 'Big Shoulders Stencil Text' as const;

--- a/packages/google-fonts/src/BigShouldersText.ts
+++ b/packages/google-fonts/src/BigShouldersText.ts
@@ -89,6 +89,7 @@ export const getInfo = () => ({
 			},
 		},
 	},
+	subsets: ['latin', 'latin-ext', 'vietnamese'],
 });
 
 export const fontFamily = 'Big Shoulders Text' as const;

--- a/packages/google-fonts/src/MontserratSubrayada.ts
+++ b/packages/google-fonts/src/MontserratSubrayada.ts
@@ -21,6 +21,7 @@ export const getInfo = () => ({
 			},
 		},
 	},
+	subsets: ['latin'],
 });
 
 export const fontFamily = 'Montserrat Subrayada' as const;

--- a/packages/google-fonts/src/base.ts
+++ b/packages/google-fonts/src/base.ts
@@ -1,5 +1,6 @@
 import {continueRender, delayRender} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
+import {resolveFontSubsetKeys} from './resolve-font-subsets';
 
 const loadedFonts: Record<string, Promise<void> | undefined> = {};
 
@@ -10,6 +11,7 @@ export type FontInfo = {
 	url: string;
 	unicodeRanges: Record<string, string>;
 	fonts: Record<string, Record<string, Record<string, string>>>;
+	subsets?: string[];
 };
 
 interface WithResolvers<T> {
@@ -118,8 +120,20 @@ export const loadFonts = (
 					`The font ${meta.fontFamily} does not  have a weight ${weight} in style ${style}`,
 				);
 			}
-			const subsets =
+			const requestedSubsets =
 				options?.subsets ?? Object.keys(meta.fonts[style][weight]);
+			const availableSubsetKeys = Object.keys(meta.fonts[style][weight]);
+			const subsets = [
+				...new Set(
+					requestedSubsets.flatMap((requestedSubset) =>
+						resolveFontSubsetKeys({
+							availableSubsetKeys,
+							metaSubsets: meta.subsets,
+							requestedSubset,
+						}),
+					),
+				),
+			];
 			for (const subset of subsets) {
 				//  Get font url from meta
 				let font = meta.fonts[style]?.[weight]?.[subset];

--- a/packages/google-fonts/src/base.ts
+++ b/packages/google-fonts/src/base.ts
@@ -11,7 +11,7 @@ export type FontInfo = {
 	url: string;
 	unicodeRanges: Record<string, string>;
 	fonts: Record<string, Record<string, Record<string, string>>>;
-	subsets?: string[];
+	subsets: string[];
 };
 
 interface WithResolvers<T> {
@@ -120,7 +120,7 @@ export const loadFonts = (
 					`The font ${meta.fontFamily} does not  have a weight ${weight} in style ${style}`,
 				);
 			}
-			const requestedSubsets =
+			const requestedSubsets: string[] =
 				options?.subsets ?? Object.keys(meta.fonts[style][weight]);
 			const availableSubsetKeys = Object.keys(meta.fonts[style][weight]);
 			const subsets = [

--- a/packages/google-fonts/src/resolve-font-subsets.ts
+++ b/packages/google-fonts/src/resolve-font-subsets.ts
@@ -1,0 +1,41 @@
+const cjkSubsets = new Set([
+	'chinese-hongkong',
+	'chinese-simplified',
+	'chinese-traditional',
+	'japanese',
+	'korean',
+]);
+
+const isChunkSubset = (subset: string) => /^\[\d+\]$/.test(subset);
+
+const compareChunkSubsets = (a: string, b: string) => {
+	return Number(a.slice(1, -1)) - Number(b.slice(1, -1));
+};
+
+export const resolveFontSubsetKeys = ({
+	availableSubsetKeys,
+	metaSubsets,
+	requestedSubset,
+}: {
+	availableSubsetKeys: string[];
+	metaSubsets: string[] | undefined;
+	requestedSubset: string;
+}) => {
+	if (availableSubsetKeys.includes(requestedSubset)) {
+		return [requestedSubset];
+	}
+
+	if (!cjkSubsets.has(requestedSubset)) {
+		return [requestedSubset];
+	}
+
+	if (!metaSubsets?.includes(requestedSubset)) {
+		return [requestedSubset];
+	}
+
+	const chunkSubsets = availableSubsetKeys
+		.filter(isChunkSubset)
+		.sort(compareChunkSubsets);
+
+	return chunkSubsets.length === 0 ? [requestedSubset] : chunkSubsets;
+};

--- a/packages/google-fonts/src/resolve-font-subsets.ts
+++ b/packages/google-fonts/src/resolve-font-subsets.ts
@@ -1,35 +1,29 @@
-const cjkSubsets = new Set([
-	'chinese-hongkong',
-	'chinese-simplified',
-	'chinese-traditional',
-	'japanese',
-	'korean',
-]);
-
 const isChunkSubset = (subset: string) => /^\[\d+\]$/.test(subset);
 
 const compareChunkSubsets = (a: string, b: string) => {
 	return Number(a.slice(1, -1)) - Number(b.slice(1, -1));
 };
 
+/**
+ * Maps a requested subset name to concrete keys in font metadata.
+ * When Google Fonts ships a subset only as numbered unicode-range chunks (typical for CJK),
+ * declared subset names appear in `meta.subsets` but not under `fonts[style][weight]`.
+ * In that case we expand to every `[n]` chunk key present for that weight.
+ */
 export const resolveFontSubsetKeys = ({
 	availableSubsetKeys,
 	metaSubsets,
 	requestedSubset,
 }: {
 	availableSubsetKeys: string[];
-	metaSubsets: string[] | undefined;
+	metaSubsets: string[];
 	requestedSubset: string;
 }) => {
 	if (availableSubsetKeys.includes(requestedSubset)) {
 		return [requestedSubset];
 	}
 
-	if (!cjkSubsets.has(requestedSubset)) {
-		return [requestedSubset];
-	}
-
-	if (!metaSubsets?.includes(requestedSubset)) {
+	if (!metaSubsets.includes(requestedSubset)) {
 		return [requestedSubset];
 	}
 

--- a/packages/google-fonts/test/generate-info.test.ts
+++ b/packages/google-fonts/test/generate-info.test.ts
@@ -38,9 +38,10 @@ const testFile = `
 
 test('Should extract correctly', () => {
 	const data = extractInfoFromCss({
-		contents: testFile,
+		contents: testFile.trim(),
 		fontFamily: 'ABeeZee',
 		importName: 'ABeeZee',
+		subsets: ['latin', 'latin-ext'],
 		url: 'https://fonts.googleapis.com/css2?family=ABeeZee:ital,wght@0,400;1,400',
 		version: 'v22',
 	});
@@ -73,5 +74,6 @@ test('Should extract correctly', () => {
 				},
 			},
 		},
+		subsets: ['latin', 'latin-ext'],
 	});
 });

--- a/packages/google-fonts/test/resolve-font-subsets.test.ts
+++ b/packages/google-fonts/test/resolve-font-subsets.test.ts
@@ -1,0 +1,42 @@
+import {expect, test} from 'bun:test';
+import {resolveFontSubsetKeys} from '../src/resolve-font-subsets';
+
+test('expands declared CJK subsets to chunk keys', () => {
+	expect(
+		resolveFontSubsetKeys({
+			availableSubsetKeys: ['latin', '[10]', '[2]', '[1]'],
+			metaSubsets: ['chinese-simplified', 'latin'],
+			requestedSubset: 'chinese-simplified',
+		}),
+	).toEqual(['[1]', '[2]', '[10]']);
+});
+
+test('prefers a direct subset key if one exists', () => {
+	expect(
+		resolveFontSubsetKeys({
+			availableSubsetKeys: ['chinese-traditional', '[1]'],
+			metaSubsets: ['chinese-traditional'],
+			requestedSubset: 'chinese-traditional',
+		}),
+	).toEqual(['chinese-traditional']);
+});
+
+test('preserves unknown subsets so the loader can throw', () => {
+	expect(
+		resolveFontSubsetKeys({
+			availableSubsetKeys: ['latin', '[1]'],
+			metaSubsets: ['chinese-simplified', 'latin'],
+			requestedSubset: 'chinese',
+		}),
+	).toEqual(['chinese']);
+});
+
+test('preserves declared CJK subsets if no chunk keys exist', () => {
+	expect(
+		resolveFontSubsetKeys({
+			availableSubsetKeys: ['latin'],
+			metaSubsets: ['korean', 'latin'],
+			requestedSubset: 'korean',
+		}),
+	).toEqual(['korean']);
+});


### PR DESCRIPTION
Fixes #7258.

Thanks @andreibarabas for the detailed reproduction and workaround patch.

This keeps the existing CJK subset names in the public API and resolves them to the numbered Google Fonts chunks at runtime when no direct subset key exists. Unknown subsets still fall through to the existing loader error.

Tested with:

- `bunx turbo run test --filter='@remotion/google-fonts'`
- `bunx turbo run lint formatting --filter='@remotion/google-fonts'`