### PR TITLE
Docs: Point out that --gl=angle needs to be used

### DIFF
--- a/packages/docs/components/demos/HtmlInCanvasDocsDemoWebGL.tsx
+++ b/packages/docs/components/demos/HtmlInCanvasDocsDemoWebGL.tsx
@@ -80,7 +80,9 @@ const HtmlInCanvasDocsWebGLInner: React.FC = () => {
 			antialias: false,
 		});
 		if (!gl) {
-			throw new Error('WebGL2 unavailable');
+			throw new Error(
+				'WebGL2 unavailable. Try rendering with the --gl=angle option. See https://remotion.dev/docs/gl-options.',
+			);
 		}
 
 		gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);

--- a/packages/docs/docs/remotion/html-in-canvas.mdx
+++ b/packages/docs/docs/remotion/html-in-canvas.mdx
@@ -321,7 +321,9 @@ export const HtmlInCanvasDocsMinimalWebGL: React.FC = () => {
       antialias: false,
     });
     if (!gl) {
-      throw new Error('WebGL2 unavailable');
+      throw new Error(
+        'WebGL2 unavailable. Try rendering with the --gl=angle option. See https://remotion.dev/docs/gl-options.',
+      );
     }
 
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);

--- a/packages/docs/docs/transitions/presentations/custom-html-in-canvas.mdx
+++ b/packages/docs/docs/transitions/presentations/custom-html-in-canvas.mdx
@@ -61,7 +61,9 @@ void main() {
 export const myShader: HtmlInCanvasShader<MyShaderProps> = (canvas) => {
   const gl = canvas.getContext('webgl2', {premultipliedAlpha: true});
   if (!gl) {
-    throw new Error('WebGL2 unavailable');
+    throw new Error(
+      'WebGL2 unavailable. Try rendering with the --gl=angle option. See https://remotion.dev/docs/gl-options.',
+    );
   }
 
   // Compile + link program, create textures, bind a fullscreen quad...

--- a/packages/example/src/HtmlInCanvas/compose-webgl-crt.tsx
+++ b/packages/example/src/HtmlInCanvas/compose-webgl-crt.tsx
@@ -127,7 +127,9 @@ export const HtmlInCanvasComposeWebGLCrt: React.FC = () => {
 			antialias: false,
 		});
 		if (!gl) {
-			throw new Error('WebGL2 unavailable');
+			throw new Error(
+				'WebGL2 unavailable. Try rendering with the --gl=angle option. See https://remotion.dev/docs/gl-options.',
+			);
 		}
 
 		gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);

--- a/packages/example/src/HtmlInCanvas/compose-webgl.tsx
+++ b/packages/example/src/HtmlInCanvas/compose-webgl.tsx
@@ -81,7 +81,9 @@ export const HtmlInCanvasComposeWebGL: React.FC = () => {
 			antialias: false,
 		});
 		if (!gl) {
-			throw new Error('WebGL2 unavailable');
+			throw new Error(
+				'WebGL2 unavailable. Try rendering with the --gl=angle option. See https://remotion.dev/docs/gl-options.',
+			);
 		}
 
 		gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);

--- a/packages/example/src/HtmlInCanvas/minimal-docs-webgl.tsx
+++ b/packages/example/src/HtmlInCanvas/minimal-docs-webgl.tsx
@@ -79,7 +79,9 @@ export const HtmlInCanvasDocsMinimalWebGL: React.FC = () => {
 			antialias: false,
 		});
 		if (!gl) {
-			throw new Error('WebGL2 unavailable');
+			throw new Error(
+				'WebGL2 unavailable. Try rendering with the --gl=angle option. See https://remotion.dev/docs/gl-options.',
+			);
 		}
 
 		gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);

--- a/packages/skills/skills/remotion/rules/html-in-canvas.md
+++ b/packages/skills/skills/remotion/rules/html-in-canvas.md
@@ -97,7 +97,11 @@ For WebGL, set up the context, program, and texture in `onInit` and return a cle
 ```tsx
 const onInit: HtmlInCanvasOnInit = useCallback(({ canvas }) => {
   const gl = canvas.getContext("webgl2", { alpha: true, premultipliedAlpha: true });
-  if (!gl) throw new Error("WebGL2 unavailable");
+  if (!gl) {
+    throw new Error(
+      "WebGL2 unavailable. Try rendering with the --gl=angle option. See https://remotion.dev/docs/gl-options.",
+    );
+  }
   gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
   // compile program, create texture, set up VAO...
   return () => {


### PR DESCRIPTION
Fixes #7204.

Updates the WebGL2 failure message in the HtmlInCanvas WebGL examples, docs snippets, and skill snippet so it points users to `--gl=angle` and the GL options docs.

Tested:
- `bunx turbo run formatting --filter=docs --filter=@remotion/example`
- `cd packages/example && bun run lint`
- `cd packages/docs && bun run lint`