### PR TITLE
Memoize wrap-in-schema to fix Sequence registering twice

### DIFF
--- a/packages/core/src/test/enable-visual-mode-env.ts
+++ b/packages/core/src/test/enable-visual-mode-env.ts
@@ -1,0 +1,4 @@
+// Side-effect module: must be imported before any module that calls
+// `wrapInSchema` at load time (e.g. Sequence.tsx), so the wrapper actually
+// installs the visual-mode code path.
+process.env.EXPERIMENTAL_VISUAL_MODE_ENABLED = '1';

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -1,0 +1,79 @@
+import './enable-visual-mode-env.js';
+import {afterEach, expect, test} from 'bun:test';
+import {cleanup, render} from '@testing-library/react';
+import React, {useCallback, useMemo, useState} from 'react';
+import {Internals} from '../internals.js';
+import {Sequence} from '../Sequence.js';
+import type {SequenceManagerContext} from '../SequenceManager.js';
+import {
+	SequenceManager,
+	VisualModeOverridesContext,
+} from '../SequenceManager.js';
+import {WrapSequenceContext} from './wrap-sequence-context.js';
+
+afterEach(cleanup);
+
+test('Sequence calls registerSequence exactly once on mount', () => {
+	let registerCalls = 0;
+
+	const Wrapper: React.FC<{readonly children: React.ReactNode}> = ({
+		children,
+	}) => {
+		// Mirror the real SequenceManagerProvider: registering produces a
+		// state update, which re-renders consumers. That re-render is what
+		// previously triggered the wrap-in-schema bug to re-fire the effect.
+		const [, setTick] = useState(0);
+
+		const registerSequence = useCallback(() => {
+			registerCalls++;
+			setTick((t) => t + 1);
+		}, []);
+
+		const unregisterSequence = useCallback(() => undefined, []);
+
+		const ctx: SequenceManagerContext = useMemo(
+			() => ({registerSequence, unregisterSequence, sequences: []}),
+			[registerSequence, unregisterSequence],
+		);
+
+		const visualOverrides = useMemo(
+			() => ({
+				visualModeEnabled: true,
+				dragOverrides: {},
+				setDragOverrides: () => undefined,
+				clearDragOverrides: () => undefined,
+				codeValues: {},
+				setCodeValues: () => undefined,
+			}),
+			[],
+		);
+
+		return (
+			<WrapSequenceContext>
+				<Internals.RemotionEnvironmentContext
+					value={{
+						isRendering: false,
+						isClientSideRendering: false,
+						isPlayer: false,
+						isStudio: true,
+						isReadOnlyStudio: false,
+					}}
+				>
+					<SequenceManager.Provider value={ctx}>
+						<VisualModeOverridesContext.Provider value={visualOverrides}>
+							{children}
+						</VisualModeOverridesContext.Provider>
+					</SequenceManager.Provider>
+				</Internals.RemotionEnvironmentContext>
+			</WrapSequenceContext>
+		);
+	};
+
+	render(
+		<Wrapper>
+			<Sequence>hi</Sequence>
+		</Wrapper>,
+	);
+
+	expect(registerCalls).toBe(1);
+});

--- a/packages/core/src/wrap-in-schema.ts
+++ b/packages/core/src/wrap-in-schema.ts
@@ -100,6 +100,11 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>(
 		return Component as unknown as React.ComponentType<Props>;
 	}
 
+	// Schema is closure-stable for the life of this wrapped component,
+	// so flatten it once instead of on every render.
+	const flatSchema = getFlatSchemaWithAllKeys(schema);
+	const flatKeys = Object.keys(flatSchema);
+
 	const Wrapped = forwardRef<unknown, Props>((props, ref) => {
 		const env = useRemotionEnvironment();
 
@@ -138,14 +143,18 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>(
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const [overrideId] = useState(() => String(Math.random()));
 
-		// 1. Flatten the schema to get every possible key (across all variants).
-		const flatSchema = getFlatSchemaWithAllKeys(schema);
-		const flatKeys = Object.keys(flatSchema);
-
-		// 2. Read the runtime values for every flat key from the JSX props.
-		const currentRuntimeValueDotNotation = readValuesFromProps(
-			props as Record<string, unknown>,
-			flatKeys,
+		// Read the runtime values for every flat key from the JSX props,
+		// memoized on the leaf values so the object reference is stable
+		// when nothing changed — otherwise downstream `useMemo`s churn and
+		// effects (e.g. Sequence registration) re-fire every render.
+		const runtimeValues = flatKeys.map((k) =>
+			getNestedValue(props as Record<string, unknown>, k),
+		);
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const currentRuntimeValueDotNotation = useMemo(
+			() => readValuesFromProps(props as Record<string, unknown>, flatKeys),
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+			runtimeValues,
 		);
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/core/src/wrap-in-schema.ts
+++ b/packages/core/src/wrap-in-schema.ts
@@ -100,8 +100,7 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>(
 		return Component as unknown as React.ComponentType<Props>;
 	}
 
-	// Schema is closure-stable for the life of this wrapped component,
-	// so flatten it once instead of on every render.
+	// Schema is static for a component, so we move this outside
 	const flatSchema = getFlatSchemaWithAllKeys(schema);
 	const flatKeys = Object.keys(flatSchema);
 

--- a/packages/studio/src/components/Timeline/TimelineStack/index.tsx
+++ b/packages/studio/src/components/Timeline/TimelineStack/index.tsx
@@ -176,7 +176,7 @@ export const TimelineStack: React.FC<{
 				: stackHovered && stackHoverable
 					? LIGHT_TEXT
 					: VERY_LIGHT_TEXT,
-			marginLeft: 10,
+			marginLeft: 5,
 			cursor: stackHoverable ? 'pointer' : undefined,
 			display: 'flex',
 			flexDirection: 'row',


### PR DESCRIPTION
## Summary
- `wrapInSchema` was rebuilding `currentRuntimeValueDotNotation` as a fresh object on every render, which made the `controls` `useMemo` return a new reference each time. That new reference flowed into `Sequence` as `_experimentalControls`, changed the registration effect's deps, and caused `registerSequence` to fire again — triggering a state update, another re-render, and so on.
- Hoisted the schema flattening out of the component (it's closure-stable) and memoized `currentRuntimeValueDotNotation` against the actual leaf values via `getNestedValue`. Reference is now stable when nothing changed.
- Added a regression test that genuinely reproduces the bug: enables visual mode via env-var side-effect module, uses a real-style `registerSequence` that bumps state, and asserts a single mount produces exactly one register call. Without the fix, the test errors out with `Maximum update depth exceeded`.

## Test plan
- [x] `bun test packages/core/src/test/sequence-register-once.test.tsx`
- [ ] Verify in studio that a simple `<Sequence>` composition only logs `registering` once