### PR TITLE
Player: fix seek timeline updates and timeupdate after seek

### DIFF
--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -41,7 +41,9 @@ export const usePlayback = ({
 	// In that case, we use setTimeout() instead.
 	const isBackgroundedRef = useIsBackgrounded();
 
-	const lastTimeUpdateTimestamp = useRef<number>(0);
+	const latestFrameForTimeUpdateRef = useRef(frame);
+	const lastTimeUpdateEmitAtRef = useRef(0);
+	const timeUpdateTimeoutRef = useRef<Timer | null>(null);
 
 	const context = useContext(Internals.BufferingContextReact);
 	if (!context) {
@@ -55,6 +57,8 @@ export const usePlayback = ({
 		playbackRate,
 		videoConfig: config,
 	});
+
+	latestFrameForTimeUpdateRef.current = frame;
 
 	useLayoutEffect(() => {
 		if (!sharedAudioContext) {
@@ -264,21 +268,35 @@ export const usePlayback = ({
 	]);
 
 	useEffect(() => {
-		const now = performance.now();
-		const timeSinceLastUpdate = now - lastTimeUpdateTimestamp.current;
+		return () => {
+			if (timeUpdateTimeoutRef.current !== null) {
+				clearTimeout(timeUpdateTimeoutRef.current);
+				timeUpdateTimeoutRef.current = null;
+			}
+		};
+	}, []);
 
-		if (timeSinceLastUpdate >= 250) {
+	useEffect(() => {
+		const now = performance.now();
+		const elapsedSinceEmit = now - lastTimeUpdateEmitAtRef.current;
+
+		if (elapsedSinceEmit >= 250) {
 			emitter.dispatchTimeUpdate({frame});
-			lastTimeUpdateTimestamp.current = now;
+			lastTimeUpdateEmitAtRef.current = now;
 			return;
 		}
 
-		const timeoutId = setTimeout(() => {
-			emitter.dispatchTimeUpdate({frame});
-			lastTimeUpdateTimestamp.current = performance.now();
-		}, 250 - timeSinceLastUpdate);
+		if (timeUpdateTimeoutRef.current !== null) {
+			return;
+		}
 
-		return () => clearTimeout(timeoutId);
+		const delay = Math.max(0, 250 - elapsedSinceEmit);
+
+		timeUpdateTimeoutRef.current = setTimeout(() => {
+			timeUpdateTimeoutRef.current = null;
+			emitter.dispatchTimeUpdate({frame: latestFrameForTimeUpdateRef.current});
+			lastTimeUpdateEmitAtRef.current = performance.now();
+		}, delay);
 	}, [emitter, frame]);
 
 	useEffect(() => {

--- a/packages/player/src/use-player.ts
+++ b/packages/player/src/use-player.ts
@@ -3,6 +3,7 @@ import {useCallback, useContext, useMemo, useRef, useState} from 'react';
 import {Internals} from 'remotion';
 import {PlayerEventEmitterContext} from './emitter-context.js';
 import type {PlayerEmitter} from './event-emitter.js';
+import {PLAYER_COMP_ID} from './SharedPlayerContext.js';
 
 type UsePlayerMethods = {
 	frameBack: (frames: number) => void;
@@ -60,15 +61,15 @@ export const usePlayer = (): UsePlayerMethods => {
 
 	const seek = useCallback(
 		(newFrame: number) => {
-			if (video?.id) {
-				setTimelinePosition((c) => ({...c, [video.id]: newFrame}));
-			}
+			const compositionId = video?.id ?? config?.id ?? PLAYER_COMP_ID;
+
+			setTimelinePosition((c) => ({...c, [compositionId]: newFrame}));
 
 			frameRef.current = newFrame;
 
 			emitter.dispatchSeek(newFrame);
 		},
-		[emitter, setTimelinePosition, video?.id],
+		[config?.id, emitter, setTimelinePosition, video?.id],
 	);
 
 	const play = useCallback(


### PR DESCRIPTION
## Summary

Fixes [GitHub issue #7205](https://github.com/remotion-dev/remotion/issues/7205) where `frameupdate` / `timeupdate` did not fire reliably after `seekTo()` (notably when paused in Firefox) and where `timeupdate` often did not fire in Chrome after seeks during playback.

## Root cause

1. **`seek()` skipped updating timeline state** when `useVideo()` had no `id` yet. Playback continues to advance frames under `config.id` (`player-comp`), but `seek()` only called `setTimelinePosition` inside `if (video?.id)`. That left React timeline position stale while `frameRef` still updated—so hooks keyed off `frame` never ran and no `frameupdate` / `timeupdate` fired.

2. **`timeupdate` throttling reset on every frame**: The previous effect cleared its `setTimeout` on each `frame` dependency change. While frames advance quickly (playback), the timer was constantly cancelled, so `timeupdate` often never emitted until motion stopped—matching “stale timestamp while playing / after seek” reports.

## Changes

- **`packages/player/src/use-player.ts`**: Always derive `compositionId` as `video?.id ?? config?.id ?? PLAYER_COMP_ID` and update timeline state on every seek (same key as `Player` initial state and playback `setFrame`).
- **`packages/player/src/use-playback.ts`**: Throttle `timeupdate` to ~250ms without cancelling a pending trailing dispatch when more frames arrive; the trailing dispatch uses the latest frame from a ref.

## Testing

- `bun run makeplayer`
- `cd packages/player && bun test src`

Made with [Cursor](https://cursor.com)