### PR TITLE
`remotion`: Start AudioContext in suspended state

### DIFF
--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import type {LogLevel} from '../log';
 import {Log} from '../log';
 import {useRemotionEnvironment} from '../use-remotion-environment';
@@ -32,7 +32,7 @@ export const useSingletonAudioContext = ({
 }) => {
 	const env = useRemotionEnvironment();
 
-	return useMemo(() => {
+	const context = useMemo(() => {
 		if (env.isRendering) {
 			return null;
 		}
@@ -56,10 +56,21 @@ export const useSingletonAudioContext = ({
 
 		const gainNode = audioContext.createGain();
 		gainNode.connect(audioContext.destination);
+		Log.trace({logLevel, tag: 'audio'}, 'Creating new audio context');
+
+		audioContext.suspend();
 
 		return {
 			audioContext,
 			gainNode,
 		};
 	}, [logLevel, latencyHint, env.isRendering, audioEnabled]);
+
+	useEffect(() => {
+		return () => {
+			context?.audioContext?.close();
+		};
+	}, [context]);
+
+	return context;
 };


### PR DESCRIPTION
`new AudioContext()` does try to play immediately!
If the auto-play blocking for a page was already resolved, it would erroneously play audio even though the video is paused.

Fixing it and also propery cleaning up audio contexts if we are mounting and unmounting Remotion Players!