### PR TITLE
@remotion/cli: Add Config.setLogLevel (deprecate setLevel)

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -224,11 +224,19 @@ declare global {
 		 */
 		readonly setShouldOpenBrowser: (should: boolean) => void;
 		/**
-		 * Set the log level.
-		 * Acceptable values: 'error' | 'warning' | 'info' | 'verbose' | 'trace'
-		 * Default value: 'info'
+		 * Set the log level used by the Remotion CLI.
+		 * Acceptable values: `'error' | 'warn' | 'info' | 'verbose' | 'trace'`
+		 * Default value: `'info'`
 		 *
-		 * Set this to 'verbose' to get browser logs and other IO.
+		 * Set this to `'verbose'` to get browser logs and other IO.
+		 */
+		readonly setLogLevel: (
+			newLogLevel: 'trace' | 'verbose' | 'info' | 'warn' | 'error',
+		) => void;
+		/**
+		 * Set the log level used by the Remotion CLI.
+		 *
+		 * @deprecated Renamed to [`setLogLevel()`](/docs/config#setloglevel).
 		 */
 		readonly setLevel: (
 			newLogLevel: 'trace' | 'verbose' | 'info' | 'warn' | 'error',
@@ -707,6 +715,7 @@ export const Config: FlatConfig = {
 	setRendererPort,
 	setPublicDir: publicDirOption.setConfig,
 	setEntryPoint,
+	setLogLevel: logLevelOption.setConfig,
 	setLevel: logLevelOption.setConfig,
 	setBrowserExecutable: browserExecutableOption.setConfig,
 	setTimeoutInMilliseconds: delayRenderTimeoutInMillisecondsOption.setConfig,

--- a/packages/docs/docs/cli/compositions.mdx
+++ b/packages/docs/docs/cli/compositions.mdx
@@ -39,7 +39,7 @@ Inline JSON string isn't supported on Windows shells because it removes the `"` 
 
 ### `--log`
 
-[Set the log level](/docs/config#setlevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
+[Set the log level](/docs/config#setloglevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
 
 :::info
 If you don't feel like passing command line flags every time, consider creating a `remotion.config.ts` [config file](/docs/config).

--- a/packages/docs/docs/cli/render.mdx
+++ b/packages/docs/docs/cli/render.mdx
@@ -182,7 +182,7 @@ Disallows the renderer from doing rendering frames and encoding at the same time
 
 ### `--log`
 
-[Set the log level](/docs/config#setlevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
+[Set the log level](/docs/config#setloglevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
 
 ### `--port`
 

--- a/packages/docs/docs/cli/still.mdx
+++ b/packages/docs/docs/cli/still.mdx
@@ -74,7 +74,7 @@ Sets the output file path, as an alternative to the `output-location` positional
 
 ### `--log`
 
-[Set the log level](/docs/config#setlevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
+[Set the log level](/docs/config#setloglevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
 
 ### `--port`
 

--- a/packages/docs/docs/cli/studio.mdx
+++ b/packages/docs/docs/cli/studio.mdx
@@ -35,7 +35,7 @@ Inline JSON string isn't supported on Windows shells because it removes the `"` 
 
 ### `--log`
 
-[Set the log level](/docs/config#setlevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
+[Set the log level](/docs/config#setloglevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
 
 ### `--port`
 

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -135,7 +135,9 @@ Config.setEntryPoint('./src/index.ts');
 
 If you pass an entry point as a CLI argument, it will take precedence.
 
-## `setLevel()`<AvailableFrom v="2.0.1" />
+## `setLogLevel()`<AvailableFrom v="2.0.1" />
+
+_previously named "setLevel"_
 
 Increase or decrease the amount of log messages in the CLI.
 Acceptable values:
@@ -148,7 +150,7 @@ Acceptable values:
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 // ---cut---
-Config.setLevel('verbose');
+Config.setLogLevel('verbose');
 ```
 
 The [command line flag](/docs/cli/render#--log) `--log` will take precedence over this option.

--- a/packages/docs/docs/lambda/cli/compositions.mdx
+++ b/packages/docs/docs/lambda/cli/compositions.mdx
@@ -82,7 +82,7 @@ Inline JSON string isn't supported on Windows shells because it removes the `"` 
 
 ### `--log`
 
-[Set the log level](/docs/config#setlevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
+[Set the log level](/docs/config#setloglevel). Increase or decrease the amount of output. Acceptable values: `error`, `warn`, `info` (_default_), `verbose`
 
 :::info
 If you don't feel like passing command line flags every time, consider creating a `remotion.config.ts` [config file](/docs/config).


### PR DESCRIPTION
## Summary
- Add `Config.setLogLevel()` as the preferred API for configuring CLI log verbosity (same behavior as the previous `setLevel()`).
- Keep `Config.setLevel()` as an alias and mark it deprecated in TypeScript with a link to the docs.
- Update the config documentation: rename the heading to `setLogLevel()`, note the previous name `setLevel`, and use `setLogLevel` in the snippet.

Fixes #7284.

## Test plan
- `bun run lint` in `packages/cli` (ESLint; no new issues in changed file).
- CI: `@remotion/cli` test suite on the PR (local `bun test` hit a pre-existing `@remotion/streaming` `dist/esm` bundle shape on this machine).
