### PR TITLE
`@remotion/studio`: Guard timeline waveform draw against zero-width canvas

### DIFF
--- a/packages/studio/src/components/draw-peaks.ts
+++ b/packages/studio/src/components/draw-peaks.ts
@@ -18,6 +18,14 @@ export const drawBars = (
 	const {height} = canvas;
 	const w = canvas.width;
 
+	// Skip drawing when the target canvas has not been laid out yet.
+	// `createImageData(0, h)` / `(w, 0)` throws a DOMException, which
+	// surfaces in Studio's console for compositions with many audio
+	// sequences — some segments are 0 px wide at certain zoom levels.
+	if (w === 0 || height === 0) {
+		return;
+	}
+
 	ctx.clearRect(0, 0, w, height);
 
 	if (volume === 0) return;


### PR DESCRIPTION
## Problem

Studio's timeline waveform painter throws

> Failed to execute 'createImageData' on 'OffscreenCanvasRenderingContext2D':
> The source width is zero or not a number.

whenever an audio sequence is laid out at 0 px — for example when the timeline is mid-resize, a track is collapsed, or many short audio sequences are stacked at a low zoom level. The error is non-fatal but spams the console.

## Repro

A composition with ~30+ `<Audio>` sequences. Open it in Studio; the error fires intermittently while the timeline lays out the audio rows.

## Fix

`drawBars` in `packages/studio/src/components/draw-peaks.ts` calls `ctx.createImageData(w, height)` without checking dimensions. `createImageData` throws a DOMException when either dimension is 0. Add an early return when there's nothing to draw. The same source is inlined into `audio-waveform-worker.ts`, so this one change fixes both call sites.

## Test plan

- [ ] Open a 30+ `<Audio>` composition in Studio — console stays clean while scrubbing/zooming the timeline.
- [ ] Waveforms still render normally at non-zero canvas widths.