### PR TITLE
Add MCP server for Remotion documentation

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"remotion-documentation": {
+			"command": "npx",
+			"args": ["@remotion/mcp@latest"]
+		}
+	}
+}


### PR DESCRIPTION
Adds a project-level `.mcp.json` so Claude Code users working in this repo can search the Remotion documentation via `@remotion/mcp`.

This mirrors the existing `.cursor/mcp.json` config already in the repo — it uses the same `npx @remotion/mcp@latest` command.