### PR TITLE
`@remotion/studio`: Fix audio waveform crash for trimmed media

### DIFF
--- a/packages/studio/src/helpers/get-timeline-sequence-layout.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-layout.ts
@@ -22,7 +22,7 @@ const getWidthOfTrack = ({
 			? fullWidth
 			: (spatialDuration / lastFrame) * fullWidth;
 
-	return base - SEQUENCE_BORDER_WIDTH + nonNegativeMarginLeft;
+	return Math.max(0, base - SEQUENCE_BORDER_WIDTH + nonNegativeMarginLeft);
 };
 
 export const getTimelineSequenceLayout = ({
@@ -48,16 +48,19 @@ export const getTimelineSequenceLayout = ({
 		(maxMediaDuration ?? Infinity) - startFromMedia;
 	const lastFrame = (video.durationInFrames ?? 1) - 1;
 
-	const spatialDuration = Math.min(
-		maxMediaSequenceDuration,
-		durationInFrames - 1,
-		lastFrame - startFrom,
+	const spatialDuration = Math.max(
+		0,
+		Math.min(
+			maxMediaSequenceDuration,
+			durationInFrames - 1,
+			lastFrame - startFrom,
+		),
 	);
 
 	// Unclipped spatial duration: without the lastFrame - startFrom constraint
-	const naturalSpatialDuration = Math.min(
-		maxMediaSequenceDuration,
-		durationInFrames - 1,
+	const naturalSpatialDuration = Math.max(
+		0,
+		Math.min(maxMediaSequenceDuration, durationInFrames - 1),
 	);
 
 	const marginLeft =

--- a/packages/studio/src/test/timeline-sequence-layout.test.ts
+++ b/packages/studio/src/test/timeline-sequence-layout.test.ts
@@ -117,6 +117,38 @@ test('naturalWidth === width when segment fits within timeline', () => {
 	expect(result.naturalWidth).toBe(result.width);
 });
 
+test('one-frame segments have zero width', () => {
+	const result = getTimelineSequenceLayout({
+		durationInFrames: 1,
+		startFrom: 0,
+		startFromMedia: 0,
+		maxMediaDuration: null,
+		premountDisplay: null,
+		postmountDisplay: null,
+		video: makeVideoConfig(300),
+		windowWidth: 1000,
+	});
+
+	expect(result.width).toBe(0);
+	expect(result.naturalWidth).toBe(0);
+});
+
+test('media trimmed past its duration has zero width', () => {
+	const result = getTimelineSequenceLayout({
+		durationInFrames: 300,
+		startFrom: 0,
+		startFromMedia: 500,
+		maxMediaDuration: 300,
+		premountDisplay: null,
+		postmountDisplay: null,
+		video: makeVideoConfig(300),
+		windowWidth: 1000,
+	});
+
+	expect(result.width).toBe(0);
+	expect(result.naturalWidth).toBe(0);
+});
+
 test('Loop overshoot: naturalWidth > width when total loop duration exceeds comp', () => {
 	// 4 full iterations of 100 frames = 400, but comp is only 350
 	const overshoot = getTimelineSequenceLayout({

--- a/packages/studio/src/test/timeline-sequence-layout.test.ts
+++ b/packages/studio/src/test/timeline-sequence-layout.test.ts
@@ -149,6 +149,22 @@ test('media trimmed past its duration has zero width', () => {
 	expect(result.naturalWidth).toBe(0);
 });
 
+test('media trimmed past its duration and timeline end has zero width', () => {
+	const result = getTimelineSequenceLayout({
+		durationInFrames: 200,
+		startFrom: 200,
+		startFromMedia: 500,
+		maxMediaDuration: 300,
+		premountDisplay: null,
+		postmountDisplay: null,
+		video: makeVideoConfig(300),
+		windowWidth: 1000,
+	});
+
+	expect(result.width).toBe(0);
+	expect(result.naturalWidth).toBe(0);
+});
+
 test('Loop overshoot: naturalWidth > width when total loop duration exceeds comp', () => {
 	// 4 full iterations of 100 frames = 400, but comp is only 350
 	const overshoot = getTimelineSequenceLayout({


### PR DESCRIPTION
## Summary
- Clamp timeline media layout widths to zero when trimmed media has no visible duration left.
- Add regression coverage for one-frame and over-trimmed media segments so waveform canvases do not receive negative widths.

## Test plan
- bun test packages/studio/src/test/timeline-sequence-layout.test.ts
- bunx oxfmt src --write (in packages/studio)

Fixes #7290