### PR TITLE
Docs: Add Mediabunny version guidance

### DIFF
--- a/packages/docs/docs/mediabunny/version.mdx
+++ b/packages/docs/docs/mediabunny/version.mdx
@@ -18,15 +18,17 @@ If you use Mediabunny as a direct dependency in your project, you can install it
 npx remotion add mediabunny
 ```
 
-## Ensuring the correct version
+## Upgrading Remotion and Mediabunny together
 
-To upgrade Remotion and Mediabunny to compatible versions, run [`npx remotion upgrade`](/docs/cli/upgrade):
+To upgrade Remotion to the latest version and pair it with the correct Mediabunny version, run [`npx remotion upgrade`](/docs/cli/upgrade):
 
 ```bash
 npx remotion upgrade
 ```
 
-Afterwards, validate that Mediabunny is installed with the correct version using [`npx remotion versions`](/docs/cli/versions):
+## Ensuring the correct version
+
+You can validate that Mediabunny is installed with the correct version using [`npx remotion versions`](/docs/cli/versions):
 
 ```bash
 npx remotion versions

--- a/packages/docs/docs/mediabunny/version.mdx
+++ b/packages/docs/docs/mediabunny/version.mdx
@@ -18,6 +18,20 @@ If you use Mediabunny as a direct dependency in your project, you can install it
 npx remotion add mediabunny
 ```
 
+## Ensuring the correct version
+
+To upgrade Remotion and Mediabunny to compatible versions, run [`npx remotion upgrade`](/docs/cli/upgrade):
+
+```bash
+npx remotion upgrade
+```
+
+Afterwards, validate that Mediabunny is installed with the correct version using [`npx remotion versions`](/docs/cli/versions):
+
+```bash
+npx remotion versions
+```
+
 ## History
 
 Older versions of Remotion use a different version of Mediabunny.  


### PR DESCRIPTION
## Summary
- Document that `npx remotion upgrade` keeps Mediabunny compatible with the active Remotion version.
- Document `npx remotion versions` as the follow-up validation command.

Fixes #7283

## Test plan
- Ran `bunx oxfmt src --write` in `packages/docs`.
- Commit hook ran docs formatting successfully.