### PR TITLE
`@remotion/media`: Fix stale audio seek buffering

### DIFF
--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -87,6 +87,13 @@ export const audioIteratorManager = ({
 	let totalAudioScheduledInSeconds = 0;
 	let currentDelayHandle: {unblock: () => void} | null = null;
 
+	const unblockCurrentDelayHandle = () => {
+		if (currentDelayHandle) {
+			currentDelayHandle.unblock();
+			currentDelayHandle = null;
+		}
+	};
+
 	const pendingScheduleWaiters: {
 		remaining: number;
 		resolve: () => void;
@@ -366,6 +373,8 @@ export const audioIteratorManager = ({
 		}
 
 		audioBufferIterator?.destroy();
+		unblockCurrentDelayHandle();
+
 		const delayHandle = delayPlaybackHandleIfNotPremounting();
 		currentDelayHandle = delayHandle;
 
@@ -442,6 +451,10 @@ export const audioIteratorManager = ({
 		fps: number;
 		getAudioContextCurrentTimeMockedInTest: () => number;
 	}) => {
+		if (nonce.isStale()) {
+			return;
+		}
+
 		if (
 			currentSeek.time === newTime &&
 			currentSeek.playbackRate === playbackRate &&
@@ -526,11 +539,7 @@ export const audioIteratorManager = ({
 		destroyIterator: () => {
 			audioBufferIterator?.destroy();
 			audioBufferIterator = null;
-
-			if (currentDelayHandle) {
-				currentDelayHandle.unblock();
-				currentDelayHandle = null;
-			}
+			unblockCurrentDelayHandle();
 		},
 		seek,
 		getAudioIteratorsCreated: () => audioIteratorsCreated,


### PR DESCRIPTION
## Summary
- Ignore stale audio seek operations before they can update seek state or start a new iterator.
- Unblock the current audio playback delay synchronously when replacing or destroying an iterator.
- Fixes #7319.

## Test plan
- `bun run formatting` in `packages/media`
- `git diff --check`
- Attempted `bunx vitest src/test/media-player.test.ts --browser --run -t "dispose should immediately unblock playback delays"`, but local browser test startup failed because the worktree is missing Vitest browser dependencies / `tsgo`.


Made with [Cursor](https://cursor.com)