### PR TITLE
`@remotion/studio`: Remove `premountFor`, `styleWhilePremounting`, `styleWhilePostmounting` when changing to layout="none"

### DIFF
--- a/packages/core/src/flatten-schema.ts
+++ b/packages/core/src/flatten-schema.ts
@@ -9,7 +9,9 @@ export const flattenActiveSchema = (
 	const out: SequenceSchema = {};
 	for (const key of Object.keys(schema)) {
 		const field = schema[key];
-		if (field.type === 'enum') {
+		if (field.type === 'hidden') {
+			continue;
+		} else if (field.type === 'enum') {
 			out[key] = field;
 			const current = (resolve(key) as string | undefined) ?? field.default;
 			const variant = field.variants[current];

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -100,6 +100,7 @@ import {
 import type {
 	SequenceFieldSchema,
 	SequenceSchema,
+	VisibleFieldSchema,
 } from './sequence-field-schema.js';
 import {sequenceSchema, sequenceStyleSchema} from './sequence-field-schema.js';
 import type {
@@ -335,6 +336,7 @@ export type {
 	MediaVolumeContextValue,
 	RemotionEnvironment,
 	SequenceFieldSchema,
+	VisibleFieldSchema,
 	SequenceSchema,
 	SerializedJSONWithCustomFields,
 	SetMediaVolumeContextValue,

--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -1,3 +1,7 @@
+export type HiddenFieldSchema = {
+	type: 'hidden';
+};
+
 export type NumberFieldSchema = {
 	type: 'number';
 	min?: number;
@@ -34,12 +38,14 @@ export type EnumFieldSchema = {
 	variants: Record<string, SequenceSchema>;
 };
 
-export type SequenceFieldSchema =
+export type VisibleFieldSchema =
 	| NumberFieldSchema
 	| BooleanFieldSchema
 	| RotationFieldSchema
 	| TranslateFieldSchema
 	| EnumFieldSchema;
+
+export type SequenceFieldSchema = VisibleFieldSchema | HiddenFieldSchema;
 
 export type SequenceSchema = {[key: string]: SequenceFieldSchema};
 
@@ -76,6 +82,17 @@ export const sequenceStyleSchema = {
 		step: 0.01,
 		default: 1,
 		description: 'Opacity',
+	},
+	premountFor: {
+		type: 'number',
+		default: 0,
+		description: 'Premount For',
+	},
+	styleWhilePremounted: {
+		type: 'hidden',
+	},
+	styleWhilePostmounted: {
+		type: 'hidden',
 	},
 } as const satisfies SequenceSchema;
 

--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -88,6 +88,9 @@ export const sequenceStyleSchema = {
 		default: 0,
 		description: 'Premount For',
 	},
+	postmountFor: {
+		type: 'hidden',
+	},
 	styleWhilePremounted: {
 		type: 'hidden',
 	},

--- a/packages/core/src/test/wrap-in-schema-helpers.test.ts
+++ b/packages/core/src/test/wrap-in-schema-helpers.test.ts
@@ -17,6 +17,9 @@ test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 			'style.scale',
 			'style.rotate',
 			'style.opacity',
+			'premountFor',
+			'styleWhilePremounted',
+			'styleWhilePostmounted',
 		].sort(),
 	);
 });
@@ -54,6 +57,9 @@ test('selectActiveKeys exposes style.* keys when layout=absolute-fill', () => {
 			'style.scale',
 			'style.rotate',
 			'style.opacity',
+			'premountFor',
+			'styleWhilePremounted',
+			'styleWhilePostmounted',
 		].sort(),
 	);
 });

--- a/packages/core/src/test/wrap-in-schema-helpers.test.ts
+++ b/packages/core/src/test/wrap-in-schema-helpers.test.ts
@@ -18,6 +18,7 @@ test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 			'style.rotate',
 			'style.opacity',
 			'premountFor',
+			'postmountFor',
 			'styleWhilePremounted',
 			'styleWhilePostmounted',
 		].sort(),
@@ -58,9 +59,15 @@ test('selectActiveKeys exposes style.* keys when layout=absolute-fill', () => {
 			'style.rotate',
 			'style.opacity',
 			'premountFor',
-			'styleWhilePremounted',
-			'styleWhilePostmounted',
 		].sort(),
+	);
+
+	const values2 = {
+		layout: 'none',
+		'style.scale': 2,
+	};
+	expect(selectActiveKeys(sequenceSchema, values2).sort()).toEqual(
+		['layout'].sort(),
 	);
 });
 

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -63,11 +63,16 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 	const merged: Record<string, unknown> = {};
 	for (const key of Object.keys(currentValue)) {
 		const codeValueStatus = propStatus?.[key] ?? null;
+		const field = findFieldInSchema(schema, key);
+		if (field?.type === 'hidden') {
+			continue;
+		}
+
 		merged[key] = getEffectiveVisualModeValue({
 			codeValue: codeValueStatus,
 			runtimeValue: currentValue[key],
 			dragOverrideValue: overrideValues[key],
-			defaultValue: findFieldInSchema(schema, key)?.default,
+			defaultValue: field?.default,
 			shouldResortToDefaultValueIfUndefined: false,
 		});
 	}

--- a/packages/example/src/AudioSmoothness/SlicedVideo.tsx
+++ b/packages/example/src/AudioSmoothness/SlicedVideo.tsx
@@ -19,7 +19,7 @@ const SlicedVideo: React.FC = () => {
 						key={i}
 						from={from}
 						durationInFrames={SLICE_DURATION_FRAMES}
-						layout={'none'}
+						premountFor={PREMOUNT_SEC * fps}
 					>
 						<Audio src={src} trimBefore={from} />
 					</Sequence>

--- a/packages/example/src/AudioSmoothness/SlicedVideo.tsx
+++ b/packages/example/src/AudioSmoothness/SlicedVideo.tsx
@@ -19,7 +19,7 @@ const SlicedVideo: React.FC = () => {
 						key={i}
 						from={from}
 						durationInFrames={SLICE_DURATION_FRAMES}
-						premountFor={PREMOUNT_SEC * fps}
+						layout={'none'}
 					>
 						<Audio src={src} trimBefore={from} />
 					</Sequence>

--- a/packages/studio-server/src/test/discriminated-union-update.test.ts
+++ b/packages/studio-server/src/test/discriminated-union-update.test.ts
@@ -37,6 +37,7 @@ test('Should expose absolute-fill variant fields when active', () => {
 		'style.scale',
 		'style.rotate',
 		'style.opacity',
+		'premountFor',
 	]);
 });
 
@@ -112,6 +113,54 @@ test('Should remove variant-specific props when switching enum value', () => {
 			__dirname,
 			'snapshots',
 			'discriminated-union-with-style-expected.tsx',
+		),
+		'utf-8',
+	);
+	const actualLines = update.serialized.split('\n');
+	const expectedLines = expected.split('\n');
+	const maxLines = Math.max(actualLines.length, expectedLines.length);
+	for (let i = 0; i < maxLines; i++) {
+		if (actualLines[i] !== expectedLines[i]) {
+			// eslint-disable-next-line no-console
+			console.log(update);
+			// eslint-disable-next-line no-console
+			console.log(actualLines[i], expectedLines[i]);
+			throw new Error(
+				`Line ${i + 1} differs ${actualLines[i]} ${expectedLines[i]}`,
+			);
+		}
+	}
+});
+
+test('Should remove premountFor and styleWhile* when switching to layout="none"', () => {
+	const file = readFileSync(
+		path.join(__dirname, 'snapshots', 'discriminated-union-with-premount.tsx'),
+		'utf-8',
+	);
+
+	const ast = parseAst(file);
+
+	const nodePath = lineColumnToNodePath(ast, 3);
+	assert(nodePath, 'No node path found');
+
+	const update = updateSequencePropsAst({
+		input: file,
+		nodePath,
+		updates: [
+			{
+				key: 'layout',
+				value: 'none',
+				defaultValue: Internals.sequenceSchema.layout.default,
+			},
+		],
+		schema: Internals.sequenceSchema,
+	});
+
+	const expected = readFileSync(
+		path.join(
+			__dirname,
+			'snapshots',
+			'discriminated-union-with-premount-expected.tsx',
 		),
 		'utf-8',
 	);

--- a/packages/studio-server/src/test/get-all-schema-keys.test.ts
+++ b/packages/studio-server/src/test/get-all-schema-keys.test.ts
@@ -14,6 +14,9 @@ test('getAllSchemaKeys returns every key across all enum variants', () => {
 			'style.scale',
 			'style.rotate',
 			'style.opacity',
+			'premountFor',
+			'styleWhilePremounted',
+			'styleWhilePostmounted',
 		].sort(),
 	);
 });

--- a/packages/studio-server/src/test/get-all-schema-keys.test.ts
+++ b/packages/studio-server/src/test/get-all-schema-keys.test.ts
@@ -15,6 +15,7 @@ test('getAllSchemaKeys returns every key across all enum variants', () => {
 			'style.rotate',
 			'style.opacity',
 			'premountFor',
+			'postmountFor',
 			'styleWhilePremounted',
 			'styleWhilePostmounted',
 		].sort(),

--- a/packages/studio-server/src/test/snapshots/discriminated-union-with-premount-expected.tsx
+++ b/packages/studio-server/src/test/snapshots/discriminated-union-with-premount-expected.tsx
@@ -1,0 +1,3 @@
+export const ExperimentalControlsShowcase: React.FC = () => {
+	return (<Sequence layout={"none"}></Sequence>);
+};

--- a/packages/studio-server/src/test/snapshots/discriminated-union-with-premount.tsx
+++ b/packages/studio-server/src/test/snapshots/discriminated-union-with-premount.tsx
@@ -1,0 +1,10 @@
+export const ExperimentalControlsShowcase: React.FC = () => {
+	return (
+		<Sequence
+			style={{opacity: 0.5}}
+			premountFor={25}
+			styleWhilePostmounted={{opacity: 0}}
+			styleWhilePremounted={{opacity: 0}}
+		></Sequence>
+	);
+};

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -2,13 +2,14 @@ import type {
 	CodeValues,
 	DragOverrides,
 	SequenceControls,
-	SequenceFieldSchema,
+	VisibleFieldSchema,
 	SequenceSchema,
 	GetDragOverrides,
 	GetCodeValues,
 	SequenceNodePath,
 } from 'remotion';
 import {Internals} from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
 
 export type {CodeValues, DragOverrides, SequenceControls};
 
@@ -19,7 +20,7 @@ export type SchemaFieldInfo = {
 	supported: boolean;
 	rowHeight: number;
 	currentRuntimeValue: unknown;
-	fieldSchema: SequenceFieldSchema;
+	fieldSchema: VisibleFieldSchema;
 };
 
 export const SCHEMA_FIELD_ROW_HEIGHT = 22;
@@ -58,19 +59,25 @@ export const getFieldsToShow = ({
 		(key) => valuesDotNotation[key],
 	);
 
-	return Object.entries(activeSchema).map(([key, fieldSchema]) => {
-		const typeName = fieldSchema.type;
-		const supported = SUPPORTED_SCHEMA_TYPES.has(typeName);
-		return {
-			key,
-			description: fieldSchema.description,
-			typeName,
-			supported,
-			rowHeight: supported
-				? SCHEMA_FIELD_ROW_HEIGHT
-				: UNSUPPORTED_FIELD_ROW_HEIGHT,
-			currentRuntimeValue: currentRuntimeValueDotNotation[key],
-			fieldSchema,
-		};
-	});
+	return Object.entries(activeSchema)
+		.map(([key, fieldSchema]) => {
+			const typeName = fieldSchema.type;
+			const supported = SUPPORTED_SCHEMA_TYPES.has(typeName);
+			if (typeName === 'hidden') {
+				return null;
+			}
+
+			return {
+				key,
+				description: fieldSchema.description,
+				typeName,
+				supported,
+				rowHeight: supported
+					? SCHEMA_FIELD_ROW_HEIGHT
+					: UNSUPPORTED_FIELD_ROW_HEIGHT,
+				currentRuntimeValue: currentRuntimeValueDotNotation[key],
+				fieldSchema,
+			};
+		})
+		.filter(NoReactInternals.truthy);
 };

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -11,6 +11,7 @@ import type {
 	GetDragOverrides,
 	TSequence,
 } from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
 import type {GetIsExpanded} from '../components/ExpandedTracksProvider';
 import type {SequenceNodePathInfo} from './get-timeline-sequence-sort-key';
 
@@ -43,10 +44,18 @@ export const getEffectSchemaLabels = (
 		return [];
 	}
 
-	return Object.entries(effect.definition.schema).map(([key, fieldSchema]) => ({
-		key,
-		description: fieldSchema.description,
-	}));
+	return Object.entries(effect.definition.schema)
+		.map(([key, fieldSchema]) => {
+			if (fieldSchema.type === 'hidden') {
+				return null;
+			}
+
+			return {
+				key,
+				description: fieldSchema.description,
+			};
+		})
+		.filter(NoReactInternals.truthy);
 };
 
 export type TimelineTreeNode =


### PR DESCRIPTION
Fixes #7323