### PR TITLE
`remotion`: Fix easing overshoot when it doesn't make sense

### DIFF
--- a/packages/core/src/bezier.ts
+++ b/packages/core/src/bezier.ts
@@ -146,19 +146,21 @@ export function bezier(
 	}
 
 	return function (x: number): number {
+		const clampedX = Math.min(1, Math.max(0, x));
+
 		if (mX1 === mY1 && mX2 === mY2) {
-			return x; // linear
+			return clampedX; // linear
 		}
 
 		// Because JavaScript number are imprecise, we should guarantee the extremes are right.
-		if (x === 0) {
+		if (clampedX === 0) {
 			return 0;
 		}
 
-		if (x === 1) {
+		if (clampedX === 1) {
 			return 1;
 		}
 
-		return calcBezier(getTForX(x), mY1, mY2);
+		return calcBezier(getTForX(clampedX), mY1, mY2);
 	};
 }

--- a/packages/core/src/easing.ts
+++ b/packages/core/src/easing.ts
@@ -2,6 +2,11 @@
 
 import {bezier} from './bezier.js';
 
+// Some easing curves are only defined on [0, 1] (e.g. quarter circle, bounce segments).
+// `interpolate(..., { extrapolate: 'extend' })` can pass values outside that interval; clamp
+// there so we return endpoints instead of NaN or unintended extrapolation.
+const clampUnit = (t: number): number => Math.min(1, Math.max(0, t));
+
 /**
  * @description The Easing module implements common easing functions. You can use it with the interpolate() API.
  * @see [Documentation](https://www.remotion.dev/docs/easing)
@@ -40,7 +45,8 @@ export class Easing {
 	}
 
 	static circle(t: number): number {
-		return 1 - Math.sqrt(1 - t * t);
+		const u = clampUnit(t);
+		return 1 - Math.sqrt(1 - u * u);
 	}
 
 	static exp(t: number): number {
@@ -58,21 +64,23 @@ export class Easing {
 	}
 
 	static bounce(t: number): number {
-		if (t < 1 / 2.75) {
-			return 7.5625 * t * t;
+		const u = clampUnit(t);
+
+		if (u < 1 / 2.75) {
+			return 7.5625 * u * u;
 		}
 
-		if (t < 2 / 2.75) {
-			const t2_ = t - 1.5 / 2.75;
+		if (u < 2 / 2.75) {
+			const t2_ = u - 1.5 / 2.75;
 			return 7.5625 * t2_ * t2_ + 0.75;
 		}
 
-		if (t < 2.5 / 2.75) {
-			const t2_ = t - 2.25 / 2.75;
+		if (u < 2.5 / 2.75) {
+			const t2_ = u - 2.25 / 2.75;
 			return 7.5625 * t2_ * t2_ + 0.9375;
 		}
 
-		const t2 = t - 2.625 / 2.75;
+		const t2 = u - 2.625 / 2.75;
 		return 7.5625 * t2 * t2 + 0.984375;
 	}
 

--- a/packages/core/src/test/bezier.test.ts
+++ b/packages/core/src/test/bezier.test.ts
@@ -61,3 +61,13 @@ test('bezier - right value at extremes', () => {
 		expect(easing(1)).toBe(1);
 	});
 });
+
+test('bezier - clamps evaluation input to [0, 1]', () => {
+	const linear = bezier(0, 0, 1, 1);
+	expect(linear(-2)).toBe(0);
+	expect(linear(3)).toBe(1);
+
+	const curved = bezier(0.42, 0, 1, 1);
+	expect(Number.isFinite(curved(2))).toBe(true);
+	expect(Number.isFinite(curved(-1))).toBe(true);
+});

--- a/packages/core/src/test/easing.test.ts
+++ b/packages/core/src/test/easing.test.ts
@@ -3,6 +3,9 @@ import {Easing} from '../easing.js';
 
 const numbersToTest = [-0.5, 0, 0.4, 0.5, 0.7, 1, 1.5];
 
+// Matches clamping in `Easing.circle` / `Easing.bounce` for tests that compare to reference impls.
+const clampUnit = (t: number): number => Math.min(1, Math.max(0, t));
+
 describe('Easing step0', () => {
 	const step0 = (n: number) => {
 		return n > 0 ? 1 : 0;
@@ -131,7 +134,10 @@ describe('Easing Cubic', () => {
 });
 
 describe('Easing Circle', () => {
-	const circle = (n: number) => 1 - Math.sqrt(1 - n * n);
+	const circle = (n: number) => {
+		const u = clampUnit(n);
+		return 1 - Math.sqrt(1 - u * u);
+	};
 	const out = (n: number) => 1 - circle(1 - n);
 	const inOut = (n: number) => {
 		if (n >= 0.5) {
@@ -186,21 +192,23 @@ describe('Easing Exp', () => {
 
 describe('Easing Bounce', () => {
 	const bounce = (n: number) => {
-		if (n < 1 / 2.75) {
-			return 7.5625 * n * n;
+		const u = clampUnit(n);
+
+		if (u < 1 / 2.75) {
+			return 7.5625 * u * u;
 		}
 
-		if (n < 2 / 2.75) {
-			const t2_ = n - 1.5 / 2.75;
+		if (u < 2 / 2.75) {
+			const t2_ = u - 1.5 / 2.75;
 			return 7.5625 * t2_ * t2_ + 0.75;
 		}
 
-		if (n < 2.5 / 2.75) {
-			const t2_ = n - 2.25 / 2.75;
+		if (u < 2.5 / 2.75) {
+			const t2_ = u - 2.25 / 2.75;
 			return 7.5625 * t2_ * t2_ + 0.9375;
 		}
 
-		const t2 = n - 2.625 / 2.75;
+		const t2 = u - 2.625 / 2.75;
 		return 7.5625 * t2 * t2 + 0.984375;
 	};
 

--- a/packages/core/src/test/easing.test.ts
+++ b/packages/core/src/test/easing.test.ts
@@ -138,6 +138,7 @@ describe('Easing Circle', () => {
 		const u = clampUnit(n);
 		return 1 - Math.sqrt(1 - u * u);
 	};
+
 	const out = (n: number) => 1 - circle(1 - n);
 	const inOut = (n: number) => {
 		if (n >= 0.5) {

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -101,6 +101,19 @@ test('Easing test', () => {
 	).toEqual(1 - Math.cos((0.5 * Math.PI) / 2));
 });
 
+test('Easing.circle with default extrapolate extend clamps normalized input', () => {
+	expect(
+		interpolate(150, [0, 100], [0, 100], {
+			easing: Easing.circle,
+		}),
+	).toBe(100);
+	expect(
+		interpolate(-50, [0, 100], [0, 100], {
+			easing: Easing.circle,
+		}),
+	).toBe(0);
+});
+
 test('Extrapolation left test', () => {
 	const testValues: ('extend' | undefined)[] = ['extend', undefined];
 	testValues.forEach((entry) => {

--- a/packages/example/src/EasingVisualizer/EasingVisualizer.tsx
+++ b/packages/example/src/EasingVisualizer/EasingVisualizer.tsx
@@ -1,0 +1,288 @@
+import React, {useMemo} from 'react';
+import {
+	AbsoluteFill,
+	Easing,
+	interpolate,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+const T_MIN = -0.18;
+const T_MAX = 1.18;
+const Y_MIN = -0.45;
+const Y_MAX = 1.75;
+
+type EasingSample = {
+	name: string;
+	fn: (t: number) => number;
+};
+
+const EASINGS: EasingSample[] = [
+	{name: 'linear', fn: Easing.linear},
+	{name: 'ease', fn: Easing.ease},
+	{name: 'quad', fn: Easing.quad},
+	{name: 'cubic', fn: Easing.cubic},
+	{name: 'poly(4)', fn: Easing.poly(4)},
+	{name: 'sin', fn: Easing.sin},
+	{name: 'circle', fn: Easing.circle},
+	{name: 'exp', fn: Easing.exp},
+	{name: 'elastic()', fn: Easing.elastic()},
+	{name: 'back()', fn: Easing.back()},
+	{name: 'bounce', fn: Easing.bounce},
+	{
+		name: 'bezier(0.8,0.22,0.96,0.65)',
+		fn: Easing.bezier(0.8, 0.22, 0.96, 0.65),
+	},
+	{name: 'inOut(quad)', fn: Easing.inOut(Easing.quad)},
+	{name: 'out(circle)', fn: Easing.out(Easing.circle)},
+];
+
+const sampleCurve = (fn: (t: number) => number, count: number) => {
+	const pts: {t: number; y: number}[] = [];
+	for (let i = 0; i < count; i++) {
+		const t = T_MIN + (i / (count - 1)) * (T_MAX - T_MIN);
+		const y = fn(t);
+		if (Number.isFinite(y)) {
+			pts.push({t, y});
+		}
+	}
+
+	return pts;
+};
+
+const MiniChart: React.FC<{
+	name: string;
+	fn: (t: number) => number;
+	playheadT: number;
+	width: number;
+	height: number;
+}> = ({name, fn, playheadT, width, height}) => {
+	const padL = 36;
+	const padR = 10;
+	const padT = 22;
+	const padB = 18;
+	const innerW = width - padL - padR;
+	const innerH = height - padT - padB;
+
+	const pathD = useMemo(() => {
+		const pts = sampleCurve(fn, 220);
+		if (pts.length === 0) {
+			return '';
+		}
+
+		const xScale = (t: number) =>
+			padL + ((t - T_MIN) / (T_MAX - T_MIN)) * innerW;
+		const yScale = (y: number) =>
+			padT + innerH - ((y - Y_MIN) / (Y_MAX - Y_MIN)) * innerH;
+
+		return pts
+			.map((p, i) => {
+				const x = xScale(p.t);
+				const y = yScale(p.y);
+				return `${i === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
+			})
+			.join(' ');
+	}, [fn, innerH, innerW, padL, padT]);
+
+	const xScale = (t: number) => padL + ((t - T_MIN) / (T_MAX - T_MIN)) * innerW;
+	const yScale = (y: number) =>
+		padT + innerH - ((y - Y_MIN) / (Y_MAX - Y_MIN)) * innerH;
+
+	const playY = fn(playheadT);
+	const playYFinite = Number.isFinite(playY);
+	const px = xScale(playheadT);
+	const py = playYFinite ? yScale(playY) : null;
+
+	return (
+		<svg width={width} height={height} style={{display: 'block'}}>
+			<title>{name}</title>
+			<rect width={width} height={height} fill="#141418" rx={6} />
+			{/* [0,1] band */}
+			<rect
+				x={xScale(0)}
+				y={padT}
+				width={xScale(1) - xScale(0)}
+				height={innerH}
+				fill="rgba(120,160,255,0.06)"
+			/>
+			<text
+				x={padL}
+				y={14}
+				fill="#9aa0ae"
+				fontSize={11}
+				fontFamily="system-ui, sans-serif"
+			>
+				{name}
+			</text>
+			{/* axes */}
+			<line
+				x1={padL}
+				x2={padL + innerW}
+				y1={yScale(0)}
+				y2={yScale(0)}
+				stroke="#2a2e38"
+				strokeWidth={1}
+			/>
+			<line
+				x1={xScale(0)}
+				x2={xScale(0)}
+				y1={padT}
+				y2={padT + innerH}
+				stroke="#3d4454"
+				strokeWidth={1}
+			/>
+			<line
+				x1={xScale(1)}
+				x2={xScale(1)}
+				y1={padT}
+				y2={padT + innerH}
+				stroke="#3d4454"
+				strokeWidth={1}
+			/>
+			<text
+				x={xScale(0)}
+				y={height - 4}
+				fill="#5c6370"
+				fontSize={9}
+				fontFamily="system-ui, sans-serif"
+				textAnchor="middle"
+			>
+				0
+			</text>
+			<text
+				x={xScale(1)}
+				y={height - 4}
+				fill="#5c6370"
+				fontSize={9}
+				fontFamily="system-ui, sans-serif"
+				textAnchor="middle"
+			>
+				1
+			</text>
+			<path
+				d={pathD}
+				fill="none"
+				stroke="#6ae3ff"
+				strokeWidth={2}
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			{py !== null ? (
+				<>
+					<line
+						x1={px}
+						x2={px}
+						y1={padT}
+						y2={padT + innerH}
+						stroke="rgba(255,200,120,0.35)"
+						strokeWidth={1}
+						strokeDasharray="4 3"
+					/>
+					<circle
+						cx={px}
+						cy={py}
+						r={5}
+						fill="#ffb86c"
+						stroke="#1a1a1f"
+						strokeWidth={2}
+					/>
+				</>
+			) : (
+				<text
+					x={px}
+					y={padT + innerH / 2}
+					fill="#ff6b6b"
+					fontSize={10}
+					fontFamily="system-ui, sans-serif"
+					textAnchor="middle"
+				>
+					NaN
+				</text>
+			)}
+		</svg>
+	);
+};
+
+export const EasingVisualizer: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {durationInFrames, width, height} = useVideoConfig();
+
+	const playheadT = interpolate(
+		frame,
+		[0, Math.max(1, durationInFrames - 1)],
+		[T_MIN, T_MAX],
+	);
+
+	const cols = 4;
+	const gap = 14;
+	const marginX = 28;
+	const marginY = 88;
+	const titleH = 52;
+	const usableW = width - marginX * 2;
+	const usableH = height - marginY - titleH;
+	const cellW = (usableW - gap * (cols - 1)) / cols;
+	const rows = Math.ceil(EASINGS.length / cols);
+	const cellH = (usableH - gap * (rows - 1)) / rows;
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: '#0b0b0e',
+				fontFamily: 'system-ui, sans-serif',
+			}}
+		>
+			<div
+				style={{
+					position: 'absolute',
+					left: marginX,
+					right: marginX,
+					top: 20,
+				}}
+			>
+				<div style={{color: '#e8eaed', fontSize: 22, fontWeight: 600}}>
+					Easing overshoot lab
+				</div>
+				<div
+					style={{
+						color: '#8b919d',
+						fontSize: 13,
+						marginTop: 6,
+						lineHeight: 1.45,
+					}}
+				>
+					Playhead sweeps <code style={{color: '#b8c0d0'}}>t</code> from {T_MIN}{' '}
+					to {T_MAX}. Shaded strip is the usual animation domain [0, 1].{' '}
+					<code style={{color: '#b8c0d0'}}>circle</code>,{' '}
+					<code style={{color: '#b8c0d0'}}>bounce</code>, and{' '}
+					<code style={{color: '#b8c0d0'}}>bezier</code> clamp{' '}
+					<code style={{color: '#b8c0d0'}}>t</code> before evaluating; others
+					may extend (e.g. <code style={{color: '#b8c0d0'}}>linear</code>,{' '}
+					<code style={{color: '#b8c0d0'}}>quad</code>
+					).
+				</div>
+			</div>
+			<div
+				style={{
+					position: 'absolute',
+					left: marginX,
+					top: titleH + marginY / 2,
+					display: 'grid',
+					gridTemplateColumns: `repeat(${cols}, 1fr)`,
+					gap,
+					width: usableW,
+				}}
+			>
+				{EASINGS.map((e) => (
+					<MiniChart
+						key={e.name}
+						name={e.name}
+						fn={e.fn}
+						playheadT={playheadT}
+						width={Math.floor(cellW)}
+						height={Math.floor(cellH)}
+					/>
+				))}
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -29,6 +29,7 @@ import {
 	discriminatedUnionRootSchema,
 } from './DiscriminatedUnionSchemaTest';
 import {DynamicDuration, dynamicDurationSchema} from './DynamicDuration';
+import {EasingVisualizer} from './EasingVisualizer/EasingVisualizer';
 import {EmojiTestbed} from './Emoji';
 import {ErrorOnFrame10} from './ErrorOnFrame10';
 import {ExperimentalControlsShowcase} from './ExperimentalControls';
@@ -481,6 +482,16 @@ export const Index: React.FC = () => {
 					height={1080}
 					fps={30}
 					durationInFrames={100}
+				/>
+			</Folder>
+			<Folder name="easing">
+				<Composition
+					id="easing-visualizer"
+					component={EasingVisualizer}
+					width={1920}
+					height={1080}
+					fps={30}
+					durationInFrames={210}
 				/>
 			</Folder>
 			<Folder name="regression-testing">


### PR DESCRIPTION
- `Ease.out(Ease.circle)` could lead to NaN if value below 0
- `Ease.bezier()` and `Easing.bounce` now is clamped to [0, 1] - these easings do not make sense in an "overshooting" context