### PR TITLE
`@remotion/effects`: subpath exports per effect (#7368)

### DIFF
--- a/packages/core/src/effects/index.ts
+++ b/packages/core/src/effects/index.ts
@@ -1,4 +1,4 @@
-// Types needed outside core for `_experimentalEffects` / `@remotion/effects` typing.
+// Types needed outside core for `_experimentalEffects` / `@remotion/effects/*` typing.
 export type {
 	EffectDefinitionAndStack,
 	EffectDescriptor,

--- a/packages/effects/bundle.ts
+++ b/packages/effects/bundle.ts
@@ -5,9 +5,17 @@ if (process.env.NODE_ENV !== 'production') {
 	throw new Error('This script must be run using NODE_ENV=production');
 }
 
+const effectEntrypoints = [
+	'src/index.ts',
+	'src/halftone.ts',
+	'src/tint.ts',
+	'src/wave.ts',
+	'src/entrypoints/blur.ts',
+];
+
 console.time('Generated.');
 const output = await build({
-	entrypoints: ['src/index.ts'],
+	entrypoints: effectEntrypoints,
 	naming: '[name].mjs',
 	external: [
 		'remotion',

--- a/packages/effects/bundle.ts
+++ b/packages/effects/bundle.ts
@@ -33,8 +33,13 @@ if (!output.success) {
 }
 
 for (const file of output.outputs) {
-	const str = await file.text();
+	let str = await file.text();
 	const out = path.join('dist', 'esm', file.path);
+
+	// Bun can emit a 0-byte file for `export {}` only; Node needs a real empty module.
+	if (path.basename(file.path) === 'index.mjs' && str.trim() === '') {
+		str = 'export {};\n';
+	}
 
 	await Bun.write(out, str);
 }

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -32,7 +32,35 @@
 			"module": "./dist/esm/index.mjs",
 			"import": "./dist/esm/index.mjs"
 		},
+		"./halftone": {
+			"types": "./dist/halftone.d.ts",
+			"module": "./dist/esm/halftone.mjs",
+			"import": "./dist/esm/halftone.mjs"
+		},
+		"./tint": {
+			"types": "./dist/tint.d.ts",
+			"module": "./dist/esm/tint.mjs",
+			"import": "./dist/esm/tint.mjs"
+		},
+		"./wave": {
+			"types": "./dist/wave.d.ts",
+			"module": "./dist/esm/wave.mjs",
+			"import": "./dist/esm/wave.mjs"
+		},
+		"./blur": {
+			"types": "./dist/entrypoints/blur.d.ts",
+			"module": "./dist/esm/blur.mjs",
+			"import": "./dist/esm/blur.mjs"
+		},
 		"./package.json": "./package.json"
+	},
+	"typesVersions": {
+		">=1.0": {
+			"halftone": ["dist/halftone.d.ts"],
+			"tint": ["dist/tint.d.ts"],
+			"wave": ["dist/wave.d.ts"],
+			"blur": ["dist/entrypoints/blur.d.ts"]
+		}
 	},
 	"devDependencies": {
 		"@remotion/eslint-config-internal": "workspace:*",

--- a/packages/effects/src/entrypoints/blur.ts
+++ b/packages/effects/src/entrypoints/blur.ts
@@ -1,0 +1,11 @@
+import * as blurExports from '../blur/index.js';
+
+export type {
+	BlurHorizontalParams,
+	BlurParams,
+	BlurVerticalParams,
+} from '../blur/index.js';
+
+const {blur, blurHorizontal, blurVertical} = blurExports;
+
+export {blur, blurHorizontal, blurVertical};

--- a/packages/effects/src/index.ts
+++ b/packages/effects/src/index.ts
@@ -1,16 +1,1 @@
-export {blur, blurHorizontal, blurVertical} from './blur/index.js';
-export type {
-	BlurHorizontalParams,
-	BlurParams,
-	BlurVerticalParams,
-} from './blur/index.js';
-export {halftone} from './halftone.js';
-export type {
-	HalftoneParams,
-	HalftoneSampling,
-	HalftoneShape,
-} from './halftone.js';
-export {tint} from './tint.js';
-export type {TintParams} from './tint.js';
-export {wave} from './wave.js';
-export type {WaveParams} from './wave.js';
+export {};

--- a/packages/example/src/HtmlInCanvas/compose-webgl-crt.tsx
+++ b/packages/example/src/HtmlInCanvas/compose-webgl-crt.tsx
@@ -1,4 +1,4 @@
-import {tint} from '@remotion/effects';
+import {tint} from '@remotion/effects/tint';
 import React, {useCallback, useRef} from 'react';
 import {
 	HtmlInCanvas,

--- a/packages/example/src/HtmlInCanvas/react-svg.tsx
+++ b/packages/example/src/HtmlInCanvas/react-svg.tsx
@@ -1,4 +1,5 @@
-import {halftone, tint} from '@remotion/effects';
+import {halftone} from '@remotion/effects/halftone';
+import {tint} from '@remotion/effects/tint';
 import React from 'react';
 import {HtmlInCanvas, useVideoConfig} from 'remotion';
 import ReactSvg from '../ReactSvg';


### PR DESCRIPTION
## Summary

- Adds `package.json` `exports` (and matching `typesVersions`) for each shipped canvas effect: `@remotion/effects/halftone`, `@remotion/effects/tint`, `@remotion/effects/wave`, and `@remotion/effects/blur`, following the same pattern as `@remotion/transitions` presentation entry points ([contributing/presentation](https://www.remotion.dev/docs/contributing/presentation)).
- Extends `packages/effects/bundle.ts` so the Bun build emits one ESM chunk per effect alongside the root barrel.
- Introduces `src/entrypoints/blur.ts` as the `./blur` entry source. Using `src/blur/index.ts` directly would produce `index.mjs` (basename collision), and a plain re-export barrel was incorrectly tree-shaken to an empty module; the namespace import + destructuring pattern keeps the blur implementation in the `./blur` bundle.

## Test plan

- `turbo run make --filter='@remotion/effects' --force`
- `bun run lint` / `bun run formatting` in `packages/effects`
- Node smoke import: `import {blur} from '@remotion/effects/blur'` (and halftone/tint/wave) from the package directory resolves and exports functions.

Fixes https://github.com/remotion-dev/remotion/issues/7368

Made with [Cursor](https://cursor.com)