### PR TITLE
`@remotion/timeline-utils`: Add film strip codec tests

### DIFF
--- a/packages/timeline-utils/src/test/extract-frames-server.test.ts
+++ b/packages/timeline-utils/src/test/extract-frames-server.test.ts
@@ -1,0 +1,71 @@
+import {beforeAll, expect, test} from 'bun:test';
+import {registerMediabunnyServer} from '@mediabunny/server';
+import {extractFrames} from '../extract-frames';
+import {ensureSlots, WEBCODECS_TIMESCALE} from '../render-frame-strip';
+
+const SAMPLE_MEDIA_URL = 'https://remotion.media/video.mp4';
+const MAX_TIMESTAMP_DEVIATION_IN_SECONDS = 0.05;
+
+beforeAll(() => {
+	registerMediabunnyServer();
+});
+
+test('extractFrames decodes MP4 frames for the timeline film strip', async () => {
+	const filledSlots = new Map<number, number | undefined>();
+	const extractedSamples: Array<{
+		timestamp: number;
+		duration: number;
+		displayWidth: number;
+		displayHeight: number;
+	}> = [];
+
+	await extractFrames({
+		src: SAMPLE_MEDIA_URL,
+		timestampsInSeconds: ({track, container, durationInSeconds}) => {
+			expect(track).toEqual({width: 1920, height: 1080});
+			expect(container).toBe('MP4');
+			expect(durationInSeconds).toBe(10);
+
+			ensureSlots({
+				filledSlots,
+				naturalWidth: 180,
+				fromSeconds: 0,
+				toSeconds: 1,
+				aspectRatio: track.width / track.height,
+				frameHeight: 50,
+			});
+
+			return Array.from(filledSlots.keys()).map(
+				(timestamp) => timestamp / WEBCODECS_TIMESCALE,
+			);
+		},
+		onVideoSample: (sample) => {
+			extractedSamples.push({
+				timestamp: sample.timestamp,
+				duration: sample.duration,
+				displayWidth: sample.displayWidth,
+				displayHeight: sample.displayHeight,
+			});
+			sample.close();
+		},
+	});
+
+	expect(extractedSamples.length).toBe(filledSlots.size);
+	expect(extractedSamples.length).toBeGreaterThan(1);
+
+	const slotTimestamps = Array.from(filledSlots.keys()).map(
+		(timestamp) => timestamp / WEBCODECS_TIMESCALE,
+	);
+
+	for (let i = 0; i < extractedSamples.length; i++) {
+		const sample = extractedSamples[i];
+		const slotTimestamp = slotTimestamps[i];
+
+		expect(sample?.displayWidth).toBe(1920);
+		expect(sample?.displayHeight).toBe(1080);
+		expect(sample?.duration).toBeGreaterThan(0);
+		expect(
+			Math.abs((sample?.timestamp ?? 0) - (slotTimestamp ?? 0)),
+		).toBeLessThanOrEqual(MAX_TIMESTAMP_DEVIATION_IN_SECONDS);
+	}
+});

--- a/packages/timeline-utils/src/test/load-waveform-peaks-server.test.ts
+++ b/packages/timeline-utils/src/test/load-waveform-peaks-server.test.ts
@@ -2,15 +2,15 @@ import {beforeAll, expect, test} from 'bun:test';
 import {registerMediabunnyServer} from '@mediabunny/server';
 import {loadWaveformPeaks} from '../audio-waveform/load-waveform-peaks';
 
-const SAMPLE_AUDIO_URL = 'https://remotion.media/dialogue.wav';
+const SAMPLE_MEDIA_URL = 'https://remotion.media/video.mp4';
 
 beforeAll(() => {
 	registerMediabunnyServer();
 });
 
-test('loadWaveformPeaks decodes remote audio with @mediabunny/server', async () => {
+test('loadWaveformPeaks decodes an MP4 audio track with @mediabunny/server', async () => {
 	const peaks = await loadWaveformPeaks(
-		SAMPLE_AUDIO_URL,
+		SAMPLE_MEDIA_URL,
 		new AbortController().signal,
 	);
 
@@ -27,12 +27,12 @@ test('loadWaveformPeaks decodes remote audio with @mediabunny/server', async () 
 	expect(max).toBeGreaterThan(0.01);
 });
 
-test('loadWaveformPeaks progress matches completed peak count for remote audio', async () => {
+test('loadWaveformPeaks progress matches completed peak count for MP4 audio', async () => {
 	let lastCompleted = 0;
 	let sawFinal = false;
 
 	const peaks = await loadWaveformPeaks(
-		SAMPLE_AUDIO_URL,
+		SAMPLE_MEDIA_URL,
 		new AbortController().signal,
 		{
 			progressIntervalInMs: 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds server-side timeline film strip coverage for `extractFrames` using the same slot generation helpers used by Studio.
- Switches the waveform integration fixture from WAV to MP4 so the test exercises codec-backed audio decoding.

## Validation

- `bun test src` in `packages/timeline-utils`
- `bun run formatting` in `packages/timeline-utils`
- `bun run lint` in `packages/timeline-utils`
- `bun run build` at repo root
- `bun run stylecheck` at repo root was attempted and reached the known `@remotion/lambda-go` Go 1.22.2 vs Go >= 1.23.0 environment failure after timeline-utils formatting/lint passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac70084b-563c-4b67-836a-f7423106642e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac70084b-563c-4b67-836a-f7423106642e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

