### PR TITLE
`@remotion/bundler`: Symlink public dir for ephemeral CLI render bundles

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -76,8 +76,9 @@ export type MandatoryLegacyBundleOptions = {
 	 * If true, the public directory is symlinked into the bundle output instead of copied.
 	 * Safe for throwaway bundles (e.g. CLI render where the output folder is deleted after);
 	 * do not use when the bundle must be self-contained for deployment.
+	 * Has no effect on Windows, where the public directory is always copied.
 	 */
-	symlinkPublicDir?: boolean;
+	symlinkPublicDir: boolean;
 };
 
 export type LegacyBundleOptions = Partial<MandatoryLegacyBundleOptions>;
@@ -366,12 +367,8 @@ export const internalBundle = async (
 	};
 
 	if (fs.existsSync(from)) {
-		if (actualArgs.symlinkPublicDir) {
-			if (process.platform === 'win32') {
-				await fs.promises.symlink(from, to, 'dir');
-			} else {
-				await fs.promises.symlink(from, to);
-			}
+		if (actualArgs.symlinkPublicDir && process.platform !== 'win32') {
+			await fs.promises.symlink(from, to);
 		} else {
 			await copyDir({
 				src: from,

--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -72,6 +72,12 @@ export type MandatoryLegacyBundleOptions = {
 	keyboardShortcutsEnabled: boolean;
 	askAIEnabled: boolean;
 	rspack: boolean;
+	/**
+	 * If true, the public directory is symlinked into the bundle output instead of copied.
+	 * Safe for throwaway bundles (e.g. CLI render where the output folder is deleted after);
+	 * do not use when the bundle must be self-contained for deployment.
+	 */
+	symlinkPublicDir?: boolean;
 };
 
 export type LegacyBundleOptions = Partial<MandatoryLegacyBundleOptions>;
@@ -360,16 +366,24 @@ export const internalBundle = async (
 	};
 
 	if (fs.existsSync(from)) {
-		await copyDir({
-			src: from,
-			dest: to,
-			onSymlinkDetected: showSymlinkWarning,
-			onProgress: (prog) => {
-				return options.onPublicDirCopyProgress?.(prog);
-			},
-			copiedBytes: 0,
-			lastReportedProgress: 0,
-		});
+		if (actualArgs.symlinkPublicDir) {
+			if (process.platform === 'win32') {
+				await fs.promises.symlink(from, to, 'dir');
+			} else {
+				await fs.promises.symlink(from, to);
+			}
+		} else {
+			await copyDir({
+				src: from,
+				dest: to,
+				onSymlinkDetected: showSymlinkWarning,
+				onProgress: (prog) => {
+					return options.onPublicDirCopyProgress?.(prog);
+				},
+				copiedBytes: 0,
+				lastReportedProgress: 0,
+			});
+		}
 	}
 
 	const html = indexHtml({
@@ -448,6 +462,7 @@ export async function bundle(...args: Arguments): Promise<string> {
 		askAIEnabled: actualArgs.askAIEnabled ?? true,
 		keyboardShortcutsEnabled: actualArgs.keyboardShortcutsEnabled ?? true,
 		rspack: actualArgs.rspack ?? false,
+		symlinkPublicDir: actualArgs.symlinkPublicDir ?? false,
 	});
 	return result;
 }

--- a/packages/cli/src/setup-cache.ts
+++ b/packages/cli/src/setup-cache.ts
@@ -223,6 +223,8 @@ export const bundleOnCli = async ({
 		askAIEnabled,
 		keyboardShortcutsEnabled,
 		rspack,
+		// Ephemeral CLI bundles (render/still/compositions/benchmark) use a temp dir; symlink avoids copying huge public folders. `npx remotion bundle` passes a fixed outDir and keeps deep copy for deployable output.
+		symlinkPublicDir: outDir === null,
 	};
 
 	const [hash] = await BundlerInternals.getConfig({

--- a/packages/cloudrun/src/api/deploy-site.ts
+++ b/packages/cloudrun/src/api/deploy-site.ts
@@ -112,6 +112,7 @@ export const internalDeploySiteRaw = async ({
 			askAIEnabled: options?.askAIEnabled ?? true,
 			keyboardShortcutsEnabled: options?.keyboardShortcutsEnabled ?? true,
 			rspack: options?.rspack ?? false,
+			symlinkPublicDir: false,
 		}),
 	]);
 

--- a/packages/lambda/src/api/deploy-site.ts
+++ b/packages/lambda/src/api/deploy-site.ts
@@ -139,6 +139,7 @@ const mandatoryDeploySite = async ({
 			keyboardShortcutsEnabled: options?.keyboardShortcutsEnabled ?? true,
 			renderDefaults: null,
 			rspack: options?.rspack ?? false,
+			symlinkPublicDir: false,
 		}),
 	]);
 


### PR DESCRIPTION
## Summary

- For CLI flows that use a temporary bundle directory (`outDir === null` in `bundleOnCli`—`remotion render`, `remotion still`, compositions, benchmark, and Studio-triggered renders), the resolved `public` folder is now **symlinked** into `<bundle>/public` instead of recursively copied, avoiding huge I/O when `public` is very large.
- `npx remotion bundle`, `bundle()` / `internalBundle()` call sites that do not set the flag (including Lambda/Cloud Run `deploySite`, which use `bundle()` / `internalBundle` directly), **keep the existing deep copy** so output remains self-contained for deployment.
- Added optional `symlinkPublicDir` on bundle options and forward it from the public `bundle()` API for advanced use.

## Test plan

- [ ] `npx remotion render` / `still` with a large `public` dir: bundling should skip multi-GB copy; `<temp-bundle>/public` should be a symlink to the project `public` (or `--public-dir`).
- [ ] `npx remotion bundle`: `build/` (or `--out-dir`) should still contain a real copied `public` tree, not a top-level symlink.
- [ ] On Windows, confirm directory symlink creation works for the temp bundle path (or document if elevation is required, consistent with existing symlink handling in `copyDir`).

Made with [Cursor](https://cursor.com)