### PR TITLE
`@remotion/skills-evals`: Compare against configurable base refs

### DIFF
--- a/packages/skills-evals/src/app/comparison.tsx
+++ b/packages/skills-evals/src/app/comparison.tsx
@@ -175,7 +175,7 @@ export const renderComparison = (comparisonData: ComparisonWithManifests) => {
 				<main className="grid min-w-0 gap-4">
 					<div className="grid grid-cols-2 gap-3 max-lg:grid-cols-1">
 						<RunPanel
-							label="Before"
+							label={`Before (${comparison.before.gitRef ?? comparison.before.source})`}
 							manifest={beforeManifest}
 							manifestPath={comparison.before.manifestPath}
 						/>

--- a/packages/skills-evals/src/app/home.tsx
+++ b/packages/skills-evals/src/app/home.tsx
@@ -39,9 +39,9 @@ export const renderHome = async () => {
 					<section className="max-w-3xl">
 						<h2 className="text-sm font-semibold text-zinc-700">Workflow</h2>
 						<p className="mt-1 text-sm leading-6 text-zinc-500">
-							When skills match HEAD, run a scenario as visual validation. When
-							you have local skill changes, run a comparison to see how those
-							changes affect the resulting videos.
+							When skills match the configured base ref, run a scenario as
+							visual validation. When you have skill changes, run a comparison
+							to see how those changes affect the resulting videos.
 						</p>
 					</section>
 					<section className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-3">

--- a/packages/skills-evals/src/app/jobs.ts
+++ b/packages/skills-evals/src/app/jobs.ts
@@ -69,7 +69,10 @@ export const getActiveJob = (scenarioId: string) =>
 		(job) => job.scenarioId === scenarioId && job.status === 'running',
 	);
 
-export const startComparison = (scenario: SkillEvalScenario) => {
+export const startComparison = (
+	scenario: SkillEvalScenario,
+	options: {beforeGitRef?: string} = {},
+) => {
 	const existingJob = getActiveJob(scenario.id);
 
 	if (existingJob) {
@@ -163,6 +166,7 @@ export const startComparison = (scenario: SkillEvalScenario) => {
 	};
 
 	const comparisonPromise = runSkillEvalComparison(scenario, {
+		beforeGitRef: options.beforeGitRef,
 		onEvent: handleEvent,
 	})
 		.then((result) => {

--- a/packages/skills-evals/src/app/routes.ts
+++ b/packages/skills-evals/src/app/routes.ts
@@ -12,14 +12,23 @@ export const routes = {
 	'/': async () => htmlResponse(await renderHome()),
 
 	'/api/compare/:scenarioId': {
-		POST: (request: BunRequest<'/api/compare/:scenarioId'>) => {
+		POST: async (request: BunRequest<'/api/compare/:scenarioId'>) => {
 			const scenario = getScenario(request.params.scenarioId);
 
 			if (!scenario) {
 				return json({error: 'Unknown scenario'}, {status: 404});
 			}
 
-			return json(startComparison(scenario));
+			const body = await request.json().catch(() => null);
+			const beforeGitRef =
+				body &&
+				typeof body === 'object' &&
+				'beforeGitRef' in body &&
+				typeof body.beforeGitRef === 'string'
+					? body.beforeGitRef
+					: undefined;
+
+			return json(startComparison(scenario, {beforeGitRef}));
 		},
 	},
 

--- a/packages/skills-evals/src/app/scenario.tsx
+++ b/packages/skills-evals/src/app/scenario.tsx
@@ -1,6 +1,7 @@
 import {basename, join} from 'node:path';
 import type {SkillEvalScenario} from '../../scenarios';
 import {runCommand} from '../command';
+import {getDefaultComparisonBaseRef} from '../compare';
 import {listFilesRecursively, readJson, sanitizePathPart} from '../files';
 import type {SkillEvalComparison, SkillEvalManifest} from '../manifest';
 import {loadComparisons} from './comparison-data';
@@ -22,6 +23,7 @@ import {
 } from './shared';
 
 type SkillDiffState = {
+	baseRef: string;
 	hasChanges: boolean;
 	message: string;
 	title: string;
@@ -34,26 +36,36 @@ type ScenarioRunListItem = {
 };
 
 const getSkillDiffState = async (): Promise<SkillDiffState> => {
+	const baseRef = getDefaultComparisonBaseRef();
 	const result = await runCommand({
-		command: ['git', 'status', '--porcelain', '--', 'packages/skills/skills'],
+		command: [
+			'git',
+			'diff',
+			'--quiet',
+			'--exit-code',
+			baseRef,
+			'--',
+			'packages/skills/skills',
+		],
 		cwd: repoRoot,
 	});
 
-	if (result.exitCode === 0) {
+	if (result.exitCode === 0 || result.exitCode === 1) {
+		const hasChanges = result.exitCode === 1;
 		return {
-			hasChanges: result.stdout.trim().length > 0,
-			message: result.stdout.trim()
-				? 'Skills differ from HEAD. Run a before/after comparison against HEAD.'
-				: 'Skills match HEAD. This will run the scenario without a diff to review.',
-			title: result.stdout.trim()
-				? 'Skills changed from HEAD'
-				: 'No skill changes',
+			baseRef,
+			hasChanges,
+			message: hasChanges
+				? `Skills differ from ${baseRef}. Run a before/after comparison against ${baseRef}.`
+				: `Skills match ${baseRef}. This will run the scenario without a diff to review.`,
+			title: hasChanges ? `Skills changed from ${baseRef}` : 'No skill changes',
 		};
 	}
 
 	return {
+		baseRef,
 		hasChanges: false,
-		message: `Could not inspect skill diff. The scenario can still run without a comparison. ${result.stderr}`,
+		message: `Could not inspect skill diff against ${baseRef}. The scenario can still run without a comparison. ${result.stderr}`,
 		title: 'Skill diff unavailable',
 	};
 };
@@ -122,11 +134,18 @@ const ScenarioRuns = ({items}: {items: ScenarioRunListItem[]}) => {
 	);
 };
 
-const ScenarioPageScript = ({activeJob}: {activeJob: Job | undefined}) => (
+const ScenarioPageScript = ({
+	activeJob,
+	baseRef,
+}: {
+	activeJob: Job | undefined;
+	baseRef: string;
+}) => (
 	<script
 		dangerouslySetInnerHTML={{
 			__html: `
 const button = document.getElementById('run-comparison');
+const baseRefInput = document.getElementById('comparison-base-ref');
 const panel = document.getElementById('active-job');
 const log = document.getElementById('job-log');
 const status = document.getElementById('job-status');
@@ -139,6 +158,7 @@ const runLog = {
 	after: document.getElementById('after-run-log'),
 };
 const activeJobId = ${JSON.stringify(activeJob?.id ?? null)};
+const defaultBaseRef = ${JSON.stringify(baseRef)};
 
 const renderJob = (job) => {
 	panel.hidden = false;
@@ -207,7 +227,11 @@ button?.addEventListener('click', async () => {
 		runLog[label].hidden = true;
 		runLog[label].textContent = '';
 	}
-	const response = await fetch(button.dataset.actionUrl, {
+	const beforeGitRef = baseRefInput?.value?.trim() || defaultBaseRef;
+	const shouldCompare = button.dataset.hasSkillChanges === 'true' || beforeGitRef !== defaultBaseRef;
+	const response = await fetch(shouldCompare ? button.dataset.compareUrl : button.dataset.runUrl, {
+		body: shouldCompare ? JSON.stringify({beforeGitRef}) : undefined,
+		headers: shouldCompare ? {'content-type': 'application/json'} : undefined,
 		method: 'POST',
 	});
 	const job = await response.json();
@@ -303,11 +327,9 @@ export const renderScenario = async (scenario: SkillEvalScenario) => {
 					action={
 						<button
 							className="rounded-full bg-zinc-900 px-3 py-2 text-[0.8125rem] font-semibold text-white hover:bg-zinc-800 disabled:bg-zinc-300 disabled:text-zinc-500"
-							data-action-url={
-								skillDiffState.hasChanges
-									? `/api/compare/${encodeURIComponent(scenario.id)}`
-									: `/api/run/${encodeURIComponent(scenario.id)}`
-							}
+							data-compare-url={`/api/compare/${encodeURIComponent(scenario.id)}`}
+							data-has-skill-changes={String(skillDiffState.hasChanges)}
+							data-run-url={`/api/run/${encodeURIComponent(scenario.id)}`}
 							data-scenario={scenario.id}
 							id="run-comparison"
 						>
@@ -342,10 +364,20 @@ export const renderScenario = async (scenario: SkillEvalScenario) => {
 							</div>
 							{skillDiffState.hasChanges ? (
 								<span className="rounded-full bg-amber-100 px-2 py-1 text-xs text-amber-800">
-									Compare against HEAD
+									Compare against {skillDiffState.baseRef}
 								</span>
 							) : null}
 						</div>
+						<label className="mt-4 block max-w-sm text-sm font-medium text-zinc-700">
+							Comparison base ref
+							<input
+								className="mt-1 w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900"
+								defaultValue={skillDiffState.baseRef}
+								id="comparison-base-ref"
+								name="comparison-base-ref"
+								spellCheck={false}
+							/>
+						</label>
 					</section>
 					<details className="min-w-0 rounded-2xl border border-zinc-200 bg-white p-4">
 						<summary className="cursor-pointer text-sm font-semibold">
@@ -364,7 +396,10 @@ export const renderScenario = async (scenario: SkillEvalScenario) => {
 						<ScenarioRuns items={runItems} />
 					</Card>
 				</main>
-				<ScenarioPageScript activeJob={activeJob} />
+				<ScenarioPageScript
+					activeJob={activeJob}
+					baseRef={skillDiffState.baseRef}
+				/>
 			</>
 		),
 		title: scenario.id,

--- a/packages/skills-evals/src/cli.ts
+++ b/packages/skills-evals/src/cli.ts
@@ -29,8 +29,14 @@ const main = async () => {
 		await import('./server');
 	} else if (command === 'compare') {
 		const scenario = getScenario(process.argv[3]);
-		process.stdout.write(`Comparing ${scenario.id} with ${scenario.model}\n`);
+		const beforeGitRef = process.argv[4];
+		process.stdout.write(
+			`Comparing ${scenario.id} with ${scenario.model}${
+				beforeGitRef ? ` against ${beforeGitRef}` : ''
+			}\n`,
+		);
 		const result = await runSkillEvalComparison(scenario, {
+			beforeGitRef,
 			onLog: (chunk) => process.stdout.write(chunk),
 		});
 
@@ -63,7 +69,7 @@ const main = async () => {
 		}
 	} else {
 		process.stdout.write(
-			'Usage: bun run eval <list|run|compare|dev> [scenario-id|--all]\n',
+			'Usage: bun run eval <list|run|compare|dev> [scenario-id|--all] [base-ref]\n',
 		);
 		process.exit(command ? 1 : 0);
 	}

--- a/packages/skills-evals/src/compare.ts
+++ b/packages/skills-evals/src/compare.ts
@@ -58,13 +58,14 @@ type SkillEvalComparisonResult =
 	  };
 
 type SkillEvalComparisonOptions = {
+	beforeGitRef?: string;
 	onEvent?: (event: SkillEvalComparisonEvent) => void;
 	onLog?: (chunk: string) => void;
 };
 
 type BeforeSkillsSource = {
-	gitRef: 'HEAD';
-	source: 'head';
+	gitRef: string;
+	source: 'git-ref';
 };
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -72,6 +73,9 @@ const repoRoot = resolve(packageRoot, '..', '..');
 const runsRoot = resolve(packageRoot, '.runs');
 const skillsSource = resolve(packageRoot, '..', 'skills', 'skills');
 const comparisonsRoot = join(runsRoot, 'comparisons');
+
+export const getDefaultComparisonBaseRef = () =>
+	process.env.REMOTION_SKILLS_EVALS_BASE_REF ?? 'origin/main';
 
 const getErrorMessage = (error: unknown) =>
 	error instanceof Error ? error.message : String(error);
@@ -99,13 +103,15 @@ const copyGitSkills = async ({gitRef, to}: {gitRef: string; to: string}) => {
 
 const prepareBeforeSkills = async ({
 	beforeSkillsPath,
+	gitRef,
 }: {
 	beforeSkillsPath: string;
+	gitRef: string;
 }): Promise<BeforeSkillsSource> => {
-	await copyGitSkills({gitRef: 'HEAD', to: beforeSkillsPath});
+	await copyGitSkills({gitRef, to: beforeSkillsPath});
 	return {
-		gitRef: 'HEAD',
-		source: 'head',
+		gitRef,
+		source: 'git-ref',
 	};
 };
 
@@ -123,6 +129,7 @@ export const runSkillEvalComparison = async (
 	const afterSkillsPath = join(comparisonDir, 'after-skills');
 	const skillDiffPath = join(comparisonDir, 'skills.diff');
 	const createdAt = new Date().toISOString();
+	const beforeGitRef = options.beforeGitRef ?? getDefaultComparisonBaseRef();
 	const emitMessage = (message: string) => {
 		options.onEvent?.({message, type: 'message'});
 		options.onLog?.(message);
@@ -131,9 +138,10 @@ export const runSkillEvalComparison = async (
 	await rm(comparisonDir, {force: true, recursive: true});
 	await mkdir(comparisonDir, {recursive: true});
 
-	emitMessage(`[compare] Preparing ${scenario.id}\n`);
+	emitMessage(`[compare] Preparing ${scenario.id} against ${beforeGitRef}\n`);
 	const beforeSource = await prepareBeforeSkills({
 		beforeSkillsPath,
+		gitRef: beforeGitRef,
 	});
 
 	await copyDirectory(skillsSource, afterSkillsPath);
@@ -154,7 +162,7 @@ export const runSkillEvalComparison = async (
 	if (diff.exitCode === 0) {
 		await rm(comparisonDir, {force: true, recursive: true});
 		return {
-			reason: 'No skill changes since HEAD.',
+			reason: `No skill changes since ${beforeGitRef}.`,
 			skipped: true,
 		};
 	}

--- a/packages/skills-evals/src/manifest.ts
+++ b/packages/skills-evals/src/manifest.ts
@@ -63,7 +63,7 @@ export type SkillEvalComparison = {
 	skillDiffPath: string;
 	before: {
 		label: 'before';
-		source: 'head';
+		source: 'git-ref' | 'head';
 		skillsPath: string;
 		hash: string;
 		gitRef?: string;


### PR DESCRIPTION
## Summary
- Let skills eval comparisons use a configurable git ref instead of always comparing against HEAD.
- Add a scenario page input for choosing the comparison base ref from the UI.
- Label comparison output with the before ref so results are easier to interpret.

## Test plan
- `bunx oxfmt src --write`
- `bun run formatting`
- `bunx turbo run make --filter='@remotion/eslint-config-internal'`
- `bun run lint`