### PR TITLE
`@remotion/layout-utils`: Fix fitTextOnNLines overflow for long words

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -976,7 +976,14 @@
       "devDependencies": {
         "@remotion/eslint-config-internal": "workspace:*",
         "@typescript/native-preview": "catalog:",
+        "@vitejs/plugin-react": "catalog:",
+        "@vitest/browser-playwright": "catalog:",
         "eslint": "catalog:",
+        "playwright": "catalog:",
+        "react": "catalog:",
+        "react-dom": "catalog:",
+        "remotion": "workspace:*",
+        "vitest": "catalog:",
       },
     },
     "packages/licensing": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"teste2e": "turbo run teste2e --no-update-notifier",
 		"testwebcodecs": "turbo run testwebcodecs --no-update-notifier",
 		"testwebrenderer": "turbo run testwebrenderer --concurrency=1 --no-update-notifier",
+		"testlayoututils": "turbo run testlayoututils --concurrency=1 --no-update-notifier",
 		"testlambda": "turbo run testlambda --concurrency=1 --no-update-notifier",
 		"ci": "turbo run make test --concurrency=1 --no-update-notifier",
 		"watch": "turbo watch make --concurrency=2 --experimental-write-cache",

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -189,6 +189,7 @@ import {StarburstExample} from './Starburst';
 import {Seek} from './StudioApis/Seek';
 import {TikTokTextBoxPlayground} from './TikTokTextbox/TikTokTextBox';
 import {FitTextOnNLines, fitTextOnNLinesSchema} from './Title/FitTextOnNLines';
+import {Issue7359FitTextOnNLines} from './Title/Issue7359FitTextOnNLines';
 import {TransitionRounding} from './TransitionRounding';
 import {WebGlTransition} from './Transitions/WebGlTransition';
 import {
@@ -712,6 +713,12 @@ export const Index: React.FC = () => {
 						maxLines: 3,
 						textAlign: 'right' as const,
 					}}
+				/>
+				<Still
+					id="issue-7359-fit-text-on-n-lines"
+					component={Issue7359FitTextOnNLines}
+					width={1280}
+					height={720}
 				/>
 				<Composition
 					id="beta-text"

--- a/packages/example/src/Title/Issue7359FitTextOnNLines.tsx
+++ b/packages/example/src/Title/Issue7359FitTextOnNLines.tsx
@@ -1,0 +1,69 @@
+import {fitTextOnNLines} from '@remotion/layout-utils';
+import React, {useMemo} from 'react';
+import {AbsoluteFill} from 'remotion';
+
+const BOX_WIDTH = 756;
+
+/**
+ * Minimal reproduction for https://github.com/remotion-dev/remotion/issues/7359
+ */
+export const Issue7359FitTextOnNLines: React.FC = () => {
+	const {fontSize, lines} = useMemo(
+		() =>
+			fitTextOnNLines({
+				text: 'microtext  abcdefghijklmnopq',
+				maxLines: 2,
+				maxBoxWidth: BOX_WIDTH,
+				maxFontSize: 80,
+				fontFamily: 'Verdana',
+				fontWeight: '900',
+				textTransform: 'uppercase',
+			}),
+		[],
+	);
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: '#111',
+				justifyContent: 'center',
+				alignItems: 'center',
+			}}
+		>
+			<div
+				style={{
+					width: BOX_WIDTH,
+					outline: '2px solid #6f6',
+					color: '#fff',
+					fontFamily: 'Verdana, sans-serif',
+					fontWeight: 900,
+					textTransform: 'uppercase',
+				}}
+			>
+				{lines.map((line) => (
+					<div
+						key={line}
+						style={{
+							fontSize,
+							lineHeight: 1.25,
+							whiteSpace: 'pre',
+						}}
+					>
+						{line}
+					</div>
+				))}
+			</div>
+			<div
+				style={{
+					position: 'absolute',
+					bottom: 40,
+					color: '#aaa',
+					fontFamily: 'monospace',
+					fontSize: 14,
+				}}
+			>
+				fontSize: {fontSize} · maxBoxWidth: {BOX_WIDTH}
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/packages/layout-utils/eslint.config.mjs
+++ b/packages/layout-utils/eslint.config.mjs
@@ -1,6 +1,6 @@
 import {remotionFlatConfig} from '@remotion/eslint-config-internal';
 
-const config = remotionFlatConfig({react: false});
+const config = remotionFlatConfig({react: true});
 
 export default {
 	...config,

--- a/packages/layout-utils/package.json
+++ b/packages/layout-utils/package.json
@@ -12,7 +12,10 @@
 		"formatting": "oxfmt src --check",
 		"format": "oxfmt src",
 		"lint": "eslint src",
-		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
+		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
+		"testlayoututils": "vitest src/test --browser --run",
+		"studio": "cd ../example && bunx remotion studio ../layout-utils/src/test/studio.ts --public-dir=../example-videos/videos",
+		"remotion": "cd ../example && bunx remotion studio ../layout-utils/src/test/studio.ts --public-dir=../example-videos/videos"
 	},
 	"exports": {
 		"./package.json": "./package.json",
@@ -25,8 +28,15 @@
 	},
 	"devDependencies": {
 		"@remotion/eslint-config-internal": "workspace:*",
+		"@vitejs/plugin-react": "catalog:",
+		"@vitest/browser-playwright": "catalog:",
+		"@typescript/native-preview": "catalog:",
 		"eslint": "catalog:",
-		"@typescript/native-preview": "catalog:"
+		"playwright": "catalog:",
+		"react": "catalog:",
+		"react-dom": "catalog:",
+		"remotion": "workspace:*",
+		"vitest": "catalog:"
 	},
 	"author": "Yehor Misiats (https://github.com/satelllte)",
 	"maintainers": [

--- a/packages/layout-utils/src/layouts/fill-text-box.ts
+++ b/packages/layout-utils/src/layouts/fill-text-box.ts
@@ -52,7 +52,7 @@ export const fillTextBox = ({
 			const widths = lineWithWord.map((w) => measureText(w).width);
 			const lineWidthWithWordAdded = widths.reduce((a, b) => a + b, 0);
 
-			if (Math.ceil(lineWidthWithWordAdded) < maxBoxWidth) {
+			if (Math.ceil(lineWidthWithWordAdded) <= maxBoxWidth) {
 				lines[currentlyAt].push({
 					text: lines[currentlyAt].length === 0 ? text.trimStart() : text,
 					fontFamily,
@@ -61,6 +61,8 @@ export const fillTextBox = ({
 					letterSpacing,
 					textTransform,
 					fontVariantNumeric,
+					validateFontIsLoaded,
+					additionalStyles,
 				});
 
 				return {exceedsBox: false, newLine: false};
@@ -70,17 +72,26 @@ export const fillTextBox = ({
 				return {exceedsBox: true, newLine: false};
 			}
 
-			lines[currentlyAt + 1] = [
-				{
-					text: text.trimStart(),
-					fontFamily,
-					fontWeight,
-					fontSize,
-					letterSpacing,
-					textTransform,
-					fontVariantNumeric,
-				},
-			];
+			const wordForNewLine: Word = {
+				text: text.trimStart(),
+				fontFamily,
+				fontWeight,
+				fontSize,
+				letterSpacing,
+				fontVariantNumeric,
+				validateFontIsLoaded,
+				textTransform,
+				additionalStyles,
+			};
+
+			const wordAloneWidth = measureText(wordForNewLine).width;
+
+			if (Math.ceil(wordAloneWidth) > maxBoxWidth) {
+				return {exceedsBox: true, newLine: false};
+			}
+
+			lines[currentlyAt + 1] = [wordForNewLine];
+
 			return {exceedsBox: false, newLine: true};
 		},
 	};

--- a/packages/layout-utils/src/test/Root.tsx
+++ b/packages/layout-utils/src/test/Root.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {Composition, Folder} from 'remotion';
+import {issue7359FitTextOnNLines} from './fixtures/issue-7359-fit-text-on-n-lines';
+import {longUnbreakableTokenFitText} from './fixtures/long-unbreakable-token-fit-text';
+
+export const Root: React.FC = () => {
+	return (
+		<Folder name="layout-utils">
+			<Composition {...issue7359FitTextOnNLines} />
+			<Composition {...longUnbreakableTokenFitText} />
+		</Folder>
+	);
+};

--- a/packages/layout-utils/src/test/fit-text-on-n-lines.test.ts
+++ b/packages/layout-utils/src/test/fit-text-on-n-lines.test.ts
@@ -1,0 +1,84 @@
+import {expect, test} from 'vitest';
+import {fitTextOnNLines} from '../layouts/fit-text-on-n-lines';
+import {measureText} from '../layouts/measure-text';
+
+const assertLinesFitBox = ({
+	lines,
+	maxBoxWidth,
+	fontFamily,
+	fontWeight,
+	fontSize,
+	textTransform,
+}: {
+	lines: string[];
+	maxBoxWidth: number;
+	fontFamily: string;
+	fontWeight?: number | string;
+	fontSize: number;
+	textTransform?: 'uppercase' | 'none' | 'lowercase';
+}) => {
+	for (const line of lines) {
+		const width = Math.ceil(
+			measureText({
+				text: line,
+				fontFamily,
+				fontWeight,
+				fontSize,
+				textTransform,
+			}).width,
+		);
+
+		expect(width).toBeLessThanOrEqual(maxBoxWidth);
+	}
+};
+
+test('issue #7359: long unbreakable word must not exceed maxBoxWidth on any line', () => {
+	const maxBoxWidth = 756;
+	const fontFamily = 'Verdana, sans-serif';
+	const fontWeight = '900';
+	const textTransform = 'uppercase' as const;
+
+	const result = fitTextOnNLines({
+		text: 'microtext  abcdefghijklmnopq',
+		maxLines: 2,
+		maxBoxWidth,
+		maxFontSize: 80,
+		fontFamily,
+		fontWeight,
+		textTransform,
+	});
+
+	expect(result.lines.length).toBeLessThanOrEqual(2);
+	assertLinesFitBox({
+		lines: result.lines,
+		maxBoxWidth,
+		fontFamily,
+		fontWeight,
+		fontSize: result.fontSize,
+		textTransform,
+	});
+});
+
+test('long URL-like token on second line still fits within maxBoxWidth', () => {
+	const maxBoxWidth = 420;
+	const fontFamily = 'Verdana, sans-serif';
+	const fontWeight = '700';
+
+	const result = fitTextOnNLines({
+		text: 'short  https://example.com/very-long-path-segment-that-must-shrink',
+		maxLines: 2,
+		maxBoxWidth,
+		maxFontSize: 48,
+		fontFamily,
+		fontWeight,
+	});
+
+	expect(result.lines.length).toBeLessThanOrEqual(2);
+	assertLinesFitBox({
+		lines: result.lines,
+		maxBoxWidth,
+		fontFamily,
+		fontWeight,
+		fontSize: result.fontSize,
+	});
+});

--- a/packages/layout-utils/src/test/fixtures/issue-7359-fit-text-on-n-lines.tsx
+++ b/packages/layout-utils/src/test/fixtures/issue-7359-fit-text-on-n-lines.tsx
@@ -1,0 +1,64 @@
+import React, {useMemo} from 'react';
+import {AbsoluteFill} from 'remotion';
+import {fitTextOnNLines} from '../../layouts/fit-text-on-n-lines';
+
+const BOX_WIDTH = 756;
+
+const Component: React.FC = () => {
+	const {fontSize, lines} = useMemo(
+		() =>
+			fitTextOnNLines({
+				text: 'microtext  abcdefghijklmnopq',
+				maxLines: 2,
+				maxBoxWidth: BOX_WIDTH,
+				maxFontSize: 80,
+				fontFamily: 'Verdana',
+				fontWeight: '900',
+				textTransform: 'uppercase',
+			}),
+		[],
+	);
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: '#111',
+				justifyContent: 'center',
+				alignItems: 'center',
+			}}
+		>
+			<div
+				style={{
+					width: BOX_WIDTH,
+					outline: '2px solid #6f6',
+					color: '#fff',
+					fontFamily: 'Verdana, sans-serif',
+					fontWeight: 900,
+					textTransform: 'uppercase',
+				}}
+			>
+				{lines.map((line) => (
+					<div
+						key={line}
+						style={{
+							fontSize,
+							lineHeight: 1.25,
+							whiteSpace: 'pre',
+						}}
+					>
+						{line}
+					</div>
+				))}
+			</div>
+		</AbsoluteFill>
+	);
+};
+
+export const issue7359FitTextOnNLines = {
+	component: Component,
+	id: 'issue-7359-fit-text-on-n-lines',
+	width: 1280,
+	height: 720,
+	fps: 30,
+	durationInFrames: 90,
+} as const;

--- a/packages/layout-utils/src/test/fixtures/long-unbreakable-token-fit-text.tsx
+++ b/packages/layout-utils/src/test/fixtures/long-unbreakable-token-fit-text.tsx
@@ -1,0 +1,63 @@
+import React, {useMemo} from 'react';
+import {AbsoluteFill} from 'remotion';
+import {fitTextOnNLines} from '../../layouts/fit-text-on-n-lines';
+
+const BOX_WIDTH = 420;
+
+const Component: React.FC = () => {
+	const {fontSize, lines} = useMemo(
+		() =>
+			fitTextOnNLines({
+				text: 'short  https://example.com/very-long-path-segment-that-must-shrink',
+				maxLines: 2,
+				maxBoxWidth: BOX_WIDTH,
+				maxFontSize: 48,
+				fontFamily: 'Verdana, sans-serif',
+				fontWeight: '700',
+			}),
+		[],
+	);
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: '#0b1020',
+				justifyContent: 'center',
+				alignItems: 'center',
+			}}
+		>
+			<div
+				style={{
+					width: BOX_WIDTH,
+					outline: '2px solid #8af',
+					color: '#e8eefc',
+					fontFamily: 'Verdana, sans-serif',
+					fontWeight: 700,
+				}}
+			>
+				{lines.map((line) => (
+					<div
+						key={line}
+						style={{
+							fontSize,
+							lineHeight: 1.25,
+							whiteSpace: 'pre',
+							wordBreak: 'keep-all',
+						}}
+					>
+						{line}
+					</div>
+				))}
+			</div>
+		</AbsoluteFill>
+	);
+};
+
+export const longUnbreakableTokenFitText = {
+	component: Component,
+	id: 'long-unbreakable-token-fit-text',
+	width: 1280,
+	height: 720,
+	fps: 30,
+	durationInFrames: 90,
+} as const;

--- a/packages/layout-utils/src/test/studio.ts
+++ b/packages/layout-utils/src/test/studio.ts
@@ -1,0 +1,4 @@
+import {registerRoot} from 'remotion';
+import {Root} from './Root';
+
+registerRoot(Root);

--- a/packages/layout-utils/vitest.config.ts
+++ b/packages/layout-utils/vitest.config.ts
@@ -1,0 +1,39 @@
+import react from '@vitejs/plugin-react';
+import {playwright} from '@vitest/browser-playwright';
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		maxWorkers: process.env.CI ? 1 : 5,
+		browser: {
+			enabled: true,
+			provider: playwright(),
+			instances: [
+				{
+					browser: 'chromium',
+					provider: playwright({
+						launchOptions: {
+							channel: 'chrome',
+						},
+						actionTimeout: 5_000,
+					}),
+					viewport: {width: 1280, height: 720},
+				} as const,
+				{
+					browser: 'firefox',
+					viewport: {width: 1280, height: 720},
+				} as const,
+				{
+					browser: 'webkit',
+					viewport: {width: 1280, height: 720},
+				} as const,
+			],
+			headless: true,
+			screenshotFailures: false,
+		},
+	},
+	esbuild: {
+		target: 'es2022',
+	},
+	plugins: [react()],
+});

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,9 @@
 		"testwebrenderer": {
 			"dependsOn": ["@remotion/web-renderer#make"]
 		},
+		"testlayoututils": {
+			"dependsOn": ["@remotion/layout-utils#make"]
+		},
 		"build": {
 			"dependsOn": ["^make"],
 			"outputs": ["dist"],


### PR DESCRIPTION
## Summary

- Fixes https://github.com/remotion-dev/remotion/issues/7359: `fillTextBox.add()` now measures the trimmed word by itself before accepting a line wrap, so `fitTextOnNLines()` binary search cannot settle on a font size where a long unbreakable token still exceeds `maxBoxWidth`.
- Treats a line whose width equals `maxBoxWidth` as fitting (`<=` instead of strict `<`).
- Adds a Remotion studio testbed under `packages/layout-utils/src/test` (same pattern as `@remotion/web-renderer`) plus Vitest **browser** mode (Chromium / Firefox / WebKit) and a root `bun run testlayoututils` Turbo task.

## Test plan

- [x] `bun run testlayoututils` (or `cd packages/layout-utils && bun run testlayoututils`)
- [ ] Optional: `cd packages/layout-utils && bun run studio` to visually inspect the two compositions

Made with [Cursor](https://cursor.com)