### PR TITLE
`@remotion/skills-evals`: Add per-run timing

### DIFF
--- a/packages/skills-evals/src/app/comparison.tsx
+++ b/packages/skills-evals/src/app/comparison.tsx
@@ -3,7 +3,15 @@ import {
 	getPreferredArtifact,
 	type ComparisonWithManifests,
 } from './comparison-data';
-import {formatDate, Header, page, Pill, toFileUrl} from './shared';
+import {
+	formatDate,
+	formatDuration,
+	getDurationMs,
+	Header,
+	page,
+	Pill,
+	toFileUrl,
+} from './shared';
 
 const Artifact = ({manifest}: {manifest: SkillEvalManifest}) => {
 	const artifact = getPreferredArtifact(manifest);
@@ -50,12 +58,14 @@ const RunPanel = ({
 	manifestPath: string;
 }) => {
 	const artifact = getPreferredArtifact(manifest);
+	const duration = formatDuration(getDurationMs(manifest));
 
 	return (
 		<section className="rounded-2xl border border-zinc-200 bg-white p-3">
 			<div className="mb-2 flex items-center justify-between gap-3">
 				<h2 className="text-[0.9375rem] font-semibold">{label}</h2>
 				<div className="flex flex-wrap items-center gap-3">
+					<Pill>Took {duration}</Pill>
 					<a
 						className="text-[0.8125rem] text-zinc-600"
 						href={toFileUrl(manifest.pi.htmlExport)}

--- a/packages/skills-evals/src/app/jobs.ts
+++ b/packages/skills-evals/src/app/jobs.ts
@@ -208,14 +208,12 @@ export const startComparison = (
 
 		if (event.type === 'run-complete') {
 			completeJobRun(run, event.completedAt);
-			run.durationMs = event.durationMs;
 			run.message = `${formatRunLabel(event.label)} complete.`;
 			updateJobMessage();
 			return;
 		}
 
 		failJobRun(run, event.completedAt);
-		run.durationMs = event.durationMs;
 		run.message = event.error;
 		updateJobMessage();
 	};

--- a/packages/skills-evals/src/app/jobs.ts
+++ b/packages/skills-evals/src/app/jobs.ts
@@ -34,8 +34,11 @@ export type JobRunGroup = {
 };
 
 export type JobRun = {
+	completedAt?: string;
+	durationMs?: number;
 	logs: string[];
 	message: string;
+	startedAt?: string;
 	status: 'completed' | 'failed' | 'running' | 'waiting';
 };
 
@@ -53,6 +56,34 @@ const createJobRun = (): JobRun => ({
 	message: 'Waiting to start',
 	status: 'waiting',
 });
+
+const startJobRun = (run: JobRun, startedAt = new Date().toISOString()) => {
+	run.completedAt = undefined;
+	run.durationMs = undefined;
+	run.startedAt = startedAt;
+	run.status = 'running';
+};
+
+const completeJobRun = (
+	run: JobRun,
+	completedAt = new Date().toISOString(),
+) => {
+	run.completedAt = completedAt;
+	run.durationMs =
+		run.startedAt === undefined
+			? undefined
+			: new Date(completedAt).getTime() - new Date(run.startedAt).getTime();
+	run.status = 'completed';
+};
+
+const failJobRun = (run: JobRun, completedAt = new Date().toISOString()) => {
+	run.completedAt = completedAt;
+	run.durationMs =
+		run.startedAt === undefined
+			? undefined
+			: new Date(completedAt).getTime() - new Date(run.startedAt).getTime();
+	run.status = 'failed';
+};
 
 export const createJobRuns = (runCount = 1): JobRunGroup[] =>
 	Array.from({length: runCount}, (_, index) => ({
@@ -151,7 +182,7 @@ export const startComparison = (
 		}
 
 		if (event.type === 'run-start') {
-			run.status = 'running';
+			startJobRun(run, event.startedAt);
 			run.message = `${formatRunLabel(event.label)} is generating.`;
 			updateJobMessage();
 			return;
@@ -176,13 +207,15 @@ export const startComparison = (
 		}
 
 		if (event.type === 'run-complete') {
-			run.status = 'completed';
+			completeJobRun(run, event.completedAt);
+			run.durationMs = event.durationMs;
 			run.message = `${formatRunLabel(event.label)} complete.`;
 			updateJobMessage();
 			return;
 		}
 
-		run.status = 'failed';
+		failJobRun(run, event.completedAt);
+		run.durationMs = event.durationMs;
 		run.message = event.error;
 		updateJobMessage();
 	};
@@ -253,6 +286,7 @@ export const startRun = (
 			}
 
 			try {
+				startJobRun(run);
 				const result = await runSkillEval({
 					...scenario,
 					onPhase: (event) => {
@@ -283,11 +317,11 @@ export const startRun = (
 					},
 				});
 
-				run.status = 'completed';
+				completeJobRun(run);
 				run.message = 'Run complete.';
 				return result;
 			} catch (error) {
-				run.status = 'failed';
+				failJobRun(run);
 				run.message = error instanceof Error ? error.message : String(error);
 				throw error;
 			}
@@ -318,7 +352,7 @@ export const startRun = (
 				const run = runGroup.after;
 
 				if (run.status === 'running' || run.status === 'waiting') {
-					run.status = 'failed';
+					failJobRun(run);
 					run.message = job.error;
 				}
 			}

--- a/packages/skills-evals/src/app/run.tsx
+++ b/packages/skills-evals/src/app/run.tsx
@@ -3,7 +3,16 @@ import {join} from 'node:path';
 import {readJson, sanitizePathPart} from '../files';
 import type {SkillEvalManifest} from '../manifest';
 import {getPreferredArtifact} from './comparison-data';
-import {Card, Header, page, runsRoot, toFileUrl} from './shared';
+import {
+	Card,
+	formatDuration,
+	getDurationMs,
+	Header,
+	page,
+	Pill,
+	runsRoot,
+	toFileUrl,
+} from './shared';
 
 export const loadRun = async (scenarioId: string, runId: string) => {
 	const manifestPath = join(
@@ -64,6 +73,7 @@ export const renderRun = (manifest: SkillEvalManifest) =>
 				<Header
 					action={
 						<div className="flex flex-wrap items-center gap-3">
+							<Pill>Took {formatDuration(getDurationMs(manifest))}</Pill>
 							<a
 								className="text-[0.8125rem] text-zinc-600"
 								href={`/scenarios/${encodeURIComponent(manifest.id)}`}

--- a/packages/skills-evals/src/app/scenario.tsx
+++ b/packages/skills-evals/src/app/scenario.tsx
@@ -16,6 +16,7 @@ import {
 import {
 	Card,
 	formatDate,
+	formatDuration,
 	Header,
 	page,
 	repoRoot,
@@ -138,6 +139,29 @@ const ScenarioRuns = ({items}: {items: ScenarioRunListItem[]}) => {
 	);
 };
 
+const getJobRunDurationMs = (jobRun: JobRun) => {
+	if (jobRun.durationMs !== undefined) {
+		return jobRun.durationMs;
+	}
+
+	if (jobRun.status === 'running' && jobRun.startedAt) {
+		return Date.now() - new Date(jobRun.startedAt).getTime();
+	}
+
+	return null;
+};
+
+const formatJobRunStatus = (jobRun: JobRun) => {
+	const message = jobRun.message || jobRun.status;
+	const durationMs = getJobRunDurationMs(jobRun);
+
+	if (durationMs === null) {
+		return message;
+	}
+
+	return `${message} - ${formatDuration(durationMs)}`;
+};
+
 const ScenarioPageScript = ({
 	activeJob,
 	baseRef,
@@ -161,6 +185,39 @@ const defaultBaseRef = ${JSON.stringify(baseRef)};
 const shouldStickToBottom = (element) =>
 	element.scrollHeight - element.scrollTop - element.clientHeight < 8;
 
+const formatDuration = (durationMs) => {
+	const totalSeconds = Math.max(0, Math.round(durationMs / 1000));
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+
+	if (hours > 0) {
+		return hours + 'h ' + minutes + 'm ' + seconds + 's';
+	}
+
+	if (minutes > 0) {
+		return minutes + 'm ' + seconds + 's';
+	}
+
+	return seconds + 's';
+};
+const getRunDurationMs = (run) => {
+	if (typeof run.durationMs === 'number') {
+		return run.durationMs;
+	}
+
+	if (run.status === 'running' && run.startedAt) {
+		return Date.now() - new Date(run.startedAt).getTime();
+	}
+
+	return null;
+};
+const formatRunStatus = (run) => {
+	const message = run.message || run.status;
+	const durationMs = getRunDurationMs(run);
+
+	return durationMs === null ? message : message + ' - ' + formatDuration(durationMs);
+};
 const formatLabel = (label) => label === 'before' ? 'Before' : 'After';
 const createRunPanel = (runGroup, label) => {
 	const run = runGroup[label];
@@ -179,7 +236,7 @@ const createRunPanel = (runGroup, label) => {
 	pill.className = 'rounded-full bg-zinc-50 px-2 py-1 text-xs text-zinc-500 data-[status=completed]:text-emerald-700 data-[status=failed]:text-red-700 data-[status=running]:text-yellow-700';
 	pill.dataset.runStatus = label;
 	pill.dataset.status = run.status;
-	pill.textContent = run.message || run.status;
+	pill.textContent = formatRunStatus(run);
 
 	header.append(title, pill);
 	section.append(header);
@@ -220,7 +277,7 @@ const updateRunPanel = (section, runGroup, label) => {
 	const logText = run.logs?.join('') || '';
 
 	pill.dataset.status = run.status;
-	pill.textContent = run.message || run.status;
+	pill.textContent = formatRunStatus(run);
 
 	if (pre.textContent !== logText) {
 		const stickToBottom = shouldStickToBottom(pre);
@@ -361,7 +418,7 @@ const RunProgressCard = ({
 				data-run-status={label}
 				data-status={jobRun.status}
 			>
-				{jobRun.message}
+				{formatJobRunStatus(jobRun)}
 			</span>
 		</div>
 		<pre

--- a/packages/skills-evals/src/app/shared.tsx
+++ b/packages/skills-evals/src/app/shared.tsx
@@ -96,6 +96,31 @@ export const formatDate = (value: string) =>
 		timeStyle: 'medium',
 	}).format(new Date(value));
 
+export const formatDuration = (durationMs: number) => {
+	const totalSeconds = Math.max(0, Math.round(durationMs / 1000));
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+
+	if (hours > 0) {
+		return `${hours}h ${minutes}m ${seconds}s`;
+	}
+
+	if (minutes > 0) {
+		return `${minutes}m ${seconds}s`;
+	}
+
+	return `${seconds}s`;
+};
+
+export const getDurationMs = ({
+	completedAt,
+	createdAt,
+}: {
+	completedAt: string;
+	createdAt: string;
+}) => new Date(completedAt).getTime() - new Date(createdAt).getTime();
+
 export const toFileUrl = (file: string) => {
 	const relativePath = relative(runsRoot, file);
 

--- a/packages/skills-evals/src/compare.ts
+++ b/packages/skills-evals/src/compare.ts
@@ -52,7 +52,7 @@ export type SkillEvalComparisonEvent =
 	  }
 	| {
 			completedAt: string;
-			durationMs?: number;
+			durationMs: number;
 			error: string;
 			label: SkillEvalComparisonRunLabel;
 			runIndex: number;

--- a/packages/skills-evals/src/compare.ts
+++ b/packages/skills-evals/src/compare.ts
@@ -28,6 +28,7 @@ export type SkillEvalComparisonEvent =
 	| {
 			label: SkillEvalComparisonRunLabel;
 			runIndex: number;
+			startedAt: string;
 			type: 'run-start';
 	  }
 	| {
@@ -43,11 +44,15 @@ export type SkillEvalComparisonEvent =
 			type: 'run-output';
 	  }
 	| {
+			completedAt: string;
+			durationMs: number;
 			label: SkillEvalComparisonRunLabel;
 			runIndex: number;
 			type: 'run-complete';
 	  }
 	| {
+			completedAt: string;
+			durationMs?: number;
 			error: string;
 			label: SkillEvalComparisonRunLabel;
 			runIndex: number;
@@ -219,8 +224,10 @@ export const runSkillEvalComparison = async (
 	const runSnapshot = async ({label, runIndex}: SnapshotTask) => {
 		const controller = new AbortController();
 		abortControllers.add(controller);
+		const startedAtMs = Date.now();
+		const startedAt = new Date(startedAtMs).toISOString();
 		emitMessage(`[compare] Running ${formatRun(label, runIndex)} snapshot\n`);
-		options.onEvent?.({label, runIndex, type: 'run-start'});
+		options.onEvent?.({label, runIndex, startedAt, type: 'run-start'});
 
 		try {
 			const result = await runSkillEval({
@@ -247,10 +254,20 @@ export const runSkillEvalComparison = async (
 					label === 'before' ? beforeSkillsPath : afterSkillsPath,
 			});
 
-			options.onEvent?.({label, runIndex, type: 'run-complete'});
+			const completedAtMs = Date.now();
+			options.onEvent?.({
+				completedAt: new Date(completedAtMs).toISOString(),
+				durationMs: completedAtMs - startedAtMs,
+				label,
+				runIndex,
+				type: 'run-complete',
+			});
 			return {label, result, runIndex};
 		} catch (error) {
+			const completedAtMs = Date.now();
 			options.onEvent?.({
+				completedAt: new Date(completedAtMs).toISOString(),
+				durationMs: completedAtMs - startedAtMs,
 				error: getErrorMessage(error),
 				label,
 				runIndex,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add per-run start/end/duration tracking for skills eval jobs.
- Show live elapsed/final timing in active run panels.
- Show manifest-derived duration pills on completed comparison and run pages.
- Address pullfrog review feedback by removing redundant duration overwrites and making error event duration non-optional.

## Walkthrough
[skills_evals_comparison_run_timing_demo.mp4](https://cursor.com/agents/bc-9b442667-ebd0-4824-b52a-68319f4b16a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskills_evals_comparison_run_timing_demo.mp4)
[skills_evals_per_run_timing_demo.mp4](https://cursor.com/agents/bc-9b442667-ebd0-4824-b52a-68319f4b16a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskills_evals_per_run_timing_demo.mp4)

## Testing
- `bun run build`
- `bun run format` in `packages/skills-evals`
- `bun run lint` in `packages/skills-evals`
- `bun run stylecheck` (fails only at known `@remotion/lambda-go` Go 1.23 requirement; `@remotion/skills-evals` formatting passed)
- Manual browser smoke test using a temporary fake `pi` executable and temporary local scenario, removed before commit

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b442667-ebd0-4824-b52a-68319f4b16a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b442667-ebd0-4824-b52a-68319f4b16a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

