### PR TITLE
Auto-register Composition in Root.tsx on "New Folder"

### DIFF
--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -29,7 +29,11 @@ import {
 	getCompletedClientRenders,
 	removeCompletedClientRender,
 } from './client-render-queue';
-import {parseAndApplyCodemod} from './codemods/duplicate-composition';
+import {
+	formatOutput,
+	parseAndApplyCodemod,
+} from './codemods/duplicate-composition';
+import {updateDefaultProps} from './codemods/update-default-props';
 import {
 	createFileWatcherRegistry,
 	installFileWatcher,
@@ -70,6 +74,8 @@ export const StudioServerInternals = {
 	AnsiDiff,
 	formatBytes,
 	parseAndApplyCodemod,
+	formatOutput,
+	updateDefaultProps,
 	getInstalledDependencies,
 	getInstalledDependenciesWithVersions,
 	getInstallCommand,

--- a/packages/template-recorder/scripts/server/create-project.ts
+++ b/packages/template-recorder/scripts/server/create-project.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync } from "fs";
 import { IncomingMessage, ServerResponse } from "http";
 import path from "path";
+import { registerComposition } from "./register-composition";
 
 export const createProject = async (
   req: IncomingMessage,
@@ -46,11 +47,25 @@ export const createProject = async (
 
   try {
     mkdirSync(finalPath);
+
+    let registrationMessage = "";
+    try {
+      const result = registerComposition({ rootDir, projectName });
+      if (result.registered) {
+        registrationMessage =
+          " Composition registered in remotion/Root.tsx.";
+      } else if (result.reason && result.reason !== "Composition already exists") {
+        registrationMessage = ` Folder created but composition was not registered: ${result.reason}. Edit remotion/Root.tsx manually to add it.`;
+      }
+    } catch (err) {
+      registrationMessage = ` Folder created but composition registration threw: ${(err as Error).message}.`;
+    }
+
     res.statusCode = 201;
     res.write(
       JSON.stringify({
         success: true,
-        message: `Project "${projectName}" created successfully.`,
+        message: `Project "${projectName}" created successfully.${registrationMessage}`,
       }),
     );
     return res.end();

--- a/packages/template-recorder/scripts/server/create-project.ts
+++ b/packages/template-recorder/scripts/server/create-project.ts
@@ -50,11 +50,14 @@ export const createProject = async (
 
     let registrationMessage = "";
     try {
-      const result = registerComposition({ rootDir, projectName });
+      const result = await registerComposition({ rootDir, projectName });
       if (result.registered) {
         registrationMessage =
           " Composition registered in remotion/Root.tsx.";
-      } else if (result.reason && result.reason !== "Composition already exists") {
+      } else if (
+        result.reason &&
+        result.reason !== "Composition already exists"
+      ) {
         registrationMessage = ` Folder created but composition was not registered: ${result.reason}. Edit remotion/Root.tsx manually to add it.`;
       }
     } catch (err) {

--- a/packages/template-recorder/scripts/server/register-composition.ts
+++ b/packages/template-recorder/scripts/server/register-composition.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import path from "path";
+
+const ROOT_RELATIVE_PATH = path.join("remotion", "Root.tsx");
+const TEMPLATE_COMPOSITION_ID = "empty";
+
+const findEmptyCompositionBlock = (src: string): string | null => {
+  const idMarker = `id="${TEMPLATE_COMPOSITION_ID}"`;
+  const idIndex = src.indexOf(idMarker);
+  if (idIndex === -1) {
+    return null;
+  }
+
+  const startIndex = src.lastIndexOf("<Composition", idIndex);
+  if (startIndex === -1) {
+    return null;
+  }
+
+  const endMarker = "/>";
+  const endIndex = src.indexOf(endMarker, idIndex);
+  if (endIndex === -1) {
+    return null;
+  }
+
+  return src.slice(startIndex, endIndex + endMarker.length);
+};
+
+export const registerComposition = ({
+  rootDir,
+  projectName,
+}: {
+  rootDir: string;
+  projectName: string;
+}): { registered: boolean; reason?: string } => {
+  const rootPath = path.join(rootDir, ROOT_RELATIVE_PATH);
+
+  if (!existsSync(rootPath)) {
+    return { registered: false, reason: "Root.tsx not found" };
+  }
+
+  const src = readFileSync(rootPath, "utf-8");
+
+  if (src.includes(`id="${projectName}"`)) {
+    return { registered: false, reason: "Composition already exists" };
+  }
+
+  const emptyBlock = findEmptyCompositionBlock(src);
+  if (!emptyBlock) {
+    return {
+      registered: false,
+      reason: 'Could not find <Composition id="empty"> to clone',
+    };
+  }
+
+  const defaultVideoScene = `          scenes: [
+            {
+              type: "videoscene" as const,
+              webcamPosition: "bottom-right" as const,
+              endOffset: 0,
+              transitionToNextScene: false,
+              newChapter: "",
+              stopChapteringAfterThis: false,
+              music: "none" as const,
+              startOffset: 0,
+              bRolls: [],
+            },
+          ],`;
+
+  const cloned = emptyBlock
+    .replace(
+      `id="${TEMPLATE_COMPOSITION_ID}"`,
+      `id="${projectName}"`,
+    )
+    .replace("          scenes: [],", defaultVideoScene);
+
+  const newSrc = src.replace(emptyBlock, `${cloned}\n      ${emptyBlock}`);
+
+  writeFileSync(rootPath, newSrc, "utf-8");
+  return { registered: true };
+};

--- a/packages/template-recorder/scripts/server/register-composition.ts
+++ b/packages/template-recorder/scripts/server/register-composition.ts
@@ -1,37 +1,45 @@
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import path from "path";
+import { StudioServerInternals } from "@remotion/studio-server";
 
 const ROOT_RELATIVE_PATH = path.join("remotion", "Root.tsx");
 const TEMPLATE_COMPOSITION_ID = "empty";
 
-const findEmptyCompositionBlock = (src: string): string | null => {
-  const idMarker = `id="${TEMPLATE_COMPOSITION_ID}"`;
-  const idIndex = src.indexOf(idMarker);
-  if (idIndex === -1) {
-    return null;
-  }
-
-  const startIndex = src.lastIndexOf("<Composition", idIndex);
-  if (startIndex === -1) {
-    return null;
-  }
-
-  const endMarker = "/>";
-  const endIndex = src.indexOf(endMarker, idIndex);
-  if (endIndex === -1) {
-    return null;
-  }
-
-  return src.slice(startIndex, endIndex + endMarker.length);
+const compositionExists = (src: string, compositionId: string) => {
+  return (
+    src.includes(`id="${compositionId}"`) ||
+    src.includes(`id={'${compositionId}'}`) ||
+    src.includes(`id={"${compositionId}"}`)
+  );
 };
 
-export const registerComposition = ({
+const getDefaultPropsForNewProject = () => ({
+  theme: "light",
+  canvasLayout: "square",
+  platform: "youtube",
+  scenes: [
+    {
+      type: "videoscene",
+      webcamPosition: "bottom-right",
+      endOffset: 0,
+      transitionToNextScene: false,
+      newChapter: "",
+      stopChapteringAfterThis: false,
+      music: "none",
+      startOffset: 0,
+      bRolls: [],
+    },
+  ],
+  scenesAndMetadata: [],
+});
+
+export const registerComposition = async ({
   rootDir,
   projectName,
 }: {
   rootDir: string;
   projectName: string;
-}): { registered: boolean; reason?: string } => {
+}): Promise<{ registered: boolean; reason?: string }> => {
   const rootPath = path.join(rootDir, ROOT_RELATIVE_PATH);
 
   if (!existsSync(rootPath)) {
@@ -40,41 +48,44 @@ export const registerComposition = ({
 
   const src = readFileSync(rootPath, "utf-8");
 
-  if (src.includes(`id="${projectName}"`)) {
+  if (compositionExists(src, projectName)) {
     return { registered: false, reason: "Composition already exists" };
   }
 
-  const emptyBlock = findEmptyCompositionBlock(src);
-  if (!emptyBlock) {
+  try {
+    const { newContents: duplicated } =
+      StudioServerInternals.parseAndApplyCodemod({
+        input: src,
+        codeMod: {
+          type: "duplicate-composition",
+          idToDuplicate: TEMPLATE_COMPOSITION_ID,
+          newId: projectName,
+          newHeight: null,
+          newWidth: null,
+          newFps: null,
+          newDurationInFrames: null,
+          tag: "Composition",
+        },
+      });
+
+    const { output: withDefaultScene } =
+      await StudioServerInternals.updateDefaultProps({
+        input: duplicated,
+        compositionId: projectName,
+        newDefaultProps: getDefaultPropsForNewProject(),
+        enumPaths: [],
+      });
+
+    const formatted = await StudioServerInternals.formatOutput(
+      withDefaultScene,
+    );
+
+    writeFileSync(rootPath, formatted, "utf-8");
+    return { registered: true };
+  } catch (err) {
     return {
       registered: false,
-      reason: 'Could not find <Composition id="empty"> to clone',
+      reason: err instanceof Error ? err.message : String(err),
     };
   }
-
-  const defaultVideoScene = `          scenes: [
-            {
-              type: "videoscene" as const,
-              webcamPosition: "bottom-right" as const,
-              endOffset: 0,
-              transitionToNextScene: false,
-              newChapter: "",
-              stopChapteringAfterThis: false,
-              music: "none" as const,
-              startOffset: 0,
-              bRolls: [],
-            },
-          ],`;
-
-  const cloned = emptyBlock
-    .replace(
-      `id="${TEMPLATE_COMPOSITION_ID}"`,
-      `id="${projectName}"`,
-    )
-    .replace("          scenes: [],", defaultVideoScene);
-
-  const newSrc = src.replace(emptyBlock, `${cloned}\n      ${emptyBlock}`);
-
-  writeFileSync(rootPath, newSrc, "utf-8");
-  return { registered: true };
 };


### PR DESCRIPTION
Closes #7411

Moved from remotion-dev/recorder#148 (recorder now lives in `packages/template-recorder`).

Patches `packages/template-recorder/remotion/Root.tsx` automatically when the existing `POST /api/create-folder` endpoint succeeds:

1. Find the `<Composition id="empty">` block.
2. Clone it with the new folder name as the id.
3. Pre-populate `scenes` with one default `videoscene` so the just-recorded take is immediately playable.
4. Inject the cloned block above the `empty` composition.

Idempotent, falls back to a clear response message if `Root.tsx` can't be parsed, no new deps.

## Test plan
- [ ] Create a new folder via the Recorder UI
- [ ] Confirm `remotion/Root.tsx` gains a new `<Composition>` with the folder name
- [ ] Record and save a take; confirm it appears in Studio without manual edits
- [ ] Create the same folder name again; confirm idempotent behavior (no duplicate composition)

Made with [Cursor](https://cursor.com)