### PR TITLE
`remotion`: Add sequence schema to AnimatedImage

### DIFF
--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -7,17 +7,39 @@ import {
 	useState,
 } from 'react';
 import {cancelRender} from '../cancel-render.js';
+import type {SequenceControls} from '../CompositionManager.js';
+import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
+import {
+	hiddenField,
+	sequenceStyleSchema,
+	type SequenceSchema,
+} from '../sequence-field-schema.js';
+import {Sequence} from '../Sequence.js';
 import {useCurrentFrame} from '../use-current-frame.js';
 import {useDelayRender} from '../use-delay-render.js';
 import {useVideoConfig} from '../use-video-config.js';
+import {wrapInSchema} from '../wrap-in-schema.js';
 import type {AnimatedImageCanvasRef} from './canvas';
 import {Canvas} from './canvas';
 import type {RemotionImageDecoder} from './decode-image.js';
 import {decodeImage} from './decode-image.js';
-import type {RemotionAnimatedImageProps} from './props';
+import type {AnimatedImageProps, RemotionAnimatedImageProps} from './props';
 import {resolveAnimatedImageSource} from './resolve-image-source';
 
-export const AnimatedImage = forwardRef<
+const animatedImageSchema = {
+	playbackRate: {
+		type: 'number',
+		min: 0,
+		max: 10,
+		step: 0.1,
+		default: 1,
+		description: 'Playback Rate',
+	},
+	...sequenceStyleSchema,
+	hidden: hiddenField,
+} as const satisfies SequenceSchema;
+
+const AnimatedImageContent = forwardRef<
 	HTMLCanvasElement,
 	RemotionAnimatedImageProps
 >(
@@ -155,3 +177,70 @@ export const AnimatedImage = forwardRef<
 		);
 	},
 );
+
+AnimatedImageContent.displayName = 'AnimatedImageContent';
+
+const AnimatedImageInner = forwardRef<
+	HTMLCanvasElement,
+	AnimatedImageProps & {
+		readonly _experimentalControls?: SequenceControls | undefined;
+	}
+>(
+	(
+		{
+			src,
+			width,
+			height,
+			onError,
+			fit,
+			playbackRate,
+			loopBehavior,
+			id,
+			className,
+			style,
+			durationInFrames,
+			_experimentalControls: controls,
+			...sequenceProps
+		},
+		ref,
+	) => {
+		const {durationInFrames: videoDuration} = useVideoConfig();
+		const resolvedDuration = durationInFrames ?? videoDuration;
+
+		const animatedImageProps: RemotionAnimatedImageProps = {
+			src,
+			width,
+			height,
+			onError,
+			fit,
+			playbackRate,
+			loopBehavior,
+			id,
+			className,
+			style,
+		};
+
+		return (
+			<Sequence
+				layout="none"
+				durationInFrames={resolvedDuration}
+				name="<AnimatedImage>"
+				_experimentalControls={controls}
+				{...sequenceProps}
+			>
+				<AnimatedImageContent {...animatedImageProps} ref={ref} />
+			</Sequence>
+		);
+	},
+);
+
+AnimatedImageInner.displayName = 'AnimatedImage';
+
+export const AnimatedImage = wrapInSchema(
+	AnimatedImageInner,
+	animatedImageSchema,
+);
+
+AnimatedImage.displayName = 'AnimatedImage';
+
+addSequenceStackTraces(AnimatedImage);

--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {
 	forwardRef,
 	useEffect,
@@ -180,61 +181,53 @@ const AnimatedImageContent = forwardRef<
 
 AnimatedImageContent.displayName = 'AnimatedImageContent';
 
-const AnimatedImageInner = forwardRef<
-	HTMLCanvasElement,
-	AnimatedImageProps & {
-		readonly _experimentalControls?: SequenceControls | undefined;
-	}
->(
-	(
-		{
-			src,
-			width,
-			height,
-			onError,
-			fit,
-			playbackRate,
-			loopBehavior,
-			id,
-			className,
-			style,
-			durationInFrames,
-			_experimentalControls: controls,
-			...sequenceProps
-		},
-		ref,
-	) => {
-		const {durationInFrames: videoDuration} = useVideoConfig();
-		const resolvedDuration = durationInFrames ?? videoDuration;
+const AnimatedImageInner = ({
+	src,
+	width,
+	height,
+	onError,
+	fit,
+	playbackRate,
+	loopBehavior,
+	id,
+	className,
+	style,
+	durationInFrames,
+	_experimentalControls: controls,
+	ref,
+	...sequenceProps
+}: AnimatedImageProps & {
+	readonly _experimentalControls?: SequenceControls | undefined;
+	readonly ref?: React.Ref<HTMLCanvasElement>;
+}) => {
+	const {durationInFrames: videoDuration} = useVideoConfig();
+	const resolvedDuration = durationInFrames ?? videoDuration;
 
-		const animatedImageProps: RemotionAnimatedImageProps = {
-			src,
-			width,
-			height,
-			onError,
-			fit,
-			playbackRate,
-			loopBehavior,
-			id,
-			className,
-			style,
-		};
+	const animatedImageProps: RemotionAnimatedImageProps = {
+		src,
+		width,
+		height,
+		onError,
+		fit,
+		playbackRate,
+		loopBehavior,
+		id,
+		className,
+		style,
+	};
 
-		return (
-			<Sequence
-				layout="none"
-				durationInFrames={resolvedDuration}
-				name="<AnimatedImage>"
-				_experimentalControls={controls}
-				{...sequenceProps}
-			>
-				<AnimatedImageContent {...animatedImageProps} ref={ref} />
-			</Sequence>
-		);
-	},
-);
-
-AnimatedImageInner.displayName = 'AnimatedImage';
+	return (
+		<Sequence
+			layout="none"
+			durationInFrames={resolvedDuration}
+			name="<AnimatedImage>"
+			_experimentalControls={controls}
+			{...sequenceProps}
+		>
+			<AnimatedImageContent {...animatedImageProps} ref={ref} />
+		</Sequence>
+	);
+};
 
 export const AnimatedImage = wrapInSchema(
 	AnimatedImageInner,

--- a/packages/core/src/animated-image/index.ts
+++ b/packages/core/src/animated-image/index.ts
@@ -1,1 +1,2 @@
 export {AnimatedImage} from './AnimatedImage';
+export type {AnimatedImageProps} from './props';

--- a/packages/core/src/animated-image/props.ts
+++ b/packages/core/src/animated-image/props.ts
@@ -1,3 +1,5 @@
+import type {SequenceProps} from '../Sequence.js';
+
 export type RemotionAnimatedImageLoopBehavior =
 	| 'loop'
 	| 'pause-after-finish'
@@ -15,5 +17,13 @@ export type RemotionAnimatedImageProps = {
 	id?: string;
 	className?: string;
 };
+
+export type AnimatedImageProps = Omit<
+	SequenceProps,
+	'children' | 'durationInFrames' | 'layout'
+> &
+	RemotionAnimatedImageProps & {
+		readonly durationInFrames?: number;
+	};
 
 export type AnimatedImageFillMode = 'contain' | 'cover' | 'fill';

--- a/packages/example/src/ExperimentalControls/index.tsx
+++ b/packages/example/src/ExperimentalControls/index.tsx
@@ -5,6 +5,7 @@ import {Starburst} from '@remotion/starburst';
 import React from 'react';
 import {
 	AbsoluteFill,
+	AnimatedImage,
 	Html5Audio,
 	Html5Video,
 	HtmlInCanvas,
@@ -141,6 +142,17 @@ export const ExperimentalControlsShowcase: React.FC = () => {
 				</Tile>
 				<Tile title="Gif">
 					<Gif
+						src={staticFile('giphy.gif')}
+						fit="contain"
+						width={400}
+						height={300}
+						style={{
+							translate: '0px 59px',
+						}}
+					/>
+				</Tile>
+				<Tile title="AnimatedImage">
+					<AnimatedImage
 						src={staticFile('giphy.gif')}
 						fit="contain"
 						width={400}


### PR DESCRIPTION
## Summary

- Wraps `<AnimatedImage>` in a `<Sequence layout="none">` with experimental controls, matching the `<Gif>` pattern
- Adds a sequence schema with `playbackRate`, style transforms (`translate`, `scale`, `rotate`, `opacity`), premount, and `hidden` toggles
- Adds `<AnimatedImage>` to the Experimental Controls showcase composition

Fixes #7406

## Test plan

- [ ] Open the `experimental-controls-showcase` composition in Remotion Studio
- [ ] Verify the AnimatedImage tile appears and renders the GIF
- [ ] Use experimental controls to adjust playback rate, opacity, translate, scale, rotation, and hidden
- [ ] Confirm existing AnimatedImage compositions (e.g. `animated-images`) still render correctly


Made with [Cursor](https://cursor.com)