### PR TITLE
`@remotion/example`: Add lightweight E2E testbed entry point

### DIFF
--- a/packages/example/e2e/constants.mts
+++ b/packages/example/e2e/constants.mts
@@ -10,7 +10,8 @@ export const exampleDir = path.resolve(
 	'..',
 );
 
-export const rootFile = path.join(exampleDir, 'src', 'Root.tsx');
+export const rootFile = path.join(exampleDir, 'src', 'E2eTestRoot.tsx');
+export const e2eEntryPoint = path.join(exampleDir, 'src', 'e2e-test-entry.ts');
 export const visualControlsFile = path.join(
 	exampleDir,
 	'src',
@@ -31,7 +32,7 @@ export const LOGS_FILE = path.join(
 );
 export const ORIGINAL_CONTENT_FILE = path.join(
 	os.tmpdir(),
-	'remotion-e2e-original-root.tsx',
+	'remotion-e2e-original-e2e-test-root.tsx',
 );
 export const ORIGINAL_VISUAL_CONTROLS_FILE = path.join(
 	os.tmpdir(),

--- a/packages/example/e2e/global-teardown.mts
+++ b/packages/example/e2e/global-teardown.mts
@@ -8,10 +8,7 @@ import {
 
 export default async function globalTeardown(): Promise<void> {
 	if (fs.existsSync(ORIGINAL_CONTENT_FILE)) {
-		fs.writeFileSync(
-			rootFile,
-			fs.readFileSync(ORIGINAL_CONTENT_FILE, 'utf-8'),
-		);
+		fs.writeFileSync(rootFile, fs.readFileSync(ORIGINAL_CONTENT_FILE, 'utf-8'));
 		fs.unlinkSync(ORIGINAL_CONTENT_FILE);
 	}
 

--- a/packages/example/e2e/helpers.mts
+++ b/packages/example/e2e/helpers.mts
@@ -1,14 +1,9 @@
+import fs from 'fs';
 import {expect} from '@playwright/test';
 import type {Page} from '@playwright/test';
-import fs from 'fs';
 import {LOGS_FILE, STUDIO_URL} from './constants.mts';
 
 export async function navigateToSchemaTest(page: Page): Promise<void> {
-	await page.goto(STUDIO_URL);
-	const schemaFolder = page.getByTitle('Schema');
-	await schemaFolder.click({timeout: 15_000});
-
-	// Wait for the default-props subscription to resolve so that saves work
 	const subscriptionPromise = page.waitForResponse(
 		(resp) =>
 			resp.url().includes('/api/subscribe-to-default-props') &&
@@ -16,21 +11,14 @@ export async function navigateToSchemaTest(page: Page): Promise<void> {
 		{timeout: 15_000},
 	);
 
-	const schemaTestLink = page.getByText('schema-test', {exact: true}).first();
-	await schemaTestLink.click({timeout: 10_000});
-	await expect(page).toHaveURL(/schema-test/, {timeout: 10_000});
+	await page.goto(`${STUDIO_URL}/schema-test`);
+	await expect(page).toHaveURL(/schema-test/, {timeout: 15_000});
 
 	await subscriptionPromise;
 }
 
 export async function navigateToVisualControls(page: Page): Promise<void> {
-	await page.goto(STUDIO_URL);
-	const folder = page.getByTitle('visual-controls');
-	await folder.click({timeout: 15_000});
-	const compositionLink = page.locator(
-		'a.__remotion-composition[data-compname="visual-controls"]',
-	);
-	await compositionLink.click({timeout: 10_000});
+	await page.goto(`${STUDIO_URL}/visual-controls`);
 	await expect(page).toHaveURL(/visual-controls/, {timeout: 10_000});
 }
 

--- a/packages/example/e2e/json-editor.test.mts
+++ b/packages/example/e2e/json-editor.test.mts
@@ -1,5 +1,5 @@
-import {expect, test} from '@playwright/test';
 import fs from 'fs';
+import {expect, test} from '@playwright/test';
 import {EXPANDED_SIDEBAR_STATE, rootFile} from './constants.mts';
 import {navigateToSchemaTest} from './helpers.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
@@ -28,9 +28,7 @@ test.describe('visual mode', () => {
 		await stopStudio();
 	});
 
-	test('should edit props via JSON editor and save on blur', async ({
-		page,
-	}) => {
+	test('should edit props via JSON editor and save on blur', async ({page}) => {
 		const textarea = await openJsonEditor(page);
 
 		const currentJson = await textarea.inputValue();
@@ -51,7 +49,7 @@ test.describe('visual mode', () => {
 					return content.includes(newTitle);
 				},
 				{
-					message: `Expected Root.tsx to contain "${newTitle}" after JSON editor edit`,
+					message: `Expected E2eTestRoot.tsx to contain "${newTitle}" after JSON editor edit`,
 					timeout: 10_000,
 				},
 			)

--- a/packages/example/e2e/schema-editor.test.mts
+++ b/packages/example/e2e/schema-editor.test.mts
@@ -41,7 +41,7 @@ test.describe('visual mode', () => {
 					return content.includes(newTitle);
 				},
 				{
-					message: `Expected Root.tsx to contain "${newTitle}" after prop edit`,
+					message: `Expected E2eTestRoot.tsx to contain "${newTitle}" after prop edit`,
 					timeout: 10_000,
 				},
 			)

--- a/packages/example/e2e/studio-server.mts
+++ b/packages/example/e2e/studio-server.mts
@@ -8,6 +8,7 @@ import {
 	ORIGINAL_VISUAL_CONTROLS_FILE,
 	STUDIO_PORT,
 	STUDIO_URL,
+	e2eEntryPoint,
 	exampleDir,
 	remotionBin,
 	rootFile,
@@ -40,10 +41,7 @@ async function waitForServer(
 export async function startStudio(): Promise<void> {
 	// Save original files if not already saved
 	if (!fs.existsSync(ORIGINAL_CONTENT_FILE)) {
-		fs.writeFileSync(
-			ORIGINAL_CONTENT_FILE,
-			fs.readFileSync(rootFile, 'utf-8'),
-		);
+		fs.writeFileSync(ORIGINAL_CONTENT_FILE, fs.readFileSync(rootFile, 'utf-8'));
 	}
 
 	if (!fs.existsSync(ORIGINAL_VISUAL_CONTROLS_FILE)) {
@@ -54,10 +52,7 @@ export async function startStudio(): Promise<void> {
 	}
 
 	// Restore original files before starting
-	fs.writeFileSync(
-		rootFile,
-		fs.readFileSync(ORIGINAL_CONTENT_FILE, 'utf-8'),
-	);
+	fs.writeFileSync(rootFile, fs.readFileSync(ORIGINAL_CONTENT_FILE, 'utf-8'));
 	fs.writeFileSync(
 		visualControlsFile,
 		fs.readFileSync(ORIGINAL_VISUAL_CONTROLS_FILE, 'utf-8'),
@@ -86,6 +81,7 @@ export async function startStudio(): Promise<void> {
 		remotionBin,
 		[
 			'studio',
+			e2eEntryPoint,
 			'--port',
 			String(STUDIO_PORT),
 			'--props',
@@ -176,10 +172,7 @@ export async function stopStudio(): Promise<void> {
 
 	// Restore original files
 	if (fs.existsSync(ORIGINAL_CONTENT_FILE)) {
-		fs.writeFileSync(
-			rootFile,
-			fs.readFileSync(ORIGINAL_CONTENT_FILE, 'utf-8'),
-		);
+		fs.writeFileSync(rootFile, fs.readFileSync(ORIGINAL_CONTENT_FILE, 'utf-8'));
 	}
 
 	if (fs.existsSync(ORIGINAL_VISUAL_CONTROLS_FILE)) {

--- a/packages/example/e2e/suppress-rebuild.test.mts
+++ b/packages/example/e2e/suppress-rebuild.test.mts
@@ -50,7 +50,7 @@ test.describe('suppress webpack rebuild', () => {
 					return content.includes(`delay: ${newDelay}`);
 				},
 				{
-					message: `Expected Root.tsx to contain "delay: ${newDelay}"`,
+					message: `Expected E2eTestRoot.tsx to contain "delay: ${newDelay}"`,
 					timeout: 10_000,
 				},
 			)
@@ -60,13 +60,9 @@ test.describe('suppress webpack rebuild', () => {
 		await expect
 			.poll(
 				() => {
-					const newLogs = readStudioLogs()
-						.slice(logCountBefore)
-						.map(stripAnsi);
+					const newLogs = readStudioLogs().slice(logCountBefore).map(stripAnsi);
 					return newLogs.some((log) =>
-						log.includes(
-							'[WatchIgnoreNextChange] All changes suppressed',
-						),
+						log.includes('[WatchIgnoreNextChange] All changes suppressed'),
 					);
 				},
 				{
@@ -84,9 +80,7 @@ test.describe('suppress webpack rebuild', () => {
 		const suppressionIndex = logsAfterApiUpdate.findIndex((log) =>
 			log.includes('[WatchIgnoreNextChange] All changes suppressed'),
 		);
-		const logsAfterSuppression = logsAfterApiUpdate.slice(
-			suppressionIndex + 1,
-		);
+		const logsAfterSuppression = logsAfterApiUpdate.slice(suppressionIndex + 1);
 		const hadRebuildAfterSuppression = logsAfterSuppression.some((log) =>
 			log.includes('Built in'),
 		);
@@ -111,8 +105,7 @@ test.describe('suppress webpack rebuild', () => {
 					return newLogs.some((log) => log.includes('Built in'));
 				},
 				{
-					message:
-						'Expected webpack to rebuild after manual file edit',
+					message: 'Expected webpack to rebuild after manual file edit',
 					timeout: 15_000,
 				},
 			)

--- a/packages/example/e2e/visual-controls.test.mts
+++ b/packages/example/e2e/visual-controls.test.mts
@@ -25,9 +25,7 @@ test.describe('visual controls', () => {
 		await expect(rotationFieldset).toBeVisible({timeout: 10_000});
 
 		// Click the dragger button to activate the number input
-		const dragger = rotationFieldset.locator(
-			'button.__remotion_input_dragger',
-		);
+		const dragger = rotationFieldset.locator('button.__remotion_input_dragger');
 		await expect(dragger).toBeVisible({timeout: 5_000});
 		await dragger.click();
 
@@ -109,7 +107,9 @@ test.describe('visual controls', () => {
 			.toBe(true);
 
 		// Now toggle to null via the checkbox
-		const nullCheckbox = page.locator('input[name="subtitle"][type="checkbox"]');
+		const nullCheckbox = page.locator(
+			'input[name="subtitle"][type="checkbox"]',
+		);
 		await expect(nullCheckbox).toBeVisible({timeout: 5_000});
 		await nullCheckbox.check();
 

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {Composition, Folder} from 'remotion';
+import {NewVideoComp} from './NewVideo';
+import {SchemaTest, schemaTestSchema} from './SchemaTest';
+import {VisualControls} from './VisualControls';
+
+export const E2eTestRoot: React.FC = () => {
+	return (
+		<>
+			<Folder name="Schema">
+				<Composition
+					id="schema-test"
+					component={SchemaTest}
+					width={1200}
+					height={630}
+					fps={30}
+					durationInFrames={150}
+					schema={schemaTestSchema}
+					defaultProps={{
+						title: 'sdasds',
+						delay: 5.2,
+						color: 'rgba(223, 42, 42, 0.46)',
+						list: [{name: 'first', age: 12}],
+						matrix: [0, 1, 1, 0] as const,
+						description: 'Sample description \nOn multiple lines',
+						country: 'Armenia' as const,
+						dropdown: 'a' as const,
+						superSchema: [
+							{type: 'a' as const, a: {a: 'hi'}},
+							{type: 'b' as const, b: {b: 'hi'}},
+						],
+						discriminatedUnion: {type: 'auto' as const},
+						tuple: ['foo', 42, {a: 'hi'}],
+					}}
+				/>
+			</Folder>
+			<Folder name="visual-controls">
+				<Composition
+					id="visual-controls"
+					component={VisualControls}
+					width={1920}
+					height={2400}
+					fps={30}
+					durationInFrames={900}
+				/>
+			</Folder>
+			<NewVideoComp />
+		</>
+	);
+};

--- a/packages/example/src/e2e-test-entry.ts
+++ b/packages/example/src/e2e-test-entry.ts
@@ -1,0 +1,4 @@
+import {registerRoot} from 'remotion';
+import {E2eTestRoot} from './E2eTestRoot';
+
+registerRoot(E2eTestRoot);

--- a/packages/studio-server/src/preview-server/project-info.ts
+++ b/packages/studio-server/src/preview-server/project-info.ts
@@ -2,10 +2,42 @@ import {existsSync} from 'node:fs';
 import path from 'node:path';
 import type {ProjectInfo} from '@remotion/studio-shared';
 
+const getRootFileFromEntryPoint = (entryPoint: string): string | null => {
+	const entryBase = path.basename(entryPoint, path.extname(entryPoint));
+	if (!entryBase.endsWith('-entry')) {
+		return null;
+	}
+
+	const stem = entryBase.slice(0, -'-entry'.length);
+	const pascalCase = stem
+		.split('-')
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join('');
+	const rootName = `${pascalCase}Root`;
+	const entryDir = path.dirname(entryPoint);
+
+	for (const ext of ['.tsx', '.ts', '.jsx', '.js']) {
+		const candidate = path.join(entryDir, rootName + ext);
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	return null;
+};
+
 export const getProjectInfo = (
 	remotionRoot: string,
 	entryPoint: string,
 ): Promise<ProjectInfo> => {
+	const rootFileFromEntryPoint = getRootFileFromEntryPoint(entryPoint);
+	if (rootFileFromEntryPoint) {
+		return Promise.resolve({
+			rootFile: rootFileFromEntryPoint,
+			relativeRootFile: path.relative(remotionRoot, rootFileFromEntryPoint),
+		});
+	}
+
 	const knownPaths = [
 		'src/Root.tsx',
 		'src/Root.jsx',


### PR DESCRIPTION
## Summary

- Adds `E2eTestRoot.tsx` and `e2e-test-entry.ts` with only the compositions used by Studio e2e tests (`schema-test`, `visual-controls`, `NewVideo`).
- Updates the e2e Playwright setup to start Studio with the lightweight entry point instead of the full example `Root.tsx`.
- Fixes `getProjectInfo()` in `@remotion/studio-server` to resolve the root file from `*-entry` entry points (e.g. `e2e-test-entry.ts` → `E2eTestRoot.tsx`), so default props updates target the correct file.

Fixes #7391

## Test plan

- [x] `cd packages/example && bun run test:e2e` — all 15 tests pass
- [x] Studio build time for e2e testbed is ~1–3s instead of compiling the full example root


Made with [Cursor](https://cursor.com)