### PR TITLE
`remotion`: Add sequence schema to `Solid`

### DIFF
--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -1,6 +1,13 @@
 import React, {useEffect, useMemo, useState} from 'react';
+import type {SequenceControls} from '../CompositionManager.js';
+import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
+import {
+	sequenceStyleSchema,
+	type SequenceSchema,
+} from '../sequence-field-schema.js';
 import {useCurrentFrame} from '../use-current-frame.js';
 import {useDelayRender} from '../use-delay-render.js';
+import {wrapInSchema} from '../wrap-in-schema.js';
 import type {EffectsProp} from './effect-types.js';
 import {runEffectChain} from './run-effect-chain.js';
 import {useEffectChainState} from './use-effect-chain-state.js';
@@ -16,11 +23,39 @@ export type SolidProps = {
 	readonly pixelRatio?: number;
 };
 
-export const Solid: React.FC<SolidProps> = ({
+const solidSchema = {
+	color: {
+		type: 'color',
+		default: '#ffffff',
+		description: 'Color',
+	},
+	width: {
+		type: 'number',
+		min: 1,
+		step: 1,
+		default: 1920,
+		description: 'Width',
+	},
+	height: {
+		type: 'number',
+		min: 1,
+		step: 1,
+		default: 1080,
+		description: 'Height',
+	},
+	...sequenceStyleSchema,
+} as const satisfies SequenceSchema;
+
+const SolidInner: React.FC<
+	SolidProps & {
+		readonly _experimentalControls: SequenceControls | undefined;
+	}
+> = ({
 	color,
 	width,
 	height,
 	_experimentalEffects: experimentalEffects = [],
+	_experimentalControls: controls,
 	className,
 	style,
 	pixelRatio = 1,
@@ -34,8 +69,7 @@ export const Solid: React.FC<SolidProps> = ({
 
 	const memoizedEffects = useMemoizedEffects({
 		effects: experimentalEffects,
-		// TODO: Add schema to Solid
-		overrideId: null,
+		overrideId: controls?.overrideId ?? null,
 	});
 
 	const sourceCanvas = useMemo(() => {
@@ -123,3 +157,11 @@ export const Solid: React.FC<SolidProps> = ({
 		/>
 	);
 };
+
+SolidInner.displayName = 'Solid';
+
+export const Solid = wrapInSchema(SolidInner, solidSchema);
+
+Solid.displayName = 'Solid';
+
+addSequenceStackTraces(Solid);

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/require-default-props */
 import React, {
 	forwardRef,
 	useCallback,
@@ -25,15 +24,23 @@ import {
 	useMemoizedEffects,
 } from './use-memoized-effects.js';
 
-export type SolidProps = {
+type MandatoryProps = {
 	readonly color: string;
 	readonly width: number;
 	readonly height: number;
-	readonly _experimentalEffects?: EffectsProp;
-	readonly className?: string;
-	readonly style?: React.CSSProperties;
-	readonly pixelRatio?: number;
 };
+
+type OptionalProps = {
+	readonly _experimentalEffects: EffectsProp;
+	readonly className: string | undefined;
+	readonly style: React.CSSProperties | undefined;
+};
+
+type InnerSolidProps = MandatoryProps &
+	OptionalProps & {
+		overrideId: string | null;
+	};
+export type SolidProps = MandatoryProps & Partial<OptionalProps>;
 
 const solidSchema = {
 	color: {
@@ -59,7 +66,7 @@ const solidSchema = {
 } as const satisfies SequenceSchema;
 
 const SolidInner: React.FC<
-	SolidProps & {
+	InnerSolidProps & {
 		readonly overrideId: string | null;
 		readonly ref?: React.Ref<HTMLCanvasElement>;
 	}
@@ -70,7 +77,6 @@ const SolidInner: React.FC<
 	_experimentalEffects: experimentalEffects = [],
 	className,
 	style,
-	pixelRatio = 1,
 	overrideId,
 	ref,
 }) => {
@@ -167,7 +173,6 @@ const SolidInner: React.FC<
 		chainState,
 		width,
 		height,
-		pixelRatio,
 		delayRender,
 		continueRender,
 		cancelRender,
@@ -203,7 +208,6 @@ const SolidOuter = forwardRef<
 			width,
 			className,
 			durationInFrames,
-			pixelRatio,
 			style,
 			name,
 			from,
@@ -228,6 +232,8 @@ const SolidOuter = forwardRef<
 				_experimentalEffects={memoizedEffectDefinitions}
 				durationInFrames={durationInFrames}
 				name={name ?? '<Solid>'}
+				// 'stack' is in props
+				{...props}
 			>
 				<SolidInner
 					ref={ref}
@@ -236,8 +242,8 @@ const SolidOuter = forwardRef<
 					height={height}
 					width={width}
 					className={className}
-					pixelRatio={pixelRatio}
 					style={style}
+					_experimentalEffects={_experimentalEffects}
 				/>
 			</Sequence>
 		);

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -1,17 +1,29 @@
-import React, {useEffect, useMemo, useState} from 'react';
+/* eslint-disable react/require-default-props */
+import React, {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react';
 import type {SequenceControls} from '../CompositionManager.js';
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {
 	sequenceStyleSchema,
 	type SequenceSchema,
 } from '../sequence-field-schema.js';
+import type {SequenceProps} from '../Sequence.js';
+import {Sequence} from '../Sequence.js';
 import {useCurrentFrame} from '../use-current-frame.js';
 import {useDelayRender} from '../use-delay-render.js';
 import {wrapInSchema} from '../wrap-in-schema.js';
 import type {EffectsProp} from './effect-types.js';
 import {runEffectChain} from './run-effect-chain.js';
 import {useEffectChainState} from './use-effect-chain-state.js';
-import {useMemoizedEffects} from './use-memoized-effects.js';
+import {
+	useMemoizedEffectDefinitions,
+	useMemoizedEffects,
+} from './use-memoized-effects.js';
 
 export type SolidProps = {
 	readonly color: string;
@@ -48,17 +60,19 @@ const solidSchema = {
 
 const SolidInner: React.FC<
 	SolidProps & {
-		readonly _experimentalControls: SequenceControls | undefined;
+		readonly overrideId: string | null;
+		readonly ref?: React.Ref<HTMLCanvasElement>;
 	}
 > = ({
 	color,
 	width,
 	height,
 	_experimentalEffects: experimentalEffects = [],
-	_experimentalControls: controls,
 	className,
 	style,
 	pixelRatio = 1,
+	overrideId,
+	ref,
 }) => {
 	const frame = useCurrentFrame();
 	const {delayRender, continueRender, cancelRender} = useDelayRender();
@@ -69,7 +83,7 @@ const SolidInner: React.FC<
 
 	const memoizedEffects = useMemoizedEffects({
 		effects: experimentalEffects,
-		overrideId: controls?.overrideId ?? null,
+		overrideId: overrideId ?? null,
 	});
 
 	const sourceCanvas = useMemo(() => {
@@ -84,6 +98,19 @@ const SolidInner: React.FC<
 	}, []);
 
 	const chainState = useEffectChainState();
+
+	const canvasRef = useCallback(
+		(canvas: HTMLCanvasElement | null) => {
+			setOutputCanvas(canvas);
+
+			if (typeof ref === 'function') {
+				ref(canvas);
+			} else if (ref) {
+				ref.current = canvas;
+			}
+		},
+		[ref],
+	);
 
 	// Fill source and run effect chain on every frame / color change.
 	useEffect(() => {
@@ -149,7 +176,7 @@ const SolidInner: React.FC<
 
 	return (
 		<canvas
-			ref={setOutputCanvas}
+			ref={canvasRef}
 			width={width}
 			height={height}
 			className={className}
@@ -158,9 +185,66 @@ const SolidInner: React.FC<
 	);
 };
 
-SolidInner.displayName = 'Solid';
+const SolidOuter = forwardRef<
+	HTMLCanvasElement,
+	SolidProps & {
+		readonly _experimentalControls: SequenceControls | undefined;
+	} & Pick<
+			SequenceProps,
+			'durationInFrames' | 'name' | 'from' | 'showInTimeline' | 'hidden'
+		>
+>(
+	(
+		{
+			_experimentalEffects = [],
+			_experimentalControls: controls,
+			color,
+			height,
+			width,
+			className,
+			durationInFrames,
+			pixelRatio,
+			style,
+			name,
+			from,
+			hidden,
+			showInTimeline,
+			...props
+		},
+		ref,
+	) => {
+		props satisfies Record<string, never>;
 
-export const Solid = wrapInSchema(SolidInner, solidSchema);
+		const memoizedEffectDefinitions =
+			useMemoizedEffectDefinitions(_experimentalEffects);
+
+		return (
+			<Sequence
+				layout="none"
+				from={from}
+				hidden={hidden}
+				showInTimeline={showInTimeline}
+				_experimentalControls={controls}
+				_experimentalEffects={memoizedEffectDefinitions}
+				durationInFrames={durationInFrames}
+				name={name ?? '<Solid>'}
+			>
+				<SolidInner
+					ref={ref}
+					overrideId={controls?.overrideId ?? null}
+					color={color}
+					height={height}
+					width={width}
+					className={className}
+					pixelRatio={pixelRatio}
+					style={style}
+				/>
+			</Sequence>
+		);
+	},
+);
+
+export const Solid = wrapInSchema(SolidOuter, solidSchema);
 
 Solid.displayName = 'Solid';
 

--- a/packages/example/src/ExperimentalControls/index.tsx
+++ b/packages/example/src/ExperimentalControls/index.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {
 	AbsoluteFill,
 	AnimatedImage,
+	Experimental,
 	Html5Audio,
 	Html5Video,
 	HtmlInCanvas,
@@ -226,6 +227,9 @@ export const ExperimentalControlsShowcase: React.FC = () => {
 							<AbsoluteFill style={{backgroundColor: 'red'}}></AbsoluteFill>
 						</Series.Sequence>
 					</Series>
+				</Tile>
+				<Tile title="Solid">
+					<Experimental.Solid color="red" width={100} height={100} />
 				</Tile>
 			</div>
 		</AbsoluteFill>


### PR DESCRIPTION
## Summary

- Wrap `Experimental.Solid` in `wrapInSchema` with fields for `color`, `width`, `height`, and `sequenceStyleSchema` (translate, scale, rotate, opacity, premount)
- Pass `controls?.overrideId` into `useMemoizedEffects` so `_experimentalEffects` can be edited in visual mode
- Register stack traces via `addSequenceStackTraces` for stable override IDs in the studio

## Test plan

- [ ] Open the effects testbed in Studio and confirm `<Experimental.Solid>` props are editable in visual mode
- [ ] Verify effect props on a Solid with `_experimentalEffects` can be updated in the timeline
- [ ] Confirm rendering still works outside Studio (no schema overrides applied)

Made with [Cursor](https://cursor.com)