### PR TITLE
`@remotion/renderer`: replace extract-zip with OS unzip/tar for Node 26

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1306,7 +1306,6 @@
         "@remotion/licensing": "workspace:*",
         "@remotion/streaming": "workspace:*",
         "execa": "5.1.1",
-        "extract-zip": "2.0.1",
         "remotion": "workspace:*",
         "source-map": "0.8.0-beta.0",
         "ws": "8.17.1",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -22,7 +22,6 @@
 	},
 	"dependencies": {
 		"execa": "5.1.1",
-		"extract-zip": "2.0.1",
 		"remotion": "workspace:*",
 		"@remotion/streaming": "workspace:*",
 		"source-map": "0.8.0-beta.0",

--- a/packages/renderer/src/browser/BrowserFetcher.ts
+++ b/packages/renderer/src/browser/BrowserFetcher.ts
@@ -18,12 +18,12 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {promisify} from 'node:util';
-import extractZip from 'extract-zip';
 import {downloadFile} from '../assets/download-file';
 import {makeFileExecutableIfItIsNot} from '../compositor/make-file-executable';
 import type {LogLevel} from '../log-level';
 import {ChromeMode} from '../options/chrome-mode';
 import type {DownloadBrowserProgressFn} from '../options/on-browser-download';
+import {extractZipArchive} from './extract-zip-archive';
 import {
 	getChromeDownloadUrl,
 	isAmazonLinux2023,
@@ -180,7 +180,7 @@ export const downloadBrowser = async ({
 			logLevel,
 			abortSignal: new AbortController().signal,
 		});
-		await extractZip(archivePath, {dir: outputPath});
+		await extractZipArchive(archivePath, outputPath);
 
 		const possibleSubdirs = [
 			'chrome-linux',

--- a/packages/renderer/src/browser/extract-zip-archive.ts
+++ b/packages/renderer/src/browser/extract-zip-archive.ts
@@ -5,6 +5,22 @@ import {promisify} from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
+const getMissingArchiveUtilityMessage = (): string => {
+	const base =
+		'Failed to extract the downloaded Chrome archive. A zip extraction utility must be installed and available on your PATH.';
+
+	switch (process.platform) {
+		case 'win32':
+			return `${base} On Windows, Remotion uses the built-in tar utility in System32. Ensure you are on Windows 10 version 1803 or later.`;
+		case 'darwin':
+			return `${base} On macOS, install unzip, for example with Homebrew: brew install unzip`;
+		case 'linux':
+			return `${base} On Linux, install unzip, for example: apt install unzip, yum install unzip, or apk add unzip`;
+		default:
+			return `${base} Install a zip extraction utility for your operating system.`;
+	}
+};
+
 export const extractZipArchive = async (
 	archivePath: string,
 	folderPath: string,
@@ -41,10 +57,7 @@ export const extractZipArchive = async (
 			'code' in error &&
 			error.code === 'ENOENT'
 		) {
-			throw new Error(
-				"Extraction failed: Required native binary ('tar.exe' or 'unzip') was not found in the system PATH.",
-				{cause: error},
-			);
+			throw new Error(getMissingArchiveUtilityMessage(), {cause: error});
 		}
 
 		const stderr =
@@ -57,8 +70,11 @@ export const extractZipArchive = async (
 
 		const message = error instanceof Error ? error.message : String(error);
 
-		throw new Error(`Extraction failed: ${stderr ?? message}`, {
-			cause: error instanceof Error ? error : undefined,
-		});
+		throw new Error(
+			`Failed to extract the downloaded Chrome archive: ${stderr ?? message}`,
+			{
+				cause: error instanceof Error ? error : undefined,
+			},
+		);
 	}
 };

--- a/packages/renderer/src/browser/extract-zip-archive.ts
+++ b/packages/renderer/src/browser/extract-zip-archive.ts
@@ -1,0 +1,64 @@
+import {execFile} from 'node:child_process';
+import {mkdir} from 'node:fs/promises';
+import * as path from 'node:path';
+import {promisify} from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const extractZipArchive = async (
+	archivePath: string,
+	folderPath: string,
+): Promise<void> => {
+	const resolvedFolderPath = path.isAbsolute(folderPath)
+		? folderPath
+		: path.resolve(process.cwd(), folderPath);
+
+	await mkdir(resolvedFolderPath, {recursive: true});
+
+	try {
+		if (process.platform === 'win32') {
+			const systemRoot =
+				process.env.SystemRoot ?? process.env.SYSTEMROOT ?? 'C:\\Windows';
+			const systemTar = path.join(systemRoot, 'System32', 'tar.exe');
+			await execFileAsync(systemTar, [
+				'-xf',
+				archivePath,
+				'-C',
+				resolvedFolderPath,
+			]);
+		} else {
+			await execFileAsync('unzip', [
+				'-o',
+				archivePath,
+				'-d',
+				resolvedFolderPath,
+			]);
+		}
+	} catch (error: unknown) {
+		if (
+			error &&
+			typeof error === 'object' &&
+			'code' in error &&
+			error.code === 'ENOENT'
+		) {
+			throw new Error(
+				"Extraction failed: Required native binary ('tar.exe' or 'unzip') was not found in the system PATH.",
+				{cause: error},
+			);
+		}
+
+		const stderr =
+			error &&
+			typeof error === 'object' &&
+			'stderr' in error &&
+			Buffer.isBuffer(error.stderr)
+				? error.stderr.toString()
+				: null;
+
+		const message = error instanceof Error ? error.message : String(error);
+
+		throw new Error(`Extraction failed: ${stderr ?? message}`, {
+			cause: error instanceof Error ? error : undefined,
+		});
+	}
+};


### PR DESCRIPTION
## Summary

- Replaces the unmaintained `extract-zip` dependency with system-native archive extraction when downloading Chrome for rendering
- On Unix (macOS/Linux), uses `unzip -o`; on Windows, uses `tar.exe` from System32
- Removes `extract-zip` from `@remotion/renderer` dependencies

Fixes silent/incomplete Chrome extraction on Node.js 26.1+ caused by [extract-zip#154](https://github.com/max-mapper/extract-zip/issues/154). Same approach as [@puppeteer/browsers](https://github.com/puppeteer/puppeteer/pull/14960).

Closes #7409

## Breaking change note

Linux/macOS environments need `unzip` on `PATH`. Remotion's official Docker images already install it. Minimal images should add `apt install unzip` or `apk add unzip`.

## Test plan

- [ ] On Node 26.1+: `npx remotion browser ensure` extracts a full Chrome headless shell (binary present)
- [ ] On Node 22 LTS: same flow still works
- [ ] On macOS: `npx remotion render` succeeds after `browser ensure`
- [ ] On Linux (with `unzip` installed): `npx remotion render` succeeds after `browser ensure`
- [ ] On Windows: `npx remotion browser ensure` extracts via `tar.exe`


Made with [Cursor](https://cursor.com)