### PR TITLE
`@remotion/timeline-utils`: Trim audio before timeline zero in waveforms

### DIFF
--- a/packages/timeline-utils/src/audio-waveform/load-waveform-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/load-waveform-peaks.ts
@@ -1,5 +1,6 @@
 import {ALL_FORMATS, AudioSampleSink, Input, UrlSource} from 'mediabunny';
 import {TARGET_SAMPLE_RATE} from './constants';
+import {getAudioSampleStartFrameAtTimelineZero} from './trim-audio-sample-before-zero';
 import {
 	createWaveformPeakProcessor,
 	emitWaveformProgress,
@@ -90,12 +91,31 @@ export async function loadWaveformPeaks(
 				return new Float32Array(0);
 			}
 
+			const startFrame = getAudioSampleStartFrameAtTimelineZero(sample);
+			if (startFrame === null) {
+				sample.close();
+				continue;
+			}
+
+			const frameCount = sample.numberOfFrames - startFrame;
+			if (frameCount <= 0) {
+				sample.close();
+				continue;
+			}
+
 			const bytesNeeded = sample.allocationSize({
 				format: 'f32',
 				planeIndex: 0,
+				frameOffset: startFrame,
+				frameCount,
 			});
 			const floats = new Float32Array(bytesNeeded / 4);
-			sample.copyTo(floats, {format: 'f32', planeIndex: 0});
+			sample.copyTo(floats, {
+				format: 'f32',
+				planeIndex: 0,
+				frameOffset: startFrame,
+				frameCount,
+			});
 			const channels = Math.max(1, sample.numberOfChannels);
 			sample.close();
 

--- a/packages/timeline-utils/src/audio-waveform/trim-audio-sample-before-zero.ts
+++ b/packages/timeline-utils/src/audio-waveform/trim-audio-sample-before-zero.ts
@@ -1,0 +1,27 @@
+export type AudioSampleTiming = {
+	readonly timestamp: number;
+	readonly numberOfFrames: number;
+	readonly duration: number;
+	readonly sampleRate: number;
+};
+
+/**
+ * Returns the first frame index to include when building a timeline-aligned waveform.
+ * Returns null when the entire sample ends before timeline t=0.
+ */
+export const getAudioSampleStartFrameAtTimelineZero = (
+	sample: AudioSampleTiming,
+): number | null => {
+	if (sample.timestamp + sample.duration <= 0) {
+		return null;
+	}
+
+	if (sample.timestamp >= 0) {
+		return 0;
+	}
+
+	return Math.min(
+		sample.numberOfFrames,
+		Math.ceil(-sample.timestamp * sample.sampleRate),
+	);
+};

--- a/packages/timeline-utils/src/test/load-waveform-peaks-server.test.ts
+++ b/packages/timeline-utils/src/test/load-waveform-peaks-server.test.ts
@@ -3,6 +3,7 @@ import {registerMediabunnyServer} from '@mediabunny/server';
 import {loadWaveformPeaks} from '../audio-waveform/load-waveform-peaks';
 
 const SAMPLE_MEDIA_URL = 'https://remotion.media/video.mp4';
+const EDTS_MEDIA_URL = 'https://remotion.media/edts.mp4';
 
 beforeAll(() => {
 	registerMediabunnyServer();
@@ -47,4 +48,14 @@ test('loadWaveformPeaks progress matches completed peak count for MP4 audio', as
 
 	expect(sawFinal).toBe(true);
 	expect(lastCompleted).toBe(peaks.length);
+});
+
+test('loadWaveformPeaks draws a non-zero first peak for edts.mp4', async () => {
+	const peaks = await loadWaveformPeaks(
+		EDTS_MEDIA_URL,
+		new AbortController().signal,
+	);
+
+	expect(peaks.length).toBeGreaterThan(0);
+	expect(Math.abs(peaks[0] ?? 0)).toBeGreaterThan(0.001);
 });

--- a/packages/timeline-utils/src/test/trim-audio-sample-before-zero.test.ts
+++ b/packages/timeline-utils/src/test/trim-audio-sample-before-zero.test.ts
@@ -1,0 +1,35 @@
+import {expect, test} from 'bun:test';
+import {getAudioSampleStartFrameAtTimelineZero} from '../audio-waveform/trim-audio-sample-before-zero';
+
+test('Should skip audio samples that end before timeline zero', () => {
+	expect(
+		getAudioSampleStartFrameAtTimelineZero({
+			timestamp: -0.05,
+			duration: 0.02,
+			numberOfFrames: 1024,
+			sampleRate: 44100,
+		}),
+	).toBe(null);
+});
+
+test('Should trim frames before timeline zero in a straddling sample', () => {
+	expect(
+		getAudioSampleStartFrameAtTimelineZero({
+			timestamp: -0.0014512471655328798,
+			duration: 0.023219954648526078,
+			numberOfFrames: 1024,
+			sampleRate: 44100,
+		}),
+	).toBe(64);
+});
+
+test('Should keep samples that start at or after timeline zero', () => {
+	expect(
+		getAudioSampleStartFrameAtTimelineZero({
+			timestamp: 0,
+			duration: 0.02,
+			numberOfFrames: 1024,
+			sampleRate: 44100,
+		}),
+	).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Trim PCM before timeline `t = 0` when building waveform peaks, so negative Mediabunny sample timestamps no longer produce a leading flat segment in Studio.
- Add a regression test for `https://remotion.media/edts.mp4` asserting the first peak is non-zero.

Fixes #7313

## Test plan

- [x] `cd packages/timeline-utils && bun test src`
- [ ] Verify audio waveform for `edts.mp4` in Studio starts at the left edge


Made with [Cursor](https://cursor.com)