### PR TITLE
`@remotion/cli`: Fix pnpm catalog upgrade detection

### DIFF
--- a/packages/cli/src/test/upgrade-protocols.test.ts
+++ b/packages/cli/src/test/upgrade-protocols.test.ts
@@ -7,6 +7,7 @@ import {
 	isCatalogProtocol,
 	updateCatalogEntry,
 } from '../catalog-utils';
+import {getPackagesToUpgrade} from '../upgrade';
 
 let tmpDir: string;
 
@@ -112,6 +113,35 @@ test('partitions packages into normal and catalog groups', () => {
 	);
 	expect(unknownResult.normalPackages).toEqual([
 		{pkg: '@remotion/core', version: '4.0.15'},
+	]);
+});
+
+test('includes Remotion and extra packages that only exist in pnpm catalog entries', () => {
+	const result = getPackagesToUpgrade({
+		depsWithVersions: {
+			dependencies: {},
+			devDependencies: {},
+			optionalDependencies: {},
+			peerDependencies: {},
+		},
+		catalogEntries: {
+			remotion: '4.0.460',
+			'@remotion/player': '4.0.460',
+			mediabunny: '1.44.0',
+			react: '19.0.0',
+		},
+		targetVersion: '4.0.462',
+		extraPackageVersions: {
+			mediabunny: '1.45.0',
+			zod: '4.3.6',
+		},
+	});
+
+	expect(result.normalPackages).toEqual([]);
+	expect(result.catalogPackages).toEqual([
+		{pkg: 'remotion', version: '4.0.462'},
+		{pkg: '@remotion/player', version: '4.0.462'},
+		{pkg: 'mediabunny', version: '1.45.0'},
 	]);
 });
 

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -4,6 +4,7 @@ import {StudioServerInternals} from '@remotion/studio-server';
 import {
 	findVersionSpecifier,
 	findWorkspaceRoot,
+	getCatalogEntries,
 	isCatalogProtocol,
 	updateCatalogEntry,
 } from './catalog-utils';
@@ -34,6 +35,65 @@ const getExtraPackageVersionsForRemotionVersion = (
 		// If we can't fetch the versions, return the default versions from EXTRA_PACKAGES
 		return EXTRA_PACKAGES;
 	}
+};
+
+type DepsWithVersions = {
+	dependencies: Record<string, string>;
+	devDependencies: Record<string, string>;
+	optionalDependencies: Record<string, string>;
+	peerDependencies: Record<string, string>;
+};
+
+export const getPackagesToUpgrade = ({
+	depsWithVersions,
+	catalogEntries,
+	targetVersion,
+	extraPackageVersions,
+}: {
+	depsWithVersions: DepsWithVersions;
+	catalogEntries: Record<string, string>;
+	targetVersion: string;
+	extraPackageVersions: Record<string, string>;
+}) => {
+	const allDeps = [
+		...Object.keys(depsWithVersions.dependencies),
+		...Object.keys(depsWithVersions.devDependencies),
+		...Object.keys(depsWithVersions.optionalDependencies),
+		...Object.keys(depsWithVersions.peerDependencies),
+	];
+	const catalogPackages = new Set(Object.keys(catalogEntries));
+
+	const remotionToUpgrade = listOfRemotionPackages.filter(
+		(u) => allDeps.includes(u) || catalogPackages.has(u),
+	);
+
+	const installedExtraPackages = Object.keys(EXTRA_PACKAGES).filter(
+		(pkg) => allDeps.includes(pkg) || catalogPackages.has(pkg),
+	);
+
+	const allPackagesToUpgrade = [
+		...remotionToUpgrade,
+		...installedExtraPackages,
+	];
+
+	const normalPackages: {pkg: string; version: string}[] = [];
+	const catalogPackagesToUpgrade: {pkg: string; version: string}[] = [];
+
+	for (const pkg of allPackagesToUpgrade) {
+		const versionSpec = findVersionSpecifier(depsWithVersions, pkg);
+		const targetVersionForPkg = extraPackageVersions[pkg] ?? targetVersion;
+
+		if (
+			(versionSpec && isCatalogProtocol(versionSpec)) ||
+			(!versionSpec && catalogPackages.has(pkg))
+		) {
+			catalogPackagesToUpgrade.push({pkg, version: targetVersionForPkg});
+		} else {
+			normalPackages.push({pkg, version: targetVersionForPkg});
+		}
+	}
+
+	return {normalPackages, catalogPackages: catalogPackagesToUpgrade};
 };
 
 export const upgradeCommand = async ({
@@ -83,52 +143,33 @@ export const upgradeCommand = async ({
 		);
 	}
 
-	const allDeps = [
-		...Object.keys(depsWithVersions.dependencies),
-		...Object.keys(depsWithVersions.devDependencies),
-		...Object.keys(depsWithVersions.optionalDependencies),
-		...Object.keys(depsWithVersions.peerDependencies),
-	];
-
-	const remotionToUpgrade = listOfRemotionPackages.filter((u) =>
-		allDeps.includes(u),
-	);
-
-	const installedExtraPackages = Object.keys(EXTRA_PACKAGES).filter((pkg) =>
-		allDeps.includes(pkg),
-	);
-
 	const extraPackageVersions =
 		getExtraPackageVersionsForRemotionVersion(targetVersion);
+	const workspaceRoot = findWorkspaceRoot(remotionRoot);
+	const catalogEntries = workspaceRoot ? getCatalogEntries(workspaceRoot) : {};
 
-	if (installedExtraPackages.length > 0) {
+	const {normalPackages, catalogPackages} = getPackagesToUpgrade({
+		depsWithVersions,
+		catalogEntries,
+		targetVersion,
+		extraPackageVersions,
+	});
+
+	if (
+		normalPackages.some(({pkg}) => pkg in EXTRA_PACKAGES) ||
+		catalogPackages.some(({pkg}) => pkg in EXTRA_PACKAGES)
+	) {
+		const installedExtraPackages = [
+			...normalPackages,
+			...catalogPackages,
+		].filter(({pkg}) => pkg in EXTRA_PACKAGES);
 		Log.info(
 			{indent: false, logLevel},
-			`Also upgrading extra packages: ${installedExtraPackages.map((pkg) => `${pkg}@${extraPackageVersions[pkg]}`).join(', ')}`,
+			`Also upgrading extra packages: ${installedExtraPackages.map(({pkg}) => `${pkg}@${extraPackageVersions[pkg]}`).join(', ')}`,
 		);
 	}
 
-	const allPackagesToUpgrade = [
-		...remotionToUpgrade,
-		...installedExtraPackages,
-	];
-
-	const normalPackages: {pkg: string; version: string}[] = [];
-	const catalogPackages: {pkg: string; version: string}[] = [];
-
-	for (const pkg of allPackagesToUpgrade) {
-		const versionSpec = findVersionSpecifier(depsWithVersions, pkg);
-		const targetVersionForPkg = extraPackageVersions[pkg] ?? targetVersion;
-
-		if (versionSpec && isCatalogProtocol(versionSpec)) {
-			catalogPackages.push({pkg, version: targetVersionForPkg});
-		} else {
-			normalPackages.push({pkg, version: targetVersionForPkg});
-		}
-	}
-
 	if (catalogPackages.length > 0) {
-		const workspaceRoot = findWorkspaceRoot(remotionRoot);
 		if (workspaceRoot) {
 			const updatedCatalogEntries: string[] = [];
 


### PR DESCRIPTION
## Summary
- Include matching `pnpm-workspace.yaml` catalog entries when deciding which Remotion packages to upgrade
- Preserve catalog references while updating catalog-only Remotion and Mediabunny versions
- Add regression coverage for catalog-only package discovery

## Test plan
- `bunx oxfmt src --write` in `packages/cli`
- `bun run formatting` in `packages/cli`
- `bun test src/test/upgrade-protocols.test.ts` in `packages/cli`
- Manual temp pnpm monorepo fixture with `pnpm-workspace.yaml` catalog entries

Fixes #7410