### PR TITLE
Remove frame from effect system; use progress and evolution params

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -25,7 +25,6 @@ import type {
 	SequenceProps,
 } from './Sequence.js';
 import {Sequence} from './Sequence.js';
-import {useCurrentFrame} from './use-current-frame.js';
 import {useDelayRender} from './use-delay-render.js';
 import {useVideoConfig} from './use-video-config.js';
 import {wrapInSchema} from './wrap-in-schema.js';
@@ -306,8 +305,6 @@ const HtmlInCanvasContent = forwardRef<
 			cancelRender(new Error(HTML_IN_CANVAS_UNSUPPORTED_MESSAGE));
 		}
 
-		const frame = useCurrentFrame();
-
 		const canvas2dRef = useRef<HTMLCanvasElement | null>(null);
 		const divRef = useRef<HTMLDivElement | null>(null);
 
@@ -335,8 +332,6 @@ const HtmlInCanvasContent = forwardRef<
 		// Refs so the paint handler always reads fresh values.
 		const effectsRef = useRef(memoizedEffects);
 		effectsRef.current = memoizedEffects;
-		const frameRef = useRef(frame);
-		frameRef.current = frame;
 		const onPaintRef = useRef(onPaint);
 		onPaintRef.current = onPaint;
 		const onInitRef = useRef(onInit);
@@ -416,7 +411,6 @@ const HtmlInCanvasContent = forwardRef<
 					source: offscreenCanvas,
 					effects: effectsRef.current,
 					output: canvas2dRef.current!,
-					frame: frameRef.current,
 					width,
 					height,
 				});

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -13,7 +13,6 @@ import {
 } from '../sequence-field-schema.js';
 import type {SequenceProps} from '../Sequence.js';
 import {Sequence} from '../Sequence.js';
-import {useCurrentFrame} from '../use-current-frame.js';
 import {useDelayRender} from '../use-delay-render.js';
 import {wrapInSchema} from '../wrap-in-schema.js';
 import type {EffectsProp} from './effect-types.js';
@@ -80,7 +79,6 @@ const SolidInner: React.FC<
 	overrideId,
 	ref,
 }) => {
-	const frame = useCurrentFrame();
 	const {delayRender, continueRender, cancelRender} = useDelayRender();
 
 	const [outputCanvas, setOutputCanvas] = useState<HTMLCanvasElement | null>(
@@ -124,7 +122,7 @@ const SolidInner: React.FC<
 			return;
 		}
 
-		const handle = delayRender(`Solid effect chain (frame ${frame})`);
+		const handle = delayRender('Solid effect chain');
 
 		if (!chainState) {
 			continueRender(handle);
@@ -149,7 +147,6 @@ const SolidInner: React.FC<
 			source: sourceCanvas,
 			effects: memoizedEffects,
 			output: outputCanvas,
-			frame,
 			width,
 			height,
 		})
@@ -166,7 +163,6 @@ const SolidInner: React.FC<
 			continueRender(handle);
 		};
 	}, [
-		frame,
 		color,
 		outputCanvas,
 		sourceCanvas,

--- a/packages/core/src/effects/create-effect.ts
+++ b/packages/core/src/effects/create-effect.ts
@@ -15,7 +15,7 @@ export const disabledEffectField: SequenceFieldSchema = {
 	description: 'Disabled',
 };
 
-// Defines an effect and returns a factory that produces per-frame descriptors.
+// Defines an effect and returns a factory that produces effect descriptors.
 // The returned function is the public API effect authors expose to users:
 //
 //   export const blur = createEffect<BlurParams, BlurState>({ ... });

--- a/packages/core/src/effects/create-effect.ts
+++ b/packages/core/src/effects/create-effect.ts
@@ -40,7 +40,7 @@ export const createEffect = <P, S>(
 		},
 		schema: {
 			disabled: disabledEffectField,
-			...(definition.schema ?? {}),
+			...definition.schema,
 		},
 	};
 	const factory = (

--- a/packages/core/src/effects/effect-types.ts
+++ b/packages/core/src/effects/effect-types.ts
@@ -23,7 +23,6 @@ export type EffectApplyParams<P, S> = {
 	readonly target: HTMLCanvasElement;
 	readonly state: S;
 	readonly params: P;
-	readonly frame: number;
 	readonly width: number;
 	readonly height: number;
 	readonly gpuDevice: AnyGpuDevice | null;

--- a/packages/core/src/effects/effect-types.ts
+++ b/packages/core/src/effects/effect-types.ts
@@ -42,7 +42,7 @@ export type EffectDefinition<P, S = unknown> = {
 	readonly setup: (target: HTMLCanvasElement) => S;
 	readonly apply: (params: EffectApplyParams<P, S>) => void;
 	readonly cleanup: (state: S) => void;
-	readonly schema: SequenceSchema | null;
+	readonly schema: SequenceSchema;
 };
 
 type BaseEffectDescriptor<P = unknown> = {

--- a/packages/core/src/effects/run-effect-chain.ts
+++ b/packages/core/src/effects/run-effect-chain.ts
@@ -54,7 +54,6 @@ export type RunEffectChainOptions = {
 	readonly source: CanvasImageSource;
 	readonly effects: EffectDefinitionAndStack<unknown>[];
 	readonly output: HTMLCanvasElement;
-	readonly frame: number;
 	readonly width: number;
 	readonly height: number;
 };
@@ -67,7 +66,6 @@ export const runEffectChain = async ({
 	source,
 	effects,
 	output,
-	frame,
 	width,
 	height,
 }: RunEffectChainOptions): Promise<boolean> => {
@@ -130,7 +128,6 @@ export const runEffectChain = async ({
 				target: dst,
 				state: setupState,
 				params: eff.params,
-				frame,
 				width,
 				height,
 				gpuDevice,

--- a/packages/core/src/test/create-effect-disabled.test.ts
+++ b/packages/core/src/test/create-effect-disabled.test.ts
@@ -14,7 +14,7 @@ const makeFoo = () =>
 		setup: () => null,
 		apply: () => undefined,
 		cleanup: () => undefined,
-		schema: null,
+		schema: {},
 	});
 
 test('createEffect factory accepts `disabled` without complaint', () => {
@@ -55,22 +55,22 @@ test('createEffect injects `disabled` into the schema for save-effect-props', ()
 		},
 	});
 	const desc = foo({amount: 1});
-	expect(desc.definition.schema?.disabled).toEqual({
+	expect(desc.definition.schema.disabled).toEqual({
 		type: 'boolean',
 		default: false,
 		description: 'Disabled',
 	});
-	expect(desc.definition.schema?.amount).toEqual({
+	expect(desc.definition.schema.amount).toEqual({
 		type: 'number',
 		default: 0,
 		description: 'Amount',
 	});
 });
 
-test('createEffect injects `disabled` even when the effect declares no schema', () => {
+test('createEffect injects `disabled` even when the effect schema is empty', () => {
 	const foo = makeFoo();
 	const desc = foo({amount: 1});
-	expect(desc.definition.schema?.disabled).toEqual({
+	expect(desc.definition.schema.disabled).toEqual({
 		type: 'boolean',
 		default: false,
 		description: 'Disabled',

--- a/packages/core/src/test/effect-internals.test.ts
+++ b/packages/core/src/test/effect-internals.test.ts
@@ -18,7 +18,7 @@ const makeDef = (
 	setup: () => null,
 	apply: () => undefined,
 	cleanup: () => undefined,
-	schema: null,
+	schema: {},
 });
 
 const makeDesc = (

--- a/packages/effects/src/wave.ts
+++ b/packages/effects/src/wave.ts
@@ -1,11 +1,49 @@
+import type {SequenceSchema} from 'remotion';
 import {Internals} from 'remotion';
 
 const {createEffect} = Internals;
 
+export const waveSchema = {
+	amplitude: {
+		type: 'number',
+		min: 0,
+		max: 500,
+		step: 1,
+		default: 60,
+		description: 'Amplitude',
+	},
+	wavelength: {
+		type: 'number',
+		min: 1,
+		max: 2000,
+		step: 1,
+		default: 240,
+		description: 'Wavelength',
+	},
+	evolution: {
+		type: 'number',
+		default: 0,
+		description: 'Evolution',
+	},
+	sliceWidth: {
+		type: 'number',
+		min: 1,
+		max: 100,
+		step: 1,
+		default: 4,
+		description: 'Slice width',
+	},
+	background: {
+		type: 'color',
+		default: 'transparent',
+		description: 'Background',
+	},
+} as const satisfies SequenceSchema;
+
 export type WaveParams = {
 	readonly amplitude?: number;
 	readonly wavelength?: number;
-	readonly speed?: number;
+	readonly evolution?: number;
 	readonly sliceWidth?: number;
 	readonly background?: string;
 };
@@ -13,7 +51,7 @@ export type WaveParams = {
 type WaveResolved = {
 	amplitude: number;
 	wavelength: number;
-	speed: number;
+	evolution: number;
 	sliceWidth: number;
 	background: string;
 };
@@ -21,23 +59,24 @@ type WaveResolved = {
 const resolve = (p: WaveParams): WaveResolved => ({
 	amplitude: p.amplitude ?? 60,
 	wavelength: p.wavelength ?? 240,
-	speed: p.speed ?? 1 / 6,
+	evolution: p.evolution ?? 0,
 	sliceWidth: p.sliceWidth ?? 4,
 	background: p.background ?? 'transparent',
 });
 
 // Vertical-displacement wave effect: shifts vertical slices of the source
-// up/down with a sine wave that animates over time. Operates on the 2D backend.
+// up/down with a sine wave phase driven by `evolution`. Operates on the 2D
+// backend.
 export const wave = createEffect<WaveParams, null>({
 	type: 'remotion/wave',
 	label: 'Wave',
 	backend: '2d',
 	calculateKey: (params) => {
 		const r = resolve(params);
-		return `wave-${r.amplitude}-${r.wavelength}-${r.speed}-${r.sliceWidth}-${r.background}`;
+		return `wave-${r.amplitude}-${r.wavelength}-${r.evolution}-${r.sliceWidth}-${r.background}`;
 	},
 	setup: () => null,
-	apply: ({source, target, frame, width, height, params}) => {
+	apply: ({source, target, width, height, params}) => {
 		const ctx = target.getContext('2d');
 		if (!ctx) {
 			throw new Error(
@@ -55,8 +94,7 @@ export const wave = createEffect<WaveParams, null>({
 
 		for (let x = 0; x < width; x += r.sliceWidth) {
 			const offset =
-				Math.sin((x / r.wavelength) * Math.PI * 2 + frame * r.speed) *
-				r.amplitude;
+				Math.sin((x / r.wavelength) * Math.PI * 2 + r.evolution) * r.amplitude;
 			ctx.drawImage(
 				source,
 				x,
@@ -71,5 +109,5 @@ export const wave = createEffect<WaveParams, null>({
 		}
 	},
 	cleanup: () => undefined,
-	schema: null,
+	schema: waveSchema,
 });

--- a/packages/example/src/EffectsTestbed/EffectsTestbed.tsx
+++ b/packages/example/src/EffectsTestbed/EffectsTestbed.tsx
@@ -6,7 +6,13 @@ import {LightLeakInternals} from '@remotion/light-leaks';
 import {Video} from '@remotion/media';
 import {StarburstInternals} from '@remotion/starburst';
 import React from 'react';
-import {AbsoluteFill, Experimental, staticFile} from 'remotion';
+import {
+	AbsoluteFill,
+	Experimental,
+	staticFile,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
 
 const SAMPLE_VIDEO = staticFile('bigbuckbunny.mp4');
 
@@ -77,6 +83,81 @@ const tileVideoStyle: React.CSSProperties = {
 	height: '100%',
 };
 
+const AnimatedWaveVideo: React.FC = () => {
+	const frame = useCurrentFrame();
+	const evolution = frame * 0.2;
+
+	return (
+		<Video
+			src={SAMPLE_VIDEO}
+			style={tileVideoStyle}
+			muted
+			loop
+			objectFit="cover"
+			_experimentalEffects={[
+				wave({
+					amplitude: 22,
+					wavelength: 180,
+					evolution,
+					sliceWidth: 4,
+					background: '#020617',
+				}),
+			]}
+		/>
+	);
+};
+
+const AnimatedLightLeakSolid: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {durationInFrames} = useVideoConfig();
+	const progress = durationInFrames <= 1 ? 0 : frame / (durationInFrames - 1);
+
+	return (
+		<Experimental.Solid
+			width={400}
+			height={300}
+			color="#ff5fa2"
+			style={tileVideoStyle}
+			_experimentalEffects={[
+				LightLeakInternals.lightLeak({
+					seed: 1,
+					hueShift: 30,
+					progress,
+				}),
+			]}
+		/>
+	);
+};
+
+const AnimatedStackVideo: React.FC = () => {
+	const frame = useCurrentFrame();
+	const evolution = frame * 0.2;
+
+	return (
+		<Video
+			src={SAMPLE_VIDEO}
+			style={tileVideoStyle}
+			muted
+			loop
+			objectFit="cover"
+			_experimentalEffects={[
+				StarburstInternals.starburst({
+					colors: ['#ff5fa2', '#ff0000'],
+					rays: 12,
+				}),
+				blur({radius: 24}),
+				wave({
+					amplitude: 22,
+					wavelength: 180,
+					evolution,
+					sliceWidth: 4,
+					background: '#020617',
+				}),
+			]}
+		/>
+	);
+};
+
 export const EffectsTestbed: React.FC = () => {
 	return (
 		<AbsoluteFill
@@ -126,23 +207,8 @@ export const EffectsTestbed: React.FC = () => {
 						]}
 					/>
 				</Tile>
-				<Tile title="wave" subtitle="amplitude 22, animated">
-					<Video
-						src={SAMPLE_VIDEO}
-						style={tileVideoStyle}
-						muted
-						loop
-						objectFit="cover"
-						_experimentalEffects={[
-							wave({
-								amplitude: 22,
-								wavelength: 180,
-								speed: 0.2,
-								sliceWidth: 4,
-								background: '#020617',
-							}),
-						]}
-					/>
+				<Tile title="wave" subtitle="amplitude 22, evolution from frame">
+					<AnimatedWaveVideo />
 				</Tile>
 			</div>
 			<div style={{flex: 1, display: 'flex', flexDirection: 'row', gap: 16}}>
@@ -156,41 +222,13 @@ export const EffectsTestbed: React.FC = () => {
 						_experimentalEffects={[blur({radius: 24})]}
 					/>
 				</Tile>
-				<Tile title="solid" subtitle="light leak">
-					<Experimental.Solid
-						width={400}
-						height={300}
-						color="#ff5fa2"
-						style={tileVideoStyle}
-						_experimentalEffects={[
-							LightLeakInternals.lightLeak({seed: 1, hueShift: 30}),
-						]}
-					/>
+				<Tile title="solid" subtitle="light leak, progress from frame">
+					<AnimatedLightLeakSolid />
 				</Tile>
 			</div>
 			<div style={{flex: 1, display: 'flex', flexDirection: 'row', gap: 16}}>
-				<Tile title="starburst" subtitle="separable Gaussian, radius 24">
-					<Video
-						src={SAMPLE_VIDEO}
-						style={tileVideoStyle}
-						muted
-						loop
-						objectFit="cover"
-						_experimentalEffects={[
-							StarburstInternals.starburst({
-								colors: ['#ff5fa2', '#ff0000'],
-								rays: 12,
-							}),
-							blur({radius: 24}),
-							wave({
-								amplitude: 22,
-								wavelength: 180,
-								speed: 0.2,
-								sliceWidth: 4,
-								background: '#020617',
-							}),
-						]}
-					/>
+				<Tile title="starburst" subtitle="starburst + blur + wave">
+					<AnimatedStackVideo />
 				</Tile>
 			</div>
 		</AbsoluteFill>

--- a/packages/light-leaks/src/light-leak-internals.ts
+++ b/packages/light-leaks/src/light-leak-internals.ts
@@ -12,36 +12,33 @@ export const lightLeakEffectSchema = {
 		default: 0,
 		description: 'Hue Shift',
 	},
-	durationInFrames: {
+	progress: {
 		type: 'number',
-		min: 1,
-		max: 100_000,
-		step: 1,
-		default: 300,
-		description: 'Duration in frames',
+		min: 0,
+		max: 1,
+		step: 0.01,
+		default: 0,
+		description: 'Progress',
 	},
 } as const satisfies SequenceSchema;
 
 export type LightLeakEffectParams = {
 	readonly seed?: number;
 	readonly hueShift?: number;
-	/**
-	 * Controls evolve/retract timing, matching `<LightLeak>` when set to the same
-	 * duration as your composition or sequence.
-	 */
-	readonly durationInFrames?: number;
+	/** Evolve/retract phase from 0 (start) to 1 (end). */
+	readonly progress?: number;
 };
 
 type LightLeakResolved = {
 	seed: number;
 	hueShift: number;
-	durationInFrames: number;
+	progress: number;
 };
 
 const resolve = (p: LightLeakEffectParams): LightLeakResolved => ({
 	seed: p.seed ?? 0,
 	hueShift: p.hueShift ?? 0,
-	durationInFrames: p.durationInFrames ?? 300,
+	progress: p.progress ?? 0,
 });
 
 const LIGHT_LEAK_VS = /* glsl */ `#version 300 es
@@ -199,7 +196,7 @@ const lightLeak = createEffect<LightLeakEffectParams, LightLeakGlState>({
 	backend: 'webgl2',
 	calculateKey: (params) => {
 		const r = resolve(params);
-		return `light-leak-${r.seed}-${r.hueShift}-${r.durationInFrames}`;
+		return `light-leak-${r.seed}-${r.hueShift}-${r.progress}`;
 	},
 	setup: (target) => {
 		const gl = target.getContext('webgl2', {
@@ -273,7 +270,7 @@ const lightLeak = createEffect<LightLeakEffectParams, LightLeakGlState>({
 			uResolution: gl.getUniformLocation(program, 'resolution'),
 		};
 	},
-	apply: ({source, width, height, params, state, frame}) => {
+	apply: ({source, width, height, params, state}) => {
 		const r = resolve(params);
 
 		if (typeof r.seed !== 'number' || !Number.isFinite(r.seed)) {
@@ -294,8 +291,7 @@ const lightLeak = createEffect<LightLeakEffectParams, LightLeakGlState>({
 			);
 		}
 
-		const duration = r.durationInFrames;
-		const normalized = duration <= 1 ? 0 : frame / (duration - 1);
+		const normalized = Math.min(1, Math.max(0, r.progress));
 		const evolveProgress = Math.min(1, normalized * 2);
 		const retractProgress = Math.max(0, normalized * 2 - 1);
 

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -213,7 +213,6 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 				tagType: 'audio',
 				getEffects: () => [],
 				getEffectChainState: () => null,
-				getCurrentFrame: () => 0,
 			});
 
 			mediaPlayerRef.current = player;

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -79,8 +79,6 @@ export class MediaPlayer {
 		height: number,
 	) => EffectChainState | null;
 
-	private getCurrentFrame: () => number;
-
 	private initializationPromise: Promise<MediaPlayerInitResult> | null = null;
 
 	private bufferState: ReturnType<typeof useBufferState>;
@@ -113,7 +111,6 @@ export class MediaPlayer {
 		tagType,
 		getEffects,
 		getEffectChainState,
-		getCurrentFrame,
 	}: {
 		canvas: HTMLCanvasElement | OffscreenCanvas | null;
 		src: string;
@@ -141,7 +138,6 @@ export class MediaPlayer {
 			width: number,
 			height: number,
 		) => EffectChainState | null;
-		getCurrentFrame: () => number;
 	}) {
 		this.canvas = canvas ?? null;
 		this.src = src;
@@ -177,7 +173,6 @@ export class MediaPlayer {
 		this.tagType = tagType;
 		this.getEffects = getEffects;
 		this.getEffectChainState = getEffectChainState;
-		this.getCurrentFrame = getCurrentFrame;
 
 		if (canvas) {
 			const context = canvas.getContext('2d', {
@@ -338,7 +333,6 @@ export class MediaPlayer {
 					getIsLooping: () => this.loop,
 					getEffects: this.getEffects,
 					getEffectChainState: this.getEffectChainState,
-					getCurrentFrame: this.getCurrentFrame,
 				});
 			}
 

--- a/packages/media/src/test/media-player.test.ts
+++ b/packages/media/src/test/media-player.test.ts
@@ -56,7 +56,6 @@ test('audio-only file should initialize without `audioStreamIndex` (regression f
 		sequenceOffset: 0,
 		credentials: undefined,
 		tagType: 'audio',
-		getCurrentFrame: () => 0,
 		getEffects: () => [],
 		getEffectChainState: () => null,
 	});
@@ -124,7 +123,6 @@ test('dispose should immediately unblock playback delays', async () => {
 		tagType: 'video',
 		getEffects: () => [],
 		getEffectChainState: () => null,
-		getCurrentFrame: () => 0,
 	});
 
 	await player.initialize(0, false);

--- a/packages/media/src/test/trim-change-seek.test.ts
+++ b/packages/media/src/test/trim-change-seek.test.ts
@@ -26,7 +26,6 @@ test('setTrimBefore and setTrimAfter should update frame when paused', async () 
 		tagType: 'video',
 		getEffects: () => [],
 		getEffectChainState: () => null,
-		getCurrentFrame: () => 0,
 	});
 
 	await player.initialize(0, false);

--- a/packages/media/src/test/video-iterator-manager.test.ts
+++ b/packages/media/src/test/video-iterator-manager.test.ts
@@ -50,7 +50,6 @@ test('seek should not cause overlapping block/unblock cycles', async () => {
 		getIsLooping: () => false,
 		getEffects: () => [],
 		getEffectChainState: () => null,
-		getCurrentFrame: () => 0,
 	});
 
 	const nonceManager = makeNonceManager();
@@ -104,7 +103,6 @@ test('rapid sequential seeks should not cause overlapping blocks', async () => {
 		getIsLooping: () => false,
 		getEffects: () => [],
 		getEffectChainState: () => null,
-		getCurrentFrame: () => 0,
 	});
 
 	const nonceManager = makeNonceManager();

--- a/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
+++ b/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
@@ -42,7 +42,6 @@ test('in preview, should properly buffer and draw frames', async (t) => {
 		getOnVideoFrameCallback: () => null,
 		getEffects: () => [],
 		getEffectChainState: () => null,
-		getCurrentFrame: () => 0,
 	});
 
 	const nonceManager = makeNonceManager();

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -29,7 +29,6 @@ export const videoIteratorManager = async ({
 	getIsLooping,
 	getEffects,
 	getEffectChainState,
-	getCurrentFrame,
 }: {
 	videoTrack: InputVideoTrack;
 	delayPlaybackHandleIfNotPremounting: () => DelayPlaybackIfNotPremounting;
@@ -46,7 +45,6 @@ export const videoIteratorManager = async ({
 		width: number,
 		height: number,
 	) => EffectChainState | null;
-	getCurrentFrame: () => number;
 }) => {
 	let videoIteratorsCreated = 0;
 	let videoFrameIterator: VideoIterator | null = null;
@@ -85,7 +83,6 @@ export const videoIteratorManager = async ({
 					source: frame.canvas,
 					effects,
 					output: canvas,
-					frame: getCurrentFrame(),
 					width: canvas.width,
 					height: canvas.height,
 				});

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -144,8 +144,6 @@ const VideoForPreviewAssertedShowing: React.FC<
 
 	const effectChainStateRef = useRef(effectChainState);
 	effectChainStateRef.current = effectChainState;
-	const frameRef = useRef(frame);
-	frameRef.current = frame;
 
 	const parentSequence = useContext(SequenceContext);
 	const isPremounting = Boolean(parentSequence?.premounting);
@@ -281,7 +279,6 @@ const VideoForPreviewAssertedShowing: React.FC<
 				getEffects: () => experimentalEffectsRef.current,
 				getEffectChainState: (width, height) =>
 					effectChainStateRef.current?.get(width, height)!,
-				getCurrentFrame: () => frameRef.current,
 			});
 
 			mediaPlayerRef.current = player;

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -108,12 +108,7 @@ export const getEffectFieldsToShow = (
 	effect: EffectDefinition<unknown>,
 	effectIndex: number,
 ): EffectSchemaFieldInfo[] => {
-	const effectSchema = effect.schema;
-	if (!effectSchema) {
-		return [];
-	}
-
-	return Object.entries(effectSchema)
+	return Object.entries(effect.schema)
 		.map(([key, fieldSchema]): EffectSchemaFieldInfo | null => {
 			const typeName = fieldSchema.type;
 			if (typeName === 'hidden') {
@@ -137,7 +132,7 @@ export const getEffectFieldsToShow = (
 				typeName,
 				rowHeight: SCHEMA_FIELD_ROW_HEIGHT,
 				fieldSchema,
-				effectSchema,
+				effectSchema: effect.schema,
 				effectIndex,
 			};
 		})

--- a/packages/studio/src/components/Timeline/SubscribeToNodePaths.tsx
+++ b/packages/studio/src/components/Timeline/SubscribeToNodePaths.tsx
@@ -1,6 +1,5 @@
 import {useMemo, type FC} from 'react';
 import type {EffectDefinition, SequenceSchema} from 'remotion';
-import {NoReactInternals} from 'remotion/no-react';
 import {useResolvedStack} from './use-resolved-stack';
 import {useSequencePropsSubscription} from './use-sequence-props-subscription';
 
@@ -13,11 +12,7 @@ export const SubscribeToNodePaths: FC<{
 	const originalLocation = useResolvedStack(stack);
 
 	const effectSubscriptions = useMemo<SequenceSchema[]>(() => {
-		return effects
-			.map((effect): SequenceSchema | null => {
-				return effect.schema;
-			})
-			.filter(NoReactInternals.truthy);
+		return effects.map((effect) => effect.schema);
 	}, [effects]);
 
 	useSequencePropsSubscription({

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -104,9 +104,7 @@ export const buildTimelineTree = ({
 						numberOfSequencesWithThisNodePath: 0,
 					},
 					label: effect.label,
-					effectInfo: effect.schema
-						? {effectIndex: i, effectSchema: effect.schema}
-						: null,
+					effectInfo: {effectIndex: i, effectSchema: effect.schema},
 					children: effectFields.map(
 						(f): TimelineTreeNode => ({
 							kind: 'field',

--- a/packages/transitions/src/html-in-canvas-presentation.tsx
+++ b/packages/transitions/src/html-in-canvas-presentation.tsx
@@ -5,7 +5,7 @@ import {
 	useDelayRender,
 	type EffectsProp,
 } from 'remotion';
-import {AbsoluteFill, Internals, useCurrentFrame} from 'remotion';
+import {AbsoluteFill, Internals} from 'remotion';
 import type {DrawFunction} from './TransitionSeries';
 import type {
 	TransitionPresentation,
@@ -49,10 +49,6 @@ export const HtmlInCanvasPresentation = <
 
 	const passedPropsRef = useRef(passedProps);
 	passedPropsRef.current = passedProps;
-
-	const frame = useCurrentFrame();
-	const frameRef = useRef(frame);
-	frameRef.current = frame;
 
 	const memoizedEffects = Internals.useMemoizedEffects({
 		effects: _experimentalEffects ?? [],
@@ -112,7 +108,6 @@ export const HtmlInCanvasPresentation = <
 				state: chainState.get(width, height)!,
 				source: offscreenCanvas,
 				effects: effectsRef.current ?? [],
-				frame: frameRef.current,
 				width,
 				height,
 				output: canvasRef.current,


### PR DESCRIPTION
## Summary

- Removes `frame` from `EffectApplyParams` and `runEffectChain` so effects are purely param-driven.
- **`lightLeak`**: replaces `durationInFrames` + internal frame math with a `progress` param (0–1) exposed in the schema.
- **`wave`**: replaces `speed` + frame-driven phase with an `evolution` param and adds `waveSchema` for Studio controls.
- Drops `getCurrentFrame` from `MediaPlayer` / `videoIteratorManager` (it only existed to pass frame into the effect chain).
- Updates `EffectsTestbed` to animate via `useCurrentFrame()` → `progress` / `evolution` in effect params.

The `<LightLeak>` component is unchanged; it still uses `durationInFrames` as a Sequence prop and drives animation internally.

## Test plan

- [x] `bun test` in `packages/core` (`effect-internals.test.ts`, `create-effect-disabled.test.ts`)
- [ ] Open `EffectsTestbed` composition and confirm wave + light leak still animate
- [ ] Verify static effects (blur, tint, halftone, starburst) render unchanged on `<Video>` / `<Solid>`


Made with [Cursor](https://cursor.com)