### PR TITLE
`@remotion/layout-utils`: Don't publish test files

### DIFF
--- a/packages/layout-utils/.npmignore
+++ b/packages/layout-utils/.npmignore
@@ -1,4 +1,5 @@
 dist/test/**
+dist/cjs/test
 src
 tsconfig.tsbuildinfo
 *.tgz
@@ -7,3 +8,4 @@ tsconfig.json
 .prettierrc.js
 bundle.ts
 eslint.config.mjs
+vitest.config.ts


### PR DESCRIPTION
## Summary
- The release on `4.0.463` aborted because `set-version.ts`'s `no-dev-files` monorepo test failed: `@remotion/layout-utils` was publishing `dist/cjs/test/Root.d.ts` and other test artifacts.
- Root cause: `layout-utils` builds to `dist/cjs` (its `tsconfig` sets `"outDir": "dist/cjs"`), but its `.npmignore` only excluded `dist/test/**`. `shapes` works because its `outDir` is `./dist`.
- Added `dist/cjs/test` (matching the convention in `core`, `player`, `lottie`, `noise`, `lambda-client`) and `vitest.config.ts` (matching `media`, `web-renderer`) to `packages/layout-utils/.npmignore`.

## Test plan
- [x] `bun test src/monorepo/no-dev-files.test.ts` → 94 pass, 0 fail
- [x] `bun pm pack --dry-run` in `packages/layout-utils` no longer lists any `test/` or `.ts` (non-`.d.ts`) files

🤖 Generated with [Claude Code](https://claude.com/claude-code)