### PR TITLE
`@remotion/vercel`: Fix nested bundle upload and surface sandbox API errors

### DIFF
--- a/packages/vercel/src/add-bundle-to-sandbox.ts
+++ b/packages/vercel/src/add-bundle-to-sandbox.ts
@@ -1,12 +1,22 @@
 import {readdir, readFile} from 'fs/promises';
 import path from 'path';
 import type {Sandbox} from '@vercel/sandbox';
-import {REMOTION_SANDBOX_BUNDLE_DIR} from './internals/add-bundle';
+import {
+	getAncestorDirectories,
+	REMOTION_SANDBOX_BUNDLE_DIR,
+	toPosixPath,
+	toSandboxBundlePath,
+} from './internals/add-bundle';
+import {rethrowSandboxError} from './internals/format-sandbox-error';
+
+const resolveBundleDirectory = (bundleDir: string): string => {
+	return path.isAbsolute(bundleDir) ? bundleDir : path.resolve(bundleDir);
+};
 
 async function getRemotionBundleFiles(
 	bundleDir: string,
 ): Promise<{path: string; content: Buffer}[]> {
-	const fullBundleDir = path.join(process.cwd(), bundleDir);
+	const fullBundleDir = resolveBundleDirectory(bundleDir);
 
 	const files: {path: string; content: Buffer}[] = [];
 
@@ -19,7 +29,7 @@ async function getRemotionBundleFiles(
 				await readDirRecursive(fullPath, relativePath);
 			} else {
 				const content = await readFile(fullPath);
-				files.push({path: relativePath, content});
+				files.push({path: toPosixPath(relativePath), content});
 			}
 		}
 	}
@@ -27,6 +37,20 @@ async function getRemotionBundleFiles(
 	await readDirRecursive(fullBundleDir);
 	return files;
 }
+
+const collectBundleDirectories = (
+	bundleFiles: {path: string; content: Buffer}[],
+): string[] => {
+	const dirs = new Set<string>();
+
+	for (const file of bundleFiles) {
+		for (const dir of getAncestorDirectories(file.path)) {
+			dirs.add(dir);
+		}
+	}
+
+	return Array.from(dirs).sort();
+};
 
 export async function addBundleToSandbox({
 	sandbox,
@@ -36,23 +60,32 @@ export async function addBundleToSandbox({
 	bundleDir: string;
 }): Promise<void> {
 	const bundleFiles = await getRemotionBundleFiles(bundleDir);
+	const directories = collectBundleDirectories(bundleFiles);
 
-	const dirs = new Set<string>();
-	for (const file of bundleFiles) {
-		const dir = path.dirname(file.path);
-		if (dir && dir !== '.') {
-			dirs.add(dir);
+	for (const dir of directories) {
+		const sandboxPath = toSandboxBundlePath(dir);
+		try {
+			await sandbox.mkDir(sandboxPath);
+		} catch (error) {
+			rethrowSandboxError({
+				error,
+				operation: `create directory "${dir}"`,
+				sandboxPath,
+			});
 		}
 	}
 
-	for (const dir of Array.from(dirs).sort()) {
-		await sandbox.mkDir(REMOTION_SANDBOX_BUNDLE_DIR + '/' + dir);
+	try {
+		await sandbox.writeFiles(
+			bundleFiles.map((file) => ({
+				path: toSandboxBundlePath(file.path),
+				content: file.content,
+			})),
+		);
+	} catch (error) {
+		rethrowSandboxError({
+			error,
+			operation: `upload ${bundleFiles.length} bundle file(s) to "${REMOTION_SANDBOX_BUNDLE_DIR}"`,
+		});
 	}
-
-	await sandbox.writeFiles(
-		bundleFiles.map((file) => ({
-			path: REMOTION_SANDBOX_BUNDLE_DIR + '/' + file.path,
-			content: file.content,
-		})),
-	);
 }

--- a/packages/vercel/src/add-bundle-to-sandbox.ts
+++ b/packages/vercel/src/add-bundle-to-sandbox.ts
@@ -10,7 +10,7 @@ import {
 import {rethrowSandboxError} from './internals/format-sandbox-error';
 
 const resolveBundleDirectory = (bundleDir: string): string => {
-	return path.isAbsolute(bundleDir) ? bundleDir : path.resolve(bundleDir);
+	return path.resolve(bundleDir);
 };
 
 async function getRemotionBundleFiles(

--- a/packages/vercel/src/internals/add-bundle.ts
+++ b/packages/vercel/src/internals/add-bundle.ts
@@ -1,1 +1,21 @@
 export const REMOTION_SANDBOX_BUNDLE_DIR = 'remotion-bundle';
+
+export const toPosixPath = (filePath: string): string => {
+	return filePath.split(/[/\\]/).join('/');
+};
+
+export const getAncestorDirectories = (relativePath: string): string[] => {
+	const normalized = toPosixPath(relativePath);
+	const parts = normalized.split('/').filter(Boolean);
+	const dirs: string[] = [];
+
+	for (let i = 0; i < parts.length - 1; i++) {
+		dirs.push(parts.slice(0, i + 1).join('/'));
+	}
+
+	return dirs;
+};
+
+export const toSandboxBundlePath = (relativePath: string): string => {
+	return `${REMOTION_SANDBOX_BUNDLE_DIR}/${toPosixPath(relativePath)}`;
+};

--- a/packages/vercel/src/internals/format-sandbox-error.ts
+++ b/packages/vercel/src/internals/format-sandbox-error.ts
@@ -1,0 +1,36 @@
+import {APIError} from '@vercel/sandbox';
+
+export const formatSandboxError = (error: unknown): string => {
+	if (error instanceof APIError) {
+		const parts = [error.message];
+		if (error.json !== undefined) {
+			parts.push(`Response JSON: ${JSON.stringify(error.json)}`);
+		} else if (error.text) {
+			parts.push(`Response body: ${error.text}`);
+		}
+
+		return parts.join('\n');
+	}
+
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
+};
+
+export const rethrowSandboxError = ({
+	error,
+	operation,
+	sandboxPath,
+}: {
+	error: unknown;
+	operation: string;
+	sandboxPath?: string;
+}): never => {
+	const pathSuffix = sandboxPath ? ` at "${sandboxPath}"` : '';
+	throw new Error(
+		`Failed to ${operation} in Vercel sandbox${pathSuffix}: ${formatSandboxError(error)}`,
+		{cause: error instanceof Error ? error : undefined},
+	);
+};


### PR DESCRIPTION
## Summary

- Create all ancestor directories (e.g. `public` before `public/fonts`) when uploading a Remotion bundle to a Vercel Sandbox, fixing failures for bundles with nested folders such as the default `public/` copy from `bundle()`.
- Surface the Vercel Sandbox API error JSON/body in thrown errors instead of only `Status code 400 is not ok`.
- Resolve `bundleDir` with `path.resolve()` and normalize sandbox paths to POSIX separators.

Fixes #7428.

## Test plan

- [ ] Bundle a project with nested files under `public/` (e.g. `public/fonts/Inter.woff2`)
- [ ] Call `createSandbox()` then `addBundleToSandbox({ sandbox, bundleDir })` with an absolute `bundleDir`
- [ ] Confirm upload succeeds and nested files are present in the sandbox
- [ ] Confirm a deliberate failure (e.g. invalid sandbox path) includes the API response body in the error message


Made with [Cursor](https://cursor.com)