### PR TITLE
`@remotion/studio`: Align timeline effect toggle with visibility toggles

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
@@ -28,6 +28,7 @@ export const TimelineEffectGroupRow: React.FC<{
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly validatedLocation: CodePosition;
 	readonly nestedDepth: number;
+	readonly depth: number;
 	readonly style: React.CSSProperties;
 	readonly getIsExpanded: GetIsExpanded;
 	readonly toggleTrack: (nodePathInfo: SequenceNodePathInfo) => void;
@@ -39,6 +40,7 @@ export const TimelineEffectGroupRow: React.FC<{
 	nodePath,
 	validatedLocation,
 	nestedDepth,
+	depth,
 	style,
 	getIsExpanded,
 	toggleTrack,
@@ -113,7 +115,6 @@ export const TimelineEffectGroupRow: React.FC<{
 
 	return (
 		<div style={mergedStyle}>
-			<Padder depth={nestedDepth + 1} />
 			{canToggle ? (
 				<TimelineLayerEye
 					type="effect"
@@ -123,6 +124,7 @@ export const TimelineEffectGroupRow: React.FC<{
 			) : (
 				<TimelineLayerEyeSpacer />
 			)}
+			<Padder depth={nestedDepth + 1 + depth} />
 			<TimelineExpandArrowButton
 				isExpanded={isExpanded}
 				onClick={() => toggleTrack(nodePathInfo)}

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -62,6 +62,11 @@ export const TimelineExpandedRow: React.FC<{
 		[paddingLeft],
 	);
 
+	const effectGroupStyle = useMemo(
+		(): React.CSSProperties => ({...groupRowBase, paddingLeft: 5}),
+		[],
+	);
+
 	const labelOnlyStyle = useMemo(
 		(): React.CSSProperties => ({
 			...labelOnlyRowBase,
@@ -82,7 +87,8 @@ export const TimelineExpandedRow: React.FC<{
 					nodePath={nodePath}
 					validatedLocation={validatedLocation}
 					nestedDepth={nestedDepth}
-					style={groupStyle}
+					depth={depth}
+					style={effectGroupStyle}
 					getIsExpanded={getIsExpanded}
 					toggleTrack={toggleTrack}
 				/>


### PR DESCRIPTION
## Summary

- Moves the effect enable/disable (`fx`) toggle to the left edge of effect group rows in the timeline layer list, aligned with the eye and speaker visibility toggles on track rows.
- Renders the toggle before nesting padding and uses the same `paddingLeft: 5` as track rows instead of the expanded-section indent.

## Test plan

- [ ] Open Remotion Studio with a composition that has sequences with effects
- [ ] Expand a track in the timeline layer list
- [ ] Confirm the effect toggle sits in the same column as the eye/speaker icons on the parent track row
- [ ] Toggle an effect off/on and confirm it still works
- [ ] Expand/collapse effect groups and verify arrow + label indentation still looks reasonable


Made with [Cursor](https://cursor.com)