### PR TITLE
Enable react-refresh/only-export-components ESLint warning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -640,7 +640,6 @@
         "eslint-plugin-10x": "1.5.2",
         "eslint-plugin-react": "7.37.4",
         "eslint-plugin-react-hooks": "5.0.0",
-        "eslint-plugin-react-refresh": "0.5.2",
       },
       "devDependencies": {
         "@types/eslint__eslintrc": "2.1.2",

--- a/bun.lock
+++ b/bun.lock
@@ -602,6 +602,7 @@
         "eslint": "catalog:",
         "eslint-plugin-react": "7.37.4",
         "eslint-plugin-react-hooks": "4.6.0",
+        "eslint-plugin-react-refresh": "0.5.2",
       },
       "peerDependencies": {
         "eslint": ">=7.15.0",
@@ -621,6 +622,7 @@
         "eslint": "catalog:",
         "eslint-plugin-react": "7.37.4",
         "eslint-plugin-react-hooks": "5.2.0",
+        "eslint-plugin-react-refresh": "0.5.2",
       },
       "peerDependencies": {
         "eslint": ">=9",
@@ -638,6 +640,7 @@
         "eslint-plugin-10x": "1.5.2",
         "eslint-plugin-react": "7.37.4",
         "eslint-plugin-react-hooks": "5.0.0",
+        "eslint-plugin-react-refresh": "0.5.2",
       },
       "devDependencies": {
         "@types/eslint__eslintrc": "2.1.2",
@@ -5744,6 +5747,8 @@
     "eslint-plugin-react": ["eslint-plugin-react@7.37.4", "", { "dependencies": { "array-includes": "3.1.8", "array.prototype.findlast": "1.2.5", "array.prototype.flatmap": "1.3.3", "array.prototype.tosorted": "1.1.4", "doctrine": "2.1.0", "es-iterator-helpers": "1.2.1", "estraverse": "5.3.0", "hasown": "2.0.2", "jsx-ast-utils": "3.3.5", "minimatch": "3.1.2", "object.entries": "1.1.8", "object.fromentries": "2.0.8", "object.values": "1.2.1", "prop-types": "15.8.1", "resolve": "2.0.0-next.5", "semver": "6.3.1", "string.prototype.matchall": "4.0.12", "string.prototype.repeat": "1.0.0" }, "peerDependencies": { "eslint": "9.19.0" } }, "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ=="],
 
     "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@4.6.0", "", { "peerDependencies": { "eslint": "9.19.0" } }, "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="],
+
+    "eslint-plugin-react-refresh": ["eslint-plugin-react-refresh@0.5.2", "", { "peerDependencies": { "eslint": "^9 || ^10" } }, "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "4.3.0", "estraverse": "5.3.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 

--- a/packages/eslint-config-flat/package.json
+++ b/packages/eslint-config-flat/package.json
@@ -32,6 +32,7 @@
 		"@eslint/js": "9.19.0",
 		"eslint-plugin-react": "7.37.4",
 		"eslint-plugin-react-hooks": "5.2.0",
+		"eslint-plugin-react-refresh": "0.5.2",
 		"@remotion/eslint-config-internal": "workspace:*",
 		"eslint": "catalog:",
 		"@typescript/native-preview": "catalog:"

--- a/packages/eslint-config-flat/src/index.ts
+++ b/packages/eslint-config-flat/src/index.ts
@@ -52,7 +52,10 @@ export const makeConfig = ({
 				'react/jsx-no-useless-fragment': 'off',
 				// This is generally okay because on every frame, there will be a full rerender anyway!
 				'react/no-array-index-key': 'off',
-				'react-refresh/only-export-components': 'warn',
+				'react-refresh/only-export-components': [
+					'warn',
+					{allowConstantExport: true},
+				],
 			},
 			settings: {
 				react: {

--- a/packages/eslint-config-flat/src/index.ts
+++ b/packages/eslint-config-flat/src/index.ts
@@ -3,6 +3,7 @@ import remotionPlugin from '@remotion/eslint-plugin';
 import type {Linter} from 'eslint';
 import reactPlugin from 'eslint-plugin-react';
 import hooksPlugin from 'eslint-plugin-react-hooks';
+import {reactRefresh} from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export const makeConfig = ({
@@ -28,6 +29,7 @@ export const makeConfig = ({
 			plugins: {
 				react: reactPlugin,
 				'react-hooks': hooksPlugin,
+				'react-refresh': reactRefresh.plugin,
 			},
 			languageOptions: {
 				...reactPlugin.configs.flat.recommended.languageOptions,
@@ -50,6 +52,7 @@ export const makeConfig = ({
 				'react/jsx-no-useless-fragment': 'off',
 				// This is generally okay because on every frame, there will be a full rerender anyway!
 				'react/no-array-index-key': 'off',
+				'react-refresh/only-export-components': 'warn',
 			},
 			settings: {
 				react: {

--- a/packages/eslint-config-internal/package.json
+++ b/packages/eslint-config-internal/package.json
@@ -29,6 +29,7 @@
 		"eslint-plugin-10x": "1.5.2",
 		"eslint-plugin-react": "7.37.4",
 		"eslint-plugin-react-hooks": "5.0.0",
+		"eslint-plugin-react-refresh": "0.5.2",
 		"@eslint/compat": "1.2.2",
 		"@eslint/eslintrc": "3.1.0",
 		"@eslint/js": "9.19.0"

--- a/packages/eslint-config-internal/package.json
+++ b/packages/eslint-config-internal/package.json
@@ -29,7 +29,6 @@
 		"eslint-plugin-10x": "1.5.2",
 		"eslint-plugin-react": "7.37.4",
 		"eslint-plugin-react-hooks": "5.0.0",
-		"eslint-plugin-react-refresh": "0.5.2",
 		"@eslint/compat": "1.2.2",
 		"@eslint/eslintrc": "3.1.0",
 		"@eslint/js": "9.19.0"

--- a/packages/eslint-config-internal/src/base.ts
+++ b/packages/eslint-config-internal/src/base.ts
@@ -583,7 +583,10 @@ export const rules = ({react}: {react: boolean}) => {
 					'react/jsx-fragments': react ? 'off' : undefined,
 					'react-hooks/rules-of-hooks': 'error',
 					'react-hooks/exhaustive-deps': 'error',
-					'react-refresh/only-export-components': 'warn',
+					'react-refresh/only-export-components': [
+						'warn',
+						{allowConstantExport: true},
+					],
 				} satisfies Partial<Linter.RulesRecord>)
 			: {}),
 	} satisfies Partial<Linter.RulesRecord>;

--- a/packages/eslint-config-internal/src/base.ts
+++ b/packages/eslint-config-internal/src/base.ts
@@ -583,6 +583,7 @@ export const rules = ({react}: {react: boolean}) => {
 					'react/jsx-fragments': react ? 'off' : undefined,
 					'react-hooks/rules-of-hooks': 'error',
 					'react-hooks/exhaustive-deps': 'error',
+					'react-refresh/only-export-components': 'warn',
 				} satisfies Partial<Linter.RulesRecord>)
 			: {}),
 	} satisfies Partial<Linter.RulesRecord>;

--- a/packages/eslint-config-internal/src/base.ts
+++ b/packages/eslint-config-internal/src/base.ts
@@ -583,10 +583,6 @@ export const rules = ({react}: {react: boolean}) => {
 					'react/jsx-fragments': react ? 'off' : undefined,
 					'react-hooks/rules-of-hooks': 'error',
 					'react-hooks/exhaustive-deps': 'error',
-					'react-refresh/only-export-components': [
-						'warn',
-						{allowConstantExport: true},
-					],
 				} satisfies Partial<Linter.RulesRecord>)
 			: {}),
 	} satisfies Partial<Linter.RulesRecord>;

--- a/packages/eslint-config-internal/src/index.ts
+++ b/packages/eslint-config-internal/src/index.ts
@@ -10,7 +10,6 @@ const __dirname = new URL('.', import.meta.url).pathname;
 const {configs, rules: reactRules} = require('eslint-plugin-react');
 
 import {Linter} from 'eslint';
-import {reactRefresh} from 'eslint-plugin-react-refresh';
 import {rules} from './base.js';
 
 const compat = new FlatCompat({
@@ -53,7 +52,6 @@ export const remotionFlatConfig = ({
 		// @ts-expect-error
 		'@typescript-eslint': typescriptPlugin,
 		...(react ? compat.plugins('react-hooks')[0].plugins : {}),
-		...(react ? {'react-refresh': reactRefresh.plugin} : {}),
 	},
 	rules: rules({react}),
 	files: [

--- a/packages/eslint-config-internal/src/index.ts
+++ b/packages/eslint-config-internal/src/index.ts
@@ -10,6 +10,7 @@ const __dirname = new URL('.', import.meta.url).pathname;
 const {configs, rules: reactRules} = require('eslint-plugin-react');
 
 import {Linter} from 'eslint';
+import {reactRefresh} from 'eslint-plugin-react-refresh';
 import {rules} from './base.js';
 
 const compat = new FlatCompat({
@@ -52,6 +53,7 @@ export const remotionFlatConfig = ({
 		// @ts-expect-error
 		'@typescript-eslint': typescriptPlugin,
 		...(react ? compat.plugins('react-hooks')[0].plugins : {}),
+		...(react ? {'react-refresh': reactRefresh.plugin} : {}),
 	},
 	rules: rules({react}),
 	files: [

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,6 +30,7 @@
 		"@typescript-eslint/parser": "6.21.0",
 		"eslint-plugin-react": "7.37.4",
 		"eslint-plugin-react-hooks": "4.6.0",
+		"eslint-plugin-react-refresh": "0.5.2",
 		"@remotion/eslint-config-internal": "workspace:*",
 		"eslint": "catalog:",
 		"@typescript/native-preview": "catalog:"

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -467,6 +467,7 @@ const getRules = (typescript: boolean) => {
 
 		'react-hooks/rules-of-hooks': 'error',
 		'react-hooks/exhaustive-deps': 'warn',
+		'react-refresh/only-export-components': 'warn',
 		// Turning off rules that are too strict or don't apply to Remotion
 		'react/jsx-no-constructed-context-values': 'off',
 		'no-console': 'off',
@@ -518,7 +519,13 @@ export = {
 		es6: true,
 		jest: true,
 	},
-	plugins: ['react', 'react-hooks', '@typescript-eslint', '@remotion'],
+	plugins: [
+		'react',
+		'react-hooks',
+		'react-refresh',
+		'@typescript-eslint',
+		'@remotion',
+	],
 	extends: baseExtends,
 	parser: require.resolve('@typescript-eslint/parser'),
 	parserOptions: {

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -467,7 +467,10 @@ const getRules = (typescript: boolean) => {
 
 		'react-hooks/rules-of-hooks': 'error',
 		'react-hooks/exhaustive-deps': 'warn',
-		'react-refresh/only-export-components': 'warn',
+		'react-refresh/only-export-components': [
+			'warn',
+			{allowConstantExport: true},
+		],
 		// Turning off rules that are too strict or don't apply to Remotion
 		'react/jsx-no-constructed-context-values': 'off',
 		'no-console': 'off',

--- a/packages/example/src/3DContext/Div3D.tsx
+++ b/packages/example/src/3DContext/Div3D.tsx
@@ -4,7 +4,7 @@ import {DivExtrusion} from './DivExtrusion';
 import {Face} from './FrontFace';
 import {RectProvider} from './path-context';
 import {BottomSide, TopSide} from './TopSide';
-import {useTransformations} from './transformation-context';
+import {useTransformations} from './use-transformations';
 import {isBacksideVisible} from './viewing-frontside';
 
 export const ExtrudeDiv: React.FC<{

--- a/packages/example/src/3DContext/DivExtrusion.tsx
+++ b/packages/example/src/3DContext/DivExtrusion.tsx
@@ -1,5 +1,5 @@
 import {SvgExtrusion} from './Extrusion';
-import {useRect} from './path-context';
+import {useRect} from './use-rect';
 
 export const DivExtrusion: React.FC<{
 	depth: number;

--- a/packages/example/src/3DContext/Extrusion.tsx
+++ b/packages/example/src/3DContext/Extrusion.tsx
@@ -6,8 +6,8 @@ import {
 	translateY,
 } from '@remotion/svg-3d-engine';
 import {Faces} from '../3DEngine/Faces';
-import {useRect} from './path-context';
-import {useTransformations} from './transformation-context';
+import {useRect} from './use-rect';
+import {useTransformations} from './use-transformations';
 
 export const SvgExtrusion: React.FC<{
 	depth: number;

--- a/packages/example/src/3DContext/FrontFace.tsx
+++ b/packages/example/src/3DContext/FrontFace.tsx
@@ -4,8 +4,8 @@ import {
 	scaleX,
 	translateZ,
 } from '@remotion/svg-3d-engine';
-import {useRect} from './path-context';
-import {useTransformations} from './transformation-context';
+import {useRect} from './use-rect';
+import {useTransformations} from './use-transformations';
 
 export const Face: React.FC<{
 	children: React.ReactNode;

--- a/packages/example/src/3DContext/FrontFaceG.tsx
+++ b/packages/example/src/3DContext/FrontFaceG.tsx
@@ -4,7 +4,7 @@ import {
 	scaleY,
 	translateZ,
 } from '@remotion/svg-3d-engine';
-import {useTransformations} from './transformation-context';
+import {useTransformations} from './use-transformations';
 
 export const FrontFaceG: React.FC<{
 	children: React.ReactNode;

--- a/packages/example/src/3DContext/TopSide.tsx
+++ b/packages/example/src/3DContext/TopSide.tsx
@@ -7,7 +7,7 @@ import {
 	translateZ,
 } from '@remotion/svg-3d-engine';
 import React from 'react';
-import {useTransformations} from './transformation-context';
+import {useTransformations} from './use-transformations';
 import {isTopsideVisible} from './viewing-frontside';
 
 export const TopSide: React.FC<{

--- a/packages/example/src/3DContext/path-context-context.tsx
+++ b/packages/example/src/3DContext/path-context-context.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export type PathContext = {
+	height: number;
+	width: number;
+	path: string;
+	viewBox: string;
+	left: number;
+	top: number;
+};
+
+export const pathContext = React.createContext<PathContext | null>(null);

--- a/packages/example/src/3DContext/path-context.tsx
+++ b/packages/example/src/3DContext/path-context.tsx
@@ -1,17 +1,7 @@
 import {getBoundingBox} from '@remotion/paths';
 import {makeRect} from '@remotion/shapes';
 import React, {useMemo} from 'react';
-
-type PathContext = {
-	height: number;
-	width: number;
-	path: string;
-	viewBox: string;
-	left: number;
-	top: number;
-};
-
-export const pathContext = React.createContext<PathContext | null>(null);
+import {pathContext} from './path-context-context';
 
 export const RectProvider: React.FC<{
 	readonly width: number;
@@ -24,7 +14,7 @@ export const RectProvider: React.FC<{
 
 	const viewBox = `0 0 ${width} ${height}`;
 
-	const value: PathContext = useMemo(() => {
+	const value = useMemo(() => {
 		return {height, width, path, viewBox, left: 0, top: 0};
 	}, [height, path, viewBox, width]);
 
@@ -37,19 +27,9 @@ export const PathProvider: React.FC<{
 }> = ({children, d}) => {
 	const {height, width, viewBox, x1, y1} = getBoundingBox(d);
 
-	const value: PathContext = useMemo(() => {
+	const value = useMemo(() => {
 		return {height, width, path: d, viewBox, left: x1, top: y1};
 	}, [d, height, viewBox, width, x1, y1]);
 
 	return <pathContext.Provider value={value}>{children}</pathContext.Provider>;
-};
-
-export const useRect = () => {
-	const value = React.useContext(pathContext);
-
-	if (!value) {
-		throw new Error('useRect must be used within a RectProvider');
-	}
-
-	return value;
 };

--- a/packages/example/src/3DContext/transformation-context-context.tsx
+++ b/packages/example/src/3DContext/transformation-context-context.tsx
@@ -1,0 +1,9 @@
+import {type MatrixTransform4D, scaled} from '@remotion/svg-3d-engine';
+import React from 'react';
+
+export const TransformContext = React.createContext<MatrixTransform4D>(
+	scaled(1),
+);
+export const CenterPointContext = React.createContext<
+	[number, number, number, number]
+>([0, 0, 0, 1]);

--- a/packages/example/src/3DContext/transformation-context-utils.ts
+++ b/packages/example/src/3DContext/transformation-context-utils.ts
@@ -1,0 +1,42 @@
+import type {MatrixTransform4D, Vector4D} from '@remotion/svg-3d-engine';
+
+export function transformPoint({
+	matrix,
+	point,
+}: {
+	matrix: MatrixTransform4D;
+	point: Vector4D;
+}): Vector4D {
+	const [x, y, z, w] = point;
+	const result: number[] = [];
+
+	for (let i = 0; i < 4; i++) {
+		result[i] =
+			matrix[4 * i + 0] * x +
+			matrix[4 * i + 1] * y +
+			matrix[4 * i + 2] * z +
+			matrix[4 * i + 3] * w;
+	}
+	return [result[0], result[1], result[2], result[3]];
+}
+
+export const isTranslateXYTransform = (
+	transform: MatrixTransform4D,
+): boolean => {
+	return (
+		transform[0] === 1 &&
+		transform[1] === 0 &&
+		transform[2] === 0 &&
+		transform[4] === 0 &&
+		transform[5] === 1 &&
+		transform[6] === 0 &&
+		transform[8] === 0 &&
+		transform[9] === 0 &&
+		transform[10] === 1 &&
+		transform[11] === 0 &&
+		transform[12] === 0 &&
+		transform[13] === 0 &&
+		transform[14] === 0 &&
+		transform[15] === 1
+	);
+};

--- a/packages/example/src/3DContext/transformation-context.tsx
+++ b/packages/example/src/3DContext/transformation-context.tsx
@@ -1,5 +1,5 @@
 import {
-	MatrixTransform4D,
+	type MatrixTransform4D,
 	reduceMatrices,
 	rotateX,
 	rotateY,
@@ -8,60 +8,13 @@ import {
 	translateX,
 	translateY,
 	translateZ,
-	Vector4D,
 } from '@remotion/svg-3d-engine';
-import React, {useContext, useMemo} from 'react';
-
-type Context = MatrixTransform4D;
-
-export const TransformContext = React.createContext<Context>(scaled(1));
-export const CenterPointContext = React.createContext<
-	[number, number, number, number]
->([0, 0, 0, 1]);
-
-export function transformPoint({
-	matrix,
-	point,
-}: {
-	matrix: MatrixTransform4D;
-	point: Vector4D;
-}): Vector4D {
-	const [x, y, z, w] = point;
-	const result: number[] = [];
-
-	for (let i = 0; i < 4; i++) {
-		// For row i, the elements are at indices 4*i, 4*i+1, 4*i+2, and 4*i+3
-		result[i] =
-			matrix[4 * i + 0] * x +
-			matrix[4 * i + 1] * y +
-			matrix[4 * i + 2] * z +
-			matrix[4 * i + 3] * w;
-	}
-	return [result[0], result[1], result[2], result[3]];
-}
-
-export const isTranslateXYTransform = (
-	transform: MatrixTransform4D,
-): boolean => {
-	return (
-		transform[0] === 1 &&
-		transform[1] === 0 &&
-		transform[2] === 0 &&
-		// 3 omitted
-		transform[4] === 0 &&
-		transform[5] === 1 &&
-		transform[6] === 0 &&
-		// 7 omitted
-		transform[8] === 0 &&
-		transform[9] === 0 &&
-		transform[10] === 1 &&
-		transform[11] === 0 &&
-		transform[12] === 0 &&
-		transform[13] === 0 &&
-		transform[14] === 0 &&
-		transform[15] === 1
-	);
-};
+import React, {useMemo} from 'react';
+import {
+	CenterPointContext,
+	TransformContext,
+} from './transformation-context-context';
+import {transformPoint} from './transformation-context-utils';
 
 export const NewTransform: React.FC<{
 	readonly children: React.ReactNode;
@@ -161,12 +114,4 @@ export const Scale: React.FC<{
 			{children}
 		</NewTransform>
 	);
-};
-
-export const useTransformations = () => {
-	return useContext(TransformContext);
-};
-
-export const useCenterPoint = () => {
-	return useContext(CenterPointContext);
 };

--- a/packages/example/src/3DContext/use-center-point.ts
+++ b/packages/example/src/3DContext/use-center-point.ts
@@ -1,0 +1,6 @@
+import {useContext} from 'react';
+import {CenterPointContext} from './transformation-context-context';
+
+export const useCenterPoint = () => {
+	return useContext(CenterPointContext);
+};

--- a/packages/example/src/3DContext/use-rect.ts
+++ b/packages/example/src/3DContext/use-rect.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+import {pathContext} from './path-context-context';
+
+export const useRect = () => {
+	const value = React.useContext(pathContext);
+
+	if (!value) {
+		throw new Error('useRect must be used within a RectProvider');
+	}
+
+	return value;
+};

--- a/packages/example/src/3DContext/use-transformations.ts
+++ b/packages/example/src/3DContext/use-transformations.ts
@@ -1,0 +1,6 @@
+import {useContext} from 'react';
+import {TransformContext} from './transformation-context-context';
+
+export const useTransformations = () => {
+	return useContext(TransformContext);
+};

--- a/packages/example/src/3DSvgContent/G3D.tsx
+++ b/packages/example/src/3DSvgContent/G3D.tsx
@@ -3,7 +3,7 @@ import React, {useMemo} from 'react';
 import {SvgExtrusion} from '../3DContext/Extrusion';
 import {FrontFaceG} from '../3DContext/FrontFaceG';
 import {PathProvider} from '../3DContext/path-context';
-import {useTransformations} from '../3DContext/transformation-context';
+import {useTransformations} from '../3DContext/use-transformations';
 import {isBacksideVisible} from '../3DContext/viewing-frontside';
 
 export const G3D: React.FC<

--- a/packages/example/src/AnimatedImage/Avif-video.tsx
+++ b/packages/example/src/AnimatedImage/Avif-video.tsx
@@ -1,0 +1,36 @@
+import {AbsoluteFill, AnimatedImage, staticFile} from 'remotion';
+
+export const AvifVideo = () => {
+	return (
+		<AbsoluteFill className="bg-white justify-center items-center flex flex-row gap-20">
+			<div className="flex flex-col items-center gap-8">
+				<AnimatedImage
+					className="h-96 inline-block rounded-2xl outline-4 outline-black"
+					src="https://colinbendell.github.io/webperf/animated-gif-decode/2.avif"
+				/>
+				<div className="text-7xl font-sans font-bold">AVIF</div>
+			</div>
+			<div className="flex flex-col items-center gap-8">
+				<AnimatedImage
+					className="h-96 inline-block rounded-2xl outline-4 outline-black"
+					src="https://mathiasbynens.be/demo/animated-webp-supported.webp"
+				/>
+				<div className="text-7xl font-sans font-bold">WebP</div>
+			</div>
+			<div className="flex flex-col items-center gap-8">
+				<AnimatedImage
+					className="h-96 inline-block rounded-2xl outline-4 outline-black"
+					src={staticFile('giphy.gif')}
+				/>
+				<div className="text-7xl font-sans font-bold">GIF</div>
+			</div>
+			<div className="flex flex-col items-center gap-8">
+				<AnimatedImage
+					className="h-96 inline-block rounded-2xl outline-8 outline-[#0B84F3]"
+					src={staticFile('animated-png.png')}
+				/>
+				<div className="text-7xl font-sans font-bold">APNG</div>
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/AnimatedImage/Avif.tsx
+++ b/packages/example/src/AnimatedImage/Avif.tsx
@@ -1,43 +1,8 @@
 import {StudioInternals} from '@remotion/studio';
-import {AbsoluteFill, AnimatedImage, staticFile} from 'remotion';
-
-const Comp = () => {
-	return (
-		<AbsoluteFill className="bg-white justify-center items-center flex flex-row gap-20">
-			<div className="flex flex-col items-center gap-8">
-				<AnimatedImage
-					className="h-96 inline-block rounded-2xl outline-4 outline-black"
-					src="https://colinbendell.github.io/webperf/animated-gif-decode/2.avif"
-				/>
-				<div className="text-7xl font-sans font-bold">AVIF</div>
-			</div>
-			<div className="flex flex-col items-center gap-8">
-				<AnimatedImage
-					className="h-96 inline-block rounded-2xl outline-4 outline-black"
-					src="https://mathiasbynens.be/demo/animated-webp-supported.webp"
-				/>
-				<div className="text-7xl font-sans font-bold">WebP</div>
-			</div>
-			<div className="flex flex-col items-center gap-8">
-				<AnimatedImage
-					className="h-96 inline-block rounded-2xl outline-4 outline-black"
-					src={staticFile('giphy.gif')}
-				/>
-				<div className="text-7xl font-sans font-bold">GIF</div>
-			</div>
-			<div className="flex flex-col items-center gap-8">
-				<AnimatedImage
-					className="h-96 inline-block rounded-2xl outline-8 outline-[#0B84F3]"
-					src={staticFile('animated-png.png')}
-				/>
-				<div className="text-7xl font-sans font-bold">APNG</div>
-			</div>
-		</AbsoluteFill>
-	);
-};
+import {AvifVideo} from './Avif-video';
 
 export const AnimatedImages = StudioInternals.createComposition({
-	component: Comp,
+	component: AvifVideo,
 	id: 'animated-images',
 	width: 2400,
 	height: 1080,

--- a/packages/example/src/AudioSmoothness/NewVideo-calculate-metadata.ts
+++ b/packages/example/src/AudioSmoothness/NewVideo-calculate-metadata.ts
@@ -1,0 +1,17 @@
+import {CalculateMetadataFunction} from 'remotion';
+import {getMediaMetadata} from '../get-media-metadata';
+
+const src = 'https://remotion.media/video.mp4';
+
+export const calculateMetadataFn: CalculateMetadataFunction<
+	Record<string, unknown>
+> = async () => {
+	const {durationInSeconds, dimensions, fps} = await getMediaMetadata(src);
+
+	return {
+		durationInFrames: Math.round(durationInSeconds * fps!),
+		fps: fps!,
+		width: dimensions!.width,
+		height: dimensions!.height,
+	};
+};

--- a/packages/example/src/AudioSmoothness/NewVideo-component.tsx
+++ b/packages/example/src/AudioSmoothness/NewVideo-component.tsx
@@ -1,0 +1,7 @@
+import {Video} from '@remotion/media';
+
+const src = 'https://remotion.media/video.mp4';
+
+export const AudioSmoothnessNewVideoComponent: React.FC = () => {
+	return <Video src={src} debugOverlay logLevel="verbose" />;
+};

--- a/packages/example/src/AudioSmoothness/NewVideo.tsx
+++ b/packages/example/src/AudioSmoothness/NewVideo.tsx
@@ -1,31 +1,11 @@
-import {Video} from '@remotion/media';
-import React from 'react';
-import {CalculateMetadataFunction, Composition} from 'remotion';
-import {getMediaMetadata} from '../get-media-metadata';
-
-const src = 'https://remotion.media/video.mp4';
-
-export const calculateMetadataFn: CalculateMetadataFunction<
-	Record<string, unknown>
-> = async () => {
-	const {durationInSeconds, dimensions, fps} = await getMediaMetadata(src);
-
-	return {
-		durationInFrames: Math.round(durationInSeconds * fps!),
-		fps: fps!,
-		width: dimensions!.width,
-		height: dimensions!.height,
-	};
-};
-
-const Component: React.FC = () => {
-	return <Video src={src} debugOverlay logLevel="verbose" />;
-};
+import {Composition} from 'remotion';
+import {calculateMetadataFn} from './NewVideo-calculate-metadata';
+import {AudioSmoothnessNewVideoComponent} from './NewVideo-component';
 
 export const AudioSmoothnessNewVideoComp: React.FC = () => {
 	return (
 		<Composition
-			component={Component}
+			component={AudioSmoothnessNewVideoComponent}
 			id="audio-smoothness-new-video"
 			calculateMetadata={calculateMetadataFn}
 		/>

--- a/packages/example/src/BetaText/index-schema.ts
+++ b/packages/example/src/BetaText/index-schema.ts
@@ -1,0 +1,7 @@
+import {zColor} from '@remotion/zod-types';
+import {z} from 'zod';
+
+const betaTextSchema = z.object({
+	word1: z.string(),
+	color: z.array(zColor()),
+});

--- a/packages/example/src/BetaText/index.tsx
+++ b/packages/example/src/BetaText/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import styled from 'styled-components';
 import {z} from 'zod';
+import {betaTextSchema} from './index-schema';
 
 const BRAND_GRADIENT = ['#5851db', '#405de6'];
 const solidBrand = mix(0.5, BRAND_GRADIENT[0], BRAND_GRADIENT[1]);
@@ -87,11 +88,6 @@ const Row: React.FC<{
 		</div>
 	);
 };
-
-export const betaTextSchema = z.object({
-	word1: z.string(),
-	color: z.array(zColor()),
-});
 
 const BetaText = ({
 	word1,

--- a/packages/example/src/CodemodTestbed.tsx
+++ b/packages/example/src/CodemodTestbed.tsx
@@ -1,7 +1,8 @@
 import React, {useCallback} from 'react';
 import {CalculateMetadataFunction, Composition, Folder} from 'remotion';
 import {z} from 'zod';
-import {DynamicDuration, dynamicDurationSchema} from './DynamicDuration';
+import {DynamicDuration} from './DynamicDuration';
+import {dynamicDurationSchema} from './DynamicDuration-schema';
 
 // TODO: This does not yet work because it would require a fragment
 function AltCodemodRootNoFragment() {

--- a/packages/example/src/Compose/JumpThenDisappear-context.tsx
+++ b/packages/example/src/Compose/JumpThenDisappear-context.tsx
@@ -1,0 +1,3 @@
+import {createContext} from 'react';
+
+export const DepthContext = createContext<number>(0);

--- a/packages/example/src/Compose/JumpThenDisappear-utils.ts
+++ b/packages/example/src/Compose/JumpThenDisappear-utils.ts
@@ -1,0 +1,13 @@
+import {interpolate} from 'remotion';
+
+export const takeOffSpeedFucntion = (f: number) =>
+	10 ** interpolate(f, [0, 120], [-1, 4]);
+
+export const remapSpeed = (frame: number, speed: (fr: number) => number) => {
+	let framesPassed = 0;
+	for (let i = 0; i <= frame; i++) {
+		framesPassed += speed(i);
+	}
+
+	return framesPassed;
+};

--- a/packages/example/src/Compose/JumpThenDisappear.tsx
+++ b/packages/example/src/Compose/JumpThenDisappear.tsx
@@ -1,22 +1,11 @@
-import {createContext} from 'react';
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {
 	TranslateX,
 	TranslateY,
 	TranslateZ,
 } from '../3DContext/transformation-context';
-
-export const takeOffSpeedFucntion = (f: number) =>
-	10 ** interpolate(f, [0, 120], [-1, 4]);
-
-export const remapSpeed = (frame: number, speed: (fr: number) => number) => {
-	let framesPassed = 0;
-	for (let i = 0; i <= frame; i++) {
-		framesPassed += speed(i);
-	}
-
-	return framesPassed;
-};
+import {DepthContext} from './JumpThenDisappear-context';
+import {remapSpeed, takeOffSpeedFucntion} from './JumpThenDisappear-utils';
 
 export const JumpThenDisappear: React.FC<{
 	children: React.ReactNode;
@@ -46,11 +35,11 @@ export const JumpThenDisappear: React.FC<{
 		<TranslateX px={-40}>
 			<TranslateY px={70}>
 				<TranslateZ px={translateZ}>
-					<DepthContext value={depth}>{children}</DepthContext>
+					<DepthContext.Provider value={depth}>
+						{children}
+					</DepthContext.Provider>
 				</TranslateZ>
 			</TranslateY>
 		</TranslateX>
 	);
 };
-
-export const DepthContext = createContext<number>(0);

--- a/packages/example/src/Context/index-context.tsx
+++ b/packages/example/src/Context/index-context.tsx
@@ -1,0 +1,11 @@
+import {createContext} from 'react';
+
+type RegressionTestContext = {
+	hi: () => 'hithere';
+};
+
+export const MyCtx = createContext<RegressionTestContext>({
+	hi: () => {
+		throw new Error('context not provided');
+	},
+});

--- a/packages/example/src/Context/index.tsx
+++ b/packages/example/src/Context/index.tsx
@@ -1,15 +1,10 @@
 import {createContext, useContext} from 'react';
 import {AbsoluteFill} from 'remotion';
+import {MyCtx} from './index-context';
 
 type RegressionTestContext = {
 	hi: () => 'hithere';
 };
-
-export const MyCtx = createContext<RegressionTestContext>({
-	hi: () => {
-		throw new Error('context not provided');
-	},
-});
 
 export const WrappedInContext: React.FC = () => {
 	const value = useContext(MyCtx);

--- a/packages/example/src/DiscriminatedUnionSchemaTest/index-schema.ts
+++ b/packages/example/src/DiscriminatedUnionSchemaTest/index-schema.ts
@@ -1,0 +1,15 @@
+import {z} from 'zod';
+
+const discriminatedUnionRootSchema = z.discriminatedUnion('preset', [
+	z.object({
+		preset: z.literal('Simple'),
+		track: z.string(),
+		fontSize: z.number().default(48),
+	}),
+	z.object({
+		preset: z.literal('Fancy'),
+		track: z.string(),
+		fontSize: z.number().default(48),
+		outline: z.boolean().default(false),
+	}),
+]);

--- a/packages/example/src/DiscriminatedUnionSchemaTest/index.tsx
+++ b/packages/example/src/DiscriminatedUnionSchemaTest/index.tsx
@@ -1,20 +1,7 @@
 import React from 'react';
 import {AbsoluteFill} from 'remotion';
 import {z} from 'zod';
-
-export const discriminatedUnionRootSchema = z.discriminatedUnion('preset', [
-	z.object({
-		preset: z.literal('Simple'),
-		track: z.string(),
-		fontSize: z.number().default(48),
-	}),
-	z.object({
-		preset: z.literal('Fancy'),
-		track: z.string(),
-		fontSize: z.number().default(48),
-		outline: z.boolean().default(false),
-	}),
-]);
+import {discriminatedUnionRootSchema} from './index-schema';
 
 export const DiscriminatedUnionSchemaTest: React.FC<
 	z.infer<typeof discriminatedUnionRootSchema>

--- a/packages/example/src/DynamicDuration-schema.ts
+++ b/packages/example/src/DynamicDuration-schema.ts
@@ -1,0 +1,5 @@
+import {z} from 'zod';
+
+const dynamicDurationSchema = z.object({
+	duration: z.number().min(1).max(1000).default(100),
+});

--- a/packages/example/src/DynamicDuration.tsx
+++ b/packages/example/src/DynamicDuration.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import {AbsoluteFill} from 'remotion';
 import {z} from 'zod';
-
-export const dynamicDurationSchema = z.object({
-	duration: z.number().min(1).max(1000).default(100),
-});
+import {dynamicDurationSchema} from './DynamicDuration-schema';
 
 export const DynamicDuration: React.FC<
 	z.infer<typeof dynamicDurationSchema>

--- a/packages/example/src/Framer/framer-utils.ts
+++ b/packages/example/src/Framer/framer-utils.ts
@@ -1,0 +1,5 @@
+import {random} from 'remotion';
+
+export function selectColor(color: string, frame: number): number {
+	return Math.floor((random(`${color}-${frame}`) * 255) % 255);
+}

--- a/packages/example/src/Framer/index.tsx
+++ b/packages/example/src/Framer/index.tsx
@@ -1,14 +1,5 @@
-import {
-	Html5Audio,
-	Sequence,
-	random,
-	staticFile,
-	useCurrentFrame,
-} from 'remotion';
-
-export function selectColor(color: string, frame: number): number {
-	return Math.floor((random(`${color}-${frame}`) * 255) % 255);
-}
+import {Html5Audio, Sequence, staticFile, useCurrentFrame} from 'remotion';
+import {selectColor} from './framer-utils';
 
 export const Framer: React.FC<{
 	playbackRate?: number;

--- a/packages/example/src/HtmlInCanvas/index.tsx
+++ b/packages/example/src/HtmlInCanvas/index.tsx
@@ -1,18 +1,18 @@
-export {HtmlInCanvasComplexText} from './complex-text';
-export {HtmlInCanvasComposeAsyncBitmap} from './compose-async-bitmap';
-export {HtmlInCanvasDocsDemo2DBlur} from './docs-demo-2d-blur';
-export {HtmlInCanvasDocsMinimalWebGL} from './minimal-docs-webgl';
-export {HtmlInCanvasDocsMinimalWebGPU} from './minimal-docs-webgpu';
-export {HtmlInCanvasComposeWebGL} from './compose-webgl';
-export {HtmlInCanvasComposeWebGLCrt} from './compose-webgl-crt';
-export {HtmlInCanvasComposeWebGPU} from './compose-webgpu';
+import {HtmlInCanvasComplexText} from './complex-text';
+import {HtmlInCanvasComposeAsyncBitmap} from './compose-async-bitmap';
+import {HtmlInCanvasComposeWebGL} from './compose-webgl';
+import {HtmlInCanvasComposeWebGLCrt} from './compose-webgl-crt';
+import {HtmlInCanvasComposeWebGPU} from './compose-webgpu';
+import {HtmlInCanvasDocsDemo2DBlur} from './docs-demo-2d-blur';
+import {HtmlInCanvasDocsMinimalWebGL} from './minimal-docs-webgl';
+import {HtmlInCanvasDocsMinimalWebGPU} from './minimal-docs-webgpu';
+import {HtmlInCanvasPrivacy} from './privacy';
+import {HtmlInCanvasReactSvg} from './react-svg';
+import {HtmlInCanvasScene} from './scene';
 export {
 	HtmlInCanvasChangingSize,
 	HtmlInCanvasChangingSize as HtmlInCanvasDemo,
 } from './changing-size';
-export {HtmlInCanvasPrivacy} from './privacy';
-export {HtmlInCanvasReactSvg} from './react-svg';
-export {HtmlInCanvasScene} from './scene';
 export {
 	ZoomBlurTransitionDoc,
 	ZoomBlurTransitionDocThumb,

--- a/packages/example/src/HugePayload-schema.ts
+++ b/packages/example/src/HugePayload-schema.ts
@@ -1,0 +1,7 @@
+import {z} from 'zod';
+
+const hugePayloadSchema = z.object({
+	str: z.string(),
+	date: z.date(),
+	file: z.string(),
+});

--- a/packages/example/src/HugePayload.tsx
+++ b/packages/example/src/HugePayload.tsx
@@ -1,11 +1,6 @@
 import {Img, useVideoConfig} from 'remotion';
 import {z} from 'zod';
-
-export const hugePayloadSchema = z.object({
-	str: z.string(),
-	date: z.date(),
-	file: z.string(),
-});
+import {hugePayloadSchema} from './HugePayload-schema';
 
 export const HugePayload: React.FC<
 	z.infer<typeof hugePayloadSchema> & {

--- a/packages/example/src/JumpCuts-calculate-metadata.ts
+++ b/packages/example/src/JumpCuts-calculate-metadata.ts
@@ -1,0 +1,23 @@
+import {CalculateMetadataFunction} from 'remotion';
+import type {Section} from './JumpCuts-sections';
+
+type Props = {
+	sections: Section[];
+};
+
+const fps = 30;
+
+export const calculateMetadataJumpCuts: CalculateMetadataFunction<Props> = ({
+	props,
+}) => {
+	const durationInFrames = props.sections.reduce((acc, section) => {
+		return acc + section.trimAfter - section.trimBefore;
+	}, 0);
+
+	return {
+		fps,
+		durationInFrames,
+	};
+};
+
+export type {Props};

--- a/packages/example/src/JumpCuts-sections.ts
+++ b/packages/example/src/JumpCuts-sections.ts
@@ -1,0 +1,18 @@
+const fps = 30;
+
+export type Section = {
+	trimBefore: number;
+	trimAfter: number;
+};
+
+export const SAMPLE_SECTIONS: Section[] = [
+	{trimBefore: 0, trimAfter: 5 * fps},
+	{
+		trimBefore: 5.2 * fps,
+		trimAfter: 10 * fps,
+	},
+	{
+		trimBefore: 13 * fps,
+		trimAfter: 18 * fps,
+	},
+];

--- a/packages/example/src/JumpCuts.tsx
+++ b/packages/example/src/JumpCuts.tsx
@@ -1,44 +1,9 @@
 import React, {useMemo} from 'react';
-import {
-	CalculateMetadataFunction,
-	OffthreadVideo,
-	useCurrentFrame,
-} from 'remotion';
-
-const fps = 30;
-
-type Section = {
-	trimBefore: number;
-	trimAfter: number;
-};
-
-export const SAMPLE_SECTIONS: Section[] = [
-	{trimBefore: 0, trimAfter: 5 * fps},
-	{
-		trimBefore: 5.2 * fps,
-		trimAfter: 10 * fps,
-	},
-	{
-		trimBefore: 13 * fps,
-		trimAfter: 18 * fps,
-	},
-];
+import {OffthreadVideo, useCurrentFrame} from 'remotion';
+import type {Section} from './JumpCuts-sections';
 
 type Props = {
 	sections: Section[];
-};
-
-export const calculateMetadataJumpCuts: CalculateMetadataFunction<Props> = ({
-	props,
-}) => {
-	const durationInFrames = props.sections.reduce((acc, section) => {
-		return acc + section.trimAfter - section.trimBefore;
-	}, 0);
-
-	return {
-		fps,
-		durationInFrames,
-	};
 };
 
 export const JumpCuts: React.FC<Props> = ({sections}) => {
@@ -70,11 +35,7 @@ export const JumpCuts: React.FC<Props> = ({sections}) => {
 		<OffthreadVideo
 			pauseWhenBuffering
 			trimBefore={cut.trimBefore}
-			// Remotion will automatically add a time fragment to the end of the video URL
-			// based on `trimBefore` and `trimAfter`. Opt out of this by adding one yourself.
-			// https://www.remotion.dev/docs/media-fragments
 			src={`https://remotion.media/BigBuckBunny.mp4#t=0,`}
-			// Force Remotion to seek when it jumps even just a tiny bit
 			acceptableTimeShiftInSeconds={
 				cut.firstFrameOfSection ? 0.000001 : undefined
 			}

--- a/packages/example/src/LoopDisplayTest-calculate-metadata.ts
+++ b/packages/example/src/LoopDisplayTest-calculate-metadata.ts
@@ -1,0 +1,17 @@
+import {CalculateMetadataFunction} from 'remotion';
+import {getMediaMetadata} from './get-media-metadata';
+
+const src = 'https://remotion.media/video-1m.mp4';
+
+export const calculateMetadataFn: CalculateMetadataFunction<
+	Record<string, unknown>
+> = async () => {
+	const {dimensions, fps} = await getMediaMetadata(src);
+
+	return {
+		durationInFrames: fps! * 180,
+		fps: fps!,
+		width: dimensions!.width,
+		height: dimensions!.height,
+	};
+};

--- a/packages/example/src/LoopDisplayTest-component.tsx
+++ b/packages/example/src/LoopDisplayTest-component.tsx
@@ -1,0 +1,29 @@
+import {Video} from '@remotion/media';
+import {Html5Video} from 'remotion';
+
+const src = 'https://remotion.media/video-1m.mp4';
+
+export const LoopDisplayTestComponent = () => {
+	return (
+		<>
+			<Html5Video
+				src={src}
+				trimBefore={90}
+				trimAfter={60 * 30}
+				playbackRate={0.5}
+				loop
+				name="Html5Video"
+				style={{width: '50%'}}
+			/>
+			<Video
+				src={src}
+				trimBefore={90}
+				trimAfter={60 * 30}
+				playbackRate={0.5}
+				loop
+				name="MediaVideo"
+				style={{width: '50%'}}
+			/>
+		</>
+	);
+};

--- a/packages/example/src/LoopDisplayTest.tsx
+++ b/packages/example/src/LoopDisplayTest.tsx
@@ -1,52 +1,11 @@
-// https://www.remotion.dev/docs/mediabunny/metadata
-import {Video} from '@remotion/media';
-import {CalculateMetadataFunction, Composition, Html5Video} from 'remotion';
-import {getMediaMetadata} from './get-media-metadata';
-
-const src = 'https://remotion.media/video-1m.mp4';
-
-export const calculateMetadataFn: CalculateMetadataFunction<
-	Record<string, unknown>
-> = async () => {
-	const {dimensions, fps} = await getMediaMetadata(src);
-
-	return {
-		durationInFrames: fps! * 180,
-		fps: fps!,
-		width: dimensions!.width,
-		height: dimensions!.height,
-	};
-};
-
-export const Component = () => {
-	return (
-		<>
-			<Html5Video
-				src={src}
-				trimBefore={90}
-				trimAfter={60 * 30}
-				playbackRate={0.5}
-				loop
-				name="Html5Video"
-				style={{width: '50%'}}
-			/>
-			<Video
-				src={src}
-				trimBefore={90}
-				trimAfter={60 * 30}
-				playbackRate={0.5}
-				loop
-				name="MediaVideo"
-				style={{width: '50%'}}
-			/>
-		</>
-	);
-};
+import {Composition} from 'remotion';
+import {calculateMetadataFn} from './LoopDisplayTest-calculate-metadata';
+import {LoopDisplayTestComponent} from './LoopDisplayTest-component';
 
 export const LoopDisplayTestComp = () => {
 	return (
 		<Composition
-			component={Component}
+			component={LoopDisplayTestComponent}
 			id="LoopDisplayTest"
 			calculateMetadata={calculateMetadataFn}
 		/>

--- a/packages/example/src/NewVideo-calculate-metadata.ts
+++ b/packages/example/src/NewVideo-calculate-metadata.ts
@@ -1,0 +1,17 @@
+import {CalculateMetadataFunction} from 'remotion';
+import {getMediaMetadata} from './get-media-metadata';
+
+const src = 'https://remotion.media/video.mp4';
+
+export const calculateMetadataFn: CalculateMetadataFunction<
+	Record<string, unknown>
+> = async () => {
+	const {durationInSeconds, dimensions, fps} = await getMediaMetadata(src);
+
+	return {
+		durationInFrames: Math.round(durationInSeconds * fps!),
+		fps: fps!,
+		width: dimensions!.width,
+		height: dimensions!.height,
+	};
+};

--- a/packages/example/src/NewVideo-component.tsx
+++ b/packages/example/src/NewVideo-component.tsx
@@ -1,0 +1,7 @@
+import {Video} from '@remotion/media';
+
+const src = 'https://remotion.media/video.mp4';
+
+export const NewVideoComponent = () => {
+	return <Video src={src} debugOverlay />;
+};

--- a/packages/example/src/NewVideo.tsx
+++ b/packages/example/src/NewVideo.tsx
@@ -1,31 +1,11 @@
-import {Video} from '@remotion/media';
-import {CalculateMetadataFunction, Composition} from 'remotion';
-// https://www.remotion.dev/docs/mediabunny/metadata
-import {getMediaMetadata} from './get-media-metadata';
-
-const src = 'https://remotion.media/video.mp4';
-
-export const calculateMetadataFn: CalculateMetadataFunction<
-	Record<string, unknown>
-> = async () => {
-	const {durationInSeconds, dimensions, fps} = await getMediaMetadata(src);
-
-	return {
-		durationInFrames: Math.round(durationInSeconds * fps!),
-		fps: fps!,
-		width: dimensions!.width,
-		height: dimensions!.height,
-	};
-};
-
-export const Component = () => {
-	return <Video src={src} debugOverlay />;
-};
+import {Composition} from 'remotion';
+import {calculateMetadataFn} from './NewVideo-calculate-metadata';
+import {NewVideoComponent} from './NewVideo-component';
 
 export const NewVideoComp = () => {
 	return (
 		<Composition
-			component={Component}
+			component={NewVideoComponent}
 			id="NewVideo"
 			calculateMetadata={calculateMetadataFn}
 		/>

--- a/packages/example/src/OffthreadRemoteVideo/ChangingTrimBefore-calculate-metadata.ts
+++ b/packages/example/src/OffthreadRemoteVideo/ChangingTrimBefore-calculate-metadata.ts
@@ -1,0 +1,17 @@
+import {CalculateMetadataFunction} from 'remotion';
+import {getMediaMetadata} from '../get-media-metadata';
+
+const src = 'https://remotion.media/dialogue.wav';
+
+export const calculateMetadataFn: CalculateMetadataFunction<
+	Record<string, unknown>
+> = async () => {
+	const {durationInSeconds} = await getMediaMetadata(src);
+
+	return {
+		durationInFrames: Math.round(durationInSeconds * 30),
+		fps: 30,
+		width: 100,
+		height: 100,
+	};
+};

--- a/packages/example/src/OffthreadRemoteVideo/ChangingTrimBefore.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/ChangingTrimBefore.tsx
@@ -1,27 +1,9 @@
 import {Audio} from '@remotion/media';
-// https://www.remotion.dev/docs/mediabunny/metadata
 import {useMemo} from 'react';
-import {
-	CalculateMetadataFunction,
-	Composition,
-	useCurrentFrame,
-} from 'remotion';
-import {getMediaMetadata} from '../get-media-metadata';
+import {Composition, useCurrentFrame} from 'remotion';
+import {calculateMetadataFn} from './ChangingTrimBefore-calculate-metadata';
 
 const src = 'https://remotion.media/dialogue.wav';
-
-export const calculateMetadataFn: CalculateMetadataFunction<
-	Record<string, unknown>
-> = async () => {
-	const {durationInSeconds} = await getMediaMetadata(src);
-
-	return {
-		durationInFrames: Math.round(durationInSeconds * 30),
-		fps: 30,
-		width: 100,
-		height: 100,
-	};
-};
 
 export const Component = () => {
 	const frame = useCurrentFrame();

--- a/packages/example/src/OffthreadRemoteVideo/LoopedNewVideo-calculate-metadata.ts
+++ b/packages/example/src/OffthreadRemoteVideo/LoopedNewVideo-calculate-metadata.ts
@@ -1,0 +1,17 @@
+import {CalculateMetadataFunction} from 'remotion';
+import {getMediaMetadata} from '../get-media-metadata';
+
+const src = 'https://remotion.media/video-1m.mp4';
+
+export const calculateMetadataFn: CalculateMetadataFunction<
+	Record<string, unknown>
+> = async () => {
+	const {dimensions, fps} = await getMediaMetadata(src);
+
+	return {
+		durationInFrames: fps! * 180,
+		fps: fps!,
+		width: dimensions!.width,
+		height: dimensions!.height,
+	};
+};

--- a/packages/example/src/OffthreadRemoteVideo/LoopedNewVideo.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/LoopedNewVideo.tsx
@@ -1,22 +1,8 @@
 import {Video} from '@remotion/media';
-import {CalculateMetadataFunction, Composition} from 'remotion';
-// https://www.remotion.dev/docs/mediabunny/metadata
-import {getMediaMetadata} from '../get-media-metadata';
+import {Composition} from 'remotion';
+import {calculateMetadataFn} from './LoopedNewVideo-calculate-metadata';
 
 const src = 'https://remotion.media/video-1m.mp4';
-
-export const calculateMetadataFn: CalculateMetadataFunction<
-	Record<string, unknown>
-> = async () => {
-	const {dimensions, fps} = await getMediaMetadata(src);
-
-	return {
-		durationInFrames: fps! * 180,
-		fps: fps!,
-		width: dimensions!.width,
-		height: dimensions!.height,
-	};
-};
 
 export const Component = () => {
 	return <Video src={src} trimBefore={90} trimAfter={60 * 30} loop />;

--- a/packages/example/src/OffthreadRemoteVideo/LoopedOffthreadRemoteVideo-video.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/LoopedOffthreadRemoteVideo-video.tsx
@@ -1,0 +1,28 @@
+import {
+	AbsoluteFill,
+	OffthreadVideo,
+	staticFile,
+	useCurrentFrame,
+} from 'remotion';
+
+const src = staticFile('bigbuckbunny.mp4') + '#t=lol';
+
+const LoopedOffthreadVideo: React.FC<{
+	durationInFrames: number;
+	muted?: boolean;
+}> = ({durationInFrames}) => {
+	const frame = useCurrentFrame();
+	if (durationInFrames <= 0) {
+		throw new Error('durationInFrames must be greater than 0');
+	}
+
+	return (
+		<AbsoluteFill style={{backgroundColor: 'green'}}>
+			<OffthreadVideo muted transparent={frame % 2 === 0} src={src} />
+		</AbsoluteFill>
+	);
+};
+
+export const LoopedOffthreadRemoteVideoComponent = () => {
+	return <LoopedOffthreadVideo durationInFrames={100} />;
+};

--- a/packages/example/src/OffthreadRemoteVideo/LoopedOffthreadRemoteVideo.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/LoopedOffthreadRemoteVideo.tsx
@@ -1,36 +1,11 @@
 import {StudioInternals} from '@remotion/studio';
-import {
-	AbsoluteFill,
-	OffthreadVideo,
-	staticFile,
-	useCurrentFrame,
-} from 'remotion';
-import {calculateMetadataFn} from './OffthreadRemoteVideo';
+import {LoopedOffthreadRemoteVideoComponent} from './LoopedOffthreadRemoteVideo-video';
+import {calculateMetadataFn} from './OffthreadRemoteVideo-calculate-metadata';
 
 const fps = 30;
 
-const src = staticFile('bigbuckbunny.mp4') + '#t=lol';
-
-export const LoopedOffthreadVideo: React.FC<{
-	durationInFrames: number;
-	muted?: boolean;
-}> = ({durationInFrames}) => {
-	const frame = useCurrentFrame();
-	if (durationInFrames <= 0) {
-		throw new Error('durationInFrames must be greater than 0');
-	}
-
-	return (
-		<AbsoluteFill style={{backgroundColor: 'green'}}>
-			<OffthreadVideo muted transparent={frame % 2 === 0} src={src} />
-		</AbsoluteFill>
-	);
-};
-
 export const LoopedOffthreadRemoteVideo = StudioInternals.createComposition({
-	component: () => {
-		return <LoopedOffthreadVideo durationInFrames={100} />;
-	},
+	component: LoopedOffthreadRemoteVideoComponent,
 	id: 'LoopedOffthreadRemoteVideo',
 	calculateMetadata: calculateMetadataFn,
 	fps,

--- a/packages/example/src/OffthreadRemoteVideo/MultiChannelAudio-calculate-metadata.ts
+++ b/packages/example/src/OffthreadRemoteVideo/MultiChannelAudio-calculate-metadata.ts
@@ -1,0 +1,22 @@
+import {parseMedia} from '@remotion/media-parser';
+import {CalculateMetadataFunction} from 'remotion';
+
+const fps = 30;
+const src = 'https://remotion.media/multiple-audio-streams.mov';
+
+export const calculateMetadataFn: CalculateMetadataFunction<
+	Record<string, unknown>
+> = async () => {
+	const {slowDurationInSeconds} = await parseMedia({
+		src,
+		acknowledgeRemotionLicense: true,
+		fields: {
+			slowDurationInSeconds: true,
+		},
+	});
+
+	return {
+		durationInFrames: Math.round(slowDurationInSeconds * fps),
+		fps,
+	};
+};

--- a/packages/example/src/OffthreadRemoteVideo/MultiChannelAudio-component.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/MultiChannelAudio-component.tsx
@@ -1,0 +1,11 @@
+import {Html5Audio} from 'remotion';
+
+const src = 'https://remotion.media/multiple-audio-streams.mov';
+
+export const MultiChannelAudioComponent = () => {
+	return (
+		<>
+			<Html5Audio src={src} audioStreamIndex={3} />
+		</>
+	);
+};

--- a/packages/example/src/OffthreadRemoteVideo/MultiChannelAudio.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/MultiChannelAudio.tsx
@@ -1,37 +1,11 @@
-import {parseMedia} from '@remotion/media-parser';
 import {StudioInternals} from '@remotion/studio';
-import {CalculateMetadataFunction, Html5Audio} from 'remotion';
+import {calculateMetadataFn} from './MultiChannelAudio-calculate-metadata';
+import {MultiChannelAudioComponent} from './MultiChannelAudio-component';
 
 const fps = 30;
-const src = 'https://remotion.media/multiple-audio-streams.mov';
-
-export const calculateMetadataFn: CalculateMetadataFunction<
-	Record<string, unknown>
-> = async () => {
-	const {slowDurationInSeconds} = await parseMedia({
-		src,
-		acknowledgeRemotionLicense: true,
-		fields: {
-			slowDurationInSeconds: true,
-		},
-	});
-
-	return {
-		durationInFrames: Math.round(slowDurationInSeconds * fps),
-		fps,
-	};
-};
-
-const Component = () => {
-	return (
-		<>
-			<Html5Audio src={src} audioStreamIndex={3} />
-		</>
-	);
-};
 
 export const MultiChannelAudio = StudioInternals.createComposition({
-	component: Component,
+	component: MultiChannelAudioComponent,
 	id: 'MultiChannelAudio',
 	calculateMetadata: calculateMetadataFn,
 	fps,

--- a/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteSeries-calculate-metadata.ts
+++ b/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteSeries-calculate-metadata.ts
@@ -1,0 +1,64 @@
+import {parseMedia} from '@remotion/media-parser';
+import {CalculateMetadataFunction, staticFile} from 'remotion';
+
+const fps = 30;
+const sources = [
+	staticFile('bigbuckbunny.mp4'),
+	'https://remotion.media/video.mp4',
+];
+
+type Props = {
+	durations: number[] | null;
+};
+
+export const calculateMetadataFn: CalculateMetadataFunction<
+	Props
+> = async () => {
+	const all = await Promise.all(
+		sources.map(async (src) => {
+			const {slowDurationInSeconds, dimensions} = await parseMedia({
+				src,
+				acknowledgeRemotionLicense: true,
+				fields: {
+					slowDurationInSeconds: true,
+					dimensions: true,
+				},
+			});
+			return {
+				src,
+				slowDurationInSeconds,
+				dimensions,
+			};
+		}),
+	);
+
+	const allDurations = all
+		.map((a) => a.slowDurationInSeconds)
+		.reduce((a, b) => a + b, 0);
+	const biggestDimension = all.reduce((a, b) => {
+		if (a.dimensions === null) {
+			return b;
+		}
+		if (b.dimensions === null) {
+			return a;
+		}
+
+		return a.dimensions.width * a.dimensions.height >
+			b.dimensions.width * b.dimensions.height
+			? a
+			: b;
+	}, all[0]);
+
+	return {
+		durationInFrames: Math.round(allDurations * fps),
+		fps,
+		width: Math.floor(biggestDimension.dimensions!.width / 2) * 2,
+		height: Math.floor(biggestDimension.dimensions!.height / 2) * 2,
+		props: {
+			durations: all.map((a) => a.slowDurationInSeconds),
+		},
+	};
+};
+
+export {sources, fps};
+export type {Props};

--- a/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteSeries-component.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteSeries-component.tsx
@@ -1,0 +1,30 @@
+import {OffthreadVideo, Series} from 'remotion';
+import {
+	fps,
+	sources,
+	type Props,
+} from './OffthreadRemoteSeries-calculate-metadata';
+
+export const OffthreadRemoteSeriesComponent: React.FC<Props> = ({
+	durations,
+}) => {
+	if (durations === null) {
+		throw new Error('Durations are null');
+	}
+
+	return (
+		<>
+			<Series>
+				{sources.map((src, index) => (
+					<Series.Sequence
+						durationInFrames={durations[index] * fps}
+						layout="none"
+						key={index}
+					>
+						<OffthreadVideo src={src} />
+					</Series.Sequence>
+				))}
+			</Series>
+		</>
+	);
+};

--- a/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteSeries.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteSeries.tsx
@@ -1,98 +1,11 @@
-import {parseMedia} from '@remotion/media-parser';
 import {StudioInternals} from '@remotion/studio';
-import {
-	CalculateMetadataFunction,
-	OffthreadVideo,
-	Series,
-	staticFile,
-} from 'remotion';
+import {calculateMetadataFn} from './OffthreadRemoteSeries-calculate-metadata';
+import {OffthreadRemoteSeriesComponent} from './OffthreadRemoteSeries-component';
 
 const fps = 30;
-const sources = [
-	staticFile('bigbuckbunny.mp4'),
-	'https://remotion.media/video.mp4',
-];
-
-type Props = {
-	durations: number[] | null;
-};
-
-export const calculateMetadataFn: CalculateMetadataFunction<
-	Props
-> = async () => {
-	const all = await Promise.all(
-		sources.map(async (src) => {
-			const {slowDurationInSeconds, dimensions} = await parseMedia({
-				src,
-				acknowledgeRemotionLicense: true,
-				fields: {
-					slowDurationInSeconds: true,
-					dimensions: true,
-				},
-			});
-			return {
-				src,
-				slowDurationInSeconds,
-				dimensions,
-			};
-		}),
-	);
-
-	const allDurations = all
-		.map((a) => a.slowDurationInSeconds)
-		.reduce((a, b) => a + b, 0);
-	// get biggest dimension
-	const biggestDimension = all.reduce((a, b) => {
-		if (a.dimensions === null) {
-			return b;
-		}
-		if (b.dimensions === null) {
-			return a;
-		}
-
-		return a.dimensions.width * a.dimensions.height >
-			b.dimensions.width * b.dimensions.height
-			? a
-			: b;
-	}, all[0]);
-
-	return {
-		durationInFrames: Math.round(allDurations * fps),
-		fps,
-		width: Math.floor(biggestDimension.dimensions!.width / 2) * 2,
-		height: Math.floor(biggestDimension.dimensions!.height / 2) * 2,
-		props: {
-			durations: all.map((a) => a.slowDurationInSeconds),
-		},
-	};
-};
-
-const Component: React.FC<{
-	durations: number[] | null;
-}> = ({durations}) => {
-	if (durations === null) {
-		throw new Error('Durations are null');
-	}
-
-	return (
-		<>
-			<Series>
-				{sources.map((src, index) => (
-					<Series.Sequence
-						durationInFrames={durations[index] * fps}
-						layout="none"
-						key={index}
-					>
-						<OffthreadVideo src={src} />
-					</Series.Sequence>
-				))}
-			</Series>
-		</>
-	);
-};
 
 export const OffthreadRemoteSeries = StudioInternals.createComposition({
-	component: Component,
+	component: OffthreadRemoteSeriesComponent,
 	id: 'OffthreadRemoteSeries',
 	calculateMetadata: calculateMetadataFn,
 	defaultProps: {

--- a/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteVideo-calculate-metadata.ts
+++ b/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteVideo-calculate-metadata.ts
@@ -1,0 +1,29 @@
+import {parseMedia} from '@remotion/media-parser';
+import {CalculateMetadataFunction, staticFile} from 'remotion';
+
+const fps = 30;
+const src = staticFile('bigbuckbunny.mp4') + '#t=lol';
+
+export const calculateMetadataFn: CalculateMetadataFunction<
+	Record<string, unknown>
+> = async () => {
+	const {slowDurationInSeconds, dimensions} = await parseMedia({
+		src,
+		acknowledgeRemotionLicense: true,
+		fields: {
+			slowDurationInSeconds: true,
+			dimensions: true,
+		},
+	});
+
+	if (dimensions === null) {
+		throw new Error('Dimensions are null');
+	}
+
+	return {
+		durationInFrames: Math.round(slowDurationInSeconds * fps),
+		fps,
+		width: Math.floor(dimensions.width / 2) * 2,
+		height: Math.floor(dimensions.height / 2) * 2,
+	};
+};

--- a/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteVideo-component.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteVideo-component.tsx
@@ -1,0 +1,11 @@
+import {OffthreadVideo, staticFile} from 'remotion';
+
+const src = staticFile('bigbuckbunny.mp4') + '#t=lol';
+
+export const OffthreadRemoteVideoComponent = () => {
+	return (
+		<>
+			<OffthreadVideo src={src} />
+		</>
+	);
+};

--- a/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteVideo.tsx
+++ b/packages/example/src/OffthreadRemoteVideo/OffthreadRemoteVideo.tsx
@@ -1,44 +1,11 @@
-import {parseMedia} from '@remotion/media-parser';
 import {StudioInternals} from '@remotion/studio';
-import {CalculateMetadataFunction, OffthreadVideo, staticFile} from 'remotion';
+import {calculateMetadataFn} from './OffthreadRemoteVideo-calculate-metadata';
+import {OffthreadRemoteVideoComponent} from './OffthreadRemoteVideo-component';
 
 const fps = 30;
-const src = staticFile('bigbuckbunny.mp4') + '#t=lol';
-
-export const calculateMetadataFn: CalculateMetadataFunction<
-	Record<string, unknown>
-> = async () => {
-	const {slowDurationInSeconds, dimensions} = await parseMedia({
-		src,
-		acknowledgeRemotionLicense: true,
-		fields: {
-			slowDurationInSeconds: true,
-			dimensions: true,
-		},
-	});
-
-	if (dimensions === null) {
-		throw new Error('Dimensions are null');
-	}
-
-	return {
-		durationInFrames: Math.round(slowDurationInSeconds * fps),
-		fps,
-		width: Math.floor(dimensions.width / 2) * 2,
-		height: Math.floor(dimensions.height / 2) * 2,
-	};
-};
-
-const Component = () => {
-	return (
-		<>
-			<OffthreadVideo src={src} />
-		</>
-	);
-};
 
 export const OffthreadRemoteVideo = StudioInternals.createComposition({
-	component: Component,
+	component: OffthreadRemoteVideoComponent,
 	id: 'OffthreadRemoteVideo',
 	calculateMetadata: calculateMetadataFn,
 	fps,

--- a/packages/example/src/PlayRangesMediaVideo-calculate-metadata.ts
+++ b/packages/example/src/PlayRangesMediaVideo-calculate-metadata.ts
@@ -1,0 +1,23 @@
+import {CalculateMetadataFunction} from 'remotion';
+import type {PlayRangeSection} from './PlayRangesMediaVideo-defaults';
+
+const fps = 24;
+
+export type PlayRangesMediaVideoProps = {
+	url: string;
+	playRanges: PlayRangeSection[];
+};
+
+export const calculateMetadataPlayRangesMedia: CalculateMetadataFunction<
+	PlayRangesMediaVideoProps
+> = ({props}) => {
+	const durationInFrames = props.playRanges.reduce(
+		(acc, s) => acc + (s.trimAfter - s.trimBefore),
+		0,
+	);
+
+	return {
+		fps,
+		durationInFrames,
+	};
+};

--- a/packages/example/src/PlayRangesMediaVideo-defaults.ts
+++ b/packages/example/src/PlayRangesMediaVideo-defaults.ts
@@ -1,0 +1,25 @@
+export type PlayRangeSection = {
+	trimBefore: number;
+	trimAfter: number;
+};
+
+const fps = 24;
+
+export const PLAY_RANGES_MEDIA_DEFAULT: PlayRangeSection[] = [
+	{trimBefore: 0.5 * fps, trimAfter: 1 * fps},
+	{trimBefore: 1.5 * fps, trimAfter: 2 * fps},
+	{trimBefore: 2.5 * fps, trimAfter: 3 * fps},
+	{trimBefore: 3.5 * fps, trimAfter: 4 * fps},
+	{trimBefore: 4.5 * fps, trimAfter: 5 * fps},
+	{trimBefore: 5.5 * fps, trimAfter: 6 * fps},
+	{trimBefore: 6.5 * fps, trimAfter: 7 * fps},
+	{trimBefore: 7.5 * fps, trimAfter: 8 * fps},
+];
+
+export const PLAY_RANGES_MEDIA_ZIP_DEFAULT: PlayRangeSection[] = [
+	{trimBefore: 0 * fps, trimAfter: 4 * fps},
+	{trimBefore: 4.5 * fps, trimAfter: 5 * fps},
+	{trimBefore: 5.5 * fps, trimAfter: 6 * fps},
+	{trimBefore: 6.5 * fps, trimAfter: 7 * fps},
+	{trimBefore: 7.5 * fps, trimAfter: 8 * fps},
+];

--- a/packages/example/src/PlayRangesMediaVideo.tsx
+++ b/packages/example/src/PlayRangesMediaVideo.tsx
@@ -1,55 +1,11 @@
 // Repro: @remotion/media Video inside Series.Sequence with trim windows and premount.
 import {Video} from '@remotion/media';
 import React from 'react';
-import {CalculateMetadataFunction, Series} from 'remotion';
+import {Series} from 'remotion';
+import type {PlayRangesMediaVideoProps} from './PlayRangesMediaVideo-calculate-metadata';
 
 export const PLAY_RANGES_MEDIA_VIDEO_URL_DEFAULT =
 	'https://d6d4ismr40iw.cloudfront.net/content-lab/filestack/custom_assets/1f132751-d675-6630-83ca-a3750ed5f908/1f132751-d677-6d40-9a71-d233250ae390/preview.mp4';
-
-const fps = 24;
-
-export type PlayRangeSection = {
-	trimBefore: number;
-	trimAfter: number;
-};
-
-export const PLAY_RANGES_MEDIA_DEFAULT: PlayRangeSection[] = [
-	{trimBefore: 0.5 * fps, trimAfter: 1 * fps},
-	{trimBefore: 1.5 * fps, trimAfter: 2 * fps},
-	{trimBefore: 2.5 * fps, trimAfter: 3 * fps},
-	{trimBefore: 3.5 * fps, trimAfter: 4 * fps},
-	{trimBefore: 4.5 * fps, trimAfter: 5 * fps},
-	{trimBefore: 5.5 * fps, trimAfter: 6 * fps},
-	{trimBefore: 6.5 * fps, trimAfter: 7 * fps},
-	{trimBefore: 7.5 * fps, trimAfter: 8 * fps},
-];
-
-export const PLAY_RANGES_MEDIA_ZIP_DEFAULT: PlayRangeSection[] = [
-	{trimBefore: 0 * fps, trimAfter: 4 * fps},
-	{trimBefore: 4.5 * fps, trimAfter: 5 * fps},
-	{trimBefore: 5.5 * fps, trimAfter: 6 * fps},
-	{trimBefore: 6.5 * fps, trimAfter: 7 * fps},
-	{trimBefore: 7.5 * fps, trimAfter: 8 * fps},
-];
-
-export type PlayRangesMediaVideoProps = {
-	url: string;
-	playRanges: PlayRangeSection[];
-};
-
-export const calculateMetadataPlayRangesMedia: CalculateMetadataFunction<
-	PlayRangesMediaVideoProps
-> = ({props}) => {
-	const durationInFrames = props.playRanges.reduce(
-		(acc, s) => acc + (s.trimAfter - s.trimBefore),
-		0,
-	);
-
-	return {
-		fps,
-		durationInFrames,
-	};
-};
 
 export const PlayRangesMediaVideo: React.FC<PlayRangesMediaVideoProps> = ({
 	url,

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -11,7 +11,8 @@ import {
 import {z} from 'zod';
 import {TwentyTwoKHzAudio} from './22KhzAudio';
 import {UseanimatedEmojis} from './AnimatedEmojis';
-import BetaText, {betaTextSchema} from './BetaText';
+import BetaText from './BetaText';
+import {betaTextSchema} from './BetaText/index-schema';
 import {NativeBufferStateForImage} from './BufferState/Image';
 import {NativeBufferState} from './BufferState/Simple';
 import {NativeBufferStateForVideo} from './BufferState/Video';
@@ -19,16 +20,16 @@ import {CancelRender} from './CancelRender';
 import {ClassSerialization} from './ClassSerialization';
 import {ColorInterpolation} from './ColorInterpolation';
 import {ComplexSounds} from './ComplexSounds';
-import {MyCtx, WrappedInContext} from './Context';
+import {WrappedInContext} from './Context';
+import {MyCtx} from './Context/index-context';
 import CorruptVideo from './CorruptVideo';
 import {CssLoaderTest} from './CssLoaderTest';
 import {DarkModeTest} from './DarkModeTest';
 import {DecoderDemo} from './DecoderDemo';
-import {
-	DiscriminatedUnionSchemaTest,
-	discriminatedUnionRootSchema,
-} from './DiscriminatedUnionSchemaTest';
-import {DynamicDuration, dynamicDurationSchema} from './DynamicDuration';
+import {DiscriminatedUnionSchemaTest} from './DiscriminatedUnionSchemaTest';
+import {discriminatedUnionRootSchema} from './DiscriminatedUnionSchemaTest/index-schema';
+import {DynamicDuration} from './DynamicDuration';
+import {dynamicDurationSchema} from './DynamicDuration-schema';
 import {EasingVisualizer} from './EasingVisualizer/EasingVisualizer';
 import {EmojiTestbed} from './Emoji';
 import {ErrorOnFrame10} from './ErrorOnFrame10';
@@ -64,7 +65,8 @@ import {
 	ZoomInOutTransitionDocThumb,
 } from './HtmlInCanvas';
 import {HugeImage} from './HugeImage';
-import {HugePayload, hugePayloadSchema} from './HugePayload';
+import {HugePayload} from './HugePayload';
+import {hugePayloadSchema} from './HugePayload-schema';
 import {Layers} from './Layers';
 import {LongAudio} from './LongAudio';
 import {ManyAudio} from './ManyAudio';
@@ -88,7 +90,8 @@ import RemoteVideo from './RemoteVideo';
 import {RetryDelayRender} from './RetryDelayRender';
 import RiveVehicle from './Rive/RiveExample';
 import {ScalePath} from './ScalePath';
-import {SchemaTest, schemaTestSchema} from './SchemaTest';
+import {SchemaTest} from './SchemaTest';
+import {schemaTestSchema} from './SchemaTest/index-schema';
 import {Scripts} from './Scripts';
 import {WidthHeightSequences} from './Sequence/WidthHeightSequences';
 import CircleTest from './Shapes/CircleTest';
@@ -105,10 +108,8 @@ import {StillHelloWorld} from './StillHelloWorld';
 import {StillZoom} from './StillZoom';
 import {DeleteStaticFile} from './StudioApis/DeleteStaticFile';
 import {ClickUpdate} from './StudioApis/RestartStudio';
-import {
-	SaveDefaultProps,
-	saveStudioSchema,
-} from './StudioApis/SaveDefaultProps';
+import {SaveDefaultProps} from './StudioApis/SaveDefaultProps';
+import {saveStudioSchema} from './StudioApis/SaveDefaultProps-schema';
 import {TriggerCalculateMetadata} from './StudioApis/TriggerCalculateMetadata';
 import {WriteStaticFile} from './StudioApis/WriteStaticFile';
 import {SubtitleArtifact} from './SubtitleArtifact/SubtitleArtifact';
@@ -121,7 +122,8 @@ import ThreeBasic from './ThreeBasic';
 import {ThreeHtml} from './ThreeHtml/ThreeHtml';
 import {VideoTextureDemo} from './ThreeScene/Scene';
 import {Timeout} from './Timeout';
-import {FitText, fitTextSchema} from './Title/FitText';
+import {FitText} from './Title/FitText';
+import {fitTextSchema} from './Title/FitText-schema';
 import {AudioTransition} from './Transitions/AudioTransition';
 import {BasicTransition} from './Transitions/BasicTransition';
 import {CustomTransition} from './Transitions/CustomTransition';
@@ -133,7 +135,8 @@ import {VideoTesting} from './VideoTesting';
 import {WarpDemoOuter} from './WarpText';
 import {WarpDemo2} from './WarpText/demo2';
 import {WatchStaticDemo} from './watch-static';
-import {ZodV4SchemaTest, zodV4Schema} from './ZodV4SchemaTest';
+import {ZodV4SchemaTest} from './ZodV4SchemaTest';
+import {zodV4Schema} from './ZodV4SchemaTest-schema';
 // @ts-expect-error no types
 import styles from './styles.module.scss';
 
@@ -160,7 +163,9 @@ import {BrowserTest} from './BrowserTest';
 import {EdgeBlur} from './EdgeBlur/EdgeBlur';
 import {EffectsTestbed} from './EffectsTestbed/EffectsTestbed';
 import {Empty} from './Empty';
-import {JumpCuts, SAMPLE_SECTIONS, calculateMetadataJumpCuts} from './JumpCuts';
+import {JumpCuts} from './JumpCuts';
+import {calculateMetadataJumpCuts} from './JumpCuts-calculate-metadata';
+import {SAMPLE_SECTIONS} from './JumpCuts-sections';
 import {LightLeakExample} from './LightLeak';
 import {LightLeakAnimatedSize} from './LightLeak/AnimatedSize';
 import {LoopDisplayTestComp} from './LoopDisplayTest';
@@ -174,12 +179,14 @@ import {MultiChannelAudio} from './OffthreadRemoteVideo/MultiChannelAudio';
 import {OffthreadRemoteSeries} from './OffthreadRemoteVideo/OffthreadRemoteSeries';
 import {ParseAndDownloadMedia} from './ParseAndDownloadMedia';
 import {
-	PLAY_RANGES_MEDIA_DEFAULT,
 	PLAY_RANGES_MEDIA_VIDEO_URL_DEFAULT,
-	PLAY_RANGES_MEDIA_ZIP_DEFAULT,
 	PlayRangesMediaVideo,
-	calculateMetadataPlayRangesMedia,
 } from './PlayRangesMediaVideo';
+import {calculateMetadataPlayRangesMedia} from './PlayRangesMediaVideo-calculate-metadata';
+import {
+	PLAY_RANGES_MEDIA_DEFAULT,
+	PLAY_RANGES_MEDIA_ZIP_DEFAULT,
+} from './PlayRangesMediaVideo-defaults';
 import {PremountOnTransitionSeries} from './PremountOnTransitionSeries';
 import {PrintProps} from './PrintProps';
 import {SfxExample} from './Sfx';
@@ -188,7 +195,8 @@ import {SpringSeason} from './SpringSeason';
 import {StarburstExample} from './Starburst';
 import {Seek} from './StudioApis/Seek';
 import {TikTokTextBoxPlayground} from './TikTokTextbox/TikTokTextBox';
-import {FitTextOnNLines, fitTextOnNLinesSchema} from './Title/FitTextOnNLines';
+import {FitTextOnNLines} from './Title/FitTextOnNLines';
+import {fitTextOnNLinesSchema} from './Title/FitTextOnNLines-schema';
 import {Issue7359FitTextOnNLines} from './Title/Issue7359FitTextOnNLines';
 import {TransitionRounding} from './TransitionRounding';
 import {WebGlTransition} from './Transitions/WebGlTransition';

--- a/packages/example/src/SchemaTest/index-schema.ts
+++ b/packages/example/src/SchemaTest/index-schema.ts
@@ -1,0 +1,35 @@
+import {zColor, zMatrix, zTextarea} from '@remotion/zod-types';
+import {z} from 'zod';
+
+const schemaTestSchema = z.object({
+	title: z.string().nullable(),
+	delay: z.number().min(0).max(1000).step(0.1),
+	color: zColor(),
+	matrix: zMatrix(),
+	list: z.array(z.object({name: z.string(), age: z.number()})),
+	description: zTextarea().nullable(),
+	country: z.enum(COUNTRY_NAMES),
+	dropdown: z.enum(['a', 'b', 'c']),
+	superSchema: z.array(
+		z.discriminatedUnion('type', [
+			z.object({
+				type: z.literal('a'),
+				a: z.object({a: z.string()}),
+			}),
+			z.object({
+				type: z.literal('b'),
+				b: z.object({b: z.string()}),
+			}),
+		]),
+	),
+	discriminatedUnion: z.discriminatedUnion('type', [
+		z.object({
+			type: z.literal('auto'),
+		}),
+		z.object({
+			type: z.literal('fixed'),
+			value: z.number().min(1080),
+		}),
+	]),
+	tuple: z.tuple([z.string(), z.number(), z.object({a: z.string()})]),
+});

--- a/packages/example/src/SchemaTest/index.tsx
+++ b/packages/example/src/SchemaTest/index.tsx
@@ -2,6 +2,7 @@ import {zColor, zMatrix, zTextarea} from '@remotion/zod-types';
 import React from 'react';
 import {AbsoluteFill, Sequence} from 'remotion';
 import {z} from 'zod';
+import {schemaTestSchema} from './index-schema';
 
 const COUNTRY_NAMES = [
 	'Afghanistan',
@@ -105,39 +106,6 @@ const COUNTRY_NAMES = [
 	'Montenegro',
 	'Morocco',
 ] as const;
-
-export const schemaTestSchema = z.object({
-	title: z.string().nullable(),
-	delay: z.number().min(0).max(1000).step(0.1),
-	color: zColor(),
-	matrix: zMatrix(),
-	list: z.array(z.object({name: z.string(), age: z.number()})),
-	description: zTextarea().nullable(),
-	country: z.enum(COUNTRY_NAMES),
-	dropdown: z.enum(['a', 'b', 'c']),
-	superSchema: z.array(
-		z.discriminatedUnion('type', [
-			z.object({
-				type: z.literal('a'),
-				a: z.object({a: z.string()}),
-			}),
-			z.object({
-				type: z.literal('b'),
-				b: z.object({b: z.string()}),
-			}),
-		]),
-	),
-	discriminatedUnion: z.discriminatedUnion('type', [
-		z.object({
-			type: z.literal('auto'),
-		}),
-		z.object({
-			type: z.literal('fixed'),
-			value: z.number().min(1080),
-		}),
-	]),
-	tuple: z.tuple([z.string(), z.number(), z.object({a: z.string()})]),
-});
 
 export const SchemaTest: React.FC<z.infer<typeof schemaTestSchema>> = ({
 	delay,

--- a/packages/example/src/Skia/Blur.tsx
+++ b/packages/example/src/Skia/Blur.tsx
@@ -3,112 +3,12 @@ import {
 	Fill,
 	ImageShader,
 	Shader,
-	Skia,
 	useImage,
 } from '@shopify/react-native-skia';
 import React, {useState} from 'react';
 import {staticFile, useCurrentFrame, useDelayRender} from 'remotion';
-
-type Value = string | number;
-type Values = Value[];
-
-export const glsl = (source: TemplateStringsArray, ...values: Values) => {
-	const processed = source.flatMap((s, i) => [s, values[i]]).filter(Boolean);
-	return processed.join('');
-};
-
-export const frag = (source: TemplateStringsArray, ...values: Values) => {
-	const code = glsl(source, ...values);
-	const rt = Skia.RuntimeEffect.Make(code);
-	if (rt === null) {
-		throw new Error("Couln't Compile Shader");
-	}
-	return rt;
-};
-
-export const transition = (t: string) => {
-	return frag`
-  uniform shader image1;
-  uniform shader image2;
-
-  uniform float progress;
-  uniform float2 resolution;
-  
-  half4 getFromColor(float2 uv) {
-    return image1.eval(uv * resolution);
-  }
-  
-  half4 getToColor(float2 uv) {
-    return image2.eval(uv * resolution);
-  }
-  
-  ${t}
-
-  half4 main(vec2 xy) {
-    vec2 uv = xy / resolution;
-    return transition(uv);
-  }
-  `;
-};
-
-export const cube: string = glsl`
-// GL Transitions format
-uniform float strength;
-
-// Constants
-const float PI = 3.141592653589793;
-
-// Easing functions
-float Linear_ease(in float begin, in float change, in float duration, in float time) {
-    return change * time / duration + begin;
-}
-
-float Exponential_easeInOut(in float begin, in float change, in float duration, in float time) {
-    if (time == 0.0)
-        return begin;
-    else if (time == duration)
-        return begin + change;
-    time /= (duration / 2.0);
-    if (time < 1.0)
-        return change / 2.0 * pow(2.0, 10.0 * (time - 1.0)) + begin;
-    return change / 2.0 * (-pow(2.0, -10.0 * (time - 1.0)) + 2.0) + begin;
-}
-
-float Sinusoidal_easeInOut(in float begin, in float change, in float duration, in float time) {
-    return -change / 2.0 * (cos(PI * time / duration) - 1.0) + begin;
-}
-
-// Random function
-float random(vec3 xyz, in vec3 scale, in float seed) {
-    return fract(sin(dot(xyz + seed, scale)) * 43758.5453 + seed);
-}
-
-// Mix textures with progress
-vec4 transition(vec2 uv) {
-    float p = progress * 0.7; // Adjusted progress
-    vec2 center = vec2(Linear_ease(0.5, 0.0, 1.0, p), 0.5);
-    float dissolve = Exponential_easeInOut(0.0, 1.0, 1.0, p);
-
-
-    float currentStrength = Sinusoidal_easeInOut(0.0, strength, 0.5, p);
-
-    vec3 color = vec3(0.0);
-    float total = 0.0;
-    vec2 toCenter = center - uv;
-
-    float offset = random(vec3(uv.xy, 0), vec3(12.9898, 78.233, 151.7182), 0.0) * 0.5;
-
-    for (float t = 0.0; t <= 20.0; t++) {
-        float percent = (t + offset) / 20.0;
-        float weight = 1.0 * (percent - percent * percent);
-        vec2 samplePoint = uv + toCenter * percent * currentStrength;
-        color += mix(getFromColor(samplePoint).rgb, getToColor(samplePoint).rgb, dissolve) * weight;
-        total += weight;
-    }
-
-    return vec4(color / total, 1.0);
-}
-`;
+import {cube} from './blur-cube-shader';
+import {transition} from './skia-shader-utils';
 
 export const RuntimeShaderZoomBlur = () => {
 	React.useState(0);

--- a/packages/example/src/Skia/Shader.tsx
+++ b/packages/example/src/Skia/Shader.tsx
@@ -3,123 +3,12 @@ import {
 	Fill,
 	ImageShader,
 	Shader,
-	Skia,
 	useImage,
 } from '@shopify/react-native-skia';
 import React from 'react';
 import {staticFile, useCurrentFrame} from 'remotion';
-
-type Value = string | number;
-type Values = Value[];
-
-export const glsl = (source: TemplateStringsArray, ...values: Values) => {
-	const processed = source.flatMap((s, i) => [s, values[i]]).filter(Boolean);
-	return processed.join('');
-};
-
-export const frag = (source: TemplateStringsArray, ...values: Values) => {
-	const code = glsl(source, ...values);
-	const rt = Skia.RuntimeEffect.Make(code);
-	if (rt === null) {
-		throw new Error("Couln't Compile Shader");
-	}
-	return rt;
-};
-
-export const transition = (t: string) => {
-	return frag`
-  uniform shader image1;
-  uniform shader image2;
-
-  uniform float progress;
-  uniform float2 resolution;
-  
-  half4 getFromColor(float2 uv) {
-    return image1.eval(uv * resolution);
-  }
-  
-  half4 getToColor(float2 uv) {
-    return image2.eval(uv * resolution);
-  }
-  
-  ${t}
-
-  half4 main(vec2 xy) {
-    vec2 uv = xy / resolution;
-    return transition(uv);
-  }
-  `;
-};
-
-export const cube = glsl`
-// Author: gre
-// License: MIT
-const float persp = 0.7;
-const float unzoom = 0.3;
-const float reflection = 0.4;
-const float floating = 3.0;
-
-vec2 project (vec2 p) {
-  return p * vec2(1.0, -1.2) + vec2(0.0, -floating/100.);
-}
-
-bool inBounds (vec2 p) {
-  return all(lessThan(vec2(0.0), p)) && all(lessThan(p, vec2(1.0)));
-}
-
-vec4 bgColor (vec2 p, vec2 pfr, vec2 pto) {
-  vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
-  pfr = project(pfr);
-  // FIXME avoid branching might help perf!
-  if (inBounds(pfr)) {
-    c += mix(vec4(0.0), getFromColor(pfr), reflection * mix(1.0, 0.0, pfr.y));
-  }
-  pto = project(pto);
-  if (inBounds(pto)) {
-    c += mix(vec4(0.0), getToColor(pto), reflection * mix(1.0, 0.0, pto.y));
-  }
-  return c;
-}
-
-// p : the position
-// persp : the perspective in [ 0, 1 ]
-// center : the xcenter in [0, 1] \ 0.5 excluded
-vec2 xskew (vec2 p, float persp, float center) {
-  float x = mix(p.x, 1.0-p.x, center);
-  return (
-    (
-      vec2( x, (p.y - 0.5*(1.0-persp) * x) / (1.0+(persp-1.0)*x) )
-      - vec2(0.5-distance(center, 0.5), 0.0)
-    )
-    * vec2(0.5 / distance(center, 0.5) * (center<0.5 ? 1.0 : -1.0), 1.0)
-    + vec2(center<0.5 ? 0.0 : 1.0, 0.0)
-  );
-}
-
-vec4 transition(vec2 op) {
-  float uz = unzoom * 2.0*(0.5-distance(0.5, progress));
-  vec2 p = -uz*0.5+(1.0+uz) * op;
-  vec2 fromP = xskew(
-    (p - vec2(progress, 0.0)) / vec2(1.0-progress, 1.0),
-    1.0-mix(progress, 0.0, persp),
-    0.0
-  );
-  vec2 toP = xskew(
-    p / vec2(progress, 1.0),
-    mix(pow(progress, 2.0), 1.0, persp),
-    1.0
-  );
-  // FIXME avoid branching might help perf!
-  if (inBounds(fromP)) {
-    return getFromColor(fromP);
-  }
-  else if (inBounds(toP)) {
-    return getToColor(toP);
-  }
-  return bgColor(op, fromP, toP);
-}
-
-`;
+import {cube} from './shader-cube-shader';
+import {transition} from './skia-shader-utils';
 
 export const RuntimeShaderDemo = () => {
 	React.useState(0);

--- a/packages/example/src/Skia/blur-cube-shader.ts
+++ b/packages/example/src/Skia/blur-cube-shader.ts
@@ -1,0 +1,60 @@
+import {glsl} from './skia-shader-utils';
+
+export const cube: string = glsl`
+// GL Transitions format
+uniform float strength;
+
+// Constants
+const float PI = 3.141592653589793;
+
+// Easing functions
+float Linear_ease(in float begin, in float change, in float duration, in float time) {
+    return change * time / duration + begin;
+}
+
+float Exponential_easeInOut(in float begin, in float change, in float duration, in float time) {
+    if (time == 0.0)
+        return begin;
+    else if (time == duration)
+        return begin + change;
+    time /= (duration / 2.0);
+    if (time < 1.0)
+        return change / 2.0 * pow(2.0, 10.0 * (time - 1.0)) + begin;
+    return change / 2.0 * (-pow(2.0, -10.0 * (time - 1.0)) + 2.0) + begin;
+}
+
+float Sinusoidal_easeInOut(in float begin, in float change, in float duration, in float time) {
+    return -change / 2.0 * (cos(PI * time / duration) - 1.0) + begin;
+}
+
+// Random function
+float random(vec3 xyz, in vec3 scale, in float seed) {
+    return fract(sin(dot(xyz + seed, scale)) * 43758.5453 + seed);
+}
+
+// Mix textures with progress
+vec4 transition(vec2 uv) {
+    float p = progress * 0.7; // Adjusted progress
+    vec2 center = vec2(Linear_ease(0.5, 0.0, 1.0, p), 0.5);
+    float dissolve = Exponential_easeInOut(0.0, 1.0, 1.0, p);
+
+
+    float currentStrength = Sinusoidal_easeInOut(0.0, strength, 0.5, p);
+
+    vec3 color = vec3(0.0);
+    float total = 0.0;
+    vec2 toCenter = center - uv;
+
+    float offset = random(vec3(uv.xy, 0), vec3(12.9898, 78.233, 151.7182), 0.0) * 0.5;
+
+    for (float t = 0.0; t <= 20.0; t++) {
+        float percent = (t + offset) / 20.0;
+        float weight = 1.0 * (percent - percent * percent);
+        vec2 samplePoint = uv + toCenter * percent * currentStrength;
+        color += mix(getFromColor(samplePoint).rgb, getToColor(samplePoint).rgb, dissolve) * weight;
+        total += weight;
+    }
+
+    return vec4(color / total, 1.0);
+}
+`;

--- a/packages/example/src/Skia/shader-cube-shader.ts
+++ b/packages/example/src/Skia/shader-cube-shader.ts
@@ -1,0 +1,71 @@
+import {glsl} from './skia-shader-utils';
+
+export const cube = glsl`
+// Author: gre
+// License: MIT
+const float persp = 0.7;
+const float unzoom = 0.3;
+const float reflection = 0.4;
+const float floating = 3.0;
+
+vec2 project (vec2 p) {
+  return p * vec2(1.0, -1.2) + vec2(0.0, -floating/100.);
+}
+
+bool inBounds (vec2 p) {
+  return all(lessThan(vec2(0.0), p)) && all(lessThan(p, vec2(1.0)));
+}
+
+vec4 bgColor (vec2 p, vec2 pfr, vec2 pto) {
+  vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
+  pfr = project(pfr);
+  // FIXME avoid branching might help perf!
+  if (inBounds(pfr)) {
+    c += mix(vec4(0.0), getFromColor(pfr), reflection * mix(1.0, 0.0, pfr.y));
+  }
+  pto = project(pto);
+  if (inBounds(pto)) {
+    c += mix(vec4(0.0), getToColor(pto), reflection * mix(1.0, 0.0, pto.y));
+  }
+  return c;
+}
+
+// p : the position
+// persp : the perspective in [ 0, 1 ]
+// center : the xcenter in [0, 1] \ 0.5 excluded
+vec2 xskew (vec2 p, float persp, float center) {
+  float x = mix(p.x, 1.0-p.x, center);
+  return (
+    (
+      vec2( x, (p.y - 0.5*(1.0-persp) * x) / (1.0+(persp-1.0)*x) )
+      - vec2(0.5-distance(center, 0.5), 0.0)
+    )
+    * vec2(0.5 / distance(center, 0.5) * (center<0.5 ? 1.0 : -1.0), 1.0)
+    + vec2(center<0.5 ? 0.0 : 1.0, 0.0)
+  );
+}
+
+vec4 transition(vec2 op) {
+  float uz = unzoom * 2.0*(0.5-distance(0.5, progress));
+  vec2 p = -uz*0.5+(1.0+uz) * op;
+  vec2 fromP = xskew(
+    (p - vec2(progress, 0.0)) / vec2(1.0-progress, 1.0),
+    1.0-mix(progress, 0.0, persp),
+    0.0
+  );
+  vec2 toP = xskew(
+    p / vec2(progress, 1.0),
+    mix(pow(progress, 2.0), 1.0, persp),
+    1.0
+  );
+  // FIXME avoid branching might help perf!
+  if (inBounds(fromP)) {
+    return getFromColor(fromP);
+  }
+  else if (inBounds(toP)) {
+    return getToColor(toP);
+  }
+  return bgColor(op, fromP, toP);
+}
+
+`;

--- a/packages/example/src/Skia/skia-shader-utils.ts
+++ b/packages/example/src/Skia/skia-shader-utils.ts
@@ -1,0 +1,43 @@
+import {Skia} from '@shopify/react-native-skia';
+
+type Value = string | number;
+type Values = Value[];
+
+export const glsl = (source: TemplateStringsArray, ...values: Values) => {
+	const processed = source.flatMap((s, i) => [s, values[i]]).filter(Boolean);
+	return processed.join('');
+};
+
+export const frag = (source: TemplateStringsArray, ...values: Values) => {
+	const code = glsl(source, ...values);
+	const rt = Skia.RuntimeEffect.Make(code);
+	if (rt === null) {
+		throw new Error("Couln't Compile Shader");
+	}
+	return rt;
+};
+
+export const transition = (t: string) => {
+	return frag`
+  uniform shader image1;
+  uniform shader image2;
+
+  uniform float progress;
+  uniform float2 resolution;
+  
+  half4 getFromColor(float2 uv) {
+    return image1.eval(uv * resolution);
+  }
+  
+  half4 getToColor(float2 uv) {
+    return image2.eval(uv * resolution);
+  }
+  
+  ${t}
+
+  half4 main(vec2 xy) {
+    vec2 uv = xy / resolution;
+    return transition(uv);
+  }
+  `;
+};

--- a/packages/example/src/SmoothTextTransition-video.tsx
+++ b/packages/example/src/SmoothTextTransition-video.tsx
@@ -1,0 +1,44 @@
+import {visualControl} from '@remotion/studio';
+import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';
+
+export const SmoothTextTransitionVideo: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	return (
+		<AbsoluteFill
+			style={{
+				fontSize: 20,
+				display: 'flex',
+				lineHeight: 1,
+				fontFamily: 'sans-serif',
+				backgroundColor: 'white',
+				textAlign: 'center',
+				flexDirection: 'row',
+			}}
+		>
+			<div style={{width: 100}}>
+				<div
+					style={{
+						transform:
+							'translateY(' + interpolate(frame, [0, 200], [0, 50]) + 'px)',
+					}}
+				>
+					hi there
+				</div>
+			</div>
+			<div style={{width: 100}}>
+				<div
+					style={{
+						transform:
+							'translateY(' +
+							interpolate(frame, [0, 200], [0, 50]) +
+							'px) perspective(100px)',
+						willChange: 'transform',
+					}}
+				>
+					{visualControl('text', 'hi there')}
+				</div>
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/SmoothTextTransition.tsx
+++ b/packages/example/src/SmoothTextTransition.tsx
@@ -1,50 +1,8 @@
-import {StudioInternals, visualControl} from '@remotion/studio';
-import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';
-
-const Comp: React.FC = () => {
-	const frame = useCurrentFrame();
-
-	return (
-		<AbsoluteFill
-			style={{
-				fontSize: 20,
-				display: 'flex',
-				lineHeight: 1,
-				fontFamily: 'sans-serif',
-				backgroundColor: 'white',
-				textAlign: 'center',
-				flexDirection: 'row',
-			}}
-		>
-			<div style={{width: 100}}>
-				<div
-					style={{
-						transform:
-							'translateY(' + interpolate(frame, [0, 200], [0, 50]) + 'px)',
-					}}
-				>
-					hi there
-				</div>
-			</div>
-			<div style={{width: 100}}>
-				<div
-					style={{
-						transform:
-							'translateY(' +
-							interpolate(frame, [0, 200], [0, 50]) +
-							'px) perspective(100px)',
-						willChange: 'transform',
-					}}
-				>
-					{visualControl('text', 'hi there')}
-				</div>
-			</div>
-		</AbsoluteFill>
-	);
-};
+import {StudioInternals} from '@remotion/studio';
+import {SmoothTextTransitionVideo} from './SmoothTextTransition-video';
 
 export const SmoothTextTransition = StudioInternals.createComposition({
-	component: Comp,
+	component: SmoothTextTransitionVideo,
 	height: 100,
 	width: 200,
 	id: 'smooth-text',

--- a/packages/example/src/StudioApis/SaveDefaultProps-schema.ts
+++ b/packages/example/src/StudioApis/SaveDefaultProps-schema.ts
@@ -1,0 +1,5 @@
+import {z} from 'zod';
+
+const saveStudioSchema = z.object({
+	color: z.string(),
+});

--- a/packages/example/src/StudioApis/SaveDefaultProps.tsx
+++ b/packages/example/src/StudioApis/SaveDefaultProps.tsx
@@ -2,10 +2,7 @@ import {saveDefaultProps, updateDefaultProps} from '@remotion/studio';
 import React, {useCallback} from 'react';
 import {AbsoluteFill, useVideoConfig} from 'remotion';
 import {z} from 'zod';
-
-export const saveStudioSchema = z.object({
-	color: z.string(),
-});
+import {saveStudioSchema} from './SaveDefaultProps-schema';
 
 export const SaveDefaultProps: React.FC = () => {
 	const {id} = useVideoConfig();

--- a/packages/example/src/ThreeScene/Scene-schema.ts
+++ b/packages/example/src/ThreeScene/Scene-schema.ts
@@ -1,0 +1,8 @@
+import {zColor} from '@remotion/zod-types';
+import {z} from 'zod';
+
+export const myCompSchema = z.object({
+	phoneColor: zColor(),
+	deviceType: z.enum(['phone', 'tablet']),
+	textureType: z.enum(['video', 'offthreadvideo']),
+});

--- a/packages/example/src/ThreeScene/Scene.tsx
+++ b/packages/example/src/ThreeScene/Scene.tsx
@@ -4,7 +4,6 @@ import {
 	useOffthreadVideoTexture,
 	useVideoTexture,
 } from '@remotion/three';
-import {zColor} from '@remotion/zod-types';
 import React, {useEffect, useRef, useState} from 'react';
 import {
 	AbsoluteFill,
@@ -13,8 +12,9 @@ import {
 	useRemotionEnvironment,
 	useVideoConfig,
 } from 'remotion';
-import {z} from 'zod';
+import type {z} from 'zod';
 import {Phone} from './Phone';
+import {myCompSchema} from './Scene-schema';
 
 const container: React.CSSProperties = {
 	backgroundColor: 'white',
@@ -24,12 +24,6 @@ const videoStyle: React.CSSProperties = {
 	position: 'absolute',
 	opacity: 0,
 };
-
-export const myCompSchema = z.object({
-	phoneColor: zColor(),
-	deviceType: z.enum(['phone', 'tablet']),
-	textureType: z.enum(['video', 'offthreadvideo']),
-});
 
 type MyCompSchemaType = z.infer<typeof myCompSchema>;
 

--- a/packages/example/src/Title/FitText-schema.ts
+++ b/packages/example/src/Title/FitText-schema.ts
@@ -1,0 +1,6 @@
+import {fitText} from '@remotion/layout-utils';
+import {z} from 'zod';
+
+const fitTextSchema = z.object({
+	line: z.string(),
+});

--- a/packages/example/src/Title/FitText.tsx
+++ b/packages/example/src/Title/FitText.tsx
@@ -2,15 +2,12 @@ import {fitText} from '@remotion/layout-utils';
 import React from 'react';
 import {AbsoluteFill} from 'remotion';
 import {z} from 'zod';
+import {fitTextSchema} from './FitText-schema';
 
 const boxWidth = 600;
 // Must be loaded before calling fitText()
 const fontFamily = 'GT Planar';
 const fontWeight = 'bold';
-
-export const fitTextSchema = z.object({
-	line: z.string(),
-});
 
 export const FitText: React.FC<z.infer<typeof fitTextSchema>> = ({line}) => {
 	const fontSize = Math.min(

--- a/packages/example/src/Title/FitTextOnNLines-schema.ts
+++ b/packages/example/src/Title/FitTextOnNLines-schema.ts
@@ -1,0 +1,8 @@
+import {fitTextOnNLines, measureText} from '@remotion/layout-utils';
+import {z} from 'zod';
+
+const fitTextOnNLinesSchema = z.object({
+	text: z.string(),
+	maxLines: z.number().step(1),
+	textAlign: z.enum(['left', 'center', 'right']),
+});

--- a/packages/example/src/Title/FitTextOnNLines.tsx
+++ b/packages/example/src/Title/FitTextOnNLines.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {AbsoluteFill} from 'remotion';
 import {z} from 'zod';
 import {TIKTOK_TEXT_BOX_HORIZONTAL_PADDING} from '../TikTokTextbox/TikTokTextBox';
+import {fitTextOnNLinesSchema} from './FitTextOnNLines-schema';
 
 const boxWidth = 1500;
 const fontFamily = 'Proxima Nova';
@@ -12,12 +13,6 @@ const horizontalPadding = 30;
 const cornerRadius = 20;
 const lineHeight = 1.5;
 const maxFontSize = 100;
-
-export const fitTextOnNLinesSchema = z.object({
-	text: z.string(),
-	maxLines: z.number().step(1),
-	textAlign: z.enum(['left', 'center', 'right']),
-});
 
 export const FitTextOnNLines: React.FC<
 	z.infer<typeof fitTextOnNLinesSchema>

--- a/packages/example/src/Transitions/AudioTransition-add-sound.tsx
+++ b/packages/example/src/Transitions/AudioTransition-add-sound.tsx
@@ -1,0 +1,33 @@
+import type {
+	TransitionPresentation,
+	TransitionPresentationComponentProps,
+} from '@remotion/transitions';
+import React from 'react';
+import {Html5Audio} from 'remotion';
+
+export function addSound<T extends Record<string, unknown>>(
+	transition: TransitionPresentation<T>,
+	src: string,
+): TransitionPresentation<T> {
+	const {component: Component, props: resultingProps} = transition;
+
+	const C = Component as React.FC<TransitionPresentationComponentProps<T>>;
+
+	const NewComponent: React.FC<TransitionPresentationComponentProps<T>> = (
+		p,
+	) => {
+		return (
+			<>
+				{p.presentationDirection === 'entering' ? (
+					<Html5Audio src={src} />
+				) : null}
+				<C {...p} />
+			</>
+		);
+	};
+
+	return {
+		component: NewComponent,
+		props: resultingProps,
+	};
+}

--- a/packages/example/src/Transitions/AudioTransition.tsx
+++ b/packages/example/src/Transitions/AudioTransition.tsx
@@ -1,41 +1,8 @@
-import {
-	TransitionPresentation,
-	TransitionPresentationComponentProps,
-} from '@remotion/transitions';
-import React from 'react';
-import {Html5Audio, staticFile} from 'remotion';
-
-export function addSound<T extends Record<string, unknown>>(
-	transition: TransitionPresentation<T>,
-	src: string,
-): TransitionPresentation<T> {
-	const {component: Component, props: resultingProps} = transition;
-
-	const C = Component as React.FC<TransitionPresentationComponentProps<T>>;
-
-	const NewComponent: React.FC<TransitionPresentationComponentProps<T>> = (
-		p,
-	) => {
-		return (
-			<>
-				{p.presentationDirection === 'entering' ? (
-					<Html5Audio src={src} />
-				) : null}
-				<C {...p} />
-			</>
-		);
-	};
-
-	return {
-		component: NewComponent,
-		props: resultingProps,
-	};
-}
-
 import {springTiming, TransitionSeries} from '@remotion/transitions';
 import {slide} from '@remotion/transitions/slide';
 import {wipe} from '@remotion/transitions/wipe';
-import {AbsoluteFill} from 'remotion';
+import {AbsoluteFill, staticFile} from 'remotion';
+import {addSound} from './AudioTransition-add-sound';
 
 export const Letter: React.FC<{
 	readonly children: React.ReactNode;

--- a/packages/example/src/ZodV4SchemaTest-schema.ts
+++ b/packages/example/src/ZodV4SchemaTest-schema.ts
@@ -1,0 +1,14 @@
+import {z} from 'zod/v4';
+
+const zodV4Schema = z.object({
+	greeting: z.string().default('Hello from Zod v4!'),
+	count: z.number().min(0).max(100),
+	enabled: z.boolean(),
+	items: z.array(z.object({label: z.string(), value: z.number()})),
+	mode: z.enum(['light', 'dark']),
+	optional: z.string().optional(),
+	nested: z.object({
+		a: z.string(),
+		b: z.number(),
+	}),
+});

--- a/packages/example/src/ZodV4SchemaTest.tsx
+++ b/packages/example/src/ZodV4SchemaTest.tsx
@@ -5,19 +5,7 @@
 import React from 'react';
 import {AbsoluteFill} from 'remotion';
 import {z} from 'zod/v4';
-
-export const zodV4Schema = z.object({
-	greeting: z.string().default('Hello from Zod v4!'),
-	count: z.number().min(0).max(100),
-	enabled: z.boolean(),
-	items: z.array(z.object({label: z.string(), value: z.number()})),
-	mode: z.enum(['light', 'dark']),
-	optional: z.string().optional(),
-	nested: z.object({
-		a: z.string(),
-		b: z.number(),
-	}),
-});
+import {zodV4Schema} from './ZodV4SchemaTest-schema';
 
 export const ZodV4SchemaTest: React.FC<z.infer<typeof zodV4Schema>> = ({
 	greeting,

--- a/packages/example/src/comp-type-tests.tsx
+++ b/packages/example/src/comp-type-tests.tsx
@@ -8,7 +8,7 @@ type MyComponentProps = {
 	readonly b: string;
 };
 
-function MyComponent(props: MyComponentProps) {
+export function MyComponent(props: MyComponentProps) {
 	return (
 		<div>
 			{props.a} {props.b}
@@ -34,7 +34,7 @@ function MyComponent(props: MyComponentProps) {
 />;
 
 // React.FC syntax
-const MyComponent2: React.FC<{
+export const MyComponent2: React.FC<{
 	readonly c: number;
 }> = ({c}) => {
 	return <div>{c}</div>;
@@ -52,7 +52,7 @@ const MyComponent2: React.FC<{
 />;
 
 // React.FC syntax
-const MyComponent3: React.FC<{
+export const MyComponent3: React.FC<{
 	readonly a: number;
 }> = ({a}) => {
 	return <div>{a}</div>;
@@ -69,7 +69,7 @@ const MyComponent3: React.FC<{
 	defaultProps={{a: 2}}
 />;
 
-const CompWithNoProps: React.FC = () => {
+export const CompWithNoProps: React.FC = () => {
 	return <div />;
 };
 

--- a/packages/player-example/pages/video-ssr.tsx
+++ b/packages/player-example/pages/video-ssr.tsx
@@ -2,11 +2,11 @@ import {Video} from '@remotion/media';
 import {Player} from '@remotion/player';
 import React from 'react';
 
-const NewVideoTag: React.FC = () => {
+export const NewVideoTag: React.FC = () => {
 	return <Video src={'https://remotion.media/video.mp4'} />;
 };
 
-export default () => {
+export default function Video-ssr() => {
 	return (
 		<Player
 			component={NewVideoTag}

--- a/packages/player-example/src/App.tsx
+++ b/packages/player-example/src/App.tsx
@@ -33,7 +33,7 @@ type CompProps<T> =
 			component: AnyComponent<T>;
 	  };
 
-const ControlsOnly: React.FC<{
+export const ControlsOnly: React.FC<{
 	readonly playerRef: React.RefObject<PlayerRef | null>;
 	readonly color: string;
 	readonly setColor: React.Dispatch<React.SetStateAction<string>>;
@@ -557,7 +557,7 @@ const ControlsOnly: React.FC<{
 	);
 };
 
-const PlayerOnly: React.FC<
+export const PlayerOnly: React.FC<
 	{
 		readonly playerRef: React.RefObject<PlayerRef | null>;
 		readonly inputProps: Record<string, unknown>;
@@ -691,7 +691,7 @@ const PlayerOnly: React.FC<
 	);
 };
 
-export default ({
+export default function App({
 	durationInFrames,
 	...props
 }: {

--- a/packages/player-example/src/CarSlideshow-ref.ts
+++ b/packages/player-example/src/CarSlideshow-ref.ts
@@ -1,0 +1,6 @@
+import {createRef, useCallback, useImperativeHandle, useState} from 'react';
+
+const playerExampleComp = createRef<{
+	triggerError: () => void;
+}>();
+

--- a/packages/player-example/src/CarSlideshow.tsx
+++ b/packages/player-example/src/CarSlideshow.tsx
@@ -1,5 +1,6 @@
 import {createRef, useCallback, useImperativeHandle, useState} from 'react';
 import {
+import {playerExampleComp} from './CarSlideshow-ref';
 	Html5Video,
 	Img,
 	Sequence,
@@ -15,9 +16,6 @@ type Props = {
 	readonly color: string;
 };
 
-export const playerExampleComp = createRef<{
-	triggerError: () => void;
-}>();
 
 const CarSlideshow = ({title, bgColor, color}: Props) => {
 	const frame = useCurrentFrame();

--- a/packages/template-code-hike/src/calculate-metadata/theme-context.tsx
+++ b/packages/template-code-hike/src/calculate-metadata/theme-context.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+
+const ThemeColorsContext = React.createContext<ThemeColors | null>(null);
+

--- a/packages/template-code-hike/src/calculate-metadata/theme-schema.ts
+++ b/packages/template-code-hike/src/calculate-metadata/theme-schema.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+const themeSchema = z.enum([
+  "dark-plus",
+  "dracula-soft",
+  "dracula",
+  "github-dark",
+  "github-dark-dimmed",
+  "github-light",
+  "light-plus",
+  "material-darker",
+  "material-default",
+  "material-lighter",
+  "material-ocean",
+  "material-palenight",
+  "min-dark",
+  "min-light",
+  "monokai",
+  "nord",
+  "one-dark-pro",
+  "poimandres",
+  "slack-dark",
+  "slack-ochin",
+  "solarized-dark",
+  "solarized-light",
+]);
+

--- a/packages/template-code-hike/src/calculate-metadata/theme.tsx
+++ b/packages/template-code-hike/src/calculate-metadata/theme.tsx
@@ -1,40 +1,16 @@
 import { getThemeColors } from "@code-hike/lighter";
 import React from "react";
 import { z } from "zod";
+import {themeSchema} from './theme-schema';
+import {ThemeColorsContext} from './theme-context';
+import {useThemeColors} from './useThemeColors';
 
 export type ThemeColors = Awaited<ReturnType<typeof getThemeColors>>;
 
-export const themeSchema = z.enum([
-  "dark-plus",
-  "dracula-soft",
-  "dracula",
-  "github-dark",
-  "github-dark-dimmed",
-  "github-light",
-  "light-plus",
-  "material-darker",
-  "material-default",
-  "material-lighter",
-  "material-ocean",
-  "material-palenight",
-  "min-dark",
-  "min-light",
-  "monokai",
-  "nord",
-  "one-dark-pro",
-  "poimandres",
-  "slack-dark",
-  "slack-ochin",
-  "solarized-dark",
-  "solarized-light",
-]);
 
 export type Theme = z.infer<typeof themeSchema>;
 
-export const ThemeColorsContext = React.createContext<ThemeColors | null>(null);
 
-export const useThemeColors = () => {
-  const themeColors = React.useContext(ThemeColorsContext);
   if (!themeColors) {
     throw new Error("ThemeColorsContext not found");
   }

--- a/packages/template-code-hike/src/calculate-metadata/useThemeColors.ts
+++ b/packages/template-code-hike/src/calculate-metadata/useThemeColors.ts
@@ -1,0 +1,5 @@
+import React from "react";
+
+const useThemeColors = () => {
+  const themeColors = React.useContext(ThemeColorsContext);
+

--- a/packages/template-helloworld/src/HelloWorld.tsx
+++ b/packages/template-helloworld/src/HelloWorld.tsx
@@ -1,4 +1,3 @@
-import { zColor } from "@remotion/zod-types";
 import {
   AbsoluteFill,
   interpolate,
@@ -7,17 +6,11 @@ import {
   useCurrentFrame,
   useVideoConfig,
 } from "remotion";
-import { z } from "zod";
+import type {z} from "zod";
 import { Logo } from "./HelloWorld/Logo";
 import { Subtitle } from "./HelloWorld/Subtitle";
 import { Title } from "./HelloWorld/Title";
-
-export const myCompSchema = z.object({
-  titleText: z.string(),
-  titleColor: zColor(),
-  logoColor1: zColor(),
-  logoColor2: zColor(),
-});
+import {myCompSchema} from "./hello-world-schema";
 
 export const HelloWorld: React.FC<z.infer<typeof myCompSchema>> = ({
   titleText: propOne,

--- a/packages/template-helloworld/src/HelloWorld/Logo.tsx
+++ b/packages/template-helloworld/src/HelloWorld/Logo.tsx
@@ -1,4 +1,3 @@
-import { zColor } from "@remotion/zod-types";
 import {
   AbsoluteFill,
   interpolate,
@@ -6,14 +5,10 @@ import {
   useCurrentFrame,
   useVideoConfig,
 } from "remotion";
-import { z } from "zod";
+import type {z} from "zod";
 import { Arc } from "./Arc";
 import { Atom } from "./Atom";
-
-export const myCompSchema2 = z.object({
-  logoColor1: zColor(),
-  logoColor2: zColor(),
-});
+import {myCompSchema2} from "./logo-schema";
 
 export const Logo: React.FC<z.infer<typeof myCompSchema2>> = ({
   logoColor1: color1,

--- a/packages/template-helloworld/src/HelloWorld/logo-schema.ts
+++ b/packages/template-helloworld/src/HelloWorld/logo-schema.ts
@@ -1,0 +1,7 @@
+import {zColor} from "@remotion/zod-types";
+import {z} from "zod";
+
+export const myCompSchema2 = z.object({
+  logoColor1: zColor(),
+  logoColor2: zColor(),
+});

--- a/packages/template-helloworld/src/Root.tsx
+++ b/packages/template-helloworld/src/Root.tsx
@@ -1,6 +1,8 @@
 import { Composition } from "remotion";
-import { HelloWorld, myCompSchema } from "./HelloWorld";
-import { Logo, myCompSchema2 } from "./HelloWorld/Logo";
+import { HelloWorld } from "./HelloWorld";
+import { Logo } from "./HelloWorld/Logo";
+import {myCompSchema} from "./hello-world-schema";
+import {myCompSchema2} from "./HelloWorld/logo-schema";
 
 // Each <Composition> is an entry in the sidebar!
 

--- a/packages/template-helloworld/src/hello-world-schema.ts
+++ b/packages/template-helloworld/src/hello-world-schema.ts
@@ -1,0 +1,9 @@
+import {zColor} from "@remotion/zod-types";
+import {z} from "zod";
+
+export const myCompSchema = z.object({
+  titleText: z.string(),
+  titleColor: zColor(),
+  logoColor1: zColor(),
+  logoColor2: zColor(),
+});

--- a/packages/template-prompt-to-video/src/components/AIVideo-schema.ts
+++ b/packages/template-prompt-to-video/src/components/AIVideo-schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { TimelineSchema } from "../lib/types";
+
+const aiVideoSchema = z.object({
+  timeline: TimelineSchema.nullable(),
+});
+

--- a/packages/template-prompt-to-video/src/components/AIVideo.tsx
+++ b/packages/template-prompt-to-video/src/components/AIVideo.tsx
@@ -7,10 +7,8 @@ import { TimelineSchema } from "../lib/types";
 import { calculateFrameTiming, getAudioPath } from "../lib/utils";
 import { Background } from "./Background";
 import Subtitle from "./Subtitle";
+import {aiVideoSchema} from './AIVideo-schema';
 
-export const aiVideoSchema = z.object({
-  timeline: TimelineSchema.nullable(),
-});
 
 const { fontFamily } = loadFont();
 

--- a/packages/template-react-router/app/root-meta.ts
+++ b/packages/template-react-router/app/root-meta.ts
@@ -1,0 +1,12 @@
+import type {MetaFunction} from "react-router";
+
+export const meta: MetaFunction = () => {
+  return [
+    {
+      title: "Remotion Starter",
+    },
+    { charset: "utf-8" },
+    { name: "viewport", content: "width=device-width,initial-scale=1" },
+    { property: "og:title", content: "Remotion + React Router" },
+  ];
+};

--- a/packages/template-react-router/app/root.tsx
+++ b/packages/template-react-router/app/root.tsx
@@ -1,22 +1,11 @@
 import {
   Links,
   Meta,
-  MetaFunction,
   Outlet,
   Scripts,
   ScrollRestoration,
 } from "react-router";
 
-export const meta: MetaFunction = () => {
-  return [
-    {
-      title: "Remotion Starter",
-    },
-    { charset: "utf-8" },
-    { name: "viewport", content: "width=device-width,initial-scale=1" },
-    { property: "og:title", content: "Remotion + React Router" },
-  ];
-};
 export default function App() {
   return (
     <html lang="en">

--- a/packages/template-recorder/remotion/captions/boxed/components/CaptionSentence-get-border-width-for-subtitles.ts
+++ b/packages/template-recorder/remotion/captions/boxed/components/CaptionSentence-get-border-width-for-subtitles.ts
@@ -1,0 +1,4 @@
+
+const getBorderWidthForSubtitles = () => {
+  return 3;
+

--- a/packages/template-recorder/remotion/captions/boxed/components/CaptionSentence-get-subtitles-font-size.ts
+++ b/packages/template-recorder/remotion/captions/boxed/components/CaptionSentence-get-subtitles-font-size.ts
@@ -1,0 +1,4 @@
+
+const getSubtitlesFontSize = () => {
+  return 56;
+

--- a/packages/template-recorder/remotion/captions/boxed/components/CaptionSentence-get-subtitles-lines.ts
+++ b/packages/template-recorder/remotion/captions/boxed/components/CaptionSentence-get-subtitles-lines.ts
@@ -1,0 +1,10 @@
+
+const getSubtitlesLines = ({
+  boxHeight,
+  fontSize,
+}: {
+  boxHeight: number;
+  fontSize: number;
+}) => {
+  const boxPadding = 50;
+

--- a/packages/template-recorder/remotion/captions/boxed/components/CaptionSentence.tsx
+++ b/packages/template-recorder/remotion/captions/boxed/components/CaptionSentence.tsx
@@ -1,6 +1,9 @@
 import { Caption } from "@remotion/captions";
 import React from "react";
 import {
+import {getSubtitlesFontSize} from './CaptionSentence-get-subtitles-font-size';
+import {getSubtitlesLines} from './CaptionSentence-get-subtitles-lines';
+import {getBorderWidthForSubtitles} from './CaptionSentence-get-border-width-for-subtitles';
   Sequence,
   interpolate,
   useCurrentFrame,
@@ -26,18 +29,8 @@ const getEndOfSegment = (segment: CaptionPage) => {
   return (segment.captions[segment.captions.length - 1] as Caption).endMs;
 };
 
-export const getSubtitlesFontSize = () => {
-  return 56;
 };
 
-export const getSubtitlesLines = ({
-  boxHeight,
-  fontSize,
-}: {
-  boxHeight: number;
-  fontSize: number;
-}) => {
-  const boxPadding = 50;
 
   const nrOfLines = Math.floor(
     (boxHeight - boxPadding) / (fontSize * LINE_HEIGHT),
@@ -45,8 +38,6 @@ export const getSubtitlesLines = ({
   return nrOfLines;
 };
 
-export const getBorderWidthForSubtitles = () => {
-  return 3;
 };
 
 const FadeSentence: React.FC<{

--- a/packages/template-recorder/remotion/captions/editor/captions-provider.tsx
+++ b/packages/template-recorder/remotion/captions/editor/captions-provider.tsx
@@ -1,5 +1,6 @@
 import { Caption } from "@remotion/captions";
 import React, { useContext } from "react";
+import {useCaptions} from './useCaptions';
 
 export type CaptionsContextType = {
   captions: Caption[] | null;
@@ -13,8 +14,6 @@ const context = React.createContext<CaptionsContextType>({
   },
 });
 
-export const useCaptions = (): Caption[] => {
-  const ctx = useContext(context);
 
   if (!ctx.captions) {
     throw new Error("Should not render without a captions");

--- a/packages/template-recorder/remotion/captions/editor/use-caption-overlay.tsx
+++ b/packages/template-recorder/remotion/captions/editor/use-caption-overlay.tsx
@@ -1,5 +1,6 @@
 import { Caption } from "@remotion/captions";
 import React, { useContext, useMemo } from "react";
+import {useCaptionOverlay} from './useCaptionOverlay';
 
 type CaptionOverlayContext = {
   open: Caption | false;
@@ -13,11 +14,6 @@ const context = React.createContext<CaptionOverlayContext>({
   },
 });
 
-export const useCaptionOverlay = (): {
-  isOpen: Caption | false;
-  setOpen: React.Dispatch<React.SetStateAction<Caption | false>>;
-} => {
-  const ctx = useContext(context);
 
   return useMemo(
     () => ({ isOpen: ctx.open, setOpen: ctx.setOpen }),

--- a/packages/template-recorder/remotion/captions/editor/useCaptionOverlay.ts
+++ b/packages/template-recorder/remotion/captions/editor/useCaptionOverlay.ts
@@ -1,0 +1,9 @@
+import { Caption } from "@remotion/captions";
+import React, { useContext, useMemo } from "react";
+
+const useCaptionOverlay = (): {
+  isOpen: Caption | false;
+  setOpen: React.Dispatch<React.SetStateAction<Caption | false>>;
+} => {
+  const ctx = useContext(context);
+

--- a/packages/template-recorder/remotion/captions/editor/useCaptions.ts
+++ b/packages/template-recorder/remotion/captions/editor/useCaptions.ts
@@ -1,0 +1,5 @@
+import { Caption } from "@remotion/captions";
+
+const useCaptions = (): Caption[] => {
+  const ctx = useContext(context);
+

--- a/packages/template-recorder/remotion/scenes/VideoScene/ActionOverlay/Actions-container.ts
+++ b/packages/template-recorder/remotion/scenes/VideoScene/ActionOverlay/Actions-container.ts
@@ -1,0 +1,19 @@
+import React, { useMemo } from "react";
+
+const container: React.CSSProperties = {
+  height: 100,
+  backgroundImage: `linear-gradient(to top,${gradientSteps
+    .map((g, i) => {
+      return `hsla(0, 100%, 100%, ${g}) ${
+        (gradientOpacities[i] as number) * globalGradientOpacity
+      }%`;
+    })
+    .join(", ")}, hsl(0, 0%, 0%) 100%)`,
+  top: 0,
+  position: "absolute",
+  justifyContent: "center",
+  color: "white",
+  display: "flex",
+  transition: "opacity 0.15s",
+};
+

--- a/packages/template-recorder/remotion/scenes/VideoScene/ActionOverlay/Actions.tsx
+++ b/packages/template-recorder/remotion/scenes/VideoScene/ActionOverlay/Actions.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { useVideoConfig } from "remotion";
 import { Cameras } from "../../../../config/scenes";
 import { DeleteRecordingAction } from "./DeleteRecordingAction";
+import {container} from './Actions-container';
 
 const gradientSteps = [
   0, 0.013, 0.049, 0.104, 0.175, 0.259, 0.352, 0.45, 0.55, 0.648, 0.741, 0.825,
@@ -15,22 +16,6 @@ const gradientOpacities = [
 
 const globalGradientOpacity = 1;
 
-export const container: React.CSSProperties = {
-  height: 100,
-  backgroundImage: `linear-gradient(to top,${gradientSteps
-    .map((g, i) => {
-      return `hsla(0, 100%, 100%, ${g}) ${
-        (gradientOpacities[i] as number) * globalGradientOpacity
-      }%`;
-    })
-    .join(", ")}, hsl(0, 0%, 0%) 100%)`,
-  top: 0,
-  position: "absolute",
-  justifyContent: "center",
-  color: "white",
-  display: "flex",
-  transition: "opacity 0.15s",
-};
 
 export const Actions: React.FC<{
   cameras: Cameras;

--- a/packages/template-recorder/src/WaitingForDevices-context.tsx
+++ b/packages/template-recorder/src/WaitingForDevices-context.tsx
@@ -1,0 +1,3 @@
+
+const DevicesContext = createContext<DevicesContext | null>(null);
+

--- a/packages/template-recorder/src/WaitingForDevices.tsx
+++ b/packages/template-recorder/src/WaitingForDevices.tsx
@@ -1,4 +1,6 @@
 import {
+import {DevicesContext} from './WaitingForDevices-context';
+import {useDevices} from './useDevices';
   createContext,
   useCallback,
   useContext,
@@ -14,7 +16,6 @@ export type DevicesContext = {
   isRescanning: boolean;
 };
 
-export const DevicesContext = createContext<DevicesContext | null>(null);
 
 export const WaitingForDevices: React.FC<{
   children: React.ReactNode;
@@ -70,8 +71,6 @@ export const WaitingForDevices: React.FC<{
   );
 };
 
-export const useDevices = (): MediaDeviceInfo[] => {
-  const context = useContext(DevicesContext);
   if (!context?.devices) {
     throw new Error("useDevices must be used within a DevicesContextProvider");
   }

--- a/packages/template-recorder/src/components/NewFolderDialog-ref.ts
+++ b/packages/template-recorder/src/components/NewFolderDialog-ref.ts
@@ -1,0 +1,5 @@
+
+const createNewFolderRef = createRef<{
+  openDialog: () => void;
+}>();
+

--- a/packages/template-recorder/src/components/NewFolderDialog.tsx
+++ b/packages/template-recorder/src/components/NewFolderDialog.tsx
@@ -1,5 +1,6 @@
 import type { ChangeEvent, SetStateAction } from "react";
 import React, {
+import {createNewFolderRef} from './NewFolderDialog-ref';
   createRef,
   useCallback,
   useImperativeHandle,
@@ -20,9 +21,6 @@ import {
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 
-export const createNewFolderRef = createRef<{
-  openDialog: () => void;
-}>();
 
 export const NewFolderDialog: React.FC<{
   setSelectedFolder: React.Dispatch<SetStateAction<string | null>>;

--- a/packages/template-recorder/src/components/StreamPicker-get-device-label.ts
+++ b/packages/template-recorder/src/components/StreamPicker-get-device-label.ts
@@ -1,0 +1,5 @@
+import { Label, formatDeviceLabel } from "../helpers/format-device-label";
+
+const getDeviceLabel = (device: MediaDeviceInfo): string => {
+  const labels: Label[] = JSON.parse(localStorage.getItem("labels") ?? "[]");
+

--- a/packages/template-recorder/src/components/StreamPicker.tsx
+++ b/packages/template-recorder/src/components/StreamPicker.tsx
@@ -4,6 +4,7 @@ import { DeviceItem } from "../DeviceItem";
 import { useDevices } from "../WaitingForDevices";
 import { Label, formatDeviceLabel } from "../helpers/format-device-label";
 import { RescanDevices } from "./RescanDevices";
+import {getDeviceLabel} from './StreamPicker-get-device-label';
 
 const title: React.CSSProperties = {
   fontWeight: "bold",
@@ -26,8 +27,6 @@ const clearStyle: React.CSSProperties = {
   cursor: "pointer",
 };
 
-export const getDeviceLabel = (device: MediaDeviceInfo): string => {
-  const labels: Label[] = JSON.parse(localStorage.getItem("labels") ?? "[]");
   const found = labels.find((l) => l.id === device.deviceId);
   if (found) {
     return found.label;

--- a/packages/template-recorder/src/state/media-sources.tsx
+++ b/packages/template-recorder/src/state/media-sources.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { useDevices } from "../WaitingForDevices";
 import { Prefix } from "../helpers/prefixes";
 import { getPreferredDeviceIfExists } from "../preferred-device-localstorage";
+import {useMediaSources} from './useMediaSources';
 
 export type StreamState =
   | { type: "initial" }
@@ -91,8 +92,6 @@ export const MediaSourcesProvider: React.FC<{
   );
 };
 
-export const useMediaSources = () => {
-  const context = React.useContext(MediaSourcesContext);
   if (!context) {
     throw new Error(
       "useMediaSources must be used within a MediaSourcesProvider",

--- a/packages/template-recorder/src/state/useMediaSources.ts
+++ b/packages/template-recorder/src/state/useMediaSources.ts
@@ -1,0 +1,5 @@
+import React, { useCallback, useMemo, useState } from "react";
+
+const useMediaSources = () => {
+  const context = React.useContext(MediaSourcesContext);
+

--- a/packages/template-recorder/src/useDevices.ts
+++ b/packages/template-recorder/src/useDevices.ts
@@ -1,0 +1,4 @@
+
+const useDevices = (): MediaDeviceInfo[] => {
+  const context = useContext(DevicesContext);
+

--- a/packages/template-render-server/remotion/HelloWorld-schema.ts
+++ b/packages/template-render-server/remotion/HelloWorld-schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { zColor } from "@remotion/zod-types";
+
+const helloWorldCompSchema = z.object({
+  titleText: z.string(),
+  titleColor: zColor(),
+  logoColor1: zColor(),
+  logoColor2: zColor(),
+});
+

--- a/packages/template-render-server/remotion/HelloWorld.tsx
+++ b/packages/template-render-server/remotion/HelloWorld.tsx
@@ -1,5 +1,6 @@
 import { spring } from "remotion";
 import {
+import {helloWorldCompSchema} from './HelloWorld-schema';
   AbsoluteFill,
   interpolate,
   Sequence,
@@ -12,12 +13,6 @@ import { Title } from "./HelloWorld/Title";
 import { z } from "zod";
 import { zColor } from "@remotion/zod-types";
 
-export const helloWorldCompSchema = z.object({
-  titleText: z.string(),
-  titleColor: zColor(),
-  logoColor1: zColor(),
-  logoColor2: zColor(),
-});
 
 export const HelloWorld: React.FC<z.infer<typeof helloWorldCompSchema>> = ({
   titleText: propOne,

--- a/packages/template-render-server/remotion/HelloWorld/Logo-my-comp-schema2.ts
+++ b/packages/template-render-server/remotion/HelloWorld/Logo-my-comp-schema2.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { zColor } from "@remotion/zod-types";
+
+const myCompSchema2 = z.object({
+  logoColor1: zColor(),
+  logoColor2: zColor(),
+});
+

--- a/packages/template-render-server/remotion/HelloWorld/Logo.tsx
+++ b/packages/template-render-server/remotion/HelloWorld/Logo.tsx
@@ -1,4 +1,5 @@
 import {
+import {myCompSchema2} from './Logo-my-comp-schema2';
   AbsoluteFill,
   interpolate,
   spring,
@@ -10,10 +11,6 @@ import { Atom } from "./Atom";
 import { z } from "zod";
 import { zColor } from "@remotion/zod-types";
 
-export const myCompSchema2 = z.object({
-  logoColor1: zColor(),
-  logoColor2: zColor(),
-});
 
 export const Logo: React.FC<z.infer<typeof myCompSchema2>> = ({
   logoColor1: color1,

--- a/packages/template-skia/src/AssetManager.tsx
+++ b/packages/template-skia/src/AssetManager.tsx
@@ -2,6 +2,8 @@ import type { SkData, SkImage, SkTypeface } from "@shopify/react-native-skia";
 import { Skia } from "@shopify/react-native-skia";
 import type { ReactNode } from "react";
 import { createContext, useContext, useEffect, useState } from "react";
+import {useTypefaces} from './useTypefaces';
+import {useImages} from './useImages';
 
 type ImagesToLoad = Record<string, ReturnType<typeof require>>;
 type TypefacesToLoad = Record<string, ReturnType<typeof require>>;
@@ -29,13 +31,9 @@ const useAssetManager = () => {
   return assetManager;
 };
 
-export const useTypefaces = () => {
-  const assetManager = useAssetManager();
   return assetManager.typefaces;
 };
 
-export const useImages = () => {
-  const assetManager = useAssetManager();
   return assetManager.images;
 };
 

--- a/packages/template-skia/src/HelloSkia-schema.ts
+++ b/packages/template-skia/src/HelloSkia-schema.ts
@@ -1,0 +1,8 @@
+import { zColor } from "@remotion/zod-types";
+import { z } from "zod";
+
+const helloSkiaSchema = z.object({
+  color1: zColor(),
+  color2: zColor(),
+});
+

--- a/packages/template-skia/src/HelloSkia.tsx
+++ b/packages/template-skia/src/HelloSkia.tsx
@@ -5,13 +5,10 @@ import { staticFile, useVideoConfig } from "remotion";
 import { z } from "zod";
 import { AssetManager } from "./AssetManager";
 import { Drawing } from "./Drawing";
+import {helloSkiaSchema} from './HelloSkia-schema';
 
 const roboto = staticFile("Roboto-Bold.ttf");
 
-export const helloSkiaSchema = z.object({
-  color1: zColor(),
-  color2: zColor(),
-});
 
 export const HelloSkia: React.FC<z.infer<typeof helloSkiaSchema>> = ({
   color1,

--- a/packages/template-skia/src/useImages.ts
+++ b/packages/template-skia/src/useImages.ts
@@ -1,0 +1,4 @@
+
+const useImages = () => {
+  const assetManager = useAssetManager();
+

--- a/packages/template-skia/src/useTypefaces.ts
+++ b/packages/template-skia/src/useTypefaces.ts
@@ -1,0 +1,4 @@
+
+const useTypefaces = () => {
+  const assetManager = useAssetManager();
+

--- a/packages/template-stargazer/src/Main-schema.ts
+++ b/packages/template-stargazer/src/Main-schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+const mainSchema = z.object({
+  repoOrg: z.string(),
+  repoName: z.string(),
+  starCount: z.number().step(1),
+  duration: z.number().step(1),
+});
+

--- a/packages/template-stargazer/src/Main.tsx
+++ b/packages/template-stargazer/src/Main.tsx
@@ -3,13 +3,8 @@ import { z } from "zod";
 import { Stargazer } from "./cache";
 import { Content } from "./Content";
 import { getProgress } from "./utils";
+import {mainSchema} from './Main-schema';
 
-export const mainSchema = z.object({
-  repoOrg: z.string(),
-  repoName: z.string(),
-  starCount: z.number().step(1),
-  duration: z.number().step(1),
-});
 
 type SchemaProps = z.infer<typeof mainSchema>;
 

--- a/packages/template-still/src/PreviewCard-schema.ts
+++ b/packages/template-still/src/PreviewCard-schema.ts
@@ -1,0 +1,9 @@
+import { zColor } from "@remotion/zod-types";
+import { z } from "zod";
+
+const myCompSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  color: zColor(),
+});
+

--- a/packages/template-still/src/PreviewCard.tsx
+++ b/packages/template-still/src/PreviewCard.tsx
@@ -4,6 +4,7 @@ import { AbsoluteFill } from "remotion";
 import { z } from "zod";
 import "./fonts.css";
 import { Swirl } from "./Swirl";
+import {myCompSchema} from './PreviewCard-schema';
 
 const fontFamily = "Inter";
 
@@ -58,11 +59,6 @@ const sloganStyle: React.CSSProperties = {
   whiteSpace: "pre",
 };
 
-export const myCompSchema = z.object({
-  title: z.string(),
-  description: z.string(),
-  color: zColor(),
-});
 
 export const PreviewCard: React.FC<z.infer<typeof myCompSchema>> = ({
   title,

--- a/packages/template-three/src/Scene-schema.ts
+++ b/packages/template-three/src/Scene-schema.ts
@@ -1,0 +1,8 @@
+import { zColor } from "@remotion/zod-types";
+import { z } from "zod";
+
+const myCompSchema = z.object({
+  phoneColor: zColor(),
+  deviceType: z.enum(["phone", "tablet"]),
+});
+

--- a/packages/template-three/src/Scene.tsx
+++ b/packages/template-three/src/Scene.tsx
@@ -6,15 +6,12 @@ import { z } from "zod";
 import { MediabunnyMetadata } from "./helpers/get-media-metadata";
 import { getPhoneLayout } from "./helpers/layout";
 import { Phone } from "./Phone";
+import {myCompSchema} from './Scene-schema';
 
 const container: React.CSSProperties = {
   backgroundColor: "white",
 };
 
-export const myCompSchema = z.object({
-  phoneColor: zColor(),
-  deviceType: z.enum(["phone", "tablet"]),
-});
 
 type MyCompSchemaType = z.infer<typeof myCompSchema>;
 

--- a/packages/template-tiktok/src/CaptionedVideo/index-calculate-metadata.ts
+++ b/packages/template-tiktok/src/CaptionedVideo/index-calculate-metadata.ts
@@ -1,0 +1,8 @@
+import { Caption, createTikTokStyleCaptions } from "@remotion/captions";
+import { z } from "zod";
+
+const calculateCaptionedVideoMetadata: CalculateMetadataFunction<
+  z.infer<typeof captionedVideoSchema>
+> = async ({ props }) => {
+  const fps = 30;
+

--- a/packages/template-tiktok/src/CaptionedVideo/index-schema.ts
+++ b/packages/template-tiktok/src/CaptionedVideo/index-schema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+const captionedVideoSchema = z.object({
+  src: z.string(),
+});
+

--- a/packages/template-tiktok/src/CaptionedVideo/index.tsx
+++ b/packages/template-tiktok/src/CaptionedVideo/index.tsx
@@ -2,6 +2,8 @@ import { Caption, createTikTokStyleCaptions } from "@remotion/captions";
 import { getVideoMetadata } from "@remotion/media-utils";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+import {captionedVideoSchema} from './index-schema';
+import {calculateCaptionedVideoMetadata} from './index-calculate-metadata';
   AbsoluteFill,
   CalculateMetadataFunction,
   cancelRender,
@@ -22,14 +24,7 @@ export type SubtitleProp = {
   text: string;
 };
 
-export const captionedVideoSchema = z.object({
-  src: z.string(),
-});
 
-export const calculateCaptionedVideoMetadata: CalculateMetadataFunction<
-  z.infer<typeof captionedVideoSchema>
-> = async ({ props }) => {
-  const fps = 30;
   const metadata = await getVideoMetadata(props.src);
 
   return {


### PR DESCRIPTION
## Summary

- Adds `eslint-plugin-react-refresh` and enables `react-refresh/only-export-components` as **warn** in `@remotion/eslint-config-internal`, `@remotion/eslint-config`, and `@remotion/eslint-config-flat`.
- Surfaces Fast Refresh issues during lint (e.g. components that are not exported, mixing component and non-component exports).

## Test plan

- [ ] `bun run make` in `packages/eslint-config-internal`, `packages/eslint-config-flat`, and `packages/eslint-config`
- [ ] Run `eslint` in a package with React (e.g. `packages/core`) and confirm the rule reports on intentional violations in `.tsx` files
- [ ] Confirm templates using `@remotion/eslint-config-flat` lint without new errors (or only expected warnings)


Made with [Cursor](https://cursor.com)