### PR TITLE
Fix Studio timeline render crash from circular import

### DIFF
--- a/packages/studio/src/components/Timeline/Padder.tsx
+++ b/packages/studio/src/components/Timeline/Padder.tsx
@@ -1,12 +1,12 @@
 import React, {useMemo} from 'react';
-import {INDENT} from './TimelineListItem';
+import {TIMELINE_INDENT} from './timeline-indent';
 
 export const Padder: React.FC<{
 	readonly depth: number;
 }> = ({depth}) => {
 	const style = useMemo(
 		(): React.CSSProperties => ({
-			width: INDENT * depth,
+			width: TIMELINE_INDENT * depth,
 			flexShrink: 0,
 		}),
 		[depth],

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -62,6 +62,11 @@ export const TimelineExpandedRow: React.FC<{
 		[paddingLeft],
 	);
 
+	const effectGroupStyle = useMemo(
+		(): React.CSSProperties => ({...groupRowBase, paddingLeft: 5}),
+		[],
+	);
+
 	const labelOnlyStyle = useMemo(
 		(): React.CSSProperties => ({
 			...labelOnlyRowBase,
@@ -82,7 +87,8 @@ export const TimelineExpandedRow: React.FC<{
 					nodePath={nodePath}
 					validatedLocation={validatedLocation}
 					nestedDepth={nestedDepth}
-					style={groupStyle}
+					depth={depth}
+					style={effectGroupStyle}
 					getIsExpanded={getIsExpanded}
 					toggleTrack={toggleTrack}
 				/>

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -11,11 +11,11 @@ import {
 } from '../../helpers/timeline-layout';
 import type {GetIsExpanded} from '../ExpandedTracksProvider';
 import {Padder} from './Padder';
+import {TIMELINE_INDENT} from './timeline-indent';
 import {TimelineEffectFieldRow} from './TimelineEffectFieldRow';
 import {TimelineEffectGroupRow} from './TimelineEffectGroupRow';
 import {TimelineExpandArrowButton} from './TimelineExpandArrowButton';
 import {TimelineFieldRow} from './TimelineFieldRow';
-import {INDENT} from './TimelineListItem';
 
 const groupRowBase: React.CSSProperties = {
 	height: TREE_GROUP_ROW_HEIGHT,
@@ -55,16 +55,11 @@ export const TimelineExpandedRow: React.FC<{
 	nodePath,
 	schema,
 }) => {
-	const paddingLeft = EXPANDED_SECTION_PADDING_LEFT + depth * INDENT;
+	const paddingLeft = EXPANDED_SECTION_PADDING_LEFT + depth * TIMELINE_INDENT;
 
 	const groupStyle = useMemo(
 		(): React.CSSProperties => ({...groupRowBase, paddingLeft}),
 		[paddingLeft],
-	);
-
-	const effectGroupStyle = useMemo(
-		(): React.CSSProperties => ({...groupRowBase, paddingLeft: 5}),
-		[],
 	);
 
 	const labelOnlyStyle = useMemo(
@@ -87,8 +82,7 @@ export const TimelineExpandedRow: React.FC<{
 					nodePath={nodePath}
 					validatedLocation={validatedLocation}
 					nestedDepth={nestedDepth}
-					depth={depth}
-					style={effectGroupStyle}
+					style={groupStyle}
 					getIsExpanded={getIsExpanded}
 					toggleTrack={toggleTrack}
 				/>

--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -26,7 +26,7 @@ import {
 import {TimelineExpandedSection} from './TimelineExpandedSection';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineStack} from './TimelineStack';
-import {useResolvedStack} from './use-resolved-stack';
+import {useResolveStackAndReactToChange} from './use-resolved-stack-react-to-change';
 
 export const TimelineListItem: React.FC<{
 	readonly sequence: TSequence;
@@ -42,7 +42,7 @@ export const TimelineListItem: React.FC<{
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
 
-	const originalLocation = useResolvedStack(sequence.stack ?? null);
+	const originalLocation = useResolveStackAndReactToChange(sequence.getStack);
 
 	const validatedLocation = useMemo(() => {
 		if (

--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -26,9 +26,7 @@ import {
 import {TimelineExpandedSection} from './TimelineExpandedSection';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineStack} from './TimelineStack';
-import {useResolveStackAndReactToChange} from './use-resolved-stack-react-to-change';
-
-export const INDENT = 10;
+import {useResolvedStack} from './use-resolved-stack';
 
 export const TimelineListItem: React.FC<{
 	readonly sequence: TSequence;
@@ -44,7 +42,7 @@ export const TimelineListItem: React.FC<{
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
 
-	const originalLocation = useResolveStackAndReactToChange(sequence.getStack);
+	const originalLocation = useResolvedStack(sequence.stack ?? null);
 
 	const validatedLocation = useMemo(() => {
 		if (

--- a/packages/studio/src/components/Timeline/timeline-indent.ts
+++ b/packages/studio/src/components/Timeline/timeline-indent.ts
@@ -1,0 +1,1 @@
+export const TIMELINE_INDENT = 10;


### PR DESCRIPTION
## Summary

- Moves `TIMELINE_INDENT` into a dedicated `timeline-indent.ts` module.
- Updates `Padder` and `TimelineExpandedRow` to import from that module instead of `TimelineListItem`.
- Breaks a circular import (`Padder` ↔ `TimelineListItem`) that could leave `Padder` as `undefined` at runtime, causing React to throw:

  > Element type is invalid … Check the render method of `TimelineListItem`.

This is independent of the Studio `/events` SSE consolidation work in #7432.

## Test plan

- [ ] Open Remotion Studio with a composition that has timeline tracks
- [ ] Confirm the timeline renders without a React crash
- [ ] Expand/collapse timeline rows and verify indentation still looks correct


Made with [Cursor](https://cursor.com)