### PR TITLE
`@remotion/timeline-utils`: `drawRepeatingImageThumbnail()`

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineImageInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineImageInfo.tsx
@@ -44,7 +44,6 @@ export const TimelineImageInfo: React.FC<{
 			drawRepeatingImageThumbnail({
 				canvas,
 				image: img,
-				visualizationWidth,
 			});
 		};
 

--- a/packages/studio/src/components/Timeline/TimelineImageInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineImageInfo.tsx
@@ -1,3 +1,4 @@
+import {drawRepeatingImageThumbnail} from '@remotion/timeline-utils';
 import React, {useEffect, useRef} from 'react';
 import {getTimelineLayerHeight} from '../../helpers/timeline-layout';
 
@@ -40,32 +41,11 @@ export const TimelineImageInfo: React.FC<{
 		img.crossOrigin = 'anonymous';
 
 		img.onload = () => {
-			const scale = (HEIGHT * window.devicePixelRatio) / img.naturalHeight;
-			const scaledWidth = img.naturalWidth * scale;
-			const scaledHeight = HEIGHT * window.devicePixelRatio;
-
-			const offscreen = document.createElement('canvas');
-			offscreen.width = scaledWidth;
-			offscreen.height = scaledHeight;
-			const offCtx = offscreen.getContext('2d');
-			if (!offCtx) {
-				return;
-			}
-
-			offCtx.drawImage(img, 0, 0, scaledWidth, scaledHeight);
-
-			const pattern = ctx.createPattern(offscreen, 'repeat-x');
-			if (!pattern) {
-				return;
-			}
-
-			ctx.fillStyle = pattern;
-			ctx.fillRect(
-				0,
-				0,
-				visualizationWidth * window.devicePixelRatio,
-				HEIGHT * window.devicePixelRatio,
-			);
+			drawRepeatingImageThumbnail({
+				canvas,
+				image: img,
+				visualizationWidth,
+			});
 		};
 
 		img.src = src;

--- a/packages/timeline-utils/src/image-thumbnail/draw-repeating-image-thumbnail.ts
+++ b/packages/timeline-utils/src/image-thumbnail/draw-repeating-image-thumbnail.ts
@@ -1,0 +1,71 @@
+import {getScaledImageThumbnailDimensions} from './get-scaled-image-thumbnail-dimensions';
+
+type ImageWithNaturalDimensions = CanvasImageSource & {
+	readonly naturalWidth: number;
+	readonly naturalHeight: number;
+};
+
+const createOffscreenCanvas = (width: number, height: number) => {
+	if (typeof document !== 'undefined') {
+		const canvas = document.createElement('canvas');
+		canvas.width = width;
+		canvas.height = height;
+		return canvas;
+	}
+
+	if (typeof OffscreenCanvas !== 'undefined') {
+		return new OffscreenCanvas(width, height);
+	}
+
+	throw new Error('No canvas implementation available');
+};
+
+export const drawRepeatingImageThumbnail = ({
+	canvas,
+	image,
+	visualizationWidth,
+}: {
+	readonly canvas: HTMLCanvasElement | OffscreenCanvas;
+	readonly image: ImageWithNaturalDimensions;
+	readonly visualizationWidth: number;
+}) => {
+	const ctx = canvas.getContext('2d');
+
+	if (!ctx) {
+		throw new Error('Failed to get canvas context');
+	}
+
+	const {width, height} = canvas;
+
+	if (width === 0 || height === 0 || visualizationWidth === 0) {
+		return;
+	}
+
+	const {scaledWidth, scaledHeight} = getScaledImageThumbnailDimensions({
+		naturalWidth: image.naturalWidth,
+		naturalHeight: image.naturalHeight,
+		canvasHeight: height,
+	});
+
+	if (scaledWidth === 0 || scaledHeight === 0) {
+		return;
+	}
+
+	const offscreen = createOffscreenCanvas(scaledWidth, scaledHeight);
+	const offCtx = offscreen.getContext('2d');
+
+	if (!offCtx) {
+		throw new Error('Failed to get offscreen canvas context');
+	}
+
+	offCtx.drawImage(image, 0, 0, scaledWidth, scaledHeight);
+
+	const pattern = ctx.createPattern(offscreen, 'repeat-x');
+
+	if (!pattern) {
+		return;
+	}
+
+	ctx.fillStyle = pattern;
+	ctx.fillRect(0, 0, width, height);
+};

--- a/packages/timeline-utils/src/image-thumbnail/draw-repeating-image-thumbnail.ts
+++ b/packages/timeline-utils/src/image-thumbnail/draw-repeating-image-thumbnail.ts
@@ -23,11 +23,9 @@ const createOffscreenCanvas = (width: number, height: number) => {
 export const drawRepeatingImageThumbnail = ({
 	canvas,
 	image,
-	visualizationWidth,
 }: {
 	readonly canvas: HTMLCanvasElement | OffscreenCanvas;
 	readonly image: ImageWithNaturalDimensions;
-	readonly visualizationWidth: number;
 }) => {
 	const ctx = canvas.getContext('2d');
 
@@ -37,7 +35,7 @@ export const drawRepeatingImageThumbnail = ({
 
 	const {width, height} = canvas;
 
-	if (width === 0 || height === 0 || visualizationWidth === 0) {
+	if (width === 0 || height === 0) {
 		return;
 	}
 

--- a/packages/timeline-utils/src/image-thumbnail/get-scaled-image-thumbnail-dimensions.ts
+++ b/packages/timeline-utils/src/image-thumbnail/get-scaled-image-thumbnail-dimensions.ts
@@ -1,0 +1,23 @@
+export const getScaledImageThumbnailDimensions = ({
+	naturalWidth,
+	naturalHeight,
+	canvasHeight,
+}: {
+	readonly naturalWidth: number;
+	readonly naturalHeight: number;
+	readonly canvasHeight: number;
+}) => {
+	if (naturalWidth === 0 || naturalHeight === 0 || canvasHeight === 0) {
+		return {
+			scaledWidth: 0,
+			scaledHeight: 0,
+		};
+	}
+
+	const scale = canvasHeight / naturalHeight;
+
+	return {
+		scaledWidth: naturalWidth * scale,
+		scaledHeight: canvasHeight,
+	};
+};

--- a/packages/timeline-utils/src/index.ts
+++ b/packages/timeline-utils/src/index.ts
@@ -12,6 +12,8 @@ export {
 	createWaveformPeakProcessor,
 	emitWaveformProgress,
 } from './audio-waveform/waveform-peak-processor';
+export {drawRepeatingImageThumbnail} from './image-thumbnail/draw-repeating-image-thumbnail';
+export {getScaledImageThumbnailDimensions} from './image-thumbnail/get-scaled-image-thumbnail-dimensions';
 export {extractFrames} from './extract-frames';
 export type {
 	ExtractFramesProps,

--- a/packages/timeline-utils/src/test/draw-repeating-image-thumbnail.test.ts
+++ b/packages/timeline-utils/src/test/draw-repeating-image-thumbnail.test.ts
@@ -1,0 +1,28 @@
+import {expect, test} from 'bun:test';
+import {getScaledImageThumbnailDimensions} from '../image-thumbnail/get-scaled-image-thumbnail-dimensions';
+
+test('Should scale image thumbnails to the canvas height', () => {
+	expect(
+		getScaledImageThumbnailDimensions({
+			naturalWidth: 1920,
+			naturalHeight: 1080,
+			canvasHeight: 50,
+		}),
+	).toEqual({
+		scaledWidth: 88.88888888888889,
+		scaledHeight: 50,
+	});
+});
+
+test('Should return zero dimensions for empty images', () => {
+	expect(
+		getScaledImageThumbnailDimensions({
+			naturalWidth: 0,
+			naturalHeight: 0,
+			canvasHeight: 50,
+		}),
+	).toEqual({
+		scaledWidth: 0,
+		scaledHeight: 0,
+	});
+});


### PR DESCRIPTION
## Summary

- Extract the repeating canvas pattern logic from Studio's `TimelineImageInfo` into `@remotion/timeline-utils` as `drawRepeatingImageThumbnail` and `getScaledImageThumbnailDimensions`
- Keep Studio as a thin consumer that handles image loading and canvas setup, matching how waveform and film strip utilities are shared

Fixes #7441.

## Test plan

- [x] `bun run format` in `packages/timeline-utils` and `packages/studio`
- [x] `bunx turbo run make --filter='@remotion/timeline-utils'`
- [x] `bun test src/test/draw-repeating-image-thumbnail.test.ts` in `packages/timeline-utils`

Made with [Cursor](https://cursor.com)