### PR TITLE
`@remotion/studio`: Hide timeline visibility controls when preview server is disconnected

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import type {GetIsExpanded} from '../ExpandedTracksProvider';
 import {Padder} from './Padder';
@@ -43,6 +44,8 @@ export const TimelineEffectGroupRow: React.FC<{
 	getIsExpanded,
 	toggleTrack,
 }) => {
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const previewConnected = previewServerState.type === 'connected';
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
 
@@ -69,7 +72,8 @@ export const TimelineEffectGroupRow: React.FC<{
 		return false;
 	}, [disabledStatus]);
 
-	const canToggle = disabledStatus !== null && disabledStatus.canUpdate;
+	const canToggle =
+		previewConnected && disabledStatus !== null && disabledStatus.canUpdate;
 
 	const onToggle = useCallback(
 		(type: 'enable' | 'disable') => {

--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -283,6 +283,7 @@ export const TimelineListItem: React.FC<{
 		Boolean(sequence.controls) || sequence.effects.length > 0;
 
 	const canToggleVisibility =
+		previewConnected &&
 		Boolean(sequence.controls) &&
 		nodePath !== null &&
 		validatedLocation !== null &&


### PR DESCRIPTION
## Summary

- Hides the sequence visibility (eye/speaker) control in `TimelineListItem` when the preview server is not connected.
- Applies the same fix to effect group visibility toggles in `TimelineEffectGroupRow`.

Fixes #7437

## Test plan

- [ ] Start Remotion Studio with a composition that has controllable sequences
- [ ] Confirm visibility icons appear when the preview server is connected
- [ ] Disconnect the preview server (or stop the dev server) and confirm visibility icons are replaced with spacers
- [ ] Reconnect and confirm visibility controls work again
- [ ] Expand a sequence with effects and verify effect visibility toggles follow the same connected/disconnected behavior


Made with [Cursor](https://cursor.com)