### PR TITLE
`@remotion/promo-pages`: Fix hero headline breaking on mobile

### DIFF
--- a/packages/promo-pages/src/components/homepage/WriteInReact.tsx
+++ b/packages/promo-pages/src/components/homepage/WriteInReact.tsx
@@ -6,12 +6,13 @@ export const WriteInReact: React.FC = () => {
 	return (
 		<div>
 			<h1
-				className="text-3xl sm:text-4xl md:text-5xl lg:text-[5em] text-center fontbrand font-black leading-none text-balance"
+				className="text-5xl lg:text-[5em] text-center fontbrand font-black leading-none"
 				style={{
 					textShadow: '0 5px 30px var(--background)',
 				}}
 			>
-				Make videos programmatically.
+				Make videos <br className="lg:hidden" />
+				programmatically.
 			</h1>
 			<p
 				style={{

--- a/packages/promo-pages/src/components/homepage/WriteInReact.tsx
+++ b/packages/promo-pages/src/components/homepage/WriteInReact.tsx
@@ -6,13 +6,12 @@ export const WriteInReact: React.FC = () => {
 	return (
 		<div>
 			<h1
-				className="text-5xl lg:text-[5em] text-center fontbrand font-black leading-none"
+				className="text-4xl sm:text-5xl lg:text-[5em] text-center fontbrand font-black leading-none text-balance"
 				style={{
 					textShadow: '0 5px 30px var(--background)',
 				}}
 			>
-				Make videos <br className="lg:hidden" />
-				programmatically.
+				Make videos programmatically.
 			</h1>
 			<p
 				style={{

--- a/packages/promo-pages/src/components/homepage/WriteInReact.tsx
+++ b/packages/promo-pages/src/components/homepage/WriteInReact.tsx
@@ -6,7 +6,7 @@ export const WriteInReact: React.FC = () => {
 	return (
 		<div>
 			<h1
-				className="text-5xl lg:text-[5em] text-center fontbrand font-black leading-none "
+				className="text-3xl sm:text-4xl md:text-5xl lg:text-[5em] text-center fontbrand font-black leading-none text-balance"
 				style={{
 					textShadow: '0 5px 30px var(--background)',
 				}}


### PR DESCRIPTION
## Summary

- Scale the homepage hero headline down on smaller viewports (`text-3xl` → `sm:text-4xl` → `md:text-5xl` → `lg:text-[5em]`) so "programmatically" no longer breaks awkwardly on mobile.
- Add `text-balance` for more even line distribution.

Fixes #7436

## Test plan

- [ ] Run `cd packages/promo-pages && bun run dev` and open the homepage
- [ ] Resize to mobile width (~375px) and confirm "Make videos programmatically." wraps cleanly without mid-word breaks
- [ ] Confirm desktop (`lg`+) headline size is unchanged


Made with [Cursor](https://cursor.com)