### PR TITLE
Allow screen capture on webcam view in template-recorder

### DIFF
--- a/packages/template-recorder/src/RecordButton.tsx
+++ b/packages/template-recorder/src/RecordButton.tsx
@@ -163,7 +163,7 @@ export const RecordButton: React.FC<{
 
   const disabled =
     mediaSources.webcam.streamState.type !== "loaded" ||
-    mediaSources.webcam.streamState.stream.getAudioTracks().length === 0 ||
+    mediaSources.webcam.streamState.stream.getVideoTracks().length === 0 ||
     processingStatus !== null;
 
   const onPressR = useCallback(() => {
@@ -214,7 +214,7 @@ export const RecordButton: React.FC<{
     <div
       title={
         disabled
-          ? "A webcam and an audio source have to be selected to start the recording"
+          ? "A video source has to be selected on the webcam view to start the recording"
           : undefined
       }
     >
@@ -234,7 +234,7 @@ export const RecordButton: React.FC<{
         <div className="w-2"></div>
         <div>
           {disabled
-            ? "Select audio+video to record"
+            ? "Select video to record"
             : recordingStatus.type === "recording-finished"
               ? "Discard and retake"
               : "Start recording"}

--- a/packages/template-recorder/src/RecordingView.tsx
+++ b/packages/template-recorder/src/RecordingView.tsx
@@ -125,8 +125,11 @@ const InnerRecordingView: React.FC<{
 
   const selectScreenWithoutAudio = useCallback(async () => {
     setVideoDevice(prefix, "display-without-audio");
+    if (recordAudio && !mediaStream.audioDevice) {
+      return;
+    }
     setShowPicker(false);
-  }, [prefix, setVideoDevice]);
+  }, [mediaStream.audioDevice, prefix, recordAudio, setVideoDevice]);
   const selectScreenWithAudio = useCallback(async () => {
     setVideoDevice(prefix, "display-with-audio");
     setShowPicker(false);
@@ -341,13 +344,13 @@ const InnerRecordingView: React.FC<{
             onPickVideo={onPickVideo}
             onPickAudio={onPickAudio}
             canSelectAudio={recordAudio}
-            canSelectScreen={prefix !== WEBCAM_PREFIX}
+            canSelectScreen
             onPickScreenWithoutAudio={selectScreenWithoutAudio}
             onPickScreenWithAudio={selectScreenWithAudio}
             selectedAudioDevice={mediaStream.audioDevice}
             selectedVideoDevice={mediaStream.videoDevice}
             clear={clear}
-            canClear={prefix !== WEBCAM_PREFIX}
+            canClear
           />
         ) : null}
         {canShowResolutionLimiter ? (

--- a/packages/template-recorder/src/RecordingView.tsx
+++ b/packages/template-recorder/src/RecordingView.tsx
@@ -344,13 +344,11 @@ const InnerRecordingView: React.FC<{
             onPickVideo={onPickVideo}
             onPickAudio={onPickAudio}
             canSelectAudio={recordAudio}
-            canSelectScreen
             onPickScreenWithoutAudio={selectScreenWithoutAudio}
             onPickScreenWithAudio={selectScreenWithAudio}
             selectedAudioDevice={mediaStream.audioDevice}
             selectedVideoDevice={mediaStream.videoDevice}
             clear={clear}
-            canClear
           />
         ) : null}
         {canShowResolutionLimiter ? (

--- a/packages/template-recorder/src/components/StreamPicker.tsx
+++ b/packages/template-recorder/src/components/StreamPicker.tsx
@@ -38,7 +38,6 @@ export const getDeviceLabel = (device: MediaDeviceInfo): string => {
 
 export const StreamPicker: React.FC<{
   canSelectAudio: boolean;
-  canSelectScreen: boolean;
   onPickVideo: (device: MediaDeviceInfo) => void;
   onPickAudio: (device: MediaDeviceInfo) => void;
   onPickScreenWithoutAudio: () => void;
@@ -46,10 +45,8 @@ export const StreamPicker: React.FC<{
   selectedVideoDevice: string | null;
   selectedAudioDevice: string | null;
   clear: () => void;
-  canClear: boolean;
 }> = ({
   canSelectAudio,
-  canSelectScreen,
   onPickAudio,
   onPickVideo,
   onPickScreenWithoutAudio,
@@ -57,7 +54,6 @@ export const StreamPicker: React.FC<{
   selectedAudioDevice,
   selectedVideoDevice,
   clear,
-  canClear,
 }) => {
   const devices = useDevices();
   const videoInputs = useMemo(() => {
@@ -80,26 +76,18 @@ export const StreamPicker: React.FC<{
           }}
         >
           <div style={title}>Select video</div>
-          {canSelectScreen ? (
-            <DeviceItem
-              handleClick={() => {
-                onPickScreenWithoutAudio();
-              }}
-              deviceLabel={"Screen capture"}
-              type="screen"
-              selected={selectedVideoDevice === "display-without-audio"}
-            />
-          ) : null}
-          {canSelectScreen ? (
-            <DeviceItem
-              handleClick={() => {
-                onPickScreenWithAudio();
-              }}
-              deviceLabel={"Screen capture with audio"}
-              type="screen"
-              selected={selectedVideoDevice === "display-with-audio"}
-            />
-          ) : null}
+          <DeviceItem
+            handleClick={onPickScreenWithoutAudio}
+            deviceLabel={"Screen capture"}
+            type="screen"
+            selected={selectedVideoDevice === "display-without-audio"}
+          />
+          <DeviceItem
+            handleClick={onPickScreenWithAudio}
+            deviceLabel={"Screen capture with audio"}
+            type="screen"
+            selected={selectedVideoDevice === "display-with-audio"}
+          />
           {videoInputs.map((d) => {
             return (
               <DeviceItem
@@ -113,7 +101,7 @@ export const StreamPicker: React.FC<{
               />
             );
           })}
-          {selectedVideoDevice && canClear ? (
+          {selectedVideoDevice ? (
             <a style={clearStyle} onClick={clear}>
               Clear
             </a>

--- a/packages/template-recorder/src/helpers/get-video-stream.ts
+++ b/packages/template-recorder/src/helpers/get-video-stream.ts
@@ -91,7 +91,18 @@ export const getVideoStream = async ({
     return getDisplayStream(selectedVideoSource);
   }
   if (selectedVideoSource.type === "display-without-audio") {
-    return getDisplayStream(selectedVideoSource);
+    const displayStream = await getDisplayStream(selectedVideoSource);
+    if (recordAudio && selectedAudioSource) {
+      const audioStream = await window.navigator.mediaDevices.getUserMedia({
+        audio: { deviceId: selectedAudioSource },
+      });
+      return new MediaStream([
+        ...displayStream.getVideoTracks(),
+        ...audioStream.getAudioTracks(),
+      ]);
+    }
+
+    return displayStream;
   }
   if (selectedVideoSource.type === "camera") {
     return getCameraStram({


### PR DESCRIPTION
## Summary

- Removes the restriction that prevented the webcam (left) panel from selecting screen capture in `template-recorder`.
- Allows recording to start when the webcam view has a video source (including screen-only), not only when audio tracks are present.
- Merges a separately selected microphone into screen capture without audio, matching camera behavior.

Fixes #7439

## Test plan

- [ ] Open `packages/template-recorder` and start the recorder UI
- [ ] On the webcam (left) view, confirm **Screen capture** and **Screen capture with audio** appear in the device picker
- [ ] Select screen capture without audio, pick a microphone, and verify recording starts
- [ ] Select screen capture with audio only and verify recording starts without a camera
- [ ] Select screen capture without audio and no microphone, and verify screen-only recording works
- [ ] Confirm the display (right) view still supports screen capture as before


Made with [Cursor](https://cursor.com)