### PR TITLE
`remotion`: No `premountFor` controls for elements that do not support it

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -18,7 +18,10 @@ import {
 	useMemoizedEffects,
 } from './effects/use-memoized-effects.js';
 import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
-import {hiddenField, sequenceStyleSchema} from './sequence-field-schema.js';
+import {
+	hiddenField,
+	sequenceVisualStyleSchema,
+} from './sequence-field-schema.js';
 import type {
 	AbsoluteFillLayout,
 	LayoutAndStyle,
@@ -571,7 +574,7 @@ const HtmlInCanvasInner = forwardRef<
 HtmlInCanvasInner.displayName = 'HtmlInCanvas';
 
 const htmlInCanvasSchema = {
-	...sequenceStyleSchema,
+	...sequenceVisualStyleSchema,
 	hidden: hiddenField,
 };
 

--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -11,7 +11,10 @@ import type {SequenceControls} from './CompositionManager.js';
 import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
 import {getCrossOriginValue} from './get-cross-origin-value.js';
 import {usePreload} from './prefetch.js';
-import {hiddenField, sequenceStyleSchema} from './sequence-field-schema.js';
+import {
+	hiddenField,
+	sequenceVisualStyleSchema,
+} from './sequence-field-schema.js';
 import {SequenceContext} from './SequenceContext.js';
 import {useBufferState} from './use-buffer-state.js';
 import {useDelayRender} from './use-delay-render.js';
@@ -337,7 +340,7 @@ const ImgInner: React.FC<
 };
 
 const imgSchema = {
-	...sequenceStyleSchema,
+	...sequenceVisualStyleSchema,
 	hidden: hiddenField,
 };
 

--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -17,7 +17,7 @@ import {
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {
 	hiddenField,
-	sequenceStyleSchema,
+	sequenceVisualStyleSchema,
 	type SequenceSchema,
 } from '../sequence-field-schema.js';
 import {Sequence} from '../Sequence.js';
@@ -41,7 +41,7 @@ const animatedImageSchema = {
 		default: 1,
 		description: 'Playback Rate',
 	},
-	...sequenceStyleSchema,
+	...sequenceVisualStyleSchema,
 	hidden: hiddenField,
 } as const satisfies SequenceSchema;
 

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -8,7 +8,7 @@ import React, {
 import type {SequenceControls} from '../CompositionManager.js';
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {
-	sequenceStyleSchema,
+	sequenceVisualStyleSchema,
 	type SequenceSchema,
 } from '../sequence-field-schema.js';
 import type {SequenceProps} from '../Sequence.js';
@@ -61,7 +61,7 @@ const solidSchema = {
 		default: 1080,
 		description: 'Height',
 	},
-	...sequenceStyleSchema,
+	...sequenceVisualStyleSchema,
 } as const satisfies SequenceSchema;
 
 const SolidInner: React.FC<

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -113,7 +113,12 @@ import {
 	type SequenceSchema,
 	type VisibleFieldSchema,
 } from './sequence-field-schema.js';
-import {sequenceSchema, sequenceStyleSchema} from './sequence-field-schema.js';
+import {
+	sequencePremountSchema,
+	sequenceSchema,
+	sequenceStyleSchema,
+	sequenceVisualStyleSchema,
+} from './sequence-field-schema.js';
 import type {
 	OverrideIdToNodePaths,
 	OverrideToNodePathGetters,
@@ -256,6 +261,8 @@ export const Internals = {
 	wrapInSchema,
 	sequenceSchema,
 	sequenceStyleSchema,
+	sequenceVisualStyleSchema,
+	sequencePremountSchema,
 	flattenActiveSchema,
 	getFlatSchemaWithAllKeys,
 	RemotionRootContexts,

--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -61,7 +61,7 @@ export type SchemaKeysRecord<S extends SequenceSchema> = Record<
 	unknown
 >;
 
-export const sequenceStyleSchema = {
+export const sequenceVisualStyleSchema = {
 	'style.translate': {
 		type: 'translate',
 		step: 1,
@@ -90,6 +90,9 @@ export const sequenceStyleSchema = {
 		default: 1,
 		description: 'Opacity',
 	},
+} as const satisfies SequenceSchema;
+
+export const sequencePremountSchema = {
 	premountFor: {
 		type: 'number',
 		default: 0,
@@ -106,6 +109,11 @@ export const sequenceStyleSchema = {
 	styleWhilePostmounted: {
 		type: 'hidden',
 	},
+} as const satisfies SequenceSchema;
+
+export const sequenceStyleSchema = {
+	...sequenceVisualStyleSchema,
+	...sequencePremountSchema,
 } as const satisfies SequenceSchema;
 
 export const hiddenField: SequenceFieldSchema = {

--- a/packages/core/src/test/wrap-in-schema-helpers.test.ts
+++ b/packages/core/src/test/wrap-in-schema-helpers.test.ts
@@ -1,12 +1,26 @@
 import {expect, test} from 'bun:test';
 import {getFlatSchemaWithAllKeys} from '../flatten-schema.js';
-import {sequenceSchema} from '../sequence-field-schema.js';
+import {
+	sequencePremountSchema,
+	sequenceSchema,
+	sequenceStyleSchema,
+	sequenceVisualStyleSchema,
+} from '../sequence-field-schema.js';
 import {
 	getNestedValue,
 	mergeValues,
 	readValuesFromProps,
 	selectActiveKeys,
 } from '../wrap-in-schema.js';
+
+test('sequenceStyleSchema is the union of visual style and premount fields', () => {
+	expect(Object.keys(sequenceStyleSchema).sort()).toEqual(
+		[
+			...Object.keys(sequenceVisualStyleSchema),
+			...Object.keys(sequencePremountSchema),
+		].sort(),
+	);
+});
 
 test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 	const flat = getFlatSchemaWithAllKeys(sequenceSchema);

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -33,7 +33,7 @@ const gifSchema = {
 		default: 1,
 		description: 'Playback Rate',
 	},
-	...Internals.sequenceStyleSchema,
+	...Internals.sequenceVisualStyleSchema,
 	hidden: Internals.hiddenField,
 } as const satisfies SequenceSchema;
 

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -36,7 +36,7 @@ const videoSchema = {
 		description: 'Hidden',
 	},
 	loop: {type: 'boolean', default: false, description: 'Loop'},
-	...Internals.sequenceStyleSchema,
+	...Internals.sequenceVisualStyleSchema,
 } as const satisfies SequenceSchema;
 
 const InnerVideo: React.FC<


### PR DESCRIPTION
## Summary

- Split `sequenceStyleSchema` into `sequenceVisualStyleSchema` (translate, scale, rotate, opacity) and `sequencePremountSchema` (premountFor, postmountFor, styleWhilePremounted, styleWhilePostmounted), then re-compose as `sequenceStyleSchema` for components that support premounting.
- Use only `sequenceVisualStyleSchema` for components that mount `<Sequence layout="none">` (`<Solid>`, `<HtmlInCanvas>`, `<AnimatedImage>`, `<Gif>`, `<Video>`) and for `<Img>` (which does not render a Sequence and inherits premount from its parent).
- Fixes #7454

## Test plan

- [x] `bun test packages/core/src/test/wrap-in-schema-helpers.test.ts` passes
- [ ] Verify in Studio that `<Solid>` no longer shows "Premount For" in the properties panel
- [ ] Verify `<Sequence layout="absolute-fill">`, `<LightLeak>`, and `<Starburst>` still expose premount fields


Made with [Cursor](https://cursor.com)