### PR TITLE
`@remotion/studio`: Better queueing of code edits

### DIFF
--- a/packages/studio-server/src/file-watcher.ts
+++ b/packages/studio-server/src/file-watcher.ts
@@ -1,9 +1,9 @@
 import fs, {readFileSync, writeFileSync} from 'node:fs';
 
 export type FileChangeEvent =
-	| {type: 'created'; content: string}
+	| {type: 'created'; content: string; originatorClientId: string | undefined}
 	| {type: 'deleted'}
-	| {type: 'changed'; content: string};
+	| {type: 'changed'; content: string; originatorClientId: string | undefined};
 
 type OnChange = (event: FileChangeEvent) => void;
 
@@ -32,7 +32,11 @@ export type FileWatcherRegistry = {
 		exists: boolean;
 		unwatch: () => void;
 	};
-	writeFileAndNotifyFileWatchers: (file: string, content: string) => void;
+	writeFileAndNotifyFileWatchers: (
+		file: string,
+		content: string,
+		originatorClientId: string | undefined,
+	) => void;
 };
 
 export const createFileWatcherRegistry = (): FileWatcherRegistry => {
@@ -84,7 +88,11 @@ export const createFileWatcherRegistry = (): FileWatcherRegistry => {
 			if (existenceOnly) {
 				if (!shared.existedBefore && existsNow) {
 					shared.existedBefore = true;
-					event = {type: 'created', content: ''};
+					event = {
+						type: 'created',
+						content: '',
+						originatorClientId: undefined,
+					};
 				} else if (shared.existedBefore && !existsNow) {
 					shared.existedBefore = false;
 					event = {type: 'deleted'};
@@ -93,7 +101,7 @@ export const createFileWatcherRegistry = (): FileWatcherRegistry => {
 				const content = readFileSync(file, 'utf-8');
 				shared.existedBefore = true;
 				shared.lastKnownContent = content;
-				event = {type: 'created', content};
+				event = {type: 'created', content, originatorClientId: undefined};
 			} else if (shared.existedBefore && !existsNow) {
 				shared.existedBefore = false;
 				shared.lastKnownContent = null;
@@ -113,7 +121,7 @@ export const createFileWatcherRegistry = (): FileWatcherRegistry => {
 				}
 
 				shared.lastKnownContent = content;
-				event = {type: 'changed', content};
+				event = {type: 'changed', content, originatorClientId: undefined};
 			}
 
 			if (!event) {
@@ -140,7 +148,11 @@ export const createFileWatcherRegistry = (): FileWatcherRegistry => {
 		};
 	};
 
-	const _writeFileAndNotifyFileWatchers = (file: string, content: string) => {
+	const _writeFileAndNotifyFileWatchers = (
+		file: string,
+		content: string,
+		originatorClientId: string | undefined,
+	) => {
 		writeFileSync(file, content);
 
 		const shared = sharedWatchers.get(getRegistryKey(file, false));
@@ -152,7 +164,7 @@ export const createFileWatcherRegistry = (): FileWatcherRegistry => {
 		shared.existedBefore = true;
 
 		for (const subscriber of shared.subscribers) {
-			subscriber({type: 'changed', content});
+			subscriber({type: 'changed', content, originatorClientId});
 		}
 	};
 
@@ -195,10 +207,14 @@ export const installFileWatcher: FileWatcherRegistry['installFileWatcher'] = (
 };
 
 export const writeFileAndNotifyFileWatchers: FileWatcherRegistry['writeFileAndNotifyFileWatchers'] =
-	(file, content) => {
+	(file, content, originatorClientId) => {
 		if (!currentRegistry) {
 			return;
 		}
 
-		getFileWatcherRegistry().writeFileAndNotifyFileWatchers(file, content);
+		getFileWatcherRegistry().writeFileAndNotifyFileWatchers(
+			file,
+			content,
+			originatorClientId,
+		);
 	};

--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -41,7 +41,11 @@ export const applyCodemodHandler: ApiHandler<
 		});
 
 		if (!dryRun) {
-			writeFileAndNotifyFileWatchers(projectInfo.rootFile, formatted);
+			writeFileAndNotifyFileWatchers(
+				projectInfo.rootFile,
+				formatted,
+				undefined,
+			);
 			const end = Date.now() - time;
 			RenderInternals.Log.info(
 				{indent: false, logLevel},

--- a/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
@@ -117,7 +117,7 @@ export const applyVisualControlHandler: ApiHandler<
 	});
 	suppressUndoStackInvalidation(absolutePath);
 	suppressBundlerUpdateForFile(absolutePath);
-	writeFileAndNotifyFileWatchers(absolutePath, output);
+	writeFileAndNotifyFileWatchers(absolutePath, output, undefined);
 
 	waitForLiveEventsListener().then((listener) => {
 		listener.sendEventToClient({

--- a/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
@@ -52,7 +52,7 @@ export const deleteJsxNodeHandler: ApiHandler<
 			suppressHmrOnFileRestore: false,
 		});
 		suppressUndoStackInvalidation(absolutePath);
-		writeFileAndNotifyFileWatchers(absolutePath, output);
+		writeFileAndNotifyFileWatchers(absolutePath, output, undefined);
 
 		const locationLabel = formatLogFileLocation({
 			remotionRoot,

--- a/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
@@ -52,7 +52,7 @@ export const duplicateJsxNodeHandler: ApiHandler<
 			suppressHmrOnFileRestore: false,
 		});
 		suppressUndoStackInvalidation(absolutePath);
-		writeFileAndNotifyFileWatchers(absolutePath, output);
+		writeFileAndNotifyFileWatchers(absolutePath, output, undefined);
 
 		const locationLabel = formatLogFileLocation({
 			remotionRoot,

--- a/packages/studio-server/src/preview-server/routes/save-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-effect-props.ts
@@ -35,6 +35,7 @@ export const saveEffectPropsHandler: ApiHandler<
 		value,
 		defaultValue,
 		schema,
+		clientId,
 	},
 	remotionRoot,
 	logLevel,
@@ -109,7 +110,7 @@ export const saveEffectPropsHandler: ApiHandler<
 		});
 		suppressUndoStackInvalidation(absolutePath);
 		suppressBundlerUpdateForFile(absolutePath);
-		writeFileAndNotifyFileWatchers(absolutePath, output);
+		writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
 
 		logEffectUpdate({
 			fileRelativeToRoot,

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -25,7 +25,7 @@ export const saveSequencePropsHandler: ApiHandler<
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse
 > = ({
-	input: {fileName, nodePath, key, value, defaultValue, schema},
+	input: {fileName, nodePath, key, value, defaultValue, schema, clientId},
 	remotionRoot,
 	logLevel,
 }) =>
@@ -101,7 +101,7 @@ export const saveSequencePropsHandler: ApiHandler<
 		});
 		suppressUndoStackInvalidation(absolutePath);
 		suppressBundlerUpdateForFile(absolutePath);
-		writeFileAndNotifyFileWatchers(absolutePath, output);
+		writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
 
 		logUpdate({
 			fileRelativeToRoot,

--- a/packages/studio-server/src/preview-server/routes/update-default-props.ts
+++ b/packages/studio-server/src/preview-server/routes/update-default-props.ts
@@ -69,7 +69,7 @@ export const updateDefaultPropsHandler: ApiHandler<
 		});
 		suppressUndoStackInvalidation(projectInfo.rootFile);
 		suppressBundlerUpdateForFile(projectInfo.rootFile);
-		writeFileAndNotifyFileWatchers(projectInfo.rootFile, output);
+		writeFileAndNotifyFileWatchers(projectInfo.rootFile, output, undefined);
 
 		const locationLabel = formatLogFileLocation({
 			remotionRoot,

--- a/packages/studio-server/src/preview-server/sequence-props-watchers.ts
+++ b/packages/studio-server/src/preview-server/sequence-props-watchers.ts
@@ -133,6 +133,10 @@ export const subscribeToSequencePropsWatchers = ({
 				return;
 			}
 
+			if (event.originatorClientId === clientId) {
+				return;
+			}
+
 			try {
 				const result = computeSequencePropsStatusFromContent({
 					fileContents: event.content,

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -307,7 +307,7 @@ export function popUndo(): {success: true} | {success: false; reason: string} {
 		suppressBundlerUpdateForFile(entry.filePath);
 	}
 
-	writeFileAndNotifyFileWatchers(entry.filePath, entry.oldContents);
+	writeFileAndNotifyFileWatchers(entry.filePath, entry.oldContents, undefined);
 
 	RenderInternals.Log.verbose(
 		{indent: false, logLevel: storedLogLevel},
@@ -347,7 +347,7 @@ export function popRedo(): {success: true} | {success: false; reason: string} {
 		suppressBundlerUpdateForFile(entry.filePath);
 	}
 
-	writeFileAndNotifyFileWatchers(entry.filePath, entry.oldContents);
+	writeFileAndNotifyFileWatchers(entry.filePath, entry.oldContents, undefined);
 
 	RenderInternals.Log.verbose(
 		{indent: false, logLevel: storedLogLevel},

--- a/packages/studio-server/src/test/file-watcher.test.ts
+++ b/packages/studio-server/src/test/file-watcher.test.ts
@@ -46,12 +46,20 @@ test('multiple watchers on the same file share a single OS watcher', () => {
 	expect(w2.exists).toBe(true);
 
 	// writeFileAndNotifyFileWatchers should notify both
-	registry.writeFileAndNotifyFileWatchers(tmpFile, 'updated');
+	registry.writeFileAndNotifyFileWatchers(tmpFile, 'updated', undefined);
 
 	expect(cb1).toHaveBeenCalledTimes(1);
-	expect(cb1).toHaveBeenCalledWith({type: 'changed', content: 'updated'});
+	expect(cb1).toHaveBeenCalledWith({
+		type: 'changed',
+		content: 'updated',
+		originatorClientId: undefined,
+	});
 	expect(cb2).toHaveBeenCalledTimes(1);
-	expect(cb2).toHaveBeenCalledWith({type: 'changed', content: 'updated'});
+	expect(cb2).toHaveBeenCalledWith({
+		type: 'changed',
+		content: 'updated',
+		originatorClientId: undefined,
+	});
 
 	w1.unwatch();
 	w2.unwatch();
@@ -103,11 +111,15 @@ test('unwatching one subscriber does not affect the other', () => {
 
 	w1.unwatch();
 
-	registry.writeFileAndNotifyFileWatchers(tmpFile, 'after-unwatch');
+	registry.writeFileAndNotifyFileWatchers(tmpFile, 'after-unwatch', undefined);
 
 	expect(cb1).toHaveBeenCalledTimes(0);
 	expect(cb2).toHaveBeenCalledTimes(1);
-	expect(cb2).toHaveBeenCalledWith({type: 'changed', content: 'after-unwatch'});
+	expect(cb2).toHaveBeenCalledWith({
+		type: 'changed',
+		content: 'after-unwatch',
+		originatorClientId: undefined,
+	});
 
 	w2.unwatch();
 });
@@ -123,7 +135,7 @@ test('writeFileAndNotifyFileWatchers passes content to subscribers', () => {
 		},
 	});
 
-	registry.writeFileAndNotifyFileWatchers(tmpFile, 'hello world');
+	registry.writeFileAndNotifyFileWatchers(tmpFile, 'hello world', undefined);
 
 	const event = receivedEvent!;
 	expect(event.type).toBe('changed');
@@ -143,7 +155,7 @@ test('writeFileAndNotifyFileWatchers writes the file to disk', () => {
 		onChange: () => {},
 	});
 
-	registry.writeFileAndNotifyFileWatchers(tmpFile, 'disk content');
+	registry.writeFileAndNotifyFileWatchers(tmpFile, 'disk content', undefined);
 
 	expect(readFileSync(tmpFile, 'utf-8')).toBe('disk content');
 
@@ -152,7 +164,7 @@ test('writeFileAndNotifyFileWatchers writes the file to disk', () => {
 
 test('writeFileAndNotifyFileWatchers works even without watchers', () => {
 	// Should not throw
-	registry.writeFileAndNotifyFileWatchers(tmpFile, 'no watchers');
+	registry.writeFileAndNotifyFileWatchers(tmpFile, 'no watchers', undefined);
 
 	expect(readFileSync(tmpFile, 'utf-8')).toBe('no watchers');
 });
@@ -167,7 +179,7 @@ test('duplicate content from fs.watchFile is suppressed', async () => {
 	});
 
 	// Simulate a write via our API — sets lastKnownContent
-	registry.writeFileAndNotifyFileWatchers(tmpFile, 'new content');
+	registry.writeFileAndNotifyFileWatchers(tmpFile, 'new content', undefined);
 	expect(cb).toHaveBeenCalledTimes(1);
 
 	// Wait for fs.watchFile to poll (100ms interval + generous buffer)
@@ -196,7 +208,11 @@ test('registries are isolated from each other', () => {
 		onChange: cb2,
 	});
 
-	registry.writeFileAndNotifyFileWatchers(tmpFile, 'from registry 1');
+	registry.writeFileAndNotifyFileWatchers(
+		tmpFile,
+		'from registry 1',
+		undefined,
+	);
 
 	expect(cb1).toHaveBeenCalledTimes(1);
 	expect(cb2).toHaveBeenCalledTimes(0);
@@ -268,7 +284,11 @@ test('existenceOnly emits created with empty content when file appears', () => {
 	writeFileSync(newFile, 'hello');
 	capturedListener!();
 
-	expect(cb).toHaveBeenCalledWith({type: 'created', content: ''});
+	expect(cb).toHaveBeenCalledWith({
+		type: 'created',
+		content: '',
+		originatorClientId: undefined,
+	});
 
 	w.unwatch();
 	unlinkSync(newFile);

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -252,6 +252,7 @@ export type SaveSequencePropsRequest = {
 	value: string;
 	defaultValue: string | null;
 	schema: SequenceSchema;
+	clientId: string;
 };
 
 export type SaveSequencePropsResponse =
@@ -272,6 +273,7 @@ export type SaveEffectPropsRequest = {
 	value: string;
 	defaultValue: string | null;
 	schema: SequenceSchema;
+	clientId: string;
 };
 
 export type SaveEffectPropsResponse = CanUpdateEffectPropsResponse;

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -3,6 +3,7 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import type {SequencePropsSubscriptionKey} from 'remotion';
 import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {EffectSchemaFieldInfo} from '../../helpers/timeline-layout';
 import {EXPANDED_SECTION_PADDING_RIGHT} from '../../helpers/timeline-layout';
 import {callApi} from '../call-api';
@@ -47,6 +48,12 @@ const Value: React.FC<{
 		Internals.VisualModeCodeValuesContext,
 	);
 
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const clientId =
+		previewServerState.type === 'connected'
+			? previewServerState.clientId
+			: null;
+
 	const effectStatus = Internals.getEffectCodeValuesCtx({
 		codeValues: visualModeCodeValues,
 		nodePath,
@@ -88,6 +95,10 @@ const Value: React.FC<{
 				return Promise.reject(new Error('Cannot save'));
 			}
 
+			if (!clientId) {
+				return Promise.reject(new Error('Not connected to studio server'));
+			}
+
 			const defaultValue =
 				field.fieldSchema.default !== undefined
 					? JSON.stringify(field.fieldSchema.default)
@@ -126,11 +137,13 @@ const Value: React.FC<{
 						value: stringifiedValue,
 						defaultValue,
 						schema: field.effectSchema,
+						clientId,
 					}),
 				errorLabel: 'Could not save effect prop',
 			});
 		},
 		[
+			clientId,
 			field.effectIndex,
 			field.effectSchema,
 			field.fieldSchema.default,

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -127,25 +127,6 @@ const Value: React.FC<{
 						defaultValue,
 						schema: field.effectSchema,
 					}),
-				mergeServerResponse: (prev, data) => {
-					if (!prev.canUpdate) {
-						return prev;
-					}
-
-					const idx = prev.effects.findIndex(
-						(e) => e.effectIndex === field.effectIndex,
-					);
-					if (idx === -1) {
-						return {
-							...prev,
-							effects: [...prev.effects, data],
-						};
-					}
-
-					const nextEffects = [...prev.effects];
-					nextEffects[idx] = data;
-					return {...prev, effects: nextEffects};
-				},
 				errorLabel: 'Could not save effect prop',
 			});
 		},

--- a/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
@@ -79,7 +79,7 @@ export const TimelineEffectGroupRow: React.FC<{
 
 	const onToggle = useCallback(
 		(type: 'enable' | 'disable') => {
-			if (!canToggle) {
+			if (!canToggle || previewServerState.type !== 'connected') {
 				return;
 			}
 
@@ -99,6 +99,7 @@ export const TimelineEffectGroupRow: React.FC<{
 				defaultValue,
 				schema: effectSchema,
 				setCodeValues,
+				clientId: previewServerState.clientId,
 			});
 		},
 		[
@@ -106,6 +107,7 @@ export const TimelineEffectGroupRow: React.FC<{
 			effectIndex,
 			effectSchema,
 			nodePath,
+			previewServerState,
 			setCodeValues,
 			validatedLocation.source,
 		],

--- a/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
@@ -6,6 +6,7 @@ import type {
 import type {SequenceSchema} from 'remotion';
 import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -67,11 +68,20 @@ const Value: React.FC<{
 	});
 
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const clientId =
+		previewServerState.type === 'connected'
+			? previewServerState.clientId
+			: null;
 
 	const onSave = useCallback<TimelineFieldOnSave>(
 		(value) => {
 			if (!codeValue || !codeValue.canUpdate) {
 				return Promise.reject(new Error('Cannot save'));
+			}
+
+			if (!clientId) {
+				return Promise.reject(new Error('Not connected to studio server'));
 			}
 
 			const defaultValue =
@@ -100,10 +110,12 @@ const Value: React.FC<{
 				defaultValue,
 				schema,
 				setCodeValues,
+				clientId,
 			});
 		},
 		[
 			codeValue,
+			clientId,
 			field.fieldSchema.default,
 			field.key,
 			nodePath,

--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -220,7 +220,8 @@ export const TimelineListItem: React.FC<{
 				!validatedLocation ||
 				!codeValuesForOverride ||
 				!codeHiddenStatus ||
-				!codeHiddenStatus.canUpdate
+				!codeHiddenStatus.canUpdate ||
+				previewServerState.type !== 'connected'
 			) {
 				return;
 			}
@@ -242,12 +243,14 @@ export const TimelineListItem: React.FC<{
 				defaultValue,
 				schema,
 				setCodeValues,
+				clientId: previewServerState.clientId,
 			});
 		},
 		[
 			codeHiddenStatus,
 			codeValuesForOverride,
 			nodePath,
+			previewServerState,
 			sequence.controls,
 			setCodeValues,
 			validatedLocation,

--- a/packages/studio/src/components/Timeline/save-effect-prop.ts
+++ b/packages/studio/src/components/Timeline/save-effect-prop.ts
@@ -13,6 +13,7 @@ export const saveEffectProp = ({
 	defaultValue,
 	schema,
 	setCodeValues,
+	clientId,
 }: {
 	fileName: string;
 	nodePath: SequencePropsSubscriptionKey;
@@ -22,6 +23,7 @@ export const saveEffectProp = ({
 	defaultValue: string | null;
 	schema: SequenceSchema;
 	setCodeValues: SetCodeValues;
+	clientId: string;
 }): Promise<void> => {
 	return enqueueSavePropChange({
 		nodePath,
@@ -43,6 +45,7 @@ export const saveEffectProp = ({
 				value: JSON.stringify(value),
 				defaultValue,
 				schema,
+				clientId,
 			}),
 		errorLabel: 'Could not save effect prop',
 	});

--- a/packages/studio/src/components/Timeline/save-effect-prop.ts
+++ b/packages/studio/src/components/Timeline/save-effect-prop.ts
@@ -44,20 +44,6 @@ export const saveEffectProp = ({
 				defaultValue,
 				schema,
 			}),
-		mergeServerResponse: (prev, data) => {
-			if (!prev.canUpdate) {
-				return prev;
-			}
-
-			const idx = prev.effects.findIndex((e) => e.effectIndex === effectIndex);
-			if (idx === -1) {
-				return {...prev, effects: [...prev.effects, data]};
-			}
-
-			const nextEffects = [...prev.effects];
-			nextEffects[idx] = data;
-			return {...prev, effects: nextEffects};
-		},
 		errorLabel: 'Could not save effect prop',
 	});
 };

--- a/packages/studio/src/components/Timeline/save-prop-queue.ts
+++ b/packages/studio/src/components/Timeline/save-prop-queue.ts
@@ -15,7 +15,6 @@ type SetCodeValues = (
 type QueueState = {
 	chain: Promise<unknown>;
 	cancelled: boolean;
-	committed: CanUpdateSequencePropsResponse | null;
 };
 
 const queues = new Map<string, QueueState>();
@@ -24,7 +23,7 @@ const getQueue = (nodePath: SequencePropsSubscriptionKey): QueueState => {
 	const key = Internals.makeSequencePropsSubscriptionKey(nodePath);
 	let q = queues.get(key);
 	if (!q) {
-		q = {chain: Promise.resolve(), cancelled: false, committed: null};
+		q = {chain: Promise.resolve(), cancelled: false};
 		queues.set(key, q);
 	}
 
@@ -48,10 +47,6 @@ export type EnqueueSaveOptions<TResponse> = {
 		prev: CanUpdateSequencePropsResponse,
 	) => CanUpdateSequencePropsResponse;
 	apiCall: () => Promise<TResponse>;
-	mergeServerResponse: (
-		prev: CanUpdateSequencePropsResponse,
-		response: TResponse,
-	) => CanUpdateSequencePropsResponse;
 	errorLabel: string;
 };
 
@@ -60,7 +55,6 @@ export const enqueueSavePropChange = <TResponse>({
 	setCodeValues,
 	applyOptimistic,
 	apiCall,
-	mergeServerResponse,
 	errorLabel,
 }: EnqueueSaveOptions<TResponse>): Promise<void> => {
 	const q = getQueue(nodePath);
@@ -70,10 +64,6 @@ export const enqueueSavePropChange = <TResponse>({
 	}
 
 	setCodeValues(nodePath, (prev) => {
-		if (q.committed === null) {
-			q.committed = prev;
-		}
-
 		return applyOptimistic(prev);
 	});
 
@@ -84,16 +74,10 @@ export const enqueueSavePropChange = <TResponse>({
 		}
 
 		try {
-			const response = await apiCall();
+			await apiCall();
 			if (myQueue.cancelled) {
 				return;
 			}
-
-			setCodeValues(nodePath, (prev) => mergeServerResponse(prev, response));
-			myQueue.committed = mergeServerResponse(
-				myQueue.committed as CanUpdateSequencePropsResponse,
-				response,
-			);
 
 			// If nothing more is queued, reset baseline so the next round starts fresh.
 			if (myQueue.chain === next) {
@@ -101,10 +85,6 @@ export const enqueueSavePropChange = <TResponse>({
 			}
 		} catch (err) {
 			myQueue.cancelled = true;
-			const {committed} = myQueue;
-			if (committed !== null) {
-				setCodeValues(nodePath, () => committed);
-			}
 
 			dropQueue(nodePath, myQueue);
 			showNotification(

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -22,6 +22,7 @@ export const saveSequenceProp = ({
 	defaultValue,
 	schema,
 	setCodeValues,
+	clientId,
 }: {
 	fileName: string;
 	nodePath: SequencePropsSubscriptionKey;
@@ -30,6 +31,7 @@ export const saveSequenceProp = ({
 	defaultValue: string | null;
 	schema: SequenceSchema;
 	setCodeValues: SetCodeValues;
+	clientId: string;
 }): Promise<void> => {
 	return enqueueSavePropChange({
 		nodePath,
@@ -49,6 +51,7 @@ export const saveSequenceProp = ({
 				value: JSON.stringify(value),
 				defaultValue,
 				schema,
+				clientId,
 			}),
 		errorLabel: 'Could not save sequence prop',
 	});

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -50,17 +50,6 @@ export const saveSequenceProp = ({
 				defaultValue,
 				schema,
 			}),
-		mergeServerResponse: (prev, data) => {
-			if (!data.canUpdate) {
-				return data;
-			}
-
-			return {
-				canUpdate: true,
-				props: data.props,
-				effects: prev.canUpdate ? prev.effects : [],
-			};
-		},
 		errorLabel: 'Could not save sequence prop',
 	});
 };


### PR DESCRIPTION
1. Does not send `sequence-props-update` to itself anymore
2. Only save optimistic props, disregard committed state because another optimistic state could have been added in the meanwhile

Fixes https://github.com/remotion-dev/remotion/issues/7451