### PR TITLE
Docs: Add HEVC VideoEncoder AMD Windows chunk bug to WebCodecs tracker

### DIFF
--- a/packages/docs/docs/mediabunny/webcodecs-bugs.mdx
+++ b/packages/docs/docs/mediabunny/webcodecs-bugs.mdx
@@ -27,3 +27,4 @@ It serves as a tracker for overall progress and known issues.
 | [VideoEncoder performance drastically degrades if the page needs to rerender](https://issues.chromium.org/issues/414491381)                                | Chrome  | @Vanilagy     | No        |
 | [AudioDecoder.isConfigSupported() returns false positive](https://issues.chromium.org/issues/360083330)                                                    | Chrome  | @JonnyBurger  | Yes       |
 | [AudioDecoder doesn't respect chunks with negative timestamps, starts AudioData timestamps at 0](https://issues.chromium.org/issues/512772321)              | Chrome  | @Vanilagy     | No        |
+| [HEVC VideoEncoder on AMD hardware on Windows labels first emitted chunk as "delta"](https://issues.chromium.org/issues/514397892)                         | Chrome  | @Vanilagy     | No        |


### PR DESCRIPTION
## Summary

- Adds [chromium:514397892](https://issues.chromium.org/issues/514397892) to the WebCodecs bug tracker
- HEVC `VideoEncoder` on AMD hardware on Windows labels the first emitted chunk as `"delta"` instead of a key frame
- Reported by @Vanilagy; not yet resolved

## Test plan

- [ ] Verify the new row appears on the WebCodecs Bugs docs page


Made with [Cursor](https://cursor.com)