### PR TITLE
Update resources.mdx to include Mappi

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -180,6 +180,7 @@ See the [Showcase](/showcase) for videos made with Remotion.
 - [aicut - Faceless Videos](https://www.aicut.pro/)
 - [vidbuilder.ai](https://vidbuilder.ai/)
 - [Indream — AI Video Editor](https://indream.ai/)
+- [Mappi - Map Animation Creator](https://mappi.studio/)
 
 ## See also
 


### PR DESCRIPTION
Add Mappi to the [product section](https://www.remotion.dev/docs/resources#products) of the 'List of resources' documentation page.

This PR adds [Mappi](https://mappi.studio/) (map animation creator powered by Remotion) to the resources list.

This change only updates documentation and does not affect existing structure or functionality.

No issues are linked and no code changes are involved.