### PR TITLE
`remotion`: Fix HtmlInCanvas for Chromium same-canvas ElementImage constraint

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -6,7 +6,6 @@ import React, {
 	useLayoutEffect,
 	useMemo,
 	useRef,
-	useState,
 } from 'react';
 import type {SequenceControls} from './CompositionManager.js';
 import {delayRender} from './delay-render.js';
@@ -66,37 +65,6 @@ declare global {
 		): DOMMatrix;
 		drawElementImage(
 			element: Element | ElementImage,
-			sx: number,
-			sy: number,
-			swidth: number,
-			sheight: number,
-			dx: number,
-			dy: number,
-			dwidth: number,
-			dheight: number,
-		): DOMMatrix;
-	}
-
-	interface OffscreenCanvasRenderingContext2D {
-		drawElementImage(element: ElementImage, dx: number, dy: number): DOMMatrix;
-		drawElementImage(
-			element: ElementImage,
-			dx: number,
-			dy: number,
-			dwidth: number,
-			dheight: number,
-		): DOMMatrix;
-		drawElementImage(
-			element: ElementImage,
-			sx: number,
-			sy: number,
-			swidth: number,
-			sheight: number,
-			dx: number,
-			dy: number,
-		): DOMMatrix;
-		drawElementImage(
-			element: ElementImage,
 			sx: number,
 			sy: number,
 			swidth: number,
@@ -172,10 +140,18 @@ declare global {
 	}
 }
 
+export type HtmlInCanvasRenderingContext = '2d' | 'webgl2' | 'webgpu';
+
 export type HtmlInCanvasOnPaintParams = {
-	readonly canvas: OffscreenCanvas;
+	/** The layout canvas (same element as the forwarded ref). */
+	readonly canvas: HTMLCanvasElement;
+	/** The scene root — direct child of `canvas`. */
 	readonly element: HTMLDivElement;
-	readonly elementImage: ElementImage;
+	/**
+	 * The 2D rendering context on `canvas`.
+	 * Only present when {@link HtmlInCanvasProps.renderingContext} is `'2d'` (default).
+	 */
+	readonly ctx?: CanvasRenderingContext2D;
 };
 
 // Memoize the support check across the session — neither the platform
@@ -235,18 +211,15 @@ function assertHtmlInCanvasDimensions(width: unknown, height: unknown): void {
 	}
 }
 
-const defaultOnPaint: HtmlInCanvasOnPaint = ({
-	canvas,
-	element,
-	elementImage,
-}) => {
-	const ctx = canvas.getContext('2d');
+const defaultOnPaint: HtmlInCanvasOnPaint = ({ctx, element}) => {
 	if (!ctx) {
-		throw new Error('Failed to acquire 2D context for <HtmlInCanvas> canvas');
+		throw new Error(
+			'HtmlInCanvas: default paint requires a 2D context (`renderingContext="2d"`).',
+		);
 	}
 
 	ctx.reset();
-	const transform = ctx.drawElementImage(elementImage, 0, 0);
+	const transform = ctx.drawElementImage(element, 0, 0);
 	element.style.transform = transform.toString();
 };
 
@@ -271,6 +244,13 @@ export type HtmlInCanvasProps = Omit<
 		readonly height: number;
 		readonly _experimentalEffects?: EffectsProp;
 		readonly children: React.ReactNode;
+		/**
+		 * Which rendering context to use on the layout canvas.
+		 * `'2d'` (default) supports {@link HtmlInCanvasProps._experimentalEffects}.
+		 * `'webgl2'` and `'webgpu'` require custom `onInit`/`onPaint` and cannot be
+		 * combined with `_experimentalEffects` on the same instance.
+		 */
+		readonly renderingContext?: HtmlInCanvasRenderingContext;
 		readonly onPaint?: HtmlInCanvasOnPaint;
 		readonly onInit?: HtmlInCanvasOnInit;
 	};
@@ -281,6 +261,7 @@ const HtmlInCanvasAncestorContext = createContext(false);
 type HtmlInCanvasContentProps = {
 	readonly width: number;
 	readonly height: number;
+	readonly renderingContext: HtmlInCanvasRenderingContext;
 	readonly effects: EffectsProp;
 	readonly children: React.ReactNode;
 	readonly onPaint: HtmlInCanvasOnPaint | undefined;
@@ -294,7 +275,17 @@ const HtmlInCanvasContent = forwardRef<
 	HtmlInCanvasContentProps
 >(
 	(
-		{width, height, effects, children, onPaint, onInit, controls, style},
+		{
+			width,
+			height,
+			renderingContext,
+			effects,
+			children,
+			onPaint,
+			onInit,
+			controls,
+			style,
+		},
 		ref,
 	) => {
 		const isInsideAncestorHtmlInCanvas = useContext(
@@ -323,7 +314,6 @@ const HtmlInCanvasContent = forwardRef<
 			},
 			[ref],
 		);
-		const [offscreenCanvas] = useState(() => new OffscreenCanvas(1, 1));
 
 		const chainState = useEffectChainState();
 
@@ -331,6 +321,14 @@ const HtmlInCanvasContent = forwardRef<
 			effects,
 			overrideId: controls?.overrideId ?? null,
 		});
+
+		const hasEffects = memoizedEffects.length > 0;
+
+		if (renderingContext !== '2d' && hasEffects) {
+			throw new Error(
+				'HtmlInCanvas: `_experimentalEffects` requires `renderingContext="2d"`. Use custom `onPaint` for WebGL/WebGPU, or split into separate compositions.',
+			);
+		}
 
 		// Refs so the paint handler always reads fresh values.
 		const effectsRef = useRef(memoizedEffects);
@@ -350,73 +348,90 @@ const HtmlInCanvasContent = forwardRef<
 				throw new Error('Canvas or scene element not found');
 			}
 
-			offscreenCanvas.width = width;
-			offscreenCanvas.height = height;
-
 			try {
 				const layoutCanvas = canvas2dRef.current;
 				if (!layoutCanvas) {
 					throw new Error('Canvas not found');
 				}
 
-				// `GPUQueue.copyElementImageToTexture` / related paths validate the
-				// layout canvas has a rendering context. `runEffectChain` only runs
-				// after `onPaint`, so acquire `2d` here before any capture or handler.
-				const layout2d = layoutCanvas.getContext('2d');
-				if (!layout2d) {
-					throw new Error(
-						'Failed to acquire 2D context for <HtmlInCanvas> layout canvas',
-					);
-				}
-
 				const handle = delayRender('onPaint');
-				if (!initializedRef.current) {
-					initializedRef.current = true;
-					// `onInit` may be async (e.g. WebGPU `requestAdapter`/`requestDevice`).
-					// Capture an `ElementImage` here only for `onInit` consumers — do NOT
-					// reuse it for the paint handler below, because awaiting `onInit`
-					// can invalidate the capture's paint context, leaving subsequent
-					// uploads (e.g. `copyElementImageToTexture`) failing with
-					// "No context found for ElementImage" on the very first paint.
-					const initImage = layoutCanvas.captureElementImage(element);
-					const currentOnInit = onInitRef.current;
-					if (currentOnInit) {
-						const cleanup = await currentOnInit({
-							canvas: offscreenCanvas,
-							element,
-							elementImage: initImage!,
-						});
-						if (typeof cleanup !== 'function') {
-							throw new Error(
-								'HtmlInCanvas: when `onInit` is provided, it must return a cleanup function, or a Promise that resolves to one.',
-							);
-						}
 
-						if (unmountedRef.current) {
-							cleanup();
-						} else {
-							onInitCleanupRef.current = cleanup;
+				const paintParams: HtmlInCanvasOnPaintParams = {
+					canvas: layoutCanvas,
+					element,
+				};
+
+				if (renderingContext === '2d') {
+					// `GPUQueue.copyElementImageToTexture` / related paths validate the
+					// layout canvas has a rendering context. Acquire `2d` before paint.
+					const layout2d = layoutCanvas.getContext('2d');
+					if (!layout2d) {
+						throw new Error(
+							'Failed to acquire 2D context for <HtmlInCanvas> layout canvas',
+						);
+					}
+
+					paintParams.ctx = layout2d;
+
+					if (!initializedRef.current) {
+						initializedRef.current = true;
+						const currentOnInit = onInitRef.current;
+						if (currentOnInit) {
+							const cleanup = await currentOnInit(paintParams);
+							if (typeof cleanup !== 'function') {
+								throw new Error(
+									'HtmlInCanvas: when `onInit` is provided, it must return a cleanup function, or a Promise that resolves to one.',
+								);
+							}
+
+							if (unmountedRef.current) {
+								cleanup();
+							} else {
+								onInitCleanupRef.current = cleanup;
+							}
 						}
 					}
+
+					const handler = onPaintRef.current ?? defaultOnPaint;
+					await handler(paintParams);
+
+					await runEffectChain({
+						state: chainState.get(width, height)!,
+						source: layoutCanvas,
+						effects: effectsRef.current,
+						output: layoutCanvas,
+						width,
+						height,
+					});
+				} else {
+					if (!initializedRef.current) {
+						initializedRef.current = true;
+						const currentOnInit = onInitRef.current;
+						if (currentOnInit) {
+							const cleanup = await currentOnInit(paintParams);
+							if (typeof cleanup !== 'function') {
+								throw new Error(
+									'HtmlInCanvas: when `onInit` is provided, it must return a cleanup function, or a Promise that resolves to one.',
+								);
+							}
+
+							if (unmountedRef.current) {
+								cleanup();
+							} else {
+								onInitCleanupRef.current = cleanup;
+							}
+						}
+					}
+
+					const handler = onPaintRef.current;
+					if (!handler) {
+						throw new Error(
+							`HtmlInCanvas: \`onPaint\` is required when \`renderingContext\` is "${renderingContext}".`,
+						);
+					}
+
+					await handler(paintParams);
 				}
-
-				const handler = onPaintRef.current ?? defaultOnPaint;
-
-				const elImage = layoutCanvas.captureElementImage(element);
-				await handler({
-					canvas: offscreenCanvas,
-					element,
-					elementImage: elImage!,
-				});
-
-				await runEffectChain({
-					state: chainState.get(width, height)!,
-					source: offscreenCanvas,
-					effects: effectsRef.current,
-					output: canvas2dRef.current!,
-					width,
-					height,
-				});
 
 				continueRender(handle);
 			} catch (error) {
@@ -428,7 +443,7 @@ const HtmlInCanvasContent = forwardRef<
 			cancelRender,
 			width,
 			height,
-			offscreenCanvas,
+			renderingContext,
 		]);
 
 		// Set up layoutSubtree and persistent paint listener. Runs as a
@@ -528,6 +543,7 @@ const HtmlInCanvasInner = forwardRef<
 		{
 			width,
 			height,
+			renderingContext = '2d',
 			_experimentalEffects: effects = [],
 			children,
 			onPaint,
@@ -558,6 +574,7 @@ const HtmlInCanvasInner = forwardRef<
 					ref={ref}
 					width={width}
 					height={height}
+					renderingContext={renderingContext}
 					effects={effects}
 					onPaint={onPaint}
 					onInit={onInit}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,6 +154,7 @@ export {
 export type {
 	HtmlInCanvasOnPaintParams,
 	HtmlInCanvasProps,
+	HtmlInCanvasRenderingContext,
 } from './HtmlInCanvas.js';
 export type {AnyZodObject} from './any-zod-type.js';
 export {Artifact} from './Artifact.js';

--- a/packages/docs/components/demos/HtmlInCanvasDocsDemo2DBlur.tsx
+++ b/packages/docs/components/demos/HtmlInCanvasDocsDemo2DBlur.tsx
@@ -18,8 +18,7 @@ const HtmlInCanvasDocsDemo2DBlurInner: React.FC = () => {
 	const {width, height, fps} = useVideoConfig();
 
 	const onPaint: HtmlInCanvasOnPaint = useCallback(
-		({canvas, element, elementImage}) => {
-			const ctx = canvas.getContext('2d');
+		({ctx, element}) => {
 			if (!ctx) {
 				throw new Error('Failed to acquire 2D context');
 			}
@@ -31,7 +30,7 @@ const HtmlInCanvasDocsDemo2DBlurInner: React.FC = () => {
 
 			ctx.reset();
 			ctx.filter = `blur(${blurPx}px)`;
-			const transform = ctx.drawElementImage(elementImage, 0, 0);
+			const transform = ctx.drawElementImage(element, 0, 0);
 			element.style.transform = transform.toString();
 		},
 		[frame, fps],

--- a/packages/docs/components/demos/HtmlInCanvasDocsDemoWebGL.tsx
+++ b/packages/docs/components/demos/HtmlInCanvasDocsDemoWebGL.tsx
@@ -123,7 +123,7 @@ const HtmlInCanvasDocsWebGLInner: React.FC = () => {
 	}, []);
 
 	const onPaint: HtmlInCanvasOnPaint = useCallback(
-		({elementImage}) => {
+		({element}) => {
 			const gpu = gpuRef.current;
 			if (!gpu) {
 				return;
@@ -141,7 +141,7 @@ const HtmlInCanvasDocsWebGLInner: React.FC = () => {
 				gl.RGBA,
 				gl.RGBA,
 				gl.UNSIGNED_BYTE,
-				elementImage,
+				element,
 			);
 
 			if (gpu.uTex) {
@@ -162,6 +162,7 @@ const HtmlInCanvasDocsWebGLInner: React.FC = () => {
 		<HtmlInCanvas
 			width={width}
 			height={height}
+			renderingContext="webgl2"
 			onInit={onInit}
 			onPaint={onPaint}
 		>

--- a/packages/docs/components/demos/HtmlInCanvasDocsDemoWebGPU.tsx
+++ b/packages/docs/components/demos/HtmlInCanvasDocsDemoWebGPU.tsx
@@ -145,7 +145,7 @@ const HtmlInCanvasDocsWebGPUInner: React.FC = () => {
 			}
 		).getContext('webgpu');
 		if (!context) {
-			throw new Error('WebGPU context unavailable on OffscreenCanvas');
+			throw new Error('WebGPU context unavailable on <HtmlInCanvas> canvas');
 		}
 
 		const presentationFormat = gpu.getPreferredCanvasFormat();
@@ -238,7 +238,7 @@ const HtmlInCanvasDocsWebGPUInner: React.FC = () => {
 	}, []);
 
 	const onPaint: HtmlInCanvasOnPaint = useCallback(
-		({elementImage}) => {
+		({canvas, element}) => {
 			const gpu = gpuRef.current;
 			if (!gpu) {
 				return;
@@ -247,6 +247,7 @@ const HtmlInCanvasDocsWebGPUInner: React.FC = () => {
 			const {device, context, pipeline, texture, bindGroup, uniformBuffer} =
 				gpu;
 
+			const elementImage = canvas.captureElementImage(element);
 			device.queue.copyElementImageToTexture(
 				elementImage,
 				gpu.width,
@@ -288,6 +289,7 @@ const HtmlInCanvasDocsWebGPUInner: React.FC = () => {
 			<HtmlInCanvas
 				width={width}
 				height={height}
+				renderingContext="webgpu"
 				onInit={onInit}
 				onPaint={onPaint}
 			>

--- a/packages/docs/docs/html-in-canvas-guide.mdx
+++ b/packages/docs/docs/html-in-canvas-guide.mdx
@@ -43,15 +43,14 @@ For rendering, you don't need to do anything — see [Rendering](#rendering) bel
 ```tsx twoslash title="MyComp.tsx"
 import {HtmlInCanvas, type HtmlInCanvasOnPaint} from 'remotion';
 
-const onPaint: HtmlInCanvasOnPaint = ({canvas, element, elementImage}) => {
-  const ctx = canvas.getContext('2d');
+const onPaint: HtmlInCanvasOnPaint = ({ctx, element}) => {
   if (!ctx) {
     throw new Error('Failed to acquire 2D context');
   }
 
   ctx.reset();
   ctx.filter = 'blur(8px)';
-  const transform = ctx.drawElementImage(elementImage, 0, 0);
+  const transform = ctx.drawElementImage(element, 0, 0);
   element.style.transform = transform.toString();
 };
 

--- a/packages/docs/docs/remotion/html-in-canvas.mdx
+++ b/packages/docs/docs/remotion/html-in-canvas.mdx
@@ -91,15 +91,14 @@ If this callback is omitted, the children are painted using a `2d` context with 
 ```tsx twoslash title="Simple example"
 import {HtmlInCanvasOnPaint} from 'remotion';
 
-const onPaint: HtmlInCanvasOnPaint = ({canvas, element, elementImage}) => {
-  const ctx = canvas.getContext('2d');
+const onPaint: HtmlInCanvasOnPaint = ({ctx, element}) => {
   if (!ctx) {
     throw new Error('Failed to acquire 2D context');
   }
 
   ctx.reset();
   ctx.filter = 'blur(10px)';
-  const transform = ctx.drawElementImage(elementImage, 0, 0);
+  const transform = ctx.drawElementImage(element, 0, 0);
   element.style.transform = transform.toString();
 };
 ```
@@ -110,24 +109,30 @@ The callback receives:
 
 #### `canvas`
 
-An [`OffscreenCanvas`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) with dimensions `width` × `height`.  
-You should paint to this canvas.
+The layout [`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) (same node as the forwarded `ref`).  
+[`drawElementImage()`](https://github.com/WICG/html-in-canvas#2-drawelementimage-and-webglwebgpu-equivalents) must target this canvas — Chrome rejects captures drawn on a different canvas.
 
 #### `element`
 
 The inner [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement) that wraps `children`.  
-You should apply the return value of [`drawElementImage`](https://github.com/WICG/html-in-canvas#2-drawelementimage-and-webglwebgpu-equivalents) to this element's `style.transform` property.
+Pass it to `drawElementImage()` / `texElementImage2D()`, and apply the returned transform to `element.style.transform` so DOM selection still aligns.
 
-#### `elementImage`
+#### `ctx?`
 
-An [`ElementImage`](https://github.com/WICG/html-in-canvas#idl-changes) handle for the current capture.  
-You should paint this image to the canvas.
+The [`CanvasRenderingContext2D`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D) on `canvas`, pre-acquired when [`renderingContext`](#renderingcontext) is `'2d'` (default). Omitted for `'webgl2'` and `'webgpu'`.
+
+### `renderingContext?`
+
+<AvailableFrom version="4.0.400" />
+
+`'2d'` (default), `'webgl2'`, or `'webgpu'`.  
+Only one context can be active per canvas. [`_experimentalEffects`](#_experimentaleffects) require `'2d'`. Custom WebGL/WebGPU handlers must set `renderingContext` accordingly and provide [`onPaint`](#onpaint).
 
 ### `onInit?`
 
-Runs once before the first paint. Use it to create GPU contexts or other resources tied to the [`OffscreenCanvas`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas). Must return a cleanup function, or a `Promise` that resolves to one. The cleanup runs on unmount.
+Runs once before the first paint. Use it to create GPU contexts or other resources on the layout canvas. Must return a cleanup function, or a `Promise` that resolves to one. The cleanup runs on unmount.
 
-The argument object matches [`onPaint`](#onpaint) (`canvas`, `element`, `elementImage`). The `elementImage` passed here is only for initialization — capture again inside [`onPaint`](#onpaint) for each frame.
+The argument object matches [`onPaint`](#onpaint) (`canvas`, `element`, and `ctx` when using `'2d'`).
 
 ### `durationInFrames?`
 
@@ -163,7 +168,7 @@ export const Example: React.FC = () => {
 
 ### 2D
 
-Call [`drawElementImage()`](https://github.com/WICG/html-in-canvas#2-drawelementimage-and-webglwebgpu-equivalents) on the 2D context to draw `elementImage` into the bitmap.  
+Call [`drawElementImage()`](https://github.com/WICG/html-in-canvas#2-drawelementimage-and-webglwebgpu-equivalents) on the 2D context to draw `element` into the bitmap.  
 HTML-in-canvas recommends that you use the return value and assign it to `element.style.transform`, so that the original DOM element matches the transform, so that selection still works.
 
 For 2D, you usually do not need `onInit`.
@@ -189,8 +194,7 @@ export const HtmlInCanvas2DBlur: React.FC = () => {
   const {width, height, fps} = useVideoConfig();
 
   const onPaint: HtmlInCanvasOnPaint = useCallback(
-    ({canvas, element, elementImage}) => {
-      const ctx = canvas.getContext('2d');
+    ({ctx, element}) => {
       if (!ctx) {
         throw new Error('Failed to acquire 2D context');
       }
@@ -202,7 +206,7 @@ export const HtmlInCanvas2DBlur: React.FC = () => {
 
       ctx.reset();
       ctx.filter = `blur(${blurPx}px)`;
-      const transform = ctx.drawElementImage(elementImage, 0, 0);
+      const transform = ctx.drawElementImage(element, 0, 0);
       element.style.transform = transform.toString();
     },
     [frame, fps],
@@ -232,7 +236,7 @@ export const HtmlInCanvas2DBlur: React.FC = () => {
 Do all setup in [`onInit`](#oninit) such as getting the WebGL context and compiling the shader.  
 `onInit` must return a cleanup function that destroys the resources that were created in `onInit`.
 
-Use [`texElementImage2D`](https://github.com/WICG/html-in-canvas#2-drawelementimage-and-webglwebgpu-equivalents) to turn the `elementImage` into a texture.
+Set `renderingContext="webgl2"` and use [`texElementImage2D`](https://github.com/WICG/html-in-canvas#2-drawelementimage-and-webglwebgpu-equivalents) with the `element` on the layout canvas.
 
 <Demo type="html-in-canvas-webgl" />
 
@@ -364,7 +368,7 @@ export const HtmlInCanvasDocsMinimalWebGL: React.FC = () => {
   }, []);
 
   const onPaint: HtmlInCanvasOnPaint = useCallback(
-    ({elementImage}) => {
+    ({element}) => {
       const gpu = gpuRef.current;
       if (!gpu) {
         return;
@@ -382,7 +386,7 @@ export const HtmlInCanvasDocsMinimalWebGL: React.FC = () => {
         gl.RGBA,
         gl.RGBA,
         gl.UNSIGNED_BYTE,
-        elementImage,
+        element,
       );
 
       if (gpu.uTex) {
@@ -403,6 +407,7 @@ export const HtmlInCanvasDocsMinimalWebGL: React.FC = () => {
     <HtmlInCanvas
       width={width}
       height={height}
+      renderingContext="webgl2"
       onInit={onInit}
       onPaint={onPaint}
     >
@@ -426,9 +431,9 @@ export const HtmlInCanvasDocsMinimalWebGL: React.FC = () => {
 
 ### WebGPU
 
-Use [`onInit`](#oninit) to get a WebGPU context, to request a GPU and to compile shaders.  
+Set `renderingContext="webgpu"`. Use [`onInit`](#oninit) to get a WebGPU context, request a GPU, and compile shaders.  
 `onInit` must return a cleanup function that destroys the resources that were created in `onInit`.  
-In `onPaint`, draw the `elementImage` to the canvas using [`copyElementImageToTexture`](https://github.com/WICG/html-in-canvas#2-drawelementimage-and-webglwebgpu-equivalents).
+In `onPaint`, call `canvas.captureElementImage(element)` on the layout canvas, then [`copyElementImageToTexture`](https://github.com/WICG/html-in-canvas#2-drawelementimage-and-webglwebgpu-equivalents) on the same canvas.
 
 <Demo type="html-in-canvas-webgpu" />
 
@@ -581,7 +586,7 @@ export const HtmlInCanvasComposeWebGPU: React.FC = () => {
       }
     ).getContext('webgpu');
     if (!context) {
-      throw new Error('WebGPU context unavailable on OffscreenCanvas');
+      throw new Error('WebGPU context unavailable on <HtmlInCanvas> canvas');
     }
 
     // Use the device's preferred swap-chain format (typically `bgra8unorm`)
@@ -677,7 +682,7 @@ export const HtmlInCanvasComposeWebGPU: React.FC = () => {
   }, []);
 
   const onPaint: HtmlInCanvasOnPaint = useCallback(
-    ({elementImage}) => {
+    ({canvas, element}) => {
       const gpu = gpuRef.current;
       if (!gpu) {
         return;
@@ -686,6 +691,7 @@ export const HtmlInCanvasComposeWebGPU: React.FC = () => {
       const {device, context, pipeline, texture, bindGroup, uniformBuffer} =
         gpu;
 
+      const elementImage = canvas.captureElementImage(element);
       device.queue.copyElementImageToTexture(
         elementImage,
         gpu.width,
@@ -727,6 +733,7 @@ export const HtmlInCanvasComposeWebGPU: React.FC = () => {
       <HtmlInCanvas
         width={width}
         height={height}
+        renderingContext="webgpu"
         onInit={onInit}
         onPaint={onPaint}
       >
@@ -759,14 +766,13 @@ This might be necessary if you are implementing a multi-pass effect using multip
 ```tsx twoslash title="Async: createImageBitmap then drawImage"
 import {HtmlInCanvasOnPaint} from 'remotion';
 
-const onPaint: HtmlInCanvasOnPaint = async ({canvas, elementImage}) => {
-  const ctx = canvas.getContext('2d');
+const onPaint: HtmlInCanvasOnPaint = async ({canvas, ctx, element}) => {
   if (!ctx) {
     return;
   }
 
   ctx.reset();
-  ctx.drawElementImage(elementImage, 0, 0);
+  ctx.drawElementImage(element, 0, 0);
   const bitmap = await createImageBitmap(canvas);
   try {
     ctx.reset();

--- a/packages/example/src/HtmlInCanvas/changing-size.tsx
+++ b/packages/example/src/HtmlInCanvas/changing-size.tsx
@@ -19,8 +19,7 @@ export const HtmlInCanvasChangingSize: React.FC = () => {
 			<HtmlInCanvas
 				width={size}
 				height={size}
-				onPaint={({canvas, elementImage, element}) => {
-					const ctx = canvas.getContext('2d', {willReadFrequently: true});
+				onPaint={({canvas, ctx, element}) => {
 					if (!ctx) {
 						throw new Error(
 							'Failed to acquire 2D context for <HtmlInCanvas> canvas',
@@ -32,7 +31,7 @@ export const HtmlInCanvasChangingSize: React.FC = () => {
 					//    actual sampled pixel data from the rendered subtree.
 					ctx.reset();
 					const transform = ctx.drawElementImage(
-						elementImage,
+						element,
 						0,
 						0,
 						canvas.width,

--- a/packages/example/src/HtmlInCanvas/complex-text.tsx
+++ b/packages/example/src/HtmlInCanvas/complex-text.tsx
@@ -18,8 +18,7 @@ export const HtmlInCanvasComplexText: React.FC = () => {
 				width={1276}
 				height={636}
 				style={{border: '2px solid blue'}}
-				onPaint={({canvas, element, elementImage}) => {
-					const ctx = canvas.getContext('2d');
+				onPaint={({ctx, element}) => {
 					if (!ctx) {
 						throw new Error('Failed to acquire 2D context');
 					}
@@ -27,7 +26,7 @@ export const HtmlInCanvasComplexText: React.FC = () => {
 					ctx.reset();
 					ctx.rotate((15 * Math.PI) / 180);
 					ctx.translate(160, -40);
-					const transform = ctx.drawElementImage(elementImage, 0, 0);
+					const transform = ctx.drawElementImage(element, 0, 0);
 					element.style.transform = transform.toString();
 				}}
 			>

--- a/packages/example/src/HtmlInCanvas/compose-async-bitmap.tsx
+++ b/packages/example/src/HtmlInCanvas/compose-async-bitmap.tsx
@@ -11,13 +11,12 @@ export const HtmlInCanvasComposeAsyncBitmap: React.FC = () => {
 			<HtmlInCanvas
 				width={width}
 				height={height}
-				onPaint={async ({canvas, elementImage}) => {
-					const ctx = canvas.getContext('2d');
+				onPaint={async ({canvas, ctx, element}) => {
 					if (!ctx) {
 						return;
 					}
 					ctx.reset();
-					ctx.drawElementImage(elementImage, 0, 0);
+					ctx.drawElementImage(element, 0, 0);
 					const bitmap = await createImageBitmap(canvas);
 					try {
 						ctx.reset();

--- a/packages/example/src/HtmlInCanvas/compose-webgl-crt.tsx
+++ b/packages/example/src/HtmlInCanvas/compose-webgl-crt.tsx
@@ -1,4 +1,3 @@
-import {tint} from '@remotion/effects/tint';
 import React, {useCallback, useRef} from 'react';
 import {
 	HtmlInCanvas,
@@ -90,6 +89,9 @@ void main() {
   // Noise
   col += (rand(uv * u_time) - 0.5) * 0.04;
 
+  // Red tint (formerly _experimentalEffects tint red)
+  col *= vec3(1.2, 0.85, 0.85);
+
   o = vec4(col, 1.0);
 }`;
 
@@ -180,7 +182,7 @@ export const HtmlInCanvasComposeWebGLCrt: React.FC = () => {
 	}, []);
 
 	const onPaint: HtmlInCanvasOnPaint = useCallback(
-		({elementImage}) => {
+		({element}) => {
 			const gpu = gpuRef.current;
 			if (!gpu) {
 				return;
@@ -198,7 +200,7 @@ export const HtmlInCanvasComposeWebGLCrt: React.FC = () => {
 				gl.RGBA,
 				gl.RGBA,
 				gl.UNSIGNED_BYTE,
-				elementImage,
+				element,
 			);
 
 			if (gpu.uTex) {
@@ -227,9 +229,9 @@ export const HtmlInCanvasComposeWebGLCrt: React.FC = () => {
 		<HtmlInCanvas
 			width={width}
 			height={height}
+			renderingContext="webgl2"
 			onInit={onInit}
 			onPaint={onPaint}
-			_experimentalEffects={[tint({color: 'red'})]}
 			style={{
 				backgroundColor: 'white',
 				color: 'black',

--- a/packages/example/src/HtmlInCanvas/compose-webgl.tsx
+++ b/packages/example/src/HtmlInCanvas/compose-webgl.tsx
@@ -124,7 +124,7 @@ export const HtmlInCanvasComposeWebGL: React.FC = () => {
 	}, []);
 
 	const onPaint: HtmlInCanvasOnPaint = useCallback(
-		({elementImage}) => {
+		({element}) => {
 			const gpu = gpuRef.current;
 			if (!gpu) {
 				return;
@@ -146,7 +146,7 @@ export const HtmlInCanvasComposeWebGL: React.FC = () => {
 				gl.RGBA,
 				gl.RGBA,
 				gl.UNSIGNED_BYTE,
-				elementImage,
+				element,
 			);
 
 			if (gpu.uTex) {
@@ -167,6 +167,7 @@ export const HtmlInCanvasComposeWebGL: React.FC = () => {
 		<HtmlInCanvas
 			width={width}
 			height={height}
+			renderingContext="webgl2"
 			onInit={onInit}
 			onPaint={onPaint}
 		>

--- a/packages/example/src/HtmlInCanvas/compose-webgpu.tsx
+++ b/packages/example/src/HtmlInCanvas/compose-webgpu.tsx
@@ -143,7 +143,7 @@ export const HtmlInCanvasComposeWebGPU: React.FC = () => {
 			}
 		).getContext('webgpu');
 		if (!context) {
-			throw new Error('WebGPU context unavailable on OffscreenCanvas');
+			throw new Error('WebGPU context unavailable on <HtmlInCanvas> canvas');
 		}
 
 		// Use the device's preferred swap-chain format (typically `bgra8unorm`)
@@ -239,7 +239,7 @@ export const HtmlInCanvasComposeWebGPU: React.FC = () => {
 	}, []);
 
 	const onPaint: HtmlInCanvasOnPaint = useCallback(
-		({elementImage}) => {
+		({canvas, element}) => {
 			const gpu = gpuRef.current;
 			if (!gpu) {
 				return;
@@ -248,6 +248,7 @@ export const HtmlInCanvasComposeWebGPU: React.FC = () => {
 			const {device, context, pipeline, texture, bindGroup, uniformBuffer} =
 				gpu;
 
+			const elementImage = canvas.captureElementImage(element);
 			device.queue.copyElementImageToTexture(
 				elementImage,
 				gpu.width,
@@ -289,6 +290,7 @@ export const HtmlInCanvasComposeWebGPU: React.FC = () => {
 			<HtmlInCanvas
 				width={width}
 				height={height}
+				renderingContext="webgpu"
 				onInit={onInit}
 				onPaint={onPaint}
 			>

--- a/packages/example/src/HtmlInCanvas/docs-demo-2d-blur.tsx
+++ b/packages/example/src/HtmlInCanvas/docs-demo-2d-blur.tsx
@@ -23,8 +23,7 @@ export const HtmlInCanvasDocsDemo2DBlur: React.FC = () => {
 	const {width, height, fps} = useVideoConfig();
 
 	const onPaint: HtmlInCanvasOnPaint = useCallback(
-		({canvas, element, elementImage}) => {
-			const ctx = canvas.getContext('2d');
+		({ctx, element}) => {
 			if (!ctx) {
 				throw new Error('Failed to acquire 2D context');
 			}
@@ -35,7 +34,7 @@ export const HtmlInCanvasDocsDemo2DBlur: React.FC = () => {
 
 			ctx.reset();
 			ctx.filter = `blur(${blurPx}px)`;
-			const transform = ctx.drawElementImage(elementImage, 0, 0);
+			const transform = ctx.drawElementImage(element, 0, 0);
 			element.style.transform = transform.toString();
 		},
 		[frame, fps],

--- a/packages/example/src/HtmlInCanvas/minimal-docs-webgl.tsx
+++ b/packages/example/src/HtmlInCanvas/minimal-docs-webgl.tsx
@@ -122,7 +122,7 @@ export const HtmlInCanvasDocsMinimalWebGL: React.FC = () => {
 	}, []);
 
 	const onPaint: HtmlInCanvasOnPaint = useCallback(
-		({elementImage}) => {
+		({element}) => {
 			const gpu = gpuRef.current;
 			if (!gpu) {
 				return;
@@ -140,7 +140,7 @@ export const HtmlInCanvasDocsMinimalWebGL: React.FC = () => {
 				gl.RGBA,
 				gl.RGBA,
 				gl.UNSIGNED_BYTE,
-				elementImage,
+				element,
 			);
 
 			if (gpu.uTex) {
@@ -161,6 +161,7 @@ export const HtmlInCanvasDocsMinimalWebGL: React.FC = () => {
 		<HtmlInCanvas
 			width={width}
 			height={height}
+			renderingContext="webgl2"
 			onInit={onInit}
 			onPaint={onPaint}
 		>

--- a/packages/example/src/HtmlInCanvas/privacy.tsx
+++ b/packages/example/src/HtmlInCanvas/privacy.tsx
@@ -123,14 +123,13 @@ export const HtmlInCanvasPrivacy: React.FC = () => {
 					width={600}
 					height={760}
 					style={{border: '1px dashed #888'}}
-					onPaint={({canvas, element, elementImage}) => {
-						const ctx = canvas.getContext('2d');
+					onPaint={({ctx, element}) => {
 						if (!ctx) {
 							throw new Error('Failed to acquire 2D context');
 						}
 
 						ctx.reset();
-						ctx.drawElementImage(elementImage, 0, 0);
+						ctx.drawElementImage(element, 0, 0);
 
 						// Push the live DOM off-screen so the canvas pixels (which
 						// have the redactions applied) are visible. CSS transforms

--- a/packages/skills/skills/remotion/rules/html-in-canvas.md
+++ b/packages/skills/skills/remotion/rules/html-in-canvas.md
@@ -49,7 +49,7 @@ export const MyComp = () => {
 
 ## 2D effect with `onPaint`
 
-`onPaint` runs whenever the content updates. Call `ctx.drawElementImage(elementImage, 0, 0)` to draw the captured DOM, and assign the returned transform to `element.style.transform` so DOM selection still aligns with the painted output.
+`onPaint` runs whenever the content updates. Draw the DOM subtree with `ctx.drawElementImage(element, 0, 0)` on the **same** layout canvas (passed as `canvas` and `ctx`), and assign the returned transform to `element.style.transform` so DOM selection still aligns with the painted output.
 
 ```tsx
 import {
@@ -66,15 +66,14 @@ export const Blur = () => {
   const { width, height, fps } = useVideoConfig();
 
   const onPaint: HtmlInCanvasOnPaint = useCallback(
-    ({ canvas, element, elementImage }) => {
-      const ctx = canvas.getContext("2d");
+    ({ ctx, element }) => {
       if (!ctx) throw new Error("Failed to acquire 2D context");
 
       const blurPx = 4 + 18 * (0.5 + 0.5 * Math.sin((frame / fps) * Math.PI));
 
       ctx.reset();
       ctx.filter = `blur(${blurPx}px)`;
-      const transform = ctx.drawElementImage(elementImage, 0, 0);
+      const transform = ctx.drawElementImage(element, 0, 0);
       element.style.transform = transform.toString();
     },
     [frame, fps],
@@ -92,7 +91,7 @@ export const Blur = () => {
 
 ## WebGL effects
 
-For WebGL, set up the context, program, and texture in `onInit` and return a cleanup function. Inside `onPaint`, upload the captured DOM with `gl.texElementImage2D(...)` and draw.
+Use `renderingContext="webgl2"`. Set up the context, program, and texture in `onInit` on the **layout** canvas. In `onPaint`, upload the DOM with `gl.texElementImage2D(..., element)` (the element, not a captured `ElementImage`).
 
 ```tsx
 const onInit: HtmlInCanvasOnInit = useCallback(({ canvas }) => {
@@ -109,11 +108,19 @@ const onInit: HtmlInCanvasOnInit = useCallback(({ canvas }) => {
   };
 }, []);
 
-const onPaint: HtmlInCanvasOnPaint = useCallback(({ elementImage }) => {
-  gl.texElementImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, elementImage);
+const onPaint: HtmlInCanvasOnPaint = useCallback(({ element }) => {
+  gl.texElementImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, element);
   gl.drawArrays(gl.TRIANGLES, 0, 6);
 }, []);
+
+return (
+  <HtmlInCanvas renderingContext="webgl2" onInit={onInit} onPaint={onPaint} width={1280} height={720}>
+    ...
+  </HtmlInCanvas>
+);
 ```
+
+`_experimentalEffects` cannot be combined with `renderingContext="webgl2"` or `"webgpu"`.
 
 For a fully working minimal example, see https://github.com/remotion-dev/remotion/blob/main/packages/docs/components/demos/HtmlInCanvasDocsDemoWebGL.tsx.
 

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -72,18 +72,18 @@ type TypeChild<PresentationProps extends Record<string, unknown>> =
 	| string;
 
 export type DrawFunction = (
-	prevImage: ElementImage | null,
-	nextImage: ElementImage | null,
+	prevImage: ImageBitmap | null,
+	nextImage: ImageBitmap | null,
 	progress: number,
 ) => void;
 
-type ElementImageAndProgress = {
-	elementImage: ElementImage | null;
+type FrameBitmapAndProgress = {
+	imageBitmap: ImageBitmap | null;
 	progress: number | null;
 	draw: DrawFunction | null;
 };
 
-type ImageMap = Record<number, ElementImageAndProgress>;
+type ImageMap = Record<number, FrameBitmapAndProgress>;
 
 const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 	children,
@@ -101,26 +101,26 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 	const drawIfSynced = useCallback((index: number) => {
 		const prevImage = prevImageRef?.current?.[index];
 		const nextImage = nextImageRef?.current?.[index];
-		if (!nextImage?.elementImage && prevImage?.elementImage) {
+		if (!nextImage?.imageBitmap && prevImage?.imageBitmap) {
 			nextImage?.draw?.(null, null, 0);
-			prevImage?.draw?.(prevImage?.elementImage ?? null, null, 0);
+			prevImage?.draw?.(prevImage?.imageBitmap ?? null, null, 0);
 			return;
 		}
 
-		if (!prevImage?.elementImage && nextImage?.elementImage) {
+		if (!prevImage?.imageBitmap && nextImage?.imageBitmap) {
 			prevImage?.draw?.(null, null, 0);
-			nextImage?.draw?.(null, nextImage?.elementImage ?? null, 0);
+			nextImage?.draw?.(null, nextImage?.imageBitmap ?? null, 0);
 			return;
 		}
 
 		if (
 			(prevImage && nextImage && prevImage.progress === nextImage.progress) ||
-			!prevImage?.elementImage ||
-			!nextImage?.elementImage
+			!prevImage?.imageBitmap ||
+			!nextImage?.imageBitmap
 		) {
 			prevImage?.draw?.(
-				prevImage?.elementImage ?? null,
-				nextImage?.elementImage ?? null,
+				prevImage?.imageBitmap ?? null,
+				nextImage?.imageBitmap ?? null,
 				prevImage?.progress ?? nextImage?.progress ?? 0,
 			);
 			nextImage?.draw?.(null, null, 0);
@@ -129,12 +129,12 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 
 	const onNextElementImage = useCallback(
 		(
-			elementImage: ElementImage | null,
+			imageBitmap: ImageBitmap | null,
 			progress: number | null,
 			draw: DrawFunction | null,
 			index: number,
 		) => {
-			prevImageRef.current[index] = {elementImage, progress, draw};
+			prevImageRef.current[index] = {imageBitmap, progress, draw};
 
 			drawIfSynced(index);
 		},
@@ -143,12 +143,12 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 
 	const onPrevElementImage = useCallback(
 		(
-			elementImage: ElementImage | null,
+			imageBitmap: ImageBitmap | null,
 			progress: number | null,
 			draw: DrawFunction | null,
 			index: number,
 		) => {
-			nextImageRef.current[index] = {elementImage, progress, draw};
+			nextImageRef.current[index] = {imageBitmap, progress, draw};
 
 			drawIfSynced(index);
 		},

--- a/packages/transitions/src/html-in-canvas-presentation.tsx
+++ b/packages/transitions/src/html-in-canvas-presentation.tsx
@@ -132,15 +132,26 @@ export const HtmlInCanvasPresentation = <
 
 		canvas.layoutSubtree = true;
 
-		const onPaint = () => {
+		const onPaint = async () => {
 			const firstChild = canvas.firstChild as HTMLElement;
 
 			if (!firstChild) {
 				return;
 			}
 
-			const elementImage = canvas.captureElementImage(firstChild);
-			onElementImage(elementImage, draw);
+			const ctx = canvas.getContext('2d');
+			if (!ctx) {
+				throw new Error(
+					'Failed to acquire 2D context for HtmlInCanvas transition canvas',
+				);
+			}
+
+			const handle = delayRender('HtmlInCanvas transition capture');
+			ctx.reset();
+			ctx.drawElementImage(firstChild, 0, 0);
+			const bitmap = await createImageBitmap(canvas);
+			continueRender(handle);
+			onElementImage(bitmap, draw);
 		};
 
 		canvas.addEventListener('paint', onPaint);
@@ -148,7 +159,14 @@ export const HtmlInCanvasPresentation = <
 		return () => {
 			canvas.removeEventListener('paint', onPaint);
 		};
-	}, [onElementImage, presentationDirection, draw, passThrough]);
+	}, [
+		onElementImage,
+		presentationDirection,
+		draw,
+		passThrough,
+		delayRender,
+		continueRender,
+	]);
 
 	useLayoutEffect(() => {
 		if (passThrough) {
@@ -205,8 +223,8 @@ export const HtmlInCanvasPresentation = <
 };
 
 export type HtmlInCanvasShaderDrawParams<Props> = {
-	prevImage: ElementImage | null;
-	nextImage: ElementImage | null;
+	prevImage: ImageBitmap | null;
+	nextImage: ImageBitmap | null;
 	width: number;
 	height: number;
 	time: number;

--- a/packages/transitions/src/presentations/zoom-blur.tsx
+++ b/packages/transitions/src/presentations/zoom-blur.tsx
@@ -216,7 +216,7 @@ export const zoomBlurShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
+			gl.texImage2D(
 				gl.TEXTURE_2D,
 				0,
 				gl.RGBA,
@@ -231,7 +231,7 @@ export const zoomBlurShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
+			gl.texImage2D(
 				gl.TEXTURE_2D,
 				0,
 				gl.RGBA,

--- a/packages/transitions/src/presentations/zoom-in-out.tsx
+++ b/packages/transitions/src/presentations/zoom-in-out.tsx
@@ -178,7 +178,7 @@ export const zoomInOutShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
+			gl.texImage2D(
 				gl.TEXTURE_2D,
 				0,
 				gl.RGBA,
@@ -193,7 +193,7 @@ export const zoomInOutShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
+			gl.texImage2D(
 				gl.TEXTURE_2D,
 				0,
 				gl.RGBA,

--- a/packages/transitions/src/types.ts
+++ b/packages/transitions/src/types.ts
@@ -35,7 +35,7 @@ export type TransitionPresentationComponentProps<
 	presentationDirection: PresentationDirection;
 	passedProps: PresentationProps;
 	presentationDurationInFrames: number;
-	onElementImage: (elementImage: ElementImage, draw: DrawFunction) => void;
+	onElementImage: (imageBitmap: ImageBitmap, draw: DrawFunction) => void;
 	onUnmount: () => void;
 	bothEnteringAndExiting: boolean;
 };


### PR DESCRIPTION
## Summary

- Removes the internal `OffscreenCanvas` scratch surface from `<HtmlInCanvas>` and paints directly on the layout canvas, matching Chromium’s new rule that `ElementImage` / DOM children may only be drawn on the canvas they belong to ([crbug/500074335](https://issues.chromium.org/issues/500074335), landed in [dbe9c63](https://chromium.googlesource.com/chromium/src/+/dbe9c63eb518f68fe93d9fc839ce3d973a0aebce)).
- Default path uses `ctx.drawElementImage(element, …)` and runs `_experimentalEffects` with `source === output` on the same canvas, fixing effects in Chrome Canary (remotion-dev/remotion#7458).
- **Breaking API:** `onPaint` / `onInit` now receive `HTMLCanvasElement`, `element`, and optional `ctx` (2D mode). `elementImage` is removed. New `renderingContext` prop (`'2d' | 'webgl2' | 'webgpu'`) for custom GPU handlers.
- Html-in-canvas transitions rasterize via `drawElementImage` + `createImageBitmap` and composite with `texImage2D` instead of cross-canvas `texElementImage2D`.

## Test plan

- [ ] Open `experimental-controls-showcase` in Chrome Canary with HTML-in-Canvas enabled — effects should render without `InvalidStateError`.
- [ ] Verify `html-in-canvas-docs-demo-2d-blur`, WebGL, and WebGPU docs demos in the example package.
- [ ] Test a transition using `makeHtmlInCanvasPresentation` (e.g. zoom blur) between two sequences.
- [ ] Confirm custom `onPaint` examples still work with `renderingContext="webgl2"` / `"webgpu"`.


Made with [Cursor](https://cursor.com)