### PR TITLE
`@remotion/rive`: Integrate effects system with Rive

### DIFF
--- a/packages/docs/docs/rive/remotionrivecanvas.mdx
+++ b/packages/docs/docs/rive/remotionrivecanvas.mdx
@@ -113,6 +113,18 @@ export const MyComp: React.FC = () => {
 };
 ```
 
+### `className?`<AvailableFrom v="4.0.464" />
+
+A class name to apply to the underlying `<canvas>` element.
+
+### `style?`<AvailableFrom v="4.0.464" />
+
+Inline styles to apply to the underlying `<canvas>` element.
+
+## Inherited props<AvailableFrom v="4.0.464" />
+
+`<RemotionRiveCanvas>` inherits [`from`](/docs/sequence#from), [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`showInTimeline`](/docs/sequence#showintimeline) and [`hidden`](/docs/sequence#hidden) from [`<Sequence>`](/docs/sequence).
+
 ## Ref<AvailableFrom v="4.0.180" />
 
 You can attach a ref to the component to access the Rive Canvas instance.

--- a/packages/example/src/ExperimentalControls/index.tsx
+++ b/packages/example/src/ExperimentalControls/index.tsx
@@ -1,6 +1,7 @@
 import {Gif} from '@remotion/gif';
 import {LightLeak} from '@remotion/light-leaks';
 import {Audio, Video} from '@remotion/media';
+import {RemotionRiveCanvas} from '@remotion/rive';
 import {Starburst} from '@remotion/starburst';
 import React from 'react';
 import {
@@ -230,6 +231,17 @@ export const ExperimentalControlsShowcase: React.FC = () => {
 				</Tile>
 				<Tile title="Solid">
 					<Solid color="red" width={100} height={100} />
+				</Tile>
+				<Tile title="RemotionRiveCanvas">
+					<RemotionRiveCanvas
+						src="https://cdn.rive.app/animations/vehicles.riv"
+						style={{
+							width: '100%',
+							height: '100%',
+							translate: '0px 20px',
+							scale: 0.95,
+						}}
+					/>
 				</Tile>
 			</div>
 		</AbsoluteFill>

--- a/packages/example/src/Rive/RiveEffects.tsx
+++ b/packages/example/src/Rive/RiveEffects.tsx
@@ -1,0 +1,210 @@
+import {blur} from '@remotion/effects/blur';
+import {halftone} from '@remotion/effects/halftone';
+import {tint} from '@remotion/effects/tint';
+import {wave} from '@remotion/effects/wave';
+import {RemotionRiveCanvas} from '@remotion/rive';
+import {StudioInternals} from '@remotion/studio';
+import React from 'react';
+import {AbsoluteFill, useCurrentFrame, useVideoConfig} from 'remotion';
+
+const RIVE_SRC = 'https://cdn.rive.app/animations/vehicles.riv';
+
+const Tile: React.FC<{
+	readonly title: string;
+	readonly subtitle: string;
+	readonly children: React.ReactNode;
+}> = ({title, subtitle, children}) => {
+	return (
+		<div
+			style={{
+				flex: 1,
+				display: 'flex',
+				flexDirection: 'column',
+				border: '1px solid #1f2937',
+				borderRadius: 12,
+				overflow: 'hidden',
+				backgroundColor: '#000',
+				minWidth: 0,
+				minHeight: 0,
+			}}
+		>
+			<div
+				style={{
+					padding: '10px 14px',
+					backgroundColor: '#0b1220',
+					borderBottom: '1px solid #1f2937',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: 2,
+				}}
+			>
+				<div
+					style={{
+						fontFamily: 'monospace',
+						fontSize: 18,
+						color: '#f8fafc',
+						fontWeight: 700,
+					}}
+				>
+					{title}
+				</div>
+				<div
+					style={{
+						fontFamily: 'monospace',
+						fontSize: 12,
+						color: '#94a3b8',
+					}}
+				>
+					{subtitle}
+				</div>
+			</div>
+			<div
+				style={{
+					flex: 1,
+					position: 'relative',
+					overflow: 'hidden',
+				}}
+			>
+				{children}
+			</div>
+		</div>
+	);
+};
+
+const tileRiveStyle: React.CSSProperties = {
+	width: '100%',
+	height: '100%',
+};
+
+const AnimatedBlurRive: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	// Pulse the blur radius between 0 and 18px to verify that the canvas is
+	// redrawn when an effect parameter changes, even between Rive frames.
+	const t = (frame / fps) * Math.PI * 2 * 0.35;
+	const blurRadius = 9 + 9 * Math.sin(t);
+
+	return (
+		<RemotionRiveCanvas
+			src={RIVE_SRC}
+			style={tileRiveStyle}
+			_experimentalEffects={[blur({radius: blurRadius})]}
+		/>
+	);
+};
+
+const AnimatedWaveRive: React.FC = () => {
+	const frame = useCurrentFrame();
+	const evolution = frame * 0.2;
+
+	return (
+		<RemotionRiveCanvas
+			src={RIVE_SRC}
+			style={tileRiveStyle}
+			_experimentalEffects={[
+				wave({
+					amplitude: 22,
+					wavelength: 180,
+					evolution,
+					sliceWidth: 4,
+					background: '#020617',
+				}),
+			]}
+		/>
+	);
+};
+
+const StackedRive: React.FC = () => {
+	const frame = useCurrentFrame();
+	const evolution = frame * 0.2;
+
+	return (
+		<RemotionRiveCanvas
+			src={RIVE_SRC}
+			style={tileRiveStyle}
+			_experimentalEffects={[
+				tint({color: '#ff5fa2', amount: 0.4}),
+				wave({
+					amplitude: 12,
+					wavelength: 160,
+					evolution,
+					sliceWidth: 4,
+					background: '#020617',
+				}),
+				blur({radius: 6}),
+			]}
+		/>
+	);
+};
+
+const Comp: React.FC = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: '#020617',
+				padding: 24,
+				gap: 16,
+				display: 'flex',
+				flexDirection: 'column',
+			}}
+		>
+			<div
+				style={{
+					fontFamily: 'monospace',
+					fontSize: 28,
+					color: '#f8fafc',
+					fontWeight: 700,
+				}}
+			>
+				@remotion/rive effects testbed
+			</div>
+			<div style={{flex: 1, display: 'flex', flexDirection: 'row', gap: 16}}>
+				<Tile title="baseline" subtitle="no effects">
+					<RemotionRiveCanvas src={RIVE_SRC} style={tileRiveStyle} />
+				</Tile>
+				<Tile title="tint" subtitle="color: '#ff5fa2', amount: 0.6">
+					<RemotionRiveCanvas
+						src={RIVE_SRC}
+						style={tileRiveStyle}
+						_experimentalEffects={[tint({color: '#ff5fa2', amount: 0.6})]}
+					/>
+				</Tile>
+				<Tile title="halftone" subtitle="circles, dotSize 12, on luminance">
+					<RemotionRiveCanvas
+						src={RIVE_SRC}
+						style={tileRiveStyle}
+						_experimentalEffects={[
+							halftone({
+								shape: 'circle',
+								dotSize: 12,
+								dotSpacing: 12,
+								color: '#000',
+							}),
+						]}
+					/>
+				</Tile>
+			</div>
+			<div style={{flex: 1, display: 'flex', flexDirection: 'row', gap: 16}}>
+				<Tile title="blur" subtitle="separable Gaussian, animated 0→18">
+					<AnimatedBlurRive />
+				</Tile>
+				<Tile title="wave" subtitle="amplitude 22, evolution from frame">
+					<AnimatedWaveRive />
+				</Tile>
+				<Tile title="tint + wave + blur" subtitle="effect chain">
+					<StackedRive />
+				</Tile>
+			</div>
+		</AbsoluteFill>
+	);
+};
+
+export const RiveEffectsTestbed = StudioInternals.createComposition({
+	component: Comp,
+	id: 'rive-effects-testbed',
+	width: 1920,
+	height: 1080,
+	durationInFrames: 300,
+	fps: 30,
+});

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -86,6 +86,7 @@ import ReactSvg from './ReactSvg';
 import InfinityVideo from './ReallyLongVideo';
 import RemoteVideo from './RemoteVideo';
 import {RetryDelayRender} from './RetryDelayRender';
+import {RiveEffectsTestbed} from './Rive/RiveEffects';
 import RiveVehicle from './Rive/RiveExample';
 import {ScalePath} from './ScalePath';
 import {SchemaTest, schemaTestSchema} from './SchemaTest';
@@ -1663,6 +1664,7 @@ export const Index: React.FC = () => {
 					}}
 					durationInFrames={150}
 				/>
+				<RiveEffectsTestbed />
 			</Folder>
 			<Folder name="Premount">
 				<Composition

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -445,9 +445,12 @@ const RemotionRiveCanvasInnerForwardRefFunction: React.ForwardRefRenderFunction<
 		from,
 		showInTimeline,
 		hidden,
+		...props
 	},
 	ref,
 ) => {
+	props satisfies Record<string, never>;
+
 	const memoizedEffectDefinitions = useMemoizedEffectDefinitions(effects);
 
 	return (
@@ -460,6 +463,8 @@ const RemotionRiveCanvasInnerForwardRefFunction: React.ForwardRefRenderFunction<
 			durationInFrames={durationInFrames}
 			_experimentalControls={controls}
 			_experimentalEffects={memoizedEffectDefinitions}
+			// 'stack' is in props
+			{...props}
 		>
 			<RemotionRiveCanvasContent
 				ref={ref}

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -287,12 +287,67 @@ const RemotionRiveCanvasContentForwardRefFunction: React.ForwardRefRenderFunctio
 	}, [onLoad, rive]);
 
 	React.useEffect(() => {
-		if (!riveCanvasInstance) {
+		if (!riveCanvasInstance || !rive) {
 			return;
 		}
 
 		const outputCanvas = canvas.current;
 		if (!outputCanvas || !sourceCanvas) {
+			return;
+		}
+
+		// Keep source/output dimensions in sync with the video config.
+		if (sourceCanvas.width !== width || sourceCanvas.height !== height) {
+			sourceCanvas.width = width;
+			sourceCanvas.height = height;
+		}
+
+		if (outputCanvas.width !== width || outputCanvas.height !== height) {
+			outputCanvas.width = width;
+			outputCanvas.height = height;
+		}
+
+		const diff = frame - lastFrame.current;
+
+		rive.renderer.clear();
+
+		if (rive.animation) {
+			rive.animation.advance(diff / fps);
+			rive.animation.apply(1);
+		}
+
+		rive.artboard.advance(diff / fps);
+
+		rive.renderer.save();
+		rive.renderer.align(
+			mapToFit(fit, riveCanvasInstance),
+			mapToAlignment(alignment, riveCanvasInstance.Alignment),
+			{
+				minX: 0,
+				minY: 0,
+				maxX: sourceCanvas.width,
+				maxY: sourceCanvas.height,
+			},
+			rive.artboard.bounds,
+		);
+
+		rive.artboard.draw(rive.renderer);
+		rive.renderer.restore();
+
+		// Flush the renderer's queued draw calls so `sourceCanvas` actually
+		// contains the pixels we just drew before `runEffectChain` reads from
+		// it. We don't use `riveCanvasInstance.requestAnimationFrame` (which
+		// would flush implicitly at the end of its own callback) because the
+		// effect chain needs the flushed pixels synchronously, and waiting
+		// for a Rive-scheduled frame would mean the very first paint after
+		// mount (and after every prop change) would composite an empty /
+		// stale source canvas to the output.
+		riveCanvasInstance.resolveAnimationFrame();
+
+		lastFrame.current = frame;
+
+		const state = chainState.get(width, height);
+		if (!state) {
 			return;
 		}
 
@@ -302,79 +357,22 @@ const RemotionRiveCanvasContentForwardRefFunction: React.ForwardRefRenderFunctio
 
 		let cancelled = false;
 
-		riveCanvasInstance.requestAnimationFrame(() => {
-			if (cancelled) {
-				return;
-			}
-
-			if (!rive) {
-				continueRender(effectChainHandle);
-				return;
-			}
-
-			// Keep source/output dimensions in sync with the video config.
-			if (sourceCanvas.width !== width || sourceCanvas.height !== height) {
-				sourceCanvas.width = width;
-				sourceCanvas.height = height;
-			}
-
-			if (outputCanvas.width !== width || outputCanvas.height !== height) {
-				outputCanvas.width = width;
-				outputCanvas.height = height;
-			}
-
-			const diff = frame - lastFrame.current;
-
-			rive.renderer.clear();
-
-			if (rive.animation) {
-				rive.animation.advance(diff / fps);
-				rive.animation.apply(1);
-			}
-
-			rive.artboard.advance(diff / fps);
-
-			rive.renderer.save();
-			rive.renderer.align(
-				mapToFit(fit, riveCanvasInstance),
-				mapToAlignment(alignment, riveCanvasInstance.Alignment),
-				{
-					minX: 0,
-					minY: 0,
-					maxX: sourceCanvas.width,
-					maxY: sourceCanvas.height,
-				},
-				rive.artboard.bounds,
-			);
-
-			rive.artboard.draw(rive.renderer);
-			rive.renderer.restore();
-
-			lastFrame.current = frame;
-
-			const state = chainState.get(width, height);
-			if (!state) {
-				continueRender(effectChainHandle);
-				return;
-			}
-
-			runEffectChain({
-				state,
-				source: sourceCanvas,
-				effects: memoizedEffects,
-				output: outputCanvas,
-				width,
-				height,
+		runEffectChain({
+			state,
+			source: sourceCanvas,
+			effects: memoizedEffects,
+			output: outputCanvas,
+			width,
+			height,
+		})
+			.then(() => {
+				if (!cancelled) {
+					continueRender(effectChainHandle);
+				}
 			})
-				.then(() => {
-					if (!cancelled) {
-						continueRender(effectChainHandle);
-					}
-				})
-				.catch((newErr) => {
-					setError(newErr);
-				});
-		});
+			.catch((newErr) => {
+				setError(newErr);
+			});
 
 		return () => {
 			cancelled = true;

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -15,17 +15,45 @@ import React, {
 	useRef,
 	useState,
 } from 'react';
-import {useCurrentFrame, useDelayRender, useVideoConfig} from 'remotion';
+import type {
+	EffectsProp,
+	SequenceControls,
+	SequenceProps,
+	SequenceSchema,
+} from 'remotion';
+import {
+	Internals,
+	Sequence,
+	useCurrentFrame,
+	useDelayRender,
+	useVideoConfig,
+} from 'remotion';
 import type {
 	RemotionRiveCanvasAlignment,
 	RemotionRiveCanvasFit,
 } from './map-enums.js';
 import {mapToAlignment, mapToFit} from './map-enums.js';
 
+const {
+	addSequenceStackTraces,
+	hiddenField,
+	runEffectChain,
+	sequenceVisualStyleSchema,
+	useEffectChainState,
+	useMemoizedEffectDefinitions,
+	useMemoizedEffects,
+	wrapInSchema,
+} = Internals;
+
 type assetLoadCallback = (asset: FileAsset, bytes: Uint8Array) => boolean;
 type onLoadCallback = (file: File) => void;
 
-interface RiveProps {
+type RiveSequenceInheritedProps = Pick<
+	SequenceProps,
+	'durationInFrames' | 'name' | 'from' | 'showInTimeline' | 'hidden'
+>;
+
+type RemotionRiveCanvasOwnProps = {
 	readonly src: string;
 	readonly fit?: RemotionRiveCanvasFit;
 	readonly alignment?: RemotionRiveCanvasAlignment;
@@ -34,7 +62,13 @@ interface RiveProps {
 	readonly onLoad?: onLoadCallback | null;
 	readonly enableRiveAssetCdn?: boolean;
 	readonly assetLoader?: assetLoadCallback;
-}
+	readonly className?: string;
+	readonly style?: React.CSSProperties;
+	readonly _experimentalEffects?: EffectsProp;
+};
+
+export type RemotionRiveCanvasProps = RemotionRiveCanvasOwnProps &
+	RiveSequenceInheritedProps;
 
 export type RiveCanvasRef = {
 	getAnimationInstance: () => LinearAnimationInstance | null;
@@ -43,19 +77,76 @@ export type RiveCanvasRef = {
 	getCanvas: () => RiveCanvas | null;
 };
 
-const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
+const riveFitVariants: Record<RemotionRiveCanvasFit, SequenceSchema> = {
+	contain: {},
+	cover: {},
+	fill: {},
+	'fit-height': {},
+	'fit-width': {},
+	none: {},
+	'scale-down': {},
+};
+
+const riveAlignmentVariants: Record<
+	RemotionRiveCanvasAlignment,
+	SequenceSchema
+> = {
+	center: {},
+	'bottom-center': {},
+	'bottom-left': {},
+	'bottom-right': {},
+	'center-left': {},
+	'center-right': {},
+	'top-center': {},
+	'top-left': {},
+	'top-right': {},
+};
+
+const riveCanvasSchema = {
+	fit: {
+		type: 'enum',
+		default: 'contain',
+		description: 'Fit',
+		variants: riveFitVariants,
+	},
+	alignment: {
+		type: 'enum',
+		default: 'center',
+		description: 'Alignment',
+		variants: riveAlignmentVariants,
+	},
+	...sequenceVisualStyleSchema,
+	hidden: hiddenField,
+} as const satisfies SequenceSchema;
+
+type RemotionRiveCanvasContentProps = Omit<
+	RemotionRiveCanvasOwnProps,
+	'_experimentalEffects'
+> & {
+	readonly fit: RemotionRiveCanvasFit;
+	readonly alignment: RemotionRiveCanvasAlignment;
+	readonly enableRiveAssetCdn: boolean;
+	readonly effects: EffectsProp;
+	readonly controls: SequenceControls | undefined;
+};
+
+const RemotionRiveCanvasContentForwardRefFunction: React.ForwardRefRenderFunction<
 	RiveCanvasRef,
-	RiveProps
+	RemotionRiveCanvasContentProps
 > = (
 	{
 		src,
-		fit = 'contain',
-		alignment = 'center',
+		fit,
+		alignment,
 		artboard: artboardName,
 		animation: animationIndex,
 		onLoad = null,
 		assetLoader,
-		enableRiveAssetCdn = true,
+		enableRiveAssetCdn,
+		className,
+		style,
+		effects,
+		controls,
 	},
 	ref,
 ) => {
@@ -67,6 +158,23 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 	const {delayRender, continueRender} = useDelayRender();
 	const [handle] = useState(() => delayRender());
 	const lastFrame = useRef<number>(0);
+
+	// Rive draws to this offscreen-style canvas; the effect chain then
+	// composites from here onto the visible output canvas.
+	const sourceCanvas = useMemo(() => {
+		if (typeof document === 'undefined') {
+			return null;
+		}
+
+		return document.createElement('canvas');
+	}, []);
+
+	const chainState = useEffectChainState();
+
+	const memoizedEffects = useMemoizedEffects({
+		effects,
+		overrideId: controls?.overrideId ?? null,
+	});
 
 	if (err) {
 		throw err;
@@ -111,13 +219,14 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 	}, [handle, continueRender]);
 
 	useEffect(() => {
-		if (!riveCanvasInstance) {
+		if (!riveCanvasInstance || !sourceCanvas) {
 			return;
 		}
 
-		const renderer = riveCanvasInstance.makeRenderer(
-			canvas.current as HTMLCanvasElement,
-		);
+		sourceCanvas.width = width;
+		sourceCanvas.height = height;
+
+		const renderer = riveCanvasInstance.makeRenderer(sourceCanvas);
 
 		fetch(new Request(src))
 			.then((f) => f.arrayBuffer())
@@ -166,6 +275,9 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 		onLoad,
 		assetLoader,
 		enableRiveAssetCdn,
+		sourceCanvas,
+		width,
+		height,
 	]);
 
 	useEffect(() => {
@@ -179,9 +291,36 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 			return;
 		}
 
+		const outputCanvas = canvas.current;
+		if (!outputCanvas || !sourceCanvas) {
+			return;
+		}
+
+		const effectChainHandle = delayRender(
+			`Rendering frame at ${frame} of <RemotionRiveCanvas src="${src}"/>`,
+		);
+
+		let cancelled = false;
+
 		riveCanvasInstance.requestAnimationFrame(() => {
-			if (!rive || !canvas.current) {
+			if (cancelled) {
 				return;
+			}
+
+			if (!rive) {
+				continueRender(effectChainHandle);
+				return;
+			}
+
+			// Keep source/output dimensions in sync with the video config.
+			if (sourceCanvas.width !== width || sourceCanvas.height !== height) {
+				sourceCanvas.width = width;
+				sourceCanvas.height = height;
+			}
+
+			if (outputCanvas.width !== width || outputCanvas.height !== height) {
+				outputCanvas.width = width;
+				outputCanvas.height = height;
 			}
 
 			const diff = frame - lastFrame.current;
@@ -202,8 +341,8 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 				{
 					minX: 0,
 					minY: 0,
-					maxX: canvas.current.width,
-					maxY: canvas.current.height,
+					maxX: sourceCanvas.width,
+					maxY: sourceCanvas.height,
 				},
 				rive.artboard.bounds,
 			);
@@ -212,20 +351,151 @@ const RemotionRiveCanvasForwardRefFunction: React.ForwardRefRenderFunction<
 			rive.renderer.restore();
 
 			lastFrame.current = frame;
-		});
-	}, [frame, fps, rive, riveCanvasInstance, fit, alignment]);
 
-	const style: React.CSSProperties = useMemo(
+			const state = chainState.get(width, height);
+			if (!state) {
+				continueRender(effectChainHandle);
+				return;
+			}
+
+			runEffectChain({
+				state,
+				source: sourceCanvas,
+				effects: memoizedEffects,
+				output: outputCanvas,
+				width,
+				height,
+			})
+				.then(() => {
+					if (!cancelled) {
+						continueRender(effectChainHandle);
+					}
+				})
+				.catch((newErr) => {
+					setError(newErr);
+				});
+		});
+
+		return () => {
+			cancelled = true;
+			continueRender(effectChainHandle);
+		};
+	}, [
+		frame,
+		fps,
+		rive,
+		riveCanvasInstance,
+		fit,
+		alignment,
+		width,
+		height,
+		sourceCanvas,
+		memoizedEffects,
+		chainState,
+		delayRender,
+		continueRender,
+		src,
+	]);
+
+	const canvasStyle: React.CSSProperties = useMemo(
 		() => ({
 			height,
 			width,
+			...style,
 		}),
-		[height, width],
+		[height, style, width],
 	);
 
-	return <canvas ref={canvas} width={width} height={height} style={style} />;
+	return (
+		<canvas
+			ref={canvas}
+			width={width}
+			height={height}
+			className={className}
+			style={canvasStyle}
+		/>
+	);
 };
 
-export const RemotionRiveCanvas = forwardRef(
-	RemotionRiveCanvasForwardRefFunction,
+const RemotionRiveCanvasContent = forwardRef(
+	RemotionRiveCanvasContentForwardRefFunction,
 );
+
+const RemotionRiveCanvasInnerForwardRefFunction: React.ForwardRefRenderFunction<
+	RiveCanvasRef,
+	RemotionRiveCanvasProps & {
+		readonly _experimentalControls?: SequenceControls | undefined;
+	}
+> = (
+	{
+		src,
+		fit = 'contain',
+		alignment = 'center',
+		artboard,
+		animation,
+		onLoad = null,
+		assetLoader,
+		enableRiveAssetCdn = true,
+		className,
+		style,
+		_experimentalEffects: effects = [],
+		_experimentalControls: controls,
+		durationInFrames,
+		name,
+		from,
+		showInTimeline,
+		hidden,
+	},
+	ref,
+) => {
+	const memoizedEffectDefinitions = useMemoizedEffectDefinitions(effects);
+
+	return (
+		<Sequence
+			layout="none"
+			from={from}
+			hidden={hidden}
+			showInTimeline={showInTimeline}
+			name={name ?? '<RemotionRiveCanvas>'}
+			durationInFrames={durationInFrames}
+			_experimentalControls={controls}
+			_experimentalEffects={memoizedEffectDefinitions}
+		>
+			<RemotionRiveCanvasContent
+				ref={ref}
+				src={src}
+				fit={fit}
+				alignment={alignment}
+				artboard={artboard}
+				animation={animation}
+				onLoad={onLoad}
+				assetLoader={assetLoader}
+				enableRiveAssetCdn={enableRiveAssetCdn}
+				className={className}
+				style={style}
+				effects={effects}
+				controls={controls}
+			/>
+		</Sequence>
+	);
+};
+
+const RemotionRiveCanvasInner = forwardRef(
+	RemotionRiveCanvasInnerForwardRefFunction,
+);
+
+export const RemotionRiveCanvas = wrapInSchema(
+	RemotionRiveCanvasInner as unknown as React.ComponentType<
+		RemotionRiveCanvasProps & {
+			readonly _experimentalControls: SequenceControls | undefined;
+		}
+	>,
+	riveCanvasSchema,
+) as React.ForwardRefExoticComponent<
+	RemotionRiveCanvasProps & React.RefAttributes<RiveCanvasRef>
+>;
+
+addSequenceStackTraces(RemotionRiveCanvas);
+
+(RemotionRiveCanvas as unknown as {displayName: string}).displayName =
+	'RemotionRiveCanvas';

--- a/packages/rive/src/index.ts
+++ b/packages/rive/src/index.ts
@@ -1,1 +1,5 @@
-export {RemotionRiveCanvas, RiveCanvasRef} from './RemotionRiveCanvas.js';
+export {
+	RemotionRiveCanvas,
+	RemotionRiveCanvasProps,
+	RiveCanvasRef,
+} from './RemotionRiveCanvas.js';


### PR DESCRIPTION
## Summary

Closes #7470.

- Wraps `<RemotionRiveCanvas>` in a `<Sequence layout="none">` so it appears in
  the timeline and accepts inheritable Sequence props (`from`,
  `durationInFrames`, `name`, `showInTimeline`, `hidden`) — modeled after
  [`<Solid>`](https://www.remotion.dev/docs/solid).
- Attaches a schema (fit, alignment, visual style, hidden) to the canvas so
  the studio can render draggable controls.
- Hooks into the effects system through `_experimentalEffects`. Rive now
  draws to an internal source canvas, and the result is composited onto the
  visible canvas through `runEffectChain`. When effects change without the
  frame advancing, the chain is rerun so updated effect parameters take
  effect immediately.
- Exposes `className` and `style` props for the underlying `<canvas>`.

## Test plan

- [ ] `cd packages/rive && bun run formatting && bun run lint && bun run make`
- [ ] In the example studio, open the existing Rive composition and confirm
      it still renders identically.
- [ ] Add an `_experimentalEffects` chain (e.g. `[blur({radius: 8})]`) and
      verify the effect is applied to the Rive output.
- [ ] Toggle the `hidden` prop / studio eye icon and confirm the Rive canvas
      hides accordingly.

Made with [Cursor](https://cursor.com)