### PR TITLE
`@remotion/studio`: Consolidate timeline `showInTimeline` filtering

### DIFF
--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -8,9 +8,9 @@ import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {SplitterContainer} from '../Splitter/SplitterContainer';
 import {SplitterElement} from '../Splitter/SplitterElement';
 import {SplitterHandle} from '../Splitter/SplitterHandle';
-import {isTrackHidden} from './is-collapsed';
 import {MAX_TIMELINE_TRACKS} from './MaxTimelineTracks';
 import {SequencePropsObserver} from './SequencePropsObserver';
+import {shouldShowTrackInTimeline} from './should-show-track-in-timeline';
 import {SubscribeToNodePaths} from './SubscribeToNodePaths';
 import {timelineVerticalScroll} from './timeline-refs';
 import {TimelineDragHandler} from './TimelineDragHandler';
@@ -66,12 +66,8 @@ const TimelineInner: React.FC = () => {
 	const durationInFrames = videoConfig?.durationInFrames ?? 0;
 
 	const filtered = useMemo(() => {
-		return timeline.filter(
-			(t) =>
-				!isTrackHidden(t) &&
-				t.sequence.from <= durationInFrames &&
-				t.sequence.duration > 0 &&
-				t.sequence.showInTimeline,
+		return timeline.filter((t) =>
+			shouldShowTrackInTimeline(t, durationInFrames),
 		);
 	}, [durationInFrames, timeline]);
 

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -16,7 +16,6 @@ import {
 	ExpandedTracksGetterContext,
 	type GetIsExpanded,
 } from '../ExpandedTracksProvider';
-import {isTrackHidden} from './is-collapsed';
 import {MaxTimelineTracksReached} from './MaxTimelineTracks';
 import {TimelineSequence} from './TimelineSequence';
 import {TimelineTimePadding} from './TimelineTimeIndicators';
@@ -73,10 +72,6 @@ const TimelineTracksInner: React.FC<{
 			<div style={content}>
 				<TimelineTimePadding />
 				{timeline.map((track) => {
-					if (isTrackHidden(track)) {
-						return null;
-					}
-
 					const isExpanded =
 						track.nodePathInfo !== null && getIsExpanded(track.nodePathInfo);
 

--- a/packages/studio/src/components/Timeline/is-collapsed.ts
+++ b/packages/studio/src/components/Timeline/is-collapsed.ts
@@ -1,9 +1,0 @@
-import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
-
-export const isTrackHidden = (track: TrackWithHash): boolean => {
-	if (!track.sequence.parent) {
-		return false;
-	}
-
-	return !track.sequence.showInTimeline;
-};

--- a/packages/studio/src/components/Timeline/should-show-track-in-timeline.ts
+++ b/packages/studio/src/components/Timeline/should-show-track-in-timeline.ts
@@ -1,0 +1,27 @@
+import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
+
+// A track is shown in the timeline list when:
+// - The sequence opted-in via `showInTimeline` (the default).
+//   Children of a sequence with `showInTimeline: false` keep being listed
+//   on their own; their depth is independently flattened by
+//   `getTimelineNestedLevel` so the parent does not contribute an indent.
+// - The sequence has a positive duration.
+// - The sequence starts before the composition ends.
+export const shouldShowTrackInTimeline = (
+	track: TrackWithHash,
+	durationInFrames: number,
+): boolean => {
+	if (!track.sequence.showInTimeline) {
+		return false;
+	}
+
+	if (track.sequence.duration <= 0) {
+		return false;
+	}
+
+	if (track.sequence.from > durationInFrames) {
+		return false;
+	}
+
+	return true;
+};


### PR DESCRIPTION
## Summary

Fixes #7471.

`Timeline.tsx` previously used two overlapping checks for `showInTimeline`: it called `isTrackHidden(t)` (which only returned `true` for *children* with `showInTimeline: false`) and *also* filtered on `t.sequence.showInTimeline`. The second check fully subsumed the first, and `TimelineTracks.tsx` then re-ran `isTrackHidden` on an already-filtered list, where it could never be `true` — dead code.

This PR collapses the rules into a single, self-documenting predicate `shouldShowTrackInTimeline(track, durationInFrames)`. All visibility rules now live in one place:

```ts
if (!track.sequence.showInTimeline) return false;
if (track.sequence.duration <= 0) return false;
if (track.sequence.from > durationInFrames) return false;
return true;
```

- `is-collapsed.ts` (`isTrackHidden`) is deleted, along with its misleading naming.
- `Timeline.tsx` filter is now a single call to the new helper.
- The redundant `isTrackHidden` check inside `TimelineTracks.tsx` is removed.

Behavior is unchanged:
- A sequence with `showInTimeline: false` is hidden from the list (root or child).
- Its children still appear, because depth is independently flattened in `getTimelineNestedLevel` (the hidden parent doesn't contribute an indent), as called out in a comment on the new helper.

## Test plan

- [x] `bun test src/test/timeline.test.ts src/test/sequenced-timeline.test.ts src/test/big-timeline.test.ts` — all timeline tests pass.
- [x] `bunx turbo run make --filter='@remotion/studio'` — builds cleanly.
- [x] `bunx turbo run lint --filter='@remotion/studio'` — 0 errors (only pre-existing warnings).


Made with [Cursor](https://cursor.com)