### PR TITLE
Docs: Document PDF not supported on Lambda for still renders

### DIFF
--- a/packages/docs/docs/lambda/cli/still.mdx
+++ b/packages/docs/docs/lambda/cli/still.mdx
@@ -91,6 +91,8 @@ The file name of the media output as stored in the S3 bucket. By default, it is 
 
 <Options id="still-image-format" />
 
+`pdf` is not supported on Remotion Lambda due to function size constraints.
+
 ### `--jpeg-quality`
 
 [Value between 0 and 100 for JPEG rendering quality](/docs/config#setjpegquality). Doesn't work when rendering an image format other than JPEG.

--- a/packages/docs/docs/lambda/renderstillonlambda.mdx
+++ b/packages/docs/docs/lambda/renderstillonlambda.mdx
@@ -83,6 +83,8 @@ From v3.2.27, negative values are allowed, with `-1` being the last frame.
 
 See [`renderStill() -> imageFormat`](/docs/renderer/render-still#imageformat). Default: `"png"`.
 
+`pdf` is not supported on Remotion Lambda due to function size constraints.
+
 ### `onInit?`<AvailableFrom v="4.0.6" />
 
 A callback function that gets called when the render starts, useful to obtain the link to the logs even if the render fails.


### PR DESCRIPTION
## Summary

- Document that `pdf` is not supported for still renders on Remotion Lambda due to function size constraints.
- Updated `renderStillOnLambda()` and `npx remotion lambda still` docs.

## Test plan

- [ ] Verify docs render correctly on the docs site preview


Made with [Cursor](https://cursor.com)