### PR TITLE
fix(studio): show Html5Video and Html5Audio playback errors in preview panel

### DIFF
--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -18,6 +18,8 @@ import {useVolume} from '../use-amplification.js';
 import {useMediaInTimeline} from '../use-media-in-timeline.js';
 import {useMediaPlayback} from '../use-media-playback.js';
 import {useMediaTag} from '../use-media-tag.js';
+import {useReportMediaPlaybackError} from '../use-report-media-playback-error.js';
+import {MediaPlaybackError} from '../video/MediaPlaybackError.js';
 import {
 	useMediaMutedState,
 	useMediaVolumeState,
@@ -78,7 +80,6 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		toneFrequency,
 		useWebAudioApi,
 		onError,
-		onNativeError,
 		audioStreamIndex,
 		...nativeProps
 	} = props;
@@ -174,6 +175,8 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 	const getStack = useCallback(() => {
 		return _remotionInternalStack ?? null;
 	}, [_remotionInternalStack]);
+
+	const reportMediaPlaybackError = useReportMediaPlaybackError();
 
 	useMediaInTimeline({
 		volume,
@@ -272,6 +275,41 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 			current.removeEventListener('loadedmetadata', onLoadedMetadata);
 		};
 	}, [audioRef, src]);
+
+	useEffect(() => {
+		const {current} = audioRef;
+		if (!current) {
+			return;
+		}
+
+		const errorHandler = () => {
+			if (current.error) {
+				// eslint-disable-next-line no-console
+				console.error('Error occurred in audio', current?.error);
+
+				reportMediaPlaybackError({
+					onError,
+					error: new MediaPlaybackError({
+						message: `The browser threw an error while playing the audio ${src}: Code ${current.error.code} - ${current?.error?.message}. See https://remotion.dev/docs/media-playback-error for help. Pass an onError() prop to handle the error.`,
+						src,
+					}),
+				});
+			} else {
+				reportMediaPlaybackError({
+					onError,
+					error: new MediaPlaybackError({
+						message: `The browser threw an error while playing the audio ${src}`,
+						src,
+					}),
+				});
+			}
+		};
+
+		current.addEventListener('error', errorHandler, {once: true});
+		return () => {
+			current.removeEventListener('error', errorHandler);
+		};
+	}, [audioRef, onError, reportMediaPlaybackError, src]);
 
 	if (initialShouldPreMountAudioElements) {
 		return null;

--- a/packages/core/src/audio/AudioForRendering.tsx
+++ b/packages/core/src/audio/AudioForRendering.tsx
@@ -15,6 +15,7 @@ import {SequenceContext} from '../SequenceContext.js';
 import {useTimelinePosition} from '../timeline-position-state.js';
 import {useCurrentFrame} from '../use-current-frame.js';
 import {useDelayRender} from '../use-delay-render.js';
+import {MediaPlaybackError} from '../video/MediaPlaybackError.js';
 import {evaluateVolume} from '../volume-prop.js';
 import {warnAboutTooHighVolume} from '../volume-safeguard.js';
 import type {RemotionAudioProps} from './props.js';
@@ -22,7 +23,6 @@ import {useFrameForVolumeProp} from './use-audio-frame.js';
 
 type AudioForRenderingProps = RemotionAudioProps & {
 	readonly onDuration: (src: string, durationInSeconds: number) => void;
-	readonly onNativeError: React.ReactEventHandler<HTMLAudioElement>;
 };
 
 const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
@@ -41,7 +41,7 @@ const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
 		_remotionInternalNativeLoopPassed,
 		acceptableTimeShiftInSeconds,
 		name,
-		onNativeError,
+		onError,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
 		loopVolumeCurveBehavior,
@@ -176,14 +176,43 @@ const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
 			current?.addEventListener('loadedmetadata', didLoad, {once: true});
 		}
 
+		const errorHandler = () => {
+			if (current?.error) {
+				// eslint-disable-next-line no-console
+				console.error('Error occurred in audio', current?.error);
+
+				if (onError) {
+					return;
+				}
+
+				throw new MediaPlaybackError({
+					message: `The browser threw an error while playing the audio ${src}: Code ${current.error.code} - ${current?.error?.message}. See https://remotion.dev/docs/media-playback-error for help. Pass an onError() prop to handle the error.`,
+					src: src as string,
+				});
+			}
+
+			if (onError) {
+				return;
+			}
+
+			throw new MediaPlaybackError({
+				message: `The browser threw an error while playing the audio ${src}`,
+				src: src as string,
+			});
+		};
+
+		current?.addEventListener('error', errorHandler, {once: true});
+
 		// If tag gets unmounted, clear pending handles because video metadata is not going to load
 		return () => {
 			current?.removeEventListener('loadedmetadata', didLoad);
+			current?.removeEventListener('error', errorHandler);
 			continueRender(newHandle);
 		};
 	}, [
 		src,
 		onDuration,
+		onError,
 		needsToRenderAudioTag,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
@@ -195,7 +224,7 @@ const AudioForRenderingRefForwardingFunction: React.ForwardRefRenderFunction<
 		return null;
 	}
 
-	return <audio ref={audioRef} {...nativeProps} onError={onNativeError} />;
+	return <audio ref={audioRef} {...nativeProps} />;
 };
 
 export const AudioForRendering = forwardRef(

--- a/packages/core/src/audio/html5-audio.tsx
+++ b/packages/core/src/audio/html5-audio.tsx
@@ -2,7 +2,6 @@
 import React, {forwardRef, useCallback, useContext} from 'react';
 import {getAbsoluteSrc} from '../absolute-src.js';
 import {calculateMediaDuration} from '../calculate-media-duration.js';
-import {cancelRender} from '../cancel-render.js';
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {Loop} from '../loop/index.js';
 import {usePreload} from '../prefetch.js';
@@ -40,7 +39,6 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 		stack,
 		pauseWhenBuffering,
 		showInTimeline,
-		onError: onRemotionError,
 		...otherProps
 	} = props;
 	const {loop, ...propsOtherThanLoop} = props;
@@ -63,31 +61,6 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 	}
 
 	const preloadedSrc = usePreload(props.src);
-
-	const onError: React.ReactEventHandler<HTMLAudioElement> = useCallback(
-		(e) => {
-			// eslint-disable-next-line no-console
-			console.log(e.currentTarget.error);
-
-			// If there is no `loop` property, we don't need to get the duration
-			// and this does not need to be a fatal error
-			const errMessage = `Could not play audio with src ${preloadedSrc}: ${e.currentTarget.error}. See https://remotion.dev/docs/media-playback-error for help.`;
-
-			if (loop) {
-				if (onRemotionError) {
-					onRemotionError(new Error(errMessage));
-					return;
-				}
-
-				cancelRender(new Error(errMessage));
-			} else {
-				onRemotionError?.(new Error(errMessage));
-				// eslint-disable-next-line no-console
-				console.warn(errMessage);
-			}
-		},
-		[loop, onRemotionError, preloadedSrc],
-	);
 
 	const onDuration = useCallback(
 		(src: string, durationInSeconds: number) => {
@@ -178,7 +151,6 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 				onDuration={onDuration}
 				{...props}
 				ref={ref}
-				onNativeError={onError}
 				_remotionInternalNeedsDurationCalculation={Boolean(loop)}
 			/>
 		);
@@ -195,7 +167,6 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 			}
 			{...props}
 			ref={ref}
-			onNativeError={onError}
 			onDuration={onDuration}
 			// Proposal: Make this default to true in v5
 			pauseWhenBuffering={pauseWhenBuffering ?? false}

--- a/packages/core/src/test/audio-for-rendering.test.tsx
+++ b/packages/core/src/test/audio-for-rendering.test.tsx
@@ -59,7 +59,6 @@ describe('Register and unregister asset', () => {
 			muted: false,
 			volume: 50,
 			onDuration: mock(),
-			onNativeError: mock(),
 			audioStreamIndex: 0,
 		};
 		const {unmount} = render(
@@ -81,7 +80,6 @@ describe('Register and unregister asset', () => {
 			muted: false,
 			volume: 50,
 			onDuration: mock(),
-			onNativeError: mock(),
 			audioStreamIndex: 0,
 		};
 		expectToThrow(() => {

--- a/packages/core/src/use-report-media-playback-error.ts
+++ b/packages/core/src/use-report-media-playback-error.ts
@@ -13,7 +13,7 @@ export const useReportMediaPlaybackError = () => {
 			onError,
 		}: {
 			error: MediaPlaybackError;
-			onError: ((error: MediaPlaybackError) => void) | undefined;
+			onError: ((error: Error) => void) | undefined;
 		}) => {
 			if (onError) {
 				onError(error);

--- a/packages/core/src/use-report-media-playback-error.ts
+++ b/packages/core/src/use-report-media-playback-error.ts
@@ -1,0 +1,32 @@
+import {useCallback, useContext} from 'react';
+import {CompositionRenderErrorContext} from './composition-render-error-context.js';
+import {useRemotionEnvironment} from './use-remotion-environment.js';
+import type {MediaPlaybackError} from './video/MediaPlaybackError.js';
+
+export const useReportMediaPlaybackError = () => {
+	const {setError} = useContext(CompositionRenderErrorContext);
+	const {isStudio} = useRemotionEnvironment();
+
+	return useCallback(
+		({
+			error,
+			onError,
+		}: {
+			error: MediaPlaybackError;
+			onError: ((error: MediaPlaybackError) => void) | undefined;
+		}) => {
+			if (onError) {
+				onError(error);
+				return;
+			}
+
+			if (isStudio) {
+				setError(error);
+				return;
+			}
+
+			throw error;
+		},
+		[isStudio, setError],
+	);
+};

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -21,6 +21,7 @@ import {useVolume} from '../use-amplification.js';
 import {useMediaInTimeline} from '../use-media-in-timeline.js';
 import {useMediaPlayback} from '../use-media-playback.js';
 import {useMediaTag} from '../use-media-tag.js';
+import {useReportMediaPlaybackError} from '../use-report-media-playback-error.js';
 import {useVideoConfig} from '../use-video-config.js';
 import {VERSION} from '../version.js';
 import {
@@ -160,6 +161,8 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		return _remotionInternalStack ?? null;
 	}, [_remotionInternalStack]);
 
+	const reportMediaPlaybackError = useReportMediaPlaybackError();
+
 	useMediaInTimeline({
 		volume,
 		mediaVolume,
@@ -248,34 +251,20 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 				// eslint-disable-next-line no-console
 				console.error('Error occurred in video', current?.error);
 
-				// If user is handling the error, we don't cause an unhandled exception
-				if (onError) {
-					const err = new MediaPlaybackError({
-						message: `Code ${current.error.code}: ${current.error.message}`,
+				reportMediaPlaybackError({
+					onError,
+					error: new MediaPlaybackError({
+						message: `The browser threw an error while playing the video ${src}: Code ${current.error.code} - ${current?.error?.message}. See https://remotion.dev/docs/media-playback-error for help. Pass an onError() prop to handle the error.`,
 						src: src as string,
-					});
-					onError(err);
-					return;
-				}
-
-				throw new MediaPlaybackError({
-					message: `The browser threw an error while playing the video ${src}: Code ${current.error.code} - ${current?.error?.message}. See https://remotion.dev/docs/media-playback-error for help. Pass an onError() prop to handle the error.`,
-					src: src as string,
+					}),
 				});
 			} else {
-				// If user is handling the error, we don't cause an unhandled exception
-				if (onError) {
-					const err = new MediaPlaybackError({
+				reportMediaPlaybackError({
+					onError,
+					error: new MediaPlaybackError({
 						message: `The browser threw an error while playing the video ${src}`,
 						src: src as string,
-					});
-					onError(err);
-					return;
-				}
-
-				throw new MediaPlaybackError({
-					message: 'The browser threw an error while playing the video',
-					src: src as string,
+					}),
 				});
 			}
 		};
@@ -284,7 +273,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		return () => {
 			current.removeEventListener('error', errorHandler);
 		};
-	}, [onError, src]);
+	}, [onError, reportMediaPlaybackError, src]);
 
 	const currentOnDurationCallback =
 		useRef<VideoForPreviewProps['onDuration']>(onDuration);


### PR DESCRIPTION
## Summary

- When `<Html5Video>` or `<Html5Audio>` fails to load in Remotion Studio (missing file, 404, format error, etc.), the error is now shown in the **preview panel** via `ErrorLoader` instead of taking over the screen with the fullscreen `#remotion-error-overlay`.
- Adds `useReportMediaPlaybackError`, which routes `MediaPlaybackError` through `CompositionRenderErrorContext` in Studio. Outside Studio, behavior is unchanged: throws unless an `onError` prop is provided.
- Aligns Html5Audio with Html5Video: errors are handled via `addEventListener('error')` in preview, use `MediaPlaybackError`, and are always fatal unless `onError` is passed (removes the previous loop/non-loop split that only warned for non-loop failures).

Fixes #7000

## Problem

`MediaPlaybackError` (video) and plain errors (audio) were thrown or handled from native media `error` event handlers. React error boundaries do not catch errors from native event handlers, so throws became unhandled exceptions and were picked up by Studio's runtime error listener (fullscreen overlay) instead of the composition render error path.

Html5Audio additionally never wired its error handler to the `<audio>` element in preview, and non-loop failures only logged a warning.

## Test plan

- [ ] In Remotion Studio, use a composition with `<Html5Video src="nonexistent.mp4" />` and confirm the error appears in the preview panel (with `MediaPlaybackErrorExplainer`), not as a fullscreen overlay.
- [ ] In Remotion Studio, use a composition with `<Html5Audio src="nonexistent.mp3" />` and confirm the same preview-panel behavior.
- [ ] Confirm passing `onError` on `<Html5Video>` / `<Html5Audio>` still calls the handler and does not show the preview error UI.
- [ ] Confirm rendering with `npx remotion render` still fails appropriately when media cannot load (unchanged throw behavior outside Studio).