### PR TITLE
`@remotion/studio`: Fix timeline tick alignment

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
@@ -20,7 +20,7 @@ import {TimelineWidthContext} from './TimelineWidthProvider';
 export const TIMELINE_TIME_INDICATOR_HEIGHT = 39;
 
 const container: React.CSSProperties = {
-	height: TIMELINE_TIME_INDICATOR_HEIGHT - 4,
+	height: TIMELINE_TIME_INDICATOR_HEIGHT,
 	boxShadow: `0 0 4px ${TIMELINE_BACKGROUND}`,
 	position: 'absolute',
 	backgroundColor: TIMELINE_BACKGROUND,
@@ -140,7 +140,6 @@ const TimelineTimeIndicatorsInner: React.FC<{
 			...container,
 			width: windowWidth - SPLITTER_HANDLE_SIZE / 2,
 			overflow: 'hidden',
-			// Since
 			marginLeft: SPLITTER_HANDLE_SIZE / 2,
 			pointerEvents: 'none',
 		};

--- a/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
@@ -11,7 +11,6 @@ import {
 	TIMELINE_PADDING,
 } from '../../helpers/timeline-layout';
 import {renderFrame} from '../../state/render-frame';
-import {SPLITTER_HANDLE_SIZE} from '../Splitter/SplitterHandle';
 import {TimeValue} from '../TimeValue';
 import {timelineVerticalScroll} from './timeline-refs';
 import {getFrameIncrementFromWidth} from './timeline-scroll-logic';
@@ -138,9 +137,8 @@ const TimelineTimeIndicatorsInner: React.FC<{
 	const style: React.CSSProperties = useMemo(() => {
 		return {
 			...container,
-			width: windowWidth - SPLITTER_HANDLE_SIZE / 2,
+			width: windowWidth,
 			overflow: 'hidden',
-			marginLeft: SPLITTER_HANDLE_SIZE / 2,
 			pointerEvents: 'none',
 		};
 	}, [windowWidth]);
@@ -175,10 +173,7 @@ const TimelineTimeIndicatorsInner: React.FC<{
 					frame: index * fps,
 					style: {
 						...secondTick,
-						left:
-							frameInterval * index * fps +
-							TIMELINE_PADDING -
-							SPLITTER_HANDLE_SIZE / 2,
+						left: frameInterval * index * fps + TIMELINE_PADDING,
 					},
 					showTime: index > 0,
 				};
@@ -192,10 +187,7 @@ const TimelineTimeIndicatorsInner: React.FC<{
 					frame: index,
 					style: {
 						...tick,
-						left:
-							frameInterval * index +
-							TIMELINE_PADDING -
-							SPLITTER_HANDLE_SIZE / 2,
+						left: frameInterval * index + TIMELINE_PADDING,
 						height:
 							index % fps === 0
 								? 10

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -23,7 +23,6 @@ import {TimelineTimePadding} from './TimelineTimeIndicators';
 const content: React.CSSProperties = {
 	paddingLeft: TIMELINE_PADDING,
 	paddingRight: TIMELINE_PADDING,
-	paddingTop: 1,
 };
 
 const timelineContent: React.CSSProperties = {

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -23,6 +23,7 @@ import {TimelineTimePadding} from './TimelineTimeIndicators';
 const content: React.CSSProperties = {
 	paddingLeft: TIMELINE_PADDING,
 	paddingRight: TIMELINE_PADDING,
+	paddingTop: 1,
 };
 
 const timelineContent: React.CSSProperties = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7306

## Summary
- Made the timeline ruler overlay fill the same 39px header height reserved by layout, so ticks/header and tracks meet without a see-through gap.

## Testing
- `bun run build`
- `bun run stylecheck` (fails only at the documented `@remotion/lambda-go` Go 1.23 requirement; Studio formatting passed before that failure)
- `bunx turbo run formatting lint --filter='@remotion/studio' --no-update-notifier`
- `bunx turbo run make --filter='@remotion/studio' --no-update-notifier`
- `bunx turbo run test --filter='@remotion/studio' --no-update-notifier`
- Manual Studio verification at `http://localhost:3000`

[studio_timeline_tick_alignment.mp4](https://cursor.com/agents/bc-d9d54dde-4371-4bf9-ae21-304ad3ccf93f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_timeline_tick_alignment.mp4)
[Timeline tick alignment](https://cursor.com/agents/bc-d9d54dde-4371-4bf9-ae21-304ad3ccf93f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_timeline_tick_alignment.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9d54dde-4371-4bf9-ae21-304ad3ccf93f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9d54dde-4371-4bf9-ae21-304ad3ccf93f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

