### PR TITLE
`@remotion/media`: Buffer when exiting premount during first-frame decode

### DIFF
--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -17,13 +17,13 @@ import {
 	getScheduledTime,
 } from './audio/get-scheduled-time';
 import {drawPreviewOverlay} from './debug-overlay/preview-overlay';
-import type {DelayPlaybackIfNotPremounting} from './delay-playback-if-not-premounting';
 import {getDurationOrCompute} from './get-duration-or-compute';
 import {calculateEndTime, getTimeInSeconds} from './get-time-in-seconds';
 import {resolveAudioTrack} from './helpers/resolve-audio-track';
 import {isNetworkError} from './is-type-of-error';
 import type {Nonce, NonceManager} from './nonce-manager';
 import {makeNonceManager} from './nonce-manager';
+import {PremountAwareDelayPlayback} from './premount-aware-delay-playback';
 import type {SharedAudioContextForMediaPlayer} from './shared-audio-context-for-media-player';
 import type {VideoIteratorManager} from './video-iterator-manager';
 import {videoIteratorManager} from './video-iterator-manager';
@@ -81,10 +81,7 @@ export class MediaPlayer {
 
 	private initializationPromise: Promise<MediaPlayerInitResult> | null = null;
 
-	private bufferState: ReturnType<typeof useBufferState>;
-
-	private isPremounting: boolean;
-	private isPostmounting: boolean;
+	private premountAwareDelayPlayback: PremountAwareDelayPlayback;
 	private seekPromiseChain: Promise<unknown> = Promise.resolve();
 
 	constructor({
@@ -151,9 +148,11 @@ export class MediaPlayer {
 		this.audioStreamIndex = audioStreamIndex;
 		this.fps = fps;
 		this.debugOverlay = debugOverlay;
-		this.bufferState = bufferState;
-		this.isPremounting = isPremounting;
-		this.isPostmounting = isPostmounting;
+		this.premountAwareDelayPlayback = new PremountAwareDelayPlayback({
+			bufferState,
+			isPremounting,
+			isPostmounting,
+		});
 		this.sequenceDurationInFrames = durationInFrames;
 		this.nonceManager = makeNonceManager();
 		this.onVideoFrameCallback = onVideoFrameCallback;
@@ -513,23 +512,9 @@ export class MediaPlayer {
 		this.drawDebugOverlay();
 	}
 
-	private delayPlaybackHandleIfNotPremounting =
-		(): DelayPlaybackIfNotPremounting => {
-			if (this.isPremounting || this.isPostmounting) {
-				return {
-					unblock: () => {},
-					[Symbol.dispose]: () => {},
-				};
-			}
-
-			const {unblock} = this.bufferState.delayPlayback();
-			return {
-				unblock,
-				[Symbol.dispose]: () => {
-					unblock();
-				},
-			};
-		};
+	private delayPlaybackHandleIfNotPremounting = () => {
+		return this.premountAwareDelayPlayback.createHandle();
+	};
 
 	public pause(): void {
 		if (!this.playing) {
@@ -630,11 +615,11 @@ export class MediaPlayer {
 	}
 
 	public setIsPremounting(isPremounting: boolean): void {
-		this.isPremounting = isPremounting;
+		this.premountAwareDelayPlayback.setIsPremounting(isPremounting);
 	}
 
 	public setIsPostmounting(isPostmounting: boolean): void {
-		this.isPostmounting = isPostmounting;
+		this.premountAwareDelayPlayback.setIsPostmounting(isPostmounting);
 	}
 
 	public async setLoop(

--- a/packages/media/src/premount-aware-delay-playback.ts
+++ b/packages/media/src/premount-aware-delay-playback.ts
@@ -77,7 +77,13 @@ export class PremountAwareDelayPlayback {
 			armed = false;
 		};
 
-		const dispose = () => {
+		const entry: TrackedDelayHandle = {
+			arm,
+			disarm,
+			dispose: () => {},
+		};
+
+		entry.dispose = () => {
 			if (disposed) {
 				return;
 			}
@@ -87,7 +93,6 @@ export class PremountAwareDelayPlayback {
 			this.activeHandles.delete(entry);
 		};
 
-		const entry: TrackedDelayHandle = {arm, disarm, dispose};
 		this.activeHandles.add(entry);
 
 		if (this.shouldDelayPlayback()) {
@@ -95,8 +100,8 @@ export class PremountAwareDelayPlayback {
 		}
 
 		return {
-			unblock: dispose,
-			[Symbol.dispose]: dispose,
+			unblock: entry.dispose,
+			[Symbol.dispose]: entry.dispose,
 		};
 	}
 }

--- a/packages/media/src/premount-aware-delay-playback.ts
+++ b/packages/media/src/premount-aware-delay-playback.ts
@@ -1,0 +1,102 @@
+import type {useBufferState} from 'remotion';
+import type {DelayPlaybackIfNotPremounting} from './delay-playback-if-not-premounting';
+
+type TrackedDelayHandle = {
+	arm: () => void;
+	disarm: () => void;
+	dispose: () => void;
+};
+
+export class PremountAwareDelayPlayback {
+	private isPremounting: boolean;
+	private isPostmounting: boolean;
+	private readonly activeHandles = new Set<TrackedDelayHandle>();
+	private readonly delayPlayback: ReturnType<
+		typeof useBufferState
+	>['delayPlayback'];
+
+	constructor({
+		bufferState,
+		isPremounting,
+		isPostmounting,
+	}: {
+		bufferState: ReturnType<typeof useBufferState>;
+		isPremounting: boolean;
+		isPostmounting: boolean;
+	}) {
+		this.delayPlayback = bufferState.delayPlayback;
+		this.isPremounting = isPremounting;
+		this.isPostmounting = isPostmounting;
+	}
+
+	private shouldDelayPlayback(): boolean {
+		return !this.isPremounting && !this.isPostmounting;
+	}
+
+	private syncHandles(): void {
+		for (const handle of this.activeHandles) {
+			if (this.shouldDelayPlayback()) {
+				handle.arm();
+			} else {
+				handle.disarm();
+			}
+		}
+	}
+
+	public setIsPremounting(isPremounting: boolean): void {
+		this.isPremounting = isPremounting;
+		this.syncHandles();
+	}
+
+	public setIsPostmounting(isPostmounting: boolean): void {
+		this.isPostmounting = isPostmounting;
+		this.syncHandles();
+	}
+
+	public createHandle(): DelayPlaybackIfNotPremounting {
+		let armed = false;
+		let unblock: (() => void) | null = null;
+		let disposed = false;
+
+		const arm = () => {
+			if (armed || disposed) {
+				return;
+			}
+
+			unblock = this.delayPlayback().unblock;
+			armed = true;
+		};
+
+		const disarm = () => {
+			if (!armed) {
+				return;
+			}
+
+			unblock?.();
+			unblock = null;
+			armed = false;
+		};
+
+		const dispose = () => {
+			if (disposed) {
+				return;
+			}
+
+			disposed = true;
+			disarm();
+			this.activeHandles.delete(entry);
+		};
+
+		const entry: TrackedDelayHandle = {arm, disarm, dispose};
+		this.activeHandles.add(entry);
+
+		if (this.shouldDelayPlayback()) {
+			arm();
+		}
+
+		return {
+			unblock: dispose,
+			[Symbol.dispose]: dispose,
+		};
+	}
+}

--- a/packages/media/src/test/premount-aware-delay-playback.test.ts
+++ b/packages/media/src/test/premount-aware-delay-playback.test.ts
@@ -1,0 +1,109 @@
+import {expect, test} from 'vitest';
+import {PremountAwareDelayPlayback} from '../premount-aware-delay-playback';
+
+const makeBufferState = () => {
+	let activeBlocks = 0;
+
+	return {
+		getActiveBlocks: () => activeBlocks,
+		bufferState: {
+			delayPlayback: () => {
+				activeBlocks++;
+				let unblocked = false;
+				return {
+					unblock: () => {
+						if (!unblocked) {
+							unblocked = true;
+							activeBlocks--;
+						}
+					},
+				};
+			},
+		},
+	};
+};
+
+test('arms delay when not premounting', () => {
+	const {bufferState, getActiveBlocks} = makeBufferState();
+	const delayPlayback = new PremountAwareDelayPlayback({
+		bufferState,
+		isPremounting: false,
+		isPostmounting: false,
+	});
+
+	const handle = delayPlayback.createHandle();
+	expect(getActiveBlocks()).toBe(1);
+
+	handle.unblock();
+	expect(getActiveBlocks()).toBe(0);
+});
+
+test('does not arm delay while premounting', () => {
+	const {bufferState, getActiveBlocks} = makeBufferState();
+	const delayPlayback = new PremountAwareDelayPlayback({
+		bufferState,
+		isPremounting: true,
+		isPostmounting: false,
+	});
+
+	const handle = delayPlayback.createHandle();
+	expect(getActiveBlocks()).toBe(0);
+
+	delayPlayback.setIsPremounting(false);
+	expect(getActiveBlocks()).toBe(1);
+
+	handle.unblock();
+	expect(getActiveBlocks()).toBe(0);
+});
+
+test('disarms delay when re-entering premount', () => {
+	const {bufferState, getActiveBlocks} = makeBufferState();
+	const delayPlayback = new PremountAwareDelayPlayback({
+		bufferState,
+		isPremounting: false,
+		isPostmounting: false,
+	});
+
+	const handle = delayPlayback.createHandle();
+	expect(getActiveBlocks()).toBe(1);
+
+	delayPlayback.setIsPremounting(true);
+	expect(getActiveBlocks()).toBe(0);
+
+	handle.unblock();
+	expect(getActiveBlocks()).toBe(0);
+});
+
+test('does not arm delay while postmounting', () => {
+	const {bufferState, getActiveBlocks} = makeBufferState();
+	const delayPlayback = new PremountAwareDelayPlayback({
+		bufferState,
+		isPremounting: false,
+		isPostmounting: true,
+	});
+
+	const handle = delayPlayback.createHandle();
+	expect(getActiveBlocks()).toBe(0);
+
+	delayPlayback.setIsPostmounting(false);
+	expect(getActiveBlocks()).toBe(1);
+
+	handle.unblock();
+	expect(getActiveBlocks()).toBe(0);
+});
+
+test('dispose via Symbol.dispose unblocks', () => {
+	const {bufferState, getActiveBlocks} = makeBufferState();
+	const delayPlayback = new PremountAwareDelayPlayback({
+		bufferState,
+		isPremounting: false,
+		isPostmounting: false,
+	});
+
+	{
+		using _handle = delayPlayback.createHandle();
+		expect(getActiveBlocks()).toBe(1);
+	}
+
+	expect(getActiveBlocks()).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Add `PremountAwareDelayPlayback` helper that tracks active delay-playback handles and syncs them when premount/postmount state changes
- Wire `MediaPlayer` to use the helper so in-flight decode/seek work arms the player buffer when premount ends, and disarms again when re-entering premount

Fixes #7510

## Test plan

- [x] Added unit tests in `premount-aware-delay-playback.test.ts` covering arm on exit premount, disarm on re-enter premount, and postmount behavior
- [ ] Run `cd packages/media && npm test`


Made with [Cursor](https://cursor.com)