### PR TITLE
Docs: Make transition presentation hover-to-preview reliable

### DIFF
--- a/packages/docs/components/transitions/previews.tsx
+++ b/packages/docs/components/transitions/previews.tsx
@@ -21,7 +21,7 @@ import type {SlideDirection} from '@remotion/transitions/slide';
 import {slide} from '@remotion/transitions/slide';
 import type {WipeDirection} from '@remotion/transitions/wipe';
 import {wipe} from '@remotion/transitions/wipe';
-import React, {useEffect, useRef} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 import type {SpringConfig} from 'remotion';
 import {AbsoluteFill, measureSpring, spring, useVideoConfig} from 'remotion';
 import {
@@ -253,46 +253,53 @@ export const PresentationPreview: React.FC<{
 	readonly durationRestThreshold: number;
 }> = ({effect, durationRestThreshold}) => {
 	const ref = useRef<PlayerRef>(null);
+	const wrapperRef = useRef<HTMLDivElement>(null);
 
-	useEffect(() => {
-		const {current} = ref;
-		if (!current) {
-			return;
-		}
-
-		const callback = () => {
-			current?.seekTo(0);
-			current?.play();
-		};
-
-		current?.getContainerNode()?.addEventListener('pointerenter', callback);
-
-		return () => {
-			current
-				?.getContainerNode()
-				?.removeEventListener('pointerenter', callback);
-		};
+	const playFromStart = useCallback(() => {
+		ref.current?.seekTo(0);
+		ref.current?.play();
 	}, []);
 
+	// `pointerenter` only fires when the pointer transitions into the
+	// element, so if the cursor happens to already be inside the tile when
+	// the component mounts (very common on this page because the tiles are
+	// small and tightly packed), the first hover after page load is missed
+	// and the preview never plays. Trigger the preview once on mount in
+	// that case so the behavior is reliable.
+	useEffect(() => {
+		if (wrapperRef.current?.matches(':hover')) {
+			playFromStart();
+		}
+	}, [playFromStart]);
+
 	return (
-		<Player
-			ref={ref}
-			acknowledgeRemotionLicense
-			component={SampleTransition}
-			compositionHeight={presentationCompositionHeight}
-			compositionWidth={presentationCompositionWidth}
-			durationInFrames={60}
-			fps={30}
-			numberOfSharedAudioTags={0}
+		<div
+			ref={wrapperRef}
+			onPointerEnter={playFromStart}
 			style={{
-				height: 60,
+				display: 'flex',
 				borderRadius: 6,
+				overflow: 'hidden',
 			}}
-			inputProps={{
-				effect,
-				durationRestThreshold,
-				small: true,
-			}}
-		/>
+		>
+			<Player
+				ref={ref}
+				acknowledgeRemotionLicense
+				component={SampleTransition}
+				compositionHeight={presentationCompositionHeight}
+				compositionWidth={presentationCompositionWidth}
+				durationInFrames={60}
+				fps={30}
+				numberOfSharedAudioTags={0}
+				style={{
+					height: 60,
+				}}
+				inputProps={{
+					effect,
+					durationRestThreshold,
+					small: true,
+				}}
+			/>
+		</div>
 	);
 };


### PR DESCRIPTION
## Summary

On https://www.remotion.dev/docs/transitions/, the Table of Contents shows a tile per transition presentation. Hovering a tile is supposed to play the preview, but it doesn't work reliably (issue #7528).

### Root cause

The previous implementation attached a `pointerenter` listener imperatively inside a `useEffect`, targeting the `<Player>`'s container via `getContainerNode()`:

```tsx
useEffect(() => {
  const {current} = ref;
  if (!current) return;
  const callback = () => { current?.seekTo(0); current?.play(); };
  current?.getContainerNode()?.addEventListener('pointerenter', callback);
  return () => current?.getContainerNode()?.removeEventListener('pointerenter', callback);
}, []);
```

`useEffect` runs after commit, hydration and paint. `pointerenter` only fires when the pointer transitions **into** the element — if the cursor is already over the tile by the time the listener attaches, the event never fires and the first hover is silently missed. This is very easy to trigger on this page because:

- there are many small tiles next to each other, so the cursor often lands over one after navigation/scroll,
- the page is SSR'd by Docusaurus and the listener only attaches after hydration,
- `PlayerUI` briefly returns `null` until its composition config resolves and then mounts the container under a stationary cursor.

### Fix

- Wrap each `<Player>` in a div with React's synthetic `onPointerEnter`, so React attaches the listener during commit (more idiomatic and less timing-sensitive than imperative `addEventListener`).
- Additionally, on mount, check `wrapperRef.current?.matches(':hover')` and trigger the preview if the cursor is already inside the wrapper. This covers the cursor-already-inside case that `pointerenter` cannot.

`borderRadius` is moved from the inner `<Player>` style to the wrapper (with `overflow: hidden`) so the visual remains unchanged.

Fixes #7528

## Test plan

- [ ] Open `/docs/transitions/` and reload with the cursor parked over a presentation tile — preview plays immediately.
- [ ] Move the cursor away and back into a tile — preview restarts as before.
- [ ] Navigate to the page via client-side routing with the cursor over the tile area — preview plays.

Made with [Cursor](https://cursor.com)