### PR TITLE
Docs: Replace `<Img>` with `<HtmlInCanvas>` in effects intro

### DIFF
--- a/packages/docs/docs/effects/index.mdx
+++ b/packages/docs/docs/effects/index.mdx
@@ -7,7 +7,7 @@ title: '@remotion/effects'
 
 # @remotion/effects<AvailableFrom v="4.0.464" />
 
-Effects that can be applied to Remotion-based canvas components such as [`<Solid>`](/docs/solid), [`<Img>`](/docs/img), and [`<Video>`](/docs/media/video).
+Effects that can be applied to Remotion-based canvas components such as [`<Solid>`](/docs/solid), [`<HtmlInCanvas>`](/docs/remotion/html-in-canvas), and [`<Video>`](/docs/media/video).
 
 import {TableOfContents} from './table-of-contents';
 


### PR DESCRIPTION
## Summary

- The `@remotion/effects` docs intro listed `<Img>` as an example of a Remotion-based canvas component that supports effects, but `<Img>` does not accept the `effects` prop and is not canvas-based.
- Replace it with `<HtmlInCanvas>`, which actually supports `effects`.
- Other monorepo locations that mention "Effects that can be applied to Remotion-based canvas components" (`packages/effects/README.md`, `packages/effects/package.json`, `packages/studio-shared/src/package-info.ts`) do not enumerate specific components, so no further changes are needed there.

Closes #7530

## Test plan

- [ ] Docs build succeeds
- [ ] `/docs/effects/api` renders the corrected sentence with a working link to `/docs/remotion/html-in-canvas`


Made with [Cursor](https://cursor.com)