### PR TITLE
Docs: Fix transition hover preview with initiallyMuted (revert #7529)

### DIFF
--- a/packages/docs/components/transitions/previews.tsx
+++ b/packages/docs/components/transitions/previews.tsx
@@ -21,7 +21,7 @@ import type {SlideDirection} from '@remotion/transitions/slide';
 import {slide} from '@remotion/transitions/slide';
 import type {WipeDirection} from '@remotion/transitions/wipe';
 import {wipe} from '@remotion/transitions/wipe';
-import React, {useCallback, useEffect, useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import type {SpringConfig} from 'remotion';
 import {AbsoluteFill, measureSpring, spring, useVideoConfig} from 'remotion';
 import {
@@ -253,53 +253,47 @@ export const PresentationPreview: React.FC<{
 	readonly durationRestThreshold: number;
 }> = ({effect, durationRestThreshold}) => {
 	const ref = useRef<PlayerRef>(null);
-	const wrapperRef = useRef<HTMLDivElement>(null);
 
-	const playFromStart = useCallback(() => {
-		ref.current?.seekTo(0);
-		ref.current?.play();
+	useEffect(() => {
+		const {current} = ref;
+		if (!current) {
+			return;
+		}
+
+		const callback = () => {
+			current?.seekTo(0);
+			current?.play();
+		};
+
+		current?.getContainerNode()?.addEventListener('pointerenter', callback);
+
+		return () => {
+			current
+				?.getContainerNode()
+				?.removeEventListener('pointerenter', callback);
+		};
 	}, []);
 
-	// `pointerenter` only fires when the pointer transitions into the
-	// element, so if the cursor happens to already be inside the tile when
-	// the component mounts (very common on this page because the tiles are
-	// small and tightly packed), the first hover after page load is missed
-	// and the preview never plays. Trigger the preview once on mount in
-	// that case so the behavior is reliable.
-	useEffect(() => {
-		if (wrapperRef.current?.matches(':hover')) {
-			playFromStart();
-		}
-	}, [playFromStart]);
-
 	return (
-		<div
-			ref={wrapperRef}
-			onPointerEnter={playFromStart}
+		<Player
+			ref={ref}
+			acknowledgeRemotionLicense
+			component={SampleTransition}
+			compositionHeight={presentationCompositionHeight}
+			compositionWidth={presentationCompositionWidth}
+			durationInFrames={60}
+			fps={30}
+			initiallyMuted
+			numberOfSharedAudioTags={0}
 			style={{
-				display: 'flex',
+				height: 60,
 				borderRadius: 6,
-				overflow: 'hidden',
 			}}
-		>
-			<Player
-				ref={ref}
-				acknowledgeRemotionLicense
-				component={SampleTransition}
-				compositionHeight={presentationCompositionHeight}
-				compositionWidth={presentationCompositionWidth}
-				durationInFrames={60}
-				fps={30}
-				numberOfSharedAudioTags={0}
-				style={{
-					height: 60,
-				}}
-				inputProps={{
-					effect,
-					durationRestThreshold,
-					small: true,
-				}}
-			/>
-		</div>
+			inputProps={{
+				effect,
+				durationRestThreshold,
+				small: true,
+			}}
+		/>
 	);
 };


### PR DESCRIPTION
## Summary

Reverts the approach from #7529, which wrapped each preview `<Player>` in a div with synthetic `onPointerEnter` and a `:hover` check on mount. That did not fix the unreliable hover-to-preview on `/docs/transitions/`.

The actual issue is that the player waits for the `AudioContext` to resume while unmuted. Without a user gesture, the context stays suspended and playback never starts on hover.

Fix: pass `initiallyMuted` to the preview `<Player>` so playback is not blocked on audio context resume. These previews have `numberOfSharedAudioTags={0}` and no audio anyway.

Reverts #7529
Fixes #7528

## Test plan

- [ ] Open `/docs/transitions/` and hover presentation tiles — preview plays reliably.
- [ ] Move cursor away and back — preview restarts on each hover.
- [ ] Reload with cursor over a tile and hover again — preview plays.


Made with [Cursor](https://cursor.com)