### PR TITLE
`@remotion/it-tests`: Fix flaky google-fonts no-dev-files test

### DIFF
--- a/packages/google-fonts/package.json
+++ b/packages/google-fonts/package.json
@@ -7,9 +7,6 @@
 	"description": "Use Google Fonts in Remotion",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.mjs",
-	"files": [
-		"dist"
-	],
 	"scripts": {
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
 		"generate": "bun --env-file=.env scripts/update-font-db.ts",

--- a/packages/google-fonts/package.json
+++ b/packages/google-fonts/package.json
@@ -7,6 +7,9 @@
 	"description": "Use Google Fonts in Remotion",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.mjs",
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts",
 		"generate": "bun --env-file=.env scripts/update-font-db.ts",

--- a/packages/it-tests/src/monorepo/no-dev-files.test.ts
+++ b/packages/it-tests/src/monorepo/no-dev-files.test.ts
@@ -5,39 +5,73 @@ import {getAllPackages} from './get-all-packages';
 
 const packages = getAllPackages();
 
+const MAX_CONCURRENT_PACK_CHECKS = 8;
+let activePackChecks = 0;
+const packCheckQueue: Array<() => void> = [];
+
+const acquirePackCheckSlot = async (): Promise<() => void> => {
+	while (activePackChecks >= MAX_CONCURRENT_PACK_CHECKS) {
+		await new Promise<void>((resolve) => {
+			packCheckQueue.push(resolve);
+		});
+	}
+
+	activePackChecks++;
+	return () => {
+		activePackChecks--;
+		const next = packCheckQueue.shift();
+		if (next) {
+			next();
+		}
+	};
+};
+
+const assertNoDevFilesPublished = async (pkgPath: string) => {
+	const packageJson = await Bun.file(pkgPath).json();
+	if (packageJson.private) {
+		return;
+	}
+
+	const dir = path.join(pkgPath, '..');
+	const release = await acquirePackCheckSlot();
+
+	try {
+		const files = $`bun pm pack --dry-run`.cwd(dir).lines();
+		for await (const file of files) {
+			if (!file.startsWith('packed')) {
+				continue;
+			}
+			const [, , filename] = file.split(' ');
+			if (
+				filename.includes('eslint.config.mjs') ||
+				filename.includes('tsconfig') ||
+				filename.includes('.turbo') ||
+				filename.includes('happydom') ||
+				filename.includes('prettier') ||
+				filename.startsWith('vite') ||
+				filename.startsWith('src/') ||
+				filename.startsWith('.env') ||
+				filename.includes('/test/') ||
+				(filename.endsWith('.ts') && !filename.endsWith('.d.ts'))
+			) {
+				console.log(filename);
+				throw new Error('Disallowed file found in ' + filename);
+			}
+		}
+	} finally {
+		release();
+	}
+};
+
 for (const pkg of packages) {
+	const isGoogleFonts = pkg.pkg === 'google-fonts';
+	const timeout = isGoogleFonts ? 120_000 : undefined;
+
 	test.concurrent(
 		'should not publish any dev files for @remotion/' + pkg.pkg,
 		async () => {
-			const packageJson = await Bun.file(pkg.path).json();
-			const isPrivate = packageJson.private;
-			if (isPrivate) {
-				return;
-			}
-
-			const dir = path.join(pkg.path, '..');
-			const files = $`bun pm pack --dry-run`.cwd(dir).lines();
-			for await (const file of files) {
-				if (!file.startsWith('packed')) {
-					continue;
-				}
-				const [, , filename] = file.split(' ');
-				if (
-					filename.includes('eslint.config.mjs') ||
-					filename.includes('tsconfig') ||
-					filename.includes('.turbo') ||
-					filename.includes('happydom') ||
-					filename.includes('prettier') ||
-					filename.startsWith('vite') ||
-					filename.startsWith('src/') ||
-					filename.startsWith('.env') ||
-					filename.includes('/test/') ||
-					(filename.endsWith('.ts') && !filename.endsWith('.d.ts'))
-				) {
-					console.log(filename);
-					throw new Error('Disallowed file found in ' + filename);
-				}
-			}
+			await assertNoDevFilesPublished(pkg.path);
 		},
+		timeout === undefined ? undefined : {timeout},
 	);
 }


### PR DESCRIPTION
## Summary

Fixes flaky CI timeout in `should not publish any dev files for @remotion/google-fonts` (issue #7533).

- Cap concurrent `bun pm pack --dry-run` checks to 8 to avoid saturating the CI runner when ~70 packages run in parallel
- Give `@remotion/google-fonts` a 120s per-test timeout (up from 40s)

## Test plan

- [x] `bun run build`
- [x] `bun run formatting`
- [ ] Confirm SSR + Monorepo checks job passes on CI