### PR TITLE
`@remotion/studio-server`: Add undo support for composition codemods

### DIFF
--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -13,7 +13,46 @@ import {simpleDiff} from '../../codemods/simple-diff';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import type {ApiHandler} from '../api-types';
 import {getProjectInfo} from '../project-info';
+import {
+	printUndoHint,
+	pushToUndoStack,
+	suppressUndoStackInvalidation,
+} from '../undo-stack';
 import {checkIfTypeScriptFile} from './can-update-default-props';
+
+const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
+	if (codemod.type === 'delete-composition') {
+		return {
+			undoMessage: `↩️  Deletion of composition "${codemod.idToDelete}"`,
+			redoMessage: `↪️  Deletion of composition "${codemod.idToDelete}"`,
+			entryType: codemod.type,
+		};
+	}
+
+	if (codemod.type === 'rename-composition') {
+		const label = `composition "${codemod.idToRename}" to "${codemod.newId}"`;
+		return {
+			undoMessage: `↩️  Rename of ${label}`,
+			redoMessage: `↪️  Rename of ${label}`,
+			entryType: codemod.type,
+		};
+	}
+
+	if (codemod.type === 'duplicate-composition') {
+		const label = `composition "${codemod.idToDuplicate}" to "${codemod.newId}"`;
+		return {
+			undoMessage: `↩️  Duplication of ${label}`,
+			redoMessage: `↪️  Duplication of ${label}`,
+			entryType: codemod.type,
+		};
+	}
+
+	return {
+		undoMessage: '↩️  Visual control change',
+		redoMessage: '↪️  Visual control change',
+		entryType: 'visual-control' as const,
+	};
+};
 
 export const applyCodemodHandler: ApiHandler<
 	ApplyCodemodRequest,
@@ -49,6 +88,22 @@ export const applyCodemodHandler: ApiHandler<
 		});
 
 		if (!dryRun) {
+			const {entryType, undoMessage, redoMessage} =
+				getCodemodUndoDescription(codemod);
+			pushToUndoStack({
+				filePath,
+				oldContents: input,
+				logLevel,
+				remotionRoot,
+				logLine: symbolicatedStack?.originalLineNumber ?? 1,
+				description: {
+					undoMessage,
+					redoMessage,
+				},
+				entryType,
+				suppressHmrOnFileRestore: false,
+			});
+			suppressUndoStackInvalidation(filePath);
 			writeFileAndNotifyFileWatchers(filePath, formatted, undefined);
 			const end = Date.now() - time;
 			const relativePath = path.relative(remotionRoot, filePath);
@@ -56,6 +111,7 @@ export const applyCodemodHandler: ApiHandler<
 				{indent: false, logLevel},
 				RenderInternals.chalk.blue(`Edited ${relativePath} in ${end}ms`),
 			);
+			printUndoHint(logLevel);
 		}
 
 		return {

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -22,7 +22,10 @@ type UndoEntryType =
 	| 'sequence-props'
 	| 'effect-props'
 	| 'delete-jsx-node'
-	| 'duplicate-jsx-node';
+	| 'duplicate-jsx-node'
+	| 'delete-composition'
+	| 'rename-composition'
+	| 'duplicate-composition';
 
 type UndoEntry = {
 	filePath: string;
@@ -39,6 +42,9 @@ type UndoEntry = {
 	| {entryType: 'effect-props'}
 	| {entryType: 'delete-jsx-node'}
 	| {entryType: 'duplicate-jsx-node'}
+	| {entryType: 'delete-composition'}
+	| {entryType: 'rename-composition'}
+	| {entryType: 'duplicate-composition'}
 );
 
 const MAX_ENTRIES = 100;

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -1,0 +1,137 @@
+import {expect, test} from 'bun:test';
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {
+	createFileWatcherRegistry,
+	setFileWatcherRegistry,
+} from '../file-watcher';
+import {setLiveEventsListener} from '../preview-server/live-events';
+import {applyCodemodHandler} from '../preview-server/routes/apply-codemod';
+import {redoHandler} from '../preview-server/routes/redo';
+import {undoHandler} from '../preview-server/routes/undo';
+import {getRedoStack, getUndoStack} from '../preview-server/undo-stack';
+
+const rootContents = `import React from 'react';
+import {Composition} from 'remotion';
+
+const Component = () => null;
+
+export const RemotionRoot: React.FC = () => {
+	return (
+		<>
+			<Composition
+				id="DeleteMe"
+				component={Component}
+				durationInFrames={120}
+				fps={30}
+				width={1280}
+				height={720}
+			/>
+			<Composition
+				id="KeepMe"
+				component={Component}
+				durationInFrames={120}
+				fps={30}
+				width={1280}
+				height={720}
+			/>
+		</>
+	);
+};
+`;
+
+const clearUndoRedoStacks = () => {
+	(getUndoStack() as unknown as unknown[]).length = 0;
+	(getRedoStack() as unknown as unknown[]).length = 0;
+};
+
+const getHandlerOptions = <T>({
+	input,
+	entryPoint,
+	remotionRoot,
+}: {
+	input: T;
+	entryPoint: string;
+	remotionRoot: string;
+}) => ({
+	input,
+	entryPoint,
+	remotionRoot,
+	request: {} as never,
+	response: {} as never,
+	logLevel: 'error' as const,
+	methods: {
+		removeJob: () => undefined,
+		cancelJob: () => undefined,
+		addJob: () => undefined,
+	},
+	publicDir: remotionRoot,
+	binariesDirectory: null,
+});
+
+test('applyCodemodHandler pushes composition changes to undo and redo stacks', async () => {
+	const remotionRoot = mkdtempSync(path.join(tmpdir(), 'remotion-codemod-'));
+	const cleanupFileWatcher = setFileWatcherRegistry(
+		createFileWatcherRegistry(),
+	);
+	const cleanupLiveEvents = setLiveEventsListener({
+		sendEventToClient: () => undefined,
+		sendEventToClientId: () => undefined,
+		router: () => Promise.resolve(),
+		closeConnections: () => Promise.resolve(),
+		addNewClientListener: () => () => undefined,
+	});
+
+	try {
+		clearUndoRedoStacks();
+		const entryPoint = path.join(remotionRoot, 'Root.tsx');
+		writeFileSync(entryPoint, rootContents);
+
+		const applyResponse = await applyCodemodHandler(
+			getHandlerOptions({
+				input: {
+					codemod: {type: 'delete-composition', idToDelete: 'DeleteMe'},
+					dryRun: false,
+					symbolicatedStack: {
+						originalFunctionName: null,
+						originalFileName: 'Root.tsx',
+						originalLineNumber: 9,
+						originalColumnNumber: 4,
+						originalScriptCode: null,
+					},
+				},
+				entryPoint,
+				remotionRoot,
+			}),
+		);
+
+		expect(applyResponse.success).toBe(true);
+		expect(readFileSync(entryPoint, 'utf-8')).not.toContain('id="DeleteMe"');
+		expect(readFileSync(entryPoint, 'utf-8')).toContain('id="KeepMe"');
+		expect(getUndoStack().length).toBe(1);
+		expect(getRedoStack().length).toBe(0);
+
+		const undoResponse = await undoHandler(
+			getHandlerOptions({input: {}, entryPoint, remotionRoot}),
+		);
+		expect(undoResponse.success).toBe(true);
+		expect(readFileSync(entryPoint, 'utf-8')).toBe(rootContents);
+		expect(getUndoStack().length).toBe(0);
+		expect(getRedoStack().length).toBe(1);
+
+		const redoResponse = await redoHandler(
+			getHandlerOptions({input: {}, entryPoint, remotionRoot}),
+		);
+		expect(redoResponse.success).toBe(true);
+		expect(readFileSync(entryPoint, 'utf-8')).not.toContain('id="DeleteMe"');
+		expect(readFileSync(entryPoint, 'utf-8')).toContain('id="KeepMe"');
+		expect(getUndoStack().length).toBe(1);
+		expect(getRedoStack().length).toBe(0);
+	} finally {
+		clearUndoRedoStacks();
+		cleanupLiveEvents();
+		cleanupFileWatcher();
+		rmSync(remotionRoot, {recursive: true, force: true});
+	}
+});

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'bun:test';
 import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
+import type {RecastCodemod} from '@remotion/studio-shared';
 import {
 	createFileWatcherRegistry,
 	setFileWatcherRegistry,
@@ -70,7 +71,15 @@ const getHandlerOptions = <T>({
 	binariesDirectory: null,
 });
 
-test('applyCodemodHandler pushes composition changes to undo and redo stacks', async () => {
+const runCompositionCodemodUndoRedoTest = async ({
+	codemod,
+	assertApplied,
+	expectedUndoMessage,
+}: {
+	codemod: RecastCodemod;
+	assertApplied: (contents: string) => void;
+	expectedUndoMessage: string;
+}) => {
 	const remotionRoot = mkdtempSync(path.join(tmpdir(), 'remotion-codemod-'));
 	const cleanupFileWatcher = setFileWatcherRegistry(
 		createFileWatcherRegistry(),
@@ -91,7 +100,7 @@ test('applyCodemodHandler pushes composition changes to undo and redo stacks', a
 		const applyResponse = await applyCodemodHandler(
 			getHandlerOptions({
 				input: {
-					codemod: {type: 'delete-composition', idToDelete: 'DeleteMe'},
+					codemod,
 					dryRun: false,
 					symbolicatedStack: {
 						originalFunctionName: null,
@@ -107,9 +116,9 @@ test('applyCodemodHandler pushes composition changes to undo and redo stacks', a
 		);
 
 		expect(applyResponse.success).toBe(true);
-		expect(readFileSync(entryPoint, 'utf-8')).not.toContain('id="DeleteMe"');
-		expect(readFileSync(entryPoint, 'utf-8')).toContain('id="KeepMe"');
+		assertApplied(readFileSync(entryPoint, 'utf-8'));
 		expect(getUndoStack().length).toBe(1);
+		expect(getUndoStack()[0].description.undoMessage).toBe(expectedUndoMessage);
 		expect(getRedoStack().length).toBe(0);
 
 		const undoResponse = await undoHandler(
@@ -124,8 +133,7 @@ test('applyCodemodHandler pushes composition changes to undo and redo stacks', a
 			getHandlerOptions({input: {}, entryPoint, remotionRoot}),
 		);
 		expect(redoResponse.success).toBe(true);
-		expect(readFileSync(entryPoint, 'utf-8')).not.toContain('id="DeleteMe"');
-		expect(readFileSync(entryPoint, 'utf-8')).toContain('id="KeepMe"');
+		assertApplied(readFileSync(entryPoint, 'utf-8'));
 		expect(getUndoStack().length).toBe(1);
 		expect(getRedoStack().length).toBe(0);
 	} finally {
@@ -134,4 +142,53 @@ test('applyCodemodHandler pushes composition changes to undo and redo stacks', a
 		cleanupFileWatcher();
 		rmSync(remotionRoot, {recursive: true, force: true});
 	}
+};
+
+test('applyCodemodHandler pushes composition deletions to undo and redo stacks', async () => {
+	await runCompositionCodemodUndoRedoTest({
+		codemod: {type: 'delete-composition', idToDelete: 'DeleteMe'},
+		assertApplied: (contents) => {
+			expect(contents).not.toContain('id="DeleteMe"');
+			expect(contents).toContain('id="KeepMe"');
+		},
+		expectedUndoMessage: '↩️  Deletion of composition "DeleteMe"',
+	});
+});
+
+test('applyCodemodHandler pushes composition renames to undo and redo stacks', async () => {
+	await runCompositionCodemodUndoRedoTest({
+		codemod: {
+			type: 'rename-composition',
+			idToRename: 'DeleteMe',
+			newId: 'Renamed',
+		},
+		assertApplied: (contents) => {
+			expect(contents).not.toContain('id="DeleteMe"');
+			expect(contents).toContain('id="Renamed"');
+			expect(contents).toContain('id="KeepMe"');
+		},
+		expectedUndoMessage: '↩️  Rename of composition "DeleteMe" to "Renamed"',
+	});
+});
+
+test('applyCodemodHandler pushes composition duplications to undo and redo stacks', async () => {
+	await runCompositionCodemodUndoRedoTest({
+		codemod: {
+			type: 'duplicate-composition',
+			idToDuplicate: 'DeleteMe',
+			newId: 'Duplicated',
+			newDurationInFrames: null,
+			newFps: null,
+			newHeight: null,
+			newWidth: null,
+			tag: 'Composition',
+		},
+		assertApplied: (contents) => {
+			expect(contents).toContain('id="DeleteMe"');
+			expect(contents).toContain('id="Duplicated"');
+			expect(contents).toContain('id="KeepMe"');
+		},
+		expectedUndoMessage:
+			'↩️  Duplication of composition "DeleteMe" to "Duplicated"',
+	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7542

## Summary
- Push composition delete, rename, and duplicate codemods onto the Studio undo stack before writing source files.
- Add undo entry types for composition codemods.
- Add route-level coverage proving delete, rename, and duplicate composition codemod changes can be undone and redone.

## Testing
- `bun test src/test/apply-codemod.test.ts`
- `bunx turbo run lint --filter='@remotion/studio-server'` (passes with existing warnings)
- `bun run build`
- `bun run formatting`
- `bun run stylecheck` attempted; blocked by the known Cloud Agent Go 1.22.2 limitation in `@remotion/lambda-go` requiring Go >= 1.23.0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5c4ba47-f2e6-4ba6-a8c7-523ef61a0947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5c4ba47-f2e6-4ba6-a8c7-523ef61a0947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

