### PR TITLE
`@remotion/example`: Deploy example as testbed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ packages/example/public/offthreadvideoregression
 
 packages/example/test-results
 packages/example/build
+packages/example/build-testbed
 packages/example-without-zod/build
 packages/docs/out
 packages/cloudrun/container/ensure-browser.mjs

--- a/packages/docs/copy-convert.ts
+++ b/packages/docs/copy-convert.ts
@@ -4,7 +4,7 @@ import {$} from 'bun';
 // @ts-ignore outside project
 import * as seo from '../convert/app/seo';
 
-await $`bunx turbo "@remotion/convert#build-spa" "@remotion/brand#bundle"`;
+await $`bunx turbo "@remotion/convert#build-spa" "@remotion/brand#bundle" "@remotion/example#bundle-testbed"`;
 
 const dir = path.join(__dirname, '../convert/spa-dist/client');
 
@@ -12,6 +12,10 @@ fs.cpSync(dir, path.join(__dirname, './build/convert'), {recursive: true});
 
 const brandDir = path.join(__dirname, '../brand/build');
 fs.cpSync(brandDir, path.join(__dirname, './build/brand'), {recursive: true});
+
+const testbedDir = path.join(__dirname, '../example/build-testbed');
+fs.cpSync(testbedDir, path.join(__dirname, './build/testbed'), {recursive: true});
+
 fs.cpSync(
 	path.join(__dirname, './build/convert/convert-service-worker.js'),
 	path.join(__dirname, './build/convert-service-worker.js'),

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -18,7 +18,7 @@
 		"start-bun": "PATCH_BUN_DEVELOPMENT=true bun --bun remotion studio",
 		"start-js": "remotion preview src/entry.jsx",
 		"comps": "remotion compositions",
-		"clean": "rm -rf build && rm -rf out",
+		"clean": "rm -rf build && rm -rf build-testbed && rm -rf out",
 		"lint": "eslint src",
 		"test": "tsc && bun test src --timeout 60000",
 		"test:e2e": "playwright test",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -25,6 +25,7 @@
 		"teste2e": "playwright test",
 		"render": "remotion render react-svg",
 		"bundle": "remotion bundle",
+		"bundle-testbed": "remotion bundle --public-path /testbed/ --out-dir build-testbed",
 		"render-js": "remotion render src/entry.jsx framer",
 		"render-gif": "remotion render framer out/video.gif --codec=gif --every-nth-frame=2",
 		"render-transparent": "remotion render --image-format=png --pixel-format=yuva420p --codec=vp8 react-svg out/video.webm"

--- a/turbo.json
+++ b/turbo.json
@@ -53,13 +53,24 @@
 			"outputs": ["build", "./node_modules/.cache"],
 			"outputLogs": "new-only"
 		},
+		"@remotion/example#bundle-testbed": {
+			"dependsOn": ["^make", "make"],
+			"outputs": ["build-testbed", "./node_modules/.cache"],
+			"outputLogs": "new-only"
+		},
 		"@remotion/example#test": {
 			"dependsOn": ["@remotion/example#bundle"],
 			"outputs": [],
 			"outputLogs": "new-only"
 		},
 		"build-docs": {
-			"dependsOn": ["^make", "make", "@remotion/convert#build-spa", "@remotion/brand#bundle"],
+			"dependsOn": [
+				"^make",
+				"make",
+				"@remotion/convert#build-spa",
+				"@remotion/brand#bundle",
+				"@remotion/example#bundle-testbed"
+			],
 			"outputs": [".docusaurus", "build", "node_modules/.cache/twoslash"],
 			"outputLogs": "new-only"
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7539.

## Summary
- Adds a dedicated `@remotion/example` testbed bundle with `/testbed/` as the public path.
- Includes the testbed bundle in the docs build graph and copies it into `packages/docs/build/testbed` alongside the existing Brand deployment.

## Testing
- `bunx oxfmt src --write` in `packages/docs`
- `bunx oxfmt src --write` in `packages/example`
- `bun run build`
- `bun run formatting`
- `bunx turbo "@remotion/example#bundle-testbed"`
- `bunx turbo run build-docs --filter=docs`
- `curl -I http://localhost:3000/testbed/ && curl -I http://localhost:3000/testbed/bundle.js`
- Manual browser smoke test at `http://localhost:3000/testbed/`

[testbed_studio_playback.mp4](https://cursor.com/agents/bc-bf0803e3-ee4d-4ece-9dd7-d35f1d136cdb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftestbed_studio_playback.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf0803e3-ee4d-4ece-9dd7-d35f1d136cdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf0803e3-ee4d-4ece-9dd7-d35f1d136cdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

