### PR TITLE
remotion.dev/convert: Clamp player seekbar progress

### DIFF
--- a/packages/convert/app/components/player/player-seekbar.tsx
+++ b/packages/convert/app/components/player/player-seekbar.tsx
@@ -2,29 +2,44 @@ import type MediaFox from '@mediafox/core';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useElementSize} from './use-element-size';
 
-const getTimeFromX = (
+const clamp = (value: number, min: number, max: number) => {
+	return Math.min(Math.max(value, min), max);
+};
+
+export const getTimeFromX = (
 	clientX: number,
 	durationInSeconds: number,
 	width: number,
 ) => {
-	const pos = clientX;
-
-	const min = 0;
-	const max = width;
-	const value = pos;
-	const outMin = 0;
-	const outMax = durationInSeconds - 1;
-	let t;
-	if (value <= min) {
-		t = 0;
-	} else if (value >= max) {
-		t = 1;
-	} else {
-		t = (value - min) / (max - min);
+	if (
+		width <= 0 ||
+		durationInSeconds <= 0 ||
+		!Number.isFinite(clientX) ||
+		!Number.isFinite(durationInSeconds) ||
+		!Number.isFinite(width)
+	) {
+		return 0;
 	}
 
-	const frame = outMin + (outMax - outMin) * t;
-	return frame;
+	const progress = clamp(clientX / width, 0, 1);
+
+	return durationInSeconds * progress;
+};
+
+export const getSeekBarProgress = (
+	currentTime: number,
+	durationInSeconds: number,
+) => {
+	if (
+		currentTime <= 0 ||
+		durationInSeconds <= 0 ||
+		!Number.isFinite(currentTime) ||
+		!Number.isFinite(durationInSeconds)
+	) {
+		return 0;
+	}
+
+	return clamp(currentTime / durationInSeconds, 0, 1);
 };
 
 const BAR_HEIGHT = 5;
@@ -250,6 +265,8 @@ export const PlayerSeekBar: React.FC<{
 	}, [dragging.dragging, onPointerMove, onPointerUp]);
 
 	const knobStyle: React.CSSProperties = useMemo(() => {
+		const progress = getSeekBarProgress(frame, playerRef.duration);
+
 		return {
 			height: KNOB_SIZE,
 			width: KNOB_SIZE,
@@ -257,21 +274,20 @@ export const PlayerSeekBar: React.FC<{
 			position: 'absolute',
 			backgroundColor: 'white',
 			top: VERTICAL_PADDING - KNOB_SIZE / 2 + 5 / 2,
-			left: Math.max(
-				0,
-				(frame / Math.max(1, playerRef.duration - 1)) * width - KNOB_SIZE / 2,
-			),
+			left: Math.max(0, progress * width - KNOB_SIZE / 2),
 			outline: '2px solid #000',
 			opacity: Number(barHovered),
-			transition: 'opacity 0.s ease',
+			transition: 'opacity 0.2s ease',
 		};
 	}, [barHovered, frame, playerRef.duration, width]);
 
 	const fillStyle: React.CSSProperties = useMemo(() => {
+		const progress = getSeekBarProgress(frame, playerRef.duration);
+
 		return {
 			height: BAR_HEIGHT,
 			backgroundColor: 'black',
-			width: (frame / (playerRef.duration - 1)) * 100 + '%',
+			width: `${progress * 100}%`,
 			borderRadius: BAR_HEIGHT / 2,
 		};
 	}, [frame, playerRef.duration]);
@@ -281,11 +297,11 @@ export const PlayerSeekBar: React.FC<{
 			height: BAR_HEIGHT,
 			backgroundColor: 'black',
 			opacity: 0.2,
-			width: ((playerRef.duration - 1) / (playerRef.duration - 1)) * 100 + '%',
+			width: '100%',
 			borderRadius: BAR_HEIGHT / 2,
 			position: 'absolute',
 		};
-	}, [playerRef.duration]);
+	}, []);
 
 	return (
 		<div

--- a/packages/convert/test/player-seekbar.test.ts
+++ b/packages/convert/test/player-seekbar.test.ts
@@ -1,0 +1,19 @@
+import {expect, test} from 'bun:test';
+import {
+	getSeekBarProgress,
+	getTimeFromX,
+} from '../app/components/player/player-seekbar';
+
+test('maps the end of the seekbar to the full media duration', () => {
+	expect(getTimeFromX(200, 10, 200)).toBe(10);
+});
+
+test('keeps seekbar progress within the visible bar', () => {
+	expect(getSeekBarProgress(12, 10)).toBe(1);
+	expect(getSeekBarProgress(-1, 10)).toBe(0);
+});
+
+test('returns an empty progress for invalid seekbar measurements', () => {
+	expect(getSeekBarProgress(1, 0)).toBe(0);
+	expect(getTimeFromX(20, 10, 0)).toBe(0);
+});


### PR DESCRIPTION
## Summary

- clamp the Convert player seekbar progress so the fill and knob stay within the visible track
- map pointer positions against the full media duration instead of `duration - 1`
- add coverage for end-of-bar, overflow, and invalid measurement cases

Fixes #7552

## Testing

- `bun test packages/convert/test/player-seekbar.test.ts`
- `bun run --cwd packages/convert test`
- `bunx turbo run make --filter='@remotion/convert^...' --no-update-notifier`
- `bun run --cwd packages/convert lint`
- `bunx prettier --check packages/convert/app/components/player/player-seekbar.tsx packages/convert/test/player-seekbar.test.ts`

## Notes

No public API changes; this only bounds the seekbar math used by the Convert page player.