### PR TITLE
`@remotion/it-tests`: Fix flaky PHP composer CI

### DIFF
--- a/packages/it-tests/src/monorepo/php-package.test.ts
+++ b/packages/it-tests/src/monorepo/php-package.test.ts
@@ -5,6 +5,8 @@ import path from 'path';
 import {LambdaClientInternals} from '@remotion/lambda-client';
 import {$} from 'bun';
 
+const lambdaPhpDir = path.join(process.cwd(), '..', 'lambda-php');
+
 const referenceVersion = readFileSync(
 	path.join(process.cwd(), '..', 'core', 'package.json'),
 	'utf-8',
@@ -12,11 +14,30 @@ const referenceVersion = readFileSync(
 const referenceVersionJson = JSON.parse(referenceVersion);
 const version = referenceVersionJson.version;
 
+const installComposerDependencies = (cwd: string) => {
+	const maxAttempts = 3;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			execSync('php composer.phar --quiet install', {cwd});
+			return;
+		} catch (err) {
+			if (attempt === maxAttempts) {
+				throw err;
+			}
+		}
+	}
+};
+
 beforeAll(async () => {
-	await $`php composer.phar update --quiet --lock`.cwd(
-		path.join(process.cwd(), '..', 'lambda-php'),
-	);
-}, 120_000);
+	const result = await $`php composer.phar validate --no-check-publish --quiet`
+		.cwd(lambdaPhpDir)
+		.nothrow();
+	if (result.exitCode === 2) {
+		throw new Error(
+			'composer.lock is not in sync with composer.json in packages/lambda-php. Run `php composer.phar update --lock` there and commit the change.',
+		);
+	}
+});
 
 describe('These should run serially', () => {
 	test('Set the right version for phpunit', () => {
@@ -65,9 +86,7 @@ class Semantic
 	});
 
 	test('PHP package should create the same renderMedia payload as normal Lambda package', async () => {
-		execSync('php composer.phar --quiet install', {
-			cwd: path.join(process.cwd(), '..', 'lambda-php'),
-		});
+		installComposerDependencies(lambdaPhpDir);
 		const phpOutput = execSync('php phpunit.phar ./tests/PHPClientTest.php', {
 			cwd: path.join(process.cwd(), '..', 'lambda-php'),
 		});
@@ -145,9 +164,7 @@ class Semantic
 	});
 
 	test('PHP package should create the same progress payload as normal Lambda package', async () => {
-		execSync('php composer.phar --quiet install', {
-			cwd: path.join(process.cwd(), '..', 'lambda-php'),
-		});
+		installComposerDependencies(lambdaPhpDir);
 		const phpOutput = execSync(
 			'php phpunit.phar ./tests/PHPRenderProgressTest.php',
 			{

--- a/packages/lambda-php/composer.lock
+++ b/packages/lambda-php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c861e1cf97b352032d9876878b11a2a0",
+    "content-hash": "d857176afe0dac36662e710ff33c552f",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7556

The `php-package.test.ts` integration test was flaky in CI because `beforeAll` ran `composer update --lock`, which requires a network call to Packagist and can fail with DNS resolution timeouts.

## Changes

- Replace the network-dependent `composer update --lock` setup step with an offline `composer validate` check that fails fast when `composer.lock` is out of sync with `composer.json`
- Add retry logic (3 attempts) around `composer install`, which still needs network access to download dependencies
- Sync `packages/lambda-php/composer.lock` content-hash with `composer.json`

## Why this works

The `beforeAll` hook only needed to ensure the committed lock file matches `composer.json`. That can be verified offline. Dependency installation still hits Packagist, but retries handle transient DNS/network failures without adding an extra network round-trip before every test run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fc7c5a3-9867-4801-9017-ba155cbe6692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fc7c5a3-9867-4801-9017-ba155cbe6692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

