### PR TITLE
`@remotion/studio`: Show keyframed status for interpolated props

### DIFF
--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -14,9 +14,15 @@ export type CanUpdateSequencePropStatusTrue = {
 	codeValue: unknown;
 };
 
+export type CanUpdateSequencePropStatusKeyframe = {
+	frame: number;
+	value: unknown;
+};
+
 export type CanUpdateSequencePropStatusFalse = {
 	canUpdate: false;
 	reason: 'computed';
+	keyframes?: CanUpdateSequencePropStatusKeyframe[];
 };
 
 export type CanUpdateSequencePropStatus =

--- a/packages/example/src/KeyframedPropsTest.tsx
+++ b/packages/example/src/KeyframedPropsTest.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {AbsoluteFill, interpolate, Sequence, useCurrentFrame} from 'remotion';
+
+const KeyframedPropsTest: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	return (
+		<AbsoluteFill
+			style={{
+				justifyContent: 'center',
+				alignItems: 'center',
+				backgroundColor: 'white',
+			}}
+		>
+			<Sequence
+				from={0}
+				durationInFrames={120}
+				style={{scale: interpolate(frame, [0, 100], [2, 4])}}
+			>
+				<div
+					style={{
+						width: 180,
+						height: 180,
+						borderRadius: 24,
+						backgroundColor: '#0b84f3',
+					}}
+				/>
+			</Sequence>
+		</AbsoluteFill>
+	);
+};
+
+export default KeyframedPropsTest;

--- a/packages/example/src/KeyframedPropsTest.tsx
+++ b/packages/example/src/KeyframedPropsTest.tsx
@@ -13,7 +13,6 @@ const KeyframedPropsTest: React.FC = () => {
 			}}
 		>
 			<Sequence
-				from={0}
 				durationInFrames={120}
 				style={{scale: interpolate(frame, [0, 100], [2, 4])}}
 			>

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -342,6 +342,16 @@ export const Index: React.FC = () => {
 
 	return (
 		<>
+			<Folder name="copilot-tests">
+				<Composition
+					id="keyframed-props-test"
+					lazyComponent={() => import('./KeyframedPropsTest')}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={120}
+				/>
+			</Folder>
 			<Folder name="dynamic-parameters">
 				<Composition
 					id="dynamic-length"

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -1,6 +1,7 @@
 import {readFileSync} from 'node:fs';
 import path from 'node:path';
 import type {
+	CallExpression,
 	Expression,
 	File,
 	JSXAttribute,
@@ -13,15 +14,20 @@ import type {
 import {RenderInternals} from '@remotion/renderer';
 import type {SubscribeToSequencePropsResponse} from '@remotion/studio-shared';
 import * as recast from 'recast';
-import type {CanUpdateSequencePropsResponseTrue, LogLevel} from 'remotion';
-import type {SequenceNodePath} from 'remotion';
-import type {CanUpdateSequencePropStatus} from 'remotion';
+import type {
+	CanUpdateSequencePropsResponseTrue,
+	CanUpdateSequencePropStatus,
+	LogLevel,
+	SequenceNodePath,
+} from 'remotion';
 import {parseAst} from '../../codemods/parse-ast';
 import {getAstNodePath} from '../../helpers/get-ast-node-path';
 import {JsxElementNotFoundAtLocationError} from '../jsx-element-not-found-at-location-error';
 import {computeEffectPropStatus} from './can-update-effect-props';
 
 type CanUpdatePropStatus = CanUpdateSequencePropStatus;
+type ComputedPropStatus = Extract<CanUpdatePropStatus, {canUpdate: false}>;
+type PropKeyframes = NonNullable<ComputedPropStatus['keyframes']>;
 
 export const isStaticValue = (node: Expression): boolean => {
 	switch (node.type) {
@@ -114,6 +120,100 @@ export const extractStaticValue = (node: Expression): unknown => {
 	}
 };
 
+const getNumericValue = (node: Expression): number | null => {
+	if (node.type === 'NumericLiteral') {
+		return node.value;
+	}
+
+	if (
+		node.type === 'UnaryExpression' &&
+		(node.operator === '-' || node.operator === '+') &&
+		node.argument.type === 'NumericLiteral'
+	) {
+		return node.operator === '-' ? -node.argument.value : node.argument.value;
+	}
+
+	if (node.type === 'TSAsExpression') {
+		return getNumericValue(node.expression as Expression);
+	}
+
+	return null;
+};
+
+const getInterpolateKeyframes = (
+	node: Expression,
+): PropKeyframes | undefined => {
+	if (node.type === 'TSAsExpression') {
+		return getInterpolateKeyframes(node.expression as Expression);
+	}
+
+	if (node.type !== 'CallExpression') {
+		return undefined;
+	}
+
+	const callExpression = node as CallExpression;
+	if (
+		callExpression.callee.type !== 'Identifier' ||
+		callExpression.callee.name !== 'interpolate'
+	) {
+		return undefined;
+	}
+
+	const inputArg = callExpression.arguments[1];
+	const outputArg = callExpression.arguments[2];
+	if (
+		!inputArg ||
+		!outputArg ||
+		inputArg.type !== 'ArrayExpression' ||
+		outputArg.type !== 'ArrayExpression'
+	) {
+		return undefined;
+	}
+
+	if (inputArg.elements.length !== outputArg.elements.length) {
+		return undefined;
+	}
+
+	const keyframes: PropKeyframes = [];
+	for (let i = 0; i < inputArg.elements.length; i++) {
+		const inputElement = inputArg.elements[i];
+		const outputElement = outputArg.elements[i];
+		if (
+			!inputElement ||
+			!outputElement ||
+			inputElement.type === 'SpreadElement' ||
+			outputElement.type === 'SpreadElement'
+		) {
+			return undefined;
+		}
+
+		const frame = getNumericValue(inputElement);
+		if (frame === null || !isStaticValue(outputElement)) {
+			return undefined;
+		}
+
+		keyframes.push({
+			frame,
+			value: extractStaticValue(outputElement),
+		});
+	}
+
+	return keyframes.length > 0 ? keyframes : undefined;
+};
+
+const getComputedStatus = (node: Expression): CanUpdatePropStatus => {
+	const keyframes = getInterpolateKeyframes(node);
+	if (!keyframes) {
+		return {canUpdate: false, reason: 'computed'};
+	}
+
+	return {
+		canUpdate: false,
+		reason: 'computed',
+		keyframes,
+	};
+};
+
 const getPropsStatus = (
 	jsxElement: JSXOpeningElement,
 ): Record<string, CanUpdatePropStatus> => {
@@ -150,11 +250,13 @@ const getPropsStatus = (
 
 		if (value.type === 'JSXExpressionContainer') {
 			const {expression} = value;
-			if (
-				expression.type === 'JSXEmptyExpression' ||
-				!isStaticValue(expression)
-			) {
+			if (expression.type === 'JSXEmptyExpression') {
 				props[name] = {canUpdate: false, reason: 'computed'};
+				continue;
+			}
+
+			if (!isStaticValue(expression)) {
+				props[name] = getComputedStatus(expression);
 				continue;
 			}
 
@@ -292,7 +394,7 @@ const getNestedPropStatus = (
 
 	const propValue = prop.value as Expression;
 	if (!isStaticValue(propValue)) {
-		return {canUpdate: false, reason: 'computed'};
+		return getComputedStatus(propValue);
 	}
 
 	const codeValue = extractStaticValue(propValue);

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -150,3 +150,26 @@ test('computeSequencePropsStatus should report unset when parent attribute missi
 		codeValue: undefined,
 	});
 });
+
+test('computeSequencePropsStatus should return keyframes for interpolated style props', () => {
+	const filePath = path.join(__dirname, 'snapshots', 'keyframed-props.tsx');
+	const result = computeSequencePropsStatus({
+		fileName: filePath,
+		nodePath: getNodePath(filePath, 8),
+		keys: ['style.scale'],
+		effects: [],
+		remotionRoot: '/',
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.scale']).toEqual({
+		canUpdate: false,
+		reason: 'computed',
+		keyframes: [
+			{frame: 0, value: 2},
+			{frame: 100, value: 4},
+		],
+	});
+});

--- a/packages/studio-server/src/test/snapshots/keyframed-props.tsx
+++ b/packages/studio-server/src/test/snapshots/keyframed-props.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import {interpolate, Sequence, useCurrentFrame} from 'remotion';
+
+export const KeyframedExample: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	return (
+		<Sequence
+			from={0}
+			durationInFrames={120}
+			style={{scale: interpolate(frame, [0, 100], [2, 4])}}
+		/>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -12,7 +12,11 @@ import {getTimelineFieldLabelRowStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
-import {TimelineFieldValue, UnsupportedStatus} from './TimelineSchemaField';
+import {
+	getComputedStatusLabel,
+	TimelineFieldValue,
+	UnsupportedStatus,
+} from './TimelineSchemaField';
 
 const fieldRowBase: React.CSSProperties = {
 	paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
@@ -181,7 +185,7 @@ const Value: React.FC<{
 
 	if (propStatus === null || !propStatus.canUpdate) {
 		if (propStatus?.reason === 'computed') {
-			return <UnsupportedStatus label="computed" />;
+			return <UnsupportedStatus label={getComputedStatusLabel(propStatus)} />;
 		}
 
 		return null;

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -37,6 +37,18 @@ export const UnsupportedStatus: React.FC<{
 	return <span style={unsupportedLabel}>{label}</span>;
 };
 
+export const getComputedStatusLabel = (
+	propStatus: CanUpdateSequencePropStatusFalse,
+): string => {
+	if (propStatus.reason !== 'computed') {
+		throw new Error(
+			`Unsupported prop status: ${propStatus.reason satisfies never}`,
+		);
+	}
+
+	return propStatus.keyframes?.length ? 'keyframed' : 'computed';
+};
+
 export const TimelineNonEditableStatus: React.FC<{
 	readonly propStatus: CanUpdateSequencePropStatusFalse;
 }> = ({propStatus}) => {
@@ -45,7 +57,9 @@ export const TimelineNonEditableStatus: React.FC<{
 	}
 
 	if (propStatus.reason === 'computed') {
-		return <span style={unsupportedLabel}>computed</span>;
+		return (
+			<span style={unsupportedLabel}>{getComputedStatusLabel(propStatus)}</span>
+		);
 	}
 
 	throw new Error(


### PR DESCRIPTION
## Summary
- detect interpolate() keyframes in sequence prop status computation
- include keyframes metadata on computed prop statuses
- add unit test for interpolated style.scale keyframes
- show `keyframed` label in Timeline when computed status includes keyframes

## Validation
- bun run build
- bun run formatting