### PR TITLE
`@remotion/studio`: Disable rename, duplicate and delete composition in read-only mode

### DIFF
--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -188,7 +188,7 @@ export const CompositionSelectorItem: React.FC<{
 				connectionStatus,
 				resolvedLocation,
 				setSelectedModal,
-				readOnlyStudio: Boolean(window.remotion_isReadOnlyStudio),
+				readOnlyStudio: window.remotion_isReadOnlyStudio,
 			});
 		}
 

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -188,6 +188,7 @@ export const CompositionSelectorItem: React.FC<{
 				connectionStatus,
 				resolvedLocation,
 				setSelectedModal,
+				readOnlyStudio: Boolean(window.remotion_isReadOnlyStudio),
 			});
 		}
 

--- a/packages/studio/src/components/composition-menu-items.ts
+++ b/packages/studio/src/components/composition-menu-items.ts
@@ -13,12 +13,14 @@ export const getCompositionMenuItems = ({
 	resolvedLocation,
 	setSelectedModal,
 	closeMenu,
+	readOnlyStudio,
 }: {
 	composition: _InternalTypes['AnyComposition'] | null;
 	connectionStatus: PreviewServerConnectionState['type'];
 	resolvedLocation: ResolvedStackLocation | null;
 	setSelectedModal: (value: SetStateAction<ModalState | null>) => void;
 	closeMenu: () => void;
+	readOnlyStudio: boolean;
 }): ComboboxValue[] => {
 	const editorName = window.remotion_editorName;
 	const showInEditorDisabled =
@@ -76,7 +78,7 @@ export const getCompositionMenuItems = ({
 			subMenu: null,
 			type: 'item' as const,
 			value: 'rename',
-			disabled: !composition,
+			disabled: !composition || readOnlyStudio,
 		},
 		{
 			id: 'duplicate',
@@ -100,7 +102,7 @@ export const getCompositionMenuItems = ({
 			subMenu: null,
 			type: 'item' as const,
 			value: 'duplicate',
-			disabled: !composition,
+			disabled: !composition || readOnlyStudio,
 		},
 		{
 			id: 'delete',
@@ -122,11 +124,7 @@ export const getCompositionMenuItems = ({
 			subMenu: null,
 			type: 'item' as const,
 			value: 'delete',
-			disabled: !composition,
-		},
-		{
-			type: 'divider' as const,
-			id: 'copy-id-divider',
+			disabled: !composition || readOnlyStudio,
 		},
 		{
 			id: 'copy-id',

--- a/packages/studio/src/components/composition-menu-items.ts
+++ b/packages/studio/src/components/composition-menu-items.ts
@@ -127,6 +127,10 @@ export const getCompositionMenuItems = ({
 			disabled: !composition || readOnlyStudio,
 		},
 		{
+			type: 'divider' as const,
+			id: 'copy-id-divider',
+		},
+		{
 			id: 'copy-id',
 			keyHint: null,
 			label: `Copy ID`,

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -689,6 +689,7 @@ export const useMenuStructure = (
 					connectionStatus: type,
 					resolvedLocation: resolvedCompositionLocation,
 					setSelectedModal,
+					readOnlyStudio,
 				}),
 				quickSwitcherLabel: null,
 			},


### PR DESCRIPTION
Fixes #7566

In the titlebar "Composition" menu and in the right-click context menu on compositions, "Rename...", "Duplicate...", and "Delete..." were active even when the Studio was in read-only mode.

## Changes

- Added `readOnlyStudio` parameter to `getCompositionMenuItems()` 
- The rename, duplicate, and delete items are now disabled when `readOnlyStudio` is `true`
- Updated the titlebar menu (`use-menu-structure.tsx`) to pass `readOnlyStudio`
- Updated the right-click context menu (`CompositionSelectorItem.tsx`) to pass `window.remotion_isReadOnlyStudio`