### PR TITLE
`@remotion/studio`: Fix empty space in dropdowns caused by scrollbar-gutter: stable

### DIFF
--- a/packages/studio/src/components/NewComposition/MenuContent.tsx
+++ b/packages/studio/src/components/NewComposition/MenuContent.tsx
@@ -25,6 +25,7 @@ const container: React.CSSProperties = {
 	marginLeft: 0 - BORDER_SIZE,
 	overflowY: 'auto',
 	overflowX: 'hidden',
+	scrollbarGutter: 'auto',
 	minWidth: 200,
 	maxWidth: MAX_MENU_WIDTH,
 };


### PR DESCRIPTION
Fixes #7567

The `.__remotion-vertical-scrollbar` CSS class has `scrollbar-gutter: stable` which always reserves 6px on the right for a scrollbar gutter — even when the container doesn't overflow.

This was fine for full-panel scroll containers but caused compact dropdown menus (`MenuContent`) to always show an empty strip on the right.

Fix: override `scrollbar-gutter` to `auto` (the default) on the `MenuContent` dropdown container via inline style, so the gutter is only reserved when a scrollbar is actually needed.