### PR TITLE
`@remotion/studio`: Reload component when hook rules error occurs

### DIFF
--- a/packages/example/e2e/constants.mts
+++ b/packages/example/e2e/constants.mts
@@ -30,6 +30,12 @@ export const errorOverlayE2eFile = path.join(
 	'ErrorOverlayE2e',
 	'ErrorOverlayRepro.tsx',
 );
+export const hookOrderChangeE2eFile = path.join(
+	exampleDir,
+	'src',
+	'HookOrderChangeE2e',
+	'HookOrderChangeRepro.tsx',
+);
 export const newVideoFile = path.join(exampleDir, 'src', 'NewVideo.tsx');
 export const remotionBin = path.join(
 	exampleDir,
@@ -57,6 +63,10 @@ export const ORIGINAL_LOST_NODE_PATH_E2E_FILE = path.join(
 export const ORIGINAL_ERROR_OVERLAY_E2E_FILE = path.join(
 	os.tmpdir(),
 	'remotion-e2e-original-error-overlay-repro.tsx',
+);
+export const ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE = path.join(
+	os.tmpdir(),
+	'remotion-e2e-original-hook-order-change-repro.tsx',
 );
 export const PID_FILE = path.join(os.tmpdir(), 'remotion-e2e-studio.pid');
 export const EXPANDED_SIDEBAR_STATE = path.join(

--- a/packages/example/e2e/global-setup.mts
+++ b/packages/example/e2e/global-setup.mts
@@ -2,9 +2,11 @@ import fs from 'fs';
 import {
 	ORIGINAL_CONTENT_FILE,
 	ORIGINAL_ERROR_OVERLAY_E2E_FILE,
+	ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE,
 	ORIGINAL_LOST_NODE_PATH_E2E_FILE,
 	ORIGINAL_VISUAL_CONTROLS_FILE,
 	errorOverlayE2eFile,
+	hookOrderChangeE2eFile,
 	lostNodePathE2eFile,
 	rootFile,
 	visualControlsFile,
@@ -23,5 +25,9 @@ export default async function globalSetup(): Promise<void> {
 	fs.writeFileSync(
 		ORIGINAL_ERROR_OVERLAY_E2E_FILE,
 		fs.readFileSync(errorOverlayE2eFile, 'utf-8'),
+	);
+	fs.writeFileSync(
+		ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE,
+		fs.readFileSync(hookOrderChangeE2eFile, 'utf-8'),
 	);
 }

--- a/packages/example/e2e/global-teardown.mts
+++ b/packages/example/e2e/global-teardown.mts
@@ -2,9 +2,11 @@ import fs from 'fs';
 import {
 	ORIGINAL_CONTENT_FILE,
 	ORIGINAL_ERROR_OVERLAY_E2E_FILE,
+	ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE,
 	ORIGINAL_LOST_NODE_PATH_E2E_FILE,
 	ORIGINAL_VISUAL_CONTROLS_FILE,
 	errorOverlayE2eFile,
+	hookOrderChangeE2eFile,
 	lostNodePathE2eFile,
 	rootFile,
 	visualControlsFile,
@@ -38,5 +40,13 @@ export default async function globalTeardown(): Promise<void> {
 			fs.readFileSync(ORIGINAL_ERROR_OVERLAY_E2E_FILE, 'utf-8'),
 		);
 		fs.unlinkSync(ORIGINAL_ERROR_OVERLAY_E2E_FILE);
+	}
+
+	if (fs.existsSync(ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE)) {
+		fs.writeFileSync(
+			hookOrderChangeE2eFile,
+			fs.readFileSync(ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE, 'utf-8'),
+		);
+		fs.unlinkSync(ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE);
 	}
 }

--- a/packages/example/e2e/hook-order-change.test.mts
+++ b/packages/example/e2e/hook-order-change.test.mts
@@ -22,16 +22,15 @@ test.describe('hook order refresh', () => {
 
 		const updatedContent = originalContent.replace(
 			'\tconst frame = useCurrentFrame();\n\n\treturn <div data-frame={frame}>one hook</div>;\n',
-			`\tconst frame = useCurrentFrame();\n\tconst [enabled] = React.useState(false);\n\n\treturn <div data-frame={frame} data-enabled={enabled ? 'yes' : 'no'}>two hooks</div>;\n`,
+			`\tconst frame = useCurrentFrame();\n\tReact.useState(false);\n\n\treturn <div data-frame={frame}>two hooks</div>;\n`,
 		);
 		expect(updatedContent).not.toBe(originalContent);
-
-		const logCountBefore = readStudioLogs().length;
 
 		await page.goto(`${STUDIO_URL}/hook-order-change-e2e`);
 		await expect(page).toHaveURL(/hook-order-change-e2e/, {timeout: 15_000});
 		await expect(page.getByText('one hook')).toBeVisible({timeout: 15_000});
 
+		const logCountBefore = readStudioLogs().length;
 		fs.writeFileSync(hookOrderChangeE2eFile, updatedContent);
 
 		await expect

--- a/packages/example/e2e/hook-order-change.test.mts
+++ b/packages/example/e2e/hook-order-change.test.mts
@@ -1,0 +1,53 @@
+import {expect, test} from '@playwright/test';
+import fs from 'fs';
+import {hookOrderChangeE2eFile, STUDIO_URL} from './constants.mts';
+import {readStudioLogs, stripAnsi} from './helpers.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test.describe('hook order refresh', () => {
+	test.beforeEach(async () => {
+		await startStudio();
+	});
+
+	test.afterEach(async () => {
+		await stopStudio();
+	});
+
+	test('reloads the Studio when a component gains a second hook', async ({
+		page,
+	}) => {
+		const originalContent = fs.readFileSync(hookOrderChangeE2eFile, 'utf-8');
+		expect(originalContent).toContain('one hook');
+		expect(originalContent).not.toContain('React.useState(false)');
+
+		const updatedContent = originalContent.replace(
+			'\tconst frame = useCurrentFrame();\n\n\treturn <div data-frame={frame}>one hook</div>;\n',
+			`\tconst frame = useCurrentFrame();\n\tconst [enabled] = React.useState(false);\n\n\treturn <div data-frame={frame} data-enabled={enabled ? 'yes' : 'no'}>two hooks</div>;\n`,
+		);
+		expect(updatedContent).not.toBe(originalContent);
+
+		const logCountBefore = readStudioLogs().length;
+
+		await page.goto(`${STUDIO_URL}/hook-order-change-e2e`);
+		await expect(page).toHaveURL(/hook-order-change-e2e/, {timeout: 15_000});
+		await expect(page.getByText('one hook')).toBeVisible({timeout: 15_000});
+
+		fs.writeFileSync(hookOrderChangeE2eFile, updatedContent);
+
+		await expect
+			.poll(
+				() => {
+					const newLogs = readStudioLogs().slice(logCountBefore).map(stripAnsi);
+					return newLogs.some((log) => log.includes('Built in'));
+				},
+				{
+					message: 'Expected webpack to rebuild after adding a second hook',
+					timeout: 30_000,
+				},
+			)
+			.toBe(true);
+
+		await expect(page.getByText('two hooks')).toBeVisible({timeout: 30_000});
+		await expect(page.getByText('one hook')).toHaveCount(0);
+	});
+});

--- a/packages/example/e2e/studio-server.mts
+++ b/packages/example/e2e/studio-server.mts
@@ -6,6 +6,7 @@ import {
 	LOGS_FILE,
 	ORIGINAL_CONTENT_FILE,
 	ORIGINAL_ERROR_OVERLAY_E2E_FILE,
+	ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE,
 	ORIGINAL_LOST_NODE_PATH_E2E_FILE,
 	ORIGINAL_VISUAL_CONTROLS_FILE,
 	STUDIO_PORT,
@@ -13,6 +14,7 @@ import {
 	e2eEntryPoint,
 	errorOverlayE2eFile,
 	exampleDir,
+	hookOrderChangeE2eFile,
 	lostNodePathE2eFile,
 	remotionBin,
 	rootFile,
@@ -69,6 +71,13 @@ export async function startStudio(): Promise<void> {
 		);
 	}
 
+	if (!fs.existsSync(ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE)) {
+		fs.writeFileSync(
+			ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE,
+			fs.readFileSync(hookOrderChangeE2eFile, 'utf-8'),
+		);
+	}
+
 	// Restore original files before starting
 	fs.writeFileSync(rootFile, fs.readFileSync(ORIGINAL_CONTENT_FILE, 'utf-8'));
 	fs.writeFileSync(
@@ -82,6 +91,10 @@ export async function startStudio(): Promise<void> {
 	fs.writeFileSync(
 		errorOverlayE2eFile,
 		fs.readFileSync(ORIGINAL_ERROR_OVERLAY_E2E_FILE, 'utf-8'),
+	);
+	fs.writeFileSync(
+		hookOrderChangeE2eFile,
+		fs.readFileSync(ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE, 'utf-8'),
 	);
 
 	fs.writeFileSync(LOGS_FILE, '');
@@ -219,6 +232,13 @@ export async function stopStudio(): Promise<void> {
 		fs.writeFileSync(
 			errorOverlayE2eFile,
 			fs.readFileSync(ORIGINAL_ERROR_OVERLAY_E2E_FILE, 'utf-8'),
+		);
+	}
+
+	if (fs.existsSync(ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE)) {
+		fs.writeFileSync(
+			hookOrderChangeE2eFile,
+			fs.readFileSync(ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE, 'utf-8'),
 		);
 	}
 }

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Composition, Folder} from 'remotion';
 import {ErrorOverlayRepro} from './ErrorOverlayE2e/ErrorOverlayRepro';
+import {HookOrderChangeE2e} from './HookOrderChangeE2e/HookOrderChangeRepro';
 import {LostNodePathRepro} from './LostNodePathE2e/LostNodePathRepro';
 import {NewVideoComp} from './NewVideo';
 import {SchemaTest, schemaTestSchema} from './SchemaTest';
@@ -65,6 +66,9 @@ export const E2eTestRoot: React.FC = () => {
 					fps={30}
 					durationInFrames={30}
 				/>
+			</Folder>
+			<Folder name="hook-order-change">
+				<HookOrderChangeE2e />
 			</Folder>
 			<NewVideoComp />
 		</>

--- a/packages/example/src/HookOrderChangeE2e/HookOrderChangeRepro.tsx
+++ b/packages/example/src/HookOrderChangeE2e/HookOrderChangeRepro.tsx
@@ -1,3 +1,5 @@
+// Regression fixture for https://github.com/remotion-dev/remotion/issues/7398
+// The e2e test toggles the hook count below to confirm the Studio refreshes.
 import React from 'react';
 import {Composition, useCurrentFrame} from 'remotion';
 

--- a/packages/example/src/HookOrderChangeE2e/HookOrderChangeRepro.tsx
+++ b/packages/example/src/HookOrderChangeE2e/HookOrderChangeRepro.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {Composition, useCurrentFrame} from 'remotion';
+
+const HookOrderChangeRepro: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	return <div data-frame={frame}>one hook</div>;
+};
+
+export const HookOrderChangeE2e: React.FC = () => {
+	return (
+		<Composition
+			id="hook-order-change-e2e"
+			component={HookOrderChangeRepro}
+			width={1920}
+			height={1080}
+			fps={30}
+			durationInFrames={60}
+		/>
+	);
+};


### PR DESCRIPTION
Adds an end-to-end regression test for the Studio fast-refresh case described in #7398: a component starts with one hook and then gains a second hook, which should force the Studio to recover instead of staying stale.

### What changed
- Adds a dedicated Studio fixture in `packages/example/src/HookOrderChangeE2e/` where the composition and component live in the same file and the component is not exported.
- Wires the fixture into the example Studio root so it can be visited from the existing e2e harness.
- Adds a Playwright test that edits the fixture from one hook to two hooks, waits for rebuild, and verifies the Studio shows the updated render.
- Extends the e2e setup/teardown helpers so the new fixture is safely restored between runs.

### Notes
- The test is intentionally structured to exercise the Fast Refresh edge case from the issue report, including the same-file/non-exported component scenario.
- No Studio runtime code changes were needed; the existing remount/recovery path is what the regression test now covers.

Closes #7398