### PR TITLE
`@remotion/studio`: Show keyframe markers in timeline

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -7,16 +7,13 @@ import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {EffectSchemaFieldInfo} from '../../helpers/timeline-layout';
 import {EXPANDED_SECTION_PADDING_RIGHT} from '../../helpers/timeline-layout';
 import {callApi} from '../call-api';
+import {getComputedStatusLabel} from './get-timeline-keyframes';
 import {enqueueSavePropChange} from './save-prop-queue';
 import {getTimelineFieldLabelRowStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
-import {
-	getComputedStatusLabel,
-	TimelineFieldValue,
-	UnsupportedStatus,
-} from './TimelineSchemaField';
+import {TimelineFieldValue, UnsupportedStatus} from './TimelineSchemaField';
 
 const fieldRowBase: React.CSSProperties = {
 	paddingRight: EXPANDED_SECTION_PADDING_RIGHT,

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -1,0 +1,168 @@
+import React, {useContext, useMemo} from 'react';
+import {Internals, type TSequence, useVideoConfig} from 'remotion';
+import {TIMELINE_TRACK_SEPARATOR, WARNING_COLOR} from '../../helpers/colors';
+import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {
+	buildTimelineTree,
+	flattenVisibleTreeNodes,
+	getExpandedTrackHeight,
+	getTreeRowHeight,
+	TIMELINE_ITEM_BORDER_BOTTOM,
+} from '../../helpers/timeline-layout';
+import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
+import {getTimelineKeyframes} from './TimelineSchemaField';
+import {TimelineWidthContext} from './TimelineWidthProvider';
+
+const row: React.CSSProperties = {
+	position: 'relative',
+};
+
+const separator: React.CSSProperties = {
+	height: 1,
+	backgroundColor: TIMELINE_TRACK_SEPARATOR,
+};
+
+const section: React.CSSProperties = {
+	borderBottom: `1px solid ${TIMELINE_TRACK_SEPARATOR}`,
+};
+
+const diamondBase: React.CSSProperties = {
+	position: 'absolute',
+	width: 8,
+	height: 8,
+	backgroundColor: WARNING_COLOR,
+	borderRadius: 1,
+	boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.4)',
+	pointerEvents: 'none',
+};
+
+const getNodeKeyframes = ({
+	node,
+	nodePath,
+	codeValues,
+}: {
+	node: ReturnType<typeof flattenVisibleTreeNodes>[number]['node'];
+	nodePath: SequenceNodePathInfo['sequenceSubscriptionKey'];
+	codeValues: React.ContextType<
+		typeof Internals.VisualModeCodeValuesContext
+	>['codeValues'];
+}): ReturnType<typeof getTimelineKeyframes> => {
+	if (node.kind !== 'field' || node.field === null) {
+		return [];
+	}
+
+	if (node.field.kind === 'sequence-field') {
+		return getTimelineKeyframes(
+			Internals.getCodeValuesCtx(codeValues, nodePath)?.[node.field.key],
+		);
+	}
+
+	const effectStatus = Internals.getEffectCodeValuesCtx({
+		codeValues,
+		nodePath,
+		effectIndex: node.field.effectIndex,
+	});
+
+	return getTimelineKeyframes(
+		effectStatus.type === 'can-update-effect'
+			? effectStatus.props?.[node.field.key]
+			: null,
+	);
+};
+
+const TimelineExpandedTrackKeyframesInner: React.FC<{
+	readonly sequence: TSequence;
+	readonly nodePathInfo: SequenceNodePathInfo;
+}> = ({nodePathInfo, sequence}) => {
+	const videoConfig = useVideoConfig();
+	const timelineWidth = useContext(TimelineWidthContext);
+	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
+	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {getDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
+
+	const tree = useMemo(
+		() =>
+			buildTimelineTree({
+				sequence,
+				nodePathInfo,
+				getDragOverrides,
+				codeValues,
+			}),
+		[codeValues, getDragOverrides, nodePathInfo, sequence],
+	);
+
+	const flat = useMemo(
+		() => flattenVisibleTreeNodes({nodes: tree, getIsExpanded}),
+		[tree, getIsExpanded],
+	);
+
+	const expandedHeight = useMemo(
+		() =>
+			getExpandedTrackHeight({
+				sequence,
+				nodePathInfo,
+				getIsExpanded,
+				codeValues,
+			}),
+		[codeValues, getIsExpanded, nodePathInfo, sequence],
+	);
+
+	const rows = useMemo(
+		() =>
+			flat.map(({node}) => ({
+				height: getTreeRowHeight(node),
+				keyframes: getNodeKeyframes({
+					node,
+					nodePath: nodePathInfo.sequenceSubscriptionKey,
+					codeValues,
+				}),
+				key: JSON.stringify(node.nodePathInfo),
+			})),
+		[codeValues, flat, nodePathInfo.sequenceSubscriptionKey],
+	);
+
+	return (
+		<div
+			style={{
+				height: expandedHeight + TIMELINE_ITEM_BORDER_BOTTOM,
+			}}
+		>
+			<div style={{...section, height: expandedHeight}}>
+				{rows.map(({height, keyframes, key}, i) => {
+					return (
+						<React.Fragment key={key}>
+							{i > 0 ? <div style={separator} /> : null}
+							<div style={{...row, height}}>
+								{timelineWidth === null
+									? null
+									: keyframes.map((keyframe) => (
+											<div
+												key={`${keyframe.frame}-${JSON.stringify(keyframe.value)}`}
+												style={{
+													...diamondBase,
+													left: getXPositionOfItemInTimelineImperatively(
+														keyframe.frame,
+														videoConfig.durationInFrames,
+														timelineWidth,
+													),
+													top: height / 2,
+													transform: 'translate(-50%, -50%) rotate(45deg)',
+												}}
+												title={`Keyframe at frame ${keyframe.frame}`}
+											/>
+										))}
+							</div>
+						</React.Fragment>
+					);
+				})}
+			</div>
+		</div>
+	);
+};
+
+export const TimelineExpandedTrackKeyframes = React.memo(
+	TimelineExpandedTrackKeyframesInner,
+);

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -12,7 +12,7 @@ import {
 	TIMELINE_PADDING,
 } from '../../helpers/timeline-layout';
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
-import {getTimelineKeyframes} from './TimelineSchemaField';
+import {getTimelineKeyframes} from './get-timeline-keyframes';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
 const row: React.CSSProperties = {
@@ -80,19 +80,16 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 	const timelineWidth = useContext(TimelineWidthContext);
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
-	const {getDragOverrides} = useContext(
-		Internals.VisualModeDragOverridesContext,
-	);
 
 	const tree = useMemo(
 		() =>
 			buildTimelineTree({
 				sequence,
 				nodePathInfo,
-				getDragOverrides,
+				getDragOverrides: () => ({}),
 				codeValues,
 			}),
-		[codeValues, getDragOverrides, nodePathInfo, sequence],
+		[codeValues, nodePathInfo, sequence],
 	);
 
 	const flat = useMemo(
@@ -141,7 +138,7 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 									? null
 									: keyframes.map((keyframe) => (
 											<div
-												key={`${keyframe.frame}-${JSON.stringify(keyframe.value)}`}
+												key={String(keyframe.frame)}
 												style={{
 													...diamondBase,
 													left:

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -1,6 +1,6 @@
 import React, {useContext, useMemo} from 'react';
 import {Internals, type TSequence, useVideoConfig} from 'remotion';
-import {TIMELINE_TRACK_SEPARATOR, WARNING_COLOR} from '../../helpers/colors';
+import {LIGHT_TEXT, TIMELINE_TRACK_SEPARATOR} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
@@ -9,6 +9,7 @@ import {
 	getExpandedTrackHeight,
 	getTreeRowHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
+	TIMELINE_PADDING,
 } from '../../helpers/timeline-layout';
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {getTimelineKeyframes} from './TimelineSchemaField';
@@ -31,7 +32,7 @@ const diamondBase: React.CSSProperties = {
 	position: 'absolute',
 	width: 8,
 	height: 8,
-	backgroundColor: WARNING_COLOR,
+	backgroundColor: LIGHT_TEXT,
 	borderRadius: 1,
 	boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.4)',
 	pointerEvents: 'none',
@@ -143,11 +144,12 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 												key={`${keyframe.frame}-${JSON.stringify(keyframe.value)}`}
 												style={{
 													...diamondBase,
-													left: getXPositionOfItemInTimelineImperatively(
-														keyframe.frame,
-														videoConfig.durationInFrames,
-														timelineWidth,
-													),
+													left:
+														getXPositionOfItemInTimelineImperatively(
+															keyframe.frame,
+															videoConfig.durationInFrames,
+															timelineWidth,
+														) - TIMELINE_PADDING,
 													top: height / 2,
 													transform: 'translate(-50%, -50%) rotate(45deg)',
 												}}

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type {
+	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusFalse,
 	CanUpdateSequencePropStatusTrue,
 } from 'remotion';
@@ -47,6 +48,22 @@ export const getComputedStatusLabel = (
 	}
 
 	return propStatus.keyframes?.length ? 'keyframed' : 'computed';
+};
+
+export const getTimelineKeyframes = (
+	propStatus: CanUpdateSequencePropStatus | null | undefined,
+): {frame: number; value: unknown}[] => {
+	if (!propStatus || propStatus.canUpdate) {
+		return [];
+	}
+
+	if (propStatus.reason !== 'computed') {
+		throw new Error(
+			`Unsupported prop status: ${propStatus.reason satisfies never}`,
+		);
+	}
+
+	return propStatus.keyframes ?? [];
 };
 
 export const TimelineNonEditableStatus: React.FC<{

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type {
-	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusFalse,
 	CanUpdateSequencePropStatusTrue,
 } from 'remotion';
@@ -9,6 +8,7 @@ import type {
 	TimelineFieldOnDragValueChange,
 	TimelineFieldOnSave,
 } from '../../helpers/timeline-layout';
+import {getComputedStatusLabel} from './get-timeline-keyframes';
 import {TimelineBooleanField} from './TimelineBooleanField';
 import {TimelineColorField} from './TimelineColorField';
 import {TimelineEnumField} from './TimelineEnumField';
@@ -36,34 +36,6 @@ export const UnsupportedStatus: React.FC<{
 	readonly label: string;
 }> = ({label}) => {
 	return <span style={unsupportedLabel}>{label}</span>;
-};
-
-export const getComputedStatusLabel = (
-	propStatus: CanUpdateSequencePropStatusFalse,
-): string => {
-	if (propStatus.reason !== 'computed') {
-		throw new Error(
-			`Unsupported prop status: ${propStatus.reason satisfies never}`,
-		);
-	}
-
-	return propStatus.keyframes?.length ? 'keyframed' : 'computed';
-};
-
-export const getTimelineKeyframes = (
-	propStatus: CanUpdateSequencePropStatus | null | undefined,
-): {frame: number; value: unknown}[] => {
-	if (!propStatus || propStatus.canUpdate) {
-		return [];
-	}
-
-	if (propStatus.reason !== 'computed') {
-		throw new Error(
-			`Unsupported prop status: ${propStatus.reason satisfies never}`,
-		);
-	}
-
-	return propStatus.keyframes ?? [];
 };
 
 export const TimelineNonEditableStatus: React.FC<{

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -1,22 +1,14 @@
 import React, {useContext, useMemo} from 'react';
-import type {CodeValues} from 'remotion';
-import {Internals, type TSequence} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
-import type {
-	SequenceNodePathInfo,
-	TrackWithHash,
-} from '../../helpers/get-timeline-sequence-sort-key';
+import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
 import {
-	getExpandedTrackHeight,
 	getTimelineLayerHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
 	TIMELINE_PADDING,
 } from '../../helpers/timeline-layout';
-import {
-	ExpandedTracksGetterContext,
-	type GetIsExpanded,
-} from '../ExpandedTracksProvider';
+import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {MaxTimelineTracksReached} from './MaxTimelineTracks';
+import {TimelineExpandedTrackKeyframes} from './TimelineExpandedTrackKeyframes';
 import {TimelineSequence} from './TimelineSequence';
 import {TimelineTimePadding} from './TimelineTimeIndicators';
 
@@ -30,34 +22,12 @@ const timelineContent: React.CSSProperties = {
 	minHeight: '100%',
 };
 
-const getExpandedPlaceholderStyle = ({
-	sequence,
-	nodePathInfo,
-	getIsExpanded,
-	codeValues,
-}: {
-	sequence: TSequence;
-	nodePathInfo: SequenceNodePathInfo;
-	getIsExpanded: GetIsExpanded;
-	codeValues: CodeValues;
-}): React.CSSProperties => ({
-	height:
-		getExpandedTrackHeight({
-			sequence,
-			nodePathInfo,
-			getIsExpanded,
-			codeValues,
-		}) + TIMELINE_ITEM_BORDER_BOTTOM,
-});
-
 const TimelineTracksInner: React.FC<{
 	readonly timeline: TrackWithHash[];
 	readonly hasBeenCut: boolean;
 }> = ({timeline, hasBeenCut}) => {
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
-
 	const previewServerConnected = previewServerState.type === 'connected';
 
 	const timelineStyle: React.CSSProperties = useMemo(() => {
@@ -86,13 +56,9 @@ const TimelineTracksInner: React.FC<{
 								<TimelineSequence s={track.sequence} />
 							</div>
 							{isExpanded && track.nodePathInfo && previewServerConnected ? (
-								<div
-									style={getExpandedPlaceholderStyle({
-										sequence: track.sequence,
-										nodePathInfo: track.nodePathInfo,
-										getIsExpanded,
-										codeValues,
-									})}
+								<TimelineExpandedTrackKeyframes
+									sequence={track.sequence}
+									nodePathInfo={track.nodePathInfo}
 								/>
 							) : null}
 						</div>

--- a/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
@@ -1,0 +1,32 @@
+import type {
+	CanUpdateSequencePropStatus,
+	CanUpdateSequencePropStatusFalse,
+} from 'remotion';
+
+export const getComputedStatusLabel = (
+	propStatus: CanUpdateSequencePropStatusFalse,
+): string => {
+	if (propStatus.reason !== 'computed') {
+		throw new Error(
+			`Unsupported prop status: ${propStatus.reason satisfies never}`,
+		);
+	}
+
+	return propStatus.keyframes?.length ? 'keyframed' : 'computed';
+};
+
+export const getTimelineKeyframes = (
+	propStatus: CanUpdateSequencePropStatus | null | undefined,
+): {frame: number; value: unknown}[] => {
+	if (!propStatus || propStatus.canUpdate) {
+		return [];
+	}
+
+	if (propStatus.reason !== 'computed') {
+		throw new Error(
+			`Unsupported prop status: ${propStatus.reason satisfies never}`,
+		);
+	}
+
+	return propStatus.keyframes ?? [];
+};


### PR DESCRIPTION
## Summary
- render keyframe diamonds in the expanded timeline track area
- reuse parsed keyframe metadata from computed prop statuses
- keep the PR focused on the Studio timeline change