### PR TITLE
`@remotion/media`: correct volume callback frame when Audio is inside Sequence from={-N}

### DIFF
--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -2,6 +2,7 @@ import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import type {LogLevel, LoopVolumeCurveBehavior, VolumeProp} from 'remotion';
 import {
 	Internals,
+	Loop,
 	Audio as RemotionAudio,
 	useBufferState,
 	useCurrentFrame,
@@ -19,7 +20,6 @@ const {
 	SharedAudioContext,
 	useMediaMutedState,
 	useMediaVolumeState,
-	useFrameForVolumeProp,
 	evaluateVolume,
 	warnAboutTooHighVolume,
 	usePreload,
@@ -46,6 +46,7 @@ type NewAudioForPreviewProps = {
 	readonly onError: MediaOnError | undefined;
 	readonly credentials: RequestCredentials | undefined;
 	readonly setMediaDurationInSeconds: (durationInSeconds: number) => void;
+	readonly mediaStartsAt: number;
 };
 
 const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
@@ -68,6 +69,7 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 	onError,
 	credentials,
 	setMediaDurationInSeconds,
+	mediaStartsAt,
 }) => {
 	const videoConfig = useUnsafeVideoConfig();
 	const frame = useCurrentFrame();
@@ -87,9 +89,11 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 	const [mediaMuted] = useMediaMutedState();
 	const [mediaVolume] = useMediaVolumeState();
 
-	const volumePropFrame = useFrameForVolumeProp(
-		loopVolumeCurveBehavior ?? 'repeat',
-	);
+	const loopInfo = Loop.useLoop();
+	const volumePropFrame =
+		loopVolumeCurveBehavior === 'repeat' || loopInfo === null
+			? frame + mediaStartsAt
+			: frame + mediaStartsAt + loopInfo.durationInFrames * loopInfo.iteration;
 
 	const userPreferredVolume = evaluateVolume({
 		frame: volumePropFrame,
@@ -404,6 +408,7 @@ type InnerAudioProps = {
 	readonly onError?: MediaOnError;
 	readonly credentials?: RequestCredentials;
 	readonly setMediaDurationInSeconds?: (durationInSeconds: number) => void;
+	readonly _remotionInternalMediaStartsAt?: number;
 };
 
 export const AudioForPreview: React.FC<InnerAudioProps> = ({
@@ -426,6 +431,7 @@ export const AudioForPreview: React.FC<InnerAudioProps> = ({
 	onError,
 	credentials,
 	setMediaDurationInSeconds,
+	_remotionInternalMediaStartsAt,
 }) => {
 	const preloadedSrc = usePreload(src);
 
@@ -433,6 +439,9 @@ export const AudioForPreview: React.FC<InnerAudioProps> = ({
 	const frame = useCurrentFrame();
 	const videoConfig = useVideoConfig();
 	const currentTime = frame / videoConfig.fps;
+
+	const startsAtFromContext = Internals.useMediaStartsAt();
+	const mediaStartsAt = _remotionInternalMediaStartsAt ?? startsAtFromContext;
 
 	const showShow = useMemo(() => {
 		return (
@@ -487,6 +496,7 @@ export const AudioForPreview: React.FC<InnerAudioProps> = ({
 			credentials={credentials}
 			fallbackHtml5AudioProps={fallbackHtml5AudioProps}
 			setMediaDurationInSeconds={setMediaDurationInSeconds}
+			mediaStartsAt={mediaStartsAt}
 		/>
 	);
 };

--- a/packages/media/src/audio/audio-for-rendering.tsx
+++ b/packages/media/src/audio/audio-for-rendering.tsx
@@ -38,6 +38,7 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 	trimBefore,
 	onError,
 	credentials,
+	_remotionInternalMediaStartsAt,
 }) => {
 	const defaultLogLevel = Internals.useLogLevel();
 	const logLevel = overriddenLogLevel ?? defaultLogLevel;
@@ -48,7 +49,8 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 	const {registerRenderAsset, unregisterRenderAsset} = useContext(
 		Internals.RenderAssetManager,
 	);
-	const startsAt = Internals.useMediaStartsAt();
+	const startsAtFromContext = Internals.useMediaStartsAt();
+	const startsAt = _remotionInternalMediaStartsAt ?? startsAtFromContext;
 
 	const environment = useRemotionEnvironment();
 

--- a/packages/media/src/audio/audio.tsx
+++ b/packages/media/src/audio/audio.tsx
@@ -141,13 +141,17 @@ const AudioInner: React.FC<
 			hidden={hidden}
 		>
 			{environment.isRendering ? (
-				<AudioForRendering {...otherProps} />
+				<AudioForRendering
+					{...otherProps}
+					_remotionInternalMediaStartsAt={mediaStartsAt}
+				/>
 			) : (
 				<AudioForPreview
 					name={name}
 					{...otherProps}
 					stack={stack ?? null}
 					setMediaDurationInSeconds={setMediaDurationInSeconds}
+					_remotionInternalMediaStartsAt={mediaStartsAt}
 				/>
 			)}
 		</Sequence>

--- a/packages/media/src/audio/props.ts
+++ b/packages/media/src/audio/props.ts
@@ -32,6 +32,10 @@ export type AudioProps = {
 	loop?: boolean;
 	audioStreamIndex?: number;
 	_remotionInternalNativeLoopPassed?: boolean;
+	/**
+	 * @deprecated For internal use only
+	 */
+	_remotionInternalMediaStartsAt?: number;
 	fallbackHtml5AudioProps?: FallbackHtml5AudioProps;
 	disallowFallbackToHtml5Audio?: boolean;
 	toneFrequency?: number;


### PR DESCRIPTION
## Problem

Fixes #7568

When `<Audio>` from `@remotion/media` is placed inside `<Sequence from={-N}>`, the `volume` callback receives the wrong frame value compared to `<Html5Audio>` from `remotion`:

- `<Html5Audio>`: volume callback gets `f=0` at the logical start ✓
- `<Audio>` (media): volume callback gets `f=N` ✗

## Root Cause

`audio.tsx` wraps children in an inner `<Sequence layout="none" from={from ?? 0}>`. This inner Sequence overrides `SequenceContext`, so when `AudioForRendering`/`AudioForPreview` call `useMediaStartsAt()`, they read `relativeFrom=0` from the inner Sequence instead of `-N` from the outer user-supplied sequence.

The bug was introduced in commit `5d0d4314bf` which added the optional `from`/`durationInFrames` feature via an inner hidden Sequence.

## Fix

`AudioInner` in `audio.tsx` already calls `Internals.useMediaStartsAt()` **before** the inner `<Sequence>`, correctly capturing the outer `-N`. This fix passes that pre-computed value down as `_remotionInternalMediaStartsAt` to both `AudioForRendering` and `AudioForPreview`, bypassing the shadowed context inside the inner Sequence.

**Changed files** (4 files, +26/-6 lines):
- `packages/media/src/audio/props.ts` — add `_remotionInternalMediaStartsAt?: number` to `AudioProps`
- `packages/media/src/audio/audio.tsx` — pass `_remotionInternalMediaStartsAt={mediaStartsAt}` to both render paths
- `packages/media/src/audio/audio-for-rendering.tsx` — use passed prop with fallback to context
- `packages/media/src/audio/audio-for-preview.tsx` — thread prop through and use in volume frame computation