### PR TITLE
`@remotion/studio-server`: Fix punctuation color invisible in light mode terminal

### DIFF
--- a/packages/studio-server/src/preview-server/routes/log-updates/formatting.ts
+++ b/packages/studio-server/src/preview-server/routes/log-updates/formatting.ts
@@ -29,7 +29,9 @@ export const bg = (r: number, g: number, b: number, str: string) =>
 // Monokai-inspired syntax colors
 export const attrName = (str: string) => fg(166, 226, 46, str);
 export const equals = (str: string) => fg(249, 38, 114, str);
-export const punctuation = (str: string) => fg(248, 248, 242, str);
+// Use the terminal's default foreground color so punctuation is visible in both
+// light and dark terminal themes.
+export const punctuation = (str: string) => str;
 export const stringValue = (str: string) => fg(230, 219, 116, str);
 export const numberValue = (str: string) => fg(174, 129, 255, str);
 export const strikeThrough = (str: string) =>


### PR DESCRIPTION
The `punctuation` helper in `formatting.ts` was using `fg(248, 248, 242)` — near-white RGB — for all punctuation characters (`(`, `{`, `:`, `}`, `)`) and property keys. This made the entire `blur({horizontal: false})` portion of Code Edits terminal logs essentially invisible on light-theme terminals.

**Fix:** Change `punctuation` to return the string unchanged, using the terminal's default foreground color. This ensures readability in both dark and light terminal themes.

Fixes #7581