### PR TITLE
@remotion/transitions: Add book flip transition

### DIFF
--- a/packages/docs/components/TableOfContents/transitions/presentations.tsx
+++ b/packages/docs/components/TableOfContents/transitions/presentations.tsx
@@ -7,6 +7,7 @@ import {none} from '@remotion/transitions/none';
 import {slide} from '@remotion/transitions/slide';
 import {wipe} from '@remotion/transitions/wipe';
 import React from 'react';
+import {BookFlipTocPreview} from '../../transitions/book-flip-toc-preview';
 import {CrosswarpTocPreview} from '../../transitions/crosswarp-toc-preview';
 import {DissolveTocPreview} from '../../transitions/dissolve-toc-preview';
 import {PresentationPreview} from '../../transitions/previews';
@@ -132,6 +133,18 @@ export const Presentations: React.FC<{
 						</strong>
 						<HtmlInCanvasLabel />
 						<div>Zoom and rotate scenes with a radial blur</div>
+					</div>
+				</div>
+			</TOCItem>
+			<TOCItem link="/docs/transitions/presentations/book-flip">
+				<div style={row}>
+					<BookFlipTocPreview />
+					<div style={{flex: 1, marginLeft: 10}}>
+						<strong>
+							<code>{'bookFlip()'}</code>
+						</strong>
+						<HtmlInCanvasLabel />
+						<div>Flip the scenes like a page turning in a book</div>
 					</div>
 				</div>
 			</TOCItem>

--- a/packages/docs/components/demos/BookFlipDemo.tsx
+++ b/packages/docs/components/demos/BookFlipDemo.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+import {BookFlipTransitionPreview} from '../transitions/book-flip-preview';
+import {useHtmlInCanvasDocsDemoBranch} from './useHtmlInCanvasDocsDemoBranch';
+
+export const BookFlipDocsDemo: React.FC = () => {
+	const branch = useHtmlInCanvasDocsDemoBranch();
+
+	if (branch === 'pending') {
+		return <AbsoluteFill style={{backgroundColor: '#000'}} />;
+	}
+
+	if (branch === 'fallback') {
+		return (
+			<AbsoluteFill
+				style={{
+					backgroundColor: '#111',
+					color: 'white',
+					justifyContent: 'center',
+					alignItems: 'center',
+					fontFamily: 'sans-serif',
+					fontSize: 34,
+					textAlign: 'center',
+					padding: 40,
+				}}
+			>
+				<div>Book flip requires Chrome with html-in-canvas enabled.</div>
+			</AbsoluteFill>
+		);
+	}
+
+	return <BookFlipTransitionPreview />;
+};

--- a/packages/docs/components/demos/index.tsx
+++ b/packages/docs/components/demos/index.tsx
@@ -14,6 +14,7 @@ import {
 	clockWipePresentationDemo,
 	cubePresentationDemo,
 	crosswarpPresentationDemo,
+	bookFlipPresentationDemo,
 	customPresentationDemo,
 	customTimingDemo,
 	ellipseDemo,
@@ -106,6 +107,7 @@ const demos: DemoType[] = [
 	dissolvePresentationDemo,
 	ripplePresentationDemo,
 	crosswarpPresentationDemo,
+	bookFlipPresentationDemo,
 	swapPresentationDemo,
 ];
 

--- a/packages/docs/components/demos/types.ts
+++ b/packages/docs/components/demos/types.ts
@@ -14,6 +14,7 @@ import {
 } from '../transitions/previews';
 import {ArrowDemo} from './Arrow';
 import {CircleDemo} from './Circle';
+import {BookFlipDocsDemo} from './BookFlipDemo';
 import {CrosswarpDocsDemo} from './CrosswarpDemo';
 import {DissolveDocsDemo} from './DissolveDemo';
 import {EllipseDemo} from './Ellipse';
@@ -932,6 +933,19 @@ export const zoomBlurPresentationDemo: DemoType = {
 	durationInFrames: 90,
 	fps: 30,
 	id: 'zoom-blur',
+	autoPlay: true,
+	controls: false,
+	logLevel: 'info',
+	options: [],
+};
+
+export const bookFlipPresentationDemo: DemoType = {
+	comp: BookFlipDocsDemo,
+	compHeight: 1080,
+	compWidth: 1920,
+	durationInFrames: 90,
+	fps: 30,
+	id: 'book-flip',
 	autoPlay: true,
 	controls: false,
 	logLevel: 'info',

--- a/packages/docs/components/transitions/book-flip-preview.tsx
+++ b/packages/docs/components/transitions/book-flip-preview.tsx
@@ -1,0 +1,67 @@
+import {linearTiming, TransitionSeries} from '@remotion/transitions';
+import {bookFlip} from '@remotion/transitions/book-flip';
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+const sceneStyle: React.CSSProperties = {
+	justifyContent: 'center',
+	alignItems: 'center',
+	fontFamily: 'sans-serif',
+	fontWeight: 900,
+	color: 'white',
+	fontSize: '40cqmin',
+};
+
+const SceneA: React.FC = () => {
+	return (
+		<AbsoluteFill style={{...sceneStyle, backgroundColor: '#0b84f3'}}>
+			A
+		</AbsoluteFill>
+	);
+};
+
+const SceneB: React.FC = () => {
+	return (
+		<AbsoluteFill style={{...sceneStyle, backgroundColor: 'pink'}}>
+			B
+		</AbsoluteFill>
+	);
+};
+
+export const BookFlipTransitionPreview: React.FC = () => {
+	return (
+		<AbsoluteFill style={{containerType: 'size'}}>
+			<TransitionSeries>
+				<TransitionSeries.Sequence durationInFrames={60}>
+					<SceneA />
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Transition
+					presentation={bookFlip({})}
+					timing={linearTiming({durationInFrames: 30})}
+				/>
+				<TransitionSeries.Sequence durationInFrames={60}>
+					<SceneB />
+				</TransitionSeries.Sequence>
+			</TransitionSeries>
+		</AbsoluteFill>
+	);
+};
+
+export const BookFlipTransitionPreviewThumb: React.FC = () => {
+	return (
+		<AbsoluteFill style={{containerType: 'size'}}>
+			<TransitionSeries>
+				<TransitionSeries.Sequence durationInFrames={30}>
+					<SceneA />
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Transition
+					presentation={bookFlip({})}
+					timing={linearTiming({durationInFrames: 30})}
+				/>
+				<TransitionSeries.Sequence durationInFrames={60}>
+					<SceneB />
+				</TransitionSeries.Sequence>
+			</TransitionSeries>
+		</AbsoluteFill>
+	);
+};

--- a/packages/docs/components/transitions/book-flip-toc-preview.tsx
+++ b/packages/docs/components/transitions/book-flip-toc-preview.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+export const BookFlipTocPreview: React.FC = () => {
+	return (
+		<div
+			style={{
+				width: 108,
+				height: 60,
+				flex: 'none',
+				borderRadius: 6,
+				overflow: 'hidden',
+				display: 'flex',
+				boxShadow: '0 1px 6px rgba(0, 0, 0, 0.18)',
+				background:
+					'linear-gradient(90deg, #0b84f3 0 50%, #f3a7c4 50% 100%)',
+				position: 'relative',
+				fontFamily: 'sans-serif',
+				fontWeight: 900,
+				color: 'white',
+			}}
+		>
+			<div
+				style={{
+					flex: 1,
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					fontSize: 26,
+				}}
+			>
+				A
+			</div>
+			<div
+				style={{
+					flex: 1,
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					fontSize: 26,
+				}}
+			>
+				B
+			</div>
+			<div
+				style={{
+					position: 'absolute',
+					top: 0,
+					bottom: 0,
+					left: '50%',
+					width: 2,
+					marginLeft: -1,
+					background: 'rgba(255, 255, 255, 0.6)',
+				}}
+			/>
+		</div>
+	);
+};

--- a/packages/docs/docs/transitions/presentations/book-flip.mdx
+++ b/packages/docs/docs/transitions/presentations/book-flip.mdx
@@ -1,0 +1,75 @@
+---
+crumb: '@remotion/transitions - Presentations'
+title: 'bookFlip()'
+---
+
+# bookFlip()<AvailableFrom v="4.0.465"/>
+
+A presentation where the scenes skew and shade like a page turning in a book.
+
+<Demo type="book-flip" />
+
+:::warning
+This presentation is built with [HTML-in-canvas](/docs/remotion/html-in-canvas) and requires [Google Chrome](https://www.google.com/chrome/) with `chrome://flags/#canvas-draw-element` enabled. It does not work in Firefox or Safari.
+:::
+
+## Example
+
+```tsx twoslash title="BookFlipTransition.tsx"
+import {AbsoluteFill} from 'remotion';
+
+const Letter: React.FC<{
+  children: React.ReactNode;
+  color: string;
+}> = ({children, color}) => {
+  return (
+    <AbsoluteFill
+      style={{
+        backgroundColor: color,
+        opacity: 0.9,
+        justifyContent: 'center',
+        alignItems: 'center',
+        fontSize: 200,
+        color: 'white',
+      }}
+    >
+      {children}
+    </AbsoluteFill>
+  );
+};
+// ---cut---
+import {linearTiming, TransitionSeries} from '@remotion/transitions';
+import {bookFlip} from '@remotion/transitions/book-flip';
+
+const BasicTransition = () => {
+  return (
+    <TransitionSeries>
+      <TransitionSeries.Sequence durationInFrames={40}>
+        <Letter color="#0b84f3">A</Letter>
+      </TransitionSeries.Sequence>
+      <TransitionSeries.Transition
+        presentation={bookFlip({})}
+        timing={linearTiming({durationInFrames: 30})}
+      />
+      <TransitionSeries.Sequence durationInFrames={60}>
+        <Letter color="pink">B</Letter>
+      </TransitionSeries.Sequence>
+    </TransitionSeries>
+  );
+};
+```
+
+## API
+
+Takes no options.
+
+## Compatibility
+
+<CompatibilityTable chrome firefox={false} safari={false} nodejs bun serverlessFunctions clientSideRendering serverSideRendering player studio />
+
+For Preview, Chrome with the `chrome://flags/#canvas-draw-element` flag enabled is required.
+
+## See also
+
+- [Source code for this presentation](https://github.com/remotion-dev/remotion/blob/main/packages/transitions/src/presentations/book-flip.tsx)
+- [Presentations](/docs/transitions/presentations)

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -788,6 +788,7 @@ const sidebars: SidebarsConfig = {
 						'transitions/presentations/clock-wipe',
 						'transitions/presentations/iris',
 						'transitions/presentations/zoom-blur',
+						'transitions/presentations/book-flip',
 						'transitions/presentations/zoom-in-out',
 						'transitions/presentations/dissolve',
 						'transitions/presentations/ripple',

--- a/packages/example/src/HtmlInCanvas/book-flip-doc.tsx
+++ b/packages/example/src/HtmlInCanvas/book-flip-doc.tsx
@@ -1,0 +1,67 @@
+import {linearTiming, TransitionSeries} from '@remotion/transitions';
+import {bookFlip} from '@remotion/transitions/book-flip';
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+const sceneStyle: React.CSSProperties = {
+	justifyContent: 'center',
+	alignItems: 'center',
+	fontFamily: 'sans-serif',
+	fontWeight: 900,
+	color: 'white',
+	fontSize: '40cqmin',
+};
+
+const SceneA: React.FC = () => {
+	return (
+		<AbsoluteFill style={{...sceneStyle, backgroundColor: '#0b84f3'}}>
+			A
+		</AbsoluteFill>
+	);
+};
+
+const SceneB: React.FC = () => {
+	return (
+		<AbsoluteFill style={{...sceneStyle, backgroundColor: 'pink'}}>
+			B
+		</AbsoluteFill>
+	);
+};
+
+export const BookFlipTransitionDoc: React.FC = () => {
+	return (
+		<AbsoluteFill style={{containerType: 'size'}}>
+			<TransitionSeries>
+				<TransitionSeries.Sequence durationInFrames={60}>
+					<SceneA />
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Transition
+					presentation={bookFlip({})}
+					timing={linearTiming({durationInFrames: 30})}
+				/>
+				<TransitionSeries.Sequence durationInFrames={60}>
+					<SceneB />
+				</TransitionSeries.Sequence>
+			</TransitionSeries>
+		</AbsoluteFill>
+	);
+};
+
+export const BookFlipTransitionDocThumb: React.FC = () => {
+	return (
+		<AbsoluteFill style={{containerType: 'size'}}>
+			<TransitionSeries>
+				<TransitionSeries.Sequence durationInFrames={30}>
+					<SceneA />
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Transition
+					presentation={bookFlip({})}
+					timing={linearTiming({durationInFrames: 30})}
+				/>
+				<TransitionSeries.Sequence durationInFrames={60}>
+					<SceneB />
+				</TransitionSeries.Sequence>
+			</TransitionSeries>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/HtmlInCanvas/index.tsx
+++ b/packages/example/src/HtmlInCanvas/index.tsx
@@ -1,4 +1,6 @@
 export {
+	BookFlipTransitionDoc,
+	BookFlipTransitionDocThumb,
 	HtmlInCanvasChangingSize,
 	HtmlInCanvasChangingSize as HtmlInCanvasDemo,
 } from './changing-size';

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -48,6 +48,8 @@ import {
 	HlsMediaVideoTrimmed,
 } from './Hls/HlsMediaVideo';
 import {
+	BookFlipTransitionDoc,
+	BookFlipTransitionDocThumb,
 	CrosswarpTransitionDoc,
 	CrosswarpTransitionDocThumb,
 	DissolveTransitionDoc,
@@ -1084,6 +1086,22 @@ export const Index: React.FC = () => {
 					<Composition
 						id="zoom-in-out-transition-doc-thumb"
 						component={ZoomInOutTransitionDocThumb}
+						fps={30}
+						height={280}
+						width={540}
+						durationInFrames={60}
+					/>
+					<Composition
+						id="book-flip-transition-doc"
+						component={BookFlipTransitionDoc}
+						fps={30}
+						height={1080}
+						width={1920}
+						durationInFrames={90}
+					/>
+					<Composition
+						id="book-flip-transition-doc-thumb"
+						component={BookFlipTransitionDocThumb}
 						fps={30}
 						height={280}
 						width={540}

--- a/packages/renderer/src/test/book-flip.test.ts
+++ b/packages/renderer/src/test/book-flip.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import {ensureBrowser} from '../ensure-browser';
+import {renderStill} from '../render-still';
+
+const exampleBuild = path.join(__dirname, '..', '..', '..', 'example', 'build');
+const expectedImage = path.join(__dirname, '__fixtures__', 'book-flip.png');
+
+const composition = {
+	width: 540,
+	height: 280,
+	fps: 30,
+	durationInFrames: 60,
+	id: 'book-flip-transition-doc-thumb',
+	defaultProps: {},
+	props: {},
+	defaultCodec: null,
+	defaultOutName: null,
+	defaultVideoImageFormat: null,
+	defaultPixelFormat: null,
+	defaultProResProfile: null,
+	defaultSampleRate: null,
+};
+
+test(
+	'bookFlip matches the reference image',
+	async () => {
+		await ensureBrowser();
+
+		const {buffer, contentType} = await renderStill({
+			composition,
+			frame: 15,
+			serveUrl: exampleBuild,
+			chromiumOptions: {
+				gl: 'angle',
+			},
+			chromeMode: 'chrome-for-testing',
+			verbose: false,
+		});
+
+		expect(contentType).toBe('image/png');
+		expect(buffer).not.toBeNull();
+		expect([...buffer!]).toEqual([...fs.readFileSync(expectedImage)]);
+	},
+	{timeout: 120000},
+);

--- a/packages/transitions/book-flip.js
+++ b/packages/transitions/book-flip.js
@@ -1,0 +1,2 @@
+// For backwards compatibility when you use `esm-wallaby`
+module.exports = require('./dist/presentations/book-flip.js');

--- a/packages/transitions/bundle.ts
+++ b/packages/transitions/bundle.ts
@@ -19,6 +19,7 @@ const presentations = [
 	'ripple',
 	'crosswarp',
 	'swap',
+	'book-flip',
 ];
 
 const output = await build({

--- a/packages/transitions/package.json
+++ b/packages/transitions/package.json
@@ -133,6 +133,12 @@
 			"import": "./dist/esm/swap.mjs",
 			"require": "./dist/presentations/swap.js"
 		},
+		"./book-flip": {
+			"types": "./dist/presentations/book-flip.d.ts",
+			"module": "./dist/esm/book-flip.mjs",
+			"import": "./dist/esm/book-flip.mjs",
+			"require": "./dist/presentations/book-flip.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"typesVersions": {
@@ -175,6 +181,9 @@
 			],
 			"swap": [
 				"dist/presentations/swap.d.ts"
+			],
+			"book-flip": [
+				"dist/presentations/book-flip.d.ts"
 			]
 		}
 	},

--- a/packages/transitions/src/html-in-canvas-presentation.tsx
+++ b/packages/transitions/src/html-in-canvas-presentation.tsx
@@ -1,11 +1,12 @@
-import {useLayoutEffect, useMemo, useRef, useState, useCallback} from 'react';
+import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {
-	HtmlInCanvas,
+	AbsoluteFill,
 	HTML_IN_CANVAS_UNSUPPORTED_MESSAGE,
+	HtmlInCanvas,
+	Internals,
 	useDelayRender,
 	type EffectsProp,
 } from 'remotion';
-import {AbsoluteFill, Internals} from 'remotion';
 import type {DrawFunction} from './TransitionSeries';
 import type {
 	TransitionPresentation,
@@ -33,6 +34,7 @@ export const HtmlInCanvasPresentation = <
 	}
 
 	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const offscreenRef = useRef<OffscreenCanvas | null>(null);
 	const canvasSubtreeStyle: React.CSSProperties = useMemo(() => {
 		return {
 			width: '100%',
@@ -46,6 +48,7 @@ export const HtmlInCanvasPresentation = <
 	}, []);
 
 	const [offscreenCanvas] = useState(() => new OffscreenCanvas(1, 1));
+	const didPaintRef = useRef(false);
 
 	const passedPropsRef = useRef(passedProps);
 	passedPropsRef.current = passedProps;
@@ -59,12 +62,32 @@ export const HtmlInCanvasPresentation = <
 	effectsRef.current = memoizedEffects;
 
 	const [instance] = useState(() => shader(offscreenCanvas));
+	const passThrough =
+		bothEnteringAndExiting && presentationDirection === 'exiting';
 
 	useLayoutEffect(() => {
 		return () => {
 			instance.cleanup();
 		};
 	}, [offscreenCanvas, instance]);
+
+	useLayoutEffect(() => {
+		if (passThrough) {
+			return;
+		}
+
+		const canvas = canvasRef.current;
+		if (!canvas) {
+			throw new Error('Canvas not found');
+		}
+
+		canvas.layoutSubtree = true;
+		offscreenRef.current = canvas.transferControlToOffscreen();
+
+		return () => {
+			offscreenRef.current = null;
+		};
+	}, [passThrough]);
 
 	const chainState = Internals.useEffectChainState();
 	const {delayRender, continueRender} = useDelayRender();
@@ -110,15 +133,28 @@ export const HtmlInCanvasPresentation = <
 				effects: effectsRef.current ?? [],
 				width,
 				height,
-				output: canvasRef.current,
+				output: offscreenRef.current ?? offscreenCanvas,
 			});
 			continueRender(handle);
 		},
 		[chainState, instance, offscreenCanvas, continueRender, delayRender],
 	);
 
-	const passThrough =
-		bothEnteringAndExiting && presentationDirection === 'exiting';
+	const captureCanvas = useCallback(() => {
+		const canvas = canvasRef.current;
+		if (!canvas) {
+			throw new Error('Canvas not found');
+		}
+
+		const firstChild = canvas.firstChild as HTMLElement | null;
+		if (!firstChild) {
+			return;
+		}
+
+		const elementImage = canvas.captureElementImage(firstChild);
+		didPaintRef.current = true;
+		onElementImage(elementImage, draw);
+	}, [draw, onElementImage]);
 
 	useLayoutEffect(() => {
 		if (passThrough) {
@@ -130,17 +166,8 @@ export const HtmlInCanvasPresentation = <
 			throw new Error('Canvas not found');
 		}
 
-		canvas.layoutSubtree = true;
-
 		const onPaint = () => {
-			const firstChild = canvas.firstChild as HTMLElement;
-
-			if (!firstChild) {
-				return;
-			}
-
-			const elementImage = canvas.captureElementImage(firstChild);
-			onElementImage(elementImage, draw);
+			captureCanvas();
 		};
 
 		canvas.addEventListener('paint', onPaint);
@@ -148,7 +175,7 @@ export const HtmlInCanvasPresentation = <
 		return () => {
 			canvas.removeEventListener('paint', onPaint);
 		};
-	}, [onElementImage, presentationDirection, draw, passThrough]);
+	}, [captureCanvas, presentationDirection, passThrough]);
 
 	useLayoutEffect(() => {
 		if (passThrough) {
@@ -160,8 +187,22 @@ export const HtmlInCanvasPresentation = <
 			throw new Error('Canvas not found');
 		}
 
-		canvas.requestPaint?.();
-	}, [presentationProgress, passThrough, memoizedEffects]);
+		if (canvas.requestPaint) {
+			didPaintRef.current = false;
+			canvas.requestPaint();
+			const timeout = setTimeout(() => {
+				if (!didPaintRef.current) {
+					captureCanvas();
+				}
+			}, 100);
+
+			return () => {
+				clearTimeout(timeout);
+			};
+		}
+
+		captureCanvas();
+	}, [captureCanvas, presentationProgress, passThrough, memoizedEffects]);
 
 	useLayoutEffect(() => {
 		if (passThrough) {

--- a/packages/transitions/src/index.ts
+++ b/packages/transitions/src/index.ts
@@ -21,3 +21,6 @@ export {
 	HtmlInCanvasShaderDrawParams,
 	makeHtmlInCanvasPresentation,
 } from './html-in-canvas-presentation.js';
+
+export {bookFlip} from './presentations/book-flip.js';
+export type {BookFlipProps} from './presentations/book-flip.js';

--- a/packages/transitions/src/presentations/book-flip.tsx
+++ b/packages/transitions/src/presentations/book-flip.tsx
@@ -1,0 +1,237 @@
+import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
+import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+
+export type BookFlipProps = {};
+
+const VERTEX_SHADER = `#version 300 es
+in vec2 a_pos;
+out vec2 v_uv;
+void main() {
+	v_uv = vec2(a_pos.x * 0.5 + 0.5, 0.5 - a_pos.y * 0.5);
+	gl_Position = vec4(a_pos, 0.0, 1.0);
+}`;
+
+const FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+
+uniform sampler2D u_prev;
+uniform sampler2D u_next;
+uniform float u_time;
+
+in vec2 v_uv;
+out vec4 outColor;
+
+const float EPSILON = 0.000001;
+
+float safeDenominator(float value) {
+	return value < 0.0 ? -max(abs(value), EPSILON) : max(abs(value), EPSILON);
+}
+
+vec2 skewRight(vec2 p, float progress) {
+	float skewX = ((p.x - progress) / safeDenominator(0.5 - progress)) * 0.5;
+	float skewY = ((p.y - 0.5) / safeDenominator(0.5 + progress * (p.x - 0.5) / 0.5)) * 0.5 + 0.5;
+	return vec2(skewX, skewY);
+}
+
+vec2 skewLeft(vec2 p, float progress) {
+	float skewX = ((p.x - 0.5) / safeDenominator(progress - 0.5)) * 0.5 + 0.5;
+	float skewY = ((p.y - 0.5) / safeDenominator(0.5 + (1.0 - progress) * (0.5 - p.x) / 0.5)) * 0.5 + 0.5;
+	return vec2(skewX, skewY);
+}
+
+vec4 addShade(float progress) {
+	float shadeVal = max(0.7, abs(progress - 0.5) * 2.0);
+	return vec4(vec3(shadeVal), 1.0);
+}
+
+vec4 transition(vec2 p, float progress) {
+	float pr = step(1.0 - progress, p.x);
+
+	if (p.x < 0.5) {
+		return mix(texture(u_prev, p), texture(u_next, skewLeft(p, progress)) * addShade(progress), pr);
+	} else {
+		return mix(texture(u_prev, skewRight(p, progress)) * addShade(progress), texture(u_next, p), pr);
+	}
+}
+
+void main() {
+	float progress = 1.0 - u_time;
+	outColor = transition(v_uv, progress);
+}`;
+
+const compileShader = (
+	gl: WebGL2RenderingContext,
+	source: string,
+	type: number,
+): WebGLShader => {
+	const shader = gl.createShader(type);
+	if (!shader) {
+		throw new Error('Failed to create shader');
+	}
+
+	gl.shaderSource(shader, source);
+	gl.compileShader(shader);
+	if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+		const log = gl.getShaderInfoLog(shader);
+		gl.deleteShader(shader);
+		throw new Error(`Failed to compile shader: ${log}`);
+	}
+
+	return shader;
+};
+
+const createProgram = (gl: WebGL2RenderingContext): WebGLProgram => {
+	const program = gl.createProgram();
+	if (!program) {
+		throw new Error('Failed to create WebGL program');
+	}
+
+	const vs = compileShader(gl, VERTEX_SHADER, gl.VERTEX_SHADER);
+	const fs = compileShader(gl, FRAGMENT_SHADER, gl.FRAGMENT_SHADER);
+	gl.attachShader(program, vs);
+	gl.attachShader(program, fs);
+	gl.linkProgram(program);
+	if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+		const log = gl.getProgramInfoLog(program);
+		gl.deleteProgram(program);
+		throw new Error(`Failed to link program: ${log}`);
+	}
+
+	return program;
+};
+
+const createTexture = (gl: WebGL2RenderingContext): WebGLTexture => {
+	const tex = gl.createTexture();
+	if (!tex) {
+		throw new Error('Failed to create texture');
+	}
+
+	gl.bindTexture(gl.TEXTURE_2D, tex);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+	gl.texImage2D(
+		gl.TEXTURE_2D,
+		0,
+		gl.RGBA,
+		1,
+		1,
+		0,
+		gl.RGBA,
+		gl.UNSIGNED_BYTE,
+		new Uint8Array([0, 0, 0, 0]),
+	);
+	return tex;
+};
+
+export const bookFlipShader = (
+	canvas: OffscreenCanvas,
+): ReturnType<HtmlInCanvasShader<BookFlipProps>> => {
+	const gl = canvas.getContext('webgl2', {premultipliedAlpha: true});
+	if (!gl) {
+		throw new Error('Failed to create WebGL2 context');
+	}
+
+	const program = createProgram(gl);
+	const prevTex = createTexture(gl);
+	const nextTex = createTexture(gl);
+
+	const vao = gl.createVertexArray();
+	gl.bindVertexArray(vao);
+	const buffer = gl.createBuffer();
+	gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+	gl.bufferData(
+		gl.ARRAY_BUFFER,
+		new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]),
+		gl.STATIC_DRAW,
+	);
+	const aPos = gl.getAttribLocation(program, 'a_pos');
+	gl.enableVertexAttribArray(aPos);
+	gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+	const uTime = gl.getUniformLocation(program, 'u_time');
+	const uPrev = gl.getUniformLocation(program, 'u_prev');
+	const uNext = gl.getUniformLocation(program, 'u_next');
+
+	const cleanup: ReturnType<
+		HtmlInCanvasShader<BookFlipProps>
+	>['cleanup'] = () => {
+		gl.deleteProgram(program);
+		gl.deleteTexture(prevTex);
+		gl.deleteTexture(nextTex);
+	};
+
+	const clear: ReturnType<HtmlInCanvasShader<BookFlipProps>>['clear'] = () => {
+		gl.clearColor(0, 0, 0, 0);
+		gl.clear(gl.COLOR_BUFFER_BIT);
+	};
+
+	const draw: ReturnType<HtmlInCanvasShader<BookFlipProps>>['draw'] = ({
+		prevImage,
+		nextImage,
+		width,
+		height,
+		time,
+	}) => {
+		if (!prevImage && !nextImage) {
+			return;
+		}
+
+		if (prevImage && (prevImage.width === 0 || prevImage.height === 0)) {
+			return;
+		}
+
+		if (nextImage && (nextImage.width === 0 || nextImage.height === 0)) {
+			return;
+		}
+
+		const effectiveTime = !prevImage ? 0 : !nextImage ? 1 : time;
+
+		gl.viewport(0, 0, width, height);
+		gl.clearColor(0, 0, 0, 0);
+		gl.clear(gl.COLOR_BUFFER_BIT);
+		gl.useProgram(program);
+
+		gl.activeTexture(gl.TEXTURE0);
+		gl.bindTexture(gl.TEXTURE_2D, prevTex);
+		if (prevImage) {
+			gl.texElementImage2D(
+				gl.TEXTURE_2D,
+				0,
+				gl.RGBA,
+				gl.RGBA,
+				gl.UNSIGNED_BYTE,
+				prevImage,
+			);
+		}
+
+		gl.uniform1i(uPrev, 0);
+
+		gl.activeTexture(gl.TEXTURE1);
+		gl.bindTexture(gl.TEXTURE_2D, nextTex);
+		if (nextImage) {
+			gl.texElementImage2D(
+				gl.TEXTURE_2D,
+				0,
+				gl.RGBA,
+				gl.RGBA,
+				gl.UNSIGNED_BYTE,
+				nextImage,
+			);
+		}
+
+		gl.uniform1i(uNext, 1);
+		gl.uniform1f(uTime, effectiveTime);
+
+		gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+	};
+
+	return {
+		clear,
+		cleanup,
+		draw,
+	};
+};
+
+export const bookFlip = makeHtmlInCanvasPresentation(bookFlipShader);

--- a/packages/web-renderer/src/test/fixtures/transition-book-flip.tsx
+++ b/packages/web-renderer/src/test/fixtures/transition-book-flip.tsx
@@ -1,0 +1,66 @@
+import {linearTiming, TransitionSeries} from '@remotion/transitions';
+import {bookFlip} from '@remotion/transitions/book-flip';
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+const SceneA: React.FC = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				justifyContent: 'center',
+				alignItems: 'center',
+				backgroundColor: '#0b84f3',
+				fontFamily: 'sans-serif',
+				fontWeight: 900,
+				color: 'white',
+				fontSize: 100,
+			}}
+		>
+			A
+		</AbsoluteFill>
+	);
+};
+
+const SceneB: React.FC = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				justifyContent: 'center',
+				alignItems: 'center',
+				backgroundColor: 'pink',
+				fontFamily: 'sans-serif',
+				fontWeight: 900,
+				color: 'white',
+				fontSize: 100,
+			}}
+		>
+			B
+		</AbsoluteFill>
+	);
+};
+
+const Component: React.FC = () => {
+	return (
+		<TransitionSeries>
+			<TransitionSeries.Sequence durationInFrames={40}>
+				<SceneA />
+			</TransitionSeries.Sequence>
+			<TransitionSeries.Transition
+				presentation={bookFlip({})}
+				timing={linearTiming({durationInFrames: 30})}
+			/>
+			<TransitionSeries.Sequence durationInFrames={60}>
+				<SceneB />
+			</TransitionSeries.Sequence>
+		</TransitionSeries>
+	);
+};
+
+export const transitionBookFlip = {
+	component: Component,
+	id: 'transition-book-flip',
+	width: 540,
+	height: 280,
+	fps: 30,
+	durationInFrames: 70,
+} as const;

--- a/packages/web-renderer/src/test/transition-book-flip.test.tsx
+++ b/packages/web-renderer/src/test/transition-book-flip.test.tsx
@@ -1,0 +1,18 @@
+import {test} from 'vitest';
+import {renderStillOnWeb} from '../render-still-on-web';
+import '../symbol-dispose';
+import {transitionBookFlip} from './fixtures/transition-book-flip';
+import {testImage} from './utils';
+
+test('bookFlip transition renders correctly', async () => {
+	const blob = await (
+		await renderStillOnWeb({
+			licenseKey: 'free-license',
+			composition: transitionBookFlip,
+			frame: 15,
+			inputProps: {},
+		})
+	).blob({format: 'png'});
+
+	await testImage({blob, testId: 'transition-book-flip'});
+});

--- a/packages/web-renderer/vitest.config.ts
+++ b/packages/web-renderer/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 					provider: playwright({
 						launchOptions: {
 							channel: 'chrome',
+							args: ['--enable-features=DrawElementImage'],
 						},
 						actionTimeout: 5_000,
 					}),


### PR DESCRIPTION
Adds `bookFlip()` to `@remotion/transitions`, updates exports/docs, and adds the example plumbing.

Validation:
- `bunx turbo make --filter="@remotion/transitions"`
- `bunx turbo make --filter="@remotion/example"`
- `bunx turbo make --filter="@remotion/renderer"`
- `bun test packages/renderer/src/test/book-flip.test.ts` times out in this environment on the html-in-canvas render path.