### PR TITLE
`@remotion/studio-server`: Resolve re-exported composition editor links

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type {
+	ExportAllDeclaration,
+	ExportNamedDeclaration,
+	ExportSpecifier,
 	File,
 	ImportDeclaration,
 	JSXAttribute,
@@ -32,6 +35,11 @@ export type ResolvedCompositionComponent = {
 };
 
 type ImportTarget = {
+	importPath: string;
+	exportName: string | 'default';
+};
+
+type ReExportTarget = {
 	importPath: string;
 	exportName: string | 'default';
 };
@@ -281,6 +289,91 @@ const findImportTarget = ({
 	});
 
 	return found;
+};
+
+const getExportedName = (exported: unknown) => {
+	if (!exported) {
+		return null;
+	}
+
+	if (!isRecord(exported)) {
+		return null;
+	}
+
+	if (exported.type === 'Identifier' && typeof exported.name === 'string') {
+		return exported.name;
+	}
+
+	if (exported.type === 'StringLiteral' && typeof exported.value === 'string') {
+		return exported.value;
+	}
+
+	return null;
+};
+
+const getSpecifierLocalName = (specifier: ExportSpecifier) => {
+	if (specifier.local.type === 'Identifier') {
+		return specifier.local.name;
+	}
+
+	return null;
+};
+
+const findReExportTargets = ({
+	ast,
+	exportName,
+}: {
+	ast: File;
+	exportName: string | 'default';
+}) => {
+	const targets: ReExportTarget[] = [];
+
+	recast.types.visit(ast, {
+		visitExportNamedDeclaration(astPath) {
+			const node = astPath.node as ExportNamedDeclaration;
+			if (typeof node.source?.value !== 'string') {
+				return false;
+			}
+
+			for (const specifier of node.specifiers) {
+				if (specifier.type !== 'ExportSpecifier') {
+					continue;
+				}
+
+				const exportedName = getExportedName(specifier.exported);
+				if (exportedName !== exportName) {
+					continue;
+				}
+
+				const localName = getSpecifierLocalName(specifier);
+				if (!localName) {
+					continue;
+				}
+
+				targets.push({
+					importPath: node.source.value,
+					exportName: localName === 'default' ? 'default' : localName,
+				});
+			}
+
+			return false;
+		},
+		visitExportAllDeclaration(astPath) {
+			const node = astPath.node as ExportAllDeclaration;
+			if (typeof node.source.value !== 'string') {
+				return false;
+			}
+
+			targets.push({
+				importPath: node.source.value,
+				exportName,
+			});
+
+			return false;
+		},
+	});
+
+	return targets;
 };
 
 const resolveImportPath = ({
@@ -733,6 +826,69 @@ const getComponentLocationInFile = async ({
 	};
 };
 
+const getComponentLocationRecursively = async ({
+	remotionRoot,
+	fileName,
+	exportName,
+	visited,
+}: {
+	remotionRoot: string;
+	fileName: string;
+	exportName: string | 'default';
+	visited: Set<string>;
+}): Promise<ResolvedCompositionComponent> => {
+	const key = `${fileName}:${exportName}`;
+	if (visited.has(key)) {
+		throw new Error(
+			`Could not resolve component export "${exportName}" in ${path.relative(remotionRoot, fileName)}`,
+		);
+	}
+
+	visited.add(key);
+
+	const input = await readSourceFile({remotionRoot, fileName});
+	const ast = parseAst(input);
+	const localDeclaration = getDeclarationByExportName({
+		ast,
+		exportName,
+	});
+	if (localDeclaration) {
+		return getComponentLocationInFile({
+			remotionRoot,
+			fileName,
+			exportName,
+		});
+	}
+
+	const reExportTargets = findReExportTargets({
+		ast,
+		exportName,
+	});
+	for (const target of reExportTargets) {
+		try {
+			const resolvedImportPath = resolveImportPath({
+				importPath: target.importPath,
+				fromFile: fileName,
+			});
+
+			return getComponentLocationRecursively({
+				remotionRoot,
+				fileName: resolvedImportPath,
+				exportName: target.exportName,
+				visited,
+			});
+		} catch {
+			continue;
+		}
+	}
+
+	return getComponentLocationInFile({
+		remotionRoot,
+		fileName,
+		exportName,
+	});
+};
+
 export const resolveCompositionComponent = async ({
 	remotionRoot,
 	compositionFile,
@@ -759,10 +915,11 @@ export const resolveCompositionComponent = async ({
 			importPath: lazyImportPath,
 			fromFile: compositionFileName,
 		});
-		return getComponentLocationInFile({
+		return getComponentLocationRecursively({
 			remotionRoot,
 			fileName: lazyComponentFile,
 			exportName: 'default',
+			visited: new Set(),
 		});
 	}
 
@@ -787,9 +944,10 @@ export const resolveCompositionComponent = async ({
 		fromFile: compositionFileName,
 	});
 
-	return getComponentLocationInFile({
+	return getComponentLocationRecursively({
 		remotionRoot,
 		fileName: importedComponentFile,
 		exportName: importTarget.exportName,
+		visited: new Set(),
 	});
 };

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -845,48 +845,57 @@ const getComponentLocationRecursively = async ({
 	}
 
 	visited.add(key);
+	try {
+		const input = await readSourceFile({remotionRoot, fileName});
+		const ast = parseAst(input);
+		const localDeclaration = getDeclarationByExportName({
+			ast,
+			exportName,
+		});
+		if (localDeclaration) {
+			return await getComponentLocationInFile({
+				remotionRoot,
+				fileName,
+				exportName,
+			});
+		}
 
-	const input = await readSourceFile({remotionRoot, fileName});
-	const ast = parseAst(input);
-	const localDeclaration = getDeclarationByExportName({
-		ast,
-		exportName,
-	});
-	if (localDeclaration) {
-		return getComponentLocationInFile({
+		const reExportTargets = findReExportTargets({
+			ast,
+			exportName,
+		});
+		for (const target of reExportTargets) {
+			try {
+				const resolvedImportPath = resolveImportPath({
+					importPath: target.importPath,
+					fromFile: fileName,
+				});
+
+				return await getComponentLocationRecursively({
+					remotionRoot,
+					fileName: resolvedImportPath,
+					exportName: target.exportName,
+					visited,
+				});
+			} catch {
+				continue;
+			}
+		}
+
+		if (reExportTargets.length > 0) {
+			throw new Error(
+				`Could not resolve component export "${exportName}" in ${path.relative(remotionRoot, fileName)}`,
+			);
+		}
+
+		return await getComponentLocationInFile({
 			remotionRoot,
 			fileName,
 			exportName,
 		});
+	} finally {
+		visited.delete(key);
 	}
-
-	const reExportTargets = findReExportTargets({
-		ast,
-		exportName,
-	});
-	for (const target of reExportTargets) {
-		try {
-			const resolvedImportPath = resolveImportPath({
-				importPath: target.importPath,
-				fromFile: fileName,
-			});
-
-			return getComponentLocationRecursively({
-				remotionRoot,
-				fileName: resolvedImportPath,
-				exportName: target.exportName,
-				visited,
-			});
-		} catch {
-			continue;
-		}
-	}
-
-	return getComponentLocationInFile({
-		remotionRoot,
-		fileName,
-		exportName,
-	});
 };
 
 export const resolveCompositionComponent = async ({

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -80,6 +80,68 @@ test('resolves recursively through re-exported composition components', async ()
 	}
 });
 
+test('resolves through fallback re-export branch after cycle', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './components';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.mkdir(path.join(tempDir, 'components', 'valid'), {
+			recursive: true,
+		});
+		await fs.writeFile(
+			path.join(tempDir, 'components', 'index.tsx'),
+			[
+				"export {MyComp} from './cycle-a';",
+				"export {MyComp} from './valid';",
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'components', 'cycle-a.tsx'),
+			["export {MyComp} from './cycle-b';", ''].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'components', 'cycle-b.tsx'),
+			["export {MyComp} from './cycle-a';", ''].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'components', 'valid', 'index.tsx'),
+			["export {MyComp} from './MyComp';", ''].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'components', 'valid', 'MyComp.tsx'),
+			[
+				'export const MyComp: React.FC = () => {',
+				'\treturn <div>hello</div>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const location = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+		});
+		expect(location.source).toBe(
+			path.join('components', 'valid', 'MyComp.tsx'),
+		);
+		expect(location.line).toBe(1);
+		expect(location.canAddSequence).toBe(true);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('resolves a same-file composition component', async () => {
 	const location = await resolveCompositionComponent({
 		remotionRoot,

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -30,6 +30,56 @@ test('resolves a lazy imported composition component', async () => {
 	expect(location.canAddSequence).toBe(true);
 });
 
+test('resolves recursively through re-exported composition components', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './components';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.mkdir(path.join(tempDir, 'components', 'inner'), {
+			recursive: true,
+		});
+		await fs.writeFile(
+			path.join(tempDir, 'components', 'index.tsx'),
+			["export {MyComp} from './inner';", ''].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'components', 'inner', 'index.tsx'),
+			["export {MyComp} from './MyComp';", ''].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'components', 'inner', 'MyComp.tsx'),
+			[
+				'export const MyComp: React.FC = () => {',
+				'\treturn <div>hello</div>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const location = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+		});
+		expect(location.source).toBe(
+			path.join('components', 'inner', 'MyComp.tsx'),
+		);
+		expect(location.line).toBe(1);
+		expect(location.canAddSequence).toBe(true);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('resolves a same-file composition component', async () => {
 	const location = await resolveCompositionComponent({
 		remotionRoot,

--- a/packages/studio/src/components/composition-menu-items.ts
+++ b/packages/studio/src/components/composition-menu-items.ts
@@ -61,7 +61,7 @@ export const getCompositionMenuItems = ({
 			? {
 					id: 'open-component-in-editor',
 					keyHint: null,
-					label: `Open component in ${editorName}`,
+					label: `Show component in ${editorName}`,
 					leftItem: null,
 					onClick: async () => {
 						closeMenu();
@@ -78,7 +78,7 @@ export const getCompositionMenuItems = ({
 							showNotification((err as Error).message, 2000);
 						}
 					},
-					quickSwitcherLabel: `Open composition component in ${editorName}`,
+					quickSwitcherLabel: `Show composition component in ${editorName}`,
 					subMenu: null,
 					type: 'item' as const,
 					value: 'open-component-in-editor',


### PR DESCRIPTION
Needs manual testing, probably fine