### PR TITLE
@remotion/effects: Promote tint() to public API

### DIFF
--- a/packages/effects/bundle.ts
+++ b/packages/effects/bundle.ts
@@ -14,6 +14,7 @@ const effectEntrypoints = [
 	'src/hue.ts',
 	'src/invert.ts',
 	'src/scale.ts',
+	'src/tint.ts',
 	'src/wave.ts',
 ];
 

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -67,6 +67,11 @@
 			"module": "./dist/esm/scale.mjs",
 			"import": "./dist/esm/scale.mjs"
 		},
+		"./tint": {
+			"types": "./dist/tint.d.ts",
+			"module": "./dist/esm/tint.mjs",
+			"import": "./dist/esm/tint.mjs"
+		},
 		"./wave": {
 			"types": "./dist/wave.d.ts",
 			"module": "./dist/esm/wave.mjs",
@@ -96,6 +101,9 @@
 			],
 			"scale": [
 				"dist/scale.d.ts"
+			],
+			"tint": [
+				"dist/tint.d.ts"
 			],
 			"wave": [
 				"dist/wave.d.ts"

--- a/packages/effects/src/index.ts
+++ b/packages/effects/src/index.ts
@@ -1,2 +1,2 @@
 export {EffectInternals} from './effect-internals.js';
-export {tintSchema, type TintParams} from './tint.js';
+export {tint, tintSchema, type TintParams} from './tint.js';


### PR DESCRIPTION
Promotes `tint()` from internals to regular API, following the same pattern as the recent `halftone()` promotion.

## Changes

- Export `tint` function from main `index.ts`
- Add `src/tint.ts` to bundle entrypoints
- Add `./tint` export configuration to `package.json`
- Add `tint` to `typesVersions` for proper type resolution

The tint effect can now be imported directly from `@remotion/effects`:

```ts
import { tint } from '@remotion/effects';
```

Or as a sub-export:

```ts
import { tint } from '@remotion/effects/tint';
```