### PR TITLE
`@remotion/studio`: Show timeline layers for stills

### DIFF
--- a/packages/studio/src/components/EditorContent.tsx
+++ b/packages/studio/src/components/EditorContent.tsx
@@ -1,6 +1,5 @@
 import React, {useContext} from 'react';
 import {Internals} from 'remotion';
-import {useIsStill} from '../helpers/is-current-selected-still';
 import {InitialCompositionLoader} from './InitialCompositionLoader';
 import {MenuToolbar} from './MenuToolbar';
 import {SplitterContainer} from './Splitter/SplitterContainer';
@@ -22,11 +21,10 @@ export const EditorContent: React.FC<{
 	readonly readOnlyStudio: boolean;
 	readonly children: React.ReactNode;
 }> = ({readOnlyStudio, children}) => {
-	const isStill = useIsStill();
 	const {canvasContent} = useContext(Internals.CompositionManager);
 
 	const showTimeline =
-		canvasContent !== null && !isStill && canvasContent.type === 'composition';
+		canvasContent !== null && canvasContent.type === 'composition';
 
 	return (
 		<div style={container}>

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -4,6 +4,7 @@ import {calculateTimeline} from '../../helpers/calculate-timeline';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {BACKGROUND} from '../../helpers/colors';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
+import {useIsStill} from '../../helpers/is-current-selected-still';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {SplitterContainer} from '../Splitter/SplitterContainer';
 import {SplitterElement} from '../Splitter/SplitterElement';
@@ -42,6 +43,7 @@ const noop = () => undefined;
 const TimelineInner: React.FC = () => {
 	const {sequences} = useContext(Internals.SequenceManager);
 	const videoConfig = Internals.useUnsafeVideoConfig();
+	const isStill = useIsStill();
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
 	);
@@ -101,36 +103,40 @@ const TimelineInner: React.FC = () => {
 				);
 			})}
 			<SequencePropsObserver />
-			<TimelineWidthProvider>
-				<TimelinePinchZoom />
-				<TimelineHeightContainer shown={shown} hasBeenCut={hasBeenCut}>
-					<SplitterContainer
-						orientation="vertical"
-						defaultFlex={0.2}
-						id="names-to-timeline"
-						maxFlex={0.5}
-						minFlex={0.15}
-					>
-						<SplitterElement
-							type="flexer"
-							sticky={<TimelineTimePlaceholders />}
+			<TimelineHeightContainer shown={shown} hasBeenCut={hasBeenCut}>
+				{isStill ? (
+					<TimelineList timeline={shown} />
+				) : (
+					<TimelineWidthProvider>
+						<TimelinePinchZoom />
+						<SplitterContainer
+							orientation="vertical"
+							defaultFlex={0.2}
+							id="names-to-timeline"
+							maxFlex={0.5}
+							minFlex={0.15}
 						>
-							<TimelineList timeline={shown} />
-						</SplitterElement>
-						<SplitterHandle onCollapse={noop} allowToCollapse="none" />
-						<SplitterElement type="anti-flexer" sticky={null}>
-							<TimelineScrollable>
-								<TimelineTracks timeline={shown} hasBeenCut={hasBeenCut} />
-								<TimelineInOutPointer />
-								<TimelinePlayCursorSyncer />
-								<TimelineDragHandler />
-								<TimelineTimeIndicators />
-								<TimelineSlider />
-							</TimelineScrollable>
-						</SplitterElement>
-					</SplitterContainer>
-				</TimelineHeightContainer>
-			</TimelineWidthProvider>
+							<SplitterElement
+								type="flexer"
+								sticky={<TimelineTimePlaceholders />}
+							>
+								<TimelineList timeline={shown} />
+							</SplitterElement>
+							<SplitterHandle onCollapse={noop} allowToCollapse="none" />
+							<SplitterElement type="anti-flexer" sticky={null}>
+								<TimelineScrollable>
+									<TimelineTracks timeline={shown} hasBeenCut={hasBeenCut} />
+									<TimelineInOutPointer />
+									<TimelinePlayCursorSyncer />
+									<TimelineDragHandler />
+									<TimelineTimeIndicators />
+									<TimelineSlider />
+								</TimelineScrollable>
+							</SplitterElement>
+						</SplitterContainer>
+					</TimelineWidthProvider>
+				)}
+			</TimelineHeightContainer>
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes #7589

- Show the Studio timeline for still compositions so visual editing controls remain accessible.
- Render only the left timeline layer pane for stills, omitting ticks, tracks, playhead, drag handlers, and zoomable timeline content.