### PR TITLE
`@remotion/player-example`: Add issue 7183 repro page

### DIFF
--- a/packages/player-example/pages/issue-7183.tsx
+++ b/packages/player-example/pages/issue-7183.tsx
@@ -1,0 +1,82 @@
+import {Player} from '@remotion/player';
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+const MyComp: React.FC = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				background:
+					'linear-gradient(180deg, #f43f5e 0 18%, #111827 18% 82%, #22c55e 82% 100%)',
+				color: 'white',
+				fontFamily: 'sans-serif',
+				fontSize: 64,
+				fontWeight: 700,
+				justifyContent: 'center',
+				alignItems: 'center',
+			}}
+		>
+			Issue #7183
+		</AbsoluteFill>
+	);
+};
+
+const Issue7183 = () => {
+	return (
+		<main
+			style={{
+				fontFamily: 'sans-serif',
+				margin: 40,
+				maxWidth: 900,
+			}}
+		>
+			<h1>Player issue #7183 repro</h1>
+			<p>
+				The 16:9 composition should fill the 320 x 180 plate. The current Player
+				measurement bug can vertically offset the composition inside this
+				3D-transformed parent.
+			</p>
+			<div
+				style={{
+					background: '#e5e7eb',
+					border: '1px solid #d1d5db',
+					borderRadius: 8,
+					marginTop: 32,
+					padding: 80,
+				}}
+			>
+				<div
+					style={{
+						width: 320,
+						height: 180,
+						transform: 'rotateY(45deg) rotateX(-15deg)',
+						transformStyle: 'preserve-3d',
+						background:
+							'repeating-conic-gradient(#f8fafc 0 25%, #cbd5e1 0 50%)',
+						backgroundSize: '40px 40px',
+						outline: '4px solid #2563eb',
+					}}
+				>
+					<Player
+						component={MyComp}
+						compositionWidth={1920}
+						compositionHeight={1080}
+						durationInFrames={300}
+						fps={30}
+						acknowledgeRemotionLicense
+						style={{width: '100%', height: '100%'}}
+					/>
+				</div>
+			</div>
+			<p>
+				Route for{' '}
+				<a href="https://github.com/remotion-dev/remotion/issues/7183">
+					github.com/remotion-dev/remotion/issues/7183
+				</a>
+				.
+			</p>
+		</main>
+	);
+};
+
+export default Issue7183;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a standalone `/issue-7183` page to `packages/player-example` reproducing the reported 3D-transformed Player measurement issue.
- Leaves `@remotion/player` behavior unchanged; this is a repro page only.

## Walkthrough
[issue_7183_player_repro_walkthrough.mp4](https://cursor.com/agents/bc-a7fa6234-93ff-4987-950d-7d70a2f2696d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_7183_player_repro_walkthrough.mp4)
[Issue 7183 player repro page](https://cursor.com/agents/bc-a7fa6234-93ff-4987-950d-7d70a2f2696d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_7183_repro_page.webp)

## Testing
- `bunx oxfmt src --write` (warning: no target files because root `.oxfmtrc.json` ignores `packages/player-example/**`)
- `bunx prettier pages/issue-7183.tsx --write`
- `bun run build`
- `bun run formatting`
- `bun run stylecheck` (warning: fails in known `@remotion/lambda-go` Go 1.22.2 environment caveat)
- `bun run build-site` from `packages/player-example`
- `bunx eslint pages/issue-7183.tsx` from `packages/player-example`
- Manual browser walkthrough of `http://localhost:3000/issue-7183`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7fa6234-93ff-4987-950d-7d70a2f2696d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7fa6234-93ff-4987-950d-7d70a2f2696d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

