### PR TITLE
`@remotion/studio`: Reorganize render modal

### DIFF
--- a/packages/studio/src/components/RenderModal/RenderModalAdvanced.tsx
+++ b/packages/studio/src/components/RenderModal/RenderModalAdvanced.tsx
@@ -1,21 +1,18 @@
-import type {ChromeMode, Codec, X264Preset} from '@remotion/renderer';
-import type {HardwareAccelerationOption} from '@remotion/renderer/client';
+import type {ChromeMode} from '@remotion/renderer';
 import {BrowserSafeApis} from '@remotion/renderer/client';
 import type {UiOpenGlOptions} from '@remotion/studio-shared';
 import type {ChangeEvent} from 'react';
 import React, {useCallback, useMemo} from 'react';
-import {labelx264Preset} from '../../helpers/presets-labels';
 import {Checkmark} from '../../icons/Checkmark';
 import {Checkbox} from '../Checkbox';
 import {Spacing} from '../layout';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
-import type {ComboboxValue, SelectionItem} from '../NewComposition/ComboBox';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {Combobox} from '../NewComposition/ComboBox';
 import {RemotionInput} from '../NewComposition/RemInput';
 import {input, label, optionRow, rightRow} from './layout';
 import {NumberSetting} from './NumberSetting';
 import {OptionExplainerBubble} from './OptionExplainerBubble';
-import {RenderModalEnvironmentVariables} from './RenderModalEnvironmentVariables';
 import {RenderModalHr} from './RenderModalHr';
 
 export type RenderType = 'still' | 'video' | 'audio' | 'sequence';
@@ -33,10 +30,6 @@ export const RenderModalAdvanced: React.FC<{
 	readonly concurrency: number;
 	readonly delayRenderTimeout: number;
 	readonly setDelayRenderTimeout: React.Dispatch<React.SetStateAction<number>>;
-	readonly disallowParallelEncoding: boolean;
-	readonly setDisallowParallelEncoding: React.Dispatch<
-		React.SetStateAction<boolean>
-	>;
 	readonly setDisableWebSecurity: React.Dispatch<React.SetStateAction<boolean>>;
 	readonly setIgnoreCertificateErrors: React.Dispatch<
 		React.SetStateAction<boolean>
@@ -53,18 +46,6 @@ export const RenderModalAdvanced: React.FC<{
 	readonly setChromeModeOption: React.Dispatch<
 		React.SetStateAction<ChromeMode>
 	>;
-	readonly envVariables: [string, string][];
-	readonly setEnvVariables: React.Dispatch<
-		React.SetStateAction<[string, string][]>
-	>;
-	readonly x264Preset: X264Preset | null;
-	readonly setx264Preset: React.Dispatch<React.SetStateAction<X264Preset>>;
-	readonly gopSize: number | null;
-	readonly setGopSize: React.Dispatch<React.SetStateAction<number | null>>;
-	readonly hardwareAcceleration: HardwareAccelerationOption;
-	readonly setHardwareAcceleration: React.Dispatch<
-		React.SetStateAction<HardwareAccelerationOption>
-	>;
 	readonly offthreadVideoCacheSizeInBytes: number | null;
 	readonly setOffthreadVideoCacheSizeInBytes: React.Dispatch<
 		React.SetStateAction<number | null>
@@ -77,7 +58,6 @@ export const RenderModalAdvanced: React.FC<{
 	readonly setOffthreadVideoThreads: React.Dispatch<
 		React.SetStateAction<number | null>
 	>;
-	readonly codec: Codec;
 	readonly enableMultiProcessOnLinux: boolean;
 	readonly darkMode: boolean;
 	readonly setDarkMode: React.Dispatch<React.SetStateAction<boolean>>;
@@ -98,8 +78,6 @@ export const RenderModalAdvanced: React.FC<{
 	concurrency,
 	delayRenderTimeout,
 	setDelayRenderTimeout,
-	disallowParallelEncoding,
-	setDisallowParallelEncoding,
 	setDisableWebSecurity,
 	setIgnoreCertificateErrors,
 	setHeadless,
@@ -108,13 +86,6 @@ export const RenderModalAdvanced: React.FC<{
 	disableWebSecurity,
 	openGlOption,
 	setOpenGlOption,
-	setEnvVariables,
-	envVariables,
-	setx264Preset,
-	x264Preset,
-	gopSize,
-	setGopSize,
-	codec,
 	setMediaCacheSizeInBytes,
 	mediaCacheSizeInBytes,
 	offthreadVideoCacheSizeInBytes,
@@ -129,10 +100,8 @@ export const RenderModalAdvanced: React.FC<{
 	setBeep,
 	repro,
 	setRepro,
-	hardwareAcceleration,
 	chromeModeOption,
 	setChromeModeOption,
-	setHardwareAcceleration,
 	darkMode,
 	setDarkMode,
 }) => {
@@ -178,16 +147,6 @@ export const RenderModalAdvanced: React.FC<{
 		});
 	}, [setOffthreadVideoThreads]);
 
-	const toggleCustomGopSize = useCallback(() => {
-		setGopSize((previous) => {
-			if (previous === null) {
-				return 120;
-			}
-
-			return null;
-		});
-	}, [setGopSize]);
-
 	const toggleCustomUserAgent = useCallback(() => {
 		setUserAgent((previous) => {
 			if (previous === null) {
@@ -197,13 +156,6 @@ export const RenderModalAdvanced: React.FC<{
 			return null;
 		});
 	}, [setUserAgent]);
-
-	const onDisallowParallelEncodingChanged = useCallback(
-		(e: ChangeEvent<HTMLInputElement>) => {
-			setDisallowParallelEncoding(e.target.checked);
-		},
-		[setDisallowParallelEncoding],
-	);
 
 	const onDisableWebSecurityChanged = useCallback(
 		(e: ChangeEvent<HTMLInputElement>) => {
@@ -296,41 +248,6 @@ export const RenderModalAdvanced: React.FC<{
 		});
 	}, [chromeModeOption, setChromeModeOption]);
 
-	const x264PresetOptions = useMemo((): ComboboxValue[] => {
-		return BrowserSafeApis.x264PresetOptions.map((option) => {
-			return {
-				label: labelx264Preset(option),
-				onClick: () => setx264Preset(option),
-				key: option,
-				type: 'item',
-				id: option,
-				keyHint: null,
-				leftItem: x264Preset === option ? <Checkmark /> : null,
-				quickSwitcherLabel: null,
-				subMenu: null,
-				value: option,
-			};
-		});
-	}, [setx264Preset, x264Preset]);
-
-	const hardwareAccelerationValues = useMemo((): ComboboxValue[] => {
-		return BrowserSafeApis.hardwareAccelerationOptions.map(
-			(option): SelectionItem => {
-				return {
-					label: option,
-					onClick: () => setHardwareAcceleration(option),
-					leftItem: hardwareAcceleration === option ? <Checkmark /> : null,
-					subMenu: null,
-					quickSwitcherLabel: null,
-					type: 'item',
-					id: option,
-					keyHint: null,
-					value: option,
-				};
-			},
-		);
-	}, [hardwareAcceleration, setHardwareAcceleration]);
-
 	const changeMediaCacheSizeInBytes: React.Dispatch<
 		React.SetStateAction<number>
 	> = useCallback(
@@ -388,24 +305,6 @@ export const RenderModalAdvanced: React.FC<{
 		[setOffthreadVideoThreads],
 	);
 
-	const changeGopSize: React.Dispatch<React.SetStateAction<number>> =
-		useCallback(
-			(cb) => {
-				setGopSize((prev) => {
-					if (prev === null) {
-						throw new TypeError('Expected previous value');
-					}
-
-					if (typeof cb === 'function') {
-						return cb(prev);
-					}
-
-					return cb;
-				});
-			},
-			[setGopSize],
-		);
-
 	return (
 		<div style={container} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 			{renderMode === 'still' ? null : (
@@ -419,66 +318,6 @@ export const RenderModalAdvanced: React.FC<{
 					value={concurrency}
 				/>
 			)}
-			{renderMode === 'video' && codec === 'h264' ? (
-				<div style={optionRow}>
-					<div style={label}>
-						x264 Preset
-						<Spacing x={0.5} />
-						<OptionExplainerBubble id="x264Option" />
-					</div>
-					<div style={rightRow}>
-						<Combobox
-							title={x264Preset as string}
-							selectedId={x264Preset as string}
-							values={x264PresetOptions}
-						/>
-					</div>
-				</div>
-			) : null}
-			{renderMode === 'video' && codec !== 'gif' ? (
-				<div style={optionRow}>
-					<div style={label}>
-						Custom GOP size
-						<Spacing x={0.5} />
-						<OptionExplainerBubble id="gopSizeOption" />
-					</div>
-					<div style={rightRow}>
-						<Checkbox
-							checked={gopSize !== null}
-							onChange={toggleCustomGopSize}
-							name="custom-gop-size"
-						/>
-					</div>
-				</div>
-			) : null}
-			{renderMode === 'video' && codec !== 'gif' && gopSize !== null ? (
-				<NumberSetting
-					min={1}
-					max={10000}
-					step={1}
-					name="GOP size"
-					formatter={(value) => `${value} frames`}
-					onValueChanged={changeGopSize}
-					value={gopSize}
-				/>
-			) : null}
-			{renderMode === 'video' ? (
-				<div style={optionRow}>
-					<div style={label}>
-						Hardware acceleration
-						<Spacing x={0.5} />
-						<OptionExplainerBubble id="hardwareAccelerationOption" />
-					</div>
-					<div style={rightRow}>
-						<Combobox
-							title={hardwareAcceleration as string}
-							selectedId={hardwareAcceleration as string}
-							values={hardwareAccelerationValues}
-						/>
-					</div>
-				</div>
-			) : null}
-
 			<NumberSetting
 				// Also appears in packages/renderer/src/validate-puppeteer-timeout.ts
 				min={7_000}
@@ -490,16 +329,6 @@ export const RenderModalAdvanced: React.FC<{
 				hint="delayRenderTimeoutInMillisecondsOption"
 				value={delayRenderTimeout}
 			/>
-			<div style={optionRow}>
-				<div style={label}>No parallel encoding</div>
-				<div style={rightRow}>
-					<Checkbox
-						checked={disallowParallelEncoding}
-						onChange={onDisallowParallelEncodingChanged}
-						name="disallow-parallel-encoding"
-					/>
-				</div>
-			</div>
 			{renderMode === 'audio' ? null : (
 				<div style={optionRow}>
 					<div style={label}>
@@ -712,11 +541,6 @@ export const RenderModalAdvanced: React.FC<{
 					/>
 				</div>
 			</div>
-			<RenderModalHr />
-			<RenderModalEnvironmentVariables
-				envVariables={envVariables}
-				setEnvVariables={setEnvVariables}
-			/>
 		</div>
 	);
 };

--- a/packages/studio/src/components/RenderModal/RenderModalEncoding.tsx
+++ b/packages/studio/src/components/RenderModal/RenderModalEncoding.tsx
@@ -1,0 +1,448 @@
+import type {
+	ColorSpace,
+	Codec,
+	PixelFormat,
+	X264Preset,
+} from '@remotion/renderer';
+import type {HardwareAccelerationOption} from '@remotion/renderer/client';
+import {BrowserSafeApis} from '@remotion/renderer/client';
+import type {ChangeEvent} from 'react';
+import React, {useCallback, useMemo} from 'react';
+import {labelx264Preset} from '../../helpers/presets-labels';
+import {Checkmark} from '../../icons/Checkmark';
+import {Checkbox} from '../Checkbox';
+import {Spacing} from '../layout';
+import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
+import type {ComboboxValue, SelectionItem} from '../NewComposition/ComboBox';
+import {Combobox} from '../NewComposition/ComboBox';
+import {RemotionInput} from '../NewComposition/RemInput';
+import type {SegmentedControlItem} from '../SegmentedControl';
+import {SegmentedControl} from '../SegmentedControl';
+import {CrfSetting} from './CrfSetting';
+import {input, label, optionRow, rightRow} from './layout';
+import {NumberSetting} from './NumberSetting';
+import {OptionExplainerBubble} from './OptionExplainerBubble';
+import type {RenderType} from './RenderModalAdvanced';
+import {RenderModalHr} from './RenderModalHr';
+
+const qualityControlModes = ['crf', 'bitrate'] as const;
+export type QualityControl = (typeof qualityControlModes)[number];
+
+const container: React.CSSProperties = {
+	flex: 1,
+	overflowY: 'auto',
+};
+
+export const RenderModalEncoding: React.FC<{
+	readonly renderMode: RenderType;
+	readonly codec: Codec;
+	readonly qualityControlType: QualityControl | null;
+	readonly setQualityControl: React.Dispatch<
+		React.SetStateAction<QualityControl>
+	>;
+	readonly shouldDisplayQualityControlPicker: boolean;
+	readonly crf: number | null;
+	readonly minCrf: number;
+	readonly maxCrf: number;
+	readonly setCrf: React.Dispatch<React.SetStateAction<number>>;
+	readonly customTargetVideoBitrate: string;
+	readonly setCustomTargetVideoBitrateValue: React.Dispatch<
+		React.SetStateAction<string>
+	>;
+	readonly encodingBufferSize: string | null;
+	readonly setEncodingBufferSize: React.Dispatch<
+		React.SetStateAction<string | null>
+	>;
+	readonly encodingMaxRate: string | null;
+	readonly setEncodingMaxRate: React.Dispatch<
+		React.SetStateAction<string | null>
+	>;
+	readonly pixelFormat: PixelFormat;
+	readonly pixelFormatOptions: ComboboxValue[];
+	readonly colorSpace: ColorSpace;
+	readonly setColorSpace: React.Dispatch<React.SetStateAction<ColorSpace>>;
+	readonly x264Preset: X264Preset | null;
+	readonly setx264Preset: React.Dispatch<React.SetStateAction<X264Preset>>;
+	readonly gopSize: number | null;
+	readonly setGopSize: React.Dispatch<React.SetStateAction<number | null>>;
+	readonly hardwareAcceleration: HardwareAccelerationOption;
+	readonly setHardwareAcceleration: React.Dispatch<
+		React.SetStateAction<HardwareAccelerationOption>
+	>;
+	readonly disallowParallelEncoding: boolean;
+	readonly setDisallowParallelEncoding: React.Dispatch<
+		React.SetStateAction<boolean>
+	>;
+}> = ({
+	renderMode,
+	codec,
+	qualityControlType,
+	setQualityControl,
+	shouldDisplayQualityControlPicker,
+	crf,
+	minCrf,
+	maxCrf,
+	setCrf,
+	customTargetVideoBitrate,
+	setCustomTargetVideoBitrateValue,
+	encodingBufferSize,
+	setEncodingBufferSize,
+	encodingMaxRate,
+	setEncodingMaxRate,
+	pixelFormat,
+	pixelFormatOptions,
+	colorSpace,
+	setColorSpace,
+	x264Preset,
+	setx264Preset,
+	gopSize,
+	setGopSize,
+	hardwareAcceleration,
+	setHardwareAcceleration,
+	disallowParallelEncoding,
+	setDisallowParallelEncoding,
+}) => {
+	const colorSpaceOptions = useMemo((): ComboboxValue[] => {
+		return BrowserSafeApis.validColorSpaces.map((option) => {
+			return {
+				label: option,
+				onClick: () => setColorSpace(option),
+				key: option,
+				id: option,
+				keyHint: null,
+				leftItem: colorSpace === option ? <Checkmark /> : null,
+				quickSwitcherLabel: null,
+				subMenu: null,
+				type: 'item',
+				value: option,
+			};
+		});
+	}, [colorSpace, setColorSpace]);
+
+	const qualityControlOptions = useMemo((): SegmentedControlItem[] => {
+		return qualityControlModes.map((option) => {
+			return {
+				label: option === 'crf' ? 'CRF' : 'Bitrate',
+				onClick: () => setQualityControl(option),
+				key: option,
+				selected: qualityControlType === option,
+			};
+		});
+	}, [qualityControlType, setQualityControl]);
+
+	const x264PresetOptions = useMemo((): ComboboxValue[] => {
+		return BrowserSafeApis.x264PresetOptions.map((option) => {
+			return {
+				label: labelx264Preset(option),
+				onClick: () => setx264Preset(option),
+				key: option,
+				type: 'item',
+				id: option,
+				keyHint: null,
+				leftItem: x264Preset === option ? <Checkmark /> : null,
+				quickSwitcherLabel: null,
+				subMenu: null,
+				value: option,
+			};
+		});
+	}, [setx264Preset, x264Preset]);
+
+	const hardwareAccelerationValues = useMemo((): ComboboxValue[] => {
+		return BrowserSafeApis.hardwareAccelerationOptions.map(
+			(option): SelectionItem => {
+				return {
+					label: option,
+					onClick: () => setHardwareAcceleration(option),
+					leftItem: hardwareAcceleration === option ? <Checkmark /> : null,
+					subMenu: null,
+					quickSwitcherLabel: null,
+					type: 'item',
+					id: option,
+					keyHint: null,
+					value: option,
+				};
+			},
+		);
+	}, [hardwareAcceleration, setHardwareAcceleration]);
+
+	const toggleCustomGopSize = useCallback(() => {
+		setGopSize((previous) => {
+			if (previous === null) {
+				return 120;
+			}
+
+			return null;
+		});
+	}, [setGopSize]);
+
+	const changeGopSize: React.Dispatch<React.SetStateAction<number>> =
+		useCallback(
+			(cb) => {
+				setGopSize((prev) => {
+					if (prev === null) {
+						throw new TypeError('Expected previous value');
+					}
+
+					if (typeof cb === 'function') {
+						return cb(prev);
+					}
+
+					return cb;
+				});
+			},
+			[setGopSize],
+		);
+
+	const onTargetVideoBitrateChanged: React.ChangeEventHandler<HTMLInputElement> =
+		useCallback(
+			(e) => {
+				setCustomTargetVideoBitrateValue(e.target.value);
+			},
+			[setCustomTargetVideoBitrateValue],
+		);
+
+	const onEncodingBufferSizeToggled = useCallback(
+		(e: ChangeEvent<HTMLInputElement>) => {
+			setEncodingBufferSize(e.target.checked ? '10000k' : null);
+		},
+		[setEncodingBufferSize],
+	);
+
+	const onEncodingMaxRateToggled = useCallback(
+		(e: ChangeEvent<HTMLInputElement>) => {
+			setEncodingMaxRate(e.target.checked ? '5000k' : null);
+		},
+		[setEncodingMaxRate],
+	);
+
+	const onEncodingBufferSizeChanged: React.ChangeEventHandler<HTMLInputElement> =
+		useCallback(
+			(e) => {
+				setEncodingBufferSize(e.target.value);
+			},
+			[setEncodingBufferSize],
+		);
+
+	const onEncodingMaxRateChanged: React.ChangeEventHandler<HTMLInputElement> =
+		useCallback(
+			(e) => {
+				setEncodingMaxRate(e.target.value);
+			},
+			[setEncodingMaxRate],
+		);
+
+	const onDisallowParallelEncodingChanged = useCallback(
+		(e: ChangeEvent<HTMLInputElement>) => {
+			setDisallowParallelEncoding(e.target.checked);
+		},
+		[setDisallowParallelEncoding],
+	);
+
+	return (
+		<div style={container} className={VERTICAL_SCROLLBAR_CLASSNAME}>
+			{shouldDisplayQualityControlPicker && renderMode === 'video' ? (
+				<div style={optionRow}>
+					<div style={label}>Quality control</div>
+
+					<div style={rightRow}>
+						<SegmentedControl items={qualityControlOptions} needsWrapping />
+					</div>
+				</div>
+			) : null}
+			{qualityControlType === 'crf' &&
+			renderMode === 'video' &&
+			crf !== null ? (
+				<CrfSetting
+					crf={crf}
+					min={minCrf}
+					max={maxCrf}
+					setCrf={setCrf}
+					option="crfOption"
+				/>
+			) : null}
+			{qualityControlType === 'bitrate' && renderMode === 'video' ? (
+				<div style={optionRow}>
+					<div style={label}>
+						Target video bitrate
+						<Spacing x={0.5} />
+						<OptionExplainerBubble id="videoBitrateOption" />
+					</div>
+
+					<div style={rightRow}>
+						<div>
+							<RemotionInput
+								style={input}
+								value={customTargetVideoBitrate}
+								onChange={onTargetVideoBitrateChanged}
+								status="ok"
+								rightAlign
+							/>
+						</div>
+					</div>
+				</div>
+			) : null}
+			{renderMode === 'video' ? (
+				<>
+					<div style={optionRow}>
+						<div style={label}>
+							Custom FFmpeg -bufsize
+							<Spacing x={0.5} />
+							<OptionExplainerBubble id="encodingBufferSizeOption" />
+						</div>
+						<div style={rightRow}>
+							<Checkbox
+								checked={encodingBufferSize !== null}
+								onChange={onEncodingBufferSizeToggled}
+								name="encoding-buffer-size"
+							/>
+						</div>
+					</div>
+					{encodingBufferSize === null ? null : (
+						<div style={optionRow}>
+							<div style={label}>-bufsize value</div>
+							<div style={rightRow}>
+								<div>
+									<RemotionInput
+										style={input}
+										value={encodingBufferSize}
+										onChange={onEncodingBufferSizeChanged}
+										status="ok"
+										rightAlign
+									/>
+								</div>
+							</div>
+						</div>
+					)}
+					<div style={optionRow}>
+						<div style={label}>
+							Custom FFmpeg -maxrate
+							<Spacing x={0.5} />
+							<OptionExplainerBubble id="encodingMaxRateOption" />
+						</div>
+						<div style={rightRow}>
+							<Checkbox
+								checked={encodingMaxRate !== null}
+								onChange={onEncodingMaxRateToggled}
+								name="encoding-max-rate"
+							/>
+						</div>
+					</div>
+					{encodingMaxRate === null ? null : (
+						<div style={optionRow}>
+							<div style={label}>-maxrate value</div>
+							<div style={rightRow}>
+								<div>
+									<RemotionInput
+										style={input}
+										value={encodingMaxRate}
+										onChange={onEncodingMaxRateChanged}
+										status="ok"
+										rightAlign
+									/>
+								</div>
+							</div>
+						</div>
+					)}
+					<RenderModalHr />
+					<div style={optionRow}>
+						<div style={label}>Pixel format</div>
+						<div style={rightRow}>
+							<Combobox
+								values={pixelFormatOptions}
+								selectedId={pixelFormat}
+								title="Pixel Format"
+							/>
+						</div>
+					</div>
+					<div style={optionRow}>
+						<div style={label}>
+							Color space
+							<Spacing x={0.5} />
+							<OptionExplainerBubble id="colorSpaceOption" />
+						</div>
+						<div style={rightRow}>
+							<Combobox
+								values={colorSpaceOptions}
+								selectedId={colorSpace}
+								title="Color Space"
+							/>
+						</div>
+					</div>
+					<RenderModalHr />
+					{codec === 'h264' ? (
+						<div style={optionRow}>
+							<div style={label}>
+								x264 Preset
+								<Spacing x={0.5} />
+								<OptionExplainerBubble id="x264Option" />
+							</div>
+							<div style={rightRow}>
+								<Combobox
+									title={x264Preset as string}
+									selectedId={x264Preset as string}
+									values={x264PresetOptions}
+								/>
+							</div>
+						</div>
+					) : null}
+					{codec !== 'gif' ? (
+						<div style={optionRow}>
+							<div style={label}>
+								Custom GOP size
+								<Spacing x={0.5} />
+								<OptionExplainerBubble id="gopSizeOption" />
+							</div>
+							<div style={rightRow}>
+								<Checkbox
+									checked={gopSize !== null}
+									onChange={toggleCustomGopSize}
+									name="custom-gop-size"
+								/>
+							</div>
+						</div>
+					) : null}
+					{codec !== 'gif' && gopSize !== null ? (
+						<NumberSetting
+							min={1}
+							max={10000}
+							step={1}
+							name="GOP size"
+							formatter={(value) => `${value} frames`}
+							onValueChanged={changeGopSize}
+							value={gopSize}
+						/>
+					) : null}
+					<div style={optionRow}>
+						<div style={label}>
+							Hardware acceleration
+							<Spacing x={0.5} />
+							<OptionExplainerBubble id="hardwareAccelerationOption" />
+						</div>
+						<div style={rightRow}>
+							<Combobox
+								title={hardwareAcceleration as string}
+								selectedId={hardwareAcceleration as string}
+								values={hardwareAccelerationValues}
+							/>
+						</div>
+					</div>
+				</>
+			) : null}
+			{renderMode === 'still' ? null : (
+				<>
+					{renderMode === 'video' ? <RenderModalHr /> : null}
+					<div style={optionRow}>
+						<div style={label}>No parallel encoding</div>
+						<div style={rightRow}>
+							<Checkbox
+								checked={disallowParallelEncoding}
+								onChange={onDisallowParallelEncodingChanged}
+								name="disallow-parallel-encoding"
+							/>
+						</div>
+					</div>
+				</>
+			)}
+		</div>
+	);
+};

--- a/packages/studio/src/components/RenderModal/RenderModalPicture.tsx
+++ b/packages/studio/src/components/RenderModal/RenderModalPicture.tsx
@@ -1,31 +1,13 @@
-import type {
-	ColorSpace,
-	PixelFormat,
-	StillImageFormat,
-	VideoImageFormat,
-} from '@remotion/renderer';
-import {BrowserSafeApis} from '@remotion/renderer/client';
-import type {ChangeEvent} from 'react';
-import React, {useCallback, useMemo} from 'react';
-import {Checkmark} from '../../icons/Checkmark';
-import {Checkbox} from '../Checkbox';
-import {Spacing} from '../layout';
+import type {StillImageFormat, VideoImageFormat} from '@remotion/renderer';
+import React from 'react';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
-import type {ComboboxValue} from '../NewComposition/ComboBox';
-import {Combobox} from '../NewComposition/ComboBox';
-import {RemotionInput} from '../NewComposition/RemInput';
 import type {SegmentedControlItem} from '../SegmentedControl';
 import {SegmentedControl} from '../SegmentedControl';
-import {CrfSetting} from './CrfSetting';
 import {JpegQualitySetting} from './JpegQualitySetting';
-import {input, label, optionRow, rightRow} from './layout';
-import {OptionExplainerBubble} from './OptionExplainerBubble';
+import {label, optionRow, rightRow} from './layout';
 import type {RenderType} from './RenderModalAdvanced';
 import {RenderModalHr} from './RenderModalHr';
 import {ScaleSetting} from './ScaleSetting';
-
-const qualityControlModes = ['crf', 'bitrate'] as const;
-export type QualityControl = (typeof qualityControlModes)[number];
 
 const container: React.CSSProperties = {
 	flex: 1,
@@ -36,133 +18,25 @@ export const RenderModalPicture: React.FC<{
 	readonly renderMode: RenderType;
 	readonly scale: number;
 	readonly setScale: React.Dispatch<React.SetStateAction<number>>;
-	readonly pixelFormat: PixelFormat;
-	readonly colorSpace: ColorSpace;
-	readonly setColorSpace: React.Dispatch<React.SetStateAction<ColorSpace>>;
 	readonly imageFormatOptions: SegmentedControlItem[];
-	readonly setQualityControl: React.Dispatch<
-		React.SetStateAction<QualityControl>
-	>;
-	readonly qualityControlType: QualityControl | null;
 	readonly videoImageFormat: VideoImageFormat;
 	readonly stillImageFormat: StillImageFormat;
 	readonly setJpegQuality: React.Dispatch<React.SetStateAction<number>>;
 	readonly jpegQuality: number;
-	readonly maxCrf: number;
-	readonly minCrf: number;
-	readonly setCrf: React.Dispatch<React.SetStateAction<number>>;
-	readonly setCustomTargetVideoBitrateValue: React.Dispatch<
-		React.SetStateAction<string>
-	>;
-	readonly crf: number | null;
-	readonly customTargetVideoBitrate: string;
-	readonly shouldDisplayQualityControlPicker: boolean;
-	readonly pixelFormatOptions: ComboboxValue[];
-	readonly encodingBufferSize: string | null;
-	readonly setEncodingBufferSize: React.Dispatch<
-		React.SetStateAction<string | null>
-	>;
-	readonly encodingMaxRate: string | null;
-	readonly setEncodingMaxRate: React.Dispatch<
-		React.SetStateAction<string | null>
-	>;
 	readonly compositionWidth: number;
 	readonly compositionHeight: number;
 }> = ({
 	renderMode,
 	scale,
 	setScale,
-	pixelFormat,
 	imageFormatOptions,
-	setQualityControl,
-	qualityControlType,
 	videoImageFormat,
 	setJpegQuality,
 	jpegQuality,
-	maxCrf,
-	minCrf,
-	setCrf,
-	shouldDisplayQualityControlPicker,
-	setCustomTargetVideoBitrateValue,
-	crf,
-	customTargetVideoBitrate,
 	stillImageFormat,
-	colorSpace,
-	setColorSpace,
-	pixelFormatOptions,
-	encodingBufferSize,
-	encodingMaxRate,
-	setEncodingBufferSize,
-	setEncodingMaxRate,
 	compositionWidth,
 	compositionHeight,
 }) => {
-	const colorSpaceOptions = useMemo((): ComboboxValue[] => {
-		return BrowserSafeApis.validColorSpaces.map((option) => {
-			return {
-				label: option,
-				onClick: () => setColorSpace(option),
-				key: option,
-				id: option,
-				keyHint: null,
-				leftItem: colorSpace === option ? <Checkmark /> : null,
-				quickSwitcherLabel: null,
-				subMenu: null,
-				type: 'item',
-				value: option,
-			};
-		});
-	}, [colorSpace, setColorSpace]);
-
-	const qualityControlOptions = useMemo((): SegmentedControlItem[] => {
-		return qualityControlModes.map((option) => {
-			return {
-				label: option === 'crf' ? 'CRF' : 'Bitrate',
-				onClick: () => setQualityControl(option),
-				key: option,
-				selected: qualityControlType === option,
-			};
-		});
-	}, [qualityControlType, setQualityControl]);
-
-	const onTargetVideoBitrateChanged: React.ChangeEventHandler<HTMLInputElement> =
-		useCallback(
-			(e) => {
-				setCustomTargetVideoBitrateValue(e.target.value);
-			},
-			[setCustomTargetVideoBitrateValue],
-		);
-
-	const onEncodingBufferSizeToggled = useCallback(
-		(e: ChangeEvent<HTMLInputElement>) => {
-			setEncodingBufferSize(e.target.checked ? '10000k' : null);
-		},
-		[setEncodingBufferSize],
-	);
-
-	const onEncodingMaxRateToggled = useCallback(
-		(e: ChangeEvent<HTMLInputElement>) => {
-			setEncodingMaxRate(e.target.checked ? '5000k' : null);
-		},
-		[setEncodingMaxRate],
-	);
-
-	const onEncodingBufferSizeChanged: React.ChangeEventHandler<HTMLInputElement> =
-		useCallback(
-			(e) => {
-				setEncodingBufferSize(e.target.value);
-			},
-			[setEncodingBufferSize],
-		);
-
-	const onEncodingMaxRateChanged: React.ChangeEventHandler<HTMLInputElement> =
-		useCallback(
-			(e) => {
-				setEncodingMaxRate(e.target.value);
-			},
-			[setEncodingMaxRate],
-		);
-
 	return (
 		<div style={container} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 			{renderMode === 'video' ? (
@@ -176,126 +50,17 @@ export const RenderModalPicture: React.FC<{
 					</div>
 				</div>
 			) : null}
-			{renderMode === 'video' && videoImageFormat === 'jpeg' && (
+			{renderMode === 'video' && videoImageFormat === 'jpeg' ? (
 				<JpegQualitySetting
 					jpegQuality={jpegQuality}
 					setJpegQuality={setJpegQuality}
 				/>
-			)}
-			{renderMode === 'still' && stillImageFormat === 'jpeg' && (
+			) : null}
+			{renderMode === 'still' && stillImageFormat === 'jpeg' ? (
 				<JpegQualitySetting
 					jpegQuality={jpegQuality}
 					setJpegQuality={setJpegQuality}
 				/>
-			)}
-			{renderMode === 'video' && qualityControlType !== null ? (
-				<RenderModalHr />
-			) : null}
-			{shouldDisplayQualityControlPicker && renderMode === 'video' ? (
-				<div style={optionRow}>
-					<div style={label}>Quality control</div>
-
-					<div style={rightRow}>
-						<SegmentedControl items={qualityControlOptions} needsWrapping />
-					</div>
-				</div>
-			) : null}
-			{qualityControlType === 'crf' &&
-			renderMode !== 'still' &&
-			renderMode !== 'sequence' &&
-			crf !== null ? (
-				<CrfSetting
-					crf={crf}
-					min={minCrf}
-					max={maxCrf}
-					setCrf={setCrf as React.Dispatch<React.SetStateAction<number>>}
-					option="crfOption"
-				/>
-			) : null}
-			{qualityControlType === 'bitrate' && renderMode === 'video' ? (
-				<div style={optionRow}>
-					<div style={label}>
-						Target video bitrate
-						<Spacing x={0.5} />
-						<OptionExplainerBubble id="videoBitrateOption" />
-					</div>
-
-					<div style={rightRow}>
-						<div>
-							<RemotionInput
-								style={input}
-								value={customTargetVideoBitrate}
-								onChange={onTargetVideoBitrateChanged}
-								status="ok"
-								rightAlign
-							/>
-						</div>
-					</div>
-				</div>
-			) : null}
-			{renderMode === 'video' ? (
-				<>
-					<div style={optionRow}>
-						<div style={label}>
-							Custom FFmpeg -bufsize
-							<Spacing x={0.5} />
-							<OptionExplainerBubble id="encodingBufferSizeOption" />
-						</div>
-						<div style={rightRow}>
-							<Checkbox
-								checked={encodingBufferSize !== null}
-								onChange={onEncodingBufferSizeToggled}
-								name="encoding-buffer-size"
-							/>
-						</div>
-					</div>
-					{encodingBufferSize === null ? null : (
-						<div style={optionRow}>
-							<div style={label}>-bufsize value</div>
-							<div style={rightRow}>
-								<div>
-									<RemotionInput
-										style={input}
-										value={encodingBufferSize}
-										onChange={onEncodingBufferSizeChanged}
-										status="ok"
-										rightAlign
-									/>
-								</div>
-							</div>
-						</div>
-					)}
-					<div style={optionRow}>
-						<div style={label}>
-							Custom FFmpeg -maxrate
-							<Spacing x={0.5} />
-							<OptionExplainerBubble id="encodingMaxRateOption" />
-						</div>
-						<div style={rightRow}>
-							<Checkbox
-								checked={encodingMaxRate !== null}
-								onChange={onEncodingMaxRateToggled}
-								name="encoding-max-rate"
-							/>
-						</div>
-					</div>
-					{encodingMaxRate === null ? null : (
-						<div style={optionRow}>
-							<div style={label}>-maxrate value</div>
-							<div style={rightRow}>
-								<div>
-									<RemotionInput
-										style={input}
-										value={encodingMaxRate}
-										onChange={onEncodingMaxRateChanged}
-										status="ok"
-										rightAlign
-									/>
-								</div>
-							</div>
-						</div>
-					)}
-				</>
 			) : null}
 			{renderMode === 'video' ? <RenderModalHr /> : null}
 			<ScaleSetting
@@ -304,35 +69,6 @@ export const RenderModalPicture: React.FC<{
 				compositionWidth={compositionWidth}
 				compositionHeight={compositionHeight}
 			/>
-			{renderMode === 'video' ? <RenderModalHr /> : null}
-			{renderMode === 'video' ? (
-				<div style={optionRow}>
-					<div style={label}>Pixel format</div>
-					<div style={rightRow}>
-						<Combobox
-							values={pixelFormatOptions}
-							selectedId={pixelFormat}
-							title="Pixel Format"
-						/>
-					</div>
-				</div>
-			) : null}
-			{renderMode === 'video' ? (
-				<div style={optionRow}>
-					<div style={label}>
-						Color space
-						<Spacing x={0.5} />
-						<OptionExplainerBubble id="colorSpaceOption" />
-					</div>
-					<div style={rightRow}>
-						<Combobox
-							values={colorSpaceOptions}
-							selectedId={colorSpace}
-							title="Color Space"
-						/>
-					</div>
-				</div>
-			) : null}
 		</div>
 	);
 };

--- a/packages/studio/src/components/RenderModal/ServerRenderModal.tsx
+++ b/packages/studio/src/components/RenderModal/ServerRenderModal.tsx
@@ -45,6 +45,7 @@ import {FileIcon} from '../../icons/file';
 import {PicIcon} from '../../icons/frame';
 import {GearIcon} from '../../icons/gear';
 import {GifIcon} from '../../icons/gif';
+import {FilmIcon} from '../../icons/video';
 import {ModalsContext} from '../../state/modals';
 import {SidebarContext} from '../../state/sidebar';
 import {Button} from '../Button';
@@ -86,8 +87,9 @@ import type {RenderType} from './RenderModalAdvanced';
 import {RenderModalAdvanced} from './RenderModalAdvanced';
 import {RenderModalAudio} from './RenderModalAudio';
 import {RenderModalBasic} from './RenderModalBasic';
+import {RenderModalEncoding, type QualityControl} from './RenderModalEncoding';
+import {RenderModalEnvironmentVariables} from './RenderModalEnvironmentVariables';
 import {RenderModalGif} from './RenderModalGif';
-import type {QualityControl} from './RenderModalPicture';
 import {RenderModalPicture} from './RenderModalPicture';
 import {
 	ResolveCompositionBeforeModal,
@@ -1484,6 +1486,30 @@ const RenderModal: React.FC<
 							GIF
 						</VerticalTab>
 					) : null}
+					{shownTabs.includes('encoding') ? (
+						<VerticalTab
+							style={horizontalTab}
+							selected={tab === 'encoding'}
+							onClick={() => setTab('encoding')}
+						>
+							<div style={iconContainer}>
+								<FilmIcon style={icon} color="currentcolor" />
+							</div>
+							Encoding
+						</VerticalTab>
+					) : null}
+					{shownTabs.includes('environment') ? (
+						<VerticalTab
+							style={horizontalTab}
+							selected={tab === 'environment'}
+							onClick={() => setTab('environment')}
+						>
+							<div style={iconContainer}>
+								<DataIcon style={icon} />
+							</div>
+							Environment
+						</VerticalTab>
+					) : null}
 					{shownTabs.includes('advanced') ? (
 						<VerticalTab
 							style={horizontalTab}
@@ -1527,30 +1553,11 @@ const RenderModal: React.FC<
 							renderMode={renderMode}
 							scale={scale}
 							setScale={setScale}
-							pixelFormat={pixelFormat}
-							pixelFormatOptions={pixelFormatOptions}
 							imageFormatOptions={imageFormatOptions}
-							crf={crf}
-							setCrf={setCrf}
-							customTargetVideoBitrate={customTargetVideoBitrate}
-							maxCrf={maxCrf}
-							minCrf={minCrf}
 							jpegQuality={jpegQuality}
-							qualityControlType={qualityControlType}
 							setJpegQuality={setJpegQuality}
-							setColorSpace={setColorSpace}
-							colorSpace={colorSpace}
-							setCustomTargetVideoBitrateValue={
-								setCustomTargetVideoBitrateValue
-							}
-							setQualityControl={setQualityControl}
 							videoImageFormat={videoImageFormat}
 							stillImageFormat={stillImageFormat}
-							shouldDisplayQualityControlPicker={supportsBothQualityControls}
-							encodingBufferSize={encodingBufferSize}
-							setEncodingBufferSize={setEncodingBufferSize}
-							encodingMaxRate={encodingMaxRate}
-							setEncodingMaxRate={setEncodingMaxRate}
 							compositionWidth={resolvedComposition.width}
 							compositionHeight={resolvedComposition.height}
 						/>
@@ -1591,6 +1598,43 @@ const RenderModal: React.FC<
 							setLimitNumberOfGifLoops={setLimitNumberOfGifLoops}
 							setNumberOfGifLoopsSetting={setNumberOfGifLoopsSetting}
 						/>
+					) : tab === 'encoding' ? (
+						<RenderModalEncoding
+							renderMode={renderMode}
+							codec={codec}
+							qualityControlType={qualityControlType}
+							setQualityControl={setQualityControl}
+							shouldDisplayQualityControlPicker={supportsBothQualityControls}
+							crf={crf}
+							setCrf={setCrf}
+							maxCrf={maxCrf}
+							minCrf={minCrf}
+							customTargetVideoBitrate={customTargetVideoBitrate}
+							setCustomTargetVideoBitrateValue={
+								setCustomTargetVideoBitrateValue
+							}
+							encodingBufferSize={encodingBufferSize}
+							setEncodingBufferSize={setEncodingBufferSize}
+							encodingMaxRate={encodingMaxRate}
+							setEncodingMaxRate={setEncodingMaxRate}
+							pixelFormat={pixelFormat}
+							pixelFormatOptions={pixelFormatOptions}
+							colorSpace={colorSpace}
+							setColorSpace={setColorSpace}
+							x264Preset={x264Preset}
+							setx264Preset={setx264Preset}
+							gopSize={gopSize}
+							setGopSize={setGopSize}
+							hardwareAcceleration={hardwareAcceleration}
+							setHardwareAcceleration={setHardwareAcceleration}
+							disallowParallelEncoding={disallowParallelEncoding}
+							setDisallowParallelEncoding={setDisallowParallelEncoding}
+						/>
+					) : tab === 'environment' ? (
+						<RenderModalEnvironmentVariables
+							envVariables={envVariables}
+							setEnvVariables={setEnvVariables}
+						/>
 					) : tab === 'data' ? (
 						<DataEditor
 							defaultProps={inputProps}
@@ -1605,10 +1649,6 @@ const RenderModal: React.FC<
 						/>
 					) : (
 						<RenderModalAdvanced
-							x264Preset={x264Preset}
-							setx264Preset={setx264Preset}
-							gopSize={gopSize}
-							setGopSize={setGopSize}
 							concurrency={concurrency}
 							maxConcurrency={maxConcurrency}
 							minConcurrency={minConcurrency}
@@ -1616,8 +1656,6 @@ const RenderModal: React.FC<
 							setConcurrency={setConcurrency}
 							delayRenderTimeout={delayRenderTimeout}
 							setDelayRenderTimeout={setDelayRenderTimeout}
-							disallowParallelEncoding={disallowParallelEncoding}
-							setDisallowParallelEncoding={setDisallowParallelEncoding}
 							setDisableWebSecurity={setDisableWebSecurity}
 							setIgnoreCertificateErrors={setIgnoreCertificateErrors}
 							setHeadless={setHeadless}
@@ -1626,8 +1664,6 @@ const RenderModal: React.FC<
 							disableWebSecurity={disableWebSecurity}
 							openGlOption={openGlOption}
 							setOpenGlOption={setOpenGlOption}
-							setEnvVariables={setEnvVariables}
-							envVariables={envVariables}
 							offthreadVideoCacheSizeInBytes={offthreadVideoCacheSizeInBytes}
 							setMediaCacheSizeInBytes={setMediaCacheSizeInBytes}
 							mediaCacheSizeInBytes={mediaCacheSizeInBytes}
@@ -1638,15 +1674,12 @@ const RenderModal: React.FC<
 							setOffthreadVideoThreads={setOffthreadVideoThreads}
 							enableMultiProcessOnLinux={multiProcessOnLinux}
 							setChromiumMultiProcessOnLinux={setChromiumMultiProcessOnLinux}
-							codec={codec}
 							userAgent={userAgent}
 							setUserAgent={setUserAgent}
 							setBeep={setBeepOnFinish}
 							beep={beepOnFinish}
 							repro={repro}
 							setRepro={setRepro}
-							hardwareAcceleration={hardwareAcceleration}
-							setHardwareAcceleration={setHardwareAcceleration}
 							chromeModeOption={chromeMode}
 							setChromeModeOption={setChromeMode}
 							darkMode={darkMode}

--- a/packages/studio/src/helpers/render-modal-sections.ts
+++ b/packages/studio/src/helpers/render-modal-sections.ts
@@ -2,7 +2,15 @@ import type {Codec} from '@remotion/renderer';
 import {useMemo, useState} from 'react';
 import type {RenderType} from '../components/RenderModal/RenderModalAdvanced';
 
-type Section = 'general' | 'picture' | 'advanced' | 'data' | 'gif' | 'audio';
+type Section =
+	| 'general'
+	| 'data'
+	| 'picture'
+	| 'audio'
+	| 'gif'
+	| 'encoding'
+	| 'environment'
+	| 'advanced';
 
 export const useRenderModalSections = (
 	renderMode: RenderType,
@@ -12,23 +20,53 @@ export const useRenderModalSections = (
 
 	const shownTabs = useMemo((): Section[] => {
 		if (renderMode === 'audio') {
-			return ['general', 'data', 'audio', 'advanced'];
+			return [
+				'general',
+				'data',
+				'audio',
+				'encoding',
+				'environment',
+				'advanced',
+			];
 		}
 
 		if (renderMode === 'still') {
-			return ['general', 'data', 'picture', 'advanced'];
+			return ['general', 'data', 'picture', 'environment', 'advanced'];
 		}
 
 		if (renderMode === 'sequence') {
-			return ['general', 'data', 'picture', 'advanced'];
+			return [
+				'general',
+				'data',
+				'picture',
+				'encoding',
+				'environment',
+				'advanced',
+			];
 		}
 
 		if (renderMode === 'video') {
 			if (codec === 'gif') {
-				return ['general', 'data', 'picture', 'gif', 'advanced'];
+				return [
+					'general',
+					'data',
+					'picture',
+					'gif',
+					'encoding',
+					'environment',
+					'advanced',
+				];
 			}
 
-			return ['general', 'data', 'picture', 'audio', 'advanced'];
+			return [
+				'general',
+				'data',
+				'picture',
+				'audio',
+				'encoding',
+				'environment',
+				'advanced',
+			];
 		}
 
 		throw new TypeError('Unknown render mode');


### PR DESCRIPTION
Closes #7634.

- Adds separate Encoding and Environment panels to the server render modal.
- Moves encoding-related video settings out of Picture/Other.
- Leaves Picture focused on image format, JPEG quality, and scale.