### PR TITLE
`@remotion/effects`: Link effect labels to documentation

### DIFF
--- a/packages/core/src/effects/create-effect.ts
+++ b/packages/core/src/effects/create-effect.ts
@@ -34,6 +34,7 @@ export const createEffect = <P, S>(
 	const {calculateKey: userCalculateKey, validateParams} = definition;
 	const widened: EffectDefinition<unknown, unknown> = {
 		...(definition as unknown as EffectDefinition<unknown, unknown>),
+		documentationLink: definition.documentationLink ?? null,
 		calculateKey: (params: unknown) => {
 			const disabled = (params as {disabled?: boolean}).disabled ?? false;
 			return `${userCalculateKey(params as P)}-disabled-${disabled}`;

--- a/packages/core/src/effects/effect-types.ts
+++ b/packages/core/src/effects/effect-types.ts
@@ -37,6 +37,7 @@ export type EffectApplyParams<P, S> = {
 export type EffectDefinition<P, S = unknown> = {
 	readonly type: string;
 	readonly label: string;
+	readonly documentationLink?: string | null;
 	readonly backend: Backend;
 	/**
 	 * Stable string for comparing effect instances: two descriptors with the same

--- a/packages/core/src/effects/effect-types.ts
+++ b/packages/core/src/effects/effect-types.ts
@@ -37,7 +37,7 @@ export type EffectApplyParams<P, S> = {
 export type EffectDefinition<P, S = unknown> = {
 	readonly type: string;
 	readonly label: string;
-	readonly documentationLink?: string | null;
+	readonly documentationLink: string | null;
 	readonly backend: Backend;
 	/**
 	 * Stable string for comparing effect instances: two descriptors with the same

--- a/packages/core/src/test/create-effect-disabled.test.ts
+++ b/packages/core/src/test/create-effect-disabled.test.ts
@@ -9,6 +9,7 @@ const makeFoo = () =>
 	createEffect<FooParams, null>({
 		type: 'test/foo',
 		label: 'Foo',
+		documentationLink: null,
 		backend: '2d',
 		calculateKey: (p) => `foo-${p.amount}`,
 		setup: () => null,
@@ -46,6 +47,7 @@ test('createEffect injects `disabled` into the schema for save-effect-props', ()
 	const foo = createEffect<FooParams, null>({
 		type: 'test/foo',
 		label: 'Foo',
+		documentationLink: null,
 		backend: '2d',
 		calculateKey: (p) => `foo-${p.amount}`,
 		setup: () => null,

--- a/packages/core/src/test/create-effect-disabled.test.ts
+++ b/packages/core/src/test/create-effect-disabled.test.ts
@@ -78,3 +78,28 @@ test('createEffect injects `disabled` even when the effect schema is empty', () 
 		description: 'Disabled',
 	});
 });
+
+test('createEffect preserves documentation links on definitions', () => {
+	const foo = createEffect<FooParams, null>({
+		type: 'test/foo',
+		label: 'Foo',
+		documentationLink: 'https://www.remotion.dev/docs/effects/foo',
+		backend: '2d',
+		calculateKey: (p) => `foo-${p.amount}`,
+		setup: () => null,
+		apply: () => undefined,
+		cleanup: () => undefined,
+		schema: {},
+		validateParams: () => {},
+	});
+	const desc = foo({amount: 1});
+	expect(desc.definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/foo',
+	);
+});
+
+test('createEffect defaults documentation links to null', () => {
+	const foo = makeFoo();
+	const desc = foo({amount: 1});
+	expect(desc.definition.documentationLink).toBe(null);
+});

--- a/packages/core/src/test/create-effect-validate-params.test.ts
+++ b/packages/core/src/test/create-effect-validate-params.test.ts
@@ -9,6 +9,7 @@ const makeEffectWithValidation = () =>
 	createEffect<RequiredParams, null>({
 		type: 'test/required',
 		label: 'Required',
+		documentationLink: null,
 		backend: '2d',
 		calculateKey: (p) => `required-${p.value}`,
 		setup: () => null,

--- a/packages/core/src/test/effect-internals.test.ts
+++ b/packages/core/src/test/effect-internals.test.ts
@@ -13,6 +13,7 @@ const makeDef = (
 ): EffectDefinition<unknown, unknown> => ({
 	type,
 	label: type,
+	documentationLink: null,
 	backend,
 	calculateKey: () => type,
 	setup: () => null,

--- a/packages/effects/src/blur/index.ts
+++ b/packages/effects/src/blur/index.ts
@@ -4,14 +4,14 @@ import {
 	assertEffectParamsObject,
 	assertRequiredFiniteNumber,
 } from '../validate-effect-param.js';
-
-const {createEffect} = Internals;
 import {
 	applyBlur,
 	cleanupBlur,
 	setupBlur,
 	type BlurState,
 } from './blur-runtime.js';
+
+const {createEffect} = Internals;
 
 export type BlurParams = {
 	readonly radius: number;
@@ -62,6 +62,7 @@ const validateBlurParams = (params: BlurParams): void => {
 export const blur = createEffect<BlurParams, BlurState>({
 	type: 'remotion/blur',
 	label: 'Blur',
+	documentationLink: 'https://www.remotion.dev/docs/effects/blur',
 	backend: 'webgl2',
 	calculateKey: (params) => {
 		const r = resolveBlurParams(params);

--- a/packages/effects/src/brightness.ts
+++ b/packages/effects/src/brightness.ts
@@ -39,6 +39,7 @@ const validateBrightnessParams = (params: BrightnessParams): void => {
 export const brightness = createEffect<BrightnessParams, null>({
 	type: 'remotion/brightness',
 	label: 'Brightness',
+	documentationLink: 'https://www.remotion.dev/docs/effects/brightness',
 	backend: '2d',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/effects/src/grayscale.ts
+++ b/packages/effects/src/grayscale.ts
@@ -38,6 +38,7 @@ const validateGrayscaleParams = (params: GrayscaleParams): void => {
 export const grayscale = createEffect<GrayscaleParams, null>({
 	type: 'remotion/grayscale',
 	label: 'Grayscale',
+	documentationLink: 'https://www.remotion.dev/docs/effects/grayscale',
 	backend: '2d',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/effects/src/halftone.ts
+++ b/packages/effects/src/halftone.ts
@@ -365,6 +365,7 @@ const parseColorRgba = (
 export const halftone = createEffect<HalftoneParams, HalftoneState>({
 	type: 'remotion/halftone',
 	label: 'Halftone',
+	documentationLink: 'https://www.remotion.dev/docs/effects/halftone',
 	backend: 'webgl2',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/effects/src/hue.ts
+++ b/packages/effects/src/hue.ts
@@ -34,6 +34,7 @@ const validateHueParams = (params: HueParams): void => {
 export const hue = createEffect<HueParams, null>({
 	type: 'remotion/hue',
 	label: 'Hue',
+	documentationLink: 'https://www.remotion.dev/docs/effects/hue',
 	backend: '2d',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/effects/src/invert.ts
+++ b/packages/effects/src/invert.ts
@@ -38,6 +38,7 @@ const validateInvertParams = (params: InvertParams): void => {
 export const invert = createEffect<InvertParams, null>({
 	type: 'remotion/invert',
 	label: 'Invert',
+	documentationLink: 'https://www.remotion.dev/docs/effects/invert',
 	backend: '2d',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/effects/src/saturation.ts
+++ b/packages/effects/src/saturation.ts
@@ -38,6 +38,7 @@ const validateSaturationParams = (params: SaturationParams): void => {
 export const saturation = createEffect<SaturationParams, null>({
 	type: 'remotion/saturation',
 	label: 'Saturation',
+	documentationLink: 'https://www.remotion.dev/docs/effects/saturation',
 	backend: '2d',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/effects/src/scale/index.ts
+++ b/packages/effects/src/scale/index.ts
@@ -82,6 +82,7 @@ const validateScaleParams = (params: ScaleParams): void => {
 export const scale = createEffect<ScaleParams, null>({
 	type: 'remotion/scale',
 	label: 'Scale',
+	documentationLink: 'https://www.remotion.dev/docs/effects/scale',
 	backend: '2d',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/effects/src/test/effect-params.test.ts
+++ b/packages/effects/src/test/effect-params.test.ts
@@ -10,6 +10,39 @@ import {scale} from '../scale.js';
 import {tint} from '../tint.js';
 import {wave} from '../wave/index.js';
 
+test('@remotion/effects expose documentation links', () => {
+	expect(blur({radius: 1}).definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/blur',
+	);
+	expect(brightness().definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/brightness',
+	);
+	expect(grayscale().definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/grayscale',
+	);
+	expect(halftone().definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/halftone',
+	);
+	expect(hue().definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/hue',
+	);
+	expect(invert().definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/invert',
+	);
+	expect(saturation().definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/saturation',
+	);
+	expect(scale({scale: 1}).definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/scale',
+	);
+	expect(tint({color: '#fff'}).definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/tint',
+	);
+	expect(wave().definition.documentationLink).toBe(
+		'https://www.remotion.dev/docs/effects/wave',
+	);
+});
+
 test('tint() throws when color is not passed', () => {
 	expect(() => tint({} as Parameters<typeof tint>[0])).toThrow(
 		'"color" must be a non-empty string, but got undefined',

--- a/packages/effects/src/tint.ts
+++ b/packages/effects/src/tint.ts
@@ -60,6 +60,7 @@ const validateTintParams = (params: TintParams): void => {
 export const tint = createEffect<TintParams, null>({
 	type: 'remotion/tint',
 	label: 'Tint',
+	documentationLink: 'https://www.remotion.dev/docs/effects/tint',
 	backend: '2d',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/effects/src/wave/index.ts
+++ b/packages/effects/src/wave/index.ts
@@ -113,6 +113,7 @@ const validateWaveParams = (params: WaveParams): void => {
 export const wave = createEffect<WaveParams, WaveState>({
 	type: 'remotion/wave',
 	label: 'Wave',
+	documentationLink: 'https://www.remotion.dev/docs/effects/wave',
 	backend: 'webgl2',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/light-leaks/src/light-leak-internals.ts
+++ b/packages/light-leaks/src/light-leak-internals.ts
@@ -193,6 +193,7 @@ const linkProgram = (
 const lightLeak = createEffect<LightLeakEffectParams, LightLeakGlState>({
 	type: 'remotion/light-leak',
 	label: 'Light leak',
+	documentationLink: 'https://www.remotion.dev/docs/light-leaks/light-leak',
 	backend: 'webgl2',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/starburst/src/starburst-effect.ts
+++ b/packages/starburst/src/starburst-effect.ts
@@ -300,6 +300,7 @@ const linkProgram = (
 export const starburst = createEffect<StarburstEffectParams, StarburstGlState>({
 	type: 'remotion/starburst',
 	label: 'Starburst',
+	documentationLink: 'https://www.remotion.dev/docs/starburst/starburst',
 	backend: 'webgl2',
 	calculateKey: (params) => {
 		const r = resolve(params);

--- a/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useMemo} from 'react';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
@@ -29,6 +29,7 @@ export const TimelineEffectGroupRow: React.FC<{
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly effectIndex: number;
 	readonly effectSchema: SequenceSchema;
+	readonly documentationLink: string | null;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly validatedLocation: CodePosition;
 	readonly rowDepth: number;
@@ -39,12 +40,14 @@ export const TimelineEffectGroupRow: React.FC<{
 	nodePathInfo,
 	effectIndex,
 	effectSchema,
+	documentationLink,
 	nodePath,
 	validatedLocation,
 	rowDepth,
 	getIsExpanded,
 	toggleTrack,
 }) => {
+	const [labelHovered, setLabelHovered] = useState(false);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewConnected = previewServerState.type === 'connected';
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
@@ -175,6 +178,24 @@ export const TimelineEffectGroupRow: React.FC<{
 		[],
 	);
 
+	const labelStyle = useMemo((): React.CSSProperties => {
+		const hoverEffect = labelHovered && documentationLink !== null;
+		return {
+			...rowLabel,
+			textDecoration: hoverEffect ? 'underline' : 'none',
+			textUnderlineOffset: 2,
+			cursor: hoverEffect ? 'pointer' : undefined,
+		};
+	}, [documentationLink, labelHovered]);
+
+	const onClickLabel = useCallback(() => {
+		if (documentationLink === null) {
+			return;
+		}
+
+		window.open(documentationLink, '_blank', 'noopener,noreferrer');
+	}, [documentationLink]);
+
 	const row = (
 		<TimelineRowChrome
 			depth={rowDepth}
@@ -199,7 +220,17 @@ export const TimelineEffectGroupRow: React.FC<{
 			}
 			style={rowStyle}
 		>
-			<span style={rowLabel}>{label}</span>
+			<span
+				onPointerEnter={() => setLabelHovered(true)}
+				onPointerLeave={() => setLabelHovered(false)}
+				onClick={onClickLabel}
+				title={
+					documentationLink ? `Open documentation: ${documentationLink}` : label
+				}
+				style={labelStyle}
+			>
+				{label}
+			</span>
 		</TimelineRowChrome>
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {SequenceSchema, SequencePropsSubscriptionKey} from 'remotion';
+import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import type {TimelineTreeNode} from '../../helpers/timeline-layout';
@@ -55,6 +55,7 @@ export const TimelineExpandedRow: React.FC<{
 					nodePathInfo={node.nodePathInfo}
 					effectIndex={node.effectInfo.effectIndex}
 					effectSchema={node.effectInfo.effectSchema}
+					documentationLink={node.effectInfo.documentationLink}
 					nodePath={nodePath}
 					validatedLocation={validatedLocation}
 					rowDepth={rowDepth}

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -47,6 +47,7 @@ export type TimelineFieldOnDragValueChange = (value: unknown) => void;
 export type TimelineEffectGroupInfo = {
 	readonly effectIndex: number;
 	readonly effectSchema: SequenceSchemaShape;
+	readonly documentationLink: string | null;
 };
 
 export type TimelineTreeNode =
@@ -128,7 +129,11 @@ export const buildTimelineTree = ({
 						numberOfSequencesWithThisNodePath: 0,
 					},
 					label: effect.label,
-					effectInfo: {effectIndex: i, effectSchema: effect.schema},
+					effectInfo: {
+						effectIndex: i,
+						effectSchema: effect.schema,
+						documentationLink: effect.documentationLink ?? null,
+					},
 					children: effectFields.map(
 						(f): TimelineTreeNode => ({
 							kind: 'field',


### PR DESCRIPTION
Fixes #7603

## Summary
- Add optional documentation links to effect definitions
- Populate docs links for @remotion/effects and the light leak effect
- Make effect labels in expanded Studio timeline rows clickable

## Testing
- bun test packages/core/src/test/create-effect-disabled.test.ts packages/effects/src/test/effect-params.test.ts
- bunx turbo run make --filter=remotion --filter=@remotion/studio --filter=@remotion/effects --filter=@remotion/light-leaks
- bun run build
- bun run formatting