### PR TITLE
`remotion`: Refactor audio states to consider transition states

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -384,7 +384,7 @@ export const SharedAudioContextProvider: React.FC<{
 	const audioContextValue: SharedAudioContextValue = useMemo(() => {
 		return {
 			audioContext: ctxAndGain?.audioContext ?? null,
-			getAudioContextState: () => ctxAndGain?.audioContext?.state ?? null,
+			getAudioContextState: () => ctxAndGain?.getState() ?? null,
 			gainNode: ctxAndGain?.gainNode ?? null,
 			audioSyncAnchor,
 			audioSyncAnchorEmitter,

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -14,6 +14,7 @@ import {playAndHandleNotAllowedError} from '../play-and-handle-not-allowed-error
 import {useRemotionEnvironment} from '../use-remotion-environment.js';
 import type {SharedElementSourceNode} from './shared-element-source-node.js';
 import {makeSharedElementSourceNode} from './shared-element-source-node.js';
+import type {RemotionAudioContextState} from './use-audio-context.js';
 import {useSingletonAudioContext} from './use-audio-context.js';
 import {waitUntilActuallyResumed} from './wait-until-actually-resumed.js';
 
@@ -75,7 +76,7 @@ export type AudioSyncAnchorEmitter = {
 
 type SharedAudioContextValue = {
 	audioContext: AudioContext | null;
-	getAudioContextState: () => AudioContextState | null;
+	getAudioContextState: () => RemotionAudioContextState | null;
 	gainNode: GainNode | null;
 	audioSyncAnchor: {value: number};
 	audioSyncAnchorEmitter: AudioSyncAnchorEmitter;

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -75,6 +75,7 @@ export type AudioSyncAnchorEmitter = {
 
 type SharedAudioContextValue = {
 	audioContext: AudioContext | null;
+	getAudioContextState: () => AudioContextState | null;
 	gainNode: GainNode | null;
 	audioSyncAnchor: {value: number};
 	audioSyncAnchorEmitter: AudioSyncAnchorEmitter;
@@ -232,7 +233,7 @@ export const SharedAudioContextProvider: React.FC<{
 			}
 
 			const saveForLater =
-				ctxAndGain.audioContext.state === 'suspended' && !isResuming.current;
+				ctxAndGain.getState() === 'suspended' && !isResuming.current;
 
 			if (duration > 0) {
 				if (saveForLater) {
@@ -383,6 +384,7 @@ export const SharedAudioContextProvider: React.FC<{
 	const audioContextValue: SharedAudioContextValue = useMemo(() => {
 		return {
 			audioContext: ctxAndGain?.audioContext ?? null,
+			getAudioContextState: () => ctxAndGain?.audioContext?.state ?? null,
 			gainNode: ctxAndGain?.gainNode ?? null,
 			audioSyncAnchor,
 			audioSyncAnchorEmitter,

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -172,12 +172,13 @@ type NodeToResume = {
 	duration: number;
 };
 
-const shouldSaveForLater = (state: RemotionAudioContextState) => {
+const shouldSaveForLater = (
+	state: Exclude<RemotionAudioContextState, 'closed'>,
+) => {
 	if (
 		state === 'suspended' ||
 		state === 'running-to-suspended' ||
-		state === 'interrupted' ||
-		state === 'closed'
+		state === 'interrupted'
 	) {
 		return true;
 	}
@@ -251,6 +252,14 @@ export const SharedAudioContextProvider: React.FC<{
 			}
 
 			const currentState = ctxAndGain.getState();
+
+			if (currentState === 'closed') {
+				return {
+					type: 'not-started',
+					reason: 'audio context is closed',
+				};
+			}
+
 			const saveForLater = shouldSaveForLater(currentState);
 
 			if (duration > 0) {

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -172,6 +172,23 @@ type NodeToResume = {
 	duration: number;
 };
 
+const shouldSaveForLater = (state: RemotionAudioContextState) => {
+	if (
+		state === 'suspended' ||
+		state === 'running-to-suspended' ||
+		state === 'interrupted' ||
+		state === 'closed'
+	) {
+		return true;
+	}
+
+	if (state === 'running' || state === 'suspended-to-running') {
+		return false;
+	}
+
+	throw new Error(`Unexpected audio context state: ${state satisfies never}`);
+};
+
 export const SharedAudioContextProvider: React.FC<{
 	readonly children: React.ReactNode;
 	readonly audioLatencyHint: AudioContextLatencyCategory;
@@ -233,8 +250,8 @@ export const SharedAudioContextProvider: React.FC<{
 				throw new Error('Audio context not found');
 			}
 
-			const saveForLater =
-				ctxAndGain.getState() === 'suspended' && !isResuming.current;
+			const currentState = ctxAndGain.getState();
+			const saveForLater = shouldSaveForLater(currentState);
 
 			if (duration > 0) {
 				if (saveForLater) {

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -83,7 +83,7 @@ type SharedAudioContextValue = {
 		options: ScheduleAudioNodeOptions,
 	) => ScheduleAudioNodeResult;
 	resume: () => Promise<void>;
-	suspend: () => void;
+	suspend: () => Promise<void>;
 	getIsResumingAudioContext: () => Promise<void> | null;
 	unscheduleAudioNode: (node: AudioBufferSourceNode) => void;
 };
@@ -342,7 +342,7 @@ export const SharedAudioContextProvider: React.FC<{
 		});
 		nodesToResume.current.clear();
 
-		const resumePromise = ctxAndGain.audioContext.resume();
+		const resumePromise = ctxAndGain.resume();
 
 		isResuming.current = new Promise<void>((resolve) => {
 			waitUntilActuallyResumed(ctxAndGain.audioContext, logLevel).then(resolve);
@@ -370,15 +370,15 @@ export const SharedAudioContextProvider: React.FC<{
 
 	const suspend = useCallback(() => {
 		if (!ctxAndGain) {
-			return;
+			return Promise.resolve();
 		}
 
 		if (!audioContextIsPlayingEventually.current) {
-			return;
+			return Promise.resolve();
 		}
 
 		audioContextIsPlayingEventually.current = false;
-		ctxAndGain.audioContext.suspend();
+		return ctxAndGain.suspend();
 	}, [ctxAndGain]);
 
 	const audioContextValue: SharedAudioContextValue = useMemo(() => {

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -3,6 +3,14 @@ import type {LogLevel} from '../log';
 import {Log} from '../log';
 import {useRemotionEnvironment} from '../use-remotion-environment';
 
+// The native AudioContext.state can be 'closed' | 'interrupted' | 'running' | 'suspended'.
+// resume() and suspend() do not change the state immediately, so we expose two
+// additional transition states to reflect that a change is in progress.
+export type RemotionAudioContextState =
+	| AudioContextState
+	| 'running-to-suspended'
+	| 'suspended-to-running';
+
 let warned = false;
 
 const warnOnce = (logLevel: LogLevel) => {
@@ -60,9 +68,49 @@ export const useSingletonAudioContext = ({
 
 		audioContext.suspend();
 
-		const getState = () => audioContext.state;
-		const resume = () => audioContext.resume();
-		const suspend = () => audioContext.suspend();
+		// Tracks the state we are transitioning towards while resume()/suspend()
+		// have been called but the native state has not updated yet.
+		let transitionTarget: 'running' | 'suspended' | null = null;
+
+		const getState = (): RemotionAudioContextState => {
+			const nativeState = audioContext.state;
+
+			if (transitionTarget === 'running' && nativeState !== 'running') {
+				return 'suspended-to-running';
+			}
+
+			if (transitionTarget === 'suspended' && nativeState !== 'suspended') {
+				return 'running-to-suspended';
+			}
+
+			return nativeState;
+		};
+
+		const resume = () => {
+			transitionTarget = 'running';
+			const promise = audioContext.resume();
+
+			promise.finally(() => {
+				if (transitionTarget === 'running') {
+					transitionTarget = null;
+				}
+			});
+
+			return promise;
+		};
+
+		const suspend = () => {
+			transitionTarget = 'suspended';
+			const promise = audioContext.suspend();
+
+			promise.finally(() => {
+				if (transitionTarget === 'suspended') {
+					transitionTarget = null;
+				}
+			});
+
+			return promise;
+		};
 
 		return {
 			audioContext,

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -61,11 +61,15 @@ export const useSingletonAudioContext = ({
 		audioContext.suspend();
 
 		const getState = () => audioContext.state;
+		const resume = () => audioContext.resume();
+		const suspend = () => audioContext.suspend();
 
 		return {
 			audioContext,
 			gainNode,
 			getState,
+			resume,
+			suspend,
 		};
 	}, [logLevel, latencyHint, env.isRendering, audioEnabled]);
 

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -60,9 +60,12 @@ export const useSingletonAudioContext = ({
 
 		audioContext.suspend();
 
+		const getState = () => audioContext.state;
+
 		return {
 			audioContext,
 			gainNode,
+			getState,
 		};
 	}, [logLevel, latencyHint, env.isRendering, audioEnabled]);
 

--- a/packages/player/src/set-global-time-anchor.ts
+++ b/packages/player/src/set-global-time-anchor.ts
@@ -19,7 +19,7 @@ export const setGlobalTimeAnchor = ({
 }): boolean => {
 	const newAnchor =
 		audioContext.currentTime - absoluteTimeInSeconds / globalPlaybackRate;
-	const shift = (newAnchor - audioSyncAnchor.value) * globalPlaybackRate;
+	const shift = newAnchor - audioSyncAnchor.value;
 	const {outputLatency} = audioContext;
 	const safeOutputLatency = outputLatency === 0 ? 0.3 : outputLatency;
 	const latency = audioContext.baseLatency + safeOutputLatency;
@@ -29,7 +29,8 @@ export const setGlobalTimeAnchor = ({
 		return false;
 	}
 
-	if (shift === 0) {
+	// If force is true, but shift is zero, no change is needed
+	if (Math.abs(shift) < Number.EPSILON) {
 		return false;
 	}
 

--- a/packages/player/src/set-global-time-anchor.ts
+++ b/packages/player/src/set-global-time-anchor.ts
@@ -29,6 +29,10 @@ export const setGlobalTimeAnchor = ({
 		return false;
 	}
 
+	if (shift === 0) {
+		return false;
+	}
+
 	Internals.Log.verbose(
 		{logLevel, tag: 'audio-scheduling'},
 		'Anchor ' +

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -104,7 +104,8 @@ export const usePlayback = ({
 		}
 
 		const callback = () => {
-			if (audioContext.state !== 'running') {
+			const newState = sharedAudioContext?.getAudioContextState();
+			if (newState !== 'running') {
 				setGlobalTimeAnchor({
 					audioContext,
 					audioSyncAnchor: sharedAudioContext.audioSyncAnchor,


### PR DESCRIPTION
2 fixes:

- Anchor setting was more strict when the playback rate was higher and less strict when the playback rate was lower, but this did not make any sense. Now the strictness is the same regardless of playback rate.
- inbetween `.resume()` and the audio context actually resuming, and `.suspend()` and the audio context actually suspending, we have a transition state which we did not handle explicitly and even wrongly. When a composition ends, we call suspend but we are still running, leading to scheduled audio nodes being wrong