### PR TITLE
`@remotion/it-tests`: Update composer.lock after bumping composer.json version

### DIFF
--- a/packages/it-tests/src/monorepo/php-package.test.ts
+++ b/packages/it-tests/src/monorepo/php-package.test.ts
@@ -70,6 +70,9 @@ class Semantic
 			path.join(process.cwd(), '..', 'lambda-php', 'composer.json'),
 			JSON.stringify(composerJsonJson, null, 2) + '\n',
 		);
+		execSync('php composer.phar update --lock --no-interaction --quiet', {
+			cwd: lambdaPhpDir,
+		});
 	});
 
 	test('Set the right version for composer.json in example', () => {


### PR DESCRIPTION
Fixes #7648

After the `php-package.test.ts` test updates the `version` field in `composer.json`, the `composer.lock` content-hash becomes out of sync. This causes the `beforeAll` validation to fail on the next run (e.g. after a publish).

**Fix:** Run `php composer.phar update --lock` after writing the updated `composer.json`, so the lock file's content-hash stays in sync.