### PR TITLE
`@remotion/media`: Fix audio anchor currentTime being stale

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -58,7 +58,6 @@ export type ScheduleAudioNodeResult =
 export type ScheduleAudioNodeOptions = {
 	readonly node: AudioBufferSourceNode;
 	readonly mediaTimestamp: number;
-	readonly currentTime: number;
 	readonly scheduledTime: number;
 	readonly originalUnloopedMediaTimestamp: number;
 	readonly duration: number;
@@ -241,7 +240,6 @@ export const SharedAudioContextProvider: React.FC<{
 		return ({
 			node,
 			mediaTimestamp,
-			currentTime,
 			scheduledTime,
 			duration,
 			offset,
@@ -314,8 +312,7 @@ export const SharedAudioContextProvider: React.FC<{
 					: Math.abs(timeDiff).toFixed(2) +
 							(timeDiff < 0 ? ' delay' : ' ahead'),
 				'',
-				'current=' + currentTime.toFixed(4),
-				'actualcurrent=' + ctxAndGain.audioContext.currentTime.toFixed(4),
+				'current=' + ctxAndGain.audioContext.currentTime.toFixed(4),
 				'offset=' + offset.toFixed(4),
 				'latency=' + latency.toFixed(4),
 				'state=' + ctxAndGain.audioContext.state,

--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -26,7 +26,6 @@ type ScheduleAudioNode = (
 	node: AudioBufferSourceNode,
 	mediaTimestamp: number,
 	originalUnloopedMediaTimestamp: number,
-	currentTime: number,
 ) => ScheduleAudioNodeResult;
 
 export const audioIteratorManager = ({
@@ -127,7 +126,6 @@ export const audioIteratorManager = ({
 		playbackRate,
 		scheduleAudioNode,
 		logLevel,
-		currentTime,
 	}: {
 		buffer: AudioBuffer;
 		mediaTimestamp: number;
@@ -135,7 +133,6 @@ export const audioIteratorManager = ({
 		scheduleAudioNode: ScheduleAudioNode;
 		logLevel: LogLevel;
 		originalUnloopedMediaTimestamp: number;
-		currentTime: number;
 	}) => {
 		if (!audioBufferIterator) {
 			throw new Error('Audio buffer iterator not found');
@@ -154,7 +151,6 @@ export const audioIteratorManager = ({
 			node,
 			mediaTimestamp,
 			originalUnloopedMediaTimestamp,
-			currentTime,
 		);
 
 		if (started.type === 'not-started') {
@@ -183,13 +179,11 @@ export const audioIteratorManager = ({
 		playbackRate,
 		scheduleAudioNode,
 		logLevel,
-		currentTime,
 	}: {
 		buffer: BufferWithMediaTimestamp;
 		playbackRate: number;
 		scheduleAudioNode: ScheduleAudioNode;
 		logLevel: LogLevel;
-		currentTime: number;
 	}) => {
 		if (muted) {
 			return;
@@ -221,7 +215,6 @@ export const audioIteratorManager = ({
 			scheduleAudioNode,
 			logLevel,
 			originalUnloopedMediaTimestamp: buffer.buffer.timestamp,
-			currentTime,
 		});
 
 		drawDebugOverlay();
@@ -303,7 +296,6 @@ export const audioIteratorManager = ({
 					playbackRate,
 					scheduleAudioNode,
 					logLevel,
-					currentTime: getAudioContextCurrentTimeMockedInTest(),
 				});
 				proceedScheduling({
 					iterator,

--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -303,7 +303,7 @@ export const audioIteratorManager = ({
 					playbackRate,
 					scheduleAudioNode,
 					logLevel,
-					currentTime,
+					currentTime: getAudioContextCurrentTimeMockedInTest(),
 				});
 				proceedScheduling({
 					iterator,

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -706,13 +706,15 @@ export class MediaPlayer {
 		node: AudioBufferSourceNode,
 		mediaTimestamp: number,
 		originalUnloopedMediaTimestamp: number,
-		currentTime: number,
 	): ScheduleAudioNodeResult => {
 		if (!this.sharedAudioContext) {
 			throw new Error('Shared audio context not found');
 		}
 
-		const targetTime = this.getTargetTime(mediaTimestamp, currentTime);
+		const targetTime = this.getTargetTime(
+			mediaTimestamp,
+			this.sharedAudioContext.audioContext.currentTime,
+		);
 		if (targetTime === null) {
 			return {
 				type: 'not-started',
@@ -720,7 +722,7 @@ export class MediaPlayer {
 					'no target for' +
 					mediaTimestamp.toFixed(3) +
 					',' +
-					currentTime.toFixed(3),
+					this.sharedAudioContext.audioContext.currentTime.toFixed(3),
 			};
 		}
 
@@ -743,14 +745,13 @@ export class MediaPlayer {
 		const scheduledTime = getScheduledTime({
 			mediaTimestamp,
 			targetTime,
-			currentTime,
 			sequenceStartTime,
+			currentTime: this.sharedAudioContext.audioContext.currentTime,
 		});
 
 		return this.sharedAudioContext.scheduleAudioNode({
 			node,
 			mediaTimestamp,
-			currentTime,
 			scheduledTime,
 			duration,
 			offset,


### PR DESCRIPTION
This was due to the time changing during scheduling, but now we pause the context while initially scheduling and we don't have this problem anymore