### PR TITLE
`remotion`: Make Sequence ref target the outer element

### DIFF
--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -113,6 +113,7 @@ export type TSequence = {
 	nonce: NonceHistory;
 	loopDisplay: LoopDisplay | undefined;
 	getStack: () => string | null;
+	getElement?: () => Element | null;
 	premountDisplay: number | null;
 	postmountDisplay: number | null;
 	controls: SequenceControls | null;

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import React, {
+	useCallback,
 	forwardRef,
 	useContext,
 	useEffect,
@@ -128,6 +129,23 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 	const {layout = 'absolute-fill'} = other;
 
 	const [id] = useState(() => String(Math.random()));
+	const absoluteFillRef = useRef<HTMLDivElement>(null);
+	const setAbsoluteFillRef = useCallback(
+		(node: HTMLDivElement | null) => {
+			absoluteFillRef.current = node;
+			if (ref === null) {
+				return;
+			}
+
+			if (typeof ref === 'function') {
+				ref(node);
+				return;
+			}
+
+			ref.current = node;
+		},
+		[ref],
+	);
 	const parentSequence = useContext(SequenceContext);
 	const {rootId} = useTimelineContext();
 	const cumulatedFrom = parentSequence
@@ -246,6 +264,18 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 	const stackRef = useRef<string | null>(null);
 	stackRef.current = stack ?? inheritedStack;
 
+	const getElement = useMemo(() => {
+		if (layout === 'absolute-fill') {
+			return () => absoluteFillRef.current;
+		}
+
+		if (typeof ref === 'function' || ref === null) {
+			return () => null;
+		}
+
+		return () => ref.current;
+	}, [layout, ref]);
+
 	useEffect(() => {
 		if (!env.isStudio) {
 			return;
@@ -271,6 +301,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 					showInTimeline,
 					src: isMedia.src,
 					getStack: () => stackRef.current,
+					getElement,
 				});
 			} else {
 				registerSequence({
@@ -293,6 +324,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 					showInTimeline,
 					src: isMedia.data.src,
 					getStack: () => stackRef.current,
+					getElement,
 					startMediaFrom: isMedia.data.startMediaFrom,
 					volume: isMedia.data.volumes,
 				});
@@ -316,6 +348,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 			nonce: nonce.get(),
 			loopDisplay,
 			getStack: () => stackRef.current,
+			getElement,
 			premountDisplay: premountDisplay ?? null,
 			postmountDisplay: postmountDisplay ?? null,
 			controls: controls ?? null,
@@ -345,6 +378,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		_remotionInternalEffects,
 		isMedia,
 		resolvedDocumentationLink,
+		getElement,
 	]);
 
 	// Ceil to support floats
@@ -368,12 +402,6 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		};
 	}, [height, styleIfThere, width]);
 
-	if (ref !== null && layout === 'none') {
-		throw new TypeError(
-			'It is not supported to pass both a `ref` and `layout="none"` to <Sequence />.',
-		);
-	}
-
 	if (hidden) {
 		return null;
 	}
@@ -384,7 +412,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 				content
 			) : (
 				<AbsoluteFill
-					ref={ref}
+					ref={setAbsoluteFillRef}
 					style={defaultStyle}
 					className={other.className}
 				>

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -258,7 +258,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	const env = useRemotionEnvironment();
 
-	const inheritedStack = (other as any)?.stack ?? null;
+	const inheritedStack = (other as {stack?: string}).stack ?? null;
 	// Our assumption: Stack doesnt' change. After we symbolicate we assign it a nodePath
 	// and if it changes, it would lead to-remounting of the sequence.
 	const stackRef = useRef<string | null>(null);

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -196,7 +196,7 @@ test('Sequence with layout="none" can register an externally assigned ref', () =
 				registeredSequences.push(sequence);
 			}}
 		>
-			<Sequence layout="none" ref={elementRef}>
+			<Sequence ref={elementRef} layout="none">
 				<div ref={elementRef}>Hello</div>
 			</Sequence>
 		</SequenceTestWrapper>,

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -167,3 +167,41 @@ test('Named Img components do not receive the default documentation link', () =>
 
 	expect(registeredSequences[0]?.documentationLink).toBe(null);
 });
+
+test('Sequence registers the absolute-fill element ref', () => {
+	const registeredSequences: TSequence[] = [];
+	const elementRef = React.createRef<HTMLDivElement>();
+
+	render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Sequence ref={elementRef}>Hello</Sequence>
+		</SequenceTestWrapper>,
+	);
+
+	expect(elementRef.current).not.toBe(null);
+	expect(registeredSequences[0]?.getElement?.()).toBe(elementRef.current);
+});
+
+test('Sequence with layout="none" can register an externally assigned ref', () => {
+	const registeredSequences: TSequence[] = [];
+	const elementRef = React.createRef<HTMLDivElement>();
+
+	render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Sequence layout="none" ref={elementRef}>
+				<div ref={elementRef}>Hello</div>
+			</Sequence>
+		</SequenceTestWrapper>,
+	);
+
+	expect(elementRef.current).not.toBe(null);
+	expect(registeredSequences[0]?.getElement?.()).toBe(elementRef.current);
+});


### PR DESCRIPTION
## Summary
- add `getElement` support to registered sequences so Studio can resolve the outer DOM element
- keep `ref` forwarding for `layout="absolute-fill"` and allow `layout="none"` to use externally-assigned refs
- add core tests for both absolute-fill and layout="none" ref registration

Fixes #7605