### PR TITLE
`@remotion/promo-pages`: Rethink homepage copy for AI workflows

### DIFF
--- a/packages/promo-pages/src/components/Homepage.tsx
+++ b/packages/promo-pages/src/components/Homepage.tsx
@@ -43,13 +43,12 @@ export const NewLanding: React.FC<{
 						<br />
 						<br />
 						<br />
-						<VideoAppsShowcase />
-						<br />
-						<br />
-						<br />
-						<br />
 						<CreatorShowcase />
 						<br />
+						<br />
+						<br />
+						<br />
+						<VideoAppsShowcase />
 						<br />
 						<br />
 						<Demo />

--- a/packages/promo-pages/src/components/Homepage.tsx
+++ b/packages/promo-pages/src/components/Homepage.tsx
@@ -5,7 +5,6 @@ import {BackgroundAnimation} from './homepage/BackgroundAnimation';
 import CommunityStats from './homepage/CommunityStats';
 import {CreatorShowcase} from './homepage/CreatorShowcase';
 import {Demo} from './homepage/Demo';
-import EditorStarterSection from './homepage/EditorStarterSection';
 import EvaluateRemotionSection from './homepage/EvaluateRemotion';
 import {IfYouKnowReact} from './homepage/IfYouKnowReact';
 import type {ColorMode} from './homepage/layout/use-color-mode';
@@ -43,7 +42,11 @@ export const NewLanding: React.FC<{
 						<br />
 						<br />
 						<br />
+						<br />
+						<br />
 						<CreatorShowcase />
+						<br />
+						<br />
 						<br />
 						<br />
 						<br />
@@ -64,10 +67,6 @@ export const NewLanding: React.FC<{
 						<br />
 						<br />
 						<CommunityStats />
-						<br />
-						<br />
-						<br />
-						<EditorStarterSection />
 						<br />
 						<br />
 						<br />

--- a/packages/promo-pages/src/components/Homepage.tsx
+++ b/packages/promo-pages/src/components/Homepage.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import {BackgroundAnimation} from './homepage/BackgroundAnimation';
 import CommunityStats from './homepage/CommunityStats';
+import {CreatorShowcase} from './homepage/CreatorShowcase';
 import {Demo} from './homepage/Demo';
 import EditorStarterSection from './homepage/EditorStarterSection';
 import EvaluateRemotionSection from './homepage/EvaluateRemotion';
@@ -43,6 +44,12 @@ export const NewLanding: React.FC<{
 						<br />
 						<br />
 						<VideoAppsShowcase />
+						<br />
+						<br />
+						<br />
+						<br />
+						<CreatorShowcase />
+						<br />
 						<br />
 						<br />
 						<Demo />

--- a/packages/promo-pages/src/components/homepage/CreatorShowcase.tsx
+++ b/packages/promo-pages/src/components/homepage/CreatorShowcase.tsx
@@ -11,7 +11,7 @@ const creatorExamples = [
 		muxPlaybackId: '2E2ksNC9FIgnczmLZZQ4iJjDp760101pcLnyLeNal9MjA',
 	},
 	{
-		title: 'B-roll for stories',
+		title: 'B-roll',
 		description:
 			'Turn screenshots, headlines, product moments, and references into supporting visuals for your edit.',
 		slug: 'news-article-headline-highlight',
@@ -63,12 +63,8 @@ const CreatorExample: React.FC<{
 				<div className="text-xl font-bold fontbrand text-text">
 					{example.title}
 				</div>
-				<div className="text-muted text-sm fontbrand leading-relaxed mt-2 flex-1">
+				<div className="text-muted text-sm fontbrand leading-relaxed mt-2">
 					{example.description}
-				</div>
-				<div className="text-brand font-brand font-bold text-sm inline-flex flex-row items-center mt-4">
-					See prompt
-					<Arrow />
 				</div>
 			</div>
 		</a>

--- a/packages/promo-pages/src/components/homepage/CreatorShowcase.tsx
+++ b/packages/promo-pages/src/components/homepage/CreatorShowcase.tsx
@@ -78,7 +78,7 @@ const CreatorExample: React.FC<{
 export const CreatorShowcase: React.FC = () => {
 	return (
 		<div>
-			<SectionTitle>For video creators</SectionTitle>
+			<SectionTitle>Create production assets</SectionTitle>
 			<div className="text-center text-muted fontbrand text-base mt-2 mb-6">
 				Prompt production assets, then iterate until they fit your edit.
 			</div>

--- a/packages/promo-pages/src/components/homepage/CreatorShowcase.tsx
+++ b/packages/promo-pages/src/components/homepage/CreatorShowcase.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import {MuxVideo} from './MuxVideo';
+import {SectionTitle} from './VideoAppsTitle';
+
+const creatorExamples = [
+	{
+		title: 'Motion graphics',
+		description:
+			'Create animated explainers, map flyovers, visual metaphors, and graphics that make a story easier to follow.',
+		slug: 'travel-route-on-map-with-3d-landmarks',
+		muxPlaybackId: '2E2ksNC9FIgnczmLZZQ4iJjDp760101pcLnyLeNal9MjA',
+	},
+	{
+		title: 'B-roll for stories',
+		description:
+			'Turn screenshots, headlines, product moments, and references into supporting visuals for your edit.',
+		slug: 'news-article-headline-highlight',
+		muxPlaybackId: 'Cb4BOLZkhLeNa01on4DH9195qH00CF1h4qQ3qRnyD9XZE',
+	},
+	{
+		title: 'Transparent video overlays',
+		description:
+			'Render lower-thirds, subscribe animations, and callouts with alpha, then drop them into DaVinci Resolve, Premiere, or Final Cut.',
+		slug: 'transparent-call-to-action-overlay',
+		muxPlaybackId: '00KwCg00hc01Ugk5UjXD02MuT47EuZSshmbIbRkeNoZyyaM',
+	},
+];
+
+const icon: React.CSSProperties = {
+	height: 16,
+	marginLeft: 10,
+};
+
+const Arrow: React.FC = () => (
+	<svg style={icon} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+		<path
+			fill="currentColor"
+			d="M438.6 278.6l-160 160C272.4 444.9 264.2 448 256 448s-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L338.8 288H32C14.33 288 .0016 273.7 .0016 256S14.33 224 32 224h306.8l-105.4-105.4c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l160 160C451.1 245.9 451.1 266.1 438.6 278.6z"
+		/>
+	</svg>
+);
+
+const CreatorExample: React.FC<{
+	readonly example: (typeof creatorExamples)[number];
+}> = ({example}) => {
+	return (
+		<a
+			href={`/prompts/${example.slug}`}
+			className="card p-0 overflow-hidden no-underline hover:no-underline flex flex-col shadow-sm"
+		>
+			<div className="aspect-video bg-black overflow-hidden">
+				<MuxVideo
+					muxId={example.muxPlaybackId}
+					className="w-full h-full object-cover"
+					muted
+					autoPlay
+					playsInline
+					loop
+					poster={`https://image.mux.com/${example.muxPlaybackId}/thumbnail.png?time=1`}
+				/>
+			</div>
+			<div className="p-5 flex flex-col flex-1">
+				<div className="text-xl font-bold fontbrand text-text">
+					{example.title}
+				</div>
+				<div className="text-muted text-sm fontbrand leading-relaxed mt-2 flex-1">
+					{example.description}
+				</div>
+				<div className="text-brand font-brand font-bold text-sm inline-flex flex-row items-center mt-4">
+					See prompt
+					<Arrow />
+				</div>
+			</div>
+		</a>
+	);
+};
+
+export const CreatorShowcase: React.FC = () => {
+	return (
+		<div>
+			<SectionTitle>For video creators</SectionTitle>
+			<div className="text-center text-muted fontbrand text-base mt-2 mb-6">
+				Prompt production assets, then iterate until they fit your edit.
+			</div>
+			<div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+				{creatorExamples.map((example) => (
+					<CreatorExample key={example.slug} example={example} />
+				))}
+			</div>
+			<div className="flex flex-col sm:flex-row gap-6 justify-center items-center mt-8 font-brand text-sm">
+				<a
+					href="/prompts"
+					className="no-underline text-brand font-bold inline-flex flex-row items-center"
+				>
+					Browse prompt examples
+					<Arrow />
+				</a>
+				<a
+					href="/docs/overlay"
+					className="no-underline text-brand font-bold inline-flex flex-row items-center"
+				>
+					Create transparent overlays
+					<Arrow />
+				</a>
+			</div>
+		</div>
+	);
+};

--- a/packages/promo-pages/src/components/homepage/IfYouKnowReact.tsx
+++ b/packages/promo-pages/src/components/homepage/IfYouKnowReact.tsx
@@ -42,7 +42,7 @@ export const IfYouKnowReact: React.FC = () => {
 					<span className="text-brand">Compose</span> with code
 				</h2>
 				<p className="leading-relaxed font-brand">
-					Use React, a powerful frontend technology, to create sophisticated
+					Describe the result, then refine it with React to create sophisticated
 					videos with code.
 				</p>
 				<div className="h-4" />

--- a/packages/promo-pages/src/components/homepage/IfYouKnowReact.tsx
+++ b/packages/promo-pages/src/components/homepage/IfYouKnowReact.tsx
@@ -42,8 +42,8 @@ export const IfYouKnowReact: React.FC = () => {
 					<span className="text-brand">Compose</span> with code
 				</h2>
 				<p className="leading-relaxed font-brand">
-					Use React to create sophisticated videos with code. Start from scratch, a
-					template, or an AI-assisted draft, then refine every frame.
+					Use React to create sophisticated videos with code. Start from
+					scratch, a template, or an AI-assisted draft, then refine every frame.
 				</p>
 				<div className="h-4" />
 				<a

--- a/packages/promo-pages/src/components/homepage/IfYouKnowReact.tsx
+++ b/packages/promo-pages/src/components/homepage/IfYouKnowReact.tsx
@@ -42,8 +42,8 @@ export const IfYouKnowReact: React.FC = () => {
 					<span className="text-brand">Compose</span> with code
 				</h2>
 				<p className="leading-relaxed font-brand">
-					Describe the result, then refine it with React to create sophisticated
-					videos with code.
+					Use React to create sophisticated videos with code. Start from scratch, a
+					template, or an AI-assisted draft, then refine every frame.
 				</p>
 				<div className="h-4" />
 				<a

--- a/packages/promo-pages/src/components/homepage/ParameterizeAndEdit.tsx
+++ b/packages/promo-pages/src/components/homepage/ParameterizeAndEdit.tsx
@@ -43,9 +43,9 @@ export const ParameterizeAndEdit: React.FC = () => {
 					Edit <span className="text-brand">dynamically</span>
 				</h2>
 				<p className="leading-relaxed">
-					Parameterize your video by passing data.
+					Turn templates into video-generating apps.
 					<br />
-					Or embed it into your app and build an interface around it.
+					Parameterize videos with data, user input, or APIs.
 				</p>
 				<div className="h-4" />
 				<div className="leading-6">

--- a/packages/promo-pages/src/components/homepage/RealMp4Videos.tsx
+++ b/packages/promo-pages/src/components/homepage/RealMp4Videos.tsx
@@ -63,7 +63,7 @@ export const RealMP4Videos: React.FC = () => {
 					<span className={'text-brand'}>Scalable</span> rendering
 				</h2>
 				<p className="leading-relaxed">
-					Render personalized videos from data, events, or inputs. <br />
+					Render the video as .mp4 or other formats. <br />
 					Locally, on the server or serverless.
 				</p>{' '}
 				<div className="h-4" />

--- a/packages/promo-pages/src/components/homepage/RealMp4Videos.tsx
+++ b/packages/promo-pages/src/components/homepage/RealMp4Videos.tsx
@@ -63,7 +63,7 @@ export const RealMP4Videos: React.FC = () => {
 					<span className={'text-brand'}>Scalable</span> rendering
 				</h2>
 				<p className="leading-relaxed">
-					Render the video as .mp4 or other formats. <br />
+					Render personalized videos from data, events, or inputs. <br />
 					Locally, on the server or serverless.
 				</p>{' '}
 				<div className="h-4" />

--- a/packages/promo-pages/src/components/homepage/VideoAppsShowcase.tsx
+++ b/packages/promo-pages/src/components/homepage/VideoAppsShowcase.tsx
@@ -279,8 +279,8 @@ const VideoAppsShowcase: React.FC = () => {
 						fontFamily: 'GTPlanar',
 					}}
 				>
-					From one-off videos to products that generate thousands of
-					personalized renders. For more examples see our{' '}
+					Build products and workflows that generate personalized videos at
+					scale. For more examples see our{' '}
 					<a href="/showcase" className="bluelink">
 						Showcase page
 					</a>

--- a/packages/promo-pages/src/components/homepage/VideoAppsShowcase.tsx
+++ b/packages/promo-pages/src/components/homepage/VideoAppsShowcase.tsx
@@ -120,7 +120,7 @@ const VideoAppsShowcase: React.FC = () => {
 
 	return (
 		<div ref={containerRef}>
-			<SectionTitle>Use Cases</SectionTitle>
+			<SectionTitle>Video apps and automations</SectionTitle>
 			<div
 				className={
 					'grid justify-center grid-flow-col grid-rows-1 gap-2.5 justify-self-center mb-4 w-[90vw] md:w-auto -mt-4'
@@ -279,7 +279,8 @@ const VideoAppsShowcase: React.FC = () => {
 						fontFamily: 'GTPlanar',
 					}}
 				>
-					For more examples see our{' '}
+					From one-off videos to products that generate thousands of
+					personalized renders. For more examples see our{' '}
 					<a href="/showcase" className="bluelink">
 						Showcase page
 					</a>

--- a/packages/promo-pages/src/components/homepage/VideoAppsShowcase.tsx
+++ b/packages/promo-pages/src/components/homepage/VideoAppsShowcase.tsx
@@ -10,6 +10,30 @@ const tabs = [
 	'Year in review',
 ];
 
+const entrypoints = [
+	{
+		title: 'Build a timeline',
+		description:
+			'Synchronize Remotion Player with tracks, clips, text, audio, and overlays.',
+		link: '/docs/building-a-timeline',
+		buttonText: 'Timeline guide',
+	},
+	{
+		title: 'Parameterize videos',
+		description:
+			'Pass props into React components to generate videos from user input, APIs, or datasets.',
+		link: '/docs/parameterized-rendering',
+		buttonText: 'Parameterized videos',
+	},
+	{
+		title: 'Render at scale',
+		description:
+			'Render many videos locally, on servers, or serverlessly with Remotion Lambda.',
+		link: '/lambda',
+		buttonText: 'Remotion Lambda',
+	},
+];
+
 const videoApps = [
 	{
 		title: 'Banger.Show',
@@ -59,6 +83,38 @@ const videoApps = [
 const icon: React.CSSProperties = {
 	height: 16,
 	marginLeft: 10,
+};
+
+const Arrow: React.FC = () => (
+	<svg style={icon} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+		<path
+			fill="currentColor"
+			d="M438.6 278.6l-160 160C272.4 444.9 264.2 448 256 448s-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L338.8 288H32C14.33 288 .0016 273.7 .0016 256S14.33 224 32 224h306.8l-105.4-105.4c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l160 160C451.1 245.9 451.1 266.1 438.6 278.6z"
+		/>
+	</svg>
+);
+
+const EntryPointCard: React.FC<{
+	readonly title: string;
+	readonly description: string;
+	readonly link: string;
+	readonly buttonText: string;
+}> = ({title, description, link, buttonText}) => {
+	return (
+		<a
+			href={link}
+			className="card p-5 no-underline hover:no-underline flex h-full flex-col text-left"
+		>
+			<dt className="text-lg font-bold fontbrand text-text">{title}</dt>
+			<dd className="text-muted text-sm fontbrand leading-relaxed mt-2 flex-1 m-0">
+				{description}
+			</dd>
+			<div className="text-brand font-brand font-bold text-sm inline-flex flex-row items-center mt-4">
+				{buttonText}
+				<Arrow />
+			</div>
+		</a>
+	);
 };
 
 const VideoAppsShowcase: React.FC = () => {
@@ -120,18 +176,55 @@ const VideoAppsShowcase: React.FC = () => {
 
 	return (
 		<div ref={containerRef}>
-			<SectionTitle>Video apps and automations</SectionTitle>
-			<div
-				className={
-					'grid justify-center grid-flow-col grid-rows-1 gap-2.5 justify-self-center mb-4 w-[90vw] md:w-auto -mt-4'
-				}
-			>
+			<SectionTitle>Create video apps and automations</SectionTitle>
+			<div className="text-center text-muted fontbrand text-base mt-2 mb-6">
+				Build products and workflows that generate personalized videos from user
+				input, APIs, or datasets.
+			</div>
+			<div className="card flex p-0 overflow-hidden mb-6">
+				<div className="flex-1 flex flex-col lg:flex-row justify-center">
+					<div className="w-full lg:w-[380px] lg:max-w-[380px] aspect-video lg:aspect-square relative overflow-hidden bg-[#eee]">
+						<MuxVideo
+							muxId="YIvIidbcAc7009B00Wr7gIbGyq67YGNlytGvMXwdsLRtc"
+							className="absolute left-0 top-0 w-full h-full object-cover object-top rounded-sm rounded-tr-none rounded-br-none"
+							loop
+							autoPlay
+							playsInline
+							muted
+						/>
+					</div>
+					<div className="p-6 flex-1 flex flex-col justify-center">
+						<div className="text-3xl font-bold fontbrand mt-0">
+							Build your own video editor
+						</div>
+						<div className="text-muted mt-3 text-base fontbrand leading-relaxed">
+							Start with Editor Starter: a React and TypeScript template with a
+							timeline, interactive canvas, asset uploads, and rendering.
+						</div>
+						<a
+							className="no-underline text-brand font-brand font-bold inline-flex flex-row items-center mt-5"
+							href="/docs/editor-starter"
+						>
+							Editor Starter
+							<Arrow />
+						</a>
+					</div>
+				</div>
+			</div>
+			<dl className="grid grid-cols-1 gap-4 lg:grid-cols-3 mb-8">
+				{entrypoints.map((entrypoint) => (
+					<EntryPointCard key={entrypoint.link} {...entrypoint} />
+				))}
+			</dl>
+			<div className="h-16" />
+			<SectionTitle>Built with Remotion</SectionTitle>
+			<div className="flex flex-wrap justify-center gap-x-8 gap-y-3 mb-6 mt-1">
 				{tabs.map((tab, index) => (
 					<button
 						key={tab}
 						type="button"
 						data-active={index === activeTab}
-						className={`bg-transparent border-none m-0 p-0 lg:mx-3 my-4 cursor-pointer text-base fontbrand font-bold transition-colors text-muted data-[active=true]:text-brand`}
+						className={`bg-transparent border-none m-0 p-0 cursor-pointer text-sm fontbrand font-bold transition-colors text-muted data-[active=true]:text-brand`}
 						onClick={() => handleTabChange(index)}
 					>
 						{tab}
@@ -143,10 +236,10 @@ const VideoAppsShowcase: React.FC = () => {
 				// Prevent this from showing up in search engine results
 				data-nosnippet
 			>
-				<div className={'flex-1 flex flex-col lg:flex-row justify-center'}>
+				<div className={'flex-1 grid grid-cols-1 lg:grid-cols-2'}>
 					<div
 						className={
-							'w-full max-w-[500px] aspect-square relative overflow-hidden bg-[#eee] cursor-pointer'
+							'w-full aspect-video lg:aspect-square relative overflow-hidden bg-[#eee] cursor-pointer'
 						}
 						onClick={handlePlayPause}
 					>
@@ -235,11 +328,11 @@ const VideoAppsShowcase: React.FC = () => {
 							)}
 						</button>
 					</div>
-					<div className={'p-6 flex-1 flex flex-col h-full'}>
-						<div className="text-4xl font-bold fontbrand mt-0">
+					<div className={'p-6 lg:p-10 flex min-w-0 flex-col justify-center'}>
+						<div className="text-3xl font-bold fontbrand mt-0">
 							{videoApps[activeTab].title}
 						</div>
-						<div className="text-muted mt-4 text-base fontbrand">
+						<div className="text-muted mt-3 text-base fontbrand leading-relaxed">
 							{videoApps[activeTab].description}
 						</div>
 						{videoApps[activeTab].additionalInfo ? (
@@ -253,16 +346,7 @@ const VideoAppsShowcase: React.FC = () => {
 							href={videoApps[activeTab].link}
 						>
 							{videoApps[activeTab].buttonText}
-							<svg
-								style={icon}
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 0 448 512"
-							>
-								<path
-									fill="currentColor"
-									d="M438.6 278.6l-160 160C272.4 444.9 264.2 448 256 448s-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L338.8 288H32C14.33 288 .0016 273.7 .0016 256S14.33 224 32 224h306.8l-105.4-105.4c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l160 160C451.1 245.9 451.1 266.1 438.6 278.6z"
-								/>
-							</svg>
+							<Arrow />
 						</a>
 					</div>
 				</div>
@@ -279,8 +363,7 @@ const VideoAppsShowcase: React.FC = () => {
 						fontFamily: 'GTPlanar',
 					}}
 				>
-					Build products and workflows that generate personalized videos at
-					scale. For more examples see our{' '}
+					For more examples of products and workflows, see our{' '}
 					<a href="/showcase" className="bluelink">
 						Showcase page
 					</a>

--- a/packages/promo-pages/src/components/homepage/WriteInReact.tsx
+++ b/packages/promo-pages/src/components/homepage/WriteInReact.tsx
@@ -11,7 +11,7 @@ export const WriteInReact: React.FC = () => {
 					textShadow: '0 5px 30px var(--background)',
 				}}
 			>
-				Create videos and video apps with React.
+				Make videos programmatically.
 			</h1>
 			<p
 				style={{

--- a/packages/promo-pages/src/components/homepage/WriteInReact.tsx
+++ b/packages/promo-pages/src/components/homepage/WriteInReact.tsx
@@ -11,7 +11,7 @@ export const WriteInReact: React.FC = () => {
 					textShadow: '0 5px 30px var(--background)',
 				}}
 			>
-				Make videos programmatically.
+				Create videos and video apps with React.
 			</h1>
 			<p
 				style={{
@@ -19,8 +19,8 @@ export const WriteInReact: React.FC = () => {
 				}}
 				className="font-medium text-center text-lg"
 			>
-				Create real MP4 videos with React. <br />
-				Use coding agents, build apps and render in bulk.
+				Use code, data, and AI agents to generate real MP4 videos. <br />
+				Build once, customize endlessly, and render at scale.
 			</p>
 			<br />
 			<div>


### PR DESCRIPTION
## Summary
- Reframe homepage copy around programmatic video creation with React, data, and AI-assisted workflows.
- Add a new "Create production assets" section for motion graphics, B-roll, and transparent video overlays.
- Split homepage positioning by use case: production assets first, then video apps and automations.
- Expand "Create video apps and automations" with concrete entrypoints for Editor Starter, timeline building, parameterized rendering, and scalable rendering.
- Refresh the "Built with Remotion" showcase layout and spacing to make the app examples easier to scan.
- Remove the standalone Editor Starter block now that it is integrated into the apps and automations section.

Addresses #7644

## Testing
- `cd packages/promo-pages && bunx oxfmt src --write`
- `bunx turbo run lint --filter='@remotion/promo-pages'`
- `bun run build`
- `bun run formatting`
