### PR TITLE
Docs: Playground for effects

### DIFF
--- a/packages/docs/components/demos/control.tsx
+++ b/packages/docs/components/demos/control.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react';
-import type {Option} from './types';
 import styles from './styles.module.css';
+import type {Option} from './types';
 
 const left: React.CSSProperties = {
 	fontFamily: 'GTPlanar',
@@ -119,6 +119,12 @@ export const Control = ({
 				<input
 					onChange={(e) => setValue(e.target.value)}
 					style={textInputStyle}
+					value={value as string}
+				/>
+			) : option.type === 'color' ? (
+				<input
+					type="color"
+					onChange={(e) => setValue(e.target.value)}
 					value={value as string}
 				/>
 			) : null}

--- a/packages/docs/components/demos/types.ts
+++ b/packages/docs/components/demos/types.ts
@@ -89,6 +89,10 @@ export type Option = {
 			default: string;
 			optional: 'no';
 	  }
+	| {
+			type: 'color';
+			default: string;
+	  }
 );
 
 export type DemoType = {
@@ -1412,7 +1416,17 @@ export const effectsBrightnessDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'amount',
+			type: 'numeric',
+			min: -1,
+			max: 1,
+			step: 0.01,
+			default: 0.25,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsGrayscaleDemo: DemoType = {
@@ -1425,7 +1439,17 @@ export const effectsGrayscaleDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'amount',
+			type: 'numeric',
+			min: 0,
+			max: 1,
+			step: 0.01,
+			default: 1,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsHueDemo: DemoType = {
@@ -1438,7 +1462,17 @@ export const effectsHueDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'degrees',
+			type: 'numeric',
+			min: 0,
+			max: 360,
+			step: 1,
+			default: 120,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsInvertDemo: DemoType = {
@@ -1451,7 +1485,17 @@ export const effectsInvertDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'amount',
+			type: 'numeric',
+			min: 0,
+			max: 1,
+			step: 0.01,
+			default: 1,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsSaturationDemo: DemoType = {
@@ -1464,7 +1508,17 @@ export const effectsSaturationDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'amount',
+			type: 'numeric',
+			min: 0,
+			max: 5,
+			step: 0.1,
+			default: 1.8,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsTintDemo: DemoType = {
@@ -1477,7 +1531,23 @@ export const effectsTintDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'color',
+			type: 'color',
+			default: '#1ec8ff',
+			optional: 'no',
+		},
+		{
+			name: 'amount',
+			type: 'numeric',
+			min: 0,
+			max: 1,
+			step: 0.01,
+			default: 0.7,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsMirrorDemo: DemoType = {
@@ -1490,7 +1560,30 @@ export const effectsMirrorDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'direction',
+			type: 'enum',
+			values: ['horizontal', 'vertical'],
+			default: 'horizontal',
+			optional: 'no',
+		},
+		{
+			name: 'position',
+			type: 'numeric',
+			min: 0,
+			max: 1,
+			step: 0.01,
+			default: 0.5,
+			optional: 'no',
+		},
+		{
+			name: 'invert',
+			type: 'boolean',
+			default: false,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsScaleDemo: DemoType = {
@@ -1503,7 +1596,29 @@ export const effectsScaleDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'scale',
+			type: 'numeric',
+			min: 0.1,
+			max: 3,
+			step: 0.05,
+			default: 0.8,
+			optional: 'no',
+		},
+		{
+			name: 'horizontal',
+			type: 'boolean',
+			default: true,
+			optional: 'no',
+		},
+		{
+			name: 'vertical',
+			type: 'boolean',
+			default: true,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsBarrelDistortionDemo: DemoType = {
@@ -1516,7 +1631,17 @@ export const effectsBarrelDistortionDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'amount',
+			type: 'numeric',
+			min: 0,
+			max: 1,
+			step: 0.01,
+			default: 0.28,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsBlurDemo: DemoType = {
@@ -1529,7 +1654,29 @@ export const effectsBlurDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'radius',
+			type: 'numeric',
+			min: 0,
+			max: 100,
+			step: 1,
+			default: 40,
+			optional: 'no',
+		},
+		{
+			name: 'horizontal',
+			type: 'boolean',
+			default: true,
+			optional: 'no',
+		},
+		{
+			name: 'vertical',
+			type: 'boolean',
+			default: true,
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsWaveDemo: DemoType = {
@@ -1542,7 +1689,42 @@ export const effectsWaveDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'phase',
+			type: 'numeric',
+			min: 0,
+			max: 6.28,
+			step: 0.01,
+			default: 1.2,
+			optional: 'no',
+		},
+		{
+			name: 'amplitude',
+			type: 'numeric',
+			min: 0,
+			max: 200,
+			step: 1,
+			default: 50,
+			optional: 'no',
+		},
+		{
+			name: 'wavelength',
+			type: 'numeric',
+			min: 1,
+			max: 1000,
+			step: 1,
+			default: 200,
+			optional: 'no',
+		},
+		{
+			name: 'direction',
+			type: 'enum',
+			values: ['horizontal', 'vertical'],
+			default: 'horizontal',
+			optional: 'no',
+		},
+	],
 };
 
 export const effectsHalftoneDemo: DemoType = {
@@ -1555,7 +1737,54 @@ export const effectsHalftoneDemo: DemoType = {
 	autoPlay: false,
 	controls: false,
 	logLevel: 'info',
-	options: [],
+	options: [
+		{
+			name: 'shape',
+			type: 'enum',
+			values: ['circle', 'square', 'line'],
+			default: 'circle',
+			optional: 'no',
+		},
+		{
+			name: 'dotSize',
+			type: 'numeric',
+			min: 1,
+			max: 50,
+			step: 1,
+			default: 8,
+			optional: 'no',
+		},
+		{
+			name: 'dotSpacing',
+			type: 'numeric',
+			min: 1,
+			max: 50,
+			step: 1,
+			default: 7,
+			optional: 'no',
+		},
+		{
+			name: 'rotation',
+			type: 'numeric',
+			min: -180,
+			max: 180,
+			step: 1,
+			default: 12,
+			optional: 'no',
+		},
+		{
+			name: 'color',
+			type: 'color',
+			default: '#0b84f3',
+			optional: 'no',
+		},
+		{
+			name: 'invert',
+			type: 'boolean',
+			default: false,
+			optional: 'no',
+		},
+	],
 };
 
 export const htmlInCanvasDemoWebGL: DemoType = {

--- a/packages/docs/components/effects/effects-barrel-distortion-preview.tsx
+++ b/packages/docs/components/effects/effects-barrel-distortion-preview.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsBarrelDistortionPreview: React.FC = () => {
+export const EffectsBarrelDistortionPreview: React.FC<{
+	readonly amount: number;
+}> = ({amount}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[barrelDistortion({amount: 0.28})]}
+			effects={[barrelDistortion({amount})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-blur-preview.tsx
+++ b/packages/docs/components/effects/effects-blur-preview.tsx
@@ -3,13 +3,17 @@ import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsBlurPreview: React.FC = () => {
+export const EffectsBlurPreview: React.FC<{
+	readonly radius: number;
+	readonly horizontal: boolean;
+	readonly vertical: boolean;
+}> = ({radius, horizontal, vertical}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[blur({radius: 40})]}
+			effects={[blur({radius, horizontal, vertical})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-brightness-preview.tsx
+++ b/packages/docs/components/effects/effects-brightness-preview.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsBrightnessPreview: React.FC = () => {
+export const EffectsBrightnessPreview: React.FC<{
+	readonly amount: number;
+}> = ({amount}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[brightness({amount: 0.25})]}
+			effects={[brightness({amount})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-grayscale-preview.tsx
+++ b/packages/docs/components/effects/effects-grayscale-preview.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsGrayscalePreview: React.FC = () => {
+export const EffectsGrayscalePreview: React.FC<{
+	readonly amount: number;
+}> = ({amount}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[grayscale()]}
+			effects={[grayscale({amount})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-halftone-preview.tsx
+++ b/packages/docs/components/effects/effects-halftone-preview.tsx
@@ -1,9 +1,17 @@
+import type {HalftoneShape} from '@remotion/effects/halftone';
 import {halftone} from '@remotion/effects/halftone';
 import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsHalftonePreview: React.FC = () => {
+export const EffectsHalftonePreview: React.FC<{
+	readonly shape: HalftoneShape;
+	readonly dotSize: number;
+	readonly dotSpacing: number;
+	readonly rotation: number;
+	readonly color: string;
+	readonly invert: boolean;
+}> = ({shape, dotSize, dotSpacing, rotation, color, invert}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
@@ -11,11 +19,12 @@ export const EffectsHalftonePreview: React.FC = () => {
 			height={720}
 			effects={[
 				halftone({
-					shape: 'circle',
-					dotSize: 8,
-					dotSpacing: 7,
-					rotation: 12,
-					color: '#0b84f3',
+					shape,
+					dotSize,
+					dotSpacing,
+					rotation,
+					color,
+					invert,
 				}),
 			]}
 		/>

--- a/packages/docs/components/effects/effects-hue-preview.tsx
+++ b/packages/docs/components/effects/effects-hue-preview.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsHuePreview: React.FC = () => {
+export const EffectsHuePreview: React.FC<{
+	readonly degrees: number;
+}> = ({degrees}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[hue({degrees: 120})]}
+			effects={[hue({degrees})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-invert-preview.tsx
+++ b/packages/docs/components/effects/effects-invert-preview.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsInvertPreview: React.FC = () => {
+export const EffectsInvertPreview: React.FC<{
+	readonly amount: number;
+}> = ({amount}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[invert()]}
+			effects={[invert({amount})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-mirror-preview.tsx
+++ b/packages/docs/components/effects/effects-mirror-preview.tsx
@@ -1,15 +1,20 @@
+import type {MirrorDirection} from '@remotion/effects/mirror';
 import {mirror} from '@remotion/effects/mirror';
 import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsMirrorPreview: React.FC = () => {
+export const EffectsMirrorPreview: React.FC<{
+	readonly direction: MirrorDirection;
+	readonly position: number;
+	readonly invert: boolean;
+}> = ({direction, position, invert}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[mirror({direction: 'horizontal', position: 0.5})]}
+			effects={[mirror({direction, position, invert})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-saturation-preview.tsx
+++ b/packages/docs/components/effects/effects-saturation-preview.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsSaturationPreview: React.FC = () => {
+export const EffectsSaturationPreview: React.FC<{
+	readonly amount: number;
+}> = ({amount}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[saturation({amount: 1.8})]}
+			effects={[saturation({amount})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-scale-preview.tsx
+++ b/packages/docs/components/effects/effects-scale-preview.tsx
@@ -3,13 +3,17 @@ import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsScalePreview: React.FC = () => {
+export const EffectsScalePreview: React.FC<{
+	readonly scale: number;
+	readonly horizontal: boolean;
+	readonly vertical: boolean;
+}> = ({scale: scaleValue, horizontal, vertical}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[scale({scale: 0.8})]}
+			effects={[scale({scale: scaleValue, horizontal, vertical})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-tint-preview.tsx
+++ b/packages/docs/components/effects/effects-tint-preview.tsx
@@ -3,13 +3,16 @@ import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsTintPreview: React.FC = () => {
+export const EffectsTintPreview: React.FC<{
+	readonly color: string;
+	readonly amount: number;
+}> = ({color, amount}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
 			width={1280}
 			height={720}
-			effects={[tint({color: '#1ec8ff', amount: 0.7})]}
+			effects={[tint({color, amount})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-wave-preview.tsx
+++ b/packages/docs/components/effects/effects-wave-preview.tsx
@@ -1,9 +1,15 @@
+import type {WaveDirection} from '@remotion/effects/wave';
 import {wave} from '@remotion/effects/wave';
 import React from 'react';
 import {CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
 
-export const EffectsWavePreview: React.FC = () => {
+export const EffectsWavePreview: React.FC<{
+	readonly phase: number;
+	readonly amplitude: number;
+	readonly wavelength: number;
+	readonly direction: WaveDirection;
+}> = ({phase, amplitude, wavelength, direction}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
@@ -11,10 +17,10 @@ export const EffectsWavePreview: React.FC = () => {
 			height={720}
 			effects={[
 				wave({
-					phase: 1.2,
-					amplitude: 50,
-					wavelength: 200,
-					direction: 'horizontal',
+					phase,
+					amplitude,
+					wavelength,
+					direction,
 				}),
 			]}
 		/>


### PR DESCRIPTION
Adds interactive controls to the docs `<Demo>` component for each effect in `/docs/effects/*`, so visitors can play with parameters directly in the docs (e.g. tweak `radius` on `blur()`, change `color` on `tint()`, etc.).

### Changes

- New `color` Option type in the demos schema, rendered as a native color picker — used by `tint` and `halftone`.
- Each effect preview component (`effects-*-preview.tsx`) now takes its parameters as React props instead of hard-coding them.
- Each effect demo (`effectsBlurDemo`, `effectsHueDemo`, …) declares its `options` array, matching the underlying effect schema (`min`/`max`/`step`/`default` mirror the effect's own schema where applicable).

Closes #7659