### PR TITLE
`@remotion/studio`: Cache timeline asset metadata

### DIFF
--- a/packages/studio/src/components/CurrentAsset.tsx
+++ b/packages/studio/src/components/CurrentAsset.tsx
@@ -72,7 +72,10 @@ export const CurrentAsset: React.FC = () => {
 	}
 
 	if (mediaMetadata) {
-		subtitleParts.push(mediaMetadata.format);
+		if (mediaMetadata.format) {
+			subtitleParts.push(mediaMetadata.format);
+		}
+
 		if (mediaMetadata.width !== null && mediaMetadata.height !== null) {
 			subtitleParts.push(`${mediaMetadata.width}x${mediaMetadata.height}`);
 		}

--- a/packages/studio/src/components/Timeline/TimelineMediaInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineMediaInfo.tsx
@@ -170,7 +170,9 @@ export const TimelineMediaInfo: React.FC<{
 		}
 
 		const parts: string[] = [];
-		parts.push(metadata.format);
+		if (metadata.format) {
+			parts.push(metadata.format);
+		}
 
 		if (type === 'video' && metadata.videoCodec) {
 			parts.push(metadata.videoCodec);

--- a/packages/studio/src/helpers/use-max-media-duration.ts
+++ b/packages/studio/src/helpers/use-max-media-duration.ts
@@ -1,10 +1,10 @@
-import {getVideoMetadata} from '@remotion/media-utils';
-import {ALL_FORMATS, Input, InputDisposedError, UrlSource} from 'mediabunny';
 import {useEffect, useState} from 'react';
 import {type TSequence} from 'remotion';
-import {getDurationOrCompute} from './get-duration-or-compute';
+import {getMediaMetadata} from './use-media-metadata';
 
 const cache = new Map<string, number>();
+
+const getCacheKey = (src: string, fps: number) => JSON.stringify([src, fps]);
 
 const getSrc = (s: TSequence) => {
 	if (s.type === 'video') {
@@ -20,48 +20,48 @@ const getSrc = (s: TSequence) => {
 
 export const useMaxMediaDuration = (s: TSequence, fps: number) => {
 	const src = getSrc(s);
+	const cacheKey = src ? getCacheKey(src, fps) : null;
 
 	const [maxMediaDuration, setMaxMediaDuration] = useState(
-		src ? (cache.get(src) ?? null) : Infinity,
+		cacheKey ? (cache.get(cacheKey) ?? null) : Infinity,
 	);
 
 	useEffect(() => {
-		if (!src) {
+		if (!src || !cacheKey) {
 			return;
 		}
 
-		const input = new Input({
-			formats: ALL_FORMATS,
-			source: new UrlSource(src),
-		});
+		const cached = cache.get(cacheKey) ?? null;
+		setMaxMediaDuration(cached);
 
-		getDurationOrCompute(input)
-			.then((duration) => {
-				cache.set(src, Math.floor(duration * fps));
-				setMaxMediaDuration(Math.floor(duration * fps));
-			})
-			.catch((e) => {
-				if (e instanceof InputDisposedError) {
+		if (cached !== null) {
+			return;
+		}
+
+		let cancelled = false;
+
+		getMediaMetadata(src)
+			.then((metadata) => {
+				if (cancelled || !metadata) {
 					return;
 				}
 
-				// In case of CORS errors, fall back to getVideoMetadata
-				return getVideoMetadata(src)
-					.then((metadata) => {
-						const durationOrInfinity = metadata.durationInSeconds ?? Infinity;
+				const duration = Math.floor(metadata.duration * fps);
+				cache.set(cacheKey, duration);
+				setMaxMediaDuration(duration);
+			})
+			.catch(() => {
+				if (cancelled) {
+					return;
+				}
 
-						cache.set(src, Math.floor(durationOrInfinity * fps));
-						setMaxMediaDuration(Math.floor(durationOrInfinity * fps));
-					})
-					.catch(() => {
-						// Silently handle getVideoMetadata failures to prevent unhandled rejections
-					});
+				setMaxMediaDuration(null);
 			});
 
 		return () => {
-			input.dispose();
+			cancelled = true;
 		};
-	}, [src, fps]);
+	}, [cacheKey, fps, src]);
 
 	if (maxMediaDuration !== null && (s.type === 'audio' || s.type === 'video')) {
 		return maxMediaDuration;

--- a/packages/studio/src/helpers/use-media-metadata.ts
+++ b/packages/studio/src/helpers/use-media-metadata.ts
@@ -1,94 +1,164 @@
+import {getVideoMetadata} from '@remotion/media-utils';
 import {ALL_FORMATS, Input, UrlSource} from 'mediabunny';
 import {useEffect, useState} from 'react';
 import {getDurationOrCompute} from './get-duration-or-compute';
 
 export type MediaMetadata = {
 	duration: number;
-	format: string;
+	format: string | null;
 	width: number | null;
 	height: number | null;
 	videoCodec: string | null;
 	audioCodec: string | null;
 };
 
+const cache = new Map<string, MediaMetadata>();
+const pendingRequests = new Map<string, Promise<MediaMetadata | null>>();
+
+const safeCall = async <T>(fn: () => Promise<T>): Promise<T | null> => {
+	try {
+		return await fn();
+	} catch {
+		return null;
+	}
+};
+
+const getMediabunnyMetadata = async (
+	src: string,
+): Promise<MediaMetadata | null> => {
+	let input: Input;
+
+	try {
+		input = new Input({
+			formats: ALL_FORMATS,
+			source: new UrlSource(src),
+		});
+	} catch {
+		return null;
+	}
+
+	try {
+		const [duration, format, videoTrack, audioTrack] = await Promise.all([
+			safeCall(() => getDurationOrCompute(input)),
+			safeCall(() => input.getFormat()),
+			safeCall(() => input.getPrimaryVideoTrack()),
+			safeCall(() => input.getPrimaryAudioTrack()),
+		]);
+
+		if (duration === null) {
+			return null;
+		}
+
+		const [width, height, videoCodec, audioCodec] = await Promise.all([
+			videoTrack ? safeCall(() => videoTrack.getDisplayWidth()) : null,
+			videoTrack ? safeCall(() => videoTrack.getDisplayHeight()) : null,
+			videoTrack ? safeCall(() => videoTrack.getCodec()) : null,
+			audioTrack ? safeCall(() => audioTrack.getCodec()) : null,
+		]);
+
+		return {
+			duration,
+			format: format?.name ?? null,
+			width,
+			height,
+			videoCodec,
+			audioCodec,
+		};
+	} finally {
+		try {
+			input.dispose();
+		} catch {
+			// ignore
+		}
+	}
+};
+
+const getFallbackVideoMetadata = async (
+	src: string,
+): Promise<MediaMetadata | null> => {
+	try {
+		const metadata = await getVideoMetadata(src);
+
+		return {
+			duration: metadata.durationInSeconds,
+			format: null,
+			width: metadata.width,
+			height: metadata.height,
+			videoCodec: null,
+			audioCodec: null,
+		};
+	} catch {
+		return null;
+	}
+};
+
+export const getMediaMetadata = (
+	src: string,
+): Promise<MediaMetadata | null> => {
+	const cached = cache.get(src);
+
+	if (cached) {
+		return Promise.resolve(cached);
+	}
+
+	const pendingRequest = pendingRequests.get(src);
+
+	if (pendingRequest) {
+		return pendingRequest;
+	}
+
+	const request = getMediabunnyMetadata(src)
+		.catch(() => null)
+		.then((metadata) => metadata ?? getFallbackVideoMetadata(src))
+		.then((metadata) => {
+			if (metadata) {
+				cache.set(src, metadata);
+			}
+
+			return metadata;
+		})
+		.finally(() => {
+			pendingRequests.delete(src);
+		});
+
+	pendingRequests.set(src, request);
+
+	return request;
+};
+
 export const useMediaMetadata = (src: string | null): MediaMetadata | null => {
 	const [mediaMetadata, setMediaMetadata] = useState<MediaMetadata | null>(
-		null,
+		src ? (cache.get(src) ?? null) : null,
 	);
 
 	useEffect(() => {
-		setMediaMetadata(null);
+		const cached = src ? (cache.get(src) ?? null) : null;
+		setMediaMetadata(cached);
 
-		if (!src) {
+		if (!src || cached) {
 			return;
 		}
 
 		let cancelled = false;
-		let input: Input | null = null;
 
-		try {
-			input = new Input({
-				formats: ALL_FORMATS,
-				source: new UrlSource(src),
+		getMediaMetadata(src)
+			.then((metadata) => {
+				if (cancelled) {
+					return;
+				}
+
+				setMediaMetadata(metadata);
+			})
+			.catch(() => {
+				if (cancelled) {
+					return;
+				}
+
+				setMediaMetadata(null);
 			});
-		} catch {
-			return;
-		}
-
-		const safeCall = async <T>(fn: () => Promise<T>): Promise<T | null> => {
-			try {
-				return await fn();
-			} catch {
-				return null;
-			}
-		};
-
-		(async () => {
-			if (!input) {
-				return;
-			}
-
-			const [duration, format, videoTrack, audioTrack] = await Promise.all([
-				safeCall(() => getDurationOrCompute(input!)),
-				safeCall(() => input!.getFormat()),
-				safeCall(() => input!.getPrimaryVideoTrack()),
-				safeCall(() => input!.getPrimaryAudioTrack()),
-			]);
-
-			if (cancelled || !format || duration === null) {
-				return;
-			}
-
-			const [width, height, videoCodec, audioCodec] = await Promise.all([
-				videoTrack ? safeCall(() => videoTrack.getDisplayWidth()) : null,
-				videoTrack ? safeCall(() => videoTrack.getDisplayHeight()) : null,
-				videoTrack ? safeCall(() => videoTrack.getCodec()) : null,
-				audioTrack ? safeCall(() => audioTrack.getCodec()) : null,
-			]);
-
-			if (cancelled) {
-				return;
-			}
-
-			setMediaMetadata({
-				duration,
-				format: format.name,
-				width,
-				height,
-				videoCodec,
-				audioCodec,
-			});
-		})().catch(() => {
-			// Swallow any unexpected error — this is a non-essential UI enhancement.
-		});
 
 		return () => {
 			cancelled = true;
-			try {
-				input?.dispose();
-			} catch {
-				// ignore
-			}
 		};
 	}, [src]);
 


### PR DESCRIPTION
Closes #7663.

## Summary
- Cache media metadata by src and share in-flight requests between timeline asset info instances.
- Reuse the same metadata loader from useMaxMediaDuration, including the getVideoMetadata fallback.

## Tests
- bun test packages/studio/src/test/timeline-video-info.test.ts
- bunx turbo make --filter='@remotion/studio'
- bun run build
- bun run formatting