### PR TITLE
`remotion`: Make Img sync decoding render-only

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -78,6 +78,7 @@ const ImgContent: React.FC<ImgContentProps> = ({
 	delayRenderTimeoutInMilliseconds,
 	onImageFrame,
 	crossOrigin,
+	decoding,
 	ref,
 	...props
 }) => {
@@ -86,7 +87,7 @@ const ImgContent: React.FC<ImgContentProps> = ({
 	const {delayPlayback} = useBufferState();
 	const sequenceContext = useContext(SequenceContext);
 
-	const _propsValid: IsExact<typeof props, Expected> = true;
+	const _propsValid: IsExact<typeof props, Omit<Expected, 'decoding'>> = true;
 
 	if (!_propsValid) {
 		throw new Error('typecheck error');
@@ -275,7 +276,7 @@ const ImgContent: React.FC<ImgContentProps> = ({
 		]);
 	}
 
-	const {isClientSideRendering} = useRemotionEnvironment();
+	const {isClientSideRendering, isRendering} = useRemotionEnvironment();
 
 	const crossOriginValue = getCrossOriginValue({
 		crossOrigin,
@@ -290,7 +291,7 @@ const ImgContent: React.FC<ImgContentProps> = ({
 			ref={imageRef}
 			crossOrigin={crossOriginValue}
 			onError={didGetError}
-			decoding="sync"
+			decoding={isRendering ? 'sync' : decoding}
 		/>
 	);
 };

--- a/packages/core/src/test/Img.test.tsx
+++ b/packages/core/src/test/Img.test.tsx
@@ -1,28 +1,70 @@
-import {afterEach, beforeEach, expect, test} from 'bun:test';
+import {afterEach, expect, test} from 'bun:test';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 import {Img} from '../Img.js';
+import type {RemotionEnvironment} from '../remotion-environment-context.js';
+import {RemotionEnvironmentContext} from '../remotion-environment-context.js';
 import {WrapSequenceContext} from './wrap-sequence-context.js';
 
 afterEach(() => {
 	cleanup();
 });
 
-const ref = React.createRef<HTMLImageElement>();
 const testImgUrl = 'https://source.unsplash.com/random/50x50';
 
-beforeEach(() => {
+const previewEnvironment: RemotionEnvironment = {
+	isClientSideRendering: false,
+	isPlayer: false,
+	isReadOnlyStudio: false,
+	isRendering: false,
+	isStudio: false,
+};
+
+const renderImg = (
+	element: React.ReactElement,
+	environment: RemotionEnvironment = previewEnvironment,
+) => {
 	render(
-		<WrapSequenceContext>
-			<Img ref={ref} src={testImgUrl} />
-		</WrapSequenceContext>,
+		<RemotionEnvironmentContext.Provider value={environment}>
+			<WrapSequenceContext>{element}</WrapSequenceContext>
+		</RemotionEnvironmentContext.Provider>,
 	);
-});
+};
 
 test('Img component renders img tag', () => {
+	const ref = React.createRef<HTMLImageElement>();
+	renderImg(<Img ref={ref} src={testImgUrl} />);
+
 	expect(ref.current?.tagName).toBe('IMG');
 });
 
 test('Src attribute is forwarded to img tag', () => {
+	const ref = React.createRef<HTMLImageElement>();
+	renderImg(<Img ref={ref} src={testImgUrl} />);
+
 	expect(ref.current).toHaveProperty('src', testImgUrl);
+});
+
+test('Img does not force synchronous decoding outside of rendering', () => {
+	const ref = React.createRef<HTMLImageElement>();
+	renderImg(<Img ref={ref} src={testImgUrl} />);
+
+	expect(ref.current?.getAttribute('decoding')).toBeNull();
+});
+
+test('Img preserves the decoding prop outside of rendering', () => {
+	const ref = React.createRef<HTMLImageElement>();
+	renderImg(<Img ref={ref} src={testImgUrl} decoding="async" />);
+
+	expect(ref.current?.getAttribute('decoding')).toBe('async');
+});
+
+test('Img forces synchronous decoding while rendering', () => {
+	const ref = React.createRef<HTMLImageElement>();
+	renderImg(<Img ref={ref} src={testImgUrl} decoding="async" />, {
+		...previewEnvironment,
+		isRendering: true,
+	});
+
+	expect(ref.current?.getAttribute('decoding')).toBe('sync');
 });


### PR DESCRIPTION
## Summary
- Make `<Img>` only force `decoding="sync"` while Remotion is rendering
- Preserve user-provided `decoding` outside rendering, and omit the attribute by default
- Add tests for render and non-render decoding behavior

## Context
`decoding="sync"` was added in 000108b997 as part of PR #5828, right after render-readiness fixes for large images. The linked older report (#4621) was about large images missing during rendered frames, and it noted that manually trying `decoding="sync"` did not resolve the issue outside that render pipeline.

## Test plan
- `cd packages/core && bun test src/test/Img.test.tsx`
- `cd packages/core && bunx oxfmt src --write`
- `bun run build`
- `bun run formatting`

Fixes #7665