### PR TITLE
`@remotion/media`: Support subframe audio rendering

### DIFF
--- a/packages/docs/docs/client-side-rendering/limitations.mdx
+++ b/packages/docs/docs/client-side-rendering/limitations.mdx
@@ -114,7 +114,7 @@ Filters are not supported in Safari/WebKit. Use Chrome or Firefox for filter sup
 The following Remotion components are supported:
 
 The [`<Video>`](/docs/media/video) from `@remotion/media` is <a style={{color: 'green'}}>supported</a>.  
-The [`<Audio>`](/docs/media/audio) from `@remotion/media` is <a style={{color: 'green'}}>supported</a>.  
+The [`<Audio>`](/docs/media/audio) from `@remotion/media` is <a style={{color: 'green'}}>supported</a>, including subframe timing during rendering.<br />
 [`<Img>`](/docs/img) is <a style={{color: 'green'}}>supported</a>.  
 [`<Gif>`](/docs/gif) from [`@remotion/gif`](/docs/gif) is <a style={{color: 'green'}}>supported</a>.  
 [`<Rive>`](/docs/rive) from [`@remotion/rive`](/docs/rive) is <a style={{color: 'green'}}>supported</a>.  

--- a/packages/media/src/audio/audio-for-rendering.tsx
+++ b/packages/media/src/audio/audio-for-rendering.tsx
@@ -11,11 +11,64 @@ import {
 } from 'remotion';
 import {useMaxMediaCacheSize} from '../caches';
 import {applyVolume} from '../convert-audiodata/apply-volume';
+import type {PcmS16AudioData} from '../convert-audiodata/convert-audiodata';
 import {getTargetSampleRate} from '../convert-audiodata/resample-audiodata';
 import {frameForVolumeProp} from '../looped-frame';
 import {callOnErrorAndResolve} from '../on-error';
 import {extractFrameViaBroadcastChannel} from '../video-extraction/extract-frame-via-broadcast-channel';
 import type {AudioProps} from './props';
+
+const NUMBER_OF_CHANNELS = 2;
+
+const isAlmostZero = (value: number) => {
+	return Math.abs(value) < 0.0000001;
+};
+
+const roundSamples = (seconds: number) => {
+	return Math.round(seconds * getTargetSampleRate());
+};
+
+const padAudioToFullFrame = ({
+	audio,
+	fps,
+	padStartInSeconds,
+	padEndInSeconds,
+}: {
+	audio: PcmS16AudioData;
+	fps: number;
+	padStartInSeconds: number;
+	padEndInSeconds: number;
+}): PcmS16AudioData => {
+	if (isAlmostZero(padStartInSeconds) && isAlmostZero(padEndInSeconds)) {
+		return audio;
+	}
+
+	const expectedFrames = Math.round(getTargetSampleRate() / fps);
+	const target = new Int16Array(expectedFrames * NUMBER_OF_CHANNELS);
+	const offset = Math.min(
+		Math.max(0, roundSamples(padStartInSeconds)),
+		expectedFrames,
+	);
+	const requestedEndPadding = Math.max(0, roundSamples(padEndInSeconds));
+	const maxFramesToCopy = Math.max(
+		0,
+		expectedFrames - offset - requestedEndPadding,
+	);
+	const framesToCopy = Math.min(audio.numberOfFrames, maxFramesToCopy);
+
+	target.set(
+		audio.data.subarray(0, framesToCopy * NUMBER_OF_CHANNELS),
+		offset * NUMBER_OF_CHANNELS,
+	);
+
+	return {
+		data: target,
+		numberOfFrames: expectedFrames,
+		timestamp: audio.timestamp - padStartInSeconds * 1_000_000,
+		durationInMicroSeconds:
+			(expectedFrames / getTargetSampleRate()) * 1_000_000,
+	};
+};
 
 export const AudioForRendering: React.FC<AudioProps> = ({
 	volume: volumeProp,
@@ -89,9 +142,6 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 	const audioEnabled = Internals.useAudioEnabled();
 
 	useLayoutEffect(() => {
-		const timestamp = frame / fps;
-		const durationInSeconds = 1 / fps;
-
 		const shouldRenderAudio = (() => {
 			if (!audioEnabled) {
 				return false;
@@ -117,96 +167,121 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 			timeoutInMilliseconds: delayRenderTimeoutInMilliseconds ?? undefined,
 		});
 
-		extractFrameViaBroadcastChannel({
-			src,
-			timeInSeconds: timestamp,
-			durationInSeconds,
-			playbackRate: playbackRate ?? 1,
-			logLevel,
-			includeAudio: shouldRenderAudio,
-			includeVideo: false,
-			isClientSideRendering: environment.isClientSideRendering,
-			loop: loop ?? false,
-			audioStreamIndex: audioStreamIndex ?? null,
-			trimAfter,
-			trimBefore,
-			fps,
-			maxCacheSize,
-			credentials,
-			requestInit: initialRequestInit,
-		})
-			.then((result) => {
-				const handleError = (
-					error: Error,
-					clientSideError: Error,
-					fallbackMessage: string,
-				) => {
-					const [action, errorToUse] = callOnErrorAndResolve({
-						onError,
-						error,
-						disallowFallback: disallowFallbackToHtml5Audio ?? false,
-						isClientSideRendering: environment.isClientSideRendering,
-						clientSideError,
-					});
-					if (action === 'fail') {
-						cancelRender(errorToUse);
-					}
+		const sequenceStartFrame =
+			(sequenceContext?.cumulatedFrom ?? 0) +
+			(sequenceContext?.relativeFrom ?? 0);
+		const sequenceEndFrame =
+			sequenceStartFrame + (sequenceContext?.durationInFrames ?? Infinity);
+		const extractAndRegister = async ({
+			sourceStartFrame,
+			durationInFrames,
+			frameToRegister,
+			padStartInSeconds,
+			padEndInSeconds,
+			volumeFrame,
+		}: {
+			sourceStartFrame: number;
+			durationInFrames: number;
+			frameToRegister: number;
+			padStartInSeconds: number;
+			padEndInSeconds: number;
+			volumeFrame: number;
+		}) => {
+			if (
+				durationInFrames <= 0 ||
+				(durationInFrames / fps) * getTargetSampleRate() < 1
+			) {
+				return;
+			}
 
-					Internals.Log.warn(
-						{logLevel, tag: '@remotion/media'},
-						fallbackMessage,
-					);
+			const result = await extractFrameViaBroadcastChannel({
+				src,
+				timeInSeconds: sourceStartFrame / fps,
+				durationInSeconds: durationInFrames / fps,
+				playbackRate: playbackRate ?? 1,
+				logLevel,
+				includeAudio: shouldRenderAudio,
+				includeVideo: false,
+				isClientSideRendering: environment.isClientSideRendering,
+				loop: loop ?? false,
+				audioStreamIndex: audioStreamIndex ?? null,
+				trimAfter,
+				trimBefore,
+				fps,
+				maxCacheSize,
+				credentials,
+				requestInit: initialRequestInit,
+			});
 
-					setReplaceWithHtml5Audio(true);
-				};
-
-				if (result.type === 'unknown-container-format') {
-					handleError(
-						new Error(`Unknown container format ${src}.`),
-						new Error(
-							`Cannot render audio "${src}": Unknown container format. See supported formats: https://www.remotion.dev/docs/mediabunny/formats`,
-						),
-						`Unknown container format for ${src} (Supported formats: https://www.remotion.dev/docs/mediabunny/formats), falling back to <Html5Audio>`,
-					);
-					return;
+			const handleError = (
+				error: Error,
+				clientSideError: Error,
+				fallbackMessage: string,
+			) => {
+				const [action, errorToUse] = callOnErrorAndResolve({
+					onError,
+					error,
+					disallowFallback: disallowFallbackToHtml5Audio ?? false,
+					isClientSideRendering: environment.isClientSideRendering,
+					clientSideError,
+				});
+				if (action === 'fail') {
+					cancelRender(errorToUse);
 				}
 
-				if (result.type === 'cannot-decode') {
-					handleError(
-						new Error(`Cannot decode ${src}.`),
-						new Error(
-							`Cannot render audio "${src}": The audio could not be decoded by the browser.`,
-						),
-						`Cannot decode ${src}, falling back to <Html5Audio>`,
-					);
-					return;
-				}
+				Internals.Log.warn({logLevel, tag: '@remotion/media'}, fallbackMessage);
 
-				if (result.type === 'cannot-decode-alpha') {
-					throw new Error(
-						`Cannot decode alpha component for ${src}, and 'disallowFallbackToHtml5Audio' was set. But this should never happen, since you used the <Audio> tag. Please report this as a bug.`,
-					);
-				}
+				setReplaceWithHtml5Audio(true);
+			};
 
-				if (result.type === 'network-error') {
-					handleError(
-						new Error(`Network error fetching ${src}.`),
-						new Error(
-							`Cannot render audio "${src}": Network error while fetching the audio (possibly CORS).`,
-						),
-						`Network error fetching ${src}, falling back to <Html5Audio>`,
-					);
-					return;
-				}
+			if (result.type === 'unknown-container-format') {
+				handleError(
+					new Error(`Unknown container format ${src}.`),
+					new Error(
+						`Cannot render audio "${src}": Unknown container format. See supported formats: https://www.remotion.dev/docs/mediabunny/formats`,
+					),
+					`Unknown container format for ${src} (Supported formats: https://www.remotion.dev/docs/mediabunny/formats), falling back to <Html5Audio>`,
+				);
+				return;
+			}
 
-				const {audio, durationInSeconds: assetDurationInSeconds} = result;
+			if (result.type === 'cannot-decode') {
+				handleError(
+					new Error(`Cannot decode ${src}.`),
+					new Error(
+						`Cannot render audio "${src}": The audio could not be decoded by the browser.`,
+					),
+					`Cannot decode ${src}, falling back to <Html5Audio>`,
+				);
+				return;
+			}
 
+			if (result.type === 'cannot-decode-alpha') {
+				throw new Error(
+					`Cannot decode alpha component for ${src}, and 'disallowFallbackToHtml5Audio' was set. But this should never happen, since you used the <Audio> tag. Please report this as a bug.`,
+				);
+			}
+
+			if (result.type === 'network-error') {
+				handleError(
+					new Error(`Network error fetching ${src}.`),
+					new Error(
+						`Cannot render audio "${src}": Network error while fetching the audio (possibly CORS).`,
+					),
+					`Network error fetching ${src}, falling back to <Html5Audio>`,
+				);
+				return;
+			}
+
+			const {audio, durationInSeconds: assetDurationInSeconds} = result;
+
+			if (audio) {
 				const volumePropsFrame = frameForVolumeProp({
 					behavior: loopVolumeCurveBehavior ?? 'repeat',
 					loop: loop ?? false,
 					assetDurationInSeconds: assetDurationInSeconds ?? 0,
 					fps,
-					frame,
+					frame: volumeFrame,
 					startsAt,
 				});
 				const volume = Internals.evaluateVolume({
@@ -217,22 +292,77 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 
 				Internals.warnAboutTooHighVolume(volume);
 
-				if (audio && volume > 0) {
-					applyVolume(audio.data, volume);
+				if (volume > 0) {
+					const paddedAudio = padAudioToFullFrame({
+						audio,
+						fps,
+						padStartInSeconds,
+						padEndInSeconds,
+					});
+					applyVolume(paddedAudio.data, volume);
 					registerRenderAsset({
 						type: 'inline-audio',
 						id,
 						audio: environment.isClientSideRendering
-							? audio.data
-							: Array.from(audio.data),
-						frame: absoluteFrame,
-						timestamp: audio.timestamp,
+							? paddedAudio.data
+							: Array.from(paddedAudio.data),
+						frame: frameToRegister,
+						timestamp: paddedAudio.timestamp,
 						duration:
-							(audio.numberOfFrames / getTargetSampleRate()) * 1_000_000,
+							(paddedAudio.numberOfFrames / getTargetSampleRate()) * 1_000_000,
 						toneFrequency: toneFrequency ?? 1,
 					});
 				}
+			}
+		};
 
+		const frameStart = absoluteFrame;
+		const frameEnd = absoluteFrame + 1;
+		const audibleStart = Math.max(frameStart, sequenceStartFrame);
+		const audibleEnd = Math.min(frameEnd, sequenceEndFrame);
+		const extractionTasks: Promise<void>[] = [];
+
+		if (audibleEnd > audibleStart) {
+			extractionTasks.push(
+				extractAndRegister({
+					sourceStartFrame: audibleStart - sequenceStartFrame,
+					durationInFrames: audibleEnd - audibleStart,
+					frameToRegister: absoluteFrame,
+					padStartInSeconds: (audibleStart - frameStart) / fps,
+					padEndInSeconds: (frameEnd - audibleEnd) / fps,
+					volumeFrame: audibleStart - sequenceStartFrame,
+				}),
+			);
+		}
+
+		const startsInPreviousFrame =
+			sequenceStartFrame % 1 !== 0 &&
+			absoluteFrame === Math.ceil(sequenceStartFrame);
+		if (startsInPreviousFrame) {
+			const previousFrameStart = absoluteFrame - 1;
+			const previousFrameEnd = absoluteFrame;
+			const previousAudibleStart = Math.max(
+				previousFrameStart,
+				sequenceStartFrame,
+			);
+			const previousAudibleEnd = Math.min(previousFrameEnd, sequenceEndFrame);
+			if (previousAudibleEnd > previousAudibleStart) {
+				extractionTasks.push(
+					extractAndRegister({
+						sourceStartFrame: previousAudibleStart - sequenceStartFrame,
+						durationInFrames: previousAudibleEnd - previousAudibleStart,
+						frameToRegister: previousFrameStart,
+						padStartInSeconds:
+							(previousAudibleStart - previousFrameStart) / fps,
+						padEndInSeconds: (previousFrameEnd - previousAudibleEnd) / fps,
+						volumeFrame: previousAudibleStart - sequenceStartFrame,
+					}),
+				);
+			}
+		}
+
+		Promise.all(extractionTasks)
+			.then(() => {
 				continueRender(newHandle);
 			})
 			.catch((error) => {
@@ -274,6 +404,9 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 		onError,
 		credentials,
 		initialRequestInit,
+		sequenceContext?.cumulatedFrom,
+		sequenceContext?.relativeFrom,
+		sequenceContext?.durationInFrames,
 	]);
 
 	if (replaceWithHtml5Audio) {

--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -1,6 +1,6 @@
 import {BufferTarget, StreamTarget} from 'mediabunny';
 import type {CalculateMetadataFunction} from 'remotion';
-import {Internals, type LogLevel} from 'remotion';
+import {Internals, type LogLevel, type TRenderAsset} from 'remotion';
 import {VERSION} from 'remotion/version';
 import type {z} from 'zod';
 import type {$ZodObject} from 'zod/v4/core';
@@ -484,6 +484,40 @@ const internalRenderMediaOnWeb = async <
 			};
 		};
 
+		const pendingAudioAssets = new Map<number, TRenderAsset[]>();
+		const queueAudioAssets = (assets: TRenderAsset[]) => {
+			for (const asset of assets) {
+				if (asset.type !== 'inline-audio') {
+					continue;
+				}
+
+				const existing = pendingAudioAssets.get(asset.frame) ?? [];
+				pendingAudioAssets.set(asset.frame, [...existing, asset]);
+			}
+		};
+
+		const encodeAudioForFrame = async (frameToEncode: number) => {
+			if (muted || audioSampleSource === null) {
+				return;
+			}
+
+			const audioCombineStart = performance.now();
+			const timestamp = Math.round(
+				((frameToEncode - realFrameRange[0]) / resolved.fps) * 1_000_000,
+			);
+			const assets = pendingAudioAssets.get(frameToEncode) ?? [];
+			pendingAudioAssets.delete(frameToEncode);
+			const audio = onlyInlineAudio({
+				assets,
+				fps: resolved.fps,
+				timestamp,
+				sampleRate,
+			});
+			internalState.addAudioMixingTime(performance.now() - audioCombineStart);
+
+			await addAudioSample(audio, audioSampleSource.audioSampleSource);
+		};
+
 		for (let frame = realFrameRange[0]; frame <= realFrameRange[1]; frame++) {
 			if (signal?.aborted) {
 				throw new Error('renderMediaOnWeb() was cancelled');
@@ -574,7 +608,6 @@ const internalRenderMediaOnWeb = async <
 
 			throttledOnProgress?.(getProgressPayload());
 
-			const audioCombineStart = performance.now();
 			const assets = collectAssets.current!.collectAssets();
 			if (onArtifact) {
 				await artifactsHandler.handle({
@@ -584,15 +617,11 @@ const internalRenderMediaOnWeb = async <
 					onArtifact,
 				});
 			}
+			queueAudioAssets(assets);
 
 			if (signal?.aborted) {
 				throw new Error('renderMediaOnWeb() was cancelled');
 			}
-
-			const audio = muted
-				? null
-				: onlyInlineAudio({assets, fps: resolved.fps, timestamp, sampleRate});
-			internalState.addAudioMixingTime(performance.now() - audioCombineStart);
 
 			const addSampleStart = performance.now();
 			const encodingPromises: Promise<void>[] = [];
@@ -605,10 +634,8 @@ const internalRenderMediaOnWeb = async <
 				);
 			}
 
-			if (audio && audioSampleSource) {
-				encodingPromises.push(
-					addAudioSample(audio, audioSampleSource.audioSampleSource),
-				);
+			if (frame > realFrameRange[0]) {
+				encodingPromises.push(encodeAudioForFrame(frame - 1));
 			}
 
 			await Promise.all(encodingPromises);
@@ -625,6 +652,32 @@ const internalRenderMediaOnWeb = async <
 				throw new Error('renderMediaOnWeb() was cancelled');
 			}
 		}
+
+		if (
+			!muted &&
+			audioSampleSource !== null &&
+			realFrameRange[1] + 1 < resolved.durationInFrames
+		) {
+			timeUpdater.current?.update(realFrameRange[1] + 1);
+
+			await waitForReady({
+				timeoutInMilliseconds: delayRenderTimeoutInMilliseconds,
+				scope: delayRenderScope,
+				signal,
+				apiName: 'renderMediaOnWeb',
+				keepalive,
+				internalState,
+			});
+			checkForError(errorHolder);
+
+			queueAudioAssets(collectAssets.current!.collectAssets());
+		}
+
+		const addFinalAudioSampleStart = performance.now();
+		await encodeAudioForFrame(realFrameRange[1]);
+		internalState.addAddSampleTime(
+			performance.now() - addFinalAudioSampleStart,
+		);
 
 		// Call progress one final time to ensure final state is reported
 		onProgress?.(getProgressPayload());

--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -617,6 +617,7 @@ const internalRenderMediaOnWeb = async <
 					onArtifact,
 				});
 			}
+
 			queueAudioAssets(assets);
 
 			if (signal?.aborted) {

--- a/packages/web-renderer/src/test/Root.tsx
+++ b/packages/web-renderer/src/test/Root.tsx
@@ -61,6 +61,7 @@ import {scalePrecomposeFixture} from './fixtures/scale-precompose';
 import {scaledTranslatedSvg} from './fixtures/scaled-translated-svg';
 import {selfTransformOrigin} from './fixtures/self-transform-origin';
 import {simpleRotatedSvg} from './fixtures/simple-rotated-svg';
+import {subframeAudio} from './fixtures/subframe-audio';
 import {svgExplicitDimensions} from './fixtures/svg-explicit-dimensions';
 import {backgroundClipText} from './fixtures/text/background-clip-text';
 import {backgroundClipText3dTransform} from './fixtures/text/background-clip-text-3d-transform';
@@ -127,6 +128,7 @@ export const Root: React.FC = () => {
 			</Folder>
 			<Composition {...threeDTransformOpacity} />
 			<Composition {...backgroundColor} />
+			<Composition {...subframeAudio} />
 			<Folder name="linear-gradient">
 				<Composition {...maskImage} />
 				<Composition {...backfaceVisibilityMask} />

--- a/packages/web-renderer/src/test/audio.test.tsx
+++ b/packages/web-renderer/src/test/audio.test.tsx
@@ -4,6 +4,7 @@ import {staticFile} from 'remotion';
 import {expect, test} from 'vitest';
 import {renderMediaOnWeb} from '../render-media-on-web';
 import '../symbol-dispose';
+import {subframeAudio} from './fixtures/subframe-audio';
 
 const getAudioTrackFromBlob = async (blob: Blob): Promise<InputAudioTrack> => {
 	using input = new Input({
@@ -26,6 +27,43 @@ const getAudioCodecFromBlob = async (
 ): Promise<InputAudioTrack['codec']> => {
 	const track = await getAudioTrackFromBlob(blob);
 	return track.codec;
+};
+
+const getPcmS16SamplesFromWav = async (blob: Blob) => {
+	const buffer = await blob.arrayBuffer();
+	const view = new DataView(buffer);
+	let offset = 12;
+
+	while (offset < view.byteLength) {
+		const chunkId = String.fromCharCode(
+			view.getUint8(offset),
+			view.getUint8(offset + 1),
+			view.getUint8(offset + 2),
+			view.getUint8(offset + 3),
+		);
+		const chunkSize = view.getUint32(offset + 4, true);
+		if (chunkId === 'data') {
+			const dataOffset = offset + 8;
+			const samples = new Int16Array(chunkSize / Int16Array.BYTES_PER_ELEMENT);
+			for (let i = 0; i < samples.length; i++) {
+				samples[i] = view.getInt16(
+					dataOffset + i * Int16Array.BYTES_PER_ELEMENT,
+					true,
+				);
+			}
+
+			return samples;
+		}
+
+		offset += 8 + chunkSize + (chunkSize % 2);
+	}
+
+	throw new Error('No data chunk found in WAV file');
+};
+
+const rms = (samples: Int16Array) => {
+	const sum = samples.reduce((acc, sample) => acc + sample * sample, 0);
+	return Math.sqrt(sum / samples.length);
 };
 
 test(
@@ -57,6 +95,34 @@ test(
 		);
 	},
 );
+
+test('should render subframe audio starts in the previous frame', async () => {
+	const result = await renderMediaOnWeb({
+		licenseKey: 'free-license',
+		composition: {
+			...subframeAudio,
+			calculateMetadata: null,
+		},
+		container: 'wav',
+		frameRange: [0, 0],
+		outputTarget: 'arraybuffer',
+		sampleRate: 48000,
+	});
+
+	const blob = await result.getBlob();
+	const samples = await getPcmS16SamplesFromWav(blob);
+	const samplesPerFrame = 48000 / subframeAudio.fps;
+	const samplesPerHalfFrame = samplesPerFrame / 2;
+	const numberOfChannels = 2;
+	const firstHalf = samples.slice(0, samplesPerHalfFrame * numberOfChannels);
+	const secondHalf = samples.slice(
+		samplesPerHalfFrame * numberOfChannels,
+		samplesPerFrame * numberOfChannels,
+	);
+
+	expect(rms(firstHalf)).toBe(0);
+	expect(rms(secondHalf)).toBeGreaterThan(1000);
+});
 
 test('should be able to render 2 audios', async (t) => {
 	if (t.task.file.projectName === 'chromium') {

--- a/packages/web-renderer/src/test/fixtures/subframe-audio.tsx
+++ b/packages/web-renderer/src/test/fixtures/subframe-audio.tsx
@@ -1,0 +1,20 @@
+import {Audio} from '@remotion/media';
+import React from 'react';
+import {AbsoluteFill, staticFile} from 'remotion';
+
+const Component: React.FC = () => {
+	return (
+		<AbsoluteFill>
+			<Audio from={0.5} src={staticFile('dialogue.wav')} />
+		</AbsoluteFill>
+	);
+};
+
+export const subframeAudio = {
+	component: Component,
+	id: 'subframe-audio',
+	width: 100,
+	height: 100,
+	fps: 30,
+	durationInFrames: 3,
+} as const;


### PR DESCRIPTION
## Summary
- Render fractional audio starts/ends by trimming and padding inline audio chunks
- Queue web-renderer inline audio by target frame so backfilled subframe chunks are included
- Add a web-renderer WAV regression test for subframe audio start timing

Fixes #7666

## Tests
- bun run build
- bun run formatting
- cd packages/web-renderer && bunx vitest run src/test/audio.test.tsx