### PR TITLE
`@remotion/effects`: Use API names as Studio labels

### DIFF
--- a/packages/effects/src/barrel-distortion/index.ts
+++ b/packages/effects/src/barrel-distortion/index.ts
@@ -55,7 +55,7 @@ export const barrelDistortion = createEffect<
 	BarrelDistortionState
 >({
 	type: 'remotion/barrel-distortion',
-	label: 'Barrel Distortion',
+	label: 'barrelDistortion()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/barrel-distortion',
 	backend: 'webgl2',
 	calculateKey: (params) => {

--- a/packages/effects/src/blur/index.ts
+++ b/packages/effects/src/blur/index.ts
@@ -61,7 +61,7 @@ const validateBlurParams = (params: BlurParams): void => {
 
 export const blur = createEffect<BlurParams, BlurState>({
 	type: 'remotion/blur',
-	label: 'Blur',
+	label: 'blur()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/blur',
 	backend: 'webgl2',
 	calculateKey: (params) => {

--- a/packages/effects/src/brightness.ts
+++ b/packages/effects/src/brightness.ts
@@ -38,7 +38,7 @@ const validateBrightnessParams = (params: BrightnessParams): void => {
 
 export const brightness = createEffect<BrightnessParams, null>({
 	type: 'remotion/brightness',
-	label: 'Brightness',
+	label: 'brightness()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/brightness',
 	backend: '2d',
 	calculateKey: (params) => {

--- a/packages/effects/src/chromatic-aberration/index.ts
+++ b/packages/effects/src/chromatic-aberration/index.ts
@@ -69,7 +69,7 @@ export const chromaticAberration = createEffect<
 	ChromaticAberrationState
 >({
 	type: 'remotion/chromatic-aberration',
-	label: 'Chromatic Aberration',
+	label: 'chromaticAberration()',
 	documentationLink:
 		'https://www.remotion.dev/docs/effects/chromatic-aberration',
 	backend: 'webgl2',

--- a/packages/effects/src/contrast.ts
+++ b/packages/effects/src/contrast.ts
@@ -38,7 +38,7 @@ const validateContrastParams = (params: ContrastParams): void => {
 
 export const contrast = createEffect<ContrastParams, null>({
 	type: 'remotion/contrast',
-	label: 'Contrast',
+	label: 'contrast()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/contrast',
 	backend: '2d',
 	calculateKey: (params) => {

--- a/packages/effects/src/duotone.ts
+++ b/packages/effects/src/duotone.ts
@@ -307,7 +307,7 @@ const getParsedColors = (
 
 export const duotone = createEffect<DuotoneParams, DuotoneState>({
 	type: 'remotion/duotone',
-	label: 'Duotone',
+	label: 'duotone()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/duotone',
 	backend: 'webgl2',
 	calculateKey: (params) => {

--- a/packages/effects/src/grayscale.ts
+++ b/packages/effects/src/grayscale.ts
@@ -37,7 +37,7 @@ const validateGrayscaleParams = (params: GrayscaleParams): void => {
 
 export const grayscale = createEffect<GrayscaleParams, null>({
 	type: 'remotion/grayscale',
-	label: 'Grayscale',
+	label: 'grayscale()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/grayscale',
 	backend: '2d',
 	calculateKey: (params) => {

--- a/packages/effects/src/halftone.ts
+++ b/packages/effects/src/halftone.ts
@@ -390,7 +390,7 @@ const linkProgram = (
 // color at each grid cell.
 export const halftone = createEffect<HalftoneParams, HalftoneState>({
 	type: 'remotion/halftone',
-	label: 'Halftone',
+	label: 'halftone()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/halftone',
 	backend: 'webgl2',
 	calculateKey: (params) => {

--- a/packages/effects/src/hue.ts
+++ b/packages/effects/src/hue.ts
@@ -33,7 +33,7 @@ const validateHueParams = (params: HueParams): void => {
 
 export const hue = createEffect<HueParams, null>({
 	type: 'remotion/hue',
-	label: 'Hue',
+	label: 'hue()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/hue',
 	backend: '2d',
 	calculateKey: (params) => {

--- a/packages/effects/src/invert.ts
+++ b/packages/effects/src/invert.ts
@@ -37,7 +37,7 @@ const validateInvertParams = (params: InvertParams): void => {
 
 export const invert = createEffect<InvertParams, null>({
 	type: 'remotion/invert',
-	label: 'Invert',
+	label: 'invert()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/invert',
 	backend: '2d',
 	calculateKey: (params) => {

--- a/packages/effects/src/mirror/index.ts
+++ b/packages/effects/src/mirror/index.ts
@@ -89,7 +89,7 @@ const validateMirrorParams = (params: MirrorParams): void => {
 
 export const mirror = createEffect<MirrorParams, MirrorState>({
 	type: 'remotion/mirror',
-	label: 'Mirror',
+	label: 'mirror()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/mirror',
 	backend: 'webgl2',
 	calculateKey: (params) => {

--- a/packages/effects/src/saturation.ts
+++ b/packages/effects/src/saturation.ts
@@ -37,7 +37,7 @@ const validateSaturationParams = (params: SaturationParams): void => {
 
 export const saturation = createEffect<SaturationParams, null>({
 	type: 'remotion/saturation',
-	label: 'Saturation',
+	label: 'saturation()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/saturation',
 	backend: '2d',
 	calculateKey: (params) => {

--- a/packages/effects/src/scale/index.ts
+++ b/packages/effects/src/scale/index.ts
@@ -81,7 +81,7 @@ const validateScaleParams = (params: ScaleParams): void => {
 
 export const scale = createEffect<ScaleParams, null>({
 	type: 'remotion/scale',
-	label: 'Scale',
+	label: 'scale()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/scale',
 	backend: '2d',
 	calculateKey: (params) => {

--- a/packages/effects/src/test/effect-params.test.ts
+++ b/packages/effects/src/test/effect-params.test.ts
@@ -70,6 +70,26 @@ test('@remotion/effects expose documentation links', () => {
 	);
 });
 
+test('@remotion/effects expose API names as Studio labels', () => {
+	expect(barrelDistortion().definition.label).toBe('barrelDistortion()');
+	expect(blur({radius: 1}).definition.label).toBe('blur()');
+	expect(chromaticAberration().definition.label).toBe('chromaticAberration()');
+	expect(brightness().definition.label).toBe('brightness()');
+	expect(contrast().definition.label).toBe('contrast()');
+	expect(duotone().definition.label).toBe('duotone()');
+	expect(grayscale().definition.label).toBe('grayscale()');
+	expect(halftone().definition.label).toBe('halftone()');
+	expect(hue().definition.label).toBe('hue()');
+	expect(invert().definition.label).toBe('invert()');
+	expect(mirror().definition.label).toBe('mirror()');
+	expect(saturation().definition.label).toBe('saturation()');
+	expect(scale({scale: 1}).definition.label).toBe('scale()');
+	expect(tint({color: '#fff'}).definition.label).toBe('tint()');
+	expect(uvTranslate().definition.label).toBe('uvTranslate()');
+	expect(xyTranslate().definition.label).toBe('xyTranslate()');
+	expect(wave().definition.label).toBe('wave()');
+});
+
 test('barrelDistortion() accepts default params', () => {
 	expect(() => barrelDistortion()).not.toThrow();
 });

--- a/packages/effects/src/tint.ts
+++ b/packages/effects/src/tint.ts
@@ -59,7 +59,7 @@ const validateTintParams = (params: TintParams): void => {
 // backend; tinting respects the source's alpha mask.
 export const tint = createEffect<TintParams, null>({
 	type: 'remotion/tint',
-	label: 'Tint',
+	label: 'tint()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/tint',
 	backend: '2d',
 	calculateKey: (params) => {

--- a/packages/effects/src/translate/index.ts
+++ b/packages/effects/src/translate/index.ts
@@ -113,7 +113,7 @@ const applyTranslate = ({
 
 export const xyTranslate = createEffect<XyTranslateParams, null>({
 	type: 'remotion/xy-translate',
-	label: 'XY Translate',
+	label: 'xyTranslate()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/xy-translate',
 	backend: '2d',
 	calculateKey: (params) => {
@@ -139,7 +139,7 @@ export const xyTranslate = createEffect<XyTranslateParams, null>({
 
 export const uvTranslate = createEffect<UvTranslateParams, null>({
 	type: 'remotion/uv-translate',
-	label: 'UV Translate',
+	label: 'uvTranslate()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/uv-translate',
 	backend: '2d',
 	calculateKey: (params) => {

--- a/packages/effects/src/wave/index.ts
+++ b/packages/effects/src/wave/index.ts
@@ -112,7 +112,7 @@ const validateWaveParams = (params: WaveParams): void => {
 // Sine wave warp: displaces source UVs along the propagation axis. WebGL2 only.
 export const wave = createEffect<WaveParams, WaveState>({
 	type: 'remotion/wave',
-	label: 'Wave',
+	label: 'wave()',
 	documentationLink: 'https://www.remotion.dev/docs/effects/wave',
 	backend: 'webgl2',
 	calculateKey: (params) => {

--- a/packages/example/e2e/lost-node-path.test.mts
+++ b/packages/example/e2e/lost-node-path.test.mts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import {expect, test} from '@playwright/test';
+import fs from 'fs';
 import {EXPANDED_SIDEBAR_STATE, lostNodePathE2eFile} from './constants.mts';
 import {
 	navigateToLostNodePathE2e,
@@ -30,6 +30,8 @@ const applyIssue7393Refactor = (content: string): string => {
 };
 
 const stackAttribution = (line: number) => `LostNodePathRepro.tsx:${line}`;
+const expandTintSectionName = /^Expand (?:Tint|tint\(\)) section$/;
+const collapseTintSectionName = /^Collapse (?:Tint|tint\(\)) section$/;
 
 test.use({storageState: EXPANDED_SIDEBAR_STATE});
 
@@ -70,7 +72,7 @@ test.describe('lost node path recovery', () => {
 		await expandEffects.click();
 
 		const expandTint = page.getByRole('button', {
-			name: 'Expand Tint section',
+			name: expandTintSectionName,
 		});
 		await expect(expandTint).toBeVisible({timeout: 10_000});
 		await expandTint.click();
@@ -82,7 +84,7 @@ test.describe('lost node path recovery', () => {
 			page.getByRole('button', {name: 'Collapse Effects section'}),
 		).toBeVisible();
 		await expect(
-			page.getByRole('button', {name: 'Collapse Tint section'}),
+			page.getByRole('button', {name: collapseTintSectionName}),
 		).toBeVisible();
 
 		const logCountBefore = readStudioLogs().length;
@@ -126,7 +128,7 @@ test.describe('lost node path recovery', () => {
 			page.getByRole('button', {name: 'Collapse Effects section'}),
 		).toBeVisible();
 		await expect(
-			page.getByRole('button', {name: 'Collapse Tint section'}),
+			page.getByRole('button', {name: collapseTintSectionName}),
 		).toBeVisible();
 	});
 });

--- a/packages/light-leaks/package.json
+++ b/packages/light-leaks/package.json
@@ -10,6 +10,7 @@
 	},
 	"type": "module",
 	"scripts": {
+		"test": "bun test src/test",
 		"formatting": "oxfmt src --check",
 		"format": "oxfmt src",
 		"lint": "eslint src",

--- a/packages/light-leaks/src/light-leak-internals.ts
+++ b/packages/light-leaks/src/light-leak-internals.ts
@@ -192,7 +192,7 @@ const linkProgram = (
 
 const lightLeak = createEffect<LightLeakEffectParams, LightLeakGlState>({
 	type: 'remotion/light-leak',
-	label: 'Light leak',
+	label: 'lightLeak()',
 	documentationLink: 'https://www.remotion.dev/docs/light-leaks/light-leak',
 	backend: 'webgl2',
 	calculateKey: (params) => {

--- a/packages/light-leaks/src/test/light-leak-effect-params.test.ts
+++ b/packages/light-leaks/src/test/light-leak-effect-params.test.ts
@@ -1,0 +1,6 @@
+import {expect, test} from 'bun:test';
+import {LightLeakInternals} from '../light-leak-internals.js';
+
+test('lightLeak() exposes its API name as the Studio label', () => {
+	expect(LightLeakInternals.lightLeak().definition.label).toBe('lightLeak()');
+});

--- a/packages/starburst/src/starburst-effect.ts
+++ b/packages/starburst/src/starburst-effect.ts
@@ -299,7 +299,7 @@ const linkProgram = (
 
 export const starburst = createEffect<StarburstEffectParams, StarburstGlState>({
 	type: 'remotion/starburst',
-	label: 'Starburst',
+	label: 'starburst()',
 	documentationLink: 'https://www.remotion.dev/docs/starburst/starburst',
 	backend: 'webgl2',
 	calculateKey: (params) => {

--- a/packages/starburst/src/test/starburst-effect-params.test.ts
+++ b/packages/starburst/src/test/starburst-effect-params.test.ts
@@ -14,3 +14,9 @@ test('starburst() accepts valid params', () => {
 		starburst({rays: 12, colors: ['#ff0000', '#00ff00']}),
 	).not.toThrow();
 });
+
+test('starburst() exposes its API name as the Studio label', () => {
+	expect(
+		starburst({rays: 12, colors: ['#ff0000', '#00ff00']}).definition.label,
+	).toBe('starburst()');
+});


### PR DESCRIPTION
## Summary
- Rename effect labels to canonical API names with `()` for `@remotion/effects`, `@remotion/light-leaks`, and `@remotion/starburst`
- Add label coverage for effects, light leaks, and starburst

Closes #7684

## Testing
- `cd packages/effects && bun run format && bun run test`
- `cd packages/light-leaks && bun run format && bun run test`
- `cd packages/starburst && bun run format && bun run test`
- `bunx turbo make --filter="@remotion/effects" --filter="@remotion/light-leaks" --filter="@remotion/starburst"`
- `cd packages/effects && bun run lint && cd ../light-leaks && bun run lint && cd ../starburst && bun run lint`