### PR TITLE
`@remotion/studio-server`: Improve outside-project file errors

### DIFF
--- a/packages/studio-server/src/codemods/apply-codemod-to-file.ts
+++ b/packages/studio-server/src/codemods/apply-codemod-to-file.ts
@@ -1,9 +1,9 @@
 import {existsSync, readFileSync} from 'node:fs';
-import path from 'node:path';
 import type {
 	RecastCodemod,
 	SymbolicatedStackFrame,
 } from '@remotion/studio-shared';
+import {resolveFileInsideProject} from '../helpers/resolve-file-inside-project';
 import {checkIfTypeScriptFile} from '../preview-server/routes/can-update-default-props';
 import {formatOutput, parseAndApplyCodemod} from './duplicate-composition';
 
@@ -17,11 +17,11 @@ export const resolveFilePathFromSymbolicatedStack = (
 		);
 	}
 
-	const absolutePath = path.resolve(remotionRoot, stack.originalFileName);
-	const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-	if (fileRelativeToRoot.startsWith('..')) {
-		throw new Error('Cannot apply codemod to a file outside the project');
-	}
+	const {absolutePath} = resolveFileInsideProject({
+		remotionRoot,
+		fileName: stack.originalFileName,
+		action: 'apply codemod to',
+	});
 
 	if (!existsSync(absolutePath)) {
 		throw new Error(`File not found: ${stack.originalFileName}`);

--- a/packages/studio-server/src/helpers/resolve-file-inside-project.ts
+++ b/packages/studio-server/src/helpers/resolve-file-inside-project.ts
@@ -1,0 +1,45 @@
+import path from 'node:path';
+
+const formatOutsideProjectError = ({
+	action,
+	fileName,
+	absolutePath,
+	remotionRoot,
+}: {
+	action: string;
+	fileName: string;
+	absolutePath: string;
+	remotionRoot: string;
+}) =>
+	`Cannot ${action} a file outside the project: "${fileName}" resolves to "${absolutePath}", but the project root is "${remotionRoot}".`;
+
+export const resolveFileInsideProject = ({
+	remotionRoot,
+	fileName,
+	action,
+}: {
+	remotionRoot: string;
+	fileName: string;
+	action: string;
+}): {absolutePath: string; fileRelativeToRoot: string} => {
+	const resolvedRemotionRoot = path.resolve(remotionRoot);
+	const absolutePath = path.resolve(resolvedRemotionRoot, fileName);
+	const fileRelativeToRoot = path.relative(resolvedRemotionRoot, absolutePath);
+
+	if (
+		fileRelativeToRoot === '..' ||
+		fileRelativeToRoot.startsWith(`..${path.sep}`) ||
+		path.isAbsolute(fileRelativeToRoot)
+	) {
+		throw new Error(
+			formatOutsideProjectError({
+				action,
+				fileName,
+				absolutePath,
+				remotionRoot: resolvedRemotionRoot,
+			}),
+		);
+	}
+
+	return {absolutePath, fileRelativeToRoot};
+};

--- a/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
@@ -1,5 +1,4 @@
 import {readFileSync} from 'node:fs';
-import path from 'node:path';
 import type {File} from '@babel/types';
 import {RenderInternals} from '@remotion/renderer';
 import type {
@@ -10,6 +9,7 @@ import * as recast from 'recast';
 import {parseAst, serializeAst} from '../../codemods/parse-ast';
 import {applyCodemod} from '../../codemods/recast-mods';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
 import {formatLogFileLocation} from '../format-log-file-location';
 import {waitForLiveEventsListener} from '../live-events';
@@ -52,13 +52,11 @@ export const applyVisualControlHandler: ApiHandler<
 		{indent: false, logLevel},
 		`[apply-visual-control] Received request for ${fileName} with ${changes.length} changes`,
 	);
-	const absolutePath = path.resolve(remotionRoot, fileName);
-	const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-	if (fileRelativeToRoot.startsWith('..')) {
-		throw new Error(
-			'Cannot apply visual control change to a file outside the project',
-		);
-	}
+	const {absolutePath} = resolveFileInsideProject({
+		remotionRoot,
+		fileName,
+		action: 'apply visual control change to',
+	});
 
 	const fileContents = readFileSync(absolutePath, 'utf-8');
 	const ast = parseAst(fileContents);

--- a/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
@@ -1,5 +1,4 @@
 import {readFileSync} from 'node:fs';
-import path from 'node:path';
 import type {
 	CallExpression,
 	Expression,
@@ -19,6 +18,7 @@ import {
 	enumerateEffectArrayElements,
 	type EffectArrayElement,
 } from '../../codemods/update-effect-props/update-effect-props';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import {
 	extractStaticValue,
 	findJsxElementAtNodePath,
@@ -210,11 +210,11 @@ export const computeEffectPropsStatusesFromFile = ({
 	keysFor: (effect: SequenceSchema) => string[];
 	remotionRoot: string;
 }): CanUpdateEffectPropsResponse[] => {
-	const absolutePath = path.resolve(remotionRoot, fileName);
-	const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-	if (fileRelativeToRoot.startsWith('..')) {
-		throw new Error('Cannot read a file outside the project');
-	}
+	const {absolutePath} = resolveFileInsideProject({
+		remotionRoot,
+		fileName,
+		action: 'read',
+	});
 
 	const fileContents = readFileSync(absolutePath, 'utf-8');
 	return computeEffectPropsStatusesFromContent({

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -1,5 +1,4 @@
 import {readFileSync} from 'node:fs';
-import path from 'node:path';
 import type {
 	CallExpression,
 	Expression,
@@ -22,6 +21,7 @@ import type {
 } from 'remotion';
 import {parseAst} from '../../codemods/parse-ast';
 import {getAstNodePath} from '../../helpers/get-ast-node-path';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import {JsxElementNotFoundAtLocationError} from '../jsx-element-not-found-at-location-error';
 import {computeEffectPropStatus} from './can-update-effect-props';
 
@@ -459,11 +459,11 @@ export const computeSequencePropsOnlyStatus = ({
 	keys: string[];
 	remotionRoot: string;
 }): {canUpdate: true; props: Record<string, CanUpdatePropStatus>} => {
-	const absolutePath = path.resolve(remotionRoot, fileName);
-	const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-	if (fileRelativeToRoot.startsWith('..')) {
-		throw new Error('Cannot read a file outside the project');
-	}
+	const {absolutePath} = resolveFileInsideProject({
+		remotionRoot,
+		fileName,
+		action: 'read',
+	});
 
 	const fileContents = readFileSync(absolutePath, 'utf-8');
 	const ast = parseAst(fileContents);
@@ -522,11 +522,11 @@ export const computeSequencePropsStatus = ({
 	effects: string[][];
 	remotionRoot: string;
 }): CanUpdateSequencePropsResponseTrue => {
-	const absolutePath = path.resolve(remotionRoot, fileName);
-	const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-	if (fileRelativeToRoot.startsWith('..')) {
-		throw new Error('Cannot read a file outside the project');
-	}
+	const {absolutePath} = resolveFileInsideProject({
+		remotionRoot,
+		fileName,
+		action: 'read',
+	});
 
 	const fileContents = readFileSync(absolutePath, 'utf-8');
 	return computeSequencePropsStatusFromContent({
@@ -553,11 +553,11 @@ export const computeSequencePropsStatusFromFilenameByLine = ({
 	logLevel: LogLevel;
 }): SubscribeToSequencePropsResponse => {
 	try {
-		const absolutePath = path.resolve(remotionRoot, fileName);
-		const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-		if (fileRelativeToRoot.startsWith('..')) {
-			throw new Error('Cannot read a file outside the project');
-		}
+		const {absolutePath} = resolveFileInsideProject({
+			remotionRoot,
+			fileName,
+			action: 'read',
+		});
 
 		const fileContents = readFileSync(absolutePath, 'utf-8');
 		const ast = parseAst(fileContents);

--- a/packages/studio-server/src/preview-server/routes/delete-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-effect.ts
@@ -1,5 +1,4 @@
 import {readFileSync} from 'node:fs';
-import path from 'node:path';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	DeleteEffectRequest,
@@ -7,6 +6,7 @@ import type {
 } from '@remotion/studio-shared';
 import {deleteEffect} from '../../codemods/delete-effect';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
 import {formatLogFileLocation} from '../format-log-file-location';
 import {
@@ -30,11 +30,11 @@ export const deleteEffectHandler: ApiHandler<
 			{indent: false, logLevel},
 			`[delete-effect] Received request for fileName="${fileName}" effectIndex=${effectIndex}`,
 		);
-		const absolutePath = path.resolve(remotionRoot, fileName);
-		const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-		if (fileRelativeToRoot.startsWith('..')) {
-			throw new Error('Cannot modify a file outside the project');
-		}
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName,
+			action: 'modify',
+		});
 
 		const fileContents = readFileSync(absolutePath, 'utf-8');
 		const {output, formatted, effectLabel, logLine} = await deleteEffect({

--- a/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
@@ -1,5 +1,4 @@
 import {readFileSync} from 'node:fs';
-import path from 'node:path';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	DeleteJsxNodeRequest,
@@ -7,6 +6,7 @@ import type {
 } from '@remotion/studio-shared';
 import {deleteJsxNode} from '../../codemods/delete-jsx-node';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
 import {formatLogFileLocation} from '../format-log-file-location';
 import {
@@ -25,11 +25,11 @@ export const deleteJsxNodeHandler: ApiHandler<
 			{indent: false, logLevel},
 			`[delete-jsx-node] Received request for fileName="${fileName}"`,
 		);
-		const absolutePath = path.resolve(remotionRoot, fileName);
-		const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-		if (fileRelativeToRoot.startsWith('..')) {
-			throw new Error('Cannot modify a file outside the project');
-		}
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName,
+			action: 'modify',
+		});
 
 		const fileContents = readFileSync(absolutePath, 'utf-8');
 

--- a/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
@@ -1,5 +1,4 @@
 import {readFileSync} from 'node:fs';
-import path from 'node:path';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	DuplicateJsxNodeRequest,
@@ -7,6 +6,7 @@ import type {
 } from '@remotion/studio-shared';
 import {duplicateJsxNode} from '../../codemods/duplicate-jsx-node';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
 import {formatLogFileLocation} from '../format-log-file-location';
 import {
@@ -25,11 +25,11 @@ export const duplicateJsxNodeHandler: ApiHandler<
 			{indent: false, logLevel},
 			`[duplicate-jsx-node] Received request for fileName="${fileName}"`,
 		);
-		const absolutePath = path.resolve(remotionRoot, fileName);
-		const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-		if (fileRelativeToRoot.startsWith('..')) {
-			throw new Error('Cannot modify a file outside the project');
-		}
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName,
+			action: 'modify',
+		});
 
 		const fileContents = readFileSync(absolutePath, 'utf-8');
 

--- a/packages/studio-server/src/preview-server/routes/save-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-effect-props.ts
@@ -1,5 +1,4 @@
 import {readFileSync} from 'node:fs';
-import path from 'node:path';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	SaveEffectPropsRequest,
@@ -9,6 +8,7 @@ import {getAllSchemaKeys} from '@remotion/studio-shared';
 import {parseAst} from '../../codemods/parse-ast';
 import {updateEffectProps} from '../../codemods/update-effect-props/update-effect-props';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
 import {
 	printUndoHint,
@@ -45,11 +45,11 @@ export const saveEffectPropsHandler: ApiHandler<
 			{indent: false, logLevel},
 			`[save-effect-props] Received request for fileName="${fileName}" effectIndex=${effectIndex} key="${key}"`,
 		);
-		const absolutePath = path.resolve(remotionRoot, fileName);
-		const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-		if (fileRelativeToRoot.startsWith('..')) {
-			throw new Error('Cannot modify a file outside the project');
-		}
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName,
+			action: 'modify',
+		});
 
 		const fileContents = readFileSync(absolutePath, 'utf-8');
 

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -1,5 +1,4 @@
 import {readFileSync} from 'node:fs';
-import path from 'node:path';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	SaveSequencePropsRequest,
@@ -9,6 +8,7 @@ import {getAllSchemaKeys} from '@remotion/studio-shared';
 import {NoReactInternals} from 'remotion/no-react';
 import {updateSequenceProps} from '../../codemods/update-sequence-props/update-sequence-props';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
 import {
 	printUndoHint,
@@ -34,11 +34,11 @@ export const saveSequencePropsHandler: ApiHandler<
 			{indent: false, logLevel},
 			`[save-sequence-props] Received request for fileName="${fileName}" key="${key}"`,
 		);
-		const absolutePath = path.resolve(remotionRoot, fileName);
-		const fileRelativeToRoot = path.relative(remotionRoot, absolutePath);
-		if (fileRelativeToRoot.startsWith('..')) {
-			throw new Error('Cannot modify a file outside the project');
-		}
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName,
+			action: 'modify',
+		});
 
 		const fileContents = readFileSync(absolutePath, 'utf-8');
 

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -45,6 +45,24 @@ test('canUpdateSequenceProps should flag computed props', () => {
 	});
 });
 
+test('computeSequencePropsStatus should explain why outside-project file reads were blocked', () => {
+	const remotionRoot = path.join(__dirname, 'snapshots');
+	const fileName = '../outside.tsx';
+	const absolutePath = path.resolve(remotionRoot, fileName);
+
+	expect(() =>
+		computeSequencePropsStatus({
+			fileName,
+			nodePath: [],
+			keys: [],
+			effects: [],
+			remotionRoot,
+		}),
+	).toThrow(
+		`Cannot read a file outside the project: "${fileName}" resolves to "${absolutePath}", but the project root is "${remotionRoot}".`,
+	);
+});
+
 test('computeSequencePropsStatus should detect static nested props', () => {
 	const filePath = path.join(__dirname, 'snapshots', 'nested-props.tsx');
 	const result = computeSequencePropsStatus({


### PR DESCRIPTION
Closes #7688

## Summary
- Add a shared project-boundary resolver for Studio server file operations
- Include the requested file, resolved path, and project root in outside-project errors
- Cover the improved read error with a test

## Checks
- bun test src (packages/studio-server)
- bun run build
- bun run formatting