### PR TITLE
`@remotion/studio`: Shift timeline keyframes by parent Sequence offset

### DIFF
--- a/packages/example/src/KeyframedPropsTest.tsx
+++ b/packages/example/src/KeyframedPropsTest.tsx
@@ -1,6 +1,5 @@
 import {blur} from '@remotion/effects/blur';
 import {scale} from '@remotion/effects/scale';
-import {Gif} from '@remotion/gif';
 import React from 'react';
 import {
 	AbsoluteFill,
@@ -52,7 +51,7 @@ const KeyframedPropsTest: React.FC = () => {
 					}}
 				/>
 			</Sequence>
-			<Sequence from={30} name="keyframes should be shown at 30 and 60">
+			<Sequence from={30} name="keyframes should be shown at 30 and 90">
 				<Shifted />
 			</Sequence>
 			<Sequence

--- a/packages/example/src/KeyframedPropsTest.tsx
+++ b/packages/example/src/KeyframedPropsTest.tsx
@@ -26,6 +26,63 @@ const Shifted = () => {
 	);
 };
 
+const NestedShifted = () => {
+	return (
+		<Sequence from={20}>
+			<Shifted />
+		</Sequence>
+	);
+};
+
+const NestedOwnFrom = () => {
+	const frame = useCurrentFrame();
+	return (
+		<Sequence
+			from={20}
+			name="nested own from keyframes should be shown at 30 and 70"
+			style={{scale: interpolate(frame, [0, 40], [2, 4])}}
+		>
+			<div
+				style={{
+					width: 180,
+					height: 180,
+					borderRadius: 24,
+					backgroundColor: '#0b84f3',
+				}}
+			/>
+		</Sequence>
+	);
+};
+
+const ShiftedEffect = () => {
+	const frame = useCurrentFrame();
+	return (
+		<AnimatedImage
+			src={staticFile('giphy.gif')}
+			fit="contain"
+			style={{
+				width: 360,
+				height: 200,
+				borderRadius: 24,
+				overflow: 'hidden',
+			}}
+			effects={[
+				blur({
+					radius: interpolate(frame, [0, 60], [0, 24]),
+				}),
+			]}
+		/>
+	);
+};
+
+const NestedShiftedEffect = () => {
+	return (
+		<Sequence from={20}>
+			<ShiftedEffect />
+		</Sequence>
+	);
+};
+
 const KeyframedPropsTest: React.FC = () => {
 	const frame = useCurrentFrame();
 
@@ -53,6 +110,21 @@ const KeyframedPropsTest: React.FC = () => {
 			</Sequence>
 			<Sequence from={30} name="keyframes should be shown at 30 and 90">
 				<Shifted />
+			</Sequence>
+			<Sequence from={30} name="nested keyframes should be shown at 50 and 110">
+				<NestedShifted />
+			</Sequence>
+			<Sequence from={30}>
+				<NestedOwnFrom />
+			</Sequence>
+			<Sequence from={30} name="effect keyframes should be shown at 30 and 90">
+				<ShiftedEffect />
+			</Sequence>
+			<Sequence
+				from={30}
+				name="nested effect keyframes should be shown at 50 and 110"
+			>
+				<NestedShiftedEffect />
 			</Sequence>
 			<Sequence
 				name="keyframes should be shown at 0 and 100 because relative to parent"

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -42,12 +42,14 @@ const getNodeKeyframes = ({
 	node,
 	nodePath,
 	codeValues,
+	keyframeDisplayOffset,
 }: {
 	node: ReturnType<typeof flattenVisibleTreeNodes>[number]['node'];
 	nodePath: SequenceNodePathInfo['sequenceSubscriptionKey'];
 	codeValues: React.ContextType<
 		typeof Internals.VisualModeCodeValuesContext
 	>['codeValues'];
+	keyframeDisplayOffset: number;
 }): ReturnType<typeof getTimelineKeyframes> => {
 	if (node.kind !== 'field' || node.field === null) {
 		return [];
@@ -56,6 +58,7 @@ const getNodeKeyframes = ({
 	if (node.field.kind === 'sequence-field') {
 		return getTimelineKeyframes(
 			Internals.getCodeValuesCtx(codeValues, nodePath)?.[node.field.key],
+			keyframeDisplayOffset,
 		);
 	}
 
@@ -69,13 +72,15 @@ const getNodeKeyframes = ({
 		effectStatus.type === 'can-update-effect'
 			? effectStatus.props?.[node.field.key]
 			: null,
+		keyframeDisplayOffset,
 	);
 };
 
 const TimelineExpandedTrackKeyframesInner: React.FC<{
 	readonly sequence: TSequence;
 	readonly nodePathInfo: SequenceNodePathInfo;
-}> = ({nodePathInfo, sequence}) => {
+	readonly keyframeDisplayOffset: number;
+}> = ({nodePathInfo, sequence, keyframeDisplayOffset}) => {
 	const videoConfig = useVideoConfig();
 	const timelineWidth = useContext(TimelineWidthContext);
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
@@ -117,10 +122,16 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 					node,
 					nodePath: nodePathInfo.sequenceSubscriptionKey,
 					codeValues,
+					keyframeDisplayOffset,
 				}),
 				key: JSON.stringify(node.nodePathInfo),
 			})),
-		[codeValues, flat, nodePathInfo.sequenceSubscriptionKey],
+		[
+			codeValues,
+			flat,
+			keyframeDisplayOffset,
+			nodePathInfo.sequenceSubscriptionKey,
+		],
 	);
 
 	return (

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -59,7 +59,7 @@ const TimelineTracksInner: React.FC<{
 								<TimelineExpandedTrackKeyframes
 									sequence={track.sequence}
 									nodePathInfo={track.nodePathInfo}
-									keyframeDisplayOffset={track.keyframeDisplayOffset ?? 0}
+									keyframeDisplayOffset={track.keyframeDisplayOffset}
 								/>
 							) : null}
 						</div>

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -59,6 +59,7 @@ const TimelineTracksInner: React.FC<{
 								<TimelineExpandedTrackKeyframes
 									sequence={track.sequence}
 									nodePathInfo={track.nodePathInfo}
+									keyframeDisplayOffset={track.keyframeDisplayOffset ?? 0}
 								/>
 							) : null}
 						</div>

--- a/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
@@ -17,6 +17,7 @@ export const getComputedStatusLabel = (
 
 export const getTimelineKeyframes = (
 	propStatus: CanUpdateSequencePropStatus | null | undefined,
+	keyframeDisplayOffset = 0,
 ): {frame: number; value: unknown}[] => {
 	if (!propStatus || propStatus.canUpdate) {
 		return [];
@@ -28,5 +29,13 @@ export const getTimelineKeyframes = (
 		);
 	}
 
-	return propStatus.keyframes ?? [];
+	const keyframes = propStatus.keyframes ?? [];
+	if (keyframeDisplayOffset === 0) {
+		return keyframes;
+	}
+
+	return keyframes.map((keyframe) => ({
+		...keyframe,
+		frame: keyframe.frame + keyframeDisplayOffset,
+	}));
 };

--- a/packages/studio/src/helpers/calculate-timeline.ts
+++ b/packages/studio/src/helpers/calculate-timeline.ts
@@ -99,9 +99,9 @@ export const calculateTimeline = ({
 			hash: actualHash,
 			cascadedStart,
 			cascadedDuration: sequence.duration,
-			...(hasKeyframeRows
-				? {keyframeDisplayOffset: cascadedStart - sequence.from}
-				: {}),
+			keyframeDisplayOffset: hasKeyframeRows
+				? cascadedStart - sequence.from
+				: 0,
 			nodePathInfo: nodePath
 				? {
 						sequenceSubscriptionKey: nodePath,

--- a/packages/studio/src/helpers/calculate-timeline.ts
+++ b/packages/studio/src/helpers/calculate-timeline.ts
@@ -82,6 +82,8 @@ export const calculateTimeline = ({
 
 		const overrideId = sequence.controls?.overrideId ?? null;
 		const nodePath = overrideId ? overrideIdsToNodePaths[overrideId] : null;
+		const hasKeyframeRows =
+			sequence.controls !== null || sequence.effects.length > 0;
 
 		tracks.push({
 			sequence: {
@@ -97,6 +99,9 @@ export const calculateTimeline = ({
 			hash: actualHash,
 			cascadedStart,
 			cascadedDuration: sequence.duration,
+			...(hasKeyframeRows
+				? {keyframeDisplayOffset: cascadedStart - sequence.from}
+				: {}),
 			nodePathInfo: nodePath
 				? {
 						sequenceSubscriptionKey: nodePath,

--- a/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
@@ -11,6 +11,7 @@ type Track = {
 	sequence: TSequence;
 	depth: number;
 	nodePathInfo: SequenceNodePathInfo | null;
+	keyframeDisplayOffset?: number;
 };
 
 export type TrackWithHash = Track & {

--- a/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
@@ -11,7 +11,7 @@ type Track = {
 	sequence: TSequence;
 	depth: number;
 	nodePathInfo: SequenceNodePathInfo | null;
-	keyframeDisplayOffset?: number;
+	keyframeDisplayOffset: number;
 };
 
 export type TrackWithHash = Track & {

--- a/packages/studio/src/test/big-timeline.test.ts
+++ b/packages/studio/src/test/big-timeline.test.ts
@@ -4,12 +4,22 @@ import {calculateTimeline} from '../helpers/calculate-timeline';
 
 const getStack = () => null;
 
+const withoutKeyframeDisplayOffset = <
+	T extends {keyframeDisplayOffset: number},
+>(
+	tracks: T[],
+) =>
+	tracks.map(({keyframeDisplayOffset, ...track}) => {
+		expect(keyframeDisplayOffset).toBe(0);
+		return track;
+	});
+
 test('Should calculate timeline as expected', () => {
 	const timeline = calculateTimeline({
 		sequences,
 		overrideIdsToNodePaths: {},
 	});
-	expect(timeline).toEqual([
+	expect(withoutKeyframeDisplayOffset(timeline)).toEqual([
 		{
 			nodePathInfo: null,
 			sequence: {

--- a/packages/studio/src/test/sequenced-timeline.test.ts
+++ b/packages/studio/src/test/sequenced-timeline.test.ts
@@ -4,13 +4,23 @@ import {calculateTimeline} from '../helpers/calculate-timeline';
 
 const getStack = () => null;
 
+const withoutKeyframeDisplayOffset = <
+	T extends {keyframeDisplayOffset: number},
+>(
+	tracks: T[],
+) =>
+	tracks.map(({keyframeDisplayOffset, ...track}) => {
+		expect(keyframeDisplayOffset).toBe(0);
+		return track;
+	});
+
 test('Should calculate sequences correctly', () => {
 	const timeline = calculateTimeline({
 		sequences,
 		overrideIdsToNodePaths: {},
 	});
 
-	expect(timeline).toEqual([
+	expect(withoutKeyframeDisplayOffset(timeline)).toEqual([
 		{
 			nodePathInfo: null,
 			sequence: {

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -98,10 +98,6 @@ test('keyframe display offsets follow the parent sequence context', () => {
 			throw new Error(`Could not find track ${id}`);
 		}
 
-		if (track.keyframeDisplayOffset === undefined) {
-			throw new Error(`Track ${id} has no keyframe display offset`);
-		}
-
 		return track.keyframeDisplayOffset;
 	};
 
@@ -111,7 +107,7 @@ test('keyframe display offsets follow the parent sequence context', () => {
 	expect(getOffset('grandchild')).toBe(30);
 	expect(
 		timeline.find((t) => t.sequence.id === 'parent')?.keyframeDisplayOffset,
-	).toBeUndefined();
+	).toBe(0);
 
 	expect(
 		getTimelineKeyframes(

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -1,0 +1,132 @@
+import {expect, test} from 'bun:test';
+import type {SequencePropsSubscriptionKey, TSequence} from 'remotion';
+import {getTimelineKeyframes} from '../components/Timeline/get-timeline-keyframes';
+import {calculateTimeline} from '../helpers/calculate-timeline';
+
+const getStack = () => null;
+
+const makeNodePath = (id: string): SequencePropsSubscriptionKey => ({
+	absolutePath: '/src/Composition.tsx',
+	nodePath: [id],
+	sequenceKeys: ['style.scale'],
+	effectKeys: [],
+});
+
+const makeControls = (
+	overrideId: string,
+): NonNullable<TSequence['controls']> => ({
+	schema: {},
+	currentRuntimeValueDotNotation: {},
+	overrideId,
+});
+
+const makeSequence = ({
+	id,
+	from,
+	parent = null,
+	overrideId = null,
+	nonce,
+}: {
+	id: string;
+	from: number;
+	parent?: string | null;
+	overrideId?: string | null;
+	nonce: number;
+}): TSequence => ({
+	type: 'sequence',
+	from,
+	duration: 120,
+	id,
+	displayName: id,
+	documentationLink: null,
+	parent,
+	rootId: 'root',
+	showInTimeline: true,
+	nonce: [[0, nonce]],
+	loopDisplay: undefined,
+	getStack,
+	premountDisplay: null,
+	postmountDisplay: null,
+	controls: overrideId ? makeControls(overrideId) : null,
+	effects: [],
+});
+
+test('keyframe display offsets follow the parent sequence context', () => {
+	const timeline = calculateTimeline({
+		sequences: [
+			makeSequence({
+				id: 'root-style',
+				from: 30,
+				overrideId: 'root-style',
+				nonce: 0,
+			}),
+			makeSequence({id: 'parent', from: 30, nonce: 1}),
+			makeSequence({
+				id: 'child',
+				from: 0,
+				parent: 'parent',
+				overrideId: 'child',
+				nonce: 2,
+			}),
+			makeSequence({id: 'outer', from: 10, nonce: 3}),
+			makeSequence({
+				id: 'own-from',
+				from: 20,
+				parent: 'outer',
+				overrideId: 'own-from',
+				nonce: 4,
+			}),
+			makeSequence({
+				id: 'grandchild',
+				from: 0,
+				parent: 'own-from',
+				overrideId: 'grandchild',
+				nonce: 5,
+			}),
+		],
+		overrideIdsToNodePaths: {
+			'root-style': makeNodePath('root-style'),
+			child: makeNodePath('child'),
+			'own-from': makeNodePath('own-from'),
+			grandchild: makeNodePath('grandchild'),
+		},
+	});
+
+	const getOffset = (id: string): number => {
+		const track = timeline.find((t) => t.sequence.id === id);
+		if (!track) {
+			throw new Error(`Could not find track ${id}`);
+		}
+
+		if (track.keyframeDisplayOffset === undefined) {
+			throw new Error(`Track ${id} has no keyframe display offset`);
+		}
+
+		return track.keyframeDisplayOffset;
+	};
+
+	expect(getOffset('root-style')).toBe(0);
+	expect(getOffset('child')).toBe(30);
+	expect(getOffset('own-from')).toBe(10);
+	expect(getOffset('grandchild')).toBe(30);
+	expect(
+		timeline.find((t) => t.sequence.id === 'parent')?.keyframeDisplayOffset,
+	).toBeUndefined();
+
+	expect(
+		getTimelineKeyframes(
+			{
+				canUpdate: false,
+				reason: 'computed',
+				keyframes: [
+					{frame: 0, value: 2},
+					{frame: 60, value: 4},
+				],
+			},
+			getOffset('child'),
+		),
+	).toEqual([
+		{frame: 30, value: 2},
+		{frame: 90, value: 4},
+	]);
+});

--- a/packages/studio/src/test/timeline.test.ts
+++ b/packages/studio/src/test/timeline.test.ts
@@ -3,6 +3,16 @@ import {calculateTimeline} from '../helpers/calculate-timeline';
 
 const getStack = () => null;
 
+const withoutKeyframeDisplayOffset = <
+	T extends {keyframeDisplayOffset: number},
+>(
+	tracks: T[],
+) =>
+	tracks.map(({keyframeDisplayOffset, ...track}) => {
+		expect(keyframeDisplayOffset).toBe(0);
+		return track;
+	});
+
 test('Should calculate timeline with no sequences', () => {
 	const calculated = calculateTimeline({
 		overrideIdsToNodePaths: {},
@@ -35,7 +45,7 @@ test('Should calculate a basic timeline', () => {
 			},
 		],
 	});
-	expect(calculated).toEqual([
+	expect(withoutKeyframeDisplayOffset(calculated)).toEqual([
 		{
 			nodePathInfo: null,
 			depth: 0,
@@ -104,7 +114,7 @@ test('Should follow order of nesting', () => {
 			},
 		],
 	});
-	expect(calculated).toEqual([
+	expect(withoutKeyframeDisplayOffset(calculated)).toEqual([
 		{
 			nodePathInfo: null,
 			sequence: {


### PR DESCRIPTION
Fixes #7582

## Summary
- Shift detected timeline keyframe markers by the parent Sequence runtime offset
- Keep keyframes on a Sequence's own props relative to the parent frame
- Add timeline coverage for root, child, and nested Sequence offsets

## Testing
- cd packages/studio && bun test src
- bunx turbo run make --filter='@remotion/studio'
- bun run build
- bun run formatting