### PR TITLE
`@remotion/studio-server`: Support interpolateColors keyframes

### DIFF
--- a/packages/example/src/KeyframedPropsTest.tsx
+++ b/packages/example/src/KeyframedPropsTest.tsx
@@ -5,7 +5,9 @@ import {
 	AbsoluteFill,
 	AnimatedImage,
 	interpolate,
+	interpolateColors,
 	Sequence,
+	Solid,
 	staticFile,
 	useCurrentFrame,
 } from 'remotion';
@@ -119,6 +121,19 @@ const KeyframedPropsTest: React.FC = () => {
 			</Sequence>
 			<Sequence from={30} name="effect keyframes should be shown at 30 and 90">
 				<ShiftedEffect />
+			</Sequence>
+			<Sequence
+				name="color keyframes should be shown at 0 and 100"
+				durationInFrames={120}
+			>
+				<Solid
+					width={180}
+					height={180}
+					color={interpolateColors(frame, [0, 100], ['#0b84f3', '#f43b00'])}
+					style={{
+						borderRadius: 24,
+					}}
+				/>
 			</Sequence>
 			<Sequence
 				from={30}

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -101,17 +101,18 @@ const getNumericValue = (node: Expression): number | null => {
 	return null;
 };
 
-const getInterpolateExpression = (
+const getInterpolationExpression = (
 	node: Expression,
 ): InterpolateExpression | null => {
 	if (node.type === 'TSAsExpression') {
-		return getInterpolateExpression(node.expression as Expression);
+		return getInterpolationExpression(node.expression as Expression);
 	}
 
 	if (
 		node.type !== 'CallExpression' ||
 		node.callee.type !== 'Identifier' ||
-		node.callee.name !== 'interpolate'
+		(node.callee.name !== 'interpolate' &&
+			node.callee.name !== 'interpolateColors')
 	) {
 		return null;
 	}
@@ -177,6 +178,20 @@ const getInterpolateExpression = (
 	};
 };
 
+const getInterpolationCalleeForValues = ({
+	staticValue,
+	newValue,
+}: {
+	staticValue: unknown;
+	newValue: unknown;
+}): ExpressionKind => {
+	return b.identifier(
+		typeof staticValue === 'string' && typeof newValue === 'string'
+			? 'interpolateColors'
+			: 'interpolate',
+	);
+};
+
 const createFrameExpression = (frame: number): ExpressionKind => {
 	return parseValueExpression(frame);
 };
@@ -214,7 +229,7 @@ const addKeyframe = ({
 	frame: number;
 	value: unknown;
 }): ExpressionKind => {
-	const existing = getInterpolateExpression(expression);
+	const existing = getInterpolationExpression(expression);
 	const newOutput = parseValueExpression(value);
 
 	if (existing) {
@@ -251,7 +266,10 @@ const addKeyframe = ({
 	const staticValue = extractStaticValue(expression);
 	const staticOutput = parseValueExpression(staticValue);
 	return createInterpolateExpression({
-		callee: b.identifier('interpolate'),
+		callee: getInterpolationCalleeForValues({
+			staticValue,
+			newValue: value,
+		}),
 		input: b.identifier('frame'),
 		extraArgs: [],
 		keyframes: [
@@ -268,7 +286,7 @@ const removeKeyframe = ({
 	expression: Expression;
 	frame: number;
 }): ExpressionKind => {
-	const existing = getInterpolateExpression(expression);
+	const existing = getInterpolationExpression(expression);
 	if (!existing) {
 		throw new Error('Cannot remove keyframe from non-interpolated expression');
 	}

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -140,11 +140,11 @@ const getNumericValue = (node: Expression): number | null => {
 	return null;
 };
 
-const getInterpolateKeyframes = (
+const getInterpolationKeyframes = (
 	node: Expression,
 ): PropKeyframes | undefined => {
 	if (node.type === 'TSAsExpression') {
-		return getInterpolateKeyframes(node.expression as Expression);
+		return getInterpolationKeyframes(node.expression as Expression);
 	}
 
 	if (node.type !== 'CallExpression') {
@@ -154,7 +154,8 @@ const getInterpolateKeyframes = (
 	const callExpression = node as CallExpression;
 	if (
 		callExpression.callee.type !== 'Identifier' ||
-		callExpression.callee.name !== 'interpolate'
+		(callExpression.callee.name !== 'interpolate' &&
+			callExpression.callee.name !== 'interpolateColors')
 	) {
 		return undefined;
 	}
@@ -202,7 +203,7 @@ const getInterpolateKeyframes = (
 };
 
 export const getComputedStatus = (node: Expression): CanUpdatePropStatus => {
-	const keyframes = getInterpolateKeyframes(node);
+	const keyframes = getInterpolationKeyframes(node);
 	if (!keyframes) {
 		return {canUpdate: false, reason: 'computed'};
 	}

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import {parseAst} from '../codemods/parse-ast';
 import {
 	computeSequencePropsStatus,
+	computeSequencePropsStatusFromContent,
 	lineColumnToNodePath,
 } from '../preview-server/routes/can-update-sequence-props';
 
@@ -13,6 +14,16 @@ const getNodePath = (filePath: string, line: number) => {
 	const result = lineColumnToNodePath(ast, line);
 	if (!result) {
 		throw new Error(`No JSX element found at line ${line} in ${filePath}`);
+	}
+
+	return result;
+};
+
+const getNodePathFromContent = (content: string, line: number) => {
+	const ast = parseAst(content);
+	const result = lineColumnToNodePath(ast, line);
+	if (!result) {
+		throw new Error(`No JSX element found at line ${line}`);
 	}
 
 	return result;
@@ -42,6 +53,37 @@ test('canUpdateSequenceProps should flag computed props', () => {
 	expect(result.props.nonExistentProp).toEqual({
 		canUpdate: true,
 		codeValue: undefined,
+	});
+});
+
+test('computeSequencePropsStatus should return keyframes for interpolated color props', () => {
+	const input = `import React from 'react';
+import {Solid, interpolateColors, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<Solid color={interpolateColors(frame, [0, 100], ['red', 'blue'])} width={100} height={100} />
+\t);
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 7),
+		keys: ['color'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props.color).toEqual({
+		canUpdate: false,
+		reason: 'computed',
+		keyframes: [
+			{frame: 0, value: 'red'},
+			{frame: 100, value: 'blue'},
+		],
 	});
 });
 

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -19,6 +19,17 @@ export const Example: React.FC = () => {
 };
 `;
 
+const colorInput = `import React from 'react';
+import {Solid, interpolateColors, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<Solid color={interpolateColors(frame, [0, 100], ['red', 'blue'])} width={100} height={100} />
+\t);
+};
+`;
+
 const effectInput = `import {tint} from '@remotion/effects/tint';
 import {HtmlInCanvas} from '@remotion/html-in-canvas';
 import {interpolate, useCurrentFrame} from 'remotion';
@@ -84,6 +95,48 @@ test('updateSequenceKeyframes converts a static value to an interpolation', asyn
 
 	expect(oldValueStrings).toEqual(['0.5']);
 	expect(output).toContain('opacity: interpolate(frame, [0, 25], [0.5, 0.75])');
+});
+
+test('updateSequenceKeyframes adds a keyframe to an existing color interpolation', async () => {
+	const {output, oldValueStrings} = await updateSequenceKeyframes({
+		input: colorInput,
+		nodePath: lineColumnToNodePath(colorInput, getLine(colorInput, '<Solid')),
+		updates: [
+			{
+				key: 'color',
+				operation: {type: 'add', frame: 50, value: '#00ff00'},
+			},
+		],
+	});
+
+	expect(oldValueStrings).toEqual([
+		"interpolateColors(frame, [0, 100], ['red', 'blue'])",
+	]);
+	expect(output).toContain(
+		"color={interpolateColors(frame, [0, 50, 100], ['red', '#00ff00', 'blue'])}",
+	);
+});
+
+test('updateSequenceKeyframes converts a static string value to a color interpolation', async () => {
+	const input = colorInput.replace(
+		"interpolateColors(frame, [0, 100], ['red', 'blue'])",
+		"'red'",
+	);
+	const {output, oldValueStrings} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, '<Solid')),
+		updates: [
+			{
+				key: 'color',
+				operation: {type: 'add', frame: 50, value: 'blue'},
+			},
+		],
+	});
+
+	expect(oldValueStrings).toEqual(["'red'"]);
+	expect(output).toContain(
+		"color={interpolateColors(frame, [0, 50], ['red', 'blue'])}",
+	);
 });
 
 test('updateSequenceKeyframes collapses to a static value when one keyframe remains', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #7700

## Summary
- Adds an `interpolateColors()` `<Solid>` case to the keyframed props example composition.
- Detects `interpolateColors()` calls as keyframed computed props for visual mode/timeline status.
- Updates the keyframe codemod to preserve `interpolateColors()` and emit it when adding string color keyframes.
- Adds focused Studio Server tests for color keyframe detection and codemod updates.

## Testing
- `bun test packages/studio-server/src/test/update-keyframes.test.ts packages/studio-server/src/test/compute-sequence-props-status.test.ts`
- `bun run build`
- `bun run formatting`
- `bun run stylecheck` (blocked by known `@remotion/lambda-go` Go 1.22.2 vs required Go >= 1.23.0 environment issue)
- `bunx turbo run lint formatting --filter='@remotion/studio-server' --filter='@remotion/example' --no-update-notifier`
- `bunx remotion still keyframed-props-test --frame=50 --props src/my-props.json --gl=swangle --output ../../out/keyframed-props-test-frame-50.png`

## Artifact
[Rendered keyframed interpolateColors Solid](https://cursor.com/agents/bc-2e88b4df-917a-4e06-b551-268be3bfa212/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkeyframed_props_interpolate_colors_frame_50.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e88b4df-917a-4e06-b551-268be3bfa212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e88b4df-917a-4e06-b551-268be3bfa212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

