### PR TITLE
Docs: Add Onda to resources

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -120,6 +120,7 @@ This list tries to compile all templates, libraries, building blocks and example
 ## Components
 
 - Free Remotion Animations & Effects ([Source Code](https://github.com/reactvideoeditor/remotion-templates), [Preview](https://www.reactvideoeditor.com/remotion-templates?utm_source=remotion))
+- [Onda](https://onda.video/) - Open-source Remotion component library with 70 components and 18 transitions ([Source Code](https://github.com/degueba/onda), [NPM](https://www.npmjs.com/package/ondajs))
 - [TikTok Text Box](https://github.com/KyleTryon/TikTokTextBox)
 
 ## Videos


### PR DESCRIPTION
## Summary
- add Onda to the resources page under Components
- include links to the website, source code, and npm package