### PR TITLE
`@remotion/studio-server`: Parse keyframe easing and clamping

### DIFF
--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -1,5 +1,6 @@
 import {findPropsToDelete} from './find-props-to-delete.js';
 import {getEffectiveVisualModeValue} from './get-effective-visual-mode-value.js';
+import type {ExtrapolateType} from './interpolate.js';
 import type {
 	SequenceFieldSchema,
 	SequenceSchema,
@@ -19,10 +20,21 @@ export type CanUpdateSequencePropStatusKeyframe = {
 	value: unknown;
 };
 
+export type CanUpdateSequencePropStatusEasing =
+	| 'linear'
+	| [number, number, number, number];
+
+export type CanUpdateSequencePropStatusClamping = {
+	left: ExtrapolateType;
+	right: ExtrapolateType;
+};
+
 export type CanUpdateSequencePropStatusFalse = {
 	canUpdate: false;
 	reason: 'computed';
 	keyframes?: CanUpdateSequencePropStatusKeyframe[];
+	easing?: CanUpdateSequencePropStatusEasing[];
+	clamping?: CanUpdateSequencePropStatusClamping;
 };
 
 export type CanUpdateSequencePropStatus =

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -291,8 +291,8 @@ const getInterpolationMetadata = (
 		return null;
 	}
 
-	let easing = defaults.easing;
-	let clamping: PropClamping = defaults.clamping;
+	let {easing} = defaults;
+	let {clamping}: {clamping: PropClamping} = defaults;
 
 	for (const property of optionsArg.properties) {
 		if (property.type !== 'ObjectProperty' || property.computed) {

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -16,6 +16,7 @@ import * as recast from 'recast';
 import type {
 	CanUpdateSequencePropsResponseTrue,
 	CanUpdateSequencePropStatus,
+	ExtrapolateType,
 	LogLevel,
 	SequenceNodePath,
 } from 'remotion';
@@ -28,6 +29,8 @@ import {computeEffectPropStatus} from './can-update-effect-props';
 type CanUpdatePropStatus = CanUpdateSequencePropStatus;
 type ComputedPropStatus = Extract<CanUpdatePropStatus, {canUpdate: false}>;
 type PropKeyframes = NonNullable<ComputedPropStatus['keyframes']>;
+type PropEasing = NonNullable<ComputedPropStatus['easing']>;
+type PropClamping = NonNullable<ComputedPropStatus['clamping']>;
 
 export const isStaticValue = (node: Expression): boolean => {
 	switch (node.type) {
@@ -140,9 +143,213 @@ const getNumericValue = (node: Expression): number | null => {
 	return null;
 };
 
+const getExtrapolateType = (node: Expression): ExtrapolateType | null => {
+	if (node.type === 'StringLiteral') {
+		if (
+			node.value === 'extend' ||
+			node.value === 'identity' ||
+			node.value === 'clamp' ||
+			node.value === 'wrap'
+		) {
+			return node.value;
+		}
+
+		return null;
+	}
+
+	if (node.type === 'TSAsExpression') {
+		return getExtrapolateType(node.expression as Expression);
+	}
+
+	return null;
+};
+
+const getKeyframeEasing = (node: Expression): PropEasing[number] | null => {
+	if (node.type === 'TSAsExpression') {
+		return getKeyframeEasing(node.expression as Expression);
+	}
+
+	if (
+		node.type === 'MemberExpression' &&
+		node.object.type === 'Identifier' &&
+		node.object.name === 'Easing' &&
+		node.property.type === 'Identifier' &&
+		node.property.name === 'linear' &&
+		node.computed === false
+	) {
+		return 'linear';
+	}
+
+	if (
+		node.type !== 'CallExpression' ||
+		node.callee.type !== 'MemberExpression' ||
+		node.callee.object.type !== 'Identifier' ||
+		node.callee.object.name !== 'Easing' ||
+		node.callee.property.type !== 'Identifier' ||
+		node.callee.property.name !== 'bezier' ||
+		node.callee.computed
+	) {
+		return null;
+	}
+
+	if (node.arguments.length !== 4) {
+		return null;
+	}
+
+	const values = node.arguments.map((arg) => {
+		if (
+			arg.type === 'ArgumentPlaceholder' ||
+			arg.type === 'JSXNamespacedName' ||
+			arg.type === 'SpreadElement'
+		) {
+			return null;
+		}
+
+		return getNumericValue(arg as Expression);
+	});
+
+	if (values.some((v) => v === null)) {
+		return null;
+	}
+
+	return values as [number, number, number, number];
+};
+
+const getKeyframeEasingArray = ({
+	easingNode,
+	segments,
+}: {
+	easingNode: Expression;
+	segments: number;
+}): PropEasing | null => {
+	if (segments === 0) {
+		return [];
+	}
+
+	if (easingNode.type === 'TSAsExpression') {
+		return getKeyframeEasingArray({
+			easingNode: easingNode.expression as Expression,
+			segments,
+		});
+	}
+
+	if (easingNode.type === 'ArrayExpression') {
+		if (easingNode.elements.length !== segments) {
+			return null;
+		}
+
+		const parsed = easingNode.elements.map((element) => {
+			if (!element || element.type === 'SpreadElement') {
+				return null;
+			}
+
+			return getKeyframeEasing(element);
+		});
+
+		if (parsed.some((value) => value === null)) {
+			return null;
+		}
+
+		return parsed as PropEasing;
+	}
+
+	const easing = getKeyframeEasing(easingNode);
+	if (!easing) {
+		return null;
+	}
+
+	return new Array(segments).fill(easing) as PropEasing;
+};
+
+const getInterpolationMetadata = (
+	callExpression: CallExpression,
+	keyframeCount: number,
+): {easing: PropEasing; clamping: PropClamping} | null => {
+	const segments = Math.max(0, keyframeCount - 1);
+	const defaultClamping: PropClamping = {
+		left: 'extend',
+		right: 'extend',
+	};
+	const defaults = {
+		easing: new Array(segments).fill('linear') as PropEasing,
+		clamping: defaultClamping,
+	};
+
+	if (
+		callExpression.callee.type !== 'Identifier' ||
+		callExpression.callee.name !== 'interpolate'
+	) {
+		return defaults;
+	}
+
+	const optionsArg = callExpression.arguments[3];
+	if (!optionsArg) {
+		return defaults;
+	}
+
+	if (optionsArg.type !== 'ObjectExpression') {
+		return null;
+	}
+
+	let easing = defaults.easing;
+	let clamping: PropClamping = defaults.clamping;
+
+	for (const property of optionsArg.properties) {
+		if (property.type !== 'ObjectProperty' || property.computed) {
+			return null;
+		}
+
+		const key =
+			property.key.type === 'Identifier'
+				? property.key.name
+				: property.key.type === 'StringLiteral'
+					? property.key.value
+					: null;
+
+		if (!key) {
+			return null;
+		}
+
+		const value = property.value as Expression;
+
+		if (key === 'easing') {
+			const parsedEasing = getKeyframeEasingArray({
+				easingNode: value,
+				segments,
+			});
+			if (!parsedEasing) {
+				return null;
+			}
+
+			easing = parsedEasing;
+			continue;
+		}
+
+		if (key === 'extrapolateLeft' || key === 'extrapolateRight') {
+			const extrapolateType = getExtrapolateType(value);
+			if (!extrapolateType) {
+				return null;
+			}
+
+			clamping =
+				key === 'extrapolateLeft'
+					? {...clamping, left: extrapolateType}
+					: {...clamping, right: extrapolateType};
+		}
+	}
+
+	return {easing, clamping};
+};
+
 const getInterpolationKeyframes = (
 	node: Expression,
-): PropKeyframes | undefined => {
+):
+	| {
+			keyframes: PropKeyframes;
+			easing: PropEasing;
+			clamping: PropClamping;
+	  }
+	| undefined => {
 	if (node.type === 'TSAsExpression') {
 		return getInterpolationKeyframes(node.expression as Expression);
 	}
@@ -199,19 +406,34 @@ const getInterpolationKeyframes = (
 		});
 	}
 
-	return keyframes.length > 0 ? keyframes : undefined;
+	if (keyframes.length === 0) {
+		return undefined;
+	}
+
+	const metadata = getInterpolationMetadata(callExpression, keyframes.length);
+	if (!metadata) {
+		return undefined;
+	}
+
+	return {
+		keyframes,
+		easing: metadata.easing,
+		clamping: metadata.clamping,
+	};
 };
 
 export const getComputedStatus = (node: Expression): CanUpdatePropStatus => {
-	const keyframes = getInterpolationKeyframes(node);
-	if (!keyframes) {
+	const interpolation = getInterpolationKeyframes(node);
+	if (!interpolation) {
 		return {canUpdate: false, reason: 'computed'};
 	}
 
 	return {
 		canUpdate: false,
 		reason: 'computed',
-		keyframes,
+		keyframes: interpolation.keyframes,
+		easing: interpolation.easing,
+		clamping: interpolation.clamping,
 	};
 };
 

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -266,20 +266,31 @@ const getInterpolationMetadata = (
 	keyframeCount: number,
 ): {easing: PropEasing; clamping: PropClamping} | null => {
 	const segments = Math.max(0, keyframeCount - 1);
-	const defaultClamping: PropClamping = {
-		left: 'extend',
-		right: 'extend',
-	};
+	if (callExpression.callee.type !== 'Identifier') {
+		return null;
+	}
+
+	const defaultClamping: PropClamping =
+		callExpression.callee.name === 'interpolateColors'
+			? {
+					left: 'clamp',
+					right: 'clamp',
+				}
+			: {
+					left: 'extend',
+					right: 'extend',
+				};
 	const defaults = {
 		easing: new Array(segments).fill('linear') as PropEasing,
 		clamping: defaultClamping,
 	};
 
-	if (
-		callExpression.callee.type !== 'Identifier' ||
-		callExpression.callee.name !== 'interpolate'
-	) {
+	if (callExpression.callee.name === 'interpolateColors') {
 		return defaults;
+	}
+
+	if (callExpression.callee.name !== 'interpolate') {
+		return null;
 	}
 
 	const optionsArg = callExpression.arguments[3];

--- a/packages/studio-server/src/test/compute-effect-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-effect-props-status.test.ts
@@ -84,6 +84,8 @@ test('computeEffectPropStatus reports keyframes for inline interpolated effect p
 			{frame: 0, value: 0.2},
 			{frame: 100, value: 0.8},
 		],
+		easing: ['linear'],
+		clamping: {left: 'extend', right: 'extend'},
 	});
 });
 

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -84,6 +84,8 @@ export const Example: React.FC = () => {
 			{frame: 0, value: 'red'},
 			{frame: 100, value: 'blue'},
 		],
+		easing: ['linear'],
+		clamping: {left: 'extend', right: 'extend'},
 	});
 });
 
@@ -231,5 +233,79 @@ test('computeSequencePropsStatus should return keyframes for interpolated style 
 			{frame: 0, value: 2},
 			{frame: 100, value: 4},
 		],
+		easing: ['linear'],
+		clamping: {left: 'extend', right: 'extend'},
+	});
+});
+
+test('computeSequencePropsStatus should parse easing arrays and clamping', () => {
+	const input = `import React from 'react';
+import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<Sequence style={{scale: interpolate(frame, [0, 50, 100], [1, 2, 3], {
+\t\t\teasing: [Easing.bezier(0.1, 0.2, 0.3, 0.4), Easing.linear],
+\t\t\textrapolateLeft: 'clamp',
+\t\t\textrapolateRight: 'identity',
+\t\t})}} />
+\t);
+};
+`;
+
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 7),
+		keys: ['style.scale'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.scale']).toEqual({
+		canUpdate: false,
+		reason: 'computed',
+		keyframes: [
+			{frame: 0, value: 1},
+			{frame: 50, value: 2},
+			{frame: 100, value: 3},
+		],
+		easing: [[0.1, 0.2, 0.3, 0.4], 'linear'],
+		clamping: {
+			left: 'clamp',
+			right: 'identity',
+		},
+	});
+});
+
+test('computeSequencePropsStatus should bail on unsupported easing expressions', () => {
+	const input = `import React from 'react';
+import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<Sequence style={{scale: interpolate(frame, [0, 100], [1, 3], {
+\t\t\teasing: Easing.inOut(Easing.linear),
+\t\t})}} />
+\t);
+};
+`;
+
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 7),
+		keys: ['style.scale'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.scale']).toEqual({
+		canUpdate: false,
+		reason: 'computed',
 	});
 });

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -85,7 +85,7 @@ export const Example: React.FC = () => {
 			{frame: 100, value: 'blue'},
 		],
 		easing: ['linear'],
-		clamping: {left: 'extend', right: 'extend'},
+		clamping: {left: 'clamp', right: 'clamp'},
 	});
 });
 


### PR DESCRIPTION
Closes #7709

## Summary
- parse keyframed `interpolate()` / `interpolateColors()` expressions into computed status with `keyframes`, `easing`, and `clamping`
- support easing parsing for `Easing.linear` and `Easing.bezier(a, b, c, d)` including per-segment arrays (`n - 1` entries)
- bail out to plain `computed` when easing/options are unsupported
- extend `CanUpdateSequencePropStatusFalse` with typed `easing` and `clamping` fields
- add/update studio-server tests for default metadata, parsed clamping/easing arrays, and unsupported easing fallback