### PR TITLE
`@remotion/studio`: Distinguish computed and keyframed sequence prop statuses

### DIFF
--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -29,13 +29,22 @@ export type CanUpdateSequencePropStatusClamping = {
 	right: ExtrapolateType;
 };
 
-export type CanUpdateSequencePropStatusFalse = {
+export type CanUpdateSequencePropStatusComputed = {
 	canUpdate: false;
 	reason: 'computed';
-	keyframes?: CanUpdateSequencePropStatusKeyframe[];
-	easing?: CanUpdateSequencePropStatusEasing[];
-	clamping?: CanUpdateSequencePropStatusClamping;
 };
+
+export type CanUpdateSequencePropStatusKeyframed = {
+	canUpdate: false;
+	reason: 'keyframed';
+	keyframes: CanUpdateSequencePropStatusKeyframe[];
+	easing: CanUpdateSequencePropStatusEasing[];
+	clamping: CanUpdateSequencePropStatusClamping;
+};
+
+export type CanUpdateSequencePropStatusFalse =
+	| CanUpdateSequencePropStatusComputed
+	| CanUpdateSequencePropStatusKeyframed;
 
 export type CanUpdateSequencePropStatus =
 	| CanUpdateSequencePropStatusTrue

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -28,9 +28,10 @@ import {computeEffectPropStatus} from './can-update-effect-props';
 
 type CanUpdatePropStatus = CanUpdateSequencePropStatus;
 type ComputedPropStatus = Extract<CanUpdatePropStatus, {canUpdate: false}>;
-type PropKeyframes = NonNullable<ComputedPropStatus['keyframes']>;
-type PropEasing = NonNullable<ComputedPropStatus['easing']>;
-type PropClamping = NonNullable<ComputedPropStatus['clamping']>;
+type KeyframedPropStatus = Extract<ComputedPropStatus, {reason: 'keyframed'}>;
+type PropKeyframes = KeyframedPropStatus['keyframes'];
+type PropEasing = KeyframedPropStatus['easing'];
+type PropClamping = KeyframedPropStatus['clamping'];
 
 export const isStaticValue = (node: Expression): boolean => {
 	switch (node.type) {
@@ -441,7 +442,7 @@ export const getComputedStatus = (node: Expression): CanUpdatePropStatus => {
 
 	return {
 		canUpdate: false,
-		reason: 'computed',
+		reason: 'keyframed',
 		keyframes: interpolation.keyframes,
 		easing: interpolation.easing,
 		clamping: interpolation.clamping,

--- a/packages/studio-server/src/test/compute-effect-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-effect-props-status.test.ts
@@ -79,7 +79,7 @@ test('computeEffectPropStatus reports keyframes for inline interpolated effect p
 
 	expect(result.props.amount).toEqual({
 		canUpdate: false,
-		reason: 'computed',
+		reason: 'keyframed',
 		keyframes: [
 			{frame: 0, value: 0.2},
 			{frame: 100, value: 0.8},

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -79,7 +79,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props.color).toEqual({
 		canUpdate: false,
-		reason: 'computed',
+		reason: 'keyframed',
 		keyframes: [
 			{frame: 0, value: 'red'},
 			{frame: 100, value: 'blue'},
@@ -228,7 +228,7 @@ test('computeSequencePropsStatus should return keyframes for interpolated style 
 
 	expect(result.props['style.scale']).toEqual({
 		canUpdate: false,
-		reason: 'computed',
+		reason: 'keyframed',
 		keyframes: [
 			{frame: 0, value: 2},
 			{frame: 100, value: 4},
@@ -266,7 +266,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.scale']).toEqual({
 		canUpdate: false,
-		reason: 'computed',
+		reason: 'keyframed',
 		keyframes: [
 			{frame: 0, value: 1},
 			{frame: 50, value: 2},

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -181,7 +181,10 @@ const Value: React.FC<{
 	}
 
 	if (propStatus === null || !propStatus.canUpdate) {
-		if (propStatus?.reason === 'computed') {
+		if (
+			propStatus?.reason === 'computed' ||
+			propStatus?.reason === 'keyframed'
+		) {
 			return <UnsupportedStatus label={getComputedStatusLabel(propStatus)} />;
 		}
 

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -45,15 +45,11 @@ export const TimelineNonEditableStatus: React.FC<{
 		return null;
 	}
 
-	if (propStatus.reason === 'computed') {
+	if (propStatus.reason === 'computed' || propStatus.reason === 'keyframed') {
 		return (
 			<span style={unsupportedLabel}>{getComputedStatusLabel(propStatus)}</span>
 		);
 	}
-
-	throw new Error(
-		`Unsupported prop status: ${propStatus.reason satisfies never}`,
-	);
 };
 
 export const TimelineFieldValue: React.FC<{

--- a/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
@@ -6,13 +6,11 @@ import type {
 export const getComputedStatusLabel = (
 	propStatus: CanUpdateSequencePropStatusFalse,
 ): string => {
-	if (propStatus.reason !== 'computed') {
-		throw new Error(
-			`Unsupported prop status: ${propStatus.reason satisfies never}`,
-		);
+	if (propStatus.reason === 'computed') {
+		return 'computed';
 	}
 
-	return propStatus.keyframes?.length ? 'keyframed' : 'computed';
+	return 'keyframed';
 };
 
 export const getTimelineKeyframes = (
@@ -23,13 +21,11 @@ export const getTimelineKeyframes = (
 		return [];
 	}
 
-	if (propStatus.reason !== 'computed') {
-		throw new Error(
-			`Unsupported prop status: ${propStatus.reason satisfies never}`,
-		);
+	if (propStatus.reason === 'computed') {
+		return [];
 	}
 
-	const keyframes = propStatus.keyframes ?? [];
+	const {keyframes} = propStatus;
 	if (keyframeDisplayOffset === 0) {
 		return keyframes;
 	}

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -113,11 +113,13 @@ test('keyframe display offsets follow the parent sequence context', () => {
 		getTimelineKeyframes(
 			{
 				canUpdate: false,
-				reason: 'computed',
+				reason: 'keyframed',
 				keyframes: [
 					{frame: 0, value: 2},
 					{frame: 60, value: 4},
 				],
+				easing: ['linear'],
+				clamping: {left: 'extend', right: 'extend'},
 			},
 			getOffset('child'),
 		),


### PR DESCRIPTION
## Summary
- Split non-editable sequence prop status into `computed` and `keyframed` variants
- Return `reason: 'keyframed'` when interpolation metadata is available
- Update timeline UI handling and tests to use the new discriminated cases

Closes #7713