### PR TITLE
`docs`: Fix interpolate per-segment easing anchor

### DIFF
--- a/packages/docs/docs/interpolate.mdx
+++ b/packages/docs/docs/interpolate.mdx
@@ -172,7 +172,7 @@ interpolate(frame, [0, 10, 40, 100], [0, 0.2, 0.6, 1], {
 });
 ```
 
-#### Per-segment easing (array) {#per-segment-easing-array}<AvailableFrom v="4.0.462" />
+#### Per-segment easing (array)<AvailableFrom v="4.0.462" /> {#per-segment-easing-array}
 
 You can pass an array of easing functions with **one entry per segment** between consecutive keyframes. Its length must be `inputRange.length - 1` (the same as `outputRange.length - 1`). The first easing applies between the first and second keyframe, the second easing between the second and third, and so on.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Affects #7708

## Summary
- Move the explicit Docusaurus heading ID for `Per-segment easing (array)` to the end of the heading so it is parsed as an anchor instead of rendered text.

## Testing
- `bun run build-docs`
- `python3 -c "from pathlib import Path; import re; html=Path('packages/docs/build/docs/interpolate/index.html').read_text(); m=re.search(r'<h4[^>]*id=per-segment-easing-array>.*?</h4>', html); assert m, 'heading not found'; assert '{#per-segment-easing-array}' not in m.group(0), m.group(0); print('rendered h4 has anchor id and clean visible title')"`
- `bun run build`
- `bunx turbo run lint formatting --filter=docs --no-update-notifier`

## Known warning
- `bun run stylecheck` fails in this VM at `@remotion/lambda-go#lint` because Go 1.22.2 is installed and `golang.org/x/crypto@v0.35.0` requires Go >= 1.23.0 (matches the repository's Cloud Agents caveat).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3222cb5a-19d2-4bb6-b7f7-32eec7a1e82a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3222cb5a-19d2-4bb6-b7f7-32eec7a1e82a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

