### PR TITLE
`remotion`: Allow single-keyframe interpolations

### DIFF
--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -103,8 +103,8 @@ function checkValidInputRange(arr: readonly number[]) {
 }
 
 function checkInfiniteRange(name: string, arr: readonly number[]) {
-	if (arr.length < 2) {
-		throw new Error(name + ' must have at least 2 elements');
+	if (arr.length < 1) {
+		throw new Error(name + ' must have at least 1 element');
 	}
 
 	for (const element of arr) {
@@ -212,6 +212,10 @@ export function interpolate(
 
 	if (typeof input !== 'number') {
 		throw new TypeError('Cannot interpolate an input which is not a number');
+	}
+
+	if (inputRange.length === 1) {
+		return outputRange[0];
 	}
 
 	const range = findRange(input, inputRange);

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -29,10 +29,29 @@ test('Must be the same length', () => {
 	}, /inputRange \(2\) and outputRange \(3\) must have the same length/);
 });
 
-test('Must pass at least 2 elements for input range', () => {
+test('Must pass at least 1 element for input range', () => {
 	expectToThrow(() => {
-		interpolate(1, [0], [9]);
-	}, /inputRange must have at least 2 elements/);
+		interpolate(1, [], []);
+	}, /inputRange must have at least 1 element/);
+});
+
+test('Can interpolate a single keyframe', () => {
+	expect(interpolate(-10, [20], [9])).toBe(9);
+	expect(interpolate(20, [20], [9])).toBe(9);
+	expect(interpolate(30, [20], [9])).toBe(9);
+	expect(
+		interpolate(30, [20], [9], {
+			extrapolateRight: 'identity',
+		}),
+	).toBe(9);
+});
+
+test('Easing array with one keyframe accepts no entries', () => {
+	expect(
+		interpolate(0.5, [0], [1], {
+			easing: [],
+		}),
+	).toBe(1);
 });
 
 test('Input range must be strictly monotonically non-decreasing', () => {

--- a/packages/core/src/test/interpolateColors.test.ts
+++ b/packages/core/src/test/interpolateColors.test.ts
@@ -41,6 +41,12 @@ test('Basic interpolate Colors', () => {
 	);
 });
 
+test('Can interpolate a single color keyframe', () => {
+	expect(interpolateColors(-10, [20], ['blue'])).toBe('rgba(0, 0, 255, 1)');
+	expect(interpolateColors(20, [20], ['blue'])).toBe('rgba(0, 0, 255, 1)');
+	expect(interpolateColors(30, [20], ['blue'])).toBe('rgba(0, 0, 255, 1)');
+});
+
 test('Clamp Right', () => {
 	expect(interpolateColors(2, [0, 1], ['#ffaadd', '#fabfdf'])).toBe(
 		'rgba(250, 191, 223, 1)',

--- a/packages/docs/docs/interpolate-colors.mdx
+++ b/packages/docs/docs/interpolate-colors.mdx
@@ -17,6 +17,10 @@ Takes three arguments:
 2. The range of values that you expect the input to assume.
 3. The range of output colors that you want the input to map to.
 
+`inputRange` and `outputRange` must have the same length and at least one color.
+With one color, `interpolateColors()` always returns the only output color as an `rgba` string.
+Single-color ranges are supported from <AvailableFrom v="4.0.469" inline />.
+
 ## Returns
 
 A `rgba` color string. eg: `rgba(255, 100, 12, 1)`

--- a/packages/docs/docs/interpolate.mdx
+++ b/packages/docs/docs/interpolate.mdx
@@ -118,6 +118,10 @@ Takes four arguments:
 3. The range of output values that you want the input to map to.
 4. Options object:
 
+`inputRange` and `outputRange` must have the same length and at least one value.
+With one value, `interpolate()` always returns the only output value.
+Single-value ranges are supported from <AvailableFrom v="4.0.469" inline />.
+
 ### extrapolateLeft?
 
 _Default_: `extend`
@@ -175,6 +179,7 @@ interpolate(frame, [0, 10, 40, 100], [0, 0.2, 0.6, 1], {
 #### Per-segment easing (array) {#per-segment-easing-array}<AvailableFrom v="4.0.462" />
 
 You can pass an array of easing functions with **one entry per segment** between consecutive keyframes. Its length must be `inputRange.length - 1` (the same as `outputRange.length - 1`). The first easing applies between the first and second keyframe, the second easing between the second and third, and so on.
+For a single keyframe, pass an empty array.
 
 ```ts twoslash
 import {useCurrentFrame} from 'remotion';

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -257,14 +257,16 @@ const addKeyframe = ({
 		throw new Error('Cannot add keyframe to computed expression');
 	}
 
-	if (frame === 0) {
-		throw new Error(
-			'Cannot add keyframe to static expression at frame 0 because interpolate requires two distinct frames',
-		);
-	}
-
 	const staticValue = extractStaticValue(expression);
 	const staticOutput = parseValueExpression(staticValue);
+	const keyframes: InterpolateKeyframe[] =
+		frame === 0
+			? [{frame, output: newOutput, value}]
+			: [
+					{frame: 0, output: staticOutput, value: staticValue},
+					{frame, output: newOutput, value},
+				];
+
 	return createInterpolateExpression({
 		callee: getInterpolationCalleeForValues({
 			staticValue,
@@ -272,10 +274,7 @@ const addKeyframe = ({
 		}),
 		input: b.identifier('frame'),
 		extraArgs: [],
-		keyframes: [
-			{frame: 0, output: staticOutput, value: staticValue},
-			{frame, output: newOutput, value},
-		],
+		keyframes,
 	});
 };
 
@@ -301,9 +300,6 @@ const removeKeyframe = ({
 	const nextKeyframes = existing.keyframes.filter(
 		(_keyframe, index) => index !== keyframeIndex,
 	);
-	if (nextKeyframes.length === 1) {
-		return parseValueExpression(nextKeyframes[0].value);
-	}
 
 	return createInterpolateExpression({
 		callee: existing.callee,

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -97,6 +97,25 @@ test('updateSequenceKeyframes converts a static value to an interpolation', asyn
 	expect(output).toContain('opacity: interpolate(frame, [0, 25], [0.5, 0.75])');
 });
 
+test('updateSequenceKeyframes converts a static value to a single-keyframe interpolation at frame 0', async () => {
+	const {output, oldValueStrings} = await updateSequenceKeyframes({
+		input: sequenceInput,
+		nodePath: lineColumnToNodePath(
+			sequenceInput,
+			getLine(sequenceInput, 'opacity'),
+		),
+		updates: [
+			{
+				key: 'style.opacity',
+				operation: {type: 'add', frame: 0, value: 0.75},
+			},
+		],
+	});
+
+	expect(oldValueStrings).toEqual(['0.5']);
+	expect(output).toContain('opacity: interpolate(frame, [0], [0.75])');
+});
+
 test('updateSequenceKeyframes adds a keyframe to an existing color interpolation', async () => {
 	const {output, oldValueStrings} = await updateSequenceKeyframes({
 		input: colorInput,
@@ -139,7 +158,7 @@ test('updateSequenceKeyframes converts a static string value to a color interpol
 	);
 });
 
-test('updateSequenceKeyframes collapses to a static value when one keyframe remains', async () => {
+test('updateSequenceKeyframes keeps an interpolation when one keyframe remains', async () => {
 	const {output, oldValueStrings} = await updateSequenceKeyframes({
 		input: sequenceInput,
 		nodePath: lineColumnToNodePath(
@@ -155,8 +174,25 @@ test('updateSequenceKeyframes collapses to a static value when one keyframe rema
 	});
 
 	expect(oldValueStrings).toEqual(['interpolate(frame, [0, 100], [2, 4])']);
-	expect(output).toContain('style={{scale: 4}}');
-	expect(output).not.toContain('scale: interpolate');
+	expect(output).toContain('style={{scale: interpolate(frame, [100], [4])}}');
+});
+
+test('updateSequenceKeyframes keeps a color interpolation when one keyframe remains', async () => {
+	const {output, oldValueStrings} = await updateSequenceKeyframes({
+		input: colorInput,
+		nodePath: lineColumnToNodePath(colorInput, getLine(colorInput, '<Solid')),
+		updates: [
+			{
+				key: 'color',
+				operation: {type: 'remove', frame: 0},
+			},
+		],
+	});
+
+	expect(oldValueStrings).toEqual([
+		"interpolateColors(frame, [0, 100], ['red', 'blue'])",
+	]);
+	expect(output).toContain("color={interpolateColors(frame, [100], ['blue'])}");
 });
 
 test('updateEffectKeyframes removes a keyframe from an effect prop interpolation', () => {
@@ -184,7 +220,7 @@ test('updateEffectKeyframes removes a keyframe from an effect prop interpolation
 	);
 });
 
-test('updateEffectKeyframes collapses an effect prop to a static value', () => {
+test('updateEffectKeyframes keeps an effect prop interpolation with one keyframe', () => {
 	const input = effectInput.replace(
 		'interpolate(frame, [0, 50, 100], [0.2, 0.5, 0.8])',
 		'interpolate(frame, [0, 100], [0.2, 0.8])',
@@ -204,6 +240,5 @@ test('updateEffectKeyframes collapses an effect prop to a static value', () => {
 		],
 	});
 
-	expect(serialized).toContain('amount: 0.2');
-	expect(serialized).not.toContain('amount: interpolate');
+	expect(serialized).toContain('amount: interpolate(frame, [0], [0.2])');
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Closes #7717.
- Keep one-keyframe `interpolate()` and `interpolateColors()` expressions when Studio removes the second-to-last keyframe.
- Allow core interpolation helpers to return a constant value for single-entry ranges.
- Document single-entry interpolation ranges.

## Testing
- `bun test src/test/interpolate.test.ts src/test/interpolateColors.test.ts` in `packages/core`
- `bun test src/test/update-keyframes.test.ts` in `packages/studio-server`
- `bun run build`
- `bunx turbo run lint formatting --filter='remotion' --filter='@remotion/studio-server' --filter='docs' --no-update-notifier`
- `bun run build-docs`

## Notes
- `bun run stylecheck` was also attempted and failed only on the known `@remotion/lambda-go` Go version caveat (`go1.22.2`, dependency requires `go >= 1.23.0`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6df81df9-97e4-4d70-a872-b41b838e2ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6df81df9-97e4-4d70-a872-b41b838e2ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

