### PR TITLE
Internal: Update PR skill body file guidance

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -24,3 +24,14 @@ Commit the changes. The title of the PR must be according to the [`pr-name`](../
 
 Push the changes to the remote branch.  
 Use the `gh` CLI to create a pull request and use the same format as above for the title.
+
+When creating the PR, do not pass the PR body inline through a shell command (for example, avoid `--body "..."` or heredocs in `bash`). Instead:
+
+1. Write the PR body to a temporary Markdown file in the system temp directory (for example `/tmp/remotion-pr-body.md`, or a unique file created under `/tmp`).
+2. Create the PR with `gh pr create --title "<title>" --body-file <path-to-temp-md-file>`.
+
+Example:
+
+```bash
+gh pr create --title '`@remotion/package`: Add feature' --body-file /tmp/remotion-pr-body.md
+```


### PR DESCRIPTION
## Summary

- Update the PR skill to recommend writing PR bodies to a temporary Markdown file.
- Instruct agents to use `gh pr create --body-file` instead of passing body text inline.
- Include a safe example that preserves literal backticks in the PR title.

## Testing

- `bun run build` *(fails: `tsgo: command not found`)*
- `bun run formatting` *(fails: `oxfmt: command not found`)*
