### PR TITLE
`@remotion/effects`: Keep halftone linear gradient background

### DIFF
--- a/packages/docs/docs/effects/halftone-linear-gradient.mdx
+++ b/packages/docs/docs/effects/halftone-linear-gradient.mdx
@@ -114,7 +114,7 @@ Controls how dots are colored. Defaults to `'solid'`.
 
 Allowed values are `'solid'` and `'source'`.
 
-When set to `'solid'`, each dot uses `dotColor`. When set to `'source'`, each dot uses the sampled source color at the grid cell.
+When set to `'solid'`, each dot uses `dotColor` and is composited over the previous effect in the chain. When set to `'source'`, each dot uses the sampled source color at the grid cell.
 
 If `colorMode` is `'source'`, don't pass `dotColor`.
 

--- a/packages/effects/src/halftone-linear-gradient.ts
+++ b/packages/effects/src/halftone-linear-gradient.ts
@@ -276,6 +276,10 @@ float gradientProgress(vec2 uv) {
 	return clamp(dot(uv - uFirstStopPosition, stopVector) / stopDistance, 0.0, 1.0);
 }
 
+vec4 sourceOver(vec4 backdrop, vec4 overlay) {
+	return overlay + backdrop * (1.0 - overlay.a);
+}
+
 void main() {
 	vec2 fragPos = vUv * uResolution;
 	vec2 center = uResolution * 0.5;
@@ -303,7 +307,8 @@ void main() {
 
 	vec2 sampleUv = clamp(centerUv, vec2(0.0), vec2(1.0));
 	vec4 texColor = texture(uSource, sampleUv);
-	fragColor = (uUseSourceColor ? texColor : uColor) * coverage;
+	vec4 dotColor = (uUseSourceColor ? texColor : uColor) * coverage;
+	fragColor = uUseSourceColor ? dotColor : sourceOver(texColor, dotColor);
 }
 `;
 


### PR DESCRIPTION
Fixes #7734.

In solid color mode, `halftoneLinearGradient()` now composites dots over the incoming source instead of clearing the background between dots.

Validated with `bun run build`, `bun run formatting`, `bun test src/test/effect-params.test.ts`, and `bunx turbo make --filter="@remotion/effects"`.
