### PR TITLE
`@remotion/studio`: Allow selecting timeline items (behind flag)

### DIFF
--- a/packages/example/src/KeyframedPropsTest.tsx
+++ b/packages/example/src/KeyframedPropsTest.tsx
@@ -100,6 +100,7 @@ const KeyframedPropsTest: React.FC = () => {
 				name="keyframes should be shown at 0 and 100"
 				durationInFrames={120}
 				style={{scale: interpolate(frame, [0, 100], [2, 4])}}
+				hidden
 			>
 				<div
 					style={{
@@ -110,10 +111,14 @@ const KeyframedPropsTest: React.FC = () => {
 					}}
 				/>
 			</Sequence>
-			<Sequence from={30} name="keyframes should be shown at 30 and 90">
+			<Sequence from={30} name="keyframes should be shown at 30 and 90" hidden>
 				<Shifted />
 			</Sequence>
-			<Sequence from={30} name="nested keyframes should be shown at 50 and 110">
+			<Sequence
+				from={30}
+				name="nested keyframes should be shown at 50 and 110"
+				hidden
+			>
 				<NestedShifted />
 			</Sequence>
 			<Sequence from={30}>

--- a/packages/example/src/KeyframedPropsTest.tsx
+++ b/packages/example/src/KeyframedPropsTest.tsx
@@ -100,7 +100,6 @@ const KeyframedPropsTest: React.FC = () => {
 				name="keyframes should be shown at 0 and 100"
 				durationInFrames={120}
 				style={{scale: interpolate(frame, [0, 100], [2, 4])}}
-				hidden
 			>
 				<div
 					style={{
@@ -111,14 +110,10 @@ const KeyframedPropsTest: React.FC = () => {
 					}}
 				/>
 			</Sequence>
-			<Sequence from={30} name="keyframes should be shown at 30 and 90" hidden>
+			<Sequence from={30} name="keyframes should be shown at 30 and 90">
 				<Shifted />
 			</Sequence>
-			<Sequence
-				from={30}
-				name="nested keyframes should be shown at 50 and 110"
-				hidden
-			>
+			<Sequence from={30} name="nested keyframes should be shown at 50 and 110">
 				<NestedShifted />
 			</Sequence>
 			<Sequence from={30}>

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -241,7 +241,7 @@ export const CompositionSelectorItem: React.FC<{
 	}
 
 	return (
-		<ContextMenu values={contextMenu}>
+		<ContextMenu values={contextMenu} onOpen={null}>
 			<Row align="center">
 				<a
 					ref={compositionRowRef}

--- a/packages/studio/src/components/ContextMenu.tsx
+++ b/packages/studio/src/components/ContextMenu.tsx
@@ -28,7 +28,8 @@ type OpenState =
 export const ContextMenu: React.FC<{
 	readonly children: React.ReactNode;
 	readonly values: ComboboxValue[];
-}> = ({children, values}) => {
+	readonly onOpen?: () => void;
+}> = ({children, values, onOpen}) => {
 	const ref = useRef<HTMLDivElement>(null);
 	const [opened, setOpened] = useState<OpenState>({type: 'not-open'});
 	const {currentZIndex} = useZIndex();
@@ -52,6 +53,7 @@ export const ContextMenu: React.FC<{
 		const onClick = (e: MouseEvent) => {
 			e.preventDefault();
 			e.stopPropagation();
+			onOpen?.();
 			setOpened({type: 'open', left: e.clientX, top: e.clientY});
 
 			return false;
@@ -62,7 +64,7 @@ export const ContextMenu: React.FC<{
 		return () => {
 			current.removeEventListener('contextmenu', onClick);
 		};
-	}, [size]);
+	}, [onOpen, size]);
 
 	const spaceToBottom = useMemo(() => {
 		if (size && opened.type === 'open') {

--- a/packages/studio/src/components/ContextMenu.tsx
+++ b/packages/studio/src/components/ContextMenu.tsx
@@ -28,7 +28,7 @@ type OpenState =
 export const ContextMenu: React.FC<{
 	readonly children: React.ReactNode;
 	readonly values: ComboboxValue[];
-	readonly onOpen?: () => void;
+	readonly onOpen: (() => void) | null;
 }> = ({children, values, onOpen}) => {
 	const ref = useRef<HTMLDivElement>(null);
 	const [opened, setOpened] = useState<OpenState>({type: 'not-open'});

--- a/packages/studio/src/components/EditorGuides/Guide.tsx
+++ b/packages/studio/src/components/EditorGuides/Guide.tsx
@@ -114,7 +114,7 @@ const GuideComp: React.FC<{
 	}, [guide.id, setGuidesList]);
 
 	return (
-		<ContextMenu values={values}>
+		<ContextMenu values={values} onOpen={null}>
 			<div
 				style={guideStyle}
 				onMouseDown={onMouseDown}

--- a/packages/studio/src/components/ExpandedTracksProvider.tsx
+++ b/packages/studio/src/components/ExpandedTracksProvider.tsx
@@ -1,4 +1,3 @@
-import {stringifySequenceExpandedRowKey} from '@remotion/studio-shared';
 import React, {createContext, useCallback, useMemo, useState} from 'react';
 import type {SequencePropsSubscriptionKey} from 'remotion';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
@@ -8,13 +7,7 @@ import {
 	persistBooleanMap,
 	toggleBooleanMapKey,
 } from '../helpers/persist-boolean-map';
-
-const nodePathInfoToExpandedKey = (info: SequenceNodePathInfo): string =>
-	[
-		stringifySequenceExpandedRowKey(info.sequenceSubscriptionKey),
-		info.auxiliaryKeys.join('.'),
-		info.index,
-	].join('.');
+import {timelineNodePathInfoToKey} from '../helpers/timeline-node-path-key';
 
 const SESSION_STORAGE_KEY = 'remotion.editor.expandedTracks';
 
@@ -61,7 +54,7 @@ export const ExpandedTracksProvider: React.FC<{
 
 	const toggleTrack = useCallback((nodePathInfo: SequenceNodePathInfo) => {
 		setExpandedTracks((prev) => {
-			const key = nodePathInfoToExpandedKey(nodePathInfo);
+			const key = timelineNodePathInfoToKey(nodePathInfo);
 			const next = toggleBooleanMapKey(prev, key);
 			persistBooleanMap(SESSION_STORAGE_KEY, next);
 			return next;
@@ -93,7 +86,7 @@ export const ExpandedTracksProvider: React.FC<{
 	const getterValue = useMemo(
 		(): ExpandedTracksGetterContextValue => ({
 			getIsExpanded: (nodePathInfo) =>
-				expandedTracks[nodePathInfoToExpandedKey(nodePathInfo)] ?? false,
+				expandedTracks[timelineNodePathInfoToKey(nodePathInfo)] ?? false,
 		}),
 		[expandedTracks],
 	);

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -21,6 +21,7 @@ import {TimelineList} from './TimelineList';
 import {TimelinePinchZoom} from './TimelinePinchZoom';
 import {TimelinePlayCursorSyncer} from './TimelinePlayCursorSyncer';
 import {TimelineScrollable} from './TimelineScrollable';
+import {TimelineSelectionProvider} from './TimelineSelection';
 import {TimelineSlider} from './TimelineSlider';
 import {
 	TimelineTimeIndicators,
@@ -87,56 +88,58 @@ const TimelineInner: React.FC = () => {
 			style={container}
 			className={'css-reset ' + VERTICAL_SCROLLBAR_CLASSNAME}
 		>
-			{sequences.map((sequence) => {
-				if (!sequence.controls || !previewConnected || !sequence.getStack()) {
-					return null;
-				}
+			<TimelineSelectionProvider>
+				{sequences.map((sequence) => {
+					if (!sequence.controls || !previewConnected || !sequence.getStack()) {
+						return null;
+					}
 
-				return (
-					<SubscribeToNodePaths
-						key={sequence.id}
-						overrideId={sequence.controls.overrideId}
-						schema={sequence.controls.schema}
-						getStack={sequence.getStack}
-						effects={sequence.effects}
-					/>
-				);
-			})}
-			<SequencePropsObserver />
-			<TimelineHeightContainer shown={shown} hasBeenCut={hasBeenCut}>
-				{isStill ? (
-					<TimelineList timeline={shown} />
-				) : (
-					<TimelineWidthProvider>
-						<TimelinePinchZoom />
-						<SplitterContainer
-							orientation="vertical"
-							defaultFlex={0.2}
-							id="names-to-timeline"
-							maxFlex={0.5}
-							minFlex={0.15}
-						>
-							<SplitterElement
-								type="flexer"
-								sticky={<TimelineTimePlaceholders />}
+					return (
+						<SubscribeToNodePaths
+							key={sequence.id}
+							overrideId={sequence.controls.overrideId}
+							schema={sequence.controls.schema}
+							getStack={sequence.getStack}
+							effects={sequence.effects}
+						/>
+					);
+				})}
+				<SequencePropsObserver />
+				<TimelineHeightContainer shown={shown} hasBeenCut={hasBeenCut}>
+					{isStill ? (
+						<TimelineList timeline={shown} />
+					) : (
+						<TimelineWidthProvider>
+							<TimelinePinchZoom />
+							<SplitterContainer
+								orientation="vertical"
+								defaultFlex={0.2}
+								id="names-to-timeline"
+								maxFlex={0.5}
+								minFlex={0.15}
 							>
-								<TimelineList timeline={shown} />
-							</SplitterElement>
-							<SplitterHandle onCollapse={noop} allowToCollapse="none" />
-							<SplitterElement type="anti-flexer" sticky={null}>
-								<TimelineScrollable>
-									<TimelineTracks timeline={shown} hasBeenCut={hasBeenCut} />
-									<TimelineInOutPointer />
-									<TimelinePlayCursorSyncer />
-									<TimelineDragHandler />
-									<TimelineTimeIndicators />
-									<TimelineSlider />
-								</TimelineScrollable>
-							</SplitterElement>
-						</SplitterContainer>
-					</TimelineWidthProvider>
-				)}
-			</TimelineHeightContainer>
+								<SplitterElement
+									type="flexer"
+									sticky={<TimelineTimePlaceholders />}
+								>
+									<TimelineList timeline={shown} />
+								</SplitterElement>
+								<SplitterHandle onCollapse={noop} allowToCollapse="none" />
+								<SplitterElement type="anti-flexer" sticky={null}>
+									<TimelineScrollable>
+										<TimelineTracks timeline={shown} hasBeenCut={hasBeenCut} />
+										<TimelineInOutPointer />
+										<TimelinePlayCursorSyncer />
+										<TimelineDragHandler />
+										<TimelineTimeIndicators />
+										<TimelineSlider />
+									</TimelineScrollable>
+								</SplitterElement>
+							</SplitterContainer>
+						</TimelineWidthProvider>
+					)}
+				</TimelineHeightContainer>
+			</TimelineSelectionProvider>
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -600,7 +600,7 @@ const TimelineDragHandlerInner: React.FC = () => {
 		<div style={style} onPointerDown={onPointerDown}>
 			<div style={inner} className={VERTICAL_SCROLLBAR_CLASSNAME} />
 			{inFrame !== null && (
-				<ContextMenu values={inContextMenu}>
+				<ContextMenu values={inContextMenu} onOpen={null}>
 					<TimelineInOutPointerHandle
 						type="in"
 						atFrame={inFrame}
@@ -609,7 +609,7 @@ const TimelineDragHandlerInner: React.FC = () => {
 				</ContextMenu>
 			)}
 			{outFrame !== null && (
-				<ContextMenu values={outContextMenu}>
+				<ContextMenu values={outContextMenu} onOpen={null}>
 					<TimelineInOutPointerHandle
 						type="out"
 						dragging={inOutDragging.dragging === 'out'}

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -16,11 +16,19 @@ import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {TimelineFieldValue, UnsupportedStatus} from './TimelineSchemaField';
 import {
-	TIMELINE_SELECTED_TEXT,
+	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	TIMELINE_SELECTED_LABEL_TEXT,
 	useTimelineRowSelection,
 } from './TimelineSelection';
 
-const fieldRowBase: React.CSSProperties = {
+const fieldRowBase: React.CSSProperties = {};
+
+const valueColumnStyle: React.CSSProperties = {
+	alignItems: 'center',
+	alignSelf: 'stretch',
+	display: 'flex',
+	flex: 1,
+	minWidth: 0,
 	paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 };
 
@@ -231,14 +239,22 @@ export const TimelineEffectFieldRow: React.FC<{
 	}, [field.rowHeight]);
 
 	const labelRowStyle = useMemo(
-		() => getTimelineFieldLabelRowStyle(rowDepth),
-		[rowDepth],
+		(): React.CSSProperties => ({
+			...getTimelineFieldLabelRowStyle(rowDepth),
+			alignSelf: 'stretch',
+			backgroundColor: selection.selected
+				? TIMELINE_SELECTED_LABEL_BACKGROUND
+				: undefined,
+		}),
+		[rowDepth, selection.selected],
 	);
 
 	const fieldNameStyle = useMemo(
 		(): React.CSSProperties => ({
 			...fieldName,
-			color: selection.selected ? TIMELINE_SELECTED_TEXT : fieldName.color,
+			color: selection.selected
+				? TIMELINE_SELECTED_LABEL_TEXT
+				: fieldName.color,
 		}),
 		[selection.selected],
 	);
@@ -256,11 +272,13 @@ export const TimelineEffectFieldRow: React.FC<{
 			<div style={labelRowStyle}>
 				<span style={fieldNameStyle}>{field.description ?? field.key}</span>
 			</div>
-			<Value
-				field={field}
-				nodePath={nodePath}
-				validatedLocation={validatedLocation}
-			/>
+			<div style={valueColumnStyle}>
+				<Value
+					field={field}
+					nodePath={nodePath}
+					validatedLocation={validatedLocation}
+				/>
+			</div>
 		</TimelineRowChrome>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -4,6 +4,7 @@ import type {SequencePropsSubscriptionKey} from 'remotion';
 import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import type {EffectSchemaFieldInfo} from '../../helpers/timeline-layout';
 import {EXPANDED_SECTION_PADDING_RIGHT} from '../../helpers/timeline-layout';
 import {callApi} from '../call-api';
@@ -14,6 +15,10 @@ import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {TimelineFieldValue, UnsupportedStatus} from './TimelineSchemaField';
+import {
+	TIMELINE_SELECTED_TEXT,
+	useTimelineRowSelection,
+} from './TimelineSelection';
 
 const fieldRowBase: React.CSSProperties = {
 	paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
@@ -215,7 +220,9 @@ export const TimelineEffectFieldRow: React.FC<{
 	readonly validatedLocation: CodePosition;
 	readonly rowDepth: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
-}> = ({field, validatedLocation, rowDepth, nodePath}) => {
+	readonly nodePathInfo: SequenceNodePathInfo;
+}> = ({field, validatedLocation, rowDepth, nodePath, nodePathInfo}) => {
+	const selection = useTimelineRowSelection(nodePathInfo);
 	const style = useMemo(() => {
 		return {
 			...fieldRowBase,
@@ -228,15 +235,26 @@ export const TimelineEffectFieldRow: React.FC<{
 		[rowDepth],
 	);
 
+	const fieldNameStyle = useMemo(
+		(): React.CSSProperties => ({
+			...fieldName,
+			color: selection.selected ? TIMELINE_SELECTED_TEXT : fieldName.color,
+		}),
+		[selection.selected],
+	);
+
 	return (
 		<TimelineRowChrome
 			depth={rowDepth}
 			eye={<TimelineLayerEyeSpacer />}
 			arrow={<TimelineExpandArrowSpacer />}
 			style={style}
+			selected={selection.selected}
+			selectable={selection.selectable}
+			onSelect={selection.onSelect}
 		>
 			<div style={labelRowStyle}>
-				<span style={fieldName}>{field.description ?? field.key}</span>
+				<span style={fieldNameStyle}>{field.description ?? field.key}</span>
 			</div>
 			<Value
 				field={field}

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -16,7 +16,7 @@ import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {TimelineFieldValue, UnsupportedStatus} from './TimelineSchemaField';
 import {
-	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	getTimelineSelectedLabelStyle,
 	TIMELINE_SELECTED_LABEL_TEXT,
 	useTimelineRowSelection,
 } from './TimelineSelection';
@@ -241,10 +241,8 @@ export const TimelineEffectFieldRow: React.FC<{
 	const labelRowStyle = useMemo(
 		(): React.CSSProperties => ({
 			...getTimelineFieldLabelRowStyle(rowDepth),
+			...getTimelineSelectedLabelStyle(selection.selected),
 			alignSelf: 'stretch',
-			backgroundColor: selection.selected
-				? TIMELINE_SELECTED_LABEL_BACKGROUND
-				: undefined,
 		}),
 		[rowDepth, selection.selected],
 	);

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -266,6 +266,7 @@ export const TimelineEffectFieldRow: React.FC<{
 			selected={selection.selected}
 			selectable={selection.selectable}
 			onSelect={selection.onSelect}
+			showSelectedBackground
 		>
 			<div style={labelRowStyle}>
 				<span style={fieldNameStyle}>{field.description ?? field.key}</span>

--- a/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
@@ -18,7 +18,8 @@ import {TimelineExpandArrowButton} from './TimelineExpandArrowButton';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {
-	TIMELINE_SELECTED_TEXT,
+	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	TIMELINE_SELECTED_LABEL_TEXT,
 	useTimelineRowSelection,
 } from './TimelineSelection';
 
@@ -178,7 +179,6 @@ export const TimelineEffectGroupRow: React.FC<{
 	const rowStyle = useMemo(
 		(): React.CSSProperties => ({
 			height: TREE_GROUP_ROW_HEIGHT,
-			paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 		}),
 		[],
 	);
@@ -187,7 +187,16 @@ export const TimelineEffectGroupRow: React.FC<{
 		const hoverEffect = labelHovered && documentationLink !== null;
 		return {
 			...rowLabel,
-			color: selection.selected ? TIMELINE_SELECTED_TEXT : rowLabel.color,
+			alignSelf: 'stretch',
+			alignItems: 'center',
+			backgroundColor: selection.selected
+				? TIMELINE_SELECTED_LABEL_BACKGROUND
+				: undefined,
+			color: selection.selected ? TIMELINE_SELECTED_LABEL_TEXT : rowLabel.color,
+			display: 'flex',
+			flex: 1,
+			minWidth: 0,
+			paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 			textDecoration: hoverEffect ? 'underline' : 'none',
 			textUnderlineOffset: 2,
 			cursor: hoverEffect ? 'pointer' : undefined,
@@ -244,7 +253,12 @@ export const TimelineEffectGroupRow: React.FC<{
 	);
 
 	return previewConnected ? (
-		<ContextMenu values={contextMenuValues}>{row}</ContextMenu>
+		<ContextMenu
+			values={contextMenuValues}
+			onOpen={selection.selectable ? selection.onSelect : undefined}
+		>
+			{row}
+		</ContextMenu>
 	) : (
 		row
 	);

--- a/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
@@ -18,7 +18,7 @@ import {TimelineExpandArrowButton} from './TimelineExpandArrowButton';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {
-	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	getTimelineSelectedLabelStyle,
 	TIMELINE_SELECTED_LABEL_TEXT,
 	useTimelineRowSelection,
 } from './TimelineSelection';
@@ -187,11 +187,9 @@ export const TimelineEffectGroupRow: React.FC<{
 		const hoverEffect = labelHovered && documentationLink !== null;
 		return {
 			...rowLabel,
+			...getTimelineSelectedLabelStyle(selection.selected),
 			alignSelf: 'stretch',
 			alignItems: 'center',
-			backgroundColor: selection.selected
-				? TIMELINE_SELECTED_LABEL_BACKGROUND
-				: undefined,
 			color: selection.selected ? TIMELINE_SELECTED_LABEL_TEXT : rowLabel.color,
 			display: 'flex',
 			flex: 1,

--- a/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
@@ -17,6 +17,10 @@ import {saveEffectProp} from './save-effect-prop';
 import {TimelineExpandArrowButton} from './TimelineExpandArrowButton';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
+import {
+	TIMELINE_SELECTED_TEXT,
+	useTimelineRowSelection,
+} from './TimelineSelection';
 
 const rowLabel: React.CSSProperties = {
 	fontSize: 12,
@@ -52,6 +56,7 @@ export const TimelineEffectGroupRow: React.FC<{
 	const previewConnected = previewServerState.type === 'connected';
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const selection = useTimelineRowSelection(nodePathInfo);
 
 	const effectStatus = useMemo(
 		() =>
@@ -182,11 +187,12 @@ export const TimelineEffectGroupRow: React.FC<{
 		const hoverEffect = labelHovered && documentationLink !== null;
 		return {
 			...rowLabel,
+			color: selection.selected ? TIMELINE_SELECTED_TEXT : rowLabel.color,
 			textDecoration: hoverEffect ? 'underline' : 'none',
 			textUnderlineOffset: 2,
 			cursor: hoverEffect ? 'pointer' : undefined,
 		};
-	}, [documentationLink, labelHovered]);
+	}, [documentationLink, labelHovered, selection.selected]);
 
 	const onClickLabel = useCallback(() => {
 		if (documentationLink === null) {
@@ -219,6 +225,9 @@ export const TimelineEffectGroupRow: React.FC<{
 				/>
 			}
 			style={rowStyle}
+			selected={selection.selected}
+			selectable={selection.selectable}
+			onSelect={selection.onSelect}
 		>
 			<span
 				onPointerEnter={() => setLabelHovered(true)}

--- a/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectGroupRow.tsx
@@ -235,6 +235,7 @@ export const TimelineEffectGroupRow: React.FC<{
 			selected={selection.selected}
 			selectable={selection.selectable}
 			onSelect={selection.onSelect}
+			showSelectedBackground
 		>
 			<span
 				onPointerEnter={() => setLabelHovered(true)}
@@ -253,7 +254,7 @@ export const TimelineEffectGroupRow: React.FC<{
 	return previewConnected ? (
 		<ContextMenu
 			values={contextMenuValues}
-			onOpen={selection.selectable ? selection.onSelect : undefined}
+			onOpen={selection.selectable ? selection.onSelect : null}
 		>
 			{row}
 		</ContextMenu>

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -104,6 +104,7 @@ export const TimelineExpandedRow: React.FC<{
 				selected={selection.selected}
 				selectable={selection.selectable}
 				onSelect={selection.onSelect}
+				showSelectedBackground
 			>
 				<span style={labelStyle}>{node.label}</span>
 			</TimelineRowChrome>
@@ -152,6 +153,7 @@ export const TimelineExpandedRow: React.FC<{
 			selected={selection.selected}
 			selectable={selection.selectable}
 			onSelect={selection.onSelect}
+			showSelectedBackground
 		>
 			<span style={labelStyle}>{node.label}</span>
 		</TimelineRowChrome>

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -19,6 +19,10 @@ import {
 import {TimelineFieldRow} from './TimelineFieldRow';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
+import {
+	TIMELINE_SELECTED_TEXT,
+	useTimelineRowSelection,
+} from './TimelineSelection';
 
 const rowLabel: React.CSSProperties = {
 	fontSize: 12,
@@ -46,6 +50,14 @@ export const TimelineExpandedRow: React.FC<{
 	schema,
 }) => {
 	const rowDepth = getExpandedRowDepth({nestedDepth, treeDepth: depth});
+	const selection = useTimelineRowSelection(node.nodePathInfo);
+	const labelStyle = React.useMemo(
+		(): React.CSSProperties => ({
+			...rowLabel,
+			color: selection.selected ? TIMELINE_SELECTED_TEXT : rowLabel.color,
+		}),
+		[selection.selected],
+	);
 
 	if (node.kind === 'group') {
 		if (node.effectInfo) {
@@ -82,8 +94,11 @@ export const TimelineExpandedRow: React.FC<{
 					height: TREE_GROUP_ROW_HEIGHT,
 					paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 				}}
+				selected={selection.selected}
+				selectable={selection.selectable}
+				onSelect={selection.onSelect}
 			>
-				<span style={rowLabel}>{node.label}</span>
+				<span style={labelStyle}>{node.label}</span>
 			</TimelineRowChrome>
 		);
 	}
@@ -96,6 +111,7 @@ export const TimelineExpandedRow: React.FC<{
 					validatedLocation={validatedLocation}
 					rowDepth={rowDepth}
 					nodePath={nodePath}
+					nodePathInfo={node.nodePathInfo}
 				/>
 			);
 		}
@@ -107,6 +123,7 @@ export const TimelineExpandedRow: React.FC<{
 					validatedLocation={validatedLocation}
 					rowDepth={rowDepth}
 					nodePath={nodePath}
+					nodePathInfo={node.nodePathInfo}
 					schema={schema}
 				/>
 			);
@@ -126,8 +143,11 @@ export const TimelineExpandedRow: React.FC<{
 				height: getTreeRowHeight(node),
 				paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 			}}
+			selected={selection.selected}
+			selectable={selection.selectable}
+			onSelect={selection.onSelect}
 		>
-			<span style={rowLabel}>{node.label}</span>
+			<span style={labelStyle}>{node.label}</span>
 		</TimelineRowChrome>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -20,7 +20,8 @@ import {TimelineFieldRow} from './TimelineFieldRow';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {
-	TIMELINE_SELECTED_TEXT,
+	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	TIMELINE_SELECTED_LABEL_TEXT,
 	useTimelineRowSelection,
 } from './TimelineSelection';
 
@@ -54,7 +55,16 @@ export const TimelineExpandedRow: React.FC<{
 	const labelStyle = React.useMemo(
 		(): React.CSSProperties => ({
 			...rowLabel,
-			color: selection.selected ? TIMELINE_SELECTED_TEXT : rowLabel.color,
+			alignSelf: 'stretch',
+			alignItems: 'center',
+			backgroundColor: selection.selected
+				? TIMELINE_SELECTED_LABEL_BACKGROUND
+				: undefined,
+			color: selection.selected ? TIMELINE_SELECTED_LABEL_TEXT : rowLabel.color,
+			display: 'flex',
+			flex: 1,
+			minWidth: 0,
+			paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 		}),
 		[selection.selected],
 	);
@@ -92,7 +102,6 @@ export const TimelineExpandedRow: React.FC<{
 				}
 				style={{
 					height: TREE_GROUP_ROW_HEIGHT,
-					paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 				}}
 				selected={selection.selected}
 				selectable={selection.selectable}
@@ -141,7 +150,6 @@ export const TimelineExpandedRow: React.FC<{
 			arrow={<TimelineExpandArrowSpacer />}
 			style={{
 				height: getTreeRowHeight(node),
-				paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 			}}
 			selected={selection.selected}
 			selectable={selection.selectable}

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -20,7 +20,7 @@ import {TimelineFieldRow} from './TimelineFieldRow';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {
-	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	getTimelineSelectedLabelStyle,
 	TIMELINE_SELECTED_LABEL_TEXT,
 	useTimelineRowSelection,
 } from './TimelineSelection';
@@ -55,11 +55,9 @@ export const TimelineExpandedRow: React.FC<{
 	const labelStyle = React.useMemo(
 		(): React.CSSProperties => ({
 			...rowLabel,
+			...getTimelineSelectedLabelStyle(selection.selected),
 			alignSelf: 'stretch',
 			alignItems: 'center',
-			backgroundColor: selection.selected
-				? TIMELINE_SELECTED_LABEL_BACKGROUND
-				: undefined,
 			color: selection.selected ? TIMELINE_SELECTED_LABEL_TEXT : rowLabel.color,
 			display: 'flex',
 			flex: 1,

--- a/packages/studio/src/components/Timeline/TimelineExpandedSection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedSection.tsx
@@ -24,8 +24,8 @@ const expandedSectionBase: React.CSSProperties = {
 };
 
 const separator: React.CSSProperties = {
-	height: 1,
-	backgroundColor: TIMELINE_TRACK_SEPARATOR,
+	height: 0,
+	borderBottom: `1px solid ${TIMELINE_TRACK_SEPARATOR}`,
 };
 
 export const TimelineExpandedSection: React.FC<{

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -1,5 +1,5 @@
 import React, {useContext, useMemo} from 'react';
-import {Internals, type TSequence, useVideoConfig} from 'remotion';
+import {Internals, useVideoConfig, type TSequence} from 'remotion';
 import {LIGHT_TEXT, TIMELINE_TRACK_SEPARATOR} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
@@ -13,6 +13,11 @@ import {
 } from '../../helpers/timeline-layout';
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {getTimelineKeyframes} from './get-timeline-keyframes';
+import {
+	TIMELINE_SELECTED_BACKGROUND,
+	useTimelineSelection,
+	type TimelineSelection,
+} from './TimelineSelection';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
 const row: React.CSSProperties = {
@@ -85,6 +90,7 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 	const timelineWidth = useContext(TimelineWidthContext);
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {canSelect, isSelected, selectItem} = useTimelineSelection();
 
 	const tree = useMemo(
 		() =>
@@ -125,6 +131,7 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 					keyframeDisplayOffset,
 				}),
 				key: JSON.stringify(node.nodePathInfo),
+				rowNodePathInfo: node.nodePathInfo,
 			})),
 		[
 			codeValues,
@@ -141,30 +148,49 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 			}}
 		>
 			<div style={{...section, height: expandedHeight}}>
-				{rows.map(({height, keyframes, key}, i) => {
+				{rows.map(({height, keyframes, key, rowNodePathInfo}, i) => {
 					return (
 						<React.Fragment key={key}>
 							{i > 0 ? <div style={separator} /> : null}
 							<div style={{...row, height}}>
 								{timelineWidth === null
 									? null
-									: keyframes.map((keyframe) => (
-											<div
-												key={String(keyframe.frame)}
-												style={{
-													...diamondBase,
-													left:
-														getXPositionOfItemInTimelineImperatively(
-															keyframe.frame,
-															videoConfig.durationInFrames,
-															timelineWidth,
-														) - TIMELINE_PADDING,
-													top: height / 2,
-													transform: 'translate(-50%, -50%) rotate(45deg)',
-												}}
-												title={`Keyframe at frame ${keyframe.frame}`}
-											/>
-										))}
+									: keyframes.map((keyframe) => {
+											const selectionItem: TimelineSelection = {
+												type: 'keyframe',
+												nodePathInfo: rowNodePathInfo,
+												frame: keyframe.frame,
+											};
+											const selected = isSelected(selectionItem);
+
+											return (
+												<button
+													key={String(keyframe.frame)}
+													type="button"
+													style={{
+														...diamondBase,
+														backgroundColor: selected
+															? TIMELINE_SELECTED_BACKGROUND
+															: LIGHT_TEXT,
+														border: 'none',
+														cursor: canSelect ? 'pointer' : 'default',
+														left:
+															getXPositionOfItemInTimelineImperatively(
+																keyframe.frame,
+																videoConfig.durationInFrames,
+																timelineWidth,
+															) - TIMELINE_PADDING,
+														padding: 0,
+														pointerEvents: 'auto',
+														top: height / 2,
+														transform: 'translate(-50%, -50%) rotate(45deg)',
+													}}
+													title={`Keyframe at frame ${keyframe.frame}`}
+													aria-label={`Select keyframe at frame ${keyframe.frame}`}
+													onClick={() => selectItem(selectionItem)}
+												/>
+											);
+										})}
 							</div>
 						</React.Fragment>
 					);

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -1,6 +1,6 @@
 import React, {useContext, useMemo} from 'react';
 import {Internals, useVideoConfig, type TSequence} from 'remotion';
-import {LIGHT_TEXT, TIMELINE_TRACK_SEPARATOR} from '../../helpers/colors';
+import {LIGHT_TEXT} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
@@ -25,13 +25,8 @@ const row: React.CSSProperties = {
 	position: 'relative',
 };
 
-const separator: React.CSSProperties = {
-	height: 1,
-	backgroundColor: TIMELINE_TRACK_SEPARATOR,
-};
-
-const section: React.CSSProperties = {
-	borderBottom: `1px solid ${TIMELINE_TRACK_SEPARATOR}`,
+const rowSeparator: React.CSSProperties = {
+	height: TIMELINE_ITEM_BORDER_BOTTOM,
 };
 
 const diamondBase: React.CSSProperties = {
@@ -148,7 +143,7 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 				height: expandedHeight + TIMELINE_ITEM_BORDER_BOTTOM,
 			}}
 		>
-			<div style={{...section, height: expandedHeight}}>
+			<div style={{height: expandedHeight}}>
 				{rows.map(({height, keyframes, key, rowNodePathInfo}, i) => {
 					const rowSelected = isSelected({
 						type: 'row',
@@ -157,7 +152,7 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 
 					return (
 						<React.Fragment key={key}>
-							{i > 0 ? <div style={separator} /> : null}
+							{i > 0 ? <div style={rowSeparator} /> : null}
 							<div style={{...row, height}}>
 								{rowSelected ? (
 									<div style={getTimelineSelectedTrackHighlightStyle()} />

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -14,6 +14,7 @@ import {
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {getTimelineKeyframes} from './get-timeline-keyframes';
 import {
+	getTimelineSelectedTrackHighlightStyle,
 	TIMELINE_SELECTED_LABEL_BACKGROUND,
 	useTimelineSelection,
 	type TimelineSelection,
@@ -149,10 +150,18 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 		>
 			<div style={{...section, height: expandedHeight}}>
 				{rows.map(({height, keyframes, key, rowNodePathInfo}, i) => {
+					const rowSelected = isSelected({
+						type: 'row',
+						nodePathInfo: rowNodePathInfo,
+					});
+
 					return (
 						<React.Fragment key={key}>
 							{i > 0 ? <div style={separator} /> : null}
 							<div style={{...row, height}}>
+								{rowSelected ? (
+									<div style={getTimelineSelectedTrackHighlightStyle()} />
+								) : null}
 								{timelineWidth === null
 									? null
 									: keyframes.map((keyframe) => {

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -14,7 +14,7 @@ import {
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {getTimelineKeyframes} from './get-timeline-keyframes';
 import {
-	TIMELINE_SELECTED_BACKGROUND,
+	TIMELINE_SELECTED_LABEL_BACKGROUND,
 	useTimelineSelection,
 	type TimelineSelection,
 } from './TimelineSelection';
@@ -90,7 +90,7 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 	const timelineWidth = useContext(TimelineWidthContext);
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
-	const {canSelect, isSelected, selectItem} = useTimelineSelection();
+	const {isSelected, selectItem} = useTimelineSelection();
 
 	const tree = useMemo(
 		() =>
@@ -170,10 +170,10 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 													style={{
 														...diamondBase,
 														backgroundColor: selected
-															? TIMELINE_SELECTED_BACKGROUND
+															? TIMELINE_SELECTED_LABEL_BACKGROUND
 															: LIGHT_TEXT,
 														border: 'none',
-														cursor: canSelect ? 'pointer' : 'default',
+														cursor: 'default',
 														left:
 															getXPositionOfItemInTimelineImperatively(
 																keyframe.frame,
@@ -187,7 +187,11 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 													}}
 													title={`Keyframe at frame ${keyframe.frame}`}
 													aria-label={`Select keyframe at frame ${keyframe.frame}`}
-													onClick={() => selectItem(selectionItem)}
+													onPointerDown={(e) => {
+														if (e.button === 0) {
+															selectItem(selectionItem);
+														}
+													}}
 												/>
 											);
 										})}

--- a/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
@@ -2,11 +2,12 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import type {
 	CanUpdateSequencePropStatusTrue,
 	SequencePropsSubscriptionKey,
+	SequenceSchema,
 } from 'remotion';
-import type {SequenceSchema} from 'remotion';
 import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -22,6 +23,10 @@ import {
 	TimelineFieldValue,
 	TimelineNonEditableStatus,
 } from './TimelineSchemaField';
+import {
+	TIMELINE_SELECTED_TEXT,
+	useTimelineRowSelection,
+} from './TimelineSelection';
 
 const fieldRowBase: React.CSSProperties = {
 	paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
@@ -153,11 +158,13 @@ export const TimelineFieldRow: React.FC<{
 	readonly validatedLocation: CodePosition;
 	readonly rowDepth: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly schema: SequenceSchema;
-}> = ({field, validatedLocation, rowDepth, nodePath, schema}) => {
+}> = ({field, validatedLocation, rowDepth, nodePath, nodePathInfo, schema}) => {
 	const {codeValues: visualModeCodeValues} = useContext(
 		Internals.VisualModeCodeValuesContext,
 	);
+	const selection = useTimelineRowSelection(nodePathInfo);
 
 	const codeValuesForOverride = Internals.getCodeValuesCtx(
 		visualModeCodeValues,
@@ -177,6 +184,14 @@ export const TimelineFieldRow: React.FC<{
 		[rowDepth],
 	);
 
+	const fieldNameStyle = useMemo(
+		(): React.CSSProperties => ({
+			...fieldName,
+			color: selection.selected ? TIMELINE_SELECTED_TEXT : fieldName.color,
+		}),
+		[selection.selected],
+	);
+
 	if (codeValue === null) {
 		return null;
 	}
@@ -187,9 +202,12 @@ export const TimelineFieldRow: React.FC<{
 			eye={<TimelineLayerEyeSpacer />}
 			arrow={<TimelineExpandArrowSpacer />}
 			style={style}
+			selected={selection.selected}
+			selectable={selection.selectable}
+			onSelect={selection.onSelect}
 		>
 			<div style={labelRowStyle}>
-				<span style={fieldName}>{field.description ?? field.key}</span>
+				<span style={fieldNameStyle}>{field.description ?? field.key}</span>
 			</div>
 			{codeValue.canUpdate ? (
 				<Value

--- a/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
@@ -24,11 +24,19 @@ import {
 	TimelineNonEditableStatus,
 } from './TimelineSchemaField';
 import {
-	TIMELINE_SELECTED_TEXT,
+	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	TIMELINE_SELECTED_LABEL_TEXT,
 	useTimelineRowSelection,
 } from './TimelineSelection';
 
-const fieldRowBase: React.CSSProperties = {
+const fieldRowBase: React.CSSProperties = {};
+
+const valueColumnStyle: React.CSSProperties = {
+	alignItems: 'center',
+	alignSelf: 'stretch',
+	display: 'flex',
+	flex: 1,
+	minWidth: 0,
 	paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 };
 
@@ -180,14 +188,22 @@ export const TimelineFieldRow: React.FC<{
 	}, [field.rowHeight]);
 
 	const labelRowStyle = useMemo(
-		() => getTimelineFieldLabelRowStyle(rowDepth),
-		[rowDepth],
+		(): React.CSSProperties => ({
+			...getTimelineFieldLabelRowStyle(rowDepth),
+			alignSelf: 'stretch',
+			backgroundColor: selection.selected
+				? TIMELINE_SELECTED_LABEL_BACKGROUND
+				: undefined,
+		}),
+		[rowDepth, selection.selected],
 	);
 
 	const fieldNameStyle = useMemo(
 		(): React.CSSProperties => ({
 			...fieldName,
-			color: selection.selected ? TIMELINE_SELECTED_TEXT : fieldName.color,
+			color: selection.selected
+				? TIMELINE_SELECTED_LABEL_TEXT
+				: fieldName.color,
 		}),
 		[selection.selected],
 	);
@@ -210,15 +226,19 @@ export const TimelineFieldRow: React.FC<{
 				<span style={fieldNameStyle}>{field.description ?? field.key}</span>
 			</div>
 			{codeValue.canUpdate ? (
-				<Value
-					field={field}
-					nodePath={nodePath}
-					validatedLocation={validatedLocation}
-					schema={schema}
-					codeValue={codeValue}
-				/>
+				<div style={valueColumnStyle}>
+					<Value
+						field={field}
+						nodePath={nodePath}
+						validatedLocation={validatedLocation}
+						schema={schema}
+						codeValue={codeValue}
+					/>
+				</div>
 			) : (
-				<TimelineNonEditableStatus propStatus={codeValue} />
+				<div style={valueColumnStyle}>
+					<TimelineNonEditableStatus propStatus={codeValue} />
+				</div>
 			)}
 		</TimelineRowChrome>
 	);

--- a/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
@@ -24,7 +24,7 @@ import {
 	TimelineNonEditableStatus,
 } from './TimelineSchemaField';
 import {
-	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	getTimelineSelectedLabelStyle,
 	TIMELINE_SELECTED_LABEL_TEXT,
 	useTimelineRowSelection,
 } from './TimelineSelection';
@@ -190,10 +190,8 @@ export const TimelineFieldRow: React.FC<{
 	const labelRowStyle = useMemo(
 		(): React.CSSProperties => ({
 			...getTimelineFieldLabelRowStyle(rowDepth),
+			...getTimelineSelectedLabelStyle(selection.selected),
 			alignSelf: 'stretch',
-			backgroundColor: selection.selected
-				? TIMELINE_SELECTED_LABEL_BACKGROUND
-				: undefined,
 		}),
 		[rowDepth, selection.selected],
 	);

--- a/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
@@ -219,6 +219,7 @@ export const TimelineFieldRow: React.FC<{
 			selected={selection.selected}
 			selectable={selection.selectable}
 			onSelect={selection.onSelect}
+			showSelectedBackground
 		>
 			<div style={labelRowStyle}>
 				<span style={fieldNameStyle}>{field.description ?? field.key}</span>

--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -27,6 +27,7 @@ import {TimelineExpandedSection} from './TimelineExpandedSection';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineMediaInfo} from './TimelineMediaInfo';
 import {TimelineRowChrome} from './TimelineRowChrome';
+import {useTimelineRowSelection} from './TimelineSelection';
 import {TimelineStack} from './TimelineStack';
 import {useResolveStackAndReactToChange} from './use-resolved-stack-react-to-change';
 
@@ -43,6 +44,7 @@ export const TimelineListItem: React.FC<{
 	const {toggleTrack} = useContext(ExpandedTracksSetterContext);
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const selection = useTimelineRowSelection(nodePathInfo);
 
 	const originalLocation = useResolveStackAndReactToChange(sequence.getStack);
 
@@ -337,11 +339,15 @@ export const TimelineListItem: React.FC<{
 					)
 				}
 				style={inner}
+				selected={selection.selected}
+				selectable={selection.selectable}
+				onSelect={selection.onSelect}
 			>
 				<TimelineStack
 					sequence={sequence}
 					isCompact={isCompact}
 					originalLocation={originalLocation}
+					selected={selection.selected}
 				/>
 			</TimelineRowChrome>
 			{mediaSrc ? (

--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -47,7 +47,8 @@ export const TimelineListItem: React.FC<{
 	const {toggleTrack} = useContext(ExpandedTracksSetterContext);
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
-	const selection = useTimelineRowSelection(nodePathInfo);
+	const {onSelect, selectable, selected} =
+		useTimelineRowSelection(nodePathInfo);
 
 	const originalLocation = useResolveStackAndReactToChange(sequence.getStack);
 
@@ -266,24 +267,22 @@ export const TimelineListItem: React.FC<{
 
 	const outer: React.CSSProperties = useMemo(() => {
 		return {
-			backgroundColor: selection.selected
-				? TIMELINE_SELECTED_BACKGROUND
-				: undefined,
+			backgroundColor: selected ? TIMELINE_SELECTED_BACKGROUND : undefined,
 			height:
 				getTimelineLayerHeight(sequence.type) + TIMELINE_ITEM_BORDER_BOTTOM,
 			borderBottom: `1px solid ${TIMELINE_TRACK_SEPARATOR}`,
 			display: 'flex',
 			flexDirection: 'column',
 		};
-	}, [selection.selected, sequence.type]);
+	}, [selected, sequence.type]);
 
 	const onSelectPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
 			if (e.button === 0) {
-				selection.onSelect();
+				onSelect();
 			}
 		},
-		[selection.onSelect],
+		[onSelect],
 	);
 
 	const inner: React.CSSProperties = useMemo(() => {
@@ -329,8 +328,8 @@ export const TimelineListItem: React.FC<{
 	const trackRow = (
 		<div
 			style={outer}
-			onPointerDown={selection.selectable ? onSelectPointerDown : undefined}
-			onContextMenu={selection.selectable ? selection.onSelect : undefined}
+			onPointerDown={selectable ? onSelectPointerDown : undefined}
+			onContextMenu={selectable ? onSelect : undefined}
 		>
 			<TimelineRowChrome
 				depth={nestedDepth}
@@ -358,15 +357,16 @@ export const TimelineListItem: React.FC<{
 					)
 				}
 				style={inner}
-				selected={selection.selected}
+				selected={selected}
 				selectable={false}
+				onSelect={onSelect}
 				showSelectedBackground={false}
 			>
 				<TimelineStack
 					sequence={sequence}
 					isCompact={isCompact}
 					originalLocation={originalLocation}
-					selected={selection.selected}
+					selected={selected}
 				/>
 			</TimelineRowChrome>
 			{mediaSrc ? (
@@ -385,7 +385,7 @@ export const TimelineListItem: React.FC<{
 			{previewConnected ? (
 				<ContextMenu
 					values={contextMenuValues}
-					onOpen={selection.selectable ? selection.onSelect : undefined}
+					onOpen={selectable ? onSelect : null}
 				>
 					{trackRow}
 				</ContextMenu>

--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -27,7 +27,10 @@ import {TimelineExpandedSection} from './TimelineExpandedSection';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineMediaInfo} from './TimelineMediaInfo';
 import {TimelineRowChrome} from './TimelineRowChrome';
-import {useTimelineRowSelection} from './TimelineSelection';
+import {
+	TIMELINE_SELECTED_BACKGROUND,
+	useTimelineRowSelection,
+} from './TimelineSelection';
 import {TimelineStack} from './TimelineStack';
 import {useResolveStackAndReactToChange} from './use-resolved-stack-react-to-change';
 
@@ -263,13 +266,25 @@ export const TimelineListItem: React.FC<{
 
 	const outer: React.CSSProperties = useMemo(() => {
 		return {
+			backgroundColor: selection.selected
+				? TIMELINE_SELECTED_BACKGROUND
+				: undefined,
 			height:
 				getTimelineLayerHeight(sequence.type) + TIMELINE_ITEM_BORDER_BOTTOM,
 			borderBottom: `1px solid ${TIMELINE_TRACK_SEPARATOR}`,
 			display: 'flex',
 			flexDirection: 'column',
 		};
-	}, [sequence.type]);
+	}, [selection.selected, sequence.type]);
+
+	const onSelectPointerDown = useCallback(
+		(e: React.PointerEvent<HTMLDivElement>) => {
+			if (e.button === 0) {
+				selection.onSelect();
+			}
+		},
+		[selection.onSelect],
+	);
 
 	const inner: React.CSSProperties = useMemo(() => {
 		return {
@@ -312,7 +327,11 @@ export const TimelineListItem: React.FC<{
 		codeHiddenStatus.canUpdate;
 
 	const trackRow = (
-		<div style={outer}>
+		<div
+			style={outer}
+			onPointerDown={selection.selectable ? onSelectPointerDown : undefined}
+			onContextMenu={selection.selectable ? selection.onSelect : undefined}
+		>
 			<TimelineRowChrome
 				depth={nestedDepth}
 				eye={
@@ -340,8 +359,8 @@ export const TimelineListItem: React.FC<{
 				}
 				style={inner}
 				selected={selection.selected}
-				selectable={selection.selectable}
-				onSelect={selection.onSelect}
+				selectable={false}
+				showSelectedBackground={false}
 			>
 				<TimelineStack
 					sequence={sequence}

--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -364,7 +364,12 @@ export const TimelineListItem: React.FC<{
 	return (
 		<>
 			{previewConnected ? (
-				<ContextMenu values={contextMenuValues}>{trackRow}</ContextMenu>
+				<ContextMenu
+					values={contextMenuValues}
+					onOpen={selection.selectable ? selection.onSelect : undefined}
+				>
+					{trackRow}
+				</ContextMenu>
 			) : (
 				trackRow
 			)}

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -4,6 +4,10 @@ import {
 	TIMELINE_ROW_BASE_PADDING,
 	getTimelineRowIndentWidth,
 } from './timeline-row-layout';
+import {
+	TIMELINE_SELECTED_BACKGROUND,
+	TIMELINE_SELECTED_TEXT,
+} from './TimelineSelection';
 
 const rowBase: React.CSSProperties = {
 	display: 'flex',
@@ -16,20 +20,35 @@ export const TimelineRowChrome: React.FC<{
 	readonly arrow: React.ReactNode;
 	readonly children: React.ReactNode;
 	readonly style?: React.CSSProperties;
-}> = ({depth, eye, arrow, children, style}) => {
+	readonly selected?: boolean;
+	readonly selectable?: boolean;
+	readonly onSelect?: () => void;
+}> = ({
+	depth,
+	eye,
+	arrow,
+	children,
+	style,
+	selected = false,
+	selectable = false,
+	onSelect,
+}) => {
 	const rowStyle = useMemo(
 		(): React.CSSProperties => ({
 			...rowBase,
 			paddingLeft: TIMELINE_ROW_BASE_PADDING,
 			...style,
+			backgroundColor: selected ? TIMELINE_SELECTED_BACKGROUND : undefined,
+			color: selected ? TIMELINE_SELECTED_TEXT : style?.color,
+			cursor: selectable ? 'pointer' : style?.cursor,
 		}),
-		[style],
+		[selectable, selected, style],
 	);
 
 	const indentWidth = getTimelineRowIndentWidth(depth);
 
 	return (
-		<div style={rowStyle}>
+		<div style={rowStyle} onClick={selectable ? onSelect : undefined}>
 			{eye}
 			{indentWidth > 0 ? <Padder depth={depth} /> : null}
 			{arrow}

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -28,6 +28,7 @@ export const TimelineRowChrome: React.FC<{
 	readonly selected?: boolean;
 	readonly selectable?: boolean;
 	readonly onSelect?: () => void;
+	readonly showSelectedBackground?: boolean;
 }> = ({
 	depth,
 	eye,
@@ -37,14 +38,18 @@ export const TimelineRowChrome: React.FC<{
 	selected = false,
 	selectable = false,
 	onSelect,
+	showSelectedBackground = true,
 }) => {
 	const rowStyle = useMemo(
 		(): React.CSSProperties => ({
 			...rowBase,
 			...style,
-			backgroundColor: selected ? TIMELINE_SELECTED_BACKGROUND : undefined,
+			backgroundColor:
+				selected && showSelectedBackground
+					? TIMELINE_SELECTED_BACKGROUND
+					: undefined,
 		}),
-		[selected, style],
+		[selected, showSelectedBackground, style],
 	);
 
 	const indentWidth = getTimelineRowIndentWidth(depth);

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -1,17 +1,22 @@
-import React, {useMemo} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {Padder} from './Padder';
 import {
 	TIMELINE_ROW_BASE_PADDING,
 	getTimelineRowIndentWidth,
 } from './timeline-row-layout';
-import {
-	TIMELINE_SELECTED_BACKGROUND,
-	TIMELINE_SELECTED_TEXT,
-} from './TimelineSelection';
+import {TIMELINE_SELECTED_BACKGROUND} from './TimelineSelection';
 
 const rowBase: React.CSSProperties = {
+	alignItems: 'stretch',
 	display: 'flex',
+};
+
+const chromeColumnStyle: React.CSSProperties = {
 	alignItems: 'center',
+	alignSelf: 'stretch',
+	display: 'flex',
+	flexShrink: 0,
+	paddingLeft: TIMELINE_ROW_BASE_PADDING,
 };
 
 export const TimelineRowChrome: React.FC<{
@@ -36,22 +41,34 @@ export const TimelineRowChrome: React.FC<{
 	const rowStyle = useMemo(
 		(): React.CSSProperties => ({
 			...rowBase,
-			paddingLeft: TIMELINE_ROW_BASE_PADDING,
 			...style,
 			backgroundColor: selected ? TIMELINE_SELECTED_BACKGROUND : undefined,
-			color: selected ? TIMELINE_SELECTED_TEXT : style?.color,
-			cursor: selectable ? 'pointer' : style?.cursor,
 		}),
-		[selectable, selected, style],
+		[selected, style],
 	);
 
 	const indentWidth = getTimelineRowIndentWidth(depth);
 
+	const onPointerDown = useCallback(
+		(e: React.PointerEvent<HTMLDivElement>) => {
+			if (e.button === 0) {
+				onSelect?.();
+			}
+		},
+		[onSelect],
+	);
+
 	return (
-		<div style={rowStyle} onClick={selectable ? onSelect : undefined}>
-			{eye}
-			{indentWidth > 0 ? <Padder depth={depth} /> : null}
-			{arrow}
+		<div
+			style={rowStyle}
+			onPointerDown={selectable ? onPointerDown : undefined}
+			onContextMenu={selectable ? onSelect : undefined}
+		>
+			<div style={chromeColumnStyle}>
+				{eye}
+				{indentWidth > 0 ? <Padder depth={depth} /> : null}
+				{arrow}
+			</div>
 			{children}
 		</div>
 	);

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -24,21 +24,21 @@ export const TimelineRowChrome: React.FC<{
 	readonly eye: React.ReactNode;
 	readonly arrow: React.ReactNode;
 	readonly children: React.ReactNode;
-	readonly style?: React.CSSProperties;
-	readonly selected?: boolean;
-	readonly selectable?: boolean;
-	readonly onSelect?: () => void;
-	readonly showSelectedBackground?: boolean;
+	readonly style: React.CSSProperties;
+	readonly selected: boolean;
+	readonly selectable: boolean;
+	readonly onSelect: () => void;
+	readonly showSelectedBackground: boolean;
 }> = ({
 	depth,
 	eye,
 	arrow,
 	children,
 	style,
-	selected = false,
-	selectable = false,
+	selected,
+	selectable,
 	onSelect,
-	showSelectedBackground = true,
+	showSelectedBackground,
 }) => {
 	const rowStyle = useMemo(
 		(): React.CSSProperties => ({
@@ -57,7 +57,7 @@ export const TimelineRowChrome: React.FC<{
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
 			if (e.button === 0) {
-				onSelect?.();
+				onSelect();
 			}
 		},
 		[onSelect],

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -5,14 +5,44 @@ import React, {
 	useEffect,
 	useMemo,
 	useState,
+	type CSSProperties,
 } from 'react';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
 
 export const TIMELINE_SELECTED_BACKGROUND = 'rgba(255, 255, 255, 0.1)';
 export const TIMELINE_SELECTED_LABEL_BACKGROUND = '#B0B0B0';
 export const TIMELINE_SELECTED_LABEL_TEXT = 'black';
+export const TIMELINE_SELECTED_LABEL_HORIZONTAL_PADDING = 2;
+
+export const getTimelineSelectedLabelStyle = (
+	selected: boolean,
+): CSSProperties => {
+	if (!selected) {
+		return {};
+	}
+
+	const padding = TIMELINE_SELECTED_LABEL_HORIZONTAL_PADDING;
+	return {
+		backgroundColor: TIMELINE_SELECTED_LABEL_BACKGROUND,
+		marginLeft: -padding,
+		marginRight: -padding,
+		paddingLeft: padding,
+		paddingRight: padding,
+	};
+};
+
+export const getTimelineSelectedTrackHighlightStyle = (): CSSProperties => ({
+	backgroundColor: TIMELINE_SELECTED_BACKGROUND,
+	bottom: 0,
+	left: -TIMELINE_PADDING,
+	pointerEvents: 'none',
+	position: 'absolute',
+	right: -TIMELINE_PADDING,
+	top: 0,
+});
 
 export const SELECTION_ENABLED = false;
 

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -10,8 +10,9 @@ import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
 
-export const TIMELINE_SELECTED_BACKGROUND = 'rgb(160, 160, 160)';
-export const TIMELINE_SELECTED_TEXT = 'black';
+export const TIMELINE_SELECTED_BACKGROUND = 'rgba(255, 255, 255, 0.1)';
+export const TIMELINE_SELECTED_LABEL_BACKGROUND = '#B0B0B0';
+export const TIMELINE_SELECTED_LABEL_TEXT = 'black';
 
 export type TimelineSelection =
 	| {

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -14,6 +14,8 @@ export const TIMELINE_SELECTED_BACKGROUND = 'rgba(255, 255, 255, 0.1)';
 export const TIMELINE_SELECTED_LABEL_BACKGROUND = '#B0B0B0';
 export const TIMELINE_SELECTED_LABEL_TEXT = 'black';
 
+export const SELECTION_ENABLED = false;
+
 export type TimelineSelection =
 	| {
 			readonly type: 'row';
@@ -51,6 +53,7 @@ export const TimelineSelectionProvider: React.FC<{
 }> = ({children}) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const canSelect =
+		SELECTION_ENABLED &&
 		previewServerState.type === 'connected' &&
 		!window.remotion_isReadOnlyStudio;
 	const [selectedItem, setSelectedItem] = useState<TimelineSelection | null>(

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -1,0 +1,131 @@
+import React, {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
+
+export const TIMELINE_SELECTED_BACKGROUND = 'rgb(160, 160, 160)';
+export const TIMELINE_SELECTED_TEXT = 'black';
+
+export type TimelineSelection =
+	| {
+			readonly type: 'row';
+			readonly nodePathInfo: SequenceNodePathInfo;
+	  }
+	| {
+			readonly type: 'keyframe';
+			readonly nodePathInfo: SequenceNodePathInfo;
+			readonly frame: number;
+	  };
+
+type TimelineSelectionContextValue = {
+	readonly canSelect: boolean;
+	readonly isSelected: (item: TimelineSelection) => boolean;
+	readonly selectItem: (item: TimelineSelection) => void;
+};
+
+const TimelineSelectionContext = createContext<TimelineSelectionContextValue>({
+	canSelect: false,
+	isSelected: () => false,
+	selectItem: () => undefined,
+});
+
+const getTimelineSelectionKey = (item: TimelineSelection): string => {
+	const rowKey = timelineNodePathInfoToKey(item.nodePathInfo);
+	if (item.type === 'row') {
+		return rowKey;
+	}
+
+	return `${rowKey}.keyframe.${item.frame}`;
+};
+
+export const TimelineSelectionProvider: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const canSelect =
+		previewServerState.type === 'connected' &&
+		!window.remotion_isReadOnlyStudio;
+	const [selectedItem, setSelectedItem] = useState<TimelineSelection | null>(
+		null,
+	);
+
+	useEffect(() => {
+		if (!canSelect) {
+			setSelectedItem(null);
+		}
+	}, [canSelect]);
+
+	const isSelected = useCallback(
+		(item: TimelineSelection) => {
+			return selectedItem === null
+				? false
+				: getTimelineSelectionKey(selectedItem) ===
+						getTimelineSelectionKey(item);
+		},
+		[selectedItem],
+	);
+
+	const selectItem = useCallback(
+		(item: TimelineSelection) => {
+			if (!canSelect) {
+				return;
+			}
+
+			setSelectedItem(item);
+		},
+		[canSelect],
+	);
+
+	const value = useMemo(
+		(): TimelineSelectionContextValue => ({
+			canSelect,
+			isSelected,
+			selectItem,
+		}),
+		[canSelect, isSelected, selectItem],
+	);
+
+	return (
+		<TimelineSelectionContext.Provider value={value}>
+			{children}
+		</TimelineSelectionContext.Provider>
+	);
+};
+
+export const useTimelineSelection = () => {
+	return useContext(TimelineSelectionContext);
+};
+
+export const useTimelineRowSelection = (
+	nodePathInfo: SequenceNodePathInfo | null,
+) => {
+	const {canSelect, isSelected, selectItem} = useTimelineSelection();
+	const selectionItem = useMemo(
+		(): TimelineSelection | null =>
+			nodePathInfo === null ? null : {type: 'row', nodePathInfo},
+		[nodePathInfo],
+	);
+
+	const selected = selectionItem === null ? false : isSelected(selectionItem);
+
+	const onSelect = useCallback(() => {
+		if (selectionItem === null) {
+			return;
+		}
+
+		selectItem(selectionItem);
+	}, [selectItem, selectionItem]);
+
+	return {
+		onSelect,
+		selectable: canSelect && selectionItem !== null,
+		selected,
+	};
+};

--- a/packages/studio/src/components/Timeline/TimelineStack/index.tsx
+++ b/packages/studio/src/components/Timeline/TimelineStack/index.tsx
@@ -14,7 +14,7 @@ import {Spacing} from '../../layout';
 import {showNotification} from '../../Notifications/NotificationCenter';
 import {Spinner} from '../../Spinner';
 import {
-	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	getTimelineSelectedLabelStyle,
 	TIMELINE_SELECTED_LABEL_TEXT,
 } from '../TimelineSelection';
 import {getOriginalSourceAttribution} from './source-attribution';
@@ -138,9 +138,7 @@ export const TimelineStack: React.FC<{
 		return {
 			alignItems: 'center',
 			alignSelf: 'stretch',
-			backgroundColor: selected
-				? TIMELINE_SELECTED_LABEL_BACKGROUND
-				: undefined,
+			...getTimelineSelectedLabelStyle(selected),
 			display: 'flex',
 			fontSize: 12,
 			whiteSpace: 'nowrap',

--- a/packages/studio/src/components/Timeline/TimelineStack/index.tsx
+++ b/packages/studio/src/components/Timeline/TimelineStack/index.tsx
@@ -19,7 +19,8 @@ export const TimelineStack: React.FC<{
 	readonly isCompact: boolean;
 	readonly sequence: TSequence;
 	readonly originalLocation: OriginalPosition | null;
-}> = ({isCompact, sequence, originalLocation}) => {
+	readonly selected: boolean;
+}> = ({isCompact, sequence, originalLocation, selected}) => {
 	const [stackHovered, setStackHovered] = useState(false);
 	const [titleHovered, setTitleHovered] = useState(false);
 	const [opening, setOpening] = useState(false);
@@ -98,11 +99,13 @@ export const TimelineStack: React.FC<{
 	const style = useMemo((): React.CSSProperties => {
 		return {
 			fontSize: 12,
-			color: opening
-				? VERY_LIGHT_TEXT
-				: stackHovered && stackHoverable
-					? LIGHT_TEXT
-					: VERY_LIGHT_TEXT,
+			color: selected
+				? 'black'
+				: opening
+					? VERY_LIGHT_TEXT
+					: stackHovered && stackHoverable
+						? LIGHT_TEXT
+						: VERY_LIGHT_TEXT,
 			marginLeft: 5,
 			cursor: stackHoverable ? 'pointer' : undefined,
 			display: 'flex',
@@ -115,7 +118,7 @@ export const TimelineStack: React.FC<{
 			userSelect: 'none',
 			WebkitUserSelect: 'none',
 		};
-	}, [opening, stackHovered, stackHoverable]);
+	}, [opening, selected, stackHovered, stackHoverable]);
 
 	const titleStyle: React.CSSProperties = useMemo(() => {
 		const hoverEffect = titleHovered && titleHoverable;
@@ -125,14 +128,18 @@ export const TimelineStack: React.FC<{
 			textOverflow: 'ellipsis',
 			overflow: 'hidden',
 			lineHeight: 1.2,
-			color: opening && isCompact ? VERY_LIGHT_TEXT : LIGHT_COLOR,
+			color: selected
+				? 'black'
+				: opening && isCompact
+					? VERY_LIGHT_TEXT
+					: LIGHT_COLOR,
 			userSelect: 'none',
 			WebkitUserSelect: 'none',
 			textDecoration: hoverEffect ? 'underline' : 'none',
 			textUnderlineOffset: 2,
 			cursor: hoverEffect ? 'pointer' : undefined,
 		};
-	}, [titleHoverable, isCompact, opening, titleHovered]);
+	}, [titleHoverable, isCompact, opening, selected, titleHovered]);
 
 	const text =
 		sequence.displayName.length > 1000

--- a/packages/studio/src/components/Timeline/TimelineStack/index.tsx
+++ b/packages/studio/src/components/Timeline/TimelineStack/index.tsx
@@ -13,6 +13,10 @@ import {openOriginalPositionInEditor} from '../../../helpers/open-in-editor';
 import {Spacing} from '../../layout';
 import {showNotification} from '../../Notifications/NotificationCenter';
 import {Spinner} from '../../Spinner';
+import {
+	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	TIMELINE_SELECTED_LABEL_TEXT,
+} from '../TimelineSelection';
 import {getOriginalSourceAttribution} from './source-attribution';
 
 export const TimelineStack: React.FC<{
@@ -99,13 +103,11 @@ export const TimelineStack: React.FC<{
 	const style = useMemo((): React.CSSProperties => {
 		return {
 			fontSize: 12,
-			color: selected
-				? 'black'
-				: opening
-					? VERY_LIGHT_TEXT
-					: stackHovered && stackHoverable
-						? LIGHT_TEXT
-						: VERY_LIGHT_TEXT,
+			color: opening
+				? VERY_LIGHT_TEXT
+				: stackHovered && stackHoverable
+					? LIGHT_TEXT
+					: VERY_LIGHT_TEXT,
 			marginLeft: 5,
 			cursor: stackHoverable ? 'pointer' : undefined,
 			display: 'flex',
@@ -118,18 +120,35 @@ export const TimelineStack: React.FC<{
 			userSelect: 'none',
 			WebkitUserSelect: 'none',
 		};
-	}, [opening, selected, stackHovered, stackHoverable]);
+	}, [opening, stackHovered, stackHoverable]);
+
+	const labelContainerStyle: React.CSSProperties = useMemo(() => {
+		return {
+			alignItems: 'center',
+			alignSelf: 'stretch',
+			display: 'flex',
+			flex: 1,
+			flexDirection: 'row',
+			minWidth: 0,
+		};
+	}, []);
 
 	const titleStyle: React.CSSProperties = useMemo(() => {
 		const hoverEffect = titleHovered && titleHoverable;
 		return {
+			alignItems: 'center',
+			alignSelf: 'stretch',
+			backgroundColor: selected
+				? TIMELINE_SELECTED_LABEL_BACKGROUND
+				: undefined,
+			display: 'flex',
 			fontSize: 12,
 			whiteSpace: 'nowrap',
 			textOverflow: 'ellipsis',
 			overflow: 'hidden',
 			lineHeight: 1.2,
 			color: selected
-				? 'black'
+				? TIMELINE_SELECTED_LABEL_TEXT
 				: opening && isCompact
 					? VERY_LIGHT_TEXT
 					: LIGHT_COLOR,
@@ -147,7 +166,7 @@ export const TimelineStack: React.FC<{
 			: sequence.displayName;
 
 	return (
-		<>
+		<div style={labelContainerStyle}>
 			<div
 				onPointerEnter={onTitlePointerEnter}
 				onPointerLeave={onTitlePointerLeave}
@@ -177,6 +196,6 @@ export const TimelineStack: React.FC<{
 					<Spinner duration={0.5} size={12} />
 				</>
 			) : null}
-		</>
+		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -19,7 +19,6 @@ import {TimelineTimePadding} from './TimelineTimeIndicators';
 const content: React.CSSProperties = {
 	paddingLeft: TIMELINE_PADDING,
 	paddingRight: TIMELINE_PADDING,
-	paddingTop: 1,
 };
 
 const timelineContent: React.CSSProperties = {

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -9,6 +9,10 @@ import {
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {MaxTimelineTracksReached} from './MaxTimelineTracks';
 import {TimelineExpandedTrackKeyframes} from './TimelineExpandedTrackKeyframes';
+import {
+	getTimelineSelectedTrackHighlightStyle,
+	useTimelineSelection,
+} from './TimelineSelection';
 import {TimelineSequence} from './TimelineSequence';
 import {TimelineTimePadding} from './TimelineTimeIndicators';
 
@@ -29,6 +33,7 @@ const TimelineTracksInner: React.FC<{
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewServerConnected = previewServerState.type === 'connected';
+	const {isSelected} = useTimelineSelection();
 
 	const timelineStyle: React.CSSProperties = useMemo(() => {
 		return {
@@ -44,6 +49,9 @@ const TimelineTracksInner: React.FC<{
 				{timeline.map((track) => {
 					const isExpanded =
 						track.nodePathInfo !== null && getIsExpanded(track.nodePathInfo);
+					const rowSelected =
+						track.nodePathInfo !== null &&
+						isSelected({type: 'row', nodePathInfo: track.nodePathInfo});
 
 					return (
 						<div key={track.sequence.id}>
@@ -51,8 +59,12 @@ const TimelineTracksInner: React.FC<{
 								style={{
 									height: getTimelineLayerHeight(track.sequence.type),
 									marginBottom: TIMELINE_ITEM_BORDER_BOTTOM,
+									position: 'relative',
 								}}
 							>
+								{rowSelected ? (
+									<div style={getTimelineSelectedTrackHighlightStyle()} />
+								) : null}
 								<TimelineSequence s={track.sequence} />
 							</div>
 							{isExpanded && track.nodePathInfo && previewServerConnected ? (

--- a/packages/studio/src/helpers/timeline-node-path-key.ts
+++ b/packages/studio/src/helpers/timeline-node-path-key.ts
@@ -1,0 +1,9 @@
+import {stringifySequenceExpandedRowKey} from '@remotion/studio-shared';
+import type {SequenceNodePathInfo} from './get-timeline-sequence-sort-key';
+
+export const timelineNodePathInfoToKey = (info: SequenceNodePathInfo): string =>
+	[
+		stringifySequenceExpandedRowKey(info.sequenceSubscriptionKey),
+		info.auxiliaryKeys.join('.'),
+		info.index,
+	].join('.');

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1,0 +1,6 @@
+import {expect, test} from 'bun:test';
+import {SELECTION_ENABLED} from '../components/Timeline/TimelineSelection';
+
+test('Timeline selection should stay disabled until released publicly', () => {
+	expect(SELECTION_ENABLED).toBe(false);
+});


### PR DESCRIPTION
Closes #6991.

## Summary

- Add non-persisted Visual Mode timeline selection state
- Allow selecting sequence rows, controls, effects, effect controls, and keyframe diamonds
- Disable and clear selection when Studio is read-only or the preview server is not connected

## Testing

- `bun run build`
- `bun run formatting`
