### PR TITLE
fix(renderer): kill remaining child processes to prevent zombies

### DIFF
--- a/packages/dockerfiles/Dockerfile.al2023
+++ b/packages/dockerfiles/Dockerfile.al2023
@@ -1,7 +1,7 @@
 FROM amazonlinux:2023
 
 WORKDIR /usr/app
-RUN yum install git tar gzip unzip -y
+RUN yum install git tar gzip unzip util-linux -y
 RUN yum install nodejs -y
 RUN curl -fsSL https://bun.com/install | bash && ln -s /root/.bun/bin/bun /usr/local/bin/bun
 

--- a/packages/dockerfiles/Dockerfile.debian
+++ b/packages/dockerfiles/Dockerfile.debian
@@ -7,6 +7,7 @@ RUN apt install -y \
   git \
   curl \
   unzip \
+  util-linux \
   libnss3 \
   libdbus-1-3 \
   libatk1.0-0 \

--- a/packages/dockerfiles/Dockerfile.ubuntu22
+++ b/packages/dockerfiles/Dockerfile.ubuntu22
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get update
-RUN apt-get install git curl make unzip -y
+RUN apt-get install git curl make unzip util-linux -y
 RUN curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s 20
 RUN curl -fsSL https://bun.com/install | bash && ln -s /root/.bun/bin/bun /usr/local/bin/bun
 WORKDIR /usr/app

--- a/packages/dockerfiles/Dockerfile.ubuntu24
+++ b/packages/dockerfiles/Dockerfile.ubuntu24
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 RUN apt-get update
-RUN apt-get install git curl make unzip -y
+RUN apt-get install git curl make unzip util-linux -y
 RUN curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s 20
 RUN curl -fsSL https://bun.com/install | bash && ln -s /root/.bun/bin/bun /usr/local/bin/bun
 WORKDIR /usr/app

--- a/packages/renderer/src/browser/BrowserRunner.ts
+++ b/packages/renderer/src/browser/BrowserRunner.ts
@@ -128,6 +128,19 @@ export const makeBrowserRunner = async ({
 						);
 						proc.kill('SIGKILL');
 					}
+
+					// Best-effort: kill any remaining child processes that may have been
+					// missed by the process group kill (e.g. if setpriv is not available
+					// in Docker containers). Without this, children become zombies (PPID 1)
+					// after the parent exits.
+					try {
+						childProcess.execSync(
+							`pkill -9 -P ${proc.pid} 2>/dev/null || true`,
+							{timeout: 2000},
+						);
+					} catch {
+						// Ignore — pkill may not be available or process may already be gone
+					}
 				}
 			} catch (error) {
 				throw new Error(


### PR DESCRIPTION
## Summary

Fixes #7065.

After rendering completes, multiple zombie chrome-headless-shell processes are left behind with PPID 1. This happens because:

1. The `setpriv --pdeathsig SIGKILL` fix (from #7207) requires `util-linux` which is not installed in the official Docker images
2. When the process group kill fails (e.g. due to permissions), only the main Chrome process is killed, leaving children as orphans

## Fix

### 1. Docker images: install `util-linux`

Added `util-linux` to all Dockerfiles that use apt/yum to ensure `setpriv` is available. This is the primary defense — `setpriv --pdeathsig SIGKILL` makes child processes receive SIGKILL when their parent dies.

### 2. Renderer code: best-effort child process cleanup

After killing the main process group, use `pkill -9 -P <pid>` as a fallback to kill any remaining child processes. This handles edge cases where:
- `setpriv` is not available
- Process group kill fails due to permissions
- Chrome spawns children outside its process group

The `pkill` call is wrapped in a try/catch with a 2-second timeout to avoid blocking if `pkill` is not available or the process is already gone.

## Testing

- Verified that `setpriv` is now available in the Docker images
- The `pkill` fallback is a no-op when no children remain (exit code 1, caught by try/catch)