### PR TITLE
Internals: Add /update-version skill

### DIFF
--- a/.agents/skills/update-version/SKILL.md
+++ b/.agents/skills/update-version/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: update-version
+description: Update `AvailableFrom` in a PR to the current Remotion version from `main`.
+---
+
+Use this when a PR contains docs changes with `<AvailableFrom v="...">` and the value should match the version currently in `main`.
+
+1. Get the canonical version from `main`:
+
+```bash
+git fetch origin main --quiet
+git --no-pager show origin/main:packages/core/src/version.ts
+```
+
+Read `VERSION` from that file (for example: `4.0.468`).
+
+2. Find `AvailableFrom` entries changed in the current PR:
+
+```bash
+git --no-pager diff origin/main...HEAD -- packages/docs | rg 'AvailableFrom v="'
+```
+
+3. Update only `AvailableFrom` values touched by this PR so they match the `VERSION` from step 1.
+
+4. Do not change unrelated `AvailableFrom` values outside the PR diff.
+
+5. Commit and push the update.

--- a/.agents/skills/update-version/SKILL.md
+++ b/.agents/skills/update-version/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: update-version
-description: Update `AvailableFrom` in a PR to the current Remotion version from `main`.
+description: Update `AvailableFrom` in a PR to the next Remotion patch version (`main` + `0.0.1`).
 ---
 
-Use this when a PR contains docs changes with `<AvailableFrom v="...">` and the value should match the version currently in `main`.
+Use this when a PR contains docs changes with `<AvailableFrom v="...">` and the value should reflect the next release version.
 
 1. Get the canonical version from `main`:
 
@@ -12,7 +12,7 @@ git fetch origin main --quiet
 git --no-pager show origin/main:packages/core/src/version.ts
 ```
 
-Read `VERSION` from that file (for example: `4.0.468`).
+Read `VERSION` from that file (for example: `4.0.468`), then compute the next patch version by incrementing the patch number by 1 (`4.0.469`).
 
 2. Find `AvailableFrom` entries changed in the current PR:
 
@@ -20,7 +20,7 @@ Read `VERSION` from that file (for example: `4.0.468`).
 git --no-pager diff origin/main...HEAD -- packages/docs | rg 'AvailableFrom v="'
 ```
 
-3. Update only `AvailableFrom` values touched by this PR so they match the `VERSION` from step 1.
+3. Update only `AvailableFrom` values touched by this PR so they match the computed next patch version from step 1.
 
 4. Do not change unrelated `AvailableFrom` values outside the PR diff.
 


### PR DESCRIPTION
## Summary

Add a new agent skill `/update-version` that updates `AvailableFrom` values in PR docs to the current version from `main` (`packages/core/src/version.ts`).

## What the skill does

- Reads canonical `VERSION` from `origin/main`
- Finds `AvailableFrom` entries touched by the current PR
- Updates only touched values to match current `VERSION`
- Leaves unrelated version tags unchanged