### PR TITLE
`@remotion/studio`: Prevent selecting TimelineNonEditableStatus

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -21,6 +21,8 @@ const unsupportedLabel: React.CSSProperties = {
 	color: 'rgba(255, 255, 255, 0.4)',
 	fontSize: 12,
 	fontStyle: 'italic',
+	userSelect: 'none',
+	WebkitUserSelect: 'none',
 };
 
 const notEditableBackground: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- make non-editable timeline status labels non-selectable in the Studio timeline UI
- apply `userSelect: 'none'` and `WebkitUserSelect: 'none'` to the status text style

Fixes #7750
