### PR TITLE
fix(studio): truncate overflowing timeline labels

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineStack/index.tsx
+++ b/packages/studio/src/components/Timeline/TimelineStack/index.tsx
@@ -117,6 +117,7 @@ export const TimelineStack: React.FC<{
 			textOverflow: 'ellipsis',
 			overflow: 'hidden',
 			flexShrink: 100000,
+			minWidth: 0,
 			userSelect: 'none',
 			WebkitUserSelect: 'none',
 		};
@@ -130,6 +131,7 @@ export const TimelineStack: React.FC<{
 			flex: 1,
 			flexDirection: 'row',
 			minWidth: 0,
+			overflow: 'hidden',
 		};
 	}, []);
 
@@ -144,6 +146,7 @@ export const TimelineStack: React.FC<{
 			whiteSpace: 'nowrap',
 			textOverflow: 'ellipsis',
 			overflow: 'hidden',
+			minWidth: 0,
 			lineHeight: 1.2,
 			color: selected
 				? TIMELINE_SELECTED_LABEL_TEXT


### PR DESCRIPTION
## What changed

Fixes timeline list labels overflowing their row in narrow Studio layouts by making the label container and its text children explicitly shrinkable.

## Why

Fixes #7752. The title/source labels already used `overflow: hidden` and `textOverflow: ellipsis`, but flex items keep `min-width: auto` by default. That can make long labels keep their intrinsic width and spill outside the timeline list instead of truncating.

This change adds `minWidth: 0` to the shrinkable label text nodes and hides overflow at the label-row container level.

## Verification

- `git diff --check`

I could not run the Studio test suite locally because this sparse checkout does not have `node_modules` installed.