### PR TITLE
Fix expanded timeline field label wrapping

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -33,9 +33,12 @@ const valueColumnStyle: React.CSSProperties = {
 };
 
 const fieldName: React.CSSProperties = {
-	fontSize: 12,
 	color: 'rgba(255, 255, 255, 0.8)',
+	fontSize: 12,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
 	userSelect: 'none',
+	whiteSpace: 'nowrap',
 };
 
 const Value: React.FC<{

--- a/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRow.tsx
@@ -41,9 +41,12 @@ const valueColumnStyle: React.CSSProperties = {
 };
 
 const fieldName: React.CSSProperties = {
-	fontSize: 12,
 	color: 'rgba(255, 255, 255, 0.8)',
+	fontSize: 12,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
 	userSelect: 'none',
+	whiteSpace: 'nowrap',
 };
 
 const Value: React.FC<{

--- a/packages/studio/src/components/Timeline/timeline-field-row-layout.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-row-layout.ts
@@ -6,9 +6,11 @@ export const getTimelineFieldLabelRowStyle = (
 ): React.CSSProperties => {
 	return {
 		flex: `0 0 ${getTimelineFieldLabelFlexBasis(depth)}`,
+		alignItems: 'center',
 		display: 'flex',
 		flexDirection: 'row',
-		alignItems: 'center',
 		gap: 6,
+		minWidth: 0,
+		overflow: 'hidden',
 	};
 };


### PR DESCRIPTION
## Summary
- Keep expanded timeline field labels on one line inside narrow label columns
- Truncate long field labels with ellipsis so value controls stay aligned
- Apply the same label behavior to sequence and effect field rows

## Validation
- npx --yes oxfmt packages/studio/src/components/Timeline/TimelineFieldRow.tsx packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx packages/studio/src/components/Timeline/timeline-field-row-layout.ts --check
- git diff --check