### PR TITLE
`@remotion/studio-server`: Normalize legacy keyframed sequence status

### DIFF
--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -683,38 +683,6 @@ const computeSequenceOnlyPropsRecord = ({
 	return filteredProps;
 };
 
-export const computeSequencePropsOnlyStatus = ({
-	fileName,
-	nodePath,
-	keys,
-	remotionRoot,
-}: {
-	fileName: string;
-	nodePath: SequenceNodePath;
-	keys: string[];
-	remotionRoot: string;
-}): {canUpdate: true; props: Record<string, CanUpdatePropStatus>} => {
-	const {absolutePath} = resolveFileInsideProject({
-		remotionRoot,
-		fileName,
-		action: 'read',
-	});
-
-	const fileContents = readFileSync(absolutePath, 'utf-8');
-	const ast = parseAst(fileContents);
-	const jsxElement = findJsxElementAtNodePath(ast, nodePath);
-	if (!jsxElement) {
-		throw new Error(
-			'Cannot compute sequence props: Could not find a JSX element at the specified location',
-		);
-	}
-
-	return {
-		canUpdate: true as const,
-		props: computeSequenceOnlyPropsRecord({jsxElement, keys}),
-	};
-};
-
 export const computeSequencePropsStatusFromContent = ({
 	fileContents,
 	nodePath,

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -5,7 +5,6 @@ import type {
 	SaveSequencePropsResponse,
 } from '@remotion/studio-shared';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
-import type {CanUpdateSequencePropStatus} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {updateSequenceProps} from '../../codemods/update-sequence-props/update-sequence-props';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
@@ -17,62 +16,10 @@ import {
 	suppressUndoStackInvalidation,
 } from '../undo-stack';
 import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
-import {computeSequencePropsOnlyStatus} from './can-update-sequence-props';
+import {computeSequencePropsStatusFromContent} from './can-update-sequence-props';
 import {formatPropChange} from './log-updates/format-prop-change';
 import {logUpdate, normalizeQuotes} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
-
-type KeyframedStatus = Extract<
-	CanUpdateSequencePropStatus,
-	{canUpdate: false; reason: 'keyframed'}
->;
-
-const getLegacyComputedKeyframes = (
-	status: CanUpdateSequencePropStatus,
-): KeyframedStatus['keyframes'] | null => {
-	if (status.canUpdate || status.reason !== 'computed') {
-		return null;
-	}
-
-	const keyframes = (status as unknown as {keyframes?: unknown}).keyframes;
-	if (!Array.isArray(keyframes)) {
-		return null;
-	}
-
-	if (
-		!keyframes.every(
-			(keyframe) =>
-				typeof keyframe === 'object' &&
-				keyframe !== null &&
-				'frame' in keyframe &&
-				typeof keyframe.frame === 'number' &&
-				'value' in keyframe,
-		)
-	) {
-		return null;
-	}
-
-	return keyframes as KeyframedStatus['keyframes'];
-};
-
-const normalizePropStatus = (
-	status: CanUpdateSequencePropStatus,
-): CanUpdateSequencePropStatus => {
-	const keyframes = getLegacyComputedKeyframes(status);
-	if (!keyframes) {
-		return status;
-	}
-
-	return {
-		canUpdate: false,
-		reason: 'keyframed',
-		keyframes,
-		easing: new Array(Math.max(0, keyframes.length - 1)).fill(
-			'linear',
-		) as KeyframedStatus['easing'],
-		clamping: {left: 'extend', right: 'extend'},
-	};
-};
 
 export const saveSequencePropsHandler: ApiHandler<
 	SaveSequencePropsRequest,
@@ -171,20 +118,15 @@ export const saveSequencePropsHandler: ApiHandler<
 
 		printUndoHint(logLevel);
 
-		const newStatus = computeSequencePropsOnlyStatus({
-			fileName,
+		const newStatus = computeSequencePropsStatusFromContent({
+			fileContents: output,
 			keys: getAllSchemaKeys(schema),
 			nodePath: nodePath.nodePath,
-			remotionRoot,
+			effects: [],
 		});
-
-		const normalizedProps: Record<string, CanUpdateSequencePropStatus> = {};
-		for (const [propKey, propStatus] of Object.entries(newStatus.props)) {
-			normalizedProps[propKey] = normalizePropStatus(propStatus);
-		}
 
 		return {
 			canUpdate: true,
-			props: normalizedProps,
+			props: newStatus.props,
 		};
 	});

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -5,6 +5,7 @@ import type {
 	SaveSequencePropsResponse,
 } from '@remotion/studio-shared';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
+import type {CanUpdateSequencePropStatus} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {updateSequenceProps} from '../../codemods/update-sequence-props/update-sequence-props';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
@@ -20,6 +21,58 @@ import {computeSequencePropsOnlyStatus} from './can-update-sequence-props';
 import {formatPropChange} from './log-updates/format-prop-change';
 import {logUpdate, normalizeQuotes} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
+
+type KeyframedStatus = Extract<
+	CanUpdateSequencePropStatus,
+	{canUpdate: false; reason: 'keyframed'}
+>;
+
+const getLegacyComputedKeyframes = (
+	status: CanUpdateSequencePropStatus,
+): KeyframedStatus['keyframes'] | null => {
+	if (status.canUpdate || status.reason !== 'computed') {
+		return null;
+	}
+
+	const keyframes = (status as unknown as {keyframes?: unknown}).keyframes;
+	if (!Array.isArray(keyframes)) {
+		return null;
+	}
+
+	if (
+		!keyframes.every(
+			(keyframe) =>
+				typeof keyframe === 'object' &&
+				keyframe !== null &&
+				'frame' in keyframe &&
+				typeof keyframe.frame === 'number' &&
+				'value' in keyframe,
+		)
+	) {
+		return null;
+	}
+
+	return keyframes as KeyframedStatus['keyframes'];
+};
+
+const normalizePropStatus = (
+	status: CanUpdateSequencePropStatus,
+): CanUpdateSequencePropStatus => {
+	const keyframes = getLegacyComputedKeyframes(status);
+	if (!keyframes) {
+		return status;
+	}
+
+	return {
+		canUpdate: false,
+		reason: 'keyframed',
+		keyframes,
+		easing: new Array(Math.max(0, keyframes.length - 1)).fill(
+			'linear',
+		) as KeyframedStatus['easing'],
+		clamping: {left: 'extend', right: 'extend'},
+	};
+};
 
 export const saveSequencePropsHandler: ApiHandler<
 	SaveSequencePropsRequest,
@@ -125,5 +178,13 @@ export const saveSequencePropsHandler: ApiHandler<
 			remotionRoot,
 		});
 
-		return newStatus;
+		const normalizedProps: Record<string, CanUpdateSequencePropStatus> = {};
+		for (const [propKey, propStatus] of Object.entries(newStatus.props)) {
+			normalizedProps[propKey] = normalizePropStatus(propStatus);
+		}
+
+		return {
+			canUpdate: true,
+			props: normalizedProps,
+		};
 	});


### PR DESCRIPTION
## Summary
- normalize legacy sequence prop status returned by `/api/save-sequence-props`
- map malformed `computed` statuses with keyframes to `keyframed`
- provide default easing/clamping fallback for normalized keyframed payloads

## Testing
- bunx oxfmt src --write (packages/studio-server)
- bun run build
- bun run formatting
