### PR TITLE
`@remotion/studio`: Delete keyframes with Backspace (WIP)

### DIFF
--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -477,6 +477,7 @@ export const updateSequenceKeyframesAst = ({
 }): {
 	serialized: string;
 	oldValueStrings: string[];
+	newValueStrings: string[];
 	logLine: number;
 } => {
 	const ast = parseAst(input);
@@ -492,23 +493,25 @@ export const updateSequenceKeyframesAst = ({
 	}
 
 	const oldValueStrings: string[] = [];
+	const newValueStrings: string[] = [];
 	for (const update of updates) {
 		const prop = getSequenceWritableProp({
 			attributes: node.attributes,
 			key: update.key,
 		});
 		oldValueStrings.push(recast.print(prop.expression).code);
-		prop.setExpression(
-			applyKeyframeOperation({
-				expression: prop.expression,
-				operation: update.operation,
-			}),
-		);
+		const nextExpression = applyKeyframeOperation({
+			expression: prop.expression,
+			operation: update.operation,
+		});
+		newValueStrings.push(recast.print(nextExpression).code);
+		prop.setExpression(nextExpression);
 	}
 
 	return {
 		serialized: serializeAst(ast),
 		oldValueStrings,
+		newValueStrings,
 		logLine: node.loc?.start.line ?? 1,
 	};
 };
@@ -527,19 +530,21 @@ export const updateSequenceKeyframes = async ({
 	output: string;
 	formatted: boolean;
 	oldValueStrings: string[];
+	newValueStrings: string[];
 	logLine: number;
 }> => {
-	const {serialized, oldValueStrings, logLine} = updateSequenceKeyframesAst({
-		input,
-		nodePath,
-		updates,
-	});
+	const {serialized, oldValueStrings, newValueStrings, logLine} =
+		updateSequenceKeyframesAst({
+			input,
+			nodePath,
+			updates,
+		});
 	const {output, formatted} = await formatFileContent({
 		input: serialized,
 		prettierConfigOverride,
 	});
 
-	return {output, formatted, oldValueStrings, logLine};
+	return {output, formatted, oldValueStrings, newValueStrings, logLine};
 };
 
 export const updateEffectKeyframesAst = ({
@@ -555,6 +560,7 @@ export const updateEffectKeyframesAst = ({
 }): {
 	serialized: string;
 	oldValueStrings: string[];
+	newValueStrings: string[];
 	logLine: number;
 	effectCallee: string;
 } => {
@@ -586,6 +592,7 @@ export const updateEffectKeyframesAst = ({
 
 	const objExpr = call.arguments[0] as ObjectExpression;
 	const oldValueStrings: string[] = [];
+	const newValueStrings: string[] = [];
 	for (const update of updates) {
 		const {prop} = findObjectProperty(objExpr, update.key);
 		if (!prop) {
@@ -593,15 +600,18 @@ export const updateEffectKeyframesAst = ({
 		}
 
 		oldValueStrings.push(recast.print(prop.value).code);
-		prop.value = applyKeyframeOperation({
+		const nextExpression = applyKeyframeOperation({
 			expression: prop.value as Expression,
 			operation: update.operation,
-		}) as ObjectProperty['value'];
+		});
+		newValueStrings.push(recast.print(nextExpression).code);
+		prop.value = nextExpression as ObjectProperty['value'];
 	}
 
 	return {
 		serialized: serializeAst(ast),
 		oldValueStrings,
+		newValueStrings,
 		logLine: call.loc?.start.line ?? jsx.loc?.start.line ?? 1,
 		effectCallee,
 	};
@@ -623,10 +633,11 @@ export const updateEffectKeyframes = async ({
 	output: string;
 	formatted: boolean;
 	oldValueStrings: string[];
+	newValueStrings: string[];
 	logLine: number;
 	effectCallee: string;
 }> => {
-	const {serialized, oldValueStrings, logLine, effectCallee} =
+	const {serialized, oldValueStrings, newValueStrings, logLine, effectCallee} =
 		updateEffectKeyframesAst({
 			input,
 			sequenceNodePath,
@@ -638,5 +649,12 @@ export const updateEffectKeyframes = async ({
 		prettierConfigOverride,
 	});
 
-	return {output, formatted, oldValueStrings, logLine, effectCallee};
+	return {
+		output,
+		formatted,
+		oldValueStrings,
+		newValueStrings,
+		logLine,
+		effectCallee,
+	};
 };

--- a/packages/studio-server/src/preview-server/routes/save-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-effect-props.ts
@@ -1,5 +1,6 @@
 import {readFileSync} from 'node:fs';
 import {RenderInternals} from '@remotion/renderer';
+import type {LogLevel} from '@remotion/renderer';
 import type {
 	SaveEffectPropsRequest,
 	SaveEffectPropsResponse,
@@ -7,6 +8,7 @@ import type {
 import {getAllSchemaKeys} from '@remotion/studio-shared';
 import {parseAst} from '../../codemods/parse-ast';
 import {updateEffectProps} from '../../codemods/update-effect-props/update-effect-props';
+import {updateEffectKeyframes} from '../../codemods/update-keyframes/update-keyframes';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
@@ -23,6 +25,127 @@ import {logEffectUpdate} from './log-updates/log-effect-update';
 import {normalizeQuotes} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
 
+const removeEffectKeyframe = async ({
+	absolutePath,
+	clientId,
+	effectIndex,
+	fileContents,
+	fileRelativeToRoot,
+	key,
+	keyframeOperation,
+	logLevel,
+	remotionRoot,
+	schema,
+	sequenceNodePath,
+}: {
+	absolutePath: string;
+	clientId: string;
+	effectIndex: number;
+	fileContents: string;
+	fileRelativeToRoot: string;
+	key: string;
+	keyframeOperation: {type: 'remove'; frame: number};
+	logLevel: LogLevel;
+	remotionRoot: string;
+	schema: SaveEffectPropsRequest['schema'];
+	sequenceNodePath: SaveEffectPropsRequest['sequenceNodePath'];
+}): Promise<SaveEffectPropsResponse> => {
+	const {
+		output,
+		oldValueStrings,
+		newValueStrings,
+		formatted,
+		logLine,
+		effectCallee,
+	} = await updateEffectKeyframes({
+		input: fileContents,
+		sequenceNodePath: sequenceNodePath.nodePath,
+		effectIndex,
+		updates: [
+			{
+				key,
+				operation: {
+					type: 'remove',
+					frame: keyframeOperation.frame,
+				},
+			},
+		],
+	});
+
+	const oldValueString = oldValueStrings[0];
+	const newValueString = newValueStrings[0];
+	const normalizedOld = normalizeQuotes(oldValueString);
+	const normalizedNew = normalizeQuotes(newValueString);
+
+	const undoPropChange = formatEffectPropChange({
+		effectName: effectCallee,
+		key,
+		oldValueString: normalizedNew,
+		newValueString: normalizedOld,
+		defaultValueString: null,
+		removedProps: [],
+		addedProps: [],
+	});
+	const redoPropChange = formatEffectPropChange({
+		effectName: effectCallee,
+		key,
+		oldValueString: normalizedOld,
+		newValueString: normalizedNew,
+		defaultValueString: null,
+		removedProps: [],
+		addedProps: [],
+	});
+
+	pushToUndoStack({
+		filePath: absolutePath,
+		oldContents: fileContents,
+		logLevel,
+		remotionRoot,
+		logLine,
+		description: {
+			undoMessage: `↩️  ${undoPropChange}`,
+			redoMessage: `↪️  ${redoPropChange}`,
+		},
+		entryType: 'effect-props',
+		suppressHmrOnFileRestore: true,
+	});
+	suppressUndoStackInvalidation(absolutePath);
+	suppressBundlerUpdateForFile(absolutePath);
+	writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
+
+	logEffectUpdate({
+		fileRelativeToRoot,
+		line: logLine,
+		effectName: effectCallee,
+		propKey: key,
+		oldValueString,
+		newValueString,
+		defaultValueString: null,
+		formatted,
+		logLevel,
+		removedProps: [],
+		addedProps: [],
+	});
+
+	printUndoHint(logLevel);
+
+	const ast = parseAst(readFileSync(absolutePath, 'utf-8'));
+	const jsx = findJsxElementAtNodePath(ast, sequenceNodePath.nodePath);
+	if (!jsx) {
+		return {
+			canUpdate: false,
+			effectIndex,
+			reason: 'not-found',
+		};
+	}
+
+	return computeEffectPropStatus({
+		jsx,
+		effectIndex,
+		keys: getAllSchemaKeys(schema),
+	});
+};
+
 export const saveEffectPropsHandler: ApiHandler<
 	SaveEffectPropsRequest,
 	SaveEffectPropsResponse
@@ -36,6 +159,7 @@ export const saveEffectPropsHandler: ApiHandler<
 		defaultValue,
 		schema,
 		clientId,
+		keyframeOperation,
 	},
 	remotionRoot,
 	logLevel,
@@ -52,6 +176,22 @@ export const saveEffectPropsHandler: ApiHandler<
 		});
 
 		const fileContents = readFileSync(absolutePath, 'utf-8');
+
+		if (keyframeOperation?.type === 'remove') {
+			return removeEffectKeyframe({
+				absolutePath,
+				clientId,
+				effectIndex,
+				fileContents,
+				fileRelativeToRoot,
+				key,
+				keyframeOperation,
+				logLevel,
+				remotionRoot,
+				schema,
+				sequenceNodePath,
+			});
+		}
 
 		const parsedDefault =
 			defaultValue !== null ? JSON.parse(defaultValue) : null;

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -1,11 +1,13 @@
 import {readFileSync} from 'node:fs';
 import {RenderInternals} from '@remotion/renderer';
+import type {LogLevel} from '@remotion/renderer';
 import type {
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse,
 } from '@remotion/studio-shared';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
 import {NoReactInternals} from 'remotion/no-react';
+import {updateSequenceKeyframes} from '../../codemods/update-keyframes/update-keyframes';
 import {updateSequenceProps} from '../../codemods/update-sequence-props/update-sequence-props';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
@@ -21,11 +23,125 @@ import {formatPropChange} from './log-updates/format-prop-change';
 import {logUpdate, normalizeQuotes} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
 
+const removeSequenceKeyframe = async ({
+	absolutePath,
+	clientId,
+	fileContents,
+	fileRelativeToRoot,
+	key,
+	keyframeOperation,
+	logLevel,
+	nodePath,
+	remotionRoot,
+	schema,
+}: {
+	absolutePath: string;
+	clientId: string;
+	fileContents: string;
+	fileRelativeToRoot: string;
+	key: string;
+	keyframeOperation: {type: 'remove'; frame: number};
+	logLevel: LogLevel;
+	nodePath: SaveSequencePropsRequest['nodePath'];
+	remotionRoot: string;
+	schema: SaveSequencePropsRequest['schema'];
+}): Promise<SaveSequencePropsResponse> => {
+	const {output, oldValueStrings, newValueStrings, formatted, logLine} =
+		await updateSequenceKeyframes({
+			input: fileContents,
+			nodePath: nodePath.nodePath,
+			updates: [
+				{
+					key,
+					operation: {
+						type: 'remove',
+						frame: keyframeOperation.frame,
+					},
+				},
+			],
+		});
+
+	const oldValueString = oldValueStrings[0];
+	const newValueString = newValueStrings[0];
+	const normalizedOld = normalizeQuotes(oldValueString);
+	const normalizedNew = normalizeQuotes(newValueString);
+
+	const undoPropChange = formatPropChange({
+		key,
+		oldValueString: normalizedNew,
+		newValueString: normalizedOld,
+		defaultValueString: null,
+		removedProps: [],
+		addedProps: [],
+	});
+	const redoPropChange = formatPropChange({
+		key,
+		oldValueString: normalizedOld,
+		newValueString: normalizedNew,
+		defaultValueString: null,
+		removedProps: [],
+		addedProps: [],
+	});
+
+	pushToUndoStack({
+		filePath: absolutePath,
+		oldContents: fileContents,
+		logLevel,
+		remotionRoot,
+		logLine,
+		description: {
+			undoMessage: `↩️  ${undoPropChange}`,
+			redoMessage: `↪️  ${redoPropChange}`,
+		},
+		entryType: 'sequence-props',
+		suppressHmrOnFileRestore: true,
+	});
+	suppressUndoStackInvalidation(absolutePath);
+	suppressBundlerUpdateForFile(absolutePath);
+	writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
+
+	logUpdate({
+		fileRelativeToRoot,
+		line: logLine,
+		key,
+		oldValueString,
+		newValueString,
+		defaultValueString: null,
+		formatted,
+		logLevel,
+		removedProps: [],
+		addedProps: [],
+	});
+
+	printUndoHint(logLevel);
+
+	const status = computeSequencePropsStatusFromContent({
+		fileContents: output,
+		keys: getAllSchemaKeys(schema),
+		nodePath: nodePath.nodePath,
+		effects: [],
+	});
+
+	return {
+		canUpdate: true,
+		props: status.props,
+	};
+};
+
 export const saveSequencePropsHandler: ApiHandler<
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse
 > = ({
-	input: {fileName, nodePath, key, value, defaultValue, schema, clientId},
+	input: {
+		fileName,
+		nodePath,
+		key,
+		value,
+		defaultValue,
+		schema,
+		clientId,
+		keyframeOperation,
+	},
 	remotionRoot,
 	logLevel,
 }) =>
@@ -41,6 +157,21 @@ export const saveSequencePropsHandler: ApiHandler<
 		});
 
 		const fileContents = readFileSync(absolutePath, 'utf-8');
+
+		if (keyframeOperation?.type === 'remove') {
+			return removeSequenceKeyframe({
+				absolutePath,
+				clientId,
+				fileContents,
+				fileRelativeToRoot,
+				key,
+				keyframeOperation,
+				logLevel,
+				nodePath,
+				remotionRoot,
+				schema,
+			});
+		}
 
 		const {output, oldValueStrings, formatted, logLine, removedProps} =
 			await updateSequenceProps({

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -248,6 +248,11 @@ export type UnsubscribeFromSequencePropsRequest = {
 	effectKeys: string[][];
 };
 
+export type KeyframeRemoveOperation = {
+	type: 'remove';
+	frame: number;
+};
+
 export type SaveSequencePropsRequest = {
 	fileName: string;
 	nodePath: SequencePropsSubscriptionKey;
@@ -256,6 +261,7 @@ export type SaveSequencePropsRequest = {
 	defaultValue: string | null;
 	schema: SequenceSchema;
 	clientId: string;
+	keyframeOperation?: KeyframeRemoveOperation;
 };
 
 export type SaveSequencePropsResponse =
@@ -277,6 +283,7 @@ export type SaveEffectPropsRequest = {
 	defaultValue: string | null;
 	schema: SequenceSchema;
 	clientId: string;
+	keyframeOperation?: KeyframeRemoveOperation;
 };
 
 export type SaveEffectPropsResponse = CanUpdateEffectPropsResponse;

--- a/packages/studio/src/components/Timeline/TimelineKeyframeKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeKeybindings.tsx
@@ -1,0 +1,69 @@
+import React, {useContext, useEffect} from 'react';
+import {Internals} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {useKeybinding} from '../../helpers/use-keybinding';
+import {deleteSelectedKeyframe} from './delete-selected-keyframe';
+import {useTimelineSelection} from './TimelineSelection';
+
+export const TimelineKeyframeKeybindings: React.FC = () => {
+	const keybindings = useKeybinding();
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {sequences} = useContext(Internals.SequenceManager);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
+	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {canSelect, selectedItem, clearSelection} = useTimelineSelection();
+
+	useEffect(() => {
+		if (
+			!canSelect ||
+			previewServerState.type !== 'connected' ||
+			selectedItem?.type !== 'keyframe'
+		) {
+			return;
+		}
+
+		const clientId = previewServerState.clientId;
+		const currentSelection = selectedItem;
+		const backspace = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'Backspace',
+			callback: () => {
+				const deletePromise = deleteSelectedKeyframe({
+					nodePathInfo: currentSelection.nodePathInfo,
+					frame: currentSelection.frame,
+					sequences,
+					overrideIdsToNodePaths: overrideIdToNodePathMappings,
+					setCodeValues,
+					clientId,
+				});
+				if (deletePromise === null) {
+					return;
+				}
+
+				clearSelection();
+				deletePromise.catch(() => undefined);
+			},
+			commandCtrlKey: false,
+			preventDefault: true,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+
+		return () => {
+			backspace.unregister();
+		};
+	}, [
+		canSelect,
+		clearSelection,
+		keybindings,
+		overrideIdToNodePathMappings,
+		previewServerState,
+		selectedItem,
+		sequences,
+		setCodeValues,
+	]);
+
+	return null;
+};

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -12,6 +12,7 @@ import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
+import {TimelineKeyframeKeybindings} from './TimelineKeyframeKeybindings';
 
 export const TIMELINE_SELECTED_BACKGROUND = '#3B3F42';
 export const TIMELINE_SELECTED_LABEL_BACKGROUND = '#B0B0B0';
@@ -51,8 +52,8 @@ export const TIMELINE_SELECTED_TRACK_HIGHLIGHT_STYLE: CSSProperties = {
 	top: 0,
 };
 
-export const SELECTION_ENABLED = false;
-export const TIMELINE_TOP_DRAG = false;
+export const SELECTION_ENABLED = true;
+export const TIMELINE_TOP_DRAG = true;
 
 export type TimelineSelection =
 	| {
@@ -67,6 +68,7 @@ export type TimelineSelection =
 
 type TimelineSelectionContextValue = {
 	readonly canSelect: boolean;
+	readonly selectedItem: TimelineSelection | null;
 	readonly isSelected: (item: TimelineSelection) => boolean;
 	readonly selectItem: (item: TimelineSelection) => void;
 	readonly containsSelection: (nodePathInfo: SequenceNodePathInfo) => boolean;
@@ -75,6 +77,7 @@ type TimelineSelectionContextValue = {
 
 const TimelineSelectionContext = createContext<TimelineSelectionContextValue>({
 	canSelect: false,
+	selectedItem: null,
 	isSelected: () => false,
 	selectItem: () => undefined,
 	containsSelection: () => false,
@@ -173,17 +176,26 @@ export const TimelineSelectionProvider: React.FC<{
 	const value = useMemo(
 		(): TimelineSelectionContextValue => ({
 			canSelect,
+			selectedItem,
 			isSelected,
 			selectItem,
 			containsSelection,
 			clearSelection,
 		}),
-		[canSelect, isSelected, selectItem, containsSelection, clearSelection],
+		[
+			canSelect,
+			selectedItem,
+			isSelected,
+			selectItem,
+			containsSelection,
+			clearSelection,
+		],
 	);
 
 	return (
 		<TimelineSelectionContext.Provider value={value}>
 			{children}
+			<TimelineKeyframeKeybindings />
 		</TimelineSelectionContext.Provider>
 	);
 };

--- a/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
@@ -1,0 +1,116 @@
+import {stringifySequenceSubscriptionKey} from '@remotion/studio-shared';
+import type {OverrideIdToNodePaths, TSequence} from 'remotion';
+import {calculateTimeline} from '../../helpers/calculate-timeline';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {callApi} from '../call-api';
+import {parseKeyframeFieldFromNodePath} from './parse-keyframe-field-from-node-path';
+import {enqueueSavePropChange} from './save-prop-queue';
+import type {SetCodeValues} from './save-sequence-prop';
+
+const findTrackForNodePathInfo = ({
+	sequences,
+	overrideIdsToNodePaths,
+	nodePathInfo,
+}: {
+	sequences: TSequence[];
+	overrideIdsToNodePaths: OverrideIdToNodePaths;
+	nodePathInfo: SequenceNodePathInfo;
+}) => {
+	const tracks = calculateTimeline({sequences, overrideIdsToNodePaths});
+	return tracks.find(
+		(candidate) =>
+			candidate.nodePathInfo !== null &&
+			stringifySequenceSubscriptionKey(
+				candidate.nodePathInfo.sequenceSubscriptionKey,
+			) ===
+				stringifySequenceSubscriptionKey(
+					nodePathInfo.sequenceSubscriptionKey,
+				) &&
+			candidate.nodePathInfo.index === nodePathInfo.index,
+	);
+};
+
+export const deleteSelectedKeyframe = ({
+	nodePathInfo,
+	frame,
+	sequences,
+	overrideIdsToNodePaths,
+	setCodeValues,
+	clientId,
+}: {
+	nodePathInfo: SequenceNodePathInfo;
+	frame: number;
+	sequences: TSequence[];
+	overrideIdsToNodePaths: OverrideIdToNodePaths;
+	setCodeValues: SetCodeValues;
+	clientId: string;
+}): Promise<void> | null => {
+	const field = parseKeyframeFieldFromNodePath(nodePathInfo.auxiliaryKeys);
+	if (field === null) {
+		return null;
+	}
+
+	const track = findTrackForNodePathInfo({
+		sequences,
+		overrideIdsToNodePaths,
+		nodePathInfo,
+	});
+	const sequence = track?.sequence ?? null;
+	if (!sequence?.controls) {
+		return null;
+	}
+
+	const sourceFrame = frame - (track?.keyframeDisplayOffset ?? 0);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const fileName = nodePath.absolutePath;
+
+	if (field.type === 'effect') {
+		const effect = sequence.effects[field.effectIndex];
+		if (!effect) {
+			return null;
+		}
+
+		return enqueueSavePropChange({
+			nodePath,
+			setCodeValues,
+			applyOptimistic: (prev) => prev,
+			apiCall: () =>
+				callApi('/api/save-effect-props', {
+					fileName,
+					sequenceNodePath: nodePath,
+					effectIndex: field.effectIndex,
+					key: field.fieldKey,
+					value: '',
+					defaultValue: null,
+					schema: effect.schema,
+					clientId,
+					keyframeOperation: {
+						type: 'remove',
+						frame: sourceFrame,
+					},
+				}),
+			errorLabel: 'Could not delete keyframe',
+		});
+	}
+
+	return enqueueSavePropChange({
+		nodePath,
+		setCodeValues,
+		applyOptimistic: (prev) => prev,
+		apiCall: () =>
+			callApi('/api/save-sequence-props', {
+				fileName,
+				nodePath,
+				key: field.fieldKey,
+				value: '',
+				defaultValue: null,
+				schema: sequence.controls!.schema,
+				clientId,
+				keyframeOperation: {
+					type: 'remove',
+					frame: sourceFrame,
+				},
+			}),
+		errorLabel: 'Could not delete keyframe',
+	});
+};

--- a/packages/studio/src/components/Timeline/parse-keyframe-field-from-node-path.ts
+++ b/packages/studio/src/components/Timeline/parse-keyframe-field-from-node-path.ts
@@ -1,0 +1,35 @@
+export const parseKeyframeFieldFromNodePath = (
+	auxiliaryKeys: string[],
+):
+	| {
+			readonly type: 'sequence';
+			readonly fieldKey: string;
+	  }
+	| {
+			readonly type: 'effect';
+			readonly effectIndex: number;
+			readonly fieldKey: string;
+	  }
+	| null => {
+	if (auxiliaryKeys[0] === 'controls' && auxiliaryKeys.length >= 2) {
+		return {
+			type: 'sequence',
+			fieldKey: auxiliaryKeys[1],
+		};
+	}
+
+	if (
+		auxiliaryKeys[0] === 'effects' &&
+		auxiliaryKeys.length >= 3 &&
+		auxiliaryKeys[1] !== undefined &&
+		auxiliaryKeys[2] !== undefined
+	) {
+		return {
+			type: 'effect',
+			effectIndex: Number(auxiliaryKeys[1]),
+			fieldKey: auxiliaryKeys[2],
+		};
+	}
+
+	return null;
+};

--- a/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
+++ b/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
@@ -33,17 +33,26 @@ export const useExpandedTrackKeyframeRows = ({
 } => {
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {getDragOverrides, getEffectDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
 
 	const tree = useMemo(
 		() =>
 			buildTimelineTree({
 				sequence,
 				nodePathInfo,
-				getDragOverrides: () => ({}),
-				getEffectDragOverrides: () => ({}),
+				getDragOverrides,
+				getEffectDragOverrides,
 				codeValues,
 			}),
-		[codeValues, nodePathInfo, sequence],
+		[
+			codeValues,
+			getDragOverrides,
+			getEffectDragOverrides,
+			nodePathInfo,
+			sequence,
+		],
 	);
 
 	const flat = useMemo(


### PR DESCRIPTION
## Summary

- Add Backspace shortcut to delete a selected timeline keyframe
- Extend `/api/save-effect-props` and `/api/save-sequence-props` with `keyframeOperation: { type: 'remove', frame }`, backed by `update-keyframes` codemods
- Enable timeline selection flags and hook expanded track keyframe rows up to drag overrides

## WIP / follow-ups

- **Optimistic updates are not hooked up yet** for keyframe deletion. The delete path currently skips optimistic UI updates and relies on the server round-trip/subscription refresh.

## Test plan

- [ ] Select a keyframe diamond in the timeline and press Backspace
- [ ] Verify the interpolation is updated in source for sequence props and effect props
- [ ] Verify undo/redo restores the removed keyframe
- [ ] Confirm Backspace does nothing when no keyframe is selected
