### PR TITLE
`@remotion/cli`: Fix dark mode config option precedence

### DIFF
--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -93,7 +93,7 @@ export type CommandLineOptions = {
 	[ignoreCertificateErrorsOption.cliFlag]: TypeOfOption<
 		typeof ignoreCertificateErrorsOption
 	>;
-	[darkModeOption.cliFlag]: TypeOfOption<typeof darkModeOption>;
+	[darkModeOption.cliFlag]: TypeOfOption<typeof darkModeOption> | null;
 	[disableWebSecurityOption.cliFlag]: TypeOfOption<
 		typeof disableWebSecurityOption
 	>;

--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -221,6 +221,7 @@ export const parsedCli = minimist<CommandLineOptions>(process.argv.slice(2), {
 		[bundleCacheOption.cliFlag]: null,
 		[allowHtmlInCanvasOption.cliFlag]: null,
 		[experimentalClientSideRenderingOption.cliFlag]: null,
+		[darkModeOption.cliFlag]: null,
 		[mutedOption.cliFlag]: null,
 	},
 }) as CommandLineOptions & {

--- a/packages/cli/src/test/config-chromium.test.ts
+++ b/packages/cli/src/test/config-chromium.test.ts
@@ -23,3 +23,18 @@ test('getChromiumOpenGlRenderer, override Puppeter Config - angle value', () => 
 		BrowserSafeApis.options.glOption.getValue({commandLine: {}}).value,
 	).toEqual('angle');
 });
+
+test('getChromiumDarkMode respects the config file if the CLI flag is absent', () => {
+	Config.setChromiumDarkMode(true);
+	expect(
+		BrowserSafeApis.options.darkModeOption.getValue({
+			commandLine: {'dark-mode': null},
+		}).value,
+	).toEqual(true);
+	expect(
+		BrowserSafeApis.options.darkModeOption.getValue({
+			commandLine: {'dark-mode': false},
+		}).value,
+	).toEqual(false);
+	Config.setChromiumDarkMode(false);
+});

--- a/packages/cli/src/test/config-chromium.test.ts
+++ b/packages/cli/src/test/config-chromium.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
 import {BrowserSafeApis} from '@remotion/renderer/client';
 import {Config} from '../config';
+import {parsedCli} from '../parsed-cli';
 
 test('getChromiumOpenGlRenderer from Config - angle value', () => {
 	Config.setChromiumOpenGlRenderer('angle');
@@ -24,17 +25,6 @@ test('getChromiumOpenGlRenderer, override Puppeter Config - angle value', () => 
 	).toEqual('angle');
 });
 
-test('getChromiumDarkMode respects the config file if the CLI flag is absent', () => {
-	Config.setChromiumDarkMode(true);
-	expect(
-		BrowserSafeApis.options.darkModeOption.getValue({
-			commandLine: {'dark-mode': null},
-		}).value,
-	).toEqual(true);
-	expect(
-		BrowserSafeApis.options.darkModeOption.getValue({
-			commandLine: {'dark-mode': false},
-		}).value,
-	).toEqual(false);
-	Config.setChromiumDarkMode(false);
+test('getChromiumDarkMode does not default to a CLI value', () => {
+	expect(parsedCli['dark-mode']).toEqual(null);
 });

--- a/packages/renderer/src/options/dark-mode.tsx
+++ b/packages/renderer/src/options/dark-mode.tsx
@@ -20,7 +20,7 @@ export const darkModeOption = {
 	docLink: 'https://www.remotion.dev/docs/chromium-flags#--dark-mode',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				source: 'cli',
 				value: commandLine[cliFlag] as boolean,

--- a/packages/renderer/src/test/dark-mode-option.test.ts
+++ b/packages/renderer/src/test/dark-mode-option.test.ts
@@ -1,0 +1,17 @@
+import {expect, test} from 'bun:test';
+import {darkModeOption} from '../options/dark-mode';
+
+test('dark mode option respects config if CLI flag is absent', () => {
+	darkModeOption.setConfig(true);
+	expect(
+		darkModeOption.getValue({
+			commandLine: {'dark-mode': null},
+		}).value,
+	).toEqual(true);
+	expect(
+		darkModeOption.getValue({
+			commandLine: {'dark-mode': false},
+		}).value,
+	).toEqual(false);
+	darkModeOption.setConfig(false);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7766

## Summary
- Treat an absent `--dark-mode` CLI flag as not provided, allowing `Config.setChromiumDarkMode(true)` from `remotion.config.ts` to take effect.
- Preserve explicit CLI override behavior for `--no-dark-mode`.
- Add regression tests for CLI parsing and renderer option precedence.

## Testing
- `bun test src/test/config-chromium.test.ts`
- `bun test src/test/dark-mode-option.test.ts`
- `bun run build`
- `bun run formatting`
- `bunx remotion still src/index.ts dark-mode-test /tmp/dark-mode-config.png --log=error` with temporary `Config.setChromiumDarkMode(true)` in `packages/example/remotion.config.ts`
- `ffmpeg -v error -i /tmp/dark-mode-config.png -vf crop=1:1:0:0,format=rgb24 -f rawvideo - | od -An -tx1` returned `1a 1a 1a`, matching the dark-mode CSS background.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9ff05df-fb97-4203-a1f8-eaf54a6429cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9ff05df-fb97-4203-a1f8-eaf54a6429cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

