### PR TITLE
`@remotion/renderer`: Remove dark mode render debug log

### DIFF
--- a/packages/renderer/src/browser/BrowserPage.ts
+++ b/packages/renderer/src/browser/BrowserPage.ts
@@ -598,7 +598,7 @@ export class Page extends EventEmitter {
 	}
 
 	async setAutoDarkModeOverride(): Promise<void> {
-		const result = await this.#client.send('Emulation.setEmulatedMedia', {
+		await this.#client.send('Emulation.setEmulatedMedia', {
 			media: 'screen',
 			features: [
 				{
@@ -607,7 +607,6 @@ export class Page extends EventEmitter {
 				},
 			],
 		});
-		console.log(result);
 	}
 
 	evaluate<T extends EvaluateFn>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Fixes #7767.

## Summary
- Remove a stray `console.log(result)` from Chromium dark-mode emulation so `remotion render --dark-mode` no longer writes DevTools responses into the CLI progress output.

## Testing
- `bunx oxfmt src --write` in `packages/renderer`
- `bun run build`
- `bun run formatting`
- `bun run stylecheck` (blocked by known `@remotion/lambda-go` Go >= 1.23 requirement on this VM)
- `bun run lint` in `packages/renderer`
- `script -q -c 'FORCE_COLOR=1 bunx remotion render color-interpolation /tmp/remotion-dark-mode-after.mp4 --frames=0-5 --dark-mode --log=info' /tmp/remotion-dark-mode-after.log`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff8860aa-32ba-4456-bc35-caa99621fbcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff8860aa-32ba-4456-bc35-caa99621fbcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

