### PR TITLE
`@remotion/cli`: Fix boolean config flag precedence

### DIFF
--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -92,11 +92,11 @@ export type CommandLineOptions = {
 	[envFileOption.cliFlag]: TypeOfOption<typeof envFileOption>;
 	[ignoreCertificateErrorsOption.cliFlag]: TypeOfOption<
 		typeof ignoreCertificateErrorsOption
-	>;
+	> | null;
 	[darkModeOption.cliFlag]: TypeOfOption<typeof darkModeOption> | null;
 	[disableWebSecurityOption.cliFlag]: TypeOfOption<
 		typeof disableWebSecurityOption
-	>;
+	> | null;
 	[everyNthFrameOption.cliFlag]: TypeOfOption<typeof everyNthFrameOption>;
 	[numberOfGifLoopsOption.cliFlag]: TypeOfOption<typeof numberOfGifLoopsOption>;
 	[numberOfSharedAudioTagsOption.cliFlag]: TypeOfOption<
@@ -108,8 +108,8 @@ export type CommandLineOptions = {
 	[colorSpaceOption.cliFlag]: TypeOfOption<typeof colorSpaceOption>;
 	[disallowParallelEncodingOption.cliFlag]: TypeOfOption<
 		typeof disallowParallelEncodingOption
-	>;
-	[beepOnFinishOption.cliFlag]: TypeOfOption<typeof beepOnFinishOption>;
+	> | null;
+	[beepOnFinishOption.cliFlag]: TypeOfOption<typeof beepOnFinishOption> | null;
 	[versionFlagOption.cliFlag]: TypeOfOption<typeof versionFlagOption>;
 	[videoCodecOption.cliFlag]: TypeOfOption<typeof videoCodecOption>;
 	[concurrencyOption.cliFlag]: TypeOfOption<typeof concurrencyOption>;
@@ -129,24 +129,26 @@ export type CommandLineOptions = {
 	[crfOption.cliFlag]: TypeOfOption<typeof crfOption>;
 	[gopSizeOption.cliFlag]: TypeOfOption<typeof gopSizeOption>;
 	output: string | undefined;
-	[overwriteOption.cliFlag]: TypeOfOption<typeof overwriteOption>;
+	[overwriteOption.cliFlag]: TypeOfOption<typeof overwriteOption> | null;
 	png: boolean;
 	[propsOption.cliFlag]: TypeOfOption<typeof propsOption>;
 	quality: number;
 	[jpegQualityOption.cliFlag]: TypeOfOption<typeof jpegQualityOption>;
 	[framesOption.cliFlag]: string | number;
 	[scaleOption.cliFlag]: TypeOfOption<typeof scaleOption>;
-	[imageSequenceOption.cliFlag]: TypeOfOption<typeof imageSequenceOption>;
+	[imageSequenceOption.cliFlag]: TypeOfOption<
+		typeof imageSequenceOption
+	> | null;
 	quiet: boolean;
 	q: boolean;
 	[logLevelOption.cliFlag]: TypeOfOption<typeof logLevelOption>;
 	help: boolean;
 	[portOption.cliFlag]: TypeOfOption<typeof portOption>;
 	[stillFrameOption.cliFlag]: TypeOfOption<typeof stillFrameOption>;
-	[headlessOption.cliFlag]: TypeOfOption<typeof headlessOption>;
+	[headlessOption.cliFlag]: TypeOfOption<typeof headlessOption> | null;
 	[keyboardShortcutsOption.cliFlag]: TypeOfOption<
 		typeof keyboardShortcutsOption
-	>;
+	> | null;
 	[allowHtmlInCanvasOption.cliFlag]: TypeOfOption<
 		typeof allowHtmlInCanvasOption
 	>;
@@ -172,20 +174,23 @@ export type CommandLineOptions = {
 	[userAgentOption.cliFlag]: TypeOfOption<typeof userAgentOption>;
 	[outDirOption.cliFlag]: TypeOfOption<typeof outDirOption>;
 	[audioLatencyHintOption.cliFlag]: AudioContextLatencyCategory;
-	[ipv4Option.cliFlag]: TypeOfOption<typeof ipv4Option>;
+	[ipv4Option.cliFlag]: TypeOfOption<typeof ipv4Option> | null;
 	[deleteAfterOption.cliFlag]: TypeOfOption<typeof deleteAfterOption>;
 	[folderExpiryOption.cliFlag]: TypeOfOption<typeof folderExpiryOption>;
 	[enableMultiprocessOnLinuxOption.cliFlag]: TypeOfOption<
 		typeof enableMultiprocessOnLinuxOption
 	>;
-	[reproOption.cliFlag]: TypeOfOption<typeof reproOption>;
+	[reproOption.cliFlag]: TypeOfOption<typeof reproOption> | null;
 	[imageSequencePatternOption.cliFlag]: TypeOfOption<
 		typeof imageSequencePatternOption
 	>;
 	'license-key': string;
 	[publicLicenseKeyOption.cliFlag]: string;
-	[forceNewStudioOption.cliFlag]: TypeOfOption<typeof forceNewStudioOption>;
+	[forceNewStudioOption.cliFlag]: TypeOfOption<
+		typeof forceNewStudioOption
+	> | null;
 	[sampleRateOption.cliFlag]: TypeOfOption<typeof sampleRateOption>;
+	[isProductionOption.cliFlag]: TypeOfOption<typeof isProductionOption> | null;
 };
 
 export const BooleanFlags = [
@@ -217,11 +222,22 @@ export const BooleanFlags = [
 export const parsedCli = minimist<CommandLineOptions>(process.argv.slice(2), {
 	boolean: BooleanFlags,
 	default: {
-		[overwriteOption.cliFlag]: true,
+		[overwriteOption.cliFlag]: null,
 		[bundleCacheOption.cliFlag]: null,
 		[allowHtmlInCanvasOption.cliFlag]: null,
 		[experimentalClientSideRenderingOption.cliFlag]: null,
 		[darkModeOption.cliFlag]: null,
+		[imageSequenceOption.cliFlag]: null,
+		[disableWebSecurityOption.cliFlag]: null,
+		[ignoreCertificateErrorsOption.cliFlag]: null,
+		[headlessOption.cliFlag]: null,
+		[keyboardShortcutsOption.cliFlag]: null,
+		[ipv4Option.cliFlag]: null,
+		[beepOnFinishOption.cliFlag]: null,
+		[disallowParallelEncodingOption.cliFlag]: null,
+		[reproOption.cliFlag]: null,
+		[isProductionOption.cliFlag]: null,
+		[forceNewStudioOption.cliFlag]: null,
 		[mutedOption.cliFlag]: null,
 	},
 }) as CommandLineOptions & {

--- a/packages/cli/src/test/boolean-flag-defaults.test.ts
+++ b/packages/cli/src/test/boolean-flag-defaults.test.ts
@@ -1,0 +1,33 @@
+import {expect, test} from 'bun:test';
+import {BrowserSafeApis} from '@remotion/renderer/client';
+import {parsedCli} from '../parsed-cli';
+
+const {
+	beepOnFinishOption,
+	disableWebSecurityOption,
+	disallowParallelEncodingOption,
+	forceNewStudioOption,
+	headlessOption,
+	ignoreCertificateErrorsOption,
+	imageSequenceOption,
+	ipv4Option,
+	isProductionOption,
+	keyboardShortcutsOption,
+	overwriteOption,
+	reproOption,
+} = BrowserSafeApis.options;
+
+test('config-backed boolean flags default to null when absent', () => {
+	expect(parsedCli[overwriteOption.cliFlag]).toEqual(null);
+	expect(parsedCli[imageSequenceOption.cliFlag]).toEqual(null);
+	expect(parsedCli[disableWebSecurityOption.cliFlag]).toEqual(null);
+	expect(parsedCli[ignoreCertificateErrorsOption.cliFlag]).toEqual(null);
+	expect(parsedCli[headlessOption.cliFlag]).toEqual(null);
+	expect(parsedCli[keyboardShortcutsOption.cliFlag]).toEqual(null);
+	expect(parsedCli[ipv4Option.cliFlag]).toEqual(null);
+	expect(parsedCli[beepOnFinishOption.cliFlag]).toEqual(null);
+	expect(parsedCli[disallowParallelEncodingOption.cliFlag]).toEqual(null);
+	expect(parsedCli[reproOption.cliFlag]).toEqual(null);
+	expect(parsedCli[isProductionOption.cliFlag]).toEqual(null);
+	expect(parsedCli[forceNewStudioOption.cliFlag]).toEqual(null);
+});

--- a/packages/renderer/src/options/beep-on-finish.tsx
+++ b/packages/renderer/src/options/beep-on-finish.tsx
@@ -16,7 +16,7 @@ export const beepOnFinishOption = {
 	docLink: 'https://www.remotion.dev/docs/config#setbeeponfinish',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				value: commandLine[cliFlag] as boolean,
 				source: 'cli',

--- a/packages/renderer/src/options/disable-web-security.tsx
+++ b/packages/renderer/src/options/disable-web-security.tsx
@@ -18,7 +18,7 @@ export const disableWebSecurityOption = {
 		'https://www.remotion.dev/docs/chromium-flags#--disable-web-security',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				source: 'cli',
 				value: Boolean(commandLine[cliFlag]),

--- a/packages/renderer/src/options/disallow-parallel-encoding.tsx
+++ b/packages/renderer/src/options/disallow-parallel-encoding.tsx
@@ -18,7 +18,7 @@ export const disallowParallelEncodingOption = {
 	docLink: 'https://www.remotion.dev/docs/config#setdisallowparallelencoding',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				value: commandLine[cliFlag] as boolean,
 				source: 'cli',

--- a/packages/renderer/src/options/force-new-studio.tsx
+++ b/packages/renderer/src/options/force-new-studio.tsx
@@ -17,7 +17,7 @@ export const forceNewStudioOption = {
 	docLink: 'https://www.remotion.dev/docs/config#setforcenewstudioenabled',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				value: commandLine[cliFlag] as boolean,
 				source: 'cli',

--- a/packages/renderer/src/options/headless.tsx
+++ b/packages/renderer/src/options/headless.tsx
@@ -24,7 +24,7 @@ export const headlessOption = {
 	docLink: 'https://www.remotion.dev/docs/chromium-flags#--disable-headless',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				source: 'cli',
 				value: !commandLine[cliFlag],

--- a/packages/renderer/src/options/ignore-certificate-errors.tsx
+++ b/packages/renderer/src/options/ignore-certificate-errors.tsx
@@ -18,7 +18,7 @@ export const ignoreCertificateErrorsOption = {
 		'https://www.remotion.dev/docs/chromium-flags#--ignore-certificate-errors',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				source: 'cli',
 				value: Boolean(commandLine[cliFlag]),

--- a/packages/renderer/src/options/image-sequence.tsx
+++ b/packages/renderer/src/options/image-sequence.tsx
@@ -20,7 +20,7 @@ export const imageSequenceOption = {
 	ssrName: null,
 	docLink: 'https://www.remotion.dev/docs/config#setimagesequence',
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				source: 'cli',
 				value: Boolean(commandLine[cliFlag]),

--- a/packages/renderer/src/options/ipv4.tsx
+++ b/packages/renderer/src/options/ipv4.tsx
@@ -14,7 +14,7 @@ export const ipv4Option = {
 	docLink: 'https://www.remotion.dev/docs/cli/studio',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				value: commandLine[cliFlag] as boolean,
 				source: 'cli',

--- a/packages/renderer/src/options/is-production.tsx
+++ b/packages/renderer/src/options/is-production.tsx
@@ -17,7 +17,7 @@ export const isProductionOption = {
 	ssrName: 'isProduction' as const,
 	docLink: 'https://www.remotion.dev/docs/licensing',
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				source: 'cli',
 				value: commandLine[cliFlag] as boolean | null,

--- a/packages/renderer/src/options/keyboard-shortcuts.tsx
+++ b/packages/renderer/src/options/keyboard-shortcuts.tsx
@@ -14,7 +14,7 @@ export const keyboardShortcutsOption = {
 	docLink: 'https://www.remotion.dev/docs/config#setkeyboardshortcutsenabled',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			keyboardShortcutsEnabled = commandLine[cliFlag] === false;
 			return {
 				value: keyboardShortcutsEnabled,

--- a/packages/renderer/src/options/overwrite.tsx
+++ b/packages/renderer/src/options/overwrite.tsx
@@ -24,7 +24,7 @@ export const overwriteOption = {
 	docLink: 'https://www.remotion.dev/docs/config#setoverwriteoutput',
 	type: false as boolean,
 	getValue: ({commandLine}, defaultValue: boolean) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			validate(commandLine[cliFlag]);
 
 			return {

--- a/packages/renderer/src/options/repro.tsx
+++ b/packages/renderer/src/options/repro.tsx
@@ -20,7 +20,7 @@ export const reproOption = {
 	docLink: 'https://www.remotion.dev/docs/render-media#repro',
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				value: commandLine[cliFlag] as boolean,
 				source: 'cli',

--- a/packages/renderer/src/test/boolean-option-precedence.test.ts
+++ b/packages/renderer/src/test/boolean-option-precedence.test.ts
@@ -1,0 +1,137 @@
+import {expect, test} from 'bun:test';
+import {beepOnFinishOption} from '../options/beep-on-finish';
+import {disableWebSecurityOption} from '../options/disable-web-security';
+import {disallowParallelEncodingOption} from '../options/disallow-parallel-encoding';
+import {forceNewStudioOption} from '../options/force-new-studio';
+import {headlessOption} from '../options/headless';
+import {ignoreCertificateErrorsOption} from '../options/ignore-certificate-errors';
+import {imageSequenceOption} from '../options/image-sequence';
+import {ipv4Option} from '../options/ipv4';
+import {isProductionOption} from '../options/is-production';
+import {keyboardShortcutsOption} from '../options/keyboard-shortcuts';
+import {overwriteOption} from '../options/overwrite';
+import {reproOption} from '../options/repro';
+
+test('boolean options respect config if CLI flag is absent', () => {
+	overwriteOption.setConfig(false);
+	expect(
+		overwriteOption.getValue({commandLine: {overwrite: null}}, true).value,
+	).toEqual(false);
+	expect(
+		overwriteOption.getValue({commandLine: {overwrite: true}}, true).value,
+	).toEqual(true);
+	overwriteOption.setConfig(true);
+
+	imageSequenceOption.setConfig(true);
+	expect(
+		imageSequenceOption.getValue({commandLine: {sequence: null}}).value,
+	).toEqual(true);
+	expect(
+		imageSequenceOption.getValue({commandLine: {sequence: false}}).value,
+	).toEqual(false);
+	imageSequenceOption.setConfig(false);
+
+	disableWebSecurityOption.setConfig(true);
+	expect(
+		disableWebSecurityOption.getValue({
+			commandLine: {'disable-web-security': null},
+		}).value,
+	).toEqual(true);
+	expect(
+		disableWebSecurityOption.getValue({
+			commandLine: {'disable-web-security': false},
+		}).value,
+	).toEqual(false);
+	disableWebSecurityOption.setConfig(false);
+
+	ignoreCertificateErrorsOption.setConfig(true);
+	expect(
+		ignoreCertificateErrorsOption.getValue({
+			commandLine: {'ignore-certificate-errors': null},
+		}).value,
+	).toEqual(true);
+	expect(
+		ignoreCertificateErrorsOption.getValue({
+			commandLine: {'ignore-certificate-errors': false},
+		}).value,
+	).toEqual(false);
+	ignoreCertificateErrorsOption.setConfig(false);
+
+	headlessOption.setConfig(false);
+	expect(
+		headlessOption.getValue({commandLine: {'disable-headless': null}}).value,
+	).toEqual(false);
+	expect(
+		headlessOption.getValue({commandLine: {'disable-headless': false}}).value,
+	).toEqual(true);
+	headlessOption.setConfig(true);
+
+	keyboardShortcutsOption.setConfig(false);
+	expect(
+		keyboardShortcutsOption.getValue({
+			commandLine: {'disable-keyboard-shortcuts': null},
+		}).value,
+	).toEqual(false);
+	expect(
+		keyboardShortcutsOption.getValue({
+			commandLine: {'disable-keyboard-shortcuts': false},
+		}).value,
+	).toEqual(true);
+	keyboardShortcutsOption.setConfig(true);
+
+	ipv4Option.setConfig(true);
+	expect(ipv4Option.getValue({commandLine: {ipv4: null}}).value).toEqual(true);
+	expect(ipv4Option.getValue({commandLine: {ipv4: false}}).value).toEqual(
+		false,
+	);
+	ipv4Option.setConfig(false);
+
+	beepOnFinishOption.setConfig(true);
+	expect(
+		beepOnFinishOption.getValue({commandLine: {'beep-on-finish': null}}).value,
+	).toEqual(true);
+	expect(
+		beepOnFinishOption.getValue({commandLine: {'beep-on-finish': false}}).value,
+	).toEqual(false);
+	beepOnFinishOption.setConfig(false);
+
+	disallowParallelEncodingOption.setConfig(true);
+	expect(
+		disallowParallelEncodingOption.getValue({
+			commandLine: {'disallow-parallel-encoding': null},
+		}).value,
+	).toEqual(true);
+	expect(
+		disallowParallelEncodingOption.getValue({
+			commandLine: {'disallow-parallel-encoding': false},
+		}).value,
+	).toEqual(false);
+	disallowParallelEncodingOption.setConfig(false);
+
+	reproOption.setConfig(true);
+	expect(reproOption.getValue({commandLine: {repro: null}}).value).toEqual(
+		true,
+	);
+	expect(reproOption.getValue({commandLine: {repro: false}}).value).toEqual(
+		false,
+	);
+	reproOption.setConfig(false);
+
+	isProductionOption.setConfig(false);
+	expect(
+		isProductionOption.getValue({commandLine: {'is-production': null}}).value,
+	).toEqual(false);
+	expect(
+		isProductionOption.getValue({commandLine: {'is-production': true}}).value,
+	).toEqual(true);
+	isProductionOption.setConfig(null);
+
+	forceNewStudioOption.setConfig(true);
+	expect(
+		forceNewStudioOption.getValue({commandLine: {'force-new': null}}).value,
+	).toEqual(true);
+	expect(
+		forceNewStudioOption.getValue({commandLine: {'force-new': false}}).value,
+	).toEqual(false);
+	forceNewStudioOption.setConfig(false);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use `null` as the absent CLI value for config-backed boolean flags that minimist otherwise defaulted to `false`.
- Update matching renderer option handlers so config values are respected when the CLI flag is absent.
- Add regression coverage for parsed CLI defaults and option precedence.

## Testing
- `bun test src/test/boolean-flag-defaults.test.ts`
- `bun test src/test/boolean-option-precedence.test.ts`
- `bun run build`
- `bun run formatting`
- `bun run stylecheck` (fails in `@remotion/lambda-go` because the VM has Go 1.22.2 and `golang.org/x/crypto@v0.35.0` requires Go >= 1.23.0; this matches the known repo caveat).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9ff05df-fb97-4203-a1f8-eaf54a6429cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9ff05df-fb97-4203-a1f8-eaf54a6429cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

