### PR TITLE
`@remotion/media`: Fix premount buffering state

### DIFF
--- a/packages/media/src/use-common-effects.ts
+++ b/packages/media/src/use-common-effects.ts
@@ -163,7 +163,7 @@ export const useCommonEffects = ({
 
 	useLayoutEffect(() => {
 		const mediaPlayer = mediaPlayerRef.current;
-		if (!mediaPlayer || !mediaPlayerReady) {
+		if (!mediaPlayer) {
 			return;
 		}
 
@@ -172,7 +172,7 @@ export const useCommonEffects = ({
 
 	useLayoutEffect(() => {
 		const mediaPlayer = mediaPlayerRef.current;
-		if (!mediaPlayer || !mediaPlayerReady) {
+		if (!mediaPlayer) {
 			return;
 		}
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

MediaPlayer can be created while still premounting, and initialization may continue after the component becomes visible. Previously, premount/postmount updates were only forwarded once the player was marked ready, so active initialization delay handles could miss the transition out of premounting and fail to trigger buffering.

This forwards premount and postmount state updates as soon as a MediaPlayer instance exists, while keeping the readiness dependency so the latest state is still synced once initialization completes.

Checks:
- `cd packages/media && bunx oxfmt src --write`
- `bun run build`
- `bun run formatting`
- `cd packages/media && bun test src/test/premount-aware-delay-playback.test.ts`