### PR TITLE
`@remotion/studio`: Add reset menu for timeline properties

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -253,14 +253,17 @@ export const TimelineEffectFieldRow: React.FC<{
 		);
 	}, [field.fieldSchema.default, propStatus]);
 
-	const canReset =
+	const canPerformReset =
 		previewServerState.type === 'connected' &&
 		propStatus !== null &&
-		propStatus.canUpdate &&
-		isNonDefault;
+		propStatus.canUpdate;
 
 	const onReset = useCallback(() => {
-		if (!canReset || previewServerState.type !== 'connected') {
+		if (
+			!canPerformReset ||
+			previewServerState.type !== 'connected' ||
+			!isNonDefault
+		) {
 			return;
 		}
 
@@ -281,11 +284,12 @@ export const TimelineEffectFieldRow: React.FC<{
 			clientId: previewServerState.clientId,
 		});
 	}, [
-		canReset,
+		canPerformReset,
 		field.effectIndex,
 		field.effectSchema,
 		field.fieldSchema.default,
 		field.key,
+		isNonDefault,
 		nodePath,
 		previewServerState,
 		setCodeValues,
@@ -300,14 +304,14 @@ export const TimelineEffectFieldRow: React.FC<{
 				keyHint: null,
 				label: 'Reset',
 				leftItem: null,
-				disabled: false,
+				disabled: !canPerformReset,
 				onClick: onReset,
 				quickSwitcherLabel: null,
 				subMenu: null,
 				value: 'reset-effect-field',
 			},
 		];
-	}, [onReset]);
+	}, [canPerformReset, onReset]);
 
 	const row = (
 		<TimelineRowChrome
@@ -337,14 +341,12 @@ export const TimelineEffectFieldRow: React.FC<{
 		</TimelineRowChrome>
 	);
 
-	return canReset ? (
+	return (
 		<ContextMenu
 			values={contextMenuValues}
 			onOpen={selection.selectable ? selection.onSelect : null}
 		>
 			{row}
 		</ContextMenu>
-	) : (
-		row
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -7,7 +7,10 @@ import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import type {EffectSchemaFieldInfo} from '../../helpers/timeline-layout';
 import {callApi} from '../call-api';
+import {ContextMenu} from '../ContextMenu';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {getComputedStatusLabel} from './get-timeline-keyframes';
+import {saveEffectProp} from './save-effect-prop';
 import {enqueueSavePropChange} from './save-prop-queue';
 import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
@@ -211,6 +214,9 @@ export const TimelineEffectFieldRow: React.FC<{
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly nodePathInfo: SequenceNodePathInfo;
 }> = ({field, validatedLocation, rowDepth, nodePath, nodePathInfo}) => {
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const selection = useTimelineRowSelection(nodePathInfo);
 	const style = useMemo(() => {
 		return {
@@ -219,7 +225,91 @@ export const TimelineEffectFieldRow: React.FC<{
 		};
 	}, [field.rowHeight]);
 
-	return (
+	const effectStatus = useMemo(
+		() =>
+			Internals.getEffectCodeValuesCtx({
+				codeValues,
+				nodePath,
+				effectIndex: field.effectIndex,
+			}),
+		[codeValues, nodePath, field.effectIndex],
+	);
+
+	const propStatus =
+		effectStatus.type === 'can-update-effect'
+			? (effectStatus.props?.[field.key] ?? null)
+			: null;
+
+	const isNonDefault = useMemo(() => {
+		if (!propStatus || !propStatus.canUpdate) {
+			return false;
+		}
+
+		const effectiveCodeValue =
+			propStatus.codeValue ?? field.fieldSchema.default;
+		return (
+			JSON.stringify(effectiveCodeValue) !==
+			JSON.stringify(field.fieldSchema.default)
+		);
+	}, [field.fieldSchema.default, propStatus]);
+
+	const canReset =
+		previewServerState.type === 'connected' &&
+		propStatus !== null &&
+		propStatus.canUpdate &&
+		isNonDefault;
+
+	const onReset = useCallback(() => {
+		if (!canReset || previewServerState.type !== 'connected') {
+			return;
+		}
+
+		const defaultValue =
+			field.fieldSchema.default !== undefined
+				? JSON.stringify(field.fieldSchema.default)
+				: null;
+
+		saveEffectProp({
+			fileName: validatedLocation.source,
+			nodePath,
+			effectIndex: field.effectIndex,
+			fieldKey: field.key,
+			value: field.fieldSchema.default,
+			defaultValue,
+			schema: field.effectSchema,
+			setCodeValues,
+			clientId: previewServerState.clientId,
+		});
+	}, [
+		canReset,
+		field.effectIndex,
+		field.effectSchema,
+		field.fieldSchema.default,
+		field.key,
+		nodePath,
+		previewServerState,
+		setCodeValues,
+		validatedLocation.source,
+	]);
+
+	const contextMenuValues = useMemo((): ComboboxValue[] => {
+		return [
+			{
+				type: 'item',
+				id: 'reset-effect-field',
+				keyHint: null,
+				label: 'Reset',
+				leftItem: null,
+				disabled: false,
+				onClick: onReset,
+				quickSwitcherLabel: null,
+				subMenu: null,
+				value: 'reset-effect-field',
+			},
+		];
+	}, [onReset]);
+
+	const row = (
 		<TimelineRowChrome
 			depth={rowDepth}
 			eye={<TimelineLayerEyeSpacer />}
@@ -245,5 +335,16 @@ export const TimelineEffectFieldRow: React.FC<{
 				/>
 			</div>
 		</TimelineRowChrome>
+	);
+
+	return canReset ? (
+		<ContextMenu
+			values={contextMenuValues}
+			onOpen={selection.selectable ? selection.onSelect : null}
+		>
+			{row}
+		</ContextMenu>
+	) : (
+		row
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -16,7 +16,6 @@ import {
 	TimelineExpandArrowButton,
 	TimelineExpandArrowSpacer,
 } from './TimelineExpandArrowButton';
-import {TimelineFieldRow} from './TimelineFieldRow';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {
@@ -24,6 +23,7 @@ import {
 	getTimelineSelectedLabelStyle,
 	useTimelineRowSelection,
 } from './TimelineSelection';
+import {TimelineSequenceFieldRow} from './TimelineSequenceFieldRow';
 
 const rowLabel: React.CSSProperties = {
 	fontSize: 12,
@@ -130,7 +130,7 @@ export const TimelineExpandedRow: React.FC<{
 
 		if (node.field.kind === 'sequence-field') {
 			return (
-				<TimelineFieldRow
+				<TimelineSequenceFieldRow
 					field={node.field}
 					validatedLocation={validatedLocation}
 					rowDepth={rowDepth}

--- a/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
@@ -184,17 +184,17 @@ export const TimelineSequenceFieldRow: React.FC<{
 		);
 	}, [codeValue, field.fieldSchema.default]);
 
-	const canReset =
+	const canPerformReset =
 		previewServerState.type === 'connected' &&
 		codeValue !== null &&
-		codeValue.canUpdate &&
-		isNonDefault;
+		codeValue.canUpdate;
 
 	const onReset = useCallback(() => {
 		if (
-			!canReset ||
+			!canPerformReset ||
 			previewServerState.type !== 'connected' ||
-			codeValue === null
+			codeValue === null ||
+			!isNonDefault
 		) {
 			return;
 		}
@@ -215,9 +215,10 @@ export const TimelineSequenceFieldRow: React.FC<{
 			clientId: previewServerState.clientId,
 		});
 	}, [
-		canReset,
+		canPerformReset,
 		field.fieldSchema.default,
 		field.key,
+		isNonDefault,
 		nodePath,
 		previewServerState,
 		schema,
@@ -234,14 +235,14 @@ export const TimelineSequenceFieldRow: React.FC<{
 				keyHint: null,
 				label: 'Reset',
 				leftItem: null,
-				disabled: false,
+				disabled: !canPerformReset,
 				onClick: onReset,
 				quickSwitcherLabel: null,
 				subMenu: null,
 				value: 'reset-sequence-field',
 			},
 		];
-	}, [onReset]);
+	}, [canPerformReset, onReset]);
 
 	if (codeValue === null) {
 		return null;
@@ -283,14 +284,12 @@ export const TimelineSequenceFieldRow: React.FC<{
 		</TimelineRowChrome>
 	);
 
-	return canReset ? (
+	return (
 		<ContextMenu
 			values={contextMenuValues}
 			onOpen={selection.selectable ? selection.onSelect : null}
 		>
 			{row}
 		</ContextMenu>
-	) : (
-		row
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
@@ -172,12 +172,8 @@ export const TimelineSequenceFieldRow: React.FC<{
 		};
 	}, [field.rowHeight]);
 
-	if (codeValue === null) {
-		return null;
-	}
-
 	const isNonDefault = useMemo(() => {
-		if (!codeValue.canUpdate) {
+		if (!codeValue || !codeValue.canUpdate) {
 			return false;
 		}
 
@@ -190,11 +186,16 @@ export const TimelineSequenceFieldRow: React.FC<{
 
 	const canReset =
 		previewServerState.type === 'connected' &&
+		codeValue !== null &&
 		codeValue.canUpdate &&
 		isNonDefault;
 
 	const onReset = useCallback(() => {
-		if (!canReset || previewServerState.type !== 'connected') {
+		if (
+			!canReset ||
+			previewServerState.type !== 'connected' ||
+			codeValue === null
+		) {
 			return;
 		}
 
@@ -222,6 +223,7 @@ export const TimelineSequenceFieldRow: React.FC<{
 		schema,
 		setCodeValues,
 		validatedLocation.source,
+		codeValue,
 	]);
 
 	const contextMenuValues = useMemo((): ComboboxValue[] => {
@@ -240,6 +242,10 @@ export const TimelineSequenceFieldRow: React.FC<{
 			},
 		];
 	}, [onReset]);
+
+	if (codeValue === null) {
+		return null;
+	}
 
 	const row = (
 		<TimelineRowChrome

--- a/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
@@ -13,6 +13,8 @@ import type {
 	TimelineFieldOnDragValueChange,
 	TimelineFieldOnSave,
 } from '../../helpers/timeline-layout';
+import {ContextMenu} from '../ContextMenu';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {saveSequenceProp} from './save-sequence-prop';
 import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
@@ -142,7 +144,7 @@ const Value: React.FC<{
 	);
 };
 
-export const TimelineFieldRow: React.FC<{
+export const TimelineSequenceFieldRow: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly validatedLocation: CodePosition;
 	readonly rowDepth: number;
@@ -153,6 +155,8 @@ export const TimelineFieldRow: React.FC<{
 	const {codeValues: visualModeCodeValues} = useContext(
 		Internals.VisualModeCodeValuesContext,
 	);
+	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const selection = useTimelineRowSelection(nodePathInfo);
 
 	const codeValuesForOverride = Internals.getCodeValuesCtx(
@@ -172,7 +176,72 @@ export const TimelineFieldRow: React.FC<{
 		return null;
 	}
 
-	return (
+	const isNonDefault = useMemo(() => {
+		if (!codeValue.canUpdate) {
+			return false;
+		}
+
+		const effectiveCodeValue = codeValue.codeValue ?? field.fieldSchema.default;
+		return (
+			JSON.stringify(effectiveCodeValue) !==
+			JSON.stringify(field.fieldSchema.default)
+		);
+	}, [codeValue, field.fieldSchema.default]);
+
+	const canReset =
+		previewServerState.type === 'connected' &&
+		codeValue.canUpdate &&
+		isNonDefault;
+
+	const onReset = useCallback(() => {
+		if (!canReset || previewServerState.type !== 'connected') {
+			return;
+		}
+
+		const defaultValue =
+			field.fieldSchema.default !== undefined
+				? JSON.stringify(field.fieldSchema.default)
+				: null;
+
+		saveSequenceProp({
+			fileName: validatedLocation.source,
+			nodePath,
+			fieldKey: field.key,
+			value: field.fieldSchema.default,
+			defaultValue,
+			schema,
+			setCodeValues,
+			clientId: previewServerState.clientId,
+		});
+	}, [
+		canReset,
+		field.fieldSchema.default,
+		field.key,
+		nodePath,
+		previewServerState,
+		schema,
+		setCodeValues,
+		validatedLocation.source,
+	]);
+
+	const contextMenuValues = useMemo((): ComboboxValue[] => {
+		return [
+			{
+				type: 'item',
+				id: 'reset-sequence-field',
+				keyHint: null,
+				label: 'Reset',
+				leftItem: null,
+				disabled: false,
+				onClick: onReset,
+				quickSwitcherLabel: null,
+				subMenu: null,
+				value: 'reset-sequence-field',
+			},
+		];
+	}, [onReset]);
+
+	const row = (
 		<TimelineRowChrome
 			depth={rowDepth}
 			eye={<TimelineLayerEyeSpacer />}
@@ -206,5 +275,16 @@ export const TimelineFieldRow: React.FC<{
 				</div>
 			)}
 		</TimelineRowChrome>
+	);
+
+	return canReset ? (
+		<ContextMenu
+			values={contextMenuValues}
+			onOpen={selection.selectable ? selection.onSelect : null}
+		>
+			{row}
+		</ContextMenu>
+	) : (
+		row
 	);
 };


### PR DESCRIPTION
## Summary
- add a right-click **Reset** context action for sequence field rows when the current value differs from the schema default
- add the same **Reset** action for effect field rows under the same non-default condition
- rename `TimelineFieldRow` to `TimelineSequenceFieldRow` and update imports/usages

Closes #7787