### PR TITLE
`@remotion/studio`: Gracefully handle waveform decode errors

### DIFF
--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -56,6 +56,12 @@ const errorMessage: React.CSSProperties = {
 	opacity: 0.75,
 };
 
+const getWaveformErrorMessage = () => {
+	return new Error(
+		'No waveform available. The audio could not be decoded or may not support CORS.',
+	);
+};
+
 const waveformCanvasStyle: React.CSSProperties = {
 	pointerEvents: 'none',
 	width: '100%',
@@ -187,6 +193,7 @@ export const AudioWaveform: React.FC<{
 		}
 
 		const worker = makeAudioWaveformWorker();
+		let workerFailed = false;
 		waveformWorker.current = worker;
 		worker.addEventListener(
 			'message',
@@ -200,6 +207,19 @@ export const AudioWaveform: React.FC<{
 				}
 			},
 		);
+		worker.addEventListener('error', (event) => {
+			event.preventDefault();
+			workerFailed = true;
+
+			if (worker !== waveformWorker.current) {
+				return;
+			}
+
+			worker.terminate();
+			waveformWorker.current = null;
+			hasTransferredCanvas.current = false;
+			setError(getWaveformErrorMessage());
+		});
 
 		let offscreen: OffscreenCanvas;
 		try {
@@ -219,7 +239,9 @@ export const AudioWaveform: React.FC<{
 		worker.postMessage({type: 'init', canvas: offscreen}, [offscreen]);
 
 		return () => {
-			worker.postMessage({type: 'dispose'});
+			if (!workerFailed) {
+				worker.postMessage({type: 'dispose'});
+			}
 			worker.terminate();
 			waveformWorker.current = null;
 			hasTransferredCanvas.current = false;
@@ -365,7 +387,8 @@ export const AudioWaveform: React.FC<{
 		return (
 			<div style={getContainerStyle(height)}>
 				<div style={errorMessage}>
-					No waveform available. Audio might not support CORS.
+					No waveform available. The audio could not be decoded or may not
+					support CORS.
 				</div>
 			</div>
 		);

--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -242,6 +242,7 @@ export const AudioWaveform: React.FC<{
 			if (!workerFailed) {
 				worker.postMessage({type: 'dispose'});
 			}
+
 			worker.terminate();
 			waveformWorker.current = null;
 			hasTransferredCanvas.current = false;

--- a/packages/timeline-utils/src/audio-waveform-worker.ts
+++ b/packages/timeline-utils/src/audio-waveform-worker.ts
@@ -148,6 +148,8 @@ self.addEventListener(
 			return;
 		}
 
-		renderWaveform(message);
+		void renderWaveform(message).catch((error) => {
+			postError(message.requestId, error);
+		});
 	},
 );

--- a/packages/timeline-utils/src/audio-waveform-worker.ts
+++ b/packages/timeline-utils/src/audio-waveform-worker.ts
@@ -148,7 +148,7 @@ self.addEventListener(
 			return;
 		}
 
-		void renderWaveform(message).catch((error) => {
+		renderWaveform(message).catch((error) => {
 			postError(message.requestId, error);
 		});
 	},


### PR DESCRIPTION
Audio waveform rendering could take down Studio when decoding fails in the worker. This change makes that path fail gracefully so invalid or undecodable media shows a fallback message instead of crashing the UI.

### What changed
- Added a worker `error` handler in `AudioWaveform` to surface a recoverable waveform failure state.
- Hardened the waveform worker so unexpected render rejections are reported back as normal errors.
- Updated the user-facing fallback copy to mention decode failures as well as CORS issues.

### Notes
- The worker is terminated and cleaned up when it errors so the broken state does not linger.
- This keeps the existing progressive waveform rendering behavior intact for valid media.