### PR TITLE
`@remotion/studio-server`: Better logs for keyframe deletions

### DIFF
--- a/packages/studio-server/src/preview-server/routes/delete-effect-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-effect-keyframe.ts
@@ -18,7 +18,6 @@ import {
 import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
 import {computeEffectPropStatus} from './can-update-effect-props';
 import {findJsxElementAtNodePath} from './can-update-sequence-props';
-import {formatEffectPropChange} from './log-updates/format-effect-prop-change';
 import {logEffectUpdate} from './log-updates/log-effect-update';
 import {normalizeQuotes} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
@@ -79,24 +78,8 @@ export const deleteEffectKeyframeHandler: ApiHandler<
 		const normalizedOld = normalizeQuotes(oldValueString);
 		const normalizedNew = normalizeQuotes(newValueString);
 
-		const undoPropChange = formatEffectPropChange({
-			effectName: effectCallee,
-			key,
-			oldValueString: normalizedNew,
-			newValueString: normalizedOld,
-			defaultValueString: null,
-			removedProps: [],
-			addedProps: [],
-		});
-		const redoPropChange = formatEffectPropChange({
-			effectName: effectCallee,
-			key,
-			oldValueString: normalizedOld,
-			newValueString: normalizedNew,
-			defaultValueString: null,
-			removedProps: [],
-			addedProps: [],
-		});
+		const undoPropChange = `${key} keyframe restored at frame ${frame}`;
+		const redoPropChange = `${key} keyframe deleted at frame ${frame}`;
 
 		pushToUndoStack({
 			filePath: absolutePath,

--- a/packages/studio-server/src/preview-server/routes/delete-effect-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-effect-keyframe.ts
@@ -19,7 +19,6 @@ import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
 import {computeEffectPropStatus} from './can-update-effect-props';
 import {findJsxElementAtNodePath} from './can-update-sequence-props';
 import {logEffectUpdate} from './log-updates/log-effect-update';
-import {normalizeQuotes} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
 
 export const deleteEffectKeyframeHandler: ApiHandler<
@@ -75,8 +74,6 @@ export const deleteEffectKeyframeHandler: ApiHandler<
 
 		const oldValueString = oldValueStrings[0];
 		const newValueString = newValueStrings[0];
-		const normalizedOld = normalizeQuotes(oldValueString);
-		const normalizedNew = normalizeQuotes(newValueString);
 
 		const undoPropChange = `${key} keyframe restored at frame ${frame}`;
 		const redoPropChange = `${key} keyframe deleted at frame ${frame}`;

--- a/packages/studio-server/src/preview-server/routes/delete-sequence-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-sequence-keyframe.ts
@@ -16,7 +16,7 @@ import {
 } from '../undo-stack';
 import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
 import {computeSequencePropsStatusFromContent} from './can-update-sequence-props';
-import {logUpdate, normalizeQuotes} from './log-updates/log-update';
+import {logUpdate} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
 
 export const deleteSequenceKeyframeHandler: ApiHandler<
@@ -57,8 +57,6 @@ export const deleteSequenceKeyframeHandler: ApiHandler<
 
 		const oldValueString = oldValueStrings[0];
 		const newValueString = newValueStrings[0];
-		const normalizedOld = normalizeQuotes(oldValueString);
-		const normalizedNew = normalizeQuotes(newValueString);
 
 		const undoPropChange = `${key} keyframe restored at frame ${frame}`;
 		const redoPropChange = `${key} keyframe deleted at frame ${frame}`;

--- a/packages/studio-server/src/preview-server/routes/delete-sequence-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-sequence-keyframe.ts
@@ -16,7 +16,6 @@ import {
 } from '../undo-stack';
 import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
 import {computeSequencePropsStatusFromContent} from './can-update-sequence-props';
-import {formatPropChange} from './log-updates/format-prop-change';
 import {logUpdate, normalizeQuotes} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
 
@@ -61,22 +60,8 @@ export const deleteSequenceKeyframeHandler: ApiHandler<
 		const normalizedOld = normalizeQuotes(oldValueString);
 		const normalizedNew = normalizeQuotes(newValueString);
 
-		const undoPropChange = formatPropChange({
-			key,
-			oldValueString: normalizedNew,
-			newValueString: normalizedOld,
-			defaultValueString: null,
-			removedProps: [],
-			addedProps: [],
-		});
-		const redoPropChange = formatPropChange({
-			key,
-			oldValueString: normalizedOld,
-			newValueString: normalizedNew,
-			defaultValueString: null,
-			removedProps: [],
-			addedProps: [],
-		});
+		const undoPropChange = `${key} keyframe restored at frame ${frame}`;
+		const redoPropChange = `${key} keyframe deleted at frame ${frame}`;
 
 		pushToUndoStack({
 			filePath: absolutePath,


### PR DESCRIPTION
Improves the console logs when deleting keyframes in the Studio by showing a concise, user-friendly message instead of the entire effect/sequence prop value.

## Changes

- **Before**: Shows entire prop value: `↪️ blur({radius: interpolate(frame, [0, 60, 119], [0, 24, 4])}) → blur({radius: interpolate(frame, [60, 119], [24, 4])})`
- **After**: Shows concise message: `↪️ radius keyframe deleted at frame 0`

## Files Modified

- packages/studio-server/src/preview-server/routes/delete-effect-keyframe.ts
- packages/studio-server/src/preview-server/routes/delete-sequence-keyframe.ts

## Benefits

✅ Less verbose logs in the console
✅ Clearer, more readable undo/redo messages  
✅ Still contains essential information (property key and frame number)
✅ Easier to scan multiple keyframe operations