### PR TITLE
`remotion`: Encode keyframe interpolation function

### DIFF
--- a/packages/core/src/interpolate-keyframed-status.ts
+++ b/packages/core/src/interpolate-keyframed-status.ts
@@ -23,7 +23,7 @@ export const interpolateKeyframedStatus = ({
 	frame: number;
 	status: CanUpdateSequencePropStatusKeyframed;
 }): number | string | null => {
-	const {keyframes, easing, clamping} = status;
+	const {keyframes, easing, clamping, interpolationFunction} = status;
 	if (keyframes.length === 0) {
 		return null;
 	}
@@ -31,10 +31,11 @@ export const interpolateKeyframedStatus = ({
 	const inputRange = keyframes.map((k) => k.frame);
 	const outputs = keyframes.map((k) => k.value);
 
-	const allNumbers = outputs.every((v) => typeof v === 'number');
-	const allStrings = outputs.every((v) => typeof v === 'string');
+	if (interpolationFunction === 'interpolateColors') {
+		if (!outputs.every((v) => typeof v === 'string')) {
+			return null;
+		}
 
-	if (allStrings) {
 		if (keyframes.length === 1) {
 			return outputs[0] as string;
 		}
@@ -46,17 +47,25 @@ export const interpolateKeyframedStatus = ({
 		}
 	}
 
-	if (allNumbers) {
-		try {
-			return interpolate(frame, inputRange, outputs as number[], {
-				easing: easing.map(easingToFn),
-				extrapolateLeft: clamping.left,
-				extrapolateRight: clamping.right,
-			});
-		} catch {
-			return null;
-		}
+	if (interpolationFunction !== 'interpolate') {
+		return null;
 	}
 
-	return null;
+	if (!outputs.every((v) => typeof v === 'number')) {
+		return null;
+	}
+
+	if (keyframes.length === 1) {
+		return outputs[0] as number;
+	}
+
+	try {
+		return interpolate(frame, inputRange, outputs as number[], {
+			easing: easing.map(easingToFn),
+			extrapolateLeft: clamping.left,
+			extrapolateRight: clamping.right,
+		});
+	} catch {
+		return null;
+	}
 };

--- a/packages/core/src/test/interpolate-keyframed-status.test.ts
+++ b/packages/core/src/test/interpolate-keyframed-status.test.ts
@@ -7,6 +7,7 @@ test('interpolates linear numeric keyframes', () => {
 		status: {
 			canUpdate: false,
 			reason: 'keyframed',
+			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
 				{frame: 60, value: 100},
@@ -24,6 +25,7 @@ test('clamps when extrapolation is clamp', () => {
 		status: {
 			canUpdate: false,
 			reason: 'keyframed',
+			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
 				{frame: 60, value: 100},
@@ -41,6 +43,7 @@ test('returns single keyframe value', () => {
 		status: {
 			canUpdate: false,
 			reason: 'keyframed',
+			interpolationFunction: 'interpolate',
 			keyframes: [{frame: 0, value: 7}],
 			easing: [],
 			clamping: {left: 'extend', right: 'extend'},
@@ -55,6 +58,7 @@ test('interpolates colors', () => {
 		status: {
 			canUpdate: false,
 			reason: 'keyframed',
+			interpolationFunction: 'interpolateColors',
 			keyframes: [
 				{frame: 0, value: '#000000'},
 				{frame: 60, value: '#ffffff'},
@@ -73,6 +77,7 @@ test('uses bezier easing', () => {
 		status: {
 			canUpdate: false,
 			reason: 'keyframed',
+			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
 				{frame: 60, value: 100},

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -30,6 +30,10 @@ export type CanUpdateSequencePropStatusClamping = {
 	right: ExtrapolateType;
 };
 
+export type CanUpdateSequencePropStatusInterpolationFunction =
+	| 'interpolate'
+	| 'interpolateColors';
+
 export type CanUpdateSequencePropStatusComputed = {
 	canUpdate: false;
 	reason: 'computed';
@@ -38,6 +42,7 @@ export type CanUpdateSequencePropStatusComputed = {
 export type CanUpdateSequencePropStatusKeyframed = {
 	canUpdate: false;
 	reason: 'keyframed';
+	interpolationFunction: CanUpdateSequencePropStatusInterpolationFunction;
 	keyframes: CanUpdateSequencePropStatusKeyframe[];
 	easing: CanUpdateSequencePropStatusEasing[];
 	clamping: CanUpdateSequencePropStatusClamping;

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -32,6 +32,7 @@ type KeyframedPropStatus = Extract<ComputedPropStatus, {reason: 'keyframed'}>;
 type PropKeyframes = KeyframedPropStatus['keyframes'];
 type PropEasing = KeyframedPropStatus['easing'];
 type PropClamping = KeyframedPropStatus['clamping'];
+type PropInterpolationFunction = KeyframedPropStatus['interpolationFunction'];
 
 export const isStaticValue = (node: Expression): boolean => {
 	switch (node.type) {
@@ -263,16 +264,13 @@ const getKeyframeEasingArray = ({
 };
 
 const getInterpolationMetadata = (
+	interpolationFunction: PropInterpolationFunction,
 	callExpression: CallExpression,
 	keyframeCount: number,
 ): {easing: PropEasing; clamping: PropClamping} | null => {
 	const segments = Math.max(0, keyframeCount - 1);
-	if (callExpression.callee.type !== 'Identifier') {
-		return null;
-	}
-
 	const defaultClamping: PropClamping =
-		callExpression.callee.name === 'interpolateColors'
+		interpolationFunction === 'interpolateColors'
 			? {
 					left: 'clamp',
 					right: 'clamp',
@@ -286,12 +284,8 @@ const getInterpolationMetadata = (
 		clamping: defaultClamping,
 	};
 
-	if (callExpression.callee.name === 'interpolateColors') {
+	if (interpolationFunction === 'interpolateColors') {
 		return defaults;
-	}
-
-	if (callExpression.callee.name !== 'interpolate') {
-		return null;
 	}
 
 	const optionsArg = callExpression.arguments[3];
@@ -360,6 +354,7 @@ const getInterpolationKeyframes = (
 			keyframes: PropKeyframes;
 			easing: PropEasing;
 			clamping: PropClamping;
+			interpolationFunction: PropInterpolationFunction;
 	  }
 	| undefined => {
 	if (node.type === 'TSAsExpression') {
@@ -378,6 +373,8 @@ const getInterpolationKeyframes = (
 	) {
 		return undefined;
 	}
+
+	const interpolationFunction = callExpression.callee.name;
 
 	const inputArg = callExpression.arguments[1];
 	const outputArg = callExpression.arguments[2];
@@ -422,12 +419,17 @@ const getInterpolationKeyframes = (
 		return undefined;
 	}
 
-	const metadata = getInterpolationMetadata(callExpression, keyframes.length);
+	const metadata = getInterpolationMetadata(
+		interpolationFunction,
+		callExpression,
+		keyframes.length,
+	);
 	if (!metadata) {
 		return undefined;
 	}
 
 	return {
+		interpolationFunction,
 		keyframes,
 		easing: metadata.easing,
 		clamping: metadata.clamping,
@@ -443,6 +445,7 @@ export const getComputedStatus = (node: Expression): CanUpdatePropStatus => {
 	return {
 		canUpdate: false,
 		reason: 'keyframed',
+		interpolationFunction: interpolation.interpolationFunction,
 		keyframes: interpolation.keyframes,
 		easing: interpolation.easing,
 		clamping: interpolation.clamping,

--- a/packages/studio-server/src/test/compute-effect-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-effect-props-status.test.ts
@@ -80,6 +80,7 @@ test('computeEffectPropStatus reports keyframes for inline interpolated effect p
 	expect(result.props.amount).toEqual({
 		canUpdate: false,
 		reason: 'keyframed',
+		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 0.2},
 			{frame: 100, value: 0.8},

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -80,6 +80,7 @@ export const Example: React.FC = () => {
 	expect(result.props.color).toEqual({
 		canUpdate: false,
 		reason: 'keyframed',
+		interpolationFunction: 'interpolateColors',
 		keyframes: [
 			{frame: 0, value: 'red'},
 			{frame: 100, value: 'blue'},
@@ -229,6 +230,7 @@ test('computeSequencePropsStatus should return keyframes for interpolated style 
 	expect(result.props['style.scale']).toEqual({
 		canUpdate: false,
 		reason: 'keyframed',
+		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 2},
 			{frame: 100, value: 4},
@@ -267,6 +269,7 @@ export const Example: React.FC = () => {
 	expect(result.props['style.scale']).toEqual({
 		canUpdate: false,
 		reason: 'keyframed',
+		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 1},
 			{frame: 50, value: 2},

--- a/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
@@ -12,6 +12,7 @@ test('optimisticDeleteSequenceKeyframe removes the matching keyframe and an easi
 			'style.opacity': {
 				canUpdate: false,
 				reason: 'keyframed',
+				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 0},
 					{frame: 30, value: 0.5},
@@ -53,6 +54,7 @@ test('optimisticDeleteSequenceKeyframe is a no-op when no keyframe matches', () 
 			'style.opacity': {
 				canUpdate: false,
 				reason: 'keyframed',
+				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 0, value: 0}],
 				easing: [],
 				clamping: {left: 'extend', right: 'extend'},
@@ -100,6 +102,7 @@ test('optimisticDeleteEffectKeyframe removes the matching keyframe on the target
 					amount: {
 						canUpdate: false,
 						reason: 'keyframed',
+						interpolationFunction: 'interpolate',
 						keyframes: [
 							{frame: 0, value: 0},
 							{frame: 30, value: 1},

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -115,6 +115,7 @@ test('keyframe display offsets follow the parent sequence context', () => {
 			{
 				canUpdate: false,
 				reason: 'keyframed',
+				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 2},
 					{frame: 60, value: 4},


### PR DESCRIPTION
## Summary
- add an explicit `interpolationFunction` field to keyframed prop status (`interpolate` or `interpolateColors`)
- compute and send that field from studio-server keyframe parsing
- use the explicit field in core keyframe interpolation instead of inferring by value types
- update keyframe-related tests across core/studio-server/studio/studio-shared

Closes #7804
