### PR TITLE
`@remotion/studio`: Add configurable preview sample rate

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -419,6 +419,7 @@ export const internalBundle = async (
 		logLevel: 'info',
 		mode: 'bundle',
 		audioLatencyHint: actualArgs.audioLatencyHint ?? 'playback',
+		sampleRate: actualArgs.renderDefaults?.sampleRate ?? 48000,
 	});
 
 	fs.writeFileSync(path.join(outDir, 'index.html'), html);

--- a/packages/bundler/src/index-html.ts
+++ b/packages/bundler/src/index-html.ts
@@ -27,6 +27,7 @@ export const indexHtml = ({
 	installedDependencies,
 	packageManager,
 	audioLatencyHint,
+	sampleRate,
 	logLevel,
 	mode,
 }: {
@@ -41,6 +42,7 @@ export const indexHtml = ({
 	completedClientRenders?: unknown | null;
 	numberOfAudioTags: number;
 	audioLatencyHint: AudioContextLatencyCategory;
+	sampleRate: number;
 	publicFiles: StaticFile[];
 	publicFolderExists: string | null;
 	includeFavicon: boolean;
@@ -70,6 +72,7 @@ export const indexHtml = ({
 	<body>
 		<script>window.remotion_numberOfAudioTags = ${numberOfAudioTags};</script>
 		<script>window.remotion_audioLatencyHint = "${audioLatencyHint}";</script>
+		<script>window.remotion_sampleRate = ${sampleRate};</script>
 		${mode === 'dev' ? `<script>window.remotion_logLevel = "${logLevel}";</script>` : ''}
 		<script>window.remotion_staticBase = "${staticHash}";</script>
 		${

--- a/packages/bundler/src/index-html.ts
+++ b/packages/bundler/src/index-html.ts
@@ -42,7 +42,7 @@ export const indexHtml = ({
 	completedClientRenders?: unknown | null;
 	numberOfAudioTags: number;
 	audioLatencyHint: AudioContextLatencyCategory;
-	sampleRate: number;
+	sampleRate: number | null;
 	publicFiles: StaticFile[];
 	publicFolderExists: string | null;
 	includeFavicon: boolean;
@@ -73,6 +73,7 @@ export const indexHtml = ({
 		<script>window.remotion_numberOfAudioTags = ${numberOfAudioTags};</script>
 		<script>window.remotion_audioLatencyHint = "${audioLatencyHint}";</script>
 		<script>window.remotion_sampleRate = ${sampleRate};</script>
+		<script>window.remotion_previewSampleRate = ${sampleRate};</script>
 		${mode === 'dev' ? `<script>window.remotion_logLevel = "${logLevel}";</script>` : ''}
 		<script>window.remotion_staticBase = "${staticHash}";</script>
 		${

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -122,6 +122,7 @@ const {
 	runsOption,
 	noOpenOption,
 	sampleRateOption,
+	previewSampleRateOption,
 } = BrowserSafeApis.options;
 
 declare global {
@@ -640,6 +641,11 @@ type FlatConfig = RemotionConfigObject &
 		 */
 		setSampleRate: (sampleRate: number) => void;
 		/**
+		 * Set the audio sample rate for preview playback.
+		 * Default: Uses Config.setSampleRate() / --sample-rate value, then 48000.
+		 */
+		setPreviewSampleRate: (sampleRate: number) => void;
+		/**
 		 * @deprecated 'The config format has changed. Change `Config.Bundling.*()` calls to `Config.*()` in your config file.'
 		 */
 		Bundling: void;
@@ -793,6 +799,7 @@ export const Config: FlatConfig = {
 	setBenchmarkRuns: runsOption.setConfig,
 	setBenchmarkConcurrencies: benchmarkConcurrenciesOption.setConfig,
 	setSampleRate: sampleRateOption.setConfig,
+	setPreviewSampleRate: previewSampleRateOption.setConfig,
 };
 
 export const ConfigInternals = {

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -642,9 +642,9 @@ type FlatConfig = RemotionConfigObject &
 		setSampleRate: (sampleRate: number) => void;
 		/**
 		 * Set the audio sample rate for preview playback.
-		 * Default: Uses Config.setSampleRate() / --sample-rate value, then 48000.
+		 * Default: null, which uses the composition sample rate and then 48000.
 		 */
-		setPreviewSampleRate: (sampleRate: number) => void;
+		setPreviewSampleRate: (sampleRate: number | null) => void;
 		/**
 		 * @deprecated 'The config format has changed. Change `Config.Bundling.*()` calls to `Config.*()` in your config file.'
 		 */

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -642,7 +642,7 @@ type FlatConfig = RemotionConfigObject &
 		setSampleRate: (sampleRate: number) => void;
 		/**
 		 * Set the audio sample rate for preview playback.
-		 * Default: null, which uses the composition sample rate and then 48000.
+		 * Default: null, which uses 48000 Hz.
 		 */
 		setPreviewSampleRate: (sampleRate: number | null) => void;
 		/**

--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -78,6 +78,7 @@ const {
 	configOption,
 	browserOption,
 	sampleRateOption,
+	previewSampleRateOption,
 } = BrowserSafeApis.options;
 
 export type CommandLineOptions = {
@@ -190,6 +191,9 @@ export type CommandLineOptions = {
 		typeof forceNewStudioOption
 	> | null;
 	[sampleRateOption.cliFlag]: TypeOfOption<typeof sampleRateOption>;
+	[previewSampleRateOption.cliFlag]: TypeOfOption<
+		typeof previewSampleRateOption
+	>;
 	[isProductionOption.cliFlag]: TypeOfOption<typeof isProductionOption> | null;
 };
 

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -34,6 +34,7 @@ const {
 	noOpenOption,
 	portOption,
 	browserOption,
+	previewSampleRateOption,
 } = BrowserSafeApis.options;
 
 export const studioCommand = async (
@@ -183,6 +184,9 @@ export const studioCommand = async (
 		binariesDirectory,
 		forceIPv4: ipv4Option.getValue({commandLine: parsedCli}).value,
 		audioLatencyHint: audioLatencyHintOption.getValue({
+			commandLine: parsedCli,
+		}).value,
+		previewSampleRate: previewSampleRateOption.getValue({
 			commandLine: parsedCli,
 		}).value,
 		enableCrossSiteIsolation,

--- a/packages/core/src/RemotionRoot.tsx
+++ b/packages/core/src/RemotionRoot.tsx
@@ -21,6 +21,7 @@ export const RemotionRootContexts: React.FC<{
 	readonly numberOfAudioTags: number;
 	readonly logLevel: LogLevel;
 	readonly audioLatencyHint: AudioContextLatencyCategory;
+	readonly previewSampleRate?: number;
 	readonly videoEnabled: boolean;
 	readonly audioEnabled: boolean;
 	readonly frameState: Record<string, number> | null;
@@ -29,6 +30,7 @@ export const RemotionRootContexts: React.FC<{
 	numberOfAudioTags,
 	logLevel,
 	audioLatencyHint,
+	previewSampleRate,
 	videoEnabled,
 	audioEnabled,
 	frameState,
@@ -60,6 +62,7 @@ export const RemotionRootContexts: React.FC<{
 											<SharedAudioContextProvider
 												audioLatencyHint={audioLatencyHint}
 												audioEnabled={audioEnabled}
+												previewSampleRate={previewSampleRate}
 											>
 												<SharedAudioTagsContextProvider
 													numberOfAudioTags={numberOfAudioTags}

--- a/packages/core/src/RemotionRoot.tsx
+++ b/packages/core/src/RemotionRoot.tsx
@@ -21,7 +21,7 @@ export const RemotionRootContexts: React.FC<{
 	readonly numberOfAudioTags: number;
 	readonly logLevel: LogLevel;
 	readonly audioLatencyHint: AudioContextLatencyCategory;
-	readonly previewSampleRate?: number;
+	readonly previewSampleRate: number | null;
 	readonly videoEnabled: boolean;
 	readonly audioEnabled: boolean;
 	readonly frameState: Record<string, number> | null;

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -4,10 +4,12 @@ import React, {
 	createRef,
 	useCallback,
 	useContext,
+	useEffect,
 	useMemo,
 	useRef,
 	useState,
 } from 'react';
+import {CompositionManager} from '../CompositionManagerContext.js';
 import {useLogLevel, useMountTime} from '../log-level-context.js';
 import {Log} from '../log.js';
 import {playAndHandleNotAllowedError} from '../play-and-handle-not-allowed-error.js';
@@ -193,12 +195,26 @@ export const SharedAudioContextProvider: React.FC<{
 	readonly children: React.ReactNode;
 	readonly audioLatencyHint: AudioContextLatencyCategory;
 	readonly audioEnabled: boolean;
-}> = ({children, audioLatencyHint, audioEnabled}) => {
+	readonly previewSampleRate?: number;
+}> = ({children, audioLatencyHint, audioEnabled, previewSampleRate}) => {
 	const logLevel = useLogLevel();
+	const {currentCompositionMetadata} = useContext(CompositionManager);
+	const sampleRate =
+		previewSampleRate ?? currentCompositionMetadata?.defaultSampleRate ?? 48000;
+
+	useEffect(() => {
+		if (typeof window === 'undefined') {
+			return;
+		}
+
+		window.remotion_sampleRate = sampleRate;
+	}, [sampleRate]);
+
 	const ctxAndGain = useSingletonAudioContext({
 		logLevel,
 		latencyHint: audioLatencyHint,
 		audioEnabled,
+		sampleRate,
 	});
 	const audioContextIsPlayingEventually = useRef(false);
 	const isResuming = useRef<Promise<void> | null>(null);

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -9,7 +9,6 @@ import React, {
 	useState,
 	type AudioHTMLAttributes,
 } from 'react';
-import {CompositionManager} from '../CompositionManagerContext.js';
 import {useLogLevel, useMountTime} from '../log-level-context.js';
 import {Log} from '../log.js';
 import {playAndHandleNotAllowedError} from '../play-and-handle-not-allowed-error.js';
@@ -198,19 +197,14 @@ export const SharedAudioContextProvider: React.FC<{
 	readonly previewSampleRate: number | null;
 }> = ({children, audioLatencyHint, audioEnabled, previewSampleRate}) => {
 	const logLevel = useLogLevel();
-	const {currentCompositionMetadata} = useContext(CompositionManager);
-	const sampleRate =
-		previewSampleRate ??
-		(currentCompositionMetadata
-			? (currentCompositionMetadata.defaultSampleRate ?? 48000)
-			: null);
+	const sampleRate = previewSampleRate ?? 48000;
 
 	useEffect(() => {
 		if (typeof window === 'undefined') {
 			return;
 		}
 
-		window.remotion_sampleRate = sampleRate ?? 48000;
+		window.remotion_sampleRate = sampleRate;
 	}, [sampleRate]);
 
 	const ctxAndGain = useSingletonAudioContext({

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -1,4 +1,3 @@
-import {type AudioHTMLAttributes} from 'react';
 import React, {
 	createContext,
 	createRef,
@@ -8,6 +7,7 @@ import React, {
 	useMemo,
 	useRef,
 	useState,
+	type AudioHTMLAttributes,
 } from 'react';
 import {CompositionManager} from '../CompositionManagerContext.js';
 import {useLogLevel, useMountTime} from '../log-level-context.js';
@@ -195,19 +195,22 @@ export const SharedAudioContextProvider: React.FC<{
 	readonly children: React.ReactNode;
 	readonly audioLatencyHint: AudioContextLatencyCategory;
 	readonly audioEnabled: boolean;
-	readonly previewSampleRate?: number;
+	readonly previewSampleRate: number | null;
 }> = ({children, audioLatencyHint, audioEnabled, previewSampleRate}) => {
 	const logLevel = useLogLevel();
 	const {currentCompositionMetadata} = useContext(CompositionManager);
 	const sampleRate =
-		previewSampleRate ?? currentCompositionMetadata?.defaultSampleRate ?? 48000;
+		previewSampleRate ??
+		(currentCompositionMetadata
+			? (currentCompositionMetadata.defaultSampleRate ?? 48000)
+			: null);
 
 	useEffect(() => {
 		if (typeof window === 'undefined') {
 			return;
 		}
 
-		window.remotion_sampleRate = sampleRate;
+		window.remotion_sampleRate = sampleRate ?? 48000;
 	}, [sampleRate]);
 
 	const ctxAndGain = useSingletonAudioContext({

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useMemo, useRef} from 'react';
 import type {LogLevel} from '../log';
 import {Log} from '../log';
 import {useRemotionEnvironment} from '../use-remotion-environment';
@@ -38,9 +38,30 @@ export const useSingletonAudioContext = ({
 	logLevel: LogLevel;
 	latencyHint: AudioContextLatencyCategory;
 	audioEnabled: boolean;
-	sampleRate: number;
+	sampleRate: number | null;
 }) => {
 	const env = useRemotionEnvironment();
+	const initialSampleRate = useRef<number | null>(null);
+
+	if (sampleRate === null && initialSampleRate.current !== null) {
+		throw new Error(
+			`Changing the AudioContext sample rate dynamically is not supported. The sample rate was initialized with ${initialSampleRate.current} Hz, but no sample rate was passed later.`,
+		);
+	}
+
+	if (sampleRate !== null && initialSampleRate.current === null) {
+		initialSampleRate.current = sampleRate;
+	}
+
+	if (
+		sampleRate !== null &&
+		initialSampleRate.current !== null &&
+		sampleRate !== initialSampleRate.current
+	) {
+		throw new Error(
+			`Changing the AudioContext sample rate dynamically is not supported. The sample rate was initialized with ${initialSampleRate.current} Hz, but ${sampleRate} Hz was passed later.`,
+		);
+	}
 
 	const context = useMemo(() => {
 		if (env.isRendering) {
@@ -48,6 +69,10 @@ export const useSingletonAudioContext = ({
 		}
 
 		if (!audioEnabled) {
+			return null;
+		}
+
+		if (sampleRate === null) {
 			return null;
 		}
 

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -38,26 +38,12 @@ export const useSingletonAudioContext = ({
 	logLevel: LogLevel;
 	latencyHint: AudioContextLatencyCategory;
 	audioEnabled: boolean;
-	sampleRate: number | null;
+	sampleRate: number;
 }) => {
 	const env = useRemotionEnvironment();
-	const initialSampleRate = useRef<number | null>(null);
+	const initialSampleRate = useRef(sampleRate);
 
-	if (sampleRate === null && initialSampleRate.current !== null) {
-		throw new Error(
-			`Changing the AudioContext sample rate dynamically is not supported. The sample rate was initialized with ${initialSampleRate.current} Hz, but no sample rate was passed later.`,
-		);
-	}
-
-	if (sampleRate !== null && initialSampleRate.current === null) {
-		initialSampleRate.current = sampleRate;
-	}
-
-	if (
-		sampleRate !== null &&
-		initialSampleRate.current !== null &&
-		sampleRate !== initialSampleRate.current
-	) {
+	if (sampleRate !== initialSampleRate.current) {
 		throw new Error(
 			`Changing the AudioContext sample rate dynamically is not supported. The sample rate was initialized with ${initialSampleRate.current} Hz, but ${sampleRate} Hz was passed later.`,
 		);
@@ -69,10 +55,6 @@ export const useSingletonAudioContext = ({
 		}
 
 		if (!audioEnabled) {
-			return null;
-		}
-
-		if (sampleRate === null) {
 			return null;
 		}
 

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -33,10 +33,12 @@ export const useSingletonAudioContext = ({
 	logLevel,
 	latencyHint,
 	audioEnabled,
+	sampleRate,
 }: {
 	logLevel: LogLevel;
 	latencyHint: AudioContextLatencyCategory;
 	audioEnabled: boolean;
+	sampleRate: number;
 }) => {
 	const env = useRemotionEnvironment();
 
@@ -59,7 +61,7 @@ export const useSingletonAudioContext = ({
 			// By default, this can end up being 44100Hz.
 			// Playing a 48000Hz file in a 44100Hz context, such as https://remotion.media/video.mp4 in a @remotion/media tag
 			// we observe some issues that seem to go away when we set the sample rate to 48000 with Sony LinkBuds Bluetooth headphones.
-			sampleRate: 48000,
+			sampleRate,
 		});
 
 		const gainNode = audioContext.createGain();
@@ -119,7 +121,7 @@ export const useSingletonAudioContext = ({
 			resume,
 			suspend,
 		};
-	}, [logLevel, latencyHint, env.isRendering, audioEnabled]);
+	}, [logLevel, latencyHint, env.isRendering, audioEnabled, sampleRate]);
 
 	return context;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,7 +84,8 @@ declare global {
 		remotion_envVariables: string;
 		remotion_isMainTab: boolean;
 		remotion_mediaCacheSizeInBytes: number | null;
-		remotion_sampleRate: number;
+		remotion_sampleRate: number | null;
+		remotion_previewSampleRate: number | null;
 		remotion_initialMemoryAvailable: number | null;
 		remotion_collectAssets: () => TRenderAsset[];
 		remotion_isPlayer: boolean;

--- a/packages/core/src/test/composition-rules.test.tsx
+++ b/packages/core/src/test/composition-rules.test.tsx
@@ -65,6 +65,7 @@ describe('Render composition-rules should throw with invalid props', () => {
 							numberOfAudioTags={0}
 							logLevel="info"
 							audioLatencyHint="interactive"
+							previewSampleRate={null}
 						>
 							<RenderAssetManagerProvider collectAssets={null}>
 								<Composition

--- a/packages/core/src/test/offthread-video.test.tsx
+++ b/packages/core/src/test/offthread-video.test.tsx
@@ -27,6 +27,7 @@ const WrapPreviewContext: React.FC<{
 				<SharedAudioContextProvider
 					audioEnabled={false}
 					audioLatencyHint="playback"
+					previewSampleRate={null}
 				>
 					{children}
 				</SharedAudioContextProvider>

--- a/packages/docs/docs/cli/studio.mdx
+++ b/packages/docs/docs/cli/studio.mdx
@@ -111,6 +111,14 @@ npx remotion studio --ipv4
 npx remotion studio --number-of-shared-audio-tags=5
 ```
 
+### `--preview-sample-rate`
+
+<Options id="preview-sample-rate" />
+
+```sh
+npx remotion studio --preview-sample-rate=44100
+```
+
 ### `--cross-site-isolation`<AvailableFrom v="4.0.364" />
 
 [Enable Cross-Site Isolation in the Studio](/docs/config#setenablecrosssiteisolation).

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -473,7 +473,7 @@ Config.setSampleRate(44100);
 
 The [command line flag](/docs/cli/render#--sample-rate) `--sample-rate` will take precedence over this option.
 
-## `setPreviewSampleRate()`
+## `setPreviewSampleRate()`<AvailableFrom v="4.0.470" />
 
 <Options id="preview-sample-rate" />
 

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -473,6 +473,18 @@ Config.setSampleRate(44100);
 
 The [command line flag](/docs/cli/render#--sample-rate) `--sample-rate` will take precedence over this option.
 
+## `setPreviewSampleRate()`
+
+<Options id="preview-sample-rate" />
+
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+// ---cut---
+Config.setPreviewSampleRate(44100);
+```
+
+The [command line flag](/docs/cli/studio#--preview-sample-rate) `--preview-sample-rate` will take precedence over this option.
+
 ## `setForSeamlessAacConcatenation()`<AvailableFrom v="4.0.123" />
 
 <Options id="for-seamless-aac-concatenation" />

--- a/packages/docs/docs/player/api.mdx
+++ b/packages/docs/docs/player/api.mdx
@@ -124,9 +124,9 @@ If you'd like to opt out of this behavior, you can pass `0` to mount native audi
 
 Once you have set this prop, you cannot change it anymore or an error will be thrown.
 
-### `sampleRate?`
+### `sampleRate?`<AvailableFrom v="4.0.470" />
 
-Controls the sample rate used by the `AudioContext` inside the Player preview. Pass a positive integer. Default `48000`.
+Controls the sample rate used by the `AudioContext` inside the Player preview. Pass a positive integer. Default `48000`. Once the Player is mounted, this property cannot be changed.
 
 ```tsx twoslash
 import {Player} from '@remotion/player';

--- a/packages/docs/docs/player/api.mdx
+++ b/packages/docs/docs/player/api.mdx
@@ -124,6 +124,27 @@ If you'd like to opt out of this behavior, you can pass `0` to mount native audi
 
 Once you have set this prop, you cannot change it anymore or an error will be thrown.
 
+### `sampleRate?`
+
+Controls the sample rate used by the `AudioContext` inside the Player preview. Pass a positive integer. Default `48000`.
+
+```tsx twoslash
+import {Player} from '@remotion/player';
+
+const MyComp: React.FC = () => null;
+
+// ---cut---
+
+<Player
+  component={MyComp}
+  durationInFrames={120}
+  compositionWidth={1920}
+  compositionHeight={1080}
+  fps={30}
+  sampleRate={44100}
+/>;
+```
+
 ### `playbackRate?`
 
 A number between -10 and 10 (excluding 0) for the speed that the Player will run the media.

--- a/packages/docs/docs/sample-rate.mdx
+++ b/packages/docs/docs/sample-rate.mdx
@@ -152,14 +152,12 @@ Choose the sample rate that matches the majority of your sources, or the highest
 
 ## Sample rate during preview
 
-During preview in the [Remotion Studio](/docs/studio), the sample rate now follows your sample-rate configuration.
+During preview in the [Remotion Studio](/docs/studio), the `AudioContext` sample rate uses the composition's `defaultSampleRate`, falling back to `48000` Hz.
 
 You can control it via:
 
 - [`Config.setPreviewSampleRate()`](/docs/config#setpreviewsamplerate)
 - `npx remotion studio --preview-sample-rate=44100`
-
-If you don't set a preview-specific value, Remotion uses [`Config.setSampleRate()`](/docs/config#setsamplerate) / `--sample-rate`.
 
 ## See also
 

--- a/packages/docs/docs/sample-rate.mdx
+++ b/packages/docs/docs/sample-rate.mdx
@@ -152,9 +152,14 @@ Choose the sample rate that matches the majority of your sources, or the highest
 
 ## Sample rate during preview
 
-During preview in the [Remotion Studio](/docs/studio), audio is always played back at 48000 Hz. This cannot currently be changed.
+During preview in the [Remotion Studio](/docs/studio), the sample rate now follows your sample-rate configuration.
 
-This means previewed audio may sound slightly different from the final render if you use a custom sample rate. The rendered output will use the correct sample rate.
+You can control it via:
+
+- [`Config.setPreviewSampleRate()`](/docs/config#setpreviewsamplerate)
+- `npx remotion studio --preview-sample-rate=44100`
+
+If you don't set a preview-specific value, Remotion uses [`Config.setSampleRate()`](/docs/config#setsamplerate) / `--sample-rate`.
 
 ## See also
 

--- a/packages/docs/docs/sample-rate.mdx
+++ b/packages/docs/docs/sample-rate.mdx
@@ -152,7 +152,7 @@ Choose the sample rate that matches the majority of your sources, or the highest
 
 ## Sample rate during preview
 
-During preview in the [Remotion Studio](/docs/studio), the `AudioContext` sample rate uses the composition's `defaultSampleRate`, falling back to `48000` Hz.
+During preview in the [Remotion Studio](/docs/studio), the `AudioContext` sample rate defaults to `48000` Hz.
 
 You can control it via:
 

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -97,6 +97,7 @@ export type PlayerProps<
 	readonly noSuspense?: boolean;
 	readonly acknowledgeRemotionLicense?: boolean;
 	readonly audioLatencyHint?: AudioContextLatencyCategory;
+	readonly sampleRate?: number;
 	readonly volumePersistenceKey?: string;
 	readonly initialVolume?: number;
 } & CompProps<Props> &
@@ -168,6 +169,7 @@ const PlayerFn = <
 		noSuspense,
 		acknowledgeRemotionLicense,
 		audioLatencyHint = 'playback',
+		sampleRate = 48000,
 		volumePersistenceKey,
 		initialVolume,
 		...componentProps
@@ -323,6 +325,18 @@ const PlayerFn = <
 	}
 
 	if (
+		typeof sampleRate !== 'number' ||
+		!Number.isFinite(sampleRate) ||
+		Number.isNaN(sampleRate) ||
+		sampleRate <= 0 ||
+		sampleRate % 1 !== 0
+	) {
+		throw new TypeError(
+			`'sampleRate' must be a positive integer but got '${sampleRate}' instead`,
+		);
+	}
+
+	if (
 		typeof initialVolume !== 'undefined' &&
 		typeof initialVolume !== 'number'
 	) {
@@ -436,6 +450,7 @@ const PlayerFn = <
 				initiallyMuted={initiallyMuted}
 				logLevel={logLevel}
 				audioLatencyHint={audioLatencyHint}
+				sampleRate={sampleRate}
 				volumePersistenceKey={volumePersistenceKey}
 				initialVolume={initialVolume}
 				inputProps={actualInputProps}

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -30,6 +30,7 @@ export const SharedPlayerContexts: React.FC<{
 	readonly initiallyMuted: boolean;
 	readonly logLevel: LogLevel;
 	readonly audioLatencyHint: AudioContextLatencyCategory;
+	readonly sampleRate: number;
 	readonly volumePersistenceKey?: string;
 	readonly initialVolume?: number;
 	readonly inputProps: Record<string, unknown>;
@@ -47,6 +48,7 @@ export const SharedPlayerContexts: React.FC<{
 	initiallyMuted,
 	logLevel,
 	audioLatencyHint,
+	sampleRate,
 	volumePersistenceKey,
 	initialVolume,
 	inputProps,
@@ -169,6 +171,7 @@ export const SharedPlayerContexts: React.FC<{
 														<Internals.SharedAudioContextProvider
 															audioLatencyHint={audioLatencyHint}
 															audioEnabled={audioEnabled}
+															previewSampleRate={sampleRate}
 														>
 															<Internals.SharedAudioTagsContextProvider
 																numberOfAudioTags={numberOfSharedAudioTags}

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -137,6 +137,7 @@ const ThumbnailFn = <
 				initiallyMuted
 				logLevel={logLevel}
 				audioLatencyHint="playback"
+				sampleRate={48000}
 				inputProps={passedInputProps}
 				audioEnabled={false}
 			>

--- a/packages/player/src/test/validate-prop.test.tsx
+++ b/packages/player/src/test/validate-prop.test.tsx
@@ -261,6 +261,39 @@ test('initialVolume out of range should give errors', () => {
 	}).toThrow(/'initialVolume' must be between 0 and 1 but got '2' instead/);
 });
 
+test('sampleRate should be okay', () => {
+	render(
+		<Player
+			compositionWidth={500}
+			compositionHeight={400}
+			fps={30}
+			durationInFrames={500}
+			component={HelloWorld}
+			controls
+			showVolumeControls
+			sampleRate={44100}
+		/>,
+	);
+	expect(true).toBe(true);
+});
+
+test('invalid sampleRate should give errors', () => {
+	expect(() => {
+		render(
+			<Player
+				compositionWidth={500}
+				compositionHeight={400}
+				fps={30}
+				durationInFrames={500}
+				component={HelloWorld}
+				controls
+				showVolumeControls
+				sampleRate={0}
+			/>,
+		);
+	}).toThrow(/'sampleRate' must be a positive integer but got '0' instead/);
+});
+
 test('passing in <Composition /> instance should not be possible', () => {
 	expect(() => {
 		render(

--- a/packages/player/src/test/validate-prop.test.tsx
+++ b/packages/player/src/test/validate-prop.test.tsx
@@ -277,6 +277,39 @@ test('sampleRate should be okay', () => {
 	expect(true).toBe(true);
 });
 
+test('sampleRate cannot be changed dynamically', () => {
+	const initial = (
+		<Player
+			compositionWidth={500}
+			compositionHeight={400}
+			fps={30}
+			durationInFrames={500}
+			component={HelloWorld}
+			controls
+			showVolumeControls
+			sampleRate={44100}
+		/>
+	);
+	const changed = (
+		<Player
+			compositionWidth={500}
+			compositionHeight={400}
+			fps={30}
+			durationInFrames={500}
+			component={HelloWorld}
+			controls
+			showVolumeControls
+			sampleRate={48000}
+		/>
+	);
+
+	const {rerender} = render(initial);
+
+	expect(() => rerender(changed)).toThrow(
+		/Changing the AudioContext sample rate dynamically is not supported/,
+	);
+});
+
 test('invalid sampleRate should give errors', () => {
 	expect(() => {
 		render(

--- a/packages/renderer/src/options/index.tsx
+++ b/packages/renderer/src/options/index.tsx
@@ -65,6 +65,7 @@ import {packageManagerOption} from './package-manager';
 import {pixelFormatOption} from './pixel-format';
 import {portOption} from './port';
 import {preferLosslessAudioOption} from './prefer-lossless';
+import {previewSampleRateOption} from './preview-sample-rate';
 import {propsOption} from './props';
 import {proResProfileOption} from './prores-profile';
 import {publicDirOption} from './public-dir';
@@ -126,6 +127,7 @@ export const allOptions = {
 	noOpenOption,
 	pixelFormatOption,
 	preferLosslessOption: preferLosslessAudioOption,
+	previewSampleRateOption,
 	proResProfileOption,
 	x264Option,
 	logLevelOption,

--- a/packages/renderer/src/options/preview-sample-rate.tsx
+++ b/packages/renderer/src/options/preview-sample-rate.tsx
@@ -10,8 +10,7 @@ export const previewSampleRateOption = {
 	description: () => (
 		<>
 			Controls the sample rate used for audio playback during preview. When
-			unset, the composition sample rate is used, falling back to{' '}
-			<code>48000</code> Hz.
+			unset, Remotion uses <code>48000</code> Hz.
 		</>
 	),
 	ssrName: null,

--- a/packages/renderer/src/options/preview-sample-rate.tsx
+++ b/packages/renderer/src/options/preview-sample-rate.tsx
@@ -1,0 +1,36 @@
+import type {AnyRemotionOption} from './option';
+import {sampleRateOption} from './sample-rate';
+
+const cliFlag = 'preview-sample-rate' as const;
+
+let currentPreviewSampleRate: number | null = null;
+
+export const previewSampleRateOption = {
+	name: 'Preview Sample Rate',
+	cliFlag,
+	description: () => (
+		<>
+			Controls the sample rate used for audio playback during preview. By
+			default, Remotion uses the render sample rate configuration.
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/config#setpreviewsamplerate',
+	type: 48000 as number,
+	getValue: ({commandLine}: {commandLine: Record<string, unknown>}) => {
+		if (commandLine[cliFlag] !== undefined) {
+			return {value: commandLine[cliFlag] as number, source: 'cli'};
+		}
+
+		if (currentPreviewSampleRate !== null) {
+			return {value: currentPreviewSampleRate, source: 'config file'};
+		}
+
+		const fallback = sampleRateOption.getValue({commandLine});
+		return {value: fallback.value, source: fallback.source};
+	},
+	setConfig: (value: number) => {
+		currentPreviewSampleRate = value;
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<number>;

--- a/packages/renderer/src/options/preview-sample-rate.tsx
+++ b/packages/renderer/src/options/preview-sample-rate.tsx
@@ -1,5 +1,4 @@
 import type {AnyRemotionOption} from './option';
-import {sampleRateOption} from './sample-rate';
 
 const cliFlag = 'preview-sample-rate' as const;
 
@@ -10,13 +9,14 @@ export const previewSampleRateOption = {
 	cliFlag,
 	description: () => (
 		<>
-			Controls the sample rate used for audio playback during preview. By
-			default, Remotion uses the render sample rate configuration.
+			Controls the sample rate used for audio playback during preview. When
+			unset, the composition sample rate is used, falling back to{' '}
+			<code>48000</code> Hz.
 		</>
 	),
 	ssrName: null,
 	docLink: 'https://www.remotion.dev/docs/config#setpreviewsamplerate',
-	type: 48000 as number,
+	type: null as number | null,
 	getValue: ({commandLine}: {commandLine: Record<string, unknown>}) => {
 		if (commandLine[cliFlag] !== undefined) {
 			return {value: commandLine[cliFlag] as number, source: 'cli'};
@@ -26,11 +26,10 @@ export const previewSampleRateOption = {
 			return {value: currentPreviewSampleRate, source: 'config file'};
 		}
 
-		const fallback = sampleRateOption.getValue({commandLine});
-		return {value: fallback.value, source: fallback.source};
+		return {value: null, source: 'default'};
 	},
-	setConfig: (value: number) => {
+	setConfig: (value: number | null) => {
 		currentPreviewSampleRate = value;
 	},
 	id: cliFlag,
-} satisfies AnyRemotionOption<number>;
+} satisfies AnyRemotionOption<number | null>;

--- a/packages/renderer/src/test/get-assets-for-markup.tsx
+++ b/packages/renderer/src/test/get-assets-for-markup.tsx
@@ -122,6 +122,7 @@ export const getAssetsForMarkup = async (
 						numberOfAudioTags={0}
 						logLevel="info"
 						audioLatencyHint="interactive"
+						previewSampleRate={null}
 					>
 						<Internals.RenderAssetManagerProvider collectAssets={null}>
 							<Internals.CompositionManager.Provider value={value}>

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -63,7 +63,7 @@ export const startServer = async (options: {
 	binariesDirectory: string | null;
 	forceIPv4: boolean;
 	audioLatencyHint: AudioContextLatencyCategory | null;
-	previewSampleRate: number;
+	previewSampleRate: number | null;
 	enableCrossSiteIsolation: boolean;
 	askAIEnabled: boolean;
 	forceNew: boolean;

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -63,6 +63,7 @@ export const startServer = async (options: {
 	binariesDirectory: string | null;
 	forceIPv4: boolean;
 	audioLatencyHint: AudioContextLatencyCategory | null;
+	previewSampleRate: number;
 	enableCrossSiteIsolation: boolean;
 	askAIEnabled: boolean;
 	forceNew: boolean;
@@ -172,6 +173,7 @@ export const startServer = async (options: {
 					gitSource: options.gitSource,
 					binariesDirectory: options.binariesDirectory,
 					audioLatencyHint: options.audioLatencyHint,
+					previewSampleRate: options.previewSampleRate,
 					enableCrossSiteIsolation: options.enableCrossSiteIsolation,
 				});
 			})

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -103,7 +103,7 @@ const handleFallback = async ({
 	getRenderDefaults: () => RenderDefaults;
 	numberOfAudioTags: number;
 	audioLatencyHint: AudioContextLatencyCategory | null;
-	previewSampleRate: number;
+	previewSampleRate: number | null;
 	gitSource: GitSource | null;
 	logLevel: LogLevel;
 	enableCrossSiteIsolation: boolean;
@@ -550,7 +550,7 @@ export const handleRoutes = ({
 	gitSource: GitSource | null;
 	binariesDirectory: string | null;
 	audioLatencyHint: AudioContextLatencyCategory | null;
-	previewSampleRate: number;
+	previewSampleRate: number | null;
 	enableCrossSiteIsolation: boolean;
 }): Promise<void> => {
 	const url = new URL(request.url as string, 'http://localhost');

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -87,6 +87,7 @@ const handleFallback = async ({
 	getRenderDefaults,
 	numberOfAudioTags,
 	audioLatencyHint,
+	previewSampleRate,
 	gitSource,
 	logLevel,
 	enableCrossSiteIsolation,
@@ -102,6 +103,7 @@ const handleFallback = async ({
 	getRenderDefaults: () => RenderDefaults;
 	numberOfAudioTags: number;
 	audioLatencyHint: AudioContextLatencyCategory | null;
+	previewSampleRate: number;
 	gitSource: GitSource | null;
 	logLevel: LogLevel;
 	enableCrossSiteIsolation: boolean;
@@ -183,6 +185,7 @@ const handleFallback = async ({
 			logLevel,
 			mode: 'dev',
 			audioLatencyHint: audioLatencyHint ?? 'playback',
+			sampleRate: previewSampleRate,
 		}),
 	);
 };
@@ -524,6 +527,7 @@ export const handleRoutes = ({
 	gitSource,
 	binariesDirectory,
 	audioLatencyHint,
+	previewSampleRate,
 	enableCrossSiteIsolation,
 }: {
 	staticHash: string;
@@ -546,6 +550,7 @@ export const handleRoutes = ({
 	gitSource: GitSource | null;
 	binariesDirectory: string | null;
 	audioLatencyHint: AudioContextLatencyCategory | null;
+	previewSampleRate: number;
 	enableCrossSiteIsolation: boolean;
 }): Promise<void> => {
 	const url = new URL(request.url as string, 'http://localhost');
@@ -689,6 +694,7 @@ export const handleRoutes = ({
 		gitSource,
 		logLevel,
 		audioLatencyHint,
+		previewSampleRate,
 		enableCrossSiteIsolation,
 	});
 };

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -52,6 +52,7 @@ export const startStudio = async ({
 	binariesDirectory,
 	forceIPv4,
 	audioLatencyHint,
+	previewSampleRate,
 	enableCrossSiteIsolation,
 	askAIEnabled,
 	forceNew,
@@ -77,6 +78,7 @@ export const startStudio = async ({
 	getRenderQueue: () => RenderJob[];
 	numberOfAudioTags: number;
 	audioLatencyHint: AudioContextLatencyCategory | null;
+	previewSampleRate: number;
 	enableCrossSiteIsolation: boolean;
 	queueMethods: QueueMethods;
 	previewEntry: string;
@@ -161,6 +163,7 @@ export const startStudio = async ({
 		binariesDirectory,
 		forceIPv4,
 		audioLatencyHint,
+		previewSampleRate,
 		enableCrossSiteIsolation,
 		askAIEnabled,
 		forceNew,

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -78,7 +78,7 @@ export const startStudio = async ({
 	getRenderQueue: () => RenderJob[];
 	numberOfAudioTags: number;
 	audioLatencyHint: AudioContextLatencyCategory | null;
-	previewSampleRate: number;
+	previewSampleRate: number | null;
 	enableCrossSiteIsolation: boolean;
 	queueMethods: QueueMethods;
 	previewEntry: string;

--- a/packages/studio/src/Studio.tsx
+++ b/packages/studio/src/Studio.tsx
@@ -31,7 +31,7 @@ const StudioInner: React.FC<{
 				logLevel={window.remotion_logLevel ?? 'info'}
 				numberOfAudioTags={window.remotion_numberOfAudioTags}
 				audioLatencyHint={window.remotion_audioLatencyHint ?? 'playback'}
-				previewSampleRate={window.remotion_sampleRate ?? 48000}
+				previewSampleRate={window.remotion_previewSampleRate}
 			>
 				<StaticFilesProvider>
 					<ResolveCompositionConfigInStudio>

--- a/packages/studio/src/Studio.tsx
+++ b/packages/studio/src/Studio.tsx
@@ -31,6 +31,7 @@ const StudioInner: React.FC<{
 				logLevel={window.remotion_logLevel ?? 'info'}
 				numberOfAudioTags={window.remotion_numberOfAudioTags}
 				audioLatencyHint={window.remotion_audioLatencyHint ?? 'playback'}
+				previewSampleRate={window.remotion_sampleRate ?? 48000}
 			>
 				<StaticFilesProvider>
 					<ResolveCompositionConfigInStudio>

--- a/packages/studio/src/renderEntry.tsx
+++ b/packages/studio/src/renderEntry.tsx
@@ -251,7 +251,7 @@ const renderContent = (Root: React.FC) => {
 					logLevel={window.remotion_logLevel ?? 'info'}
 					numberOfAudioTags={0}
 					audioLatencyHint={window.remotion_audioLatencyHint ?? 'playback'}
-					previewSampleRate={window.remotion_sampleRate ?? 48000}
+					previewSampleRate={window.remotion_previewSampleRate}
 				>
 					<Internals.RenderAssetManagerProvider collectAssets={null}>
 						<Root />
@@ -279,7 +279,7 @@ const renderContent = (Root: React.FC) => {
 					logLevel={window.remotion_logLevel ?? 'info'}
 					numberOfAudioTags={0}
 					audioLatencyHint={window.remotion_audioLatencyHint ?? 'playback'}
-					previewSampleRate={window.remotion_sampleRate ?? 48000}
+					previewSampleRate={window.remotion_previewSampleRate}
 				>
 					<Internals.RenderAssetManagerProvider collectAssets={null}>
 						<Root />

--- a/packages/studio/src/renderEntry.tsx
+++ b/packages/studio/src/renderEntry.tsx
@@ -251,6 +251,7 @@ const renderContent = (Root: React.FC) => {
 					logLevel={window.remotion_logLevel ?? 'info'}
 					numberOfAudioTags={0}
 					audioLatencyHint={window.remotion_audioLatencyHint ?? 'playback'}
+					previewSampleRate={window.remotion_sampleRate ?? 48000}
 				>
 					<Internals.RenderAssetManagerProvider collectAssets={null}>
 						<Root />
@@ -278,6 +279,7 @@ const renderContent = (Root: React.FC) => {
 					logLevel={window.remotion_logLevel ?? 'info'}
 					numberOfAudioTags={0}
 					audioLatencyHint={window.remotion_audioLatencyHint ?? 'playback'}
+					previewSampleRate={window.remotion_sampleRate ?? 48000}
 				>
 					<Internals.RenderAssetManagerProvider collectAssets={null}>
 						<Root />

--- a/packages/web-renderer/src/update-time.tsx
+++ b/packages/web-renderer/src/update-time.tsx
@@ -41,6 +41,7 @@ export const UpdateTime: React.FC<{
 			logLevel={logLevel}
 			numberOfAudioTags={0}
 			audioLatencyHint="interactive"
+			previewSampleRate={null}
 			frameState={{
 				[compId]: frame,
 			}}


### PR DESCRIPTION
## Summary
- add a new `preview-sample-rate` Remotion option with CLI/config support via `--preview-sample-rate` and `Config.setPreviewSampleRate()`
- wire preview sample rate through Studio startup and HTML bootstrap so preview uses configured sample rate
- make preview audio context sample rate configurable in core, and set `window.remotion_sampleRate` from preview context
- add a `sampleRate` prop to `@remotion/player` and pass it into the shared preview audio context
- update docs for Studio CLI, config, Player API, and sample-rate behavior

## Validation
- `bunx oxfmt src --write` in affected packages
- `bun run build`
- `bun run formatting`