### PR TITLE
`remotion`: Add OffthreadVideo frame callback

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -238,7 +238,7 @@ export {
 	Video,
 } from './video/index.js';
 export {MediaPlaybackError} from './video/MediaPlaybackError.js';
-export type {OnVideoFrame} from './video/props.js';
+export type {OnVideoFrame, OnVideoFramePresented} from './video/props.js';
 export type {VolumeProp} from './volume-prop.js';
 export {watchStaticFile} from './watch-static-file.js';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -238,7 +238,7 @@ export {
 	Video,
 } from './video/index.js';
 export {MediaPlaybackError} from './video/MediaPlaybackError.js';
-export type {OnVideoFrame, OnVideoFramePresented} from './video/props.js';
+export type {OnVideoFrame, OnVideoFrameCallback} from './video/props.js';
 export type {VolumeProp} from './volume-prop.js';
 export {watchStaticFile} from './watch-static-file.js';
 

--- a/packages/core/src/test/offthread-video.test.tsx
+++ b/packages/core/src/test/offthread-video.test.tsx
@@ -106,11 +106,11 @@ describe('OffthreadVideo render correctly with props', () => {
 		).not.toThrow();
 	});
 
-	test('It should render OffthreadVideo with onVideoFramePresented prop', () => {
+	test('It should render OffthreadVideo with onVideoFrameCallback prop', () => {
 		expect(() =>
 			render(
 				<WrapSequenceContext>
-					<OffthreadVideo src="test" onVideoFramePresented={() => undefined} />
+					<OffthreadVideo src="test" onVideoFrameCallback={() => undefined} />
 				</WrapSequenceContext>,
 			),
 		).not.toThrow();

--- a/packages/core/src/test/offthread-video.test.tsx
+++ b/packages/core/src/test/offthread-video.test.tsx
@@ -106,6 +106,16 @@ describe('OffthreadVideo render correctly with props', () => {
 		).not.toThrow();
 	});
 
+	test('It should render OffthreadVideo with onVideoFramePresented prop', () => {
+		expect(() =>
+			render(
+				<WrapSequenceContext>
+					<OffthreadVideo src="test" onVideoFramePresented={() => undefined} />
+				</WrapSequenceContext>,
+			),
+		).not.toThrow();
+	});
+
 	test('It should throw when both startFrom and trimBefore are provided', () => {
 		expect(() =>
 			render(

--- a/packages/core/src/test/video.test.tsx
+++ b/packages/core/src/test/video.test.tsx
@@ -72,6 +72,16 @@ test('It should render Video with trimBefore and trimAfter props', () => {
 	).not.toThrow();
 });
 
+test('It should render Video with onVideoFrameCallback prop', () => {
+	expect(() =>
+		render(
+			<WrapSequenceContext>
+				<Html5Video src="test" onVideoFrameCallback={() => undefined} />
+			</WrapSequenceContext>,
+		),
+	).not.toThrow();
+});
+
 test('It should throw when both startFrom and trimBefore are provided', () => {
 	expect(() =>
 		render(

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -107,7 +107,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 		toneMapped,
 		onAutoPlayError,
 		onVideoFrame,
-		onVideoFramePresented,
+		onVideoFrameCallback,
 		crossOrigin,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
@@ -123,7 +123,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 			showInTimeline={showInTimeline ?? true}
 			onAutoPlayError={onAutoPlayError ?? undefined}
 			onVideoFrame={onVideoFrame ?? null}
-			onVideoFramePresented={onVideoFramePresented ?? null}
+			onVideoFrameCallback={onVideoFrameCallback ?? null}
 			crossOrigin={crossOrigin}
 			{...propsForPreview}
 			_remotionInternalNativeLoopPassed={false}
@@ -152,7 +152,7 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 	onAutoPlayError,
 	onError,
 	onVideoFrame,
-	onVideoFramePresented,
+	onVideoFrameCallback,
 	pauseWhenBuffering,
 	playbackRate,
 	preservePitch,
@@ -193,7 +193,7 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 			onAutoPlayError={onAutoPlayError ?? null}
 			onError={onError}
 			onVideoFrame={onVideoFrame}
-			onVideoFramePresented={onVideoFramePresented}
+			onVideoFrameCallback={onVideoFrameCallback}
 			pauseWhenBuffering={pauseWhenBuffering ?? true}
 			playbackRate={playbackRate ?? 1}
 			preservePitch={preservePitch}

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -107,6 +107,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 		toneMapped,
 		onAutoPlayError,
 		onVideoFrame,
+		onVideoFramePresented,
 		crossOrigin,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
@@ -122,6 +123,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 			showInTimeline={showInTimeline ?? true}
 			onAutoPlayError={onAutoPlayError ?? undefined}
 			onVideoFrame={onVideoFrame ?? null}
+			onVideoFramePresented={onVideoFramePresented ?? null}
 			crossOrigin={crossOrigin}
 			{...propsForPreview}
 			_remotionInternalNativeLoopPassed={false}
@@ -150,6 +152,7 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 	onAutoPlayError,
 	onError,
 	onVideoFrame,
+	onVideoFramePresented,
 	pauseWhenBuffering,
 	playbackRate,
 	preservePitch,
@@ -190,6 +193,7 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 			onAutoPlayError={onAutoPlayError ?? null}
 			onError={onError}
 			onVideoFrame={onVideoFrame}
+			onVideoFramePresented={onVideoFramePresented}
 			pauseWhenBuffering={pauseWhenBuffering ?? true}
 			playbackRate={playbackRate ?? 1}
 			preservePitch={preservePitch}

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -31,7 +31,12 @@ import {evaluateVolume} from '../volume-prop.js';
 import {warnAboutTooHighVolume} from '../volume-safeguard.js';
 import {useEmitVideoFrame} from './emit-video-frame.js';
 import {MediaPlaybackError} from './MediaPlaybackError.js';
-import type {NativeVideoProps, OnVideoFrame, RemotionVideoProps} from './props';
+import type {
+	NativeVideoProps,
+	OnVideoFrame,
+	OnVideoFramePresented,
+	RemotionVideoProps,
+} from './props';
 import {isIosSafari, useAppendVideoFragment} from './video-fragment.js';
 
 type VideoForPreviewProps = RemotionVideoProps & {
@@ -42,6 +47,7 @@ type VideoForPreviewProps = RemotionVideoProps & {
 	readonly _remotionInternalStack: string | null;
 	readonly showInTimeline: boolean;
 	readonly onVideoFrame: null | OnVideoFrame;
+	readonly onVideoFramePresented: null | OnVideoFramePresented;
 	readonly crossOrigin?: '' | 'anonymous' | 'use-credentials';
 };
 
@@ -114,6 +120,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		onError,
 		onAutoPlayError,
 		onVideoFrame,
+		onVideoFramePresented,
 		crossOrigin,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
@@ -297,7 +304,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		useRef<VideoForPreviewProps['onDuration']>(onDuration);
 	currentOnDurationCallback.current = onDuration;
 
-	useEmitVideoFrame({ref: videoRef, onVideoFrame});
+	useEmitVideoFrame({ref: videoRef, onVideoFrame, onVideoFramePresented});
 
 	useEffect(() => {
 		const {current} = videoRef;

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -34,7 +34,7 @@ import {MediaPlaybackError} from './MediaPlaybackError.js';
 import type {
 	NativeVideoProps,
 	OnVideoFrame,
-	OnVideoFramePresented,
+	OnVideoFrameCallback,
 	RemotionVideoProps,
 } from './props';
 import {isIosSafari, useAppendVideoFragment} from './video-fragment.js';
@@ -47,7 +47,7 @@ type VideoForPreviewProps = RemotionVideoProps & {
 	readonly _remotionInternalStack: string | null;
 	readonly showInTimeline: boolean;
 	readonly onVideoFrame: null | OnVideoFrame;
-	readonly onVideoFramePresented: null | OnVideoFramePresented;
+	readonly onVideoFrameCallback: null | OnVideoFrameCallback;
 	readonly crossOrigin?: '' | 'anonymous' | 'use-credentials';
 };
 
@@ -120,7 +120,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		onError,
 		onAutoPlayError,
 		onVideoFrame,
-		onVideoFramePresented,
+		onVideoFrameCallback,
 		crossOrigin,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
@@ -304,7 +304,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		useRef<VideoForPreviewProps['onDuration']>(onDuration);
 	currentOnDurationCallback.current = onDuration;
 
-	useEmitVideoFrame({ref: videoRef, onVideoFrame, onVideoFramePresented});
+	useEmitVideoFrame({ref: videoRef, onVideoFrame, onVideoFrameCallback});
 
 	useEffect(() => {
 		const {current} = videoRef;

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -356,7 +356,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	const crossOriginValue = getCrossOriginValue({
 		crossOrigin,
-		requestsVideoFrame: Boolean(onVideoFrame),
+		requestsVideoFrame: Boolean(onVideoFrame || onVideoFrameCallback),
 		isClientSideRendering: false,
 	});
 

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -1,12 +1,12 @@
 import React, {
 	forwardRef,
+	useCallback,
 	useContext,
 	useEffect,
 	useImperativeHandle,
 	useMemo,
 	useRef,
 	useState,
-	useCallback,
 } from 'react';
 import type {IsExact} from '../audio/props.js';
 import {SharedAudioContext} from '../audio/shared-audio-tags.js';
@@ -39,7 +39,7 @@ import type {
 } from './props';
 import {isIosSafari, useAppendVideoFragment} from './video-fragment.js';
 
-type VideoForPreviewProps = RemotionVideoProps & {
+type VideoForPreviewProps = Omit<RemotionVideoProps, 'onVideoFrameCallback'> & {
 	readonly onlyWarnForMediaSeekingError: boolean;
 	readonly onDuration: (src: string, durationInSeconds: number) => void;
 	readonly pauseWhenBuffering: boolean;

--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -25,14 +25,23 @@ import {useRemotionEnvironment} from '../use-remotion-environment.js';
 import {useUnsafeVideoConfig} from '../use-unsafe-video-config.js';
 import {evaluateVolume} from '../volume-prop.js';
 import {warnAboutTooHighVolume} from '../volume-safeguard.js';
+import {useEmitVideoFrame} from './emit-video-frame.js';
 import {getMediaTime} from './get-current-time.js';
 import {MediaPlaybackError} from './MediaPlaybackError.js';
-import type {OnVideoFrame, RemotionVideoProps} from './props';
+import type {
+	OnVideoFrame,
+	OnVideoFrameCallback,
+	RemotionVideoProps,
+} from './props';
 import {seekToTimeMultipleUntilRight} from './seek-until-right.js';
 
-type VideoForRenderingProps = RemotionVideoProps & {
+type VideoForRenderingProps = Omit<
+	RemotionVideoProps,
+	'onVideoFrameCallback'
+> & {
 	readonly onDuration: (src: string, durationInSeconds: number) => void;
 	readonly onVideoFrame: null | OnVideoFrame;
+	readonly onVideoFrameCallback: null | OnVideoFrameCallback;
 };
 
 const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
@@ -53,6 +62,7 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 		loopVolumeCurveBehavior,
 		audioStreamIndex,
 		onVideoFrame,
+		onVideoFrameCallback,
 		preservePitch: _preservePitch,
 		...props
 	},
@@ -155,6 +165,8 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 	useImperativeHandle(ref, () => {
 		return videoRef.current as HTMLVideoElement;
 	}, []);
+
+	useEmitVideoFrame({ref: videoRef, onVideoFrame, onVideoFrameCallback});
 
 	useEffect(() => {
 		if (!window.remotion_videoEnabled) {

--- a/packages/core/src/video/emit-video-frame.ts
+++ b/packages/core/src/video/emit-video-frame.ts
@@ -1,12 +1,14 @@
 import {useEffect} from 'react';
-import type {OnVideoFrame} from './props';
+import type {OnVideoFrame, OnVideoFramePresented} from './props';
 
 export const useEmitVideoFrame = ({
 	ref,
 	onVideoFrame,
+	onVideoFramePresented,
 }: {
 	ref: React.RefObject<HTMLVideoElement | null>;
 	onVideoFrame: OnVideoFrame | null;
+	onVideoFramePresented: OnVideoFramePresented | null;
 }) => {
 	useEffect(() => {
 		const {current} = ref;
@@ -14,24 +16,32 @@ export const useEmitVideoFrame = ({
 			return;
 		}
 
-		if (!onVideoFrame) {
+		if (!onVideoFrame && !onVideoFramePresented) {
 			return;
 		}
 
 		let handle = 0;
-		const callback = () => {
+		const callback: VideoFrameRequestCallback = (_now, metadata) => {
 			if (!ref.current) {
 				return;
 			}
 
-			onVideoFrame(ref.current);
+			onVideoFrame?.(ref.current);
+			onVideoFramePresented?.(ref.current, metadata);
 			handle = ref.current.requestVideoFrameCallback(callback);
 		};
 
-		callback();
+		onVideoFrame?.(current);
+		if (!current.requestVideoFrameCallback) {
+			return;
+		}
+
+		handle = current.requestVideoFrameCallback(callback);
 
 		return () => {
-			current.cancelVideoFrameCallback(handle);
+			if (handle) {
+				current.cancelVideoFrameCallback(handle);
+			}
 		};
-	}, [onVideoFrame, ref]);
+	}, [onVideoFrame, onVideoFramePresented, ref]);
 };

--- a/packages/core/src/video/emit-video-frame.ts
+++ b/packages/core/src/video/emit-video-frame.ts
@@ -1,14 +1,14 @@
 import {useEffect} from 'react';
-import type {OnVideoFrame, OnVideoFramePresented} from './props';
+import type {OnVideoFrame, OnVideoFrameCallback} from './props';
 
 export const useEmitVideoFrame = ({
 	ref,
 	onVideoFrame,
-	onVideoFramePresented,
+	onVideoFrameCallback,
 }: {
 	ref: React.RefObject<HTMLVideoElement | null>;
 	onVideoFrame: OnVideoFrame | null;
-	onVideoFramePresented: OnVideoFramePresented | null;
+	onVideoFrameCallback: OnVideoFrameCallback | null;
 }) => {
 	useEffect(() => {
 		const {current} = ref;
@@ -16,7 +16,7 @@ export const useEmitVideoFrame = ({
 			return;
 		}
 
-		if (!onVideoFrame && !onVideoFramePresented) {
+		if (!onVideoFrame && !onVideoFrameCallback) {
 			return;
 		}
 
@@ -27,7 +27,7 @@ export const useEmitVideoFrame = ({
 			}
 
 			onVideoFrame?.(ref.current);
-			onVideoFramePresented?.(_now, metadata);
+			onVideoFrameCallback?.(_now, metadata);
 			handle = ref.current.requestVideoFrameCallback(callback);
 		};
 
@@ -43,5 +43,5 @@ export const useEmitVideoFrame = ({
 				current.cancelVideoFrameCallback(handle);
 			}
 		};
-	}, [onVideoFrame, onVideoFramePresented, ref]);
+	}, [onVideoFrame, onVideoFrameCallback, ref]);
 };

--- a/packages/core/src/video/emit-video-frame.ts
+++ b/packages/core/src/video/emit-video-frame.ts
@@ -27,7 +27,7 @@ export const useEmitVideoFrame = ({
 			}
 
 			onVideoFrame?.(ref.current);
-			onVideoFramePresented?.(ref.current, metadata);
+			onVideoFramePresented?.(_now, metadata);
 			handle = ref.current.requestVideoFrameCallback(callback);
 		};
 

--- a/packages/core/src/video/html5-video.tsx
+++ b/packages/core/src/video/html5-video.tsx
@@ -176,6 +176,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			{...otherProps}
 			ref={ref}
 			onVideoFrame={null}
+			onVideoFramePresented={null}
 			// Proposal: Make this default to true in v5
 			pauseWhenBuffering={pauseWhenBuffering ?? false}
 			onDuration={onDuration}

--- a/packages/core/src/video/html5-video.tsx
+++ b/packages/core/src/video/html5-video.tsx
@@ -176,7 +176,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			{...otherProps}
 			ref={ref}
 			onVideoFrame={null}
-			onVideoFramePresented={null}
+			onVideoFrameCallback={null}
 			// Proposal: Make this default to true in v5
 			pauseWhenBuffering={pauseWhenBuffering ?? false}
 			onDuration={onDuration}

--- a/packages/core/src/video/html5-video.tsx
+++ b/packages/core/src/video/html5-video.tsx
@@ -39,6 +39,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 		_remotionInternalNativeLoopPassed,
 		showInTimeline,
 		onAutoPlayError,
+		onVideoFrameCallback,
 		...otherProps
 	} = props;
 	const {loop, ...propsOtherThanLoop} = props;
@@ -142,6 +143,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			>
 				<Html5Video
 					pauseWhenBuffering={pauseWhenBuffering ?? false}
+					onVideoFrameCallback={onVideoFrameCallback}
 					{...otherProps}
 					ref={ref}
 					stack={stack}
@@ -164,6 +166,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			<VideoForRendering
 				onDuration={onDuration}
 				onVideoFrame={onVideoFrame ?? null}
+				onVideoFrameCallback={onVideoFrameCallback ?? null}
 				{...otherProps}
 				ref={ref}
 			/>
@@ -176,7 +179,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			{...otherProps}
 			ref={ref}
 			onVideoFrame={null}
-			onVideoFrameCallback={null}
+			onVideoFrameCallback={onVideoFrameCallback ?? null}
 			// Proposal: Make this default to true in v5
 			pauseWhenBuffering={pauseWhenBuffering ?? false}
 			onDuration={onDuration}

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -97,6 +97,7 @@ type OptionalOffthreadVideoProps = {
 	showInTimeline: boolean;
 	onAutoPlayError: null | (() => void);
 	onVideoFrame: OnVideoFrame | undefined;
+	onVideoFramePresented: OnVideoFramePresented | undefined;
 	crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined;
 	audioStreamIndex: number;
 };
@@ -111,3 +112,7 @@ export type RemotionOffthreadVideoProps = MandatoryOffthreadVideoProps &
 	Partial<DeprecatedOffthreadVideoProps>;
 
 export type OnVideoFrame = (frame: CanvasImageSource) => void;
+export type OnVideoFramePresented = (
+	frame: HTMLVideoElement,
+	metadata: VideoFrameCallbackMetadata,
+) => void;

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -56,6 +56,7 @@ export type RemotionVideoProps = NativeVideoProps & {
 	delayRenderRetries?: number;
 	onError?: (err: Error) => void;
 	onAutoPlayError?: null | (() => void);
+	onVideoFrameCallback?: OnVideoFrameCallback;
 	audioStreamIndex?: number;
 };
 

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -113,6 +113,6 @@ export type RemotionOffthreadVideoProps = MandatoryOffthreadVideoProps &
 
 export type OnVideoFrame = (frame: CanvasImageSource) => void;
 export type OnVideoFramePresented = (
-	frame: HTMLVideoElement,
+	now: DOMHighResTimeStamp,
 	metadata: VideoFrameCallbackMetadata,
 ) => void;

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -97,7 +97,7 @@ type OptionalOffthreadVideoProps = {
 	showInTimeline: boolean;
 	onAutoPlayError: null | (() => void);
 	onVideoFrame: OnVideoFrame | undefined;
-	onVideoFramePresented: OnVideoFramePresented | undefined;
+	onVideoFrameCallback: OnVideoFrameCallback | undefined;
 	crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined;
 	audioStreamIndex: number;
 };
@@ -112,7 +112,7 @@ export type RemotionOffthreadVideoProps = MandatoryOffthreadVideoProps &
 	Partial<DeprecatedOffthreadVideoProps>;
 
 export type OnVideoFrame = (frame: CanvasImageSource) => void;
-export type OnVideoFramePresented = (
+export type OnVideoFrameCallback = (
 	now: DOMHighResTimeStamp,
 	metadata: VideoFrameCallbackMetadata,
 ) => void;

--- a/packages/docs/docs/html5-video.mdx
+++ b/packages/docs/docs/html5-video.mdx
@@ -293,46 +293,10 @@ If you don't pass a callback, the video will be muted and be retried once.
 This prop is useful if you want to handle the error yourself, e.g. for pausing the Player.  
 Read more here about [autoplay restrictions](/docs/player/autoplay).
 
-### `requestVideoFrameCallback()`
+### `onVideoFrameCallback?`<AvailableFrom v="4.0.472" />
 
-`<Html5Video>` exposes a native [`HTMLVideoElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement) through its ref. To receive presented-frame callbacks, use the browser's [`requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback) API on the element.
-
-The `onVideoFrameCallback` prop is only available on [`<OffthreadVideo>`](/docs/offthreadvideo#onvideoframecallback).
-
-```tsx twoslash title="MyComposition.tsx"
-import {AbsoluteFill, Html5Video, staticFile} from 'remotion';
-import {useEffect, useRef} from 'react';
-
-// ---cut---
-export const MyComposition = () => {
-  const ref = useRef<HTMLVideoElement>(null);
-
-  useEffect(() => {
-    const video = ref.current;
-
-    if (!video?.requestVideoFrameCallback) {
-      return;
-    }
-
-    let handle: number;
-
-    const callback = (now: DOMHighResTimeStamp, metadata: VideoFrameCallbackMetadata) => {
-      console.log(now, metadata);
-      handle = video.requestVideoFrameCallback(callback);
-    };
-
-    handle = video.requestVideoFrameCallback(callback);
-
-    return () => video.cancelVideoFrameCallback(handle);
-  }, []);
-
-  return (
-    <AbsoluteFill>
-      <Html5Video ref={ref} src={staticFile('video.webm')} />
-    </AbsoluteFill>
-  );
-};
-```
+A callback function that gets called when the browser reports a presented video frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback).
+The callback has the same signature as `requestVideoFrameCallback()`: It receives a `DOMHighResTimeStamp` and the [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata).
 
 ### `crossOrigin?`<AvailableFrom v="4.0.190" />
 

--- a/packages/docs/docs/html5-video.mdx
+++ b/packages/docs/docs/html5-video.mdx
@@ -293,6 +293,47 @@ If you don't pass a callback, the video will be muted and be retried once.
 This prop is useful if you want to handle the error yourself, e.g. for pausing the Player.  
 Read more here about [autoplay restrictions](/docs/player/autoplay).
 
+### `requestVideoFrameCallback()`
+
+`<Html5Video>` exposes a native [`HTMLVideoElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement) through its ref. To receive presented-frame callbacks, use the browser's [`requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback) API on the element.
+
+The `onVideoFrameCallback` prop is only available on [`<OffthreadVideo>`](/docs/offthreadvideo#onvideoframecallback).
+
+```tsx twoslash title="MyComposition.tsx"
+import {AbsoluteFill, Html5Video, staticFile} from 'remotion';
+import {useEffect, useRef} from 'react';
+
+// ---cut---
+export const MyComposition = () => {
+  const ref = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = ref.current;
+
+    if (!video?.requestVideoFrameCallback) {
+      return;
+    }
+
+    let handle: number;
+
+    const callback = (now: DOMHighResTimeStamp, metadata: VideoFrameCallbackMetadata) => {
+      console.log(now, metadata);
+      handle = video.requestVideoFrameCallback(callback);
+    };
+
+    handle = video.requestVideoFrameCallback(callback);
+
+    return () => video.cancelVideoFrameCallback(handle);
+  }, []);
+
+  return (
+    <AbsoluteFill>
+      <Html5Video ref={ref} src={staticFile('video.webm')} />
+    </AbsoluteFill>
+  );
+};
+```
+
 ### `crossOrigin?`<AvailableFrom v="4.0.190" />
 
 Corresponds to the [`crossOrigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-crossorigin) attribute of the `<video>` element.  

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -455,6 +455,11 @@ Maps to [`<OffthreadVideo />` -> `onAutoPlayError`](/docs/offthreadvideo#onautop
 Maps to [`<OffthreadVideo />` -> `preservePitch`](/docs/offthreadvideo#preservepitch).  
 Only affects preview playback when falling back to [`<Html5Video>`](/docs/html5-video) or [`<OffthreadVideo>`](/docs/offthreadvideo).
 
+#### `onVideoFrameCallback?`<AvailableFrom v="4.0.472" />
+
+Maps to [`<OffthreadVideo />` -> `onVideoFrameCallback`](/docs/offthreadvideo#onvideoframecallback).
+Only affects preview playback when falling back to [`<OffthreadVideo>`](/docs/offthreadvideo).
+
 ### `disallowFallbackToOffthreadVideo?`
 
 By default, if the video cannot be embedded using this tag, [a fallback to `<OffthreadVideo>`](/docs/media/fallback) will be attempted.

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -297,7 +297,7 @@ During preview, this is a `HTMLVideoElement` object, during rendering, it is an 
 ### `onVideoFramePresented?`
 
 A callback function that gets called during preview when the browser reports a presented video frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback).  
-The callback receives the `HTMLVideoElement` and the [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata).
+The callback has the same signature as `requestVideoFrameCallback()`: It receives a `DOMHighResTimeStamp` and the [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata).
 
 This callback only fires during preview, since rendering uses image extraction instead of a browser video element.
 

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -294,7 +294,7 @@ Useful for [video manipulation](/docs/video-manipulation).
 The callback is called with a [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource) object.  
 During preview, this is a `HTMLVideoElement` object, during rendering, it is an `HTMLImageElement`.
 
-### `onVideoFrameCallback?`
+### `onVideoFrameCallback?`<AvailableFrom v="4.0.470" />
 
 A callback function that gets called during preview when the browser reports a presented video frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback).  
 The callback has the same signature as `requestVideoFrameCallback()`: It receives a `DOMHighResTimeStamp` and the [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata).

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -294,7 +294,7 @@ Useful for [video manipulation](/docs/video-manipulation).
 The callback is called with a [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource) object.  
 During preview, this is a `HTMLVideoElement` object, during rendering, it is an `HTMLImageElement`.
 
-### `onVideoFramePresented?`
+### `onVideoFrameCallback?`
 
 A callback function that gets called during preview when the browser reports a presented video frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback).  
 The callback has the same signature as `requestVideoFrameCallback()`: It receives a `DOMHighResTimeStamp` and the [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata).

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -294,7 +294,7 @@ Useful for [video manipulation](/docs/video-manipulation).
 The callback is called with a [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource) object.  
 During preview, this is a `HTMLVideoElement` object, during rendering, it is an `HTMLImageElement`.
 
-### `onVideoFrameCallback?`<AvailableFrom v="4.0.470" />
+### `onVideoFrameCallback?`<AvailableFrom v="4.0.472" />
 
 A callback function that gets called during preview when the browser reports a presented video frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback).  
 The callback has the same signature as `requestVideoFrameCallback()`: It receives a `DOMHighResTimeStamp` and the [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata).

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -294,6 +294,13 @@ Useful for [video manipulation](/docs/video-manipulation).
 The callback is called with a [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource) object.  
 During preview, this is a `HTMLVideoElement` object, during rendering, it is an `HTMLImageElement`.
 
+### `onVideoFramePresented?`
+
+A callback function that gets called during preview when the browser reports a presented video frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback).  
+The callback receives the `HTMLVideoElement` and the [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata).
+
+This callback only fires during preview, since rendering uses image extraction instead of a browser video element.
+
 ### `crossOrigin?`<AvailableFrom v="4.0.190" />
 
 Corresponds to the [`crossOrigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-crossorigin) attribute of the `<video>` element.  

--- a/packages/media/src/video/props.ts
+++ b/packages/media/src/video/props.ts
@@ -4,6 +4,7 @@ import type {
 	LogLevel,
 	LoopVolumeCurveBehavior,
 	OnVideoFrame,
+	OnVideoFrameCallback,
 	SequenceProps,
 	VolumeProp,
 } from 'remotion';
@@ -31,6 +32,7 @@ export type FallbackOffthreadVideoProps = {
 	pauseWhenBuffering?: boolean;
 	onAutoPlayError?: null | (() => void);
 	preservePitch?: boolean;
+	onVideoFrameCallback?: OnVideoFrameCallback;
 };
 
 type MandatoryVideoProps = {

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -460,6 +460,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 				audioStreamIndex={audioStreamIndex ?? 0}
 				className={className}
 				onVideoFrame={onVideoFrame}
+				onVideoFrameCallback={fallbackOffthreadVideoProps?.onVideoFrameCallback}
 				volume={volumeProp}
 				id={id}
 				onError={fallbackOffthreadVideoProps?.onError}


### PR DESCRIPTION
## Summary
- Adds an `onVideoFrameCallback` prop to `<OffthreadVideo>` that mirrors `HTMLVideoElement.requestVideoFrameCallback()` during preview.
- Threads the callback through the preview video path and exports the new `OnVideoFrameCallback` type.
- Documents the callback and allows `@remotion/media` fallback OffthreadVideo props to pass it through.

## Test plan
- `bun run format`
- `bunx tsc -p packages/core/tsconfig.json --noEmit`


Made with [Cursor](https://cursor.com)