### PR TITLE
Fix : Await browser and page close to prevent defunct Chrome processes

### DIFF
--- a/packages/renderer/src/assets/download-and-map-assets-to-file.ts
+++ b/packages/renderer/src/assets/download-and-map-assets-to-file.ts
@@ -445,8 +445,8 @@ export const attachDownloadListenerToEmitter = (
 		return Promise.resolve();
 	});
 
-	return () => {
-		cleanup.forEach((c) => c());
+	return async () => {
+		await Promise.all(cleanup.map((c) => c()));
 	};
 };
 

--- a/packages/renderer/src/get-browser-instance.ts
+++ b/packages/renderer/src/get-browser-instance.ts
@@ -50,9 +50,7 @@ export const getPageAndCleanupFn = async ({
 		return {
 			page,
 			cleanupPage: () => {
-				// Close puppeteer page and don't wait for it to finish.
-				// Keep browser open.
-				page.close().catch((err) => {
+				return page.close().catch((err) => {
 					if (!(err as Error).message.includes('Target closed')) {
 						Log.error(
 							{indent, logLevel},
@@ -61,7 +59,6 @@ export const getPageAndCleanupFn = async ({
 						);
 					}
 				});
-				return Promise.resolve();
 			},
 		};
 	}
@@ -89,8 +86,7 @@ export const getPageAndCleanupFn = async ({
 	return {
 		page: browserPage,
 		cleanupPage: () => {
-			// Close whole browser that was just created and don't wait for it to finish.
-			browserInstance.close({silent: true}).catch((err) => {
+			return browserInstance.close({silent: true}).catch((err) => {
 				if (!(err as Error).message.includes('Target closed')) {
 					Log.error(
 						{indent, logLevel},
@@ -99,7 +95,6 @@ export const getPageAndCleanupFn = async ({
 					);
 				}
 			});
-			return Promise.resolve();
 		},
 	};
 };

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -264,10 +264,16 @@ const internalGetCompositionsRaw = async ({
 			.catch((err) => {
 				reject(err);
 			})
-			.finally(() => {
-				cleanup.forEach((c) => {
-					c();
-				});
+			.finally(async () => {
+				await Promise.all(
+					cleanup.map(async (c) => {
+						try {
+							await c();
+						} catch (err) {
+							Log.error({indent, logLevel}, 'Cleanup error:', err);
+						}
+					}),
+				);
 			});
 	});
 };

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -10,6 +10,7 @@ import {defaultOnLog} from './default-on-log';
 import {handleJavascriptException} from './error-handling/handle-javascript-exception';
 import {findRemotionRoot} from './find-closest-package-json';
 import {getPageAndCleanupFn} from './get-browser-instance';
+import {Log} from './logger';
 import {getAvailableMemory} from './memory/get-available-memory';
 import type {ChromiumOptions} from './open-browser';
 import {DEFAULT_RENDER_FRAMES_OFFTHREAD_VIDEO_THREADS} from './options/offthreadvideo-threads';

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -651,21 +651,29 @@ const internalRenderFramesRaw = ({
 				return resolve(res);
 			})
 			.catch((err) => reject(err))
-			.finally(() => {
+			.finally(async () => {
 				// If browser instance was passed in, we close all the pages
 				// we opened.
 				// If new browser was opened, then closing the browser as a cleanup.
 
 				if (puppeteerInstance) {
-					Promise.all(openedPages.map((p) => p.close())).catch((err) => {
-						if (isTargetClosedErr(err)) {
-							return;
-						}
+					await Promise.all(
+						openedPages.map((p) =>
+							p.close().catch((err) => {
+								if (isTargetClosedErr(err)) {
+									return;
+								}
 
-						Log.error({indent, logLevel}, 'Unable to close browser tab', err);
-					});
+								Log.error(
+									{indent, logLevel},
+									'Unable to close browser tab',
+									err,
+								);
+							}),
+						),
+					);
 				} else {
-					Promise.resolve(browserInstance)
+					await Promise.resolve(browserInstance)
 						.then((instance) => {
 							return instance.close({silent: true});
 						})
@@ -678,9 +686,15 @@ const internalRenderFramesRaw = ({
 						});
 				}
 
-				cleanup.forEach((c) => {
-					c();
-				});
+				await Promise.all(
+					cleanup.map(async (c) => {
+						try {
+							await c();
+						} catch (err) {
+							Log.error({indent, logLevel}, 'Cleanup error:', err);
+						}
+					}),
+				);
 				// Don't clear download dir because it might be used by stitchFramesToVideo
 			});
 	});

--- a/packages/renderer/src/render-still.ts
+++ b/packages/renderer/src/render-still.ts
@@ -461,12 +461,16 @@ const internalRenderStillRaw = (
 					});
 			})
 			.catch((err) => reject(err))
-			.finally(() => {
-				cleanup.forEach((c) => {
-					c().catch((err) => {
-						Log.error(options, 'Cleanup error:', err);
-					});
-				});
+			.finally(async () => {
+				await Promise.all(
+					cleanup.map(async (c) => {
+						try {
+							await c();
+						} catch (err) {
+							Log.error(options, 'Cleanup error:', err);
+						}
+					}),
+				);
 			});
 	});
 

--- a/packages/renderer/src/select-composition.ts
+++ b/packages/renderer/src/select-composition.ts
@@ -302,14 +302,16 @@ export const internalSelectCompositionRaw = async (
 			.catch((err) => {
 				reject(err);
 			})
-			.finally(() => {
-				cleanup.forEach((c) => {
-					// Must prevent unhandled exception in cleanup function.
-					// Promise has already been resolved, so we can't reject it.
-					c().catch((err) => {
-						Log.error({indent, logLevel}, 'Cleanup error:', err);
-					});
-				});
+			.finally(async () => {
+				await Promise.all(
+					cleanup.map(async (c) => {
+						try {
+							await c();
+						} catch (err) {
+							Log.error({indent, logLevel}, 'Cleanup error:', err);
+						}
+					}),
+				);
 			});
 	});
 };

--- a/packages/renderer/src/test/get-browser-instance.test.ts
+++ b/packages/renderer/src/test/get-browser-instance.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, test} from 'bun:test';
+import {getPageAndCleanupFn} from '../get-browser-instance';
+
+describe('getPageAndCleanupFn', () => {
+	test('awaits page.close when cleanup is invoked for a passed-in browser', async () => {
+		let pageClosed = false;
+		const fakePage = {
+			close: async () => {
+				pageClosed = true;
+			},
+		};
+
+		const fakeBrowser = {
+			newPage: async () => fakePage,
+		};
+
+		const {cleanupPage} = await getPageAndCleanupFn({
+			passedInInstance: fakeBrowser as any,
+			browserExecutable: null,
+			chromiumOptions: {},
+			forceDeviceScaleFactor: undefined,
+			indent: false,
+			logLevel: 'info',
+			onBrowserDownload: (() => undefined) as any,
+			chromeMode: 'headless-shell',
+			pageIndex: 0,
+			onBrowserLog: null,
+			onLog: () => undefined,
+		});
+
+		await cleanupPage();
+		expect(pageClosed).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Await browser and page closure during renderer cleanup so `renderFrames()` / other browser-driven renderer flows do not resolve before Chrome is fully terminated. This fixes the Ubuntu `chrome-headless` defunct process issue.

## What changed

- Updated `packages/renderer/src/get-browser-instance.ts` to return cleanup functions that await `page.close()` / `browserInstance.close()`
- Updated renderer cleanup finalizers in:
  - `packages/renderer/src/render-frames.ts`
  - `packages/renderer/src/get-compositions.ts`
  - `packages/renderer/src/render-still.ts`
  - `packages/renderer/src/select-composition.ts`
- Updated download cleanup in `packages/renderer/src/assets/download-and-map-assets-to-file.ts` to await cleanup callbacks

## Tests

- `npm exec -- bun test .\src\test\get-browser-instance.test.ts`
- `npm exec -- bun test .\src\test\get-browser-instance.test.ts .\src\test\wrap-with-setpriv.test.ts`

## Tradeoffs

- Cleanup now waits for browser teardown, which may slightly increase teardown time but prevents orphaned Chrome processes and improves stability.
- No user-facing API changes.

## Issue

- Fixes: #7065 