### PR TITLE
`@remotion/studio`: Extend timeline unselection area

### DIFF
--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useMemo} from 'react';
+import React, {useCallback, useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {calculateTimeline} from '../../helpers/calculate-timeline';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
@@ -22,7 +22,10 @@ import {TimelineList} from './TimelineList';
 import {TimelinePinchZoom} from './TimelinePinchZoom';
 import {TimelinePlayCursorSyncer} from './TimelinePlayCursorSyncer';
 import {TimelineScrollable} from './TimelineScrollable';
-import {TimelineSelectionProvider} from './TimelineSelection';
+import {
+	TimelineSelectionProvider,
+	useTimelineSelection,
+} from './TimelineSelection';
 import {TimelineSlider} from './TimelineSlider';
 import {
 	TimelineTimeIndicators,
@@ -41,6 +44,37 @@ const container: React.CSSProperties = {
 };
 
 const noop = () => undefined;
+
+const TimelineClearSelectionArea: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	const {clearSelection} = useTimelineSelection();
+
+	// Selection-triggering click handlers in children call e.stopPropagation(),
+	// so any pointerdown that bubbles up here is by definition on empty space
+	// and should clear the current selection.
+	const onPointerDown = useCallback(
+		(e: React.PointerEvent<HTMLDivElement>) => {
+			if (e.button !== 0) {
+				return;
+			}
+
+			clearSelection();
+		},
+		[clearSelection],
+	);
+
+	return (
+		<div
+			ref={timelineVerticalScroll}
+			style={container}
+			className={'css-reset ' + VERTICAL_SCROLLBAR_CLASSNAME}
+			onPointerDown={onPointerDown}
+		>
+			{children}
+		</div>
+	);
+};
 
 const TimelineInner: React.FC = () => {
 	const {sequences} = useContext(Internals.SequenceManager);
@@ -84,12 +118,8 @@ const TimelineInner: React.FC = () => {
 	const hasBeenCut = filtered.length > shown.length;
 
 	return (
-		<div
-			ref={timelineVerticalScroll}
-			style={container}
-			className={'css-reset ' + VERTICAL_SCROLLBAR_CLASSNAME}
-		>
-			<TimelineSelectionProvider timeline={shown}>
+		<TimelineSelectionProvider timeline={shown}>
+			<TimelineClearSelectionArea>
 				{sequences.map((sequence) => {
 					if (!sequence.controls || !previewConnected || !sequence.getStack()) {
 						return null;
@@ -141,8 +171,8 @@ const TimelineInner: React.FC = () => {
 						</TimelineWidthProvider>
 					)}
 				</TimelineHeightContainer>
-			</TimelineSelectionProvider>
-		</div>
+			</TimelineClearSelectionArea>
+		</TimelineSelectionProvider>
 	);
 };
 

--- a/packages/studio/src/components/Timeline/TimelineList.tsx
+++ b/packages/studio/src/components/Timeline/TimelineList.tsx
@@ -1,8 +1,7 @@
-import React, {useCallback} from 'react';
+import React from 'react';
 import {BACKGROUND} from '../../helpers/colors';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
 import {TimelineListItem} from './TimelineListItem';
-import {useTimelineSelection} from './TimelineSelection';
 import {TimelineTimePadding} from './TimelineTimeIndicators';
 
 const container: React.CSSProperties = {
@@ -13,24 +12,8 @@ const container: React.CSSProperties = {
 export const TimelineList: React.FC<{
 	readonly timeline: TrackWithHash[];
 }> = ({timeline}) => {
-	const {clearSelection} = useTimelineSelection();
-
-	// Selection-triggering click handlers in children call e.stopPropagation(),
-	// so any pointerdown that bubbles up here is by definition on empty space
-	// and should clear the current selection.
-	const onPointerDown = useCallback(
-		(e: React.PointerEvent<HTMLDivElement>) => {
-			if (e.button !== 0) {
-				return;
-			}
-
-			clearSelection();
-		},
-		[clearSelection],
-	);
-
 	return (
-		<div style={container} onPointerDown={onPointerDown}>
+		<div style={container}>
 			<TimelineTimePadding />
 			{timeline.map((track) => {
 				return (

--- a/packages/studio/src/components/Timeline/TimelineScrollable.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScrollable.tsx
@@ -1,8 +1,7 @@
-import React, {useCallback, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import {TIMELINE_BACKGROUND} from '../../helpers/colors';
 import {HORIZONTAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {scrollableRef} from './timeline-refs';
-import {useTimelineSelection} from './TimelineSelection';
 
 const outer: React.CSSProperties = {
 	width: '100%',
@@ -16,22 +15,6 @@ const outer: React.CSSProperties = {
 export const TimelineScrollable: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
-	const {clearSelection} = useTimelineSelection();
-
-	// Selection-triggering click handlers in children call e.stopPropagation(),
-	// so any pointerdown that bubbles up here is by definition on empty space
-	// and should clear the current selection.
-	const onPointerDown = useCallback(
-		(e: React.PointerEvent<HTMLDivElement>) => {
-			if (e.button !== 0) {
-				return;
-			}
-
-			clearSelection();
-		},
-		[clearSelection],
-	);
-
 	const containerStyle: React.CSSProperties = useMemo(() => {
 		return {
 			width: '100%',
@@ -45,9 +28,7 @@ export const TimelineScrollable: React.FC<{
 			style={outer}
 			className={HORIZONTAL_SCROLLBAR_CLASSNAME}
 		>
-			<div style={containerStyle} onPointerDown={onPointerDown}>
-				{children}
-			</div>
+			<div style={containerStyle}>{children}</div>
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

- Move timeline selection clearing to the full timeline panel wrapper
- Remove duplicate empty-space deselection handlers from the timeline list and scrollable track area

Fixes #7826

## Testing

- bun run build
- bun run formatting
