### PR TITLE
`@remotion/studio`: Move install package menu

### DIFF
--- a/packages/studio/src/components/Menu/MenuItem.tsx
+++ b/packages/studio/src/components/Menu/MenuItem.tsx
@@ -28,7 +28,6 @@ export type MenuId =
 	| 'file'
 	| 'view'
 	| 'composition'
-	| 'install'
 	| 'tools'
 	| 'help';
 

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -761,20 +761,12 @@ export const useMenuStructure = (
 						type: 'item' as const,
 						quickSwitcherLabel: 'Open spring() Editor',
 					},
-				].filter(Internals.truthy),
-				quickSwitcherLabel: null,
-			},
-			readOnlyStudio || remotion_packageManager === 'unknown'
-				? null
-				: {
-						id: 'install' as const,
-						label: 'Packages',
-						leaveLeftPadding: false,
-						items: [
-							{
+					readOnlyStudio || remotion_packageManager === 'unknown'
+						? null
+						: {
 								id: 'install-packages',
 								value: 'install-packages',
-								label: 'Install...',
+								label: 'Install package',
 								onClick: () => {
 									closeMenu();
 									setSelectedModal({
@@ -786,10 +778,11 @@ export const useMenuStructure = (
 								keyHint: null,
 								leftItem: null,
 								subMenu: null,
-								quickSwitcherLabel: `Install packages`,
+								quickSwitcherLabel: `Install package`,
 							},
-						],
-					},
+				].filter(Internals.truthy),
+				quickSwitcherLabel: null,
+			},
 			{
 				id: 'help' as const,
 				label: 'Help',


### PR DESCRIPTION
Fixes #7831.

## Summary
- Moves the install package action from the top-level Packages menu into Tools.
- Updates the menu and quick switcher label to "Install package".

## Testing
- bun test src/test/menu-typeahead.test.ts (from packages/studio)
- bunx turbo make --filter='@remotion/studio'
- bun run build
- bun run formatting
