### PR TITLE
`@remotion/studio`: Fix timeline arrow spacer cursor

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineExpandArrowButton.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandArrowButton.tsx
@@ -19,6 +19,11 @@ const arrowButton: React.CSSProperties = {
 	lineHeight: 1,
 };
 
+const arrowSpacer: React.CSSProperties = {
+	...arrowButton,
+	cursor: 'default',
+};
+
 const svgStyle: React.CSSProperties = {display: 'block'};
 
 export const TimelineExpandArrowButton: React.FC<{
@@ -53,5 +58,5 @@ export const TimelineExpandArrowButton: React.FC<{
 };
 
 export const TimelineExpandArrowSpacer: React.FC = () => {
-	return <div style={{...arrowButton, cursor: 'default'}} />;
+	return <div style={arrowSpacer} />;
 };

--- a/packages/studio/src/components/Timeline/TimelineExpandArrowButton.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandArrowButton.tsx
@@ -53,5 +53,5 @@ export const TimelineExpandArrowButton: React.FC<{
 };
 
 export const TimelineExpandArrowSpacer: React.FC = () => {
-	return <div style={arrowButton} />;
+	return <div style={{...arrowButton, cursor: 'default'}} />;
 };


### PR DESCRIPTION
Fixes the timeline expand arrow spacer so empty placeholder areas do not show a pointer cursor.

Closes #7834.
