### PR TITLE
`@remotion/studio`: Prevent TimeValue from unselecting item

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -16,7 +16,7 @@ import {
 import type {RemInputStatus} from './RemInput';
 import {RemotionInput, inputBaseStyle} from './RemInput';
 
-type Props = InputHTMLAttributes<HTMLInputElement> & {
+type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'onPointerDown'> & {
 	readonly onValueChange: (newVal: number) => void;
 	readonly onValueChangeEnd?: (newVal: number) => void;
 	readonly onTextChange: (newVal: string) => void;
@@ -24,6 +24,7 @@ type Props = InputHTMLAttributes<HTMLInputElement> & {
 	readonly formatter?: (str: number | string) => string;
 	readonly rightAlign: boolean;
 	readonly small?: boolean;
+	readonly onPointerDown?: PointerEventHandler<HTMLButtonElement>;
 };
 
 const isInt = (num: number) => {
@@ -46,6 +47,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 		status,
 		rightAlign,
 		small,
+		onPointerDown: onPointerDownProp,
 		...props
 	},
 	ref,
@@ -144,8 +146,9 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 		return Math.ceil(val * factor) / factor;
 	};
 
-	const onPointerDown: PointerEventHandler = useCallback(
+	const onPointerDown: PointerEventHandler<HTMLButtonElement> = useCallback(
 		(e) => {
+			onPointerDownProp?.(e);
 			pointerDownRef.current = true;
 			const target = e.currentTarget as HTMLButtonElement;
 			const {pageX, pageY, button} = e;
@@ -203,7 +206,15 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 				},
 			);
 		},
-		[_step, _min, _max, value, onValueChange, onValueChangeEnd],
+		[
+			_step,
+			_min,
+			_max,
+			value,
+			onValueChange,
+			onValueChangeEnd,
+			onPointerDownProp,
+		],
 	);
 
 	useEffect(() => {

--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -16,7 +16,7 @@ import {
 import type {RemInputStatus} from './RemInput';
 import {RemotionInput, inputBaseStyle} from './RemInput';
 
-type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'onPointerDown'> & {
+type Props = InputHTMLAttributes<HTMLInputElement> & {
 	readonly onValueChange: (newVal: number) => void;
 	readonly onValueChangeEnd?: (newVal: number) => void;
 	readonly onTextChange: (newVal: string) => void;
@@ -24,7 +24,6 @@ type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'onPointerDown'> & {
 	readonly formatter?: (str: number | string) => string;
 	readonly rightAlign: boolean;
 	readonly small?: boolean;
-	readonly onPointerDown?: PointerEventHandler<HTMLButtonElement>;
 };
 
 const isInt = (num: number) => {
@@ -47,7 +46,6 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 		status,
 		rightAlign,
 		small,
-		onPointerDown: onPointerDownProp,
 		...props
 	},
 	ref,
@@ -148,7 +146,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 
 	const onPointerDown: PointerEventHandler<HTMLButtonElement> = useCallback(
 		(e) => {
-			onPointerDownProp?.(e);
+			e.stopPropagation();
 			pointerDownRef.current = true;
 			const target = e.currentTarget as HTMLButtonElement;
 			const {pageX, pageY, button} = e;
@@ -206,15 +204,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 				},
 			);
 		},
-		[
-			_step,
-			_min,
-			_max,
-			value,
-			onValueChange,
-			onValueChangeEnd,
-			onPointerDownProp,
-		],
+		[_step, _min, _max, value, onValueChange, onValueChangeEnd],
 	);
 
 	useEffect(() => {

--- a/packages/studio/src/components/TimeValue.tsx
+++ b/packages/studio/src/components/TimeValue.tsx
@@ -59,13 +59,6 @@ export const TimeValue: React.FC = () => {
 		},
 		[seek],
 	);
-	const onPointerDown = useCallback(
-		(e: React.PointerEvent<HTMLButtonElement>) => {
-			e.stopPropagation();
-		},
-		[],
-	);
-
 	useImperativeHandle(
 		Internals.timeValueRef,
 		() => ({
@@ -119,7 +112,6 @@ export const TimeValue: React.FC = () => {
 				rightAlign
 				status="ok"
 				style={frameStyle}
-				onPointerDown={onPointerDown}
 			/>
 		</div>
 	);

--- a/packages/studio/src/components/TimeValue.tsx
+++ b/packages/studio/src/components/TimeValue.tsx
@@ -59,9 +59,12 @@ export const TimeValue: React.FC = () => {
 		},
 		[seek],
 	);
-	const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-		e.stopPropagation();
-	}, []);
+	const onPointerDown = useCallback(
+		(e: React.PointerEvent<HTMLButtonElement>) => {
+			e.stopPropagation();
+		},
+		[],
+	);
 
 	useImperativeHandle(
 		Internals.timeValueRef,
@@ -104,7 +107,7 @@ export const TimeValue: React.FC = () => {
 	}
 
 	return (
-		<div style={text} onPointerDown={onPointerDown}>
+		<div style={text}>
 			<div style={time}>{renderFrame(frame, config.fps)}</div>
 			<Spacing x={2} />
 			<Flex />
@@ -116,6 +119,7 @@ export const TimeValue: React.FC = () => {
 				rightAlign
 				status="ok"
 				style={frameStyle}
+				onPointerDown={onPointerDown}
 			/>
 		</div>
 	);

--- a/packages/studio/src/components/TimeValue.tsx
+++ b/packages/studio/src/components/TimeValue.tsx
@@ -59,6 +59,9 @@ export const TimeValue: React.FC = () => {
 		},
 		[seek],
 	);
+	const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+		e.stopPropagation();
+	}, []);
 
 	useImperativeHandle(
 		Internals.timeValueRef,
@@ -101,7 +104,7 @@ export const TimeValue: React.FC = () => {
 	}
 
 	return (
-		<div style={text}>
+		<div style={text} onPointerDown={onPointerDown}>
 			<div style={time}>{renderFrame(frame, config.fps)}</div>
 			<Spacing x={2} />
 			<Flex />


### PR DESCRIPTION
Fixes #7835.

- Stops pointerdown propagation from the Studio TimeValue control so clicking it does not trigger selection clearing.
- Keeps the behavior scoped to TimeValue instead of changing the reusable InputDragger globally.