### PR TITLE
`@remotion/studio`: Add keyframe navigation controls to timeline field rows

### DIFF
--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -1,6 +1,8 @@
 import type {ApiRoutes} from '@remotion/studio-shared';
 import type {ApiHandler} from './api-types';
+import {addEffectKeyframeHandler} from './routes/add-effect-keyframe';
 import {handleAddRender} from './routes/add-render';
+import {addSequenceKeyframeHandler} from './routes/add-sequence-keyframe';
 import {applyCodemodHandler} from './routes/apply-codemod';
 import {applyVisualControlHandler} from './routes/apply-visual-control-change';
 import {handleCancelRender} from './routes/cancel-render';
@@ -50,7 +52,9 @@ export const allApiRoutes: {
 	'/api/save-sequence-props': saveSequencePropsHandler,
 	'/api/save-effect-props': saveEffectPropsHandler,
 	'/api/delete-sequence-keyframe': deleteSequenceKeyframeHandler,
+	'/api/add-sequence-keyframe': addSequenceKeyframeHandler,
 	'/api/delete-effect-keyframe': deleteEffectKeyframeHandler,
+	'/api/add-effect-keyframe': addEffectKeyframeHandler,
 	'/api/delete-effect': deleteEffectHandler,
 	'/api/delete-jsx-node': deleteJsxNodeHandler,
 	'/api/duplicate-jsx-node': duplicateJsxNodeHandler,

--- a/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
@@ -1,0 +1,132 @@
+import {readFileSync} from 'node:fs';
+import {RenderInternals} from '@remotion/renderer';
+import type {
+	AddEffectKeyframeRequest,
+	AddEffectKeyframeResponse,
+} from '@remotion/studio-shared';
+import {getAllSchemaKeys} from '@remotion/studio-shared';
+import {parseAst} from '../../codemods/parse-ast';
+import {updateEffectKeyframes} from '../../codemods/update-keyframes/update-keyframes';
+import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
+import type {ApiHandler} from '../api-types';
+import {
+	printUndoHint,
+	pushToUndoStack,
+	suppressUndoStackInvalidation,
+} from '../undo-stack';
+import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
+import {computeEffectPropStatus} from './can-update-effect-props';
+import {findJsxElementAtNodePath} from './can-update-sequence-props';
+import {logEffectUpdate} from './log-updates/log-effect-update';
+import {withSavePropsLock} from './save-props-mutex';
+
+export const addEffectKeyframeHandler: ApiHandler<
+	AddEffectKeyframeRequest,
+	AddEffectKeyframeResponse
+> = ({
+	input: {
+		fileName,
+		sequenceNodePath,
+		effectIndex,
+		key,
+		frame,
+		value,
+		schema,
+		clientId,
+	},
+	remotionRoot,
+	logLevel,
+}) =>
+	withSavePropsLock(async () => {
+		RenderInternals.Log.trace(
+			{indent: false, logLevel},
+			`[add-effect-keyframe] Received request for fileName="${fileName}" effectIndex=${effectIndex} key="${key}" frame=${frame}`,
+		);
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName,
+			action: 'modify',
+		});
+
+		const fileContents = readFileSync(absolutePath, 'utf-8');
+		const parsedValue = JSON.parse(value);
+
+		const {
+			output,
+			oldValueStrings,
+			newValueStrings,
+			formatted,
+			logLine,
+			effectCallee,
+		} = await updateEffectKeyframes({
+			input: fileContents,
+			sequenceNodePath: sequenceNodePath.nodePath,
+			effectIndex,
+			updates: [
+				{
+					key,
+					operation: {
+						type: 'add',
+						frame,
+						value: parsedValue,
+					},
+				},
+			],
+		});
+
+		const oldValueString = oldValueStrings[0];
+		const newValueString = newValueStrings[0];
+
+		const undoPropChange = `${key} keyframe removed at frame ${frame}`;
+		const redoPropChange = `${key} keyframe added at frame ${frame}`;
+
+		pushToUndoStack({
+			filePath: absolutePath,
+			oldContents: fileContents,
+			logLevel,
+			remotionRoot,
+			logLine,
+			description: {
+				undoMessage: `↩️  ${undoPropChange}`,
+				redoMessage: `↪️  ${redoPropChange}`,
+			},
+			entryType: 'effect-props',
+			suppressHmrOnFileRestore: true,
+		});
+		suppressUndoStackInvalidation(absolutePath);
+		suppressBundlerUpdateForFile(absolutePath);
+		writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
+
+		logEffectUpdate({
+			fileRelativeToRoot,
+			line: logLine,
+			effectName: effectCallee,
+			propKey: key,
+			oldValueString,
+			newValueString,
+			defaultValueString: null,
+			formatted,
+			logLevel,
+			removedProps: [],
+			addedProps: [],
+		});
+
+		printUndoHint(logLevel);
+
+		const ast = parseAst(readFileSync(absolutePath, 'utf-8'));
+		const jsx = findJsxElementAtNodePath(ast, sequenceNodePath.nodePath);
+		if (!jsx) {
+			return {
+				canUpdate: false,
+				effectIndex,
+				reason: 'not-found',
+			};
+		}
+
+		return computeEffectPropStatus({
+			jsx,
+			effectIndex,
+			keys: getAllSchemaKeys(schema),
+		});
+	});

--- a/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
@@ -1,0 +1,109 @@
+import {readFileSync} from 'node:fs';
+import {RenderInternals} from '@remotion/renderer';
+import type {
+	AddSequenceKeyframeRequest,
+	AddSequenceKeyframeResponse,
+} from '@remotion/studio-shared';
+import {getAllSchemaKeys} from '@remotion/studio-shared';
+import {updateSequenceKeyframes} from '../../codemods/update-keyframes/update-keyframes';
+import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
+import type {ApiHandler} from '../api-types';
+import {
+	printUndoHint,
+	pushToUndoStack,
+	suppressUndoStackInvalidation,
+} from '../undo-stack';
+import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
+import {computeSequencePropsStatusFromContent} from './can-update-sequence-props';
+import {logUpdate} from './log-updates/log-update';
+import {withSavePropsLock} from './save-props-mutex';
+
+export const addSequenceKeyframeHandler: ApiHandler<
+	AddSequenceKeyframeRequest,
+	AddSequenceKeyframeResponse
+> = ({
+	input: {fileName, nodePath, key, frame, value, schema, clientId},
+	remotionRoot,
+	logLevel,
+}) =>
+	withSavePropsLock(async () => {
+		RenderInternals.Log.trace(
+			{indent: false, logLevel},
+			`[add-sequence-keyframe] Received request for fileName="${fileName}" key="${key}" frame=${frame}`,
+		);
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName,
+			action: 'modify',
+		});
+
+		const fileContents = readFileSync(absolutePath, 'utf-8');
+		const parsedValue = JSON.parse(value);
+
+		const {output, oldValueStrings, newValueStrings, formatted, logLine} =
+			await updateSequenceKeyframes({
+				input: fileContents,
+				nodePath: nodePath.nodePath,
+				updates: [
+					{
+						key,
+						operation: {
+							type: 'add',
+							frame,
+							value: parsedValue,
+						},
+					},
+				],
+			});
+
+		const oldValueString = oldValueStrings[0];
+		const newValueString = newValueStrings[0];
+
+		const undoPropChange = `${key} keyframe removed at frame ${frame}`;
+		const redoPropChange = `${key} keyframe added at frame ${frame}`;
+
+		pushToUndoStack({
+			filePath: absolutePath,
+			oldContents: fileContents,
+			logLevel,
+			remotionRoot,
+			logLine,
+			description: {
+				undoMessage: `↩️  ${undoPropChange}`,
+				redoMessage: `↪️  ${redoPropChange}`,
+			},
+			entryType: 'sequence-props',
+			suppressHmrOnFileRestore: true,
+		});
+		suppressUndoStackInvalidation(absolutePath);
+		suppressBundlerUpdateForFile(absolutePath);
+		writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
+
+		logUpdate({
+			fileRelativeToRoot,
+			line: logLine,
+			key,
+			oldValueString,
+			newValueString,
+			defaultValueString: null,
+			formatted,
+			logLevel,
+			removedProps: [],
+			addedProps: [],
+		});
+
+		printUndoHint(logLevel);
+
+		const status = computeSequencePropsStatusFromContent({
+			fileContents: output,
+			keys: getAllSchemaKeys(schema),
+			nodePath: nodePath.nodePath,
+			effects: [],
+		});
+
+		return {
+			canUpdate: true,
+			props: status.props,
+		};
+	});

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -292,6 +292,18 @@ export type DeleteSequenceKeyframeRequest = {
 
 export type DeleteSequenceKeyframeResponse = SaveSequencePropsResponse;
 
+export type AddSequenceKeyframeRequest = {
+	fileName: string;
+	nodePath: SequencePropsSubscriptionKey;
+	key: string;
+	frame: number;
+	value: string;
+	schema: SequenceSchema;
+	clientId: string;
+};
+
+export type AddSequenceKeyframeResponse = SaveSequencePropsResponse;
+
 export type DeleteEffectKeyframeRequest = {
 	fileName: string;
 	sequenceNodePath: SequencePropsSubscriptionKey;
@@ -303,6 +315,19 @@ export type DeleteEffectKeyframeRequest = {
 };
 
 export type DeleteEffectKeyframeResponse = SaveEffectPropsResponse;
+
+export type AddEffectKeyframeRequest = {
+	fileName: string;
+	sequenceNodePath: SequencePropsSubscriptionKey;
+	effectIndex: number;
+	key: string;
+	frame: number;
+	value: string;
+	schema: SequenceSchema;
+	clientId: string;
+};
+
+export type AddEffectKeyframeResponse = SaveEffectPropsResponse;
 
 export type DeleteEffectRequest = {
 	fileName: string;
@@ -445,9 +470,17 @@ export type ApiRoutes = {
 		DeleteSequenceKeyframeRequest,
 		DeleteSequenceKeyframeResponse
 	>;
+	'/api/add-sequence-keyframe': ReqAndRes<
+		AddSequenceKeyframeRequest,
+		AddSequenceKeyframeResponse
+	>;
 	'/api/delete-effect-keyframe': ReqAndRes<
 		DeleteEffectKeyframeRequest,
 		DeleteEffectKeyframeResponse
+	>;
+	'/api/add-effect-keyframe': ReqAndRes<
+		AddEffectKeyframeRequest,
+		AddEffectKeyframeResponse
 	>;
 	'/api/delete-effect': ReqAndRes<DeleteEffectRequest, DeleteEffectResponse>;
 	'/api/delete-jsx-node': ReqAndRes<

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -11,6 +11,10 @@ export {
 	CancelRenderRequest,
 	CancelRenderResponse,
 	CopyStillToClipboardRequest,
+	AddEffectKeyframeRequest,
+	AddEffectKeyframeResponse,
+	AddSequenceKeyframeRequest,
+	AddSequenceKeyframeResponse,
 	DeleteEffectKeyframeRequest,
 	DeleteEffectKeyframeResponse,
 	DeleteEffectRequest,
@@ -130,6 +134,10 @@ export {
 	optimisticDeleteEffectKeyframe,
 	optimisticDeleteSequenceKeyframe,
 } from './optimistic-delete-keyframe';
+export {
+	optimisticAddEffectKeyframe,
+	optimisticAddSequenceKeyframe,
+} from './optimistic-add-keyframe';
 export {optimisticUpdateForCodeValues} from './optimistic-update-for-code-values';
 export {optimisticUpdateForEffectCodeValues} from './optimistic-update-for-effect-code-values';
 export {

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -1,0 +1,154 @@
+import {
+	type CanUpdateSequencePropStatus,
+	type CanUpdateSequencePropsResponse,
+} from 'remotion';
+
+const getInterpolationFunction = (
+	staticValue: unknown,
+	newValue: unknown,
+): 'interpolate' | 'interpolateColors' => {
+	return typeof staticValue === 'string' && typeof newValue === 'string'
+		? 'interpolateColors'
+		: 'interpolate';
+};
+
+const addKeyframeToPropStatus = ({
+	status,
+	frame,
+	value,
+}: {
+	status: CanUpdateSequencePropStatus;
+	frame: number;
+	value: unknown;
+}): CanUpdateSequencePropStatus => {
+	if (status.canUpdate) {
+		const staticValue = status.codeValue ?? value;
+		const keyframes =
+			frame === 0
+				? [{frame, value}]
+				: [
+						{frame: 0, value: staticValue},
+						{frame, value},
+					];
+
+		return {
+			canUpdate: false,
+			reason: 'keyframed',
+			interpolationFunction: getInterpolationFunction(staticValue, value),
+			keyframes,
+			easing: frame === 0 ? [] : ['linear'],
+			clamping: {left: 'extend', right: 'extend'},
+			posterize: undefined,
+		};
+	}
+
+	if (status.reason !== 'keyframed') {
+		return status;
+	}
+
+	const existingIndex = status.keyframes.findIndex((kf) => kf.frame === frame);
+	if (existingIndex !== -1) {
+		const keyframes = status.keyframes.map((keyframe, index) =>
+			index === existingIndex ? {frame, value} : keyframe,
+		);
+
+		return {
+			...status,
+			keyframes,
+		};
+	}
+
+	const keyframes = [...status.keyframes, {frame, value}].sort(
+		(first, second) => first.frame - second.frame,
+	);
+	const easing = [...status.easing];
+	while (easing.length < keyframes.length - 1) {
+		easing.push('linear');
+	}
+
+	return {
+		...status,
+		keyframes,
+		easing,
+	};
+};
+
+export const optimisticAddSequenceKeyframe = ({
+	previous,
+	fieldKey,
+	frame,
+	value,
+}: {
+	previous: CanUpdateSequencePropsResponse;
+	fieldKey: string;
+	frame: number;
+	value: unknown;
+}): CanUpdateSequencePropsResponse => {
+	if (!previous.canUpdate) {
+		return previous;
+	}
+
+	const status = previous.props[fieldKey];
+	if (!status) {
+		return previous;
+	}
+
+	return {
+		...previous,
+		props: {
+			...previous.props,
+			[fieldKey]: addKeyframeToPropStatus({status, frame, value}),
+		},
+	};
+};
+
+export const optimisticAddEffectKeyframe = ({
+	previous,
+	effectIndex,
+	fieldKey,
+	frame,
+	value,
+}: {
+	previous: CanUpdateSequencePropsResponse;
+	effectIndex: number;
+	fieldKey: string;
+	frame: number;
+	value: unknown;
+}): CanUpdateSequencePropsResponse => {
+	if (!previous.canUpdate) {
+		return previous;
+	}
+
+	const targetIndex = previous.effects.findIndex(
+		(e) => e.effectIndex === effectIndex,
+	);
+	if (targetIndex === -1) {
+		return previous;
+	}
+
+	const target = previous.effects[targetIndex];
+	if (!target.canUpdate) {
+		return previous;
+	}
+
+	const status = target.props[fieldKey];
+	if (!status) {
+		return previous;
+	}
+
+	const updatedEffect = {
+		...target,
+		props: {
+			...target.props,
+			[fieldKey]: addKeyframeToPropStatus({status, frame, value}),
+		},
+	};
+
+	const effects = [...previous.effects];
+	effects[targetIndex] = updatedEffect;
+
+	return {
+		...previous,
+		effects,
+	};
+};

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -1,0 +1,137 @@
+import {expect, test} from 'bun:test';
+import type {CanUpdateSequencePropsResponse} from 'remotion';
+import {
+	optimisticAddEffectKeyframe,
+	optimisticAddSequenceKeyframe,
+} from '../optimistic-add-keyframe';
+
+test('optimisticAddSequenceKeyframe converts a static prop to keyframed', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			opacity: {
+				canUpdate: true,
+				codeValue: 0.5,
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticAddSequenceKeyframe({
+		previous,
+		fieldKey: 'opacity',
+		frame: 25,
+		value: 0.75,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const status = updated.props.opacity;
+	if (!status || status.canUpdate || status.reason !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([
+		{frame: 0, value: 0.5},
+		{frame: 25, value: 0.75},
+	]);
+	expect(status.easing).toEqual(['linear']);
+});
+
+test('optimisticAddSequenceKeyframe appends a keyframe to an existing interpolation', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			scale: {
+				canUpdate: false,
+				reason: 'keyframed',
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 1},
+					{frame: 60, value: 2},
+				],
+				easing: ['linear'],
+				clamping: {left: 'extend', right: 'extend'},
+				posterize: undefined,
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticAddSequenceKeyframe({
+		previous,
+		fieldKey: 'scale',
+		frame: 30,
+		value: 1.5,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const status = updated.props.scale;
+	if (!status || status.canUpdate || status.reason !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([
+		{frame: 0, value: 1},
+		{frame: 30, value: 1.5},
+		{frame: 60, value: 2},
+	]);
+	expect(status.easing).toEqual(['linear', 'linear']);
+});
+
+test('optimisticAddEffectKeyframe appends a keyframe on the target effect', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {},
+		effects: [
+			{
+				canUpdate: true,
+				effectIndex: 0,
+				callee: 'tint',
+				props: {
+					amount: {
+						canUpdate: false,
+						reason: 'keyframed',
+						interpolationFunction: 'interpolate',
+						keyframes: [{frame: 0, value: 0.2}],
+						easing: [],
+						clamping: {left: 'extend', right: 'extend'},
+						posterize: undefined,
+					},
+				},
+			},
+		],
+	};
+
+	const updated = optimisticAddEffectKeyframe({
+		previous,
+		effectIndex: 0,
+		fieldKey: 'amount',
+		frame: 30,
+		value: 0.5,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const effect = updated.effects[0];
+	if (!effect.canUpdate) {
+		throw new Error('expected updateable effect');
+	}
+
+	const status = effect.props.amount;
+	if (!status || status.canUpdate || status.reason !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([
+		{frame: 0, value: 0.2},
+		{frame: 30, value: 0.5},
+	]);
+});

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -15,6 +15,7 @@ import {enqueueSavePropChange} from './save-prop-queue';
 import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineFieldLabel} from './TimelineFieldLabel';
+import {TimelineKeyframeControls} from './TimelineKeyframeControls';
 import {TimelineKeyframedValue} from './TimelineKeyframedValue';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
@@ -234,6 +235,9 @@ export const TimelineEffectFieldRow: React.FC<{
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {getEffectDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
 	const selection = useTimelineRowSelection(nodePathInfo);
 	const style = useMemo(() => {
 		return {
@@ -256,6 +260,26 @@ export const TimelineEffectFieldRow: React.FC<{
 		effectStatus.type === 'can-update-effect'
 			? (effectStatus.props?.[field.key] ?? null)
 			: null;
+
+	const dragOverrideValue = useMemo(() => {
+		const overrides = getEffectDragOverrides(nodePath, field.effectIndex);
+		return overrides[field.key];
+	}, [getEffectDragOverrides, nodePath, field.effectIndex, field.key]);
+
+	const keyframeControls =
+		selection.selected && propStatus !== null ? (
+			<TimelineKeyframeControls
+				fieldKey={field.key}
+				propStatus={propStatus}
+				nodePath={nodePath}
+				fileName={validatedLocation.source}
+				keyframeDisplayOffset={keyframeDisplayOffset}
+				defaultValue={field.fieldSchema.default}
+				dragOverrideValue={dragOverrideValue}
+				schema={field.effectSchema}
+				effectIndex={field.effectIndex}
+			/>
+		) : null;
 
 	const isNonDefault = useMemo(() => {
 		if (!propStatus || !propStatus.canUpdate) {
@@ -334,6 +358,7 @@ export const TimelineEffectFieldRow: React.FC<{
 		<TimelineRowChrome
 			depth={rowDepth}
 			eye={<TimelineLayerEyeSpacer />}
+			keyframeControls={keyframeControls}
 			arrow={<TimelineExpandArrowSpacer />}
 			style={style}
 			selected={selection.selected}

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -1,0 +1,343 @@
+import React, {useCallback, useContext, useMemo} from 'react';
+import type {
+	CanUpdateSequencePropStatus,
+	SequencePropsSubscriptionKey,
+	SequenceSchema,
+} from 'remotion';
+import {Internals, useVideoConfig} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {BLUE, LIGHT_TEXT} from '../../helpers/colors';
+import {
+	callAddEffectKeyframe,
+	callAddSequenceKeyframe,
+} from './call-add-keyframe';
+import {
+	callDeleteEffectKeyframe,
+	callDeleteSequenceKeyframe,
+} from './call-delete-keyframe';
+import {
+	getNextKeyframeDisplayFrame,
+	getPreviousKeyframeDisplayFrame,
+	hasKeyframeAtSourceFrame,
+} from './get-keyframe-navigation';
+import {getTimelineKeyframes} from './get-timeline-keyframes';
+
+const controlsContainerStyle: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	flexShrink: 0,
+	gap: 2,
+	marginRight: 4,
+};
+
+const navButtonStyle: React.CSSProperties = {
+	alignItems: 'center',
+	background: 'none',
+	border: 'none',
+	color: 'white',
+	cursor: 'pointer',
+	display: 'flex',
+	flexShrink: 0,
+	fontSize: 8,
+	height: 12,
+	justifyContent: 'center',
+	lineHeight: 1,
+	outline: 'none',
+	padding: 0,
+	userSelect: 'none',
+	width: 10,
+};
+
+const diamondButtonStyle: React.CSSProperties = {
+	...navButtonStyle,
+	height: 10,
+	width: 10,
+};
+
+const svgStyle: React.CSSProperties = {display: 'block'};
+
+const getCurrentKeyframeValue = ({
+	propStatus,
+	jsxFrame,
+	defaultValue,
+	dragOverrideValue,
+}: {
+	propStatus: CanUpdateSequencePropStatus;
+	jsxFrame: number;
+	defaultValue: unknown;
+	dragOverrideValue: unknown;
+}): unknown | null => {
+	if (propStatus.canUpdate) {
+		return Internals.getEffectiveVisualModeValue({
+			codeValue: propStatus,
+			dragOverrideValue,
+			defaultValue,
+			shouldResortToDefaultValueIfUndefined: true,
+		});
+	}
+
+	if (propStatus.reason === 'keyframed') {
+		return Internals.interpolateKeyframedStatus({
+			frame: jsxFrame,
+			status: propStatus,
+		});
+	}
+
+	return null;
+};
+
+export const TimelineKeyframeControls: React.FC<{
+	readonly fieldKey: string;
+	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly fileName: string;
+	readonly keyframeDisplayOffset: number;
+	readonly defaultValue: unknown;
+	readonly dragOverrideValue: unknown | undefined;
+	readonly schema: SequenceSchema;
+	readonly effectIndex: number | null;
+}> = ({
+	fieldKey,
+	propStatus,
+	nodePath,
+	fileName,
+	keyframeDisplayOffset,
+	defaultValue,
+	dragOverrideValue,
+	schema,
+	effectIndex,
+}) => {
+	const videoConfig = useVideoConfig();
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const setFrame = Internals.useTimelineSetFrame();
+	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+
+	const clientId =
+		previewServerState.type === 'connected'
+			? previewServerState.clientId
+			: null;
+
+	const jsxFrame = timelinePosition - keyframeDisplayOffset;
+	const keyframes = useMemo(
+		() => getTimelineKeyframes(propStatus, keyframeDisplayOffset),
+		[propStatus, keyframeDisplayOffset],
+	);
+
+	const hasKeyframeAtCurrentFrame = useMemo(() => {
+		if (propStatus.canUpdate || propStatus.reason === 'computed') {
+			return false;
+		}
+
+		return hasKeyframeAtSourceFrame(propStatus.keyframes, jsxFrame);
+	}, [jsxFrame, propStatus]);
+
+	const previousDisplayFrame = useMemo(
+		() => getPreviousKeyframeDisplayFrame(keyframes, timelinePosition),
+		[keyframes, timelinePosition],
+	);
+	const nextDisplayFrame = useMemo(
+		() => getNextKeyframeDisplayFrame(keyframes, timelinePosition),
+		[keyframes, timelinePosition],
+	);
+
+	const canToggleKeyframe =
+		propStatus.canUpdate || propStatus.reason === 'keyframed';
+
+	const seekToDisplayFrame = useCallback(
+		(frame: number) => {
+			setFrame((current) => {
+				const next = {...current, [videoConfig.id]: frame};
+				Internals.persistCurrentFrame(next);
+				return next;
+			});
+		},
+		[setFrame, videoConfig.id],
+	);
+
+	const onPrevious = useCallback(
+		(e: React.PointerEvent<HTMLButtonElement>) => {
+			e.stopPropagation();
+			if (previousDisplayFrame !== null) {
+				seekToDisplayFrame(previousDisplayFrame);
+			}
+		},
+		[previousDisplayFrame, seekToDisplayFrame],
+	);
+
+	const onNext = useCallback(
+		(e: React.PointerEvent<HTMLButtonElement>) => {
+			e.stopPropagation();
+			if (nextDisplayFrame !== null) {
+				seekToDisplayFrame(nextDisplayFrame);
+			}
+		},
+		[nextDisplayFrame, seekToDisplayFrame],
+	);
+
+	const onToggleKeyframe = useCallback(
+		(e: React.PointerEvent<HTMLButtonElement>) => {
+			e.stopPropagation();
+			if (!clientId || !canToggleKeyframe) {
+				return;
+			}
+
+			if (
+				hasKeyframeAtCurrentFrame &&
+				!propStatus.canUpdate &&
+				propStatus.reason === 'keyframed'
+			) {
+				if (effectIndex === null) {
+					void callDeleteSequenceKeyframe({
+						fileName,
+						nodePath,
+						fieldKey,
+						sourceFrame: jsxFrame,
+						schema,
+						setCodeValues,
+						clientId,
+					});
+					return;
+				}
+
+				void callDeleteEffectKeyframe({
+					fileName,
+					nodePath,
+					effectIndex,
+					fieldKey,
+					sourceFrame: jsxFrame,
+					schema,
+					setCodeValues,
+					clientId,
+				});
+				return;
+			}
+
+			const value = getCurrentKeyframeValue({
+				propStatus,
+				jsxFrame,
+				defaultValue,
+				dragOverrideValue,
+			});
+			if (value === null) {
+				return;
+			}
+
+			if (effectIndex === null) {
+				void callAddSequenceKeyframe({
+					fileName,
+					nodePath,
+					fieldKey,
+					sourceFrame: jsxFrame,
+					value,
+					schema,
+					setCodeValues,
+					clientId,
+				});
+				return;
+			}
+
+			void callAddEffectKeyframe({
+				fileName,
+				nodePath,
+				effectIndex,
+				fieldKey,
+				sourceFrame: jsxFrame,
+				value,
+				schema,
+				setCodeValues,
+				clientId,
+			});
+		},
+		[
+			canToggleKeyframe,
+			clientId,
+			defaultValue,
+			dragOverrideValue,
+			effectIndex,
+			fieldKey,
+			fileName,
+			hasKeyframeAtCurrentFrame,
+			jsxFrame,
+			nodePath,
+			propStatus,
+			schema,
+			setCodeValues,
+		],
+	);
+
+	const previousDisabled = previousDisplayFrame === null;
+	const nextDisabled = nextDisplayFrame === null;
+
+	const previousStyle = useMemo(
+		(): React.CSSProperties => ({
+			...navButtonStyle,
+			cursor: previousDisabled ? 'default' : 'pointer',
+			opacity: previousDisabled ? 0.35 : 1,
+		}),
+		[previousDisabled],
+	);
+
+	const nextStyle = useMemo(
+		(): React.CSSProperties => ({
+			...navButtonStyle,
+			cursor: nextDisabled ? 'default' : 'pointer',
+			opacity: nextDisabled ? 0.35 : 1,
+		}),
+		[nextDisabled],
+	);
+
+	const diamondStyle = useMemo(
+		(): React.CSSProperties => ({
+			...diamondButtonStyle,
+			backgroundColor: hasKeyframeAtCurrentFrame ? BLUE : LIGHT_TEXT,
+			borderRadius: 1,
+			boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.4)',
+			cursor: canToggleKeyframe && clientId ? 'pointer' : 'default',
+			opacity: canToggleKeyframe && clientId ? 1 : 0.35,
+			transform: 'rotate(45deg)',
+		}),
+		[canToggleKeyframe, clientId, hasKeyframeAtCurrentFrame],
+	);
+
+	return (
+		<div style={controlsContainerStyle}>
+			<button
+				type="button"
+				style={previousStyle}
+				disabled={previousDisabled}
+				onPointerDown={previousDisabled ? undefined : onPrevious}
+				aria-label="Go to previous keyframe"
+				title="Previous keyframe"
+			>
+				<svg width="8" height="8" viewBox="0 0 8 8" style={svgStyle}>
+					<path d="M5 1L2 4L5 7Z" fill="#ccc" />
+				</svg>
+			</button>
+			<button
+				type="button"
+				style={diamondStyle}
+				disabled={!canToggleKeyframe || !clientId}
+				onPointerDown={
+					canToggleKeyframe && clientId ? onToggleKeyframe : undefined
+				}
+				aria-label={
+					hasKeyframeAtCurrentFrame ? 'Remove keyframe' : 'Add keyframe'
+				}
+				title={hasKeyframeAtCurrentFrame ? 'Remove keyframe' : 'Add keyframe'}
+			/>
+			<button
+				type="button"
+				style={nextStyle}
+				disabled={nextDisabled}
+				onPointerDown={nextDisabled ? undefined : onNext}
+				aria-label="Go to next keyframe"
+				title="Next keyframe"
+			>
+				<svg width="8" height="8" viewBox="0 0 8 8" style={svgStyle}>
+					<path d="M3 1L6 4L3 7Z" fill="#ccc" />
+				</svg>
+			</button>
+		</div>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -23,6 +23,7 @@ const chromeColumnStyle: React.CSSProperties = {
 export const TimelineRowChrome: React.FC<{
 	readonly depth: number;
 	readonly eye: React.ReactNode;
+	readonly keyframeControls?: React.ReactNode;
 	readonly arrow: React.ReactNode;
 	readonly children: React.ReactNode;
 	readonly style: React.CSSProperties;
@@ -39,6 +40,7 @@ export const TimelineRowChrome: React.FC<{
 }> = ({
 	depth,
 	eye,
+	keyframeControls,
 	arrow,
 	children,
 	style,
@@ -105,6 +107,7 @@ export const TimelineRowChrome: React.FC<{
 			<div style={chromeColumnStyle}>
 				{eye}
 				{indentWidth > 0 ? <Padder depth={depth} /> : null}
+				{keyframeControls}
 				{arrow}
 			</div>
 			{children}

--- a/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
@@ -19,6 +19,7 @@ import {saveSequenceProp} from './save-sequence-prop';
 import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineFieldLabel} from './TimelineFieldLabel';
+import {TimelineKeyframeControls} from './TimelineKeyframeControls';
 import {TimelineKeyframedValue} from './TimelineKeyframedValue';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
@@ -165,6 +166,9 @@ export const TimelineSequenceFieldRow: React.FC<{
 	const {codeValues: visualModeCodeValues} = useContext(
 		Internals.VisualModeCodeValuesContext,
 	);
+	const {getDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const selection = useTimelineRowSelection(nodePathInfo);
@@ -174,6 +178,25 @@ export const TimelineSequenceFieldRow: React.FC<{
 		nodePath,
 	);
 	const codeValue = codeValuesForOverride?.[field.key] ?? null;
+
+	const dragOverrideValue = useMemo(() => {
+		return (getDragOverrides(nodePath) ?? {})[field.key];
+	}, [getDragOverrides, nodePath, field.key]);
+
+	const keyframeControls =
+		selection.selected && codeValue !== null ? (
+			<TimelineKeyframeControls
+				fieldKey={field.key}
+				propStatus={codeValue}
+				nodePath={nodePath}
+				fileName={validatedLocation.source}
+				keyframeDisplayOffset={keyframeDisplayOffset}
+				defaultValue={field.fieldSchema.default}
+				dragOverrideValue={dragOverrideValue}
+				schema={schema}
+				effectIndex={null}
+			/>
+		) : null;
 
 	const style = useMemo(() => {
 		return {
@@ -262,6 +285,7 @@ export const TimelineSequenceFieldRow: React.FC<{
 		<TimelineRowChrome
 			depth={rowDepth}
 			eye={<TimelineLayerEyeSpacer />}
+			keyframeControls={keyframeControls}
 			arrow={<TimelineExpandArrowSpacer />}
 			style={style}
 			selected={selection.selected}

--- a/packages/studio/src/components/Timeline/call-add-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-add-keyframe.ts
@@ -1,0 +1,98 @@
+import {
+	optimisticAddEffectKeyframe,
+	optimisticAddSequenceKeyframe,
+} from '@remotion/studio-shared';
+import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
+import {callApi} from '../call-api';
+import {enqueueSavePropChange} from './save-prop-queue';
+import type {SetCodeValues} from './save-sequence-prop';
+
+export const callAddSequenceKeyframe = ({
+	fileName,
+	nodePath,
+	fieldKey,
+	sourceFrame,
+	value,
+	schema,
+	setCodeValues,
+	clientId,
+}: {
+	fileName: string;
+	nodePath: SequencePropsSubscriptionKey;
+	fieldKey: string;
+	sourceFrame: number;
+	value: unknown;
+	schema: SequenceSchema;
+	setCodeValues: SetCodeValues;
+	clientId: string;
+}): Promise<void> => {
+	return enqueueSavePropChange({
+		nodePath,
+		setCodeValues,
+		applyOptimistic: (prev) =>
+			optimisticAddSequenceKeyframe({
+				previous: prev,
+				fieldKey,
+				frame: sourceFrame,
+				value,
+			}),
+		apiCall: () =>
+			callApi('/api/add-sequence-keyframe', {
+				fileName,
+				nodePath,
+				key: fieldKey,
+				frame: sourceFrame,
+				value: JSON.stringify(value),
+				schema,
+				clientId,
+			}),
+		errorLabel: 'Could not add keyframe',
+	});
+};
+
+export const callAddEffectKeyframe = ({
+	fileName,
+	nodePath,
+	effectIndex,
+	fieldKey,
+	sourceFrame,
+	value,
+	schema,
+	setCodeValues,
+	clientId,
+}: {
+	fileName: string;
+	nodePath: SequencePropsSubscriptionKey;
+	effectIndex: number;
+	fieldKey: string;
+	sourceFrame: number;
+	value: unknown;
+	schema: SequenceSchema;
+	setCodeValues: SetCodeValues;
+	clientId: string;
+}): Promise<void> => {
+	return enqueueSavePropChange({
+		nodePath,
+		setCodeValues,
+		applyOptimistic: (prev) =>
+			optimisticAddEffectKeyframe({
+				previous: prev,
+				effectIndex,
+				fieldKey,
+				frame: sourceFrame,
+				value,
+			}),
+		apiCall: () =>
+			callApi('/api/add-effect-keyframe', {
+				fileName,
+				sequenceNodePath: nodePath,
+				effectIndex,
+				key: fieldKey,
+				frame: sourceFrame,
+				value: JSON.stringify(value),
+				schema,
+				clientId,
+			}),
+		errorLabel: 'Could not add keyframe',
+	});
+};

--- a/packages/studio/src/components/Timeline/get-keyframe-navigation.ts
+++ b/packages/studio/src/components/Timeline/get-keyframe-navigation.ts
@@ -1,0 +1,33 @@
+export const getPreviousKeyframeDisplayFrame = (
+	keyframes: readonly {frame: number}[],
+	currentDisplayFrame: number,
+): number | null => {
+	let previous: number | null = null;
+	for (const keyframe of keyframes) {
+		if (keyframe.frame < currentDisplayFrame) {
+			previous = keyframe.frame;
+		}
+	}
+
+	return previous;
+};
+
+export const getNextKeyframeDisplayFrame = (
+	keyframes: readonly {frame: number}[],
+	currentDisplayFrame: number,
+): number | null => {
+	for (const keyframe of keyframes) {
+		if (keyframe.frame > currentDisplayFrame) {
+			return keyframe.frame;
+		}
+	}
+
+	return null;
+};
+
+export const hasKeyframeAtSourceFrame = (
+	keyframes: readonly {frame: number}[],
+	sourceFrame: number,
+): boolean => {
+	return keyframes.some((keyframe) => keyframe.frame === sourceFrame);
+};

--- a/packages/studio/src/test/timeline-keyframe-navigation.test.ts
+++ b/packages/studio/src/test/timeline-keyframe-navigation.test.ts
@@ -1,0 +1,29 @@
+import {expect, test} from 'bun:test';
+import {
+	getNextKeyframeDisplayFrame,
+	getPreviousKeyframeDisplayFrame,
+	hasKeyframeAtSourceFrame,
+} from '../components/Timeline/get-keyframe-navigation';
+
+const keyframes = [{frame: 10}, {frame: 30}, {frame: 90}];
+
+test('getPreviousKeyframeDisplayFrame returns the nearest earlier keyframe', () => {
+	expect(getPreviousKeyframeDisplayFrame(keyframes, 0)).toBe(null);
+	expect(getPreviousKeyframeDisplayFrame(keyframes, 10)).toBe(null);
+	expect(getPreviousKeyframeDisplayFrame(keyframes, 11)).toBe(10);
+	expect(getPreviousKeyframeDisplayFrame(keyframes, 30)).toBe(10);
+	expect(getPreviousKeyframeDisplayFrame(keyframes, 100)).toBe(90);
+});
+
+test('getNextKeyframeDisplayFrame returns the nearest later keyframe', () => {
+	expect(getNextKeyframeDisplayFrame(keyframes, 0)).toBe(10);
+	expect(getNextKeyframeDisplayFrame(keyframes, 10)).toBe(30);
+	expect(getNextKeyframeDisplayFrame(keyframes, 29)).toBe(30);
+	expect(getNextKeyframeDisplayFrame(keyframes, 90)).toBe(null);
+	expect(getNextKeyframeDisplayFrame(keyframes, 100)).toBe(null);
+});
+
+test('hasKeyframeAtSourceFrame checks source frame membership', () => {
+	expect(hasKeyframeAtSourceFrame(keyframes, 10)).toBe(true);
+	expect(hasKeyframeAtSourceFrame(keyframes, 11)).toBe(false);
+});


### PR DESCRIPTION
## Summary

- Adds previous / keyframe toggle / next controls to the left of selected sequence control and effect prop rows in the timeline list
- Introduces `/api/add-sequence-keyframe` and `/api/add-effect-keyframe` routes with optimistic updates for adding keyframes
- The diamond button turns blue when the playhead is on an existing keyframe; chevrons seek to adjacent keyframes and are disabled when none exist

Fixes #7776

## Test plan

- [ ] Expand a sequence with keyframed controls in Remotion Studio
- [ ] Select a sequence control or effect prop row and verify the three buttons appear on the left
- [ ] Click the left/right chevrons to jump between keyframes
- [ ] Click the diamond to add a keyframe at the current frame (blue when one exists)
- [ ] Click the diamond again on a keyed frame to remove the keyframe
- [ ] Verify controls are not mounted when the row is not selected

Note: Timeline row selection is still gated behind `SELECTION_ENABLED = false`, so these controls appear once selection is enabled publicly.
