### PR TITLE
`@remotion/studio`: Add copy file location menu item

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -3,6 +3,7 @@ import type {TSequence} from 'remotion';
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {formatFileLocation} from '../../helpers/format-file-location';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
 	getTimelineLayerHeight,
@@ -68,6 +69,14 @@ export const TimelineListItem: React.FC<{
 
 	const {canOpenInEditor, openInEditor, originalLocation} =
 		useOpenSequenceInEditor(sequence);
+	const fileLocation = useMemo(
+		() =>
+			formatFileLocation({
+				location: originalLocation,
+				root: window.remotion_cwd,
+			}),
+		[originalLocation],
+	);
 
 	const validatedLocation = useMemo(() => {
 		if (
@@ -197,6 +206,34 @@ export const TimelineListItem: React.FC<{
 						value: 'show-in-editor',
 					}
 				: null,
+			{
+				type: 'item' as const,
+				id: 'copy-file-location',
+				keyHint: null,
+				label: 'Copy file location',
+				leftItem: null,
+				disabled: !fileLocation,
+				onClick: () => {
+					if (!fileLocation) {
+						return;
+					}
+
+					navigator.clipboard
+						.writeText(fileLocation)
+						.then(() => {
+							showNotification('Copied file location to clipboard', 1000);
+						})
+						.catch((err) => {
+							showNotification(
+								`Could not copy to clipboard: ${(err as Error).message}`,
+								1000,
+							);
+						});
+				},
+				quickSwitcherLabel: null,
+				subMenu: null,
+				value: 'copy-file-location',
+			},
 			documentationLink
 				? {
 						type: 'item' as const,
@@ -276,6 +313,7 @@ export const TimelineListItem: React.FC<{
 		assetLinkInfo,
 		deleteDisabled,
 		duplicateDisabled,
+		fileLocation,
 		onDeleteSequenceFromSource,
 		onDuplicateSequenceFromSource,
 		canOpenInEditor,

--- a/packages/studio/src/components/composition-menu-items.ts
+++ b/packages/studio/src/components/composition-menu-items.ts
@@ -1,6 +1,7 @@
 import type {SetStateAction} from 'react';
 import type {ResolvedStackLocation, _InternalTypes} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
+import {formatFileLocation} from '../helpers/format-file-location';
 import {
 	openCompositionComponentInEditor,
 	openOriginalPositionInEditor,
@@ -26,10 +27,15 @@ export const getCompositionMenuItems = ({
 	readOnlyStudio: boolean;
 }): ComboboxValue[] => {
 	const editorName = window.remotion_editorName;
+	const fileLocation = formatFileLocation({
+		location: resolvedLocation,
+		root: window.remotion_cwd,
+	});
 	const showInEditorDisabled =
 		!composition || connectionStatus !== 'connected' || !resolvedLocation;
 	const openComponentInEditorDisabled =
 		showInEditorDisabled || !resolvedLocation?.source;
+	const copyFileLocationDisabled = !composition || !fileLocation;
 
 	return [
 		editorName
@@ -57,6 +63,35 @@ export const getCompositionMenuItems = ({
 					disabled: showInEditorDisabled,
 				}
 			: null,
+		{
+			id: 'copy-file-location',
+			keyHint: null,
+			label: `Copy file location`,
+			leftItem: null,
+			onClick: () => {
+				closeMenu();
+				if (!fileLocation) {
+					return;
+				}
+
+				navigator.clipboard
+					.writeText(fileLocation)
+					.then(() => {
+						showNotification('Copied file location to clipboard', 1000);
+					})
+					.catch((err) => {
+						showNotification(
+							`Could not copy to clipboard: ${(err as Error).message}`,
+							1000,
+						);
+					});
+			},
+			quickSwitcherLabel: 'Copy composition file location',
+			subMenu: null,
+			type: 'item' as const,
+			value: 'copy-file-location',
+			disabled: copyFileLocationDisabled,
+		},
 		editorName
 			? {
 					id: 'open-component-in-editor',
@@ -85,7 +120,7 @@ export const getCompositionMenuItems = ({
 					disabled: openComponentInEditorDisabled,
 				}
 			: null,
-		editorName
+		editorName || fileLocation
 			? {
 					type: 'divider' as const,
 					id: 'show-in-editor-divider',

--- a/packages/studio/src/helpers/format-file-location.ts
+++ b/packages/studio/src/helpers/format-file-location.ts
@@ -1,0 +1,39 @@
+type FileLocation = {
+	readonly source: string | null;
+	readonly line: number | null;
+};
+
+const normalizeSlashes = (path: string) => path.replace(/\\/g, '/');
+
+const stripTrailingSlashes = (path: string) => path.replace(/\/+$/, '');
+
+export const formatFileLocation = ({
+	location,
+	root,
+}: {
+	readonly location: FileLocation | null;
+	readonly root: string;
+}) => {
+	if (!location?.source || location.line === null) {
+		return null;
+	}
+
+	const source = normalizeSlashes(location.source);
+	const normalizedRoot = stripTrailingSlashes(normalizeSlashes(root));
+	const shouldCompareCaseInsensitive =
+		/^[a-z]:\//i.test(source) || /^[a-z]:\//i.test(normalizedRoot);
+	const sourceForComparison = shouldCompareCaseInsensitive
+		? source.toLowerCase()
+		: source;
+	const rootForComparison = shouldCompareCaseInsensitive
+		? normalizedRoot.toLowerCase()
+		: normalizedRoot;
+	const sourceIsInsideRoot =
+		normalizedRoot.length > 0 &&
+		sourceForComparison.startsWith(rootForComparison + '/');
+	const relativeSource = sourceIsInsideRoot
+		? source.slice(normalizedRoot.length + 1)
+		: source;
+
+	return `${relativeSource}:${location.line}`;
+};

--- a/packages/studio/src/helpers/format-file-location.ts
+++ b/packages/studio/src/helpers/format-file-location.ts
@@ -7,6 +7,8 @@ const normalizeSlashes = (path: string) => path.replace(/\\/g, '/');
 
 const stripTrailingSlashes = (path: string) => path.replace(/\/+$/, '');
 
+const stripLeadingDotSlash = (path: string) => path.replace(/^\.\/+/, '');
+
 export const formatFileLocation = ({
 	location,
 	root,
@@ -35,5 +37,5 @@ export const formatFileLocation = ({
 		? source.slice(normalizedRoot.length + 1)
 		: source;
 
-	return `${relativeSource}:${location.line}`;
+	return `${stripLeadingDotSlash(relativeSource)}:${location.line}`;
 };

--- a/packages/studio/src/test/format-file-location.test.ts
+++ b/packages/studio/src/test/format-file-location.test.ts
@@ -13,6 +13,18 @@ test('Should format file locations relative to the project root', () => {
 	).toBe('src/Root.tsx:42');
 });
 
+test('Should remove leading dot slash from relative file locations', () => {
+	expect(
+		formatFileLocation({
+			location: {
+				source: '/Users/example/video/./src/Root.tsx',
+				line: 42,
+			},
+			root: '/Users/example/video',
+		}),
+	).toBe('src/Root.tsx:42');
+});
+
 test('Should format Windows file locations relative to the project root', () => {
 	expect(
 		formatFileLocation({

--- a/packages/studio/src/test/format-file-location.test.ts
+++ b/packages/studio/src/test/format-file-location.test.ts
@@ -1,0 +1,59 @@
+import {expect, test} from 'bun:test';
+import {formatFileLocation} from '../helpers/format-file-location';
+
+test('Should format file locations relative to the project root', () => {
+	expect(
+		formatFileLocation({
+			location: {
+				source: '/Users/example/video/src/Root.tsx',
+				line: 42,
+			},
+			root: '/Users/example/video',
+		}),
+	).toBe('src/Root.tsx:42');
+});
+
+test('Should format Windows file locations relative to the project root', () => {
+	expect(
+		formatFileLocation({
+			location: {
+				source: 'C:\\Users\\example\\video\\src\\Root.tsx',
+				line: 42,
+			},
+			root: 'c:\\Users\\example\\video\\',
+		}),
+	).toBe('src/Root.tsx:42');
+});
+
+test('Should keep absolute file locations outside the project root', () => {
+	expect(
+		formatFileLocation({
+			location: {
+				source: '/Users/example/other/Root.tsx',
+				line: 42,
+			},
+			root: '/Users/example/video',
+		}),
+	).toBe('/Users/example/other/Root.tsx:42');
+});
+
+test('Should not format missing file locations', () => {
+	expect(
+		formatFileLocation({
+			location: {
+				source: null,
+				line: 42,
+			},
+			root: '/Users/example/video',
+		}),
+	).toBe(null);
+	expect(
+		formatFileLocation({
+			location: {
+				source: '/Users/example/video/src/Root.tsx',
+				line: null,
+			},
+			root: '/Users/example/video',
+		}),
+	).toBe(null);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #7850

## Summary
- Add a Studio context menu item to copy clean `relative/path:line` locations for timeline sequences.
- Add the same copy action for composition rows.
- Add formatter coverage for POSIX, Windows, `./src`, outside-root, and missing-location cases.

## Testing
- `bun test src/test/format-file-location.test.ts`
- `bun run test && bun run lint && bun run formatting` in `packages/studio` (lint has existing warnings only)
- `bun run build`
- `bun run formatting`
- Browser verification against `packages/example` Studio copied `src/Root.tsx:362` from a composition and `src/KeyframedPropsTest.tsx:99` from a sequence. Evidence: `/opt/cursor/artifacts/studio_copy_location_playwright_verified.log`
- `bun run stylecheck` (blocked by documented `@remotion/lambda-go` Go 1.22.2 vs Go >= 1.23.0 environment issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c33d0571-75f6-4037-aee1-a7041aaf7c9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c33d0571-75f6-4037-aee1-a7041aaf7c9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

