### PR TITLE
`@remotion/studio`: Add timeline duplicate shortcut

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -4,6 +4,7 @@ import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {useKeybinding} from '../../helpers/use-keybinding';
 import {deleteSelectedTimelineItems} from './delete-selected-timeline-item';
+import {duplicateSelectedTimelineItems} from './duplicate-selected-timeline-item';
 import {
 	useCurrentTimelineSelectionStateAsRef,
 	useTimelineSelection,
@@ -55,9 +56,34 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
+		const duplicate = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'd',
+			callback: () => {
+				const {selectedItems} = currentSelection.current;
+				if (selectedItems.length === 0) {
+					return;
+				}
+
+				const duplicatePromise = duplicateSelectedTimelineItems({
+					selections: selectedItems,
+				});
+
+				if (duplicatePromise === null) {
+					return;
+				}
+
+				duplicatePromise.catch(() => undefined);
+			},
+			commandCtrlKey: true,
+			preventDefault: true,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
 
 		return () => {
 			backspace.unregister();
+			duplicate.unregister();
 		};
 	}, [
 		canSelect,

--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -17,6 +17,7 @@ import {
 } from '../ExpandedTracksProvider';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
+import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
 import {saveSequenceProp} from './save-sequence-prop';
 import {
 	TimelineExpandArrowButton,
@@ -94,36 +95,13 @@ export const TimelineListItem: React.FC<{
 
 	const duplicateDisabled = deleteDisabled;
 
-	const onDuplicateSequenceFromSource = useCallback(async () => {
-		if (!validatedLocation?.source || !nodePath) {
+	const onDuplicateSequenceFromSource = useCallback(() => {
+		if (!validatedLocation?.source || !nodePathInfo) {
 			return;
 		}
 
-		if (nodePathInfo && nodePathInfo.numberOfSequencesWithThisNodePath > 1) {
-			const message =
-				'This sequence is programmatically duplicated ' +
-				nodePathInfo.numberOfSequencesWithThisNodePath +
-				' times in the code. Duplicating inserts another copy. Continue?';
-			// eslint-disable-next-line no-alert -- native confirm before applying duplicate codemod in .map callbacks
-			if (!window.confirm(message)) {
-				return;
-			}
-		}
-
-		try {
-			const result = await callApi('/api/duplicate-jsx-node', {
-				fileName: validatedLocation.source,
-				nodePath: nodePath.nodePath,
-			});
-			if (result.success) {
-				showNotification('Duplicated sequence in source file', 2000);
-			} else {
-				showNotification(result.reason, 4000);
-			}
-		} catch (err) {
-			showNotification((err as Error).message, 4000);
-		}
-	}, [nodePath, validatedLocation?.source, nodePathInfo]);
+		duplicateSequencesFromSource([nodePathInfo]).catch(() => undefined);
+	}, [nodePathInfo, validatedLocation?.source]);
 
 	const onDeleteSequenceFromSource = useCallback(async () => {
 		if (!validatedLocation?.source || !nodePath) {

--- a/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
@@ -6,15 +6,12 @@ import type {TimelineSelection} from './TimelineSelection';
 const confirmDuplicatingProgrammaticallyDuplicatedSequences = (
 	nodePathInfos: readonly SequenceNodePathInfo[],
 ): boolean => {
-	const duplicatedNodePathInfos = nodePathInfos.filter(
-		(nodePathInfo) => nodePathInfo.numberOfSequencesWithThisNodePath > 1,
-	);
-	if (duplicatedNodePathInfos.length === 0) {
+	if (nodePathInfos.length === 0) {
 		return true;
 	}
 
-	if (duplicatedNodePathInfos.length === 1) {
-		const [nodePathInfo] = duplicatedNodePathInfos;
+	if (nodePathInfos.length === 1) {
+		const [nodePathInfo] = nodePathInfos;
 		const singleDuplicatedSequenceMessage =
 			'This sequence is programmatically duplicated ' +
 			nodePathInfo.numberOfSequencesWithThisNodePath +
@@ -24,38 +21,54 @@ const confirmDuplicatingProgrammaticallyDuplicatedSequences = (
 	}
 
 	const multipleDuplicatedSequencesMessage =
-		duplicatedNodePathInfos.length +
+		nodePathInfos.length +
 		' selected sequences are programmatically duplicated in the code. Duplicating inserts another copy of each. Continue?';
 	// eslint-disable-next-line no-alert -- native confirm before applying duplicate codemod in .map callbacks
 	return window.confirm(multipleDuplicatedSequencesMessage);
 };
 
-const duplicateSequences = (
+const duplicateSequence = (nodePathInfo: SequenceNodePathInfo) => {
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	return callApi('/api/duplicate-jsx-node', {
+		fileName: nodePath.absolutePath,
+		nodePath: nodePath.nodePath,
+	});
+};
+
+export const duplicateSequencesFromSource = (
 	nodePathInfos: readonly SequenceNodePathInfo[],
 ): Promise<void> => {
-	if (!confirmDuplicatingProgrammaticallyDuplicatedSequences(nodePathInfos)) {
+	const programmaticallyDuplicated = nodePathInfos.filter(
+		(nodePathInfo) => nodePathInfo.numberOfSequencesWithThisNodePath > 1,
+	);
+	const regular = nodePathInfos.filter(
+		(nodePathInfo) => nodePathInfo.numberOfSequencesWithThisNodePath <= 1,
+	);
+
+	const toDuplicate = [...regular];
+	if (
+		programmaticallyDuplicated.length === 0 ||
+		confirmDuplicatingProgrammaticallyDuplicatedSequences(
+			programmaticallyDuplicated,
+		)
+	) {
+		toDuplicate.push(...programmaticallyDuplicated);
+	}
+
+	if (toDuplicate.length === 0) {
 		return Promise.resolve();
 	}
 
-	return Promise.all(
-		nodePathInfos.map((nodePathInfo) => {
-			const nodePath = nodePathInfo.sequenceSubscriptionKey;
-
-			return callApi('/api/duplicate-jsx-node', {
-				fileName: nodePath.absolutePath,
-				nodePath: nodePath.nodePath,
-			});
-		}),
-	)
+	return Promise.all(toDuplicate.map(duplicateSequence))
 		.then((results) => {
 			const failedResult = results.find((result) => !result.success);
-			if (failedResult) {
+			if (failedResult && !failedResult.success) {
 				showNotification(failedResult.reason, 4000);
 				return;
 			}
 
 			showNotification(
-				nodePathInfos.length === 1
+				toDuplicate.length === 1
 					? 'Duplicated sequence in source file'
 					: 'Duplicated sequences in source files',
 				2000,
@@ -85,7 +98,7 @@ export const duplicateSelectedTimelineItems = ({
 		return null;
 	}
 
-	return duplicateSequences(
+	return duplicateSequencesFromSource(
 		sequenceSelections.map((selection) => selection.nodePathInfo),
 	);
 };

--- a/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
@@ -1,0 +1,91 @@
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {callApi} from '../call-api';
+import {showNotification} from '../Notifications/NotificationCenter';
+import type {TimelineSelection} from './TimelineSelection';
+
+const confirmDuplicatingProgrammaticallyDuplicatedSequences = (
+	nodePathInfos: readonly SequenceNodePathInfo[],
+): boolean => {
+	const duplicatedNodePathInfos = nodePathInfos.filter(
+		(nodePathInfo) => nodePathInfo.numberOfSequencesWithThisNodePath > 1,
+	);
+	if (duplicatedNodePathInfos.length === 0) {
+		return true;
+	}
+
+	if (duplicatedNodePathInfos.length === 1) {
+		const [nodePathInfo] = duplicatedNodePathInfos;
+		const singleDuplicatedSequenceMessage =
+			'This sequence is programmatically duplicated ' +
+			nodePathInfo.numberOfSequencesWithThisNodePath +
+			' times in the code. Duplicating inserts another copy. Continue?';
+		// eslint-disable-next-line no-alert -- native confirm before applying duplicate codemod in .map callbacks
+		return window.confirm(singleDuplicatedSequenceMessage);
+	}
+
+	const multipleDuplicatedSequencesMessage =
+		duplicatedNodePathInfos.length +
+		' selected sequences are programmatically duplicated in the code. Duplicating inserts another copy of each. Continue?';
+	// eslint-disable-next-line no-alert -- native confirm before applying duplicate codemod in .map callbacks
+	return window.confirm(multipleDuplicatedSequencesMessage);
+};
+
+const duplicateSequences = (
+	nodePathInfos: readonly SequenceNodePathInfo[],
+): Promise<void> => {
+	if (!confirmDuplicatingProgrammaticallyDuplicatedSequences(nodePathInfos)) {
+		return Promise.resolve();
+	}
+
+	return Promise.all(
+		nodePathInfos.map((nodePathInfo) => {
+			const nodePath = nodePathInfo.sequenceSubscriptionKey;
+
+			return callApi('/api/duplicate-jsx-node', {
+				fileName: nodePath.absolutePath,
+				nodePath: nodePath.nodePath,
+			});
+		}),
+	)
+		.then((results) => {
+			const failedResult = results.find((result) => !result.success);
+			if (failedResult) {
+				showNotification(failedResult.reason, 4000);
+				return;
+			}
+
+			showNotification(
+				nodePathInfos.length === 1
+					? 'Duplicated sequence in source file'
+					: 'Duplicated sequences in source files',
+				2000,
+			);
+		})
+		.catch((err) => {
+			showNotification((err as Error).message, 4000);
+		});
+};
+
+export const isDuplicatableSequenceRowSelection = (
+	selection: TimelineSelection,
+): selection is TimelineSelection & {
+	type: 'row';
+} =>
+	selection.type === 'row' && selection.nodePathInfo.auxiliaryKeys.length === 0;
+
+export const duplicateSelectedTimelineItems = ({
+	selections,
+}: {
+	selections: readonly TimelineSelection[];
+}): Promise<void> | null => {
+	const sequenceSelections = selections.filter(
+		isDuplicatableSequenceRowSelection,
+	);
+	if (sequenceSelections.length === 0) {
+		return null;
+	}
+
+	return duplicateSequences(
+		sequenceSelections.map((selection) => selection.nodePathInfo),
+	);
+};

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from 'bun:test';
 import type {SequenceNodePath, SequencePropsSubscriptionKey} from 'remotion';
+import {isDuplicatableSequenceRowSelection} from '../components/Timeline/duplicate-selected-timeline-item';
 import {
 	ENABLE_OUTLINES,
 	getSelectableTimelineSequenceSelections,
@@ -48,6 +49,28 @@ test('Cmd+A selection only targets selectable timeline sequences', () => {
 			{nodePathInfo: sequenceNodePathInfo},
 			{nodePathInfo: effectNodePathInfo},
 		]),
+	).toEqual([
+		{
+			type: 'row',
+			nodePathInfo: sequenceNodePathInfo,
+		},
+	]);
+});
+
+test('Cmd+D only duplicates selected timeline sequence rows', () => {
+	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const effectNodePathInfo = makeNodePathInfo(['body', 1], ['effects', '0']);
+
+	expect(
+		[
+			{type: 'row' as const, nodePathInfo: sequenceNodePathInfo},
+			{type: 'row' as const, nodePathInfo: effectNodePathInfo},
+			{
+				type: 'keyframe' as const,
+				nodePathInfo: sequenceNodePathInfo,
+				frame: 12,
+			},
+		].filter(isDuplicatableSequenceRowSelection),
 	).toEqual([
 		{
 			type: 'row',


### PR DESCRIPTION
## What changed
- Added Cmd/Ctrl+D handling for selected timeline sequence rows.
- Reused the existing duplicate JSX node API and notification behavior for source-file duplication.
- Added coverage to ensure Cmd+D only targets sequence rows, not keyframes or nested effect/property rows.

## Why it changed
This adds the requested keyboard path for duplicating a sequence from the timeline, matching the existing source-level duplicate action.

Fixes #7849

## Tests run
- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run formatting` in `packages/studio`
- `bun run lint -- src/components/Timeline/TimelineDeleteKeybindings.tsx src/components/Timeline/duplicate-selected-timeline-item.ts src/test/timeline-selection.test.ts` in `packages/studio` (passes with existing warnings elsewhere in `src`)
- `bun run make` in `packages/studio`