### PR TITLE
`@remotion/studio`: Show keyframe controls for keyframed props

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -15,7 +15,10 @@ import {enqueueSavePropChange} from './save-prop-queue';
 import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineFieldLabel} from './TimelineFieldLabel';
-import {TimelineKeyframeControls} from './TimelineKeyframeControls';
+import {
+	shouldShowTimelineKeyframeControls,
+	TimelineKeyframeControls,
+} from './TimelineKeyframeControls';
 import {TimelineKeyframedValue} from './TimelineKeyframedValue';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
@@ -268,8 +271,10 @@ export const TimelineEffectFieldRow: React.FC<{
 
 	const keyframeControls =
 		propStatus !== null &&
-		(selection.selected ||
-			(!propStatus.canUpdate && propStatus.reason === 'keyframed')) ? (
+		shouldShowTimelineKeyframeControls({
+			propStatus,
+			selected: selection.selected,
+		}) ? (
 			<TimelineKeyframeControls
 				fieldKey={field.key}
 				propStatus={propStatus}

--- a/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectFieldRow.tsx
@@ -267,7 +267,9 @@ export const TimelineEffectFieldRow: React.FC<{
 	}, [getEffectDragOverrides, nodePath, field.effectIndex, field.key]);
 
 	const keyframeControls =
-		selection.selected && propStatus !== null ? (
+		propStatus !== null &&
+		(selection.selected ||
+			(!propStatus.canUpdate && propStatus.reason === 'keyframed')) ? (
 			<TimelineKeyframeControls
 				fieldKey={field.key}
 				propStatus={propStatus}

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -21,6 +21,7 @@ import {
 	hasKeyframeAtSourceFrame,
 } from './get-keyframe-navigation';
 import {getTimelineKeyframes} from './get-timeline-keyframes';
+import {SELECTION_ENABLED} from './TimelineSelection';
 
 const controlsContainerStyle: React.CSSProperties = {
 	alignItems: 'center',
@@ -84,6 +85,28 @@ const getCurrentKeyframeValue = ({
 	}
 
 	return null;
+};
+
+export const shouldShowTimelineKeyframeControls = ({
+	propStatus,
+	selected,
+}: {
+	propStatus: CanUpdateSequencePropStatus | null;
+	selected: boolean;
+}): boolean => {
+	if (propStatus === null) {
+		return false;
+	}
+
+	if (selected) {
+		return true;
+	}
+
+	return (
+		SELECTION_ENABLED &&
+		!propStatus.canUpdate &&
+		propStatus.reason === 'keyframed'
+	);
 };
 
 export const TimelineKeyframeControls: React.FC<{

--- a/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
@@ -184,7 +184,9 @@ export const TimelineSequenceFieldRow: React.FC<{
 	}, [getDragOverrides, nodePath, field.key]);
 
 	const keyframeControls =
-		selection.selected && codeValue !== null ? (
+		codeValue !== null &&
+		(selection.selected ||
+			(!codeValue.canUpdate && codeValue.reason === 'keyframed')) ? (
 			<TimelineKeyframeControls
 				fieldKey={field.key}
 				propStatus={codeValue}

--- a/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceFieldRow.tsx
@@ -19,7 +19,10 @@ import {saveSequenceProp} from './save-sequence-prop';
 import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineFieldLabel} from './TimelineFieldLabel';
-import {TimelineKeyframeControls} from './TimelineKeyframeControls';
+import {
+	shouldShowTimelineKeyframeControls,
+	TimelineKeyframeControls,
+} from './TimelineKeyframeControls';
 import {TimelineKeyframedValue} from './TimelineKeyframedValue';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
@@ -185,8 +188,10 @@ export const TimelineSequenceFieldRow: React.FC<{
 
 	const keyframeControls =
 		codeValue !== null &&
-		(selection.selected ||
-			(!codeValue.canUpdate && codeValue.reason === 'keyframed')) ? (
+		shouldShowTimelineKeyframeControls({
+			propStatus: codeValue,
+			selected: selection.selected,
+		}) ? (
 			<TimelineKeyframeControls
 				fieldKey={field.key}
 				propStatus={codeValue}


### PR DESCRIPTION
## Summary
- show timeline keyframe left / diamond / right controls when the field is selected
- also show those controls when the prop status is already `keyframed`, even if the row is not selected
- apply the behavior for both sequence field rows and effect field rows

Fixes #7848