### PR TITLE
`@remotion/studio`: Add Shift/Cmd timeline multi-select

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
@@ -56,7 +56,10 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 		(e: React.PointerEvent<HTMLButtonElement>) => {
 			if (e.button === 0) {
 				e.stopPropagation();
-				onSelect();
+				onSelect({
+					shiftKey: e.shiftKey,
+					toggleKey: e.metaKey || e.ctrlKey,
+				});
 			}
 		},
 		[onSelect],

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -6,6 +6,7 @@ import {
 	TIMELINE_ROW_BASE_PADDING,
 	getTimelineRowIndentWidth,
 } from './timeline-row-layout';
+import type {TimelineSelectionInteraction} from './TimelineSelection';
 import {TIMELINE_SELECTED_BACKGROUND} from './TimelineSelection';
 
 const rowBase: React.CSSProperties = {
@@ -38,7 +39,7 @@ export const TimelineRowChrome: React.FC<{
 	readonly style: React.CSSProperties;
 	readonly selected: boolean;
 	readonly selectable: boolean;
-	readonly onSelect: () => void;
+	readonly onSelect: (interaction?: TimelineSelectionInteraction) => void;
 	readonly showSelectedBackground: boolean;
 	readonly containsSelection: boolean;
 	// When set, the chrome is wrapped in an outer container of this height with a
@@ -78,7 +79,10 @@ export const TimelineRowChrome: React.FC<{
 		(e: React.PointerEvent<HTMLDivElement>) => {
 			if (e.button === 0) {
 				e.stopPropagation();
-				onSelect();
+				onSelect({
+					shiftKey: e.shiftKey,
+					toggleKey: e.metaKey || e.ctrlKey,
+				});
 			}
 		},
 		[onSelect],

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -74,12 +74,151 @@ export type TimelineSelection =
 			readonly frame: number;
 	  };
 
+export type TimelineSelectionInteraction = {
+	readonly shiftKey: boolean;
+	readonly toggleKey: boolean;
+};
+
+export type TimelineSelectionState = {
+	readonly selectedItems: readonly TimelineSelection[];
+	readonly anchor: TimelineSelection | null;
+};
+
+const getTimelineSelectionType = (item: TimelineSelection) => item.type;
+
+const getTimelineSelectionAnchor = (
+	selectedItems: readonly TimelineSelection[],
+	previousAnchor: TimelineSelection | null,
+	targetType: TimelineSelection['type'],
+) => {
+	if (
+		previousAnchor &&
+		getTimelineSelectionType(previousAnchor) === targetType
+	) {
+		return previousAnchor;
+	}
+
+	for (let i = selectedItems.length - 1; i >= 0; i--) {
+		const candidate = selectedItems[i];
+		if (getTimelineSelectionType(candidate) === targetType) {
+			return candidate;
+		}
+	}
+
+	return null;
+};
+
+const getRangeSelection = ({
+	anchor,
+	clickedItem,
+	allSelectableItems,
+}: {
+	readonly anchor: TimelineSelection;
+	readonly clickedItem: TimelineSelection;
+	readonly allSelectableItems: readonly TimelineSelection[];
+}): readonly TimelineSelection[] => {
+	const anchorKey = getTimelineSelectionKey(anchor);
+	const clickedKey = getTimelineSelectionKey(clickedItem);
+	const orderedOfType = allSelectableItems.filter(
+		(item) => getTimelineSelectionType(item) === clickedItem.type,
+	);
+	const anchorIndex = orderedOfType.findIndex(
+		(item) => getTimelineSelectionKey(item) === anchorKey,
+	);
+	const clickedIndex = orderedOfType.findIndex(
+		(item) => getTimelineSelectionKey(item) === clickedKey,
+	);
+
+	if (anchorIndex === -1 || clickedIndex === -1) {
+		return [clickedItem];
+	}
+
+	const [from, to] =
+		anchorIndex < clickedIndex
+			? [anchorIndex, clickedIndex]
+			: [clickedIndex, anchorIndex];
+	return orderedOfType.slice(from, to + 1);
+};
+
+export const getTimelineSelectionAfterInteraction = ({
+	currentState,
+	clickedItem,
+	interaction,
+	allSelectableItems,
+}: {
+	readonly currentState: TimelineSelectionState;
+	readonly clickedItem: TimelineSelection;
+	readonly interaction: TimelineSelectionInteraction;
+	readonly allSelectableItems: readonly TimelineSelection[];
+}): TimelineSelectionState => {
+	const {selectedItems, anchor: previousAnchor} = currentState;
+	const clickedType = getTimelineSelectionType(clickedItem);
+	const nextAnchor = getTimelineSelectionAnchor(
+		selectedItems,
+		previousAnchor,
+		clickedType,
+	);
+	const clickedKey = getTimelineSelectionKey(clickedItem);
+
+	if (interaction.shiftKey && nextAnchor) {
+		return {
+			selectedItems: getRangeSelection({
+				anchor: nextAnchor,
+				clickedItem,
+				allSelectableItems,
+			}),
+			anchor: nextAnchor,
+		};
+	}
+
+	if (interaction.toggleKey) {
+		const sameTypeItems = selectedItems.filter(
+			(item) => getTimelineSelectionType(item) === clickedType,
+		);
+		const existingKeySet = new Set(sameTypeItems.map(getTimelineSelectionKey));
+		if (existingKeySet.has(clickedKey)) {
+			const nextSelection = sameTypeItems.filter(
+				(item) => getTimelineSelectionKey(item) !== clickedKey,
+			);
+			return {
+				selectedItems: nextSelection,
+				anchor: nextSelection.length === 0 ? null : clickedItem,
+			};
+		}
+
+		const selectableOrderMap = new Map(
+			allSelectableItems
+				.filter((item) => getTimelineSelectionType(item) === clickedType)
+				.map((item, index) => [getTimelineSelectionKey(item), index] as const),
+		);
+		const nextSelection = [...sameTypeItems, clickedItem].sort((a, b) => {
+			return (
+				(selectableOrderMap.get(getTimelineSelectionKey(a)) ?? 0) -
+				(selectableOrderMap.get(getTimelineSelectionKey(b)) ?? 0)
+			);
+		});
+		return {
+			selectedItems: nextSelection,
+			anchor: clickedItem,
+		};
+	}
+
+	return {
+		selectedItems: [clickedItem],
+		anchor: clickedItem,
+	};
+};
+
 type TimelineSelectionContextValue = {
 	readonly canSelect: boolean;
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly isSelected: (item: TimelineSelection) => boolean;
-	readonly selectItem: (item: TimelineSelection) => void;
+	readonly selectItem: (
+		item: TimelineSelection,
+		interaction?: TimelineSelectionInteraction,
+	) => void;
 	readonly selectItems: (items: readonly TimelineSelection[]) => void;
+	readonly registerSelectableItem: (item: TimelineSelection) => () => void;
 	readonly containsSelection: (nodePathInfo: SequenceNodePathInfo) => boolean;
 	readonly clearSelection: () => void;
 };
@@ -90,6 +229,7 @@ const defaultTimelineSelectionContextValue: TimelineSelectionContextValue = {
 	isSelected: () => false,
 	selectItem: () => undefined,
 	selectItems: () => undefined,
+	registerSelectableItem: () => () => undefined,
 	containsSelection: () => false,
 	clearSelection: () => undefined,
 };
@@ -212,6 +352,10 @@ export const TimelineSelectionProvider: React.FC<{
 	const [selectedItems, setSelectedItems] = useState<
 		readonly TimelineSelection[]
 	>([]);
+	const selectionAnchor = useRef<TimelineSelection | null>(null);
+	const selectableItemsOrder = useRef(new Map<string, number>());
+	const selectableItems = useRef(new Map<string, TimelineSelection>());
+	const registrationCounter = useRef(0);
 
 	useEffect(() => {
 		if (!canSelect) {
@@ -232,12 +376,40 @@ export const TimelineSelectionProvider: React.FC<{
 	);
 
 	const selectItem = useCallback(
-		(item: TimelineSelection) => {
+		(
+			item: TimelineSelection,
+			interaction: TimelineSelectionInteraction = {
+				shiftKey: false,
+				toggleKey: false,
+			},
+		) => {
 			if (!canSelect) {
 				return;
 			}
 
-			setSelectedItems([item]);
+			setSelectedItems((currentSelection) => {
+				const orderedSelectableItems = [
+					...selectableItems.current.values(),
+				].sort((a, b) => {
+					return (
+						(selectableItemsOrder.current.get(getTimelineSelectionKey(a)) ??
+							0) -
+						(selectableItemsOrder.current.get(getTimelineSelectionKey(b)) ?? 0)
+					);
+				});
+
+				const nextState = getTimelineSelectionAfterInteraction({
+					currentState: {
+						selectedItems: currentSelection,
+						anchor: selectionAnchor.current,
+					},
+					clickedItem: item,
+					interaction,
+					allSelectableItems: orderedSelectableItems,
+				});
+				selectionAnchor.current = nextState.anchor;
+				return nextState.selectedItems;
+			});
 		},
 		[canSelect],
 	);
@@ -248,12 +420,27 @@ export const TimelineSelectionProvider: React.FC<{
 				return;
 			}
 
+			selectionAnchor.current =
+				items.length === 0 ? null : items[items.length - 1];
 			setSelectedItems(items);
 		},
 		[canSelect],
 	);
 
+	const registerSelectableItem = useCallback((item: TimelineSelection) => {
+		const key = getTimelineSelectionKey(item);
+		const registrationOrder = registrationCounter.current;
+		registrationCounter.current += 1;
+		selectableItems.current.set(key, item);
+		selectableItemsOrder.current.set(key, registrationOrder);
+		return () => {
+			selectableItems.current.delete(key);
+			selectableItemsOrder.current.delete(key);
+		};
+	}, []);
+
 	const clearSelection = useCallback(() => {
+		selectionAnchor.current = null;
 		setSelectedItems([]);
 	}, []);
 
@@ -273,6 +460,7 @@ export const TimelineSelectionProvider: React.FC<{
 			isSelected,
 			selectItem,
 			selectItems,
+			registerSelectableItem,
 			containsSelection,
 			clearSelection,
 		}),
@@ -282,6 +470,7 @@ export const TimelineSelectionProvider: React.FC<{
 			isSelected,
 			selectItem,
 			selectItems,
+			registerSelectableItem,
 			containsSelection,
 			clearSelection,
 		],
@@ -317,22 +506,34 @@ export const useCurrentTimelineSelectionStateAsRef = () => {
 export const useTimelineRowSelection = (
 	nodePathInfo: SequenceNodePathInfo | null,
 ) => {
-	const {canSelect, isSelected, selectItem} = useTimelineSelection();
+	const {canSelect, isSelected, selectItem, registerSelectableItem} =
+		useTimelineSelection();
 	const selectionItem = useMemo(
 		(): TimelineSelection | null =>
 			nodePathInfo === null ? null : {type: 'row', nodePathInfo},
 		[nodePathInfo],
 	);
 
-	const selected = selectionItem === null ? false : isSelected(selectionItem);
-
-	const onSelect = useCallback(() => {
+	useEffect(() => {
 		if (selectionItem === null) {
 			return;
 		}
 
-		selectItem(selectionItem);
-	}, [selectItem, selectionItem]);
+		return registerSelectableItem(selectionItem);
+	}, [registerSelectableItem, selectionItem]);
+
+	const selected = selectionItem === null ? false : isSelected(selectionItem);
+
+	const onSelect = useCallback(
+		(interaction?: TimelineSelectionInteraction) => {
+			if (selectionItem === null) {
+				return;
+			}
+
+			selectItem(selectionItem, interaction);
+		},
+		[selectItem, selectionItem],
+	);
 
 	return {
 		onSelect,
@@ -345,7 +546,8 @@ export const useTimelineKeyframeSelection = (
 	nodePathInfo: SequenceNodePathInfo,
 	frame: number,
 ) => {
-	const {canSelect, isSelected, selectItem} = useTimelineSelection();
+	const {canSelect, isSelected, selectItem, registerSelectableItem} =
+		useTimelineSelection();
 	const selectionItem = useMemo(
 		(): TimelineSelection => ({
 			type: 'keyframe',
@@ -355,11 +557,18 @@ export const useTimelineKeyframeSelection = (
 		[nodePathInfo, frame],
 	);
 
+	useEffect(() => {
+		return registerSelectableItem(selectionItem);
+	}, [registerSelectableItem, selectionItem]);
+
 	const selected = isSelected(selectionItem);
 
-	const onSelect = useCallback(() => {
-		selectItem(selectionItem);
-	}, [selectItem, selectionItem]);
+	const onSelect = useCallback(
+		(interaction?: TimelineSelectionInteraction) => {
+			selectItem(selectionItem, interaction);
+		},
+		[selectItem, selectionItem],
+	);
 
 	return {
 		onSelect,

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -59,9 +59,9 @@ export const getTimelineSelectedTrackHighlightStyle = (
 	width: timelineWidth,
 });
 
-export const SELECTION_ENABLED = false;
-export const TIMELINE_TOP_DRAG = false;
-export const ENABLE_OUTLINES = false;
+export const SELECTION_ENABLED = true;
+export const TIMELINE_TOP_DRAG = true;
+export const ENABLE_OUTLINES = true;
 
 export type TimelineSelection =
 	| {
@@ -177,12 +177,12 @@ export const getTimelineSelectionAfterInteraction = ({
 		);
 		const existingKeySet = new Set(sameTypeItems.map(getTimelineSelectionKey));
 		if (existingKeySet.has(clickedKey)) {
-			const nextSelection = sameTypeItems.filter(
+			const toggledSelection = sameTypeItems.filter(
 				(item) => getTimelineSelectionKey(item) !== clickedKey,
 			);
 			return {
-				selectedItems: nextSelection,
-				anchor: nextSelection.length === 0 ? null : clickedItem,
+				selectedItems: toggledSelection,
+				anchor: toggledSelection.length === 0 ? null : clickedItem,
 			};
 		}
 
@@ -191,14 +191,14 @@ export const getTimelineSelectionAfterInteraction = ({
 				.filter((item) => getTimelineSelectionType(item) === clickedType)
 				.map((item, index) => [getTimelineSelectionKey(item), index] as const),
 		);
-		const nextSelection = [...sameTypeItems, clickedItem].sort((a, b) => {
+		const extendedSelection = [...sameTypeItems, clickedItem].sort((a, b) => {
 			return (
 				(selectableOrderMap.get(getTimelineSelectionKey(a)) ?? 0) -
 				(selectableOrderMap.get(getTimelineSelectionKey(b)) ?? 0)
 			);
 		});
 		return {
-			selectedItems: nextSelection,
+			selectedItems: extendedSelection,
 			anchor: clickedItem,
 		};
 	}
@@ -387,7 +387,7 @@ export const TimelineSelectionProvider: React.FC<{
 				return;
 			}
 
-			setSelectedItems((currentSelection) => {
+			setSelectedItems((currentSelectedItems) => {
 				const orderedSelectableItems = [
 					...selectableItems.current.values(),
 				].sort((a, b) => {
@@ -400,7 +400,7 @@ export const TimelineSelectionProvider: React.FC<{
 
 				const nextState = getTimelineSelectionAfterInteraction({
 					currentState: {
-						selectedItems: currentSelection,
+						selectedItems: currentSelectedItems,
 						anchor: selectionAnchor.current,
 					},
 					clickedItem: item,

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -59,9 +59,9 @@ export const getTimelineSelectedTrackHighlightStyle = (
 	width: timelineWidth,
 });
 
-export const SELECTION_ENABLED = true;
-export const TIMELINE_TOP_DRAG = true;
-export const ENABLE_OUTLINES = true;
+export const SELECTION_ENABLED = false;
+export const TIMELINE_TOP_DRAG = false;
+export const ENABLE_OUTLINES = false;
 
 export type TimelineSelection =
 	| {

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -66,7 +66,10 @@ const TimelineSequenceCurrentFrame: React.FC<{
 		(e: React.PointerEvent<HTMLDivElement>) => {
 			if (e.button === 0) {
 				e.stopPropagation();
-				onSelect();
+				onSelect({
+					shiftKey: e.shiftKey,
+					toggleKey: e.metaKey || e.ctrlKey,
+				});
 			}
 		},
 		[onSelect],

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -4,6 +4,7 @@ import {isDuplicatableSequenceRowSelection} from '../components/Timeline/duplica
 import {
 	ENABLE_OUTLINES,
 	getSelectableTimelineSequenceSelections,
+	getTimelineSelectionAfterInteraction,
 	getTimelineSequenceSelectionKey,
 	SELECTION_ENABLED,
 	TIMELINE_TOP_DRAG,
@@ -93,4 +94,104 @@ test('Child timeline selections resolve to the parent sequence selection key', (
 	expect(getTimelineSequenceSelectionKey(propNodePathInfo)).toBe(
 		getTimelineSequenceSelectionKey(sequenceNodePathInfo),
 	);
+});
+
+test('Cmd/Ctrl+click toggles row selections', () => {
+	const rowA = {
+		type: 'row' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], []),
+	};
+	const rowB = {
+		type: 'row' as const,
+		nodePathInfo: makeNodePathInfo(['body', 1], []),
+	};
+	const allSelectableItems = [rowA, rowB];
+
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [rowA],
+				anchor: rowA,
+			},
+			clickedItem: rowB,
+			interaction: {shiftKey: false, toggleKey: true},
+			allSelectableItems,
+		}),
+	).toEqual({
+		selectedItems: [rowA, rowB],
+		anchor: rowB,
+	});
+
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [rowA, rowB],
+				anchor: rowB,
+			},
+			clickedItem: rowA,
+			interaction: {shiftKey: false, toggleKey: true},
+			allSelectableItems,
+		}),
+	).toEqual({
+		selectedItems: [rowB],
+		anchor: rowA,
+	});
+});
+
+test('Shift+click selects a contiguous row range from the anchor', () => {
+	const rowA = {
+		type: 'row' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], []),
+	};
+	const rowB = {
+		type: 'row' as const,
+		nodePathInfo: makeNodePathInfo(['body', 1], []),
+	};
+	const rowC = {
+		type: 'row' as const,
+		nodePathInfo: makeNodePathInfo(['body', 2], []),
+	};
+	const allSelectableItems = [rowA, rowB, rowC];
+
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [rowA],
+				anchor: rowA,
+			},
+			clickedItem: rowC,
+			interaction: {shiftKey: true, toggleKey: false},
+			allSelectableItems,
+		}),
+	).toEqual({
+		selectedItems: [rowA, rowB, rowC],
+		anchor: rowA,
+	});
+});
+
+test('Shift+click with no matching anchor falls back to single selection', () => {
+	const rowA = {
+		type: 'row' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], []),
+	};
+	const keyframe = {
+		type: 'keyframe' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], []),
+		frame: 10,
+	};
+
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [keyframe],
+				anchor: keyframe,
+			},
+			clickedItem: rowA,
+			interaction: {shiftKey: true, toggleKey: false},
+			allSelectableItems: [rowA],
+		}),
+	).toEqual({
+		selectedItems: [rowA],
+		anchor: rowA,
+	});
 });


### PR DESCRIPTION
## Summary
- add modifier-aware timeline selection interactions for rows and keyframes
- implement **Shift+click** contiguous range selection using registered visible timeline items
- implement **Cmd/Ctrl+click** toggle selection behavior
- keep selection constrained to one item type at a time (row or keyframe)
- wire pointer handlers to pass modifier state into selection logic
- add unit tests covering range/toggle and mixed-type fallback behavior

## Notes
- if the current anchor type does not match the clicked item type, Shift+click falls back to selecting only the clicked item

Closes #7800