### PR TITLE
`@remotion/webcontainer-studio`: Add new package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2523,6 +2523,23 @@
         "vite": "6.4.2",
       },
     },
+    "packages/webcontainer-studio": {
+      "name": "@remotion/webcontainer-studio",
+      "version": "4.0.469",
+      "dependencies": {
+        "@webcontainer/api": "1.6.0",
+        "react": "catalog:",
+        "react-dom": "catalog:",
+      },
+      "devDependencies": {
+        "@types/react": "catalog:",
+        "@types/react-dom": "catalog:",
+        "@vitejs/plugin-react": "catalog:",
+        "eslint": "catalog:",
+        "typescript": "5.9.3",
+        "vite": "6.4.2",
+      },
+    },
     "packages/whisper-web": {
       "name": "@remotion/whisper-web",
       "version": "4.0.469",
@@ -4067,6 +4084,8 @@
 
     "@remotion/webcodecs": ["@remotion/webcodecs@workspace:packages/webcodecs"],
 
+    "@remotion/webcontainer-studio": ["@remotion/webcontainer-studio@workspace:packages/webcontainer-studio"],
+
     "@remotion/whisper-web": ["@remotion/whisper-web@workspace:packages/whisper-web"],
 
     "@remotion/zod-types": ["@remotion/zod-types@workspace:packages/zod-types"],
@@ -5066,6 +5085,8 @@
     "@webassemblyjs/wasm-parser": ["@webassemblyjs/wasm-parser@1.14.1", "", { "dependencies": { "@webassemblyjs/ast": "1.14.1", "@webassemblyjs/helper-api-error": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2", "@webassemblyjs/ieee754": "1.13.2", "@webassemblyjs/leb128": "1.13.2", "@webassemblyjs/utf8": "1.13.2" } }, "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ=="],
 
     "@webassemblyjs/wast-printer": ["@webassemblyjs/wast-printer@1.14.1", "", { "dependencies": { "@webassemblyjs/ast": "1.14.1", "@xtuc/long": "4.2.2" } }, "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw=="],
+
+    "@webcontainer/api": ["@webcontainer/api@1.6.0", "", {}, "sha512-U3v9Tc3aFJPQh5J5LPXfHTNJrgJRQofQCOkUFVifOY5J5nPEi3GsrXDlCSYXOMpvMDZXwL7kBVmXEzr0Q0Dbtg=="],
 
     "@webgpu/types": ["@webgpu/types@0.1.21", "", {}, "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="],
 

--- a/packages/webcontainer-studio/README.md
+++ b/packages/webcontainer-studio/README.md
@@ -1,0 +1,30 @@
+# @remotion/webcontainer-studio
+
+Run Remotion Studio entirely in the browser using [WebContainers](https://webcontainers.io).
+
+## How it works
+
+1. Boots a Node.js WebContainer inside the browser tab
+2. Mounts the Remotion blank template files
+3. Runs `npm install`
+4. Starts `remotion studio`
+5. Embeds the Studio in an iframe
+
+## Development
+
+```bash
+bun run dev
+```
+
+Opens at http://localhost:3100.
+
+## Requirements
+
+The page must be served with:
+
+```
+Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Opener-Policy: same-origin
+```
+
+These headers are automatically set by the Vite dev server via `vite.config.ts`.

--- a/packages/webcontainer-studio/eslint.config.mjs
+++ b/packages/webcontainer-studio/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { remotionFlatConfig } from "@remotion/eslint-config-flat";
+
+export default remotionFlatConfig({ react: true });

--- a/packages/webcontainer-studio/index.html
+++ b/packages/webcontainer-studio/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Remotion Studio — WebContainer</title>
+		<style>
+			* {
+				box-sizing: border-box;
+			}
+			html,
+			body,
+			#root {
+				margin: 0;
+				padding: 0;
+				height: 100%;
+				width: 100%;
+				background: #0f0f0f;
+				color: #fff;
+				font-family:
+					-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
+</html>

--- a/packages/webcontainer-studio/package.json
+++ b/packages/webcontainer-studio/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@remotion/webcontainer-studio",
+	"version": "4.0.469",
+	"private": true,
+	"type": "module",
+	"description": "Run Remotion Studio in the browser using WebContainers",
+	"author": "Jonny Burger <jonny@remotion.dev>",
+	"repository": {
+		"url": "https://github.com/remotion-dev/remotion/tree/main/packages/webcontainer-studio"
+	},
+	"homepage": "https://webcontainer-studio.remotion.dev",
+	"scripts": {
+		"dev": "vite",
+		"build": "vite build",
+		"preview": "vite preview",
+		"lint": "eslint src",
+		"typecheck": "tsc"
+	},
+	"dependencies": {
+		"@webcontainer/api": "1.6.0",
+		"react": "catalog:",
+		"react-dom": "catalog:"
+	},
+	"devDependencies": {
+		"@types/react": "catalog:",
+		"@types/react-dom": "catalog:",
+		"@vitejs/plugin-react": "catalog:",
+		"eslint": "catalog:",
+		"typescript": "5.9.3",
+		"vite": "6.4.2"
+	}
+}

--- a/packages/webcontainer-studio/src/App.tsx
+++ b/packages/webcontainer-studio/src/App.tsx
@@ -1,0 +1,148 @@
+import {useWebContainerStudio} from './use-web-container-studio';
+
+const styles = {
+	container: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		height: '100%',
+		width: '100%',
+	},
+	header: {
+		padding: '12px 20px',
+		background: '#1a1a1a',
+		borderBottom: '1px solid #333',
+		display: 'flex',
+		alignItems: 'center',
+		gap: '10px',
+	},
+	logo: {
+		fontSize: '16px',
+		fontWeight: 700,
+		color: '#fff',
+	},
+	badge: {
+		fontSize: '11px',
+		background: '#0B84F3',
+		color: '#fff',
+		padding: '2px 8px',
+		borderRadius: '12px',
+	},
+	main: {
+		flex: 1,
+		position: 'relative' as const,
+		overflow: 'hidden',
+	},
+	iframe: {
+		width: '100%',
+		height: '100%',
+		border: 'none',
+	},
+	overlay: {
+		position: 'absolute' as const,
+		inset: 0,
+		display: 'flex',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
+		justifyContent: 'center',
+		padding: '40px',
+	},
+	statusTitle: {
+		fontSize: '20px',
+		fontWeight: 600,
+		marginBottom: '8px',
+	},
+	statusSub: {
+		fontSize: '14px',
+		color: '#888',
+		marginBottom: '24px',
+	},
+	terminal: {
+		background: '#111',
+		border: '1px solid #333',
+		borderRadius: '8px',
+		padding: '16px',
+		width: '100%',
+		maxWidth: '640px',
+		maxHeight: '300px',
+		overflow: 'auto',
+		fontFamily: 'monospace',
+		fontSize: '12px',
+		color: '#aaa',
+		whiteSpace: 'pre-wrap' as const,
+		wordBreak: 'break-all' as const,
+	},
+	spinner: {
+		width: '40px',
+		height: '40px',
+		border: '3px solid #333',
+		borderTop: '3px solid #0B84F3',
+		borderRadius: '50%',
+		animation: 'spin 1s linear infinite',
+		marginBottom: '20px',
+	},
+	errorBox: {
+		background: '#2a0a0a',
+		border: '1px solid #6b2121',
+		borderRadius: '8px',
+		padding: '16px',
+		maxWidth: '640px',
+		fontFamily: 'monospace',
+		fontSize: '13px',
+		color: '#f87171',
+	},
+};
+
+const phaseLabels: Record<string, string> = {
+	booting: 'Booting WebContainer…',
+	mounting: 'Mounting Remotion template…',
+	installing: 'Running npm install…',
+	starting: 'Starting Remotion Studio…',
+};
+
+export function App() {
+	const {phase} = useWebContainerStudio();
+
+	return (
+		<div style={styles.container}>
+			<style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+			<header style={styles.header}>
+				<span style={styles.logo}>🎬 Remotion Studio</span>
+				<span style={styles.badge}>WebContainer</span>
+			</header>
+			<main style={styles.main}>
+				{phase.type === 'ready' ? (
+					<iframe
+						src={phase.url}
+						style={styles.iframe}
+						title="Remotion Studio"
+					/>
+				) : (
+					<div style={styles.overlay}>
+						{phase.type === 'error' ? (
+							<>
+								<div style={{...styles.statusTitle, color: '#f87171'}}>
+									Something went wrong
+								</div>
+								<div style={styles.errorBox}>{phase.message}</div>
+							</>
+						) : (
+							<>
+								<div style={styles.spinner} />
+								<div style={styles.statusTitle}>
+									{phaseLabels[phase.type] ?? 'Loading…'}
+								</div>
+								{phase.type === 'installing' && phase.output ? (
+									<pre style={styles.terminal}>{phase.output}</pre>
+								) : (
+									<div style={styles.statusSub}>
+										Please wait, this may take a minute
+									</div>
+								)}
+							</>
+						)}
+					</div>
+				)}
+			</main>
+		</div>
+	);
+}

--- a/packages/webcontainer-studio/src/main.tsx
+++ b/packages/webcontainer-studio/src/main.tsx
@@ -1,0 +1,12 @@
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import {App} from './App';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('No #root element');
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>,
+);

--- a/packages/webcontainer-studio/src/template-files.ts
+++ b/packages/webcontainer-studio/src/template-files.ts
@@ -1,0 +1,110 @@
+import type {FileSystemTree} from '@webcontainer/api';
+
+/**
+ * The files for the Remotion blank template, prepared for mounting
+ * into a WebContainer. Uses published npm versions instead of workspace:*.
+ */
+export const REMOTION_VERSION = '4.0.469';
+
+export const templateFiles: FileSystemTree = {
+	'package.json': {
+		file: {
+			contents: JSON.stringify(
+				{
+					name: 'remotion-webcontainer',
+					version: '1.0.0',
+					description: 'My Remotion video',
+					scripts: {
+						dev: 'remotion studio --log=verbose',
+						build: 'remotion bundle',
+					},
+					dependencies: {
+						'@remotion/cli': REMOTION_VERSION,
+						react: '19.2.3',
+						'react-dom': '19.2.3',
+						remotion: REMOTION_VERSION,
+					},
+					devDependencies: {
+						'@types/react': '19.2.7',
+						typescript: '5.9.3',
+					},
+				},
+				null,
+				2,
+			),
+		},
+	},
+	'remotion.config.ts': {
+		file: {
+			contents: `import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("jpeg");
+Config.setOverwriteOutput(true);
+`,
+		},
+	},
+	'tsconfig.json': {
+		file: {
+			contents: JSON.stringify(
+				{
+					compilerOptions: {
+						target: 'ES2018',
+						module: 'commonjs',
+						jsx: 'react-jsx',
+						strict: true,
+						noEmit: true,
+						lib: ['es2015'],
+						esModuleInterop: true,
+						skipLibCheck: true,
+					},
+					exclude: ['remotion.config.ts'],
+				},
+				null,
+				2,
+			),
+		},
+	},
+	src: {
+		directory: {
+			'index.ts': {
+				file: {
+					contents: `import { registerRoot } from "remotion";
+import { RemotionRoot } from "./Root";
+
+registerRoot(RemotionRoot);
+`,
+				},
+			},
+			'Root.tsx': {
+				file: {
+					contents: `import { Composition } from "remotion";
+import { MyComposition } from "./Composition";
+
+export const RemotionRoot: React.FC = () => {
+  return (
+    <>
+      <Composition
+        id="MyComp"
+        component={MyComposition}
+        durationInFrames={60}
+        fps={30}
+        width={1280}
+        height={720}
+      />
+    </>
+  );
+};
+`,
+				},
+			},
+			'Composition.tsx': {
+				file: {
+					contents: `export const MyComposition = () => {
+  return null;
+};
+`,
+				},
+			},
+		},
+	},
+};

--- a/packages/webcontainer-studio/src/use-web-container-studio.ts
+++ b/packages/webcontainer-studio/src/use-web-container-studio.ts
@@ -1,0 +1,97 @@
+import {WebContainer} from '@webcontainer/api';
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {templateFiles} from './template-files';
+
+type Phase =
+	| {type: 'booting'}
+	| {type: 'mounting'}
+	| {type: 'installing'; output: string}
+	| {type: 'starting'}
+	| {type: 'ready'; url: string}
+	| {type: 'error'; message: string};
+
+export function useWebContainerStudio() {
+	const [phase, setPhase] = useState<Phase>({type: 'booting'});
+	const containerRef = useRef<WebContainer | null>(null);
+
+	const appendOutput = useCallback((text: string) => {
+		setPhase((prev) => {
+			if (prev.type === 'installing') {
+				return {type: 'installing', output: prev.output + text};
+			}
+
+			return {type: 'installing', output: text};
+		});
+	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		async function run() {
+			try {
+				setPhase({type: 'booting'});
+				const container = await WebContainer.boot();
+				containerRef.current = container;
+				if (cancelled) {
+					await container.teardown();
+					return;
+				}
+
+				setPhase({type: 'mounting'});
+				await container.mount(templateFiles);
+
+				setPhase({type: 'installing', output: ''});
+				const installProcess = await container.spawn('npm', ['install']);
+
+				installProcess.output.pipeTo(
+					new WritableStream({
+						write(data) {
+							appendOutput(data);
+						},
+					}),
+				);
+
+				const installExitCode = await installProcess.exit;
+				if (cancelled) return;
+				if (installExitCode !== 0) {
+					setPhase({
+						type: 'error',
+						message: `npm install failed with exit code ${installExitCode}`,
+					});
+					return;
+				}
+
+				setPhase({type: 'starting'});
+				const devProcess = await container.spawn('npm', ['run', 'dev']);
+
+				devProcess.output.pipeTo(
+					new WritableStream({
+						write(data) {
+							appendOutput(data);
+						},
+					}),
+				);
+
+				container.on('server-ready', (port, url) => {
+					if (cancelled) return;
+					setPhase({type: 'ready', url});
+				});
+			} catch (err) {
+				if (cancelled) return;
+				setPhase({
+					type: 'error',
+					message: err instanceof Error ? err.message : String(err),
+				});
+			}
+		}
+
+		run();
+
+		return () => {
+			cancelled = true;
+			containerRef.current?.teardown();
+		};
+	}, [appendOutput]);
+
+	return {phase};
+}

--- a/packages/webcontainer-studio/src/use-web-container-studio.ts
+++ b/packages/webcontainer-studio/src/use-web-container-studio.ts
@@ -1,5 +1,5 @@
 import {WebContainer} from '@webcontainer/api';
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {templateFiles} from './template-files';
 
 type Phase =
@@ -10,9 +10,18 @@ type Phase =
 	| {type: 'ready'; url: string}
 	| {type: 'error'; message: string};
 
+let webContainerPromise: Promise<WebContainer> | null = null;
+
+const getWebContainer = () => {
+	if (!webContainerPromise) {
+		webContainerPromise = WebContainer.boot();
+	}
+
+	return webContainerPromise;
+};
+
 export function useWebContainerStudio() {
 	const [phase, setPhase] = useState<Phase>({type: 'booting'});
-	const containerRef = useRef<WebContainer | null>(null);
 
 	const appendOutput = useCallback((text: string) => {
 		setPhase((prev) => {
@@ -30,12 +39,8 @@ export function useWebContainerStudio() {
 		async function run() {
 			try {
 				setPhase({type: 'booting'});
-				const container = await WebContainer.boot();
-				containerRef.current = container;
-				if (cancelled) {
-					await container.teardown();
-					return;
-				}
+				const container = await getWebContainer();
+				if (cancelled) return;
 
 				setPhase({type: 'mounting'});
 				await container.mount(templateFiles);
@@ -89,7 +94,6 @@ export function useWebContainerStudio() {
 
 		return () => {
 			cancelled = true;
-			containerRef.current?.teardown();
 		};
 	}, [appendOutput]);
 

--- a/packages/webcontainer-studio/tsconfig.json
+++ b/packages/webcontainer-studio/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ES2020",
+		"moduleResolution": "bundler",
+		"jsx": "react-jsx",
+		"strict": true,
+		"noEmit": true,
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"include": ["src"]
+}

--- a/packages/webcontainer-studio/vite.config.ts
+++ b/packages/webcontainer-studio/vite.config.ts
@@ -1,0 +1,29 @@
+import react from "@vitejs/plugin-react";
+import type { Plugin } from "vite";
+import { defineConfig } from "vite";
+
+// WebContainers require SharedArrayBuffer which needs COOP/COEP headers
+const coopCoepPlugin = (): Plugin => ({
+	name: "coop-coep-headers",
+	configureServer(server) {
+		server.middlewares.use((_req, res, next) => {
+			res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+			res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+			next();
+		});
+	},
+	configurePreviewServer(server) {
+		server.middlewares.use((_req, res, next) => {
+			res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+			res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+			next();
+		});
+	},
+});
+
+export default defineConfig({
+	plugins: [coopCoepPlugin(), react()],
+	server: {
+		port: 3100,
+	},
+});


### PR DESCRIPTION
## Summary

- Add a new `@remotion/webcontainer-studio` package that runs Remotion Studio in a browser via WebContainers.

- Boot a WebContainer, mount template files, run `npm install`, and start Studio in an iframe.

- Add Vite config with COOP/COEP headers required for SharedArrayBuffer/WebContainers.
