### PR TITLE
`@remotion/studio`: Ignore selection modifier double clicks

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineListItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineListItem.tsx
@@ -34,6 +34,7 @@ import {
 } from './TimelineMediaInfo';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {
+	isTimelineSelectionModifierEvent,
 	SELECTION_ENABLED,
 	useTimelineRowContainsSelection,
 	useTimelineRowSelection,
@@ -315,6 +316,11 @@ export const TimelineListItem: React.FC<{
 	const onShowInEditorDoubleClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
 			if (!SELECTION_ENABLED || !canOpenInEditor) {
+				return;
+			}
+
+			if (isTimelineSelectionModifierEvent(e)) {
+				e.stopPropagation();
 				return;
 			}
 

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -79,6 +79,18 @@ export type TimelineSelectionInteraction = {
 	readonly toggleKey: boolean;
 };
 
+export const isTimelineSelectionModifierEvent = ({
+	shiftKey,
+	metaKey,
+	ctrlKey,
+}: {
+	readonly shiftKey: boolean;
+	readonly metaKey: boolean;
+	readonly ctrlKey: boolean;
+}) => {
+	return shiftKey || metaKey || ctrlKey;
+};
+
 export type TimelineSelectionState = {
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly anchor: TimelineSelection | null;

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -6,6 +6,7 @@ import {
 	getSelectableTimelineSequenceSelections,
 	getTimelineSelectionAfterInteraction,
 	getTimelineSequenceSelectionKey,
+	isTimelineSelectionModifierEvent,
 	SELECTION_ENABLED,
 	TIMELINE_TOP_DRAG,
 } from '../components/Timeline/TimelineSelection';
@@ -194,4 +195,35 @@ test('Shift+click with no matching anchor falls back to single selection', () =>
 		selectedItems: [rowA],
 		anchor: rowA,
 	});
+});
+
+test('Timeline double-click actions ignore selection modifier clicks', () => {
+	expect(
+		isTimelineSelectionModifierEvent({
+			shiftKey: true,
+			metaKey: false,
+			ctrlKey: false,
+		}),
+	).toBe(true);
+	expect(
+		isTimelineSelectionModifierEvent({
+			shiftKey: false,
+			metaKey: true,
+			ctrlKey: false,
+		}),
+	).toBe(true);
+	expect(
+		isTimelineSelectionModifierEvent({
+			shiftKey: false,
+			metaKey: false,
+			ctrlKey: true,
+		}),
+	).toBe(true);
+	expect(
+		isTimelineSelectionModifierEvent({
+			shiftKey: false,
+			metaKey: false,
+			ctrlKey: false,
+		}),
+	).toBe(false);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7860.

## Summary
- Prevent timeline row double-click open behavior when Shift, Cmd, or Ctrl is held for selection interactions.
- Add focused coverage for modifier event detection in timeline selection tests.

## Testing
- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run formatting`
- `bun run stylecheck` (fails on unrelated environment tooling: missing PHP for `@remotion/lambda-php`, Go 1.22.2 for `@remotion/lambda-go` which requires Go >= 1.23)
- `bunx turbo run lint formatting --filter='@remotion/studio' --no-update-notifier`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e620fc4b-48a0-4c57-a871-36526d6949c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e620fc4b-48a0-4c57-a871-36526d6949c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

