### PR TITLE
`@remotion/studio`: Internal rename for timeline items

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -29,7 +29,7 @@ const rowLabel: React.CSSProperties = {
 	userSelect: 'none',
 };
 
-export const TimelineEffectGroupRow: React.FC<{
+export const TimelineEffectItem: React.FC<{
 	readonly label: string;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly effectIndex: number;

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -220,7 +220,7 @@ const Value: React.FC<{
 	);
 };
 
-export const TimelineEffectFieldRow: React.FC<{
+export const TimelineEffectPropItem: React.FC<{
 	readonly field: EffectSchemaFieldInfo;
 	readonly validatedLocation: CodePosition;
 	readonly rowDepth: number;

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -10,8 +10,8 @@ import {
 } from '../../helpers/timeline-layout';
 import type {GetIsExpanded} from '../ExpandedTracksProvider';
 import {getExpandedRowDepth} from './timeline-row-layout';
-import {TimelineEffectFieldRow} from './TimelineEffectFieldRow';
-import {TimelineEffectGroupRow} from './TimelineEffectGroupRow';
+import {TimelineEffectItem} from './TimelineEffectItem';
+import {TimelineEffectPropItem} from './TimelineEffectPropItem';
 import {
 	TimelineExpandArrowButton,
 	TimelineExpandArrowSpacer,
@@ -23,7 +23,7 @@ import {
 	getTimelineSelectedLabelStyle,
 	useTimelineRowSelection,
 } from './TimelineSelection';
-import {TimelineSequenceFieldRow} from './TimelineSequenceFieldRow';
+import {TimelineSequencePropItem} from './TimelineSequencePropItem';
 
 const rowLabel: React.CSSProperties = {
 	fontSize: 12,
@@ -73,7 +73,7 @@ export const TimelineExpandedRow: React.FC<{
 		if (node.effectInfo) {
 			return (
 				// A single effect
-				<TimelineEffectGroupRow
+				<TimelineEffectItem
 					label={node.label}
 					nodePathInfo={node.nodePathInfo}
 					effectIndex={node.effectInfo.effectIndex}
@@ -120,7 +120,7 @@ export const TimelineExpandedRow: React.FC<{
 	if (node.field) {
 		if (node.field.kind === 'effect-field') {
 			return (
-				<TimelineEffectFieldRow
+				<TimelineEffectPropItem
 					field={node.field}
 					validatedLocation={validatedLocation}
 					rowDepth={rowDepth}
@@ -133,7 +133,7 @@ export const TimelineExpandedRow: React.FC<{
 
 		if (node.field.kind === 'sequence-field') {
 			return (
-				<TimelineSequenceFieldRow
+				<TimelineSequencePropItem
 					field={node.field}
 					validatedLocation={validatedLocation}
 					rowDepth={rowDepth}

--- a/packages/studio/src/components/Timeline/TimelineList.tsx
+++ b/packages/studio/src/components/Timeline/TimelineList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {BACKGROUND} from '../../helpers/colors';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
-import {TimelineListItem} from './TimelineListItem';
+import {TimelineSequenceItem} from './TimelineSequenceItem';
 import {TimelineTimePadding} from './TimelineTimeIndicators';
 
 const container: React.CSSProperties = {
@@ -18,7 +18,7 @@ export const TimelineList: React.FC<{
 			{timeline.map((track) => {
 				return (
 					<div key={track.sequence.id}>
-						<TimelineListItem
+						<TimelineSequenceItem
 							key={track.sequence.id}
 							nestedDepth={track.depth}
 							sequence={track.sequence}

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -63,16 +63,34 @@ export const SELECTION_ENABLED = false;
 export const TIMELINE_TOP_DRAG = false;
 export const ENABLE_OUTLINES = false;
 
+type TimelineSelectionBase = {
+	readonly nodePathInfo: SequenceNodePathInfo;
+};
+
 export type TimelineSelection =
-	| {
-			readonly type: 'row';
-			readonly nodePathInfo: SequenceNodePathInfo;
-	  }
-	| {
+	| (TimelineSelectionBase & {
+			readonly type: 'sequence';
+	  })
+	| (TimelineSelectionBase & {
+			readonly type: 'sequence-prop';
+			readonly key: string;
+	  })
+	| (TimelineSelectionBase & {
+			readonly type: 'sequence-all-effects';
+	  })
+	| (TimelineSelectionBase & {
+			readonly type: 'sequence-effect';
+			readonly i: number;
+	  })
+	| (TimelineSelectionBase & {
+			readonly type: 'sequence-effect-prop';
+			readonly i: number;
+			readonly key: string;
+	  })
+	| (TimelineSelectionBase & {
 			readonly type: 'keyframe';
-			readonly nodePathInfo: SequenceNodePathInfo;
 			readonly frame: number;
-	  };
+	  });
 
 export type TimelineSelectionInteraction = {
 	readonly shiftKey: boolean;
@@ -241,13 +259,80 @@ const TimelineSelectionContext = createContext<TimelineSelectionContextValue>(
 const CurrentTimelineSelectionContext =
 	createContext<React.RefObject<TimelineSelectionContextValue> | null>(null);
 
-const getTimelineSelectionKey = (item: TimelineSelection): string => {
-	const rowKey = timelineNodePathInfoToKey(item.nodePathInfo);
-	if (item.type === 'row') {
-		return rowKey;
+const parseEffectIndex = (effectIndex: string): number | null => {
+	const parsed = Number(effectIndex);
+	if (!Number.isInteger(parsed) || parsed < 0) {
+		return null;
 	}
 
-	return `${rowKey}.keyframe.${item.frame}`;
+	return parsed;
+};
+
+export const getTimelineSelectionFromNodePathInfo = (
+	nodePathInfo: SequenceNodePathInfo | null,
+): TimelineSelection | null => {
+	if (nodePathInfo === null) {
+		return null;
+	}
+
+	const {auxiliaryKeys} = nodePathInfo;
+	if (auxiliaryKeys.length === 0) {
+		return {type: 'sequence', nodePathInfo};
+	}
+
+	if (auxiliaryKeys.length === 2 && auxiliaryKeys[0] === 'controls') {
+		return {type: 'sequence-prop', nodePathInfo, key: auxiliaryKeys[1]};
+	}
+
+	if (auxiliaryKeys.length === 1 && auxiliaryKeys[0] === 'effects') {
+		return {type: 'sequence-all-effects', nodePathInfo};
+	}
+
+	if (auxiliaryKeys[0] === 'effects') {
+		const effectIndex = parseEffectIndex(auxiliaryKeys[1]);
+		if (effectIndex === null) {
+			return null;
+		}
+
+		if (auxiliaryKeys.length === 2) {
+			return {type: 'sequence-effect', nodePathInfo, i: effectIndex};
+		}
+
+		if (auxiliaryKeys.length === 3) {
+			return {
+				type: 'sequence-effect-prop',
+				nodePathInfo,
+				i: effectIndex,
+				key: auxiliaryKeys[2],
+			};
+		}
+	}
+
+	return null;
+};
+
+const getTimelineSelectionKey = (item: TimelineSelection): string => {
+	const sequenceKey = getTimelineSequenceSelectionKey(item.nodePathInfo);
+	switch (item.type) {
+		case 'sequence':
+			return `${sequenceKey}.sequence`;
+		case 'sequence-prop':
+			return `${sequenceKey}.sequence-prop.${item.key}`;
+		case 'sequence-all-effects':
+			return `${sequenceKey}.sequence-all-effects`;
+		case 'sequence-effect':
+			return `${sequenceKey}.sequence-effect.${item.i}`;
+		case 'sequence-effect-prop':
+			return `${sequenceKey}.sequence-effect-prop.${item.i}.${item.key}`;
+		case 'keyframe':
+			return `${timelineNodePathInfoToKey(item.nodePathInfo)}.keyframe.${
+				item.frame
+			}`;
+		default:
+			throw new Error(
+				`Unexpected timeline selection type: ${item satisfies never}`,
+			);
+	}
 };
 
 const nodePathDescendsFrom = (
@@ -286,7 +371,7 @@ export const getSelectableTimelineSequenceSelections = (
 			return [];
 		}
 
-		return [{type: 'row', nodePathInfo: track.nodePathInfo}];
+		return [{type: 'sequence', nodePathInfo: track.nodePathInfo}];
 	});
 };
 
@@ -510,7 +595,7 @@ export const useTimelineRowSelection = (
 		useTimelineSelection();
 	const selectionItem = useMemo(
 		(): TimelineSelection | null =>
-			nodePathInfo === null ? null : {type: 'row', nodePathInfo},
+			getTimelineSelectionFromNodePathInfo(nodePathInfo),
 		[nodePathInfo],
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -50,7 +50,7 @@ const labelContainerStyle: React.CSSProperties = {
 	gap: 4,
 };
 
-export const TimelineListItem: React.FC<{
+export const TimelineSequenceItem: React.FC<{
 	readonly sequence: TSequence;
 	readonly nestedDepth: number;
 	readonly nodePathInfo: SequenceNodePathInfo | null;

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -149,7 +149,7 @@ const Value: React.FC<{
 	);
 };
 
-export const TimelineSequenceFieldRow: React.FC<{
+export const TimelineSequencePropItem: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly validatedLocation: CodePosition;
 	readonly rowDepth: number;

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -114,34 +114,27 @@ export const deleteSelectedTimelineItem = ({
 		});
 	}
 
-	const {nodePathInfo} = selection;
-	const {auxiliaryKeys} = nodePathInfo;
-
-	// The sequence track row itself has no auxiliary keys.
-	if (auxiliaryKeys.length === 0) {
-		return deleteSequences([nodePathInfo]);
-	}
-
-	// An effect group row is ['effects', effectIndex].
-	if (auxiliaryKeys.length === 2 && auxiliaryKeys[0] === 'effects') {
-		const effectIndex = Number(auxiliaryKeys[1]);
-		if (!Number.isInteger(effectIndex) || effectIndex < 0) {
+	switch (selection.type) {
+		case 'sequence':
+			return deleteSequences([selection.nodePathInfo]);
+		case 'sequence-effect':
+			return deleteEffect(selection.nodePathInfo, selection.i);
+		case 'sequence-prop':
+		case 'sequence-all-effects':
+		case 'sequence-effect-prop':
 			return null;
-		}
-
-		return deleteEffect(nodePathInfo, effectIndex);
+		default:
+			throw new Error(
+				`Unexpected timeline selection type: ${selection satisfies never}`,
+			);
 	}
-
-	// Field rows and other intermediate rows are not deletable on their own.
-	return null;
 };
 
 const isSequenceRowSelection = (
 	selection: TimelineSelection,
 ): selection is TimelineSelection & {
-	type: 'row';
-} =>
-	selection.type === 'row' && selection.nodePathInfo.auxiliaryKeys.length === 0;
+	type: 'sequence';
+} => selection.type === 'sequence';
 
 export const deleteSelectedTimelineItems = ({
 	selections,

--- a/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
@@ -82,9 +82,8 @@ export const duplicateSequencesFromSource = (
 export const isDuplicatableSequenceRowSelection = (
 	selection: TimelineSelection,
 ): selection is TimelineSelection & {
-	type: 'row';
-} =>
-	selection.type === 'row' && selection.nodePathInfo.auxiliaryKeys.length === 0;
+	type: 'sequence';
+} => selection.type === 'sequence';
 
 export const duplicateSelectedTimelineItems = ({
 	selections,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -5,6 +5,7 @@ import {
 	ENABLE_OUTLINES,
 	getSelectableTimelineSequenceSelections,
 	getTimelineSelectionAfterInteraction,
+	getTimelineSelectionFromNodePathInfo,
 	getTimelineSequenceSelectionKey,
 	SELECTION_ENABLED,
 	TIMELINE_TOP_DRAG,
@@ -52,7 +53,7 @@ test('Cmd+A selection only targets selectable timeline sequences', () => {
 		]),
 	).toEqual([
 		{
-			type: 'row',
+			type: 'sequence',
 			nodePathInfo: sequenceNodePathInfo,
 		},
 	]);
@@ -64,8 +65,12 @@ test('Cmd+D only duplicates selected timeline sequence rows', () => {
 
 	expect(
 		[
-			{type: 'row' as const, nodePathInfo: sequenceNodePathInfo},
-			{type: 'row' as const, nodePathInfo: effectNodePathInfo},
+			{type: 'sequence' as const, nodePathInfo: sequenceNodePathInfo},
+			{
+				type: 'sequence-effect' as const,
+				nodePathInfo: effectNodePathInfo,
+				i: 0,
+			},
 			{
 				type: 'keyframe' as const,
 				nodePathInfo: sequenceNodePathInfo,
@@ -74,7 +79,7 @@ test('Cmd+D only duplicates selected timeline sequence rows', () => {
 		].filter(isDuplicatableSequenceRowSelection),
 	).toEqual([
 		{
-			type: 'row',
+			type: 'sequence',
 			nodePathInfo: sequenceNodePathInfo,
 		},
 	]);
@@ -96,13 +101,59 @@ test('Child timeline selections resolve to the parent sequence selection key', (
 	);
 });
 
+test('Timeline row selections use explicit item variants', () => {
+	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const sequencePropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+	const allEffectsNodePathInfo = makeNodePathInfo(['body', 0], ['effects']);
+	const effectNodePathInfo = makeNodePathInfo(['body', 0], ['effects', '1']);
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '1', 'blur'],
+	);
+
+	expect(getTimelineSelectionFromNodePathInfo(sequenceNodePathInfo)).toEqual({
+		type: 'sequence',
+		nodePathInfo: sequenceNodePathInfo,
+	});
+	expect(
+		getTimelineSelectionFromNodePathInfo(sequencePropNodePathInfo),
+	).toEqual({
+		type: 'sequence-prop',
+		nodePathInfo: sequencePropNodePathInfo,
+		key: 'opacity',
+	});
+	expect(getTimelineSelectionFromNodePathInfo(allEffectsNodePathInfo)).toEqual({
+		type: 'sequence-all-effects',
+		nodePathInfo: allEffectsNodePathInfo,
+	});
+	expect(getTimelineSelectionFromNodePathInfo(effectNodePathInfo)).toEqual({
+		type: 'sequence-effect',
+		nodePathInfo: effectNodePathInfo,
+		i: 1,
+	});
+	expect(getTimelineSelectionFromNodePathInfo(effectPropNodePathInfo)).toEqual({
+		type: 'sequence-effect-prop',
+		nodePathInfo: effectPropNodePathInfo,
+		i: 1,
+		key: 'blur',
+	});
+	expect(
+		getTimelineSelectionFromNodePathInfo(
+			makeNodePathInfo(['body', 0], ['effects', 'not-a-number']),
+		),
+	).toBe(null);
+});
+
 test('Cmd/Ctrl+click toggles row selections', () => {
 	const rowA = {
-		type: 'row' as const,
+		type: 'sequence' as const,
 		nodePathInfo: makeNodePathInfo(['body', 0], []),
 	};
 	const rowB = {
-		type: 'row' as const,
+		type: 'sequence' as const,
 		nodePathInfo: makeNodePathInfo(['body', 1], []),
 	};
 	const allSelectableItems = [rowA, rowB];
@@ -140,15 +191,15 @@ test('Cmd/Ctrl+click toggles row selections', () => {
 
 test('Shift+click selects a contiguous row range from the anchor', () => {
 	const rowA = {
-		type: 'row' as const,
+		type: 'sequence' as const,
 		nodePathInfo: makeNodePathInfo(['body', 0], []),
 	};
 	const rowB = {
-		type: 'row' as const,
+		type: 'sequence' as const,
 		nodePathInfo: makeNodePathInfo(['body', 1], []),
 	};
 	const rowC = {
-		type: 'row' as const,
+		type: 'sequence' as const,
 		nodePathInfo: makeNodePathInfo(['body', 2], []),
 	};
 	const allSelectableItems = [rowA, rowB, rowC];
@@ -171,7 +222,7 @@ test('Shift+click selects a contiguous row range from the anchor', () => {
 
 test('Shift+click with no matching anchor falls back to single selection', () => {
 	const rowA = {
-		type: 'row' as const,
+		type: 'sequence' as const,
 		nodePathInfo: makeNodePathInfo(['body', 0], []),
 	};
 	const keyframe = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Fixes #7858.

## Summary
- Rename timeline row components to canonical `*Item` names.
- Refactor timeline selection rows into explicit `sequence`, `sequence-prop`, `sequence-all-effects`, `sequence-effect`, and `sequence-effect-prop` variants.
- Update duplicate/delete selection logic and timeline selection tests for the discriminated union.

## Testing
- `bun test src/test/timeline-selection.test.ts`
- `bun run formatting` from `packages/studio`
- `bunx turbo run make --filter='@remotion/studio'`
- `bun run build`
- `bunx turbo run lint formatting --filter='@remotion/studio'` (passes with pre-existing Studio lint warnings)
- `bun run stylecheck` (blocked by known `@remotion/lambda-go` Go 1.22.2 environment limitation; package-specific Studio stylecheck passes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e069ec9-19f5-47cf-b098-dca987b6312a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e069ec9-19f5-47cf-b098-dca987b6312a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

