### PR TITLE
`@remotion/studio`: Allow outline dragging

### DIFF
--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -272,7 +272,7 @@ const CompWhenItHasDimensions: React.FC<{
 				xCorrection={xCorrection}
 				yCorrection={yCorrection}
 			/>
-			<SelectedOutlineOverlay />
+			<SelectedOutlineOverlay scale={scale} />
 		</div>
 	);
 };

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -12,10 +12,6 @@ import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {BLUE} from '../helpers/colors';
 import {getBoxQuadsPonyfill} from '../helpers/get-box-quads-ponyfill';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
-import {
-	forceSpecificCursor,
-	stopForcingSpecificCursor,
-} from './ForceSpecificCursor';
 import {saveSequenceProp} from './Timeline/save-sequence-prop';
 import {
 	parseTranslate,
@@ -339,8 +335,6 @@ export const SelectedOutlineOverlay: React.FC<{
 					: null;
 			let lastValue: string | null = null;
 
-			forceSpecificCursor('move');
-
 			const onPointerMove = (moveEvent: PointerEvent) => {
 				moveEvent.preventDefault();
 
@@ -354,7 +348,6 @@ export const SelectedOutlineOverlay: React.FC<{
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
-				stopForcingSpecificCursor();
 
 				const stringifiedValue =
 					lastValue === null ? null : JSON.stringify(lastValue);
@@ -461,7 +454,6 @@ export const SelectedOutlineOverlay: React.FC<{
 								points={outline.points.map(pointToString).join(' ')}
 								fill="transparent"
 								pointerEvents="all"
-								cursor="move"
 								onPointerDown={(event) => onPointerDown(event, target)}
 							/>
 						) : null}

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1,9 +1,26 @@
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
-import type {OverrideIdToNodePaths, TSequence} from 'remotion';
+import type {
+	CanUpdateSequencePropStatusTrue,
+	OverrideIdToNodePaths,
+	SequencePropsSubscriptionKey,
+	SequenceSchema,
+	TSequence,
+} from 'remotion';
 import {Internals} from 'remotion';
 import {calculateTimeline} from '../helpers/calculate-timeline';
+import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {BLUE} from '../helpers/colors';
 import {getBoxQuadsPonyfill} from '../helpers/get-box-quads-ponyfill';
+import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+import {
+	forceSpecificCursor,
+	stopForcingSpecificCursor,
+} from './ForceSpecificCursor';
+import {saveSequenceProp} from './Timeline/save-sequence-prop';
+import {
+	parseTranslate,
+	serializeTranslate,
+} from './Timeline/timeline-translate-utils';
 import {
 	ENABLE_OUTLINES,
 	getTimelineSequenceSelectionKey,
@@ -29,7 +46,26 @@ type SelectedOutline = {
 type SelectedOutlineTarget = {
 	readonly key: string;
 	readonly ref: React.RefObject<HTMLElement | null>;
+	readonly drag: SelectedOutlineDragTarget | null;
 };
+
+type SelectedOutlineDragTarget = {
+	readonly codeValue: CanUpdateSequencePropStatusTrue;
+	readonly clientId: string;
+	readonly fieldDefault: string | undefined;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly schema: SequenceSchema;
+};
+
+type SequenceWithSelectedOutline = {
+	readonly key: string;
+	readonly nodePathInfo: SequenceNodePathInfo;
+	readonly sequence: TSequence;
+};
+
+const translateFieldKey = 'style.translate';
+
+const outlineHitStrokeWidth = 12;
 
 const outlineContainer: React.CSSProperties = {
 	position: 'absolute',
@@ -115,7 +151,7 @@ const getSequencesWithSelectedOutlines = ({
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly sequences: readonly TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
-}): TSequence[] => {
+}): SequenceWithSelectedOutline[] => {
 	const selectedSequenceKeys = getSelectedSequenceKeys(selectedItems);
 
 	if (selectedSequenceKeys.size === 0) {
@@ -135,8 +171,18 @@ const getSequencesWithSelectedOutlines = ({
 				getTimelineSequenceSelectionKey(track.nodePathInfo),
 			);
 		})
-		.map((track) => track.sequence)
-		.filter((sequence) => sequence.refForOutline !== null);
+		.filter((track) => track.sequence.refForOutline !== null)
+		.map((track) => {
+			if (track.nodePathInfo === null) {
+				throw new Error('Expected selected outline to have a node path');
+			}
+
+			return {
+				key: getTimelineSequenceSelectionKey(track.nodePathInfo),
+				nodePathInfo: track.nodePathInfo,
+				sequence: track.sequence,
+			};
+		});
 };
 
 const measureOutlines = (
@@ -189,9 +235,19 @@ const outlinesAreEqual = (
 	return true;
 };
 
-export const SelectedOutlineOverlay: React.FC = () => {
+export const SelectedOutlineOverlay: React.FC<{
+	readonly scale: number;
+}> = ({scale}) => {
 	const {selectedItems} = useTimelineSelection();
 	const {sequences} = useContext(Internals.SequenceManager);
+	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {getDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
+	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
+		Internals.VisualModeSettersContext,
+	);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
 	);
@@ -207,17 +263,142 @@ export const SelectedOutlineOverlay: React.FC = () => {
 			selectedItems,
 			sequences,
 			overrideIdsToNodePaths: overrideIdToNodePathMappings,
-		}).map((sequence) => {
+		}).map(({key, nodePathInfo, sequence}) => {
 			if (sequence.refForOutline === null) {
 				throw new Error('Expected sequence to have a ref for outline');
 			}
 
+			const nodePath = nodePathInfo.sequenceSubscriptionKey;
+			const {controls} = sequence;
+			const fieldSchema = controls?.schema[translateFieldKey];
+			const codeValue = Internals.getCodeValuesCtx(codeValues, nodePath)?.[
+				translateFieldKey
+			];
+			const canDrag =
+				previewServerState.type === 'connected' &&
+				controls !== null &&
+				fieldSchema?.type === 'translate' &&
+				codeValue?.canUpdate === true;
+
 			return {
-				key: sequence.id,
+				key,
 				ref: sequence.refForOutline,
+				drag: canDrag
+					? {
+							codeValue,
+							clientId: previewServerState.clientId,
+							fieldDefault: fieldSchema.default,
+							nodePath,
+							schema: controls.schema,
+						}
+					: null,
 			};
 		});
-	}, [overrideIdToNodePathMappings, selectedItems, sequences]);
+	}, [
+		codeValues,
+		overrideIdToNodePathMappings,
+		previewServerState,
+		selectedItems,
+		sequences,
+	]);
+
+	const targetsByKey = useMemo(() => {
+		return new Map(
+			selectedOutlineTargets.map((target) => [target.key, target]),
+		);
+	}, [selectedOutlineTargets]);
+
+	const onPointerDown = React.useCallback(
+		(
+			event: React.PointerEvent<SVGPolygonElement>,
+			target: SelectedOutlineTarget,
+		) => {
+			const {drag} = target;
+			if (event.button !== 0 || drag === null) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			const startPointerX = event.clientX;
+			const startPointerY = event.clientY;
+			const dragOverrideValue = (getDragOverrides(drag.nodePath) ?? {})[
+				translateFieldKey
+			];
+			const effectiveValue = Internals.getEffectiveVisualModeValue({
+				codeValue: drag.codeValue,
+				dragOverrideValue,
+				defaultValue: drag.fieldDefault,
+				shouldResortToDefaultValueIfUndefined: true,
+			});
+			const [startX, startY] = parseTranslate(
+				String(effectiveValue ?? '0px 0px'),
+			);
+			const defaultValue =
+				drag.fieldDefault !== undefined
+					? JSON.stringify(drag.fieldDefault)
+					: null;
+			let lastValue: string | null = null;
+
+			forceSpecificCursor('move');
+
+			const onPointerMove = (moveEvent: PointerEvent) => {
+				moveEvent.preventDefault();
+
+				const nextX = startX + (moveEvent.clientX - startPointerX) / scale;
+				const nextY = startY + (moveEvent.clientY - startPointerY) / scale;
+				lastValue = serializeTranslate(nextX, nextY);
+				setDragOverrides(drag.nodePath, translateFieldKey, lastValue);
+			};
+
+			const onPointerUp = () => {
+				window.removeEventListener('pointermove', onPointerMove);
+				window.removeEventListener('pointerup', onPointerUp);
+				window.removeEventListener('pointercancel', onPointerUp);
+				stopForcingSpecificCursor();
+
+				const stringifiedValue =
+					lastValue === null ? null : JSON.stringify(lastValue);
+				const shouldSave =
+					lastValue !== null &&
+					lastValue !== drag.codeValue.codeValue &&
+					!(
+						defaultValue === stringifiedValue &&
+						drag.codeValue.codeValue === undefined
+					);
+
+				if (!shouldSave) {
+					clearDragOverrides(drag.nodePath);
+					return;
+				}
+
+				saveSequenceProp({
+					fileName: drag.nodePath.absolutePath,
+					nodePath: drag.nodePath,
+					fieldKey: translateFieldKey,
+					value: lastValue,
+					defaultValue,
+					schema: drag.schema,
+					setCodeValues,
+					clientId: drag.clientId,
+				}).finally(() => {
+					clearDragOverrides(drag.nodePath);
+				});
+			};
+
+			window.addEventListener('pointermove', onPointerMove);
+			window.addEventListener('pointerup', onPointerUp);
+			window.addEventListener('pointercancel', onPointerUp);
+		},
+		[
+			clearDragOverrides,
+			getDragOverrides,
+			scale,
+			setCodeValues,
+			setDragOverrides,
+		],
+	);
 
 	useEffect(() => {
 		if (selectedOutlineTargets.length === 0) {
@@ -266,16 +447,32 @@ export const SelectedOutlineOverlay: React.FC = () => {
 			height="100%"
 			aria-hidden="true"
 		>
-			{outlines.map((outline) => (
-				<polygon
-					key={outline.key}
-					points={outline.points.map(pointToString).join(' ')}
-					fill="none"
-					stroke={BLUE}
-					strokeWidth={2}
-					vectorEffect="non-scaling-stroke"
-				/>
-			))}
+			{outlines.map((outline) => {
+				const target = targetsByKey.get(outline.key);
+				return (
+					<React.Fragment key={outline.key}>
+						<polygon
+							points={outline.points.map(pointToString).join(' ')}
+							fill="none"
+							stroke={BLUE}
+							strokeWidth={2}
+							vectorEffect="non-scaling-stroke"
+						/>
+						{target?.drag ? (
+							<polygon
+								points={outline.points.map(pointToString).join(' ')}
+								fill="none"
+								stroke="transparent"
+								strokeWidth={outlineHitStrokeWidth}
+								vectorEffect="non-scaling-stroke"
+								pointerEvents="stroke"
+								cursor="move"
+								onPointerDown={(event) => onPointerDown(event, target)}
+							/>
+						) : null}
+					</React.Fragment>
+				);
+			})}
 		</svg>
 	);
 };

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -65,8 +65,6 @@ type SequenceWithSelectedOutline = {
 
 const translateFieldKey = 'style.translate';
 
-const outlineHitStrokeWidth = 12;
-
 const outlineContainer: React.CSSProperties = {
 	position: 'absolute',
 	inset: 0,
@@ -461,11 +459,8 @@ export const SelectedOutlineOverlay: React.FC<{
 						{target?.drag ? (
 							<polygon
 								points={outline.points.map(pointToString).join(' ')}
-								fill="none"
-								stroke="transparent"
-								strokeWidth={outlineHitStrokeWidth}
-								vectorEffect="non-scaling-stroke"
-								pointerEvents="stroke"
+								fill="transparent"
+								pointerEvents="all"
 								cursor="move"
 								onPointerDown={(event) => onPointerDown(event, target)}
 							/>

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -229,85 +229,25 @@ const outlinesAreEqual = (
 	return true;
 };
 
-export const SelectedOutlineOverlay: React.FC<{
+const SelectedOutlinePolygon: React.FC<{
+	readonly outline: SelectedOutline;
 	readonly scale: number;
-}> = ({scale}) => {
-	const {selectedItems} = useTimelineSelection();
-	const {sequences} = useContext(Internals.SequenceManager);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	readonly target: SelectedOutlineTarget | undefined;
+}> = ({outline, scale, target}) => {
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
 	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
-	const {previewServerState} = useContext(StudioServerConnectionCtx);
-	const {overrideIdToNodePathMappings} = useContext(
-		Internals.OverrideIdsToNodePathsGettersContext,
+	const points = useMemo(
+		() => outline.points.map(pointToString).join(' '),
+		[outline.points],
 	);
-	const [outlines, setOutlines] = useState<readonly SelectedOutline[]>([]);
-	const overlayRef = useRef<SVGSVGElement>(null);
-
-	const selectedOutlineTargets = useMemo((): SelectedOutlineTarget[] => {
-		if (!ENABLE_OUTLINES) {
-			return [];
-		}
-
-		return getSequencesWithSelectedOutlines({
-			selectedItems,
-			sequences,
-			overrideIdsToNodePaths: overrideIdToNodePathMappings,
-		}).map(({key, nodePathInfo, sequence}) => {
-			if (sequence.refForOutline === null) {
-				throw new Error('Expected sequence to have a ref for outline');
-			}
-
-			const nodePath = nodePathInfo.sequenceSubscriptionKey;
-			const {controls} = sequence;
-			const fieldSchema = controls?.schema[translateFieldKey];
-			const codeValue = Internals.getCodeValuesCtx(codeValues, nodePath)?.[
-				translateFieldKey
-			];
-			const canDrag =
-				previewServerState.type === 'connected' &&
-				controls !== null &&
-				fieldSchema?.type === 'translate' &&
-				codeValue?.canUpdate === true;
-
-			return {
-				key,
-				ref: sequence.refForOutline,
-				drag: canDrag
-					? {
-							codeValue,
-							clientId: previewServerState.clientId,
-							fieldDefault: fieldSchema.default,
-							nodePath,
-							schema: controls.schema,
-						}
-					: null,
-			};
-		});
-	}, [
-		codeValues,
-		overrideIdToNodePathMappings,
-		previewServerState,
-		selectedItems,
-		sequences,
-	]);
-
-	const targetsByKey = useMemo(() => {
-		return new Map(
-			selectedOutlineTargets.map((target) => [target.key, target]),
-		);
-	}, [selectedOutlineTargets]);
+	const drag = target?.drag ?? null;
 
 	const onPointerDown = React.useCallback(
-		(
-			event: React.PointerEvent<SVGPolygonElement>,
-			target: SelectedOutlineTarget,
-		) => {
-			const {drag} = target;
+		(event: React.PointerEvent<SVGPolygonElement>) => {
 			if (event.button !== 0 || drag === null) {
 				return;
 			}
@@ -384,12 +324,93 @@ export const SelectedOutlineOverlay: React.FC<{
 		},
 		[
 			clearDragOverrides,
+			drag,
 			getDragOverrides,
 			scale,
 			setCodeValues,
 			setDragOverrides,
 		],
 	);
+
+	return (
+		<polygon
+			points={points}
+			fill={drag === null ? 'none' : 'transparent'}
+			stroke={BLUE}
+			strokeWidth={2}
+			vectorEffect="non-scaling-stroke"
+			pointerEvents={drag === null ? undefined : 'all'}
+			onPointerDown={drag === null ? undefined : onPointerDown}
+		/>
+	);
+};
+
+export const SelectedOutlineOverlay: React.FC<{
+	readonly scale: number;
+}> = ({scale}) => {
+	const {selectedItems} = useTimelineSelection();
+	const {sequences} = useContext(Internals.SequenceManager);
+	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
+	const [outlines, setOutlines] = useState<readonly SelectedOutline[]>([]);
+	const overlayRef = useRef<SVGSVGElement>(null);
+
+	const selectedOutlineTargets = useMemo((): SelectedOutlineTarget[] => {
+		if (!ENABLE_OUTLINES) {
+			return [];
+		}
+
+		return getSequencesWithSelectedOutlines({
+			selectedItems,
+			sequences,
+			overrideIdsToNodePaths: overrideIdToNodePathMappings,
+		}).map(({key, nodePathInfo, sequence}) => {
+			if (sequence.refForOutline === null) {
+				throw new Error('Expected sequence to have a ref for outline');
+			}
+
+			const nodePath = nodePathInfo.sequenceSubscriptionKey;
+			const {controls} = sequence;
+			const fieldSchema = controls?.schema[translateFieldKey];
+			const codeValue = Internals.getCodeValuesCtx(codeValues, nodePath)?.[
+				translateFieldKey
+			];
+			const canDrag =
+				previewServerState.type === 'connected' &&
+				controls !== null &&
+				fieldSchema?.type === 'translate' &&
+				codeValue?.canUpdate === true;
+
+			return {
+				key,
+				ref: sequence.refForOutline,
+				drag: canDrag
+					? {
+							codeValue,
+							clientId: previewServerState.clientId,
+							fieldDefault: fieldSchema.default,
+							nodePath,
+							schema: controls.schema,
+						}
+					: null,
+			};
+		});
+	}, [
+		codeValues,
+		overrideIdToNodePathMappings,
+		previewServerState,
+		selectedItems,
+		sequences,
+	]);
+
+	const targetsByKey = useMemo(() => {
+		return new Map(
+			selectedOutlineTargets.map((target) => [target.key, target]),
+		);
+	}, [selectedOutlineTargets]);
 
 	useEffect(() => {
 		if (selectedOutlineTargets.length === 0) {
@@ -438,28 +459,14 @@ export const SelectedOutlineOverlay: React.FC<{
 			height="100%"
 			aria-hidden="true"
 		>
-			{outlines.map((outline) => {
-				const target = targetsByKey.get(outline.key);
-				return (
-					<React.Fragment key={outline.key}>
-						<polygon
-							points={outline.points.map(pointToString).join(' ')}
-							fill="none"
-							stroke={BLUE}
-							strokeWidth={2}
-							vectorEffect="non-scaling-stroke"
-						/>
-						{target?.drag ? (
-							<polygon
-								points={outline.points.map(pointToString).join(' ')}
-								fill="transparent"
-								pointerEvents="all"
-								onPointerDown={(event) => onPointerDown(event, target)}
-							/>
-						) : null}
-					</React.Fragment>
-				);
-			})}
+			{outlines.map((outline) => (
+				<SelectedOutlinePolygon
+					key={outline.key}
+					outline={outline}
+					scale={scale}
+					target={targetsByKey.get(outline.key)}
+				/>
+			))}
 		</svg>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
@@ -7,6 +7,7 @@ import type {
 } from '../../helpers/timeline-layout';
 import {InputDragger} from '../NewComposition/InputDragger';
 import {getDecimalPlaces} from './timeline-field-utils';
+import {parseTranslate, serializeTranslate} from './timeline-translate-utils';
 
 const leftDraggerStyle: React.CSSProperties = {
 	paddingLeft: 0,
@@ -14,17 +15,6 @@ const leftDraggerStyle: React.CSSProperties = {
 
 const rightDraggerStyle: React.CSSProperties = {
 	paddingRight: 0,
-};
-
-const PIXEL_PATTERN = /^(-?\d+(?:\.\d+)?)px(?:\s+(-?\d+(?:\.\d+)?)px)?$/;
-
-const parseTranslate = (value: string): [number, number] => {
-	const m = value.match(PIXEL_PATTERN);
-	if (!m) {
-		return [0, 0];
-	}
-
-	return [Number(m[1]), m[2] !== undefined ? Number(m[2]) : 0];
 };
 
 const containerStyle: React.CSSProperties = {
@@ -55,8 +45,6 @@ export const TimelineTranslateField: React.FC<{
 		[effectiveValue],
 	);
 
-	const makeString = useCallback((x: number, y: number) => `${x}px ${y}px`, []);
-
 	const step =
 		field.fieldSchema.type === 'translate' ? (field.fieldSchema.step ?? 1) : 1;
 
@@ -77,15 +65,15 @@ export const TimelineTranslateField: React.FC<{
 		(newVal: number) => {
 			setDragX(newVal);
 			const currentY = dragY ?? codeY;
-			onDragValueChange(makeString(newVal, currentY));
+			onDragValueChange(serializeTranslate(newVal, currentY));
 		},
-		[onDragValueChange, dragY, codeY, makeString],
+		[onDragValueChange, dragY, codeY],
 	);
 
 	const onXChangeEnd = useCallback(
 		(newVal: number) => {
 			const currentY = dragY ?? codeY;
-			const newStr = makeString(newVal, currentY);
+			const newStr = serializeTranslate(newVal, currentY);
 			if (propStatus.canUpdate && newStr !== propStatus.codeValue) {
 				onSave(newStr).finally(() => {
 					setDragX(null);
@@ -96,7 +84,7 @@ export const TimelineTranslateField: React.FC<{
 				onDragEnd();
 			}
 		},
-		[dragY, codeY, makeString, propStatus, onSave, onDragEnd],
+		[dragY, codeY, propStatus, onSave, onDragEnd],
 	);
 
 	const onXTextChange = useCallback(
@@ -105,7 +93,7 @@ export const TimelineTranslateField: React.FC<{
 				const parsed = Number(newVal);
 				if (!Number.isNaN(parsed)) {
 					const currentY = dragY ?? codeY;
-					const newStr = makeString(parsed, currentY);
+					const newStr = serializeTranslate(parsed, currentY);
 					if (newStr !== propStatus.codeValue) {
 						setDragX(parsed);
 						onSave(newStr).finally(() => {
@@ -115,7 +103,7 @@ export const TimelineTranslateField: React.FC<{
 				}
 			}
 		},
-		[propStatus, dragY, codeY, makeString, onSave],
+		[propStatus, dragY, codeY, onSave],
 	);
 
 	// --- Y callbacks ---
@@ -123,15 +111,15 @@ export const TimelineTranslateField: React.FC<{
 		(newVal: number) => {
 			setDragY(newVal);
 			const currentX = dragX ?? codeX;
-			onDragValueChange(makeString(currentX, newVal));
+			onDragValueChange(serializeTranslate(currentX, newVal));
 		},
-		[onDragValueChange, dragX, codeX, makeString],
+		[onDragValueChange, dragX, codeX],
 	);
 
 	const onYChangeEnd = useCallback(
 		(newVal: number) => {
 			const currentX = dragX ?? codeX;
-			const newStr = makeString(currentX, newVal);
+			const newStr = serializeTranslate(currentX, newVal);
 			if (propStatus.canUpdate && newStr !== propStatus.codeValue) {
 				onSave(newStr).finally(() => {
 					setDragY(null);
@@ -142,7 +130,7 @@ export const TimelineTranslateField: React.FC<{
 				onDragEnd();
 			}
 		},
-		[dragX, codeX, makeString, propStatus, onSave, onDragEnd],
+		[dragX, codeX, propStatus, onSave, onDragEnd],
 	);
 
 	const onYTextChange = useCallback(
@@ -151,7 +139,7 @@ export const TimelineTranslateField: React.FC<{
 				const parsed = Number(newVal);
 				if (!Number.isNaN(parsed)) {
 					const currentX = dragX ?? codeX;
-					const newStr = makeString(currentX, parsed);
+					const newStr = serializeTranslate(currentX, parsed);
 					if (newStr !== propStatus.codeValue) {
 						setDragY(parsed);
 						onSave(newStr).finally(() => {
@@ -161,7 +149,7 @@ export const TimelineTranslateField: React.FC<{
 				}
 			}
 		},
-		[propStatus, onSave, dragX, codeX, makeString],
+		[propStatus, onSave, dragX, codeX],
 	);
 
 	return (

--- a/packages/studio/src/components/Timeline/timeline-translate-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-translate-utils.ts
@@ -1,0 +1,19 @@
+const PIXEL_PATTERN = /^(-?\d+(?:\.\d+)?)px(?:\s+(-?\d+(?:\.\d+)?)px)?$/;
+
+export const parseTranslate = (value: string): [number, number] => {
+	const m = value.match(PIXEL_PATTERN);
+	if (!m) {
+		return [0, 0];
+	}
+
+	return [Number(m[1]), m[2] !== undefined ? Number(m[2]) : 0];
+};
+
+const formatTranslateCoordinate = (value: number): string => {
+	const rounded = Math.round(value * 1000) / 1000;
+	return String(Object.is(rounded, -0) ? 0 : rounded);
+};
+
+export const serializeTranslate = (x: number, y: number): string => {
+	return `${formatTranslateCoordinate(x)}px ${formatTranslateCoordinate(y)}px`;
+};


### PR DESCRIPTION
## Summary
- Enable dragging selected sequence outlines to update `style.translate` via visual-mode drag overrides.
- Account for preview scale when converting pointer movement to composition pixels.
- Share translate parsing/serialization between the timeline field and outline dragging.

## Checks
- `bun run build`
- `bun run formatting`
