### PR TITLE
`@remotion/studio`: Batch delete effects

### DIFF
--- a/packages/studio-server/src/codemods/delete-effect.ts
+++ b/packages/studio-server/src/codemods/delete-effect.ts
@@ -1,9 +1,15 @@
-import type {ArrayExpression, Expression, JSXAttribute} from '@babel/types';
+import type {
+	ArrayExpression,
+	Expression,
+	JSXAttribute,
+	JSXSpreadAttribute,
+} from '@babel/types';
 import type {SequenceNodePath} from 'remotion';
 import {findJsxElementAtNodePath} from '../preview-server/routes/can-update-sequence-props';
 import {formatFileContent} from './format-file-content';
 import {parseAst, serializeAst} from './parse-ast';
 import {
+	enumerateEffectArrayElements,
 	findEffectCallExpression,
 	findEffectsAttr,
 } from './update-effect-props/update-effect-props';
@@ -19,6 +25,159 @@ const getEffectsArray = (attr: JSXAttribute): ArrayExpression => {
 	}
 
 	return expr;
+};
+
+export type EffectDeletionTarget = {
+	sequenceNodePath: SequenceNodePath;
+	effectIndex: number | null;
+};
+
+type EffectsArrayDeletion = {
+	jsxAttributes: Array<JSXAttribute | JSXSpreadAttribute>;
+	attr: JSXAttribute;
+	effectsArray: ArrayExpression;
+	allEffects: boolean;
+	effectIndices: Set<number>;
+	effectLabels: string[];
+	logLines: number[];
+};
+
+const getAllEffectLabels = (
+	effectsArray: ArrayExpression,
+	attr: JSXAttribute,
+): {effectLabels: string[]; logLines: number[]} => {
+	if (effectsArray.elements.length === 0) {
+		throw new Error('Cannot delete effect: no effects found');
+	}
+
+	const elements = enumerateEffectArrayElements(effectsArray);
+	return {
+		effectLabels: elements.map((effect) =>
+			effect.kind === 'call' ? `${effect.callee}()` : 'effect',
+		),
+		logLines: elements.map((effect) =>
+			effect.kind === 'call'
+				? (effect.node.loc?.start.line ?? attr.loc?.start.line ?? 1)
+				: (attr.loc?.start.line ?? 1),
+		),
+	};
+};
+
+export const deleteEffects = async ({
+	input,
+	effects,
+	prettierConfigOverride,
+}: {
+	input: string;
+	effects: EffectDeletionTarget[];
+	prettierConfigOverride?: Record<string, unknown> | null;
+}): Promise<{
+	output: string;
+	formatted: boolean;
+	effectLabels: string[];
+	logLines: number[];
+}> => {
+	if (effects.length === 0) {
+		throw new Error('No effects were specified for deletion');
+	}
+
+	const ast = parseAst(input);
+	const deletionsByAttr = new Map<JSXAttribute, EffectsArrayDeletion>();
+
+	for (const {sequenceNodePath, effectIndex} of effects) {
+		const jsx = findJsxElementAtNodePath(ast, sequenceNodePath);
+		if (!jsx) {
+			throw new Error(
+				'Could not find a JSX element at the specified location to delete effect',
+			);
+		}
+
+		const attr = findEffectsAttr(jsx.attributes ?? []);
+		if (!attr) {
+			throw new Error('Could not find effects on the target JSX element');
+		}
+
+		const effectsArray = getEffectsArray(attr);
+		const existingDeletion = deletionsByAttr.get(attr);
+		const deletion =
+			existingDeletion ??
+			({
+				jsxAttributes: jsx.attributes,
+				attr,
+				effectsArray,
+				allEffects: false,
+				effectIndices: new Set<number>(),
+				effectLabels: [],
+				logLines: [],
+			} satisfies EffectsArrayDeletion);
+
+		deletionsByAttr.set(attr, deletion);
+
+		if (effectIndex === null) {
+			const {effectLabels, logLines} = getAllEffectLabels(effectsArray, attr);
+			deletion.allEffects = true;
+			deletion.effectIndices.clear();
+			deletion.effectLabels = effectLabels;
+			deletion.logLines = logLines;
+			continue;
+		}
+
+		if (deletion.allEffects || deletion.effectIndices.has(effectIndex)) {
+			continue;
+		}
+
+		const found = findEffectCallExpression({attr, effectIndex});
+		if (found.kind === 'error') {
+			throw new Error(`Cannot delete effect: ${found.reason}`);
+		}
+
+		deletion.effectIndices.add(effectIndex);
+		deletion.effectLabels.push(`${found.callee}()`);
+		deletion.logLines.push(
+			found.call.loc?.start.line ?? jsx.loc?.start.line ?? 1,
+		);
+	}
+
+	for (const deletion of deletionsByAttr.values()) {
+		if (deletion.allEffects) {
+			const attrIndex = deletion.jsxAttributes.indexOf(deletion.attr);
+			if (attrIndex !== -1) {
+				deletion.jsxAttributes.splice(attrIndex, 1);
+			}
+
+			continue;
+		}
+
+		for (const effectIndex of [...deletion.effectIndices].sort(
+			(a, b) => b - a,
+		)) {
+			deletion.effectsArray.elements.splice(effectIndex, 1);
+		}
+
+		if (deletion.effectsArray.elements.length === 0) {
+			const attrIndex = deletion.jsxAttributes.indexOf(deletion.attr);
+			if (attrIndex !== -1) {
+				deletion.jsxAttributes.splice(attrIndex, 1);
+			}
+		}
+	}
+
+	const finalFile = serializeAst(ast);
+	const {output, formatted} = await formatFileContent({
+		input: finalFile,
+		prettierConfigOverride,
+	});
+
+	return {
+		output,
+		formatted,
+		effectLabels: [...deletionsByAttr.values()].flatMap(
+			(deletion) => deletion.effectLabels,
+		),
+		logLines: [...deletionsByAttr.values()].flatMap(
+			(deletion) => deletion.logLines,
+		),
+	};
 };
 
 export const deleteEffect = async ({
@@ -37,44 +196,16 @@ export const deleteEffect = async ({
 	effectLabel: string;
 	logLine: number;
 }> => {
-	const ast = parseAst(input);
-	const jsx = findJsxElementAtNodePath(ast, sequenceNodePath);
-	if (!jsx) {
-		throw new Error(
-			'Could not find a JSX element at the specified location to delete effect',
-		);
-	}
-
-	const attr = findEffectsAttr(jsx.attributes ?? []);
-	if (!attr) {
-		throw new Error('Could not find effects on the target JSX element');
-	}
-
-	const effectsArray = getEffectsArray(attr);
-	const found = findEffectCallExpression({attr, effectIndex});
-	if (found.kind === 'error') {
-		throw new Error(`Cannot delete effect: ${found.reason}`);
-	}
-
-	effectsArray.elements.splice(effectIndex, 1);
-
-	if (effectsArray.elements.length === 0) {
-		const attrIndex = jsx.attributes.indexOf(attr);
-		if (attrIndex !== -1) {
-			jsx.attributes.splice(attrIndex, 1);
-		}
-	}
-
-	const finalFile = serializeAst(ast);
-	const {output, formatted} = await formatFileContent({
-		input: finalFile,
+	const {output, formatted, effectLabels, logLines} = await deleteEffects({
+		input,
+		effects: [{sequenceNodePath, effectIndex}],
 		prettierConfigOverride,
 	});
 
 	return {
 		output,
 		formatted,
-		effectLabel: `${found.callee}()`,
-		logLine: found.call.loc?.start.line ?? jsx.loc?.start.line ?? 1,
+		effectLabel: effectLabels[0],
+		logLine: logLines[0],
 	};
 };

--- a/packages/studio-server/src/codemods/delete-effect.ts
+++ b/packages/studio-server/src/codemods/delete-effect.ts
@@ -29,8 +29,15 @@ const getEffectsArray = (attr: JSXAttribute): ArrayExpression => {
 
 export type EffectDeletionTarget = {
 	sequenceNodePath: SequenceNodePath;
-	effectIndex: number | null;
-};
+} & (
+	| {
+			type: 'single-effect';
+			effectIndex: number;
+	  }
+	| {
+			type: 'all-effects';
+	  }
+);
 
 type EffectsArrayDeletion = {
 	jsxAttributes: Array<JSXAttribute | JSXSpreadAttribute>;
@@ -84,7 +91,8 @@ export const deleteEffects = async ({
 	const ast = parseAst(input);
 	const deletionsByAttr = new Map<JSXAttribute, EffectsArrayDeletion>();
 
-	for (const {sequenceNodePath, effectIndex} of effects) {
+	for (const effect of effects) {
+		const {sequenceNodePath} = effect;
 		const jsx = findJsxElementAtNodePath(ast, sequenceNodePath);
 		if (!jsx) {
 			throw new Error(
@@ -113,7 +121,7 @@ export const deleteEffects = async ({
 
 		deletionsByAttr.set(attr, deletion);
 
-		if (effectIndex === null) {
+		if (effect.type === 'all-effects') {
 			const {effectLabels, logLines} = getAllEffectLabels(effectsArray, attr);
 			deletion.allEffects = true;
 			deletion.effectIndices.clear();
@@ -122,6 +130,7 @@ export const deleteEffects = async ({
 			continue;
 		}
 
+		const {effectIndex} = effect;
 		if (deletion.allEffects || deletion.effectIndices.has(effectIndex)) {
 			continue;
 		}
@@ -198,7 +207,7 @@ export const deleteEffect = async ({
 }> => {
 	const {output, formatted, effectLabels, logLines} = await deleteEffects({
 		input,
-		effects: [{sequenceNodePath, effectIndex}],
+		effects: [{type: 'single-effect', sequenceNodePath, effectIndex}],
 		prettierConfigOverride,
 	});
 

--- a/packages/studio-server/src/preview-server/routes/delete-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-effect.ts
@@ -58,10 +58,18 @@ export const deleteEffectHandler: ApiHandler<
 				const {output, formatted, effectLabels, logLines} = await deleteEffects(
 					{
 						input: fileContents,
-						effects: fileItems.map((item) => ({
-							sequenceNodePath: item.sequenceNodePath.nodePath,
-							effectIndex: item.effectIndex,
-						})),
+						effects: fileItems.map((item) =>
+							item.type === 'single-effect'
+								? {
+										type: 'single-effect',
+										sequenceNodePath: item.sequenceNodePath.nodePath,
+										effectIndex: item.effectIndex,
+									}
+								: {
+										type: 'all-effects',
+										sequenceNodePath: item.sequenceNodePath.nodePath,
+									},
+						),
 					},
 				);
 

--- a/packages/studio-server/src/preview-server/routes/delete-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-effect.ts
@@ -4,7 +4,7 @@ import type {
 	DeleteEffectRequest,
 	DeleteEffectResponse,
 } from '@remotion/studio-shared';
-import {deleteEffect} from '../../codemods/delete-effect';
+import {deleteEffects} from '../../codemods/delete-effect';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
@@ -17,65 +17,109 @@ import {
 import {strikeThroughOrRemovedPrefix} from './log-updates/formatting';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
 
+const getDeletedEffectDescription = (effectLabels: string[]): string => {
+	if (effectLabels.length === 1) {
+		return effectLabels[0];
+	}
+
+	return `${effectLabels.length} effects`;
+};
+
 export const deleteEffectHandler: ApiHandler<
 	DeleteEffectRequest,
 	DeleteEffectResponse
-> = async ({
-	input: {fileName, sequenceNodePath, effectIndex},
-	remotionRoot,
-	logLevel,
-}) => {
+> = async ({input: effects, remotionRoot, logLevel}) => {
 	try {
-		RenderInternals.Log.trace(
-			{indent: false, logLevel},
-			`[delete-effect] Received request for fileName="${fileName}" effectIndex=${effectIndex}`,
-		);
-		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
-			remotionRoot,
-			fileName,
-			action: 'modify',
-		});
-
-		const fileContents = readFileSync(absolutePath, 'utf-8');
-		const {output, formatted, effectLabel, logLine} = await deleteEffect({
-			input: fileContents,
-			sequenceNodePath: sequenceNodePath.nodePath,
-			effectIndex,
-		});
-
-		pushToUndoStack({
-			filePath: absolutePath,
-			oldContents: fileContents,
-			logLevel,
-			remotionRoot,
-			logLine,
-			description: {
-				undoMessage: `↩️  Deletion of ${effectLabel}`,
-				redoMessage: `↪️  Deletion of ${effectLabel}`,
-			},
-			entryType: 'delete-effect',
-			suppressHmrOnFileRestore: false,
-		});
-		suppressUndoStackInvalidation(absolutePath);
-		writeFileAndNotifyFileWatchers(absolutePath, output, undefined);
-
-		const locationLabel = formatLogFileLocation({
-			remotionRoot,
-			absolutePath,
-			line: logLine,
-		});
-		RenderInternals.Log.info(
-			{indent: false, logLevel},
-			`${RenderInternals.chalk.blueBright(`${locationLabel}`)} ${strikeThroughOrRemovedPrefix(effectLabel)}`,
-		);
-		if (!formatted) {
-			warnAboutPrettierOnce(logLevel);
+		if (effects.length === 0) {
+			throw new Error('No effects were specified for deletion');
 		}
 
-		RenderInternals.Log.verbose(
+		RenderInternals.Log.trace(
 			{indent: false, logLevel},
-			`[delete-effect] Wrote ${fileRelativeToRoot}${formatted ? ' (formatted)' : ''}`,
+			`[delete-effect] Received request to delete ${effects.length} effect target${effects.length === 1 ? '' : 's'}`,
 		);
+
+		const itemsByFileName = new Map<string, typeof effects>();
+		for (const item of effects) {
+			const fileItems = itemsByFileName.get(item.fileName) ?? [];
+			fileItems.push(item);
+			itemsByFileName.set(item.fileName, fileItems);
+		}
+
+		const updates = await Promise.all(
+			[...itemsByFileName.entries()].map(async ([fileName, fileItems]) => {
+				const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+					remotionRoot,
+					fileName,
+					action: 'modify',
+				});
+
+				const fileContents = readFileSync(absolutePath, 'utf-8');
+				const {output, formatted, effectLabels, logLines} = await deleteEffects(
+					{
+						input: fileContents,
+						effects: fileItems.map((item) => ({
+							sequenceNodePath: item.sequenceNodePath.nodePath,
+							effectIndex: item.effectIndex,
+						})),
+					},
+				);
+
+				return {
+					absolutePath,
+					fileRelativeToRoot,
+					fileContents,
+					output,
+					formatted,
+					effectLabels,
+					logLine: Math.min(...logLines),
+				};
+			}),
+		);
+
+		for (const update of updates) {
+			const deletedEffectDescription = getDeletedEffectDescription(
+				update.effectLabels,
+			);
+
+			pushToUndoStack({
+				filePath: update.absolutePath,
+				oldContents: update.fileContents,
+				logLevel,
+				remotionRoot,
+				logLine: update.logLine,
+				description: {
+					undoMessage: `↩️  Deletion of ${deletedEffectDescription}`,
+					redoMessage: `↪️  Deletion of ${deletedEffectDescription}`,
+				},
+				entryType: 'delete-effect',
+				suppressHmrOnFileRestore: false,
+			});
+			suppressUndoStackInvalidation(update.absolutePath);
+			writeFileAndNotifyFileWatchers(
+				update.absolutePath,
+				update.output,
+				undefined,
+			);
+
+			const locationLabel = formatLogFileLocation({
+				remotionRoot,
+				absolutePath: update.absolutePath,
+				line: update.logLine,
+			});
+			RenderInternals.Log.info(
+				{indent: false, logLevel},
+				`${RenderInternals.chalk.blueBright(`${locationLabel}`)} ${strikeThroughOrRemovedPrefix(deletedEffectDescription)}`,
+			);
+			if (!update.formatted) {
+				warnAboutPrettierOnce(logLevel);
+			}
+
+			RenderInternals.Log.verbose(
+				{indent: false, logLevel},
+				`[delete-effect] Wrote ${update.fileRelativeToRoot}${update.formatted ? ' (formatted)' : ''}`,
+			);
+		}
 
 		printUndoHint(logLevel);
 

--- a/packages/studio-server/src/test/delete-effect.test.ts
+++ b/packages/studio-server/src/test/delete-effect.test.ts
@@ -54,10 +54,12 @@ test('deleteEffects removes multiple targeted effects in one pass', async () => 
 		input,
 		effects: [
 			{
+				type: 'single-effect',
 				sequenceNodePath: lineColumnToNodePath(input, 6),
 				effectIndex: 0,
 			},
 			{
+				type: 'single-effect',
 				sequenceNodePath: lineColumnToNodePath(input, 6),
 				effectIndex: 2,
 			},
@@ -79,8 +81,8 @@ test('deleteEffects removes all effects from the target sequence', async () => {
 		input,
 		effects: [
 			{
+				type: 'all-effects',
 				sequenceNodePath: lineColumnToNodePath(input, 6),
-				effectIndex: null,
 			},
 		],
 	});

--- a/packages/studio-server/src/test/delete-effect.test.ts
+++ b/packages/studio-server/src/test/delete-effect.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'bun:test';
-import {deleteEffect} from '../codemods/delete-effect';
+import {deleteEffect, deleteEffects} from '../codemods/delete-effect';
 import {lineColumnToNodePath} from './test-utils';
 
 const buildInput = (
@@ -44,6 +44,51 @@ test('deleteEffect removes the targeted effect by index', async () => {
 	expect(output).not.toMatch(/color: ['"]green['"]/);
 	expect(output).toMatch(/color: ['"]blue['"]/);
 	expect(output).toContain('effects={[');
+});
+
+test('deleteEffects removes multiple targeted effects in one pass', async () => {
+	const input = buildInput(
+		'[tint({color: "red"}), tint({color: "green"}), tint({color: "blue"})]',
+	);
+	const {output, effectLabels} = await deleteEffects({
+		input,
+		effects: [
+			{
+				sequenceNodePath: lineColumnToNodePath(input, 6),
+				effectIndex: 0,
+			},
+			{
+				sequenceNodePath: lineColumnToNodePath(input, 6),
+				effectIndex: 2,
+			},
+		],
+	});
+
+	expect(effectLabels).toEqual(['tint()', 'tint()']);
+	expect(output).not.toMatch(/color: ['"]red['"]/);
+	expect(output).toMatch(/color: ['"]green['"]/);
+	expect(output).not.toMatch(/color: ['"]blue['"]/);
+	expect(output).toContain('effects={[');
+});
+
+test('deleteEffects removes all effects from the target sequence', async () => {
+	const input = buildInput(
+		'[tint({color: "red"}), tint({color: "green"}), tint({color: "blue"})]',
+	);
+	const {output, effectLabels} = await deleteEffects({
+		input,
+		effects: [
+			{
+				sequenceNodePath: lineColumnToNodePath(input, 6),
+				effectIndex: null,
+			},
+		],
+	});
+
+	expect(effectLabels).toEqual(['tint()', 'tint()', 'tint()']);
+	expect(output).not.toContain('effects=');
+	expect(output).not.toContain('tint(');
+	expect(output).toContain('<HtmlInCanvas>');
 });
 
 test('deleteEffect keeps the effects prop when other effects remain', async () => {

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -329,11 +329,19 @@ export type AddEffectKeyframeRequest = {
 
 export type AddEffectKeyframeResponse = SaveEffectPropsResponse;
 
-export type DeleteEffectRequestItem = {
+type BaseDeleteEffectRequestItem = {
 	fileName: string;
 	sequenceNodePath: SequencePropsSubscriptionKey;
-	effectIndex: number | null;
 };
+
+export type DeleteEffectRequestItem =
+	| (BaseDeleteEffectRequestItem & {
+			type: 'single-effect';
+			effectIndex: number;
+	  })
+	| (BaseDeleteEffectRequestItem & {
+			type: 'all-effects';
+	  });
 
 export type DeleteEffectRequest = DeleteEffectRequestItem[];
 

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -329,11 +329,13 @@ export type AddEffectKeyframeRequest = {
 
 export type AddEffectKeyframeResponse = SaveEffectPropsResponse;
 
-export type DeleteEffectRequest = {
+export type DeleteEffectRequestItem = {
 	fileName: string;
 	sequenceNodePath: SequencePropsSubscriptionKey;
-	effectIndex: number;
+	effectIndex: number | null;
 };
+
+export type DeleteEffectRequest = DeleteEffectRequestItem[];
 
 export type DeleteEffectResponse =
 	| {

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -18,6 +18,7 @@ export {
 	DeleteEffectKeyframeRequest,
 	DeleteEffectKeyframeResponse,
 	DeleteEffectRequest,
+	DeleteEffectRequestItem,
 	DeleteEffectResponse,
 	DeleteJsxNodeRequest,
 	DeleteJsxNodeRequestItem,

--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -97,6 +97,7 @@ export const TimelineEffectItem: React.FC<{
 		try {
 			const result = await callApi('/api/delete-effect', [
 				{
+					type: 'single-effect',
 					fileName: validatedLocation.source,
 					sequenceNodePath: nodePath,
 					effectIndex,

--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -95,11 +95,13 @@ export const TimelineEffectItem: React.FC<{
 		}
 
 		try {
-			const result = await callApi('/api/delete-effect', {
-				fileName: validatedLocation.source,
-				sequenceNodePath: nodePath,
-				effectIndex,
-			});
+			const result = await callApi('/api/delete-effect', [
+				{
+					fileName: validatedLocation.source,
+					sequenceNodePath: nodePath,
+					effectIndex,
+				},
+			]);
 			if (result.success) {
 				showNotification('Removed effect from source file', 2000);
 			} else {

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -68,10 +68,17 @@ const deleteSequences = (
 };
 
 const deleteEffects = (
-	effects: {
+	effects: ({
 		nodePathInfo: SequenceNodePathInfo;
-		effectIndex: number | null;
-	}[],
+	} & (
+		| {
+				type: 'single-effect';
+				effectIndex: number;
+		  }
+		| {
+				type: 'all-effects';
+		  }
+	))[],
 ): Promise<void> => {
 	if (effects.length === 0) {
 		return Promise.resolve();
@@ -79,20 +86,27 @@ const deleteEffects = (
 
 	return callApi(
 		'/api/delete-effect',
-		effects.map(({nodePathInfo, effectIndex}) => {
-			const nodePath = nodePathInfo.sequenceSubscriptionKey;
-			return {
-				fileName: nodePath.absolutePath,
-				sequenceNodePath: nodePath,
-				effectIndex,
-			};
+		effects.map((effect) => {
+			const nodePath = effect.nodePathInfo.sequenceSubscriptionKey;
+			return effect.type === 'single-effect'
+				? {
+						type: 'single-effect',
+						fileName: nodePath.absolutePath,
+						sequenceNodePath: nodePath,
+						effectIndex: effect.effectIndex,
+					}
+				: {
+						type: 'all-effects',
+						fileName: nodePath.absolutePath,
+						sequenceNodePath: nodePath,
+					};
 		}),
 	)
 		.then((result) => {
 			if (result.success) {
 				const singleEffect = effects[0];
 				showNotification(
-					effects.length === 1 && singleEffect?.effectIndex !== null
+					effects.length === 1 && singleEffect?.type === 'single-effect'
 						? 'Removed effect from source file'
 						: effects.length === 1
 							? 'Removed effects from source file'
@@ -137,14 +151,18 @@ export const deleteSelectedTimelineItem = ({
 			return deleteSequences([selection.nodePathInfo]);
 		case 'sequence-effect':
 			return deleteEffects([
-				{nodePathInfo: selection.nodePathInfo, effectIndex: selection.i},
+				{
+					type: 'single-effect',
+					nodePathInfo: selection.nodePathInfo,
+					effectIndex: selection.i,
+				},
 			]);
 		case 'sequence-prop':
 		case 'sequence-effect-prop':
 			return null;
 		case 'sequence-all-effects':
 			return deleteEffects([
-				{nodePathInfo: selection.nodePathInfo, effectIndex: null},
+				{type: 'all-effects', nodePathInfo: selection.nodePathInfo},
 			]);
 		default:
 			throw new Error(
@@ -224,6 +242,7 @@ export const deleteSelectedTimelineItems = ({
 		case 'sequence-effect':
 			return deleteEffects(
 				selections.filter(isSequenceEffectSelection).map((selection) => ({
+					type: 'single-effect',
 					nodePathInfo: selection.nodePathInfo,
 					effectIndex: selection.i,
 				})),
@@ -256,8 +275,8 @@ export const deleteSelectedTimelineItems = ({
 		case 'sequence-all-effects':
 			return deleteEffects(
 				selections.filter(isSequenceAllEffectsSelection).map((selection) => ({
+					type: 'all-effects',
 					nodePathInfo: selection.nodePathInfo,
-					effectIndex: null,
 				})),
 			);
 		default:

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -67,20 +67,38 @@ const deleteSequences = (
 		});
 };
 
-const deleteEffect = (
-	nodePathInfo: SequenceNodePathInfo,
-	effectIndex: number,
+const deleteEffects = (
+	effects: {
+		nodePathInfo: SequenceNodePathInfo;
+		effectIndex: number | null;
+	}[],
 ): Promise<void> => {
-	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	if (effects.length === 0) {
+		return Promise.resolve();
+	}
 
-	return callApi('/api/delete-effect', {
-		fileName: nodePath.absolutePath,
-		sequenceNodePath: nodePath,
-		effectIndex,
-	})
+	return callApi(
+		'/api/delete-effect',
+		effects.map(({nodePathInfo, effectIndex}) => {
+			const nodePath = nodePathInfo.sequenceSubscriptionKey;
+			return {
+				fileName: nodePath.absolutePath,
+				sequenceNodePath: nodePath,
+				effectIndex,
+			};
+		}),
+	)
 		.then((result) => {
 			if (result.success) {
-				showNotification('Removed effect from source file', 2000);
+				const singleEffect = effects[0];
+				showNotification(
+					effects.length === 1 && singleEffect?.effectIndex !== null
+						? 'Removed effect from source file'
+						: effects.length === 1
+							? 'Removed effects from source file'
+							: 'Removed effects from source files',
+					2000,
+				);
 			} else {
 				showNotification(result.reason, 4000);
 			}
@@ -118,11 +136,16 @@ export const deleteSelectedTimelineItem = ({
 		case 'sequence':
 			return deleteSequences([selection.nodePathInfo]);
 		case 'sequence-effect':
-			return deleteEffect(selection.nodePathInfo, selection.i);
+			return deleteEffects([
+				{nodePathInfo: selection.nodePathInfo, effectIndex: selection.i},
+			]);
 		case 'sequence-prop':
-		case 'sequence-all-effects':
 		case 'sequence-effect-prop':
 			return null;
+		case 'sequence-all-effects':
+			return deleteEffects([
+				{nodePathInfo: selection.nodePathInfo, effectIndex: null},
+			]);
 		default:
 			throw new Error(
 				`Unexpected timeline selection type: ${selection satisfies never}`,
@@ -141,6 +164,12 @@ const isSequenceEffectSelection = (
 ): selection is TimelineSelection & {
 	type: 'sequence-effect';
 } => selection.type === 'sequence-effect';
+
+const isSequenceAllEffectsSelection = (
+	selection: TimelineSelection,
+): selection is TimelineSelection & {
+	type: 'sequence-all-effects';
+} => selection.type === 'sequence-all-effects';
 
 const isKeyframeSelection = (
 	selection: TimelineSelection,
@@ -193,13 +222,12 @@ export const deleteSelectedTimelineItems = ({
 					.map((selection) => selection.nodePathInfo),
 			);
 		case 'sequence-effect':
-			return Promise.all(
-				selections
-					.filter(isSequenceEffectSelection)
-					.map((selection) =>
-						deleteEffect(selection.nodePathInfo, selection.i),
-					),
-			).then(() => undefined);
+			return deleteEffects(
+				selections.filter(isSequenceEffectSelection).map((selection) => ({
+					nodePathInfo: selection.nodePathInfo,
+					effectIndex: selection.i,
+				})),
+			);
 		case 'keyframe': {
 			const deletePromises = selections
 				.filter(isKeyframeSelection)
@@ -223,9 +251,15 @@ export const deleteSelectedTimelineItems = ({
 		}
 
 		case 'sequence-prop':
-		case 'sequence-all-effects':
 		case 'sequence-effect-prop':
 			return null;
+		case 'sequence-all-effects':
+			return deleteEffects(
+				selections.filter(isSequenceAllEffectsSelection).map((selection) => ({
+					nodePathInfo: selection.nodePathInfo,
+					effectIndex: null,
+				})),
+			);
 		default:
 			throw new Error(
 				`Unexpected timeline selection type: ${firstSelection satisfies never}`,


### PR DESCRIPTION
## Summary
- Batch `/api/delete-effect` so multiple effect deletions are processed in one request.
- Delete all effects through the same endpoint when the effects group row is selected.
- Update Studio callers to use the array request shape.

Fixes #7862

## Test plan
- `bun test packages/studio-server/src/test/delete-effect.test.ts packages/studio/src/test/timeline-selection.test.ts`
- `bunx turbo make --filter='@remotion/studio-shared' --filter='@remotion/studio-server' --filter='@remotion/studio'`
- `bun run build`
- `bun run formatting`