### PR TITLE
`@remotion/studio`: Add UV effect handles

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -381,7 +381,7 @@ type SelectedEffectFields = {
 	fieldKeys: Set<string>;
 };
 
-const getSelectedEffectFieldsBySequenceKey = (
+export const getSelectedEffectFieldsBySequenceKey = (
 	selectedItems: readonly TimelineSelection[],
 ): Map<string, Map<number, SelectedEffectFields>> => {
 	const selectedEffects = new Map<string, Map<number, SelectedEffectFields>>();

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -403,11 +403,7 @@ export const getSelectedEffectFieldsBySequenceKey = (
 			fieldKeys: new Set<string>(),
 		};
 
-		if (item.type === 'sequence-effect') {
-			selectedFields.allFields = true;
-		} else {
-			selectedFields.fieldKeys.add(item.key);
-		}
+		selectedFields.allFields = true;
 
 		effectsForSequence.set(item.i, selectedFields);
 		selectedEffects.set(sequenceKey, effectsForSequence);

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1,7 +1,10 @@
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import type {
 	CanUpdateSequencePropStatusTrue,
+	CodeValues,
+	GetEffectDragOverrides,
 	OverrideIdToNodePaths,
+	SequenceFieldSchema,
 	SequencePropsSubscriptionKey,
 	SequenceSchema,
 	TSequence,
@@ -12,7 +15,9 @@ import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {BLUE} from '../helpers/colors';
 import {getBoxQuadsPonyfill} from '../helpers/get-box-quads-ponyfill';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+import {saveEffectProp} from './Timeline/save-effect-prop';
 import {saveSequenceProp} from './Timeline/save-sequence-prop';
+import {getDecimalPlaces} from './Timeline/timeline-field-utils';
 import {
 	parseTranslate,
 	serializeTranslate,
@@ -39,10 +44,30 @@ type SelectedOutline = {
 	];
 };
 
+type UvCoordinate = readonly [number, number];
+
+type UvCoordinateFieldSchema = Extract<
+	SequenceFieldSchema,
+	{type: 'uv-coordinate'}
+>;
+
+type SelectedOutlineUvHandle = {
+	readonly clientId: string;
+	readonly codeValue: CanUpdateSequencePropStatusTrue;
+	readonly effectIndex: number;
+	readonly fieldDefault: UvCoordinate | undefined;
+	readonly fieldKey: string;
+	readonly fieldSchema: UvCoordinateFieldSchema;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly schema: SequenceSchema;
+	readonly value: UvCoordinate;
+};
+
 type SelectedOutlineTarget = {
 	readonly key: string;
 	readonly ref: React.RefObject<HTMLElement | null>;
 	readonly drag: SelectedOutlineDragTarget | null;
+	readonly uvHandles: readonly SelectedOutlineUvHandle[];
 };
 
 type SelectedOutlineDragTarget = {
@@ -69,6 +94,113 @@ const outlineContainer: React.CSSProperties = {
 };
 
 const pointToString = (point: OutlinePoint) => `${point.x},${point.y}`;
+
+const parseUvCoordinate = (value: unknown): UvCoordinate | null => {
+	if (
+		Array.isArray(value) &&
+		value.length === 2 &&
+		value.every((item) => typeof item === 'number' && Number.isFinite(item))
+	) {
+		return [value[0], value[1]];
+	}
+
+	return null;
+};
+
+const tuplesEqual = (left: unknown, right: UvCoordinate): boolean => {
+	if (!Array.isArray(left) || left.length !== 2) {
+		return false;
+	}
+
+	return left[0] === right[0] && left[1] === right[1];
+};
+
+const mix = (from: number, to: number, progress: number): number => {
+	return from + (to - from) * progress;
+};
+
+const mixPoint = (
+	from: OutlinePoint,
+	to: OutlinePoint,
+	progress: number,
+): OutlinePoint => {
+	return {
+		x: mix(from.x, to.x, progress),
+		y: mix(from.y, to.y, progress),
+	};
+};
+
+export const getUvHandlePosition = (
+	points: SelectedOutline['points'],
+	uv: UvCoordinate,
+): OutlinePoint => {
+	const [tl, tr, br, bl] = points;
+	const top = mixPoint(tl, tr, uv[0]);
+	const bottom = mixPoint(bl, br, uv[0]);
+	return mixPoint(top, bottom, uv[1]);
+};
+
+const vectorBetween = (from: OutlinePoint, to: OutlinePoint): OutlinePoint => {
+	return {x: to.x - from.x, y: to.y - from.y};
+};
+
+export const getUvCoordinateForPoint = (
+	points: SelectedOutline['points'],
+	point: OutlinePoint,
+): UvCoordinate => {
+	const [tl, tr, br, bl] = points;
+	let u = 0.5;
+	let v = 0.5;
+
+	for (let i = 0; i < 8; i++) {
+		const current = getUvHandlePosition(points, [u, v]);
+		const errorX = current.x - point.x;
+		const errorY = current.y - point.y;
+		if (Math.abs(errorX) + Math.abs(errorY) < 0.001) {
+			break;
+		}
+
+		const du = {
+			x: mix(tr.x - tl.x, br.x - bl.x, v),
+			y: mix(tr.y - tl.y, br.y - bl.y, v),
+		};
+		const dv = vectorBetween(mixPoint(tl, tr, u), mixPoint(bl, br, u));
+		const determinant = du.x * dv.y - du.y * dv.x;
+		if (Math.abs(determinant) < 0.000001) {
+			break;
+		}
+
+		u -= (errorX * dv.y - errorY * dv.x) / determinant;
+		v -= (du.x * errorY - du.y * errorX) / determinant;
+	}
+
+	return [u, v];
+};
+
+const clamp = (value: number, min: number, max: number): number => {
+	return Math.min(max, Math.max(min, value));
+};
+
+const roundToStep = (value: number, step: number | undefined): number => {
+	if (step === undefined || !Number.isFinite(step) || step <= 0) {
+		return value;
+	}
+
+	const decimals = getDecimalPlaces(step);
+	return Number((Math.round(value / step) * step).toFixed(decimals));
+};
+
+const constrainUv = (
+	value: UvCoordinate,
+	schema: UvCoordinateFieldSchema,
+): UvCoordinate => {
+	const min = schema.min ?? -Infinity;
+	const max = schema.max ?? Infinity;
+	return [
+		clamp(roundToStep(value[0], schema.step), min, max),
+		clamp(roundToStep(value[1], schema.step), min, max),
+	];
+};
 
 const rectToPoints = (
 	elementRect: DOMRect,
@@ -137,6 +269,46 @@ const getSelectedSequenceKeys = (
 	);
 };
 
+type SelectedEffectFields = {
+	allFields: boolean;
+	fieldKeys: Set<string>;
+};
+
+const getSelectedEffectFieldsBySequenceKey = (
+	selectedItems: readonly TimelineSelection[],
+): Map<string, Map<number, SelectedEffectFields>> => {
+	const selectedEffects = new Map<string, Map<number, SelectedEffectFields>>();
+
+	for (const item of selectedItems) {
+		if (
+			item.type !== 'sequence-effect' &&
+			item.type !== 'sequence-effect-prop'
+		) {
+			continue;
+		}
+
+		const sequenceKey = getTimelineSequenceSelectionKey(item.nodePathInfo);
+		const effectsForSequence =
+			selectedEffects.get(sequenceKey) ??
+			new Map<number, SelectedEffectFields>();
+		const selectedFields = effectsForSequence.get(item.i) ?? {
+			allFields: false,
+			fieldKeys: new Set<string>(),
+		};
+
+		if (item.type === 'sequence-effect') {
+			selectedFields.allFields = true;
+		} else {
+			selectedFields.fieldKeys.add(item.key);
+		}
+
+		effectsForSequence.set(item.i, selectedFields);
+		selectedEffects.set(sequenceKey, effectsForSequence);
+	}
+
+	return selectedEffects;
+};
+
 const getSequencesWithSelectedOutlines = ({
 	selectedItems,
 	sequences,
@@ -177,6 +349,99 @@ const getSequencesWithSelectedOutlines = ({
 				sequence: track.sequence,
 			};
 		});
+};
+
+const getSelectedUvHandles = ({
+	codeValues,
+	clientId,
+	getEffectDragOverrides,
+	nodePath,
+	selectedEffects,
+	sequence,
+}: {
+	readonly codeValues: CodeValues;
+	readonly clientId: string | null;
+	readonly getEffectDragOverrides: GetEffectDragOverrides;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly selectedEffects: Map<number, SelectedEffectFields> | undefined;
+	readonly sequence: TSequence;
+}): SelectedOutlineUvHandle[] => {
+	if (clientId === null || selectedEffects === undefined) {
+		return [];
+	}
+
+	const handles: SelectedOutlineUvHandle[] = [];
+
+	for (const [effectIndex, selectedFields] of selectedEffects) {
+		const effect = sequence.effects[effectIndex];
+		if (!effect) {
+			continue;
+		}
+
+		const effectStatus = Internals.getEffectCodeValuesCtx({
+			codeValues,
+			nodePath,
+			effectIndex,
+		});
+		if (effectStatus.type !== 'can-update-effect') {
+			continue;
+		}
+
+		const dragOverrides = getEffectDragOverrides(nodePath, effectIndex);
+		const activeSchema = Internals.flattenActiveSchema(effect.schema, (key) => {
+			const dragOverride = dragOverrides[key];
+			if (dragOverride !== undefined) {
+				return dragOverride;
+			}
+
+			const propStatus = effectStatus.props[key];
+			if (!propStatus?.canUpdate) {
+				return undefined;
+			}
+
+			return propStatus.codeValue;
+		});
+
+		for (const [fieldKey, fieldSchema] of Object.entries(activeSchema)) {
+			if (
+				fieldSchema.type !== 'uv-coordinate' ||
+				(!selectedFields.allFields && !selectedFields.fieldKeys.has(fieldKey))
+			) {
+				continue;
+			}
+
+			const propStatus = effectStatus.props[fieldKey];
+			if (!propStatus?.canUpdate) {
+				continue;
+			}
+
+			const dragOverrideValue = dragOverrides[fieldKey];
+			const effectiveValue = Internals.getEffectiveVisualModeValue({
+				codeValue: propStatus,
+				dragOverrideValue,
+				defaultValue: fieldSchema.default,
+				shouldResortToDefaultValueIfUndefined: true,
+			});
+			const value = parseUvCoordinate(effectiveValue);
+			if (value === null) {
+				continue;
+			}
+
+			handles.push({
+				clientId,
+				codeValue: propStatus,
+				effectIndex,
+				fieldDefault: fieldSchema.default,
+				fieldKey,
+				fieldSchema,
+				nodePath,
+				schema: effect.schema,
+				value,
+			});
+		}
+	}
+
+	return handles;
 };
 
 const measureOutlines = (
@@ -345,6 +610,142 @@ const SelectedOutlinePolygon: React.FC<{
 	);
 };
 
+const getSvgPointFromPointerEvent = ({
+	event,
+	rect,
+}: {
+	readonly event: Pick<PointerEvent, 'clientX' | 'clientY'>;
+	readonly rect: DOMRect;
+}): OutlinePoint => {
+	return {
+		x: event.clientX - rect.left,
+		y: event.clientY - rect.top,
+	};
+};
+
+const SelectedUvHandleCircle: React.FC<{
+	readonly handle: SelectedOutlineUvHandle;
+	readonly outline: SelectedOutline;
+}> = ({handle, outline}) => {
+	const {setEffectDragOverrides, clearEffectDragOverrides, setCodeValues} =
+		useContext(Internals.VisualModeSettersContext);
+	const position = useMemo(
+		() => getUvHandlePosition(outline.points, handle.value),
+		[handle.value, outline.points],
+	);
+
+	const onPointerDown = React.useCallback(
+		(event: React.PointerEvent<SVGCircleElement>) => {
+			if (event.button !== 0) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			const svg = event.currentTarget.ownerSVGElement;
+			if (svg === null) {
+				return;
+			}
+
+			const svgRect = svg.getBoundingClientRect();
+			let lastValue: UvCoordinate | null = null;
+			const defaultValue =
+				handle.fieldDefault !== undefined
+					? JSON.stringify(handle.fieldDefault)
+					: null;
+
+			const updateFromPointerEvent = (
+				pointerEvent: PointerEvent | React.PointerEvent<SVGCircleElement>,
+			) => {
+				const point = getSvgPointFromPointerEvent({
+					event: pointerEvent,
+					rect: svgRect,
+				});
+				const nextValue = constrainUv(
+					getUvCoordinateForPoint(outline.points, point),
+					handle.fieldSchema,
+				);
+				lastValue = nextValue;
+				setEffectDragOverrides(
+					handle.nodePath,
+					handle.effectIndex,
+					handle.fieldKey,
+					nextValue,
+				);
+			};
+
+			updateFromPointerEvent(event);
+
+			const onPointerMove = (moveEvent: PointerEvent) => {
+				moveEvent.preventDefault();
+				updateFromPointerEvent(moveEvent);
+			};
+
+			const onPointerUp = () => {
+				window.removeEventListener('pointermove', onPointerMove);
+				window.removeEventListener('pointerup', onPointerUp);
+				window.removeEventListener('pointercancel', onPointerUp);
+
+				const stringifiedValue =
+					lastValue === null ? null : JSON.stringify(lastValue);
+				const shouldSave =
+					lastValue !== null &&
+					!tuplesEqual(handle.codeValue.codeValue, lastValue) &&
+					!(
+						defaultValue === stringifiedValue &&
+						handle.codeValue.codeValue === undefined
+					);
+
+				if (!shouldSave) {
+					clearEffectDragOverrides(handle.nodePath, handle.effectIndex);
+					return;
+				}
+
+				saveEffectProp({
+					fileName: handle.nodePath.absolutePath,
+					nodePath: handle.nodePath,
+					effectIndex: handle.effectIndex,
+					fieldKey: handle.fieldKey,
+					value: lastValue,
+					defaultValue,
+					schema: handle.schema,
+					setCodeValues,
+					clientId: handle.clientId,
+				}).finally(() => {
+					clearEffectDragOverrides(handle.nodePath, handle.effectIndex);
+				});
+			};
+
+			window.addEventListener('pointermove', onPointerMove);
+			window.addEventListener('pointerup', onPointerUp);
+			window.addEventListener('pointercancel', onPointerUp);
+		},
+		[
+			clearEffectDragOverrides,
+			handle,
+			outline.points,
+			setCodeValues,
+			setEffectDragOverrides,
+		],
+	);
+
+	return (
+		<circle
+			cx={position.x}
+			cy={position.y}
+			r={6}
+			fill="white"
+			stroke={BLUE}
+			strokeWidth={2}
+			vectorEffect="non-scaling-stroke"
+			pointerEvents="all"
+			cursor="move"
+			onPointerDown={onPointerDown}
+		/>
+	);
+};
+
 export const SelectedOutlineOverlay: React.FC<{
 	readonly scale: number;
 }> = ({scale}) => {
@@ -355,6 +756,9 @@ export const SelectedOutlineOverlay: React.FC<{
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
 	);
+	const {getEffectDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
 	const [outlines, setOutlines] = useState<readonly SelectedOutline[]>([]);
 	const overlayRef = useRef<SVGSVGElement>(null);
 
@@ -362,6 +766,13 @@ export const SelectedOutlineOverlay: React.FC<{
 		if (!ENABLE_OUTLINES) {
 			return [];
 		}
+
+		const selectedEffectsBySequenceKey =
+			getSelectedEffectFieldsBySequenceKey(selectedItems);
+		const clientId =
+			previewServerState.type === 'connected'
+				? previewServerState.clientId
+				: null;
 
 		return getSequencesWithSelectedOutlines({
 			selectedItems,
@@ -396,10 +807,19 @@ export const SelectedOutlineOverlay: React.FC<{
 							schema: controls.schema,
 						}
 					: null,
+				uvHandles: getSelectedUvHandles({
+					codeValues,
+					clientId,
+					getEffectDragOverrides,
+					nodePath,
+					selectedEffects: selectedEffectsBySequenceKey.get(key),
+					sequence,
+				}),
 			};
 		});
 	}, [
 		codeValues,
+		getEffectDragOverrides,
 		overrideIdToNodePathMappings,
 		previewServerState,
 		selectedItems,
@@ -460,12 +880,20 @@ export const SelectedOutlineOverlay: React.FC<{
 			aria-hidden="true"
 		>
 			{outlines.map((outline) => (
-				<SelectedOutlinePolygon
-					key={outline.key}
-					outline={outline}
-					scale={scale}
-					target={targetsByKey.get(outline.key)}
-				/>
+				<React.Fragment key={outline.key}>
+					<SelectedOutlinePolygon
+						outline={outline}
+						scale={scale}
+						target={targetsByKey.get(outline.key)}
+					/>
+					{targetsByKey.get(outline.key)?.uvHandles.map((handle) => (
+						<SelectedUvHandleCircle
+							key={`${handle.effectIndex}-${handle.fieldKey}`}
+							handle={handle}
+							outline={outline}
+						/>
+					))}
+				</React.Fragment>
 			))}
 		</svg>
 	);

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -130,7 +130,7 @@ const mixPoint = (
 	};
 };
 
-export const getUvHandlePosition = (
+const getBilinearUvHandlePosition = (
 	points: SelectedOutline['points'],
 	uv: UvCoordinate,
 ): OutlinePoint => {
@@ -140,11 +140,80 @@ export const getUvHandlePosition = (
 	return mixPoint(top, bottom, uv[1]);
 };
 
+type ProjectiveTransform = {
+	readonly a: number;
+	readonly b: number;
+	readonly c: number;
+	readonly d: number;
+	readonly e: number;
+	readonly f: number;
+	readonly g: number;
+	readonly h: number;
+};
+
+const projectiveEpsilon = 0.000001;
+
+const getProjectiveTransform = (
+	points: SelectedOutline['points'],
+): ProjectiveTransform | null => {
+	const [tl, tr, br, bl] = points;
+	const dx1 = tr.x - br.x;
+	const dx2 = bl.x - br.x;
+	const dx3 = tl.x - tr.x + br.x - bl.x;
+	const dy1 = tr.y - br.y;
+	const dy2 = bl.y - br.y;
+	const dy3 = tl.y - tr.y + br.y - bl.y;
+
+	let g = 0;
+	let h = 0;
+	if (Math.abs(dx3) > projectiveEpsilon || Math.abs(dy3) > projectiveEpsilon) {
+		const determinant = dx1 * dy2 - dx2 * dy1;
+		if (Math.abs(determinant) < projectiveEpsilon) {
+			return null;
+		}
+
+		g = (dx3 * dy2 - dx2 * dy3) / determinant;
+		h = (dx1 * dy3 - dx3 * dy1) / determinant;
+	}
+
+	return {
+		a: tr.x - tl.x + g * tr.x,
+		b: bl.x - tl.x + h * bl.x,
+		c: tl.x,
+		d: tr.y - tl.y + g * tr.y,
+		e: bl.y - tl.y + h * bl.y,
+		f: tl.y,
+		g,
+		h,
+	};
+};
+
+const applyProjectiveTransform = (
+	transform: ProjectiveTransform,
+	uv: UvCoordinate,
+): OutlinePoint => {
+	const denominator = transform.g * uv[0] + transform.h * uv[1] + 1;
+	return {
+		x: (transform.a * uv[0] + transform.b * uv[1] + transform.c) / denominator,
+		y: (transform.d * uv[0] + transform.e * uv[1] + transform.f) / denominator,
+	};
+};
+
+export const getUvHandlePosition = (
+	points: SelectedOutline['points'],
+	uv: UvCoordinate,
+): OutlinePoint => {
+	const transform = getProjectiveTransform(points);
+	return transform === null
+		? getBilinearUvHandlePosition(points, uv)
+		: applyProjectiveTransform(transform, uv);
+};
+
 const vectorBetween = (from: OutlinePoint, to: OutlinePoint): OutlinePoint => {
 	return {x: to.x - from.x, y: to.y - from.y};
 };
 
-export const getUvCoordinateForPoint = (
+const getBilinearUvCoordinateForPoint = (
 	points: SelectedOutline['points'],
 	point: OutlinePoint,
 ): UvCoordinate => {
@@ -153,7 +222,7 @@ export const getUvCoordinateForPoint = (
 	let v = 0.5;
 
 	for (let i = 0; i < 8; i++) {
-		const current = getUvHandlePosition(points, [u, v]);
+		const current = getBilinearUvHandlePosition(points, [u, v]);
 		const errorX = current.x - point.x;
 		const errorY = current.y - point.y;
 		if (Math.abs(errorX) + Math.abs(errorY) < 0.001) {
@@ -175,6 +244,44 @@ export const getUvCoordinateForPoint = (
 	}
 
 	return [u, v];
+};
+
+export const getUvCoordinateForPoint = (
+	points: SelectedOutline['points'],
+	point: OutlinePoint,
+): UvCoordinate => {
+	const transform = getProjectiveTransform(points);
+	if (transform === null) {
+		return getBilinearUvCoordinateForPoint(points, point);
+	}
+
+	const determinant =
+		transform.a * (transform.e - transform.f * transform.h) -
+		transform.b * (transform.d - transform.f * transform.g) +
+		transform.c * (transform.d * transform.h - transform.e * transform.g);
+	if (Math.abs(determinant) < projectiveEpsilon) {
+		return getBilinearUvCoordinateForPoint(points, point);
+	}
+
+	const inverseA = transform.e - transform.f * transform.h;
+	const inverseB = transform.c * transform.h - transform.b;
+	const inverseC = transform.b * transform.f - transform.c * transform.e;
+	const inverseD = transform.f * transform.g - transform.d;
+	const inverseE = transform.a - transform.c * transform.g;
+	const inverseF = transform.c * transform.d - transform.a * transform.f;
+	const inverseG = transform.d * transform.h - transform.e * transform.g;
+	const inverseH = transform.b * transform.g - transform.a * transform.h;
+	const inverseI = transform.a * transform.e - transform.b * transform.d;
+
+	const denominator = inverseG * point.x + inverseH * point.y + inverseI;
+	if (Math.abs(denominator) < projectiveEpsilon) {
+		return getBilinearUvCoordinateForPoint(points, point);
+	}
+
+	return [
+		(inverseA * point.x + inverseB * point.y + inverseC) / denominator,
+		(inverseD * point.x + inverseE * point.y + inverseF) / denominator,
+	];
 };
 
 const clamp = (value: number, min: number, max: number): number => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -47,7 +47,7 @@ test('Timeline outlines should not be enabled', () => {
 	expect(ENABLE_OUTLINES).toBe(false);
 });
 
-test('UV handles interpolate semantic outline corners', () => {
+test('UV handles project semantic outline corners', () => {
 	const points = [
 		{x: 200, y: 200},
 		{x: 100, y: 200},
@@ -58,6 +58,20 @@ test('UV handles interpolate semantic outline corners', () => {
 	expect(getUvHandlePosition(points, [0, 0])).toEqual({x: 200, y: 200});
 	expect(getUvHandlePosition(points, [1, 1])).toEqual({x: 100, y: 100});
 	expect(getUvHandlePosition(points, [0.5, 0.5])).toEqual({x: 150, y: 150});
+});
+
+test('UV handles use projective projection for perspective quads', () => {
+	const points = [
+		{x: 0, y: 0},
+		{x: 100, y: 0},
+		{x: 150, y: 100},
+		{x: -50, y: 100},
+	] as const;
+
+	const projectedCenter = getUvHandlePosition(points, [0.5, 0.5]);
+
+	expect(projectedCenter.x).toBeCloseTo(50, 5);
+	expect(projectedCenter.y).toBeCloseTo(100 / 3, 5);
 });
 
 test('UV handle pointer position maps back to UV coordinates', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
 import type {SequenceNodePath, SequencePropsSubscriptionKey} from 'remotion';
 import {
+	getSelectedEffectFieldsBySequenceKey,
 	getUvCoordinateForPoint,
 	getUvHandlePosition,
 } from '../components/SelectedOutlineOverlay';
@@ -87,6 +88,45 @@ test('UV handle pointer position maps back to UV coordinates', () => {
 
 	expect(result[0]).toBeCloseTo(uv[0], 5);
 	expect(result[1]).toBeCloseTo(uv[1], 5);
+});
+
+test('UV handles are requested for selected effect props', () => {
+	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const effectNodePathInfo = makeNodePathInfo(['body', 0], ['effects', '1']);
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '1', 'origin'],
+	);
+	const selectedEffects = getSelectedEffectFieldsBySequenceKey([
+		{
+			type: 'sequence-effect-prop',
+			nodePathInfo: effectPropNodePathInfo,
+			i: 1,
+			key: 'origin',
+		},
+	]);
+
+	expect(
+		selectedEffects
+			.get(getTimelineSequenceSelectionKey(sequenceNodePathInfo))
+			?.get(1),
+	).toEqual({
+		allFields: false,
+		fieldKeys: new Set(['origin']),
+	});
+
+	const selectedWholeEffects = getSelectedEffectFieldsBySequenceKey([
+		{type: 'sequence-effect', nodePathInfo: effectNodePathInfo, i: 1},
+	]);
+
+	expect(
+		selectedWholeEffects
+			.get(getTimelineSequenceSelectionKey(sequenceNodePathInfo))
+			?.get(1),
+	).toEqual({
+		allFields: true,
+		fieldKeys: new Set(),
+	});
 });
 
 test('Cmd+A selection only targets selectable timeline sequences', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1,5 +1,9 @@
 import {expect, test} from 'bun:test';
 import type {SequenceNodePath, SequencePropsSubscriptionKey} from 'remotion';
+import {
+	getUvCoordinateForPoint,
+	getUvHandlePosition,
+} from '../components/SelectedOutlineOverlay';
 import {deleteSelectedTimelineItems} from '../components/Timeline/delete-selected-timeline-item';
 import {isDuplicatableSequenceRowSelection} from '../components/Timeline/duplicate-selected-timeline-item';
 import {
@@ -41,6 +45,34 @@ test('Timeline top drag should not be enabled', () => {
 
 test('Timeline outlines should not be enabled', () => {
 	expect(ENABLE_OUTLINES).toBe(false);
+});
+
+test('UV handles interpolate semantic outline corners', () => {
+	const points = [
+		{x: 200, y: 200},
+		{x: 100, y: 200},
+		{x: 100, y: 100},
+		{x: 200, y: 100},
+	] as const;
+
+	expect(getUvHandlePosition(points, [0, 0])).toEqual({x: 200, y: 200});
+	expect(getUvHandlePosition(points, [1, 1])).toEqual({x: 100, y: 100});
+	expect(getUvHandlePosition(points, [0.5, 0.5])).toEqual({x: 150, y: 150});
+});
+
+test('UV handle pointer position maps back to UV coordinates', () => {
+	const points = [
+		{x: 20, y: 10},
+		{x: 140, y: 30},
+		{x: 170, y: 120},
+		{x: 40, y: 100},
+	] as const;
+	const uv = [0.25, 0.75] as const;
+	const position = getUvHandlePosition(points, uv);
+	const result = getUvCoordinateForPoint(points, position);
+
+	expect(result[0]).toBeCloseTo(uv[0], 5);
+	expect(result[1]).toBeCloseTo(uv[1], 5);
 });
 
 test('Cmd+A selection only targets selectable timeline sequences', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -90,19 +90,19 @@ test('UV handle pointer position maps back to UV coordinates', () => {
 	expect(result[1]).toBeCloseTo(uv[1], 5);
 });
 
-test('UV handles are requested for selected effect props', () => {
+test('UV handles are requested for selected effect children', () => {
 	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
 	const effectNodePathInfo = makeNodePathInfo(['body', 0], ['effects', '1']);
 	const effectPropNodePathInfo = makeNodePathInfo(
 		['body', 0],
-		['effects', '1', 'origin'],
+		['effects', '1', 'rays'],
 	);
 	const selectedEffects = getSelectedEffectFieldsBySequenceKey([
 		{
 			type: 'sequence-effect-prop',
 			nodePathInfo: effectPropNodePathInfo,
 			i: 1,
-			key: 'origin',
+			key: 'rays',
 		},
 	]);
 
@@ -111,8 +111,8 @@ test('UV handles are requested for selected effect props', () => {
 			.get(getTimelineSequenceSelectionKey(sequenceNodePathInfo))
 			?.get(1),
 	).toEqual({
-		allFields: false,
-		fieldKeys: new Set(['origin']),
+		allFields: true,
+		fieldKeys: new Set(),
 	});
 
 	const selectedWholeEffects = getSelectedEffectFieldsBySequenceKey([


### PR DESCRIPTION
Fixes #7786.

## Summary
- Show draggable canvas handles for selected effect UV coordinate props.
- Position handles by interpolating the measured outline quad in semantic corner order.
- Save dragged UV values through the existing effect prop update pipeline.

## Testing
- `cd packages/studio && bun test src/test/timeline-selection.test.ts`
- `bunx turbo run make --filter='@remotion/studio'`
- `cd packages/studio && bun run lint --quiet`
- `bun run build && bun run stylecheck`