### PR TITLE
`@remotion/studio-server`: Batch sequence prop saves

### DIFF
--- a/packages/studio-server/src/codemods/update-sequence-props/update-sequence-props.ts
+++ b/packages/studio-server/src/codemods/update-sequence-props/update-sequence-props.ts
@@ -33,6 +33,28 @@ export type SequencePropsNodeUpdate = {
 	schema: SequenceSchema;
 };
 
+export type SequencePropsNodeUpdateResult = {
+	oldValueStrings: string[];
+	logLine: number;
+	removedProps: RemovedProp[];
+};
+
+type PrettierConfigOverride = Record<string, unknown> | null;
+
+type UpdateMultipleSequencePropsResult = {
+	output: string;
+	formatted: boolean;
+	results: SequencePropsNodeUpdateResult[];
+};
+
+type UpdateSequencePropsResult = {
+	output: string;
+	oldValueStrings: string[];
+	formatted: boolean;
+	logLine: number;
+	removedProps: RemovedProp[];
+};
+
 const removeVariantKey = ({
 	node,
 	variantKey,
@@ -290,16 +312,8 @@ export const updateMultipleSequenceProps = async ({
 }: {
 	input: string;
 	changes: SequencePropsNodeUpdate[];
-	prettierConfigOverride?: Record<string, unknown> | null;
-}): Promise<{
-	output: string;
-	formatted: boolean;
-	results: Array<{
-		oldValueStrings: string[];
-		logLine: number;
-		removedProps: RemovedProp[];
-	}>;
-}> => {
+	prettierConfigOverride: PrettierConfigOverride;
+}): Promise<UpdateMultipleSequencePropsResult> => {
 	const ast = parseAst(input);
 	const results = changes.map(({nodePath, updates, schema}) => {
 		const node = findJsxElementAtNodePath(ast, nodePath);
@@ -335,14 +349,8 @@ export const updateSequenceProps = async ({
 	nodePath: SequenceNodePath;
 	updates: SequencePropUpdate[];
 	schema: SequenceSchema;
-	prettierConfigOverride?: Record<string, unknown> | null;
-}): Promise<{
-	output: string;
-	oldValueStrings: string[];
-	formatted: boolean;
-	logLine: number;
-	removedProps: RemovedProp[];
-}> => {
+	prettierConfigOverride: PrettierConfigOverride;
+}): Promise<UpdateSequencePropsResult> => {
 	const {serialized, oldValueStrings, logLine, removedProps} =
 		updateSequencePropsAst({
 			input,

--- a/packages/studio-server/src/codemods/update-sequence-props/update-sequence-props.ts
+++ b/packages/studio-server/src/codemods/update-sequence-props/update-sequence-props.ts
@@ -7,8 +7,7 @@ import type {
 	StringLiteral,
 } from '@babel/types';
 import * as recast from 'recast';
-import type {SequenceNodePath} from 'remotion';
-import type {SequenceSchema} from 'remotion';
+import type {SequenceNodePath, SequenceSchema} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {findJsxElementAtNodePath} from '../../preview-server/routes/can-update-sequence-props';
 import {formatFileContent} from '../format-file-content';
@@ -26,6 +25,12 @@ export type SequencePropUpdate = {
 export type RemovedProp = {
 	key: string;
 	valueString: string;
+};
+
+export type SequencePropsNodeUpdate = {
+	nodePath: SequenceNodePath;
+	updates: SequencePropUpdate[];
+	schema: SequenceSchema;
 };
 
 const removeVariantKey = ({
@@ -92,31 +97,19 @@ type JSXOpeningElementLike = NonNullable<
 	ReturnType<typeof findJsxElementAtNodePath>
 >;
 
-export const updateSequencePropsAst = ({
-	input,
-	nodePath,
+const updateSequencePropsNode = ({
+	node,
 	updates,
 	schema,
 }: {
-	input: string;
-	nodePath: SequenceNodePath;
+	node: JSXOpeningElementLike;
 	updates: SequencePropUpdate[];
 	schema: SequenceSchema;
 }): {
-	serialized: string;
 	oldValueStrings: string[];
 	logLine: number;
 	removedProps: RemovedProp[];
 } => {
-	const ast = parseAst(input);
-
-	const node = findJsxElementAtNodePath(ast, nodePath);
-	if (!node) {
-		throw new Error(
-			'Could not find a JSX element at the specified line to update',
-		);
-	}
-
 	const logLine = node.loc?.start.line ?? 1;
 
 	const oldValueStrings: string[] = [];
@@ -245,10 +238,89 @@ export const updateSequencePropsAst = ({
 	}
 
 	return {
+		oldValueStrings,
+		logLine,
+		removedProps,
+	};
+};
+
+export const updateSequencePropsAst = ({
+	input,
+	nodePath,
+	updates,
+	schema,
+}: {
+	input: string;
+	nodePath: SequenceNodePath;
+	updates: SequencePropUpdate[];
+	schema: SequenceSchema;
+}): {
+	serialized: string;
+	oldValueStrings: string[];
+	logLine: number;
+	removedProps: RemovedProp[];
+} => {
+	const ast = parseAst(input);
+
+	const node = findJsxElementAtNodePath(ast, nodePath);
+	if (!node) {
+		throw new Error(
+			'Could not find a JSX element at the specified line to update',
+		);
+	}
+
+	const {oldValueStrings, logLine, removedProps} = updateSequencePropsNode({
+		node,
+		updates,
+		schema,
+	});
+
+	return {
 		serialized: serializeAst(ast),
 		oldValueStrings,
 		logLine,
 		removedProps,
+	};
+};
+
+export const updateMultipleSequenceProps = async ({
+	input,
+	changes,
+	prettierConfigOverride,
+}: {
+	input: string;
+	changes: SequencePropsNodeUpdate[];
+	prettierConfigOverride?: Record<string, unknown> | null;
+}): Promise<{
+	output: string;
+	formatted: boolean;
+	results: Array<{
+		oldValueStrings: string[];
+		logLine: number;
+		removedProps: RemovedProp[];
+	}>;
+}> => {
+	const ast = parseAst(input);
+	const results = changes.map(({nodePath, updates, schema}) => {
+		const node = findJsxElementAtNodePath(ast, nodePath);
+		if (!node) {
+			throw new Error(
+				'Could not find a JSX element at the specified line to update',
+			);
+		}
+
+		return updateSequencePropsNode({node, updates, schema});
+	});
+
+	const {output, formatted} = await formatFileContent({
+		input: serializeAst(ast),
+		prettierConfigOverride,
+	});
+
+	return {
+		output,
+		formatted,
+		results,
 	};
 };
 

--- a/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
@@ -84,6 +84,7 @@ export const addEffectKeyframeHandler: ApiHandler<
 		pushToUndoStack({
 			filePath: absolutePath,
 			oldContents: fileContents,
+			newContents: null,
 			logLevel,
 			remotionRoot,
 			logLine,

--- a/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
@@ -106,5 +106,6 @@ export const addSequenceKeyframeHandler: ApiHandler<
 		return {
 			canUpdate: true,
 			props: status.props,
+			results: [{fileName, nodePath, props: status.props}],
 		};
 	});

--- a/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
@@ -66,6 +66,7 @@ export const addSequenceKeyframeHandler: ApiHandler<
 		pushToUndoStack({
 			filePath: absolutePath,
 			oldContents: fileContents,
+			newContents: null,
 			logLevel,
 			remotionRoot,
 			logLine,

--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -93,6 +93,7 @@ export const applyCodemodHandler: ApiHandler<
 			pushToUndoStack({
 				filePath,
 				oldContents: input,
+				newContents: null,
 				logLevel,
 				remotionRoot,
 				logLine: symbolicatedStack?.originalLineNumber ?? 1,

--- a/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
@@ -103,6 +103,7 @@ export const applyVisualControlHandler: ApiHandler<
 	pushToUndoStack({
 		filePath: absolutePath,
 		oldContents: fileContents,
+		newContents: null,
 		logLevel,
 		remotionRoot,
 		logLine,

--- a/packages/studio-server/src/preview-server/routes/delete-effect-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-effect-keyframe.ts
@@ -81,6 +81,7 @@ export const deleteEffectKeyframeHandler: ApiHandler<
 		pushToUndoStack({
 			filePath: absolutePath,
 			oldContents: fileContents,
+			newContents: null,
 			logLevel,
 			remotionRoot,
 			logLine,

--- a/packages/studio-server/src/preview-server/routes/delete-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-effect.ts
@@ -93,6 +93,7 @@ export const deleteEffectHandler: ApiHandler<
 			pushToUndoStack({
 				filePath: update.absolutePath,
 				oldContents: update.fileContents,
+				newContents: null,
 				logLevel,
 				remotionRoot,
 				logLine: update.logLine,

--- a/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
@@ -80,6 +80,7 @@ export const deleteJsxNodeHandler: ApiHandler<
 			pushToUndoStack({
 				filePath: update.absolutePath,
 				oldContents: update.fileContents,
+				newContents: null,
 				logLevel,
 				remotionRoot,
 				logLine: update.logLine,

--- a/packages/studio-server/src/preview-server/routes/delete-sequence-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-sequence-keyframe.ts
@@ -104,5 +104,6 @@ export const deleteSequenceKeyframeHandler: ApiHandler<
 		return {
 			canUpdate: true,
 			props: status.props,
+			results: [{fileName, nodePath, props: status.props}],
 		};
 	});

--- a/packages/studio-server/src/preview-server/routes/delete-sequence-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-sequence-keyframe.ts
@@ -64,6 +64,7 @@ export const deleteSequenceKeyframeHandler: ApiHandler<
 		pushToUndoStack({
 			filePath: absolutePath,
 			oldContents: fileContents,
+			newContents: null,
 			logLevel,
 			remotionRoot,
 			logLine,

--- a/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
@@ -41,6 +41,7 @@ export const duplicateJsxNodeHandler: ApiHandler<
 		pushToUndoStack({
 			filePath: absolutePath,
 			oldContents: fileContents,
+			newContents: null,
 			logLevel,
 			remotionRoot,
 			logLine,

--- a/packages/studio-server/src/preview-server/routes/save-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-effect-props.ts
@@ -109,6 +109,7 @@ export const saveEffectPropsHandler: ApiHandler<
 		pushToUndoStack({
 			filePath: absolutePath,
 			oldContents: fileContents,
+			newContents: null,
 			logLevel,
 			remotionRoot,
 			logLine,

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -156,7 +156,7 @@ export const saveSequencePropsHandler: ApiHandler<
 		}
 
 		const undoMessage =
-			undoLabel !== undefined
+			undoLabel !== null
 				? `↩️  ${undoLabel}`
 				: edits.length === 1
 					? `↩️  ${formatPropChange({
@@ -176,7 +176,7 @@ export const saveSequencePropsHandler: ApiHandler<
 						})}`
 					: '↩️  Update selected sequence props';
 		const redoMessage =
-			redoLabel !== undefined
+			redoLabel !== null
 				? `↪️  ${redoLabel}`
 				: edits.length === 1
 					? `↪️  ${formatPropChange({

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -1,12 +1,17 @@
 import {readFileSync} from 'node:fs';
 import {RenderInternals} from '@remotion/renderer';
 import type {
+	SaveSequencePropEdit,
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse,
+	SaveSequencePropsResult,
 } from '@remotion/studio-shared';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
 import {NoReactInternals} from 'remotion/no-react';
-import {updateMultipleSequenceProps} from '../../codemods/update-sequence-props/update-sequence-props';
+import {
+	type RemovedProp,
+	updateMultipleSequenceProps,
+} from '../../codemods/update-sequence-props/update-sequence-props';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
@@ -20,6 +25,37 @@ import {computeSequencePropsStatusFromContent} from './can-update-sequence-props
 import {formatPropChange} from './log-updates/format-prop-change';
 import {logUpdate, normalizeQuotes} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
+
+type ResolvedSequencePropEdit = {
+	index: number;
+	fileName: SaveSequencePropEdit['fileName'];
+	nodePath: SaveSequencePropEdit['nodePath'];
+	key: SaveSequencePropEdit['key'];
+	value: unknown;
+	valueString: string;
+	defaultValue: unknown | null;
+	defaultValueString: string | null;
+	schema: SaveSequencePropEdit['schema'];
+};
+
+type SequencePropEditGroup = {
+	fileRelativeToRoot: string;
+	edits: ResolvedSequencePropEdit[];
+};
+
+type SequencePropUndoSnapshot = {
+	filePath: string;
+	oldContents: string;
+	newContents: string;
+	logLine: number;
+};
+
+type SequencePropEditResult = {
+	oldValueString: string;
+	logLine: number;
+	removedProps: RemovedProp[];
+	formatted: boolean;
+};
 
 export const saveSequencePropsHandler: ApiHandler<
 	SaveSequencePropsRequest,
@@ -39,23 +75,7 @@ export const saveSequencePropsHandler: ApiHandler<
 			`[save-sequence-props] Received request with ${edits.length} edit(s)`,
 		);
 
-		const editGroups = new Map<
-			string,
-			{
-				fileRelativeToRoot: string;
-				edits: Array<{
-					index: number;
-					fileName: string;
-					nodePath: SaveSequencePropsRequest['edits'][number]['nodePath'];
-					key: string;
-					value: unknown;
-					valueString: string;
-					defaultValue: unknown | null;
-					defaultValueString: string | null;
-					schema: SaveSequencePropsRequest['edits'][number]['schema'];
-				}>;
-			}
-		>();
+		const editGroups = new Map<string, SequencePropEditGroup>();
 
 		for (const [index, edit] of edits.entries()) {
 			const parsedValue = JSON.parse(edit.value);
@@ -88,22 +108,9 @@ export const saveSequencePropsHandler: ApiHandler<
 			editGroups.set(absolutePath, group);
 		}
 
-		const snapshots: Array<{
-			filePath: string;
-			oldContents: string;
-			newContents: string;
-			logLine: number;
-		}> = [];
+		const snapshots: SequencePropUndoSnapshot[] = [];
 		const outputByPath = new Map<string, string>();
-		const resultByIndex = new Map<
-			number,
-			{
-				oldValueString: string;
-				logLine: number;
-				removedProps: Array<{key: string; valueString: string}>;
-				formatted: boolean;
-			}
-		>();
+		const resultByIndex = new Map<number, SequencePropEditResult>();
 
 		for (const [absolutePath, group] of editGroups) {
 			const fileContents = readFileSync(absolutePath, 'utf-8');
@@ -127,6 +134,7 @@ export const saveSequencePropsHandler: ApiHandler<
 						schema: NoReactInternals.sequenceSchema,
 					};
 				}),
+				prettierConfigOverride: null,
 			});
 
 			const [{logLine: firstLogLine}] = updateResults;
@@ -235,7 +243,7 @@ export const saveSequencePropsHandler: ApiHandler<
 
 		printUndoHint(logLevel);
 
-		const results = edits.map((edit) => {
+		const results: SaveSequencePropsResult[] = edits.map((edit) => {
 			const {absolutePath} = resolveFileInsideProject({
 				remotionRoot,
 				fileName: edit.fileName,

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -6,13 +6,13 @@ import type {
 } from '@remotion/studio-shared';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
 import {NoReactInternals} from 'remotion/no-react';
-import {updateSequenceProps} from '../../codemods/update-sequence-props/update-sequence-props';
+import {updateMultipleSequenceProps} from '../../codemods/update-sequence-props/update-sequence-props';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
 import {
 	printUndoHint,
-	pushToUndoStack,
+	pushTransactionToUndoStack,
 	suppressUndoStackInvalidation,
 } from '../undo-stack';
 import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
@@ -25,108 +25,244 @@ export const saveSequencePropsHandler: ApiHandler<
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse
 > = ({
-	input: {fileName, nodePath, key, value, defaultValue, schema, clientId},
+	input: {edits, clientId, undoLabel, redoLabel},
 	remotionRoot,
 	logLevel,
 }) =>
 	withSavePropsLock(async () => {
+		if (edits.length === 0) {
+			throw new Error('No sequence prop edits to save');
+		}
+
 		RenderInternals.Log.trace(
 			{indent: false, logLevel},
-			`[save-sequence-props] Received request for fileName="${fileName}" key="${key}"`,
+			`[save-sequence-props] Received request with ${edits.length} edit(s)`,
 		);
-		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
-			remotionRoot,
-			fileName,
-			action: 'modify',
-		});
 
-		const fileContents = readFileSync(absolutePath, 'utf-8');
+		const editGroups = new Map<
+			string,
+			{
+				fileRelativeToRoot: string;
+				edits: Array<{
+					index: number;
+					fileName: string;
+					nodePath: SaveSequencePropsRequest['edits'][number]['nodePath'];
+					key: string;
+					value: unknown;
+					valueString: string;
+					defaultValue: unknown | null;
+					defaultValueString: string | null;
+					schema: SaveSequencePropsRequest['edits'][number]['schema'];
+				}>;
+			}
+		>();
 
-		const {output, oldValueStrings, formatted, logLine, removedProps} =
-			await updateSequenceProps({
-				input: fileContents,
-				nodePath: nodePath.nodePath,
-				updates: [
-					{
-						key,
-						value: JSON.parse(value),
-						defaultValue:
-							defaultValue !== null ? JSON.parse(defaultValue) : null,
-					},
-				],
-				schema: NoReactInternals.sequenceSchema,
+		for (const [index, edit] of edits.entries()) {
+			const parsedValue = JSON.parse(edit.value);
+			const parsedDefaultValue =
+				edit.defaultValue !== null ? JSON.parse(edit.defaultValue) : null;
+			const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+				remotionRoot,
+				fileName: edit.fileName,
+				action: 'modify',
 			});
-		const oldValueString = oldValueStrings[0];
 
-		const newValueString = JSON.stringify(JSON.parse(value));
-		const parsedDefault =
-			defaultValue !== null ? JSON.parse(defaultValue) : null;
-		const defaultValueString =
-			parsedDefault !== null ? JSON.stringify(parsedDefault) : null;
+			const group = editGroups.get(absolutePath) ?? {
+				fileRelativeToRoot,
+				edits: [],
+			};
+			group.edits.push({
+				index,
+				fileName: edit.fileName,
+				nodePath: edit.nodePath,
+				key: edit.key,
+				value: parsedValue,
+				valueString: JSON.stringify(parsedValue),
+				defaultValue: parsedDefaultValue,
+				defaultValueString:
+					parsedDefaultValue !== null
+						? JSON.stringify(parsedDefaultValue)
+						: null,
+				schema: edit.schema,
+			});
+			editGroups.set(absolutePath, group);
+		}
 
-		const normalizedOld = normalizeQuotes(oldValueString);
-		const normalizedNew = normalizeQuotes(newValueString);
-		const normalizedDefault =
-			defaultValueString !== null ? normalizeQuotes(defaultValueString) : null;
+		const snapshots: Array<{
+			filePath: string;
+			oldContents: string;
+			newContents: string;
+			logLine: number;
+		}> = [];
+		const outputByPath = new Map<string, string>();
+		const resultByIndex = new Map<
+			number,
+			{
+				oldValueString: string;
+				logLine: number;
+				removedProps: Array<{key: string; valueString: string}>;
+				formatted: boolean;
+			}
+		>();
 
-		const undoPropChange = formatPropChange({
-			key,
-			oldValueString: normalizedNew,
-			newValueString: normalizedOld,
-			defaultValueString: normalizedDefault,
-			removedProps: [],
-			addedProps: removedProps,
-		});
-		const redoPropChange = formatPropChange({
-			key,
-			oldValueString: normalizedOld,
-			newValueString: normalizedNew,
-			defaultValueString: normalizedDefault,
-			removedProps,
-			addedProps: [],
-		});
+		for (const [absolutePath, group] of editGroups) {
+			const fileContents = readFileSync(absolutePath, 'utf-8');
 
-		pushToUndoStack({
-			filePath: absolutePath,
-			oldContents: fileContents,
+			const {
+				output,
+				formatted,
+				results: updateResults,
+			} = await updateMultipleSequenceProps({
+				input: fileContents,
+				changes: group.edits.map((edit) => {
+					return {
+						nodePath: edit.nodePath.nodePath,
+						updates: [
+							{
+								key: edit.key,
+								value: edit.value,
+								defaultValue: edit.defaultValue,
+							},
+						],
+						schema: NoReactInternals.sequenceSchema,
+					};
+				}),
+			});
+
+			const [{logLine: firstLogLine}] = updateResults;
+			outputByPath.set(absolutePath, output);
+			snapshots.push({
+				filePath: absolutePath,
+				oldContents: fileContents,
+				newContents: output,
+				logLine: firstLogLine,
+			});
+
+			for (const [resultIndex, result] of updateResults.entries()) {
+				const edit = group.edits[resultIndex];
+				resultByIndex.set(edit.index, {
+					oldValueString: result.oldValueStrings[0],
+					logLine: result.logLine,
+					removedProps: result.removedProps,
+					formatted,
+				});
+			}
+		}
+
+		const [firstEdit] = edits;
+		const firstResult = resultByIndex.get(0);
+		if (!firstResult) {
+			throw new Error('Could not compute sequence prop edit result');
+		}
+
+		const undoMessage =
+			undoLabel !== undefined
+				? `↩️  ${undoLabel}`
+				: edits.length === 1
+					? `↩️  ${formatPropChange({
+							key: firstEdit.key,
+							oldValueString: normalizeQuotes(
+								JSON.stringify(JSON.parse(firstEdit.value)),
+							),
+							newValueString: normalizeQuotes(firstResult.oldValueString),
+							defaultValueString:
+								firstEdit.defaultValue !== null
+									? normalizeQuotes(
+											JSON.stringify(JSON.parse(firstEdit.defaultValue)),
+										)
+									: null,
+							removedProps: [],
+							addedProps: firstResult.removedProps,
+						})}`
+					: '↩️  Update selected sequence props';
+		const redoMessage =
+			redoLabel !== undefined
+				? `↪️  ${redoLabel}`
+				: edits.length === 1
+					? `↪️  ${formatPropChange({
+							key: firstEdit.key,
+							oldValueString: normalizeQuotes(firstResult.oldValueString),
+							newValueString: normalizeQuotes(
+								JSON.stringify(JSON.parse(firstEdit.value)),
+							),
+							defaultValueString:
+								firstEdit.defaultValue !== null
+									? normalizeQuotes(
+											JSON.stringify(JSON.parse(firstEdit.defaultValue)),
+										)
+									: null,
+							removedProps: firstResult.removedProps,
+							addedProps: [],
+						})}`
+					: '↪️  Update selected sequence props';
+
+		pushTransactionToUndoStack({
+			snapshots,
 			logLevel,
 			remotionRoot,
-			logLine,
-			description: {
-				undoMessage: `↩️  ${undoPropChange}`,
-				redoMessage: `↪️  ${redoPropChange}`,
-			},
+			description: {undoMessage, redoMessage},
 			entryType: 'sequence-props',
 			suppressHmrOnFileRestore: true,
 		});
-		suppressUndoStackInvalidation(absolutePath);
-		suppressBundlerUpdateForFile(absolutePath);
-		writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
 
-		logUpdate({
-			fileRelativeToRoot,
-			line: logLine,
-			key,
-			oldValueString,
-			newValueString,
-			defaultValueString,
-			formatted,
-			logLevel,
-			removedProps,
-			addedProps: [],
-		});
+		for (const [absolutePath, output] of outputByPath) {
+			suppressUndoStackInvalidation(absolutePath);
+			suppressBundlerUpdateForFile(absolutePath);
+			writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
+		}
+
+		for (const {edits: groupEdits, fileRelativeToRoot} of editGroups.values()) {
+			for (const edit of groupEdits) {
+				const result = resultByIndex.get(edit.index);
+				if (!result) {
+					throw new Error('Could not compute sequence prop edit result');
+				}
+
+				logUpdate({
+					fileRelativeToRoot,
+					line: result.logLine,
+					key: edit.key,
+					oldValueString: result.oldValueString,
+					newValueString: edit.valueString,
+					defaultValueString: edit.defaultValueString,
+					formatted: result.formatted,
+					logLevel,
+					removedProps: result.removedProps,
+					addedProps: [],
+				});
+			}
+		}
 
 		printUndoHint(logLevel);
 
-		const newStatus = computeSequencePropsStatusFromContent({
-			fileContents: output,
-			keys: getAllSchemaKeys(schema),
-			nodePath: nodePath.nodePath,
-			effects: [],
+		const results = edits.map((edit) => {
+			const {absolutePath} = resolveFileInsideProject({
+				remotionRoot,
+				fileName: edit.fileName,
+				action: 'modify',
+			});
+			const output = outputByPath.get(absolutePath);
+			if (!output) {
+				throw new Error('Could not compute sequence prop edit status');
+			}
+
+			const newStatus = computeSequencePropsStatusFromContent({
+				fileContents: output,
+				keys: getAllSchemaKeys(edit.schema),
+				nodePath: edit.nodePath.nodePath,
+				effects: [],
+			});
+
+			return {
+				fileName: edit.fileName,
+				nodePath: edit.nodePath,
+				props: newStatus.props,
+			};
 		});
 
 		return {
 			canUpdate: true,
-			props: newStatus.props,
+			props: results[0].props,
+			results,
 		};
 	});

--- a/packages/studio-server/src/preview-server/routes/update-default-props.ts
+++ b/packages/studio-server/src/preview-server/routes/update-default-props.ts
@@ -57,6 +57,7 @@ export const updateDefaultPropsHandler: ApiHandler<
 		pushToUndoStack({
 			filePath: projectInfo.rootFile,
 			oldContents: fileContents,
+			newContents: null,
 			logLevel,
 			remotionRoot,
 			logLine,

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -28,11 +28,19 @@ type UndoEntryType =
 	| 'rename-composition'
 	| 'duplicate-composition';
 
-type UndoEntry = {
+type UndoEntrySnapshot = {
 	filePath: string;
 	oldContents: string;
+	newContents: string | null;
 	/** 1-based source line for terminal/IDE file links (e.g. path:line). */
 	logLine: number;
+};
+
+type UndoEntry = {
+	filePath: string;
+	/** 1-based source line for terminal/IDE file links (e.g. path:line). */
+	logLine: number;
+	snapshots: UndoEntrySnapshot[];
 	description: UndoEntryDescription;
 	/** When true, undo/redo file restores call `suppressBundlerUpdateForFile` (skip HMR refresh). */
 	suppressHmrOnFileRestore: boolean;
@@ -73,9 +81,43 @@ function broadcastState() {
 	});
 }
 
+const entryTouchesFile = (entry: UndoEntry, filePath: string) => {
+	return entry.snapshots.some((snapshot) => snapshot.filePath === filePath);
+};
+
+const getEntryFilePaths = (entry: UndoEntry) => {
+	return entry.snapshots.map((snapshot) => snapshot.filePath);
+};
+
+const makeUndoEntry = ({
+	snapshots,
+	description,
+	entryType,
+	suppressHmrOnFileRestore,
+}: {
+	snapshots: UndoEntrySnapshot[];
+	description: UndoEntryDescription;
+	entryType: UndoEntryType;
+	suppressHmrOnFileRestore: boolean;
+}): UndoEntry => {
+	if (snapshots.length === 0) {
+		throw new Error('Cannot create an undo entry without snapshots');
+	}
+
+	return {
+		filePath: snapshots[0].filePath,
+		logLine: snapshots[0].logLine,
+		snapshots,
+		description,
+		entryType,
+		suppressHmrOnFileRestore,
+	};
+};
+
 export function pushToUndoStack({
 	filePath,
 	oldContents,
+	newContents,
 	logLevel,
 	remotionRoot,
 	logLine,
@@ -85,6 +127,7 @@ export function pushToUndoStack({
 }: {
 	filePath: string;
 	oldContents: string;
+	newContents?: string;
 	logLevel: LogLevel;
 	remotionRoot: string;
 	logLine: number;
@@ -92,16 +135,53 @@ export function pushToUndoStack({
 	entryType: UndoEntryType;
 	suppressHmrOnFileRestore: boolean;
 }) {
-	storedLogLevel = logLevel;
-	storedRemotionRoot = remotionRoot;
-	undoStack.push({
-		filePath,
-		oldContents,
-		logLine,
+	pushTransactionToUndoStack({
+		snapshots: [
+			{
+				filePath,
+				oldContents,
+				newContents: newContents ?? null,
+				logLine,
+			},
+		],
+		logLevel,
+		remotionRoot,
 		description,
 		entryType,
 		suppressHmrOnFileRestore,
 	});
+}
+
+export function pushTransactionToUndoStack({
+	snapshots,
+	logLevel,
+	remotionRoot,
+	description,
+	entryType,
+	suppressHmrOnFileRestore,
+}: {
+	snapshots: Array<{
+		filePath: string;
+		oldContents: string;
+		newContents: string | null;
+		logLine: number;
+	}>;
+	logLevel: LogLevel;
+	remotionRoot: string;
+	description: UndoEntryDescription;
+	entryType: UndoEntryType;
+	suppressHmrOnFileRestore: boolean;
+}) {
+	storedLogLevel = logLevel;
+	storedRemotionRoot = remotionRoot;
+
+	const entry = makeUndoEntry({
+		snapshots,
+		description,
+		entryType,
+		suppressHmrOnFileRestore,
+	});
+	undoStack.push(entry);
 	if (undoStack.length > MAX_ENTRIES) {
 		undoStack.shift();
 	}
@@ -111,11 +191,14 @@ export function pushToUndoStack({
 	RenderInternals.Log.verbose(
 		{indent: false, logLevel},
 		RenderInternals.chalk.gray(
-			`Undo stack: added entry for ${filePath} (${undoStack.length} items)`,
+			`Undo stack: added entry for ${entry.filePath} (${undoStack.length} items)`,
 		),
 	);
 
-	ensureWatching(filePath);
+	for (const filePath of getEntryFilePaths(entry)) {
+		ensureWatching(filePath);
+	}
+
 	broadcastState();
 }
 
@@ -133,6 +216,7 @@ export function printUndoHint(logLevel: LogLevel) {
 export function pushToRedoStack({
 	filePath,
 	oldContents,
+	newContents,
 	logLine,
 	description,
 	entryType,
@@ -140,19 +224,26 @@ export function pushToRedoStack({
 }: {
 	filePath: string;
 	oldContents: string;
+	newContents?: string;
 	logLine: number;
 	description: UndoEntryDescription;
 	entryType: UndoEntryType;
 	suppressHmrOnFileRestore: boolean;
 }) {
-	redoStack.push({
-		filePath,
-		oldContents,
-		logLine,
+	const entry = makeUndoEntry({
+		snapshots: [
+			{
+				filePath,
+				oldContents,
+				newContents: newContents ?? null,
+				logLine,
+			},
+		],
 		description,
 		entryType,
 		suppressHmrOnFileRestore,
 	});
+	redoStack.push(entry);
 	if (redoStack.length > MAX_ENTRIES) {
 		redoStack.shift();
 	}
@@ -160,11 +251,14 @@ export function pushToRedoStack({
 	RenderInternals.Log.verbose(
 		{indent: false, logLevel: storedLogLevel},
 		RenderInternals.chalk.gray(
-			`Redo stack: added entry for ${filePath} (${redoStack.length} items)`,
+			`Redo stack: added entry for ${entry.filePath} (${redoStack.length} items)`,
 		),
 	);
 
-	ensureWatching(filePath);
+	for (const watchedFilePath of getEntryFilePaths(entry)) {
+		ensureWatching(watchedFilePath);
+	}
+
 	broadcastState();
 }
 
@@ -204,7 +298,7 @@ function invalidateForFile(filePath: string) {
 
 	let lastUndoIndex = -1;
 	for (let i = undoStack.length - 1; i >= 0; i--) {
-		if (undoStack[i].filePath === filePath) {
+		if (entryTouchesFile(undoStack[i], filePath)) {
 			lastUndoIndex = i;
 			break;
 		}
@@ -224,7 +318,7 @@ function invalidateForFile(filePath: string) {
 
 	let lastRedoIndex = -1;
 	for (let i = redoStack.length - 1; i >= 0; i--) {
-		if (redoStack[i].filePath === filePath) {
+		if (entryTouchesFile(redoStack[i], filePath)) {
 			lastRedoIndex = i;
 			break;
 		}
@@ -251,8 +345,8 @@ function invalidateForFile(filePath: string) {
 
 function cleanupWatchers() {
 	const filesInStacks = new Set([
-		...undoStack.map((e) => e.filePath),
-		...redoStack.map((e) => e.filePath),
+		...undoStack.flatMap(getEntryFilePaths),
+		...redoStack.flatMap(getEntryFilePaths),
 	]);
 	for (const [filePath, watcher] of watchers) {
 		if (!filesInStacks.has(filePath)) {
@@ -300,22 +394,37 @@ export function popUndo(): {success: true} | {success: false; reason: string} {
 		return {success: false, reason: 'Nothing to undo'};
 	}
 
-	const currentContents = readFileSync(entry.filePath, 'utf-8');
-	redoStack.push({
-		filePath: entry.filePath,
-		oldContents: currentContents,
-		logLine: entry.logLine,
-		description: entry.description,
-		entryType: entry.entryType,
-		suppressHmrOnFileRestore: entry.suppressHmrOnFileRestore,
+	const redoSnapshots = entry.snapshots.map((snapshot) => {
+		return {
+			...snapshot,
+			newContents:
+				snapshot.newContents ?? readFileSync(snapshot.filePath, 'utf-8'),
+		};
 	});
-
-	suppressUndoStackInvalidation(entry.filePath);
-	if (entry.suppressHmrOnFileRestore) {
-		suppressBundlerUpdateForFile(entry.filePath);
+	redoStack.push(
+		makeUndoEntry({
+			snapshots: redoSnapshots,
+			description: entry.description,
+			entryType: entry.entryType,
+			suppressHmrOnFileRestore: entry.suppressHmrOnFileRestore,
+		}),
+	);
+	if (redoStack.length > MAX_ENTRIES) {
+		redoStack.shift();
 	}
 
-	writeFileAndNotifyFileWatchers(entry.filePath, entry.oldContents, undefined);
+	for (const snapshot of entry.snapshots) {
+		suppressUndoStackInvalidation(snapshot.filePath);
+		if (entry.suppressHmrOnFileRestore) {
+			suppressBundlerUpdateForFile(snapshot.filePath);
+		}
+
+		writeFileAndNotifyFileWatchers(
+			snapshot.filePath,
+			snapshot.oldContents,
+			undefined,
+		);
+	}
 
 	RenderInternals.Log.verbose(
 		{indent: false, logLevel: storedLogLevel},
@@ -326,10 +435,15 @@ export function popUndo(): {success: true} | {success: false; reason: string} {
 	logFileAction(entry.description.undoMessage, entry.filePath, entry.logLine);
 
 	if (entry.entryType === 'visual-control') {
-		emitVisualControlChanges(entry.oldContents);
+		for (const snapshot of entry.snapshots) {
+			emitVisualControlChanges(snapshot.oldContents);
+		}
 	}
 
-	ensureWatching(entry.filePath);
+	for (const filePath of getEntryFilePaths(entry)) {
+		ensureWatching(filePath);
+	}
+
 	broadcastState();
 	return {success: true};
 }
@@ -340,22 +454,44 @@ export function popRedo(): {success: true} | {success: false; reason: string} {
 		return {success: false, reason: 'Nothing to redo'};
 	}
 
-	const currentContents = readFileSync(entry.filePath, 'utf-8');
-	undoStack.push({
-		filePath: entry.filePath,
-		oldContents: currentContents,
-		logLine: entry.logLine,
-		description: entry.description,
-		entryType: entry.entryType,
-		suppressHmrOnFileRestore: entry.suppressHmrOnFileRestore,
-	});
+	const snapshotsWithNewContents: Array<
+		UndoEntrySnapshot & {newContents: string}
+	> = [];
+	for (const snapshot of entry.snapshots) {
+		if (snapshot.newContents === null) {
+			return {success: false, reason: 'Redo entry is incomplete'};
+		}
 
-	suppressUndoStackInvalidation(entry.filePath);
-	if (entry.suppressHmrOnFileRestore) {
-		suppressBundlerUpdateForFile(entry.filePath);
+		snapshotsWithNewContents.push({
+			...snapshot,
+			newContents: snapshot.newContents,
+		});
 	}
 
-	writeFileAndNotifyFileWatchers(entry.filePath, entry.oldContents, undefined);
+	undoStack.push(
+		makeUndoEntry({
+			snapshots: snapshotsWithNewContents,
+			description: entry.description,
+			entryType: entry.entryType,
+			suppressHmrOnFileRestore: entry.suppressHmrOnFileRestore,
+		}),
+	);
+	if (undoStack.length > MAX_ENTRIES) {
+		undoStack.shift();
+	}
+
+	for (const snapshot of snapshotsWithNewContents) {
+		suppressUndoStackInvalidation(snapshot.filePath);
+		if (entry.suppressHmrOnFileRestore) {
+			suppressBundlerUpdateForFile(snapshot.filePath);
+		}
+
+		writeFileAndNotifyFileWatchers(
+			snapshot.filePath,
+			snapshot.newContents,
+			undefined,
+		);
+	}
 
 	RenderInternals.Log.verbose(
 		{indent: false, logLevel: storedLogLevel},
@@ -366,18 +502,36 @@ export function popRedo(): {success: true} | {success: false; reason: string} {
 	logFileAction(entry.description.redoMessage, entry.filePath, entry.logLine);
 
 	if (entry.entryType === 'visual-control') {
-		emitVisualControlChanges(entry.oldContents);
+		for (const snapshot of entry.snapshots) {
+			if (snapshot.newContents !== null) {
+				emitVisualControlChanges(snapshot.newContents);
+			}
+		}
 	}
 
-	ensureWatching(entry.filePath);
+	for (const filePath of getEntryFilePaths(entry)) {
+		ensureWatching(filePath);
+	}
+
 	broadcastState();
 	return {success: true};
 }
 
+/*
+ * Keep stack accessors typed as readonly arrays so callers can only inspect
+ * whether undo/redo is available and which file represents the top entry.
+ */
 export function getUndoStack(): readonly UndoEntry[] {
 	return undoStack;
 }
 
 export function getRedoStack(): readonly UndoEntry[] {
 	return redoStack;
+}
+
+export function clearUndoStackForTests() {
+	undoStack.length = 0;
+	redoStack.length = 0;
+	suppressedWrites.clear();
+	cleanupWatchers();
 }

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -127,7 +127,7 @@ export function pushToUndoStack({
 }: {
 	filePath: string;
 	oldContents: string;
-	newContents?: string;
+	newContents: string | null;
 	logLevel: LogLevel;
 	remotionRoot: string;
 	logLine: number;
@@ -140,7 +140,7 @@ export function pushToUndoStack({
 			{
 				filePath,
 				oldContents,
-				newContents: newContents ?? null,
+				newContents,
 				logLine,
 			},
 		],
@@ -224,7 +224,7 @@ export function pushToRedoStack({
 }: {
 	filePath: string;
 	oldContents: string;
-	newContents?: string;
+	newContents: string | null;
 	logLine: number;
 	description: UndoEntryDescription;
 	entryType: UndoEntryType;
@@ -235,7 +235,7 @@ export function pushToRedoStack({
 			{
 				filePath,
 				oldContents,
-				newContents: newContents ?? null,
+				newContents,
 				logLine,
 			},
 		],

--- a/packages/studio-server/src/test/log-update.test.ts
+++ b/packages/studio-server/src/test/log-update.test.ts
@@ -55,6 +55,7 @@ test('logUpdate emits Monokai-colored output after an AST update', async () => {
 			nodePath: lineColumnToNodePath(input, 8),
 			updates: [{key: 'hueShift', value: 90, defaultValue: null}],
 			schema: NoReactInternals.sequenceSchema,
+			prettierConfigOverride: null,
 		});
 
 	expect(oldValueStrings[0]).toBe('30');
@@ -109,6 +110,7 @@ test('logUpdate emits change-from-default output for discriminated union enum ch
 				},
 			],
 			schema: NoReactInternals.sequenceSchema,
+			prettierConfigOverride: null,
 		});
 
 	expect(oldValueStrings[0]).toBe('"absolute-fill"');
@@ -176,6 +178,7 @@ test('Undo prop change should not nest key={key={value}} for re-added props', as
 			},
 		],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 
 	const premount = removedProps.find((p) => p.key === 'premountFor');

--- a/packages/studio-server/src/test/undo-stack.test.ts
+++ b/packages/studio-server/src/test/undo-stack.test.ts
@@ -1,0 +1,74 @@
+import {expect, test} from 'bun:test';
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {
+	createFileWatcherRegistry,
+	setFileWatcherRegistry,
+} from '../file-watcher';
+import {setLiveEventsListener} from '../preview-server/live-events';
+import {
+	clearUndoStackForTests,
+	popRedo,
+	popUndo,
+	pushTransactionToUndoStack,
+} from '../preview-server/undo-stack';
+
+test('undo and redo restore every file in a transaction', () => {
+	const cleanupFileWatcher = setFileWatcherRegistry(
+		createFileWatcherRegistry(),
+	);
+	const cleanupLiveEvents = setLiveEventsListener({
+		addNewClientListener: () => () => undefined,
+		closeConnections: () => Promise.resolve(),
+		router: () => Promise.resolve(),
+		sendEventToClient: () => undefined,
+		sendEventToClientId: () => undefined,
+	});
+	const dir = mkdtempSync(join(tmpdir(), 'remotion-undo-stack-'));
+	const firstFile = join(dir, 'first.tsx');
+	const secondFile = join(dir, 'second.tsx');
+
+	try {
+		writeFileSync(firstFile, 'new first');
+		writeFileSync(secondFile, 'new second');
+
+		pushTransactionToUndoStack({
+			snapshots: [
+				{
+					filePath: firstFile,
+					oldContents: 'old first',
+					newContents: 'new first',
+					logLine: 1,
+				},
+				{
+					filePath: secondFile,
+					oldContents: 'old second',
+					newContents: 'new second',
+					logLine: 1,
+				},
+			],
+			logLevel: 'error',
+			remotionRoot: dir,
+			description: {
+				undoMessage: 'Undo test transaction',
+				redoMessage: 'Redo test transaction',
+			},
+			entryType: 'sequence-props',
+			suppressHmrOnFileRestore: true,
+		});
+
+		expect(popUndo()).toEqual({success: true});
+		expect(readFileSync(firstFile, 'utf-8')).toBe('old first');
+		expect(readFileSync(secondFile, 'utf-8')).toBe('old second');
+
+		expect(popRedo()).toEqual({success: true});
+		expect(readFileSync(firstFile, 'utf-8')).toBe('new first');
+		expect(readFileSync(secondFile, 'utf-8')).toBe('new second');
+	} finally {
+		clearUndoStackForTests();
+		cleanupLiveEvents();
+		cleanupFileWatcher();
+		rmSync(dir, {force: true, recursive: true});
+	}
+});

--- a/packages/studio-server/src/test/update-nested-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-nested-sequence-props.test.ts
@@ -22,6 +22,7 @@ test('updateSequenceProps should update a nested style property', async () => {
 		nodePath: lineColumnToNodePath(nestedInput, 7),
 		updates: [{key: 'style.opacity', value: 0.8, defaultValue: null}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -36,6 +37,7 @@ test('updateSequenceProps should add a nested property to existing object', asyn
 		nodePath: lineColumnToNodePath(nestedInput, 7),
 		updates: [{key: 'style.rotate', value: 45, defaultValue: null}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -52,6 +54,7 @@ test('updateSequenceProps should create style attribute when it does not exist',
 		nodePath: lineColumnToNodePath(nestedInput, 8),
 		updates: [{key: 'style.opacity', value: 0.3, defaultValue: null}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -66,6 +69,7 @@ test('updateSequenceProps should remove nested property when value equals defaul
 		nodePath: lineColumnToNodePath(nestedInput, 7),
 		updates: [{key: 'style.opacity', value: 1, defaultValue: 1}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -89,6 +93,7 @@ export const Example: React.FC = () => {
 		nodePath: lineColumnToNodePath(singlePropInput, 4),
 		updates: [{key: 'style.opacity', value: 1, defaultValue: 1}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -102,6 +107,7 @@ test('updateSequenceProps should report default as oldValueString for missing ne
 		nodePath: lineColumnToNodePath(nestedInput, 8),
 		updates: [{key: 'style.opacity', value: 0.5, defaultValue: 1}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 

--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -1,6 +1,9 @@
 import {expect, test} from 'bun:test';
 import {NoReactInternals} from 'remotion/no-react';
-import {updateSequenceProps} from '../codemods/update-sequence-props/update-sequence-props';
+import {
+	updateMultipleSequenceProps,
+	updateSequenceProps,
+} from '../codemods/update-sequence-props/update-sequence-props';
 import {lineColumnToNodePath} from './test-utils';
 
 const lightLeakInput = `import {LightLeak} from '@remotion/light-leaks';
@@ -123,4 +126,27 @@ test('updateSequenceProps should throw for non-existent nodePath', async () => {
 	).rejects.toThrow(
 		'Could not find a JSX element at the specified line to update',
 	);
+});
+
+test('updateMultipleSequenceProps should update multiple nodes in one format pass', async () => {
+	const {output, results} = await updateMultipleSequenceProps({
+		input: lightLeakInput,
+		changes: [
+			{
+				nodePath: lineColumnToNodePath(lightLeakInput, 8),
+				updates: [{key: 'hueShift', value: 90, defaultValue: null}],
+				schema: NoReactInternals.sequenceSchema,
+			},
+			{
+				nodePath: lineColumnToNodePath(lightLeakInput, 9),
+				updates: [{key: 'durationInFrames', value: 120, defaultValue: null}],
+				schema: NoReactInternals.sequenceSchema,
+			},
+		],
+	});
+
+	expect(results[0].oldValueStrings[0]).toBe('30');
+	expect(results[1].oldValueStrings[0]).toBe('60');
+	expect(output.split('\n')[7]).toContain('hueShift={90}');
+	expect(output.split('\n')[8]).toContain('durationInFrames={120}');
 });

--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -26,6 +26,7 @@ test('updateSequenceProps should update a number value', async () => {
 		nodePath: lineColumnToNodePath(lightLeakInput, 8),
 		updates: [{key: 'hueShift', value: 90, defaultValue: null}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -41,6 +42,7 @@ test('updateSequenceProps should update durationInFrames', async () => {
 		nodePath: lineColumnToNodePath(lightLeakInput, 9),
 		updates: [{key: 'durationInFrames', value: 120, defaultValue: null}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -56,6 +58,7 @@ test('updateSequenceProps should add a new attribute', async () => {
 		nodePath: lineColumnToNodePath(lightLeakInput, 9),
 		updates: [{key: 'speed', value: 2, defaultValue: null}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -69,6 +72,7 @@ test('updateSequenceProps should remove attribute when value equals default', as
 		nodePath: lineColumnToNodePath(lightLeakInput, 9),
 		updates: [{key: 'hueShift', value: 0, defaultValue: 0}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -84,6 +88,7 @@ test('updateSequenceProps should set boolean true as shorthand', async () => {
 		nodePath: lineColumnToNodePath(lightLeakInput, 8),
 		updates: [{key: 'loop', value: true, defaultValue: false}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 
 	// true booleans become shorthand: `loop` not `loop={true}`
@@ -97,6 +102,7 @@ test('updateSequenceProps should report oldValueString for computed expressions'
 		nodePath: lineColumnToNodePath(lightLeakInput, 8),
 		updates: [{key: 'seed', value: 5, defaultValue: null}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -109,6 +115,7 @@ test('updateSequenceProps should report default as oldValueString for missing at
 		nodePath: lineColumnToNodePath(lightLeakInput, 8),
 		updates: [{key: 'speed', value: 2, defaultValue: 1}],
 		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
 	});
 	const oldValueString = oldValueStrings[0];
 
@@ -122,6 +129,7 @@ test('updateSequenceProps should throw for non-existent nodePath', async () => {
 			nodePath: ['program', 'body', 999],
 			updates: [{key: 'hueShift', value: 90, defaultValue: null}],
 			schema: NoReactInternals.sequenceSchema,
+			prettierConfigOverride: null,
 		}),
 	).rejects.toThrow(
 		'Could not find a JSX element at the specified line to update',
@@ -143,6 +151,7 @@ test('updateMultipleSequenceProps should update multiple nodes in one format pas
 				schema: NoReactInternals.sequenceSchema,
 			},
 		],
+		prettierConfigOverride: null,
 	});
 
 	expect(results[0].oldValueStrings[0]).toBe('30');

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -264,15 +264,17 @@ export type SaveSequencePropsRequest = {
 	redoLabel: string | null;
 };
 
+export type SaveSequencePropsResult = {
+	fileName: string;
+	nodePath: SequencePropsSubscriptionKey;
+	props: Record<string, CanUpdateSequencePropStatus>;
+};
+
 export type SaveSequencePropsResponse =
 	| {
 			canUpdate: true;
 			props: Record<string, CanUpdateSequencePropStatus>;
-			results: Array<{
-				fileName: string;
-				nodePath: SequencePropsSubscriptionKey;
-				props: Record<string, CanUpdateSequencePropStatus>;
-			}>;
+			results: SaveSequencePropsResult[];
 	  }
 	| {
 			canUpdate: false;

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -248,20 +248,31 @@ export type UnsubscribeFromSequencePropsRequest = {
 	effectKeys: string[][];
 };
 
-export type SaveSequencePropsRequest = {
+export type SaveSequencePropEdit = {
 	fileName: string;
 	nodePath: SequencePropsSubscriptionKey;
 	key: string;
 	value: string;
 	defaultValue: string | null;
 	schema: SequenceSchema;
+};
+
+export type SaveSequencePropsRequest = {
+	edits: SaveSequencePropEdit[];
 	clientId: string;
+	undoLabel?: string;
+	redoLabel?: string;
 };
 
 export type SaveSequencePropsResponse =
 	| {
 			canUpdate: true;
 			props: Record<string, CanUpdateSequencePropStatus>;
+			results?: Array<{
+				fileName: string;
+				nodePath: SequencePropsSubscriptionKey;
+				props: Record<string, CanUpdateSequencePropStatus>;
+			}>;
 	  }
 	| {
 			canUpdate: false;

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -260,15 +260,15 @@ export type SaveSequencePropEdit = {
 export type SaveSequencePropsRequest = {
 	edits: SaveSequencePropEdit[];
 	clientId: string;
-	undoLabel?: string;
-	redoLabel?: string;
+	undoLabel: string | null;
+	redoLabel: string | null;
 };
 
 export type SaveSequencePropsResponse =
 	| {
 			canUpdate: true;
 			props: Record<string, CanUpdateSequencePropStatus>;
-			results?: Array<{
+			results: Array<{
 				fileName: string;
 				nodePath: SequencePropsSubscriptionKey;
 				props: Record<string, CanUpdateSequencePropStatus>;

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -44,6 +44,7 @@ export {
 	SaveSequencePropEdit,
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse,
+	SaveSequencePropsResult,
 	SimpleDiff,
 	SubscribeToDefaultPropsRequest,
 	SubscribeToDefaultPropsResponse,

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -1,6 +1,10 @@
 export {splitAnsi, stripAnsi} from './ansi';
 export {
+	AddEffectKeyframeRequest,
+	AddEffectKeyframeResponse,
 	AddRenderRequest,
+	AddSequenceKeyframeRequest,
+	AddSequenceKeyframeResponse,
 	ApiRoutes,
 	ApplyCodemodRequest,
 	ApplyCodemodResponse,
@@ -11,10 +15,6 @@ export {
 	CancelRenderRequest,
 	CancelRenderResponse,
 	CopyStillToClipboardRequest,
-	AddEffectKeyframeRequest,
-	AddEffectKeyframeResponse,
-	AddSequenceKeyframeRequest,
-	AddSequenceKeyframeResponse,
 	DeleteEffectKeyframeRequest,
 	DeleteEffectKeyframeResponse,
 	DeleteEffectRequest,
@@ -41,6 +41,7 @@ export {
 	RestartStudioResponse,
 	SaveEffectPropsRequest,
 	SaveEffectPropsResponse,
+	SaveSequencePropEdit,
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse,
 	SimpleDiff,
@@ -132,13 +133,13 @@ export {EnumPath, stringifyDefaultProps} from './stringify-default-props';
 
 export type {VisualControlChange} from './codemods';
 export {
-	optimisticDeleteEffectKeyframe,
-	optimisticDeleteSequenceKeyframe,
-} from './optimistic-delete-keyframe';
-export {
 	optimisticAddEffectKeyframe,
 	optimisticAddSequenceKeyframe,
 } from './optimistic-add-keyframe';
+export {
+	optimisticDeleteEffectKeyframe,
+	optimisticDeleteSequenceKeyframe,
+} from './optimistic-delete-keyframe';
 export {optimisticUpdateForCodeValues} from './optimistic-update-for-code-values';
 export {optimisticUpdateForEffectCodeValues} from './optimistic-update-for-effect-code-values';
 export {

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -33,8 +33,8 @@ export const saveSequenceProps = ({
 	changes: SaveSequencePropChange[];
 	setCodeValues: SetCodeValues;
 	clientId: string;
-	undoLabel?: string;
-	redoLabel?: string;
+	undoLabel: string | null;
+	redoLabel: string | null;
 }): Promise<void> => {
 	if (changes.length === 0) {
 		return Promise.resolve();
@@ -110,6 +110,8 @@ export const saveSequenceProp = ({
 					},
 				],
 				clientId,
+				undoLabel: null,
+				redoLabel: null,
 			}),
 		errorLabel: 'Could not save sequence prop',
 	});

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -14,6 +14,60 @@ export type SetCodeValues = (
 	) => CanUpdateSequencePropsResponse,
 ) => void;
 
+export type SaveSequencePropChange = {
+	fileName: string;
+	nodePath: SequencePropsSubscriptionKey;
+	fieldKey: string;
+	value: unknown;
+	defaultValue: string | null;
+	schema: SequenceSchema;
+};
+
+export const saveSequenceProps = ({
+	changes,
+	setCodeValues,
+	clientId,
+	undoLabel,
+	redoLabel,
+}: {
+	changes: SaveSequencePropChange[];
+	setCodeValues: SetCodeValues;
+	clientId: string;
+	undoLabel?: string;
+	redoLabel?: string;
+}): Promise<void> => {
+	if (changes.length === 0) {
+		return Promise.resolve();
+	}
+
+	for (const change of changes) {
+		setCodeValues(change.nodePath, (prev) =>
+			optimisticUpdateForCodeValues({
+				previous: prev,
+				fieldKey: change.fieldKey,
+				value: change.value,
+				schema: change.schema,
+			}),
+		);
+	}
+
+	return callApi('/api/save-sequence-props', {
+		edits: changes.map((change) => {
+			return {
+				fileName: change.fileName,
+				nodePath: change.nodePath,
+				key: change.fieldKey,
+				value: JSON.stringify(change.value),
+				defaultValue: change.defaultValue,
+				schema: change.schema,
+			};
+		}),
+		clientId,
+		undoLabel,
+		redoLabel,
+	}).then(() => undefined);
+};
+
 export const saveSequenceProp = ({
 	fileName,
 	nodePath,
@@ -45,12 +99,16 @@ export const saveSequenceProp = ({
 			}),
 		apiCall: () =>
 			callApi('/api/save-sequence-props', {
-				fileName,
-				nodePath,
-				key: fieldKey,
-				value: JSON.stringify(value),
-				defaultValue,
-				schema,
+				edits: [
+					{
+						fileName,
+						nodePath,
+						key: fieldKey,
+						value: JSON.stringify(value),
+						defaultValue,
+						schema,
+					},
+				],
 				clientId,
 			}),
 		errorLabel: 'Could not save sequence prop',

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -23,19 +23,26 @@ export type SaveSequencePropChange = {
 	schema: SequenceSchema;
 };
 
+type SaveSequencePropsOptions = {
+	changes: SaveSequencePropChange[];
+	setCodeValues: SetCodeValues;
+	clientId: string;
+	undoLabel: string | null;
+	redoLabel: string | null;
+};
+
+type SaveSequencePropOptions = SaveSequencePropChange & {
+	setCodeValues: SetCodeValues;
+	clientId: string;
+};
+
 export const saveSequenceProps = ({
 	changes,
 	setCodeValues,
 	clientId,
 	undoLabel,
 	redoLabel,
-}: {
-	changes: SaveSequencePropChange[];
-	setCodeValues: SetCodeValues;
-	clientId: string;
-	undoLabel: string | null;
-	redoLabel: string | null;
-}): Promise<void> => {
+}: SaveSequencePropsOptions): Promise<void> => {
 	if (changes.length === 0) {
 		return Promise.resolve();
 	}
@@ -77,16 +84,7 @@ export const saveSequenceProp = ({
 	schema,
 	setCodeValues,
 	clientId,
-}: {
-	fileName: string;
-	nodePath: SequencePropsSubscriptionKey;
-	fieldKey: string;
-	value: unknown;
-	defaultValue: string | null;
-	schema: SequenceSchema;
-	setCodeValues: SetCodeValues;
-	clientId: string;
-}): Promise<void> => {
+}: SaveSequencePropOptions): Promise<void> => {
 	return enqueueSavePropChange({
 		nodePath,
 		setCodeValues,


### PR DESCRIPTION
## Summary
- Batch `/api/save-sequence-props` edits so multiple sequence prop changes are saved through one transaction.
- Apply same-file sequence prop edits against one parsed AST and one formatted output.
- Extend undo/redo entries to restore all files in a transaction.

Fixes #7874.

## Tests
- `bun run build`
- `bun run formatting`
- `cd packages/studio-server && bun test src/test/update-sequence-props.test.ts src/test/undo-stack.test.ts`
