### PR TITLE
`@remotion/convert`: Restore loading from x.com

### DIFF
--- a/packages/convert/app/components/AlternativePickFileOptions.tsx
+++ b/packages/convert/app/components/AlternativePickFileOptions.tsx
@@ -1,6 +1,7 @@
 import {Button} from '@remotion/design';
 import React from 'react';
 import {LoadFromUrl} from './LoadFromUrl';
+import {LoadFromX} from './LoadFromX';
 
 export const AlternativePickFileOptions: React.FC<{
 	readonly onSampleFile: () => void;
@@ -14,6 +15,7 @@ export const AlternativePickFileOptions: React.FC<{
 				Use a sample file
 			</Button>
 			<LoadFromUrl />
+			<LoadFromX />
 		</div>
 	);
 };

--- a/packages/convert/app/components/LoadFromX.tsx
+++ b/packages/convert/app/components/LoadFromX.tsx
@@ -1,0 +1,172 @@
+import {Button as RemotionButton} from '@remotion/design';
+import React, {useCallback, useMemo} from 'react';
+import {extractTweetId} from '~/lib/extract-tweet-id';
+import {Button} from './ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from './ui/dialog';
+import {Input} from './ui/input';
+
+const loadFromXEndpoint =
+	'https://lzpqleuj7axkrgoxsa3h7ecynq0vveim.lambda-url.eu-central-1.on.aws/';
+
+type LoadFromXResponse =
+	| {
+			type: 'success';
+			urls: string[];
+	  }
+	| {
+			type: 'error';
+			error?: string;
+	  };
+
+const isLoadFromXResponse = (data: unknown): data is LoadFromXResponse => {
+	if (!data || typeof data !== 'object' || !('type' in data)) {
+		return false;
+	}
+
+	if (data.type === 'success') {
+		return (
+			'urls' in data &&
+			Array.isArray(data.urls) &&
+			data.urls.every((url) => typeof url === 'string')
+		);
+	}
+
+	return (
+		data.type === 'error' &&
+		(!('error' in data) || typeof data.error === 'string')
+	);
+};
+
+export const LoadFromX: React.FC = () => {
+	const [open, setOpen] = React.useState(false);
+	const [value, setValue] = React.useState('');
+	const [loading, setLoading] = React.useState(false);
+	const [error, setError] = React.useState<string | null>(null);
+
+	const onOpenChange = React.useCallback(() => {
+		setOpen((prev) => !prev);
+		setError(null);
+	}, []);
+
+	const tweetId = useMemo(() => extractTweetId(value), [value]);
+	const isValid = tweetId !== null;
+
+	const onOpenUrl = React.useCallback(() => {
+		setOpen(true);
+	}, []);
+
+	const set = useCallback(async () => {
+		if (!tweetId) {
+			return;
+		}
+
+		setLoading(true);
+		setError(null);
+
+		try {
+			const endpoint = new URL(loadFromXEndpoint);
+			endpoint.searchParams.set('id', tweetId);
+
+			const response = await fetch(endpoint);
+
+			if (!response.ok) {
+				setError(`Failed to load from x.com (${response.status})`);
+				return;
+			}
+
+			const json: unknown = await response.json();
+
+			if (!isLoadFromXResponse(json)) {
+				setError('Received an invalid response from x.com');
+				return;
+			}
+
+			if (json.type !== 'success') {
+				setError(json.error || 'Failed to load from x.com');
+				return;
+			}
+
+			const [firstUrl] = json.urls;
+
+			if (!firstUrl) {
+				setError('No videos found in this post');
+				return;
+			}
+
+			const currentUrl = new URL(
+				window.location.pathname === '/'
+					? '/convert'
+					: window.location.pathname,
+				window.location.href,
+			);
+			currentUrl.searchParams.set('url', firstUrl);
+
+			window.location.href = currentUrl.toString();
+		} catch (err) {
+			setError(
+				err instanceof Error ? err.message : 'An unexpected error occurred',
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, [tweetId]);
+
+	const onKeydown = useCallback(
+		(e: React.KeyboardEvent<HTMLInputElement>) => {
+			if (!isValid || loading) {
+				return;
+			}
+
+			if (e.key === 'Enter') {
+				set();
+			}
+		},
+		[isValid, loading, set],
+	);
+
+	return (
+		<>
+			<RemotionButton
+				className="font-brand text-brand rounded-full text-sm h-10"
+				onClick={onOpenUrl}
+			>
+				Load from x.com
+			</RemotionButton>
+			<Dialog open={open} onOpenChange={onOpenChange}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle className="font-brand">Load from x.com</DialogTitle>
+						<div className="h-1" />
+						<DialogDescription>
+							Enter a post URL to load a video from x.com.
+						</DialogDescription>
+						<div className="h-2" />
+						<Input
+							onKeyDown={onKeydown}
+							value={value}
+							onChange={(e) => setValue(e.target.value)}
+							placeholder="For example: https://x.com/JNYBGR/status/1859650265021817143"
+						/>
+						{error ? (
+							<p className="text-red-500 text-sm mt-2">{error}</p>
+						) : null}
+						<div className="h-2" />
+						<Button
+							disabled={!isValid || loading}
+							variant="brand"
+							onClick={set}
+						>
+							{loading ? 'Loading...' : 'Load'}
+						</Button>
+					</DialogHeader>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+};

--- a/packages/convert/test/extract-tweet-id.test.ts
+++ b/packages/convert/test/extract-tweet-id.test.ts
@@ -1,0 +1,28 @@
+import {expect, test} from 'bun:test';
+import {extractTweetId} from '~/lib/extract-tweet-id';
+
+test('extracts tweet IDs from x.com URLs', () => {
+	expect(
+		extractTweetId('https://x.com/JNYBGR/status/1859650265021817143'),
+	).toBe('1859650265021817143');
+	expect(
+		extractTweetId('https://mobile.x.com/JNYBGR/statuses/1859650265021817143'),
+	).toBe('1859650265021817143');
+	expect(
+		extractTweetId(
+			'https://x.com/JNYBGR/status/1859650265021817143?s=20&t=abc',
+		),
+	).toBe('1859650265021817143');
+});
+
+test('extracts tweet IDs from twitter.com URLs', () => {
+	expect(
+		extractTweetId('https://twitter.com/JNYBGR/status/1859650265021817143'),
+	).toBe('1859650265021817143');
+});
+
+test('returns null when no tweet ID can be extracted', () => {
+	expect(extractTweetId('')).toBe(null);
+	expect(extractTweetId('https://x.com/JNYBGR')).toBe(null);
+	expect(extractTweetId('not a tweet')).toBe(null);
+});


### PR DESCRIPTION
## Summary
- Restore the remotion.dev/convert "Load from x.com" entry point.
- Resolve x.com/twitter.com post URLs through the existing x.com video resolver and load the returned HLS URL into the converter.
- Add tests for extracting tweet IDs from supported URL formats.

Fixes #7880.

## Checks
- bun test test (packages/convert)
- bun run typecheck (packages/convert)
- bun run lint (packages/convert)
- bunx turbo make --filter='@remotion/convert'
- bun run build
- bun run formatting
