### PR TITLE
Docs: Add convert workspace dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -431,6 +431,7 @@
         "@remotion/captions": "workspace:*",
         "@remotion/cli": "workspace:*",
         "@remotion/cloudrun": "workspace:*",
+        "@remotion/convert": "workspace:*",
         "@remotion/design": "workspace:*",
         "@remotion/docusaurus-plugin": "workspace:*",
         "@remotion/effects": "workspace:*",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -41,6 +41,7 @@
 		"@remotion/captions": "workspace:*",
 		"@remotion/cli": "workspace:*",
 		"@remotion/cloudrun": "workspace:*",
+		"@remotion/convert": "workspace:*",
 		"@remotion/design": "workspace:*",
 		"@remotion/docusaurus-plugin": "workspace:*",
 		"@remotion/effects": "workspace:*",


### PR DESCRIPTION
Fixes Vercel affected detection for convert changes by declaring `@remotion/convert` as a workspace dependency of the docs package.

This matches the existing Turbo docs build pipeline, which already runs `@remotion/convert#build-spa` and copies its output into the docs deployment.
Future `packages/convert` changes should now mark `docs` as affected in package-level Turbo/Vercel checks.

Checks:
- `cd packages/docs && bunx oxfmt src --write`
- `bun run build && bun run formatting`
