### PR TITLE
`@remotion/studio-server`: Fix sequence keyframe insertion

### DIFF
--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -16,6 +16,7 @@ import type {SequenceNodePath} from 'remotion';
 import {getAstNodePath} from '../../helpers/get-ast-node-path';
 import {
 	extractStaticValue,
+	findNodePathForJsxElement,
 	findJsxElementAtNodePath,
 	isStaticValue,
 } from '../../preview-server/routes/can-update-sequence-props';
@@ -277,14 +278,7 @@ const addKeyframe = ({
 	}
 
 	const staticValue = extractStaticValue(expression);
-	const staticOutput = parseValueExpression(staticValue);
-	const keyframes: InterpolateKeyframe[] =
-		frame === 0
-			? [{frame, output: newOutput, value}]
-			: [
-					{frame: 0, output: staticOutput, value: staticValue},
-					{frame, output: newOutput, value},
-				];
+	const keyframes: InterpolateKeyframe[] = [{frame, output: newOutput, value}];
 
 	const callee = getInterpolationCalleeForValues({
 		staticValue,
@@ -512,6 +506,7 @@ export const updateSequenceKeyframesAst = ({
 	oldValueStrings: string[];
 	newValueStrings: string[];
 	logLine: number;
+	updatedNodePath: SequenceNodePath;
 } => {
 	const ast = parseAst(input);
 	const jsxPath = getAstNodePath(ast, nodePath);
@@ -563,11 +558,19 @@ export const updateSequenceKeyframesAst = ({
 
 	ensureRemotionImports(ast, requiredImports);
 
+	const updatedNodePath = findNodePathForJsxElement(ast, node);
+	if (!updatedNodePath) {
+		throw new Error(
+			'Could not find updated JSX element location after updating keyframes',
+		);
+	}
+
 	return {
 		serialized: serializeAst(ast),
 		oldValueStrings,
 		newValueStrings,
 		logLine: node.loc?.start.line ?? 1,
+		updatedNodePath,
 	};
 };
 
@@ -587,19 +590,32 @@ export const updateSequenceKeyframes = async ({
 	oldValueStrings: string[];
 	newValueStrings: string[];
 	logLine: number;
+	updatedNodePath: SequenceNodePath;
 }> => {
-	const {serialized, oldValueStrings, newValueStrings, logLine} =
-		updateSequenceKeyframesAst({
-			input,
-			nodePath,
-			updates,
-		});
+	const {
+		serialized,
+		oldValueStrings,
+		newValueStrings,
+		logLine,
+		updatedNodePath,
+	} = updateSequenceKeyframesAst({
+		input,
+		nodePath,
+		updates,
+	});
 	const {output, formatted} = await formatFileContent({
 		input: serialized,
 		prettierConfigOverride,
 	});
 
-	return {output, formatted, oldValueStrings, newValueStrings, logLine};
+	return {
+		output,
+		formatted,
+		oldValueStrings,
+		newValueStrings,
+		logLine,
+		updatedNodePath,
+	};
 };
 
 export const updateEffectKeyframesAst = ({
@@ -618,6 +634,7 @@ export const updateEffectKeyframesAst = ({
 	newValueStrings: string[];
 	logLine: number;
 	effectCallee: string;
+	updatedSequenceNodePath: SequenceNodePath;
 } => {
 	const ast = parseAst(input);
 	const jsxPath = getAstNodePath(ast, sequenceNodePath);
@@ -684,12 +701,20 @@ export const updateEffectKeyframesAst = ({
 
 	ensureRemotionImports(ast, requiredImports);
 
+	const updatedSequenceNodePath = findNodePathForJsxElement(ast, jsx);
+	if (!updatedSequenceNodePath) {
+		throw new Error(
+			'Could not find updated JSX element location after updating effect keyframes',
+		);
+	}
+
 	return {
 		serialized: serializeAst(ast),
 		oldValueStrings,
 		newValueStrings,
 		logLine: call.loc?.start.line ?? jsx.loc?.start.line ?? 1,
 		effectCallee,
+		updatedSequenceNodePath,
 	};
 };
 
@@ -712,14 +737,21 @@ export const updateEffectKeyframes = async ({
 	newValueStrings: string[];
 	logLine: number;
 	effectCallee: string;
+	updatedSequenceNodePath: SequenceNodePath;
 }> => {
-	const {serialized, oldValueStrings, newValueStrings, logLine, effectCallee} =
-		updateEffectKeyframesAst({
-			input,
-			sequenceNodePath,
-			effectIndex,
-			updates,
-		});
+	const {
+		serialized,
+		oldValueStrings,
+		newValueStrings,
+		logLine,
+		effectCallee,
+		updatedSequenceNodePath,
+	} = updateEffectKeyframesAst({
+		input,
+		sequenceNodePath,
+		effectIndex,
+		updates,
+	});
 	const {output, formatted} = await formatFileContent({
 		input: serialized,
 		prettierConfigOverride,
@@ -732,5 +764,6 @@ export const updateEffectKeyframes = async ({
 		newValueStrings,
 		logLine,
 		effectCallee,
+		updatedSequenceNodePath,
 	};
 };

--- a/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
@@ -59,6 +59,7 @@ export const addEffectKeyframeHandler: ApiHandler<
 			formatted,
 			logLine,
 			effectCallee,
+			updatedSequenceNodePath,
 		} = await updateEffectKeyframes({
 			input: fileContents,
 			sequenceNodePath: sequenceNodePath.nodePath,
@@ -116,7 +117,7 @@ export const addEffectKeyframeHandler: ApiHandler<
 		printUndoHint(logLevel);
 
 		const ast = parseAst(readFileSync(absolutePath, 'utf-8'));
-		const jsx = findJsxElementAtNodePath(ast, sequenceNodePath.nodePath);
+		const jsx = findJsxElementAtNodePath(ast, updatedSequenceNodePath);
 		if (!jsx) {
 			return {
 				canUpdate: false,

--- a/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
@@ -41,21 +41,27 @@ export const addSequenceKeyframeHandler: ApiHandler<
 		const fileContents = readFileSync(absolutePath, 'utf-8');
 		const parsedValue = JSON.parse(value);
 
-		const {output, oldValueStrings, newValueStrings, formatted, logLine} =
-			await updateSequenceKeyframes({
-				input: fileContents,
-				nodePath: nodePath.nodePath,
-				updates: [
-					{
-						key,
-						operation: {
-							type: 'add',
-							frame,
-							value: parsedValue,
-						},
+		const {
+			output,
+			oldValueStrings,
+			newValueStrings,
+			formatted,
+			logLine,
+			updatedNodePath,
+		} = await updateSequenceKeyframes({
+			input: fileContents,
+			nodePath: nodePath.nodePath,
+			updates: [
+				{
+					key,
+					operation: {
+						type: 'add',
+						frame,
+						value: parsedValue,
 					},
-				],
-			});
+				},
+			],
+		});
 
 		const oldValueString = oldValueStrings[0];
 		const newValueString = newValueStrings[0];
@@ -99,13 +105,16 @@ export const addSequenceKeyframeHandler: ApiHandler<
 		const status = computeSequencePropsStatusFromContent({
 			fileContents: output,
 			keys: getAllSchemaKeys(schema),
-			nodePath: nodePath.nodePath,
+			nodePath: updatedNodePath,
 			effects: [],
 		});
+		const updatedSubscriptionKey = {...nodePath, nodePath: updatedNodePath};
 
 		return {
 			canUpdate: true,
 			props: status.props,
-			results: [{fileName, nodePath, props: status.props}],
+			results: [
+				{fileName, nodePath: updatedSubscriptionKey, props: status.props},
+			],
 		};
 	});

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -582,6 +582,26 @@ export const findJsxElementAtNodePath = (
 	return null;
 };
 
+export const findNodePathForJsxElement = (
+	ast: File,
+	target: JSXOpeningElement,
+): SequenceNodePath | null => {
+	let foundPath: SequenceNodePath | null = null;
+
+	recast.types.visit(ast, {
+		visitJSXOpeningElement(p) {
+			if (p.node === target) {
+				foundPath = getNodePathForRecastPath(p);
+				return false;
+			}
+
+			return this.traverse(p);
+		},
+	});
+
+	return foundPath;
+};
+
 export const lineColumnToNodePath = (
 	ast: File,
 	targetLine: number,

--- a/packages/studio-server/src/test/update-keyframes-imports.test.ts
+++ b/packages/studio-server/src/test/update-keyframes-imports.test.ts
@@ -44,7 +44,7 @@ export const Example: React.FC = () => {
 		/import\s*\{[^}]*\bAbsoluteFill\b[^}]*\binterpolate\b[^}]*\buseCurrentFrame\b[^}]*\}\s*from\s*['"]remotion['"]/,
 	);
 	expect(serialized).toContain('const frame = useCurrentFrame();');
-	expect(serialized).toContain('interpolate(frame, [0, 30], [0.5, 1])');
+	expect(serialized).toContain('interpolate(frame, [30], [1])');
 });
 
 test('adds interpolateColors import (not interpolate) for color conversion', () => {
@@ -329,7 +329,7 @@ export const Example: React.FC = () => (
 
 	expect(serialized).toContain('const frame = useCurrentFrame();');
 	expect(serialized).toContain('return');
-	expect(serialized).toContain('interpolate(frame, [0, 20], [0.5, 1])');
+	expect(serialized).toContain('interpolate(frame, [20], [1])');
 });
 
 test('does not add a duplicate frame hook when user already has one with a different intermediate statement', () => {
@@ -388,7 +388,7 @@ export const Comp = () => {
 		/import\s*\{[^}]*\binterpolate\b[^}]*\buseCurrentFrame\b[^}]*\}\s*from\s*['"]remotion['"]/,
 	);
 	expect(serialized).toContain('const frame = useCurrentFrame();');
-	expect(serialized).toContain('interpolate(frame, [0, 100], [0.5, 1])');
+	expect(serialized).toContain('interpolate(frame, [100], [1])');
 });
 
 test('effect keyframe remove does not modify imports or insert a frame hook', () => {

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -3,6 +3,7 @@ import {
 	updateEffectKeyframesAst,
 	updateSequenceKeyframes,
 } from '../codemods/update-keyframes/update-keyframes';
+import {computeSequencePropsStatusFromContent} from '../preview-server/routes/can-update-sequence-props';
 import {lineColumnToNodePath} from './test-utils';
 
 const sequenceInput = `import React from 'react';
@@ -94,7 +95,7 @@ test('updateSequenceKeyframes converts a static value to an interpolation', asyn
 	});
 
 	expect(oldValueStrings).toEqual(['0.5']);
-	expect(output).toContain('opacity: interpolate(frame, [0, 25], [0.5, 0.75])');
+	expect(output).toContain('opacity: interpolate(frame, [25], [0.75])');
 });
 
 test('updateSequenceKeyframes converts a static value to a single-keyframe interpolation at frame 0', async () => {
@@ -153,9 +154,66 @@ test('updateSequenceKeyframes converts a static string value to a color interpol
 	});
 
 	expect(oldValueStrings).toEqual(["'red'"]);
-	expect(output).toContain(
-		"color={interpolateColors(frame, [0, 50], ['red', 'blue'])}",
-	);
+	expect(output).toContain("color={interpolateColors(frame, [50], ['blue'])}");
+});
+
+test('updateSequenceKeyframes returns a node path that still resolves after inserting a frame hook', async () => {
+	const input = `import {starburst} from '@remotion/starburst';
+import React from 'react';
+import {AbsoluteFill, Solid} from 'remotion';
+
+const CenteredSolid: React.FC = () => {
+\treturn (
+\t\t<AbsoluteFill style={{perspective: 300}}>
+\t\t\t<Solid
+\t\t\t\twidth={240}
+\t\t\t\theight={240}
+\t\t\t\tcolor={'#d8d8d8'}
+\t\t\t\tstyle={{
+\t\t\t\t\tposition: 'absolute',
+\t\t\t\t\tleft: '50%',
+\t\t\t\t\ttop: '50%',
+\t\t\t\t\ttransform: 'translate(-50%, -50%) rotateX(40deg)',
+\t\t\t\t\trotate: '40deg',
+\t\t\t\t\tscale: 2.42,
+\t\t\t\t\ttranslate: '0px 191px',
+\t\t\t\t}}
+\t\t\t\teffects={[starburst({rays: 10, colors: ['#eeeeee', '#bbbbbb']})]}
+\t\t\t/>
+\t\t</AbsoluteFill>
+\t);
+};
+
+export default CenteredSolid;
+`;
+	const nodePath = lineColumnToNodePath(input, getLine(input, '<Solid'));
+	const {output, updatedNodePath} = await updateSequenceKeyframes({
+		input,
+		nodePath,
+		updates: [
+			{
+				key: 'width',
+				operation: {type: 'add', frame: 11, value: 240},
+			},
+		],
+	});
+
+	expect(output).toContain('width={interpolate(frame, [11], [240])}');
+	const status = computeSequencePropsStatusFromContent({
+		fileContents: output,
+		nodePath: updatedNodePath,
+		keys: ['width'],
+		effects: [],
+	});
+	expect(status.props.width).toEqual({
+		canUpdate: false,
+		reason: 'keyframed',
+		interpolationFunction: 'interpolate',
+		keyframes: [{frame: 11, value: 240}],
+		easing: [],
+		clamping: {left: 'extend', right: 'extend'},
+		posterize: undefined,
+	});
 });
 
 test('updateSequenceKeyframes keeps an interpolation when one keyframe remains', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7889.

### Summary
- Add keyframes to static values at the requested frame only.
- Track the updated JSX node path after inserting `useCurrentFrame()` so keyframe routes can recompute prop status against the moved node.
- Add regression coverage for the reported `CenteredSolid` width keyframe case.

### Testing
- `bun test src/test/update-keyframes.test.ts src/test/update-keyframes-imports.test.ts` passed.
- `bun run test` in `packages/studio-server` passed all keyframe coverage; one unrelated `logEffectUpdate` expectation failed.
- `bun run formatting` in `packages/studio-server` passed.
- `bun run make` in `packages/studio-server` passed.
- `bun run build` from the repository root passed.
- `bun run formatting` from the repository root passed.
- `bun run stylecheck` from the repository root is blocked by the known `@remotion/lambda-go` Go 1.23 requirement on this VM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6968934-e259-4516-8e26-c46a8dbc4ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6968934-e259-4516-8e26-c46a8dbc4ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

