### PR TITLE
`@remotion/studio`: Add backspace reset for selected timeline props

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -5,6 +5,7 @@ import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {useKeybinding} from '../../helpers/use-keybinding';
 import {deleteSelectedTimelineItems} from './delete-selected-timeline-item';
 import {duplicateSelectedTimelineItems} from './duplicate-selected-timeline-item';
+import {resetSelectedTimelineProps} from './reset-selected-timeline-props';
 import {
 	useCurrentTimelineSelectionStateAsRef,
 	useTimelineSelection,
@@ -17,6 +18,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
 	);
+	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
 	const {canSelect} = useTimelineSelection();
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
@@ -33,6 +35,20 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 			callback: () => {
 				const {selectedItems, clearSelection} = currentSelection.current;
 				if (selectedItems.length === 0) {
+					return;
+				}
+
+				const resetPromise = resetSelectedTimelineProps({
+					selections: selectedItems,
+					sequences,
+					overrideIdsToNodePaths: overrideIdToNodePathMappings,
+					codeValues,
+					setCodeValues,
+					clientId,
+				});
+
+				if (resetPromise !== null) {
+					resetPromise.catch(() => undefined);
 					return;
 				}
 
@@ -87,6 +103,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		};
 	}, [
 		canSelect,
+		codeValues,
 		currentSelection,
 		keybindings,
 		overrideIdToNodePathMappings,

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -1,0 +1,227 @@
+import type {
+	CodeValues,
+	OverrideIdToNodePaths,
+	SequenceFieldSchema,
+	SequencePropsSubscriptionKey,
+	SequenceSchema,
+	TSequence,
+} from 'remotion';
+import {Internals} from 'remotion';
+import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
+import {saveEffectProp} from './save-effect-prop';
+import {saveSequenceProp} from './save-sequence-prop';
+import type {SetCodeValues} from './save-sequence-prop';
+import type {TimelineSelection} from './TimelineSelection';
+
+type SequencePropResetTarget = {
+	readonly type: 'sequence-prop';
+	readonly fileName: string;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly fieldKey: string;
+	readonly value: unknown;
+	readonly defaultValue: string | null;
+	readonly schema: SequenceSchema;
+};
+
+type EffectPropResetTarget = {
+	readonly type: 'effect-prop';
+	readonly fileName: string;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly effectIndex: number;
+	readonly fieldKey: string;
+	readonly value: unknown;
+	readonly defaultValue: string | null;
+	readonly schema: SequenceSchema;
+};
+
+type TimelinePropResetTarget = SequencePropResetTarget | EffectPropResetTarget;
+
+const isPropResetSelection = (
+	selection: TimelineSelection,
+): selection is TimelineSelection & {
+	type: 'sequence-prop' | 'sequence-effect-prop';
+} =>
+	selection.type === 'sequence-prop' ||
+	selection.type === 'sequence-effect-prop';
+
+const isVisibleFieldSchema = (
+	fieldSchema: SequenceFieldSchema | undefined,
+): fieldSchema is Exclude<SequenceFieldSchema, {type: 'hidden'}> =>
+	fieldSchema !== undefined && fieldSchema.type !== 'hidden';
+
+const isNonDefaultCodeValue = ({
+	codeValue,
+	defaultValue,
+}: {
+	readonly codeValue: unknown;
+	readonly defaultValue: unknown;
+}) =>
+	JSON.stringify(codeValue ?? defaultValue) !== JSON.stringify(defaultValue);
+
+const getDefaultValue = (
+	fieldSchema: Exclude<SequenceFieldSchema, {type: 'hidden'}>,
+) =>
+	fieldSchema.default !== undefined
+		? JSON.stringify(fieldSchema.default)
+		: null;
+
+export const getTimelinePropResetTargets = ({
+	selections,
+	sequences,
+	overrideIdsToNodePaths,
+	codeValues,
+}: {
+	readonly selections: readonly TimelineSelection[];
+	readonly sequences: TSequence[];
+	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
+	readonly codeValues: CodeValues;
+}): TimelinePropResetTarget[] | null => {
+	const firstSelection = selections[0];
+	if (!firstSelection || !isPropResetSelection(firstSelection)) {
+		return null;
+	}
+
+	const resetTargets: TimelinePropResetTarget[] = [];
+	for (const selection of selections) {
+		if (!isPropResetSelection(selection)) {
+			throw new Error(
+				`Assertion failed: Cannot reset timeline selections of different types (${firstSelection.type}, ${selection.type})`,
+			);
+		}
+
+		const track = findTrackForNodePathInfo({
+			sequences,
+			overrideIdsToNodePaths,
+			nodePathInfo: selection.nodePathInfo,
+		});
+		const sequence = track?.sequence ?? null;
+		if (!sequence) {
+			continue;
+		}
+
+		const nodePath = selection.nodePathInfo.sequenceSubscriptionKey;
+		if (selection.type === 'sequence-prop') {
+			if (!sequence.controls) {
+				continue;
+			}
+
+			const sequenceFieldSchema = sequence.controls.schema[selection.key];
+			const sequencePropStatus = Internals.getCodeValuesCtx(
+				codeValues,
+				nodePath,
+			)?.[selection.key];
+			if (
+				!isVisibleFieldSchema(sequenceFieldSchema) ||
+				!sequencePropStatus?.canUpdate ||
+				!isNonDefaultCodeValue({
+					codeValue: sequencePropStatus.codeValue,
+					defaultValue: sequenceFieldSchema.default,
+				})
+			) {
+				continue;
+			}
+
+			resetTargets.push({
+				type: 'sequence-prop',
+				fileName: nodePath.absolutePath,
+				nodePath,
+				fieldKey: selection.key,
+				value: sequenceFieldSchema.default,
+				defaultValue: getDefaultValue(sequenceFieldSchema),
+				schema: sequence.controls.schema,
+			});
+			continue;
+		}
+
+		const effect = sequence.effects[selection.i];
+		const fieldSchema = effect?.schema[selection.key];
+		const effectStatus = Internals.getEffectCodeValuesCtx({
+			codeValues,
+			nodePath,
+			effectIndex: selection.i,
+		});
+		const propStatus =
+			effectStatus.type === 'can-update-effect'
+				? effectStatus.props[selection.key]
+				: null;
+		if (
+			!effect ||
+			!isVisibleFieldSchema(fieldSchema) ||
+			!propStatus?.canUpdate ||
+			!isNonDefaultCodeValue({
+				codeValue: propStatus.codeValue,
+				defaultValue: fieldSchema.default,
+			})
+		) {
+			continue;
+		}
+
+		resetTargets.push({
+			type: 'effect-prop',
+			fileName: nodePath.absolutePath,
+			nodePath,
+			effectIndex: selection.i,
+			fieldKey: selection.key,
+			value: fieldSchema.default,
+			defaultValue: getDefaultValue(fieldSchema),
+			schema: effect.schema,
+		});
+	}
+
+	return resetTargets;
+};
+
+export const resetSelectedTimelineProps = ({
+	selections,
+	sequences,
+	overrideIdsToNodePaths,
+	codeValues,
+	setCodeValues,
+	clientId,
+}: {
+	readonly selections: readonly TimelineSelection[];
+	readonly sequences: TSequence[];
+	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
+	readonly codeValues: CodeValues;
+	readonly setCodeValues: SetCodeValues;
+	readonly clientId: string;
+}): Promise<void> | null => {
+	const resetTargets = getTimelinePropResetTargets({
+		selections,
+		sequences,
+		overrideIdsToNodePaths,
+		codeValues,
+	});
+	if (resetTargets === null || resetTargets.length === 0) {
+		return null;
+	}
+
+	const resetPromises = resetTargets.map((target) => {
+		if (target.type === 'sequence-prop') {
+			return saveSequenceProp({
+				fileName: target.fileName,
+				nodePath: target.nodePath,
+				fieldKey: target.fieldKey,
+				value: target.value,
+				defaultValue: target.defaultValue,
+				schema: target.schema,
+				setCodeValues,
+				clientId,
+			});
+		}
+
+		return saveEffectProp({
+			fileName: target.fileName,
+			nodePath: target.nodePath,
+			effectIndex: target.effectIndex,
+			fieldKey: target.fieldKey,
+			value: target.value,
+			defaultValue: target.defaultValue,
+			schema: target.schema,
+			setCodeValues,
+			clientId,
+		});
+	});
+
+	return Promise.all(resetPromises).then(() => undefined);
+};

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1,5 +1,12 @@
 import {expect, test} from 'bun:test';
-import type {SequenceNodePath, SequencePropsSubscriptionKey} from 'remotion';
+import {
+	Internals,
+	type CodeValues,
+	type SequenceNodePath,
+	type SequencePropsSubscriptionKey,
+	type SequenceSchema,
+	type TSequence,
+} from 'remotion';
 import {
 	getSelectedEffectFieldsBySequenceKey,
 	getUvCoordinateForPoint,
@@ -7,6 +14,7 @@ import {
 } from '../components/SelectedOutlineOverlay';
 import {deleteSelectedTimelineItems} from '../components/Timeline/delete-selected-timeline-item';
 import {isDuplicatableSequenceRowSelection} from '../components/Timeline/duplicate-selected-timeline-item';
+import {getTimelinePropResetTargets} from '../components/Timeline/reset-selected-timeline-props';
 import {
 	ENABLE_OUTLINES,
 	getSelectableTimelineSequenceSelections,
@@ -35,6 +43,37 @@ const makeNodePathInfo = (
 	index: 0,
 	numberOfSequencesWithThisNodePath: 1,
 });
+
+const makeTimelineSequence = ({
+	schema,
+	effects = [],
+}: {
+	readonly schema: SequenceSchema;
+	readonly effects?: readonly {readonly schema: SequenceSchema}[];
+}): TSequence =>
+	({
+		type: 'sequence',
+		from: 0,
+		duration: 100,
+		id: 'sequence',
+		displayName: 'Sequence',
+		documentationLink: null,
+		parent: null,
+		rootId: 'root',
+		showInTimeline: true,
+		nonce: [[0, 0]],
+		loopDisplay: undefined,
+		getStack: () => null,
+		premountDisplay: null,
+		postmountDisplay: null,
+		controls: {
+			schema,
+			currentRuntimeValueDotNotation: {},
+			overrideId: 'override',
+		},
+		refForOutline: null,
+		effects,
+	}) as TSequence;
 
 test('Timeline selection should stay disabled until released publicly', () => {
 	expect(SELECTION_ENABLED).toBe(false);
@@ -169,6 +208,116 @@ test('Cmd+D only duplicates selected timeline sequence rows', () => {
 		{
 			type: 'sequence',
 			nodePathInfo: sequenceNodePathInfo,
+		},
+	]);
+});
+
+test('Backspace reset targets multiple selected sequence props', () => {
+	const schema = {
+		opacity: {type: 'number', default: 1},
+		'style.rotate': {type: 'rotation', default: '0deg'},
+	} satisfies SequenceSchema;
+	const opacityNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+	const rotateNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'style.rotate'],
+	);
+	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
+	const codeValues = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {
+				opacity: {canUpdate: true, codeValue: 0.5},
+				'style.rotate': {canUpdate: true, codeValue: '45deg'},
+			},
+			effects: [],
+		},
+	} satisfies CodeValues;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-prop',
+				nodePathInfo: opacityNodePathInfo,
+				key: 'opacity',
+			},
+			{
+				type: 'sequence-prop',
+				nodePathInfo: rotateNodePathInfo,
+				key: 'style.rotate',
+			},
+		],
+		sequences: [makeTimelineSequence({schema})],
+		overrideIdsToNodePaths: {override: nodePath},
+		codeValues,
+	});
+
+	expect(resetTargets?.map((target) => target.fieldKey)).toEqual([
+		'opacity',
+		'style.rotate',
+	]);
+	expect(resetTargets?.map((target) => target.value)).toEqual([1, '0deg']);
+});
+
+test('Backspace reset targets selected effect props', () => {
+	const schema = {} satisfies SequenceSchema;
+	const effectSchema = {
+		intensity: {type: 'number', default: 0},
+	} satisfies SequenceSchema;
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'intensity'],
+	);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const codeValues = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'effect',
+					effectIndex: 0,
+					props: {
+						intensity: {canUpdate: true, codeValue: 10},
+					},
+				},
+			],
+		},
+	} satisfies CodeValues;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-effect-prop',
+				nodePathInfo,
+				i: 0,
+				key: 'intensity',
+			},
+		],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				effects: [{schema: effectSchema}],
+			}),
+		],
+		overrideIdsToNodePaths: {override: nodePath},
+		codeValues,
+	});
+
+	expect(resetTargets).toEqual([
+		{
+			type: 'effect-prop',
+			fileName: '/project/src/Comp.tsx',
+			nodePath,
+			effectIndex: 0,
+			fieldKey: 'intensity',
+			value: 0,
+			defaultValue: '0',
+			schema: effectSchema,
 		},
 	]);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Closes #7888.

## Summary
- Add Backspace reset handling for selected sequence prop and effect prop rows.
- Support multiple selected prop rows by resolving reset targets from selection state.
- Cover reset target resolution for sequence and effect props in timeline selection tests.

## Testing
- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bunx oxfmt src --write` in `packages/studio`
- `bun run build`
- `bun run formatting`
- `bunx turbo run lint formatting --filter='@remotion/studio' --no-update-notifier`
- `bunx turbo run make --filter='@remotion/studio' --no-update-notifier`
- `bun run stylecheck` (blocked by documented `@remotion/lambda-go` Go 1.22.2 environment caveat)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cbc0514-760a-4db5-addd-c14a9b876f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cbc0514-760a-4db5-addd-c14a9b876f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

