### PR TITLE
`@remotion/studio`: Fix enum dropdown outside-clicks

### DIFF
--- a/packages/studio/src/components/NewComposition/ComboBox.tsx
+++ b/packages/studio/src/components/NewComposition/ComboBox.tsx
@@ -267,7 +267,7 @@ export const Combobox: React.FC<{
 			</button>
 			{portalStyle
 				? ReactDOM.createPortal(
-						<div style={fullScreenOverlay}>
+						<div style={fullScreenOverlay} onPointerDown={onHide}>
 							<div style={outerPortal} className="css-reset">
 								<HigherZIndex onOutsideClick={onHide} onEscape={onHide}>
 									<div style={portalStyle}>


### PR DESCRIPTION
## Description

Fixes #7763.

Clicking outside the enum dropdown in Studio did not always dismiss it because the fullscreen overlay intercepted pointer events but had no direct dismiss handler.

### What changed

- Added `onPointerDown={onHide}` to the `fullScreenOverlay` in `ComboBox.tsx`, so backdrop clicks immediately close the dropdown.