### PR TITLE
`@remotion/studio`: Fix right-click layer while context menu is open

### DIFF
--- a/packages/studio/src/components/ContextMenu.tsx
+++ b/packages/studio/src/components/ContextMenu.tsx
@@ -179,7 +179,28 @@ export const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
 				</div>
 				{portalStyle
 					? ReactDOM.createPortal(
-							<div style={fullScreenOverlay}>
+							<div
+								style={fullScreenOverlay}
+								onPointerDown={onHide}
+								onContextMenu={(e) => {
+									e.preventDefault();
+									e.stopPropagation();
+									onHide();
+									const {clientX, clientY} = e;
+									requestAnimationFrame(() => {
+										const el = document.elementFromPoint(clientX, clientY);
+										if (el) {
+											el.dispatchEvent(
+												new MouseEvent('contextmenu', {
+													bubbles: true,
+													clientX,
+													clientY,
+												}),
+											);
+										}
+									});
+								}}
+							>
 								<div style={outerPortal} className="css-reset">
 									<HigherZIndex onOutsideClick={onHide} onEscape={onHide}>
 										<div style={portalStyle} onPointerDown={onMenuPointerDown}>


### PR DESCRIPTION
## Description

Fixes #7755.

When a context menu is already open, right-clicking another layer should close the current menu and open a new menu on the clicked layer.

### What changed

- Added `onPointerDown={onHide}` to the fullscreen context menu overlay.
- Added `onContextMenu` handling on the overlay to:
  - prevent and stop the overlay event,
  - hide the current menu,
  - re-dispatch a fresh `contextmenu` event to the element under the cursor after unmount via `requestAnimationFrame` + `document.elementFromPoint()`.