### PR TITLE
`@remotion/studio`: Fix timeline layer width regression

### DIFF
--- a/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
+++ b/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
@@ -229,7 +229,7 @@ export const getFrameIncrementFromWidth = (
 	durationInFrames: number,
 	width: number,
 ) => {
-	return (width - TIMELINE_PADDING * 2) / (durationInFrames - 1);
+	return (width - TIMELINE_PADDING * 2) / durationInFrames;
 };
 
 export const getFrameWhileScrollingRight = ({
@@ -267,15 +267,18 @@ export const getFrameFromX = ({
 	extrapolate: 'clamp' | 'extend';
 }) => {
 	const pos = clientX - TIMELINE_PADDING;
-	const frame = Math.round(
-		interpolate(
-			pos,
-			[0, width - TIMELINE_PADDING * 2],
-			[0, durationInFrames - 1],
-			{
-				extrapolateLeft: extrapolate,
-				extrapolateRight: extrapolate,
-			},
+	const frame = Math.min(
+		durationInFrames - 1,
+		Math.round(
+			interpolate(
+				pos,
+				[0, width - TIMELINE_PADDING * 2],
+				[0, durationInFrames],
+				{
+					extrapolateLeft: extrapolate,
+					extrapolateRight: extrapolate,
+				},
+			),
 		),
 	);
 	return frame;

--- a/packages/studio/src/helpers/get-left-of-timeline-slider.ts
+++ b/packages/studio/src/helpers/get-left-of-timeline-slider.ts
@@ -5,7 +5,7 @@ export const getXPositionOfItemInTimelineImperatively = (
 	duration: number,
 	width: number,
 ) => {
-	const proportion = frame / (duration - 1);
+	const proportion = frame / duration;
 
 	return proportion * (width - TIMELINE_PADDING * 2) + TIMELINE_PADDING;
 };

--- a/packages/studio/src/helpers/get-timeline-sequence-layout.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-layout.ts
@@ -5,22 +5,22 @@ export const SEQUENCE_BORDER_WIDTH = 1;
 
 const getWidthOfTrack = ({
 	durationInFrames,
-	lastFrame,
+	timelineDuration,
 	windowWidth,
 	spatialDuration,
 	nonNegativeMarginLeft,
 }: {
 	durationInFrames: number;
-	lastFrame: number;
+	timelineDuration: number;
 	windowWidth: number;
 	spatialDuration: number;
 	nonNegativeMarginLeft: number;
 }) => {
 	const fullWidth = windowWidth - TIMELINE_PADDING * 2;
 	const base =
-		durationInFrames === Infinity || lastFrame === 0
+		durationInFrames === Infinity || timelineDuration <= 0
 			? fullWidth
-			: (spatialDuration / lastFrame) * fullWidth;
+			: (spatialDuration / timelineDuration) * fullWidth;
 
 	return Math.max(0, base - SEQUENCE_BORDER_WIDTH + nonNegativeMarginLeft);
 };
@@ -47,7 +47,6 @@ export const getTimelineSequenceLayout = ({
 	const maxMediaSequenceDuration =
 		(maxMediaDuration ?? Infinity) - startFromMedia;
 	const timelineDuration = video.durationInFrames ?? 1;
-	const lastFrame = timelineDuration - 1;
 
 	const spatialDuration = Math.max(
 		0,
@@ -58,22 +57,22 @@ export const getTimelineSequenceLayout = ({
 		),
 	);
 
-	// Unclipped spatial duration: without the lastFrame - startFrom constraint
+	// Unclipped spatial duration: without the timeline-end constraint
 	const naturalSpatialDuration = Math.max(
 		0,
 		Math.min(maxMediaSequenceDuration, durationInFrames),
 	);
 
 	const marginLeft =
-		lastFrame === 0
+		timelineDuration <= 0
 			? 0
-			: (startFrom / lastFrame) * (windowWidth - TIMELINE_PADDING * 2);
+			: (startFrom / timelineDuration) * (windowWidth - TIMELINE_PADDING * 2);
 
 	const nonNegativeMarginLeft = Math.min(marginLeft, 0);
 
 	const width = getWidthOfTrack({
 		durationInFrames,
-		lastFrame,
+		timelineDuration,
 		nonNegativeMarginLeft,
 		spatialDuration,
 		windowWidth,
@@ -81,7 +80,7 @@ export const getTimelineSequenceLayout = ({
 
 	const naturalWidth = getWidthOfTrack({
 		durationInFrames,
-		lastFrame,
+		timelineDuration,
 		nonNegativeMarginLeft,
 		spatialDuration: naturalSpatialDuration,
 		windowWidth,
@@ -90,7 +89,7 @@ export const getTimelineSequenceLayout = ({
 	const premountWidth = premountDisplay
 		? getWidthOfTrack({
 				durationInFrames: premountDisplay,
-				lastFrame,
+				timelineDuration,
 				nonNegativeMarginLeft,
 				spatialDuration: premountDisplay,
 				windowWidth,
@@ -100,7 +99,7 @@ export const getTimelineSequenceLayout = ({
 	const postmountWidth = postmountDisplay
 		? getWidthOfTrack({
 				durationInFrames: postmountDisplay,
-				lastFrame,
+				timelineDuration,
 				nonNegativeMarginLeft,
 				spatialDuration: postmountDisplay,
 				windowWidth,

--- a/packages/studio/src/test/timeline-sequence-layout.test.ts
+++ b/packages/studio/src/test/timeline-sequence-layout.test.ts
@@ -44,11 +44,11 @@ test('Should test timeline sequence layout without max media duration', () => {
 			windowWidth: 1414.203125,
 		}),
 	).toEqual({
-		marginLeft: 1154.4991419797689,
+		marginLeft: 1154.0226668902187,
 		premountWidth: null,
 		postmountWidth: null,
-		width: 227.2746696944674,
-		naturalWidth: 227.2746696944674,
+		width: 227.18045810978126,
+		naturalWidth: 227.18045810978126,
 	});
 });
 test('Should test timeline sequence layout with max media duration', () => {
@@ -78,11 +78,11 @@ test('Should test timeline sequence layout with max media duration', () => {
 			windowWidth: 1414.203125,
 		}),
 	).toEqual({
-		marginLeft: 1154.4991419797689,
+		marginLeft: 1154.0226668902187,
 		premountWidth: null,
 		postmountWidth: null,
-		width: 221.5678029521057,
-		naturalWidth: 221.5678029521057,
+		width: 221.47594665703676,
+		naturalWidth: 221.47594665703676,
 	});
 });
 
@@ -132,8 +132,8 @@ test('one-frame segments have a one-frame width', () => {
 		windowWidth: 1000,
 	});
 
-	expect(result.width).toBe(2.237458193979933);
-	expect(result.naturalWidth).toBe(2.237458193979933);
+	expect(result.width).toBe(2.226666666666667);
+	expect(result.naturalWidth).toBe(2.226666666666667);
 });
 
 test('adjacent sequences have no visual gap', () => {


### PR DESCRIPTION
Fixes #7908.

## Problem

PR #7670 changed `spatialDuration` from `durationInFrames - 1` to `durationInFrames` to make adjacent sequences appear seamless in the timeline. However, `lastFrame = timelineDuration - 1` was kept as the divisor for all position/width calculations.

This caused a regression: for a full-composition sequence (duration = N, comp = N), the width becomes `N / (N - 1) * fullWidth`, which overflows past the composition end. On a short 10-frame composition, this is an ~11% overflow.

## Fix

Change the divisor from `lastFrame` (`timelineDuration - 1`) to `timelineDuration` throughout all timeline layout calculations.

This satisfies both requirements:
- **Full-comp layer**: `durationInFrames / timelineDuration * fullWidth = fullWidth` ✓  
- **Seamless adjacency**: `marginLeft(A) + width(A) = marginLeft(B)` for adjacent sequences ✓

### Files changed

- `get-timeline-sequence-layout.ts` — rename `lastFrame` param to `timelineDuration`, use as divisor in `marginLeft` and `getWidthOfTrack`
- `get-left-of-timeline-slider.ts` — change `frame / (duration - 1)` to `frame / duration`
- `timeline-scroll-logic.ts` — update `getFrameIncrementFromWidth` and `getFrameFromX` to use `durationInFrames` as divisor
- Tests updated to reflect the corrected numeric values
