### PR TITLE
`@remotion/studio-server`: canAddSequence=false when root is ThreeCanvas, RiveCanvas, SkiaCanvas or canvas

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -923,6 +923,23 @@ const addElementToComponentRoot = ({
 		throw new Error('Cannot insert into a self-closing root JSX element');
 	}
 
+	const CANVAS_ROOT_ELEMENTS = [
+		'ThreeCanvas',
+		'RiveCanvas',
+		'SkiaCanvas',
+		'canvas',
+	];
+
+	if (
+		rootNode.type === 'JSXElement' &&
+		rootNode.openingElement.name.type === 'JSXIdentifier' &&
+		CANVAS_ROOT_ELEMENTS.includes(rootNode.openingElement.name.name)
+	) {
+		throw new Error(
+			`Cannot insert a <Solid> into a composition whose root element is <${rootNode.openingElement.name.name}>`,
+		);
+	}
+
 	if (!rootNode.children) {
 		throw new Error('Composition component root does not accept children');
 	}

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -339,6 +339,156 @@ test('canAddSequence=false for self-closing root JSX return', async () => {
 	}
 });
 
+test('canAddSequence=false for ThreeCanvas root element', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				"import {ThreeCanvas} from '@remotion/three';",
+				'',
+				'export const MyComp: React.FC = () => {',
+				'\treturn <ThreeCanvas></ThreeCanvas>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const location = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+		});
+		expect(location.source).toBe('MyComp.tsx');
+		expect(location.canAddSequence).toBe(false);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('canAddSequence=false for RiveCanvas root element', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				"import {RiveCanvas} from '@remotion/rive';",
+				'',
+				'export const MyComp: React.FC = () => {',
+				'\treturn <RiveCanvas></RiveCanvas>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const location = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+		});
+		expect(location.source).toBe('MyComp.tsx');
+		expect(location.canAddSequence).toBe(false);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('canAddSequence=false for SkiaCanvas root element', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				"import {SkiaCanvas} from '@remotion/skia';",
+				'',
+				'export const MyComp: React.FC = () => {',
+				'\treturn <SkiaCanvas></SkiaCanvas>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const location = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+		});
+		expect(location.source).toBe('MyComp.tsx');
+		expect(location.canAddSequence).toBe(false);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('canAddSequence=false for plain canvas root element', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				'export const MyComp: React.FC = () => {',
+				'\treturn <canvas></canvas>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const location = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+		});
+		expect(location.source).toBe('MyComp.tsx');
+		expect(location.canAddSequence).toBe(false);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('inserts a Solid into the resolved composition component', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {


### PR DESCRIPTION
Fixes #7919

## What changed

When the top-level component in a composition returns a canvas-based root element (`<ThreeCanvas>`, `<RiveCanvas>`, `<SkiaCanvas>`, or a plain `<canvas>`), `canAddSequence` now correctly returns `false`, preventing the "Add `<Solid>`" button from appearing in the Remotion Studio.

## How it works

Added a check in `addElementToComponentRoot` that throws if the root JSX element is one of the known canvas-based components. The existing `canAddSequenceToComponent` wrapper already catches thrown errors and returns `false`.

## Tests

Added 4 new test cases in `resolve-composition-component.test.ts`:
- `canAddSequence=false` for `<ThreeCanvas>` root
- `canAddSequence=false` for `<RiveCanvas>` root
- `canAddSequence=false` for `<SkiaCanvas>` root
- `canAddSequence=false` for plain `<canvas>` root
