### PR TITLE
`@remotion/studio-server`: Fix add-solid insertion edge cases

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -743,12 +743,107 @@ const createSolidElement = ({
 			[
 				createNumberAttribute('width', width),
 				createNumberAttribute('height', height),
+				recast.types.builders.jsxAttribute(
+					recast.types.builders.jsxIdentifier('style'),
+					recast.types.builders.jsxExpressionContainer(
+						recast.types.builders.objectExpression([
+							recast.types.builders.objectProperty(
+								recast.types.builders.identifier('position'),
+								recast.types.builders.stringLiteral('absolute'),
+							),
+						]),
+					),
+				),
 			],
 			true,
 		),
 		null,
 		[],
 	);
+};
+
+const createFragmentWithElement = (element: namedTypes.JSXElement) => {
+	return recast.types.builders.jsxFragment(
+		recast.types.builders.jsxOpeningFragment(),
+		recast.types.builders.jsxClosingFragment(),
+		[element],
+	);
+};
+
+const replaceNullReturnInFunctionLike = ({
+	fn,
+	element,
+}: {
+	fn: FunctionLikeNode;
+	element: namedTypes.JSXElement;
+}): number | null => {
+	if (fn.type === 'ArrowFunctionExpression' && fn.body.type === 'NullLiteral') {
+		fn.body = createFragmentWithElement(element);
+		return fn.loc?.start.line ?? 1;
+	}
+
+	if (fn.body.type !== 'BlockStatement') {
+		return null;
+	}
+
+	const returnStatement = getTopLevelReturnStatement(fn.body.body);
+	if (
+		!returnStatement?.argument ||
+		returnStatement.argument.type !== 'NullLiteral'
+	) {
+		return null;
+	}
+
+	returnStatement.argument = createFragmentWithElement(element);
+	return returnStatement.loc?.start.line ?? 1;
+};
+
+const addElementToNullComponentReturn = ({
+	declaration,
+	element,
+}: {
+	declaration: LocalComponentDeclaration | DefaultExportDeclaration;
+	element: namedTypes.JSXElement;
+}): number | null => {
+	if (declaration.type === 'VariableDeclarator') {
+		if (
+			!declaration.init ||
+			(declaration.init.type !== 'ArrowFunctionExpression' &&
+				declaration.init.type !== 'FunctionExpression')
+		) {
+			return null;
+		}
+
+		return replaceNullReturnInFunctionLike({fn: declaration.init, element});
+	}
+
+	if (
+		declaration.type === 'ArrowFunctionExpression' ||
+		declaration.type === 'FunctionExpression' ||
+		declaration.type === 'FunctionDeclaration'
+	) {
+		return replaceNullReturnInFunctionLike({fn: declaration, element});
+	}
+
+	if (declaration.type !== 'ClassDeclaration') {
+		return null;
+	}
+
+	const renderMethod = findRenderMethod(declaration);
+	if (!renderMethod) {
+		return null;
+	}
+
+	const returnStatement = getTopLevelReturnStatement(renderMethod.body.body);
+	if (
+		!returnStatement?.argument ||
+		returnStatement.argument.type !== 'NullLiteral'
+	) {
+		return null;
+	}
+
+	returnStatement.argument = createFragmentWithElement(element);
+	return returnStatement.loc?.start.line ?? 1;
 };
 
 const getImportedName = (specifier: ImportSpecifier) => {
@@ -916,6 +1011,11 @@ const addElementToComponentRoot = ({
 
 	const rootNode = getComponentRootNode(declaration);
 	if (!rootNode) {
+		const insertedAt = addElementToNullComponentReturn({declaration, element});
+		if (insertedAt !== null) {
+			return insertedAt;
+		}
+
 		throw new Error('Composition component does not return JSX');
 	}
 

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -531,7 +531,10 @@ test('inserts a Solid into the resolved composition component', async () => {
 		expect(result.output).toContain(
 			"import { AbsoluteFill, Solid } from 'remotion';",
 		);
-		expect(result.output).toContain('<Solid width={1280} height={720} />');
+		expect(result.output).toContain('<Solid');
+		expect(result.output).toContain('width={1280}');
+		expect(result.output).toContain('height={720}');
+		expect(result.output).toContain("position: 'absolute'");
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}
@@ -580,9 +583,51 @@ test('inserts an aliased Solid import if Solid is already defined', async () => 
 		expect(result.output).toContain(
 			"import { AbsoluteFill, Solid as RemotionSolid } from 'remotion';",
 		);
-		expect(result.output).toContain(
-			'<RemotionSolid width={1920} height={1080} />',
+		expect(result.output).toContain('<RemotionSolid');
+		expect(result.output).toContain('width={1920}');
+		expect(result.output).toContain('height={1080}');
+		expect(result.output).toContain("position: 'absolute'");
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('inserts a Solid into an empty component returning null', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
 		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			['export const MyComp: React.FC = () => null;', ''].join('\n'),
+		);
+
+		const result = await insertJsxElementIntoComposition({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+			element: {
+				type: 'solid',
+				width: 640,
+				height: 360,
+			},
+			prettierConfigOverride: {singleQuote: true, useTabs: true},
+		});
+
+		expect(result.output).toContain("import { Solid } from 'remotion';");
+		expect(result.output).toContain('<Solid');
+		expect(result.output).toContain('width={640}');
+		expect(result.output).toContain('height={360}');
+		expect(result.output).toContain("position: 'absolute'");
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -624,10 +624,35 @@ test('inserts a Solid into an empty component returning null', async () => {
 		});
 
 		expect(result.output).toContain("import { Solid } from 'remotion';");
-		expect(result.output).toContain('<Solid');
+		expect(result.output).toContain('export const MyComp: React.FC = () => (');
+		expect(result.output).toContain('\t<>');
+		expect(result.output).toContain('\t\t<Solid');
+		expect(result.output).toContain('\t</>');
 		expect(result.output).toContain('width={640}');
 		expect(result.output).toContain('height={360}');
 		expect(result.output).toContain("position: 'absolute'");
+
+		await fs.writeFile(path.join(tempDir, 'MyComp.tsx'), result.output);
+
+		const afterFirstInsert = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+		});
+		expect(afterFirstInsert.canAddSequence).toBe(true);
+
+		const secondInsert = await insertJsxElementIntoComposition({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+			element: {
+				type: 'solid',
+				width: 320,
+				height: 180,
+			},
+			prettierConfigOverride: {singleQuote: true, useTabs: true},
+		});
+		expect(secondInsert.output.match(/<Solid/g)?.length).toBe(2);
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}


### PR DESCRIPTION
## Summary
- add `style={{position: 'absolute'}}` by default when inserting `<Solid>`
- allow inserting `<Solid>` into components that currently return `null`
- add/adjust tests for both behaviors in `resolve-composition-component.test.ts`

Closes #7924
Closes #7927