### PR TITLE
`@remotion/media`: Wire Video outline refs

### DIFF
--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -1,4 +1,5 @@
 import React, {
+	useCallback,
 	useContext,
 	useEffect,
 	useLayoutEffect,
@@ -70,6 +71,7 @@ type VideoForPreviewProps = {
 	readonly setMediaDurationInSeconds: (durationInSeconds: number) => void;
 	readonly _experimentalInitiallyDrawCachedFrame: boolean;
 	readonly effects: EffectDefinitionAndStack<unknown>[];
+	readonly refForOutline: React.RefObject<HTMLElement | null>;
 };
 
 type VideoForPreviewAssertedShowingProps = VideoForPreviewProps;
@@ -103,10 +105,11 @@ const VideoForPreviewAssertedShowing: React.FC<
 	_experimentalInitiallyDrawCachedFrame,
 	effects,
 	setMediaDurationInSeconds,
+	refForOutline,
 }) => {
 	const src = usePreload(unpreloadedSrc);
 
-	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const canvasRef = useRef<HTMLCanvasElement | null>(null);
 	const videoConfig = useUnsafeVideoConfig();
 	const frame = useCurrentFrame();
 	const mediaPlayerRef = useRef<MediaPlayer | null>(null);
@@ -123,6 +126,21 @@ const VideoForPreviewAssertedShowing: React.FC<
 	const {playbackRate: globalPlaybackRate} = Internals.usePlaybackRate();
 	const sharedAudioContext = useContext(SharedAudioContext);
 	const buffer = useBufferState();
+
+	const canvasRefCallback = useCallback(
+		(canvas: HTMLCanvasElement | null) => {
+			canvasRef.current = canvas;
+			refForOutline.current = canvas;
+		},
+		[refForOutline],
+	);
+
+	const fallbackVideoRef = useCallback(
+		(video: HTMLVideoElement | null) => {
+			refForOutline.current = video;
+		},
+		[refForOutline],
+	);
 
 	const [mediaMuted] = useMediaMutedState();
 	const [mediaVolume] = useMediaVolumeState();
@@ -496,6 +514,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 		// not using <OffthreadVideo> because it does not support looping
 		return (
 			<Html5Video
+				ref={fallbackVideoRef}
 				src={src}
 				style={actualStyle}
 				className={className}
@@ -520,7 +539,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 
 	return (
 		<canvas
-			ref={canvasRef}
+			ref={canvasRefCallback}
 			// Don't set width and height here.
 			// Width is set in the video iterator manager, if props are being updated, they are being applied again by React.
 			// This will lead to inefficient resizes.

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -44,6 +44,7 @@ const InnerVideo: React.FC<
 	InnerVideoProps & {
 		readonly _experimentalControls: SequenceControls | undefined;
 		readonly setMediaDurationInSeconds: (durationInSeconds: number) => void;
+		readonly refForOutline: React.RefObject<HTMLElement | null>;
 	}
 > = ({
 	src,
@@ -76,6 +77,7 @@ const InnerVideo: React.FC<
 	_experimentalInitiallyDrawCachedFrame,
 	effects,
 	setMediaDurationInSeconds,
+	refForOutline,
 }) => {
 	const environment = useRemotionEnvironment();
 
@@ -170,6 +172,7 @@ const InnerVideo: React.FC<
 			_experimentalInitiallyDrawCachedFrame={
 				_experimentalInitiallyDrawCachedFrame
 			}
+			refForOutline={refForOutline}
 		/>
 	);
 };
@@ -278,6 +281,7 @@ const VideoInner: React.FC<
 	const memoizedEffectDefinitions = Internals.useMemoizedEffectDefinitions(
 		effects ?? [],
 	);
+	const refForOutline = React.useRef<HTMLElement | null>(null);
 
 	if (sequenceDurationInFrames === 0) {
 		return null;
@@ -299,6 +303,7 @@ const VideoInner: React.FC<
 			_experimentalControls={controls}
 			_remotionInternalLoopDisplay={loopDisplay}
 			_remotionInternalEffects={memoizedEffectDefinitions}
+			_remotionInternalRefForOutline={refForOutline}
 			showInTimeline={showInTimeline ?? true}
 			hidden={hidden}
 		>
@@ -339,6 +344,7 @@ const VideoInner: React.FC<
 				}
 				effects={memoizedEffects}
 				setMediaDurationInSeconds={setMediaDurationInSeconds}
+				refForOutline={refForOutline}
 			/>
 		</Sequence>
 	);


### PR DESCRIPTION
## Summary

- Wire @remotion/media <Video> sequence outline refs to the preview canvas.
- Preserve the outline target when falling back to Html5Video.
