### PR TITLE
`@remotion/studio-server`: Prefer nodePath for sequence props resubscribe

### DIFF
--- a/packages/studio-server/src/preview-server/routes/subscribe-to-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/subscribe-to-sequence-props.ts
@@ -9,7 +9,7 @@ export const subscribeToSequenceProps: ApiHandler<
 	SubscribeToSequencePropsRequest,
 	SubscribeToSequencePropsResponse
 > = ({
-	input: {fileName, line, column, keys, effects, clientId},
+	input: {fileName, line, column, nodePath, keys, effects, clientId},
 	remotionRoot,
 	logLevel,
 }) => {
@@ -17,6 +17,7 @@ export const subscribeToSequenceProps: ApiHandler<
 		fileName,
 		line,
 		column,
+		nodePath,
 		keys,
 		effects,
 		remotionRoot,

--- a/packages/studio-server/src/preview-server/sequence-props-watchers.ts
+++ b/packages/studio-server/src/preview-server/sequence-props-watchers.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
-import {RenderInternals} from '@remotion/renderer';
 import type {LogLevel} from '@remotion/renderer';
+import {RenderInternals} from '@remotion/renderer';
 import {
 	stringifySequenceSubscriptionKey,
 	type SubscribeToSequencePropsResponse,
@@ -11,9 +11,9 @@ import {JsxElementNotFoundAtLocationError} from './jsx-element-not-found-at-loca
 import {waitForLiveEventsListener} from './live-events';
 import {getCachedNodePath, setCachedNodePath} from './node-path-cache';
 import {
+	computeSequencePropsStatus,
 	computeSequencePropsStatusFromContent,
 	computeSequencePropsStatusFromFilenameByLine,
-	computeSequencePropsStatus,
 } from './routes/can-update-sequence-props';
 
 type WatcherInfo = {
@@ -27,6 +27,7 @@ const getSequencePropsStatus = ({
 	fileName,
 	line,
 	column,
+	preferredNodePath,
 	keys,
 	effects,
 	remotionRoot,
@@ -35,11 +36,32 @@ const getSequencePropsStatus = ({
 	fileName: string;
 	line: number;
 	column: number;
+	preferredNodePath: SequenceNodePath | null;
 	keys: string[];
 	effects: string[][];
 	remotionRoot: string;
 	logLevel: LogLevel;
 }): SubscribeToSequencePropsResponse => {
+	if (preferredNodePath) {
+		const fromNodePath = computeSequencePropsStatus({
+			fileName,
+			nodePath: preferredNodePath,
+			keys,
+			effects,
+			remotionRoot,
+		});
+		return {
+			status: fromNodePath,
+			nodePath: {
+				absolutePath: path.resolve(remotionRoot, fileName),
+				nodePath: preferredNodePath,
+				sequenceKeys: keys,
+				effectKeys: effects,
+			},
+			success: true,
+		};
+	}
+
 	// Try cached nodePath first (handles stale source maps after suppressed rebuilds)
 	const cachedNodePath = getCachedNodePath(fileName, line, column);
 
@@ -82,6 +104,7 @@ export const subscribeToSequencePropsWatchers = ({
 	fileName,
 	line,
 	column,
+	nodePath: preferredNodePath,
 	keys,
 	effects,
 	remotionRoot,
@@ -91,6 +114,7 @@ export const subscribeToSequencePropsWatchers = ({
 	fileName: string;
 	line: number;
 	column: number;
+	nodePath: SequenceNodePath | null;
 	keys: string[];
 	effects: string[][];
 	remotionRoot: string;
@@ -101,6 +125,7 @@ export const subscribeToSequencePropsWatchers = ({
 		fileName,
 		line,
 		column,
+		preferredNodePath,
 		keys,
 		effects,
 		remotionRoot,

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -249,6 +249,7 @@ export type SubscribeToSequencePropsRequest = {
 	fileName: string;
 	line: number;
 	column: number;
+	nodePath: SequenceNodePath | null;
 	keys: string[];
 	effects: string[][];
 	clientId: string;

--- a/packages/studio/src/components/Timeline/sequence-props-subscription-store.ts
+++ b/packages/studio/src/components/Timeline/sequence-props-subscription-store.ts
@@ -1,5 +1,5 @@
 import {getAllSchemaKeys} from '@remotion/studio-shared';
-import type {SequenceSchema} from 'remotion';
+import type {SequenceNodePath, SequenceSchema} from 'remotion';
 import {Internals} from 'remotion';
 import {callApi} from '../call-api';
 
@@ -36,6 +36,7 @@ export const acquireSequencePropsSubscription = ({
 	column,
 	schema,
 	effects,
+	nodePath,
 	clientId,
 	applyOnce,
 	applyEach,
@@ -45,6 +46,7 @@ export const acquireSequencePropsSubscription = ({
 	column: number;
 	schema: SequenceSchema;
 	effects: SequenceSchema[];
+	nodePath: SequenceNodePath | null;
 	clientId: string;
 	applyOnce: ApplyResult;
 	applyEach: ApplyResult;
@@ -59,6 +61,7 @@ export const acquireSequencePropsSubscription = ({
 			fileName,
 			line,
 			column,
+			nodePath,
 			keys: getAllSchemaKeys(schema),
 			effects: effectKeys,
 			clientId,

--- a/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
+++ b/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
@@ -3,8 +3,8 @@ import {
 	stringifySequenceSubscriptionKey,
 } from '@remotion/studio-shared';
 import {useContext, useEffect, useMemo, useRef} from 'react';
-import {Internals} from 'remotion';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
+import {Internals} from 'remotion';
 import type {OriginalPosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {ExpandedTracksSetterContext} from '../ExpandedTracksProvider';
@@ -84,6 +84,7 @@ export const useSequencePropsSubscription = ({
 			column: locationColumn,
 			schema,
 			effects,
+			nodePath: nodePathAtResubscribe?.nodePath ?? null,
 			clientId,
 			applyOnce: (result) => {
 				if (!result.success) {


### PR DESCRIPTION
## Summary

- Add `nodePath` to `/api/subscribe-to-sequence-props` request payload
- Send the currently known node path from `useSequencePropsSubscription()` when re-subscribing
- Make server-side subscribe resolution prefer provided `nodePath` over line/column lookup

This avoids transient `not-found` subscribe failures during the HMR/source-map timing window.

Fixes #7946
Closes #7922