### PR TITLE
@remotion/example: Add premounting repro composition

### DIFF
--- a/packages/example/src/NewVideo.tsx
+++ b/packages/example/src/NewVideo.tsx
@@ -1,5 +1,5 @@
 import {Video} from '@remotion/media';
-import {CalculateMetadataFunction, Composition} from 'remotion';
+import {CalculateMetadataFunction, Composition, Sequence} from 'remotion';
 // https://www.remotion.dev/docs/mediabunny/metadata
 import {getMediaMetadata} from './get-media-metadata';
 
@@ -28,6 +28,27 @@ export const NewVideoComp = () => {
 			component={Component}
 			id="NewVideo"
 			calculateMetadata={calculateMetadataFn}
+		/>
+	);
+};
+
+const PremountSequenceVideo = () => {
+	return (
+		<Sequence from={90} premountFor={30}>
+			<Video src={src} debugOverlay />
+		</Sequence>
+	);
+};
+
+export const PremountSequenceVideoComp = () => {
+	return (
+		<Composition
+			id="PremountSequenceVideo"
+			component={PremountSequenceVideo}
+			width={1920}
+			height={1080}
+			fps={30}
+			durationInFrames={180}
 		/>
 	);
 };

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -187,7 +187,7 @@ import {LightLeakExample} from './LightLeak';
 import {LightLeakAnimatedSize} from './LightLeak/AnimatedSize';
 import {LoopDisplayTestComp} from './LoopDisplayTest';
 import {NewAudioExample} from './NewAudio/NewAudio';
-import {NewVideoComp} from './NewVideo';
+import {NewVideoComp, PremountSequenceVideoComp} from './NewVideo';
 import {ObjectFitTestComp} from './ObjectFitTest';
 import {ChangingTrimBeforeValue} from './OffthreadRemoteVideo/ChangingTrimBefore';
 import {Issue7562OffthreadVideoCuts} from './OffthreadRemoteVideo/Issue7562OffthreadVideoCuts';
@@ -960,6 +960,7 @@ export const Index: React.FC = () => {
 				/>
 				<OffthreadRemoteVideo />
 				<NewVideoComp />
+				<PremountSequenceVideoComp />
 				<ObjectFitTestComp />
 				<NewVideoBufferStateComp />
 				<LoopDisplayTestComp />


### PR DESCRIPTION
Adds a dedicated example composition that wraps a video in a middle-of-composition <Sequence> with premounting enabled, to reproduce the 4.0.456 regression investigation.