### PR TITLE
`@remotion/studio`: Drag selected sequences together in visual mode

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -15,6 +15,7 @@ import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {BLUE} from '../helpers/colors';
 import {getBoxQuadsPonyfill} from '../helpers/get-box-quads-ponyfill';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+import {showNotification} from './Notifications/NotificationCenter';
 import {saveEffectProp} from './Timeline/save-effect-prop';
 import {saveSequenceProps} from './Timeline/save-sequence-prop';
 import {getDecimalPlaces} from './Timeline/timeline-field-utils';
@@ -782,9 +783,18 @@ const SelectedOutlinePolygon: React.FC<{
 					clientId: drag.clientId,
 					undoLabel: changes.length > 1 ? 'Move selected sequences' : null,
 					redoLabel: changes.length > 1 ? 'Move selected sequences back' : null,
-				}).finally(() => {
-					clearSelectedOutlineDragOverrides({clearDragOverrides, dragStates});
-				});
+				})
+					.catch((err) => {
+						showNotification(
+							`Could not save sequence props: ${
+								err instanceof Error ? err.message : String(err)
+							}`,
+							4000,
+						);
+					})
+					.finally(() => {
+						clearSelectedOutlineDragOverrides({clearDragOverrides, dragStates});
+					});
 			};
 
 			window.addEventListener('pointermove', onPointerMove);

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -16,7 +16,7 @@ import {BLUE} from '../helpers/colors';
 import {getBoxQuadsPonyfill} from '../helpers/get-box-quads-ponyfill';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {saveEffectProp} from './Timeline/save-effect-prop';
-import {saveSequenceProp} from './Timeline/save-sequence-prop';
+import {saveSequenceProps} from './Timeline/save-sequence-prop';
 import {getDecimalPlaces} from './Timeline/timeline-field-utils';
 import {
 	parseTranslate,
@@ -76,6 +76,14 @@ type SelectedOutlineDragTarget = {
 	readonly fieldDefault: string | undefined;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: SequenceSchema;
+};
+
+export type SelectedOutlineDragState = {
+	readonly defaultValue: string | null;
+	readonly key: string;
+	readonly startX: number;
+	readonly startY: number;
+	readonly target: SelectedOutlineDragTarget;
 };
 
 type SequenceWithSelectedOutline = {
@@ -597,11 +605,115 @@ const outlinesAreEqual = (
 	return true;
 };
 
+const getSelectedOutlineDragStates = ({
+	dragTargets,
+	getDragOverrides,
+}: {
+	readonly dragTargets: readonly SelectedOutlineDragTarget[];
+	readonly getDragOverrides: (
+		nodePath: SequencePropsSubscriptionKey,
+	) => Record<string, unknown>;
+}): SelectedOutlineDragState[] => {
+	return dragTargets.map((target) => {
+		const dragOverrideValue = (getDragOverrides(target.nodePath) ?? {})[
+			translateFieldKey
+		];
+		const effectiveValue = Internals.getEffectiveVisualModeValue({
+			codeValue: target.codeValue,
+			dragOverrideValue,
+			defaultValue: target.fieldDefault,
+			shouldResortToDefaultValueIfUndefined: true,
+		});
+		const [startX, startY] = parseTranslate(
+			String(effectiveValue ?? '0px 0px'),
+		);
+
+		return {
+			defaultValue:
+				target.fieldDefault !== undefined
+					? JSON.stringify(target.fieldDefault)
+					: null,
+			key: Internals.makeSequencePropsSubscriptionKey(target.nodePath),
+			startX,
+			startY,
+			target,
+		};
+	});
+};
+
+export const getSelectedOutlineDragValues = ({
+	dragStates,
+	deltaX,
+	deltaY,
+}: {
+	readonly dragStates: readonly SelectedOutlineDragState[];
+	readonly deltaX: number;
+	readonly deltaY: number;
+}): Map<string, string> => {
+	return new Map(
+		dragStates.map((dragState) => [
+			dragState.key,
+			serializeTranslate(dragState.startX + deltaX, dragState.startY + deltaY),
+		]),
+	);
+};
+
+export const getSelectedOutlineDragChanges = ({
+	dragStates,
+	lastValues,
+}: {
+	readonly dragStates: readonly SelectedOutlineDragState[];
+	readonly lastValues: ReadonlyMap<string, string>;
+}) => {
+	return dragStates.flatMap((dragState) => {
+		const value = lastValues.get(dragState.key);
+		if (value === undefined) {
+			return [];
+		}
+
+		const stringifiedValue = JSON.stringify(value);
+		const shouldSave =
+			value !== dragState.target.codeValue.codeValue &&
+			!(
+				dragState.defaultValue === stringifiedValue &&
+				dragState.target.codeValue.codeValue === undefined
+			);
+
+		if (!shouldSave) {
+			return [];
+		}
+
+		return [
+			{
+				fileName: dragState.target.nodePath.absolutePath,
+				nodePath: dragState.target.nodePath,
+				fieldKey: translateFieldKey,
+				value,
+				defaultValue: dragState.defaultValue,
+				schema: dragState.target.schema,
+			},
+		];
+	});
+};
+
+const clearSelectedOutlineDragOverrides = ({
+	clearDragOverrides,
+	dragStates,
+}: {
+	readonly clearDragOverrides: (nodePath: SequencePropsSubscriptionKey) => void;
+	readonly dragStates: readonly SelectedOutlineDragState[];
+}) => {
+	for (const dragState of dragStates) {
+		clearDragOverrides(dragState.target.nodePath);
+	}
+};
+
 const SelectedOutlinePolygon: React.FC<{
+	readonly allDragTargets: readonly SelectedOutlineDragTarget[];
 	readonly outline: SelectedOutline;
 	readonly scale: number;
 	readonly target: SelectedOutlineTarget | undefined;
-}> = ({outline, scale, target}) => {
+}> = ({allDragTargets, outline, scale, target}) => {
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
@@ -625,31 +737,28 @@ const SelectedOutlinePolygon: React.FC<{
 
 			const startPointerX = event.clientX;
 			const startPointerY = event.clientY;
-			const dragOverrideValue = (getDragOverrides(drag.nodePath) ?? {})[
-				translateFieldKey
-			];
-			const effectiveValue = Internals.getEffectiveVisualModeValue({
-				codeValue: drag.codeValue,
-				dragOverrideValue,
-				defaultValue: drag.fieldDefault,
-				shouldResortToDefaultValueIfUndefined: true,
+			const dragStates = getSelectedOutlineDragStates({
+				dragTargets: allDragTargets,
+				getDragOverrides,
 			});
-			const [startX, startY] = parseTranslate(
-				String(effectiveValue ?? '0px 0px'),
-			);
-			const defaultValue =
-				drag.fieldDefault !== undefined
-					? JSON.stringify(drag.fieldDefault)
-					: null;
-			let lastValue: string | null = null;
+			let lastValues = new Map<string, string>();
 
 			const onPointerMove = (moveEvent: PointerEvent) => {
 				moveEvent.preventDefault();
 
-				const nextX = startX + (moveEvent.clientX - startPointerX) / scale;
-				const nextY = startY + (moveEvent.clientY - startPointerY) / scale;
-				lastValue = serializeTranslate(nextX, nextY);
-				setDragOverrides(drag.nodePath, translateFieldKey, lastValue);
+				lastValues = getSelectedOutlineDragValues({
+					dragStates,
+					deltaX: (moveEvent.clientX - startPointerX) / scale,
+					deltaY: (moveEvent.clientY - startPointerY) / scale,
+				});
+				for (const dragState of dragStates) {
+					const value = lastValues.get(dragState.key);
+					if (value === undefined) {
+						throw new Error('Expected drag value to be available');
+					}
+
+					setDragOverrides(dragState.target.nodePath, translateFieldKey, value);
+				}
 			};
 
 			const onPointerUp = () => {
@@ -657,32 +766,24 @@ const SelectedOutlinePolygon: React.FC<{
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
 
-				const stringifiedValue =
-					lastValue === null ? null : JSON.stringify(lastValue);
-				const shouldSave =
-					lastValue !== null &&
-					lastValue !== drag.codeValue.codeValue &&
-					!(
-						defaultValue === stringifiedValue &&
-						drag.codeValue.codeValue === undefined
-					);
+				const changes = getSelectedOutlineDragChanges({
+					dragStates,
+					lastValues,
+				});
 
-				if (!shouldSave) {
-					clearDragOverrides(drag.nodePath);
+				if (changes.length === 0) {
+					clearSelectedOutlineDragOverrides({clearDragOverrides, dragStates});
 					return;
 				}
 
-				saveSequenceProp({
-					fileName: drag.nodePath.absolutePath,
-					nodePath: drag.nodePath,
-					fieldKey: translateFieldKey,
-					value: lastValue,
-					defaultValue,
-					schema: drag.schema,
+				saveSequenceProps({
+					changes,
 					setCodeValues,
 					clientId: drag.clientId,
+					undoLabel: changes.length > 1 ? 'Move selected sequences' : null,
+					redoLabel: changes.length > 1 ? 'Move selected sequences back' : null,
 				}).finally(() => {
-					clearDragOverrides(drag.nodePath);
+					clearSelectedOutlineDragOverrides({clearDragOverrides, dragStates});
 				});
 			};
 
@@ -691,6 +792,7 @@ const SelectedOutlinePolygon: React.FC<{
 			window.addEventListener('pointercancel', onPointerUp);
 		},
 		[
+			allDragTargets,
 			clearDragOverrides,
 			drag,
 			getDragOverrides,
@@ -934,6 +1036,11 @@ export const SelectedOutlineOverlay: React.FC<{
 			selectedOutlineTargets.map((target) => [target.key, target]),
 		);
 	}, [selectedOutlineTargets]);
+	const allDragTargets = useMemo(() => {
+		return selectedOutlineTargets.flatMap((target) =>
+			target.drag === null ? [] : [target.drag],
+		);
+	}, [selectedOutlineTargets]);
 
 	useEffect(() => {
 		if (selectedOutlineTargets.length === 0) {
@@ -985,6 +1092,7 @@ export const SelectedOutlineOverlay: React.FC<{
 			{outlines.map((outline) => (
 				<React.Fragment key={outline.key}>
 					<SelectedOutlinePolygon
+						allDragTargets={allDragTargets}
 						outline={outline}
 						scale={scale}
 						target={targetsByKey.get(outline.key)}

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -9,8 +9,11 @@ import {
 } from 'remotion';
 import {
 	getSelectedEffectFieldsBySequenceKey,
+	getSelectedOutlineDragChanges,
+	getSelectedOutlineDragValues,
 	getUvCoordinateForPoint,
 	getUvHandlePosition,
+	type SelectedOutlineDragState,
 } from '../components/SelectedOutlineOverlay';
 import {deleteSelectedTimelineItems} from '../components/Timeline/delete-selected-timeline-item';
 import {isDuplicatableSequenceRowSelection} from '../components/Timeline/duplicate-selected-timeline-item';
@@ -260,6 +263,74 @@ test('Backspace reset targets multiple selected sequence props', () => {
 		'style.rotate',
 	]);
 	expect(resetTargets?.map((target) => target.value)).toEqual([1, '0deg']);
+});
+
+test('Selected outline dragging applies the same delta to all selected sequences', () => {
+	const schema = {
+		'style.translate': {type: 'translate', default: '0px 0px'},
+	} satisfies SequenceSchema;
+	const firstNodePath = makeKey(['body', 0]);
+	const secondNodePath = makeKey(['body', 1]);
+	const dragStates = [
+		{
+			defaultValue: JSON.stringify('0px 0px'),
+			key: Internals.makeSequencePropsSubscriptionKey(firstNodePath),
+			startX: 10,
+			startY: 20,
+			target: {
+				clientId: 'client',
+				codeValue: {canUpdate: true, codeValue: '10px 20px'},
+				fieldDefault: '0px 0px',
+				nodePath: firstNodePath,
+				schema,
+			},
+		},
+		{
+			defaultValue: JSON.stringify('0px 0px'),
+			key: Internals.makeSequencePropsSubscriptionKey(secondNodePath),
+			startX: -5,
+			startY: 3,
+			target: {
+				clientId: 'client',
+				codeValue: {canUpdate: true, codeValue: '-5px 3px'},
+				fieldDefault: '0px 0px',
+				nodePath: secondNodePath,
+				schema,
+			},
+		},
+	] satisfies SelectedOutlineDragState[];
+
+	const lastValues = getSelectedOutlineDragValues({
+		dragStates,
+		deltaX: 7,
+		deltaY: -4,
+	});
+
+	expect(lastValues.get(dragStates[0].key)).toBe('17px 16px');
+	expect(lastValues.get(dragStates[1].key)).toBe('2px -1px');
+	expect(
+		getSelectedOutlineDragChanges({
+			dragStates,
+			lastValues,
+		}),
+	).toEqual([
+		{
+			fileName: '/project/src/Comp.tsx',
+			nodePath: firstNodePath,
+			fieldKey: 'style.translate',
+			value: '17px 16px',
+			defaultValue: JSON.stringify('0px 0px'),
+			schema,
+		},
+		{
+			fileName: '/project/src/Comp.tsx',
+			nodePath: secondNodePath,
+			fieldKey: 'style.translate',
+			value: '2px -1px',
+			defaultValue: JSON.stringify('0px 0px'),
+			schema,
+		},
+	]);
 });
 
 test('Backspace reset targets selected effect props', () => {


### PR DESCRIPTION
## Summary
- move all selected draggable sequence outlines together when dragging in visual mode
- batch the resulting `style.translate` saves into one `/api/save-sequence-props` request
- add a Studio test covering shared drag deltas across multiple selected sequences

Closes #7871