### PR TITLE
`@remotion/studio-server`: Fix Zed editor support

### DIFF
--- a/packages/create-video/src/open-in-editor.ts
+++ b/packages/create-video/src/open-in-editor.ts
@@ -113,7 +113,9 @@ const editorNames = [
 	'zeditor',
 	'zed-editor',
 	'/Applications/Zed.app/Contents/MacOS/zed',
+	'/Applications/Zed.app/Contents/MacOS/cli',
 	'/Applications/Zed Preview.app/Contents/MacOS/zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/cli',
 	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview',
 ] as const;
 
@@ -174,7 +176,9 @@ const displayNameForEditor: {[key in Editor]: string} = {
 	zeditor: 'Zed',
 	'zed-editor': 'Zed',
 	'/Applications/Zed.app/Contents/MacOS/zed': 'Zed',
+	'/Applications/Zed.app/Contents/MacOS/cli': 'Zed',
 	'/Applications/Zed Preview.app/Contents/MacOS/zed': 'Zed Preview',
+	'/Applications/Zed Preview.app/Contents/MacOS/cli': 'Zed Preview',
 	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview': 'Zed Preview',
 	gvim: 'GVim',
 	idea: 'IDEA',
@@ -223,11 +227,12 @@ const COMMON_EDITORS_OSX: Record<string, Editor> = {
 		'code-insiders',
 	'/Applications/VSCodium.app/Contents/MacOS/Electron': 'vscodium',
 	'/Applications/Cursor.app/Contents/MacOS/Cursor': 'cursor',
-	'/Applications/Zed.app/Contents/MacOS/zed': 'zed',
+	'/Applications/Zed.app/Contents/MacOS/zed':
+		'/Applications/Zed.app/Contents/MacOS/cli',
 	'/Applications/Zed Preview.app/Contents/MacOS/zed':
-		'/Applications/Zed Preview.app/Contents/MacOS/zed',
+		'/Applications/Zed Preview.app/Contents/MacOS/cli',
 	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview':
-		'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview',
+		'/Applications/Zed Preview.app/Contents/MacOS/cli',
 	'/Applications/AppCode.app/Contents/MacOS/appcode':
 		'/Applications/AppCode.app/Contents/MacOS/appcode',
 	'/Applications/CLion.app/Contents/MacOS/clion':
@@ -318,6 +323,18 @@ function getArgumentsForLineNumber(
 	colNumber: number,
 ) {
 	const editorBasename = path.basename(editor).replace(/\.(exe|cmd|bat)$/i, '');
+	const isZedEditor =
+		editor === 'zed' ||
+		editor === 'zedit' ||
+		editor === 'zeditor' ||
+		editor === 'zed-editor' ||
+		editor === 'Zed.exe' ||
+		editor.endsWith('/Zed.app/Contents/MacOS/cli') ||
+		editor.endsWith('/Zed Preview.app/Contents/MacOS/cli');
+	if (isZedEditor) {
+		return [fileName + ':' + lineNumber + ':' + colNumber];
+	}
+
 	switch (editorBasename) {
 		case 'atom':
 		case 'Atom':
@@ -355,14 +372,6 @@ function getArgumentsForLineNumber(
 		case 'Windsurf':
 		case 'Windsurf.exe':
 			return ['-g', fileName + ':' + lineNumber + ':' + colNumber];
-		case 'zed':
-		case 'zedit':
-		case 'zeditor':
-		case 'zed-editor':
-		case 'Zed':
-		case 'Zed Preview':
-		case 'Zed.exe':
-			return [fileName + ':' + lineNumber + ':' + colNumber];
 		case 'appcode':
 		case 'clion':
 		case 'clion64':

--- a/packages/create-video/src/open-in-editor.ts
+++ b/packages/create-video/src/open-in-editor.ts
@@ -108,8 +108,13 @@ const editorNames = [
 	'windsurf',
 	'Windsurf.exe',
 	'Zed.exe',
-	'Cursor.exe',
 	'zed',
+	'zedit',
+	'zeditor',
+	'zed-editor',
+	'/Applications/Zed.app/Contents/MacOS/zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview',
 ] as const;
 
 const displayNameForEditor: {[key in Editor]: string} = {
@@ -165,6 +170,12 @@ const displayNameForEditor: {[key in Editor]: string} = {
 	emacs: 'emacs',
 	windsurf: 'Windsurf',
 	zed: 'Zed',
+	zedit: 'Zed',
+	zeditor: 'Zed',
+	'zed-editor': 'Zed',
+	'/Applications/Zed.app/Contents/MacOS/zed': 'Zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/zed': 'Zed Preview',
+	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview': 'Zed Preview',
 	gvim: 'GVim',
 	idea: 'IDEA',
 	mvim: 'mvim',
@@ -212,6 +223,11 @@ const COMMON_EDITORS_OSX: Record<string, Editor> = {
 		'code-insiders',
 	'/Applications/VSCodium.app/Contents/MacOS/Electron': 'vscodium',
 	'/Applications/Cursor.app/Contents/MacOS/Cursor': 'cursor',
+	'/Applications/Zed.app/Contents/MacOS/zed': 'zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/zed':
+		'/Applications/Zed Preview.app/Contents/MacOS/zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview':
+		'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview',
 	'/Applications/AppCode.app/Contents/MacOS/appcode':
 		'/Applications/AppCode.app/Contents/MacOS/appcode',
 	'/Applications/CLion.app/Contents/MacOS/clion':
@@ -242,6 +258,11 @@ const COMMON_EDITORS_LINUX: Record<string, Editor> = {
 	'code-insiders': 'code-insiders',
 	vscodium: 'vscodium',
 	cursor: 'cursor',
+	windsurf: 'windsurf',
+	zed: 'zed',
+	zedit: 'zedit',
+	zeditor: 'zeditor',
+	'zed-editor': 'zed-editor',
 	emacs: 'emacs',
 	gvim: 'gvim',
 	'idea.sh': 'idea',
@@ -261,6 +282,8 @@ const COMMON_EDITORS_WIN: Editor[] = [
 	'Code - Insiders.exe',
 	'VSCodium.exe',
 	'Cursor.exe',
+	'Windsurf.exe',
+	'Zed.exe',
 	'atom.exe',
 	'sublime_text.exe',
 	'notepad++.exe',
@@ -328,7 +351,18 @@ function getArgumentsForLineNumber(
 		case 'VSCodium':
 		case 'Cursor.exe':
 		case 'cursor':
+		case 'windsurf':
+		case 'Windsurf':
+		case 'Windsurf.exe':
 			return ['-g', fileName + ':' + lineNumber + ':' + colNumber];
+		case 'zed':
+		case 'zedit':
+		case 'zeditor':
+		case 'zed-editor':
+		case 'Zed':
+		case 'Zed Preview':
+		case 'Zed.exe':
+			return [fileName + ':' + lineNumber + ':' + colNumber];
 		case 'appcode':
 		case 'clion':
 		case 'clion64':

--- a/packages/studio-server/src/helpers/open-in-editor.ts
+++ b/packages/studio-server/src/helpers/open-in-editor.ts
@@ -119,7 +119,9 @@ const editorNames = [
 	'zeditor',
 	'zed-editor',
 	'/Applications/Zed.app/Contents/MacOS/zed',
+	'/Applications/Zed.app/Contents/MacOS/cli',
 	'/Applications/Zed Preview.app/Contents/MacOS/zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/cli',
 	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview',
 	'Zed.exe',
 ] as const;
@@ -181,7 +183,9 @@ const displayNameForEditor: {[key in Editor]: string} = {
 	zeditor: 'Zed',
 	'zed-editor': 'Zed',
 	'/Applications/Zed.app/Contents/MacOS/zed': 'Zed',
+	'/Applications/Zed.app/Contents/MacOS/cli': 'Zed',
 	'/Applications/Zed Preview.app/Contents/MacOS/zed': 'Zed Preview',
+	'/Applications/Zed Preview.app/Contents/MacOS/cli': 'Zed Preview',
 	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview': 'Zed Preview',
 	emacs: 'emacs',
 	goland: 'GoLand',
@@ -240,11 +244,12 @@ const COMMON_EDITORS_OSX: Record<string, Editor> = {
 	'/Applications/VSCodium.app/Contents/MacOS/Electron': 'vscodium',
 	'/Applications/Cursor.app/Contents/MacOS/Cursor': 'cursor',
 	'/Applications/Windsurf.app/Contents/MacOS/Electron': 'windsurf',
-	'/Applications/Zed.app/Contents/MacOS/zed': 'zed',
+	'/Applications/Zed.app/Contents/MacOS/zed':
+		'/Applications/Zed.app/Contents/MacOS/cli',
 	'/Applications/Zed Preview.app/Contents/MacOS/zed':
-		'/Applications/Zed Preview.app/Contents/MacOS/zed',
+		'/Applications/Zed Preview.app/Contents/MacOS/cli',
 	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview':
-		'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview',
+		'/Applications/Zed Preview.app/Contents/MacOS/cli',
 	'/Applications/AppCode.app/Contents/MacOS/appcode':
 		'/Applications/AppCode.app/Contents/MacOS/appcode',
 	'/Applications/CLion.app/Contents/MacOS/clion':
@@ -335,8 +340,20 @@ function getArgumentsForLineNumber(
 	colNumber: number,
 ) {
 	const editorBasename = path.basename(editor).replace(/\.(exe|cmd|bat)$/i, '');
+	const isZedEditor =
+		editor === 'zed' ||
+		editor === 'zedit' ||
+		editor === 'zeditor' ||
+		editor === 'zed-editor' ||
+		editor === 'Zed.exe' ||
+		editor.endsWith('/Zed.app/Contents/MacOS/cli') ||
+		editor.endsWith('/Zed Preview.app/Contents/MacOS/cli');
 	const isFolder =
 		fs.existsSync(fileName) && fs.lstatSync(fileName).isDirectory();
+	if (isZedEditor) {
+		return [fileName + ':' + lineNumber + ':' + colNumber];
+	}
+
 	switch (editorBasename) {
 		case 'atom':
 		case 'Atom':
@@ -375,13 +392,6 @@ function getArgumentsForLineNumber(
 		case 'windsurf':
 		case 'Windsurf':
 			return ['-g', fileName + ':' + lineNumber + ':' + colNumber];
-		case 'zed':
-		case 'zedit':
-		case 'zeditor':
-		case 'zed-editor':
-		case 'Zed':
-		case 'Zed Preview':
-			return [fileName + ':' + lineNumber + ':' + colNumber];
 		case 'appcode':
 		case 'clion':
 		case 'clion64':

--- a/packages/studio-server/src/helpers/open-in-editor.ts
+++ b/packages/studio-server/src/helpers/open-in-editor.ts
@@ -115,6 +115,13 @@ const editorNames = [
 	'/Applications/Windsurf.app/Contents/MacOS/Windsurf',
 	'Windsurf.exe',
 	'zed',
+	'zedit',
+	'zeditor',
+	'zed-editor',
+	'/Applications/Zed.app/Contents/MacOS/zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview',
+	'Zed.exe',
 ] as const;
 
 const displayNameForEditor: {[key in Editor]: string} = {
@@ -142,6 +149,7 @@ const displayNameForEditor: {[key in Editor]: string} = {
 	'Code.exe': 'VS Code',
 	'Cursor.exe': 'Cursor',
 	'Windsurf.exe': 'Windsurf',
+	'Zed.exe': 'Zed',
 	'VSCodium.exe': 'VS Codium',
 	'atom.exe': 'Atom',
 	'clion.exe': 'CLion',
@@ -169,6 +177,12 @@ const displayNameForEditor: {[key in Editor]: string} = {
 	cursor: 'Cursor',
 	windsurf: 'Windsurf',
 	zed: 'Zed',
+	zedit: 'Zed',
+	zeditor: 'Zed',
+	'zed-editor': 'Zed',
+	'/Applications/Zed.app/Contents/MacOS/zed': 'Zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/zed': 'Zed Preview',
+	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview': 'Zed Preview',
 	emacs: 'emacs',
 	goland: 'GoLand',
 	gvim: 'GVim',
@@ -226,6 +240,11 @@ const COMMON_EDITORS_OSX: Record<string, Editor> = {
 	'/Applications/VSCodium.app/Contents/MacOS/Electron': 'vscodium',
 	'/Applications/Cursor.app/Contents/MacOS/Cursor': 'cursor',
 	'/Applications/Windsurf.app/Contents/MacOS/Electron': 'windsurf',
+	'/Applications/Zed.app/Contents/MacOS/zed': 'zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/zed':
+		'/Applications/Zed Preview.app/Contents/MacOS/zed',
+	'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview':
+		'/Applications/Zed Preview.app/Contents/MacOS/Zed Preview',
 	'/Applications/AppCode.app/Contents/MacOS/appcode':
 		'/Applications/AppCode.app/Contents/MacOS/appcode',
 	'/Applications/CLion.app/Contents/MacOS/clion':
@@ -257,6 +276,9 @@ const COMMON_EDITORS_LINUX: Record<string, Editor> = {
 	cursor: 'cursor',
 	windsurf: 'windsurf',
 	zed: 'zed',
+	zedit: 'zedit',
+	zeditor: 'zeditor',
+	'zed-editor': 'zed-editor',
 	vscodium: 'vscodium',
 	emacs: 'emacs',
 	gvim: 'gvim',
@@ -278,6 +300,7 @@ const COMMON_EDITORS_WIN: Editor[] = [
 	'VSCodium.exe',
 	'Cursor.exe',
 	'Windsurf.exe',
+	'Zed.exe',
 	'atom.exe',
 	'sublime_text.exe',
 	'notepad++.exe',
@@ -353,7 +376,12 @@ function getArgumentsForLineNumber(
 		case 'Windsurf':
 			return ['-g', fileName + ':' + lineNumber + ':' + colNumber];
 		case 'zed':
-			return ['--new', fileName + ':' + lineNumber + ':' + colNumber];
+		case 'zedit':
+		case 'zeditor':
+		case 'zed-editor':
+		case 'Zed':
+		case 'Zed Preview':
+			return [fileName + ':' + lineNumber + ':' + colNumber];
 		case 'appcode':
 		case 'clion':
 		case 'clion64':


### PR DESCRIPTION
Fixes Zed support for Open in editor on macOS by recognizing the actual lowercase Zed process path and using arguments accepted by both the app binary and CLI.

Also brings create-video editor detection in line with Studio Server for Zed variants.

Fixes #7958
Validated with `bun run build` and `bun run formatting`.
