### PR TITLE
`@remotion/promo-pages`: Update homepage location endpoint

### DIFF
--- a/packages/promo-pages/src/components/homepage/Demo/Comp.tsx
+++ b/packages/promo-pages/src/components/homepage/Demo/Comp.tsx
@@ -27,9 +27,9 @@ export type LocationAndTrending = {
 };
 
 export const getDataAndProps = async () => {
-	const location = (await fetch(
-		'https://bugs-five.vercel.app/api/location',
-	).then((res) => res.json())) as Location;
+	const location = (await fetch('https://utils.remotion.dev/location').then(
+		(res) => res.json(),
+	)) as Location;
 
 	const trending = await fetch(
 		`https://bugs.remotion.dev/trending?lat=${location.latitude}&lng=${location.longitude}&country=${location.country}`,


### PR DESCRIPTION
## Summary

- Switch the homepage demo location lookup to `https://utils.remotion.dev/location`
- Use the Cloudflare-backed endpoint for more accurate location data

Fixes #7814.

## Testing

- `cd packages/promo-pages && bunx oxfmt src --write`
- `bun run build`
- `bun run formatting`
