### PR TITLE
`remotion`: Add `refForOutline` for `<Img>`

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -1,10 +1,4 @@
-import React, {
-	useCallback,
-	useContext,
-	useImperativeHandle,
-	useLayoutEffect,
-	useRef,
-} from 'react';
+import React, {useCallback, useContext, useLayoutEffect, useRef} from 'react';
 import type {IsExact} from './audio/props.js';
 import type {ImageFit} from './calculate-image-fit.js';
 import {CanvasImage} from './canvas-image/index.js';
@@ -73,7 +67,9 @@ type ImgContentProps = Omit<
 	| 'from'
 	| 'durationInFrames'
 	| 'effects'
->;
+> & {
+	readonly refForOutline: React.RefObject<HTMLElement | null>;
+};
 
 const ImgContent: React.FC<ImgContentProps> = ({
 	onError,
@@ -86,6 +82,7 @@ const ImgContent: React.FC<ImgContentProps> = ({
 	crossOrigin,
 	decoding,
 	ref,
+	refForOutline,
 	...props
 }) => {
 	const imageRef = useRef<HTMLImageElement>(null);
@@ -99,9 +96,19 @@ const ImgContent: React.FC<ImgContentProps> = ({
 		throw new Error('typecheck error');
 	}
 
-	useImperativeHandle(ref, () => {
-		return imageRef.current as HTMLImageElement;
-	}, []);
+	const imageCallbackRef = useCallback(
+		(img: HTMLImageElement | null) => {
+			imageRef.current = img;
+			refForOutline.current = img;
+
+			if (typeof ref === 'function') {
+				ref(img);
+			} else if (ref) {
+				ref.current = img;
+			}
+		},
+		[ref, refForOutline],
+	);
 
 	const actualSrc = usePreload(src as string);
 
@@ -294,7 +301,7 @@ const ImgContent: React.FC<ImgContentProps> = ({
 	return (
 		<img
 			{...props}
-			ref={imageRef}
+			ref={imageCallbackRef}
 			crossOrigin={crossOriginValue}
 			onError={didGetError}
 			decoding={isRendering ? 'sync' : decoding}
@@ -304,6 +311,7 @@ const ImgContent: React.FC<ImgContentProps> = ({
 
 type NativeImgInnerProps = Omit<ImgProps, 'effects'> & {
 	readonly _experimentalControls: SequenceControls | undefined;
+	readonly _remotionInternalRefForOutline: React.RefObject<HTMLElement | null>;
 };
 
 const NativeImgInner: React.FC<NativeImgInnerProps> = ({
@@ -315,6 +323,7 @@ const NativeImgInner: React.FC<NativeImgInnerProps> = ({
 	from,
 	durationInFrames,
 	_experimentalControls: controls,
+	_remotionInternalRefForOutline: refForOutline,
 	...props
 }) => {
 	if (!src) {
@@ -335,8 +344,9 @@ const NativeImgInner: React.FC<NativeImgInnerProps> = ({
 			_experimentalControls={controls}
 			showInTimeline={showInTimeline ?? true}
 			hidden={hidden}
+			_remotionInternalRefForOutline={refForOutline}
 		>
-			<ImgContent src={src} {...props} />
+			<ImgContent src={src} refForOutline={refForOutline} {...props} />
 		</Sequence>
 	);
 };
@@ -344,6 +354,7 @@ const NativeImgInner: React.FC<NativeImgInnerProps> = ({
 const CanvasImageWithPrivateProps = CanvasImage as React.ComponentType<
 	CanvasImageProps & {
 		readonly _experimentalControls?: SequenceControls | undefined;
+		readonly _remotionInternalRefForOutline?: React.RefObject<HTMLElement | null> | null;
 	}
 >;
 
@@ -453,6 +464,8 @@ const ImgInner: React.FC<
 	delayRenderTimeoutInMilliseconds,
 	...props
 }) => {
+	const refForOutline = useRef<HTMLElement | null>(null);
+
 	if (effects.length === 0) {
 		return (
 			<NativeImgInner
@@ -475,6 +488,7 @@ const ImgInner: React.FC<
 				maxRetries={maxRetries}
 				delayRenderRetries={delayRenderRetries}
 				delayRenderTimeoutInMilliseconds={delayRenderTimeoutInMilliseconds}
+				_remotionInternalRefForOutline={refForOutline}
 			/>
 		);
 	}
@@ -519,6 +533,7 @@ const ImgInner: React.FC<
 				name === undefined ? 'https://www.remotion.dev/docs/img' : undefined
 			}
 			_experimentalControls={controls}
+			_remotionInternalRefForOutline={refForOutline}
 			{...canvasProps}
 		/>
 	);

--- a/packages/core/src/canvas-image/CanvasImage.tsx
+++ b/packages/core/src/canvas-image/CanvasImage.tsx
@@ -5,6 +5,7 @@ import {
 	useEffect,
 	useMemo,
 	useState,
+	type RefObject,
 } from 'react';
 import {calculateImageFit} from '../calculate-image-fit.js';
 import type {SequenceControls} from '../CompositionManager.js';
@@ -158,6 +159,7 @@ type CanvasImageContentProps = Pick<
 > & {
 	readonly effects: EffectsProp;
 	readonly controls: SequenceControls | undefined;
+	readonly refForOutline: RefObject<HTMLElement | null> | null;
 } & CanvasImageCanvasProps;
 
 const CanvasImageContent = forwardRef<
@@ -180,6 +182,7 @@ const CanvasImageContent = forwardRef<
 			maxRetries = 2,
 			delayRenderRetries,
 			delayRenderTimeoutInMilliseconds,
+			refForOutline,
 			...canvasProps
 		},
 		ref,
@@ -208,6 +211,9 @@ const CanvasImageContent = forwardRef<
 		const canvasRef = useCallback(
 			(canvas: HTMLCanvasElement | null) => {
 				setOutputCanvas(canvas);
+				if (refForOutline) {
+					refForOutline.current = canvas;
+				}
 
 				if (typeof ref === 'function') {
 					ref(canvas);
@@ -215,7 +221,7 @@ const CanvasImageContent = forwardRef<
 					ref.current = canvas;
 				}
 			},
-			[ref],
+			[ref, refForOutline],
 		);
 
 		useEffect(() => {
@@ -407,6 +413,7 @@ const CanvasImageInner = forwardRef<
 			stack,
 			_experimentalControls: controls,
 			_remotionInternalDocumentationLink,
+			_remotionInternalRefForOutline,
 			...canvasProps
 		},
 		ref,
@@ -433,6 +440,7 @@ const CanvasImageInner = forwardRef<
 				_remotionInternalEffects={memoizedEffectDefinitions}
 				_remotionInternalIsMedia={{type: 'image', src}}
 				_remotionInternalStack={stack}
+				_remotionInternalRefForOutline={_remotionInternalRefForOutline ?? null}
 			>
 				<CanvasImageContent
 					ref={ref}
@@ -450,6 +458,7 @@ const CanvasImageInner = forwardRef<
 					maxRetries={maxRetries}
 					delayRenderRetries={delayRenderRetries}
 					delayRenderTimeoutInMilliseconds={delayRenderTimeoutInMilliseconds}
+					refForOutline={_remotionInternalRefForOutline ?? null}
 					{...canvasProps}
 				/>
 			</Sequence>

--- a/packages/core/src/canvas-image/props.ts
+++ b/packages/core/src/canvas-image/props.ts
@@ -37,4 +37,8 @@ export type CanvasImageProps = CanvasImageSequenceProps &
 		 * @deprecated For internal use only.
 		 */
 		readonly _remotionInternalDocumentationLink?: string;
+		/**
+		 * @deprecated For internal use only.
+		 */
+		readonly _remotionInternalRefForOutline?: React.RefObject<HTMLElement | null> | null;
 	};

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -167,3 +167,19 @@ test('Named Img components do not receive the default documentation link', () =>
 
 	expect(registeredSequences[0]?.documentationLink).toBe(null);
 });
+
+test('Img registers a refForOutline pointing to the rendered image element', () => {
+	const registeredSequences: TSequence[] = [];
+
+	render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Img src="test.png" />
+		</SequenceTestWrapper>,
+	);
+
+	expect(registeredSequences[0]?.refForOutline?.current?.tagName).toBe('IMG');
+});


### PR DESCRIPTION
Closes #7936

Adds `refForOutline` support to the `<Img>` component, enabling the Remotion Studio to draw selection outlines around `<Img>` elements in the timeline.

## Changes

- **`packages/core/src/Img.tsx`**: Added `refForOutline` threading through the native `<img>` path. Replaced `useImperativeHandle` with a callback ref that sets both the image ref and the outline ref. Passes `_remotionInternalRefForOutline` to `<Sequence>`.
- **`packages/core/src/canvas-image/CanvasImage.tsx`**: Added `refForOutline` threading through the canvas-effects path. Updated the `canvasRef` callback to also set `refForOutline.current`. Threads `_remotionInternalRefForOutline` through `CanvasImageInner` to `<Sequence>`.
- **`packages/core/src/canvas-image/props.ts`**: Added optional `_remotionInternalRefForOutline` to `CanvasImageProps`.
- **`packages/core/src/test/sequence-register-once.test.tsx`**: Added a test asserting the `refForOutline` points to the rendered `<img>` element.

## Pattern

Mirrors the same pattern implemented in `<Solid>` and recently added to `<Video>`: each visual component creates a `useRef<HTMLElement | null>(null)` at the outer wrapper level, passes it as `_remotionInternalRefForOutline` to `<Sequence>`, and threads it into the inner rendering component where it is assigned via callback ref to the actual DOM element.