### PR TITLE
`@remotion/studio`: Fix visual outline clipping

### DIFF
--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -103,6 +103,7 @@ const containerStyle = (options: {
 		width: options.width,
 		height: options.height,
 		display: 'flex',
+		overflow: 'hidden',
 		position: 'absolute',
 		backgroundColor: checkerboardBackgroundColor(options.checkerboard),
 		backgroundImage: checkerboardBackgroundImage(options.checkerboard),
@@ -212,7 +213,7 @@ const CompWhenItHasDimensions: React.FC<{
 			position: 'absolute',
 			left: centerX - previewSize.translation.x,
 			top: centerY - previewSize.translation.y,
-			overflow: 'hidden',
+			overflow: canvasContent.type === 'composition' ? 'visible' : 'hidden',
 			justifyContent: canvasContent.type === 'asset' ? 'center' : 'flex-start',
 			alignItems:
 				canvasContent.type === 'asset' &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7928.

Moves composition overflow clipping from the outer preview wrapper to the actual portal content so Visual Mode outlines can render outside the clipped canvas while composition contents remain clipped.

Testing:
- `bun run build`
- `bun run formatting`
- `bunx turbo run lint test --filter='@remotion/studio' --no-update-notifier`

Manual Studio verification was attempted, but the browser executor hit Chrome renderer crashes and then the VM execution environment became unreachable before a walkthrough artifact could be captured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d21afb0-aae3-4627-a65a-94771b947df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d21afb0-aae3-4627-a65a-94771b947df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

