### PR TITLE
`remotion`: Add CanvasImage outline ref [LGTM]

### DIFF
--- a/packages/core/src/canvas-image/CanvasImage.tsx
+++ b/packages/core/src/canvas-image/CanvasImage.tsx
@@ -3,7 +3,9 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	useImperativeHandle,
 	useMemo,
+	useRef,
 	useState,
 } from 'react';
 import {calculateImageFit} from '../calculate-image-fit.js';
@@ -416,6 +418,10 @@ const CanvasImageInner = forwardRef<
 		}
 
 		const memoizedEffectDefinitions = useMemoizedEffectDefinitions(effects);
+		const actualRef = useRef<HTMLCanvasElement | null>(null);
+		useImperativeHandle(ref, () => {
+			return actualRef.current as HTMLCanvasElement;
+		}, []);
 
 		return (
 			<Sequence
@@ -433,9 +439,10 @@ const CanvasImageInner = forwardRef<
 				_remotionInternalEffects={memoizedEffectDefinitions}
 				_remotionInternalIsMedia={{type: 'image', src}}
 				_remotionInternalStack={stack}
+				_remotionInternalRefForOutline={actualRef}
 			>
 				<CanvasImageContent
-					ref={ref}
+					ref={actualRef}
 					src={src}
 					width={width}
 					height={height}

--- a/packages/core/src/test/canvas-image.test.tsx
+++ b/packages/core/src/test/canvas-image.test.tsx
@@ -2,11 +2,15 @@ import {afterEach, beforeEach, expect, test} from 'bun:test';
 import {cleanup, render, waitFor} from '@testing-library/react';
 import React from 'react';
 import {CanvasImage} from '../canvas-image/index.js';
+import type {TSequence} from '../CompositionManager.js';
 import type {
 	EffectApplyParams,
 	EffectDefinition,
 	EffectDescriptor,
 } from '../effects/effect-types.js';
+import {Internals} from '../internals.js';
+import type {SequenceManagerContext} from '../SequenceManager.js';
+import {SequenceManager} from '../SequenceManager.js';
 import {WrapSequenceContext} from './wrap-sequence-context.js';
 
 type DrawImageCall = {
@@ -68,6 +72,45 @@ class MockImage {
 
 const OriginalImage = globalThis.Image;
 
+const studioEnv = {
+	isRendering: false,
+	isClientSideRendering: false,
+	isPlayer: false,
+	isStudio: true,
+	isReadOnlyStudio: false,
+};
+
+const SequenceRegistrationWrapper: React.FC<{
+	readonly children: React.ReactNode;
+	readonly onRegisterSequence: (sequence: TSequence) => void;
+}> = ({children, onRegisterSequence}) => {
+	const registerSequence = React.useCallback(
+		(sequence: TSequence) => {
+			onRegisterSequence(sequence);
+		},
+		[onRegisterSequence],
+	);
+	const unregisterSequence = React.useCallback(() => undefined, []);
+	const sequenceManagerContext: SequenceManagerContext = React.useMemo(
+		() => ({
+			registerSequence,
+			unregisterSequence,
+			sequences: [],
+		}),
+		[registerSequence, unregisterSequence],
+	);
+
+	return (
+		<WrapSequenceContext>
+			<Internals.RemotionEnvironmentContext value={studioEnv}>
+				<SequenceManager.Provider value={sequenceManagerContext}>
+					{children}
+				</SequenceManager.Provider>
+			</Internals.RemotionEnvironmentContext>
+		</WrapSequenceContext>
+	);
+};
+
 beforeEach(() => {
 	drawImageCalls.length = 0;
 	globalThis.Image = MockImage as unknown as typeof Image;
@@ -107,6 +150,26 @@ test('<CanvasImage> forwards a canvas ref', async () => {
 		expect(ref.current?.tagName).toBe('CANVAS');
 		expect(ref.current?.getAttribute('width')).toBe('120');
 		expect(ref.current?.getAttribute('height')).toBe('80');
+	});
+});
+
+test('<CanvasImage> registers its canvas as the outline ref', async () => {
+	const registeredSequences: TSequence[] = [];
+
+	render(
+		<SequenceRegistrationWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<CanvasImage src="test.png" width={120} height={80} />
+		</SequenceRegistrationWrapper>,
+	);
+
+	await waitFor(() => {
+		expect(registeredSequences[0]?.refForOutline?.current?.tagName).toBe(
+			'CANVAS',
+		);
 	});
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #7937.

## Summary
- Add an internal canvas ref for `<CanvasImage>` and register it via `_remotionInternalRefForOutline` so Studio outline selection can target the rendered canvas.
- Keep the public forwarded ref behavior intact.
- Add a regression test that verifies Studio sequence registration receives the canvas outline ref.

## Evidence
[CanvasImage still render](https://cursor.com/agents/bc-87d52398-f9b6-4738-a0e1-bb41c0ff4350/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcanvas_image_still.png)

## Tests
- `bun test src/test/canvas-image.test.tsx` from `packages/core`
- `bun run formatting && bun run lint && bun run make && bun test src/test/canvas-image.test.tsx` from `packages/core`
- `bun run build` from repo root
- `bun run stylecheck` from repo root (fails only in known `@remotion/lambda-go` lint due Go 1.22.2 vs required Go >= 1.23.0)
- `bun run test` from `packages/core`
- `bunx remotion still canvas-img --output /opt/cursor/artifacts/canvas_image_still.png` from `packages/example`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87d52398-f9b6-4738-a0e1-bb41c0ff4350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87d52398-f9b6-4738-a0e1-bb41c0ff4350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

