### PR TITLE
Docs: Use range input for effect offsets

### DIFF
--- a/packages/docs/components/effects-demos/schema-control.tsx
+++ b/packages/docs/components/effects-demos/schema-control.tsx
@@ -32,6 +32,21 @@ const getNumberValue = (
 	return getDefaultValueFromSchema(field) as number;
 };
 
+const getDemoNumberRange = (
+	fieldKey: string,
+	field: Extract<SequenceFieldSchema, {type: 'number'}>,
+): {min: number; max: number} | null => {
+	if (field.min !== undefined && field.max !== undefined) {
+		return {min: field.min, max: field.max};
+	}
+
+	if (fieldKey === 'offset') {
+		return {min: -400, max: 400};
+	}
+
+	return null;
+};
+
 const getStringValue = (value: unknown, fallback: unknown): string => {
 	if (typeof value === 'string') {
 		return value;
@@ -96,14 +111,18 @@ export const SchemaControl = ({
 	}
 
 	const label = field.description ?? fieldKey;
+	const numberRange =
+		field.type === 'number' ? getDemoNumberRange(fieldKey, field) : null;
 
 	return (
 		<label style={labelStyle} className={styles.item}>
 			<div style={left}>{label}</div>
 			{field.type === 'number' ? (
-				field.min === undefined || field.max === undefined ? (
+				numberRange ? (
 					<input
-						type="number"
+						type="range"
+						min={numberRange.min}
+						max={numberRange.max}
 						step={field.step}
 						value={getNumberValue(value, field)}
 						style={inputStyle}
@@ -111,9 +130,7 @@ export const SchemaControl = ({
 					/>
 				) : (
 					<input
-						type="range"
-						min={field.min}
-						max={field.max}
+						type="number"
 						step={field.step}
 						value={getNumberValue(value, field)}
 						style={inputStyle}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7955

## Summary
- Render unbounded `offset` fields in effects demos as range inputs with demo-only `-400..400` bounds.
- Keep other unbounded numeric effect controls as number inputs.

## Walkthrough
[effects_offset_range_updates_to_120.mp4](https://cursor.com/agents/bc-14a1f2b5-3302-48a4-b7d4-6e74ad36882e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feffects_offset_range_updates_to_120.mp4)
[Offset slider updated to 120](https://cursor.com/agents/bc-14a1f2b5-3302-48a4-b7d4-6e74ad36882e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feffects_offset_range_updated.png)

## Testing
- `bunx oxfmt src --write` in `packages/docs`
- `bunx oxfmt components/effects-demos/schema-control.tsx --write && bunx oxfmt components/effects-demos/schema-control.tsx --check` in `packages/docs`
- `bun run build`
- `bun run formatting`
- `bun run stylecheck` (expected `@remotion/lambda-go` Go version failure on this VM)
- `bun run lint && bun run formatting` in `packages/docs`
- Playwright/Chrome DOM check: `Offset` input is `type=range`, `min=-400`, `max=400`, and displayed value updates to `120`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14a1f2b5-3302-48a4-b7d4-6e74ad36882e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14a1f2b5-3302-48a4-b7d4-6e74ad36882e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

