### PR TITLE
Docs: Use Solid in generate effect examples

### DIFF
--- a/packages/docs/docs/effects/halftone-linear-gradient.mdx
+++ b/packages/docs/docs/effects/halftone-linear-gradient.mdx
@@ -21,15 +21,16 @@ Use it for dot-pattern wipes, overlays, and backgrounds on canvas-based componen
 ## Example
 
 ```tsx twoslash title="MyComp.tsx"
-import {AbsoluteFill} from 'remotion';
-import {Video} from '@remotion/media';
+import {AbsoluteFill, Solid} from 'remotion';
 import {halftoneLinearGradient} from '@remotion/effects/halftone-linear-gradient';
 
 export const MyComp: React.FC = () => {
   return (
     <AbsoluteFill>
-      <Video
-        src="https://remotion.media/video.mp4"
+      <Solid
+        width={1280}
+        height={720}
+        color="black"
         effects={[
           halftoneLinearGradient({
             firstStopDotSize: 0,
@@ -49,15 +50,16 @@ export const MyComp: React.FC = () => {
 To use colors from the previous effect in the chain, set `colorMode` to `'source'`:
 
 ```tsx twoslash title="MyComp.tsx"
-import {AbsoluteFill} from 'remotion';
-import {Video} from '@remotion/media';
+import {AbsoluteFill, Solid} from 'remotion';
 import {halftoneLinearGradient} from '@remotion/effects/halftone-linear-gradient';
 
 export const MyComp: React.FC = () => {
   return (
     <AbsoluteFill>
-      <Video
-        src="https://remotion.media/video.mp4"
+      <Solid
+        width={1280}
+        height={720}
+        color="#0b84f3"
         effects={[
           halftoneLinearGradient({
             firstStopDotSize: 8,

--- a/packages/docs/docs/effects/lines.mdx
+++ b/packages/docs/docs/effects/lines.mdx
@@ -22,16 +22,16 @@ Each line color is composited over the source.
 
 ```tsx twoslash title="MyComp.tsx"
 import {lines} from '@remotion/effects/lines';
-import {Video} from '@remotion/media';
-import {AbsoluteFill, useCurrentFrame} from 'remotion';
+import {AbsoluteFill, Solid, useCurrentFrame} from 'remotion';
 
 export const MyComp: React.FC = () => {
   const frame = useCurrentFrame();
 
   return (
     <AbsoluteFill>
-      <Video
-        src="https://remotion.media/video.mp4"
+      <Solid
+        width={1280}
+        height={720}
         effects={[
           lines({
             colors: ['#dff4ff', '#7cc6ff'],

--- a/packages/docs/docs/effects/noise.mdx
+++ b/packages/docs/docs/effects/noise.mdx
@@ -21,15 +21,16 @@ The effect preserves the source alpha mask. Transparent regions stay transparent
 ## Example
 
 ```tsx twoslash title="MyComp.tsx"
-import {AbsoluteFill} from 'remotion';
-import {Video} from '@remotion/media';
+import {AbsoluteFill, Solid} from 'remotion';
 import {noise} from '@remotion/effects/noise';
 
 export const MyComp: React.FC = () => {
   return (
     <AbsoluteFill>
-      <Video
-        src="https://remotion.media/video.mp4"
+      <Solid
+        width={1280}
+        height={720}
+        color="black"
         effects={[
           noise({
             amount: 0.25,

--- a/packages/docs/docs/effects/waves.mdx
+++ b/packages/docs/docs/effects/waves.mdx
@@ -22,16 +22,16 @@ Colors are composited over the source.
 
 ```tsx twoslash title="MyComp.tsx"
 import {waves} from '@remotion/effects/waves';
-import {Video} from '@remotion/media';
-import {AbsoluteFill, useCurrentFrame} from 'remotion';
+import {AbsoluteFill, Solid, useCurrentFrame} from 'remotion';
 
 export const MyComp: React.FC = () => {
   const frame = useCurrentFrame();
 
   return (
     <AbsoluteFill>
-      <Video
-        src="https://remotion.media/video.mp4"
+      <Solid
+        width={1280}
+        height={720}
         effects={[
           waves({
             colors: ['#dff4ff', '#7cc6ff'],

--- a/packages/docs/docs/effects/white-noise.mdx
+++ b/packages/docs/docs/effects/white-noise.mdx
@@ -29,15 +29,16 @@ The effect preserves the source alpha mask. Transparent regions stay transparent
 ## Example
 
 ```tsx twoslash title="MyComp.tsx"
-import {AbsoluteFill} from 'remotion';
-import {Video} from '@remotion/media';
+import {AbsoluteFill, Solid} from 'remotion';
 import {whiteNoise} from '@remotion/effects/white-noise';
 
 export const MyComp: React.FC = () => {
   return (
     <AbsoluteFill>
-      <Video
-        src="https://remotion.media/video.mp4"
+      <Solid
+        width={1280}
+        height={720}
+        color="black"
         effects={[
           whiteNoise({
             amount: 1,

--- a/packages/docs/docs/effects/zigzag.mdx
+++ b/packages/docs/docs/effects/zigzag.mdx
@@ -22,16 +22,16 @@ It uses the same band controls as [`lines()`](/docs/effects/lines), and the same
 
 ```tsx twoslash title="MyComp.tsx"
 import {zigzag} from '@remotion/effects/zigzag';
-import {Video} from '@remotion/media';
-import {AbsoluteFill, useCurrentFrame} from 'remotion';
+import {AbsoluteFill, Solid, useCurrentFrame} from 'remotion';
 
 export const MyComp: React.FC = () => {
   const frame = useCurrentFrame();
 
   return (
     <AbsoluteFill>
-      <Video
-        src="https://remotion.media/video.mp4"
+      <Solid
+        width={1280}
+        height={720}
         effects={[
           zigzag({
             colors: ['#d7b8ff', 'transparent'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7954

## Summary
- Replace `<Video>` snippets in Generate effect examples with `<Solid>`.
- Keep the changes scoped to the affected effect docs pages.

## Testing
- `bunx oxfmt src --write` from `packages/docs`
- `rg` assertion that targeted Generate docs no longer import or render `<Video>` examples
- `bun run build`
- `bun run formatting`
- `bun run build-docs`
- `bunx turbo run lint --filter=docs --no-update-notifier`

## Notes
- `bun run stylecheck` was attempted and reached the known `@remotion/lambda-go` Go version limitation documented in `AGENTS.md` (`go >= 1.23.0` required, VM has Go 1.22.2).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dfcc95e-a791-4c91-b1cc-2de584fcf296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dfcc95e-a791-4c91-b1cc-2de584fcf296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

