### PR TITLE
`remotion`: Add HtmlInCanvas outline ref

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -265,6 +265,7 @@ export type HtmlInCanvasProps = Omit<
 	| 'durationInFrames'
 	| keyof LayoutAndStyle
 	| '_remotionInternalEffects'
+	| '_remotionInternalRefForOutline'
 > &
 	Omit<
 		AbsoluteFillLayout,
@@ -564,6 +565,19 @@ const HtmlInCanvasInner = forwardRef<
 		const resolvedDuration = durationInFrames ?? videoDuration;
 
 		const memoizedEffectDefinitions = useMemoizedEffectDefinitions(effects);
+		const actualRef = useRef<HTMLCanvasElement | null>(null);
+		const setCanvasRef = useCallback(
+			(node: HTMLCanvasElement | null) => {
+				actualRef.current = node;
+				if (typeof ref === 'function') {
+					ref(node);
+				} else if (ref) {
+					(ref as React.MutableRefObject<HTMLCanvasElement | null>).current =
+						node;
+				}
+			},
+			[ref],
+		);
 
 		return (
 			<Sequence
@@ -576,11 +590,12 @@ const HtmlInCanvasInner = forwardRef<
 				}
 				_experimentalControls={controls}
 				_remotionInternalEffects={memoizedEffectDefinitions}
+				_remotionInternalRefForOutline={actualRef}
 				layout="none"
 				{...sequenceProps}
 			>
 				<HtmlInCanvasContent
-					ref={ref}
+					ref={setCanvasRef}
 					width={width}
 					height={height}
 					effects={effects}

--- a/packages/core/src/test/html-in-canvas.test.tsx
+++ b/packages/core/src/test/html-in-canvas.test.tsx
@@ -1,0 +1,222 @@
+import {afterEach, expect, test} from 'bun:test';
+import {cleanup, render, waitFor} from '@testing-library/react';
+import React, {useCallback, useMemo} from 'react';
+import type {TSequence} from '../CompositionManager.js';
+import {HtmlInCanvas} from '../HtmlInCanvas.js';
+import {Internals} from '../internals.js';
+import type {SequenceManagerContext} from '../SequenceManager.js';
+import {
+	SequenceManager,
+	VisualModeCodeValuesContext,
+	VisualModeDragOverridesContext,
+	VisualModeSettersContext,
+} from '../SequenceManager.js';
+import {WrapSequenceContext} from './wrap-sequence-context.js';
+
+const stub2dContext = () => ({
+	canvas: null as unknown as HTMLCanvasElement,
+	reset: () => undefined,
+	drawElementImage: () => new DOMMatrix(),
+	getImageData: () => ({
+		data: new Uint8ClampedArray(4),
+		width: 1,
+		height: 1,
+	}),
+	putImageData: () => undefined,
+});
+
+Object.defineProperties(HTMLCanvasElement.prototype, {
+	getContext: {
+		configurable: true,
+		value(this: HTMLCanvasElement, kind: string) {
+			if (kind === '2d') {
+				const ctx = stub2dContext();
+				ctx.canvas = this;
+				return ctx;
+			}
+
+			return null;
+		},
+	},
+	requestPaint: {
+		configurable: true,
+		value: () => undefined,
+	},
+	captureElementImage: {
+		configurable: true,
+		value: () => ({
+			close: () => undefined,
+			height: 1,
+			width: 1,
+		}),
+	},
+	transferControlToOffscreen: {
+		configurable: true,
+		value(this: HTMLCanvasElement) {
+			return {
+				getContext: (kind: string) => {
+					if (kind === '2d') {
+						const ctx = stub2dContext();
+						ctx.canvas = this;
+						return ctx;
+					}
+
+					return null;
+				},
+				height: this.height,
+				width: this.width,
+			};
+		},
+	},
+});
+
+afterEach(cleanup);
+
+const SequenceTestWrapper: React.FC<{
+	readonly children: React.ReactNode;
+	readonly onRegisterSequence: (sequence: TSequence) => void;
+}> = ({children, onRegisterSequence}) => {
+	const registerSequence = useCallback(
+		(sequence: TSequence) => {
+			onRegisterSequence(sequence);
+		},
+		[onRegisterSequence],
+	);
+
+	const unregisterSequence = useCallback(() => undefined, []);
+
+	const sequenceManagerContext: SequenceManagerContext = useMemo(() => {
+		return {
+			registerSequence,
+			sequences: [],
+			unregisterSequence,
+		};
+	}, [registerSequence, unregisterSequence]);
+
+	const visualCodeValues = useMemo(
+		() => ({
+			codeValues: {},
+		}),
+		[],
+	);
+
+	const visualDragOverrides = useMemo(
+		() => ({
+			getDragOverrides: () => {
+				throw new Error('VisualModeDragOverridesContext not initialized');
+			},
+			getEffectDragOverrides: () => {
+				throw new Error('VisualModeDragOverridesContext not initialized');
+			},
+		}),
+		[],
+	);
+
+	const visualSetters = useMemo(
+		() => ({
+			clearDragOverrides: () => undefined,
+			clearEffectDragOverrides: () => undefined,
+			setCodeValues: () => undefined,
+			setDragOverrides: () => undefined,
+			setEffectDragOverrides: () => undefined,
+		}),
+		[],
+	);
+
+	return (
+		<WrapSequenceContext>
+			<Internals.RemotionEnvironmentContext
+				value={{
+					isClientSideRendering: false,
+					isPlayer: false,
+					isReadOnlyStudio: false,
+					isRendering: false,
+					isStudio: true,
+				}}
+			>
+				<SequenceManager.Provider value={sequenceManagerContext}>
+					<VisualModeCodeValuesContext.Provider value={visualCodeValues}>
+						<VisualModeDragOverridesContext.Provider
+							value={visualDragOverrides}
+						>
+							<VisualModeSettersContext.Provider value={visualSetters}>
+								{children}
+							</VisualModeSettersContext.Provider>
+						</VisualModeDragOverridesContext.Provider>
+					</VisualModeCodeValuesContext.Provider>
+				</SequenceManager.Provider>
+			</Internals.RemotionEnvironmentContext>
+		</WrapSequenceContext>
+	);
+};
+
+test('<HtmlInCanvas> registers its canvas for outline selection', async () => {
+	const registeredSequences: TSequence[] = [];
+	const canvasRef = React.createRef<HTMLCanvasElement>();
+
+	const {container} = render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<HtmlInCanvas ref={canvasRef} width={120} height={80}>
+				<div>Test</div>
+			</HtmlInCanvas>
+		</SequenceTestWrapper>,
+	);
+
+	await waitFor(() => {
+		expect(registeredSequences.length).toBe(1);
+	});
+
+	const canvas = container.querySelector('canvas');
+	expect(canvas).not.toBeNull();
+	expect(canvasRef.current).toBe(canvas);
+	expect(registeredSequences[0]?.refForOutline?.current).toBe(canvas);
+});
+
+test('<HtmlInCanvas> keeps refs current when the canvas remounts', async () => {
+	const registeredSequences: TSequence[] = [];
+	const canvasRef = React.createRef<HTMLCanvasElement>();
+
+	const {container, rerender} = render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<HtmlInCanvas ref={canvasRef} width={120} height={80}>
+				<div>Test</div>
+			</HtmlInCanvas>
+		</SequenceTestWrapper>,
+	);
+
+	await waitFor(() => {
+		expect(registeredSequences.length).toBe(1);
+	});
+
+	const firstCanvas = container.querySelector('canvas');
+	expect(firstCanvas).not.toBeNull();
+
+	rerender(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<HtmlInCanvas ref={canvasRef} width={121} height={80}>
+				<div>Test</div>
+			</HtmlInCanvas>
+		</SequenceTestWrapper>,
+	);
+
+	await waitFor(() => {
+		expect(canvasRef.current).not.toBe(firstCanvas);
+	});
+
+	const nextCanvas = container.querySelector('canvas');
+	expect(nextCanvas).not.toBeNull();
+	expect(canvasRef.current).toBe(nextCanvas);
+	expect(registeredSequences[0]?.refForOutline?.current).toBe(nextCanvas);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #7939

## Summary
- Registers the `<HtmlInCanvas>` canvas ref with `_remotionInternalRefForOutline` so Studio outlines can target the rendered canvas.
- Keeps the public forwarded ref and outline ref in sync when the keyed canvas remounts after a size change.
- Adds core tests for outline registration and remount ref updates.

## Testing
- `bun test src/test/html-in-canvas.test.tsx`
- `bun run test` in `packages/core`
- `bun run make` in `packages/core`
- `bun run lint` in `packages/core` (passes with existing warnings)
- `bun run formatting` in `packages/core`
- `bun run build`
- `bun run formatting`
- `bun run stylecheck` (blocked by documented `@remotion/lambda-go` Go >= 1.23 requirement; VM has Go 1.22.2)

## Manual testing
- Started `packages/example` Studio and navigated to `html-in-canvas-changing-size`; VM Chrome is 146, so HtmlInCanvas reports the expected unsupported-browser message before the outline UI can render.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd416d1f-3285-41ae-8de8-2c5635a0743b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd416d1f-3285-41ae-8de8-2c5635a0743b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

