### PR TITLE
`@remotion/promo-pages`: Fix investors link

### DIFF
--- a/packages/promo-pages/src/components/team/TrustSection.tsx
+++ b/packages/promo-pages/src/components/team/TrustSection.tsx
@@ -188,7 +188,7 @@ export const TrustSection: React.FC = () => {
 					<div className="font-brand">
 						Remotion is profitable. Aside from our{' '}
 						<a
-							href="/investors"
+							href="/docs/investors"
 							className="text-brand hover:underline underline-offset-4"
 						>
 							early investors


### PR DESCRIPTION
## Summary
- Point the team page investors link directly to `/docs/investors`
- Confirmed `/investors` already redirects to `/docs/investors`

## Testing
- `cd packages/promo-pages && find src -type f \( -name '*.ts' -o -name '*.tsx' \) -print0 | xargs -0 bunx oxfmt --write`
- `bun run build`
- `bun run formatting`
