### PR TITLE
`@remotion/gif`: Add refForOutline support to Gif

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -793,6 +793,7 @@
       },
       "devDependencies": {
         "@remotion/eslint-config-internal": "workspace:*",
+        "@testing-library/react": "16.1.0",
         "@typescript/native-preview": "catalog:",
         "esbuild": "0.28.0",
         "eslint": "catalog:",

--- a/packages/gif/bunfig.toml
+++ b/packages/gif/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "../core/happydom.ts"

--- a/packages/gif/package.json
+++ b/packages/gif/package.json
@@ -17,6 +17,7 @@
 		"formatting": "oxfmt src --check",
 		"format": "oxfmt src",
 		"lint": "eslint src",
+		"test": "bun test src/test",
 		"make": "tsgo -d && node build.mjs && bun --env-file=../.env.bundle bundle.ts"
 	},
 	"exports": {
@@ -32,6 +33,7 @@
 		"remotion": "workspace:*"
 	},
 	"devDependencies": {
+		"@testing-library/react": "16.1.0",
 		"esbuild": "0.28.0",
 		"react": "catalog:",
 		"react-dom": "catalog:",

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -70,6 +70,7 @@ const GifInner = ({
 	const env = useRemotionEnvironment();
 	const {durationInFrames: videoDuration} = useVideoConfig();
 	const resolvedDuration = durationInFrames ?? videoDuration;
+	const refForOutline = React.useRef<HTMLElement | null>(null);
 
 	const memoizedEffectDefinitions = useMemoizedEffectDefinitions(effects);
 	const memoizedEffects = useMemoizedEffects({
@@ -95,9 +96,9 @@ const GifInner = ({
 	};
 
 	const inner = env.isRendering ? (
-		<GifForRendering {...gifProps} ref={ref} />
+		<GifForRendering {...gifProps} ref={ref} refForOutline={refForOutline} />
 	) : (
-		<GifForDevelopment {...gifProps} ref={ref} />
+		<GifForDevelopment {...gifProps} ref={ref} refForOutline={refForOutline} />
 	);
 
 	return (
@@ -109,6 +110,7 @@ const GifInner = ({
 			_experimentalControls={controls}
 			_remotionInternalEffects={memoizedEffectDefinitions}
 			{...sequenceProps}
+			_remotionInternalRefForOutline={refForOutline}
 		>
 			{inner}
 		</Sequence>

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -96,7 +96,7 @@ const GifInner = ({
 	};
 
 	const inner = env.isRendering ? (
-		<GifForRendering {...gifProps} ref={ref} refForOutline={refForOutline} />
+		<GifForRendering {...gifProps} ref={ref} />
 	) : (
 		<GifForDevelopment {...gifProps} ref={ref} refForOutline={refForOutline} />
 	);

--- a/packages/gif/src/GifForDevelopment.tsx
+++ b/packages/gif/src/GifForDevelopment.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import {forwardRef, useEffect, useRef, useState} from 'react';
+import {forwardRef, useEffect, useRef, useState, type RefObject} from 'react';
 import type {EffectDefinitionAndStack} from 'remotion';
 import {Canvas} from './canvas';
 import {manuallyManagedGifCache, volatileGifCache} from './gif-cache';
@@ -13,6 +13,7 @@ export const GifForDevelopment = forwardRef<
 	HTMLCanvasElement,
 	RemotionGifProps & {
 		readonly effects: EffectDefinitionAndStack<unknown>[];
+		readonly refForOutline: RefObject<HTMLElement | null>;
 	}
 >(
 	(
@@ -26,6 +27,7 @@ export const GifForDevelopment = forwardRef<
 			onLoad,
 			fit = 'fill',
 			effects,
+			refForOutline,
 			...props
 		},
 		ref,
@@ -117,6 +119,7 @@ export const GifForDevelopment = forwardRef<
 				width={width}
 				height={height}
 				effects={effects}
+				refForOutline={refForOutline}
 				{...props}
 				ref={ref}
 			/>

--- a/packages/gif/src/GifForRendering.tsx
+++ b/packages/gif/src/GifForRendering.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, useEffect, useRef, useState} from 'react';
+import {forwardRef, useEffect, useRef, useState, type RefObject} from 'react';
 import {Internals, useDelayRender} from 'remotion';
 import type {EffectDefinitionAndStack} from 'remotion';
 import {Canvas} from './canvas';
@@ -13,6 +13,7 @@ export const GifForRendering = forwardRef<
 	HTMLCanvasElement,
 	RemotionGifProps & {
 		readonly effects: EffectDefinitionAndStack<unknown>[];
+		readonly refForOutline: RefObject<HTMLElement | null>;
 	}
 >(
 	(
@@ -27,6 +28,7 @@ export const GifForRendering = forwardRef<
 			fit = 'fill',
 			delayRenderTimeoutInMilliseconds,
 			effects,
+			refForOutline,
 			...props
 		},
 		ref,
@@ -160,6 +162,7 @@ export const GifForRendering = forwardRef<
 				width={width}
 				height={height}
 				effects={effects}
+				refForOutline={refForOutline}
 				{...props}
 				ref={ref}
 			/>

--- a/packages/gif/src/GifForRendering.tsx
+++ b/packages/gif/src/GifForRendering.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, useEffect, useRef, useState, type RefObject} from 'react';
+import {forwardRef, useEffect, useRef, useState} from 'react';
 import {Internals, useDelayRender} from 'remotion';
 import type {EffectDefinitionAndStack} from 'remotion';
 import {Canvas} from './canvas';
@@ -13,7 +13,6 @@ export const GifForRendering = forwardRef<
 	HTMLCanvasElement,
 	RemotionGifProps & {
 		readonly effects: EffectDefinitionAndStack<unknown>[];
-		readonly refForOutline: RefObject<HTMLElement | null>;
 	}
 >(
 	(
@@ -28,7 +27,6 @@ export const GifForRendering = forwardRef<
 			fit = 'fill',
 			delayRenderTimeoutInMilliseconds,
 			effects,
-			refForOutline,
 			...props
 		},
 		ref,
@@ -162,7 +160,6 @@ export const GifForRendering = forwardRef<
 				width={width}
 				height={height}
 				effects={effects}
-				refForOutline={refForOutline}
 				{...props}
 				ref={ref}
 			/>

--- a/packages/gif/src/canvas.tsx
+++ b/packages/gif/src/canvas.tsx
@@ -110,7 +110,7 @@ type Props = {
 	readonly className?: string;
 	readonly style?: React.CSSProperties;
 	readonly effects: EffectDefinitionAndStack<unknown>[];
-	readonly refForOutline: RefObject<HTMLElement | null>;
+	readonly refForOutline?: RefObject<HTMLElement | null>;
 };
 
 export const Canvas = forwardRef(
@@ -160,7 +160,9 @@ export const Canvas = forwardRef(
 		const canvasCallbackRef = useCallback(
 			(canvas: HTMLCanvasElement | null) => {
 				canvasRef.current = canvas;
-				refForOutline.current = canvas;
+				if (refForOutline) {
+					refForOutline.current = canvas;
+				}
 			},
 			[refForOutline],
 		);

--- a/packages/gif/src/canvas.tsx
+++ b/packages/gif/src/canvas.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable react/require-default-props */
 import {
 	forwardRef,
+	useCallback,
 	useEffect,
 	useImperativeHandle,
 	useMemo,
 	useRef,
 	useState,
+	type RefObject,
 } from 'react';
 import type {EffectDefinitionAndStack} from 'remotion';
 import {Internals, useDelayRender} from 'remotion';
@@ -108,11 +110,22 @@ type Props = {
 	readonly className?: string;
 	readonly style?: React.CSSProperties;
 	readonly effects: EffectDefinitionAndStack<unknown>[];
+	readonly refForOutline: RefObject<HTMLElement | null>;
 };
 
 export const Canvas = forwardRef(
 	(
-		{index, frames, width, height, fit, className, style, effects}: Props,
+		{
+			index,
+			frames,
+			width,
+			height,
+			fit,
+			className,
+			style,
+			effects,
+			refForOutline,
+		}: Props,
 		ref,
 	) => {
 		const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -144,6 +157,13 @@ export const Canvas = forwardRef(
 		useImperativeHandle(ref, () => {
 			return canvasRef.current as HTMLCanvasElement;
 		}, []);
+		const canvasCallbackRef = useCallback(
+			(canvas: HTMLCanvasElement | null) => {
+				canvasRef.current = canvas;
+				refForOutline.current = canvas;
+			},
+			[refForOutline],
+		);
 
 		useEffect(() => {
 			if (!size) {
@@ -290,7 +310,7 @@ export const Canvas = forwardRef(
 
 		return (
 			<canvas
-				ref={canvasRef}
+				ref={canvasCallbackRef}
 				className={className}
 				style={style}
 				width={width ?? size?.width}

--- a/packages/gif/src/test/Gif.test.tsx
+++ b/packages/gif/src/test/Gif.test.tsx
@@ -1,0 +1,202 @@
+import {afterEach, beforeEach, expect, test} from 'bun:test';
+import {cleanup, render, waitFor} from '@testing-library/react';
+import React, {useCallback, useMemo} from 'react';
+import {Internals} from 'remotion';
+import {Gif} from '../Gif';
+import {manuallyManagedGifCache} from '../gif-cache';
+import type {GifState} from '../props';
+
+type RegisteredSequence = {
+	readonly refForOutline: React.RefObject<HTMLElement | null> | null;
+};
+
+class MockWorker {
+	public addEventListener = () => undefined;
+	public removeEventListener = () => undefined;
+	public postMessage = () => undefined;
+	public terminate = () => undefined;
+}
+
+const OriginalWorker = globalThis.Worker;
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+const stub2dContext = (canvas: HTMLCanvasElement) => ({
+	canvas,
+	clearRect: () => undefined,
+	drawImage: () => undefined,
+	putImageData: () => undefined,
+});
+
+const gifState: GifState = {
+	delays: [100],
+	frames: [
+		{
+			data: new Uint8ClampedArray(4),
+			width: 1,
+			height: 1,
+			colorSpace: 'srgb',
+		} as ImageData,
+	],
+	width: 1,
+	height: 1,
+};
+
+const studioEnvironment = {
+	isRendering: false,
+	isClientSideRendering: false,
+	isPlayer: false,
+	isStudio: true,
+	isReadOnlyStudio: false,
+};
+
+const compositionContext = {
+	compositions: [
+		{
+			id: 'comp',
+			durationInFrames: 100,
+			component: () => null,
+			defaultProps: {},
+			folderName: null,
+			fps: 30,
+			height: 1080,
+			width: 1920,
+			parentFolderName: null,
+			nonce: [[0, 0]],
+			calculateMetadata: null,
+			schema: null,
+			stack: null,
+		},
+	],
+	folders: [],
+	canvasContent: {type: 'composition' as const, compositionId: 'comp'},
+	currentCompositionMetadata: {
+		defaultCodec: null,
+		defaultOutName: null,
+		defaultPixelFormat: null,
+		defaultProResProfile: null,
+		defaultSampleRate: null,
+		defaultVideoImageFormat: null,
+		durationInFrames: 100,
+		fps: 30,
+		height: 1080,
+		width: 1920,
+		props: {},
+	},
+} as React.ContextType<typeof Internals.CompositionManager>;
+
+const timelineContext = {
+	frame: {},
+	playing: false,
+	rootId: 'test-root',
+	imperativePlaying: {current: false},
+	audioAndVideoTags: {current: []},
+} as React.ContextType<typeof Internals.TimelineContext>;
+
+const playbackRateContext = {
+	playbackRate: 1,
+	setPlaybackRate: () => undefined,
+} as React.ContextType<typeof Internals.PlaybackRateContext>;
+
+const logContext = {
+	logLevel: 'info',
+	mountTime: 0,
+} as React.ContextType<typeof Internals.LogLevelContext>;
+
+const SequenceRegistrationWrapper: React.FC<{
+	readonly children: React.ReactNode;
+	readonly onRegisterSequence: (sequence: RegisteredSequence) => void;
+}> = ({children, onRegisterSequence}) => {
+	const registerSequence = useCallback(
+		(sequence: RegisteredSequence) => {
+			onRegisterSequence(sequence);
+		},
+		[onRegisterSequence],
+	);
+	const unregisterSequence = useCallback(() => undefined, []);
+	const sequenceManagerContext = useMemo(
+		() =>
+			({
+				registerSequence,
+				unregisterSequence,
+				sequences: [],
+			}) as React.ContextType<typeof Internals.SequenceManager>,
+		[registerSequence, unregisterSequence],
+	);
+
+	return (
+		<Internals.LogLevelContext.Provider value={logContext}>
+			<Internals.BufferingProvider>
+				<Internals.CanUseRemotionHooksProvider>
+					<Internals.AbsoluteTimeContext.Provider value={timelineContext}>
+						<Internals.TimelineContext.Provider value={timelineContext}>
+							<Internals.PlaybackRateContext.Provider
+								value={playbackRateContext}
+							>
+								<Internals.RemotionEnvironmentContext.Provider
+									value={studioEnvironment}
+								>
+									<Internals.SequenceManager.Provider
+										value={sequenceManagerContext}
+									>
+										<Internals.CompositionManager.Provider
+											value={compositionContext}
+										>
+											{children}
+										</Internals.CompositionManager.Provider>
+									</Internals.SequenceManager.Provider>
+								</Internals.RemotionEnvironmentContext.Provider>
+							</Internals.PlaybackRateContext.Provider>
+						</Internals.TimelineContext.Provider>
+					</Internals.AbsoluteTimeContext.Provider>
+				</Internals.CanUseRemotionHooksProvider>
+			</Internals.BufferingProvider>
+		</Internals.LogLevelContext.Provider>
+	);
+};
+
+beforeEach(() => {
+	globalThis.Worker = MockWorker as unknown as typeof Worker;
+	HTMLCanvasElement.prototype.getContext = function (
+		this: HTMLCanvasElement,
+		kind: string,
+	) {
+		if (kind === '2d') {
+			return stub2dContext(this);
+		}
+
+		return null;
+	} as HTMLCanvasElement['getContext'];
+	manuallyManagedGifCache.set('test.gif', gifState);
+});
+
+afterEach(() => {
+	cleanup();
+	globalThis.Worker = OriginalWorker;
+	HTMLCanvasElement.prototype.getContext = originalGetContext;
+	manuallyManagedGifCache.clear();
+});
+
+test('<Gif> registers its canvas as the outline ref', async () => {
+	const registeredSequences: RegisteredSequence[] = [];
+	const ref = React.createRef<HTMLCanvasElement>();
+
+	render(
+		<SequenceRegistrationWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Gif ref={ref} src="test.gif" />
+		</SequenceRegistrationWrapper>,
+	);
+
+	await waitFor(() => {
+		expect(registeredSequences[0]?.refForOutline?.current).toBeInstanceOf(
+			HTMLCanvasElement,
+		);
+	});
+
+	const refForOutline = registeredSequences[0]
+		.refForOutline as React.RefObject<HTMLCanvasElement | null>;
+	expect(ref.current).toBe(refForOutline.current);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an internal Studio outline ref for `<Gif>` and pass it to the wrapping `<Sequence>`.
- Thread the outline ref only through the development/Studio preview path to the rendered `<canvas>` while keeping `GifForRendering` unchanged.
- Add a package-level regression test for GIF outline ref registration.

Fixes #7974.

## Testing
- `bun test src/test/Gif.test.tsx`
- `bun run formatting && bun run lint && bun run test && bun run make` in `packages/gif`
- `bunx turbo run lint formatting --filter='@remotion/gif'`
- `bunx turbo run test --filter='@remotion/gif'`
- `bunx turbo run make --filter='@remotion/gif'`
- `bun run build`
- `bun run stylecheck` (blocked by known `@remotion/lambda-go` Go >= 1.23 requirement; VM has Go 1.22.2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5bc0192-afab-4119-bf0e-e62bc30e07b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5bc0192-afab-4119-bf0e-e62bc30e07b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

