### PR TITLE
Docs: Polish showcase page

### DIFF
--- a/packages/docs/src/components/VideoPreview.tsx
+++ b/packages/docs/src/components/VideoPreview.tsx
@@ -3,8 +3,7 @@ import type {ShowcaseVideo} from '../data/showcase-videos';
 
 const card: React.CSSProperties = {
 	backgroundColor: 'var(--card-bg)',
-	border: '2px solid var(--box-stroke)',
-	borderBottomWidth: 4,
+	border: '2px solid var(--border-color)',
 	borderRadius: 18,
 	color: 'var(--text-color)',
 	cursor: 'pointer',

--- a/packages/docs/src/components/VideoPreview.tsx
+++ b/packages/docs/src/components/VideoPreview.tsx
@@ -58,6 +58,7 @@ export const VideoPreview: React.FC<
 		image.onload = () => {
 			setAnimatedLoaded(true);
 		};
+
 		image.src = animated;
 
 		return () => {
@@ -100,7 +101,7 @@ export const VideoPreview: React.FC<
 
 	const placeholder: React.CSSProperties = {
 		backgroundColor: 'rgba(0, 0, 0, 0.05)',
-		aspectRatio: '16 / 9',
+		aspectRatio: `${width} / ${height}`,
 		overflow: 'hidden',
 		width: '100%',
 	};

--- a/packages/docs/src/components/VideoPreview.tsx
+++ b/packages/docs/src/components/VideoPreview.tsx
@@ -1,38 +1,41 @@
-import clsx from 'clsx';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import type {ShowcaseVideo} from '../data/showcase-videos';
 
-const videoStyle: React.CSSProperties = {
+const card: React.CSSProperties = {
+	backgroundColor: 'var(--card-bg)',
+	border: '2px solid var(--box-stroke)',
+	borderBottomWidth: 4,
+	borderRadius: 18,
+	color: 'var(--text-color)',
+	cursor: 'pointer',
 	display: 'flex',
 	flexDirection: 'column',
-	alignItems: 'center',
-	padding: '2rem 0',
+	overflow: 'hidden',
+	textAlign: 'left',
+	textDecoration: 'none',
 	width: '100%',
 };
 
+const content: React.CSSProperties = {
+	display: 'flex',
+	flex: 1,
+	flexDirection: 'column',
+	gap: 10,
+	padding: 20,
+};
+
 const videoTitle: React.CSSProperties = {
-	marginTop: '1rem',
-	textAlign: 'center',
-	alignSelf: 'center',
-	padding: '10px',
+	fontSize: '1.25rem',
+	fontWeight: 650,
+	letterSpacing: '-0.02em',
+	margin: 0,
 };
 
 const videoDescription: React.CSSProperties = {
-	textAlign: 'center',
-	padding: '10px',
-};
-
-const padding: React.CSSProperties = {
-	display: 'flex',
-	flexDirection: 'column',
-	alignItems: 'center',
-};
-
-const containerTitleDescription: React.CSSProperties = {
-	display: 'flex',
-	flexDirection: 'column',
-	alignItems: 'center',
-	textAlign: 'center',
+	color: 'var(--subtitle)',
+	fontSize: '1rem',
+	lineHeight: 1.6,
+	margin: 0,
 };
 
 export const VideoPreview: React.FC<
@@ -43,11 +46,25 @@ export const VideoPreview: React.FC<
 	}
 > = ({title, description, onClick, muxId, width, height, time}) => {
 	const [hover, setHover] = useState(false);
-
+	const [animatedLoaded, setAnimatedLoaded] = useState(false);
 	const container = useRef<HTMLAnchorElement>(null);
 
 	const animated = `https://image.mux.com/${muxId}/animated.gif?width=600`;
-	const thumbnail = `https://image.mux.com/${muxId}/thumbnail.png?width=600&time=${time}`;
+	const thumbnail = `https://image.mux.com/${muxId}/thumbnail.png?width=600&time=${time ?? 0}`;
+
+	useEffect(() => {
+		setAnimatedLoaded(false);
+
+		const image = new Image();
+		image.onload = () => {
+			setAnimatedLoaded(true);
+		};
+		image.src = animated;
+
+		return () => {
+			image.onload = null;
+		};
+	}, [animated]);
 
 	useEffect(() => {
 		const {current} = container;
@@ -72,51 +89,29 @@ export const VideoPreview: React.FC<
 		};
 	}, []);
 
-	const a: React.CSSProperties = useMemo(() => {
+	const previewStyle: React.CSSProperties = useMemo(() => {
 		return {
-			color: 'inherit',
-			cursor: 'pointer',
-			margin: 'auto',
-			display: 'block',
-			flex: 1,
-		};
-	}, []);
-
-	const style = useMemo(() => {
-		return {
-			width: '100%',
-			aspectRatio: `${width} / ${height}`,
-			backgroundImage: `url(${hover ? animated : thumbnail})`,
-			backgroundSize: 'cover',
+			backgroundImage: `url(${hover && animatedLoaded ? animated : thumbnail})`,
 			backgroundPosition: '50% 50%',
+			backgroundSize: 'cover',
+			height: '100%',
+			width: '100%',
 		};
-	}, [width, height, hover, animated, thumbnail]);
+	}, [hover, animatedLoaded, animated, thumbnail]);
 
-	const placeholder: React.CSSProperties = useMemo(() => {
-		return {
-			backgroundColor: 'rgba(0, 0, 0, 0.05)',
-			aspectRatio: `${width} / ${height}`,
-		};
-	}, [height, width]);
-
-	const frameStyle: React.CSSProperties = {
-		border: '2px solid var(--border-color)',
-		borderRadius: 5,
-		backgroundColor: 'var(--ifm-background-color)',
+	const placeholder: React.CSSProperties = {
+		backgroundColor: 'rgba(0, 0, 0, 0.05)',
+		aspectRatio: '16 / 9',
 		overflow: 'hidden',
+		width: '100%',
 	};
 
 	return (
-		<a
-			ref={container}
-			style={{...a, ...frameStyle}}
-			className={clsx(videoStyle)}
-			onClick={onClick}
-		>
+		<a ref={container} style={card} onClick={onClick}>
 			<div style={placeholder}>
-				<div style={style} />
+				<div style={previewStyle} />
 			</div>
-			<div style={{...padding, ...containerTitleDescription}}>
+			<div style={content}>
 				<h3 style={videoTitle}>{title}</h3>
 				<p style={videoDescription}>{description}</p>
 			</div>

--- a/packages/docs/src/pages/showcase/index.tsx
+++ b/packages/docs/src/pages/showcase/index.tsx
@@ -8,54 +8,29 @@ import {
 	showcaseVideos,
 	shuffledShowcaseVideos,
 } from '../../data/showcase-videos';
-import {useMobileLayout} from '../../helpers/mobile-layout';
-import headerStyles from './header.module.css';
 import styles from './styles.module.css';
 
 const PageHeader: React.FC = () => {
 	return (
-		<div
-			style={{
-				maxWidth: 'var(--ifm-container-width)',
-				paddingLeft: 20,
-				paddingRight: 20,
-				margin: 'auto',
-				marginTop: 50,
-			}}
-		>
-			<div style={{flex: 1}}>
-				<h1 className={headerStyles.title}>Showcase</h1>
-
-				<p>
-					This page showcases products and campaigns crafted with Remotion. From
-					dynamic video content to engaging animations, each project highlights
-					the versatility and creativity enabled by Remotion.{' '}
+		<header className={styles.hero}>
+			<div className={styles.container}>
+				<h1 className={styles.title}>Showcase</h1>
+				<p className={styles.lede}>
+					Products, campaigns, launch videos, tutorials and creative tools made
+					with Remotion. Scan the gallery by use case, then open any card to
+					watch the motion in detail.
 				</p>
-				<p>
-					We have moved to curating the showcase ourselves and are not taking
-					any new submissions at this time.
-				</p>
-				<p>
-					See more projects, applications, examples and libraries on the{' '}
-					<a href="/docs/resources">Resources</a> page.
+				<p className={styles.note}>
+					Curated by Remotion. We are not taking new showcase submissions right
+					now. For more projects, applications, examples and libraries, browse
+					the <a href="/docs/resources">Resources</a> page.
 				</p>
 			</div>
-		</div>
+		</header>
 	);
 };
 
-const container: React.CSSProperties = {
-	maxWidth: 'var(--ifm-container-width)',
-	width: '100%',
-	margin: 'auto',
-	marginTop: 50,
-	paddingLeft: 20,
-	paddingRight: 20,
-};
-
 const Showcase = () => {
-	const mobileLayout = useMobileLayout();
-
 	const [userHasInteractedWithPage, setUserHasInteractedWithPage] =
 		useState(false);
 	const [video, setVideo] = useState<ShowcaseVideo | null>(() => {
@@ -119,20 +94,6 @@ const Showcase = () => {
 		setVideo(null);
 	}, []);
 
-	const layoutStyle: React.CSSProperties = useMemo(() => {
-		if (mobileLayout) {
-			return {
-				width: '100%',
-				marginBottom: 20,
-			};
-		}
-
-		return {
-			display: 'inline-block',
-			width: '100%',
-		};
-	}, [mobileLayout]);
-
 	return (
 		<Layout>
 			<Head>
@@ -144,35 +105,36 @@ const Showcase = () => {
 			</Head>
 			<div>
 				<PageHeader />
+				<VideoPlayer
+					hasNext={hasNext}
+					hasPrevious={hasPrevious}
+					toNext={goToNextVideo}
+					toPrevious={goToPreviousVideo}
+					dismiss={dismiss}
+					video={video}
+					userHasInteractedWithPage={userHasInteractedWithPage}
+				/>
+				<main>
+					<section className={styles.gallerySection}>
+						<div className={styles.container}>
+							<div className={styles.videosGrid}>
+								{shuffledShowcaseVideos.map((vid) => {
+									return (
+										<VideoPreview
+											key={vid.muxId}
+											onClick={() => {
+												setVideo(vid);
+												setUserHasInteractedWithPage(true);
+											}}
+											{...vid}
+										/>
+									);
+								})}
+							</div>
+						</div>
+					</section>
+				</main>
 			</div>
-			<VideoPlayer
-				hasNext={hasNext}
-				hasPrevious={hasPrevious}
-				toNext={goToNextVideo}
-				toPrevious={goToPreviousVideo}
-				dismiss={dismiss}
-				video={video}
-				userHasInteractedWithPage={userHasInteractedWithPage}
-			/>
-			<main>
-				<section className={styles.videos}>
-					<div className={styles.container} style={container}>
-						{shuffledShowcaseVideos.map((vid) => {
-							return (
-								<div key={vid.muxId} style={layoutStyle}>
-									<VideoPreview
-										onClick={() => {
-											setVideo(vid);
-											setUserHasInteractedWithPage(true);
-										}}
-										{...vid}
-									/>
-								</div>
-							);
-						})}
-					</div>
-				</section>
-			</main>
 		</Layout>
 	);
 };

--- a/packages/docs/src/pages/showcase/styles.module.css
+++ b/packages/docs/src/pages/showcase/styles.module.css
@@ -1,30 +1,70 @@
 /* stylelint-disable docusaurus/copyright-header */
 
-/**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
- */
-
-.heroBanner {
-	padding-top: 4rem;
-	padding-bottom: 0;
-	position: relative;
-	overflow: hidden;
-}
-
-.videos {
-	display: flex;
-	align-items: center;
-	width: 100%;
+.hero {
+	padding: 56px 0 32px;
 }
 
 .container {
-	column-count: 3;
-	column-gap: 20px;
+	margin: 0 auto;
+	max-width: var(--ifm-container-width);
+	padding: 0 20px;
+	width: 100%;
 }
 
-@media (max-width: 900px) {
-	.container {
-		column-count: 1;
+.title {
+	font-size: clamp(2.75rem, 8vw, 5rem);
+	font-weight: 650;
+	letter-spacing: -0.05em;
+	line-height: 1;
+	margin: 0;
+}
+
+.lede {
+	color: var(--subtitle);
+	font-size: 1.25rem;
+	line-height: 1.65;
+	margin: 20px 0 0;
+	max-width: 68ch;
+}
+
+.note {
+	color: var(--subtitle);
+	font-size: 1rem;
+	line-height: 1.6;
+	margin: 18px 0 0;
+	max-width: 68ch;
+}
+
+.note a {
+	font-weight: 650;
+}
+
+.gallerySection {
+	padding: 20px 0 80px;
+}
+
+.videosGrid {
+	display: grid;
+	gap: 24px;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media screen and (max-width: 996px) {
+	.videosGrid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media screen and (max-width: 650px) {
+	.hero {
+		padding: 44px 0 28px;
+	}
+
+	.videosGrid {
+		grid-template-columns: 1fr;
+	}
+
+	.lede {
+		font-size: 1.0625rem;
 	}
 }


### PR DESCRIPTION
## Summary

- Refresh the docs showcase page with cleaner spacing and typography
- Replace the masonry-style showcase layout with a more consistent card grid
- Keep hover video previews while avoiding flicker by waiting for the animated preview to load

## Testing

- `cd packages/docs && bunx oxfmt src --write`
- `bun run build`
- `bun run formatting`
