### PR TITLE
`@remotion/docs`: Move whiteNoise to Stylize effects

### DIFF
--- a/packages/docs/docs/effects/table-of-contents.tsx
+++ b/packages/docs/docs/effects/table-of-contents.tsx
@@ -237,6 +237,13 @@ const categories: {
 				name: 'vignette()',
 				description: 'Edge darkening or transparency effect',
 			},
+			{
+				link: '/docs/effects/white-noise',
+				preview: '/img/effects-white-noise-preview.png',
+				alt: 'white noise effect preview',
+				name: 'whiteNoise()',
+				description: 'Random grayscale noise layer',
+			},
 		],
 	},
 	{
@@ -255,13 +262,6 @@ const categories: {
 				alt: 'noise effect preview',
 				name: 'noise()',
 				description: 'Procedural grain effect',
-			},
-			{
-				link: '/docs/effects/white-noise',
-				preview: '/img/effects-white-noise-preview.png',
-				alt: 'white noise effect preview',
-				name: 'whiteNoise()',
-				description: 'Random grayscale noise layer',
 			},
 			{
 				link: '/docs/effects/lines',


### PR DESCRIPTION
Fixes #7957.

## Problem
The effects overview currently groups `whiteNoise()` under Generate. Since it overlays randomized grayscale grain on the source, it fits the Stylize group better than procedural source generation.

## Approach
Move the `whiteNoise()` table-of-contents entry from Generate to Stylize while preserving the existing link, preview, alt text, name, and description.

## Tradeoffs
This is a docs/navigation-only change and does not affect the effect implementation or public API.