### PR TITLE
`@remotion/studio`: Fix enum dropdown dismissal

### DIFF
--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -102,7 +102,9 @@ export const HigherZIndex: React.FC<{
 		// If a menu is opened, then this component will also still receive the pointerdown event.
 		// However we may not interpret it as a outside click, so we need to wait for the next tick
 		requestAnimationFrame(() => {
-			window.addEventListener('pointerdown', listener);
+			// Some Studio elements stop pointerdown propagation while still being outside
+			// the menu, so listen during capture to dismiss menus consistently.
+			window.addEventListener('pointerdown', listener, true);
 		});
 		return () => {
 			if (onUp) {
@@ -112,7 +114,7 @@ export const HigherZIndex: React.FC<{
 
 			onUp = null;
 
-			return window.removeEventListener('pointerdown', listener);
+			return window.removeEventListener('pointerdown', listener, true);
 		};
 	}, [currentIndex, disabled, highestContext.highestIndex, onOutsideClick]);
 

--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -102,8 +102,9 @@ export const HigherZIndex: React.FC<{
 		// If a menu is opened, then this component will also still receive the pointerdown event.
 		// However we may not interpret it as a outside click, so we need to wait for the next tick
 		requestAnimationFrame(() => {
-			// Some Studio elements stop pointerdown propagation while still being outside
-			// the menu, so listen during capture to dismiss menus consistently.
+			// The third argument `true` registers a capture-phase listener. Some Studio
+			// elements stop pointerdown propagation while still being outside the menu,
+			// so bubbling listeners would miss those clicks and keep the menu open.
 			window.addEventListener('pointerdown', listener, true);
 		});
 		return () => {


### PR DESCRIPTION
Fixes #7763.

## Summary
- Listen for `HigherZIndex` outside pointerdowns during capture so Timeline rows that stop propagation still dismiss open dropdowns.
- Keep the delayed listener registration to avoid treating the opening click as an outside click.

## Testing
- `cd packages/studio && bun run lint && bun run test && bun run make`