### PR TITLE
`@remotion/web-renderer`: Scale text-shadow with the export scale option

### DIFF
--- a/packages/web-renderer/src/drawing/text/draw-text.ts
+++ b/packages/web-renderer/src/drawing/text/draw-text.ts
@@ -96,6 +96,10 @@ export const drawText = ({
 
 		const textShadows = parseTextShadow(textShadowValue);
 
+		// Shadow offset/blur ignore the CTM (unlike fillText), so apply it manually.
+		const ctm = contextToDraw.getTransform();
+		const blurScale = Math.hypot(ctm.a, ctm.b);
+
 		const {strokeFirst} = parsePaintOrder(paintOrder);
 
 		for (const token of tokens) {
@@ -115,9 +119,11 @@ export const drawText = ({
 			for (let i = textShadows.length - 1; i >= 0; i--) {
 				const shadow = textShadows[i];
 				contextToDraw.shadowColor = shadow.color;
-				contextToDraw.shadowBlur = shadow.blurRadius;
-				contextToDraw.shadowOffsetX = shadow.offsetX;
-				contextToDraw.shadowOffsetY = shadow.offsetY;
+				contextToDraw.shadowBlur = shadow.blurRadius * blurScale;
+				contextToDraw.shadowOffsetX =
+					shadow.offsetX * ctm.a + shadow.offsetY * ctm.c;
+				contextToDraw.shadowOffsetY =
+					shadow.offsetX * ctm.b + shadow.offsetY * ctm.d;
 				contextToDraw.fillText(token.text, x, y);
 			}
 

--- a/packages/web-renderer/src/test/Root.tsx
+++ b/packages/web-renderer/src/test/Root.tsx
@@ -71,6 +71,7 @@ import {letterSpacing} from './fixtures/text/letter-spacing';
 import {paragraphs} from './fixtures/text/paragraphs';
 import {textFixture} from './fixtures/text/text';
 import {textShadow} from './fixtures/text/text-shadow';
+import {textShadowScale} from './fixtures/text/text-shadow-scale';
 import {textTransform} from './fixtures/text/text-transform';
 import {webkitTextFillColor} from './fixtures/text/webkit-text-fill-color';
 import {webkitTextStroke} from './fixtures/text/webkit-text-stroke';
@@ -165,6 +166,7 @@ export const Root: React.FC = () => {
 				<Composition {...backgroundClipText} />
 				<Composition {...backgroundClipText3dTransform} />
 				<Composition {...textShadow} />
+				<Composition {...textShadowScale} />
 				<Composition {...whiteSpaceCollapsing} />
 				<Composition {...whiteSpaceCollapsing2} />
 				<Composition {...filterText} />

--- a/packages/web-renderer/src/test/fixtures/text/text-shadow-scale.tsx
+++ b/packages/web-renderer/src/test/fixtures/text/text-shadow-scale.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+// A single glyph with a hard, blur-free horizontal text-shadow offset far
+// enough to the right that the (red) shadow is fully separated from the
+// (black) glyph. Used to assert that the shadow offset scales with the export
+// `scale` option instead of staying at its unscaled pixel size.
+const Component: React.FC = () => {
+	return (
+		<AbsoluteFill style={{backgroundColor: 'white'}}>
+			<div
+				style={{
+					position: 'absolute',
+					left: 20,
+					top: 20,
+					fontSize: 40,
+					fontWeight: 'bold',
+					color: 'black',
+					textShadow: '60px 0px 0px red',
+				}}
+			>
+				1
+			</div>
+		</AbsoluteFill>
+	);
+};
+
+export const textShadowScale = {
+	component: Component,
+	id: 'text-shadow-scale',
+	width: 300,
+	height: 100,
+	fps: 25,
+	durationInFrames: 1,
+} as const;

--- a/packages/web-renderer/src/test/text-shadow-scale.test.tsx
+++ b/packages/web-renderer/src/test/text-shadow-scale.test.tsx
@@ -1,0 +1,79 @@
+import {expect, test} from 'vitest';
+import {renderStillOnWeb} from '../render-still-on-web';
+import '../symbol-dispose';
+import {withResolvers} from '../with-resolvers';
+import {textShadowScale} from './fixtures/text/text-shadow-scale';
+
+const decode = async (blob: Blob) => {
+	const img = document.createElement('img');
+	img.src = URL.createObjectURL(blob);
+
+	const {promise, resolve, reject} = withResolvers<void>();
+	img.onload = () => resolve();
+	img.onerror = () => reject(new Error('Image failed to load'));
+	await promise;
+
+	const canvas = document.createElement('canvas');
+	canvas.width = img.naturalWidth;
+	canvas.height = img.naturalHeight;
+	const ctx = canvas.getContext('2d')!;
+	ctx.drawImage(img, 0, 0);
+	return ctx.getImageData(0, 0, canvas.width, canvas.height);
+};
+
+const leftmostX = (
+	img: ImageData,
+	pred: (r: number, g: number, b: number, a: number) => boolean,
+) => {
+	for (let x = 0; x < img.width; x++) {
+		for (let y = 0; y < img.height; y++) {
+			const i = (y * img.width + x) * 4;
+			if (
+				pred(img.data[i], img.data[i + 1], img.data[i + 2], img.data[i + 3])
+			) {
+				return x;
+			}
+		}
+	}
+
+	return -1;
+};
+
+const isBlack = (r: number, g: number, b: number, a: number) =>
+	a > 200 && r < 60 && g < 60 && b < 60;
+const isRed = (r: number, g: number, b: number, a: number) =>
+	a > 200 && r > 180 && g < 80 && b < 80;
+
+// The fixture draws a black glyph with a red shadow offset 60px to the right.
+// Since the shadow is a copy of the glyph shifted by the offset, the gap
+// between the leftmost red pixel and the leftmost black pixel equals the
+// shadow's horizontal offset in output pixels.
+const measureShadowOffset = (img: ImageData) =>
+	leftmostX(img, isRed) - leftmostX(img, isBlack);
+
+const render = async (scale: number) => {
+	const blob = await (
+		await renderStillOnWeb({
+			licenseKey: 'free-license',
+			composition: textShadowScale,
+			frame: 0,
+			inputProps: {},
+			scale,
+		})
+	).blob({format: 'png'});
+	return decode(blob);
+};
+
+test('text-shadow offset scales with the export scale option', async () => {
+	const offset1x = measureShadowOffset(await render(1));
+	const offset3x = measureShadowOffset(await render(3));
+
+	// Sanity: at 1x the offset is roughly the 60px the fixture specifies.
+	expect(offset1x).toBeGreaterThan(45);
+	expect(offset1x).toBeLessThan(75);
+
+	// The shadow offset must scale with the export scale, like the glyph does.
+	const ratio = offset3x / offset1x;
+	expect(ratio).toBeGreaterThan(2.7);
+	expect(ratio).toBeLessThan(3.3);
+});


### PR DESCRIPTION
## Problem

`@remotion/web-renderer` rasterizes the DOM to a canvas and bakes the export `scale` (and any element transform) into the canvas transform matrix. Per the canvas drawing model, `shadowOffsetX`, `shadowOffsetY` and `shadowBlur` are measured in the **output bitmap** and are **not** affected by the current transform — unlike `fillText`, which goes through the CTM.

As a result, when exporting at a higher resolution (e.g. a 1280×720 composition at `scale: 3`), text glyphs scale correctly but their `text-shadow` offset/blur stay at the original, unscaled pixel size.

## Fix

In `draw-text.ts`, read the live CTM and apply its linear part to the shadow offset vector (and its magnitude to the blur) before assigning the canvas shadow properties:

```ts
contextToDraw.shadowOffsetX = shadow.offsetX * ctm.a + shadow.offsetY * ctm.c;
contextToDraw.shadowOffsetY = shadow.offsetX * ctm.b + shadow.offsetY * ctm.d;
contextToDraw.shadowBlur    = shadow.blurRadius * Math.hypot(ctm.a, ctm.b);
```

This is a no-op at `scale: 1` and also keeps shadows correct on rotated/scaled elements.

## Why `box-shadow` is not touched

`box-shadow` is handled differently: it bakes the shadow onto a fresh `OffscreenCanvas` (identity transform) and composites it with `ctx.drawImage(...)`, where `ctx` already carries the scale CTM. Since `drawImage` respects the CTM, the baked offset already scales — multiplying by the scale there would double-scale it. Verified empirically with a Chromium canvas probe (a directly-drawn shadow keeps its unscaled offset, while a `drawImage`-composited one scales).

## Test

Adds `text-shadow-scale.test.tsx` with a fixture rendering a glyph with a hard horizontal `text-shadow`. The test decodes the output PNG and asserts the shadow offset scales ~3× between `scale: 1` and `scale: 3` (rather than a screenshot snapshot, so it asserts the behavior directly and needs no per-browser baselines). Confirmed it fails without the fix (ratio ≈ 1.0) and passes with it (ratio ≈ 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
