### PR TITLE
`@remotion/studio`: Add X and Y scale controls

### DIFF
--- a/packages/core/src/interpolate-keyframed-status.ts
+++ b/packages/core/src/interpolate-keyframed-status.ts
@@ -3,6 +3,8 @@ import {Easing} from './easing.js';
 import {interpolateColors} from './interpolate-colors.js';
 import type {EasingFunction} from './interpolate.js';
 import {interpolate} from './interpolate.js';
+import type {ScaleValue} from './scale-value.js';
+import {parseValidScaleValue, serializeScaleValue} from './scale-value.js';
 import type {
 	CanUpdateSequencePropStatusEasing,
 	CanUpdateSequencePropStatusKeyframed,
@@ -14,6 +16,10 @@ const easingToFn = (e: CanUpdateSequencePropStatusEasing): EasingFunction => {
 	}
 
 	return bezier(e[0], e[1], e[2], e[3]);
+};
+
+const isScaleValue = (value: ScaleValue | null): value is ScaleValue => {
+	return value !== null;
 };
 
 export const interpolateKeyframedStatus = ({
@@ -54,7 +60,54 @@ export const interpolateKeyframedStatus = ({
 	}
 
 	if (!outputs.every((v) => typeof v === 'number')) {
-		return null;
+		const scaleValues = outputs.map(parseValidScaleValue);
+		if (!scaleValues.every(isScaleValue)) {
+			return null;
+		}
+
+		if (keyframes.length === 1) {
+			return serializeScaleValue(scaleValues[0]);
+		}
+
+		try {
+			return serializeScaleValue([
+				interpolate(
+					frame,
+					inputRange,
+					scaleValues.map((scaleValue) => scaleValue[0]),
+					{
+						easing: easing.map(easingToFn),
+						extrapolateLeft: clamping.left,
+						extrapolateRight: clamping.right,
+						posterize: status.posterize,
+					},
+				),
+				interpolate(
+					frame,
+					inputRange,
+					scaleValues.map((scaleValue) => scaleValue[1]),
+					{
+						easing: easing.map(easingToFn),
+						extrapolateLeft: clamping.left,
+						extrapolateRight: clamping.right,
+						posterize: status.posterize,
+					},
+				),
+				interpolate(
+					frame,
+					inputRange,
+					scaleValues.map((scaleValue) => scaleValue[2]),
+					{
+						easing: easing.map(easingToFn),
+						extrapolateLeft: clamping.left,
+						extrapolateRight: clamping.right,
+						posterize: status.posterize,
+					},
+				),
+			]);
+		} catch {
+			return null;
+		}
 	}
 
 	if (keyframes.length === 1) {

--- a/packages/core/src/no-react.ts
+++ b/packages/core/src/no-react.ts
@@ -33,6 +33,7 @@ import {
 import {DATE_TOKEN, FILE_TOKEN} from './input-props-serialization.js';
 import {colorNames, processColor} from './interpolate-colors';
 import {proResProfileOptions} from './prores-profile';
+import {parseScaleValue, serializeScaleValue} from './scale-value';
 import {sequenceSchema} from './sequence-field-schema';
 import {truthy} from './truthy';
 import {ENABLE_V5_BREAKING_CHANGES} from './v5-flag';
@@ -73,4 +74,6 @@ export const NoReactInternals = {
 	proResProfileOptions,
 	findPropsToDelete,
 	sequenceSchema,
+	parseScaleValue,
+	serializeScaleValue,
 };

--- a/packages/core/src/scale-value.ts
+++ b/packages/core/src/scale-value.ts
@@ -1,0 +1,57 @@
+export type ScaleValue = readonly [number, number, number];
+
+const defaultScaleValue: ScaleValue = [1, 1, 1];
+
+const normalizeScaleNumber = (value: number): number => {
+	return Math.round(value * 1000000) / 1000000;
+};
+
+const parseScaleString = (value: string): ScaleValue | null => {
+	const parts = value.trim().split(/\s+/);
+	if (parts.length < 1 || parts.length > 3 || parts[0] === '') {
+		return null;
+	}
+
+	const parsed = parts.map((part) => Number(part));
+	if (!parsed.every((part) => Number.isFinite(part))) {
+		return null;
+	}
+
+	const x = parsed[0];
+	const y = parsed[1] ?? x;
+	const z = parsed[2] ?? 1;
+
+	return [x, y, z];
+};
+
+export const parseValidScaleValue = (value: unknown): ScaleValue | null => {
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? [value, value, 1] : null;
+	}
+
+	if (typeof value === 'string') {
+		return parseScaleString(value);
+	}
+
+	return null;
+};
+
+export const parseScaleValue = (value: unknown): ScaleValue => {
+	return parseValidScaleValue(value) ?? defaultScaleValue;
+};
+
+export const serializeScaleValue = ([x, y, z]: ScaleValue): number | string => {
+	const normalizedX = normalizeScaleNumber(x);
+	const normalizedY = normalizeScaleNumber(y);
+	const normalizedZ = normalizeScaleNumber(z);
+
+	if (normalizedX === normalizedY && normalizedZ === 1) {
+		return normalizedX;
+	}
+
+	if (normalizedZ === 1) {
+		return `${normalizedX} ${normalizedY}`;
+	}
+
+	return `${normalizedX} ${normalizedY} ${normalizedZ}`;
+};

--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -31,6 +31,15 @@ export type TranslateFieldSchema = {
 	description?: string;
 };
 
+export type ScaleFieldSchema = {
+	type: 'scale';
+	min?: number;
+	max?: number;
+	step?: number;
+	default: number | string | undefined;
+	description?: string;
+};
+
 export type UvCoordinateFieldSchema = {
 	type: 'uv-coordinate';
 	min?: number;
@@ -58,6 +67,7 @@ export type VisibleFieldSchema =
 	| BooleanFieldSchema
 	| RotationFieldSchema
 	| TranslateFieldSchema
+	| ScaleFieldSchema
 	| UvCoordinateFieldSchema
 	| ColorFieldSchema
 	| EnumFieldSchema;
@@ -79,7 +89,7 @@ export const sequenceVisualStyleSchema = {
 		description: 'Offset',
 	},
 	'style.scale': {
-		type: 'number',
+		type: 'scale',
 		min: 0.05,
 		max: 100,
 		step: 0.01,

--- a/packages/core/src/test/interpolate-keyframed-status.test.ts
+++ b/packages/core/src/test/interpolate-keyframed-status.test.ts
@@ -132,3 +132,22 @@ test('uses bezier easing', () => {
 	expect(result).toBeGreaterThan(0);
 	expect(result).toBeLessThan(100);
 });
+
+test('interpolates scale strings component-wise', () => {
+	const result = interpolateKeyframedStatus({
+		frame: 30,
+		status: {
+			canUpdate: false,
+			reason: 'keyframed',
+			interpolationFunction: 'interpolate',
+			keyframes: [
+				{frame: 0, value: 2},
+				{frame: 60, value: '4 8 3'},
+			],
+			easing: ['linear'],
+			clamping: {left: 'extend', right: 'extend'},
+			posterize: undefined,
+		},
+	});
+	expect(result).toBe('3 5 2');
+});

--- a/packages/core/src/test/scale-value.test.ts
+++ b/packages/core/src/test/scale-value.test.ts
@@ -1,0 +1,29 @@
+import {expect, test} from 'bun:test';
+import {
+	parseScaleValue,
+	parseValidScaleValue,
+	serializeScaleValue,
+} from '../scale-value';
+
+test('parses a numeric scale as uniform X and Y', () => {
+	expect(parseScaleValue(2)).toEqual([2, 2, 1]);
+});
+
+test('parses two and three component scale strings', () => {
+	expect(parseScaleValue('2 3')).toEqual([2, 3, 1]);
+	expect(parseScaleValue('2 3 4')).toEqual([2, 3, 4]);
+});
+
+test('falls back for unsupported scale values', () => {
+	expect(parseScaleValue('2px 3px')).toEqual([1, 1, 1]);
+	expect(parseValidScaleValue('2px 3px')).toBe(null);
+});
+
+test('serializes uniform XY scale as a number', () => {
+	expect(serializeScaleValue([2, 2, 1])).toBe(2);
+});
+
+test('serializes non-uniform scale as CSS scale syntax', () => {
+	expect(serializeScaleValue([2, 3, 1])).toBe('2 3');
+	expect(serializeScaleValue([2, 3, 4])).toBe('2 3 4');
+});

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -43,6 +43,7 @@ const SUPPORTED_SCHEMA_TYPES = [
 	'boolean',
 	'rotation',
 	'translate',
+	'scale',
 	'uv-coordinate',
 	'color',
 	'enum',

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -39,18 +39,19 @@ const navButtonStyle: React.CSSProperties = {
 	cursor: 'pointer',
 	display: 'flex',
 	flexShrink: 0,
-	height: 12,
+	height: 14,
 	justifyContent: 'center',
 	lineHeight: 1,
 	outline: 'none',
 	padding: 0,
 	userSelect: 'none',
-	width: 12,
+	width: 14,
 };
 
 const diamondButtonStyle: React.CSSProperties = {
 	...navButtonStyle,
 	background: 'none',
+	translate: '0 -0.5px',
 };
 
 const diamondIconStyle: React.CSSProperties = {

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -161,6 +161,17 @@ export const TimelineKeyframeControls: React.FC<{
 		return hasKeyframeAtSourceFrame(propStatus.keyframes, jsxFrame);
 	}, [jsxFrame, propStatus]);
 
+	const currentKeyframeValue = useMemo(
+		() =>
+			getCurrentKeyframeValue({
+				propStatus,
+				jsxFrame,
+				defaultValue,
+				dragOverrideValue,
+			}),
+		[defaultValue, dragOverrideValue, jsxFrame, propStatus],
+	);
+
 	const previousDisplayFrame = useMemo(
 		() => getPreviousKeyframeDisplayFrame(keyframes, timelinePosition),
 		[keyframes, timelinePosition],
@@ -170,8 +181,12 @@ export const TimelineKeyframeControls: React.FC<{
 		[keyframes, timelinePosition],
 	);
 
+	const fieldSchema = schema[fieldKey];
+	const canAddKeyframe =
+		fieldSchema?.type !== 'scale' || typeof currentKeyframeValue === 'number';
 	const canToggleKeyframe =
-		propStatus.canUpdate || propStatus.reason === 'keyframed';
+		(propStatus.canUpdate || propStatus.reason === 'keyframed') &&
+		(hasKeyframeAtCurrentFrame || canAddKeyframe);
 
 	const seekToDisplayFrame = useCallback(
 		(frame: number) => {
@@ -242,12 +257,7 @@ export const TimelineKeyframeControls: React.FC<{
 				return;
 			}
 
-			const value = getCurrentKeyframeValue({
-				propStatus,
-				jsxFrame,
-				defaultValue,
-				dragOverrideValue,
-			});
+			const value = currentKeyframeValue;
 			if (value === null) {
 				return;
 			}
@@ -281,12 +291,11 @@ export const TimelineKeyframeControls: React.FC<{
 		[
 			canToggleKeyframe,
 			clientId,
-			defaultValue,
-			dragOverrideValue,
 			effectIndex,
 			fieldKey,
 			fileName,
 			hasKeyframeAtCurrentFrame,
+			currentKeyframeValue,
 			jsxFrame,
 			nodePath,
 			propStatus,

--- a/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
+++ b/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
@@ -19,7 +19,7 @@ const speakerIcon: React.CSSProperties = {
 	marginLeft: -1,
 };
 
-const container: React.CSSProperties = {
+export const timelineLayerIconContainer: React.CSSProperties = {
 	height: 16,
 	width: 16,
 	borderRadius: 2,
@@ -106,7 +106,7 @@ export const TimelineLayerEye: React.FC<{
 
 	return (
 		<div
-			style={container}
+			style={timelineLayerIconContainer}
 			onPointerEnter={onPointerEnter}
 			onPointerDown={onPointerDown}
 		>

--- a/packages/studio/src/components/Timeline/TimelineScaleField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScaleField.tsx
@@ -1,0 +1,476 @@
+import React, {useCallback, useMemo, useRef, useState} from 'react';
+import type {CanUpdateSequencePropStatus} from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
+import {LIGHT_COLOR} from '../../helpers/colors';
+import type {
+	SchemaFieldInfo,
+	TimelineFieldOnDragValueChange,
+	TimelineFieldOnSave,
+} from '../../helpers/timeline-layout';
+import {InputDragger} from '../NewComposition/InputDragger';
+import {getDecimalPlaces} from './timeline-field-utils';
+import {timelineLayerIconContainer} from './TimelineLayerEye';
+
+const leftDraggerStyle: React.CSSProperties = {
+	paddingLeft: 0,
+};
+
+const rightDraggerStyle: React.CSSProperties = {
+	paddingRight: 0,
+};
+
+const containerStyle: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	gap: 4,
+};
+
+const toggleStyle: React.CSSProperties = {
+	...timelineLayerIconContainer,
+	border: 'none',
+	color: LIGHT_COLOR,
+	cursor: 'pointer',
+	marginRight: 0,
+	padding: 0,
+};
+
+const linkIconStyle: React.CSSProperties = {
+	width: 12,
+	height: 12,
+	pointerEvents: 'none',
+};
+
+const gapStyle: React.CSSProperties = {
+	marginLeft: -6,
+	marginRight: -6,
+};
+
+const clamp = (value: number, min: number, max: number): number => {
+	return Math.min(max, Math.max(min, value));
+};
+
+const getLinkedScale = ({
+	axis,
+	newValue,
+	baseX,
+	baseY,
+	min,
+	max,
+}: {
+	readonly axis: 'x' | 'y';
+	readonly newValue: number;
+	readonly baseX: number;
+	readonly baseY: number;
+	readonly min: number;
+	readonly max: number;
+}): [number, number] => {
+	const drivingBase = axis === 'x' ? baseX : baseY;
+	const linkedBase = axis === 'x' ? baseY : baseX;
+
+	if (drivingBase === 0 || linkedBase === 0) {
+		const clamped = clamp(newValue, min, max);
+		return [clamped, clamped];
+	}
+
+	let factor = newValue / drivingBase;
+	let driving = newValue;
+	let linked = linkedBase * factor;
+	const clampedLinked = clamp(linked, min, max);
+
+	if (clampedLinked !== linked) {
+		factor = clampedLinked / linkedBase;
+		linked = clampedLinked;
+		driving = drivingBase * factor;
+	}
+
+	const clampedDriving = clamp(driving, min, max);
+
+	return axis === 'x' ? [clampedDriving, linked] : [linked, clampedDriving];
+};
+
+const valuesEqual = (left: unknown, right: unknown): boolean => {
+	return JSON.stringify(left) === JSON.stringify(right);
+};
+
+const LinkToggle: React.FC<{
+	readonly linked: boolean;
+	readonly onToggle: () => void;
+}> = ({linked, onToggle}) => {
+	const onPointerDown = useCallback(
+		(e: React.PointerEvent<HTMLButtonElement>) => {
+			if (e.button !== 0) {
+				return;
+			}
+
+			e.stopPropagation();
+			onToggle();
+		},
+		[onToggle],
+	);
+
+	return (
+		<button
+			type="button"
+			style={toggleStyle}
+			onPointerDown={onPointerDown}
+			title={linked ? 'Unlink scale axes' : 'Link scale axes'}
+			aria-label={linked ? 'Unlink scale axes' : 'Link scale axes'}
+		>
+			<svg viewBox="0 0 16 16" fill="none" style={linkIconStyle}>
+				<path
+					d="M6.3 5.1L5.1 6.3C4.2 7.2 4.2 8.8 5.1 9.7C6 10.6 7.6 10.6 8.5 9.7L9.7 8.5"
+					stroke="currentColor"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+				/>
+				<path
+					d="M9.7 10.9L10.9 9.7C11.8 8.8 11.8 7.2 10.9 6.3C10 5.4 8.4 5.4 7.5 6.3L6.3 7.5"
+					stroke="currentColor"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+				/>
+				{linked ? null : (
+					<path
+						d="M3 13L13 3"
+						stroke="currentColor"
+						strokeWidth="1.5"
+						strokeLinecap="round"
+					/>
+				)}
+			</svg>
+		</button>
+	);
+};
+
+export const TimelineScaleField: React.FC<{
+	readonly field: SchemaFieldInfo;
+	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly effectiveValue: unknown;
+	readonly onSave: TimelineFieldOnSave;
+	readonly onDragValueChange: TimelineFieldOnDragValueChange;
+	readonly onDragEnd: () => void;
+}> = ({
+	field,
+	propStatus,
+	effectiveValue,
+	onSave,
+	onDragValueChange,
+	onDragEnd,
+}) => {
+	const [dragX, setDragX] = useState<number | null>(null);
+	const [dragY, setDragY] = useState<number | null>(null);
+	const dragStartRef = useRef<readonly [number, number] | null>(null);
+
+	const [codeX, codeY, codeZ] = useMemo(
+		() => NoReactInternals.parseScaleValue(effectiveValue),
+		[effectiveValue],
+	);
+
+	const [linked, setLinked] = useState(() => codeX === codeY);
+
+	const step =
+		field.fieldSchema.type === 'scale'
+			? (field.fieldSchema.step ?? 0.01)
+			: 0.01;
+	const min =
+		field.fieldSchema.type === 'scale'
+			? (field.fieldSchema.min ?? -Infinity)
+			: -Infinity;
+	const max =
+		field.fieldSchema.type === 'scale'
+			? (field.fieldSchema.max ?? Infinity)
+			: Infinity;
+
+	const stepDecimals = useMemo(() => getDecimalPlaces(step), [step]);
+
+	const formatter = useCallback(
+		(v: number | string) => {
+			const num = Number(v);
+			const digits = Math.max(stepDecimals, getDecimalPlaces(num));
+			return digits === 0 ? String(num) : num.toFixed(digits);
+		},
+		[stepDecimals],
+	);
+
+	const getDragStart = useCallback((): readonly [number, number] => {
+		if (dragStartRef.current === null) {
+			dragStartRef.current = [dragX ?? codeX, dragY ?? codeY];
+		}
+
+		return dragStartRef.current;
+	}, [codeX, codeY, dragX, dragY]);
+
+	const serialize = useCallback(
+		(x: number, y: number) => {
+			return NoReactInternals.serializeScaleValue([x, y, codeZ]);
+		},
+		[codeZ],
+	);
+
+	const onXChange = useCallback(
+		(newVal: number) => {
+			if (linked) {
+				const [baseX, baseY] = getDragStart();
+				const [newX, newY] = getLinkedScale({
+					axis: 'x',
+					newValue: newVal,
+					baseX,
+					baseY,
+					min,
+					max,
+				});
+				setDragX(newX);
+				setDragY(newY);
+				onDragValueChange(serialize(newX, newY));
+				return;
+			}
+
+			setDragX(newVal);
+			const currentY = dragY ?? codeY;
+			onDragValueChange(serialize(newVal, currentY));
+		},
+		[
+			codeY,
+			dragY,
+			getDragStart,
+			linked,
+			max,
+			min,
+			onDragValueChange,
+			serialize,
+		],
+	);
+
+	const onXChangeEnd = useCallback(
+		(newVal: number) => {
+			const [newX, newY] = linked
+				? getLinkedScale({
+						axis: 'x',
+						newValue: newVal,
+						baseX: dragStartRef.current?.[0] ?? codeX,
+						baseY: dragStartRef.current?.[1] ?? codeY,
+						min,
+						max,
+					})
+				: [newVal, dragY ?? codeY];
+			const newScale = serialize(newX, newY);
+
+			const clearDragState = () => {
+				dragStartRef.current = null;
+				setDragX(null);
+				setDragY(null);
+				onDragEnd();
+			};
+
+			if (
+				propStatus.canUpdate &&
+				!valuesEqual(newScale, propStatus.codeValue)
+			) {
+				onSave(newScale).finally(clearDragState);
+			} else {
+				clearDragState();
+			}
+		},
+		[
+			codeX,
+			codeY,
+			dragY,
+			linked,
+			max,
+			min,
+			onDragEnd,
+			onSave,
+			propStatus,
+			serialize,
+		],
+	);
+
+	const onXTextChange = useCallback(
+		(newVal: string) => {
+			if (!propStatus.canUpdate) {
+				return;
+			}
+
+			const parsed = Number(newVal);
+			if (Number.isNaN(parsed)) {
+				return;
+			}
+
+			const [newX, newY] = linked
+				? getLinkedScale({
+						axis: 'x',
+						newValue: parsed,
+						baseX: codeX,
+						baseY: codeY,
+						min,
+						max,
+					})
+				: [parsed, dragY ?? codeY];
+			const newScale = serialize(newX, newY);
+			if (!valuesEqual(newScale, propStatus.codeValue)) {
+				setDragX(newX);
+				setDragY(newY);
+				onSave(newScale).finally(() => {
+					dragStartRef.current = null;
+					setDragX(null);
+					setDragY(null);
+				});
+			}
+		},
+		[codeX, codeY, dragY, linked, max, min, onSave, propStatus, serialize],
+	);
+
+	const onYChange = useCallback(
+		(newVal: number) => {
+			if (linked) {
+				const [baseX, baseY] = getDragStart();
+				const [newX, newY] = getLinkedScale({
+					axis: 'y',
+					newValue: newVal,
+					baseX,
+					baseY,
+					min,
+					max,
+				});
+				setDragX(newX);
+				setDragY(newY);
+				onDragValueChange(serialize(newX, newY));
+				return;
+			}
+
+			setDragY(newVal);
+			const currentX = dragX ?? codeX;
+			onDragValueChange(serialize(currentX, newVal));
+		},
+		[
+			codeX,
+			dragX,
+			getDragStart,
+			linked,
+			max,
+			min,
+			onDragValueChange,
+			serialize,
+		],
+	);
+
+	const onYChangeEnd = useCallback(
+		(newVal: number) => {
+			const [newX, newY] = linked
+				? getLinkedScale({
+						axis: 'y',
+						newValue: newVal,
+						baseX: dragStartRef.current?.[0] ?? codeX,
+						baseY: dragStartRef.current?.[1] ?? codeY,
+						min,
+						max,
+					})
+				: [dragX ?? codeX, newVal];
+			const newScale = serialize(newX, newY);
+
+			const clearDragState = () => {
+				dragStartRef.current = null;
+				setDragX(null);
+				setDragY(null);
+				onDragEnd();
+			};
+
+			if (
+				propStatus.canUpdate &&
+				!valuesEqual(newScale, propStatus.codeValue)
+			) {
+				onSave(newScale).finally(clearDragState);
+			} else {
+				clearDragState();
+			}
+		},
+		[
+			codeX,
+			codeY,
+			dragX,
+			linked,
+			max,
+			min,
+			onDragEnd,
+			onSave,
+			propStatus,
+			serialize,
+		],
+	);
+
+	const onYTextChange = useCallback(
+		(newVal: string) => {
+			if (!propStatus.canUpdate) {
+				return;
+			}
+
+			const parsed = Number(newVal);
+			if (Number.isNaN(parsed)) {
+				return;
+			}
+
+			const [newX, newY] = linked
+				? getLinkedScale({
+						axis: 'y',
+						newValue: parsed,
+						baseX: codeX,
+						baseY: codeY,
+						min,
+						max,
+					})
+				: [dragX ?? codeX, parsed];
+			const newScale = serialize(newX, newY);
+			if (!valuesEqual(newScale, propStatus.codeValue)) {
+				setDragX(newX);
+				setDragY(newY);
+				onSave(newScale).finally(() => {
+					dragStartRef.current = null;
+					setDragX(null);
+					setDragY(null);
+				});
+			}
+		},
+		[codeX, codeY, dragX, linked, max, min, onSave, propStatus, serialize],
+	);
+
+	const onToggleLink = useCallback(() => {
+		setLinked((current) => !current);
+	}, []);
+
+	return (
+		<span style={containerStyle}>
+			<LinkToggle linked={linked} onToggle={onToggleLink} />
+			<InputDragger
+				type="number"
+				value={dragX ?? codeX}
+				style={leftDraggerStyle}
+				status="ok"
+				small
+				onValueChange={onXChange}
+				onValueChangeEnd={onXChangeEnd}
+				onTextChange={onXTextChange}
+				min={min}
+				max={max}
+				step={step}
+				formatter={formatter}
+				rightAlign={false}
+			/>
+			<div style={gapStyle} />
+			<InputDragger
+				type="number"
+				value={dragY ?? codeY}
+				style={rightDraggerStyle}
+				status="ok"
+				small
+				onValueChange={onYChange}
+				onValueChangeEnd={onYChangeEnd}
+				onTextChange={onYTextChange}
+				min={min}
+				max={max}
+				step={step}
+				formatter={formatter}
+				rightAlign={false}
+			/>
+		</span>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelineScaleField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScaleField.tsx
@@ -49,6 +49,10 @@ const clamp = (value: number, min: number, max: number): number => {
 	return Math.min(max, Math.max(min, value));
 };
 
+const normalizeScaleNumber = (value: number): number => {
+	return Math.round(value * 1000000) / 1000000;
+};
+
 const getLinkedScale = ({
 	axis,
 	newValue,
@@ -68,7 +72,7 @@ const getLinkedScale = ({
 	const linkedBase = axis === 'x' ? baseY : baseX;
 
 	if (drivingBase === 0 || linkedBase === 0) {
-		const clamped = clamp(newValue, min, max);
+		const clamped = normalizeScaleNumber(clamp(newValue, min, max));
 		return [clamped, clamped];
 	}
 
@@ -84,8 +88,12 @@ const getLinkedScale = ({
 	}
 
 	const clampedDriving = clamp(driving, min, max);
+	const normalizedDriving = normalizeScaleNumber(clampedDriving);
+	const normalizedLinked = normalizeScaleNumber(linked);
 
-	return axis === 'x' ? [clampedDriving, linked] : [linked, clampedDriving];
+	return axis === 'x'
+		? [normalizedDriving, normalizedLinked]
+		: [normalizedLinked, normalizedDriving];
 };
 
 const valuesEqual = (left: unknown, right: unknown): boolean => {

--- a/packages/studio/src/components/Timeline/TimelineScaleField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScaleField.tsx
@@ -35,8 +35,8 @@ const toggleStyle: React.CSSProperties = {
 };
 
 const linkIconStyle: React.CSSProperties = {
-	width: 12,
-	height: 12,
+	width: 14,
+	height: 14,
 	pointerEvents: 'none',
 };
 
@@ -116,28 +116,18 @@ const LinkToggle: React.FC<{
 			title={linked ? 'Unlink scale axes' : 'Link scale axes'}
 			aria-label={linked ? 'Unlink scale axes' : 'Link scale axes'}
 		>
-			<svg viewBox="0 0 16 16" fill="none" style={linkIconStyle}>
-				<path
-					d="M6.3 5.1L5.1 6.3C4.2 7.2 4.2 8.8 5.1 9.7C6 10.6 7.6 10.6 8.5 9.7L9.7 8.5"
-					stroke="currentColor"
-					strokeWidth="1.5"
-					strokeLinecap="round"
-				/>
-				<path
-					d="M9.7 10.9L10.9 9.7C11.8 8.8 11.8 7.2 10.9 6.3C10 5.4 8.4 5.4 7.5 6.3L6.3 7.5"
-					stroke="currentColor"
-					strokeWidth="1.5"
-					strokeLinecap="round"
-				/>
-				{linked ? null : (
+			{linked ? (
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 640 640"
+					style={linkIconStyle}
+				>
 					<path
-						d="M3 13L13 3"
-						stroke="currentColor"
-						strokeWidth="1.5"
-						strokeLinecap="round"
+						fill="currentcolor"
+						d="M32 320C32 214 118 128 224 128L288 128L288 192L224 192C153.3 192 96 249.3 96 320C96 390.7 153.3 448 224 448L288 448L288 512L224 512C118 512 32 426 32 320zM608 320C608 426 522 512 416 512L352 512L352 448L416 448C486.7 448 544 390.7 544 320C544 249.3 486.7 192 416 192L352 192L352 128L416 128C522 128 608 214 608 320zM224 288L448 288L448 352L192 352L192 288L224 288z"
 					/>
-				)}
-			</svg>
+				</svg>
+			) : null}
 		</button>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -14,6 +14,7 @@ import {TimelineColorField} from './TimelineColorField';
 import {TimelineEnumField} from './TimelineEnumField';
 import {TimelineNumberField} from './TimelineNumberField';
 import {TimelineRotationField} from './TimelineRotationField';
+import {TimelineScaleField} from './TimelineScaleField';
 import {TimelineTranslateField} from './TimelineTranslateField';
 import {TimelineUvCoordinateField} from './TimelineUvCoordinateField';
 
@@ -108,6 +109,21 @@ export const TimelineFieldValue: React.FC<{
 		return (
 			<span style={wrapperStyle}>
 				<TimelineTranslateField
+					field={field}
+					effectiveValue={effectiveValue}
+					propStatus={propStatus}
+					onSave={onSave}
+					onDragValueChange={onDragValueChange}
+					onDragEnd={onDragEnd}
+				/>
+			</span>
+		);
+	}
+
+	if (field.typeName === 'scale') {
+		return (
+			<span style={wrapperStyle}>
+				<TimelineScaleField
 					field={field}
 					effectiveValue={effectiveValue}
 					propStatus={propStatus}


### PR DESCRIPTION
Closes #7984.

## Summary
- Add a dedicated `scale` timeline field with X/Y draggers and a chain-link toggle
- Save uniform X/Y scale as a single number and non-uniform scale as CSS scale syntax
- Share scale parsing/serialization and support component-wise scale interpolation internally
- Add a dedicated scale icon for the timeline field
- Fix floating-point display when X/Y scale are linked

## Testing
- `bun test packages/core/src/test/scale-value.test.ts packages/core/src/test/interpolate-keyframed-status.test.ts`
- `bun test packages/studio/src/test/timeline-keyframes.test.ts packages/studio-server/src/test/update-keyframes.test.ts packages/studio-server/src/test/compute-sequence-props-status.test.ts`
- `bunx turbo make --filter="remotion" --filter="@remotion/studio-shared" --filter="@remotion/studio"`
- `bun run stylecheck`
- `bunx oxfmt src --write` in `packages/core`, `packages/studio-shared`, and `packages/studio`
- `bun run build`
- `bun run formatting`
- `bun run lint` in `packages/core` and `packages/studio`
