### PR TITLE
`@remotion/studio`: Copy and paste sequence effects

### DIFF
--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -99,6 +99,7 @@ export type SequenceControls = {
 	schema: SequenceSchema;
 	currentRuntimeValueDotNotation: Record<string, unknown>;
 	overrideId: string;
+	supportsEffects: boolean;
 };
 
 export type TSequence = {

--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -618,7 +618,11 @@ const htmlInCanvasSchema = {
 	hidden: hiddenField,
 };
 
-const HtmlInCanvasWrapped = wrapInSchema(HtmlInCanvasInner, htmlInCanvasSchema);
+const HtmlInCanvasWrapped = wrapInSchema({
+	Component: HtmlInCanvasInner,
+	schema: htmlInCanvasSchema,
+	supportsEffects: true,
+});
 
 export const HtmlInCanvas = Object.assign(HtmlInCanvasWrapped, {
 	isSupported: isHtmlInCanvasSupported,

--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -543,5 +543,9 @@ const ImgInner: React.FC<
  * @description Works just like a regular HTML img tag. When you use the <Img> tag, Remotion will ensure that the image is loaded before rendering the frame.
  * @see [Documentation](https://remotion.dev/docs/img)
  */
-export const Img = wrapInSchema(ImgInner, imgSchema);
+export const Img = wrapInSchema({
+	Component: ImgInner,
+	schema: imgSchema,
+	supportsEffects: true,
+});
 addSequenceStackTraces(Img);

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -539,4 +539,8 @@ const SequenceInner = forwardRef(SequenceRefForwardingFunction);
  * @description A component that time-shifts its children and wraps them in an absolutely positioned <div>.
  * @see [Documentation](https://www.remotion.dev/docs/sequence)
  */
-export const Sequence = wrapInSchema(SequenceInner, sequenceSchema);
+export const Sequence = wrapInSchema({
+	Component: SequenceInner,
+	schema: sequenceSchema,
+	supportsEffects: false,
+});

--- a/packages/core/src/SequenceManager.tsx
+++ b/packages/core/src/SequenceManager.tsx
@@ -64,6 +64,7 @@ export type VisualModeSetters = {
 export type CanUpdateEffectPropsResponseTrue = {
 	canUpdate: true;
 	callee: string;
+	importPath: string | null;
 	effectIndex: number;
 	props: Record<string, CanUpdateSequencePropStatus>;
 };

--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -288,10 +288,11 @@ const AnimatedImageInner = ({
 	);
 };
 
-export const AnimatedImage = wrapInSchema(
-	AnimatedImageInner,
-	animatedImageSchema,
-);
+export const AnimatedImage = wrapInSchema({
+	Component: AnimatedImageInner,
+	schema: animatedImageSchema,
+	supportsEffects: true,
+});
 
 AnimatedImage.displayName = 'AnimatedImage';
 

--- a/packages/core/src/canvas-image/CanvasImage.tsx
+++ b/packages/core/src/canvas-image/CanvasImage.tsx
@@ -478,7 +478,11 @@ const CanvasImageInner = forwardRef<
  * @description Renders a static image to a `<canvas>` and applies Remotion effects.
  * @see [Documentation](https://www.remotion.dev/docs/canvasimage)
  */
-export const CanvasImage = wrapInSchema(CanvasImageInner, canvasImageSchema);
+export const CanvasImage = wrapInSchema({
+	Component: CanvasImageInner,
+	schema: canvasImageSchema,
+	supportsEffects: true,
+});
 
 CanvasImage.displayName = 'CanvasImage';
 

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -261,7 +261,11 @@ const SolidOuter = forwardRef<
 	},
 );
 
-export const Solid = wrapInSchema(SolidOuter, solidSchema);
+export const Solid = wrapInSchema({
+	Component: SolidOuter,
+	schema: solidSchema,
+	supportsEffects: true,
+});
 
 Solid.displayName = 'Solid';
 

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -1,5 +1,10 @@
-import {type FC, type PropsWithChildren} from 'react';
-import React, {Children, forwardRef, useMemo} from 'react';
+import React, {
+	Children,
+	forwardRef,
+	useMemo,
+	type FC,
+	type PropsWithChildren,
+} from 'react';
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {sequenceSchemaDefaultLayoutNone} from '../sequence-field-schema.js';
 import type {LayoutAndStyle, SequenceProps} from '../Sequence.js';
@@ -145,9 +150,16 @@ const SeriesInner: FC<SeriesProps> = (props) => {
  */
 const Series: React.ComponentType<SeriesProps> & {
 	Sequence: typeof SeriesSequence;
-} = Object.assign(wrapInSchema(SeriesInner, sequenceSchemaDefaultLayoutNone), {
-	Sequence: SeriesSequence,
-});
+} = Object.assign(
+	wrapInSchema({
+		Component: SeriesInner,
+		schema: sequenceSchemaDefaultLayoutNone,
+		supportsEffects: false,
+	}),
+	{
+		Sequence: SeriesSequence,
+	},
+);
 
 export {Series};
 

--- a/packages/core/src/wrap-in-schema.ts
+++ b/packages/core/src/wrap-in-schema.ts
@@ -101,12 +101,17 @@ export const mergeValues = ({
 
 const stackToOverrideMap: Record<string, string> = {};
 
-export const wrapInSchema = <S extends SequenceSchema, Props extends object>(
+export const wrapInSchema = <S extends SequenceSchema, Props extends object>({
+	Component,
+	schema,
+	supportsEffects,
+}: {
 	Component: React.ComponentType<
 		Props & {readonly _experimentalControls: SequenceControls | undefined}
-	>,
-	schema: S,
-): React.ComponentType<Props> => {
+	>;
+	schema: S;
+	supportsEffects: boolean;
+}): React.ComponentType<Props> => {
 	// Schema is static for a component, so we move this outside
 	const flatSchema = getFlatSchemaWithAllKeys(schema);
 	const flatKeys = Object.keys(flatSchema);
@@ -180,13 +185,14 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>(
 		);
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const controls = useMemo(() => {
+		const controls = useMemo((): SequenceControls => {
 			return {
 				schema,
 				currentRuntimeValueDotNotation,
 				overrideId,
+				supportsEffects,
 			};
-		}, [currentRuntimeValueDotNotation, overrideId]);
+		}, [currentRuntimeValueDotNotation, overrideId, schema, supportsEffects]);
 
 		// 3. Apply drag/code overrides on top of the runtime values.
 		// eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/core/src/wrap-in-schema.ts
+++ b/packages/core/src/wrap-in-schema.ts
@@ -192,7 +192,7 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>({
 				overrideId,
 				supportsEffects,
 			};
-		}, [currentRuntimeValueDotNotation, overrideId, schema, supportsEffects]);
+		}, [currentRuntimeValueDotNotation, overrideId]);
 
 		// 3. Apply drag/code overrides on top of the runtime values.
 		// eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -119,7 +119,11 @@ const GifInner = ({
 	);
 };
 
-export const Gif = wrapInSchema(GifInner, gifSchema);
+export const Gif = wrapInSchema({
+	Component: GifInner,
+	schema: gifSchema,
+	supportsEffects: true,
+});
 
 Gif.displayName = 'Gif';
 

--- a/packages/light-leaks/src/LightLeak.tsx
+++ b/packages/light-leaks/src/LightLeak.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {type SequenceControls, type SequenceSchema} from 'remotion';
 import {
 	AbsoluteFill,
 	Internals,
@@ -9,7 +8,9 @@ import {
 	useVideoConfig,
 	type AbsoluteFillLayout,
 	type LayoutAndStyle,
+	type SequenceControls,
 	type SequenceProps,
+	type SequenceSchema,
 } from 'remotion';
 
 const {createWebGLContextError} = Internals;
@@ -291,10 +292,11 @@ const LightLeakInner: React.FC<
 	);
 };
 
-export const LightLeak = Internals.wrapInSchema(
-	LightLeakInner,
-	lightLeakSchema,
-);
+export const LightLeak = Internals.wrapInSchema({
+	Component: LightLeakInner,
+	schema: lightLeakSchema,
+	supportsEffects: false,
+});
 
 LightLeak.displayName = 'LightLeak';
 

--- a/packages/media/src/audio/audio.tsx
+++ b/packages/media/src/audio/audio.tsx
@@ -1,12 +1,12 @@
-import {useState} from 'react';
-import React from 'react';
-import {useMemo} from 'react';
+import React, {useMemo, useState} from 'react';
 import {
+	Internals,
+	Sequence,
+	useRemotionEnvironment,
 	useVideoConfig,
 	type SequenceControls,
 	type SequenceSchema,
 } from 'remotion';
-import {Internals, Sequence, useRemotionEnvironment} from 'remotion';
 import {getLoopDisplay} from '../show-in-timeline';
 import {AudioForPreview} from './audio-for-preview';
 import {AudioForRendering} from './audio-for-rendering';
@@ -159,6 +159,10 @@ const AudioInner: React.FC<
 	);
 };
 
-export const Audio = Internals.wrapInSchema(AudioInner, audioSchema);
+export const Audio = Internals.wrapInSchema({
+	Component: AudioInner,
+	schema: audioSchema,
+	supportsEffects: false,
+});
 
 Internals.addSequenceStackTraces(Audio);

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -238,9 +238,9 @@ const VideoForPreviewAssertedShowing: React.FC<
 			return;
 		}
 
-		const canvas = canvasRef.current;
-
 		return () => {
+			const canvas = canvasRef.current;
+
 			if (
 				!canvas ||
 				!hasDrawnRealFrameRef.current ||

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -350,6 +350,10 @@ const VideoInner: React.FC<
 	);
 };
 
-export const Video = Internals.wrapInSchema(VideoInner, videoSchema);
+export const Video = Internals.wrapInSchema({
+	Component: VideoInner,
+	schema: videoSchema,
+	supportsEffects: true,
+});
 
 Internals.addSequenceStackTraces(Video);

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -492,14 +492,15 @@ const RemotionRiveCanvasInner = forwardRef(
 	RemotionRiveCanvasInnerForwardRefFunction,
 );
 
-export const RemotionRiveCanvas = wrapInSchema(
-	RemotionRiveCanvasInner as unknown as React.ComponentType<
+export const RemotionRiveCanvas = wrapInSchema({
+	Component: RemotionRiveCanvasInner as unknown as React.ComponentType<
 		RemotionRiveCanvasProps & {
 			readonly _experimentalControls: SequenceControls | undefined;
 		}
 	>,
-	riveCanvasSchema,
-) as React.ForwardRefExoticComponent<
+	schema: riveCanvasSchema,
+	supportsEffects: true,
+}) as React.ForwardRefExoticComponent<
 	RemotionRiveCanvasProps & React.RefAttributes<RiveCanvasRef>
 >;
 

--- a/packages/serverless-client/src/find-output-file-in-bucket.ts
+++ b/packages/serverless-client/src/find-output-file-in-bucket.ts
@@ -1,0 +1,79 @@
+import type {CustomCredentials} from './constants';
+import {getExpectedOutName} from './expected-out-name';
+import type {ProviderSpecifics} from './provider-implementation';
+import type {RenderMetadata} from './render-metadata';
+import type {CloudProvider} from './types';
+
+export type OutputFileMetadata = {
+	url: string;
+	sizeInBytes: number | null;
+};
+
+export const findOutputFileInBucket = async <Provider extends CloudProvider>({
+	region,
+	renderMetadata,
+	bucketName,
+	customCredentials,
+	currentRegion,
+	providerSpecifics,
+	forcePathStyle,
+	requestHandler,
+}: {
+	region: Provider['region'];
+	renderMetadata: RenderMetadata<Provider>;
+	bucketName: string;
+	customCredentials: CustomCredentials<Provider> | null;
+	currentRegion: Provider['region'];
+	providerSpecifics: ProviderSpecifics<Provider>;
+	forcePathStyle: boolean;
+	requestHandler: Provider['requestHandler'] | null;
+}): Promise<OutputFileMetadata | null> => {
+	const {renderBucketName, key} = getExpectedOutName({
+		renderMetadata,
+		bucketName,
+		customCredentials,
+		bucketNamePrefix: providerSpecifics.getBucketPrefix(),
+	});
+
+	try {
+		const metadata = await providerSpecifics.headFile({
+			bucketName: renderBucketName,
+			key,
+			region,
+			customCredentials,
+			forcePathStyle,
+			requestHandler,
+		});
+
+		return {
+			url: providerSpecifics.getOutputUrl({
+				renderMetadata,
+				bucketName,
+				customCredentials,
+				currentRegion,
+			}).url,
+			sizeInBytes: metadata.ContentLength ?? null,
+		};
+	} catch (err) {
+		if ((err as Error).name === 'NotFound') {
+			return null;
+		}
+
+		if (
+			(err as Error).message === 'UnknownError' ||
+			(err as {$metadata: {httpStatusCode: number}}).$metadata
+				?.httpStatusCode === 403
+		) {
+			throw new Error(
+				`Unable to access item "${key}" from bucket "${renderBucketName}" ${
+					customCredentials?.endpoint
+						? `(S3 Endpoint = ${customCredentials?.endpoint})`
+						: ''
+				} - got a 403 error when heading the file. Check your credentials and permissions. The Lambda role must have permission for both "s3:GetObject" and "s3:ListBucket" actions.`,
+				{cause: err},
+			);
+		}
+
+		throw err;
+	}
+};

--- a/packages/serverless-client/src/index.ts
+++ b/packages/serverless-client/src/index.ts
@@ -74,6 +74,10 @@ export {
 	getCredentialsFromOutName,
 	getExpectedOutName,
 } from './expected-out-name';
+export {
+	findOutputFileInBucket,
+	type OutputFileMetadata,
+} from './find-output-file-in-bucket';
 export {formatCostsInfo} from './format-costs-info';
 export {FileNameAndSize, GetFolderFiles} from './get-files-in-folder';
 export {

--- a/packages/serverless-client/src/progress.ts
+++ b/packages/serverless-client/src/progress.ts
@@ -3,6 +3,7 @@ import {calculateChunkTimes} from './calculate-chunk-times';
 import type {CustomCredentials} from './constants';
 import {estimatePriceFromMetadata} from './estimate-price-from-bucket';
 import {getExpectedOutName} from './expected-out-name';
+import {findOutputFileInBucket} from './find-output-file-in-bucket';
 import {formatCostsInfo} from './format-costs-info';
 import {getOverallProgress} from './get-overall-progress';
 import {getOverallProgressFromStorage} from './get-overall-progress-from-storage';
@@ -249,6 +250,87 @@ export const getProgress = async <Provider extends CloudProvider>({
 	// 2. If we have no missing chunks, but the encoding is not done, even after the additional `merge` function has been spawned, we consider it timed out
 	const isBeyondTimeoutAndHasStitchTimeout =
 		Date.now() > renderMetadata.startedDate + timeoutInMilliseconds * 2 + 20000;
+
+	const shouldCheckForCompletedOutput =
+		allChunks &&
+		(isBeyondTimeoutAndHasStitchTimeout ||
+			(overallProgress.combinedFrames >= frameCount &&
+				overallProgress.timeToCombine !== null));
+
+	if (shouldCheckForCompletedOutput) {
+		const outputFile = await findOutputFileInBucket({
+			bucketName,
+			customCredentials,
+			renderMetadata,
+			region,
+			currentRegion: region,
+			providerSpecifics,
+			forcePathStyle,
+			requestHandler,
+		});
+
+		if (outputFile) {
+			const outData = getExpectedOutName({
+				renderMetadata,
+				bucketName,
+				customCredentials,
+				bucketNamePrefix: providerSpecifics.getBucketPrefix(),
+			});
+			const now = Date.now();
+			const timeToFinishChunks = calculateChunkTimes({
+				type: 'absolute-time',
+				timings: overallProgress.timings,
+			});
+
+			return {
+				framesRendered: frameCount,
+				bucket: bucketName,
+				renderSize: outputFile.sizeInBytes ?? 0,
+				chunks: renderMetadata.totalChunks,
+				cleanup: {
+					doneIn: null,
+					filesDeleted: 0,
+					minFilesToDelete: 0,
+				},
+				costs: priceFromBucket
+					? formatCostsInfo(priceFromBucket.accruedSoFar)
+					: formatCostsInfo(0),
+				currentTime: now,
+				done: true,
+				encodingStatus: {
+					framesEncoded: frameCount,
+					combinedFrames: frameCount,
+					timeToCombine: overallProgress.timeToCombine,
+				},
+				errors: errorExplanations,
+				fatalErrorEncountered: false,
+				lambdasInvoked: renderMetadata.totalChunks,
+				outputFile: outputFile.url,
+				renderId,
+				timeToFinish: now - renderMetadata.startedDate,
+				timeToFinishChunks,
+				timeToRenderFrames: overallProgress.timeToRenderFrames,
+				overallProgress: 1,
+				retriesInfo: overallProgress.retries ?? [],
+				outKey: outData.key,
+				outBucket: outData.renderBucketName,
+				mostExpensiveFrameRanges: null,
+				timeToEncode: overallProgress.timeToEncode,
+				outputSizeInBytes: outputFile.sizeInBytes ?? 0,
+				type: 'success',
+				estimatedBillingDurationInMilliseconds:
+					priceFromBucket?.estimatedBillingDurationInMilliseconds ?? null,
+				timeToCombine: overallProgress.timeToCombine,
+				combinedFrames: frameCount,
+				renderMetadata,
+				timeoutTimestamp: overallProgress.timeoutTimestamp,
+				compositionValidated: overallProgress.compositionValidated,
+				functionLaunched: overallProgress.functionLaunched,
+				serveUrlOpened: overallProgress.serveUrlOpened,
+				artifacts: overallProgress.receivedArtifact,
+			};
+		}
+	}
 
 	const allErrors: EnhancedErrorInfo[] = [
 		isBeyondTimeoutAndMissingChunks || isBeyondTimeoutAndHasStitchTimeout

--- a/packages/serverless-client/src/test/progress.test.ts
+++ b/packages/serverless-client/src/test/progress.test.ts
@@ -1,0 +1,188 @@
+import {expect, test} from 'bun:test';
+import {Readable} from 'node:stream';
+import {overallProgressKey} from '../constants';
+import {getExpectedOutName} from '../expected-out-name';
+import type {OverallRenderProgress} from '../overall-render-progress';
+import {getProgress} from '../progress';
+import type {ProviderSpecifics} from '../provider-implementation';
+import type {RenderMetadata} from '../render-metadata';
+import type {CloudProvider} from '../types';
+
+type MockProvider = CloudProvider<
+	'eu-central-1',
+	{s3Key: string; s3Url: string},
+	{},
+	'standard',
+	{}
+>;
+
+const renderId = 'test-render';
+const bucketName = 'source-bucket';
+const startedDate = Date.now() - 30000;
+
+const renderMetadata: RenderMetadata<MockProvider> = {
+	audioBitrate: null,
+	audioCodec: null,
+	codec: 'h264',
+	compositionId: 'comp',
+	deleteAfter: null,
+	dimensions: {
+		height: 1080,
+		width: 1920,
+	},
+	downloadBehavior: {type: 'play-in-browser'},
+	estimatedRenderLambdaInvokations: 2,
+	estimatedTotalLambdaInvokations: 3,
+	everyNthFrame: 1,
+	frameRange: [0, 19],
+	framesPerLambda: 10,
+	functionName: 'remotion-render-4-0-0-mem2048mb-disk512mb-120sec',
+	imageFormat: 'png',
+	inputProps: {
+		type: 'payload',
+		payload: '{}',
+	},
+	lambdaVersion: '4.0.0',
+	memorySizeInMb: 2048,
+	metadata: null,
+	muted: true,
+	numberOfGifLoops: null,
+	outName: {
+		bucketName: 'output-bucket',
+		key: 'custom-output.mp4',
+	},
+	privacy: 'private',
+	region: 'eu-central-1',
+	rendererFunctionName: 'remotion-render-4-0-0-mem2048mb-disk512mb-120sec',
+	renderId,
+	scale: 1,
+	siteId: 'site',
+	startedDate,
+	totalChunks: 2,
+	type: 'video',
+};
+
+const progress: OverallRenderProgress<MockProvider> = {
+	chunks: [0, 1],
+	combinedFrames: 20,
+	compositionValidated: startedDate + 2,
+	errors: [],
+	fatalErrorTimestamp: null,
+	framesEncoded: 20,
+	framesRendered: 20,
+	functionLaunched: startedDate,
+	lambdasInvoked: 2,
+	postRenderData: null,
+	receivedArtifact: [],
+	renderMetadata,
+	retries: [],
+	serveUrlOpened: startedDate + 1,
+	timeToCombine: 500,
+	timeToEncode: 1000,
+	timeToRenderFrames: 750,
+	timeoutTimestamp: startedDate + 120000,
+	timings: [
+		{chunk: 0, start: startedDate, rendered: startedDate + 100},
+		{chunk: 1, start: startedDate + 100, rendered: startedDate + 250},
+	],
+};
+
+const makeProviderSpecifics = ({
+	onHeadFile,
+}: {
+	onHeadFile: ProviderSpecifics<MockProvider>['headFile'];
+}): ProviderSpecifics<MockProvider> => {
+	return {
+		applyLifeCycle: () => Promise.resolve(),
+		bucketExists: () => Promise.resolve(true),
+		callFunctionAsync: () => Promise.resolve(),
+		callFunctionStreaming: () => Promise.resolve(),
+		callFunctionSync: () => Promise.reject(new Error('Not implemented')),
+		checkCredentials: () => undefined,
+		convertToServeUrl: () => 'serve-url',
+		createBucket: () => Promise.resolve(),
+		deleteFile: () => Promise.resolve(),
+		deleteFunction: () => Promise.resolve(),
+		estimatePrice: () => 0.01,
+		getAccountId: () => Promise.resolve('123456789012'),
+		getBucketPrefix: () => 'remotionlambda-',
+		getBuckets: () => Promise.resolve([]),
+		getChromiumPath: () => null,
+		getEphemeralStorageForPriceCalculation: () => 512,
+		getFunctions: () => Promise.resolve([]),
+		getLoggingUrlForMethod: () => 'logs',
+		getLoggingUrlForRendererFunction: () => 'logs',
+		getMaxNonInlinePayloadSizePerFunction: () => 0,
+		getMaxStillInlinePayloadSize: () => 0,
+		getOutputUrl: ({
+			renderMetadata: metadata,
+			customCredentials,
+			currentRegion,
+		}) => {
+			const {key, renderBucketName} = getExpectedOutName({
+				renderMetadata: metadata,
+				bucketName,
+				customCredentials,
+				bucketNamePrefix: 'remotionlambda-',
+			});
+			return {
+				key,
+				url: `https://s3.${currentRegion}.amazonaws.com/${renderBucketName}/${key}`,
+			};
+		},
+		isFlakyError: () => false,
+		listObjects: () => Promise.resolve([]),
+		parseFunctionName: () => ({
+			diskSizeInMb: 512,
+			memorySizeInMb: 2048,
+			timeoutInSeconds: 120,
+			version: '4.0.0',
+		}),
+		printLoggingHelper: false,
+		randomHash: () => 'hash',
+		readFile: ({key}) => {
+			expect(key).toBe(overallProgressKey(renderId));
+			return Promise.resolve(
+				Readable.from([Buffer.from(JSON.stringify(progress))]),
+			);
+		},
+		serverStorageProductName: () => 'S3',
+		validateDeleteAfter: () => undefined,
+		writeFile: () => Promise.resolve(),
+		headFile: onHeadFile,
+	};
+};
+
+test('getProgress treats an existing output file as finished if postRenderData was not persisted', async () => {
+	const headedFiles: {bucketName: string; key: string}[] = [];
+	const providerSpecifics = makeProviderSpecifics({
+		onHeadFile: ({bucketName: headedBucketName, key}) => {
+			headedFiles.push({bucketName: headedBucketName, key});
+			return Promise.resolve({ContentLength: 1234});
+		},
+	});
+
+	const renderProgress = await getProgress({
+		bucketName,
+		customCredentials: null,
+		expectedBucketOwner: null,
+		forcePathStyle: false,
+		functionName: renderMetadata.functionName,
+		memorySizeInMb: 2048,
+		providerSpecifics,
+		region: 'eu-central-1',
+		renderId,
+		requestHandler: null,
+		timeoutInMilliseconds: 1000,
+	});
+
+	expect(headedFiles).toEqual([
+		{bucketName: 'output-bucket', key: 'custom-output.mp4'},
+	]);
+	expect(renderProgress.done).toBe(true);
+	expect(renderProgress.outputFile).toBe(
+		'https://s3.eu-central-1.amazonaws.com/output-bucket/custom-output.mp4',
+	);
+	expect(renderProgress.outputSizeInBytes).toBe(1234);
+	expect(renderProgress.errors).toEqual([]);
+});

--- a/packages/serverless/src/find-output-file-in-bucket.ts
+++ b/packages/serverless/src/find-output-file-in-bucket.ts
@@ -1,16 +1,15 @@
 import type {
 	CloudProvider,
 	CustomCredentials,
+	OutputFileMetadata,
 	ProviderSpecifics,
 	RenderMetadata,
 } from '@remotion/serverless-client';
-import {getExpectedOutName} from '@remotion/serverless-client';
+import {findOutputFileInBucket as findOutputFileInBucketShared} from '@remotion/serverless-client';
 
-export type OutputFileMetadata = {
-	url: string;
-};
+export type {OutputFileMetadata} from '@remotion/serverless-client';
 
-export const findOutputFileInBucket = async <Provider extends CloudProvider>({
+export const findOutputFileInBucket = <Provider extends CloudProvider>({
 	region,
 	renderMetadata,
 	bucketName,
@@ -33,50 +32,14 @@ export const findOutputFileInBucket = async <Provider extends CloudProvider>({
 		throw new Error('unexpectedly did not get renderMetadata');
 	}
 
-	const {renderBucketName, key} = getExpectedOutName({
+	return findOutputFileInBucketShared({
+		region,
 		renderMetadata,
 		bucketName,
 		customCredentials,
-		bucketNamePrefix: providerSpecifics.getBucketPrefix(),
+		currentRegion,
+		providerSpecifics,
+		forcePathStyle,
+		requestHandler,
 	});
-
-	try {
-		await providerSpecifics.headFile({
-			bucketName,
-			key,
-			region,
-			customCredentials,
-			forcePathStyle,
-			requestHandler,
-		});
-		return {
-			url: providerSpecifics.getOutputUrl({
-				renderMetadata,
-				bucketName,
-				customCredentials,
-				currentRegion,
-			}).url,
-		};
-	} catch (err) {
-		if ((err as Error).name === 'NotFound') {
-			return null;
-		}
-
-		if (
-			(err as Error).message === 'UnknownError' ||
-			(err as {$metadata: {httpStatusCode: number}}).$metadata
-				.httpStatusCode === 403
-		) {
-			throw new Error(
-				`Unable to access item "${key}" from bucket "${renderBucketName}" ${
-					customCredentials?.endpoint
-						? `(S3 Endpoint = ${customCredentials?.endpoint})`
-						: ''
-				} - got a 403 error when heading the file. Check your credentials and permissions. The Lambda role must have permission for both "s3:GetObject" and "s3:ListBucket" actions.`,
-				{cause: err},
-			);
-		}
-
-		throw err;
-	}
 };

--- a/packages/serverless/src/merge-chunks.ts
+++ b/packages/serverless/src/merge-chunks.ts
@@ -148,6 +148,7 @@ export const mergeChunksAndFinishRender = async <
 		errorExplanations,
 		timeToDelete: (await cleanupProm).reduce((a, b) => Math.max(a, b), 0),
 		outputFile: {
+			sizeInBytes: outputSize,
 			url: outputUrl,
 		},
 		outputSize,

--- a/packages/serverless/src/overall-render-progress.ts
+++ b/packages/serverless/src/overall-render-progress.ts
@@ -11,6 +11,14 @@ import type {
 } from '@remotion/serverless-client';
 import {overallProgressKey} from '@remotion/serverless-client';
 
+const progressUploadAttempts = 3;
+
+const wait = (duration: number) => {
+	return new Promise<void>((resolve) => {
+		setTimeout(resolve, duration);
+	});
+};
+
 export type OverallProgressHelper<Provider extends CloudProvider> = {
 	upload: (reason: string) => Promise<void>;
 	setFrames: ({
@@ -110,21 +118,12 @@ export const makeOverallRenderProgress = <Provider extends CloudProvider>({
 		dirtyReasons.push(reason);
 	};
 
-	const runUploadLoop = async () => {
-		while (dirty) {
-			dirty = false;
-			const reasons = dirtyReasons.join(', ');
-			dirtyReasons = [];
-			const toWrite = JSON.stringify(renderProgress);
-
-			RenderInternals.Log.verbose(
-				{indent: false, logLevel},
-				`Uploading progress - ${reasons} (${toWrite.length} bytes)`,
-			);
+	const uploadWithRetries = async (body: string, reasons: string) => {
+		for (let attempt = 1; attempt <= progressUploadAttempts; attempt++) {
 			const start = Date.now();
 			try {
 				await providerSpecifics.writeFile({
-					body: toWrite,
+					body,
 					bucketName,
 					customCredentials: null,
 					downloadBehavior: null,
@@ -140,19 +139,38 @@ export const makeOverallRenderProgress = <Provider extends CloudProvider>({
 					{indent: false, logLevel},
 					`Uploaded progress in ${Date.now() - start}ms`,
 				);
-				// Space out the requests a bit
-				await new Promise<void>((resolve) => {
-					setTimeout(resolve, Math.max(0, 250 - (Date.now() - start)));
-				});
+				return;
 			} catch (err) {
-				// If an error occurs in uploading the state that contains the errors,
-				// that is unfortunate. We just log it.
+				const willRetry = attempt < progressUploadAttempts;
 				RenderInternals.Log.error(
 					{indent: false, logLevel},
-					'Error uploading progress',
+					willRetry
+						? `Error uploading progress (${reasons}), retrying (${attempt}/${progressUploadAttempts})`
+						: `Error uploading progress (${reasons})`,
 					err,
 				);
+				if (willRetry) {
+					await wait(100 * 2 ** (attempt - 1));
+				}
 			}
+		}
+	};
+
+	const runUploadLoop = async () => {
+		while (dirty) {
+			dirty = false;
+			const reasons = dirtyReasons.join(', ');
+			dirtyReasons = [];
+			const toWrite = JSON.stringify(renderProgress);
+
+			RenderInternals.Log.verbose(
+				{indent: false, logLevel},
+				`Uploading progress - ${reasons} (${toWrite.length} bytes)`,
+			);
+			const start = Date.now();
+			await uploadWithRetries(toWrite, reasons);
+			// Space out the requests a bit
+			await wait(Math.max(0, 250 - (Date.now() - start)));
 		}
 
 		uploadLoopPromise = null;

--- a/packages/serverless/src/test/overall-render-progress.test.ts
+++ b/packages/serverless/src/test/overall-render-progress.test.ts
@@ -1,0 +1,118 @@
+import {expect, test} from 'bun:test';
+import type {
+	CloudProvider,
+	PostRenderData,
+	ProviderSpecifics,
+} from '@remotion/serverless-client';
+import {makeOverallRenderProgress} from '../overall-render-progress';
+
+type MockProvider = CloudProvider<
+	'eu-central-1',
+	{s3Key: string; s3Url: string},
+	{},
+	'standard',
+	{}
+>;
+
+const makeProviderSpecifics = ({
+	writeFile,
+}: {
+	writeFile: ProviderSpecifics<MockProvider>['writeFile'];
+}): ProviderSpecifics<MockProvider> => {
+	return {
+		applyLifeCycle: () => Promise.resolve(),
+		bucketExists: () => Promise.resolve(true),
+		callFunctionAsync: () => Promise.resolve(),
+		callFunctionStreaming: () => Promise.resolve(),
+		callFunctionSync: () => Promise.reject(new Error('Not implemented')),
+		checkCredentials: () => undefined,
+		convertToServeUrl: () => 'serve-url',
+		createBucket: () => Promise.resolve(),
+		deleteFile: () => Promise.resolve(),
+		deleteFunction: () => Promise.resolve(),
+		estimatePrice: () => 0,
+		getAccountId: () => Promise.resolve('123456789012'),
+		getBucketPrefix: () => 'remotionlambda-',
+		getBuckets: () => Promise.resolve([]),
+		getChromiumPath: () => null,
+		getEphemeralStorageForPriceCalculation: () => 512,
+		getFunctions: () => Promise.resolve([]),
+		getLoggingUrlForMethod: () => 'logs',
+		getLoggingUrlForRendererFunction: () => 'logs',
+		getMaxNonInlinePayloadSizePerFunction: () => 0,
+		getMaxStillInlinePayloadSize: () => 0,
+		getOutputUrl: () => ({key: 'out.mp4', url: 'https://example.com/out.mp4'}),
+		headFile: () => Promise.resolve({}),
+		isFlakyError: () => false,
+		listObjects: () => Promise.resolve([]),
+		parseFunctionName: () => null,
+		printLoggingHelper: false,
+		randomHash: () => 'hash',
+		readFile: () => Promise.reject(new Error('Not implemented')),
+		serverStorageProductName: () => 'S3',
+		validateDeleteAfter: () => undefined,
+		writeFile,
+	};
+};
+
+const postRenderData: PostRenderData<MockProvider> = {
+	artifactProgress: [],
+	cost: {
+		currency: 'USD',
+		disclaimer: 'test',
+		estimatedCost: 0,
+		estimatedDisplayCost: '$0',
+	},
+	deleteAfter: null,
+	endTime: 1,
+	errors: [],
+	estimatedBillingDurationInMilliseconds: 1,
+	filesCleanedUp: 0,
+	mostExpensiveFrameRanges: [],
+	outputFile: 'https://example.com/out.mp4',
+	outputSize: 1,
+	renderSize: 1,
+	retriesInfo: [],
+	startTime: 0,
+	timeToCleanUp: 0,
+	timeToCombine: 1,
+	timeToEncode: 1,
+	timeToFinish: 1,
+	timeToRenderChunks: 1,
+	timeToRenderFrames: 1,
+};
+
+test('setPostRenderData retries transient progress upload failures', async () => {
+	let attempts = 0;
+	let persistedBody: string | null = null;
+	const providerSpecifics = makeProviderSpecifics({
+		writeFile: ({body}) => {
+			attempts++;
+			if (attempts < 3) {
+				return Promise.reject(new Error('Temporary progress upload failure'));
+			}
+
+			persistedBody = String(body);
+			return Promise.resolve();
+		},
+	});
+	const overallProgress = makeOverallRenderProgress({
+		bucketName: 'bucket',
+		expectedBucketOwner: '123456789012',
+		forcePathStyle: false,
+		logLevel: 'error',
+		providerSpecifics,
+		region: 'eu-central-1',
+		renderId: 'render-id',
+		timeoutTimestamp: 1,
+	});
+
+	await overallProgress.setPostRenderData(postRenderData);
+
+	expect(attempts).toBe(3);
+	if (persistedBody === null) {
+		throw new Error('Expected progress to be persisted');
+	}
+
+	expect(JSON.parse(persistedBody).postRenderData).toEqual(postRenderData);
+});

--- a/packages/starburst/src/Starburst.tsx
+++ b/packages/starburst/src/Starburst.tsx
@@ -415,10 +415,11 @@ const StarburstInner: React.FC<
 	);
 };
 
-export const Starburst = Internals.wrapInSchema(
-	StarburstInner,
-	starburstSchema,
-);
+export const Starburst = Internals.wrapInSchema({
+	Component: StarburstInner,
+	schema: starburstSchema,
+	supportsEffects: false,
+});
 
 Starburst.displayName = 'Starburst';
 

--- a/packages/studio-server/src/codemods/add-effect.ts
+++ b/packages/studio-server/src/codemods/add-effect.ts
@@ -24,7 +24,7 @@ const b = recast.types.builders;
 
 const identifierRegex = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
 
-const assertValidEffect = ({
+export const assertValidEffect = ({
 	effectName,
 	effectImportPath,
 }: {
@@ -156,7 +156,7 @@ const getAvailableLocalName = ({
 	throw new Error(`Cannot find a local name for ${effectName}`);
 };
 
-const ensureEffectImport = ({
+export const ensureEffectImport = ({
 	ast,
 	effectName,
 	effectImportPath,
@@ -238,7 +238,7 @@ const makeEffectsAttr = (array: ArrayExpression): JSXAttribute => {
 	) as unknown as JSXAttribute;
 };
 
-const makeConfigObjectExpression = (
+export const makeConfigObjectExpression = (
 	config: Record<string, unknown>,
 ): ObjectExpression => {
 	return b.objectExpression(

--- a/packages/studio-server/src/codemods/paste-effects.ts
+++ b/packages/studio-server/src/codemods/paste-effects.ts
@@ -1,37 +1,30 @@
-import type {
-	ArrayExpression,
-	CallExpression,
-	Expression,
-	JSXAttribute,
-} from '@babel/types';
+import type {ArrayExpression, CallExpression, JSXAttribute} from '@babel/types';
 import type {
 	EffectClipboardPasteType,
-	EffectClipboardSource,
+	EffectClipboardSnapshot,
 } from '@remotion/studio-shared';
 import * as recast from 'recast';
 import type {SequenceNodePath} from 'remotion';
 import {findJsxElementAtNodePath} from '../preview-server/routes/can-update-sequence-props';
+import {
+	assertValidEffect,
+	ensureEffectImport,
+	makeConfigObjectExpression,
+} from './add-effect';
 import {formatFileContent} from './format-file-content';
 import {parseAst, serializeAst} from './parse-ast';
-import {
-	enumerateEffectArrayElements,
-	findEffectCallExpression,
-	findEffectsAttr,
-} from './update-effect-props/update-effect-props';
+import {findEffectsAttr} from './update-effect-props/update-effect-props';
 
 const b = recast.types.builders;
 
-const getEffectsArray = (
-	attr: JSXAttribute,
-	action: 'read' | 'append',
-): ArrayExpression => {
+const getEffectsArray = (attr: JSXAttribute): ArrayExpression => {
 	if (!attr.value || attr.value.type !== 'JSXExpressionContainer') {
-		throw new Error(`Cannot ${action} effects: effects prop is not an array`);
+		throw new Error('Cannot append effects: effects prop is not an array');
 	}
 
-	const expr = attr.value.expression as Expression;
+	const expr = attr.value.expression;
 	if (expr.type !== 'ArrayExpression') {
-		throw new Error(`Cannot ${action} effects: effects prop is not an array`);
+		throw new Error('Cannot append effects: effects prop is not an array');
 	}
 
 	return expr;
@@ -48,88 +41,26 @@ const makeEffectsArray = (calls: CallExpression[]): ArrayExpression => {
 	return b.arrayExpression(calls as never) as unknown as ArrayExpression;
 };
 
-const cloneCallExpression = (call: CallExpression): CallExpression => {
-	const {code} = recast.print(call);
-	const ast = parseAst(`const __remotionEffect = ${code};`);
-	const stmt = ast.program.body[0];
-	if (
-		stmt.type !== 'VariableDeclaration' ||
-		stmt.declarations[0]?.init?.type !== 'CallExpression'
-	) {
-		throw new Error('Cannot paste effects: failed to clone effect expression');
-	}
-
-	return stmt.declarations[0].init as CallExpression;
-};
-
-const getSourceEffects = ({
-	source,
-	targetFileName,
+const makeEffectCall = ({
 	ast,
+	effect,
 }: {
-	readonly source: EffectClipboardSource;
-	readonly targetFileName: string;
-	readonly ast: ReturnType<typeof parseAst>;
-}): {calls: CallExpression[]; labels: string[]} => {
-	if (source.fileName !== targetFileName) {
-		throw new Error(
-			'Cannot paste effects from a different source file yet. Paste between sequences in the same file to preserve keyframes and referenced values.',
-		);
-	}
-
-	const jsx = findJsxElementAtNodePath(
+	ast: ReturnType<typeof parseAst>;
+	effect: EffectClipboardSnapshot;
+}): CallExpression => {
+	assertValidEffect({
+		effectName: effect.callee,
+		effectImportPath: effect.importPath,
+	});
+	const localName = ensureEffectImport({
 		ast,
-		source.sequenceNodePath.nodePath as SequenceNodePath,
-	);
-	if (!jsx) {
-		throw new Error(
-			'Could not find a JSX element at the specified location to copy effects',
-		);
-	}
+		effectName: effect.callee,
+		effectImportPath: effect.importPath,
+	});
 
-	const attr = findEffectsAttr(jsx.attributes ?? []);
-	if (!attr) {
-		if (source.type === 'all-effects') {
-			return {calls: [], labels: []};
-		}
-
-		throw new Error('Could not find effects on the source JSX element');
-	}
-
-	if (source.type === 'single-effect') {
-		const found = findEffectCallExpression({
-			attr,
-			effectIndex: source.effectIndex,
-		});
-		if (found.kind === 'error') {
-			throw new Error(
-				`Cannot paste source effect at index ${source.effectIndex}: ${found.reason}`,
-			);
-		}
-
-		return {
-			calls: [cloneCallExpression(found.call)],
-			labels: [`${found.callee}()`],
-		};
-	}
-
-	const effectsArray = getEffectsArray(attr, 'read');
-	const elements = enumerateEffectArrayElements(effectsArray);
-	const calls: CallExpression[] = [];
-	const labels: string[] = [];
-
-	for (const [index, effect] of elements.entries()) {
-		if (effect.kind !== 'call') {
-			throw new Error(
-				`Cannot paste source effect at index ${index}: ${effect.reason}`,
-			);
-		}
-
-		calls.push(cloneCallExpression(effect.node));
-		labels.push(`${effect.callee}()`);
-	}
-
-	return {calls, labels};
+	return b.callExpression(b.identifier(localName), [
+		makeConfigObjectExpression(effect.params) as never,
+	]) as unknown as CallExpression;
 };
 
 const removeEffectsAttr = (
@@ -146,17 +77,16 @@ const removeEffectsAttr = (
 
 export const pasteEffects = async ({
 	input,
-	targetFileName,
 	targetSequenceNodePath,
 	type,
-	sources,
+	effects,
 	prettierConfigOverride,
 }: {
 	readonly input: string;
 	readonly targetFileName: string;
 	readonly targetSequenceNodePath: SequenceNodePath;
 	readonly type: EffectClipboardPasteType;
-	readonly sources: EffectClipboardSource[];
+	readonly effects: EffectClipboardSnapshot[];
 	readonly prettierConfigOverride?: Record<string, unknown> | null;
 }): Promise<{
 	readonly output: string;
@@ -165,18 +95,15 @@ export const pasteEffects = async ({
 	readonly logLine: number;
 }> => {
 	const ast = parseAst(input);
-	const copied = sources.map((source) =>
-		getSourceEffects({source, targetFileName, ast}),
-	);
-	const effectCalls = copied.flatMap((item) => item.calls);
-	const effectLabels = copied.flatMap((item) => item.labels);
-
 	const targetJsx = findJsxElementAtNodePath(ast, targetSequenceNodePath);
 	if (!targetJsx) {
 		throw new Error(
 			'Could not find a JSX element at the specified location to paste effects',
 		);
 	}
+
+	const effectCalls = effects.map((effect) => makeEffectCall({ast, effect}));
+	const effectLabels = effects.map((effect) => `${effect.callee}()`);
 
 	const existingAttr = findEffectsAttr(targetJsx.attributes ?? []);
 
@@ -189,7 +116,7 @@ export const pasteEffects = async ({
 			targetJsx.attributes.push(makeEffectsAttr(makeEffectsArray(effectCalls)));
 		}
 	} else if (existingAttr) {
-		getEffectsArray(existingAttr, 'append').elements.push(
+		getEffectsArray(existingAttr).elements.push(
 			...(effectCalls as ArrayExpression['elements']),
 		);
 	} else if (effectCalls.length > 0) {

--- a/packages/studio-server/src/codemods/paste-effects.ts
+++ b/packages/studio-server/src/codemods/paste-effects.ts
@@ -1,0 +1,213 @@
+import type {
+	ArrayExpression,
+	CallExpression,
+	Expression,
+	JSXAttribute,
+} from '@babel/types';
+import type {
+	EffectClipboardPasteType,
+	EffectClipboardSource,
+} from '@remotion/studio-shared';
+import * as recast from 'recast';
+import type {SequenceNodePath} from 'remotion';
+import {findJsxElementAtNodePath} from '../preview-server/routes/can-update-sequence-props';
+import {formatFileContent} from './format-file-content';
+import {parseAst, serializeAst} from './parse-ast';
+import {
+	enumerateEffectArrayElements,
+	findEffectCallExpression,
+	findEffectsAttr,
+} from './update-effect-props/update-effect-props';
+
+const b = recast.types.builders;
+
+const getEffectsArray = (
+	attr: JSXAttribute,
+	action: 'read' | 'append',
+): ArrayExpression => {
+	if (!attr.value || attr.value.type !== 'JSXExpressionContainer') {
+		throw new Error(`Cannot ${action} effects: effects prop is not an array`);
+	}
+
+	const expr = attr.value.expression as Expression;
+	if (expr.type !== 'ArrayExpression') {
+		throw new Error(`Cannot ${action} effects: effects prop is not an array`);
+	}
+
+	return expr;
+};
+
+const makeEffectsAttr = (array: ArrayExpression): JSXAttribute => {
+	return b.jsxAttribute(
+		b.jsxIdentifier('effects'),
+		b.jsxExpressionContainer(array as never),
+	) as unknown as JSXAttribute;
+};
+
+const makeEffectsArray = (calls: CallExpression[]): ArrayExpression => {
+	return b.arrayExpression(calls as never) as unknown as ArrayExpression;
+};
+
+const cloneCallExpression = (call: CallExpression): CallExpression => {
+	const {code} = recast.print(call);
+	const ast = parseAst(`const __remotionEffect = ${code};`);
+	const stmt = ast.program.body[0];
+	if (
+		stmt.type !== 'VariableDeclaration' ||
+		stmt.declarations[0]?.init?.type !== 'CallExpression'
+	) {
+		throw new Error('Cannot paste effects: failed to clone effect expression');
+	}
+
+	return stmt.declarations[0].init as CallExpression;
+};
+
+const getSourceEffects = ({
+	source,
+	targetFileName,
+	ast,
+}: {
+	readonly source: EffectClipboardSource;
+	readonly targetFileName: string;
+	readonly ast: ReturnType<typeof parseAst>;
+}): {calls: CallExpression[]; labels: string[]} => {
+	if (source.fileName !== targetFileName) {
+		throw new Error(
+			'Cannot paste effects from a different source file yet. Paste between sequences in the same file to preserve keyframes and referenced values.',
+		);
+	}
+
+	const jsx = findJsxElementAtNodePath(
+		ast,
+		source.sequenceNodePath.nodePath as SequenceNodePath,
+	);
+	if (!jsx) {
+		throw new Error(
+			'Could not find a JSX element at the specified location to copy effects',
+		);
+	}
+
+	const attr = findEffectsAttr(jsx.attributes ?? []);
+	if (!attr) {
+		if (source.type === 'all-effects') {
+			return {calls: [], labels: []};
+		}
+
+		throw new Error('Could not find effects on the source JSX element');
+	}
+
+	if (source.type === 'single-effect') {
+		const found = findEffectCallExpression({
+			attr,
+			effectIndex: source.effectIndex,
+		});
+		if (found.kind === 'error') {
+			throw new Error(
+				`Cannot paste source effect at index ${source.effectIndex}: ${found.reason}`,
+			);
+		}
+
+		return {
+			calls: [cloneCallExpression(found.call)],
+			labels: [`${found.callee}()`],
+		};
+	}
+
+	const effectsArray = getEffectsArray(attr, 'read');
+	const elements = enumerateEffectArrayElements(effectsArray);
+	const calls: CallExpression[] = [];
+	const labels: string[] = [];
+
+	for (const [index, effect] of elements.entries()) {
+		if (effect.kind !== 'call') {
+			throw new Error(
+				`Cannot paste source effect at index ${index}: ${effect.reason}`,
+			);
+		}
+
+		calls.push(cloneCallExpression(effect.node));
+		labels.push(`${effect.callee}()`);
+	}
+
+	return {calls, labels};
+};
+
+const removeEffectsAttr = (
+	attributes: NonNullable<
+		ReturnType<typeof findJsxElementAtNodePath>
+	>['attributes'],
+	attr: JSXAttribute,
+) => {
+	const index = attributes.indexOf(attr);
+	if (index !== -1) {
+		attributes.splice(index, 1);
+	}
+};
+
+export const pasteEffects = async ({
+	input,
+	targetFileName,
+	targetSequenceNodePath,
+	type,
+	sources,
+	prettierConfigOverride,
+}: {
+	readonly input: string;
+	readonly targetFileName: string;
+	readonly targetSequenceNodePath: SequenceNodePath;
+	readonly type: EffectClipboardPasteType;
+	readonly sources: EffectClipboardSource[];
+	readonly prettierConfigOverride?: Record<string, unknown> | null;
+}): Promise<{
+	readonly output: string;
+	readonly formatted: boolean;
+	readonly effectLabels: string[];
+	readonly logLine: number;
+}> => {
+	const ast = parseAst(input);
+	const copied = sources.map((source) =>
+		getSourceEffects({source, targetFileName, ast}),
+	);
+	const effectCalls = copied.flatMap((item) => item.calls);
+	const effectLabels = copied.flatMap((item) => item.labels);
+
+	const targetJsx = findJsxElementAtNodePath(ast, targetSequenceNodePath);
+	if (!targetJsx) {
+		throw new Error(
+			'Could not find a JSX element at the specified location to paste effects',
+		);
+	}
+
+	const existingAttr = findEffectsAttr(targetJsx.attributes ?? []);
+
+	if (type === 'effects-replacing') {
+		if (existingAttr) {
+			removeEffectsAttr(targetJsx.attributes, existingAttr);
+		}
+
+		if (effectCalls.length > 0) {
+			targetJsx.attributes.push(makeEffectsAttr(makeEffectsArray(effectCalls)));
+		}
+	} else if (existingAttr) {
+		getEffectsArray(existingAttr, 'append').elements.push(
+			...(effectCalls as ArrayExpression['elements']),
+		);
+	} else if (effectCalls.length > 0) {
+		targetJsx.attributes.push(makeEffectsAttr(makeEffectsArray(effectCalls)));
+	} else {
+		throw new Error('Cannot paste effects: no effects were copied');
+	}
+
+	const finalFile = serializeAst(ast);
+	const {output, formatted} = await formatFileContent({
+		input: finalFile,
+		prettierConfigOverride,
+	});
+
+	return {
+		output,
+		formatted,
+		effectLabels,
+		logLine: targetJsx.loc?.start.line ?? 1,
+	};
+};

--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -17,6 +17,7 @@ import {insertJsxElementHandler} from './routes/insert-jsx-element';
 import {handleInstallPackage} from './routes/install-dependency';
 import {openInEditorHandler} from './routes/open-in-editor';
 import {handleOpenInFileExplorer} from './routes/open-in-file-explorer';
+import {pasteEffectsHandler} from './routes/paste-effects';
 import {projectInfoHandler} from './routes/project-info';
 import {redoHandler} from './routes/redo';
 import {registerClientRenderHandler} from './routes/register-client-render';
@@ -67,6 +68,7 @@ export const allApiRoutes: {
 	'/api/add-sequence-keyframe': addSequenceKeyframeHandler,
 	'/api/add-effect-keyframe': addEffectKeyframeHandler,
 	'/api/delete-effect': deleteEffectHandler,
+	'/api/paste-effects': pasteEffectsHandler,
 	'/api/delete-jsx-node': deleteJsxNodeHandler,
 	'/api/duplicate-jsx-node': duplicateJsxNodeHandler,
 	'/api/update-available': handleUpdate,

--- a/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
@@ -127,6 +127,7 @@ export const addEffectKeyframeHandler: ApiHandler<
 		}
 
 		return computeEffectPropStatus({
+			ast,
 			jsx,
 			effectIndex,
 			keys: getAllSchemaKeys(schema),

--- a/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
@@ -2,6 +2,7 @@ import {readFileSync} from 'node:fs';
 import type {
 	CallExpression,
 	Expression,
+	File,
 	JSXAttribute,
 	JSXOpeningElement,
 	ObjectExpression,
@@ -55,6 +56,89 @@ const getEffectsArrayElements = (
 	return enumerateEffectArrayElements(expr);
 };
 
+const getImportedName = (specifier: {
+	readonly imported?: {
+		readonly type: string;
+		readonly name?: string;
+		readonly value?: string;
+	};
+}) => {
+	if (!specifier.imported) {
+		return null;
+	}
+
+	if (specifier.imported.type === 'Identifier') {
+		return specifier.imported.name ?? null;
+	}
+
+	return specifier.imported.value ?? null;
+};
+
+const resolveEffectImport = ({
+	ast,
+	call,
+	fallbackCallee,
+}: {
+	ast: File;
+	call: CallExpression;
+	fallbackCallee: string;
+}): {callee: string; importPath: string | null} => {
+	const {callee} = call;
+
+	if (callee.type === 'Identifier') {
+		const localName = callee.name;
+		for (const node of ast.program.body) {
+			if (node.type !== 'ImportDeclaration') {
+				continue;
+			}
+
+			const matchingSpecifier = node.specifiers?.find((specifier) => {
+				return (
+					specifier.type === 'ImportSpecifier' &&
+					specifier.local?.name === localName
+				);
+			});
+
+			if (matchingSpecifier?.type === 'ImportSpecifier') {
+				return {
+					callee: getImportedName(matchingSpecifier) ?? fallbackCallee,
+					importPath: String(node.source.value),
+				};
+			}
+		}
+	}
+
+	if (
+		callee.type === 'MemberExpression' &&
+		callee.object.type === 'Identifier' &&
+		callee.property.type === 'Identifier' &&
+		!callee.computed
+	) {
+		const namespaceName = callee.object.name;
+		for (const node of ast.program.body) {
+			if (node.type !== 'ImportDeclaration') {
+				continue;
+			}
+
+			const matchingSpecifier = node.specifiers?.find((specifier) => {
+				return (
+					specifier.type === 'ImportNamespaceSpecifier' &&
+					specifier.local?.name === namespaceName
+				);
+			});
+
+			if (matchingSpecifier) {
+				return {
+					callee: callee.property.name,
+					importPath: String(node.source.value),
+				};
+			}
+		}
+	}
+
+	return {callee: fallbackCallee, importPath: null};
+};
+
 const getPropsFromObjectExpression = ({
 	objExpr,
 	keys,
@@ -94,10 +178,12 @@ const getPropsFromObjectExpression = ({
 };
 
 export const computeEffectPropStatus = ({
+	ast,
 	jsx,
 	effectIndex,
 	keys,
 }: {
+	ast: File;
 	jsx: JSXOpeningElement;
 	effectIndex: number;
 	keys: string[];
@@ -131,6 +217,11 @@ export const computeEffectPropStatus = ({
 	}
 
 	const call: CallExpression = target.node;
+	const effectImport = resolveEffectImport({
+		ast,
+		call,
+		fallbackCallee: target.callee,
+	});
 	if (call.arguments.length === 0) {
 		const emptyProps: Record<string, CanUpdateSequencePropStatus> = {};
 		for (const key of keys) {
@@ -139,7 +230,8 @@ export const computeEffectPropStatus = ({
 
 		return {
 			canUpdate: true,
-			callee: target.callee,
+			callee: effectImport.callee,
+			importPath: effectImport.importPath,
 			effectIndex,
 			props: emptyProps,
 		};
@@ -162,7 +254,8 @@ export const computeEffectPropStatus = ({
 	return {
 		canUpdate: true,
 		effectIndex,
-		callee: target.callee,
+		callee: effectImport.callee,
+		importPath: effectImport.importPath,
 		props: resolvedProps,
 	};
 };
@@ -190,6 +283,7 @@ export const computeEffectPropsStatusesFromContent = ({
 
 	return effects.map((effect, effectIndex) =>
 		computeEffectPropStatus({
+			ast,
 			jsx,
 			effectIndex,
 			keys: keysFor(effect),

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -699,14 +699,17 @@ const getNestedPropStatus = (
 };
 
 const computeEffectsForJsx = ({
+	ast,
 	jsxElement,
 	effects,
 }: {
+	ast: File;
 	jsxElement: JSXOpeningElement;
 	effects: string[][];
 }) => {
 	return effects.map((effect, effectIndex) =>
 		computeEffectPropStatus({
+			ast,
 			jsx: jsxElement,
 			effectIndex,
 			keys: effect,
@@ -761,7 +764,7 @@ export const computeSequencePropsStatusFromContent = ({
 	}
 
 	const filteredProps = computeSequenceOnlyPropsRecord({jsxElement, keys});
-	const effectsStatuses = computeEffectsForJsx({jsxElement, effects});
+	const effectsStatuses = computeEffectsForJsx({ast, jsxElement, effects});
 
 	return {
 		canUpdate: true as const,

--- a/packages/studio-server/src/preview-server/routes/delete-keyframes.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-keyframes.ts
@@ -364,6 +364,7 @@ export const deleteKeyframes = async ({
 		}
 
 		return computeEffectPropStatus({
+			ast,
 			jsx,
 			effectIndex: keyframe.effectIndex,
 			keys: getAllSchemaKeys(keyframe.schema),

--- a/packages/studio-server/src/preview-server/routes/paste-effects.ts
+++ b/packages/studio-server/src/preview-server/routes/paste-effects.ts
@@ -29,18 +29,18 @@ export const pasteEffectsHandler: ApiHandler<
 	PasteEffectsRequest,
 	PasteEffectsResponse
 > = async ({
-	input: {targetFileName, targetSequenceNodePath, type, sources, clientId},
+	input: {targetFileName, targetSequenceNodePath, type, effects, clientId},
 	remotionRoot,
 	logLevel,
 }) => {
 	try {
-		if (sources.length === 0) {
+		if (effects.length === 0 && type !== 'effects-replacing') {
 			throw new Error('No effects were specified for pasting');
 		}
 
 		RenderInternals.Log.trace(
 			{indent: false, logLevel},
-			`[paste-effects] Received request to paste ${sources.length} effect source${sources.length === 1 ? '' : 's'} into fileName="${targetFileName}"`,
+			`[paste-effects] Received request to paste ${effects.length} effect${effects.length === 1 ? '' : 's'} into fileName="${targetFileName}"`,
 		);
 
 		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
@@ -55,7 +55,7 @@ export const pasteEffectsHandler: ApiHandler<
 			targetFileName,
 			targetSequenceNodePath: targetSequenceNodePath.nodePath,
 			type,
-			sources,
+			effects,
 		});
 
 		const effectDescription = getPastedEffectDescription(effectLabels);

--- a/packages/studio-server/src/preview-server/routes/paste-effects.ts
+++ b/packages/studio-server/src/preview-server/routes/paste-effects.ts
@@ -1,0 +1,110 @@
+import {readFileSync} from 'node:fs';
+import {RenderInternals} from '@remotion/renderer';
+import type {
+	PasteEffectsRequest,
+	PasteEffectsResponse,
+} from '@remotion/studio-shared';
+import {pasteEffects} from '../../codemods/paste-effects';
+import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
+import type {ApiHandler} from '../api-types';
+import {formatLogFileLocation} from '../format-log-file-location';
+import {
+	printUndoHint,
+	pushToUndoStack,
+	suppressUndoStackInvalidation,
+} from '../undo-stack';
+import {attrName} from './log-updates/formatting';
+import {warnAboutPrettierOnce} from './log-updates/log-update';
+
+const getPastedEffectDescription = (effectLabels: string[]): string => {
+	if (effectLabels.length === 1) {
+		return effectLabels[0];
+	}
+
+	return `${effectLabels.length} effects`;
+};
+
+export const pasteEffectsHandler: ApiHandler<
+	PasteEffectsRequest,
+	PasteEffectsResponse
+> = async ({
+	input: {targetFileName, targetSequenceNodePath, type, sources, clientId},
+	remotionRoot,
+	logLevel,
+}) => {
+	try {
+		if (sources.length === 0) {
+			throw new Error('No effects were specified for pasting');
+		}
+
+		RenderInternals.Log.trace(
+			{indent: false, logLevel},
+			`[paste-effects] Received request to paste ${sources.length} effect source${sources.length === 1 ? '' : 's'} into fileName="${targetFileName}"`,
+		);
+
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName: targetFileName,
+			action: 'modify',
+		});
+
+		const fileContents = readFileSync(absolutePath, 'utf-8');
+		const {output, formatted, effectLabels, logLine} = await pasteEffects({
+			input: fileContents,
+			targetFileName,
+			targetSequenceNodePath: targetSequenceNodePath.nodePath,
+			type,
+			sources,
+		});
+
+		const effectDescription = getPastedEffectDescription(effectLabels);
+
+		pushToUndoStack({
+			filePath: absolutePath,
+			oldContents: fileContents,
+			newContents: null,
+			logLevel,
+			remotionRoot,
+			logLine,
+			description: {
+				undoMessage: `↩️  Pasting of ${effectDescription}`,
+				redoMessage: `↪️  Pasting of ${effectDescription}`,
+			},
+			entryType: 'paste-effects',
+			suppressHmrOnFileRestore: false,
+		});
+		suppressUndoStackInvalidation(absolutePath);
+		writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
+
+		const locationLabel = formatLogFileLocation({
+			remotionRoot,
+			absolutePath,
+			line: logLine,
+		});
+		RenderInternals.Log.info(
+			{indent: false, logLevel},
+			`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Pasted ${attrName(effectDescription)}`,
+		);
+		if (!formatted) {
+			warnAboutPrettierOnce(logLevel);
+		}
+
+		RenderInternals.Log.verbose(
+			{indent: false, logLevel},
+			`[paste-effects] Wrote ${fileRelativeToRoot}${formatted ? ' (formatted)' : ''}`,
+		);
+
+		printUndoHint(logLevel);
+
+		return {
+			success: true,
+		};
+	} catch (err) {
+		return {
+			success: false,
+			reason: (err as Error).message,
+			stack: (err as Error).stack as string,
+		};
+	}
+};

--- a/packages/studio-server/src/preview-server/routes/save-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-effect-props.ts
@@ -151,6 +151,7 @@ export const saveEffectPropsHandler: ApiHandler<
 		}
 
 		return computeEffectPropStatus({
+			ast,
 			jsx,
 			effectIndex,
 			keys: getAllSchemaKeys(schema),

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -24,6 +24,7 @@ type UndoEntryType =
 	| 'keyframe-delete'
 	| 'add-effect'
 	| 'delete-effect'
+	| 'paste-effects'
 	| 'reorder-effect'
 	| 'delete-jsx-node'
 	| 'duplicate-jsx-node'
@@ -56,6 +57,7 @@ type UndoEntry = {
 	| {entryType: 'keyframe-delete'}
 	| {entryType: 'add-effect'}
 	| {entryType: 'delete-effect'}
+	| {entryType: 'paste-effects'}
 	| {entryType: 'reorder-effect'}
 	| {entryType: 'delete-jsx-node'}
 	| {entryType: 'duplicate-jsx-node'}

--- a/packages/studio-server/src/test/compute-effect-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-effect-props-status.test.ts
@@ -25,13 +25,15 @@ const findJsx = (input: string) => {
 		throw new Error('JSX not found');
 	}
 
-	return jsx;
+	return {ast, jsx};
 };
 
 test('computeEffectPropStatus reports static props as canUpdate=true with codeValue', () => {
 	const input = buildInput('[tint({color: "red", opacity: 0.5})]');
+	const {ast, jsx} = findJsx(input);
 	const result = computeEffectPropStatus({
-		jsx: findJsx(input),
+		ast,
+		jsx,
 		effectIndex: 0,
 		keys: ['color', 'opacity'],
 	});
@@ -43,12 +45,15 @@ test('computeEffectPropStatus reports static props as canUpdate=true with codeVa
 
 	expect(result.props.color).toEqual({canUpdate: true, codeValue: 'red'});
 	expect(result.props.opacity).toEqual({canUpdate: true, codeValue: 0.5});
+	expect(result.importPath).toBe('@remotion/effects/tint');
 });
 
 test('computeEffectPropStatus reports computed props', () => {
 	const input = buildInput('[tint({color: getColor(), opacity: 0.5})]');
+	const {ast, jsx} = findJsx(input);
 	const result = computeEffectPropStatus({
-		jsx: findJsx(input),
+		ast,
+		jsx,
 		effectIndex: 0,
 		keys: ['color', 'opacity'],
 	});
@@ -66,8 +71,10 @@ test('computeEffectPropStatus reports keyframes for inline interpolated effect p
 	const input = buildInput(
 		'[tint({amount: interpolate(frame, [0, 100], [0.2, 0.8])})]',
 	);
+	const {ast, jsx} = findJsx(input);
 	const result = computeEffectPropStatus({
-		jsx: findJsx(input),
+		ast,
+		jsx,
 		effectIndex: 0,
 		keys: ['amount'],
 	});
@@ -93,8 +100,10 @@ test('computeEffectPropStatus reports keyframes for inline interpolated effect p
 
 test('computeEffectPropStatus reports unset props as undefined codeValue', () => {
 	const input = buildInput('[tint({color: "red"})]');
+	const {ast, jsx} = findJsx(input);
 	const result = computeEffectPropStatus({
-		jsx: findJsx(input),
+		ast,
+		jsx,
 		effectIndex: 0,
 		keys: ['color', 'opacity'],
 	});
@@ -110,8 +119,10 @@ test('computeEffectPropStatus reports unset props as undefined codeValue', () =>
 
 test('computeEffectPropStatus flags non-call expressions', () => {
 	const input = buildInput('[someEffect, tint({color: "red"})]');
+	const {ast, jsx} = findJsx(input);
 	const result = computeEffectPropStatus({
-		jsx: findJsx(input),
+		ast,
+		jsx,
 		effectIndex: 0,
 		keys: ['color'],
 	});
@@ -126,8 +137,10 @@ test('computeEffectPropStatus flags non-call expressions', () => {
 
 test('computeEffectPropStatus flags out-of-range effect indices', () => {
 	const input = buildInput('[tint({color: "red"})]');
+	const {ast, jsx} = findJsx(input);
 	const result = computeEffectPropStatus({
-		jsx: findJsx(input),
+		ast,
+		jsx,
 		effectIndex: 5,
 		keys: ['color'],
 	});
@@ -142,8 +155,10 @@ test('computeEffectPropStatus flags out-of-range effect indices', () => {
 
 test('computeEffectPropStatus treats non-object first arg as computed', () => {
 	const input = buildInput('[tint(getParams())]');
+	const {ast, jsx} = findJsx(input);
 	const result = computeEffectPropStatus({
-		jsx: findJsx(input),
+		ast,
+		jsx,
 		effectIndex: 0,
 		keys: ['color'],
 	});
@@ -158,8 +173,10 @@ test('computeEffectPropStatus treats non-object first arg as computed', () => {
 
 test('computeEffectPropStatus treats zero-arg effect as editable with undefined props', () => {
 	const input = buildInput('[tint()]');
+	const {ast, jsx} = findJsx(input);
 	const result = computeEffectPropStatus({
-		jsx: findJsx(input),
+		ast,
+		jsx,
 		effectIndex: 0,
 		keys: ['amount'],
 	});

--- a/packages/studio-server/src/test/paste-effects.test.ts
+++ b/packages/studio-server/src/test/paste-effects.test.ts
@@ -1,0 +1,135 @@
+import {expect, test} from 'bun:test';
+import {pasteEffects} from '../codemods/paste-effects';
+import {lineColumnToNodePath} from './test-utils';
+
+const buildInput = (
+	jsx: string,
+) => `import {HtmlInCanvas} from '@remotion/html-in-canvas';
+import {blur} from '@remotion/effects/blur';
+import {tint} from '@remotion/effects/tint';
+import {interpolate, useCurrentFrame} from 'remotion';
+
+export const Comp = () => {
+\tconst frame = useCurrentFrame();
+\treturn ${jsx};
+};
+`;
+
+const makeNodePath = (input: string, line: number) => ({
+	absolutePath: 'Comp.tsx',
+	nodePath: lineColumnToNodePath(input, line),
+	sequenceKeys: [],
+	effectKeys: [],
+});
+
+test('pasteEffects appends a copied effect to a target sequence', async () => {
+	const input = buildInput(`<>
+\t\t<HtmlInCanvas effects={[tint({color: "red"})]} />
+\t\t<HtmlInCanvas effects={[blur({radius: 5})]} />
+\t</>`);
+	const source = makeNodePath(input, 9);
+	const target = makeNodePath(input, 10);
+
+	const {output, effectLabels} = await pasteEffects({
+		input,
+		targetFileName: 'Comp.tsx',
+		targetSequenceNodePath: target.nodePath,
+		type: 'effects-additive',
+		sources: [
+			{
+				type: 'single-effect',
+				fileName: 'Comp.tsx',
+				sequenceNodePath: source,
+				effectIndex: 0,
+			},
+		],
+	});
+
+	expect(effectLabels).toEqual(['tint()']);
+	expect(output).toContain('blur({radius: 5})');
+	expect(output).toMatch(/tint\(\{color: ['"]red['"]\}\)/);
+});
+
+test('pasteEffects replaces existing effects with all copied effects', async () => {
+	const input = buildInput(`<>
+\t\t<HtmlInCanvas effects={[tint({color: "red"}), blur({radius: 10})]} />
+\t\t<HtmlInCanvas effects={[tint({color: "blue"})]} />
+\t</>`);
+	const source = makeNodePath(input, 9);
+	const target = makeNodePath(input, 10);
+
+	const {output, effectLabels} = await pasteEffects({
+		input,
+		targetFileName: 'Comp.tsx',
+		targetSequenceNodePath: target.nodePath,
+		type: 'effects-replacing',
+		sources: [
+			{
+				type: 'all-effects',
+				fileName: 'Comp.tsx',
+				sequenceNodePath: source,
+			},
+		],
+	});
+
+	expect(effectLabels).toEqual(['tint()', 'blur()']);
+	expect(output).toMatch(/color: ['"]red['"]/);
+	expect(output).toContain('radius: 10');
+	expect(output).not.toMatch(/color: ['"]blue['"]/);
+});
+
+test('pasteEffects preserves inline effect keyframes in the same file', async () => {
+	const input = buildInput(`<>
+\t\t<HtmlInCanvas
+\t\t\teffects={[tint({amount: interpolate(frame, [0, 20], [0.2, 0.8])})]}
+\t\t/>
+\t\t<HtmlInCanvas />
+\t</>`);
+	const source = makeNodePath(input, 9);
+	const target = makeNodePath(input, 12);
+
+	const {output} = await pasteEffects({
+		input,
+		targetFileName: 'Comp.tsx',
+		targetSequenceNodePath: target.nodePath,
+		type: 'effects-additive',
+		sources: [
+			{
+				type: 'single-effect',
+				fileName: 'Comp.tsx',
+				sequenceNodePath: source,
+				effectIndex: 0,
+			},
+		],
+	});
+
+	expect(output).toContain(
+		'tint({amount: interpolate(frame, [0, 20], [0.2, 0.8])})',
+	);
+});
+
+test('pasteEffects rejects cross-file pastes to avoid broken keyframe references', async () => {
+	const input = buildInput(`<>
+\t\t<HtmlInCanvas effects={[tint({color: "red"})]} />
+\t\t<HtmlInCanvas />
+\t</>`);
+	const source = makeNodePath(input, 9);
+	const target = makeNodePath(input, 10);
+
+	await expect(
+		pasteEffects({
+			input,
+			targetFileName: 'Comp.tsx',
+			targetSequenceNodePath: target.nodePath,
+			type: 'effects-additive',
+			sources: [
+				{
+					type: 'single-effect',
+					fileName: 'Other.tsx',
+					sequenceNodePath: source,
+					effectIndex: 0,
+				},
+			],
+		}),
+	).rejects.toThrow(/different source file/);
+});

--- a/packages/studio-server/src/test/paste-effects.test.ts
+++ b/packages/studio-server/src/test/paste-effects.test.ts
@@ -10,8 +10,8 @@ import {tint} from '@remotion/effects/tint';
 import {interpolate, useCurrentFrame} from 'remotion';
 
 export const Comp = () => {
-\tconst frame = useCurrentFrame();
-\treturn ${jsx};
+	const frame = useCurrentFrame();
+	return ${jsx};
 };
 `;
 
@@ -24,50 +24,50 @@ const makeNodePath = (input: string, line: number) => ({
 
 test('pasteEffects appends a copied effect to a target sequence', async () => {
 	const input = buildInput(`<>
-\t\t<HtmlInCanvas effects={[tint({color: "red"})]} />
-\t\t<HtmlInCanvas effects={[blur({radius: 5})]} />
-\t</>`);
-	const source = makeNodePath(input, 9);
-	const target = makeNodePath(input, 10);
+		<HtmlInCanvas effects={[blur({radius: 5})]} />
+	</>`);
+	const target = makeNodePath(input, 9);
 
 	const {output, effectLabels} = await pasteEffects({
 		input,
 		targetFileName: 'Comp.tsx',
 		targetSequenceNodePath: target.nodePath,
 		type: 'effects-additive',
-		sources: [
+		effects: [
 			{
-				type: 'single-effect',
-				fileName: 'Comp.tsx',
-				sequenceNodePath: source,
-				effectIndex: 0,
+				callee: 'tint',
+				importPath: '@remotion/effects/tint',
+				params: {color: 'red'},
 			},
 		],
 	});
 
 	expect(effectLabels).toEqual(['tint()']);
 	expect(output).toContain('blur({radius: 5})');
-	expect(output).toMatch(/tint\(\{color: ['"]red['"]\}\)/);
+	expect(output).toMatch(/tint\(\{\s*color: ['"]red['"],?\s*\}\)/);
 });
 
 test('pasteEffects replaces existing effects with all copied effects', async () => {
 	const input = buildInput(`<>
-\t\t<HtmlInCanvas effects={[tint({color: "red"}), blur({radius: 10})]} />
-\t\t<HtmlInCanvas effects={[tint({color: "blue"})]} />
-\t</>`);
-	const source = makeNodePath(input, 9);
-	const target = makeNodePath(input, 10);
+		<HtmlInCanvas effects={[tint({color: "blue"})]} />
+	</>`);
+	const target = makeNodePath(input, 9);
 
 	const {output, effectLabels} = await pasteEffects({
 		input,
 		targetFileName: 'Comp.tsx',
 		targetSequenceNodePath: target.nodePath,
 		type: 'effects-replacing',
-		sources: [
+		effects: [
 			{
-				type: 'all-effects',
-				fileName: 'Comp.tsx',
-				sequenceNodePath: source,
+				callee: 'tint',
+				importPath: '@remotion/effects/tint',
+				params: {color: 'red'},
+			},
+			{
+				callee: 'blur',
+				importPath: '@remotion/effects/blur',
+				params: {radius: 10},
 			},
 		],
 	});
@@ -78,58 +78,53 @@ test('pasteEffects replaces existing effects with all copied effects', async () 
 	expect(output).not.toMatch(/color: ['"]blue['"]/);
 });
 
-test('pasteEffects preserves inline effect keyframes in the same file', async () => {
+test('pasteEffects can paste after the source sequence no longer exists', async () => {
 	const input = buildInput(`<>
-\t\t<HtmlInCanvas
-\t\t\teffects={[tint({amount: interpolate(frame, [0, 20], [0.2, 0.8])})]}
-\t\t/>
-\t\t<HtmlInCanvas />
-\t</>`);
-	const source = makeNodePath(input, 9);
-	const target = makeNodePath(input, 12);
+		<HtmlInCanvas />
+	</>`);
+	const target = makeNodePath(input, 9);
 
 	const {output} = await pasteEffects({
 		input,
 		targetFileName: 'Comp.tsx',
 		targetSequenceNodePath: target.nodePath,
 		type: 'effects-additive',
-		sources: [
+		effects: [
 			{
-				type: 'single-effect',
-				fileName: 'Comp.tsx',
-				sequenceNodePath: source,
-				effectIndex: 0,
+				callee: 'tint',
+				importPath: '@remotion/effects/tint',
+				params: {amount: 0.8},
 			},
 		],
 	});
 
-	expect(output).toContain(
-		'tint({amount: interpolate(frame, [0, 20], [0.2, 0.8])})',
-	);
+	expect(output).toMatch(/tint\(\{\s*amount: 0.8,?\s*\}\)/);
 });
 
-test('pasteEffects rejects cross-file pastes to avoid broken keyframe references', async () => {
+test('pasteEffects inserts imports for copied effects', async () => {
 	const input = buildInput(`<>
-\t\t<HtmlInCanvas effects={[tint({color: "red"})]} />
-\t\t<HtmlInCanvas />
-\t</>`);
-	const source = makeNodePath(input, 9);
-	const target = makeNodePath(input, 10);
+		<HtmlInCanvas />
+	</>`);
+	const inputWithoutTintImport = input.replace(
+		"import {tint} from '@remotion/effects/tint';\n",
+		'',
+	);
+	const target = makeNodePath(inputWithoutTintImport, 8);
 
-	await expect(
-		pasteEffects({
-			input,
-			targetFileName: 'Comp.tsx',
-			targetSequenceNodePath: target.nodePath,
-			type: 'effects-additive',
-			sources: [
-				{
-					type: 'single-effect',
-					fileName: 'Other.tsx',
-					sequenceNodePath: source,
-					effectIndex: 0,
-				},
-			],
-		}),
-	).rejects.toThrow(/different source file/);
+	const {output} = await pasteEffects({
+		input: inputWithoutTintImport,
+		targetFileName: 'Comp.tsx',
+		targetSequenceNodePath: target.nodePath,
+		type: 'effects-additive',
+		effects: [
+			{
+				callee: 'tint',
+				importPath: '@remotion/effects/tint',
+				params: {color: 'red'},
+			},
+		],
+	});
+
+	expect(output).toContain("import {tint} from '@remotion/effects/tint';");
+	expect(output).toMatch(/tint\(\{\s*color: ['"]red['"],?\s*\}\)/);
 });

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -22,6 +22,10 @@ import type {
 	SequenceSchema,
 } from 'remotion';
 import type {RecastCodemod, VisualControlChange} from './codemods';
+import type {
+	EffectClipboardPasteType,
+	EffectClipboardSource,
+} from './effect-clipboard-data';
 import type {PackageManager} from './package-manager';
 import type {ProjectInfo} from './project-info';
 import type {
@@ -435,6 +439,24 @@ export type DeleteEffectResponse =
 			stack: string;
 	  };
 
+export type PasteEffectsRequest = {
+	targetFileName: string;
+	targetSequenceNodePath: SequencePropsSubscriptionKey;
+	type: EffectClipboardPasteType;
+	sources: EffectClipboardSource[];
+	clientId: string;
+};
+
+export type PasteEffectsResponse =
+	| {
+			success: true;
+	  }
+	| {
+			success: false;
+			reason: string;
+			stack: string;
+	  };
+
 export type DeleteJsxNodeRequestItem = {
 	fileName: string;
 	nodePath: SequenceNodePath;
@@ -600,6 +622,7 @@ export type ApiRoutes = {
 		AddEffectKeyframeResponse
 	>;
 	'/api/delete-effect': ReqAndRes<DeleteEffectRequest, DeleteEffectResponse>;
+	'/api/paste-effects': ReqAndRes<PasteEffectsRequest, PasteEffectsResponse>;
 	'/api/delete-jsx-node': ReqAndRes<
 		DeleteJsxNodeRequest,
 		DeleteJsxNodeResponse

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -24,7 +24,7 @@ import type {
 import type {RecastCodemod, VisualControlChange} from './codemods';
 import type {
 	EffectClipboardPasteType,
-	EffectClipboardSource,
+	EffectClipboardSnapshot,
 } from './effect-clipboard-data';
 import type {PackageManager} from './package-manager';
 import type {ProjectInfo} from './project-info';
@@ -443,7 +443,7 @@ export type PasteEffectsRequest = {
 	targetFileName: string;
 	targetSequenceNodePath: SequencePropsSubscriptionKey;
 	type: EffectClipboardPasteType;
-	sources: EffectClipboardSource[];
+	effects: EffectClipboardSnapshot[];
 	clientId: string;
 };
 

--- a/packages/studio-shared/src/effect-clipboard-data.ts
+++ b/packages/studio-shared/src/effect-clipboard-data.ts
@@ -1,6 +1,3 @@
-export const EFFECT_CLIPBOARD_MIME_TYPE =
-	'application/vnd.remotion.effects-clipboard+json';
-
 export type EffectClipboardPasteType = 'effects-additive' | 'effects-replacing';
 
 export type EffectClipboardSnapshot = {

--- a/packages/studio-shared/src/effect-clipboard-data.ts
+++ b/packages/studio-shared/src/effect-clipboard-data.ts
@@ -1,0 +1,118 @@
+import type {SequencePropsSubscriptionKey} from 'remotion';
+
+export const EFFECT_CLIPBOARD_MIME_TYPE =
+	'application/vnd.remotion.effects-clipboard+json';
+
+export type EffectClipboardPasteType = 'effects-additive' | 'effects-replacing';
+
+export type EffectClipboardSource = {
+	readonly fileName: string;
+	readonly sequenceNodePath: SequencePropsSubscriptionKey;
+} & (
+	| {
+			readonly type: 'single-effect';
+			readonly effectIndex: number;
+	  }
+	| {
+			readonly type: 'all-effects';
+	  }
+);
+
+export type EffectClipboardData = {
+	readonly type: EffectClipboardPasteType;
+	readonly version: 1;
+	readonly remotionClipboard: 'effects';
+	readonly sources: EffectClipboardSource[];
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isStringArray = (value: unknown): value is string[] => {
+	return (
+		Array.isArray(value) && value.every((item) => typeof item === 'string')
+	);
+};
+
+const isStringArrayArray = (value: unknown): value is string[][] => {
+	return Array.isArray(value) && value.every(isStringArray);
+};
+
+const isSequenceNodePath = (
+	value: unknown,
+): value is SequencePropsSubscriptionKey => {
+	if (!isRecord(value)) {
+		return false;
+	}
+
+	if (
+		typeof value.absolutePath !== 'string' ||
+		!Array.isArray(value.nodePath) ||
+		!isStringArray(value.sequenceKeys) ||
+		!isStringArrayArray(value.effectKeys)
+	) {
+		return false;
+	}
+
+	return value.nodePath.every(
+		(item) => typeof item === 'string' || typeof item === 'number',
+	);
+};
+
+const isEffectClipboardSource = (
+	value: unknown,
+): value is EffectClipboardSource => {
+	if (!isRecord(value)) {
+		return false;
+	}
+
+	if (
+		typeof value.fileName !== 'string' ||
+		!isSequenceNodePath(value.sequenceNodePath)
+	) {
+		return false;
+	}
+
+	if (value.type === 'all-effects') {
+		return true;
+	}
+
+	return (
+		value.type === 'single-effect' &&
+		typeof value.effectIndex === 'number' &&
+		Number.isInteger(value.effectIndex) &&
+		value.effectIndex >= 0
+	);
+};
+
+export const parseEffectClipboardData = (
+	value: string,
+): EffectClipboardData | null => {
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!isRecord(parsed)) {
+			return null;
+		}
+
+		if (
+			parsed.remotionClipboard !== 'effects' ||
+			parsed.version !== 1 ||
+			(parsed.type !== 'effects-additive' &&
+				parsed.type !== 'effects-replacing') ||
+			!Array.isArray(parsed.sources) ||
+			!parsed.sources.every(isEffectClipboardSource)
+		) {
+			return null;
+		}
+
+		return {
+			type: parsed.type,
+			version: 1,
+			remotionClipboard: 'effects',
+			sources: parsed.sources,
+		};
+	} catch {
+		return null;
+	}
+};

--- a/packages/studio-shared/src/effect-clipboard-data.ts
+++ b/packages/studio-shared/src/effect-clipboard-data.ts
@@ -1,88 +1,36 @@
-import type {SequencePropsSubscriptionKey} from 'remotion';
-
 export const EFFECT_CLIPBOARD_MIME_TYPE =
 	'application/vnd.remotion.effects-clipboard+json';
 
 export type EffectClipboardPasteType = 'effects-additive' | 'effects-replacing';
 
-export type EffectClipboardSource = {
-	readonly fileName: string;
-	readonly sequenceNodePath: SequencePropsSubscriptionKey;
-} & (
-	| {
-			readonly type: 'single-effect';
-			readonly effectIndex: number;
-	  }
-	| {
-			readonly type: 'all-effects';
-	  }
-);
+export type EffectClipboardSnapshot = {
+	readonly callee: string;
+	readonly importPath: string;
+	readonly params: Record<string, unknown>;
+};
 
 export type EffectClipboardData = {
 	readonly type: EffectClipboardPasteType;
-	readonly version: 1;
+	readonly version: 2;
 	readonly remotionClipboard: 'effects';
-	readonly sources: EffectClipboardSource[];
+	readonly effects: EffectClipboardSnapshot[];
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
 
-const isStringArray = (value: unknown): value is string[] => {
-	return (
-		Array.isArray(value) && value.every((item) => typeof item === 'string')
-	);
-};
-
-const isStringArrayArray = (value: unknown): value is string[][] => {
-	return Array.isArray(value) && value.every(isStringArray);
-};
-
-const isSequenceNodePath = (
+const isEffectClipboardSnapshot = (
 	value: unknown,
-): value is SequencePropsSubscriptionKey => {
+): value is EffectClipboardSnapshot => {
 	if (!isRecord(value)) {
 		return false;
 	}
 
-	if (
-		typeof value.absolutePath !== 'string' ||
-		!Array.isArray(value.nodePath) ||
-		!isStringArray(value.sequenceKeys) ||
-		!isStringArrayArray(value.effectKeys)
-	) {
-		return false;
-	}
-
-	return value.nodePath.every(
-		(item) => typeof item === 'string' || typeof item === 'number',
-	);
-};
-
-const isEffectClipboardSource = (
-	value: unknown,
-): value is EffectClipboardSource => {
-	if (!isRecord(value)) {
-		return false;
-	}
-
-	if (
-		typeof value.fileName !== 'string' ||
-		!isSequenceNodePath(value.sequenceNodePath)
-	) {
-		return false;
-	}
-
-	if (value.type === 'all-effects') {
-		return true;
-	}
-
 	return (
-		value.type === 'single-effect' &&
-		typeof value.effectIndex === 'number' &&
-		Number.isInteger(value.effectIndex) &&
-		value.effectIndex >= 0
+		typeof value.callee === 'string' &&
+		typeof value.importPath === 'string' &&
+		isRecord(value.params)
 	);
 };
 
@@ -97,20 +45,20 @@ export const parseEffectClipboardData = (
 
 		if (
 			parsed.remotionClipboard !== 'effects' ||
-			parsed.version !== 1 ||
+			parsed.version !== 2 ||
 			(parsed.type !== 'effects-additive' &&
 				parsed.type !== 'effects-replacing') ||
-			!Array.isArray(parsed.sources) ||
-			!parsed.sources.every(isEffectClipboardSource)
+			!Array.isArray(parsed.effects) ||
+			!parsed.effects.every(isEffectClipboardSnapshot)
 		) {
 			return null;
 		}
 
 		return {
 			type: parsed.type,
-			version: 1,
+			version: 2,
 			remotionClipboard: 'effects',
-			sources: parsed.sources,
+			effects: parsed.effects,
 		};
 	} catch {
 		return null;

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -78,7 +78,6 @@ export {
 export type {ApplyVisualControlCodemod, RecastCodemod} from './codemods';
 export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state-delay-in-milliseconds';
 export {
-	EFFECT_CLIPBOARD_MIME_TYPE,
 	parseEffectClipboardData,
 	type EffectClipboardData,
 	type EffectClipboardPasteType,

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -1,9 +1,9 @@
 export {splitAnsi, stripAnsi} from './ansi';
 export {
-	AddEffectRequest,
-	AddEffectResponse,
 	AddEffectKeyframeRequest,
 	AddEffectKeyframeResponse,
+	AddEffectRequest,
+	AddEffectResponse,
 	AddRenderRequest,
 	AddSequenceKeyframeRequest,
 	AddSequenceKeyframeResponse,
@@ -33,14 +33,16 @@ export {
 	DeleteStaticFileResponse,
 	DuplicateJsxNodeRequest,
 	DuplicateJsxNodeResponse,
-	InstallPackageRequest,
-	InstallPackageResponse,
-	InsertableCompositionElement,
 	InsertJsxElementRequest,
 	InsertJsxElementResponse,
+	InsertableCompositionElement,
+	InstallPackageRequest,
+	InstallPackageResponse,
 	OpenInEditorRequest,
 	OpenInEditorResponse,
 	OpenInFileExplorerRequest,
+	PasteEffectsRequest,
+	PasteEffectsResponse,
 	ProjectInfoRequest,
 	ProjectInfoResponse,
 	RedoRequest,
@@ -75,6 +77,13 @@ export {
 } from './api-requests';
 export type {ApplyVisualControlCodemod, RecastCodemod} from './codemods';
 export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state-delay-in-milliseconds';
+export {
+	EFFECT_CLIPBOARD_MIME_TYPE,
+	parseEffectClipboardData,
+	type EffectClipboardData,
+	type EffectClipboardPasteType,
+	type EffectClipboardSource,
+} from './effect-clipboard-data';
 export {
 	EFFECT_DRAG_MIME_TYPE,
 	parseEffectDragData,

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -82,7 +82,7 @@ export {
 	parseEffectClipboardData,
 	type EffectClipboardData,
 	type EffectClipboardPasteType,
-	type EffectClipboardSource,
+	type EffectClipboardSnapshot,
 } from './effect-clipboard-data';
 export {
 	EFFECT_DRAG_MIME_TYPE,

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -90,6 +90,7 @@ test('optimisticAddEffectKeyframe appends a keyframe on the target effect', () =
 				canUpdate: true,
 				effectIndex: 0,
 				callee: 'tint',
+				importPath: null,
 				props: {
 					amount: {
 						canUpdate: false,
@@ -142,6 +143,7 @@ test('optimisticAddEffectKeyframe converts a static prop to a single keyframe', 
 				canUpdate: true,
 				effectIndex: 0,
 				callee: 'tint',
+				importPath: null,
 				props: {
 					amount: {
 						canUpdate: true,

--- a/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
@@ -177,6 +177,7 @@ test('optimisticDeleteEffectKeyframe removes the matching keyframe on the target
 				canUpdate: true,
 				effectIndex: 0,
 				callee: 'tint',
+				importPath: null,
 				props: {
 					amount: {
 						canUpdate: false,
@@ -229,6 +230,7 @@ test('optimisticDeleteEffectKeyframe converts the last keyframe on the target ef
 				canUpdate: true,
 				effectIndex: 0,
 				callee: 'tint',
+				importPath: null,
 				props: {
 					amount: {
 						canUpdate: false,
@@ -292,6 +294,7 @@ test('optimisticDeleteEffectKeyframes deletes multiple keyframes in one pass', (
 				canUpdate: true,
 				effectIndex: 0,
 				callee: 'tint',
+				importPath: null,
 				props: {
 					amount: {
 						canUpdate: false,

--- a/packages/studio-shared/src/test/optimistic-update-for-effect-code-values.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-for-effect-code-values.test.ts
@@ -15,6 +15,7 @@ test('optimisticUpdateForEffectCodeValues updates the matching effect prop', () 
 					opacity: {canUpdate: true, codeValue: 0.5},
 				},
 				callee: 'tint',
+				importPath: null,
 			},
 		],
 	};
@@ -84,6 +85,7 @@ test('optimisticUpdateForEffectCodeValues applies when effect props are unset (z
 				canUpdate: true,
 				effectIndex: 0,
 				callee: 'tint',
+				importPath: null,
 				props: {
 					amount: {canUpdate: true, codeValue: undefined},
 				},

--- a/packages/studio-shared/src/test/schema-field-info.test.ts
+++ b/packages/studio-shared/src/test/schema-field-info.test.ts
@@ -58,6 +58,7 @@ test('getEffectFieldsToShow uses the active enum variant', () => {
 					{
 						canUpdate: true,
 						callee: 'halftone',
+						importPath: null,
 						effectIndex: 0,
 						props: {
 							colorMode: {canUpdate: true, codeValue: 'source'},

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -7,6 +7,7 @@ import type React from 'react';
 import {useContext, useEffect} from 'react';
 import {Internals, type SequencePropsSubscriptionKey} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {useKeybinding} from '../../helpers/use-keybinding';
 import {callApi} from '../call-api';
 import {showNotification} from '../Notifications/NotificationCenter';
@@ -28,18 +29,71 @@ const makeTargetKey = (nodePath: SequencePropsSubscriptionKey): string => {
 	});
 };
 
-const getTargetSequenceNodePath = (
+export type PasteEffectsTarget =
+	| {
+			readonly type: 'valid';
+			readonly nodePathInfo: SequenceNodePathInfo;
+	  }
+	| {
+			readonly type: 'none';
+	  }
+	| {
+			readonly type: 'multiple';
+	  }
+	| {
+			readonly type: 'unsupported';
+	  };
+
+const getTargetSequenceNodePathInfo = (
 	selection: TimelineSelection,
-): SequencePropsSubscriptionKey | null => {
+): SequenceNodePathInfo | null => {
 	if (
 		selection.type === 'sequence' ||
 		selection.type === 'sequence-effect' ||
 		selection.type === 'sequence-all-effects'
 	) {
-		return selection.nodePathInfo.sequenceSubscriptionKey;
+		return selection.nodePathInfo;
 	}
 
 	return null;
+};
+
+export const getPasteEffectsTarget = (
+	selectedItems: readonly TimelineSelection[],
+): PasteEffectsTarget => {
+	const targetNodePathInfos = selectedItems
+		.map(getTargetSequenceNodePathInfo)
+		.filter(
+			(targetNodePathInfo): targetNodePathInfo is SequenceNodePathInfo =>
+				targetNodePathInfo !== null,
+		);
+	const uniqueTargetKeys = new Set(
+		targetNodePathInfos.map((targetNodePathInfo) =>
+			makeTargetKey(targetNodePathInfo.sequenceSubscriptionKey),
+		),
+	);
+
+	if (uniqueTargetKeys.size === 0) {
+		return {type: 'none'};
+	}
+
+	if (uniqueTargetKeys.size !== 1) {
+		return {type: 'multiple'};
+	}
+
+	const [nodePathInfo] = targetNodePathInfos;
+	if (!nodePathInfo) {
+		return {type: 'none'};
+	}
+
+	if (!nodePathInfo.supportsEffects) {
+		return {type: 'unsupported'};
+	}
+
+	return {
+		type: 'valid',
+		nodePathInfo,
+	};
 };
 
 type CopyableEffectStatus = {
@@ -237,17 +291,8 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 
 						e.preventDefault();
 
-						const targetNodePaths = selectedItems
-							.map(getTargetSequenceNodePath)
-							.filter(
-								(nodePath): nodePath is SequencePropsSubscriptionKey =>
-									nodePath !== null,
-							);
-						const uniqueTargetKeys = new Set(
-							targetNodePaths.map(makeTargetKey),
-						);
-
-						if (uniqueTargetKeys.size !== 1) {
+						const target = getPasteEffectsTarget(selectedItems);
+						if (target.type === 'multiple') {
 							showNotification(
 								'Select one target sequence to paste effects',
 								3000,
@@ -255,12 +300,18 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 							return;
 						}
 
-						const [targetSequenceNodePath] = targetNodePaths;
-						if (!targetSequenceNodePath) {
+						if (target.type === 'none') {
 							showNotification('Select a sequence to paste effects onto', 3000);
 							return;
 						}
 
+						if (target.type === 'unsupported') {
+							showNotification('This sequence does not support effects', 3000);
+							return;
+						}
+
+						const {sequenceSubscriptionKey: targetSequenceNodePath} =
+							target.nodePathInfo;
 						return callApi('/api/paste-effects', {
 							targetFileName: targetSequenceNodePath.absolutePath,
 							targetSequenceNodePath,

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -1,0 +1,217 @@
+import {
+	parseEffectClipboardData,
+	type EffectClipboardData,
+	type EffectClipboardSource,
+} from '@remotion/studio-shared';
+import type React from 'react';
+import {useContext, useEffect} from 'react';
+import type {SequencePropsSubscriptionKey} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {useKeybinding} from '../../helpers/use-keybinding';
+import {callApi} from '../call-api';
+import {showNotification} from '../Notifications/NotificationCenter';
+import {
+	useCurrentTimelineSelectionStateAsRef,
+	useTimelineSelection,
+	type TimelineSelection,
+} from './TimelineSelection';
+
+const makeClipboardText = (payload: EffectClipboardData) =>
+	JSON.stringify(payload);
+
+const makeTargetKey = (nodePath: SequencePropsSubscriptionKey): string => {
+	return JSON.stringify({
+		absolutePath: nodePath.absolutePath,
+		nodePath: nodePath.nodePath,
+		sequenceKeys: nodePath.sequenceKeys,
+		effectKeys: nodePath.effectKeys,
+	});
+};
+
+const sourceFromSelection = (
+	selection: TimelineSelection,
+): EffectClipboardSource | null => {
+	if (selection.type === 'sequence-effect') {
+		const {sequenceSubscriptionKey} = selection.nodePathInfo;
+		return {
+			type: 'single-effect',
+			fileName: sequenceSubscriptionKey.absolutePath,
+			sequenceNodePath: sequenceSubscriptionKey,
+			effectIndex: selection.i,
+		};
+	}
+
+	if (selection.type === 'sequence-all-effects') {
+		const {sequenceSubscriptionKey} = selection.nodePathInfo;
+		return {
+			type: 'all-effects',
+			fileName: sequenceSubscriptionKey.absolutePath,
+			sequenceNodePath: sequenceSubscriptionKey,
+		};
+	}
+
+	return null;
+};
+
+const getTargetSequenceNodePath = (
+	selection: TimelineSelection,
+): SequencePropsSubscriptionKey | null => {
+	if (
+		selection.type === 'sequence' ||
+		selection.type === 'sequence-effect' ||
+		selection.type === 'sequence-all-effects'
+	) {
+		return selection.nodePathInfo.sequenceSubscriptionKey;
+	}
+
+	return null;
+};
+
+export const TimelineClipboardKeybindings: React.FC = () => {
+	const keybindings = useKeybinding();
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {canSelect} = useTimelineSelection();
+	const currentSelection = useCurrentTimelineSelectionStateAsRef();
+
+	useEffect(() => {
+		if (!canSelect || previewServerState.type !== 'connected') {
+			return;
+		}
+
+		const {clientId} = previewServerState;
+
+		const copy = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'c',
+			callback: (e) => {
+				const {selectedItems} = currentSelection.current;
+				if (selectedItems.length === 0) {
+					return;
+				}
+
+				const sources = selectedItems.map(sourceFromSelection);
+				if (sources.some((source) => source === null)) {
+					return;
+				}
+
+				const firstSelection = selectedItems[0];
+				const type =
+					firstSelection?.type === 'sequence-effect'
+						? 'effects-additive'
+						: firstSelection?.type === 'sequence-all-effects'
+							? 'effects-replacing'
+							: null;
+
+				if (type === null) {
+					return;
+				}
+
+				e.preventDefault();
+				navigator.clipboard
+					.writeText(
+						makeClipboardText({
+							type,
+							version: 1,
+							remotionClipboard: 'effects',
+							sources: sources as EffectClipboardSource[],
+						}),
+					)
+					.then(() => {
+						showNotification(
+							sources.length === 1
+								? 'Copied effect to clipboard'
+								: 'Copied effects to clipboard',
+							1000,
+						);
+					})
+					.catch((err) => {
+						showNotification(
+							`Could not copy effects: ${(err as Error).message}`,
+							2000,
+						);
+					});
+			},
+			commandCtrlKey: true,
+			preventDefault: false,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+
+		const paste = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'v',
+			callback: (e) => {
+				const {selectedItems} = currentSelection.current;
+				if (selectedItems.length === 0) {
+					return;
+				}
+
+				navigator.clipboard
+					.readText()
+					.then((text) => {
+						const payload = parseEffectClipboardData(text);
+						if (payload === null) {
+							return;
+						}
+
+						e.preventDefault();
+
+						const targetNodePaths = selectedItems
+							.map(getTargetSequenceNodePath)
+							.filter(
+								(nodePath): nodePath is SequencePropsSubscriptionKey =>
+									nodePath !== null,
+							);
+						const uniqueTargetKeys = new Set(
+							targetNodePaths.map(makeTargetKey),
+						);
+
+						if (uniqueTargetKeys.size !== 1) {
+							showNotification(
+								'Select one target sequence to paste effects',
+								3000,
+							);
+							return;
+						}
+
+						const [targetSequenceNodePath] = targetNodePaths;
+						if (!targetSequenceNodePath) {
+							showNotification('Select a sequence to paste effects onto', 3000);
+							return;
+						}
+
+						return callApi('/api/paste-effects', {
+							targetFileName: targetSequenceNodePath.absolutePath,
+							targetSequenceNodePath,
+							type: payload.type,
+							sources: payload.sources,
+							clientId,
+						}).then((result) => {
+							if (result.success) {
+								showNotification('Pasted effects', 2000);
+							} else {
+								showNotification(result.reason, 4000);
+							}
+						});
+					})
+					.catch((err) => {
+						showNotification(
+							`Could not paste effects: ${(err as Error).message}`,
+							3000,
+						);
+					});
+			},
+			commandCtrlKey: true,
+			preventDefault: false,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+
+		return () => {
+			copy.unregister();
+			paste.unregister();
+		};
+	}, [canSelect, currentSelection, keybindings, previewServerState]);
+
+	return null;
+};

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -1,11 +1,11 @@
 import {
 	parseEffectClipboardData,
 	type EffectClipboardData,
-	type EffectClipboardSource,
+	type EffectClipboardSnapshot,
 } from '@remotion/studio-shared';
 import type React from 'react';
 import {useContext, useEffect} from 'react';
-import type {SequencePropsSubscriptionKey} from 'remotion';
+import {Internals, type SequencePropsSubscriptionKey} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {useKeybinding} from '../../helpers/use-keybinding';
 import {callApi} from '../call-api';
@@ -28,31 +28,6 @@ const makeTargetKey = (nodePath: SequencePropsSubscriptionKey): string => {
 	});
 };
 
-const sourceFromSelection = (
-	selection: TimelineSelection,
-): EffectClipboardSource | null => {
-	if (selection.type === 'sequence-effect') {
-		const {sequenceSubscriptionKey} = selection.nodePathInfo;
-		return {
-			type: 'single-effect',
-			fileName: sequenceSubscriptionKey.absolutePath,
-			sequenceNodePath: sequenceSubscriptionKey,
-			effectIndex: selection.i,
-		};
-	}
-
-	if (selection.type === 'sequence-all-effects') {
-		const {sequenceSubscriptionKey} = selection.nodePathInfo;
-		return {
-			type: 'all-effects',
-			fileName: sequenceSubscriptionKey.absolutePath,
-			sequenceNodePath: sequenceSubscriptionKey,
-		};
-	}
-
-	return null;
-};
-
 const getTargetSequenceNodePath = (
 	selection: TimelineSelection,
 ): SequencePropsSubscriptionKey | null => {
@@ -67,11 +42,106 @@ const getTargetSequenceNodePath = (
 	return null;
 };
 
+type CopyableEffectStatus = {
+	readonly canUpdate: true;
+	readonly callee: string;
+	readonly importPath: string | null;
+	readonly props: Record<
+		string,
+		| {
+				readonly canUpdate: true;
+				readonly codeValue?: unknown;
+		  }
+		| {
+				readonly canUpdate: false;
+		  }
+	>;
+};
+
+const effectStatusToSnapshot = (
+	effect: CopyableEffectStatus,
+): EffectClipboardSnapshot | null => {
+	if (effect.importPath === null) {
+		return null;
+	}
+
+	const params: Record<string, unknown> = {};
+	for (const [key, prop] of Object.entries(effect.props)) {
+		if (!prop.canUpdate) {
+			return null;
+		}
+
+		if (prop.codeValue !== undefined) {
+			params[key] = prop.codeValue;
+		}
+	}
+
+	return {
+		callee: effect.callee,
+		importPath: effect.importPath,
+		params,
+	};
+};
+
+const getSnapshotsFromSelection = ({
+	selection,
+	codeValues,
+}: {
+	selection: TimelineSelection;
+	codeValues: React.ContextType<
+		typeof Internals.VisualModeCodeValuesContext
+	>['codeValues'];
+}): EffectClipboardSnapshot[] | null => {
+	if (
+		selection.type !== 'sequence-effect' &&
+		selection.type !== 'sequence-all-effects'
+	) {
+		return null;
+	}
+
+	const {sequenceSubscriptionKey} = selection.nodePathInfo;
+	const sequenceStatus =
+		codeValues[
+			Internals.makeSequencePropsSubscriptionKey(sequenceSubscriptionKey)
+		];
+	if (!sequenceStatus || !sequenceStatus.canUpdate) {
+		return null;
+	}
+
+	const effects =
+		selection.type === 'sequence-effect'
+			? sequenceStatus.effects.filter(
+					(effect) => effect.effectIndex === selection.i,
+				)
+			: sequenceStatus.effects;
+
+	if (selection.type === 'sequence-effect' && effects.length !== 1) {
+		return null;
+	}
+
+	const snapshots: EffectClipboardSnapshot[] = [];
+	for (const effect of effects) {
+		if (!effect.canUpdate) {
+			return null;
+		}
+
+		const snapshot = effectStatusToSnapshot(effect);
+		if (snapshot === null) {
+			return null;
+		}
+
+		snapshots.push(snapshot);
+	}
+
+	return snapshots;
+};
+
 export const TimelineClipboardKeybindings: React.FC = () => {
 	const keybindings = useKeybinding();
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {canSelect} = useTimelineSelection();
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
+	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 
 	useEffect(() => {
 		if (!canSelect || previewServerState.type !== 'connected') {
@@ -89,11 +159,6 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 					return;
 				}
 
-				const sources = selectedItems.map(sourceFromSelection);
-				if (sources.some((source) => source === null)) {
-					return;
-				}
-
 				const firstSelection = selectedItems[0];
 				const type =
 					firstSelection?.type === 'sequence-effect'
@@ -106,19 +171,35 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 					return;
 				}
 
+				const snapshots = selectedItems.flatMap((selection) => {
+					const itemSnapshots = getSnapshotsFromSelection({
+						selection,
+						codeValues,
+					});
+					return itemSnapshots ?? [null];
+				});
+				if (snapshots.some((snapshot) => snapshot === null)) {
+					e.preventDefault();
+					showNotification(
+						'Cannot copy effects because one of them contains values that cannot be copied',
+						3000,
+					);
+					return;
+				}
+
 				e.preventDefault();
 				navigator.clipboard
 					.writeText(
 						makeClipboardText({
 							type,
-							version: 1,
+							version: 2,
 							remotionClipboard: 'effects',
-							sources: sources as EffectClipboardSource[],
+							effects: snapshots as EffectClipboardSnapshot[],
 						}),
 					)
 					.then(() => {
 						showNotification(
-							sources.length === 1
+							snapshots.length === 1
 								? 'Copied effect to clipboard'
 								: 'Copied effects to clipboard',
 							1000,
@@ -184,7 +265,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 							targetFileName: targetSequenceNodePath.absolutePath,
 							targetSequenceNodePath,
 							type: payload.type,
-							sources: payload.sources,
+							effects: payload.effects,
 							clientId,
 						}).then((result) => {
 							if (result.success) {
@@ -211,7 +292,13 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 			copy.unregister();
 			paste.unregister();
 		};
-	}, [canSelect, currentSelection, keybindings, previewServerState]);
+	}, [
+		canSelect,
+		codeValues,
+		currentSelection,
+		keybindings,
+		previewServerState,
+	]);
 
 	return null;
 };

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -1,6 +1,7 @@
 import {
 	parseEffectClipboardData,
 	type EffectClipboardData,
+	type EffectClipboardPasteType,
 	type EffectClipboardSnapshot,
 } from '@remotion/studio-shared';
 import type React from 'react';
@@ -25,7 +26,6 @@ const makeTargetKey = (nodePath: SequencePropsSubscriptionKey): string => {
 		absolutePath: nodePath.absolutePath,
 		nodePath: nodePath.nodePath,
 		sequenceKeys: nodePath.sequenceKeys,
-		effectKeys: nodePath.effectKeys,
 	});
 };
 
@@ -53,6 +53,20 @@ const getTargetSequenceNodePathInfo = (
 		selection.type === 'sequence-all-effects'
 	) {
 		return selection.nodePathInfo;
+	}
+
+	return null;
+};
+
+const getCopyType = (
+	selection: TimelineSelection,
+): EffectClipboardPasteType | null => {
+	if (selection.type === 'sequence-effect') {
+		return 'effects-additive';
+	}
+
+	if (selection.type === 'sequence-all-effects') {
+		return 'effects-replacing';
 	}
 
 	return null;
@@ -214,14 +228,20 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 				}
 
 				const firstSelection = selectedItems[0];
-				const type =
-					firstSelection?.type === 'sequence-effect'
-						? 'effects-additive'
-						: firstSelection?.type === 'sequence-all-effects'
-							? 'effects-replacing'
-							: null;
+				const type = firstSelection ? getCopyType(firstSelection) : null;
 
 				if (type === null) {
+					return;
+				}
+
+				if (
+					selectedItems.some((selection) => getCopyType(selection) !== type)
+				) {
+					e.preventDefault();
+					showNotification(
+						'Cannot copy individual effects together with all effects',
+						3000,
+					);
 					return;
 				}
 

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -17,6 +17,7 @@ import type {
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
 import {useKeybinding} from '../../helpers/use-keybinding';
+import {TimelineClipboardKeybindings} from './TimelineClipboardKeybindings';
 import {TimelineDeleteKeybindings} from './TimelineDeleteKeybindings';
 
 export const TIMELINE_SELECTED_BACKGROUND = '#3B3F42';
@@ -579,6 +580,7 @@ export const TimelineSelectionProvider: React.FC<{
 		<CurrentTimelineSelectionContext.Provider value={currentSelection}>
 			<TimelineSelectionContext.Provider value={value}>
 				{children}
+				<TimelineClipboardKeybindings />
 				<TimelineDeleteKeybindings />
 			</TimelineSelectionContext.Provider>
 		</CurrentTimelineSelectionContext.Provider>

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -475,7 +475,7 @@ export const TimelineSequenceItem: React.FC<{
 		previewServerState.type === 'connected' &&
 		nodePath !== null &&
 		validatedLocation !== null &&
-		sequence.type !== 'audio';
+		sequence.controls?.supportsEffects === true;
 
 	const onEffectDragOver = useCallback(
 		(e: React.DragEvent<HTMLDivElement>) => {

--- a/packages/studio/src/helpers/calculate-timeline.ts
+++ b/packages/studio/src/helpers/calculate-timeline.ts
@@ -108,6 +108,7 @@ export const calculateTimeline = ({
 						auxiliaryKeys: [],
 						index: 0,
 						numberOfSequencesWithThisNodePath: 0,
+						supportsEffects: sequence.controls?.supportsEffects === true,
 					}
 				: null,
 		});
@@ -162,6 +163,7 @@ export const calculateTimeline = ({
 					auxiliaryKeys: track.nodePathInfo.auxiliaryKeys,
 					index,
 					numberOfSequencesWithThisNodePath: 0,
+					supportsEffects: track.nodePathInfo.supportsEffects,
 				},
 			};
 		})
@@ -182,6 +184,7 @@ export const calculateTimeline = ({
 					index: track.nodePathInfo.index,
 					numberOfSequencesWithThisNodePath:
 						nodePathIndexCounters.get(key) ?? 0,
+					supportsEffects: track.nodePathInfo.supportsEffects,
 				},
 			};
 		});

--- a/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
@@ -5,6 +5,7 @@ export type SequenceNodePathInfo = {
 	auxiliaryKeys: string[];
 	index: number;
 	numberOfSequencesWithThisNodePath: number;
+	supportsEffects: boolean;
 };
 
 type Track = {

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -83,7 +83,8 @@ export const buildTimelineTree = ({
 	codeValues: CodeValues;
 }): TimelineTreeNode[] => {
 	const roots: TimelineTreeNode[] = [];
-	const {sequenceSubscriptionKey, index, auxiliaryKeys} = nodePathInfo;
+	const {sequenceSubscriptionKey, index, auxiliaryKeys, supportsEffects} =
+		nodePathInfo;
 
 	const controlFields = getFieldsToShow({
 		schema: sequence.controls!.schema,
@@ -103,6 +104,7 @@ export const buildTimelineTree = ({
 					auxiliaryKeys: [...auxiliaryKeys, 'controls', f.key],
 					index,
 					numberOfSequencesWithThisNodePath: 0,
+					supportsEffects,
 				},
 				label: f.description ?? f.key,
 				field: f,
@@ -118,6 +120,7 @@ export const buildTimelineTree = ({
 				auxiliaryKeys: [...auxiliaryKeys, 'effects'],
 				index,
 				numberOfSequencesWithThisNodePath: 0,
+				supportsEffects,
 			},
 			label: 'Effects',
 			effectInfo: null,
@@ -136,6 +139,7 @@ export const buildTimelineTree = ({
 						auxiliaryKeys: [...auxiliaryKeys, 'effects', i.toString()],
 						index,
 						numberOfSequencesWithThisNodePath: 0,
+						supportsEffects,
 					},
 					label: effect.label,
 					effectInfo: {
@@ -156,6 +160,7 @@ export const buildTimelineTree = ({
 								],
 								index,
 								numberOfSequencesWithThisNodePath: 0,
+								supportsEffects,
 							},
 							label: f.description ?? f.key,
 							field: f,

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -18,6 +18,7 @@ const makeControls = (
 	schema: {},
 	currentRuntimeValueDotNotation: {},
 	overrideId,
+	supportsEffects: false,
 });
 
 const makeSequence = ({

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -34,19 +34,23 @@ import {
 } from '../components/Timeline/TimelineSelection';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 
-const makeKey = (nodePath: SequenceNodePath): SequencePropsSubscriptionKey => ({
+const makeKey = (
+	nodePath: SequenceNodePath,
+	effectKeys: string[][] = [],
+): SequencePropsSubscriptionKey => ({
 	absolutePath: '/project/src/Comp.tsx',
 	nodePath,
 	sequenceKeys: ['from', 'durationInFrames'],
-	effectKeys: [],
+	effectKeys,
 });
 
 const makeNodePathInfo = (
 	nodePath: SequenceNodePath,
 	auxiliaryKeys: string[],
 	supportsEffects = true,
+	effectKeys: string[][] = [],
 ): SequenceNodePathInfo => ({
-	sequenceSubscriptionKey: makeKey(nodePath),
+	sequenceSubscriptionKey: makeKey(nodePath, effectKeys),
 	auxiliaryKeys,
 	index: 0,
 	numberOfSequencesWithThisNodePath: 1,
@@ -111,6 +115,31 @@ test('pasting effects is blocked for sequences that do not support effects', () 
 	).toEqual({
 		type: 'valid',
 		nodePathInfo: supportedSequenceNodePathInfo,
+	} satisfies PasteEffectsTarget);
+});
+
+test('pasting effects treats effect selections on one sequence as one target', () => {
+	const firstEffectNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0'],
+		true,
+		[['0']],
+	);
+	const secondEffectNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '1'],
+		true,
+		[['1']],
+	);
+
+	expect(
+		getPasteEffectsTarget([
+			{type: 'sequence-effect', nodePathInfo: firstEffectNodePathInfo, i: 0},
+			{type: 'sequence-effect', nodePathInfo: secondEffectNodePathInfo, i: 1},
+		]),
+	).toEqual({
+		type: 'valid',
+		nodePathInfo: firstEffectNodePathInfo,
 	} satisfies PasteEffectsTarget);
 });
 

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -351,6 +351,7 @@ test('Backspace reset targets selected effect props', () => {
 				{
 					canUpdate: true,
 					callee: 'effect',
+					importPath: null,
 					effectIndex: 0,
 					props: {
 						intensity: {canUpdate: true, codeValue: 10},

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -19,6 +19,10 @@ import {deleteSelectedTimelineItems} from '../components/Timeline/delete-selecte
 import {isDuplicatableSequenceRowSelection} from '../components/Timeline/duplicate-selected-timeline-item';
 import {getTimelinePropResetTargets} from '../components/Timeline/reset-selected-timeline-props';
 import {
+	getPasteEffectsTarget,
+	type PasteEffectsTarget,
+} from '../components/Timeline/TimelineClipboardKeybindings';
+import {
 	ENABLE_OUTLINES,
 	getSelectableTimelineSequenceSelections,
 	getTimelineSelectionAfterInteraction,
@@ -40,11 +44,13 @@ const makeKey = (nodePath: SequenceNodePath): SequencePropsSubscriptionKey => ({
 const makeNodePathInfo = (
 	nodePath: SequenceNodePath,
 	auxiliaryKeys: string[],
+	supportsEffects = true,
 ): SequenceNodePathInfo => ({
 	sequenceSubscriptionKey: makeKey(nodePath),
 	auxiliaryKeys,
 	index: 0,
 	numberOfSequencesWithThisNodePath: 1,
+	supportsEffects,
 });
 
 const makeTimelineSequence = ({
@@ -73,6 +79,7 @@ const makeTimelineSequence = ({
 			schema,
 			currentRuntimeValueDotNotation: {},
 			overrideId: 'override',
+			supportsEffects: true,
 		},
 		refForOutline: null,
 		effects,
@@ -80,6 +87,31 @@ const makeTimelineSequence = ({
 
 test('Timeline selection should stay disabled until released publicly', () => {
 	expect(SELECTION_ENABLED).toBe(false);
+});
+
+test('pasting effects is blocked for sequences that do not support effects', () => {
+	const unsupportedSequenceNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		[],
+		false,
+	);
+	const supportedSequenceNodePathInfo = makeNodePathInfo(['body', 1], [], true);
+
+	expect(
+		getPasteEffectsTarget([
+			{type: 'sequence', nodePathInfo: unsupportedSequenceNodePathInfo},
+		]),
+	).toEqual({
+		type: 'unsupported',
+	} satisfies PasteEffectsTarget);
+	expect(
+		getPasteEffectsTarget([
+			{type: 'sequence', nodePathInfo: supportedSequenceNodePathInfo},
+		]),
+	).toEqual({
+		type: 'valid',
+		nodePathInfo: supportedSequenceNodePathInfo,
+	} satisfies PasteEffectsTarget);
 });
 
 test('Timeline top drag should not be enabled', () => {


### PR DESCRIPTION
## Summary
- Add Visual Mode clipboard payload parsing for sequence effects.
- Add Cmd/Ctrl+C and Cmd/Ctrl+V keybindings for additive/replacing effect copy-paste.
- Add a server codemod/API route that clones same-file effect AST calls, preserving inline keyframes.

## Testing
- bun test packages/studio-server/src/test/paste-effects.test.ts
- bunx turbo run make --filter=@remotion/studio-shared --filter=@remotion/studio-server --filter=@remotion/studio
- bunx turbo run lint --filter=@remotion/studio-shared --filter=@remotion/studio-server --filter=@remotion/studio
- bunx turbo run formatting --filter=@remotion/studio-shared --filter=@remotion/studio-server --filter=@remotion/studio
- bun run build
- bun run formatting

Closes #7990
