### PR TITLE
`@remotion/serverless-client`: Stabilize Lambda render completion progress

### DIFF
--- a/packages/serverless-client/src/find-output-file-in-bucket.ts
+++ b/packages/serverless-client/src/find-output-file-in-bucket.ts
@@ -1,0 +1,79 @@
+import type {CustomCredentials} from './constants';
+import {getExpectedOutName} from './expected-out-name';
+import type {ProviderSpecifics} from './provider-implementation';
+import type {RenderMetadata} from './render-metadata';
+import type {CloudProvider} from './types';
+
+export type OutputFileMetadata = {
+	url: string;
+	sizeInBytes: number | null;
+};
+
+export const findOutputFileInBucket = async <Provider extends CloudProvider>({
+	region,
+	renderMetadata,
+	bucketName,
+	customCredentials,
+	currentRegion,
+	providerSpecifics,
+	forcePathStyle,
+	requestHandler,
+}: {
+	region: Provider['region'];
+	renderMetadata: RenderMetadata<Provider>;
+	bucketName: string;
+	customCredentials: CustomCredentials<Provider> | null;
+	currentRegion: Provider['region'];
+	providerSpecifics: ProviderSpecifics<Provider>;
+	forcePathStyle: boolean;
+	requestHandler: Provider['requestHandler'] | null;
+}): Promise<OutputFileMetadata | null> => {
+	const {renderBucketName, key} = getExpectedOutName({
+		renderMetadata,
+		bucketName,
+		customCredentials,
+		bucketNamePrefix: providerSpecifics.getBucketPrefix(),
+	});
+
+	try {
+		const metadata = await providerSpecifics.headFile({
+			bucketName: renderBucketName,
+			key,
+			region,
+			customCredentials,
+			forcePathStyle,
+			requestHandler,
+		});
+
+		return {
+			url: providerSpecifics.getOutputUrl({
+				renderMetadata,
+				bucketName,
+				customCredentials,
+				currentRegion,
+			}).url,
+			sizeInBytes: metadata.ContentLength ?? null,
+		};
+	} catch (err) {
+		if ((err as Error).name === 'NotFound') {
+			return null;
+		}
+
+		if (
+			(err as Error).message === 'UnknownError' ||
+			(err as {$metadata: {httpStatusCode: number}}).$metadata
+				?.httpStatusCode === 403
+		) {
+			throw new Error(
+				`Unable to access item "${key}" from bucket "${renderBucketName}" ${
+					customCredentials?.endpoint
+						? `(S3 Endpoint = ${customCredentials?.endpoint})`
+						: ''
+				} - got a 403 error when heading the file. Check your credentials and permissions. The Lambda role must have permission for both "s3:GetObject" and "s3:ListBucket" actions.`,
+				{cause: err},
+			);
+		}
+
+		throw err;
+	}
+};

--- a/packages/serverless-client/src/index.ts
+++ b/packages/serverless-client/src/index.ts
@@ -74,6 +74,10 @@ export {
 	getCredentialsFromOutName,
 	getExpectedOutName,
 } from './expected-out-name';
+export {
+	findOutputFileInBucket,
+	type OutputFileMetadata,
+} from './find-output-file-in-bucket';
 export {formatCostsInfo} from './format-costs-info';
 export {FileNameAndSize, GetFolderFiles} from './get-files-in-folder';
 export {

--- a/packages/serverless-client/src/progress.ts
+++ b/packages/serverless-client/src/progress.ts
@@ -3,6 +3,7 @@ import {calculateChunkTimes} from './calculate-chunk-times';
 import type {CustomCredentials} from './constants';
 import {estimatePriceFromMetadata} from './estimate-price-from-bucket';
 import {getExpectedOutName} from './expected-out-name';
+import {findOutputFileInBucket} from './find-output-file-in-bucket';
 import {formatCostsInfo} from './format-costs-info';
 import {getOverallProgress} from './get-overall-progress';
 import {getOverallProgressFromStorage} from './get-overall-progress-from-storage';
@@ -249,6 +250,87 @@ export const getProgress = async <Provider extends CloudProvider>({
 	// 2. If we have no missing chunks, but the encoding is not done, even after the additional `merge` function has been spawned, we consider it timed out
 	const isBeyondTimeoutAndHasStitchTimeout =
 		Date.now() > renderMetadata.startedDate + timeoutInMilliseconds * 2 + 20000;
+
+	const shouldCheckForCompletedOutput =
+		allChunks &&
+		(isBeyondTimeoutAndHasStitchTimeout ||
+			(overallProgress.combinedFrames >= frameCount &&
+				overallProgress.timeToCombine !== null));
+
+	if (shouldCheckForCompletedOutput) {
+		const outputFile = await findOutputFileInBucket({
+			bucketName,
+			customCredentials,
+			renderMetadata,
+			region,
+			currentRegion: region,
+			providerSpecifics,
+			forcePathStyle,
+			requestHandler,
+		});
+
+		if (outputFile) {
+			const outData = getExpectedOutName({
+				renderMetadata,
+				bucketName,
+				customCredentials,
+				bucketNamePrefix: providerSpecifics.getBucketPrefix(),
+			});
+			const now = Date.now();
+			const timeToFinishChunks = calculateChunkTimes({
+				type: 'absolute-time',
+				timings: overallProgress.timings,
+			});
+
+			return {
+				framesRendered: frameCount,
+				bucket: bucketName,
+				renderSize: outputFile.sizeInBytes ?? 0,
+				chunks: renderMetadata.totalChunks,
+				cleanup: {
+					doneIn: null,
+					filesDeleted: 0,
+					minFilesToDelete: 0,
+				},
+				costs: priceFromBucket
+					? formatCostsInfo(priceFromBucket.accruedSoFar)
+					: formatCostsInfo(0),
+				currentTime: now,
+				done: true,
+				encodingStatus: {
+					framesEncoded: frameCount,
+					combinedFrames: frameCount,
+					timeToCombine: overallProgress.timeToCombine,
+				},
+				errors: errorExplanations,
+				fatalErrorEncountered: false,
+				lambdasInvoked: renderMetadata.totalChunks,
+				outputFile: outputFile.url,
+				renderId,
+				timeToFinish: now - renderMetadata.startedDate,
+				timeToFinishChunks,
+				timeToRenderFrames: overallProgress.timeToRenderFrames,
+				overallProgress: 1,
+				retriesInfo: overallProgress.retries ?? [],
+				outKey: outData.key,
+				outBucket: outData.renderBucketName,
+				mostExpensiveFrameRanges: null,
+				timeToEncode: overallProgress.timeToEncode,
+				outputSizeInBytes: outputFile.sizeInBytes ?? 0,
+				type: 'success',
+				estimatedBillingDurationInMilliseconds:
+					priceFromBucket?.estimatedBillingDurationInMilliseconds ?? null,
+				timeToCombine: overallProgress.timeToCombine,
+				combinedFrames: frameCount,
+				renderMetadata,
+				timeoutTimestamp: overallProgress.timeoutTimestamp,
+				compositionValidated: overallProgress.compositionValidated,
+				functionLaunched: overallProgress.functionLaunched,
+				serveUrlOpened: overallProgress.serveUrlOpened,
+				artifacts: overallProgress.receivedArtifact,
+			};
+		}
+	}
 
 	const allErrors: EnhancedErrorInfo[] = [
 		isBeyondTimeoutAndMissingChunks || isBeyondTimeoutAndHasStitchTimeout

--- a/packages/serverless-client/src/test/progress.test.ts
+++ b/packages/serverless-client/src/test/progress.test.ts
@@ -1,0 +1,188 @@
+import {expect, test} from 'bun:test';
+import {Readable} from 'node:stream';
+import {overallProgressKey} from '../constants';
+import {getExpectedOutName} from '../expected-out-name';
+import type {OverallRenderProgress} from '../overall-render-progress';
+import {getProgress} from '../progress';
+import type {ProviderSpecifics} from '../provider-implementation';
+import type {RenderMetadata} from '../render-metadata';
+import type {CloudProvider} from '../types';
+
+type MockProvider = CloudProvider<
+	'eu-central-1',
+	{s3Key: string; s3Url: string},
+	{},
+	'standard',
+	{}
+>;
+
+const renderId = 'test-render';
+const bucketName = 'source-bucket';
+const startedDate = Date.now() - 30000;
+
+const renderMetadata: RenderMetadata<MockProvider> = {
+	audioBitrate: null,
+	audioCodec: null,
+	codec: 'h264',
+	compositionId: 'comp',
+	deleteAfter: null,
+	dimensions: {
+		height: 1080,
+		width: 1920,
+	},
+	downloadBehavior: {type: 'play-in-browser'},
+	estimatedRenderLambdaInvokations: 2,
+	estimatedTotalLambdaInvokations: 3,
+	everyNthFrame: 1,
+	frameRange: [0, 19],
+	framesPerLambda: 10,
+	functionName: 'remotion-render-4-0-0-mem2048mb-disk512mb-120sec',
+	imageFormat: 'png',
+	inputProps: {
+		type: 'payload',
+		payload: '{}',
+	},
+	lambdaVersion: '4.0.0',
+	memorySizeInMb: 2048,
+	metadata: null,
+	muted: true,
+	numberOfGifLoops: null,
+	outName: {
+		bucketName: 'output-bucket',
+		key: 'custom-output.mp4',
+	},
+	privacy: 'private',
+	region: 'eu-central-1',
+	rendererFunctionName: 'remotion-render-4-0-0-mem2048mb-disk512mb-120sec',
+	renderId,
+	scale: 1,
+	siteId: 'site',
+	startedDate,
+	totalChunks: 2,
+	type: 'video',
+};
+
+const progress: OverallRenderProgress<MockProvider> = {
+	chunks: [0, 1],
+	combinedFrames: 20,
+	compositionValidated: startedDate + 2,
+	errors: [],
+	fatalErrorTimestamp: null,
+	framesEncoded: 20,
+	framesRendered: 20,
+	functionLaunched: startedDate,
+	lambdasInvoked: 2,
+	postRenderData: null,
+	receivedArtifact: [],
+	renderMetadata,
+	retries: [],
+	serveUrlOpened: startedDate + 1,
+	timeToCombine: 500,
+	timeToEncode: 1000,
+	timeToRenderFrames: 750,
+	timeoutTimestamp: startedDate + 120000,
+	timings: [
+		{chunk: 0, start: startedDate, rendered: startedDate + 100},
+		{chunk: 1, start: startedDate + 100, rendered: startedDate + 250},
+	],
+};
+
+const makeProviderSpecifics = ({
+	onHeadFile,
+}: {
+	onHeadFile: ProviderSpecifics<MockProvider>['headFile'];
+}): ProviderSpecifics<MockProvider> => {
+	return {
+		applyLifeCycle: () => Promise.resolve(),
+		bucketExists: () => Promise.resolve(true),
+		callFunctionAsync: () => Promise.resolve(),
+		callFunctionStreaming: () => Promise.resolve(),
+		callFunctionSync: () => Promise.reject(new Error('Not implemented')),
+		checkCredentials: () => undefined,
+		convertToServeUrl: () => 'serve-url',
+		createBucket: () => Promise.resolve(),
+		deleteFile: () => Promise.resolve(),
+		deleteFunction: () => Promise.resolve(),
+		estimatePrice: () => 0.01,
+		getAccountId: () => Promise.resolve('123456789012'),
+		getBucketPrefix: () => 'remotionlambda-',
+		getBuckets: () => Promise.resolve([]),
+		getChromiumPath: () => null,
+		getEphemeralStorageForPriceCalculation: () => 512,
+		getFunctions: () => Promise.resolve([]),
+		getLoggingUrlForMethod: () => 'logs',
+		getLoggingUrlForRendererFunction: () => 'logs',
+		getMaxNonInlinePayloadSizePerFunction: () => 0,
+		getMaxStillInlinePayloadSize: () => 0,
+		getOutputUrl: ({
+			renderMetadata: metadata,
+			customCredentials,
+			currentRegion,
+		}) => {
+			const {key, renderBucketName} = getExpectedOutName({
+				renderMetadata: metadata,
+				bucketName,
+				customCredentials,
+				bucketNamePrefix: 'remotionlambda-',
+			});
+			return {
+				key,
+				url: `https://s3.${currentRegion}.amazonaws.com/${renderBucketName}/${key}`,
+			};
+		},
+		isFlakyError: () => false,
+		listObjects: () => Promise.resolve([]),
+		parseFunctionName: () => ({
+			diskSizeInMb: 512,
+			memorySizeInMb: 2048,
+			timeoutInSeconds: 120,
+			version: '4.0.0',
+		}),
+		printLoggingHelper: false,
+		randomHash: () => 'hash',
+		readFile: ({key}) => {
+			expect(key).toBe(overallProgressKey(renderId));
+			return Promise.resolve(
+				Readable.from([Buffer.from(JSON.stringify(progress))]),
+			);
+		},
+		serverStorageProductName: () => 'S3',
+		validateDeleteAfter: () => undefined,
+		writeFile: () => Promise.resolve(),
+		headFile: onHeadFile,
+	};
+};
+
+test('getProgress treats an existing output file as finished if postRenderData was not persisted', async () => {
+	const headedFiles: {bucketName: string; key: string}[] = [];
+	const providerSpecifics = makeProviderSpecifics({
+		onHeadFile: ({bucketName: headedBucketName, key}) => {
+			headedFiles.push({bucketName: headedBucketName, key});
+			return Promise.resolve({ContentLength: 1234});
+		},
+	});
+
+	const renderProgress = await getProgress({
+		bucketName,
+		customCredentials: null,
+		expectedBucketOwner: null,
+		forcePathStyle: false,
+		functionName: renderMetadata.functionName,
+		memorySizeInMb: 2048,
+		providerSpecifics,
+		region: 'eu-central-1',
+		renderId,
+		requestHandler: null,
+		timeoutInMilliseconds: 1000,
+	});
+
+	expect(headedFiles).toEqual([
+		{bucketName: 'output-bucket', key: 'custom-output.mp4'},
+	]);
+	expect(renderProgress.done).toBe(true);
+	expect(renderProgress.outputFile).toBe(
+		'https://s3.eu-central-1.amazonaws.com/output-bucket/custom-output.mp4',
+	);
+	expect(renderProgress.outputSizeInBytes).toBe(1234);
+	expect(renderProgress.errors).toEqual([]);
+});

--- a/packages/serverless/src/find-output-file-in-bucket.ts
+++ b/packages/serverless/src/find-output-file-in-bucket.ts
@@ -1,16 +1,15 @@
 import type {
 	CloudProvider,
 	CustomCredentials,
+	OutputFileMetadata,
 	ProviderSpecifics,
 	RenderMetadata,
 } from '@remotion/serverless-client';
-import {getExpectedOutName} from '@remotion/serverless-client';
+import {findOutputFileInBucket as findOutputFileInBucketShared} from '@remotion/serverless-client';
 
-export type OutputFileMetadata = {
-	url: string;
-};
+export type {OutputFileMetadata} from '@remotion/serverless-client';
 
-export const findOutputFileInBucket = async <Provider extends CloudProvider>({
+export const findOutputFileInBucket = <Provider extends CloudProvider>({
 	region,
 	renderMetadata,
 	bucketName,
@@ -33,50 +32,14 @@ export const findOutputFileInBucket = async <Provider extends CloudProvider>({
 		throw new Error('unexpectedly did not get renderMetadata');
 	}
 
-	const {renderBucketName, key} = getExpectedOutName({
+	return findOutputFileInBucketShared({
+		region,
 		renderMetadata,
 		bucketName,
 		customCredentials,
-		bucketNamePrefix: providerSpecifics.getBucketPrefix(),
+		currentRegion,
+		providerSpecifics,
+		forcePathStyle,
+		requestHandler,
 	});
-
-	try {
-		await providerSpecifics.headFile({
-			bucketName,
-			key,
-			region,
-			customCredentials,
-			forcePathStyle,
-			requestHandler,
-		});
-		return {
-			url: providerSpecifics.getOutputUrl({
-				renderMetadata,
-				bucketName,
-				customCredentials,
-				currentRegion,
-			}).url,
-		};
-	} catch (err) {
-		if ((err as Error).name === 'NotFound') {
-			return null;
-		}
-
-		if (
-			(err as Error).message === 'UnknownError' ||
-			(err as {$metadata: {httpStatusCode: number}}).$metadata
-				.httpStatusCode === 403
-		) {
-			throw new Error(
-				`Unable to access item "${key}" from bucket "${renderBucketName}" ${
-					customCredentials?.endpoint
-						? `(S3 Endpoint = ${customCredentials?.endpoint})`
-						: ''
-				} - got a 403 error when heading the file. Check your credentials and permissions. The Lambda role must have permission for both "s3:GetObject" and "s3:ListBucket" actions.`,
-				{cause: err},
-			);
-		}
-
-		throw err;
-	}
 };

--- a/packages/serverless/src/merge-chunks.ts
+++ b/packages/serverless/src/merge-chunks.ts
@@ -148,6 +148,7 @@ export const mergeChunksAndFinishRender = async <
 		errorExplanations,
 		timeToDelete: (await cleanupProm).reduce((a, b) => Math.max(a, b), 0),
 		outputFile: {
+			sizeInBytes: outputSize,
 			url: outputUrl,
 		},
 		outputSize,

--- a/packages/serverless/src/overall-render-progress.ts
+++ b/packages/serverless/src/overall-render-progress.ts
@@ -11,6 +11,14 @@ import type {
 } from '@remotion/serverless-client';
 import {overallProgressKey} from '@remotion/serverless-client';
 
+const progressUploadAttempts = 3;
+
+const wait = (duration: number) => {
+	return new Promise<void>((resolve) => {
+		setTimeout(resolve, duration);
+	});
+};
+
 export type OverallProgressHelper<Provider extends CloudProvider> = {
 	upload: (reason: string) => Promise<void>;
 	setFrames: ({
@@ -110,21 +118,12 @@ export const makeOverallRenderProgress = <Provider extends CloudProvider>({
 		dirtyReasons.push(reason);
 	};
 
-	const runUploadLoop = async () => {
-		while (dirty) {
-			dirty = false;
-			const reasons = dirtyReasons.join(', ');
-			dirtyReasons = [];
-			const toWrite = JSON.stringify(renderProgress);
-
-			RenderInternals.Log.verbose(
-				{indent: false, logLevel},
-				`Uploading progress - ${reasons} (${toWrite.length} bytes)`,
-			);
+	const uploadWithRetries = async (body: string, reasons: string) => {
+		for (let attempt = 1; attempt <= progressUploadAttempts; attempt++) {
 			const start = Date.now();
 			try {
 				await providerSpecifics.writeFile({
-					body: toWrite,
+					body,
 					bucketName,
 					customCredentials: null,
 					downloadBehavior: null,
@@ -140,19 +139,38 @@ export const makeOverallRenderProgress = <Provider extends CloudProvider>({
 					{indent: false, logLevel},
 					`Uploaded progress in ${Date.now() - start}ms`,
 				);
-				// Space out the requests a bit
-				await new Promise<void>((resolve) => {
-					setTimeout(resolve, Math.max(0, 250 - (Date.now() - start)));
-				});
+				return;
 			} catch (err) {
-				// If an error occurs in uploading the state that contains the errors,
-				// that is unfortunate. We just log it.
+				const willRetry = attempt < progressUploadAttempts;
 				RenderInternals.Log.error(
 					{indent: false, logLevel},
-					'Error uploading progress',
+					willRetry
+						? `Error uploading progress (${reasons}), retrying (${attempt}/${progressUploadAttempts})`
+						: `Error uploading progress (${reasons})`,
 					err,
 				);
+				if (willRetry) {
+					await wait(100 * 2 ** (attempt - 1));
+				}
 			}
+		}
+	};
+
+	const runUploadLoop = async () => {
+		while (dirty) {
+			dirty = false;
+			const reasons = dirtyReasons.join(', ');
+			dirtyReasons = [];
+			const toWrite = JSON.stringify(renderProgress);
+
+			RenderInternals.Log.verbose(
+				{indent: false, logLevel},
+				`Uploading progress - ${reasons} (${toWrite.length} bytes)`,
+			);
+			const start = Date.now();
+			await uploadWithRetries(toWrite, reasons);
+			// Space out the requests a bit
+			await wait(Math.max(0, 250 - (Date.now() - start)));
 		}
 
 		uploadLoopPromise = null;

--- a/packages/serverless/src/test/overall-render-progress.test.ts
+++ b/packages/serverless/src/test/overall-render-progress.test.ts
@@ -1,0 +1,118 @@
+import {expect, test} from 'bun:test';
+import type {
+	CloudProvider,
+	PostRenderData,
+	ProviderSpecifics,
+} from '@remotion/serverless-client';
+import {makeOverallRenderProgress} from '../overall-render-progress';
+
+type MockProvider = CloudProvider<
+	'eu-central-1',
+	{s3Key: string; s3Url: string},
+	{},
+	'standard',
+	{}
+>;
+
+const makeProviderSpecifics = ({
+	writeFile,
+}: {
+	writeFile: ProviderSpecifics<MockProvider>['writeFile'];
+}): ProviderSpecifics<MockProvider> => {
+	return {
+		applyLifeCycle: () => Promise.resolve(),
+		bucketExists: () => Promise.resolve(true),
+		callFunctionAsync: () => Promise.resolve(),
+		callFunctionStreaming: () => Promise.resolve(),
+		callFunctionSync: () => Promise.reject(new Error('Not implemented')),
+		checkCredentials: () => undefined,
+		convertToServeUrl: () => 'serve-url',
+		createBucket: () => Promise.resolve(),
+		deleteFile: () => Promise.resolve(),
+		deleteFunction: () => Promise.resolve(),
+		estimatePrice: () => 0,
+		getAccountId: () => Promise.resolve('123456789012'),
+		getBucketPrefix: () => 'remotionlambda-',
+		getBuckets: () => Promise.resolve([]),
+		getChromiumPath: () => null,
+		getEphemeralStorageForPriceCalculation: () => 512,
+		getFunctions: () => Promise.resolve([]),
+		getLoggingUrlForMethod: () => 'logs',
+		getLoggingUrlForRendererFunction: () => 'logs',
+		getMaxNonInlinePayloadSizePerFunction: () => 0,
+		getMaxStillInlinePayloadSize: () => 0,
+		getOutputUrl: () => ({key: 'out.mp4', url: 'https://example.com/out.mp4'}),
+		headFile: () => Promise.resolve({}),
+		isFlakyError: () => false,
+		listObjects: () => Promise.resolve([]),
+		parseFunctionName: () => null,
+		printLoggingHelper: false,
+		randomHash: () => 'hash',
+		readFile: () => Promise.reject(new Error('Not implemented')),
+		serverStorageProductName: () => 'S3',
+		validateDeleteAfter: () => undefined,
+		writeFile,
+	};
+};
+
+const postRenderData: PostRenderData<MockProvider> = {
+	artifactProgress: [],
+	cost: {
+		currency: 'USD',
+		disclaimer: 'test',
+		estimatedCost: 0,
+		estimatedDisplayCost: '$0',
+	},
+	deleteAfter: null,
+	endTime: 1,
+	errors: [],
+	estimatedBillingDurationInMilliseconds: 1,
+	filesCleanedUp: 0,
+	mostExpensiveFrameRanges: [],
+	outputFile: 'https://example.com/out.mp4',
+	outputSize: 1,
+	renderSize: 1,
+	retriesInfo: [],
+	startTime: 0,
+	timeToCleanUp: 0,
+	timeToCombine: 1,
+	timeToEncode: 1,
+	timeToFinish: 1,
+	timeToRenderChunks: 1,
+	timeToRenderFrames: 1,
+};
+
+test('setPostRenderData retries transient progress upload failures', async () => {
+	let attempts = 0;
+	let persistedBody: string | null = null;
+	const providerSpecifics = makeProviderSpecifics({
+		writeFile: ({body}) => {
+			attempts++;
+			if (attempts < 3) {
+				return Promise.reject(new Error('Temporary progress upload failure'));
+			}
+
+			persistedBody = String(body);
+			return Promise.resolve();
+		},
+	});
+	const overallProgress = makeOverallRenderProgress({
+		bucketName: 'bucket',
+		expectedBucketOwner: '123456789012',
+		forcePathStyle: false,
+		logLevel: 'error',
+		providerSpecifics,
+		region: 'eu-central-1',
+		renderId: 'render-id',
+		timeoutTimestamp: 1,
+	});
+
+	await overallProgress.setPostRenderData(postRenderData);
+
+	expect(attempts).toBe(3);
+	if (persistedBody === null) {
+		throw new Error('Expected progress to be persisted');
+	}
+
+	expect(JSON.parse(persistedBody).postRenderData).toEqual(postRenderData);
+});


### PR DESCRIPTION
## Summary

- Retry Lambda overall progress uploads so transient storage failures do not immediately drop progress updates
- Let `getProgress()` recover completed renders by checking the output object when all chunks are done but `postRenderData` is missing
- Share output-object lookup between serverless and serverless-client, including custom output bucket handling

## Testing

- `bun run build`
- `bun run formatting`
