### PR TITLE
`@remotion/studio-server`: Make nodePath ignore top-level imports

### DIFF
--- a/packages/studio-server/src/helpers/get-ast-node-path.ts
+++ b/packages/studio-server/src/helpers/get-ast-node-path.ts
@@ -1,13 +1,19 @@
 import type {File} from '@babel/types';
 import * as recast from 'recast';
 import type {SequenceNodePath} from 'remotion';
+import {fromImportAgnosticNodePath} from './import-agnostic-node-path';
 
 export const getAstNodePath = (
 	ast: File,
 	nodePath: SequenceNodePath,
 ): recast.types.NodePath | null => {
+	const resolvedNodePath = fromImportAgnosticNodePath({ast, nodePath});
+	if (!resolvedNodePath) {
+		return null;
+	}
+
 	let current = new recast.types.NodePath(ast);
-	for (const segment of nodePath) {
+	for (const segment of resolvedNodePath) {
 		current = current.get(segment);
 		if (current.value === null || current.value === undefined) {
 			return null;

--- a/packages/studio-server/src/helpers/import-agnostic-node-path.ts
+++ b/packages/studio-server/src/helpers/import-agnostic-node-path.ts
@@ -1,0 +1,106 @@
+import type {File, Statement} from '@babel/types';
+import type {SequenceNodePath} from 'remotion';
+
+const getActualProgramBodyIndex = ({
+	body,
+	importAgnosticIndex,
+}: {
+	body: Statement[];
+	importAgnosticIndex: number;
+}): number | null => {
+	let seenNonImports = 0;
+	for (let i = 0; i < body.length; i++) {
+		if (body[i].type === 'ImportDeclaration') {
+			continue;
+		}
+
+		if (seenNonImports === importAgnosticIndex) {
+			return i;
+		}
+
+		seenNonImports++;
+	}
+
+	return null;
+};
+
+const getImportAgnosticProgramBodyIndex = ({
+	body,
+	actualIndex,
+}: {
+	body: Statement[];
+	actualIndex: number;
+}): number | null => {
+	if (actualIndex < 0 || actualIndex >= body.length) {
+		return null;
+	}
+
+	let seenNonImports = 0;
+	for (let i = 0; i <= actualIndex; i++) {
+		if (body[i].type === 'ImportDeclaration') {
+			continue;
+		}
+
+		if (i === actualIndex) {
+			return seenNonImports;
+		}
+
+		seenNonImports++;
+	}
+
+	return null;
+};
+
+const hasProgramBodyIndex = (
+	nodePath: SequenceNodePath,
+): nodePath is ['program', 'body', number, ...Array<string | number>] => {
+	return (
+		nodePath[0] === 'program' &&
+		nodePath[1] === 'body' &&
+		typeof nodePath[2] === 'number'
+	);
+};
+
+export const toImportAgnosticNodePath = ({
+	ast,
+	nodePath,
+}: {
+	ast: File;
+	nodePath: SequenceNodePath;
+}): SequenceNodePath => {
+	if (!hasProgramBodyIndex(nodePath)) {
+		return nodePath;
+	}
+
+	const importAgnosticIndex = getImportAgnosticProgramBodyIndex({
+		body: ast.program.body,
+		actualIndex: nodePath[2],
+	});
+	if (importAgnosticIndex === null) {
+		return nodePath;
+	}
+
+	return ['program', 'body', importAgnosticIndex, ...nodePath.slice(3)];
+};
+
+export const fromImportAgnosticNodePath = ({
+	ast,
+	nodePath,
+}: {
+	ast: File;
+	nodePath: SequenceNodePath;
+}): SequenceNodePath | null => {
+	if (!hasProgramBodyIndex(nodePath)) {
+		return nodePath;
+	}
+
+	const actualIndex = getActualProgramBodyIndex({
+		body: ast.program.body,
+		importAgnosticIndex: nodePath[2],
+	});
+	if (actualIndex === null) {
+		return null;
+	}
+
+	return ['program', 'body', actualIndex, ...nodePath.slice(3)];
+};

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -22,6 +22,7 @@ import type {
 } from 'remotion';
 import {parseAst} from '../../codemods/parse-ast';
 import {getAstNodePath} from '../../helpers/get-ast-node-path';
+import {toImportAgnosticNodePath} from '../../helpers/import-agnostic-node-path';
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import {JsxElementNotFoundAtLocationError} from '../jsx-element-not-found-at-location-error';
 import {computeEffectPropStatus} from './can-update-effect-props';
@@ -549,6 +550,7 @@ const getPropsStatus = (
 const getNodePathForRecastPath = (
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	recastPath: any,
+	ast: File,
 ): SequenceNodePath => {
 	const segments: Array<string | number> = [];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -560,10 +562,10 @@ const getNodePathForRecastPath = (
 
 	// Recast paths start with "root" which doesn't correspond to a real AST property
 	if (segments.length > 0 && segments[0] === 'root') {
-		return segments.slice(1);
+		return toImportAgnosticNodePath({ast, nodePath: segments.slice(1)});
 	}
 
-	return segments;
+	return toImportAgnosticNodePath({ast, nodePath: segments});
 };
 
 export const findJsxElementAtNodePath = (
@@ -591,7 +593,7 @@ export const findNodePathForJsxElement = (
 	recast.types.visit(ast, {
 		visitJSXOpeningElement(p) {
 			if (p.node === target) {
-				foundPath = getNodePathForRecastPath(p);
+				foundPath = getNodePathForRecastPath(p, ast);
 				return false;
 			}
 
@@ -612,7 +614,7 @@ export const lineColumnToNodePath = (
 		visitJSXOpeningElement(p) {
 			const {node} = p;
 			if (node.loc && node.loc.start.line === targetLine) {
-				foundPath = getNodePathForRecastPath(p);
+				foundPath = getNodePathForRecastPath(p, ast);
 				return false;
 			}
 

--- a/packages/studio-server/src/test/add-effect.test.ts
+++ b/packages/studio-server/src/test/add-effect.test.ts
@@ -76,6 +76,35 @@ export const Comp = () => {
 	expect(output).toContain('brightnessEffect({');
 });
 
+test('addEffect keeps nodePath stable when a new import gets inserted', async () => {
+	const input = buildInput('<Solid width={100} height={100} />');
+	const nodePath = lineColumnToNodePath(input, 4);
+	const firstPass = await addEffect({
+		input,
+		sequenceNodePath: nodePath,
+		effectName: 'brightness',
+		effectImportPath: '@remotion/effects/brightness',
+		effectConfig: {amount: 0.5},
+	});
+
+	const secondPass = await addEffect({
+		input: firstPass.output,
+		sequenceNodePath: nodePath,
+		effectName: 'contrast',
+		effectImportPath: '@remotion/effects/contrast',
+		effectConfig: {amount: 1.2},
+	});
+
+	expect(secondPass.output).toContain('brightness({');
+	expect(secondPass.output).toContain('contrast({');
+	expect(secondPass.output).toContain(
+		"import {brightness} from '@remotion/effects/brightness';",
+	);
+	expect(secondPass.output).toContain(
+		"import {contrast} from '@remotion/effects/contrast';",
+	);
+});
+
 test('addEffect rejects non-Remotion effect imports', async () => {
 	const input = buildInput('<Solid width={100} height={100} />');
 


### PR DESCRIPTION
## Summary
- make `SequenceNodePath` import-agnostic for top-level `program.body` indexing
- apply the mapping in both directions: nodePath calculation and nodePath traversal
- add a regression test that reuses the same nodePath after inserting a new effect import

Fixes #7956