### PR TITLE
`remotion`: Split rotation schema types

### DIFF
--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -17,10 +17,19 @@ export type BooleanFieldSchema = {
 	description?: string;
 };
 
-export type RotationFieldSchema = {
-	type: 'rotation';
+export type RotationCssFieldSchema = {
+	type: 'rotation-css';
 	step?: number;
 	default: string | undefined;
+	description?: string;
+};
+
+export type RotationDegreesFieldSchema = {
+	type: 'rotation-degrees';
+	min?: number;
+	max?: number;
+	step?: number;
+	default: number | undefined;
 	description?: string;
 };
 
@@ -65,7 +74,8 @@ export type EnumFieldSchema = {
 export type VisibleFieldSchema =
 	| NumberFieldSchema
 	| BooleanFieldSchema
-	| RotationFieldSchema
+	| RotationCssFieldSchema
+	| RotationDegreesFieldSchema
 	| TranslateFieldSchema
 	| ScaleFieldSchema
 	| UvCoordinateFieldSchema
@@ -97,7 +107,7 @@ export const sequenceVisualStyleSchema = {
 		description: 'Scale',
 	},
 	'style.rotate': {
-		type: 'rotation',
+		type: 'rotation-css',
 		step: 1,
 		default: '0deg',
 		description: 'Rotation',

--- a/packages/docs/components/effects-demos/get-default-props-from-schema.ts
+++ b/packages/docs/components/effects-demos/get-default-props-from-schema.ts
@@ -1,4 +1,8 @@
-import {Internals, type SequenceFieldSchema, type SequenceSchema} from 'remotion';
+import {
+	Internals,
+	type SequenceFieldSchema,
+	type SequenceSchema,
+} from 'remotion';
 
 const shouldSkipField = (key: string, field: SequenceFieldSchema): boolean => {
 	return field.type === 'hidden' || key === 'disabled';
@@ -23,8 +27,12 @@ export const getDefaultValueFromSchema = (
 		return '#000000';
 	}
 
-	if (field.type === 'rotation') {
+	if (field.type === 'rotation-css') {
 		return '0deg';
+	}
+
+	if (field.type === 'rotation-degrees') {
+		return 0;
 	}
 
 	if (field.type === 'translate') {
@@ -49,7 +57,10 @@ export const fillSchemaDefaults = ({
 
 	for (let i = 0; i < 10; i++) {
 		let changed = false;
-		const activeSchema = Internals.flattenActiveSchema(schema, (key) => next[key]);
+		const activeSchema = Internals.flattenActiveSchema(
+			schema,
+			(key) => next[key],
+		);
 
 		for (const [key, field] of Object.entries(activeSchema)) {
 			if (shouldSkipField(key, field) || next[key] !== undefined) {

--- a/packages/docs/components/effects-demos/schema-control.tsx
+++ b/packages/docs/components/effects-demos/schema-control.tsx
@@ -1,7 +1,7 @@
 import React, {useMemo} from 'react';
 import type {SequenceFieldSchema} from 'remotion';
-import {getDefaultValueFromSchema} from './get-default-props-from-schema';
 import styles from '../demos/styles.module.css';
+import {getDefaultValueFromSchema} from './get-default-props-from-schema';
 
 const left: React.CSSProperties = {
 	fontFamily: 'GTPlanar',
@@ -23,7 +23,10 @@ const right: React.CSSProperties = {
 
 const getNumberValue = (
 	value: unknown,
-	field: Extract<SequenceFieldSchema, {type: 'number'}>,
+	field: Extract<
+		SequenceFieldSchema,
+		{type: 'number'} | {type: 'rotation-degrees'}
+	>,
 ): number => {
 	if (typeof value === 'number') {
 		return value;
@@ -34,7 +37,10 @@ const getNumberValue = (
 
 const getDemoNumberRange = (
 	fieldKey: string,
-	field: Extract<SequenceFieldSchema, {type: 'number'}>,
+	field: Extract<
+		SequenceFieldSchema,
+		{type: 'number'} | {type: 'rotation-degrees'}
+	>,
 ): {min: number; max: number} | null => {
 	if (field.min !== undefined && field.max !== undefined) {
 		return {min: field.min, max: field.max};
@@ -112,12 +118,14 @@ export const SchemaControl = ({
 
 	const label = field.description ?? fieldKey;
 	const numberRange =
-		field.type === 'number' ? getDemoNumberRange(fieldKey, field) : null;
+		field.type === 'number' || field.type === 'rotation-degrees'
+			? getDemoNumberRange(fieldKey, field)
+			: null;
 
 	return (
 		<label style={labelStyle} className={styles.item}>
 			<div style={left}>{label}</div>
-			{field.type === 'number' ? (
+			{field.type === 'number' || field.type === 'rotation-degrees' ? (
 				numberRange ? (
 					<input
 						type="range"
@@ -169,7 +177,7 @@ export const SchemaControl = ({
 					/>
 				</>
 			) : null}
-			{field.type === 'number' ? (
+			{field.type === 'number' || field.type === 'rotation-degrees' ? (
 				<div style={right}>
 					<code>{getNumberValue(value, field)}</code>
 				</div>
@@ -209,7 +217,7 @@ export const SchemaControl = ({
 					onChange={(e) => setValue(e.target.value)}
 					value={getStringValue(value, getDefaultValueFromSchema(field))}
 				/>
-			) : field.type === 'rotation' || field.type === 'translate' ? (
+			) : field.type === 'rotation-css' || field.type === 'translate' ? (
 				<input
 					onChange={(e) => setValue(e.target.value)}
 					style={textInputStyle}

--- a/packages/effects/src/chromatic-aberration/index.ts
+++ b/packages/effects/src/chromatic-aberration/index.ts
@@ -27,7 +27,7 @@ const chromaticAberrationSchema = {
 		description: 'Amount',
 	},
 	angle: {
-		type: 'number',
+		type: 'rotation-degrees',
 		step: 1,
 		default: DEFAULT_CHROMATIC_ABERRATION_ANGLE,
 		description: 'Angle',

--- a/packages/effects/src/color-utils.ts
+++ b/packages/effects/src/color-utils.ts
@@ -32,7 +32,7 @@ export const brightnessAmountSchema = {
 } as const satisfies SequenceSchema['amount'];
 
 export const hueDegreesSchema = {
-	type: 'number',
+	type: 'rotation-degrees',
 	step: 1,
 	default: DEFAULT_HUE_DEGREES,
 	description: 'Degrees',

--- a/packages/effects/src/halftone.ts
+++ b/packages/effects/src/halftone.ts
@@ -34,8 +34,6 @@ export const halftoneSchema = {
 	},
 	rotation: {
 		type: 'rotation-degrees',
-		min: -180,
-		max: 180,
 		step: 1,
 		default: 0,
 		description: 'Rotation',

--- a/packages/effects/src/halftone.ts
+++ b/packages/effects/src/halftone.ts
@@ -33,7 +33,7 @@ export const halftoneSchema = {
 		description: 'Dot spacing',
 	},
 	rotation: {
-		type: 'number',
+		type: 'rotation-degrees',
 		min: -180,
 		max: 180,
 		step: 1,

--- a/packages/effects/src/lines.ts
+++ b/packages/effects/src/lines.ts
@@ -49,8 +49,6 @@ export const linesSchema = {
 	},
 	angle: {
 		type: 'rotation-degrees',
-		min: -180,
-		max: 180,
 		step: 1,
 		default: DEFAULT_ANGLE,
 		description: 'Angle',

--- a/packages/effects/src/lines.ts
+++ b/packages/effects/src/lines.ts
@@ -48,7 +48,7 @@ export const linesSchema = {
 		description: 'Gap',
 	},
 	angle: {
-		type: 'number',
+		type: 'rotation-degrees',
 		min: -180,
 		max: 180,
 		step: 1,

--- a/packages/effects/src/shine.ts
+++ b/packages/effects/src/shine.ts
@@ -25,7 +25,7 @@ const shineSchema = {
 		description: 'Progress',
 	},
 	angle: {
-		type: 'number',
+		type: 'rotation-degrees',
 		min: -180,
 		max: 180,
 		step: 1,

--- a/packages/effects/src/shine.ts
+++ b/packages/effects/src/shine.ts
@@ -26,8 +26,6 @@ const shineSchema = {
 	},
 	angle: {
 		type: 'rotation-degrees',
-		min: -180,
-		max: 180,
 		step: 1,
 		default: DEFAULT_ANGLE,
 		description: 'Angle',

--- a/packages/effects/src/waves.ts
+++ b/packages/effects/src/waves.ts
@@ -52,8 +52,6 @@ export const wavesSchema = {
 	},
 	angle: {
 		type: 'rotation-degrees',
-		min: -180,
-		max: 180,
 		step: 1,
 		default: DEFAULT_ANGLE,
 		description: 'Angle',

--- a/packages/effects/src/waves.ts
+++ b/packages/effects/src/waves.ts
@@ -51,7 +51,7 @@ export const wavesSchema = {
 		description: 'Gap',
 	},
 	angle: {
-		type: 'number',
+		type: 'rotation-degrees',
 		min: -180,
 		max: 180,
 		step: 1,

--- a/packages/effects/src/zigzag.ts
+++ b/packages/effects/src/zigzag.ts
@@ -51,8 +51,6 @@ export const zigzagSchema = {
 	},
 	angle: {
 		type: 'rotation-degrees',
-		min: -180,
-		max: 180,
 		step: 1,
 		default: DEFAULT_ANGLE,
 		description: 'Angle',

--- a/packages/effects/src/zigzag.ts
+++ b/packages/effects/src/zigzag.ts
@@ -50,7 +50,7 @@ export const zigzagSchema = {
 		description: 'Gap',
 	},
 	angle: {
-		type: 'number',
+		type: 'rotation-degrees',
 		min: -180,
 		max: 180,
 		step: 1,

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -41,7 +41,8 @@ export const SCHEMA_FIELD_ROW_HEIGHT = 22;
 const SUPPORTED_SCHEMA_TYPES = [
 	'number',
 	'boolean',
-	'rotation',
+	'rotation-css',
+	'rotation-degrees',
 	'translate',
 	'scale',
 	'uv-coordinate',

--- a/packages/studio/src/components/Timeline/TimelineRotationField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRotationField.tsx
@@ -47,25 +47,34 @@ export const TimelineRotationField: React.FC<{
 	onDragEnd,
 }) => {
 	const [dragValue, setDragValue] = useState<number | null>(null);
+	const isCssRotation = field.fieldSchema.type === 'rotation-css';
 
-	const degrees = useMemo(
-		() => parseCssRotationToDegrees(String(effectiveValue ?? '0deg')),
-		[effectiveValue],
+	const degrees = useMemo(() => {
+		if (isCssRotation) {
+			return parseCssRotationToDegrees(String(effectiveValue ?? '0deg'));
+		}
+
+		return typeof effectiveValue === 'number' ? effectiveValue : 0;
+	}, [effectiveValue, isCssRotation]);
+
+	const serializeValue = useCallback(
+		(value: number) => (isCssRotation ? `${value}deg` : value),
+		[isCssRotation],
 	);
 
 	const onValueChange = useCallback(
 		(newVal: number) => {
 			setDragValue(newVal);
-			onDragValueChange(`${newVal}deg`);
+			onDragValueChange(serializeValue(newVal));
 		},
-		[onDragValueChange],
+		[onDragValueChange, serializeValue],
 	);
 
 	const onValueChangeEnd = useCallback(
 		(newVal: number) => {
-			const newStr = `${newVal}deg`;
-			if (propStatus.canUpdate && newStr !== propStatus.codeValue) {
-				onSave(newStr).finally(() => {
+			const newValue = serializeValue(newVal);
+			if (propStatus.canUpdate && newValue !== propStatus.codeValue) {
+				onSave(newValue).finally(() => {
 					setDragValue(null);
 					onDragEnd();
 				});
@@ -74,7 +83,7 @@ export const TimelineRotationField: React.FC<{
 				onDragEnd();
 			}
 		},
-		[propStatus, onSave, onDragEnd],
+		[propStatus, onSave, onDragEnd, serializeValue],
 	);
 
 	const onTextChange = useCallback(
@@ -82,21 +91,32 @@ export const TimelineRotationField: React.FC<{
 			if (propStatus.canUpdate) {
 				const parsed = Number(newVal);
 				if (!Number.isNaN(parsed)) {
-					const newStr = `${parsed}deg`;
-					if (newStr !== propStatus.codeValue) {
+					const newValue = serializeValue(parsed);
+					if (newValue !== propStatus.codeValue) {
 						setDragValue(parsed);
-						onSave(newStr).finally(() => {
+						onSave(newValue).finally(() => {
 							setDragValue(null);
 						});
 					}
 				}
 			}
 		},
-		[propStatus, onSave],
+		[propStatus, onSave, serializeValue],
 	);
 
 	const step =
-		field.fieldSchema.type === 'rotation' ? (field.fieldSchema.step ?? 1) : 1;
+		field.fieldSchema.type === 'rotation-css' ||
+		field.fieldSchema.type === 'rotation-degrees'
+			? (field.fieldSchema.step ?? 1)
+			: 1;
+	const min =
+		field.fieldSchema.type === 'rotation-degrees'
+			? (field.fieldSchema.min ?? -Infinity)
+			: -Infinity;
+	const max =
+		field.fieldSchema.type === 'rotation-degrees'
+			? (field.fieldSchema.max ?? Infinity)
+			: Infinity;
 
 	const stepDecimals = useMemo(() => getDecimalPlaces(step), [step]);
 
@@ -120,8 +140,8 @@ export const TimelineRotationField: React.FC<{
 			onValueChange={onValueChange}
 			onValueChangeEnd={onValueChangeEnd}
 			onTextChange={onTextChange}
-			min={-Infinity}
-			max={Infinity}
+			min={min}
+			max={max}
 			step={step}
 			formatter={formatter}
 			rightAlign={false}

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -90,7 +90,10 @@ export const TimelineFieldValue: React.FC<{
 		);
 	}
 
-	if (field.typeName === 'rotation') {
+	if (
+		field.typeName === 'rotation-css' ||
+		field.typeName === 'rotation-degrees'
+	) {
 		return (
 			<span style={wrapperStyle}>
 				<TimelineRotationField

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -218,7 +218,7 @@ test('Cmd+D only duplicates selected timeline sequence rows', () => {
 test('Backspace reset targets multiple selected sequence props', () => {
 	const schema = {
 		opacity: {type: 'number', default: 1},
-		'style.rotate': {type: 'rotation', default: '0deg'},
+		'style.rotate': {type: 'rotation-css', default: '0deg'},
 	} satisfies SequenceSchema;
 	const opacityNodePathInfo = makeNodePathInfo(
 		['body', 0],


### PR DESCRIPTION
## Summary

- Split visual rotation schemas into `rotation-css` and `rotation-degrees`.

- Use `rotation-degrees` for effect degree controls while keeping CSS rotate as a string schema.
- Update Studio and docs controls to render/save the correct value shapes.



Closes #7606


## Tests

- bunx turbo run make --filter="remotion" --filter="@remotion/studio-shared" --filter="@remotion/effects" --filter="@remotion/studio"
- bun test packages/studio/src/test/timeline-selection.test.ts packages/effects/src/test/effect-params.test.ts

- bun run build

- bun run stylecheck
- bun run formatting




