### PR TITLE
`@remotion/studio`: Restore canvas resize responsiveness

### DIFF
--- a/packages/studio/src/components/CanvasIfSizeIsAvailable.tsx
+++ b/packages/studio/src/components/CanvasIfSizeIsAvailable.tsx
@@ -1,17 +1,15 @@
-import {useContext, useMemo} from 'react';
-import {Internals} from 'remotion';
+import type {Size} from '@remotion/player';
+import {useMemo} from 'react';
 import {RULER_WIDTH} from '../state/editor-rulers';
 import {CanvasOrLoading} from './CanvasOrLoading';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
 
-export const CanvasIfSizeIsAvailable: React.FC = () => {
+export const CanvasIfSizeIsAvailable: React.FC<{
+	readonly size: Size | null;
+}> = ({size}) => {
 	const rulersAreVisible = useIsRulerVisible();
-	const context = useContext(Internals.CurrentScaleContext);
 
 	const sizeWithRulersApplied = useMemo(() => {
-		const size =
-			context && context.type === 'canvas-size' ? context.canvasSize : null;
-
 		if (!rulersAreVisible) {
 			return size;
 		}
@@ -25,7 +23,7 @@ export const CanvasIfSizeIsAvailable: React.FC = () => {
 			width: size.width - RULER_WIDTH,
 			height: size.height - RULER_WIDTH,
 		};
-	}, [context, rulersAreVisible]);
+	}, [size, rulersAreVisible]);
 
 	if (!sizeWithRulersApplied) {
 		return null;

--- a/packages/studio/src/components/Editor.tsx
+++ b/packages/studio/src/components/Editor.tsx
@@ -96,6 +96,7 @@ export const Editor: React.FC<{
 									<EditorContent readOnlyStudio={readOnlyStudio}>
 										<TopPanel
 											drawRef={drawRef}
+											size={size}
 											bufferStateDelayInMilliseconds={
 												BUFFER_STATE_DELAY_IN_MILLISECONDS
 											}

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -1,3 +1,4 @@
+import type {Size} from '@remotion/player';
 import React, {useCallback, useContext, useEffect, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {useMobileLayout} from '../helpers/mobile-layout';
@@ -57,8 +58,15 @@ const TopPanelInner: React.FC<{
 	readonly readOnlyStudio: boolean;
 	readonly onMounted: () => void;
 	readonly drawRef: React.RefObject<HTMLDivElement | null>;
+	readonly size: Size | null;
 	readonly bufferStateDelayInMilliseconds: number;
-}> = ({readOnlyStudio, onMounted, drawRef, bufferStateDelayInMilliseconds}) => {
+}> = ({
+	readOnlyStudio,
+	onMounted,
+	drawRef,
+	size,
+	bufferStateDelayInMilliseconds,
+}) => {
 	const {setSidebarCollapsedState, sidebarCollapsedStateRight} =
 		useContext(SidebarContext);
 	const rulersAreVisible = useIsRulerVisible();
@@ -144,7 +152,7 @@ const TopPanelInner: React.FC<{
 							>
 								<SplitterElement sticky={null} type="flexer">
 									<div ref={drawRef} style={canvasContainerStyle}>
-										<CanvasIfSizeIsAvailable />
+										<CanvasIfSizeIsAvailable size={size} />
 									</div>
 								</SplitterElement>
 								{actualStateRight === 'expanded' ? (


### PR DESCRIPTION
## Summary
- restore Studio canvas responsiveness on browser resize by re-enabling window resize updates for the editor canvas size hook

## Testing
- bunx oxfmt src --write (packages/studio)
- bun run build
- bun run formatting

Fixes #8015
