### PR TITLE
`@remotion/studio`: Refactor code value status types

### DIFF
--- a/packages/core/src/effects/use-memoized-effects.ts
+++ b/packages/core/src/effects/use-memoized-effects.ts
@@ -57,9 +57,7 @@ const mergeOverrides = ({
 };
 
 const extractCodeOverrides = (
-	propStatus:
-		| Record<string, {canUpdate: boolean; codeValue?: unknown}>
-		| undefined,
+	propStatus: Record<string, CanUpdateSequencePropStatus> | undefined,
 ): Record<string, unknown> | null => {
 	if (!propStatus) {
 		return null;
@@ -68,7 +66,7 @@ const extractCodeOverrides = (
 	const out: Record<string, unknown> = {};
 	let hasAny = false;
 	for (const [key, status] of Object.entries(propStatus)) {
-		if (status.canUpdate) {
+		if (status.status !== 'computed') {
 			out[key] = status.codeValue;
 			hasAny = true;
 		}

--- a/packages/core/src/get-effective-visual-mode-value.ts
+++ b/packages/core/src/get-effective-visual-mode-value.ts
@@ -1,4 +1,4 @@
-import type {CanUpdaterSequencePropStatusStatic} from './use-schema';
+import type {CanUpdateSequencePropStatusStatic} from './use-schema';
 
 export const getEffectiveVisualModeValue = ({
 	codeValue,
@@ -6,7 +6,7 @@ export const getEffectiveVisualModeValue = ({
 	defaultValue,
 	shouldResortToDefaultValueIfUndefined = false,
 }: {
-	codeValue: CanUpdaterSequencePropStatusStatic;
+	codeValue: CanUpdateSequencePropStatusStatic;
 	dragOverrideValue: unknown;
 	defaultValue: unknown;
 	shouldResortToDefaultValueIfUndefined: boolean;

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -183,7 +183,7 @@ import {
 	useMediaInTimeline,
 } from './use-media-in-timeline.js';
 import type {
-	CanUpdaterSequencePropStatusStatic,
+	CanUpdateSequencePropStatusStatic,
 	CanUpdateSequencePropStatusFalse,
 	CanUpdateSequencePropStatusKeyframed,
 	GetCodeValues,
@@ -384,7 +384,7 @@ export type {
 	CanUpdateEffectPropsResponse,
 	CanUpdateEffectPropsResponseFalse,
 	CanUpdateEffectPropsResponseTrue,
-	CanUpdaterSequencePropStatusStatic,
+	CanUpdateSequencePropStatusStatic,
 	CanUpdateSequencePropsResponse,
 	CanUpdateSequencePropsResponseFalse,
 	CanUpdateSequencePropsResponseTrue,

--- a/packages/core/src/test/interpolate-keyframed-status.test.ts
+++ b/packages/core/src/test/interpolate-keyframed-status.test.ts
@@ -5,9 +5,8 @@ test('interpolates linear numeric keyframes', () => {
 	const result = interpolateKeyframedStatus({
 		frame: 30,
 		status: {
-			canUpdate: true,
+			status: 'keyframed',
 			codeValue: undefined,
-			keyframed: true,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -25,9 +24,8 @@ test('clamps when extrapolation is clamp', () => {
 	const result = interpolateKeyframedStatus({
 		frame: 120,
 		status: {
-			canUpdate: true,
+			status: 'keyframed',
 			codeValue: undefined,
-			keyframed: true,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -45,9 +43,8 @@ test('posterizes the frame before interpolating numeric keyframes', () => {
 	const result = interpolateKeyframedStatus({
 		frame: 17,
 		status: {
-			canUpdate: true,
+			status: 'keyframed',
 			codeValue: undefined,
-			keyframed: true,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -65,9 +62,8 @@ test('returns single keyframe value', () => {
 	const result = interpolateKeyframedStatus({
 		frame: 100,
 		status: {
-			canUpdate: true,
+			status: 'keyframed',
 			codeValue: undefined,
-			keyframed: true,
 			interpolationFunction: 'interpolate',
 			keyframes: [{frame: 0, value: 7}],
 			easing: [],
@@ -82,9 +78,8 @@ test('interpolates colors', () => {
 	const result = interpolateKeyframedStatus({
 		frame: 30,
 		status: {
-			canUpdate: true,
+			status: 'keyframed',
 			codeValue: undefined,
-			keyframed: true,
 			interpolationFunction: 'interpolateColors',
 			keyframes: [
 				{frame: 0, value: '#000000'},
@@ -103,9 +98,8 @@ test('posterizes the frame before interpolating color keyframes', () => {
 	const result = interpolateKeyframedStatus({
 		frame: 17,
 		status: {
-			canUpdate: true,
+			status: 'keyframed',
 			codeValue: undefined,
-			keyframed: true,
 			interpolationFunction: 'interpolateColors',
 			keyframes: [
 				{frame: 0, value: 'black'},
@@ -123,9 +117,8 @@ test('uses bezier easing', () => {
 	const result = interpolateKeyframedStatus({
 		frame: 30,
 		status: {
-			canUpdate: true,
+			status: 'keyframed',
 			codeValue: undefined,
-			keyframed: true,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -144,9 +137,8 @@ test('interpolates scale strings component-wise', () => {
 	const result = interpolateKeyframedStatus({
 		frame: 30,
 		status: {
-			canUpdate: true,
+			status: 'keyframed',
 			codeValue: undefined,
-			keyframed: true,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 2},

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -11,10 +11,9 @@ import type {
 	SequencePropsSubscriptionKey,
 } from './SequenceManager.js';
 
-export type CanUpdaterSequencePropStatusStatic = {
-	canUpdate: true;
+export type CanUpdateSequencePropStatusStatic = {
+	status: 'static';
 	codeValue: unknown;
-	keyframed: false;
 };
 
 export type CanUpdateSequencePropStatusKeyframe = {
@@ -36,14 +35,12 @@ export type CanUpdateSequencePropStatusInterpolationFunction =
 	| 'interpolateColors';
 
 export type CanUpdateSequencePropStatusComputed = {
-	canUpdate: false;
-	reason: 'computed';
+	status: 'computed';
 };
 
 export type CanUpdateSequencePropStatusKeyframed = {
-	canUpdate: true;
+	status: 'keyframed';
 	codeValue: unknown;
-	keyframed: true;
 	interpolationFunction: CanUpdateSequencePropStatusInterpolationFunction;
 	keyframes: CanUpdateSequencePropStatusKeyframe[];
 	easing: CanUpdateSequencePropStatusEasing[];
@@ -55,7 +52,7 @@ export type CanUpdateSequencePropStatusFalse =
 	CanUpdateSequencePropStatusComputed;
 
 export type CanUpdateSequencePropStatus =
-	| CanUpdaterSequencePropStatusStatic
+	| CanUpdateSequencePropStatusStatic
 	| CanUpdateSequencePropStatusKeyframed
 	| CanUpdateSequencePropStatusFalse;
 
@@ -84,7 +81,7 @@ export type GetEffectDragOverrides = (
 export const isKeyframedStatus = (
 	status: CanUpdateSequencePropStatus | null,
 ): status is CanUpdateSequencePropStatusKeyframed => {
-	return status !== null && status.canUpdate && 'keyframes' in status;
+	return status !== null && status.status === 'keyframed';
 };
 
 const findFieldInSchema = (
@@ -147,7 +144,7 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 			} else {
 				value = currentValue[key];
 			}
-		} else if (codeValueStatus.canUpdate === false) {
+		} else if (codeValueStatus.status === 'computed') {
 			value = currentValue[key];
 		} else {
 			value = getEffectiveVisualModeValue({

--- a/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
@@ -27,6 +27,11 @@ import {
 	isStaticValue,
 } from './can-update-sequence-props';
 
+const staticStatus = (codeValue: unknown): CanUpdateSequencePropStatus => ({
+	status: 'static',
+	codeValue,
+});
+
 const findEffectsAttr = (jsx: JSXOpeningElement): JSXAttribute | null => {
 	for (const attr of jsx.attributes) {
 		if (attr.type !== 'JSXAttribute') {
@@ -158,7 +163,7 @@ const getPropsFromObjectExpression = ({
 		) as ObjectProperty | undefined;
 
 		if (!prop) {
-			out[key] = {canUpdate: true, codeValue: undefined, keyframed: false};
+			out[key] = staticStatus(undefined);
 			continue;
 		}
 
@@ -169,9 +174,8 @@ const getPropsFromObjectExpression = ({
 		}
 
 		out[key] = {
-			canUpdate: true,
+			status: 'static',
 			codeValue: extractStaticValue(valueExpr),
-			keyframed: false,
 		};
 	}
 
@@ -226,11 +230,7 @@ export const computeEffectPropStatus = ({
 	if (call.arguments.length === 0) {
 		const emptyProps: Record<string, CanUpdateSequencePropStatus> = {};
 		for (const key of keys) {
-			emptyProps[key] = {
-				canUpdate: true,
-				codeValue: undefined,
-				keyframed: false,
-			};
+			emptyProps[key] = staticStatus(undefined);
 		}
 
 		return {

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -28,12 +28,21 @@ import {JsxElementNotFoundAtLocationError} from '../jsx-element-not-found-at-loc
 import {computeEffectPropStatus} from './can-update-effect-props';
 
 type CanUpdatePropStatus = CanUpdateSequencePropStatus;
-type KeyframedPropStatus = Extract<CanUpdatePropStatus, {keyframed: true}>;
+type KeyframedPropStatus = Extract<CanUpdatePropStatus, {status: 'keyframed'}>;
 type PropKeyframes = KeyframedPropStatus['keyframes'];
 type PropEasing = KeyframedPropStatus['easing'];
 type PropClamping = KeyframedPropStatus['clamping'];
 type PropPosterize = KeyframedPropStatus['posterize'];
 type PropInterpolationFunction = KeyframedPropStatus['interpolationFunction'];
+
+const staticStatus = (codeValue: unknown): CanUpdatePropStatus => ({
+	status: 'static',
+	codeValue,
+});
+
+const computedStatus = (): CanUpdatePropStatus => ({
+	status: 'computed',
+});
 
 export const isStaticValue = (node: Expression): boolean => {
 	switch (node.type) {
@@ -473,13 +482,12 @@ const getInterpolationKeyframes = (
 export const getComputedStatus = (node: Expression): CanUpdatePropStatus => {
 	const interpolation = getInterpolationKeyframes(node);
 	if (!interpolation) {
-		return {canUpdate: false, reason: 'computed'};
+		return computedStatus();
 	}
 
 	return {
-		canUpdate: true,
+		status: 'keyframed',
 		codeValue: undefined,
-		keyframed: true,
 		interpolationFunction: interpolation.interpolationFunction,
 		keyframes: interpolation.keyframes,
 		easing: interpolation.easing,
@@ -510,23 +518,19 @@ const getPropsStatus = (
 		const {value} = attr as JSXAttribute;
 
 		if (!value) {
-			props[name] = {canUpdate: true, codeValue: true, keyframed: false};
+			props[name] = staticStatus(true);
 			continue;
 		}
 
 		if (value.type === 'StringLiteral') {
-			props[name] = {
-				canUpdate: true,
-				codeValue: (value as {value: string}).value,
-				keyframed: false,
-			};
+			props[name] = staticStatus((value as {value: string}).value);
 			continue;
 		}
 
 		if (value.type === 'JSXExpressionContainer') {
 			const {expression} = value;
 			if (expression.type === 'JSXEmptyExpression') {
-				props[name] = {canUpdate: false, reason: 'computed'};
+				props[name] = computedStatus();
 				continue;
 			}
 
@@ -535,15 +539,11 @@ const getPropsStatus = (
 				continue;
 			}
 
-			props[name] = {
-				canUpdate: true,
-				codeValue: extractStaticValue(expression),
-				keyframed: false,
-			};
+			props[name] = staticStatus(extractStaticValue(expression));
 			continue;
 		}
 
-		props[name] = {canUpdate: false, reason: 'computed'};
+		props[name] = computedStatus();
 	}
 
 	return props;
@@ -660,11 +660,11 @@ const getNestedPropStatus = (
 
 	if (!attr || !attr.value) {
 		// Parent attribute doesn't exist, nested prop can be added
-		return {canUpdate: true, codeValue: undefined, keyframed: false};
+		return staticStatus(undefined);
 	}
 
 	if (attr.value.type !== 'JSXExpressionContainer') {
-		return {canUpdate: false, reason: 'computed'};
+		return computedStatus();
 	}
 
 	const {expression} = attr.value;
@@ -673,7 +673,7 @@ const getNestedPropStatus = (
 		expression.type !== 'ObjectExpression'
 	) {
 		// Parent is not an object literal (e.g. style={myStyles})
-		return {canUpdate: false, reason: 'computed'};
+		return computedStatus();
 	}
 
 	const objExpr = expression as ObjectExpression;
@@ -686,7 +686,7 @@ const getNestedPropStatus = (
 
 	if (!prop) {
 		// Property not set in the object, can be added
-		return {canUpdate: true, codeValue: undefined, keyframed: false};
+		return staticStatus(undefined);
 	}
 
 	const propValue = prop.value as Expression;
@@ -696,10 +696,10 @@ const getNestedPropStatus = (
 
 	const codeValue = extractStaticValue(propValue);
 	if (!validateStyleValue(childKey, codeValue)) {
-		return {canUpdate: false, reason: 'computed'};
+		return computedStatus();
 	}
 
-	return {canUpdate: true, codeValue, keyframed: false};
+	return staticStatus(codeValue);
 };
 
 const computeEffectsForJsx = ({
@@ -741,11 +741,7 @@ const computeSequenceOnlyPropsRecord = ({
 		} else if (key in allProps) {
 			filteredProps[key] = allProps[key];
 		} else {
-			filteredProps[key] = {
-				canUpdate: true,
-				codeValue: undefined,
-				keyframed: false,
-			};
+			filteredProps[key] = staticStatus(undefined);
 		}
 	}
 

--- a/packages/studio-server/src/test/compute-effect-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-effect-props-status.test.ts
@@ -44,14 +44,12 @@ test('computeEffectPropStatus reports static props as canUpdate=true with codeVa
 	}
 
 	expect(result.props.color).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 'red',
-		keyframed: false,
 	});
 	expect(result.props.opacity).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 0.5,
-		keyframed: false,
 	});
 	expect(result.importPath).toBe('@remotion/effects/tint');
 });
@@ -71,11 +69,10 @@ test('computeEffectPropStatus reports computed props', () => {
 		throw new Error('expected canUpdate true');
 	}
 
-	expect(result.props.color).toEqual({canUpdate: false, reason: 'computed'});
+	expect(result.props.color).toEqual({status: 'computed'});
 	expect(result.props.opacity).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 0.5,
-		keyframed: false,
 	});
 });
 
@@ -97,9 +94,8 @@ test('computeEffectPropStatus reports keyframes for inline interpolated effect p
 	}
 
 	expect(result.props.amount).toEqual({
-		canUpdate: true,
+		status: 'keyframed',
 		codeValue: undefined,
-		keyframed: true,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 0.2},
@@ -127,14 +123,12 @@ test('computeEffectPropStatus reports unset props as undefined codeValue', () =>
 	}
 
 	expect(result.props.color).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 'red',
-		keyframed: false,
 	});
 	expect(result.props.opacity).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: undefined,
-		keyframed: false,
 	});
 });
 
@@ -208,8 +202,7 @@ test('computeEffectPropStatus treats zero-arg effect as editable with undefined 
 	}
 
 	expect(result.props.amount).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: undefined,
-		keyframed: false,
 	});
 });

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -45,20 +45,17 @@ test('canUpdateSequenceProps should flag computed props', () => {
 	}
 
 	expect(result.props.durationInFrames).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 60,
-		keyframed: false,
 	});
 	expect(result.props.hueShift).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 30,
-		keyframed: false,
 	});
-	expect(result.props.seed).toEqual({canUpdate: false, reason: 'computed'});
+	expect(result.props.seed).toEqual({status: 'computed'});
 	expect(result.props.nonExistentProp).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: undefined,
-		keyframed: false,
 	});
 });
 
@@ -84,9 +81,8 @@ export const Example: React.FC = () => {
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props.color).toEqual({
-		canUpdate: true,
+		status: 'keyframed',
 		codeValue: undefined,
-		keyframed: true,
 		interpolationFunction: 'interpolateColors',
 		keyframes: [
 			{frame: 0, value: 'red'},
@@ -130,14 +126,12 @@ test('computeSequencePropsStatus should detect static nested props', () => {
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props['style.opacity']).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 0.5,
-		keyframed: false,
 	});
 	expect(result.props['style.scale']).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 2,
-		keyframed: false,
 	});
 });
 
@@ -156,14 +150,12 @@ test('computeSequencePropsStatus should flag computed nested props', () => {
 
 	// opacity uses getOpacity() — computed
 	expect(result.props['style.opacity']).toEqual({
-		canUpdate: false,
-		reason: 'computed',
+		status: 'computed',
 	});
 	// scale is static
 	expect(result.props['style.scale']).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 2,
-		keyframed: false,
 	});
 });
 
@@ -182,8 +174,7 @@ test('computeSequencePropsStatus should flag computed when parent is not an obje
 
 	// style={dynamicStyles} — entire parent is computed
 	expect(result.props['style.opacity']).toEqual({
-		canUpdate: false,
-		reason: 'computed',
+		status: 'computed',
 	});
 });
 
@@ -201,9 +192,8 @@ test('computeSequencePropsStatus should report unset nested props as undefined',
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props['style.rotate']).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: undefined,
-		keyframed: false,
 	});
 });
 
@@ -221,9 +211,8 @@ test('computeSequencePropsStatus should report unset when parent attribute missi
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props['style.opacity']).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: undefined,
-		keyframed: false,
 	});
 });
 
@@ -241,9 +230,8 @@ test('computeSequencePropsStatus should return keyframes for interpolated style 
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props['style.scale']).toEqual({
-		canUpdate: true,
+		status: 'keyframed',
 		codeValue: undefined,
-		keyframed: true,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 2},
@@ -282,9 +270,8 @@ export const Example: React.FC = () => {
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props['style.scale']).toEqual({
-		canUpdate: true,
+		status: 'keyframed',
 		codeValue: undefined,
-		keyframed: true,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 1},
@@ -323,9 +310,8 @@ export const Example: React.FC = () => {
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props['style.scale']).toEqual({
-		canUpdate: true,
+		status: 'keyframed',
 		codeValue: undefined,
-		keyframed: true,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 1},
@@ -360,9 +346,8 @@ export const Example: React.FC = () => {
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props.color).toEqual({
-		canUpdate: true,
+		status: 'keyframed',
 		codeValue: undefined,
-		keyframed: true,
 		interpolationFunction: 'interpolateColors',
 		keyframes: [
 			{frame: 0, value: 'red'},
@@ -398,8 +383,7 @@ export const Example: React.FC = () => {
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props['style.scale']).toEqual({
-		canUpdate: false,
-		reason: 'computed',
+		status: 'computed',
 	});
 });
 
@@ -428,7 +412,6 @@ export const Example: React.FC = () => {
 	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
 
 	expect(result.props['style.scale']).toEqual({
-		canUpdate: false,
-		reason: 'computed',
+		status: 'computed',
 	});
 });

--- a/packages/studio-server/src/test/unsupported-translate.test.ts
+++ b/packages/studio-server/src/test/unsupported-translate.test.ts
@@ -40,89 +40,89 @@ const getTranslateStatus = (translateValue: string) => {
 // Supported: two values in pixels
 test('Should be able to update translate if it is two pixel values', () => {
 	const status = getTranslateStatus('0px 202px');
-	expect(status.canUpdate).toBe(true);
-	assert(status.canUpdate);
+	expect(status.status).toBe('static');
+	assert(status.status === 'static');
 	expect(status.codeValue).toBe('0px 202px');
 });
 
 // Supported: single value in pixels
 test('Should be able to update translate if it is a single pixel value', () => {
 	const status = getTranslateStatus('100px');
-	expect(status.canUpdate).toBe(true);
-	assert(status.canUpdate);
+	expect(status.status).toBe('static');
+	assert(status.status === 'static');
 	expect(status.codeValue).toBe('100px');
 });
 
 test('Should be able to update translate with 0px', () => {
 	const status = getTranslateStatus('0px');
-	expect(status.canUpdate).toBe(true);
-	assert(status.canUpdate);
+	expect(status.status).toBe('static');
+	assert(status.status === 'static');
 	expect(status.codeValue).toBe('0px');
 });
 
 test('Should be able to update translate with negative pixel values', () => {
 	const status = getTranslateStatus('-50px 100px');
-	expect(status.canUpdate).toBe(true);
-	assert(status.canUpdate);
+	expect(status.status).toBe('static');
+	assert(status.status === 'static');
 	expect(status.codeValue).toBe('-50px 100px');
 });
 
 // Unsupported: three values (x, y, z)
 test('Should not support translate with three values', () => {
 	const status = getTranslateStatus('0px 100px 200px');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 // Unsupported: global CSS values
 test('Should not support translate with "inherit"', () => {
 	const status = getTranslateStatus('inherit');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 test('Should not support translate with "initial"', () => {
 	const status = getTranslateStatus('initial');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 test('Should not support translate with "unset"', () => {
 	const status = getTranslateStatus('unset');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 test('Should not support translate with "revert"', () => {
 	const status = getTranslateStatus('revert');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 test('Should not support translate with "revert-layer"', () => {
 	const status = getTranslateStatus('revert-layer');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 // Unsupported: keyword values
 test('Should not support translate with "none"', () => {
 	const status = getTranslateStatus('none');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 // Unsupported: percentage values
 test('Should not support translate with percentage values', () => {
 	const status = getTranslateStatus('50%');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 test('Should not support translate with mixed px and percentage', () => {
 	const status = getTranslateStatus('100px 50%');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 // Unsupported: other units
 test('Should not support translate with em values', () => {
 	const status = getTranslateStatus('10em');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });
 
 test('Should not support translate with rem values', () => {
 	const status = getTranslateStatus('10rem');
-	expect(status.canUpdate).toBe(false);
+	expect(status.status).toBe('computed');
 });

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -206,9 +206,8 @@ export default CenteredSolid;
 		effects: [],
 	});
 	expect(status.props.width).toEqual({
-		canUpdate: true,
+		status: 'keyframed',
 		codeValue: undefined,
-		keyframed: true,
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 11, value: 240}],
 		easing: [],
@@ -263,9 +262,8 @@ test('updateSequenceKeyframes converts the last keyframe to a static value', asy
 		effects: [],
 	});
 	expect(status.props['style.scale']).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 320,
-		keyframed: false,
 	});
 });
 
@@ -314,9 +312,8 @@ test('updateSequenceKeyframes converts the last color keyframe to a static value
 		effects: [],
 	});
 	expect(status.props.color).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 'blue',
-		keyframed: false,
 	});
 });
 

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -21,7 +21,7 @@ const addKeyframeToPropStatus = ({
 	frame: number;
 	value: unknown;
 }): CanUpdateSequencePropStatus => {
-	if ('keyframes' in status) {
+	if (status.status === 'keyframed') {
 		const existingIndex = status.keyframes.findIndex(
 			(kf) => kf.frame === frame,
 		);
@@ -51,13 +51,12 @@ const addKeyframeToPropStatus = ({
 		};
 	}
 
-	if (status.canUpdate) {
+	if (status.status === 'static') {
 		const staticValue = status.codeValue ?? value;
 
 		return {
-			canUpdate: true,
+			status: 'keyframed',
 			codeValue: undefined,
-			keyframed: true,
 			interpolationFunction: getInterpolationFunction(staticValue, value),
 			keyframes: [{frame, value}],
 			easing: [],

--- a/packages/studio-shared/src/optimistic-delete-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-delete-keyframe.ts
@@ -10,7 +10,7 @@ const removeKeyframeFromPropStatus = ({
 	status: CanUpdateSequencePropStatus;
 	frame: number;
 }): CanUpdateSequencePropStatus => {
-	if (!('keyframes' in status)) {
+	if (status.status !== 'keyframed') {
 		return status;
 	}
 
@@ -22,9 +22,8 @@ const removeKeyframeFromPropStatus = ({
 	const keyframes = status.keyframes.filter((_, i) => i !== index);
 	if (keyframes.length === 0) {
 		return {
-			canUpdate: true,
+			status: 'static',
 			codeValue: status.keyframes[index].value,
-			keyframed: false,
 		};
 	}
 

--- a/packages/studio-shared/src/optimistic-update-for-code-values.ts
+++ b/packages/studio-shared/src/optimistic-update-for-code-values.ts
@@ -22,7 +22,7 @@ export const optimisticUpdateForCodeValues = ({
 
 	const props: Record<string, CanUpdateSequencePropStatus> = {
 		...previous.props,
-		[fieldKey]: {canUpdate: true, codeValue: value, keyframed: false},
+		[fieldKey]: {status: 'static', codeValue: value},
 	};
 
 	if (schema[fieldKey]?.type === 'enum') {

--- a/packages/studio-shared/src/optimistic-update-for-effect-code-values.ts
+++ b/packages/studio-shared/src/optimistic-update-for-effect-code-values.ts
@@ -37,7 +37,7 @@ export const optimisticUpdateForEffectCodeValues = ({
 
 	const props: Record<string, CanUpdateSequencePropStatus> = {
 		...target.props,
-		[fieldKey]: {canUpdate: true, codeValue: value, keyframed: false},
+		[fieldKey]: {status: 'static', codeValue: value},
 	};
 
 	if (schema[fieldKey]?.type === 'enum') {

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -143,7 +143,7 @@ export const getEffectFieldsToShow = ({
 		}
 
 		const propStatus = effectStatus.props[key];
-		if (!propStatus || !propStatus.canUpdate) {
+		if (propStatus?.status !== 'static') {
 			return undefined;
 		}
 

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -10,9 +10,8 @@ test('optimisticAddSequenceKeyframe converts a static prop to a single keyframe'
 		canUpdate: true,
 		props: {
 			opacity: {
-				canUpdate: true,
+				status: 'static',
 				codeValue: 0.5,
-				keyframed: false,
 			},
 		},
 		effects: [],
@@ -30,7 +29,7 @@ test('optimisticAddSequenceKeyframe converts a static prop to a single keyframe'
 	}
 
 	const status = updated.props.opacity;
-	if (!status || !status.canUpdate || !('keyframes' in status)) {
+	if (!status || status.status !== 'keyframed') {
 		throw new Error('expected keyframed status');
 	}
 
@@ -43,9 +42,8 @@ test('optimisticAddSequenceKeyframe appends a keyframe to an existing interpolat
 		canUpdate: true,
 		props: {
 			scale: {
-				canUpdate: true,
+				status: 'keyframed',
 				codeValue: undefined,
-				keyframed: true,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 1},
@@ -71,7 +69,7 @@ test('optimisticAddSequenceKeyframe appends a keyframe to an existing interpolat
 	}
 
 	const status = updated.props.scale;
-	if (!status || !status.canUpdate || !('keyframes' in status)) {
+	if (!status || status.status !== 'keyframed') {
 		throw new Error('expected keyframed status');
 	}
 
@@ -95,9 +93,8 @@ test('optimisticAddEffectKeyframe appends a keyframe on the target effect', () =
 				importPath: null,
 				props: {
 					amount: {
-						canUpdate: true,
+						status: 'keyframed',
 						codeValue: undefined,
-						keyframed: true,
 						interpolationFunction: 'interpolate',
 						keyframes: [{frame: 0, value: 0.2}],
 						easing: [],
@@ -127,7 +124,7 @@ test('optimisticAddEffectKeyframe appends a keyframe on the target effect', () =
 	}
 
 	const status = effect.props.amount;
-	if (!status || !status.canUpdate || !('keyframes' in status)) {
+	if (!status || status.status !== 'keyframed') {
 		throw new Error('expected keyframed status');
 	}
 
@@ -149,9 +146,8 @@ test('optimisticAddEffectKeyframe converts a static prop to a single keyframe', 
 				importPath: null,
 				props: {
 					amount: {
-						canUpdate: true,
+						status: 'static',
 						codeValue: 0.2,
-						keyframed: false,
 					},
 				},
 			},
@@ -176,7 +172,7 @@ test('optimisticAddEffectKeyframe converts a static prop to a single keyframe', 
 	}
 
 	const status = effect.props.amount;
-	if (!status || !status.canUpdate || !('keyframes' in status)) {
+	if (!status || status.status !== 'keyframed') {
 		throw new Error('expected keyframed status');
 	}
 

--- a/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
@@ -12,9 +12,8 @@ test('optimisticDeleteSequenceKeyframe removes the matching keyframe and an easi
 		canUpdate: true,
 		props: {
 			'style.opacity': {
-				canUpdate: true,
+				status: 'keyframed',
 				codeValue: undefined,
-				keyframed: true,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 0},
@@ -40,7 +39,7 @@ test('optimisticDeleteSequenceKeyframe removes the matching keyframe and an easi
 	}
 
 	const status = updated.props['style.opacity'];
-	if (!status.canUpdate || !('keyframes' in status)) {
+	if (status.status !== 'keyframed') {
 		throw new Error('expected keyframed status');
 	}
 
@@ -56,9 +55,8 @@ test('optimisticDeleteSequenceKeyframe converts the last keyframe to a static va
 		canUpdate: true,
 		props: {
 			width: {
-				canUpdate: true,
+				status: 'keyframed',
 				codeValue: undefined,
-				keyframed: true,
 				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 12, value: 320}],
 				easing: [],
@@ -80,9 +78,8 @@ test('optimisticDeleteSequenceKeyframe converts the last keyframe to a static va
 	}
 
 	expect(updated.props.width).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 320,
-		keyframed: false,
 	});
 });
 
@@ -91,9 +88,8 @@ test('optimisticDeleteSequenceKeyframe is a no-op when no keyframe matches', () 
 		canUpdate: true,
 		props: {
 			'style.opacity': {
-				canUpdate: true,
+				status: 'keyframed',
 				codeValue: undefined,
-				keyframed: true,
 				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 0, value: 0}],
 				easing: [],
@@ -135,9 +131,8 @@ test('optimisticDeleteSequenceKeyframes deletes multiple keyframes in one pass',
 		canUpdate: true,
 		props: {
 			width: {
-				canUpdate: true,
+				status: 'keyframed',
 				codeValue: undefined,
-				keyframed: true,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 100},
@@ -165,7 +160,7 @@ test('optimisticDeleteSequenceKeyframes deletes multiple keyframes in one pass',
 	}
 
 	const status = updated.props.width;
-	if (!status.canUpdate || !('keyframes' in status)) {
+	if (status.status !== 'keyframed') {
 		throw new Error('expected keyframed status');
 	}
 
@@ -185,9 +180,8 @@ test('optimisticDeleteEffectKeyframe removes the matching keyframe on the target
 				importPath: null,
 				props: {
 					amount: {
-						canUpdate: true,
+						status: 'keyframed',
 						codeValue: undefined,
-						keyframed: true,
 						interpolationFunction: 'interpolate',
 						keyframes: [
 							{frame: 0, value: 0},
@@ -219,7 +213,7 @@ test('optimisticDeleteEffectKeyframe removes the matching keyframe on the target
 	}
 
 	const status = effect.props.amount;
-	if (!status.canUpdate || !('keyframes' in status)) {
+	if (status.status !== 'keyframed') {
 		throw new Error('expected keyframed status');
 	}
 
@@ -239,9 +233,8 @@ test('optimisticDeleteEffectKeyframe converts the last keyframe on the target ef
 				importPath: null,
 				props: {
 					amount: {
-						canUpdate: true,
+						status: 'keyframed',
 						codeValue: undefined,
-						keyframed: true,
 						interpolationFunction: 'interpolate',
 						keyframes: [{frame: 40, value: 0.6}],
 						easing: [],
@@ -270,9 +263,8 @@ test('optimisticDeleteEffectKeyframe converts the last keyframe on the target ef
 	}
 
 	expect(effect.props.amount).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 0.6,
-		keyframed: false,
 	});
 });
 
@@ -305,9 +297,8 @@ test('optimisticDeleteEffectKeyframes deletes multiple keyframes in one pass', (
 				importPath: null,
 				props: {
 					amount: {
-						canUpdate: true,
+						status: 'keyframed',
 						codeValue: undefined,
-						keyframed: true,
 						interpolationFunction: 'interpolate',
 						keyframes: [
 							{frame: 0, value: 0},
@@ -341,7 +332,7 @@ test('optimisticDeleteEffectKeyframes deletes multiple keyframes in one pass', (
 	}
 
 	const status = effect.props.amount;
-	if (!status.canUpdate || !('keyframes' in status)) {
+	if (status.status !== 'keyframed') {
 		throw new Error('expected keyframed status');
 	}
 

--- a/packages/studio-shared/src/test/optimistic-update-for-code-values.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-for-code-values.test.ts
@@ -8,9 +8,8 @@ test('optimisticUpdateForCodeValues should return the correct response', () => {
 		canUpdate: true,
 		props: {
 			'style.opacity': {
-				canUpdate: true,
+				status: 'static',
 				codeValue: 0.5,
-				keyframed: false,
 			},
 		},
 		effects: [],
@@ -26,9 +25,8 @@ test('optimisticUpdateForCodeValues should return the correct response', () => {
 		canUpdate: true,
 		props: {
 			'style.opacity': {
-				canUpdate: true,
+				status: 'static',
 				codeValue: 0.6,
-				keyframed: false,
 			},
 		},
 		effects: [],
@@ -44,9 +42,8 @@ test('optimisticUpdateForCodeValues should return the correct response', () => {
 		canUpdate: true,
 		props: {
 			layout: {
-				canUpdate: true,
+				status: 'static',
 				codeValue: 'none',
-				keyframed: false,
 			},
 		},
 		effects: [],

--- a/packages/studio-shared/src/test/optimistic-update-for-effect-code-values.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-for-effect-code-values.test.ts
@@ -11,8 +11,8 @@ test('optimisticUpdateForEffectCodeValues updates the matching effect prop', () 
 				canUpdate: true,
 				effectIndex: 0,
 				props: {
-					color: {canUpdate: true, codeValue: 'red', keyframed: false},
-					opacity: {canUpdate: true, codeValue: 0.5, keyframed: false},
+					color: {status: 'static', codeValue: 'red'},
+					opacity: {status: 'static', codeValue: 0.5},
 				},
 				callee: 'tint',
 				importPath: null,
@@ -38,14 +38,12 @@ test('optimisticUpdateForEffectCodeValues updates the matching effect prop', () 
 	}
 
 	expect(effect.props.opacity).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 0.8,
-		keyframed: false,
 	});
 	expect(effect.props.color).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 'red',
-		keyframed: false,
 	});
 });
 
@@ -95,7 +93,7 @@ test('optimisticUpdateForEffectCodeValues applies when effect props are unset (z
 				callee: 'tint',
 				importPath: null,
 				props: {
-					amount: {canUpdate: true, codeValue: undefined, keyframed: false},
+					amount: {status: 'static', codeValue: undefined},
 				},
 			},
 		],
@@ -119,8 +117,7 @@ test('optimisticUpdateForEffectCodeValues applies when effect props are unset (z
 	}
 
 	expect(effect.props.amount).toEqual({
-		canUpdate: true,
+		status: 'static',
 		codeValue: 0.5,
-		keyframed: false,
 	});
 });

--- a/packages/studio-shared/src/test/schema-field-info.test.ts
+++ b/packages/studio-shared/src/test/schema-field-info.test.ts
@@ -62,9 +62,8 @@ test('getEffectFieldsToShow uses the active enum variant', () => {
 						effectIndex: 0,
 						props: {
 							colorMode: {
-								canUpdate: true,
+								status: 'static',
 								codeValue: 'source',
-								keyframed: false,
 							},
 						},
 					},

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import type {
-	CanUpdaterSequencePropStatusStatic,
+	CanUpdateSequencePropStatusStatic,
 	CodeValues,
 	GetEffectDragOverrides,
 	OverrideIdToNodePaths,
@@ -54,7 +54,7 @@ type UvCoordinateFieldSchema = Extract<
 
 type SelectedOutlineUvHandle = {
 	readonly clientId: string;
-	readonly codeValue: CanUpdaterSequencePropStatusStatic;
+	readonly codeValue: CanUpdateSequencePropStatusStatic;
 	readonly effectIndex: number;
 	readonly fieldDefault: UvCoordinate | undefined;
 	readonly fieldKey: string;
@@ -72,7 +72,7 @@ type SelectedOutlineTarget = {
 };
 
 type SelectedOutlineDragTarget = {
-	readonly codeValue: CanUpdaterSequencePropStatusStatic;
+	readonly codeValue: CanUpdateSequencePropStatusStatic;
 	readonly clientId: string;
 	readonly fieldDefault: string | undefined;
 	readonly nodePath: SequencePropsSubscriptionKey;
@@ -507,7 +507,7 @@ const getSelectedUvHandles = ({
 			}
 
 			const propStatus = effectStatus.props[key];
-			if (!propStatus?.canUpdate) {
+			if (propStatus?.status !== 'static') {
 				return undefined;
 			}
 
@@ -523,7 +523,7 @@ const getSelectedUvHandles = ({
 			}
 
 			const propStatus = effectStatus.props[fieldKey];
-			if (!propStatus?.canUpdate || propStatus.keyframed) {
+			if (propStatus?.status !== 'static') {
 				continue;
 			}
 
@@ -1008,8 +1008,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				previewServerState.type === 'connected' &&
 				controls !== null &&
 				fieldSchema?.type === 'translate' &&
-				codeValue?.canUpdate === true &&
-				codeValue.keyframed === false;
+				codeValue?.status === 'static';
 
 			return {
 				key,

--- a/packages/studio/src/components/Timeline/TimelineBooleanField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineBooleanField.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import type {CanUpdateSequencePropStatus} from 'remotion';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnSave,
@@ -12,7 +12,7 @@ const checkboxContainer: React.CSSProperties = {
 
 export const TimelineBooleanField: React.FC<{
 	readonly field: SchemaFieldInfo;
-	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly effectiveValue: unknown;
 	readonly onSave: TimelineFieldOnSave;
 }> = ({field, propStatus, effectiveValue, onSave}) => {
@@ -20,7 +20,7 @@ export const TimelineBooleanField: React.FC<{
 
 	const onChange = useCallback(() => {
 		const newValue = !checked;
-		if (propStatus.canUpdate && newValue !== propStatus.codeValue) {
+		if (newValue !== propStatus.codeValue) {
 			onSave(newValue);
 		}
 	}, [propStatus, onSave, checked]);
@@ -31,7 +31,7 @@ export const TimelineBooleanField: React.FC<{
 				checked={checked}
 				onChange={onChange}
 				name={field.key}
-				disabled={!propStatus.canUpdate}
+				disabled={false}
 				variant="small"
 			/>
 		</div>

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -127,11 +127,7 @@ const effectStatusToSnapshot = (
 
 	const params: Record<string, unknown> = {};
 	for (const [key, prop] of Object.entries(effect.props)) {
-		if (!prop.canUpdate) {
-			return null;
-		}
-
-		if (prop.keyframed) {
+		if (prop.status !== 'static') {
 			return null;
 		}
 

--- a/packages/studio/src/components/Timeline/TimelineColorField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineColorField.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
-import type {CanUpdateSequencePropStatus} from 'remotion';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -19,7 +19,7 @@ const SWATCH_HEIGHT = 15;
 export const TimelineColorField: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly effectiveValue: unknown;
-	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly onSave: TimelineFieldOnSave;
 	readonly onDragValueChange: TimelineFieldOnDragValueChange;
 	readonly onDragEnd: () => void;
@@ -40,21 +40,13 @@ export const TimelineColorField: React.FC<{
 
 	const onChange = useCallback(
 		(next: string) => {
-			if (!propStatus.canUpdate) {
-				return;
-			}
-
 			onDragValueChange(next);
 		},
-		[onDragValueChange, propStatus.canUpdate],
+		[onDragValueChange],
 	);
 
 	const onChangeComplete = useCallback(
 		(next: string) => {
-			if (!propStatus.canUpdate) {
-				return;
-			}
-
 			if (next !== propStatus.codeValue) {
 				onSave(next);
 			}
@@ -79,7 +71,7 @@ export const TimelineColorField: React.FC<{
 				onChangeComplete={onChangeComplete}
 				width={SWATCH_WIDTH}
 				height={SWATCH_HEIGHT}
-				disabled={!propStatus.canUpdate}
+				disabled={false}
 				name={field.key}
 				title={currentValue}
 				style={swatchStyle}

--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -147,15 +147,14 @@ export const TimelineEffectItem: React.FC<{
 			: null;
 
 	const isDisabled = useMemo(() => {
-		if (disabledStatus && disabledStatus.canUpdate) {
+		if (disabledStatus?.status === 'static') {
 			return Boolean(disabledStatus.codeValue);
 		}
 
 		return false;
 	}, [disabledStatus]);
 
-	const canToggle =
-		previewConnected && disabledStatus !== null && disabledStatus.canUpdate;
+	const canToggle = previewConnected && disabledStatus?.status === 'static';
 
 	const deleteDisabled =
 		!previewConnected ||

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -34,7 +34,7 @@ const fieldRowBase: React.CSSProperties = {};
 const isKeyframedStatus = (
 	status: CanUpdateSequencePropStatus,
 ): status is CanUpdateSequencePropStatusKeyframed => {
-	return 'keyframes' in status;
+	return status.status === 'keyframed';
 };
 
 const Value: React.FC<{
@@ -97,7 +97,7 @@ const Value: React.FC<{
 				return Promise.reject(new Error('Cannot save'));
 			}
 
-			if (!propStatus.canUpdate) {
+			if (propStatus.status !== 'static') {
 				return Promise.reject(new Error('Cannot save'));
 			}
 
@@ -207,7 +207,7 @@ const Value: React.FC<{
 		);
 	}
 
-	if (!propStatus.canUpdate) {
+	if (propStatus.status === 'computed') {
 		return <UnsupportedStatus label={getComputedStatusLabel(propStatus)} />;
 	}
 
@@ -299,7 +299,7 @@ export const TimelineEffectPropItem: React.FC<{
 		) : null;
 
 	const isNonDefault = useMemo(() => {
-		if (!propStatus || !propStatus.canUpdate) {
+		if (!propStatus || propStatus.status === 'computed') {
 			return false;
 		}
 
@@ -314,7 +314,7 @@ export const TimelineEffectPropItem: React.FC<{
 	const canPerformReset =
 		previewServerState.type === 'connected' &&
 		propStatus !== null &&
-		propStatus.canUpdate;
+		propStatus.status !== 'computed';
 
 	const onReset = useCallback(() => {
 		if (

--- a/packages/studio/src/components/Timeline/TimelineEnumField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEnumField.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
-import type {CanUpdateSequencePropStatus} from 'remotion';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -14,7 +14,7 @@ const comboboxStyle: React.CSSProperties = {
 
 export const TimelineEnumField: React.FC<{
 	readonly field: SchemaFieldInfo;
-	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly effectiveValue: unknown;
 	readonly onSave: TimelineFieldOnSave;
 	readonly onDragValueChange: TimelineFieldOnDragValueChange;
@@ -37,7 +37,7 @@ export const TimelineEnumField: React.FC<{
 
 	const onSelect = useCallback(
 		(newValue: string) => {
-			if (!propStatus.canUpdate || newValue === propStatus.codeValue) {
+			if (newValue === propStatus.codeValue) {
 				return;
 			}
 
@@ -60,9 +60,9 @@ export const TimelineEnumField: React.FC<{
 			leftItem: null,
 			subMenu: null,
 			quickSwitcherLabel: null,
-			disabled: !propStatus.canUpdate,
+			disabled: false,
 		}));
-	}, [variantKeys, onSelect, propStatus]);
+	}, [variantKeys, onSelect]);
 
 	return (
 		<Combobox

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -52,7 +52,7 @@ const navButtonStyle: React.CSSProperties = {
 const isKeyframedStatus = (
 	status: CanUpdateSequencePropStatus,
 ): status is CanUpdateSequencePropStatusKeyframed => {
-	return 'keyframes' in status;
+	return status.status === 'keyframed';
 };
 
 const diamondButtonStyle: React.CSSProperties = {
@@ -90,7 +90,7 @@ const getCurrentKeyframeValue = ({
 		});
 	}
 
-	if (propStatus.canUpdate) {
+	if (propStatus.status === 'static') {
 		return Internals.getEffectiveVisualModeValue({
 			codeValue: propStatus,
 			dragOverrideValue,
@@ -193,7 +193,8 @@ export const TimelineKeyframeControls: React.FC<{
 	const canAddKeyframe =
 		fieldSchema?.type !== 'scale' || typeof currentKeyframeValue === 'number';
 	const canToggleKeyframe =
-		propStatus.canUpdate && (hasKeyframeAtCurrentFrame || canAddKeyframe);
+		propStatus.status !== 'computed' &&
+		(hasKeyframeAtCurrentFrame || canAddKeyframe);
 
 	const seekToDisplayFrame = useCallback(
 		(frame: number) => {

--- a/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
@@ -1,7 +1,7 @@
 import React, {useMemo} from 'react';
 import type {
-	CanUpdateSequencePropStatus,
-	CanUpdaterSequencePropStatusStatic,
+	CanUpdateSequencePropStatusKeyframed,
+	CanUpdateSequencePropStatusStatic,
 } from 'remotion';
 import {Internals} from 'remotion';
 import type {SchemaFieldInfo} from '../../helpers/timeline-layout';
@@ -17,17 +17,13 @@ const noopAsync = () => Promise.resolve();
 
 export const TimelineKeyframedValue: React.FC<{
 	readonly field: SchemaFieldInfo;
-	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly propStatus: CanUpdateSequencePropStatusKeyframed;
 	readonly keyframeDisplayOffset: number;
 }> = ({field, propStatus, keyframeDisplayOffset}) => {
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const jsxFrame = timelinePosition - keyframeDisplayOffset;
 
 	const computedValue = useMemo(() => {
-		if (!('keyframes' in propStatus)) {
-			return null;
-		}
-
 		const raw = Internals.interpolateKeyframedStatus({
 			frame: jsxFrame,
 			status: propStatus,
@@ -39,11 +35,10 @@ export const TimelineKeyframedValue: React.FC<{
 		return raw;
 	}, [jsxFrame, propStatus]);
 
-	const fakeStatus: CanUpdaterSequencePropStatusStatic = useMemo(
+	const fakeStatus: CanUpdateSequencePropStatusStatic = useMemo(
 		() => ({
-			canUpdate: true,
+			status: 'static',
 			codeValue: computedValue,
-			keyframed: false,
 		}),
 		[computedValue],
 	);

--- a/packages/studio/src/components/Timeline/TimelineNumberField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineNumberField.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo, useState} from 'react';
-import type {CanUpdateSequencePropStatus} from 'remotion';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -11,7 +11,7 @@ import {draggerStyle, getDecimalPlaces} from './timeline-field-utils';
 export const TimelineNumberField: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly effectiveValue: unknown;
-	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly onSave: TimelineFieldOnSave;
 	readonly onDragValueChange: TimelineFieldOnDragValueChange;
 	readonly onDragEnd: () => void;
@@ -35,7 +35,7 @@ export const TimelineNumberField: React.FC<{
 
 	const onValueChangeEnd = useCallback(
 		(newVal: number) => {
-			if (propStatus.canUpdate && newVal !== propStatus.codeValue) {
+			if (newVal !== propStatus.codeValue) {
 				onSave(newVal).finally(() => {
 					setDragValue(null);
 					onDragEnd();
@@ -50,18 +50,12 @@ export const TimelineNumberField: React.FC<{
 
 	const onTextChange = useCallback(
 		(newVal: string) => {
-			if (propStatus.canUpdate) {
-				const parsed = Number(newVal);
-				if (
-					!Number.isNaN(parsed) &&
-					propStatus.canUpdate &&
-					parsed !== propStatus.codeValue
-				) {
-					setDragValue(parsed);
-					onSave(parsed).finally(() => {
-						setDragValue(null);
-					});
-				}
+			const parsed = Number(newVal);
+			if (!Number.isNaN(parsed) && parsed !== propStatus.codeValue) {
+				setDragValue(parsed);
+				onSave(parsed).finally(() => {
+					setDragValue(null);
+				});
 			}
 		},
 		[onSave, propStatus],

--- a/packages/studio/src/components/Timeline/TimelineRotationField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRotationField.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo, useState} from 'react';
-import type {CanUpdateSequencePropStatus} from 'remotion';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -34,7 +34,7 @@ const parseCssRotationToDegrees = (value: string): number => {
 export const TimelineRotationField: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly effectiveValue: unknown;
-	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly onSave: TimelineFieldOnSave;
 	readonly onDragValueChange: TimelineFieldOnDragValueChange;
 	readonly onDragEnd: () => void;
@@ -73,7 +73,7 @@ export const TimelineRotationField: React.FC<{
 	const onValueChangeEnd = useCallback(
 		(newVal: number) => {
 			const newValue = serializeValue(newVal);
-			if (propStatus.canUpdate && newValue !== propStatus.codeValue) {
+			if (newValue !== propStatus.codeValue) {
 				onSave(newValue).finally(() => {
 					setDragValue(null);
 					onDragEnd();
@@ -88,16 +88,14 @@ export const TimelineRotationField: React.FC<{
 
 	const onTextChange = useCallback(
 		(newVal: string) => {
-			if (propStatus.canUpdate) {
-				const parsed = Number(newVal);
-				if (!Number.isNaN(parsed)) {
-					const newValue = serializeValue(parsed);
-					if (newValue !== propStatus.codeValue) {
-						setDragValue(parsed);
-						onSave(newValue).finally(() => {
-							setDragValue(null);
-						});
-					}
+			const parsed = Number(newVal);
+			if (!Number.isNaN(parsed)) {
+				const newValue = serializeValue(parsed);
+				if (newValue !== propStatus.codeValue) {
+					setDragValue(parsed);
+					onSave(newValue).finally(() => {
+						setDragValue(null);
+					});
 				}
 			}
 		},

--- a/packages/studio/src/components/Timeline/TimelineScaleField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScaleField.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo, useRef, useState} from 'react';
-import type {CanUpdateSequencePropStatus} from 'remotion';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {LIGHT_COLOR} from '../../helpers/colors';
 import type {
@@ -142,7 +142,7 @@ const LinkToggle: React.FC<{
 
 export const TimelineScaleField: React.FC<{
 	readonly field: SchemaFieldInfo;
-	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly effectiveValue: unknown;
 	readonly onSave: TimelineFieldOnSave;
 	readonly onDragValueChange: TimelineFieldOnDragValueChange;
@@ -260,10 +260,7 @@ export const TimelineScaleField: React.FC<{
 				onDragEnd();
 			};
 
-			if (
-				propStatus.canUpdate &&
-				!valuesEqual(newScale, propStatus.codeValue)
-			) {
+			if (!valuesEqual(newScale, propStatus.codeValue)) {
 				onSave(newScale).finally(clearDragState);
 			} else {
 				clearDragState();
@@ -285,10 +282,6 @@ export const TimelineScaleField: React.FC<{
 
 	const onXTextChange = useCallback(
 		(newVal: string) => {
-			if (!propStatus.canUpdate) {
-				return;
-			}
-
 			const parsed = Number(newVal);
 			if (Number.isNaN(parsed)) {
 				return;
@@ -373,10 +366,7 @@ export const TimelineScaleField: React.FC<{
 				onDragEnd();
 			};
 
-			if (
-				propStatus.canUpdate &&
-				!valuesEqual(newScale, propStatus.codeValue)
-			) {
+			if (!valuesEqual(newScale, propStatus.codeValue)) {
 				onSave(newScale).finally(clearDragState);
 			} else {
 				clearDragState();
@@ -398,10 +388,6 @@ export const TimelineScaleField: React.FC<{
 
 	const onYTextChange = useCallback(
 		(newVal: string) => {
-			if (!propStatus.canUpdate) {
-				return;
-			}
-
 			const parsed = Number(newVal);
 			if (Number.isNaN(parsed)) {
 				return;

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type {
 	CanUpdateSequencePropStatusFalse,
-	CanUpdaterSequencePropStatusStatic,
+	CanUpdateSequencePropStatusStatic,
 } from 'remotion';
 import type {
 	SchemaFieldInfo,
@@ -26,12 +26,6 @@ const unsupportedLabel: React.CSSProperties = {
 	WebkitUserSelect: 'none',
 };
 
-const notEditableBackground: React.CSSProperties = {
-	backgroundColor: 'rgba(255, 0, 0, 0.2)',
-	borderRadius: 3,
-	padding: '0 4px',
-};
-
 const inlineWrapper: React.CSSProperties = {
 	fontSize: 12,
 };
@@ -45,11 +39,7 @@ export const UnsupportedStatus: React.FC<{
 export const TimelineNonEditableStatus: React.FC<{
 	readonly propStatus: CanUpdateSequencePropStatusFalse;
 }> = ({propStatus}) => {
-	if (propStatus.canUpdate) {
-		return null;
-	}
-
-	if (propStatus.reason === 'computed') {
+	if (propStatus.status === 'computed') {
 		return (
 			<span style={unsupportedLabel}>{getComputedStatusLabel(propStatus)}</span>
 		);
@@ -61,7 +51,7 @@ export const TimelineFieldValue: React.FC<{
 	readonly onSave: TimelineFieldOnSave;
 	readonly onDragValueChange: TimelineFieldOnDragValueChange;
 	readonly onDragEnd: () => void;
-	readonly propStatus: CanUpdaterSequencePropStatusStatic;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly effectiveValue: unknown;
 }> = ({
 	field,
@@ -71,13 +61,9 @@ export const TimelineFieldValue: React.FC<{
 	propStatus,
 	effectiveValue,
 }) => {
-	const wrapperStyle: React.CSSProperties | undefined = !propStatus.canUpdate
-		? notEditableBackground
-		: undefined;
-
 	if (field.typeName === 'number') {
 		return (
-			<span style={wrapperStyle}>
+			<span>
 				<TimelineNumberField
 					field={field}
 					effectiveValue={effectiveValue}
@@ -95,7 +81,7 @@ export const TimelineFieldValue: React.FC<{
 		field.typeName === 'rotation-degrees'
 	) {
 		return (
-			<span style={wrapperStyle}>
+			<span>
 				<TimelineRotationField
 					field={field}
 					effectiveValue={effectiveValue}
@@ -110,7 +96,7 @@ export const TimelineFieldValue: React.FC<{
 
 	if (field.typeName === 'translate') {
 		return (
-			<span style={wrapperStyle}>
+			<span>
 				<TimelineTranslateField
 					field={field}
 					effectiveValue={effectiveValue}
@@ -125,7 +111,7 @@ export const TimelineFieldValue: React.FC<{
 
 	if (field.typeName === 'scale') {
 		return (
-			<span style={wrapperStyle}>
+			<span>
 				<TimelineScaleField
 					field={field}
 					effectiveValue={effectiveValue}
@@ -140,7 +126,7 @@ export const TimelineFieldValue: React.FC<{
 
 	if (field.typeName === 'uv-coordinate') {
 		return (
-			<span style={wrapperStyle}>
+			<span>
 				<TimelineUvCoordinateField
 					field={field}
 					effectiveValue={effectiveValue}
@@ -155,7 +141,7 @@ export const TimelineFieldValue: React.FC<{
 
 	if (field.typeName === 'boolean') {
 		return (
-			<span style={wrapperStyle}>
+			<span>
 				<TimelineBooleanField
 					field={field}
 					propStatus={propStatus}
@@ -168,7 +154,7 @@ export const TimelineFieldValue: React.FC<{
 
 	if (field.typeName === 'color') {
 		return (
-			<span style={wrapperStyle}>
+			<span>
 				<TimelineColorField
 					field={field}
 					propStatus={propStatus}

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -380,7 +380,7 @@ export const TimelineSequenceItem: React.FC<{
 
 	const isItemHidden = useMemo(() => {
 		const codeValue =
-			codeHiddenStatus && codeHiddenStatus.canUpdate
+			codeHiddenStatus && codeHiddenStatus.status === 'static'
 				? codeHiddenStatus.codeValue
 				: undefined;
 		const runtimeValue =
@@ -397,7 +397,7 @@ export const TimelineSequenceItem: React.FC<{
 				!validatedLocation ||
 				!codeValuesForOverride ||
 				!codeHiddenStatus ||
-				!codeHiddenStatus.canUpdate ||
+				codeHiddenStatus.status !== 'static' ||
 				previewServerState.type !== 'connected'
 			) {
 				return;
@@ -469,7 +469,7 @@ export const TimelineSequenceItem: React.FC<{
 		validatedLocation !== null &&
 		codeHiddenStatus !== undefined &&
 		codeHiddenStatus !== null &&
-		codeHiddenStatus.canUpdate;
+		codeHiddenStatus.status === 'static';
 
 	const canDropEffect =
 		previewServerState.type === 'connected' &&

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -1,8 +1,8 @@
 import React, {useCallback, useContext, useMemo} from 'react';
 import type {
-	CanUpdaterSequencePropStatusStatic,
 	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusKeyframed,
+	CanUpdateSequencePropStatusStatic,
 	SequencePropsSubscriptionKey,
 	SequenceSchema,
 } from 'remotion';
@@ -39,7 +39,7 @@ const fieldRowBase: React.CSSProperties = {};
 const isKeyframedStatus = (
 	status: CanUpdateSequencePropStatus,
 ): status is CanUpdateSequencePropStatusKeyframed => {
-	return 'keyframes' in status;
+	return status.status === 'keyframed';
 };
 
 const Value: React.FC<{
@@ -47,7 +47,7 @@ const Value: React.FC<{
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly validatedLocation: CodePosition;
 	readonly schema: SequenceSchema;
-	readonly codeValue: CanUpdaterSequencePropStatusStatic;
+	readonly codeValue: CanUpdateSequencePropStatusStatic;
 }> = ({field, nodePath, validatedLocation, schema, codeValue}) => {
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
@@ -77,10 +77,6 @@ const Value: React.FC<{
 
 	const onSave = useCallback<TimelineFieldOnSave>(
 		(value) => {
-			if (!codeValue || !codeValue.canUpdate) {
-				return Promise.reject(new Error('Cannot save'));
-			}
-
 			if (!clientId) {
 				return Promise.reject(new Error('Not connected to studio server'));
 			}
@@ -221,7 +217,7 @@ export const TimelineSequencePropItem: React.FC<{
 	}, [field.rowHeight]);
 
 	const isNonDefault = useMemo(() => {
-		if (!codeValue || !codeValue.canUpdate) {
+		if (!codeValue || codeValue.status === 'computed') {
 			return false;
 		}
 
@@ -235,7 +231,7 @@ export const TimelineSequencePropItem: React.FC<{
 	const canPerformReset =
 		previewServerState.type === 'connected' &&
 		codeValue !== null &&
-		codeValue.canUpdate;
+		codeValue.status !== 'computed';
 
 	const onReset = useCallback(() => {
 		if (
@@ -323,7 +319,7 @@ export const TimelineSequencePropItem: React.FC<{
 						keyframeDisplayOffset={keyframeDisplayOffset}
 					/>
 				</div>
-			) : codeValue.canUpdate ? (
+			) : codeValue.status === 'static' ? (
 				<div style={timelineFieldValueColumnStyle}>
 					<Value
 						field={field}

--- a/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo, useState} from 'react';
-import type {CanUpdateSequencePropStatus} from 'remotion';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -24,7 +24,7 @@ const containerStyle: React.CSSProperties = {
 
 export const TimelineTranslateField: React.FC<{
 	readonly field: SchemaFieldInfo;
-	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly effectiveValue: unknown;
 	readonly onSave: TimelineFieldOnSave;
 	readonly onDragValueChange: TimelineFieldOnDragValueChange;
@@ -74,7 +74,7 @@ export const TimelineTranslateField: React.FC<{
 		(newVal: number) => {
 			const currentY = dragY ?? codeY;
 			const newStr = serializeTranslate(newVal, currentY);
-			if (propStatus.canUpdate && newStr !== propStatus.codeValue) {
+			if (newStr !== propStatus.codeValue) {
 				onSave(newStr).finally(() => {
 					setDragX(null);
 					onDragEnd();
@@ -89,17 +89,15 @@ export const TimelineTranslateField: React.FC<{
 
 	const onXTextChange = useCallback(
 		(newVal: string) => {
-			if (propStatus.canUpdate) {
-				const parsed = Number(newVal);
-				if (!Number.isNaN(parsed)) {
-					const currentY = dragY ?? codeY;
-					const newStr = serializeTranslate(parsed, currentY);
-					if (newStr !== propStatus.codeValue) {
-						setDragX(parsed);
-						onSave(newStr).finally(() => {
-							setDragX(null);
-						});
-					}
+			const parsed = Number(newVal);
+			if (!Number.isNaN(parsed)) {
+				const currentY = dragY ?? codeY;
+				const newStr = serializeTranslate(parsed, currentY);
+				if (newStr !== propStatus.codeValue) {
+					setDragX(parsed);
+					onSave(newStr).finally(() => {
+						setDragX(null);
+					});
 				}
 			}
 		},
@@ -120,7 +118,7 @@ export const TimelineTranslateField: React.FC<{
 		(newVal: number) => {
 			const currentX = dragX ?? codeX;
 			const newStr = serializeTranslate(currentX, newVal);
-			if (propStatus.canUpdate && newStr !== propStatus.codeValue) {
+			if (newStr !== propStatus.codeValue) {
 				onSave(newStr).finally(() => {
 					setDragY(null);
 					onDragEnd();
@@ -135,17 +133,15 @@ export const TimelineTranslateField: React.FC<{
 
 	const onYTextChange = useCallback(
 		(newVal: string) => {
-			if (propStatus.canUpdate) {
-				const parsed = Number(newVal);
-				if (!Number.isNaN(parsed)) {
-					const currentX = dragX ?? codeX;
-					const newStr = serializeTranslate(currentX, parsed);
-					if (newStr !== propStatus.codeValue) {
-						setDragY(parsed);
-						onSave(newStr).finally(() => {
-							setDragY(null);
-						});
-					}
+			const parsed = Number(newVal);
+			if (!Number.isNaN(parsed)) {
+				const currentX = dragX ?? codeX;
+				const newStr = serializeTranslate(currentX, parsed);
+				if (newStr !== propStatus.codeValue) {
+					setDragY(parsed);
+					onSave(newStr).finally(() => {
+						setDragY(null);
+					});
 				}
 			}
 		},

--- a/packages/studio/src/components/Timeline/TimelineUvCoordinateField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineUvCoordinateField.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo, useState} from 'react';
-import type {CanUpdateSequencePropStatus} from 'remotion';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -46,7 +46,7 @@ const tuplesEqual = (
 
 export const TimelineUvCoordinateField: React.FC<{
 	readonly field: SchemaFieldInfo;
-	readonly propStatus: CanUpdateSequencePropStatus;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly effectiveValue: unknown;
 	readonly onSave: TimelineFieldOnSave;
 	readonly onDragValueChange: TimelineFieldOnDragValueChange;
@@ -106,10 +106,7 @@ export const TimelineUvCoordinateField: React.FC<{
 		(newVal: number) => {
 			const currentY = dragY ?? codeY;
 			const newTuple: [number, number] = [newVal, currentY];
-			if (
-				propStatus.canUpdate &&
-				!tuplesEqual(propStatus.codeValue, newTuple)
-			) {
+			if (!tuplesEqual(propStatus.codeValue, newTuple)) {
 				onSave(newTuple).finally(() => {
 					setDragX(null);
 					onDragEnd();
@@ -124,17 +121,15 @@ export const TimelineUvCoordinateField: React.FC<{
 
 	const onXTextChange = useCallback(
 		(newVal: string) => {
-			if (propStatus.canUpdate) {
-				const parsed = Number(newVal);
-				if (!Number.isNaN(parsed)) {
-					const currentY = dragY ?? codeY;
-					const newTuple: [number, number] = [parsed, currentY];
-					if (!tuplesEqual(propStatus.codeValue, newTuple)) {
-						setDragX(parsed);
-						onSave(newTuple).finally(() => {
-							setDragX(null);
-						});
-					}
+			const parsed = Number(newVal);
+			if (!Number.isNaN(parsed)) {
+				const currentY = dragY ?? codeY;
+				const newTuple: [number, number] = [parsed, currentY];
+				if (!tuplesEqual(propStatus.codeValue, newTuple)) {
+					setDragX(parsed);
+					onSave(newTuple).finally(() => {
+						setDragX(null);
+					});
 				}
 			}
 		},
@@ -154,10 +149,7 @@ export const TimelineUvCoordinateField: React.FC<{
 		(newVal: number) => {
 			const currentX = dragX ?? codeX;
 			const newTuple: [number, number] = [currentX, newVal];
-			if (
-				propStatus.canUpdate &&
-				!tuplesEqual(propStatus.codeValue, newTuple)
-			) {
+			if (!tuplesEqual(propStatus.codeValue, newTuple)) {
 				onSave(newTuple).finally(() => {
 					setDragY(null);
 					onDragEnd();
@@ -172,17 +164,15 @@ export const TimelineUvCoordinateField: React.FC<{
 
 	const onYTextChange = useCallback(
 		(newVal: string) => {
-			if (propStatus.canUpdate) {
-				const parsed = Number(newVal);
-				if (!Number.isNaN(parsed)) {
-					const currentX = dragX ?? codeX;
-					const newTuple: [number, number] = [currentX, parsed];
-					if (!tuplesEqual(propStatus.codeValue, newTuple)) {
-						setDragY(parsed);
-						onSave(newTuple).finally(() => {
-							setDragY(null);
-						});
-					}
+			const parsed = Number(newVal);
+			if (!Number.isNaN(parsed)) {
+				const currentX = dragX ?? codeX;
+				const newTuple: [number, number] = [currentX, parsed];
+				if (!tuplesEqual(propStatus.codeValue, newTuple)) {
+					setDragY(parsed);
+					onSave(newTuple).finally(() => {
+						setDragY(null);
+					});
 				}
 			}
 		},

--- a/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
@@ -6,11 +6,13 @@ import type {
 export const getComputedStatusLabel: (
 	propStatus: CanUpdateSequencePropStatusFalse,
 ) => string = (propStatus) => {
-	if (propStatus.reason === 'computed') {
+	if (propStatus.status === 'computed') {
 		return 'computed';
 	}
 
-	return 'keyframed';
+	throw new Error(
+		`Unsupported prop status: ${propStatus.status satisfies never}`,
+	);
 };
 
 export const getTimelineKeyframes = (
@@ -21,24 +23,17 @@ export const getTimelineKeyframes = (
 		return [];
 	}
 
-	if (!propStatus.canUpdate) {
+	if (propStatus.status !== 'keyframed') {
 		return [];
 	}
 
-	if ('keyframes' in propStatus) {
-		const {keyframes} = propStatus as Extract<
-			CanUpdateSequencePropStatus,
-			{keyframes: unknown}
-		>;
-		if (keyframeDisplayOffset === 0) {
-			return keyframes;
-		}
-
-		return keyframes.map((keyframe) => ({
-			...keyframe,
-			frame: keyframe.frame + keyframeDisplayOffset,
-		}));
+	const {keyframes} = propStatus;
+	if (keyframeDisplayOffset === 0) {
+		return keyframes;
 	}
 
-	return [];
+	return keyframes.map((keyframe) => ({
+		...keyframe,
+		frame: keyframe.frame + keyframeDisplayOffset,
+	}));
 };

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -112,7 +112,7 @@ export const getTimelinePropResetTargets = ({
 			)?.[selection.key];
 			if (
 				!isVisibleFieldSchema(sequenceFieldSchema) ||
-				!sequencePropStatus?.canUpdate ||
+				sequencePropStatus?.status !== 'static' ||
 				!isNonDefaultCodeValue({
 					codeValue: sequencePropStatus.codeValue,
 					defaultValue: sequenceFieldSchema.default,
@@ -147,7 +147,7 @@ export const getTimelinePropResetTargets = ({
 		if (
 			!effect ||
 			!isVisibleFieldSchema(fieldSchema) ||
-			!propStatus?.canUpdate ||
+			propStatus?.status !== 'static' ||
 			!isNonDefaultCodeValue({
 				codeValue: propStatus.codeValue,
 				defaultValue: fieldSchema.default,

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -114,9 +114,8 @@ test('keyframe display offsets follow the parent sequence context', () => {
 	expect(
 		getTimelineKeyframes(
 			{
-				canUpdate: true,
+				status: 'keyframed',
 				codeValue: undefined,
-				keyframed: true,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 2},

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -164,9 +164,8 @@ test('copying a keyframed effect is blocked', () => {
 					effectIndex: 0,
 					props: {
 						intensity: {
-							canUpdate: true,
+							status: 'keyframed',
 							codeValue: 10,
-							keyframed: true,
 							interpolationFunction: 'interpolate',
 							keyframes: [{frame: 0, value: 10}],
 							easing: ['linear'],
@@ -342,8 +341,8 @@ test('Backspace reset targets multiple selected sequence props', () => {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
-				opacity: {canUpdate: true, codeValue: 0.5, keyframed: false},
-				'style.rotate': {canUpdate: true, codeValue: '45deg', keyframed: false},
+				opacity: {status: 'static', codeValue: 0.5},
+				'style.rotate': {status: 'static', codeValue: '45deg'},
 			},
 			effects: [],
 		},
@@ -388,7 +387,7 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			startY: 20,
 			target: {
 				clientId: 'client',
-				codeValue: {canUpdate: true, codeValue: '10px 20px', keyframed: false},
+				codeValue: {status: 'static', codeValue: '10px 20px'},
 				fieldDefault: '0px 0px',
 				nodePath: firstNodePath,
 				schema,
@@ -401,7 +400,7 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			startY: 3,
 			target: {
 				clientId: 'client',
-				codeValue: {canUpdate: true, codeValue: '-5px 3px', keyframed: false},
+				codeValue: {status: 'static', codeValue: '-5px 3px'},
 				fieldDefault: '0px 0px',
 				nodePath: secondNodePath,
 				schema,
@@ -463,7 +462,7 @@ test('Backspace reset targets selected effect props', () => {
 					importPath: null,
 					effectIndex: 0,
 					props: {
-						intensity: {canUpdate: true, codeValue: 10, keyframed: false},
+						intensity: {status: 'static', codeValue: 10},
 					},
 				},
 			],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Refactors visual-mode sequence/effect prop code values from `canUpdate`/`keyframed` booleans to a `status` discriminated union: `static`, `keyframed`, or `computed`.
- Updates Studio timeline, outline, reset, clipboard, and optimistic update paths to branch explicitly on `status`.
- Updates parser/codemod/unit tests for the new status shape.

Fixes #8024.

## Testing

- `bun test packages/core/src/test/interpolate-keyframed-status.test.ts packages/studio-shared/src/test/optimistic-add-keyframe.test.ts packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts packages/studio-shared/src/test/optimistic-update-for-code-values.test.ts packages/studio-shared/src/test/optimistic-update-for-effect-code-values.test.ts packages/studio-server/src/test/compute-sequence-props-status.test.ts packages/studio-server/src/test/compute-effect-props-status.test.ts packages/studio-server/src/test/update-keyframes.test.ts packages/studio-server/src/test/unsupported-translate.test.ts packages/studio/src/test/timeline-keyframes.test.ts packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run formatting`
- `(cd packages/core && bun run lint) && (cd packages/studio && bun run lint) && (cd packages/studio-shared && bun run lint) && (cd packages/studio-server && bun run lint)`
- `bun run stylecheck` (fails on known environment issue: `@remotion/lambda-go` requires Go >= 1.23.0, VM has Go 1.22.2)
- `curl -I http://localhost:3000` after starting `packages/example` with `bun run dev -- --gl=angle`; manual screenshot/video was blocked by the computer-use executor returning `No handler found for server message of type computerUseArgs`. Remotion Studio server remained running and returned HTTP 200.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa2b928d-2779-4ca8-ad01-caed198c09c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa2b928d-2779-4ca8-ad01-caed198c09c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

