### PR TITLE
`@remotion/studio`: Restore canvas resize responsiveness

### DIFF
--- a/packages/studio/src/components/CanvasIfSizeIsAvailable.tsx
+++ b/packages/studio/src/components/CanvasIfSizeIsAvailable.tsx
@@ -1,17 +1,15 @@
-import {useContext, useMemo} from 'react';
-import {Internals} from 'remotion';
+import type {Size} from '@remotion/player';
+import {useMemo} from 'react';
 import {RULER_WIDTH} from '../state/editor-rulers';
 import {CanvasOrLoading} from './CanvasOrLoading';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
 
-export const CanvasIfSizeIsAvailable: React.FC = () => {
+export const CanvasIfSizeIsAvailable: React.FC<{
+	readonly size: Size | null;
+}> = ({size}) => {
 	const rulersAreVisible = useIsRulerVisible();
-	const context = useContext(Internals.CurrentScaleContext);
 
 	const sizeWithRulersApplied = useMemo(() => {
-		const size =
-			context && context.type === 'canvas-size' ? context.canvasSize : null;
-
 		if (!rulersAreVisible) {
 			return size;
 		}
@@ -25,7 +23,7 @@ export const CanvasIfSizeIsAvailable: React.FC = () => {
 			width: size.width - RULER_WIDTH,
 			height: size.height - RULER_WIDTH,
 		};
-	}, [context, rulersAreVisible]);
+	}, [rulersAreVisible, size]);
 
 	if (!sizeWithRulersApplied) {
 		return null;

--- a/packages/studio/src/components/Editor.tsx
+++ b/packages/studio/src/components/Editor.tsx
@@ -96,6 +96,7 @@ export const Editor: React.FC<{
 									<EditorContent readOnlyStudio={readOnlyStudio}>
 										<TopPanel
 											drawRef={drawRef}
+											size={size}
 											bufferStateDelayInMilliseconds={
 												BUFFER_STATE_DELAY_IN_MILLISECONDS
 											}

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -1,3 +1,4 @@
+import type {Size} from '@remotion/player';
 import React, {useCallback, useContext, useEffect, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {useMobileLayout} from '../helpers/mobile-layout';
@@ -57,8 +58,15 @@ const TopPanelInner: React.FC<{
 	readonly readOnlyStudio: boolean;
 	readonly onMounted: () => void;
 	readonly drawRef: React.RefObject<HTMLDivElement | null>;
+	readonly size: Size | null;
 	readonly bufferStateDelayInMilliseconds: number;
-}> = ({readOnlyStudio, onMounted, drawRef, bufferStateDelayInMilliseconds}) => {
+}> = ({
+	readOnlyStudio,
+	onMounted,
+	drawRef,
+	size,
+	bufferStateDelayInMilliseconds,
+}) => {
 	const {setSidebarCollapsedState, sidebarCollapsedStateRight} =
 		useContext(SidebarContext);
 	const rulersAreVisible = useIsRulerVisible();
@@ -144,7 +152,7 @@ const TopPanelInner: React.FC<{
 							>
 								<SplitterElement sticky={null} type="flexer">
 									<div ref={drawRef} style={canvasContainerStyle}>
-										<CanvasIfSizeIsAvailable />
+										<CanvasIfSizeIsAvailable size={size} />
 									</div>
 								</SplitterElement>
 								{actualStateRight === 'expanded' ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Pass the measured Studio canvas size through `TopPanel` so the memoized canvas subtree receives resize updates.
- Keep ruler-adjusted sizing in `CanvasIfSizeIsAvailable` based on the explicit size prop.

## Testing
- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run formatting --filter='@remotion/studio'`
- `bun run build`
- `bun run build && bun run stylecheck` (build completed; stylecheck hit the documented `@remotion/lambda-go` Go 1.22.2 / Go >= 1.23.0 caveat)
- `curl -sS -I http://localhost:3000 && curl -sS http://localhost:3000 | rg -n "Remotion|studio|root|script|bundle"`
- `bunx remotion compositions` from `packages/example`

## Tradeoffs
- This mirrors the previous Studio responsiveness fix by using prop updates to refresh the memoized panel subtree, without changing shared `useElementSize` behavior.
- GUI resize verification was blocked because the computer-use executor failed and Chrome headless/CDP hung or crashed in this VM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7bb9284-0e2d-4d46-9865-6fc1fb8b3103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7bb9284-0e2d-4d46-9865-6fc1fb8b3103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

