### PR TITLE
`@remotion/studio-server`: Resolve Prettier config for null override

### DIFF
--- a/packages/studio-server/src/codemods/format-file-content.ts
+++ b/packages/studio-server/src/codemods/format-file-content.ts
@@ -23,7 +23,7 @@ export const formatFileContent = async ({
 
 	let prettierConfig: Record<string, unknown> | null;
 
-	if (prettierConfigOverride !== undefined) {
+	if (prettierConfigOverride !== undefined && prettierConfigOverride !== null) {
 		prettierConfig = prettierConfigOverride;
 	} else {
 		const configFilePath = await resolveConfigFile();

--- a/packages/studio-server/src/test/code-shift.test.ts
+++ b/packages/studio-server/src/test/code-shift.test.ts
@@ -44,3 +44,17 @@ export const Component = () => {
 };
 `);
 });
+
+test('Should resolve prettier config if override is null', async () => {
+	const {output, formatted} = await updateSequenceProps({
+		input: componentInput,
+		nodePath: lineColumnToNodePath(componentInput, 6),
+		updates: [{key: 'style.scale', value: 2, defaultValue: null}],
+		prettierConfigOverride: null,
+		schema: NoReactInternals.sequenceSchema,
+	});
+
+	expect(formatted).toBe(true);
+	expect(output).toContain('\treturn (');
+	expect(output).toContain('style={{');
+});


### PR DESCRIPTION
Fixes #7970.

## Summary
- Resolve the project Prettier config when codemods pass `prettierConfigOverride: null`.

## Testing
- `cd packages/studio-server && bunx oxfmt src --write && bun test src/test/code-shift.test.ts`
- `bun run build`
- `bun run formatting`
