### PR TITLE
`remotion`: Make playback rates non-keyframable

### DIFF
--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -44,6 +44,7 @@ const animatedImageSchema = {
 		default: 1,
 		description: 'Playback Rate',
 		hiddenFromList: false,
+		keyframable: false,
 	},
 	...sequenceVisualStyleSchema,
 	hidden: hiddenField,

--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -1,5 +1,6 @@
 export type HiddenFieldSchema = {
 	type: 'hidden';
+	keyframable?: boolean;
 };
 
 export type NumberFieldSchema = {
@@ -10,12 +11,14 @@ export type NumberFieldSchema = {
 	default: number | undefined;
 	description?: string;
 	hiddenFromList: boolean;
+	keyframable?: boolean;
 };
 
 export type BooleanFieldSchema = {
 	type: 'boolean';
 	default: boolean;
 	description?: string;
+	keyframable?: boolean;
 };
 
 export type RotationCssFieldSchema = {
@@ -23,6 +26,7 @@ export type RotationCssFieldSchema = {
 	step?: number;
 	default: string | undefined;
 	description?: string;
+	keyframable?: boolean;
 };
 
 export type RotationDegreesFieldSchema = {
@@ -32,6 +36,7 @@ export type RotationDegreesFieldSchema = {
 	step?: number;
 	default: number | undefined;
 	description?: string;
+	keyframable?: boolean;
 };
 
 export type TranslateFieldSchema = {
@@ -39,6 +44,7 @@ export type TranslateFieldSchema = {
 	step?: number;
 	default: string | undefined;
 	description?: string;
+	keyframable?: boolean;
 };
 
 export type ScaleFieldSchema = {
@@ -48,6 +54,7 @@ export type ScaleFieldSchema = {
 	step?: number;
 	default: number | string | undefined;
 	description?: string;
+	keyframable?: boolean;
 };
 
 export type UvCoordinateFieldSchema = {
@@ -57,12 +64,14 @@ export type UvCoordinateFieldSchema = {
 	step?: number;
 	default: readonly [number, number] | undefined;
 	description?: string;
+	keyframable?: boolean;
 };
 
 export type ColorFieldSchema = {
 	type: 'color';
 	default: string | undefined;
 	description?: string;
+	keyframable?: boolean;
 };
 
 export type EnumFieldSchema = {
@@ -70,6 +79,7 @@ export type EnumFieldSchema = {
 	default: string;
 	description?: string;
 	variants: Record<string, SequenceSchema>;
+	keyframable?: boolean;
 };
 
 export type VisibleFieldSchema =

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -44,6 +44,7 @@ const gifSchema = {
 		default: 1,
 		description: 'Playback Rate',
 		hiddenFromList: false,
+		keyframable: false,
 	},
 	...Internals.sequenceVisualStyleSchema,
 	hidden: Internals.hiddenField,

--- a/packages/media/src/audio/audio.tsx
+++ b/packages/media/src/audio/audio.tsx
@@ -31,6 +31,7 @@ const audioSchema = {
 		default: 1,
 		description: 'Playback Rate',
 		hiddenFromList: false,
+		keyframable: false,
 	},
 	loop: {type: 'boolean', default: false, description: 'Loop'},
 	hidden: Internals.hiddenField,

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -32,6 +32,7 @@ const videoSchema = {
 		default: 1,
 		description: 'Playback Rate',
 		hiddenFromList: false,
+		keyframable: false,
 	},
 	hidden: {
 		type: 'boolean',

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -14,6 +14,7 @@ import {
 	getKeyframeInterpolationFunction,
 	getKeyframeInterpolationFunctionForSchemaField,
 	isKeyframeInterpolationFunction,
+	isSchemaFieldKeyframable,
 	type KeyframeInterpolationFunction,
 } from '@remotion/studio-shared';
 import type {ExpressionKind, SpreadElementKind} from 'ast-types/lib/gen/kinds';
@@ -22,8 +23,8 @@ import type {SequenceNodePath, SequenceSchema} from 'remotion';
 import {getAstNodePath} from '../../helpers/get-ast-node-path';
 import {
 	extractStaticValue,
-	findNodePathForJsxElement,
 	findJsxElementAtNodePath,
+	findNodePathForJsxElement,
 	isStaticValue,
 } from '../../preview-server/routes/can-update-sequence-props';
 import {formatFileContent} from '../format-file-content';
@@ -262,6 +263,10 @@ const addKeyframe = ({
 	value: unknown;
 	schema: SequenceSchema | null;
 }): {expression: ExpressionKind; introduced: IntroducedKeyframeIdentifiers} => {
+	if (!isSchemaFieldKeyframable({schema, key})) {
+		throw new Error(`Cannot add keyframe: "${key}" is not keyframable`);
+	}
+
 	const existing = getInterpolationExpression(expression);
 	const newOutput = parseValueExpression(value);
 

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -118,6 +118,34 @@ test('updateSequenceKeyframes converts a static value to an interpolation', asyn
 	expect(output).toContain('opacity: interpolate(frame, [25], [0.75])');
 });
 
+test('updateSequenceKeyframes rejects non-keyframable fields', async () => {
+	const schema = {
+		'style.opacity': {
+			type: 'number',
+			default: 1,
+			hiddenFromList: false,
+			keyframable: false,
+		},
+	} satisfies SequenceSchema;
+
+	await expect(
+		updateSequenceKeyframes({
+			input: sequenceInput,
+			nodePath: lineColumnToNodePath(
+				sequenceInput,
+				getLine(sequenceInput, 'opacity'),
+			),
+			schema,
+			updates: [
+				{
+					key: 'style.opacity',
+					operation: {type: 'add', frame: 25, value: 0.75},
+				},
+			],
+		}),
+	).rejects.toThrow(/not keyframable/);
+});
+
 test('updateSequenceKeyframes converts a static value to a single-keyframe interpolation at frame 0', async () => {
 	const {output, oldValueStrings} = await updateSequenceKeyframes({
 		input: sequenceInput,

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -108,6 +108,7 @@ export {
 	getKeyframeInterpolationFunction,
 	getKeyframeInterpolationFunctionForSchemaField,
 	isKeyframeInterpolationFunction,
+	isSchemaFieldKeyframable,
 	keyframeInterpolationFunctions,
 	type KeyframeInterpolationFunction,
 } from './keyframe-interpolation-function';

--- a/packages/studio-shared/src/keyframe-interpolation-function.ts
+++ b/packages/studio-shared/src/keyframe-interpolation-function.ts
@@ -41,6 +41,17 @@ const findFieldInSchema = (
 	return undefined;
 };
 
+export const isSchemaFieldKeyframable = ({
+	schema,
+	key,
+}: {
+	schema: SequenceSchema | null;
+	key: string;
+}): boolean => {
+	const field = schema ? findFieldInSchema(schema, key) : undefined;
+	return field?.keyframable !== false;
+};
+
 export const getKeyframeInterpolationFunctionForSchemaField = ({
 	schema,
 	key,

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -3,7 +3,10 @@ import {
 	type CanUpdateSequencePropsResponse,
 	type SequenceSchema,
 } from 'remotion';
-import {getKeyframeInterpolationFunction} from './keyframe-interpolation-function';
+import {
+	getKeyframeInterpolationFunction,
+	isSchemaFieldKeyframable,
+} from './keyframe-interpolation-function';
 
 const addKeyframeToPropStatus = ({
 	status,
@@ -87,6 +90,10 @@ export const optimisticAddSequenceKeyframe = ({
 		return previous;
 	}
 
+	if (!isSchemaFieldKeyframable({schema: schema ?? null, key: fieldKey})) {
+		return previous;
+	}
+
 	const status = previous.props[fieldKey];
 	if (!status) {
 		return previous;
@@ -123,6 +130,10 @@ export const optimisticAddEffectKeyframe = ({
 	schema?: SequenceSchema;
 }): CanUpdateSequencePropsResponse => {
 	if (!previous.canUpdate) {
+		return previous;
+	}
+
+	if (!isSchemaFieldKeyframable({schema: schema ?? null, key: fieldKey})) {
 		return previous;
 	}
 

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -76,6 +76,37 @@ test('optimisticAddSequenceKeyframe uses interpolateTranslate for translate fiel
 	expect(status.keyframes).toEqual([{frame: 44, value: '0px 59px'}]);
 });
 
+test('optimisticAddSequenceKeyframe ignores non-keyframable fields', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			playbackRate: {
+				status: 'static',
+				codeValue: 1,
+			},
+		},
+		effects: [],
+	};
+	const schema = {
+		playbackRate: {
+			type: 'number',
+			default: 1,
+			hiddenFromList: false,
+			keyframable: false,
+		},
+	} satisfies SequenceSchema;
+
+	const updated = optimisticAddSequenceKeyframe({
+		previous,
+		fieldKey: 'playbackRate',
+		frame: 25,
+		value: 2,
+		schema,
+	});
+
+	expect(updated).toEqual(previous);
+});
+
 test('optimisticAddSequenceKeyframe appends a keyframe to an existing interpolation', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -284,6 +284,7 @@ export const TimelineEffectPropItem: React.FC<{
 		shouldShowTimelineKeyframeControls({
 			propStatus,
 			selected: selection.selected,
+			keyframable: field.fieldSchema.keyframable !== false,
 		}) ? (
 			<TimelineKeyframeControls
 				fieldKey={field.key}

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -105,11 +105,17 @@ const getCurrentKeyframeValue = ({
 export const shouldShowTimelineKeyframeControls = ({
 	propStatus,
 	selected,
+	keyframable,
 }: {
 	propStatus: CanUpdateSequencePropStatus | null;
 	selected: boolean;
+	keyframable: boolean;
 }): boolean => {
 	if (propStatus === null) {
+		return false;
+	}
+
+	if (!keyframable && !isKeyframedStatus(propStatus)) {
 		return false;
 	}
 
@@ -190,8 +196,10 @@ export const TimelineKeyframeControls: React.FC<{
 	);
 
 	const fieldSchema = schema[fieldKey];
+	const keyframable = fieldSchema?.keyframable !== false;
 	const canAddKeyframe =
-		fieldSchema?.type !== 'scale' || typeof currentKeyframeValue === 'number';
+		keyframable &&
+		(fieldSchema?.type !== 'scale' || typeof currentKeyframeValue === 'number');
 	const canToggleKeyframe =
 		propStatus.status !== 'computed' &&
 		(hasKeyframeAtCurrentFrame || canAddKeyframe);

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -195,6 +195,7 @@ export const TimelineSequencePropItem: React.FC<{
 		shouldShowTimelineKeyframeControls({
 			propStatus: codeValue,
 			selected: selection.selected,
+			keyframable: field.fieldSchema.keyframable !== false,
 		}) ? (
 			<TimelineKeyframeControls
 				fieldKey={field.key}


### PR DESCRIPTION
## Summary

- Add a schema-level keyframable flag for visual-mode fields
- Mark playbackRate fields as non-keyframable for media, GIF, and animated image components
- Block adding non-keyframable keyframes in optimistic updates and codemods

Fixes #8040

## Testing

- bun run build
- bun run formatting
