### PR TITLE
`@remotion/effects`: Add center control to vignette effect

### DIFF
--- a/packages/docs/components/effects/effects-vignette-preview.tsx
+++ b/packages/docs/components/effects/effects-vignette-preview.tsx
@@ -1,4 +1,8 @@
-import {vignette, type VignetteMode} from '@remotion/effects/vignette';
+import {
+	vignette,
+	type VignetteCenter,
+	type VignetteMode,
+} from '@remotion/effects/vignette';
 import React from 'react';
 import {AbsoluteFill, CanvasImage} from 'remotion';
 import {EFFECTS_PREVIEW_IMAGE_SRC} from './effects-preview-image';
@@ -23,7 +27,8 @@ export const EffectsVignettePreview: React.FC<{
 	readonly roundness: number;
 	readonly color: string;
 	readonly mode: VignetteMode;
-}> = ({amount, radius, feather, roundness, color, mode}) => {
+	readonly center: VignetteCenter;
+}> = ({amount, radius, feather, roundness, color, mode, center}) => {
 	return (
 		<AbsoluteFill style={checkerboard}>
 			<CanvasImage
@@ -40,6 +45,7 @@ export const EffectsVignettePreview: React.FC<{
 						roundness,
 						color,
 						mode,
+						center,
 					}),
 				]}
 			/>

--- a/packages/docs/docs/effects/vignette.mdx
+++ b/packages/docs/docs/effects/vignette.mdx
@@ -35,6 +35,7 @@ export const MyComp: React.FC = () => {
             amount: 0.75,
             radius: 0.55,
             feather: 0.35,
+            center: [0.35, 0.5],
             color: '#000000',
           }),
         ]}
@@ -60,6 +61,12 @@ Strength from `0` to `1`. Defaults to `0.5`.
 Size of the unaffected center from `0` to `1`. Defaults to `0.65`.
 
 Higher values move the vignette closer to the outer edge.
+
+### `center?`
+
+Center of the vignette in UV coordinates. Defaults to `[0.5, 0.5]`.
+
+Values below `0` or above `1` are allowed.
 
 ### `feather?`
 

--- a/packages/docs/src/remotion/Root.tsx
+++ b/packages/docs/src/remotion/Root.tsx
@@ -220,6 +220,7 @@ export const RemotionRoot: React.FC = () => {
 						roundness: 1,
 						mode: 'color',
 						color: '#000000',
+						center: [0.5, 0.5],
 					}}
 				/>
 				<Still

--- a/packages/effects/src/test/effect-params.test.ts
+++ b/packages/effects/src/test/effect-params.test.ts
@@ -970,6 +970,7 @@ test('vignette() accepts valid color mode params', () => {
 			roundness: 0.9,
 			color: '#221144',
 			mode: 'color',
+			center: [0.3, 0.8],
 		}),
 	).not.toThrow();
 });
@@ -1001,6 +1002,17 @@ test('vignette() rejects roundness above range', () => {
 	expect(() => vignette({roundness: 1.1})).toThrow('"roundness" must be <= 1');
 });
 
+test('vignette() rejects invalid center', () => {
+	const invalidCenter = [0.5] as unknown as [number, number];
+	expect(() => vignette({center: invalidCenter})).toThrow(
+		'"center" must be a [number, number] tuple',
+	);
+});
+
+test('vignette() accepts center outside the unit square', () => {
+	expect(() => vignette({center: [-0.25, 1.25]})).not.toThrow();
+});
+
 test('vignette() rejects empty color strings', () => {
 	expect(() => vignette({color: ''})).toThrow(
 		'"color" must be a non-empty string, but got ""',
@@ -1026,6 +1038,7 @@ test('vignette() parameters produce distinct effect keys', () => {
 	const rectangularVignette = vignette({roundness: 0});
 	const coloredVignette = vignette({color: '#0000ff'});
 	const alphaVignette = vignette({mode: 'alpha'});
+	const shiftedVignette = vignette({center: [0.3, 0.7]});
 
 	expect(
 		new Set([
@@ -1036,8 +1049,9 @@ test('vignette() parameters produce distinct effect keys', () => {
 			rectangularVignette.effectKey,
 			coloredVignette.effectKey,
 			alphaVignette.effectKey,
+			shiftedVignette.effectKey,
 		]).size,
-	).toBe(7);
+	).toBe(8);
 });
 
 test('halftone() accepts default params', () => {

--- a/packages/effects/src/vignette.ts
+++ b/packages/effects/src/vignette.ts
@@ -21,6 +21,7 @@ const DEFAULT_FEATHER = 0.35 as const;
 const DEFAULT_ROUNDNESS = 1 as const;
 const DEFAULT_COLOR = '#000000' as const;
 const DEFAULT_MODE = 'color' as const;
+const DEFAULT_CENTER = [0.5, 0.5] as const;
 
 export const vignetteSchema = {
 	amount: {
@@ -73,9 +74,16 @@ export const vignetteSchema = {
 			alpha: {},
 		},
 	},
+	center: {
+		type: 'uv-coordinate',
+		step: 0.01,
+		default: DEFAULT_CENTER,
+		description: 'Center',
+	},
 } as const satisfies SequenceSchema;
 
 export type VignetteMode = (typeof VIGNETTE_MODES)[number];
+export type VignetteCenter = readonly [number, number];
 
 export type VignetteParams = {
 	/** Strength of the vignette from `0` to `1`. Defaults to `0.5`. */
@@ -90,6 +98,8 @@ export type VignetteParams = {
 	readonly color?: string;
 	/** `color` blends a color into the edges, `alpha` fades edges transparent. Defaults to `color`. */
 	readonly mode?: VignetteMode;
+	/** Center of the vignette in UV coordinates. Defaults to `[0.5, 0.5]`. */
+	readonly center?: VignetteCenter;
 };
 
 type VignetteResolved = {
@@ -99,6 +109,7 @@ type VignetteResolved = {
 	roundness: number;
 	color: string;
 	mode: VignetteMode;
+	center: VignetteCenter;
 };
 
 type VignetteState = {
@@ -115,6 +126,7 @@ type VignetteState = {
 		readonly uRoundness: WebGLUniformLocation | null;
 		readonly uColor: WebGLUniformLocation | null;
 		readonly uMode: WebGLUniformLocation | null;
+		readonly uCenter: WebGLUniformLocation | null;
 	};
 	readonly colorCtx: CanvasRenderingContext2D;
 	cachedColor: string;
@@ -155,7 +167,22 @@ const resolve = (p: VignetteParams): VignetteResolved => ({
 	roundness: p.roundness ?? DEFAULT_ROUNDNESS,
 	color: p.color ?? DEFAULT_COLOR,
 	mode: p.mode ?? DEFAULT_MODE,
+	center: [...(p.center ?? DEFAULT_CENTER)] as VignetteCenter,
 });
+
+const assertOptionalUvCoordinate = (value: unknown, name: string): void => {
+	if (value === undefined) {
+		return;
+	}
+
+	if (
+		!Array.isArray(value) ||
+		value.length !== 2 ||
+		value.some((item) => typeof item !== 'number' || !Number.isFinite(item))
+	) {
+		throw new TypeError(`"${name}" must be a [number, number] tuple`);
+	}
+};
 
 const validateVignetteParams = (params: VignetteParams): void => {
 	assertEffectParamsObject(params, 'Vignette');
@@ -165,6 +192,7 @@ const validateVignetteParams = (params: VignetteParams): void => {
 	assertOptionalFiniteNumber(params.roundness, 'roundness');
 	assertOptionalColor(params.color, 'color');
 	assertOptionalEnum(params.mode, 'mode', VIGNETTE_MODES);
+	assertOptionalUvCoordinate(params.center, 'center');
 
 	const r = resolve(params);
 	validateUnitInterval(r.amount, 'amount');
@@ -197,9 +225,10 @@ uniform float uFeather;
 uniform float uRoundness;
 uniform vec4 uColor;
 uniform int uMode;
+uniform vec2 uCenter;
 
 float vignetteMask() {
-	vec2 centered = abs(vUv * 2.0 - 1.0);
+	vec2 centered = abs(vUv - uCenter) * 2.0;
 	float rectangleDistance = max(centered.x, centered.y);
 	float ellipseDistance = length(centered);
 	float distanceFromCenter = mix(rectangleDistance, ellipseDistance, uRoundness);
@@ -367,6 +396,7 @@ const setupVignette = (target: HTMLCanvasElement): VignetteState => {
 			uRoundness: gl.getUniformLocation(program, 'uRoundness'),
 			uColor: gl.getUniformLocation(program, 'uColor'),
 			uMode: gl.getUniformLocation(program, 'uMode'),
+			uCenter: gl.getUniformLocation(program, 'uCenter'),
 		},
 		colorCtx,
 		cachedColor: '',
@@ -399,7 +429,7 @@ export const vignette = createEffect<VignetteParams, VignetteState>({
 	backend: 'webgl2',
 	calculateKey: (params) => {
 		const r = resolve(params);
-		return `vignette-${r.amount}-${r.radius}-${r.feather}-${r.roundness}-${r.color}-${r.mode}`;
+		return `vignette-${r.amount}-${r.radius}-${r.feather}-${r.roundness}-${r.color}-${r.mode}-${r.center.join(':')}`;
 	},
 	setup: (target) => setupVignette(target),
 	apply: ({source, width, height, params, state, flipSourceY}) => {
@@ -434,6 +464,8 @@ export const vignette = createEffect<VignetteParams, VignetteState>({
 		if (uniforms.uColor) gl.uniform4f(uniforms.uColor, red, green, blue, alpha);
 		if (uniforms.uMode)
 			gl.uniform1i(uniforms.uMode, r.mode === 'alpha' ? 1 : 0);
+		if (uniforms.uCenter)
+			gl.uniform2f(uniforms.uCenter, r.center[0], r.center[1]);
 
 		gl.bindVertexArray(vao);
 		gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Fixes #8054.

## Summary
- Add a `center` UV coordinate option to `vignette()`.
- Wire the option into the WebGL shader, effect key, docs demo, preview composition, and vignette docs.

## Walkthrough
<a href="https://cursor.com/agents/bc-9a997782-5a8d-44f3-bda2-864fd57b91ef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvignette_center_shifted_clean_demo.mp4"><img src="https://cursor.com/artifacts/c/art-5bf05be5-c4f6-4a18-91c8-5ec5b0c0e35d" alt="vignette_center_shifted_clean_demo.mp4" /></a>
![Shifted center vignette still](https://cursor.com/artifacts/c/art-9e081f91-81ba-4280-a05e-dd7720be6197)

## Testing
- `bun test src/test/effect-params.test.ts` in `packages/effects`
- `bunx turbo run make --filter='@remotion/effects'`
- `bun run build`
- `bun run formatting`
- `bun run lint` in `packages/effects`
- `bun run lint` in `packages/docs`
- `bunx remotion still src/remotion/entry.ts effects-vignette-preview /opt/cursor/artifacts/vignette_center_shifted.png --overwrite --image-format=png --props='{"amount":1,"radius":0.25,"feather":0.2,"roundness":1,"mode":"color","color":"#000000","center":[0.25,0.5]}'` in `packages/docs`
- Manual browser walkthrough of the rendered shifted-center still

## Notes
- `bun run stylecheck` is blocked by the repository's known `@remotion/lambda-go` lint environment issue: the VM has Go 1.22.2, while `golang.org/x/crypto@v0.35.0` requires Go >= 1.23.0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a997782-5a8d-44f3-bda2-864fd57b91ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a997782-5a8d-44f3-bda2-864fd57b91ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

