### PR TITLE
`@remotion/studio-server`: Allow keyframes on missing sequence props

### DIFF
--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -19,7 +19,11 @@ import {
 } from '@remotion/studio-shared';
 import type {ExpressionKind, SpreadElementKind} from 'ast-types/lib/gen/kinds';
 import * as recast from 'recast';
-import type {SequenceNodePath, SequenceSchema} from 'remotion';
+import type {
+	SequenceFieldSchema,
+	SequenceNodePath,
+	SequenceSchema,
+} from 'remotion';
 import {getAstNodePath} from '../../helpers/get-ast-node-path';
 import {
 	extractStaticValue,
@@ -66,6 +70,10 @@ export type EffectKeyframeUpdate = {
 type WritableProp = {
 	expression: Expression;
 	setExpression: (expression: ExpressionKind) => void;
+};
+
+type MissingPropInitialValue = {
+	value: unknown;
 };
 
 type InterpolateKeyframe = {
@@ -471,6 +479,47 @@ const findObjectProperty = (
 	};
 };
 
+const findFieldInSchema = (
+	schema: SequenceSchema,
+	key: string,
+): SequenceFieldSchema | undefined => {
+	if (key in schema) {
+		return schema[key];
+	}
+
+	for (const field of Object.values(schema)) {
+		if (field.type !== 'enum') {
+			continue;
+		}
+
+		for (const variant of Object.values(field.variants)) {
+			const found = findFieldInSchema(variant, key);
+			if (found) {
+				return found;
+			}
+		}
+	}
+
+	return undefined;
+};
+
+const getInitialValueForMissingProp = ({
+	schema,
+	key,
+	newValue,
+}: {
+	schema: SequenceSchema | null;
+	key: string;
+	newValue: unknown;
+}): unknown => {
+	const field = schema ? findFieldInSchema(schema, key) : undefined;
+	if (field && field.type !== 'hidden' && field.default !== undefined) {
+		return field.default;
+	}
+
+	return newValue;
+};
+
 const getObjectExpression = (attr: JSXAttribute): ObjectExpression | null => {
 	if (!attr.value || attr.value.type !== 'JSXExpressionContainer') {
 		return null;
@@ -486,14 +535,32 @@ const getObjectExpression = (attr: JSXAttribute): ObjectExpression | null => {
 const getSequenceWritableProp = ({
 	attributes,
 	key,
+	missingPropInitialValue,
 }: {
 	attributes: (JSXAttribute | JSXSpreadAttribute)[];
 	key: string;
+	missingPropInitialValue: MissingPropInitialValue | null;
 }): WritableProp => {
 	const dotIndex = key.indexOf('.');
 	if (dotIndex === -1) {
 		const {attr: topLevelAttr} = findJsxAttribute(attributes, key);
 		if (!topLevelAttr) {
+			if (missingPropInitialValue) {
+				return {
+					expression: parseValueExpression(
+						missingPropInitialValue.value,
+					) as Expression,
+					setExpression: (nextExpression) => {
+						attributes.push(
+							b.jsxAttribute(
+								b.jsxIdentifier(key),
+								b.jsxExpressionContainer(nextExpression),
+							) as JSXAttribute,
+						);
+					},
+				};
+			}
+
 			throw new Error(`Cannot update keyframes: "${key}" is not set`);
 		}
 
@@ -520,6 +587,26 @@ const getSequenceWritableProp = ({
 	const childKey = key.slice(dotIndex + 1);
 	const {attr: parentAttr} = findJsxAttribute(attributes, parentKey);
 	if (!parentAttr) {
+		if (missingPropInitialValue) {
+			return {
+				expression: parseValueExpression(
+					missingPropInitialValue.value,
+				) as Expression,
+				setExpression: (nextExpression) => {
+					attributes.push(
+						b.jsxAttribute(
+							b.jsxIdentifier(parentKey),
+							b.jsxExpressionContainer(
+								b.objectExpression([
+									b.objectProperty(b.identifier(childKey), nextExpression),
+								]),
+							),
+						) as JSXAttribute,
+					);
+				},
+			};
+		}
+
 		throw new Error(`Cannot update keyframes: "${parentKey}" is not set`);
 	}
 
@@ -530,6 +617,22 @@ const getSequenceWritableProp = ({
 
 	const {prop} = findObjectProperty(objExpr, childKey);
 	if (!prop) {
+		if (missingPropInitialValue) {
+			return {
+				expression: parseValueExpression(
+					missingPropInitialValue.value,
+				) as Expression,
+				setExpression: (nextExpression) => {
+					objExpr.properties.push(
+						b.objectProperty(
+							b.identifier(childKey),
+							nextExpression,
+						) as ObjectProperty,
+					);
+				},
+			};
+		}
+
 		throw new Error(`Cannot update keyframes: "${key}" is not set`);
 	}
 
@@ -580,6 +683,16 @@ export const updateSequenceKeyframesAst = ({
 		const prop = getSequenceWritableProp({
 			attributes: node.attributes,
 			key: update.key,
+			missingPropInitialValue:
+				update.operation.type === 'add'
+					? {
+							value: getInitialValueForMissingProp({
+								schema: schema ?? null,
+								key: update.key,
+								newValue: update.operation.value,
+							}),
+						}
+					: null,
 		});
 		oldValueStrings.push(recast.print(prop.expression).code);
 		const {expression: nextExpression, introduced} = applyKeyframeOperation({

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -532,6 +532,42 @@ const getObjectExpression = (attr: JSXAttribute): ObjectExpression | null => {
 	return attr.value.expression as ObjectExpression;
 };
 
+const createJsxExpressionAttribute = (
+	key: string,
+	expression: ExpressionKind,
+): JSXAttribute => {
+	return b.jsxAttribute(
+		b.jsxIdentifier(key),
+		b.jsxExpressionContainer(expression),
+	) as JSXAttribute;
+};
+
+const createObjectProperty = (key: string, value: ExpressionKind) =>
+	b.objectProperty(b.identifier(key), value);
+
+const createObjectExpressionAttribute = ({
+	parentKey,
+	childKey,
+	expression,
+}: {
+	parentKey: string;
+	childKey: string;
+	expression: ExpressionKind;
+}): JSXAttribute => {
+	return createJsxExpressionAttribute(
+		parentKey,
+		b.objectExpression([
+			createObjectProperty(childKey, expression),
+		]) as ExpressionKind,
+	);
+};
+
+const createMissingPropExpression = (
+	missingPropInitialValue: MissingPropInitialValue,
+): Expression => {
+	return parseValueExpression(missingPropInitialValue.value) as Expression;
+};
+
 const getSequenceWritableProp = ({
 	attributes,
 	key,
@@ -547,16 +583,9 @@ const getSequenceWritableProp = ({
 		if (!topLevelAttr) {
 			if (missingPropInitialValue) {
 				return {
-					expression: parseValueExpression(
-						missingPropInitialValue.value,
-					) as Expression,
+					expression: createMissingPropExpression(missingPropInitialValue),
 					setExpression: (nextExpression) => {
-						attributes.push(
-							b.jsxAttribute(
-								b.jsxIdentifier(key),
-								b.jsxExpressionContainer(nextExpression),
-							) as JSXAttribute,
-						);
+						attributes.push(createJsxExpressionAttribute(key, nextExpression));
 					},
 				};
 			}
@@ -589,19 +618,14 @@ const getSequenceWritableProp = ({
 	if (!parentAttr) {
 		if (missingPropInitialValue) {
 			return {
-				expression: parseValueExpression(
-					missingPropInitialValue.value,
-				) as Expression,
+				expression: createMissingPropExpression(missingPropInitialValue),
 				setExpression: (nextExpression) => {
 					attributes.push(
-						b.jsxAttribute(
-							b.jsxIdentifier(parentKey),
-							b.jsxExpressionContainer(
-								b.objectExpression([
-									b.objectProperty(b.identifier(childKey), nextExpression),
-								]),
-							),
-						) as JSXAttribute,
+						createObjectExpressionAttribute({
+							parentKey,
+							childKey,
+							expression: nextExpression,
+						}),
 					);
 				},
 			};
@@ -619,15 +643,10 @@ const getSequenceWritableProp = ({
 	if (!prop) {
 		if (missingPropInitialValue) {
 			return {
-				expression: parseValueExpression(
-					missingPropInitialValue.value,
-				) as Expression,
+				expression: createMissingPropExpression(missingPropInitialValue),
 				setExpression: (nextExpression) => {
 					objExpr.properties.push(
-						b.objectProperty(
-							b.identifier(childKey),
-							nextExpression,
-						) as ObjectProperty,
+						createObjectProperty(childKey, nextExpression) as ObjectProperty,
 					);
 				},
 			};

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -228,6 +228,54 @@ test('updateSequenceKeyframes converts static translate to interpolateTranslate'
 	expect(output).toContain('interpolateTranslate');
 });
 
+test('updateSequenceKeyframes adds a missing nested prop before keyframing it', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+export const Example: React.FC = () => {
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{opacity: 1}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output, oldValueStrings, updatedNodePath} =
+		await updateSequenceKeyframes({
+			input,
+			nodePath: lineColumnToNodePath(input, getLine(input, '<div')),
+			schema: translateSchema,
+			updates: [
+				{
+					key: 'style.translate',
+					operation: {type: 'add', frame: 44, value: '100px 20px'},
+				},
+			],
+		});
+
+	expect(oldValueStrings).toEqual(['"0px 0px"']);
+	expect(output).toContain(
+		"translate: interpolateTranslate(frame, [44], ['100px 20px'])",
+	);
+	expect(output).toContain('useCurrentFrame');
+	expect(output).toContain('interpolateTranslate');
+	const status = computeSequencePropsStatusFromContent({
+		fileContents: output,
+		nodePath: updatedNodePath,
+		keys: ['style.translate'],
+		effects: [],
+	});
+	expect(status.props['style.translate']).toEqual({
+		status: 'keyframed',
+		codeValue: undefined,
+		interpolationFunction: 'interpolateTranslate',
+		keyframes: [{frame: 44, value: '100px 20px'}],
+		easing: [],
+		clamping: {left: 'extend', right: 'extend'},
+		posterize: undefined,
+	});
+});
+
 test('updateSequenceKeyframes migrates translate away from interpolateColors', async () => {
 	const input = translateInput
 		.replace(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8041

## Summary
- Allow add-keyframe codemods to materialize missing sequence props before converting them to keyframed expressions.
- Use schema defaults, such as `style.translate` = `0px 0px`, as the implied previous value when available.
- Add a regression test for adding a `style.translate` keyframe when the style object does not yet contain `translate`.

## Testing
- `bun test src/test/update-keyframes.test.ts`
- `bun run build && bun run formatting`
- `bun run stylecheck` (fails only on known `@remotion/lambda-go` Go >= 1.23 requirement in this VM)
- `bunx turbo run lint formatting --filter='@remotion/studio-server'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61fe9c03-5a30-495f-beea-6562db44f91b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61fe9c03-5a30-495f-beea-6562db44f91b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

