### PR TITLE
`create-video`: Handle version lookup failures

### DIFF
--- a/packages/create-video/src/init.ts
+++ b/packages/create-video/src/init.ts
@@ -148,7 +148,9 @@ export const init = async () => {
 		}
 	}
 
-	const latestRemotionVersionPromise = getLatestRemotionVersion();
+	const latestRemotionVersionPromise = getLatestRemotionVersion({
+		onError: Log.warn,
+	});
 
 	const shouldOverrideTailwind = selectedTemplate.allowEnableTailwind
 		? isYesFlagSelected()

--- a/packages/create-video/src/latest-remotion-version.ts
+++ b/packages/create-video/src/latest-remotion-version.ts
@@ -3,6 +3,7 @@ import http from 'node:http';
 import https from 'node:https';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+const packageJson = require('../package.json') as {version: string};
 
 const getRegistry = (): string => {
 	try {
@@ -22,8 +23,7 @@ const getRegistry = (): string => {
 	return DEFAULT_REGISTRY;
 };
 
-const getPackageJsonForRemotion = (): Promise<string> => {
-	const registry = getRegistry();
+const getPackageJsonForRemotion = (registry: string): Promise<string> => {
 	const url = `${registry}/remotion`;
 	const client = url.startsWith('https') ? https : http;
 
@@ -55,17 +55,47 @@ const getPackageJsonForRemotion = (): Promise<string> => {
 	});
 };
 
-export const getLatestRemotionVersion = async () => {
-	const pkgJson = await getPackageJsonForRemotion();
+type GetLatestRemotionVersionOptions = {
+	getRegistry?: () => string;
+	getPackageJsonForRemotion?: (registry: string) => Promise<string>;
+	fallbackVersion?: string;
+	onError?: (message: string) => void;
+};
+
+const parseLatestVersion = (pkgJson: string) => {
+	const latest = JSON.parse(pkgJson)['dist-tags']?.latest;
+	if (typeof latest !== 'string') {
+		throw new Error('The response did not include dist-tags.latest.');
+	}
+
+	return latest;
+};
+
+const stringifyError = (error: unknown) => {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
+};
+
+export const getLatestRemotionVersion = async ({
+	getRegistry: getRegistryOption = getRegistry,
+	getPackageJsonForRemotion:
+		getPackageJsonForRemotionOption = getPackageJsonForRemotion,
+	fallbackVersion = packageJson.version,
+	onError,
+}: GetLatestRemotionVersionOptions = {}) => {
+	const registry = getRegistryOption();
 	try {
-		return JSON.parse(pkgJson)['dist-tags'].latest;
-	} catch {
-		const registry = getRegistry();
-		throw new Error(
-			`Failed to fetch the latest Remotion version from ${registry}. ` +
-				`The response was not valid JSON. ` +
-				`If you are behind a corporate proxy, make sure your npm registry is configured correctly ` +
-				`(npm config set registry <your-registry-url>).`,
+		const pkgJson = await getPackageJsonForRemotionOption(registry);
+		return parseLatestVersion(pkgJson);
+	} catch (err) {
+		onError?.(
+			`Could not fetch the latest Remotion version from ${registry} (${stringifyError(
+				err,
+			)}). Continuing with ${fallbackVersion}.`,
 		);
+		return fallbackVersion;
 	}
 };

--- a/packages/create-video/src/test/latest-remotion-version.test.ts
+++ b/packages/create-video/src/test/latest-remotion-version.test.ts
@@ -1,0 +1,50 @@
+import {expect, test} from 'bun:test';
+import {getLatestRemotionVersion} from '../latest-remotion-version';
+
+test('uses the latest Remotion version from the registry response', async () => {
+	const warnings: string[] = [];
+	const version = await getLatestRemotionVersion({
+		getRegistry: () => 'https://registry.example.com',
+		getPackageJsonForRemotion: () =>
+			Promise.resolve(JSON.stringify({'dist-tags': {latest: '5.0.0'}})),
+		fallbackVersion: '4.0.0',
+		onError: (message) => warnings.push(message),
+	});
+
+	expect(version).toBe('5.0.0');
+	expect(warnings).toEqual([]);
+});
+
+test('falls back if a private registry returns a non-JSON auth response', async () => {
+	const warnings: string[] = [];
+	const version = await getLatestRemotionVersion({
+		getRegistry: () => 'https://registry.example.com',
+		getPackageJsonForRemotion: () =>
+			Promise.resolve('<html>Authentication required</html>'),
+		fallbackVersion: '4.0.0',
+		onError: (message) => warnings.push(message),
+	});
+
+	expect(version).toBe('4.0.0');
+	expect(warnings).toHaveLength(1);
+	expect(warnings[0]).toContain(
+		'Could not fetch the latest Remotion version from https://registry.example.com',
+	);
+	expect(warnings[0]).toContain('Continuing with 4.0.0.');
+});
+
+test('falls back if the registry request fails', async () => {
+	const warnings: string[] = [];
+	const version = await getLatestRemotionVersion({
+		getRegistry: () => 'https://registry.example.com',
+		getPackageJsonForRemotion: () =>
+			Promise.reject(new Error('401 Unauthorized')),
+		fallbackVersion: '4.0.0',
+		onError: (message) => warnings.push(message),
+	});
+
+	expect(version).toBe('4.0.0');
+	expect(warnings).toEqual([
+		'Could not fetch the latest Remotion version from https://registry.example.com (401 Unauthorized). Continuing with 4.0.0.',
+	]);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8051

## Summary
- Make `create-video` continue when the Remotion version registry lookup fails or returns invalid JSON.
- Fall back to the bundled `create-video` package version and emit a warning instead of aborting project creation.
- Add regression tests for private-registry auth responses and rejected registry requests.

## Testing
- `bunx oxfmt src --write`
- `bun test src`
- `bun run lint`
- `bun run formatting`
- `bun run build`
- `bun run stylecheck` (fails only because `@remotion/lambda-go` requires Go >= 1.23.0 while the VM has Go 1.22.2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7e4cb8e-8a4a-410e-a4b3-24a91e1798a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7e4cb8e-8a4a-410e-a4b3-24a91e1798a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

