### PR TITLE
`@remotion/studio-server`: Add clamp defaults for new Studio keyframes

### DIFF
--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -216,6 +216,16 @@ const createFrameExpression = (frame: number): ExpressionKind => {
 	return parseValueExpression(frame);
 };
 
+const createClampOptionsExpression = (): ExpressionKind => {
+	return b.objectExpression([
+		b.objectProperty(b.identifier('extrapolateLeft'), b.stringLiteral('clamp')),
+		b.objectProperty(
+			b.identifier('extrapolateRight'),
+			b.stringLiteral('clamp'),
+		),
+	]) as ExpressionKind;
+};
+
 const createInterpolateExpression = ({
 	callee,
 	input,
@@ -322,12 +332,16 @@ const addKeyframe = ({
 		staticValue,
 		newValue: value,
 	});
+	const extraArgs =
+		callee.type === 'Identifier' && callee.name === 'interpolateColors'
+			? []
+			: [createClampOptionsExpression()];
 
 	return {
 		expression: createInterpolateExpression({
 			callee,
 			input: b.identifier('frame'),
-			extraArgs: [],
+			extraArgs,
 			keyframes,
 		}),
 		introduced: {

--- a/packages/studio-server/src/test/update-keyframes-imports.test.ts
+++ b/packages/studio-server/src/test/update-keyframes-imports.test.ts
@@ -134,6 +134,8 @@ export const Example: React.FC = () => {
 
 	expect(serialized).toContain('interpolateRotate');
 	expect(serialized).not.toContain('interpolateColors');
+	expect(serialized).toContain('extrapolateLeft: "clamp"');
+	expect(serialized).toContain('extrapolateRight: "clamp"');
 	expect(serialized).toContain('useCurrentFrame');
 	expect(serialized).toContain('const frame = useCurrentFrame();');
 });

--- a/packages/studio-server/src/test/update-keyframes-imports.test.ts
+++ b/packages/studio-server/src/test/update-keyframes-imports.test.ts
@@ -59,7 +59,9 @@ export const Example: React.FC = () => {
 		/import\s*\{[^}]*\bAbsoluteFill\b[^}]*\binterpolate\b[^}]*\buseCurrentFrame\b[^}]*\}\s*from\s*['"]remotion['"]/,
 	);
 	expect(serialized).toContain('const frame = useCurrentFrame();');
-	expect(serialized).toContain('interpolate(frame, [30], [1])');
+	expect(serialized).toContain('interpolate(frame, [30], [1], {');
+	expect(serialized).toContain('extrapolateLeft: "clamp"');
+	expect(serialized).toContain('extrapolateRight: "clamp"');
 });
 
 test('adds interpolateColors import (not interpolate) for color conversion', () => {
@@ -396,7 +398,9 @@ export const Example: React.FC = () => (
 
 	expect(serialized).toContain('const frame = useCurrentFrame();');
 	expect(serialized).toContain('return');
-	expect(serialized).toContain('interpolate(frame, [20], [1])');
+	expect(serialized).toContain('interpolate(frame, [20], [1], {');
+	expect(serialized).toContain('extrapolateLeft: "clamp"');
+	expect(serialized).toContain('extrapolateRight: "clamp"');
 });
 
 test('does not add a duplicate frame hook when user already has one with a different intermediate statement', () => {
@@ -455,7 +459,9 @@ export const Comp = () => {
 		/import\s*\{[^}]*\binterpolate\b[^}]*\buseCurrentFrame\b[^}]*\}\s*from\s*['"]remotion['"]/,
 	);
 	expect(serialized).toContain('const frame = useCurrentFrame();');
-	expect(serialized).toContain('interpolate(frame, [100], [1])');
+	expect(serialized).toContain('interpolate(frame, [100], [1], {');
+	expect(serialized).toContain('extrapolateLeft: "clamp"');
+	expect(serialized).toContain('extrapolateRight: "clamp"');
 });
 
 test('effect keyframe remove does not modify imports or insert a frame hook', () => {

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -298,7 +298,11 @@ test('updateSequenceKeyframes converts static rotate to interpolateRotate', asyn
 	});
 
 	expect(oldValueStrings).toEqual(["'19deg'"]);
-	expect(output).toContain("rotate: interpolateRotate(frame, [55], ['19deg'])");
+	expect(output).toContain(
+		"rotate: interpolateRotate(frame, [55], ['19deg'], {",
+	);
+	expect(output).toContain("extrapolateLeft: 'clamp'");
+	expect(output).toContain("extrapolateRight: 'clamp'");
 	expect(output).toContain('interpolateRotate');
 });
 

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -134,7 +134,9 @@ test('updateSequenceKeyframes converts a static value to an interpolation', asyn
 	});
 
 	expect(oldValueStrings).toEqual(['0.5']);
-	expect(output).toContain('opacity: interpolate(frame, [25], [0.75])');
+	expect(output).toContain('opacity: interpolate(frame, [25], [0.75], {');
+	expect(output).toContain("extrapolateLeft: 'clamp'");
+	expect(output).toContain("extrapolateRight: 'clamp'");
 });
 
 test('updateSequenceKeyframes rejects non-keyframable fields', async () => {
@@ -181,7 +183,9 @@ test('updateSequenceKeyframes converts a static value to a single-keyframe inter
 	});
 
 	expect(oldValueStrings).toEqual(['0.5']);
-	expect(output).toContain('opacity: interpolate(frame, [0], [0.75])');
+	expect(output).toContain('opacity: interpolate(frame, [0], [0.75], {');
+	expect(output).toContain("extrapolateLeft: 'clamp'");
+	expect(output).toContain("extrapolateRight: 'clamp'");
 });
 
 test('updateSequenceKeyframes adds a keyframe to an existing color interpolation', async () => {
@@ -242,8 +246,10 @@ test('updateSequenceKeyframes converts static translate to interpolateTranslate'
 
 	expect(oldValueStrings).toEqual(["'0px 59px'"]);
 	expect(output).toContain(
-		"translate: interpolateTranslate(frame, [44], ['0px 59px'])",
+		"translate: interpolateTranslate(frame, [44], ['0px 59px'], {",
 	);
+	expect(output).toContain("extrapolateLeft: 'clamp'");
+	expect(output).toContain("extrapolateRight: 'clamp'");
 	expect(output).toContain('interpolateTranslate');
 });
 
@@ -368,8 +374,10 @@ export default CenteredSolid;
 		],
 	});
 
-	expect(output).toContain('width={interpolate(frame, [11], [240])}');
 	expect(updatedNodePath).toEqual(nodePath);
+	expect(output).toContain('width={interpolate(frame, [11], [240], {');
+	expect(output).toContain("extrapolateLeft: 'clamp'");
+	expect(output).toContain("extrapolateRight: 'clamp'");
 	const status = computeSequencePropsStatusFromContent({
 		fileContents: output,
 		nodePath: updatedNodePath,
@@ -382,7 +390,7 @@ export default CenteredSolid;
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 11, value: 240}],
 		easing: [],
-		clamping: {left: 'extend', right: 'extend'},
+		clamping: {left: 'clamp', right: 'clamp'},
 		posterize: undefined,
 	});
 });
@@ -454,6 +462,32 @@ test('updateSequenceKeyframes keeps a color interpolation when one keyframe rema
 		"interpolateColors(frame, [0, 100], ['red', 'blue'])",
 	]);
 	expect(output).toContain("color={interpolateColors(frame, [100], ['blue'])}");
+});
+
+test('updateEffectKeyframes converts a static value to a clamped interpolation', () => {
+	const input = effectInput.replace(
+		'interpolate(frame, [0, 50, 100], [0.2, 0.5, 0.8])',
+		'0.2',
+	);
+	const {serialized, oldValueStrings} = updateEffectKeyframesAst({
+		input,
+		sequenceNodePath: lineColumnToNodePath(
+			input,
+			getLine(input, '<HtmlInCanvas'),
+		),
+		effectIndex: 0,
+		updates: [
+			{
+				key: 'amount',
+				operation: {type: 'add', frame: 40, value: 0.6},
+			},
+		],
+	});
+
+	expect(oldValueStrings).toEqual(['0.2']);
+	expect(serialized).toContain('amount: interpolate(frame, [40], [0.6], {');
+	expect(serialized).toContain('extrapolateLeft: "clamp"');
+	expect(serialized).toContain('extrapolateRight: "clamp"');
 });
 
 test('updateSequenceKeyframes converts the last color keyframe to a static value', async () => {

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -65,7 +65,7 @@ const addKeyframeToPropStatus = ({
 			}),
 			keyframes: [{frame, value}],
 			easing: [],
-			clamping: {left: 'extend', right: 'extend'},
+			clamping: {left: 'clamp', right: 'clamp'},
 			posterize: undefined,
 		};
 	}

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -35,6 +35,7 @@ test('optimisticAddSequenceKeyframe converts a static prop to a single keyframe'
 
 	expect(status.keyframes).toEqual([{frame: 25, value: 0.75}]);
 	expect(status.easing).toEqual([]);
+	expect(status.clamping).toEqual({left: 'clamp', right: 'clamp'});
 });
 
 test('optimisticAddSequenceKeyframe uses interpolateTranslate for translate fields', () => {
@@ -74,6 +75,7 @@ test('optimisticAddSequenceKeyframe uses interpolateTranslate for translate fiel
 
 	expect(status.interpolationFunction).toBe('interpolateTranslate');
 	expect(status.keyframes).toEqual([{frame: 44, value: '0px 59px'}]);
+	expect(status.clamping).toEqual({left: 'clamp', right: 'clamp'});
 });
 
 test('optimisticAddSequenceKeyframe uses interpolateRotate for rotation-css fields', () => {
@@ -287,4 +289,5 @@ test('optimisticAddEffectKeyframe converts a static prop to a single keyframe', 
 
 	expect(status.keyframes).toEqual([{frame: 30, value: 0.5}]);
 	expect(status.easing).toEqual([]);
+	expect(status.clamping).toEqual({left: 'clamp', right: 'clamp'});
 });

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -115,6 +115,7 @@ test('optimisticAddSequenceKeyframe uses interpolateRotate for rotation-css fiel
 
 	expect(status.interpolationFunction).toBe('interpolateRotate');
 	expect(status.keyframes).toEqual([{frame: 44, value: '19deg'}]);
+	expect(status.clamping).toEqual({left: 'clamp', right: 'clamp'});
 });
 
 test('optimisticAddSequenceKeyframe ignores non-keyframable fields', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8057

## Summary
- Add explicit `extrapolateLeft: 'clamp'` and `extrapolateRight: 'clamp'` options when Studio converts static numeric/translate values into keyframed interpolations.
- Keep `interpolateColors()` generation unchanged because color interpolation is already clamped and Studio's parser rejects extrapolation options on color interpolation.
- Update optimistic Studio state to report fresh keyframes as clamped and expand keyframe tests for sequence and effect paths.

## Testing
- `bunx oxfmt src --write` in `packages/studio-shared`
- `bunx oxfmt src --write` in `packages/studio-server`
- `bun run build`
- `bun run formatting`
- `bun test src/test/optimistic-add-keyframe.test.ts` in `packages/studio-shared`
- `bun test src/test/update-keyframes.test.ts src/test/update-keyframes-imports.test.ts src/test/compute-sequence-props-status.test.ts src/test/compute-effect-props-status.test.ts` in `packages/studio-server`

## Notes
- `bun run stylecheck` was also run and failed only in `@remotion/lambda-go` because the VM has Go 1.22.2 while `golang.org/x/crypto@v0.35.0` requires Go >= 1.23.0, matching the known Cloud Agents caveat.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-742d076d-6c3c-4b0e-ad01-1a9d9e5d414b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-742d076d-6c3c-4b0e-ad01-1a9d9e5d414b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

