### PR TITLE
`remotion`: Simplify video frame callback

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -251,7 +251,7 @@ export {
 	Video,
 } from './video/index.js';
 export {MediaPlaybackError} from './video/MediaPlaybackError.js';
-export type {OnVideoFrame, OnVideoFrameCallback} from './video/props.js';
+export type {OnVideoFrame} from './video/props.js';
 export type {VolumeProp} from './volume-prop.js';
 export {watchStaticFile} from './watch-static-file.js';
 

--- a/packages/core/src/test/offthread-video.test.tsx
+++ b/packages/core/src/test/offthread-video.test.tsx
@@ -107,11 +107,14 @@ describe('OffthreadVideo render correctly with props', () => {
 		).not.toThrow();
 	});
 
-	test('It should render OffthreadVideo with onVideoFrameCallback prop', () => {
+	test('It should render OffthreadVideo with onVideoFrame metadata arguments', () => {
 		expect(() =>
 			render(
 				<WrapSequenceContext>
-					<OffthreadVideo src="test" onVideoFrameCallback={() => undefined} />
+					<OffthreadVideo
+						src="test"
+						onVideoFrame={(_frame, _now, _metadata) => undefined}
+					/>
 				</WrapSequenceContext>,
 			),
 		).not.toThrow();

--- a/packages/core/src/test/video.test.tsx
+++ b/packages/core/src/test/video.test.tsx
@@ -72,11 +72,14 @@ test('It should render Video with trimBefore and trimAfter props', () => {
 	).not.toThrow();
 });
 
-test('It should render Video with onVideoFrameCallback prop', () => {
+test('It should render Video with onVideoFrame metadata arguments', () => {
 	expect(() =>
 		render(
 			<WrapSequenceContext>
-				<Html5Video src="test" onVideoFrameCallback={() => undefined} />
+				<Html5Video
+					src="test"
+					onVideoFrame={(_frame, _now, _metadata) => undefined}
+				/>
 			</WrapSequenceContext>,
 		),
 	).not.toThrow();

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -107,7 +107,6 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 		toneMapped,
 		onAutoPlayError,
 		onVideoFrame,
-		onVideoFrameCallback,
 		crossOrigin,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
@@ -123,7 +122,6 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 			showInTimeline={showInTimeline ?? true}
 			onAutoPlayError={onAutoPlayError ?? undefined}
 			onVideoFrame={onVideoFrame ?? null}
-			onVideoFrameCallback={onVideoFrameCallback ?? null}
 			crossOrigin={crossOrigin}
 			{...propsForPreview}
 			_remotionInternalNativeLoopPassed={false}
@@ -152,7 +150,6 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 	onAutoPlayError,
 	onError,
 	onVideoFrame,
-	onVideoFrameCallback,
 	pauseWhenBuffering,
 	playbackRate,
 	preservePitch,
@@ -193,7 +190,6 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 			onAutoPlayError={onAutoPlayError ?? null}
 			onError={onError}
 			onVideoFrame={onVideoFrame}
-			onVideoFrameCallback={onVideoFrameCallback}
 			pauseWhenBuffering={pauseWhenBuffering ?? true}
 			playbackRate={playbackRate ?? 1}
 			preservePitch={preservePitch}

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -31,15 +31,10 @@ import {evaluateVolume} from '../volume-prop.js';
 import {warnAboutTooHighVolume} from '../volume-safeguard.js';
 import {useEmitVideoFrame} from './emit-video-frame.js';
 import {MediaPlaybackError} from './MediaPlaybackError.js';
-import type {
-	NativeVideoProps,
-	OnVideoFrame,
-	OnVideoFrameCallback,
-	RemotionVideoProps,
-} from './props';
+import type {NativeVideoProps, OnVideoFrame, RemotionVideoProps} from './props';
 import {isIosSafari, useAppendVideoFragment} from './video-fragment.js';
 
-type VideoForPreviewProps = Omit<RemotionVideoProps, 'onVideoFrameCallback'> & {
+type VideoForPreviewProps = Omit<RemotionVideoProps, 'onVideoFrame'> & {
 	readonly onlyWarnForMediaSeekingError: boolean;
 	readonly onDuration: (src: string, durationInSeconds: number) => void;
 	readonly pauseWhenBuffering: boolean;
@@ -47,7 +42,6 @@ type VideoForPreviewProps = Omit<RemotionVideoProps, 'onVideoFrameCallback'> & {
 	readonly _remotionInternalStack: string | null;
 	readonly showInTimeline: boolean;
 	readonly onVideoFrame: null | OnVideoFrame;
-	readonly onVideoFrameCallback: null | OnVideoFrameCallback;
 	readonly crossOrigin?: '' | 'anonymous' | 'use-credentials';
 };
 
@@ -120,7 +114,6 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		onError,
 		onAutoPlayError,
 		onVideoFrame,
-		onVideoFrameCallback,
 		crossOrigin,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
@@ -304,7 +297,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		useRef<VideoForPreviewProps['onDuration']>(onDuration);
 	currentOnDurationCallback.current = onDuration;
 
-	useEmitVideoFrame({ref: videoRef, onVideoFrame, onVideoFrameCallback});
+	useEmitVideoFrame({ref: videoRef, onVideoFrame});
 
 	useEffect(() => {
 		const {current} = videoRef;
@@ -356,7 +349,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	const crossOriginValue = getCrossOriginValue({
 		crossOrigin,
-		requestsVideoFrame: Boolean(onVideoFrame || onVideoFrameCallback),
+		requestsVideoFrame: Boolean(onVideoFrame),
 		isClientSideRendering: false,
 	});
 

--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -28,20 +28,12 @@ import {warnAboutTooHighVolume} from '../volume-safeguard.js';
 import {useEmitVideoFrame} from './emit-video-frame.js';
 import {getMediaTime} from './get-current-time.js';
 import {MediaPlaybackError} from './MediaPlaybackError.js';
-import type {
-	OnVideoFrame,
-	OnVideoFrameCallback,
-	RemotionVideoProps,
-} from './props';
+import type {OnVideoFrame, RemotionVideoProps} from './props';
 import {seekToTimeMultipleUntilRight} from './seek-until-right.js';
 
-type VideoForRenderingProps = Omit<
-	RemotionVideoProps,
-	'onVideoFrameCallback'
-> & {
+type VideoForRenderingProps = Omit<RemotionVideoProps, 'onVideoFrame'> & {
 	readonly onDuration: (src: string, durationInSeconds: number) => void;
 	readonly onVideoFrame: null | OnVideoFrame;
-	readonly onVideoFrameCallback: null | OnVideoFrameCallback;
 };
 
 const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
@@ -62,7 +54,6 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 		loopVolumeCurveBehavior,
 		audioStreamIndex,
 		onVideoFrame,
-		onVideoFrameCallback,
 		preservePitch: _preservePitch,
 		...props
 	},
@@ -166,7 +157,7 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 		return videoRef.current as HTMLVideoElement;
 	}, []);
 
-	useEmitVideoFrame({ref: videoRef, onVideoFrame, onVideoFrameCallback});
+	useEmitVideoFrame({ref: videoRef, onVideoFrame});
 
 	useEffect(() => {
 		if (!window.remotion_videoEnabled) {

--- a/packages/core/src/video/emit-video-frame.ts
+++ b/packages/core/src/video/emit-video-frame.ts
@@ -1,14 +1,12 @@
 import {useEffect} from 'react';
-import type {OnVideoFrame, OnVideoFrameCallback} from './props';
+import type {OnVideoFrame} from './props';
 
 export const useEmitVideoFrame = ({
 	ref,
 	onVideoFrame,
-	onVideoFrameCallback,
 }: {
 	ref: React.RefObject<HTMLVideoElement | null>;
 	onVideoFrame: OnVideoFrame | null;
-	onVideoFrameCallback: OnVideoFrameCallback | null;
 }) => {
 	useEffect(() => {
 		const {current} = ref;
@@ -16,7 +14,7 @@ export const useEmitVideoFrame = ({
 			return;
 		}
 
-		if (!onVideoFrame && !onVideoFrameCallback) {
+		if (!onVideoFrame) {
 			return;
 		}
 
@@ -26,12 +24,11 @@ export const useEmitVideoFrame = ({
 				return;
 			}
 
-			onVideoFrame?.(ref.current);
-			onVideoFrameCallback?.(_now, metadata);
+			onVideoFrame(ref.current, _now, metadata);
 			handle = ref.current.requestVideoFrameCallback(callback);
 		};
 
-		onVideoFrame?.(current);
+		onVideoFrame(current);
 		if (!current.requestVideoFrameCallback) {
 			return;
 		}
@@ -43,5 +40,5 @@ export const useEmitVideoFrame = ({
 				current.cancelVideoFrameCallback(handle);
 			}
 		};
-	}, [onVideoFrame, onVideoFrameCallback, ref]);
+	}, [onVideoFrame, ref]);
 };

--- a/packages/core/src/video/html5-video.tsx
+++ b/packages/core/src/video/html5-video.tsx
@@ -39,7 +39,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 		_remotionInternalNativeLoopPassed,
 		showInTimeline,
 		onAutoPlayError,
-		onVideoFrameCallback,
+		onVideoFrame,
 		...otherProps
 	} = props;
 	const {loop, ...propsOtherThanLoop} = props;
@@ -74,8 +74,6 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 		},
 		[setDurations],
 	);
-
-	const onVideoFrame = useCallback(() => {}, []);
 
 	const durationFetched =
 		durations[getAbsoluteSrc(preloadedSrc)] ??
@@ -143,7 +141,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			>
 				<Html5Video
 					pauseWhenBuffering={pauseWhenBuffering ?? false}
-					onVideoFrameCallback={onVideoFrameCallback}
+					onVideoFrame={onVideoFrame}
 					{...otherProps}
 					ref={ref}
 					stack={stack}
@@ -166,7 +164,6 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			<VideoForRendering
 				onDuration={onDuration}
 				onVideoFrame={onVideoFrame ?? null}
-				onVideoFrameCallback={onVideoFrameCallback ?? null}
 				{...otherProps}
 				ref={ref}
 			/>
@@ -178,8 +175,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			onlyWarnForMediaSeekingError={false}
 			{...otherProps}
 			ref={ref}
-			onVideoFrame={null}
-			onVideoFrameCallback={onVideoFrameCallback ?? null}
+			onVideoFrame={onVideoFrame ?? null}
 			// Proposal: Make this default to true in v5
 			pauseWhenBuffering={pauseWhenBuffering ?? false}
 			onDuration={onDuration}

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -56,7 +56,7 @@ export type RemotionVideoProps = NativeVideoProps & {
 	delayRenderRetries?: number;
 	onError?: (err: Error) => void;
 	onAutoPlayError?: null | (() => void);
-	onVideoFrameCallback?: OnVideoFrameCallback;
+	onVideoFrame?: OnVideoFrame;
 	audioStreamIndex?: number;
 };
 
@@ -98,7 +98,6 @@ type OptionalOffthreadVideoProps = {
 	showInTimeline: boolean;
 	onAutoPlayError: null | (() => void);
 	onVideoFrame: OnVideoFrame | undefined;
-	onVideoFrameCallback: OnVideoFrameCallback | undefined;
 	crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined;
 	audioStreamIndex: number;
 };
@@ -112,8 +111,8 @@ export type RemotionOffthreadVideoProps = MandatoryOffthreadVideoProps &
 	Partial<CommonVideoProps> &
 	Partial<DeprecatedOffthreadVideoProps>;
 
-export type OnVideoFrame = (frame: CanvasImageSource) => void;
-export type OnVideoFrameCallback = (
-	now: DOMHighResTimeStamp,
-	metadata: VideoFrameCallbackMetadata,
+export type OnVideoFrame = (
+	frame: CanvasImageSource,
+	now?: DOMHighResTimeStamp,
+	metadata?: VideoFrameCallbackMetadata,
 ) => void;

--- a/packages/docs/docs/html5-video.mdx
+++ b/packages/docs/docs/html5-video.mdx
@@ -293,10 +293,14 @@ If you don't pass a callback, the video will be muted and be retried once.
 This prop is useful if you want to handle the error yourself, e.g. for pausing the Player.  
 Read more here about [autoplay restrictions](/docs/player/autoplay).
 
-### `onVideoFrameCallback?`<AvailableFrom v="4.0.472" />
+### `onVideoFrame?`<AvailableFrom v="4.0.472" />
 
-A callback function that gets called when the browser reports a presented video frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback).
-The callback has the same signature as `requestVideoFrameCallback()`: It receives a `DOMHighResTimeStamp` and the [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata).
+A callback function that gets called when a frame is extracted from the video.  
+Useful for [video manipulation](/docs/video-manipulation).  
+The first argument is a [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource), more specifically a `HTMLVideoElement`.
+
+When the browser reports a presented frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback), the callback also receives the `DOMHighResTimeStamp` and [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata) as the second and third argument.  
+These arguments are `undefined` for the first synchronous callback and in browsers that don't support `requestVideoFrameCallback()`.
 
 ### `crossOrigin?`<AvailableFrom v="4.0.190" />
 

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -327,8 +327,6 @@ A callback function that gets called when a frame is extracted from the video.
 Useful for [video manipulation](/docs/video-manipulation).  
 The callback is called with a [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource) object, more specifically, either an `ImageBitmap` or a `VideoFrame`.
 
-Unlike [`<Html5Video>`](/docs/html5-video#onvideoframe) and [`<OffthreadVideo>`](/docs/offthreadvideo#onvideoframe), this component does not pass `requestVideoFrameCallback()` timing metadata to `onVideoFrame`.
-
 ### `audioStreamIndex?`
 
 Select the audio stream to use. The default is `0`.

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -327,6 +327,8 @@ A callback function that gets called when a frame is extracted from the video.
 Useful for [video manipulation](/docs/video-manipulation).  
 The callback is called with a [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource) object, more specifically, either an `ImageBitmap` or a `VideoFrame`.
 
+Unlike [`<Html5Video>`](/docs/html5-video#onvideoframe) and [`<OffthreadVideo>`](/docs/offthreadvideo#onvideoframe), this component does not pass `requestVideoFrameCallback()` timing metadata to `onVideoFrame`.
+
 ### `audioStreamIndex?`
 
 Select the audio stream to use. The default is `0`.
@@ -454,11 +456,6 @@ Maps to [`<OffthreadVideo />` -> `onAutoPlayError`](/docs/offthreadvideo#onautop
 
 Maps to [`<OffthreadVideo />` -> `preservePitch`](/docs/offthreadvideo#preservepitch).  
 Only affects preview playback when falling back to [`<Html5Video>`](/docs/html5-video) or [`<OffthreadVideo>`](/docs/offthreadvideo).
-
-#### `onVideoFrameCallback?`<AvailableFrom v="4.0.472" />
-
-Maps to [`<OffthreadVideo />` -> `onVideoFrameCallback`](/docs/offthreadvideo#onvideoframecallback).
-Only affects preview playback when falling back to [`<OffthreadVideo>`](/docs/offthreadvideo).
 
 ### `disallowFallbackToOffthreadVideo?`
 

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -294,12 +294,8 @@ Useful for [video manipulation](/docs/video-manipulation).
 The callback is called with a [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource) object.  
 During preview, this is a `HTMLVideoElement` object, during rendering, it is an `HTMLImageElement`.
 
-### `onVideoFrameCallback?`<AvailableFrom v="4.0.472" />
-
-A callback function that gets called during preview when the browser reports a presented video frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback).  
-The callback has the same signature as `requestVideoFrameCallback()`: It receives a `DOMHighResTimeStamp` and the [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata).
-
-This callback only fires during preview, since rendering uses image extraction instead of a browser video element.
+During preview, if the browser reports a presented frame using [`HTMLVideoElement.requestVideoFrameCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback), the callback also receives the `DOMHighResTimeStamp` and [`VideoFrameCallbackMetadata`](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrameCallbackMetadata) as the second and third argument. <AvailableFrom v="4.0.472" inline />  
+These arguments are `undefined` for the first synchronous callback, in browsers that don't support `requestVideoFrameCallback()` and during rendering.
 
 ### `crossOrigin?`<AvailableFrom v="4.0.190" />
 

--- a/packages/media/src/video/props.ts
+++ b/packages/media/src/video/props.ts
@@ -4,7 +4,6 @@ import type {
 	LogLevel,
 	LoopVolumeCurveBehavior,
 	OnVideoFrame,
-	OnVideoFrameCallback,
 	SequenceProps,
 	VolumeProp,
 } from 'remotion';
@@ -32,7 +31,6 @@ export type FallbackOffthreadVideoProps = {
 	pauseWhenBuffering?: boolean;
 	onAutoPlayError?: null | (() => void);
 	preservePitch?: boolean;
-	onVideoFrameCallback?: OnVideoFrameCallback;
 };
 
 type MandatoryVideoProps = {

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -460,7 +460,6 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 				audioStreamIndex={audioStreamIndex ?? 0}
 				className={className}
 				onVideoFrame={onVideoFrame}
-				onVideoFrameCallback={fallbackOffthreadVideoProps?.onVideoFrameCallback}
 				volume={volumeProp}
 				id={id}
 				onError={fallbackOffthreadVideoProps?.onError}


### PR DESCRIPTION
## Summary
- Reverts the separate `onVideoFrameCallback` prop from PR #7817.
- Extends the existing `onVideoFrame` callback with optional `requestVideoFrameCallback()` timing metadata instead.
- Updates docs and smoke tests for the simplified API.

## Test plan
- `bunx turbo run make --filter=remotion --filter=@remotion/media`
- `cd packages/core && bun test src/test/video.test.tsx src/test/offthread-video.test.tsx`
- `bun run build`
- `bun run stylecheck`
