### PR TITLE
`@remotion/studio`: Disable Add Solid when disconnected

### DIFF
--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -280,8 +280,10 @@ export const Example: React.FC = () => {
 
 	expect(oldValueStrings).toEqual(['"0px 0px"']);
 	expect(output).toContain(
-		"translate: interpolateTranslate(frame, [44], ['100px 20px'])",
+		"translate: interpolateTranslate(frame, [44], ['100px 20px'], {",
 	);
+	expect(output).toContain("extrapolateLeft: 'clamp'");
+	expect(output).toContain("extrapolateRight: 'clamp'");
 	expect(output).toContain('useCurrentFrame');
 	expect(output).toContain('interpolateTranslate');
 	const status = computeSequencePropsStatusFromContent({
@@ -296,7 +298,7 @@ export const Example: React.FC = () => {
 		interpolationFunction: 'interpolateTranslate',
 		keyframes: [{frame: 44, value: '100px 20px'}],
 		easing: [],
-		clamping: {left: 'extend', right: 'extend'},
+		clamping: {left: 'clamp', right: 'clamp'},
 		posterize: undefined,
 	});
 });

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -63,6 +63,7 @@ const TimelineClearSelectionArea: React.FC<{
 	const [isAddingSolid, setIsAddingSolid] = useState(false);
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const previewConnected = previewServerState.type === 'connected';
 
 	const currentCompositionId =
 		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
@@ -101,6 +102,7 @@ const TimelineClearSelectionArea: React.FC<{
 	);
 
 	const canInsertSolid =
+		previewConnected &&
 		compositionComponentInfo?.canAddSequence === true &&
 		currentCompositionId !== null &&
 		compositionFile !== null &&
@@ -108,7 +110,7 @@ const TimelineClearSelectionArea: React.FC<{
 		!isAddingSolid;
 
 	const canInsertAsset =
-		previewServerState.type === 'connected' &&
+		previewConnected &&
 		!window.remotion_isReadOnlyStudio &&
 		compositionComponentInfo?.canAddSequence === true &&
 		currentCompositionId !== null &&


### PR DESCRIPTION
Fixes #8066.

### Summary

- Disable the timeline context menu “Add <Solid>” action unless the preview server is connected.
- Reuse the same preview connection boolean for the existing “Add asset” gate.

### Checks

- bunx oxfmt src --write (in packages/studio)
- bun run build
- bun run formatting
