### PR TITLE
`@remotion/studio`: Make keyframed timeline values editable

### DIFF
--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -118,6 +118,27 @@ test('updateSequenceKeyframes adds a keyframe to an existing interpolation', asy
 	);
 });
 
+test('updateSequenceKeyframes updates a keyframe at the same frame', async () => {
+	const {output, oldValueStrings, newValueStrings} =
+		await updateSequenceKeyframes({
+			input: sequenceInput,
+			nodePath: lineColumnToNodePath(
+				sequenceInput,
+				getLine(sequenceInput, 'scale'),
+			),
+			updates: [
+				{
+					key: 'style.scale',
+					operation: {type: 'add', frame: 100, value: 5},
+				},
+			],
+		});
+
+	expect(oldValueStrings).toEqual(['interpolate(frame, [0, 100], [2, 4])']);
+	expect(newValueStrings).toEqual(['interpolate(frame, [0, 100], [2, 5])']);
+	expect(output).toContain('scale: interpolate(frame, [0, 100], [2, 5])');
+});
+
 test('updateSequenceKeyframes converts a static value to an interpolation', async () => {
 	const {output, oldValueStrings} = await updateSequenceKeyframes({
 		input: sequenceInput,
@@ -280,8 +301,10 @@ export const Example: React.FC = () => {
 
 	expect(oldValueStrings).toEqual(['"0px 0px"']);
 	expect(output).toContain(
-		"translate: interpolateTranslate(frame, [44], ['100px 20px'])",
+		"translate: interpolateTranslate(frame, [44], ['100px 20px'], {",
 	);
+	expect(output).toContain("extrapolateLeft: 'clamp'");
+	expect(output).toContain("extrapolateRight: 'clamp'");
 	expect(output).toContain('useCurrentFrame');
 	expect(output).toContain('interpolateTranslate');
 	const status = computeSequencePropsStatusFromContent({
@@ -296,7 +319,7 @@ export const Example: React.FC = () => {
 		interpolationFunction: 'interpolateTranslate',
 		keyframes: [{frame: 44, value: '100px 20px'}],
 		easing: [],
-		clamping: {left: 'extend', right: 'extend'},
+		clamping: {left: 'clamp', right: 'clamp'},
 		posterize: undefined,
 	});
 });

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -193,6 +193,49 @@ test('optimisticAddSequenceKeyframe appends a keyframe to an existing interpolat
 	expect(status.easing).toEqual(['linear', 'linear']);
 });
 
+test('optimisticAddSequenceKeyframe updates an existing keyframe at the same frame', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			scale: {
+				status: 'keyframed',
+				codeValue: undefined,
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 1},
+					{frame: 60, value: 2},
+				],
+				easing: ['linear'],
+				clamping: {left: 'extend', right: 'extend'},
+				posterize: undefined,
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticAddSequenceKeyframe({
+		previous,
+		fieldKey: 'scale',
+		frame: 60,
+		value: 3,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const status = updated.props.scale;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([
+		{frame: 0, value: 1},
+		{frame: 60, value: 3},
+	]);
+	expect(status.easing).toEqual(['linear']);
+});
+
 test('optimisticAddEffectKeyframe appends a keyframe on the target effect', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -13,6 +13,7 @@ import type {EffectSchemaFieldInfo} from '../../helpers/timeline-layout';
 import {callApi} from '../call-api';
 import {ContextMenu} from '../ContextMenu';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {callAddEffectKeyframe} from './call-add-keyframe';
 import {getComputedStatusLabel} from './get-timeline-keyframes';
 import {saveEffectProp} from './save-effect-prop';
 import {enqueueSavePropChange} from './save-prop-queue';
@@ -161,6 +162,39 @@ const Value: React.FC<{
 		],
 	);
 
+	const onSaveKeyframed = useCallback(
+		(value: unknown, sourceFrame: number) => {
+			if (!validatedLocation) {
+				return Promise.reject(new Error('Cannot save'));
+			}
+
+			if (!clientId) {
+				return Promise.reject(new Error('Not connected to studio server'));
+			}
+
+			return callAddEffectKeyframe({
+				fileName: validatedLocation.source,
+				nodePath,
+				effectIndex: field.effectIndex,
+				fieldKey: field.key,
+				sourceFrame,
+				value,
+				schema: field.effectSchema,
+				setCodeValues,
+				clientId,
+			});
+		},
+		[
+			clientId,
+			field.effectIndex,
+			field.effectSchema,
+			field.key,
+			nodePath,
+			setCodeValues,
+			validatedLocation,
+		],
+	);
+
 	if (effectStatus.type === 'cannot-update-effect') {
 		if (effectStatus.reason === 'computed') {
 			return <UnsupportedStatus label="computed" />;
@@ -203,6 +237,10 @@ const Value: React.FC<{
 				field={field}
 				propStatus={propStatus}
 				keyframeDisplayOffset={keyframeDisplayOffset}
+				dragOverrideValue={dragOverrideValue}
+				onSave={onSaveKeyframed}
+				onDragValueChange={onDragValueChange}
+				onDragEnd={onDragEnd}
 			/>
 		);
 	}

--- a/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
@@ -1,25 +1,37 @@
-import React, {useMemo} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import type {
 	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
 } from 'remotion';
 import {Internals} from 'remotion';
-import type {SchemaFieldInfo} from '../../helpers/timeline-layout';
+import type {
+	SchemaFieldInfo,
+	TimelineFieldOnDragValueChange,
+	TimelineFieldOnSave,
+} from '../../helpers/timeline-layout';
 import {TimelineFieldValue} from './TimelineSchemaField';
 
-const wrapperStyle: React.CSSProperties = {
-	opacity: 0.5,
-	pointerEvents: 'none',
+const valuesEqual = (left: unknown, right: unknown): boolean => {
+	return JSON.stringify(left) === JSON.stringify(right);
 };
-
-const noop = () => undefined;
-const noopAsync = () => Promise.resolve();
 
 export const TimelineKeyframedValue: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly propStatus: CanUpdateSequencePropStatusKeyframed;
 	readonly keyframeDisplayOffset: number;
-}> = ({field, propStatus, keyframeDisplayOffset}) => {
+	readonly dragOverrideValue: unknown;
+	readonly onSave: (value: unknown, sourceFrame: number) => Promise<void>;
+	readonly onDragValueChange: TimelineFieldOnDragValueChange;
+	readonly onDragEnd: () => void;
+}> = ({
+	field,
+	propStatus,
+	keyframeDisplayOffset,
+	dragOverrideValue,
+	onSave,
+	onDragValueChange,
+	onDragEnd,
+}) => {
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const jsxFrame = timelinePosition - keyframeDisplayOffset;
 
@@ -43,20 +55,38 @@ export const TimelineKeyframedValue: React.FC<{
 		[computedValue],
 	);
 
+	const effectiveValue =
+		dragOverrideValue === undefined ? computedValue : dragOverrideValue;
+
+	const onSaveIfChanged = useCallback<TimelineFieldOnSave>(
+		(value) => {
+			const existingKeyframe = propStatus.keyframes.find(
+				(keyframe) => keyframe.frame === jsxFrame,
+			);
+			if (
+				valuesEqual(value, computedValue) ||
+				(existingKeyframe && valuesEqual(value, existingKeyframe.value))
+			) {
+				return Promise.resolve();
+			}
+
+			return onSave(value, jsxFrame);
+		},
+		[computedValue, jsxFrame, onSave, propStatus.keyframes],
+	);
+
 	if (computedValue === null) {
 		return null;
 	}
 
 	return (
-		<div style={wrapperStyle}>
-			<TimelineFieldValue
-				field={field}
-				propStatus={fakeStatus}
-				effectiveValue={computedValue}
-				onSave={noopAsync}
-				onDragValueChange={noop}
-				onDragEnd={noop}
-			/>
-		</div>
+		<TimelineFieldValue
+			field={field}
+			propStatus={fakeStatus}
+			effectiveValue={effectiveValue}
+			onSave={onSaveIfChanged}
+			onDragValueChange={onDragValueChange}
+			onDragEnd={onDragEnd}
+		/>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -17,6 +17,7 @@ import type {
 } from '../../helpers/timeline-layout';
 import {ContextMenu} from '../ContextMenu';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {callAddSequenceKeyframe} from './call-add-keyframe';
 import {saveSequenceProp} from './save-sequence-prop';
 import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
@@ -176,9 +177,15 @@ export const TimelineSequencePropItem: React.FC<{
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
+		Internals.VisualModeSettersContext,
+	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const selection = useTimelineRowSelection(nodePathInfo);
+	const clientId =
+		previewServerState.type === 'connected'
+			? previewServerState.clientId
+			: null;
 
 	const codeValuesForOverride = Internals.getCodeValuesCtx(
 		visualModeCodeValues,
@@ -272,6 +279,45 @@ export const TimelineSequencePropItem: React.FC<{
 		codeValue,
 	]);
 
+	const onSaveKeyframed = useCallback(
+		(value: unknown, sourceFrame: number) => {
+			if (!clientId) {
+				return Promise.reject(new Error('Not connected to studio server'));
+			}
+
+			return callAddSequenceKeyframe({
+				fileName: validatedLocation.source,
+				nodePath,
+				fieldKey: field.key,
+				sourceFrame,
+				value,
+				schema,
+				setCodeValues,
+				clientId,
+			});
+		},
+		[
+			clientId,
+			field.key,
+			nodePath,
+			schema,
+			setCodeValues,
+			validatedLocation.source,
+		],
+	);
+
+	const onKeyframedDragValueChange =
+		useCallback<TimelineFieldOnDragValueChange>(
+			(value) => {
+				setDragOverrides(nodePath, field.key, value);
+			},
+			[field.key, nodePath, setDragOverrides],
+		);
+
+	const onKeyframedDragEnd = useCallback(() => {
+		clearDragOverrides(nodePath);
+	}, [clearDragOverrides, nodePath]);
+
 	const contextMenuValues = useMemo((): ComboboxValue[] => {
 		return [
 			{
@@ -318,6 +364,10 @@ export const TimelineSequencePropItem: React.FC<{
 						field={field}
 						propStatus={codeValue}
 						keyframeDisplayOffset={keyframeDisplayOffset}
+						dragOverrideValue={dragOverrideValue}
+						onSave={onSaveKeyframed}
+						onDragValueChange={onKeyframedDragValueChange}
+						onDragEnd={onKeyframedDragEnd}
 					/>
 				</div>
 			) : codeValue.status === 'static' ? (

--- a/packages/studio/src/components/Timeline/get-node-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-node-keyframes.ts
@@ -1,31 +1,85 @@
 import {
 	Internals,
 	type CodeValues,
+	type GetDragOverrides,
+	type GetEffectDragOverrides,
 	type SequencePropsSubscriptionKey,
 } from 'remotion';
 import type {TimelineTreeNode} from '../../helpers/timeline-layout';
 import {getTimelineKeyframes} from './get-timeline-keyframes';
+
+const hasOverride = (
+	overrides: Record<string, unknown>,
+	key: string,
+): boolean => Object.prototype.hasOwnProperty.call(overrides, key);
+
+const withDragOverrideKeyframe = ({
+	propStatus,
+	keyframeDisplayOffset,
+	timelinePosition,
+	dragOverrideValue,
+	hasDragOverride,
+}: {
+	propStatus: Parameters<typeof getTimelineKeyframes>[0];
+	keyframeDisplayOffset: number;
+	timelinePosition: number;
+	dragOverrideValue: unknown;
+	hasDragOverride: boolean;
+}): ReturnType<typeof getTimelineKeyframes> => {
+	const keyframes = getTimelineKeyframes(propStatus, keyframeDisplayOffset);
+
+	if (!hasDragOverride || propStatus?.status !== 'keyframed') {
+		return keyframes;
+	}
+
+	const dragKeyframe = {frame: timelinePosition, value: dragOverrideValue};
+	const existingIndex = keyframes.findIndex(
+		(keyframe) => keyframe.frame === timelinePosition,
+	);
+
+	if (existingIndex !== -1) {
+		return keyframes.map((keyframe, index) =>
+			index === existingIndex ? dragKeyframe : keyframe,
+		);
+	}
+
+	return [...keyframes, dragKeyframe].sort(
+		(first, second) => first.frame - second.frame,
+	);
+};
 
 export const getNodeKeyframes = ({
 	node,
 	nodePath,
 	codeValues,
 	keyframeDisplayOffset,
+	getDragOverrides,
+	getEffectDragOverrides,
+	timelinePosition,
 }: {
 	node: TimelineTreeNode;
 	nodePath: SequencePropsSubscriptionKey;
 	codeValues: CodeValues;
 	keyframeDisplayOffset: number;
+	getDragOverrides: GetDragOverrides;
+	getEffectDragOverrides: GetEffectDragOverrides;
+	timelinePosition: number;
 }): ReturnType<typeof getTimelineKeyframes> => {
 	if (node.kind !== 'field' || node.field === null) {
 		return [];
 	}
 
 	if (node.field.kind === 'sequence-field') {
-		return getTimelineKeyframes(
-			Internals.getCodeValuesCtx(codeValues, nodePath)?.[node.field.key],
+		const dragOverrides = getDragOverrides(nodePath);
+		return withDragOverrideKeyframe({
+			propStatus: Internals.getCodeValuesCtx(codeValues, nodePath)?.[
+				node.field.key
+			],
 			keyframeDisplayOffset,
-		);
+			timelinePosition,
+			dragOverrideValue: dragOverrides[node.field.key],
+			hasDragOverride: hasOverride(dragOverrides, node.field.key),
+		});
 	}
 
 	const effectStatus = Internals.getEffectCodeValuesCtx({
@@ -33,11 +87,19 @@ export const getNodeKeyframes = ({
 		nodePath,
 		effectIndex: node.field.effectIndex,
 	});
-
-	return getTimelineKeyframes(
-		effectStatus.type === 'can-update-effect'
-			? effectStatus.props?.[node.field.key]
-			: null,
-		keyframeDisplayOffset,
+	const effectDragOverrides = getEffectDragOverrides(
+		nodePath,
+		node.field.effectIndex,
 	);
+
+	return withDragOverrideKeyframe({
+		propStatus:
+			effectStatus.type === 'can-update-effect'
+				? effectStatus.props?.[node.field.key]
+				: null,
+		keyframeDisplayOffset,
+		timelinePosition,
+		dragOverrideValue: effectDragOverrides[node.field.key],
+		hasDragOverride: hasOverride(effectDragOverrides, node.field.key),
+	});
 };

--- a/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
+++ b/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
@@ -36,6 +36,7 @@ export const useExpandedTrackKeyframeRows = ({
 	const {getDragOverrides, getEffectDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
 
 	const tree = useMemo(
 		() =>
@@ -80,6 +81,9 @@ export const useExpandedTrackKeyframeRows = ({
 					nodePath: nodePathInfo.sequenceSubscriptionKey,
 					codeValues,
 					keyframeDisplayOffset,
+					getDragOverrides,
+					getEffectDragOverrides,
+					timelinePosition,
 				}),
 				rowKey: timelineNodePathInfoToKey(node.nodePathInfo),
 				nodePathInfo: node.nodePathInfo,
@@ -87,8 +91,11 @@ export const useExpandedTrackKeyframeRows = ({
 		[
 			codeValues,
 			flat,
+			getDragOverrides,
+			getEffectDragOverrides,
 			keyframeDisplayOffset,
 			nodePathInfo.sequenceSubscriptionKey,
+			timelinePosition,
 		],
 	);
 

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -1,7 +1,14 @@
 import {expect, test} from 'bun:test';
-import type {SequencePropsSubscriptionKey, TSequence} from 'remotion';
+import {Internals, type CodeValues} from 'remotion';
+import type {
+	CanUpdateSequencePropStatusKeyframed,
+	SequencePropsSubscriptionKey,
+	TSequence,
+} from 'remotion';
+import {getNodeKeyframes} from '../components/Timeline/get-node-keyframes';
 import {getTimelineKeyframes} from '../components/Timeline/get-timeline-keyframes';
 import {calculateTimeline} from '../helpers/calculate-timeline';
+import type {TimelineTreeNode} from '../helpers/timeline-layout';
 
 const getStack = () => null;
 
@@ -52,6 +59,94 @@ const makeSequence = ({
 	postmountDisplay: null,
 	controls: overrideId ? makeControls(overrideId) : null,
 	effects: [],
+});
+
+const numberFieldSchema = {
+	type: 'number',
+	default: 1,
+	hiddenFromList: false,
+} as const;
+
+const makeKeyframedStatus = (): CanUpdateSequencePropStatusKeyframed => ({
+	status: 'keyframed',
+	codeValue: undefined,
+	interpolationFunction: 'interpolate',
+	keyframes: [
+		{frame: 0, value: 2},
+		{frame: 60, value: 4},
+	],
+	easing: ['linear'],
+	clamping: {left: 'extend', right: 'extend'},
+	posterize: undefined,
+});
+
+const makeSequenceFieldNode = (key: string): TimelineTreeNode => ({
+	kind: 'field',
+	label: key,
+	nodePathInfo: {
+		sequenceSubscriptionKey: makeNodePath('sequence'),
+		auxiliaryKeys: ['controls', key],
+		index: 0,
+		numberOfSequencesWithThisNodePath: 1,
+		supportsEffects: true,
+	},
+	field: {
+		kind: 'sequence-field',
+		key,
+		description: undefined,
+		typeName: 'number',
+		rowHeight: 22,
+		fieldSchema: numberFieldSchema,
+	},
+});
+
+const makeEffectFieldNode = (
+	key: string,
+	effectIndex: number,
+): TimelineTreeNode => ({
+	kind: 'field',
+	label: key,
+	nodePathInfo: {
+		sequenceSubscriptionKey: makeNodePath('sequence'),
+		auxiliaryKeys: ['effects', String(effectIndex), key],
+		index: 0,
+		numberOfSequencesWithThisNodePath: 1,
+		supportsEffects: true,
+	},
+	field: {
+		kind: 'effect-field',
+		key,
+		description: undefined,
+		typeName: 'number',
+		rowHeight: 22,
+		fieldSchema: numberFieldSchema,
+		effectIndex,
+		effectSchema: {
+			[key]: numberFieldSchema,
+		},
+	},
+});
+
+const makeCodeValues = (
+	nodePath: SequencePropsSubscriptionKey,
+): CodeValues => ({
+	[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+		canUpdate: true,
+		props: {
+			'style.scale': makeKeyframedStatus(),
+		},
+		effects: [
+			{
+				canUpdate: true,
+				effectIndex: 0,
+				callee: 'blur',
+				importPath: null,
+				props: {
+					amount: makeKeyframedStatus(),
+				},
+			},
+		],
+	},
 });
 
 test('keyframe display offsets follow the parent sequence context', () => {
@@ -131,5 +226,44 @@ test('keyframe display offsets follow the parent sequence context', () => {
 	).toEqual([
 		{frame: 30, value: 2},
 		{frame: 90, value: 4},
+	]);
+});
+
+test('getNodeKeyframes shows a temporary sequence keyframe from drag overrides', () => {
+	const nodePath = makeNodePath('sequence');
+
+	expect(
+		getNodeKeyframes({
+			node: makeSequenceFieldNode('style.scale'),
+			nodePath,
+			codeValues: makeCodeValues(nodePath),
+			keyframeDisplayOffset: 30,
+			getDragOverrides: () => ({'style.scale': 3}),
+			getEffectDragOverrides: () => ({}),
+			timelinePosition: 60,
+		}),
+	).toEqual([
+		{frame: 30, value: 2},
+		{frame: 60, value: 3},
+		{frame: 90, value: 4},
+	]);
+});
+
+test('getNodeKeyframes shows a temporary effect keyframe from drag overrides', () => {
+	const nodePath = makeNodePath('sequence');
+
+	expect(
+		getNodeKeyframes({
+			node: makeEffectFieldNode('amount', 0),
+			nodePath,
+			codeValues: makeCodeValues(nodePath),
+			keyframeDisplayOffset: 30,
+			getDragOverrides: () => ({}),
+			getEffectDragOverrides: () => ({amount: 5}),
+			timelinePosition: 90,
+		}),
+	).toEqual([
+		{frame: 30, value: 2},
+		{frame: 90, value: 5},
 	]);
 });


### PR DESCRIPTION
## Summary
- Make keyframed timeline values editable instead of disabled/grayed out.
- Save edits and drag changes through the existing add-keyframe flow, which updates an existing keyframe at the current frame or inserts one otherwise.
- Add regression coverage for same-frame keyframe updates in optimistic state and codemod output.

## Validation
- bun test packages/studio-shared/src/test/optimistic-add-keyframe.test.ts packages/studio-server/src/test/update-keyframes.test.ts
- bunx turbo run make --filter='@remotion/studio' --filter='@remotion/studio-shared' --filter='@remotion/studio-server'
- bun run build
- bun run formatting
- bun run stylecheck
