### PR TITLE
`@remotion/studio`: Allow dragging timeline sequence from

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -19,6 +19,7 @@ import {
 import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
 import {
 	durationInFramesField,
+	fromField,
 	hiddenField,
 	sequenceVisualStyleSchema,
 } from './sequence-field-schema.js';
@@ -616,6 +617,7 @@ HtmlInCanvasInner.displayName = 'HtmlInCanvas';
 
 const htmlInCanvasSchema = {
 	durationInFrames: durationInFramesField,
+	from: fromField,
 	...sequenceVisualStyleSchema,
 	hidden: hiddenField,
 };

--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -12,6 +12,7 @@ import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
 import {getCrossOriginValue} from './get-cross-origin-value.js';
 import {usePreload} from './prefetch.js';
 import {
+	fromField,
 	hiddenField,
 	sequenceVisualStyleSchema,
 	durationInFramesField,
@@ -361,6 +362,7 @@ const CanvasImageWithPrivateProps = CanvasImage as React.ComponentType<
 
 export const imgSchema = {
 	durationInFrames: durationInFramesField,
+	from: fromField,
 	...sequenceVisualStyleSchema,
 	hidden: hiddenField,
 } as const satisfies SequenceSchema;

--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -17,6 +17,7 @@ import {
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {
 	durationInFramesField,
+	fromField,
 	hiddenField,
 	sequenceVisualStyleSchema,
 	type SequenceSchema,
@@ -36,6 +37,7 @@ import {resolveAnimatedImageSource} from './resolve-image-source';
 
 const animatedImageSchema = {
 	durationInFrames: durationInFramesField,
+	from: fromField,
 	playbackRate: {
 		type: 'number',
 		min: 0,

--- a/packages/core/src/canvas-image/CanvasImage.tsx
+++ b/packages/core/src/canvas-image/CanvasImage.tsx
@@ -21,6 +21,7 @@ import {
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {usePreload} from '../prefetch.js';
 import {
+	fromField,
 	hiddenField,
 	sequenceVisualStyleSchema,
 	durationInFramesField,
@@ -36,6 +37,7 @@ import type {CanvasImageCanvasProps, CanvasImageProps} from './props.js';
 
 export const canvasImageSchema = {
 	durationInFrames: durationInFramesField,
+	from: fromField,
 	fit: {
 		type: 'enum',
 		default: 'fill',

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -11,6 +11,7 @@ import type {SequenceControls} from '../CompositionManager.js';
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {
 	durationInFramesField,
+	fromField,
 	hiddenField,
 	sequenceVisualStyleSchema,
 	type SequenceSchema,
@@ -47,6 +48,7 @@ export type SolidProps = MandatoryProps & Partial<OptionalProps>;
 
 const solidSchema = {
 	durationInFrames: durationInFramesField,
+	from: fromField,
 	color: {
 		type: 'color',
 		default: 'transparent',

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -116,6 +116,7 @@ import {
 } from './ResolveCompositionConfig.js';
 import {
 	durationInFramesField,
+	fromField,
 	hiddenField,
 	sequencePremountSchema,
 	sequenceSchema,
@@ -379,6 +380,7 @@ export const Internals = {
 	getEffectCodeValuesCtx,
 	hiddenField,
 	durationInFramesField,
+	fromField,
 } as const;
 
 export type {

--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -177,8 +177,16 @@ export const durationInFramesField = {
 	hiddenFromList: true,
 } as const satisfies SequenceFieldSchema;
 
+export const fromField = {
+	type: 'number',
+	default: 0,
+	step: 1,
+	hiddenFromList: true,
+} as const satisfies SequenceFieldSchema;
+
 export const sequenceSchema = {
 	hidden: hiddenField,
+	from: fromField,
 	durationInFrames: durationInFramesField,
 	layout: {
 		type: 'enum',

--- a/packages/core/src/test/wrap-in-schema-helpers.test.ts
+++ b/packages/core/src/test/wrap-in-schema-helpers.test.ts
@@ -37,6 +37,7 @@ test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 			'styleWhilePremounted',
 			'styleWhilePostmounted',
 			'durationInFrames',
+			'from',
 		].sort(),
 	);
 });
@@ -60,7 +61,7 @@ test('selectActiveKeys returns only the hidden + layout keys when layout=none', 
 		'style.scale': 2,
 	};
 	expect(selectActiveKeys(sequenceSchema, values).sort()).toEqual(
-		['hidden', 'layout', 'durationInFrames'].sort(),
+		['hidden', 'layout', 'durationInFrames', 'from'].sort(),
 	);
 });
 
@@ -74,6 +75,7 @@ test('selectActiveKeys exposes style.* keys when layout=absolute-fill', () => {
 			'hidden',
 			'layout',
 			'durationInFrames',
+			'from',
 			'style.translate',
 			'style.scale',
 			'style.rotate',
@@ -88,7 +90,7 @@ test('selectActiveKeys exposes style.* keys when layout=absolute-fill', () => {
 		'style.scale': 2,
 	};
 	expect(selectActiveKeys(sequenceSchema, values2).sort()).toEqual(
-		['hidden', 'layout', 'durationInFrames'].sort(),
+		['hidden', 'layout', 'durationInFrames', 'from'].sort(),
 	);
 });
 
@@ -117,7 +119,7 @@ test('end-to-end: layout=none drops style.scale from active props', () => {
 		propsToDelete: new Set(),
 	});
 	expect(activeKeys.sort()).toEqual(
-		['hidden', 'layout', 'durationInFrames'].sort(),
+		['hidden', 'layout', 'durationInFrames', 'from'].sort(),
 	);
 	// style.scale was not in activeKeys → original style preserved, not overwritten
 	expect((merged.style as {scale: number}).scale).toBe(2);

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -19,6 +19,7 @@ const {
 	useMemoizedEffects,
 	wrapInSchema,
 	durationInFramesField,
+	fromField,
 } = Internals;
 
 export type GifProps = Omit<
@@ -36,6 +37,7 @@ export type GifProps = Omit<
  */
 const gifSchema = {
 	durationInFrames: durationInFramesField,
+	from: fromField,
 	playbackRate: {
 		type: 'number',
 		min: 0,

--- a/packages/light-leaks/src/LightLeak.tsx
+++ b/packages/light-leaks/src/LightLeak.tsx
@@ -235,6 +235,7 @@ const LightLeakCanvas: React.FC<{
  */
 const lightLeakSchema = {
 	durationInFrames: Internals.durationInFramesField,
+	from: Internals.fromField,
 	seed: {
 		type: 'number',
 		default: 0,

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -37,6 +37,7 @@ import {mapToAlignment, mapToFit} from './map-enums.js';
 const {
 	addSequenceStackTraces,
 	durationInFramesField,
+	fromField,
 	hiddenField,
 	runEffectChain,
 	sequenceVisualStyleSchema,
@@ -105,6 +106,7 @@ const riveAlignmentVariants: Record<
 
 const riveCanvasSchema = {
 	durationInFrames: durationInFramesField,
+	from: fromField,
 	fit: {
 		type: 'enum',
 		default: 'contain',

--- a/packages/starburst/src/Starburst.tsx
+++ b/packages/starburst/src/Starburst.tsx
@@ -276,6 +276,7 @@ const StarburstCanvas: React.FC<{
  */
 const starburstSchema = {
 	durationInFrames: Internals.durationInFramesField,
+	from: Internals.fromField,
 	rays: {
 		type: 'number',
 		min: 2,

--- a/packages/studio-server/src/test/get-all-schema-keys.test.ts
+++ b/packages/studio-server/src/test/get-all-schema-keys.test.ts
@@ -21,6 +21,7 @@ test('getAllSchemaKeys returns every key across all enum variants', () => {
 			'styleWhilePremounted',
 			'styleWhilePostmounted',
 			'durationInFrames',
+			'from',
 		].sort(),
 	);
 });

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -110,9 +110,8 @@ const TimelineSequenceCurrentFrame: React.FC<{
 		return {
 			...style,
 			opacity: isInRange ? 1 : 0.5,
-			...(TIMELINE_TOP_DRAG && fromCanUpdate ? {cursor: 'grab'} : {}),
 		};
-	}, [fromCanUpdate, isInRange, style]);
+	}, [isInRange, style]);
 
 	return (
 		<div

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -17,7 +17,10 @@ import {LoopedTimelineIndicator} from './LoopedTimelineIndicators';
 import {TimelineImageInfo} from './TimelineImageInfo';
 import {TIMELINE_TOP_DRAG, useTimelineRowSelection} from './TimelineSelection';
 import {TimelineSequenceFrame} from './TimelineSequenceFrame';
-import {TimelineSequenceRightEdgeDragHandle} from './TimelineSequenceRightEdgeDragHandle';
+import {
+	TimelineSequenceRightEdgeDragHandle,
+	useTimelineSequenceFromDrag,
+} from './TimelineSequenceRightEdgeDragHandle';
 import {TimelineVideoInfo} from './TimelineVideoInfo';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 import {useResolveStackAndReactToChange} from './use-resolved-stack-react-to-change';
@@ -53,6 +56,10 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	readonly style: React.CSSProperties;
 	readonly children: React.ReactNode;
 	readonly nodePathInfo: SequenceNodePathInfo | null;
+	readonly fromCanUpdate: boolean;
+	readonly onMoveDragPointerDown: (
+		e: React.PointerEvent<HTMLDivElement>,
+	) => void;
 }> = ({
 	s,
 	displayDurationInFrames,
@@ -61,6 +68,8 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	style,
 	children,
 	nodePathInfo,
+	fromCanUpdate,
+	onMoveDragPointerDown,
 }) => {
 	const {onSelect, selectable} = useTimelineRowSelection(nodePathInfo);
 
@@ -72,9 +81,12 @@ const TimelineSequenceCurrentFrame: React.FC<{
 					shiftKey: e.shiftKey,
 					toggleKey: e.metaKey || e.ctrlKey,
 				});
+				if (TIMELINE_TOP_DRAG && fromCanUpdate) {
+					onMoveDragPointerDown(e);
+				}
 			}
 		},
-		[onSelect],
+		[fromCanUpdate, onMoveDragPointerDown, onSelect],
 	);
 	const frame = useCurrentFrame();
 	const relativeFrame = frame - s.from;
@@ -98,9 +110,9 @@ const TimelineSequenceCurrentFrame: React.FC<{
 		return {
 			...style,
 			opacity: isInRange ? 1 : 0.5,
-			...(TIMELINE_TOP_DRAG ? {cursor: 'pointer'} : {}),
+			...(TIMELINE_TOP_DRAG && fromCanUpdate ? {cursor: 'grab'} : {}),
 		};
-	}, [isInRange, style]);
+	}, [fromCanUpdate, isInRange, style]);
 
 	return (
 		<div
@@ -210,6 +222,15 @@ const TimelineSequenceInner: React.FC<{
 	const durationCanUpdate = Boolean(
 		codeValuesForOverride?.durationInFrames?.status === 'static',
 	);
+	const fromCanUpdate = Boolean(
+		codeValuesForOverride?.from?.status === 'static',
+	);
+
+	const {onPointerDown: onMoveDragPointerDown} = useTimelineSequenceFromDrag({
+		nodePathInfo,
+		windowWidth,
+		timelineDurationInFrames: video?.durationInFrames ?? 1,
+	});
 
 	if (!video) {
 		throw new TypeError('Expected video config');
@@ -282,6 +303,8 @@ const TimelineSequenceInner: React.FC<{
 			postmountWidth={postmountWidth}
 			style={style}
 			nodePathInfo={nodePathInfo}
+			fromCanUpdate={fromCanUpdate}
+			onMoveDragPointerDown={onMoveDragPointerDown}
 		>
 			{s.type === 'audio' ? (
 				<AudioWaveform

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -413,7 +413,6 @@ export const useTimelineSequenceFromDrag = ({
 		dragStateRef.current = null;
 		document.body.style.userSelect = '';
 		document.body.style.webkitUserSelect = '';
-		stopForcingSpecificCursor();
 		setDragging(false);
 
 		if (!dragState) {
@@ -520,7 +519,6 @@ export const useTimelineSequenceFromDrag = ({
 			};
 			document.body.style.userSelect = 'none';
 			document.body.style.webkitUserSelect = 'none';
-			forceSpecificCursor('grabbing');
 			setDragging(true);
 		},
 		[timelineDurationInFrames, windowWidth],

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -51,6 +51,12 @@ export type TimelineSequenceDurationDragTarget = {
 	readonly nodePath: SequencePropsSubscriptionKey;
 };
 
+export type TimelineSequenceFromDragTarget = {
+	readonly fileName: string;
+	readonly initialFrom: number;
+	readonly nodePath: SequencePropsSubscriptionKey;
+};
+
 const canUpdateDurationInFrames = ({
 	codeValues,
 	nodePath,
@@ -64,9 +70,29 @@ const canUpdateDurationInFrames = ({
 	return status === 'static';
 };
 
+const canUpdateFrom = ({
+	codeValues,
+	nodePath,
+}: {
+	readonly codeValues: CodeValues;
+	readonly nodePath: SequencePropsSubscriptionKey;
+}) => {
+	const status = Internals.getCodeValuesCtx(codeValues, nodePath)?.from?.status;
+
+	return status === 'static';
+};
+
 const isDurationDraggableSequence = (sequence: TSequence) => {
 	return (
 		(sequence.type === 'sequence' || sequence.type === 'image') &&
+		!sequence.loopDisplay &&
+		!sequence.isInsideSeries &&
+		Boolean(sequence.controls)
+	);
+};
+
+const isFromDraggableSequence = (sequence: TSequence) => {
+	return (
 		!sequence.loopDisplay &&
 		!sequence.isInsideSeries &&
 		Boolean(sequence.controls)
@@ -105,6 +131,44 @@ export const getTimelineSequenceDurationDragChanges = ({
 				fieldKey: 'durationInFrames',
 				value: nextValue,
 				defaultValue: null,
+				schema: NoReactInternals.sequenceSchema,
+			},
+		];
+	});
+};
+
+export const getTimelineSequenceFromDragValue = ({
+	initialFrom,
+	deltaFrames,
+}: {
+	readonly initialFrom: number;
+	readonly deltaFrames: number;
+}) => initialFrom + deltaFrames;
+
+export const getTimelineSequenceFromDragChanges = ({
+	targets,
+	deltaFrames,
+}: {
+	readonly targets: readonly TimelineSequenceFromDragTarget[];
+	readonly deltaFrames: number;
+}): SaveSequencePropChange[] => {
+	return targets.flatMap((target) => {
+		const nextValue = getTimelineSequenceFromDragValue({
+			initialFrom: target.initialFrom,
+			deltaFrames,
+		});
+
+		if (nextValue === target.initialFrom) {
+			return [];
+		}
+
+		return [
+			{
+				fileName: target.fileName,
+				nodePath: target.nodePath,
+				fieldKey: 'from',
+				value: nextValue,
+				defaultValue: '0',
 				schema: NoReactInternals.sequenceSchema,
 			},
 		];
@@ -198,6 +262,76 @@ export const getTimelineSequenceDurationDragTargets = ({
 	return [...targets.values()];
 };
 
+export const getTimelineSequenceFromDragTargets = ({
+	draggedNodePathInfo,
+	selectedItems,
+	sequences,
+	overrideIdsToNodePaths,
+	codeValues,
+}: {
+	readonly draggedNodePathInfo: SequenceNodePathInfo;
+	readonly selectedItems: readonly TimelineSelection[];
+	readonly sequences: TSequence[];
+	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
+	readonly codeValues: CodeValues;
+}): TimelineSequenceFromDragTarget[] | null => {
+	const draggedSelectionKey =
+		getTimelineSequenceSelectionKey(draggedNodePathInfo);
+	const selectedSequenceItems = selectedItems.filter(
+		(item): item is TimelineSelection & {type: 'sequence'} =>
+			item.type === 'sequence',
+	);
+	const draggedItemIsSelected = selectedSequenceItems.some(
+		(item) =>
+			getTimelineSequenceSelectionKey(item.nodePathInfo) ===
+			draggedSelectionKey,
+	);
+
+	if (
+		draggedItemIsSelected &&
+		selectedSequenceItems.length !== selectedItems.length
+	) {
+		return null;
+	}
+
+	const targetNodePathInfos =
+		draggedItemIsSelected && selectedSequenceItems.length > 1
+			? selectedSequenceItems.map((item) => item.nodePathInfo)
+			: [draggedNodePathInfo];
+	const tracks = calculateTimeline({sequences, overrideIdsToNodePaths});
+	const targets = new Map<string, TimelineSequenceFromDragTarget>();
+
+	for (const nodePathInfo of targetNodePathInfos) {
+		const track = findSequenceTrack({tracks, nodePathInfo});
+		const originalSequence = track
+			? sequences.find((sequence) => sequence.id === track.sequence.id)
+			: null;
+		if (
+			!track ||
+			!originalSequence ||
+			!isFromDraggableSequence(originalSequence)
+		) {
+			return null;
+		}
+
+		const nodePath = nodePathInfo.sequenceSubscriptionKey;
+		if (!canUpdateFrom({codeValues, nodePath})) {
+			return null;
+		}
+
+		const key = stringifySequenceSubscriptionKey(nodePath);
+		if (!targets.has(key)) {
+			targets.set(key, {
+				fileName: nodePath.absolutePath,
+				initialFrom: originalSequence.from,
+				nodePath,
+			});
+		}
+	}
+
+	return [...targets.values()];
+};
+
 const clearDurationDragOverrides = ({
 	clearDragOverrides,
 	targets,
@@ -208,6 +342,255 @@ const clearDurationDragOverrides = ({
 	for (const target of targets) {
 		clearDragOverrides(target.nodePath);
 	}
+};
+
+const clearFromDragOverrides = ({
+	clearDragOverrides,
+	targets,
+}: {
+	readonly clearDragOverrides: (nodePath: SequencePropsSubscriptionKey) => void;
+	readonly targets: readonly TimelineSequenceFromDragTarget[];
+}) => {
+	for (const target of targets) {
+		clearDragOverrides(target.nodePath);
+	}
+};
+
+export const useTimelineSequenceFromDrag = ({
+	nodePathInfo,
+	windowWidth,
+	timelineDurationInFrames,
+}: {
+	readonly nodePathInfo: SequenceNodePathInfo | null;
+	readonly windowWidth: number;
+	readonly timelineDurationInFrames: number;
+}) => {
+	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
+		Internals.VisualModeSettersContext,
+	);
+	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {sequences} = useContext(Internals.SequenceManager);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {selectedItems} = useTimelineSelection();
+
+	const [dragging, setDragging] = useState(false);
+	const dragStateRef = useRef<{
+		initialClientX: number;
+		latestDeltaFrames: number;
+		pxPerFrame: number;
+		pointerId: number;
+		targets: readonly TimelineSequenceFromDragTarget[];
+	} | null>(null);
+
+	const latestRef = useRef({
+		nodePathInfo,
+		setCodeValues,
+		setDragOverrides,
+		clearDragOverrides,
+		previewServerState,
+		codeValues,
+		sequences,
+		overrideIdToNodePathMappings,
+		selectedItems,
+	});
+	latestRef.current = {
+		nodePathInfo,
+		setCodeValues,
+		setDragOverrides,
+		clearDragOverrides,
+		previewServerState,
+		codeValues,
+		sequences,
+		overrideIdToNodePathMappings,
+		selectedItems,
+	};
+
+	const finishDrag = useCallback((commit: boolean) => {
+		const dragState = dragStateRef.current;
+		dragStateRef.current = null;
+		document.body.style.userSelect = '';
+		document.body.style.webkitUserSelect = '';
+		stopForcingSpecificCursor();
+		setDragging(false);
+
+		if (!dragState) {
+			return;
+		}
+
+		const {
+			setCodeValues: latestSetCodeValues,
+			clearDragOverrides: latestClear,
+			previewServerState: latestServerState,
+		} = latestRef.current;
+
+		const changes = getTimelineSequenceFromDragChanges({
+			targets: dragState.targets,
+			deltaFrames: dragState.latestDeltaFrames,
+		});
+
+		if (
+			!commit ||
+			latestServerState.type !== 'connected' ||
+			changes.length === 0
+		) {
+			clearFromDragOverrides({
+				clearDragOverrides: latestClear,
+				targets: dragState.targets,
+			});
+			return;
+		}
+
+		const savePromise =
+			changes.length === 1
+				? saveSequenceProp({
+						...changes[0],
+						setCodeValues: latestSetCodeValues,
+						clientId: latestServerState.clientId,
+					})
+				: saveSequenceProps({
+						changes,
+						setCodeValues: latestSetCodeValues,
+						clientId: latestServerState.clientId,
+						undoLabel: 'Move selected sequences',
+						redoLabel: 'Move selected sequences back',
+					});
+
+		savePromise
+			.catch((err) => {
+				Internals.Log.error(
+					{logLevel: 'error', tag: null},
+					'Could not save from',
+					err,
+				);
+			})
+			.finally(() => {
+				clearFromDragOverrides({
+					clearDragOverrides: latestClear,
+					targets: dragState.targets,
+				});
+			});
+	}, []);
+
+	const onPointerDown = useCallback(
+		(e: React.PointerEvent<HTMLDivElement>) => {
+			if (e.button !== 0) {
+				return;
+			}
+
+			const pxPerFrame =
+				timelineDurationInFrames > 0
+					? (windowWidth - TIMELINE_PADDING * 2) / timelineDurationInFrames
+					: 0;
+			if (pxPerFrame <= 0) {
+				return;
+			}
+
+			const {
+				nodePathInfo: latestNodePathInfo,
+				selectedItems: latestSelectedItems,
+				sequences: latestSequences,
+				overrideIdToNodePathMappings: latestOverrideIdsToNodePaths,
+				codeValues: latestCodeValues,
+			} = latestRef.current;
+			if (latestNodePathInfo === null) {
+				return;
+			}
+
+			const targets = getTimelineSequenceFromDragTargets({
+				draggedNodePathInfo: latestNodePathInfo,
+				selectedItems: latestSelectedItems,
+				sequences: latestSequences,
+				overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
+				codeValues: latestCodeValues,
+			});
+			if (targets === null || targets.length === 0) {
+				return;
+			}
+
+			e.preventDefault();
+			dragStateRef.current = {
+				initialClientX: e.clientX,
+				latestDeltaFrames: 0,
+				pxPerFrame,
+				pointerId: e.pointerId,
+				targets,
+			};
+			document.body.style.userSelect = 'none';
+			document.body.style.webkitUserSelect = 'none';
+			forceSpecificCursor('grabbing');
+			setDragging(true);
+		},
+		[timelineDurationInFrames, windowWidth],
+	);
+
+	useEffect(() => {
+		if (!dragging) {
+			return;
+		}
+
+		const onMove = (e: PointerEvent) => {
+			const dragState = dragStateRef.current;
+			if (!dragState || e.pointerId !== dragState.pointerId) {
+				return;
+			}
+
+			const dx = e.clientX - dragState.initialClientX;
+			const deltaFrames = Math.round(dx / dragState.pxPerFrame);
+			dragState.latestDeltaFrames = deltaFrames;
+			for (const target of dragState.targets) {
+				latestRef.current.setDragOverrides(
+					target.nodePath,
+					'from',
+					getTimelineSequenceFromDragValue({
+						initialFrom: target.initialFrom,
+						deltaFrames,
+					}),
+				);
+			}
+		};
+
+		const onUp = (e: PointerEvent) => {
+			const dragState = dragStateRef.current;
+			if (!dragState || e.pointerId !== dragState.pointerId) {
+				return;
+			}
+
+			finishDrag(true);
+		};
+
+		const onCancel = (e: PointerEvent) => {
+			const dragState = dragStateRef.current;
+			if (!dragState || e.pointerId !== dragState.pointerId) {
+				return;
+			}
+
+			finishDrag(false);
+		};
+
+		const onWindowBlur = () => {
+			finishDrag(false);
+		};
+
+		window.addEventListener('pointermove', onMove);
+		window.addEventListener('pointerup', onUp);
+		window.addEventListener('pointercancel', onCancel);
+		window.addEventListener('blur', onWindowBlur);
+
+		return () => {
+			window.removeEventListener('pointermove', onMove);
+			window.removeEventListener('pointerup', onUp);
+			window.removeEventListener('pointercancel', onCancel);
+			window.removeEventListener('blur', onWindowBlur);
+		};
+	}, [dragging, finishDrag]);
+
+	return {
+		dragging,
+		onPointerDown,
+	};
 };
 
 export const TimelineSequenceRightEdgeDragHandle: React.FC<{

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -7,6 +7,7 @@ import {
 	type SequenceSchema,
 	type TSequence,
 } from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
 import {
 	getSelectedEffectFieldsBySequenceKey,
 	getSelectedOutlineDragChanges,
@@ -37,6 +38,9 @@ import {
 	getTimelineSequenceDurationDragChanges,
 	getTimelineSequenceDurationDragTargets,
 	getTimelineSequenceDurationDragValue,
+	getTimelineSequenceFromDragChanges,
+	getTimelineSequenceFromDragTargets,
+	getTimelineSequenceFromDragValue,
 } from '../components/Timeline/TimelineSequenceRightEdgeDragHandle';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 
@@ -70,6 +74,7 @@ const makeTimelineSequence = ({
 	overrideId = 'override',
 	duration = 100,
 	from = 0,
+	parent = null,
 	type = 'sequence',
 }: {
 	readonly schema: SequenceSchema;
@@ -78,6 +83,7 @@ const makeTimelineSequence = ({
 	readonly overrideId?: string;
 	readonly duration?: number;
 	readonly from?: number;
+	readonly parent?: string | null;
 	readonly type?: TSequence['type'];
 }): TSequence =>
 	({
@@ -87,7 +93,7 @@ const makeTimelineSequence = ({
 		id,
 		displayName: id,
 		documentationLink: null,
-		parent: null,
+		parent,
 		rootId: 'root',
 		showInTimeline: true,
 		nonce: [[0, 0]],
@@ -115,6 +121,23 @@ const makeDurationCodeValues = (
 			canUpdate: true,
 			props: {
 				durationInFrames: {status: 'static', codeValue: 100},
+			},
+			effects: [],
+		};
+	}
+
+	return codeValues;
+};
+
+const makeFromCodeValues = (
+	nodePaths: readonly SequencePropsSubscriptionKey[],
+): CodeValues => {
+	const codeValues: CodeValues = {};
+	for (const nodePath of nodePaths) {
+		codeValues[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
+			canUpdate: true,
+			props: {
+				from: {status: 'static', codeValue: 0},
 			},
 			effects: [],
 		};
@@ -465,6 +488,172 @@ test('Timeline duration drag ignores selection if dragged sequence is not select
 	expect(targets?.map((target) => target.nodePath)).toEqual([
 		firstNodePathInfo.sequenceSubscriptionKey,
 	]);
+});
+
+test('Timeline from drag applies the same delta to selected sequences', () => {
+	const schema = {} satisfies SequenceSchema;
+	const firstNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const secondNodePathInfo = makeNodePathInfo(['body', 1], []);
+	const sequences = [
+		makeTimelineSequence({
+			schema,
+			id: 'first',
+			overrideId: 'first',
+			duration: 40,
+			from: 0,
+		}),
+		makeTimelineSequence({
+			schema,
+			id: 'second',
+			overrideId: 'second',
+			duration: 15,
+			from: 10,
+			type: 'audio',
+		}),
+	];
+	const targets = getTimelineSequenceFromDragTargets({
+		draggedNodePathInfo: firstNodePathInfo,
+		selectedItems: [
+			{type: 'sequence', nodePathInfo: firstNodePathInfo},
+			{type: 'sequence', nodePathInfo: secondNodePathInfo},
+		],
+		sequences,
+		overrideIdsToNodePaths: {
+			first: firstNodePathInfo.sequenceSubscriptionKey,
+			second: secondNodePathInfo.sequenceSubscriptionKey,
+		},
+		codeValues: makeFromCodeValues([
+			firstNodePathInfo.sequenceSubscriptionKey,
+			secondNodePathInfo.sequenceSubscriptionKey,
+		]),
+	});
+
+	expect(targets?.map((target) => target.initialFrom)).toEqual([0, 10]);
+	expect(
+		getTimelineSequenceFromDragChanges({
+			targets: targets ?? [],
+			deltaFrames: 12,
+		}).map((change) => change.value),
+	).toEqual([12, 22]);
+});
+
+test('Timeline from drag supports negative offsets', () => {
+	expect(
+		getTimelineSequenceFromDragValue({
+			initialFrom: 4,
+			deltaFrames: -10,
+		}),
+	).toBe(-6);
+});
+
+test('Timeline from drag saves relative from for nested sequences', () => {
+	const schema = {} satisfies SequenceSchema;
+	const childNodePathInfo = makeNodePathInfo(['body', 1], []);
+	const targets = getTimelineSequenceFromDragTargets({
+		draggedNodePathInfo: childNodePathInfo,
+		selectedItems: [{type: 'sequence', nodePathInfo: childNodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				id: 'parent',
+				overrideId: 'parent',
+				duration: 100,
+				from: 50,
+			}),
+			makeTimelineSequence({
+				schema,
+				id: 'child',
+				overrideId: 'child',
+				duration: 20,
+				from: 10,
+				parent: 'parent',
+			}),
+		],
+		overrideIdsToNodePaths: {
+			child: childNodePathInfo.sequenceSubscriptionKey,
+		},
+		codeValues: makeFromCodeValues([childNodePathInfo.sequenceSubscriptionKey]),
+	});
+
+	expect(targets?.map((target) => target.initialFrom)).toEqual([10]);
+	expect(
+		getTimelineSequenceFromDragChanges({
+			targets: targets ?? [],
+			deltaFrames: 5,
+		}).map((change) => change.value),
+	).toEqual([15]);
+});
+
+test('Timeline from drag is blocked if one selected sequence cannot update from', () => {
+	const schema = {} satisfies SequenceSchema;
+	const firstNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const secondNodePathInfo = makeNodePathInfo(['body', 1], []);
+	const codeValues = makeFromCodeValues([
+		firstNodePathInfo.sequenceSubscriptionKey,
+	]);
+
+	codeValues[
+		Internals.makeSequencePropsSubscriptionKey(
+			secondNodePathInfo.sequenceSubscriptionKey,
+		)
+	] = {
+		canUpdate: true,
+		props: {},
+		effects: [],
+	};
+
+	expect(
+		getTimelineSequenceFromDragTargets({
+			draggedNodePathInfo: firstNodePathInfo,
+			selectedItems: [
+				{type: 'sequence', nodePathInfo: firstNodePathInfo},
+				{type: 'sequence', nodePathInfo: secondNodePathInfo},
+			],
+			sequences: [
+				makeTimelineSequence({
+					schema,
+					id: 'first',
+					overrideId: 'first',
+					duration: 40,
+				}),
+				makeTimelineSequence({
+					schema,
+					id: 'second',
+					overrideId: 'second',
+					duration: 15,
+					from: 10,
+				}),
+			],
+			overrideIdsToNodePaths: {
+				first: firstNodePathInfo.sequenceSubscriptionKey,
+				second: secondNodePathInfo.sequenceSubscriptionKey,
+			},
+			codeValues,
+		}),
+	).toBe(null);
+});
+
+test('Timeline from drag removes the prop at the default value', () => {
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const [change] = getTimelineSequenceFromDragChanges({
+		targets: [
+			{
+				fileName: nodePathInfo.sequenceSubscriptionKey.absolutePath,
+				initialFrom: 5,
+				nodePath: nodePathInfo.sequenceSubscriptionKey,
+			},
+		],
+		deltaFrames: -5,
+	});
+
+	expect(change).toEqual({
+		fileName: nodePathInfo.sequenceSubscriptionKey.absolutePath,
+		nodePath: nodePathInfo.sequenceSubscriptionKey,
+		fieldKey: 'from',
+		value: 0,
+		defaultValue: '0',
+		schema: NoReactInternals.sequenceSchema,
+	});
 });
 
 test('Timeline outlines should not be enabled', () => {


### PR DESCRIPTION
Fixes #7346.

## Summary
- Adds `from` to the internal Sequence schema so Studio Visual Mode can determine when it is statically editable.
- Allows dragging a timeline layer horizontally to update the Sequence `from` prop, including multi-selected rows with all-or-nothing eligibility.
- Keeps right-edge duration resizing separate and adds regression tests for nested Sequences so saved `from` remains relative rather than visible/cascaded.

## Tests
- bun test packages/studio/src/test/timeline-selection.test.ts packages/core/src/test/wrap-in-schema-helpers.test.ts packages/studio-server/src/test/get-all-schema-keys.test.ts
- bun run build
- bun run formatting
