### PR TITLE
`@remotion/skills`: Add effects skill

### DIFF
--- a/.agents/skills/add-effect/SKILL.md
+++ b/.agents/skills/add-effect/SKILL.md
@@ -329,15 +329,11 @@ Keep the agent-facing Remotion skill in sync with the new effect.
 
 Update `packages/skills/skills/remotion/SKILL.md`:
 
-- Add `effectName()` to the `Available effects:` line under `## Visual effects`.
+- Add `effectName()` to the `Available effects:` line under `## Visual and pixel effects`.
 - Keep the list sorted in the same order as `packages/docs/docs/effects/table-of-contents.tsx`.
 - Keep this top-level entry concise; do not add props or examples here.
 
-Update `packages/skills/skills/remotion/rules/effects.md`:
-
-- Add `effectName()` to the right category under `## Available effects`.
-- Add the subpath import under `## Imports`: `` `effectName` from `@remotion/effects/<effect-name>` ``.
-- Ensure the docs URL still resolves to `https://www.remotion.dev/docs/effects/<effect-name>`.
+Do not duplicate the full list in `packages/skills/skills/remotion/rules/effects.md`; keep that rule limited to general usage mechanics unless the new effect changes import or installation conventions.
 
 ## 10. Format, build, and verify
 
@@ -364,7 +360,7 @@ git status --short
 
 - Do not forget `package.json` `exports` and `typesVersions`; subpath imports like `@remotion/effects/my-effect` depend on them.
 - Do not forget `bundle.ts`; otherwise the ESM subpath will not be built.
-- Do not forget to update `packages/skills/skills/remotion/SKILL.md` and `packages/skills/skills/remotion/rules/effects.md`.
+- Do not forget to update the top-level available effects list in `packages/skills/skills/remotion/SKILL.md`.
 - Do not leave temporary render entry points in `packages/docs/src/remotion`.
 - Do not use a hand-written SVG for the effect TOC preview.
 - Preserve alpha unless the effect intentionally changes it.

--- a/.agents/skills/add-effect/SKILL.md
+++ b/.agents/skills/add-effect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-effect
-description: Add a new effect to @remotion/effects, including implementation, package exports, docs, demos, preview images, tests, formatting, and builds.
+description: Add a new effect to @remotion/effects, including implementation, package exports, docs, demos, preview images, Remotion skill updates, tests, formatting, and builds.
 ---
 
 # Add a new `@remotion/effects` effect
@@ -323,7 +323,23 @@ Commit the generated `packages/docs/static/generated/articles-docs-effects-<effe
 
 If `render-cards.ts` opportunistically generates unrelated missing cards, remove those unrelated files unless they belong to the current change.
 
-## 9. Format, build, and verify
+## 9. Update the Remotion skill
+
+Keep the agent-facing Remotion skill in sync with the new effect.
+
+Update `packages/skills/skills/remotion/SKILL.md`:
+
+- Add `effectName()` to the `Available effects:` line under `## Visual effects`.
+- Keep the list sorted in the same order as `packages/docs/docs/effects/table-of-contents.tsx`.
+- Keep this top-level entry concise; do not add props or examples here.
+
+Update `packages/skills/skills/remotion/rules/effects.md`:
+
+- Add `effectName()` to the right category under `## Available effects`.
+- Add the subpath import under `## Imports`: `` `effectName` from `@remotion/effects/<effect-name>` ``.
+- Ensure the docs URL still resolves to `https://www.remotion.dev/docs/effects/<effect-name>`.
+
+## 10. Format, build, and verify
 
 Run:
 
@@ -348,6 +364,7 @@ git status --short
 
 - Do not forget `package.json` `exports` and `typesVersions`; subpath imports like `@remotion/effects/my-effect` depend on them.
 - Do not forget `bundle.ts`; otherwise the ESM subpath will not be built.
+- Do not forget to update `packages/skills/skills/remotion/SKILL.md` and `packages/skills/skills/remotion/rules/effects.md`.
 - Do not leave temporary render entry points in `packages/docs/src/remotion`.
 - Do not use a hand-written SVG for the effect TOC preview.
 - Preserve alpha unless the effect intentionally changes it.

--- a/packages/skills/skills/remotion/SKILL.md
+++ b/packages/skills/skills/remotion/SKILL.md
@@ -234,11 +234,7 @@ When needing to use sound effects, load the [./rules/sfx.md](./rules/sfx.md) fil
 
 ## Visual and pixel effects
 
-When creating a visual effect, choose the simplest fitting approach:
-
-1. If the look can be achieved with normal Remotion components, HTML, CSS, SVG, masks, filters, blending, or animation, use that first.
-2. If pixel manipulation is useful and a listed effect matches the requested look, load [rules/effects.md](rules/effects.md). Existing effects can also be applied to HTML rendered through `<HtmlInCanvas>`.
-3. If no existing effect fits and custom pixel manipulation is needed, load [rules/html-in-canvas.md](rules/html-in-canvas.md) and use `<HtmlInCanvas>` with a custom `onPaint` handler.
+When creating a visual effect, prefer: 1. normal Remotion/HTML/CSS/SVG/filter/blend/mask animation, 2. a listed effect via [rules/effects.md](rules/effects.md), including on HTML rendered through `<HtmlInCanvas>`, 3. custom `<HtmlInCanvas onPaint>` via [rules/html-in-canvas.md](rules/html-in-canvas.md) only if no listed effect fits.
 
 For light leak overlays, see [rules/light-leaks.md](rules/light-leaks.md). Docs: https://www.remotion.dev/docs/effects
 

--- a/packages/skills/skills/remotion/SKILL.md
+++ b/packages/skills/skills/remotion/SKILL.md
@@ -232,6 +232,12 @@ When needing to visualize audio (spectrum bars, waveforms, bass-reactive effects
 
 When needing to use sound effects, load the [./rules/sfx.md](./rules/sfx.md) file for more information.
 
+## Visual effects
+
+When needing a canvas/WebGL visual effect, only use a listed effect if it matches the requested look. Load [rules/effects.md](rules/effects.md) before using one. Docs: https://www.remotion.dev/docs/effects
+
+Available effects: `barrelDistortion()`, `blur()`, `brightness()`, `chromaticAberration()`, `colorKey()`, `contrast()`, `dotGrid()`, `dropShadow()`, `duotone()`, `evolve()`, `fisheye()`, `glow()`, `grayscale()`, `halftone()`, `halftoneLinearGradient()`, `hue()`, `invert()`, `lightLeak()`, `linearProgressiveBlur()`, `lines()`, `mirror()`, `noise()`, `pixelDissolve()`, `rings()`, `saturation()`, `scale()`, `scanlines()`, `shine()`, `speckle()`, `starburst()`, `tint()`, `uvTranslate()`, `vignette()`, `wave()`, `waves()`, `whiteNoise()`, `xyTranslate()`, `zigzag()`.
+
 ## 3D content
 
 See [rules/3d.md](rules/3d.md) for 3D content in Remotion using Three.js and React Three Fiber.

--- a/packages/skills/skills/remotion/SKILL.md
+++ b/packages/skills/skills/remotion/SKILL.md
@@ -232,9 +232,15 @@ When needing to visualize audio (spectrum bars, waveforms, bass-reactive effects
 
 When needing to use sound effects, load the [./rules/sfx.md](./rules/sfx.md) file for more information.
 
-## Visual effects
+## Visual and pixel effects
 
-When needing a canvas/WebGL visual effect, only use a listed effect if it matches the requested look. Load [rules/effects.md](rules/effects.md) before using one. Docs: https://www.remotion.dev/docs/effects
+When creating a visual effect, choose the simplest fitting approach:
+
+1. If the look can be achieved with normal Remotion components, HTML, CSS, SVG, masks, filters, blending, or animation, use that first.
+2. If pixel manipulation is useful and a listed effect matches the requested look, load [rules/effects.md](rules/effects.md). Existing effects can also be applied to HTML rendered through `<HtmlInCanvas>`.
+3. If no existing effect fits and custom pixel manipulation is needed, load [rules/html-in-canvas.md](rules/html-in-canvas.md) and use `<HtmlInCanvas>` with a custom `onPaint` handler.
+
+For light leak overlays, see [rules/light-leaks.md](rules/light-leaks.md). Docs: https://www.remotion.dev/docs/effects
 
 Available effects: `barrelDistortion()`, `blur()`, `brightness()`, `chromaticAberration()`, `colorKey()`, `contrast()`, `dotGrid()`, `dropShadow()`, `duotone()`, `evolve()`, `fisheye()`, `glow()`, `grayscale()`, `halftone()`, `halftoneLinearGradient()`, `hue()`, `invert()`, `lightLeak()`, `linearProgressiveBlur()`, `lines()`, `mirror()`, `noise()`, `pixelDissolve()`, `rings()`, `saturation()`, `scale()`, `scanlines()`, `shine()`, `speckle()`, `starburst()`, `tint()`, `uvTranslate()`, `vignette()`, `wave()`, `waves()`, `whiteNoise()`, `xyTranslate()`, `zigzag()`.
 
@@ -282,17 +288,9 @@ See [rules/gifs.md](rules/gifs.md) for how to display GIFs synchronized with Rem
 
 See [rules/images.md](rules/images.md) for sizing and positioning images, dynamic image paths, and getting image dimensions.
 
-## Light leaks
-
-See [rules/light-leaks.md](rules/light-leaks.md) for light leak overlay effects using `@remotion/light-leaks`.
-
 ## Lottie animations
 
 See [rules/lottie.md](rules/lottie.md) for embedding Lottie animations in Remotion.
-
-## HTML in canvas
-
-See [rules/html-in-canvas.md](rules/html-in-canvas.md) if you need to render HTML into a `<canvas>` to apply 2D or WebGL effects via `<HtmlInCanvas>`.
 
 ## Measuring DOM nodes
 

--- a/packages/skills/skills/remotion/rules/effects.md
+++ b/packages/skills/skills/remotion/rules/effects.md
@@ -1,0 +1,98 @@
+---
+name: effects
+description: Canvas/WebGL visual effects for Remotion using effects arrays.
+metadata:
+  tags: effects, visual-effects, webgl, canvas, video
+---
+
+Use this rule only when the user asks for a visual effect that matches one of the available effects below. If no effect fits, do not force `@remotion/effects`; use normal Remotion animation, composition, canvas, or WebGL patterns instead.
+
+Docs: https://www.remotion.dev/docs/effects
+
+## Usage
+
+Install the package that provides the chosen effect:
+
+```bash
+npx remotion add @remotion/effects
+```
+
+Use `npx remotion add @remotion/light-leaks` for `lightLeak()` and `npx remotion add @remotion/starburst` for `starburst()`.
+
+Effects are functions passed to the `effects` prop of canvas-based components such as `<Video>` from `@remotion/media`, `<Solid>`, `<CanvasImage>`, and `<HtmlInCanvas>`.
+
+```tsx
+import {Video} from '@remotion/media';
+import {blur} from '@remotion/effects/blur';
+
+<Video src="https://remotion.media/video.mp4" effects={[blur({radius: 8})]} />;
+```
+
+Use subpath imports. Do not import effects from the package root unless that effect's documentation says to.
+
+These effects use WebGL2. During renders, enable WebGL with:
+
+```ts
+import {Config} from '@remotion/cli/config';
+
+Config.setChromiumOpenGlRenderer('angle');
+```
+
+## Available effects
+
+Color: `brightness()`, `contrast()`, `colorKey()`, `duotone()`, `grayscale()`, `hue()`, `invert()`, `saturation()`, `tint()`.
+
+Blur & shadow: `blur()`, `linearProgressiveBlur()`, `dropShadow()`, `glow()`.
+
+Reveal: `evolve()`.
+
+Transform: `mirror()`, `scale()`, `uvTranslate()`, `xyTranslate()`.
+
+Distort: `barrelDistortion()`, `chromaticAberration()`, `fisheye()`, `wave()`.
+
+Stylize: `dotGrid()`, `halftone()`, `noise()`, `pixelDissolve()`, `scanlines()`, `speckle()`, `shine()`, `vignette()`.
+
+Generate: `halftoneLinearGradient()`, `whiteNoise()`, `lines()`, `rings()`, `waves()`, `zigzag()`, `lightLeak()`, `starburst()`.
+
+## Imports
+
+- `barrelDistortion` from `@remotion/effects/barrel-distortion`
+- `blur` from `@remotion/effects/blur`
+- `brightness` from `@remotion/effects/brightness`
+- `chromaticAberration` from `@remotion/effects/chromatic-aberration`
+- `colorKey` from `@remotion/effects/color-key`
+- `contrast` from `@remotion/effects/contrast`
+- `dotGrid` from `@remotion/effects/dot-grid`
+- `dropShadow` from `@remotion/effects/drop-shadow`
+- `duotone` from `@remotion/effects/duotone`
+- `evolve` from `@remotion/effects/evolve`
+- `fisheye` from `@remotion/effects/fisheye`
+- `glow` from `@remotion/effects/glow`
+- `grayscale` from `@remotion/effects/grayscale`
+- `halftone` from `@remotion/effects/halftone`
+- `halftoneLinearGradient` from `@remotion/effects/halftone-linear-gradient`
+- `hue` from `@remotion/effects/hue`
+- `invert` from `@remotion/effects/invert`
+- `lightLeak` from `@remotion/light-leaks`
+- `linearProgressiveBlur` from `@remotion/effects/linear-progressive-blur`
+- `lines` from `@remotion/effects/lines`
+- `mirror` from `@remotion/effects/mirror`
+- `noise` from `@remotion/effects/noise`
+- `pixelDissolve` from `@remotion/effects/pixel-dissolve`
+- `rings` from `@remotion/effects/rings`
+- `saturation` from `@remotion/effects/saturation`
+- `scale` from `@remotion/effects/scale`
+- `scanlines` from `@remotion/effects/scanlines`
+- `shine` from `@remotion/effects/shine`
+- `speckle` from `@remotion/effects/speckle`
+- `starburst` from `@remotion/starburst`
+- `tint` from `@remotion/effects/tint`
+- `uvTranslate` from `@remotion/effects/translate`
+- `vignette` from `@remotion/effects/vignette`
+- `wave` from `@remotion/effects/wave`
+- `waves` from `@remotion/effects/waves`
+- `whiteNoise` from `@remotion/effects/white-noise`
+- `xyTranslate` from `@remotion/effects/translate`
+- `zigzag` from `@remotion/effects/zigzag`
+
+For exact props and examples, open the effect page at `https://www.remotion.dev/docs/effects/[effect-slug]`. Use `/docs/light-leaks/light-leak-effect` for `lightLeak()` and `/docs/starburst/starburst-effect` for `starburst()`.

--- a/packages/skills/skills/remotion/rules/effects.md
+++ b/packages/skills/skills/remotion/rules/effects.md
@@ -9,6 +9,14 @@ Use this rule only when the user asks for a visual effect that matches one of th
 
 Docs: https://www.remotion.dev/docs/effects
 
+## Choosing an approach
+
+Prefer normal Remotion components, HTML, CSS, SVG, masks, filters, blending, and animation when they can create the requested look without pixel manipulation.
+
+If pixel manipulation is useful, use an existing effect from this list when it fits. To apply an existing effect to HTML, render the HTML through `<HtmlInCanvas>` and pass the effect in its `effects` prop.
+
+Use `<HtmlInCanvas onPaint>` with custom canvas or WebGL code as a last resort when the requested effect is too specific or complex for HTML/CSS and no existing effect matches.
+
 ## Usage
 
 Install the package that provides the chosen effect:

--- a/packages/skills/skills/remotion/rules/effects.md
+++ b/packages/skills/skills/remotion/rules/effects.md
@@ -5,17 +5,9 @@ metadata:
   tags: effects, visual-effects, webgl, canvas, video
 ---
 
-Use this rule only when the user asks for a visual effect that matches one of the available effects below. If no effect fits, do not force `@remotion/effects`; use normal Remotion animation, composition, canvas, or WebGL patterns instead.
+Use this rule only when the top-level skill lists an effect that matches the requested look.
 
 Docs: https://www.remotion.dev/docs/effects
-
-## Choosing an approach
-
-Prefer normal Remotion components, HTML, CSS, SVG, masks, filters, blending, and animation when they can create the requested look without pixel manipulation.
-
-If pixel manipulation is useful, use an existing effect from this list when it fits. To apply an existing effect to HTML, render the HTML through `<HtmlInCanvas>` and pass the effect in its `effects` prop.
-
-Use `<HtmlInCanvas onPaint>` with custom canvas or WebGL code as a last resort when the requested effect is too specific or complex for HTML/CSS and no existing effect matches.
 
 ## Usage
 
@@ -36,7 +28,7 @@ import {blur} from '@remotion/effects/blur';
 <Video src="https://remotion.media/video.mp4" effects={[blur({radius: 8})]} />;
 ```
 
-Use subpath imports. Do not import effects from the package root unless that effect's documentation says to.
+Use the effect docs for exact props and imports. Most `@remotion/effects` imports use `@remotion/effects/<effect-slug>`; `uvTranslate()` and `xyTranslate()` use `@remotion/effects/translate`; `lightLeak()` uses `@remotion/light-leaks`; `starburst()` uses `@remotion/starburst`.
 
 These effects use WebGL2. During renders, enable WebGL with:
 
@@ -45,62 +37,3 @@ import {Config} from '@remotion/cli/config';
 
 Config.setChromiumOpenGlRenderer('angle');
 ```
-
-## Available effects
-
-Color: `brightness()`, `contrast()`, `colorKey()`, `duotone()`, `grayscale()`, `hue()`, `invert()`, `saturation()`, `tint()`.
-
-Blur & shadow: `blur()`, `linearProgressiveBlur()`, `dropShadow()`, `glow()`.
-
-Reveal: `evolve()`.
-
-Transform: `mirror()`, `scale()`, `uvTranslate()`, `xyTranslate()`.
-
-Distort: `barrelDistortion()`, `chromaticAberration()`, `fisheye()`, `wave()`.
-
-Stylize: `dotGrid()`, `halftone()`, `noise()`, `pixelDissolve()`, `scanlines()`, `speckle()`, `shine()`, `vignette()`.
-
-Generate: `halftoneLinearGradient()`, `whiteNoise()`, `lines()`, `rings()`, `waves()`, `zigzag()`, `lightLeak()`, `starburst()`.
-
-## Imports
-
-- `barrelDistortion` from `@remotion/effects/barrel-distortion`
-- `blur` from `@remotion/effects/blur`
-- `brightness` from `@remotion/effects/brightness`
-- `chromaticAberration` from `@remotion/effects/chromatic-aberration`
-- `colorKey` from `@remotion/effects/color-key`
-- `contrast` from `@remotion/effects/contrast`
-- `dotGrid` from `@remotion/effects/dot-grid`
-- `dropShadow` from `@remotion/effects/drop-shadow`
-- `duotone` from `@remotion/effects/duotone`
-- `evolve` from `@remotion/effects/evolve`
-- `fisheye` from `@remotion/effects/fisheye`
-- `glow` from `@remotion/effects/glow`
-- `grayscale` from `@remotion/effects/grayscale`
-- `halftone` from `@remotion/effects/halftone`
-- `halftoneLinearGradient` from `@remotion/effects/halftone-linear-gradient`
-- `hue` from `@remotion/effects/hue`
-- `invert` from `@remotion/effects/invert`
-- `lightLeak` from `@remotion/light-leaks`
-- `linearProgressiveBlur` from `@remotion/effects/linear-progressive-blur`
-- `lines` from `@remotion/effects/lines`
-- `mirror` from `@remotion/effects/mirror`
-- `noise` from `@remotion/effects/noise`
-- `pixelDissolve` from `@remotion/effects/pixel-dissolve`
-- `rings` from `@remotion/effects/rings`
-- `saturation` from `@remotion/effects/saturation`
-- `scale` from `@remotion/effects/scale`
-- `scanlines` from `@remotion/effects/scanlines`
-- `shine` from `@remotion/effects/shine`
-- `speckle` from `@remotion/effects/speckle`
-- `starburst` from `@remotion/starburst`
-- `tint` from `@remotion/effects/tint`
-- `uvTranslate` from `@remotion/effects/translate`
-- `vignette` from `@remotion/effects/vignette`
-- `wave` from `@remotion/effects/wave`
-- `waves` from `@remotion/effects/waves`
-- `whiteNoise` from `@remotion/effects/white-noise`
-- `xyTranslate` from `@remotion/effects/translate`
-- `zigzag` from `@remotion/effects/zigzag`
-
-For exact props and examples, open the effect page at `https://www.remotion.dev/docs/effects/[effect-slug]`. Use `/docs/light-leaks/light-leak-effect` for `lightLeak()` and `/docs/starburst/starburst-effect` for `starburst()`.


### PR DESCRIPTION
## Summary
- Add a concise Remotion effects rule for agent guidance
- Surface the available visual effects in the top-level Remotion skill
- Include import paths, package exceptions, and WebGL render guidance

## Testing
- `cd packages/skills && bunx oxfmt src --write`
- `bun run build`
- `bun run formatting`
