### PR TITLE
`@remotion/studio`: Select sequences from canvas outlines

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -969,20 +969,20 @@ const SelectedOutlinePolygon: React.FC<{
 			event.stopPropagation();
 
 			const interaction = getOutlineSelectionInteraction(event);
-			if (!selected || interaction.shiftKey || interaction.toggleKey) {
+			const shouldUpdateSelection =
+				!selected || interaction.shiftKey || interaction.toggleKey;
+			if (shouldUpdateSelection) {
 				onSelect(target.selection, interaction);
-				return;
 			}
 
-			if (drag === null) {
-				onSelect(target.selection, interaction);
+			if (drag === null || interaction.shiftKey || interaction.toggleKey) {
 				return;
 			}
 
 			const startPointerX = event.clientX;
 			const startPointerY = event.clientY;
 			const dragStates = getSelectedOutlineDragStates({
-				dragTargets: allDragTargets,
+				dragTargets: selected ? allDragTargets : [drag],
 				getDragOverrides,
 			});
 			let lastValues = new Map<string, string>();
@@ -1078,8 +1078,20 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 	readonly allScaleDragTargets: readonly SelectedOutlineScaleDragTarget[];
 	readonly edge: SelectedOutlineScaleEdge;
 	readonly outline: SelectedOutline;
+	readonly onHoverChange: (key: string | null) => void;
+	readonly onSelect: (
+		item: TimelineSelection,
+		interaction: TimelineSelectionInteraction,
+	) => void;
 	readonly target: SelectedOutlineTarget | undefined;
-}> = ({allScaleDragTargets, edge, outline, target}) => {
+}> = ({
+	allScaleDragTargets,
+	edge,
+	outline,
+	onHoverChange,
+	onSelect,
+	target,
+}) => {
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
@@ -1087,6 +1099,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 		Internals.VisualModeSettersContext,
 	);
 	const scaleDrag = target?.scaleDrag ?? null;
+	const selected = target?.selected ?? false;
 	const edgeInfo = useMemo(
 		() => getSelectedOutlineScaleEdgeInfo(outline.points, edge),
 		[edge, outline.points],
@@ -1101,9 +1114,20 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			event.preventDefault();
 			event.stopPropagation();
 
+			const interaction = getOutlineSelectionInteraction(event);
+			const shouldUpdateSelection =
+				!selected || interaction.shiftKey || interaction.toggleKey;
+			if (shouldUpdateSelection && target !== undefined) {
+				onSelect(target.selection, interaction);
+			}
+
+			if (interaction.shiftKey || interaction.toggleKey) {
+				return;
+			}
+
 			const startPointer = {x: event.clientX, y: event.clientY};
 			const dragStates = getSelectedOutlineScaleDragStates({
-				dragTargets: allScaleDragTargets,
+				dragTargets: selected ? allScaleDragTargets : [scaleDrag],
 				getDragOverrides,
 			});
 			let lastValues = new Map<string, number | string>();
@@ -1188,9 +1212,12 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			clearDragOverrides,
 			edgeInfo,
 			getDragOverrides,
+			onSelect,
 			scaleDrag,
+			selected,
 			setCodeValues,
 			setDragOverrides,
+			target,
 		],
 	);
 
@@ -1209,6 +1236,8 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			vectorEffect="non-scaling-stroke"
 			pointerEvents="stroke"
 			cursor={edgeInfo.cursor}
+			onPointerEnter={() => onHoverChange(outline.key)}
+			onPointerLeave={() => onHoverChange(null)}
 			onPointerDown={onPointerDown}
 		/>
 	);
@@ -1419,45 +1448,43 @@ export const SelectedOutlineOverlay: React.FC<{
 				ref: sequence.refForOutline,
 				selected,
 				selection: {type: 'sequence', nodePathInfo},
-				drag:
-					selected && canDrag
-						? {
-								codeValue,
-								clientId: previewServerState.clientId,
-								fieldDefault: fieldSchema.default,
+				drag: canDrag
+					? {
+							codeValue,
+							clientId: previewServerState.clientId,
+							fieldDefault: fieldSchema.default,
+							nodePath,
+							schema: controls.schema,
+						}
+					: null,
+				scaleDrag: canScaleDrag
+					? {
+							codeValue: scaleCodeValue,
+							clientId: previewServerState.clientId,
+							fieldDefault: scaleFieldSchema.default,
+							fieldSchema: scaleFieldSchema,
+							linked: getScaleLockState({
 								nodePath,
-								schema: controls.schema,
-							}
-						: null,
-				scaleDrag:
-					selected && canScaleDrag
-						? {
-								codeValue: scaleCodeValue,
-								clientId: previewServerState.clientId,
-								fieldDefault: scaleFieldSchema.default,
-								fieldSchema: scaleFieldSchema,
-								linked: getScaleLockState({
-									nodePath,
-									fieldKey: scaleFieldKey,
-									defaultValue: (() => {
-										const dragOverrideValue = (getDragOverrides(nodePath) ??
-											{})[scaleFieldKey];
-										const effectiveValue =
-											Internals.getEffectiveVisualModeValue({
-												codeValue: scaleCodeValue,
-												dragOverrideValue,
-												defaultValue: scaleFieldSchema.default,
-												shouldResortToDefaultValueIfUndefined: true,
-											});
-										const [x, y] =
-											NoReactInternals.parseScaleValue(effectiveValue);
-										return x === y;
-									})(),
-								}),
-								nodePath,
-								schema: controls.schema,
-							}
-						: null,
+								fieldKey: scaleFieldKey,
+								defaultValue: (() => {
+									const dragOverrideValue = (getDragOverrides(nodePath) ?? {})[
+										scaleFieldKey
+									];
+									const effectiveValue = Internals.getEffectiveVisualModeValue({
+										codeValue: scaleCodeValue,
+										dragOverrideValue,
+										defaultValue: scaleFieldSchema.default,
+										shouldResortToDefaultValueIfUndefined: true,
+									});
+									const [x, y] =
+										NoReactInternals.parseScaleValue(effectiveValue);
+									return x === y;
+								})(),
+							}),
+							nodePath,
+							schema: controls.schema,
+						}
+					: null,
 				uvHandles: selected
 					? getSelectedUvHandles({
 							codeValues,
@@ -1495,12 +1522,12 @@ export const SelectedOutlineOverlay: React.FC<{
 	}, [outlineTargets]);
 	const allDragTargets = useMemo(() => {
 		return outlineTargets.flatMap((target) =>
-			target.drag === null ? [] : [target.drag],
+			target.selected && target.drag !== null ? [target.drag] : [],
 		);
 	}, [outlineTargets]);
 	const allScaleDragTargets = useMemo(() => {
 		return outlineTargets.flatMap((target) =>
-			target.scaleDrag === null ? [] : [target.scaleDrag],
+			target.selected && target.scaleDrag !== null ? [target.scaleDrag] : [],
 		);
 	}, [outlineTargets]);
 
@@ -1562,13 +1589,16 @@ export const SelectedOutlineOverlay: React.FC<{
 						scale={scale}
 						target={targetsByKey.get(outline.key)}
 					/>
-					{targetsByKey.get(outline.key)?.selected
+					{targetsByKey.get(outline.key)?.selected ||
+					hoveredOutlineKey === outline.key
 						? (['top', 'right', 'bottom', 'left'] as const).map((edge) => (
 								<SelectedOutlineScaleEdgeLine
 									key={edge}
 									allScaleDragTargets={allScaleDragTargets}
 									edge={edge}
 									outline={outline}
+									onHoverChange={setHoveredOutlineKey}
+									onSelect={selectItem}
 									target={targetsByKey.get(outline.key)}
 								/>
 							))

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -30,6 +30,7 @@ import {
 	ENABLE_OUTLINES,
 	getTimelineSequenceSelectionKey,
 	type TimelineSelection,
+	type TimelineSelectionInteraction,
 	useTimelineSelection,
 } from './Timeline/TimelineSelection';
 
@@ -69,7 +70,10 @@ type SelectedOutlineUvHandle = {
 
 type SelectedOutlineTarget = {
 	readonly key: string;
+	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly ref: React.RefObject<HTMLElement | null>;
+	readonly selected: boolean;
+	readonly selection: TimelineSelection;
 	readonly drag: SelectedOutlineDragTarget | null;
 	readonly scaleDrag: SelectedOutlineScaleDragTarget | null;
 	readonly uvHandles: readonly SelectedOutlineUvHandle[];
@@ -113,6 +117,7 @@ export type SelectedOutlineScaleDragState = {
 };
 
 type SequenceWithSelectedOutline = {
+	readonly depth: number;
 	readonly key: string;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly sequence: TSequence;
@@ -423,6 +428,19 @@ const getSelectedSequenceKeys = (
 	);
 };
 
+export const getOutlineSelectionInteraction = ({
+	shiftKey,
+	metaKey,
+	ctrlKey,
+}: {
+	readonly shiftKey: boolean;
+	readonly metaKey: boolean;
+	readonly ctrlKey: boolean;
+}): TimelineSelectionInteraction => ({
+	shiftKey,
+	toggleKey: metaKey || ctrlKey,
+});
+
 type SelectedEffectFields = {
 	allFields: boolean;
 	fieldKeys: Set<string>;
@@ -459,21 +477,13 @@ export const getSelectedEffectFieldsBySequenceKey = (
 	return selectedEffects;
 };
 
-const getSequencesWithSelectedOutlines = ({
-	selectedItems,
+export const getSequencesWithSelectableOutlines = ({
 	sequences,
 	overrideIdsToNodePaths,
 }: {
-	readonly selectedItems: readonly TimelineSelection[];
 	readonly sequences: readonly TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
 }): SequenceWithSelectedOutline[] => {
-	const selectedSequenceKeys = getSelectedSequenceKeys(selectedItems);
-
-	if (selectedSequenceKeys.size === 0) {
-		return [];
-	}
-
 	return calculateTimeline({
 		sequences: [...sequences],
 		overrideIdsToNodePaths,
@@ -483,17 +493,17 @@ const getSequencesWithSelectedOutlines = ({
 				return false;
 			}
 
-			return selectedSequenceKeys.has(
-				getTimelineSequenceSelectionKey(track.nodePathInfo),
-			);
+			return track.nodePathInfo.auxiliaryKeys.length === 0;
 		})
 		.filter((track) => track.sequence.refForOutline !== null)
+		.sort((a, b) => a.depth - b.depth)
 		.map((track) => {
 			if (track.nodePathInfo === null) {
 				throw new Error('Expected selected outline to have a node path');
 			}
 
 			return {
+				depth: track.depth,
 				key: getTimelineSequenceSelectionKey(track.nodePathInfo),
 				nodePathInfo: track.nodePathInfo,
 				sequence: track.sequence,
@@ -917,10 +927,24 @@ const clearSelectedOutlineScaleDragOverrides = ({
 
 const SelectedOutlinePolygon: React.FC<{
 	readonly allDragTargets: readonly SelectedOutlineDragTarget[];
+	readonly hovered: boolean;
 	readonly outline: SelectedOutline;
+	readonly onHoverChange: (key: string | null) => void;
+	readonly onSelect: (
+		item: TimelineSelection,
+		interaction: TimelineSelectionInteraction,
+	) => void;
 	readonly scale: number;
 	readonly target: SelectedOutlineTarget | undefined;
-}> = ({allDragTargets, outline, scale, target}) => {
+}> = ({
+	allDragTargets,
+	hovered,
+	outline,
+	onHoverChange,
+	onSelect,
+	scale,
+	target,
+}) => {
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
@@ -932,15 +956,28 @@ const SelectedOutlinePolygon: React.FC<{
 		[outline.points],
 	);
 	const drag = target?.drag ?? null;
+	const selected = target?.selected ?? false;
+	const visible = selected || hovered;
 
 	const onPointerDown = React.useCallback(
 		(event: React.PointerEvent<SVGPolygonElement>) => {
-			if (event.button !== 0 || drag === null) {
+			if (event.button !== 0 || target === undefined) {
 				return;
 			}
 
 			event.preventDefault();
 			event.stopPropagation();
+
+			const interaction = getOutlineSelectionInteraction(event);
+			if (!selected || interaction.shiftKey || interaction.toggleKey) {
+				onSelect(target.selection, interaction);
+				return;
+			}
+
+			if (drag === null) {
+				onSelect(target.selection, interaction);
+				return;
+			}
 
 			const startPointerX = event.clientX;
 			const startPointerY = event.clientY;
@@ -1012,21 +1049,34 @@ const SelectedOutlinePolygon: React.FC<{
 			clearDragOverrides,
 			drag,
 			getDragOverrides,
+			onSelect,
 			scale,
+			selected,
 			setCodeValues,
 			setDragOverrides,
+			target,
 		],
 	);
 
 	return (
 		<polygon
 			points={points}
-			fill={drag === null ? 'none' : 'transparent'}
+			fill="transparent"
 			stroke={BLUE}
+			strokeOpacity={visible ? 1 : 0}
 			strokeWidth={2}
 			vectorEffect="non-scaling-stroke"
-			pointerEvents={drag === null ? undefined : 'all'}
-			onPointerDown={drag === null ? undefined : onPointerDown}
+			pointerEvents={target === undefined ? undefined : 'all'}
+			cursor={
+				target === undefined
+					? undefined
+					: selected && drag !== null
+						? 'move'
+						: 'pointer'
+			}
+			onPointerEnter={() => onHoverChange(outline.key)}
+			onPointerLeave={() => onHoverChange(null)}
+			onPointerDown={onPointerDown}
 		/>
 	);
 };
@@ -1310,7 +1360,7 @@ const SelectedUvHandleCircle: React.FC<{
 export const SelectedOutlineOverlay: React.FC<{
 	readonly scale: number;
 }> = ({scale}) => {
-	const {selectedItems} = useTimelineSelection();
+	const {selectedItems, selectItem} = useTimelineSelection();
 	const {sequences} = useContext(Internals.SequenceManager);
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
@@ -1322,13 +1372,17 @@ export const SelectedOutlineOverlay: React.FC<{
 	);
 	const {getScaleLockState} = useContext(ScaleLockContext);
 	const [outlines, setOutlines] = useState<readonly SelectedOutline[]>([]);
+	const [hoveredOutlineKey, setHoveredOutlineKey] = useState<string | null>(
+		null,
+	);
 	const overlayRef = useRef<SVGSVGElement>(null);
 
-	const selectedOutlineTargets = useMemo((): SelectedOutlineTarget[] => {
+	const outlineTargets = useMemo((): SelectedOutlineTarget[] => {
 		if (!ENABLE_OUTLINES) {
 			return [];
 		}
 
+		const selectedSequenceKeys = getSelectedSequenceKeys(selectedItems);
 		const selectedEffectsBySequenceKey =
 			getSelectedEffectFieldsBySequenceKey(selectedItems);
 		const clientId =
@@ -1336,8 +1390,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				? previewServerState.clientId
 				: null;
 
-		return getSequencesWithSelectedOutlines({
-			selectedItems,
+		return getSequencesWithSelectableOutlines({
 			sequences,
 			overrideIdsToNodePaths: overrideIdToNodePathMappings,
 		}).map(({key, nodePathInfo, sequence}) => {
@@ -1345,6 +1398,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				throw new Error('Expected sequence to have a ref for outline');
 			}
 
+			const selected = selectedSequenceKeys.has(key);
 			const nodePath = nodePathInfo.sequenceSubscriptionKey;
 			const {controls} = sequence;
 			const fieldSchema = controls?.schema[translateFieldKey];
@@ -1368,52 +1422,59 @@ export const SelectedOutlineOverlay: React.FC<{
 
 			return {
 				key,
+				nodePathInfo,
 				ref: sequence.refForOutline,
-				drag: canDrag
-					? {
-							codeValue,
-							clientId: previewServerState.clientId,
-							fieldDefault: fieldSchema.default,
-							nodePath,
-							schema: controls.schema,
-						}
-					: null,
-				scaleDrag: canScaleDrag
-					? {
-							codeValue: scaleCodeValue,
-							clientId: previewServerState.clientId,
-							fieldDefault: scaleFieldSchema.default,
-							fieldSchema: scaleFieldSchema,
-							linked: getScaleLockState({
+				selected,
+				selection: {type: 'sequence', nodePathInfo},
+				drag:
+					selected && canDrag
+						? {
+								codeValue,
+								clientId: previewServerState.clientId,
+								fieldDefault: fieldSchema.default,
 								nodePath,
-								fieldKey: scaleFieldKey,
-								defaultValue: (() => {
-									const dragOverrideValue = (getDragOverrides(nodePath) ?? {})[
-										scaleFieldKey
-									];
-									const effectiveValue = Internals.getEffectiveVisualModeValue({
-										codeValue: scaleCodeValue,
-										dragOverrideValue,
-										defaultValue: scaleFieldSchema.default,
-										shouldResortToDefaultValueIfUndefined: true,
-									});
-									const [x, y] =
-										NoReactInternals.parseScaleValue(effectiveValue);
-									return x === y;
-								})(),
-							}),
+								schema: controls.schema,
+							}
+						: null,
+				scaleDrag:
+					selected && canScaleDrag
+						? {
+								codeValue: scaleCodeValue,
+								clientId: previewServerState.clientId,
+								fieldDefault: scaleFieldSchema.default,
+								fieldSchema: scaleFieldSchema,
+								linked: getScaleLockState({
+									nodePath,
+									fieldKey: scaleFieldKey,
+									defaultValue: (() => {
+										const dragOverrideValue = (getDragOverrides(nodePath) ??
+											{})[scaleFieldKey];
+										const effectiveValue =
+											Internals.getEffectiveVisualModeValue({
+												codeValue: scaleCodeValue,
+												dragOverrideValue,
+												defaultValue: scaleFieldSchema.default,
+												shouldResortToDefaultValueIfUndefined: true,
+											});
+										const [x, y] =
+											NoReactInternals.parseScaleValue(effectiveValue);
+										return x === y;
+									})(),
+								}),
+								nodePath,
+								schema: controls.schema,
+							}
+						: null,
+				uvHandles: selected
+					? getSelectedUvHandles({
+							codeValues,
+							clientId,
+							getEffectDragOverrides,
 							nodePath,
-							schema: controls.schema,
-						}
-					: null,
-				uvHandles: getSelectedUvHandles({
-					codeValues,
-					clientId,
-					getEffectDragOverrides,
-					nodePath,
-					selectedEffects: selectedEffectsBySequenceKey.get(key),
-					sequence,
-				}),
+							selectedEffects: selectedEffectsBySequenceKey.get(key),
+							sequence,
+						})
+					: [],
 			};
 		});
 	}, [
@@ -1427,24 +1488,31 @@ export const SelectedOutlineOverlay: React.FC<{
 		sequences,
 	]);
 
+	useEffect(() => {
+		if (
+			hoveredOutlineKey !== null &&
+			!outlineTargets.some((target) => target.key === hoveredOutlineKey)
+		) {
+			setHoveredOutlineKey(null);
+		}
+	}, [hoveredOutlineKey, outlineTargets]);
+
 	const targetsByKey = useMemo(() => {
-		return new Map(
-			selectedOutlineTargets.map((target) => [target.key, target]),
-		);
-	}, [selectedOutlineTargets]);
+		return new Map(outlineTargets.map((target) => [target.key, target]));
+	}, [outlineTargets]);
 	const allDragTargets = useMemo(() => {
-		return selectedOutlineTargets.flatMap((target) =>
+		return outlineTargets.flatMap((target) =>
 			target.drag === null ? [] : [target.drag],
 		);
-	}, [selectedOutlineTargets]);
+	}, [outlineTargets]);
 	const allScaleDragTargets = useMemo(() => {
-		return selectedOutlineTargets.flatMap((target) =>
+		return outlineTargets.flatMap((target) =>
 			target.scaleDrag === null ? [] : [target.scaleDrag],
 		);
-	}, [selectedOutlineTargets]);
+	}, [outlineTargets]);
 
 	useEffect(() => {
-		if (selectedOutlineTargets.length === 0) {
+		if (outlineTargets.length === 0) {
 			setOutlines((prevOutlines) =>
 				prevOutlines.length === 0 ? prevOutlines : [],
 			);
@@ -1457,7 +1525,7 @@ export const SelectedOutlineOverlay: React.FC<{
 			if (overlayRef.current) {
 				const nextOutlines = measureOutlines(
 					overlayRef.current,
-					selectedOutlineTargets,
+					outlineTargets,
 				);
 				setOutlines((prevOutlines) =>
 					outlinesAreEqual(prevOutlines, nextOutlines)
@@ -1476,9 +1544,9 @@ export const SelectedOutlineOverlay: React.FC<{
 				cancelAnimationFrame(animationFrame);
 			}
 		};
-	}, [selectedOutlineTargets]);
+	}, [outlineTargets]);
 
-	if (selectedOutlineTargets.length === 0) {
+	if (outlineTargets.length === 0) {
 		return null;
 	}
 
@@ -1494,26 +1562,35 @@ export const SelectedOutlineOverlay: React.FC<{
 				<React.Fragment key={outline.key}>
 					<SelectedOutlinePolygon
 						allDragTargets={allDragTargets}
+						hovered={hoveredOutlineKey === outline.key}
 						outline={outline}
+						onHoverChange={setHoveredOutlineKey}
+						onSelect={selectItem}
 						scale={scale}
 						target={targetsByKey.get(outline.key)}
 					/>
-					{(['top', 'right', 'bottom', 'left'] as const).map((edge) => (
-						<SelectedOutlineScaleEdgeLine
-							key={edge}
-							allScaleDragTargets={allScaleDragTargets}
-							edge={edge}
-							outline={outline}
-							target={targetsByKey.get(outline.key)}
-						/>
-					))}
-					{targetsByKey.get(outline.key)?.uvHandles.map((handle) => (
-						<SelectedUvHandleCircle
-							key={`${handle.effectIndex}-${handle.fieldKey}`}
-							handle={handle}
-							outline={outline}
-						/>
-					))}
+					{targetsByKey.get(outline.key)?.selected
+						? (['top', 'right', 'bottom', 'left'] as const).map((edge) => (
+								<SelectedOutlineScaleEdgeLine
+									key={edge}
+									allScaleDragTargets={allScaleDragTargets}
+									edge={edge}
+									outline={outline}
+									target={targetsByKey.get(outline.key)}
+								/>
+							))
+						: null}
+					{targetsByKey.get(outline.key)?.selected
+						? targetsByKey
+								.get(outline.key)
+								?.uvHandles.map((handle) => (
+									<SelectedUvHandleCircle
+										key={`${handle.effectIndex}-${handle.fieldKey}`}
+										handle={handle}
+										outline={outline}
+									/>
+								))
+						: null}
 				</React.Fragment>
 			))}
 		</svg>

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1067,13 +1067,6 @@ const SelectedOutlinePolygon: React.FC<{
 			strokeWidth={2}
 			vectorEffect="non-scaling-stroke"
 			pointerEvents={target === undefined ? undefined : 'all'}
-			cursor={
-				target === undefined
-					? undefined
-					: selected && drag !== null
-						? 'move'
-						: 'pointer'
-			}
 			onPointerEnter={() => onHoverChange(outline.key)}
 			onPointerLeave={() => onHoverChange(null)}
 			onPointerDown={onPointerDown}

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -444,7 +444,7 @@ export const TimelineSelectionProvider: React.FC<{
 }> = ({children}) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const canSelect =
-		SELECTION_ENABLED &&
+		(SELECTION_ENABLED || ENABLE_OUTLINES) &&
 		previewServerState.type === 'connected' &&
 		!window.remotion_isReadOnlyStudio;
 	const [selectedItems, setSelectedItems] = useState<

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from 'bun:test';
+import type {RefObject} from 'react';
 import {
 	Internals,
 	type CodeValues,
@@ -9,6 +10,8 @@ import {
 } from 'remotion';
 import {
 	getSelectedEffectFieldsBySequenceKey,
+	getOutlineSelectionInteraction,
+	getSequencesWithSelectableOutlines,
 	getSelectedOutlineDragChanges,
 	getSelectedOutlineDragValues,
 	getSelectedOutlineScaleDragChanges,
@@ -72,6 +75,8 @@ const makeTimelineSequence = ({
 	effects = [],
 	id = 'sequence',
 	overrideId = 'override',
+	parent = null,
+	refForOutline = null,
 	duration = 100,
 	from = 0,
 	type = 'sequence',
@@ -80,6 +85,8 @@ const makeTimelineSequence = ({
 	readonly effects?: readonly {readonly schema: SequenceSchema}[];
 	readonly id?: string;
 	readonly overrideId?: string;
+	readonly parent?: string | null;
+	readonly refForOutline?: RefObject<HTMLElement | null> | null;
 	readonly duration?: number;
 	readonly from?: number;
 	readonly type?: TSequence['type'];
@@ -91,7 +98,7 @@ const makeTimelineSequence = ({
 		id,
 		displayName: id,
 		documentationLink: null,
-		parent: null,
+		parent,
 		rootId: 'root',
 		showInTimeline: true,
 		nonce: [[0, 0]],
@@ -105,7 +112,7 @@ const makeTimelineSequence = ({
 			overrideId,
 			supportsEffects: true,
 		},
-		refForOutline: null,
+		refForOutline,
 		isInsideSeries: false,
 		effects,
 	}) as TSequence;
@@ -473,6 +480,63 @@ test('Timeline duration drag ignores selection if dragged sequence is not select
 
 test('Timeline outlines should not be enabled', () => {
 	expect(ENABLE_OUTLINES).toBe(false);
+});
+
+test('Canvas outline selection uses conventional modifier keys', () => {
+	expect(
+		getOutlineSelectionInteraction({
+			shiftKey: true,
+			metaKey: false,
+			ctrlKey: false,
+		}),
+	).toEqual({shiftKey: true, toggleKey: false});
+	expect(
+		getOutlineSelectionInteraction({
+			shiftKey: false,
+			metaKey: true,
+			ctrlKey: false,
+		}),
+	).toEqual({shiftKey: false, toggleKey: true});
+	expect(
+		getOutlineSelectionInteraction({
+			shiftKey: false,
+			metaKey: false,
+			ctrlKey: true,
+		}),
+	).toEqual({shiftKey: false, toggleKey: true});
+});
+
+test('Canvas outline hit targets render nested sequences above parents', () => {
+	const schema = {} satisfies SequenceSchema;
+	const refForOutline = {current: null};
+	const parentNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const childNodePathInfo = makeNodePathInfo(['body', 0, 'children', 0], []);
+	const outlines = getSequencesWithSelectableOutlines({
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				id: 'parent',
+				overrideId: 'parent',
+				refForOutline,
+			}),
+			makeTimelineSequence({
+				schema,
+				id: 'child',
+				overrideId: 'child',
+				parent: 'parent',
+				refForOutline,
+			}),
+		],
+		overrideIdsToNodePaths: {
+			parent: parentNodePathInfo.sequenceSubscriptionKey,
+			child: childNodePathInfo.sequenceSubscriptionKey,
+		},
+	});
+
+	expect(outlines.map((outline) => outline.key)).toEqual([
+		getTimelineSequenceSelectionKey(parentNodePathInfo),
+		getTimelineSequenceSelectionKey(childNodePathInfo),
+	]);
 });
 
 test('UV handles project semantic outline corners', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -75,7 +75,7 @@ const makeTimelineSequence = ({
 	effects = [],
 	id = 'sequence',
 	overrideId = 'override',
-	parent = null,
+	parentId = null,
 	refForOutline = null,
 	duration = 100,
 	from = 0,
@@ -85,7 +85,7 @@ const makeTimelineSequence = ({
 	readonly effects?: readonly {readonly schema: SequenceSchema}[];
 	readonly id?: string;
 	readonly overrideId?: string;
-	readonly parent?: string | null;
+	readonly parentId?: string | null;
 	readonly refForOutline?: RefObject<HTMLElement | null> | null;
 	readonly duration?: number;
 	readonly from?: number;
@@ -98,7 +98,7 @@ const makeTimelineSequence = ({
 		id,
 		displayName: id,
 		documentationLink: null,
-		parent,
+		parent: parentId,
 		rootId: 'root',
 		showInTimeline: true,
 		nonce: [[0, 0]],
@@ -523,7 +523,7 @@ test('Canvas outline hit targets render nested sequences above parents', () => {
 				schema,
 				id: 'child',
 				overrideId: 'child',
-				parent: 'parent',
+				parentId: 'parent',
 				refForOutline,
 			}),
 		],


### PR DESCRIPTION
## Summary
- Gate canvas outline selection behavior behind `ENABLE_OUTLINES`
- Render invisible hit targets for all selectable canvas outlines, reveal them on hover, and select on click
- Support Cmd/Ctrl-click and Shift-click selection semantics from the canvas

Fixes #7995

## Checks
- `cd packages/studio && bunx oxfmt src --write && bun test src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run formatting`
