### PR TITLE
`@remotion/studio`: Prevent enum fields from being keyframed

### DIFF
--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -189,6 +189,25 @@ test('updateSequenceKeyframes rejects non-keyframable fields', async () => {
 	).rejects.toThrow(/not keyframable/);
 });
 
+test('updateSequenceKeyframes rejects enum fields', async () => {
+	await expect(
+		updateSequenceKeyframes({
+			input: sequenceInput,
+			nodePath: lineColumnToNodePath(
+				sequenceInput,
+				getLine(sequenceInput, '<AbsoluteFill>'),
+			),
+			schema: NoReactInternals.sequenceSchema,
+			updates: [
+				{
+					key: 'layout',
+					operation: {type: 'add', frame: 25, value: 'none'},
+				},
+			],
+		}),
+	).rejects.toThrow(/not keyframable/);
+});
+
 test('updateSequenceKeyframes converts a static value to a single-keyframe interpolation at frame 0', async () => {
 	const {output, oldValueStrings} = await updateSequenceKeyframes({
 		input: sequenceInput,

--- a/packages/studio-shared/src/keyframe-interpolation-function.ts
+++ b/packages/studio-shared/src/keyframe-interpolation-function.ts
@@ -48,7 +48,7 @@ export const isSchemaFieldKeyframable = ({
 	key: string;
 }): boolean => {
 	const field = schema ? findFieldInSchema(schema, key) : undefined;
-	return field?.keyframable !== false;
+	return field?.type !== 'enum' && field?.keyframable !== false;
 };
 
 export const getKeyframeInterpolationFunctionForSchemaField = ({

--- a/packages/studio-shared/src/test/keyframe-interpolation-function.test.ts
+++ b/packages/studio-shared/src/test/keyframe-interpolation-function.test.ts
@@ -1,0 +1,53 @@
+import {expect, test} from 'bun:test';
+import type {SequenceSchema} from 'remotion';
+import {isSchemaFieldKeyframable} from '../keyframe-interpolation-function';
+
+test('isSchemaFieldKeyframable rejects enum fields', () => {
+	const schema = {
+		layout: {
+			type: 'enum',
+			default: 'absolute-fill',
+			keyframable: true,
+			variants: {
+				'absolute-fill': {},
+				none: {},
+			},
+		},
+	} satisfies SequenceSchema;
+
+	expect(isSchemaFieldKeyframable({schema, key: 'layout'})).toBe(false);
+});
+
+test('isSchemaFieldKeyframable rejects explicitly disabled fields', () => {
+	const schema = {
+		playbackRate: {
+			type: 'number',
+			default: 1,
+			hiddenFromList: false,
+			keyframable: false,
+		},
+	} satisfies SequenceSchema;
+
+	expect(isSchemaFieldKeyframable({schema, key: 'playbackRate'})).toBe(false);
+});
+
+test('isSchemaFieldKeyframable finds keyframable fields in enum variants', () => {
+	const schema = {
+		layout: {
+			type: 'enum',
+			default: 'absolute-fill',
+			variants: {
+				'absolute-fill': {
+					'style.opacity': {
+						type: 'number',
+						default: 1,
+						hiddenFromList: false,
+					},
+				},
+				none: {},
+			},
+		},
+	} satisfies SequenceSchema;
+
+	expect(isSchemaFieldKeyframable({schema, key: 'style.opacity'})).toBe(true);
+});

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -149,6 +149,39 @@ test('optimisticAddSequenceKeyframe ignores non-keyframable fields', () => {
 	expect(updated).toEqual(previous);
 });
 
+test('optimisticAddSequenceKeyframe ignores enum fields', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			layout: {
+				status: 'static',
+				codeValue: 'absolute-fill',
+			},
+		},
+		effects: [],
+	};
+	const schema = {
+		layout: {
+			type: 'enum',
+			default: 'absolute-fill',
+			variants: {
+				'absolute-fill': {},
+				none: {},
+			},
+		},
+	} satisfies SequenceSchema;
+
+	const updated = optimisticAddSequenceKeyframe({
+		previous,
+		fieldKey: 'layout',
+		frame: 25,
+		value: 'none',
+		schema,
+	});
+
+	expect(updated).toEqual(previous);
+});
+
 test('optimisticAddSequenceKeyframe appends a keyframe to an existing interpolation', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -1,4 +1,7 @@
-import {optimisticUpdateForEffectCodeValues} from '@remotion/studio-shared';
+import {
+	isSchemaFieldKeyframable,
+	optimisticUpdateForEffectCodeValues,
+} from '@remotion/studio-shared';
 import React, {useCallback, useContext, useMemo} from 'react';
 import type {
 	CanUpdateSequencePropStatus,
@@ -328,7 +331,10 @@ export const TimelineEffectPropItem: React.FC<{
 		shouldShowTimelineKeyframeControls({
 			propStatus,
 			selected: selection.selected,
-			keyframable: field.fieldSchema.keyframable !== false,
+			keyframable: isSchemaFieldKeyframable({
+				schema: field.effectSchema,
+				key: field.key,
+			}),
 		}) ? (
 			<TimelineKeyframeControls
 				fieldKey={field.key}

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -1,3 +1,4 @@
+import {isSchemaFieldKeyframable} from '@remotion/studio-shared';
 import React, {useCallback, useContext, useMemo} from 'react';
 import type {
 	CanUpdateSequencePropStatus,
@@ -195,8 +196,10 @@ export const TimelineKeyframeControls: React.FC<{
 		[keyframes, timelinePosition],
 	);
 
-	const fieldSchema = schema[fieldKey];
-	const keyframable = fieldSchema?.keyframable !== false;
+	const keyframable = isSchemaFieldKeyframable({
+		schema,
+		key: fieldKey,
+	});
 	const canAddKeyframe = keyframable;
 	const canToggleKeyframe =
 		propStatus.status !== 'computed' &&

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -1,3 +1,4 @@
+import {isSchemaFieldKeyframable} from '@remotion/studio-shared';
 import React, {useCallback, useContext, useMemo} from 'react';
 import type {
 	CanUpdateSequencePropStatus,
@@ -203,7 +204,10 @@ export const TimelineSequencePropItem: React.FC<{
 		shouldShowTimelineKeyframeControls({
 			propStatus: codeValue,
 			selected: selection.selected,
-			keyframable: field.fieldSchema.keyframable !== false,
+			keyframable: isSchemaFieldKeyframable({
+				schema,
+				key: field.key,
+			}),
 		}) ? (
 			<TimelineKeyframeControls
 				fieldKey={field.key}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Fixes #8076.

## Summary
- Treat `type: 'enum'` schema fields as not keyframable in the shared keyframe helper.
- Reuse the shared helper in Studio timeline keyframe controls for sequence and effect fields.
- Add regression tests for enum keyframe rejection in shared optimistic updates and server codemods.

## Testing
- `bun test packages/studio-shared/src/test/keyframe-interpolation-function.test.ts packages/studio-shared/src/test/optimistic-add-keyframe.test.ts`
- `bunx turbo run make --filter='@remotion/studio-shared' --filter='@remotion/studio-server' --filter='@remotion/studio'`
- `bun test packages/studio-server/src/test/update-keyframes.test.ts`
- `bun run build`
- `bun run formatting`
- `bunx turbo run lint formatting --filter='@remotion/studio-shared' --filter='@remotion/studio' --filter='@remotion/studio-server' --no-update-notifier`
- `bun run stylecheck` fails only at `@remotion/lambda-go#lint` because the VM has Go 1.22.2 and that package requires Go >= 1.23.0.

## Walkthrough
![Expanded Studio keyframe rows showing Layout without keyframe controls](https://cursor.com/artifacts/c/art-e202507d-27a1-482b-b68e-a173e28dc691)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ddc52b8-e8b7-4d49-88c5-70ecfa3e3475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ddc52b8-e8b7-4d49-88c5-70ecfa3e3475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

