### PR TITLE
`@remotion/studio`: Drag keyframes in timeline

### DIFF
--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -55,6 +55,11 @@ export type KeyframeOperation =
 	| {
 			type: 'remove';
 			frame: number;
+	  }
+	| {
+			type: 'move';
+			fromFrame: number;
+			toFrame: number;
 	  };
 
 export type SequenceKeyframeUpdate = {
@@ -397,6 +402,48 @@ const removeKeyframe = ({
 	});
 };
 
+const moveKeyframe = ({
+	expression,
+	fromFrame,
+	toFrame,
+}: {
+	expression: Expression;
+	fromFrame: number;
+	toFrame: number;
+}): ExpressionKind => {
+	if (fromFrame === toFrame) {
+		return expression as ExpressionKind;
+	}
+
+	const existing = getInterpolationExpression(expression);
+	if (!existing) {
+		throw new Error('Cannot move keyframe in non-interpolated expression');
+	}
+
+	const keyframeIndex = existing.keyframes.findIndex(
+		(keyframe) => keyframe.frame === fromFrame,
+	);
+	if (keyframeIndex === -1) {
+		throw new Error(`Cannot move keyframe at frame ${fromFrame}: not found`);
+	}
+
+	const collision = existing.keyframes.some(
+		(keyframe) => keyframe.frame === toFrame,
+	);
+	if (collision) {
+		throw new Error(`Cannot move keyframe to frame ${toFrame}: already exists`);
+	}
+
+	return createInterpolateExpression({
+		callee: existing.callee,
+		input: existing.input,
+		extraArgs: existing.extraArgs,
+		keyframes: existing.keyframes.map((keyframe, index) =>
+			index === keyframeIndex ? {...keyframe, frame: toFrame} : keyframe,
+		),
+	});
+};
+
 const applyKeyframeOperation = ({
 	expression,
 	key,
@@ -416,6 +463,17 @@ const applyKeyframeOperation = ({
 			value: operation.value,
 			schema,
 		});
+	}
+
+	if (operation.type === 'move') {
+		return {
+			expression: moveKeyframe({
+				expression,
+				fromFrame: operation.fromFrame,
+				toFrame: operation.toFrame,
+			}),
+			introduced: noIntroducedIdentifiers,
+		};
 	}
 
 	return {

--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -15,6 +15,7 @@ import {deleteStaticFileHandler} from './routes/delete-static-file';
 import {duplicateJsxNodeHandler} from './routes/duplicate-jsx-node';
 import {insertJsxElementHandler} from './routes/insert-jsx-element';
 import {handleInstallPackage} from './routes/install-dependency';
+import {moveKeyframesHandler} from './routes/move-keyframes';
 import {openInEditorHandler} from './routes/open-in-editor';
 import {handleOpenInFileExplorer} from './routes/open-in-file-explorer';
 import {pasteEffectsHandler} from './routes/paste-effects';
@@ -65,6 +66,7 @@ export const allApiRoutes: {
 	'/api/add-effect': addEffectHandler,
 	'/api/reorder-effect': reorderEffectHandler,
 	'/api/delete-keyframes': deleteKeyframesHandler,
+	'/api/move-keyframes': moveKeyframesHandler,
 	'/api/add-sequence-keyframe': addSequenceKeyframeHandler,
 	'/api/add-effect-keyframe': addEffectKeyframeHandler,
 	'/api/delete-effect': deleteEffectHandler,

--- a/packages/studio-server/src/preview-server/routes/move-keyframes.ts
+++ b/packages/studio-server/src/preview-server/routes/move-keyframes.ts
@@ -1,0 +1,370 @@
+import {readFileSync} from 'node:fs';
+import type {LogLevel} from '@remotion/renderer';
+import {RenderInternals} from '@remotion/renderer';
+import type {
+	MoveEffectKeyframe,
+	MoveKeyframesRequest,
+	MoveKeyframesResponse,
+	MoveSequenceKeyframe,
+} from '@remotion/studio-shared';
+import {
+	updateEffectKeyframes,
+	updateSequenceKeyframes,
+} from '../../codemods/update-keyframes/update-keyframes';
+import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
+import type {ApiHandler} from '../api-types';
+import {
+	printUndoHint,
+	pushTransactionToUndoStack,
+	suppressUndoStackInvalidation,
+} from '../undo-stack';
+import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
+import {logEffectUpdate} from './log-updates/log-effect-update';
+import {logUpdate} from './log-updates/log-update';
+import {withSavePropsLock} from './save-props-mutex';
+
+type ResolvedSequenceKeyframe = MoveSequenceKeyframe & {
+	index: number;
+	absolutePath: string;
+	fileRelativeToRoot: string;
+};
+
+type ResolvedEffectKeyframe = MoveEffectKeyframe & {
+	index: number;
+	absolutePath: string;
+	fileRelativeToRoot: string;
+};
+
+type FileGroup = {
+	fileRelativeToRoot: string;
+	sequenceKeyframes: ResolvedSequenceKeyframe[];
+	effectKeyframes: ResolvedEffectKeyframe[];
+};
+
+type UndoSnapshot = {
+	filePath: string;
+	oldContents: string;
+	newContents: string;
+	logLine: number;
+};
+
+type SequenceLog = {
+	fileRelativeToRoot: string;
+	line: number;
+	key: string;
+	oldValueString: string;
+	newValueString: string;
+	formatted: boolean;
+};
+
+type EffectLog = {
+	fileRelativeToRoot: string;
+	line: number;
+	effectName: string;
+	propKey: string;
+	oldValueString: string;
+	newValueString: string;
+	formatted: boolean;
+};
+
+const groupBy = <T>(items: T[], getKey: (item: T) => string): T[][] => {
+	const groups = new Map<string, T[]>();
+	for (const item of items) {
+		const key = getKey(item);
+		const group = groups.get(key) ?? [];
+		group.push(item);
+		groups.set(key, group);
+	}
+
+	return [...groups.values()];
+};
+
+const sortKeyframeMovesForApplication = <
+	T extends {key: string; fromFrame: number; toFrame: number},
+>(
+	keyframes: T[],
+): T[] => {
+	return [...keyframes].sort((a, b) => {
+		if (a.key !== b.key) {
+			return 0;
+		}
+
+		const delta = a.toFrame - a.fromFrame;
+		if (delta > 0) {
+			return b.fromFrame - a.fromFrame;
+		}
+
+		if (delta < 0) {
+			return a.fromFrame - b.fromFrame;
+		}
+
+		return 0;
+	});
+};
+
+const getBatchDescription = ({
+	totalKeyframes,
+	firstKeyframe,
+}: {
+	totalKeyframes: number;
+	firstKeyframe: {key: string; fromFrame: number; toFrame: number};
+}) => {
+	if (totalKeyframes === 1) {
+		return {
+			undoMessage: `↩️  ${firstKeyframe.key} keyframe moved back to frame ${firstKeyframe.fromFrame}`,
+			redoMessage: `↪️  ${firstKeyframe.key} keyframe moved to frame ${firstKeyframe.toFrame}`,
+		};
+	}
+
+	return {
+		undoMessage: `↩️  ${totalKeyframes} keyframes moved back`,
+		redoMessage: `↪️  ${totalKeyframes} keyframes moved`,
+	};
+};
+
+export const moveKeyframes = async ({
+	sequenceKeyframes,
+	effectKeyframes,
+	clientId,
+	remotionRoot,
+	logLevel,
+}: {
+	sequenceKeyframes: MoveSequenceKeyframe[];
+	effectKeyframes: MoveEffectKeyframe[];
+	clientId: string;
+	remotionRoot: string;
+	logLevel: LogLevel;
+}): Promise<void> => {
+	const totalKeyframes = sequenceKeyframes.length + effectKeyframes.length;
+	if (totalKeyframes === 0) {
+		throw new Error('No keyframes were specified for moving');
+	}
+
+	const fileGroups = new Map<string, FileGroup>();
+
+	for (const [index, keyframe] of sequenceKeyframes.entries()) {
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName: keyframe.fileName,
+			action: 'modify',
+		});
+		const group = fileGroups.get(absolutePath) ?? {
+			fileRelativeToRoot,
+			sequenceKeyframes: [],
+			effectKeyframes: [],
+		};
+		group.sequenceKeyframes.push({
+			...keyframe,
+			index,
+			absolutePath,
+			fileRelativeToRoot,
+		});
+		fileGroups.set(absolutePath, group);
+	}
+
+	for (const [index, keyframe] of effectKeyframes.entries()) {
+		const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+			remotionRoot,
+			fileName: keyframe.fileName,
+			action: 'modify',
+		});
+		const group = fileGroups.get(absolutePath) ?? {
+			fileRelativeToRoot,
+			sequenceKeyframes: [],
+			effectKeyframes: [],
+		};
+		group.effectKeyframes.push({
+			...keyframe,
+			index,
+			absolutePath,
+			fileRelativeToRoot,
+		});
+		fileGroups.set(absolutePath, group);
+	}
+
+	const snapshots: UndoSnapshot[] = [];
+	const sequenceLogs: SequenceLog[] = [];
+	const effectLogs: EffectLog[] = [];
+
+	for (const [absolutePath, group] of fileGroups) {
+		const fileContents = readFileSync(absolutePath, 'utf-8');
+		let output = fileContents;
+		let firstLogLine = Number.POSITIVE_INFINITY;
+
+		for (const keyframeGroup of groupBy(group.sequenceKeyframes, (keyframe) =>
+			JSON.stringify(keyframe.nodePath.nodePath),
+		)) {
+			const [firstSequenceKeyframe] = keyframeGroup;
+			if (!firstSequenceKeyframe) {
+				continue;
+			}
+
+			const sortedKeyframeGroup =
+				sortKeyframeMovesForApplication(keyframeGroup);
+			const result = await updateSequenceKeyframes({
+				input: output,
+				nodePath: firstSequenceKeyframe.nodePath.nodePath,
+				updates: sortedKeyframeGroup.map((keyframe) => ({
+					key: keyframe.key,
+					operation: {
+						type: 'move',
+						fromFrame: keyframe.fromFrame,
+						toFrame: keyframe.toFrame,
+					},
+				})),
+			});
+			output = result.output;
+			firstLogLine = Math.min(firstLogLine, result.logLine);
+
+			for (const [keyframeIndex, keyframe] of sortedKeyframeGroup.entries()) {
+				sequenceLogs.push({
+					fileRelativeToRoot: keyframe.fileRelativeToRoot,
+					line: result.logLine,
+					key: keyframe.key,
+					oldValueString: result.oldValueStrings[keyframeIndex],
+					newValueString: result.newValueStrings[keyframeIndex],
+					formatted: result.formatted,
+				});
+			}
+		}
+
+		for (const keyframeGroup of groupBy(
+			group.effectKeyframes,
+			(keyframe) =>
+				`${JSON.stringify(keyframe.sequenceNodePath.nodePath)}:${keyframe.effectIndex}`,
+		)) {
+			const [firstEffectKeyframe] = keyframeGroup;
+			if (!firstEffectKeyframe) {
+				continue;
+			}
+
+			const sortedKeyframeGroup =
+				sortKeyframeMovesForApplication(keyframeGroup);
+			const result = await updateEffectKeyframes({
+				input: output,
+				sequenceNodePath: firstEffectKeyframe.sequenceNodePath.nodePath,
+				effectIndex: firstEffectKeyframe.effectIndex,
+				updates: sortedKeyframeGroup.map((keyframe) => ({
+					key: keyframe.key,
+					operation: {
+						type: 'move',
+						fromFrame: keyframe.fromFrame,
+						toFrame: keyframe.toFrame,
+					},
+				})),
+			});
+			output = result.output;
+			firstLogLine = Math.min(firstLogLine, result.logLine);
+
+			for (const [keyframeIndex, keyframe] of sortedKeyframeGroup.entries()) {
+				effectLogs.push({
+					fileRelativeToRoot: keyframe.fileRelativeToRoot,
+					line: result.logLine,
+					effectName: result.effectCallee,
+					propKey: keyframe.key,
+					oldValueString: result.oldValueStrings[keyframeIndex],
+					newValueString: result.newValueStrings[keyframeIndex],
+					formatted: result.formatted,
+				});
+			}
+		}
+
+		snapshots.push({
+			filePath: absolutePath,
+			oldContents: fileContents,
+			newContents: output,
+			logLine: Number.isFinite(firstLogLine) ? firstLogLine : 1,
+		});
+	}
+
+	const [firstKeyframe] =
+		sequenceKeyframes.length > 0 ? sequenceKeyframes : effectKeyframes;
+	if (!firstKeyframe) {
+		throw new Error('No keyframes were specified for moving');
+	}
+
+	pushTransactionToUndoStack({
+		snapshots,
+		logLevel,
+		remotionRoot,
+		description: getBatchDescription({totalKeyframes, firstKeyframe}),
+		entryType:
+			sequenceKeyframes.length > 0 && effectKeyframes.length > 0
+				? 'keyframe-delete'
+				: sequenceKeyframes.length > 0
+					? 'sequence-props'
+					: 'effect-props',
+		suppressHmrOnFileRestore: true,
+	});
+
+	for (const snapshot of snapshots) {
+		suppressUndoStackInvalidation(snapshot.filePath);
+		suppressBundlerUpdateForFile(snapshot.filePath);
+		writeFileAndNotifyFileWatchers(
+			snapshot.filePath,
+			snapshot.newContents,
+			clientId,
+		);
+	}
+
+	for (const log of sequenceLogs) {
+		logUpdate({
+			fileRelativeToRoot: log.fileRelativeToRoot,
+			line: log.line,
+			key: log.key,
+			oldValueString: log.oldValueString,
+			newValueString: log.newValueString,
+			defaultValueString: null,
+			formatted: log.formatted,
+			logLevel,
+			removedProps: [],
+			addedProps: [],
+		});
+	}
+
+	for (const log of effectLogs) {
+		logEffectUpdate({
+			fileRelativeToRoot: log.fileRelativeToRoot,
+			line: log.line,
+			effectName: log.effectName,
+			propKey: log.propKey,
+			oldValueString: log.oldValueString,
+			newValueString: log.newValueString,
+			defaultValueString: null,
+			formatted: log.formatted,
+			logLevel,
+			removedProps: [],
+			addedProps: [],
+		});
+	}
+
+	printUndoHint(logLevel);
+};
+
+export const moveKeyframesHandler: ApiHandler<
+	MoveKeyframesRequest,
+	MoveKeyframesResponse
+> = ({
+	input: {sequenceKeyframes, effectKeyframes, clientId},
+	remotionRoot,
+	logLevel,
+}) =>
+	withSavePropsLock(async () => {
+		RenderInternals.Log.trace(
+			{indent: false, logLevel},
+			`[move-keyframes] Received request to move ${
+				sequenceKeyframes.length + effectKeyframes.length
+			} keyframe(s)`,
+		);
+
+		await moveKeyframes({
+			sequenceKeyframes,
+			effectKeyframes,
+			clientId,
+			remotionRoot,
+			logLevel,
+		});
+
+		return {success: true};
+	});

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -140,6 +140,45 @@ test('updateSequenceKeyframes updates a keyframe at the same frame', async () =>
 	expect(output).toContain('scale: interpolate(frame, [0, 100], [2, 5])');
 });
 
+test('updateSequenceKeyframes moves a keyframe to a new frame', async () => {
+	const {output, oldValueStrings, newValueStrings} =
+		await updateSequenceKeyframes({
+			input: sequenceInput,
+			nodePath: lineColumnToNodePath(
+				sequenceInput,
+				getLine(sequenceInput, 'scale'),
+			),
+			updates: [
+				{
+					key: 'style.scale',
+					operation: {type: 'move', fromFrame: 100, toFrame: 50},
+				},
+			],
+		});
+
+	expect(oldValueStrings).toEqual(['interpolate(frame, [0, 100], [2, 4])']);
+	expect(newValueStrings).toEqual(['interpolate(frame, [0, 50], [2, 4])']);
+	expect(output).toContain('scale: interpolate(frame, [0, 50], [2, 4])');
+});
+
+test('updateSequenceKeyframes rejects moving a keyframe onto an existing frame', async () => {
+	await expect(
+		updateSequenceKeyframes({
+			input: sequenceInput,
+			nodePath: lineColumnToNodePath(
+				sequenceInput,
+				getLine(sequenceInput, 'scale'),
+			),
+			updates: [
+				{
+					key: 'style.scale',
+					operation: {type: 'move', fromFrame: 100, toFrame: 0},
+				},
+			],
+		}),
+	).rejects.toThrow(/already exists/);
+});
+
 test('updateSequenceKeyframes converts a static value to an interpolation', async () => {
 	const {output, oldValueStrings} = await updateSequenceKeyframes({
 		input: sequenceInput,
@@ -649,6 +688,35 @@ test('updateEffectKeyframes removes a keyframe from an effect prop interpolation
 	]);
 	expect(serialized).toContain(
 		'amount: interpolate(frame, [0, 100], [0.2, 0.8])',
+	);
+});
+
+test('updateEffectKeyframes moves a keyframe in an effect prop interpolation', () => {
+	const {serialized, oldValueStrings, newValueStrings, effectCallee} =
+		updateEffectKeyframesAst({
+			input: effectInput,
+			sequenceNodePath: lineColumnToNodePath(
+				effectInput,
+				getLine(effectInput, '<HtmlInCanvas'),
+			),
+			effectIndex: 0,
+			updates: [
+				{
+					key: 'amount',
+					operation: {type: 'move', fromFrame: 50, toFrame: 75},
+				},
+			],
+		});
+
+	expect(effectCallee).toBe('tint');
+	expect(oldValueStrings).toEqual([
+		'interpolate(frame, [0, 50, 100], [0.2, 0.5, 0.8])',
+	]);
+	expect(newValueStrings).toEqual([
+		'interpolate(frame, [0, 75, 100], [0.2, 0.5, 0.8])',
+	]);
+	expect(serialized).toContain(
+		'amount: interpolate(frame, [0, 75, 100], [0.2, 0.5, 0.8])',
 	);
 });
 

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -369,6 +369,15 @@ export type DeleteSequenceKeyframe = {
 	schema: SequenceSchema;
 };
 
+export type MoveSequenceKeyframe = {
+	fileName: string;
+	nodePath: SequencePropsSubscriptionKey;
+	key: string;
+	fromFrame: number;
+	toFrame: number;
+	schema: SequenceSchema;
+};
+
 export type AddSequenceKeyframeRequest = {
 	fileName: string;
 	nodePath: SequencePropsSubscriptionKey;
@@ -390,6 +399,16 @@ export type DeleteEffectKeyframe = {
 	schema: SequenceSchema;
 };
 
+export type MoveEffectKeyframe = {
+	fileName: string;
+	sequenceNodePath: SequencePropsSubscriptionKey;
+	effectIndex: number;
+	key: string;
+	fromFrame: number;
+	toFrame: number;
+	schema: SequenceSchema;
+};
+
 export type DeleteKeyframesRequest = {
 	sequenceKeyframes: DeleteSequenceKeyframe[];
 	effectKeyframes: DeleteEffectKeyframe[];
@@ -397,6 +416,16 @@ export type DeleteKeyframesRequest = {
 };
 
 export type DeleteKeyframesResponse = {
+	success: true;
+};
+
+export type MoveKeyframesRequest = {
+	sequenceKeyframes: MoveSequenceKeyframe[];
+	effectKeyframes: MoveEffectKeyframe[];
+	clientId: string;
+};
+
+export type MoveKeyframesResponse = {
 	success: true;
 };
 
@@ -623,6 +652,7 @@ export type ApiRoutes = {
 		DeleteKeyframesRequest,
 		DeleteKeyframesResponse
 	>;
+	'/api/move-keyframes': ReqAndRes<MoveKeyframesRequest, MoveKeyframesResponse>;
 	'/api/add-sequence-keyframe': ReqAndRes<
 		AddSequenceKeyframeRequest,
 		AddSequenceKeyframeResponse

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -41,6 +41,10 @@ export {
 	OpenInEditorRequest,
 	OpenInEditorResponse,
 	OpenInFileExplorerRequest,
+	MoveEffectKeyframe,
+	MoveKeyframesRequest,
+	MoveKeyframesResponse,
+	MoveSequenceKeyframe,
 	PasteEffectsRequest,
 	PasteEffectsResponse,
 	ProjectInfoRequest,
@@ -185,6 +189,12 @@ export {
 	optimisticDeleteSequenceKeyframe,
 	optimisticDeleteSequenceKeyframes,
 } from './optimistic-delete-keyframe';
+export {
+	optimisticMoveEffectKeyframe,
+	optimisticMoveEffectKeyframes,
+	optimisticMoveSequenceKeyframe,
+	optimisticMoveSequenceKeyframes,
+} from './optimistic-move-keyframe';
 export {optimisticUpdateForCodeValues} from './optimistic-update-for-code-values';
 export {optimisticUpdateForEffectCodeValues} from './optimistic-update-for-effect-code-values';
 export {

--- a/packages/studio-shared/src/optimistic-move-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-move-keyframe.ts
@@ -1,0 +1,167 @@
+import {
+	type CanUpdateSequencePropStatus,
+	type CanUpdateSequencePropsResponse,
+} from 'remotion';
+
+const moveKeyframeInPropStatus = ({
+	status,
+	fromFrame,
+	toFrame,
+}: {
+	status: CanUpdateSequencePropStatus;
+	fromFrame: number;
+	toFrame: number;
+}): CanUpdateSequencePropStatus => {
+	if (status.status !== 'keyframed' || fromFrame === toFrame) {
+		return status;
+	}
+
+	const keyframeIndex = status.keyframes.findIndex(
+		(keyframe) => keyframe.frame === fromFrame,
+	);
+	if (keyframeIndex === -1) {
+		return status;
+	}
+
+	const collision = status.keyframes.some(
+		(keyframe) => keyframe.frame === toFrame,
+	);
+	if (collision) {
+		return status;
+	}
+
+	const keyframes = status.keyframes
+		.map((keyframe, index) =>
+			index === keyframeIndex ? {...keyframe, frame: toFrame} : keyframe,
+		)
+		.sort((first, second) => first.frame - second.frame);
+
+	return {
+		...status,
+		keyframes,
+	};
+};
+
+export const optimisticMoveSequenceKeyframe = ({
+	previous,
+	fieldKey,
+	fromFrame,
+	toFrame,
+}: {
+	previous: CanUpdateSequencePropsResponse;
+	fieldKey: string;
+	fromFrame: number;
+	toFrame: number;
+}): CanUpdateSequencePropsResponse => {
+	if (!previous.canUpdate) {
+		return previous;
+	}
+
+	const status = previous.props[fieldKey];
+	if (!status) {
+		return previous;
+	}
+
+	return {
+		...previous,
+		props: {
+			...previous.props,
+			[fieldKey]: moveKeyframeInPropStatus({status, fromFrame, toFrame}),
+		},
+	};
+};
+
+export const optimisticMoveSequenceKeyframes = ({
+	previous,
+	keyframes,
+}: {
+	previous: CanUpdateSequencePropsResponse;
+	keyframes: {fieldKey: string; fromFrame: number; toFrame: number}[];
+}): CanUpdateSequencePropsResponse => {
+	return keyframes.reduce(
+		(current, keyframe) =>
+			optimisticMoveSequenceKeyframe({
+				previous: current,
+				fieldKey: keyframe.fieldKey,
+				fromFrame: keyframe.fromFrame,
+				toFrame: keyframe.toFrame,
+			}),
+		previous,
+	);
+};
+
+export const optimisticMoveEffectKeyframe = ({
+	previous,
+	effectIndex,
+	fieldKey,
+	fromFrame,
+	toFrame,
+}: {
+	previous: CanUpdateSequencePropsResponse;
+	effectIndex: number;
+	fieldKey: string;
+	fromFrame: number;
+	toFrame: number;
+}): CanUpdateSequencePropsResponse => {
+	if (!previous.canUpdate) {
+		return previous;
+	}
+
+	const targetIndex = previous.effects.findIndex(
+		(effect) => effect.effectIndex === effectIndex,
+	);
+	if (targetIndex === -1) {
+		return previous;
+	}
+
+	const target = previous.effects[targetIndex];
+	if (!target.canUpdate) {
+		return previous;
+	}
+
+	const status = target.props[fieldKey];
+	if (!status) {
+		return previous;
+	}
+
+	const updatedEffect = {
+		...target,
+		props: {
+			...target.props,
+			[fieldKey]: moveKeyframeInPropStatus({status, fromFrame, toFrame}),
+		},
+	};
+
+	const effects = [...previous.effects];
+	effects[targetIndex] = updatedEffect;
+
+	return {
+		...previous,
+		effects,
+	};
+};
+
+export const optimisticMoveEffectKeyframes = ({
+	previous,
+	keyframes,
+}: {
+	previous: CanUpdateSequencePropsResponse;
+	keyframes: {
+		effectIndex: number;
+		fieldKey: string;
+		fromFrame: number;
+		toFrame: number;
+	}[];
+}): CanUpdateSequencePropsResponse => {
+	return keyframes.reduce(
+		(current, keyframe) =>
+			optimisticMoveEffectKeyframe({
+				previous: current,
+				effectIndex: keyframe.effectIndex,
+				fieldKey: keyframe.fieldKey,
+				fromFrame: keyframe.fromFrame,
+				toFrame: keyframe.toFrame,
+			}),
+		previous,
+	);
+};

--- a/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
@@ -1,0 +1,137 @@
+import {expect, test} from 'bun:test';
+import type {CanUpdateSequencePropsResponse} from 'remotion';
+import {
+	optimisticMoveEffectKeyframe,
+	optimisticMoveSequenceKeyframe,
+} from '../optimistic-move-keyframe';
+
+test('optimisticMoveSequenceKeyframe moves and re-sorts the matching keyframe', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			opacity: {
+				status: 'keyframed',
+				codeValue: undefined,
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 0},
+					{frame: 30, value: 0.5},
+					{frame: 60, value: 1},
+				],
+				easing: ['linear', 'linear'],
+				clamping: {left: 'clamp', right: 'clamp'},
+				posterize: undefined,
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticMoveSequenceKeyframe({
+		previous,
+		fieldKey: 'opacity',
+		fromFrame: 30,
+		toFrame: 10,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected canUpdate true');
+	}
+
+	const status = updated.props.opacity;
+	if (status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([
+		{frame: 0, value: 0},
+		{frame: 10, value: 0.5},
+		{frame: 60, value: 1},
+	]);
+	expect(status.easing).toEqual(['linear', 'linear']);
+});
+
+test('optimisticMoveSequenceKeyframe ignores collisions', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			opacity: {
+				status: 'keyframed',
+				codeValue: undefined,
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 0},
+					{frame: 30, value: 0.5},
+				],
+				easing: ['linear'],
+				clamping: {left: 'clamp', right: 'clamp'},
+				posterize: undefined,
+			},
+		},
+		effects: [],
+	};
+
+	expect(
+		optimisticMoveSequenceKeyframe({
+			previous,
+			fieldKey: 'opacity',
+			fromFrame: 0,
+			toFrame: 30,
+		}),
+	).toEqual(previous);
+});
+
+test('optimisticMoveEffectKeyframe moves a keyframe on the target effect', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {},
+		effects: [
+			{
+				canUpdate: true,
+				callee: 'tint',
+				importPath: null,
+				effectIndex: 0,
+				props: {
+					amount: {
+						status: 'keyframed',
+						codeValue: undefined,
+						interpolationFunction: 'interpolate',
+						keyframes: [
+							{frame: 0, value: 0},
+							{frame: 30, value: 1},
+						],
+						easing: ['linear'],
+						clamping: {left: 'clamp', right: 'clamp'},
+						posterize: undefined,
+					},
+				},
+			},
+		],
+	};
+
+	const updated = optimisticMoveEffectKeyframe({
+		previous,
+		effectIndex: 0,
+		fieldKey: 'amount',
+		fromFrame: 30,
+		toFrame: 15,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected canUpdate true');
+	}
+
+	const effect = updated.effects[0];
+	if (!effect.canUpdate) {
+		throw new Error('expected effect canUpdate true');
+	}
+
+	const status = effect.props.amount;
+	if (status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([
+		{frame: 0, value: 0},
+		{frame: 15, value: 1},
+	]);
+});

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -55,6 +55,55 @@ const getClientXWithScroll = (x: number) => {
 	return x + (scrollableRef.current?.scrollLeft as number);
 };
 
+const getKeyframeButtonAtPoint = (
+	clientX: number,
+	clientY: number,
+): HTMLButtonElement | null => {
+	for (const element of document.querySelectorAll<HTMLButtonElement>(
+		'button[title^="Drag keyframe at frame"]',
+	)) {
+		const rect = element.getBoundingClientRect();
+		if (
+			clientX >= rect.left &&
+			clientX <= rect.right &&
+			clientY >= rect.top &&
+			clientY <= rect.bottom
+		) {
+			return element;
+		}
+	}
+
+	return null;
+};
+
+const forwardPointerDownToKeyframe = (
+	e: React.PointerEvent<HTMLDivElement>,
+): boolean => {
+	const keyframeButton = getKeyframeButtonAtPoint(e.clientX, e.clientY);
+	if (keyframeButton === null) {
+		return false;
+	}
+
+	e.stopPropagation();
+	e.preventDefault();
+	keyframeButton.dispatchEvent(
+		new PointerEvent('pointerdown', {
+			bubbles: true,
+			cancelable: true,
+			button: e.button,
+			buttons: e.buttons,
+			clientX: e.clientX,
+			clientY: e.clientY,
+			ctrlKey: e.ctrlKey,
+			metaKey: e.metaKey,
+			pointerId: e.pointerId,
+			pointerType: e.pointerType,
+			shiftKey: e.shiftKey,
+		}),
+	);
+	return true;
+};
+
 export const TimelineDragHandler: React.FC = () => {
 	const video = Internals.useUnsafeVideoConfig();
 
@@ -126,6 +175,10 @@ const TimelineDragHandlerInner: React.FC = () => {
 			}
 
 			if (!isHighestContext) {
+				return;
+			}
+
+			if (forwardPointerDownToKeyframe(e)) {
 				return;
 			}
 

--- a/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
@@ -57,6 +57,7 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 			touchAction: 'none',
 			top: rowHeight / 2,
 			transform: 'translate(-50%, -50%) rotate(45deg)',
+			zIndex: 2,
 		};
 	}, [
 		dragging,

--- a/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
@@ -6,6 +6,7 @@ import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sor
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {useTimelineKeyframeSelection} from './TimelineSelection';
 import {TimelineWidthContext} from './TimelineWidthProvider';
+import {useTimelineKeyframeDrag} from './use-timeline-keyframe-drag';
 
 const diamondBase: React.CSSProperties = {
 	position: 'absolute',
@@ -27,6 +28,12 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 		nodePathInfo,
 		frame,
 	);
+	const {dragging, onPointerDown: onDragPointerDown} = useTimelineKeyframeDrag({
+		nodePathInfo,
+		frame,
+		timelineWidth,
+		timelineDurationInFrames: videoConfig.durationInFrames,
+	});
 
 	const style = useMemo((): React.CSSProperties | null => {
 		if (timelineWidth === null) {
@@ -38,7 +45,7 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 			backgroundColor: LIGHT_TEXT,
 			outline: selected ? '2px solid ' + BLUE : 'none',
 			border: 'none',
-			cursor: 'pointer',
+			cursor: dragging ? 'grabbing' : 'ew-resize',
 			left:
 				getXPositionOfItemInTimelineImperatively(
 					frame,
@@ -47,10 +54,18 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 				) - TIMELINE_PADDING,
 			padding: 0,
 			pointerEvents: 'auto',
+			touchAction: 'none',
 			top: rowHeight / 2,
 			transform: 'translate(-50%, -50%) rotate(45deg)',
 		};
-	}, [frame, rowHeight, selected, timelineWidth, videoConfig.durationInFrames]);
+	}, [
+		dragging,
+		frame,
+		rowHeight,
+		selected,
+		timelineWidth,
+		videoConfig.durationInFrames,
+	]);
 
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLButtonElement>) => {
@@ -60,9 +75,10 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 					shiftKey: e.shiftKey,
 					toggleKey: e.metaKey || e.ctrlKey,
 				});
+				onDragPointerDown(e);
 			}
 		},
-		[onSelect],
+		[onDragPointerDown, onSelect],
 	);
 
 	if (style === null) {
@@ -73,8 +89,8 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 		<button
 			type="button"
 			style={style}
-			title={`Keyframe at frame ${frame}`}
-			aria-label={`Select keyframe at frame ${frame}`}
+			title={`Drag keyframe at frame ${frame}`}
+			aria-label={`Drag keyframe at frame ${frame}`}
 			onPointerDown={selectable ? onPointerDown : undefined}
 		/>
 	);

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -60,7 +60,7 @@ export const getTimelineSelectedTrackHighlightStyle = (
 	width: timelineWidth,
 });
 
-export const SELECTION_ENABLED = false;
+export const SELECTION_ENABLED = true;
 export const TIMELINE_TOP_DRAG = false;
 export const ENABLE_OUTLINES = false;
 

--- a/packages/studio/src/components/Timeline/call-move-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-move-keyframe.ts
@@ -1,0 +1,113 @@
+import {
+	optimisticMoveEffectKeyframes,
+	optimisticMoveSequenceKeyframes,
+} from '@remotion/studio-shared';
+import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
+import {callApi} from '../call-api';
+import {sortTimelineKeyframeMoveChangesForApplication} from './move-selected-keyframe';
+import type {SetCodeValues} from './save-sequence-prop';
+
+export type MoveSequenceKeyframeChange = {
+	fileName: string;
+	nodePath: SequencePropsSubscriptionKey;
+	fieldKey: string;
+	fromFrame: number;
+	toFrame: number;
+	schema: SequenceSchema;
+};
+
+export type MoveEffectKeyframeChange = MoveSequenceKeyframeChange & {
+	effectIndex: number;
+};
+
+const groupByNodePath = <T extends {nodePath: SequencePropsSubscriptionKey}>(
+	keyframes: T[],
+): T[][] => {
+	const groups = new Map<string, T[]>();
+	for (const keyframe of keyframes) {
+		const key = JSON.stringify(keyframe.nodePath);
+		const group = groups.get(key) ?? [];
+		group.push(keyframe);
+		groups.set(key, group);
+	}
+
+	return [...groups.values()];
+};
+
+export const callMoveKeyframes = ({
+	sequenceKeyframes,
+	effectKeyframes,
+	setCodeValues,
+	clientId,
+}: {
+	sequenceKeyframes: MoveSequenceKeyframeChange[];
+	effectKeyframes: MoveEffectKeyframeChange[];
+	setCodeValues: SetCodeValues;
+	clientId: string;
+}): Promise<void> => {
+	if (sequenceKeyframes.length === 0 && effectKeyframes.length === 0) {
+		return Promise.resolve();
+	}
+
+	for (const keyframes of groupByNodePath(sequenceKeyframes)) {
+		const sortedKeyframes =
+			sortTimelineKeyframeMoveChangesForApplication(keyframes);
+		const [firstKeyframe] = keyframes;
+		if (!firstKeyframe) {
+			continue;
+		}
+
+		setCodeValues(firstKeyframe.nodePath, (prev) =>
+			optimisticMoveSequenceKeyframes({
+				previous: prev,
+				keyframes: sortedKeyframes.map((keyframe) => ({
+					fieldKey: keyframe.fieldKey,
+					fromFrame: keyframe.fromFrame,
+					toFrame: keyframe.toFrame,
+				})),
+			}),
+		);
+	}
+
+	for (const keyframes of groupByNodePath(effectKeyframes)) {
+		const sortedKeyframes =
+			sortTimelineKeyframeMoveChangesForApplication(keyframes);
+		const [firstKeyframe] = keyframes;
+		if (!firstKeyframe) {
+			continue;
+		}
+
+		setCodeValues(firstKeyframe.nodePath, (prev) =>
+			optimisticMoveEffectKeyframes({
+				previous: prev,
+				keyframes: sortedKeyframes.map((keyframe) => ({
+					effectIndex: keyframe.effectIndex,
+					fieldKey: keyframe.fieldKey,
+					fromFrame: keyframe.fromFrame,
+					toFrame: keyframe.toFrame,
+				})),
+			}),
+		);
+	}
+
+	return callApi('/api/move-keyframes', {
+		sequenceKeyframes: sequenceKeyframes.map((keyframe) => ({
+			fileName: keyframe.fileName,
+			nodePath: keyframe.nodePath,
+			key: keyframe.fieldKey,
+			fromFrame: keyframe.fromFrame,
+			toFrame: keyframe.toFrame,
+			schema: keyframe.schema,
+		})),
+		effectKeyframes: effectKeyframes.map((keyframe) => ({
+			fileName: keyframe.fileName,
+			sequenceNodePath: keyframe.nodePath,
+			effectIndex: keyframe.effectIndex,
+			key: keyframe.fieldKey,
+			fromFrame: keyframe.fromFrame,
+			toFrame: keyframe.toFrame,
+			schema: keyframe.schema,
+		})),
+		clientId,
+	}).then(() => undefined);
+};

--- a/packages/studio/src/components/Timeline/move-selected-keyframe.ts
+++ b/packages/studio/src/components/Timeline/move-selected-keyframe.ts
@@ -1,0 +1,436 @@
+import {stringifySequenceSubscriptionKey} from '@remotion/studio-shared';
+import type {
+	CodeValues,
+	OverrideIdToNodePaths,
+	TSequence,
+	CanUpdateSequencePropStatus,
+	SequenceSchema,
+} from 'remotion';
+import {Internals} from 'remotion';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
+import type {
+	MoveEffectKeyframeChange,
+	MoveSequenceKeyframeChange,
+} from './call-move-keyframe';
+import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
+import {parseKeyframeFieldFromNodePath} from './parse-keyframe-field-from-node-path';
+import type {TimelineSelection} from './TimelineSelection';
+
+export type TimelineKeyframeMoveTarget =
+	| {
+			type: 'sequence';
+			fileName: string;
+			fieldKey: string;
+			initialDisplayFrame: number;
+			initialSourceFrame: number;
+			nodePathInfo: SequenceNodePathInfo;
+			nodePath: SequenceNodePathInfo['sequenceSubscriptionKey'];
+			schema: SequenceSchema;
+			sourceFrames: readonly number[];
+	  }
+	| {
+			type: 'effect';
+			effectIndex: number;
+			fileName: string;
+			fieldKey: string;
+			initialDisplayFrame: number;
+			initialSourceFrame: number;
+			nodePathInfo: SequenceNodePathInfo;
+			nodePath: SequenceNodePathInfo['sequenceSubscriptionKey'];
+			schema: SequenceSchema;
+			sourceFrames: readonly number[];
+	  };
+
+const getKeyframeSelectionKey = ({
+	nodePathInfo,
+	frame,
+}: {
+	nodePathInfo: SequenceNodePathInfo;
+	frame: number;
+}) => `${timelineNodePathInfoToKey(nodePathInfo)}.keyframe.${frame}`;
+
+const getKeyframedSourceFrames = (
+	status: CanUpdateSequencePropStatus | undefined,
+): readonly number[] | null => {
+	if (status?.status !== 'keyframed') {
+		return null;
+	}
+
+	return status.keyframes.map((keyframe) => keyframe.frame);
+};
+
+const getTargetForKeyframe = ({
+	nodePathInfo,
+	frame,
+	sequences,
+	overrideIdsToNodePaths,
+	codeValues,
+}: {
+	nodePathInfo: SequenceNodePathInfo;
+	frame: number;
+	sequences: TSequence[];
+	overrideIdsToNodePaths: OverrideIdToNodePaths;
+	codeValues: CodeValues;
+}): TimelineKeyframeMoveTarget | null => {
+	const field = parseKeyframeFieldFromNodePath(nodePathInfo.auxiliaryKeys);
+	if (field === null) {
+		return null;
+	}
+
+	const track = findTrackForNodePathInfo({
+		sequences,
+		overrideIdsToNodePaths,
+		nodePathInfo,
+	});
+	const sequence = track?.sequence ?? null;
+	if (!sequence?.controls) {
+		return null;
+	}
+
+	const sourceFrame = frame - (track?.keyframeDisplayOffset ?? 0);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const fileName = nodePath.absolutePath;
+	const codeValue = Internals.getCodeValuesCtx(codeValues, nodePath);
+	if (!codeValue) {
+		return null;
+	}
+
+	if (field.type === 'effect') {
+		const effect = sequence.effects[field.effectIndex];
+		if (!effect) {
+			return null;
+		}
+
+		const effectStatus = Internals.getEffectCodeValuesCtx({
+			codeValues,
+			nodePath,
+			effectIndex: field.effectIndex,
+		});
+		const effectSourceFrames =
+			effectStatus.type === 'can-update-effect'
+				? getKeyframedSourceFrames(effectStatus.props?.[field.fieldKey])
+				: null;
+		if (!effectSourceFrames?.includes(sourceFrame)) {
+			return null;
+		}
+
+		return {
+			type: 'effect',
+			fileName,
+			nodePath,
+			nodePathInfo,
+			effectIndex: field.effectIndex,
+			fieldKey: field.fieldKey,
+			initialDisplayFrame: frame,
+			initialSourceFrame: sourceFrame,
+			schema: effect.schema,
+			sourceFrames: effectSourceFrames,
+		};
+	}
+
+	const sequenceSourceFrames = getKeyframedSourceFrames(
+		codeValue[field.fieldKey],
+	);
+	if (!sequenceSourceFrames?.includes(sourceFrame)) {
+		return null;
+	}
+
+	return {
+		type: 'sequence',
+		fileName,
+		nodePath,
+		nodePathInfo,
+		fieldKey: field.fieldKey,
+		initialDisplayFrame: frame,
+		initialSourceFrame: sourceFrame,
+		schema: sequence.controls.schema,
+		sourceFrames: sequenceSourceFrames,
+	};
+};
+
+export const getTimelineKeyframeMoveTargets = ({
+	draggedNodePathInfo,
+	draggedFrame,
+	selectedItems,
+	sequences,
+	overrideIdsToNodePaths,
+	codeValues,
+}: {
+	draggedNodePathInfo: SequenceNodePathInfo;
+	draggedFrame: number;
+	selectedItems: readonly TimelineSelection[];
+	sequences: TSequence[];
+	overrideIdsToNodePaths: OverrideIdToNodePaths;
+	codeValues: CodeValues;
+}): TimelineKeyframeMoveTarget[] | null => {
+	const draggedSelectionKey = getKeyframeSelectionKey({
+		nodePathInfo: draggedNodePathInfo,
+		frame: draggedFrame,
+	});
+	const selectedKeyframes = selectedItems.filter(
+		(item): item is TimelineSelection & {type: 'keyframe'} =>
+			item.type === 'keyframe',
+	);
+	const draggedItemIsSelected = selectedKeyframes.some(
+		(item) =>
+			getKeyframeSelectionKey({
+				nodePathInfo: item.nodePathInfo,
+				frame: item.frame,
+			}) === draggedSelectionKey,
+	);
+
+	if (
+		draggedItemIsSelected &&
+		selectedKeyframes.length !== selectedItems.length
+	) {
+		return null;
+	}
+
+	const targetSelections =
+		draggedItemIsSelected && selectedKeyframes.length > 1
+			? selectedKeyframes
+			: [
+					{
+						type: 'keyframe' as const,
+						nodePathInfo: draggedNodePathInfo,
+						frame: draggedFrame,
+					},
+				];
+
+	const targets = new Map<string, TimelineKeyframeMoveTarget>();
+	for (const selection of targetSelections) {
+		const target = getTargetForKeyframe({
+			nodePathInfo: selection.nodePathInfo,
+			frame: selection.frame,
+			sequences,
+			overrideIdsToNodePaths,
+			codeValues,
+		});
+		if (target === null) {
+			return null;
+		}
+
+		const key = `${timelineNodePathInfoToKey(target.nodePathInfo)}.${target.initialDisplayFrame}`;
+		targets.set(key, target);
+	}
+
+	return [...targets.values()];
+};
+
+export const getTimelineKeyframeMoveDelta = ({
+	targets,
+	deltaFrames,
+	durationInFrames,
+}: {
+	targets: readonly TimelineKeyframeMoveTarget[];
+	deltaFrames: number;
+	durationInFrames: number;
+}): number => {
+	if (targets.length === 0) {
+		return 0;
+	}
+
+	const minDelta = Math.max(
+		...targets.map((target) => -target.initialDisplayFrame),
+	);
+	const maxDelta = Math.min(
+		...targets.map(
+			(target) => durationInFrames - 1 - target.initialDisplayFrame,
+		),
+	);
+
+	return Math.max(minDelta, Math.min(maxDelta, deltaFrames));
+};
+
+const hasCollision = ({
+	target,
+	toSourceFrame,
+	targets,
+}: {
+	target: TimelineKeyframeMoveTarget;
+	toSourceFrame: number;
+	targets: readonly TimelineKeyframeMoveTarget[];
+}) => {
+	const movingFramesForSameField = targets
+		.filter((candidate) => {
+			if (candidate.type !== target.type) {
+				return false;
+			}
+
+			if (
+				stringifySequenceSubscriptionKey(candidate.nodePath) !==
+				stringifySequenceSubscriptionKey(target.nodePath)
+			) {
+				return false;
+			}
+
+			if (candidate.fieldKey !== target.fieldKey) {
+				return false;
+			}
+
+			if (target.type === 'sequence') {
+				return true;
+			}
+
+			return (
+				candidate.type === 'effect' &&
+				candidate.effectIndex === target.effectIndex
+			);
+		})
+		.map((candidate) => candidate.initialSourceFrame);
+
+	return (
+		target.sourceFrames.includes(toSourceFrame) &&
+		!movingFramesForSameField.includes(toSourceFrame)
+	);
+};
+
+export const sortTimelineKeyframeMoveChangesForApplication = <
+	T extends {
+		fieldKey: string;
+		fromFrame: number;
+		toFrame: number;
+		effectIndex?: number;
+	},
+>(
+	keyframes: T[],
+): T[] => {
+	return [...keyframes].sort((a, b) => {
+		if (a.fieldKey !== b.fieldKey || a.effectIndex !== b.effectIndex) {
+			return 0;
+		}
+
+		const delta = a.toFrame - a.fromFrame;
+		if (delta > 0) {
+			return b.fromFrame - a.fromFrame;
+		}
+
+		if (delta < 0) {
+			return a.fromFrame - b.fromFrame;
+		}
+
+		return 0;
+	});
+};
+
+export const getTimelineKeyframeMoveChanges = ({
+	targets,
+	deltaFrames,
+	durationInFrames,
+}: {
+	targets: readonly TimelineKeyframeMoveTarget[];
+	deltaFrames: number;
+	durationInFrames: number;
+}): {
+	sequenceKeyframes: MoveSequenceKeyframeChange[];
+	effectKeyframes: MoveEffectKeyframeChange[];
+	appliedDeltaFrames: number;
+} | null => {
+	const appliedDeltaFrames = getTimelineKeyframeMoveDelta({
+		targets,
+		deltaFrames,
+		durationInFrames,
+	});
+	if (appliedDeltaFrames === 0) {
+		return {
+			sequenceKeyframes: [],
+			effectKeyframes: [],
+			appliedDeltaFrames,
+		};
+	}
+
+	const sequenceKeyframes: MoveSequenceKeyframeChange[] = [];
+	const effectKeyframes: MoveEffectKeyframeChange[] = [];
+	for (const target of targets) {
+		const toSourceFrame = target.initialSourceFrame + appliedDeltaFrames;
+		if (hasCollision({target, toSourceFrame, targets})) {
+			return null;
+		}
+
+		if (target.type === 'effect') {
+			effectKeyframes.push({
+				fileName: target.fileName,
+				nodePath: target.nodePath,
+				effectIndex: target.effectIndex,
+				fieldKey: target.fieldKey,
+				fromFrame: target.initialSourceFrame,
+				toFrame: toSourceFrame,
+				schema: target.schema,
+			});
+		} else {
+			sequenceKeyframes.push({
+				fileName: target.fileName,
+				nodePath: target.nodePath,
+				fieldKey: target.fieldKey,
+				fromFrame: target.initialSourceFrame,
+				toFrame: toSourceFrame,
+				schema: target.schema,
+			});
+		}
+	}
+
+	return {sequenceKeyframes, effectKeyframes, appliedDeltaFrames};
+};
+
+export const getTimelineKeyframeMovePreviewChanges = ({
+	targets,
+	fromDeltaFrames,
+	toDeltaFrames,
+	durationInFrames,
+}: {
+	targets: readonly TimelineKeyframeMoveTarget[];
+	fromDeltaFrames: number;
+	toDeltaFrames: number;
+	durationInFrames: number;
+}): {
+	sequenceKeyframes: MoveSequenceKeyframeChange[];
+	effectKeyframes: MoveEffectKeyframeChange[];
+	appliedDeltaFrames: number;
+} | null => {
+	const appliedDeltaFrames = getTimelineKeyframeMoveDelta({
+		targets,
+		deltaFrames: toDeltaFrames,
+		durationInFrames,
+	});
+	if (appliedDeltaFrames === fromDeltaFrames) {
+		return {
+			sequenceKeyframes: [],
+			effectKeyframes: [],
+			appliedDeltaFrames,
+		};
+	}
+
+	const sequenceKeyframes: MoveSequenceKeyframeChange[] = [];
+	const effectKeyframes: MoveEffectKeyframeChange[] = [];
+	for (const target of targets) {
+		const toSourceFrame = target.initialSourceFrame + appliedDeltaFrames;
+		if (hasCollision({target, toSourceFrame, targets})) {
+			return null;
+		}
+
+		const fromFrame = target.initialSourceFrame + fromDeltaFrames;
+		if (target.type === 'effect') {
+			effectKeyframes.push({
+				fileName: target.fileName,
+				nodePath: target.nodePath,
+				effectIndex: target.effectIndex,
+				fieldKey: target.fieldKey,
+				fromFrame,
+				toFrame: toSourceFrame,
+				schema: target.schema,
+			});
+		} else {
+			sequenceKeyframes.push({
+				fileName: target.fileName,
+				nodePath: target.nodePath,
+				fieldKey: target.fieldKey,
+				fromFrame,
+				toFrame: toSourceFrame,
+				schema: target.schema,
+			});
+		}
+	}
+
+	return {sequenceKeyframes, effectKeyframes, appliedDeltaFrames};
+};

--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -1,0 +1,331 @@
+import {
+	optimisticMoveEffectKeyframes,
+	optimisticMoveSequenceKeyframes,
+} from '@remotion/studio-shared';
+import type {ContextType, PointerEvent as ReactPointerEvent} from 'react';
+import {useCallback, useContext, useEffect, useRef, useState} from 'react';
+import {Internals, type SequencePropsSubscriptionKey} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
+import {
+	forceSpecificCursor,
+	stopForcingSpecificCursor,
+} from '../ForceSpecificCursor';
+import {callMoveKeyframes} from './call-move-keyframe';
+import {
+	getTimelineKeyframeMoveChanges,
+	getTimelineKeyframeMovePreviewChanges,
+	getTimelineKeyframeMoveTargets,
+	sortTimelineKeyframeMoveChangesForApplication,
+	type TimelineKeyframeMoveTarget,
+} from './move-selected-keyframe';
+import {useTimelineSelection} from './TimelineSelection';
+
+const groupByNodePath = <T extends {nodePath: SequencePropsSubscriptionKey}>(
+	keyframes: T[],
+): T[][] => {
+	const groups = new Map<string, T[]>();
+	for (const keyframe of keyframes) {
+		const key = JSON.stringify(keyframe.nodePath);
+		const group = groups.get(key) ?? [];
+		group.push(keyframe);
+		groups.set(key, group);
+	}
+
+	return [...groups.values()];
+};
+
+const applyPreviewChanges = ({
+	changes,
+	setCodeValues,
+}: {
+	changes: NonNullable<
+		ReturnType<typeof getTimelineKeyframeMovePreviewChanges>
+	>;
+	setCodeValues: ContextType<
+		typeof Internals.VisualModeSettersContext
+	>['setCodeValues'];
+}) => {
+	for (const keyframes of groupByNodePath(changes.sequenceKeyframes)) {
+		const sortedKeyframes =
+			sortTimelineKeyframeMoveChangesForApplication(keyframes);
+		const [firstKeyframe] = keyframes;
+		if (!firstKeyframe) {
+			continue;
+		}
+
+		setCodeValues(firstKeyframe.nodePath, (prev) =>
+			optimisticMoveSequenceKeyframes({
+				previous: prev,
+				keyframes: sortedKeyframes.map((keyframe) => ({
+					fieldKey: keyframe.fieldKey,
+					fromFrame: keyframe.fromFrame,
+					toFrame: keyframe.toFrame,
+				})),
+			}),
+		);
+	}
+
+	for (const keyframes of groupByNodePath(changes.effectKeyframes)) {
+		const sortedKeyframes =
+			sortTimelineKeyframeMoveChangesForApplication(keyframes);
+		const [firstKeyframe] = keyframes;
+		if (!firstKeyframe) {
+			continue;
+		}
+
+		setCodeValues(firstKeyframe.nodePath, (prev) =>
+			optimisticMoveEffectKeyframes({
+				previous: prev,
+				keyframes: sortedKeyframes.map((keyframe) => ({
+					effectIndex: keyframe.effectIndex,
+					fieldKey: keyframe.fieldKey,
+					fromFrame: keyframe.fromFrame,
+					toFrame: keyframe.toFrame,
+				})),
+			}),
+		);
+	}
+};
+
+export const useTimelineKeyframeDrag = ({
+	nodePathInfo,
+	frame,
+	timelineWidth,
+	timelineDurationInFrames,
+}: {
+	nodePathInfo: SequenceNodePathInfo;
+	frame: number;
+	timelineWidth: number | null;
+	timelineDurationInFrames: number;
+}) => {
+	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {sequences} = useContext(Internals.SequenceManager);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {selectedItems, selectItems} = useTimelineSelection();
+	const [dragging, setDragging] = useState(false);
+	const dragStateRef = useRef<{
+		initialClientX: number;
+		latestDeltaFrames: number;
+		pointerId: number;
+		pxPerFrame: number;
+		targets: readonly TimelineKeyframeMoveTarget[];
+	} | null>(null);
+	const latestRef = useRef({
+		nodePathInfo,
+		frame,
+		setCodeValues,
+		previewServerState,
+		codeValues,
+		sequences,
+		overrideIdToNodePathMappings,
+		selectedItems,
+		selectItems,
+		timelineDurationInFrames,
+	});
+	latestRef.current = {
+		nodePathInfo,
+		frame,
+		setCodeValues,
+		previewServerState,
+		codeValues,
+		sequences,
+		overrideIdToNodePathMappings,
+		selectedItems,
+		selectItems,
+		timelineDurationInFrames,
+	};
+
+	const finishDrag = useCallback((commit: boolean) => {
+		const dragState = dragStateRef.current;
+		dragStateRef.current = null;
+		document.body.style.userSelect = '';
+		document.body.style.webkitUserSelect = '';
+		stopForcingSpecificCursor();
+		setDragging(false);
+
+		if (!dragState) {
+			return;
+		}
+
+		const {
+			setCodeValues: latestSetCodeValues,
+			previewServerState: latestServerState,
+			selectItems: latestSelectItems,
+			timelineDurationInFrames: latestDuration,
+		} = latestRef.current;
+
+		if (!commit || latestServerState.type !== 'connected') {
+			const revertChanges = getTimelineKeyframeMovePreviewChanges({
+				targets: dragState.targets,
+				fromDeltaFrames: dragState.latestDeltaFrames,
+				toDeltaFrames: 0,
+				durationInFrames: latestDuration,
+			});
+			if (revertChanges) {
+				applyPreviewChanges({
+					changes: revertChanges,
+					setCodeValues: latestSetCodeValues,
+				});
+			}
+
+			return;
+		}
+
+		const changes = getTimelineKeyframeMoveChanges({
+			targets: dragState.targets,
+			deltaFrames: dragState.latestDeltaFrames,
+			durationInFrames: latestDuration,
+		});
+		if (
+			changes === null ||
+			(changes.sequenceKeyframes.length === 0 &&
+				changes.effectKeyframes.length === 0)
+		) {
+			return;
+		}
+
+		latestSelectItems(
+			dragState.targets.map((target) => ({
+				type: 'keyframe',
+				nodePathInfo: target.nodePathInfo,
+				frame: target.initialDisplayFrame + changes.appliedDeltaFrames,
+			})),
+		);
+
+		callMoveKeyframes({
+			sequenceKeyframes: changes.sequenceKeyframes,
+			effectKeyframes: changes.effectKeyframes,
+			setCodeValues: latestSetCodeValues,
+			clientId: latestServerState.clientId,
+		}).catch((err) => {
+			Internals.Log.error(
+				{logLevel: 'error', tag: null},
+				'Could not move keyframes',
+				err,
+			);
+		});
+	}, []);
+
+	const onPointerDown = useCallback(
+		(e: ReactPointerEvent<HTMLButtonElement>) => {
+			if (e.button !== 0 || timelineWidth === null) {
+				return;
+			}
+
+			const pxPerFrame =
+				timelineDurationInFrames > 0
+					? (timelineWidth - TIMELINE_PADDING * 2) / timelineDurationInFrames
+					: 0;
+			if (pxPerFrame <= 0) {
+				return;
+			}
+
+			const {
+				nodePathInfo: latestNodePathInfo,
+				frame: latestFrame,
+				selectedItems: latestSelectedItems,
+				sequences: latestSequences,
+				overrideIdToNodePathMappings: latestOverrideIdsToNodePaths,
+				codeValues: latestCodeValues,
+			} = latestRef.current;
+			const targets = getTimelineKeyframeMoveTargets({
+				draggedNodePathInfo: latestNodePathInfo,
+				draggedFrame: latestFrame,
+				selectedItems: latestSelectedItems,
+				sequences: latestSequences,
+				overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
+				codeValues: latestCodeValues,
+			});
+			if (targets === null || targets.length === 0) {
+				return;
+			}
+
+			e.preventDefault();
+			dragStateRef.current = {
+				initialClientX: e.clientX,
+				latestDeltaFrames: 0,
+				pointerId: e.pointerId,
+				pxPerFrame,
+				targets,
+			};
+			document.body.style.userSelect = 'none';
+			document.body.style.webkitUserSelect = 'none';
+			forceSpecificCursor('ew-resize');
+			setDragging(true);
+		},
+		[timelineDurationInFrames, timelineWidth],
+	);
+
+	useEffect(() => {
+		if (!dragging) {
+			return;
+		}
+
+		const onMove = (e: PointerEvent) => {
+			const dragState = dragStateRef.current;
+			if (!dragState || e.pointerId !== dragState.pointerId) {
+				return;
+			}
+
+			const dx = e.clientX - dragState.initialClientX;
+			const nextDeltaFrames = Math.round(dx / dragState.pxPerFrame);
+			const changes = getTimelineKeyframeMovePreviewChanges({
+				targets: dragState.targets,
+				fromDeltaFrames: dragState.latestDeltaFrames,
+				toDeltaFrames: nextDeltaFrames,
+				durationInFrames: latestRef.current.timelineDurationInFrames,
+			});
+			if (changes === null) {
+				return;
+			}
+
+			dragState.latestDeltaFrames = changes.appliedDeltaFrames;
+			applyPreviewChanges({
+				changes,
+				setCodeValues: latestRef.current.setCodeValues,
+			});
+		};
+
+		const onUp = (e: PointerEvent) => {
+			const dragState = dragStateRef.current;
+			if (!dragState || e.pointerId !== dragState.pointerId) {
+				return;
+			}
+
+			finishDrag(true);
+		};
+
+		const onCancel = (e: PointerEvent) => {
+			const dragState = dragStateRef.current;
+			if (!dragState || e.pointerId !== dragState.pointerId) {
+				return;
+			}
+
+			finishDrag(false);
+		};
+
+		const onWindowBlur = () => {
+			finishDrag(false);
+		};
+
+		window.addEventListener('pointermove', onMove);
+		window.addEventListener('pointerup', onUp);
+		window.addEventListener('pointercancel', onCancel);
+		window.addEventListener('blur', onWindowBlur);
+
+		return () => {
+			window.removeEventListener('pointermove', onMove);
+			window.removeEventListener('pointerup', onUp);
+			window.removeEventListener('pointercancel', onCancel);
+			window.removeEventListener('blur', onWindowBlur);
+		};
+	}, [dragging, finishDrag]);
+
+	return {dragging, onPointerDown};
+};

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -25,6 +25,10 @@ import {
 } from '../components/SelectedOutlineOverlay';
 import {deleteSelectedTimelineItems} from '../components/Timeline/delete-selected-timeline-item';
 import {isDuplicatableSequenceRowSelection} from '../components/Timeline/duplicate-selected-timeline-item';
+import {
+	getTimelineKeyframeMoveChanges,
+	getTimelineKeyframeMoveTargets,
+} from '../components/Timeline/move-selected-keyframe';
 import {getTimelinePropResetTargets} from '../components/Timeline/reset-selected-timeline-props';
 import {
 	getPasteEffectsTarget,
@@ -155,8 +159,34 @@ const makeFromCodeValues = (
 	return codeValues;
 };
 
-test('Timeline selection should stay disabled until released publicly', () => {
-	expect(SELECTION_ENABLED).toBe(false);
+const makeKeyframeCodeValues = ({
+	nodePath,
+	fieldKey,
+	frames,
+}: {
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly fieldKey: string;
+	readonly frames: readonly number[];
+}): CodeValues => ({
+	[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+		canUpdate: true,
+		props: {
+			[fieldKey]: {
+				status: 'keyframed',
+				codeValue: undefined,
+				interpolationFunction: 'interpolate',
+				keyframes: frames.map((frame) => ({frame, value: frame})),
+				easing: frames.slice(1).map(() => 'linear'),
+				clamping: {left: 'clamp', right: 'clamp'},
+				posterize: undefined,
+			},
+		},
+		effects: [],
+	},
+});
+
+test('Timeline selection is enabled for keyframe dragging', () => {
+	expect(SELECTION_ENABLED).toBe(true);
 });
 
 test('pasting effects is blocked for sequences that do not support effects', () => {
@@ -207,6 +237,106 @@ test('pasting effects treats effect selections on one sequence as one target', (
 		type: 'valid',
 		nodePathInfo: firstEffectNodePathInfo,
 	} satisfies PasteEffectsTarget);
+});
+
+test('Timeline keyframe drag applies the same delta to selected keyframes', () => {
+	const schema = {
+		opacity: {type: 'number', default: 0, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const nodePathInfo = makeNodePathInfo(['body', 0], ['controls', 'opacity']);
+	const targets = getTimelineKeyframeMoveTargets({
+		draggedNodePathInfo: nodePathInfo,
+		draggedFrame: 10,
+		selectedItems: [
+			{type: 'keyframe', nodePathInfo, frame: 10},
+			{type: 'keyframe', nodePathInfo, frame: 20},
+		],
+		sequences: [makeTimelineSequence({schema})],
+		overrideIdsToNodePaths: {
+			override: nodePathInfo.sequenceSubscriptionKey,
+		},
+		codeValues: makeKeyframeCodeValues({
+			nodePath: nodePathInfo.sequenceSubscriptionKey,
+			fieldKey: 'opacity',
+			frames: [10, 20],
+		}),
+	});
+	const changes = getTimelineKeyframeMoveChanges({
+		targets: targets ?? [],
+		deltaFrames: 5,
+		durationInFrames: 100,
+	});
+
+	expect(changes?.sequenceKeyframes.map((change) => change.fromFrame)).toEqual([
+		10, 20,
+	]);
+	expect(changes?.sequenceKeyframes.map((change) => change.toFrame)).toEqual([
+		15, 25,
+	]);
+	expect(changes?.appliedDeltaFrames).toBe(5);
+});
+
+test('Timeline keyframe drag clamps the shared delta to the composition bounds', () => {
+	const schema = {
+		opacity: {type: 'number', default: 0, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const nodePathInfo = makeNodePathInfo(['body', 0], ['controls', 'opacity']);
+	const targets = getTimelineKeyframeMoveTargets({
+		draggedNodePathInfo: nodePathInfo,
+		draggedFrame: 2,
+		selectedItems: [
+			{type: 'keyframe', nodePathInfo, frame: 2},
+			{type: 'keyframe', nodePathInfo, frame: 98},
+		],
+		sequences: [makeTimelineSequence({schema})],
+		overrideIdsToNodePaths: {
+			override: nodePathInfo.sequenceSubscriptionKey,
+		},
+		codeValues: makeKeyframeCodeValues({
+			nodePath: nodePathInfo.sequenceSubscriptionKey,
+			fieldKey: 'opacity',
+			frames: [2, 98],
+		}),
+	});
+	const changes = getTimelineKeyframeMoveChanges({
+		targets: targets ?? [],
+		deltaFrames: -10,
+		durationInFrames: 100,
+	});
+
+	expect(changes?.sequenceKeyframes.map((change) => change.toFrame)).toEqual([
+		0, 96,
+	]);
+	expect(changes?.appliedDeltaFrames).toBe(-2);
+});
+
+test('Timeline keyframe drag blocks collisions with unmoved keyframes', () => {
+	const schema = {
+		opacity: {type: 'number', default: 0, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const nodePathInfo = makeNodePathInfo(['body', 0], ['controls', 'opacity']);
+	const targets = getTimelineKeyframeMoveTargets({
+		draggedNodePathInfo: nodePathInfo,
+		draggedFrame: 10,
+		selectedItems: [{type: 'keyframe', nodePathInfo, frame: 10}],
+		sequences: [makeTimelineSequence({schema})],
+		overrideIdsToNodePaths: {
+			override: nodePathInfo.sequenceSubscriptionKey,
+		},
+		codeValues: makeKeyframeCodeValues({
+			nodePath: nodePathInfo.sequenceSubscriptionKey,
+			fieldKey: 'opacity',
+			frames: [10, 20],
+		}),
+	});
+
+	expect(
+		getTimelineKeyframeMoveChanges({
+			targets: targets ?? [],
+			deltaFrames: 10,
+			durationInFrames: 100,
+		}),
+	).toBe(null);
 });
 
 test('copying a keyframed effect creates a structured snapshot', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #7777

## Walkthrough
<a href="https://cursor.com/agents/bc-e9beca20-e380-451e-814b-d9a519824ab9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkeyframe_timeline_drag_demo.mp4"><img src="https://cursor.com/artifacts/c/art-5732a8a4-2658-4fdb-a89a-e2255b032ed5" alt="keyframe_timeline_drag_demo.mp4" /></a>

## Summary
- Enable timeline keyframe selection and drag interactions in Studio.
- Add batch keyframe move API, optimistic updates, and codemod support for sequence and effect keyframes.
- Cover multi-selected keyframe deltas, bounds clamping, collisions, optimistic updates, and AST rewrites with tests.

## Testing
- `bun test src/test/timeline-selection.test.ts`
- `bun test src/test/optimistic-move-keyframe.test.ts`
- `bun test src/test/update-keyframes.test.ts`
- `bun run formatting`
- `bun run build`
- `bunx turbo run lint --filter=@remotion/studio --filter=@remotion/studio-shared --filter=@remotion/studio-server`
- `bunx turbo run lint --filter=@remotion/studio`
- Manual Studio walkthrough in `keyframed-props-test` (see video).

## Notes
- `bun run stylecheck` still hits the existing `@remotion/lambda-go` Go version caveat documented in AGENTS.md (VM has Go 1.22.2; package requires Go >= 1.23.0).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9beca20-e380-451e-814b-d9a519824ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9beca20-e380-451e-814b-d9a519824ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

