### PR TITLE
`@remotion/media`, `remotion`: Forward native props from media Video components

### DIFF
--- a/packages/core/src/test/offthread-video.test.tsx
+++ b/packages/core/src/test/offthread-video.test.tsx
@@ -1,5 +1,5 @@
 import {afterEach, describe, expect, test} from 'bun:test';
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import type React from 'react';
 import {SharedAudioContextProvider} from '../audio/shared-audio-tags.js';
 import {RemotionEnvironmentContext} from '../remotion-environment-context.js';
@@ -196,6 +196,37 @@ describe('OffthreadVideo render correctly with props', () => {
 		);
 
 		expect(container.querySelector('video')?.preservesPitch).toBe(false);
+	});
+
+	test('It should forward native props on OffthreadVideo', () => {
+		let clicks = 0;
+
+		const {container} = render(
+			<WrapPreviewContext>
+				<OffthreadVideo
+					aria-label="Video preview"
+					data-testid="offthread-video"
+					onClick={() => {
+						clicks++;
+					}}
+					role="img"
+					src="https://example.com/test.mp4"
+					tabIndex={0}
+					title="Preview video"
+				/>
+			</WrapPreviewContext>,
+		);
+
+		const video = container.querySelector('video');
+
+		expect(video?.getAttribute('aria-label')).toBe('Video preview');
+		expect(video?.getAttribute('data-testid')).toBe('offthread-video');
+		expect(video?.getAttribute('role')).toBe('img');
+		expect(video?.getAttribute('tabindex')).toBe('0');
+		expect(video?.getAttribute('title')).toBe('Preview video');
+
+		fireEvent.click(video as HTMLVideoElement);
+		expect(clicks).toBe(1);
 	});
 
 	test('It should reject invalid preservePitch values on OffthreadVideo', () => {

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -139,11 +139,9 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 	acceptableTimeShiftInSeconds,
 	allowAmplificationDuringRender,
 	audioStreamIndex,
-	className,
 	crossOrigin,
 	delayRenderRetries,
 	delayRenderTimeoutInMilliseconds,
-	id,
 	loopVolumeCurveBehavior,
 	muted,
 	name,
@@ -180,11 +178,9 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 			acceptableTimeShiftInSeconds={acceptableTimeShiftInSeconds}
 			allowAmplificationDuringRender={allowAmplificationDuringRender ?? true}
 			audioStreamIndex={audioStreamIndex ?? 0}
-			className={className}
 			crossOrigin={crossOrigin}
 			delayRenderRetries={delayRenderRetries}
 			delayRenderTimeoutInMilliseconds={delayRenderTimeoutInMilliseconds}
-			id={id}
 			loopVolumeCurveBehavior={loopVolumeCurveBehavior ?? 'repeat'}
 			muted={muted ?? false}
 			name={name}

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -167,6 +167,7 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 	stack,
 	startFrom,
 	imageFormat,
+	...props
 }) => {
 	if (imageFormat) {
 		throw new TypeError(
@@ -209,6 +210,7 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 			trimBefore={trimBefore}
 			useWebAudioApi={useWebAudioApi ?? false}
 			volume={volume}
+			{...props}
 		/>
 	);
 };

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -72,9 +72,7 @@ type MandatoryOffthreadVideoProps = {
 };
 
 type OptionalOffthreadVideoProps = {
-	className: string | undefined;
 	name: string | undefined;
-	id: string | undefined;
 	style: React.CSSProperties | undefined;
 	volume: VolumeProp | undefined;
 	playbackRate: number;

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -102,14 +102,26 @@ type OptionalOffthreadVideoProps = {
 	audioStreamIndex: number;
 };
 
+type NativeOffthreadVideoProps = Omit<
+	React.HTMLAttributes<HTMLElement>,
+	| keyof MandatoryOffthreadVideoProps
+	| keyof OptionalOffthreadVideoProps
+	| keyof CommonVideoProps
+	| keyof DeprecatedOffthreadVideoProps
+	| 'onError'
+> &
+	Record<`data-${string}`, string | undefined>;
+
 export type AllOffthreadVideoProps = MandatoryOffthreadVideoProps &
 	OptionalOffthreadVideoProps &
-	CommonVideoProps;
+	CommonVideoProps &
+	NativeOffthreadVideoProps;
 
 export type RemotionOffthreadVideoProps = MandatoryOffthreadVideoProps &
 	Partial<OptionalOffthreadVideoProps> &
 	Partial<CommonVideoProps> &
-	Partial<DeprecatedOffthreadVideoProps>;
+	Partial<DeprecatedOffthreadVideoProps> &
+	NativeOffthreadVideoProps;
 
 export type OnVideoFrame = (
 	frame: CanvasImageSource,

--- a/packages/media/src/video/props.ts
+++ b/packages/media/src/video/props.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import type {
 	EffectDefinitionAndStack,
 	EffectsProp,
@@ -79,13 +80,24 @@ type OptionalVideoProps = {
 	effects: EffectsProp;
 };
 
+export type NativeVideoProps = Omit<
+	React.HTMLAttributes<HTMLElement>,
+	| keyof MandatoryVideoProps
+	| keyof OuterVideoProps
+	| keyof OptionalVideoProps
+	| 'onError'
+> &
+	Record<`data-${string}`, string | undefined>;
+
 export type InnerVideoProps = MandatoryVideoProps &
 	OuterVideoProps &
-	Omit<OptionalVideoProps, 'effects'> & {
+	Omit<OptionalVideoProps, 'effects'> &
+	NativeVideoProps & {
 		effects: EffectDefinitionAndStack<unknown>[];
 	};
 
 export type VideoProps = MandatoryVideoProps &
 	Partial<OuterVideoProps> &
 	Partial<OptionalVideoProps> &
+	NativeVideoProps &
 	Pick<SequenceProps, 'durationInFrames' | 'from' | 'name' | 'hidden'>;

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -26,7 +26,11 @@ import {MediaPlayer} from '../media-player';
 import {type MediaOnError, callOnErrorAndResolve} from '../on-error';
 import type {MediaRequestInit} from '../request-init';
 import {useCommonEffects} from '../use-common-effects';
-import type {FallbackOffthreadVideoProps, VideoObjectFit} from './props';
+import type {
+	FallbackOffthreadVideoProps,
+	NativeVideoProps,
+	VideoObjectFit,
+} from './props';
 import {cacheVideoFrame, getCachedVideoFrame} from './video-frame-cache';
 import {warnAboutObjectFitInStyleOrClassName} from './warn-object-fit-css';
 
@@ -44,7 +48,7 @@ const {
 	useEffectChainState,
 } = Internals;
 
-type VideoForPreviewProps = {
+type VideoForPreviewProps = NativeVideoProps & {
 	readonly src: string;
 	readonly style: React.CSSProperties | undefined;
 	readonly playbackRate: number;
@@ -106,6 +110,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 	effects,
 	setMediaDurationInSeconds,
 	refForOutline,
+	...props
 }) => {
 	const src = usePreload(unpreloadedSrc);
 
@@ -514,6 +519,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 		// not using <OffthreadVideo> because it does not support looping
 		return (
 			<Html5Video
+				{...props}
 				ref={fallbackVideoRef}
 				src={src}
 				style={actualStyle}
@@ -539,6 +545,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 
 	return (
 		<canvas
+			{...props}
 			ref={canvasRefCallback}
 			// Don't set width and height here.
 			// Width is set in the video iterator manager, if props are being updated, they are being applied again by React.

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -28,10 +28,14 @@ import {frameForVolumeProp} from '../looped-frame';
 import {type MediaOnError, callOnErrorAndResolve} from '../on-error';
 import type {MediaRequestInit} from '../request-init';
 import {extractFrameViaBroadcastChannel} from '../video-extraction/extract-frame-via-broadcast-channel';
-import type {FallbackOffthreadVideoProps, VideoObjectFit} from './props';
+import type {
+	FallbackOffthreadVideoProps,
+	NativeVideoProps,
+	VideoObjectFit,
+} from './props';
 import {warnAboutObjectFitInStyleOrClassName} from './warn-object-fit-css';
 
-type InnerVideoProps = {
+type InnerVideoProps = NativeVideoProps & {
 	readonly className: string | undefined;
 	readonly loop: boolean;
 	readonly src: string;
@@ -89,6 +93,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 	requestInit,
 	objectFit: objectFitProp,
 	effects,
+	...props
 }) => {
 	if (!src) {
 		throw new TypeError('No `src` was passed to <Video>.');
@@ -441,6 +446,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 	if (replaceWithOffthreadVideo) {
 		const fallback = (
 			<Internals.InnerOffthreadVideo
+				{...props}
 				src={src}
 				playbackRate={playbackRate ?? 1}
 				muted={muted ?? false}
@@ -518,6 +524,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 
 	return (
 		<canvas
+			{...props}
 			ref={canvasRef}
 			style={styleWithObjectFit}
 			className={classNameValue}

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -81,6 +81,7 @@ const InnerVideo: React.FC<
 	effects,
 	setMediaDurationInSeconds,
 	refForOutline,
+	...props
 }) => {
 	const environment = useRemotionEnvironment();
 
@@ -111,6 +112,7 @@ const InnerVideo: React.FC<
 	if (environment.isRendering) {
 		return (
 			<VideoForRendering
+				{...props}
 				audioStreamIndex={audioStreamIndex ?? 0}
 				className={className}
 				delayRenderRetries={delayRenderRetries ?? null}
@@ -146,6 +148,7 @@ const InnerVideo: React.FC<
 
 	return (
 		<VideoForPreview
+			{...props}
 			setMediaDurationInSeconds={setMediaDurationInSeconds}
 			audioStreamIndex={audioStreamIndex ?? 0}
 			className={className}
@@ -218,6 +221,7 @@ const VideoInner: React.FC<
 	durationInFrames,
 	from,
 	hidden,
+	...props
 }) => {
 	const fallbackLogLevel = Internals.useLogLevel();
 	const [mediaVolume] = Internals.useMediaVolumeState();
@@ -311,6 +315,7 @@ const VideoInner: React.FC<
 			hidden={hidden}
 		>
 			<InnerVideo
+				{...props}
 				audioStreamIndex={audioStreamIndex ?? 0}
 				className={className}
 				delayRenderRetries={delayRenderRetries ?? null}


### PR DESCRIPTION
## Summary
- Forward common native HTML attributes from `@remotion/media` `<Video>` through preview, render, canvas, and fallback paths.
- Forward the same common attributes from `<OffthreadVideo>` while keeping the render-time prop type compatible with its image-backed implementation.
- Add coverage that `<OffthreadVideo>` preserves ARIA, `data-*`, role, tabIndex, title, and click handlers.

## Test plan
- `cd packages/core && bun test src/test/offthread-video.test.tsx`
- `cd packages/core && bun run formatting && bun run lint && bun run make`
- `cd packages/media && bun run formatting && bun run lint && bun run make`

Lint passes with existing warnings in untouched files.

Made with [Cursor](https://cursor.com)