### PR TITLE
Internals: Require stylecheck in PR skill

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -14,11 +14,11 @@ Then run
 
 ```
 bun run build
-bun run formatting
+bun run stylecheck
 
 ```
 
-to ensure we compile.
+to ensure we compile and CI linting/formatting passes.
 
 Commit the changes. The title of the PR must be according to the [`pr-name`](../pr-name/SKILL.md) skill.
 


### PR DESCRIPTION
## Summary

- Update the `/pr` skill to require `bun run stylecheck` instead of only `bun run formatting` so lint failures are caught before opening PRs.
