### PR TITLE
`remotion`: Add `pixelDensity` prop to `<Solid>`

### DIFF
--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -38,6 +38,25 @@ type OptionalProps = {
 	readonly effects: EffectsProp;
 	readonly className: string | undefined;
 	readonly style: React.CSSProperties | undefined;
+	readonly pixelDensity: number | undefined;
+};
+
+const resolveSolidPixelDensity = (pixelDensity: number | undefined): number => {
+	if (pixelDensity === undefined) {
+		return 1;
+	}
+
+	if (
+		typeof pixelDensity !== 'number' ||
+		!Number.isFinite(pixelDensity) ||
+		pixelDensity <= 0
+	) {
+		throw new Error(
+			`<Solid>: \`pixelDensity\` must be a positive finite number. Received: ${String(pixelDensity)}.`,
+		);
+	}
+
+	return pixelDensity;
 };
 
 type InnerSolidProps = MandatoryProps &
@@ -86,10 +105,15 @@ const SolidInner: React.FC<
 	effects = [],
 	className,
 	style,
+	pixelDensity,
 	overrideId,
 	reference,
 }) => {
 	const {delayRender, continueRender, cancelRender} = useDelayRender();
+
+	const resolvedPixelDensity = resolveSolidPixelDensity(pixelDensity);
+	const canvasWidth = Math.ceil(width * resolvedPixelDensity);
+	const canvasHeight = Math.ceil(height * resolvedPixelDensity);
 
 	const [outputCanvas, setOutputCanvas] = useState<HTMLCanvasElement | null>(
 		null,
@@ -156,12 +180,12 @@ const SolidInner: React.FC<
 		}
 
 		runEffectChain({
-			state: chainState.get(width, height)!,
+			state: chainState.get(canvasWidth, canvasHeight)!,
 			source: sourceCanvas,
 			effects: memoizedEffects,
 			output: outputCanvas,
-			width,
-			height,
+			width: canvasWidth,
+			height: canvasHeight,
 		})
 			.then((completed) => {
 				if (completed) {
@@ -180,21 +204,29 @@ const SolidInner: React.FC<
 		outputCanvas,
 		sourceCanvas,
 		chainState,
-		width,
-		height,
+		canvasWidth,
+		canvasHeight,
 		delayRender,
 		continueRender,
 		cancelRender,
 		memoizedEffects,
 	]);
 
+	const canvasStyle = useMemo(() => {
+		return {
+			width,
+			height,
+			...(style ?? {}),
+		};
+	}, [height, style, width]);
+
 	return (
 		<canvas
 			ref={canvasRef}
-			width={width}
-			height={height}
+			width={canvasWidth}
+			height={canvasHeight}
 			className={className}
-			style={style}
+			style={canvasStyle}
 		/>
 	);
 };
@@ -222,6 +254,7 @@ const SolidOuter = forwardRef<
 			from,
 			hidden,
 			showInTimeline,
+			pixelDensity,
 			...props
 		},
 		ref,
@@ -261,6 +294,7 @@ const SolidOuter = forwardRef<
 					className={className}
 					style={style}
 					effects={effects}
+					pixelDensity={pixelDensity}
 				/>
 			</Sequence>
 		);

--- a/packages/core/src/test/solid.test.tsx
+++ b/packages/core/src/test/solid.test.tsx
@@ -88,3 +88,39 @@ test('<Solid> accepts an empty effects array', () => {
 
 	expect(container.querySelector('canvas')).not.toBeNull();
 });
+
+test('<Solid> scales the backing canvas by pixelDensity while keeping logical CSS size', () => {
+	const {container} = render(
+		<WrapSequenceContext>
+			<Solid color="red" width={120} height={80} pixelDensity={2} />
+		</WrapSequenceContext>,
+	);
+
+	const canvas = container.querySelector('canvas');
+	expect(canvas?.getAttribute('width')).toBe('240');
+	expect(canvas?.getAttribute('height')).toBe('160');
+	expect(canvas?.style.width).toBe('120px');
+	expect(canvas?.style.height).toBe('80px');
+});
+
+test('<Solid> rounds up the backing canvas for fractional pixelDensity', () => {
+	const {container} = render(
+		<WrapSequenceContext>
+			<Solid color="red" width={101} height={50} pixelDensity={1.5} />
+		</WrapSequenceContext>,
+	);
+
+	const canvas = container.querySelector('canvas');
+	expect(canvas?.getAttribute('width')).toBe('152');
+	expect(canvas?.getAttribute('height')).toBe('75');
+});
+
+test('<Solid> throws for an invalid pixelDensity', () => {
+	expect(() =>
+		render(
+			<WrapSequenceContext>
+				<Solid color="red" width={120} height={80} pixelDensity={0} />
+			</WrapSequenceContext>,
+		),
+	).toThrow(/`pixelDensity` must be a positive finite number/);
+});

--- a/packages/docs/docs/remotion/html-in-canvas.mdx
+++ b/packages/docs/docs/remotion/html-in-canvas.mdx
@@ -78,7 +78,8 @@ _number_
 
 Controls the backing bitmap density. Default: `1`.
 
-Set a higher value to paint to a higher-resolution backing canvas while keeping the logical canvas size unchanged.
+Set a higher value to paint to a higher-resolution backing canvas while keeping the logical canvas size unchanged.  
+This is useful to counteract quality loss when the canvas is scaled up – for example via the [`scale`](/docs/scaling) render option. Pass [`usePixelDensity()`](/docs/use-pixel-density) to match the render scale.
 
 ### `children`
 

--- a/packages/docs/docs/remotion/html-in-canvas.mdx
+++ b/packages/docs/docs/remotion/html-in-canvas.mdx
@@ -79,7 +79,7 @@ _number_
 Controls the backing bitmap density. Default: `1`.
 
 Set a higher value to paint to a higher-resolution backing canvas while keeping the logical canvas size unchanged.  
-This is useful to counteract quality loss when the canvas is scaled up – for example via the [`scale`](/docs/scaling) render option. Pass [`usePixelDensity()`](/docs/use-pixel-density) to match the render scale.
+This is useful to counteract quality loss when the canvas is scaled up – for example via the [`scale`](/docs/scaling) render option, or on a high-DPI display in the preview. Pass [`usePixelDensity()`](/docs/use-pixel-density) to use the render `scale` while rendering and `window.devicePixelRatio` while previewing.
 
 ### `children`
 

--- a/packages/docs/docs/scaling.mdx
+++ b/packages/docs/docs/scaling.mdx
@@ -50,13 +50,15 @@ Elements that can be upscaled and that will enhance increased resolution are:
 - SVG elements
 - Images (if their resolution is sufficient to display in a higher resolution)
 
-Canvas and WebGL elements cannot be upscaled automatically, since their backing bitmap resolution is fixed and device-independent by design (so preview and render look the same).  
-You can however opt into a higher backing resolution for the following components by passing a `pixelDensity` prop. Combine it with [`usePixelDensity()`](/docs/use-pixel-density) to match the render `scale`:
+Canvas and WebGL elements cannot be upscaled automatically, since their backing bitmap resolution is fixed by design.  
+You can however opt into a higher backing resolution for the following components by passing a `pixelDensity` prop:
 
 - [`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) – [`pixelDensity`](/docs/remotion/html-in-canvas#pixeldensity)
 - [`<Solid>`](/docs/solid) – [`pixelDensity`](/docs/solid#pixeldensity)
 
-```tsx twoslash title="Matching the render scale"
+To support the `scale` option during a render, pass [`usePixelDensity()`](/docs/use-pixel-density), which resolves to the render `scale`:
+
+```tsx twoslash title="Supporting scale in the render"
 import {AbsoluteFill, Solid, usePixelDensity} from 'remotion';
 
 export const MyComp: React.FC = () => {

--- a/packages/docs/docs/scaling.mdx
+++ b/packages/docs/docs/scaling.mdx
@@ -50,7 +50,25 @@ Elements that can be upscaled and that will enhance increased resolution are:
 - SVG elements
 - Images (if their resolution is sufficient to display in a higher resolution)
 
+Canvas and WebGL elements cannot be upscaled automatically, since their backing bitmap resolution is fixed and device-independent by design (so preview and render look the same).  
+You can however opt into a higher backing resolution for the following components by passing a `pixelDensity` prop. Combine it with [`usePixelDensity()`](/docs/use-pixel-density) to match the render `scale`:
+
+- [`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) – [`pixelDensity`](/docs/remotion/html-in-canvas#pixeldensity)
+- [`<Solid>`](/docs/solid) – [`pixelDensity`](/docs/solid#pixeldensity)
+
+```tsx twoslash title="Matching the render scale"
+import {AbsoluteFill, Solid, usePixelDensity} from 'remotion';
+
+export const MyComp: React.FC = () => {
+  const pixelDensity = usePixelDensity();
+  return (
+    <AbsoluteFill>
+      <Solid color="#3344ff" width={1920} height={1080} pixelDensity={pixelDensity} />
+    </AbsoluteFill>
+  );
+};
+```
+
 Elements that **cannot** be upscaled for increased resolution are:
 
 - Videos
-- Canvas and WebGL elements

--- a/packages/docs/docs/solid.mdx
+++ b/packages/docs/docs/solid.mdx
@@ -43,7 +43,7 @@ _number_
 Controls the backing bitmap density. Default: `1`.
 
 Set a higher value to paint to a higher-resolution backing canvas while keeping the logical canvas size unchanged.  
-This is useful to counteract quality loss when the `<Solid>` is scaled up – for example via the [`scale`](/docs/scaling) render option. Pass [`usePixelDensity()`](/docs/use-pixel-density) to match the render scale:
+This is useful to counteract quality loss when the `<Solid>` is scaled up – for example via the [`scale`](/docs/scaling) render option, or on a high-DPI display in the preview. Pass [`usePixelDensity()`](/docs/use-pixel-density) to use the render `scale` while rendering and `window.devicePixelRatio` while previewing:
 
 ```tsx twoslash title="MyComp.tsx"
 import {AbsoluteFill, Solid, usePixelDensity} from 'remotion';

--- a/packages/docs/docs/solid.mdx
+++ b/packages/docs/docs/solid.mdx
@@ -25,16 +25,38 @@ export const MyComp: React.FC = () => {
 
 ### `width`
 
-Width of the canvas in pixels. Must be a positive integer.
+Logical width of the canvas in pixels. Must be a positive integer.
 
 ### `height`
 
-Height of the canvas in pixels. Must be a positive integer.
+Logical height of the canvas in pixels. Must be a positive integer.
 
 ### `color?`
 
 Fill color of the rectangle.  
 If omitted, it is `transparent`.
+
+### `pixelDensity?`<AvailableFrom v="4.0.472" />
+
+_number_
+
+Controls the backing bitmap density. Default: `1`.
+
+Set a higher value to paint to a higher-resolution backing canvas while keeping the logical canvas size unchanged.  
+This is useful to counteract quality loss when the `<Solid>` is scaled up – for example via the [`scale`](/docs/scaling) render option. Pass [`usePixelDensity()`](/docs/use-pixel-density) to match the render scale:
+
+```tsx twoslash title="MyComp.tsx"
+import {AbsoluteFill, Solid, usePixelDensity} from 'remotion';
+
+export const MyComp: React.FC = () => {
+  const pixelDensity = usePixelDensity();
+  return (
+    <AbsoluteFill>
+      <Solid color="#3344ff" width={1920} height={1080} pixelDensity={pixelDensity} />
+    </AbsoluteFill>
+  );
+};
+```
 
 ### `className?`
 
@@ -76,3 +98,5 @@ Effects are an upcoming feature of Remotion - if you are here, you are early!
 
 - [Source code for this component](https://github.com/remotion-dev/remotion/blob/main/packages/core/src/effects/Solid.tsx)
 - [`<AbsoluteFill>`](/docs/absolute-fill)
+- [Output scaling](/docs/scaling)
+- [`usePixelDensity()`](/docs/use-pixel-density)


### PR DESCRIPTION
Adds a `pixelDensity` prop to `<Solid>`, mirroring the prop added to [`<HtmlInCanvas>`](https://github.com/remotion-dev/remotion/pull/8088).

Closes #8091.

## What it does

`pixelDensity` controls the backing bitmap resolution of the `<Solid>` canvas:

- The backing canvas dimensions become `ceil(width * pixelDensity)` × `ceil(height * pixelDensity)`.
- The logical (CSS) display size stays `width` × `height`, so preview/layout and selection outlines are unchanged.
- The effect chain runs at the scaled resolution.

This counteracts quality loss when scaling the canvas up (e.g. via the render `scale` option). Combine it with [`usePixelDensity()`](https://www.remotion.dev/docs/use-pixel-density) to match the render scale:

```tsx
const pixelDensity = usePixelDensity();

<Solid color="#3344ff" width={1920} height={1080} pixelDensity={pixelDensity} />
```

Invalid values (non-positive, non-finite) throw an explicit error. Default is `1`.

## Docs (#8093)

- Documented `pixelDensity` on the `<Solid>` page.
- Updated [Output scaling](https://www.remotion.dev/docs/scaling#scalable-elements) to list `<Solid>` and `<HtmlInCanvas>` as opt-in scalable elements and cross-referenced the new props.
- Cross-referenced `<HtmlInCanvas>`' `pixelDensity` to scaling / `usePixelDensity()`.

## `ENABLE_OUTLINES` / uv-coordinate

No changes needed:

- Selection outlines use the canvas' DOM layout box, which stays at the logical CSS size, so they remain correct.
- uv-coordinate effect fields are normalized (0–1), so they are resolution-independent.

## Tests

Added tests covering the scaled backing size, fractional rounding, preserved logical CSS size, and validation errors.
