### PR TITLE
`@remotion/studio`: Fix keyframed timeline prop reset

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -387,10 +387,15 @@ export const TimelineEffectPropItem: React.FC<{
 		previewServerState.type === 'connected' &&
 		propStatus !== null &&
 		propStatus.status !== 'computed';
-	const canShowReset = canPerformReset && canResetToDefault;
+	const canShowReset =
+		canPerformReset && field.fieldSchema.default !== undefined;
 
 	const onReset = useCallback(() => {
-		if (!canShowReset || previewServerState.type !== 'connected') {
+		if (
+			!canShowReset ||
+			!canResetToDefault ||
+			previewServerState.type !== 'connected'
+		) {
 			return;
 		}
 
@@ -411,6 +416,7 @@ export const TimelineEffectPropItem: React.FC<{
 			clientId: previewServerState.clientId,
 		});
 	}, [
+		canResetToDefault,
 		canShowReset,
 		field.effectIndex,
 		field.effectSchema,

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -41,6 +41,29 @@ const isKeyframedStatus = (
 	return status.status === 'keyframed';
 };
 
+const isResettableStatus = ({
+	status,
+	defaultValue,
+}: {
+	readonly status: CanUpdateSequencePropStatus;
+	readonly defaultValue: unknown;
+}) => {
+	if (defaultValue === undefined) {
+		return false;
+	}
+
+	if (status.status === 'keyframed') {
+		return true;
+	}
+
+	if (status.status === 'computed') {
+		return false;
+	}
+
+	const effectiveCodeValue = status.codeValue ?? defaultValue;
+	return JSON.stringify(effectiveCodeValue) !== JSON.stringify(defaultValue);
+};
+
 const Value: React.FC<{
 	readonly field: EffectSchemaFieldInfo;
 	readonly nodePath: SequencePropsSubscriptionKey;
@@ -349,17 +372,15 @@ export const TimelineEffectPropItem: React.FC<{
 			/>
 		) : null;
 
-	const isNonDefault = useMemo(() => {
+	const canResetToDefault = useMemo(() => {
 		if (!propStatus || propStatus.status === 'computed') {
 			return false;
 		}
 
-		const effectiveCodeValue =
-			propStatus.codeValue ?? field.fieldSchema.default;
-		return (
-			JSON.stringify(effectiveCodeValue) !==
-			JSON.stringify(field.fieldSchema.default)
-		);
+		return isResettableStatus({
+			status: propStatus,
+			defaultValue: field.fieldSchema.default,
+		});
 	}, [field.fieldSchema.default, propStatus]);
 
 	const canPerformReset =
@@ -371,7 +392,7 @@ export const TimelineEffectPropItem: React.FC<{
 		if (
 			!canPerformReset ||
 			previewServerState.type !== 'connected' ||
-			!isNonDefault
+			!canResetToDefault
 		) {
 			return;
 		}
@@ -394,11 +415,11 @@ export const TimelineEffectPropItem: React.FC<{
 		});
 	}, [
 		canPerformReset,
+		canResetToDefault,
 		field.effectIndex,
 		field.effectSchema,
 		field.fieldSchema.default,
 		field.key,
-		isNonDefault,
 		nodePath,
 		previewServerState,
 		setCodeValues,

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -387,13 +387,10 @@ export const TimelineEffectPropItem: React.FC<{
 		previewServerState.type === 'connected' &&
 		propStatus !== null &&
 		propStatus.status !== 'computed';
+	const canShowReset = canPerformReset && canResetToDefault;
 
 	const onReset = useCallback(() => {
-		if (
-			!canPerformReset ||
-			previewServerState.type !== 'connected' ||
-			!canResetToDefault
-		) {
+		if (!canShowReset || previewServerState.type !== 'connected') {
 			return;
 		}
 
@@ -414,8 +411,7 @@ export const TimelineEffectPropItem: React.FC<{
 			clientId: previewServerState.clientId,
 		});
 	}, [
-		canPerformReset,
-		canResetToDefault,
+		canShowReset,
 		field.effectIndex,
 		field.effectSchema,
 		field.fieldSchema.default,
@@ -434,14 +430,14 @@ export const TimelineEffectPropItem: React.FC<{
 				keyHint: null,
 				label: 'Reset',
 				leftItem: null,
-				disabled: !canPerformReset,
+				disabled: !canShowReset,
 				onClick: onReset,
 				quickSwitcherLabel: null,
 				subMenu: null,
 				value: 'reset-effect-field',
 			},
 		];
-	}, [canPerformReset, onReset]);
+	}, [canShowReset, onReset]);
 
 	const row = (
 		<TimelineRowChrome

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -267,13 +267,13 @@ export const TimelineSequencePropItem: React.FC<{
 		previewServerState.type === 'connected' &&
 		codeValue !== null &&
 		codeValue.status !== 'computed';
+	const canShowReset = canPerformReset && canResetToDefault;
 
 	const onReset = useCallback(() => {
 		if (
-			!canPerformReset ||
+			!canShowReset ||
 			previewServerState.type !== 'connected' ||
-			codeValue === null ||
-			!canResetToDefault
+			codeValue === null
 		) {
 			return;
 		}
@@ -294,8 +294,7 @@ export const TimelineSequencePropItem: React.FC<{
 			clientId: previewServerState.clientId,
 		});
 	}, [
-		canPerformReset,
-		canResetToDefault,
+		canShowReset,
 		field.fieldSchema.default,
 		field.key,
 		nodePath,
@@ -353,14 +352,14 @@ export const TimelineSequencePropItem: React.FC<{
 				keyHint: null,
 				label: 'Reset',
 				leftItem: null,
-				disabled: !canPerformReset,
+				disabled: !canShowReset,
 				onClick: onReset,
 				quickSwitcherLabel: null,
 				subMenu: null,
 				value: 'reset-sequence-field',
 			},
 		];
-	}, [canPerformReset, onReset]);
+	}, [canShowReset, onReset]);
 
 	if (codeValue === null) {
 		return null;

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -267,11 +267,13 @@ export const TimelineSequencePropItem: React.FC<{
 		previewServerState.type === 'connected' &&
 		codeValue !== null &&
 		codeValue.status !== 'computed';
-	const canShowReset = canPerformReset && canResetToDefault;
+	const canShowReset =
+		canPerformReset && field.fieldSchema.default !== undefined;
 
 	const onReset = useCallback(() => {
 		if (
 			!canShowReset ||
+			!canResetToDefault ||
 			previewServerState.type !== 'connected' ||
 			codeValue === null
 		) {
@@ -294,6 +296,7 @@ export const TimelineSequencePropItem: React.FC<{
 			clientId: previewServerState.clientId,
 		});
 	}, [
+		canResetToDefault,
 		canShowReset,
 		field.fieldSchema.default,
 		field.key,

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -44,6 +44,29 @@ const isKeyframedStatus = (
 	return status.status === 'keyframed';
 };
 
+const isResettableStatus = ({
+	status,
+	defaultValue,
+}: {
+	readonly status: CanUpdateSequencePropStatus;
+	readonly defaultValue: unknown;
+}) => {
+	if (defaultValue === undefined) {
+		return false;
+	}
+
+	if (status.status === 'keyframed') {
+		return true;
+	}
+
+	if (status.status === 'computed') {
+		return false;
+	}
+
+	const effectiveCodeValue = status.codeValue ?? defaultValue;
+	return JSON.stringify(effectiveCodeValue) !== JSON.stringify(defaultValue);
+};
+
 const Value: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly nodePath: SequencePropsSubscriptionKey;
@@ -229,16 +252,15 @@ export const TimelineSequencePropItem: React.FC<{
 		};
 	}, [field.rowHeight]);
 
-	const isNonDefault = useMemo(() => {
+	const canResetToDefault = useMemo(() => {
 		if (!codeValue || codeValue.status === 'computed') {
 			return false;
 		}
 
-		const effectiveCodeValue = codeValue.codeValue ?? field.fieldSchema.default;
-		return (
-			JSON.stringify(effectiveCodeValue) !==
-			JSON.stringify(field.fieldSchema.default)
-		);
+		return isResettableStatus({
+			status: codeValue,
+			defaultValue: field.fieldSchema.default,
+		});
 	}, [codeValue, field.fieldSchema.default]);
 
 	const canPerformReset =
@@ -251,7 +273,7 @@ export const TimelineSequencePropItem: React.FC<{
 			!canPerformReset ||
 			previewServerState.type !== 'connected' ||
 			codeValue === null ||
-			!isNonDefault
+			!canResetToDefault
 		) {
 			return;
 		}
@@ -273,9 +295,9 @@ export const TimelineSequencePropItem: React.FC<{
 		});
 	}, [
 		canPerformReset,
+		canResetToDefault,
 		field.fieldSchema.default,
 		field.key,
-		isNonDefault,
 		nodePath,
 		previewServerState,
 		schema,

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -1,4 +1,5 @@
 import type {
+	CanUpdateSequencePropStatus,
 	CodeValues,
 	OverrideIdToNodePaths,
 	SequenceFieldSchema,
@@ -58,6 +59,31 @@ const isNonDefaultCodeValue = ({
 }) =>
 	JSON.stringify(codeValue ?? defaultValue) !== JSON.stringify(defaultValue);
 
+const isResettablePropStatus = ({
+	propStatus,
+	defaultValue,
+}: {
+	readonly propStatus: CanUpdateSequencePropStatus | null | undefined;
+	readonly defaultValue: unknown;
+}) => {
+	if (!propStatus || propStatus.status === 'computed') {
+		return false;
+	}
+
+	if (defaultValue === undefined) {
+		return false;
+	}
+
+	if (propStatus.status === 'keyframed') {
+		return true;
+	}
+
+	return isNonDefaultCodeValue({
+		codeValue: propStatus.codeValue,
+		defaultValue,
+	});
+};
+
 const getDefaultValue = (
 	fieldSchema: Exclude<SequenceFieldSchema, {type: 'hidden'}>,
 ) =>
@@ -112,9 +138,8 @@ export const getTimelinePropResetTargets = ({
 			)?.[selection.key];
 			if (
 				!isVisibleFieldSchema(sequenceFieldSchema) ||
-				sequencePropStatus?.status !== 'static' ||
-				!isNonDefaultCodeValue({
-					codeValue: sequencePropStatus.codeValue,
+				!isResettablePropStatus({
+					propStatus: sequencePropStatus,
 					defaultValue: sequenceFieldSchema.default,
 				})
 			) {
@@ -147,9 +172,8 @@ export const getTimelinePropResetTargets = ({
 		if (
 			!effect ||
 			!isVisibleFieldSchema(fieldSchema) ||
-			propStatus?.status !== 'static' ||
-			!isNonDefaultCodeValue({
-				codeValue: propStatus.codeValue,
+			!isResettablePropStatus({
+				propStatus,
 				defaultValue: fieldSchema.default,
 			})
 		) {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -10,14 +10,14 @@ import {
 } from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {
-	getSelectedEffectFieldsBySequenceKey,
 	getOutlineSelectionInteraction,
-	getSequencesWithSelectableOutlines,
+	getSelectedEffectFieldsBySequenceKey,
 	getSelectedOutlineDragChanges,
 	getSelectedOutlineDragValues,
 	getSelectedOutlineScaleDragChanges,
 	getSelectedOutlineScaleDragValues,
 	getSelectedOutlineScaleEdgeInfo,
+	getSequencesWithSelectableOutlines,
 	getUvCoordinateForPoint,
 	getUvHandlePosition,
 	type SelectedOutlineDragState,
@@ -901,6 +901,108 @@ test('Backspace reset targets multiple selected sequence props', () => {
 	expect(resetTargets?.map((target) => target.value)).toEqual([1, '0deg']);
 });
 
+test('Backspace reset targets selected keyframed sequence props', () => {
+	const schema = {
+		opacity: {type: 'number', default: 1, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const opacityNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
+	const codeValues = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {
+				opacity: {
+					status: 'keyframed',
+					codeValue: undefined,
+					interpolationFunction: 'interpolate',
+					keyframes: [
+						{frame: 0, value: 0},
+						{frame: 20, value: 0.5},
+					],
+					easing: ['linear'],
+					clamping: {left: 'extend', right: 'extend'},
+					posterize: undefined,
+				},
+			},
+			effects: [],
+		},
+	} satisfies CodeValues;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-prop',
+				nodePathInfo: opacityNodePathInfo,
+				key: 'opacity',
+			},
+		],
+		sequences: [makeTimelineSequence({schema})],
+		overrideIdsToNodePaths: {override: nodePath},
+		codeValues,
+	});
+
+	expect(resetTargets).toEqual([
+		{
+			type: 'sequence-prop',
+			fileName: '/project/src/Comp.tsx',
+			nodePath,
+			fieldKey: 'opacity',
+			value: 1,
+			defaultValue: '1',
+			schema,
+		},
+	]);
+});
+
+test('Backspace reset skips keyframed sequence props without defaults', () => {
+	const schema = {
+		opacity: {type: 'number', default: undefined, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const opacityNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
+	const codeValues = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {
+				opacity: {
+					status: 'keyframed',
+					codeValue: undefined,
+					interpolationFunction: 'interpolate',
+					keyframes: [
+						{frame: 0, value: 0},
+						{frame: 20, value: 0.5},
+					],
+					easing: ['linear'],
+					clamping: {left: 'extend', right: 'extend'},
+					posterize: undefined,
+				},
+			},
+			effects: [],
+		},
+	} satisfies CodeValues;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-prop',
+				nodePathInfo: opacityNodePathInfo,
+				key: 'opacity',
+			},
+		],
+		sequences: [makeTimelineSequence({schema})],
+		overrideIdsToNodePaths: {override: nodePath},
+		codeValues,
+	});
+
+	expect(resetTargets).toEqual([]);
+});
+
 test('Selected outline dragging applies the same delta to all selected sequences', () => {
 	const schema = {
 		'style.translate': {type: 'translate', default: '0px 0px'},
@@ -1127,6 +1229,139 @@ test('Backspace reset targets selected effect props', () => {
 			schema: effectSchema,
 		},
 	]);
+});
+
+test('Backspace reset targets selected keyframed effect props', () => {
+	const schema = {} satisfies SequenceSchema;
+	const effectSchema = {
+		intensity: {type: 'number', default: 0, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'intensity'],
+	);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const codeValues = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'effect',
+					importPath: null,
+					effectIndex: 0,
+					props: {
+						intensity: {
+							status: 'keyframed',
+							codeValue: undefined,
+							interpolationFunction: 'interpolate',
+							keyframes: [
+								{frame: 0, value: 10},
+								{frame: 20, value: 20},
+							],
+							easing: ['linear'],
+							clamping: {left: 'extend', right: 'extend'},
+							posterize: undefined,
+						},
+					},
+				},
+			],
+		},
+	} satisfies CodeValues;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-effect-prop',
+				nodePathInfo,
+				i: 0,
+				key: 'intensity',
+			},
+		],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				effects: [{schema: effectSchema}],
+			}),
+		],
+		overrideIdsToNodePaths: {override: nodePath},
+		codeValues,
+	});
+
+	expect(resetTargets).toEqual([
+		{
+			type: 'effect-prop',
+			fileName: '/project/src/Comp.tsx',
+			nodePath,
+			effectIndex: 0,
+			fieldKey: 'intensity',
+			value: 0,
+			defaultValue: '0',
+			schema: effectSchema,
+		},
+	]);
+});
+
+test('Backspace reset skips keyframed effect props without defaults', () => {
+	const schema = {} satisfies SequenceSchema;
+	const effectSchema = {
+		intensity: {type: 'number', default: undefined, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'intensity'],
+	);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const codeValues = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'effect',
+					importPath: null,
+					effectIndex: 0,
+					props: {
+						intensity: {
+							status: 'keyframed',
+							codeValue: undefined,
+							interpolationFunction: 'interpolate',
+							keyframes: [
+								{frame: 0, value: 10},
+								{frame: 20, value: 20},
+							],
+							easing: ['linear'],
+							clamping: {left: 'extend', right: 'extend'},
+							posterize: undefined,
+						},
+					},
+				},
+			],
+		},
+	} satisfies CodeValues;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-effect-prop',
+				nodePathInfo,
+				i: 0,
+				key: 'intensity',
+			},
+		],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				effects: [{schema: effectSchema}],
+			}),
+		],
+		overrideIdsToNodePaths: {override: nodePath},
+		codeValues,
+	});
+
+	expect(resetTargets).toEqual([]);
 });
 
 test('Deleting mixed timeline selection types throws an assertion error', () => {


### PR DESCRIPTION
Fixes #8097.

## Summary

- Allow timeline Reset to target keyframed sequence and effect props when they have a concrete default value
- Keep undefined-default keyframed props from generating invalid save payloads
- Add timeline selection regression tests for keyframed reset targets

## Testing

- `cd packages/studio && bun test src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`
