### PR TITLE
`remotion`: Support keyframed drag overrides

### DIFF
--- a/packages/core/src/SequenceManager.tsx
+++ b/packages/core/src/SequenceManager.tsx
@@ -3,6 +3,7 @@ import type {TSequence} from './CompositionManager.js';
 import type {
 	CanUpdateSequencePropStatus,
 	CodeValues,
+	DragOverrideValue,
 	DragOverrides,
 	EffectDragOverrides,
 	GetDragOverrides,
@@ -40,14 +41,14 @@ export type VisualModeSetters = {
 	setDragOverrides: (
 		nodePath: SequencePropsSubscriptionKey,
 		key: string,
-		value: unknown,
+		value: DragOverrideValue,
 	) => void;
 	clearDragOverrides: (nodePath: SequencePropsSubscriptionKey) => void;
 	setEffectDragOverrides: (
 		nodePath: SequencePropsSubscriptionKey,
 		effectIndex: number,
 		key: string,
-		value: unknown,
+		value: DragOverrideValue,
 	) => void;
 	clearEffectDragOverrides: (
 		nodePath: SequencePropsSubscriptionKey,
@@ -165,7 +166,11 @@ export const SequenceManagerProvider: React.FC<{
 	const [codeValues, setCodeValuesMapState] = useState<CodeValues>({});
 
 	const setDragOverrides = useCallback(
-		(nodePath: SequencePropsSubscriptionKey, key: string, value: unknown) => {
+		(
+			nodePath: SequencePropsSubscriptionKey,
+			key: string,
+			value: DragOverrideValue,
+		) => {
 			setControlOverrides((prev) => ({
 				...prev,
 				[makeSequencePropsSubscriptionKey(nodePath)]: {
@@ -198,7 +203,7 @@ export const SequenceManagerProvider: React.FC<{
 			nodePath: SequencePropsSubscriptionKey,
 			effectIndex: number,
 			key: string,
-			value: unknown,
+			value: DragOverrideValue,
 		) => {
 			setEffectDragOverridesState((prev) => {
 				const mapKey = effectDragOverridesKey(nodePath, effectIndex);

--- a/packages/core/src/effects/use-memoized-effects.ts
+++ b/packages/core/src/effects/use-memoized-effects.ts
@@ -1,4 +1,5 @@
 import {useContext, useRef} from 'react';
+import {resolveDragOverrideValue} from '../get-effective-visual-mode-value.js';
 import {OverrideIdsToNodePathsGettersContext} from '../sequence-node-path.js';
 import type {
 	CannotUpdateEffectReason,
@@ -14,7 +15,6 @@ import {
 } from '../SequenceManager.js';
 import {useCurrentFrame} from '../use-current-frame.js';
 import {
-	resolveDragOverrideValue,
 	type CanUpdateSequencePropStatus,
 	type CodeValues,
 	type DragOverrideValue,

--- a/packages/core/src/effects/use-memoized-effects.ts
+++ b/packages/core/src/effects/use-memoized-effects.ts
@@ -12,7 +12,13 @@ import {
 	VisualModeCodeValuesContext,
 	VisualModeDragOverridesContext,
 } from '../SequenceManager.js';
-import type {CanUpdateSequencePropStatus, CodeValues} from '../use-schema.js';
+import {useCurrentFrame} from '../use-current-frame.js';
+import {
+	resolveDragOverrideValue,
+	type CanUpdateSequencePropStatus,
+	type CodeValues,
+	type DragOverrideValue,
+} from '../use-schema.js';
 import type {
 	EffectDefinition,
 	EffectDefinitionAndStack,
@@ -23,10 +29,12 @@ const mergeOverrides = ({
 	descriptor,
 	codeOverrides,
 	dragOverrides,
+	frame,
 }: {
 	descriptor: EffectDescriptor<unknown>;
 	codeOverrides: Record<string, unknown> | null;
-	dragOverrides: Record<string, unknown> | null;
+	dragOverrides: Record<string, DragOverrideValue> | null;
+	frame: number;
 }): {params: unknown; effectKey: string} => {
 	if (!codeOverrides && !dragOverrides) {
 		return {params: descriptor.params, effectKey: descriptor.effectKey};
@@ -46,7 +54,13 @@ const mergeOverrides = ({
 
 	if (dragOverrides) {
 		for (const [key, value] of Object.entries(dragOverrides)) {
-			merged[key] = value;
+			const resolved = resolveDragOverrideValue({
+				dragOverrideValue: value,
+				frame,
+			});
+			if (resolved.type === 'resolved') {
+				merged[key] = resolved.value;
+			}
 		}
 	}
 
@@ -169,6 +183,7 @@ export const useMemoizedEffects = ({
 
 	const {codeValues} = useContext(VisualModeCodeValuesContext);
 	const {getEffectDragOverrides} = useContext(VisualModeDragOverridesContext);
+	const frame = useCurrentFrame();
 
 	const {overrideIdToNodePathMappings} = useContext(
 		OverrideIdsToNodePathsGettersContext,
@@ -206,6 +221,7 @@ export const useMemoizedEffects = ({
 			descriptor,
 			codeOverrides,
 			dragOverrides,
+			frame,
 		});
 
 		return {descriptor, params, effectKey};

--- a/packages/core/src/get-effective-visual-mode-value.ts
+++ b/packages/core/src/get-effective-visual-mode-value.ts
@@ -1,4 +1,7 @@
-import type {CanUpdateSequencePropStatusStatic} from './use-schema';
+import type {
+	CanUpdateSequencePropStatusStatic,
+	DragOverrideValue,
+} from './use-schema';
 
 export const getEffectiveVisualModeValue = ({
 	codeValue,
@@ -7,12 +10,16 @@ export const getEffectiveVisualModeValue = ({
 	shouldResortToDefaultValueIfUndefined = false,
 }: {
 	codeValue: CanUpdateSequencePropStatusStatic;
-	dragOverrideValue: unknown;
+	dragOverrideValue: DragOverrideValue | undefined;
 	defaultValue: unknown;
 	shouldResortToDefaultValueIfUndefined: boolean;
 }) => {
-	if (dragOverrideValue !== undefined) {
-		return dragOverrideValue;
+	if (
+		dragOverrideValue !== undefined &&
+		dragOverrideValue.type === 'static' &&
+		dragOverrideValue.value !== undefined
+	) {
+		return dragOverrideValue.value;
 	}
 
 	if (

--- a/packages/core/src/get-effective-visual-mode-value.ts
+++ b/packages/core/src/get-effective-visual-mode-value.ts
@@ -1,25 +1,77 @@
+import {interpolateKeyframedStatus} from './interpolate-keyframed-status';
 import type {
+	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
 	DragOverrideValue,
 } from './use-schema';
+
+export type ResolvedDragOverrideValue =
+	| {
+			readonly type: 'none';
+	  }
+	| {
+			readonly type: 'resolved';
+			readonly value: unknown;
+	  };
+
+export const resolveDragOverrideValue = ({
+	dragOverrideValue,
+	frame,
+}: {
+	dragOverrideValue: DragOverrideValue | undefined;
+	frame: number | null;
+}): ResolvedDragOverrideValue => {
+	if (dragOverrideValue === undefined) {
+		return {type: 'none'};
+	}
+
+	if (dragOverrideValue.type === 'static') {
+		return {type: 'resolved', value: dragOverrideValue.value};
+	}
+
+	if (frame === null) {
+		return {type: 'none'};
+	}
+
+	const interpolated = interpolateKeyframedStatus({
+		frame,
+		status: dragOverrideValue.status,
+	});
+	if (interpolated === null) {
+		return {type: 'none'};
+	}
+
+	return {type: 'resolved', value: interpolated};
+};
 
 export const getEffectiveVisualModeValue = ({
 	codeValue,
 	dragOverrideValue,
 	defaultValue,
+	frame = null,
 	shouldResortToDefaultValueIfUndefined = false,
 }: {
-	codeValue: CanUpdateSequencePropStatusStatic;
+	codeValue:
+		| CanUpdateSequencePropStatusStatic
+		| CanUpdateSequencePropStatusKeyframed;
 	dragOverrideValue: DragOverrideValue | undefined;
 	defaultValue: unknown;
+	frame?: number | null;
 	shouldResortToDefaultValueIfUndefined: boolean;
 }) => {
-	if (
-		dragOverrideValue !== undefined &&
-		dragOverrideValue.type === 'static' &&
-		dragOverrideValue.value !== undefined
-	) {
-		return dragOverrideValue.value;
+	const dragOverride = resolveDragOverrideValue({
+		dragOverrideValue,
+		frame,
+	});
+	if (dragOverride.type === 'resolved' && dragOverride.value !== undefined) {
+		return dragOverride.value;
+	}
+
+	if (codeValue.status === 'keyframed' && frame !== null) {
+		return interpolateKeyframedStatus({
+			frame,
+			status: codeValue,
+		});
 	}
 
 	if (

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -189,6 +189,7 @@ import type {
 	CanUpdateSequencePropStatusStatic,
 	CanUpdateSequencePropStatusFalse,
 	CanUpdateSequencePropStatusKeyframed,
+	DragOverrideValue,
 	GetCodeValues,
 	GetDragOverrides,
 	GetEffectCodeValues,
@@ -200,6 +201,10 @@ import {
 	type CodeValues,
 	type DragOverrides,
 	type EffectDragOverrides,
+	getStaticDragOverrideValue,
+	makeKeyframedDragOverride,
+	makeStaticDragOverride,
+	resolveDragOverrideValue,
 } from './use-schema.js';
 import {useUnsafeVideoConfig} from './use-unsafe-video-config.js';
 import {useVideo} from './use-video.js';
@@ -374,6 +379,10 @@ export const Internals = {
 	createWebGL2ContextError,
 	computeEffectiveSchemaValuesDotNotation,
 	interpolateKeyframedStatus,
+	makeStaticDragOverride,
+	makeKeyframedDragOverride,
+	resolveDragOverrideValue,
+	getStaticDragOverrideValue,
 	OverrideIdsToNodePathsGettersContext,
 	OverrideIdsToNodePathsSettersContext,
 	findPropsToDelete,
@@ -401,6 +410,7 @@ export type {
 	CompositionManagerContext,
 	CompProps,
 	DragOverrides,
+	DragOverrideValue,
 	EffectDragOverrides,
 	GetCodeValues,
 	GetDragOverrides,

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -73,7 +73,10 @@ import {
 	getFlatSchemaWithAllKeys,
 } from './flatten-schema.js';
 import {getAssetDisplayName} from './get-asset-file-name.js';
-import {getEffectiveVisualModeValue} from './get-effective-visual-mode-value.js';
+import {
+	getEffectiveVisualModeValue,
+	resolveDragOverrideValue,
+} from './get-effective-visual-mode-value.js';
 import {
 	getPreviewDomElement,
 	REMOTION_STUDIO_CONTAINER_ELEMENT,
@@ -204,7 +207,6 @@ import {
 	getStaticDragOverrideValue,
 	makeKeyframedDragOverride,
 	makeStaticDragOverride,
-	resolveDragOverrideValue,
 } from './use-schema.js';
 import {useUnsafeVideoConfig} from './use-unsafe-video-config.js';
 import {useVideo} from './use-video.js';

--- a/packages/core/src/test/drag-override-value.test.ts
+++ b/packages/core/src/test/drag-override-value.test.ts
@@ -1,8 +1,11 @@
 import {expect, test} from 'bun:test';
 import {
+	getEffectiveVisualModeValue,
+	resolveDragOverrideValue,
+} from '../get-effective-visual-mode-value';
+import {
 	computeEffectiveSchemaValuesDotNotation,
 	makeKeyframedDragOverride,
-	resolveDragOverrideValue,
 	type CanUpdateSequencePropStatusKeyframed,
 } from '../use-schema';
 
@@ -92,4 +95,25 @@ test('computeEffectiveSchemaValuesDotNotation resolves keyframed drag overrides 
 	});
 
 	expect(merged.opacity).toBe(3);
+});
+
+test('getEffectiveVisualModeValue resolves keyframed drag overrides at the source frame', () => {
+	const status = makeKeyframedStatus();
+
+	expect(
+		getEffectiveVisualModeValue({
+			codeValue: {
+				status: 'static',
+				codeValue: 2,
+			},
+			dragOverrideValue: makeKeyframedDragOverride({
+				status,
+				frame: 30,
+				value: 3,
+			}),
+			defaultValue: 1,
+			frame: 30,
+			shouldResortToDefaultValueIfUndefined: true,
+		}),
+	).toBe(3);
 });

--- a/packages/core/src/test/drag-override-value.test.ts
+++ b/packages/core/src/test/drag-override-value.test.ts
@@ -1,0 +1,95 @@
+import {expect, test} from 'bun:test';
+import {
+	computeEffectiveSchemaValuesDotNotation,
+	makeKeyframedDragOverride,
+	resolveDragOverrideValue,
+	type CanUpdateSequencePropStatusKeyframed,
+} from '../use-schema';
+
+const makeKeyframedStatus = (): CanUpdateSequencePropStatusKeyframed => ({
+	status: 'keyframed',
+	codeValue: undefined,
+	interpolationFunction: 'interpolate',
+	keyframes: [
+		{frame: 0, value: 2},
+		{frame: 60, value: 4},
+	],
+	easing: ['linear'],
+	clamping: {left: 'extend', right: 'extend'},
+	posterize: undefined,
+});
+
+test('makeKeyframedDragOverride inserts a new keyframe and preserves easing length', () => {
+	const override = makeKeyframedDragOverride({
+		status: makeKeyframedStatus(),
+		frame: 30,
+		value: 3,
+	});
+
+	expect(override).toEqual({
+		type: 'keyframed',
+		status: {
+			...makeKeyframedStatus(),
+			keyframes: [
+				{frame: 0, value: 2},
+				{frame: 30, value: 3},
+				{frame: 60, value: 4},
+			],
+			easing: ['linear', 'linear'],
+		},
+	});
+
+	expect(
+		resolveDragOverrideValue({dragOverrideValue: override, frame: 30}),
+	).toEqual({
+		type: 'resolved',
+		value: 3,
+	});
+});
+
+test('makeKeyframedDragOverride replaces an existing keyframe without changing easing length', () => {
+	const override = makeKeyframedDragOverride({
+		status: makeKeyframedStatus(),
+		frame: 60,
+		value: 5,
+	});
+
+	expect(override).toEqual({
+		type: 'keyframed',
+		status: {
+			...makeKeyframedStatus(),
+			keyframes: [
+				{frame: 0, value: 2},
+				{frame: 60, value: 5},
+			],
+			easing: ['linear'],
+		},
+	});
+});
+
+test('computeEffectiveSchemaValuesDotNotation resolves keyframed drag overrides at the current frame', () => {
+	const status = makeKeyframedStatus();
+	const {merged} = computeEffectiveSchemaValuesDotNotation({
+		schema: {
+			opacity: {
+				type: 'number',
+				default: 1,
+				hiddenFromList: false,
+			},
+		},
+		currentValue: {opacity: 2},
+		overrideValues: {
+			opacity: makeKeyframedDragOverride({
+				status,
+				frame: 30,
+				value: 3,
+			}),
+		},
+		propStatus: {
+			opacity: status,
+		},
+		frame: 30,
+	});
+
+	expect(merged.opacity).toBe(3);
+});

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -56,8 +56,21 @@ export type CanUpdateSequencePropStatus =
 	| CanUpdateSequencePropStatusKeyframed
 	| CanUpdateSequencePropStatusFalse;
 
-export type DragOverrides = Record<string, Record<string, unknown>>;
-export type EffectDragOverrides = Record<string, Record<string, unknown>>;
+export type DragOverrideValue =
+	| {
+			readonly type: 'static';
+			readonly value: unknown;
+	  }
+	| {
+			readonly type: 'keyframed';
+			readonly status: CanUpdateSequencePropStatusKeyframed;
+	  };
+
+export type DragOverrides = Record<string, Record<string, DragOverrideValue>>;
+export type EffectDragOverrides = Record<
+	string,
+	Record<string, DragOverrideValue>
+>;
 export type CodeValues = Record<string, CanUpdateSequencePropsResponse>;
 
 export type GetCodeValues = (
@@ -76,7 +89,99 @@ export type GetDragOverrides = (
 export type GetEffectDragOverrides = (
 	nodePath: SequencePropsSubscriptionKey,
 	effectIndex: number,
-) => Record<string, unknown>;
+) => Record<string, DragOverrideValue>;
+
+export const makeStaticDragOverride = (value: unknown): DragOverrideValue => {
+	return {type: 'static', value};
+};
+
+export const makeKeyframedDragOverride = ({
+	status,
+	frame,
+	value,
+}: {
+	status: CanUpdateSequencePropStatusKeyframed;
+	frame: number;
+	value: unknown;
+}): DragOverrideValue => {
+	const existingIndex = status.keyframes.findIndex(
+		(keyframe) => keyframe.frame === frame,
+	);
+	const keyframes =
+		existingIndex === -1
+			? [...status.keyframes, {frame, value}].sort(
+					(first, second) => first.frame - second.frame,
+				)
+			: status.keyframes.map((keyframe, index) =>
+					index === existingIndex ? {frame, value} : keyframe,
+				);
+	const easing = [...status.easing];
+	while (easing.length < keyframes.length - 1) {
+		easing.push('linear');
+	}
+
+	if (easing.length > keyframes.length - 1) {
+		easing.length = keyframes.length - 1;
+	}
+
+	return {
+		type: 'keyframed',
+		status: {
+			...status,
+			keyframes,
+			easing,
+		},
+	};
+};
+
+export type ResolvedDragOverrideValue =
+	| {
+			readonly type: 'none';
+	  }
+	| {
+			readonly type: 'resolved';
+			readonly value: unknown;
+	  };
+
+export const resolveDragOverrideValue = ({
+	dragOverrideValue,
+	frame,
+}: {
+	dragOverrideValue: DragOverrideValue | undefined;
+	frame: number | null;
+}): ResolvedDragOverrideValue => {
+	if (dragOverrideValue === undefined) {
+		return {type: 'none'};
+	}
+
+	if (dragOverrideValue.type === 'static') {
+		return {type: 'resolved', value: dragOverrideValue.value};
+	}
+
+	if (frame === null) {
+		return {type: 'none'};
+	}
+
+	const interpolated = interpolateKeyframedStatus({
+		frame,
+		status: dragOverrideValue.status,
+	});
+	if (interpolated === null) {
+		return {type: 'none'};
+	}
+
+	return {type: 'resolved', value: interpolated};
+};
+
+export const getStaticDragOverrideValue = (
+	dragOverrideValue: DragOverrideValue | undefined,
+): unknown => {
+	if (dragOverrideValue?.type !== 'static') {
+		return undefined;
+	}
+
+	return dragOverrideValue.value;
+};
 
 export const isKeyframedStatus = (
 	status: CanUpdateSequencePropStatus | null,
@@ -117,7 +222,7 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 }: {
 	schema: SequenceSchema;
 	currentValue: Record<string, unknown>;
-	overrideValues: Record<string, unknown>;
+	overrideValues: Record<string, DragOverrideValue>;
 	propStatus: Record<string, CanUpdateSequencePropStatus> | undefined;
 	frame: number | null;
 }): {merged: Record<string, unknown>; propsToDelete: Set<string>} => {
@@ -135,7 +240,13 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 		if (codeValueStatus === null) {
 			value = currentValue[key];
 		} else if (isKeyframedStatus(codeValueStatus)) {
-			if (frame !== null) {
+			const dragOverride = resolveDragOverrideValue({
+				dragOverrideValue: overrideValues[key],
+				frame,
+			});
+			if (dragOverride.type === 'resolved') {
+				value = dragOverride.value;
+			} else if (frame !== null) {
 				const interpolated = interpolateKeyframedStatus({
 					frame,
 					status: codeValueStatus,

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -1,5 +1,8 @@
 import {findPropsToDelete} from './find-props-to-delete.js';
-import {getEffectiveVisualModeValue} from './get-effective-visual-mode-value.js';
+import {
+	getEffectiveVisualModeValue,
+	resolveDragOverrideValue,
+} from './get-effective-visual-mode-value.js';
 import {interpolateKeyframedStatus} from './interpolate-keyframed-status.js';
 import type {ExtrapolateType} from './interpolate.js';
 import type {
@@ -134,45 +137,6 @@ export const makeKeyframedDragOverride = ({
 	};
 };
 
-export type ResolvedDragOverrideValue =
-	| {
-			readonly type: 'none';
-	  }
-	| {
-			readonly type: 'resolved';
-			readonly value: unknown;
-	  };
-
-export const resolveDragOverrideValue = ({
-	dragOverrideValue,
-	frame,
-}: {
-	dragOverrideValue: DragOverrideValue | undefined;
-	frame: number | null;
-}): ResolvedDragOverrideValue => {
-	if (dragOverrideValue === undefined) {
-		return {type: 'none'};
-	}
-
-	if (dragOverrideValue.type === 'static') {
-		return {type: 'resolved', value: dragOverrideValue.value};
-	}
-
-	if (frame === null) {
-		return {type: 'none'};
-	}
-
-	const interpolated = interpolateKeyframedStatus({
-		frame,
-		status: dragOverrideValue.status,
-	});
-	if (interpolated === null) {
-		return {type: 'none'};
-	}
-
-	return {type: 'resolved', value: interpolated};
-};
-
 export const getStaticDragOverrideValue = (
 	dragOverrideValue: DragOverrideValue | undefined,
 ): unknown => {
@@ -262,6 +226,7 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 				codeValue: codeValueStatus,
 				dragOverrideValue: overrideValues[key],
 				defaultValue: field?.default,
+				frame,
 				shouldResortToDefaultValueIfUndefined: false,
 			});
 		}

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -137,7 +137,9 @@ export const getEffectFieldsToShow = ({
 	const dragOverrides =
 		nodePath === null ? {} : getEffectDragOverrides(nodePath, effectIndex);
 	const activeSchema = Internals.flattenActiveSchema(effect.schema, (key) => {
-		const dragOverride = dragOverrides[key];
+		const dragOverride = Internals.getStaticDragOverrideValue(
+			dragOverrides[key],
+		);
 		if (dragOverride !== undefined) {
 			return dragOverride;
 		}

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -2,6 +2,7 @@ import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import type {
 	CanUpdateSequencePropStatusStatic,
 	CodeValues,
+	GetDragOverrides,
 	GetEffectDragOverrides,
 	OverrideIdToNodePaths,
 	SequenceFieldSchema,
@@ -549,7 +550,9 @@ const getSelectedUvHandles = ({
 
 		const dragOverrides = getEffectDragOverrides(nodePath, effectIndex);
 		const activeSchema = Internals.flattenActiveSchema(effect.schema, (key) => {
-			const dragOverride = dragOverrides[key];
+			const dragOverride = Internals.getStaticDragOverrideValue(
+				dragOverrides[key],
+			);
 			if (dragOverride !== undefined) {
 				return dragOverride;
 			}
@@ -659,9 +662,7 @@ const getSelectedOutlineDragStates = ({
 	getDragOverrides,
 }: {
 	readonly dragTargets: readonly SelectedOutlineDragTarget[];
-	readonly getDragOverrides: (
-		nodePath: SequencePropsSubscriptionKey,
-	) => Record<string, unknown>;
+	readonly getDragOverrides: GetDragOverrides;
 }): SelectedOutlineDragState[] => {
 	return dragTargets.map((target) => {
 		const dragOverrideValue = (getDragOverrides(target.nodePath) ?? {})[
@@ -794,9 +795,7 @@ export const getSelectedOutlineScaleDragStates = ({
 	getDragOverrides,
 }: {
 	readonly dragTargets: readonly SelectedOutlineScaleDragTarget[];
-	readonly getDragOverrides: (
-		nodePath: SequencePropsSubscriptionKey,
-	) => Record<string, unknown>;
+	readonly getDragOverrides: GetDragOverrides;
 }): SelectedOutlineScaleDragState[] => {
 	return dragTargets.map((target) => {
 		const dragOverrideValue = (getDragOverrides(target.nodePath) ?? {})[
@@ -1001,7 +1000,11 @@ const SelectedOutlinePolygon: React.FC<{
 						throw new Error('Expected drag value to be available');
 					}
 
-					setDragOverrides(dragState.target.nodePath, translateFieldKey, value);
+					setDragOverrides(
+						dragState.target.nodePath,
+						translateFieldKey,
+						Internals.makeStaticDragOverride(value),
+					);
 				}
 			};
 
@@ -1157,7 +1160,11 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 						throw new Error('Expected scale drag value to be available');
 					}
 
-					setDragOverrides(dragState.target.nodePath, scaleFieldKey, value);
+					setDragOverrides(
+						dragState.target.nodePath,
+						scaleFieldKey,
+						Internals.makeStaticDragOverride(value),
+					);
 				}
 			};
 
@@ -1304,7 +1311,7 @@ const SelectedUvHandleCircle: React.FC<{
 					handle.nodePath,
 					handle.effectIndex,
 					handle.fieldKey,
-					nextValue,
+					Internals.makeStaticDragOverride(nextValue),
 				);
 			};
 

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -74,12 +74,35 @@ const Value: React.FC<{
 		effectStatus.type === 'can-update-effect'
 			? (effectStatus.props?.[field.key] ?? null)
 			: null;
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const jsxFrame = timelinePosition - keyframeDisplayOffset;
 
 	const onDragValueChange = useCallback(
 		(value: unknown) => {
-			setEffectDragOverrides(nodePath, field.effectIndex, field.key, value);
+			const nextDragOverrideValue =
+				propStatus !== null && isKeyframedStatus(propStatus)
+					? Internals.makeKeyframedDragOverride({
+							status: propStatus,
+							frame: jsxFrame,
+							value,
+						})
+					: Internals.makeStaticDragOverride(value);
+
+			setEffectDragOverrides(
+				nodePath,
+				field.effectIndex,
+				field.key,
+				nextDragOverrideValue,
+			);
 		},
-		[setEffectDragOverrides, nodePath, field.effectIndex, field.key],
+		[
+			field.effectIndex,
+			field.key,
+			jsxFrame,
+			nodePath,
+			propStatus,
+			setEffectDragOverrides,
+		],
 	);
 
 	const onDragEnd = useCallback(() => {

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -284,6 +284,7 @@ const Value: React.FC<{
 		codeValue: propStatus,
 		dragOverrideValue,
 		defaultValue: field.fieldSchema.default,
+		frame: jsxFrame,
 		shouldResortToDefaultValueIfUndefined: true,
 	});
 

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -85,18 +85,12 @@ const getCurrentKeyframeValue = ({
 	dragOverrideValue: DragOverrideValue | undefined;
 }): unknown | null => {
 	if (isKeyframedStatus(propStatus)) {
-		const dragOverride = Internals.resolveDragOverrideValue({
+		return Internals.getEffectiveVisualModeValue({
+			codeValue: propStatus,
 			dragOverrideValue,
 			frame: jsxFrame,
-		});
-		if (dragOverride.type === 'resolved') {
-			return dragOverride.value;
-		}
-
-		const keyframedStatus = propStatus as CanUpdateSequencePropStatusKeyframed;
-		return Internals.interpolateKeyframedStatus({
-			frame: jsxFrame,
-			status: keyframedStatus,
+			defaultValue,
+			shouldResortToDefaultValueIfUndefined: true,
 		});
 	}
 
@@ -104,6 +98,7 @@ const getCurrentKeyframeValue = ({
 		return Internals.getEffectiveVisualModeValue({
 			codeValue: propStatus,
 			dragOverrideValue,
+			frame: jsxFrame,
 			defaultValue,
 			shouldResortToDefaultValueIfUndefined: true,
 		});

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -3,6 +3,7 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import type {
 	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusKeyframed,
+	DragOverrideValue,
 	SequencePropsSubscriptionKey,
 	SequenceSchema,
 } from 'remotion';
@@ -81,9 +82,17 @@ const getCurrentKeyframeValue = ({
 	propStatus: CanUpdateSequencePropStatus;
 	jsxFrame: number;
 	defaultValue: unknown;
-	dragOverrideValue: unknown;
+	dragOverrideValue: DragOverrideValue | undefined;
 }): unknown | null => {
 	if (isKeyframedStatus(propStatus)) {
+		const dragOverride = Internals.resolveDragOverrideValue({
+			dragOverrideValue,
+			frame: jsxFrame,
+		});
+		if (dragOverride.type === 'resolved') {
+			return dragOverride.value;
+		}
+
 		const keyframedStatus = propStatus as CanUpdateSequencePropStatusKeyframed;
 		return Internals.interpolateKeyframedStatus({
 			frame: jsxFrame,
@@ -134,7 +143,7 @@ export const TimelineKeyframeControls: React.FC<{
 	readonly fileName: string;
 	readonly keyframeDisplayOffset: number;
 	readonly defaultValue: unknown;
-	readonly dragOverrideValue: unknown | undefined;
+	readonly dragOverrideValue: DragOverrideValue | undefined;
 	readonly schema: SequenceSchema;
 	readonly effectIndex: number | null;
 }> = ({

--- a/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useMemo} from 'react';
 import type {
 	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
+	DragOverrideValue,
 	SequencePropsSubscriptionKey,
 } from 'remotion';
 import {Internals} from 'remotion';
@@ -20,7 +21,7 @@ export const TimelineKeyframedValue: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly propStatus: CanUpdateSequencePropStatusKeyframed;
 	readonly keyframeDisplayOffset: number;
-	readonly dragOverrideValue: unknown;
+	readonly dragOverrideValue: DragOverrideValue | undefined;
 	readonly onSave: (value: unknown, sourceFrame: number) => Promise<void>;
 	readonly onDragValueChange: TimelineFieldOnDragValueChange;
 	readonly onDragEnd: () => void;
@@ -58,8 +59,13 @@ export const TimelineKeyframedValue: React.FC<{
 		[computedValue],
 	);
 
-	const effectiveValue =
-		dragOverrideValue === undefined ? computedValue : dragOverrideValue;
+	const effectiveValue = useMemo(() => {
+		const resolved = Internals.resolveDragOverrideValue({
+			dragOverrideValue,
+			frame: jsxFrame,
+		});
+		return resolved.type === 'resolved' ? resolved.value : computedValue;
+	}, [computedValue, dragOverrideValue, jsxFrame]);
 
 	const onSaveIfChanged = useCallback<TimelineFieldOnSave>(
 		(value) => {

--- a/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
@@ -60,12 +60,14 @@ export const TimelineKeyframedValue: React.FC<{
 	);
 
 	const effectiveValue = useMemo(() => {
-		const resolved = Internals.resolveDragOverrideValue({
+		return Internals.getEffectiveVisualModeValue({
+			codeValue: fakeStatus,
 			dragOverrideValue,
 			frame: jsxFrame,
+			defaultValue: field.fieldSchema.default,
+			shouldResortToDefaultValueIfUndefined: true,
 		});
-		return resolved.type === 'resolved' ? resolved.value : computedValue;
-	}, [computedValue, dragOverrideValue, jsxFrame]);
+	}, [dragOverrideValue, fakeStatus, field.fieldSchema.default, jsxFrame]);
 
 	const onSaveIfChanged = useCallback<TimelineFieldOnSave>(
 		(value) => {

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -130,7 +130,11 @@ const Value: React.FC<{
 				throw new Error('Cannot drag value');
 			}
 
-			setDragOverrides(nodePath, field.key, value);
+			setDragOverrides(
+				nodePath,
+				field.key,
+				Internals.makeStaticDragOverride(value),
+			);
 		},
 		[setDragOverrides, nodePath, field.key],
 	);
@@ -194,6 +198,8 @@ export const TimelineSequencePropItem: React.FC<{
 		nodePath,
 	);
 	const codeValue = codeValuesForOverride?.[field.key] ?? null;
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const jsxFrame = timelinePosition - keyframeDisplayOffset;
 
 	const dragOverrideValue = useMemo(() => {
 		return (getDragOverrides(nodePath) ?? {})[field.key];
@@ -314,9 +320,21 @@ export const TimelineSequencePropItem: React.FC<{
 	const onKeyframedDragValueChange =
 		useCallback<TimelineFieldOnDragValueChange>(
 			(value) => {
-				setDragOverrides(nodePath, field.key, value);
+				if (codeValue === null || !isKeyframedStatus(codeValue)) {
+					throw new Error('Expected keyframed status');
+				}
+
+				setDragOverrides(
+					nodePath,
+					field.key,
+					Internals.makeKeyframedDragOverride({
+						status: codeValue,
+						frame: jsxFrame,
+						value,
+					}),
+				);
 			},
-			[field.key, nodePath, setDragOverrides],
+			[codeValue, field.key, jsxFrame, nodePath, setDragOverrides],
 		);
 
 	const onKeyframedDragEnd = useCallback(() => {

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -542,10 +542,12 @@ export const useTimelineSequenceFromDrag = ({
 				latestRef.current.setDragOverrides(
 					target.nodePath,
 					'from',
-					getTimelineSequenceFromDragValue({
-						initialFrom: target.initialFrom,
-						deltaFrames,
-					}),
+					Internals.makeStaticDragOverride(
+						getTimelineSequenceFromDragValue({
+							initialFrom: target.initialFrom,
+							deltaFrames,
+						}),
+					),
 				);
 			}
 		};
@@ -776,10 +778,12 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 				latestRef.current.setDragOverrides(
 					target.nodePath,
 					'durationInFrames',
-					getTimelineSequenceDurationDragValue({
-						initialDuration: target.initialDuration,
-						deltaFrames,
-					}),
+					Internals.makeStaticDragOverride(
+						getTimelineSequenceDurationDragValue({
+							initialDuration: target.initialDuration,
+							deltaFrames,
+						}),
+					),
 				);
 			}
 		};

--- a/packages/studio/src/components/Timeline/get-node-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-node-keyframes.ts
@@ -1,6 +1,7 @@
 import {
 	Internals,
 	type CodeValues,
+	type DragOverrideValue,
 	type GetDragOverrides,
 	type GetEffectDragOverrides,
 	type SequencePropsSubscriptionKey,
@@ -9,7 +10,7 @@ import type {TimelineTreeNode} from '../../helpers/timeline-layout';
 import {getTimelineKeyframes} from './get-timeline-keyframes';
 
 const hasOverride = (
-	overrides: Record<string, unknown>,
+	overrides: Record<string, DragOverrideValue>,
 	key: string,
 ): boolean => Object.prototype.hasOwnProperty.call(overrides, key);
 
@@ -23,16 +24,26 @@ const withDragOverrideKeyframe = ({
 	propStatus: Parameters<typeof getTimelineKeyframes>[0];
 	keyframeDisplayOffset: number;
 	timelinePosition: number;
-	dragOverrideValue: unknown;
+	dragOverrideValue: DragOverrideValue | undefined;
 	hasDragOverride: boolean;
 }): ReturnType<typeof getTimelineKeyframes> => {
+	if (dragOverrideValue?.type === 'keyframed') {
+		return getTimelineKeyframes(
+			dragOverrideValue.status,
+			keyframeDisplayOffset,
+		);
+	}
+
 	const keyframes = getTimelineKeyframes(propStatus, keyframeDisplayOffset);
 
 	if (!hasDragOverride || propStatus?.status !== 'keyframed') {
 		return keyframes;
 	}
 
-	const dragKeyframe = {frame: timelinePosition, value: dragOverrideValue};
+	const dragKeyframe = {
+		frame: timelinePosition,
+		value: dragOverrideValue?.value,
+	};
 	const existingIndex = keyframes.findIndex(
 		(keyframe) => keyframe.frame === timelinePosition,
 	);

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -238,7 +238,9 @@ test('getNodeKeyframes shows a temporary sequence keyframe from drag overrides',
 			nodePath,
 			codeValues: makeCodeValues(nodePath),
 			keyframeDisplayOffset: 30,
-			getDragOverrides: () => ({'style.scale': 3}),
+			getDragOverrides: () => ({
+				'style.scale': Internals.makeStaticDragOverride(3),
+			}),
 			getEffectDragOverrides: () => ({}),
 			timelinePosition: 60,
 		}),
@@ -259,7 +261,60 @@ test('getNodeKeyframes shows a temporary effect keyframe from drag overrides', (
 			codeValues: makeCodeValues(nodePath),
 			keyframeDisplayOffset: 30,
 			getDragOverrides: () => ({}),
-			getEffectDragOverrides: () => ({amount: 5}),
+			getEffectDragOverrides: () => ({
+				amount: Internals.makeStaticDragOverride(5),
+			}),
+			timelinePosition: 90,
+		}),
+	).toEqual([
+		{frame: 30, value: 2},
+		{frame: 90, value: 5},
+	]);
+});
+
+test('getNodeKeyframes shows sequence keyframes from keyframed drag overrides', () => {
+	const nodePath = makeNodePath('sequence');
+
+	expect(
+		getNodeKeyframes({
+			node: makeSequenceFieldNode('style.scale'),
+			nodePath,
+			codeValues: makeCodeValues(nodePath),
+			keyframeDisplayOffset: 30,
+			getDragOverrides: () => ({
+				'style.scale': Internals.makeKeyframedDragOverride({
+					status: makeKeyframedStatus(),
+					frame: 30,
+					value: 3,
+				}),
+			}),
+			getEffectDragOverrides: () => ({}),
+			timelinePosition: 60,
+		}),
+	).toEqual([
+		{frame: 30, value: 2},
+		{frame: 60, value: 3},
+		{frame: 90, value: 4},
+	]);
+});
+
+test('getNodeKeyframes replaces existing keyframes from keyframed drag overrides', () => {
+	const nodePath = makeNodePath('sequence');
+
+	expect(
+		getNodeKeyframes({
+			node: makeEffectFieldNode('amount', 0),
+			nodePath,
+			codeValues: makeCodeValues(nodePath),
+			keyframeDisplayOffset: 30,
+			getDragOverrides: () => ({}),
+			getEffectDragOverrides: () => ({
+				amount: Internals.makeKeyframedDragOverride({
+					status: makeKeyframedStatus(),
+					frame: 60,
+					value: 5,
+				}),
+			}),
 			timelinePosition: 90,
 		}),
 	).toEqual([


### PR DESCRIPTION
## Summary

- Add static/keyframed drag override values for visual mode
- Resolve keyframed drag overrides live in canvas, timeline, and effect rendering
- Add focused coverage for keyframed drag override insertion and timeline display

Fixes #8101.

## Testing

- `bun test packages/core/src/test/drag-override-value.test.ts packages/studio/src/test/timeline-keyframes.test.ts`
- `bun run build`
- `bun run stylecheck`
