### PR TITLE
`@remotion/studio`: Support keyframed outline translate dragging

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1,5 +1,6 @@
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import type {
+	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
 	CodeValues,
 	GetDragOverrides,
@@ -19,8 +20,12 @@ import {getBoxQuadsPonyfill} from '../helpers/get-box-quads-ponyfill';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {ScaleLockContext} from '../state/scale-lock';
 import {showNotification} from './Notifications/NotificationCenter';
+import {callAddSequenceKeyframe} from './Timeline/call-add-keyframe';
 import {saveEffectProp} from './Timeline/save-effect-prop';
-import {saveSequenceProps} from './Timeline/save-sequence-prop';
+import {
+	saveSequenceProps,
+	type SaveSequencePropChange,
+} from './Timeline/save-sequence-prop';
 import {getDecimalPlaces} from './Timeline/timeline-field-utils';
 import {
 	parseTranslate,
@@ -81,9 +86,12 @@ type SelectedOutlineTarget = {
 };
 
 type SelectedOutlineDragTarget = {
-	readonly codeValue: CanUpdateSequencePropStatusStatic;
+	readonly codeValue:
+		| CanUpdateSequencePropStatusStatic
+		| CanUpdateSequencePropStatusKeyframed;
 	readonly clientId: string;
 	readonly fieldDefault: string | undefined;
+	readonly keyframeDisplayOffset: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: SequenceSchema;
 };
@@ -103,6 +111,7 @@ type SelectedOutlineScaleDragTarget = {
 export type SelectedOutlineDragState = {
 	readonly defaultValue: string | null;
 	readonly key: string;
+	readonly sourceFrame: number;
 	readonly startX: number;
 	readonly startY: number;
 	readonly target: SelectedOutlineDragTarget;
@@ -119,6 +128,7 @@ export type SelectedOutlineScaleDragState = {
 
 type SequenceWithSelectedOutline = {
 	readonly depth: number;
+	readonly keyframeDisplayOffset: number;
 	readonly key: string;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly sequence: TSequence;
@@ -505,6 +515,7 @@ export const getSequencesWithSelectableOutlines = ({
 
 			return {
 				depth: track.depth,
+				keyframeDisplayOffset: track.keyframeDisplayOffset,
 				key: getTimelineSequenceSelectionKey(track.nodePathInfo),
 				nodePathInfo: track.nodePathInfo,
 				sequence: track.sequence,
@@ -660,18 +671,22 @@ const outlinesAreEqual = (
 const getSelectedOutlineDragStates = ({
 	dragTargets,
 	getDragOverrides,
+	timelinePosition,
 }: {
 	readonly dragTargets: readonly SelectedOutlineDragTarget[];
 	readonly getDragOverrides: GetDragOverrides;
+	readonly timelinePosition: number;
 }): SelectedOutlineDragState[] => {
 	return dragTargets.map((target) => {
 		const dragOverrideValue = (getDragOverrides(target.nodePath) ?? {})[
 			translateFieldKey
 		];
+		const sourceFrame = timelinePosition - target.keyframeDisplayOffset;
 		const effectiveValue = Internals.getEffectiveVisualModeValue({
 			codeValue: target.codeValue,
 			dragOverrideValue,
 			defaultValue: target.fieldDefault,
+			frame: sourceFrame,
 			shouldResortToDefaultValueIfUndefined: true,
 		});
 		const [startX, startY] = parseTranslate(
@@ -684,6 +699,7 @@ const getSelectedOutlineDragStates = ({
 					? JSON.stringify(target.fieldDefault)
 					: null,
 			key: Internals.makeSequencePropsSubscriptionKey(target.nodePath),
+			sourceFrame,
 			startX,
 			startY,
 			target,
@@ -708,17 +724,57 @@ export const getSelectedOutlineDragValues = ({
 	);
 };
 
+export type SelectedOutlineStaticDragChange = SaveSequencePropChange & {
+	readonly type: 'static';
+};
+
+export type SelectedOutlineKeyframedDragChange = {
+	readonly type: 'keyframed';
+	readonly fileName: string;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly fieldKey: string;
+	readonly sourceFrame: number;
+	readonly value: unknown;
+	readonly schema: SequenceSchema;
+	readonly clientId: string;
+};
+
+export type SelectedOutlineDragChange =
+	| SelectedOutlineStaticDragChange
+	| SelectedOutlineKeyframedDragChange;
+
 export const getSelectedOutlineDragChanges = ({
 	dragStates,
 	lastValues,
 }: {
 	readonly dragStates: readonly SelectedOutlineDragState[];
 	readonly lastValues: ReadonlyMap<string, string>;
-}) => {
-	return dragStates.flatMap((dragState) => {
+}): SelectedOutlineDragChange[] => {
+	const changes: SelectedOutlineDragChange[] = [];
+
+	for (const dragState of dragStates) {
 		const value = lastValues.get(dragState.key);
 		if (value === undefined) {
-			return [];
+			continue;
+		}
+
+		if (dragState.target.codeValue.status === 'keyframed') {
+			const startValue = serializeTranslate(dragState.startX, dragState.startY);
+			if (value === startValue) {
+				continue;
+			}
+
+			changes.push({
+				type: 'keyframed',
+				fileName: dragState.target.nodePath.absolutePath,
+				nodePath: dragState.target.nodePath,
+				fieldKey: translateFieldKey,
+				sourceFrame: dragState.sourceFrame,
+				value,
+				schema: dragState.target.schema,
+				clientId: dragState.target.clientId,
+			});
+			continue;
 		}
 
 		const stringifiedValue = JSON.stringify(value);
@@ -730,20 +786,21 @@ export const getSelectedOutlineDragChanges = ({
 			);
 
 		if (!shouldSave) {
-			return [];
+			continue;
 		}
 
-		return [
-			{
-				fileName: dragState.target.nodePath.absolutePath,
-				nodePath: dragState.target.nodePath,
-				fieldKey: translateFieldKey,
-				value,
-				defaultValue: dragState.defaultValue,
-				schema: dragState.target.schema,
-			},
-		];
-	});
+		changes.push({
+			type: 'static',
+			fileName: dragState.target.nodePath.absolutePath,
+			nodePath: dragState.target.nodePath,
+			fieldKey: translateFieldKey,
+			value,
+			defaultValue: dragState.defaultValue,
+			schema: dragState.target.schema,
+		});
+	}
+
+	return changes;
 };
 
 export type SelectedOutlineScaleEdge = 'top' | 'right' | 'bottom' | 'left';
@@ -950,6 +1007,9 @@ const SelectedOutlinePolygon: React.FC<{
 	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const timelinePositionRef = useRef(timelinePosition);
+	timelinePositionRef.current = timelinePosition;
 	const points = useMemo(
 		() => outline.points.map(pointToString).join(' '),
 		[outline.points],
@@ -983,6 +1043,7 @@ const SelectedOutlinePolygon: React.FC<{
 			const dragStates = getSelectedOutlineDragStates({
 				dragTargets: selected ? allDragTargets : [drag],
 				getDragOverrides,
+				timelinePosition: timelinePositionRef.current,
 			});
 			let lastValues = new Map<string, string>();
 
@@ -1000,11 +1061,23 @@ const SelectedOutlinePolygon: React.FC<{
 						throw new Error('Expected drag value to be available');
 					}
 
-					setDragOverrides(
-						dragState.target.nodePath,
-						translateFieldKey,
-						Internals.makeStaticDragOverride(value),
-					);
+					if (dragState.target.codeValue.status === 'keyframed') {
+						setDragOverrides(
+							dragState.target.nodePath,
+							translateFieldKey,
+							Internals.makeKeyframedDragOverride({
+								status: dragState.target.codeValue,
+								frame: dragState.sourceFrame,
+								value,
+							}),
+						);
+					} else {
+						setDragOverrides(
+							dragState.target.nodePath,
+							translateFieldKey,
+							Internals.makeStaticDragOverride(value),
+						);
+					}
 				}
 			};
 
@@ -1023,13 +1096,40 @@ const SelectedOutlinePolygon: React.FC<{
 					return;
 				}
 
-				saveSequenceProps({
-					changes,
-					setCodeValues,
-					clientId: drag.clientId,
-					undoLabel: changes.length > 1 ? 'Move selected sequences' : null,
-					redoLabel: changes.length > 1 ? 'Move selected sequences back' : null,
-				})
+				const staticChanges = changes.filter(
+					(change): change is SelectedOutlineStaticDragChange =>
+						change.type === 'static',
+				);
+				const keyframedChanges = changes.filter(
+					(change): change is SelectedOutlineKeyframedDragChange =>
+						change.type === 'keyframed',
+				);
+
+				Promise.all([
+					staticChanges.length > 0
+						? saveSequenceProps({
+								changes: staticChanges,
+								setCodeValues,
+								clientId: drag.clientId,
+								undoLabel:
+									changes.length > 1 ? 'Move selected sequences' : null,
+								redoLabel:
+									changes.length > 1 ? 'Move selected sequences back' : null,
+							})
+						: Promise.resolve(),
+					...keyframedChanges.map((change) =>
+						callAddSequenceKeyframe({
+							fileName: change.fileName,
+							nodePath: change.nodePath,
+							fieldKey: change.fieldKey,
+							sourceFrame: change.sourceFrame,
+							value: change.value,
+							schema: change.schema,
+							setCodeValues,
+							clientId: change.clientId,
+						}),
+					),
+				])
 					.catch((err) => {
 						showNotification(
 							`Could not save sequence props: ${
@@ -1422,7 +1522,7 @@ export const SelectedOutlineOverlay: React.FC<{
 		return getSequencesWithSelectableOutlines({
 			sequences,
 			overrideIdsToNodePaths: overrideIdToNodePathMappings,
-		}).map(({key, nodePathInfo, sequence}) => {
+		}).map(({key, keyframeDisplayOffset, nodePathInfo, sequence}) => {
 			if (sequence.refForOutline === null) {
 				throw new Error('Expected sequence to have a ref for outline');
 			}
@@ -1438,11 +1538,15 @@ export const SelectedOutlineOverlay: React.FC<{
 			const scaleCodeValue = Internals.getCodeValuesCtx(codeValues, nodePath)?.[
 				scaleFieldKey
 			];
+			const canDragStatus =
+				codeValue?.status === 'static' ||
+				(codeValue?.status === 'keyframed' &&
+					codeValue.interpolationFunction === 'interpolate');
 			const canDrag =
 				previewServerState.type === 'connected' &&
 				controls !== null &&
 				fieldSchema?.type === 'translate' &&
-				codeValue?.status === 'static';
+				canDragStatus;
 			const canScaleDrag =
 				previewServerState.type === 'connected' &&
 				controls !== null &&
@@ -1460,6 +1564,7 @@ export const SelectedOutlineOverlay: React.FC<{
 							codeValue,
 							clientId: previewServerState.clientId,
 							fieldDefault: fieldSchema.default,
+							keyframeDisplayOffset,
 							nodePath,
 							schema: controls.schema,
 						}

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1013,12 +1013,14 @@ test('Selected outline dragging applies the same delta to all selected sequences
 		{
 			defaultValue: JSON.stringify('0px 0px'),
 			key: Internals.makeSequencePropsSubscriptionKey(firstNodePath),
+			sourceFrame: 12,
 			startX: 10,
 			startY: 20,
 			target: {
 				clientId: 'client',
 				codeValue: {status: 'static', codeValue: '10px 20px'},
 				fieldDefault: '0px 0px',
+				keyframeDisplayOffset: 30,
 				nodePath: firstNodePath,
 				schema,
 			},
@@ -1026,12 +1028,14 @@ test('Selected outline dragging applies the same delta to all selected sequences
 		{
 			defaultValue: JSON.stringify('0px 0px'),
 			key: Internals.makeSequencePropsSubscriptionKey(secondNodePath),
+			sourceFrame: 12,
 			startX: -5,
 			startY: 3,
 			target: {
 				clientId: 'client',
 				codeValue: {status: 'static', codeValue: '-5px 3px'},
 				fieldDefault: '0px 0px',
+				keyframeDisplayOffset: 30,
 				nodePath: secondNodePath,
 				schema,
 			},
@@ -1053,6 +1057,7 @@ test('Selected outline dragging applies the same delta to all selected sequences
 		}),
 	).toEqual([
 		{
+			type: 'static',
 			fileName: '/project/src/Comp.tsx',
 			nodePath: firstNodePath,
 			fieldKey: 'style.translate',
@@ -1061,6 +1066,7 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			schema,
 		},
 		{
+			type: 'static',
 			fileName: '/project/src/Comp.tsx',
 			nodePath: secondNodePath,
 			fieldKey: 'style.translate',
@@ -1069,6 +1075,72 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			schema,
 		},
 	]);
+});
+
+test('Selected outline dragging keyframed translate adds a keyframe at the source frame', () => {
+	const schema = {
+		'style.translate': {type: 'translate', default: '0px 0px'},
+	} satisfies SequenceSchema;
+	const nodePath = makeKey(['body', 0]);
+	const dragStates = [
+		{
+			defaultValue: JSON.stringify('0px 0px'),
+			key: Internals.makeSequencePropsSubscriptionKey(nodePath),
+			sourceFrame: 20,
+			startX: 50,
+			startY: 25,
+			target: {
+				clientId: 'client',
+				codeValue: {
+					status: 'keyframed',
+					codeValue: undefined,
+					interpolationFunction: 'interpolate',
+					keyframes: [
+						{frame: 0, value: '0px 0px'},
+						{frame: 40, value: '100px 50px'},
+					],
+					easing: ['linear'],
+					clamping: {left: 'extend', right: 'extend'},
+					posterize: undefined,
+				},
+				fieldDefault: '0px 0px',
+				keyframeDisplayOffset: 30,
+				nodePath,
+				schema,
+			},
+		},
+	] satisfies SelectedOutlineDragState[];
+
+	const lastValues = getSelectedOutlineDragValues({
+		dragStates,
+		deltaX: 7,
+		deltaY: -4,
+	});
+
+	expect(lastValues.get(dragStates[0].key)).toBe('57px 21px');
+	expect(
+		getSelectedOutlineDragChanges({
+			dragStates,
+			lastValues,
+		}),
+	).toEqual([
+		{
+			type: 'keyframed',
+			fileName: '/project/src/Comp.tsx',
+			nodePath,
+			fieldKey: 'style.translate',
+			sourceFrame: 20,
+			value: '57px 21px',
+			schema,
+			clientId: 'client',
+		},
+	]);
+	expect(
+		getSelectedOutlineDragChanges({
+			dragStates,
+			lastValues: new Map([[dragStates[0].key, '50px 25px']]),
+		}),
+	).toEqual([]);
 });
 
 test('Selected outline edge dragging scales one axis when scale is unlinked', () => {


### PR DESCRIPTION
## Summary
- Allow selected sequence outlines with keyframed `style.translate` to be dragged in Visual Mode.
- Preview keyframed translate drags at the current sequence source frame and persist them through the existing add-keyframe API.
- Add coverage for keyframed outline translate drag changes and no-op drag suppression.

Fixes #8044.

## Testing
- `cd packages/studio && bun test src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`
