### PR TITLE
`@remotion/studio`: Fix negative sequence frame labels

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -32,7 +32,8 @@ const IMAGE_GRADIENT = 'linear-gradient(to top, #2980b9, #3498db)';
 const TimelineSequenceFn: React.FC<{
 	readonly s: TSequence;
 	readonly nodePathInfo: SequenceNodePathInfo | null;
-}> = ({s, nodePathInfo}) => {
+	readonly sequenceFrameOffset: number;
+}> = ({s, nodePathInfo, sequenceFrameOffset}) => {
 	const windowWidth = useContext(TimelineWidthContext);
 
 	if (windowWidth === null) {
@@ -44,6 +45,7 @@ const TimelineSequenceFn: React.FC<{
 			windowWidth={windowWidth}
 			s={s}
 			nodePathInfo={nodePathInfo}
+			sequenceFrameOffset={sequenceFrameOffset}
 		/>
 	);
 };
@@ -56,6 +58,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	readonly style: React.CSSProperties;
 	readonly children: React.ReactNode;
 	readonly nodePathInfo: SequenceNodePathInfo | null;
+	readonly sequenceFrameOffset: number;
 	readonly fromCanUpdate: boolean;
 	readonly onMoveDragPointerDown: (
 		e: React.PointerEvent<HTMLDivElement>,
@@ -68,6 +71,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	style,
 	children,
 	nodePathInfo,
+	sequenceFrameOffset,
 	fromCanUpdate,
 	onMoveDragPointerDown,
 }) => {
@@ -90,10 +94,11 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	);
 	const frame = useCurrentFrame();
 	const relativeFrame = frame - s.from;
+	const sequenceFrame = relativeFrame + sequenceFrameOffset;
 	const relativeFrameWithPremount = relativeFrame + (s.premountDisplay ?? 0);
 	const relativeFrameWithPostmount = relativeFrame - displayDurationInFrames;
 
-	const roundedFrame = Math.round(relativeFrame * 100) / 100;
+	const roundedFrame = Math.round(sequenceFrame * 100) / 100;
 
 	const isInRange =
 		relativeFrame >= 0 && relativeFrame < displayDurationInFrames;
@@ -184,7 +189,8 @@ const TimelineSequenceInner: React.FC<{
 	readonly s: TSequence;
 	readonly windowWidth: number;
 	readonly nodePathInfo: SequenceNodePathInfo | null;
-}> = ({s, windowWidth, nodePathInfo}) => {
+	readonly sequenceFrameOffset: number;
+}> = ({s, windowWidth, nodePathInfo, sequenceFrameOffset}) => {
 	// If a duration is 1, it is essentially a still and it should have width 0
 	// Some compositions may not be longer than their media duration,
 	// if that is the case, it needs to be asynchronously determined
@@ -302,6 +308,7 @@ const TimelineSequenceInner: React.FC<{
 			postmountWidth={postmountWidth}
 			style={style}
 			nodePathInfo={nodePathInfo}
+			sequenceFrameOffset={sequenceFrameOffset}
 			fromCanUpdate={fromCanUpdate}
 			onMoveDragPointerDown={onMoveDragPointerDown}
 		>

--- a/packages/studio/src/components/Timeline/TimelineSequenceFrame.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceFrame.tsx
@@ -7,6 +7,7 @@ const relativeFrameStyle: React.CSSProperties = {
 	opacity: 0.5,
 	whiteSpace: 'nowrap',
 	pointerEvents: 'none',
+	userSelect: 'none',
 };
 
 export const TimelineSequenceFrame: React.FC<{

--- a/packages/studio/src/components/Timeline/TimelineTrack.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTrack.tsx
@@ -51,6 +51,7 @@ const TimelineTrackUnmemoized: React.FC<{
 				<TimelineSequence
 					s={track.sequence}
 					nodePathInfo={track.nodePathInfo}
+					sequenceFrameOffset={track.sequenceFrameOffset}
 				/>
 			</div>
 			{showExpandedKeyframes && track.nodePathInfo ? (

--- a/packages/studio/src/helpers/calculate-timeline.ts
+++ b/packages/studio/src/helpers/calculate-timeline.ts
@@ -102,6 +102,7 @@ export const calculateTimeline = ({
 			keyframeDisplayOffset: hasKeyframeRows
 				? cascadedStart - sequence.from
 				: 0,
+			sequenceFrameOffset: visibleStart - cascadedStart,
 			nodePathInfo: nodePath
 				? {
 						sequenceSubscriptionKey: nodePath,

--- a/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
@@ -13,6 +13,7 @@ type Track = {
 	depth: number;
 	nodePathInfo: SequenceNodePathInfo | null;
 	keyframeDisplayOffset: number;
+	sequenceFrameOffset: number;
 };
 
 export type TrackWithHash = Track & {

--- a/packages/studio/src/test/big-timeline.test.ts
+++ b/packages/studio/src/test/big-timeline.test.ts
@@ -5,12 +5,13 @@ import {calculateTimeline} from '../helpers/calculate-timeline';
 const getStack = () => null;
 
 const withoutKeyframeDisplayOffset = <
-	T extends {keyframeDisplayOffset: number},
+	T extends {keyframeDisplayOffset: number; sequenceFrameOffset: number},
 >(
 	tracks: T[],
 ) =>
-	tracks.map(({keyframeDisplayOffset, ...track}) => {
+	tracks.map(({keyframeDisplayOffset, sequenceFrameOffset, ...track}) => {
 		expect(keyframeDisplayOffset).toBe(0);
+		expect(sequenceFrameOffset).toBeGreaterThanOrEqual(0);
 		return track;
 	});
 

--- a/packages/studio/src/test/sequenced-timeline.test.ts
+++ b/packages/studio/src/test/sequenced-timeline.test.ts
@@ -5,12 +5,13 @@ import {calculateTimeline} from '../helpers/calculate-timeline';
 const getStack = () => null;
 
 const withoutKeyframeDisplayOffset = <
-	T extends {keyframeDisplayOffset: number},
+	T extends {keyframeDisplayOffset: number; sequenceFrameOffset: number},
 >(
 	tracks: T[],
 ) =>
-	tracks.map(({keyframeDisplayOffset, ...track}) => {
+	tracks.map(({keyframeDisplayOffset, sequenceFrameOffset, ...track}) => {
 		expect(keyframeDisplayOffset).toBe(0);
+		expect(sequenceFrameOffset).toBeGreaterThanOrEqual(0);
 		return track;
 	});
 

--- a/packages/studio/src/test/timeline.test.ts
+++ b/packages/studio/src/test/timeline.test.ts
@@ -4,12 +4,13 @@ import {calculateTimeline} from '../helpers/calculate-timeline';
 const getStack = () => null;
 
 const withoutKeyframeDisplayOffset = <
-	T extends {keyframeDisplayOffset: number},
+	T extends {keyframeDisplayOffset: number; sequenceFrameOffset: number},
 >(
 	tracks: T[],
 ) =>
-	tracks.map(({keyframeDisplayOffset, ...track}) => {
+	tracks.map(({keyframeDisplayOffset, sequenceFrameOffset, ...track}) => {
 		expect(keyframeDisplayOffset).toBe(0);
+		expect(sequenceFrameOffset).toBe(0);
 		return track;
 	});
 
@@ -237,4 +238,35 @@ test('Should inherit loop display from parent for media tracks', () => {
 		numberOfTimes: 3,
 		startOffset: -50,
 	});
+});
+
+test('Should calculate sequence frame offset for negative from values', () => {
+	const calculated = calculateTimeline({
+		overrideIdsToNodePaths: {},
+		sequences: [
+			{
+				displayName: 'Trimmed',
+				documentationLink: null,
+				duration: 137,
+				from: -37,
+				id: 'trimmed',
+				parent: null,
+				rootId: 'trimmed',
+				showInTimeline: true,
+				type: 'sequence',
+				nonce: [[0, 0]],
+				getStack,
+				refForOutline: null,
+				isInsideSeries: false,
+				premountDisplay: null,
+				postmountDisplay: null,
+				controls: null,
+				loopDisplay: undefined,
+				effects: [],
+			},
+		],
+	});
+
+	expect(calculated[0].sequence.from).toBe(0);
+	expect(calculated[0].sequenceFrameOffset).toBe(37);
 });


### PR DESCRIPTION
## Summary
- Fix Studio timeline sequence frame labels for sequences whose visible start is clipped by a negative `from` value.
- Make the displayed frame number non-selectable.

Closes #8106.

## Tests
- `bun test packages/studio/src/test/timeline.test.ts packages/studio/src/test/sequenced-timeline.test.ts packages/studio/src/test/big-timeline.test.ts packages/studio/src/test/timeline-keyframes.test.ts`
- `bun run build`
- `bun run stylecheck`
