### PR TITLE
Docs: Document `effects` prop

### DIFF
--- a/packages/docs/docs/animatedimage.mdx
+++ b/packages/docs/docs/animatedimage.mdx
@@ -64,6 +64,10 @@ Must be one of these values:
 - `'contain'`: The image is scaled to fit the box, while aspect ratio is maintained.
 - `'cover'`: The image completely fills the container and maintains it's aspect ratio. It will be cropped if necessary.
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) to each frame after it has been drawn to the canvas.
+
 ### `style?`
 
 Allows to pass in custom CSS styles. You may not pass `width` and `height`, instead use the props `width` and `height` to set the size of the image.

--- a/packages/docs/docs/animatedimage.mdx
+++ b/packages/docs/docs/animatedimage.mdx
@@ -48,6 +48,10 @@ Remote images need to support [CORS](https://developer.mozilla.org/en-US/docs/We
 </details>
 :::
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) to each frame after it has been drawn to the canvas.
+
 ### `width?`
 
 The display width.
@@ -63,10 +67,6 @@ Must be one of these values:
 - `'fill'`: The image will completely fill the container, and will be stretched if necessary. (_default_)
 - `'contain'`: The image is scaled to fit the box, while aspect ratio is maintained.
 - `'cover'`: The image completely fills the container and maintains it's aspect ratio. It will be cropped if necessary.
-
-### `effects?`<AvailableFrom v="4.0.464" />
-
-Apply [effects](/docs/effects/api) to each frame after it has been drawn to the canvas.
 
 ### `style?`
 

--- a/packages/docs/docs/canvasimage.mdx
+++ b/packages/docs/docs/canvasimage.mdx
@@ -33,6 +33,10 @@ The URL of the image. Can be a remote URL or a local file path from [`staticFile
 
 Remote images need to support [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) because the image is drawn onto a canvas.
 
+### `effects?`
+
+An array of Remotion [effects](/docs/effects/api) to apply to the image after it has been drawn to the source canvas.
+
 ### `width?`
 
 The canvas width in pixels.  
@@ -50,10 +54,6 @@ Must be one of these values:
 - `'fill'`: The image will completely fill the canvas, and will be stretched if necessary. (_default_)
 - `'contain'`: The image is scaled to fit the canvas, while aspect ratio is maintained.
 - `'cover'`: The image completely fills the canvas and maintains its aspect ratio. It will be cropped if necessary.
-
-### `effects?`
-
-An array of Remotion [effects](/docs/effects/api) to apply to the image after it has been drawn to the source canvas.
 
 ### `className?`
 

--- a/packages/docs/docs/effects.mdx
+++ b/packages/docs/docs/effects.mdx
@@ -14,12 +14,13 @@ Pixels of canvas-based components can be manipulated using effects.
 The following components support effects:
 
 - [`<Solid>`](/docs/solid)
-- [`<HtmlInCanvas>`](/docs/html-in-canvas)
+- [`<HtmlInCanvas>`](/docs/remotion/html-in-canvas)
 - [`<Video>`](/docs/media/video)
 - [`<Img>`](/docs/img)
 - [`<CanvasImage>`](/docs/canvasimage)
 - [`<AnimatedImage>`](/docs/animatedimage)
 - [`<Gif>`](/docs/gif/gif)
+- [`<RemotionRiveCanvas>`](/docs/rive/remotionrivecanvas)
 
 ## Usage
 

--- a/packages/docs/docs/effects/index.mdx
+++ b/packages/docs/docs/effects/index.mdx
@@ -7,11 +7,24 @@ title: '@remotion/effects'
 
 # @remotion/effects<AvailableFrom v="4.0.464" />
 
-[Effects](/docs/effects) that can be applied to Remotion-based canvas components such as [`<Solid>`](/docs/solid), [`<HtmlInCanvas>`](/docs/remotion/html-in-canvas), and [`<Video>`](/docs/media/video).
+[Effects](/docs/effects) that can be applied to Remotion-based canvas components.
 
 import {TableOfContents} from './table-of-contents';
 
 <Installation pkg="@remotion/effects" />
+
+## Supported components
+
+Pass effects through the `effects` prop of these components:
+
+- [`<Solid>`](/docs/solid)
+- [`<HtmlInCanvas>`](/docs/remotion/html-in-canvas)
+- [`<Video>`](/docs/media/video)
+- [`<Img>`](/docs/img)
+- [`<CanvasImage>`](/docs/canvasimage)
+- [`<AnimatedImage>`](/docs/animatedimage)
+- [`<Gif>`](/docs/gif/gif)
+- [`<RemotionRiveCanvas>`](/docs/rive/remotionrivecanvas)
 
 ## Effects
 

--- a/packages/docs/docs/gif/gif.mdx
+++ b/packages/docs/docs/gif/gif.mdx
@@ -74,6 +74,10 @@ Must be one of these values:
 - `'contain'`: The GIF is scaled to fit the box, while aspect ratio is maintained.
 - `'cover'`: The GIF completely fills the container and maintains it's aspect ratio. It will be cropped if necessary.
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) to each GIF frame after it has been drawn to the canvas.
+
 ### `onLoad`
 
 Callback that gets called once the GIF has loaded and finished processing. As its only argument, the callback gives the following object:

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -280,6 +280,10 @@ export const MyComposition = () => {
 The CSS property `object-fit` is not supported.
 :::
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) to the video frame after it has been drawn to the canvas.
+
 ### `loop?`
 
 Makes the video loop indefinitely.

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -66,6 +66,10 @@ For more information on HLS support, see the [HLS documentation](/docs/hls).
 
 The URL of the video to be rendered. Can be a remote URL or a local file referenced with [`staticFile()`](/docs/staticfile).
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) to the video frame after it has been drawn to the canvas.
+
 ### `from?`<AvailableFrom v="4.0.445" />
 
 At which frame this clip should start relative to the parent timeline. Default is `0`. Same meaning as [`from`](/docs/sequence#from) on [`<Sequence>`](/docs/sequence).
@@ -279,10 +283,6 @@ export const MyComposition = () => {
 :::note
 The CSS property `object-fit` is not supported.
 :::
-
-### `effects?`<AvailableFrom v="4.0.464" />
-
-Apply [effects](/docs/effects/api) to the video frame after it has been drawn to the canvas.
 
 ### `loop?`
 

--- a/packages/docs/docs/remotion/html-in-canvas.mdx
+++ b/packages/docs/docs/remotion/html-in-canvas.mdx
@@ -92,6 +92,11 @@ Do not nest `<HtmlInCanvas>` inside another `<HtmlInCanvas>`. Nesting is not sup
 <HtmlInCanvas> effects cannot be nested together. Chrome will only display the outer effect. Consider merging the effects into one if you can.
 ```
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) after the children have been painted to the canvas.  
+If you also pass [`onPaint`](#onpaint), effects are applied after `onPaint` has finished drawing.
+
 ### `onPaint?`
 
 Called when the children are updated and can be painted onto the canvas.  

--- a/packages/docs/docs/rive/remotionrivecanvas.mdx
+++ b/packages/docs/docs/rive/remotionrivecanvas.mdx
@@ -121,6 +121,10 @@ A class name to apply to the underlying `<canvas>` element.
 
 Inline styles to apply to the underlying `<canvas>` element.
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) after the Rive animation has been drawn to the canvas.
+
 ## Inherited props<AvailableFrom v="4.0.464" />
 
 `<RemotionRiveCanvas>` inherits [`from`](/docs/sequence#from), [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`showInTimeline`](/docs/sequence#showintimeline) and [`hidden`](/docs/sequence#hidden) from [`<Sequence>`](/docs/sequence).

--- a/packages/docs/docs/rive/remotionrivecanvas.mdx
+++ b/packages/docs/docs/rive/remotionrivecanvas.mdx
@@ -26,6 +26,10 @@ function App() {
 
 a valid URL of the rive file to load. Can be a local file loaded using [`staticFile()`](/docs/staticfile) or a remote URL like `"https://cdn.rive.app/animations/vehicles.riv"`.
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) after the Rive animation has been drawn to the canvas.
+
 ### `fit?`
 
 One of: `"contain" | "cover" | "fill" | "fit-height" | "none" | "scale-down" | "fit-width"`. Default is `"contain"`.
@@ -120,10 +124,6 @@ A class name to apply to the underlying `<canvas>` element.
 ### `style?`<AvailableFrom v="4.0.464" />
 
 Inline styles to apply to the underlying `<canvas>` element.
-
-### `effects?`<AvailableFrom v="4.0.464" />
-
-Apply [effects](/docs/effects/api) after the Rive animation has been drawn to the canvas.
 
 ## Inherited props<AvailableFrom v="4.0.464" />
 

--- a/packages/docs/docs/solid.mdx
+++ b/packages/docs/docs/solid.mdx
@@ -31,14 +31,14 @@ Logical width of the canvas in pixels. Must be a positive integer.
 
 Logical height of the canvas in pixels. Must be a positive integer.
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) after the rectangle has been painted to the canvas.
+
 ### `color?`
 
 Fill color of the rectangle.  
 If omitted, it is `transparent`.
-
-### `effects?`<AvailableFrom v="4.0.464" />
-
-Apply [effects](/docs/effects/api) after the rectangle has been painted to the canvas.
 
 ### `pixelDensity?`<AvailableFrom v="4.0.472" />
 

--- a/packages/docs/docs/solid.mdx
+++ b/packages/docs/docs/solid.mdx
@@ -36,6 +36,10 @@ Logical height of the canvas in pixels. Must be a positive integer.
 Fill color of the rectangle.  
 If omitted, it is `transparent`.
 
+### `effects?`<AvailableFrom v="4.0.464" />
+
+Apply [effects](/docs/effects/api) after the rectangle has been painted to the canvas.
+
 ### `pixelDensity?`<AvailableFrom v="4.0.472" />
 
 _number_
@@ -87,8 +91,7 @@ const MyComp = () => {
 
 ## What is this component for?
 
-This is mainly a component for adding effects to.  
-Effects are an upcoming feature of Remotion - if you are here, you are early!
+This is mainly a component for adding [effects](/docs/effects/api) to a solid color.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

- Document the `effects` prop on all supported component API pages.
- Add complete supported-component lists to `/docs/effects` and `/docs/effects/api`.

## Checks
- `bun run build`
- `bun run stylecheck`
