### PR TITLE
`@remotion/studio`: Add folder context menu

### DIFF
--- a/packages/core/src/CompositionManagerContext.tsx
+++ b/packages/core/src/CompositionManagerContext.tsx
@@ -55,6 +55,7 @@ export type CompositionManagerSetters = {
 		name: string,
 		parent: string | null,
 		nonce: NonceHistory,
+		stack: string | null,
 	) => void;
 	unregisterFolder: (name: string, parent: string | null) => void;
 	setCanvasContent: React.Dispatch<React.SetStateAction<CanvasContent | null>>;

--- a/packages/core/src/CompositionManagerProvider.tsx
+++ b/packages/core/src/CompositionManagerProvider.tsx
@@ -79,7 +79,12 @@ export const CompositionManagerProvider = ({
 	}, []);
 
 	const registerFolder = useCallback(
-		(name: string, parent: string | null, nonce: NonceHistory) => {
+		(
+			name: string,
+			parent: string | null,
+			nonce: NonceHistory,
+			stack: string | null,
+		) => {
 			setFolders((prevFolders) => {
 				return [
 					...prevFolders,
@@ -87,6 +92,7 @@ export const CompositionManagerProvider = ({
 						name,
 						parent,
 						nonce,
+						stack,
 					},
 				];
 			});

--- a/packages/core/src/Folder.tsx
+++ b/packages/core/src/Folder.tsx
@@ -10,6 +10,7 @@ export type TFolder = {
 	name: string;
 	parent: string | null;
 	nonce: NonceHistory;
+	stack: string | null;
 };
 
 type FolderContextType = {
@@ -29,10 +30,12 @@ export const FolderContext = createContext<FolderContextType>({
 export const Folder: FC<{
 	readonly name: string;
 	readonly children: React.ReactNode;
-}> = ({name, children}) => {
+}> = (props) => {
+	const {name, children} = props;
 	const parent = useContext(FolderContext);
 	const {registerFolder, unregisterFolder} = useContext(CompositionSetters);
 	const nonce = useNonce();
+	const stack = (props as {stack?: string}).stack ?? null;
 
 	validateFolderName(name);
 
@@ -49,7 +52,7 @@ export const Folder: FC<{
 	}, [name, parentName]);
 
 	useEffect(() => {
-		registerFolder(name, parentName, nonce.get());
+		registerFolder(name, parentName, nonce.get(), stack);
 
 		return () => {
 			unregisterFolder(name, parentName);
@@ -61,6 +64,7 @@ export const Folder: FC<{
 		registerFolder,
 		unregisterFolder,
 		nonce,
+		stack,
 	]);
 
 	return (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ import type {
 } from './CompositionManager.js';
 import type {DelayRenderScope} from './delay-render.js';
 import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
+import {Folder, type TFolder} from './Folder.js';
 import type {StaticFile} from './get-static-files.js';
 import {useIsPlayer} from './is-player.js';
 import type {LogLevel} from './log.js';
@@ -302,9 +303,11 @@ export const Config = new Proxy(proxyObj, {
 Sequence.displayName = 'Sequence';
 addSequenceStackTraces(Sequence);
 addSequenceStackTraces(Composition);
+addSequenceStackTraces(Folder);
 
 export type _InternalTypes = {
 	AnyComposition: AnyComposition;
+	TFolder: TFolder;
 	BundleCompositionState: BundleCompositionState;
 	BundleState: BundleState;
 	VideoConfigWithSerializedProps: VideoConfigWithSerializedProps;

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -220,6 +220,10 @@ import {
 	invalidCompositionErrorMessage,
 	isCompositionIdValid,
 } from './validation/validate-composition-id.js';
+import {
+	invalidFolderNameErrorMessage,
+	isFolderNameValid,
+} from './validation/validate-folder-name.js';
 import {DurationsContextProvider} from './video/duration-state.js';
 import {InnerOffthreadVideo} from './video/OffthreadVideo.js';
 import {isIosSafari} from './video/video-fragment.js';
@@ -305,8 +309,10 @@ export const Internals = {
 	SharedAudioTagsContext,
 	SharedAudioTagsContextProvider,
 	invalidCompositionErrorMessage,
+	invalidFolderNameErrorMessage,
 	calculateMediaDuration,
 	isCompositionIdValid,
+	isFolderNameValid,
 	getPreviewDomElement,
 	compositionsRef,
 	portalNode,

--- a/packages/studio-server/src/codemods/recast-mods.ts
+++ b/packages/studio-server/src/codemods/recast-mods.ts
@@ -39,7 +39,7 @@ export const applyCodemod = ({
 	}
 
 	const body = file.program.body.map((node) => {
-		return mapAll(node, codeMod, changesMade);
+		return mapAll(node, codeMod, changesMade, null);
 	});
 
 	return {
@@ -58,9 +58,15 @@ const mapAll = <T extends Statement | Expression>(
 	node: T,
 	transformation: RecastCodemod,
 	changesMade: Change[],
+	parentFolderName: string | null,
 ): T => {
 	if (isRecognizedType(node)) {
-		return mapRecognizedType(node, transformation, changesMade);
+		return mapRecognizedType(
+			node,
+			transformation,
+			changesMade,
+			parentFolderName,
+		);
 	}
 
 	return node;
@@ -97,11 +103,17 @@ const mapVariableDeclarator = (
 	variableDeclarator: VariableDeclarator,
 	transformation: RecastCodemod,
 	changesMade: Change[],
+	parentFolderName: string | null,
 ): VariableDeclarator => {
 	return {
 		...variableDeclarator,
 		init: variableDeclarator.init
-			? mapAll(variableDeclarator.init, transformation, changesMade)
+			? mapAll(
+					variableDeclarator.init,
+					transformation,
+					changesMade,
+					parentFolderName,
+				)
 			: variableDeclarator.init,
 	};
 };
@@ -110,11 +122,12 @@ const mapBlockStatement = (
 	blockStatement: BlockStatement,
 	transformation: RecastCodemod,
 	changesMade: Change[],
+	parentFolderName: string | null,
 ): BlockStatement => {
 	return {
 		...blockStatement,
 		body: blockStatement.body.map((a) => {
-			return mapAll(a, transformation, changesMade);
+			return mapAll(a, transformation, changesMade, parentFolderName);
 		}),
 	};
 };
@@ -123,6 +136,7 @@ const mapReturnStatement = (
 	statement: ReturnStatement,
 	transformation: RecastCodemod,
 	changesMade: Change[],
+	parentFolderName: string | null,
 ): ReturnStatement => {
 	if (!statement.argument) {
 		return statement;
@@ -132,6 +146,7 @@ const mapReturnStatement = (
 		statement.argument,
 		transformation,
 		changesMade,
+		parentFolderName,
 	);
 	if (replacement !== null) {
 		return {...statement, argument: replacement};
@@ -139,7 +154,12 @@ const mapReturnStatement = (
 
 	return {
 		...statement,
-		argument: mapAll(statement.argument, transformation, changesMade),
+		argument: mapAll(
+			statement.argument,
+			transformation,
+			changesMade,
+			parentFolderName,
+		),
 	};
 };
 
@@ -166,12 +186,28 @@ const stripParenthesizedExtra = <T extends {extra?: unknown}>(node: T): T => {
 	return {...node, extra: rest};
 };
 
-const wrapInJsxFragment = (children: JSXElement[]): JSXFragment => ({
+const wrapInJsxFragment = (children: JSXFragment['children']): JSXFragment => ({
 	type: 'JSXFragment',
 	openingFragment: {type: 'JSXOpeningFragment'},
 	closingFragment: {type: 'JSXClosingFragment'},
-	children: children.map(stripParenthesizedExtra),
+	children: children.map((child) => {
+		if (child.type === 'JSXElement' || child.type === 'JSXFragment') {
+			return stripParenthesizedExtra(child);
+		}
+
+		return child;
+	}),
 });
+
+const isJsxExpression = (
+	child: JSXFragment['children'][number],
+): child is JSXElement | JSXFragment => {
+	return child.type === 'JSXElement' || child.type === 'JSXFragment';
+};
+
+const isMeaningfulJsxChild = (child: JSXFragment['children'][number]) => {
+	return child.type !== 'JSXText' || child.value.trim() !== '';
+};
 
 // When a <Composition> JSX element appears in a position where it cannot
 // simply be removed from a parent's children list (e.g. as the sole return
@@ -182,14 +218,27 @@ const transformLoneJsxElement = (
 	expression: Expression,
 	transformation: RecastCodemod,
 	changesMade: Change[],
+	parentFolderName: string | null,
 ): Expression | null => {
 	if (expression.type !== 'JSXElement') {
 		return null;
 	}
 
 	const compId = getCompositionIdFromJSXElement(expression);
+	const folderName = getFolderNameFromJSXElement(expression);
 	if (compId === null) {
-		return null;
+		const isFolderMatch =
+			folderName !== null &&
+			((transformation.type === 'delete-folder' &&
+				folderName === transformation.folderName &&
+				parentFolderName === transformation.parentName) ||
+				(transformation.type === 'rename-folder' &&
+					folderName === transformation.folderName &&
+					parentFolderName === transformation.parentName));
+
+		if (!isFolderMatch) {
+			return null;
+		}
 	}
 
 	const isMatch =
@@ -198,20 +247,32 @@ const transformLoneJsxElement = (
 		(transformation.type === 'rename-composition' &&
 			compId === transformation.idToRename) ||
 		(transformation.type === 'duplicate-composition' &&
-			compId === transformation.idToDuplicate);
+			compId === transformation.idToDuplicate) ||
+		(transformation.type === 'delete-folder' &&
+			folderName === transformation.folderName &&
+			parentFolderName === transformation.parentName) ||
+		(transformation.type === 'rename-folder' &&
+			folderName === transformation.folderName &&
+			parentFolderName === transformation.parentName);
 
 	if (!isMatch) {
 		return null;
 	}
 
-	const transformed = mapJsxChild(expression, transformation, changesMade);
+	const transformed = mapJsxChild(
+		expression,
+		transformation,
+		changesMade,
+		parentFolderName,
+	);
+	const meaningful = transformed.filter(isMeaningfulJsxChild);
 
-	if (transformed.length === 0) {
+	if (meaningful.length === 0) {
 		return nullLiteral();
 	}
 
-	if (transformed.length === 1) {
-		return transformed[0];
+	if (meaningful.length === 1 && isJsxExpression(meaningful[0])) {
+		return meaningful[0];
 	}
 
 	return wrapInJsxFragment(transformed);
@@ -221,6 +282,7 @@ const mapJsxElementOrFragment = <T extends JSXFragment | JSXElement>(
 	jsxFragment: T,
 	transformation: RecastCodemod,
 	changesMade: Change[],
+	parentFolderName: string | null,
 ): T => {
 	return {
 		...jsxFragment,
@@ -230,18 +292,30 @@ const mapJsxElementOrFragment = <T extends JSXFragment | JSXElement>(
 					return c;
 				}
 
-				return mapJsxChild(c, transformation, changesMade);
+				return mapJsxChild(c, transformation, changesMade, parentFolderName);
 			})
 			.flat(1),
 	};
+};
+
+const getChildFolderParentName = ({
+	folderName,
+	parentFolderName,
+}: {
+	folderName: string;
+	parentFolderName: string | null;
+}) => {
+	return [parentFolderName, folderName].filter(Boolean).join('/');
 };
 
 const mapJsxChild = (
 	c: JSXElement,
 	transformation: RecastCodemod | null,
 	changesMade: Change[],
-): JSXElement[] => {
+	parentFolderName: string | null,
+): JSXFragment['children'] => {
 	const compId = getCompositionIdFromJSXElement(c);
+	const folderName = getFolderNameFromJSXElement(c);
 
 	if (transformation === null) {
 		return [c];
@@ -294,19 +368,50 @@ const mapJsxChild = (
 		return [];
 	}
 
-	return [mapAll(c, transformation, changesMade)];
+	if (
+		transformation.type === 'rename-folder' &&
+		folderName === transformation.folderName &&
+		parentFolderName === transformation.parentName
+	) {
+		return [
+			changeFolderName({
+				jsxElement: c,
+				newFolderName: transformation.newName,
+				changesMade,
+			}),
+		];
+	}
+
+	if (
+		transformation.type === 'delete-folder' &&
+		folderName === transformation.folderName &&
+		parentFolderName === transformation.parentName
+	) {
+		changesMade.push({
+			description: 'Deleted folder',
+		});
+		return c.children;
+	}
+
+	const childParentFolderName = folderName
+		? getChildFolderParentName({folderName, parentFolderName})
+		: parentFolderName;
+
+	return [mapAll(c, transformation, changesMade, childParentFolderName)];
 };
 
 const mapRecognizedType = <T extends RecognizedType>(
 	expression: T,
 	transformation: RecastCodemod,
 	changesMade: Change[],
+	parentFolderName: string | null,
 ): T => {
 	if (expression.type === 'JSXFragment' || expression.type === 'JSXElement') {
 		return mapJsxElementOrFragment(
 			expression,
 			transformation,
 			changesMade,
+			parentFolderName,
 		) as T;
 	}
 
@@ -322,6 +427,7 @@ const mapRecognizedType = <T extends RecognizedType>(
 				expression.body,
 				transformation,
 				changesMade,
+				parentFolderName,
 			);
 			if (replacement !== null) {
 				return {
@@ -333,13 +439,23 @@ const mapRecognizedType = <T extends RecognizedType>(
 
 		return {
 			...expression,
-			body: mapAll(expression.body, transformation, changesMade),
+			body: mapAll(
+				expression.body,
+				transformation,
+				changesMade,
+				parentFolderName,
+			),
 		};
 	}
 
 	if (expression.type === 'VariableDeclaration') {
 		const declarations = expression.declarations.map((d) => {
-			return mapVariableDeclarator(d, transformation, changesMade);
+			return mapVariableDeclarator(
+				d,
+				transformation,
+				changesMade,
+				parentFolderName,
+			);
 		});
 		return {...expression, declarations};
 	}
@@ -347,7 +463,12 @@ const mapRecognizedType = <T extends RecognizedType>(
 	if (expression.type === 'FunctionDeclaration') {
 		return {
 			...expression,
-			body: mapBlockStatement(expression.body, transformation, changesMade),
+			body: mapBlockStatement(
+				expression.body,
+				transformation,
+				changesMade,
+				parentFolderName,
+			),
 		};
 	}
 
@@ -361,16 +482,31 @@ const mapRecognizedType = <T extends RecognizedType>(
 
 		return {
 			...expression,
-			declaration: mapAll(expression.declaration, transformation, changesMade),
+			declaration: mapAll(
+				expression.declaration,
+				transformation,
+				changesMade,
+				parentFolderName,
+			),
 		};
 	}
 
 	if (expression.type === 'ReturnStatement') {
-		return mapReturnStatement(expression, transformation, changesMade) as T;
+		return mapReturnStatement(
+			expression,
+			transformation,
+			changesMade,
+			parentFolderName,
+		) as T;
 	}
 
 	if (expression.type === 'BlockStatement') {
-		return mapBlockStatement(expression, transformation, changesMade) as T;
+		return mapBlockStatement(
+			expression,
+			transformation,
+			changesMade,
+			parentFolderName,
+		) as T;
 	}
 
 	return expression;
@@ -427,6 +563,136 @@ const getCompositionIdFromJSXElement = (
 		.filter(Boolean);
 
 	return id[0];
+};
+
+const getFolderNameFromJSXElement = (
+	jsxElement: JSXFragment['children'][number],
+) => {
+	if (jsxElement.type !== 'JSXElement') {
+		return null;
+	}
+
+	const {openingElement} = jsxElement;
+	const {name} = openingElement;
+	if (name.type !== 'JSXIdentifier') {
+		return null;
+	}
+
+	if (name.name !== 'Folder') {
+		return null;
+	}
+
+	const folderName = openingElement.attributes
+		.map((attribute) => {
+			if (attribute.type === 'JSXSpreadAttribute') {
+				return null;
+			}
+
+			if (attribute.name.type === 'JSXNamespacedName') {
+				return null;
+			}
+
+			if (attribute.name.name !== 'name') {
+				return null;
+			}
+
+			if (!attribute.value) {
+				return null;
+			}
+
+			if (attribute.value.type === 'StringLiteral') {
+				return attribute.value.value;
+			}
+
+			if (
+				attribute.value.type === 'JSXExpressionContainer' &&
+				attribute.value.expression.type === 'StringLiteral'
+			) {
+				return attribute.value.expression.value;
+			}
+
+			return null;
+		})
+		.filter(Boolean);
+
+	return folderName[0];
+};
+
+const changeFolderName = ({
+	jsxElement,
+	newFolderName,
+	changesMade,
+}: {
+	jsxElement: JSXElement;
+	newFolderName: string;
+	changesMade: Change[];
+}): JSXElement => {
+	const {openingElement} = jsxElement;
+	const {name} = openingElement;
+	if (name.type !== 'JSXIdentifier') {
+		return jsxElement;
+	}
+
+	if (name.name !== 'Folder') {
+		return jsxElement;
+	}
+
+	const attributes = openingElement.attributes.map((attribute) => {
+		if (attribute.type === 'JSXSpreadAttribute') {
+			return attribute;
+		}
+
+		if (attribute.name.type === 'JSXNamespacedName') {
+			return attribute;
+		}
+
+		if (
+			attribute.name.name === 'name' &&
+			attribute.value &&
+			attribute.value.type === 'StringLiteral'
+		) {
+			changesMade.push({
+				description: 'Replaced folder name',
+			});
+
+			return {
+				...attribute,
+				value: {...attribute.value, value: newFolderName},
+			};
+		}
+
+		if (
+			attribute.name.name === 'name' &&
+			attribute.value &&
+			attribute.value.type === 'JSXExpressionContainer' &&
+			attribute.value.expression.type === 'StringLiteral'
+		) {
+			changesMade.push({
+				description: 'Replaced folder name',
+			});
+
+			return {
+				...attribute,
+				value: {
+					...attribute.value,
+					expression: {
+						...attribute.value.expression,
+						value: newFolderName,
+					},
+				},
+			};
+		}
+
+		return attribute;
+	});
+
+	return {
+		...jsxElement,
+		openingElement: {
+			...jsxElement.openingElement,
+			attributes,
+		},
+	};
 };
 
 const changeComposition = ({

--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -47,6 +47,26 @@ const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
 		};
 	}
 
+	if (codemod.type === 'delete-folder') {
+		const label = `folder "${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}"`;
+		return {
+			undoMessage: `↩️  Deletion of ${label}`,
+			redoMessage: `↪️  Deletion of ${label}`,
+			entryType: codemod.type,
+		};
+	}
+
+	if (codemod.type === 'rename-folder') {
+		const oldName = `${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}`;
+		const newName = `${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.newName}`;
+		const label = `folder "${oldName}" to "${newName}"`;
+		return {
+			undoMessage: `↩️  Rename of ${label}`,
+			redoMessage: `↪️  Rename of ${label}`,
+			entryType: codemod.type,
+		};
+	}
+
 	return {
 		undoMessage: '↩️  Visual control change',
 		redoMessage: '↪️  Visual control change',

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -31,7 +31,9 @@ type UndoEntryType =
 	| 'insert-jsx-element'
 	| 'delete-composition'
 	| 'rename-composition'
-	| 'duplicate-composition';
+	| 'duplicate-composition'
+	| 'delete-folder'
+	| 'rename-folder';
 
 type UndoEntrySnapshot = {
 	filePath: string;
@@ -65,6 +67,8 @@ type UndoEntry = {
 	| {entryType: 'delete-composition'}
 	| {entryType: 'rename-composition'}
 	| {entryType: 'duplicate-composition'}
+	| {entryType: 'delete-folder'}
+	| {entryType: 'rename-folder'}
 );
 
 const MAX_ENTRIES = 100;

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -3,6 +3,7 @@ import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import type {RecastCodemod} from '@remotion/studio-shared';
+import {parseAndApplyCodemod} from '../codemods/duplicate-composition';
 import {
 	createFileWatcherRegistry,
 	setFileWatcherRegistry,
@@ -37,6 +38,43 @@ export const RemotionRoot: React.FC = () => {
 				width={1280}
 				height={720}
 			/>
+		</>
+	);
+};
+`;
+
+const folderRootContents = `import React from 'react';
+import {Composition, Folder} from 'remotion';
+
+const Component = () => null;
+
+export const RemotionRoot: React.FC = () => {
+	return (
+		<>
+			<Folder name="Parent">
+				<Folder name="Shared">
+					<Composition
+						id="NestedA"
+						component={Component}
+						durationInFrames={120}
+						fps={30}
+						width={1280}
+						height={720}
+					/>
+				</Folder>
+			</Folder>
+			<Folder name="Other">
+				<Folder name="Shared">
+					<Composition
+						id="NestedB"
+						component={Component}
+						durationInFrames={120}
+						fps={30}
+						width={1280}
+						height={720}
+					/>
+				</Folder>
+			</Folder>
 		</>
 	);
 };
@@ -191,4 +229,56 @@ test('applyCodemodHandler pushes composition duplications to undo and redo stack
 		expectedUndoMessage:
 			'↩️  Duplication of composition "DeleteMe" to "Duplicated"',
 	});
+});
+
+test('renames a nested folder by parent path', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: folderRootContents,
+		codeMod: {
+			type: 'rename-folder',
+			folderName: 'Shared',
+			parentName: 'Parent',
+			newName: 'Renamed',
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents).toContain('<Folder name="Renamed">');
+	expect(newContents.match(/<Folder name="Shared">/g)?.length).toBe(1);
+	expect(newContents).toContain('id="NestedA"');
+	expect(newContents).toContain('id="NestedB"');
+});
+
+test('deletes a nested folder by unwrapping its children', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: folderRootContents,
+		codeMod: {
+			type: 'delete-folder',
+			folderName: 'Shared',
+			parentName: 'Parent',
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents.match(/<Folder name="Shared">/g)?.length).toBe(1);
+	expect(newContents).toContain('<Folder name="Parent">');
+	expect(newContents).toContain('id="NestedA"');
+	expect(newContents).toContain('id="NestedB"');
+});
+
+test('deletes a top-level folder by unwrapping its children', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: folderRootContents,
+		codeMod: {
+			type: 'delete-folder',
+			folderName: 'Parent',
+			parentName: null,
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents).not.toContain('<Folder name="Parent">');
+	expect(newContents.match(/<Folder name="Shared">/g)?.length).toBe(2);
+	expect(newContents).toContain('id="NestedA"');
+	expect(newContents).toContain('id="NestedB"');
 });

--- a/packages/studio-shared/src/codemods.ts
+++ b/packages/studio-shared/src/codemods.ts
@@ -32,4 +32,15 @@ export type RecastCodemod =
 			type: 'delete-composition';
 			idToDelete: string;
 	  }
+	| {
+			type: 'rename-folder';
+			folderName: string;
+			parentName: string | null;
+			newName: string;
+	  }
+	| {
+			type: 'delete-folder';
+			folderName: string;
+			parentName: string | null;
+	  }
 	| ApplyVisualControlCodemod;

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -27,6 +27,7 @@ import {ModalsContext} from '../state/modals';
 import {getCompositionMenuItems} from './composition-menu-items';
 import {CompositionContextButton} from './CompositionContextButton';
 import {ContextMenu} from './ContextMenu';
+import {getFolderMenuItems} from './folder-menu-items';
 import {Row, Spacing} from './layout';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {SidebarRenderButton} from './SidebarRenderButton';
@@ -78,6 +79,7 @@ export type CompositionSelectorItemType =
 	| {
 			key: string;
 			type: 'folder';
+			folder: _InternalTypes['TFolder'];
 			folderName: string;
 			parentName: string | null;
 			items: CompositionSelectorItemType[];
@@ -177,7 +179,7 @@ export const CompositionSelectorItem: React.FC<{
 	const connectionStatus = useContext(StudioServerConnectionCtx)
 		.previewServerState.type;
 	const resolvedLocation = useResolvedStack(
-		item.type === 'composition' ? item.composition.stack : null,
+		item.type === 'composition' ? item.composition.stack : item.folder.stack,
 	);
 
 	const contextMenu = useMemo((): ComboboxValue[] => {
@@ -192,35 +194,51 @@ export const CompositionSelectorItem: React.FC<{
 			});
 		}
 
-		return [];
+		return getFolderMenuItems({
+			closeMenu: noop,
+			connectionStatus,
+			folder: item.folder,
+			resolvedLocation,
+			setSelectedModal,
+			readOnlyStudio: window.remotion_isReadOnlyStudio,
+		});
 	}, [connectionStatus, item, resolvedLocation, setSelectedModal]);
 
 	if (item.type === 'folder') {
 		return (
 			<>
-				<button
-					style={style}
-					onPointerEnter={onPointerEnter}
-					onPointerLeave={onPointerLeave}
-					tabIndex={tabIndex}
-					onClick={onClick}
-					type="button"
-					title={item.folderName}
-				>
-					{item.expanded ? (
-						<ExpandedFolderIcon
-							style={iconStyle}
-							color={hovered || selected ? 'white' : LIGHT_TEXT}
-						/>
-					) : (
-						<CollapsedFolderIcon
-							color={hovered || selected ? 'white' : LIGHT_TEXT}
-							style={iconStyle}
-						/>
-					)}
-					<Spacing x={1} />
-					<div style={label}>{item.folderName}</div>
-				</button>
+				<ContextMenu values={contextMenu} onOpen={null}>
+					<Row align="center">
+						<button
+							style={style}
+							onPointerEnter={onPointerEnter}
+							onPointerLeave={onPointerLeave}
+							tabIndex={tabIndex}
+							onClick={onClick}
+							type="button"
+							title={item.folderName}
+						>
+							{item.expanded ? (
+								<ExpandedFolderIcon
+									style={iconStyle}
+									color={hovered || selected ? 'white' : LIGHT_TEXT}
+								/>
+							) : (
+								<CollapsedFolderIcon
+									color={hovered || selected ? 'white' : LIGHT_TEXT}
+									style={iconStyle}
+								/>
+							)}
+							<Spacing x={1} />
+							<div style={label}>{item.folderName}</div>
+							<Spacing x={0.5} />
+							<CompositionContextButton
+								values={contextMenu}
+								visible={hovered}
+							/>
+						</button>
+					</Row>
+				</ContextMenu>
 				{item.expanded
 					? item.items.map((childItem) => {
 							return (

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -4,8 +4,10 @@ import {ModalsContext} from '../state/modals';
 import {AskAiModal} from './AskAiModal';
 import {InstallPackageModal} from './InstallPackage';
 import {DeleteComposition} from './NewComposition/DeleteComposition';
+import {DeleteFolder} from './NewComposition/DeleteFolder';
 import {DuplicateComposition} from './NewComposition/DuplicateComposition';
 import {RenameComposition} from './NewComposition/RenameComposition';
+import {RenameFolder} from './NewComposition/RenameFolder';
 import {OverrideInputPropsModal} from './OverrideInputProps';
 import QuickSwitcher from './QuickSwitcher/QuickSwitcher';
 import {RenderStatusModal} from './RenderModal/RenderStatusModal';
@@ -34,6 +36,20 @@ export const Modals: React.FC<{
 			)}
 			{modalContextType && modalContextType.type === 'rename-comp' && (
 				<RenameComposition compositionId={modalContextType.compositionId} />
+			)}
+			{modalContextType && modalContextType.type === 'delete-folder' && (
+				<DeleteFolder
+					folderName={modalContextType.folderName}
+					parentName={modalContextType.parentName}
+					stack={modalContextType.stack}
+				/>
+			)}
+			{modalContextType && modalContextType.type === 'rename-folder' && (
+				<RenameFolder
+					folderName={modalContextType.folderName}
+					parentName={modalContextType.parentName}
+					stack={modalContextType.stack}
+				/>
 			)}
 			{modalContextType && modalContextType.type === 'input-props-override' && (
 				<OverrideInputPropsModal />

--- a/packages/studio/src/components/NewComposition/CodemodFooter.tsx
+++ b/packages/studio/src/components/NewComposition/CodemodFooter.tsx
@@ -112,7 +112,7 @@ export const CodemodFooter: React.FC<{
 		if (!stack) {
 			setCanApplyCodemod({
 				type: 'fail',
-				error: 'Could not determine where this composition is defined',
+				error: 'Could not determine where this item is defined',
 			});
 			return;
 		}
@@ -124,7 +124,7 @@ export const CodemodFooter: React.FC<{
 		if (!symbolicatedStack) {
 			setCanApplyCodemod({
 				type: 'fail',
-				error: 'Could not resolve the source location of this composition',
+				error: 'Could not resolve the source location of this item',
 			});
 			return;
 		}

--- a/packages/studio/src/components/NewComposition/DeleteFolder.tsx
+++ b/packages/studio/src/components/NewComposition/DeleteFolder.tsx
@@ -1,0 +1,66 @@
+import type {RecastCodemod} from '@remotion/studio-shared';
+import React, {useCallback, useMemo} from 'react';
+import {getFolderId} from '../../helpers/get-folder-id';
+import {inlineCodeSnippet} from '../Menu/styles';
+import {ModalFooterContainer} from '../ModalFooter';
+import {ModalHeader} from '../ModalHeader';
+import {CodemodFooter} from './CodemodFooter';
+import {DismissableModal} from './DismissableModal';
+
+const content: React.CSSProperties = {
+	padding: 16,
+	fontSize: 14,
+	flex: 1,
+	minWidth: 500,
+};
+
+export const DeleteFolder: React.FC<{
+	readonly folderName: string;
+	readonly parentName: string | null;
+	readonly stack: string | null;
+}> = ({folderName, parentName, stack}) => {
+	const codemod: RecastCodemod = useMemo(() => {
+		return {
+			type: 'delete-folder',
+			folderName,
+			parentName,
+		};
+	}, [folderName, parentName]);
+
+	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((e) => {
+		e.preventDefault();
+	}, []);
+
+	const folderId = getFolderId({folderName, parentName});
+
+	return (
+		<DismissableModal>
+			<ModalHeader title={'Delete folder'} />
+			<form onSubmit={onSubmit}>
+				<div style={content}>
+					Do you want to delete the{' '}
+					<code style={inlineCodeSnippet}>Folder</code> with ID {'"'}
+					{folderId}
+					{'"'}?
+					<br />
+					The compositions and nested folders inside it will stay in your code.
+				</div>
+				<ModalFooterContainer>
+					<CodemodFooter
+						errorNotification={`Could not delete folder`}
+						loadingNotification={'Deleting folder'}
+						successNotification={`Deleted folder ${folderId}`}
+						genericSubmitLabel={`Delete`}
+						submitLabel={({relativeRootPath}) =>
+							`Delete from ${relativeRootPath}`
+						}
+						codemod={codemod}
+						stack={stack}
+						valid
+						onSuccess={null}
+					/>
+				</ModalFooterContainer>
+			</form>
+		</DismissableModal>
+	);
+};

--- a/packages/studio/src/components/NewComposition/RenameFolder.tsx
+++ b/packages/studio/src/components/NewComposition/RenameFolder.tsx
@@ -1,0 +1,111 @@
+import type {RecastCodemod} from '@remotion/studio-shared';
+import type {ChangeEventHandler} from 'react';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
+import {Internals} from 'remotion';
+import {getFolderId} from '../../helpers/get-folder-id';
+import {validateFolderRename} from '../../helpers/validate-folder-rename';
+import {Spacing} from '../layout';
+import {ModalFooterContainer} from '../ModalFooter';
+import {ModalHeader} from '../ModalHeader';
+import {label, optionRow, rightRow} from '../RenderModal/layout';
+import {CodemodFooter} from './CodemodFooter';
+import {DismissableModal} from './DismissableModal';
+import {RemotionInput} from './RemInput';
+import {ValidationMessage} from './ValidationMessage';
+
+const content: React.CSSProperties = {
+	padding: 12,
+	paddingRight: 12,
+	flex: 1,
+	fontSize: 13,
+	minWidth: 500,
+};
+
+export const RenameFolder: React.FC<{
+	readonly folderName: string;
+	readonly parentName: string | null;
+	readonly stack: string | null;
+}> = ({folderName, parentName, stack}) => {
+	const {folders} = useContext(Internals.CompositionManager);
+	const [newName, setName] = useState(folderName);
+
+	const onNameChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+		(e) => {
+			setName(e.target.value);
+		},
+		[],
+	);
+
+	const folderNameErrMessage = validateFolderRename({
+		folders,
+		newName,
+		originalName: folderName,
+		parentName,
+	});
+
+	const valid = folderNameErrMessage === null && folderName !== newName;
+
+	const codemod: RecastCodemod = useMemo(() => {
+		return {
+			type: 'rename-folder',
+			folderName,
+			parentName,
+			newName,
+		};
+	}, [folderName, newName, parentName]);
+
+	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((e) => {
+		e.preventDefault();
+	}, []);
+
+	const folderId = getFolderId({folderName, parentName});
+
+	return (
+		<DismissableModal>
+			<ModalHeader title={`Rename ${folderId}`} />
+			<form onSubmit={onSubmit}>
+				<div style={content}>
+					<div style={optionRow}>
+						<div style={label}>Name</div>
+						<div style={rightRow}>
+							<div>
+								<RemotionInput
+									value={newName}
+									onChange={onNameChange}
+									type="text"
+									autoFocus
+									placeholder="Folder name"
+									status="ok"
+									rightAlign
+								/>
+								{folderNameErrMessage ? (
+									<>
+										<Spacing y={1} block />
+										<ValidationMessage
+											align="flex-start"
+											message={folderNameErrMessage}
+											type="error"
+										/>
+									</>
+								) : null}
+							</div>
+						</div>
+					</div>
+				</div>
+				<ModalFooterContainer>
+					<CodemodFooter
+						loadingNotification={'Renaming folder...'}
+						errorNotification={'Could not rename folder'}
+						successNotification={`Renamed folder to ${newName}`}
+						genericSubmitLabel={'Rename'}
+						submitLabel={({relativeRootPath}) => `Modify ${relativeRootPath}`}
+						codemod={codemod}
+						stack={stack}
+						valid={valid}
+						onSuccess={null}
+					/>
+				</ModalFooterContainer>
+			</form>
+		</DismissableModal>
+	);
+};

--- a/packages/studio/src/components/folder-menu-items.ts
+++ b/packages/studio/src/components/folder-menu-items.ts
@@ -1,0 +1,172 @@
+import type {SetStateAction} from 'react';
+import type {ResolvedStackLocation, _InternalTypes} from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
+import {formatFileLocation} from '../helpers/format-file-location';
+import {getFolderId} from '../helpers/get-folder-id';
+import {openOriginalPositionInEditor} from '../helpers/open-in-editor';
+import type {PreviewServerConnectionState} from '../helpers/preview-server-events';
+import type {ModalState} from '../state/modals';
+import type {ComboboxValue} from './NewComposition/ComboBox';
+import {showNotification} from './Notifications/NotificationCenter';
+
+export const getFolderMenuItems = ({
+	closeMenu,
+	connectionStatus,
+	folder,
+	readOnlyStudio,
+	resolvedLocation,
+	setSelectedModal,
+}: {
+	closeMenu: () => void;
+	connectionStatus: PreviewServerConnectionState['type'];
+	folder: _InternalTypes['TFolder'];
+	readOnlyStudio: boolean;
+	resolvedLocation: ResolvedStackLocation | null;
+	setSelectedModal: (value: SetStateAction<ModalState | null>) => void;
+}): ComboboxValue[] => {
+	const editorName = window.remotion_editorName;
+	const folderId = getFolderId({
+		folderName: folder.name,
+		parentName: folder.parent,
+	});
+	const fileLocation = formatFileLocation({
+		location: resolvedLocation,
+		root: window.remotion_cwd,
+	});
+	const showInEditorDisabled =
+		connectionStatus !== 'connected' || !resolvedLocation;
+	const copyFileLocationDisabled = !fileLocation;
+	const codemodDisabled = readOnlyStudio || !folder.stack;
+
+	return [
+		editorName
+			? {
+					id: 'show-folder-in-editor',
+					keyHint: null,
+					label: `Show folder in ${editorName}`,
+					leftItem: null,
+					onClick: async () => {
+						closeMenu();
+						if (!resolvedLocation) {
+							return;
+						}
+
+						try {
+							await openOriginalPositionInEditor(resolvedLocation);
+						} catch (err) {
+							showNotification((err as Error).message, 2000);
+						}
+					},
+					quickSwitcherLabel: `Show folder in ${editorName}`,
+					subMenu: null,
+					type: 'item' as const,
+					value: 'show-folder-in-editor',
+					disabled: showInEditorDisabled,
+				}
+			: null,
+		{
+			id: 'copy-folder-file-location',
+			keyHint: null,
+			label: `Copy file location`,
+			leftItem: null,
+			onClick: () => {
+				closeMenu();
+				if (!fileLocation) {
+					return;
+				}
+
+				navigator.clipboard
+					.writeText(fileLocation)
+					.then(() => {
+						showNotification('Copied file location to clipboard', 1000);
+					})
+					.catch((err) => {
+						showNotification(
+							`Could not copy to clipboard: ${(err as Error).message}`,
+							1000,
+						);
+					});
+			},
+			quickSwitcherLabel: 'Copy folder file location',
+			subMenu: null,
+			type: 'item' as const,
+			value: 'copy-folder-file-location',
+			disabled: copyFileLocationDisabled,
+		},
+		editorName || fileLocation
+			? {
+					type: 'divider' as const,
+					id: 'show-folder-in-editor-divider',
+				}
+			: null,
+		{
+			id: 'rename-folder',
+			keyHint: null,
+			label: `Rename...`,
+			leftItem: null,
+			onClick: () => {
+				closeMenu();
+				setSelectedModal({
+					type: 'rename-folder',
+					folderName: folder.name,
+					parentName: folder.parent,
+					stack: folder.stack,
+				});
+			},
+			quickSwitcherLabel: 'Rename folder...',
+			subMenu: null,
+			type: 'item' as const,
+			value: 'rename-folder',
+			disabled: codemodDisabled,
+		},
+		{
+			id: 'delete-folder',
+			keyHint: null,
+			label: `Delete...`,
+			leftItem: null,
+			onClick: () => {
+				closeMenu();
+				setSelectedModal({
+					type: 'delete-folder',
+					folderName: folder.name,
+					parentName: folder.parent,
+					stack: folder.stack,
+				});
+			},
+			quickSwitcherLabel: 'Delete folder...',
+			subMenu: null,
+			type: 'item' as const,
+			value: 'delete-folder',
+			disabled: codemodDisabled,
+		},
+		{
+			type: 'divider' as const,
+			id: 'copy-folder-id-divider',
+		},
+		{
+			id: 'copy-folder-id',
+			keyHint: null,
+			label: `Copy ID`,
+			leftItem: null,
+			onClick: () => {
+				closeMenu();
+				navigator.clipboard
+					.writeText(folderId)
+					.then(() => {
+						showNotification('Copied to clipboard', 1000);
+					})
+					.catch((err) => {
+						showNotification(
+							`Could not copy to clipboard: ${(err as Error).message}`,
+							1000,
+						);
+					});
+			},
+			quickSwitcherLabel: 'Copy folder ID',
+			subMenu: null,
+			type: 'item' as const,
+			value: 'copy-folder-id',
+			disabled: false,
+		},
+	].filter(NoReactInternals.truthy);
+};

--- a/packages/studio/src/helpers/create-folder-tree.ts
+++ b/packages/studio/src/helpers/create-folder-tree.ts
@@ -177,6 +177,7 @@ const createFolderIfDoesNotExist = (
 
 	itemList.push({
 		type: 'folder',
+		folder: folderItem,
 		folderName: folderItem.name,
 		items: [],
 		key: folderItem.name,

--- a/packages/studio/src/helpers/get-folder-id.ts
+++ b/packages/studio/src/helpers/get-folder-id.ts
@@ -1,0 +1,9 @@
+export const getFolderId = ({
+	folderName,
+	parentName,
+}: {
+	folderName: string;
+	parentName: string | null;
+}) => {
+	return [parentName, folderName].filter(Boolean).join('/');
+};

--- a/packages/studio/src/helpers/validate-folder-rename.ts
+++ b/packages/studio/src/helpers/validate-folder-rename.ts
@@ -1,0 +1,32 @@
+import type {_InternalTypes} from 'remotion';
+import {Internals} from 'remotion';
+
+export const validateFolderRename = ({
+	folders,
+	newName,
+	originalName,
+	parentName,
+}: {
+	folders: _InternalTypes['TFolder'][];
+	newName: string;
+	originalName: string;
+	parentName: string | null;
+}): string | null => {
+	if (!Internals.isFolderNameValid(newName)) {
+		return Internals.invalidFolderNameErrorMessage;
+	}
+
+	if (newName === originalName) {
+		return null;
+	}
+
+	if (
+		folders.find((folder) => {
+			return folder.name === newName && folder.parent === parentName;
+		})
+	) {
+		return `A folder with that name already exists.`;
+	}
+
+	return null;
+};

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -123,6 +123,18 @@ export type ModalState =
 			compositionId: string;
 	  }
 	| {
+			type: 'delete-folder';
+			folderName: string;
+			parentName: string | null;
+			stack: string | null;
+	  }
+	| {
+			type: 'rename-folder';
+			folderName: string;
+			parentName: string | null;
+			stack: string | null;
+	  }
+	| {
 			type: 'input-props-override';
 	  }
 	| RenderModalState

--- a/packages/studio/src/test/folder-tree.test.ts
+++ b/packages/studio/src/test/folder-tree.test.ts
@@ -8,6 +8,12 @@ const SampleComp: React.FC<{}> = () => null;
 const component = React.lazy(() =>
 	Promise.resolve({default: SampleComp as ComponentType<unknown>}),
 );
+const testFolder = (name: string, parent: string | null) => ({
+	name,
+	parent,
+	nonce: [[0, 0]] as [[number, number]],
+	stack: null,
+});
 
 const getZ = async () => {
 	const z = await getZodIfPossible();
@@ -55,18 +61,13 @@ test('Should create a good folder tree with 1 item inside and 1 item outside', a
 				stack: null,
 			},
 		],
-		[
-			{
-				name: 'my-folder',
-				parent: null,
-				nonce: [[0, 0]],
-			},
-		],
+		[testFolder('my-folder', null)],
 		{},
 	);
 
 	expect(tree).toEqual([
 		{
+			folder: testFolder('my-folder', null),
 			folderName: 'my-folder',
 			items: [
 				{
@@ -139,27 +140,16 @@ test('Should handle nested folders well', async () => {
 			},
 		],
 		[
-			{
-				name: 'my-second-folder',
-				parent: 'my-third-folder',
-				nonce: [[0, 0]],
-			},
-			{
-				name: 'my-third-folder',
-				parent: null,
-				nonce: [[0, 0]],
-			},
-			{
-				name: 'my-folder',
-				parent: 'my-third-folder/my-second-folder',
-				nonce: [[0, 0]],
-			},
+			testFolder('my-second-folder', 'my-third-folder'),
+			testFolder('my-third-folder', null),
+			testFolder('my-folder', 'my-third-folder/my-second-folder'),
 		],
 		{},
 	);
 
 	expect(tree).toEqual([
 		{
+			folder: testFolder('my-third-folder', null),
 			folderName: 'my-third-folder',
 			expanded: false,
 			key: 'my-third-folder',
@@ -167,6 +157,7 @@ test('Should handle nested folders well', async () => {
 			items: [
 				{
 					type: 'folder',
+					folder: testFolder('my-second-folder', 'my-third-folder'),
 					expanded: false,
 					key: 'my-second-folder',
 					folderName: 'my-second-folder',
@@ -174,6 +165,10 @@ test('Should handle nested folders well', async () => {
 					items: [
 						{
 							type: 'folder',
+							folder: testFolder(
+								'my-folder',
+								'my-third-folder/my-second-folder',
+							),
 							key: 'my-folder',
 							folderName: 'my-folder',
 							parentName: 'my-third-folder/my-second-folder',
@@ -229,18 +224,7 @@ test('Should throw if two folders with the same name', () => {
 	expect(() =>
 		createFolderTree(
 			[],
-			[
-				{
-					name: 'my-folder',
-					parent: null,
-					nonce: [[0, 0]],
-				},
-				{
-					name: 'my-folder',
-					parent: null,
-					nonce: [[0, 0]],
-				},
-			],
+			[testFolder('my-folder', null), testFolder('my-folder', null)],
 			{},
 		),
 	).toThrow(


### PR DESCRIPTION
## Summary
- Add a context menu for Studio composition folders with editor/file-location actions, rename/delete, and Copy ID.
- Capture folder stack metadata so folder actions can resolve source locations.
- Add folder rename/delete codemods, preserving children when deleting a folder.

Fixes #8116
Fixes #8117
Fixes #8118
Fixes #8119
Fixes #8120

## Tests
- bun test src/test/apply-codemod.test.ts (packages/studio-server)
- bun test src/test/folder-tree.test.ts (packages/studio)
- bunx turbo run make --filter='remotion' --filter='@remotion/studio-shared' --filter='@remotion/studio-server' --filter='@remotion/studio'
- bun run build
- bun run stylecheck
