### PR TITLE
`@remotion/studio`: Fix canvas responsiveness

### DIFF
--- a/packages/player/src/utils/use-element-size.ts
+++ b/packages/player/src/utils/use-element-size.ts
@@ -26,19 +26,37 @@ export const updateAllElementsSizes = () => {
 	}
 };
 
+type ElementSizeSource =
+	| React.RefObject<HTMLElement | null>
+	| HTMLElement
+	| null;
+
+const getElement = (source: ElementSizeSource): HTMLElement | null => {
+	if (!source) {
+		return null;
+	}
+
+	if ('current' in source) {
+		return source.current;
+	}
+
+	return source;
+};
+
 export const useElementSize = (
-	ref: React.RefObject<HTMLElement | null>,
+	source: ElementSizeSource,
 	options: {
 		triggerOnWindowResize: boolean;
 		shouldApplyCssTransforms: boolean;
 	},
 ): Size | null => {
 	const [size, setSize] = useState<Omit<Size, 'refresh'> | null>(() => {
-		if (!ref.current) {
+		const element = getElement(source);
+		if (!element) {
 			return null;
 		}
 
-		const rect = ref.current.getClientRects();
+		const rect = element.getClientRects();
 		if (!rect[0]) {
 			return null;
 		}
@@ -115,11 +133,12 @@ export const useElementSize = (
 	}, [options.shouldApplyCssTransforms]);
 
 	const updateSize = useCallback(() => {
-		if (!ref.current) {
+		const element = getElement(source);
+		if (!element) {
 			return;
 		}
 
-		const rect = ref.current.getClientRects();
+		const rect = element.getClientRects();
 		if (!rect[0]) {
 			setSize(null);
 			return;
@@ -149,24 +168,28 @@ export const useElementSize = (
 				},
 			};
 		});
-	}, [ref]);
+	}, [source]);
+
+	useEffect(() => {
+		updateSize();
+	}, [updateSize]);
 
 	useEffect(() => {
 		if (!observer) {
 			return;
 		}
 
-		const {current} = ref;
-		if (current) {
-			observer.observe(current);
+		const element = getElement(source);
+		if (element) {
+			observer.observe(element);
 		}
 
 		return (): void => {
-			if (current) {
-				observer.unobserve(current);
+			if (element) {
+				observer.unobserve(element);
 			}
 		};
-	}, [observer, ref, updateSize]);
+	}, [observer, source]);
 
 	useEffect(() => {
 		if (!options.triggerOnWindowResize) {

--- a/packages/studio/src/components/CanvasIfSizeIsAvailable.tsx
+++ b/packages/studio/src/components/CanvasIfSizeIsAvailable.tsx
@@ -1,15 +1,17 @@
-import type {Size} from '@remotion/player';
-import {useMemo} from 'react';
+import {useContext, useMemo} from 'react';
+import {Internals} from 'remotion';
 import {RULER_WIDTH} from '../state/editor-rulers';
 import {CanvasOrLoading} from './CanvasOrLoading';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
 
-export const CanvasIfSizeIsAvailable: React.FC<{
-	readonly size: Size | null;
-}> = ({size}) => {
+export const CanvasIfSizeIsAvailable: React.FC = () => {
 	const rulersAreVisible = useIsRulerVisible();
+	const context = useContext(Internals.CurrentScaleContext);
 
 	const sizeWithRulersApplied = useMemo(() => {
+		const size =
+			context && context.type === 'canvas-size' ? context.canvasSize : null;
+
 		if (!rulersAreVisible) {
 			return size;
 		}
@@ -23,7 +25,7 @@ export const CanvasIfSizeIsAvailable: React.FC<{
 			width: size.width - RULER_WIDTH,
 			height: size.height - RULER_WIDTH,
 		};
-	}, [rulersAreVisible, size]);
+	}, [context, rulersAreVisible]);
 
 	if (!sizeWithRulersApplied) {
 		return null;

--- a/packages/studio/src/components/Editor.tsx
+++ b/packages/studio/src/components/Editor.tsx
@@ -38,7 +38,8 @@ export const Editor: React.FC<{
 	readonly Root: React.FC;
 	readonly readOnlyStudio: boolean;
 }> = ({Root, readOnlyStudio}) => {
-	const size = PlayerInternals.useElementSize(drawRef, {
+	const [drawElement, setDrawElement] = useState<HTMLDivElement | null>(null);
+	const size = PlayerInternals.useElementSize(drawElement, {
 		triggerOnWindowResize: false,
 		shouldApplyCssTransforms: true,
 	});
@@ -47,6 +48,13 @@ export const Editor: React.FC<{
 
 	const onMounted = useCallback(() => {
 		setCanvasMounted(true);
+	}, []);
+
+	// Use a callback ref so the late-mounted canvas container triggers a render
+	// and useElementSize() can observe it. See GitHub issue #8098.
+	const setDrawRef = useCallback((node: HTMLDivElement | null) => {
+		drawRef.current = node;
+		setDrawElement(node);
 	}, []);
 
 	const value: CurrentScaleContextType | null = useMemo(() => {
@@ -97,8 +105,7 @@ export const Editor: React.FC<{
 									<RenderErrorContext.Provider value={renderErrorContextValue}>
 										<EditorContent readOnlyStudio={readOnlyStudio}>
 											<TopPanel
-												drawRef={drawRef}
-												size={size}
+												drawRef={setDrawRef}
 												bufferStateDelayInMilliseconds={
 													BUFFER_STATE_DELAY_IN_MILLISECONDS
 												}

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -1,4 +1,3 @@
-import type {Size} from '@remotion/player';
 import React, {useCallback, useContext, useEffect, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {useMobileLayout} from '../helpers/mobile-layout';
@@ -57,16 +56,9 @@ export const useResponsiveSidebarStatus = (): 'collapsed' | 'expanded' => {
 const TopPanelInner: React.FC<{
 	readonly readOnlyStudio: boolean;
 	readonly onMounted: () => void;
-	readonly drawRef: React.RefObject<HTMLDivElement | null>;
-	readonly size: Size | null;
+	readonly drawRef: React.Ref<HTMLDivElement>;
 	readonly bufferStateDelayInMilliseconds: number;
-}> = ({
-	readOnlyStudio,
-	onMounted,
-	drawRef,
-	size,
-	bufferStateDelayInMilliseconds,
-}) => {
+}> = ({readOnlyStudio, onMounted, drawRef, bufferStateDelayInMilliseconds}) => {
 	const {setSidebarCollapsedState, sidebarCollapsedStateRight} =
 		useContext(SidebarContext);
 	const rulersAreVisible = useIsRulerVisible();
@@ -152,7 +144,7 @@ const TopPanelInner: React.FC<{
 							>
 								<SplitterElement sticky={null} type="flexer">
 									<div ref={drawRef} style={canvasContainerStyle}>
-										<CanvasIfSizeIsAvailable size={size} />
+										<CanvasIfSizeIsAvailable />
 									</div>
 								</SplitterElement>
 								{actualStateRight === 'expanded' ? (


### PR DESCRIPTION
## Summary
- Fix Studio canvas responsiveness by making the late-mounted canvas container reactive for `useElementSize()`.
- Keep the exported `drawRef` updated for fullscreen/menu usage while observing the actual mounted element.
- Revert the previous size-prop plumbing workaround so `CanvasIfSizeIsAvailable` reads from `CurrentScaleContext` again.

Fixes #8098.

## Testing
- `bunx oxfmt src --write` in `packages/player` and `packages/studio`
- `bun run build`
- `bun run stylecheck`
