### PR TITLE
`@remotion/studio`: Fix timeline resize with negative from

### DIFF
--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -216,6 +216,7 @@ import {StarburstExample} from './Starburst';
 import {Seek} from './StudioApis/Seek';
 import {SubframeAudio} from './SubframeAudio';
 import {TikTokTextBoxPlayground} from './TikTokTextbox/TikTokTextBox';
+import {TimelineNegativeFromResize} from './TimelineNegativeFromResize';
 import {FitTextOnNLines, fitTextOnNLinesSchema} from './Title/FitTextOnNLines';
 import {Issue7359FitTextOnNLines} from './Title/Issue7359FitTextOnNLines';
 import {TransitionRounding} from './TransitionRounding';
@@ -2376,6 +2377,14 @@ export const Index: React.FC = () => {
 				<Composition
 					id="starburst"
 					component={StarburstExample}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={90}
+				/>
+				<Composition
+					id="starburst-negative-from-resize"
+					component={TimelineNegativeFromResize}
 					width={1080}
 					height={1080}
 					fps={30}

--- a/packages/example/src/TimelineNegativeFromResize/index.tsx
+++ b/packages/example/src/TimelineNegativeFromResize/index.tsx
@@ -1,0 +1,17 @@
+import {Starburst} from '@remotion/starburst';
+import React from 'react';
+import {AbsoluteFill, Sequence} from 'remotion';
+
+export const TimelineNegativeFromResize: React.FC = () => {
+	return (
+		<AbsoluteFill style={{backgroundColor: '#202020'}}>
+			<Sequence
+				from={-3}
+				durationInFrames={36}
+				style={{backgroundColor: 'black'}}
+			>
+				<Starburst rays={16} colors={['#ffdd00', '#ff8800']} />
+			</Sequence>
+		</AbsoluteFill>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -240,7 +240,14 @@ export const getTimelineSequenceDurationDragTargets = ({
 
 	for (const nodePathInfo of targetNodePathInfos) {
 		const track = findSequenceTrack({tracks, nodePathInfo});
-		if (!track || !isDurationDraggableSequence(track.sequence)) {
+		const originalSequence = track
+			? sequences.find((sequence) => sequence.id === track.sequence.id)
+			: null;
+		if (
+			!track ||
+			!originalSequence ||
+			!isDurationDraggableSequence(originalSequence)
+		) {
 			return null;
 		}
 
@@ -253,7 +260,7 @@ export const getTimelineSequenceDurationDragTargets = ({
 		if (!targets.has(key)) {
 			targets.set(key, {
 				fileName: nodePath.absolutePath,
-				initialDuration: track.sequence.duration,
+				initialDuration: originalSequence.duration,
 				nodePath,
 			});
 		}

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -325,6 +325,34 @@ test('Timeline duration drag applies the same delta to selected sequences', () =
 	).toEqual([30, 5]);
 });
 
+test('Timeline duration drag uses the declared duration for negative from values', () => {
+	const schema = {} satisfies SequenceSchema;
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const targets = getTimelineSequenceDurationDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		selectedItems: [{type: 'sequence', nodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				duration: 36,
+				from: -3,
+			}),
+		],
+		overrideIdsToNodePaths: {
+			override: nodePathInfo.sequenceSubscriptionKey,
+		},
+		codeValues: makeDurationCodeValues([nodePathInfo.sequenceSubscriptionKey]),
+	});
+
+	expect(targets?.map((target) => target.initialDuration)).toEqual([36]);
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: targets ?? [],
+			deltaFrames: 0,
+		}),
+	).toEqual([]);
+});
+
 test('Timeline duration drag clamps each selected sequence to one frame', () => {
 	expect(
 		getTimelineSequenceDurationDragValue({


### PR DESCRIPTION
## Summary
- Fix timeline right-edge duration dragging for sequences with negative `from` values by using the declared sequence duration instead of the timeline-clipped visible duration.
- Add a regression test for the `from={-3}` / `durationInFrames={36}` case from #8107.

Fixes #8107

## Test plan
- `cd packages/studio && bun test src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`
