### PR TITLE
`@remotion/studio`: Expand parents of selected timeline item

### DIFF
--- a/packages/studio/src/components/ExpandedTracksProvider.tsx
+++ b/packages/studio/src/components/ExpandedTracksProvider.tsx
@@ -23,6 +23,9 @@ type ExpandedTracksGetterContextValue = {
 
 type ExpandedTracksSetterContextValue = {
 	readonly toggleTrack: (nodePathInfo: SequenceNodePathInfo) => void;
+	readonly expandTracks: (
+		nodePathInfos: readonly SequenceNodePathInfo[],
+	) => void;
 	readonly migrateExpandedTracksForSubscriptionKey: (
 		oldKey: SequencePropsSubscriptionKey,
 		newKey: SequencePropsSubscriptionKey,
@@ -39,6 +42,9 @@ export const ExpandedTracksGetterContext =
 export const ExpandedTracksSetterContext =
 	createContext<ExpandedTracksSetterContextValue>({
 		toggleTrack: () => {
+			throw new Error('ExpandedTracksSetterContext not initialized');
+		},
+		expandTracks: () => {
 			throw new Error('ExpandedTracksSetterContext not initialized');
 		},
 		migrateExpandedTracksForSubscriptionKey: () => {
@@ -60,6 +66,32 @@ export const ExpandedTracksProvider: React.FC<{
 			return next;
 		});
 	}, []);
+
+	const expandTracks = useCallback(
+		(nodePathInfos: readonly SequenceNodePathInfo[]) => {
+			setExpandedTracks((prev) => {
+				let next: Record<string, boolean> | null = null;
+
+				for (const nodePathInfo of nodePathInfos) {
+					const key = timelineNodePathInfoToKey(nodePathInfo);
+					if (prev[key]) {
+						continue;
+					}
+
+					next ??= {...prev};
+					next[key] = true;
+				}
+
+				if (next === null) {
+					return prev;
+				}
+
+				persistBooleanMap(SESSION_STORAGE_KEY, next);
+				return next;
+			});
+		},
+		[],
+	);
 
 	const migrateExpandedTracks = useCallback(
 		(
@@ -94,9 +126,10 @@ export const ExpandedTracksProvider: React.FC<{
 	const setterValue = useMemo(
 		(): ExpandedTracksSetterContextValue => ({
 			toggleTrack,
+			expandTracks,
 			migrateExpandedTracksForSubscriptionKey: migrateExpandedTracks,
 		}),
-		[toggleTrack, migrateExpandedTracks],
+		[toggleTrack, expandTracks, migrateExpandedTracks],
 	);
 
 	return (

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -17,6 +17,7 @@ import type {
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
 import {useKeybinding} from '../../helpers/use-keybinding';
+import {ExpandedTracksSetterContext} from '../ExpandedTracksProvider';
 import {TimelineClipboardKeybindings} from './TimelineClipboardKeybindings';
 import {TimelineDeleteKeybindings} from './TimelineDeleteKeybindings';
 
@@ -392,6 +393,39 @@ export const getTimelineSequenceSelectionKey = (
 	nodePathInfo: SequenceNodePathInfo,
 ): string => timelineNodePathInfoToKey({...nodePathInfo, auxiliaryKeys: []});
 
+export const getTimelineSelectionExpansionTargets = (
+	item: TimelineSelection,
+): SequenceNodePathInfo[] => {
+	const {nodePathInfo} = item;
+	const {auxiliaryKeys} = nodePathInfo;
+
+	if (auxiliaryKeys.length === 0) {
+		return [];
+	}
+
+	const sequenceTarget: SequenceNodePathInfo = {
+		...nodePathInfo,
+		auxiliaryKeys: [],
+	};
+	if (auxiliaryKeys[0] !== 'effects') {
+		return [sequenceTarget];
+	}
+
+	const targets: SequenceNodePathInfo[] = [sequenceTarget];
+	if (auxiliaryKeys.length > 1) {
+		targets.push({...nodePathInfo, auxiliaryKeys: ['effects']});
+	}
+
+	if (auxiliaryKeys.length > 2) {
+		targets.push({
+			...nodePathInfo,
+			auxiliaryKeys: ['effects', auxiliaryKeys[1]],
+		});
+	}
+
+	return targets;
+};
+
 export const TimelineSelectAllKeybindings: React.FC<{
 	readonly timeline: readonly TrackWithHash[];
 }> = ({timeline}) => {
@@ -450,6 +484,7 @@ export const TimelineSelectionProvider: React.FC<{
 	const [selectedItems, setSelectedItems] = useState<
 		readonly TimelineSelection[]
 	>([]);
+	const {expandTracks} = useContext(ExpandedTracksSetterContext);
 	const selectionAnchor = useRef<TimelineSelection | null>(null);
 	const selectableItemsOrder = useRef(new Map<string, number>());
 	const selectableItems = useRef(new Map<string, TimelineSelection>());
@@ -460,6 +495,17 @@ export const TimelineSelectionProvider: React.FC<{
 			setSelectedItems([]);
 		}
 	}, [canSelect]);
+
+	useEffect(() => {
+		const expansionTargets = selectedItems.flatMap(
+			getTimelineSelectionExpansionTargets,
+		);
+		if (expansionTargets.length === 0) {
+			return;
+		}
+
+		expandTracks(expansionTargets);
+	}, [expandTracks, selectedItems]);
 
 	const selectedKeys = useMemo(
 		() => new Set(selectedItems.map(getTimelineSelectionKey)),

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -35,6 +35,7 @@ import {
 	ENABLE_OUTLINES,
 	getSelectableTimelineSequenceSelections,
 	getTimelineSelectionAfterInteraction,
+	getTimelineSelectionExpansionTargets,
 	getTimelineSelectionFromNodePathInfo,
 	getTimelineSequenceSelectionKey,
 	isTimelineSelectionModifierEvent,
@@ -1546,6 +1547,52 @@ test('Timeline row selections use explicit item variants', () => {
 			makeNodePathInfo(['body', 0], ['effects', 'not-a-number']),
 		),
 	).toBe(null);
+});
+
+test('Timeline selections expand parent rows to reveal the selected row', () => {
+	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const sequencePropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+	const effectNodePathInfo = makeNodePathInfo(['body', 0], ['effects', '1']);
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '1', 'radius'],
+	);
+
+	expect(
+		getTimelineSelectionExpansionTargets({
+			type: 'sequence',
+			nodePathInfo: sequenceNodePathInfo,
+		}),
+	).toEqual([]);
+	expect(
+		getTimelineSelectionExpansionTargets({
+			type: 'sequence-prop',
+			nodePathInfo: sequencePropNodePathInfo,
+			key: 'opacity',
+		}),
+	).toEqual([sequenceNodePathInfo]);
+	expect(
+		getTimelineSelectionExpansionTargets({
+			type: 'sequence-effect',
+			nodePathInfo: effectNodePathInfo,
+			i: 1,
+		}),
+	).toEqual([sequenceNodePathInfo, makeNodePathInfo(['body', 0], ['effects'])]);
+	expect(
+		getTimelineSelectionExpansionTargets({
+			type: 'sequence-effect-prop',
+			nodePathInfo: effectPropNodePathInfo,
+			i: 1,
+			key: 'radius',
+		}),
+	).toEqual([
+		sequenceNodePathInfo,
+		makeNodePathInfo(['body', 0], ['effects']),
+		effectNodePathInfo,
+	]);
 });
 
 test('Cmd/Ctrl+click toggles row selections', () => {


### PR DESCRIPTION
Fixes #8127.

### What changed

- Expands timeline parent rows when a selected timeline item is nested under a collapsed row.
- Adds an idempotent expanded-track setter so selection can reveal rows without toggling user state.
- Covers sequence props, effect groups, and effect props in timeline selection tests.

### Testing

- bunx turbo run test --filter='@remotion/studio' --no-update-notifier
- bun run build
- bun run stylecheck
