### PR TITLE
`@remotion/studio`: Support audio asset imports

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -1099,6 +1099,15 @@ const ensureVideoImport = (ast: File) => {
 	});
 };
 
+const ensureAudioImport = (ast: File) => {
+	return ensureOfficialNamedImport({
+		ast,
+		importedName: 'Audio',
+		sourcePath: '@remotion/media',
+		label: '<Audio>',
+	});
+};
+
 const ensureGifImport = (ast: File) => {
 	return ensureOfficialNamedImport({
 		ast,
@@ -1434,12 +1443,18 @@ const createInsertableJsxElement = ({
 
 	if (element.type === 'asset') {
 		const staticFileLocalName = ensureStaticFileImport(ast);
-		const localName =
-			element.assetType === 'image'
-				? ensureImgImport(ast)
-				: element.assetType === 'video'
-					? ensureVideoImport(ast)
-					: ensureGifImport(ast);
+		let localName: string;
+		if (element.assetType === 'image') {
+			localName = ensureImgImport(ast);
+		} else if (element.assetType === 'video') {
+			localName = ensureVideoImport(ast);
+		} else if (element.assetType === 'gif') {
+			localName = ensureGifImport(ast);
+		} else if (element.assetType === 'audio') {
+			localName = ensureAudioImport(ast);
+		} else {
+			throw new Error('Unsupported asset type');
+		}
 
 		return createAssetElement({
 			localName,

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -62,6 +62,10 @@ const getElementLabel = (element: InsertableCompositionElement) => {
 		if (element.assetType === 'gif') {
 			return '<Gif>';
 		}
+
+		if (element.assetType === 'audio') {
+			return '<Audio>';
+		}
 	}
 
 	throw new Error('Unsupported element type');

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -814,3 +814,100 @@ test('inserts a Gif asset into the resolved composition component', async () => 
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}
 });
+
+test('inserts an Audio asset into the resolved composition component', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				"import {AbsoluteFill} from 'remotion';",
+				'',
+				'export const MyComp: React.FC = () => {',
+				'\treturn <AbsoluteFill>hello</AbsoluteFill>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const result = await insertJsxElementIntoComposition({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+			element: {
+				type: 'asset',
+				assetType: 'audio',
+				src: 'audio.mp3',
+				dimensions: null,
+			},
+			prettierConfigOverride: {singleQuote: true, useTabs: true},
+		});
+
+		expect(result.output).toContain("import { Audio } from '@remotion/media';");
+		expect(result.output).toContain(
+			"import { AbsoluteFill, staticFile } from 'remotion';",
+		);
+		expect(result.output).toContain('<Audio');
+		expect(result.output).toContain("src={staticFile('audio.mp3')}");
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('rejects inserting an Audio asset if Audio is already defined', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				"import {AbsoluteFill} from 'remotion';",
+				'',
+				'export const Audio = () => null;',
+				'',
+				'export const MyComp: React.FC = () => {',
+				'\treturn <AbsoluteFill>hello</AbsoluteFill>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		await expect(
+			insertJsxElementIntoComposition({
+				remotionRoot: tempDir,
+				compositionFile: 'Root.tsx',
+				compositionId: 'test',
+				element: {
+					type: 'asset',
+					assetType: 'audio',
+					src: 'audio.mp3',
+					dimensions: null,
+				},
+				prettierConfigOverride: {singleQuote: true, useTabs: true},
+			}),
+		).rejects.toThrow('Cannot add <Audio> because Audio is already defined');
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -528,7 +528,7 @@ export type InsertableCompositionElement =
 	  }
 	| {
 			type: 'asset';
-			assetType: 'image' | 'video' | 'gif';
+			assetType: 'image' | 'video' | 'gif' | 'audio';
 			src: string;
 			dimensions: {
 				width: number;

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -5,7 +5,7 @@ import {detectFileType, type FileType} from '../helpers/detect-file-type';
 import {callApi} from './call-api';
 import {showNotification} from './Notifications/NotificationCenter';
 
-const getAssetElement = ({
+export const getAssetElement = ({
 	fileType,
 	src,
 }: {
@@ -49,6 +49,20 @@ const getAssetElement = ({
 		};
 	}
 
+	if (
+		fileType.type === 'wav' ||
+		fileType.type === 'mp3' ||
+		fileType.type === 'aac' ||
+		fileType.type === 'flac'
+	) {
+		return {
+			type: 'asset',
+			assetType: 'audio',
+			src,
+			dimensions: null,
+		};
+	}
+
 	return null;
 };
 
@@ -65,7 +79,15 @@ const getAssetLabel = (element: InsertableCompositionElement) => {
 		return '<Video>';
 	}
 
-	return '<Gif>';
+	if (element.assetType === 'gif') {
+		return '<Gif>';
+	}
+
+	if (element.assetType === 'audio') {
+		return '<Audio>';
+	}
+
+	throw new Error('Unsupported asset type');
 };
 
 export const pickFilesToImport = (): Promise<File[]> => {

--- a/packages/studio/src/test/detect-file-type.test.ts
+++ b/packages/studio/src/test/detect-file-type.test.ts
@@ -40,6 +40,20 @@ test('detects iso base media and WebM files as videos', () => {
 	expect(detectFileType(webm)).toEqual({type: 'webm'});
 });
 
+test('detects audio file signatures', () => {
+	const wav = new Uint8Array([
+		0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45,
+	]);
+	const mp3 = new Uint8Array([0x49, 0x44, 0x33, 3]);
+	const aac = new Uint8Array([0xff, 0xf1]);
+	const flac = new Uint8Array([0x66, 0x4c, 0x61, 0x43]);
+
+	expect(detectFileType(wav)).toEqual({type: 'wav'});
+	expect(detectFileType(mp3)).toEqual({type: 'mp3'});
+	expect(detectFileType(aac)).toEqual({type: 'aac'});
+	expect(detectFileType(flac)).toEqual({type: 'flac'});
+});
+
 test('returns unknown for unsupported signatures', () => {
 	expect(detectFileType(new Uint8Array([1, 2, 3, 4]))).toEqual({
 		type: 'unknown',

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -1,0 +1,27 @@
+import {expect, test} from 'bun:test';
+import {getAssetElement} from '../components/import-assets';
+
+test('maps audio file types to Audio assets', () => {
+	for (const type of ['wav', 'mp3', 'aac', 'flac'] as const) {
+		expect(
+			getAssetElement({
+				fileType: {type},
+				src: `sound.${type}`,
+			}),
+		).toEqual({
+			type: 'asset',
+			assetType: 'audio',
+			src: `sound.${type}`,
+			dimensions: null,
+		});
+	}
+});
+
+test('does not map M3U playlists to Audio assets', () => {
+	expect(
+		getAssetElement({
+			fileType: {type: 'm3u'},
+			src: 'playlist.m3u',
+		}),
+	).toBe(null);
+});


### PR DESCRIPTION
## Summary
- Support WAV, MP3, AAC, and FLAC files in the Studio asset import flow
- Insert imported audio as `<Audio src={staticFile(...)} />` from `@remotion/media`
- Keep playlist-style M3U files unsupported and add focused coverage for detection, mapping, and JSX insertion

Fixes #8129

## Testing
- `bun test packages/studio/src/test/detect-file-type.test.ts packages/studio/src/test/import-assets.test.ts packages/studio-server/src/test/resolve-composition-component.test.ts`
- `bun run build`
- `bun run stylecheck`
