### PR TITLE
`@remotion/studio`: Prevent keyframe drag collisions

### DIFF
--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -196,6 +196,7 @@ export {
 	optimisticDeleteSequenceKeyframes,
 } from './optimistic-delete-keyframe';
 export {
+	canMoveKeyframesWithoutCollisions,
 	optimisticMoveEffectKeyframes,
 	optimisticMoveSequenceKeyframes,
 	type OptimisticKeyframeMove,

--- a/packages/studio-shared/src/optimistic-move-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-move-keyframe.ts
@@ -9,6 +9,65 @@ export type OptimisticKeyframeMove = {
 	readonly toFrame: number;
 };
 
+const getMoveMap = (
+	moves: readonly {fromFrame: number; toFrame: number}[],
+): Map<number, number> | null => {
+	const moveMap = new Map<number, number>();
+	for (const move of moves) {
+		if (move.fromFrame === move.toFrame) {
+			continue;
+		}
+
+		if (moveMap.has(move.fromFrame)) {
+			return null;
+		}
+
+		moveMap.set(move.fromFrame, move.toFrame);
+	}
+
+	return moveMap;
+};
+
+export const canMoveKeyframesWithoutCollisions = ({
+	status,
+	moves,
+}: {
+	status: CanUpdateSequencePropStatus;
+	moves: readonly {fromFrame: number; toFrame: number}[];
+}): boolean => {
+	if (status.status !== 'keyframed') {
+		return false;
+	}
+
+	const moveMap = getMoveMap(moves);
+	if (moveMap === null) {
+		return false;
+	}
+
+	if (moveMap.size === 0) {
+		return true;
+	}
+
+	const frames = new Set(status.keyframes.map((keyframe) => keyframe.frame));
+	for (const fromFrame of moveMap.keys()) {
+		if (!frames.has(fromFrame)) {
+			return false;
+		}
+	}
+
+	const nextFrames = new Set<number>();
+	for (const keyframe of status.keyframes) {
+		const frame = moveMap.get(keyframe.frame) ?? keyframe.frame;
+		if (nextFrames.has(frame)) {
+			return false;
+		}
+
+		nextFrames.add(frame);
+	}
+
+	return true;
+};
+
 const moveKeyframesInPropStatus = ({
 	status,
 	moves,
@@ -20,51 +79,27 @@ const moveKeyframesInPropStatus = ({
 		return status;
 	}
 
-	const moveMap = new Map<number, number>();
-	for (const move of moves) {
-		if (move.fromFrame !== move.toFrame) {
-			moveMap.set(move.fromFrame, move.toFrame);
-		}
+	if (!canMoveKeyframesWithoutCollisions({status, moves})) {
+		return status;
+	}
+
+	const moveMap = getMoveMap(moves);
+	if (moveMap === null) {
+		return status;
 	}
 
 	if (moveMap.size === 0) {
 		return status;
 	}
 
-	const sourceFrames = new Set(
-		status.keyframes.map((keyframe) => keyframe.frame),
-	);
-	for (const fromFrame of moveMap.keys()) {
-		if (!sourceFrames.has(fromFrame)) {
-			return status;
-		}
-	}
-
-	const nextFrames = new Set<number>();
-	const keyframes = status.keyframes
-		.map((keyframe) => {
-			const frame = moveMap.get(keyframe.frame) ?? keyframe.frame;
-			if (nextFrames.has(frame)) {
-				return null;
-			}
-
-			nextFrames.add(frame);
-			return {
-				...keyframe,
-				frame,
-			};
-		})
-		.filter((keyframe): keyframe is NonNullable<typeof keyframe> => {
-			return keyframe !== null;
-		});
-
-	if (keyframes.length !== status.keyframes.length) {
-		return status;
-	}
-
 	return {
 		...status,
-		keyframes: keyframes.sort((a, b) => a.frame - b.frame),
+		keyframes: status.keyframes
+			.map((keyframe) => ({
+				...keyframe,
+				frame: moveMap.get(keyframe.frame) ?? keyframe.frame,
+			}))
+			.sort((a, b) => a.frame - b.frame),
 	};
 };
 

--- a/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
 import type {CanUpdateSequencePropsResponse} from 'remotion';
 import {
+	canMoveKeyframesWithoutCollisions,
 	optimisticMoveEffectKeyframes,
 	optimisticMoveSequenceKeyframes,
 } from '../optimistic-move-keyframe';
@@ -95,6 +96,45 @@ test('optimisticMoveSequenceKeyframes resorts when moving past an adjacent keyfr
 	expect(status.easing).toEqual(['linear', 'linear']);
 });
 
+test('optimisticMoveSequenceKeyframes no-ops when moving onto an existing keyframe', () => {
+	const updated = optimisticMoveSequenceKeyframes({
+		previous,
+		keyframes: [{fieldKey: 'scale', fromFrame: 0, toFrame: 20}],
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const status = updated.props.scale;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([
+		{frame: 0, value: 1},
+		{frame: 20, value: 2},
+		{frame: 40, value: 3},
+	]);
+});
+
+test('canMoveKeyframesWithoutCollisions allows moving onto a frame vacated by another selected keyframe', () => {
+	const status = previous.props.scale;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(
+		canMoveKeyframesWithoutCollisions({
+			status,
+			moves: [
+				{fromFrame: 0, toFrame: 20},
+				{fromFrame: 20, toFrame: 30},
+			],
+		}),
+	).toBe(true);
+});
+
 test('optimisticMoveSequenceKeyframes allows moving keyframes before frame 0', () => {
 	const updated = optimisticMoveSequenceKeyframes({
 		previous,
@@ -141,6 +181,34 @@ test('optimisticMoveEffectKeyframes moves effect keyframes', () => {
 
 	expect(status.keyframes).toEqual([
 		{frame: 12, value: 0.2},
+		{frame: 20, value: 0.5},
+	]);
+});
+
+test('optimisticMoveEffectKeyframes no-ops when moving onto an existing keyframe', () => {
+	const updated = optimisticMoveEffectKeyframes({
+		previous,
+		keyframes: [
+			{effectIndex: 0, fieldKey: 'amount', fromFrame: 0, toFrame: 20},
+		],
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const effect = updated.effects[0];
+	if (!effect.canUpdate) {
+		throw new Error('expected updateable effect');
+	}
+
+	const status = effect.props.amount;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([
+		{frame: 0, value: 0.2},
 		{frame: 20, value: 0.5},
 	]);
 });

--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -1,3 +1,4 @@
+import {canMoveKeyframesWithoutCollisions} from '@remotion/studio-shared';
 import type React from 'react';
 import {useCallback, useContext} from 'react';
 import type {
@@ -179,6 +180,37 @@ const groupTargets = (targets: readonly TimelineKeyframeDragTarget[]) => {
 	return [...groups.values()];
 };
 
+const getMovesForGroup = ({
+	group,
+	delta,
+}: {
+	readonly group: readonly TimelineKeyframeDragTarget[];
+	readonly delta: number;
+}) =>
+	group.map((target) => ({
+		fromFrame: target.sourceFrame,
+		toFrame: target.sourceFrame + delta,
+	}));
+
+const canMoveTimelineKeyframeDragTargets = ({
+	targets,
+	delta,
+}: {
+	readonly targets: readonly TimelineKeyframeDragTarget[];
+	readonly delta: number;
+}) =>
+	groupTargets(targets).every((group) => {
+		const [first] = group;
+		if (!first) {
+			return true;
+		}
+
+		return canMoveKeyframesWithoutCollisions({
+			status: first.propStatus,
+			moves: getMovesForGroup({group, delta}),
+		});
+	});
+
 const makeMovedKeyframedDragOverride = ({
 	group,
 	delta,
@@ -192,8 +224,8 @@ const makeMovedKeyframedDragOverride = ({
 	}
 
 	const moves = new Map(
-		group.map(
-			(target) => [target.sourceFrame, target.sourceFrame + delta] as const,
+		getMovesForGroup({group, delta}).map(
+			(move) => [move.fromFrame, move.toFrame] as const,
 		),
 	);
 
@@ -445,6 +477,12 @@ export const useTimelineKeyframeDrag = ({
 
 				hasDragged = true;
 				lastDelta = delta;
+				if (!canMoveTimelineKeyframeDragTargets({targets, delta})) {
+					clearActiveOverrides();
+					clearDraggedKeyframes();
+					return;
+				}
+
 				setDraggedKeyframes(
 					targets.map((target) => ({
 						nodePathInfo: target.nodePathInfo,
@@ -464,6 +502,17 @@ export const useTimelineKeyframeDrag = ({
 
 				const targets = dragTargets;
 				if (!hasDragged || lastDelta === 0 || targets === null) {
+					clearActiveOverrides();
+					clearDraggedKeyframes();
+					return;
+				}
+
+				if (
+					!canMoveTimelineKeyframeDragTargets({
+						targets,
+						delta: lastDelta,
+					})
+				) {
 					clearActiveOverrides();
 					clearDraggedKeyframes();
 					return;


### PR DESCRIPTION
## Summary

- Prevent keyframe drags from writing preview overrides when the destination frame already has a keyframe
- Skip persisting invalid keyframe moves on pointer up
- Add shared collision detection coverage for sequence and effect keyframes

Closes #8128

## Testing

- bun test packages/studio-shared/src/test/optimistic-move-keyframe.test.ts packages/studio/src/test/timeline-keyframes.test.ts
- bunx turbo make --filter='@remotion/studio-shared' --filter='@remotion/studio'
- bun run build
- bun run stylecheck
