### PR TITLE
`@remotion/studio`: Settle effect keyframes from server response

### DIFF
--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -22,8 +22,7 @@ import {
 } from '../undo-stack';
 import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
 import {computeSequencePropsStatusFromContent} from './can-update-sequence-props';
-import {formatPropChange} from './log-updates/format-prop-change';
-import {logUpdate, normalizeQuotes} from './log-updates/log-update';
+import {logUpdate} from './log-updates/log-update';
 import {withSavePropsLock} from './save-props-mutex';
 
 type ResolvedSequencePropEdit = {
@@ -157,52 +156,8 @@ export const saveSequencePropsHandler: ApiHandler<
 			}
 		}
 
-		const [firstEdit] = edits;
-		const firstResult = resultByIndex.get(0);
-		if (!firstResult) {
-			throw new Error('Could not compute sequence prop edit result');
-		}
-
-		const undoMessage =
-			undoLabel !== null
-				? `↩️  ${undoLabel}`
-				: edits.length === 1
-					? `↩️  ${formatPropChange({
-							key: firstEdit.key,
-							oldValueString: normalizeQuotes(
-								JSON.stringify(JSON.parse(firstEdit.value)),
-							),
-							newValueString: normalizeQuotes(firstResult.oldValueString),
-							defaultValueString:
-								firstEdit.defaultValue !== null
-									? normalizeQuotes(
-											JSON.stringify(JSON.parse(firstEdit.defaultValue)),
-										)
-									: null,
-							removedProps: [],
-							addedProps: firstResult.removedProps,
-						})}`
-					: '↩️  Update selected sequence props';
-		const redoMessage =
-			redoLabel !== null
-				? `↪️  ${redoLabel}`
-				: edits.length === 1
-					? `↪️  ${formatPropChange({
-							key: firstEdit.key,
-							oldValueString: normalizeQuotes(firstResult.oldValueString),
-							newValueString: normalizeQuotes(
-								JSON.stringify(JSON.parse(firstEdit.value)),
-							),
-							defaultValueString:
-								firstEdit.defaultValue !== null
-									? normalizeQuotes(
-											JSON.stringify(JSON.parse(firstEdit.defaultValue)),
-										)
-									: null,
-							removedProps: firstResult.removedProps,
-							addedProps: [],
-						})}`
-					: '↪️  Update selected sequence props';
+		const undoMessage = `↩️  ${undoLabel}`;
+		const redoMessage = `↪️  ${redoLabel}`;
 
 		pushTransactionToUndoStack({
 			snapshots,

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -291,8 +291,8 @@ export type SaveSequencePropEdit = {
 export type SaveSequencePropsRequest = {
 	edits: SaveSequencePropEdit[];
 	clientId: string;
-	undoLabel: string | null;
-	redoLabel: string | null;
+	undoLabel: string;
+	redoLabel: string;
 };
 
 export type SaveSequencePropsResult = {

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1112,9 +1112,13 @@ const SelectedOutlinePolygon: React.FC<{
 								setCodeValues,
 								clientId: drag.clientId,
 								undoLabel:
-									changes.length > 1 ? 'Move selected sequences' : null,
+									changes.length > 1
+										? 'Move selected sequences'
+										: 'Move sequence',
 								redoLabel:
-									changes.length > 1 ? 'Move selected sequences back' : null,
+									changes.length > 1
+										? 'Move selected sequences back'
+										: 'Move sequence back',
 							})
 						: Promise.resolve(),
 					...keyframedChanges.map((change) =>
@@ -1290,9 +1294,12 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 					changes,
 					setCodeValues,
 					clientId: scaleDrag.clientId,
-					undoLabel: changes.length > 1 ? 'Scale selected sequences' : null,
+					undoLabel:
+						changes.length > 1 ? 'Scale selected sequences' : 'Scale sequence',
 					redoLabel:
-						changes.length > 1 ? 'Scale selected sequences back' : null,
+						changes.length > 1
+							? 'Scale selected sequences back'
+							: 'Scale sequence back',
 				})
 					.catch((err) => {
 						showNotification(

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -23,7 +23,7 @@ import {
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
-import {saveSequenceProp} from './save-sequence-prop';
+import {saveSequenceProps} from './save-sequence-prop';
 import {
 	TimelineExpandArrowButton,
 	TimelineExpandArrowSpacer,
@@ -412,13 +412,17 @@ export const TimelineSequenceItem: React.FC<{
 					? JSON.stringify(fieldSchema.default)
 					: null;
 
-			saveSequenceProp({
-				fileName: validatedLocation.source,
-				nodePath,
-				fieldKey: 'hidden',
-				value: newValue,
-				defaultValue,
-				schema,
+			saveSequenceProps({
+				changes: [
+					{
+						fileName: validatedLocation.source,
+						nodePath,
+						fieldKey: 'hidden',
+						value: newValue,
+						defaultValue,
+						schema,
+					},
+				],
 				setCodeValues,
 				clientId: previewServerState.clientId,
 			});

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -425,6 +425,8 @@ export const TimelineSequenceItem: React.FC<{
 				],
 				setCodeValues,
 				clientId: previewServerState.clientId,
+				undoLabel: newValue ? 'Hide sequence' : 'Show sequence',
+				redoLabel: newValue ? 'Hide sequence again' : 'Show sequence again',
 			});
 		},
 		[

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -20,7 +20,7 @@ import {ModalsContext} from '../../state/modals';
 import {ContextMenu} from '../ContextMenu';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {callAddSequenceKeyframe} from './call-add-keyframe';
-import {saveSequenceProp} from './save-sequence-prop';
+import {saveSequenceProps} from './save-sequence-prop';
 import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineFieldLabel} from './TimelineFieldLabel';
@@ -125,13 +125,17 @@ const Value: React.FC<{
 				return Promise.resolve();
 			}
 
-			return saveSequenceProp({
-				fileName: validatedLocation.source,
-				nodePath,
-				fieldKey: field.key,
-				value,
-				defaultValue,
-				schema,
+			return saveSequenceProps({
+				changes: [
+					{
+						fileName: validatedLocation.source,
+						nodePath,
+						fieldKey: field.key,
+						value,
+						defaultValue,
+						schema,
+					},
+				],
 				setCodeValues,
 				clientId,
 			});
@@ -293,13 +297,17 @@ export const TimelineSequencePropItem: React.FC<{
 				? JSON.stringify(field.fieldSchema.default)
 				: null;
 
-		saveSequenceProp({
-			fileName: validatedLocation.source,
-			nodePath,
-			fieldKey: field.key,
-			value: field.fieldSchema.default,
-			defaultValue,
-			schema,
+		saveSequenceProps({
+			changes: [
+				{
+					fileName: validatedLocation.source,
+					nodePath,
+					fieldKey: field.key,
+					value: field.fieldSchema.default,
+					defaultValue,
+					schema,
+				},
+			],
 			setCodeValues,
 			clientId: previewServerState.clientId,
 		});

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -113,6 +113,7 @@ const Value: React.FC<{
 					: null;
 
 			const stringifiedValue = JSON.stringify(value);
+			const fieldLabel = field.description ?? field.key;
 
 			if (value === codeValue.codeValue) {
 				return Promise.resolve();
@@ -138,11 +139,14 @@ const Value: React.FC<{
 				],
 				setCodeValues,
 				clientId,
+				undoLabel: `Update ${fieldLabel}`,
+				redoLabel: `Update ${fieldLabel} again`,
 			});
 		},
 		[
 			codeValue,
 			clientId,
+			field.description,
 			field.fieldSchema.default,
 			field.key,
 			nodePath,
@@ -296,6 +300,7 @@ export const TimelineSequencePropItem: React.FC<{
 			field.fieldSchema.default !== undefined
 				? JSON.stringify(field.fieldSchema.default)
 				: null;
+		const fieldLabel = field.description ?? field.key;
 
 		saveSequenceProps({
 			changes: [
@@ -310,10 +315,13 @@ export const TimelineSequencePropItem: React.FC<{
 			],
 			setCodeValues,
 			clientId: previewServerState.clientId,
+			undoLabel: `Reset ${fieldLabel}`,
+			redoLabel: `Reapply ${fieldLabel}`,
 		});
 	}, [
 		canResetToDefault,
 		canShowReset,
+		field.description,
 		field.fieldSchema.default,
 		field.key,
 		nodePath,

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -23,7 +23,6 @@ import {
 	stopForcingSpecificCursor,
 } from '../ForceSpecificCursor';
 import {
-	saveSequenceProp,
 	saveSequenceProps,
 	type SaveSequencePropChange,
 } from './save-sequence-prop';
@@ -449,20 +448,13 @@ export const useTimelineSequenceFromDrag = ({
 			return;
 		}
 
-		const savePromise =
-			changes.length === 1
-				? saveSequenceProp({
-						...changes[0],
-						setCodeValues: latestSetCodeValues,
-						clientId: latestServerState.clientId,
-					})
-				: saveSequenceProps({
-						changes,
-						setCodeValues: latestSetCodeValues,
-						clientId: latestServerState.clientId,
-						undoLabel: 'Move selected sequences',
-						redoLabel: 'Move selected sequences back',
-					});
+		const savePromise = saveSequenceProps({
+			changes,
+			setCodeValues: latestSetCodeValues,
+			clientId: latestServerState.clientId,
+			undoLabel: changes.length > 1 ? 'Move selected sequences' : null,
+			redoLabel: changes.length > 1 ? 'Move selected sequences back' : null,
+		});
 
 		savePromise
 			.catch((err) => {
@@ -684,20 +676,13 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 			return;
 		}
 
-		const savePromise =
-			changes.length === 1
-				? saveSequenceProp({
-						...changes[0],
-						setCodeValues: latestSetCodeValues,
-						clientId: latestServerState.clientId,
-					})
-				: saveSequenceProps({
-						changes,
-						setCodeValues: latestSetCodeValues,
-						clientId: latestServerState.clientId,
-						undoLabel: 'Resize selected sequences',
-						redoLabel: 'Resize selected sequences back',
-					});
+		const savePromise = saveSequenceProps({
+			changes,
+			setCodeValues: latestSetCodeValues,
+			clientId: latestServerState.clientId,
+			undoLabel: changes.length > 1 ? 'Resize selected sequences' : null,
+			redoLabel: changes.length > 1 ? 'Resize selected sequences back' : null,
+		});
 
 		savePromise
 			.catch((err) => {

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -452,8 +452,12 @@ export const useTimelineSequenceFromDrag = ({
 			changes,
 			setCodeValues: latestSetCodeValues,
 			clientId: latestServerState.clientId,
-			undoLabel: changes.length > 1 ? 'Move selected sequences' : null,
-			redoLabel: changes.length > 1 ? 'Move selected sequences back' : null,
+			undoLabel:
+				changes.length > 1 ? 'Move selected sequences' : 'Move sequence',
+			redoLabel:
+				changes.length > 1
+					? 'Move selected sequences back'
+					: 'Move sequence back',
 		});
 
 		savePromise
@@ -680,8 +684,12 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 			changes,
 			setCodeValues: latestSetCodeValues,
 			clientId: latestServerState.clientId,
-			undoLabel: changes.length > 1 ? 'Resize selected sequences' : null,
-			redoLabel: changes.length > 1 ? 'Resize selected sequences back' : null,
+			undoLabel:
+				changes.length > 1 ? 'Resize selected sequences' : 'Resize sequence',
+			redoLabel:
+				changes.length > 1
+					? 'Resize selected sequences back'
+					: 'Resize sequence back',
 		});
 
 		savePromise

--- a/packages/studio/src/components/Timeline/apply-effect-response-to-code-values.ts
+++ b/packages/studio/src/components/Timeline/apply-effect-response-to-code-values.ts
@@ -1,0 +1,31 @@
+import type {
+	CanUpdateEffectPropsResponse,
+	CanUpdateSequencePropsResponse,
+} from 'remotion';
+
+export const applyEffectResponseToCodeValues = ({
+	previous,
+	response,
+}: {
+	previous: CanUpdateSequencePropsResponse;
+	response: CanUpdateEffectPropsResponse;
+}): CanUpdateSequencePropsResponse => {
+	if (!previous.canUpdate) {
+		return previous;
+	}
+
+	const targetIndex = previous.effects.findIndex(
+		(effect) => effect.effectIndex === response.effectIndex,
+	);
+	if (targetIndex === -1) {
+		return previous;
+	}
+
+	const effects = [...previous.effects];
+	effects[targetIndex] = response;
+
+	return {
+		...previous,
+		effects,
+	};
+};

--- a/packages/studio/src/components/Timeline/call-add-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-add-keyframe.ts
@@ -4,6 +4,7 @@ import {
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
+import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
 import {enqueueSavePropChange} from './save-prop-queue';
 import type {SetCodeValues} from './save-sequence-prop';
 
@@ -84,6 +85,8 @@ export const callAddEffectKeyframe = ({
 				value,
 				schema,
 			}),
+		applyServerResponse: (prev, response) =>
+			applyEffectResponseToCodeValues({previous: prev, response}),
 		apiCall: () =>
 			callApi('/api/add-effect-keyframe', {
 				fileName,

--- a/packages/studio/src/components/Timeline/call-update-keyframe-settings.ts
+++ b/packages/studio/src/components/Timeline/call-update-keyframe-settings.ts
@@ -5,6 +5,7 @@ import {
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
+import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
 import {enqueueSavePropChange} from './save-prop-queue';
 import type {SetCodeValues} from './save-sequence-prop';
 
@@ -76,6 +77,8 @@ export const callUpdateEffectKeyframeSettings = ({
 				fieldKey,
 				settings,
 			}),
+		applyServerResponse: (prev, response) =>
+			applyEffectResponseToCodeValues({previous: prev, response}),
 		apiCall: () =>
 			callApi('/api/update-effect-keyframe-settings', {
 				fileName,

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -246,11 +246,11 @@ export const resetSelectedTimelineProps = ({
 				undoLabel:
 					sequencePropTargets.length > 1
 						? 'Reset selected sequence props'
-						: null,
+						: 'Reset sequence prop',
 				redoLabel:
 					sequencePropTargets.length > 1
 						? 'Reapply selected sequence props'
-						: null,
+						: 'Reapply sequence prop',
 			}),
 		);
 	}

--- a/packages/studio/src/components/Timeline/save-effect-prop.ts
+++ b/packages/studio/src/components/Timeline/save-effect-prop.ts
@@ -1,6 +1,7 @@
 import {optimisticUpdateForEffectCodeValues} from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
+import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
 import {enqueueSavePropChange} from './save-prop-queue';
 import type {SetCodeValues} from './save-sequence-prop';
 
@@ -36,6 +37,8 @@ export const saveEffectProp = ({
 				value,
 				schema,
 			}),
+		applyServerResponse: (prev, response) =>
+			applyEffectResponseToCodeValues({previous: prev, response}),
 		apiCall: () =>
 			callApi('/api/save-effect-props', {
 				fileName,

--- a/packages/studio/src/components/Timeline/save-prop-queue.ts
+++ b/packages/studio/src/components/Timeline/save-prop-queue.ts
@@ -46,6 +46,10 @@ export type EnqueueSaveOptions<TResponse> = {
 	applyOptimistic: (
 		prev: CanUpdateSequencePropsResponse,
 	) => CanUpdateSequencePropsResponse;
+	applyServerResponse?: (
+		prev: CanUpdateSequencePropsResponse,
+		response: TResponse,
+	) => CanUpdateSequencePropsResponse;
 	apiCall: () => Promise<TResponse>;
 	errorLabel: string;
 };
@@ -54,6 +58,7 @@ export const enqueueSavePropChange = <TResponse>({
 	nodePath,
 	setCodeValues,
 	applyOptimistic,
+	applyServerResponse,
 	apiCall,
 	errorLabel,
 }: EnqueueSaveOptions<TResponse>): Promise<void> => {
@@ -74,13 +79,19 @@ export const enqueueSavePropChange = <TResponse>({
 		}
 
 		try {
-			await apiCall();
+			const response = await apiCall();
 			if (myQueue.cancelled) {
 				return;
 			}
 
 			// If nothing more is queued, reset baseline so the next round starts fresh.
 			if (myQueue.chain === next) {
+				if (applyServerResponse) {
+					setCodeValues(nodePath, (prev) =>
+						applyServerResponse(prev, response),
+					);
+				}
+
 				dropQueue(nodePath, myQueue);
 			}
 		} catch (err) {

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -27,24 +27,55 @@ type SaveSequencePropsOptions = {
 	changes: SaveSequencePropChange[];
 	setCodeValues: SetCodeValues;
 	clientId: string;
-	undoLabel: string | null;
-	redoLabel: string | null;
-};
-
-type SaveSequencePropOptions = SaveSequencePropChange & {
-	setCodeValues: SetCodeValues;
-	clientId: string;
+	undoLabel?: string | null;
+	redoLabel?: string | null;
 };
 
 export const saveSequenceProps = ({
 	changes,
 	setCodeValues,
 	clientId,
-	undoLabel,
-	redoLabel,
+	undoLabel = null,
+	redoLabel = null,
 }: SaveSequencePropsOptions): Promise<void> => {
 	if (changes.length === 0) {
 		return Promise.resolve();
+	}
+
+	if (changes.length === 1 && undoLabel === null && redoLabel === null) {
+		const change = changes[0];
+		if (change === undefined) {
+			throw new Error('Expected a sequence prop change');
+		}
+
+		return enqueueSavePropChange({
+			nodePath: change.nodePath,
+			setCodeValues,
+			applyOptimistic: (prev) =>
+				optimisticUpdateForCodeValues({
+					previous: prev,
+					fieldKey: change.fieldKey,
+					value: change.value,
+					schema: change.schema,
+				}),
+			apiCall: () =>
+				callApi('/api/save-sequence-props', {
+					edits: [
+						{
+							fileName: change.fileName,
+							nodePath: change.nodePath,
+							key: change.fieldKey,
+							value: JSON.stringify(change.value),
+							defaultValue: change.defaultValue,
+							schema: change.schema,
+						},
+					],
+					clientId,
+					undoLabel,
+					redoLabel,
+				}),
+			errorLabel: 'Could not save sequence prop',
+		});
 	}
 
 	for (const change of changes) {
@@ -73,44 +104,4 @@ export const saveSequenceProps = ({
 		undoLabel,
 		redoLabel,
 	}).then(() => undefined);
-};
-
-export const saveSequenceProp = ({
-	fileName,
-	nodePath,
-	fieldKey,
-	value,
-	defaultValue,
-	schema,
-	setCodeValues,
-	clientId,
-}: SaveSequencePropOptions): Promise<void> => {
-	return enqueueSavePropChange({
-		nodePath,
-		setCodeValues,
-		applyOptimistic: (prev) =>
-			optimisticUpdateForCodeValues({
-				previous: prev,
-				fieldKey,
-				value,
-				schema,
-			}),
-		apiCall: () =>
-			callApi('/api/save-sequence-props', {
-				edits: [
-					{
-						fileName,
-						nodePath,
-						key: fieldKey,
-						value: JSON.stringify(value),
-						defaultValue,
-						schema,
-					},
-				],
-				clientId,
-				undoLabel: null,
-				redoLabel: null,
-			}),
-		errorLabel: 'Could not save sequence prop',
-	});
 };

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -27,22 +27,22 @@ type SaveSequencePropsOptions = {
 	changes: SaveSequencePropChange[];
 	setCodeValues: SetCodeValues;
 	clientId: string;
-	undoLabel?: string | null;
-	redoLabel?: string | null;
+	undoLabel: string;
+	redoLabel: string;
 };
 
 export const saveSequenceProps = ({
 	changes,
 	setCodeValues,
 	clientId,
-	undoLabel = null,
-	redoLabel = null,
+	undoLabel,
+	redoLabel,
 }: SaveSequencePropsOptions): Promise<void> => {
 	if (changes.length === 0) {
 		return Promise.resolve();
 	}
 
-	if (changes.length === 1 && undoLabel === null && redoLabel === null) {
+	if (changes.length === 1) {
 		const change = changes[0];
 		if (change === undefined) {
 			throw new Error('Expected a sequence prop change');


### PR DESCRIPTION
## Summary

- Settle effect prop saves/keyframe edits with the authoritative server response after the save queue drains.
- Fixes effect keyframe edits reverting to stale values after releasing the input dragger.

Fixes #8099
