### PR TITLE
`@remotion/studio`: Settle effect keyframes from server response

### DIFF
--- a/packages/studio/src/components/Timeline/apply-effect-response-to-code-values.ts
+++ b/packages/studio/src/components/Timeline/apply-effect-response-to-code-values.ts
@@ -1,0 +1,31 @@
+import type {
+	CanUpdateEffectPropsResponse,
+	CanUpdateSequencePropsResponse,
+} from 'remotion';
+
+export const applyEffectResponseToCodeValues = ({
+	previous,
+	response,
+}: {
+	previous: CanUpdateSequencePropsResponse;
+	response: CanUpdateEffectPropsResponse;
+}): CanUpdateSequencePropsResponse => {
+	if (!previous.canUpdate) {
+		return previous;
+	}
+
+	const targetIndex = previous.effects.findIndex(
+		(effect) => effect.effectIndex === response.effectIndex,
+	);
+	if (targetIndex === -1) {
+		return previous;
+	}
+
+	const effects = [...previous.effects];
+	effects[targetIndex] = response;
+
+	return {
+		...previous,
+		effects,
+	};
+};

--- a/packages/studio/src/components/Timeline/call-add-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-add-keyframe.ts
@@ -4,6 +4,7 @@ import {
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
+import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
 import {enqueueSavePropChange} from './save-prop-queue';
 import type {SetCodeValues} from './save-sequence-prop';
 
@@ -84,6 +85,8 @@ export const callAddEffectKeyframe = ({
 				value,
 				schema,
 			}),
+		applyServerResponse: (prev, response) =>
+			applyEffectResponseToCodeValues({previous: prev, response}),
 		apiCall: () =>
 			callApi('/api/add-effect-keyframe', {
 				fileName,

--- a/packages/studio/src/components/Timeline/call-update-keyframe-settings.ts
+++ b/packages/studio/src/components/Timeline/call-update-keyframe-settings.ts
@@ -5,6 +5,7 @@ import {
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
+import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
 import {enqueueSavePropChange} from './save-prop-queue';
 import type {SetCodeValues} from './save-sequence-prop';
 
@@ -76,6 +77,8 @@ export const callUpdateEffectKeyframeSettings = ({
 				fieldKey,
 				settings,
 			}),
+		applyServerResponse: (prev, response) =>
+			applyEffectResponseToCodeValues({previous: prev, response}),
 		apiCall: () =>
 			callApi('/api/update-effect-keyframe-settings', {
 				fileName,

--- a/packages/studio/src/components/Timeline/save-effect-prop.ts
+++ b/packages/studio/src/components/Timeline/save-effect-prop.ts
@@ -1,6 +1,7 @@
 import {optimisticUpdateForEffectCodeValues} from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
+import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
 import {enqueueSavePropChange} from './save-prop-queue';
 import type {SetCodeValues} from './save-sequence-prop';
 
@@ -36,6 +37,8 @@ export const saveEffectProp = ({
 				value,
 				schema,
 			}),
+		applyServerResponse: (prev, response) =>
+			applyEffectResponseToCodeValues({previous: prev, response}),
 		apiCall: () =>
 			callApi('/api/save-effect-props', {
 				fileName,

--- a/packages/studio/src/components/Timeline/save-prop-queue.ts
+++ b/packages/studio/src/components/Timeline/save-prop-queue.ts
@@ -46,6 +46,10 @@ export type EnqueueSaveOptions<TResponse> = {
 	applyOptimistic: (
 		prev: CanUpdateSequencePropsResponse,
 	) => CanUpdateSequencePropsResponse;
+	applyServerResponse?: (
+		prev: CanUpdateSequencePropsResponse,
+		response: TResponse,
+	) => CanUpdateSequencePropsResponse;
 	apiCall: () => Promise<TResponse>;
 	errorLabel: string;
 };
@@ -54,6 +58,7 @@ export const enqueueSavePropChange = <TResponse>({
 	nodePath,
 	setCodeValues,
 	applyOptimistic,
+	applyServerResponse,
 	apiCall,
 	errorLabel,
 }: EnqueueSaveOptions<TResponse>): Promise<void> => {
@@ -74,13 +79,19 @@ export const enqueueSavePropChange = <TResponse>({
 		}
 
 		try {
-			await apiCall();
+			const response = await apiCall();
 			if (myQueue.cancelled) {
 				return;
 			}
 
 			// If nothing more is queued, reset baseline so the next round starts fresh.
 			if (myQueue.chain === next) {
+				if (applyServerResponse) {
+					setCodeValues(nodePath, (prev) =>
+						applyServerResponse(prev, response),
+					);
+				}
+
 				dropQueue(nodePath, myQueue);
 			}
 		} catch (err) {


### PR DESCRIPTION
## Summary

- Settle effect prop saves/keyframe edits with the authoritative server response after the save queue drains.
- Fixes effect keyframe edits reverting to stale values after releasing the input dragger.

Fixes #8099
