### PR TITLE
`@remotion/studio`: Allow negative scale values in Visual Mode

### DIFF
--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -173,7 +173,6 @@ export const sequenceVisualStyleSchema = {
 	},
 	'style.scale': {
 		type: 'scale',
-		min: 0.05,
 		max: 100,
 		step: 0.01,
 		default: 1,

--- a/packages/core/src/test/wrap-in-schema-helpers.test.ts
+++ b/packages/core/src/test/wrap-in-schema-helpers.test.ts
@@ -42,6 +42,11 @@ test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 	);
 });
 
+test('style.scale does not impose a minimum value', () => {
+	const scaleSchema = sequenceVisualStyleSchema['style.scale'];
+	expect('min' in scaleSchema).toBe(false);
+});
+
 test('readValuesFromProps reads dot-notation keys via getNestedValue', () => {
 	const props = {
 		layout: 'absolute-fill',

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1173,7 +1173,7 @@ test('Selected outline dragging keyframed translate adds a keyframe at the sourc
 
 test('Selected outline edge dragging scales one axis when scale is unlinked', () => {
 	const schema = {
-		'style.scale': {type: 'scale', default: 1, min: 0.05, max: 100},
+		'style.scale': {type: 'scale', default: 1, max: 100},
 	} satisfies SequenceSchema;
 	const nodePath = makeKey(['body', 0]);
 	const dragStates = [
@@ -1217,11 +1217,19 @@ test('Selected outline edge dragging scales one axis when scale is unlinked', ()
 			schema,
 		},
 	]);
+
+	const negativeValues = getSelectedOutlineScaleDragValues({
+		dragStates,
+		axis: 'x',
+		scaleFactor: -0.5,
+	});
+
+	expect(negativeValues.get(dragStates[0].key)).toBe('-1 3');
 });
 
 test('Selected outline edge dragging preserves aspect ratio when scale is linked', () => {
 	const schema = {
-		'style.scale': {type: 'scale', default: 1, min: 0.05, max: 100},
+		'style.scale': {type: 'scale', default: 1, max: 100},
 	} satisfies SequenceSchema;
 	const nodePath = makeKey(['body', 0]);
 	const dragStates = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes the `style.scale` minimum from the shared sequence schema so Studio controls can accept zero and negative scale values.
- Adds focused coverage for the schema contract and selected-outline scale drag behavior.

Fixes #8142

## Walkthrough
<a href="https://cursor.com/agents/bc-00fe76cf-4a2c-47a6-84b8-973e5f2b172c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnegative_scale_studio_timeline.mp4"><img src="https://cursor.com/artifacts/c/art-8052b9fa-8482-4522-9d86-7e909b7d827d" alt="negative_scale_studio_timeline.mp4" /></a>
![Scale input retaining -2.50](https://cursor.com/artifacts/c/art-84559a6f-302f-4f4b-92ef-5ac009b3cd77)

## Testing
- `bun test src/test/wrap-in-schema-helpers.test.ts`
- `bun test src/test/timeline-selection.test.ts`
- `bunx oxfmt src --write` in `packages/core`
- `bunx oxfmt src --write` in `packages/studio`
- `bun run build`
- `bunx turbo run lint formatting --filter='remotion' --filter='@remotion/studio' --no-update-notifier`
- `bun run stylecheck` was attempted; it fails only on the documented `@remotion/lambda-go` Go version caveat (`go >= 1.23`, VM has `1.22.2`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00fe76cf-4a2c-47a6-84b8-973e5f2b172c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00fe76cf-4a2c-47a6-84b8-973e5f2b172c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

