### PR TITLE
`@remotion/studio`: Limit translate decimal places

### DIFF
--- a/packages/studio/src/components/Timeline/timeline-translate-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-translate-utils.ts
@@ -1,6 +1,7 @@
 import {normalizeTimelineNumber} from './timeline-field-utils';
 
 const PIXEL_PATTERN = /^(-?\d+(?:\.\d+)?)px(?:\s+(-?\d+(?:\.\d+)?)px)?$/;
+const translateDecimalPlaces = 1;
 
 export const parseTranslate = (value: string): [number, number] => {
 	const m = value.match(PIXEL_PATTERN);
@@ -15,7 +16,9 @@ export const parseTranslate = (value: string): [number, number] => {
 };
 
 const formatTranslateCoordinate = (value: number): string => {
-	const rounded = normalizeTimelineNumber(value);
+	const normalized = normalizeTimelineNumber(value);
+	const factor = 10 ** translateDecimalPlaces;
+	const rounded = Math.round(normalized * factor) / factor;
 	return String(Object.is(rounded, -0) ? 0 : rounded);
 };
 

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1072,12 +1072,12 @@ test('Selected outline dragging applies the same delta to all selected sequences
 
 	const lastValues = getSelectedOutlineDragValues({
 		dragStates,
-		deltaX: 7,
-		deltaY: -4,
+		deltaX: 7.333333,
+		deltaY: -4.666667,
 	});
 
-	expect(lastValues.get(dragStates[0].key)).toBe('17px 16px');
-	expect(lastValues.get(dragStates[1].key)).toBe('2px -1px');
+	expect(lastValues.get(dragStates[0].key)).toBe('17.3px 15.3px');
+	expect(lastValues.get(dragStates[1].key)).toBe('2.3px -1.7px');
 	expect(
 		getSelectedOutlineDragChanges({
 			dragStates,
@@ -1089,7 +1089,7 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			fileName: '/project/src/Comp.tsx',
 			nodePath: firstNodePath,
 			fieldKey: 'style.translate',
-			value: '17px 16px',
+			value: '17.3px 15.3px',
 			defaultValue: JSON.stringify('0px 0px'),
 			schema,
 		},
@@ -1098,7 +1098,7 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			fileName: '/project/src/Comp.tsx',
 			nodePath: secondNodePath,
 			fieldKey: 'style.translate',
-			value: '2px -1px',
+			value: '2.3px -1.7px',
 			defaultValue: JSON.stringify('0px 0px'),
 			schema,
 		},

--- a/packages/studio/src/test/timeline-translate-utils.test.ts
+++ b/packages/studio/src/test/timeline-translate-utils.test.ts
@@ -11,7 +11,9 @@ test('parseTranslate normalizes floating point noise', () => {
 });
 
 test('serializeTranslate normalizes floating point noise', () => {
-	expect(serializeTranslate(0.1 + 0.2, 10.020000000000001)).toBe(
-		'0.3px 10.02px',
-	);
+	expect(serializeTranslate(0.1 + 0.2, 10.020000000000001)).toBe('0.3px 10px');
+});
+
+test('serializeTranslate limits coordinates to one decimal place', () => {
+	expect(serializeTranslate(254.854512, 393.565342)).toBe('254.9px 393.6px');
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8114.

## Summary
- Limit generated `style.translate` coordinates to at most one decimal place.
- Add direct serializer coverage and Visual Mode outline drag coverage for fractional deltas.

## Testing
- `bun test src/test/timeline-translate-utils.test.ts src/test/timeline-selection.test.ts`
- `bun run test` in `packages/studio`
- `bun run lint` in `packages/studio` (passes with pre-existing warnings)
- `bun run formatting` in `packages/studio`
- `bun run build`
- `bun run stylecheck` (blocked by documented Cloud Agent Go 1.22.2 limitation for `@remotion/lambda-go`, which requires Go >= 1.23.0)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38bf1ff0-95d7-4cf9-b831-56516678ff7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38bf1ff0-95d7-4cf9-b831-56516678ff7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

