### PR TITLE
`@remotion/studio`: Fix timeline asset reveal

### DIFF
--- a/packages/studio/src/components/ExplorerPanel.tsx
+++ b/packages/studio/src/components/ExplorerPanel.tsx
@@ -1,8 +1,9 @@
-import {createRef, useCallback, useImperativeHandle, useState} from 'react';
+import {useCallback, useImperativeHandle, useState} from 'react';
 import {BACKGROUND} from '../helpers/colors';
 import {AssetSelector} from './AssetSelector';
 import {CompositionSelector} from './CompositionSelector';
 import {CompSelectorRef} from './CompSelectorRef';
+import {explorerSidebarTabs} from './ExplorerPanelRef';
 import {Tab, Tabs} from './Tabs';
 
 const container: React.CSSProperties = {
@@ -34,11 +35,6 @@ const tabsContainer: React.CSSProperties = {
 const persistSelectedOptionsSidebarPanel = (panel: OptionsSidebarPanel) => {
 	localStorage.setItem(localStorageKey, panel);
 };
-
-export const explorerSidebarTabs = createRef<{
-	selectAssetsPanel: () => void;
-	selectCompositionPanel: () => void;
-}>();
 
 export const ExplorerPanel: React.FC<{
 	readOnlyStudio: boolean;

--- a/packages/studio/src/components/ExplorerPanelRef.ts
+++ b/packages/studio/src/components/ExplorerPanelRef.ts
@@ -1,0 +1,6 @@
+import {createRef} from 'react';
+
+export const explorerSidebarTabs = createRef<{
+	selectAssetsPanel: () => void;
+	selectCompositionPanel: () => void;
+}>();

--- a/packages/studio/src/components/InitialCompositionLoader.tsx
+++ b/packages/studio/src/components/InitialCompositionLoader.tsx
@@ -9,37 +9,10 @@ import {persistExpandedFolders} from '../helpers/persist-open-folders';
 import {getRoute, pushUrl} from '../helpers/url-state';
 import {FolderContext} from '../state/folders';
 import {SidebarContext} from '../state/sidebar';
-import {explorerSidebarTabs} from './ExplorerPanel';
+import {explorerSidebarTabs} from './ExplorerPanelRef';
 import {deriveCanvasContentFromUrl} from './load-canvas-content-from-url';
+import {useSelectAsset} from './use-select-asset';
 import {useStaticFiles} from './use-static-files';
-
-export const useSelectAsset = () => {
-	const {setCanvasContent} = useContext(Internals.CompositionSetters);
-	const {setAssetFoldersExpanded} = useContext(FolderContext);
-
-	return useCallback(
-		(asset: string) => {
-			setCanvasContent({type: 'asset', asset});
-			explorerSidebarTabs.current?.selectAssetsPanel();
-			setAssetFoldersExpanded((ex) => {
-				const split = asset.split('/');
-
-				const keysToExpand = split.map((_, i) => {
-					return split.slice(0, i).join('/');
-				});
-				const newState: ExpandedFoldersState = {
-					...ex,
-				};
-				for (const key of keysToExpand) {
-					newState[key] = true;
-				}
-
-				return newState;
-			});
-		},
-		[setAssetFoldersExpanded, setCanvasContent],
-	);
-};
 
 export const useSelectComposition = () => {
 	const {setCompositionFoldersExpanded} = useContext(FolderContext);

--- a/packages/studio/src/components/Timeline/TimelineMediaInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineMediaInfo.tsx
@@ -1,7 +1,11 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import {Internals} from 'remotion';
 import {LIGHT_TEXT, VERY_LIGHT_TEXT} from '../../helpers/colors';
-import {pushUrl} from '../../helpers/url-state';
+import {useSelectAsset} from '../use-select-asset';
+import {
+	getTimelineAssetLinkInfo,
+	openTimelineAssetLink,
+} from './timeline-asset-link';
 import {SELECTION_ENABLED} from './TimelineSelection';
 
 const lineStyle: React.CSSProperties = {
@@ -14,67 +18,8 @@ const lineStyle: React.CSSProperties = {
 	display: 'inline-block',
 };
 
-type LinkInfo =
-	| {
-			kind: 'local';
-			assetPath: string;
-			title: string;
-	  }
-	| {
-			kind: 'remote';
-			href: string;
-			title: string;
-	  }
-	| null;
-
-export type TimelineAssetLinkInfo = Exclude<LinkInfo, null>;
-
-export const getTimelineAssetLinkInfo = (src: string): LinkInfo => {
-	const staticBase =
-		typeof window === 'undefined' ? null : window.remotion_staticBase;
-
-	if (staticBase && src.startsWith(staticBase + '/')) {
-		const assetPath = src.slice(staticBase.length + 1);
-		return {
-			kind: 'local',
-			assetPath: decodeURIComponent(assetPath),
-			title: decodeURIComponent(assetPath),
-		};
-	}
-
-	if (
-		src.startsWith('http://') ||
-		src.startsWith('https://') ||
-		src.startsWith('//')
-	) {
-		try {
-			const url = new URL(src.startsWith('//') ? 'https:' + src : src);
-			return {kind: 'remote', href: src, title: url.hostname};
-		} catch {
-			return {kind: 'remote', href: src, title: src};
-		}
-	}
-
-	return null;
-};
-
-export const openTimelineAssetLink = (
-	linkInfo: TimelineAssetLinkInfo,
-	setCanvasContent: React.ContextType<
-		typeof Internals.CompositionSetters
-	>['setCanvasContent'],
-) => {
-	if (linkInfo.kind === 'local') {
-		setCanvasContent({type: 'asset', asset: linkInfo.assetPath});
-		pushUrl(`/assets/${linkInfo.assetPath}`);
-		return;
-	}
-
-	window.open(linkInfo.href, '_blank', 'noopener,noreferrer');
-};
-
 const useAssetLink = (src: string) => {
-	const {setCanvasContent} = React.useContext(Internals.CompositionSetters);
+	const selectAsset = useSelectAsset();
 	const [hovered, setHovered] = useState(false);
 
 	const linkInfo = useMemo(() => getTimelineAssetLinkInfo(src), [src]);
@@ -89,9 +34,9 @@ const useAssetLink = (src: string) => {
 			e.preventDefault();
 			e.stopPropagation();
 
-			openTimelineAssetLink(linkInfo, setCanvasContent);
+			openTimelineAssetLink(linkInfo, selectAsset);
 		},
-		[linkInfo, setCanvasContent],
+		[linkInfo, selectAsset],
 	);
 
 	const onPointerEnter = useCallback(() => setHovered(true), []);

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -22,8 +22,13 @@ import {
 } from '../ExpandedTracksProvider';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
+import {useSelectAsset} from '../use-select-asset';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
 import {saveSequenceProps} from './save-sequence-prop';
+import {
+	getTimelineAssetLinkInfo,
+	openTimelineAssetLink,
+} from './timeline-asset-link';
 import {
 	TimelineExpandArrowButton,
 	TimelineExpandArrowSpacer,
@@ -31,11 +36,7 @@ import {
 import {TimelineExpandedSection} from './TimelineExpandedSection';
 import {TimelineItemStack} from './TimelineItemStack';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
-import {
-	getTimelineAssetLinkInfo,
-	openTimelineAssetLink,
-	TimelineMediaInfo,
-} from './TimelineMediaInfo';
+import {TimelineMediaInfo} from './TimelineMediaInfo';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {
 	isTimelineSelectionModifierEvent,
@@ -103,7 +104,7 @@ export const TimelineSequenceItem: React.FC<{
 	const {toggleTrack} = useContext(ExpandedTracksSetterContext);
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
-	const {setCanvasContent} = useContext(Internals.CompositionSetters);
+	const selectAsset = useSelectAsset();
 	const {onSelect, selectable, selected} =
 		useTimelineRowSelection(nodePathInfo);
 	const containsSelection = useTimelineRowContainsSelection(nodePathInfo);
@@ -278,7 +279,7 @@ export const TimelineSequenceItem: React.FC<{
 						leftItem: null,
 						disabled: false,
 						onClick: () => {
-							openTimelineAssetLink(assetLinkInfo, setCanvasContent);
+							openTimelineAssetLink(assetLinkInfo, selectAsset);
 						},
 						quickSwitcherLabel: null,
 						subMenu: null,
@@ -338,8 +339,8 @@ export const TimelineSequenceItem: React.FC<{
 		canOpenInEditor,
 		openInEditor,
 		previewConnected,
+		selectAsset,
 		sequence,
-		setCanvasContent,
 	]);
 
 	const isExpanded =

--- a/packages/studio/src/components/Timeline/timeline-asset-link.ts
+++ b/packages/studio/src/components/Timeline/timeline-asset-link.ts
@@ -1,0 +1,58 @@
+import {pushUrl} from '../../helpers/url-state';
+
+type LinkInfo =
+	| {
+			kind: 'local';
+			assetPath: string;
+			title: string;
+	  }
+	| {
+			kind: 'remote';
+			href: string;
+			title: string;
+	  }
+	| null;
+
+export type TimelineAssetLinkInfo = Exclude<LinkInfo, null>;
+
+export const getTimelineAssetLinkInfo = (src: string): LinkInfo => {
+	const staticBase =
+		typeof window === 'undefined' ? null : window.remotion_staticBase;
+
+	if (staticBase && src.startsWith(staticBase + '/')) {
+		const assetPath = src.slice(staticBase.length + 1);
+		return {
+			kind: 'local',
+			assetPath: decodeURIComponent(assetPath),
+			title: decodeURIComponent(assetPath),
+		};
+	}
+
+	if (
+		src.startsWith('http://') ||
+		src.startsWith('https://') ||
+		src.startsWith('//')
+	) {
+		try {
+			const url = new URL(src.startsWith('//') ? 'https:' + src : src);
+			return {kind: 'remote', href: src, title: url.hostname};
+		} catch {
+			return {kind: 'remote', href: src, title: src};
+		}
+	}
+
+	return null;
+};
+
+export const openTimelineAssetLink = (
+	linkInfo: TimelineAssetLinkInfo,
+	selectAsset: (asset: string) => void,
+) => {
+	if (linkInfo.kind === 'local') {
+		selectAsset(linkInfo.assetPath);
+		pushUrl(`/assets/${linkInfo.assetPath}`);
+		return;
+	}
+
+	window.open(linkInfo.href, '_blank', 'noopener,noreferrer');
+};

--- a/packages/studio/src/components/use-select-asset.ts
+++ b/packages/studio/src/components/use-select-asset.ts
@@ -1,0 +1,33 @@
+import {useCallback, useContext} from 'react';
+import {Internals} from 'remotion';
+import type {ExpandedFoldersState} from '../helpers/persist-open-folders';
+import {FolderContext} from '../state/folders';
+import {explorerSidebarTabs} from './ExplorerPanelRef';
+
+export const useSelectAsset = () => {
+	const {setCanvasContent} = useContext(Internals.CompositionSetters);
+	const {setAssetFoldersExpanded} = useContext(FolderContext);
+
+	return useCallback(
+		(asset: string) => {
+			setCanvasContent({type: 'asset', asset});
+			explorerSidebarTabs.current?.selectAssetsPanel();
+			setAssetFoldersExpanded((ex) => {
+				const split = asset.split('/');
+
+				const keysToExpand = split.map((_, i) => {
+					return split.slice(0, i).join('/');
+				});
+				const newState: ExpandedFoldersState = {
+					...ex,
+				};
+				for (const key of keysToExpand) {
+					newState[key] = true;
+				}
+
+				return newState;
+			});
+		},
+		[setAssetFoldersExpanded, setCanvasContent],
+	);
+};

--- a/packages/studio/src/test/timeline-video-info.test.ts
+++ b/packages/studio/src/test/timeline-video-info.test.ts
@@ -1,5 +1,57 @@
-import {expect, test} from 'bun:test';
+import {afterEach, expect, test} from 'bun:test';
 import {getTimelineVideoInfoWidths} from '../components/Timeline/get-timeline-video-info-widths';
+import {
+	getTimelineAssetLinkInfo,
+	openTimelineAssetLink,
+} from '../components/Timeline/timeline-asset-link';
+
+type TestWindow = Pick<
+	Window,
+	| 'history'
+	| 'location'
+	| 'open'
+	| 'remotion_isReadOnlyStudio'
+	| 'remotion_staticBase'
+>;
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+		return;
+	}
+
+	Reflect.deleteProperty(globalThis, 'window');
+});
+
+const installTestWindow = ({
+	onPushState,
+	onOpen,
+}: {
+	onPushState: (url: string | URL | null | undefined) => void;
+	onOpen: Window['open'];
+}) => {
+	const testWindow: TestWindow = {
+		remotion_staticBase: '/static-abcdef',
+		remotion_isReadOnlyStudio: false,
+		history: {
+			pushState: (_state, _title, url) => onPushState(url),
+		} as History,
+		location: {
+			pathname: '/',
+		} as Location,
+		open: onOpen,
+	};
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: testWindow,
+	});
+};
 
 test('video timeline thumbnails ignore premount and postmount width', () => {
 	const withoutPremount = getTimelineVideoInfoWidths({
@@ -30,4 +82,71 @@ test('video timeline thumbnail widths never go negative', () => {
 		mediaVisualizationWidth: 0,
 		mediaNaturalWidth: 0,
 	});
+});
+
+test('timeline local asset links select the asset and push the asset route', () => {
+	const pushedUrls: (string | URL | null | undefined)[] = [];
+	installTestWindow({
+		onPushState: (url) => {
+			pushedUrls.push(url);
+		},
+		onOpen: () => null,
+	});
+
+	const linkInfo = getTimelineAssetLinkInfo(
+		'/static-abcdef/folder%20name/image.png',
+	);
+	const selectedAssets: string[] = [];
+
+	expect(linkInfo).toEqual({
+		kind: 'local',
+		assetPath: 'folder name/image.png',
+		title: 'folder name/image.png',
+	});
+
+	if (!linkInfo) {
+		throw new Error('Expected local asset link');
+	}
+
+	openTimelineAssetLink(linkInfo, (asset) => {
+		selectedAssets.push(asset);
+	});
+
+	expect(selectedAssets).toEqual(['folder name/image.png']);
+	expect(pushedUrls).toEqual(['/assets/folder name/image.png']);
+});
+
+test('timeline remote asset links still open in a new tab', () => {
+	const pushedUrls: (string | URL | null | undefined)[] = [];
+	const openedUrls: Parameters<Window['open']>[] = [];
+	installTestWindow({
+		onPushState: (url) => {
+			pushedUrls.push(url);
+		},
+		onOpen: (...args) => {
+			openedUrls.push(args);
+			return null;
+		},
+	});
+
+	const linkInfo = getTimelineAssetLinkInfo('https://example.com/image.png');
+
+	expect(linkInfo).toEqual({
+		kind: 'remote',
+		href: 'https://example.com/image.png',
+		title: 'example.com',
+	});
+
+	if (!linkInfo) {
+		throw new Error('Expected remote asset link');
+	}
+
+	openTimelineAssetLink(linkInfo, () => {
+		throw new Error('Remote links should not select assets');
+	});
+
+	expect(openedUrls).toEqual([
+		['https://example.com/image.png', '_blank', 'noopener,noreferrer'],
+	]);
+	expect(pushedUrls).toEqual([]);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8033.

### Summary
- Reuse the Studio asset-selection path for timeline asset links so `Show asset` opens the Assets panel and expands parent folders before pushing the asset route.
- Share timeline asset-link parsing/opening between the context-menu action and clickable media filename.
- Add focused regression tests for local and remote timeline asset links.

### Walkthrough
<a href="https://cursor.com/agents/bc-ba59bb84-629d-4a92-ac1d-2d075719c75e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshow_asset_reveals_sidebar.mp4"><img src="https://cursor.com/artifacts/c/art-bb413381-465b-40fb-9e7d-b16a61af4cc7" alt="show_asset_reveals_sidebar.mp4" /></a>
![Final Assets sidebar selection](https://cursor.com/artifacts/c/art-ad2b6a1f-f23a-4fa5-bbb5-8c73be3f689d)

### Testing
- `bunx oxfmt src --write` in `packages/studio`
- `bun test packages/studio/src/test/timeline-video-info.test.ts`
- `bun run --cwd packages/studio test`
- `bun run --cwd packages/studio make`
- `bun run build`
- `bun run --cwd packages/studio lint` (passes with existing warnings)
- `bun run stylecheck` (blocked by known Go version warning for `@remotion/lambda-go` in this VM)
- Manual Studio verification: right-click `framer.webm` timeline media row in `postmount-example`, click `Show asset`, verify `/assets/framer.webm`, Assets tab, and highlighted row.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba59bb84-629d-4a92-ac1d-2d075719c75e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba59bb84-629d-4a92-ac1d-2d075719c75e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

