### PR TITLE
`@remotion/studio`: Fix image asset metadata lookup

### DIFF
--- a/packages/studio/src/components/CurrentAsset.tsx
+++ b/packages/studio/src/components/CurrentAsset.tsx
@@ -3,6 +3,7 @@ import React, {useContext, useMemo} from 'react';
 import {Internals, staticFile} from 'remotion';
 import {BACKGROUND, BORDER_COLOR} from '../helpers/colors';
 import {formatMediaDuration} from '../helpers/format-media-duration';
+import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import {useMediaMetadata} from '../helpers/use-media-metadata';
 import {useStaticFiles} from './use-static-files';
 
@@ -40,6 +41,17 @@ const row: React.CSSProperties = {
 	backgroundColor: BACKGROUND,
 };
 
+export const getCurrentAssetMetadataSource = (assetName: string | null) => {
+	if (!assetName) {
+		return null;
+	}
+
+	const fileType = getPreviewFileType(assetName);
+	return fileType === 'audio' || fileType === 'video'
+		? staticFile(assetName)
+		: null;
+};
+
 export const CurrentAsset: React.FC = () => {
 	const {canvasContent} = useContext(Internals.CompositionManager);
 
@@ -57,7 +69,7 @@ export const CurrentAsset: React.FC = () => {
 		return file?.sizeInBytes ?? null;
 	}, [assetName, staticFiles]);
 
-	const src = assetName ? staticFile(assetName) : null;
+	const src = getCurrentAssetMetadataSource(assetName);
 	const mediaMetadata = useMediaMetadata(src);
 
 	if (!assetName) {

--- a/packages/studio/src/components/FilePreview.tsx
+++ b/packages/studio/src/components/FilePreview.tsx
@@ -1,9 +1,9 @@
 import {formatBytes} from '@remotion/studio-shared';
 import React from 'react';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
+import type {AssetFileType} from '../helpers/get-preview-file-type';
 import {JSONViewer} from './JSONViewer';
 import {Spacing} from './layout';
-import type {AssetFileType} from './Preview';
 import {TextViewer} from './TextViewer';
 
 const msgStyle: React.CSSProperties = {

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -12,6 +12,7 @@ import {
 } from '../helpers/checkerboard-background';
 import {LIGHT_TEXT} from '../helpers/colors';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
+import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import type {Dimensions} from '../helpers/is-current-selected-still';
 import {CheckerboardContext} from '../state/checkerboard';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from './Menu/is-menu-item';
@@ -40,50 +41,6 @@ const assetMetadataErrorContainer: React.CSSProperties = {
 	position: 'absolute',
 	height: '100%',
 	overflowY: 'auto',
-};
-
-export type AssetFileType =
-	| 'audio'
-	| 'video'
-	| 'image'
-	| 'json'
-	| 'txt'
-	| 'other';
-export const getPreviewFileType = (fileName: string | null): AssetFileType => {
-	if (!fileName) {
-		return 'other';
-	}
-
-	const audioExtensions = ['mp3', 'wav', 'ogg', 'aac'];
-	const videoExtensions = ['mp4', 'avi', 'mkv', 'mov', 'webm'];
-	const imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp'];
-
-	const fileExtension = fileName.split('.').pop()?.toLowerCase();
-	if (fileExtension === undefined) {
-		throw new Error('File extension is undefined');
-	}
-
-	if (audioExtensions.includes(fileExtension)) {
-		return 'audio';
-	}
-
-	if (videoExtensions.includes(fileExtension)) {
-		return 'video';
-	}
-
-	if (imageExtensions.includes(fileExtension)) {
-		return 'image';
-	}
-
-	if (fileExtension === 'json') {
-		return 'json';
-	}
-
-	if (fileExtension === 'txt') {
-		return 'txt';
-	}
-
-	return 'other';
 };
 
 const checkerboardSize = 49;

--- a/packages/studio/src/components/RenderPreview.tsx
+++ b/packages/studio/src/components/RenderPreview.tsx
@@ -3,8 +3,8 @@ import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {LIGHT_TEXT} from '../helpers/colors';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
 import {remotion_outputsBase} from '../helpers/get-asset-metadata';
+import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import {FilePreview} from './FilePreview';
-import {getPreviewFileType} from './Preview';
 
 const msgStyle: React.CSSProperties = {
 	fontSize: 13,

--- a/packages/studio/src/components/SizeSelector.tsx
+++ b/packages/studio/src/components/SizeSelector.tsx
@@ -1,12 +1,12 @@
 import React, {useContext, useMemo} from 'react';
 import type {PreviewSize} from 'remotion';
 import {Internals} from 'remotion';
+import type {AssetFileType} from '../helpers/get-preview-file-type';
+import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import {Checkmark} from '../icons/Checkmark';
 import {CONTROL_BUTTON_PADDING} from './ControlButton';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {Combobox} from './NewComposition/ComboBox';
-import type {AssetFileType} from './Preview';
-import {getPreviewFileType} from './Preview';
 
 const commonPreviewSizes: PreviewSize[] = [
 	{

--- a/packages/studio/src/components/StaticFilePreview.tsx
+++ b/packages/studio/src/components/StaticFilePreview.tsx
@@ -3,8 +3,8 @@ import {staticFile} from 'remotion';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {LIGHT_TEXT} from '../helpers/colors';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
+import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import {FilePreview} from './FilePreview';
-import {getPreviewFileType} from './Preview';
 import {useStaticFiles} from './use-static-files';
 
 const msgStyle: React.CSSProperties = {

--- a/packages/studio/src/helpers/get-asset-metadata.ts
+++ b/packages/studio/src/helpers/get-asset-metadata.ts
@@ -1,7 +1,7 @@
 import {getVideoMetadata} from '@remotion/media-utils';
 import type {CanvasContent} from 'remotion';
 import {staticFile} from 'remotion';
-import {getPreviewFileType} from '../components/Preview';
+import {getPreviewFileType} from './get-preview-file-type';
 import type {Dimensions} from './is-current-selected-still';
 
 export const remotion_outputsBase = window.remotion_staticBase.replace(

--- a/packages/studio/src/helpers/get-preview-file-type.ts
+++ b/packages/studio/src/helpers/get-preview-file-type.ts
@@ -1,0 +1,44 @@
+export type AssetFileType =
+	| 'audio'
+	| 'video'
+	| 'image'
+	| 'json'
+	| 'txt'
+	| 'other';
+
+export const getPreviewFileType = (fileName: string | null): AssetFileType => {
+	if (!fileName) {
+		return 'other';
+	}
+
+	const audioExtensions = ['mp3', 'wav', 'ogg', 'aac'];
+	const videoExtensions = ['mp4', 'avi', 'mkv', 'mov', 'webm'];
+	const imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp'];
+
+	const fileExtension = fileName.split('.').pop()?.toLowerCase();
+	if (fileExtension === undefined) {
+		throw new Error('File extension is undefined');
+	}
+
+	if (audioExtensions.includes(fileExtension)) {
+		return 'audio';
+	}
+
+	if (videoExtensions.includes(fileExtension)) {
+		return 'video';
+	}
+
+	if (imageExtensions.includes(fileExtension)) {
+		return 'image';
+	}
+
+	if (fileExtension === 'json') {
+		return 'json';
+	}
+
+	if (fileExtension === 'txt') {
+		return 'txt';
+	}
+
+	return 'other';
+};

--- a/packages/studio/src/test/current-asset.test.ts
+++ b/packages/studio/src/test/current-asset.test.ts
@@ -1,0 +1,15 @@
+import {expect, test} from 'bun:test';
+import {getCurrentAssetMetadataSource} from '../components/CurrentAsset';
+
+test('does not request media metadata for image assets', () => {
+	expect(getCurrentAssetMetadataSource('1.jpg')).toBe(null);
+	expect(getCurrentAssetMetadataSource('nested/file.png')).toBe(null);
+	expect(getCurrentAssetMetadataSource('animation.gif')).toBe(null);
+});
+
+test('requests media metadata for audio and video assets', () => {
+	expect(getCurrentAssetMetadataSource('video.mp4')).toBe('/video.mp4');
+	expect(getCurrentAssetMetadataSource('nested/audio.mp3')).toBe(
+		'/nested/audio.mp3',
+	);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8032

## Summary
- Prevent `CurrentAsset` from calling media metadata probing for image and other non-media static assets.
- Move preview file type detection into a lightweight helper so it can be reused without importing browser-only preview UI.
- Add a regression test covering JPG/PNG/GIF assets and preserving audio/video metadata lookup.

## Walkthrough
<a href="https://cursor.com/agents/bc-da03dfa8-ff92-4c98-8f74-e6482fa9bab2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_jpg_asset_clean_pass.mp4"><img src="https://cursor.com/artifacts/c/art-d7da3e7d-12cb-411f-8215-c144d9feee02" alt="studio_jpg_asset_clean_pass.mp4" /></a>

## Testing
- `bun test packages/studio/src/test/current-asset.test.ts`
- `bun run build`
- `bunx turbo run lint formatting --filter='@remotion/studio'`
- Manual Studio verification at `http://localhost:3001/assets/1.jpg`
- `bun run stylecheck` (fails in this VM on `@remotion/lambda-go` because Go 1.22.2 is installed and the module requires Go >= 1.23.0; known cloud caveat)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da03dfa8-ff92-4c98-8f74-e6482fa9bab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da03dfa8-ff92-4c98-8f74-e6482fa9bab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

