### PR TITLE
`@remotion/studio`: Prevent keyframe drags outside timeline

### DIFF
--- a/packages/studio/src/components/Timeline/get-bounded-keyframe-drag-delta.ts
+++ b/packages/studio/src/components/Timeline/get-bounded-keyframe-drag-delta.ts
@@ -1,0 +1,24 @@
+export type TimelineKeyframeDragBoundsTarget = {
+	readonly displayFrame: number;
+};
+
+export const getBoundedKeyframeDragDelta = ({
+	delta,
+	durationInFrames,
+	targets,
+}: {
+	readonly delta: number;
+	readonly durationInFrames: number;
+	readonly targets: readonly TimelineKeyframeDragBoundsTarget[];
+}) => {
+	if (targets.length === 0 || durationInFrames <= 0) {
+		return 0;
+	}
+
+	const minDelta = Math.max(...targets.map((target) => -target.displayFrame));
+	const maxDelta = Math.min(
+		...targets.map((target) => durationInFrames - 1 - target.displayFrame),
+	);
+
+	return Math.min(Math.max(delta, minDelta), maxDelta);
+};

--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -16,6 +16,7 @@ import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sor
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {callMoveKeyframes} from './call-move-keyframe';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
+import {getBoundedKeyframeDragDelta} from './get-bounded-keyframe-drag-delta';
 import {parseKeyframeFieldFromNodePath} from './parse-keyframe-field-from-node-path';
 import {useTimelineKeyframeDragState} from './TimelineKeyframeDragState';
 import {
@@ -469,7 +470,11 @@ export const useTimelineKeyframeDrag = ({
 					durationInFrames: videoConfig.durationInFrames,
 					timelineWidth,
 				});
-				const delta = rawDelta;
+				const delta = getBoundedKeyframeDragDelta({
+					delta: rawDelta,
+					durationInFrames: videoConfig.durationInFrames,
+					targets,
+				});
 
 				if (hasDragged && delta === lastDelta) {
 					return;

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -5,6 +5,7 @@ import type {
 	TSequence,
 } from 'remotion';
 import {Internals, type CodeValues} from 'remotion';
+import {getBoundedKeyframeDragDelta} from '../components/Timeline/get-bounded-keyframe-drag-delta';
 import {getNodeKeyframes} from '../components/Timeline/get-node-keyframes';
 import {getTimelineKeyframes} from '../components/Timeline/get-timeline-keyframes';
 import {getTimelineKeyframeDragKey} from '../components/Timeline/TimelineKeyframeDragState';
@@ -228,6 +229,54 @@ test('keyframe display offsets follow the parent sequence context', () => {
 		{frame: 30, value: 2},
 		{frame: 90, value: 4},
 	]);
+});
+
+test('bounded keyframe drag delta stays inside the composition timeline', () => {
+	expect(
+		getBoundedKeyframeDragDelta({
+			targets: [{displayFrame: 10}],
+			delta: -20,
+			durationInFrames: 100,
+		}),
+	).toBe(-10);
+
+	expect(
+		getBoundedKeyframeDragDelta({
+			targets: [{displayFrame: 90}],
+			delta: 20,
+			durationInFrames: 100,
+		}),
+	).toBe(9);
+});
+
+test('bounded keyframe drag delta allows negative source frames when display frames stay in range', () => {
+	expect(
+		getBoundedKeyframeDragDelta({
+			targets: [{displayFrame: 30}],
+			delta: -30,
+			durationInFrames: 100,
+		}),
+	).toBe(-30);
+});
+
+test('bounded keyframe drag delta clamps multi-selection at the first timeline edge', () => {
+	const targets = [{displayFrame: 20}, {displayFrame: 95}];
+
+	expect(
+		getBoundedKeyframeDragDelta({
+			targets,
+			delta: -30,
+			durationInFrames: 100,
+		}),
+	).toBe(-20);
+
+	expect(
+		getBoundedKeyframeDragDelta({
+			targets,
+			delta: 10,
+			durationInFrames: 100,
+		}),
+	).toBe(4);
 });
 
 test('getNodeKeyframes shows a temporary sequence keyframe from drag overrides', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8145

- Clamp keyframe drag deltas against the absolute composition timeline so dragged keyframes stay within frames `0..durationInFrames - 1`.
- Preserve negative source-frame moves for nested sequences when their display frame remains in range.
- Add focused Studio tests for start/end bounds and multi-keyframe drags.

Manual walkthrough:
<a href="https://cursor.com/agents/bc-12330417-ecc6-432f-a92d-bc9eb929fc68/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkeyframe_drag_left_boundary_clamp_trimmed.mp4"><img src="https://cursor.com/artifacts/c/art-39958994-6aff-4394-b047-e7193097016f" alt="keyframe_drag_left_boundary_clamp_trimmed.mp4" /></a>

Testing:
- `bun test src/test/timeline-keyframes.test.ts` passed.
- `bun run test` in `packages/studio` passed.
- `bun run lint` in `packages/studio` passed with existing warnings only.
- `bun run formatting` in `packages/studio` passed.
- `bun run build` from the repository root passed.
- Manual Studio test passed: moved a Scale keyframe right, then dragged it past frame 0 and confirmed it clamped at the timeline start.
- `bun run stylecheck` reached the known `@remotion/lambda-go` Go version failure: module requires Go >= 1.23.0, VM has Go 1.22.2.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12330417-ecc6-432f-a92d-bc9eb929fc68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12330417-ecc6-432f-a92d-bc9eb929fc68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

