### PR TITLE
`@remotion/studio-server`: Fix computed interpolation keyframe detection

### DIFF
--- a/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
@@ -145,9 +145,11 @@ const resolveEffectImport = ({
 };
 
 const getPropsFromObjectExpression = ({
+	ast,
 	objExpr,
 	keys,
 }: {
+	ast: File;
 	objExpr: ObjectExpression;
 	keys: string[];
 }): Record<string, CanUpdateSequencePropStatus> => {
@@ -169,7 +171,7 @@ const getPropsFromObjectExpression = ({
 
 		const valueExpr = prop.value as Expression;
 		if (!isStaticValue(valueExpr)) {
-			out[key] = getComputedStatus(valueExpr);
+			out[key] = getComputedStatus(valueExpr, ast);
 			continue;
 		}
 
@@ -252,6 +254,7 @@ export const computeEffectPropStatus = ({
 	}
 
 	const resolvedProps = getPropsFromObjectExpression({
+		ast,
 		objExpr: firstArg as ObjectExpression,
 		keys,
 	});

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -391,6 +391,7 @@ const getInterpolationMetadata = (
 
 const getInterpolationKeyframes = (
 	node: Expression,
+	ast: File,
 ):
 	| {
 			keyframes: PropKeyframes;
@@ -401,7 +402,7 @@ const getInterpolationKeyframes = (
 	  }
 	| undefined => {
 	if (node.type === 'TSAsExpression') {
-		return getInterpolationKeyframes(node.expression as Expression);
+		return getInterpolationKeyframes(node.expression as Expression, ast);
 	}
 
 	if (node.type !== 'CallExpression') {
@@ -418,9 +419,13 @@ const getInterpolationKeyframes = (
 
 	const interpolationFunction = callExpression.callee.name;
 
+	const frameArg = callExpression.arguments[0];
 	const inputArg = callExpression.arguments[1];
 	const outputArg = callExpression.arguments[2];
 	if (
+		!frameArg ||
+		frameArg.type === 'SpreadElement' ||
+		!isCurrentFrameIdentifier(frameArg as Expression, ast) ||
 		!inputArg ||
 		!outputArg ||
 		inputArg.type !== 'ArrayExpression' ||
@@ -479,8 +484,52 @@ const getInterpolationKeyframes = (
 	};
 };
 
-export const getComputedStatus = (node: Expression): CanUpdatePropStatus => {
-	const interpolation = getInterpolationKeyframes(node);
+const isUseCurrentFrameCall = (node: Expression): boolean => {
+	return (
+		node.type === 'CallExpression' &&
+		node.callee.type === 'Identifier' &&
+		node.callee.name === 'useCurrentFrame' &&
+		node.arguments.length === 0
+	);
+};
+
+const isCurrentFrameIdentifier = (node: Expression, ast: File): boolean => {
+	if (node.type === 'TSAsExpression') {
+		return isCurrentFrameIdentifier(node.expression as Expression, ast);
+	}
+
+	if (node.type !== 'Identifier') {
+		return false;
+	}
+
+	let hasUseCurrentFrameDeclaration = false;
+	let hasOtherDeclaration = false;
+
+	recast.types.visit(ast, {
+		visitVariableDeclarator(p) {
+			const {id, init} = p.node;
+			if (id.type !== 'Identifier' || id.name !== node.name) {
+				return this.traverse(p);
+			}
+
+			if (init && isUseCurrentFrameCall(init as Expression)) {
+				hasUseCurrentFrameDeclaration = true;
+			} else {
+				hasOtherDeclaration = true;
+			}
+
+			return false;
+		},
+	});
+
+	return hasUseCurrentFrameDeclaration && !hasOtherDeclaration;
+};
+
+export const getComputedStatus = (
+	node: Expression,
+	ast: File,
+): CanUpdatePropStatus => {
+	const interpolation = getInterpolationKeyframes(node, ast);
 	if (!interpolation) {
 		return computedStatus();
 	}
@@ -498,6 +547,7 @@ export const getComputedStatus = (node: Expression): CanUpdatePropStatus => {
 
 const getPropsStatus = (
 	jsxElement: JSXOpeningElement,
+	ast: File,
 ): Record<string, CanUpdatePropStatus> => {
 	const props: Record<string, CanUpdatePropStatus> = {};
 
@@ -535,7 +585,7 @@ const getPropsStatus = (
 			}
 
 			if (!isStaticValue(expression)) {
-				props[name] = getComputedStatus(expression);
+				props[name] = getComputedStatus(expression, ast);
 				continue;
 			}
 
@@ -648,6 +698,7 @@ const validateStyleValue = (childKey: string, value: unknown): boolean => {
 
 const getNestedPropStatus = (
 	jsxElement: JSXOpeningElement,
+	ast: File,
 	parentKey: string,
 	childKey: string,
 ): CanUpdatePropStatus => {
@@ -691,7 +742,7 @@ const getNestedPropStatus = (
 
 	const propValue = prop.value as Expression;
 	if (!isStaticValue(propValue)) {
-		return getComputedStatus(propValue);
+		return getComputedStatus(propValue, ast);
 	}
 
 	const codeValue = extractStaticValue(propValue);
@@ -723,18 +774,21 @@ const computeEffectsForJsx = ({
 
 const computeSequenceOnlyPropsRecord = ({
 	jsxElement,
+	ast,
 	keys,
 }: {
 	jsxElement: JSXOpeningElement;
+	ast: File;
 	keys: string[];
 }): Record<string, CanUpdatePropStatus> => {
-	const allProps = getPropsStatus(jsxElement);
+	const allProps = getPropsStatus(jsxElement, ast);
 	const filteredProps: Record<string, CanUpdatePropStatus> = {};
 	for (const key of keys) {
 		const dotIndex = key.indexOf('.');
 		if (dotIndex !== -1) {
 			filteredProps[key] = getNestedPropStatus(
 				jsxElement,
+				ast,
 				key.slice(0, dotIndex),
 				key.slice(dotIndex + 1),
 			);
@@ -767,7 +821,7 @@ export const computeSequencePropsStatusFromContent = ({
 		throw new JsxElementNotFoundAtLocationError();
 	}
 
-	const filteredProps = computeSequenceOnlyPropsRecord({jsxElement, keys});
+	const filteredProps = computeSequenceOnlyPropsRecord({jsxElement, ast, keys});
 	const effectsStatuses = computeEffectsForJsx({ast, jsxElement, effects});
 
 	return {

--- a/packages/studio-server/src/test/compute-effect-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-effect-props-status.test.ts
@@ -8,8 +8,10 @@ const buildInput = (
 	effects: string,
 ) => `import {HtmlInCanvas} from '@remotion/html-in-canvas';
 import {tint} from '@remotion/effects/tint';
+import {interpolate, useCurrentFrame} from 'remotion';
 
 export const Comp = () => {
+\tconst frame = useCurrentFrame();
 \treturn (
 \t\t<HtmlInCanvas effects={${effects}}>
 \t\t\thi
@@ -18,9 +20,21 @@ export const Comp = () => {
 };
 `;
 
+const getLine = (input: string, search: string) => {
+	const line = input.split('\n').findIndex((l) => l.includes(search));
+	if (line === -1) {
+		throw new Error(`Could not find line containing ${search}`);
+	}
+
+	return line + 1;
+};
+
 const findJsx = (input: string) => {
 	const ast = parseAst(input);
-	const jsx = findJsxElementAtNodePath(ast, lineColumnToNodePath(input, 6));
+	const jsx = findJsxElementAtNodePath(
+		ast,
+		lineColumnToNodePath(input, getLine(input, '<HtmlInCanvas')),
+	);
 	if (!jsx) {
 		throw new Error('JSX not found');
 	}
@@ -105,6 +119,37 @@ test('computeEffectPropStatus reports keyframes for inline interpolated effect p
 		clamping: {left: 'extend', right: 'extend'},
 		posterize: undefined,
 	});
+});
+
+test('computeEffectPropStatus reports interpolations over computed values as computed', () => {
+	const input = `import {HtmlInCanvas} from '@remotion/html-in-canvas';
+import {tint} from '@remotion/effects/tint';
+import {interpolate, useCurrentFrame} from 'remotion';
+
+export const Comp = () => {
+\tconst frame = useCurrentFrame();
+\tconst progress = interpolate(frame, [0, 100], [0, 1], {posterize: 3});
+\treturn (
+\t\t<HtmlInCanvas effects={[tint({amount: interpolate(progress, [0, 1], [0.2, 0.8])})]}>
+\t\t\thi
+\t\t</HtmlInCanvas>
+\t);
+};
+`;
+	const {ast, jsx} = findJsx(input);
+	const result = computeEffectPropStatus({
+		ast,
+		jsx,
+		effectIndex: 0,
+		keys: ['amount'],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) {
+		throw new Error('expected canUpdate true');
+	}
+
+	expect(result.props.amount).toEqual({status: 'computed'});
 });
 
 test('computeEffectPropStatus reports unset props as undefined codeValue', () => {

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -129,6 +129,33 @@ export const Example: React.FC = () => {
 	});
 });
 
+test('computeSequencePropsStatus should flag interpolations over computed values as computed', () => {
+	const input = `import React from 'react';
+import {Sequence, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\tconst progress = interpolate(frame, [0, 100], [0, 1], {posterize: 3});
+\treturn (
+\t\t<Sequence style={{translate: interpolate(progress, [0, 1], ['0px 59px', '100px 20px'])}} />
+\t);
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 8),
+		keys: ['style.translate'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.translate']).toEqual({
+		status: 'computed',
+	});
+});
+
 test('computeSequencePropsStatus should return keyframes for interpolated rotate props', () => {
 	const input = `import React from 'react';
 import {Sequence, interpolate, useCurrentFrame} from 'remotion';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8139.

## Summary
- Treat interpolations as keyframable only when their input identifier resolves to `useCurrentFrame()`.
- Mark interpolations over computed values like `progress` as `computed` for sequence and effect props.
- Add regression coverage for the reported computed interpolation pattern.

## Testing
- Pass: `bun test packages/studio-server/src/test/compute-sequence-props-status.test.ts packages/studio-server/src/test/compute-effect-props-status.test.ts`
- Pass: `bun run build`
- Pass with warnings: `cd packages/studio-server && bun run lint`
- Pass: `cd packages/studio-server && bun run formatting`
- Warning: `bun run stylecheck` fails in `@remotion/lambda-go` because the VM has Go 1.22.2 and the package requires Go >= 1.23.0.
- Warning: `cd packages/studio-server && bun run test` fails only in `log-effect-update.test.ts`, whose isolated expectation currently receives `added: halftone(...)`; this is unrelated to keyframe status detection.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ba205de-ce1a-49d9-8a1c-52d0ae24c856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ba205de-ce1a-49d9-8a1c-52d0ae24c856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

