### PR TITLE
`@remotion/studio`: Add asset panel drag import

### DIFF
--- a/packages/studio-shared/src/asset-drag-data.ts
+++ b/packages/studio-shared/src/asset-drag-data.ts
@@ -1,0 +1,44 @@
+export const ASSET_DRAG_MIME_TYPE = 'application/vnd.remotion.asset+json';
+
+export type AssetDragData = {
+	type: 'remotion-asset';
+	version: 1;
+	assetPath: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+export const makeAssetDragData = (assetPath: string): AssetDragData => {
+	return {
+		type: 'remotion-asset',
+		version: 1,
+		assetPath,
+	};
+};
+
+export const parseAssetDragData = (value: string): AssetDragData | null => {
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!isRecord(parsed)) {
+			return null;
+		}
+
+		if (parsed.type !== 'remotion-asset' || parsed.version !== 1) {
+			return null;
+		}
+
+		if (typeof parsed.assetPath !== 'string' || parsed.assetPath.length === 0) {
+			return null;
+		}
+
+		return {
+			type: 'remotion-asset',
+			version: 1,
+			assetPath: parsed.assetPath,
+		};
+	} catch {
+		return null;
+	}
+};

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -85,6 +85,12 @@ export {
 	type KeyframeSettings,
 } from './api-requests';
 export type {ApplyVisualControlCodemod, RecastCodemod} from './codemods';
+export {
+	ASSET_DRAG_MIME_TYPE,
+	makeAssetDragData,
+	parseAssetDragData,
+	type AssetDragData,
+} from './asset-drag-data';
 export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state-delay-in-milliseconds';
 export {
 	parseEffectClipboardData,

--- a/packages/studio-shared/src/test/asset-drag-data.test.ts
+++ b/packages/studio-shared/src/test/asset-drag-data.test.ts
@@ -1,0 +1,35 @@
+import {expect, test} from 'bun:test';
+import {makeAssetDragData, parseAssetDragData} from '../asset-drag-data';
+
+test('parses asset drag data', () => {
+	expect(
+		parseAssetDragData(JSON.stringify(makeAssetDragData('nested/image.png'))),
+	).toEqual({
+		type: 'remotion-asset',
+		version: 1,
+		assetPath: 'nested/image.png',
+	});
+});
+
+test('rejects invalid asset drag data', () => {
+	expect(parseAssetDragData('')).toBe(null);
+	expect(parseAssetDragData('{')).toBe(null);
+	expect(
+		parseAssetDragData(
+			JSON.stringify({
+				type: 'remotion-asset',
+				version: 2,
+				assetPath: 'image.png',
+			}),
+		),
+	).toBe(null);
+	expect(
+		parseAssetDragData(
+			JSON.stringify({
+				type: 'remotion-asset',
+				version: 1,
+				assetPath: '',
+			}),
+		),
+	).toBe(null);
+});

--- a/packages/studio/src/components/AssetSelector.tsx
+++ b/packages/studio/src/components/AssetSelector.tsx
@@ -6,7 +6,9 @@ import {BACKGROUND, CLEAR_HOVER, LIGHT_TEXT} from '../helpers/colors';
 import {buildAssetFolderStructure} from '../helpers/create-folder-tree';
 import {toggleBooleanMapKey} from '../helpers/persist-boolean-map';
 import {persistExpandedFolders} from '../helpers/persist-open-folders';
-import useAssetDragEvents from '../helpers/use-asset-drag-events';
+import useAssetDragEvents, {
+	isFileDragEvent,
+} from '../helpers/use-asset-drag-events';
 import {FolderContext} from '../state/folders';
 import {useZIndex} from '../state/z-index';
 import {AssetFolderTree} from './AssetSelectorItem';
@@ -93,6 +95,10 @@ export const AssetSelector: React.FC<{
 	});
 	const onDragOver: React.DragEventHandler<HTMLDivElement> = useCallback(
 		(e) => {
+			if (!isFileDragEvent(e)) {
+				return;
+			}
+
 			e.preventDefault();
 		},
 		[],
@@ -101,9 +107,19 @@ export const AssetSelector: React.FC<{
 	const onDrop: React.DragEventHandler<HTMLDivElement> = useCallback(
 		async (e) => {
 			try {
+				if (!isFileDragEvent(e)) {
+					setDropLocation(null);
+					return;
+				}
+
 				e.preventDefault();
 				e.stopPropagation();
 				const {files} = e.dataTransfer;
+				if (files.length === 0) {
+					setDropLocation(null);
+					return;
+				}
+
 				const assetPath = dropLocation ?? null;
 
 				const makePath = (file: File) => {

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -23,7 +23,9 @@ import {
 	maybeScrollAssetSidebarRowIntoView,
 } from '../helpers/sidebar-scroll-into-view';
 import {pushUrl} from '../helpers/url-state';
-import useAssetDragEvents from '../helpers/use-asset-drag-events';
+import useAssetDragEvents, {
+	isFileDragEvent,
+} from '../helpers/use-asset-drag-events';
 import {ClipboardIcon} from '../icons/clipboard';
 import {FileIcon} from '../icons/file';
 import {CollapsedFolderIcon, ExpandedFolderIcon} from '../icons/folder';
@@ -154,14 +156,22 @@ const AssetFolderItem: React.FC<{
 				tabIndex={tabIndex}
 				title={item.name}
 				onClick={onClick}
-				onDragEnter={() => {
+				onDragEnter={(event) => {
+					if (!isFileDragEvent(event)) {
+						return;
+					}
+
 					if (!item.expanded) {
 						openFolderTimerRef.current = window.setTimeout(() => {
 							toggleFolder(item.name, parentFolder);
 						}, 1000);
 					}
 				}}
-				onDragLeave={() => {
+				onDragLeave={(event) => {
+					if (!isFileDragEvent(event)) {
+						return;
+					}
+
 					if (openFolderTimerRef.current) {
 						clearTimeout(openFolderTimerRef.current);
 					}
@@ -261,6 +271,7 @@ const AssetSelectorItem: React.FC<{
 }> = ({item, tabIndex, level, parentFolder, readOnlyStudio}) => {
 	const isMobileLayout = useMobileLayout();
 	const [hovered, setHovered] = useState(false);
+	const [isDragging, setIsDragging] = useState(false);
 	const {setSidebarCollapsedState} = useContext(SidebarContext);
 	const onPointerEnter = useCallback(() => {
 		setHovered(true);
@@ -319,6 +330,7 @@ const AssetSelectorItem: React.FC<{
 				return;
 			}
 
+			setIsDragging(true);
 			e.dataTransfer.effectAllowed = 'copy';
 			e.dataTransfer.setData(
 				ASSET_DRAG_MIME_TYPE,
@@ -327,6 +339,10 @@ const AssetSelectorItem: React.FC<{
 		},
 		[canDragAsset, relativePath],
 	);
+
+	const onDragEnd: React.DragEventHandler<HTMLDivElement> = useCallback(() => {
+		setIsDragging(false);
+	}, []);
 
 	const style: React.CSSProperties = useMemo(() => {
 		return {
@@ -339,10 +355,9 @@ const AssetSelectorItem: React.FC<{
 				: selected
 					? SELECTED_BACKGROUND
 					: 'transparent',
-			cursor: canDragAsset ? 'grab' : 'default',
 			paddingLeft: 12 + level * 8,
 		};
-	}, [canDragAsset, hovered, level, selected]);
+	}, [hovered, level, selected]);
 
 	const label = useMemo(() => {
 		return {
@@ -403,13 +418,14 @@ const AssetSelectorItem: React.FC<{
 				onClick={onClick}
 				draggable={canDragAsset}
 				onDragStart={onDragStart}
+				onDragEnd={onDragEnd}
 				tabIndex={tabIndex}
 				title={item.name}
 			>
 				<FileIcon style={iconStyle} color={LIGHT_TEXT} />
 				<Spacing x={1} />
 				<div style={label}>{item.name}</div>
-				{hovered ? (
+				{hovered && !isDragging ? (
 					<>
 						<Spacing x={0.5} />
 						<InlineAction

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -1,3 +1,4 @@
+import {ASSET_DRAG_MIME_TYPE, makeAssetDragData} from '@remotion/studio-shared';
 import React, {
 	useCallback,
 	useContext,
@@ -27,6 +28,7 @@ import {ClipboardIcon} from '../icons/clipboard';
 import {FileIcon} from '../icons/file';
 import {CollapsedFolderIcon, ExpandedFolderIcon} from '../icons/folder';
 import {SidebarContext} from '../state/sidebar';
+import {getAssetElementFromPath} from './import-assets';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 import {Row, Spacing} from './layout';
@@ -279,6 +281,10 @@ const AssetSelectorItem: React.FC<{
 		return false;
 	}, [canvasContent, relativePath]);
 
+	const canDragAsset = useMemo(() => {
+		return !readOnlyStudio && getAssetElementFromPath(relativePath) !== null;
+	}, [readOnlyStudio, relativePath]);
+
 	const onPointerLeave = useCallback(() => {
 		setHovered(false);
 	}, []);
@@ -306,6 +312,22 @@ const AssetSelectorItem: React.FC<{
 		setSidebarCollapsedState,
 	]);
 
+	const onDragStart: React.DragEventHandler<HTMLDivElement> = useCallback(
+		(e) => {
+			if (!canDragAsset) {
+				e.preventDefault();
+				return;
+			}
+
+			e.dataTransfer.effectAllowed = 'copy';
+			e.dataTransfer.setData(
+				ASSET_DRAG_MIME_TYPE,
+				JSON.stringify(makeAssetDragData(relativePath)),
+			);
+		},
+		[canDragAsset, relativePath],
+	);
+
 	const style: React.CSSProperties = useMemo(() => {
 		return {
 			...itemStyle,
@@ -317,9 +339,10 @@ const AssetSelectorItem: React.FC<{
 				: selected
 					? SELECTED_BACKGROUND
 					: 'transparent',
+			cursor: canDragAsset ? 'grab' : 'default',
 			paddingLeft: 12 + level * 8,
 		};
-	}, [hovered, level, selected]);
+	}, [canDragAsset, hovered, level, selected]);
 
 	const label = useMemo(() => {
 		return {
@@ -378,6 +401,8 @@ const AssetSelectorItem: React.FC<{
 				onPointerEnter={onPointerEnter}
 				onPointerLeave={onPointerLeave}
 				onClick={onClick}
+				draggable={canDragAsset}
+				onDragStart={onDragStart}
 				tabIndex={tabIndex}
 				title={item.name}
 			>

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1,4 +1,8 @@
 import type {Size} from '@remotion/player';
+import {
+	ASSET_DRAG_MIME_TYPE,
+	parseAssetDragData,
+} from '@remotion/studio-shared';
 import React, {
 	useCallback,
 	useContext,
@@ -31,7 +35,7 @@ import {EditorZoomGesturesContext} from '../state/editor-zoom-gestures';
 import EditorGuides from './EditorGuides';
 import {EditorRulers} from './EditorRuler';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
-import {importAssets} from './import-assets';
+import {importAssets, insertExistingAssets} from './import-assets';
 import {SPACING_UNIT} from './layout';
 import {VideoPreview} from './Preview';
 import {ResetZoomButton} from './ResetZoomButton';
@@ -64,6 +68,21 @@ type WebKitGestureEvent = UIEvent & {
 
 const isFileDragEvent = (event: DragEvent): boolean => {
 	return Array.from(event.dataTransfer?.types ?? []).includes('Files');
+};
+
+const isAssetDragEvent = (event: DragEvent): boolean => {
+	return Array.from(event.dataTransfer?.types ?? []).includes(
+		ASSET_DRAG_MIME_TYPE,
+	);
+};
+
+const getAssetDragPath = (event: DragEvent): string | null => {
+	const value = event.dataTransfer?.getData(ASSET_DRAG_MIME_TYPE);
+	if (!value) {
+		return null;
+	}
+
+	return parseAssetDragData(value)?.assetPath ?? null;
 };
 
 const isDragEventInsideCanvas = (event: DragEvent): boolean => {
@@ -598,7 +617,7 @@ export const Canvas: React.FC<{
 		(event: DragEvent) => {
 			if (
 				!canDropAssets ||
-				!isFileDragEvent(event) ||
+				(!isFileDragEvent(event) && !isAssetDragEvent(event)) ||
 				!isDragEventInsideCanvas(event)
 			) {
 				return;
@@ -618,7 +637,7 @@ export const Canvas: React.FC<{
 				!canDropAssets ||
 				compositionFile === null ||
 				currentCompositionId === null ||
-				!isFileDragEvent(event) ||
+				(!isFileDragEvent(event) && !isAssetDragEvent(event)) ||
 				!isDragEventInsideCanvas(event)
 			) {
 				return;
@@ -627,18 +646,31 @@ export const Canvas: React.FC<{
 			event.preventDefault();
 			event.stopPropagation();
 
-			const files = Array.from(event.dataTransfer?.files ?? []);
-			if (files.length === 0) {
-				return;
-			}
-
 			setIsAddingAsset(true);
 			try {
-				await importAssets({
-					files,
-					compositionFile,
-					compositionId: currentCompositionId,
-				});
+				if (isFileDragEvent(event)) {
+					const files = Array.from(event.dataTransfer?.files ?? []);
+					if (files.length === 0) {
+						return;
+					}
+
+					await importAssets({
+						files,
+						compositionFile,
+						compositionId: currentCompositionId,
+					});
+				} else {
+					const assetPath = getAssetDragPath(event);
+					if (assetPath === null) {
+						return;
+					}
+
+					await insertExistingAssets({
+						assetPaths: [assetPath],
+						compositionFile,
+						compositionId: currentCompositionId,
+					});
+				}
 			} finally {
 				setIsAddingAsset(false);
 			}

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -66,6 +66,57 @@ export const getAssetElement = ({
 	return null;
 };
 
+export const getAssetElementFromPath = (
+	assetPath: string,
+): InsertableCompositionElement | null => {
+	if (!assetPath || assetPath.includes('\\')) {
+		return null;
+	}
+
+	const extension = assetPath.split('.').pop()?.toLowerCase();
+	if (!extension || extension === assetPath.toLowerCase()) {
+		return null;
+	}
+
+	if (['png', 'jpg', 'jpeg', 'webp', 'bmp'].includes(extension)) {
+		return {
+			type: 'asset',
+			assetType: 'image',
+			src: assetPath,
+			dimensions: null,
+		};
+	}
+
+	if (extension === 'gif') {
+		return {
+			type: 'asset',
+			assetType: 'gif',
+			src: assetPath,
+			dimensions: null,
+		};
+	}
+
+	if (['mp4', 'm4v', 'mov', 'avi', 'webm', 'ts', 'm2ts'].includes(extension)) {
+		return {
+			type: 'asset',
+			assetType: 'video',
+			src: assetPath,
+			dimensions: null,
+		};
+	}
+
+	if (['wav', 'mp3', 'aac', 'flac'].includes(extension)) {
+		return {
+			type: 'asset',
+			assetType: 'audio',
+			src: assetPath,
+			dimensions: null,
+		};
+	}
+
+	return null;
+};
+
 const getAssetLabel = (element: InsertableCompositionElement) => {
 	if (element.type !== 'asset') {
 		throw new Error('Expected asset element');
@@ -118,6 +169,54 @@ export const pickFilesToImport = (): Promise<File[]> => {
 		document.body.appendChild(input);
 		input.click();
 	});
+};
+
+const notifyInsertedAssets = (insertedLabels: string[]) => {
+	if (insertedLabels.length === 1) {
+		showNotification(`Added ${insertedLabels[0]} to source file`, 2000);
+	} else if (insertedLabels.length > 1) {
+		showNotification(
+			`Added ${insertedLabels.length} assets to source file`,
+			2000,
+		);
+	}
+};
+
+const notifyUnsupportedFiles = (unsupportedFiles: string[]) => {
+	if (unsupportedFiles.length === 1) {
+		showNotification(
+			`Cannot add ${unsupportedFiles[0]}: Unsupported file type`,
+			3000,
+		);
+	} else if (unsupportedFiles.length > 1) {
+		showNotification(
+			`Skipped ${unsupportedFiles.length} unsupported files`,
+			3000,
+		);
+	}
+};
+
+const insertAssetElement = async ({
+	compositionFile,
+	compositionId,
+	element,
+}: {
+	compositionFile: string;
+	compositionId: string;
+	element: InsertableCompositionElement;
+}) => {
+	const result = await callApi('/api/insert-jsx-element', {
+		compositionFile,
+		compositionId,
+		element,
+	});
+
+	if (!result.success) {
+		showNotification(result.reason, 4000);
+		return false;
+	}
+
+	return true;
 };
 
 export const importAssets = async ({
@@ -191,15 +290,14 @@ export const importAssets = async ({
 				addedStaticFiles.push(file.name);
 			}
 
-			const result = await callApi('/api/insert-jsx-element', {
+			const inserted = await insertAssetElement({
 				compositionFile,
 				compositionId,
 				element,
 			});
 
-			if (!result.success) {
+			if (!inserted) {
 				notifyAddedStaticFiles();
-				showNotification(result.reason, 4000);
 				return;
 			}
 
@@ -207,27 +305,57 @@ export const importAssets = async ({
 		}
 
 		notifyAddedStaticFiles();
+		notifyInsertedAssets(insertedLabels);
+		notifyUnsupportedFiles(unsupportedFiles);
+	} catch (error) {
+		showNotification(
+			`Could not add asset: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+			4000,
+		);
+	}
+};
 
-		if (insertedLabels.length === 1) {
-			showNotification(`Added ${insertedLabels[0]} to source file`, 2000);
-		} else if (insertedLabels.length > 1) {
-			showNotification(
-				`Added ${insertedLabels.length} assets to source file`,
-				2000,
-			);
+export const insertExistingAssets = async ({
+	assetPaths,
+	compositionFile,
+	compositionId,
+}: {
+	assetPaths: string[];
+	compositionFile: string;
+	compositionId: string;
+}) => {
+	if (assetPaths.length === 0) {
+		return;
+	}
+
+	const insertedLabels: string[] = [];
+	const unsupportedFiles: string[] = [];
+
+	try {
+		for (const assetPath of assetPaths) {
+			const element = getAssetElementFromPath(assetPath);
+			if (element === null) {
+				unsupportedFiles.push(assetPath);
+				continue;
+			}
+
+			const inserted = await insertAssetElement({
+				compositionFile,
+				compositionId,
+				element,
+			});
+
+			if (!inserted) {
+				return;
+			}
+
+			insertedLabels.push(getAssetLabel(element));
 		}
 
-		if (unsupportedFiles.length === 1) {
-			showNotification(
-				`Cannot add ${unsupportedFiles[0]}: Unsupported file type`,
-				3000,
-			);
-		} else if (unsupportedFiles.length > 1) {
-			showNotification(
-				`Skipped ${unsupportedFiles.length} unsupported files`,
-				3000,
-			);
-		}
+		notifyInsertedAssets(insertedLabels);
+		notifyUnsupportedFiles(unsupportedFiles);
 	} catch (error) {
 		showNotification(
 			`Could not add asset: ${

--- a/packages/studio/src/helpers/use-asset-drag-events.ts
+++ b/packages/studio/src/helpers/use-asset-drag-events.ts
@@ -1,6 +1,12 @@
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {NoReactInternals} from 'remotion/no-react';
 
+export const isFileDragEvent = (event: {
+	readonly dataTransfer: DataTransfer;
+}): boolean => {
+	return Array.from(event.dataTransfer.types).includes('Files');
+};
+
 function useAssetDragEvents({
 	name,
 	parentFolder,
@@ -22,26 +28,40 @@ function useAssetDragEvents({
 		return dropLocation === combinedParents;
 	}, [combinedParents, dropLocation]);
 
-	const onDragEnter = useCallback(() => {
-		if (dragDepthRef.current === 0) {
-			setDropLocation((currentDropLocation) =>
-				currentDropLocation?.includes(combinedParents)
-					? currentDropLocation
-					: combinedParents,
-			);
-		}
+	const onDragEnter: React.DragEventHandler = useCallback(
+		(event) => {
+			if (!isFileDragEvent(event)) {
+				return;
+			}
 
-		dragDepthRef.current++;
-	}, [combinedParents, dragDepthRef, setDropLocation]);
+			if (dragDepthRef.current === 0) {
+				setDropLocation((currentDropLocation) =>
+					currentDropLocation?.includes(combinedParents)
+						? currentDropLocation
+						: combinedParents,
+				);
+			}
 
-	const onDragLeave = useCallback(() => {
-		dragDepthRef.current--;
-		if (dragDepthRef.current === 0) {
-			setDropLocation((currentPath) =>
-				currentPath === combinedParents ? parentFolder : currentPath,
-			);
-		}
-	}, [combinedParents, dragDepthRef, parentFolder, setDropLocation]);
+			dragDepthRef.current++;
+		},
+		[combinedParents, dragDepthRef, setDropLocation],
+	);
+
+	const onDragLeave: React.DragEventHandler = useCallback(
+		(event) => {
+			if (!isFileDragEvent(event)) {
+				return;
+			}
+
+			dragDepthRef.current--;
+			if (dragDepthRef.current === 0) {
+				setDropLocation((currentPath) =>
+					currentPath === combinedParents ? parentFolder : currentPath,
+				);
+			}
+		},
+		[combinedParents, dragDepthRef, parentFolder, setDropLocation],
+	);
 
 	useEffect(() => {
 		if (dropLocation === null) {

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -1,5 +1,8 @@
 import {expect, test} from 'bun:test';
-import {getAssetElement} from '../components/import-assets';
+import {
+	getAssetElement,
+	getAssetElementFromPath,
+} from '../components/import-assets';
 
 test('maps audio file types to Audio assets', () => {
 	for (const type of ['wav', 'mp3', 'aac', 'flac'] as const) {
@@ -24,4 +27,37 @@ test('does not map M3U playlists to Audio assets', () => {
 			src: 'playlist.m3u',
 		}),
 	).toBe(null);
+});
+
+test('maps existing static file paths to insertable assets', () => {
+	expect(getAssetElementFromPath('nested/photo.JPG')).toEqual({
+		type: 'asset',
+		assetType: 'image',
+		src: 'nested/photo.JPG',
+		dimensions: null,
+	});
+	expect(getAssetElementFromPath('movie.webm')).toEqual({
+		type: 'asset',
+		assetType: 'video',
+		src: 'movie.webm',
+		dimensions: null,
+	});
+	expect(getAssetElementFromPath('audio.flac')).toEqual({
+		type: 'asset',
+		assetType: 'audio',
+		src: 'audio.flac',
+		dimensions: null,
+	});
+	expect(getAssetElementFromPath('animation.gif')).toEqual({
+		type: 'asset',
+		assetType: 'gif',
+		src: 'animation.gif',
+		dimensions: null,
+	});
+});
+
+test('does not map unsupported existing static file paths', () => {
+	expect(getAssetElementFromPath('data.json')).toBe(null);
+	expect(getAssetElementFromPath('asset-without-extension')).toBe(null);
+	expect(getAssetElementFromPath('nested\\photo.png')).toBe(null);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a Studio asset drag payload so public assets can be dragged from the Assets panel.
- Accept that payload on the canvas and insert the existing static asset into the current composition.
- Add focused tests for asset path mapping and drag payload parsing.

Fixes #8065

## Walkthrough
<a href="https://cursor.com/agents/bc-b9d85cd7-9a36-4fae-bec3-12a04034de44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fasset_panel_drag_to_canvas_import_success.mp4"><img src="https://cursor.com/artifacts/c/art-656fd6bd-b747-4927-a7e3-87a178f41c30" alt="asset_panel_drag_to_canvas_import_success.mp4" /></a>
![Asset drag import result](https://cursor.com/artifacts/c/art-67ace4c3-3e64-4957-aa42-48c67275ae3e)

## Testing
- `bun test packages/studio/src/test/import-assets.test.ts`
- `bun test packages/studio-shared/src/test/asset-drag-data.test.ts`
- `bun run build`
- `bun run stylecheck` (blocked by existing `@remotion/lambda-go` Go >= 1.23 requirement in this VM)
- `bunx turbo run lint formatting --filter=@remotion/studio --filter=@remotion/studio-shared`
- Manual Studio browser validation: dispatched the real draggable `1.jpg` asset row payload to the canvas and verified `<Img src={staticFile('1.jpg')}>` was inserted, rendered, and logged by Studio.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9d85cd7-9a36-4fae-bec3-12a04034de44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9d85cd7-9a36-4fae-bec3-12a04034de44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

