### PR TITLE
`@remotion/studio`: Add outline context menu

### DIFF
--- a/packages/studio/src/components/ContextMenu.tsx
+++ b/packages/studio/src/components/ContextMenu.tsx
@@ -1,5 +1,5 @@
 import {PlayerInternals} from '@remotion/player';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import {noop} from '../helpers/noop';
@@ -38,6 +38,11 @@ type ContextMenuProps = {
 	// eslint-disable-next-line react/require-default-props
 	readonly onPointerDown?: React.PointerEventHandler<HTMLDivElement>;
 };
+
+type ContextMenuOpenEvent = Pick<
+	MouseEvent | React.MouseEvent,
+	'clientX' | 'clientY' | 'preventDefault' | 'stopPropagation'
+>;
 
 const ContextMenuPortal: React.FC<{
 	readonly containerRef: React.RefObject<HTMLDivElement | null>;
@@ -146,6 +151,48 @@ const ContextMenuPortal: React.FC<{
 	);
 };
 
+export const useContextMenu = ({
+	containerRef,
+	onOpen,
+	values,
+}: {
+	readonly containerRef: React.RefObject<HTMLDivElement | null>;
+	readonly onOpen: (() => void) | null;
+	readonly values: ComboboxValue[];
+}) => {
+	const [opened, setOpened] = useState<OpenState>({type: 'not-open'});
+	const {currentZIndex} = useZIndex();
+
+	const onContextMenu = useCallback(
+		(e: ContextMenuOpenEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			onOpen?.();
+			setOpened({type: 'open', left: e.clientX, top: e.clientY});
+
+			return false;
+		},
+		[onOpen],
+	);
+
+	const onHide = useCallback(() => {
+		setOpened({type: 'not-open'});
+	}, []);
+
+	const portal =
+		opened.type === 'open' ? (
+			<ContextMenuPortal
+				containerRef={containerRef}
+				currentZIndex={currentZIndex}
+				onHide={onHide}
+				opened={opened}
+				values={values}
+			/>
+		) : null;
+
+	return {onContextMenu, portal};
+};
+
 export const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
 	(
 		{
@@ -159,8 +206,11 @@ export const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
 		forwardedRef,
 	) => {
 		const ref = useRef<HTMLDivElement>(null);
-		const [opened, setOpened] = useState<OpenState>({type: 'not-open'});
-		const {currentZIndex} = useZIndex();
+		const {onContextMenu, portal} = useContextMenu({
+			containerRef: ref,
+			onOpen,
+			values,
+		});
 
 		const setRef = useCallback(
 			(node: HTMLDivElement | null) => {
@@ -179,52 +229,18 @@ export const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
 			[forwardedRef],
 		);
 
-		useEffect(() => {
-			const {current} = ref;
-			if (!current) {
-				return;
-			}
-
-			const onClick = (e: MouseEvent) => {
-				e.preventDefault();
-				e.stopPropagation();
-				onOpen?.();
-				setOpened({type: 'open', left: e.clientX, top: e.clientY});
-
-				return false;
-			};
-
-			current.addEventListener('contextmenu', onClick);
-
-			return () => {
-				current.removeEventListener('contextmenu', onClick);
-			};
-		}, [onOpen]);
-
-		const onHide = useCallback(() => {
-			setOpened({type: 'not-open'});
-		}, []);
-
 		return (
 			<>
 				<div
 					ref={setRef}
-					onContextMenu={() => false}
+					onContextMenu={onContextMenu}
 					style={style}
 					className={className}
 					onPointerDown={onPointerDown}
 				>
 					{children}
 				</div>
-				{opened.type === 'open' ? (
-					<ContextMenuPortal
-						containerRef={ref}
-						currentZIndex={currentZIndex}
-						onHide={onHide}
-						opened={opened}
-						values={values}
-					/>
-				) : null}
+				{portal}
 			</>
 		);
 	},

--- a/packages/studio/src/components/ExpandedTracksProvider.tsx
+++ b/packages/studio/src/components/ExpandedTracksProvider.tsx
@@ -22,6 +22,9 @@ type ExpandedTracksGetterContextValue = {
 };
 
 type ExpandedTracksSetterContextValue = {
+	readonly expandTracks: (
+		nodePathInfos: readonly SequenceNodePathInfo[],
+	) => void;
 	readonly toggleTrack: (nodePathInfo: SequenceNodePathInfo) => void;
 	readonly migrateExpandedTracksForSubscriptionKey: (
 		oldKey: SequencePropsSubscriptionKey,
@@ -38,6 +41,9 @@ export const ExpandedTracksGetterContext =
 
 export const ExpandedTracksSetterContext =
 	createContext<ExpandedTracksSetterContextValue>({
+		expandTracks: () => {
+			throw new Error('ExpandedTracksSetterContext not initialized');
+		},
 		toggleTrack: () => {
 			throw new Error('ExpandedTracksSetterContext not initialized');
 		},
@@ -51,6 +57,34 @@ export const ExpandedTracksProvider: React.FC<{
 }> = ({children}) => {
 	const [expandedTracks, setExpandedTracks] =
 		useState<Record<string, boolean>>(loadExpandedTracks);
+
+	const expandTracks = useCallback(
+		(nodePathInfos: readonly SequenceNodePathInfo[]) => {
+			if (nodePathInfos.length === 0) {
+				return;
+			}
+
+			setExpandedTracks((prev) => {
+				let changed = false;
+				const next = {...prev};
+				for (const nodePathInfo of nodePathInfos) {
+					const key = timelineNodePathInfoToKey(nodePathInfo);
+					if (next[key] !== true) {
+						next[key] = true;
+						changed = true;
+					}
+				}
+
+				if (!changed) {
+					return prev;
+				}
+
+				persistBooleanMap(SESSION_STORAGE_KEY, next);
+				return next;
+			});
+		},
+		[],
+	);
 
 	const toggleTrack = useCallback((nodePathInfo: SequenceNodePathInfo) => {
 		setExpandedTracks((prev) => {
@@ -93,10 +127,11 @@ export const ExpandedTracksProvider: React.FC<{
 
 	const setterValue = useMemo(
 		(): ExpandedTracksSetterContextValue => ({
+			expandTracks,
 			toggleTrack,
 			migrateExpandedTracksForSubscriptionKey: migrateExpandedTracks,
 		}),
-		[toggleTrack, migrateExpandedTracks],
+		[expandTracks, toggleTrack, migrateExpandedTracks],
 	);
 
 	return (

--- a/packages/studio/src/components/Menu/portals.ts
+++ b/packages/studio/src/components/Menu/portals.ts
@@ -1,11 +1,14 @@
-export const portals = [
-	document.getElementById('menuportal-0') as Element,
-	document.getElementById('menuportal-1') as Element,
-	document.getElementById('menuportal-2') as Element,
-	document.getElementById('menuportal-3') as Element,
-	document.getElementById('menuportal-4') as Element,
-	document.getElementById('menuportal-5') as Element,
-];
+export const portals =
+	typeof document === 'undefined'
+		? []
+		: [
+				document.getElementById('menuportal-0') as Element,
+				document.getElementById('menuportal-1') as Element,
+				document.getElementById('menuportal-2') as Element,
+				document.getElementById('menuportal-3') as Element,
+				document.getElementById('menuportal-4') as Element,
+				document.getElementById('menuportal-5') as Element,
+			];
 
 export const getPortal = (i: number) => {
 	return portals[i];

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -19,13 +19,21 @@ import {BLUE} from '../helpers/colors';
 import {getBoxQuadsPonyfill} from '../helpers/get-box-quads-ponyfill';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {ScaleLockContext} from '../state/scale-lock';
+import {useContextMenu} from './ContextMenu';
+import {ExpandedTracksSetterContext} from './ExpandedTracksProvider';
+import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
 import {callAddSequenceKeyframe} from './Timeline/call-add-keyframe';
+import {
+	getTimelineRevealAncestorNodePathInfos,
+	scrollTimelineSequenceIntoView,
+} from './Timeline/reveal-timeline-selection';
 import {saveEffectProp} from './Timeline/save-effect-prop';
 import {
 	saveSequenceProps,
 	type SaveSequencePropChange,
 } from './Timeline/save-sequence-prop';
+import {useSequenceSourceContextMenuItems} from './Timeline/sequence-source-context-menu-items';
 import {getDecimalPlaces} from './Timeline/timeline-field-utils';
 import {
 	parseTranslate,
@@ -78,6 +86,7 @@ type SelectedOutlineTarget = {
 	readonly key: string;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly ref: React.RefObject<HTMLElement | null>;
+	readonly sequence: TSequence;
 	readonly selected: boolean;
 	readonly selection: TimelineSelection;
 	readonly drag: SelectedOutlineDragTarget | null;
@@ -142,6 +151,12 @@ const outlineContainer: React.CSSProperties = {
 	inset: 0,
 	pointerEvents: 'none',
 	overflow: 'visible',
+};
+
+const outlineContextMenuAnchor: React.CSSProperties = {
+	position: 'absolute',
+	inset: 0,
+	pointerEvents: 'none',
 };
 
 const pointToString = (point: OutlinePoint) => `${point.x},${point.y}`;
@@ -985,6 +1000,7 @@ const SelectedOutlinePolygon: React.FC<{
 	readonly allDragTargets: readonly SelectedOutlineDragTarget[];
 	readonly hovered: boolean;
 	readonly outline: SelectedOutline;
+	readonly onContextMenu?: React.MouseEventHandler<SVGPolygonElement>;
 	readonly onHoverChange: (key: string | null) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
@@ -996,6 +1012,7 @@ const SelectedOutlinePolygon: React.FC<{
 	allDragTargets,
 	hovered,
 	outline,
+	onContextMenu,
 	onHoverChange,
 	onSelect,
 	scale,
@@ -1177,6 +1194,7 @@ const SelectedOutlinePolygon: React.FC<{
 			onPointerEnter={() => onHoverChange(outline.key)}
 			onPointerLeave={() => onHoverChange(null)}
 			onPointerDown={onPointerDown}
+			onContextMenu={selected ? onContextMenu : undefined}
 		/>
 	);
 };
@@ -1185,6 +1203,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 	readonly allScaleDragTargets: readonly SelectedOutlineScaleDragTarget[];
 	readonly edge: SelectedOutlineScaleEdge;
 	readonly outline: SelectedOutline;
+	readonly onContextMenu?: React.MouseEventHandler<SVGLineElement>;
 	readonly onHoverChange: (key: string | null) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
@@ -1195,6 +1214,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 	allScaleDragTargets,
 	edge,
 	outline,
+	onContextMenu,
 	onHoverChange,
 	onSelect,
 	target,
@@ -1353,6 +1373,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			onPointerEnter={() => onHoverChange(outline.key)}
 			onPointerLeave={() => onHoverChange(null)}
 			onPointerDown={onPointerDown}
+			onContextMenu={selected ? onContextMenu : undefined}
 		/>
 	);
 };
@@ -1493,6 +1514,106 @@ const SelectedUvHandleCircle: React.FC<{
 	);
 };
 
+const SelectedOutlineTargetGroup: React.FC<{
+	readonly allDragTargets: readonly SelectedOutlineDragTarget[];
+	readonly allScaleDragTargets: readonly SelectedOutlineScaleDragTarget[];
+	readonly contextMenuContainerRef: React.RefObject<HTMLDivElement | null>;
+	readonly hovered: boolean;
+	readonly outline: SelectedOutline;
+	readonly onHoverChange: (key: string | null) => void;
+	readonly onSelect: (
+		item: TimelineSelection,
+		interaction?: TimelineSelectionInteraction,
+	) => void;
+	readonly scale: number;
+	readonly target: SelectedOutlineTarget;
+}> = ({
+	allDragTargets,
+	allScaleDragTargets,
+	contextMenuContainerRef,
+	hovered,
+	outline,
+	onHoverChange,
+	onSelect,
+	scale,
+	target,
+}) => {
+	const {expandTracks} = useContext(ExpandedTracksSetterContext);
+	const {sequenceSourceContextMenuItems} = useSequenceSourceContextMenuItems(
+		target.sequence,
+	);
+	const revealInTimeline = React.useCallback(() => {
+		onSelect(target.selection);
+		expandTracks(getTimelineRevealAncestorNodePathInfos(target.nodePathInfo));
+		window.requestAnimationFrame(() => {
+			scrollTimelineSequenceIntoView(target.nodePathInfo);
+		});
+	}, [expandTracks, onSelect, target.nodePathInfo, target.selection]);
+
+	const contextMenuValues = useMemo((): ComboboxValue[] => {
+		return [
+			...sequenceSourceContextMenuItems,
+			{
+				type: 'item',
+				id: 'reveal-in-timeline',
+				keyHint: null,
+				label: 'Reveal in timeline',
+				leftItem: null,
+				disabled: false,
+				onClick: revealInTimeline,
+				quickSwitcherLabel: null,
+				subMenu: null,
+				value: 'reveal-in-timeline',
+			},
+		];
+	}, [revealInTimeline, sequenceSourceContextMenuItems]);
+
+	const {onContextMenu, portal} = useContextMenu({
+		containerRef: contextMenuContainerRef,
+		onOpen: null,
+		values: contextMenuValues,
+	});
+
+	return (
+		<>
+			<SelectedOutlinePolygon
+				allDragTargets={allDragTargets}
+				hovered={hovered}
+				outline={outline}
+				onContextMenu={onContextMenu}
+				onHoverChange={onHoverChange}
+				onSelect={onSelect}
+				scale={scale}
+				target={target}
+			/>
+			{target.selected || hovered
+				? (['top', 'right', 'bottom', 'left'] as const).map((edge) => (
+						<SelectedOutlineScaleEdgeLine
+							key={edge}
+							allScaleDragTargets={allScaleDragTargets}
+							edge={edge}
+							outline={outline}
+							onContextMenu={onContextMenu}
+							onHoverChange={onHoverChange}
+							onSelect={onSelect}
+							target={target}
+						/>
+					))
+				: null}
+			{target.selected
+				? target.uvHandles.map((handle) => (
+						<SelectedUvHandleCircle
+							key={`${handle.effectIndex}-${handle.fieldKey}`}
+							handle={handle}
+							outline={outline}
+						/>
+					))
+				: null}
+			{portal}
+		</>
+	);
+};
+
 export const SelectedOutlineOverlay: React.FC<{
 	readonly scale: number;
 }> = ({scale}) => {
@@ -1512,6 +1633,7 @@ export const SelectedOutlineOverlay: React.FC<{
 		null,
 	);
 	const overlayRef = useRef<SVGSVGElement>(null);
+	const contextMenuContainerRef = useRef<HTMLDivElement>(null);
 
 	const outlineTargets = useMemo((): SelectedOutlineTarget[] => {
 		if (!ENABLE_OUTLINES) {
@@ -1564,6 +1686,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				key,
 				nodePathInfo,
 				ref: sequence.refForOutline,
+				sequence,
 				selected,
 				selection: {type: 'sequence', nodePathInfo},
 				drag: canDrag
@@ -1690,51 +1813,48 @@ export const SelectedOutlineOverlay: React.FC<{
 	}
 
 	return (
-		<svg
-			ref={overlayRef}
-			style={outlineContainer}
-			width="100%"
-			height="100%"
-			aria-hidden="true"
-		>
-			{outlines.map((outline) => (
-				<React.Fragment key={outline.key}>
-					<SelectedOutlinePolygon
-						allDragTargets={allDragTargets}
-						hovered={hoveredOutlineKey === outline.key}
-						outline={outline}
-						onHoverChange={setHoveredOutlineKey}
-						onSelect={selectItem}
-						scale={scale}
-						target={targetsByKey.get(outline.key)}
-					/>
-					{targetsByKey.get(outline.key)?.selected ||
-					hoveredOutlineKey === outline.key
-						? (['top', 'right', 'bottom', 'left'] as const).map((edge) => (
-								<SelectedOutlineScaleEdgeLine
-									key={edge}
+		<>
+			<div ref={contextMenuContainerRef} style={outlineContextMenuAnchor} />
+			<svg
+				ref={overlayRef}
+				style={outlineContainer}
+				width="100%"
+				height="100%"
+				aria-hidden="true"
+			>
+				{outlines.map((outline) => {
+					const target = targetsByKey.get(outline.key);
+					const hovered = hoveredOutlineKey === outline.key;
+
+					return (
+						<React.Fragment key={outline.key}>
+							{target ? (
+								<SelectedOutlineTargetGroup
+									allDragTargets={allDragTargets}
 									allScaleDragTargets={allScaleDragTargets}
-									edge={edge}
+									contextMenuContainerRef={contextMenuContainerRef}
+									hovered={hovered}
 									outline={outline}
 									onHoverChange={setHoveredOutlineKey}
 									onSelect={selectItem}
-									target={targetsByKey.get(outline.key)}
+									scale={scale}
+									target={target}
 								/>
-							))
-						: null}
-					{targetsByKey.get(outline.key)?.selected
-						? targetsByKey
-								.get(outline.key)
-								?.uvHandles.map((handle) => (
-									<SelectedUvHandleCircle
-										key={`${handle.effectIndex}-${handle.fieldKey}`}
-										handle={handle}
-										outline={outline}
-									/>
-								))
-						: null}
-				</React.Fragment>
-			))}
-		</svg>
+							) : (
+								<SelectedOutlinePolygon
+									allDragTargets={allDragTargets}
+									hovered={hovered}
+									outline={outline}
+									onHoverChange={setHoveredOutlineKey}
+									onSelect={selectItem}
+									scale={scale}
+									target={undefined}
+								/>
+							)}
+						</React.Fragment>
+					);
+				})}
+			</svg>
+		</>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -7,7 +7,6 @@ import type {TSequence} from 'remotion';
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
-import {formatFileLocation} from '../../helpers/format-file-location';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
 	getTimelineLayerHeight,
@@ -24,7 +23,9 @@ import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {useSelectAsset} from '../use-select-asset';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
+import {registerTimelineSequenceRow} from './reveal-timeline-selection';
 import {saveSequenceProps} from './save-sequence-prop';
+import {useSequenceSourceContextMenuItems} from './sequence-source-context-menu-items';
 import {
 	getTimelineAssetLinkInfo,
 	openTimelineAssetLink,
@@ -45,7 +46,6 @@ import {
 	useTimelineRowSelection,
 } from './TimelineSelection';
 import {TimelineSequenceName} from './TimelineSequenceName';
-import {useOpenSequenceInEditor} from './use-open-sequence-in-editor';
 
 const labelContainerStyle: React.CSSProperties = {
 	alignItems: 'center',
@@ -110,16 +110,12 @@ export const TimelineSequenceItem: React.FC<{
 	const containsSelection = useTimelineRowContainsSelection(nodePathInfo);
 	const [effectDropHovered, setEffectDropHovered] = useState(false);
 
-	const {canOpenInEditor, openInEditor, originalLocation} =
-		useOpenSequenceInEditor(sequence);
-	const fileLocation = useMemo(
-		() =>
-			formatFileLocation({
-				location: originalLocation,
-				root: window.remotion_cwd,
-			}),
-		[originalLocation],
-	);
+	const {
+		canOpenInEditor,
+		openInEditor,
+		originalLocation,
+		sequenceSourceContextMenuItems,
+	} = useSequenceSourceContextMenuItems(sequence);
 
 	const validatedLocation = useMemo(() => {
 		if (
@@ -206,54 +202,10 @@ export const TimelineSequenceItem: React.FC<{
 			return [];
 		}
 
-		const editorName = window.remotion_editorName;
 		const {documentationLink} = sequence;
 
 		return [
-			editorName
-				? {
-						type: 'item' as const,
-						id: 'show-in-editor',
-						keyHint: null,
-						label: `Show in ${editorName}`,
-						leftItem: null,
-						disabled: !canOpenInEditor,
-						onClick: () => {
-							openInEditor();
-						},
-						quickSwitcherLabel: null,
-						subMenu: null,
-						value: 'show-in-editor',
-					}
-				: null,
-			{
-				type: 'item' as const,
-				id: 'copy-file-location',
-				keyHint: null,
-				label: 'Copy file location',
-				leftItem: null,
-				disabled: !fileLocation,
-				onClick: () => {
-					if (!fileLocation) {
-						return;
-					}
-
-					navigator.clipboard
-						.writeText(fileLocation)
-						.then(() => {
-							showNotification('Copied file location to clipboard', 1000);
-						})
-						.catch((err) => {
-							showNotification(
-								`Could not copy to clipboard: ${(err as Error).message}`,
-								1000,
-							);
-						});
-				},
-				quickSwitcherLabel: null,
-				subMenu: null,
-				value: 'copy-file-location',
-			},
+			...sequenceSourceContextMenuItems,
 			documentationLink
 				? {
 						type: 'item' as const,
@@ -333,14 +285,12 @@ export const TimelineSequenceItem: React.FC<{
 		assetLinkInfo,
 		deleteDisabled,
 		duplicateDisabled,
-		fileLocation,
 		onDeleteSequenceFromSource,
 		onDuplicateSequenceFromSource,
-		canOpenInEditor,
-		openInEditor,
 		previewConnected,
 		selectAsset,
 		sequence,
+		sequenceSourceContextMenuItems,
 	]);
 
 	const isExpanded =
@@ -484,6 +434,20 @@ export const TimelineSequenceItem: React.FC<{
 		validatedLocation !== null &&
 		sequence.controls?.supportsEffects === true;
 
+	const rowRef = useCallback(
+		(element: HTMLDivElement | null) => {
+			if (nodePathInfo === null) {
+				return;
+			}
+
+			registerTimelineSequenceRow({
+				element,
+				nodePathInfo,
+			});
+		},
+		[nodePathInfo],
+	);
+
 	const onEffectDragOver = useCallback(
 		(e: React.DragEvent<HTMLDivElement>) => {
 			if (!canDropEffect || !hasEffectDragType(e.dataTransfer)) {
@@ -606,7 +570,7 @@ export const TimelineSequenceItem: React.FC<{
 	);
 
 	return (
-		<>
+		<div ref={rowRef}>
 			{previewConnected ? (
 				<ContextMenu
 					values={contextMenuValues}
@@ -630,6 +594,6 @@ export const TimelineSequenceItem: React.FC<{
 					keyframeDisplayOffset={keyframeDisplayOffset}
 				/>
 			) : null}
-		</>
+		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/reveal-timeline-selection.ts
+++ b/packages/studio/src/components/Timeline/reveal-timeline-selection.ts
@@ -1,0 +1,41 @@
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {getTimelineSequenceSelectionKey} from './TimelineSelection';
+
+const timelineSequenceRows = new Map<string, HTMLElement>();
+
+export const getTimelineRevealAncestorNodePathInfos = (
+	nodePathInfo: SequenceNodePathInfo,
+): SequenceNodePathInfo[] => {
+	return nodePathInfo.auxiliaryKeys.map((_, i) => ({
+		...nodePathInfo,
+		auxiliaryKeys: nodePathInfo.auxiliaryKeys.slice(0, i),
+	}));
+};
+
+export const registerTimelineSequenceRow = ({
+	element,
+	nodePathInfo,
+}: {
+	readonly element: HTMLElement | null;
+	readonly nodePathInfo: SequenceNodePathInfo;
+}) => {
+	const key = getTimelineSequenceSelectionKey(nodePathInfo);
+	if (element === null) {
+		timelineSequenceRows.delete(key);
+		return;
+	}
+
+	timelineSequenceRows.set(key, element);
+};
+
+export const scrollTimelineSequenceIntoView = (
+	nodePathInfo: SequenceNodePathInfo,
+) => {
+	const row = timelineSequenceRows.get(
+		getTimelineSequenceSelectionKey(nodePathInfo),
+	);
+	row?.scrollIntoView({
+		block: 'nearest',
+		inline: 'nearest',
+	});
+};

--- a/packages/studio/src/components/Timeline/sequence-source-context-menu-items.ts
+++ b/packages/studio/src/components/Timeline/sequence-source-context-menu-items.ts
@@ -1,0 +1,110 @@
+import React, {useMemo} from 'react';
+import type {TSequence} from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
+import type {OriginalPosition} from '../../error-overlay/react-overlay/utils/get-source-map';
+import {formatFileLocation} from '../../helpers/format-file-location';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {showNotification} from '../Notifications/NotificationCenter';
+import {useOpenSequenceInEditor} from './use-open-sequence-in-editor';
+
+export const getSequenceSourceContextMenuItems = ({
+	canOpenInEditor,
+	editorName,
+	fileLocation,
+	onCopyFileLocation,
+	onShowInEditor,
+}: {
+	readonly canOpenInEditor: boolean;
+	readonly editorName: string | null;
+	readonly fileLocation: string | null;
+	readonly onCopyFileLocation: () => void;
+	readonly onShowInEditor: () => void;
+}): ComboboxValue[] => {
+	return [
+		editorName
+			? {
+					type: 'item' as const,
+					id: 'show-in-editor',
+					keyHint: null,
+					label: `Show in ${editorName}`,
+					leftItem: null,
+					disabled: !canOpenInEditor,
+					onClick: onShowInEditor,
+					quickSwitcherLabel: null,
+					subMenu: null,
+					value: 'show-in-editor',
+				}
+			: null,
+		{
+			type: 'item' as const,
+			id: 'copy-file-location',
+			keyHint: null,
+			label: 'Copy file location',
+			leftItem: null,
+			disabled: !fileLocation,
+			onClick: onCopyFileLocation,
+			quickSwitcherLabel: null,
+			subMenu: null,
+			value: 'copy-file-location',
+		},
+	].filter(NoReactInternals.truthy);
+};
+
+export const useSequenceSourceContextMenuItems = (
+	sequence: TSequence,
+): {
+	readonly canOpenInEditor: boolean;
+	readonly fileLocation: string | null;
+	readonly openInEditor: () => void;
+	readonly originalLocation: OriginalPosition | null;
+	readonly sequenceSourceContextMenuItems: ComboboxValue[];
+} => {
+	const {canOpenInEditor, openInEditor, originalLocation} =
+		useOpenSequenceInEditor(sequence);
+	const fileLocation = useMemo(
+		() =>
+			formatFileLocation({
+				location: originalLocation,
+				root: window.remotion_cwd,
+			}),
+		[originalLocation],
+	);
+
+	const onCopyFileLocation = React.useCallback(() => {
+		if (!fileLocation) {
+			return;
+		}
+
+		navigator.clipboard
+			.writeText(fileLocation)
+			.then(() => {
+				showNotification('Copied file location to clipboard', 1000);
+			})
+			.catch((err) => {
+				showNotification(
+					`Could not copy to clipboard: ${(err as Error).message}`,
+					1000,
+				);
+			});
+	}, [fileLocation]);
+
+	const sequenceSourceContextMenuItems = useMemo(
+		() =>
+			getSequenceSourceContextMenuItems({
+				canOpenInEditor,
+				editorName: window.remotion_editorName,
+				fileLocation,
+				onCopyFileLocation,
+				onShowInEditor: openInEditor,
+			}),
+		[canOpenInEditor, fileLocation, onCopyFileLocation, openInEditor],
+	);
+
+	return {
+		canOpenInEditor,
+		fileLocation,
+		openInEditor,
+		originalLocation,
+		sequenceSourceContextMenuItems,
+	};
+};

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -26,6 +26,8 @@ import {
 import {deleteSelectedTimelineItems} from '../components/Timeline/delete-selected-timeline-item';
 import {isDuplicatableSequenceRowSelection} from '../components/Timeline/duplicate-selected-timeline-item';
 import {getTimelinePropResetTargets} from '../components/Timeline/reset-selected-timeline-props';
+import {getTimelineRevealAncestorNodePathInfos} from '../components/Timeline/reveal-timeline-selection';
+import {getSequenceSourceContextMenuItems} from '../components/Timeline/sequence-source-context-menu-items';
 import {
 	getPasteEffectsTarget,
 	getSnapshotsFromSelection,
@@ -695,6 +697,74 @@ test('Timeline from drag removes the prop at the default value', () => {
 
 test('Timeline outlines should not be enabled', () => {
 	expect(ENABLE_OUTLINES).toBe(false);
+});
+
+test('Timeline reveal expands ancestor rows only', () => {
+	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '1', 'opacity'],
+	);
+
+	expect(getTimelineRevealAncestorNodePathInfos(sequenceNodePathInfo)).toEqual(
+		[],
+	);
+	expect(
+		getTimelineRevealAncestorNodePathInfos(effectPropNodePathInfo).map(
+			(info) => info.auxiliaryKeys,
+		),
+	).toEqual([[], ['effects'], ['effects', '1']]);
+});
+
+test('Sequence source context menu exposes editor and file location actions', () => {
+	let didShowInEditor = false;
+	let didCopyFileLocation = false;
+	const items = getSequenceSourceContextMenuItems({
+		canOpenInEditor: true,
+		editorName: 'VS Code',
+		fileLocation: '/project/src/Comp.tsx:12',
+		onCopyFileLocation: () => {
+			didCopyFileLocation = true;
+		},
+		onShowInEditor: () => {
+			didShowInEditor = true;
+		},
+	});
+
+	expect(items.map((item) => item.id)).toEqual([
+		'show-in-editor',
+		'copy-file-location',
+	]);
+	expect(items.map((item) => item.type === 'item' && item.disabled)).toEqual([
+		false,
+		false,
+	]);
+	const [showInEditor, copyFileLocation] = items;
+	if (showInEditor.type !== 'item' || copyFileLocation.type !== 'item') {
+		throw new Error('Expected menu items');
+	}
+
+	showInEditor.onClick('show-in-editor', null);
+	copyFileLocation.onClick('copy-file-location', null);
+	expect(didShowInEditor).toBe(true);
+	expect(didCopyFileLocation).toBe(true);
+});
+
+test('Sequence source context menu disables missing source actions', () => {
+	const items = getSequenceSourceContextMenuItems({
+		canOpenInEditor: false,
+		editorName: null,
+		fileLocation: null,
+		onCopyFileLocation: () => {
+			throw new Error('Should not copy');
+		},
+		onShowInEditor: () => {
+			throw new Error('Should not open');
+		},
+	});
+
+	expect(items.map((item) => item.id)).toEqual(['copy-file-location']);
+	expect(items[0].type === 'item' && items[0].disabled).toBe(true);
 });
 
 test('Canvas outline selection uses conventional modifier keys', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8130

## Summary
- Add a selected canvas outline context menu with sequence source actions and `Reveal in timeline`.
- Reuse shared sequence source menu items for timeline rows and outline menus.
- Add timeline row reveal helpers that expand ancestor rows and scroll the sequence row into view.
- Make menu portal imports safe for Node-side tests.

## Walkthrough
<a href="https://cursor.com/agents/bc-9dd2468d-330a-4096-a5d4-cff423e0ee46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foutline_context_menu_reveal_demo.mp4"><img src="https://cursor.com/artifacts/c/art-db4994ad-6625-41bf-9fcf-eb0fb17fbdc6" alt="outline_context_menu_reveal_demo.mp4" /></a>

## Testing
- `bun test src/test/timeline-selection.test.ts`
- `bunx turbo run make --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck` (fails in this VM at `@remotion/lambda-go#lint` because Go 1.22.2 is installed and the module requires Go >= 1.23.0; Studio formatting/lint passed separately)
- `bunx turbo run lint formatting --filter='@remotion/studio'`
- Manual Studio test in `greenscreen` with outlines temporarily enabled locally: selected video outline opens the custom menu and `Reveal in timeline` keeps the row selected/in view.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dd2468d-330a-4096-a5d4-cff423e0ee46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dd2468d-330a-4096-a5d4-cff423e0ee46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

