### PR TITLE
`@remotion/studio`: Add UV coordinate connector lines

### DIFF
--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -62,6 +62,7 @@ export type UvCoordinateFieldSchema = {
 	min?: number;
 	max?: number;
 	step?: number;
+	lineTo?: string;
 	default: readonly [number, number] | undefined;
 	description?: string;
 	keyframable?: boolean;

--- a/packages/effects/src/halftone-linear-gradient.ts
+++ b/packages/effects/src/halftone-linear-gradient.ts
@@ -47,6 +47,7 @@ export const halftoneLinearGradientSchema = {
 		step: 0.01,
 		default: DEFAULT_FIRST_STOP_POSITION,
 		description: 'First stop position',
+		lineTo: 'secondStopPosition',
 	},
 	secondStopPosition: {
 		type: 'uv-coordinate',

--- a/packages/effects/src/linear-progressive-blur/index.ts
+++ b/packages/effects/src/linear-progressive-blur/index.ts
@@ -52,6 +52,7 @@ const linearProgressiveBlurSchema = {
 		step: 0.01,
 		default: DEFAULT_START,
 		description: 'Start',
+		lineTo: 'end',
 	},
 	end: {
 		type: 'uv-coordinate',

--- a/packages/effects/src/test/effect-params.test.ts
+++ b/packages/effects/src/test/effect-params.test.ts
@@ -1131,6 +1131,15 @@ test('halftoneLinearGradient() accepts default params', () => {
 	expect(() => halftoneLinearGradient()).not.toThrow();
 });
 
+test('halftoneLinearGradient() connects its stop position controls', () => {
+	expect(
+		halftoneLinearGradient().definition.schema.firstStopPosition,
+	).toMatchObject({
+		type: 'uv-coordinate',
+		lineTo: 'secondStopPosition',
+	});
+});
+
 test('halftoneLinearGradient() rejects first stop dot size below range', () => {
 	expect(() => halftoneLinearGradient({firstStopDotSize: -1})).toThrow(
 		'"firstStopDotSize" must be >= 0',
@@ -1546,6 +1555,13 @@ test('lines() parameters produce distinct effect keys', () => {
 
 test('linearProgressiveBlur() accepts default params', () => {
 	expect(() => linearProgressiveBlur()).not.toThrow();
+});
+
+test('linearProgressiveBlur() connects its start and end controls', () => {
+	expect(linearProgressiveBlur().definition.schema.start).toMatchObject({
+		type: 'uv-coordinate',
+		lineTo: 'end',
+	});
 });
 
 test('linearProgressiveBlur() rejects invalid start', () => {

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -74,6 +74,17 @@ type SelectedOutlineUvHandle = {
 	readonly value: UvCoordinate;
 };
 
+type UvConnectionHandle = Pick<
+	SelectedOutlineUvHandle,
+	'effectIndex' | 'fieldKey' | 'fieldSchema' | 'value'
+>;
+
+type UvHandleConnectionLine = {
+	readonly key: string;
+	readonly from: OutlinePoint;
+	readonly to: OutlinePoint;
+};
+
 type SelectedOutlineTarget = {
 	readonly key: string;
 	readonly nodePathInfo: SequenceNodePathInfo;
@@ -270,6 +281,54 @@ export const getUvHandlePosition = (
 	return transform === null
 		? getBilinearUvHandlePosition(points, uv)
 		: applyProjectiveTransform(transform, uv);
+};
+
+export const getUvHandleConnectionLines = ({
+	handles,
+	points,
+}: {
+	readonly handles: readonly UvConnectionHandle[];
+	readonly points: SelectedOutline['points'];
+}): UvHandleConnectionLine[] => {
+	const handlesByField = new Map(
+		handles.map((handle) => [
+			`${handle.effectIndex}\u0000${handle.fieldKey}`,
+			handle,
+		]),
+	);
+	const seenPairs = new Set<string>();
+	const lines: UvHandleConnectionLine[] = [];
+
+	for (const handle of handles) {
+		const targetFieldKey = handle.fieldSchema.lineTo;
+		if (targetFieldKey === undefined || targetFieldKey === handle.fieldKey) {
+			continue;
+		}
+
+		const target = handlesByField.get(
+			`${handle.effectIndex}\u0000${targetFieldKey}`,
+		);
+		if (target === undefined) {
+			continue;
+		}
+
+		const pairKey = [
+			handle.effectIndex,
+			...[handle.fieldKey, targetFieldKey].sort(),
+		].join('\u0000');
+		if (seenPairs.has(pairKey)) {
+			continue;
+		}
+
+		seenPairs.add(pairKey);
+		lines.push({
+			key: `${handle.effectIndex}-${handle.fieldKey}-${targetFieldKey}`,
+			from: getUvHandlePosition(points, handle.value),
+			to: getUvHandlePosition(points, target.value),
+		});
+	}
+
+	return lines;
 };
 
 const vectorBetween = (from: OutlinePoint, to: OutlinePoint): OutlinePoint => {
@@ -1370,6 +1429,34 @@ const getSvgPointFromPointerEvent = ({
 	};
 };
 
+const SelectedUvHandleConnectionLines: React.FC<{
+	readonly handles: readonly SelectedOutlineUvHandle[];
+	readonly outline: SelectedOutline;
+}> = ({handles, outline}) => {
+	const lines = useMemo(
+		() => getUvHandleConnectionLines({handles, points: outline.points}),
+		[handles, outline.points],
+	);
+
+	return (
+		<>
+			{lines.map((line) => (
+				<line
+					key={line.key}
+					x1={line.from.x}
+					y1={line.from.y}
+					x2={line.to.x}
+					y2={line.to.y}
+					stroke={BLUE}
+					strokeWidth={2}
+					vectorEffect="non-scaling-stroke"
+					pointerEvents="none"
+				/>
+			))}
+		</>
+	);
+};
+
 const SelectedUvHandleCircle: React.FC<{
 	readonly handle: SelectedOutlineUvHandle;
 	readonly outline: SelectedOutline;
@@ -1723,15 +1810,25 @@ export const SelectedOutlineOverlay: React.FC<{
 							))
 						: null}
 					{targetsByKey.get(outline.key)?.selected
-						? targetsByKey
-								.get(outline.key)
-								?.uvHandles.map((handle) => (
-									<SelectedUvHandleCircle
-										key={`${handle.effectIndex}-${handle.fieldKey}`}
-										handle={handle}
-										outline={outline}
-									/>
-								))
+						? (() => {
+								const uvHandles =
+									targetsByKey.get(outline.key)?.uvHandles ?? [];
+								return (
+									<>
+										<SelectedUvHandleConnectionLines
+											handles={uvHandles}
+											outline={outline}
+										/>
+										{uvHandles.map((handle) => (
+											<SelectedUvHandleCircle
+												key={`${handle.effectIndex}-${handle.fieldKey}`}
+												handle={handle}
+												outline={outline}
+											/>
+										))}
+									</>
+								);
+							})()
 						: null}
 				</React.Fragment>
 			))}

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -19,6 +19,7 @@ import {
 	getSelectedOutlineScaleEdgeInfo,
 	getSequencesWithSelectableOutlines,
 	getUvCoordinateForPoint,
+	getUvHandleConnectionLines,
 	getUvHandlePosition,
 	type SelectedOutlineDragState,
 	type SelectedOutlineScaleDragState,
@@ -794,6 +795,104 @@ test('UV handle pointer position maps back to UV coordinates', () => {
 
 	expect(result[0]).toBeCloseTo(uv[0], 5);
 	expect(result[1]).toBeCloseTo(uv[1], 5);
+});
+
+test('UV handle connection lines connect fields from schema metadata', () => {
+	const points = [
+		{x: 0, y: 0},
+		{x: 100, y: 0},
+		{x: 100, y: 100},
+		{x: 0, y: 100},
+	] as const;
+
+	const lines = getUvHandleConnectionLines({
+		points,
+		handles: [
+			{
+				effectIndex: 0,
+				fieldKey: 'start',
+				fieldSchema: {
+					type: 'uv-coordinate',
+					default: [0, 0],
+					lineTo: 'end',
+				},
+				value: [0.2, 0.3],
+			},
+			{
+				effectIndex: 0,
+				fieldKey: 'end',
+				fieldSchema: {
+					type: 'uv-coordinate',
+					default: [1, 1],
+				},
+				value: [0.8, 0.7],
+			},
+		],
+	});
+
+	expect(lines).toEqual([
+		{
+			key: '0-start-end',
+			from: {x: 20, y: 30},
+			to: {x: 80, y: 70},
+		},
+	]);
+});
+
+test('UV handle connection lines stay within the same effect instance', () => {
+	const points = [
+		{x: 0, y: 0},
+		{x: 100, y: 0},
+		{x: 100, y: 100},
+		{x: 0, y: 100},
+	] as const;
+
+	const lines = getUvHandleConnectionLines({
+		points,
+		handles: [
+			{
+				effectIndex: 0,
+				fieldKey: 'start',
+				fieldSchema: {
+					type: 'uv-coordinate',
+					default: [0, 0],
+					lineTo: 'end',
+				},
+				value: [0.2, 0.3],
+			},
+			{
+				effectIndex: 1,
+				fieldKey: 'end',
+				fieldSchema: {
+					type: 'uv-coordinate',
+					default: [1, 1],
+				},
+				value: [0.8, 0.7],
+			},
+			{
+				effectIndex: 2,
+				fieldKey: 'start',
+				fieldSchema: {
+					type: 'uv-coordinate',
+					default: [0, 0],
+					lineTo: 'end',
+				},
+				value: [0.2, 0.3],
+			},
+			{
+				effectIndex: 2,
+				fieldKey: 'end',
+				fieldSchema: {
+					type: 'uv-coordinate',
+					default: [1, 1],
+					lineTo: 'start',
+				},
+				value: [0.8, 0.7],
+			},
+		],
+	});
+
+	expect(lines.map((line) => line.key)).toEqual(['2-start-end']);
 });
 
 test('UV handles are requested for selected effect children', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8052

## Summary
- Add `lineTo` metadata to UV coordinate schema fields.
- Draw blue connector lines between linked UV controls in the Studio selected outline overlay.
- Link the built-in `linearProgressiveBlur()` and `halftoneLinearGradient()` UV controls.

## Walkthrough
<a href="https://cursor.com/agents/bc-8e9beee4-9fd9-4955-8cfe-a8a5c4f9b4d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuv_coordinate_connector_line_clean_demo.mp4"><img src="https://cursor.com/artifacts/c/art-8dc91d39-67bb-47e6-a097-02105bce13f4" alt="uv_coordinate_connector_line_clean_demo.mp4" /></a>
![UV coordinate connector line in Studio](https://cursor.com/artifacts/c/art-2e701e52-a9d9-45a7-b092-97ccb229f576)

## Testing
- `bun test src/test/timeline-selection.test.ts`
- `bun test src/test/effect-params.test.ts`
- `bun run build`
- `bunx turbo run lint formatting --filter='remotion' --filter='@remotion/effects' --filter='@remotion/studio' --no-update-notifier`
- `bun run stylecheck` (fails only on known Cloud Agent Go 1.22.2 vs `@remotion/lambda-go` requiring Go >= 1.23.0)
- Manual Studio verification using `halftone-gradient` with local-only visual mode flags temporarily enabled and reverted before finalizing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e9beee4-9fd9-4955-8cfe-a8a5c4f9b4d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e9beee4-9fd9-4955-8cfe-a8a5c4f9b4d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

