### PR TITLE
`@remotion/studio`: Move scale lock to the right

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineScaleField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScaleField.tsx
@@ -438,7 +438,6 @@ export const TimelineScaleField: React.FC<{
 
 	return (
 		<span style={containerStyle}>
-			<LinkToggle linked={linked} onToggle={onToggleLink} />
 			<InputDragger
 				type="number"
 				value={dragX ?? codeX}
@@ -470,6 +469,7 @@ export const TimelineScaleField: React.FC<{
 				formatter={formatter}
 				rightAlign={false}
 			/>
+			<LinkToggle linked={linked} onToggle={onToggleLink} />
 		</span>
 	);
 };


### PR DESCRIPTION
## Summary

- Move the Studio scale lock toggle to the right of the scale values

Fixes #8105.

## Testing

- bun run build
- bun run stylecheck
