### PR TITLE
`@remotion/studio`: Auto-install packages before drop codemods

### DIFF
--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -152,6 +152,10 @@ export {PackageManager} from './package-manager';
 export {ProjectInfo} from './project-info';
 export type {RenderDefaults} from './render-defaults';
 export {
+	getRequiredPackageForEffectImportPath,
+	getRequiredPackageForInsertableElement,
+} from './required-package';
+export {
 	AggregateRenderProgress,
 	ArtifactProgress,
 	BrowserDownloadState,

--- a/packages/studio-shared/src/required-package.ts
+++ b/packages/studio-shared/src/required-package.ts
@@ -1,0 +1,36 @@
+import type {InsertableCompositionElement} from './api-requests';
+
+export const getRequiredPackageForInsertableElement = (
+	element: InsertableCompositionElement,
+): string | null => {
+	if (element.type === 'solid') {
+		return null;
+	}
+
+	if (element.assetType === 'video' || element.assetType === 'audio') {
+		return '@remotion/media';
+	}
+
+	if (element.assetType === 'gif') {
+		return '@remotion/gif';
+	}
+
+	return null;
+};
+
+export const getRequiredPackageForEffectImportPath = (
+	importPath: string,
+): string | null => {
+	if (importPath.startsWith('@remotion/effects/')) {
+		return '@remotion/effects';
+	}
+
+	if (
+		importPath === '@remotion/light-leaks' ||
+		importPath === '@remotion/starburst'
+	) {
+		return importPath;
+	}
+
+	return null;
+};

--- a/packages/studio-shared/src/test/required-package.test.ts
+++ b/packages/studio-shared/src/test/required-package.test.ts
@@ -1,0 +1,60 @@
+import {expect, test} from 'bun:test';
+import {
+	getRequiredPackageForEffectImportPath,
+	getRequiredPackageForInsertableElement,
+} from '../required-package';
+
+test('gets required package for insertable elements', () => {
+	expect(
+		getRequiredPackageForInsertableElement({
+			type: 'solid',
+			width: 1920,
+			height: 1080,
+		}),
+	).toBe(null);
+	expect(
+		getRequiredPackageForInsertableElement({
+			type: 'asset',
+			assetType: 'image',
+			src: 'image.png',
+			dimensions: null,
+		}),
+	).toBe(null);
+	expect(
+		getRequiredPackageForInsertableElement({
+			type: 'asset',
+			assetType: 'video',
+			src: 'video.mp4',
+			dimensions: null,
+		}),
+	).toBe('@remotion/media');
+	expect(
+		getRequiredPackageForInsertableElement({
+			type: 'asset',
+			assetType: 'audio',
+			src: 'audio.mp3',
+			dimensions: null,
+		}),
+	).toBe('@remotion/media');
+	expect(
+		getRequiredPackageForInsertableElement({
+			type: 'asset',
+			assetType: 'gif',
+			src: 'animation.gif',
+			dimensions: null,
+		}),
+	).toBe('@remotion/gif');
+});
+
+test('gets required package for effect import paths', () => {
+	expect(
+		getRequiredPackageForEffectImportPath('@remotion/effects/brightness'),
+	).toBe('@remotion/effects');
+	expect(getRequiredPackageForEffectImportPath('@remotion/light-leaks')).toBe(
+		'@remotion/light-leaks',
+	);
+	expect(getRequiredPackageForEffectImportPath('@remotion/starburst')).toBe(
+		'@remotion/starburst',
+	);
+	expect(getRequiredPackageForEffectImportPath('remotion')).toBe(null);
+});

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -1,5 +1,6 @@
 import {
 	EFFECT_DRAG_MIME_TYPE,
+	getRequiredPackageForEffectImportPath,
 	parseEffectDragData,
 } from '@remotion/studio-shared';
 import React, {useCallback, useContext, useMemo, useState} from 'react';
@@ -9,6 +10,7 @@ import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {formatFileLocation} from '../../helpers/format-file-location';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {installRequiredPackages} from '../../helpers/install-required-package';
 import {
 	getTimelineLayerHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
@@ -530,6 +532,11 @@ export const TimelineSequenceItem: React.FC<{
 			}
 
 			try {
+				const requiredPackage = getRequiredPackageForEffectImportPath(
+					dragData.effect.importPath,
+				);
+				await installRequiredPackages(requiredPackage ? [requiredPackage] : []);
+
 				const result = await callApi('/api/add-effect', {
 					fileName: validatedLocation.source,
 					sequenceNodePath: nodePath,

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -1,7 +1,11 @@
-import type {InsertableCompositionElement} from '@remotion/studio-shared';
+import {
+	getRequiredPackageForInsertableElement,
+	type InsertableCompositionElement,
+} from '@remotion/studio-shared';
 import {getStaticFiles} from '../api/get-static-files';
 import {writeStaticFile} from '../api/write-static-file';
 import {detectFileType, type FileType} from '../helpers/detect-file-type';
+import {installRequiredPackages} from '../helpers/install-required-package';
 import {callApi} from './call-api';
 import {showNotification} from './Notifications/NotificationCenter';
 
@@ -205,6 +209,9 @@ const insertAssetElement = async ({
 	compositionId: string;
 	element: InsertableCompositionElement;
 }) => {
+	const requiredPackage = getRequiredPackageForInsertableElement(element);
+	await installRequiredPackages(requiredPackage ? [requiredPackage] : []);
+
 	const result = await callApi('/api/insert-jsx-element', {
 		compositionFile,
 		compositionId,

--- a/packages/studio/src/helpers/install-required-package.ts
+++ b/packages/studio/src/helpers/install-required-package.ts
@@ -1,0 +1,51 @@
+import {installPackages} from '../api/install-package';
+import {showNotification} from '../components/Notifications/NotificationCenter';
+
+let installQueue: Promise<void> = Promise.resolve();
+
+const getMissingPackages = (packageNames: string[]) => {
+	const uniquePackageNames = Array.from(new Set(packageNames));
+	const installedPackages = window.remotion_installedPackages ?? [];
+
+	return uniquePackageNames.filter(
+		(packageName) => !installedPackages.includes(packageName),
+	);
+};
+
+const addInstalledPackages = (packageNames: string[]) => {
+	const installedPackages = window.remotion_installedPackages ?? [];
+	window.remotion_installedPackages = Array.from(
+		new Set([...installedPackages, ...packageNames]),
+	);
+};
+
+const formatPackageList = (packageNames: string[]) => {
+	if (packageNames.length === 1) {
+		return packageNames[0];
+	}
+
+	return `${packageNames.length} packages`;
+};
+
+export const installRequiredPackages = async (
+	packageNames: string[],
+): Promise<void> => {
+	const runInstall = async () => {
+		const missingPackages = getMissingPackages(packageNames);
+		if (missingPackages.length === 0) {
+			return;
+		}
+
+		showNotification(
+			`Installing ${formatPackageList(missingPackages)}...`,
+			3000,
+		);
+		await installPackages(missingPackages);
+		addInstalledPackages(missingPackages);
+		showNotification(`Installed ${formatPackageList(missingPackages)}`, 3000);
+	};
+
+	const queuedInstall = installQueue.then(runInstall, runInstall);
+	installQueue = queuedInstall.catch(() => undefined);
+	await queuedInstall;
+};


### PR DESCRIPTION
## Summary
- Auto-install missing Remotion packages before applying drop codemods in Studio.
- Cover effect drops, media/audio asset drops, and GIF asset drops.
- Serialize package installs so rapid drops do not run overlapping package manager commands.

Fixes #7914

## Test plan
- bun test packages/studio-shared/src/test/required-package.test.ts
- bunx turbo make --filter='@remotion/studio-shared' --filter='@remotion/studio'
- bun run build
- bun run stylecheck
