### PR TITLE
`@remotion/studio`: Add asset context menu

### DIFF
--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -23,6 +23,7 @@ import {projectInfoHandler} from './routes/project-info';
 import {redoHandler} from './routes/redo';
 import {registerClientRenderHandler} from './routes/register-client-render';
 import {handleRemoveRender} from './routes/remove-render';
+import {renameStaticFileHandler} from './routes/rename-static-file';
 import {reorderEffectHandler} from './routes/reorder-effect';
 import {handleRestartStudio} from './routes/restart-studio';
 import {saveEffectPropsHandler} from './routes/save-effect-props';
@@ -81,6 +82,7 @@ export const allApiRoutes: {
 	'/api/update-available': handleUpdate,
 	'/api/project-info': projectInfoHandler,
 	'/api/delete-static-file': deleteStaticFileHandler,
+	'/api/rename-static-file': renameStaticFileHandler,
 	'/api/restart-studio': handleRestartStudio,
 	'/api/install-package': handleInstallPackage,
 	'/api/insert-jsx-element': insertJsxElementHandler,

--- a/packages/studio-server/src/preview-server/routes/rename-static-file.ts
+++ b/packages/studio-server/src/preview-server/routes/rename-static-file.ts
@@ -1,0 +1,75 @@
+import {existsSync, mkdirSync, renameSync, statSync} from 'fs';
+import path from 'path';
+import type {
+	RenameStaticFileRequest,
+	RenameStaticFileResponse,
+} from '@remotion/studio-shared';
+import type {ApiHandler} from '../api-types';
+
+const resolvePublicPath = ({
+	publicDir,
+	relativePath,
+}: {
+	publicDir: string;
+	relativePath: string;
+}) => {
+	if (relativePath.length === 0) {
+		throw new Error('Path cannot be empty');
+	}
+
+	const resolved = path.join(publicDir, relativePath);
+	const relativeToPublicDir = path.relative(publicDir, resolved);
+
+	if (
+		relativeToPublicDir.startsWith('..') ||
+		path.isAbsolute(relativeToPublicDir)
+	) {
+		throw new Error(`Not allowed to write to ${relativeToPublicDir}`);
+	}
+
+	return resolved;
+};
+
+export const renameStaticFileHandler: ApiHandler<
+	RenameStaticFileRequest,
+	RenameStaticFileResponse
+> = ({input: {oldRelativePath, newRelativePath}, publicDir}) => {
+	const oldResolved = resolvePublicPath({
+		publicDir,
+		relativePath: oldRelativePath,
+	});
+	const newResolved = resolvePublicPath({
+		publicDir,
+		relativePath: newRelativePath,
+	});
+
+	if (oldResolved === newResolved) {
+		return Promise.resolve({success: true});
+	}
+
+	if (!existsSync(oldResolved)) {
+		throw new Error(`${oldRelativePath} does not exist`);
+	}
+
+	const oldStat = statSync(oldResolved);
+	if (!oldStat.isFile()) {
+		throw new Error(`${oldRelativePath} is not a file`);
+	}
+
+	if (existsSync(newResolved)) {
+		const newStat = statSync(newResolved);
+		const pointsToSameFile =
+			oldStat.dev === newStat.dev && oldStat.ino === newStat.ino;
+
+		if (!pointsToSameFile) {
+			throw new Error(`${newRelativePath} already exists`);
+		}
+	}
+
+	mkdirSync(path.dirname(newResolved), {recursive: true});
+	renameSync(oldResolved, newResolved);
+
+	return Promise.resolve({
+		success: true,
+	});
+};

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -222,6 +222,15 @@ export type DeleteStaticFileResponse = {
 	existed: boolean;
 };
 
+export type RenameStaticFileRequest = {
+	oldRelativePath: string;
+	newRelativePath: string;
+};
+
+export type RenameStaticFileResponse = {
+	success: boolean;
+};
+
 export type CanUpdateDefaultPropsResponse =
 	| {
 			canUpdate: true;
@@ -726,6 +735,10 @@ export type ApiRoutes = {
 	'/api/delete-static-file': ReqAndRes<
 		DeleteStaticFileRequest,
 		DeleteStaticFileResponse
+	>;
+	'/api/rename-static-file': ReqAndRes<
+		RenameStaticFileRequest,
+		RenameStaticFileResponse
 	>;
 	'/api/restart-studio': ReqAndRes<RestartStudioRequest, RestartStudioResponse>;
 	'/api/install-package': ReqAndRes<

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -54,6 +54,8 @@ export {
 	RemoveRenderRequest,
 	ReorderEffectRequest,
 	ReorderEffectResponse,
+	RenameStaticFileRequest,
+	RenameStaticFileResponse,
 	RestartStudioRequest,
 	RestartStudioResponse,
 	SaveEffectPropsRequest,

--- a/packages/studio/src/api/rename-static-file.ts
+++ b/packages/studio/src/api/rename-static-file.ts
@@ -1,0 +1,26 @@
+import type {RenameStaticFileResponse} from '@remotion/studio-shared';
+import {getRemotionEnvironment} from 'remotion';
+import {callApi} from '../components/call-api';
+
+export const renameStaticFile = async ({
+	oldRelativePath,
+	newRelativePath,
+}: {
+	oldRelativePath: string;
+	newRelativePath: string;
+}): Promise<RenameStaticFileResponse> => {
+	if (!getRemotionEnvironment().isStudio) {
+		throw new Error('renameStaticFile() is only available in the Studio');
+	}
+
+	if (window.remotion_isReadOnlyStudio) {
+		throw new Error('renameStaticFile() is not available in Read-Only Studio');
+	}
+
+	return callApi('/api/rename-static-file', {
+		oldRelativePath,
+		newRelativePath,
+	});
+};
+
+export {RenameStaticFileResponse};

--- a/packages/studio/src/api/rename-static-file.ts
+++ b/packages/studio/src/api/rename-static-file.ts
@@ -2,7 +2,7 @@ import type {RenameStaticFileResponse} from '@remotion/studio-shared';
 import {getRemotionEnvironment} from 'remotion';
 import {callApi} from '../components/call-api';
 
-export const renameStaticFile = async ({
+export const renameStaticFile = ({
 	oldRelativePath,
 	newRelativePath,
 }: {

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import {Internals, type StaticFile} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
+import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {
 	BACKGROUND,
 	CLEAR_HOVER,
@@ -29,11 +30,14 @@ import useAssetDragEvents, {
 import {ClipboardIcon} from '../icons/clipboard';
 import {FileIcon} from '../icons/file';
 import {CollapsedFolderIcon, ExpandedFolderIcon} from '../icons/folder';
+import {ModalsContext} from '../state/modals';
 import {SidebarContext} from '../state/sidebar';
+import {ContextMenu} from './ContextMenu';
 import {getAssetElementFromPath} from './import-assets';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 import {Row, Spacing} from './layout';
+import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
 import {openInFileExplorer} from './RenderQueue/actions';
 
@@ -273,6 +277,9 @@ const AssetSelectorItem: React.FC<{
 	const [hovered, setHovered] = useState(false);
 	const [isDragging, setIsDragging] = useState(false);
 	const {setSidebarCollapsedState} = useContext(SidebarContext);
+	const {setSelectedModal} = useContext(ModalsContext);
+	const connectionStatus = useContext(StudioServerConnectionCtx)
+		.previewServerState.type;
 	const onPointerEnter = useCallback(() => {
 		setHovered(true);
 	}, []);
@@ -374,78 +381,186 @@ const AssetSelectorItem: React.FC<{
 		return <ClipboardIcon style={revealIconStyle} color={color} />;
 	}, []);
 
+	const copyFileName = useCallback(() => {
+		copyText(item.name)
+			.then(() => {
+				showNotification(`Copied '${item.name}' to clipboard`, 1000);
+			})
+			.catch((err) => {
+				showNotification(`Could not copy: ${err.message}`, 2000);
+			});
+	}, [item.name]);
+
+	const copyStaticFilePath = useCallback(() => {
+		const content = `staticFile("${relativePath}")`;
+		copyText(content)
+			.then(() => {
+				showNotification(`Copied '${content}' to clipboard`, 1000);
+			})
+			.catch((err) => {
+				showNotification(`Could not copy: ${err.message}`, 2000);
+			});
+	}, [relativePath]);
+
+	const openAssetInExplorer = useCallback(() => {
+		if (!window.remotion_publicFolderExists) {
+			showNotification('Could not find the public folder', 2000);
+			return;
+		}
+
+		openInFileExplorer({
+			directory: window.remotion_publicFolderExists + '/' + relativePath,
+		}).catch((err) => {
+			showNotification(`Could not open file: ${err.message}`, 2000);
+		});
+	}, [relativePath]);
+
+	const serverActionDisabled =
+		readOnlyStudio || connectionStatus !== 'connected';
+
+	const contextMenu = useMemo((): ComboboxValue[] => {
+		return [
+			{
+				id: 'copy-asset-file-name',
+				keyHint: null,
+				label: 'Copy file name',
+				leftItem: null,
+				onClick: copyFileName,
+				quickSwitcherLabel: 'Copy asset file name',
+				subMenu: null,
+				type: 'item',
+				value: 'copy-asset-file-name',
+			},
+			{
+				id: 'copy-asset-static-file-path',
+				keyHint: null,
+				label: 'Copy staticFile() path',
+				leftItem: null,
+				onClick: copyStaticFilePath,
+				quickSwitcherLabel: 'Copy staticFile() path',
+				subMenu: null,
+				type: 'item',
+				value: 'copy-asset-static-file-path',
+			},
+			{
+				type: 'divider',
+				id: 'asset-file-actions-divider',
+			},
+			{
+				id: 'open-asset-in-explorer',
+				keyHint: null,
+				label: 'Open in Explorer',
+				leftItem: null,
+				onClick: openAssetInExplorer,
+				quickSwitcherLabel: 'Open asset in Explorer',
+				subMenu: null,
+				type: 'item',
+				value: 'open-asset-in-explorer',
+				disabled:
+					serverActionDisabled || window.remotion_publicFolderExists === null,
+			},
+			{
+				id: 'rename-asset',
+				keyHint: null,
+				label: 'Rename...',
+				leftItem: null,
+				onClick: () => {
+					setSelectedModal({
+						type: 'rename-static-file',
+						relativePath,
+					});
+				},
+				quickSwitcherLabel: 'Rename asset...',
+				subMenu: null,
+				type: 'item',
+				value: 'rename-asset',
+				disabled: serverActionDisabled,
+			},
+			{
+				id: 'delete-asset',
+				keyHint: null,
+				label: 'Delete...',
+				leftItem: null,
+				onClick: () => {
+					setSelectedModal({
+						type: 'delete-static-file',
+						relativePath,
+					});
+				},
+				quickSwitcherLabel: 'Delete asset...',
+				subMenu: null,
+				type: 'item',
+				value: 'delete-asset',
+				disabled: serverActionDisabled,
+			},
+		];
+	}, [
+		copyFileName,
+		copyStaticFilePath,
+		openAssetInExplorer,
+		relativePath,
+		serverActionDisabled,
+		setSelectedModal,
+	]);
+
 	const revealInExplorer: React.MouseEventHandler<HTMLButtonElement> =
-		React.useCallback(
+		useCallback(
 			(e) => {
 				e.stopPropagation();
-				openInFileExplorer({
-					directory:
-						window.remotion_publicFolderExists +
-						'/' +
-						parentFolder +
-						'/' +
-						item.name,
-				}).catch((err) => {
-					showNotification(`Could not open file: ${err.message}`, 2000);
-				});
+				openAssetInExplorer();
 			},
-			[item.name, parentFolder],
+			[openAssetInExplorer],
 		);
 
 	const copyToClipboard: React.MouseEventHandler<HTMLButtonElement> =
 		useCallback(
 			(e) => {
 				e.stopPropagation();
-				const content = `staticFile("${[parentFolder, item.name].join('/')}")`;
-				copyText(content)
-					.then(() => {
-						showNotification(`Copied '${content}' to clipboard`, 1000);
-					})
-					.catch((err) => {
-						showNotification(`Could not copy: ${err.message}`, 2000);
-					});
+				copyStaticFilePath();
 			},
-			[item.name, parentFolder],
+			[copyStaticFilePath],
 		);
 
 	return (
-		<Row align="center">
-			<div
-				ref={rowRef}
-				style={style}
-				onPointerEnter={onPointerEnter}
-				onPointerLeave={onPointerLeave}
-				onClick={onClick}
-				draggable={canDragAsset}
-				onDragStart={onDragStart}
-				onDragEnd={onDragEnd}
-				tabIndex={tabIndex}
-				title={item.name}
-			>
-				<FileIcon style={iconStyle} color={LIGHT_TEXT} />
-				<Spacing x={1} />
-				<div style={label}>{item.name}</div>
-				{hovered && !isDragging ? (
-					<>
-						<Spacing x={0.5} />
-						<InlineAction
-							title="Copy staticFile() name"
-							renderAction={renderCopyAction}
-							onClick={copyToClipboard}
-						/>
-						{readOnlyStudio ? null : (
-							<>
-								<Spacing x={0.5} />
-								<InlineAction
-									title="Open in Explorer"
-									renderAction={renderFileExplorerAction}
-									onClick={revealInExplorer}
-								/>
-							</>
-						)}
-					</>
-				) : null}
-			</div>
-		</Row>
+		<ContextMenu values={contextMenu} onOpen={null}>
+			<Row align="center">
+				<div
+					ref={rowRef}
+					style={style}
+					onPointerEnter={onPointerEnter}
+					onPointerLeave={onPointerLeave}
+					onClick={onClick}
+					draggable={canDragAsset}
+					onDragStart={onDragStart}
+					onDragEnd={onDragEnd}
+					tabIndex={tabIndex}
+					title={item.name}
+				>
+					<FileIcon style={iconStyle} color={LIGHT_TEXT} />
+					<Spacing x={1} />
+					<div style={label}>{item.name}</div>
+					{hovered && !isDragging ? (
+						<>
+							<Spacing x={0.5} />
+							<InlineAction
+								title="Copy staticFile() path"
+								renderAction={renderCopyAction}
+								onClick={copyToClipboard}
+							/>
+							{serverActionDisabled ? null : (
+								<>
+									<Spacing x={0.5} />
+									<InlineAction
+										title="Open in Explorer"
+										renderAction={renderFileExplorerAction}
+										onClick={revealInExplorer}
+									/>
+								</>
+							)}
+						</>
+					) : null}
+				</div>
+			</Row>
+		</ContextMenu>
 	);
 };

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -5,9 +5,11 @@ import {AskAiModal} from './AskAiModal';
 import {InstallPackageModal} from './InstallPackage';
 import {DeleteComposition} from './NewComposition/DeleteComposition';
 import {DeleteFolder} from './NewComposition/DeleteFolder';
+import {DeleteStaticFileModal} from './NewComposition/DeleteStaticFile';
 import {DuplicateComposition} from './NewComposition/DuplicateComposition';
 import {RenameComposition} from './NewComposition/RenameComposition';
 import {RenameFolder} from './NewComposition/RenameFolder';
+import {RenameStaticFileModal} from './NewComposition/RenameStaticFile';
 import {OverrideInputPropsModal} from './OverrideInputProps';
 import QuickSwitcher from './QuickSwitcher/QuickSwitcher';
 import {RenderStatusModal} from './RenderModal/RenderStatusModal';
@@ -51,6 +53,12 @@ export const Modals: React.FC<{
 					parentName={modalContextType.parentName}
 					stack={modalContextType.stack}
 				/>
+			)}
+			{modalContextType && modalContextType.type === 'delete-static-file' && (
+				<DeleteStaticFileModal relativePath={modalContextType.relativePath} />
+			)}
+			{modalContextType && modalContextType.type === 'rename-static-file' && (
+				<RenameStaticFileModal relativePath={modalContextType.relativePath} />
 			)}
 			{modalContextType && modalContextType.type === 'input-props-override' && (
 				<OverrideInputPropsModal />

--- a/packages/studio/src/components/NewComposition/DeleteStaticFile.tsx
+++ b/packages/studio/src/components/NewComposition/DeleteStaticFile.tsx
@@ -1,0 +1,62 @@
+import React, {useCallback, useContext, useState} from 'react';
+import {deleteStaticFile} from '../../api/delete-static-file';
+import {ModalsContext} from '../../state/modals';
+import {Button} from '../Button';
+import {Row, Spacing} from '../layout';
+import {inlineCodeSnippet} from '../Menu/styles';
+import {ModalFooterContainer} from '../ModalFooter';
+import {ModalHeader} from '../ModalHeader';
+import {showNotification} from '../Notifications/NotificationCenter';
+import {DismissableModal} from './DismissableModal';
+
+const content: React.CSSProperties = {
+	padding: 16,
+	fontSize: 14,
+	flex: 1,
+	minWidth: 500,
+};
+
+export const DeleteStaticFileModal: React.FC<{
+	readonly relativePath: string;
+}> = ({relativePath}) => {
+	const {setSelectedModal} = useContext(ModalsContext);
+	const [submitting, setSubmitting] = useState(false);
+
+	const onDelete = useCallback(() => {
+		setSubmitting(true);
+		const notification = showNotification(`Deleting ${relativePath}...`, null);
+
+		deleteStaticFile(relativePath)
+			.then(() => {
+				setSelectedModal(null);
+				notification.replaceContent(`Deleted ${relativePath}`, 2000);
+			})
+			.catch((err) => {
+				setSubmitting(false);
+				notification.replaceContent(
+					`Could not delete ${relativePath}: ${(err as Error).message}`,
+					3000,
+				);
+			});
+	}, [relativePath, setSelectedModal]);
+
+	return (
+		<DismissableModal>
+			<ModalHeader title={'Delete asset'} />
+			<div style={content}>
+				Do you want to delete the asset{' '}
+				<code style={inlineCodeSnippet}>{relativePath}</code> from your public
+				folder?
+			</div>
+			<ModalFooterContainer>
+				<Row align="center" justify="flex-end">
+					<Button onClick={() => setSelectedModal(null)}>Cancel</Button>
+					<Spacing x={1} />
+					<Button onClick={onDelete} disabled={submitting}>
+						Delete
+					</Button>
+				</Row>
+			</ModalFooterContainer>
+		</DismissableModal>
+	);
+};

--- a/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
+++ b/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
@@ -148,6 +148,8 @@ export const RenameStaticFileModal: React.FC<{
 									onChange={onNameChange}
 									type="text"
 									autoFocus
+									autoComplete="off"
+									data-1p-ignore
 									placeholder="Asset name"
 									status={validationMessage ? 'error' : 'ok'}
 									rightAlign

--- a/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
+++ b/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
@@ -116,7 +116,6 @@ export const RenameStaticFileModal: React.FC<{
 			});
 	}, [
 		canvasContent,
-		changed,
 		newRelativePath,
 		relativePath,
 		setCanvasContent,

--- a/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
+++ b/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
@@ -47,6 +47,7 @@ export const RenameStaticFileModal: React.FC<{
 	const newRelativePath = useMemo(() => {
 		return [parent, newName].filter(Boolean).join('/');
 	}, [newName, parent]);
+	const changed = newRelativePath !== relativePath;
 
 	const validationMessage = useMemo(() => {
 		const trimmedName = newName.trim();
@@ -62,10 +63,6 @@ export const RenameStaticFileModal: React.FC<{
 			return 'Name cannot include slashes';
 		}
 
-		if (newRelativePath === relativePath) {
-			return 'Choose a different name';
-		}
-
 		const existingFile = staticFiles.find((file) => {
 			return file.name === newRelativePath && file.name !== relativePath;
 		});
@@ -77,7 +74,7 @@ export const RenameStaticFileModal: React.FC<{
 		return null;
 	}, [newName, newRelativePath, relativePath, staticFiles]);
 
-	const valid = validationMessage === null;
+	const valid = changed && validationMessage === null;
 
 	const onNameChange: ChangeEventHandler<HTMLInputElement> = useCallback(
 		(e) => {
@@ -119,6 +116,7 @@ export const RenameStaticFileModal: React.FC<{
 			});
 	}, [
 		canvasContent,
+		changed,
 		newRelativePath,
 		relativePath,
 		setCanvasContent,

--- a/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
+++ b/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
@@ -1,0 +1,181 @@
+import type {ChangeEventHandler} from 'react';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
+import {Internals} from 'remotion';
+import {renameStaticFile} from '../../api/rename-static-file';
+import {pushUrl} from '../../helpers/url-state';
+import {ModalsContext} from '../../state/modals';
+import {Button} from '../Button';
+import {Row, Spacing} from '../layout';
+import {ModalFooterContainer} from '../ModalFooter';
+import {ModalHeader} from '../ModalHeader';
+import {showNotification} from '../Notifications/NotificationCenter';
+import {label, optionRow, rightRow} from '../RenderModal/layout';
+import {useStaticFiles} from '../use-static-files';
+import {DismissableModal} from './DismissableModal';
+import {RemotionInput} from './RemInput';
+import {ValidationMessage} from './ValidationMessage';
+
+const content: React.CSSProperties = {
+	padding: 12,
+	paddingRight: 12,
+	flex: 1,
+	fontSize: 13,
+	minWidth: 500,
+};
+
+const getParent = (relativePath: string) => {
+	const slashIndex = relativePath.lastIndexOf('/');
+	return slashIndex === -1 ? '' : relativePath.slice(0, slashIndex);
+};
+
+const getBaseName = (relativePath: string) => {
+	const slashIndex = relativePath.lastIndexOf('/');
+	return slashIndex === -1 ? relativePath : relativePath.slice(slashIndex + 1);
+};
+
+export const RenameStaticFileModal: React.FC<{
+	readonly relativePath: string;
+}> = ({relativePath}) => {
+	const {setSelectedModal} = useContext(ModalsContext);
+	const {canvasContent} = useContext(Internals.CompositionManager);
+	const {setCanvasContent} = useContext(Internals.CompositionSetters);
+	const staticFiles = useStaticFiles();
+	const [newName, setNewName] = useState(() => getBaseName(relativePath));
+	const [submitting, setSubmitting] = useState(false);
+
+	const parent = useMemo(() => getParent(relativePath), [relativePath]);
+	const newRelativePath = useMemo(() => {
+		return [parent, newName].filter(Boolean).join('/');
+	}, [newName, parent]);
+
+	const validationMessage = useMemo(() => {
+		const trimmedName = newName.trim();
+		if (trimmedName.length === 0) {
+			return 'Name cannot be empty';
+		}
+
+		if (trimmedName !== newName) {
+			return 'Name cannot start or end with whitespace';
+		}
+
+		if (newName.includes('/') || newName.includes('\\')) {
+			return 'Name cannot include slashes';
+		}
+
+		if (newRelativePath === relativePath) {
+			return 'Choose a different name';
+		}
+
+		const existingFile = staticFiles.find((file) => {
+			return file.name === newRelativePath && file.name !== relativePath;
+		});
+
+		if (existingFile) {
+			return 'An asset with this name already exists';
+		}
+
+		return null;
+	}, [newName, newRelativePath, relativePath, staticFiles]);
+
+	const valid = validationMessage === null;
+
+	const onNameChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+		(e) => {
+			setNewName(e.target.value);
+		},
+		[],
+	);
+
+	const onRename = useCallback(() => {
+		if (!valid) {
+			return;
+		}
+
+		setSubmitting(true);
+		const notification = showNotification(`Renaming ${relativePath}...`, null);
+
+		renameStaticFile({
+			oldRelativePath: relativePath,
+			newRelativePath,
+		})
+			.then(() => {
+				setSelectedModal(null);
+				if (
+					canvasContent?.type === 'asset' &&
+					canvasContent.asset === relativePath
+				) {
+					setCanvasContent({type: 'asset', asset: newRelativePath});
+					pushUrl(`/assets/${newRelativePath}`);
+				}
+
+				notification.replaceContent(`Renamed to ${newRelativePath}`, 2000);
+			})
+			.catch((err) => {
+				setSubmitting(false);
+				notification.replaceContent(
+					`Could not rename ${relativePath}: ${(err as Error).message}`,
+					3000,
+				);
+			});
+	}, [
+		canvasContent,
+		newRelativePath,
+		relativePath,
+		setCanvasContent,
+		setSelectedModal,
+		valid,
+	]);
+
+	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback(
+		(e) => {
+			e.preventDefault();
+			onRename();
+		},
+		[onRename],
+	);
+
+	return (
+		<DismissableModal>
+			<ModalHeader title={`Rename ${relativePath}`} />
+			<form onSubmit={onSubmit}>
+				<div style={content}>
+					<div style={optionRow}>
+						<div style={label}>Name</div>
+						<div style={rightRow}>
+							<div>
+								<RemotionInput
+									value={newName}
+									onChange={onNameChange}
+									type="text"
+									autoFocus
+									placeholder="Asset name"
+									status={validationMessage ? 'error' : 'ok'}
+									rightAlign
+								/>
+								{validationMessage ? (
+									<>
+										<Spacing y={1} block />
+										<ValidationMessage
+											align="flex-start"
+											message={validationMessage}
+											type="error"
+										/>
+									</>
+								) : null}
+							</div>
+						</div>
+					</div>
+				</div>
+				<ModalFooterContainer>
+					<Row align="center" justify="flex-end">
+						<Button onClick={() => setSelectedModal(null)}>Cancel</Button>
+						<Spacing x={1} />
+						<Button onClick={onRename} disabled={!valid || submitting}>
+							Rename
+						</Button>
+					</Row>
+				</ModalFooterContainer>
+			</form>
+		</DismissableModal>
+	);
+};

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -136,6 +136,14 @@ export type ModalState =
 			stack: string | null;
 	  }
 	| {
+			type: 'delete-static-file';
+			relativePath: string;
+	  }
+	| {
+			type: 'rename-static-file';
+			relativePath: string;
+	  }
+	| {
 			type: 'input-props-override';
 	  }
 	| KeyframeSettingsModalState


### PR DESCRIPTION
## Summary
- Add a context menu to Studio asset rows for copying the file name, copying the staticFile() path, opening in Explorer, renaming, and deleting.
- Add a rename-static-file Studio server route and modal flow for asset renames.

Fixes #8163

## Testing
- bun run build
- bun run stylecheck
