### PR TITLE
`@remotion/studio`: Fix assets root route

### DIFF
--- a/packages/studio/src/components/load-canvas-content-from-url.ts
+++ b/packages/studio/src/components/load-canvas-content-from-url.ts
@@ -1,14 +1,19 @@
 import type {CanvasContent} from 'remotion';
 import {getRoute} from '../helpers/url-state';
 
-export const deriveCanvasContentFromUrl = (): CanvasContent | null => {
-	const route = getRoute();
+export const deriveCanvasContentFromRoute = (
+	route: string,
+): CanvasContent | null => {
 	const substrings = route.split('/').filter(Boolean);
 
 	// CJK-named composition IDs are not automatically reselected after page refresh
 	const lastPart = substrings[substrings.length - 1];
 
 	if (substrings[0] === 'assets') {
+		if (!lastPart || substrings.length === 1) {
+			return null;
+		}
+
 		return {
 			type: 'asset',
 			asset: decodeURIComponent(route.substring('/assets/'.length)),
@@ -30,4 +35,8 @@ export const deriveCanvasContentFromUrl = (): CanvasContent | null => {
 	}
 
 	return null;
+};
+
+export const deriveCanvasContentFromUrl = (): CanvasContent | null => {
+	return deriveCanvasContentFromRoute(getRoute());
 };

--- a/packages/studio/src/test/load-canvas-content-from-url.test.ts
+++ b/packages/studio/src/test/load-canvas-content-from-url.test.ts
@@ -1,0 +1,16 @@
+import {expect, test} from 'bun:test';
+import {deriveCanvasContentFromRoute} from '../components/load-canvas-content-from-url';
+
+test('does not derive an asset from the assets root route', () => {
+	expect(deriveCanvasContentFromRoute('/assets')).toBe(null);
+	expect(deriveCanvasContentFromRoute('/assets/')).toBe(null);
+});
+
+test('derives an asset route', () => {
+	expect(
+		deriveCanvasContentFromRoute('/assets/folder%20name/image.png'),
+	).toEqual({
+		type: 'asset',
+		asset: 'folder name/image.png',
+	});
+});


### PR DESCRIPTION
## Summary

- Fix Studio route parsing so `/assets` and `/assets/` resolve to an empty canvas instead of an empty asset path
- Add a regression test for the assets root route

Fixes #8030.

## Testing

- `bun test packages/studio/src/test/load-canvas-content-from-url.test.ts --quiet`
- `bun run build`
- `bun run stylecheck`
