### PR TITLE
`@remotion/studio`: Add confirmation dialog

### DIFF
--- a/packages/studio/src/components/ConfirmationDialog-types.ts
+++ b/packages/studio/src/components/ConfirmationDialog-types.ts
@@ -1,0 +1,12 @@
+import type React from 'react';
+
+export type ConfirmationDialogOptions = {
+	readonly title: string;
+	readonly message: React.ReactNode;
+	readonly confirmLabel?: string;
+	readonly cancelLabel?: string;
+};
+
+export type ConfirmationDialogFunction = (
+	options: ConfirmationDialogOptions,
+) => Promise<boolean>;

--- a/packages/studio/src/components/ConfirmationDialog.tsx
+++ b/packages/studio/src/components/ConfirmationDialog.tsx
@@ -1,0 +1,145 @@
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+} from 'react';
+import {ShortcutHint} from '../error-overlay/remotion-overlay/ShortcutHint';
+import type {ConfirmationDialogState} from '../state/modals';
+import {ModalsContext} from '../state/modals';
+import {Button} from './Button';
+import type {ConfirmationDialogFunction} from './ConfirmationDialog-types';
+import {Flex, Row, Spacing} from './layout';
+import {ModalButton} from './ModalButton';
+import {ModalContainer} from './ModalContainer';
+import {ModalFooterContainer} from './ModalFooter';
+import {ModalHeader} from './ModalHeader';
+
+const content: React.CSSProperties = {
+	padding: 16,
+	fontSize: 14,
+	flex: 1,
+	minWidth: 420,
+	maxWidth: 560,
+	lineHeight: 1.4,
+};
+
+export const useConfirmationDialog = (): ConfirmationDialogFunction => {
+	const {setSelectedModal} = useContext(ModalsContext);
+
+	return useCallback(
+		(options) => {
+			return new Promise<boolean>((resolve) => {
+				let settled = false;
+				const settle = (result: boolean) => {
+					if (settled) {
+						return;
+					}
+
+					settled = true;
+					resolve(result);
+				};
+
+				setSelectedModal({
+					type: 'confirmation-dialog',
+					id: String(Math.random()),
+					title: options.title,
+					message: options.message,
+					confirmLabel: options.confirmLabel ?? 'Continue',
+					cancelLabel: options.cancelLabel ?? 'Cancel',
+					onConfirm: () => settle(true),
+					onCancel: () => settle(false),
+				});
+			});
+		},
+		[setSelectedModal],
+	);
+};
+
+export const ConfirmationDialog: React.FC<{
+	readonly state: ConfirmationDialogState;
+}> = ({state}) => {
+	const {setSelectedModal} = useContext(ModalsContext);
+	const settledRef = useRef(false);
+
+	const closeCurrentModal = useCallback(() => {
+		setSelectedModal((modal) =>
+			modal?.type === 'confirmation-dialog' && modal.id === state.id
+				? null
+				: modal,
+		);
+	}, [setSelectedModal, state.id]);
+
+	const settle = useCallback(
+		(confirmed: boolean) => {
+			if (settledRef.current) {
+				return;
+			}
+
+			settledRef.current = true;
+			closeCurrentModal();
+			if (confirmed) {
+				state.onConfirm();
+			} else {
+				state.onCancel();
+			}
+		},
+		[closeCurrentModal, state],
+	);
+
+	useEffect(() => {
+		return () => {
+			if (settledRef.current) {
+				return;
+			}
+
+			settledRef.current = true;
+			state.onCancel();
+		};
+	}, [state]);
+
+	const onCancel = useCallback(() => {
+		settle(false);
+	}, [settle]);
+
+	const onConfirm = useCallback(() => {
+		settle(true);
+	}, [settle]);
+
+	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback(
+		(e) => {
+			e.preventDefault();
+			onConfirm();
+		},
+		[onConfirm],
+	);
+
+	const cancelStyle = useMemo((): React.CSSProperties => {
+		return {
+			minWidth: 90,
+		};
+	}, []);
+
+	return (
+		<ModalContainer onOutsideClick={onCancel} onEscape={onCancel}>
+			<ModalHeader title={state.title} onClose={onCancel} />
+			<form onSubmit={onSubmit}>
+				<div style={content}>{state.message}</div>
+				<ModalFooterContainer>
+					<Row align="center">
+						<Flex />
+						<Button onClick={onCancel} style={cancelStyle}>
+							{state.cancelLabel}
+						</Button>
+						<Spacing x={1} />
+						<ModalButton onClick={onConfirm} autoFocus>
+							{state.confirmLabel}
+							<ShortcutHint keyToPress="↵" cmdOrCtrl={false} />
+						</ModalButton>
+					</Row>
+				</ModalFooterContainer>
+			</form>
+		</ModalContainer>
+	);
+};

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -2,6 +2,7 @@ import React, {useContext} from 'react';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {ModalsContext} from '../state/modals';
 import {AskAiModal} from './AskAiModal';
+import {ConfirmationDialog} from './ConfirmationDialog';
 import {InstallPackageModal} from './InstallPackage';
 import {DeleteComposition} from './NewComposition/DeleteComposition';
 import {DeleteFolder} from './NewComposition/DeleteFolder';
@@ -157,6 +158,9 @@ export const Modals: React.FC<{
 					invocationTimestamp={modalContextType.invocationTimestamp}
 					initialMode={modalContextType.mode}
 				/>
+			)}
+			{modalContextType && modalContextType.type === 'confirmation-dialog' && (
+				<ConfirmationDialog state={modalContextType} />
 			)}
 			{process.env.ASK_AI_ENABLED && <AskAiModal />}
 		</>

--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -3,6 +3,7 @@ import {useContext, useEffect} from 'react';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {useKeybinding} from '../../helpers/use-keybinding';
+import {useConfirmationDialog} from '../ConfirmationDialog';
 import {deleteSelectedTimelineItems} from './delete-selected-timeline-item';
 import {duplicateSelectedTimelineItems} from './duplicate-selected-timeline-item';
 import {resetSelectedTimelineProps} from './reset-selected-timeline-props';
@@ -22,6 +23,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
 	const {canSelect} = useTimelineSelection();
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
+	const confirm = useConfirmationDialog();
 
 	useEffect(() => {
 		if (!canSelect || previewServerState.type !== 'connected') {
@@ -58,14 +60,20 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 					overrideIdsToNodePaths: overrideIdToNodePathMappings,
 					setCodeValues,
 					clientId,
+					confirm,
 				});
 
 				if (deletePromise === null) {
 					return;
 				}
 
-				clearSelection();
-				deletePromise.catch(() => undefined);
+				deletePromise
+					.then((deleted) => {
+						if (deleted) {
+							clearSelection();
+						}
+					})
+					.catch(() => undefined);
 			},
 			commandCtrlKey: false,
 			preventDefault: true,
@@ -83,6 +91,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 
 				const duplicatePromise = duplicateSelectedTimelineItems({
 					selections: selectedItems,
+					confirm,
 				});
 
 				if (duplicatePromise === null) {
@@ -104,6 +113,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 	}, [
 		canSelect,
 		codeValues,
+		confirm,
 		currentSelection,
 		keybindings,
 		overrideIdToNodePathMappings,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -15,6 +15,7 @@ import {
 	TIMELINE_LIST_ITEM_ROW_HEIGHT,
 } from '../../helpers/timeline-layout';
 import {callApi} from '../call-api';
+import {useConfirmationDialog} from '../ConfirmationDialog';
 import {ContextMenu} from '../ContextMenu';
 import {
 	ExpandedTracksGetterContext,
@@ -138,6 +139,7 @@ export const TimelineSequenceItem: React.FC<{
 	}, [originalLocation]);
 
 	const canDeleteFromSource = Boolean(nodePath && validatedLocation?.source);
+	const confirm = useConfirmationDialog();
 
 	const deleteDisabled = useMemo(
 		() => !previewConnected || !sequence.controls || !canDeleteFromSource,
@@ -151,8 +153,10 @@ export const TimelineSequenceItem: React.FC<{
 			return;
 		}
 
-		duplicateSequencesFromSource([nodePathInfo]).catch(() => undefined);
-	}, [nodePathInfo, validatedLocation?.source]);
+		duplicateSequencesFromSource([nodePathInfo], confirm).catch(
+			() => undefined,
+		);
+	}, [confirm, nodePathInfo, validatedLocation?.source]);
 
 	const onDeleteSequenceFromSource = useCallback(async () => {
 		if (!validatedLocation?.source || !nodePath) {
@@ -160,12 +164,15 @@ export const TimelineSequenceItem: React.FC<{
 		}
 
 		if (nodePathInfo && nodePathInfo.numberOfSequencesWithThisNodePath > 1) {
-			const message =
-				'This sequence is programmatically duplicated ' +
-				nodePathInfo.numberOfSequencesWithThisNodePath +
-				' times in the code. Deleting removes all instances. Continue?';
-			// eslint-disable-next-line no-alert -- native confirm before applying duplicate codemod in .map callbacks
-			if (!window.confirm(message)) {
+			const shouldDelete = await confirm({
+				title: 'Delete sequence?',
+				message:
+					'This sequence is programmatically duplicated ' +
+					nodePathInfo.numberOfSequencesWithThisNodePath +
+					' times in the code. Deleting removes all instances. Continue?',
+				confirmLabel: 'Delete',
+			});
+			if (!shouldDelete) {
 				return;
 			}
 		}
@@ -187,7 +194,7 @@ export const TimelineSequenceItem: React.FC<{
 		} catch (err) {
 			showNotification((err as Error).message, 4000);
 		}
-	}, [nodePath, validatedLocation?.source, nodePathInfo]);
+	}, [confirm, nodePath, validatedLocation?.source, nodePathInfo]);
 
 	const mediaSrc =
 		sequence.type === 'audio' ||

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -1,6 +1,7 @@
 import type {OverrideIdToNodePaths, TSequence} from 'remotion';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {callApi} from '../call-api';
+import type {ConfirmationDialogFunction} from '../ConfirmationDialog-types';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {
 	deleteSelectedKeyframe,
@@ -11,36 +12,42 @@ import type {TimelineSelection} from './TimelineSelection';
 
 const confirmDeletingDuplicatedSequences = (
 	nodePathInfos: SequenceNodePathInfo[],
-): boolean => {
+	confirm: ConfirmationDialogFunction,
+): Promise<boolean> => {
 	const duplicatedNodePathInfos = nodePathInfos.filter(
 		(nodePathInfo) => nodePathInfo.numberOfSequencesWithThisNodePath > 1,
 	);
 	if (duplicatedNodePathInfos.length === 0) {
-		return true;
+		return Promise.resolve(true);
 	}
 
 	if (duplicatedNodePathInfos.length === 1) {
 		const [nodePathInfo] = duplicatedNodePathInfos;
-		const singleDuplicatedSequenceMessage =
-			'This sequence is programmatically duplicated ' +
-			nodePathInfo.numberOfSequencesWithThisNodePath +
-			' times in the code. Deleting removes all instances. Continue?';
-		// eslint-disable-next-line no-alert -- native confirm before deleting all instances of a duplicated sequence
-		return window.confirm(singleDuplicatedSequenceMessage);
+		return confirm({
+			title: 'Delete sequence?',
+			message:
+				'This sequence is programmatically duplicated ' +
+				nodePathInfo.numberOfSequencesWithThisNodePath +
+				' times in the code. Deleting removes all instances. Continue?',
+			confirmLabel: 'Delete',
+		});
 	}
 
-	const multipleDuplicatedSequencesMessage =
-		duplicatedNodePathInfos.length +
-		' selected sequences are programmatically duplicated in the code. Deleting removes all instances. Continue?';
-	// eslint-disable-next-line no-alert -- native confirm before deleting all instances of duplicated sequences
-	return window.confirm(multipleDuplicatedSequencesMessage);
+	return confirm({
+		title: 'Delete sequences?',
+		message:
+			duplicatedNodePathInfos.length +
+			' selected sequences are programmatically duplicated in the code. Deleting removes all instances. Continue?',
+		confirmLabel: 'Delete',
+	});
 };
 
-const deleteSequences = (
+const deleteSequences = async (
 	nodePathInfos: SequenceNodePathInfo[],
-): Promise<void> => {
-	if (!confirmDeletingDuplicatedSequences(nodePathInfos)) {
-		return Promise.resolve();
+	confirm: ConfirmationDialogFunction,
+): Promise<boolean> => {
+	if (!(await confirmDeletingDuplicatedSequences(nodePathInfos, confirm))) {
+		return false;
 	}
 
 	return callApi('/api/delete-jsx-node', {
@@ -64,9 +71,12 @@ const deleteSequences = (
 			} else {
 				showNotification(result.reason, 4000);
 			}
+
+			return true;
 		})
 		.catch((err) => {
 			showNotification((err as Error).message, 4000);
+			return true;
 		});
 };
 
@@ -82,9 +92,9 @@ const deleteEffects = (
 				type: 'all-effects';
 		  }
 	))[],
-): Promise<void> => {
+): Promise<boolean> => {
 	if (effects.length === 0) {
-		return Promise.resolve();
+		return Promise.resolve(false);
 	}
 
 	return callApi(
@@ -119,9 +129,12 @@ const deleteEffects = (
 			} else {
 				showNotification(result.reason, 4000);
 			}
+
+			return true;
 		})
 		.catch((err) => {
 			showNotification((err as Error).message, 4000);
+			return true;
 		});
 };
 
@@ -131,15 +144,17 @@ export const deleteSelectedTimelineItem = ({
 	overrideIdsToNodePaths,
 	setCodeValues,
 	clientId,
+	confirm,
 }: {
 	selection: TimelineSelection;
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
 	setCodeValues: SetCodeValues;
 	clientId: string;
-}): Promise<void> | null => {
+	confirm: ConfirmationDialogFunction;
+}): Promise<boolean> | null => {
 	if (selection.type === 'keyframe') {
-		return deleteSelectedKeyframe({
+		const promise = deleteSelectedKeyframe({
 			nodePathInfo: selection.nodePathInfo,
 			frame: selection.frame,
 			sequences,
@@ -147,11 +162,12 @@ export const deleteSelectedTimelineItem = ({
 			setCodeValues,
 			clientId,
 		});
+		return promise?.then(() => true) ?? null;
 	}
 
 	switch (selection.type) {
 		case 'sequence':
-			return deleteSequences([selection.nodePathInfo]);
+			return deleteSequences([selection.nodePathInfo], confirm);
 		case 'sequence-effect':
 			return deleteEffects([
 				{
@@ -221,13 +237,15 @@ export const deleteSelectedTimelineItems = ({
 	overrideIdsToNodePaths,
 	setCodeValues,
 	clientId,
+	confirm,
 }: {
 	selections: readonly TimelineSelection[];
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
 	setCodeValues: SetCodeValues;
 	clientId: string;
-}): Promise<void> | null => {
+	confirm: ConfirmationDialogFunction;
+}): Promise<boolean> | null => {
 	const firstSelection = selections[0];
 	if (!firstSelection) {
 		return null;
@@ -241,6 +259,7 @@ export const deleteSelectedTimelineItems = ({
 				selections
 					.filter(isSequenceRowSelection)
 					.map((selection) => selection.nodePathInfo),
+				confirm,
 			);
 		case 'sequence-effect':
 			return deleteEffects(
@@ -251,7 +270,7 @@ export const deleteSelectedTimelineItems = ({
 				})),
 			);
 		case 'keyframe': {
-			return deleteSelectedKeyframes({
+			const promise = deleteSelectedKeyframes({
 				keyframes: selections.filter(isKeyframeSelection).map((selection) => ({
 					nodePathInfo: selection.nodePathInfo,
 					frame: selection.frame,
@@ -261,6 +280,7 @@ export const deleteSelectedTimelineItems = ({
 				setCodeValues,
 				clientId,
 			});
+			return promise?.then(() => true) ?? null;
 		}
 
 		case 'sequence-prop':

--- a/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
@@ -1,30 +1,36 @@
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {callApi} from '../call-api';
+import type {ConfirmationDialogFunction} from '../ConfirmationDialog-types';
 import {showNotification} from '../Notifications/NotificationCenter';
 import type {TimelineSelection} from './TimelineSelection';
 
 const confirmDuplicatingProgrammaticallyDuplicatedSequences = (
 	nodePathInfos: readonly SequenceNodePathInfo[],
-): boolean => {
+	confirm: ConfirmationDialogFunction,
+): Promise<boolean> => {
 	if (nodePathInfos.length === 0) {
-		return true;
+		return Promise.resolve(true);
 	}
 
 	if (nodePathInfos.length === 1) {
 		const [nodePathInfo] = nodePathInfos;
-		const singleDuplicatedSequenceMessage =
-			'This sequence is programmatically duplicated ' +
-			nodePathInfo.numberOfSequencesWithThisNodePath +
-			' times in the code. Duplicating inserts another copy. Continue?';
-		// eslint-disable-next-line no-alert -- native confirm before applying duplicate codemod in .map callbacks
-		return window.confirm(singleDuplicatedSequenceMessage);
+		return confirm({
+			title: 'Duplicate sequence?',
+			message:
+				'This sequence is programmatically duplicated ' +
+				nodePathInfo.numberOfSequencesWithThisNodePath +
+				' times in the code. Duplicating inserts another copy. Continue?',
+			confirmLabel: 'Duplicate',
+		});
 	}
 
-	const multipleDuplicatedSequencesMessage =
-		nodePathInfos.length +
-		' selected sequences are programmatically duplicated in the code. Duplicating inserts another copy of each. Continue?';
-	// eslint-disable-next-line no-alert -- native confirm before applying duplicate codemod in .map callbacks
-	return window.confirm(multipleDuplicatedSequencesMessage);
+	return confirm({
+		title: 'Duplicate sequences?',
+		message:
+			nodePathInfos.length +
+			' selected sequences are programmatically duplicated in the code. Duplicating inserts another copy of each. Continue?',
+		confirmLabel: 'Duplicate',
+	});
 };
 
 const duplicateSequence = (nodePathInfo: SequenceNodePathInfo) => {
@@ -37,6 +43,7 @@ const duplicateSequence = (nodePathInfo: SequenceNodePathInfo) => {
 
 export const duplicateSequencesFromSource = (
 	nodePathInfos: readonly SequenceNodePathInfo[],
+	confirm: ConfirmationDialogFunction,
 ): Promise<void> => {
 	const programmaticallyDuplicated = nodePathInfos.filter(
 		(nodePathInfo) => nodePathInfo.numberOfSequencesWithThisNodePath > 1,
@@ -45,38 +52,38 @@ export const duplicateSequencesFromSource = (
 		(nodePathInfo) => nodePathInfo.numberOfSequencesWithThisNodePath <= 1,
 	);
 
-	const toDuplicate = [...regular];
-	if (
-		programmaticallyDuplicated.length === 0 ||
-		confirmDuplicatingProgrammaticallyDuplicatedSequences(
-			programmaticallyDuplicated,
-		)
-	) {
-		toDuplicate.push(...programmaticallyDuplicated);
-	}
+	return confirmDuplicatingProgrammaticallyDuplicatedSequences(
+		programmaticallyDuplicated,
+		confirm,
+	).then((shouldDuplicateProgrammaticSequences) => {
+		const toDuplicate = [...regular];
+		if (shouldDuplicateProgrammaticSequences) {
+			toDuplicate.push(...programmaticallyDuplicated);
+		}
 
-	if (toDuplicate.length === 0) {
-		return Promise.resolve();
-	}
+		if (toDuplicate.length === 0) {
+			return Promise.resolve();
+		}
 
-	return Promise.all(toDuplicate.map(duplicateSequence))
-		.then((results) => {
-			const failedResult = results.find((result) => !result.success);
-			if (failedResult && !failedResult.success) {
-				showNotification(failedResult.reason, 4000);
-				return;
-			}
+		return Promise.all(toDuplicate.map(duplicateSequence))
+			.then((results) => {
+				const failedResult = results.find((result) => !result.success);
+				if (failedResult && !failedResult.success) {
+					showNotification(failedResult.reason, 4000);
+					return;
+				}
 
-			showNotification(
-				toDuplicate.length === 1
-					? 'Duplicated sequence in source file'
-					: 'Duplicated sequences in source files',
-				2000,
-			);
-		})
-		.catch((err) => {
-			showNotification((err as Error).message, 4000);
-		});
+				showNotification(
+					toDuplicate.length === 1
+						? 'Duplicated sequence in source file'
+						: 'Duplicated sequences in source files',
+					2000,
+				);
+			})
+			.catch((err) => {
+				showNotification((err as Error).message, 4000);
+			});
+	});
 };
 
 export const isDuplicatableSequenceRowSelection = (
@@ -87,8 +94,10 @@ export const isDuplicatableSequenceRowSelection = (
 
 export const duplicateSelectedTimelineItems = ({
 	selections,
+	confirm,
 }: {
 	selections: readonly TimelineSelection[];
+	confirm: ConfirmationDialogFunction;
 }): Promise<void> | null => {
 	const sequenceSelections = selections.filter(
 		isDuplicatableSequenceRowSelection,
@@ -99,5 +108,6 @@ export const duplicateSelectedTimelineItems = ({
 
 	return duplicateSequencesFromSource(
 		sequenceSelections.map((selection) => selection.nodePathInfo),
+		confirm,
 	);
 };

--- a/packages/studio/src/error-overlay/remotion-overlay/ShortcutHint.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ShortcutHint.tsx
@@ -1,9 +1,10 @@
 import React, {useMemo} from 'react';
 import {areKeyboardShortcutsDisabled} from '../../helpers/use-keybinding';
 
-export const cmdOrCtrlCharacter = window.navigator.platform.startsWith('Mac')
-	? '⌘'
-	: 'Ctrl';
+export const cmdOrCtrlCharacter =
+	typeof window !== 'undefined' && window.navigator.platform.startsWith('Mac')
+		? '⌘'
+		: 'Ctrl';
 
 const container: React.CSSProperties = {
 	display: 'inline-block',

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -109,6 +109,17 @@ export type RenderModalState = {
 	renderDefaults: RenderDefaults;
 };
 
+export type ConfirmationDialogState = {
+	type: 'confirmation-dialog';
+	id: string;
+	title: string;
+	message: React.ReactNode;
+	confirmLabel: string;
+	cancelLabel: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+};
+
 export type ModalState =
 	| {
 			type: 'duplicate-comp';
@@ -158,7 +169,8 @@ export type ModalState =
 			type: 'quick-switcher';
 			mode: QuickSwitcherMode;
 			invocationTimestamp: number;
-	  };
+	  }
+	| ConfirmationDialogState;
 
 export type ModalContextType = {
 	selectedModal: ModalState | null;

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1574,6 +1574,7 @@ test('Backspace reset skips keyframed effect props without defaults', () => {
 test('Deleting mixed timeline selection types throws an assertion error', () => {
 	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
 	const effectNodePathInfo = makeNodePathInfo(['body', 1], ['effects', '0']);
+	const confirm = () => Promise.resolve(true);
 
 	expect(() =>
 		deleteSelectedTimelineItems({
@@ -1589,6 +1590,7 @@ test('Deleting mixed timeline selection types throws an assertion error', () => 
 			overrideIdsToNodePaths: {},
 			setCodeValues: () => undefined,
 			clientId: 'client',
+			confirm,
 		}),
 	).toThrow(/Assertion failed/);
 });


### PR DESCRIPTION
## Summary

- Add a reusable Studio confirmation dialog using the existing modal system.
- Replace timeline sequence delete/duplicate native confirmations with the Remotion-styled dialog while preserving cancellation behavior.

Fixes #8035
