### PR TITLE
`@remotion/studio`: Disable outline hover while dragging

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1042,8 +1042,10 @@ const clearSelectedOutlineScaleDragOverrides = ({
 
 const SelectedOutlinePolygon: React.FC<{
 	readonly allDragTargets: readonly SelectedOutlineDragTarget[];
+	readonly dragging: boolean;
 	readonly hovered: boolean;
 	readonly outline: SelectedOutline;
+	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onHoverChange: (key: string | null) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
@@ -1053,8 +1055,10 @@ const SelectedOutlinePolygon: React.FC<{
 	readonly target: SelectedOutlineTarget | undefined;
 }> = ({
 	allDragTargets,
+	dragging,
 	hovered,
 	outline,
+	onDraggingChange,
 	onHoverChange,
 	onSelect,
 	scale,
@@ -1096,6 +1100,8 @@ const SelectedOutlinePolygon: React.FC<{
 			if (drag === null || interaction.shiftKey || interaction.toggleKey) {
 				return;
 			}
+
+			onDraggingChange(true);
 
 			const startPointerX = event.clientX;
 			const startPointerY = event.clientY;
@@ -1144,6 +1150,7 @@ const SelectedOutlinePolygon: React.FC<{
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
+				onDraggingChange(false);
 
 				const changes = getSelectedOutlineDragChanges({
 					dragStates,
@@ -1215,6 +1222,7 @@ const SelectedOutlinePolygon: React.FC<{
 			clearDragOverrides,
 			drag,
 			getDragOverrides,
+			onDraggingChange,
 			onSelect,
 			scale,
 			selected,
@@ -1233,8 +1241,16 @@ const SelectedOutlinePolygon: React.FC<{
 			strokeWidth={2}
 			vectorEffect="non-scaling-stroke"
 			pointerEvents={target === undefined ? undefined : 'all'}
-			onPointerEnter={() => onHoverChange(outline.key)}
-			onPointerLeave={() => onHoverChange(null)}
+			onPointerEnter={() => {
+				if (!dragging) {
+					onHoverChange(outline.key);
+				}
+			}}
+			onPointerLeave={() => {
+				if (!dragging) {
+					onHoverChange(null);
+				}
+			}}
 			onPointerDown={onPointerDown}
 		/>
 	);
@@ -1242,8 +1258,10 @@ const SelectedOutlinePolygon: React.FC<{
 
 const SelectedOutlineScaleEdgeLine: React.FC<{
 	readonly allScaleDragTargets: readonly SelectedOutlineScaleDragTarget[];
+	readonly dragging: boolean;
 	readonly edge: SelectedOutlineScaleEdge;
 	readonly outline: SelectedOutline;
+	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onHoverChange: (key: string | null) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
@@ -1252,8 +1270,10 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 	readonly target: SelectedOutlineTarget | undefined;
 }> = ({
 	allScaleDragTargets,
+	dragging,
 	edge,
 	outline,
+	onDraggingChange,
 	onHoverChange,
 	onSelect,
 	target,
@@ -1290,6 +1310,8 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			if (interaction.shiftKey || interaction.toggleKey) {
 				return;
 			}
+
+			onDraggingChange(true);
 
 			const startPointer = {x: event.clientX, y: event.clientY};
 			const dragStates = getSelectedOutlineScaleDragStates({
@@ -1335,6 +1357,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
+				onDraggingChange(false);
 
 				const changes = getSelectedOutlineScaleDragChanges({
 					dragStates,
@@ -1385,6 +1408,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			clearDragOverrides,
 			edgeInfo,
 			getDragOverrides,
+			onDraggingChange,
 			onSelect,
 			scaleDrag,
 			selected,
@@ -1409,8 +1433,16 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			vectorEffect="non-scaling-stroke"
 			pointerEvents="stroke"
 			cursor={edgeInfo.cursor}
-			onPointerEnter={() => onHoverChange(outline.key)}
-			onPointerLeave={() => onHoverChange(null)}
+			onPointerEnter={() => {
+				if (!dragging) {
+					onHoverChange(outline.key);
+				}
+			}}
+			onPointerLeave={() => {
+				if (!dragging) {
+					onHoverChange(null);
+				}
+			}}
 			onPointerDown={onPointerDown}
 		/>
 	);
@@ -1458,9 +1490,10 @@ const SelectedUvHandleConnectionLines: React.FC<{
 };
 
 const SelectedUvHandleCircle: React.FC<{
+	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly handle: SelectedOutlineUvHandle;
 	readonly outline: SelectedOutline;
-}> = ({handle, outline}) => {
+}> = ({handle, onDraggingChange, outline}) => {
 	const {setEffectDragOverrides, clearEffectDragOverrides, setCodeValues} =
 		useContext(Internals.VisualModeSettersContext);
 	const position = useMemo(
@@ -1484,6 +1517,7 @@ const SelectedUvHandleCircle: React.FC<{
 
 			const svgRect = svg.getBoundingClientRect();
 			let lastValue: UvCoordinate | null = null;
+			onDraggingChange(true);
 			const defaultValue =
 				handle.fieldDefault !== undefined
 					? JSON.stringify(handle.fieldDefault)
@@ -1520,6 +1554,7 @@ const SelectedUvHandleCircle: React.FC<{
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
+				onDraggingChange(false);
 
 				const stringifiedValue =
 					lastValue === null ? null : JSON.stringify(lastValue);
@@ -1558,6 +1593,7 @@ const SelectedUvHandleCircle: React.FC<{
 		[
 			clearEffectDragOverrides,
 			handle,
+			onDraggingChange,
 			outline.points,
 			setCodeValues,
 			setEffectDragOverrides,
@@ -1598,7 +1634,15 @@ export const SelectedOutlineOverlay: React.FC<{
 	const [hoveredOutlineKey, setHoveredOutlineKey] = useState<string | null>(
 		null,
 	);
+	const [draggingOutline, setDraggingOutline] = useState(false);
 	const overlayRef = useRef<SVGSVGElement>(null);
+
+	const onDraggingChange = React.useCallback((dragging: boolean) => {
+		setDraggingOutline(dragging);
+		if (dragging) {
+			setHoveredOutlineKey(null);
+		}
+	}, []);
 
 	const outlineTargets = useMemo((): SelectedOutlineTarget[] => {
 		if (!ENABLE_OUTLINES) {
@@ -1788,8 +1832,10 @@ export const SelectedOutlineOverlay: React.FC<{
 				<React.Fragment key={outline.key}>
 					<SelectedOutlinePolygon
 						allDragTargets={allDragTargets}
+						dragging={draggingOutline}
 						hovered={hoveredOutlineKey === outline.key}
 						outline={outline}
+						onDraggingChange={onDraggingChange}
 						onHoverChange={setHoveredOutlineKey}
 						onSelect={selectItem}
 						scale={scale}
@@ -1801,8 +1847,10 @@ export const SelectedOutlineOverlay: React.FC<{
 								<SelectedOutlineScaleEdgeLine
 									key={edge}
 									allScaleDragTargets={allScaleDragTargets}
+									dragging={draggingOutline}
 									edge={edge}
 									outline={outline}
+									onDraggingChange={onDraggingChange}
 									onHoverChange={setHoveredOutlineKey}
 									onSelect={selectItem}
 									target={targetsByKey.get(outline.key)}
@@ -1823,6 +1871,7 @@ export const SelectedOutlineOverlay: React.FC<{
 											<SelectedUvHandleCircle
 												key={`${handle.effectIndex}-${handle.fieldKey}`}
 												handle={handle}
+												onDraggingChange={onDraggingChange}
 												outline={outline}
 											/>
 										))}


### PR DESCRIPTION
## Summary
- Disable hover-reveal outline updates while a canvas outline interaction is being dragged
- Clear existing outline hover state when move, scale, or UV handle drags start

Fixes #8115.

## Testing
- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio' --no-update-notifier`
