### PR TITLE
`@remotion/studio`: Support dragging remote images into canvas

### DIFF
--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -12,6 +12,7 @@ import {deleteEffectHandler} from './routes/delete-effect';
 import {deleteJsxNodeHandler} from './routes/delete-jsx-node';
 import {deleteKeyframesHandler} from './routes/delete-keyframes';
 import {deleteStaticFileHandler} from './routes/delete-static-file';
+import {downloadRemoteAssetHandler} from './routes/download-remote-asset';
 import {duplicateJsxNodeHandler} from './routes/duplicate-jsx-node';
 import {insertJsxElementHandler} from './routes/insert-jsx-element';
 import {handleInstallPackage} from './routes/install-dependency';
@@ -84,6 +85,7 @@ export const allApiRoutes: {
 	'/api/restart-studio': handleRestartStudio,
 	'/api/install-package': handleInstallPackage,
 	'/api/insert-jsx-element': insertJsxElementHandler,
+	'/api/download-remote-asset': downloadRemoteAssetHandler,
 	'/api/undo': undoHandler,
 	'/api/redo': redoHandler,
 };

--- a/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
+++ b/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
@@ -1,0 +1,488 @@
+import {lookup} from 'node:dns/promises';
+import {existsSync, mkdirSync, statSync, writeFileSync} from 'node:fs';
+import {isIP} from 'node:net';
+import path from 'node:path';
+import type {
+	DownloadRemoteAssetRequest,
+	DownloadRemoteAssetResponse,
+	InsertableCompositionElement,
+} from '@remotion/studio-shared';
+import type {ApiHandler} from '../api-types';
+import {validateSameOrigin} from '../validate-same-origin';
+
+const maxRemoteAssetSize = 50 * 1024 * 1024;
+const remoteAssetDownloadTimeout = 15000;
+
+type RemoteImageFileType = {
+	type: 'png' | 'jpeg' | 'webp' | 'bmp' | 'gif';
+	dimensions: {width: number; height: number} | null;
+};
+
+const matchesPattern = (pattern: Uint8Array) => {
+	return (data: Uint8Array) => {
+		return pattern.every((value, index) => data[index] === value);
+	};
+};
+
+const getPngDimensions = (pngData: Uint8Array) => {
+	if (pngData.length < 24) {
+		return null;
+	}
+
+	const view = new DataView(pngData.buffer, pngData.byteOffset);
+	const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
+	for (let i = 0; i < 8; i++) {
+		if (pngData[i] !== pngSignature[i]) {
+			return null;
+		}
+	}
+
+	return {
+		width: view.getUint32(16, false),
+		height: view.getUint32(20, false),
+	};
+};
+
+const getJpegDimensions = (data: Uint8Array) => {
+	const readUint16BE = (index: number): number => {
+		return (data[index] << 8) | data[index + 1];
+	};
+
+	if (data.length < 4 || readUint16BE(0) !== 0xffd8) {
+		return null;
+	}
+
+	let offset = 2;
+	while (offset + 9 < data.length) {
+		if (data[offset] !== 0xff) {
+			offset++;
+			continue;
+		}
+
+		const marker = data[offset + 1];
+		if (marker === 0xc0 || marker === 0xc2) {
+			const height = readUint16BE(offset + 5);
+			const width = readUint16BE(offset + 7);
+			return {width, height};
+		}
+
+		if (offset + 3 >= data.length) {
+			return null;
+		}
+
+		const length = readUint16BE(offset + 2);
+		if (length <= 0) {
+			return null;
+		}
+
+		offset += length + 2;
+	}
+
+	return null;
+};
+
+const getGifDimensions = (data: Uint8Array) => {
+	if (data.length < 10) {
+		return null;
+	}
+
+	const view = new DataView(data.buffer, data.byteOffset);
+	return {
+		width: view.getUint16(6, true),
+		height: view.getUint16(8, true),
+	};
+};
+
+const getWebPDimensions = (bytes: Uint8Array) => {
+	if (bytes.length < 30) {
+		return null;
+	}
+
+	if (
+		bytes[0] !== 0x52 ||
+		bytes[1] !== 0x49 ||
+		bytes[2] !== 0x46 ||
+		bytes[3] !== 0x46 ||
+		bytes[8] !== 0x57 ||
+		bytes[9] !== 0x45 ||
+		bytes[10] !== 0x42 ||
+		bytes[11] !== 0x50
+	) {
+		return null;
+	}
+
+	if (bytes[12] === 0x56 && bytes[13] === 0x50 && bytes[14] === 0x38) {
+		if (bytes[15] === 0x20) {
+			return {
+				width: bytes[26] | ((bytes[27] << 8) & 0x3fff),
+				height: bytes[28] | ((bytes[29] << 8) & 0x3fff),
+			};
+		}
+	}
+
+	if (
+		bytes[12] === 0x56 &&
+		bytes[13] === 0x50 &&
+		bytes[14] === 0x38 &&
+		bytes[15] === 0x4c
+	) {
+		return {
+			width: 1 + (bytes[21] | ((bytes[22] & 0x3f) << 8)),
+			height:
+				1 +
+				(((bytes[22] & 0xc0) >> 6) |
+					(bytes[23] << 2) |
+					((bytes[24] & 0x0f) << 10)),
+		};
+	}
+
+	if (
+		bytes[12] === 0x56 &&
+		bytes[13] === 0x50 &&
+		bytes[14] === 0x38 &&
+		bytes[15] === 0x58
+	) {
+		return {
+			width: 1 + (bytes[24] | (bytes[25] << 8) | (bytes[26] << 16)),
+			height: 1 + (bytes[27] | (bytes[28] << 8) | (bytes[29] << 16)),
+		};
+	}
+
+	return null;
+};
+
+const getBmpDimensions = (bmpData: Uint8Array) => {
+	if (bmpData.length < 26) {
+		return null;
+	}
+
+	const view = new DataView(bmpData.buffer, bmpData.byteOffset);
+
+	return {
+		width: view.getUint32(18, true),
+		height: Math.abs(view.getInt32(22, true)),
+	};
+};
+
+export const detectRemoteImageFileType = (
+	data: Uint8Array,
+): RemoteImageFileType | null => {
+	if (matchesPattern(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))(data)) {
+		return {type: 'png', dimensions: getPngDimensions(data)};
+	}
+
+	if (matchesPattern(new Uint8Array([0xff, 0xd8]))(data)) {
+		return {type: 'jpeg', dimensions: getJpegDimensions(data)};
+	}
+
+	if (matchesPattern(new Uint8Array([0x47, 0x49, 0x46, 0x38]))(data)) {
+		return {type: 'gif', dimensions: getGifDimensions(data)};
+	}
+
+	if (matchesPattern(new Uint8Array([0x52, 0x49, 0x46, 0x46]))(data)) {
+		return {type: 'webp', dimensions: getWebPDimensions(data)};
+	}
+
+	if (matchesPattern(new Uint8Array([0x42, 0x4d]))(data)) {
+		return {type: 'bmp', dimensions: getBmpDimensions(data)};
+	}
+
+	return null;
+};
+
+const extensionsForFileType: Record<RemoteImageFileType['type'], string[]> = {
+	png: ['png'],
+	jpeg: ['jpg', 'jpeg'],
+	webp: ['webp'],
+	bmp: ['bmp'],
+	gif: ['gif'],
+};
+
+const safeDecodeURIComponent = (value: string) => {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+};
+
+const sanitizeAssetFilename = (filename: string) => {
+	return Array.from(filename)
+		.map((character) => {
+			const charCode = character.charCodeAt(0);
+			return charCode <= 31 || '<>:"/\\|?*'.includes(character)
+				? '-'
+				: character;
+		})
+		.join('')
+		.trim()
+		.replace(/^[. ]+|[. ]+$/g, '');
+};
+
+export const getRemoteAssetFilename = ({
+	fileType,
+	url,
+}: {
+	fileType: RemoteImageFileType;
+	url: URL;
+}) => {
+	const basename = safeDecodeURIComponent(path.posix.basename(url.pathname));
+	const sanitized = sanitizeAssetFilename(basename);
+	const filenameWithoutFallback = sanitized === '' ? 'image' : sanitized;
+	const extensions = extensionsForFileType[fileType.type];
+	const extension = path
+		.extname(filenameWithoutFallback)
+		.slice(1)
+		.toLowerCase();
+
+	if (extensions.includes(extension)) {
+		return filenameWithoutFallback;
+	}
+
+	const withoutExtension = extension
+		? filenameWithoutFallback.slice(0, -(extension.length + 1))
+		: filenameWithoutFallback;
+	const safeName = withoutExtension === '' ? 'image' : withoutExtension;
+	return `${safeName}.${extensions[0]}`;
+};
+
+const isForbiddenIpv4Address = (address: string) => {
+	const parts = address.split('.').map((part) => Number(part));
+	if (
+		parts.length !== 4 ||
+		parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+	) {
+		return true;
+	}
+
+	const [first, second] = parts;
+	return (
+		first === 0 ||
+		first === 10 ||
+		first === 127 ||
+		(first === 100 && second >= 64 && second <= 127) ||
+		(first === 169 && second === 254) ||
+		(first === 172 && second >= 16 && second <= 31) ||
+		(first === 192 && second === 168) ||
+		(first === 198 && (second === 18 || second === 19)) ||
+		first >= 224
+	);
+};
+
+const isForbiddenIpv6Address = (address: string) => {
+	const normalized = address.toLowerCase();
+	const mappedIpv4 = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)?.[1];
+	if (mappedIpv4) {
+		return isForbiddenIpv4Address(mappedIpv4);
+	}
+
+	return (
+		normalized === '::' ||
+		normalized === '::1' ||
+		normalized.startsWith('fc') ||
+		normalized.startsWith('fd') ||
+		normalized.startsWith('fe8') ||
+		normalized.startsWith('fe9') ||
+		normalized.startsWith('fea') ||
+		normalized.startsWith('feb')
+	);
+};
+
+const ensureRemoteUrlIsAllowed = async (url: URL) => {
+	if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+		throw new Error('Only HTTP(S) URLs can be imported');
+	}
+
+	if (url.username !== '' || url.password !== '') {
+		throw new Error('Remote asset URLs cannot include credentials');
+	}
+
+	if (url.hostname === 'localhost' || url.hostname.endsWith('.localhost')) {
+		throw new Error('Localhost URLs cannot be imported');
+	}
+
+	const hostnameAsIp = isIP(url.hostname);
+	if (hostnameAsIp === 4 && isForbiddenIpv4Address(url.hostname)) {
+		throw new Error('Private IP addresses cannot be imported');
+	}
+
+	if (hostnameAsIp === 6 && isForbiddenIpv6Address(url.hostname)) {
+		throw new Error('Private IP addresses cannot be imported');
+	}
+
+	const addresses = hostnameAsIp
+		? [{address: url.hostname, family: hostnameAsIp}]
+		: await lookup(url.hostname, {all: true});
+
+	if (addresses.length === 0) {
+		throw new Error(`Could not resolve ${url.hostname}`);
+	}
+
+	for (const address of addresses) {
+		if (
+			(address.family === 4 && isForbiddenIpv4Address(address.address)) ||
+			(address.family === 6 && isForbiddenIpv6Address(address.address))
+		) {
+			throw new Error('Private IP addresses cannot be imported');
+		}
+	}
+};
+
+const readRemoteAsset = async ({
+	response,
+	abort,
+}: {
+	response: Response;
+	abort: () => void;
+}) => {
+	const contentLength = response.headers.get('content-length');
+	if (contentLength !== null && Number(contentLength) > maxRemoteAssetSize) {
+		abort();
+		throw new Error('Remote asset exceeds the 50MB size limit');
+	}
+
+	if (!response.body) {
+		const buffer = await response.arrayBuffer();
+		if (buffer.byteLength > maxRemoteAssetSize) {
+			throw new Error('Remote asset exceeds the 50MB size limit');
+		}
+
+		return new Uint8Array(buffer);
+	}
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let size = 0;
+
+	while (true) {
+		const {done, value} = await reader.read();
+		if (done) {
+			break;
+		}
+
+		if (!value) {
+			continue;
+		}
+
+		size += value.byteLength;
+		if (size > maxRemoteAssetSize) {
+			abort();
+			await reader.cancel();
+			throw new Error('Remote asset exceeds the 50MB size limit');
+		}
+
+		chunks.push(value);
+	}
+
+	const result = new Uint8Array(size);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+
+	return result;
+};
+
+export const downloadRemoteAssetHandler: ApiHandler<
+	DownloadRemoteAssetRequest,
+	DownloadRemoteAssetResponse
+> = async ({input, publicDir, request}) => {
+	validateSameOrigin(request);
+
+	if (typeof input.url !== 'string') {
+		throw new Error('No `url` provided');
+	}
+
+	if (typeof fetch !== 'function') {
+		throw new Error(
+			'Downloading remote assets requires Node.js 18 or newer. Drag a local file instead.',
+		);
+	}
+
+	const url = new URL(input.url);
+	await ensureRemoteUrlIsAllowed(url);
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => {
+		controller.abort();
+	}, remoteAssetDownloadTimeout);
+
+	let contents: Uint8Array;
+	try {
+		const response = await fetch(url, {
+			headers: {
+				accept: 'image/png,image/jpeg,image/webp,image/bmp,image/gif',
+			},
+			redirect: 'manual',
+			signal: controller.signal,
+		});
+
+		if (response.status >= 300 && response.status < 400) {
+			throw new Error('Remote asset redirects are not supported');
+		}
+
+		if (!response.ok) {
+			throw new Error(`Could not download remote asset: ${response.status}`);
+		}
+
+		contents = await readRemoteAsset({
+			response,
+			abort: () => controller.abort(),
+		});
+	} catch (err) {
+		if (err instanceof Error && err.name === 'AbortError') {
+			throw new Error('Timed out downloading remote asset');
+		}
+
+		throw err;
+	} finally {
+		clearTimeout(timeout);
+	}
+
+	const fileType = detectRemoteImageFileType(contents);
+	if (fileType === null) {
+		throw new Error('Remote asset is not a supported image');
+	}
+
+	const assetPath = getRemoteAssetFilename({fileType, url});
+	const absolutePath = path.join(publicDir, assetPath);
+	const relativeToPublicDir = path.relative(publicDir, absolutePath);
+	if (
+		relativeToPublicDir.startsWith('..') ||
+		path.isAbsolute(relativeToPublicDir)
+	) {
+		throw new Error(`Not allowed to write to ${relativeToPublicDir}`);
+	}
+
+	const exists = existsSync(absolutePath);
+	if (exists) {
+		const stat = statSync(absolutePath);
+		if (!stat.isFile()) {
+			throw new Error(`${assetPath} already exists and is not a file`);
+		}
+
+		if (stat.size !== contents.byteLength) {
+			throw new Error(
+				`File with name ${assetPath} already exists and is different`,
+			);
+		}
+	} else {
+		mkdirSync(path.dirname(absolutePath), {recursive: true});
+		writeFileSync(absolutePath, contents);
+	}
+
+	const element: InsertableCompositionElement = {
+		type: 'asset',
+		assetType: fileType.type === 'gif' ? 'gif' : 'image',
+		src: assetPath,
+		dimensions: fileType.dimensions,
+	};
+
+	return {
+		assetPath,
+		sizeInBytes: contents.byteLength,
+		created: !exists,
+		element,
+	};
+};

--- a/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
+++ b/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
@@ -2,195 +2,24 @@ import {lookup} from 'node:dns/promises';
 import {existsSync, mkdirSync, statSync, writeFileSync} from 'node:fs';
 import {isIP} from 'node:net';
 import path from 'node:path';
-import type {
-	DownloadRemoteAssetRequest,
-	DownloadRemoteAssetResponse,
-	InsertableCompositionElement,
+import {
+	detectFileType,
+	isImageFileType,
+	type DownloadRemoteAssetRequest,
+	type DownloadRemoteAssetResponse,
+	type ImageFileType,
+	type InsertableCompositionElement,
 } from '@remotion/studio-shared';
 import type {ApiHandler} from '../api-types';
 import {validateSameOrigin} from '../validate-same-origin';
 
 const maxRemoteAssetSize = 50 * 1024 * 1024;
 const remoteAssetDownloadTimeout = 15000;
+const maxRemoteAssetRedirects = 5;
+const remoteAssetAcceptHeader =
+	'image/png,image/jpeg,image/webp,image/bmp,image/gif';
 
-type RemoteImageFileType = {
-	type: 'png' | 'jpeg' | 'webp' | 'bmp' | 'gif';
-	dimensions: {width: number; height: number} | null;
-};
-
-const matchesPattern = (pattern: Uint8Array) => {
-	return (data: Uint8Array) => {
-		return pattern.every((value, index) => data[index] === value);
-	};
-};
-
-const getPngDimensions = (pngData: Uint8Array) => {
-	if (pngData.length < 24) {
-		return null;
-	}
-
-	const view = new DataView(pngData.buffer, pngData.byteOffset);
-	const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
-	for (let i = 0; i < 8; i++) {
-		if (pngData[i] !== pngSignature[i]) {
-			return null;
-		}
-	}
-
-	return {
-		width: view.getUint32(16, false),
-		height: view.getUint32(20, false),
-	};
-};
-
-const getJpegDimensions = (data: Uint8Array) => {
-	const readUint16BE = (index: number): number => {
-		return (data[index] << 8) | data[index + 1];
-	};
-
-	if (data.length < 4 || readUint16BE(0) !== 0xffd8) {
-		return null;
-	}
-
-	let offset = 2;
-	while (offset + 9 < data.length) {
-		if (data[offset] !== 0xff) {
-			offset++;
-			continue;
-		}
-
-		const marker = data[offset + 1];
-		if (marker === 0xc0 || marker === 0xc2) {
-			const height = readUint16BE(offset + 5);
-			const width = readUint16BE(offset + 7);
-			return {width, height};
-		}
-
-		if (offset + 3 >= data.length) {
-			return null;
-		}
-
-		const length = readUint16BE(offset + 2);
-		if (length <= 0) {
-			return null;
-		}
-
-		offset += length + 2;
-	}
-
-	return null;
-};
-
-const getGifDimensions = (data: Uint8Array) => {
-	if (data.length < 10) {
-		return null;
-	}
-
-	const view = new DataView(data.buffer, data.byteOffset);
-	return {
-		width: view.getUint16(6, true),
-		height: view.getUint16(8, true),
-	};
-};
-
-const getWebPDimensions = (bytes: Uint8Array) => {
-	if (bytes.length < 30) {
-		return null;
-	}
-
-	if (
-		bytes[0] !== 0x52 ||
-		bytes[1] !== 0x49 ||
-		bytes[2] !== 0x46 ||
-		bytes[3] !== 0x46 ||
-		bytes[8] !== 0x57 ||
-		bytes[9] !== 0x45 ||
-		bytes[10] !== 0x42 ||
-		bytes[11] !== 0x50
-	) {
-		return null;
-	}
-
-	if (bytes[12] === 0x56 && bytes[13] === 0x50 && bytes[14] === 0x38) {
-		if (bytes[15] === 0x20) {
-			return {
-				width: bytes[26] | ((bytes[27] << 8) & 0x3fff),
-				height: bytes[28] | ((bytes[29] << 8) & 0x3fff),
-			};
-		}
-	}
-
-	if (
-		bytes[12] === 0x56 &&
-		bytes[13] === 0x50 &&
-		bytes[14] === 0x38 &&
-		bytes[15] === 0x4c
-	) {
-		return {
-			width: 1 + (bytes[21] | ((bytes[22] & 0x3f) << 8)),
-			height:
-				1 +
-				(((bytes[22] & 0xc0) >> 6) |
-					(bytes[23] << 2) |
-					((bytes[24] & 0x0f) << 10)),
-		};
-	}
-
-	if (
-		bytes[12] === 0x56 &&
-		bytes[13] === 0x50 &&
-		bytes[14] === 0x38 &&
-		bytes[15] === 0x58
-	) {
-		return {
-			width: 1 + (bytes[24] | (bytes[25] << 8) | (bytes[26] << 16)),
-			height: 1 + (bytes[27] | (bytes[28] << 8) | (bytes[29] << 16)),
-		};
-	}
-
-	return null;
-};
-
-const getBmpDimensions = (bmpData: Uint8Array) => {
-	if (bmpData.length < 26) {
-		return null;
-	}
-
-	const view = new DataView(bmpData.buffer, bmpData.byteOffset);
-
-	return {
-		width: view.getUint32(18, true),
-		height: Math.abs(view.getInt32(22, true)),
-	};
-};
-
-export const detectRemoteImageFileType = (
-	data: Uint8Array,
-): RemoteImageFileType | null => {
-	if (matchesPattern(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))(data)) {
-		return {type: 'png', dimensions: getPngDimensions(data)};
-	}
-
-	if (matchesPattern(new Uint8Array([0xff, 0xd8]))(data)) {
-		return {type: 'jpeg', dimensions: getJpegDimensions(data)};
-	}
-
-	if (matchesPattern(new Uint8Array([0x47, 0x49, 0x46, 0x38]))(data)) {
-		return {type: 'gif', dimensions: getGifDimensions(data)};
-	}
-
-	if (matchesPattern(new Uint8Array([0x52, 0x49, 0x46, 0x46]))(data)) {
-		return {type: 'webp', dimensions: getWebPDimensions(data)};
-	}
-
-	if (matchesPattern(new Uint8Array([0x42, 0x4d]))(data)) {
-		return {type: 'bmp', dimensions: getBmpDimensions(data)};
-	}
-
-	return null;
-};
-
-const extensionsForFileType: Record<RemoteImageFileType['type'], string[]> = {
+const extensionsForFileType: Record<ImageFileType['type'], string[]> = {
 	png: ['png'],
 	jpeg: ['jpg', 'jpeg'],
 	webp: ['webp'],
@@ -223,7 +52,7 @@ export const getRemoteAssetFilename = ({
 	fileType,
 	url,
 }: {
-	fileType: RemoteImageFileType;
+	fileType: ImageFileType;
 	url: URL;
 }) => {
 	const basename = safeDecodeURIComponent(path.posix.basename(url.pathname));
@@ -328,6 +157,46 @@ const ensureRemoteUrlIsAllowed = async (url: URL) => {
 	}
 };
 
+const fetchRemoteAsset = async ({
+	signal,
+	url,
+}: {
+	signal: AbortSignal;
+	url: URL;
+}) => {
+	let currentUrl = url;
+
+	for (let redirects = 0; redirects <= maxRemoteAssetRedirects; redirects++) {
+		await ensureRemoteUrlIsAllowed(currentUrl);
+
+		const response = await fetch(currentUrl, {
+			headers: {
+				accept: remoteAssetAcceptHeader,
+			},
+			redirect: 'manual',
+			signal,
+		});
+
+		if (response.status < 300 || response.status >= 400) {
+			return response;
+		}
+
+		const location = response.headers.get('location');
+		if (location === null) {
+			throw new Error('Remote asset redirect is missing a Location header');
+		}
+
+		if (redirects === maxRemoteAssetRedirects) {
+			throw new Error('Remote asset redirected too many times');
+		}
+
+		await response.body?.cancel();
+		currentUrl = new URL(location, currentUrl);
+	}
+
+	throw new Error('Remote asset redirected too many times');
+};
+
 const readRemoteAsset = async ({
 	response,
 	abort,
@@ -401,7 +270,6 @@ export const downloadRemoteAssetHandler: ApiHandler<
 	}
 
 	const url = new URL(input.url);
-	await ensureRemoteUrlIsAllowed(url);
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => {
@@ -410,17 +278,10 @@ export const downloadRemoteAssetHandler: ApiHandler<
 
 	let contents: Uint8Array;
 	try {
-		const response = await fetch(url, {
-			headers: {
-				accept: 'image/png,image/jpeg,image/webp,image/bmp,image/gif',
-			},
-			redirect: 'manual',
+		const response = await fetchRemoteAsset({
 			signal: controller.signal,
+			url,
 		});
-
-		if (response.status >= 300 && response.status < 400) {
-			throw new Error('Remote asset redirects are not supported');
-		}
 
 		if (!response.ok) {
 			throw new Error(`Could not download remote asset: ${response.status}`);
@@ -440,8 +301,8 @@ export const downloadRemoteAssetHandler: ApiHandler<
 		clearTimeout(timeout);
 	}
 
-	const fileType = detectRemoteImageFileType(contents);
-	if (fileType === null) {
+	const fileType = detectFileType(contents);
+	if (!isImageFileType(fileType)) {
 		throw new Error('Remote asset is not a supported image');
 	}
 

--- a/packages/studio-server/src/test/download-remote-asset.test.ts
+++ b/packages/studio-server/src/test/download-remote-asset.test.ts
@@ -1,25 +1,12 @@
 import {expect, test} from 'bun:test';
+import {mkdtempSync, rmSync} from 'node:fs';
+import type {IncomingMessage, ServerResponse} from 'node:http';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
 import {
-	detectRemoteImageFileType,
+	downloadRemoteAssetHandler,
 	getRemoteAssetFilename,
 } from '../preview-server/routes/download-remote-asset';
-
-test('detects remote PNG dimensions', () => {
-	const png = new Uint8Array(24);
-	png.set([0x89, 0x50, 0x4e, 0x47, 13, 10, 26, 10], 0);
-	png.set([0, 0, 0, 13], 8);
-	png.set([0x49, 0x48, 0x44, 0x52], 12);
-	png.set([0, 0, 7, 128], 16);
-	png.set([0, 0, 4, 56], 20);
-
-	expect(detectRemoteImageFileType(png)).toEqual({
-		type: 'png',
-		dimensions: {
-			width: 1920,
-			height: 1080,
-		},
-	});
-});
 
 test('sanitizes remote asset filenames and uses detected extensions', () => {
 	expect(
@@ -35,4 +22,130 @@ test('sanitizes remote asset filenames and uses detected extensions', () => {
 			url: new URL('https://example.com/photos/image'),
 		}),
 	).toBe('image.jpg');
+});
+
+test('follows validated redirects for remote assets', async () => {
+	const publicDir = mkdtempSync(path.join(tmpdir(), 'remotion-remote-asset-'));
+	const originalFetch = globalThis.fetch;
+	const requestedUrls: string[] = [];
+	const gif = new Uint8Array([
+		0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x20, 0x03, 0x58, 0x02,
+	]);
+
+	globalThis.fetch = Object.assign(
+		async (input: Parameters<typeof fetch>[0]) => {
+			requestedUrls.push(input.toString());
+
+			if (requestedUrls.length === 1) {
+				return new Response(null, {
+					headers: {
+						location: 'https://93.184.216.35/logo.gif',
+					},
+					status: 302,
+				});
+			}
+
+			return new Response(gif, {
+				headers: {
+					'content-length': String(gif.byteLength),
+				},
+				status: 200,
+			});
+		},
+		{
+			preconnect: originalFetch.preconnect,
+		},
+	);
+
+	try {
+		const response = await downloadRemoteAssetHandler({
+			binariesDirectory: null,
+			entryPoint: '',
+			input: {url: 'https://93.184.216.34/raw-link'},
+			logLevel: 'info',
+			methods: {
+				addJob: () => undefined,
+				cancelJob: () => undefined,
+				removeJob: () => undefined,
+			},
+			publicDir,
+			remotionRoot: '',
+			request: {
+				headers: {
+					host: 'studio.local',
+					origin: 'http://studio.local',
+				},
+			} as IncomingMessage,
+			response: {} as ServerResponse,
+		});
+
+		expect(requestedUrls).toEqual([
+			'https://93.184.216.34/raw-link',
+			'https://93.184.216.35/logo.gif',
+		]);
+		expect(response).toEqual({
+			assetPath: 'raw-link.gif',
+			created: true,
+			element: {
+				assetType: 'gif',
+				dimensions: {
+					height: 600,
+					width: 800,
+				},
+				src: 'raw-link.gif',
+				type: 'asset',
+			},
+			sizeInBytes: gif.byteLength,
+		});
+	} finally {
+		globalThis.fetch = originalFetch;
+		rmSync(publicDir, {force: true, recursive: true});
+	}
+});
+
+test('blocks redirects to private IP addresses', async () => {
+	const publicDir = mkdtempSync(path.join(tmpdir(), 'remotion-remote-asset-'));
+	const originalFetch = globalThis.fetch;
+
+	globalThis.fetch = Object.assign(
+		async (_input: Parameters<typeof fetch>[0]) => {
+			return new Response(null, {
+				headers: {
+					location: 'http://127.0.0.1/logo.gif',
+				},
+				status: 302,
+			});
+		},
+		{
+			preconnect: originalFetch.preconnect,
+		},
+	);
+
+	try {
+		await expect(
+			downloadRemoteAssetHandler({
+				binariesDirectory: null,
+				entryPoint: '',
+				input: {url: 'https://93.184.216.34/raw-link'},
+				logLevel: 'info',
+				methods: {
+					addJob: () => undefined,
+					cancelJob: () => undefined,
+					removeJob: () => undefined,
+				},
+				publicDir,
+				remotionRoot: '',
+				request: {
+					headers: {
+						host: 'studio.local',
+						origin: 'http://studio.local',
+					},
+				} as IncomingMessage,
+				response: {} as ServerResponse,
+			}),
+		).rejects.toThrow('Private IP addresses cannot be imported');
+	} finally {
+		globalThis.fetch = originalFetch;
+		rmSync(publicDir, {force: true, recursive: true});
+	}
 });

--- a/packages/studio-server/src/test/download-remote-asset.test.ts
+++ b/packages/studio-server/src/test/download-remote-asset.test.ts
@@ -1,0 +1,38 @@
+import {expect, test} from 'bun:test';
+import {
+	detectRemoteImageFileType,
+	getRemoteAssetFilename,
+} from '../preview-server/routes/download-remote-asset';
+
+test('detects remote PNG dimensions', () => {
+	const png = new Uint8Array(24);
+	png.set([0x89, 0x50, 0x4e, 0x47, 13, 10, 26, 10], 0);
+	png.set([0, 0, 0, 13], 8);
+	png.set([0x49, 0x48, 0x44, 0x52], 12);
+	png.set([0, 0, 7, 128], 16);
+	png.set([0, 0, 4, 56], 20);
+
+	expect(detectRemoteImageFileType(png)).toEqual({
+		type: 'png',
+		dimensions: {
+			width: 1920,
+			height: 1080,
+		},
+	});
+});
+
+test('sanitizes remote asset filenames and uses detected extensions', () => {
+	expect(
+		getRemoteAssetFilename({
+			fileType: {type: 'png', dimensions: null},
+			url: new URL('https://example.com/../bad:name.jpg?size=large'),
+		}),
+	).toBe('bad-name.png');
+
+	expect(
+		getRemoteAssetFilename({
+			fileType: {type: 'jpeg', dimensions: null},
+			url: new URL('https://example.com/photos/image'),
+		}),
+	).toBe('image.jpg');
+});

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -586,6 +586,17 @@ export type InsertJsxElementResponse =
 			stack: string;
 	  };
 
+export type DownloadRemoteAssetRequest = {
+	url: string;
+};
+
+export type DownloadRemoteAssetResponse = {
+	assetPath: string;
+	sizeInBytes: number;
+	created: boolean;
+	element: InsertableCompositionElement;
+};
+
 export type UpdateAvailableRequest = {};
 export type UpdateAvailableResponse = {
 	currentVersion: string;
@@ -716,6 +727,10 @@ export type ApiRoutes = {
 	'/api/insert-jsx-element': ReqAndRes<
 		InsertJsxElementRequest,
 		InsertJsxElementResponse
+	>;
+	'/api/download-remote-asset': ReqAndRes<
+		DownloadRemoteAssetRequest,
+		DownloadRemoteAssetResponse
 	>;
 	'/api/update-available': ReqAndRes<
 		UpdateAvailableRequest,

--- a/packages/studio-shared/src/detect-file-type.ts
+++ b/packages/studio-shared/src/detect-file-type.ts
@@ -117,22 +117,30 @@ const getJpegDimensions = (data: Uint8Array): FileDimensions | null => {
 		return (data[o] << 8) | data[o + 1];
 	};
 
-	if (readUint16BE(offset) !== 0xffd8) {
+	if (data.length < 4 || readUint16BE(offset) !== 0xffd8) {
 		return null;
 	}
 
 	offset += 2;
 
-	while (offset < data.length) {
+	while (offset + 3 < data.length) {
 		if (data[offset] === 0xff) {
 			const marker = data[offset + 1];
 			if (marker === 0xc0 || marker === 0xc2) {
+				if (offset + 8 >= data.length) {
+					return null;
+				}
+
 				const height = readUint16BE(offset + 5);
 				const width = readUint16BE(offset + 7);
 				return {width, height};
 			}
 
 			const length = readUint16BE(offset + 2);
+			if (length <= 0) {
+				return null;
+			}
+
 			offset += length + 2;
 		} else {
 			offset++;
@@ -154,7 +162,11 @@ const isJpeg = (data: Uint8Array): JpegType | null => {
 	return {dimensions: dim, type: 'jpeg'};
 };
 
-const getGifDimensions = (data: Uint8Array) => {
+const getGifDimensions = (data: Uint8Array): FileDimensions | null => {
+	if (data.length < 10) {
+		return null;
+	}
+
 	const view = new DataView(data.buffer, data.byteOffset);
 
 	const width = view.getUint16(6, true);
@@ -308,7 +320,7 @@ export type WavType = {
 
 export type GifType = {
 	type: 'gif';
-	dimensions: FileDimensions;
+	dimensions: FileDimensions | null;
 };
 
 export type FlacType = {
@@ -365,6 +377,20 @@ export type FileType =
 	| FlacType
 	| M3uType
 	| UnknownType;
+
+export type ImageFileType = JpegType | WebpType | GifType | PngType | BmpType;
+
+export const isImageFileType = (
+	fileType: FileType,
+): fileType is ImageFileType => {
+	return (
+		fileType.type === 'jpeg' ||
+		fileType.type === 'webp' ||
+		fileType.type === 'gif' ||
+		fileType.type === 'png' ||
+		fileType.type === 'bmp'
+	);
+};
 
 export const detectFileType = (data: Uint8Array): FileType => {
 	if (isRiffWave(data)) {

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -76,24 +76,31 @@ export {
 	UnsubscribeFromDefaultPropsRequest,
 	UnsubscribeFromFileExistenceRequest,
 	UnsubscribeFromSequencePropsRequest,
-	UpdateEffectKeyframeSettingsRequest,
-	UpdateEffectKeyframeSettingsResponse,
 	UpdateAvailableRequest,
 	UpdateAvailableResponse,
 	UpdateDefaultPropsRequest,
 	UpdateDefaultPropsResponse,
+	UpdateEffectKeyframeSettingsRequest,
+	UpdateEffectKeyframeSettingsResponse,
 	UpdateSequenceKeyframeSettingsRequest,
 	UpdateSequenceKeyframeSettingsResponse,
 	type KeyframeSettings,
 } from './api-requests';
-export type {ApplyVisualControlCodemod, RecastCodemod} from './codemods';
 export {
 	ASSET_DRAG_MIME_TYPE,
 	makeAssetDragData,
 	parseAssetDragData,
 	type AssetDragData,
 } from './asset-drag-data';
+export type {ApplyVisualControlCodemod, RecastCodemod} from './codemods';
 export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state-delay-in-milliseconds';
+export {
+	detectFileType,
+	isImageFileType,
+	type FileDimensions,
+	type FileType,
+	type ImageFileType,
+} from './detect-file-type';
 export {
 	parseEffectClipboardData,
 	parseEffectClipboardDataResult,
@@ -154,10 +161,6 @@ export {PackageManager} from './package-manager';
 export {ProjectInfo} from './project-info';
 export type {RenderDefaults} from './render-defaults';
 export {
-	getRequiredPackageForEffectImportPath,
-	getRequiredPackageForInsertableElement,
-} from './required-package';
-export {
 	AggregateRenderProgress,
 	ArtifactProgress,
 	BrowserDownloadState,
@@ -174,6 +177,10 @@ export {
 	UiOpenGlOptions,
 } from './render-job';
 export type {CompletedClientRender} from './render-job';
+export {
+	getRequiredPackageForEffectImportPath,
+	getRequiredPackageForInsertableElement,
+} from './required-package';
 export {
 	SCHEMA_FIELD_ROW_HEIGHT,
 	getEffectFieldsToShow,

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -31,6 +31,8 @@ export {
 	DeleteSequenceKeyframe,
 	DeleteStaticFileRequest,
 	DeleteStaticFileResponse,
+	DownloadRemoteAssetRequest,
+	DownloadRemoteAssetResponse,
 	DuplicateJsxNodeRequest,
 	DuplicateJsxNodeResponse,
 	InsertJsxElementRequest,

--- a/packages/studio-shared/src/test/detect-file-type.test.ts
+++ b/packages/studio-shared/src/test/detect-file-type.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'bun:test';
-import {detectFileType} from '../helpers/detect-file-type';
+import {detectFileType} from '../detect-file-type';
 
 test('detects PNG dimensions', () => {
 	const png = new Uint8Array(24);
@@ -29,6 +29,13 @@ test('detects GIF dimensions', () => {
 			width: 800,
 			height: 600,
 		},
+	});
+});
+
+test('returns null dimensions for short GIF signatures', () => {
+	expect(detectFileType(new Uint8Array([0x47, 0x49, 0x46, 0x38]))).toEqual({
+		type: 'gif',
+		dimensions: null,
 	});
 });
 

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -23,6 +23,10 @@ import {
 } from '../helpers/get-effective-translation';
 import {useCachedCompositionComponentInfo} from '../helpers/open-in-editor';
 import {
+	getRemoteAssetUrlFromDataTransfer,
+	hasRemoteAssetDragData,
+} from '../helpers/remote-asset-drag';
+import {
 	MAX_ZOOM,
 	MIN_ZOOM,
 	smoothenZoom,
@@ -35,7 +39,11 @@ import {EditorZoomGesturesContext} from '../state/editor-zoom-gestures';
 import EditorGuides from './EditorGuides';
 import {EditorRulers} from './EditorRuler';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
-import {importAssets, insertExistingAssets} from './import-assets';
+import {
+	importAssets,
+	importRemoteAsset,
+	insertExistingAssets,
+} from './import-assets';
 import {SPACING_UNIT} from './layout';
 import {VideoPreview} from './Preview';
 import {ResetZoomButton} from './ResetZoomButton';
@@ -73,6 +81,14 @@ const isFileDragEvent = (event: DragEvent): boolean => {
 const isAssetDragEvent = (event: DragEvent): boolean => {
 	return Array.from(event.dataTransfer?.types ?? []).includes(
 		ASSET_DRAG_MIME_TYPE,
+	);
+};
+
+const isRemoteAssetDragEvent = (event: DragEvent): boolean => {
+	return (
+		!isFileDragEvent(event) &&
+		!isAssetDragEvent(event) &&
+		hasRemoteAssetDragData(event.dataTransfer)
 	);
 };
 
@@ -617,7 +633,9 @@ export const Canvas: React.FC<{
 		(event: DragEvent) => {
 			if (
 				!canDropAssets ||
-				(!isFileDragEvent(event) && !isAssetDragEvent(event)) ||
+				(!isFileDragEvent(event) &&
+					!isAssetDragEvent(event) &&
+					!isRemoteAssetDragEvent(event)) ||
 				!isDragEventInsideCanvas(event)
 			) {
 				return;
@@ -637,7 +655,9 @@ export const Canvas: React.FC<{
 				!canDropAssets ||
 				compositionFile === null ||
 				currentCompositionId === null ||
-				(!isFileDragEvent(event) && !isAssetDragEvent(event)) ||
+				(!isFileDragEvent(event) &&
+					!isAssetDragEvent(event) &&
+					!isRemoteAssetDragEvent(event)) ||
 				!isDragEventInsideCanvas(event)
 			) {
 				return;
@@ -659,7 +679,7 @@ export const Canvas: React.FC<{
 						compositionFile,
 						compositionId: currentCompositionId,
 					});
-				} else {
+				} else if (isAssetDragEvent(event)) {
 					const assetPath = getAssetDragPath(event);
 					if (assetPath === null) {
 						return;
@@ -667,6 +687,17 @@ export const Canvas: React.FC<{
 
 					await insertExistingAssets({
 						assetPaths: [assetPath],
+						compositionFile,
+						compositionId: currentCompositionId,
+					});
+				} else {
+					const url = getRemoteAssetUrlFromDataTransfer(event.dataTransfer);
+					if (url === null) {
+						return;
+					}
+
+					await importRemoteAsset({
+						url,
 						compositionFile,
 						compositionId: currentCompositionId,
 					});

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -1,11 +1,12 @@
 import {
+	detectFileType,
 	getRequiredPackageForInsertableElement,
 	type DownloadRemoteAssetResponse,
+	type FileType,
 	type InsertableCompositionElement,
 } from '@remotion/studio-shared';
 import {getStaticFiles} from '../api/get-static-files';
 import {writeStaticFile} from '../api/write-static-file';
-import {detectFileType, type FileType} from '../helpers/detect-file-type';
 import {installRequiredPackages} from '../helpers/install-required-package';
 import {callApi} from './call-api';
 import {showNotification} from './Notifications/NotificationCenter';

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -1,5 +1,6 @@
 import {
 	getRequiredPackageForInsertableElement,
+	type DownloadRemoteAssetResponse,
 	type InsertableCompositionElement,
 } from '@remotion/studio-shared';
 import {getStaticFiles} from '../api/get-static-files';
@@ -226,6 +227,12 @@ const insertAssetElement = async ({
 	return true;
 };
 
+const downloadRemoteAsset = async (
+	url: string,
+): Promise<DownloadRemoteAssetResponse> => {
+	return callApi('/api/download-remote-asset', {url});
+};
+
 export const importAssets = async ({
 	compositionFile,
 	compositionId,
@@ -317,6 +324,43 @@ export const importAssets = async ({
 	} catch (error) {
 		showNotification(
 			`Could not add asset: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+			4000,
+		);
+	}
+};
+
+export const importRemoteAsset = async ({
+	compositionFile,
+	compositionId,
+	url,
+}: {
+	compositionFile: string;
+	compositionId: string;
+	url: string;
+}) => {
+	try {
+		const {assetPath, created, element} = await downloadRemoteAsset(url);
+
+		if (created) {
+			showNotification(`Created ${assetPath} in public folder`, 3000);
+		}
+
+		const inserted = await insertAssetElement({
+			compositionFile,
+			compositionId,
+			element,
+		});
+
+		if (!inserted) {
+			return;
+		}
+
+		notifyInsertedAssets([getAssetLabel(element)]);
+	} catch (error) {
+		showNotification(
+			`Could not add remote asset: ${
 				error instanceof Error ? error.message : String(error)
 			}`,
 			4000,

--- a/packages/studio/src/helpers/remote-asset-drag.ts
+++ b/packages/studio/src/helpers/remote-asset-drag.ts
@@ -1,0 +1,84 @@
+const remoteAssetDragTypes = ['text/uri-list', 'text/html', 'text/plain'];
+
+const isHttpUrl = (value: string): boolean => {
+	try {
+		const url = new URL(value);
+		return url.protocol === 'http:' || url.protocol === 'https:';
+	} catch {
+		return false;
+	}
+};
+
+const decodeHtmlAttribute = (value: string): string => {
+	return value
+		.replace(/&amp;/g, '&')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>');
+};
+
+export const hasRemoteAssetDragData = (
+	dataTransfer: DataTransfer | null,
+): boolean => {
+	return remoteAssetDragTypes.some((type) =>
+		Array.from(dataTransfer?.types ?? []).includes(type),
+	);
+};
+
+export const getRemoteAssetUrlFromUriList = (
+	uriList: string,
+): string | null => {
+	const lines = uriList.split(/\r?\n/g);
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (trimmed === '' || trimmed.startsWith('#')) {
+			continue;
+		}
+
+		if (isHttpUrl(trimmed)) {
+			return trimmed;
+		}
+	}
+
+	return null;
+};
+
+export const getRemoteAssetUrlFromHtml = (html: string): string | null => {
+	const imgSrc = html.match(
+		/<img\b[^>]*\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>]+))/i,
+	);
+	const match = imgSrc?.[1] ?? imgSrc?.[2] ?? imgSrc?.[3] ?? null;
+	if (match) {
+		const decoded = decodeHtmlAttribute(match.trim());
+		if (isHttpUrl(decoded)) {
+			return decoded;
+		}
+	}
+
+	const fallback = html.match(/https?:\/\/[^\s"'<>]+/i)?.[0] ?? null;
+	return fallback && isHttpUrl(fallback) ? decodeHtmlAttribute(fallback) : null;
+};
+
+export const getRemoteAssetUrlFromDataTransfer = (
+	dataTransfer: DataTransfer | null,
+): string | null => {
+	if (!dataTransfer) {
+		return null;
+	}
+
+	const uriListUrl = getRemoteAssetUrlFromUriList(
+		dataTransfer.getData('text/uri-list'),
+	);
+	if (uriListUrl) {
+		return uriListUrl;
+	}
+
+	const htmlUrl = getRemoteAssetUrlFromHtml(dataTransfer.getData('text/html'));
+	if (htmlUrl) {
+		return htmlUrl;
+	}
+
+	const plainText = dataTransfer.getData('text/plain').trim();
+	return isHttpUrl(plainText) ? plainText : null;
+};

--- a/packages/studio/src/test/remote-asset-drag.test.ts
+++ b/packages/studio/src/test/remote-asset-drag.test.ts
@@ -1,0 +1,27 @@
+import {expect, test} from 'bun:test';
+import {
+	getRemoteAssetUrlFromHtml,
+	getRemoteAssetUrlFromUriList,
+} from '../helpers/remote-asset-drag';
+
+test('extracts the first HTTP URL from a uri-list', () => {
+	expect(
+		getRemoteAssetUrlFromUriList(
+			'# comment\r\nfile:///tmp/image.png\r\nhttps://example.com/image.png',
+		),
+	).toBe('https://example.com/image.png');
+});
+
+test('extracts image sources from HTML drag data', () => {
+	expect(
+		getRemoteAssetUrlFromHtml(
+			'<a href="https://example.com"><img src="https://img.example.com/photo.jpg?size=large&amp;x=1"></a>',
+		),
+	).toBe('https://img.example.com/photo.jpg?size=large&x=1');
+});
+
+test('falls back to HTTP URLs in HTML drag data', () => {
+	expect(
+		getRemoteAssetUrlFromHtml('<p>https://example.com/image.webp</p>'),
+	).toBe('https://example.com/image.webp');
+});


### PR DESCRIPTION
Fixes #8037.

## Summary

- Support dropping remote image URLs/HTML drag data onto the Studio canvas.
- Download remote images through the Studio server with same-origin checks, URL validation, private-IP blocking, size limits, sanitized filenames, and byte-based image type detection.
- Insert the downloaded asset as `<Img>` or `<Gif>` with detected dimensions and add focused tests for drag parsing and remote asset handling.

## Testing

- `bun test packages/studio/src/test/remote-asset-drag.test.ts packages/studio-server/src/test/download-remote-asset.test.ts`
- `bunx turbo make --filter='@remotion/studio' --filter='@remotion/studio-server' --filter='@remotion/studio-shared'`
- `bun run build`
- `bun run stylecheck`
