### PR TITLE
`@remotion/studio`: Support copying effect props

### DIFF
--- a/packages/studio-server/src/codemods/effect-param-expression.ts
+++ b/packages/studio-server/src/codemods/effect-param-expression.ts
@@ -1,0 +1,213 @@
+import type {File, ObjectExpression, ObjectProperty} from '@babel/types';
+import type {
+	EffectClipboardKeyframedParam,
+	EffectClipboardParam,
+	EffectClipboardSnapshot,
+} from '@remotion/studio-shared';
+import type {ExpressionKind} from 'ast-types/lib/gen/kinds';
+import * as recast from 'recast';
+import {ensureNamedImport} from '../helpers/imports';
+import {parseValueExpression} from './update-nested-prop';
+
+const b = recast.types.builders;
+
+export type RemotionImportName =
+	| 'Easing'
+	| 'interpolate'
+	| 'interpolateColors'
+	| 'useCurrentFrame';
+
+export type RemotionLocalNames = Partial<Record<RemotionImportName, string>>;
+
+const isNonLinearEasing = (
+	easing: EffectClipboardKeyframedParam['easing'][number],
+) => easing !== 'linear';
+
+const keyframedParamNeedsEasingImport = (
+	param: EffectClipboardKeyframedParam,
+) => {
+	return (
+		param.interpolationFunction !== 'interpolateColors' &&
+		param.easing.some(isNonLinearEasing)
+	);
+};
+
+export const getRequiredRemotionImportsForEffectParams = (
+	params: Iterable<EffectClipboardParam>,
+): Set<RemotionImportName> => {
+	const requiredImports = new Set<RemotionImportName>();
+
+	for (const param of params) {
+		if (param.type !== 'keyframed') {
+			continue;
+		}
+
+		requiredImports.add('useCurrentFrame');
+		requiredImports.add(param.interpolationFunction);
+		if (keyframedParamNeedsEasingImport(param)) {
+			requiredImports.add('Easing');
+		}
+	}
+
+	return requiredImports;
+};
+
+export const getRequiredRemotionImports = (
+	effects: EffectClipboardSnapshot[],
+): Set<RemotionImportName> => {
+	return getRequiredRemotionImportsForEffectParams(
+		effects.flatMap((effect) => Object.values(effect.params)),
+	);
+};
+
+export const ensureRemotionImportLocalNames = ({
+	ast,
+	requiredImports,
+}: {
+	ast: File;
+	requiredImports: Set<RemotionImportName>;
+}): RemotionLocalNames => {
+	const localNames: RemotionLocalNames = {};
+	for (const importedName of requiredImports) {
+		localNames[importedName] = ensureNamedImport({
+			ast,
+			importedName,
+			sourcePath: 'remotion',
+			localName: importedName,
+		});
+	}
+
+	return localNames;
+};
+
+const makeEasingExpression = ({
+	easing,
+	easingLocalName,
+}: {
+	easing: EffectClipboardKeyframedParam['easing'][number];
+	easingLocalName: string;
+}): ExpressionKind => {
+	if (easing === 'linear') {
+		return b.memberExpression(
+			b.identifier(easingLocalName),
+			b.identifier('linear'),
+		) as ExpressionKind;
+	}
+
+	return b.callExpression(
+		b.memberExpression(b.identifier(easingLocalName), b.identifier('bezier')),
+		easing.map((value) => parseValueExpression(value)) as never,
+	) as ExpressionKind;
+};
+
+const makeKeyframedOptions = ({
+	param,
+	remotionLocalNames,
+}: {
+	param: EffectClipboardKeyframedParam;
+	remotionLocalNames: RemotionLocalNames;
+}): ObjectExpression | null => {
+	const properties: ObjectProperty[] = [];
+
+	if (param.interpolationFunction !== 'interpolateColors') {
+		if (param.clamping.left !== 'extend') {
+			properties.push(
+				b.objectProperty(
+					b.identifier('extrapolateLeft'),
+					b.stringLiteral(param.clamping.left),
+				) as ObjectProperty,
+			);
+		}
+
+		if (param.clamping.right !== 'extend') {
+			properties.push(
+				b.objectProperty(
+					b.identifier('extrapolateRight'),
+					b.stringLiteral(param.clamping.right),
+				) as ObjectProperty,
+			);
+		}
+
+		if (keyframedParamNeedsEasingImport(param)) {
+			const easingLocalName = remotionLocalNames.Easing ?? 'Easing';
+			properties.push(
+				b.objectProperty(
+					b.identifier('easing'),
+					b.arrayExpression(
+						param.easing.map((easing) =>
+							makeEasingExpression({easing, easingLocalName}),
+						) as never,
+					),
+				) as ObjectProperty,
+			);
+		}
+	}
+
+	if (param.posterize !== undefined) {
+		properties.push(
+			b.objectProperty(
+				b.identifier('posterize'),
+				parseValueExpression(param.posterize) as never,
+			) as ObjectProperty,
+		);
+	}
+
+	if (properties.length === 0) {
+		return null;
+	}
+
+	return b.objectExpression(properties as never) as ObjectExpression;
+};
+
+const makeKeyframedExpression = ({
+	param,
+	remotionLocalNames,
+}: {
+	param: EffectClipboardKeyframedParam;
+	remotionLocalNames: RemotionLocalNames;
+}): ExpressionKind => {
+	const expectedEasingCount = Math.max(0, param.keyframes.length - 1);
+	if (param.easing.length !== expectedEasingCount) {
+		throw new Error('Cannot paste keyframed effect: invalid easing metadata');
+	}
+
+	const calleeName =
+		remotionLocalNames[param.interpolationFunction] ??
+		param.interpolationFunction;
+	const args: ExpressionKind[] = [
+		b.identifier('frame') as ExpressionKind,
+		b.arrayExpression(
+			param.keyframes.map((keyframe) =>
+				parseValueExpression(keyframe.frame),
+			) as never,
+		) as ExpressionKind,
+		b.arrayExpression(
+			param.keyframes.map((keyframe) =>
+				parseValueExpression(keyframe.value),
+			) as never,
+		) as ExpressionKind,
+	];
+	const options = makeKeyframedOptions({param, remotionLocalNames});
+	if (options) {
+		args.push(options as ExpressionKind);
+	}
+
+	return b.callExpression(
+		b.identifier(calleeName),
+		args as never,
+	) as ExpressionKind;
+};
+
+export const makeParamExpression = ({
+	param,
+	remotionLocalNames,
+}: {
+	param: EffectClipboardParam;
+	remotionLocalNames: RemotionLocalNames;
+}): ExpressionKind => {
+	if (param.type === 'static') {
+		return parseValueExpression(param.value);
+	}
+
+	return makeKeyframedExpression({param, remotionLocalNames});
+};

--- a/packages/studio-server/src/codemods/paste-effects.ts
+++ b/packages/studio-server/src/codemods/paste-effects.ts
@@ -1,24 +1,25 @@
 import type {
 	ArrayExpression,
 	CallExpression,
-	File,
 	JSXAttribute,
 	ObjectExpression,
 	ObjectProperty,
 } from '@babel/types';
 import type {
-	EffectClipboardKeyframedParam,
-	EffectClipboardParam,
 	EffectClipboardPasteType,
 	EffectClipboardSnapshot,
 } from '@remotion/studio-shared';
-import type {ExpressionKind} from 'ast-types/lib/gen/kinds';
 import * as recast from 'recast';
 import type {SequenceNodePath} from 'remotion';
 import {getAstNodePath} from '../helpers/get-ast-node-path';
-import {ensureNamedImport} from '../helpers/imports';
 import {findJsxElementAtNodePath} from '../preview-server/routes/can-update-sequence-props';
 import {assertValidEffect, ensureEffectImport} from './add-effect';
+import {
+	ensureRemotionImportLocalNames,
+	getRequiredRemotionImports,
+	makeParamExpression,
+	type RemotionLocalNames,
+} from './effect-param-expression';
 import {formatFileContent} from './format-file-content';
 import {parseAst, serializeAst} from './parse-ast';
 import {findEffectsAttr} from './update-effect-props/update-effect-props';
@@ -26,18 +27,9 @@ import {
 	ensureUseCurrentFrameHook,
 	findEnclosingFunctionPath,
 } from './update-keyframes/ensure-imports-and-frame-hook';
-import {parseValueExpression} from './update-nested-prop';
 
 const b = recast.types.builders;
 const identifierRegex = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
-
-type RemotionImportName =
-	| 'Easing'
-	| 'interpolate'
-	| 'interpolateColors'
-	| 'useCurrentFrame';
-
-type RemotionLocalNames = Partial<Record<RemotionImportName, string>>;
 
 const getEffectsArray = (attr: JSXAttribute): ArrayExpression => {
 	if (!attr.value || attr.value.type !== 'JSXExpressionContainer') {
@@ -61,193 +53,6 @@ const makeEffectsAttr = (array: ArrayExpression): JSXAttribute => {
 
 const makeEffectsArray = (calls: CallExpression[]): ArrayExpression => {
 	return b.arrayExpression(calls as never) as unknown as ArrayExpression;
-};
-
-const isNonLinearEasing = (
-	easing: EffectClipboardKeyframedParam['easing'][number],
-) => easing !== 'linear';
-
-const keyframedParamNeedsEasingImport = (
-	param: EffectClipboardKeyframedParam,
-) => {
-	return (
-		param.interpolationFunction !== 'interpolateColors' &&
-		param.easing.some(isNonLinearEasing)
-	);
-};
-
-const getRequiredRemotionImports = (
-	effects: EffectClipboardSnapshot[],
-): Set<RemotionImportName> => {
-	const requiredImports = new Set<RemotionImportName>();
-
-	for (const effect of effects) {
-		for (const param of Object.values(effect.params)) {
-			if (param.type !== 'keyframed') {
-				continue;
-			}
-
-			requiredImports.add('useCurrentFrame');
-			requiredImports.add(param.interpolationFunction);
-			if (keyframedParamNeedsEasingImport(param)) {
-				requiredImports.add('Easing');
-			}
-		}
-	}
-
-	return requiredImports;
-};
-
-const ensureRemotionImportLocalNames = ({
-	ast,
-	requiredImports,
-}: {
-	ast: File;
-	requiredImports: Set<RemotionImportName>;
-}): RemotionLocalNames => {
-	const localNames: RemotionLocalNames = {};
-	for (const importedName of requiredImports) {
-		localNames[importedName] = ensureNamedImport({
-			ast,
-			importedName,
-			sourcePath: 'remotion',
-			localName: importedName,
-		});
-	}
-
-	return localNames;
-};
-
-const makeEasingExpression = ({
-	easing,
-	easingLocalName,
-}: {
-	easing: EffectClipboardKeyframedParam['easing'][number];
-	easingLocalName: string;
-}): ExpressionKind => {
-	if (easing === 'linear') {
-		return b.memberExpression(
-			b.identifier(easingLocalName),
-			b.identifier('linear'),
-		) as ExpressionKind;
-	}
-
-	return b.callExpression(
-		b.memberExpression(b.identifier(easingLocalName), b.identifier('bezier')),
-		easing.map((value) => parseValueExpression(value)) as never,
-	) as ExpressionKind;
-};
-
-const makeKeyframedOptions = ({
-	param,
-	remotionLocalNames,
-}: {
-	param: EffectClipboardKeyframedParam;
-	remotionLocalNames: RemotionLocalNames;
-}): ObjectExpression | null => {
-	const properties: ObjectProperty[] = [];
-
-	if (param.interpolationFunction !== 'interpolateColors') {
-		if (param.clamping.left !== 'extend') {
-			properties.push(
-				b.objectProperty(
-					b.identifier('extrapolateLeft'),
-					b.stringLiteral(param.clamping.left),
-				) as ObjectProperty,
-			);
-		}
-
-		if (param.clamping.right !== 'extend') {
-			properties.push(
-				b.objectProperty(
-					b.identifier('extrapolateRight'),
-					b.stringLiteral(param.clamping.right),
-				) as ObjectProperty,
-			);
-		}
-
-		if (keyframedParamNeedsEasingImport(param)) {
-			const easingLocalName = remotionLocalNames.Easing ?? 'Easing';
-			properties.push(
-				b.objectProperty(
-					b.identifier('easing'),
-					b.arrayExpression(
-						param.easing.map((easing) =>
-							makeEasingExpression({easing, easingLocalName}),
-						) as never,
-					),
-				) as ObjectProperty,
-			);
-		}
-	}
-
-	if (param.posterize !== undefined) {
-		properties.push(
-			b.objectProperty(
-				b.identifier('posterize'),
-				parseValueExpression(param.posterize) as never,
-			) as ObjectProperty,
-		);
-	}
-
-	if (properties.length === 0) {
-		return null;
-	}
-
-	return b.objectExpression(properties as never) as ObjectExpression;
-};
-
-const makeKeyframedExpression = ({
-	param,
-	remotionLocalNames,
-}: {
-	param: EffectClipboardKeyframedParam;
-	remotionLocalNames: RemotionLocalNames;
-}): ExpressionKind => {
-	const expectedEasingCount = Math.max(0, param.keyframes.length - 1);
-	if (param.easing.length !== expectedEasingCount) {
-		throw new Error('Cannot paste keyframed effect: invalid easing metadata');
-	}
-
-	const calleeName =
-		remotionLocalNames[param.interpolationFunction] ??
-		param.interpolationFunction;
-	const args: ExpressionKind[] = [
-		b.identifier('frame') as ExpressionKind,
-		b.arrayExpression(
-			param.keyframes.map((keyframe) =>
-				parseValueExpression(keyframe.frame),
-			) as never,
-		) as ExpressionKind,
-		b.arrayExpression(
-			param.keyframes.map((keyframe) =>
-				parseValueExpression(keyframe.value),
-			) as never,
-		) as ExpressionKind,
-	];
-	const options = makeKeyframedOptions({param, remotionLocalNames});
-	if (options) {
-		args.push(options as ExpressionKind);
-	}
-
-	return b.callExpression(
-		b.identifier(calleeName),
-		args as never,
-	) as ExpressionKind;
-};
-
-const makeParamExpression = ({
-	param,
-	remotionLocalNames,
-}: {
-	param: EffectClipboardParam;
-	remotionLocalNames: RemotionLocalNames;
-}): ExpressionKind => {
-	if (param.type === 'static') {
-		return parseValueExpression(param.value);
-	}
-
-	return makeKeyframedExpression({param, remotionLocalNames});
 };
 
 const makeParamsObjectExpression = ({

--- a/packages/studio-server/src/codemods/update-effect-props/update-effect-props.ts
+++ b/packages/studio-server/src/codemods/update-effect-props/update-effect-props.ts
@@ -2,32 +2,51 @@ import type {
 	ArrayExpression,
 	CallExpression,
 	Expression,
+	File,
 	JSXAttribute,
 	ObjectExpression,
 	ObjectProperty,
 	StringLiteral,
 } from '@babel/types';
-import {stringifyDefaultProps} from '@remotion/studio-shared';
+import type {EffectClipboardParam} from '@remotion/studio-shared';
 import type {ExpressionKind} from 'ast-types/lib/gen/kinds';
 import * as recast from 'recast';
 import type {SequenceNodePath, SequenceSchema} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
+import {getAstNodePath} from '../../helpers/get-ast-node-path';
 import {findJsxElementAtNodePath} from '../../preview-server/routes/can-update-sequence-props';
+import {
+	ensureRemotionImportLocalNames,
+	getRequiredRemotionImportsForEffectParams,
+	makeParamExpression,
+} from '../effect-param-expression';
 import {formatFileContent} from '../format-file-content';
 import {parseAst, serializeAst} from '../parse-ast';
+import {
+	ensureUseCurrentFrameHook,
+	findEnclosingFunctionPath,
+} from '../update-keyframes/ensure-imports-and-frame-hook';
+import {parseValueExpression} from '../update-nested-prop';
 
 const b = recast.types.builders;
 
-export type EffectPropUpdate = {
-	key: string;
-	value: unknown;
-	defaultValue: unknown | null;
-};
+export type EffectPropUpdate =
+	| {
+			key: string;
+			value: unknown;
+			defaultValue: unknown | null;
+	  }
+	| {
+			key: string;
+			effectParam: EffectClipboardParam;
+			defaultValue: unknown | null;
+	  };
 
 export type UpdateEffectPropsResult = {
 	output: string;
 	formatted: boolean;
 	oldValueString: string;
+	newValueString: string;
 	logLine: number;
 	effectCallee: string;
 	removedProps: PropDelta[];
@@ -36,20 +55,6 @@ export type UpdateEffectPropsResult = {
 export type PropDelta = {
 	key: string;
 	valueString: string;
-};
-
-const parseValueExpression = (value: unknown): ExpressionKind => {
-	const code = `a = ${stringifyDefaultProps({props: value, enumPaths: []})}`;
-	const ast = parseAst(code);
-	const stmt = ast.program.body[0];
-	if (
-		stmt.type !== 'ExpressionStatement' ||
-		stmt.expression.type !== 'AssignmentExpression'
-	) {
-		throw new Error('Failed to parse effect prop value expression');
-	}
-
-	return stmt.expression.right as ExpressionKind;
 };
 
 export const findEffectsAttr = (
@@ -186,6 +191,77 @@ const printObjectPropertyValue = (prop: ObjectProperty) =>
 		.replace(/,(\s*[}\]])/g, '$1')
 		.trim();
 
+const updateHasEffectParam = (
+	update: EffectPropUpdate,
+): update is Extract<EffectPropUpdate, {effectParam: EffectClipboardParam}> =>
+	'effectParam' in update;
+
+const getStaticUpdateValue = (update: EffectPropUpdate): unknown | null => {
+	if (updateHasEffectParam(update)) {
+		return update.effectParam.type === 'static'
+			? update.effectParam.value
+			: null;
+	}
+
+	return update.value;
+};
+
+const ensureClipboardParamImports = ({
+	ast,
+	sequenceNodePath,
+	param,
+}: {
+	ast: File;
+	sequenceNodePath: SequenceNodePath;
+	param: EffectClipboardParam;
+}) => {
+	const requiredImports = getRequiredRemotionImportsForEffectParams([param]);
+	const remotionLocalNames = ensureRemotionImportLocalNames({
+		ast,
+		requiredImports,
+	});
+
+	if (requiredImports.has('useCurrentFrame')) {
+		const targetJsxPath = getAstNodePath(ast, sequenceNodePath);
+		if (targetJsxPath) {
+			const fnPath = findEnclosingFunctionPath(targetJsxPath);
+			if (fnPath) {
+				ensureUseCurrentFrameHook(
+					fnPath,
+					remotionLocalNames.useCurrentFrame ?? 'useCurrentFrame',
+				);
+			}
+		}
+	}
+
+	return remotionLocalNames;
+};
+
+const makeUpdateValueExpression = ({
+	ast,
+	sequenceNodePath,
+	update,
+}: {
+	ast: File;
+	sequenceNodePath: SequenceNodePath;
+	update: EffectPropUpdate;
+}): ExpressionKind => {
+	if (!updateHasEffectParam(update)) {
+		return parseValueExpression(update.value);
+	}
+
+	const remotionLocalNames = ensureClipboardParamImports({
+		ast,
+		sequenceNodePath,
+		param: update.effectParam,
+	});
+
+	return makeParamExpression({
+		param: update.effectParam,
+		remotionLocalNames,
+	});
+};
+
 const removeObjectProperty = ({
 	objExpr,
 	propertyName,
@@ -222,6 +298,7 @@ export const updateEffectPropsAst = ({
 }): {
 	serialized: string;
 	oldValueString: string;
+	newValueString: string;
 	logLine: number;
 	effectCallee: string;
 	removedProps: PropDelta[];
@@ -251,6 +328,7 @@ export const updateEffectPropsAst = ({
 	const {call, callee: effectCallee} = found;
 
 	const isDefault =
+		!updateHasEffectParam(update) &&
 		update.defaultValue !== null &&
 		JSON.stringify(update.value) === JSON.stringify(update.defaultValue);
 
@@ -261,6 +339,7 @@ export const updateEffectPropsAst = ({
 			return {
 				serialized: serializeAst(ast),
 				oldValueString: '',
+				newValueString: JSON.stringify(update.defaultValue),
 				logLine: call.loc?.start.line ?? jsx.loc?.start.line ?? 1,
 				effectCallee,
 				removedProps: [],
@@ -285,7 +364,9 @@ export const updateEffectPropsAst = ({
 		oldValueString = JSON.stringify(update.defaultValue);
 	}
 
+	let newValueString = '';
 	if (isDefault) {
+		newValueString = JSON.stringify(update.defaultValue);
 		if (prop) {
 			const idx = objExpr.properties.indexOf(prop);
 			if (idx !== -1) {
@@ -293,7 +374,12 @@ export const updateEffectPropsAst = ({
 			}
 		}
 	} else {
-		const newValueExpr = parseValueExpression(update.value);
+		const newValueExpr = makeUpdateValueExpression({
+			ast,
+			sequenceNodePath,
+			update,
+		});
+		newValueString = recast.print(newValueExpr).code;
 		if (prop) {
 			prop.value = newValueExpr as ObjectProperty['value'];
 		} else {
@@ -307,11 +393,16 @@ export const updateEffectPropsAst = ({
 	}
 
 	const fieldSchema = schema[update.key];
-	if (fieldSchema && fieldSchema.type === 'enum') {
+	const staticUpdateValue = getStaticUpdateValue(update);
+	if (
+		fieldSchema &&
+		fieldSchema.type === 'enum' &&
+		staticUpdateValue !== null
+	) {
 		const propsToDelete = NoReactInternals.findPropsToDelete({
 			schema,
 			key: update.key,
-			value: update.value,
+			value: staticUpdateValue,
 		});
 		for (const propToDelete of propsToDelete) {
 			const removed = removeObjectProperty({
@@ -329,6 +420,7 @@ export const updateEffectPropsAst = ({
 	return {
 		serialized: serializeAst(ast),
 		oldValueString,
+		newValueString,
 		logLine,
 		effectCallee,
 		removedProps,
@@ -350,14 +442,20 @@ export const updateEffectProps = async ({
 	schema: SequenceSchema;
 	prettierConfigOverride?: Record<string, unknown> | null;
 }): Promise<UpdateEffectPropsResult> => {
-	const {serialized, oldValueString, logLine, effectCallee, removedProps} =
-		updateEffectPropsAst({
-			input,
-			sequenceNodePath,
-			effectIndex,
-			update,
-			schema,
-		});
+	const {
+		serialized,
+		oldValueString,
+		newValueString,
+		logLine,
+		effectCallee,
+		removedProps,
+	} = updateEffectPropsAst({
+		input,
+		sequenceNodePath,
+		effectIndex,
+		update,
+		schema,
+	});
 
 	const {output, formatted} = await formatFileContent({
 		input: serialized,
@@ -367,6 +465,7 @@ export const updateEffectProps = async ({
 	return {
 		output,
 		oldValueString,
+		newValueString,
 		formatted,
 		logLine,
 		effectCallee,

--- a/packages/studio-server/src/preview-server/routes/save-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-effect-props.ts
@@ -26,21 +26,17 @@ import {withSavePropsLock} from './save-props-mutex';
 export const saveEffectPropsHandler: ApiHandler<
 	SaveEffectPropsRequest,
 	SaveEffectPropsResponse
-> = ({
-	input: {
-		fileName,
-		sequenceNodePath,
-		effectIndex,
-		key,
-		value,
-		defaultValue,
-		schema,
-		clientId,
-	},
-	remotionRoot,
-	logLevel,
-}) =>
+> = ({input, remotionRoot, logLevel}) =>
 	withSavePropsLock(async () => {
+		const {
+			fileName,
+			sequenceNodePath,
+			effectIndex,
+			key,
+			defaultValue,
+			schema,
+			clientId,
+		} = input;
 		RenderInternals.Log.trace(
 			{indent: false, logLevel},
 			`[save-effect-props] Received request for fileName="${fileName}" effectIndex=${effectIndex} key="${key}"`,
@@ -59,6 +55,7 @@ export const saveEffectPropsHandler: ApiHandler<
 		const {
 			output,
 			oldValueString,
+			newValueString,
 			formatted,
 			logLine,
 			effectCallee,
@@ -69,7 +66,9 @@ export const saveEffectPropsHandler: ApiHandler<
 			effectIndex,
 			update: {
 				key,
-				value: JSON.parse(value),
+				...(input.type === 'effect-param'
+					? {effectParam: input.effectParam}
+					: {value: JSON.parse(input.value)}),
 				defaultValue: parsedDefault,
 			},
 			schema,
@@ -79,7 +78,7 @@ export const saveEffectPropsHandler: ApiHandler<
 			parsedDefault !== null ? JSON.stringify(parsedDefault) : null;
 
 		const normalizedOld = normalizeQuotes(oldValueString);
-		const normalizedNew = normalizeQuotes(value);
+		const normalizedNew = normalizeQuotes(newValueString);
 		const normalizedDefault =
 			defaultValueString !== null ? normalizeQuotes(defaultValueString) : null;
 		const normalizedRemovedProps = removedProps.map((prop) => ({
@@ -130,7 +129,7 @@ export const saveEffectPropsHandler: ApiHandler<
 			effectName: effectCallee,
 			propKey: key,
 			oldValueString,
-			newValueString: value,
+			newValueString,
 			defaultValueString,
 			formatted,
 			logLevel,

--- a/packages/studio-server/src/preview-server/routes/save-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-effect-props.ts
@@ -52,6 +52,29 @@ export const saveEffectPropsHandler: ApiHandler<
 		const parsedDefault =
 			defaultValue !== null ? JSON.parse(defaultValue) : null;
 
+		const update = (() => {
+			switch (input.type) {
+				case 'value':
+					return {
+						key,
+						value: JSON.parse(input.value),
+						defaultValue: parsedDefault,
+					};
+				case 'effect-param':
+					return {
+						key,
+						effectParam: input.effectParam,
+						defaultValue: parsedDefault,
+					};
+				default:
+					throw new Error(
+						`Unsupported save effect props request type: ${
+							(input as {type?: unknown}).type
+						}`,
+					);
+			}
+		})();
+
 		const {
 			output,
 			oldValueString,
@@ -64,13 +87,7 @@ export const saveEffectPropsHandler: ApiHandler<
 			input: fileContents,
 			sequenceNodePath: sequenceNodePath.nodePath,
 			effectIndex,
-			update: {
-				key,
-				...(input.type === 'effect-param'
-					? {effectParam: input.effectParam}
-					: {value: JSON.parse(input.value)}),
-				defaultValue: parsedDefault,
-			},
+			update,
 			schema,
 		});
 

--- a/packages/studio-server/src/test/update-effect-props.test.ts
+++ b/packages/studio-server/src/test/update-effect-props.test.ts
@@ -213,3 +213,41 @@ test('updateEffectProps removes props from inactive enum variants', () => {
 	expect(serialized).toContain('opacity: 0.5');
 	expect(removedProps).toEqual([{key: 'dotColor', valueString: '"red  blue"'}]);
 });
+
+test('updateEffectProps writes keyframed effect params from clipboard data', () => {
+	const input = buildInput('[tint({color: "red"})]');
+	const {serialized, newValueString} = updateEffectPropsAst({
+		input,
+		sequenceNodePath: lineColumnToNodePath(input, 6),
+		effectIndex: 0,
+		update: {
+			key: 'opacity',
+			effectParam: {
+				type: 'keyframed',
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 0},
+					{frame: 30, value: 1},
+				],
+				easing: [[0.1, 0.2, 0.3, 0.4]],
+				clamping: {left: 'clamp', right: 'extend'},
+				posterize: 2,
+			},
+			defaultValue: null,
+		},
+		schema: tintSchema,
+	});
+
+	expect(serialized).toContain('Easing');
+	expect(serialized).toContain('interpolate');
+	expect(serialized).toContain('useCurrentFrame');
+	expect(serialized).toContain('from "remotion"');
+	expect(serialized).toContain('const frame = useCurrentFrame();');
+	expect(serialized).toContain(
+		'opacity: interpolate(frame, [0, 30], [0, 1], {',
+	);
+	expect(serialized).toContain('extrapolateLeft: "clamp"');
+	expect(serialized).toContain('easing: [Easing.bezier(0.1, 0.2, 0.3, 0.4)]');
+	expect(serialized).toContain('posterize: 2');
+	expect(newValueString).toContain('interpolate(frame, [0, 30], [0, 1]');
+});

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -325,7 +325,7 @@ type SaveEffectPropsRequestBase = {
 
 export type SaveEffectPropsRequest =
 	| (SaveEffectPropsRequestBase & {
-			type?: 'value';
+			type: 'value';
 			value: string;
 	  })
 	| (SaveEffectPropsRequestBase & {

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -24,6 +24,7 @@ import type {
 } from 'remotion';
 import type {RecastCodemod, VisualControlChange} from './codemods';
 import type {
+	EffectClipboardParam,
 	EffectClipboardPasteType,
 	EffectClipboardSnapshot,
 } from './effect-clipboard-data';
@@ -312,16 +313,25 @@ export type SaveSequencePropsResponse =
 			reason: CannotUpdateSequenceReason;
 	  };
 
-export type SaveEffectPropsRequest = {
+type SaveEffectPropsRequestBase = {
 	fileName: string;
 	sequenceNodePath: SequencePropsSubscriptionKey;
 	effectIndex: number;
 	key: string;
-	value: string;
 	defaultValue: string | null;
 	schema: SequenceSchema;
 	clientId: string;
 };
+
+export type SaveEffectPropsRequest =
+	| (SaveEffectPropsRequestBase & {
+			type?: 'value';
+			value: string;
+	  })
+	| (SaveEffectPropsRequestBase & {
+			type: 'effect-param';
+			effectParam: EffectClipboardParam;
+	  });
 
 export type SaveEffectPropsResponse = CanUpdateEffectPropsResponse;
 

--- a/packages/studio-shared/src/effect-clipboard-data.ts
+++ b/packages/studio-shared/src/effect-clipboard-data.ts
@@ -57,10 +57,35 @@ export type EffectClipboardData = {
 	readonly effects: EffectClipboardSnapshot[];
 };
 
+export type EffectPropClipboardData = {
+	readonly type: 'effect-prop';
+	readonly version: 1;
+	readonly remotionClipboard: 'effect-prop';
+	readonly effect: {
+		readonly callee: string;
+		readonly importPath: string;
+	};
+	readonly key: string;
+	readonly param: EffectClipboardParam;
+};
+
 export type EffectClipboardDataParseResult =
 	| {
 			readonly status: 'valid';
 			readonly data: EffectClipboardData;
+	  }
+	| {
+			readonly status: 'unsupported-version';
+			readonly version: unknown;
+	  }
+	| {
+			readonly status: 'invalid';
+	  };
+
+export type EffectPropClipboardDataParseResult =
+	| {
+			readonly status: 'valid';
+			readonly data: EffectPropClipboardData;
 	  }
 	| {
 			readonly status: 'unsupported-version';
@@ -210,6 +235,79 @@ export const parseEffectClipboardData = (
 	value: string,
 ): EffectClipboardData | null => {
 	const result = parseEffectClipboardDataResult(value);
+	if (result.status !== 'valid') {
+		return null;
+	}
+
+	return result.data;
+};
+
+export const parseEffectPropClipboardDataResult = (
+	value: string,
+): EffectPropClipboardDataParseResult => {
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!isRecord(parsed)) {
+			return {status: 'invalid'};
+		}
+
+		if (parsed.remotionClipboard !== 'effect-prop') {
+			return {status: 'invalid'};
+		}
+
+		if (parsed.version !== 1) {
+			return {
+				status: 'unsupported-version',
+				version: parsed.version,
+			};
+		}
+
+		if (parsed.type !== 'effect-prop') {
+			return {status: 'invalid'};
+		}
+
+		if (!isRecord(parsed.effect)) {
+			return {status: 'invalid'};
+		}
+
+		if (
+			typeof parsed.effect.callee !== 'string' ||
+			typeof parsed.effect.importPath !== 'string'
+		) {
+			return {status: 'invalid'};
+		}
+
+		if (typeof parsed.key !== 'string') {
+			return {status: 'invalid'};
+		}
+
+		if (!isEffectClipboardParam(parsed.param)) {
+			return {status: 'invalid'};
+		}
+
+		return {
+			status: 'valid',
+			data: {
+				type: 'effect-prop',
+				version: 1,
+				remotionClipboard: 'effect-prop',
+				effect: {
+					callee: parsed.effect.callee,
+					importPath: parsed.effect.importPath,
+				},
+				key: parsed.key,
+				param: parsed.param,
+			},
+		};
+	} catch {
+		return {status: 'invalid'};
+	}
+};
+
+export const parseEffectPropClipboardData = (
+	value: string,
+): EffectPropClipboardData | null => {
+	const result = parseEffectPropClipboardDataResult(value);
 	if (result.status !== 'valid') {
 		return null;
 	}

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -95,6 +95,8 @@ export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state
 export {
 	parseEffectClipboardData,
 	parseEffectClipboardDataResult,
+	parseEffectPropClipboardData,
+	parseEffectPropClipboardDataResult,
 	type EffectClipboardClamping,
 	type EffectClipboardData,
 	type EffectClipboardDataParseResult,
@@ -107,6 +109,8 @@ export {
 	type EffectClipboardPasteType,
 	type EffectClipboardSnapshot,
 	type EffectClipboardStaticParam,
+	type EffectPropClipboardData,
+	type EffectPropClipboardDataParseResult,
 } from './effect-clipboard-data';
 export {
 	EFFECT_DRAG_MIME_TYPE,

--- a/packages/studio-shared/src/test/effect-clipboard-data.test.ts
+++ b/packages/studio-shared/src/test/effect-clipboard-data.test.ts
@@ -2,6 +2,8 @@ import {expect, test} from 'bun:test';
 import {
 	parseEffectClipboardData,
 	parseEffectClipboardDataResult,
+	parseEffectPropClipboardData,
+	parseEffectPropClipboardDataResult,
 } from '../effect-clipboard-data';
 
 test('parseEffectClipboardData accepts keyframed v3 effect payloads', () => {
@@ -149,4 +151,70 @@ test('parseEffectClipboardData rejects malformed keyframed payloads', () => {
 			}),
 		),
 	).toBe(null);
+});
+
+test('parseEffectPropClipboardData accepts keyframed effect prop payloads', () => {
+	const parsed = parseEffectPropClipboardData(
+		JSON.stringify({
+			type: 'effect-prop',
+			version: 1,
+			remotionClipboard: 'effect-prop',
+			effect: {
+				callee: 'brightness',
+				importPath: '@remotion/effects/brightness',
+			},
+			key: 'amount',
+			param: {
+				type: 'keyframed',
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 0},
+					{frame: 100, value: 1},
+				],
+				easing: ['linear'],
+				clamping: {left: 'clamp', right: 'clamp'},
+			},
+		}),
+	);
+
+	expect(parsed).toEqual({
+		type: 'effect-prop',
+		version: 1,
+		remotionClipboard: 'effect-prop',
+		effect: {
+			callee: 'brightness',
+			importPath: '@remotion/effects/brightness',
+		},
+		key: 'amount',
+		param: {
+			type: 'keyframed',
+			interpolationFunction: 'interpolate',
+			keyframes: [
+				{frame: 0, value: 0},
+				{frame: 100, value: 1},
+			],
+			easing: ['linear'],
+			clamping: {left: 'clamp', right: 'clamp'},
+		},
+	});
+});
+
+test('parseEffectPropClipboardData reports old payloads as unsupported', () => {
+	const payload = JSON.stringify({
+		type: 'effect-prop',
+		version: 0,
+		remotionClipboard: 'effect-prop',
+		effect: {
+			callee: 'brightness',
+			importPath: '@remotion/effects/brightness',
+		},
+		key: 'amount',
+		param: {type: 'static', value: 1},
+	});
+
+	expect(parseEffectPropClipboardData(payload)).toBe(null);
+	expect(parseEffectPropClipboardDataResult(payload)).toEqual({
+		status: 'unsupported-version',
+		version: 0,
+	});
 });

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -35,9 +35,9 @@ import {getLinkedScale} from './Timeline/TimelineScaleField';
 import {
 	ENABLE_OUTLINES,
 	getTimelineSequenceSelectionKey,
+	useTimelineSelection,
 	type TimelineSelection,
 	type TimelineSelectionInteraction,
-	useTimelineSelection,
 } from './Timeline/TimelineSelection';
 
 type OutlinePoint = {
@@ -1537,6 +1537,7 @@ const SelectedUvHandleCircle: React.FC<{
 				}
 
 				saveEffectProp({
+					type: 'value',
 					fileName: handle.nodePath.absolutePath,
 					nodePath: handle.nodePath,
 					effectIndex: handle.effectIndex,

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -658,8 +658,14 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 								effectIndex: effectPropTarget.effectIndex,
 								fieldKey: effectPropTarget.fieldKey,
 								...(effectPropResult.data.param.type === 'static'
-									? {value: effectPropResult.data.param.value}
-									: {effectParam: effectPropResult.data.param}),
+									? {
+											type: 'value' as const,
+											value: effectPropResult.data.param.value,
+										}
+									: {
+											type: 'effect-param' as const,
+											effectParam: effectPropResult.data.param,
+										}),
 								defaultValue: effectPropTarget.defaultValue,
 								schema: effectPropTarget.schema,
 								setCodeValues,

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -1,28 +1,41 @@
 import {
 	isKeyframeInterpolationFunction,
 	parseEffectClipboardDataResult,
+	parseEffectPropClipboardDataResult,
 	type EffectClipboardData,
 	type EffectClipboardInterpolationFunction,
 	type EffectClipboardParam,
 	type EffectClipboardPasteType,
 	type EffectClipboardSnapshot,
+	type EffectPropClipboardData,
 } from '@remotion/studio-shared';
 import type React from 'react';
 import {useContext, useEffect} from 'react';
-import {Internals, type SequencePropsSubscriptionKey} from 'remotion';
+import {
+	Internals,
+	type CodeValues,
+	type OverrideIdToNodePaths,
+	type SequenceFieldSchema,
+	type SequencePropsSubscriptionKey,
+	type SequenceSchema,
+	type TSequence,
+} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {useKeybinding} from '../../helpers/use-keybinding';
 import {callApi} from '../call-api';
 import {showNotification} from '../Notifications/NotificationCenter';
+import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
+import {saveEffectProp} from './save-effect-prop';
 import {
 	useCurrentTimelineSelectionStateAsRef,
 	useTimelineSelection,
 	type TimelineSelection,
 } from './TimelineSelection';
 
-const makeClipboardText = (payload: EffectClipboardData) =>
-	JSON.stringify(payload);
+const makeClipboardText = (
+	payload: EffectClipboardData | EffectPropClipboardData,
+) => JSON.stringify(payload);
 
 const makeTargetKey = (nodePath: SequencePropsSubscriptionKey): string => {
 	return JSON.stringify({
@@ -46,6 +59,38 @@ export type PasteEffectsTarget =
 	| {
 			readonly type: 'unsupported';
 	  };
+
+export type PasteEffectPropTarget =
+	| {
+			readonly type: 'valid';
+			readonly fileName: string;
+			readonly nodePath: SequencePropsSubscriptionKey;
+			readonly effectIndex: number;
+			readonly fieldKey: string;
+			readonly defaultValue: string | null;
+			readonly schema: SequenceSchema;
+	  }
+	| {
+			readonly type:
+				| 'none'
+				| 'multiple'
+				| 'unsupported'
+				| 'effect-type-mismatch'
+				| 'prop-mismatch'
+				| 'uncopyable';
+	  };
+
+const isVisibleFieldSchema = (
+	fieldSchema: SequenceFieldSchema | undefined,
+): fieldSchema is Exclude<SequenceFieldSchema, {type: 'hidden'}> =>
+	fieldSchema !== undefined && fieldSchema.type !== 'hidden';
+
+const getDefaultValue = (
+	fieldSchema: Exclude<SequenceFieldSchema, {type: 'hidden'}>,
+) =>
+	fieldSchema.default !== undefined
+		? JSON.stringify(fieldSchema.default)
+		: null;
 
 const getTargetSequenceNodePathInfo = (
 	selection: TimelineSelection,
@@ -127,6 +172,38 @@ const isClipboardInterpolationFunction = (
 	return isKeyframeInterpolationFunction(value);
 };
 
+const effectPropStatusToClipboardParam = (
+	prop: CopyableEffectStatus['props'][string],
+): EffectClipboardParam | null => {
+	if (prop.status === 'computed') {
+		return null;
+	}
+
+	if (prop.status === 'static') {
+		if (prop.codeValue === undefined) {
+			return null;
+		}
+
+		return {
+			type: 'static',
+			value: prop.codeValue,
+		};
+	}
+
+	if (!isClipboardInterpolationFunction(prop.interpolationFunction)) {
+		return null;
+	}
+
+	return {
+		type: 'keyframed',
+		interpolationFunction: prop.interpolationFunction,
+		keyframes: prop.keyframes,
+		easing: prop.easing,
+		clamping: prop.clamping,
+		...(prop.posterize === undefined ? {} : {posterize: prop.posterize}),
+	};
+};
+
 const effectStatusToSnapshot = (
 	effect: CopyableEffectStatus,
 ): EffectClipboardSnapshot | null => {
@@ -136,33 +213,16 @@ const effectStatusToSnapshot = (
 
 	const params: Record<string, EffectClipboardParam> = {};
 	for (const [key, prop] of Object.entries(effect.props)) {
-		if (prop.status === 'computed') {
-			return null;
-		}
-
-		if (prop.status === 'static') {
-			if (prop.codeValue !== undefined) {
-				params[key] = {
-					type: 'static',
-					value: prop.codeValue,
-				};
-			}
-
+		if (prop.status === 'static' && prop.codeValue === undefined) {
 			continue;
 		}
 
-		if (!isClipboardInterpolationFunction(prop.interpolationFunction)) {
+		const param = effectPropStatusToClipboardParam(prop);
+		if (param === null) {
 			return null;
 		}
 
-		params[key] = {
-			type: 'keyframed',
-			interpolationFunction: prop.interpolationFunction,
-			keyframes: prop.keyframes,
-			easing: prop.easing,
-			clamping: prop.clamping,
-			...(prop.posterize === undefined ? {} : {posterize: prop.posterize}),
-		};
+		params[key] = param;
 	}
 
 	return {
@@ -225,12 +285,175 @@ export const getSnapshotsFromSelection = ({
 	return snapshots;
 };
 
+export const getEffectPropClipboardDataFromSelection = ({
+	selection,
+	codeValues,
+}: {
+	selection: TimelineSelection;
+	codeValues: CodeValues;
+}): EffectPropClipboardData | null => {
+	if (selection.type !== 'sequence-effect-prop') {
+		return null;
+	}
+
+	const sequenceStatus =
+		codeValues[
+			Internals.makeSequencePropsSubscriptionKey(
+				selection.nodePathInfo.sequenceSubscriptionKey,
+			)
+		];
+	if (!sequenceStatus || !sequenceStatus.canUpdate) {
+		return null;
+	}
+
+	const effect = sequenceStatus.effects.find(
+		(item) => item.effectIndex === selection.i,
+	);
+	if (!effect?.canUpdate || effect.importPath === null) {
+		return null;
+	}
+
+	const prop = effect.props[selection.key];
+	if (!prop) {
+		return null;
+	}
+
+	const param = effectPropStatusToClipboardParam(prop);
+	if (param === null) {
+		return null;
+	}
+
+	return {
+		type: 'effect-prop',
+		version: 1,
+		remotionClipboard: 'effect-prop',
+		effect: {
+			callee: effect.callee,
+			importPath: effect.importPath,
+		},
+		key: selection.key,
+		param,
+	};
+};
+
+export const getPasteEffectPropTarget = ({
+	selectedItems,
+	payload,
+	codeValues,
+	sequences,
+	overrideIdsToNodePaths,
+}: {
+	readonly selectedItems: readonly TimelineSelection[];
+	readonly payload: EffectPropClipboardData;
+	readonly codeValues: CodeValues;
+	readonly sequences: TSequence[];
+	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
+}): PasteEffectPropTarget => {
+	if (selectedItems.length === 0) {
+		return {type: 'none'};
+	}
+
+	if (selectedItems.length !== 1) {
+		return {type: 'multiple'};
+	}
+
+	const [selection] = selectedItems;
+	if (!selection) {
+		return {type: 'none'};
+	}
+
+	if (!selection.nodePathInfo.supportsEffects) {
+		return {type: 'unsupported'};
+	}
+
+	const target =
+		selection.type === 'sequence-effect-prop'
+			? {
+					effectIndex: selection.i,
+					fieldKey: selection.key,
+				}
+			: selection.type === 'sequence-effect'
+				? {
+						effectIndex: selection.i,
+						fieldKey: payload.key,
+					}
+				: null;
+
+	if (target === null) {
+		return {type: 'none'};
+	}
+
+	if (
+		selection.type === 'sequence-effect-prop' &&
+		selection.key !== payload.key
+	) {
+		return {type: 'prop-mismatch'};
+	}
+
+	const track = findTrackForNodePathInfo({
+		sequences,
+		overrideIdsToNodePaths,
+		nodePathInfo: selection.nodePathInfo,
+	});
+	const sequence = track?.sequence ?? null;
+	if (!sequence) {
+		return {type: 'none'};
+	}
+
+	const effect = sequence.effects[target.effectIndex];
+	const fieldSchema = effect?.schema[target.fieldKey];
+	if (!effect || !isVisibleFieldSchema(fieldSchema)) {
+		return {type: 'prop-mismatch'};
+	}
+
+	const sequenceStatus =
+		codeValues[
+			Internals.makeSequencePropsSubscriptionKey(
+				selection.nodePathInfo.sequenceSubscriptionKey,
+			)
+		];
+	if (!sequenceStatus?.canUpdate) {
+		return {type: 'uncopyable'};
+	}
+
+	const effectStatus = sequenceStatus.effects.find(
+		(item) => item.effectIndex === target.effectIndex,
+	);
+	if (!effectStatus?.canUpdate) {
+		return {type: 'uncopyable'};
+	}
+
+	if (effectStatus.importPath !== payload.effect.importPath) {
+		return {type: 'effect-type-mismatch'};
+	}
+
+	const propStatus = effectStatus.props[target.fieldKey];
+	if (!propStatus || propStatus.status === 'computed') {
+		return {type: 'uncopyable'};
+	}
+
+	return {
+		type: 'valid',
+		fileName: selection.nodePathInfo.sequenceSubscriptionKey.absolutePath,
+		nodePath: selection.nodePathInfo.sequenceSubscriptionKey,
+		effectIndex: target.effectIndex,
+		fieldKey: target.fieldKey,
+		defaultValue: getDefaultValue(fieldSchema),
+		schema: effect.schema,
+	};
+};
+
 export const TimelineClipboardKeybindings: React.FC = () => {
 	const keybindings = useKeybinding();
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {canSelect} = useTimelineSelection();
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {sequences} = useContext(Internals.SequenceManager);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
 
 	useEffect(() => {
 		if (!canSelect || previewServerState.type !== 'connected') {
@@ -245,6 +468,46 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 			callback: (e) => {
 				const {selectedItems} = currentSelection.current;
 				if (selectedItems.length === 0) {
+					return;
+				}
+
+				if (
+					selectedItems.some(
+						(selection) => selection.type === 'sequence-effect-prop',
+					)
+				) {
+					e.preventDefault();
+					if (
+						selectedItems.length !== 1 ||
+						selectedItems[0]?.type !== 'sequence-effect-prop'
+					) {
+						showNotification('Select one effect prop to copy its value', 3000);
+						return;
+					}
+
+					const payload = getEffectPropClipboardDataFromSelection({
+						selection: selectedItems[0],
+						codeValues,
+					});
+					if (payload === null) {
+						showNotification(
+							'Cannot copy effect prop because its value cannot be copied',
+							3000,
+						);
+						return;
+					}
+
+					navigator.clipboard
+						.writeText(makeClipboardText(payload))
+						.then(() => {
+							showNotification('Copied effect prop to clipboard', 1000);
+						})
+						.catch((err) => {
+							showNotification(
+								`Could not copy effect prop: ${(err as Error).message}`,
+								2000,
+							);
+						});
 					return;
 				}
 
@@ -325,6 +588,87 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 				navigator.clipboard
 					.readText()
 					.then((text) => {
+						const effectPropResult = parseEffectPropClipboardDataResult(text);
+						if (effectPropResult.status !== 'invalid') {
+							e.preventDefault();
+							if (effectPropResult.status === 'unsupported-version') {
+								showNotification(
+									'Cannot paste effect prop copied from a different Remotion Studio version',
+									4000,
+								);
+								return;
+							}
+
+							const effectPropTarget = getPasteEffectPropTarget({
+								selectedItems,
+								payload: effectPropResult.data,
+								codeValues,
+								sequences,
+								overrideIdsToNodePaths: overrideIdToNodePathMappings,
+							});
+
+							if (effectPropTarget.type !== 'valid') {
+								switch (effectPropTarget.type) {
+									case 'multiple':
+										showNotification(
+											'Select one target effect prop or effect to paste onto',
+											3000,
+										);
+										return;
+									case 'none':
+										showNotification(
+											'Select a matching effect prop or effect to paste onto',
+											3000,
+										);
+										return;
+									case 'unsupported':
+										showNotification(
+											'This sequence does not support effects',
+											3000,
+										);
+										return;
+									case 'effect-type-mismatch':
+										showNotification(
+											'Select an effect of the same type to paste this prop',
+											3000,
+										);
+										return;
+									case 'prop-mismatch':
+										showNotification(
+											'Select the same effect prop, or an effect with that prop',
+											3000,
+										);
+										return;
+									case 'uncopyable':
+										showNotification(
+											'Cannot paste onto an effect prop that cannot be updated',
+											3000,
+										);
+										return;
+									default:
+										throw new Error(
+											`Unexpected paste target: ${effectPropTarget satisfies never}`,
+										);
+								}
+							}
+
+							return saveEffectProp({
+								fileName: effectPropTarget.fileName,
+								nodePath: effectPropTarget.nodePath,
+								effectIndex: effectPropTarget.effectIndex,
+								fieldKey: effectPropTarget.fieldKey,
+								...(effectPropResult.data.param.type === 'static'
+									? {value: effectPropResult.data.param.value}
+									: {effectParam: effectPropResult.data.param}),
+								defaultValue: effectPropTarget.defaultValue,
+								schema: effectPropTarget.schema,
+								setCodeValues,
+								clientId,
+							}).then(() => {
+								showNotification('Pasted effect prop', 2000);
+							});
+						}
+
 						const result = parseEffectClipboardDataResult(text);
 						if (result.status === 'invalid') {
 							return;
@@ -398,7 +742,10 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 		codeValues,
 		currentSelection,
 		keybindings,
+		overrideIdToNodePathMappings,
 		previewServerState,
+		sequences,
+		setCodeValues,
 	]);
 
 	return null;

--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -265,6 +265,7 @@ export const TimelineEffectItem: React.FC<{
 					: null;
 
 			saveEffectProp({
+				type: 'value',
 				fileName: validatedLocation.source,
 				nodePath,
 				effectIndex,

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -187,6 +187,7 @@ const Value: React.FC<{
 					}),
 				apiCall: () =>
 					callApi('/api/save-effect-props', {
+						type: 'value',
 						fileName: validatedLocation.source,
 						sequenceNodePath: nodePath,
 						effectIndex: field.effectIndex,
@@ -431,6 +432,7 @@ export const TimelineEffectPropItem: React.FC<{
 				: null;
 
 		saveEffectProp({
+			type: 'value',
 			fileName: validatedLocation.source,
 			nodePath,
 			effectIndex: field.effectIndex,

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -258,6 +258,7 @@ export const resetSelectedTimelineProps = ({
 	for (const target of effectPropTargets) {
 		resetPromises.push(
 			saveEffectProp({
+				type: 'value',
 				fileName: target.fileName,
 				nodePath: target.nodePath,
 				effectIndex: target.effectIndex,

--- a/packages/studio/src/components/Timeline/save-effect-prop.ts
+++ b/packages/studio/src/components/Timeline/save-effect-prop.ts
@@ -1,4 +1,7 @@
-import {optimisticUpdateForEffectCodeValues} from '@remotion/studio-shared';
+import {
+	optimisticUpdateForEffectCodeValues,
+	type EffectClipboardParam,
+} from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
 import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
@@ -11,6 +14,7 @@ export const saveEffectProp = ({
 	effectIndex,
 	fieldKey,
 	value,
+	effectParam,
 	defaultValue,
 	schema,
 	setCodeValues,
@@ -20,7 +24,8 @@ export const saveEffectProp = ({
 	nodePath: SequencePropsSubscriptionKey;
 	effectIndex: number;
 	fieldKey: string;
-	value: unknown;
+	value?: unknown;
+	effectParam?: EffectClipboardParam;
 	defaultValue: string | null;
 	schema: SequenceSchema;
 	setCodeValues: SetCodeValues;
@@ -30,26 +35,43 @@ export const saveEffectProp = ({
 		nodePath,
 		setCodeValues,
 		applyOptimistic: (prev) =>
-			optimisticUpdateForEffectCodeValues({
-				previous: prev,
-				effectIndex,
-				fieldKey,
-				value,
-				schema,
-			}),
+			effectParam
+				? prev
+				: optimisticUpdateForEffectCodeValues({
+						previous: prev,
+						effectIndex,
+						fieldKey,
+						value,
+						schema,
+					}),
 		applyServerResponse: (prev, response) =>
 			applyEffectResponseToCodeValues({previous: prev, response}),
 		apiCall: () =>
-			callApi('/api/save-effect-props', {
-				fileName,
-				sequenceNodePath: nodePath,
-				effectIndex,
-				key: fieldKey,
-				value: JSON.stringify(value),
-				defaultValue,
-				schema,
-				clientId,
-			}),
+			callApi(
+				'/api/save-effect-props',
+				effectParam
+					? {
+							type: 'effect-param',
+							fileName,
+							sequenceNodePath: nodePath,
+							effectIndex,
+							key: fieldKey,
+							effectParam,
+							defaultValue,
+							schema,
+							clientId,
+						}
+					: {
+							fileName,
+							sequenceNodePath: nodePath,
+							effectIndex,
+							key: fieldKey,
+							value: JSON.stringify(value),
+							defaultValue,
+							schema,
+							clientId,
+						},
+			),
 		errorLabel: 'Could not save effect prop',
 	});
 };

--- a/packages/studio/src/components/Timeline/save-effect-prop.ts
+++ b/packages/studio/src/components/Timeline/save-effect-prop.ts
@@ -8,40 +8,52 @@ import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-v
 import {enqueueSavePropChange} from './save-prop-queue';
 import type {SetCodeValues} from './save-sequence-prop';
 
-export const saveEffectProp = ({
-	fileName,
-	nodePath,
-	effectIndex,
-	fieldKey,
-	value,
-	effectParam,
-	defaultValue,
-	schema,
-	setCodeValues,
-	clientId,
-}: {
+type SaveEffectPropBase = {
 	fileName: string;
 	nodePath: SequencePropsSubscriptionKey;
 	effectIndex: number;
 	fieldKey: string;
-	value?: unknown;
-	effectParam?: EffectClipboardParam;
 	defaultValue: string | null;
 	schema: SequenceSchema;
 	setCodeValues: SetCodeValues;
 	clientId: string;
-}): Promise<void> => {
+};
+
+type SaveEffectPropValue = SaveEffectPropBase & {
+	type: 'value';
+	value: unknown;
+};
+
+type SaveEffectPropEffectParam = SaveEffectPropBase & {
+	type: 'effect-param';
+	effectParam: EffectClipboardParam;
+};
+
+type SaveEffectPropInput = SaveEffectPropValue | SaveEffectPropEffectParam;
+
+export const saveEffectProp = (input: SaveEffectPropInput): Promise<void> => {
+	const {
+		fileName,
+		nodePath,
+		effectIndex,
+		fieldKey,
+		defaultValue,
+		schema,
+		setCodeValues,
+		clientId,
+	} = input;
+
 	return enqueueSavePropChange({
 		nodePath,
 		setCodeValues,
 		applyOptimistic: (prev) =>
-			effectParam
+			input.type === 'effect-param'
 				? prev
 				: optimisticUpdateForEffectCodeValues({
 						previous: prev,
 						effectIndex,
 						fieldKey,
-						value,
+						value: input.value,
 						schema,
 					}),
 		applyServerResponse: (prev, response) =>
@@ -49,24 +61,25 @@ export const saveEffectProp = ({
 		apiCall: () =>
 			callApi(
 				'/api/save-effect-props',
-				effectParam
+				input.type === 'effect-param'
 					? {
 							type: 'effect-param',
 							fileName,
 							sequenceNodePath: nodePath,
 							effectIndex,
 							key: fieldKey,
-							effectParam,
+							effectParam: input.effectParam,
 							defaultValue,
 							schema,
 							clientId,
 						}
 					: {
+							type: 'value',
 							fileName,
 							sequenceNodePath: nodePath,
 							effectIndex,
 							key: fieldKey,
-							value: JSON.stringify(value),
+							value: JSON.stringify(input.value),
 							defaultValue,
 							schema,
 							clientId,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -28,8 +28,11 @@ import {deleteSelectedTimelineItems} from '../components/Timeline/delete-selecte
 import {isDuplicatableSequenceRowSelection} from '../components/Timeline/duplicate-selected-timeline-item';
 import {getTimelinePropResetTargets} from '../components/Timeline/reset-selected-timeline-props';
 import {
+	getEffectPropClipboardDataFromSelection,
+	getPasteEffectPropTarget,
 	getPasteEffectsTarget,
 	getSnapshotsFromSelection,
+	type PasteEffectPropTarget,
 	type PasteEffectsTarget,
 } from '../components/Timeline/TimelineClipboardKeybindings';
 import {
@@ -274,6 +277,222 @@ test('copying a keyframed effect creates a structured snapshot', () => {
 			},
 		},
 	]);
+});
+
+test('copying a selected effect prop creates an effect prop payload', () => {
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'intensity'],
+		true,
+		[['0', 'intensity']],
+	);
+	const nodePath = effectPropNodePathInfo.sequenceSubscriptionKey;
+	const codeValues = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'halftone',
+					importPath: '@remotion/effects/halftone',
+					effectIndex: 0,
+					props: {
+						intensity: {
+							status: 'keyframed',
+							codeValue: 10,
+							interpolationFunction: 'interpolate',
+							keyframes: [
+								{frame: 0, value: 10},
+								{frame: 100, value: 20},
+							],
+							easing: ['linear'],
+							clamping: {left: 'clamp', right: 'clamp'},
+							posterize: undefined,
+						},
+					},
+				},
+			],
+		},
+	} satisfies CodeValues;
+
+	expect(
+		getEffectPropClipboardDataFromSelection({
+			selection: {
+				type: 'sequence-effect-prop',
+				nodePathInfo: effectPropNodePathInfo,
+				i: 0,
+				key: 'intensity',
+			},
+			codeValues,
+		}),
+	).toEqual({
+		type: 'effect-prop',
+		version: 1,
+		remotionClipboard: 'effect-prop',
+		effect: {
+			callee: 'halftone',
+			importPath: '@remotion/effects/halftone',
+		},
+		key: 'intensity',
+		param: {
+			type: 'keyframed',
+			interpolationFunction: 'interpolate',
+			keyframes: [
+				{frame: 0, value: 10},
+				{frame: 100, value: 20},
+			],
+			easing: ['linear'],
+			clamping: {left: 'clamp', right: 'clamp'},
+		},
+	});
+});
+
+test('pasting an effect prop targets a matching selected effect', () => {
+	const effectNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '1'],
+		true,
+		[['1']],
+	);
+	const nodePath = effectNodePathInfo.sequenceSubscriptionKey;
+	const effectSchema = {
+		intensity: {type: 'number', default: 0, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const codeValues = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'halftone',
+					importPath: '@remotion/effects/halftone',
+					effectIndex: 1,
+					props: {
+						intensity: {status: 'static', codeValue: 0},
+					},
+				},
+			],
+		},
+	} satisfies CodeValues;
+
+	expect(
+		getPasteEffectPropTarget({
+			selectedItems: [
+				{type: 'sequence-effect', nodePathInfo: effectNodePathInfo, i: 1},
+			],
+			payload: {
+				type: 'effect-prop',
+				version: 1,
+				remotionClipboard: 'effect-prop',
+				effect: {
+					callee: 'halftone',
+					importPath: '@remotion/effects/halftone',
+				},
+				key: 'intensity',
+				param: {type: 'static', value: 10},
+			},
+			codeValues,
+			sequences: [
+				makeTimelineSequence({
+					schema: {},
+					effects: [{schema: effectSchema}, {schema: effectSchema}],
+				}),
+			],
+			overrideIdsToNodePaths: {override: nodePath},
+		}),
+	).toEqual({
+		type: 'valid',
+		fileName: '/project/src/Comp.tsx',
+		nodePath,
+		effectIndex: 1,
+		fieldKey: 'intensity',
+		defaultValue: '0',
+		schema: effectSchema,
+	} satisfies PasteEffectPropTarget);
+});
+
+test('pasting an effect prop requires the same effect type and prop key', () => {
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'opacity'],
+		true,
+		[['0', 'opacity']],
+	);
+	const nodePath = effectPropNodePathInfo.sequenceSubscriptionKey;
+	const effectSchema = {
+		opacity: {type: 'number', default: 1, hiddenFromList: false},
+		intensity: {type: 'number', default: 0, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const codeValues = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'blur',
+					importPath: '@remotion/effects/blur',
+					effectIndex: 0,
+					props: {
+						opacity: {status: 'static', codeValue: 1},
+						intensity: {status: 'static', codeValue: 0},
+					},
+				},
+			],
+		},
+	} satisfies CodeValues;
+	const basePayload = {
+		type: 'effect-prop' as const,
+		version: 1 as const,
+		remotionClipboard: 'effect-prop' as const,
+		effect: {
+			callee: 'halftone',
+			importPath: '@remotion/effects/halftone',
+		},
+		key: 'intensity',
+		param: {type: 'static' as const, value: 10},
+	};
+
+	expect(
+		getPasteEffectPropTarget({
+			selectedItems: [
+				{
+					type: 'sequence-effect-prop',
+					nodePathInfo: effectPropNodePathInfo,
+					i: 0,
+					key: 'opacity',
+				},
+			],
+			payload: basePayload,
+			codeValues,
+			sequences: [
+				makeTimelineSequence({
+					schema: {},
+					effects: [{schema: effectSchema}],
+				}),
+			],
+			overrideIdsToNodePaths: {override: nodePath},
+		}),
+	).toEqual({type: 'prop-mismatch'} satisfies PasteEffectPropTarget);
+
+	expect(
+		getPasteEffectPropTarget({
+			selectedItems: [
+				{type: 'sequence-effect', nodePathInfo: effectPropNodePathInfo, i: 0},
+			],
+			payload: basePayload,
+			codeValues,
+			sequences: [
+				makeTimelineSequence({
+					schema: {},
+					effects: [{schema: effectSchema}],
+				}),
+			],
+			overrideIdsToNodePaths: {override: nodePath},
+		}),
+	).toEqual({type: 'effect-type-mismatch'} satisfies PasteEffectPropTarget);
 });
 
 test('Timeline top drag should not be enabled', () => {


### PR DESCRIPTION
## Summary

- Add an effect-prop clipboard payload for copying individual effect values.
- Allow pasting onto the exact matching effect prop or onto a matching effect that has the prop.
- Reuse keyframed effect expression generation so pasted keyframes write interpolate() code correctly.

Fixes #7991

## Testing

- bun test packages/studio-shared/src/test/effect-clipboard-data.test.ts packages/studio/src/test/timeline-selection.test.ts packages/studio-server/src/test/update-effect-props.test.ts
- bun run build
- bun run stylecheck
