### PR TITLE
`@remotion/media`: Fix non-monotonic frame cache

### DIFF
--- a/packages/media/src/test/keyframe-bank.test.ts
+++ b/packages/media/src/test/keyframe-bank.test.ts
@@ -1,0 +1,79 @@
+import type {VideoSample, VideoSampleSink} from 'mediabunny';
+import {expect, test} from 'vitest';
+import {makeKeyframeBank} from '../video-extraction/keyframe-bank';
+
+type FakeFrame = VideoSample & {
+	closed: boolean;
+};
+
+const makeFrame = (timestamp: number): FakeFrame => {
+	return {
+		timestamp,
+		duration: 0.001,
+		codedWidth: 1,
+		codedHeight: 1,
+		format: null,
+		closed: false,
+		allocationSize: () => 4,
+		close() {
+			this.closed = true;
+		},
+	} as FakeFrame;
+};
+
+const makeVideoSampleSink = (timestamps: number[]): VideoSampleSink => {
+	const samples = async function* () {
+		for (const timestamp of timestamps) {
+			yield makeFrame(timestamp);
+		}
+	};
+
+	return {
+		samples,
+	} as unknown as VideoSampleSink;
+};
+
+const makeReorderedTimestamps = (frames: number) => {
+	const timestamps = [0];
+	for (let base = 0; timestamps.length < frames; base += 4) {
+		for (const offset of [3, 2, 4, 1]) {
+			timestamps.push((base + offset) / 1000);
+			if (timestamps.length === frames) {
+				break;
+			}
+		}
+	}
+
+	return timestamps;
+};
+
+test('keyframe bank handles samples with non-monotonic timestamps', async () => {
+	const bank = await makeKeyframeBank({
+		logLevel: 'error',
+		src: 'test-src',
+		videoSampleSink: makeVideoSampleSink(makeReorderedTimestamps(120)),
+		initialTimestampRequest: 0,
+	});
+
+	const frame = await bank.getFrameFromTimestamp(0.0018, 1000);
+
+	expect(frame?.timestamp).toBe(0.002);
+
+	const {timestamps} = bank.getOpenFrameCount();
+	expect(timestamps).toEqual([...timestamps].sort((a, b) => a - b));
+});
+
+test('keyframe bank evicts old frames despite non-monotonic timestamps', async () => {
+	const bank = await makeKeyframeBank({
+		logLevel: 'error',
+		src: 'test-src',
+		videoSampleSink: makeVideoSampleSink(makeReorderedTimestamps(160)),
+		initialTimestampRequest: 0,
+	});
+
+	await bank.getFrameFromTimestamp(0.1, 1000);
+
+	const {timestamps} = bank.getOpenFrameCount();
+	expect(timestamps.length).toBeLessThan(25);
+	expect(timestamps[0]).toBeGreaterThanOrEqual(0.093);
+});

--- a/packages/media/src/video-extraction/keyframe-bank.ts
+++ b/packages/media/src/video-extraction/keyframe-bank.ts
@@ -72,11 +72,11 @@ export const makeKeyframeBank = async ({
 		}
 
 		const nextTimestamp = frameTimestamps[index + 1];
-		if (!nextTimestamp) {
+		if (nextTimestamp === undefined) {
 			return null;
 		}
 
-		return nextTimestamp - timestamp;
+		return Math.max(0, nextTimestamp - timestamp);
 	};
 
 	const deleteFrameAtTimestamp = (timestamp: number) => {
@@ -126,9 +126,25 @@ export const makeKeyframeBank = async ({
 		}
 	};
 
-	const hasDecodedEnoughForTimestamp = (timestamp: number) => {
+	const findFrameIndexAtOrBeforeTimestamp = (timestamp: number) => {
+		for (let i = frameTimestamps.length - 1; i >= 0; i--) {
+			const frameTimestamp = frameTimestamps[i];
+			if (
+				roundTo4Digits(frameTimestamp) <= roundTo4Digits(timestamp) ||
+				// Match 0.3333333333 to 0.33355555
+				// this does not satisfy the previous condition, since one rounds up and one rounds down
+				Math.abs(frameTimestamp - timestamp) <= 0.001
+			) {
+				return i;
+			}
+		}
+
+		return null;
+	};
+
+	const hasDecodedEnoughForTimestamp = (timestamp: number, fps: number) => {
 		const lastFrameTimestamp = frameTimestamps[frameTimestamps.length - 1];
-		if (!lastFrameTimestamp) {
+		if (lastFrameTimestamp === undefined) {
 			return false;
 		}
 
@@ -139,13 +155,50 @@ export const makeKeyframeBank = async ({
 			return true;
 		}
 
+		const frameIndex = findFrameIndexAtOrBeforeTimestamp(timestamp);
+		if (frameIndex === null) {
+			return true;
+		}
+
+		const frameTimestamp = frameTimestamps[frameIndex];
+		const frame = frames[frameTimestamp];
+		if (!frame) {
+			return true;
+		}
+
 		const duration =
-			getDurationOfFrame(lastFrameTimestamp) ??
-			(lastFrame as VideoSample).duration;
+			getDurationOfFrame(frameTimestamp) ?? (frame as VideoSample).duration;
+
+		if (
+			roundTo4Digits(frameTimestamp + duration) <= roundTo4Digits(timestamp)
+		) {
+			return false;
+		}
+
+		const nextTimestamp = frameTimestamps[frameIndex + 1];
+		const hasSuspiciousGap =
+			nextTimestamp !== undefined && nextTimestamp - frameTimestamp > 1.5 / fps;
+
+		if (!hasSuspiciousGap) {
+			return true;
+		}
 
 		return (
-			roundTo4Digits(lastFrameTimestamp + duration) > roundTo4Digits(timestamp)
+			roundTo4Digits(lastFrameTimestamp) >=
+			roundTo4Digits(timestamp + getSafeWindowOfMonotonicity(fps))
 		);
+	};
+
+	const insertFrameTimestamp = (timestamp: number) => {
+		const index = frameTimestamps.findIndex(
+			(frameTimestamp) => frameTimestamp > timestamp,
+		);
+		if (index === -1) {
+			frameTimestamps.push(timestamp);
+			return;
+		}
+
+		frameTimestamps.splice(index, 0, timestamp);
 	};
 
 	const addFrame = (frame: VideoSample, logLevel: LogLevel) => {
@@ -154,7 +207,7 @@ export const makeKeyframeBank = async ({
 		}
 
 		frames[frame.timestamp] = frame;
-		frameTimestamps.push(frame.timestamp);
+		insertFrameTimestamp(frame.timestamp);
 		allocationSize += getAllocationSize(frame);
 
 		lastUsed = Date.now();
@@ -169,7 +222,7 @@ export const makeKeyframeBank = async ({
 		logLevel: LogLevel,
 		fps: number,
 	) => {
-		while (!hasDecodedEnoughForTimestamp(timestampInSeconds)) {
+		while (!hasDecodedEnoughForTimestamp(timestampInSeconds, fps)) {
 			const sample = await sampleIterator.next();
 
 			if (sample.value) {


### PR DESCRIPTION
## Summary

- Fix `@remotion/media` keyframe bank handling for non-monotonic video frame timestamps.
- Keep cached frame timestamps in presentation order and avoid negative inferred frame durations.
- Add regression tests for non-monotonic timestamp lookup and eviction.

Closes #8167.

## Testing

- `cd packages/media && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/media && bun run test`
- `bunx turbo make --filter='@remotion/media'`