### PR TITLE
`remotion`: Fix Series sequence stack traces

### DIFF
--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -75,7 +75,7 @@ export type SequencePropsWithoutDuration = {
 	/**
 	 * @deprecated For internal use only.
 	 */
-	readonly _remotionInternalStack?: string;
+	readonly _remotionInternalStack?: string | null;
 	/**
 	 * @deprecated For internal use only.
 	 */
@@ -278,11 +278,11 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	const isInsideSeries = useContext(IsInsideSeriesContext);
 
-	const inheritedStack = (other as any)?.stack ?? null;
+	const inheritedStack = (other as {readonly stack?: string})?.stack ?? null;
 	// Our assumption: Stack doesnt' change. After we symbolicate we assign it a nodePath
 	// and if it changes, it would lead to-remounting of the sequence.
 	const stackRef = useRef<string | null>(null);
-	stackRef.current = stack ?? inheritedStack;
+	stackRef.current = stack === undefined ? inheritedStack : stack;
 
 	useEffect(() => {
 		if (!env.isStudio) {

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -75,7 +75,7 @@ export type SequencePropsWithoutDuration = {
 	/**
 	 * @deprecated For internal use only.
 	 */
-	readonly _remotionInternalStack?: string | null;
+	readonly _remotionInternalStack?: string;
 	/**
 	 * @deprecated For internal use only.
 	 */
@@ -282,7 +282,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 	// Our assumption: Stack doesnt' change. After we symbolicate we assign it a nodePath
 	// and if it changes, it would lead to-remounting of the sequence.
 	const stackRef = useRef<string | null>(null);
-	stackRef.current = stack === undefined ? inheritedStack : stack;
+	stackRef.current = stack ?? inheritedStack;
 
 	useEffect(() => {
 		if (!env.isStudio) {
@@ -546,6 +546,7 @@ const SequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 };
 
 const SequenceInner = forwardRef(SequenceRefForwardingFunction);
+export const SequenceWithoutSchema = SequenceInner;
 
 /*
  * @description A component that time-shifts its children and wraps them in an absolutely positioned <div>.

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -142,7 +142,7 @@ import {
 } from './sequence-node-path.js';
 import type {ResolvedStackLocation} from './sequence-stack-traces.js';
 import {SequenceStackTracesUpdateContext} from './sequence-stack-traces.js';
-import {SequenceWithoutFrom} from './Sequence.js';
+import {SequenceWithoutSchema} from './Sequence.js';
 import {SequenceContext} from './SequenceContext.js';
 import type {CannotUpdateSequenceReason} from './SequenceManager.js';
 import {
@@ -284,7 +284,7 @@ export const Internals = {
 	SequenceStackTracesUpdateContext,
 	wrapInSchema,
 	sequenceSchema,
-	SequenceWithoutFrom,
+	SequenceWithoutSchema,
 	sequenceStyleSchema,
 	sequenceVisualStyleSchema,
 	sequencePremountSchema,

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -8,7 +8,7 @@ import React, {
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {sequenceSchemaDefaultLayoutNone} from '../sequence-field-schema.js';
 import type {LayoutAndStyle, SequenceProps} from '../Sequence.js';
-import {Sequence, SequenceWithoutFrom} from '../Sequence.js';
+import {Sequence, SequenceWithoutSchema} from '../Sequence.js';
 import {validateDurationInFrames} from '../validation/validate-duration-in-frames.js';
 import {wrapInSchema} from '../wrap-in-schema.js';
 import {flattenChildren} from './flatten-children.js';
@@ -23,10 +23,6 @@ type SeriesSequenceProps = PropsWithChildren<
 		readonly durationInFrames: number;
 		readonly offset?: number;
 		readonly className?: string;
-		/**
-		 * @deprecated For internal use only.
-		 */
-		readonly stack?: string;
 	} & Pick<SequenceProps, 'layout' | 'name' | 'hidden'> &
 		LayoutAndStyle
 >;
@@ -44,9 +40,10 @@ const SeriesSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 const SeriesSequence = forwardRef(SeriesSequenceRefForwardingFunction);
 
 type SeriesProps = SequenceProps;
-const SequenceWithoutFromWithRef = SequenceWithoutFrom as React.ComponentType<
-	SequenceProps & {readonly ref?: React.Ref<HTMLDivElement>}
->;
+const SequenceWithoutSchemaWithRef =
+	SequenceWithoutSchema as React.ComponentType<
+		SequenceProps & {readonly ref?: React.Ref<HTMLDivElement>}
+	>;
 
 const SeriesInner: FC<SeriesProps> = (props) => {
 	const childrenValue = useMemo(() => {
@@ -119,10 +116,9 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 
 			const currentStartFrame = startFrame + offset;
 			startFrame += durationInFramesProp + offset;
-			const sequenceStack = passedProps.stack ?? null;
 
 			return (
-				<SequenceWithoutFromWithRef
+				<SequenceWithoutSchemaWithRef
 					ref={castedChild.ref}
 					name={name || '<Series.Sequence>'}
 					_remotionInternalDocumentationLink={
@@ -131,14 +127,12 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 					from={currentStartFrame}
 					durationInFrames={durationInFramesProp}
 					{...passedProps}
-					_remotionInternalStack={sequenceStack}
 				>
 					{child}
-				</SequenceWithoutFromWithRef>
+				</SequenceWithoutSchemaWithRef>
 			);
 		});
 	}, [props.children]);
-	const seriesStack = (props as {readonly stack?: string}).stack ?? null;
 
 	return (
 		<IsInsideSeriesContainer>
@@ -147,7 +141,6 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 				name="<Series>"
 				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/series"
 				{...props}
-				_remotionInternalStack={seriesStack}
 			>
 				{childrenValue}
 			</Sequence>
@@ -171,8 +164,5 @@ const Series: React.ComponentType<SeriesProps> & {
 		Sequence: SeriesSequence,
 	},
 );
-
 export {Series};
-
 addSequenceStackTraces(Series);
-addSequenceStackTraces(SeriesSequence);

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -23,6 +23,10 @@ type SeriesSequenceProps = PropsWithChildren<
 		readonly durationInFrames: number;
 		readonly offset?: number;
 		readonly className?: string;
+		/**
+		 * @deprecated For internal use only.
+		 */
+		readonly stack?: string;
 	} & Pick<SequenceProps, 'layout' | 'name' | 'hidden'> &
 		LayoutAndStyle
 >;
@@ -115,6 +119,7 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 
 			const currentStartFrame = startFrame + offset;
 			startFrame += durationInFramesProp + offset;
+			const sequenceStack = passedProps.stack ?? null;
 
 			return (
 				<SequenceWithoutFromWithRef
@@ -126,12 +131,14 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 					from={currentStartFrame}
 					durationInFrames={durationInFramesProp}
 					{...passedProps}
+					_remotionInternalStack={sequenceStack}
 				>
 					{child}
 				</SequenceWithoutFromWithRef>
 			);
 		});
 	}, [props.children]);
+	const seriesStack = (props as {readonly stack?: string}).stack ?? null;
 
 	return (
 		<IsInsideSeriesContainer>
@@ -140,6 +147,7 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 				name="<Series>"
 				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/series"
 				{...props}
+				_remotionInternalStack={seriesStack}
 			>
 				{childrenValue}
 			</Sequence>

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -164,6 +164,58 @@ test('Series.Sequence registers controls without a from field', () => {
 	}
 });
 
+test('Sequence can ignore internally injected stack traces', () => {
+	const registeredSequences: TSequence[] = [];
+	const SequenceWithStack = Sequence as React.ComponentType<
+		React.ComponentProps<typeof Sequence> & {readonly stack?: string}
+	>;
+
+	render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<SequenceWithStack stack="core-stack" _remotionInternalStack={null}>
+				hi
+			</SequenceWithStack>
+		</SequenceTestWrapper>,
+	);
+
+	expect(registeredSequences[0]?.getStack()).toBe(null);
+});
+
+test('Series forwards userland stack traces to its internal sequences', () => {
+	const registeredSequences: TSequence[] = [];
+	const seriesSequenceProps = {
+		durationInFrames: 10,
+		premountFor: 30,
+		stack: 'sequence-userland-stack',
+	} as React.ComponentProps<typeof Series.Sequence> & {readonly stack: string};
+
+	render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Series {...({stack: 'series-userland-stack'} as {stack: string})}>
+				<Series.Sequence {...seriesSequenceProps}>First</Series.Sequence>
+			</Series>
+		</SequenceTestWrapper>,
+	);
+
+	const series = registeredSequences.find(
+		(sequence) => sequence.displayName === '<Series>',
+	);
+	const seriesSequence = registeredSequences.find(
+		(sequence) => sequence.displayName === '<Series.Sequence>',
+	);
+
+	expect(series?.getStack()).toBe('series-userland-stack');
+	expect(seriesSequence?.getStack()).toBe('sequence-userland-stack');
+});
+
 test('Img registers its documentation link for default labels', () => {
 	const registeredSequences: TSequence[] = [];
 

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -136,7 +136,7 @@ test('Sequence registers its documentation link', () => {
 	);
 });
 
-test('Series.Sequence registers controls without a from field', () => {
+test('Series.Sequence registers without visual controls', () => {
 	const registeredSequences: TSequence[] = [];
 
 	render(
@@ -146,7 +146,9 @@ test('Series.Sequence registers controls without a from field', () => {
 			}}
 		>
 			<Series>
-				<Series.Sequence durationInFrames={10}>First</Series.Sequence>
+				<Series.Sequence durationInFrames={10} premountFor={30}>
+					First
+				</Series.Sequence>
 				<Series.Sequence durationInFrames={20}>Second</Series.Sequence>
 			</Series>
 		</SequenceTestWrapper>,
@@ -156,64 +158,10 @@ test('Series.Sequence registers controls without a from field', () => {
 		(sequence) => sequence.displayName === '<Series.Sequence>',
 	);
 
-	expect(seriesSequences.map((sequence) => sequence.from)).toEqual([0, 10]);
 	expect(seriesSequences).toHaveLength(2);
 	for (const sequence of seriesSequences) {
-		expect(sequence.controls?.schema.from).toBeUndefined();
-		expect(sequence.controls?.schema.durationInFrames).toBeDefined();
+		expect(sequence.controls).toBe(null);
 	}
-});
-
-test('Sequence can ignore internally injected stack traces', () => {
-	const registeredSequences: TSequence[] = [];
-	const SequenceWithStack = Sequence as React.ComponentType<
-		React.ComponentProps<typeof Sequence> & {readonly stack?: string}
-	>;
-
-	render(
-		<SequenceTestWrapper
-			onRegisterSequence={(sequence) => {
-				registeredSequences.push(sequence);
-			}}
-		>
-			<SequenceWithStack stack="core-stack" _remotionInternalStack={null}>
-				hi
-			</SequenceWithStack>
-		</SequenceTestWrapper>,
-	);
-
-	expect(registeredSequences[0]?.getStack()).toBe(null);
-});
-
-test('Series forwards userland stack traces to its internal sequences', () => {
-	const registeredSequences: TSequence[] = [];
-	const seriesSequenceProps = {
-		durationInFrames: 10,
-		premountFor: 30,
-		stack: 'sequence-userland-stack',
-	} as React.ComponentProps<typeof Series.Sequence> & {readonly stack: string};
-
-	render(
-		<SequenceTestWrapper
-			onRegisterSequence={(sequence) => {
-				registeredSequences.push(sequence);
-			}}
-		>
-			<Series {...({stack: 'series-userland-stack'} as {stack: string})}>
-				<Series.Sequence {...seriesSequenceProps}>First</Series.Sequence>
-			</Series>
-		</SequenceTestWrapper>,
-	);
-
-	const series = registeredSequences.find(
-		(sequence) => sequence.displayName === '<Series>',
-	);
-	const seriesSequence = registeredSequences.find(
-		(sequence) => sequence.displayName === '<Series.Sequence>',
-	);
-
-	expect(series?.getStack()).toBe('series-userland-stack');
-	expect(seriesSequence?.getStack()).toBe('sequence-userland-stack');
 });
 
 test('Img registers its documentation link for default labels', () => {

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -469,6 +469,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 						from={actualStartFrame}
 						durationInFrames={durationInFramesProp}
 						{...passedProps}
+						_remotionInternalStack={passedProps.stack ?? null}
 						name={passedProps.name || '<TS.Sequence>'}
 						_remotionInternalDocumentationLink={
 							passedProps.name
@@ -533,6 +534,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 						from={actualStartFrame}
 						durationInFrames={durationInFramesProp}
 						{...passedProps}
+						_remotionInternalStack={passedProps.stack ?? null}
 						name={passedProps.name || '<TS.Sequence>'}
 						_remotionInternalDocumentationLink={
 							passedProps.name
@@ -577,6 +579,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 						from={actualStartFrame}
 						durationInFrames={durationInFramesProp}
 						{...passedProps}
+						_remotionInternalStack={passedProps.stack ?? null}
 						name={passedProps.name || '<TS.Sequence>'}
 						_remotionInternalDocumentationLink={
 							passedProps.name
@@ -614,6 +617,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					from={actualStartFrame}
 					durationInFrames={durationInFramesProp}
 					{...passedProps}
+					_remotionInternalStack={passedProps.stack ?? null}
 					name={passedProps.name || '<TS.Sequence>'}
 					_remotionInternalDocumentationLink={
 						passedProps.name
@@ -646,6 +650,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					_remotionInternalDocumentationLink="https://www.remotion.dev/docs/transitions/transitionseries"
 					layout="absolute-fill"
 					{...(info.stack ? {stack: info.stack} : {})}
+					_remotionInternalStack={info.stack ?? null}
 				>
 					{info.children}
 				</Sequence>
@@ -689,6 +694,9 @@ const TransitionSeries: FC<SequencePropsWithoutDuration> & {
 					: undefined
 			}
 			{...otherProps}
+			_remotionInternalStack={
+				(otherProps as {readonly stack?: string}).stack ?? null
+			}
 		>
 			<TransitionSeriesChildren>{children}</TransitionSeriesChildren>
 		</Sequence>

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -19,7 +19,7 @@ import type {
 } from './types.js';
 import {validateDurationInFrames} from './validate.js';
 
-const {SequenceWithoutFrom} = Internals;
+const {SequenceWithoutSchema} = Internals;
 
 const TransitionSeriesTransition = function <
 	PresentationProps extends Record<string, unknown>,
@@ -41,10 +41,6 @@ type SeriesSequenceProps = PropsWithChildren<
 		readonly durationInFrames: number;
 		readonly offset?: number;
 		readonly className?: string;
-		/**
-		 * @deprecated For internal use only
-		 */
-		readonly stack?: string;
 	} & LayoutBasedProps &
 		Pick<SequencePropsWithoutDuration, 'name'>
 >;
@@ -289,7 +285,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					halfDuration,
 					children: overlayProps.children,
 					index: i,
-					stack: overlayProps.stack,
 				} as unknown as React.ReactNode);
 
 				return null;
@@ -463,13 +458,12 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 				const UppercasePrevPresentation = prevPresentation.component;
 
 				return (
-					<SequenceWithoutFrom
+					<SequenceWithoutSchema
 						// eslint-disable-next-line react/no-array-index-key
 						key={i}
 						from={actualStartFrame}
 						durationInFrames={durationInFramesProp}
 						{...passedProps}
-						_remotionInternalStack={passedProps.stack ?? null}
 						name={passedProps.name || '<TS.Sequence>'}
 						_remotionInternalDocumentationLink={
 							passedProps.name
@@ -518,7 +512,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 								</UppercasePrevPresentation>
 							</WrapInExitingProgressContext>
 						</UppercaseNextPresentation>
-					</SequenceWithoutFrom>
+					</SequenceWithoutSchema>
 				);
 			}
 
@@ -528,13 +522,12 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 				const UppercasePrevPresentation = prevPresentation.component;
 
 				return (
-					<SequenceWithoutFrom
+					<SequenceWithoutSchema
 						// eslint-disable-next-line react/no-array-index-key
 						key={i}
 						from={actualStartFrame}
 						durationInFrames={durationInFramesProp}
 						{...passedProps}
-						_remotionInternalStack={passedProps.stack ?? null}
 						name={passedProps.name || '<TS.Sequence>'}
 						_remotionInternalDocumentationLink={
 							passedProps.name
@@ -563,7 +556,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 								{child}
 							</WrapInEnteringProgressContext>
 						</UppercasePrevPresentation>
-					</SequenceWithoutFrom>
+					</SequenceWithoutSchema>
 				);
 			}
 
@@ -573,13 +566,12 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 				const UppercaseNextPresentation = nextPresentation.component;
 
 				return (
-					<SequenceWithoutFrom
+					<SequenceWithoutSchema
 						// eslint-disable-next-line react/no-array-index-key
 						key={i}
 						from={actualStartFrame}
 						durationInFrames={durationInFramesProp}
 						{...passedProps}
-						_remotionInternalStack={passedProps.stack ?? null}
 						name={passedProps.name || '<TS.Sequence>'}
 						_remotionInternalDocumentationLink={
 							passedProps.name
@@ -606,18 +598,17 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 								{child}
 							</WrapInExitingProgressContext>
 						</UppercaseNextPresentation>
-					</SequenceWithoutFrom>
+					</SequenceWithoutSchema>
 				);
 			}
 
 			return (
-				<SequenceWithoutFrom
+				<SequenceWithoutSchema
 					// eslint-disable-next-line react/no-array-index-key
 					key={i}
 					from={actualStartFrame}
 					durationInFrames={durationInFramesProp}
 					{...passedProps}
-					_remotionInternalStack={passedProps.stack ?? null}
 					name={passedProps.name || '<TS.Sequence>'}
 					_remotionInternalDocumentationLink={
 						passedProps.name
@@ -626,7 +617,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					}
 				>
 					{child}
-				</SequenceWithoutFrom>
+				</SequenceWithoutSchema>
 			);
 		});
 
@@ -638,22 +629,19 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 				durationInFrames: number;
 				children: React.ReactNode;
 				index: number;
-				stack: string | undefined;
 			};
 
 			return (
-				<Sequence
+				<SequenceWithoutSchema
 					key={`overlay-${info.index}`}
 					from={Math.round(info.overlayFrom)}
 					durationInFrames={info.durationInFrames}
 					name="<TS.Overlay>"
 					_remotionInternalDocumentationLink="https://www.remotion.dev/docs/transitions/transitionseries"
 					layout="absolute-fill"
-					{...(info.stack ? {stack: info.stack} : {})}
-					_remotionInternalStack={info.stack ?? null}
 				>
 					{info.children}
-				</Sequence>
+				</SequenceWithoutSchema>
 			);
 		});
 
@@ -694,9 +682,6 @@ const TransitionSeries: FC<SequencePropsWithoutDuration> & {
 					: undefined
 			}
 			{...otherProps}
-			_remotionInternalStack={
-				(otherProps as {readonly stack?: string}).stack ?? null
-			}
 		>
 			<TransitionSeriesChildren>{children}</TransitionSeriesChildren>
 		</Sequence>
@@ -710,5 +695,3 @@ TransitionSeries.Overlay = SeriesOverlay;
 export {TransitionSeries};
 
 Internals.addSequenceStackTraces(TransitionSeries);
-Internals.addSequenceStackTraces(SeriesSequence);
-Internals.addSequenceStackTraces(SeriesOverlay);

--- a/packages/transitions/src/types.ts
+++ b/packages/transitions/src/types.ts
@@ -44,8 +44,4 @@ export type TransitionSeriesOverlayProps = {
 	readonly durationInFrames: number;
 	readonly offset?: number;
 	readonly children: React.ReactNode;
-	/**
-	 * @deprecated For internal use only
-	 */
-	readonly stack?: string;
 };


### PR DESCRIPTION
## Summary
- Stop registering visual-control schemas for generated `Series.Sequence`, `TransitionSeries.Sequence`, and transition overlay sequence rows.
- Keep the generated rows in the timeline through an internal unwrapped Sequence component, avoiding core stack-trace subscriptions.

## Testing
- bun run build
- bun run stylecheck