### PR TITLE
`@remotion/it-tests`: Exclude Google Fonts from dev file test

### DIFF
--- a/packages/it-tests/src/monorepo/no-dev-files.test.ts
+++ b/packages/it-tests/src/monorepo/no-dev-files.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import {$} from 'bun';
 import {getAllPackages} from './get-all-packages';
 
-const packages = getAllPackages();
+const packages = getAllPackages().filter((pkg) => pkg.pkg !== 'google-fonts');
 
 const MAX_CONCURRENT_PACK_CHECKS = 8;
 let activePackChecks = 0;
@@ -64,14 +64,10 @@ const assertNoDevFilesPublished = async (pkgPath: string) => {
 };
 
 for (const pkg of packages) {
-	const isGoogleFonts = pkg.pkg === 'google-fonts';
-	const timeout = isGoogleFonts ? 120_000 : undefined;
-
 	test.concurrent(
 		'should not publish any dev files for @remotion/' + pkg.pkg,
 		async () => {
 			await assertNoDevFilesPublished(pkg.path);
 		},
-		timeout === undefined ? undefined : {timeout},
 	);
 }


### PR DESCRIPTION
## Summary

- Exclude `@remotion/google-fonts` from the monorepo no-dev-files pack dry-run test because the package is generated and expensive to enumerate in CI.
- Remove the package-specific 120s timeout now that the test no longer runs for it.

Fixes #8178.

## Tests

- `cd packages/it-tests && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/it-tests && bun test src/monorepo/no-dev-files.test.ts --timeout 40000`
