### PR TITLE
`remotion`: Refactor keyframed prop statuses

### DIFF
--- a/packages/core/src/SequenceManager.tsx
+++ b/packages/core/src/SequenceManager.tsx
@@ -2,12 +2,12 @@ import React, {useCallback, useMemo, useRef, useState} from 'react';
 import type {TSequence} from './CompositionManager.js';
 import type {
 	CanUpdateSequencePropStatus,
-	CodeValues,
 	DragOverrideValue,
 	DragOverrides,
 	EffectDragOverrides,
 	GetDragOverrides,
 	GetEffectDragOverrides,
+	PropStatuses,
 } from './use-schema.js';
 
 export type SequenceManagerContext = {
@@ -28,8 +28,8 @@ export const SequenceManager = React.createContext<SequenceManagerContext>({
 	sequences: [],
 });
 
-export type VisualModeCodeValues = {
-	codeValues: CodeValues;
+export type VisualModePropStatuses = {
+	propStatuses: PropStatuses;
 };
 
 export type VisualModeDragOverrides = {
@@ -54,7 +54,7 @@ export type VisualModeSetters = {
 		nodePath: SequencePropsSubscriptionKey,
 		effectIndex: number,
 	) => void;
-	setCodeValues: (
+	setPropStatuses: (
 		nodePath: SequencePropsSubscriptionKey,
 		values: (
 			prev: CanUpdateSequencePropsResponse,
@@ -108,9 +108,9 @@ export const makeSequencePropsSubscriptionKey = (
 	return `${key.nodePath.join('.')}.${key.sequenceKeys.join('.')}.${key.effectKeys.map((keys) => keys.join('.')).join('.')}`;
 };
 
-export const VisualModeCodeValuesContext =
-	React.createContext<VisualModeCodeValues>({
-		codeValues: {},
+export const VisualModePropStatusesContext =
+	React.createContext<VisualModePropStatuses>({
+		propStatuses: {},
 	});
 
 export const VisualModeDragOverridesContext =
@@ -136,7 +136,7 @@ export const VisualModeSettersContext = React.createContext<VisualModeSetters>({
 	clearEffectDragOverrides: () => {
 		throw new Error('VisualModeSettersContext not initialized');
 	},
-	setCodeValues: () => {
+	setPropStatuses: () => {
 		throw new Error('VisualModeSettersContext not initialized');
 	},
 });
@@ -163,7 +163,7 @@ export const SequenceManagerProvider: React.FC<{
 	controlOverridesRef.current = dragOverrides;
 	const [effectDragOverridesState, setEffectDragOverridesState] =
 		useState<EffectDragOverrides>({});
-	const [codeValues, setCodeValuesMapState] = useState<CodeValues>({});
+	const [propStatuses, setPropStatusesMapState] = useState<PropStatuses>({});
 
 	const setDragOverrides = useCallback(
 		(
@@ -235,14 +235,14 @@ export const SequenceManagerProvider: React.FC<{
 		[],
 	);
 
-	const setCodeValues = useCallback(
+	const setPropStatuses = useCallback(
 		(
 			nodePath: SequencePropsSubscriptionKey,
 			values: (
 				prev: CanUpdateSequencePropsResponse,
 			) => CanUpdateSequencePropsResponse,
 		) => {
-			setCodeValuesMapState((prev) => {
+			setPropStatusesMapState((prev) => {
 				const key = makeSequencePropsSubscriptionKey(nodePath);
 
 				const prevKey = prev[key];
@@ -294,11 +294,11 @@ export const SequenceManagerProvider: React.FC<{
 		[effectDragOverridesState],
 	);
 
-	const codeValuesContext: VisualModeCodeValues = useMemo(() => {
+	const propStatusesContext: VisualModePropStatuses = useMemo(() => {
 		return {
-			codeValues,
+			propStatuses,
 		};
-	}, [codeValues]);
+	}, [propStatuses]);
 
 	const dragOverridesContext: VisualModeDragOverrides = useMemo(() => {
 		return {
@@ -313,25 +313,25 @@ export const SequenceManagerProvider: React.FC<{
 			clearDragOverrides,
 			setEffectDragOverrides,
 			clearEffectDragOverrides,
-			setCodeValues,
+			setPropStatuses,
 		};
 	}, [
 		setDragOverrides,
 		clearDragOverrides,
 		setEffectDragOverrides,
 		clearEffectDragOverrides,
-		setCodeValues,
+		setPropStatuses,
 	]);
 
 	return (
 		<SequenceManager.Provider value={sequenceContext}>
-			<VisualModeCodeValuesContext.Provider value={codeValuesContext}>
+			<VisualModePropStatusesContext.Provider value={propStatusesContext}>
 				<VisualModeDragOverridesContext.Provider value={dragOverridesContext}>
 					<VisualModeSettersContext.Provider value={settersContext}>
 						{children}
 					</VisualModeSettersContext.Provider>
 				</VisualModeDragOverridesContext.Provider>
-			</VisualModeCodeValuesContext.Provider>
+			</VisualModePropStatusesContext.Provider>
 		</SequenceManager.Provider>
 	);
 };

--- a/packages/core/src/effects/use-memoized-effects.ts
+++ b/packages/core/src/effects/use-memoized-effects.ts
@@ -1,5 +1,6 @@
 import {useContext, useRef} from 'react';
 import {resolveDragOverrideValue} from '../get-effective-visual-mode-value.js';
+import {interpolateKeyframedStatus} from '../interpolate-keyframed-status.js';
 import {OverrideIdsToNodePathsGettersContext} from '../sequence-node-path.js';
 import type {
 	CannotUpdateEffectReason,
@@ -7,17 +8,15 @@ import type {
 } from '../SequenceManager.js';
 import {
 	makeSequencePropsSubscriptionKey,
-	type SequencePropsSubscriptionKey,
-} from '../SequenceManager.js';
-import {
-	VisualModeCodeValuesContext,
 	VisualModeDragOverridesContext,
+	VisualModePropStatusesContext,
+	type SequencePropsSubscriptionKey,
 } from '../SequenceManager.js';
 import {useCurrentFrame} from '../use-current-frame.js';
 import {
 	type CanUpdateSequencePropStatus,
-	type CodeValues,
 	type DragOverrideValue,
+	type PropStatuses,
 } from '../use-schema.js';
 import type {
 	EffectDefinition,
@@ -27,16 +26,16 @@ import type {
 
 const mergeOverrides = ({
 	descriptor,
-	codeOverrides,
+	propStatusOverrides,
 	dragOverrides,
 	frame,
 }: {
 	descriptor: EffectDescriptor<unknown>;
-	codeOverrides: Record<string, unknown> | null;
+	propStatusOverrides: Record<string, unknown> | null;
 	dragOverrides: Record<string, DragOverrideValue> | null;
 	frame: number;
 }): {params: unknown; effectKey: string} => {
-	if (!codeOverrides && !dragOverrides) {
+	if (!propStatusOverrides && !dragOverrides) {
 		return {params: descriptor.params, effectKey: descriptor.effectKey};
 	}
 
@@ -44,8 +43,8 @@ const mergeOverrides = ({
 		...(descriptor.params as Record<string, unknown>),
 	};
 
-	if (codeOverrides) {
-		for (const [key, value] of Object.entries(codeOverrides)) {
+	if (propStatusOverrides) {
+		for (const [key, value] of Object.entries(propStatusOverrides)) {
 			if (value !== undefined) {
 				merged[key] = value;
 			}
@@ -70,8 +69,9 @@ const mergeOverrides = ({
 	};
 };
 
-const extractCodeOverrides = (
+const resolvePropStatusOverrides = (
 	propStatus: Record<string, CanUpdateSequencePropStatus> | undefined,
+	frame: number,
 ): Record<string, unknown> | null => {
 	if (!propStatus) {
 		return null;
@@ -80,9 +80,21 @@ const extractCodeOverrides = (
 	const out: Record<string, unknown> = {};
 	let hasAny = false;
 	for (const [key, status] of Object.entries(propStatus)) {
-		if (status.status !== 'computed') {
+		if (status.status === 'static') {
 			out[key] = status.codeValue;
 			hasAny = true;
+			continue;
+		}
+
+		if (status.status === 'keyframed') {
+			const value = interpolateKeyframedStatus({
+				frame,
+				status,
+			});
+			if (value !== null) {
+				out[key] = value;
+				hasAny = true;
+			}
 		}
 	}
 
@@ -124,16 +136,16 @@ type EffectStatus =
 			props: Record<string, CanUpdateSequencePropStatus>;
 	  };
 
-export const getEffectCodeValuesCtx = ({
-	codeValues,
+export const getEffectPropStatusesCtx = ({
+	propStatuses,
 	nodePath,
 	effectIndex,
 }: {
-	codeValues: CodeValues;
+	propStatuses: PropStatuses;
 	nodePath: SequencePropsSubscriptionKey;
 	effectIndex: number;
 }): EffectStatus => {
-	const status = codeValues[makeSequencePropsSubscriptionKey(nodePath)];
+	const status = propStatuses[makeSequencePropsSubscriptionKey(nodePath)];
 	if (!status) {
 		return {type: 'cannot-update-sequence', reason: 'not-found'};
 	}
@@ -154,11 +166,11 @@ export const getEffectCodeValuesCtx = ({
 	return {type: 'can-update-effect', props: effect.props};
 };
 
-export const getCodeValuesCtx = (
-	codeValues: CodeValues,
+export const getPropStatusesCtx = (
+	propStatuses: PropStatuses,
 	nodePath: SequencePropsSubscriptionKey,
 ) => {
-	const status = codeValues[makeSequencePropsSubscriptionKey(nodePath)];
+	const status = propStatuses[makeSequencePropsSubscriptionKey(nodePath)];
 	if (!status) {
 		return undefined;
 	}
@@ -170,7 +182,7 @@ export const getCodeValuesCtx = (
 	return status.props;
 };
 
-export type GetCodeValuesType = typeof getCodeValuesCtx;
+export type GetPropStatusesType = typeof getPropStatusesCtx;
 
 export const useMemoizedEffects = ({
 	effects,
@@ -181,7 +193,7 @@ export const useMemoizedEffects = ({
 }): EffectDefinitionAndStack<unknown>[] => {
 	const previousRef = useRef<EffectDefinitionAndStack<unknown>[] | null>(null);
 
-	const {codeValues} = useContext(VisualModeCodeValuesContext);
+	const {propStatuses} = useContext(VisualModePropStatusesContext);
 	const {getEffectDragOverrides} = useContext(VisualModeDragOverridesContext);
 	const frame = useCurrentFrame();
 
@@ -204,14 +216,14 @@ export const useMemoizedEffects = ({
 			};
 		}
 
-		const effectStatus = getEffectCodeValuesCtx({
-			codeValues,
+		const effectStatus = getEffectPropStatusesCtx({
+			propStatuses,
 			nodePath,
 			effectIndex: index,
 		});
-		const codeOverrides =
+		const propStatusOverrides =
 			effectStatus.type === 'can-update-effect'
-				? extractCodeOverrides(effectStatus.props)
+				? resolvePropStatusOverrides(effectStatus.props, frame)
 				: null;
 		const dragOverridesMap = getEffectDragOverrides(nodePath, index);
 		const dragOverrides =
@@ -219,7 +231,7 @@ export const useMemoizedEffects = ({
 
 		const {params, effectKey} = mergeOverrides({
 			descriptor,
-			codeOverrides,
+			propStatusOverrides,
 			dragOverrides,
 			frame,
 		});

--- a/packages/core/src/get-effective-visual-mode-value.ts
+++ b/packages/core/src/get-effective-visual-mode-value.ts
@@ -45,13 +45,13 @@ export const resolveDragOverrideValue = ({
 };
 
 export const getEffectiveVisualModeValue = ({
-	codeValue,
+	propStatus,
 	dragOverrideValue,
 	defaultValue,
 	frame = null,
 	shouldResortToDefaultValueIfUndefined = false,
 }: {
-	codeValue:
+	propStatus:
 		| CanUpdateSequencePropStatusStatic
 		| CanUpdateSequencePropStatusKeyframed;
 	dragOverrideValue: DragOverrideValue | undefined;
@@ -67,19 +67,23 @@ export const getEffectiveVisualModeValue = ({
 		return dragOverride.value;
 	}
 
-	if (codeValue.status === 'keyframed' && frame !== null) {
-		return interpolateKeyframedStatus({
-			frame,
-			status: codeValue,
-		});
+	if (propStatus.status === 'keyframed') {
+		if (frame !== null) {
+			return interpolateKeyframedStatus({
+				frame,
+				status: propStatus,
+			});
+		}
+
+		return shouldResortToDefaultValueIfUndefined ? defaultValue : undefined;
 	}
 
 	if (
-		codeValue.codeValue === undefined &&
+		propStatus.codeValue === undefined &&
 		shouldResortToDefaultValueIfUndefined
 	) {
 		return defaultValue;
 	}
 
-	return codeValue.codeValue;
+	return propStatus.codeValue;
 };

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -54,8 +54,8 @@ import {
 } from './effects/run-effect-chain.js';
 import {useEffectChainState} from './effects/use-effect-chain-state.js';
 import {
-	getCodeValuesCtx,
-	getEffectCodeValuesCtx,
+	getEffectPropStatusesCtx,
+	getPropStatusesCtx,
 	useMemoizedEffectDefinitions,
 	useMemoizedEffects,
 } from './effects/use-memoized-effects.js';
@@ -148,8 +148,8 @@ import type {CannotUpdateSequenceReason} from './SequenceManager.js';
 import {
 	makeSequencePropsSubscriptionKey,
 	SequenceManager,
-	VisualModeCodeValuesContext,
 	VisualModeDragOverridesContext,
+	VisualModePropStatusesContext,
 	VisualModeSettersContext,
 	type CanUpdateEffectPropsResponse,
 	type CanUpdateEffectPropsResponseFalse,
@@ -196,10 +196,10 @@ import type {
 	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
 	DragOverrideValue,
-	GetCodeValues,
 	GetDragOverrides,
-	GetEffectCodeValues,
 	GetEffectDragOverrides,
+	GetEffectPropStatuses,
+	GetPropStatuses,
 } from './use-schema.js';
 import {
 	computeEffectiveSchemaValuesDotNotation,
@@ -207,9 +207,9 @@ import {
 	makeKeyframedDragOverride,
 	makeStaticDragOverride,
 	type CanUpdateSequencePropStatus,
-	type CodeValues,
 	type DragOverrides,
 	type EffectDragOverrides,
+	type PropStatuses,
 } from './use-schema.js';
 import {useUnsafeVideoConfig} from './use-unsafe-video-config.js';
 import {useVideo} from './use-video.js';
@@ -277,7 +277,7 @@ export const Internals = {
 	VideoForPreview,
 	CompositionManager,
 	CompositionSetters,
-	VisualModeCodeValuesContext,
+	VisualModePropStatusesContext,
 	VisualModeDragOverridesContext,
 	VisualModeSettersContext,
 	SequenceManager,
@@ -399,8 +399,8 @@ export const Internals = {
 	OverrideIdsToNodePathsSettersContext,
 	findPropsToDelete,
 	makeSequencePropsSubscriptionKey,
-	getCodeValuesCtx,
-	getEffectCodeValuesCtx,
+	getPropStatusesCtx,
+	getEffectPropStatusesCtx,
 	hiddenField,
 	durationInFramesField,
 	fromField,
@@ -420,16 +420,15 @@ export type {
 	CanUpdateSequencePropStatusFalse,
 	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
-	CodeValues,
 	CompositionManagerContext,
 	CompProps,
 	DragOverrides,
 	DragOverrideValue,
 	EffectDragOverrides,
-	GetCodeValues,
 	GetDragOverrides,
-	GetEffectCodeValues,
 	GetEffectDragOverrides,
+	GetEffectPropStatuses,
+	GetPropStatuses,
 	LoggingContextValue,
 	MediaVolumeContextValue,
 	NonceHistory,
@@ -439,6 +438,7 @@ export type {
 	OverrideToNodePathGetters,
 	OverrideToNodeSetters,
 	PlaybackRateContextValue,
+	PropStatuses,
 	RemotionAudioContextState,
 	RemotionEnvironment,
 	ResolvedStackLocation,

--- a/packages/core/src/test/drag-override-value.test.ts
+++ b/packages/core/src/test/drag-override-value.test.ts
@@ -11,7 +11,6 @@ import {
 
 const makeKeyframedStatus = (): CanUpdateSequencePropStatusKeyframed => ({
 	status: 'keyframed',
-	codeValue: undefined,
 	interpolationFunction: 'interpolate',
 	keyframes: [
 		{frame: 0, value: 2},
@@ -102,7 +101,7 @@ test('getEffectiveVisualModeValue resolves keyframed drag overrides at the sourc
 
 	expect(
 		getEffectiveVisualModeValue({
-			codeValue: {
+			propStatus: {
 				status: 'static',
 				codeValue: 2,
 			},

--- a/packages/core/src/test/html-in-canvas.test.tsx
+++ b/packages/core/src/test/html-in-canvas.test.tsx
@@ -8,8 +8,8 @@ import {Internals} from '../internals.js';
 import type {SequenceManagerContext} from '../SequenceManager.js';
 import {
 	SequenceManager,
-	VisualModeCodeValuesContext,
 	VisualModeDragOverridesContext,
+	VisualModePropStatusesContext,
 	VisualModeSettersContext,
 } from '../SequenceManager.js';
 import {WrapSequenceContext} from './wrap-sequence-context.js';
@@ -133,9 +133,9 @@ const SequenceTestWrapper: React.FC<{
 		};
 	}, [registerSequence, unregisterSequence]);
 
-	const visualCodeValues = useMemo(
+	const visualPropStatuses = useMemo(
 		() => ({
-			codeValues: {},
+			propStatuses: {},
 		}),
 		[],
 	);
@@ -156,7 +156,7 @@ const SequenceTestWrapper: React.FC<{
 		() => ({
 			clearDragOverrides: () => undefined,
 			clearEffectDragOverrides: () => undefined,
-			setCodeValues: () => undefined,
+			setPropStatuses: () => undefined,
 			setDragOverrides: () => undefined,
 			setEffectDragOverrides: () => undefined,
 		}),
@@ -175,7 +175,7 @@ const SequenceTestWrapper: React.FC<{
 				}}
 			>
 				<SequenceManager.Provider value={sequenceManagerContext}>
-					<VisualModeCodeValuesContext.Provider value={visualCodeValues}>
+					<VisualModePropStatusesContext.Provider value={visualPropStatuses}>
 						<VisualModeDragOverridesContext.Provider
 							value={visualDragOverrides}
 						>
@@ -183,7 +183,7 @@ const SequenceTestWrapper: React.FC<{
 								{children}
 							</VisualModeSettersContext.Provider>
 						</VisualModeDragOverridesContext.Provider>
-					</VisualModeCodeValuesContext.Provider>
+					</VisualModePropStatusesContext.Provider>
 				</SequenceManager.Provider>
 			</Internals.RemotionEnvironmentContext>
 		</WrapSequenceContext>

--- a/packages/core/src/test/interpolate-keyframed-status.test.ts
+++ b/packages/core/src/test/interpolate-keyframed-status.test.ts
@@ -6,7 +6,6 @@ test('interpolates linear numeric keyframes', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -25,7 +24,6 @@ test('interpolates linear tuple keyframes', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: [0, 0.5]},
@@ -44,7 +42,6 @@ test('sorts keyframes before interpolating numeric values', () => {
 		frame: 75,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 100, value: 100},
@@ -64,7 +61,6 @@ test('clamps when extrapolation is clamp', () => {
 		frame: 120,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -83,7 +79,6 @@ test('posterizes the frame before interpolating numeric keyframes', () => {
 		frame: 17,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -102,7 +97,6 @@ test('returns single keyframe value', () => {
 		frame: 100,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [{frame: 0, value: 7}],
 			easing: [],
@@ -118,7 +112,6 @@ test('interpolates colors', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolateColors',
 			keyframes: [
 				{frame: 0, value: '#000000'},
@@ -138,7 +131,6 @@ test('posterizes the frame before interpolating color keyframes', () => {
 		frame: 17,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolateColors',
 			keyframes: [
 				{frame: 0, value: 'black'},
@@ -157,7 +149,6 @@ test('interpolates translate keyframes', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: '0px 0px'},
@@ -176,7 +167,6 @@ test('interpolates rotate keyframes', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: '0deg'},
@@ -195,7 +185,6 @@ test('uses bezier easing', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -215,7 +204,6 @@ test('interpolates scale strings component-wise', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 2},

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -9,8 +9,8 @@ import {Sequence} from '../Sequence.js';
 import type {SequenceManagerContext} from '../SequenceManager.js';
 import {
 	SequenceManager,
-	VisualModeCodeValuesContext,
 	VisualModeDragOverridesContext,
+	VisualModePropStatusesContext,
 	VisualModeSettersContext,
 } from '../SequenceManager.js';
 import {Series} from '../series/index.js';
@@ -42,9 +42,9 @@ const SequenceTestWrapper: React.FC<{
 		[registerSequence, unregisterSequence],
 	);
 
-	const visualCodeValues = useMemo(
+	const visualPropStatuses = useMemo(
 		() => ({
-			codeValues: {},
+			propStatuses: {},
 		}),
 		[],
 	);
@@ -67,7 +67,7 @@ const SequenceTestWrapper: React.FC<{
 			clearDragOverrides: () => undefined,
 			setEffectDragOverrides: () => undefined,
 			clearEffectDragOverrides: () => undefined,
-			setCodeValues: () => undefined,
+			setPropStatuses: () => undefined,
 		}),
 		[],
 	);
@@ -84,7 +84,7 @@ const SequenceTestWrapper: React.FC<{
 				}}
 			>
 				<SequenceManager.Provider value={ctx}>
-					<VisualModeCodeValuesContext.Provider value={visualCodeValues}>
+					<VisualModePropStatusesContext.Provider value={visualPropStatuses}>
 						<VisualModeDragOverridesContext.Provider
 							value={visualDragOverrides}
 						>
@@ -92,7 +92,7 @@ const SequenceTestWrapper: React.FC<{
 								{children}
 							</VisualModeSettersContext.Provider>
 						</VisualModeDragOverridesContext.Provider>
-					</VisualModeCodeValuesContext.Provider>
+					</VisualModePropStatusesContext.Provider>
 				</SequenceManager.Provider>
 			</Internals.RemotionEnvironmentContext>
 		</WrapSequenceContext>

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -43,7 +43,6 @@ export type CanUpdateSequencePropStatusComputed = {
 
 export type CanUpdateSequencePropStatusKeyframed = {
 	status: 'keyframed';
-	codeValue: unknown;
 	interpolationFunction: CanUpdateSequencePropStatusInterpolationFunction;
 	keyframes: CanUpdateSequencePropStatusKeyframe[];
 	easing: CanUpdateSequencePropStatusEasing[];
@@ -74,13 +73,13 @@ export type EffectDragOverrides = Record<
 	string,
 	Record<string, DragOverrideValue>
 >;
-export type CodeValues = Record<string, CanUpdateSequencePropsResponse>;
+export type PropStatuses = Record<string, CanUpdateSequencePropsResponse>;
 
-export type GetCodeValues = (
+export type GetPropStatuses = (
 	nodePath: SequencePropsSubscriptionKey,
 ) => Record<string, CanUpdateSequencePropStatus> | undefined;
 
-export type GetEffectCodeValues = (
+export type GetEffectPropStatuses = (
 	nodePath: SequencePropsSubscriptionKey,
 	effectIndex: number,
 ) => Record<string, CanUpdateSequencePropStatus> | undefined;
@@ -193,7 +192,7 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 	const merged: Record<string, unknown> = {};
 	const propsToDelete = new Set<string>();
 	for (const key of Object.keys(currentValue)) {
-		const codeValueStatus = propStatus?.[key] ?? null;
+		const status = propStatus?.[key] ?? null;
 		const field = findFieldInSchema(schema, key);
 
 		if (field?.type === 'hidden') {
@@ -201,9 +200,9 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 		}
 
 		let value: unknown;
-		if (codeValueStatus === null) {
+		if (status === null) {
 			value = currentValue[key];
-		} else if (isKeyframedStatus(codeValueStatus)) {
+		} else if (isKeyframedStatus(status)) {
 			if (field?.type === 'array' || field?.keyframable === false) {
 				value = currentValue[key];
 			} else {
@@ -216,18 +215,18 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 				} else if (frame !== null) {
 					const interpolated = interpolateKeyframedStatus({
 						frame,
-						status: codeValueStatus,
+						status,
 					});
 					value = interpolated ?? currentValue[key];
 				} else {
 					value = currentValue[key];
 				}
 			}
-		} else if (codeValueStatus.status === 'computed') {
+		} else if (status.status === 'computed') {
 			value = currentValue[key];
 		} else {
 			value = getEffectiveVisualModeValue({
-				codeValue: codeValueStatus,
+				propStatus: status,
 				dragOverrideValue: overrideValues[key],
 				defaultValue: field?.default,
 				frame,

--- a/packages/core/src/wrap-in-schema.ts
+++ b/packages/core/src/wrap-in-schema.ts
@@ -1,7 +1,7 @@
 import React, {forwardRef, useContext, useMemo, useState} from 'react';
 import type {SequenceControls} from './CompositionManager.js';
 import {deleteNestedKey} from './delete-nested-key.js';
-import {getCodeValuesCtx} from './effects/use-memoized-effects.js';
+import {getPropStatusesCtx} from './effects/use-memoized-effects.js';
 import {
 	flattenActiveSchema,
 	getFlatSchemaWithAllKeys,
@@ -9,8 +9,8 @@ import {
 import type {SequenceSchema} from './sequence-field-schema.js';
 import {OverrideIdsToNodePathsGettersContext} from './sequence-node-path.js';
 import {
-	VisualModeCodeValuesContext,
 	VisualModeDragOverridesContext,
+	VisualModePropStatusesContext,
 } from './SequenceManager.js';
 import {useCurrentFrame} from './use-current-frame.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
@@ -131,7 +131,7 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>({
 		}
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const {codeValues} = useContext(VisualModeCodeValuesContext);
+		const {propStatuses} = useContext(VisualModePropStatusesContext);
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const {getDragOverrides} = useContext(VisualModeDragOverridesContext);
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -204,14 +204,14 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>({
 				propStatus:
 					nodePath === null
 						? undefined
-						: getCodeValuesCtx(codeValues, nodePath),
+						: getPropStatusesCtx(propStatuses, nodePath),
 				frame,
 			});
 		}, [
 			currentRuntimeValueDotNotation,
 			getDragOverrides,
 			nodePath,
-			codeValues,
+			propStatuses,
 			frame,
 		]);
 

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -11,8 +11,8 @@ import type {
 	UnaryExpression,
 } from '@babel/types';
 import {RenderInternals} from '@remotion/renderer';
-import {isKeyframeInterpolationFunction} from '@remotion/studio-shared';
 import type {SubscribeToSequencePropsResponse} from '@remotion/studio-shared';
+import {isKeyframeInterpolationFunction} from '@remotion/studio-shared';
 import * as recast from 'recast';
 import type {
 	CanUpdateSequencePropsResponseTrue,
@@ -536,7 +536,6 @@ export const getComputedStatus = (
 
 	return {
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: interpolation.interpolationFunction,
 		keyframes: interpolation.keyframes,
 		easing: interpolation.easing,
@@ -745,12 +744,12 @@ const getNestedPropStatus = (
 		return getComputedStatus(propValue, ast);
 	}
 
-	const codeValue = extractStaticValue(propValue);
-	if (!validateStyleValue(childKey, codeValue)) {
+	const propStatus = extractStaticValue(propValue);
+	if (!validateStyleValue(childKey, propStatus)) {
 		return computedStatus();
 	}
 
-	return staticStatus(codeValue);
+	return staticStatus(propStatus);
 };
 
 const computeEffectsForJsx = ({

--- a/packages/studio-server/src/test/compute-effect-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-effect-props-status.test.ts
@@ -109,7 +109,6 @@ test('computeEffectPropStatus reports keyframes for inline interpolated effect p
 
 	expect(result.props.amount).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 0.2},

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -82,7 +82,6 @@ export const Example: React.FC = () => {
 
 	expect(result.props.color).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolateColors',
 		keyframes: [
 			{frame: 0, value: 'red'},
@@ -117,7 +116,6 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.translate']).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: '0px 59px'},
@@ -179,7 +177,6 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.rotate']).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 55, value: '19deg'},
@@ -328,7 +325,6 @@ test('computeSequencePropsStatus should return keyframes for interpolated style 
 
 	expect(result.props['style.scale']).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 2},
@@ -368,7 +364,6 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.scale']).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 1},
@@ -408,7 +403,6 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.scale']).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 1},
@@ -444,7 +438,6 @@ export const Example: React.FC = () => {
 
 	expect(result.props.color).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolateColors',
 		keyframes: [
 			{frame: 0, value: 'red'},

--- a/packages/studio-server/src/test/discriminated-union-update.test.ts
+++ b/packages/studio-server/src/test/discriminated-union-update.test.ts
@@ -21,7 +21,7 @@ test('Should correctly separate discriminated union for layout', () => {
 			sequenceKeys: [],
 			effectKeys: [],
 		},
-		codeValues: {},
+		propStatuses: {},
 		getDragOverrides: () => ({}),
 	});
 	expect(schemaFields?.map((s) => s.key)).toEqual(['layout']);
@@ -39,7 +39,7 @@ test('Should expose absolute-fill variant fields when active', () => {
 			sequenceKeys: [],
 			effectKeys: [],
 		},
-		codeValues: {},
+		propStatuses: {},
 		getDragOverrides: () => ({}),
 	});
 	expect(schemaFields?.map((s) => s.key)).toEqual([

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -424,7 +424,6 @@ export const Example: React.FC = () => {
 	});
 	expect(status.props['style.translate']).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 44, value: '100px 20px'}],
 		easing: [],
@@ -568,7 +567,6 @@ export default CenteredSolid;
 	});
 	expect(status.props.width).toEqual({
 		status: 'keyframed',
-		codeValue: undefined,
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 11, value: 240}],
 		easing: [],

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -56,13 +56,13 @@ export {
 	RedoRequest,
 	RedoResponse,
 	RemoveRenderRequest,
+	RenameStaticFileRequest,
+	RenameStaticFileResponse,
 	ReorderEffectRequest,
 	ReorderEffectResponse,
 	ReorderSequencePosition,
 	ReorderSequenceRequest,
 	ReorderSequenceResponse,
-	RenameStaticFileRequest,
-	RenameStaticFileResponse,
 	RestartStudioRequest,
 	RestartStudioResponse,
 	SaveEffectPropsRequest,
@@ -199,9 +199,9 @@ export {
 } from './schema-field-info';
 export type {
 	AnySchemaFieldInfo,
-	CodeValues,
 	DragOverrides,
 	EffectSchemaFieldInfo,
+	PropStatuses,
 	SchemaFieldInfo,
 	SequenceControls,
 	SequenceSchemaFieldInfo,
@@ -231,8 +231,8 @@ export {
 	optimisticMoveSequenceKeyframes,
 	type OptimisticKeyframeMove,
 } from './optimistic-move-keyframe';
-export {optimisticUpdateForCodeValues} from './optimistic-update-for-code-values';
-export {optimisticUpdateForEffectCodeValues} from './optimistic-update-for-effect-code-values';
+export {optimisticUpdateForPropStatuses} from './optimistic-update-for-prop-statuses';
+export {optimisticUpdateForEffectPropStatuses} from './optimistic-update-for-effect-prop-statuses';
 export {
 	optimisticUpdateEffectKeyframeSettings,
 	optimisticUpdateSequenceKeyframeSettings,

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -56,7 +56,6 @@ const addKeyframeToPropStatus = ({
 
 		return {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: getKeyframeInterpolationFunction({
 				schema,
 				key: fieldKey,

--- a/packages/studio-shared/src/optimistic-update-for-effect-prop-statuses.ts
+++ b/packages/studio-shared/src/optimistic-update-for-effect-prop-statuses.ts
@@ -1,17 +1,20 @@
 import {
+	type CanUpdateEffectPropsResponse,
 	type CanUpdateSequencePropsResponse,
 	type CanUpdateSequencePropStatus,
 	type SequenceSchema,
 } from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 
-export const optimisticUpdateForCodeValues = ({
+export const optimisticUpdateForEffectPropStatuses = ({
 	previous,
+	effectIndex,
 	fieldKey,
 	value,
 	schema,
 }: {
 	previous: CanUpdateSequencePropsResponse;
+	effectIndex: number;
 	fieldKey: string;
 	value: unknown;
 	schema: SequenceSchema;
@@ -20,8 +23,20 @@ export const optimisticUpdateForCodeValues = ({
 		return previous;
 	}
 
+	const targetIndex = previous.effects.findIndex(
+		(e) => e.effectIndex === effectIndex,
+	);
+	if (targetIndex === -1) {
+		return previous;
+	}
+
+	const target = previous.effects[targetIndex];
+	if (!target.canUpdate) {
+		return previous;
+	}
+
 	const props: Record<string, CanUpdateSequencePropStatus> = {
-		...previous.props,
+		...target.props,
 		[fieldKey]: {status: 'static', codeValue: value},
 	};
 
@@ -36,9 +51,16 @@ export const optimisticUpdateForCodeValues = ({
 		}
 	}
 
-	return {
-		canUpdate: true,
+	const updatedEffect: CanUpdateEffectPropsResponse = {
+		...target,
 		props,
-		effects: previous.effects,
+	};
+
+	const effects = [...previous.effects];
+	effects[targetIndex] = updatedEffect;
+
+	return {
+		...previous,
+		effects,
 	};
 };

--- a/packages/studio-shared/src/optimistic-update-for-prop-statuses.ts
+++ b/packages/studio-shared/src/optimistic-update-for-prop-statuses.ts
@@ -1,20 +1,17 @@
 import {
-	type CanUpdateEffectPropsResponse,
 	type CanUpdateSequencePropsResponse,
 	type CanUpdateSequencePropStatus,
 	type SequenceSchema,
 } from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 
-export const optimisticUpdateForEffectCodeValues = ({
+export const optimisticUpdateForPropStatuses = ({
 	previous,
-	effectIndex,
 	fieldKey,
 	value,
 	schema,
 }: {
 	previous: CanUpdateSequencePropsResponse;
-	effectIndex: number;
 	fieldKey: string;
 	value: unknown;
 	schema: SequenceSchema;
@@ -23,20 +20,8 @@ export const optimisticUpdateForEffectCodeValues = ({
 		return previous;
 	}
 
-	const targetIndex = previous.effects.findIndex(
-		(e) => e.effectIndex === effectIndex,
-	);
-	if (targetIndex === -1) {
-		return previous;
-	}
-
-	const target = previous.effects[targetIndex];
-	if (!target.canUpdate) {
-		return previous;
-	}
-
 	const props: Record<string, CanUpdateSequencePropStatus> = {
-		...target.props,
+		...previous.props,
 		[fieldKey]: {status: 'static', codeValue: value},
 	};
 
@@ -51,16 +36,9 @@ export const optimisticUpdateForEffectCodeValues = ({
 		}
 	}
 
-	const updatedEffect: CanUpdateEffectPropsResponse = {
-		...target,
-		props,
-	};
-
-	const effects = [...previous.effects];
-	effects[targetIndex] = updatedEffect;
-
 	return {
-		...previous,
-		effects,
+		canUpdate: true,
+		props,
+		effects: previous.effects,
 	};
 };

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -1,10 +1,10 @@
 import type {
 	ArrayFieldSchema,
-	CodeValues,
 	DragOverrides,
 	EffectDefinition,
 	GetDragOverrides,
 	GetEffectDragOverrides,
+	PropStatuses,
 	SequenceControls,
 	SequencePropsSubscriptionKey,
 	SequenceSchema,
@@ -13,7 +13,7 @@ import type {
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 
-export type {CodeValues, DragOverrides, SequenceControls};
+export type {DragOverrides, PropStatuses, SequenceControls};
 
 export type SchemaFieldInfo = {
 	key: string;
@@ -98,7 +98,7 @@ const getEffectFieldValue = ({
 }: {
 	key: string;
 	dragOverrides: DragOverrides[string];
-	effectStatus: ReturnType<typeof Internals.getEffectCodeValuesCtx> | null;
+	effectStatus: ReturnType<typeof Internals.getEffectPropStatusesCtx> | null;
 }): unknown => {
 	const dragOverride = Internals.getStaticDragOverrideValue(dragOverrides[key]);
 	if (dragOverride !== undefined) {
@@ -119,7 +119,7 @@ const getEffectFieldValue = ({
 
 export const getFieldsToShow = ({
 	getDragOverrides,
-	codeValues,
+	propStatuses,
 	nodePath,
 	schema,
 	currentRuntimeValueDotNotation,
@@ -127,7 +127,7 @@ export const getFieldsToShow = ({
 	schema: SequenceSchema;
 	currentRuntimeValueDotNotation: Record<string, unknown>;
 	getDragOverrides: GetDragOverrides;
-	codeValues: CodeValues;
+	propStatuses: PropStatuses;
 	nodePath: SequencePropsSubscriptionKey;
 }): SequenceSchemaFieldInfo[] | null => {
 	const {merged: valuesDotNotation} =
@@ -135,7 +135,7 @@ export const getFieldsToShow = ({
 			schema,
 			currentValue: currentRuntimeValueDotNotation,
 			overrideValues: getDragOverrides(nodePath),
-			propStatus: Internals.getCodeValuesCtx(codeValues, nodePath),
+			propStatus: Internals.getPropStatusesCtx(propStatuses, nodePath),
 			frame: null,
 		});
 
@@ -184,20 +184,20 @@ export const getEffectFieldsToShow = ({
 	effect,
 	effectIndex,
 	nodePath,
-	codeValues,
+	propStatuses,
 	getEffectDragOverrides,
 }: {
 	effect: EffectDefinition<unknown>;
 	effectIndex: number;
 	nodePath: SequencePropsSubscriptionKey | null;
-	codeValues: CodeValues;
+	propStatuses: PropStatuses;
 	getEffectDragOverrides: GetEffectDragOverrides;
 }): EffectSchemaFieldInfo[] => {
 	const effectStatus =
 		nodePath === null
 			? null
-			: Internals.getEffectCodeValuesCtx({
-					codeValues,
+			: Internals.getEffectPropStatusesCtx({
+					propStatuses,
 					nodePath,
 					effectIndex,
 				});

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -188,7 +188,6 @@ test('optimisticAddSequenceKeyframe appends a keyframe to an existing interpolat
 		props: {
 			scale: {
 				status: 'keyframed',
-				codeValue: undefined,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 1},
@@ -232,7 +231,6 @@ test('optimisticAddSequenceKeyframe updates an existing keyframe at the same fra
 		props: {
 			scale: {
 				status: 'keyframed',
-				codeValue: undefined,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 1},
@@ -282,7 +280,6 @@ test('optimisticAddEffectKeyframe appends a keyframe on the target effect', () =
 				props: {
 					amount: {
 						status: 'keyframed',
-						codeValue: undefined,
 						interpolationFunction: 'interpolate',
 						keyframes: [{frame: 0, value: 0.2}],
 						easing: [],

--- a/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
@@ -13,7 +13,6 @@ test('optimisticDeleteSequenceKeyframe removes the matching keyframe and an easi
 		props: {
 			'style.opacity': {
 				status: 'keyframed',
-				codeValue: undefined,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 0},
@@ -56,7 +55,6 @@ test('optimisticDeleteSequenceKeyframe converts the last keyframe to a static va
 		props: {
 			width: {
 				status: 'keyframed',
-				codeValue: undefined,
 				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 12, value: 320}],
 				easing: [],
@@ -89,7 +87,6 @@ test('optimisticDeleteSequenceKeyframe is a no-op when no keyframe matches', () 
 		props: {
 			'style.opacity': {
 				status: 'keyframed',
-				codeValue: undefined,
 				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 0, value: 0}],
 				easing: [],
@@ -132,7 +129,6 @@ test('optimisticDeleteSequenceKeyframes deletes multiple keyframes in one pass',
 		props: {
 			width: {
 				status: 'keyframed',
-				codeValue: undefined,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 100},
@@ -181,7 +177,6 @@ test('optimisticDeleteEffectKeyframe removes the matching keyframe on the target
 				props: {
 					amount: {
 						status: 'keyframed',
-						codeValue: undefined,
 						interpolationFunction: 'interpolate',
 						keyframes: [
 							{frame: 0, value: 0},
@@ -234,7 +229,6 @@ test('optimisticDeleteEffectKeyframe converts the last keyframe on the target ef
 				props: {
 					amount: {
 						status: 'keyframed',
-						codeValue: undefined,
 						interpolationFunction: 'interpolate',
 						keyframes: [{frame: 40, value: 0.6}],
 						easing: [],
@@ -298,7 +292,6 @@ test('optimisticDeleteEffectKeyframes deletes multiple keyframes in one pass', (
 				props: {
 					amount: {
 						status: 'keyframed',
-						codeValue: undefined,
 						interpolationFunction: 'interpolate',
 						keyframes: [
 							{frame: 0, value: 0},

--- a/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
@@ -11,7 +11,6 @@ const previous: CanUpdateSequencePropsResponse = {
 	props: {
 		scale: {
 			status: 'keyframed',
-			codeValue: undefined,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 1},
@@ -32,7 +31,6 @@ const previous: CanUpdateSequencePropsResponse = {
 			props: {
 				amount: {
 					status: 'keyframed',
-					codeValue: undefined,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0.2},

--- a/packages/studio-shared/src/test/optimistic-update-for-effect-prop-statuses.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-for-effect-prop-statuses.test.ts
@@ -1,8 +1,8 @@
 import {expect, test} from 'bun:test';
 import type {CanUpdateSequencePropsResponse} from 'remotion';
-import {optimisticUpdateForEffectCodeValues} from '../optimistic-update-for-effect-code-values';
+import {optimisticUpdateForEffectPropStatuses} from '../optimistic-update-for-effect-prop-statuses';
 
-test('optimisticUpdateForEffectCodeValues updates the matching effect prop', () => {
+test('optimisticUpdateForEffectPropStatuses updates the matching effect prop', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,
 		props: {},
@@ -20,7 +20,7 @@ test('optimisticUpdateForEffectCodeValues updates the matching effect prop', () 
 		],
 	};
 
-	const updated = optimisticUpdateForEffectCodeValues({
+	const updated = optimisticUpdateForEffectPropStatuses({
 		previous,
 		effectIndex: 0,
 		fieldKey: 'opacity',
@@ -47,13 +47,13 @@ test('optimisticUpdateForEffectCodeValues updates the matching effect prop', () 
 	});
 });
 
-test('optimisticUpdateForEffectCodeValues is a no-op when sequence is not updateable', () => {
+test('optimisticUpdateForEffectPropStatuses is a no-op when sequence is not updateable', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: false,
 		reason: 'not-found',
 	};
 
-	const result = optimisticUpdateForEffectCodeValues({
+	const result = optimisticUpdateForEffectPropStatuses({
 		previous,
 		effectIndex: 0,
 		fieldKey: 'opacity',
@@ -64,14 +64,14 @@ test('optimisticUpdateForEffectCodeValues is a no-op when sequence is not update
 	expect(result).toBe(previous);
 });
 
-test('optimisticUpdateForEffectCodeValues is a no-op when effect index not found', () => {
+test('optimisticUpdateForEffectPropStatuses is a no-op when effect index not found', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,
 		props: {},
 		effects: [],
 	};
 
-	const result = optimisticUpdateForEffectCodeValues({
+	const result = optimisticUpdateForEffectPropStatuses({
 		previous,
 		effectIndex: 0,
 		fieldKey: 'opacity',
@@ -82,7 +82,7 @@ test('optimisticUpdateForEffectCodeValues is a no-op when effect index not found
 	expect(result).toBe(previous);
 });
 
-test('optimisticUpdateForEffectCodeValues applies when effect props are unset (zero-arg style)', () => {
+test('optimisticUpdateForEffectPropStatuses applies when effect props are unset (zero-arg style)', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,
 		props: {},
@@ -99,7 +99,7 @@ test('optimisticUpdateForEffectCodeValues applies when effect props are unset (z
 		],
 	};
 
-	const updated = optimisticUpdateForEffectCodeValues({
+	const updated = optimisticUpdateForEffectPropStatuses({
 		previous,
 		effectIndex: 0,
 		fieldKey: 'amount',

--- a/packages/studio-shared/src/test/optimistic-update-for-prop-statuses.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-for-prop-statuses.test.ts
@@ -1,9 +1,9 @@
 import {expect, test} from 'bun:test';
 import {type CanUpdateSequencePropsResponse} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
-import {optimisticUpdateForCodeValues} from '../optimistic-update-for-code-values';
+import {optimisticUpdateForPropStatuses} from '../optimistic-update-for-prop-statuses';
 
-test('optimisticUpdateForCodeValues should return the correct response', () => {
+test('optimisticUpdateForPropStatuses should return the correct response', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,
 		props: {
@@ -14,7 +14,7 @@ test('optimisticUpdateForCodeValues should return the correct response', () => {
 		},
 		effects: [],
 	};
-	const updated = optimisticUpdateForCodeValues({
+	const updated = optimisticUpdateForPropStatuses({
 		previous,
 		fieldKey: 'style.opacity',
 		value: 0.6,
@@ -32,7 +32,7 @@ test('optimisticUpdateForCodeValues should return the correct response', () => {
 		effects: [],
 	});
 
-	const layout = optimisticUpdateForCodeValues({
+	const layout = optimisticUpdateForPropStatuses({
 		previous: updated,
 		fieldKey: 'layout',
 		value: 'none',

--- a/packages/studio-shared/src/test/schema-field-info.test.ts
+++ b/packages/studio-shared/src/test/schema-field-info.test.ts
@@ -64,7 +64,7 @@ test('getEffectFieldsToShow uses the active enum variant', () => {
 		effect,
 		effectIndex: 0,
 		nodePath,
-		codeValues: {
+		propStatuses: {
 			[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 				canUpdate: true,
 				props: {},
@@ -99,7 +99,7 @@ test('getEffectFieldsToShow uses default enum variant if no code value exists', 
 		effect,
 		effectIndex: 0,
 		nodePath: null,
-		codeValues: {},
+		propStatuses: {},
 		getEffectDragOverrides: () => ({}),
 	});
 
@@ -116,7 +116,7 @@ test('getEffectFieldsToShow returns array fields', () => {
 		effect,
 		effectIndex: 0,
 		nodePath: null,
-		codeValues: {},
+		propStatuses: {},
 		getEffectDragOverrides: () => ({}),
 	});
 
@@ -130,7 +130,7 @@ test('getEffectFieldsToShow sizes array fields from the current value', () => {
 		effect,
 		effectIndex: 0,
 		nodePath,
-		codeValues: {
+		propStatuses: {
 			[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 				canUpdate: true,
 				props: {},

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -2,10 +2,10 @@ import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import type {
 	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
-	CodeValues,
 	GetDragOverrides,
 	GetEffectDragOverrides,
 	OverrideIdToNodePaths,
+	PropStatuses,
 	ResolvedStackLocation,
 	SequenceFieldSchema,
 	SequencePropsSubscriptionKey,
@@ -71,7 +71,7 @@ type UvCoordinateFieldSchema = Extract<
 
 type SelectedOutlineUvHandle = {
 	readonly clientId: string;
-	readonly codeValue: CanUpdateSequencePropStatusStatic;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly effectIndex: number;
 	readonly fieldDefault: UvCoordinate | undefined;
 	readonly fieldKey: string;
@@ -114,7 +114,7 @@ type SelectedOutlineTarget = {
 };
 
 type SelectedOutlineDragTarget = {
-	readonly codeValue:
+	readonly propStatus:
 		| CanUpdateSequencePropStatusStatic
 		| CanUpdateSequencePropStatusKeyframed;
 	readonly clientId: string;
@@ -127,7 +127,7 @@ type SelectedOutlineDragTarget = {
 type ScaleFieldSchema = Extract<SequenceFieldSchema, {type: 'scale'}>;
 
 type SelectedOutlineScaleDragTarget = {
-	readonly codeValue: CanUpdateSequencePropStatusStatic;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
 	readonly clientId: string;
 	readonly fieldDefault: number | string | undefined;
 	readonly fieldSchema: ScaleFieldSchema;
@@ -602,14 +602,14 @@ export const getSequencesWithSelectableOutlines = ({
 };
 
 const getSelectedUvHandles = ({
-	codeValues,
+	propStatuses,
 	clientId,
 	getEffectDragOverrides,
 	nodePath,
 	selectedEffects,
 	sequence,
 }: {
-	readonly codeValues: CodeValues;
+	readonly propStatuses: PropStatuses;
 	readonly clientId: string | null;
 	readonly getEffectDragOverrides: GetEffectDragOverrides;
 	readonly nodePath: SequencePropsSubscriptionKey;
@@ -628,8 +628,8 @@ const getSelectedUvHandles = ({
 			continue;
 		}
 
-		const effectStatus = Internals.getEffectCodeValuesCtx({
-			codeValues,
+		const effectStatus = Internals.getEffectPropStatusesCtx({
+			propStatuses,
 			nodePath,
 			effectIndex,
 		});
@@ -669,7 +669,7 @@ const getSelectedUvHandles = ({
 
 			const dragOverrideValue = dragOverrides[fieldKey];
 			const effectiveValue = Internals.getEffectiveVisualModeValue({
-				codeValue: propStatus,
+				propStatus,
 				dragOverrideValue,
 				defaultValue: fieldSchema.default,
 				shouldResortToDefaultValueIfUndefined: true,
@@ -681,7 +681,7 @@ const getSelectedUvHandles = ({
 
 			handles.push({
 				clientId,
-				codeValue: propStatus,
+				propStatus,
 				effectIndex,
 				fieldDefault: fieldSchema.default,
 				fieldKey,
@@ -761,7 +761,7 @@ const getSelectedOutlineDragStates = ({
 		];
 		const sourceFrame = timelinePosition - target.keyframeDisplayOffset;
 		const effectiveValue = Internals.getEffectiveVisualModeValue({
-			codeValue: target.codeValue,
+			propStatus: target.propStatus,
 			dragOverrideValue,
 			defaultValue: target.fieldDefault,
 			frame: sourceFrame,
@@ -836,7 +836,7 @@ export const getSelectedOutlineDragChanges = ({
 			continue;
 		}
 
-		if (dragState.target.codeValue.status === 'keyframed') {
+		if (dragState.target.propStatus.status === 'keyframed') {
 			const startValue = serializeTranslate(dragState.startX, dragState.startY);
 			if (value === startValue) {
 				continue;
@@ -857,10 +857,10 @@ export const getSelectedOutlineDragChanges = ({
 
 		const stringifiedValue = JSON.stringify(value);
 		const shouldSave =
-			value !== dragState.target.codeValue.codeValue &&
+			value !== dragState.target.propStatus.codeValue &&
 			!(
 				dragState.defaultValue === stringifiedValue &&
-				dragState.target.codeValue.codeValue === undefined
+				dragState.target.propStatus.codeValue === undefined
 			);
 
 		if (!shouldSave) {
@@ -937,7 +937,7 @@ export const getSelectedOutlineScaleDragStates = ({
 			scaleFieldKey
 		];
 		const effectiveValue = Internals.getEffectiveVisualModeValue({
-			codeValue: target.codeValue,
+			propStatus: target.propStatus,
 			dragOverrideValue,
 			defaultValue: target.fieldDefault,
 			shouldResortToDefaultValueIfUndefined: true,
@@ -1012,10 +1012,10 @@ export const getSelectedOutlineScaleDragChanges = ({
 		const stringifiedValue = JSON.stringify(value);
 		const shouldSave =
 			stringifiedValue !==
-				JSON.stringify(dragState.target.codeValue.codeValue) &&
+				JSON.stringify(dragState.target.propStatus.codeValue) &&
 			!(
 				dragState.defaultValue === stringifiedValue &&
-				dragState.target.codeValue.codeValue === undefined
+				dragState.target.propStatus.codeValue === undefined
 			);
 
 		if (!shouldSave) {
@@ -1090,7 +1090,7 @@ const SelectedOutlinePolygon: React.FC<{
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
-	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
+	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
@@ -1150,12 +1150,12 @@ const SelectedOutlinePolygon: React.FC<{
 						throw new Error('Expected drag value to be available');
 					}
 
-					if (dragState.target.codeValue.status === 'keyframed') {
+					if (dragState.target.propStatus.status === 'keyframed') {
 						setDragOverrides(
 							dragState.target.nodePath,
 							translateFieldKey,
 							Internals.makeKeyframedDragOverride({
-								status: dragState.target.codeValue,
+								status: dragState.target.propStatus,
 								frame: dragState.sourceFrame,
 								value,
 							}),
@@ -1199,7 +1199,7 @@ const SelectedOutlinePolygon: React.FC<{
 					staticChanges.length > 0
 						? saveSequenceProps({
 								changes: staticChanges,
-								setCodeValues,
+								setPropStatuses,
 								clientId: drag.clientId,
 								undoLabel:
 									changes.length > 1
@@ -1219,7 +1219,7 @@ const SelectedOutlinePolygon: React.FC<{
 							sourceFrame: change.sourceFrame,
 							value: change.value,
 							schema: change.schema,
-							setCodeValues,
+							setPropStatuses,
 							clientId: change.clientId,
 						}),
 					),
@@ -1250,7 +1250,7 @@ const SelectedOutlinePolygon: React.FC<{
 			onSelect,
 			scale,
 			selected,
-			setCodeValues,
+			setPropStatuses,
 			setDragOverrides,
 			target,
 		],
@@ -1316,7 +1316,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
-	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
+	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
 	const scaleDrag = target?.scaleDrag ?? null;
@@ -1410,7 +1410,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 
 				saveSequenceProps({
 					changes,
-					setCodeValues,
+					setPropStatuses,
 					clientId: scaleDrag.clientId,
 					undoLabel:
 						changes.length > 1 ? 'Scale selected sequences' : 'Scale sequence',
@@ -1448,7 +1448,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			onSelect,
 			scaleDrag,
 			selected,
-			setCodeValues,
+			setPropStatuses,
 			setDragOverrides,
 			target,
 		],
@@ -1538,7 +1538,7 @@ const SelectedUvHandleCircle: React.FC<{
 	readonly handle: SelectedOutlineUvHandle;
 	readonly outline: SelectedOutline;
 }> = ({handle, onDraggingChange, outline}) => {
-	const {setEffectDragOverrides, clearEffectDragOverrides, setCodeValues} =
+	const {setEffectDragOverrides, clearEffectDragOverrides, setPropStatuses} =
 		useContext(Internals.VisualModeSettersContext);
 	const position = useMemo(
 		() => getUvHandlePosition(outline.points, handle.value),
@@ -1604,10 +1604,10 @@ const SelectedUvHandleCircle: React.FC<{
 					lastValue === null ? null : JSON.stringify(lastValue);
 				const shouldSave =
 					lastValue !== null &&
-					!tuplesEqual(handle.codeValue.codeValue, lastValue) &&
+					!tuplesEqual(handle.propStatus.codeValue, lastValue) &&
 					!(
 						defaultValue === stringifiedValue &&
-						handle.codeValue.codeValue === undefined
+						handle.propStatus.codeValue === undefined
 					);
 
 				if (!shouldSave) {
@@ -1624,7 +1624,7 @@ const SelectedUvHandleCircle: React.FC<{
 					value: lastValue,
 					defaultValue,
 					schema: handle.schema,
-					setCodeValues,
+					setPropStatuses,
 					clientId: handle.clientId,
 				}).finally(() => {
 					clearEffectDragOverrides(handle.nodePath, handle.effectIndex);
@@ -1640,7 +1640,7 @@ const SelectedUvHandleCircle: React.FC<{
 			handle,
 			onDraggingChange,
 			outline.points,
-			setCodeValues,
+			setPropStatuses,
 			setEffectDragOverrides,
 		],
 	);
@@ -1840,7 +1840,7 @@ export const SelectedOutlineOverlay: React.FC<{
 }> = ({scale}) => {
 	const {selectedItems, selectItem} = useTimelineSelection();
 	const {sequences} = useContext(Internals.SequenceManager);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
@@ -1889,17 +1889,18 @@ export const SelectedOutlineOverlay: React.FC<{
 			const nodePath = nodePathInfo.sequenceSubscriptionKey;
 			const {controls} = sequence;
 			const fieldSchema = controls?.schema[translateFieldKey];
-			const codeValue = Internals.getCodeValuesCtx(codeValues, nodePath)?.[
+			const propStatus = Internals.getPropStatusesCtx(propStatuses, nodePath)?.[
 				translateFieldKey
 			];
 			const scaleFieldSchema = controls?.schema[scaleFieldKey];
-			const scaleCodeValue = Internals.getCodeValuesCtx(codeValues, nodePath)?.[
-				scaleFieldKey
-			];
+			const scalePropStatus = Internals.getPropStatusesCtx(
+				propStatuses,
+				nodePath,
+			)?.[scaleFieldKey];
 			const canDragStatus =
-				codeValue?.status === 'static' ||
-				(codeValue?.status === 'keyframed' &&
-					codeValue.interpolationFunction === 'interpolate');
+				propStatus?.status === 'static' ||
+				(propStatus?.status === 'keyframed' &&
+					propStatus.interpolationFunction === 'interpolate');
 			const canDrag =
 				previewServerState.type === 'connected' &&
 				controls !== null &&
@@ -1909,7 +1910,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				previewServerState.type === 'connected' &&
 				controls !== null &&
 				scaleFieldSchema?.type === 'scale' &&
-				scaleCodeValue?.status === 'static';
+				scalePropStatus?.status === 'static';
 
 			return {
 				key,
@@ -1920,7 +1921,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				sequence,
 				drag: canDrag
 					? {
-							codeValue,
+							propStatus,
 							clientId: previewServerState.clientId,
 							fieldDefault: fieldSchema.default,
 							keyframeDisplayOffset,
@@ -1930,7 +1931,7 @@ export const SelectedOutlineOverlay: React.FC<{
 					: null,
 				scaleDrag: canScaleDrag
 					? {
-							codeValue: scaleCodeValue,
+							propStatus: scalePropStatus,
 							clientId: previewServerState.clientId,
 							fieldDefault: scaleFieldSchema.default,
 							fieldSchema: scaleFieldSchema,
@@ -1942,7 +1943,7 @@ export const SelectedOutlineOverlay: React.FC<{
 										scaleFieldKey
 									];
 									const effectiveValue = Internals.getEffectiveVisualModeValue({
-										codeValue: scaleCodeValue,
+										propStatus: scalePropStatus,
 										dragOverrideValue,
 										defaultValue: scaleFieldSchema.default,
 										shouldResortToDefaultValueIfUndefined: true,
@@ -1958,7 +1959,7 @@ export const SelectedOutlineOverlay: React.FC<{
 					: null,
 				uvHandles: selected
 					? getSelectedUvHandles({
-							codeValues,
+							propStatuses,
 							clientId,
 							getEffectDragOverrides,
 							nodePath,
@@ -1969,7 +1970,7 @@ export const SelectedOutlineOverlay: React.FC<{
 			};
 		});
 	}, [
-		codeValues,
+		propStatuses,
 		getDragOverrides,
 		getEffectDragOverrides,
 		getScaleLockState,

--- a/packages/studio/src/components/Timeline/KeyframeSettingsModal.tsx
+++ b/packages/studio/src/components/Timeline/KeyframeSettingsModal.tsx
@@ -99,7 +99,7 @@ export const KeyframeSettingsModal: React.FC<{
 	readonly state: KeyframeSettingsModalState;
 }> = ({state}) => {
 	const {setSelectedModal} = useContext(ModalsContext);
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const [left, setLeft] = useState(state.status.clamping.left);
 	const [right, setRight] = useState(state.status.clamping.right);
@@ -142,7 +142,7 @@ export const KeyframeSettingsModal: React.FC<{
 						fieldKey: state.fieldKey,
 						settings,
 						schema: state.schema,
-						setCodeValues,
+						setPropStatuses,
 						clientId: previewServerState.clientId,
 					})
 				: callUpdateEffectKeyframeSettings({
@@ -152,7 +152,7 @@ export const KeyframeSettingsModal: React.FC<{
 						fieldKey: state.fieldKey,
 						settings,
 						schema: state.schema,
-						setCodeValues,
+						setPropStatuses,
 						clientId: previewServerState.clientId,
 					});
 
@@ -166,7 +166,7 @@ export const KeyframeSettingsModal: React.FC<{
 		posterize,
 		previewServerState,
 		right,
-		setCodeValues,
+		setPropStatuses,
 		state,
 	]);
 

--- a/packages/studio/src/components/Timeline/SequencePropsObserver.tsx
+++ b/packages/studio/src/components/Timeline/SequencePropsObserver.tsx
@@ -5,7 +5,7 @@ import {StudioServerConnectionCtx} from '../../helpers/client-id';
 
 export const SequencePropsObserver = () => {
 	const {subscribeToEvent} = useContext(StudioServerConnectionCtx);
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 
 	useEffect(() => {
 		const handleEvent = (event: EventSourceEvent) => {
@@ -13,7 +13,7 @@ export const SequencePropsObserver = () => {
 				return;
 			}
 
-			setCodeValues(event.nodePath, () => event.result);
+			setPropStatuses(event.nodePath, () => event.result);
 		};
 
 		const unsubscribe = subscribeToEvent('sequence-props-updated', handleEvent);
@@ -21,7 +21,7 @@ export const SequencePropsObserver = () => {
 		return () => {
 			unsubscribe();
 		};
-	}, [setCodeValues, subscribeToEvent]);
+	}, [setPropStatuses, subscribeToEvent]);
 
 	return null;
 };

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -13,8 +13,8 @@ import type React from 'react';
 import {useContext, useEffect} from 'react';
 import {
 	Internals,
-	type CodeValues,
 	type OverrideIdToNodePaths,
+	type PropStatuses,
 	type SequenceFieldSchema,
 	type SequencePropsSubscriptionKey,
 	type SequenceSchema,
@@ -159,8 +159,8 @@ export const getPasteEffectsTarget = (
 };
 
 type CopyableEffectStatus = React.ContextType<
-	typeof Internals.VisualModeCodeValuesContext
->['codeValues'][string] extends infer TCodeValue
+	typeof Internals.VisualModePropStatusesContext
+>['propStatuses'][string] extends infer TCodeValue
 	? TCodeValue extends {canUpdate: true; effects: readonly unknown[]}
 		? Extract<TCodeValue['effects'][number], {canUpdate: true}>
 		: never
@@ -234,12 +234,12 @@ const effectStatusToSnapshot = (
 
 export const getSnapshotsFromSelection = ({
 	selection,
-	codeValues,
+	propStatuses,
 }: {
 	selection: TimelineSelection;
-	codeValues: React.ContextType<
-		typeof Internals.VisualModeCodeValuesContext
-	>['codeValues'];
+	propStatuses: React.ContextType<
+		typeof Internals.VisualModePropStatusesContext
+	>['propStatuses'];
 }): EffectClipboardSnapshot[] | null => {
 	if (
 		selection.type !== 'sequence-effect' &&
@@ -250,7 +250,7 @@ export const getSnapshotsFromSelection = ({
 
 	const {sequenceSubscriptionKey} = selection.nodePathInfo;
 	const sequenceStatus =
-		codeValues[
+		propStatuses[
 			Internals.makeSequencePropsSubscriptionKey(sequenceSubscriptionKey)
 		];
 	if (!sequenceStatus || !sequenceStatus.canUpdate) {
@@ -287,17 +287,17 @@ export const getSnapshotsFromSelection = ({
 
 export const getEffectPropClipboardDataFromSelection = ({
 	selection,
-	codeValues,
+	propStatuses,
 }: {
 	selection: TimelineSelection;
-	codeValues: CodeValues;
+	propStatuses: PropStatuses;
 }): EffectPropClipboardData | null => {
 	if (selection.type !== 'sequence-effect-prop') {
 		return null;
 	}
 
 	const sequenceStatus =
-		codeValues[
+		propStatuses[
 			Internals.makeSequencePropsSubscriptionKey(
 				selection.nodePathInfo.sequenceSubscriptionKey,
 			)
@@ -339,13 +339,13 @@ export const getEffectPropClipboardDataFromSelection = ({
 export const getPasteEffectPropTarget = ({
 	selectedItems,
 	payload,
-	codeValues,
+	propStatuses,
 	sequences,
 	overrideIdsToNodePaths,
 }: {
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly payload: EffectPropClipboardData;
-	readonly codeValues: CodeValues;
+	readonly propStatuses: PropStatuses;
 	readonly sequences: TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
 }): PasteEffectPropTarget => {
@@ -407,7 +407,7 @@ export const getPasteEffectPropTarget = ({
 	}
 
 	const sequenceStatus =
-		codeValues[
+		propStatuses[
 			Internals.makeSequencePropsSubscriptionKey(
 				selection.nodePathInfo.sequenceSubscriptionKey,
 			)
@@ -448,8 +448,8 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {canSelect} = useTimelineSelection();
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {sequences} = useContext(Internals.SequenceManager);
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
@@ -487,7 +487,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 
 					const payload = getEffectPropClipboardDataFromSelection({
 						selection: selectedItems[0],
-						codeValues,
+						propStatuses,
 					});
 					if (payload === null) {
 						showNotification(
@@ -532,7 +532,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 				const snapshots = selectedItems.flatMap((selection) => {
 					const itemSnapshots = getSnapshotsFromSelection({
 						selection,
-						codeValues,
+						propStatuses,
 					});
 					return itemSnapshots ?? [null];
 				});
@@ -602,7 +602,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 							const effectPropTarget = getPasteEffectPropTarget({
 								selectedItems,
 								payload: effectPropResult.data,
-								codeValues,
+								propStatuses,
 								sequences,
 								overrideIdsToNodePaths: overrideIdToNodePathMappings,
 							});
@@ -668,7 +668,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 										}),
 								defaultValue: effectPropTarget.defaultValue,
 								schema: effectPropTarget.schema,
-								setCodeValues,
+								setPropStatuses,
 								clientId,
 							}).then(() => {
 								showNotification('Pasted effect prop', 2000);
@@ -745,13 +745,13 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 		};
 	}, [
 		canSelect,
-		codeValues,
+		propStatuses,
 		currentSelection,
 		keybindings,
 		overrideIdToNodePathMappings,
 		previewServerState,
 		sequences,
-		setCodeValues,
+		setPropStatuses,
 	]);
 
 	return null;

--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -19,8 +19,8 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
 	);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {canSelect} = useTimelineSelection();
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 	const confirm = useConfirmationDialog();
@@ -44,8 +44,8 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 					selections: selectedItems,
 					sequences,
 					overrideIdsToNodePaths: overrideIdToNodePathMappings,
-					codeValues,
-					setCodeValues,
+					propStatuses,
+					setPropStatuses,
 					clientId,
 				});
 
@@ -58,7 +58,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 					selections: selectedItems,
 					sequences,
 					overrideIdsToNodePaths: overrideIdToNodePathMappings,
-					setCodeValues,
+					setPropStatuses,
 					clientId,
 					confirm,
 				});
@@ -112,14 +112,14 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		};
 	}, [
 		canSelect,
-		codeValues,
+		propStatuses,
 		confirm,
 		currentSelection,
 		keybindings,
 		overrideIdToNodePathMappings,
 		previewServerState,
 		sequences,
-		setCodeValues,
+		setPropStatuses,
 	]);
 
 	return null;

--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -124,8 +124,8 @@ export const TimelineEffectItem: React.FC<{
 }) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewConnected = previewServerState.type === 'connected';
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const selection = useTimelineRowSelection(nodePathInfo);
 	const [dropIndicator, setDropIndicator] = useState<'before' | 'after' | null>(
 		null,
@@ -133,12 +133,12 @@ export const TimelineEffectItem: React.FC<{
 
 	const effectStatus = useMemo(
 		() =>
-			Internals.getEffectCodeValuesCtx({
-				codeValues,
+			Internals.getEffectPropStatusesCtx({
+				propStatuses,
 				nodePath,
 				effectIndex,
 			}),
-		[codeValues, nodePath, effectIndex],
+		[propStatuses, nodePath, effectIndex],
 	);
 
 	const disabledStatus =
@@ -273,7 +273,7 @@ export const TimelineEffectItem: React.FC<{
 				value: newValue,
 				defaultValue,
 				schema: effectSchema,
-				setCodeValues,
+				setPropStatuses,
 				clientId: previewServerState.clientId,
 			});
 		},
@@ -283,7 +283,7 @@ export const TimelineEffectItem: React.FC<{
 			effectSchema,
 			nodePath,
 			previewServerState,
-			setCodeValues,
+			setPropStatuses,
 			validatedLocation.source,
 		],
 	);

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -1,6 +1,6 @@
 import {
 	isSchemaFieldKeyframable,
-	optimisticUpdateForEffectCodeValues,
+	optimisticUpdateForEffectPropStatuses,
 } from '@remotion/studio-shared';
 import React, {useCallback, useContext, useMemo} from 'react';
 import type {
@@ -71,15 +71,15 @@ const Value: React.FC<{
 	readonly validatedLocation: CodePosition;
 	readonly keyframeDisplayOffset: number;
 }> = ({field, nodePath, validatedLocation, keyframeDisplayOffset}) => {
-	const {setEffectDragOverrides, clearEffectDragOverrides, setCodeValues} =
+	const {setEffectDragOverrides, clearEffectDragOverrides, setPropStatuses} =
 		useContext(Internals.VisualModeSettersContext);
 
 	const {getEffectDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
 
-	const {codeValues: visualModeCodeValues} = useContext(
-		Internals.VisualModeCodeValuesContext,
+	const {propStatuses: visualModePropStatuses} = useContext(
+		Internals.VisualModePropStatusesContext,
 	);
 
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
@@ -88,8 +88,8 @@ const Value: React.FC<{
 			? previewServerState.clientId
 			: null;
 
-	const effectStatus = Internals.getEffectCodeValuesCtx({
-		codeValues: visualModeCodeValues,
+	const effectStatus = Internals.getEffectPropStatusesCtx({
+		propStatuses: visualModePropStatuses,
 		nodePath,
 		effectIndex: field.effectIndex,
 	});
@@ -176,9 +176,9 @@ const Value: React.FC<{
 
 			return enqueueSavePropChange({
 				nodePath,
-				setCodeValues,
+				setPropStatuses,
 				applyOptimistic: (prev) =>
-					optimisticUpdateForEffectCodeValues({
+					optimisticUpdateForEffectPropStatuses({
 						previous: prev,
 						effectIndex: field.effectIndex,
 						fieldKey: field.key,
@@ -208,7 +208,7 @@ const Value: React.FC<{
 			field.key,
 			nodePath,
 			propStatus,
-			setCodeValues,
+			setPropStatuses,
 			validatedLocation,
 		],
 	);
@@ -231,7 +231,7 @@ const Value: React.FC<{
 				sourceFrame,
 				value,
 				schema: field.effectSchema,
-				setCodeValues,
+				setPropStatuses,
 				clientId,
 			});
 		},
@@ -241,7 +241,7 @@ const Value: React.FC<{
 			field.effectSchema,
 			field.key,
 			nodePath,
-			setCodeValues,
+			setPropStatuses,
 			validatedLocation,
 		],
 	);
@@ -306,7 +306,7 @@ const Value: React.FC<{
 	}
 
 	const effectiveValue = Internals.getEffectiveVisualModeValue({
-		codeValue: propStatus,
+		propStatus,
 		dragOverrideValue,
 		defaultValue: field.fieldSchema.default,
 		frame: jsxFrame,
@@ -343,8 +343,8 @@ export const TimelineEffectPropItem: React.FC<{
 }) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {setSelectedModal} = useContext(ModalsContext);
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {getEffectDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
@@ -358,12 +358,12 @@ export const TimelineEffectPropItem: React.FC<{
 
 	const effectStatus = useMemo(
 		() =>
-			Internals.getEffectCodeValuesCtx({
-				codeValues,
+			Internals.getEffectPropStatusesCtx({
+				propStatuses,
 				nodePath,
 				effectIndex: field.effectIndex,
 			}),
-		[codeValues, nodePath, field.effectIndex],
+		[propStatuses, nodePath, field.effectIndex],
 	);
 
 	const propStatus =
@@ -440,7 +440,7 @@ export const TimelineEffectPropItem: React.FC<{
 			value: field.fieldSchema.default,
 			defaultValue,
 			schema: field.effectSchema,
-			setCodeValues,
+			setPropStatuses,
 			clientId: previewServerState.clientId,
 		});
 	}, [
@@ -452,7 +452,7 @@ export const TimelineEffectPropItem: React.FC<{
 		field.key,
 		nodePath,
 		previewServerState,
-		setCodeValues,
+		setPropStatuses,
 		validatedLocation.source,
 	]);
 

--- a/packages/studio/src/components/Timeline/TimelineExpandedSection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedSection.tsx
@@ -43,8 +43,8 @@ export const TimelineExpandedSection: React.FC<{
 }) => {
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {toggleTrack} = useContext(ExpandedTracksSetterContext);
-	const {codeValues: visualModeCodeValues} = useContext(
-		Internals.VisualModeCodeValuesContext,
+	const {propStatuses: visualModePropStatuses} = useContext(
+		Internals.VisualModePropStatusesContext,
 	);
 	const {getDragOverrides, getEffectDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
@@ -57,14 +57,14 @@ export const TimelineExpandedSection: React.FC<{
 				nodePathInfo,
 				getDragOverrides,
 				getEffectDragOverrides,
-				codeValues: visualModeCodeValues,
+				propStatuses: visualModePropStatuses,
 			}),
 		[
 			sequence,
 			nodePathInfo,
 			getDragOverrides,
 			getEffectDragOverrides,
-			visualModeCodeValues,
+			visualModePropStatuses,
 		],
 	);
 
@@ -79,9 +79,9 @@ export const TimelineExpandedSection: React.FC<{
 				sequence,
 				nodePathInfo,
 				getIsExpanded,
-				codeValues: visualModeCodeValues,
+				propStatuses: visualModePropStatuses,
 			}),
-		[sequence, nodePathInfo, getIsExpanded, visualModeCodeValues],
+		[sequence, nodePathInfo, getIsExpanded, visualModePropStatuses],
 	);
 
 	const style = useMemo(() => {

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -78,7 +78,7 @@ const getCurrentKeyframeValue = ({
 }): unknown | null => {
 	if (isKeyframedStatus(propStatus)) {
 		return Internals.getEffectiveVisualModeValue({
-			codeValue: propStatus,
+			propStatus,
 			dragOverrideValue,
 			frame: jsxFrame,
 			defaultValue,
@@ -88,7 +88,7 @@ const getCurrentKeyframeValue = ({
 
 	if (propStatus.status === 'static') {
 		return Internals.getEffectiveVisualModeValue({
-			codeValue: propStatus,
+			propStatus,
 			dragOverrideValue,
 			frame: jsxFrame,
 			defaultValue,
@@ -147,7 +147,7 @@ export const TimelineKeyframeControls: React.FC<{
 	const videoConfig = useVideoConfig();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const setFrame = Internals.useTimelineSetFrame();
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 
 	const clientId =
@@ -257,7 +257,7 @@ export const TimelineKeyframeControls: React.FC<{
 						fieldKey,
 						sourceFrame: jsxFrame,
 						schema,
-						setCodeValues,
+						setPropStatuses,
 						clientId,
 					});
 					return;
@@ -270,7 +270,7 @@ export const TimelineKeyframeControls: React.FC<{
 					fieldKey,
 					sourceFrame: jsxFrame,
 					schema,
-					setCodeValues,
+					setPropStatuses,
 					clientId,
 				});
 				return;
@@ -289,7 +289,7 @@ export const TimelineKeyframeControls: React.FC<{
 					sourceFrame: jsxFrame,
 					value,
 					schema,
-					setCodeValues,
+					setPropStatuses,
 					clientId,
 				});
 				return;
@@ -303,7 +303,7 @@ export const TimelineKeyframeControls: React.FC<{
 				sourceFrame: jsxFrame,
 				value,
 				schema,
-				setCodeValues,
+				setPropStatuses,
 				clientId,
 			});
 		},
@@ -319,7 +319,7 @@ export const TimelineKeyframeControls: React.FC<{
 			nodePath,
 			propStatus,
 			schema,
-			setCodeValues,
+			setPropStatuses,
 		],
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
@@ -61,7 +61,7 @@ export const TimelineKeyframedValue: React.FC<{
 
 	const effectiveValue = useMemo(() => {
 		return Internals.getEffectiveVisualModeValue({
-			codeValue: fakeStatus,
+			propStatus: fakeStatus,
 			dragOverrideValue,
 			frame: jsxFrame,
 			defaultValue: field.fieldSchema.default,

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -217,18 +217,18 @@ const TimelineSequenceInner: React.FC<{
 		};
 	}, [originalLocation]);
 
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const nodePath = nodePathInfo?.sequenceSubscriptionKey ?? null;
-	const codeValuesForOverride = useMemo(() => {
+	const propStatusesForOverride = useMemo(() => {
 		return nodePath
-			? Internals.getCodeValuesCtx(codeValues, nodePath)
+			? Internals.getPropStatusesCtx(propStatuses, nodePath)
 			: undefined;
-	}, [codeValues, nodePath]);
+	}, [propStatuses, nodePath]);
 	const durationCanUpdate = Boolean(
-		codeValuesForOverride?.durationInFrames?.status === 'static',
+		propStatusesForOverride?.durationInFrames?.status === 'static',
 	);
 	const fromCanUpdate = Boolean(
-		codeValuesForOverride?.from?.status === 'static',
+		propStatusesForOverride?.from?.status === 'static',
 	);
 
 	const {onPointerDown: onMoveDragPointerDown} = useTimelineSequenceFromDrag({

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -211,8 +211,8 @@ export const TimelineSequenceItem: React.FC<{
 	const previewConnected = previewServerState.type === 'connected';
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {toggleTrack} = useContext(ExpandedTracksSetterContext);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const selectAsset = useSelectAsset();
 	const {onSelect, selectable, selected} =
 		useTimelineRowSelection(nodePathInfo);
@@ -709,22 +709,22 @@ export const TimelineSequenceItem: React.FC<{
 		[canOpenInEditor, openInEditor],
 	);
 
-	const codeValuesForOverride = useMemo(() => {
+	const propStatusesForOverride = useMemo(() => {
 		return nodePath
-			? Internals.getCodeValuesCtx(codeValues, nodePath)
+			? Internals.getPropStatusesCtx(propStatuses, nodePath)
 			: undefined;
-	}, [codeValues, nodePath]);
+	}, [propStatuses, nodePath]);
 
-	const codeHiddenStatus = codeValuesForOverride?.hidden;
+	const codeHiddenStatus = propStatusesForOverride?.hidden;
 
 	const isItemHidden = useMemo(() => {
-		const codeValue =
+		const propStatus =
 			codeHiddenStatus && codeHiddenStatus.status === 'static'
 				? codeHiddenStatus.codeValue
 				: undefined;
 		const runtimeValue =
 			sequence.controls?.currentRuntimeValueDotNotation.hidden;
-		const effective = (codeValue ?? runtimeValue) as boolean | undefined;
+		const effective = (propStatus ?? runtimeValue) as boolean | undefined;
 		return effective ?? false;
 	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
 
@@ -734,7 +734,7 @@ export const TimelineSequenceItem: React.FC<{
 				!sequence.controls ||
 				!nodePath ||
 				!validatedLocation ||
-				!codeValuesForOverride ||
+				!propStatusesForOverride ||
 				!codeHiddenStatus ||
 				codeHiddenStatus.status !== 'static' ||
 				previewServerState.type !== 'connected'
@@ -762,7 +762,7 @@ export const TimelineSequenceItem: React.FC<{
 						schema,
 					},
 				],
-				setCodeValues,
+				setPropStatuses,
 				clientId: previewServerState.clientId,
 				undoLabel: newValue ? 'Hide sequence' : 'Show sequence',
 				redoLabel: newValue ? 'Hide sequence again' : 'Show sequence again',
@@ -770,11 +770,11 @@ export const TimelineSequenceItem: React.FC<{
 		},
 		[
 			codeHiddenStatus,
-			codeValuesForOverride,
+			propStatusesForOverride,
 			nodePath,
 			previewServerState,
 			sequence.controls,
-			setCodeValues,
+			setPropStatuses,
 			validatedLocation,
 		],
 	);

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -73,8 +73,8 @@ const Value: React.FC<{
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly validatedLocation: CodePosition;
 	readonly schema: SequenceSchema;
-	readonly codeValue: CanUpdateSequencePropStatusStatic;
-}> = ({field, nodePath, validatedLocation, schema, codeValue}) => {
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
+}> = ({field, nodePath, validatedLocation, schema, propStatus}) => {
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
@@ -88,13 +88,13 @@ const Value: React.FC<{
 	}, [getDragOverrides, nodePath, field.key]);
 
 	const effectiveValue = Internals.getEffectiveVisualModeValue({
-		codeValue,
+		propStatus,
 		dragOverrideValue,
 		defaultValue: field.fieldSchema.default,
 		shouldResortToDefaultValueIfUndefined: true,
 	});
 
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const clientId =
 		previewServerState.type === 'connected'
@@ -115,13 +115,13 @@ const Value: React.FC<{
 			const stringifiedValue = JSON.stringify(value);
 			const fieldLabel = field.description ?? field.key;
 
-			if (value === codeValue.codeValue) {
+			if (value === propStatus.codeValue) {
 				return Promise.resolve();
 			}
 
 			if (
 				defaultValue === stringifiedValue &&
-				codeValue.codeValue === undefined
+				propStatus.codeValue === undefined
 			) {
 				return Promise.resolve();
 			}
@@ -137,21 +137,21 @@ const Value: React.FC<{
 						schema,
 					},
 				],
-				setCodeValues,
+				setPropStatuses,
 				clientId,
 				undoLabel: `Update ${fieldLabel}`,
 				redoLabel: `Update ${fieldLabel} again`,
 			});
 		},
 		[
-			codeValue,
+			propStatus,
 			clientId,
 			field.description,
 			field.fieldSchema.default,
 			field.key,
 			nodePath,
 			schema,
-			setCodeValues,
+			setPropStatuses,
 			validatedLocation,
 		],
 	);
@@ -182,7 +182,7 @@ const Value: React.FC<{
 	return (
 		<TimelineFieldValue
 			field={field}
-			propStatus={codeValue}
+			propStatus={propStatus}
 			onSave={onSave}
 			onDragValueChange={onDragValueChange}
 			onDragEnd={onDragEnd}
@@ -209,13 +209,13 @@ export const TimelineSequencePropItem: React.FC<{
 	schema,
 	keyframeDisplayOffset,
 }) => {
-	const {codeValues: visualModeCodeValues} = useContext(
-		Internals.VisualModeCodeValuesContext,
+	const {propStatuses: visualModePropStatuses} = useContext(
+		Internals.VisualModePropStatusesContext,
 	);
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
-	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
+	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
@@ -226,11 +226,11 @@ export const TimelineSequencePropItem: React.FC<{
 			? previewServerState.clientId
 			: null;
 
-	const codeValuesForOverride = Internals.getCodeValuesCtx(
-		visualModeCodeValues,
+	const propStatusesForOverride = Internals.getPropStatusesCtx(
+		visualModePropStatuses,
 		nodePath,
 	);
-	const codeValue = codeValuesForOverride?.[field.key] ?? null;
+	const propStatus = propStatusesForOverride?.[field.key] ?? null;
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const jsxFrame = timelinePosition - keyframeDisplayOffset;
 
@@ -239,9 +239,9 @@ export const TimelineSequencePropItem: React.FC<{
 	}, [getDragOverrides, nodePath, field.key]);
 
 	const keyframeControls =
-		codeValue !== null &&
+		propStatus !== null &&
 		shouldShowTimelineKeyframeControls({
-			propStatus: codeValue,
+			propStatus,
 			selected: selection.selected,
 			keyframable: isSchemaFieldKeyframable({
 				schema,
@@ -250,7 +250,7 @@ export const TimelineSequencePropItem: React.FC<{
 		}) ? (
 			<TimelineKeyframeControls
 				fieldKey={field.key}
-				propStatus={codeValue}
+				propStatus={propStatus}
 				nodePath={nodePath}
 				fileName={validatedLocation.source}
 				keyframeDisplayOffset={keyframeDisplayOffset}
@@ -269,20 +269,20 @@ export const TimelineSequencePropItem: React.FC<{
 	}, [field.rowHeight]);
 
 	const canResetToDefault = useMemo(() => {
-		if (!codeValue || codeValue.status === 'computed') {
+		if (!propStatus || propStatus.status === 'computed') {
 			return false;
 		}
 
 		return isResettableStatus({
-			status: codeValue,
+			status: propStatus,
 			defaultValue: field.fieldSchema.default,
 		});
-	}, [codeValue, field.fieldSchema.default]);
+	}, [propStatus, field.fieldSchema.default]);
 
 	const canPerformReset =
 		previewServerState.type === 'connected' &&
-		codeValue !== null &&
-		codeValue.status !== 'computed';
+		propStatus !== null &&
+		propStatus.status !== 'computed';
 	const canShowReset =
 		canPerformReset && field.fieldSchema.default !== undefined;
 
@@ -291,7 +291,7 @@ export const TimelineSequencePropItem: React.FC<{
 			!canShowReset ||
 			!canResetToDefault ||
 			previewServerState.type !== 'connected' ||
-			codeValue === null
+			propStatus === null
 		) {
 			return;
 		}
@@ -313,7 +313,7 @@ export const TimelineSequencePropItem: React.FC<{
 					schema,
 				},
 			],
-			setCodeValues,
+			setPropStatuses,
 			clientId: previewServerState.clientId,
 			undoLabel: `Reset ${fieldLabel}`,
 			redoLabel: `Reapply ${fieldLabel}`,
@@ -327,9 +327,9 @@ export const TimelineSequencePropItem: React.FC<{
 		nodePath,
 		previewServerState,
 		schema,
-		setCodeValues,
+		setPropStatuses,
 		validatedLocation.source,
-		codeValue,
+		propStatus,
 	]);
 
 	const onSaveKeyframed = useCallback(
@@ -345,7 +345,7 @@ export const TimelineSequencePropItem: React.FC<{
 				sourceFrame,
 				value,
 				schema,
-				setCodeValues,
+				setPropStatuses,
 				clientId,
 			});
 		},
@@ -354,7 +354,7 @@ export const TimelineSequencePropItem: React.FC<{
 			field.key,
 			nodePath,
 			schema,
-			setCodeValues,
+			setPropStatuses,
 			validatedLocation.source,
 		],
 	);
@@ -362,7 +362,7 @@ export const TimelineSequencePropItem: React.FC<{
 	const onKeyframedDragValueChange =
 		useCallback<TimelineFieldOnDragValueChange>(
 			(value) => {
-				if (codeValue === null || !isKeyframedStatus(codeValue)) {
+				if (propStatus === null || !isKeyframedStatus(propStatus)) {
 					throw new Error('Expected keyframed status');
 				}
 
@@ -370,13 +370,13 @@ export const TimelineSequencePropItem: React.FC<{
 					nodePath,
 					field.key,
 					Internals.makeKeyframedDragOverride({
-						status: codeValue,
+						status: propStatus,
 						frame: jsxFrame,
 						value,
 					}),
 				);
 			},
-			[codeValue, field.key, jsxFrame, nodePath, setDragOverrides],
+			[propStatus, field.key, jsxFrame, nodePath, setDragOverrides],
 		);
 
 	const onKeyframedDragEnd = useCallback(() => {
@@ -384,7 +384,7 @@ export const TimelineSequencePropItem: React.FC<{
 	}, [clearDragOverrides, nodePath]);
 
 	const onOpenKeyframeSettings = useCallback(() => {
-		if (codeValue === null || !isKeyframedStatus(codeValue)) {
+		if (propStatus === null || !isKeyframedStatus(propStatus)) {
 			return;
 		}
 
@@ -394,12 +394,12 @@ export const TimelineSequencePropItem: React.FC<{
 			nodePath,
 			fieldKey: field.key,
 			fieldLabel: field.description ?? field.key,
-			status: codeValue,
+			status: propStatus,
 			schema,
 			effectIndex: null,
 		});
 	}, [
-		codeValue,
+		propStatus,
 		field.description,
 		field.key,
 		nodePath,
@@ -424,7 +424,7 @@ export const TimelineSequencePropItem: React.FC<{
 			},
 		];
 
-		if (codeValue !== null && isKeyframedStatus(codeValue)) {
+		if (propStatus !== null && isKeyframedStatus(propStatus)) {
 			values.push({
 				type: 'item',
 				id: 'keyframe-settings-sequence-field',
@@ -442,13 +442,13 @@ export const TimelineSequencePropItem: React.FC<{
 		return values;
 	}, [
 		canShowReset,
-		codeValue,
+		propStatus,
 		onOpenKeyframeSettings,
 		onReset,
 		previewServerState,
 	]);
 
-	if (codeValue === null) {
+	if (propStatus === null) {
 		return null;
 	}
 
@@ -471,11 +471,11 @@ export const TimelineSequencePropItem: React.FC<{
 				selected={selection.selected}
 				label={field.description ?? field.key}
 			/>
-			{isKeyframedStatus(codeValue) ? (
+			{isKeyframedStatus(propStatus) ? (
 				<div style={timelineFieldValueColumnStyle}>
 					<TimelineKeyframedValue
 						field={field}
-						propStatus={codeValue}
+						propStatus={propStatus}
 						keyframeDisplayOffset={keyframeDisplayOffset}
 						dragOverrideValue={dragOverrideValue}
 						onSave={onSaveKeyframed}
@@ -484,19 +484,19 @@ export const TimelineSequencePropItem: React.FC<{
 						scaleLockNodePath={nodePath}
 					/>
 				</div>
-			) : codeValue.status === 'static' ? (
+			) : propStatus.status === 'static' ? (
 				<div style={timelineFieldValueColumnStyle}>
 					<Value
 						field={field}
 						nodePath={nodePath}
 						validatedLocation={validatedLocation}
 						schema={schema}
-						codeValue={codeValue}
+						propStatus={propStatus}
 					/>
 				</div>
 			) : (
 				<div style={timelineFieldValueColumnStyle}>
-					<TimelineNonEditableStatus propStatus={codeValue} />
+					<TimelineNonEditableStatus propStatus={propStatus} />
 				</div>
 			)}
 		</TimelineRowChrome>

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -7,8 +7,8 @@ import React, {
 	useState,
 } from 'react';
 import type {
-	CodeValues,
 	OverrideIdToNodePaths,
+	PropStatuses,
 	SequencePropsSubscriptionKey,
 	TSequence,
 } from 'remotion';
@@ -28,8 +28,8 @@ import {
 } from './save-sequence-prop';
 import {
 	getTimelineSequenceSelectionKey,
-	type TimelineSelection,
 	useTimelineSelection,
+	type TimelineSelection,
 } from './TimelineSelection';
 
 const HANDLE_WIDTH = 6;
@@ -57,26 +57,27 @@ export type TimelineSequenceFromDragTarget = {
 };
 
 const canUpdateDurationInFrames = ({
-	codeValues,
+	propStatuses,
 	nodePath,
 }: {
-	readonly codeValues: CodeValues;
+	readonly propStatuses: PropStatuses;
 	readonly nodePath: SequencePropsSubscriptionKey;
 }) => {
-	const status = Internals.getCodeValuesCtx(codeValues, nodePath)
+	const status = Internals.getPropStatusesCtx(propStatuses, nodePath)
 		?.durationInFrames?.status;
 
 	return status === 'static';
 };
 
 const canUpdateFrom = ({
-	codeValues,
+	propStatuses,
 	nodePath,
 }: {
-	readonly codeValues: CodeValues;
+	readonly propStatuses: PropStatuses;
 	readonly nodePath: SequencePropsSubscriptionKey;
 }) => {
-	const status = Internals.getCodeValuesCtx(codeValues, nodePath)?.from?.status;
+	const status = Internals.getPropStatusesCtx(propStatuses, nodePath)?.from
+		?.status;
 
 	return status === 'static';
 };
@@ -203,13 +204,13 @@ export const getTimelineSequenceDurationDragTargets = ({
 	selectedItems,
 	sequences,
 	overrideIdsToNodePaths,
-	codeValues,
+	propStatuses,
 }: {
 	readonly draggedNodePathInfo: SequenceNodePathInfo;
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly sequences: TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
-	readonly codeValues: CodeValues;
+	readonly propStatuses: PropStatuses;
 }): TimelineSequenceDurationDragTarget[] | null => {
 	const draggedSelectionKey =
 		getTimelineSequenceSelectionKey(draggedNodePathInfo);
@@ -251,7 +252,7 @@ export const getTimelineSequenceDurationDragTargets = ({
 		}
 
 		const nodePath = nodePathInfo.sequenceSubscriptionKey;
-		if (!canUpdateDurationInFrames({codeValues, nodePath})) {
+		if (!canUpdateDurationInFrames({propStatuses, nodePath})) {
 			return null;
 		}
 
@@ -273,13 +274,13 @@ export const getTimelineSequenceFromDragTargets = ({
 	selectedItems,
 	sequences,
 	overrideIdsToNodePaths,
-	codeValues,
+	propStatuses,
 }: {
 	readonly draggedNodePathInfo: SequenceNodePathInfo;
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly sequences: TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
-	readonly codeValues: CodeValues;
+	readonly propStatuses: PropStatuses;
 }): TimelineSequenceFromDragTarget[] | null => {
 	const draggedSelectionKey =
 		getTimelineSequenceSelectionKey(draggedNodePathInfo);
@@ -321,7 +322,7 @@ export const getTimelineSequenceFromDragTargets = ({
 		}
 
 		const nodePath = nodePathInfo.sequenceSubscriptionKey;
-		if (!canUpdateFrom({codeValues, nodePath})) {
+		if (!canUpdateFrom({propStatuses, nodePath})) {
 			return null;
 		}
 
@@ -371,10 +372,10 @@ export const useTimelineSequenceFromDrag = ({
 	readonly windowWidth: number;
 	readonly timelineDurationInFrames: number;
 }) => {
-	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
+	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {sequences} = useContext(Internals.SequenceManager);
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
@@ -393,22 +394,22 @@ export const useTimelineSequenceFromDrag = ({
 
 	const latestRef = useRef({
 		nodePathInfo,
-		setCodeValues,
+		setPropStatuses,
 		setDragOverrides,
 		clearDragOverrides,
 		previewServerState,
-		codeValues,
+		propStatuses,
 		sequences,
 		overrideIdToNodePathMappings,
 		selectedItems,
 	});
 	latestRef.current = {
 		nodePathInfo,
-		setCodeValues,
+		setPropStatuses,
 		setDragOverrides,
 		clearDragOverrides,
 		previewServerState,
-		codeValues,
+		propStatuses,
 		sequences,
 		overrideIdToNodePathMappings,
 		selectedItems,
@@ -426,7 +427,7 @@ export const useTimelineSequenceFromDrag = ({
 		}
 
 		const {
-			setCodeValues: latestSetCodeValues,
+			setPropStatuses: latestSetPropStatuses,
 			clearDragOverrides: latestClear,
 			previewServerState: latestServerState,
 		} = latestRef.current;
@@ -450,7 +451,7 @@ export const useTimelineSequenceFromDrag = ({
 
 		const savePromise = saveSequenceProps({
 			changes,
-			setCodeValues: latestSetCodeValues,
+			setPropStatuses: latestSetPropStatuses,
 			clientId: latestServerState.clientId,
 			undoLabel:
 				changes.length > 1 ? 'Move selected sequences' : 'Move sequence',
@@ -495,7 +496,7 @@ export const useTimelineSequenceFromDrag = ({
 				selectedItems: latestSelectedItems,
 				sequences: latestSequences,
 				overrideIdToNodePathMappings: latestOverrideIdsToNodePaths,
-				codeValues: latestCodeValues,
+				propStatuses: latestPropStatuses,
 			} = latestRef.current;
 			if (latestNodePathInfo === null) {
 				return;
@@ -506,7 +507,7 @@ export const useTimelineSequenceFromDrag = ({
 				selectedItems: latestSelectedItems,
 				sequences: latestSequences,
 				overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
-				codeValues: latestCodeValues,
+				propStatuses: latestPropStatuses,
 			});
 			if (targets === null || targets.length === 0) {
 				return;
@@ -601,10 +602,10 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 	readonly windowWidth: number;
 	readonly timelineDurationInFrames: number;
 }> = ({nodePathInfo, windowWidth, timelineDurationInFrames}) => {
-	const {setCodeValues, setDragOverrides, clearDragOverrides} = useContext(
+	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {sequences} = useContext(Internals.SequenceManager);
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
@@ -624,22 +625,22 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 	// Keep latest props/setters available to window listeners installed once at pointerdown.
 	const latestRef = useRef({
 		nodePathInfo,
-		setCodeValues,
+		setPropStatuses,
 		setDragOverrides,
 		clearDragOverrides,
 		previewServerState,
-		codeValues,
+		propStatuses,
 		sequences,
 		overrideIdToNodePathMappings,
 		selectedItems,
 	});
 	latestRef.current = {
 		nodePathInfo,
-		setCodeValues,
+		setPropStatuses,
 		setDragOverrides,
 		clearDragOverrides,
 		previewServerState,
-		codeValues,
+		propStatuses,
 		sequences,
 		overrideIdToNodePathMappings,
 		selectedItems,
@@ -658,7 +659,7 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 		}
 
 		const {
-			setCodeValues: latestSetCodeValues,
+			setPropStatuses: latestSetPropStatuses,
 			clearDragOverrides: latestClear,
 			previewServerState: latestServerState,
 		} = latestRef.current;
@@ -682,7 +683,7 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 
 		const savePromise = saveSequenceProps({
 			changes,
-			setCodeValues: latestSetCodeValues,
+			setPropStatuses: latestSetPropStatuses,
 			clientId: latestServerState.clientId,
 			undoLabel:
 				changes.length > 1 ? 'Resize selected sequences' : 'Resize sequence',
@@ -727,14 +728,14 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 				selectedItems: latestSelectedItems,
 				sequences: latestSequences,
 				overrideIdToNodePathMappings: latestOverrideIdsToNodePaths,
-				codeValues: latestCodeValues,
+				propStatuses: latestPropStatuses,
 			} = latestRef.current;
 			const targets = getTimelineSequenceDurationDragTargets({
 				draggedNodePathInfo: latestNodePathInfo,
 				selectedItems: latestSelectedItems,
 				sequences: latestSequences,
 				overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
-				codeValues: latestCodeValues,
+				propStatuses: latestPropStatuses,
 			});
 			if (targets === null || targets.length === 0) {
 				return;

--- a/packages/studio/src/components/Timeline/apply-effect-response-to-prop-statuses.ts
+++ b/packages/studio/src/components/Timeline/apply-effect-response-to-prop-statuses.ts
@@ -3,7 +3,7 @@ import type {
 	CanUpdateSequencePropsResponse,
 } from 'remotion';
 
-export const applyEffectResponseToCodeValues = ({
+export const applyEffectResponseToPropStatuses = ({
 	previous,
 	response,
 }: {

--- a/packages/studio/src/components/Timeline/call-add-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-add-keyframe.ts
@@ -4,9 +4,9 @@ import {
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
-import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
+import {applyEffectResponseToPropStatuses} from './apply-effect-response-to-prop-statuses';
 import {enqueueSavePropChange} from './save-prop-queue';
-import type {SetCodeValues} from './save-sequence-prop';
+import type {SetPropStatuses} from './save-sequence-prop';
 
 export const callAddSequenceKeyframe = ({
 	fileName,
@@ -15,7 +15,7 @@ export const callAddSequenceKeyframe = ({
 	sourceFrame,
 	value,
 	schema,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	fileName: string;
@@ -24,12 +24,12 @@ export const callAddSequenceKeyframe = ({
 	sourceFrame: number;
 	value: unknown;
 	schema: SequenceSchema;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> => {
 	return enqueueSavePropChange({
 		nodePath,
-		setCodeValues,
+		setPropStatuses,
 		applyOptimistic: (prev) =>
 			optimisticAddSequenceKeyframe({
 				previous: prev,
@@ -60,7 +60,7 @@ export const callAddEffectKeyframe = ({
 	sourceFrame,
 	value,
 	schema,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	fileName: string;
@@ -70,12 +70,12 @@ export const callAddEffectKeyframe = ({
 	sourceFrame: number;
 	value: unknown;
 	schema: SequenceSchema;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> => {
 	return enqueueSavePropChange({
 		nodePath,
-		setCodeValues,
+		setPropStatuses,
 		applyOptimistic: (prev) =>
 			optimisticAddEffectKeyframe({
 				previous: prev,
@@ -86,7 +86,7 @@ export const callAddEffectKeyframe = ({
 				schema,
 			}),
 		applyServerResponse: (prev, response) =>
-			applyEffectResponseToCodeValues({previous: prev, response}),
+			applyEffectResponseToPropStatuses({previous: prev, response}),
 		apiCall: () =>
 			callApi('/api/add-effect-keyframe', {
 				fileName,

--- a/packages/studio/src/components/Timeline/call-delete-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-delete-keyframe.ts
@@ -7,7 +7,7 @@ import {
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
 import {enqueueSavePropChange} from './save-prop-queue';
-import type {SetCodeValues} from './save-sequence-prop';
+import type {SetPropStatuses} from './save-sequence-prop';
 
 export type DeleteSequenceKeyframeChange = {
 	fileName: string;
@@ -41,7 +41,7 @@ export const callDeleteSequenceKeyframe = ({
 	fieldKey,
 	sourceFrame,
 	schema,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	fileName: string;
@@ -49,12 +49,12 @@ export const callDeleteSequenceKeyframe = ({
 	fieldKey: string;
 	sourceFrame: number;
 	schema: SequenceSchema;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> => {
 	return enqueueSavePropChange({
 		nodePath,
-		setCodeValues,
+		setPropStatuses,
 		applyOptimistic: (prev) =>
 			optimisticDeleteSequenceKeyframe({
 				previous: prev,
@@ -86,7 +86,7 @@ export const callDeleteEffectKeyframe = ({
 	fieldKey,
 	sourceFrame,
 	schema,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	fileName: string;
@@ -95,12 +95,12 @@ export const callDeleteEffectKeyframe = ({
 	fieldKey: string;
 	sourceFrame: number;
 	schema: SequenceSchema;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> => {
 	return enqueueSavePropChange({
 		nodePath,
-		setCodeValues,
+		setPropStatuses,
 		applyOptimistic: (prev) =>
 			optimisticDeleteEffectKeyframe({
 				previous: prev,
@@ -130,12 +130,12 @@ export const callDeleteEffectKeyframe = ({
 export const callDeleteKeyframes = ({
 	sequenceKeyframes,
 	effectKeyframes,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	sequenceKeyframes: DeleteSequenceKeyframeChange[];
 	effectKeyframes: DeleteEffectKeyframeChange[];
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> => {
 	if (sequenceKeyframes.length === 0 && effectKeyframes.length === 0) {
@@ -148,7 +148,7 @@ export const callDeleteKeyframes = ({
 			continue;
 		}
 
-		setCodeValues(firstKeyframe.nodePath, (prev) =>
+		setPropStatuses(firstKeyframe.nodePath, (prev) =>
 			optimisticDeleteSequenceKeyframes({
 				previous: prev,
 				keyframes: keyframes.map((keyframe) => ({
@@ -165,7 +165,7 @@ export const callDeleteKeyframes = ({
 			continue;
 		}
 
-		setCodeValues(firstKeyframe.nodePath, (prev) =>
+		setPropStatuses(firstKeyframe.nodePath, (prev) =>
 			optimisticDeleteEffectKeyframes({
 				previous: prev,
 				keyframes: keyframes.map((keyframe) => ({

--- a/packages/studio/src/components/Timeline/call-move-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-move-keyframe.ts
@@ -4,7 +4,7 @@ import {
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
-import type {SetCodeValues} from './save-sequence-prop';
+import type {SetPropStatuses} from './save-sequence-prop';
 
 export type MoveSequenceKeyframeChange = {
 	fileName: string;
@@ -36,12 +36,12 @@ const groupByNodePath = <T extends {nodePath: SequencePropsSubscriptionKey}>(
 export const callMoveKeyframes = ({
 	sequenceKeyframes,
 	effectKeyframes,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	sequenceKeyframes: MoveSequenceKeyframeChange[];
 	effectKeyframes: MoveEffectKeyframeChange[];
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> => {
 	if (sequenceKeyframes.length === 0 && effectKeyframes.length === 0) {
@@ -54,7 +54,7 @@ export const callMoveKeyframes = ({
 			continue;
 		}
 
-		setCodeValues(firstKeyframe.nodePath, (prev) =>
+		setPropStatuses(firstKeyframe.nodePath, (prev) =>
 			optimisticMoveSequenceKeyframes({
 				previous: prev,
 				keyframes: keyframes.map((keyframe) => ({
@@ -72,7 +72,7 @@ export const callMoveKeyframes = ({
 			continue;
 		}
 
-		setCodeValues(firstKeyframe.nodePath, (prev) =>
+		setPropStatuses(firstKeyframe.nodePath, (prev) =>
 			optimisticMoveEffectKeyframes({
 				previous: prev,
 				keyframes: keyframes.map((keyframe) => ({

--- a/packages/studio/src/components/Timeline/call-update-keyframe-settings.ts
+++ b/packages/studio/src/components/Timeline/call-update-keyframe-settings.ts
@@ -5,9 +5,9 @@ import {
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
-import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
+import {applyEffectResponseToPropStatuses} from './apply-effect-response-to-prop-statuses';
 import {enqueueSavePropChange} from './save-prop-queue';
-import type {SetCodeValues} from './save-sequence-prop';
+import type {SetPropStatuses} from './save-sequence-prop';
 
 export const callUpdateSequenceKeyframeSettings = ({
 	fileName,
@@ -15,7 +15,7 @@ export const callUpdateSequenceKeyframeSettings = ({
 	fieldKey,
 	settings,
 	schema,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	fileName: string;
@@ -23,12 +23,12 @@ export const callUpdateSequenceKeyframeSettings = ({
 	fieldKey: string;
 	settings: KeyframeSettings;
 	schema: SequenceSchema;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> => {
 	return enqueueSavePropChange({
 		nodePath,
-		setCodeValues,
+		setPropStatuses,
 		applyOptimistic: (prev) =>
 			optimisticUpdateSequenceKeyframeSettings({
 				previous: prev,
@@ -55,7 +55,7 @@ export const callUpdateEffectKeyframeSettings = ({
 	fieldKey,
 	settings,
 	schema,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	fileName: string;
@@ -64,12 +64,12 @@ export const callUpdateEffectKeyframeSettings = ({
 	fieldKey: string;
 	settings: KeyframeSettings;
 	schema: SequenceSchema;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> => {
 	return enqueueSavePropChange({
 		nodePath,
-		setCodeValues,
+		setPropStatuses,
 		applyOptimistic: (prev) =>
 			optimisticUpdateEffectKeyframeSettings({
 				previous: prev,
@@ -78,7 +78,7 @@ export const callUpdateEffectKeyframeSettings = ({
 				settings,
 			}),
 		applyServerResponse: (prev, response) =>
-			applyEffectResponseToCodeValues({previous: prev, response}),
+			applyEffectResponseToPropStatuses({previous: prev, response}),
 		apiCall: () =>
 			callApi('/api/update-effect-keyframe-settings', {
 				fileName,

--- a/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
@@ -1,15 +1,15 @@
 import type {OverrideIdToNodePaths, TSequence} from 'remotion';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
-	callDeleteKeyframes,
 	callDeleteEffectKeyframe,
+	callDeleteKeyframes,
 	callDeleteSequenceKeyframe,
 	type DeleteEffectKeyframeChange,
 	type DeleteSequenceKeyframeChange,
 } from './call-delete-keyframe';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
 import {parseKeyframeFieldFromNodePath} from './parse-keyframe-field-from-node-path';
-import type {SetCodeValues} from './save-sequence-prop';
+import type {SetPropStatuses} from './save-sequence-prop';
 
 type SelectedKeyframeDeletion =
 	| ({type: 'sequence'} & DeleteSequenceKeyframeChange)
@@ -77,14 +77,14 @@ export const deleteSelectedKeyframe = ({
 	frame,
 	sequences,
 	overrideIdsToNodePaths,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	nodePathInfo: SequenceNodePathInfo;
 	frame: number;
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> | null => {
 	const deletion = getSelectedKeyframeDeletion({
@@ -100,14 +100,14 @@ export const deleteSelectedKeyframe = ({
 	if (deletion.type === 'effect') {
 		return callDeleteEffectKeyframe({
 			...deletion,
-			setCodeValues,
+			setPropStatuses,
 			clientId,
 		});
 	}
 
 	return callDeleteSequenceKeyframe({
 		...deletion,
-		setCodeValues,
+		setPropStatuses,
 		clientId,
 	});
 };
@@ -116,7 +116,7 @@ export const deleteSelectedKeyframes = ({
 	keyframes,
 	sequences,
 	overrideIdsToNodePaths,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 }: {
 	keyframes: {
@@ -125,7 +125,7 @@ export const deleteSelectedKeyframes = ({
 	}[];
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 }): Promise<void> | null => {
 	const deletions = keyframes
@@ -160,7 +160,7 @@ export const deleteSelectedKeyframes = ({
 				type: 'effect';
 			} => deletion.type === 'effect',
 		),
-		setCodeValues,
+		setPropStatuses,
 		clientId,
 	});
 };

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -7,7 +7,7 @@ import {
 	deleteSelectedKeyframe,
 	deleteSelectedKeyframes,
 } from './delete-selected-keyframe';
-import type {SetCodeValues} from './save-sequence-prop';
+import type {SetPropStatuses} from './save-sequence-prop';
 import type {TimelineSelection} from './TimelineSelection';
 
 const confirmDeletingDuplicatedSequences = (
@@ -142,14 +142,14 @@ export const deleteSelectedTimelineItem = ({
 	selection,
 	sequences,
 	overrideIdsToNodePaths,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 	confirm,
 }: {
 	selection: TimelineSelection;
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 	confirm: ConfirmationDialogFunction;
 }): Promise<boolean> | null => {
@@ -159,7 +159,7 @@ export const deleteSelectedTimelineItem = ({
 			frame: selection.frame,
 			sequences,
 			overrideIdsToNodePaths,
-			setCodeValues,
+			setPropStatuses,
 			clientId,
 		});
 		return promise?.then(() => true) ?? null;
@@ -235,14 +235,14 @@ export const deleteSelectedTimelineItems = ({
 	selections,
 	sequences,
 	overrideIdsToNodePaths,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 	confirm,
 }: {
 	selections: readonly TimelineSelection[];
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 	confirm: ConfirmationDialogFunction;
 }): Promise<boolean> | null => {
@@ -277,7 +277,7 @@ export const deleteSelectedTimelineItems = ({
 				})),
 				sequences,
 				overrideIdsToNodePaths,
-				setCodeValues,
+				setPropStatuses,
 				clientId,
 			});
 			return promise?.then(() => true) ?? null;

--- a/packages/studio/src/components/Timeline/get-node-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-node-keyframes.ts
@@ -1,9 +1,9 @@
 import {
 	Internals,
-	type CodeValues,
 	type DragOverrideValue,
 	type GetDragOverrides,
 	type GetEffectDragOverrides,
+	type PropStatuses,
 	type SequencePropsSubscriptionKey,
 } from 'remotion';
 import type {TimelineTreeNode} from '../../helpers/timeline-layout';
@@ -62,7 +62,7 @@ const withDragOverrideKeyframe = ({
 export const getNodeKeyframes = ({
 	node,
 	nodePath,
-	codeValues,
+	propStatuses,
 	keyframeDisplayOffset,
 	getDragOverrides,
 	getEffectDragOverrides,
@@ -70,7 +70,7 @@ export const getNodeKeyframes = ({
 }: {
 	node: TimelineTreeNode;
 	nodePath: SequencePropsSubscriptionKey;
-	codeValues: CodeValues;
+	propStatuses: PropStatuses;
 	keyframeDisplayOffset: number;
 	getDragOverrides: GetDragOverrides;
 	getEffectDragOverrides: GetEffectDragOverrides;
@@ -83,7 +83,7 @@ export const getNodeKeyframes = ({
 	if (node.field.kind === 'sequence-field') {
 		const dragOverrides = getDragOverrides(nodePath);
 		return withDragOverrideKeyframe({
-			propStatus: Internals.getCodeValuesCtx(codeValues, nodePath)?.[
+			propStatus: Internals.getPropStatusesCtx(propStatuses, nodePath)?.[
 				node.field.key
 			],
 			keyframeDisplayOffset,
@@ -93,8 +93,8 @@ export const getNodeKeyframes = ({
 		});
 	}
 
-	const effectStatus = Internals.getEffectCodeValuesCtx({
-		codeValues,
+	const effectStatus = Internals.getEffectPropStatusesCtx({
+		propStatuses,
 		nodePath,
 		effectIndex: node.field.effectIndex,
 	});

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -1,7 +1,7 @@
 import type {
 	CanUpdateSequencePropStatus,
-	CodeValues,
 	OverrideIdToNodePaths,
+	PropStatuses,
 	SequenceFieldSchema,
 	SequencePropsSubscriptionKey,
 	SequenceSchema,
@@ -10,7 +10,7 @@ import type {
 import {Internals} from 'remotion';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
 import {saveEffectProp} from './save-effect-prop';
-import type {SetCodeValues} from './save-sequence-prop';
+import type {SetPropStatuses} from './save-sequence-prop';
 import {saveSequenceProps} from './save-sequence-prop';
 import type {TimelineSelection} from './TimelineSelection';
 
@@ -51,13 +51,13 @@ const isVisibleFieldSchema = (
 	fieldSchema !== undefined && fieldSchema.type !== 'hidden';
 
 const isNonDefaultCodeValue = ({
-	codeValue,
+	propStatus,
 	defaultValue,
 }: {
-	readonly codeValue: unknown;
+	readonly propStatus: unknown;
 	readonly defaultValue: unknown;
 }) =>
-	JSON.stringify(codeValue ?? defaultValue) !== JSON.stringify(defaultValue);
+	JSON.stringify(propStatus ?? defaultValue) !== JSON.stringify(defaultValue);
 
 const isResettablePropStatus = ({
 	propStatus,
@@ -79,7 +79,7 @@ const isResettablePropStatus = ({
 	}
 
 	return isNonDefaultCodeValue({
-		codeValue: propStatus.codeValue,
+		propStatus: propStatus.codeValue,
 		defaultValue,
 	});
 };
@@ -95,12 +95,12 @@ export const getTimelinePropResetTargets = ({
 	selections,
 	sequences,
 	overrideIdsToNodePaths,
-	codeValues,
+	propStatuses,
 }: {
 	readonly selections: readonly TimelineSelection[];
 	readonly sequences: TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
-	readonly codeValues: CodeValues;
+	readonly propStatuses: PropStatuses;
 }): TimelinePropResetTarget[] | null => {
 	const firstSelection = selections[0];
 	if (!firstSelection || !isPropResetSelection(firstSelection)) {
@@ -132,8 +132,8 @@ export const getTimelinePropResetTargets = ({
 			}
 
 			const sequenceFieldSchema = sequence.controls.schema[selection.key];
-			const sequencePropStatus = Internals.getCodeValuesCtx(
-				codeValues,
+			const sequencePropStatus = Internals.getPropStatusesCtx(
+				propStatuses,
 				nodePath,
 			)?.[selection.key];
 			if (
@@ -160,8 +160,8 @@ export const getTimelinePropResetTargets = ({
 
 		const effect = sequence.effects[selection.i];
 		const fieldSchema = effect?.schema[selection.key];
-		const effectStatus = Internals.getEffectCodeValuesCtx({
-			codeValues,
+		const effectStatus = Internals.getEffectPropStatusesCtx({
+			propStatuses,
 			nodePath,
 			effectIndex: selection.i,
 		});
@@ -199,22 +199,22 @@ export const resetSelectedTimelineProps = ({
 	selections,
 	sequences,
 	overrideIdsToNodePaths,
-	codeValues,
-	setCodeValues,
+	propStatuses,
+	setPropStatuses,
 	clientId,
 }: {
 	readonly selections: readonly TimelineSelection[];
 	readonly sequences: TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
-	readonly codeValues: CodeValues;
-	readonly setCodeValues: SetCodeValues;
+	readonly propStatuses: PropStatuses;
+	readonly setPropStatuses: SetPropStatuses;
 	readonly clientId: string;
 }): Promise<void> | null => {
 	const resetTargets = getTimelinePropResetTargets({
 		selections,
 		sequences,
 		overrideIdsToNodePaths,
-		codeValues,
+		propStatuses,
 	});
 	if (resetTargets === null || resetTargets.length === 0) {
 		return null;
@@ -241,7 +241,7 @@ export const resetSelectedTimelineProps = ({
 					defaultValue: target.defaultValue,
 					schema: target.schema,
 				})),
-				setCodeValues,
+				setPropStatuses,
 				clientId,
 				undoLabel:
 					sequencePropTargets.length > 1
@@ -266,7 +266,7 @@ export const resetSelectedTimelineProps = ({
 				value: target.value,
 				defaultValue: target.defaultValue,
 				schema: target.schema,
-				setCodeValues,
+				setPropStatuses,
 				clientId,
 			}),
 		);

--- a/packages/studio/src/components/Timeline/save-effect-prop.ts
+++ b/packages/studio/src/components/Timeline/save-effect-prop.ts
@@ -1,12 +1,12 @@
 import {
-	optimisticUpdateForEffectCodeValues,
+	optimisticUpdateForEffectPropStatuses,
 	type EffectClipboardParam,
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey, SequenceSchema} from 'remotion';
 import {callApi} from '../call-api';
-import {applyEffectResponseToCodeValues} from './apply-effect-response-to-code-values';
+import {applyEffectResponseToPropStatuses} from './apply-effect-response-to-prop-statuses';
 import {enqueueSavePropChange} from './save-prop-queue';
-import type {SetCodeValues} from './save-sequence-prop';
+import type {SetPropStatuses} from './save-sequence-prop';
 
 type SaveEffectPropBase = {
 	fileName: string;
@@ -15,7 +15,7 @@ type SaveEffectPropBase = {
 	fieldKey: string;
 	defaultValue: string | null;
 	schema: SequenceSchema;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 };
 
@@ -39,17 +39,17 @@ export const saveEffectProp = (input: SaveEffectPropInput): Promise<void> => {
 		fieldKey,
 		defaultValue,
 		schema,
-		setCodeValues,
+		setPropStatuses,
 		clientId,
 	} = input;
 
 	return enqueueSavePropChange({
 		nodePath,
-		setCodeValues,
+		setPropStatuses,
 		applyOptimistic: (prev) =>
 			input.type === 'effect-param'
 				? prev
-				: optimisticUpdateForEffectCodeValues({
+				: optimisticUpdateForEffectPropStatuses({
 						previous: prev,
 						effectIndex,
 						fieldKey,
@@ -57,7 +57,7 @@ export const saveEffectProp = (input: SaveEffectPropInput): Promise<void> => {
 						schema,
 					}),
 		applyServerResponse: (prev, response) =>
-			applyEffectResponseToCodeValues({previous: prev, response}),
+			applyEffectResponseToPropStatuses({previous: prev, response}),
 		apiCall: () =>
 			callApi(
 				'/api/save-effect-props',

--- a/packages/studio/src/components/Timeline/save-prop-queue.ts
+++ b/packages/studio/src/components/Timeline/save-prop-queue.ts
@@ -5,7 +5,7 @@ import type {
 import {Internals} from 'remotion';
 import {showNotification} from '../Notifications/NotificationCenter';
 
-type SetCodeValues = (
+type SetPropStatuses = (
 	nodePath: SequencePropsSubscriptionKey,
 	values: (
 		prev: CanUpdateSequencePropsResponse,
@@ -42,7 +42,7 @@ const dropQueue = (
 
 export type EnqueueSaveOptions<TResponse> = {
 	nodePath: SequencePropsSubscriptionKey;
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	applyOptimistic: (
 		prev: CanUpdateSequencePropsResponse,
 	) => CanUpdateSequencePropsResponse;
@@ -56,7 +56,7 @@ export type EnqueueSaveOptions<TResponse> = {
 
 export const enqueueSavePropChange = <TResponse>({
 	nodePath,
-	setCodeValues,
+	setPropStatuses,
 	applyOptimistic,
 	applyServerResponse,
 	apiCall,
@@ -68,7 +68,7 @@ export const enqueueSavePropChange = <TResponse>({
 		return Promise.resolve();
 	}
 
-	setCodeValues(nodePath, (prev) => {
+	setPropStatuses(nodePath, (prev) => {
 		return applyOptimistic(prev);
 	});
 
@@ -87,7 +87,7 @@ export const enqueueSavePropChange = <TResponse>({
 			// If nothing more is queued, reset baseline so the next round starts fresh.
 			if (myQueue.chain === next) {
 				if (applyServerResponse) {
-					setCodeValues(nodePath, (prev) =>
+					setPropStatuses(nodePath, (prev) =>
 						applyServerResponse(prev, response),
 					);
 				}

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -1,4 +1,4 @@
-import {optimisticUpdateForCodeValues} from '@remotion/studio-shared';
+import {optimisticUpdateForPropStatuses} from '@remotion/studio-shared';
 import type {
 	CanUpdateSequencePropsResponse,
 	SequencePropsSubscriptionKey,
@@ -7,7 +7,7 @@ import type {
 import {callApi} from '../call-api';
 import {enqueueSavePropChange} from './save-prop-queue';
 
-export type SetCodeValues = (
+export type SetPropStatuses = (
 	nodePath: SequencePropsSubscriptionKey,
 	values: (
 		prev: CanUpdateSequencePropsResponse,
@@ -25,7 +25,7 @@ export type SaveSequencePropChange = {
 
 type SaveSequencePropsOptions = {
 	changes: SaveSequencePropChange[];
-	setCodeValues: SetCodeValues;
+	setPropStatuses: SetPropStatuses;
 	clientId: string;
 	undoLabel: string;
 	redoLabel: string;
@@ -33,7 +33,7 @@ type SaveSequencePropsOptions = {
 
 export const saveSequenceProps = ({
 	changes,
-	setCodeValues,
+	setPropStatuses,
 	clientId,
 	undoLabel,
 	redoLabel,
@@ -50,9 +50,9 @@ export const saveSequenceProps = ({
 
 		return enqueueSavePropChange({
 			nodePath: change.nodePath,
-			setCodeValues,
+			setPropStatuses,
 			applyOptimistic: (prev) =>
-				optimisticUpdateForCodeValues({
+				optimisticUpdateForPropStatuses({
 					previous: prev,
 					fieldKey: change.fieldKey,
 					value: change.value,
@@ -79,8 +79,8 @@ export const saveSequenceProps = ({
 	}
 
 	for (const change of changes) {
-		setCodeValues(change.nodePath, (prev) =>
-			optimisticUpdateForCodeValues({
+		setPropStatuses(change.nodePath, (prev) =>
+			optimisticUpdateForPropStatuses({
 				previous: prev,
 				fieldKey: change.fieldKey,
 				value: change.value,

--- a/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
+++ b/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
@@ -32,7 +32,7 @@ export const useExpandedTrackKeyframeRows = ({
 	readonly expandedHeight: number;
 } => {
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {getDragOverrides, getEffectDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
@@ -45,10 +45,10 @@ export const useExpandedTrackKeyframeRows = ({
 				nodePathInfo,
 				getDragOverrides,
 				getEffectDragOverrides,
-				codeValues,
+				propStatuses,
 			}),
 		[
-			codeValues,
+			propStatuses,
 			getDragOverrides,
 			getEffectDragOverrides,
 			nodePathInfo,
@@ -67,9 +67,9 @@ export const useExpandedTrackKeyframeRows = ({
 				sequence,
 				nodePathInfo,
 				getIsExpanded,
-				codeValues,
+				propStatuses,
 			}),
-		[codeValues, getIsExpanded, nodePathInfo, sequence],
+		[propStatuses, getIsExpanded, nodePathInfo, sequence],
 	);
 
 	const rows = useMemo(
@@ -79,7 +79,7 @@ export const useExpandedTrackKeyframeRows = ({
 				keyframes: getNodeKeyframes({
 					node,
 					nodePath: nodePathInfo.sequenceSubscriptionKey,
-					codeValues,
+					propStatuses,
 					keyframeDisplayOffset,
 					getDragOverrides,
 					getEffectDragOverrides,
@@ -89,7 +89,7 @@ export const useExpandedTrackKeyframeRows = ({
 				nodePathInfo: node.nodePathInfo,
 			})),
 		[
-			codeValues,
+			propStatuses,
 			flat,
 			getDragOverrides,
 			getEffectDragOverrides,

--- a/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
+++ b/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
@@ -21,7 +21,7 @@ export const useSequencePropsSubscription = ({
 	effects: SequenceSchema[];
 	originalLocation: OriginalPosition | null;
 }) => {
-	const {setCodeValues} = useContext(Internals.VisualModeSettersContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {setOverrideIdToNodePath} = useContext(
 		Internals.OverrideIdsToNodePathsSettersContext,
 	);
@@ -91,7 +91,7 @@ export const useSequencePropsSubscription = ({
 					return;
 				}
 
-				setCodeValues(result.nodePath, () => result.status);
+				setPropStatuses(result.nodePath, () => result.status);
 			},
 			applyEach: (result) => {
 				if (!result.success) {
@@ -135,7 +135,7 @@ export const useSequencePropsSubscription = ({
 		migrateExpandedTracksForSubscriptionKey,
 		overrideId,
 		schema,
-		setCodeValues,
+		setPropStatuses,
 		setOverrideIdToNodePath,
 	]);
 };

--- a/packages/studio/src/components/Timeline/use-timeline-height.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-height.ts
@@ -20,7 +20,7 @@ export const useTimelineHeight = ({
 }): number => {
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 
 	const previewServerConnected = previewServerState.type === 'connected';
 
@@ -39,7 +39,7 @@ export const useTimelineHeight = ({
 							sequence: track.sequence,
 							nodePathInfo: track.nodePathInfo,
 							getIsExpanded,
-							codeValues,
+							propStatuses,
 						}) + TIMELINE_ITEM_BORDER_BOTTOM
 					: 0;
 			return acc + layerHeight + expandedHeight;
@@ -51,5 +51,5 @@ export const useTimelineHeight = ({
 			(hasBeenCut ? MAX_TIMELINE_TRACKS_NOTICE_HEIGHT : 0) +
 			TIMELINE_TIME_INDICATOR_HEIGHT
 		);
-	}, [shown, hasBeenCut, previewServerConnected, getIsExpanded, codeValues]);
+	}, [shown, hasBeenCut, previewServerConnected, getIsExpanded, propStatuses]);
 };

--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -3,9 +3,9 @@ import type React from 'react';
 import {useCallback, useContext} from 'react';
 import type {
 	CanUpdateSequencePropStatusKeyframed,
-	CodeValues,
 	DragOverrideValue,
 	OverrideIdToNodePaths,
+	PropStatuses,
 	SequencePropsSubscriptionKey,
 	SequenceSchema,
 	TSequence,
@@ -55,21 +55,21 @@ const isKeyframeSelection = (
 ): selection is TimelineKeyframeSelection => selection.type === 'keyframe';
 
 const getCodeValueForTarget = ({
-	codeValues,
+	propStatuses,
 	nodePath,
 }: {
-	readonly codeValues: CodeValues;
+	readonly propStatuses: PropStatuses;
 	readonly nodePath: SequencePropsSubscriptionKey;
-}) => codeValues[Internals.makeSequencePropsSubscriptionKey(nodePath)];
+}) => propStatuses[Internals.makeSequencePropsSubscriptionKey(nodePath)];
 
 const getTimelineKeyframeDragTarget = ({
-	codeValues,
+	propStatuses,
 	displayFrame,
 	nodePathInfo,
 	overrideIdsToNodePaths,
 	sequences,
 }: {
-	readonly codeValues: CodeValues;
+	readonly propStatuses: PropStatuses;
 	readonly displayFrame: number;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
@@ -93,7 +93,7 @@ const getTimelineKeyframeDragTarget = ({
 	const sourceFrame = displayFrame - (track?.keyframeDisplayOffset ?? 0);
 	const nodePath = nodePathInfo.sequenceSubscriptionKey;
 	const fileName = nodePath.absolutePath;
-	const sequenceStatus = getCodeValueForTarget({codeValues, nodePath});
+	const sequenceStatus = getCodeValueForTarget({propStatuses, nodePath});
 	if (!sequenceStatus?.canUpdate) {
 		return null;
 	}
@@ -358,11 +358,11 @@ export const useTimelineKeyframeDrag = ({
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
 	);
-	const {codeValues} = useContext(Internals.VisualModeCodeValuesContext);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {
 		clearDragOverrides,
 		clearEffectDragOverrides,
-		setCodeValues,
+		setPropStatuses,
 		setDragOverrides,
 		setEffectDragOverrides,
 	} = useContext(Internals.VisualModeSettersContext);
@@ -420,7 +420,7 @@ export const useTimelineKeyframeDrag = ({
 				dragTargets = keyframesToDrag
 					.map((keyframe) =>
 						getTimelineKeyframeDragTarget({
-							codeValues,
+							propStatuses,
 							displayFrame: keyframe.frame,
 							nodePathInfo: keyframe.nodePathInfo,
 							overrideIdsToNodePaths: overrideIdToNodePathMappings,
@@ -568,7 +568,7 @@ export const useTimelineKeyframeDrag = ({
 							toFrame: target.sourceFrame + lastDelta,
 							schema: target.schema,
 						})),
-					setCodeValues,
+					setPropStatuses,
 					clientId: previewServerState.clientId,
 				}).catch(() => undefined);
 			};
@@ -587,7 +587,7 @@ export const useTimelineKeyframeDrag = ({
 			clearDragOverrides,
 			clearEffectDragOverrides,
 			clearDraggedKeyframes,
-			codeValues,
+			propStatuses,
 			currentSelection,
 			frame,
 			nodePathInfo,
@@ -597,7 +597,7 @@ export const useTimelineKeyframeDrag = ({
 			selectable,
 			selected,
 			sequences,
-			setCodeValues,
+			setPropStatuses,
 			setDragOverrides,
 			setDraggedKeyframes,
 			setEffectDragOverrides,

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -2,9 +2,9 @@ import {
 	getEffectFieldsToShow,
 	getFieldsToShow,
 	type AnySchemaFieldInfo,
-	type CodeValues,
 	type DragOverrides,
 	type EffectSchemaFieldInfo,
+	type PropStatuses,
 	type SchemaFieldInfo,
 	type SequenceControls,
 	type SequenceSchemaFieldInfo,
@@ -25,9 +25,9 @@ export {
 } from '@remotion/studio-shared';
 export type {
 	AnySchemaFieldInfo,
-	CodeValues,
 	DragOverrides,
 	EffectSchemaFieldInfo,
+	PropStatuses,
 	SchemaFieldInfo,
 	SequenceControls,
 	SequenceSchemaFieldInfo,
@@ -74,13 +74,13 @@ export const buildTimelineTree = ({
 	nodePathInfo,
 	getDragOverrides,
 	getEffectDragOverrides,
-	codeValues,
+	propStatuses,
 }: {
 	sequence: TSequence;
 	nodePathInfo: SequenceNodePathInfo;
 	getDragOverrides: GetDragOverrides;
 	getEffectDragOverrides: GetEffectDragOverrides;
-	codeValues: CodeValues;
+	propStatuses: PropStatuses;
 }): TimelineTreeNode[] => {
 	const roots: TimelineTreeNode[] = [];
 	const {sequenceSubscriptionKey, index, auxiliaryKeys, supportsEffects} =
@@ -91,7 +91,7 @@ export const buildTimelineTree = ({
 		currentRuntimeValueDotNotation:
 			sequence.controls!.currentRuntimeValueDotNotation,
 		getDragOverrides,
-		codeValues,
+		propStatuses,
 		nodePath: sequenceSubscriptionKey,
 	});
 
@@ -129,7 +129,7 @@ export const buildTimelineTree = ({
 					effect,
 					effectIndex: i,
 					nodePath: sequenceSubscriptionKey,
-					codeValues,
+					propStatuses,
 					getEffectDragOverrides,
 				});
 				return {
@@ -217,12 +217,12 @@ export const getExpandedTrackHeight = ({
 	sequence,
 	nodePathInfo,
 	getIsExpanded,
-	codeValues,
+	propStatuses,
 }: {
 	sequence: TSequence;
 	nodePathInfo: SequenceNodePathInfo;
 	getIsExpanded: GetIsExpanded;
-	codeValues: CodeValues;
+	propStatuses: PropStatuses;
 }): number => {
 	const tree = buildTimelineTree({
 		sequence,
@@ -230,7 +230,7 @@ export const getExpandedTrackHeight = ({
 		// We assume that no drag overrides can change the timeline layout
 		getDragOverrides: () => ({}),
 		getEffectDragOverrides: () => ({}),
-		codeValues,
+		propStatuses,
 	});
 	const flat = flattenVisibleTreeNodes({nodes: tree, getIsExpanded});
 

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -4,7 +4,7 @@ import type {
 	SequencePropsSubscriptionKey,
 	TSequence,
 } from 'remotion';
-import {Internals, type CodeValues} from 'remotion';
+import {Internals, type PropStatuses} from 'remotion';
 import {getBoundedKeyframeDragDelta} from '../components/Timeline/get-bounded-keyframe-drag-delta';
 import {getNodeKeyframes} from '../components/Timeline/get-node-keyframes';
 import {getTimelineKeyframes} from '../components/Timeline/get-timeline-keyframes';
@@ -71,7 +71,6 @@ const numberFieldSchema = {
 
 const makeKeyframedStatus = (): CanUpdateSequencePropStatusKeyframed => ({
 	status: 'keyframed',
-	codeValue: undefined,
 	interpolationFunction: 'interpolate',
 	keyframes: [
 		{frame: 0, value: 2},
@@ -129,9 +128,9 @@ const makeEffectFieldNode = (
 	},
 });
 
-const makeCodeValues = (
+const makePropStatuses = (
 	nodePath: SequencePropsSubscriptionKey,
-): CodeValues => ({
+): PropStatuses => ({
 	[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 		canUpdate: true,
 		props: {
@@ -213,7 +212,6 @@ test('keyframe display offsets follow the parent sequence context', () => {
 		getTimelineKeyframes(
 			{
 				status: 'keyframed',
-				codeValue: undefined,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 2},
@@ -286,7 +284,7 @@ test('getNodeKeyframes shows a temporary sequence keyframe from drag overrides',
 		getNodeKeyframes({
 			node: makeSequenceFieldNode('style.scale'),
 			nodePath,
-			codeValues: makeCodeValues(nodePath),
+			propStatuses: makePropStatuses(nodePath),
 			keyframeDisplayOffset: 30,
 			getDragOverrides: () => ({
 				'style.scale': Internals.makeStaticDragOverride(3),
@@ -308,7 +306,7 @@ test('getNodeKeyframes shows a temporary effect keyframe from drag overrides', (
 		getNodeKeyframes({
 			node: makeEffectFieldNode('amount', 0),
 			nodePath,
-			codeValues: makeCodeValues(nodePath),
+			propStatuses: makePropStatuses(nodePath),
 			keyframeDisplayOffset: 30,
 			getDragOverrides: () => ({}),
 			getEffectDragOverrides: () => ({
@@ -329,7 +327,7 @@ test('getNodeKeyframes shows sequence keyframes from keyframed drag overrides', 
 		getNodeKeyframes({
 			node: makeSequenceFieldNode('style.scale'),
 			nodePath,
-			codeValues: makeCodeValues(nodePath),
+			propStatuses: makePropStatuses(nodePath),
 			keyframeDisplayOffset: 30,
 			getDragOverrides: () => ({
 				'style.scale': Internals.makeKeyframedDragOverride({
@@ -355,7 +353,7 @@ test('getNodeKeyframes replaces existing keyframes from keyframed drag overrides
 		getNodeKeyframes({
 			node: makeEffectFieldNode('amount', 0),
 			nodePath,
-			codeValues: makeCodeValues(nodePath),
+			propStatuses: makePropStatuses(nodePath),
 			keyframeDisplayOffset: 30,
 			getDragOverrides: () => ({}),
 			getEffectDragOverrides: () => ({

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -2,7 +2,7 @@ import {expect, test} from 'bun:test';
 import type {RefObject} from 'react';
 import {
 	Internals,
-	type CodeValues,
+	type PropStatuses,
 	type SequenceNodePath,
 	type SequencePropsSubscriptionKey,
 	type SequenceSchema,
@@ -162,12 +162,12 @@ const makeTimelineSequence = ({
 		effects,
 	}) as TSequence;
 
-const makeDurationCodeValues = (
+const makeDurationPropStatuses = (
 	nodePaths: readonly SequencePropsSubscriptionKey[],
-): CodeValues => {
-	const codeValues: CodeValues = {};
+): PropStatuses => {
+	const propStatuses: PropStatuses = {};
 	for (const nodePath of nodePaths) {
-		codeValues[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
+		propStatuses[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
 			canUpdate: true,
 			props: {
 				durationInFrames: {status: 'static', codeValue: 100},
@@ -176,15 +176,15 @@ const makeDurationCodeValues = (
 		};
 	}
 
-	return codeValues;
+	return propStatuses;
 };
 
-const makeFromCodeValues = (
+const makeFromPropStatuses = (
 	nodePaths: readonly SequencePropsSubscriptionKey[],
-): CodeValues => {
-	const codeValues: CodeValues = {};
+): PropStatuses => {
+	const propStatuses: PropStatuses = {};
 	for (const nodePath of nodePaths) {
-		codeValues[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
+		propStatuses[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
 			canUpdate: true,
 			props: {
 				from: {status: 'static', codeValue: 0},
@@ -193,7 +193,7 @@ const makeFromCodeValues = (
 		};
 	}
 
-	return codeValues;
+	return propStatuses;
 };
 
 test('Timeline selection should stay disabled until released publicly', () => {
@@ -258,7 +258,7 @@ test('copying a keyframed effect creates a structured snapshot', () => {
 		[['0']],
 	);
 	const nodePath = effectNodePathInfo.sequenceSubscriptionKey;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {},
@@ -271,7 +271,6 @@ test('copying a keyframed effect creates a structured snapshot', () => {
 					props: {
 						intensity: {
 							status: 'keyframed',
-							codeValue: 10,
 							interpolationFunction: 'interpolate',
 							keyframes: [
 								{frame: 0, value: 10},
@@ -285,7 +284,7 @@ test('copying a keyframed effect creates a structured snapshot', () => {
 				},
 			],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 
 	expect(
 		getSnapshotsFromSelection({
@@ -294,7 +293,7 @@ test('copying a keyframed effect creates a structured snapshot', () => {
 				nodePathInfo: effectNodePathInfo,
 				i: 0,
 			},
-			codeValues,
+			propStatuses,
 		}),
 	).toEqual([
 		{
@@ -324,7 +323,7 @@ test('copying a selected effect prop creates an effect prop payload', () => {
 		[['0', 'intensity']],
 	);
 	const nodePath = effectPropNodePathInfo.sequenceSubscriptionKey;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {},
@@ -337,7 +336,6 @@ test('copying a selected effect prop creates an effect prop payload', () => {
 					props: {
 						intensity: {
 							status: 'keyframed',
-							codeValue: 10,
 							interpolationFunction: 'interpolate',
 							keyframes: [
 								{frame: 0, value: 10},
@@ -351,7 +349,7 @@ test('copying a selected effect prop creates an effect prop payload', () => {
 				},
 			],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 
 	expect(
 		getEffectPropClipboardDataFromSelection({
@@ -361,7 +359,7 @@ test('copying a selected effect prop creates an effect prop payload', () => {
 				i: 0,
 				key: 'intensity',
 			},
-			codeValues,
+			propStatuses,
 		}),
 	).toEqual({
 		type: 'effect-prop',
@@ -396,7 +394,7 @@ test('pasting an effect prop targets a matching selected effect', () => {
 	const effectSchema = {
 		intensity: {type: 'number', default: 0, hiddenFromList: false},
 	} satisfies SequenceSchema;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {},
@@ -412,7 +410,7 @@ test('pasting an effect prop targets a matching selected effect', () => {
 				},
 			],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 
 	expect(
 		getPasteEffectPropTarget({
@@ -430,7 +428,7 @@ test('pasting an effect prop targets a matching selected effect', () => {
 				key: 'intensity',
 				param: {type: 'static', value: 10},
 			},
-			codeValues,
+			propStatuses,
 			sequences: [
 				makeTimelineSequence({
 					schema: {},
@@ -462,7 +460,7 @@ test('pasting an effect prop requires the same effect type and prop key', () => 
 		opacity: {type: 'number', default: 1, hiddenFromList: false},
 		intensity: {type: 'number', default: 0, hiddenFromList: false},
 	} satisfies SequenceSchema;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {},
@@ -479,7 +477,7 @@ test('pasting an effect prop requires the same effect type and prop key', () => 
 				},
 			],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 	const basePayload = {
 		type: 'effect-prop' as const,
 		version: 1 as const,
@@ -503,7 +501,7 @@ test('pasting an effect prop requires the same effect type and prop key', () => 
 				},
 			],
 			payload: basePayload,
-			codeValues,
+			propStatuses,
 			sequences: [
 				makeTimelineSequence({
 					schema: {},
@@ -520,7 +518,7 @@ test('pasting an effect prop requires the same effect type and prop key', () => 
 				{type: 'sequence-effect', nodePathInfo: effectPropNodePathInfo, i: 0},
 			],
 			payload: basePayload,
-			codeValues,
+			propStatuses,
 			sequences: [
 				makeTimelineSequence({
 					schema: {},
@@ -567,7 +565,7 @@ test('Timeline duration drag applies the same delta to selected sequences', () =
 			first: firstNodePathInfo.sequenceSubscriptionKey,
 			second: secondNodePathInfo.sequenceSubscriptionKey,
 		},
-		codeValues: makeDurationCodeValues([
+		propStatuses: makeDurationPropStatuses([
 			firstNodePathInfo.sequenceSubscriptionKey,
 			secondNodePathInfo.sequenceSubscriptionKey,
 		]),
@@ -598,7 +596,9 @@ test('Timeline duration drag uses the declared duration for negative from values
 		overrideIdsToNodePaths: {
 			override: nodePathInfo.sequenceSubscriptionKey,
 		},
-		codeValues: makeDurationCodeValues([nodePathInfo.sequenceSubscriptionKey]),
+		propStatuses: makeDurationPropStatuses([
+			nodePathInfo.sequenceSubscriptionKey,
+		]),
 	});
 
 	expect(targets?.map((target) => target.initialDuration)).toEqual([36]);
@@ -629,11 +629,11 @@ test('Timeline duration drag is blocked if one selected sequence cannot update d
 	const schema = {} satisfies SequenceSchema;
 	const firstNodePathInfo = makeNodePathInfo(['body', 0], []);
 	const secondNodePathInfo = makeNodePathInfo(['body', 1], []);
-	const codeValues = makeDurationCodeValues([
+	const propStatuses = makeDurationPropStatuses([
 		firstNodePathInfo.sequenceSubscriptionKey,
 	]);
 
-	codeValues[
+	propStatuses[
 		Internals.makeSequencePropsSubscriptionKey(
 			secondNodePathInfo.sequenceSubscriptionKey,
 		)
@@ -669,7 +669,7 @@ test('Timeline duration drag is blocked if one selected sequence cannot update d
 				first: firstNodePathInfo.sequenceSubscriptionKey,
 				second: secondNodePathInfo.sequenceSubscriptionKey,
 			},
-			codeValues,
+			propStatuses,
 		}),
 	).toBe(null);
 });
@@ -678,12 +678,12 @@ test('Timeline duration drag is blocked if one selected sequence duration is key
 	const schema = {} satisfies SequenceSchema;
 	const firstNodePathInfo = makeNodePathInfo(['body', 0], []);
 	const secondNodePathInfo = makeNodePathInfo(['body', 1], []);
-	const codeValues = makeDurationCodeValues([
+	const propStatuses = makeDurationPropStatuses([
 		firstNodePathInfo.sequenceSubscriptionKey,
 		secondNodePathInfo.sequenceSubscriptionKey,
 	]);
 
-	codeValues[
+	propStatuses[
 		Internals.makeSequencePropsSubscriptionKey(
 			secondNodePathInfo.sequenceSubscriptionKey,
 		)
@@ -692,7 +692,6 @@ test('Timeline duration drag is blocked if one selected sequence duration is key
 		props: {
 			durationInFrames: {
 				status: 'keyframed',
-				codeValue: 15,
 				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 0, value: 15}],
 				easing: ['linear'],
@@ -729,7 +728,7 @@ test('Timeline duration drag is blocked if one selected sequence duration is key
 				first: firstNodePathInfo.sequenceSubscriptionKey,
 				second: secondNodePathInfo.sequenceSubscriptionKey,
 			},
-			codeValues,
+			propStatuses,
 		}),
 	).toBe(null);
 });
@@ -772,7 +771,7 @@ test('Timeline duration drag ignores selection if dragged sequence is not select
 			second: secondNodePathInfo.sequenceSubscriptionKey,
 			third: thirdNodePathInfo.sequenceSubscriptionKey,
 		},
-		codeValues: makeDurationCodeValues([
+		propStatuses: makeDurationPropStatuses([
 			firstNodePathInfo.sequenceSubscriptionKey,
 			secondNodePathInfo.sequenceSubscriptionKey,
 			thirdNodePathInfo.sequenceSubscriptionKey,
@@ -816,7 +815,7 @@ test('Timeline from drag applies the same delta to selected sequences', () => {
 			first: firstNodePathInfo.sequenceSubscriptionKey,
 			second: secondNodePathInfo.sequenceSubscriptionKey,
 		},
-		codeValues: makeFromCodeValues([
+		propStatuses: makeFromPropStatuses([
 			firstNodePathInfo.sequenceSubscriptionKey,
 			secondNodePathInfo.sequenceSubscriptionKey,
 		]),
@@ -866,7 +865,9 @@ test('Timeline from drag saves relative from for nested sequences', () => {
 		overrideIdsToNodePaths: {
 			child: childNodePathInfo.sequenceSubscriptionKey,
 		},
-		codeValues: makeFromCodeValues([childNodePathInfo.sequenceSubscriptionKey]),
+		propStatuses: makeFromPropStatuses([
+			childNodePathInfo.sequenceSubscriptionKey,
+		]),
 	});
 
 	expect(targets?.map((target) => target.initialFrom)).toEqual([10]);
@@ -882,11 +883,11 @@ test('Timeline from drag is blocked if one selected sequence cannot update from'
 	const schema = {} satisfies SequenceSchema;
 	const firstNodePathInfo = makeNodePathInfo(['body', 0], []);
 	const secondNodePathInfo = makeNodePathInfo(['body', 1], []);
-	const codeValues = makeFromCodeValues([
+	const propStatuses = makeFromPropStatuses([
 		firstNodePathInfo.sequenceSubscriptionKey,
 	]);
 
-	codeValues[
+	propStatuses[
 		Internals.makeSequencePropsSubscriptionKey(
 			secondNodePathInfo.sequenceSubscriptionKey,
 		)
@@ -922,7 +923,7 @@ test('Timeline from drag is blocked if one selected sequence cannot update from'
 				first: firstNodePathInfo.sequenceSubscriptionKey,
 				second: secondNodePathInfo.sequenceSubscriptionKey,
 			},
-			codeValues,
+			propStatuses,
 		}),
 	).toBe(null);
 });
@@ -1260,7 +1261,7 @@ test('Backspace reset targets multiple selected sequence props', () => {
 		['controls', 'style.rotate'],
 	);
 	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
@@ -1269,7 +1270,7 @@ test('Backspace reset targets multiple selected sequence props', () => {
 			},
 			effects: [],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 
 	const resetTargets = getTimelinePropResetTargets({
 		selections: [
@@ -1286,7 +1287,7 @@ test('Backspace reset targets multiple selected sequence props', () => {
 		],
 		sequences: [makeTimelineSequence({schema})],
 		overrideIdsToNodePaths: {override: nodePath},
-		codeValues,
+		propStatuses,
 	});
 
 	expect(resetTargets?.map((target) => target.fieldKey)).toEqual([
@@ -1305,13 +1306,12 @@ test('Backspace reset targets selected keyframed sequence props', () => {
 		['controls', 'opacity'],
 	);
 	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
 				opacity: {
 					status: 'keyframed',
-					codeValue: undefined,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0},
@@ -1324,7 +1324,7 @@ test('Backspace reset targets selected keyframed sequence props', () => {
 			},
 			effects: [],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 
 	const resetTargets = getTimelinePropResetTargets({
 		selections: [
@@ -1336,7 +1336,7 @@ test('Backspace reset targets selected keyframed sequence props', () => {
 		],
 		sequences: [makeTimelineSequence({schema})],
 		overrideIdsToNodePaths: {override: nodePath},
-		codeValues,
+		propStatuses,
 	});
 
 	expect(resetTargets).toEqual([
@@ -1361,13 +1361,12 @@ test('Backspace reset skips keyframed sequence props without defaults', () => {
 		['controls', 'opacity'],
 	);
 	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
 				opacity: {
 					status: 'keyframed',
-					codeValue: undefined,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0},
@@ -1380,7 +1379,7 @@ test('Backspace reset skips keyframed sequence props without defaults', () => {
 			},
 			effects: [],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 
 	const resetTargets = getTimelinePropResetTargets({
 		selections: [
@@ -1392,7 +1391,7 @@ test('Backspace reset skips keyframed sequence props without defaults', () => {
 		],
 		sequences: [makeTimelineSequence({schema})],
 		overrideIdsToNodePaths: {override: nodePath},
-		codeValues,
+		propStatuses,
 	});
 
 	expect(resetTargets).toEqual([]);
@@ -1413,7 +1412,7 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			startY: 20,
 			target: {
 				clientId: 'client',
-				codeValue: {status: 'static', codeValue: '10px 20px'},
+				propStatus: {status: 'static', codeValue: '10px 20px'},
 				fieldDefault: '0px 0px',
 				keyframeDisplayOffset: 30,
 				nodePath: firstNodePath,
@@ -1428,7 +1427,7 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			startY: 3,
 			target: {
 				clientId: 'client',
-				codeValue: {status: 'static', codeValue: '-5px 3px'},
+				propStatus: {status: 'static', codeValue: '-5px 3px'},
 				fieldDefault: '0px 0px',
 				keyframeDisplayOffset: 30,
 				nodePath: secondNodePath,
@@ -1486,9 +1485,8 @@ test('Selected outline dragging keyframed translate adds a keyframe at the sourc
 			startY: 25,
 			target: {
 				clientId: 'client',
-				codeValue: {
+				propStatus: {
 					status: 'keyframed',
-					codeValue: undefined,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: '0px 0px'},
@@ -1552,7 +1550,7 @@ test('Selected outline edge dragging scales one axis when scale is unlinked', ()
 			startZ: 1,
 			target: {
 				clientId: 'client',
-				codeValue: {status: 'static', codeValue: '2 3'},
+				propStatus: {status: 'static', codeValue: '2 3'},
 				fieldDefault: 1,
 				fieldSchema: schema['style.scale'],
 				linked: false,
@@ -1608,7 +1606,7 @@ test('Selected outline edge dragging preserves aspect ratio when scale is linked
 			startZ: 1,
 			target: {
 				clientId: 'client',
-				codeValue: {status: 'static', codeValue: '2 3'},
+				propStatus: {status: 'static', codeValue: '2 3'},
 				fieldDefault: 1,
 				fieldSchema: schema['style.scale'],
 				linked: true,
@@ -1655,7 +1653,7 @@ test('Backspace reset targets selected effect props', () => {
 		['effects', '0', 'intensity'],
 	);
 	const nodePath = nodePathInfo.sequenceSubscriptionKey;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {},
@@ -1671,7 +1669,7 @@ test('Backspace reset targets selected effect props', () => {
 				},
 			],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 
 	const resetTargets = getTimelinePropResetTargets({
 		selections: [
@@ -1689,7 +1687,7 @@ test('Backspace reset targets selected effect props', () => {
 			}),
 		],
 		overrideIdsToNodePaths: {override: nodePath},
-		codeValues,
+		propStatuses,
 	});
 
 	expect(resetTargets).toEqual([
@@ -1716,7 +1714,7 @@ test('Backspace reset targets selected keyframed effect props', () => {
 		['effects', '0', 'intensity'],
 	);
 	const nodePath = nodePathInfo.sequenceSubscriptionKey;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {},
@@ -1729,7 +1727,6 @@ test('Backspace reset targets selected keyframed effect props', () => {
 					props: {
 						intensity: {
 							status: 'keyframed',
-							codeValue: undefined,
 							interpolationFunction: 'interpolate',
 							keyframes: [
 								{frame: 0, value: 10},
@@ -1743,7 +1740,7 @@ test('Backspace reset targets selected keyframed effect props', () => {
 				},
 			],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 
 	const resetTargets = getTimelinePropResetTargets({
 		selections: [
@@ -1761,7 +1758,7 @@ test('Backspace reset targets selected keyframed effect props', () => {
 			}),
 		],
 		overrideIdsToNodePaths: {override: nodePath},
-		codeValues,
+		propStatuses,
 	});
 
 	expect(resetTargets).toEqual([
@@ -1788,7 +1785,7 @@ test('Backspace reset skips keyframed effect props without defaults', () => {
 		['effects', '0', 'intensity'],
 	);
 	const nodePath = nodePathInfo.sequenceSubscriptionKey;
-	const codeValues = {
+	const propStatuses = {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {},
@@ -1801,7 +1798,6 @@ test('Backspace reset skips keyframed effect props without defaults', () => {
 					props: {
 						intensity: {
 							status: 'keyframed',
-							codeValue: undefined,
 							interpolationFunction: 'interpolate',
 							keyframes: [
 								{frame: 0, value: 10},
@@ -1815,7 +1811,7 @@ test('Backspace reset skips keyframed effect props without defaults', () => {
 				},
 			],
 		},
-	} satisfies CodeValues;
+	} satisfies PropStatuses;
 
 	const resetTargets = getTimelinePropResetTargets({
 		selections: [
@@ -1833,7 +1829,7 @@ test('Backspace reset skips keyframed effect props without defaults', () => {
 			}),
 		],
 		overrideIdsToNodePaths: {override: nodePath},
-		codeValues,
+		propStatuses,
 	});
 
 	expect(resetTargets).toEqual([]);
@@ -1856,7 +1852,7 @@ test('Deleting mixed timeline selection types throws an assertion error', () => 
 			],
 			sequences: [],
 			overrideIdsToNodePaths: {},
-			setCodeValues: () => undefined,
+			setPropStatuses: () => undefined,
 			clientId: 'client',
 			confirm,
 		}),


### PR DESCRIPTION
## Summary

- Removes the static `codeValue` sentinel from keyframed prop statuses.
- Renames visual-mode code-value helpers/state to prop-status terminology.
- Resolves keyframed effect prop statuses at the current frame for optimistic visual-mode effect previews.

Fixes #8180.

## Testing

- `bun test packages/studio-shared/src/test/optimistic-update-for-prop-statuses.test.ts packages/studio-shared/src/test/optimistic-update-for-effect-prop-statuses.test.ts packages/studio-shared/src/test/optimistic-add-keyframe.test.ts packages/studio-server/src/test/compute-effect-props-status.test.ts packages/core/src/test/interpolate-keyframed-status.test.ts`
- `bun test packages/studio/src/test/timeline-selection.test.ts -t keyframed`
- `bunx turbo make --filter=remotion --filter=@remotion/studio-shared --filter=@remotion/studio-server --filter=@remotion/studio`
- `bun run build`
- `bun run stylecheck`
