### PR TITLE
`@remotion/media`: Fix frame cache duration check

### DIFF
--- a/packages/media/src/test/keyframe-bank.test.ts
+++ b/packages/media/src/test/keyframe-bank.test.ts
@@ -1,0 +1,55 @@
+import {VideoSample, type VideoSampleSink} from 'mediabunny';
+import {expect, test} from 'vitest';
+import {makeKeyframeBank} from '../video-extraction/keyframe-bank';
+
+const makeSample = ({
+	timestamp,
+	duration,
+}: {
+	timestamp: number;
+	duration: number;
+}) => {
+	return new VideoSample(new Uint8Array(4), {
+		format: 'RGBA',
+		codedWidth: 1,
+		codedHeight: 1,
+		timestamp,
+		duration,
+	});
+};
+
+const makeVideoSampleSink = (samples: VideoSample[]): VideoSampleSink => {
+	return {
+		getSample() {
+			return Promise.reject(new Error('Not implemented'));
+		},
+		async *samples() {
+			for (const sample of samples) {
+				yield sample;
+			}
+		},
+		async *samplesAtTimestamps() {
+			yield* [];
+		},
+	};
+};
+
+test('a long frame duration can satisfy requests beyond the jump threshold', async () => {
+	const samples = [
+		makeSample({timestamp: 0.3, duration: 12}),
+		makeSample({timestamp: 12.5, duration: 0.03}),
+	];
+
+	const bank = await makeKeyframeBank({
+		logLevel: 'error',
+		src: 'long-duration-frame.mp4',
+		videoSampleSink: makeVideoSampleSink(samples),
+		initialTimestampRequest: 0,
+	});
+
+	expect(bank.canSatisfyTimestamp(12)).toBe(true);
+	expect(bank.canSatisfyTimestamp(15.31)).toBe(false);
+
+	bank.prepareForDeletion('error', 'test');
+	samples[1].close();
+});

--- a/packages/media/src/video-extraction/keyframe-bank.ts
+++ b/packages/media/src/video-extraction/keyframe-bank.ts
@@ -328,9 +328,15 @@ export const makeKeyframeBank = async ({
 
 		const roundedTimestamp = roundTo4Digits(timestamp);
 		const firstFrameTimestamp = roundTo4Digits(frameTimestamps[0]);
+		const range = getRangeOfTimestamps();
+		if (!range) {
+			return false;
+		}
+
 		const lastFrameTimestamp = roundTo4Digits(
 			frameTimestamps[frameTimestamps.length - 1],
 		);
+		const lastFrameEndTimestamp = roundTo4Digits(range.lastTimestamp);
 
 		if (hasReachedEndOfVideo && roundedTimestamp > lastFrameTimestamp) {
 			return true;
@@ -348,7 +354,7 @@ export const makeKeyframeBank = async ({
 
 		if (
 			roundedTimestamp - BIGGEST_ALLOWED_JUMP_FORWARD_SECONDS >
-			lastFrameTimestamp
+			lastFrameEndTimestamp
 		) {
 			return false;
 		}


### PR DESCRIPTION
## Summary
- Use the cached keyframe bank range end timestamp when checking the 3 second jump threshold, so long-duration frames can still satisfy requests.
- Add a regression test for a first frame at 0.3s with a 12s duration followed by a 12.5s frame.

Fixes #8167

## Tests
- `cd packages/media && bun run make && bun run lint && bunx vitest src/test/keyframe-bank.test.ts --browser --run`
- `bun run build && bun run stylecheck`
