### PR TITLE
`@remotion/studio`: Limit timeline decimals

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineNumberField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineNumberField.tsx
@@ -6,7 +6,11 @@ import type {
 	TimelineFieldOnSave,
 } from '../../helpers/timeline-layout';
 import {InputDragger} from '../NewComposition/InputDragger';
-import {draggerStyle, getDecimalPlaces} from './timeline-field-utils';
+import {
+	draggerStyle,
+	formatTimelineNumber,
+	getDecimalPlaces,
+} from './timeline-field-utils';
 
 export const TimelineNumberField: React.FC<{
 	readonly field: SchemaFieldInfo;
@@ -61,16 +65,29 @@ export const TimelineNumberField: React.FC<{
 		[onSave, propStatus],
 	);
 
-	const step =
-		field.fieldSchema.type === 'number' ? (field.fieldSchema.step ?? 1) : 1;
+	const configuredStep =
+		field.fieldSchema.type === 'number' ? field.fieldSchema.step : undefined;
+	const step = configuredStep ?? 1;
 
-	const stepDecimals = useMemo(() => getDecimalPlaces(step), [step]);
+	const stepDecimals = useMemo(
+		() =>
+			configuredStep === undefined ? null : getDecimalPlaces(configuredStep),
+		[configuredStep],
+	);
 
 	const formatter = useCallback(
 		(v: number | string) => {
 			const num = Number(v);
-			const digits = Math.max(stepDecimals, getDecimalPlaces(num));
-			return digits === 0 ? String(num) : num.toFixed(digits);
+			if (stepDecimals === null) {
+				const digits = getDecimalPlaces(num);
+				return digits === 0 ? String(num) : num.toFixed(digits);
+			}
+
+			return formatTimelineNumber({
+				decimalPlaces: stepDecimals,
+				fixed: true,
+				value: num,
+			});
 		},
 		[stepDecimals],
 	);

--- a/packages/studio/src/components/Timeline/TimelineRotationField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRotationField.tsx
@@ -8,7 +8,8 @@ import type {
 import {InputDragger} from '../NewComposition/InputDragger';
 import {
 	draggerStyle,
-	getDecimalPlaces,
+	formatTimelineNumber,
+	getTimelineDisplayDecimalPlaces,
 	normalizeTimelineNumber,
 } from './timeline-field-utils';
 
@@ -109,11 +110,12 @@ export const TimelineRotationField: React.FC<{
 		[propStatus, onSave, serializeValue],
 	);
 
-	const step =
+	const configuredStep =
 		field.fieldSchema.type === 'rotation-css' ||
 		field.fieldSchema.type === 'rotation-degrees'
-			? (field.fieldSchema.step ?? 1)
-			: 1;
+			? field.fieldSchema.step
+			: undefined;
+	const step = configuredStep ?? 1;
 	const min =
 		field.fieldSchema.type === 'rotation-degrees'
 			? (field.fieldSchema.min ?? -Infinity)
@@ -123,16 +125,25 @@ export const TimelineRotationField: React.FC<{
 			? (field.fieldSchema.max ?? Infinity)
 			: Infinity;
 
-	const stepDecimals = useMemo(() => getDecimalPlaces(step), [step]);
+	const decimalPlaces = useMemo(
+		() =>
+			getTimelineDisplayDecimalPlaces({
+				defaultDecimalPlaces: 1,
+				step: configuredStep,
+			}),
+		[configuredStep],
+	);
 
 	const formatter = useCallback(
 		(v: number | string) => {
-			const num = normalizeTimelineNumber(Number(v));
-			const digits = Math.max(stepDecimals, getDecimalPlaces(num));
-			const formatted = digits === 0 ? String(num) : num.toFixed(digits);
+			const formatted = formatTimelineNumber({
+				decimalPlaces,
+				fixed: false,
+				value: normalizeTimelineNumber(Number(v)),
+			});
 			return `${formatted}\u00B0`;
 		},
-		[stepDecimals],
+		[decimalPlaces],
 	);
 
 	return (

--- a/packages/studio/src/components/Timeline/TimelineScaleField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScaleField.tsx
@@ -13,7 +13,8 @@ import type {
 import {ScaleLockContext} from '../../state/scale-lock';
 import {InputDragger} from '../NewComposition/InputDragger';
 import {
-	getDecimalPlaces,
+	formatTimelineNumber,
+	getTimelineDisplayDecimalPlaces,
 	normalizeTimelineNumber,
 } from './timeline-field-utils';
 import {timelineLayerIconContainer} from './TimelineLayerEye';
@@ -177,10 +178,9 @@ export const TimelineScaleField: React.FC<{
 		defaultValue: defaultLinked,
 	});
 
-	const step =
-		field.fieldSchema.type === 'scale'
-			? (field.fieldSchema.step ?? 0.01)
-			: 0.01;
+	const configuredStep =
+		field.fieldSchema.type === 'scale' ? field.fieldSchema.step : undefined;
+	const step = configuredStep ?? 0.01;
 	const min =
 		field.fieldSchema.type === 'scale'
 			? (field.fieldSchema.min ?? -Infinity)
@@ -190,15 +190,24 @@ export const TimelineScaleField: React.FC<{
 			? (field.fieldSchema.max ?? Infinity)
 			: Infinity;
 
-	const stepDecimals = useMemo(() => getDecimalPlaces(step), [step]);
+	const decimalPlaces = useMemo(
+		() =>
+			getTimelineDisplayDecimalPlaces({
+				defaultDecimalPlaces: 2,
+				step: configuredStep,
+			}),
+		[configuredStep],
+	);
 
 	const formatter = useCallback(
 		(v: number | string) => {
-			const num = Number(v);
-			const digits = Math.max(stepDecimals, getDecimalPlaces(num));
-			return digits === 0 ? String(num) : num.toFixed(digits);
+			return formatTimelineNumber({
+				decimalPlaces,
+				fixed: true,
+				value: v,
+			});
 		},
-		[stepDecimals],
+		[decimalPlaces],
 	);
 
 	const getDragStart = useCallback((): readonly [number, number] => {

--- a/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
@@ -7,8 +7,8 @@ import type {
 } from '../../helpers/timeline-layout';
 import {InputDragger} from '../NewComposition/InputDragger';
 import {
-	getDecimalPlaces,
-	normalizeTimelineNumber,
+	formatTimelineNumber,
+	getTimelineDisplayDecimalPlaces,
 } from './timeline-field-utils';
 import {parseTranslate, serializeTranslate} from './timeline-translate-utils';
 
@@ -48,19 +48,29 @@ export const TimelineTranslateField: React.FC<{
 		[effectiveValue],
 	);
 
-	const step =
-		field.fieldSchema.type === 'translate' ? (field.fieldSchema.step ?? 1) : 1;
+	const configuredStep =
+		field.fieldSchema.type === 'translate' ? field.fieldSchema.step : undefined;
+	const step = configuredStep ?? 1;
 
-	const stepDecimals = useMemo(() => getDecimalPlaces(step), [step]);
+	const decimalPlaces = useMemo(
+		() =>
+			getTimelineDisplayDecimalPlaces({
+				defaultDecimalPlaces: 1,
+				step: configuredStep,
+			}),
+		[configuredStep],
+	);
 
 	const formatter = useCallback(
 		(v: number | string) => {
-			const num = normalizeTimelineNumber(Number(v));
-			const digits = Math.max(stepDecimals, getDecimalPlaces(num));
-			const formatted = digits === 0 ? String(num) : num.toFixed(digits);
+			const formatted = formatTimelineNumber({
+				decimalPlaces,
+				fixed: false,
+				value: v,
+			});
 			return `${formatted}px`;
 		},
-		[stepDecimals],
+		[decimalPlaces],
 	);
 
 	// --- X callbacks ---
@@ -68,15 +78,15 @@ export const TimelineTranslateField: React.FC<{
 		(newVal: number) => {
 			setDragX(newVal);
 			const currentY = dragY ?? codeY;
-			onDragValueChange(serializeTranslate(newVal, currentY));
+			onDragValueChange(serializeTranslate(newVal, currentY, decimalPlaces));
 		},
-		[onDragValueChange, dragY, codeY],
+		[onDragValueChange, dragY, codeY, decimalPlaces],
 	);
 
 	const onXChangeEnd = useCallback(
 		(newVal: number) => {
 			const currentY = dragY ?? codeY;
-			const newStr = serializeTranslate(newVal, currentY);
+			const newStr = serializeTranslate(newVal, currentY, decimalPlaces);
 			if (newStr !== propStatus.codeValue) {
 				onSave(newStr).finally(() => {
 					setDragX(null);
@@ -87,7 +97,7 @@ export const TimelineTranslateField: React.FC<{
 				onDragEnd();
 			}
 		},
-		[dragY, codeY, propStatus, onSave, onDragEnd],
+		[dragY, codeY, decimalPlaces, propStatus, onSave, onDragEnd],
 	);
 
 	const onXTextChange = useCallback(
@@ -95,7 +105,7 @@ export const TimelineTranslateField: React.FC<{
 			const parsed = Number(newVal);
 			if (!Number.isNaN(parsed)) {
 				const currentY = dragY ?? codeY;
-				const newStr = serializeTranslate(parsed, currentY);
+				const newStr = serializeTranslate(parsed, currentY, decimalPlaces);
 				if (newStr !== propStatus.codeValue) {
 					setDragX(parsed);
 					onSave(newStr).finally(() => {
@@ -104,7 +114,7 @@ export const TimelineTranslateField: React.FC<{
 				}
 			}
 		},
-		[propStatus, dragY, codeY, onSave],
+		[propStatus, dragY, codeY, decimalPlaces, onSave],
 	);
 
 	// --- Y callbacks ---
@@ -112,15 +122,15 @@ export const TimelineTranslateField: React.FC<{
 		(newVal: number) => {
 			setDragY(newVal);
 			const currentX = dragX ?? codeX;
-			onDragValueChange(serializeTranslate(currentX, newVal));
+			onDragValueChange(serializeTranslate(currentX, newVal, decimalPlaces));
 		},
-		[onDragValueChange, dragX, codeX],
+		[onDragValueChange, dragX, codeX, decimalPlaces],
 	);
 
 	const onYChangeEnd = useCallback(
 		(newVal: number) => {
 			const currentX = dragX ?? codeX;
-			const newStr = serializeTranslate(currentX, newVal);
+			const newStr = serializeTranslate(currentX, newVal, decimalPlaces);
 			if (newStr !== propStatus.codeValue) {
 				onSave(newStr).finally(() => {
 					setDragY(null);
@@ -131,7 +141,7 @@ export const TimelineTranslateField: React.FC<{
 				onDragEnd();
 			}
 		},
-		[dragX, codeX, propStatus, onSave, onDragEnd],
+		[dragX, codeX, decimalPlaces, propStatus, onSave, onDragEnd],
 	);
 
 	const onYTextChange = useCallback(
@@ -139,7 +149,7 @@ export const TimelineTranslateField: React.FC<{
 			const parsed = Number(newVal);
 			if (!Number.isNaN(parsed)) {
 				const currentX = dragX ?? codeX;
-				const newStr = serializeTranslate(currentX, parsed);
+				const newStr = serializeTranslate(currentX, parsed, decimalPlaces);
 				if (newStr !== propStatus.codeValue) {
 					setDragY(parsed);
 					onSave(newStr).finally(() => {
@@ -148,7 +158,7 @@ export const TimelineTranslateField: React.FC<{
 				}
 			}
 		},
-		[propStatus, onSave, dragX, codeX],
+		[propStatus, onSave, dragX, codeX, decimalPlaces],
 	);
 
 	return (

--- a/packages/studio/src/components/Timeline/TimelineUvCoordinateField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineUvCoordinateField.tsx
@@ -6,7 +6,10 @@ import type {
 	TimelineFieldOnSave,
 } from '../../helpers/timeline-layout';
 import {InputDragger} from '../NewComposition/InputDragger';
-import {getDecimalPlaces} from './timeline-field-utils';
+import {
+	formatTimelineNumber,
+	getTimelineDisplayDecimalPlaces,
+} from './timeline-field-utils';
 
 const leftDraggerStyle: React.CSSProperties = {
 	paddingLeft: 0,
@@ -67,10 +70,11 @@ export const TimelineUvCoordinateField: React.FC<{
 		[effectiveValue],
 	);
 
-	const step =
+	const configuredStep =
 		field.fieldSchema.type === 'uv-coordinate'
-			? (field.fieldSchema.step ?? 0.01)
-			: 0.01;
+			? field.fieldSchema.step
+			: undefined;
+	const step = configuredStep ?? 0.01;
 
 	const min =
 		field.fieldSchema.type === 'uv-coordinate'
@@ -82,15 +86,24 @@ export const TimelineUvCoordinateField: React.FC<{
 			? (field.fieldSchema.max ?? Infinity)
 			: Infinity;
 
-	const stepDecimals = useMemo(() => getDecimalPlaces(step), [step]);
+	const decimalPlaces = useMemo(
+		() =>
+			getTimelineDisplayDecimalPlaces({
+				defaultDecimalPlaces: 2,
+				step: configuredStep,
+			}),
+		[configuredStep],
+	);
 
 	const formatter = useCallback(
 		(v: number | string) => {
-			const num = Number(v);
-			const digits = Math.max(stepDecimals, getDecimalPlaces(num));
-			return digits === 0 ? String(num) : num.toFixed(digits);
+			return formatTimelineNumber({
+				decimalPlaces,
+				fixed: true,
+				value: v,
+			});
 		},
-		[stepDecimals],
+		[decimalPlaces],
 	);
 
 	const onXChange = useCallback(

--- a/packages/studio/src/components/Timeline/timeline-field-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-utils.ts
@@ -1,11 +1,55 @@
 export const getDecimalPlaces = (num: number): number => {
-	const str = String(num);
-	const decimalIndex = str.indexOf('.');
-	return decimalIndex === -1 ? 0 : str.length - decimalIndex - 1;
+	const [coefficient, exponent] = String(num).toLowerCase().split('e');
+	const decimalIndex = coefficient.indexOf('.');
+	const coefficientDecimals =
+		decimalIndex === -1 ? 0 : coefficient.length - decimalIndex - 1;
+
+	if (exponent === undefined) {
+		return coefficientDecimals;
+	}
+
+	return Math.max(0, coefficientDecimals - Number(exponent));
+};
+
+export const getTimelineDisplayDecimalPlaces = ({
+	defaultDecimalPlaces,
+	step,
+}: {
+	readonly defaultDecimalPlaces: number;
+	readonly step: number | undefined;
+}): number => {
+	return Math.max(
+		defaultDecimalPlaces,
+		step === undefined ? 0 : getDecimalPlaces(step),
+	);
+};
+
+export const roundToDecimalPlaces = (
+	value: number,
+	decimalPlaces: number,
+): number => {
+	const factor = 10 ** decimalPlaces;
+	const rounded = Math.round(value * factor) / factor;
+	return Object.is(rounded, -0) ? 0 : rounded;
+};
+
+export const formatTimelineNumber = ({
+	decimalPlaces,
+	fixed,
+	value,
+}: {
+	readonly decimalPlaces: number;
+	readonly fixed: boolean;
+	readonly value: number | string;
+}): string => {
+	const rounded = roundToDecimalPlaces(Number(value), decimalPlaces);
+	return fixed && decimalPlaces > 0
+		? rounded.toFixed(decimalPlaces)
+		: String(rounded);
 };
 
 export const normalizeTimelineNumber = (value: number): number => {
-	return Math.round(value * 1000000) / 1000000;
+	return roundToDecimalPlaces(value, 6);
 };
 
 export const draggerStyle: React.CSSProperties = {

--- a/packages/studio/src/components/Timeline/timeline-translate-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-translate-utils.ts
@@ -1,4 +1,7 @@
-import {normalizeTimelineNumber} from './timeline-field-utils';
+import {
+	normalizeTimelineNumber,
+	roundToDecimalPlaces,
+} from './timeline-field-utils';
 
 const PIXEL_PATTERN = /^(-?\d+(?:\.\d+)?)px(?:\s+(-?\d+(?:\.\d+)?)px)?$/;
 const translateDecimalPlaces = 1;
@@ -15,13 +18,22 @@ export const parseTranslate = (value: string): [number, number] => {
 	];
 };
 
-const formatTranslateCoordinate = (value: number): string => {
+const formatTranslateCoordinate = (
+	value: number,
+	decimalPlaces: number,
+): string => {
 	const normalized = normalizeTimelineNumber(value);
-	const factor = 10 ** translateDecimalPlaces;
-	const rounded = Math.round(normalized * factor) / factor;
+	const rounded = roundToDecimalPlaces(normalized, decimalPlaces);
 	return String(Object.is(rounded, -0) ? 0 : rounded);
 };
 
-export const serializeTranslate = (x: number, y: number): string => {
-	return `${formatTranslateCoordinate(x)}px ${formatTranslateCoordinate(y)}px`;
+export const serializeTranslate = (
+	x: number,
+	y: number,
+	decimalPlaces = translateDecimalPlaces,
+): string => {
+	return `${formatTranslateCoordinate(x, decimalPlaces)}px ${formatTranslateCoordinate(
+		y,
+		decimalPlaces,
+	)}px`;
 };

--- a/packages/studio/src/test/timeline-field-utils.test.ts
+++ b/packages/studio/src/test/timeline-field-utils.test.ts
@@ -1,0 +1,50 @@
+import {expect, test} from 'bun:test';
+import {
+	formatTimelineNumber,
+	getDecimalPlaces,
+	getTimelineDisplayDecimalPlaces,
+} from '../components/Timeline/timeline-field-utils';
+
+test('getDecimalPlaces supports scientific notation', () => {
+	expect(getDecimalPlaces(1e-7)).toBe(7);
+	expect(getDecimalPlaces(1.25e-7)).toBe(9);
+	expect(getDecimalPlaces(1.25e2)).toBe(0);
+});
+
+test('getTimelineDisplayDecimalPlaces uses the default cap if step is coarser', () => {
+	expect(
+		getTimelineDisplayDecimalPlaces({
+			defaultDecimalPlaces: 2,
+			step: 1,
+		}),
+	).toBe(2);
+});
+
+test('getTimelineDisplayDecimalPlaces respects more precise steps', () => {
+	expect(
+		getTimelineDisplayDecimalPlaces({
+			defaultDecimalPlaces: 2,
+			step: 0.001,
+		}),
+	).toBe(3);
+});
+
+test('formatTimelineNumber trims floating point noise', () => {
+	expect(
+		formatTimelineNumber({
+			decimalPlaces: 2,
+			fixed: true,
+			value: 1.2000000000000002,
+		}),
+	).toBe('1.20');
+});
+
+test('formatTimelineNumber can omit unnecessary trailing zeroes', () => {
+	expect(
+		formatTimelineNumber({
+			decimalPlaces: 1,
+			fixed: false,
+			value: 10.000000000000002,
+		}),
+	).toBe('10');
+});

--- a/packages/studio/src/test/timeline-translate-utils.test.ts
+++ b/packages/studio/src/test/timeline-translate-utils.test.ts
@@ -17,3 +17,9 @@ test('serializeTranslate normalizes floating point noise', () => {
 test('serializeTranslate limits coordinates to one decimal place', () => {
 	expect(serializeTranslate(254.854512, 393.565342)).toBe('254.9px 393.6px');
 });
+
+test('serializeTranslate respects more precise steps', () => {
+	expect(serializeTranslate(254.854512, 393.565342, 2)).toBe(
+		'254.85px 393.57px',
+	);
+});


### PR DESCRIPTION
Fixes #8161.

This PR limits floating point precision in Studio timeline controls while still respecting more precise configured steps.

Validated with `bun run build` and `bun run stylecheck`.
Also added focused tests for timeline number formatting and translate serialization.
