### PR TITLE
`remotion`: Preserve subframe media durations

### DIFF
--- a/packages/core/src/calculate-media-duration.ts
+++ b/packages/core/src/calculate-media-duration.ts
@@ -23,5 +23,5 @@ export const calculateMediaDuration = ({
 
 	const actualDuration = duration / playbackRate;
 
-	return Math.floor(actualDuration);
+	return Number(actualDuration.toFixed(10));
 };

--- a/packages/core/src/test/get-media-duration.test.ts
+++ b/packages/core/src/test/get-media-duration.test.ts
@@ -66,6 +66,19 @@ test('parentSequence with subframe duration caps without truncation', () => {
 	expect(duration).toBe(23.5);
 });
 
+test('subframe sequence duration is not truncated', () => {
+	const duration = getTimelineDuration({
+		compositionDurationInFrames: 10.920000000000016,
+		playbackRate: 1,
+		trimBefore: undefined,
+		trimAfter: undefined,
+		parentSequenceDurationInFrames: 10.920000000000016,
+		loop: false,
+	});
+
+	expect(duration).toBe(10.92);
+});
+
 test('parentSequence with playbackRate 2.45 caps correctly', () => {
 	const duration = getTimelineDuration({
 		compositionDurationInFrames: 300,

--- a/packages/core/src/test/nested-sequences.test.tsx
+++ b/packages/core/src/test/nested-sequences.test.tsx
@@ -1,6 +1,7 @@
 import {afterEach, expect, test} from 'bun:test';
 import {cleanup, render} from '@testing-library/react';
 import {AbsoluteFill} from '../AbsoluteFill.js';
+import {getTimelineDuration} from '../get-timeline-duration.js';
 import {Sequence} from '../Sequence.js';
 import {TimelineContext} from '../TimelineContext.js';
 import {useCurrentFrame} from '../use-current-frame.js';
@@ -152,4 +153,25 @@ test('Floats', () => {
 	expect(getForFrame(133, content)(/^Two$/i)).toBe(null);
 	cleanup();
 	expect(getForFrame(134, content)(/^Two$/i)).not.toBe(null);
+});
+
+test('Nested media sequence with subframe duration stays mounted for final visible frame', () => {
+	const durationInFrames = 10.920000000000016;
+	const mediaSequenceDuration = getTimelineDuration({
+		compositionDurationInFrames: durationInFrames,
+		playbackRate: 1,
+		trimBefore: undefined,
+		trimAfter: undefined,
+		parentSequenceDurationInFrames: durationInFrames,
+		loop: false,
+	});
+	const content = (
+		<Sequence durationInFrames={durationInFrames}>
+			<Sequence layout="none" durationInFrames={mediaSequenceDuration}>
+				<h1>Video</h1>
+			</Sequence>
+		</Sequence>
+	);
+
+	expect(getForFrame(10, content)(/^Video$/i)).not.toBe(null);
 });

--- a/packages/example/src/FractionalSequenceVideo.tsx
+++ b/packages/example/src/FractionalSequenceVideo.tsx
@@ -1,0 +1,16 @@
+import {Video} from '@remotion/media';
+import React from 'react';
+import {AbsoluteFill, Sequence} from 'remotion';
+
+export const FractionalSequenceVideo: React.FC = () => {
+	return (
+		<AbsoluteFill>
+			<Sequence durationInFrames={10.920000000000016}>
+				<Video src="https://remotion.media/video.mp4" />
+			</Sequence>
+			<Sequence from={10.920000000000016}>
+				<Video src="https://remotion.media/video.mp4" />
+			</Sequence>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -36,6 +36,7 @@ import {ErrorOnFrame10} from './ErrorOnFrame10';
 import {ExperimentalControlsShowcase} from './ExperimentalControls';
 import {Expert} from './Expert';
 import {FontDemo} from './Fonts';
+import {FractionalSequenceVideo} from './FractionalSequenceVideo';
 import {Framer} from './Framer';
 import {FreezeExample} from './Freeze/FreezeExample';
 import {FreezePortion} from './FreezePortion/FreezePortion';
@@ -1332,6 +1333,14 @@ export const Index: React.FC = () => {
 						url: PLAY_RANGES_MEDIA_VIDEO_URL_DEFAULT,
 						playRanges: PLAY_RANGES_MEDIA_ZIP_DEFAULT,
 					}}
+				/>
+				<Composition
+					id="fractional-sequence-video"
+					component={FractionalSequenceVideo}
+					width={640}
+					height={360}
+					fps={24}
+					durationInFrames={600}
 				/>
 				<Composition
 					id="corrupt-video"


### PR DESCRIPTION
## Summary

- Preserve subframe media durations instead of flooring them, so media inside fractional Sequences stays mounted through the final visible frame.
- Add a `fractional-sequence-video` example composition for the issue #8191 repro.
- Add regression coverage for the nested media sequence boundary.

Fixes #8191

## Test plan

- `cd packages/core && bun test src/test/get-media-duration.test.ts src/test/nested-sequences.test.tsx`
- `bun run build`
- `bun run stylecheck`
