### PR TITLE
`@remotion/studio`: Allow dropping effects onto timeline layers

### DIFF
--- a/packages/studio-shared/src/test/effect-drag-data.test.ts
+++ b/packages/studio-shared/src/test/effect-drag-data.test.ts
@@ -1,0 +1,74 @@
+import {expect, test} from 'bun:test';
+import {parseEffectDragData} from '../effect-drag-data';
+
+test('parses effect drag data', () => {
+	expect(
+		parseEffectDragData(
+			JSON.stringify({
+				type: 'remotion-effect',
+				version: 1,
+				effect: {
+					name: 'glow',
+					importPath: '@remotion/effects',
+					config: {
+						intensity: 0.5,
+					},
+				},
+			}),
+		),
+	).toEqual({
+		type: 'remotion-effect',
+		version: 1,
+		effect: {
+			name: 'glow',
+			importPath: '@remotion/effects',
+			config: {
+				intensity: 0.5,
+			},
+		},
+	});
+});
+
+test('rejects invalid effect drag data', () => {
+	expect(parseEffectDragData('')).toBe(null);
+	expect(parseEffectDragData('{')).toBe(null);
+	expect(
+		parseEffectDragData(
+			JSON.stringify({
+				type: 'remotion-effect',
+				version: 2,
+				effect: {
+					name: 'glow',
+					importPath: '@remotion/effects',
+					config: {},
+				},
+			}),
+		),
+	).toBe(null);
+	expect(
+		parseEffectDragData(
+			JSON.stringify({
+				type: 'remotion-effect',
+				version: 1,
+				effect: {
+					name: 'glow',
+					importPath: '@remotion/effects',
+					config: [],
+				},
+			}),
+		),
+	).toBe(null);
+	expect(
+		parseEffectDragData(
+			JSON.stringify({
+				type: 'remotion-effect',
+				version: 1,
+				effect: {
+					name: 1,
+					importPath: '@remotion/effects',
+					config: {},
+				},
+			}),
+		),
+	).toBe(null);
+});

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useContext, useMemo} from 'react';
 import type {TSequence} from 'remotion';
 import {Internals, useCurrentFrame} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {BLUE} from '../../helpers/colors';
 import {
 	getTimelineSequenceLayout,
@@ -13,6 +14,10 @@ import {
 } from '../../helpers/timeline-layout';
 import {useMaxMediaDuration} from '../../helpers/use-max-media-duration';
 import {AudioWaveform} from '../AudioWaveform';
+import {
+	effectDropHighlight,
+	useEffectDropTarget,
+} from './effect-drag-to-sequence';
 import {LoopedTimelineIndicator} from './LoopedTimelineIndicators';
 import {TimelineImageInfo} from './TimelineImageInfo';
 import {TIMELINE_TOP_DRAG, useTimelineRowSelection} from './TimelineSelection';
@@ -63,6 +68,10 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	readonly onMoveDragPointerDown: (
 		e: React.PointerEvent<HTMLDivElement>,
 	) => void;
+	readonly canDropEffect: boolean;
+	readonly onEffectDragLeave: (e: React.DragEvent<HTMLDivElement>) => void;
+	readonly onEffectDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+	readonly onEffectDrop: (e: React.DragEvent<HTMLDivElement>) => void;
 }> = ({
 	s,
 	displayDurationInFrames,
@@ -74,6 +83,10 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	sequenceFrameOffset,
 	fromCanUpdate,
 	onMoveDragPointerDown,
+	canDropEffect,
+	onEffectDragLeave,
+	onEffectDragOver,
+	onEffectDrop,
 }) => {
 	const {onSelect, selectable} = useTimelineRowSelection(nodePathInfo);
 
@@ -122,6 +135,9 @@ const TimelineSequenceCurrentFrame: React.FC<{
 		<div
 			style={actualStyle}
 			title={s.displayName}
+			onDragLeave={canDropEffect ? onEffectDragLeave : undefined}
+			onDragOver={canDropEffect ? onEffectDragOver : undefined}
+			onDrop={canDropEffect ? onEffectDrop : undefined}
 			onPointerDown={selectable ? onPointerDown : undefined}
 		>
 			{premountWidth ? (
@@ -218,6 +234,7 @@ const TimelineSequenceInner: React.FC<{
 	}, [originalLocation]);
 
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const nodePath = nodePathInfo?.sequenceSubscriptionKey ?? null;
 	const propStatusesForOverride = useMemo(() => {
 		return nodePath
@@ -235,6 +252,18 @@ const TimelineSequenceInner: React.FC<{
 		nodePathInfo,
 		windowWidth,
 		timelineDurationInFrames: video?.durationInFrames ?? 1,
+	});
+	const {
+		canDropEffect,
+		effectDropHovered,
+		onEffectDragLeave,
+		onEffectDragOver,
+		onEffectDrop,
+	} = useEffectDropTarget({
+		fileName: validatedLocation?.source ?? null,
+		nodePath,
+		previewServerState,
+		supportsEffects: s.controls?.supportsEffects === true,
 	});
 
 	if (!video) {
@@ -284,8 +313,9 @@ const TimelineSequenceInner: React.FC<{
 			width,
 			color: 'white',
 			overflow: 'hidden',
+			...(effectDropHovered ? effectDropHighlight : null),
 		};
-	}, [marginLeft, s.type, width]);
+	}, [effectDropHovered, marginLeft, s.type, width]);
 
 	const showRightEdgeDragHandle =
 		TIMELINE_TOP_DRAG &&
@@ -311,6 +341,10 @@ const TimelineSequenceInner: React.FC<{
 			sequenceFrameOffset={sequenceFrameOffset}
 			fromCanUpdate={fromCanUpdate}
 			onMoveDragPointerDown={onMoveDragPointerDown}
+			canDropEffect={canDropEffect}
+			onEffectDragLeave={onEffectDragLeave}
+			onEffectDragOver={onEffectDragOver}
+			onEffectDrop={onEffectDrop}
 		>
 			{s.type === 'audio' ? (
 				<AudioWaveform

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -1,9 +1,4 @@
-import {
-	EFFECT_DRAG_MIME_TYPE,
-	getRequiredPackageForEffectImportPath,
-	parseEffectDragData,
-	type ReorderSequencePosition,
-} from '@remotion/studio-shared';
+import {type ReorderSequencePosition} from '@remotion/studio-shared';
 import React, {useCallback, useContext, useMemo, useState} from 'react';
 import type {SequencePropsSubscriptionKey, TSequence} from 'remotion';
 import {Internals} from 'remotion';
@@ -11,7 +6,6 @@ import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {formatFileLocation} from '../../helpers/format-file-location';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
-import {installRequiredPackages} from '../../helpers/install-required-package';
 import {
 	getTimelineLayerHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
@@ -28,6 +22,10 @@ import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {useSelectAsset} from '../use-select-asset';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
+import {
+	effectDropHighlight,
+	useEffectDropTarget,
+} from './effect-drag-to-sequence';
 import {saveSequenceProps} from './save-sequence-prop';
 import {
 	getTimelineAssetLinkInfo,
@@ -58,12 +56,6 @@ const labelContainerStyle: React.CSSProperties = {
 	flexDirection: 'row',
 	minWidth: 0,
 	gap: 4,
-};
-
-const effectDropHighlight: React.CSSProperties = {
-	backgroundColor: 'rgba(0, 155, 255, 0.16)',
-	outline: '1px solid rgba(0, 155, 255, 0.75)',
-	outlineOffset: -1,
 };
 
 const SEQUENCE_REORDER_MIME_TYPE = 'application/remotion-sequence-reorder';
@@ -164,35 +156,6 @@ type SequenceDropTarget =
 			readonly reason: string;
 	  };
 
-const hasEffectDragType = (dataTransfer: DataTransfer) => {
-	return Array.from(dataTransfer.types).some(
-		(type) =>
-			type === EFFECT_DRAG_MIME_TYPE ||
-			type === 'application/json' ||
-			type === 'text/plain',
-	);
-};
-
-const getEffectDragData = (dataTransfer: DataTransfer) => {
-	for (const type of [
-		EFFECT_DRAG_MIME_TYPE,
-		'application/json',
-		'text/plain',
-	]) {
-		const value = dataTransfer.getData(type);
-		if (!value) {
-			continue;
-		}
-
-		const parsed = parseEffectDragData(value);
-		if (parsed) {
-			return parsed;
-		}
-	}
-
-	return null;
-};
-
 export const TimelineSequenceItem: React.FC<{
 	readonly sequence: TSequence;
 	readonly nestedDepth: number;
@@ -217,7 +180,6 @@ export const TimelineSequenceItem: React.FC<{
 	const {onSelect, selectable, selected} =
 		useTimelineRowSelection(nodePathInfo);
 	const containsSelection = useTimelineRowContainsSelection(nodePathInfo);
-	const [effectDropHovered, setEffectDropHovered] = useState(false);
 	const [sequenceDropIndicator, setSequenceDropIndicator] =
 		useState<ReorderSequencePosition | null>(null);
 	const [sequenceDropRejection, setSequenceDropRejection] = useState<
@@ -795,6 +757,19 @@ export const TimelineSequenceItem: React.FC<{
 		};
 	}, []);
 
+	const {
+		canDropEffect,
+		effectDropHovered,
+		onEffectDragLeave,
+		onEffectDragOver,
+		onEffectDrop,
+	} = useEffectDropTarget({
+		fileName: validatedLocation?.source ?? null,
+		nodePath,
+		previewServerState,
+		supportsEffects: sequence.controls?.supportsEffects === true,
+	});
+
 	const rowStyle = useMemo((): React.CSSProperties => {
 		return effectDropHovered
 			? {
@@ -816,12 +791,6 @@ export const TimelineSequenceItem: React.FC<{
 		codeHiddenStatus !== null &&
 		codeHiddenStatus.status === 'static';
 
-	const canDropEffect =
-		previewServerState.type === 'connected' &&
-		nodePath !== null &&
-		validatedLocation !== null &&
-		sequence.controls?.supportsEffects === true;
-
 	const sequenceReorderLineStyle = useMemo((): React.CSSProperties | null => {
 		if (!sequenceDropIndicator) {
 			return null;
@@ -832,78 +801,6 @@ export const TimelineSequenceItem: React.FC<{
 			...(sequenceDropIndicator === 'before' ? {top: -1} : {bottom: -1}),
 		};
 	}, [sequenceDropIndicator]);
-
-	const onEffectDragOver = useCallback(
-		(e: React.DragEvent<HTMLDivElement>) => {
-			if (!canDropEffect || !hasEffectDragType(e.dataTransfer)) {
-				return;
-			}
-
-			e.preventDefault();
-			e.dataTransfer.dropEffect = 'copy';
-			setEffectDropHovered(true);
-		},
-		[canDropEffect],
-	);
-
-	const onEffectDragLeave = useCallback(
-		(e: React.DragEvent<HTMLDivElement>) => {
-			if (e.currentTarget.contains(e.relatedTarget as Node | null)) {
-				return;
-			}
-
-			setEffectDropHovered(false);
-		},
-		[],
-	);
-
-	const onEffectDrop = useCallback(
-		async (e: React.DragEvent<HTMLDivElement>) => {
-			if (
-				!canDropEffect ||
-				previewServerState.type !== 'connected' ||
-				nodePath === null ||
-				validatedLocation === null
-			) {
-				return;
-			}
-
-			e.preventDefault();
-			e.stopPropagation();
-			setEffectDropHovered(false);
-
-			const dragData = getEffectDragData(e.dataTransfer);
-			if (!dragData) {
-				showNotification('Could not read effect drag data', 3000);
-				return;
-			}
-
-			try {
-				const requiredPackage = getRequiredPackageForEffectImportPath(
-					dragData.effect.importPath,
-				);
-				await installRequiredPackages(requiredPackage ? [requiredPackage] : []);
-
-				const result = await callApi('/api/add-effect', {
-					fileName: validatedLocation.source,
-					sequenceNodePath: nodePath,
-					effectName: dragData.effect.name,
-					effectImportPath: dragData.effect.importPath,
-					effectConfig: dragData.effect.config,
-					clientId: previewServerState.clientId,
-				});
-
-				if (result.success) {
-					showNotification(`Added ${dragData.effect.name}()`, 2000);
-				} else {
-					showNotification(result.reason, 4000);
-				}
-			} catch (err) {
-				showNotification((err as Error).message, 4000);
-			}
-		},
-		[canDropEffect, nodePath, previewServerState, validatedLocation],
-	);
 
 	const trackRow = (
 		<TimelineRowChrome

--- a/packages/studio/src/components/Timeline/effect-drag-to-sequence.ts
+++ b/packages/studio/src/components/Timeline/effect-drag-to-sequence.ts
@@ -1,0 +1,143 @@
+import {
+	EFFECT_DRAG_MIME_TYPE,
+	getRequiredPackageForEffectImportPath,
+	parseEffectDragData,
+} from '@remotion/studio-shared';
+import {useCallback, useState, type CSSProperties, type DragEvent} from 'react';
+import type {SequencePropsSubscriptionKey} from 'remotion';
+import {installRequiredPackages} from '../../helpers/install-required-package';
+import type {PreviewServerConnectionState} from '../../helpers/preview-server-events';
+import {callApi} from '../call-api';
+import {showNotification} from '../Notifications/NotificationCenter';
+
+export const effectDropHighlight: CSSProperties = {
+	backgroundColor: 'rgba(0, 155, 255, 0.16)',
+	boxShadow: 'inset 0 0 0 2px rgba(0, 155, 255, 0.5)',
+	outline: '1px solid rgba(0, 155, 255, 0.75)',
+	outlineOffset: -1,
+};
+
+export const hasEffectDragType = (dataTransfer: DataTransfer) => {
+	return Array.from(dataTransfer.types).some(
+		(type) =>
+			type === EFFECT_DRAG_MIME_TYPE ||
+			type === 'application/json' ||
+			type === 'text/plain',
+	);
+};
+
+export const getEffectDragData = (dataTransfer: DataTransfer) => {
+	for (const type of [
+		EFFECT_DRAG_MIME_TYPE,
+		'application/json',
+		'text/plain',
+	]) {
+		const value = dataTransfer.getData(type);
+		if (!value) {
+			continue;
+		}
+
+		const parsed = parseEffectDragData(value);
+		if (parsed) {
+			return parsed;
+		}
+	}
+
+	return null;
+};
+
+export const useEffectDropTarget = ({
+	fileName,
+	nodePath,
+	previewServerState,
+	supportsEffects,
+}: {
+	readonly fileName: string | null;
+	readonly nodePath: SequencePropsSubscriptionKey | null;
+	readonly previewServerState: PreviewServerConnectionState;
+	readonly supportsEffects: boolean;
+}) => {
+	const [effectDropHovered, setEffectDropHovered] = useState(false);
+	const canDropEffect =
+		previewServerState.type === 'connected' &&
+		nodePath !== null &&
+		fileName !== null &&
+		supportsEffects;
+
+	const onEffectDragOver = useCallback(
+		(e: DragEvent<HTMLDivElement>) => {
+			if (!canDropEffect || !hasEffectDragType(e.dataTransfer)) {
+				return;
+			}
+
+			e.preventDefault();
+			e.dataTransfer.dropEffect = 'copy';
+			setEffectDropHovered(true);
+		},
+		[canDropEffect],
+	);
+
+	const onEffectDragLeave = useCallback((e: DragEvent<HTMLDivElement>) => {
+		if (e.currentTarget.contains(e.relatedTarget as Node | null)) {
+			return;
+		}
+
+		setEffectDropHovered(false);
+	}, []);
+
+	const onEffectDrop = useCallback(
+		async (e: DragEvent<HTMLDivElement>) => {
+			if (
+				!canDropEffect ||
+				previewServerState.type !== 'connected' ||
+				nodePath === null ||
+				fileName === null
+			) {
+				return;
+			}
+
+			e.preventDefault();
+			e.stopPropagation();
+			setEffectDropHovered(false);
+
+			const dragData = getEffectDragData(e.dataTransfer);
+			if (!dragData) {
+				showNotification('Could not read effect drag data', 3000);
+				return;
+			}
+
+			try {
+				const requiredPackage = getRequiredPackageForEffectImportPath(
+					dragData.effect.importPath,
+				);
+				await installRequiredPackages(requiredPackage ? [requiredPackage] : []);
+
+				const result = await callApi('/api/add-effect', {
+					fileName,
+					sequenceNodePath: nodePath,
+					effectName: dragData.effect.name,
+					effectImportPath: dragData.effect.importPath,
+					effectConfig: dragData.effect.config,
+					clientId: previewServerState.clientId,
+				});
+
+				if (result.success) {
+					showNotification(`Added ${dragData.effect.name}()`, 2000);
+				} else {
+					showNotification(result.reason, 4000);
+				}
+			} catch (err) {
+				showNotification((err as Error).message, 4000);
+			}
+		},
+		[canDropEffect, fileName, nodePath, previewServerState],
+	);
+
+	return {
+		canDropEffect,
+		effectDropHovered,
+		onEffectDragLeave,
+		onEffectDragOver,
+		onEffectDrop,
+	};
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8175

## Summary
- Allow external effect drag payloads to be dropped directly on the colored timeline layer bar.
- Reuse the existing add-effect API/drop behavior between the timeline row label and layer bar.
- Add parser coverage for effect drag payloads.

## Walkthrough
<a href="https://cursor.com/agents/bc-cdcacbfe-67dd-4041-85b8-d6aa57f6352b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feffect_drop_on_layer_clean.mp4"><img src="https://cursor.com/artifacts/c/art-6a0ac069-2507-4875-a455-4f951a6f8dfd" alt="effect_drop_on_layer_clean.mp4" /></a>

## Testing
- `bun test src/test/effect-drag-data.test.ts`
- `bun test src/test/timeline-selection.test.ts`
- `bunx turbo run make --filter='@remotion/studio' --filter='@remotion/studio-shared'`
- `bun run build`
- `bunx turbo run lint formatting --filter='@remotion/studio' --filter='@remotion/studio-shared'`
- Manual Studio validation on `simple-img`: simulated a Remotion effect drag payload onto the `<Img>` timeline layer bar and confirmed the image inverted without a red error banner.

## Notes
- `bun run stylecheck` reaches the known `@remotion/lambda-go` Go version caveat in this Cursor Cloud VM (Go 1.22.2 vs required >=1.23.0).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdcacbfe-67dd-4041-85b8-d6aa57f6352b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdcacbfe-67dd-4041-85b8-d6aa57f6352b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

