### PR TITLE
`@remotion/studio`: Add SFX drag support for Studio

### DIFF
--- a/packages/docs/components/sfx-demos/sfx-drag-data.ts
+++ b/packages/docs/components/sfx-demos/sfx-drag-data.ts
@@ -1,0 +1,46 @@
+import {SFX_DRAG_MIME_TYPE, type SfxDragData} from '@remotion/studio-shared';
+
+export const makeSfxDragData = ({
+	name,
+	url,
+}: {
+	readonly name: string;
+	readonly url: string;
+}): SfxDragData => {
+	return {
+		type: 'remotion-sfx',
+		version: 1,
+		sfx: {
+			name,
+			url,
+		},
+	};
+};
+
+export const getSfxNameFromUrl = (src: string): string => {
+	try {
+		const url = new URL(src);
+		return (
+			url.pathname
+				.split('/')
+				.pop()
+				?.replace(/\.[^.]+$/, '') || 'SFX'
+		);
+	} catch {
+		return 'SFX';
+	}
+};
+
+export const setSfxDragData = ({
+	dataTransfer,
+	dragData,
+}: {
+	readonly dataTransfer: DataTransfer;
+	readonly dragData: SfxDragData;
+}) => {
+	const serialized = JSON.stringify(dragData);
+	dataTransfer.effectAllowed = 'copy';
+	dataTransfer.setData(SFX_DRAG_MIME_TYPE, serialized);
+	dataTransfer.setData('application/json', serialized);
+	dataTransfer.setData('text/plain', serialized);
+};

--- a/packages/docs/docs/sfx/PlayButton.tsx
+++ b/packages/docs/docs/sfx/PlayButton.tsx
@@ -1,5 +1,10 @@
 import {Button} from '@remotion/design';
 import React, {useCallback, useRef, useState} from 'react';
+import {
+	getSfxNameFromUrl,
+	makeSfxDragData,
+	setSfxDragData,
+} from '../../components/sfx-demos/sfx-drag-data';
 
 export const PlayButton: React.FC<{
 	readonly src: string;
@@ -8,6 +13,7 @@ export const PlayButton: React.FC<{
 }> = ({src, size = 48, depth}) => {
 	const [playing, setPlaying] = useState(false);
 	const audioRef = useRef<HTMLAudioElement | null>(null);
+	const sfxName = getSfxNameFromUrl(src);
 
 	const iconSize = Math.round(size * 0.5);
 
@@ -34,8 +40,26 @@ export const PlayButton: React.FC<{
 		[playing, src],
 	);
 
+	const onDragStart = useCallback(
+		(e: React.DragEvent<HTMLDivElement>) => {
+			setSfxDragData({
+				dataTransfer: e.dataTransfer,
+				dragData: makeSfxDragData({
+					name: sfxName,
+					url: src,
+				}),
+			});
+		},
+		[sfxName, src],
+	);
+
 	return (
-		<div style={{width: size, height: size}}>
+		<div
+			style={{width: size, height: size}}
+			draggable
+			onDragStart={onDragStart}
+			title="Drag this sound effect into Remotion Studio"
+		>
 			<Button
 				className={`rounded-full p-0`}
 				style={{width: size, height: size}}

--- a/packages/docs/docs/sfx/table-of-contents.tsx
+++ b/packages/docs/docs/sfx/table-of-contents.tsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import {
+	makeSfxDragData,
+	setSfxDragData,
+} from '../../components/sfx-demos/sfx-drag-data';
 import {Grid} from '../../components/TableOfContents/Grid';
 import {TOCItem} from '../../components/TableOfContents/TOCItem';
 import {PlayButton} from './PlayButton';
@@ -9,8 +13,20 @@ const SfxItem: React.FC<{
 	readonly name: string;
 	readonly description: string;
 }> = ({link, src, name, description}) => {
+	const dragData = makeSfxDragData({name, url: src});
+
 	return (
-		<TOCItem link={link}>
+		<TOCItem
+			link={link}
+			draggable
+			onDragStart={(e) => {
+				setSfxDragData({
+					dataTransfer: e.dataTransfer,
+					dragData,
+				});
+			}}
+			title="Drag this sound effect into Remotion Studio"
+		>
 			<div
 				style={{
 					display: 'flex',

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -13,7 +13,10 @@ import type {
 	JSXElement,
 	VariableDeclaration,
 } from '@babel/types';
-import type {InsertableCompositionElement} from '@remotion/studio-shared';
+import {
+	isRemotionSfxUrl,
+	type InsertableCompositionElement,
+} from '@remotion/studio-shared';
 import type {namedTypes} from 'ast-types';
 import * as recast from 'recast';
 import {formatFileContent} from '../codemods/format-file-content';
@@ -765,6 +768,13 @@ const createStaticFileSrcAttribute = ({
 	);
 };
 
+const createStringSrcAttribute = (src: string): namedTypes.JSXAttribute => {
+	return recast.types.builders.jsxAttribute(
+		recast.types.builders.jsxIdentifier('src'),
+		recast.types.builders.stringLiteral(src),
+	);
+};
+
 const createSolidElement = ({
 	localName,
 	width,
@@ -796,7 +806,7 @@ const createAssetElement = ({
 	dimensions,
 }: {
 	localName: string;
-	staticFileLocalName: string;
+	staticFileLocalName: string | null;
 	src: string;
 	dimensions: {width: number; height: number} | null;
 }): namedTypes.JSXElement => {
@@ -804,7 +814,9 @@ const createAssetElement = ({
 		recast.types.builders.jsxOpeningElement(
 			recast.types.builders.jsxIdentifier(localName),
 			[
-				createStaticFileSrcAttribute({staticFileLocalName, src}),
+				staticFileLocalName === null
+					? createStringSrcAttribute(src)
+					: createStaticFileSrcAttribute({staticFileLocalName, src}),
 				createPositionAbsoluteStyleAttribute(),
 				...(dimensions
 					? [
@@ -1442,7 +1454,15 @@ const createInsertableJsxElement = ({
 	}
 
 	if (element.type === 'asset') {
-		const staticFileLocalName = ensureStaticFileImport(ast);
+		if (
+			element.srcType === 'remote' &&
+			(element.assetType !== 'audio' || !isRemotionSfxUrl(element.src))
+		) {
+			throw new Error('Only @remotion/sfx audio URLs can be inserted remotely');
+		}
+
+		const staticFileLocalName =
+			element.srcType === 'remote' ? null : ensureStaticFileImport(ast);
 		let localName: string;
 		if (element.assetType === 'image') {
 			localName = ensureImgImport(ast);

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -14,7 +14,7 @@ import type {
 	VariableDeclaration,
 } from '@babel/types';
 import {
-	isRemotionSfxUrl,
+	isUrl,
 	type InsertableCompositionElement,
 } from '@remotion/studio-shared';
 import type {namedTypes} from 'ast-types';
@@ -1454,11 +1454,8 @@ const createInsertableJsxElement = ({
 	}
 
 	if (element.type === 'asset') {
-		if (
-			element.srcType === 'remote' &&
-			(element.assetType !== 'audio' || !isRemotionSfxUrl(element.src))
-		) {
-			throw new Error('Only @remotion/sfx audio URLs can be inserted remotely');
+		if (element.srcType === 'remote' && !isUrl(element.src)) {
+			throw new Error('Remote asset source must be a URL');
 		}
 
 		const staticFileLocalName =

--- a/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
+++ b/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
@@ -337,6 +337,7 @@ export const downloadRemoteAssetHandler: ApiHandler<
 		type: 'asset',
 		assetType: fileType.type === 'gif' ? 'gif' : 'image',
 		src: assetPath,
+		srcType: 'static',
 		dimensions: fileType.dimensions,
 	};
 

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -1,6 +1,6 @@
 import {RenderInternals} from '@remotion/renderer';
 import {
-	isRemotionSfxUrl,
+	isUrl,
 	type InsertJsxElementRequest,
 	type InsertJsxElementResponse,
 	type InsertableCompositionElement,
@@ -32,10 +32,8 @@ const validateElement = (element: InsertableCompositionElement) => {
 
 	if (element.type === 'asset') {
 		if (element.srcType === 'remote') {
-			if (element.assetType !== 'audio' || !isRemotionSfxUrl(element.src)) {
-				throw new Error(
-					'Only @remotion/sfx audio URLs can be inserted remotely',
-				);
+			if (!isUrl(element.src)) {
+				throw new Error('Remote asset source must be a URL');
 			}
 		} else if (!element.src || element.src.includes('\\')) {
 			throw new Error('Asset path must be a static file path');

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -1,8 +1,9 @@
 import {RenderInternals} from '@remotion/renderer';
-import type {
-	InsertJsxElementRequest,
-	InsertJsxElementResponse,
-	InsertableCompositionElement,
+import {
+	isRemotionSfxUrl,
+	type InsertJsxElementRequest,
+	type InsertJsxElementResponse,
+	type InsertableCompositionElement,
 } from '@remotion/studio-shared';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import {insertJsxElementIntoComposition} from '../../helpers/resolve-composition-component';
@@ -30,7 +31,13 @@ const validateElement = (element: InsertableCompositionElement) => {
 	}
 
 	if (element.type === 'asset') {
-		if (!element.src || element.src.includes('\\')) {
+		if (element.srcType === 'remote') {
+			if (element.assetType !== 'audio' || !isRemotionSfxUrl(element.src)) {
+				throw new Error(
+					'Only @remotion/sfx audio URLs can be inserted remotely',
+				);
+			}
+		} else if (!element.src || element.src.includes('\\')) {
 			throw new Error('Asset path must be a static file path');
 		}
 

--- a/packages/studio-server/src/test/download-remote-asset.test.ts
+++ b/packages/studio-server/src/test/download-remote-asset.test.ts
@@ -93,6 +93,7 @@ test('follows validated redirects for remote assets', async () => {
 					width: 800,
 				},
 				src: 'raw-link.gif',
+				srcType: 'static',
 				type: 'asset',
 			},
 			sizeInBytes: gif.byteLength,

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -865,6 +865,57 @@ test('inserts an Audio asset into the resolved composition component', async () 
 	}
 });
 
+test('inserts a remote SFX audio asset with a literal URL', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				"import {AbsoluteFill} from 'remotion';",
+				'',
+				'export const MyComp: React.FC = () => {',
+				'\treturn <AbsoluteFill>hello</AbsoluteFill>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const result = await insertJsxElementIntoComposition({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+			element: {
+				type: 'asset',
+				assetType: 'audio',
+				src: 'https://remotion.media/whip.wav',
+				srcType: 'remote',
+				dimensions: null,
+			},
+			prettierConfigOverride: {singleQuote: true, useTabs: true},
+		});
+
+		expect(result.output).toContain("import { Audio } from '@remotion/media';");
+		expect(result.output).toContain("import { AbsoluteFill } from 'remotion';");
+		expect(result.output).toContain('<Audio');
+		expect(result.output).toContain('src="https://remotion.media/whip.wav"');
+		expect(result.output).not.toContain('staticFile');
+		expect(result.output).not.toContain('@remotion/sfx');
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('rejects inserting an Audio asset if Audio is already defined', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -692,6 +692,7 @@ test('inserts an Img asset into the resolved composition component', async () =>
 				type: 'asset',
 				assetType: 'image',
 				src: 'image.png',
+				srcType: 'static',
 				dimensions: {
 					width: 800,
 					height: 600,
@@ -750,6 +751,7 @@ test('rejects inserting a Video asset if Video is already defined', async () => 
 					type: 'asset',
 					assetType: 'video',
 					src: 'clip.mp4',
+					srcType: 'static',
 					dimensions: null,
 				},
 				prettierConfigOverride: {singleQuote: true, useTabs: true},
@@ -794,6 +796,7 @@ test('inserts a Gif asset into the resolved composition component', async () => 
 				type: 'asset',
 				assetType: 'gif',
 				src: 'animation.gif',
+				srcType: 'static',
 				dimensions: {
 					width: 320,
 					height: 180,
@@ -849,6 +852,7 @@ test('inserts an Audio asset into the resolved composition component', async () 
 				type: 'asset',
 				assetType: 'audio',
 				src: 'audio.mp3',
+				srcType: 'static',
 				dimensions: null,
 			},
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
@@ -865,7 +869,7 @@ test('inserts an Audio asset into the resolved composition component', async () 
 	}
 });
 
-test('inserts a remote SFX audio asset with a literal URL', async () => {
+test('inserts a remote audio asset with a literal URL', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {
 		await fs.writeFile(
@@ -898,7 +902,7 @@ test('inserts a remote SFX audio asset with a literal URL', async () => {
 			element: {
 				type: 'asset',
 				assetType: 'audio',
-				src: 'https://remotion.media/whip.wav',
+				src: 'https://example.com/whip.wav',
 				srcType: 'remote',
 				dimensions: null,
 			},
@@ -908,7 +912,7 @@ test('inserts a remote SFX audio asset with a literal URL', async () => {
 		expect(result.output).toContain("import { Audio } from '@remotion/media';");
 		expect(result.output).toContain("import { AbsoluteFill } from 'remotion';");
 		expect(result.output).toContain('<Audio');
-		expect(result.output).toContain('src="https://remotion.media/whip.wav"');
+		expect(result.output).toContain('src="https://example.com/whip.wav"');
 		expect(result.output).not.toContain('staticFile');
 		expect(result.output).not.toContain('@remotion/sfx');
 	} finally {
@@ -953,6 +957,7 @@ test('rejects inserting an Audio asset if Audio is already defined', async () =>
 					type: 'asset',
 					assetType: 'audio',
 					src: 'audio.mp3',
+					srcType: 'static',
 					dimensions: null,
 				},
 				prettierConfigOverride: {singleQuote: true, useTabs: true},

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -603,6 +603,7 @@ export type InsertableCompositionElement =
 			type: 'asset';
 			assetType: 'image' | 'video' | 'gif' | 'audio';
 			src: string;
+			srcType?: 'static' | 'remote';
 			dimensions: {
 				width: number;
 				height: number;

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -603,7 +603,7 @@ export type InsertableCompositionElement =
 			type: 'asset';
 			assetType: 'image' | 'video' | 'gif' | 'audio';
 			src: string;
-			srcType?: 'static' | 'remote';
+			srcType: 'static' | 'remote';
 			dimensions: {
 				width: number;
 				height: number;

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -197,6 +197,13 @@ export {
 	getEffectFieldsToShow,
 	getFieldsToShow,
 } from './schema-field-info';
+export {
+	REMOTION_MEDIA_SFX_PREFIX,
+	SFX_DRAG_MIME_TYPE,
+	isRemotionSfxUrl,
+	parseSfxDragData,
+	type SfxDragData,
+} from './sfx-drag-data';
 export type {
 	AnySchemaFieldInfo,
 	DragOverrides,

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -198,9 +198,7 @@ export {
 	getFieldsToShow,
 } from './schema-field-info';
 export {
-	REMOTION_MEDIA_SFX_PREFIX,
 	SFX_DRAG_MIME_TYPE,
-	isRemotionSfxUrl,
 	parseSfxDragData,
 	type SfxDragData,
 } from './sfx-drag-data';
@@ -248,3 +246,4 @@ export {
 	stringifySequenceExpandedRowKey,
 	stringifySequenceSubscriptionKey,
 } from './stringify-sequence-subscription-key';
+export {isUrl} from './url';

--- a/packages/studio-shared/src/sfx-drag-data.ts
+++ b/packages/studio-shared/src/sfx-drag-data.ts
@@ -1,6 +1,6 @@
-export const SFX_DRAG_MIME_TYPE = 'application/vnd.remotion.sfx+json';
+import {isUrl} from './url';
 
-export const REMOTION_MEDIA_SFX_PREFIX = 'https://remotion.media/';
+export const SFX_DRAG_MIME_TYPE = 'application/vnd.remotion.sfx+json';
 
 export type SfxDragData = {
 	type: 'remotion-sfx';
@@ -13,20 +13,6 @@ export type SfxDragData = {
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
-};
-
-export const isRemotionSfxUrl = (value: string): boolean => {
-	try {
-		const url = new URL(value);
-		return (
-			url.protocol === 'https:' &&
-			url.host === 'remotion.media' &&
-			url.href.startsWith(REMOTION_MEDIA_SFX_PREFIX) &&
-			url.pathname.length > 1
-		);
-	} catch {
-		return false;
-	}
 };
 
 export const parseSfxDragData = (value: string): SfxDragData | null => {
@@ -49,7 +35,7 @@ export const parseSfxDragData = (value: string): SfxDragData | null => {
 			typeof name !== 'string' ||
 			name.length === 0 ||
 			typeof url !== 'string' ||
-			!isRemotionSfxUrl(url)
+			!isUrl(url)
 		) {
 			return null;
 		}

--- a/packages/studio-shared/src/sfx-drag-data.ts
+++ b/packages/studio-shared/src/sfx-drag-data.ts
@@ -1,0 +1,68 @@
+export const SFX_DRAG_MIME_TYPE = 'application/vnd.remotion.sfx+json';
+
+export const REMOTION_MEDIA_SFX_PREFIX = 'https://remotion.media/';
+
+export type SfxDragData = {
+	type: 'remotion-sfx';
+	version: 1;
+	sfx: {
+		name: string;
+		url: string;
+	};
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+export const isRemotionSfxUrl = (value: string): boolean => {
+	try {
+		const url = new URL(value);
+		return (
+			url.protocol === 'https:' &&
+			url.host === 'remotion.media' &&
+			url.href.startsWith(REMOTION_MEDIA_SFX_PREFIX) &&
+			url.pathname.length > 1
+		);
+	} catch {
+		return false;
+	}
+};
+
+export const parseSfxDragData = (value: string): SfxDragData | null => {
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!isRecord(parsed)) {
+			return null;
+		}
+
+		if (parsed.type !== 'remotion-sfx' || parsed.version !== 1) {
+			return null;
+		}
+
+		if (!isRecord(parsed.sfx)) {
+			return null;
+		}
+
+		const {name, url} = parsed.sfx;
+		if (
+			typeof name !== 'string' ||
+			name.length === 0 ||
+			typeof url !== 'string' ||
+			!isRemotionSfxUrl(url)
+		) {
+			return null;
+		}
+
+		return {
+			type: 'remotion-sfx',
+			version: 1,
+			sfx: {
+				name,
+				url,
+			},
+		};
+	} catch {
+		return null;
+	}
+};

--- a/packages/studio-shared/src/test/required-package.test.ts
+++ b/packages/studio-shared/src/test/required-package.test.ts
@@ -17,6 +17,7 @@ test('gets required package for insertable elements', () => {
 			type: 'asset',
 			assetType: 'image',
 			src: 'image.png',
+			srcType: 'static',
 			dimensions: null,
 		}),
 	).toBe(null);
@@ -25,6 +26,7 @@ test('gets required package for insertable elements', () => {
 			type: 'asset',
 			assetType: 'video',
 			src: 'video.mp4',
+			srcType: 'static',
 			dimensions: null,
 		}),
 	).toBe('@remotion/media');
@@ -33,6 +35,7 @@ test('gets required package for insertable elements', () => {
 			type: 'asset',
 			assetType: 'audio',
 			src: 'audio.mp3',
+			srcType: 'static',
 			dimensions: null,
 		}),
 	).toBe('@remotion/media');
@@ -41,6 +44,7 @@ test('gets required package for insertable elements', () => {
 			type: 'asset',
 			assetType: 'gif',
 			src: 'animation.gif',
+			srcType: 'static',
 			dimensions: null,
 		}),
 	).toBe('@remotion/gif');

--- a/packages/studio-shared/src/test/sfx-drag-data.test.ts
+++ b/packages/studio-shared/src/test/sfx-drag-data.test.ts
@@ -1,0 +1,62 @@
+import {expect, test} from 'bun:test';
+import {
+	isRemotionSfxUrl,
+	parseSfxDragData,
+	type SfxDragData,
+} from '../sfx-drag-data';
+
+const validSfxDragData: SfxDragData = {
+	type: 'remotion-sfx',
+	version: 1,
+	sfx: {
+		name: 'whip',
+		url: 'https://remotion.media/whip.wav',
+	},
+};
+
+test('parses SFX drag data', () => {
+	expect(parseSfxDragData(JSON.stringify(validSfxDragData))).toEqual(
+		validSfxDragData,
+	);
+});
+
+test('validates remotion.media SFX URLs', () => {
+	expect(isRemotionSfxUrl('https://remotion.media/whip.wav')).toBe(true);
+	expect(isRemotionSfxUrl('http://remotion.media/whip.wav')).toBe(false);
+	expect(isRemotionSfxUrl('https://example.com/whip.wav')).toBe(false);
+});
+
+test('rejects invalid SFX drag data', () => {
+	expect(parseSfxDragData('')).toBe(null);
+	expect(parseSfxDragData('{')).toBe(null);
+	expect(
+		parseSfxDragData(
+			JSON.stringify({
+				...validSfxDragData,
+				version: 2,
+			}),
+		),
+	).toBe(null);
+	expect(
+		parseSfxDragData(
+			JSON.stringify({
+				...validSfxDragData,
+				sfx: {
+					...validSfxDragData.sfx,
+					name: '',
+				},
+			}),
+		),
+	).toBe(null);
+	expect(
+		parseSfxDragData(
+			JSON.stringify({
+				...validSfxDragData,
+				sfx: {
+					...validSfxDragData.sfx,
+					url: 'https://example.com/whip.wav',
+				},
+			}),
+		),
+	).toBe(null);
+});

--- a/packages/studio-shared/src/test/sfx-drag-data.test.ts
+++ b/packages/studio-shared/src/test/sfx-drag-data.test.ts
@@ -1,9 +1,6 @@
 import {expect, test} from 'bun:test';
-import {
-	isRemotionSfxUrl,
-	parseSfxDragData,
-	type SfxDragData,
-} from '../sfx-drag-data';
+import {parseSfxDragData, type SfxDragData} from '../sfx-drag-data';
+import {isUrl} from '../url';
 
 const validSfxDragData: SfxDragData = {
 	type: 'remotion-sfx',
@@ -20,10 +17,20 @@ test('parses SFX drag data', () => {
 	);
 });
 
-test('validates remotion.media SFX URLs', () => {
-	expect(isRemotionSfxUrl('https://remotion.media/whip.wav')).toBe(true);
-	expect(isRemotionSfxUrl('http://remotion.media/whip.wav')).toBe(false);
-	expect(isRemotionSfxUrl('https://example.com/whip.wav')).toBe(false);
+test('accepts any URL in SFX drag data', () => {
+	const nonRemotionUrlDragData: SfxDragData = {
+		...validSfxDragData,
+		sfx: {
+			...validSfxDragData.sfx,
+			url: 'https://example.com/whip.wav',
+		},
+	};
+	expect(parseSfxDragData(JSON.stringify(nonRemotionUrlDragData))).toEqual(
+		nonRemotionUrlDragData,
+	);
+	expect(isUrl('https://remotion.media/whip.wav')).toBe(true);
+	expect(isUrl('https://example.com/whip.wav')).toBe(true);
+	expect(isUrl('not-a-url')).toBe(false);
 });
 
 test('rejects invalid SFX drag data', () => {
@@ -54,7 +61,7 @@ test('rejects invalid SFX drag data', () => {
 				...validSfxDragData,
 				sfx: {
 					...validSfxDragData.sfx,
-					url: 'https://example.com/whip.wav',
+					url: 'not-a-url',
 				},
 			}),
 		),

--- a/packages/studio-shared/src/url.ts
+++ b/packages/studio-shared/src/url.ts
@@ -1,0 +1,8 @@
+export const isUrl = (value: string): boolean => {
+	try {
+		const parsed = new URL(value);
+		return parsed.href.length > 0;
+	} catch {
+		return false;
+	}
+};

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1,7 +1,9 @@
 import type {Size} from '@remotion/player';
 import {
 	ASSET_DRAG_MIME_TYPE,
+	SFX_DRAG_MIME_TYPE,
 	parseAssetDragData,
+	parseSfxDragData,
 } from '@remotion/studio-shared';
 import React, {
 	useCallback,
@@ -42,6 +44,7 @@ import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
 import {
 	importAssets,
 	importRemoteAsset,
+	insertRemoteAudio,
 	insertExistingAssets,
 } from './import-assets';
 import {SPACING_UNIT} from './layout';
@@ -84,10 +87,17 @@ const isAssetDragEvent = (event: DragEvent): boolean => {
 	);
 };
 
+const isSfxDragEvent = (event: DragEvent): boolean => {
+	return Array.from(event.dataTransfer?.types ?? []).includes(
+		SFX_DRAG_MIME_TYPE,
+	);
+};
+
 const isRemoteAssetDragEvent = (event: DragEvent): boolean => {
 	return (
 		!isFileDragEvent(event) &&
 		!isAssetDragEvent(event) &&
+		!isSfxDragEvent(event) &&
 		hasRemoteAssetDragData(event.dataTransfer)
 	);
 };
@@ -99,6 +109,27 @@ const getAssetDragPath = (event: DragEvent): string | null => {
 	}
 
 	return parseAssetDragData(value)?.assetPath ?? null;
+};
+
+const getSfxDragUrl = (event: DragEvent): string | null => {
+	const {dataTransfer} = event;
+	if (!dataTransfer) {
+		return null;
+	}
+
+	for (const type of [SFX_DRAG_MIME_TYPE, 'application/json', 'text/plain']) {
+		const value = dataTransfer.getData(type);
+		if (!value) {
+			continue;
+		}
+
+		const parsed = parseSfxDragData(value);
+		if (parsed) {
+			return parsed.sfx.url;
+		}
+	}
+
+	return null;
 };
 
 const isDragEventInsideCanvas = (event: DragEvent): boolean => {
@@ -635,6 +666,7 @@ export const Canvas: React.FC<{
 				!canDropAssets ||
 				(!isFileDragEvent(event) &&
 					!isAssetDragEvent(event) &&
+					!isSfxDragEvent(event) &&
 					!isRemoteAssetDragEvent(event)) ||
 				!isDragEventInsideCanvas(event)
 			) {
@@ -657,6 +689,7 @@ export const Canvas: React.FC<{
 				currentCompositionId === null ||
 				(!isFileDragEvent(event) &&
 					!isAssetDragEvent(event) &&
+					!isSfxDragEvent(event) &&
 					!isRemoteAssetDragEvent(event)) ||
 				!isDragEventInsideCanvas(event)
 			) {
@@ -687,6 +720,17 @@ export const Canvas: React.FC<{
 
 					await insertExistingAssets({
 						assetPaths: [assetPath],
+						compositionFile,
+						compositionId: currentCompositionId,
+					});
+				} else if (isSfxDragEvent(event)) {
+					const url = getSfxDragUrl(event);
+					if (url === null) {
+						return;
+					}
+
+					await insertRemoteAudio({
+						url,
 						compositionFile,
 						compositionId: currentCompositionId,
 					});

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -1,6 +1,7 @@
 import {
 	detectFileType,
 	getRequiredPackageForInsertableElement,
+	isRemotionSfxUrl,
 	type DownloadRemoteAssetResponse,
 	type FileType,
 	type InsertableCompositionElement,
@@ -362,6 +363,50 @@ export const importRemoteAsset = async ({
 	} catch (error) {
 		showNotification(
 			`Could not add remote asset: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+			4000,
+		);
+	}
+};
+
+export const insertRemoteAudio = async ({
+	compositionFile,
+	compositionId,
+	url,
+}: {
+	compositionFile: string;
+	compositionId: string;
+	url: string;
+}) => {
+	if (!isRemotionSfxUrl(url)) {
+		showNotification('Cannot add sound effect: Unsupported URL', 3000);
+		return;
+	}
+
+	const element: InsertableCompositionElement = {
+		type: 'asset',
+		assetType: 'audio',
+		src: url,
+		srcType: 'remote',
+		dimensions: null,
+	};
+
+	try {
+		const inserted = await insertAssetElement({
+			compositionFile,
+			compositionId,
+			element,
+		});
+
+		if (!inserted) {
+			return;
+		}
+
+		notifyInsertedAssets([getAssetLabel(element)]);
+	} catch (error) {
+		showNotification(
+			`Could not add sound effect: ${
 				error instanceof Error ? error.message : String(error)
 			}`,
 			4000,

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -1,7 +1,7 @@
 import {
 	detectFileType,
 	getRequiredPackageForInsertableElement,
-	isRemotionSfxUrl,
+	isUrl,
 	type DownloadRemoteAssetResponse,
 	type FileType,
 	type InsertableCompositionElement,
@@ -29,6 +29,7 @@ export const getAssetElement = ({
 			type: 'asset',
 			assetType: 'image',
 			src,
+			srcType: 'static',
 			dimensions: fileType.dimensions,
 		};
 	}
@@ -38,6 +39,7 @@ export const getAssetElement = ({
 			type: 'asset',
 			assetType: 'gif',
 			src,
+			srcType: 'static',
 			dimensions: fileType.dimensions,
 		};
 	}
@@ -52,6 +54,7 @@ export const getAssetElement = ({
 			type: 'asset',
 			assetType: 'video',
 			src,
+			srcType: 'static',
 			dimensions: null,
 		};
 	}
@@ -66,6 +69,7 @@ export const getAssetElement = ({
 			type: 'asset',
 			assetType: 'audio',
 			src,
+			srcType: 'static',
 			dimensions: null,
 		};
 	}
@@ -90,6 +94,7 @@ export const getAssetElementFromPath = (
 			type: 'asset',
 			assetType: 'image',
 			src: assetPath,
+			srcType: 'static',
 			dimensions: null,
 		};
 	}
@@ -99,6 +104,7 @@ export const getAssetElementFromPath = (
 			type: 'asset',
 			assetType: 'gif',
 			src: assetPath,
+			srcType: 'static',
 			dimensions: null,
 		};
 	}
@@ -108,6 +114,7 @@ export const getAssetElementFromPath = (
 			type: 'asset',
 			assetType: 'video',
 			src: assetPath,
+			srcType: 'static',
 			dimensions: null,
 		};
 	}
@@ -117,6 +124,7 @@ export const getAssetElementFromPath = (
 			type: 'asset',
 			assetType: 'audio',
 			src: assetPath,
+			srcType: 'static',
 			dimensions: null,
 		};
 	}
@@ -379,7 +387,7 @@ export const insertRemoteAudio = async ({
 	compositionId: string;
 	url: string;
 }) => {
-	if (!isRemotionSfxUrl(url)) {
+	if (!isUrl(url)) {
 		showNotification('Cannot add sound effect: Unsupported URL', 3000);
 		return;
 	}

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -15,6 +15,7 @@ test('maps audio file types to Audio assets', () => {
 			type: 'asset',
 			assetType: 'audio',
 			src: `sound.${type}`,
+			srcType: 'static',
 			dimensions: null,
 		});
 	}
@@ -34,24 +35,28 @@ test('maps existing static file paths to insertable assets', () => {
 		type: 'asset',
 		assetType: 'image',
 		src: 'nested/photo.JPG',
+		srcType: 'static',
 		dimensions: null,
 	});
 	expect(getAssetElementFromPath('movie.webm')).toEqual({
 		type: 'asset',
 		assetType: 'video',
 		src: 'movie.webm',
+		srcType: 'static',
 		dimensions: null,
 	});
 	expect(getAssetElementFromPath('audio.flac')).toEqual({
 		type: 'asset',
 		assetType: 'audio',
 		src: 'audio.flac',
+		srcType: 'static',
 		dimensions: null,
 	});
 	expect(getAssetElementFromPath('animation.gif')).toEqual({
 		type: 'asset',
 		assetType: 'gif',
 		src: 'animation.gif',
+		srcType: 'static',
 		dimensions: null,
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Closes #8200.
- Adds an SFX drag payload for docs and generic URL validation.
- Lets SFX docs pages and the SFX table of contents drag audio into Studio canvas.
- Inserts remote SFX as `@remotion/media` `<Audio src="https://remotion.media/..." />` without importing `@remotion/sfx`.
- Makes asset `srcType` mandatory and supports any valid remote URL for remote insertions.

## Demo
<a href="https://cursor.com/agents/bc-37079a1c-a7a9-427f-9e56-4f98e864e1d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsfx_drop_into_studio_canvas_success.mp4"><img src="https://cursor.com/artifacts/c/art-2e3556b2-2523-4ccd-9594-16bb5b8648b2" alt="sfx_drop_into_studio_canvas_success.mp4" /></a>

## Testing
- `bun test src/test/sfx-drag-data.test.ts src/test/required-package.test.ts`
- `bun test src/test/import-assets.test.ts`
- `bun test src/test/resolve-composition-component.test.ts src/test/download-remote-asset.test.ts`
- `bun run build`
- `bunx turbo run lint formatting --filter='@remotion/studio' --filter='@remotion/studio-server' --filter='@remotion/studio-shared'`
- Manual Studio canvas drop verification (see demo video)

## Notes
- `bun run stylecheck` is blocked in this VM by the known `@remotion/lambda-go` Go requirement: `golang.org/x/crypto@v0.35.0 requires go >= 1.23.0`, while the VM has Go 1.22.2.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37079a1c-a7a9-427f-9e56-4f98e864e1d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37079a1c-a7a9-427f-9e56-4f98e864e1d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

