### PR TITLE
`@remotion/studio`: Add selectable timeline easing lines

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -6,6 +6,7 @@ import type {getTimelineKeyframes} from './get-timeline-keyframes';
 import {TimelineKeyframeDiamond} from './TimelineKeyframeDiamond';
 import {TimelineKeyframeEasingLine} from './TimelineKeyframeEasingLine';
 import {
+	ENABLE_OUTLINES,
 	getTimelineSelectedTrackHighlightStyle,
 	useTimelineRowSelection,
 } from './TimelineSelection';
@@ -27,7 +28,9 @@ const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
 }> = ({height, keyframes, nodePathInfo, showSeparator}) => {
 	const timelineWidth = useContext(TimelineWidthContext);
 	const {selected: rowSelected} = useTimelineRowSelection(nodePathInfo);
-	const easingSegments = getTimelineEasingSegments(keyframes);
+	const easingSegments = ENABLE_OUTLINES
+		? getTimelineEasingSegments(keyframes)
+		: [];
 
 	return (
 		<>

--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -1,8 +1,10 @@
 import React, {useContext} from 'react';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {TIMELINE_ITEM_BORDER_BOTTOM} from '../../helpers/timeline-layout';
+import {getTimelineEasingSegments} from './get-timeline-easing-segments';
 import type {getTimelineKeyframes} from './get-timeline-keyframes';
 import {TimelineKeyframeDiamond} from './TimelineKeyframeDiamond';
+import {TimelineKeyframeEasingLine} from './TimelineKeyframeEasingLine';
 import {
 	getTimelineSelectedTrackHighlightStyle,
 	useTimelineRowSelection,
@@ -25,6 +27,7 @@ const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
 }> = ({height, keyframes, nodePathInfo, showSeparator}) => {
 	const timelineWidth = useContext(TimelineWidthContext);
 	const {selected: rowSelected} = useTimelineRowSelection(nodePathInfo);
+	const easingSegments = getTimelineEasingSegments(keyframes);
 
 	return (
 		<>
@@ -33,6 +36,16 @@ const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
 				{rowSelected && timelineWidth !== null ? (
 					<div style={getTimelineSelectedTrackHighlightStyle(timelineWidth)} />
 				) : null}
+				{easingSegments.map((segment) => (
+					<TimelineKeyframeEasingLine
+						key={`${segment.segmentIndex}-${segment.fromFrame}-${segment.toFrame}`}
+						fromFrame={segment.fromFrame}
+						toFrame={segment.toFrame}
+						rowHeight={height}
+						nodePathInfo={nodePathInfo}
+						segmentIndex={segment.segmentIndex}
+					/>
+				))}
 				{keyframes.map((keyframe) => (
 					<TimelineKeyframeDiamond
 						key={keyframe.frame}

--- a/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
@@ -46,7 +46,6 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 
 		return {
 			...diamondBase,
-			cursor: 'pointer',
 			left:
 				getXPositionOfItemInTimelineImperatively(
 					frame,

--- a/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
@@ -71,7 +71,6 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 
 		return {
 			...easingLineButton,
-			cursor: selectable ? 'pointer' : 'default',
 			left,
 			pointerEvents: selectable ? 'auto' : 'none',
 			top: rowHeight / 2,
@@ -89,7 +88,7 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 	const lineStyle = useMemo(
 		(): React.CSSProperties => ({
 			...easingLine,
-			outline: selected ? `1.5px solid ${BLUE}` : undefined,
+			outline: selected ? `1px solid ${BLUE}` : undefined,
 		}),
 		[selected],
 	);

--- a/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
@@ -1,0 +1,132 @@
+import React, {useCallback, useContext, useMemo} from 'react';
+import {useVideoConfig} from 'remotion';
+import {BLUE, LINE_COLOR} from '../../helpers/colors';
+import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
+import {useTimelineEasingSelection} from './TimelineSelection';
+import {TimelineWidthContext} from './TimelineWidthProvider';
+
+const hitTargetHeight = 12;
+const lineHeight = 2;
+
+const easingLineButton: React.CSSProperties = {
+	background: 'none',
+	border: 'none',
+	height: hitTargetHeight,
+	padding: 0,
+	position: 'absolute',
+	transform: 'translateY(-50%)',
+};
+
+const easingLine: React.CSSProperties = {
+	backgroundColor: LINE_COLOR,
+	borderRadius: lineHeight / 2,
+	height: lineHeight,
+	left: 0,
+	position: 'absolute',
+	right: 0,
+	top: '50%',
+	transform: 'translateY(-50%)',
+};
+
+const TimelineKeyframeEasingLineUnmemoized: React.FC<{
+	readonly fromFrame: number;
+	readonly toFrame: number;
+	readonly rowHeight: number;
+	readonly nodePathInfo: SequenceNodePathInfo;
+	readonly segmentIndex: number;
+}> = ({fromFrame, toFrame, rowHeight, nodePathInfo, segmentIndex}) => {
+	const videoConfig = useVideoConfig();
+	const timelineWidth = useContext(TimelineWidthContext);
+	const {selected, onSelect, selectable} = useTimelineEasingSelection({
+		nodePathInfo,
+		fromFrame,
+		toFrame,
+		segmentIndex,
+	});
+
+	const style = useMemo((): React.CSSProperties | null => {
+		if (timelineWidth === null) {
+			return null;
+		}
+
+		const fromLeft =
+			getXPositionOfItemInTimelineImperatively(
+				fromFrame,
+				videoConfig.durationInFrames,
+				timelineWidth,
+			) - TIMELINE_PADDING;
+		const toLeft =
+			getXPositionOfItemInTimelineImperatively(
+				toFrame,
+				videoConfig.durationInFrames,
+				timelineWidth,
+			) - TIMELINE_PADDING;
+		const left = Math.min(fromLeft, toLeft);
+		const width = Math.abs(toLeft - fromLeft);
+		if (width === 0) {
+			return null;
+		}
+
+		return {
+			...easingLineButton,
+			cursor: selectable ? 'pointer' : 'default',
+			left,
+			pointerEvents: selectable ? 'auto' : 'none',
+			top: rowHeight / 2,
+			width,
+		};
+	}, [
+		fromFrame,
+		rowHeight,
+		selectable,
+		timelineWidth,
+		toFrame,
+		videoConfig.durationInFrames,
+	]);
+
+	const lineStyle = useMemo(
+		(): React.CSSProperties => ({
+			...easingLine,
+			outline: selected ? `1.5px solid ${BLUE}` : undefined,
+		}),
+		[selected],
+	);
+
+	const onPointerDown = useCallback(
+		(event: React.PointerEvent<HTMLButtonElement>) => {
+			if (!selectable || event.button !== 0) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			onSelect({
+				shiftKey: event.shiftKey,
+				toggleKey: event.metaKey || event.ctrlKey,
+			});
+		},
+		[onSelect, selectable],
+	);
+
+	if (style === null) {
+		return null;
+	}
+
+	return (
+		<button
+			type="button"
+			style={style}
+			title={`Easing from frame ${fromFrame} to ${toFrame}`}
+			aria-label={`Select easing from frame ${fromFrame} to ${toFrame}`}
+			onPointerDown={selectable ? onPointerDown : undefined}
+		>
+			<div style={lineStyle} />
+		</button>
+	);
+};
+
+export const TimelineKeyframeEasingLine = React.memo(
+	TimelineKeyframeEasingLineUnmemoized,
+);

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -91,6 +91,12 @@ export type TimelineSelection =
 	| (TimelineSelectionBase & {
 			readonly type: 'keyframe';
 			readonly frame: number;
+	  })
+	| (TimelineSelectionBase & {
+			readonly type: 'easing';
+			readonly fromFrame: number;
+			readonly toFrame: number;
+			readonly segmentIndex: number;
 	  });
 
 export type TimelineSelectionInteraction = {
@@ -341,6 +347,10 @@ const getTimelineSelectionKey = (item: TimelineSelection): string => {
 			return `${timelineNodePathInfoToKey(item.nodePathInfo)}.keyframe.${
 				item.frame
 			}`;
+		case 'easing':
+			return `${timelineNodePathInfoToKey(item.nodePathInfo)}.easing.${
+				item.segmentIndex
+			}.${item.fromFrame}.${item.toFrame}`;
 		default:
 			throw new Error(
 				`Unexpected timeline selection type: ${item satisfies never}`,
@@ -654,6 +664,50 @@ export const useTimelineKeyframeSelection = (
 			frame,
 		}),
 		[nodePathInfo, frame],
+	);
+
+	useEffect(() => {
+		return registerSelectableItem(selectionItem);
+	}, [registerSelectableItem, selectionItem]);
+
+	const selected = isSelected(selectionItem);
+
+	const onSelect = useCallback(
+		(interaction?: TimelineSelectionInteraction) => {
+			selectItem(selectionItem, interaction);
+		},
+		[selectItem, selectionItem],
+	);
+
+	return {
+		onSelect,
+		selectable: canSelect,
+		selected,
+	};
+};
+
+export const useTimelineEasingSelection = ({
+	nodePathInfo,
+	fromFrame,
+	toFrame,
+	segmentIndex,
+}: {
+	readonly nodePathInfo: SequenceNodePathInfo;
+	readonly fromFrame: number;
+	readonly toFrame: number;
+	readonly segmentIndex: number;
+}) => {
+	const {canSelect, isSelected, selectItem, registerSelectableItem} =
+		useTimelineSelection();
+	const selectionItem = useMemo(
+		(): TimelineSelection => ({
+			type: 'easing',
+			nodePathInfo,
+			fromFrame,
+			toFrame,
+			segmentIndex,
+		}),
+		[nodePathInfo, fromFrame, segmentIndex, toFrame],
 	);
 
 	useEffect(() => {

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -178,6 +178,7 @@ export const deleteSelectedTimelineItem = ({
 			]);
 		case 'sequence-prop':
 		case 'sequence-effect-prop':
+		case 'easing':
 			return null;
 		case 'sequence-all-effects':
 			return deleteEffects([
@@ -285,6 +286,7 @@ export const deleteSelectedTimelineItems = ({
 
 		case 'sequence-prop':
 		case 'sequence-effect-prop':
+		case 'easing':
 			return null;
 		case 'sequence-all-effects':
 			return deleteEffects(

--- a/packages/studio/src/components/Timeline/get-timeline-easing-segments.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-easing-segments.ts
@@ -1,0 +1,26 @@
+import type {getTimelineKeyframes} from './get-timeline-keyframes';
+
+export type TimelineEasingSegment = {
+	readonly fromFrame: number;
+	readonly toFrame: number;
+	readonly segmentIndex: number;
+};
+
+export const getTimelineEasingSegments = (
+	keyframes: ReturnType<typeof getTimelineKeyframes>,
+): TimelineEasingSegment[] => {
+	return keyframes.flatMap((keyframe, index) => {
+		const nextKeyframe = keyframes[index + 1];
+		if (!nextKeyframe) {
+			return [];
+		}
+
+		return [
+			{
+				fromFrame: keyframe.frame,
+				toFrame: nextKeyframe.frame,
+				segmentIndex: index,
+			},
+		];
+	});
+};

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -7,6 +7,7 @@ import type {
 import {Internals, type PropStatuses} from 'remotion';
 import {getBoundedKeyframeDragDelta} from '../components/Timeline/get-bounded-keyframe-drag-delta';
 import {getNodeKeyframes} from '../components/Timeline/get-node-keyframes';
+import {getTimelineEasingSegments} from '../components/Timeline/get-timeline-easing-segments';
 import {getTimelineKeyframes} from '../components/Timeline/get-timeline-keyframes';
 import {getTimelineKeyframeDragKey} from '../components/Timeline/TimelineKeyframeDragState';
 import {calculateTimeline} from '../helpers/calculate-timeline';
@@ -226,6 +227,23 @@ test('keyframe display offsets follow the parent sequence context', () => {
 	).toEqual([
 		{frame: 30, value: 2},
 		{frame: 90, value: 4},
+	]);
+});
+
+test('timeline easing segments connect adjacent display keyframes', () => {
+	const status: CanUpdateSequencePropStatusKeyframed = {
+		...makeKeyframedStatus(),
+		keyframes: [
+			{frame: 0, value: 2},
+			{frame: 30, value: 3},
+			{frame: 60, value: 4},
+		],
+		easing: ['linear', 'linear'],
+	};
+
+	expect(getTimelineEasingSegments(getTimelineKeyframes(status, 30))).toEqual([
+		{fromFrame: 30, toFrame: 60, segmentIndex: 0},
+		{fromFrame: 60, toFrame: 90, segmentIndex: 1},
 	]);
 });
 

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -2021,6 +2021,36 @@ test('Shift+click with no matching anchor falls back to single selection', () =>
 	});
 });
 
+test('Selecting an easing segment replaces keyframe selection with the new type', () => {
+	const keyframe = {
+		type: 'keyframe' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], []),
+		frame: 10,
+	};
+	const easing = {
+		type: 'easing' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], []),
+		fromFrame: 10,
+		toFrame: 20,
+		segmentIndex: 0,
+	};
+
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [keyframe],
+				anchor: keyframe,
+			},
+			clickedItem: easing,
+			interaction: {shiftKey: false, toggleKey: false},
+			allSelectableItems: [keyframe, easing],
+		}),
+	).toEqual({
+		selectedItems: [easing],
+		anchor: easing,
+	});
+});
+
 test('Timeline double-click actions ignore selection modifier clicks', () => {
 	expect(
 		isTimelineSelectionModifierEvent({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #8206

## Summary
- Draw subtle 2px easing lines between adjacent keyframe diamonds in expanded Studio timeline rows.
- Add `easing` as a selectable timeline item type with selected blue outline styling.
- Keep deletion/reset/duplication behavior as no-op for easing selections for now.

## Walkthrough
<a href="https://cursor.com/agents/bc-cce2d532-814b-4f01-8153-71babcee3e9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_timeline_easing_line_clean_demo.mp4"><img src="https://cursor.com/artifacts/c/art-dfe170b2-7eb6-48cd-ad7d-0f8552df9fe8" alt="studio_timeline_easing_line_clean_demo.mp4" /></a>
![Studio timeline easing line](https://cursor.com/artifacts/c/art-f32a73cb-612a-4ea3-a044-dd25d5a27ef2)

## Validation
- `bun test src/test/timeline-keyframes.test.ts src/test/timeline-selection.test.ts`
- `bunx turbo run make test lint --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck` (expected VM limitation: `@remotion/lambda-go` requires Go >= 1.23; VM has Go 1.22.2)
- Manual Studio validation via the `keyframed-props-test` composition; the VM-specific WebGL error overlay was hidden to expose the timeline UI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cce2d532-814b-4f01-8153-71babcee3e9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cce2d532-814b-4f01-8153-71babcee3e9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

