### PR TITLE
Fix invalid YAML in issue management skill

### DIFF
--- a/.agents/skills/issue-management/SKILL.md
+++ b/.agents/skills/issue-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-management
-description: Manage GitHub Issues 2.0 relationships with gh CLI: parent issues, sub-issues, blocked-by, and blocking links.
+description: "Manage GitHub Issues 2.0 relationships with gh CLI: parent issues, sub-issues, blocked-by, and blocking links."
 ---
 
 Use this skill when creating, editing, inspecting, or removing relationships between GitHub issues.


### PR DESCRIPTION
## Summary

- Quote the issue management skill description so its YAML frontmatter can be parsed.
- Keep the skill description and behavior unchanged.

## Validation

- Codex skill validator (`quick_validate.py .agents/skills/issue-management`): `Skill is valid!`
- `bun run build`
- `git diff --check`

## Notes

- `bun run stylecheck` currently reports existing formatting mismatches in unrelated packages. This change only modifies `.agents/skills/issue-management/SKILL.md`.
