### PR TITLE
`@remotion/studio`: Keep UV controls above outlines

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1810,27 +1810,45 @@ const SelectedOutlineElement: React.FC<{
 						/>
 					))
 				: null}
-			{target?.selected
-				? (() => {
-						const {uvHandles} = target;
-						return (
-							<>
-								<SelectedUvHandleConnectionLines
-									handles={uvHandles}
-									outline={outline}
-								/>
-								{uvHandles.map((handle) => (
-									<SelectedUvHandleCircle
-										key={`${handle.effectIndex}-${handle.fieldKey}`}
-										handle={handle}
-										onDraggingChange={onDraggingChange}
-										outline={outline}
-									/>
-								))}
-							</>
-						);
-					})()
-				: null}
+		</>
+	);
+};
+
+const SelectedOutlineUvHandleConnectionLayer: React.FC<{
+	readonly outline: SelectedOutline;
+	readonly target: SelectedOutlineTarget | undefined;
+}> = ({outline, target}) => {
+	if (!target?.selected || target.uvHandles.length === 0) {
+		return null;
+	}
+
+	return (
+		<SelectedUvHandleConnectionLines
+			handles={target.uvHandles}
+			outline={outline}
+		/>
+	);
+};
+
+const SelectedOutlineUvHandleCircleLayer: React.FC<{
+	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly outline: SelectedOutline;
+	readonly target: SelectedOutlineTarget | undefined;
+}> = ({onDraggingChange, outline, target}) => {
+	if (!target?.selected || target.uvHandles.length === 0) {
+		return null;
+	}
+
+	return (
+		<>
+			{target.uvHandles.map((handle) => (
+				<SelectedUvHandleCircle
+					key={`${handle.effectIndex}-${handle.fieldKey}`}
+					handle={handle}
+					onDraggingChange={onDraggingChange}
+					outline={outline}
+				/>
+			))}
 		</>
 	);
 };
@@ -2063,6 +2081,22 @@ export const SelectedOutlineOverlay: React.FC<{
 					onHoverChange={setHoveredOutlineKey}
 					onSelect={selectItem}
 					scale={scale}
+					target={targetsByKey.get(outline.key)}
+				/>
+			))}
+			{/* Keep UV controls above every transparent outline polygon so SVG hit-testing reaches the handles first. */}
+			{outlines.map((outline) => (
+				<SelectedOutlineUvHandleConnectionLayer
+					key={`${outline.key}-uv-connection-lines`}
+					outline={outline}
+					target={targetsByKey.get(outline.key)}
+				/>
+			))}
+			{outlines.map((outline) => (
+				<SelectedOutlineUvHandleCircleLayer
+					key={`${outline.key}-uv-handles`}
+					onDraggingChange={onDraggingChange}
+					outline={outline}
 					target={targetsByKey.get(outline.key)}
 				/>
 			))}


### PR DESCRIPTION
## Summary

- Render selected UV handle connection lines and circles in top-level SVG layers after all outline polygons.
- Keep UV handle circles above transparent outline hit targets so pointer events reach the handles first.

Fixes #8214.

## Testing

- `cd packages/studio && bun test src/test/timeline-selection.test.ts`
- `bunx turbo make --filter="@remotion/studio"`
- `cd packages/studio && bun run lint && bun run formatting`
- `cd packages/studio && bun run test`
- `bun run build && bun run stylecheck`
