### PR TITLE
`@remotion/studio`: Fix sequence reorder drop handling

### DIFF
--- a/packages/example/e2e/sequence-reorder.test.mts
+++ b/packages/example/e2e/sequence-reorder.test.mts
@@ -1,0 +1,89 @@
+import {expect, test, type Page} from '@playwright/test';
+import {STUDIO_URL} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+const effectDragError = 'Could not read effect drag data';
+
+const dropOnTimelineRow = async ({
+	page,
+	title,
+	data,
+}: {
+	readonly page: Page;
+	readonly title: string;
+	readonly data: Record<string, string>;
+}) => {
+	await page
+		.locator(`[title="${title}"]`)
+		.first()
+		.evaluate((element, dropData) => {
+			const timelineRow = element.parentElement?.parentElement?.parentElement;
+			if (!timelineRow) {
+				throw new Error('Could not find timeline row');
+			}
+
+			const dataTransfer = new DataTransfer();
+			for (const [type, value] of Object.entries(dropData)) {
+				dataTransfer.setData(type, value);
+			}
+
+			timelineRow.dispatchEvent(
+				new DragEvent('drop', {
+					bubbles: true,
+					cancelable: true,
+					dataTransfer,
+				}),
+			);
+		}, data);
+};
+
+test.describe('sequence reorder', () => {
+	test.beforeEach(async () => {
+		await startStudio();
+	});
+
+	test.afterEach(async () => {
+		await stopStudio();
+	});
+
+	test('does not parse sequence reorder data as effect drag data', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/issue-8216`);
+		await expect(page).toHaveURL(/issue-8216/, {timeout: 15_000});
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+
+		await expect(page.locator('[title="Background"]').first()).toBeVisible({
+			timeout: 15_000,
+		});
+
+		await dropOnTimelineRow({
+			page,
+			title: 'Background',
+			data: {
+				'text/plain': 'not effect drag data',
+			},
+		});
+		await expect(page.getByText(effectDragError)).toBeVisible({timeout: 5_000});
+		await expect(page.getByText(effectDragError)).toBeHidden({timeout: 5_000});
+
+		await dropOnTimelineRow({
+			page,
+			title: 'Background',
+			data: {
+				'application/remotion-sequence-reorder': JSON.stringify({
+					nodePath: {nodePath: [0]},
+					nodePathKey: 'source',
+					trackIndex: 0,
+					parentId: null,
+					fileName: 'Issue8216.tsx',
+				}),
+			},
+		});
+
+		await expect(page.getByText(effectDragError)).toBeHidden();
+	});
+});

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Composition, Folder} from 'remotion';
 import {ErrorOverlayRepro} from './ErrorOverlayE2e/ErrorOverlayRepro';
 import {HookOrderChangeE2e} from './HookOrderChangeE2e/HookOrderChangeRepro';
+import {Issue8216} from './Issue8216/Issue8216';
 import {LostNodePathRepro} from './LostNodePathE2e/LostNodePathRepro';
 import {NewVideoComp} from './NewVideo';
 import {SchemaTest, schemaTestSchema} from './SchemaTest';
@@ -70,6 +71,14 @@ export const E2eTestRoot: React.FC = () => {
 			<Folder name="hook-order-change">
 				<HookOrderChangeE2e />
 			</Folder>
+			<Composition
+				id="issue-8216"
+				component={Issue8216}
+				width={1280}
+				height={720}
+				fps={30}
+				durationInFrames={90}
+			/>
 			<NewVideoComp />
 		</>
 	);

--- a/packages/example/src/Issue8216/Issue8216.tsx
+++ b/packages/example/src/Issue8216/Issue8216.tsx
@@ -1,0 +1,28 @@
+import {Solid} from 'remotion';
+
+export const Issue8216 = () => {
+	return (
+		<>
+			<Solid
+				name="Foreground"
+				width={200}
+				height={200}
+				color="#0b84ff"
+				style={{
+					position: 'absolute',
+					translate: '172.4px 83.1px',
+				}}
+			/>
+			<Solid
+				name="Background"
+				width={1280}
+				height={720}
+				color="#ffffff"
+				style={{
+					position: 'absolute',
+					translate: '0.2px 0px',
+				}}
+			/>
+		</>
+	);
+};

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1810,27 +1810,45 @@ const SelectedOutlineElement: React.FC<{
 						/>
 					))
 				: null}
-			{target?.selected
-				? (() => {
-						const {uvHandles} = target;
-						return (
-							<>
-								<SelectedUvHandleConnectionLines
-									handles={uvHandles}
-									outline={outline}
-								/>
-								{uvHandles.map((handle) => (
-									<SelectedUvHandleCircle
-										key={`${handle.effectIndex}-${handle.fieldKey}`}
-										handle={handle}
-										onDraggingChange={onDraggingChange}
-										outline={outline}
-									/>
-								))}
-							</>
-						);
-					})()
-				: null}
+		</>
+	);
+};
+
+const SelectedOutlineUvHandleConnectionLayer: React.FC<{
+	readonly outline: SelectedOutline;
+	readonly target: SelectedOutlineTarget | undefined;
+}> = ({outline, target}) => {
+	if (!target?.selected || target.uvHandles.length === 0) {
+		return null;
+	}
+
+	return (
+		<SelectedUvHandleConnectionLines
+			handles={target.uvHandles}
+			outline={outline}
+		/>
+	);
+};
+
+const SelectedOutlineUvHandleCircleLayer: React.FC<{
+	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly outline: SelectedOutline;
+	readonly target: SelectedOutlineTarget | undefined;
+}> = ({onDraggingChange, outline, target}) => {
+	if (!target?.selected || target.uvHandles.length === 0) {
+		return null;
+	}
+
+	return (
+		<>
+			{target.uvHandles.map((handle) => (
+				<SelectedUvHandleCircle
+					key={`${handle.effectIndex}-${handle.fieldKey}`}
+					handle={handle}
+					onDraggingChange={onDraggingChange}
+					outline={outline}
+				/>
+			))}
 		</>
 	);
 };
@@ -2063,6 +2081,22 @@ export const SelectedOutlineOverlay: React.FC<{
 					onHoverChange={setHoveredOutlineKey}
 					onSelect={selectItem}
 					scale={scale}
+					target={targetsByKey.get(outline.key)}
+				/>
+			))}
+			{/* Keep UV controls above every transparent outline polygon so SVG hit-testing reaches the handles first. */}
+			{outlines.map((outline) => (
+				<SelectedOutlineUvHandleConnectionLayer
+					key={`${outline.key}-uv-connection-lines`}
+					outline={outline}
+					target={targetsByKey.get(outline.key)}
+				/>
+			))}
+			{outlines.map((outline) => (
+				<SelectedOutlineUvHandleCircleLayer
+					key={`${outline.key}-uv-handles`}
+					onDraggingChange={onDraggingChange}
+					outline={outline}
 					target={targetsByKey.get(outline.key)}
 				/>
 			))}

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -112,6 +112,12 @@ const hasSequenceReorderDragType = (dataTransfer: DataTransfer) => {
 	return Array.from(dataTransfer.types).includes(SEQUENCE_REORDER_MIME_TYPE);
 };
 
+const isSequenceReorderDrag = (dataTransfer: DataTransfer) => {
+	return (
+		currentSequenceDrag !== null || hasSequenceReorderDragType(dataTransfer)
+	);
+};
+
 const getSequenceReorderDragData = (
 	dataTransfer: DataTransfer,
 ): SequenceReorderDragData | null => {
@@ -835,7 +841,11 @@ export const TimelineSequenceItem: React.FC<{
 
 	const onEffectDragOver = useCallback(
 		(e: React.DragEvent<HTMLDivElement>) => {
-			if (!canDropEffect || !hasEffectDragType(e.dataTransfer)) {
+			if (
+				!canDropEffect ||
+				isSequenceReorderDrag(e.dataTransfer) ||
+				!hasEffectDragType(e.dataTransfer)
+			) {
 				return;
 			}
 
@@ -863,7 +873,9 @@ export const TimelineSequenceItem: React.FC<{
 				!canDropEffect ||
 				previewServerState.type !== 'connected' ||
 				nodePath === null ||
-				validatedLocation === null
+				validatedLocation === null ||
+				isSequenceReorderDrag(e.dataTransfer) ||
+				!hasEffectDragType(e.dataTransfer)
 			) {
 				return;
 			}


### PR DESCRIPTION
## Summary
- Prevent sequence-reorder drag/drop payloads from being handled as effect drops in the timeline
- Add an E2E regression fixture for issue #8216
- Verify invalid effect drops still hit the effect-drop handler while sequence-reorder payloads do not show the effect-data error

Fixes #8216.

## Tests
- `bunx turbo make --filter="@remotion/studio"`
- `cd packages/example && bunx playwright test e2e/sequence-reorder.test.mts --project=chromium`
- `bun run build`
- `bun run stylecheck`
