### PR TITLE
`@remotion/studio`: Allow dragging effects onto canvas outlines

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -24,6 +24,11 @@ import {openOriginalPositionInEditor} from '../helpers/open-in-editor';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ScaleLockContext} from '../state/scale-lock';
 import {ContextMenuForTarget} from './ContextMenu';
+import {
+	addEffectFromDragData,
+	getEffectDragData,
+	hasEffectDragType,
+} from './effect-drag-and-drop';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
 import {callAddSequenceKeyframe} from './Timeline/call-add-keyframe';
@@ -103,6 +108,7 @@ type SelectedOutlineContextMenuOpenHandler = () =>
 type SelectedOutlineTarget = {
 	readonly key: string;
 	readonly containsSelection: boolean;
+	readonly effectDrop: SelectedOutlineEffectDropTarget | null;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly ref: React.RefObject<Element | null>;
 	readonly selected: boolean;
@@ -111,6 +117,12 @@ type SelectedOutlineTarget = {
 	readonly drag: SelectedOutlineDragTarget | null;
 	readonly scaleDrag: SelectedOutlineScaleDragTarget | null;
 	readonly uvHandles: readonly SelectedOutlineUvHandle[];
+};
+
+type SelectedOutlineEffectDropTarget = {
+	readonly clientId: string;
+	readonly fileName: string;
+	readonly nodePath: SequencePropsSubscriptionKey;
 };
 
 type SelectedOutlineDragTarget = {
@@ -1106,6 +1118,8 @@ const SelectedOutlinePolygon: React.FC<{
 	const drag = target?.drag ?? null;
 	const selected = target?.selected ?? false;
 	const containsSelection = target?.containsSelection ?? false;
+	const effectDrop = target?.effectDrop ?? null;
+	const [effectDropHovered, setEffectDropHovered] = useState(false);
 	const visible = containsSelection || hovered;
 
 	const onPointerDown = React.useCallback(
@@ -1258,14 +1272,66 @@ const SelectedOutlinePolygon: React.FC<{
 			target,
 		],
 	);
+
+	const onEffectDragOver = React.useCallback(
+		(event: React.DragEvent<SVGPolygonElement>) => {
+			if (effectDrop === null || !hasEffectDragType(event.dataTransfer)) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			event.dataTransfer.dropEffect = 'copy';
+			setEffectDropHovered(true);
+		},
+		[effectDrop],
+	);
+
+	const onEffectDragLeave = React.useCallback(
+		(event: React.DragEvent<SVGPolygonElement>) => {
+			if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+				return;
+			}
+
+			setEffectDropHovered(false);
+		},
+		[],
+	);
+
+	const onEffectDrop = React.useCallback(
+		async (event: React.DragEvent<SVGPolygonElement>) => {
+			if (effectDrop === null || !hasEffectDragType(event.dataTransfer)) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			setEffectDropHovered(false);
+
+			const dragData = getEffectDragData(event.dataTransfer);
+			if (!dragData) {
+				showNotification('Could not read effect drag data', 3000);
+				return;
+			}
+
+			await addEffectFromDragData({
+				dragData,
+				fileName: effectDrop.fileName,
+				nodePath: effectDrop.nodePath,
+				clientId: effectDrop.clientId,
+			});
+		},
+		[effectDrop],
+	);
+
 	return (
 		<>
 			<polygon
 				ref={polygonRef}
 				points={points}
-				fill="transparent"
+				fill={effectDropHovered ? 'rgba(0, 155, 255, 0.12)' : 'transparent'}
 				stroke={BLUE}
-				strokeOpacity={visible ? 1 : 0}
+				strokeOpacity={visible || effectDropHovered ? 1 : 0}
 				strokeWidth={2}
 				vectorEffect="non-scaling-stroke"
 				pointerEvents={target === undefined ? undefined : 'all'}
@@ -1280,6 +1346,9 @@ const SelectedOutlinePolygon: React.FC<{
 					}
 				}}
 				onPointerDown={onPointerDown}
+				onDragOver={effectDrop === null ? undefined : onEffectDragOver}
+				onDragLeave={effectDrop === null ? undefined : onEffectDragLeave}
+				onDrop={effectDrop === null ? undefined : onEffectDrop}
 			/>
 			<ContextMenuForTarget
 				triggerRef={polygonRef}
@@ -1935,10 +2004,20 @@ export const SelectedOutlineOverlay: React.FC<{
 				controls !== null &&
 				scaleFieldSchema?.type === 'scale' &&
 				scalePropStatus?.status === 'static';
+			const canDropEffect =
+				previewServerState.type === 'connected' &&
+				controls?.supportsEffects === true;
 
 			return {
 				key,
 				containsSelection,
+				effectDrop: canDropEffect
+					? {
+							clientId: previewServerState.clientId,
+							fileName: nodePath.absolutePath,
+							nodePath,
+						}
+					: null,
 				nodePathInfo,
 				ref: sequence.refForOutline,
 				selected,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -1,9 +1,4 @@
-import {
-	EFFECT_DRAG_MIME_TYPE,
-	getRequiredPackageForEffectImportPath,
-	parseEffectDragData,
-	type ReorderSequencePosition,
-} from '@remotion/studio-shared';
+import {type ReorderSequencePosition} from '@remotion/studio-shared';
 import React, {useCallback, useContext, useMemo, useState} from 'react';
 import type {SequencePropsSubscriptionKey, TSequence} from 'remotion';
 import {Internals} from 'remotion';
@@ -11,7 +6,6 @@ import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {formatFileLocation} from '../../helpers/format-file-location';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
-import {installRequiredPackages} from '../../helpers/install-required-package';
 import {
 	getTimelineLayerHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
@@ -20,6 +14,11 @@ import {
 import {callApi} from '../call-api';
 import {useConfirmationDialog} from '../ConfirmationDialog';
 import {ContextMenu} from '../ContextMenu';
+import {
+	addEffectFromDragData,
+	getEffectDragData,
+	hasEffectDragType,
+} from '../effect-drag-and-drop';
 import {
 	ExpandedTracksGetterContext,
 	ExpandedTracksSetterContext,
@@ -169,35 +168,6 @@ type SequenceDropTarget =
 			readonly type: 'invalid';
 			readonly reason: string;
 	  };
-
-const hasEffectDragType = (dataTransfer: DataTransfer) => {
-	return Array.from(dataTransfer.types).some(
-		(type) =>
-			type === EFFECT_DRAG_MIME_TYPE ||
-			type === 'application/json' ||
-			type === 'text/plain',
-	);
-};
-
-const getEffectDragData = (dataTransfer: DataTransfer) => {
-	for (const type of [
-		EFFECT_DRAG_MIME_TYPE,
-		'application/json',
-		'text/plain',
-	]) {
-		const value = dataTransfer.getData(type);
-		if (!value) {
-			continue;
-		}
-
-		const parsed = parseEffectDragData(value);
-		if (parsed) {
-			return parsed;
-		}
-	}
-
-	return null;
-};
 
 export const TimelineSequenceItem: React.FC<{
 	readonly sequence: TSequence;
@@ -890,29 +860,12 @@ export const TimelineSequenceItem: React.FC<{
 				return;
 			}
 
-			try {
-				const requiredPackage = getRequiredPackageForEffectImportPath(
-					dragData.effect.importPath,
-				);
-				await installRequiredPackages(requiredPackage ? [requiredPackage] : []);
-
-				const result = await callApi('/api/add-effect', {
-					fileName: validatedLocation.source,
-					sequenceNodePath: nodePath,
-					effectName: dragData.effect.name,
-					effectImportPath: dragData.effect.importPath,
-					effectConfig: dragData.effect.config,
-					clientId: previewServerState.clientId,
-				});
-
-				if (result.success) {
-					showNotification(`Added ${dragData.effect.name}()`, 2000);
-				} else {
-					showNotification(result.reason, 4000);
-				}
-			} catch (err) {
-				showNotification((err as Error).message, 4000);
-			}
+			await addEffectFromDragData({
+				dragData,
+				fileName: validatedLocation.source,
+				nodePath,
+				clientId: previewServerState.clientId,
+			});
 		},
 		[canDropEffect, nodePath, previewServerState, validatedLocation],
 	);

--- a/packages/studio/src/components/effect-drag-and-drop.ts
+++ b/packages/studio/src/components/effect-drag-and-drop.ts
@@ -1,0 +1,77 @@
+import {
+	EFFECT_DRAG_MIME_TYPE,
+	getRequiredPackageForEffectImportPath,
+	parseEffectDragData,
+	type EffectDragData,
+} from '@remotion/studio-shared';
+import type {SequencePropsSubscriptionKey} from 'remotion';
+import {installRequiredPackages} from '../helpers/install-required-package';
+import {callApi} from './call-api';
+import {showNotification} from './Notifications/NotificationCenter';
+
+export const hasEffectDragType = (dataTransfer: DataTransfer) => {
+	return Array.from(dataTransfer.types).some(
+		(type) =>
+			type === EFFECT_DRAG_MIME_TYPE ||
+			type === 'application/json' ||
+			type === 'text/plain',
+	);
+};
+
+export const getEffectDragData = (
+	dataTransfer: DataTransfer,
+): EffectDragData | null => {
+	for (const type of [
+		EFFECT_DRAG_MIME_TYPE,
+		'application/json',
+		'text/plain',
+	]) {
+		const value = dataTransfer.getData(type);
+		if (!value) {
+			continue;
+		}
+
+		const parsed = parseEffectDragData(value);
+		if (parsed) {
+			return parsed;
+		}
+	}
+
+	return null;
+};
+
+export const addEffectFromDragData = async ({
+	clientId,
+	dragData,
+	fileName,
+	nodePath,
+}: {
+	readonly clientId: string;
+	readonly dragData: EffectDragData;
+	readonly fileName: string;
+	readonly nodePath: SequencePropsSubscriptionKey;
+}) => {
+	try {
+		const requiredPackage = getRequiredPackageForEffectImportPath(
+			dragData.effect.importPath,
+		);
+		await installRequiredPackages(requiredPackage ? [requiredPackage] : []);
+
+		const result = await callApi('/api/add-effect', {
+			fileName,
+			sequenceNodePath: nodePath,
+			effectName: dragData.effect.name,
+			effectImportPath: dragData.effect.importPath,
+			effectConfig: dragData.effect.config,
+			clientId,
+		});
+
+		if (result.success) {
+			showNotification(`Added ${dragData.effect.name}()`, 2000);
+		} else {
+			showNotification(result.reason, 4000);
+		}
+	} catch (err) {
+		showNotification((err as Error).message, 4000);
+	}
+};


### PR DESCRIPTION
## Summary

- Allow effect drag payloads to be dropped onto canvas layer outlines.
- Share the timeline effect-drop parsing/add-effect flow so both drop targets install required packages and show the same notifications.

Fixes #8175

## Testing

- `cd packages/studio && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
