### PR TITLE
`@remotion/studio-server`: Omit absolute positioning for audio insertions

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -859,11 +859,13 @@ const createComponentElement = ({
 };
 
 const createAssetElement = ({
+	addPositionStyle,
 	localName,
 	staticFileLocalName,
 	src,
 	dimensions,
 }: {
+	addPositionStyle: boolean;
 	localName: string;
 	staticFileLocalName: string | null;
 	src: string;
@@ -876,7 +878,7 @@ const createAssetElement = ({
 				staticFileLocalName === null
 					? createStringSrcAttribute(src)
 					: createStaticFileSrcAttribute({staticFileLocalName, src}),
-				createPositionAbsoluteStyleAttribute(),
+				...(addPositionStyle ? [createPositionAbsoluteStyleAttribute()] : []),
 				...(dimensions
 					? [
 							createNumberAttribute('width', dimensions.width),
@@ -1608,6 +1610,7 @@ const createInsertableJsxElement = ({
 		}
 
 		return createAssetElement({
+			addPositionStyle: element.assetType !== 'audio',
 			localName,
 			staticFileLocalName,
 			src: element.src,

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -864,6 +864,7 @@ test('inserts an Audio asset into the resolved composition component', async () 
 		);
 		expect(result.output).toContain('<Audio');
 		expect(result.output).toContain("src={staticFile('audio.mp3')}");
+		expect(result.output).not.toContain("position: 'absolute'");
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}
@@ -915,6 +916,7 @@ test('inserts a remote audio asset with a literal URL', async () => {
 		expect(result.output).toContain('src="https://example.com/whip.wav"');
 		expect(result.output).not.toContain('staticFile');
 		expect(result.output).not.toContain('@remotion/sfx');
+		expect(result.output).not.toContain("position: 'absolute'");
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}


### PR DESCRIPTION
Fixes #8212.

## Summary

- Omit `style={{position: "absolute"}}` when inserting audio assets into compositions
- Keep absolute positioning for visual assets and components
- Add regression coverage for static and remote audio insertions

## Testing

- `bunx turbo run make --filter="@remotion/studio-server"`
- `bunx turbo run test --filter="@remotion/studio-server"`
- `bun run build`
- `bun run stylecheck`
