### PR TITLE
`@remotion/studio`: Add keyframe easing controls

### DIFF
--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -384,7 +384,7 @@ const getKeyframeEasingArray = ({
 	}
 
 	if (easingNode.type === 'ArrayExpression') {
-		if (easingNode.elements.length !== segmentCount) {
+		if (easingNode.elements.length > segmentCount) {
 			return null;
 		}
 
@@ -400,7 +400,12 @@ const getKeyframeEasingArray = ({
 			return null;
 		}
 
-		return parsed as KeyframeEasing[];
+		const easingArray = parsed as KeyframeEasing[];
+		while (easingArray.length < segmentCount) {
+			easingArray.push('linear');
+		}
+
+		return easingArray;
 	}
 
 	const easing = getKeyframeEasing(easingNode);
@@ -434,6 +439,21 @@ const getExistingEasingArray = ({
 	return easing;
 };
 
+const getExistingEasingArrayOrNull = ({
+	options,
+	segmentCount,
+}: {
+	options: ObjectExpression;
+	segmentCount: number;
+}): KeyframeEasing[] | null => {
+	const {prop} = findObjectOptionProperty(options, 'easing');
+	if (!prop) {
+		return null;
+	}
+
+	return getExistingEasingArray({options, segmentCount});
+};
+
 const createEasingExpression = (easing: KeyframeEasing): ExpressionKind => {
 	if (easing === 'linear') {
 		return b.memberExpression(
@@ -454,6 +474,129 @@ const createEasingArrayExpression = (
 	b.arrayExpression(
 		easing.map((easingValue) => createEasingExpression(easingValue)) as never,
 	) as ExpressionKind;
+
+const setEasingOption = ({
+	options,
+	easing,
+}: {
+	options: ObjectExpression;
+	easing: KeyframeEasing[];
+}): boolean => {
+	const hasNonLinearEasing = easing.some(
+		(easingValue) => !isLinearEasing(easingValue),
+	);
+	setOptionsProperty({
+		options,
+		propertyName: 'easing',
+		value: hasNonLinearEasing ? createEasingArrayExpression(easing) : null,
+	});
+	return hasNonLinearEasing;
+};
+
+const getExtraArgsWithOptions = ({
+	extraArgs,
+	options,
+}: {
+	extraArgs: (ExpressionKind | SpreadElementKind)[];
+	options: ObjectExpression;
+}): (ExpressionKind | SpreadElementKind)[] => {
+	return options.properties.length === 0
+		? extraArgs.slice(1)
+		: [options as ExpressionKind, ...extraArgs.slice(1)];
+};
+
+const getInlineOptionsFromExtraArgs = (
+	extraArgs: (ExpressionKind | SpreadElementKind)[],
+): ObjectExpression | null => {
+	const existingOptions = extraArgs[0];
+	if (!existingOptions || existingOptions.type !== 'ObjectExpression') {
+		return null;
+	}
+
+	return existingOptions as ObjectExpression;
+};
+
+const normalizeEasingAfterAddingKeyframe = ({
+	extraArgs,
+	previousSegmentCount,
+	nextSegmentCount,
+}: {
+	extraArgs: (ExpressionKind | SpreadElementKind)[];
+	previousSegmentCount: number;
+	nextSegmentCount: number;
+}): {
+	extraArgs: (ExpressionKind | SpreadElementKind)[];
+	needsEasingImport: boolean;
+} => {
+	const options = getInlineOptionsFromExtraArgs(extraArgs);
+	if (!options) {
+		return {extraArgs, needsEasingImport: false};
+	}
+
+	const easing = getExistingEasingArrayOrNull({
+		options,
+		segmentCount: previousSegmentCount,
+	});
+	if (easing === null) {
+		return {extraArgs, needsEasingImport: false};
+	}
+
+	while (easing.length < nextSegmentCount) {
+		easing.push('linear');
+	}
+
+	return {
+		extraArgs: getExtraArgsWithOptions({extraArgs, options}),
+		needsEasingImport: setEasingOption({options, easing}),
+	};
+};
+
+const normalizeEasingAfterRemovingKeyframe = ({
+	extraArgs,
+	previousSegmentCount,
+	nextSegmentCount,
+	removedKeyframeIndex,
+}: {
+	extraArgs: (ExpressionKind | SpreadElementKind)[];
+	previousSegmentCount: number;
+	nextSegmentCount: number;
+	removedKeyframeIndex: number;
+}): {
+	extraArgs: (ExpressionKind | SpreadElementKind)[];
+	needsEasingImport: boolean;
+} => {
+	const options = getInlineOptionsFromExtraArgs(extraArgs);
+	if (!options) {
+		return {extraArgs, needsEasingImport: false};
+	}
+
+	const easing = getExistingEasingArrayOrNull({
+		options,
+		segmentCount: previousSegmentCount,
+	});
+	if (easing === null) {
+		return {extraArgs, needsEasingImport: false};
+	}
+
+	if (easing.length > 0) {
+		const easingIndexToRemove =
+			removedKeyframeIndex === 0 ? 0 : removedKeyframeIndex - 1;
+		easing.splice(easingIndexToRemove, 1);
+	}
+
+	while (easing.length > nextSegmentCount) {
+		easing.pop();
+	}
+
+	while (easing.length < nextSegmentCount) {
+		easing.push('linear');
+	}
+
+	return {
+		extraArgs: getExtraArgsWithOptions({extraArgs, options}),
+		needsEasingImport: setEasingOption({options, easing}),
+	};
+};
 
 const validatePosterize = (posterize: number | undefined) => {
 	if (posterize === undefined) {
@@ -683,12 +826,20 @@ const addKeyframe = ({
 							? {frame, output: newOutput, value}
 							: keyframe,
 					);
+		const normalizedEasing =
+			existingIndex === -1
+				? normalizeEasingAfterAddingKeyframe({
+						extraArgs: existing.extraArgs,
+						previousSegmentCount: Math.max(existing.keyframes.length - 1, 0),
+						nextSegmentCount: Math.max(nextKeyframes.length - 1, 0),
+					})
+				: {extraArgs: existing.extraArgs, needsEasingImport: false};
 
 		return {
 			expression: createInterpolateExpression({
 				callee: b.identifier(nextCalleeName),
 				input: existing.input,
-				extraArgs: existing.extraArgs,
+				extraArgs: normalizedEasing.extraArgs,
 				keyframes: nextKeyframes,
 			}),
 			introduced: {
@@ -697,7 +848,7 @@ const addKeyframe = ({
 						? schemaCalleeName
 						: null,
 				needsFrameHook: false,
-				needsEasingImport: false,
+				needsEasingImport: normalizedEasing.needsEasingImport,
 			},
 		};
 	}
@@ -744,7 +895,7 @@ const removeKeyframe = ({
 }: {
 	expression: Expression;
 	frame: number;
-}): ExpressionKind => {
+}): {expression: ExpressionKind; introduced: IntroducedKeyframeIdentifiers} => {
 	const existing = getInterpolationExpression(expression);
 	if (!existing) {
 		throw new Error('Cannot remove keyframe from non-interpolated expression');
@@ -762,15 +913,31 @@ const removeKeyframe = ({
 	);
 
 	if (nextKeyframes.length === 0) {
-		return existing.keyframes[keyframeIndex].output;
+		return {
+			expression: existing.keyframes[keyframeIndex].output,
+			introduced: noIntroducedIdentifiers,
+		};
 	}
 
-	return createInterpolateExpression({
-		callee: existing.callee,
-		input: existing.input,
+	const normalizedEasing = normalizeEasingAfterRemovingKeyframe({
 		extraArgs: existing.extraArgs,
-		keyframes: nextKeyframes,
+		previousSegmentCount: Math.max(existing.keyframes.length - 1, 0),
+		nextSegmentCount: Math.max(nextKeyframes.length - 1, 0),
+		removedKeyframeIndex: keyframeIndex,
 	});
+
+	return {
+		expression: createInterpolateExpression({
+			callee: existing.callee,
+			input: existing.input,
+			extraArgs: normalizedEasing.extraArgs,
+			keyframes: nextKeyframes,
+		}),
+		introduced: {
+			...noIntroducedIdentifiers,
+			needsEasingImport: normalizedEasing.needsEasingImport,
+		},
+	};
 };
 
 const moveKeyframes = ({
@@ -896,10 +1063,7 @@ const applyKeyframeOperation = ({
 		};
 	}
 
-	return {
-		expression: removeKeyframe({expression, frame: operation.frame}),
-		introduced: noIntroducedIdentifiers,
-	};
+	return removeKeyframe({expression, frame: operation.frame});
 };
 
 const getExpressionFromJsxAttribute = (

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -20,6 +20,7 @@ import {
 import type {ExpressionKind, SpreadElementKind} from 'ast-types/lib/gen/kinds';
 import * as recast from 'recast';
 import type {
+	CanUpdateSequencePropStatus,
 	ExtrapolateType,
 	SequenceFieldSchema,
 	SequenceNodePath,
@@ -47,6 +48,11 @@ import {
 
 const b = recast.types.builders;
 
+type KeyframeEasing = Extract<
+	CanUpdateSequencePropStatus,
+	{status: 'keyframed'}
+>['easing'][number];
+
 export type KeyframeOperation =
 	| {
 			type: 'add';
@@ -66,6 +72,11 @@ export type KeyframeOperation =
 				  }
 				| undefined;
 			posterize: number | undefined;
+	  }
+	| {
+			type: 'easing';
+			segmentIndex: number;
+			easing: KeyframeEasing;
 	  }
 	| {
 			type: 'move';
@@ -304,6 +315,146 @@ const setOptionsProperty = ({
 	);
 };
 
+const isLinearEasing = (easing: KeyframeEasing) => easing === 'linear';
+
+const getKeyframeEasing = (node: Expression): KeyframeEasing | null => {
+	if (node.type === 'TSAsExpression') {
+		return getKeyframeEasing(node.expression as Expression);
+	}
+
+	if (
+		node.type === 'MemberExpression' &&
+		node.object.type === 'Identifier' &&
+		node.object.name === 'Easing' &&
+		node.property.type === 'Identifier' &&
+		node.property.name === 'linear' &&
+		node.computed === false
+	) {
+		return 'linear';
+	}
+
+	if (
+		node.type !== 'CallExpression' ||
+		node.callee.type !== 'MemberExpression' ||
+		node.callee.object.type !== 'Identifier' ||
+		node.callee.object.name !== 'Easing' ||
+		node.callee.property.type !== 'Identifier' ||
+		node.callee.property.name !== 'bezier' ||
+		node.callee.computed ||
+		node.arguments.length !== 4
+	) {
+		return null;
+	}
+
+	const values = node.arguments.map((arg) => {
+		if (
+			arg.type === 'ArgumentPlaceholder' ||
+			arg.type === 'JSXNamespacedName' ||
+			arg.type === 'SpreadElement'
+		) {
+			return null;
+		}
+
+		return getNumericValue(arg as Expression);
+	});
+
+	if (values.some((value) => value === null)) {
+		return null;
+	}
+
+	return values as [number, number, number, number];
+};
+
+const getKeyframeEasingArray = ({
+	easingNode,
+	segmentCount,
+}: {
+	easingNode: Expression;
+	segmentCount: number;
+}): KeyframeEasing[] | null => {
+	if (segmentCount === 0) {
+		return [];
+	}
+
+	if (easingNode.type === 'TSAsExpression') {
+		return getKeyframeEasingArray({
+			easingNode: easingNode.expression as Expression,
+			segmentCount,
+		});
+	}
+
+	if (easingNode.type === 'ArrayExpression') {
+		if (easingNode.elements.length !== segmentCount) {
+			return null;
+		}
+
+		const parsed = easingNode.elements.map((element) => {
+			if (!element || element.type === 'SpreadElement') {
+				return null;
+			}
+
+			return getKeyframeEasing(element as Expression);
+		});
+
+		if (parsed.some((value) => value === null)) {
+			return null;
+		}
+
+		return parsed as KeyframeEasing[];
+	}
+
+	const easing = getKeyframeEasing(easingNode);
+	if (!easing) {
+		return null;
+	}
+
+	return new Array(segmentCount).fill(easing);
+};
+
+const getExistingEasingArray = ({
+	options,
+	segmentCount,
+}: {
+	options: ObjectExpression;
+	segmentCount: number;
+}): KeyframeEasing[] => {
+	const {prop} = findObjectOptionProperty(options, 'easing');
+	if (!prop) {
+		return new Array(segmentCount).fill('linear');
+	}
+
+	const easing = getKeyframeEasingArray({
+		easingNode: prop.value as Expression,
+		segmentCount,
+	});
+	if (!easing) {
+		throw new Error('Cannot update easing: easing must be inline');
+	}
+
+	return easing;
+};
+
+const createEasingExpression = (easing: KeyframeEasing): ExpressionKind => {
+	if (easing === 'linear') {
+		return b.memberExpression(
+			b.identifier('Easing'),
+			b.identifier('linear'),
+		) as ExpressionKind;
+	}
+
+	return b.callExpression(
+		b.memberExpression(b.identifier('Easing'), b.identifier('bezier')),
+		easing.map((value) => parseValueExpression(value)) as never,
+	) as ExpressionKind;
+};
+
+const createEasingArrayExpression = (
+	easing: KeyframeEasing[],
+): ExpressionKind =>
+	b.arrayExpression(
+		easing.map((easingValue) => createEasingExpression(easingValue)) as never,
+	) as ExpressionKind;
+
 const validatePosterize = (posterize: number | undefined) => {
 	if (posterize === undefined) {
 		return;
@@ -388,6 +539,73 @@ const updateKeyframeSettings = ({
 	});
 };
 
+const updateKeyframeEasing = ({
+	expression,
+	segmentIndex,
+	easing,
+}: {
+	expression: Expression;
+	segmentIndex: number;
+	easing: KeyframeEasing;
+}): {expression: ExpressionKind; needsEasingImport: boolean} => {
+	const existing = getInterpolationExpression(expression);
+	if (!existing) {
+		throw new Error('Cannot update easing on non-keyframed value');
+	}
+
+	const calleeName =
+		existing.callee.type === 'Identifier' ? existing.callee.name : null;
+	if (calleeName === 'interpolateColors') {
+		throw new Error('Cannot update easing on color keyframes');
+	}
+
+	const segmentCount = Math.max(0, existing.keyframes.length - 1);
+	if (
+		!Number.isInteger(segmentIndex) ||
+		segmentIndex < 0 ||
+		segmentIndex >= segmentCount
+	) {
+		throw new Error('Cannot update easing: segment index out of range');
+	}
+
+	const extraArgs = [...existing.extraArgs];
+	const existingOptions = extraArgs[0];
+	if (existingOptions && existingOptions.type !== 'ObjectExpression') {
+		throw new Error('Cannot update easing: options must be inline');
+	}
+
+	const options =
+		existingOptions?.type === 'ObjectExpression'
+			? (existingOptions as ObjectExpression)
+			: createEmptyOptionsExpression();
+	const nextEasing = getExistingEasingArray({options, segmentCount});
+	nextEasing[segmentIndex] = easing;
+	const hasNonLinearEasing = nextEasing.some(
+		(easingValue) => !isLinearEasing(easingValue),
+	);
+
+	setOptionsProperty({
+		options,
+		propertyName: 'easing',
+		value: hasNonLinearEasing ? createEasingArrayExpression(nextEasing) : null,
+	});
+
+	const nextExtraArgs =
+		options.properties.length === 0
+			? extraArgs.slice(1)
+			: [options as ExpressionKind, ...extraArgs.slice(1)];
+
+	return {
+		expression: createInterpolateExpression({
+			callee: existing.callee,
+			input: existing.input,
+			extraArgs: nextExtraArgs,
+			keyframes: existing.keyframes,
+		}),
+		needsEasingImport: hasNonLinearEasing,
+	};
+};
+
 const createInterpolateExpression = ({
 	callee,
 	input,
@@ -415,11 +633,13 @@ const createInterpolateExpression = ({
 export type IntroducedKeyframeIdentifiers = {
 	calleeName: KeyframeInterpolationFunction | null;
 	needsFrameHook: boolean;
+	needsEasingImport: boolean;
 };
 
 const noIntroducedIdentifiers: IntroducedKeyframeIdentifiers = {
 	calleeName: null,
 	needsFrameHook: false,
+	needsEasingImport: false,
 };
 
 const addKeyframe = ({
@@ -477,6 +697,7 @@ const addKeyframe = ({
 						? schemaCalleeName
 						: null,
 				needsFrameHook: false,
+				needsEasingImport: false,
 			},
 		};
 	}
@@ -512,6 +733,7 @@ const addKeyframe = ({
 					? (callee.name as KeyframeInterpolationFunction)
 					: null,
 			needsFrameHook: true,
+			needsEasingImport: false,
 		},
 	};
 };
@@ -649,6 +871,21 @@ const applyKeyframeOperation = ({
 				posterize: operation.posterize,
 			}),
 			introduced: noIntroducedIdentifiers,
+		};
+	}
+
+	if (operation.type === 'easing') {
+		const updated = updateKeyframeEasing({
+			expression,
+			segmentIndex: operation.segmentIndex,
+			easing: operation.easing,
+		});
+		return {
+			expression: updated.expression,
+			introduced: {
+				...noIntroducedIdentifiers,
+				needsEasingImport: updated.needsEasingImport,
+			},
 		};
 	}
 
@@ -986,6 +1223,10 @@ export const updateSequenceKeyframesAst = ({
 			requiredImports.add('useCurrentFrame');
 			needsFrameHook = true;
 		}
+
+		if (introduced.needsEasingImport) {
+			requiredImports.add('Easing');
+		}
 	}
 
 	if (needsFrameHook) {
@@ -1135,6 +1376,10 @@ export const updateEffectKeyframesAst = ({
 		if (introduced.needsFrameHook) {
 			requiredImports.add('useCurrentFrame');
 			needsFrameHook = true;
+		}
+
+		if (introduced.needsEasingImport) {
+			requiredImports.add('Easing');
 		}
 	}
 

--- a/packages/studio-server/src/helpers/imports.ts
+++ b/packages/studio-server/src/helpers/imports.ts
@@ -143,7 +143,11 @@ export const ensureNamedImports = ({
 				continue;
 			}
 
-			existingNames.add(getImportedName(importSpecifierCandidate));
+			const importedName = getImportedName(importSpecifierCandidate);
+			const localName = importSpecifierCandidate.local?.name ?? importedName;
+			if (localName === importedName) {
+				existingNames.add(importedName);
+			}
 		}
 	}
 

--- a/packages/studio-server/src/preview-server/routes/update-effect-keyframe-settings.ts
+++ b/packages/studio-server/src/preview-server/routes/update-effect-keyframe-settings.ts
@@ -65,11 +65,18 @@ export const updateEffectKeyframeSettingsHandler: ApiHandler<
 			updates: [
 				{
 					key,
-					operation: {
-						type: 'settings',
-						clamping: settings.clamping,
-						posterize: settings.posterize,
-					},
+					operation:
+						settings.type === 'settings'
+							? {
+									type: 'settings',
+									clamping: settings.clamping,
+									posterize: settings.posterize,
+								}
+							: {
+									type: 'easing',
+									segmentIndex: settings.segmentIndex,
+									easing: settings.easing,
+								},
 				},
 			],
 		});

--- a/packages/studio-server/src/preview-server/routes/update-sequence-keyframe-settings.ts
+++ b/packages/studio-server/src/preview-server/routes/update-sequence-keyframe-settings.ts
@@ -53,11 +53,18 @@ export const updateSequenceKeyframeSettingsHandler: ApiHandler<
 			updates: [
 				{
 					key,
-					operation: {
-						type: 'settings',
-						clamping: settings.clamping,
-						posterize: settings.posterize,
-					},
+					operation:
+						settings.type === 'settings'
+							? {
+									type: 'settings',
+									clamping: settings.clamping,
+									posterize: settings.posterize,
+								}
+							: {
+									type: 'easing',
+									segmentIndex: settings.segmentIndex,
+									easing: settings.easing,
+								},
 				},
 			],
 		});

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -119,6 +119,36 @@ test('updateSequenceKeyframes adds a keyframe to an existing interpolation', asy
 	);
 });
 
+test('updateSequenceKeyframes pads easing arrays when adding keyframes', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [91, 126], [1080, 833], {extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: [Easing.bezier(0.42, 0, 1, 1)]})}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {type: 'add', frame: 134, value: 700},
+			},
+		],
+	});
+
+	expect(output).toContain('interpolate(frame, [91, 126, 134]');
+	expect(output).toContain(
+		'easing: [Easing.bezier(0.42, 0, 1, 1), Easing.linear]',
+	);
+});
+
 test('updateSequenceKeyframes updates a keyframe at the same frame', async () => {
 	const {output, oldValueStrings, newValueStrings} =
 		await updateSequenceKeyframes({
@@ -239,6 +269,39 @@ export const Example: React.FC = () => {
 	expect(output).toContain('Easing as RemotionEasing');
 	expect(output).toContain('Easing,');
 	expect(output).toContain('Easing.bezier(0.42, 0, 1, 1)');
+});
+
+test('updateSequenceKeyframes pads existing easing arrays before editing them', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [91, 126, 134], [1080, 1080, 833], {easing: [Easing.bezier(0.42, 0, 1, 1)]})}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {
+					type: 'easing',
+					segmentIndex: 1,
+					easing: [0, 0, 0.58, 1],
+				},
+			},
+		],
+	});
+
+	expect(output).toContain('easing: [');
+	expect(output).toContain('Easing.bezier(0.42, 0, 1, 1)');
+	expect(output).toContain('Easing.bezier(0, 0, 0.58, 1)');
 });
 
 test('updateSequenceKeyframes removes easing once all segments are linear', async () => {
@@ -710,6 +773,34 @@ test('updateSequenceKeyframes keeps an interpolation when one keyframe remains',
 
 	expect(oldValueStrings).toEqual(['interpolate(frame, [0, 100], [2, 4])']);
 	expect(output).toContain('style={{scale: interpolate(frame, [100], [4])}}');
+});
+
+test('updateSequenceKeyframes removes the adjacent easing segment when deleting keyframes', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [91, 126, 134], [1080, 1080, 833], {easing: [Easing.linear, Easing.bezier(0.42, 0, 1, 1)]})}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {type: 'remove', frame: 91},
+			},
+		],
+	});
+
+	expect(output).toContain('interpolate(frame, [126, 134]');
+	expect(output).toContain('easing: [Easing.bezier(0.42, 0, 1, 1)]');
 });
 
 test('updateSequenceKeyframes moves overlapping selected keyframes together', async () => {

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -174,6 +174,124 @@ export const Example: React.FC = () => {
 	expect(output).not.toContain('posterize');
 });
 
+test('updateSequenceKeyframes sets one easing segment and fills linear segments', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [0, 50, 100], [2, 3, 4])}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {
+					type: 'easing',
+					segmentIndex: 1,
+					easing: [0.42, 0, 1, 1],
+				},
+			},
+		],
+	});
+
+	expect(output).toContain('Easing');
+	expect(output).toContain(
+		'easing: [Easing.linear, Easing.bezier(0.42, 0, 1, 1)]',
+	);
+});
+
+test('updateSequenceKeyframes adds an unaliased Easing import for easing edits', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, Easing as RemotionEasing, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [0, 50, 100], [2, 3, 4])}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {
+					type: 'easing',
+					segmentIndex: 1,
+					easing: [0.42, 0, 1, 1],
+				},
+			},
+		],
+	});
+
+	expect(output).toContain('Easing as RemotionEasing');
+	expect(output).toContain('Easing,');
+	expect(output).toContain('Easing.bezier(0.42, 0, 1, 1)');
+});
+
+test('updateSequenceKeyframes removes easing once all segments are linear', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [0, 50, 100], [2, 3, 4], {easing: [Easing.linear, Easing.bezier(0.42, 0, 1, 1)], posterize: 2})}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {
+					type: 'easing',
+					segmentIndex: 1,
+					easing: 'linear',
+				},
+			},
+		],
+	});
+
+	expect(output).not.toContain('easing:');
+	expect(output).toContain('posterize: 2');
+});
+
+test('updateSequenceKeyframes rejects easing updates for color keyframes', async () => {
+	await expect(
+		updateSequenceKeyframes({
+			input: colorInput,
+			nodePath: lineColumnToNodePath(colorInput, getLine(colorInput, '<Solid')),
+			updates: [
+				{
+					key: 'color',
+					operation: {
+						type: 'easing',
+						segmentIndex: 0,
+						easing: [0.42, 0, 1, 1],
+					},
+				},
+			],
+		}),
+	).rejects.toThrow(/color keyframes/);
+});
+
 test('updateSequenceKeyframes only updates posterize for color keyframes', async () => {
 	const {output} = await updateSequenceKeyframes({
 		input: colorInput,
@@ -763,6 +881,32 @@ test('updateEffectKeyframes converts a static value to a clamped interpolation',
 	expect(serialized).toContain('amount: interpolate(frame, [40], [0.6], {');
 	expect(serialized).toContain('extrapolateLeft: "clamp"');
 	expect(serialized).toContain('extrapolateRight: "clamp"');
+});
+
+test('updateEffectKeyframes sets one easing segment and fills linear segments', () => {
+	const {serialized} = updateEffectKeyframesAst({
+		input: effectInput,
+		sequenceNodePath: lineColumnToNodePath(
+			effectInput,
+			getLine(effectInput, '<HtmlInCanvas'),
+		),
+		effectIndex: 0,
+		updates: [
+			{
+				key: 'amount',
+				operation: {
+					type: 'easing',
+					segmentIndex: 1,
+					easing: [0, 0, 0.58, 1],
+				},
+			},
+		],
+	});
+
+	expect(serialized).toContain('Easing');
+	expect(serialized).toContain(
+		'easing: [Easing.linear, Easing.bezier(0, 0, 0.58, 1)]',
+	);
 });
 
 test('updateSequenceKeyframes converts the last color keyframe to a static value', async () => {

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -38,6 +38,11 @@ import type {
 import type {SymbolicatedStackFrame} from './stack-types';
 import type {EnumPath} from './stringify-default-props';
 
+type KeyframeEasing = Extract<
+	CanUpdateSequencePropStatus,
+	{status: 'keyframed'}
+>['easing'][number];
+
 export type OpenInFileExplorerRequest = {
 	directory: string;
 };
@@ -483,15 +488,22 @@ export type AddEffectKeyframeRequest = {
 
 export type AddEffectKeyframeResponse = SaveEffectPropsResponse;
 
-export type KeyframeSettings = {
-	clamping:
-		| {
-				left: ExtrapolateType;
-				right: ExtrapolateType;
-		  }
-		| undefined;
-	posterize: number | undefined;
-};
+export type KeyframeSettings =
+	| {
+			type: 'settings';
+			clamping:
+				| {
+						left: ExtrapolateType;
+						right: ExtrapolateType;
+				  }
+				| undefined;
+			posterize: number | undefined;
+	  }
+	| {
+			type: 'easing';
+			segmentIndex: number;
+			easing: KeyframeEasing;
+	  };
 
 export type UpdateSequenceKeyframeSettingsRequest = {
 	fileName: string;

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -112,6 +112,10 @@ export {
 } from './component-drag-data';
 export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state-delay-in-milliseconds';
 export {
+	KEYFRAME_EASING_PRESETS,
+	type KeyframeEasingPreset,
+} from './keyframe-easing-presets';
+export {
 	detectFileType,
 	isImageFileType,
 	type FileDimensions,

--- a/packages/studio-shared/src/keyframe-easing-presets.ts
+++ b/packages/studio-shared/src/keyframe-easing-presets.ts
@@ -1,0 +1,13 @@
+export type KeyframeEasing = 'linear' | [number, number, number, number];
+
+export type KeyframeEasingPreset = {
+	readonly id: 'ease-in' | 'ease-out' | 'ease-in-out';
+	readonly label: string;
+	readonly easing: KeyframeEasing;
+};
+
+export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [
+	{id: 'ease-in', label: 'Ease in', easing: [0.42, 0, 1, 1]},
+	{id: 'ease-out', label: 'Ease out', easing: [0, 0, 0.58, 1]},
+	{id: 'ease-in-out', label: 'Ease in-out', easing: [0.42, 0, 0.58, 1]},
+];

--- a/packages/studio-shared/src/optimistic-update-keyframe-settings.ts
+++ b/packages/studio-shared/src/optimistic-update-keyframe-settings.ts
@@ -4,6 +4,37 @@ import type {
 } from 'remotion';
 import type {KeyframeSettings} from './api-requests';
 
+type KeyframeEasing = Extract<
+	CanUpdateSequencePropStatus,
+	{status: 'keyframed'}
+>['easing'][number];
+
+const updateEasing = ({
+	easing,
+	segmentCount,
+	segmentIndex,
+	value,
+}: {
+	easing: KeyframeEasing[];
+	segmentCount: number;
+	segmentIndex: number;
+	value: KeyframeEasing;
+}): KeyframeEasing[] => {
+	if (
+		!Number.isInteger(segmentIndex) ||
+		segmentIndex < 0 ||
+		segmentIndex >= segmentCount
+	) {
+		throw new Error('Cannot update easing: segment index out of range');
+	}
+
+	const nextEasing = Array.from({length: segmentCount}, (_, index) => {
+		return easing[index] ?? 'linear';
+	});
+	nextEasing[segmentIndex] = value;
+	return nextEasing;
+};
+
 const applySettingsToStatus = (
 	status: CanUpdateSequencePropStatus | undefined,
 	settings: KeyframeSettings,
@@ -14,8 +45,20 @@ const applySettingsToStatus = (
 
 	return {
 		...status,
-		...(settings.clamping ? {clamping: settings.clamping} : {}),
-		posterize: settings.posterize,
+		...(settings.type === 'settings' && settings.clamping
+			? {clamping: settings.clamping}
+			: {}),
+		...(settings.type === 'settings' ? {posterize: settings.posterize} : {}),
+		...(settings.type === 'easing'
+			? {
+					easing: updateEasing({
+						easing: status.easing,
+						segmentCount: Math.max(0, status.keyframes.length - 1),
+						segmentIndex: settings.segmentIndex,
+						value: settings.easing,
+					}),
+				}
+			: {}),
 	};
 };
 

--- a/packages/studio-shared/src/test/optimistic-update-keyframe-settings.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-keyframe-settings.test.ts
@@ -1,0 +1,99 @@
+import {expect, test} from 'bun:test';
+import type {CanUpdateSequencePropsResponse} from 'remotion';
+import {
+	optimisticUpdateEffectKeyframeSettings,
+	optimisticUpdateSequenceKeyframeSettings,
+} from '../optimistic-update-keyframe-settings';
+
+const previous: CanUpdateSequencePropsResponse = {
+	canUpdate: true,
+	props: {
+		scale: {
+			status: 'keyframed',
+			interpolationFunction: 'interpolate',
+			keyframes: [
+				{frame: 0, value: 1},
+				{frame: 20, value: 2},
+				{frame: 40, value: 3},
+			],
+			easing: ['linear'],
+			clamping: {left: 'clamp', right: 'wrap'},
+			posterize: 3,
+		},
+	},
+	effects: [
+		{
+			canUpdate: true,
+			effectIndex: 0,
+			callee: 'blur',
+			importPath: null,
+			props: {
+				amount: {
+					status: 'keyframed',
+					interpolationFunction: 'interpolate',
+					keyframes: [
+						{frame: 0, value: 0.2},
+						{frame: 20, value: 0.5},
+					],
+					easing: [],
+					clamping: {left: 'extend', right: 'extend'},
+					posterize: undefined,
+				},
+			},
+		},
+	],
+};
+
+test('optimisticUpdateSequenceKeyframeSettings updates easing without changing other settings', () => {
+	const updated = optimisticUpdateSequenceKeyframeSettings({
+		previous,
+		fieldKey: 'scale',
+		settings: {
+			type: 'easing',
+			segmentIndex: 1,
+			easing: [0.42, 0, 1, 1],
+		},
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const status = updated.props.scale;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.easing).toEqual(['linear', [0.42, 0, 1, 1]]);
+	expect(status.clamping).toEqual({left: 'clamp', right: 'wrap'});
+	expect(status.posterize).toBe(3);
+});
+
+test('optimisticUpdateEffectKeyframeSettings updates easing', () => {
+	const updated = optimisticUpdateEffectKeyframeSettings({
+		previous,
+		effectIndex: 0,
+		fieldKey: 'amount',
+		settings: {
+			type: 'easing',
+			segmentIndex: 0,
+			easing: [0, 0, 0.58, 1],
+		},
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const effect = updated.effects[0];
+	if (!effect.canUpdate) {
+		throw new Error('expected updateable effect');
+	}
+
+	const status = effect.props.amount;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.easing).toEqual([[0, 0, 0.58, 1]]);
+});

--- a/packages/studio/src/components/Timeline/KeyframeSettingsModal.tsx
+++ b/packages/studio/src/components/Timeline/KeyframeSettingsModal.tsx
@@ -129,6 +129,7 @@ export const KeyframeSettingsModal: React.FC<{
 		}
 
 		const settings: KeyframeSettings = {
+			type: 'settings',
 			clamping: canEditClamping ? {left, right} : undefined,
 			posterize: posterize <= 0 ? undefined : posterize,
 		};

--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -11,6 +11,7 @@ import {
 	useCurrentTimelineSelectionStateAsRef,
 	useTimelineSelection,
 } from './TimelineSelection';
+import {updateSelectedTimelineEasings} from './update-selected-easing';
 
 export const TimelineDeleteKeybindings: React.FC = () => {
 	const keybindings = useKeybinding();
@@ -23,12 +24,15 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		Internals.VisualModePropStatusesRefContext,
 	);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
-	const {canSelect} = useTimelineSelection();
+	const {canSelect, canSelectEasing} = useTimelineSelection();
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 	const confirm = useConfirmationDialog();
 
 	useEffect(() => {
-		if (!canSelect || previewServerState.type !== 'connected') {
+		if (
+			(!canSelect && !canSelectEasing) ||
+			previewServerState.type !== 'connected'
+		) {
 			return;
 		}
 
@@ -41,6 +45,21 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 				const sequences = sequencesRef.current;
 				const propStatuses = propStatusesRef.current;
 				if (selectedItems.length === 0) {
+					return;
+				}
+
+				const resetEasingPromise = updateSelectedTimelineEasings({
+					selections: selectedItems,
+					sequences,
+					overrideIdsToNodePaths: overrideIdToNodePathMappings,
+					propStatuses,
+					setPropStatuses,
+					clientId,
+					easing: 'linear',
+				});
+
+				if (resetEasingPromise !== null) {
+					resetEasingPromise.catch(() => undefined);
 					return;
 				}
 
@@ -116,6 +135,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		};
 	}, [
 		canSelect,
+		canSelectEasing,
 		confirm,
 		currentSelection,
 		keybindings,

--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -7,6 +7,7 @@ import {TimelineKeyframeDiamond} from './TimelineKeyframeDiamond';
 import {TimelineKeyframeEasingLine} from './TimelineKeyframeEasingLine';
 import {
 	ENABLE_OUTLINES,
+	EASING_SELECTION_ENABLED,
 	getTimelineSelectedTrackHighlightStyle,
 	useTimelineRowSelection,
 } from './TimelineSelection';
@@ -23,14 +24,16 @@ const rowSeparator: React.CSSProperties = {
 const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
 	readonly height: number;
 	readonly keyframes: ReturnType<typeof getTimelineKeyframes>;
+	readonly canEditEasing: boolean;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly showSeparator: boolean;
-}> = ({height, keyframes, nodePathInfo, showSeparator}) => {
+}> = ({height, keyframes, canEditEasing, nodePathInfo, showSeparator}) => {
 	const timelineWidth = useContext(TimelineWidthContext);
 	const {selected: rowSelected} = useTimelineRowSelection(nodePathInfo);
-	const easingSegments = ENABLE_OUTLINES
-		? getTimelineEasingSegments(keyframes)
-		: [];
+	const easingSegments =
+		(ENABLE_OUTLINES || EASING_SELECTION_ENABLED) && canEditEasing
+			? getTimelineEasingSegments(keyframes)
+			: [];
 
 	return (
 		<>

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -22,6 +22,7 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 					key={row.rowKey}
 					height={row.height}
 					keyframes={row.keyframes}
+					canEditEasing={row.canEditEasing}
 					nodePathInfo={row.nodePathInfo}
 					showSeparator={index > 0}
 				/>

--- a/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
@@ -1,11 +1,22 @@
-import React, {useCallback, useContext, useMemo} from 'react';
-import {useVideoConfig} from 'remotion';
+import {KEYFRAME_EASING_PRESETS} from '@remotion/studio-shared';
+import React, {useCallback, useContext, useMemo, useRef} from 'react';
+import {Internals, useVideoConfig} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {BLUE, LINE_COLOR} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
-import {useTimelineEasingSelection} from './TimelineSelection';
+import {ContextMenuForTarget} from '../ContextMenu';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {
+	useCurrentTimelineSelectionStateAsRef,
+	useTimelineEasingSelection,
+} from './TimelineSelection';
 import {TimelineWidthContext} from './TimelineWidthProvider';
+import {
+	getEasingSelections,
+	updateSelectedTimelineEasings,
+} from './update-selected-easing';
 
 const hitTargetHeight = 12;
 const lineHeight = 2;
@@ -37,14 +48,92 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly segmentIndex: number;
 }> = ({fromFrame, toFrame, rowHeight, nodePathInfo, segmentIndex}) => {
+	const buttonRef = useRef<HTMLButtonElement>(null);
 	const videoConfig = useVideoConfig();
 	const timelineWidth = useContext(TimelineWidthContext);
-	const {selected, onSelect, selectable} = useTimelineEasingSelection({
-		nodePathInfo,
-		fromFrame,
-		toFrame,
-		segmentIndex,
-	});
+	const {selected, onSelect, selectable, selectionItem} =
+		useTimelineEasingSelection({
+			nodePathInfo,
+			fromFrame,
+			toFrame,
+			segmentIndex,
+		});
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const sequencesRef = useContext(Internals.SequenceManagerRefContext);
+	const propStatusesRef = useContext(
+		Internals.VisualModePropStatusesRefContext,
+	);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
+	const currentSelection = useCurrentTimelineSelectionStateAsRef();
+
+	const updateEasing = useCallback(
+		(easing: (typeof KEYFRAME_EASING_PRESETS)[number]['easing']) => {
+			if (previewServerState.type !== 'connected') {
+				return;
+			}
+
+			const selectedEasings = getEasingSelections(
+				currentSelection.current.selectedItems,
+			);
+			const selections = selected ? selectedEasings : [selectionItem];
+			const promise = updateSelectedTimelineEasings({
+				selections,
+				sequences: sequencesRef.current,
+				overrideIdsToNodePaths: overrideIdToNodePathMappings,
+				propStatuses: propStatusesRef.current,
+				setPropStatuses,
+				clientId: previewServerState.clientId,
+				easing,
+			});
+			promise?.catch(() => undefined);
+		},
+		[
+			currentSelection,
+			overrideIdToNodePathMappings,
+			previewServerState,
+			propStatusesRef,
+			selected,
+			selectionItem,
+			sequencesRef,
+			setPropStatuses,
+		],
+	);
+
+	const contextMenuValues = useMemo((): ComboboxValue[] => {
+		return KEYFRAME_EASING_PRESETS.map((preset) => ({
+			type: 'item',
+			id: preset.id,
+			keyHint: null,
+			label: preset.label,
+			leftItem: null,
+			disabled: previewServerState.type !== 'connected',
+			onClick: () => updateEasing(preset.easing),
+			quickSwitcherLabel: null,
+			subMenu: null,
+			value: preset.id,
+		}));
+	}, [previewServerState.type, updateEasing]);
+
+	const onOpenContextMenu = useCallback(
+		(event: MouseEvent) => {
+			if (!selectable) {
+				return false;
+			}
+
+			if (!selected) {
+				onSelect({
+					shiftKey: event.shiftKey,
+					toggleKey: event.metaKey || event.ctrlKey,
+				});
+			}
+
+			return contextMenuValues;
+		},
+		[contextMenuValues, onSelect, selectable, selected],
+	);
 
 	const style = useMemo((): React.CSSProperties | null => {
 		if (timelineWidth === null) {
@@ -114,15 +203,23 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 	}
 
 	return (
-		<button
-			type="button"
-			style={style}
-			title={`Easing from frame ${fromFrame} to ${toFrame}`}
-			aria-label={`Select easing from frame ${fromFrame} to ${toFrame}`}
-			onPointerDown={selectable ? onPointerDown : undefined}
-		>
-			<div style={lineStyle} />
-		</button>
+		<>
+			<button
+				ref={buttonRef}
+				type="button"
+				style={style}
+				title={`Easing from frame ${fromFrame} to ${toFrame}`}
+				aria-label={`Select easing from frame ${fromFrame} to ${toFrame}`}
+				onPointerDown={selectable ? onPointerDown : undefined}
+			>
+				<div style={lineStyle} />
+			</button>
+			<ContextMenuForTarget
+				triggerRef={buttonRef}
+				values={contextMenuValues}
+				onOpen={onOpenContextMenu}
+			/>
+		</>
 	);
 };
 

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -63,6 +63,7 @@ export const getTimelineSelectedTrackHighlightStyle = (
 export const SELECTION_ENABLED = false;
 export const TIMELINE_TOP_DRAG = false;
 export const ENABLE_OUTLINES = false;
+export const EASING_SELECTION_ENABLED = true;
 
 type TimelineSelectionBase = {
 	readonly nodePathInfo: SequenceNodePathInfo;
@@ -248,6 +249,7 @@ export const getTimelineSelectionAfterInteraction = ({
 
 type TimelineSelectionContextValue = {
 	readonly canSelect: boolean;
+	readonly canSelectEasing: boolean;
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly isSelected: (item: TimelineSelection) => boolean;
 	readonly selectItem: (
@@ -262,6 +264,7 @@ type TimelineSelectionContextValue = {
 
 const defaultTimelineSelectionContextValue: TimelineSelectionContextValue = {
 	canSelect: false,
+	canSelectEasing: false,
 	selectedItems: [],
 	isSelected: () => false,
 	selectItem: () => undefined,
@@ -457,6 +460,10 @@ export const TimelineSelectionProvider: React.FC<{
 		(SELECTION_ENABLED || ENABLE_OUTLINES) &&
 		previewServerState.type === 'connected' &&
 		!window.remotion_isReadOnlyStudio;
+	const canSelectEasing =
+		EASING_SELECTION_ENABLED &&
+		previewServerState.type === 'connected' &&
+		!window.remotion_isReadOnlyStudio;
 	const [selectedItems, setSelectedItems] = useState<
 		readonly TimelineSelection[]
 	>([]);
@@ -466,10 +473,16 @@ export const TimelineSelectionProvider: React.FC<{
 	const registrationCounter = useRef(0);
 
 	useEffect(() => {
-		if (!canSelect) {
+		if (!canSelect && !canSelectEasing) {
 			setSelectedItems([]);
 		}
-	}, [canSelect]);
+	}, [canSelect, canSelectEasing]);
+
+	const canSelectItem = useCallback(
+		(item: TimelineSelection) =>
+			canSelect || (canSelectEasing && item.type === 'easing'),
+		[canSelect, canSelectEasing],
+	);
 
 	const selectedKeys = useMemo(
 		() => new Set(selectedItems.map(getTimelineSelectionKey)),
@@ -491,7 +504,7 @@ export const TimelineSelectionProvider: React.FC<{
 				toggleKey: false,
 			},
 		) => {
-			if (!canSelect) {
+			if (!canSelectItem(item)) {
 				return;
 			}
 
@@ -519,12 +532,12 @@ export const TimelineSelectionProvider: React.FC<{
 				return nextState.selectedItems;
 			});
 		},
-		[canSelect],
+		[canSelectItem],
 	);
 
 	const selectItems = useCallback(
 		(items: readonly TimelineSelection[]) => {
-			if (!canSelect) {
+			if (!items.every(canSelectItem)) {
 				return;
 			}
 
@@ -532,7 +545,7 @@ export const TimelineSelectionProvider: React.FC<{
 				items.length === 0 ? null : items[items.length - 1];
 			setSelectedItems(items);
 		},
-		[canSelect],
+		[canSelectItem],
 	);
 
 	const registerSelectableItem = useCallback((item: TimelineSelection) => {
@@ -564,6 +577,7 @@ export const TimelineSelectionProvider: React.FC<{
 	const value = useMemo(
 		(): TimelineSelectionContextValue => ({
 			canSelect,
+			canSelectEasing,
 			selectedItems,
 			isSelected,
 			selectItem,
@@ -574,6 +588,7 @@ export const TimelineSelectionProvider: React.FC<{
 		}),
 		[
 			canSelect,
+			canSelectEasing,
 			selectedItems,
 			isSelected,
 			selectItem,
@@ -697,7 +712,7 @@ export const useTimelineEasingSelection = ({
 	readonly toFrame: number;
 	readonly segmentIndex: number;
 }) => {
-	const {canSelect, isSelected, selectItem, registerSelectableItem} =
+	const {canSelectEasing, isSelected, selectItem, registerSelectableItem} =
 		useTimelineSelection();
 	const selectionItem = useMemo(
 		(): TimelineSelection => ({
@@ -725,8 +740,9 @@ export const useTimelineEasingSelection = ({
 
 	return {
 		onSelect,
-		selectable: canSelect,
+		selectable: canSelectEasing,
 		selected,
+		selectionItem,
 	};
 };
 

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -63,7 +63,7 @@ export const getTimelineSelectedTrackHighlightStyle = (
 export const SELECTION_ENABLED = false;
 export const TIMELINE_TOP_DRAG = false;
 export const ENABLE_OUTLINES = false;
-export const EASING_SELECTION_ENABLED = true;
+export const EASING_SELECTION_ENABLED = false;
 
 type TimelineSelectionBase = {
 	readonly nodePathInfo: SequenceNodePathInfo;

--- a/packages/studio/src/components/Timeline/update-selected-easing.ts
+++ b/packages/studio/src/components/Timeline/update-selected-easing.ts
@@ -1,0 +1,181 @@
+import type {OverrideIdToNodePaths, PropStatuses, TSequence} from 'remotion';
+import {Internals} from 'remotion';
+import {
+	callUpdateEffectKeyframeSettings,
+	callUpdateSequenceKeyframeSettings,
+} from './call-update-keyframe-settings';
+import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
+import {parseKeyframeFieldFromNodePath} from './parse-keyframe-field-from-node-path';
+import type {SetPropStatuses} from './save-sequence-prop';
+import type {TimelineSelection} from './TimelineSelection';
+
+type EasingSelection = TimelineSelection & {type: 'easing'};
+export type TimelineEasingValue = 'linear' | [number, number, number, number];
+
+const isEasingSelection = (
+	selection: TimelineSelection,
+): selection is EasingSelection => selection.type === 'easing';
+
+const getSelectedEasingUpdate = ({
+	selection,
+	sequences,
+	overrideIdsToNodePaths,
+	propStatuses,
+}: {
+	selection: EasingSelection;
+	sequences: TSequence[];
+	overrideIdsToNodePaths: OverrideIdToNodePaths;
+	propStatuses: PropStatuses;
+}) => {
+	const field = parseKeyframeFieldFromNodePath(
+		selection.nodePathInfo.auxiliaryKeys,
+	);
+	if (field === null) {
+		return null;
+	}
+
+	const track = findTrackForNodePathInfo({
+		sequences,
+		overrideIdsToNodePaths,
+		nodePathInfo: selection.nodePathInfo,
+	});
+	const sequence = track?.sequence ?? null;
+	if (!sequence) {
+		return null;
+	}
+
+	const nodePath = selection.nodePathInfo.sequenceSubscriptionKey;
+	const fileName = nodePath.absolutePath;
+
+	if (field.type === 'sequence') {
+		if (!sequence.controls) {
+			return null;
+		}
+
+		const sequencePropStatus = Internals.getPropStatusesCtx(
+			propStatuses,
+			nodePath,
+		)?.[field.fieldKey];
+		if (
+			sequencePropStatus?.status !== 'keyframed' ||
+			sequencePropStatus.interpolationFunction !== 'interpolate'
+		) {
+			return null;
+		}
+
+		return {
+			type: 'sequence' as const,
+			fileName,
+			nodePath,
+			fieldKey: field.fieldKey,
+			schema: sequence.controls.schema,
+			segmentIndex: selection.segmentIndex,
+		};
+	}
+
+	const effect = sequence.effects[field.effectIndex];
+	if (!effect) {
+		return null;
+	}
+
+	const effectStatus = Internals.getEffectPropStatusesCtx({
+		propStatuses,
+		nodePath,
+		effectIndex: field.effectIndex,
+	});
+	const effectPropStatus =
+		effectStatus.type === 'can-update-effect'
+			? effectStatus.props[field.fieldKey]
+			: null;
+	if (
+		effectPropStatus?.status !== 'keyframed' ||
+		effectPropStatus.interpolationFunction !== 'interpolate'
+	) {
+		return null;
+	}
+
+	return {
+		type: 'effect' as const,
+		fileName,
+		nodePath,
+		effectIndex: field.effectIndex,
+		fieldKey: field.fieldKey,
+		schema: effect.schema,
+		segmentIndex: selection.segmentIndex,
+	};
+};
+
+export const getEasingSelections = (
+	selections: readonly TimelineSelection[],
+): EasingSelection[] => selections.filter(isEasingSelection);
+
+export const updateSelectedTimelineEasings = ({
+	selections,
+	sequences,
+	overrideIdsToNodePaths,
+	propStatuses,
+	setPropStatuses,
+	clientId,
+	easing,
+}: {
+	selections: readonly TimelineSelection[];
+	sequences: TSequence[];
+	overrideIdsToNodePaths: OverrideIdToNodePaths;
+	propStatuses: PropStatuses;
+	setPropStatuses: SetPropStatuses;
+	clientId: string;
+	easing: TimelineEasingValue;
+}): Promise<void> | null => {
+	const easingSelections = getEasingSelections(selections);
+	if (easingSelections.length === 0) {
+		return null;
+	}
+
+	const updates = easingSelections
+		.map((selection) =>
+			getSelectedEasingUpdate({
+				selection,
+				sequences,
+				overrideIdsToNodePaths,
+				propStatuses,
+			}),
+		)
+		.filter((update): update is NonNullable<typeof update> => update !== null);
+
+	if (updates.length === 0) {
+		return null;
+	}
+
+	return Promise.all(
+		updates.map((update) => {
+			const settings = {
+				type: 'easing' as const,
+				segmentIndex: update.segmentIndex,
+				easing,
+			};
+
+			if (update.type === 'sequence') {
+				return callUpdateSequenceKeyframeSettings({
+					fileName: update.fileName,
+					nodePath: update.nodePath,
+					fieldKey: update.fieldKey,
+					settings,
+					schema: update.schema,
+					setPropStatuses,
+					clientId,
+				});
+			}
+
+			return callUpdateEffectKeyframeSettings({
+				fileName: update.fileName,
+				nodePath: update.nodePath,
+				effectIndex: update.effectIndex,
+				fieldKey: update.fieldKey,
+				settings,
+				schema: update.schema,
+				setPropStatuses,
+				clientId,
+			});
+		}),
+	).then(() => undefined);
+};

--- a/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
+++ b/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
@@ -15,8 +15,48 @@ import type {getTimelineKeyframes} from './get-timeline-keyframes';
 export type ExpandedTrackKeyframeRow = {
 	readonly height: number;
 	readonly keyframes: ReturnType<typeof getTimelineKeyframes>;
+	readonly canEditEasing: boolean;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly rowKey: string;
+};
+
+const getNodeCanEditEasing = ({
+	node,
+	nodePath,
+	propStatuses,
+}: {
+	node: ReturnType<typeof flattenVisibleTreeNodes>[number]['node'];
+	nodePath: Parameters<typeof getNodeKeyframes>[0]['nodePath'];
+	propStatuses: Parameters<typeof getNodeKeyframes>[0]['propStatuses'];
+}) => {
+	if (node.kind !== 'field' || node.field === null) {
+		return false;
+	}
+
+	if (node.field.kind === 'sequence-field') {
+		const sequencePropStatus = Internals.getPropStatusesCtx(
+			propStatuses,
+			nodePath,
+		)?.[node.field.key];
+		return (
+			sequencePropStatus?.status === 'keyframed' &&
+			sequencePropStatus.interpolationFunction === 'interpolate'
+		);
+	}
+
+	const effectStatus = Internals.getEffectPropStatusesCtx({
+		propStatuses,
+		nodePath,
+		effectIndex: node.field.effectIndex,
+	});
+	const effectPropStatus =
+		effectStatus.type === 'can-update-effect'
+			? effectStatus.props[node.field.key]
+			: null;
+	return (
+		effectPropStatus?.status === 'keyframed' &&
+		effectPropStatus.interpolationFunction === 'interpolate'
+	);
 };
 
 export const useExpandedTrackKeyframeRows = ({
@@ -84,6 +124,11 @@ export const useExpandedTrackKeyframeRows = ({
 					getDragOverrides,
 					getEffectDragOverrides,
 					timelinePosition,
+				}),
+				canEditEasing: getNodeCanEditEasing({
+					node,
+					nodePath: nodePathInfo.sequenceSubscriptionKey,
+					propStatuses,
 				}),
 				rowKey: timelineNodePathInfoToKey(node.nodePathInfo),
 				nodePathInfo: node.nodePathInfo,


### PR DESCRIPTION
Fixes #7780

## Summary

- add timeline easing segment controls with bezier-based Ease in, Ease out, and Ease in-out presets
- support bulk edits for multiple selected easing segments
- reset selected easing segments to linear with Backspace and omit the easing option when all segments are linear

## Testing

- bun test packages/studio-server/src/test/update-keyframes.test.ts
- bun test packages/studio-shared/src/test/optimistic-update-keyframe-settings.test.ts packages/studio/src/test/timeline-keyframes.test.ts packages/studio/src/test/timeline-selection.test.ts
- bun run build
- bun run stylecheck
