### PR TITLE
`@remotion/studio`: Support mixed timeline selections

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -11,7 +11,10 @@ import {
 	useCurrentTimelineSelectionStateAsRef,
 	useTimelineSelection,
 } from './TimelineSelection';
-import {updateSelectedTimelineEasings} from './update-selected-easing';
+import {
+	getEasingSelections,
+	updateSelectedTimelineEasings,
+} from './update-selected-easing';
 
 export const TimelineDeleteKeybindings: React.FC = () => {
 	const keybindings = useKeybinding();
@@ -37,19 +40,38 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		}
 
 		const {clientId} = previewServerState;
-		const backspace = keybindings.registerKeybinding({
-			event: 'keydown',
-			key: 'Backspace',
-			callback: () => {
-				const {selectedItems, clearSelection} = currentSelection.current;
-				const sequences = sequencesRef.current;
-				const propStatuses = propStatusesRef.current;
-				if (selectedItems.length === 0) {
-					return;
-				}
+		const handleDelete = () => {
+			const {selectedItems, clearSelection} = currentSelection.current;
+			const sequences = sequencesRef.current;
+			const propStatuses = propStatusesRef.current;
+			if (selectedItems.length === 0) {
+				return;
+			}
 
+			const deletePromise = deleteSelectedTimelineItems({
+				selections: selectedItems,
+				sequences,
+				overrideIdsToNodePaths: overrideIdToNodePathMappings,
+				setPropStatuses,
+				clientId,
+				confirm,
+			});
+
+			if (deletePromise !== null) {
+				deletePromise
+					.then((deleted) => {
+						if (deleted) {
+							clearSelection();
+						}
+					})
+					.catch(() => undefined);
+				return;
+			}
+
+			const easingSelections = getEasingSelections(selectedItems);
+			if (easingSelections.length === selectedItems.length) {
 				const resetEasingPromise = updateSelectedTimelineEasings({
-					selections: selectedItems,
+					selections: easingSelections,
 					sequences,
 					overrideIdsToNodePaths: overrideIdToNodePathMappings,
 					propStatuses,
@@ -62,42 +84,35 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 					resetEasingPromise.catch(() => undefined);
 					return;
 				}
+			}
 
-				const resetPromise = resetSelectedTimelineProps({
-					selections: selectedItems,
-					sequences,
-					overrideIdsToNodePaths: overrideIdToNodePathMappings,
-					propStatuses,
-					setPropStatuses,
-					clientId,
-				});
+			const resetPromise = resetSelectedTimelineProps({
+				selections: selectedItems,
+				sequences,
+				overrideIdsToNodePaths: overrideIdToNodePathMappings,
+				propStatuses,
+				setPropStatuses,
+				clientId,
+			});
 
-				if (resetPromise !== null) {
-					resetPromise.catch(() => undefined);
-					return;
-				}
+			if (resetPromise !== null) {
+				resetPromise.catch(() => undefined);
+			}
+		};
 
-				const deletePromise = deleteSelectedTimelineItems({
-					selections: selectedItems,
-					sequences,
-					overrideIdsToNodePaths: overrideIdToNodePathMappings,
-					setPropStatuses,
-					clientId,
-					confirm,
-				});
-
-				if (deletePromise === null) {
-					return;
-				}
-
-				deletePromise
-					.then((deleted) => {
-						if (deleted) {
-							clearSelection();
-						}
-					})
-					.catch(() => undefined);
-			},
+		const backspace = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'Backspace',
+			callback: handleDelete,
+			commandCtrlKey: false,
+			preventDefault: true,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+		const deleteKey = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'Delete',
+			callback: handleDelete,
 			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
@@ -131,6 +146,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 
 		return () => {
 			backspace.unregister();
+			deleteKey.unregister();
 			duplicate.unregister();
 		};
 	}, [

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -124,6 +124,27 @@ export type TimelineSelectionState = {
 
 const getTimelineSelectionType = (item: TimelineSelection) => item.type;
 
+const areTimelineSelectionTypesCompatible = (
+	firstType: TimelineSelection['type'],
+	secondType: TimelineSelection['type'],
+): boolean => {
+	if (firstType === secondType) {
+		return true;
+	}
+
+	return (
+		(firstType === 'sequence-prop' && secondType === 'sequence-effect-prop') ||
+		(firstType === 'sequence-effect-prop' && secondType === 'sequence-prop') ||
+		(firstType === 'keyframe' && secondType === 'easing') ||
+		(firstType === 'easing' && secondType === 'keyframe')
+	);
+};
+
+const isTimelineSelectionCompatibleWithType = (
+	item: TimelineSelection,
+	type: TimelineSelection['type'],
+) => areTimelineSelectionTypesCompatible(getTimelineSelectionType(item), type);
+
 const getTimelineSelectionAnchor = (
 	selectedItems: readonly TimelineSelection[],
 	previousAnchor: TimelineSelection | null,
@@ -210,12 +231,14 @@ export const getTimelineSelectionAfterInteraction = ({
 	}
 
 	if (interaction.toggleKey) {
-		const sameTypeItems = selectedItems.filter(
-			(item) => getTimelineSelectionType(item) === clickedType,
+		const compatibleItems = selectedItems.filter((item) =>
+			isTimelineSelectionCompatibleWithType(item, clickedType),
 		);
-		const existingKeySet = new Set(sameTypeItems.map(getTimelineSelectionKey));
+		const existingKeySet = new Set(
+			compatibleItems.map(getTimelineSelectionKey),
+		);
 		if (existingKeySet.has(clickedKey)) {
-			const toggledSelection = sameTypeItems.filter(
+			const toggledSelection = compatibleItems.filter(
 				(item) => getTimelineSelectionKey(item) !== clickedKey,
 			);
 			return {
@@ -226,10 +249,12 @@ export const getTimelineSelectionAfterInteraction = ({
 
 		const selectableOrderMap = new Map(
 			allSelectableItems
-				.filter((item) => getTimelineSelectionType(item) === clickedType)
+				.filter((item) =>
+					isTimelineSelectionCompatibleWithType(item, clickedType),
+				)
 				.map((item, index) => [getTimelineSelectionKey(item), index] as const),
 		);
-		const extendedSelection = [...sameTypeItems, clickedItem].sort((a, b) => {
+		const extendedSelection = [...compatibleItems, clickedItem].sort((a, b) => {
 			return (
 				(selectableOrderMap.get(getTimelineSelectionKey(a)) ?? 0) -
 				(selectableOrderMap.get(getTimelineSelectionKey(b)) ?? 0)

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -220,6 +220,23 @@ const areSelectionsOnlyOfType = (
 	type: TimelineSelection['type'],
 ): boolean => selections.every((selection) => selection.type === type);
 
+const assertTimelineSelectionsHaveSameType = (
+	selections: readonly TimelineSelection[],
+): void => {
+	const firstSelection = selections[0];
+	if (!firstSelection) {
+		return;
+	}
+
+	for (const selection of selections) {
+		if (selection.type !== firstSelection.type) {
+			throw new Error(
+				`Assertion failed: Cannot delete timeline selections of different types (${firstSelection.type}, ${selection.type})`,
+			);
+		}
+	}
+};
+
 const containsOnlyKeyframesAndEasings = (
 	selections: readonly TimelineSelection[],
 ): boolean =>
@@ -266,12 +283,14 @@ export const deleteSelectedTimelineItems = ({
 		return promise?.then(() => true) ?? null;
 	}
 
+	if (!areSelectionsOnlyOfType(selections, firstSelection.type)) {
+		return null;
+	}
+
+	assertTimelineSelectionsHaveSameType(selections);
+
 	switch (firstSelection.type) {
 		case 'sequence':
-			if (!areSelectionsOnlyOfType(selections, 'sequence')) {
-				return null;
-			}
-
 			return deleteSequences(
 				selections
 					.filter(isSequenceRowSelection)
@@ -279,10 +298,6 @@ export const deleteSelectedTimelineItems = ({
 				confirm,
 			);
 		case 'sequence-effect':
-			if (!areSelectionsOnlyOfType(selections, 'sequence-effect')) {
-				return null;
-			}
-
 			return deleteEffects(
 				selections.filter(isSequenceEffectSelection).map((selection) => ({
 					type: 'single-effect',
@@ -296,10 +311,6 @@ export const deleteSelectedTimelineItems = ({
 		case 'easing':
 			return null;
 		case 'sequence-all-effects':
-			if (!areSelectionsOnlyOfType(selections, 'sequence-all-effects')) {
-				return null;
-			}
-
 			return deleteEffects(
 				selections.filter(isSequenceAllEffectsSelection).map((selection) => ({
 					type: 'all-effects',

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -215,22 +215,17 @@ const isKeyframeSelection = (
 	type: 'keyframe';
 } => selection.type === 'keyframe';
 
-const assertTimelineSelectionsHaveSameType = (
+const areSelectionsOnlyOfType = (
 	selections: readonly TimelineSelection[],
-): void => {
-	const firstSelection = selections[0];
-	if (!firstSelection) {
-		return;
-	}
+	type: TimelineSelection['type'],
+): boolean => selections.every((selection) => selection.type === type);
 
-	for (const selection of selections) {
-		if (selection.type !== firstSelection.type) {
-			throw new Error(
-				`Assertion failed: Cannot delete timeline selections of different types (${firstSelection.type}, ${selection.type})`,
-			);
-		}
-	}
-};
+const containsOnlyKeyframesAndEasings = (
+	selections: readonly TimelineSelection[],
+): boolean =>
+	selections.every(
+		(selection) => selection.type === 'keyframe' || selection.type === 'easing',
+	);
 
 export const deleteSelectedTimelineItems = ({
 	selections,
@@ -252,10 +247,31 @@ export const deleteSelectedTimelineItems = ({
 		return null;
 	}
 
-	assertTimelineSelectionsHaveSameType(selections);
+	if (containsOnlyKeyframesAndEasings(selections)) {
+		const keyframes = selections.filter(isKeyframeSelection);
+		if (keyframes.length === 0) {
+			return null;
+		}
+
+		const promise = deleteSelectedKeyframes({
+			keyframes: keyframes.map((selection) => ({
+				nodePathInfo: selection.nodePathInfo,
+				frame: selection.frame,
+			})),
+			sequences,
+			overrideIdsToNodePaths,
+			setPropStatuses,
+			clientId,
+		});
+		return promise?.then(() => true) ?? null;
+	}
 
 	switch (firstSelection.type) {
 		case 'sequence':
+			if (!areSelectionsOnlyOfType(selections, 'sequence')) {
+				return null;
+			}
+
 			return deleteSequences(
 				selections
 					.filter(isSequenceRowSelection)
@@ -263,6 +279,10 @@ export const deleteSelectedTimelineItems = ({
 				confirm,
 			);
 		case 'sequence-effect':
+			if (!areSelectionsOnlyOfType(selections, 'sequence-effect')) {
+				return null;
+			}
+
 			return deleteEffects(
 				selections.filter(isSequenceEffectSelection).map((selection) => ({
 					type: 'single-effect',
@@ -270,25 +290,16 @@ export const deleteSelectedTimelineItems = ({
 					effectIndex: selection.i,
 				})),
 			);
-		case 'keyframe': {
-			const promise = deleteSelectedKeyframes({
-				keyframes: selections.filter(isKeyframeSelection).map((selection) => ({
-					nodePathInfo: selection.nodePathInfo,
-					frame: selection.frame,
-				})),
-				sequences,
-				overrideIdsToNodePaths,
-				setPropStatuses,
-				clientId,
-			});
-			return promise?.then(() => true) ?? null;
-		}
-
+		case 'keyframe':
 		case 'sequence-prop':
 		case 'sequence-effect-prop':
 		case 'easing':
 			return null;
 		case 'sequence-all-effects':
+			if (!areSelectionsOnlyOfType(selections, 'sequence-all-effects')) {
+				return null;
+			}
+
 			return deleteEffects(
 				selections.filter(isSequenceAllEffectsSelection).map((selection) => ({
 					type: 'all-effects',

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -102,19 +102,17 @@ export const getTimelinePropResetTargets = ({
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
 	readonly propStatuses: PropStatuses;
 }): TimelinePropResetTarget[] | null => {
-	const firstSelection = selections[0];
-	if (!firstSelection || !isPropResetSelection(firstSelection)) {
+	const propSelections = selections.filter(isPropResetSelection);
+	if (propSelections.length === 0) {
+		return null;
+	}
+
+	if (propSelections.length !== selections.length) {
 		return null;
 	}
 
 	const resetTargets: TimelinePropResetTarget[] = [];
-	for (const selection of selections) {
-		if (!isPropResetSelection(selection)) {
-			throw new Error(
-				`Assertion failed: Cannot reset timeline selections of different types (${firstSelection.type}, ${selection.type})`,
-			);
-		}
-
+	for (const selection of propSelections) {
 		const track = findTrackForNodePathInfo({
 			sequences,
 			overrideIdsToNodePaths,

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -37,13 +37,27 @@ type EffectPropResetTarget = {
 
 type TimelinePropResetTarget = SequencePropResetTarget | EffectPropResetTarget;
 
+type PropResetSelection = TimelineSelection & {
+	type: 'sequence-prop' | 'sequence-effect-prop';
+};
+
 const isPropResetSelection = (
 	selection: TimelineSelection,
-): selection is TimelineSelection & {
-	type: 'sequence-prop' | 'sequence-effect-prop';
-} =>
+): selection is PropResetSelection =>
 	selection.type === 'sequence-prop' ||
 	selection.type === 'sequence-effect-prop';
+
+function assertPropResetSelections(
+	selections: readonly TimelineSelection[],
+): asserts selections is readonly PropResetSelection[] {
+	for (const selection of selections) {
+		if (!isPropResetSelection(selection)) {
+			throw new Error(
+				`Assertion failed: Cannot reset timeline selection of type ${selection.type}`,
+			);
+		}
+	}
+}
 
 const isVisibleFieldSchema = (
 	fieldSchema: SequenceFieldSchema | undefined,
@@ -111,8 +125,10 @@ export const getTimelinePropResetTargets = ({
 		return null;
 	}
 
+	assertPropResetSelections(selections);
+
 	const resetTargets: TimelinePropResetTarget[] = [];
-	for (const selection of propSelections) {
+	for (const selection of selections) {
 		const track = findTrackForNodePathInfo({
 			sequences,
 			overrideIdsToNodePaths,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1915,12 +1915,117 @@ test('Backspace reset skips keyframed effect props without defaults', () => {
 	expect(resetTargets).toEqual([]);
 });
 
-test('Deleting mixed timeline selection types throws an assertion error', () => {
+test('Backspace reset targets mixed selected sequence and effect props', () => {
+	const schema = {
+		opacity: {type: 'number', default: 1, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const effectSchema = {
+		intensity: {type: 'number', default: 0, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const opacityNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+	const intensityNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'intensity'],
+	);
+	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {
+				opacity: {status: 'static', codeValue: 0.5},
+			},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'effect',
+					importPath: null,
+					effectIndex: 0,
+					props: {
+						intensity: {status: 'static', codeValue: 10},
+					},
+				},
+			],
+		},
+	} satisfies PropStatuses;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-prop',
+				nodePathInfo: opacityNodePathInfo,
+				key: 'opacity',
+			},
+			{
+				type: 'sequence-effect-prop',
+				nodePathInfo: intensityNodePathInfo,
+				i: 0,
+				key: 'intensity',
+			},
+		],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				effects: [{schema: effectSchema}],
+			}),
+		],
+		overrideIdsToNodePaths: {override: nodePath},
+		propStatuses,
+	});
+
+	expect(resetTargets?.map((target) => target.type)).toEqual([
+		'sequence-prop',
+		'effect-prop',
+	]);
+	expect(resetTargets?.map((target) => target.fieldKey)).toEqual([
+		'opacity',
+		'intensity',
+	]);
+	expect(resetTargets?.map((target) => target.value)).toEqual([1, 0]);
+});
+
+test('Backspace reset ignores incompatible mixed prop selections', () => {
+	const schema = {
+		opacity: {type: 'number', default: 1, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const opacityNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+
+	expect(
+		getTimelinePropResetTargets({
+			selections: [
+				{
+					type: 'sequence-prop',
+					nodePathInfo: opacityNodePathInfo,
+					key: 'opacity',
+				},
+				{
+					type: 'keyframe',
+					nodePathInfo: opacityNodePathInfo,
+					frame: 12,
+				},
+			],
+			sequences: [makeTimelineSequence({schema})],
+			overrideIdsToNodePaths: {
+				override: opacityNodePathInfo.sequenceSubscriptionKey,
+			},
+			propStatuses: makeDurationPropStatuses([
+				opacityNodePathInfo.sequenceSubscriptionKey,
+			]),
+		}),
+	).toBe(null);
+});
+
+test('Deleting unsupported mixed timeline selection types returns null', () => {
 	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
 	const effectNodePathInfo = makeNodePathInfo(['body', 1], ['effects', '0']);
 	const confirm = () => Promise.resolve(true);
 
-	expect(() =>
+	expect(
 		deleteSelectedTimelineItems({
 			selections: [
 				{type: 'sequence', nodePathInfo: sequenceNodePathInfo},
@@ -1936,7 +2041,79 @@ test('Deleting mixed timeline selection types throws an assertion error', () => 
 			clientId: 'client',
 			confirm,
 		}),
-	).toThrow(/Assertion failed/);
+	).toBe(null);
+});
+
+test('Deleting selected keyframes ignores selected easings', async () => {
+	const schema = {
+		opacity: {type: 'number', default: 1, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const opacityNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
+	const fetchCalls: unknown[] = [];
+	const previousFetch = globalThis.fetch;
+	globalThis.fetch = ((input, init) => {
+		fetchCalls.push({
+			input,
+			body:
+				typeof init?.body === 'string'
+					? JSON.parse(init.body)
+					: (init?.body ?? null),
+		});
+
+		return Promise.resolve({
+			json: () => Promise.resolve({success: true, data: {}}),
+		} as Response);
+	}) as typeof fetch;
+
+	try {
+		const result = await deleteSelectedTimelineItems({
+			selections: [
+				{
+					type: 'keyframe',
+					nodePathInfo: opacityNodePathInfo,
+					frame: 12,
+				},
+				{
+					type: 'easing',
+					nodePathInfo: opacityNodePathInfo,
+					fromFrame: 12,
+					toFrame: 24,
+					segmentIndex: 0,
+				},
+			],
+			sequences: [makeTimelineSequence({schema})],
+			overrideIdsToNodePaths: {override: nodePath},
+			setPropStatuses: () => undefined,
+			clientId: 'client',
+			confirm: () => Promise.resolve(true),
+		});
+
+		expect(result).toBe(true);
+		expect(fetchCalls).toEqual([
+			{
+				input: '/api/delete-keyframes',
+				body: {
+					sequenceKeyframes: [
+						{
+							fileName: '/project/src/Comp.tsx',
+							nodePath,
+							key: 'opacity',
+							frame: 12,
+							schema,
+						},
+					],
+					effectKeyframes: [],
+					clientId: 'client',
+				},
+			},
+		]);
+	} finally {
+		globalThis.fetch = previousFetch;
+	}
 });
 
 test('Child timeline selections resolve to the parent sequence selection key', () => {
@@ -2040,6 +2217,109 @@ test('Cmd/Ctrl+click toggles row selections', () => {
 	).toEqual({
 		selectedItems: [rowB],
 		anchor: rowA,
+	});
+});
+
+test('Cmd/Ctrl+click mixes compatible prop row selections', () => {
+	const sequenceProp = {
+		type: 'sequence-prop' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], ['controls', 'opacity']),
+		key: 'opacity',
+	};
+	const effectProp = {
+		type: 'sequence-effect-prop' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], ['effects', '0', 'intensity']),
+		i: 0,
+		key: 'intensity',
+	};
+	const allSelectableItems = [sequenceProp, effectProp];
+
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [sequenceProp],
+				anchor: sequenceProp,
+			},
+			clickedItem: effectProp,
+			interaction: {shiftKey: false, toggleKey: true},
+			allSelectableItems,
+		}),
+	).toEqual({
+		selectedItems: [sequenceProp, effectProp],
+		anchor: effectProp,
+	});
+
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [sequenceProp, effectProp],
+				anchor: effectProp,
+			},
+			clickedItem: effectProp,
+			interaction: {shiftKey: false, toggleKey: true},
+			allSelectableItems,
+		}),
+	).toEqual({
+		selectedItems: [sequenceProp],
+		anchor: effectProp,
+	});
+});
+
+test('Cmd/Ctrl+click mixes compatible keyframe and easing selections', () => {
+	const keyframe = {
+		type: 'keyframe' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], ['controls', 'opacity']),
+		frame: 10,
+	};
+	const easing = {
+		type: 'easing' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], ['controls', 'opacity']),
+		fromFrame: 10,
+		toFrame: 20,
+		segmentIndex: 0,
+	};
+
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [keyframe],
+				anchor: keyframe,
+			},
+			clickedItem: easing,
+			interaction: {shiftKey: false, toggleKey: true},
+			allSelectableItems: [keyframe, easing],
+		}),
+	).toEqual({
+		selectedItems: [keyframe, easing],
+		anchor: easing,
+	});
+});
+
+test('Cmd/Ctrl+click replaces incompatible mixed selections', () => {
+	const sequenceProp = {
+		type: 'sequence-prop' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], ['controls', 'opacity']),
+		key: 'opacity',
+	};
+	const keyframe = {
+		type: 'keyframe' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], ['controls', 'opacity']),
+		frame: 10,
+	};
+
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [sequenceProp],
+				anchor: sequenceProp,
+			},
+			clickedItem: keyframe,
+			interaction: {shiftKey: false, toggleKey: true},
+			allSelectableItems: [sequenceProp, keyframe],
+		}),
+	).toEqual({
+		selectedItems: [keyframe],
+		anchor: keyframe,
 	});
 });
 


### PR DESCRIPTION
Fixes #8235.

### What changed

- Allows compatible mixed timeline selections for sequence props with effect props, and keyframes with easing segments.
- Makes Backspace/Delete action handlers type-aware so unsupported mixed selections no-op instead of throwing invariants.
- Keeps useful actions available: mixed prop keyframe controls/reset, keyframe deletion while ignoring selected easings, and easing edits while ignoring selected keyframes.

### Testing
- bun test packages/studio/src/test/timeline-selection.test.ts
- bun run build
- bun run stylecheck
