### PR TITLE
`@remotion/studio`: Allow visual editing keyframed UV coordinates

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -31,7 +31,10 @@ import {
 } from './effect-drag-and-drop';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
-import {callAddSequenceKeyframe} from './Timeline/call-add-keyframe';
+import {
+	callAddEffectKeyframe,
+	callAddSequenceKeyframe,
+} from './Timeline/call-add-keyframe';
 import {saveEffectProp} from './Timeline/save-effect-prop';
 import {
 	saveSequenceProps,
@@ -75,13 +78,16 @@ export type UvCoordinateFieldSchema = Extract<
 
 type SelectedOutlineUvHandle = {
 	readonly clientId: string;
-	readonly propStatus: CanUpdateSequencePropStatusStatic;
+	readonly propStatus:
+		| CanUpdateSequencePropStatusStatic
+		| CanUpdateSequencePropStatusKeyframed;
 	readonly effectIndex: number;
 	readonly fieldDefault: UvCoordinate | undefined;
 	readonly fieldKey: string;
 	readonly fieldSchema: UvCoordinateFieldSchema;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: SequenceSchema;
+	readonly sourceFrame: number;
 	readonly value: UvCoordinate;
 };
 
@@ -615,13 +621,14 @@ export const getSequencesWithSelectableOutlines = ({
 		});
 };
 
-const getSelectedUvHandles = ({
+export const getSelectedUvHandles = ({
 	propStatuses,
 	clientId,
 	getEffectDragOverrides,
 	nodePath,
 	selectedEffects,
 	sequence,
+	sourceFrame,
 }: {
 	readonly propStatuses: PropStatuses;
 	readonly clientId: string | null;
@@ -629,6 +636,7 @@ const getSelectedUvHandles = ({
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly selectedEffects: Map<number, SelectedEffectFields> | undefined;
 	readonly sequence: TSequence;
+	readonly sourceFrame: number;
 }): SelectedOutlineUvHandle[] => {
 	if (clientId === null || selectedEffects === undefined) {
 		return [];
@@ -653,19 +661,21 @@ const getSelectedUvHandles = ({
 
 		const dragOverrides = getEffectDragOverrides(nodePath, effectIndex);
 		const activeSchema = Internals.flattenActiveSchema(effect.schema, (key) => {
-			const dragOverride = Internals.getStaticDragOverrideValue(
-				dragOverrides[key],
-			);
-			if (dragOverride !== undefined) {
-				return dragOverride;
-			}
-
 			const propStatus = effectStatus.props[key];
-			if (propStatus?.status !== 'static') {
+			if (
+				propStatus?.status !== 'static' &&
+				propStatus?.status !== 'keyframed'
+			) {
 				return undefined;
 			}
 
-			return propStatus.codeValue;
+			return Internals.getEffectiveVisualModeValue({
+				propStatus,
+				dragOverrideValue: dragOverrides[key],
+				defaultValue: undefined,
+				frame: sourceFrame,
+				shouldResortToDefaultValueIfUndefined: false,
+			});
 		});
 
 		for (const [fieldKey, fieldSchema] of Object.entries(activeSchema)) {
@@ -677,7 +687,10 @@ const getSelectedUvHandles = ({
 			}
 
 			const propStatus = effectStatus.props[fieldKey];
-			if (propStatus?.status !== 'static') {
+			if (
+				propStatus?.status !== 'static' &&
+				propStatus?.status !== 'keyframed'
+			) {
 				continue;
 			}
 
@@ -686,6 +699,7 @@ const getSelectedUvHandles = ({
 				propStatus,
 				dragOverrideValue,
 				defaultValue: fieldSchema.default,
+				frame: sourceFrame,
 				shouldResortToDefaultValueIfUndefined: true,
 			});
 			const value = parseUvCoordinate(effectiveValue);
@@ -702,6 +716,7 @@ const getSelectedUvHandles = ({
 				fieldSchema,
 				nodePath,
 				schema: effect.schema,
+				sourceFrame,
 				value,
 			});
 		}
@@ -1655,7 +1670,13 @@ const SelectedUvHandleCircle: React.FC<{
 					handle.nodePath,
 					handle.effectIndex,
 					handle.fieldKey,
-					Internals.makeStaticDragOverride(nextValue),
+					handle.propStatus.status === 'keyframed'
+						? Internals.makeKeyframedDragOverride({
+								status: handle.propStatus,
+								frame: handle.sourceFrame,
+								value: nextValue,
+							})
+						: Internals.makeStaticDragOverride(nextValue),
 				);
 			};
 
@@ -1674,31 +1695,54 @@ const SelectedUvHandleCircle: React.FC<{
 
 				const stringifiedValue =
 					lastValue === null ? null : JSON.stringify(lastValue);
-				const shouldSave =
-					lastValue !== null &&
-					!tuplesEqual(handle.propStatus.codeValue, lastValue) &&
-					!(
-						defaultValue === stringifiedValue &&
-						handle.propStatus.codeValue === undefined
+				const shouldSave = (() => {
+					if (lastValue === null) {
+						return false;
+					}
+
+					if (handle.propStatus.status === 'keyframed') {
+						return !tuplesEqual(handle.value, lastValue);
+					}
+
+					return (
+						!tuplesEqual(handle.propStatus.codeValue, lastValue) &&
+						!(
+							defaultValue === stringifiedValue &&
+							handle.propStatus.codeValue === undefined
+						)
 					);
+				})();
 
 				if (!shouldSave) {
 					clearEffectDragOverrides(handle.nodePath, handle.effectIndex);
 					return;
 				}
 
-				saveEffectProp({
-					type: 'value',
-					fileName: handle.nodePath.absolutePath,
-					nodePath: handle.nodePath,
-					effectIndex: handle.effectIndex,
-					fieldKey: handle.fieldKey,
-					value: lastValue,
-					defaultValue,
-					schema: handle.schema,
-					setPropStatuses,
-					clientId: handle.clientId,
-				}).finally(() => {
+				(handle.propStatus.status === 'keyframed'
+					? callAddEffectKeyframe({
+							fileName: handle.nodePath.absolutePath,
+							nodePath: handle.nodePath,
+							effectIndex: handle.effectIndex,
+							fieldKey: handle.fieldKey,
+							sourceFrame: handle.sourceFrame,
+							value: lastValue,
+							schema: handle.schema,
+							setPropStatuses,
+							clientId: handle.clientId,
+						})
+					: saveEffectProp({
+							type: 'value',
+							fileName: handle.nodePath.absolutePath,
+							nodePath: handle.nodePath,
+							effectIndex: handle.effectIndex,
+							fieldKey: handle.fieldKey,
+							value: lastValue,
+							defaultValue,
+							schema: handle.schema,
+							setPropStatuses,
+							clientId: handle.clientId,
+						})
+				).finally(() => {
 					clearEffectDragOverrides(handle.nodePath, handle.effectIndex);
 				});
 			};
@@ -1940,6 +1984,7 @@ export const SelectedOutlineOverlay: React.FC<{
 	);
 	const {getScaleLockState} = useContext(ScaleLockContext);
 	const {editorShowOutlines} = useContext(EditorShowOutlinesContext);
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const [outlines, setOutlines] = useState<readonly SelectedOutline[]>([]);
 	const [hoveredOutlineKey, setHoveredOutlineKey] = useState<string | null>(
 		null,
@@ -2069,6 +2114,7 @@ export const SelectedOutlineOverlay: React.FC<{
 							nodePath,
 							selectedEffects: selectedEffectsBySequenceKey.get(key),
 							sequence,
+							sourceFrame: timelinePosition - keyframeDisplayOffset,
 						})
 					: [],
 			};
@@ -2083,6 +2129,7 @@ export const SelectedOutlineOverlay: React.FC<{
 		previewServerState,
 		selectedItems,
 		sequences,
+		timelinePosition,
 	]);
 
 	useEffect(() => {

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -3,9 +3,7 @@ import type {
 	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
 	GetDragOverrides,
-	GetEffectDragOverrides,
 	OverrideIdToNodePaths,
-	PropStatuses,
 	ResolvedStackLocation,
 	SequenceFieldSchema,
 	SequencePropsSubscriptionKey,
@@ -32,10 +30,20 @@ import {
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
 import {
-	callAddEffectKeyframe,
-	callAddSequenceKeyframe,
-} from './Timeline/call-add-keyframe';
-import {saveEffectProp} from './Timeline/save-effect-prop';
+	clamp,
+	mixPoint,
+	type OutlinePoint,
+	type SelectedOutline,
+} from './selected-outline-geometry';
+import {
+	getSelectedUvHandles,
+	type SelectedOutlineUvHandle,
+} from './selected-outline-uv';
+import {
+	SelectedOutlineUvHandleCircleLayer,
+	SelectedOutlineUvHandleConnectionLayer,
+} from './SelectedOutlineUvControls';
+import {callAddSequenceKeyframe} from './Timeline/call-add-keyframe';
 import {
 	saveSequenceProps,
 	type SaveSequencePropChange,
@@ -48,59 +56,11 @@ import {getLinkedScale} from './Timeline/TimelineScaleField';
 import {
 	ENABLE_OUTLINES,
 	getTimelineSequenceSelectionKey,
-	useTimelineSelection,
 	type TimelineSelection,
 	type TimelineSelectionInteraction,
+	useTimelineSelection,
 } from './Timeline/TimelineSelection';
 import {getOriginalLocationFromStack} from './Timeline/TimelineStack/get-stack';
-
-type OutlinePoint = {
-	readonly x: number;
-	readonly y: number;
-};
-
-type SelectedOutline = {
-	readonly key: string;
-	readonly points: readonly [
-		OutlinePoint,
-		OutlinePoint,
-		OutlinePoint,
-		OutlinePoint,
-	];
-};
-
-export type UvCoordinate = readonly [number, number];
-
-export type UvCoordinateFieldSchema = Extract<
-	SequenceFieldSchema,
-	{type: 'uv-coordinate'}
->;
-
-type SelectedOutlineUvHandle = {
-	readonly clientId: string;
-	readonly propStatus:
-		| CanUpdateSequencePropStatusStatic
-		| CanUpdateSequencePropStatusKeyframed;
-	readonly effectIndex: number;
-	readonly fieldDefault: UvCoordinate | undefined;
-	readonly fieldKey: string;
-	readonly fieldSchema: UvCoordinateFieldSchema;
-	readonly nodePath: SequencePropsSubscriptionKey;
-	readonly schema: SequenceSchema;
-	readonly sourceFrame: number;
-	readonly value: UvCoordinate;
-};
-
-type UvConnectionHandle = Pick<
-	SelectedOutlineUvHandle,
-	'effectIndex' | 'fieldKey' | 'fieldSchema' | 'value'
->;
-
-type UvHandleConnectionLine = {
-	readonly key: string;
-	readonly from: OutlinePoint;
-	readonly to: OutlinePoint;
-};
 
 type SelectedOutlineContextMenuOpenResult =
 	| false
@@ -194,41 +154,6 @@ const emptyContextMenuValues: readonly ComboboxValue[] = [];
 
 const pointToString = (point: OutlinePoint) => `${point.x},${point.y}`;
 
-const parseUvCoordinate = (value: unknown): UvCoordinate | null => {
-	if (
-		Array.isArray(value) &&
-		value.length === 2 &&
-		value.every((item) => typeof item === 'number' && Number.isFinite(item))
-	) {
-		return [value[0], value[1]];
-	}
-
-	return null;
-};
-
-const tuplesEqual = (left: unknown, right: UvCoordinate): boolean => {
-	if (!Array.isArray(left) || left.length !== 2) {
-		return false;
-	}
-
-	return left[0] === right[0] && left[1] === right[1];
-};
-
-const mix = (from: number, to: number, progress: number): number => {
-	return from + (to - from) * progress;
-};
-
-const mixPoint = (
-	from: OutlinePoint,
-	to: OutlinePoint,
-	progress: number,
-): OutlinePoint => {
-	return {
-		x: mix(from.x, to.x, progress),
-		y: mix(from.y, to.y, progress),
-	};
-};
-
 const midpoint = (from: OutlinePoint, to: OutlinePoint): OutlinePoint => {
 	return mixPoint(from, to, 0.5);
 };
@@ -241,220 +166,9 @@ const vectorLength = (vector: OutlinePoint): number => {
 	return Math.hypot(vector.x, vector.y);
 };
 
-const getBilinearUvHandlePosition = (
-	points: SelectedOutline['points'],
-	uv: UvCoordinate,
-): OutlinePoint => {
-	const [tl, tr, br, bl] = points;
-	const top = mixPoint(tl, tr, uv[0]);
-	const bottom = mixPoint(bl, br, uv[0]);
-	return mixPoint(top, bottom, uv[1]);
-};
-
-type ProjectiveTransform = {
-	readonly a: number;
-	readonly b: number;
-	readonly c: number;
-	readonly d: number;
-	readonly e: number;
-	readonly f: number;
-	readonly g: number;
-	readonly h: number;
-};
-
-const projectiveEpsilon = 0.000001;
-
-const getProjectiveTransform = (
-	points: SelectedOutline['points'],
-): ProjectiveTransform | null => {
-	const [tl, tr, br, bl] = points;
-	const dx1 = tr.x - br.x;
-	const dx2 = bl.x - br.x;
-	const dx3 = tl.x - tr.x + br.x - bl.x;
-	const dy1 = tr.y - br.y;
-	const dy2 = bl.y - br.y;
-	const dy3 = tl.y - tr.y + br.y - bl.y;
-
-	let g = 0;
-	let h = 0;
-	if (Math.abs(dx3) > projectiveEpsilon || Math.abs(dy3) > projectiveEpsilon) {
-		const determinant = dx1 * dy2 - dx2 * dy1;
-		if (Math.abs(determinant) < projectiveEpsilon) {
-			return null;
-		}
-
-		g = (dx3 * dy2 - dx2 * dy3) / determinant;
-		h = (dx1 * dy3 - dx3 * dy1) / determinant;
-	}
-
-	return {
-		a: tr.x - tl.x + g * tr.x,
-		b: bl.x - tl.x + h * bl.x,
-		c: tl.x,
-		d: tr.y - tl.y + g * tr.y,
-		e: bl.y - tl.y + h * bl.y,
-		f: tl.y,
-		g,
-		h,
-	};
-};
-
-const applyProjectiveTransform = (
-	transform: ProjectiveTransform,
-	uv: UvCoordinate,
-): OutlinePoint => {
-	const denominator = transform.g * uv[0] + transform.h * uv[1] + 1;
-	return {
-		x: (transform.a * uv[0] + transform.b * uv[1] + transform.c) / denominator,
-		y: (transform.d * uv[0] + transform.e * uv[1] + transform.f) / denominator,
-	};
-};
-
-export const getUvHandlePosition = (
-	points: SelectedOutline['points'],
-	uv: UvCoordinate,
-): OutlinePoint => {
-	const transform = getProjectiveTransform(points);
-	return transform === null
-		? getBilinearUvHandlePosition(points, uv)
-		: applyProjectiveTransform(transform, uv);
-};
-
-export const getUvHandleConnectionLines = ({
-	handles,
-	points,
-}: {
-	readonly handles: readonly UvConnectionHandle[];
-	readonly points: SelectedOutline['points'];
-}): UvHandleConnectionLine[] => {
-	const handlesByField = new Map(
-		handles.map((handle) => [
-			`${handle.effectIndex}\u0000${handle.fieldKey}`,
-			handle,
-		]),
-	);
-	const seenPairs = new Set<string>();
-	const lines: UvHandleConnectionLine[] = [];
-
-	for (const handle of handles) {
-		const targetFieldKey = handle.fieldSchema.lineTo;
-		if (targetFieldKey === undefined || targetFieldKey === handle.fieldKey) {
-			continue;
-		}
-
-		const target = handlesByField.get(
-			`${handle.effectIndex}\u0000${targetFieldKey}`,
-		);
-		if (target === undefined) {
-			continue;
-		}
-
-		const pairKey = [
-			handle.effectIndex,
-			...[handle.fieldKey, targetFieldKey].sort(),
-		].join('\u0000');
-		if (seenPairs.has(pairKey)) {
-			continue;
-		}
-
-		seenPairs.add(pairKey);
-		lines.push({
-			key: `${handle.effectIndex}-${handle.fieldKey}-${targetFieldKey}`,
-			from: getUvHandlePosition(points, handle.value),
-			to: getUvHandlePosition(points, target.value),
-		});
-	}
-
-	return lines;
-};
-
 const vectorBetween = (from: OutlinePoint, to: OutlinePoint): OutlinePoint => {
 	return {x: to.x - from.x, y: to.y - from.y};
 };
-
-const getBilinearUvCoordinateForPoint = (
-	points: SelectedOutline['points'],
-	point: OutlinePoint,
-): UvCoordinate => {
-	const [tl, tr, br, bl] = points;
-	let u = 0.5;
-	let v = 0.5;
-
-	for (let i = 0; i < 8; i++) {
-		const current = getBilinearUvHandlePosition(points, [u, v]);
-		const errorX = current.x - point.x;
-		const errorY = current.y - point.y;
-		if (Math.abs(errorX) + Math.abs(errorY) < 0.001) {
-			break;
-		}
-
-		const du = {
-			x: mix(tr.x - tl.x, br.x - bl.x, v),
-			y: mix(tr.y - tl.y, br.y - bl.y, v),
-		};
-		const dv = vectorBetween(mixPoint(tl, tr, u), mixPoint(bl, br, u));
-		const determinant = du.x * dv.y - du.y * dv.x;
-		if (Math.abs(determinant) < 0.000001) {
-			break;
-		}
-
-		u -= (errorX * dv.y - errorY * dv.x) / determinant;
-		v -= (du.x * errorY - du.y * errorX) / determinant;
-	}
-
-	return [u, v];
-};
-
-export const getUvCoordinateForPoint = (
-	points: SelectedOutline['points'],
-	point: OutlinePoint,
-): UvCoordinate => {
-	const transform = getProjectiveTransform(points);
-	if (transform === null) {
-		return getBilinearUvCoordinateForPoint(points, point);
-	}
-
-	const determinant =
-		transform.a * (transform.e - transform.f * transform.h) -
-		transform.b * (transform.d - transform.f * transform.g) +
-		transform.c * (transform.d * transform.h - transform.e * transform.g);
-	if (Math.abs(determinant) < projectiveEpsilon) {
-		return getBilinearUvCoordinateForPoint(points, point);
-	}
-
-	const inverseA = transform.e - transform.f * transform.h;
-	const inverseB = transform.c * transform.h - transform.b;
-	const inverseC = transform.b * transform.f - transform.c * transform.e;
-	const inverseD = transform.f * transform.g - transform.d;
-	const inverseE = transform.a - transform.c * transform.g;
-	const inverseF = transform.c * transform.d - transform.a * transform.f;
-	const inverseG = transform.d * transform.h - transform.e * transform.g;
-	const inverseH = transform.b * transform.g - transform.a * transform.h;
-	const inverseI = transform.a * transform.e - transform.b * transform.d;
-
-	const denominator = inverseG * point.x + inverseH * point.y + inverseI;
-	if (Math.abs(denominator) < projectiveEpsilon) {
-		return getBilinearUvCoordinateForPoint(points, point);
-	}
-
-	return [
-		(inverseA * point.x + inverseB * point.y + inverseC) / denominator,
-		(inverseD * point.x + inverseE * point.y + inverseF) / denominator,
-	];
-};
-
-const clamp = (value: number, min: number, max: number): number => {
-	return Math.min(max, Math.max(min, value));
-};
-
-export function constrainUv(
-	value: UvCoordinate,
-	schema: UvCoordinateFieldSchema,
-): UvCoordinate {
-	const min = schema.min ?? -Infinity;
-	const max = schema.max ?? Infinity;
-	return [clamp(value[0], min, max), clamp(value[1], min, max)];
-}
 
 const rectToPoints = (
 	elementRect: DOMRect,
@@ -619,110 +333,6 @@ export const getSequencesWithSelectableOutlines = ({
 				sequence: track.sequence,
 			};
 		});
-};
-
-export const getSelectedUvHandles = ({
-	propStatuses,
-	clientId,
-	getEffectDragOverrides,
-	nodePath,
-	selectedEffects,
-	sequence,
-	sourceFrame,
-}: {
-	readonly propStatuses: PropStatuses;
-	readonly clientId: string | null;
-	readonly getEffectDragOverrides: GetEffectDragOverrides;
-	readonly nodePath: SequencePropsSubscriptionKey;
-	readonly selectedEffects: Map<number, SelectedEffectFields> | undefined;
-	readonly sequence: TSequence;
-	readonly sourceFrame: number;
-}): SelectedOutlineUvHandle[] => {
-	if (clientId === null || selectedEffects === undefined) {
-		return [];
-	}
-
-	const handles: SelectedOutlineUvHandle[] = [];
-
-	for (const [effectIndex, selectedFields] of selectedEffects) {
-		const effect = sequence.effects[effectIndex];
-		if (!effect) {
-			continue;
-		}
-
-		const effectStatus = Internals.getEffectPropStatusesCtx({
-			propStatuses,
-			nodePath,
-			effectIndex,
-		});
-		if (effectStatus.type !== 'can-update-effect') {
-			continue;
-		}
-
-		const dragOverrides = getEffectDragOverrides(nodePath, effectIndex);
-		const activeSchema = Internals.flattenActiveSchema(effect.schema, (key) => {
-			const propStatus = effectStatus.props[key];
-			if (
-				propStatus?.status !== 'static' &&
-				propStatus?.status !== 'keyframed'
-			) {
-				return undefined;
-			}
-
-			return Internals.getEffectiveVisualModeValue({
-				propStatus,
-				dragOverrideValue: dragOverrides[key],
-				defaultValue: undefined,
-				frame: sourceFrame,
-				shouldResortToDefaultValueIfUndefined: false,
-			});
-		});
-
-		for (const [fieldKey, fieldSchema] of Object.entries(activeSchema)) {
-			if (
-				fieldSchema.type !== 'uv-coordinate' ||
-				(!selectedFields.allFields && !selectedFields.fieldKeys.has(fieldKey))
-			) {
-				continue;
-			}
-
-			const propStatus = effectStatus.props[fieldKey];
-			if (
-				propStatus?.status !== 'static' &&
-				propStatus?.status !== 'keyframed'
-			) {
-				continue;
-			}
-
-			const dragOverrideValue = dragOverrides[fieldKey];
-			const effectiveValue = Internals.getEffectiveVisualModeValue({
-				propStatus,
-				dragOverrideValue,
-				defaultValue: fieldSchema.default,
-				frame: sourceFrame,
-				shouldResortToDefaultValueIfUndefined: true,
-			});
-			const value = parseUvCoordinate(effectiveValue);
-			if (value === null) {
-				continue;
-			}
-
-			handles.push({
-				clientId,
-				propStatus,
-				effectIndex,
-				fieldDefault: fieldSchema.default,
-				fieldKey,
-				fieldSchema,
-				nodePath,
-				schema: effect.schema,
-				sourceFrame,
-				value,
-			});
-		}
-	}
-
-	return handles;
 };
 
 const measureOutlines = (
@@ -1579,204 +1189,6 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 	);
 };
 
-const getSvgPointFromPointerEvent = ({
-	event,
-	rect,
-}: {
-	readonly event: Pick<PointerEvent, 'clientX' | 'clientY'>;
-	readonly rect: DOMRect;
-}): OutlinePoint => {
-	return {
-		x: event.clientX - rect.left,
-		y: event.clientY - rect.top,
-	};
-};
-
-const SelectedUvHandleConnectionLines: React.FC<{
-	readonly handles: readonly SelectedOutlineUvHandle[];
-	readonly outline: SelectedOutline;
-}> = ({handles, outline}) => {
-	const lines = useMemo(
-		() => getUvHandleConnectionLines({handles, points: outline.points}),
-		[handles, outline.points],
-	);
-
-	return (
-		<>
-			{lines.map((line) => (
-				<line
-					key={line.key}
-					x1={line.from.x}
-					y1={line.from.y}
-					x2={line.to.x}
-					y2={line.to.y}
-					stroke={BLUE}
-					strokeWidth={2}
-					vectorEffect="non-scaling-stroke"
-					pointerEvents="none"
-				/>
-			))}
-		</>
-	);
-};
-
-const SelectedUvHandleCircle: React.FC<{
-	readonly onDraggingChange: (dragging: boolean) => void;
-	readonly handle: SelectedOutlineUvHandle;
-	readonly outline: SelectedOutline;
-}> = ({handle, onDraggingChange, outline}) => {
-	const {setEffectDragOverrides, clearEffectDragOverrides, setPropStatuses} =
-		useContext(Internals.VisualModeSettersContext);
-	const position = useMemo(
-		() => getUvHandlePosition(outline.points, handle.value),
-		[handle.value, outline.points],
-	);
-
-	const onPointerDown = React.useCallback(
-		(event: React.PointerEvent<SVGCircleElement>) => {
-			if (event.button !== 0) {
-				return;
-			}
-
-			event.preventDefault();
-			event.stopPropagation();
-
-			const svg = event.currentTarget.ownerSVGElement;
-			if (svg === null) {
-				return;
-			}
-
-			const svgRect = svg.getBoundingClientRect();
-			let lastValue: UvCoordinate | null = null;
-			onDraggingChange(true);
-			const defaultValue =
-				handle.fieldDefault !== undefined
-					? JSON.stringify(handle.fieldDefault)
-					: null;
-
-			const updateFromPointerEvent = (
-				pointerEvent: PointerEvent | React.PointerEvent<SVGCircleElement>,
-			) => {
-				const point = getSvgPointFromPointerEvent({
-					event: pointerEvent,
-					rect: svgRect,
-				});
-				const nextValue = constrainUv(
-					getUvCoordinateForPoint(outline.points, point),
-					handle.fieldSchema,
-				);
-				lastValue = nextValue;
-				setEffectDragOverrides(
-					handle.nodePath,
-					handle.effectIndex,
-					handle.fieldKey,
-					handle.propStatus.status === 'keyframed'
-						? Internals.makeKeyframedDragOverride({
-								status: handle.propStatus,
-								frame: handle.sourceFrame,
-								value: nextValue,
-							})
-						: Internals.makeStaticDragOverride(nextValue),
-				);
-			};
-
-			updateFromPointerEvent(event);
-
-			const onPointerMove = (moveEvent: PointerEvent) => {
-				moveEvent.preventDefault();
-				updateFromPointerEvent(moveEvent);
-			};
-
-			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
-				onDraggingChange(false);
-
-				const stringifiedValue =
-					lastValue === null ? null : JSON.stringify(lastValue);
-				const shouldSave = (() => {
-					if (lastValue === null) {
-						return false;
-					}
-
-					if (handle.propStatus.status === 'keyframed') {
-						return !tuplesEqual(handle.value, lastValue);
-					}
-
-					return (
-						!tuplesEqual(handle.propStatus.codeValue, lastValue) &&
-						!(
-							defaultValue === stringifiedValue &&
-							handle.propStatus.codeValue === undefined
-						)
-					);
-				})();
-
-				if (!shouldSave) {
-					clearEffectDragOverrides(handle.nodePath, handle.effectIndex);
-					return;
-				}
-
-				(handle.propStatus.status === 'keyframed'
-					? callAddEffectKeyframe({
-							fileName: handle.nodePath.absolutePath,
-							nodePath: handle.nodePath,
-							effectIndex: handle.effectIndex,
-							fieldKey: handle.fieldKey,
-							sourceFrame: handle.sourceFrame,
-							value: lastValue,
-							schema: handle.schema,
-							setPropStatuses,
-							clientId: handle.clientId,
-						})
-					: saveEffectProp({
-							type: 'value',
-							fileName: handle.nodePath.absolutePath,
-							nodePath: handle.nodePath,
-							effectIndex: handle.effectIndex,
-							fieldKey: handle.fieldKey,
-							value: lastValue,
-							defaultValue,
-							schema: handle.schema,
-							setPropStatuses,
-							clientId: handle.clientId,
-						})
-				).finally(() => {
-					clearEffectDragOverrides(handle.nodePath, handle.effectIndex);
-				});
-			};
-
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
-		},
-		[
-			clearEffectDragOverrides,
-			handle,
-			onDraggingChange,
-			outline.points,
-			setPropStatuses,
-			setEffectDragOverrides,
-		],
-	);
-
-	return (
-		<circle
-			cx={position.x}
-			cy={position.y}
-			r={6}
-			fill="white"
-			stroke={BLUE}
-			strokeWidth={2}
-			vectorEffect="non-scaling-stroke"
-			pointerEvents="all"
-			cursor="default"
-			onPointerDown={onPointerDown}
-		/>
-	);
-};
-
 const SelectedOutlineElement: React.FC<{
 	readonly allDragTargets: readonly SelectedOutlineDragTarget[];
 	readonly allScaleDragTargets: readonly SelectedOutlineScaleDragTarget[];
@@ -1926,45 +1338,6 @@ const SelectedOutlineElement: React.FC<{
 						/>
 					))
 				: null}
-		</>
-	);
-};
-
-const SelectedOutlineUvHandleConnectionLayer: React.FC<{
-	readonly outline: SelectedOutline;
-	readonly target: SelectedOutlineTarget | undefined;
-}> = ({outline, target}) => {
-	if (!target?.containsSelection || target.uvHandles.length === 0) {
-		return null;
-	}
-
-	return (
-		<SelectedUvHandleConnectionLines
-			handles={target.uvHandles}
-			outline={outline}
-		/>
-	);
-};
-
-const SelectedOutlineUvHandleCircleLayer: React.FC<{
-	readonly onDraggingChange: (dragging: boolean) => void;
-	readonly outline: SelectedOutline;
-	readonly target: SelectedOutlineTarget | undefined;
-}> = ({onDraggingChange, outline, target}) => {
-	if (!target?.containsSelection || target.uvHandles.length === 0) {
-		return null;
-	}
-
-	return (
-		<>
-			{target.uvHandles.map((handle) => (
-				<SelectedUvHandleCircle
-					key={`${handle.effectIndex}-${handle.fieldKey}`}
-					handle={handle}
-					onDraggingChange={onDraggingChange}
-					outline={outline}
-				/>
-			))}
 		</>
 	);
 };

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -1,0 +1,257 @@
+import React, {useContext, useMemo} from 'react';
+import {Internals} from 'remotion';
+import {BLUE} from '../helpers/colors';
+import type {OutlinePoint, SelectedOutline} from './selected-outline-geometry';
+import {
+	constrainUv,
+	getUvCoordinateForPoint,
+	getUvHandleConnectionLines,
+	getUvHandlePosition,
+	tuplesEqual,
+	type SelectedOutlineUvHandle,
+	type UvCoordinate,
+} from './selected-outline-uv';
+import {callAddEffectKeyframe} from './Timeline/call-add-keyframe';
+import {saveEffectProp} from './Timeline/save-effect-prop';
+
+const getSvgPointFromPointerEvent = ({
+	event,
+	rect,
+}: {
+	readonly event: Pick<PointerEvent, 'clientX' | 'clientY'>;
+	readonly rect: DOMRect;
+}): OutlinePoint => {
+	return {
+		x: event.clientX - rect.left,
+		y: event.clientY - rect.top,
+	};
+};
+
+const SelectedUvHandleConnectionLines: React.FC<{
+	readonly handles: readonly SelectedOutlineUvHandle[];
+	readonly outline: SelectedOutline;
+}> = ({handles, outline}) => {
+	const lines = useMemo(
+		() => getUvHandleConnectionLines({handles, points: outline.points}),
+		[handles, outline.points],
+	);
+
+	return (
+		<>
+			{lines.map((line) => (
+				<line
+					key={line.key}
+					x1={line.from.x}
+					y1={line.from.y}
+					x2={line.to.x}
+					y2={line.to.y}
+					stroke={BLUE}
+					strokeWidth={2}
+					vectorEffect="non-scaling-stroke"
+					pointerEvents="none"
+				/>
+			))}
+		</>
+	);
+};
+
+const SelectedUvHandleCircle: React.FC<{
+	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly handle: SelectedOutlineUvHandle;
+	readonly outline: SelectedOutline;
+}> = ({handle, onDraggingChange, outline}) => {
+	const {setEffectDragOverrides, clearEffectDragOverrides, setPropStatuses} =
+		useContext(Internals.VisualModeSettersContext);
+	const position = useMemo(
+		() => getUvHandlePosition(outline.points, handle.value),
+		[handle.value, outline.points],
+	);
+
+	const onPointerDown = React.useCallback(
+		(event: React.PointerEvent<SVGCircleElement>) => {
+			if (event.button !== 0) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			const svg = event.currentTarget.ownerSVGElement;
+			if (svg === null) {
+				return;
+			}
+
+			const svgRect = svg.getBoundingClientRect();
+			let lastValue: UvCoordinate | null = null;
+			onDraggingChange(true);
+			const defaultValue =
+				handle.fieldDefault !== undefined
+					? JSON.stringify(handle.fieldDefault)
+					: null;
+
+			const updateFromPointerEvent = (
+				pointerEvent: PointerEvent | React.PointerEvent<SVGCircleElement>,
+			) => {
+				const point = getSvgPointFromPointerEvent({
+					event: pointerEvent,
+					rect: svgRect,
+				});
+				const nextValue = constrainUv(
+					getUvCoordinateForPoint(outline.points, point),
+					handle.fieldSchema,
+				);
+				lastValue = nextValue;
+				setEffectDragOverrides(
+					handle.nodePath,
+					handle.effectIndex,
+					handle.fieldKey,
+					handle.propStatus.status === 'keyframed'
+						? Internals.makeKeyframedDragOverride({
+								status: handle.propStatus,
+								frame: handle.sourceFrame,
+								value: nextValue,
+							})
+						: Internals.makeStaticDragOverride(nextValue),
+				);
+			};
+
+			updateFromPointerEvent(event);
+
+			const onPointerMove = (moveEvent: PointerEvent) => {
+				moveEvent.preventDefault();
+				updateFromPointerEvent(moveEvent);
+			};
+
+			const onPointerUp = () => {
+				window.removeEventListener('pointermove', onPointerMove);
+				window.removeEventListener('pointerup', onPointerUp);
+				window.removeEventListener('pointercancel', onPointerUp);
+				onDraggingChange(false);
+
+				const stringifiedValue =
+					lastValue === null ? null : JSON.stringify(lastValue);
+				const shouldSave = (() => {
+					if (lastValue === null) {
+						return false;
+					}
+
+					if (handle.propStatus.status === 'keyframed') {
+						return !tuplesEqual(handle.value, lastValue);
+					}
+
+					return (
+						!tuplesEqual(handle.propStatus.codeValue, lastValue) &&
+						!(
+							defaultValue === stringifiedValue &&
+							handle.propStatus.codeValue === undefined
+						)
+					);
+				})();
+
+				if (!shouldSave) {
+					clearEffectDragOverrides(handle.nodePath, handle.effectIndex);
+					return;
+				}
+
+				(handle.propStatus.status === 'keyframed'
+					? callAddEffectKeyframe({
+							fileName: handle.nodePath.absolutePath,
+							nodePath: handle.nodePath,
+							effectIndex: handle.effectIndex,
+							fieldKey: handle.fieldKey,
+							sourceFrame: handle.sourceFrame,
+							value: lastValue,
+							schema: handle.schema,
+							setPropStatuses,
+							clientId: handle.clientId,
+						})
+					: saveEffectProp({
+							type: 'value',
+							fileName: handle.nodePath.absolutePath,
+							nodePath: handle.nodePath,
+							effectIndex: handle.effectIndex,
+							fieldKey: handle.fieldKey,
+							value: lastValue,
+							defaultValue,
+							schema: handle.schema,
+							setPropStatuses,
+							clientId: handle.clientId,
+						})
+				).finally(() => {
+					clearEffectDragOverrides(handle.nodePath, handle.effectIndex);
+				});
+			};
+
+			window.addEventListener('pointermove', onPointerMove);
+			window.addEventListener('pointerup', onPointerUp);
+			window.addEventListener('pointercancel', onPointerUp);
+		},
+		[
+			clearEffectDragOverrides,
+			handle,
+			onDraggingChange,
+			outline.points,
+			setPropStatuses,
+			setEffectDragOverrides,
+		],
+	);
+
+	return (
+		<circle
+			cx={position.x}
+			cy={position.y}
+			r={6}
+			fill="white"
+			stroke={BLUE}
+			strokeWidth={2}
+			vectorEffect="non-scaling-stroke"
+			pointerEvents="all"
+			cursor="default"
+			onPointerDown={onPointerDown}
+		/>
+	);
+};
+
+type UvTarget = {
+	readonly containsSelection: boolean;
+	readonly uvHandles: readonly SelectedOutlineUvHandle[];
+};
+
+export const SelectedOutlineUvHandleConnectionLayer: React.FC<{
+	readonly outline: SelectedOutline;
+	readonly target: UvTarget | undefined;
+}> = ({outline, target}) => {
+	if (!target?.containsSelection || target.uvHandles.length === 0) {
+		return null;
+	}
+
+	return (
+		<SelectedUvHandleConnectionLines
+			handles={target.uvHandles}
+			outline={outline}
+		/>
+	);
+};
+
+export const SelectedOutlineUvHandleCircleLayer: React.FC<{
+	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly outline: SelectedOutline;
+	readonly target: UvTarget | undefined;
+}> = ({onDraggingChange, outline, target}) => {
+	if (!target?.containsSelection || target.uvHandles.length === 0) {
+		return null;
+	}
+
+	return (
+		<>
+			{target.uvHandles.map((handle) => (
+				<SelectedUvHandleCircle
+					key={`${handle.effectIndex}-${handle.fieldKey}`}
+					handle={handle}
+					onDraggingChange={onDraggingChange}
+					outline={outline}
+				/>
+			))}
+		</>
+	);
+};

--- a/packages/studio/src/components/selected-outline-geometry.ts
+++ b/packages/studio/src/components/selected-outline-geometry.ts
@@ -1,0 +1,33 @@
+export type OutlinePoint = {
+	readonly x: number;
+	readonly y: number;
+};
+
+export type SelectedOutline = {
+	readonly key: string;
+	readonly points: readonly [
+		OutlinePoint,
+		OutlinePoint,
+		OutlinePoint,
+		OutlinePoint,
+	];
+};
+
+export const clamp = (value: number, min: number, max: number): number => {
+	return Math.min(max, Math.max(min, value));
+};
+
+export const mix = (from: number, to: number, progress: number): number => {
+	return from + (to - from) * progress;
+};
+
+export const mixPoint = (
+	from: OutlinePoint,
+	to: OutlinePoint,
+	progress: number,
+): OutlinePoint => {
+	return {
+		x: mix(from.x, to.x, progress),
+		y: mix(from.y, to.y, progress),
+	};
+};

--- a/packages/studio/src/components/selected-outline-uv.ts
+++ b/packages/studio/src/components/selected-outline-uv.ts
@@ -1,0 +1,391 @@
+import type {
+	CanUpdateSequencePropStatusKeyframed,
+	CanUpdateSequencePropStatusStatic,
+	GetEffectDragOverrides,
+	PropStatuses,
+	SequenceFieldSchema,
+	SequencePropsSubscriptionKey,
+	SequenceSchema,
+	TSequence,
+} from 'remotion';
+import {Internals} from 'remotion';
+import {
+	clamp,
+	mix,
+	mixPoint,
+	type OutlinePoint,
+	type SelectedOutline,
+} from './selected-outline-geometry';
+
+export type UvCoordinate = readonly [number, number];
+
+export type UvCoordinateFieldSchema = Extract<
+	SequenceFieldSchema,
+	{type: 'uv-coordinate'}
+>;
+
+export type SelectedOutlineUvHandle = {
+	readonly clientId: string;
+	readonly propStatus:
+		| CanUpdateSequencePropStatusStatic
+		| CanUpdateSequencePropStatusKeyframed;
+	readonly effectIndex: number;
+	readonly fieldDefault: UvCoordinate | undefined;
+	readonly fieldKey: string;
+	readonly fieldSchema: UvCoordinateFieldSchema;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly schema: SequenceSchema;
+	readonly sourceFrame: number;
+	readonly value: UvCoordinate;
+};
+
+type UvConnectionHandle = Pick<
+	SelectedOutlineUvHandle,
+	'effectIndex' | 'fieldKey' | 'fieldSchema' | 'value'
+>;
+
+type UvHandleConnectionLine = {
+	readonly key: string;
+	readonly from: OutlinePoint;
+	readonly to: OutlinePoint;
+};
+
+type SelectedEffectFields = {
+	readonly allFields: boolean;
+	readonly fieldKeys: ReadonlySet<string>;
+};
+
+const parseUvCoordinate = (value: unknown): UvCoordinate | null => {
+	if (
+		Array.isArray(value) &&
+		value.length === 2 &&
+		value.every((item) => typeof item === 'number' && Number.isFinite(item))
+	) {
+		return [value[0], value[1]];
+	}
+
+	return null;
+};
+
+export const tuplesEqual = (left: unknown, right: UvCoordinate): boolean => {
+	if (!Array.isArray(left) || left.length !== 2) {
+		return false;
+	}
+
+	return left[0] === right[0] && left[1] === right[1];
+};
+
+const getBilinearUvHandlePosition = (
+	points: SelectedOutline['points'],
+	uv: UvCoordinate,
+): OutlinePoint => {
+	const [tl, tr, br, bl] = points;
+	const top = mixPoint(tl, tr, uv[0]);
+	const bottom = mixPoint(bl, br, uv[0]);
+	return mixPoint(top, bottom, uv[1]);
+};
+
+type ProjectiveTransform = {
+	readonly a: number;
+	readonly b: number;
+	readonly c: number;
+	readonly d: number;
+	readonly e: number;
+	readonly f: number;
+	readonly g: number;
+	readonly h: number;
+};
+
+const projectiveEpsilon = 0.000001;
+
+const getProjectiveTransform = (
+	points: SelectedOutline['points'],
+): ProjectiveTransform | null => {
+	const [tl, tr, br, bl] = points;
+	const dx1 = tr.x - br.x;
+	const dx2 = bl.x - br.x;
+	const dx3 = tl.x - tr.x + br.x - bl.x;
+	const dy1 = tr.y - br.y;
+	const dy2 = bl.y - br.y;
+	const dy3 = tl.y - tr.y + br.y - bl.y;
+
+	let g = 0;
+	let h = 0;
+	if (Math.abs(dx3) > projectiveEpsilon || Math.abs(dy3) > projectiveEpsilon) {
+		const determinant = dx1 * dy2 - dx2 * dy1;
+		if (Math.abs(determinant) < projectiveEpsilon) {
+			return null;
+		}
+
+		g = (dx3 * dy2 - dx2 * dy3) / determinant;
+		h = (dx1 * dy3 - dx3 * dy1) / determinant;
+	}
+
+	return {
+		a: tr.x - tl.x + g * tr.x,
+		b: bl.x - tl.x + h * bl.x,
+		c: tl.x,
+		d: tr.y - tl.y + g * tr.y,
+		e: bl.y - tl.y + h * bl.y,
+		f: tl.y,
+		g,
+		h,
+	};
+};
+
+const applyProjectiveTransform = (
+	transform: ProjectiveTransform,
+	uv: UvCoordinate,
+): OutlinePoint => {
+	const denominator = transform.g * uv[0] + transform.h * uv[1] + 1;
+	return {
+		x: (transform.a * uv[0] + transform.b * uv[1] + transform.c) / denominator,
+		y: (transform.d * uv[0] + transform.e * uv[1] + transform.f) / denominator,
+	};
+};
+
+export const getUvHandlePosition = (
+	points: SelectedOutline['points'],
+	uv: UvCoordinate,
+): OutlinePoint => {
+	const transform = getProjectiveTransform(points);
+	return transform === null
+		? getBilinearUvHandlePosition(points, uv)
+		: applyProjectiveTransform(transform, uv);
+};
+
+export const getUvHandleConnectionLines = ({
+	handles,
+	points,
+}: {
+	readonly handles: readonly UvConnectionHandle[];
+	readonly points: SelectedOutline['points'];
+}): UvHandleConnectionLine[] => {
+	const handlesByField = new Map(
+		handles.map((handle) => [
+			`${handle.effectIndex}\u0000${handle.fieldKey}`,
+			handle,
+		]),
+	);
+	const seenPairs = new Set<string>();
+	const lines: UvHandleConnectionLine[] = [];
+
+	for (const handle of handles) {
+		const targetFieldKey = handle.fieldSchema.lineTo;
+		if (targetFieldKey === undefined || targetFieldKey === handle.fieldKey) {
+			continue;
+		}
+
+		const target = handlesByField.get(
+			`${handle.effectIndex}\u0000${targetFieldKey}`,
+		);
+		if (target === undefined) {
+			continue;
+		}
+
+		const pairKey = [
+			handle.effectIndex,
+			...[handle.fieldKey, targetFieldKey].sort(),
+		].join('\u0000');
+		if (seenPairs.has(pairKey)) {
+			continue;
+		}
+
+		seenPairs.add(pairKey);
+		lines.push({
+			key: `${handle.effectIndex}-${handle.fieldKey}-${targetFieldKey}`,
+			from: getUvHandlePosition(points, handle.value),
+			to: getUvHandlePosition(points, target.value),
+		});
+	}
+
+	return lines;
+};
+
+const vectorBetween = (from: OutlinePoint, to: OutlinePoint): OutlinePoint => {
+	return {x: to.x - from.x, y: to.y - from.y};
+};
+
+const getBilinearUvCoordinateForPoint = (
+	points: SelectedOutline['points'],
+	point: OutlinePoint,
+): UvCoordinate => {
+	const [tl, tr, br, bl] = points;
+	let u = 0.5;
+	let v = 0.5;
+
+	for (let i = 0; i < 8; i++) {
+		const current = getBilinearUvHandlePosition(points, [u, v]);
+		const errorX = current.x - point.x;
+		const errorY = current.y - point.y;
+		if (Math.abs(errorX) + Math.abs(errorY) < 0.001) {
+			break;
+		}
+
+		const du = {
+			x: mix(tr.x - tl.x, br.x - bl.x, v),
+			y: mix(tr.y - tl.y, br.y - bl.y, v),
+		};
+		const dv = vectorBetween(mixPoint(tl, tr, u), mixPoint(bl, br, u));
+		const determinant = du.x * dv.y - du.y * dv.x;
+		if (Math.abs(determinant) < 0.000001) {
+			break;
+		}
+
+		u -= (errorX * dv.y - errorY * dv.x) / determinant;
+		v -= (du.x * errorY - du.y * errorX) / determinant;
+	}
+
+	return [u, v];
+};
+
+export const getUvCoordinateForPoint = (
+	points: SelectedOutline['points'],
+	point: OutlinePoint,
+): UvCoordinate => {
+	const transform = getProjectiveTransform(points);
+	if (transform === null) {
+		return getBilinearUvCoordinateForPoint(points, point);
+	}
+
+	const determinant =
+		transform.a * (transform.e - transform.f * transform.h) -
+		transform.b * (transform.d - transform.f * transform.g) +
+		transform.c * (transform.d * transform.h - transform.e * transform.g);
+	if (Math.abs(determinant) < projectiveEpsilon) {
+		return getBilinearUvCoordinateForPoint(points, point);
+	}
+
+	const inverseA = transform.e - transform.f * transform.h;
+	const inverseB = transform.c * transform.h - transform.b;
+	const inverseC = transform.b * transform.f - transform.c * transform.e;
+	const inverseD = transform.f * transform.g - transform.d;
+	const inverseE = transform.a - transform.c * transform.g;
+	const inverseF = transform.c * transform.d - transform.a * transform.f;
+	const inverseG = transform.d * transform.h - transform.e * transform.g;
+	const inverseH = transform.b * transform.g - transform.a * transform.h;
+	const inverseI = transform.a * transform.e - transform.b * transform.d;
+
+	const denominator = inverseG * point.x + inverseH * point.y + inverseI;
+	if (Math.abs(denominator) < projectiveEpsilon) {
+		return getBilinearUvCoordinateForPoint(points, point);
+	}
+
+	return [
+		(inverseA * point.x + inverseB * point.y + inverseC) / denominator,
+		(inverseD * point.x + inverseE * point.y + inverseF) / denominator,
+	];
+};
+
+export function constrainUv(
+	value: UvCoordinate,
+	schema: UvCoordinateFieldSchema,
+): UvCoordinate {
+	const min = schema.min ?? -Infinity;
+	const max = schema.max ?? Infinity;
+	return [clamp(value[0], min, max), clamp(value[1], min, max)];
+}
+
+export const getSelectedUvHandles = ({
+	propStatuses,
+	clientId,
+	getEffectDragOverrides,
+	nodePath,
+	selectedEffects,
+	sequence,
+	sourceFrame,
+}: {
+	readonly propStatuses: PropStatuses;
+	readonly clientId: string | null;
+	readonly getEffectDragOverrides: GetEffectDragOverrides;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly selectedEffects: Map<number, SelectedEffectFields> | undefined;
+	readonly sequence: TSequence;
+	readonly sourceFrame: number;
+}): SelectedOutlineUvHandle[] => {
+	if (clientId === null || selectedEffects === undefined) {
+		return [];
+	}
+
+	const handles: SelectedOutlineUvHandle[] = [];
+
+	for (const [effectIndex, selectedFields] of selectedEffects) {
+		const effect = sequence.effects[effectIndex];
+		if (!effect) {
+			continue;
+		}
+
+		const effectStatus = Internals.getEffectPropStatusesCtx({
+			propStatuses,
+			nodePath,
+			effectIndex,
+		});
+		if (effectStatus.type !== 'can-update-effect') {
+			continue;
+		}
+
+		const dragOverrides = getEffectDragOverrides(nodePath, effectIndex);
+		const activeSchema = Internals.flattenActiveSchema(effect.schema, (key) => {
+			const propStatus = effectStatus.props[key];
+			if (
+				propStatus?.status !== 'static' &&
+				propStatus?.status !== 'keyframed'
+			) {
+				return undefined;
+			}
+
+			return Internals.getEffectiveVisualModeValue({
+				propStatus,
+				dragOverrideValue: dragOverrides[key],
+				defaultValue: undefined,
+				frame: sourceFrame,
+				shouldResortToDefaultValueIfUndefined: false,
+			});
+		});
+
+		for (const [fieldKey, fieldSchema] of Object.entries(activeSchema)) {
+			if (
+				fieldSchema.type !== 'uv-coordinate' ||
+				(!selectedFields.allFields && !selectedFields.fieldKeys.has(fieldKey))
+			) {
+				continue;
+			}
+
+			const propStatus = effectStatus.props[fieldKey];
+			if (
+				propStatus?.status !== 'static' &&
+				propStatus?.status !== 'keyframed'
+			) {
+				continue;
+			}
+
+			const dragOverrideValue = dragOverrides[fieldKey];
+			const effectiveValue = Internals.getEffectiveVisualModeValue({
+				propStatus,
+				dragOverrideValue,
+				defaultValue: fieldSchema.default,
+				frame: sourceFrame,
+				shouldResortToDefaultValueIfUndefined: true,
+			});
+			const value = parseUvCoordinate(effectiveValue);
+			if (value === null) {
+				continue;
+			}
+
+			handles.push({
+				clientId,
+				propStatus,
+				effectIndex,
+				fieldDefault: fieldSchema.default,
+				fieldKey,
+				fieldSchema,
+				nodePath,
+				schema: effect.schema,
+				sourceFrame,
+				value,
+			});
+		}
+	}
+
+	return handles;
+};

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -11,6 +11,12 @@ import {
 import {NoReactInternals} from 'remotion/no-react';
 import {
 	constrainUv,
+	getSelectedUvHandles,
+	getUvCoordinateForPoint,
+	getUvHandleConnectionLines,
+	getUvHandlePosition,
+} from '../components/selected-outline-uv';
+import {
 	getOutlineSelectionInteraction,
 	getSelectedEffectFieldsBySequenceKey,
 	getSelectedOutlineDragChanges,
@@ -18,12 +24,8 @@ import {
 	getSelectedOutlineScaleDragChanges,
 	getSelectedOutlineScaleDragValues,
 	getSelectedOutlineScaleEdgeInfo,
-	getSelectedUvHandles,
 	getSelectedSequenceKeys,
 	getSequencesWithSelectableOutlines,
-	getUvCoordinateForPoint,
-	getUvHandleConnectionLines,
-	getUvHandlePosition,
 	type SelectedOutlineDragState,
 	type SelectedOutlineScaleDragState,
 } from '../components/SelectedOutlineOverlay';

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -18,6 +18,7 @@ import {
 	getSelectedOutlineScaleDragChanges,
 	getSelectedOutlineScaleDragValues,
 	getSelectedOutlineScaleEdgeInfo,
+	getSelectedUvHandles,
 	getSelectedSequenceKeys,
 	getSequencesWithSelectableOutlines,
 	getUvCoordinateForPoint,
@@ -1255,6 +1256,72 @@ test('UV handles are requested for selected effect children', () => {
 		allFields: true,
 		fieldKeys: new Set(),
 	});
+});
+
+test('UV handles are requested for keyframed selected effect props', () => {
+	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'position'],
+	);
+	const nodePath = sequenceNodePathInfo.sequenceSubscriptionKey;
+	const effectSchema = {
+		position: {
+			type: 'uv-coordinate',
+			default: [0, 0],
+		},
+	} as const satisfies SequenceSchema;
+	const propStatuses: PropStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					effectIndex: 0,
+					callee: 'testEffect',
+					importPath: null,
+					props: {
+						position: {
+							status: 'keyframed',
+							interpolationFunction: 'interpolate',
+							keyframes: [
+								{frame: 0, value: [0, 0]},
+								{frame: 100, value: [1, 1]},
+							],
+							easing: ['linear'],
+							clamping: {left: 'extend', right: 'extend'},
+							posterize: undefined,
+						},
+					},
+				},
+			],
+		},
+	};
+
+	const handles = getSelectedUvHandles({
+		propStatuses,
+		clientId: 'client-id',
+		getEffectDragOverrides: () => ({}),
+		nodePath,
+		selectedEffects: getSelectedEffectFieldsBySequenceKey([
+			{
+				type: 'sequence-effect-prop',
+				nodePathInfo: effectPropNodePathInfo,
+				i: 0,
+				key: 'position',
+			},
+		]).get(getTimelineSequenceSelectionKey(sequenceNodePathInfo)),
+		sequence: {
+			effects: [{schema: effectSchema}],
+		} as unknown as TSequence,
+		sourceFrame: 50,
+	});
+
+	expect(handles).toHaveLength(1);
+	expect(handles[0].propStatus.status).toBe('keyframed');
+	expect(handles[0].sourceFrame).toBe(50);
+	expect(handles[0].value).toEqual([0.5, 0.5]);
 });
 
 test('selected sequence keys only include exact sequence selections', () => {


### PR DESCRIPTION
Fixes #8224

## Summary
- Allow visual UV handles for keyframed effect props by resolving their value at the current source frame.
- Preview UV drags with keyframed drag overrides and save them through the effect keyframe API.
- Split selected outline geometry, UV helpers, and UV control layers into separate files.
- Add a regression test for keyframed selected effect `uv-coordinate` props.

## Testing
- cd packages/studio && bun test src/test/timeline-selection.test.ts
- bun run build
- bun run stylecheck
