### PR TITLE
`@remotion/renderer`: Add Node 24 selectComposition repro

### DIFF
--- a/packages/dockerfiles/README.md
+++ b/packages/dockerfiles/README.md
@@ -35,3 +35,31 @@ Located in `packages/example/src/BrowserTest/index.tsx`, it tests:
 Located in `packages/example/src/HtmlInCanvas/index.tsx`, it tests the experimental [WICG html-in-canvas](https://github.com/WICG/html-in-canvas) `CanvasRenderingContext2D.drawElementImage()` API. If the API is unavailable in the bundled Chrome (for example without `chrome://flags/#canvas-draw-element` enabled), the composition fails the render with an error.
 
 The bundle is built from `packages/example` and copied into each Docker container during build.
+
+## Issue #8198 selectComposition repro
+
+`issue-8198-node-24-select-composition` is a standalone Docker repro for a
+reported `selectComposition()` stall on Ubuntu 22.04 with Node 24.16.0 and
+Remotion 4.0.447. It intentionally lets `selectComposition()` download Chrome
+Headless Shell during the run, matching the reported failure path.
+
+```bash
+cd packages/dockerfiles/issue-8198-node-24-select-composition
+./run.sh
+```
+
+To compare against Node 24.15.0:
+
+```bash
+NODE_VERSION=24.15.0 ./run.sh
+```
+
+To test another Remotion version with the same Node version:
+
+```bash
+REMOTION_VERSION=4.0.474 ./run.sh
+```
+
+Remotion 4.0.447 reproduces the stall on Node 24.16.0 after the Chrome
+Headless Shell download completes. Remotion 4.0.474 resolves successfully,
+which verifies the vendored `yauzl` / `fd-slicer` lifecycle patch.

--- a/packages/dockerfiles/issue-8198-node-24-select-composition/Dockerfile
+++ b/packages/dockerfiles/issue-8198-node-24-select-composition/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:22.04
+
+ARG NODE_VERSION=24.16.0
+ARG REMOTION_VERSION=4.0.447
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  xz-utils \
+  libnss3 \
+  libdbus-1-3 \
+  libatk1.0-0 \
+  libgbm-dev \
+  libasound2 \
+  libxrandr2 \
+  libxkbcommon-dev \
+  libxfixes3 \
+  libxcomposite1 \
+  libxdamage1 \
+  libatk-bridge2.0-0 \
+  libpango-1.0-0 \
+  libcairo2 \
+  libcups2 \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+  architecture="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+  case "$architecture" in \
+    amd64) node_arch="x64" ;; \
+    arm64) node_arch="arm64" ;; \
+    *) echo "Unsupported architecture: $architecture" >&2; exit 1 ;; \
+  esac; \
+  curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${node_arch}.tar.xz"; \
+  tar -xJf "node-v${NODE_VERSION}-linux-${node_arch}.tar.xz" -C /usr/local --strip-components=1; \
+  rm "node-v${NODE_VERSION}-linux-${node_arch}.tar.xz"; \
+  node --version; \
+  npm --version
+
+WORKDIR /usr/app
+
+COPY repro-package.json ./package.json
+RUN npm install --no-audit --no-fund \
+  "@remotion/bundler@${REMOTION_VERSION}" \
+  "@remotion/renderer@${REMOTION_VERSION}" \
+  "remotion@${REMOTION_VERSION}" \
+  "react@18.3.1" \
+  "react-dom@18.3.1"
+
+COPY render.mjs ./
+COPY src ./src
+
+CMD ["node", "render.mjs"]

--- a/packages/dockerfiles/issue-8198-node-24-select-composition/render.mjs
+++ b/packages/dockerfiles/issue-8198-node-24-select-composition/render.mjs
@@ -1,0 +1,60 @@
+import {createRequire} from 'node:module';
+import {bundle} from '@remotion/bundler';
+import {selectComposition} from '@remotion/renderer';
+
+const require = createRequire(import.meta.url);
+
+const compositionId = 'Issue8198';
+const timeoutMs = Number(process.env.SELECT_COMPOSITION_TIMEOUT_MS ?? 120000);
+
+if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+	throw new Error('SELECT_COMPOSITION_TIMEOUT_MS must be a positive number');
+}
+
+const withTimeout = async (promise, label) => {
+	let timeout;
+	const timeoutPromise = new Promise((_, reject) => {
+		timeout = setTimeout(() => {
+			reject(new Error(`${label} did not resolve within ${timeoutMs}ms`));
+		}, timeoutMs);
+	});
+
+	try {
+		return await Promise.race([promise, timeoutPromise]);
+	} finally {
+		clearTimeout(timeout);
+	}
+};
+
+console.info(`[issue-8198] Node ${process.version}`);
+console.info('[issue-8198] Bundling minimal Remotion project');
+
+const serveUrl = await bundle({
+	entryPoint: require.resolve('./src/Root.jsx'),
+	logLevel: 'verbose',
+});
+
+console.info(`[issue-8198] Bundle ready at ${serveUrl}`);
+console.info(`[issue-8198] Calling selectComposition(${compositionId})`);
+
+const startedAt = Date.now();
+const composition = await withTimeout(
+	selectComposition({
+		id: compositionId,
+		inputProps: {},
+		logLevel: 'verbose',
+		serveUrl,
+	}),
+	'selectComposition()',
+);
+
+console.info(
+	`[issue-8198] selectComposition() resolved in ${Date.now() - startedAt}ms`,
+);
+console.info('[issue-8198] Composition:', {
+	durationInFrames: composition.durationInFrames,
+	fps: composition.fps,
+	height: composition.height,
+	id: composition.id,
+	width: composition.width,
+});

--- a/packages/dockerfiles/issue-8198-node-24-select-composition/repro-package.json
+++ b/packages/dockerfiles/issue-8198-node-24-select-composition/repro-package.json
@@ -1,0 +1,7 @@
+{
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"repro": "node render.mjs"
+	}
+}

--- a/packages/dockerfiles/issue-8198-node-24-select-composition/run.sh
+++ b/packages/dockerfiles/issue-8198-node-24-select-composition/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+image="${IMAGE:-remotion-issue-8198-node-24-select-composition}"
+node_version="${NODE_VERSION:-24.16.0}"
+remotion_version="${REMOTION_VERSION:-4.0.447}"
+timeout_ms="${SELECT_COMPOSITION_TIMEOUT_MS:-120000}"
+tag="$image:node-$node_version-remotion-$remotion_version"
+
+docker build \
+  --build-arg NODE_VERSION="$node_version" \
+  --build-arg REMOTION_VERSION="$remotion_version" \
+  -t "$tag" \
+  .
+docker run --rm -e SELECT_COMPOSITION_TIMEOUT_MS="$timeout_ms" "$tag"

--- a/packages/dockerfiles/issue-8198-node-24-select-composition/src/Root.jsx
+++ b/packages/dockerfiles/issue-8198-node-24-select-composition/src/Root.jsx
@@ -1,0 +1,33 @@
+import {AbsoluteFill, Composition, registerRoot} from 'remotion';
+
+const Issue8198 = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				alignItems: 'center',
+				backgroundColor: '#111827',
+				color: 'white',
+				fontFamily: 'Arial, sans-serif',
+				fontSize: 64,
+				justifyContent: 'center',
+			}}
+		>
+			Node 24.16.0 SSR
+		</AbsoluteFill>
+	);
+};
+
+const RemotionRoot = () => {
+	return (
+		<Composition
+			component={Issue8198}
+			durationInFrames={30}
+			fps={30}
+			height={720}
+			id="Issue8198"
+			width={1280}
+		/>
+	);
+};
+
+registerRoot(RemotionRoot);


### PR DESCRIPTION
## Summary

- Add a standalone Docker repro for #8198 using Ubuntu 22.04, Node 24.16.0, and Remotion 4.0.447.
- Allow overriding NODE_VERSION and REMOTION_VERSION to compare the failing version against patched/current Remotion versions.
- Document the observed failure and the successful Remotion 4.0.474 control run.

## Testing

- `cd packages/dockerfiles/issue-8198-node-24-select-composition && REMOTION_VERSION=4.0.474 SELECT_COMPOSITION_TIMEOUT_MS=120000 ./run.sh`
- `cd packages/dockerfiles/issue-8198-node-24-select-composition && SELECT_COMPOSITION_TIMEOUT_MS=30000 ./run.sh` (expected timeout on Remotion 4.0.447)
- `bun run build`
- `bun run stylecheck`
