### PR TITLE
`@remotion/studio`: Add Shift axis lock for outline dragging

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -441,6 +441,26 @@ export const getSelectedOutlineDragValues = ({
 	);
 };
 
+export const applySelectedOutlineDragAxisLock = ({
+	deltaX,
+	deltaY,
+	axisLocked,
+}: {
+	readonly deltaX: number;
+	readonly deltaY: number;
+	readonly axisLocked: boolean;
+}) => {
+	if (!axisLocked) {
+		return {deltaX, deltaY};
+	}
+
+	if (Math.abs(deltaX) >= Math.abs(deltaY)) {
+		return {deltaX, deltaY: 0};
+	}
+
+	return {deltaX: 0, deltaY};
+};
+
 export type SelectedOutlineStaticDragChange = SaveSequencePropChange & {
 	readonly type: 'static';
 };
@@ -780,11 +800,16 @@ const SelectedOutlinePolygon: React.FC<{
 
 			const onPointerMove = (moveEvent: PointerEvent) => {
 				moveEvent.preventDefault();
+				const dragDelta = applySelectedOutlineDragAxisLock({
+					deltaX: (moveEvent.clientX - startPointerX) / scale,
+					deltaY: (moveEvent.clientY - startPointerY) / scale,
+					axisLocked: moveEvent.shiftKey,
+				});
 
 				lastValues = getSelectedOutlineDragValues({
 					dragStates,
-					deltaX: (moveEvent.clientX - startPointerX) / scale,
-					deltaY: (moveEvent.clientY - startPointerY) / scale,
+					deltaX: dragDelta.deltaX,
+					deltaY: dragDelta.deltaY,
 				});
 				for (const dragState of dragStates) {
 					const value = lastValues.get(dragState.key);

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -797,13 +797,15 @@ const SelectedOutlinePolygon: React.FC<{
 				timelinePosition: timelinePositionRef.current,
 			});
 			let lastValues = new Map<string, string>();
+			let currentPointerX = startPointerX;
+			let currentPointerY = startPointerY;
+			let axisLocked = false;
 
-			const onPointerMove = (moveEvent: PointerEvent) => {
-				moveEvent.preventDefault();
+			const updateDragOverrides = () => {
 				const dragDelta = applySelectedOutlineDragAxisLock({
-					deltaX: (moveEvent.clientX - startPointerX) / scale,
-					deltaY: (moveEvent.clientY - startPointerY) / scale,
-					axisLocked: moveEvent.shiftKey,
+					deltaX: (currentPointerX - startPointerX) / scale,
+					deltaY: (currentPointerY - startPointerY) / scale,
+					axisLocked,
 				});
 
 				lastValues = getSelectedOutlineDragValues({
@@ -837,10 +839,34 @@ const SelectedOutlinePolygon: React.FC<{
 				}
 			};
 
+			const onPointerMove = (moveEvent: PointerEvent) => {
+				moveEvent.preventDefault();
+				currentPointerX = moveEvent.clientX;
+				currentPointerY = moveEvent.clientY;
+				axisLocked = moveEvent.shiftKey;
+				updateDragOverrides();
+			};
+
+			const onKeyChange = (keyEvent: KeyboardEvent) => {
+				if (keyEvent.key !== 'Shift') {
+					return;
+				}
+
+				const nextAxisLocked = keyEvent.type === 'keydown';
+				if (nextAxisLocked === axisLocked) {
+					return;
+				}
+
+				axisLocked = nextAxisLocked;
+				updateDragOverrides();
+			};
+
 			const onPointerUp = () => {
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
+				window.removeEventListener('keydown', onKeyChange);
+				window.removeEventListener('keyup', onKeyChange);
 				onDraggingChange(false);
 
 				const changes = getSelectedOutlineDragChanges({
@@ -907,6 +933,8 @@ const SelectedOutlinePolygon: React.FC<{
 			window.addEventListener('pointermove', onPointerMove);
 			window.addEventListener('pointerup', onPointerUp);
 			window.addEventListener('pointercancel', onPointerUp);
+			window.addEventListener('keydown', onKeyChange);
+			window.addEventListener('keyup', onKeyChange);
 		},
 		[
 			allDragTargets,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -17,6 +17,7 @@ import {
 	getUvHandlePosition,
 } from '../components/selected-outline-uv';
 import {
+	applySelectedOutlineDragAxisLock,
 	getOutlineSelectionInteraction,
 	getSelectedEffectFieldsBySequenceKey,
 	getSelectedOutlineDragChanges,
@@ -1618,6 +1619,30 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			schema,
 		},
 	]);
+});
+
+test('Selected outline dragging can lock movement to the dominant axis', () => {
+	expect(
+		applySelectedOutlineDragAxisLock({
+			deltaX: 12,
+			deltaY: 7,
+			axisLocked: true,
+		}),
+	).toEqual({deltaX: 12, deltaY: 0});
+	expect(
+		applySelectedOutlineDragAxisLock({
+			deltaX: 12,
+			deltaY: 13,
+			axisLocked: true,
+		}),
+	).toEqual({deltaX: 0, deltaY: 13});
+	expect(
+		applySelectedOutlineDragAxisLock({
+			deltaX: 12,
+			deltaY: 13,
+			axisLocked: false,
+		}),
+	).toEqual({deltaX: 12, deltaY: 13});
 });
 
 test('Selected outline dragging keyframed translate adds a keyframe at the source frame', () => {


### PR DESCRIPTION
Fixes #8236.

## Summary

- Lock canvas outline dragging to the dominant axis while Shift is held
- Allow releasing and re-holding Shift during the same drag by reading the current pointer event modifier state
- Add unit coverage for the axis-lock delta behavior

## Testing

- bun test src/test/timeline-selection.test.ts (from packages/studio)
- bun run build
- bun run stylecheck
