### PR TITLE
`@remotion/studio-server`: Avoid blank lines in keyframed props

### DIFF
--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -48,6 +48,89 @@ import {
 
 const b = recast.types.builders;
 
+const getObjectPropertyNameFromUpdateKey = (key: string): string => {
+	const dotIndex = key.indexOf('.');
+	return dotIndex === -1 ? key : key.slice(dotIndex + 1);
+};
+
+const lineStartsWithPropertyName = ({
+	line,
+	propertyName,
+}: {
+	line: string;
+	propertyName: string;
+}) => {
+	const trimmed = line.trimStart();
+	return (
+		trimmed.startsWith(`${propertyName}:`) ||
+		trimmed.startsWith(`'${propertyName}':`) ||
+		trimmed.startsWith(`"${propertyName}":`)
+	);
+};
+
+const getIndent = (line: string) => line.match(/^[ \t]*/)?.[0] ?? '';
+
+const removeBlankLinesFromObjectsWithProperties = ({
+	input,
+	propertyNames,
+}: {
+	input: string;
+	propertyNames: string[];
+}) => {
+	if (propertyNames.length === 0) {
+		return input;
+	}
+
+	const lines = input.split('\n');
+	const linesToRemove = new Set<number>();
+
+	for (let i = 0; i < lines.length; i++) {
+		const propertyName = propertyNames.find((name) =>
+			lineStartsWithPropertyName({line: lines[i], propertyName: name}),
+		);
+		if (!propertyName) {
+			continue;
+		}
+
+		const propertyIndentLength = getIndent(lines[i]).length;
+		let objectStart = i;
+		for (let j = i - 1; j >= 0; j--) {
+			const trimmed = lines[j].trim();
+			if (
+				trimmed.endsWith('{') &&
+				getIndent(lines[j]).length < propertyIndentLength
+			) {
+				objectStart = j;
+				break;
+			}
+		}
+
+		let objectEnd = i;
+		for (let j = i + 1; j < lines.length; j++) {
+			const trimmed = lines[j].trim();
+			if (
+				trimmed.startsWith('}') &&
+				getIndent(lines[j]).length < propertyIndentLength
+			) {
+				objectEnd = j;
+				break;
+			}
+		}
+
+		for (let j = objectStart + 1; j < objectEnd; j++) {
+			if (lines[j].trim() === '') {
+				linesToRemove.add(j);
+			}
+		}
+	}
+
+	if (linesToRemove.size === 0) {
+		return input;
+	}
+
+	return lines.filter((_, index) => !linesToRemove.has(index)).join('\n');
+};
+
 type KeyframeEasing = Extract<
 	CanUpdateSequencePropStatus,
 	{status: 'keyframed'}
@@ -1448,9 +1531,16 @@ export const updateSequenceKeyframes = async ({
 		input: serialized,
 		prettierConfigOverride,
 	});
+	const outputWithoutInsertedBlankLines =
+		removeBlankLinesFromObjectsWithProperties({
+			input: output,
+			propertyNames: updates.map((update) =>
+				getObjectPropertyNameFromUpdateKey(update.key),
+			),
+		});
 
 	return {
-		output,
+		output: outputWithoutInsertedBlankLines,
 		formatted,
 		oldValueStrings,
 		newValueStrings,
@@ -1608,9 +1698,14 @@ export const updateEffectKeyframes = async ({
 		input: serialized,
 		prettierConfigOverride,
 	});
+	const outputWithoutInsertedBlankLines =
+		removeBlankLinesFromObjectsWithProperties({
+			input: output,
+			propertyNames: updates.map((update) => update.key),
+		});
 
 	return {
-		output,
+		output: outputWithoutInsertedBlankLines,
 		formatted,
 		oldValueStrings,
 		newValueStrings,

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -404,6 +404,67 @@ test('updateSequenceKeyframes converts a static value to an interpolation', asyn
 	expect(output).toContain("extrapolateRight: 'clamp'");
 });
 
+test('updateSequenceKeyframes does not preserve blank lines around keyframed object properties', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+export const Example: React.FC = () => {
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div
+\t\t\t\tstyle={{
+\t\t\t\t\twidth: 360,
+\t\t\t\t\theight: 200,
+\t\t\t\t\tborderRadius: 24,
+\t\t\t\t\toverflow: 'hidden',
+
+\t\t\t\t\ttranslate: '0px 0px',
+
+\t\t\t\t\tscale: 1,
+\t\t\t\t}}
+\t\t\t/>
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const schema = {
+		'style.translate': {
+			type: 'translate',
+			default: '0px 0px',
+		},
+		'style.scale': {
+			type: 'number',
+			default: 1,
+			hiddenFromList: false,
+		},
+	} satisfies SequenceSchema;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, '<div')),
+		schema,
+		updates: [
+			{
+				key: 'style.translate',
+				operation: {type: 'add', frame: 14, value: '0px 0px'},
+			},
+			{
+				key: 'style.scale',
+				operation: {type: 'add', frame: 14, value: 1},
+			},
+		],
+	});
+
+	const styleStart = output.indexOf('style={{');
+	const styleEnd = output.indexOf('\t\t\t\t}}', styleStart);
+	expect(output.slice(styleStart, styleEnd)).not.toContain('\n\n');
+	expect(output).toContain(
+		"overflow: 'hidden',\n\t\t\t\t\ttranslate: interpolate(frame, [14], ['0px 0px'], {",
+	);
+	expect(output).toContain(
+		'\t\t\t\t\t}),\n\t\t\t\t\tscale: interpolate(frame, [14], [1], {',
+	);
+});
+
 test('updateSequenceKeyframes rejects non-keyframable fields', async () => {
 	const schema = {
 		'style.opacity': {


### PR DESCRIPTION
Fixes #8231.

## Summary
- Remove blank separator lines from objects containing newly written keyframe properties after formatting.
- Add a regression test for style keyframes created from objects with existing blank lines.

## Testing
- bun test packages/studio-server/src/test/update-keyframes.test.ts
- bun run build
- bun run stylecheck
