### PR TITLE
`@remotion/skills`: Add Studio-editable animation guidance

### DIFF
--- a/packages/docs/docs/ai/dynamic-compilation.mdx
+++ b/packages/docs/docs/ai/dynamic-compilation.mdx
@@ -188,17 +188,10 @@ export function useCompilation(code: string): CompilationResult {
 <TabItem value="generated" label="Input code">
 
 ```ts title="Example AI Output"
-const generatedCode = `import {useCurrentFrame, AbsoluteFill, spring, useVideoConfig} from 'remotion';
+const generatedCode = `import {useCurrentFrame, AbsoluteFill, interpolate, Easing} from 'remotion';
 
 export const MyComposition = () => {
   const frame = useCurrentFrame();
-  const {fps} = useVideoConfig();
-
-  const scale = spring({
-    frame,
-    fps,
-    config: {damping: 10, stiffness: 100},
-  });
 
   return (
     <AbsoluteFill
@@ -212,7 +205,11 @@ export const MyComposition = () => {
         style={{
           fontSize: 120,
           color: 'white',
-          transform: \`scale(\${scale})\`,
+          scale: interpolate(frame, [0, 20], [0, 1], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+            easing: Easing.bezier(0.34, 1.56, 0.64, 1),
+          }),
         }}
       >
         Hello World

--- a/packages/docs/docs/ai/generate.mdx
+++ b/packages/docs/docs/ai/generate.mdx
@@ -26,7 +26,8 @@ Generate a single React component that uses Remotion.
 Rules:
 - Export the component as a named export called "MyComposition"
 - Use useCurrentFrame() and useVideoConfig() from "remotion"
-- Animate values with interpolate() or spring() as appropriate
+- Prefer interpolate() with Easing over spring() unless physics-based motion is explicitly requested
+- Use inline interpolate() calls in style props and prefer scale, translate, rotate over transform strings
 - Only output the code, no markdown or explanations
 `.trim();
 
@@ -76,7 +77,8 @@ Generate a React component that uses Remotion. For the code property, ALWAYS dir
 Rules:
 - The component should be a named export called "MyComposition"
 - Use useCurrentFrame() and useVideoConfig() from "remotion"
-- Animate with interpolate() (and Easing from "remotion" when needed) or spring() as appropriate
+- Prefer interpolate() with Easing from "remotion" over spring() unless physics-based motion is explicitly requested
+- Use inline interpolate() calls in style props and prefer scale, translate, rotate over transform strings
 - Keep it self-contained with no external dependencies
 `.trim();
 

--- a/packages/docs/docs/transforms.mdx
+++ b/packages/docs/docs/transforms.mdx
@@ -97,7 +97,7 @@ See the explorer below to see how skewing affects an element.
 
 Translating an element means moving it. A translation can be done on the X, Y or even Z axis. The transformation can be specified in `px`.
 
-You can set the translation of an element using the `transform` property.
+You can set the translation of an element using the `translate` property.
 
 ```tsx twoslash {6} title="MyComponent.tsx"
 <div
@@ -105,7 +105,7 @@ You can set the translation of an element using the `transform` property.
     height: 100,
     width: 100,
     backgroundColor: 'red',
-    transform: `translateX(100px)`,
+    translate: '100px 0px',
   }}
 />
 ```
@@ -118,7 +118,7 @@ As opposed to changing the position of an element using `margin-top` and `margin
 
 By rotating an element, you can make it appear as if it has been turned around its center. The rotation can be specified in `rad` (radians) or `deg` (degrees) and you can rotate an element around the Z axis (the default) but also around the X and Y axis.
 
-You can set the translation of an element using the `transform` property.
+You can set the rotation of an element using the `rotate` property.
 
 ```tsx twoslash {6} title="MyComponent.tsx"
 <div
@@ -126,7 +126,7 @@ You can set the translation of an element using the `transform` property.
     height: 100,
     width: 100,
     backgroundColor: 'red',
-    transform: `rotate(45deg)`, // the same as rotateZ(45deg)
+    rotate: '45deg',
   }}
 />
 ```
@@ -141,9 +141,9 @@ Note that when rotating SVG elements, the transform origin is the top left corne
 
 ## Multiple transformations
 
-Oftentimes, you want to combine multiple transformations. If they use different CSS properties like `transform` and `opacity`, simply specify both properties in the `style` object.
+Oftentimes, you want to combine multiple transformations. If they use different CSS properties like `translate`, `scale` and `opacity`, specify them separately in the `style` object.
 
-If both transformations use the `transform` property, specify multiple transformations separated by a space.
+This also makes animations easier to edit in Remotion Studio.
 
 ```tsx twoslash {6} title="MyComponent.tsx"
 <div
@@ -151,16 +151,17 @@ If both transformations use the `transform` property, specify multiple transform
     height: 100,
     width: 100,
     backgroundColor: 'red',
-    transform: `translateX(100px) scale(2)`,
+    translate: '100px 0px',
+    scale: 2,
   }}
 />
 ```
 
-Note that the order matters. The transformations are applied in the order they are specified.
+Use `transform` strings when individual CSS transform properties do not cover the effect, such as `skew()`, `perspective()` or order-sensitive transform chains.
 
 ## Using the `makeTransform()` helper
 
-Install [`@remotion/animation-utils`](/docs/animation-utils/) to [get a type-safe helper function](/docs/animation-utils/make-transform) to generate `transform` strings.
+When you need a `transform` string, install [`@remotion/animation-utils`](/docs/animation-utils/) to [get a type-safe helper function](/docs/animation-utils/make-transform) to generate it.
 
 ```tsx twoslash
 import {makeTransform, rotate, translate} from '@remotion/animation-utils';

--- a/packages/skills/skills/remotion/SKILL.md
+++ b/packages/skills/skills/remotion/SKILL.md
@@ -23,10 +23,12 @@ Replace `my-video` with a suitable project name.
 
 Before designing visual scenes, layouts, promos, motion graphics, or text-heavy videos, load [rules/video-layout.md](rules/video-layout.md) for video-first layout and text sizing guidance.
 
-Animate properties using `useCurrentFrame()` and `interpolate()`. Use Easing to customize the timing of the animation.
+Animate properties using `useCurrentFrame()` and `interpolate()`. Prefer `interpolate()` over `spring()` unless physics-based motion is explicitly needed. Use `Easing.bezier()` to customize timing, including jumpy or overshooting motion.
+
+For animations that should be editable in Remotion Studio, keep the `interpolate()` call inline in the `style` prop and use individual CSS transform properties (`scale`, `translate`, `rotate`) instead of composing a `transform` string.
 
 ```tsx
-import { useCurrentFrame, Easing } from "remotion";
+import { useCurrentFrame, Easing, interpolate, useVideoConfig } from "remotion";
 
 export const FadeIn = () => {
   const frame = useCurrentFrame();
@@ -40,6 +42,26 @@ export const FadeIn = () => {
 
   return <div style={{ opacity }}>Hello World!</div>;
 };
+```
+
+Prefer:
+
+```tsx
+style={{
+  scale: interpolate(frame, [0, 100], [0, 1]),
+  translate: interpolate(frame, [0, 100], ["0px 0px", "100px 100px"]),
+  rotate: interpolate(frame, [0, 100], ["20deg", "90deg"]),
+}}
+```
+
+Over:
+
+```tsx
+const scale = interpolate(frame, [0, 100], [0, 1]);
+
+style={{
+  transform: `scale(${scale})`,
+}}
 ```
 
 CSS transitions or animations are FORBIDDEN - they will not render correctly.  

--- a/packages/skills/skills/remotion/rules/timing.md
+++ b/packages/skills/skills/remotion/rules/timing.md
@@ -5,7 +5,7 @@ metadata:
   tags: easing, bezier, interpolation, spring, timing
 ---
 
-Drive motion with `interpolate()` over explicit frame range. To customize timing, use **`Easing.bezier`**. The four parameters are the same as CSS `cubic-bezier(x1, y1, x2, y2)`.
+Drive motion with `interpolate()` over an explicit frame range. Prefer `interpolate()` over `spring()` unless the user explicitly asks for physics-based motion. To customize timing, use **`Easing.bezier`**. The four parameters are the same as CSS `cubic-bezier(x1, y1, x2, y2)`.
 
 A simple linear interpolation is done using the `interpolate` function.
 
@@ -24,6 +24,30 @@ const opacity = interpolate(frame, [0, 100], [0, 1], {
   extrapolateLeft: "clamp",
 });
 ```
+
+## Studio-editable animation patterns
+
+When an animation should be editable in Remotion Studio, keep the `interpolate()` call directly in the `style` prop and prefer individual CSS transform properties:
+
+```tsx
+style={{
+  scale: interpolate(frame, [0, 100], [0, 1]),
+  translate: interpolate(frame, [0, 100], ["0px 0px", "100px 100px"]),
+  rotate: interpolate(frame, [0, 100], ["20deg", "90deg"]),
+}}
+```
+
+Avoid extracting the value and composing a `transform` string:
+
+```tsx
+const scale = interpolate(frame, [0, 100], [0, 1]);
+
+style={{
+  transform: `scale(${scale})`,
+}}
+```
+
+Use `transform` strings only when individual CSS transform properties do not cover the effect, such as `skew()`, `perspective()`, or order-sensitive multi-transform chains.
 
 ## Bézier easing
 
@@ -106,7 +130,7 @@ Use `Easing.out` for enter animations (starts fast, decelerates into place) and 
 
 ## Composing interpolations
 
-When multiple properties share the same timing (e.g. a slide-in panel and a video shift), avoid duplicating the full interpolation for each property. Instead, create a single normalized progress value (0 to 1) and derive each property from it:
+When multiple properties share the same timing and do not need Studio keyframe editing (e.g. a slide-in panel and a video shift), avoid duplicating the full interpolation for each property. Instead, create a single normalized progress value (0 to 1) and derive each property from it:
 
 ```tsx
 const slideIn = interpolate(
@@ -134,3 +158,5 @@ const opacity = interpolate(progress, [0, 1], [0, 1]);
 ```
 
 The key idea: separate **timing** (when and how fast) from **mapping** (what values to animate between).
+
+If the values should be visually keyframed in Studio, prefer inline `interpolate()` calls in the relevant style props, even if it duplicates the timing.


### PR DESCRIPTION
## Summary

- Add Studio-editable animation guidance to the Remotion skills
- Prefer inline `interpolate()` and individual transform properties in agent-facing guidance
- Update related docs examples for transforms and AI code generation

## Testing

- `cd packages/skills && bunx oxfmt src --write`
- `cd packages/docs && bunx oxfmt src --write`
- `bun run build && bun run stylecheck`
- `cd packages/docs && bun run build-docs`
