### PR TITLE
Docs: Reduce docs build Node memory

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,7 +10,7 @@
 		"format": "oxfmt src",
 		"docusaurus": "docusaurus",
 		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && docusaurus start --host 0.0.0.0",
-		"build-docs": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun prewarm-twoslash.ts && NODE_OPTIONS=\"--max-old-space-size=200\" DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus build && bun copy-convert.ts && bun count-pages.ts",
+		"build-docs": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun prewarm-twoslash.ts && NODE_OPTIONS=\"--max-old-space-size=1024\" DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus build && bun copy-convert.ts && bun count-pages.ts",
 		"swizzle": "docusaurus swizzle",
 		"deploy": "docusaurus deploy",
 		"serve": "docusaurus serve",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,7 +10,7 @@
 		"format": "oxfmt src",
 		"docusaurus": "docusaurus",
 		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && docusaurus start --host 0.0.0.0",
-		"build-docs": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun prewarm-twoslash.ts && DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus build && bun copy-convert.ts && bun count-pages.ts",
+		"build-docs": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun prewarm-twoslash.ts && NODE_OPTIONS=\"--max-old-space-size=200\" DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus build && bun copy-convert.ts && bun count-pages.ts",
 		"swizzle": "docusaurus swizzle",
 		"deploy": "docusaurus deploy",
 		"serve": "docusaurus serve",


### PR DESCRIPTION
## Summary

- Cap Node old-space during the Docusaurus docs build at 1024 MB
- Leave the Twoslash prewarm and post-build docs steps unchanged

## Context

Follow-up to #8242. Profiling showed that cached Docusaurus/Rspack builds still use multiple GB of memory, while lowering Node old-space kept the docs build passing. 1024 MB is a less aggressive cap than the initial 200 MB experiment while still preventing Node from growing without bounds during the Rspack build.

## Test

- `cd packages/docs && bun run build-docs`
- `cd packages/docs && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
