### PR TITLE
`@remotion/studio-server`: Make log updates more concise

### DIFF
--- a/packages/studio-server/src/preview-server/routes/log-updates/formatting.ts
+++ b/packages/studio-server/src/preview-server/routes/log-updates/formatting.ts
@@ -34,6 +34,7 @@ export const equals = (str: string) => fg(249, 38, 114, str);
 export const punctuation = (str: string) => str;
 export const stringValue = (str: string) => fg(230, 219, 116, str);
 export const numberValue = (str: string) => fg(174, 129, 255, str);
+export const inlineAddition = (str: string) => fg(166, 226, 46, str);
 export const strikeThrough = (str: string) =>
 	`\u001b[9m\u001b[38;2;255;85;85m${stripAnsi(str)}\u001b[39m\u001b[29m`;
 export const strikeThroughOrRemovedPrefix = (str: string) =>
@@ -74,6 +75,10 @@ const formatValueDelta = ({
 	const shortened = removeUnchangedInterpolateOptionProperties(
 		withoutUnchangedOptions,
 	);
+	const inlineDelta = formatInlineAdditionOrRemoval(shortened);
+	if (inlineDelta !== null) {
+		return inlineDelta;
+	}
 
 	return `${colorValue(shortened.oldValueString)} ${punctuation('→')} ${colorValue(shortened.newValueString)}`;
 };
@@ -202,6 +207,84 @@ const splitTopLevelArgs = (argsSource: string) => {
 
 	args.push(argsSource.slice(start).trim());
 	return args;
+};
+
+const getCommonPrefixLength = (
+	oldValueString: string,
+	newValueString: string,
+) => {
+	const maxLength = Math.min(oldValueString.length, newValueString.length);
+	let index = 0;
+
+	while (index < maxLength && oldValueString[index] === newValueString[index]) {
+		index++;
+	}
+
+	return index;
+};
+
+const getCommonSuffixLength = ({
+	oldValueString,
+	newValueString,
+	prefixLength,
+}: {
+	oldValueString: string;
+	newValueString: string;
+	prefixLength: number;
+}) => {
+	const maxLength =
+		Math.min(oldValueString.length, newValueString.length) - prefixLength;
+	let index = 0;
+
+	while (
+		index < maxLength &&
+		oldValueString[oldValueString.length - 1 - index] ===
+			newValueString[newValueString.length - 1 - index]
+	) {
+		index++;
+	}
+
+	return index;
+};
+
+const minSharedInlineDeltaChars = 12;
+
+const formatInlineAdditionOrRemoval = ({
+	oldValueString,
+	newValueString,
+}: {
+	oldValueString: string;
+	newValueString: string;
+}) => {
+	if (!colorEnabled()) {
+		return null;
+	}
+
+	const prefixLength = getCommonPrefixLength(oldValueString, newValueString);
+	const suffixLength = getCommonSuffixLength({
+		oldValueString,
+		newValueString,
+		prefixLength,
+	});
+
+	if (prefixLength + suffixLength < minSharedInlineDeltaChars) {
+		return null;
+	}
+
+	const oldMiddleEnd = oldValueString.length - suffixLength;
+	const newMiddleEnd = newValueString.length - suffixLength;
+	const oldMiddle = oldValueString.slice(prefixLength, oldMiddleEnd);
+	const newMiddle = newValueString.slice(prefixLength, newMiddleEnd);
+
+	if (oldMiddle.length === 0 && newMiddle.length > 0) {
+		return `${newValueString.slice(0, prefixLength)}${inlineAddition(newMiddle)}${newValueString.slice(newMiddleEnd)}`;
+	}
+
+	if (newMiddle.length === 0 && oldMiddle.length > 0) {
+		return `${oldValueString.slice(0, prefixLength)}${strikeThrough(oldMiddle)}${oldValueString.slice(oldMiddleEnd)}`;
+	}
+
+	return null;
 };
 
 const getObjectPropertyKey = (propertySource: string): string | null => {

--- a/packages/studio-server/src/test/log-update.test.ts
+++ b/packages/studio-server/src/test/log-update.test.ts
@@ -12,8 +12,10 @@ import {formatPropChange} from '../preview-server/routes/log-updates/format-prop
 import {
 	attrName,
 	equals,
+	inlineAddition,
 	numberValue,
 	punctuation,
+	strikeThrough,
 } from '../preview-server/routes/log-updates/formatting';
 import {
 	logUpdate,
@@ -146,6 +148,44 @@ test('formatPropChange omits unchanged interpolate clamping when easing changes'
 	expect(formatted).not.toContain('extrapolateRight');
 	expect(formatted).toContain('Easing.bezier(0.5526, 3.9109, 0.995, 5)');
 	expect(formatted).toContain('Easing.bezier(0.5526, 3.9109, 0.6487, 4.8024)');
+});
+
+test('formatPropChange condenses added interpolateColors options', () => {
+	const addedOptions = `, {
+    easing: [Easing.bezier(0.4507, 2.3556, 0.6118, 0.0554)]
+}`;
+	const formatted = formatPropChange({
+		key: 'color',
+		oldValueString: `interpolateColors(frame, [0, 100], ['#0b84f3', '#f43b00'])`,
+		newValueString: `interpolateColors(frame, [0, 100], ['#0b84f3', '#f43b00']${addedOptions})`,
+		defaultValueString: null,
+		removedProps: [],
+		addedProps: [],
+	});
+
+	expect(formatted).toBe(
+		`${attrName('color')}${equals('=')}${punctuation('{')}interpolateColors(frame, [0, 100], ['#0b84f3', '#f43b00']${inlineAddition(addedOptions)})${punctuation('}')}`,
+	);
+	expect(formatted).not.toContain(' → ');
+});
+
+test('formatPropChange condenses removed interpolateColors options', () => {
+	const removedOptions = `, {
+    easing: [Easing.bezier(0.4507, 2.3556, 0.6118, 0.0554)]
+}`;
+	const formatted = formatPropChange({
+		key: 'color',
+		oldValueString: `interpolateColors(frame, [0, 100], ['#0b84f3', '#f43b00']${removedOptions})`,
+		newValueString: `interpolateColors(frame, [0, 100], ['#0b84f3', '#f43b00'])`,
+		defaultValueString: null,
+		removedProps: [],
+		addedProps: [],
+	});
+
+	expect(formatted).toBe(
+		`${attrName('color')}${equals('=')}${punctuation('{')}interpolateColors(frame, [0, 100], ['#0b84f3', '#f43b00']${strikeThrough(removedOptions)})${punctuation('}')}`,
+	);
+	expect(formatted).not.toContain(' → ');
 });
 
 test('logUpdate emits change-from-default output for discriminated union enum change', async () => {


### PR DESCRIPTION
## Summary

- Make prop update logs more concise for pure inline additions/removals by highlighting only the changed segment.
- Add regression coverage for `interpolateColors()` easing option additions and removals.

Fixes #8254.

## Testing

- bun test packages/studio-server/src/test/log-update.test.ts
- bunx turbo make --filter="@remotion/studio-server"
- bun run build
- bun run stylecheck
