### PR TITLE
`@remotion/studio`: Add timeline marquee selection

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -26,7 +26,11 @@ import {
 	getScrollPositionForCursorOnRightEdge,
 	scrollToTimelineXOffset,
 } from './timeline-scroll-logic';
-import {TIMELINE_TOP_DRAG} from './TimelineSelection';
+import {
+	TIMELINE_SCRUBBER_ATTR,
+	TIMELINE_TOP_DRAG,
+	useTimelineSelection,
+} from './TimelineSelection';
 import {redrawTimelineSliderFast} from './TimelineSlider';
 import {TIMELINE_TIME_INDICATOR_HEIGHT} from './TimelineTimeIndicators';
 
@@ -60,6 +64,7 @@ export const TimelineDragHandler: React.FC = () => {
 
 	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
 	const {canvasContent} = useContext(Internals.CompositionManager);
+	const {canSelect, canSelectEasing} = useTimelineSelection();
 
 	const containerStyle: React.CSSProperties = useMemo(() => {
 		if (!canvasContent || canvasContent.type !== 'composition') {
@@ -70,16 +75,22 @@ export const TimelineDragHandler: React.FC = () => {
 		return {
 			...container,
 			width: 100 * zoom + '%',
-			...(TIMELINE_TOP_DRAG ? {height: TIMELINE_TIME_INDICATOR_HEIGHT} : {}),
+			...(TIMELINE_TOP_DRAG || canSelect || canSelectEasing
+				? {height: TIMELINE_TIME_INDICATOR_HEIGHT}
+				: {}),
 		};
-	}, [canvasContent, zoomMap]);
+	}, [canSelect, canSelectEasing, canvasContent, zoomMap]);
 
 	if (!canvasContent || canvasContent.type !== 'composition') {
 		return null;
 	}
 
 	return (
-		<div ref={sliderAreaRef} style={containerStyle}>
+		<div
+			ref={sliderAreaRef}
+			style={containerStyle}
+			{...{[TIMELINE_SCRUBBER_ATTR]: true}}
+		>
 			{video ? <TimelineDragHandlerInnerMemo /> : null}
 		</div>
 	);

--- a/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useMemo} from 'react';
+import React, {useContext, useMemo, useRef} from 'react';
 import {useVideoConfig} from 'remotion';
 import {LIGHT_TEXT} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
@@ -6,7 +6,11 @@ import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sor
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {TimelineKeyframeDiamondIcon} from './TimelineKeyframeDiamondIcon';
 import {useTimelineKeyframeDragState} from './TimelineKeyframeDragState';
-import {useTimelineKeyframeSelection} from './TimelineSelection';
+import {
+	TIMELINE_MARQUEE_ITEM_ATTR,
+	useTimelineKeyframeSelection,
+	useTimelineMarqueeSelectableItem,
+} from './TimelineSelection';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 import {useTimelineKeyframeDrag} from './use-timeline-keyframe-drag';
 
@@ -31,10 +35,10 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 }> = ({frame, rowHeight, nodePathInfo}) => {
 	const videoConfig = useVideoConfig();
 	const timelineWidth = useContext(TimelineWidthContext);
-	const {selected, onSelect, selectable} = useTimelineKeyframeSelection(
-		nodePathInfo,
-		frame,
-	);
+	const ref = useRef<HTMLButtonElement>(null);
+	const {selected, onSelect, selectable, selectionItem} =
+		useTimelineKeyframeSelection(nodePathInfo, frame);
+	useTimelineMarqueeSelectableItem(selectionItem, ref);
 	const {isKeyframeDragging} = useTimelineKeyframeDragState();
 	const visuallySelected =
 		selected || isKeyframeDragging({nodePathInfo, frame});
@@ -72,6 +76,8 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 
 	return (
 		<button
+			ref={ref}
+			{...{[TIMELINE_MARQUEE_ITEM_ATTR]: true}}
 			type="button"
 			style={style}
 			title={`Keyframe at frame ${frame}`}

--- a/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
@@ -10,8 +10,10 @@ import {ModalsContext} from '../../state/modals';
 import {ContextMenuForTarget} from '../ContextMenu';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {
+	TIMELINE_MARQUEE_ITEM_ATTR,
 	useCurrentTimelineSelectionStateAsRef,
 	useTimelineEasingSelection,
+	useTimelineMarqueeSelectableItem,
 } from './TimelineSelection';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 import {
@@ -61,6 +63,7 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 			toFrame,
 			segmentIndex,
 		});
+	useTimelineMarqueeSelectableItem(selectionItem, buttonRef);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const sequencesRef = useContext(Internals.SequenceManagerRefContext);
 	const propStatusesRef = useContext(
@@ -272,6 +275,7 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 		<>
 			<button
 				ref={buttonRef}
+				{...{[TIMELINE_MARQUEE_ITEM_ATTR]: true}}
 				type="button"
 				style={style}
 				title={`Easing from frame ${fromFrame} to ${toFrame}`}

--- a/packages/studio/src/components/Timeline/TimelineScrollable.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScrollable.tsx
@@ -2,7 +2,6 @@ import React, {useMemo} from 'react';
 import {TIMELINE_BACKGROUND} from '../../helpers/colors';
 import {HORIZONTAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {scrollableRef} from './timeline-refs';
-import {useTimelineMarqueeSelection} from './TimelineSelection';
 
 const outer: React.CSSProperties = {
 	width: '100%',
@@ -13,19 +12,9 @@ const outer: React.CSSProperties = {
 	backgroundColor: TIMELINE_BACKGROUND,
 };
 
-const marqueeStyle: React.CSSProperties = {
-	backgroundColor: 'rgba(70, 130, 255, 0.16)',
-	border: '1px solid rgba(70, 130, 255, 0.75)',
-	boxSizing: 'border-box',
-	pointerEvents: 'none',
-	position: 'fixed',
-	zIndex: 10,
-};
-
 export const TimelineScrollable: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
-	const {marqueeRect, onPointerDownCapture} = useTimelineMarqueeSelection();
 	const containerStyle: React.CSSProperties = useMemo(() => {
 		return {
 			width: '100%',
@@ -38,20 +27,8 @@ export const TimelineScrollable: React.FC<{
 			ref={scrollableRef}
 			style={outer}
 			className={HORIZONTAL_SCROLLBAR_CLASSNAME}
-			onPointerDownCapture={onPointerDownCapture}
 		>
 			<div style={containerStyle}>{children}</div>
-			{marqueeRect === null ? null : (
-				<div
-					style={{
-						...marqueeStyle,
-						height: marqueeRect.bottom - marqueeRect.top,
-						left: marqueeRect.left,
-						top: marqueeRect.top,
-						width: marqueeRect.right - marqueeRect.left,
-					}}
-				/>
-			)}
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineScrollable.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScrollable.tsx
@@ -2,6 +2,7 @@ import React, {useMemo} from 'react';
 import {TIMELINE_BACKGROUND} from '../../helpers/colors';
 import {HORIZONTAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {scrollableRef} from './timeline-refs';
+import {useTimelineMarqueeSelection} from './TimelineSelection';
 
 const outer: React.CSSProperties = {
 	width: '100%',
@@ -12,9 +13,19 @@ const outer: React.CSSProperties = {
 	backgroundColor: TIMELINE_BACKGROUND,
 };
 
+const marqueeStyle: React.CSSProperties = {
+	backgroundColor: 'rgba(70, 130, 255, 0.16)',
+	border: '1px solid rgba(70, 130, 255, 0.75)',
+	boxSizing: 'border-box',
+	pointerEvents: 'none',
+	position: 'fixed',
+	zIndex: 10,
+};
+
 export const TimelineScrollable: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
+	const {marqueeRect, onPointerDownCapture} = useTimelineMarqueeSelection();
 	const containerStyle: React.CSSProperties = useMemo(() => {
 		return {
 			width: '100%',
@@ -27,8 +38,20 @@ export const TimelineScrollable: React.FC<{
 			ref={scrollableRef}
 			style={outer}
 			className={HORIZONTAL_SCROLLBAR_CLASSNAME}
+			onPointerDownCapture={onPointerDownCapture}
 		>
 			<div style={containerStyle}>{children}</div>
+			{marqueeRect === null ? null : (
+				<div
+					style={{
+						...marqueeStyle,
+						height: marqueeRect.bottom - marqueeRect.top,
+						left: marqueeRect.left,
+						top: marqueeRect.top,
+						width: marqueeRect.right - marqueeRect.left,
+					}}
+				/>
+			)}
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -60,10 +60,10 @@ export const getTimelineSelectedTrackHighlightStyle = (
 	width: timelineWidth,
 });
 
-export const SELECTION_ENABLED = true;
-export const TIMELINE_TOP_DRAG = true;
-export const ENABLE_OUTLINES = true;
-export const EASING_SELECTION_ENABLED = true;
+export const SELECTION_ENABLED = false;
+export const TIMELINE_TOP_DRAG = false;
+export const ENABLE_OUTLINES = false;
+export const EASING_SELECTION_ENABLED = false;
 
 type TimelineSelectionBase = {
 	readonly nodePathInfo: SequenceNodePathInfo;
@@ -360,26 +360,35 @@ export const getTimelineMarqueeSelection = ({
 			timelineMarqueeRectsIntersect(candidate.rect, marqueeRect)
 		);
 	});
-	const nextLockedSelectionKind =
-		lockedSelectionKind ??
-		(intersectingCandidates.length === 0
+	const getFirstIntersectingSelectionKind = () =>
+		intersectingCandidates.length === 0
 			? null
-			: getTimelineMarqueeSelectionKind(intersectingCandidates[0].item));
+			: getTimelineMarqueeSelectionKind(intersectingCandidates[0].item);
+	let nextLockedSelectionKind =
+		lockedSelectionKind ?? getFirstIntersectingSelectionKind();
+	const getSelectedItemsForKind = (kind: TimelineMarqueeSelectionKind) =>
+		intersectingCandidates
+			.filter((candidate) =>
+				isTimelineSelectionCompatibleWithMarqueeKind(candidate.item, kind),
+			)
+			.map((candidate) => candidate.item);
 
 	if (nextLockedSelectionKind === null) {
 		return {lockedSelectionKind: null, selectedItems: []};
 	}
 
+	let selectedItems = getSelectedItemsForKind(nextLockedSelectionKind);
+	if (lockedSelectionKind !== null && selectedItems.length === 0) {
+		nextLockedSelectionKind = getFirstIntersectingSelectionKind();
+		selectedItems =
+			nextLockedSelectionKind === null
+				? []
+				: getSelectedItemsForKind(nextLockedSelectionKind);
+	}
+
 	return {
 		lockedSelectionKind: nextLockedSelectionKind,
-		selectedItems: intersectingCandidates
-			.filter((candidate) =>
-				isTimelineSelectionCompatibleWithMarqueeKind(
-					candidate.item,
-					nextLockedSelectionKind,
-				),
-			)
-			.map((candidate) => candidate.item),
+		selectedItems,
 	};
 };
 

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -60,10 +60,10 @@ export const getTimelineSelectedTrackHighlightStyle = (
 	width: timelineWidth,
 });
 
-export const SELECTION_ENABLED = false;
-export const TIMELINE_TOP_DRAG = false;
-export const ENABLE_OUTLINES = false;
-export const EASING_SELECTION_ENABLED = false;
+export const SELECTION_ENABLED = true;
+export const TIMELINE_TOP_DRAG = true;
+export const ENABLE_OUTLINES = true;
+export const EASING_SELECTION_ENABLED = true;
 
 type TimelineSelectionBase = {
 	readonly nodePathInfo: SequenceNodePathInfo;
@@ -880,9 +880,6 @@ export const useTimelineMarqueeSelection = () => {
 			) {
 				return;
 			}
-
-			event.preventDefault();
-			event.stopPropagation();
 
 			const {currentTarget: target, pointerId} = event;
 			if (target.setPointerCapture) {

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -60,10 +60,10 @@ export const getTimelineSelectedTrackHighlightStyle = (
 	width: timelineWidth,
 });
 
-export const SELECTION_ENABLED = false;
-export const TIMELINE_TOP_DRAG = false;
-export const ENABLE_OUTLINES = false;
-export const EASING_SELECTION_ENABLED = false;
+export const SELECTION_ENABLED = true;
+export const TIMELINE_TOP_DRAG = true;
+export const ENABLE_OUTLINES = true;
+export const EASING_SELECTION_ENABLED = true;
 
 type TimelineSelectionBase = {
 	readonly nodePathInfo: SequenceNodePathInfo;
@@ -306,6 +306,22 @@ export const getNormalizedTimelineMarqueeRect = ({
 	top: Math.min(startY, currentY),
 	right: Math.max(startX, currentX),
 	bottom: Math.max(startY, currentY),
+});
+
+export const getClampedTimelineMarqueePoint = ({
+	x,
+	y,
+	bounds,
+}: {
+	readonly x: number;
+	readonly y: number;
+	readonly bounds: TimelineMarqueeRect;
+}): {
+	readonly x: number;
+	readonly y: number;
+} => ({
+	x: Math.min(bounds.right, Math.max(bounds.left, x)),
+	y: Math.min(bounds.bottom, Math.max(bounds.top, y)),
 });
 
 export const timelineMarqueeRectsIntersect = (
@@ -895,8 +911,20 @@ export const useTimelineMarqueeSelection = () => {
 				target.setPointerCapture(pointerId);
 			}
 
-			const startX = event.clientX;
-			const startY = event.clientY;
+			const initialBounds = target.getBoundingClientRect();
+			const marqueeBounds: TimelineMarqueeRect = {
+				bottom: initialBounds.bottom,
+				left: initialBounds.left,
+				right: initialBounds.right,
+				top: initialBounds.top,
+			};
+			const start = getClampedTimelineMarqueePoint({
+				bounds: marqueeBounds,
+				x: event.clientX,
+				y: event.clientY,
+			});
+			const startX = start.x;
+			const startY = start.y;
 			const previousUserSelect = document.body.style.userSelect;
 			const previousWebkitUserSelect = document.body.style.webkitUserSelect;
 			document.body.style.userSelect = 'none';
@@ -919,17 +947,23 @@ export const useTimelineMarqueeSelection = () => {
 			};
 
 			const updateSelection = (clientX: number, clientY: number) => {
+				const current = getClampedTimelineMarqueePoint({
+					bounds: marqueeBounds,
+					x: clientX,
+					y: clientY,
+				});
 				if (
 					!hasDragged &&
-					Math.max(Math.abs(clientX - startX), Math.abs(clientY - startY)) < 3
+					Math.max(Math.abs(current.x - startX), Math.abs(current.y - startY)) <
+						3
 				) {
 					return;
 				}
 
 				hasDragged = true;
 				const rect = getNormalizedTimelineMarqueeRect({
-					currentX: clientX,
-					currentY: clientY,
+					currentX: current.x,
+					currentY: current.y,
 					startX,
 					startY,
 				});

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -127,6 +127,20 @@ export type TimelineSelectionState = {
 	readonly anchor: TimelineSelection | null;
 };
 
+export type TimelineMarqueeRect = {
+	readonly left: number;
+	readonly top: number;
+	readonly right: number;
+	readonly bottom: number;
+};
+
+export type TimelineMarqueeSelectionKind = 'sequence' | 'keyframes-and-easings';
+
+export type TimelineMarqueeSelectionCandidate = {
+	readonly item: TimelineSelection;
+	readonly rect: TimelineMarqueeRect;
+};
+
 const getTimelineSelectionType = (item: TimelineSelection) => item.type;
 
 const areTimelineSelectionTypesCompatible = (
@@ -277,6 +291,98 @@ export const getTimelineSelectionAfterInteraction = ({
 	};
 };
 
+export const getNormalizedTimelineMarqueeRect = ({
+	startX,
+	startY,
+	currentX,
+	currentY,
+}: {
+	readonly startX: number;
+	readonly startY: number;
+	readonly currentX: number;
+	readonly currentY: number;
+}): TimelineMarqueeRect => ({
+	left: Math.min(startX, currentX),
+	top: Math.min(startY, currentY),
+	right: Math.max(startX, currentX),
+	bottom: Math.max(startY, currentY),
+});
+
+export const timelineMarqueeRectsIntersect = (
+	a: TimelineMarqueeRect,
+	b: TimelineMarqueeRect,
+) =>
+	a.left <= b.right &&
+	a.right >= b.left &&
+	a.top <= b.bottom &&
+	a.bottom >= b.top;
+
+const getTimelineMarqueeSelectionKind = (
+	item: TimelineSelection,
+): TimelineMarqueeSelectionKind | null => {
+	if (item.type === 'sequence') {
+		return 'sequence';
+	}
+
+	if (item.type === 'keyframe' || item.type === 'easing') {
+		return 'keyframes-and-easings';
+	}
+
+	return null;
+};
+
+const isTimelineSelectionCompatibleWithMarqueeKind = (
+	item: TimelineSelection,
+	kind: TimelineMarqueeSelectionKind,
+) => {
+	if (kind === 'sequence') {
+		return item.type === 'sequence';
+	}
+
+	return item.type === 'keyframe' || item.type === 'easing';
+};
+
+export const getTimelineMarqueeSelection = ({
+	candidates,
+	lockedSelectionKind,
+	marqueeRect,
+}: {
+	readonly candidates: readonly TimelineMarqueeSelectionCandidate[];
+	readonly lockedSelectionKind: TimelineMarqueeSelectionKind | null;
+	readonly marqueeRect: TimelineMarqueeRect;
+}): {
+	readonly lockedSelectionKind: TimelineMarqueeSelectionKind | null;
+	readonly selectedItems: readonly TimelineSelection[];
+} => {
+	const intersectingCandidates = candidates.filter((candidate) => {
+		return (
+			getTimelineMarqueeSelectionKind(candidate.item) !== null &&
+			timelineMarqueeRectsIntersect(candidate.rect, marqueeRect)
+		);
+	});
+	const nextLockedSelectionKind =
+		lockedSelectionKind ??
+		(intersectingCandidates.length === 0
+			? null
+			: getTimelineMarqueeSelectionKind(intersectingCandidates[0].item));
+
+	if (nextLockedSelectionKind === null) {
+		return {lockedSelectionKind: null, selectedItems: []};
+	}
+
+	return {
+		lockedSelectionKind: nextLockedSelectionKind,
+		selectedItems: intersectingCandidates
+			.filter((candidate) =>
+				isTimelineSelectionCompatibleWithMarqueeKind(
+					candidate.item,
+					nextLockedSelectionKind,
+				),
+			)
+			.map((candidate) => candidate.item),
+	};
+};
+
 type TimelineSelectionContextValue = {
 	readonly canSelect: boolean;
 	readonly canSelectEasing: boolean;
@@ -288,6 +394,17 @@ type TimelineSelectionContextValue = {
 	) => void;
 	readonly selectItems: (items: readonly TimelineSelection[]) => void;
 	readonly registerSelectableItem: (item: TimelineSelection) => () => void;
+	readonly registerMarqueeSelectableItem: (
+		item: TimelineSelection,
+		getRect: () => DOMRect | null,
+	) => () => void;
+	readonly getMarqueeSelection: (
+		marqueeRect: TimelineMarqueeRect,
+		lockedSelectionKind: TimelineMarqueeSelectionKind | null,
+	) => {
+		readonly lockedSelectionKind: TimelineMarqueeSelectionKind | null;
+		readonly selectedItems: readonly TimelineSelection[];
+	};
 	readonly containsSelection: (nodePathInfo: SequenceNodePathInfo) => boolean;
 	readonly clearSelection: () => void;
 };
@@ -300,6 +417,11 @@ const defaultTimelineSelectionContextValue: TimelineSelectionContextValue = {
 	selectItem: () => undefined,
 	selectItems: () => undefined,
 	registerSelectableItem: () => () => undefined,
+	registerMarqueeSelectableItem: () => () => undefined,
+	getMarqueeSelection: () => ({
+		lockedSelectionKind: null,
+		selectedItems: [],
+	}),
 	containsSelection: () => false,
 	clearSelection: () => undefined,
 };
@@ -500,7 +622,18 @@ export const TimelineSelectionProvider: React.FC<{
 	const selectionAnchor = useRef<TimelineSelection | null>(null);
 	const selectableItemsOrder = useRef(new Map<string, number>());
 	const selectableItems = useRef(new Map<string, TimelineSelection>());
+	const marqueeSelectableItems = useRef(
+		new Map<
+			string,
+			{
+				readonly getRect: () => DOMRect | null;
+				readonly item: TimelineSelection;
+				readonly order: number;
+			}
+		>(),
+	);
 	const registrationCounter = useRef(0);
+	const marqueeRegistrationCounter = useRef(0);
 
 	useEffect(() => {
 		if (!canSelect && !canSelectEasing) {
@@ -590,6 +723,62 @@ export const TimelineSelectionProvider: React.FC<{
 		};
 	}, []);
 
+	const registerMarqueeSelectableItem = useCallback(
+		(item: TimelineSelection, getRect: () => DOMRect | null) => {
+			const key = getTimelineSelectionKey(item);
+			const registrationOrder = marqueeRegistrationCounter.current;
+			marqueeRegistrationCounter.current += 1;
+			marqueeSelectableItems.current.set(key, {
+				getRect,
+				item,
+				order: registrationOrder,
+			});
+			return () => {
+				marqueeSelectableItems.current.delete(key);
+			};
+		},
+		[],
+	);
+
+	const getMarqueeSelectionForRect = useCallback(
+		(
+			marqueeRect: TimelineMarqueeRect,
+			lockedSelectionKind: TimelineMarqueeSelectionKind | null,
+		) => {
+			const candidates = [...marqueeSelectableItems.current.values()]
+				.sort((a, b) => a.order - b.order)
+				.flatMap((candidate): TimelineMarqueeSelectionCandidate[] => {
+					if (!canSelectItem(candidate.item)) {
+						return [];
+					}
+
+					const rect = candidate.getRect();
+					if (rect === null) {
+						return [];
+					}
+
+					return [
+						{
+							item: candidate.item,
+							rect: {
+								bottom: rect.bottom,
+								left: rect.left,
+								right: rect.right,
+								top: rect.top,
+							},
+						},
+					];
+				});
+
+			return getTimelineMarqueeSelection({
+				candidates,
+				lockedSelectionKind,
+				marqueeRect,
+			});
+		},
+		[canSelectItem],
+	);
+
 	const clearSelection = useCallback(() => {
 		selectionAnchor.current = null;
 		setSelectedItems([]);
@@ -613,6 +802,8 @@ export const TimelineSelectionProvider: React.FC<{
 			selectItem,
 			selectItems,
 			registerSelectableItem,
+			registerMarqueeSelectableItem,
+			getMarqueeSelection: getMarqueeSelectionForRect,
 			containsSelection,
 			clearSelection,
 		}),
@@ -624,6 +815,8 @@ export const TimelineSelectionProvider: React.FC<{
 			selectItem,
 			selectItems,
 			registerSelectableItem,
+			registerMarqueeSelectableItem,
+			getMarqueeSelectionForRect,
 			containsSelection,
 			clearSelection,
 		],
@@ -646,6 +839,9 @@ export const useTimelineSelection = () => {
 	return useContext(TimelineSelectionContext);
 };
 
+export const TIMELINE_MARQUEE_ITEM_ATTR = 'data-timeline-marquee-item';
+export const TIMELINE_SCRUBBER_ATTR = 'data-timeline-scrubber';
+
 export const useCurrentTimelineSelectionStateAsRef = () => {
 	const currentSelection = useContext(CurrentTimelineSelectionContext);
 	if (currentSelection === null) {
@@ -655,6 +851,127 @@ export const useCurrentTimelineSelectionStateAsRef = () => {
 	}
 
 	return currentSelection;
+};
+
+export const useTimelineMarqueeSelection = () => {
+	const {canSelect, canSelectEasing, getMarqueeSelection, selectItems} =
+		useTimelineSelection();
+	const [marqueeRect, setMarqueeRect] = useState<TimelineMarqueeRect | null>(
+		null,
+	);
+
+	const onPointerDownCapture = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>) => {
+			if (event.button !== 0 || (!canSelect && !canSelectEasing)) {
+				return;
+			}
+
+			if (event.shiftKey || event.metaKey || event.ctrlKey) {
+				return;
+			}
+
+			if (!(event.target instanceof Element)) {
+				return;
+			}
+
+			if (
+				event.target.closest(`[${TIMELINE_MARQUEE_ITEM_ATTR}]`) ||
+				event.target.closest(`[${TIMELINE_SCRUBBER_ATTR}]`)
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			const {currentTarget: target, pointerId} = event;
+			if (target.setPointerCapture) {
+				target.setPointerCapture(pointerId);
+			}
+
+			const startX = event.clientX;
+			const startY = event.clientY;
+			const previousUserSelect = document.body.style.userSelect;
+			const previousWebkitUserSelect = document.body.style.webkitUserSelect;
+			document.body.style.userSelect = 'none';
+			document.body.style.webkitUserSelect = 'none';
+
+			let hasDragged = false;
+			let lockedSelectionKind: TimelineMarqueeSelectionKind | null = null;
+
+			const cleanup = () => {
+				window.removeEventListener('pointermove', onPointerMove);
+				window.removeEventListener('pointerup', onPointerUp);
+				window.removeEventListener('pointercancel', onPointerCancel);
+				if (target.hasPointerCapture?.(pointerId)) {
+					target.releasePointerCapture(pointerId);
+				}
+
+				document.body.style.userSelect = previousUserSelect;
+				document.body.style.webkitUserSelect = previousWebkitUserSelect;
+				setMarqueeRect(null);
+			};
+
+			const updateSelection = (clientX: number, clientY: number) => {
+				if (
+					!hasDragged &&
+					Math.max(Math.abs(clientX - startX), Math.abs(clientY - startY)) < 3
+				) {
+					return;
+				}
+
+				hasDragged = true;
+				const rect = getNormalizedTimelineMarqueeRect({
+					currentX: clientX,
+					currentY: clientY,
+					startX,
+					startY,
+				});
+				const nextSelection = getMarqueeSelection(rect, lockedSelectionKind);
+				lockedSelectionKind = nextSelection.lockedSelectionKind;
+				setMarqueeRect(rect);
+				selectItems(nextSelection.selectedItems);
+			};
+
+			const onPointerMove = (moveEvent: PointerEvent) => {
+				updateSelection(moveEvent.clientX, moveEvent.clientY);
+			};
+
+			const onPointerUp = (upEvent: PointerEvent) => {
+				updateSelection(upEvent.clientX, upEvent.clientY);
+				cleanup();
+			};
+
+			const onPointerCancel = () => {
+				cleanup();
+			};
+
+			window.addEventListener('pointermove', onPointerMove);
+			window.addEventListener('pointerup', onPointerUp);
+			window.addEventListener('pointercancel', onPointerCancel);
+		},
+		[canSelect, canSelectEasing, getMarqueeSelection, selectItems],
+	);
+
+	return {marqueeRect, onPointerDownCapture};
+};
+
+export const useTimelineMarqueeSelectableItem = (
+	item: TimelineSelection | null,
+	ref: React.RefObject<Element | null>,
+) => {
+	const {registerMarqueeSelectableItem} = useTimelineSelection();
+
+	useEffect(() => {
+		if (item === null) {
+			return;
+		}
+
+		return registerMarqueeSelectableItem(
+			item,
+			() => ref.current?.getBoundingClientRect() ?? null,
+		);
+	}, [item, ref, registerMarqueeSelectableItem]);
 };
 
 export const useTimelineRowSelection = (
@@ -692,6 +1009,7 @@ export const useTimelineRowSelection = (
 	return {
 		onSelect,
 		selectable: canSelect && selectionItem !== null,
+		selectionItem,
 		selected,
 	};
 };
@@ -727,6 +1045,7 @@ export const useTimelineKeyframeSelection = (
 	return {
 		onSelect,
 		selectable: canSelect,
+		selectionItem,
 		selected,
 	};
 };

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -60,10 +60,10 @@ export const getTimelineSelectedTrackHighlightStyle = (
 	width: timelineWidth,
 });
 
-export const SELECTION_ENABLED = true;
-export const TIMELINE_TOP_DRAG = true;
-export const ENABLE_OUTLINES = true;
-export const EASING_SELECTION_ENABLED = true;
+export const SELECTION_ENABLED = false;
+export const TIMELINE_TOP_DRAG = false;
+export const ENABLE_OUTLINES = false;
+export const EASING_SELECTION_ENABLED = false;
 
 type TimelineSelectionBase = {
 	readonly nodePathInfo: SequenceNodePathInfo;

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useMemo} from 'react';
+import React, {useCallback, useContext, useMemo, useRef} from 'react';
 import type {TSequence} from 'remotion';
 import {Internals, useCurrentFrame} from 'remotion';
 import {BLUE} from '../../helpers/colors';
@@ -15,7 +15,12 @@ import {useMaxMediaDuration} from '../../helpers/use-max-media-duration';
 import {AudioWaveform} from '../AudioWaveform';
 import {LoopedTimelineIndicator} from './LoopedTimelineIndicators';
 import {TimelineImageInfo} from './TimelineImageInfo';
-import {TIMELINE_TOP_DRAG, useTimelineRowSelection} from './TimelineSelection';
+import {
+	TIMELINE_MARQUEE_ITEM_ATTR,
+	TIMELINE_TOP_DRAG,
+	useTimelineMarqueeSelectableItem,
+	useTimelineRowSelection,
+} from './TimelineSelection';
 import {TimelineSequenceFrame} from './TimelineSequenceFrame';
 import {
 	TimelineSequenceRightEdgeDragHandle,
@@ -75,7 +80,10 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	fromCanUpdate,
 	onMoveDragPointerDown,
 }) => {
-	const {onSelect, selectable} = useTimelineRowSelection(nodePathInfo);
+	const ref = useRef<HTMLDivElement>(null);
+	const {onSelect, selectable, selectionItem} =
+		useTimelineRowSelection(nodePathInfo);
+	useTimelineMarqueeSelectableItem(selectionItem, ref);
 
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
@@ -120,6 +128,8 @@ const TimelineSequenceCurrentFrame: React.FC<{
 
 	return (
 		<div
+			ref={ref}
+			{...{[TIMELINE_MARQUEE_ITEM_ATTR]: true}}
 			style={actualStyle}
 			title={s.displayName}
 			onPointerDown={selectable ? onPointerDown : undefined}

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -2,6 +2,7 @@ import React, {useMemo} from 'react';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {MaxTimelineTracksReached} from './MaxTimelineTracks';
+import {useTimelineMarqueeSelection} from './TimelineSelection';
 import {TimelineTimePadding} from './TimelineTimeIndicators';
 import {TimelineTrack} from './TimelineTrack';
 
@@ -14,10 +15,20 @@ const timelineContent: React.CSSProperties = {
 	minHeight: '100%',
 };
 
+const marqueeStyle: React.CSSProperties = {
+	backgroundColor: 'rgba(70, 130, 255, 0.16)',
+	border: '1px solid rgba(70, 130, 255, 0.75)',
+	boxSizing: 'border-box',
+	pointerEvents: 'none',
+	position: 'fixed',
+	zIndex: 10,
+};
+
 const TimelineTracksInner: React.FC<{
 	readonly timeline: TrackWithHash[];
 	readonly hasBeenCut: boolean;
 }> = ({timeline, hasBeenCut}) => {
+	const {marqueeRect, onPointerDownCapture} = useTimelineMarqueeSelection();
 	const timelineStyle: React.CSSProperties = useMemo(() => {
 		return {
 			...timelineContent,
@@ -26,7 +37,7 @@ const TimelineTracksInner: React.FC<{
 	}, []);
 
 	return (
-		<div style={timelineStyle}>
+		<div style={timelineStyle} onPointerDownCapture={onPointerDownCapture}>
 			<div style={content}>
 				<TimelineTimePadding />
 				{timeline.map((track) => (
@@ -34,6 +45,17 @@ const TimelineTracksInner: React.FC<{
 				))}
 			</div>
 			{hasBeenCut ? <MaxTimelineTracksReached /> : null}
+			{marqueeRect === null ? null : (
+				<div
+					style={{
+						...marqueeStyle,
+						height: marqueeRect.bottom - marqueeRect.top,
+						left: marqueeRect.left,
+						top: marqueeRect.top,
+						width: marqueeRect.right - marqueeRect.left,
+					}}
+				/>
+			)}
 		</div>
 	);
 };

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -323,6 +323,49 @@ test('timeline marquee keeps its locked item kind while dragging', () => {
 	]);
 });
 
+test('timeline marquee can choose a new item kind after the locked kind selects nothing', () => {
+	const keyframe = makeNodePathInfo(['body', 0], ['controls', 'opacity']);
+	const sequence = makeNodePathInfo(['body', 1], []);
+
+	const result = getTimelineMarqueeSelection({
+		lockedSelectionKind: 'sequence',
+		marqueeRect: {left: 0, top: 0, right: 100, bottom: 100},
+		candidates: [
+			{
+				item: {type: 'keyframe', nodePathInfo: keyframe, frame: 20},
+				rect: {left: 20, top: 0, right: 30, bottom: 10},
+			},
+			{
+				item: {type: 'sequence', nodePathInfo: sequence},
+				rect: {left: 120, top: 0, right: 130, bottom: 10},
+			},
+		],
+	});
+
+	expect(result.lockedSelectionKind).toBe('keyframes-and-easings');
+	expect(result.selectedItems).toEqual([
+		{type: 'keyframe', nodePathInfo: keyframe, frame: 20},
+	]);
+});
+
+test('timeline marquee clears its item kind when no target is selected', () => {
+	const sequence = makeNodePathInfo(['body', 0], []);
+
+	const result = getTimelineMarqueeSelection({
+		lockedSelectionKind: 'sequence',
+		marqueeRect: {left: 0, top: 0, right: 100, bottom: 100},
+		candidates: [
+			{
+				item: {type: 'sequence', nodePathInfo: sequence},
+				rect: {left: 120, top: 0, right: 130, bottom: 10},
+			},
+		],
+	});
+
+	expect(result.lockedSelectionKind).toBe(null);
+	expect(result.selectedItems).toEqual([]);
+});
+
 test('keyframe diamond target resolution uses all selected prop rows when clicked row is selected', () => {
 	const opacity = makeNodePathInfo(['body', 0], ['controls', 'style.opacity']);
 	const rotate = makeNodePathInfo(['body', 0], ['controls', 'style.rotate']);

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -44,6 +44,7 @@ import {
 import {getSelectedKeyframeControlNodePathInfos} from '../components/Timeline/TimelineKeyframeControls';
 import {
 	ENABLE_OUTLINES,
+	getClampedTimelineMarqueePoint,
 	getSelectableTimelineSequenceSelections,
 	getTimelineMarqueeSelection,
 	getTimelineSelectionAfterInteraction,
@@ -222,6 +223,23 @@ test('timeline marquee rectangle intersection detects overlapping targets', () =
 			{left: 11, top: 0, right: 20, bottom: 10},
 		),
 	).toBe(false);
+});
+
+test('timeline marquee points are clamped to the track bounds', () => {
+	expect(
+		getClampedTimelineMarqueePoint({
+			bounds: {left: 10, top: 20, right: 100, bottom: 200},
+			x: 5,
+			y: 250,
+		}),
+	).toEqual({x: 10, y: 200});
+	expect(
+		getClampedTimelineMarqueePoint({
+			bounds: {left: 10, top: 20, right: 100, bottom: 200},
+			x: 80,
+			y: 60,
+		}),
+	).toEqual({x: 80, y: 60});
 });
 
 test('timeline marquee locks to sequences after capturing a sequence first', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -45,12 +45,14 @@ import {getSelectedKeyframeControlNodePathInfos} from '../components/Timeline/Ti
 import {
 	ENABLE_OUTLINES,
 	getSelectableTimelineSequenceSelections,
+	getTimelineMarqueeSelection,
 	getTimelineSelectionAfterInteraction,
 	getTimelineSelectionFromNodePathInfo,
 	getTimelineSequenceSelectionKey,
 	isTimelineSelectionModifierEvent,
 	SELECTION_ENABLED,
 	TIMELINE_TOP_DRAG,
+	timelineMarqueeRectsIntersect,
 } from '../components/Timeline/TimelineSelection';
 import {
 	getTimelineSequenceDurationDragChanges,
@@ -205,6 +207,120 @@ const makeFromPropStatuses = (
 
 test('Timeline selection should stay disabled until released publicly', () => {
 	expect(SELECTION_ENABLED).toBe(false);
+});
+
+test('timeline marquee rectangle intersection detects overlapping targets', () => {
+	expect(
+		timelineMarqueeRectsIntersect(
+			{left: 0, top: 0, right: 10, bottom: 10},
+			{left: 5, top: 5, right: 15, bottom: 15},
+		),
+	).toBe(true);
+	expect(
+		timelineMarqueeRectsIntersect(
+			{left: 0, top: 0, right: 10, bottom: 10},
+			{left: 11, top: 0, right: 20, bottom: 10},
+		),
+	).toBe(false);
+});
+
+test('timeline marquee locks to sequences after capturing a sequence first', () => {
+	const firstSequence = makeNodePathInfo(['body', 0], []);
+	const keyframe = makeNodePathInfo(['body', 1], ['controls', 'opacity']);
+	const secondSequence = makeNodePathInfo(['body', 2], []);
+
+	const result = getTimelineMarqueeSelection({
+		lockedSelectionKind: null,
+		marqueeRect: {left: 0, top: 0, right: 100, bottom: 100},
+		candidates: [
+			{
+				item: {type: 'sequence', nodePathInfo: firstSequence},
+				rect: {left: 0, top: 0, right: 10, bottom: 10},
+			},
+			{
+				item: {type: 'keyframe', nodePathInfo: keyframe, frame: 20},
+				rect: {left: 20, top: 0, right: 30, bottom: 10},
+			},
+			{
+				item: {type: 'sequence', nodePathInfo: secondSequence},
+				rect: {left: 40, top: 0, right: 50, bottom: 10},
+			},
+		],
+	});
+
+	expect(result.lockedSelectionKind).toBe('sequence');
+	expect(result.selectedItems).toEqual([
+		{type: 'sequence', nodePathInfo: firstSequence},
+		{type: 'sequence', nodePathInfo: secondSequence},
+	]);
+});
+
+test('timeline marquee locks to keyframes and easings after capturing a keyframe first', () => {
+	const keyframe = makeNodePathInfo(['body', 0], ['controls', 'opacity']);
+	const sequence = makeNodePathInfo(['body', 1], []);
+	const easing = makeNodePathInfo(['body', 2], ['controls', 'scale']);
+
+	const result = getTimelineMarqueeSelection({
+		lockedSelectionKind: null,
+		marqueeRect: {left: 0, top: 0, right: 100, bottom: 100},
+		candidates: [
+			{
+				item: {type: 'keyframe', nodePathInfo: keyframe, frame: 20},
+				rect: {left: 0, top: 0, right: 10, bottom: 10},
+			},
+			{
+				item: {type: 'sequence', nodePathInfo: sequence},
+				rect: {left: 20, top: 0, right: 30, bottom: 10},
+			},
+			{
+				item: {
+					type: 'easing',
+					nodePathInfo: easing,
+					fromFrame: 20,
+					toFrame: 30,
+					segmentIndex: 0,
+				},
+				rect: {left: 40, top: 0, right: 50, bottom: 10},
+			},
+		],
+	});
+
+	expect(result.lockedSelectionKind).toBe('keyframes-and-easings');
+	expect(result.selectedItems).toEqual([
+		{type: 'keyframe', nodePathInfo: keyframe, frame: 20},
+		{
+			type: 'easing',
+			nodePathInfo: easing,
+			fromFrame: 20,
+			toFrame: 30,
+			segmentIndex: 0,
+		},
+	]);
+});
+
+test('timeline marquee keeps its locked item kind while dragging', () => {
+	const keyframe = makeNodePathInfo(['body', 0], ['controls', 'opacity']);
+	const sequence = makeNodePathInfo(['body', 1], []);
+
+	const result = getTimelineMarqueeSelection({
+		lockedSelectionKind: 'keyframes-and-easings',
+		marqueeRect: {left: 0, top: 0, right: 100, bottom: 100},
+		candidates: [
+			{
+				item: {type: 'sequence', nodePathInfo: sequence},
+				rect: {left: 0, top: 0, right: 10, bottom: 10},
+			},
+			{
+				item: {type: 'keyframe', nodePathInfo: keyframe, frame: 20},
+				rect: {left: 20, top: 0, right: 30, bottom: 10},
+			},
+		],
+	});
+
+	expect(result.lockedSelectionKind).toBe('keyframes-and-easings');
+	expect(result.selectedItems).toEqual([
+		{type: 'keyframe', nodePathInfo: keyframe, frame: 20},
+	]);
 });
 
 test('keyframe diamond target resolution uses all selected prop rows when clicked row is selected', () => {


### PR DESCRIPTION
## Summary

- Add marquee box selection support for timeline sequences, keyframes, and easing segments
- Lock marquee selection to sequences when a sequence is captured first, or keyframes/easings when either of those is captured first
- Keep timeline scrubbing confined to the ruler while timeline selection is active so track items can receive pointer events

Fixes #7784.

## Testing

- `cd packages/studio && bun test src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`
