### PR TITLE
Docs: Allow dragging shape demos into Studio

### DIFF
--- a/packages/docs/components/demos/index.tsx
+++ b/packages/docs/components/demos/index.tsx
@@ -2,6 +2,10 @@ import {useColorMode} from '@docusaurus/theme-common';
 import {Player} from '@remotion/player';
 import React, {useCallback, useMemo, useState} from 'react';
 import {AbsoluteFill} from 'remotion';
+import {
+	makeShapeComponentDragDataFromDemoState,
+	setComponentDragData,
+} from '../shapes/shape-component-drag-data';
 import {Control} from './control';
 import type {DemoType, Option} from './types';
 import {
@@ -64,6 +68,18 @@ const container: React.CSSProperties = {
 	border: '1px solid var(--ifm-color-emphasis-300)',
 	borderRadius: 'var(--ifm-pre-border-radius)',
 	marginBottom: 40,
+};
+
+const dragHandle: React.CSSProperties = {
+	alignItems: 'center',
+	borderBottom: '1px solid var(--ifm-color-emphasis-300)',
+	cursor: 'grab',
+	display: 'flex',
+	fontSize: 13,
+	fontWeight: 600,
+	gap: 6,
+	padding: '8px 10px',
+	userSelect: 'none',
 };
 
 const demos: DemoType[] = [
@@ -159,6 +175,25 @@ export const Demo: React.FC<{
 
 	const [state, setState] = useState(() => initialState);
 
+	const shapeDragData = useMemo(() => {
+		return makeShapeComponentDragDataFromDemoState({
+			demoId: demo.id,
+			state,
+		});
+	}, [demo.id, state]);
+
+	const onDragStart = useCallback(
+		(e: React.DragEvent<HTMLDivElement>) => {
+			if (shapeDragData !== null) {
+				setComponentDragData({
+					dataTransfer: e.dataTransfer,
+					dragData: shapeDragData,
+				});
+			}
+		},
+		[shapeDragData],
+	);
+
 	const restart = useCallback(() => {
 		setState(initialState);
 		setKey((k) => k + 1);
@@ -182,7 +217,7 @@ export const Demo: React.FC<{
 					width: '100%',
 					aspectRatio: demo.compWidth / demo.compHeight,
 					borderBottom:
-						demo.options.length > 0
+						demo.options.length > 0 || shapeDragData !== null
 							? '1px solid var(--ifm-color-emphasis-300)'
 							: 0,
 				}}
@@ -218,6 +253,17 @@ export const Demo: React.FC<{
 				initiallyMuted
 				loop
 			/>
+			{shapeDragData === null ? null : (
+				<div
+					draggable
+					onDragStart={onDragStart}
+					style={dragHandle}
+					title="Drag this shape into Remotion Studio"
+				>
+					<span aria-hidden="true">::</span>
+					<span>Drag current shape into a layer in the Studio</span>
+				</div>
+			)}
 			<div className={styles.containerrow}>
 				{demo.options
 					.filter((option) => shouldShowOption(option, state))

--- a/packages/docs/components/shapes/shape-component-drag-data.ts
+++ b/packages/docs/components/shapes/shape-component-drag-data.ts
@@ -66,15 +66,121 @@ const shapeDefaultProps: Record<ShapeName, readonly ComponentProp[]> = {
 	],
 };
 
-export const makeDefaultShapeComponentDragData = (
-	shape: ShapeName,
-): ComponentDragData => {
+const shapeNameByDemoId: Partial<Record<string, ShapeName>> = {
+	arrow: 'Arrow',
+	circle: 'Circle',
+	ellipse: 'Ellipse',
+	heart: 'Heart',
+	pie: 'Pie',
+	polygon: 'Polygon',
+	rect: 'Rect',
+	star: 'Star',
+	triangle: 'Triangle',
+};
+
+const shapeDemoPropNames: Record<ShapeName, readonly string[]> = {
+	Arrow: [
+		'length',
+		'headWidth',
+		'headLength',
+		'shaftWidth',
+		'direction',
+		'cornerRadius',
+	],
+	Circle: ['radius'],
+	Ellipse: ['rx', 'ry'],
+	Heart: [
+		'height',
+		'aspectRatio',
+		'bottomRoundnessAdjustment',
+		'depthAdjustment',
+	],
+	Pie: ['radius', 'progress', 'closePath', 'counterClockwise', 'rotation'],
+	Polygon: ['points', 'radius', 'cornerRadius', 'edgeRoundness'],
+	Rect: ['width', 'height', 'cornerRadius', 'edgeRoundness'],
+	Star: [
+		'points',
+		'innerRadius',
+		'outerRadius',
+		'cornerRadius',
+		'edgeRoundness',
+	],
+	Triangle: ['length', 'direction', 'cornerRadius', 'edgeRoundness'],
+};
+
+const isComponentPropValue = (
+	value: unknown,
+): value is ComponentProp['value'] => {
+	return (
+		typeof value === 'string' ||
+		typeof value === 'boolean' ||
+		(typeof value === 'number' && Number.isFinite(value))
+	);
+};
+
+const makeShapeComponentDragData = ({
+	shape,
+	props,
+}: {
+	readonly shape: ShapeName;
+	readonly props: ComponentProp[];
+}): ComponentDragData => {
 	return makeComponentDragData({
 		componentName: shape,
 		importName: shape,
 		importPath: '@remotion/shapes',
+		props,
+	});
+};
+
+export const makeDefaultShapeComponentDragData = (
+	shape: ShapeName,
+): ComponentDragData => {
+	return makeShapeComponentDragData({
+		shape,
 		props: [...shapeDefaultProps[shape]],
 	});
+};
+
+export const makeShapeComponentDragDataFromDemoState = ({
+	demoId,
+	state,
+}: {
+	readonly demoId: string;
+	readonly state: Record<string, unknown>;
+}): ComponentDragData | null => {
+	const shape = shapeNameByDemoId[demoId];
+	if (!shape) {
+		return null;
+	}
+
+	const defaultProps = shapeDefaultProps[shape];
+	const defaultPropsByName = new Map(
+		defaultProps.map((prop) => [prop.name, prop.value] as const),
+	);
+	const props: ComponentProp[] = [];
+	const usedPropNames = new Set<string>();
+
+	for (const name of shapeDemoPropNames[shape]) {
+		const stateValue = state[name];
+		const value =
+			stateValue === null || typeof stateValue === 'undefined'
+				? defaultPropsByName.get(name)
+				: stateValue;
+
+		if (isComponentPropValue(value)) {
+			props.push({name, value});
+			usedPropNames.add(name);
+		}
+	}
+
+	for (const prop of defaultProps) {
+		if (!usedPropNames.has(prop.name)) {
+			props.push(prop);
+		}
+	}
+
+	return makeShapeComponentDragData({shape, props});
 };
 
 export const setComponentDragData = ({


### PR DESCRIPTION
Fixes #8201

### Summary

- Adds a draggable handle to @remotion/shapes interactive docs demos
- Serializes the current demo controls into the existing Remotion Studio component drag payload
- Keeps playground-only controls out of the inserted JSX payload

### Validation

- bun run build
- bun run stylecheck
