### PR TITLE
`@remotion/studio`: Preserve selection while dragging sequences

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -122,6 +122,22 @@ export const isTimelineSelectionModifierEvent = ({
 	return shiftKey || metaKey || ctrlKey;
 };
 
+export const shouldSelectTimelineRowOnPointerDown = ({
+	selected,
+	shiftKey,
+	metaKey,
+	ctrlKey,
+}: {
+	readonly selected: boolean;
+	readonly shiftKey: boolean;
+	readonly metaKey: boolean;
+	readonly ctrlKey: boolean;
+}) => {
+	return (
+		!selected || isTimelineSelectionModifierEvent({shiftKey, metaKey, ctrlKey})
+	);
+};
+
 export type TimelineSelectionState = {
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly anchor: TimelineSelection | null;

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -18,6 +18,7 @@ import {TimelineImageInfo} from './TimelineImageInfo';
 import {
 	TIMELINE_MARQUEE_ITEM_ATTR,
 	TIMELINE_TOP_DRAG,
+	shouldSelectTimelineRowOnPointerDown,
 	useTimelineMarqueeSelectableItem,
 	useTimelineRowSelection,
 } from './TimelineSelection';
@@ -81,7 +82,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	onMoveDragPointerDown,
 }) => {
 	const ref = useRef<HTMLDivElement>(null);
-	const {onSelect, selectable, selectionItem} =
+	const {onSelect, selectable, selected, selectionItem} =
 		useTimelineRowSelection(nodePathInfo);
 	useTimelineMarqueeSelectableItem(selectionItem, ref);
 
@@ -89,16 +90,26 @@ const TimelineSequenceCurrentFrame: React.FC<{
 		(e: React.PointerEvent<HTMLDivElement>) => {
 			if (e.button === 0) {
 				e.stopPropagation();
-				onSelect({
-					shiftKey: e.shiftKey,
-					toggleKey: e.metaKey || e.ctrlKey,
-				});
+				if (
+					shouldSelectTimelineRowOnPointerDown({
+						selected,
+						shiftKey: e.shiftKey,
+						metaKey: e.metaKey,
+						ctrlKey: e.ctrlKey,
+					})
+				) {
+					onSelect({
+						shiftKey: e.shiftKey,
+						toggleKey: e.metaKey || e.ctrlKey,
+					});
+				}
+
 				if (TIMELINE_TOP_DRAG && fromCanUpdate) {
 					onMoveDragPointerDown(e);
 				}
 			}
 		},
-		[fromCanUpdate, onMoveDragPointerDown, onSelect],
+		[fromCanUpdate, onMoveDragPointerDown, onSelect, selected],
 	);
 	const frame = useCurrentFrame();
 	const relativeFrame = frame - s.from;

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -52,6 +52,7 @@ import {
 	getTimelineSequenceSelectionKey,
 	isTimelineSelectionModifierEvent,
 	SELECTION_ENABLED,
+	shouldSelectTimelineRowOnPointerDown,
 	TIMELINE_TOP_DRAG,
 	timelineMarqueeRectsIntersect,
 } from '../components/Timeline/TimelineSelection';
@@ -2711,4 +2712,31 @@ test('Timeline double-click actions ignore selection modifier clicks', () => {
 			ctrlKey: false,
 		}),
 	).toBe(false);
+});
+
+test('Selected timeline rows do not reselect on pointer down without modifiers', () => {
+	expect(
+		shouldSelectTimelineRowOnPointerDown({
+			selected: true,
+			shiftKey: false,
+			metaKey: false,
+			ctrlKey: false,
+		}),
+	).toBe(false);
+	expect(
+		shouldSelectTimelineRowOnPointerDown({
+			selected: false,
+			shiftKey: false,
+			metaKey: false,
+			ctrlKey: false,
+		}),
+	).toBe(true);
+	expect(
+		shouldSelectTimelineRowOnPointerDown({
+			selected: true,
+			shiftKey: false,
+			metaKey: true,
+			ctrlKey: false,
+		}),
+	).toBe(true);
 });


### PR DESCRIPTION
## Summary

- Keep multi-selected timeline sequences selected when starting a drag from an already-selected sequence
- Add a regression test for the pointer-down selection guard

Fixes #8259.

## Tests

- `cd packages/studio && bunx oxfmt src --write && bun test src/test/timeline-selection.test.ts`
- `bun run build && bun run stylecheck`
