### PR TITLE
`@remotion/studio`: Fix asset and effect drop conflict

### DIFF
--- a/packages/example/e2e/sequence-reorder.test.mts
+++ b/packages/example/e2e/sequence-reorder.test.mts
@@ -67,8 +67,7 @@ test.describe('sequence reorder', () => {
 				'text/plain': 'not effect drag data',
 			},
 		});
-		await expect(page.getByText(effectDragError)).toBeVisible({timeout: 5_000});
-		await expect(page.getByText(effectDragError)).toBeHidden({timeout: 5_000});
+		await expect(page.getByText(effectDragError)).toBeHidden();
 
 		await dropOnTimelineRow({
 			page,

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -44,6 +44,7 @@ import {EditorZoomGesturesContext} from '../state/editor-zoom-gestures';
 import EditorGuides from './EditorGuides';
 import {EditorRulers} from './EditorRuler';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
+import {getEffectDragData} from './effect-drag-and-drop';
 import {
 	importAssets,
 	importRemoteAsset,
@@ -726,6 +727,14 @@ export const Canvas: React.FC<{
 					!isRemoteAssetDragEvent(event)) ||
 				!isDragEventInsideCanvas(event)
 			) {
+				return;
+			}
+
+			if (
+				event.dataTransfer &&
+				getEffectDragData(event.dataTransfer) !== null
+			) {
+				event.preventDefault();
 				return;
 			}
 

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -25,6 +25,7 @@ import {ContextMenuForTarget} from './ContextMenu';
 import {
 	addEffectFromDragData,
 	getEffectDragData,
+	hasExplicitEffectDragType,
 	hasEffectDragType,
 } from './effect-drag-and-drop';
 import type {ComboboxValue} from './NewComposition/ComboBox';
@@ -982,15 +983,21 @@ const SelectedOutlinePolygon: React.FC<{
 				return;
 			}
 
+			const dragData = getEffectDragData(event.dataTransfer);
+			if (!dragData) {
+				if (hasExplicitEffectDragType(event.dataTransfer)) {
+					event.preventDefault();
+					event.stopPropagation();
+					setEffectDropHovered(false);
+					showNotification('Could not read effect drag data', 3000);
+				}
+
+				return;
+			}
+
 			event.preventDefault();
 			event.stopPropagation();
 			setEffectDropHovered(false);
-
-			const dragData = getEffectDragData(event.dataTransfer);
-			if (!dragData) {
-				showNotification('Could not read effect drag data', 3000);
-				return;
-			}
 
 			await addEffectFromDragData({
 				dragData,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -17,6 +17,7 @@ import {ContextMenu} from '../ContextMenu';
 import {
 	addEffectFromDragData,
 	getEffectDragData,
+	hasExplicitEffectDragType,
 	hasEffectDragType,
 } from '../effect-drag-and-drop';
 import {
@@ -850,15 +851,21 @@ export const TimelineSequenceItem: React.FC<{
 				return;
 			}
 
+			const dragData = getEffectDragData(e.dataTransfer);
+			if (!dragData) {
+				if (hasExplicitEffectDragType(e.dataTransfer)) {
+					e.preventDefault();
+					e.stopPropagation();
+					setEffectDropHovered(false);
+					showNotification('Could not read effect drag data', 3000);
+				}
+
+				return;
+			}
+
 			e.preventDefault();
 			e.stopPropagation();
 			setEffectDropHovered(false);
-
-			const dragData = getEffectDragData(e.dataTransfer);
-			if (!dragData) {
-				showNotification('Could not read effect drag data', 3000);
-				return;
-			}
 
 			await addEffectFromDragData({
 				dragData,

--- a/packages/studio/src/components/effect-drag-and-drop.ts
+++ b/packages/studio/src/components/effect-drag-and-drop.ts
@@ -1,7 +1,10 @@
 import {
+	ASSET_DRAG_MIME_TYPE,
+	COMPONENT_DRAG_MIME_TYPE,
 	EFFECT_DRAG_MIME_TYPE,
 	getRequiredPackageForEffectImportPath,
 	parseEffectDragData,
+	SFX_DRAG_MIME_TYPE,
 	type EffectDragData,
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey} from 'remotion';
@@ -10,11 +13,34 @@ import {callApi} from './call-api';
 import {showNotification} from './Notifications/NotificationCenter';
 
 export const hasEffectDragType = (dataTransfer: DataTransfer) => {
+	const types = Array.from(dataTransfer.types);
+	const hasExplicitEffectType = types.includes(EFFECT_DRAG_MIME_TYPE);
+	if (!hasExplicitEffectType && hasImportableAssetDragType(dataTransfer)) {
+		return false;
+	}
+
+	return types.some(
+		(type) => type === EFFECT_DRAG_MIME_TYPE || isGenericDragType(type),
+	);
+};
+
+export const hasExplicitEffectDragType = (dataTransfer: DataTransfer) => {
+	return Array.from(dataTransfer.types).includes(EFFECT_DRAG_MIME_TYPE);
+};
+
+const isGenericDragType = (type: string) => {
+	return type === 'application/json' || type === 'text/plain';
+};
+
+const hasImportableAssetDragType = (dataTransfer: DataTransfer) => {
 	return Array.from(dataTransfer.types).some(
 		(type) =>
-			type === EFFECT_DRAG_MIME_TYPE ||
-			type === 'application/json' ||
-			type === 'text/plain',
+			type === 'Files' ||
+			type === ASSET_DRAG_MIME_TYPE ||
+			type === COMPONENT_DRAG_MIME_TYPE ||
+			type === SFX_DRAG_MIME_TYPE ||
+			type === 'text/uri-list' ||
+			type === 'text/html',
 	);
 };
 

--- a/packages/studio/src/test/effect-drag-and-drop.test.ts
+++ b/packages/studio/src/test/effect-drag-and-drop.test.ts
@@ -1,0 +1,77 @@
+import {expect, test} from 'bun:test';
+import {
+	ASSET_DRAG_MIME_TYPE,
+	EFFECT_DRAG_MIME_TYPE,
+	type EffectDragData,
+} from '@remotion/studio-shared';
+import {
+	getEffectDragData,
+	hasEffectDragType,
+} from '../components/effect-drag-and-drop';
+
+const effectDragData: EffectDragData = {
+	type: 'remotion-effect',
+	version: 1,
+	effect: {
+		name: 'Opacity',
+		importPath: '@remotion/effects',
+		config: {},
+	},
+};
+
+const makeDataTransfer = ({
+	types,
+	data,
+}: {
+	readonly types: string[];
+	readonly data?: Record<string, string>;
+}): DataTransfer => {
+	return {
+		types,
+		getData: (type: string) => data?.[type] ?? '',
+	} as unknown as DataTransfer;
+};
+
+test('detects explicit effect drags', () => {
+	expect(
+		hasEffectDragType(
+			makeDataTransfer({
+				types: [EFFECT_DRAG_MIME_TYPE, 'application/json', 'text/plain'],
+			}),
+		),
+	).toBe(true);
+});
+
+test('keeps generic effect drag fallback', () => {
+	const serialized = JSON.stringify(effectDragData);
+	const dataTransfer = makeDataTransfer({
+		types: ['application/json', 'text/plain'],
+		data: {
+			'application/json': serialized,
+			'text/plain': serialized,
+		},
+	});
+
+	expect(hasEffectDragType(dataTransfer)).toBe(true);
+	expect(getEffectDragData(dataTransfer)).toEqual(effectDragData);
+});
+
+test('does not treat asset imports as effect drags', () => {
+	expect(
+		hasEffectDragType(
+			makeDataTransfer({
+				types: [ASSET_DRAG_MIME_TYPE, 'application/json', 'text/plain'],
+			}),
+		),
+	).toBe(false);
+});
+
+test('does not treat remote asset imports as effect drags', () => {
+	expect(
+		hasEffectDragType(
+			makeDataTransfer({
+				types: ['text/uri-list', 'text/plain'],
+			}),
+		),
+	).toBe(false);
+});


### PR DESCRIPTION
## Summary
- Prevent asset, component, SFX, and remote asset drags from being classified as effect drops.
- Let canvas asset import handling yield when the payload is actually an effect drop.
- Add tests for effect drag classification with generic and asset MIME types.

Closes #8260.

## Test plan
- bun test packages/studio/src/test/effect-drag-and-drop.test.ts
- bunx turbo make --filter=@remotion/studio
- bun run build
- bun run stylecheck
