### PR TITLE
fix: lower docs build heap to avoid OOM

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,7 +10,7 @@
 		"format": "oxfmt src",
 		"docusaurus": "docusaurus",
 		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && docusaurus start --host 0.0.0.0",
-		"build-docs": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun prewarm-twoslash.ts && NODE_OPTIONS=\"--max-old-space-size=2048\" DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus build && bun copy-convert.ts && bun count-pages.ts",
+		"build-docs": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun prewarm-twoslash.ts && NODE_OPTIONS=\"--max-old-space-size=512\" DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus build && bun copy-convert.ts && bun count-pages.ts",
 		"swizzle": "docusaurus swizzle",
 		"deploy": "docusaurus deploy",
 		"serve": "docusaurus serve",


### PR DESCRIPTION
## Summary

Lowers the Node heap cap on the docs `build-docs` script from `--max-old-space-size=2048` to `512` so the Docusaurus/Rspack build no longer OOMs on lower-memory machines.

## Why this matters

Per #8242, the docs build only reliably succeeds on ~16GB machines today. The root cause was traced to the Rspack build phase, not a Twoslash leak. With the current 2048MB heap the build peaked at ~5.1GB RSS, while a run with a much smaller heap cap dropped peak RSS to ~3.1GB. A smaller Node heap forces earlier GC and leaves more system memory for the Rust/Rspack side (which isn't counted in Node's heap). 512MB is a conservative middle ground between the 200MB experiment and the prior 2048MB.

Fixes #8242
