### PR TITLE
`@remotion/media`: Prevent initial double seek

### DIFF
--- a/packages/media/src/test/trim-change-seek.test.ts
+++ b/packages/media/src/test/trim-change-seek.test.ts
@@ -40,7 +40,7 @@ test('setTrimBefore and setTrimAfter should update frame when paused', async () 
 	const framesAfterTrimBefore =
 		player.videoIteratorManager!.getFramesRendered();
 	await player.setTrimAfter(90, 0);
-	expect(player.videoIteratorManager!.getFramesRendered()).toBeGreaterThan(
+	expect(player.videoIteratorManager!.getFramesRendered()).toBe(
 		framesAfterTrimBefore,
 	);
 

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -7,6 +7,7 @@ import type {
 } from 'remotion';
 import {Internals} from 'remotion';
 import type {DelayPlaybackIfNotPremounting} from './delay-playback-if-not-premounting';
+import {roundTo4Digits} from './helpers/round-to-4-digits';
 import type {Nonce} from './nonce-manager';
 import {makePrewarmedVideoIteratorCache} from './prewarm-iterator-for-looping';
 import {
@@ -51,6 +52,7 @@ export const videoIteratorManager = async ({
 	let framesRendered = 0;
 	let currentDelayHandle: {unblock: () => void} | null = null;
 	let lastDrawnFrame: WrappedCanvas | null = null;
+	let currentSeek: number | null = null;
 
 	const clearLastDrawnFrame = () => {
 		lastDrawnFrame = null;
@@ -143,6 +145,7 @@ export const videoIteratorManager = async ({
 		videoFrameIterator?.destroy();
 		using delayHandle = delayPlaybackHandleIfNotPremounting();
 		currentDelayHandle = delayHandle;
+		currentSeek = timeToSeek;
 
 		const iterator = await createVideoIterator(
 			timeToSeek,
@@ -175,6 +178,15 @@ export const videoIteratorManager = async ({
 		if (!videoFrameIterator) {
 			return;
 		}
+
+		if (
+			currentSeek !== null &&
+			roundTo4Digits(currentSeek) === roundTo4Digits(newTime)
+		) {
+			return;
+		}
+
+		currentSeek = newTime;
 
 		if (getIsLooping()) {
 			// If less than 1 second from the end away, we pre-warm a new iterator

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -197,7 +197,8 @@ export const videoIteratorManager = async ({
 			}
 		}
 
-		const videoSatisfyResult = videoFrameIterator.tryToSatisfySeek(newTime);
+		const videoSatisfyResult =
+			await videoFrameIterator.tryToSatisfySeek(newTime);
 
 		// Doing this before the staleness check, because
 		// frame might be better than what we currently have

--- a/packages/media/src/video/video-preview-iterator.ts
+++ b/packages/media/src/video/video-preview-iterator.ts
@@ -17,7 +17,33 @@ export const createVideoIterator = async (
 			: await firstAwait.wait();
 	let lastReturnedFrame = initialFrame;
 
+	let peekedFrame: WrappedCanvas | null = null;
+
+	const peek = async () => {
+		if (peekedFrame) {
+			return peekedFrame;
+		}
+
+		const next = iterator.next();
+		if (next.type === 'ready') {
+			peekedFrame = next.frame;
+		} else {
+			peekedFrame = await next.wait();
+		}
+
+		return peekedFrame;
+	};
+
 	const getNextOrNullIfNotAvailable = () => {
+		if (peekedFrame) {
+			const retValue = {
+				type: 'got-frame-or-end' as const,
+				frame: peekedFrame,
+			};
+			peekedFrame = null;
+			return retValue;
+		}
+
 		const next = iterator.next();
 
 		if (next.type === 'pending') {
@@ -54,9 +80,9 @@ export const createVideoIterator = async (
 		iterator.closeIterator().catch(() => undefined);
 	};
 
-	const tryToSatisfySeek = (
+	const tryToSatisfySeek = async (
 		time: number,
-	):
+	): Promise<
 		| {
 				type: 'not-satisfied';
 				reason: string;
@@ -64,7 +90,8 @@ export const createVideoIterator = async (
 		| {
 				type: 'satisfied';
 				frame: WrappedCanvas;
-		  } => {
+		  }
+	> => {
 		if (lastReturnedFrame) {
 			const frameTimestamp = roundTo4Digits(lastReturnedFrame.timestamp);
 
@@ -87,9 +114,18 @@ export const createVideoIterator = async (
 				};
 			}
 
+			let lastFrameDuration = lastReturnedFrame.duration;
+			if (lastFrameDuration === 0) {
+				const peeked = await peek();
+				if (peeked) {
+					lastFrameDuration = peeked.timestamp - lastReturnedFrame.timestamp;
+				}
+			}
+
 			const frameEndTimestamp = roundTo4Digits(
-				lastReturnedFrame.timestamp + lastReturnedFrame.duration,
+				lastReturnedFrame.timestamp + lastFrameDuration,
 			);
+
 			const timestamp = roundTo4Digits(time);
 			if (frameTimestamp <= timestamp && frameEndTimestamp > timestamp) {
 				return {
@@ -115,6 +151,7 @@ export const createVideoIterator = async (
 
 		while (true) {
 			const frame = getNextOrNullIfNotAvailable();
+
 			if (frame.type === 'need-to-wait-for-it') {
 				return {
 					type: 'not-satisfied' as const,


### PR DESCRIPTION
Fixes first bug in https://github.com/remotion-dev/remotion/issues/8277