### PR TITLE
`@remotion/studio`: Fix marquee selection from empty timeline area

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineScrollable.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScrollable.tsx
@@ -1,7 +1,10 @@
 import React, {useMemo} from 'react';
 import {HORIZONTAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {scrollableRef} from './timeline-refs';
-import {TIMELINE_BACKGROUND} from './TimelineSelection';
+import {
+	TIMELINE_BACKGROUND,
+	useTimelineMarqueeSelection,
+} from './TimelineSelection';
 
 const outer: React.CSSProperties = {
 	width: '100%',
@@ -12,9 +15,19 @@ const outer: React.CSSProperties = {
 	backgroundColor: TIMELINE_BACKGROUND,
 };
 
+const marqueeStyle: React.CSSProperties = {
+	backgroundColor: 'rgba(70, 130, 255, 0.16)',
+	border: '1px solid rgba(70, 130, 255, 0.75)',
+	boxSizing: 'border-box',
+	pointerEvents: 'none',
+	position: 'fixed',
+	zIndex: 10,
+};
+
 export const TimelineScrollable: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
+	const {marqueeRect, onPointerDownCapture} = useTimelineMarqueeSelection();
 	const containerStyle: React.CSSProperties = useMemo(() => {
 		return {
 			width: '100%',
@@ -27,8 +40,20 @@ export const TimelineScrollable: React.FC<{
 			ref={scrollableRef}
 			style={outer}
 			className={HORIZONTAL_SCROLLBAR_CLASSNAME}
+			onPointerDownCapture={onPointerDownCapture}
 		>
 			<div style={containerStyle}>{children}</div>
+			{marqueeRect === null ? null : (
+				<div
+					style={{
+						...marqueeStyle,
+						height: marqueeRect.bottom - marqueeRect.top,
+						left: marqueeRect.left,
+						top: marqueeRect.top,
+						width: marqueeRect.right - marqueeRect.left,
+					}}
+				/>
+			)}
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineTracks.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTracks.tsx
@@ -2,7 +2,6 @@ import React, {useMemo} from 'react';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {MaxTimelineTracksReached} from './MaxTimelineTracks';
-import {useTimelineMarqueeSelection} from './TimelineSelection';
 import {TimelineTimePadding} from './TimelineTimeIndicators';
 import {TimelineTrack} from './TimelineTrack';
 
@@ -15,20 +14,10 @@ const timelineContent: React.CSSProperties = {
 	minHeight: '100%',
 };
 
-const marqueeStyle: React.CSSProperties = {
-	backgroundColor: 'rgba(70, 130, 255, 0.16)',
-	border: '1px solid rgba(70, 130, 255, 0.75)',
-	boxSizing: 'border-box',
-	pointerEvents: 'none',
-	position: 'fixed',
-	zIndex: 10,
-};
-
 const TimelineTracksInner: React.FC<{
 	readonly timeline: TrackWithHash[];
 	readonly hasBeenCut: boolean;
 }> = ({timeline, hasBeenCut}) => {
-	const {marqueeRect, onPointerDownCapture} = useTimelineMarqueeSelection();
 	const timelineStyle: React.CSSProperties = useMemo(() => {
 		return {
 			...timelineContent,
@@ -37,7 +26,7 @@ const TimelineTracksInner: React.FC<{
 	}, []);
 
 	return (
-		<div style={timelineStyle} onPointerDownCapture={onPointerDownCapture}>
+		<div style={timelineStyle}>
 			<div style={content}>
 				<TimelineTimePadding />
 				{timeline.map((track) => (
@@ -45,17 +34,6 @@ const TimelineTracksInner: React.FC<{
 				))}
 			</div>
 			{hasBeenCut ? <MaxTimelineTracksReached /> : null}
-			{marqueeRect === null ? null : (
-				<div
-					style={{
-						...marqueeStyle,
-						height: marqueeRect.bottom - marqueeRect.top,
-						left: marqueeRect.left,
-						top: marqueeRect.top,
-						width: marqueeRect.right - marqueeRect.left,
-					}}
-				/>
-			)}
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

- Move timeline marquee selection handling from the rendered track rows to the scrollable timeline viewport
- Keep rendering the marquee overlay at the viewport level so drags can start from empty timeline space

Fixes #8276.

## Testing

- `cd packages/studio && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
