### PR TITLE
`@remotion/studio`: Exclude hidden timeline elements from canvas selection

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -512,7 +512,10 @@ export const getSequencesWithSelectableOutlines = ({
 				return false;
 			}
 
-			return track.nodePathInfo.auxiliaryKeys.length === 0;
+			return (
+				track.sequence.showInTimeline &&
+				track.nodePathInfo.auxiliaryKeys.length === 0
+			);
 		})
 		.filter((track) => track.sequence.refForOutline !== null)
 		.sort((a, b) => a.depth - b.depth)

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -146,6 +146,7 @@ const makeTimelineSequence = ({
 	duration = 100,
 	from = 0,
 	type = 'sequence',
+	showInTimeline = true,
 }: {
 	readonly schema: SequenceSchema;
 	readonly effects?: readonly {readonly schema: SequenceSchema}[];
@@ -156,6 +157,7 @@ const makeTimelineSequence = ({
 	readonly duration?: number;
 	readonly from?: number;
 	readonly type?: TSequence['type'];
+	readonly showInTimeline?: boolean;
 }): TSequence =>
 	({
 		type,
@@ -166,7 +168,7 @@ const makeTimelineSequence = ({
 		documentationLink: null,
 		parent: parentId,
 		rootId: 'root',
-		showInTimeline: true,
+		showInTimeline,
 		nonce: [[0, 0]],
 		loopDisplay: undefined,
 		getStack: () => null,
@@ -1239,6 +1241,50 @@ test('Canvas outline hit targets render nested sequences above parents', () => {
 		getTimelineSequenceSelectionKey(parentNodePathInfo),
 		getTimelineSequenceSelectionKey(childNodePathInfo),
 	]);
+});
+
+test('Canvas outline hit targets exclude sequences hidden from the timeline', () => {
+	const schema = {} satisfies SequenceSchema;
+	const refForOutline = {current: null};
+	const hiddenNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const visibleNodePathInfo = makeNodePathInfo(['body', 1], []);
+	const childNodePathInfo = makeNodePathInfo(['body', 0, 'children', 0], []);
+	const outlines = getSequencesWithSelectableOutlines({
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				id: 'hidden',
+				overrideId: 'hidden',
+				refForOutline,
+				showInTimeline: false,
+			}),
+			makeTimelineSequence({
+				schema,
+				id: 'visible',
+				overrideId: 'visible',
+				refForOutline,
+			}),
+			makeTimelineSequence({
+				schema,
+				id: 'child',
+				overrideId: 'child',
+				parentId: 'hidden',
+				refForOutline,
+			}),
+		],
+		overrideIdsToNodePaths: {
+			hidden: hiddenNodePathInfo.sequenceSubscriptionKey,
+			visible: visibleNodePathInfo.sequenceSubscriptionKey,
+			child: childNodePathInfo.sequenceSubscriptionKey,
+		},
+	});
+
+	expect(outlines.map((outline) => outline.key).sort()).toEqual(
+		[
+			getTimelineSequenceSelectionKey(visibleNodePathInfo),
+			getTimelineSequenceSelectionKey(childNodePathInfo),
+		].sort(),
+	);
 });
 
 test('UV handles project semantic outline corners', () => {


### PR DESCRIPTION
## Summary
- Exclude `showInTimeline={false}` sequences from canvas outline hit targets
- Keep visible child sequences selectable even when their parent is hidden from the timeline
- Add a regression test for canvas outline selectability

Fixes #8281

## Test plan
- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bunx turbo make --filter="@remotion/studio"`
- `bun run build`
- `bun run stylecheck`
