### PR TITLE
Fix orphaned `PreviewToolbar` scroll indicators when leaving mobile layout

### DIFF
--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -125,7 +125,24 @@ export const PreviewToolbar: React.FC<{
 	const isMobileLayout = useMobileLayout();
 
 	useEffect(() => {
-		if (isMobileLayout && previewToolbarRef.current) {
+		if (!isMobileLayout) {
+			// The indicators are `position: fixed` and are shown/placed
+			// imperatively by the scroll handler below. Without this reset,
+			// leaving the mobile layout (window resized past the breakpoint)
+			// leaves them visible at stale viewport coordinates — an orphaned
+			// grey gradient rectangle floating over the canvas.
+			if (leftScrollIndicatorRef.current) {
+				leftScrollIndicatorRef.current.style.display = 'none';
+			}
+
+			if (rightScrollIndicatorRef.current) {
+				rightScrollIndicatorRef.current.style.display = 'none';
+			}
+
+			return;
+		}
+
+		if (previewToolbarRef.current) {
 			const updateScrollableIndicatorProps = (target: HTMLDivElement) => {
 				const boundingBox = target.getBoundingClientRect();
 				const {scrollLeft, scrollWidth, clientWidth} = target;


### PR DESCRIPTION
## Problem

The `PreviewToolbar`'s horizontal scroll indicators (the grey `linear-gradient` pills shown on mobile layout when the toolbar overflows) are `position: fixed` elements that are shown and positioned **imperatively** by the scroll handler inside the mobile-layout effect.

When the window is resized back across the 900px breakpoint to the desktop layout, the effect's cleanup removes the scroll listener but nothing resets the indicators. An indicator that was visible at that moment stays `display: block` at its last fixed viewport coordinates — an orphaned grey gradient rectangle floating over the UI, often on top of the preview canvas. React doesn't reconcile it away because the `style` prop is a constant object, so the imperative mutations persist.

This is especially common when the Studio is embedded in an iframe/panel whose width straddles the breakpoint (users repeatedly reported it as a mysterious "watermark" on their video).

## Reproduction (verified on 4.0.454 and the published 4.0.474)

1. Open the Studio with a viewport \< 900px wide (mobile layout), narrow enough that the preview toolbar overflows.
2. Scroll the toolbar horizontally → the left gradient indicator appears (correct).
3. Resize the window to \> 900px (desktop layout).
4. The indicator remains visible at stale fixed coordinates.

Scriptable repro (Playwright):

```ts
const page = await browser.newPage({viewport: {width: 640, height: 720}});
await page.goto(studioUrl);
// scroll the toolbar, then:
await page.setViewportSize({width: 1400, height: 800});
// → a fixed-position div with background 'linear-gradient(to right, rgb(31,36,40), …)'
//   is still visible at its old coordinates
```

## Fix

Reset both indicators to `display: none` when the layout is not mobile. The effect already runs on every render, so the reset applies as soon as `useMobileLayout()` flips.

Verified with the repro above: indicator still appears correctly in mobile layout when the toolbar is scrolled, and no longer lingers after crossing back to the desktop layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)