### PR TITLE
`@remotion/studio`: Add disable interactivity codemod

### DIFF
--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -246,6 +246,10 @@ export const hiddenField: SequenceFieldSchema = {
 	description: 'Hidden',
 };
 
+const showInTimelineField: SequenceFieldSchema = {
+	type: 'hidden',
+};
+
 export const durationInFramesField = {
 	type: 'number',
 	default: undefined,
@@ -263,6 +267,7 @@ export const fromField = {
 
 export const sequenceSchema = {
 	hidden: hiddenField,
+	showInTimeline: showInTimelineField,
 	from: fromField,
 	durationInFrames: durationInFramesField,
 	layout: {
@@ -278,6 +283,7 @@ export const sequenceSchema = {
 
 export const sequenceSchemaWithoutFrom = {
 	hidden: hiddenField,
+	showInTimeline: showInTimelineField,
 	durationInFrames: durationInFramesField,
 	layout: sequenceSchema.layout,
 } as const satisfies SequenceSchema;

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -23,7 +23,7 @@ type SeriesSequenceProps = PropsWithChildren<
 		readonly durationInFrames: number;
 		readonly offset?: number;
 		readonly className?: string;
-	} & Pick<SequenceProps, 'layout' | 'name' | 'hidden'> &
+	} & Pick<SequenceProps, 'layout' | 'name' | 'hidden' | 'showInTimeline'> &
 		LayoutAndStyle
 >;
 

--- a/packages/core/src/test/wrap-in-schema-helpers.test.ts
+++ b/packages/core/src/test/wrap-in-schema-helpers.test.ts
@@ -28,6 +28,7 @@ test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 	expect(Object.keys(flat).sort()).toEqual(
 		[
 			'hidden',
+			'showInTimeline',
 			'layout',
 			'style.translate',
 			'style.scale',

--- a/packages/docs/docs/series.mdx
+++ b/packages/docs/docs/series.mdx
@@ -87,6 +87,10 @@ CSS styles to be applied to the container. If `layout` is set to `none`, there i
 
 A class name to be applied to the container. If `layout` is set to `none`, there is no container and setting this style is not allowed.
 
+### `showInTimeline?`
+
+Whether this sequence should be shown in the timeline in the Studio. See [`showInTimeline`](/docs/sequence#showintimeline).
+
 ### `premountFor?`<AvailableFrom v="4.0.140"/>
 
 [Premount](/docs/player/premounting) the sequence for a set number of frames.

--- a/packages/docs/docs/transitions/transitionseries.mdx
+++ b/packages/docs/docs/transitions/transitionseries.mdx
@@ -89,7 +89,7 @@ The `<TransitionSeries>` component can only contain `<TransitionSeries.Sequence>
 
 ### `<TransitionSeries.Sequence>`
 
-Inherits the [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`className`](/docs/sequence#classname), [`style`](/docs/sequence#style), [`premountFor`](/docs/sequence#premountfor), [`postmountFor`](/docs/sequence#postmountfor) and [`layout`](/docs/sequence#layout) props from [`<Sequence>`](/docs/sequence).
+Inherits the [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`className`](/docs/sequence#classname), [`style`](/docs/sequence#style), [`showInTimeline`](/docs/sequence#showintimeline), [`premountFor`](/docs/sequence#premountfor), [`postmountFor`](/docs/sequence#postmountfor) and [`layout`](/docs/sequence#layout) props from [`<Sequence>`](/docs/sequence).
 
 As children, put the contents of your scene.
 

--- a/packages/example/src/KeyframedPropsTest.tsx
+++ b/packages/example/src/KeyframedPropsTest.tsx
@@ -166,6 +166,7 @@ const KeyframedPropsTest: React.FC = () => {
 						height: 200,
 						borderRadius: 24,
 						overflow: 'hidden',
+						translate: '184.8px 412.4px',
 					}}
 					effects={[
 						blur({

--- a/packages/media/src/video/props.ts
+++ b/packages/media/src/video/props.ts
@@ -100,4 +100,7 @@ export type VideoProps = MandatoryVideoProps &
 	Partial<OuterVideoProps> &
 	Partial<OptionalVideoProps> &
 	NativeVideoProps &
-	Pick<SequenceProps, 'durationInFrames' | 'from' | 'name' | 'hidden'>;
+	Pick<
+		SequenceProps,
+		'durationInFrames' | 'from' | 'name' | 'showInTimeline' | 'hidden'
+	>;

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -56,6 +56,12 @@ type SequencePropEditResult = {
 	formatted: boolean;
 };
 
+export const shouldSuppressHmrForSequencePropEdits = (
+	edits: readonly {key: string}[],
+): boolean => {
+	return edits.every((edit) => edit.key !== 'showInTimeline');
+};
+
 export const saveSequencePropsHandler: ApiHandler<
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse
@@ -158,6 +164,7 @@ export const saveSequencePropsHandler: ApiHandler<
 
 		const undoMessage = `↩️  ${undoLabel}`;
 		const redoMessage = `↪️  ${redoLabel}`;
+		const suppressHmr = shouldSuppressHmrForSequencePropEdits(edits);
 
 		pushTransactionToUndoStack({
 			snapshots,
@@ -165,12 +172,15 @@ export const saveSequencePropsHandler: ApiHandler<
 			remotionRoot,
 			description: {undoMessage, redoMessage},
 			entryType: 'sequence-props',
-			suppressHmrOnFileRestore: true,
+			suppressHmrOnFileRestore: suppressHmr,
 		});
 
 		for (const [absolutePath, output] of outputByPath) {
 			suppressUndoStackInvalidation(absolutePath);
-			suppressBundlerUpdateForFile(absolutePath);
+			if (suppressHmr) {
+				suppressBundlerUpdateForFile(absolutePath);
+			}
+
 			writeFileAndNotifyFileWatchers(absolutePath, output, clientId);
 		}
 

--- a/packages/studio-server/src/test/get-all-schema-keys.test.ts
+++ b/packages/studio-server/src/test/get-all-schema-keys.test.ts
@@ -11,6 +11,7 @@ test('getAllSchemaKeys returns every key across all enum variants', () => {
 	expect(keys.sort()).toEqual(
 		[
 			'hidden',
+			'showInTimeline',
 			'layout',
 			'style.translate',
 			'style.scale',

--- a/packages/studio-server/src/test/save-sequence-props.test.ts
+++ b/packages/studio-server/src/test/save-sequence-props.test.ts
@@ -1,0 +1,20 @@
+import {expect, test} from 'bun:test';
+import {shouldSuppressHmrForSequencePropEdits} from '../preview-server/routes/save-sequence-props';
+
+test('saveSequenceProps suppresses HMR for regular visual prop edits', () => {
+	expect(
+		shouldSuppressHmrForSequencePropEdits([
+			{key: 'style.translate'},
+			{key: 'hidden'},
+		]),
+	).toBe(true);
+});
+
+test('saveSequenceProps does not suppress HMR for showInTimeline edits', () => {
+	expect(
+		shouldSuppressHmrForSequencePropEdits([
+			{key: 'style.translate'},
+			{key: 'showInTimeline'},
+		]),
+	).toBe(false);
+});

--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -96,6 +96,19 @@ test('updateSequenceProps should set boolean true as shorthand', async () => {
 	expect(output.split('\n')[7]).not.toContain('loop={true}');
 });
 
+test('updateSequenceProps should add showInTimeline false', async () => {
+	const {output, oldValueStrings} = await updateSequenceProps({
+		input: lightLeakInput,
+		nodePath: lineColumnToNodePath(lightLeakInput, 8),
+		updates: [{key: 'showInTimeline', value: false, defaultValue: true}],
+		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
+	});
+
+	expect(oldValueStrings[0]).toBe('true');
+	expect(output).toContain('showInTimeline={false}');
+});
+
 test('updateSequenceProps should report oldValueString for computed expressions', async () => {
 	const {oldValueStrings} = await updateSequenceProps({
 		input: lightLeakInput,

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -55,6 +55,7 @@ import {
 	callAddSequenceKeyframe,
 	type AddSequenceKeyframeChange,
 } from './Timeline/call-add-keyframe';
+import {disableSequenceInteractivity} from './Timeline/disable-sequence-interactivity';
 import {parseKeyframeFieldFromNodePath} from './Timeline/parse-keyframe-field-from-node-path';
 import {
 	saveSequenceProps,
@@ -2269,6 +2270,7 @@ const SelectedOutlineElement: React.FC<{
 	target,
 }) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const updateResolvedStackTrace = useContext(
 		Internals.SequenceStackTracesUpdateContext,
 	);
@@ -2304,6 +2306,7 @@ const SelectedOutlineElement: React.FC<{
 			root: window.remotion_cwd,
 		});
 		const editorName = window.remotion_editorName;
+		const disableInteractivityDisabled = !target.sequence.showInTimeline;
 
 		return [
 			editorName
@@ -2356,8 +2359,41 @@ const SelectedOutlineElement: React.FC<{
 				subMenu: null,
 				value: 'copy-outline-file-location',
 			},
+			{
+				type: 'item' as const,
+				id: 'disable-outline-interactivity',
+				keyHint: null,
+				label: 'Disable interactivity',
+				leftItem: null,
+				disabled: disableInteractivityDisabled,
+				onClick: () => {
+					if (
+						disableInteractivityDisabled ||
+						previewServerState.type !== 'connected'
+					) {
+						return;
+					}
+
+					const nodePath = target.nodePathInfo.sequenceSubscriptionKey;
+					disableSequenceInteractivity({
+						fileName: nodePath.absolutePath,
+						nodePath,
+						setPropStatuses,
+						clientId: previewServerState.clientId,
+					});
+				},
+				quickSwitcherLabel: null,
+				subMenu: null,
+				value: 'disable-outline-interactivity',
+			},
 		].filter(NoReactInternals.truthy);
-	}, [onSelect, previewServerState.type, target, updateResolvedStackTrace]);
+	}, [
+		onSelect,
+		previewServerState,
+		setPropStatuses,
+		target,
+		updateResolvedStackTrace,
+	]);
 
 	return (
 		<>

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -28,6 +28,7 @@ import {Spacing} from '../layout';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {useSelectAsset} from '../use-select-asset';
+import {disableSequenceInteractivity} from './disable-sequence-interactivity';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
 import {saveSequenceProps} from './save-sequence-prop';
 import {
@@ -247,6 +248,11 @@ export const TimelineSequenceItem: React.FC<{
 	);
 
 	const duplicateDisabled = deleteDisabled;
+	const disableInteractivityDisabled =
+		!previewConnected ||
+		!sequence.showInTimeline ||
+		!nodePath ||
+		!validatedLocation?.source;
 
 	const onDuplicateSequenceFromSource = useCallback(() => {
 		if (!validatedLocation?.source || !nodePathInfo) {
@@ -295,6 +301,30 @@ export const TimelineSequenceItem: React.FC<{
 			showNotification((err as Error).message, 4000);
 		}
 	}, [confirm, nodePath, validatedLocation?.source, nodePathInfo]);
+
+	const onDisableSequenceInteractivity = useCallback(() => {
+		if (
+			disableInteractivityDisabled ||
+			!nodePath ||
+			!validatedLocation?.source ||
+			previewServerState.type !== 'connected'
+		) {
+			return;
+		}
+
+		disableSequenceInteractivity({
+			fileName: validatedLocation.source,
+			nodePath,
+			setPropStatuses,
+			clientId: previewServerState.clientId,
+		});
+	}, [
+		disableInteractivityDisabled,
+		nodePath,
+		previewServerState,
+		setPropStatuses,
+		validatedLocation?.source,
+	]);
 
 	const getSequenceDropTarget = useCallback(
 		(e: React.DragEvent<HTMLDivElement>): SequenceDropTarget | null => {
@@ -607,6 +637,20 @@ export const TimelineSequenceItem: React.FC<{
 				: null,
 			{
 				type: 'item' as const,
+				id: 'disable-interactivity',
+				keyHint: null,
+				label: 'Disable interactivity',
+				leftItem: null,
+				disabled: disableInteractivityDisabled,
+				onClick: () => {
+					onDisableSequenceInteractivity();
+				},
+				quickSwitcherLabel: null,
+				subMenu: null,
+				value: 'disable-interactivity',
+			},
+			{
+				type: 'item' as const,
 				id: 'duplicate-sequence',
 				keyHint: null,
 				label: 'Duplicate',
@@ -645,9 +689,11 @@ export const TimelineSequenceItem: React.FC<{
 	}, [
 		assetLinkInfo,
 		deleteDisabled,
+		disableInteractivityDisabled,
 		duplicateDisabled,
 		fileLocation,
 		onDeleteSequenceFromSource,
+		onDisableSequenceInteractivity,
 		onDuplicateSequenceFromSource,
 		canOpenInEditor,
 		openInEditor,

--- a/packages/studio/src/components/Timeline/disable-sequence-interactivity.ts
+++ b/packages/studio/src/components/Timeline/disable-sequence-interactivity.ts
@@ -1,0 +1,32 @@
+import type {SequencePropsSubscriptionKey} from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
+import {saveSequenceProps, type SetPropStatuses} from './save-sequence-prop';
+
+export const disableSequenceInteractivity = ({
+	clientId,
+	fileName,
+	nodePath,
+	setPropStatuses,
+}: {
+	readonly clientId: string;
+	readonly fileName: string;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly setPropStatuses: SetPropStatuses;
+}): Promise<void> => {
+	return saveSequenceProps({
+		changes: [
+			{
+				fileName,
+				nodePath,
+				fieldKey: 'showInTimeline',
+				value: false,
+				defaultValue: 'true',
+				schema: NoReactInternals.sequenceSchema,
+			},
+		],
+		setPropStatuses,
+		clientId,
+		undoLabel: 'Disable interactivity',
+		redoLabel: 'Disable interactivity again',
+	});
+};

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -42,7 +42,7 @@ type SeriesSequenceProps = PropsWithChildren<
 		readonly offset?: number;
 		readonly className?: string;
 	} & LayoutBasedProps &
-		Pick<SequencePropsWithoutDuration, 'name'>
+		Pick<SequencePropsWithoutDuration, 'name' | 'showInTimeline'>
 >;
 
 const SeriesSequence = ({children}: SeriesSequenceProps) => {


### PR DESCRIPTION
## Summary

- Add "Disable interactivity" context menu actions for Studio timeline rows and selected canvas outlines.
- Codemod the selected JSX node to `showInTimeline={false}` through the existing sequence prop save flow.
- Expose `showInTimeline` on additional Sequence-backed component types and document it for Series wrappers.

Fixes #8285.

## Tests

- `bun test src/test/wrap-in-schema-helpers.test.ts` in `packages/core`
- `bun test src/test/update-sequence-props.test.ts` in `packages/studio-server`
- `bun run build`
- `bun run stylecheck`
