### PR TITLE
`@remotion/studio`: Reset computed sequence props with Backspace

### DIFF
--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -80,7 +80,7 @@ const isResettablePropStatus = ({
 	readonly propStatus: CanUpdateSequencePropStatus | null | undefined;
 	readonly defaultValue: unknown;
 }) => {
-	if (!propStatus || propStatus.status === 'computed') {
+	if (!propStatus) {
 		return false;
 	}
 
@@ -88,7 +88,7 @@ const isResettablePropStatus = ({
 		return false;
 	}
 
-	if (propStatus.status === 'keyframed') {
+	if (propStatus.status === 'keyframed' || propStatus.status === 'computed') {
 		return true;
 	}
 

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1770,6 +1770,53 @@ test('Backspace reset targets selected keyframed sequence props', () => {
 	]);
 });
 
+test('Backspace reset targets selected computed sequence props with defaults', () => {
+	const schema = {
+		'style.scale': {type: 'scale', default: 1, max: 100},
+	} satisfies SequenceSchema;
+	const scaleNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'style.scale'],
+	);
+	const nodePath = scaleNodePathInfo.sequenceSubscriptionKey;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {
+				'style.scale': {
+					status: 'computed',
+				},
+			},
+			effects: [],
+		},
+	} satisfies PropStatuses;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-prop',
+				nodePathInfo: scaleNodePathInfo,
+				key: 'style.scale',
+			},
+		],
+		sequences: [makeTimelineSequence({schema})],
+		overrideIdsToNodePaths: {override: nodePath},
+		propStatuses,
+	});
+
+	expect(resetTargets).toEqual([
+		{
+			type: 'sequence-prop',
+			fileName: '/project/src/Comp.tsx',
+			nodePath,
+			fieldKey: 'style.scale',
+			value: 1,
+			defaultValue: '1',
+			schema,
+		},
+	]);
+});
+
 test('Backspace reset skips keyframed sequence props without defaults', () => {
 	const schema = {
 		opacity: {type: 'number', default: undefined, hiddenFromList: false},


### PR DESCRIPTION
Fixes #8270

## Summary
- Allow Backspace/Delete reset handling to reset selected computed sequence props when a default value exists.
- Add regression coverage for resetting a computed `style.scale` prop back to its default.

## Testing
- bun test packages/studio/src/test/timeline-selection.test.ts --timeout 30000
- bun run build
- bun run stylecheck
