### PR TITLE
`remotion`: Add documentation link to Interactive sequences

### DIFF
--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -143,6 +143,11 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 				showInTimeline={showInTimeline ?? true}
 				_experimentalControls={_experimentalControls}
 				_remotionInternalStack={stack}
+				_remotionInternalDocumentationLink={
+					name === undefined
+						? 'https://www.remotion.dev/docs/interactive'
+						: undefined
+				}
 				_remotionInternalRefForOutline={refForOutline}
 			>
 				{React.createElement(tag, {

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -242,6 +242,7 @@ test('Img registers a refForOutline pointing to the rendered image element', () 
 test('Interactive elements register their rendered element for Studio outlines', () => {
 	const registeredSequences: TSequence[] = [];
 	const divRef = React.createRef<HTMLDivElement>();
+	const documentationLink = 'https://www.remotion.dev/docs/interactive';
 
 	render(
 		<SequenceTestWrapper
@@ -282,6 +283,12 @@ test('Interactive elements register their rendered element for Studio outlines',
 	);
 	expect(getByName('<Interactive.Rect>')?.refForOutline?.current?.tagName).toBe(
 		'rect',
+	);
+	expect(getByName('<Interactive.Div>')?.documentationLink).toBe(
+		documentationLink,
+	);
+	expect(getByName('<Interactive.Rect>')?.documentationLink).toBe(
+		documentationLink,
 	);
 	expect(getByName('<Interactive.Div>')?.refForOutline?.current).toBe(
 		divRef.current,


### PR DESCRIPTION
## Summary
`Interactive.*` elements now register `_remotionInternalDocumentationLink` pointing at the Interactive docs, matching the pattern `Img`, `Loop`, and `Series` already use, so the Studio timeline can surface a docs link for default-named Interactive sequences. Custom-named sequences keep their name without a link, same as the existing components.

## Testing
Extended the existing registration test to assert the documentation link for `<Interactive.Div>` and `<Interactive.Rect>`. `bun test src/test/sequence-register-once.test.tsx` passes (9 tests).

Fixes #8288
