### PR TITLE
`@remotion/studio`: Support transform origin anchor for SVG elements

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -560,7 +560,12 @@ const measureOutlines = (
 							width: element.offsetWidth,
 							height: element.offsetHeight,
 						}
-					: null,
+					: element instanceof SVGSVGElement
+						? {
+								width: element.width.baseVal.value,
+								height: element.height.baseVal.value,
+							}
+						: null,
 			points,
 		});
 	}


### PR DESCRIPTION
The transform origin anchor was not showing up for shape components like `<Arrow>`, `<Circle>`, etc.

**Root cause:** The dimensions check in `SelectedOutlineOverlay.tsx` only handled `HTMLElement` (using `offsetWidth`/`offsetHeight`). Shape components render as `<svg>` elements (`SVGSVGElement`), so `dimensions` was always `null`, and the anchor component bailed out early.

**Fix:** Added an `SVGSVGElement` branch that reads dimensions from the SVG `width`/`height` base values.