### PR TITLE
`@remotion/convert`: Use document-level drop handler for reliable file drops

### DIFF
--- a/packages/convert/app/components/PickFile.tsx
+++ b/packages/convert/app/components/PickFile.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect} from 'react';
 import {SAMPLE_FILE_CONVERT, SAMPLE_FILE_TRANSCRIBE} from '~/lib/config';
 import type {Source} from '~/lib/convert-state';
 import type {RouteAction} from '~/seo';
@@ -22,29 +22,30 @@ export const PickFile: React.FC<{
 		});
 	}, [setSrc, action]);
 
-	const onDrop = useCallback(
-		(event: React.DragEvent<HTMLDivElement>) => {
-			event.preventDefault();
-			event.stopPropagation();
-			const file = event.dataTransfer.files[0];
+	useEffect(() => {
+		const onDragOver = (e: DragEvent) => {
+			e.preventDefault();
+		};
+
+		const onDrop = (e: DragEvent) => {
+			e.preventDefault();
+			const file = e.dataTransfer?.files[0];
 			if (file) {
 				setSrc({type: 'file', file});
 			}
-		},
-		[setSrc],
-	);
+		};
 
-	const onDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
-		event.preventDefault();
-		event.stopPropagation();
-	}, []);
+		document.body.addEventListener('dragover', onDragOver);
+		document.body.addEventListener('drop', onDrop);
+
+		return () => {
+			document.body.removeEventListener('dragover', onDragOver);
+			document.body.removeEventListener('drop', onDrop);
+		};
+	}, [setSrc]);
 
 	return (
-		<div
-			className="text-center items-center justify-center flex flex-col h-full w-full"
-			onDragOver={onDragOver}
-			onDrop={onDrop}
-		>
+		<div className="text-center items-center justify-center flex flex-col h-full w-full">
 			<div className="bg-[#F9FAFC] w-full">
 				<div className="h-10" />
 				<TextMarkLogo text="Remotion Convert" />


### PR DESCRIPTION
## Summary

Fixes the drop handler on the remotion.dev/convert homepage so dropping a video file works reliably anywhere on the page.

## Problem

The `PickFile` component used React's `onDragOver`/`onDrop` handlers on a container `<div>` with `h-full` (CSS `height: 100%`). Because the parent uses `min-h-screen` rather than a fixed height, the container may not cover the entire viewport — leaving areas where dropping a file triggers the browser's default behavior (opening the file in a new tab).

## Solution

Replaced the React event handlers with `document.body` event listeners (via `useEffect`), matching the approach already used by the `ReplaceVideo` component. This ensures `dragover` is always `preventDefault()`-ed across the entire page.

Closes #8299
