### PR TITLE
`@remotion/studio`: Allow scaling keyframed sequences in visual mode

### DIFF
--- a/packages/example/src/KeyframedPropsTest.tsx
+++ b/packages/example/src/KeyframedPropsTest.tsx
@@ -67,7 +67,20 @@ const ShiftedEffect = () => {
 				height: 200,
 				borderRadius: 24,
 				overflow: 'hidden',
-				translate: '254.854512px 393.565342px',
+				translate: '484.5px 439px',
+				scale: interpolate(frame, [16], [2.044585], {
+					extrapolateLeft: 'clamp',
+					extrapolateRight: 'clamp',
+				}),
+				rotate: interpolate(
+					frame,
+					[16, 39],
+					['76.455165deg', '144.692528deg'],
+					{
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+					},
+				),
 			}}
 			effects={[
 				blur({

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -148,10 +148,13 @@ type ScaleFieldSchema = Extract<SequenceFieldSchema, {type: 'scale'}>;
 type RotationFieldSchema = Extract<SequenceFieldSchema, {type: 'rotation-css'}>;
 
 type SelectedOutlineScaleDragTarget = {
-	readonly propStatus: CanUpdateSequencePropStatusStatic;
+	readonly propStatus:
+		| CanUpdateSequencePropStatusStatic
+		| CanUpdateSequencePropStatusKeyframed;
 	readonly clientId: string;
 	readonly fieldDefault: number | string | undefined;
 	readonly fieldSchema: ScaleFieldSchema;
+	readonly keyframeDisplayOffset: number;
 	readonly linked: boolean;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: SequenceSchema;
@@ -181,6 +184,7 @@ export type SelectedOutlineDragState = {
 export type SelectedOutlineScaleDragState = {
 	readonly defaultValue: string | null;
 	readonly key: string;
+	readonly sourceFrame: number;
 	readonly startX: number;
 	readonly startY: number;
 	readonly startZ: number;
@@ -803,18 +807,22 @@ export const getSelectedOutlineScaleEdgeInfo = (
 export const getSelectedOutlineScaleDragStates = ({
 	dragTargets,
 	getDragOverrides,
+	timelinePosition,
 }: {
 	readonly dragTargets: readonly SelectedOutlineScaleDragTarget[];
 	readonly getDragOverrides: GetDragOverrides;
+	readonly timelinePosition: number;
 }): SelectedOutlineScaleDragState[] => {
 	return dragTargets.map((target) => {
 		const dragOverrideValue = (getDragOverrides(target.nodePath) ?? {})[
 			scaleFieldKey
 		];
+		const sourceFrame = timelinePosition - target.keyframeDisplayOffset;
 		const effectiveValue = Internals.getEffectiveVisualModeValue({
 			propStatus: target.propStatus,
 			dragOverrideValue,
 			defaultValue: target.fieldDefault,
+			frame: sourceFrame,
 			shouldResortToDefaultValueIfUndefined: true,
 		});
 		const [startX, startY, startZ] =
@@ -826,6 +834,7 @@ export const getSelectedOutlineScaleDragStates = ({
 					? JSON.stringify(target.fieldDefault)
 					: null,
 			key: Internals.makeSequencePropsSubscriptionKey(target.nodePath),
+			sourceFrame,
 			startX,
 			startY,
 			startZ,
@@ -877,11 +886,36 @@ export const getSelectedOutlineScaleDragChanges = ({
 }: {
 	readonly dragStates: readonly SelectedOutlineScaleDragState[];
 	readonly lastValues: ReadonlyMap<string, number | string>;
-}) => {
-	return dragStates.flatMap((dragState) => {
+}): SelectedOutlineDragChange[] => {
+	const changes: SelectedOutlineDragChange[] = [];
+
+	for (const dragState of dragStates) {
 		const value = lastValues.get(dragState.key);
 		if (value === undefined) {
-			return [];
+			continue;
+		}
+
+		if (dragState.target.propStatus.status === 'keyframed') {
+			const startValue = NoReactInternals.serializeScaleValue([
+				dragState.startX,
+				dragState.startY,
+				dragState.startZ,
+			]);
+			if (value === startValue) {
+				continue;
+			}
+
+			changes.push({
+				type: 'keyframed',
+				fileName: dragState.target.nodePath.absolutePath,
+				nodePath: dragState.target.nodePath,
+				fieldKey: scaleFieldKey,
+				sourceFrame: dragState.sourceFrame,
+				value,
+				schema: dragState.target.schema,
+				clientId: dragState.target.clientId,
+			});
+			continue;
 		}
 
 		const stringifiedValue = JSON.stringify(value);
@@ -894,20 +928,21 @@ export const getSelectedOutlineScaleDragChanges = ({
 			);
 
 		if (!shouldSave) {
-			return [];
+			continue;
 		}
 
-		return [
-			{
-				fileName: dragState.target.nodePath.absolutePath,
-				nodePath: dragState.target.nodePath,
-				fieldKey: scaleFieldKey,
-				value,
-				defaultValue: dragState.defaultValue,
-				schema: dragState.target.schema,
-			},
-		];
-	});
+		changes.push({
+			type: 'static',
+			fileName: dragState.target.nodePath.absolutePath,
+			nodePath: dragState.target.nodePath,
+			fieldKey: scaleFieldKey,
+			value,
+			defaultValue: dragState.defaultValue,
+			schema: dragState.target.schema,
+		});
+	}
+
+	return changes;
 };
 
 export const getSelectedOutlineRotationDragStates = ({
@@ -1777,6 +1812,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const scaleDrag = target?.scaleDrag ?? null;
 	const selected = target?.selected ?? false;
 	const lineRef = useRef<SVGLineElement>(null);
@@ -1811,6 +1847,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			const dragStates = getSelectedOutlineScaleDragStates({
 				dragTargets: selected ? allScaleDragTargets : [scaleDrag],
 				getDragOverrides,
+				timelinePosition,
 			});
 			let lastValues = new Map<string, number | string>();
 
@@ -1839,11 +1876,23 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 						throw new Error('Expected scale drag value to be available');
 					}
 
-					setDragOverrides(
-						dragState.target.nodePath,
-						scaleFieldKey,
-						Internals.makeStaticDragOverride(value),
-					);
+					if (dragState.target.propStatus.status === 'keyframed') {
+						setDragOverrides(
+							dragState.target.nodePath,
+							scaleFieldKey,
+							Internals.makeKeyframedDragOverride({
+								status: dragState.target.propStatus,
+								frame: dragState.sourceFrame,
+								value,
+							}),
+						);
+					} else {
+						setDragOverrides(
+							dragState.target.nodePath,
+							scaleFieldKey,
+							Internals.makeStaticDragOverride(value),
+						);
+					}
 				}
 			};
 
@@ -1866,17 +1915,44 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 					return;
 				}
 
-				saveSequenceProps({
-					changes,
-					setPropStatuses,
-					clientId: scaleDrag.clientId,
-					undoLabel:
-						changes.length > 1 ? 'Scale selected sequences' : 'Scale sequence',
-					redoLabel:
-						changes.length > 1
-							? 'Scale selected sequences back'
-							: 'Scale sequence back',
-				})
+				const staticChanges = changes.filter(
+					(change): change is SelectedOutlineStaticDragChange =>
+						change.type === 'static',
+				);
+				const keyframedChanges = changes.filter(
+					(change): change is SelectedOutlineKeyframedDragChange =>
+						change.type === 'keyframed',
+				);
+
+				Promise.all([
+					staticChanges.length > 0
+						? saveSequenceProps({
+								changes: staticChanges,
+								setPropStatuses,
+								clientId: scaleDrag.clientId,
+								undoLabel:
+									changes.length > 1
+										? 'Scale selected sequences'
+										: 'Scale sequence',
+								redoLabel:
+									changes.length > 1
+										? 'Scale selected sequences back'
+										: 'Scale sequence back',
+							})
+						: Promise.resolve(),
+					...keyframedChanges.map((change) =>
+						callAddSequenceKeyframe({
+							fileName: change.fileName,
+							nodePath: change.nodePath,
+							fieldKey: change.fieldKey,
+							sourceFrame: change.sourceFrame,
+							value: change.value,
+							schema: change.schema,
+							setPropStatuses,
+							clientId: change.clientId,
+						}),
+					),
+				])
 					.catch((err) => {
 						showNotification(
 							`Could not save sequence props: ${
@@ -1909,6 +1985,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			setPropStatuses,
 			setDragOverrides,
 			target,
+			timelinePosition,
 		],
 	);
 
@@ -2489,11 +2566,15 @@ export const SelectedOutlineOverlay: React.FC<{
 				controls !== null &&
 				fieldSchema?.type === 'translate' &&
 				canDragStatus;
+			const canScaleDragStatus =
+				scalePropStatus?.status === 'static' ||
+				(scalePropStatus?.status === 'keyframed' &&
+					scalePropStatus.interpolationFunction === 'interpolate');
 			const canScaleDrag =
 				previewServerState.type === 'connected' &&
 				controls !== null &&
 				scaleFieldSchema?.type === 'scale' &&
-				scalePropStatus?.status === 'static';
+				canScaleDragStatus;
 			const canRotationDrag =
 				previewServerState.type === 'connected' &&
 				controls !== null &&
@@ -2557,6 +2638,7 @@ export const SelectedOutlineOverlay: React.FC<{
 							clientId: previewServerState.clientId,
 							fieldDefault: scaleFieldSchema.default,
 							fieldSchema: scaleFieldSchema,
+							keyframeDisplayOffset,
 							linked: getScaleLockState({
 								nodePath,
 								fieldKey: scaleFieldKey,

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -1813,6 +1813,8 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 		Internals.VisualModeSettersContext,
 	);
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const timelinePositionRef = useRef(timelinePosition);
+	timelinePositionRef.current = timelinePosition;
 	const scaleDrag = target?.scaleDrag ?? null;
 	const selected = target?.selected ?? false;
 	const lineRef = useRef<SVGLineElement>(null);
@@ -1847,7 +1849,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			const dragStates = getSelectedOutlineScaleDragStates({
 				dragTargets: selected ? allScaleDragTargets : [scaleDrag],
 				getDragOverrides,
-				timelinePosition,
+				timelinePosition: timelinePositionRef.current,
 			});
 			let lastValues = new Map<string, number | string>();
 
@@ -1985,7 +1987,6 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			setPropStatuses,
 			setDragOverrides,
 			target,
-			timelinePosition,
 		],
 	);
 

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -2034,6 +2034,7 @@ test('Selected outline edge dragging scales one axis when scale is unlinked', ()
 		{
 			defaultValue: JSON.stringify(1),
 			key: Internals.makeSequencePropsSubscriptionKey(nodePath),
+			sourceFrame: 0,
 			startX: 2,
 			startY: 3,
 			startZ: 1,
@@ -2042,6 +2043,7 @@ test('Selected outline edge dragging scales one axis when scale is unlinked', ()
 				propStatus: {status: 'static', codeValue: '2 3'},
 				fieldDefault: 1,
 				fieldSchema: schema['style.scale'],
+				keyframeDisplayOffset: 0,
 				linked: false,
 				nodePath,
 				schema,
@@ -2063,6 +2065,7 @@ test('Selected outline edge dragging scales one axis when scale is unlinked', ()
 		}),
 	).toEqual([
 		{
+			type: 'static',
 			fileName: '/project/src/Comp.tsx',
 			nodePath,
 			fieldKey: 'style.scale',
@@ -2090,6 +2093,7 @@ test('Selected outline edge dragging preserves aspect ratio when scale is linked
 		{
 			defaultValue: JSON.stringify(1),
 			key: Internals.makeSequencePropsSubscriptionKey(nodePath),
+			sourceFrame: 0,
 			startX: 2,
 			startY: 3,
 			startZ: 1,
@@ -2098,6 +2102,7 @@ test('Selected outline edge dragging preserves aspect ratio when scale is linked
 				propStatus: {status: 'static', codeValue: '2 3'},
 				fieldDefault: 1,
 				fieldSchema: schema['style.scale'],
+				keyframeDisplayOffset: 0,
 				linked: true,
 				nodePath,
 				schema,


### PR DESCRIPTION
Closes #8298

When `style.scale` was keyframed, the Studio visual mode scale drag was disabled because `canScaleDrag` only allowed `status === 'static'`. Meanwhile, `style.rotate` and `style.translate` already supported keyframed values.

This PR mirrors the keyframed support from translate/rotation to scale:

- Allow `canScaleDrag` when prop status is `keyframed` (with `interpolate` function)
- Add `keyframeDisplayOffset` and `sourceFrame` to scale drag targets/states
- Use `makeKeyframedDragOverride` during pointer move for keyframed scales
- Split scale changes into static/keyframed on pointer up, calling `callAddSequenceKeyframe` for keyframed values
- Update tests to match the new type shape
