### PR TITLE
`@remotion/studio-server`: Ensure `Still` import when duplicating composition as Still

### DIFF
--- a/packages/studio-server/src/codemods/duplicate-composition.ts
+++ b/packages/studio-server/src/codemods/duplicate-composition.ts
@@ -1,4 +1,5 @@
 import type {RecastCodemod} from '@remotion/studio-shared';
+import {ensureNamedImport} from '../helpers/imports';
 import {parseAst, serializeAst} from './parse-ast';
 import type {Change} from './recast-mods';
 import {applyCodemod} from './recast-mods';
@@ -56,6 +57,15 @@ export const parseAndApplyCodemod = ({
 		throw new Error(
 			'Unable to calculate the changes needed for this file. Edit the file manually.',
 		);
+	}
+
+	if (codeMod.type === 'duplicate-composition' && codeMod.tag) {
+		ensureNamedImport({
+			ast: newAst,
+			importedName: codeMod.tag,
+			sourcePath: 'remotion',
+			localName: codeMod.tag,
+		});
 	}
 
 	const output = serializeAst(newAst);

--- a/packages/studio-server/src/test/recast-mods.test.ts
+++ b/packages/studio-server/src/test/recast-mods.test.ts
@@ -160,3 +160,74 @@ test('Rename concise-arrow composition keeps the arrow expression body', () => {
 	expect(newContents).toContain('id="Renamed"');
 	expect(newContents).not.toContain('id="NewVideo"');
 });
+
+test('Duplicate composition as Still adds Still import', () => {
+	const {newContents, changesMade} = parseAndApplyCodemod({
+		input: compositionInOwnFile,
+		codeMod: {
+			type: 'duplicate-composition',
+			idToDuplicate: 'NewVideo',
+			newId: 'Duplicated',
+			newDurationInFrames: null,
+			newFps: null,
+			newHeight: null,
+			newWidth: null,
+			tag: 'Still',
+		},
+	});
+
+	expect(changesMade.length).toBeGreaterThan(0);
+	expect(newContents).toContain('id="NewVideo"');
+	expect(newContents).toContain('id="Duplicated"');
+	expect(newContents).toContain('<Still');
+	expect(newContents).toContain('Still');
+	expect(newContents).toMatch(
+		/import\s*\{[^}]*Still[^}]*\}\s*from\s*['"]remotion['"]/,
+	);
+});
+
+test('Duplicate composition as Still does not duplicate import if Still already imported', () => {
+	const inputWithStill = `import {Composition, Still} from 'remotion';
+
+const Component = () => null;
+
+export const NewVideoComp = () => {
+	return (
+		<Composition
+			component={Component}
+			id="NewVideo"
+			durationInFrames={120}
+			fps={30}
+			width={1280}
+			height={720}
+		/>
+	);
+};
+`;
+
+	const {newContents} = parseAndApplyCodemod({
+		input: inputWithStill,
+		codeMod: {
+			type: 'duplicate-composition',
+			idToDuplicate: 'NewVideo',
+			newId: 'Duplicated',
+			newDurationInFrames: null,
+			newFps: null,
+			newHeight: null,
+			newWidth: null,
+			tag: 'Still',
+		},
+	});
+
+	// Should only have one import of Still, not two
+	// Still appears in: import + JSX tag opening
+	expect(newContents).toContain('<Still');
+	expect(newContents).toMatch(
+		/import\s*\{[^}]*Still[^}]*\}\s*from\s*['"]remotion['"]/,
+	);
+	// Ensure no duplicate import declarations
+	const importLines = newContents
+		.split('\n')
+		.filter((l: string) => l.includes('import') && l.includes('remotion'));
+	expect(importLines.length).toBe(1);
+});


### PR DESCRIPTION
## Summary

When duplicating a `<Composition durationInFrames={1}>`, the Studio UI offers to create a `<Still>` instead. The codemod correctly changes the JSX tag from `<Composition>` to `<Still>`, but it doesn't add the `Still` import — resulting in a broken file.

## Fix

After the AST transformation in `parseAndApplyCodemod`, call `ensureNamedImport` to add the `Still` (or `Composition`) import from `'remotion'` when the tag is specified in the duplicate-composition codemod. The `ensureNamedImport` helper already handles deduplication.

## Tests

Added two test cases:
- Duplicating as `<Still>` adds the `Still` import
- Duplicating as `<Still>` when `Still` is already imported doesn't create a duplicate import

Fixes #8293
