### PR TITLE
`remotion`: Add spring easing

### DIFF
--- a/packages/core/src/easing.ts
+++ b/packages/core/src/easing.ts
@@ -1,11 +1,18 @@
 // Taken from https://github.com/facebook/react-native/blob/0b9ea60b4fee8cacc36e7160e31b91fc114dbc0d/Libraries/Animated/src/Easing.js
 
 import {bezier} from './bezier.js';
+import {spring} from './spring/index.js';
+import type {SpringConfig} from './spring/spring-utils.js';
+
+export type EasingSpringConfig = Partial<
+	Pick<SpringConfig, 'damping' | 'mass' | 'stiffness' | 'overshootClamping'>
+>;
 
 // Some easing curves are only defined on [0, 1] (e.g. quarter circle, bounce segments).
 // `interpolate(..., { extrapolate: 'extend' })` can pass values outside that interval; clamp
 // there so we return endpoints instead of NaN or unintended extrapolation.
 const clampUnit = (t: number): number => Math.min(1, Math.max(0, t));
+const springEasingDurationInFrames = 30;
 
 /**
  * @description The Easing module implements common easing functions. You can use it with the interpolate() API.
@@ -61,6 +68,25 @@ export class Easing {
 
 	static back(s = 1.70158): (t: number) => number {
 		return (t): number => t * t * ((s + 1) * t - s);
+	}
+
+	static spring(config: EasingSpringConfig = {}): (t: number) => number {
+		return (t): number => {
+			if (t <= 0) {
+				return 0;
+			}
+
+			if (t >= 1) {
+				return 1;
+			}
+
+			return spring({
+				fps: springEasingDurationInFrames,
+				frame: t * springEasingDurationInFrames,
+				config,
+				durationInFrames: springEasingDurationInFrames,
+			});
+		};
 	}
 
 	static bounce(t: number): number {

--- a/packages/core/src/test/easing.test.ts
+++ b/packages/core/src/test/easing.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from 'bun:test';
 import {Easing} from '../easing.js';
+import {spring} from '../spring/index.js';
 
 const numbersToTest = [-0.5, 0, 0.4, 0.5, 0.7, 1, 1.5];
 
@@ -235,5 +236,41 @@ describe('Easing Bounce', () => {
 	test('Easing Out', () => {
 		const easingInOut = Easing.inOut(Easing.bounce);
 		numbersToTest.forEach((n) => expect(easingInOut(n)).toBe(inOut(n)));
+	});
+});
+
+describe('Easing spring', () => {
+	test('matches a duration-stretched spring', () => {
+		const config = {
+			damping: 12,
+			mass: 0.8,
+			stiffness: 150,
+		};
+		const easing = Easing.spring(config);
+
+		for (const t of [0.1, 0.25, 0.5, 0.75, 0.9]) {
+			expect(easing(t)).toBe(
+				spring({
+					fps: 30,
+					frame: t * 30,
+					durationInFrames: 30,
+					config,
+				}),
+			);
+		}
+	});
+
+	test('clamps the endpoints', () => {
+		const easing = Easing.spring();
+
+		expect(easing(-1)).toBe(0);
+		expect(easing(0)).toBe(0);
+		expect(easing(1)).toBe(1);
+		expect(easing(2)).toBe(1);
+	});
+
+	test('supports overshoot clamping', () => {
+		expect(Easing.spring()(0.5)).toBeGreaterThan(1);
+		expect(Easing.spring({overshootClamping: true})(0.5)).toBe(1);
 	});
 });

--- a/packages/docs/docs/easing.mdx
+++ b/packages/docs/docs/easing.mdx
@@ -17,6 +17,7 @@ The `Easing` module provides several predefined animations through the following
 - [`bounce`](/docs/easing#bounce) provides a bouncing animation
 - [`ease`](/docs/easing#ease) provides a basic inertial animation
 - [`elastic`](/docs/easing#elastic) provides a basic spring interaction
+- [`spring`](/docs/easing#spring) provides a physics-based spring animation
 
 ### Standard functions
 
@@ -201,6 +202,29 @@ A basic elastic interaction, similar to a spring oscillating back and forth.
 Default bounciness is 1, which overshoots a little bit once. 0 bounciness doesn't overshoot at all, and bounciness of N > 1 will overshoot about N times.
 
 http://easings.net/#easeInElastic
+
+---
+
+### `spring()`<AvailableFrom v="4.0.476" />
+
+```jsx
+static spring(config?): (t) => number
+```
+
+Creates a spring easing function for [`interpolate()`](/docs/interpolate).
+The curve is normalized to the interpolation progress, so it does not take `frame`, `fps` or `durationInFrames`.
+
+```tsx twoslash title="MyComponent.tsx"
+import {Easing, interpolate} from 'remotion';
+// ---cut---
+const scale = interpolate(30, [0, 60], [0, 1], {
+  easing: Easing.spring({
+    damping: 200,
+  }),
+});
+```
+
+The supported config fields are `damping`, `mass`, `stiffness` and `overshootClamping`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `Easing.spring()` for duration-normalized spring easing in `interpolate()`
- Support `damping`, `mass`, `stiffness`, and `overshootClamping` config fields
- Document the new easing helper and add tests

Fixes #8310
