### PR TITLE
`@remotion/studio`: Allow arbitrary translate offsets

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -31,6 +31,30 @@ const isInt = (num: number) => {
 	return num % 1 === 0;
 };
 
+export const deriveInputDraggerStep = ({
+	min,
+	snapToStep,
+	step,
+}: {
+	readonly min: React.InputHTMLAttributes<HTMLInputElement>['min'];
+	readonly snapToStep: boolean;
+	readonly step: React.InputHTMLAttributes<HTMLInputElement>['step'];
+}) => {
+	if (!snapToStep) {
+		return 'any';
+	}
+
+	if (step !== undefined) {
+		return step;
+	}
+
+	if (typeof min === 'number' && isInt(min)) {
+		return 1;
+	}
+
+	return 0.0001;
+};
+
 const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 	HTMLButtonElement,
 	Props
@@ -216,19 +240,11 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 	}, [inputFallback]);
 
 	const deriveStep = useMemo(() => {
-		if (!snapToStep) {
-			return 'any';
-		}
-
-		if (_step !== undefined) {
-			return _step;
-		}
-
-		if (typeof _min === 'number' && isInt(_min)) {
-			return 1;
-		}
-
-		return 0.0001;
+		return deriveInputDraggerStep({
+			min: _min,
+			snapToStep,
+			step: _step,
+		});
 	}, [_min, _step, snapToStep]);
 
 	if (inputFallback) {

--- a/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
@@ -177,6 +177,7 @@ export const TimelineTranslateField: React.FC<{
 				step={step}
 				formatter={formatter}
 				rightAlign={false}
+				snapToStep={false}
 			/>
 			<div style={{marginLeft: -6, marginRight: -6}} />
 			<InputDragger
@@ -193,6 +194,7 @@ export const TimelineTranslateField: React.FC<{
 				step={step}
 				formatter={formatter}
 				rightAlign={false}
+				snapToStep={false}
 			/>
 		</span>
 	);

--- a/packages/studio/src/test/input-dragger.test.ts
+++ b/packages/studio/src/test/input-dragger.test.ts
@@ -1,0 +1,22 @@
+import {expect, test} from 'bun:test';
+import {deriveInputDraggerStep} from '../components/NewComposition/InputDragger';
+
+test('deriveInputDraggerStep disables HTML step validation if snapping is disabled', () => {
+	expect(
+		deriveInputDraggerStep({
+			min: -Infinity,
+			snapToStep: false,
+			step: 1,
+		}),
+	).toBe('any');
+});
+
+test('deriveInputDraggerStep keeps configured step while snapping is enabled', () => {
+	expect(
+		deriveInputDraggerStep({
+			min: -Infinity,
+			snapToStep: true,
+			step: 0.5,
+		}),
+	).toBe(0.5);
+});


### PR DESCRIPTION
## Summary
- Disable step snapping and HTML step validation for timeline translate inputs so offsets like `0` can be entered from fractional current values.
- Extract InputDragger step derivation and cover disabled snapping with a unit test.

Fixes #8306

## Testing
- `bun test packages/studio/src/test/input-dragger.test.ts`
- `bun run build`
- `bun run stylecheck`
