### PR TITLE
`@remotion/effects`: Expose palette effect colors

### DIFF
--- a/packages/docs/components/effects/effects-lines-preview.tsx
+++ b/packages/docs/components/effects/effects-lines-preview.tsx
@@ -3,19 +3,20 @@ import React from 'react';
 import {Solid, useVideoConfig} from 'remotion';
 
 export const EffectsLinesPreview: React.FC<{
+	readonly colors: readonly string[];
 	readonly direction: 'horizontal' | 'vertical';
 	readonly thickness: number;
 	readonly gap: number;
 	readonly angle: number;
 	readonly offset: number;
-}> = ({direction, thickness, gap, angle, offset}) => {
+}> = ({colors, direction, thickness, gap, angle, offset}) => {
 	const {width, height} = useVideoConfig();
 
 	return (
 		<Solid
 			width={width}
 			height={height}
-			effects={[lines({direction, thickness, gap, angle, offset})]}
+			effects={[lines({colors, direction, thickness, gap, angle, offset})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-rings-preview.tsx
+++ b/packages/docs/components/effects/effects-rings-preview.tsx
@@ -4,18 +4,19 @@ import React from 'react';
 import {Solid, useVideoConfig} from 'remotion';
 
 export const EffectsRingsPreview: React.FC<{
+	readonly colors: readonly string[];
 	readonly center: RingsCenter;
 	readonly thickness: number;
 	readonly gap: number;
 	readonly offset: number;
-}> = ({center, thickness, gap, offset}) => {
+}> = ({colors, center, thickness, gap, offset}) => {
 	const {width, height} = useVideoConfig();
 
 	return (
 		<Solid
 			width={width}
 			height={height}
-			effects={[rings({center, thickness, gap, offset})]}
+			effects={[rings({colors, center, thickness, gap, offset})]}
 		/>
 	);
 };

--- a/packages/docs/components/effects/effects-waves-preview.tsx
+++ b/packages/docs/components/effects/effects-waves-preview.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {Solid, useVideoConfig} from 'remotion';
 
 export const EffectsWavesPreview: React.FC<{
+	readonly colors: readonly string[];
 	readonly direction: WavesDirection;
 	readonly thickness: number;
 	readonly gap: number;
@@ -12,7 +13,17 @@ export const EffectsWavesPreview: React.FC<{
 	readonly amplitude: number;
 	readonly wavelength: number;
 	readonly phase: number;
-}> = ({direction, thickness, gap, angle, offset, amplitude, wavelength, phase}) => {
+}> = ({
+	colors,
+	direction,
+	thickness,
+	gap,
+	angle,
+	offset,
+	amplitude,
+	wavelength,
+	phase,
+}) => {
 	const {width, height} = useVideoConfig();
 
 	return (
@@ -21,6 +32,7 @@ export const EffectsWavesPreview: React.FC<{
 			height={height}
 			effects={[
 				waves({
+					colors,
 					direction,
 					thickness,
 					gap,

--- a/packages/docs/components/effects/effects-zigzag-preview.tsx
+++ b/packages/docs/components/effects/effects-zigzag-preview.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {Solid, useVideoConfig} from 'remotion';
 
 export const EffectsZigzagPreview: React.FC<{
+	readonly colors: readonly string[];
 	readonly direction: 'horizontal' | 'vertical';
 	readonly thickness: number;
 	readonly gap: number;
@@ -10,7 +11,16 @@ export const EffectsZigzagPreview: React.FC<{
 	readonly offset: number;
 	readonly amplitude: number;
 	readonly wavelength: number;
-}> = ({direction, thickness, gap, angle, offset, amplitude, wavelength}) => {
+}> = ({
+	colors,
+	direction,
+	thickness,
+	gap,
+	angle,
+	offset,
+	amplitude,
+	wavelength,
+}) => {
 	const {width, height} = useVideoConfig();
 
 	return (
@@ -19,6 +29,7 @@ export const EffectsZigzagPreview: React.FC<{
 			height={height}
 			effects={[
 				zigzag({
+					colors,
 					direction,
 					thickness,
 					gap,

--- a/packages/docs/src/remotion/Root.tsx
+++ b/packages/docs/src/remotion/Root.tsx
@@ -53,6 +53,8 @@ import {Article} from './Article';
 import {Expert} from './Expert';
 import {TemplateComp} from './Template';
 
+const DEFAULT_EFFECT_COLORS = ['#dff4ff', '#7cc6ff'] as const;
+
 export const RemotionRoot: React.FC = () => {
 	return (
 		<>
@@ -420,6 +422,7 @@ export const RemotionRoot: React.FC = () => {
 					width={1280}
 					height={720}
 					defaultProps={{
+						colors: DEFAULT_EFFECT_COLORS,
 						direction: 'horizontal',
 						thickness: 40,
 						gap: 0,
@@ -433,6 +436,7 @@ export const RemotionRoot: React.FC = () => {
 					width={1280}
 					height={720}
 					defaultProps={{
+						colors: DEFAULT_EFFECT_COLORS,
 						center: [0.5, 0.5],
 						thickness: 40,
 						gap: 0,
@@ -445,6 +449,7 @@ export const RemotionRoot: React.FC = () => {
 					width={1280}
 					height={720}
 					defaultProps={{
+						colors: DEFAULT_EFFECT_COLORS,
 						direction: 'horizontal',
 						thickness: 40,
 						gap: 0,
@@ -461,6 +466,7 @@ export const RemotionRoot: React.FC = () => {
 					width={1280}
 					height={720}
 					defaultProps={{
+						colors: DEFAULT_EFFECT_COLORS,
 						direction: 'horizontal',
 						thickness: 40,
 						gap: 0,

--- a/packages/effects/src/lines.ts
+++ b/packages/effects/src/lines.ts
@@ -24,6 +24,17 @@ const DEFAULT_OFFSET = 0 as const;
 const DEFAULT_MASK_TO_SOURCE_ALPHA = false as const;
 
 export const linesSchema = {
+	colors: {
+		type: 'array',
+		item: {
+			type: 'color',
+		},
+		default: DEFAULT_COLORS,
+		minLength: 2,
+		newItemDefault: '#ff0000',
+		description: 'Colors',
+		keyframable: false,
+	},
 	direction: {
 		type: 'enum',
 		variants: {

--- a/packages/effects/src/rings.ts
+++ b/packages/effects/src/rings.ts
@@ -22,6 +22,17 @@ const DEFAULT_OFFSET = 0 as const;
 const DEFAULT_MASK_TO_SOURCE_ALPHA = false as const;
 
 export const ringsSchema = {
+	colors: {
+		type: 'array',
+		item: {
+			type: 'color',
+		},
+		default: DEFAULT_COLORS,
+		minLength: 2,
+		newItemDefault: '#ff0000',
+		description: 'Colors',
+		keyframable: false,
+	},
 	center: {
 		type: 'uv-coordinate',
 		min: 0,

--- a/packages/effects/src/test/effect-params.test.ts
+++ b/packages/effects/src/test/effect-params.test.ts
@@ -39,6 +39,22 @@ import {waves} from '../waves.js';
 import {whiteNoise} from '../white-noise.js';
 import {zigzag} from '../zigzag.js';
 
+const expectDefaultBlueColorArrayControl = (schema: {
+	readonly colors?: unknown;
+}): void => {
+	expect(schema.colors).toEqual({
+		type: 'array',
+		item: {
+			type: 'color',
+		},
+		default: ['#dff4ff', '#7cc6ff'],
+		minLength: 2,
+		newItemDefault: '#ff0000',
+		description: 'Colors',
+		keyframable: false,
+	});
+};
+
 test('@remotion/effects expose documentation links', () => {
 	expect(barrelDistortion().definition.documentationLink).toBe(
 		'https://www.remotion.dev/docs/effects/barrel-distortion',
@@ -198,6 +214,13 @@ test('@remotion/effects expose API names as Studio labels', () => {
 	expect(waves().definition.label).toBe('waves()');
 	expect(zigzag().definition.label).toBe('zigzag()');
 	expect(whiteNoise().definition.label).toBe('whiteNoise()');
+});
+
+test('@remotion/effects palette effects expose colors as array controls', () => {
+	expectDefaultBlueColorArrayControl(lines().definition.schema);
+	expectDefaultBlueColorArrayControl(rings().definition.schema);
+	expectDefaultBlueColorArrayControl(waves().definition.schema);
+	expectDefaultBlueColorArrayControl(zigzag().definition.schema);
 });
 
 test('barrelDistortion() accepts default params', () => {

--- a/packages/effects/src/waves.ts
+++ b/packages/effects/src/waves.ts
@@ -27,6 +27,17 @@ const DEFAULT_PHASE = 0 as const;
 const DEFAULT_MASK_TO_SOURCE_ALPHA = false as const;
 
 export const wavesSchema = {
+	colors: {
+		type: 'array',
+		item: {
+			type: 'color',
+		},
+		default: DEFAULT_COLORS,
+		minLength: 2,
+		newItemDefault: '#ff0000',
+		description: 'Colors',
+		keyframable: false,
+	},
 	direction: {
 		type: 'enum',
 		variants: {

--- a/packages/effects/src/zigzag.ts
+++ b/packages/effects/src/zigzag.ts
@@ -26,6 +26,17 @@ const DEFAULT_WAVELENGTH = 160 as const;
 const DEFAULT_MASK_TO_SOURCE_ALPHA = false as const;
 
 export const zigzagSchema = {
+	colors: {
+		type: 'array',
+		item: {
+			type: 'color',
+		},
+		default: DEFAULT_COLORS,
+		minLength: 2,
+		newItemDefault: '#ff0000',
+		description: 'Colors',
+		keyframable: false,
+	},
 	direction: {
 		type: 'enum',
 		variants: {


### PR DESCRIPTION
## Summary
- Expose palette color arrays in the schemas for lines(), waves(), zigzag(), and rings().
- Wire the docs effect demos and preview stills so color controls affect the rendered output.
- Add regression coverage for the palette color-array schema shape.

## Testing
- bun run build
- bun run stylecheck
