### PR TITLE
`@remotion/studio`: Fix scale outline cursor flicker

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -770,7 +770,7 @@ export type SelectedOutlineScaleEdge = 'top' | 'right' | 'bottom' | 'left';
 
 type SelectedOutlineScaleEdgeInfo = {
 	readonly axis: 'x' | 'y';
-	readonly cursor: React.CSSProperties['cursor'];
+	readonly cursor: string;
 	readonly end: OutlinePoint;
 	readonly extent: number;
 	readonly normal: OutlinePoint;
@@ -1851,6 +1851,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			}
 
 			onDraggingChange(true);
+			forceSpecificCursor(edgeInfo.cursor);
 
 			const startPointer = {x: event.clientX, y: event.clientY};
 			const dragStates = getSelectedOutlineScaleDragStates({
@@ -1909,6 +1910,7 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
+				stopForcingSpecificCursor();
 				onDraggingChange(false);
 
 				const changes = getSelectedOutlineScaleDragChanges({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8320.

## Summary
- Force the Studio cursor during selected outline scale edge drags, matching rotation drags.
- Tighten scale edge cursor info to a concrete string because the forced cursor API requires one.

## Walkthrough
<a href="https://cursor.com/agents/bc-86c6d43b-1880-4b34-8908-9ca6a909ae5e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_scale_edge_cursor_stays_resize.mp4"><img src="https://cursor.com/artifacts/c/art-e0f39b39-5f54-4cb1-97aa-23dd07049329" alt="studio_scale_edge_cursor_stays_resize.mp4" /></a>

![Scale edge drag starts with resize cursor](https://cursor.com/artifacts/c/art-1b5b3d0e-1e93-47d6-ae23-df4c3456b8c6)
![Scale edge drag keeps resize cursor while moving right](https://cursor.com/artifacts/c/art-4c7dfa2d-7074-4529-910c-ea7bf6eee8de)
![Scale edge drag keeps resize cursor while moving left](https://cursor.com/artifacts/c/art-dfdc0dfe-fdcb-42ea-9095-657010cb4684)

## Testing
- `bunx oxfmt src --write` in `packages/studio`
- `bun test src/test/timeline-selection.test.ts` in `packages/studio`
- `bun run build`
- `bun run stylecheck` (blocked by known `@remotion/lambda-go` Go version limitation in this VM)
- `bunx turbo run lint formatting --filter='@remotion/studio' --no-update-notifier`
- Manual Studio test in `keyframed-props-test`: selected an outline and dragged the right scale edge while observing the resize cursor.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86c6d43b-1880-4b34-8908-9ca6a909ae5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86c6d43b-1880-4b34-8908-9ca6a909ae5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

