### PR TITLE
`@remotion/studio`: Fix SVG selection outlines

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -345,6 +345,42 @@ const rectToPoints = (
 	];
 };
 
+type SvgViewport = {
+	readonly x: number;
+	readonly y: number;
+	readonly width: number;
+	readonly height: number;
+};
+
+type SvgScreenCtm = Pick<DOMMatrixReadOnly, 'a' | 'b' | 'c' | 'd' | 'e' | 'f'>;
+
+export const getTransformedSvgViewportPoints = ({
+	viewport,
+	ctm,
+	containerRect,
+}: {
+	readonly viewport: SvgViewport;
+	readonly ctm: SvgScreenCtm;
+	readonly containerRect: Pick<DOMRect, 'left' | 'top'>;
+}): SelectedOutline['points'] => {
+	const transformPoint = (x: number, y: number): OutlinePoint => ({
+		x: ctm.a * x + ctm.c * y + ctm.e - containerRect.left,
+		y: ctm.b * x + ctm.d * y + ctm.f - containerRect.top,
+	});
+
+	const left = viewport.x;
+	const top = viewport.y;
+	const right = viewport.x + viewport.width;
+	const bottom = viewport.y + viewport.height;
+
+	return [
+		transformPoint(left, top),
+		transformPoint(right, top),
+		transformPoint(right, bottom),
+		transformPoint(left, bottom),
+	];
+};
+
 const quadToPoints = (
 	quad: DOMQuad,
 	containerRect: DOMRect,
@@ -364,6 +400,51 @@ const quadToPoints = (
 	];
 };
 
+const isSvgSvgElement = (element: Element): element is SVGSVGElement => {
+	const ownerSvgSvgElement = element.ownerDocument.defaultView?.SVGSVGElement;
+	return (
+		(typeof SVGSVGElement !== 'undefined' &&
+			element instanceof SVGSVGElement) ||
+		(ownerSvgSvgElement !== undefined && element instanceof ownerSvgSvgElement)
+	);
+};
+
+const getSvgSvgElementViewport = (element: SVGSVGElement): SvgViewport => {
+	const viewBox = element.viewBox.baseVal;
+	if (viewBox.width > 0 && viewBox.height > 0) {
+		return {
+			x: viewBox.x,
+			y: viewBox.y,
+			width: viewBox.width,
+			height: viewBox.height,
+		};
+	}
+
+	return {
+		x: 0,
+		y: 0,
+		width: element.width.baseVal.value,
+		height: element.height.baseVal.value,
+	};
+};
+
+const getSvgSvgElementOutlinePoints = (
+	element: SVGSVGElement,
+	containerRect: DOMRect,
+): SelectedOutline['points'] | null => {
+	const ctm = element.getScreenCTM();
+	const viewport = getSvgSvgElementViewport(element);
+	if (ctm === null || (viewport.width === 0 && viewport.height === 0)) {
+		return null;
+	}
+
+	return getTransformedSvgViewportPoints({
+		viewport,
+		ctm,
+		containerRect,
+	});
+};
+
 const getElementOutlinePoints = (
 	element: Element,
 	containerRect: DOMRect,
@@ -372,6 +453,10 @@ const getElementOutlinePoints = (
 
 	if (elementRect.width === 0 && elementRect.height === 0) {
 		return null;
+	}
+
+	if (isSvgSvgElement(element)) {
+		return getSvgSvgElementOutlinePoints(element, containerRect);
 	}
 
 	const quads = getBoxQuadsPonyfill(element, {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -32,6 +32,7 @@ import {
 	getSelectedOutlineScaleEdgeInfo,
 	getSelectedSequenceKeys,
 	getSequencesWithSelectableOutlines,
+	getTransformedSvgViewportPoints,
 	type SelectedOutlineDragState,
 	type SelectedOutlineRotationDragState,
 	type SelectedOutlineScaleDragState,
@@ -1390,6 +1391,21 @@ test('UV coordinate constraints still clamp to schema min and max', () => {
 			step: 0.01,
 		}),
 	).toEqual([0, 1]);
+});
+
+test('SVG viewport outline points are projected through the screen CTM', () => {
+	const points = getTransformedSvgViewportPoints({
+		viewport: {x: 0, y: 0, width: 100, height: 50},
+		ctm: {a: 0, b: 1, c: -1, d: 0, e: 75, f: -25},
+		containerRect: {left: 10, top: 20},
+	});
+
+	expect(points).toEqual([
+		{x: 65, y: -45},
+		{x: 65, y: 55},
+		{x: 15, y: 55},
+		{x: 15, y: -45},
+	]);
 });
 
 test('UV handle connection lines connect fields from schema metadata', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8304.

### Summary
- Project root SVG outline corners through `getScreenCTM()` so Studio selection boxes follow rotated SVG elements.
- Add a regression test for SVG viewport corner projection.

### Testing
- `bun test src/test/timeline-selection.test.ts` from `packages/studio`
- `bun run build`
- `bun run lint && bun run formatting` from `packages/studio`
- `bun run stylecheck` was attempted; it fails on the documented `@remotion/lambda-go` Go 1.23 requirement in this VM.
- Manual Studio validation was attempted with a temporary rotated Star example, but the VM browser cannot acquire a WebGL2 context for the Studio canvas effect path, so the Studio UI does not load in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02a074cc-c24f-45fa-b7b7-e3588a6d0172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02a074cc-c24f-45fa-b7b7-e3588a6d0172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

