### PR TITLE
`@remotion/studio`: Respect transform origin for outline rotation

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -171,6 +171,7 @@ type SelectedOutlineRotationDragTarget = {
 	readonly keyframeDisplayOffset: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: SequenceSchema;
+	readonly transformOriginValue: string;
 };
 
 export type SelectedOutlineDragState = {
@@ -326,6 +327,36 @@ export const getSelectedOutlineRotationCornerInfo = (
 		cursorDegrees,
 		point,
 	};
+};
+
+export const getSelectedOutlineRotationPivot = ({
+	dimensions,
+	points,
+	transformOriginValue,
+}: {
+	readonly dimensions: SelectedOutline['dimensions'];
+	readonly points: SelectedOutline['points'];
+	readonly transformOriginValue: string;
+}): OutlinePoint => {
+	if (dimensions === null) {
+		return getOutlineCenter(points);
+	}
+
+	const parsed = parseTransformOrigin(transformOriginValue);
+	if (parsed === null) {
+		return getOutlineCenter(points);
+	}
+
+	const uv = parsedTransformOriginToUv({
+		parsed,
+		width: dimensions.width,
+		height: dimensions.height,
+	});
+	if (uv === null) {
+		return getOutlineCenter(points);
+	}
+
+	return getUvHandlePosition(points, uv);
 };
 
 const rectToPoints = (
@@ -2204,7 +2235,14 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 			forceSpecificCursor(cornerInfo.cursor);
 
 			const svgRect = svg.getBoundingClientRect();
-			const center = svgPointToClientPoint(cornerInfo.center, svgRect);
+			const center = svgPointToClientPoint(
+				getSelectedOutlineRotationPivot({
+					dimensions: outline.dimensions,
+					points: outline.points,
+					transformOriginValue: rotationDrag.transformOriginValue,
+				}),
+				svgRect,
+			);
 			const dragStates = getSelectedOutlineRotationDragStates({
 				dragTargets: selected ? allRotationDragTargets : [rotationDrag],
 				getDragOverrides,
@@ -2347,6 +2385,8 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 			cornerInfo,
 			getDragOverrides,
 			onDraggingChange,
+			outline.dimensions,
+			outline.points,
 			onSelect,
 			rotationDrag,
 			selected,
@@ -2683,6 +2723,23 @@ export const SelectedOutlineOverlay: React.FC<{
 				controls?.schema[transformOriginFieldKey];
 			const transformOriginPropStatus =
 				nodePropStatuses?.[transformOriginFieldKey];
+			const rotationSourceFrame = timelinePosition - keyframeDisplayOffset;
+			const transformOriginValueForRotation =
+				transformOriginFieldSchema?.type === 'transform-origin' &&
+				(transformOriginPropStatus?.status === 'static' ||
+					transformOriginPropStatus?.status === 'keyframed')
+					? String(
+							Internals.getEffectiveVisualModeValue({
+								propStatus: transformOriginPropStatus,
+								dragOverrideValue: (getDragOverrides(nodePath) ?? {})[
+									transformOriginFieldKey
+								],
+								defaultValue: transformOriginFieldSchema.default,
+								frame: rotationSourceFrame,
+								shouldResortToDefaultValueIfUndefined: true,
+							}) ?? transformOriginFieldSchema.default,
+						)
+					: '50% 50%';
 			const canDragStatus =
 				propStatus?.status === 'static' ||
 				(propStatus?.status === 'keyframed' &&
@@ -2800,6 +2857,7 @@ export const SelectedOutlineOverlay: React.FC<{
 							keyframeDisplayOffset,
 							nodePath,
 							schema: controls.schema,
+							transformOriginValue: transformOriginValueForRotation,
 						}
 					: null,
 				transformOriginDrag: canTransformOriginDrag

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -27,6 +27,7 @@ import {
 	getSelectedOutlineRotationDeltaDegrees,
 	getSelectedOutlineRotationDragChanges,
 	getSelectedOutlineRotationDragValues,
+	getSelectedOutlineRotationPivot,
 	getSelectedOutlineScaleDragChanges,
 	getSelectedOutlineScaleDragValues,
 	getSelectedOutlineScaleEdgeInfo,
@@ -2155,6 +2156,7 @@ test('Selected outline corner dragging rotates selected sequences', () => {
 				keyframeDisplayOffset: 30,
 				nodePath: firstNodePath,
 				schema,
+				transformOriginValue: '50% 50%',
 			},
 		},
 		{
@@ -2170,6 +2172,7 @@ test('Selected outline corner dragging rotates selected sequences', () => {
 				keyframeDisplayOffset: 30,
 				nodePath: secondNodePath,
 				schema,
+				transformOriginValue: '50% 50%',
 			},
 		},
 	] satisfies SelectedOutlineRotationDragState[];
@@ -2237,6 +2240,7 @@ test('Selected outline corner dragging keyframed rotation adds a keyframe at the
 				keyframeDisplayOffset: 30,
 				nodePath,
 				schema,
+				transformOriginValue: '50% 50%',
 			},
 		},
 	] satisfies SelectedOutlineRotationDragState[];
@@ -2301,6 +2305,52 @@ test('Selected outline rotation corners use the outline corners and center', () 
 		'<svg width="24" height="24"',
 	);
 	expect(topRight.cursor).toContain('") 12 12, alias');
+});
+
+test('Selected outline rotation pivot follows transform origin', () => {
+	const points = [
+		{x: 0, y: 0},
+		{x: 100, y: 0},
+		{x: 100, y: 50},
+		{x: 0, y: 50},
+	] as const;
+	const dimensions = {width: 100, height: 50};
+
+	expect(
+		getSelectedOutlineRotationPivot({
+			dimensions,
+			points,
+			transformOriginValue: 'center',
+		}),
+	).toEqual({x: 50, y: 25});
+	expect(
+		getSelectedOutlineRotationPivot({
+			dimensions,
+			points,
+			transformOriginValue: 'left bottom',
+		}),
+	).toEqual({x: 0, y: 50});
+	expect(
+		getSelectedOutlineRotationPivot({
+			dimensions,
+			points,
+			transformOriginValue: '25px top',
+		}),
+	).toEqual({x: 25, y: 0});
+	expect(
+		getSelectedOutlineRotationPivot({
+			dimensions,
+			points,
+			transformOriginValue: 'calc(50% + 1px) center',
+		}),
+	).toEqual({x: 50, y: 25});
+	expect(
+		getSelectedOutlineRotationPivot({
+			dimensions: null,
+			points,
+			transformOriginValue: 'left top',
+		}),
+	).toEqual({x: 50, y: 25});
 });
 
 test('Selected outline rotation cursors use the outline rotation', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Respect `style.transformOrigin` when calculating the Studio selected-outline rotation pivot.
- Add regression coverage for transform-origin-based rotation pivots.

Fixes #8324

## Walkthrough
<a href="https://cursor.com/agents/bc-9f6c8aca-bf87-42a6-ac56-530f3275686d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_transform_origin_outline_rotation.mp4"><img src="https://cursor.com/artifacts/c/art-44242d00-1379-41e3-a968-b4c4198c4b33" alt="studio_transform_origin_outline_rotation.mp4" /></a>

## Testing
- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck` (environment-limited: `@remotion/lambda-go` requires Go >= 1.23.0, VM has Go 1.22.2; `@remotion/lambda-php` reports missing PHP/Composer and skips)
- `cd packages/studio && bun run lint && bun run formatting`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f6c8aca-bf87-42a6-ac56-530f3275686d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f6c8aca-bf87-42a6-ac56-530f3275686d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

