### PR TITLE
`@remotion/studio`: Preselect filename stem in rename dialog

### DIFF
--- a/packages/studio/src/components/NewComposition/RenameComposition.tsx
+++ b/packages/studio/src/components/NewComposition/RenameComposition.tsx
@@ -1,6 +1,13 @@
 import type {RecastCodemod} from '@remotion/studio-shared';
 import type {ChangeEventHandler} from 'react';
-import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {Internals} from 'remotion';
 import {validateCompositionName} from '../../helpers/validate-new-comp-data';
 import {Spacing} from '../layout';
@@ -43,7 +50,6 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 		const input = inputRef.current;
 		if (!input) return;
 		input.select();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const onNameChange: ChangeEventHandler<HTMLInputElement> = useCallback(

--- a/packages/studio/src/components/NewComposition/RenameComposition.tsx
+++ b/packages/studio/src/components/NewComposition/RenameComposition.tsx
@@ -1,6 +1,6 @@
 import type {RecastCodemod} from '@remotion/studio-shared';
 import type {ChangeEventHandler} from 'react';
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {Internals} from 'remotion';
 import {validateCompositionName} from '../../helpers/validate-new-comp-data';
 import {Spacing} from '../layout';
@@ -37,6 +37,14 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 	const [newId, setName] = useState(() => {
 		return resolved.result.id;
 	});
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		const input = inputRef.current;
+		if (!input) return;
+		input.select();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	const onNameChange: ChangeEventHandler<HTMLInputElement> = useCallback(
 		(e) => {
@@ -74,6 +82,7 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 						<div style={rightRow}>
 							<div>
 								<RemotionInput
+									ref={inputRef}
 									value={newId}
 									onChange={onNameChange}
 									type="text"

--- a/packages/studio/src/components/NewComposition/RenameFolder.tsx
+++ b/packages/studio/src/components/NewComposition/RenameFolder.tsx
@@ -1,6 +1,13 @@
 import type {RecastCodemod} from '@remotion/studio-shared';
 import type {ChangeEventHandler} from 'react';
-import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {Internals} from 'remotion';
 import {getFolderId} from '../../helpers/get-folder-id';
 import {validateFolderRename} from '../../helpers/validate-folder-rename';
@@ -34,7 +41,6 @@ export const RenameFolder: React.FC<{
 		const input = inputRef.current;
 		if (!input) return;
 		input.select();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const onNameChange: ChangeEventHandler<HTMLInputElement> = useCallback(

--- a/packages/studio/src/components/NewComposition/RenameFolder.tsx
+++ b/packages/studio/src/components/NewComposition/RenameFolder.tsx
@@ -1,6 +1,6 @@
 import type {RecastCodemod} from '@remotion/studio-shared';
 import type {ChangeEventHandler} from 'react';
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {Internals} from 'remotion';
 import {getFolderId} from '../../helpers/get-folder-id';
 import {validateFolderRename} from '../../helpers/validate-folder-rename';
@@ -28,6 +28,14 @@ export const RenameFolder: React.FC<{
 }> = ({folderName, parentName, stack}) => {
 	const {folders} = useContext(Internals.CompositionManager);
 	const [newName, setName] = useState(folderName);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		const input = inputRef.current;
+		if (!input) return;
+		input.select();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	const onNameChange: ChangeEventHandler<HTMLInputElement> = useCallback(
 		(e) => {
@@ -70,6 +78,7 @@ export const RenameFolder: React.FC<{
 						<div style={rightRow}>
 							<div>
 								<RemotionInput
+									ref={inputRef}
 									value={newName}
 									onChange={onNameChange}
 									type="text"

--- a/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
+++ b/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
@@ -1,5 +1,12 @@
 import type {ChangeEventHandler} from 'react';
-import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {Internals} from 'remotion';
 import {renameStaticFile} from '../../api/rename-static-file';
 import {pushUrl} from '../../helpers/url-state';

--- a/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
+++ b/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
@@ -1,5 +1,5 @@
 import type {ChangeEventHandler} from 'react';
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {Internals} from 'remotion';
 import {renameStaticFile} from '../../api/rename-static-file';
 import {pushUrl} from '../../helpers/url-state';
@@ -42,6 +42,16 @@ export const RenameStaticFileModal: React.FC<{
 	const staticFiles = useStaticFiles();
 	const [newName, setNewName] = useState(() => getBaseName(relativePath));
 	const [submitting, setSubmitting] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		const input = inputRef.current;
+		if (!input) return;
+		const dotIndex = newName.lastIndexOf('.');
+		const stemEnd = dotIndex === -1 ? newName.length : dotIndex;
+		input.setSelectionRange(0, stemEnd);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	const parent = useMemo(() => getParent(relativePath), [relativePath]);
 	const newRelativePath = useMemo(() => {
@@ -141,6 +151,7 @@ export const RenameStaticFileModal: React.FC<{
 						<div style={rightRow}>
 							<div>
 								<RemotionInput
+									ref={inputRef}
 									value={newName}
 									onChange={onNameChange}
 									type="text"


### PR DESCRIPTION
## What does this fix?

Fixes #8318

The rename dialog does not pre-select the filename correctly when it opens. The user has to manually position the cursor before editing.

## What did I change?

* RenameStaticFile: on mount, call `setSelectionRange(0, stemEnd)` where `stemEnd` is the index of the last dot (or the full length if there is no dot). This selects `my-video` and leaves `.mp4` unselected.
* RenameFolder / RenameComposition: call `input.select()` on mount since folder names and composition IDs carry no extension.

## How to verify

1. Right-click any asset in Remotion Studio → Rename.
2. The dialog opens with `my-video` highlighted (not `my-video.mp4`).
3. Start typing to replace only the stem.
4. `.mp4` is preserved unchanged.
