### PR TITLE
`@remotion/studio`: Add outline drag threshold

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -212,6 +212,7 @@ const translateFieldKey = 'style.translate';
 const scaleFieldKey = 'style.scale';
 const rotateFieldKey = 'style.rotate';
 const transformOriginFieldKey = 'style.transformOrigin';
+export const selectedOutlineDragThresholdPx = 4;
 
 const outlineContainer: React.CSSProperties = {
 	position: 'absolute',
@@ -770,6 +771,16 @@ export const applySelectedOutlineDragAxisLock = ({
 	}
 
 	return {deltaX: 0, deltaY};
+};
+
+export const isSelectedOutlineDragPastThreshold = ({
+	deltaX,
+	deltaY,
+}: {
+	readonly deltaX: number;
+	readonly deltaY: number;
+}) => {
+	return Math.hypot(deltaX, deltaY) >= selectedOutlineDragThresholdPx;
 };
 
 export type SelectedOutlineStaticDragChange = SaveSequencePropChange & {
@@ -1616,8 +1627,6 @@ const SelectedOutlinePolygon: React.FC<{
 				return;
 			}
 
-			onDraggingChange(true);
-
 			const startPointerX = event.clientX;
 			const startPointerY = event.clientY;
 			const dragStates = getSelectedOutlineDragStates({
@@ -1629,11 +1638,28 @@ const SelectedOutlinePolygon: React.FC<{
 			let currentPointerX = startPointerX;
 			let currentPointerY = startPointerY;
 			let axisLocked = false;
+			let dragStarted = false;
 
 			const updateDragOverrides = () => {
+				const screenDeltaX = currentPointerX - startPointerX;
+				const screenDeltaY = currentPointerY - startPointerY;
+				if (!dragStarted) {
+					if (
+						!isSelectedOutlineDragPastThreshold({
+							deltaX: screenDeltaX,
+							deltaY: screenDeltaY,
+						})
+					) {
+						return;
+					}
+
+					dragStarted = true;
+					onDraggingChange(true);
+				}
+
 				const dragDelta = applySelectedOutlineDragAxisLock({
-					deltaX: (currentPointerX - startPointerX) / scale,
-					deltaY: (currentPointerY - startPointerY) / scale,
+					deltaX: screenDeltaX / scale,
+					deltaY: screenDeltaY / scale,
 					axisLocked,
 				});
 
@@ -1696,7 +1722,9 @@ const SelectedOutlinePolygon: React.FC<{
 				window.removeEventListener('pointercancel', onPointerUp);
 				window.removeEventListener('keydown', onKeyChange);
 				window.removeEventListener('keyup', onKeyChange);
-				onDraggingChange(false);
+				if (dragStarted) {
+					onDraggingChange(false);
+				}
 
 				const changes = getSelectedOutlineDragChanges({
 					dragStates,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -33,6 +33,8 @@ import {
 	getSelectedSequenceKeys,
 	getSequencesWithSelectableOutlines,
 	getTransformedSvgViewportPoints,
+	isSelectedOutlineDragPastThreshold,
+	selectedOutlineDragThresholdPx,
 	type SelectedOutlineDragState,
 	type SelectedOutlineRotationDragState,
 	type SelectedOutlineScaleDragState,
@@ -1974,6 +1976,27 @@ test('Selected outline dragging can lock movement to the dominant axis', () => {
 			axisLocked: false,
 		}),
 	).toEqual({deltaX: 12, deltaY: 13});
+});
+
+test('Selected outline dragging starts after a screen pixel threshold', () => {
+	expect(
+		isSelectedOutlineDragPastThreshold({
+			deltaX: selectedOutlineDragThresholdPx - 0.1,
+			deltaY: 0,
+		}),
+	).toBe(false);
+	expect(
+		isSelectedOutlineDragPastThreshold({
+			deltaX: selectedOutlineDragThresholdPx,
+			deltaY: 0,
+		}),
+	).toBe(true);
+	expect(
+		isSelectedOutlineDragPastThreshold({
+			deltaX: 3,
+			deltaY: 3,
+		}),
+	).toBe(true);
 });
 
 test('Selected outline dragging keyframed translate adds a keyframe at the source frame', () => {


### PR DESCRIPTION
## Summary

- Add a 4px screen-space threshold before selected outline dragging starts
- Keep outline selection immediate while preventing tiny accidental translate edits
- Cover the threshold helper in timeline selection tests

## Test plan

- bun test packages/studio/src/test/timeline-selection.test.ts
- bun run build
- bun run stylecheck
