### PR TITLE
`@remotion/studio`: Add inline sequence rename

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -665,11 +665,7 @@ const HtmlInCanvasInner = forwardRef<
 			<Sequence
 				durationInFrames={resolvedDuration}
 				name={name ?? '<HtmlInCanvas>'}
-				_remotionInternalDocumentationLink={
-					name === undefined
-						? 'https://www.remotion.dev/docs/remotion/html-in-canvas'
-						: undefined
-				}
+				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/remotion/html-in-canvas"
 				_experimentalControls={controls}
 				_remotionInternalEffects={memoizedEffectDefinitions}
 				_remotionInternalRefForOutline={actualRef}

--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -338,9 +338,7 @@ const NativeImgInner: React.FC<NativeImgInnerProps> = ({
 			from={from ?? 0}
 			durationInFrames={durationInFrames ?? Infinity}
 			_remotionInternalStack={stack}
-			_remotionInternalDocumentationLink={
-				name === undefined ? 'https://www.remotion.dev/docs/img' : undefined
-			}
+			_remotionInternalDocumentationLink="https://www.remotion.dev/docs/img"
 			_remotionInternalIsMedia={{type: 'image', src}}
 			name={name ?? '<Img>'}
 			_experimentalControls={controls}
@@ -533,9 +531,7 @@ const ImgInner: React.FC<
 			name={name ?? '<Img>'}
 			showInTimeline={showInTimeline}
 			stack={stack}
-			_remotionInternalDocumentationLink={
-				name === undefined ? 'https://www.remotion.dev/docs/img' : undefined
-			}
+			_remotionInternalDocumentationLink="https://www.remotion.dev/docs/img"
 			_experimentalControls={controls}
 			_remotionInternalRefForOutline={refForOutline}
 			{...canvasProps}

--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -143,11 +143,7 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 				showInTimeline={showInTimeline ?? true}
 				_experimentalControls={_experimentalControls}
 				_remotionInternalStack={stack}
-				_remotionInternalDocumentationLink={
-					name === undefined
-						? 'https://www.remotion.dev/docs/interactive'
-						: undefined
-				}
+				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/interactive"
 				_remotionInternalRefForOutline={refForOutline}
 			>
 				{React.createElement(tag, {

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -271,8 +271,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 	}, [name]);
 
 	const resolvedDocumentationLink =
-		documentationLink ??
-		(name === undefined ? 'https://www.remotion.dev/docs/sequence' : null);
+		documentationLink ?? 'https://www.remotion.dev/docs/sequence';
 
 	const env = useRemotionEnvironment();
 

--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -188,8 +188,7 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		premountDisplay: sequenceContext?.premountDisplay ?? null,
 		postmountDisplay: sequenceContext?.postmountDisplay ?? null,
 		loopDisplay: undefined,
-		documentationLink:
-			name === undefined ? 'https://www.remotion.dev/docs/html5-audio' : null,
+		documentationLink: 'https://www.remotion.dev/docs/html5-audio',
 		refForOutline: null,
 	});
 

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -279,9 +279,7 @@ const SolidOuter = forwardRef<
 				durationInFrames={durationInFrames}
 				name={name ?? '<Solid>'}
 				_remotionInternalRefForOutline={actualRef}
-				_remotionInternalDocumentationLink={
-					name === undefined ? 'https://www.remotion.dev/docs/solid' : undefined
-				}
+				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/solid"
 				// 'stack' is in props
 				{...props}
 			>

--- a/packages/core/src/loop/index.tsx
+++ b/packages/core/src/loop/index.tsx
@@ -96,9 +96,7 @@ export const Loop: React.FC<LoopProps> & {
 				durationInFrames={durationInFrames}
 				from={from}
 				name={name ?? '<Loop>'}
-				_remotionInternalDocumentationLink={
-					name === undefined ? 'https://www.remotion.dev/docs/loop' : undefined
-				}
+				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/loop"
 				_remotionInternalLoopDisplay={loopDisplay}
 				layout={props.layout}
 				style={style}

--- a/packages/core/src/sequence-field-schema.ts
+++ b/packages/core/src/sequence-field-schema.ts
@@ -250,6 +250,19 @@ const showInTimelineField: SequenceFieldSchema = {
 	type: 'hidden',
 };
 
+export const sequenceNameField: SequenceFieldSchema = {
+	type: 'hidden',
+};
+
+export const extendSchemaWithSequenceName = <S extends SequenceSchema>(
+	schema: S,
+): S & {name: SequenceFieldSchema} => {
+	return {
+		name: sequenceNameField,
+		...schema,
+	};
+};
+
 export const durationInFramesField = {
 	type: 'number',
 	default: undefined,
@@ -265,7 +278,7 @@ export const fromField = {
 	hiddenFromList: true,
 } as const satisfies SequenceFieldSchema;
 
-export const sequenceSchema = {
+export const sequenceSchema = extendSchemaWithSequenceName({
 	hidden: hiddenField,
 	showInTimeline: showInTimelineField,
 	from: fromField,
@@ -279,14 +292,14 @@ export const sequenceSchema = {
 			none: {},
 		},
 	},
-} as const satisfies SequenceSchema;
+} as const satisfies SequenceSchema);
 
-export const sequenceSchemaWithoutFrom = {
+export const sequenceSchemaWithoutFrom = extendSchemaWithSequenceName({
 	hidden: hiddenField,
 	showInTimeline: showInTimelineField,
 	durationInFrames: durationInFramesField,
 	layout: sequenceSchema.layout,
-} as const satisfies SequenceSchema;
+} as const satisfies SequenceSchema);
 
 export const sequenceSchemaDefaultLayoutNone: SequenceSchema = {
 	...sequenceSchema,

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -186,7 +186,7 @@ test('Img registers its documentation link for default labels', () => {
 	);
 });
 
-test('Named Img components do not receive the default documentation link', () => {
+test('Named Img components keep the default documentation link', () => {
 	const registeredSequences: TSequence[] = [];
 
 	render(
@@ -199,7 +199,9 @@ test('Named Img components do not receive the default documentation link', () =>
 		</SequenceTestWrapper>,
 	);
 
-	expect(registeredSequences[0]?.documentationLink).toBe(null);
+	expect(registeredSequences[0]?.documentationLink).toBe(
+		'https://www.remotion.dev/docs/img',
+	);
 });
 
 test('AnimatedImage registers its canvas ref for the Studio outline', () => {

--- a/packages/core/src/test/use-media-in-timeline.test.tsx
+++ b/packages/core/src/test/use-media-in-timeline.test.tsx
@@ -90,3 +90,56 @@ test('useMediaInTimeline registers and unregisters new sequence', () => {
 	unmount();
 	expect(unregisterSequence).toHaveBeenCalled();
 });
+
+test('useMediaInTimeline keeps documentation links for custom display names', () => {
+	const registerSequence = mock();
+	const unregisterSequence = mock();
+	const wrapper: React.FC<{
+		children: React.ReactNode;
+	}> = ({children}) => {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const sequenceManagerContext: SequenceManagerContext = useMemo(() => {
+			return {
+				registerSequence,
+				unregisterSequence,
+				sequences: [],
+			};
+		}, []);
+
+		return (
+			<WrapSequenceContext>
+				<SequenceManager.Provider value={sequenceManagerContext}>
+					{children}
+				</SequenceManager.Provider>
+			</WrapSequenceContext>
+		);
+	};
+
+	renderHook(
+		() =>
+			useMediaInTimeline({
+				volume: 1,
+				src: 'test.mp4',
+				mediaVolume: 1,
+				mediaType: 'video',
+				playbackRate: 1,
+				displayName: 'Intro',
+				id: 'test',
+				getStack: () => null,
+				showInTimeline: true,
+				premountDisplay: null,
+				postmountDisplay: null,
+				loopDisplay: undefined,
+				documentationLink: 'https://www.remotion.dev/docs/html5-video',
+				refForOutline: null,
+			}),
+		{
+			wrapper,
+		},
+	);
+
+	expect(registerSequence.mock.calls[0]?.[0]).toMatchObject({
+		displayName: 'Intro',
+		documentationLink: 'https://www.remotion.dev/docs/html5-video',
+	});
+});

--- a/packages/core/src/test/wrap-in-schema-helpers.test.ts
+++ b/packages/core/src/test/wrap-in-schema-helpers.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
 import {getFlatSchemaWithAllKeys} from '../flatten-schema.js';
 import {
+	extendSchemaWithSequenceName,
 	sequencePremountSchema,
 	sequenceSchema,
 	sequenceSchemaWithoutFrom,
@@ -28,6 +29,7 @@ test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 	expect(Object.keys(flat).sort()).toEqual(
 		[
 			'hidden',
+			'name',
 			'showInTimeline',
 			'layout',
 			'style.translate',
@@ -43,6 +45,21 @@ test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 			'from',
 		].sort(),
 	);
+});
+
+test('extendSchemaWithSequenceName adds hidden name to wrapped schemas', () => {
+	const flat = getFlatSchemaWithAllKeys(
+		extendSchemaWithSequenceName({
+			opacity: {
+				type: 'number',
+				default: 1,
+				hiddenFromList: false,
+			},
+		}),
+	);
+
+	expect(flat.name).toEqual({type: 'hidden'});
+	expect(flat.opacity.type).toBe('number');
 });
 
 test('sequenceSchemaWithoutFrom does not expose from', () => {

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -173,12 +173,9 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		premountDisplay: parentSequence?.premountDisplay ?? null,
 		postmountDisplay: parentSequence?.postmountDisplay ?? null,
 		loopDisplay: undefined,
-		documentationLink:
-			name === undefined
-				? onlyWarnForMediaSeekingError
-					? 'https://www.remotion.dev/docs/offthreadvideo'
-					: 'https://www.remotion.dev/docs/html5-video'
-				: null,
+		documentationLink: onlyWarnForMediaSeekingError
+			? 'https://www.remotion.dev/docs/offthreadvideo'
+			: 'https://www.remotion.dev/docs/html5-video',
 		refForOutline: videoRef,
 	});
 

--- a/packages/core/src/wrap-in-schema.ts
+++ b/packages/core/src/wrap-in-schema.ts
@@ -6,7 +6,10 @@ import {
 	flattenActiveSchema,
 	getFlatSchemaWithAllKeys,
 } from './flatten-schema.js';
-import type {SequenceSchema} from './sequence-field-schema.js';
+import {
+	extendSchemaWithSequenceName,
+	type SequenceSchema,
+} from './sequence-field-schema.js';
 import {OverrideIdsToNodePathsGettersContext} from './sequence-node-path.js';
 import {
 	VisualModeDragOverridesContext,
@@ -113,7 +116,8 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>({
 	supportsEffects: boolean;
 }): React.ComponentType<Props> => {
 	// Schema is static for a component, so we move this outside
-	const flatSchema = getFlatSchemaWithAllKeys(schema);
+	const schemaWithSequenceName = extendSchemaWithSequenceName(schema);
+	const flatSchema = getFlatSchemaWithAllKeys(schemaWithSequenceName);
 	const flatKeys = Object.keys(flatSchema);
 
 	const Wrapped = forwardRef<unknown, Props>((props, ref) => {
@@ -187,7 +191,7 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>({
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const controls = useMemo((): SequenceControls => {
 			return {
-				schema,
+				schema: schemaWithSequenceName,
 				currentRuntimeValueDotNotation,
 				overrideId,
 				supportsEffects,
@@ -198,7 +202,7 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>({
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const {merged: valuesDotNotation, propsToDelete} = useMemo(() => {
 			return computeEffectiveSchemaValuesDotNotation({
-				schema,
+				schema: schemaWithSequenceName,
 				currentValue: currentRuntimeValueDotNotation,
 				overrideValues: nodePath === null ? {} : getDragOverrides(nodePath),
 				propStatus:
@@ -216,7 +220,10 @@ export const wrapInSchema = <S extends SequenceSchema, Props extends object>({
 		]);
 
 		// 4. Eliminate values forbidden by the resolved discriminated union.
-		const activeKeys = selectActiveKeys(schema, valuesDotNotation);
+		const activeKeys = selectActiveKeys(
+			schemaWithSequenceName,
+			valuesDotNotation,
+		);
 
 		// 5. Apply the active values back onto the props.
 		const mergedProps = mergeValues({

--- a/packages/studio-server/src/test/get-all-schema-keys.test.ts
+++ b/packages/studio-server/src/test/get-all-schema-keys.test.ts
@@ -11,6 +11,7 @@ test('getAllSchemaKeys returns every key across all enum variants', () => {
 	expect(keys.sort()).toEqual(
 		[
 			'hidden',
+			'name',
 			'showInTimeline',
 			'layout',
 			'style.translate',

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -11,6 +11,7 @@ import {
 	TIMELINE_ITEM_BORDER_BOTTOM,
 	TIMELINE_LIST_ITEM_ROW_HEIGHT,
 } from '../../helpers/timeline-layout';
+import {useKeybinding} from '../../helpers/use-keybinding';
 import {callApi} from '../call-api';
 import {useConfirmationDialog} from '../ConfirmationDialog';
 import {ContextMenu} from '../ContextMenu';
@@ -48,6 +49,7 @@ import {
 	isTimelineSelectionModifierEvent,
 	useTimelineRowContainsSelection,
 	useTimelineRowSelection,
+	useTimelineSelection,
 } from './TimelineSelection';
 import {TimelineSequenceName} from './TimelineSequenceName';
 import {useOpenSequenceInEditor} from './use-open-sequence-in-editor';
@@ -190,11 +192,14 @@ export const TimelineSequenceItem: React.FC<{
 	const {toggleTrack} = useContext(ExpandedTracksSetterContext);
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
+	const {isHighestContext} = useKeybinding();
 	const selectAsset = useSelectAsset();
 	const {onSelect, selectable, selected} =
 		useTimelineRowSelection(nodePathInfo);
+	const {selectedItems} = useTimelineSelection();
 	const containsSelection = useTimelineRowContainsSelection(nodePathInfo);
 	const [effectDropHovered, setEffectDropHovered] = useState(false);
+	const [isRenaming, setIsRenaming] = useState(false);
 	const [sequenceDropIndicator, setSequenceDropIndicator] =
 		useState<ReorderSequencePosition | null>(null);
 	const [sequenceDropRejection, setSequenceDropRejection] = useState<
@@ -544,6 +549,268 @@ export const TimelineSequenceItem: React.FC<{
 		[mediaSrc],
 	);
 
+	const isExpanded =
+		previewConnected && nodePathInfo !== null && getIsExpanded(nodePathInfo);
+
+	const onToggleExpand = useCallback(() => {
+		if (nodePathInfo === null) {
+			return;
+		}
+
+		toggleTrack(nodePathInfo);
+	}, [nodePathInfo, toggleTrack]);
+
+	const onShowInEditorDoubleClick = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (!canOpenInEditor) {
+				return;
+			}
+
+			if (isTimelineSelectionModifierEvent(e)) {
+				e.stopPropagation();
+				return;
+			}
+
+			e.stopPropagation();
+			openInEditor();
+		},
+		[canOpenInEditor, openInEditor],
+	);
+
+	const propStatusesForOverride = useMemo(() => {
+		return nodePath
+			? Internals.getPropStatusesCtx(propStatuses, nodePath)
+			: undefined;
+	}, [propStatuses, nodePath]);
+
+	const codeHiddenStatus = propStatusesForOverride?.hidden;
+	const codeNameStatus = propStatusesForOverride?.name;
+
+	const isItemHidden = useMemo(() => {
+		const propStatus =
+			codeHiddenStatus && codeHiddenStatus.status === 'static'
+				? codeHiddenStatus.codeValue
+				: undefined;
+		const runtimeValue =
+			sequence.controls?.currentRuntimeValueDotNotation.hidden;
+		const effective = (propStatus ?? runtimeValue) as boolean | undefined;
+		return effective ?? false;
+	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
+
+	const displayName = useMemo(() => {
+		if (
+			codeNameStatus &&
+			codeNameStatus.status === 'static' &&
+			typeof codeNameStatus.codeValue === 'string'
+		) {
+			return codeNameStatus.codeValue;
+		}
+
+		return sequence.displayName;
+	}, [codeNameStatus, sequence.displayName]);
+
+	const onToggleVisibility = useCallback(
+		(type: 'enable' | 'disable') => {
+			if (
+				!sequence.controls ||
+				!nodePath ||
+				!validatedLocation ||
+				!propStatusesForOverride ||
+				!codeHiddenStatus ||
+				codeHiddenStatus.status !== 'static' ||
+				previewServerState.type !== 'connected'
+			) {
+				return;
+			}
+
+			const newValue = type !== 'enable';
+			const {schema} = sequence.controls;
+
+			const fieldSchema = schema.hidden;
+			const defaultValue =
+				fieldSchema && fieldSchema.type === 'boolean'
+					? JSON.stringify(fieldSchema.default)
+					: null;
+
+			saveSequenceProps({
+				changes: [
+					{
+						fileName: validatedLocation.source,
+						nodePath,
+						fieldKey: 'hidden',
+						value: newValue,
+						defaultValue,
+						schema,
+					},
+				],
+				setPropStatuses,
+				clientId: previewServerState.clientId,
+				undoLabel: newValue ? 'Hide sequence' : 'Show sequence',
+				redoLabel: newValue ? 'Hide sequence again' : 'Show sequence again',
+			});
+		},
+		[
+			codeHiddenStatus,
+			propStatusesForOverride,
+			nodePath,
+			previewServerState,
+			sequence.controls,
+			setPropStatuses,
+			validatedLocation,
+		],
+	);
+
+	const outerHeight = useMemo(
+		() => getTimelineLayerHeight(sequence.type) + TIMELINE_ITEM_BORDER_BOTTOM,
+		[sequence.type],
+	);
+
+	const inner: React.CSSProperties = useMemo(() => {
+		return {
+			height: TIMELINE_LIST_ITEM_ROW_HEIGHT,
+			color: 'white',
+			fontFamily: 'Arial, Helvetica, sans-serif',
+			wordBreak: 'break-all',
+			textAlign: 'left',
+			flexShrink: 0,
+		};
+	}, []);
+
+	const rowStyle = useMemo((): React.CSSProperties => {
+		return effectDropHovered
+			? {
+					...inner,
+					...effectDropHighlight,
+				}
+			: inner;
+	}, [effectDropHovered, inner]);
+
+	const hasExpandableContent =
+		Boolean(sequence.controls) || sequence.effects.length > 0;
+
+	const canToggleVisibility =
+		previewConnected &&
+		Boolean(sequence.controls) &&
+		nodePath !== null &&
+		validatedLocation !== null &&
+		codeHiddenStatus !== undefined &&
+		codeHiddenStatus !== null &&
+		codeHiddenStatus.status === 'static';
+
+	const canRenameThisSequence =
+		previewServerState.type === 'connected' &&
+		!window.remotion_isReadOnlyStudio &&
+		Boolean(sequence.controls) &&
+		nodePath !== null &&
+		validatedLocation !== null &&
+		codeNameStatus !== undefined &&
+		codeNameStatus !== null &&
+		codeNameStatus.status === 'static';
+
+	const canRenameSelectedSequence =
+		canRenameThisSequence &&
+		selected &&
+		selectedItems.length === 1 &&
+		selectedItems[0]?.type === 'sequence';
+
+	const onCancelRenaming = useCallback(() => {
+		setIsRenaming(false);
+	}, []);
+
+	const onSaveName = useCallback(
+		async (name: string) => {
+			if (
+				!canRenameThisSequence ||
+				previewServerState.type !== 'connected' ||
+				!sequence.controls ||
+				!nodePath ||
+				!validatedLocation
+			) {
+				setIsRenaming(false);
+				return;
+			}
+
+			if (name === displayName) {
+				setIsRenaming(false);
+				return;
+			}
+
+			const savePromise = saveSequenceProps({
+				changes: [
+					{
+						fileName: validatedLocation.source,
+						nodePath,
+						fieldKey: 'name',
+						value: name,
+						defaultValue: null,
+						schema: sequence.controls.schema,
+					},
+				],
+				setPropStatuses,
+				clientId: previewServerState.clientId,
+				undoLabel: 'Rename sequence',
+				redoLabel: 'Rename sequence again',
+			});
+			setIsRenaming(false);
+			await savePromise;
+		},
+		[
+			canRenameThisSequence,
+			displayName,
+			nodePath,
+			previewServerState,
+			sequence.controls,
+			setPropStatuses,
+			validatedLocation,
+		],
+	);
+
+	React.useEffect(() => {
+		if (!canRenameSelectedSequence || !process.env.KEYBOARD_SHORTCUTS_ENABLED) {
+			setIsRenaming(false);
+			return;
+		}
+
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (!isHighestContext) {
+				return;
+			}
+
+			const commandKey = window.navigator.platform.startsWith('Mac')
+				? e.metaKey
+				: e.ctrlKey;
+
+			if (commandKey || e.key.toLowerCase() !== 'enter') {
+				return;
+			}
+
+			if (
+				document.activeElement instanceof HTMLInputElement ||
+				document.activeElement instanceof HTMLTextAreaElement
+			) {
+				return;
+			}
+
+			e.preventDefault();
+			e.stopImmediatePropagation();
+			setIsRenaming(true);
+		};
+
+		window.addEventListener('keydown', onKeyDown, true);
+
+		return () => {
+			window.removeEventListener('keydown', onKeyDown, true);
+		};
+	}, [canRenameSelectedSequence, isHighestContext]);
+
+	const onRenameSequence = useCallback(() => {
+		if (!canRenameThisSequence) {
+			return;
+		}
+
+		setIsRenaming(true);
+	}, [canRenameThisSequence]);
+
 	const contextMenuValues = useMemo((): ComboboxValue[] => {
 		if (!previewConnected) {
 			return [];
@@ -637,6 +904,20 @@ export const TimelineSequenceItem: React.FC<{
 				: null,
 			{
 				type: 'item' as const,
+				id: 'rename-sequence',
+				keyHint: 'Enter',
+				label: 'Rename...',
+				leftItem: null,
+				disabled: !canRenameThisSequence,
+				onClick: () => {
+					onRenameSequence();
+				},
+				quickSwitcherLabel: null,
+				subMenu: null,
+				value: 'rename-sequence',
+			},
+			{
+				type: 'item' as const,
 				id: 'disable-interactivity',
 				keyHint: null,
 				label: 'Disable interactivity',
@@ -688,6 +969,8 @@ export const TimelineSequenceItem: React.FC<{
 		].filter(NoReactInternals.truthy);
 	}, [
 		assetLinkInfo,
+		canOpenInEditor,
+		canRenameThisSequence,
 		deleteDisabled,
 		disableInteractivityDisabled,
 		duplicateDisabled,
@@ -695,147 +978,12 @@ export const TimelineSequenceItem: React.FC<{
 		onDeleteSequenceFromSource,
 		onDisableSequenceInteractivity,
 		onDuplicateSequenceFromSource,
-		canOpenInEditor,
+		onRenameSequence,
 		openInEditor,
 		previewConnected,
 		selectAsset,
 		sequence,
 	]);
-
-	const isExpanded =
-		previewConnected && nodePathInfo !== null && getIsExpanded(nodePathInfo);
-
-	const onToggleExpand = useCallback(() => {
-		if (nodePathInfo === null) {
-			return;
-		}
-
-		toggleTrack(nodePathInfo);
-	}, [nodePathInfo, toggleTrack]);
-
-	const onShowInEditorDoubleClick = useCallback(
-		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!canOpenInEditor) {
-				return;
-			}
-
-			if (isTimelineSelectionModifierEvent(e)) {
-				e.stopPropagation();
-				return;
-			}
-
-			e.stopPropagation();
-			openInEditor();
-		},
-		[canOpenInEditor, openInEditor],
-	);
-
-	const propStatusesForOverride = useMemo(() => {
-		return nodePath
-			? Internals.getPropStatusesCtx(propStatuses, nodePath)
-			: undefined;
-	}, [propStatuses, nodePath]);
-
-	const codeHiddenStatus = propStatusesForOverride?.hidden;
-
-	const isItemHidden = useMemo(() => {
-		const propStatus =
-			codeHiddenStatus && codeHiddenStatus.status === 'static'
-				? codeHiddenStatus.codeValue
-				: undefined;
-		const runtimeValue =
-			sequence.controls?.currentRuntimeValueDotNotation.hidden;
-		const effective = (propStatus ?? runtimeValue) as boolean | undefined;
-		return effective ?? false;
-	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
-
-	const onToggleVisibility = useCallback(
-		(type: 'enable' | 'disable') => {
-			if (
-				!sequence.controls ||
-				!nodePath ||
-				!validatedLocation ||
-				!propStatusesForOverride ||
-				!codeHiddenStatus ||
-				codeHiddenStatus.status !== 'static' ||
-				previewServerState.type !== 'connected'
-			) {
-				return;
-			}
-
-			const newValue = type !== 'enable';
-			const {schema} = sequence.controls;
-
-			const fieldSchema = schema.hidden;
-			const defaultValue =
-				fieldSchema && fieldSchema.type === 'boolean'
-					? JSON.stringify(fieldSchema.default)
-					: null;
-
-			saveSequenceProps({
-				changes: [
-					{
-						fileName: validatedLocation.source,
-						nodePath,
-						fieldKey: 'hidden',
-						value: newValue,
-						defaultValue,
-						schema,
-					},
-				],
-				setPropStatuses,
-				clientId: previewServerState.clientId,
-				undoLabel: newValue ? 'Hide sequence' : 'Show sequence',
-				redoLabel: newValue ? 'Hide sequence again' : 'Show sequence again',
-			});
-		},
-		[
-			codeHiddenStatus,
-			propStatusesForOverride,
-			nodePath,
-			previewServerState,
-			sequence.controls,
-			setPropStatuses,
-			validatedLocation,
-		],
-	);
-
-	const outerHeight = useMemo(
-		() => getTimelineLayerHeight(sequence.type) + TIMELINE_ITEM_BORDER_BOTTOM,
-		[sequence.type],
-	);
-
-	const inner: React.CSSProperties = useMemo(() => {
-		return {
-			height: TIMELINE_LIST_ITEM_ROW_HEIGHT,
-			color: 'white',
-			fontFamily: 'Arial, Helvetica, sans-serif',
-			wordBreak: 'break-all',
-			textAlign: 'left',
-			flexShrink: 0,
-		};
-	}, []);
-
-	const rowStyle = useMemo((): React.CSSProperties => {
-		return effectDropHovered
-			? {
-					...inner,
-					...effectDropHighlight,
-				}
-			: inner;
-	}, [effectDropHovered, inner]);
-
-	const hasExpandableContent =
-		Boolean(sequence.controls) || sequence.effects.length > 0;
-
-	const canToggleVisibility =
-		previewConnected &&
-		Boolean(sequence.controls) &&
-		nodePath !== null &&
-		validatedLocation !== null &&
-		codeHiddenStatus !== undefined &&
-		codeHiddenStatus !== null &&
-		codeHiddenStatus.status === 'static';
 
 	const canDropEffect =
 		previewServerState.type === 'connected' &&
@@ -961,9 +1109,12 @@ export const TimelineSequenceItem: React.FC<{
 		>
 			<div style={labelContainerStyle}>
 				<TimelineSequenceName
-					sequence={sequence}
+					displayName={displayName}
 					selected={selected}
 					containsSelection={containsSelection}
+					editing={isRenaming}
+					onCancelEditing={onCancelRenaming}
+					onSaveName={onSaveName}
 				/>
 				{mediaSrc ? (
 					<>

--- a/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
@@ -1,5 +1,4 @@
-import React, {useMemo} from 'react';
-import type {TSequence} from 'remotion';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {
 	getTimelineColor,
 	getTimelineSelectedLabelStyle,
@@ -7,6 +6,8 @@ import {
 } from './TimelineSelection';
 
 const MAX_DISPLAY_NAME_LENGTH = 1000;
+const MAX_RENAME_INPUT_WIDTH = 240;
+const RENAME_INPUT_CLASS_NAME = 'remotion-timeline-sequence-name-input';
 
 const getTruncatedDisplayName = (displayName: string): string => {
 	if (displayName.length > MAX_DISPLAY_NAME_LENGTH) {
@@ -17,10 +18,23 @@ const getTruncatedDisplayName = (displayName: string): string => {
 };
 
 export const TimelineSequenceName: React.FC<{
-	readonly sequence: TSequence;
+	readonly displayName: string;
 	readonly selected: boolean;
 	readonly containsSelection: boolean;
-}> = ({sequence, selected, containsSelection}) => {
+	readonly editing: boolean;
+	readonly onCancelEditing: () => void;
+	readonly onSaveName: (name: string) => Promise<void>;
+}> = ({
+	displayName,
+	selected,
+	containsSelection,
+	editing,
+	onCancelEditing,
+	onSaveName,
+}) => {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [draftName, setDraftName] = useState(displayName);
+	const cancelNextBlurRef = useRef(false);
 	const style = useMemo((): React.CSSProperties => {
 		return {
 			alignItems: 'center',
@@ -41,7 +55,94 @@ export const TimelineSequenceName: React.FC<{
 		};
 	}, [selected, containsSelection]);
 
-	const text = getTruncatedDisplayName(sequence.displayName) || '<Sequence>';
+	const inputStyle = useMemo((): React.CSSProperties => {
+		return {
+			...style,
+			background: 'transparent',
+			border: 0,
+			color: getTimelineColor(false, false),
+			fontFamily: 'inherit',
+			fontSize: 12,
+			outline: 'none',
+			paddingBottom: 0,
+			paddingTop: 0,
+			boxSizing: 'border-box',
+			maxWidth: MAX_RENAME_INPUT_WIDTH,
+			minWidth: 0,
+			userSelect: 'text',
+			WebkitUserSelect: 'text',
+		};
+	}, [style]);
+
+	const text = getTruncatedDisplayName(displayName) || '<Sequence>';
+
+	useEffect(() => {
+		if (!editing) {
+			setDraftName(displayName);
+			return;
+		}
+
+		const input = inputRef.current;
+		if (!input) {
+			return;
+		}
+
+		input.focus();
+		const basenameIndex = displayName.lastIndexOf('.');
+		const selectionEnd = basenameIndex > 0 ? basenameIndex : displayName.length;
+		input.setSelectionRange(0, selectionEnd);
+	}, [displayName, editing]);
+
+	const save = useCallback(() => {
+		onSaveName(draftName).catch(() => undefined);
+	}, [draftName, onSaveName]);
+
+	const onKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLInputElement>) => {
+			if (e.key === 'Escape') {
+				cancelNextBlurRef.current = true;
+				e.preventDefault();
+				onCancelEditing();
+				return;
+			}
+
+			if (e.key === 'Enter') {
+				cancelNextBlurRef.current = true;
+				e.preventDefault();
+				save();
+			}
+		},
+		[onCancelEditing, save],
+	);
+
+	const onBlur = useCallback(() => {
+		if (cancelNextBlurRef.current) {
+			cancelNextBlurRef.current = false;
+			return;
+		}
+
+		save();
+	}, [save]);
+
+	if (editing) {
+		return (
+			<>
+				<style>
+					{`.${RENAME_INPUT_CLASS_NAME}::selection { background: rgba(255, 255, 255, 0.72); color: black; }`}
+				</style>
+				<input
+					ref={inputRef}
+					className={RENAME_INPUT_CLASS_NAME}
+					value={draftName}
+					onChange={(e) => setDraftName(e.target.value)}
+					onBlur={onBlur}
+					onKeyDown={onKeyDown}
+					size={Math.max(1, draftName.length)}
+					style={inputStyle}
+				/>
+			</>
+		);
+	}
 
 	return (
 		<div title={text} style={style}>


### PR DESCRIPTION
Fixes #8342.

## Summary

- Add `name` as a hidden sequence schema field so Studio can save it through the existing sequence prop API.
- Add inline timeline sequence rename on Enter for a single selected editable sequence.
- Save on blur or Enter, and cancel without saving on Escape.

## Testing

- `bun test packages/core/src/test/wrap-in-schema-helpers.test.ts`
- `bunx turbo run make --filter='remotion' --filter='@remotion/studio'`
- `bun run stylecheck`
- `bun run build`
