### PR TITLE
fix: use schema defaults for undefined values in wrapInSchema (#8338)

### DIFF
--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -235,7 +235,11 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 		}
 
 		if (value === undefined) {
-			propsToDelete.add(key);
+			if (field?.default !== undefined) {
+				value = field.default;
+			} else {
+				propsToDelete.add(key);
+			}
 		}
 
 		merged[key] = value;

--- a/packages/shapes/src/test/make-star.test.ts
+++ b/packages/shapes/src/test/make-star.test.ts
@@ -18,3 +18,33 @@ test('Should be able to make a star path', () => {
 		starPath.path.startsWith('M 190.21130325903073 0 L 278.3790911029017 78.'),
 	).toBeTruthy();
 });
+
+test('Should throw a clear error if points is undefined', () => {
+	expect(() =>
+		makeStar({
+			points: undefined as unknown as number,
+			innerRadius: 174,
+			outerRadius: 207,
+		}),
+	).toThrow('must be a positive finite number');
+});
+
+test('Should throw a clear error if points is NaN', () => {
+	expect(() =>
+		makeStar({
+			points: NaN,
+			innerRadius: 174,
+			outerRadius: 207,
+		}),
+	).toThrow('must be a positive finite number');
+});
+
+test('Should throw a clear error if outerRadius is undefined', () => {
+	expect(() =>
+		makeStar({
+			points: 20,
+			innerRadius: 174,
+			outerRadius: undefined as unknown as number,
+		}),
+	).toThrow('must be a positive finite number');
+});

--- a/packages/shapes/src/utils/make-star.ts
+++ b/packages/shapes/src/utils/make-star.ts
@@ -75,6 +75,18 @@ export const makeStar = ({
 	cornerRadius = 0,
 	edgeRoundness = null,
 }: MakeStarProps): ShapeInfo => {
+	if (!Number.isFinite(points) || points < 1) {
+		throw new TypeError(
+			`[@remotion/shapes] <Star> "points" must be a positive finite number, got ${points}.`,
+		);
+	}
+
+	if (!Number.isFinite(outerRadius) || outerRadius <= 0) {
+		throw new TypeError(
+			`[@remotion/shapes] <Star> "outerRadius" must be a positive finite number, got ${outerRadius}.`,
+		);
+	}
+
 	const width = outerRadius * 2;
 	const height = outerRadius * 2;
 


### PR DESCRIPTION
## Fix: Prevent `RangeError` when shapes are wrapped in `<Interactive.Div>`

Fixes #8338

### Root Cause

When a shape component (e.g. `<Star>`) is wrapped inside `<Interactive.Div>` in the Studio, the prop status system may not yet have resolved values for the shape's schema fields. In `computeEffectiveSchemaValuesDotNotation`, when a value resolves to `undefined`, it was unconditionally added to `propsToDelete`. This caused the prop to be removed from the merged props passed to the component, resulting in `points` being `undefined` inside `makeStar`, which crashed with:

```
RangeError: Invalid array length
    at star (make-star.js:16:7)
    at makeStar (make-star.js:39:29)
    at StarInner (star.js:31:2)
```

### Changes

**`packages/core/src/use-schema.ts`** — When a schema value resolves to `undefined`, fall back to the field's schema default (e.g. `points` → `5`) instead of deleting it. Only add to `propsToDelete` if no default exists.

**`packages/shapes/src/utils/make-star.ts`** — Add defensive validation for `points` and `outerRadius` to throw clear `TypeError` messages instead of cryptic `RangeError: Invalid array length`.

**`packages/shapes/src/test/make-star.test.ts`** — Add tests for `undefined` and `NaN` inputs to `makeStar`.

### Testing

All 45 existing shapes tests pass, plus 3 new tests for invalid input validation.

```
packages/shapes: 45 pass, 0 fail
packages/core:  10 pass, 0 fail
```