### PR TITLE
`@remotion/studio-server`: Use element schema for sequence prop saves

### DIFF
--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -7,9 +7,9 @@ import type {
 	SaveSequencePropsResult,
 } from '@remotion/studio-shared';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
-import {NoReactInternals} from 'remotion/no-react';
 import {
 	type RemovedProp,
+	type SequencePropsNodeUpdate,
 	updateMultipleSequenceProps,
 } from '../../codemods/update-sequence-props/update-sequence-props';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
@@ -54,6 +54,25 @@ type SequencePropEditResult = {
 	logLine: number;
 	removedProps: RemovedProp[];
 	formatted: boolean;
+};
+
+export const convertSequencePropEditToCodemodChange = (
+	edit: Pick<
+		ResolvedSequencePropEdit,
+		'nodePath' | 'key' | 'value' | 'defaultValue' | 'schema'
+	>,
+): SequencePropsNodeUpdate => {
+	return {
+		nodePath: edit.nodePath.nodePath,
+		updates: [
+			{
+				key: edit.key,
+				value: edit.value,
+				defaultValue: edit.defaultValue,
+			},
+		],
+		schema: edit.schema,
+	};
 };
 
 export const shouldSuppressHmrForSequencePropEdits = (
@@ -126,19 +145,7 @@ export const saveSequencePropsHandler: ApiHandler<
 				results: updateResults,
 			} = await updateMultipleSequenceProps({
 				input: fileContents,
-				changes: group.edits.map((edit) => {
-					return {
-						nodePath: edit.nodePath.nodePath,
-						updates: [
-							{
-								key: edit.key,
-								value: edit.value,
-								defaultValue: edit.defaultValue,
-							},
-						],
-						schema: NoReactInternals.sequenceSchema,
-					};
-				}),
+				changes: group.edits.map(convertSequencePropEditToCodemodChange),
 				prettierConfigOverride: null,
 			});
 

--- a/packages/studio-server/src/test/save-sequence-props.test.ts
+++ b/packages/studio-server/src/test/save-sequence-props.test.ts
@@ -1,5 +1,18 @@
 import {expect, test} from 'bun:test';
-import {shouldSuppressHmrForSequencePropEdits} from '../preview-server/routes/save-sequence-props';
+import type {SequenceSchema} from 'remotion';
+import {
+	convertSequencePropEditToCodemodChange,
+	shouldSuppressHmrForSequencePropEdits,
+} from '../preview-server/routes/save-sequence-props';
+
+const starSchema = {
+	points: {
+		type: 'number',
+		default: 5,
+		description: 'Points',
+		hiddenFromList: false,
+	},
+} satisfies SequenceSchema;
 
 test('saveSequenceProps suppresses HMR for regular visual prop edits', () => {
 	expect(
@@ -17,4 +30,31 @@ test('saveSequenceProps does not suppress HMR for showInTimeline edits', () => {
 			{key: 'showInTimeline'},
 		]),
 	).toBe(false);
+});
+
+test('saveSequenceProps forwards element schemas to the codemod', () => {
+	const change = convertSequencePropEditToCodemodChange({
+		nodePath: {
+			absolutePath: '/tmp/Composition.tsx',
+			nodePath: ['program', 'body', 0],
+			sequenceKeys: [],
+			effectKeys: [],
+		},
+		key: 'points',
+		value: 7,
+		defaultValue: 5,
+		schema: starSchema,
+	});
+
+	expect(change).toEqual({
+		nodePath: ['program', 'body', 0],
+		updates: [
+			{
+				key: 'points',
+				value: 7,
+				defaultValue: 5,
+			},
+		],
+		schema: starSchema,
+	});
 });


### PR DESCRIPTION
## Summary

- Use each visual edit's element schema when saving sequence props
- Add regression coverage for preserving a shape-specific `points` schema through the save route mapping

Fixes #8344.

## Testing

- `bun run build`
- `bun test src/test/save-sequence-props.test.ts`
- `bun run formatting` in `packages/studio-server`
- `bun run make` in `packages/studio-server`
- `bun run test` in `packages/studio-server` (fails on unrelated existing log-format expectations and the networked latest-version test)
- `bun run stylecheck`
