### PR TITLE
Docs: Improve docs build memory usage

### DIFF
--- a/packages/docs/build-docs.ts
+++ b/packages/docs/build-docs.ts
@@ -1,0 +1,67 @@
+import {spawn} from 'child_process';
+
+const isVercel = process.env.VERCEL === '1' || process.env.VERCEL === 'true';
+const lowMemoryBuild =
+	isVercel || process.env.REMOTION_DOCS_LOW_MEMORY_BUILD === '1';
+
+const appendNodeOption = (value: string) => {
+	const current = process.env.NODE_OPTIONS ?? '';
+	if (current.includes('--max-old-space-size=')) {
+		return current;
+	}
+
+	return [current, value].filter(Boolean).join(' ');
+};
+
+const run = (
+	command: string,
+	args: string[],
+	env: Record<string, string | undefined> = {},
+) =>
+	new Promise<void>((resolve, reject) => {
+		const child = spawn(command, args, {
+			env: {...process.env, ...env},
+			shell: false,
+			stdio: 'inherit',
+		});
+
+		child.on('close', (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(new Error(`${command} ${args.join(' ')} exited with ${code}`));
+			}
+		});
+
+		child.on('error', reject);
+	});
+
+const docusaurusEnv = {
+	DOCUSAURUS_IGNORE_SSG_WARNINGS: 'true',
+	NODE_OPTIONS: appendNodeOption('--max-old-space-size=4096'),
+	...(lowMemoryBuild
+		? {
+				DOCUSAURUS_SSG_WORKER_THREAD_COUNT:
+					process.env.DOCUSAURUS_SSG_WORKER_THREAD_COUNT ?? '2',
+				DOCUSAURUS_SSG_WORKER_THREAD_TASK_SIZE:
+					process.env.DOCUSAURUS_SSG_WORKER_THREAD_TASK_SIZE ?? '5',
+				DOCUSAURUS_SSR_CONCURRENCY:
+					process.env.DOCUSAURUS_SSR_CONCURRENCY ?? '8',
+			}
+		: null),
+};
+
+const twoslashEnv = lowMemoryBuild
+	? {
+			TWOSLASH_WORKER_COUNT: process.env.TWOSLASH_WORKER_COUNT ?? '2',
+			TWOSLASH_RECYCLE_LIMIT_BYTES:
+				process.env.TWOSLASH_RECYCLE_LIMIT_BYTES ?? String(1024 * 1024 * 1024),
+		}
+	: {};
+
+await run('bun', ['copy-raw-docs.ts']);
+await run('bun', ['fetch-prompt-submissions.ts']);
+await run('bun', ['prewarm-twoslash.ts'], twoslashEnv);
+await run('docusaurus', ['build'], docusaurusEnv);
+await run('bun', ['copy-convert.ts']);
+await run('bun', ['count-pages.ts']);

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,7 +10,7 @@
 		"format": "oxfmt src",
 		"docusaurus": "docusaurus",
 		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && docusaurus start --host 0.0.0.0",
-		"build-docs": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun prewarm-twoslash.ts && NODE_OPTIONS=\"--max-old-space-size=2048\" DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus build && bun copy-convert.ts && bun count-pages.ts",
+		"build-docs": "bun build-docs.ts",
 		"swizzle": "docusaurus swizzle",
 		"deploy": "docusaurus deploy",
 		"serve": "docusaurus serve",

--- a/packages/docs/prewarm-twoslash.ts
+++ b/packages/docs/prewarm-twoslash.ts
@@ -1,4 +1,3 @@
-import {Glob} from 'bun';
 import type {ChildProcessWithoutNullStreams} from 'child_process';
 import {spawn} from 'child_process';
 import {createHash} from 'crypto';
@@ -7,6 +6,7 @@ import {createRequire} from 'module';
 import {availableParallelism, cpus, totalmem} from 'os';
 import {join, resolve} from 'path';
 import {createInterface} from 'readline';
+import {Glob} from 'bun';
 
 const DOCS_ROOT = resolve(import.meta.dirname);
 const CACHE_ROOT = join(DOCS_ROOT, 'node_modules', '.cache', 'twoslash');
@@ -24,15 +24,27 @@ const cpuCap = process.env.VERCEL
 // Cap the worker count so the combined RSS leaves room for the OS and
 // other processes on low-memory machines.
 const memCap = Math.max(1, Math.floor((totalmem() - 4 * GIB) / (1.25 * GIB)));
-const NUM_WORKERS = Math.min(cpuCap, memCap);
+const workerCountOverride = process.env.TWOSLASH_WORKER_COUNT
+	? parseInt(process.env.TWOSLASH_WORKER_COUNT, 10)
+	: null;
+const NUM_WORKERS =
+	workerCountOverride && Number.isFinite(workerCountOverride)
+		? Math.max(1, workerCountOverride)
+		: Math.min(cpuCap, memCap);
 
 // Per-worker RSS threshold after which a worker is replaced with a fresh
 // process. Derived from a global budget of half the machine's memory so the
 // combined RSS of all workers stays bounded even on long runs.
 const MEM_BUDGET = Math.max(2 * GIB, totalmem() / 2);
-const RECYCLE_LIMIT_BYTES = Math.round(
-	Math.min(1.5 * GIB, Math.max(0.75 * GIB, MEM_BUDGET / NUM_WORKERS)),
-);
+const recycleLimitOverride = process.env.TWOSLASH_RECYCLE_LIMIT_BYTES
+	? parseInt(process.env.TWOSLASH_RECYCLE_LIMIT_BYTES, 10)
+	: null;
+const RECYCLE_LIMIT_BYTES =
+	recycleLimitOverride && Number.isFinite(recycleLimitOverride)
+		? recycleLimitOverride
+		: Math.round(
+				Math.min(1.5 * GIB, Math.max(0.75 * GIB, MEM_BUDGET / NUM_WORKERS)),
+			);
 
 // Blocks per work unit handed to a worker at a time. Small enough for
 // fine-grained work stealing, large enough to amortize dispatch overhead.


### PR DESCRIPTION
## Summary

- route docs builds through a small build script
- use lower-memory twoslash and Docusaurus SSG defaults on Vercel
- allow twoslash worker count and recycle threshold overrides

## Testing

- bunx oxfmt src --write
- bun run build
- bun run stylecheck
- REMOTION_DOCS_LOW_MEMORY_BUILD=1 bun run build-docs
- bun run build-docs
