### PR TITLE
`@remotion/media`: Fix premounted audio scheduling

### DIFF
--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -144,6 +144,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 	const cumulatedFrom = parentSequence
 		? parentSequence.cumulatedFrom + parentSequence.relativeFrom
 		: 0;
+	const absoluteFrom = (parentSequence?.absoluteFrom ?? 0) + from;
 	const nonce = useNonce();
 
 	if (layout !== 'absolute-fill' && layout !== 'none') {
@@ -238,6 +239,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	const contextValue = useMemo((): SequenceContextType => {
 		return {
+			absoluteFrom,
 			cumulatedFrom,
 			relativeFrom: from,
 			cumulatedNegativeFrom,
@@ -253,6 +255,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		};
 	}, [
 		cumulatedFrom,
+		absoluteFrom,
 		from,
 		actualDurationInFrames,
 		parentSequence,

--- a/packages/core/src/SequenceContext.tsx
+++ b/packages/core/src/SequenceContext.tsx
@@ -3,6 +3,7 @@ import {createContext} from 'react';
 export const SequenceContext = createContext<SequenceContextType | null>(null);
 
 export type SequenceContextType = {
+	absoluteFrom: number;
 	cumulatedFrom: number;
 	cumulatedNegativeFrom: number;
 	relativeFrom: number;

--- a/packages/core/src/test/series.test.tsx
+++ b/packages/core/src/test/series.test.tsx
@@ -4,6 +4,7 @@ import {renderToString} from 'react-dom/server';
 import {AbsoluteFill} from '../AbsoluteFill.js';
 import {CanUseRemotionHooksProvider} from '../CanUseRemotionHooks.js';
 import {Internals} from '../internals.js';
+import {Sequence} from '../Sequence.js';
 import {Series} from '../series/index.js';
 import type {TimelineContextValue} from '../TimelineContext.js';
 import {AbsoluteTimeContext, TimelineContext} from '../TimelineContext.js';
@@ -31,6 +32,17 @@ const Third = () => {
 const Fourth = () => {
 	const frame = useCurrentFrame();
 	return <div>{'fourth ' + frame}</div>;
+};
+
+const AbsoluteFromPrinter = () => {
+	const frame = useCurrentFrame();
+	const sequenceContext = React.useContext(Internals.SequenceContext);
+
+	return (
+		<div>
+			frame {frame} absoluteFrom {sequenceContext?.absoluteFrom}
+		</div>
+	);
 };
 
 const renderForFrame = (frame: number, markup: React.ReactNode) => {
@@ -456,4 +468,33 @@ test('should be the same with or without premountFor', () => {
 		</WrapSequenceContext>,
 	);
 	expect(outerHTML).toContain('this must be printed');
+});
+
+test('preserves the real sequence start while premounting', () => {
+	const outerHTML = renderForFrame(
+		76,
+		<WrapSequenceContext>
+			<Internals.RemotionEnvironmentContext
+				value={{
+					isRendering: false,
+					isClientSideRendering: false,
+					isPlayer: true,
+					isStudio: true,
+					isReadOnlyStudio: false,
+				}}
+			>
+				<Sequence from={76}>
+					<Series>
+						<Series.Sequence durationInFrames={30} />
+						<Series.Sequence durationInFrames={146} premountFor={30}>
+							<AbsoluteFromPrinter />
+						</Series.Sequence>
+					</Series>
+				</Sequence>
+			</Internals.RemotionEnvironmentContext>
+		</WrapSequenceContext>,
+	);
+	expect(outerHTML).toContain(
+		'frame <!-- -->0<!-- --> absoluteFrom <!-- -->106',
+	);
 });

--- a/packages/core/src/test/use-media-in-timeline.test.tsx
+++ b/packages/core/src/test/use-media-in-timeline.test.tsx
@@ -37,7 +37,7 @@ beforeAll(() => {
 	}));
 });
 afterAll(() => {
-	spyOn(useVideoConfigModule, 'useVideoConfig').mockClear();
+	mock.restore();
 });
 
 test('useMediaInTimeline registers and unregisters new sequence', () => {

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -122,9 +122,9 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 	const isPremounting = Boolean(parentSequence?.premounting);
 	const isPostmounting = Boolean(parentSequence?.postmounting);
 	const sequenceOffset =
-		((parentSequence?.cumulatedFrom ?? 0) +
-			(parentSequence?.relativeFrom ?? 0)) /
-		videoConfig.fps;
+		(parentSequence?.absoluteFrom ??
+			(parentSequence?.cumulatedFrom ?? 0) +
+				(parentSequence?.relativeFrom ?? 0)) / videoConfig.fps;
 
 	const bufferingContext = useContext(Internals.BufferingContextReact);
 

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -121,10 +121,7 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 	const parentSequence = useContext(SequenceContext);
 	const isPremounting = Boolean(parentSequence?.premounting);
 	const isPostmounting = Boolean(parentSequence?.postmounting);
-	const sequenceOffset =
-		(parentSequence?.absoluteFrom ??
-			(parentSequence?.cumulatedFrom ?? 0) +
-				(parentSequence?.relativeFrom ?? 0)) / videoConfig.fps;
+	const sequenceOffset = (parentSequence?.absoluteFrom ?? 0) / videoConfig.fps;
 
 	const bufferingContext = useContext(Internals.BufferingContextReact);
 

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -176,9 +176,9 @@ const VideoForPreviewAssertedShowing: React.FC<
 	const isPremounting = Boolean(parentSequence?.premounting);
 	const isPostmounting = Boolean(parentSequence?.postmounting);
 	const sequenceOffset =
-		((parentSequence?.cumulatedFrom ?? 0) +
-			(parentSequence?.relativeFrom ?? 0)) /
-		videoConfig.fps;
+		(parentSequence?.absoluteFrom ??
+			(parentSequence?.cumulatedFrom ?? 0) +
+				(parentSequence?.relativeFrom ?? 0)) / videoConfig.fps;
 
 	const currentTime = frame / videoConfig.fps;
 

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -175,10 +175,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 	const parentSequence = useContext(SequenceContext);
 	const isPremounting = Boolean(parentSequence?.premounting);
 	const isPostmounting = Boolean(parentSequence?.postmounting);
-	const sequenceOffset =
-		(parentSequence?.absoluteFrom ??
-			(parentSequence?.cumulatedFrom ?? 0) +
-				(parentSequence?.relativeFrom ?? 0)) / videoConfig.fps;
+	const sequenceOffset = (parentSequence?.absoluteFrom ?? 0) / videoConfig.fps;
 
 	const currentTime = frame / videoConfig.fps;
 


### PR DESCRIPTION
## Summary

- Preserve the real absolute sequence start in `SequenceContext`, even while premounting freezes the visual frame.
- Use that absolute start for `@remotion/media` preview audio/video scheduling offsets.
- Add a regression test covering a premounted nested `Series.Sequence`.

## Testing

- `bun test packages/core/src/test/series.test.tsx`
- `bun run test` in `packages/media`
- `bun run make` in `packages/core`
- `bun run make` in `packages/media`
- `bun tsc` in `packages/example`
- `bun run build`
- `bun run stylecheck`
