### PR TITLE
`@remotion/studio`: Show autosave notice for Cmd+S

### DIFF
--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -44,6 +44,17 @@ export const GlobalKeybindings: React.FC = () => {
 			commandCtrlKey: true,
 			preventDefault: true,
 		});
+		const cmdSKey = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 's',
+			callback: () => {
+				showNotification('Remotion saves automatically', 2000);
+			},
+			triggerIfInputFieldFocused: true,
+			keepRegisteredWhenNotHighestContext: false,
+			commandCtrlKey: true,
+			preventDefault: true,
+		});
 		const cmdIKey = process.env.ASK_AI_ENABLED
 			? keybindings.registerKeybinding({
 					event: 'keydown',
@@ -110,6 +121,7 @@ export const GlobalKeybindings: React.FC = () => {
 			cKey.unregister();
 			questionMark.unregister();
 			cmdKKey.unregister();
+			cmdSKey.unregister();
 			cmdIKey?.unregister();
 			pageDown.unregister();
 			pageUp.unregister();

--- a/packages/studio/src/components/Notifications/Notification.tsx
+++ b/packages/studio/src/components/Notifications/Notification.tsx
@@ -1,13 +1,14 @@
 import React, {useEffect} from 'react';
+import {TEXT_COLOR} from '../../helpers/colors';
 
 const notification: React.CSSProperties = {
 	backgroundColor: '#111111',
-	color: 'white',
+	color: TEXT_COLOR,
 	fontFamily: 'Arial, Helvetica, sans-serif',
 	display: 'inline-flex',
-	padding: '8px 14px',
-	borderRadius: 4,
-	fontSize: 15,
+	padding: '6px 14px',
+	borderRadius: 6,
+	fontSize: 13,
 	border: '0.25px solid rgba(255, 255, 255, 0.1)',
 	boxShadow: '0 2px 3px rgba(0, 0, 0, 1)',
 	marginTop: 3,

--- a/packages/studio/src/components/Notifications/NotificationCenter.tsx
+++ b/packages/studio/src/components/Notifications/NotificationCenter.tsx
@@ -13,7 +13,7 @@ const container: React.CSSProperties = {
 	display: 'flex',
 	width: '100%',
 	flexDirection: 'column',
-	paddingTop: 20,
+	paddingTop: 40,
 	pointerEvents: 'none',
 	backgroundColor: 'transparent',
 };


### PR DESCRIPTION
Fixes #8341.

## Summary
- Add a global Cmd/Ctrl+S keybinding in Studio.
- Prevent the browser save dialog and show "Remotion saves automatically".
- Adjust notification styling to be smaller, use the shared text color, and sit lower in the viewport.

## Testing
- `bun run build`
- `bun run stylecheck` (fails in unrelated `template-react-router#lint` generated React Router types: `Generic type 'GetAnnotations' requires 1 type argument(s).`; `@remotion/studio` lint and formatting passed before the failure)
- `cd packages/studio && bun run lint` (passes with existing warnings)
