### PR TITLE
Docs: Improve shape drag previews

### DIFF
--- a/packages/docs/components/demos/index.tsx
+++ b/packages/docs/components/demos/index.tsx
@@ -1,12 +1,14 @@
 import {useColorMode} from '@docusaurus/theme-common';
 import {Player} from '@remotion/player';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {AbsoluteFill} from 'remotion';
 import {
 	makeShapeComponentDragDataFromDemoState,
 	setComponentDragData,
 } from '../shapes/shape-component-drag-data';
+import {ShapeDragPreview} from '../shapes/shape-drag-preview';
 import {Control} from './control';
+import styles from './styles.module.css';
 import type {DemoType, Option} from './types';
 import {
 	animationMathDemo,
@@ -60,7 +62,6 @@ import {
 	zoomBlurPresentationDemo,
 	zoomInOutPresentationDemo,
 } from './types';
-import styles from './styles.module.css';
 
 const container: React.CSSProperties = {
 	overflow: 'hidden',
@@ -80,6 +81,23 @@ const dragHandle: React.CSSProperties = {
 	gap: 6,
 	padding: '8px 10px',
 	userSelect: 'none',
+};
+
+const draggablePreview: React.CSSProperties = {
+	cursor: 'grab',
+};
+
+const previewSeparator: React.CSSProperties = {
+	borderBottom: '1px solid var(--ifm-color-emphasis-300)',
+};
+
+const dragPreviewSource: React.CSSProperties = {
+	height: 128,
+	left: -10000,
+	pointerEvents: 'none',
+	position: 'fixed',
+	top: -10000,
+	width: 128,
 };
 
 const demos: DemoType[] = [
@@ -157,6 +175,7 @@ export const Demo: React.FC<{
 	const {colorMode} = useColorMode();
 
 	const [key, setKey] = useState(() => 0);
+	const previewRef = useRef<SVGSVGElement>(null);
 
 	const initialState = useMemo(() => {
 		return demo.options
@@ -188,6 +207,7 @@ export const Demo: React.FC<{
 				setComponentDragData({
 					dataTransfer: e.dataTransfer,
 					dragData: shapeDragData,
+					dragImage: previewRef.current,
 				});
 			}
 		},
@@ -205,54 +225,77 @@ export const Demo: React.FC<{
 
 	return (
 		<div style={container}>
-			<Player
-				key={key}
-				acknowledgeRemotionLicense
-				component={demo.comp}
-				compositionWidth={demo.compWidth}
-				compositionHeight={demo.compHeight}
-				durationInFrames={demo.durationInFrames}
-				fps={demo.fps}
+			<div
+				draggable={shapeDragData !== null}
+				onDragStart={shapeDragData === null ? undefined : onDragStart}
 				style={{
-					width: '100%',
-					aspectRatio: demo.compWidth / demo.compHeight,
-					borderBottom:
-						demo.options.length > 0 || shapeDragData !== null
-							? '1px solid var(--ifm-color-emphasis-300)'
-							: 0,
+					...(shapeDragData === null ? {} : draggablePreview),
+					...(demo.options.length > 0 || shapeDragData !== null
+						? previewSeparator
+						: {}),
 				}}
-				logLevel={demo.logLevel}
-				errorFallback={({error}) => {
-					return (
-						<AbsoluteFill
-							style={{
-								justifyContent: 'center',
-								alignItems: 'center',
-								fontSize: 30,
-								textAlign: 'center',
-								lineHeight: 1.5,
-							}}
-						>
-							{error.message}
-							<br />
-							<button
-								style={{
-									fontSize: 30,
-								}}
-								onClick={restart}
-								type="button"
-							>
-								Restart
-							</button>
-						</AbsoluteFill>
-					);
-				}}
-				inputProps={{...state, darkMode: colorMode === 'dark'}}
-				autoPlay={demo.autoPlay}
-				controls={demo.controls}
-				initiallyMuted
-				loop
-			/>
+				title={
+					shapeDragData === null
+						? undefined
+						: 'Drag this shape into Remotion Studio'
+				}
+			>
+				<div>
+					<Player
+						key={key}
+						acknowledgeRemotionLicense
+						component={demo.comp}
+						compositionWidth={demo.compWidth}
+						compositionHeight={demo.compHeight}
+						durationInFrames={demo.durationInFrames}
+						fps={demo.fps}
+						style={{
+							width: '100%',
+							aspectRatio: demo.compWidth / demo.compHeight,
+						}}
+						logLevel={demo.logLevel}
+						errorFallback={({error}) => {
+							return (
+								<AbsoluteFill
+									style={{
+										justifyContent: 'center',
+										alignItems: 'center',
+										fontSize: 30,
+										textAlign: 'center',
+										lineHeight: 1.5,
+									}}
+								>
+									{error.message}
+									<br />
+									<button
+										style={{
+											fontSize: 30,
+										}}
+										onClick={restart}
+										type="button"
+									>
+										Restart
+									</button>
+								</AbsoluteFill>
+							);
+						}}
+						inputProps={{...state, darkMode: colorMode === 'dark'}}
+						autoPlay={demo.autoPlay}
+						controls={demo.controls}
+						initiallyMuted
+						loop
+					/>
+				</div>
+			</div>
+			{shapeDragData === null ? null : (
+				<div style={dragPreviewSource}>
+					<ShapeDragPreview
+						ref={previewRef}
+						dragData={shapeDragData}
+						size={128}
+					/>
+				</div>
+			)}
 			{shapeDragData === null ? null : (
 				<div
 					draggable

--- a/packages/docs/components/shapes/shape-component-drag-data.ts
+++ b/packages/docs/components/shapes/shape-component-drag-data.ts
@@ -142,6 +142,12 @@ export const makeDefaultShapeComponentDragData = (
 	});
 };
 
+export const getDefaultShapeComponentProps = (
+	shape: ShapeName,
+): ComponentProp[] => {
+	return [...shapeDefaultProps[shape]];
+};
+
 export const makeShapeComponentDragDataFromDemoState = ({
 	demoId,
 	state,
@@ -186,13 +192,20 @@ export const makeShapeComponentDragDataFromDemoState = ({
 export const setComponentDragData = ({
 	dataTransfer,
 	dragData,
+	dragImage,
 }: {
 	readonly dataTransfer: DataTransfer;
 	readonly dragData: ComponentDragData;
+	readonly dragImage?: Element | null;
 }) => {
 	const serialized = JSON.stringify(dragData);
 	dataTransfer.effectAllowed = 'copy';
 	dataTransfer.setData(COMPONENT_DRAG_MIME_TYPE, serialized);
 	dataTransfer.setData('application/json', serialized);
 	dataTransfer.setData('text/plain', serialized);
+
+	if (dragImage) {
+		const rect = dragImage.getBoundingClientRect();
+		dataTransfer.setDragImage(dragImage, rect.width / 2, rect.height / 2);
+	}
 };

--- a/packages/docs/components/shapes/shape-drag-preview.tsx
+++ b/packages/docs/components/shapes/shape-drag-preview.tsx
@@ -1,0 +1,226 @@
+import {
+	makeArrow,
+	makeCircle,
+	makeEllipse,
+	makeHeart,
+	makePie,
+	makePolygon,
+	makeRect,
+	makeStar,
+	makeTriangle,
+} from '@remotion/shapes';
+import type {ComponentDragData} from '@remotion/studio-shared';
+import React from 'react';
+import type {ShapeName} from './shapes-info';
+
+type ShapeInfo = {
+	readonly path: string;
+	readonly width: number;
+	readonly height: number;
+	readonly fill: string;
+};
+
+const shapeNames: readonly ShapeName[] = [
+	'Arrow',
+	'Circle',
+	'Ellipse',
+	'Heart',
+	'Pie',
+	'Polygon',
+	'Rect',
+	'Star',
+	'Triangle',
+];
+
+const isShapeName = (value: string): value is ShapeName => {
+	return shapeNames.includes(value as ShapeName);
+};
+
+const getProp = (
+	props: Record<string, string | number | boolean>,
+	name: string,
+) => props[name];
+
+const getNumber = (
+	props: Record<string, string | number | boolean>,
+	name: string,
+) => {
+	const value = getProp(props, name);
+	if (typeof value !== 'number') {
+		throw new Error(`Expected ${name} to be a number`);
+	}
+
+	return value;
+};
+
+const getBoolean = (
+	props: Record<string, string | number | boolean>,
+	name: string,
+) => {
+	const value = getProp(props, name);
+	if (typeof value !== 'boolean') {
+		throw new Error(`Expected ${name} to be a boolean`);
+	}
+
+	return value;
+};
+
+const getDirection = (
+	props: Record<string, string | number | boolean>,
+	name: string,
+) => {
+	const value = getProp(props, name);
+	if (
+		value !== 'left' &&
+		value !== 'right' &&
+		value !== 'up' &&
+		value !== 'down'
+	) {
+		throw new Error(`Expected ${name} to be a direction`);
+	}
+
+	return value;
+};
+
+const withFill = (
+	shapeInfo: Omit<ShapeInfo, 'fill'>,
+	props: Record<string, string | number | boolean>,
+): ShapeInfo => {
+	const fill = getProp(props, 'fill');
+
+	return {
+		...shapeInfo,
+		fill: typeof fill === 'string' ? fill : '#0b84ff',
+	};
+};
+
+const makeShapeInfo = (dragData: ComponentDragData): ShapeInfo | null => {
+	const shape = dragData.component.componentName;
+	if (!isShapeName(shape)) {
+		return null;
+	}
+
+	const props = Object.fromEntries(
+		dragData.component.props.map((prop) => [prop.name, prop.value]),
+	);
+
+	switch (shape) {
+		case 'Arrow':
+			return withFill(
+				makeArrow({
+					length: getNumber(props, 'length'),
+					headWidth: getNumber(props, 'headWidth'),
+					headLength: getNumber(props, 'headLength'),
+					shaftWidth: getNumber(props, 'shaftWidth'),
+					direction: getDirection(props, 'direction'),
+					cornerRadius:
+						typeof props.cornerRadius === 'number' ? props.cornerRadius : 0,
+				}),
+				props,
+			);
+		case 'Circle':
+			return withFill(makeCircle({radius: getNumber(props, 'radius')}), props);
+		case 'Ellipse':
+			return withFill(
+				makeEllipse({
+					rx: getNumber(props, 'rx'),
+					ry: getNumber(props, 'ry'),
+				}),
+				props,
+			);
+		case 'Heart':
+			return withFill(
+				makeHeart({
+					height: getNumber(props, 'height'),
+					aspectRatio: getNumber(props, 'aspectRatio'),
+					bottomRoundnessAdjustment: getNumber(
+						props,
+						'bottomRoundnessAdjustment',
+					),
+					depthAdjustment: getNumber(props, 'depthAdjustment'),
+				}),
+				props,
+			);
+		case 'Pie':
+			return withFill(
+				makePie({
+					radius: getNumber(props, 'radius'),
+					progress: getNumber(props, 'progress'),
+					closePath: getBoolean(props, 'closePath'),
+					counterClockwise: getBoolean(props, 'counterClockwise'),
+					rotation: getNumber(props, 'rotation'),
+				}),
+				props,
+			);
+		case 'Polygon':
+			return withFill(
+				makePolygon({
+					points: getNumber(props, 'points'),
+					radius: getNumber(props, 'radius'),
+					cornerRadius: getNumber(props, 'cornerRadius'),
+				}),
+				props,
+			);
+		case 'Rect':
+			return withFill(
+				makeRect({
+					width: getNumber(props, 'width'),
+					height: getNumber(props, 'height'),
+					cornerRadius: getNumber(props, 'cornerRadius'),
+				}),
+				props,
+			);
+		case 'Star':
+			return withFill(
+				makeStar({
+					points: getNumber(props, 'points'),
+					innerRadius: getNumber(props, 'innerRadius'),
+					outerRadius: getNumber(props, 'outerRadius'),
+					cornerRadius: getNumber(props, 'cornerRadius'),
+				}),
+				props,
+			);
+		case 'Triangle':
+			return withFill(
+				makeTriangle({
+					length: getNumber(props, 'length'),
+					direction: getDirection(props, 'direction'),
+					cornerRadius: getNumber(props, 'cornerRadius'),
+				}),
+				props,
+			);
+		default:
+			return null;
+	}
+};
+
+export const ShapeDragPreview = React.forwardRef<
+	SVGSVGElement,
+	{
+		readonly dragData: ComponentDragData;
+		readonly size: number;
+	}
+>(({dragData, size}, ref) => {
+	const shapeInfo = makeShapeInfo(dragData);
+	if (shapeInfo === null) {
+		return null;
+	}
+
+	const padding = Math.max(shapeInfo.width, shapeInfo.height) * 0.08;
+
+	return (
+		<svg
+			ref={ref}
+			width={size}
+			height={size}
+			viewBox={`${-padding} ${-padding} ${shapeInfo.width + padding * 2} ${
+				shapeInfo.height + padding * 2
+			}`}
+			style={{display: 'block'}}
+		>
+			<path d={shapeInfo.path} fill={shapeInfo.fill} />
+		</svg>
+	);
+});
+
+ShapeDragPreview.displayName = 'ShapeDragPreview';

--- a/packages/docs/docs/shapes/table-of-contents.tsx
+++ b/packages/docs/docs/shapes/table-of-contents.tsx
@@ -1,11 +1,227 @@
+import {
+	makeArrow,
+	makeCircle,
+	makeEllipse,
+	makeHeart,
+	makePie,
+	makePolygon,
+	makeRect,
+	makeStar,
+	makeTriangle,
+} from '@remotion/shapes';
 import React from 'react';
 import {
+	getDefaultShapeComponentProps,
 	makeDefaultShapeComponentDragData,
 	setComponentDragData,
 } from '../../components/shapes/shape-component-drag-data';
-import {shapeComponents} from '../../components/shapes/shapes-info';
+import {
+	type ShapeName,
+	shapeComponents,
+} from '../../components/shapes/shapes-info';
 import {Grid} from '../../components/TableOfContents/Grid';
 import {TOCItem} from '../../components/TableOfContents/TOCItem';
+
+type ShapeInfo = {
+	readonly path: string;
+	readonly width: number;
+	readonly height: number;
+};
+
+const shapeItem: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	gap: 16,
+	justifyContent: 'space-between',
+};
+
+const shapeItemText: React.CSSProperties = {
+	minWidth: 0,
+};
+
+const shapeThumbnailContainer: React.CSSProperties = {
+	alignItems: 'center',
+	backgroundColor: 'var(--ifm-color-emphasis-100)',
+	border: '1px solid var(--ifm-color-emphasis-300)',
+	borderRadius: 6,
+	display: 'flex',
+	flexShrink: 0,
+	height: 64,
+	justifyContent: 'center',
+	pointerEvents: 'none',
+	width: 64,
+};
+
+const shapeThumbnail: React.CSSProperties = {
+	display: 'block',
+};
+
+const getProp = (
+	props: Record<string, string | number | boolean>,
+	name: string,
+) => props[name];
+
+const getNumber = (
+	props: Record<string, string | number | boolean>,
+	name: string,
+) => {
+	const value = getProp(props, name);
+	if (typeof value !== 'number') {
+		throw new Error(`Expected ${name} to be a number`);
+	}
+
+	return value;
+};
+
+const getBoolean = (
+	props: Record<string, string | number | boolean>,
+	name: string,
+) => {
+	const value = getProp(props, name);
+	if (typeof value !== 'boolean') {
+		throw new Error(`Expected ${name} to be a boolean`);
+	}
+
+	return value;
+};
+
+const getDirection = (
+	props: Record<string, string | number | boolean>,
+	name: string,
+) => {
+	const value = getProp(props, name);
+	if (
+		value !== 'left' &&
+		value !== 'right' &&
+		value !== 'up' &&
+		value !== 'down'
+	) {
+		throw new Error(`Expected ${name} to be a direction`);
+	}
+
+	return value;
+};
+
+const makeDefaultShapeInfo = (shape: ShapeName): ShapeInfo => {
+	const props = Object.fromEntries(
+		getDefaultShapeComponentProps(shape).map((prop) => [prop.name, prop.value]),
+	);
+
+	switch (shape) {
+		case 'Arrow':
+			return makeArrow({
+				length: getNumber(props, 'length'),
+				headWidth: getNumber(props, 'headWidth'),
+				headLength: getNumber(props, 'headLength'),
+				shaftWidth: getNumber(props, 'shaftWidth'),
+				direction: getDirection(props, 'direction'),
+			});
+		case 'Circle':
+			return makeCircle({radius: getNumber(props, 'radius')});
+		case 'Ellipse':
+			return makeEllipse({
+				rx: getNumber(props, 'rx'),
+				ry: getNumber(props, 'ry'),
+			});
+		case 'Heart':
+			return makeHeart({
+				height: getNumber(props, 'height'),
+				aspectRatio: getNumber(props, 'aspectRatio'),
+				bottomRoundnessAdjustment: getNumber(
+					props,
+					'bottomRoundnessAdjustment',
+				),
+				depthAdjustment: getNumber(props, 'depthAdjustment'),
+			});
+		case 'Pie':
+			return makePie({
+				radius: getNumber(props, 'radius'),
+				progress: getNumber(props, 'progress'),
+				closePath: getBoolean(props, 'closePath'),
+				counterClockwise: getBoolean(props, 'counterClockwise'),
+				rotation: getNumber(props, 'rotation'),
+			});
+		case 'Polygon':
+			return makePolygon({
+				points: getNumber(props, 'points'),
+				radius: getNumber(props, 'radius'),
+				cornerRadius: getNumber(props, 'cornerRadius'),
+			});
+		case 'Rect':
+			return makeRect({
+				width: getNumber(props, 'width'),
+				height: getNumber(props, 'height'),
+				cornerRadius: getNumber(props, 'cornerRadius'),
+			});
+		case 'Star':
+			return makeStar({
+				points: getNumber(props, 'points'),
+				innerRadius: getNumber(props, 'innerRadius'),
+				outerRadius: getNumber(props, 'outerRadius'),
+				cornerRadius: getNumber(props, 'cornerRadius'),
+			});
+		case 'Triangle':
+			return makeTriangle({
+				length: getNumber(props, 'length'),
+				direction: getDirection(props, 'direction'),
+				cornerRadius: getNumber(props, 'cornerRadius'),
+			});
+	}
+};
+
+const ShapeDragPreview = React.forwardRef<SVGSVGElement, {shape: ShapeName}>(
+	({shape}, ref) => {
+		const shapeInfo = makeDefaultShapeInfo(shape);
+		const padding = Math.max(shapeInfo.width, shapeInfo.height) * 0.08;
+
+		return (
+			<div style={shapeThumbnailContainer}>
+				<svg
+					ref={ref}
+					width="48"
+					height="48"
+					viewBox={`${-padding} ${-padding} ${shapeInfo.width + padding * 2} ${
+						shapeInfo.height + padding * 2
+					}`}
+					style={shapeThumbnail}
+				>
+					<path d={shapeInfo.path} fill="#0b84ff" />
+				</svg>
+			</div>
+		);
+	},
+);
+
+ShapeDragPreview.displayName = 'ShapeDragPreview';
+
+const ShapeTOCItem: React.FC<{
+	readonly shape: ShapeName;
+}> = ({shape}) => {
+	const dragImageRef = React.useRef<SVGSVGElement>(null);
+
+	return (
+		<TOCItem
+			link={'/docs/shapes/' + shape.toLowerCase()}
+			draggable
+			onDragStart={(e) => {
+				setComponentDragData({
+					dataTransfer: e.dataTransfer,
+					dragData: makeDefaultShapeComponentDragData(shape),
+					dragImage: dragImageRef.current,
+				});
+			}}
+			title="Drag this shape into Remotion Studio"
+		>
+			<div style={shapeItem}>
+				<div style={shapeItemText}>
+					<strong>{'<' + shape + '/>'}</strong>
+					<div>Render a {shape.toLowerCase()}</div>
+				</div>
+				<ShapeDragPreview ref={dragImageRef} shape={shape} />
+			</div>
+		</TOCItem>
+	);
+};
 
 export const TableOfContents: React.FC = () => {
 	return (
@@ -18,20 +234,7 @@ export const TableOfContents: React.FC = () => {
 								<strong>make{c.shape}()</strong>
 								<div>Generate SVG Path for a {c.shape.toLowerCase()}</div>
 							</TOCItem>
-							<TOCItem
-								link={'/docs/shapes/' + c.shape.toLowerCase()}
-								draggable
-								onDragStart={(e) => {
-									setComponentDragData({
-										dataTransfer: e.dataTransfer,
-										dragData: makeDefaultShapeComponentDragData(c.shape),
-									});
-								}}
-								title="Drag this shape into Remotion Studio"
-							>
-								<strong>{'<' + c.shape + '/>'}</strong>
-								<div>Render a {c.shape.toLowerCase()}</div>
-							</TOCItem>
+							<ShapeTOCItem shape={c.shape} />
 						</React.Fragment>
 					);
 				})}


### PR DESCRIPTION
## Summary

- make shape docs demos draggable from the live preview itself
- use `dataTransfer.setDragImage()` so shape drags show the preview/thumbnail instead of the link card
- add generated SVG thumbnails to the shapes overview drag cards

## Testing

- `bunx oxfmt src --write` in `packages/docs`
- `bun run build`
- `bun run stylecheck`
