### PR TITLE
`@remotion/studio`: Round visual drag values

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -25,10 +25,17 @@ type Props = InputHTMLAttributes<HTMLInputElement> & {
 	readonly rightAlign: boolean;
 	readonly small?: boolean;
 	readonly snapToStep?: boolean;
+	readonly dragDecimalPlaces?: number;
 };
 
 const isInt = (num: number) => {
 	return num % 1 === 0;
+};
+
+const roundToDecimalPlaces = (val: number, decimalPlaces: number) => {
+	const factor = 10 ** decimalPlaces;
+	const rounded = Math.round(val * factor) / factor;
+	return Object.is(rounded, -0) ? 0 : rounded;
 };
 
 export const deriveInputDraggerStep = ({
@@ -72,6 +79,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 		rightAlign,
 		small,
 		snapToStep = true,
+		dragDecimalPlaces,
 		...props
 	},
 	ref,
@@ -204,7 +212,11 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 					[-step, 0, 0, 0, step],
 				);
 				const newValue = Math.min(max, Math.max(min, Number(value) + diff));
-				const nextValue = snapToStep ? roundToStep(newValue, step) : newValue;
+				const nextValue = snapToStep
+					? roundToStep(newValue, step)
+					: dragDecimalPlaces === undefined
+						? newValue
+						: roundToDecimalPlaces(newValue, dragDecimalPlaces);
 				lastDragValue = nextValue;
 				onValueChange(nextValue);
 			};
@@ -230,7 +242,16 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 				},
 			);
 		},
-		[_step, _min, _max, value, onValueChange, onValueChangeEnd, snapToStep],
+		[
+			_step,
+			_min,
+			_max,
+			value,
+			onValueChange,
+			onValueChangeEnd,
+			snapToStep,
+			dragDecimalPlaces,
+		],
 	);
 
 	useEffect(() => {

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -62,6 +62,10 @@ import {
 	type SaveSequencePropChange,
 } from './Timeline/save-sequence-prop';
 import {
+	getTimelineDisplayDecimalPlaces,
+	roundToDecimalPlaces,
+} from './Timeline/timeline-field-utils';
+import {
 	parseCssRotationToDegrees,
 	serializeCssRotation,
 } from './Timeline/timeline-rotation-utils';
@@ -989,10 +993,14 @@ export const getSelectedOutlineScaleDragValues = ({
 		dragStates.map((dragState) => {
 			const min = dragState.target.fieldSchema.min ?? -Infinity;
 			const max = dragState.target.fieldSchema.max ?? Infinity;
+			const decimalPlaces = getTimelineDisplayDecimalPlaces({
+				defaultDecimalPlaces: 3,
+				step: dragState.target.fieldSchema.step,
+			});
 			const baseX = dragState.startX;
 			const baseY = dragState.startY;
 			const newValue = (axis === 'x' ? baseX : baseY) * scaleFactor;
-			const [x, y] = dragState.target.linked
+			const [rawX, rawY] = dragState.target.linked
 				? getLinkedScale({
 						axis,
 						newValue,
@@ -1004,6 +1012,8 @@ export const getSelectedOutlineScaleDragValues = ({
 				: axis === 'x'
 					? [clamp(newValue, min, max), baseY]
 					: [baseX, clamp(newValue, min, max)];
+			const x = roundToDecimalPlaces(rawX, decimalPlaces);
+			const y = roundToDecimalPlaces(rawY, decimalPlaces);
 
 			return [
 				dragState.key,
@@ -1121,10 +1131,20 @@ export const getSelectedOutlineRotationDragValues = ({
 	readonly rotationDeltaDegrees: number;
 }): Map<string, string> => {
 	return new Map(
-		dragStates.map((dragState) => [
-			dragState.key,
-			serializeCssRotation(dragState.startDegrees + rotationDeltaDegrees),
-		]),
+		dragStates.map((dragState) => {
+			const decimalPlaces = getTimelineDisplayDecimalPlaces({
+				defaultDecimalPlaces: 1,
+				step: dragState.target.fieldSchema.step,
+			});
+
+			return [
+				dragState.key,
+				serializeCssRotation(
+					dragState.startDegrees + rotationDeltaDegrees,
+					decimalPlaces,
+				),
+			];
+		}),
 	);
 };
 
@@ -1144,7 +1164,14 @@ export const getSelectedOutlineRotationDragChanges = ({
 		}
 
 		if (dragState.target.propStatus.status === 'keyframed') {
-			const startValue = serializeCssRotation(dragState.startDegrees);
+			const decimalPlaces = getTimelineDisplayDecimalPlaces({
+				defaultDecimalPlaces: 1,
+				step: dragState.target.fieldSchema.step,
+			});
+			const startValue = serializeCssRotation(
+				dragState.startDegrees,
+				decimalPlaces,
+			);
 			if (value === startValue) {
 				continue;
 			}

--- a/packages/studio/src/components/Timeline/TimelineRotationField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRotationField.tsx
@@ -43,13 +43,37 @@ export const TimelineRotationField: React.FC<{
 		return typeof effectiveValue === 'number' ? effectiveValue : 0;
 	}, [effectiveValue, isCssRotation]);
 
+	const configuredStep =
+		field.fieldSchema.type === 'rotation-css' ||
+		field.fieldSchema.type === 'rotation-degrees'
+			? field.fieldSchema.step
+			: undefined;
+	const step = configuredStep ?? 1;
+	const min =
+		field.fieldSchema.type === 'rotation-degrees'
+			? (field.fieldSchema.min ?? -Infinity)
+			: -Infinity;
+	const max =
+		field.fieldSchema.type === 'rotation-degrees'
+			? (field.fieldSchema.max ?? Infinity)
+			: Infinity;
+
+	const decimalPlaces = useMemo(
+		() =>
+			getTimelineDisplayDecimalPlaces({
+				defaultDecimalPlaces: 1,
+				step: configuredStep,
+			}),
+		[configuredStep],
+	);
+
 	const serializeValue = useCallback(
 		(value: number) => {
 			return isCssRotation
-				? serializeCssRotation(value)
+				? serializeCssRotation(value, decimalPlaces)
 				: normalizeTimelineNumber(value);
 		},
-		[isCssRotation],
+		[decimalPlaces, isCssRotation],
 	);
 
 	const onValueChange = useCallback(
@@ -90,30 +114,6 @@ export const TimelineRotationField: React.FC<{
 			}
 		},
 		[propStatus, onSave, serializeValue],
-	);
-
-	const configuredStep =
-		field.fieldSchema.type === 'rotation-css' ||
-		field.fieldSchema.type === 'rotation-degrees'
-			? field.fieldSchema.step
-			: undefined;
-	const step = configuredStep ?? 1;
-	const min =
-		field.fieldSchema.type === 'rotation-degrees'
-			? (field.fieldSchema.min ?? -Infinity)
-			: -Infinity;
-	const max =
-		field.fieldSchema.type === 'rotation-degrees'
-			? (field.fieldSchema.max ?? Infinity)
-			: Infinity;
-
-	const decimalPlaces = useMemo(
-		() =>
-			getTimelineDisplayDecimalPlaces({
-				defaultDecimalPlaces: 1,
-				step: configuredStep,
-			}),
-		[configuredStep],
 	);
 
 	const formatter = useCallback(

--- a/packages/studio/src/components/Timeline/TimelineScaleField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScaleField.tsx
@@ -193,7 +193,7 @@ export const TimelineScaleField: React.FC<{
 	const decimalPlaces = useMemo(
 		() =>
 			getTimelineDisplayDecimalPlaces({
-				defaultDecimalPlaces: 2,
+				defaultDecimalPlaces: 3,
 				step: configuredStep,
 			}),
 		[configuredStep],

--- a/packages/studio/src/components/Timeline/TimelineTransformOriginField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTransformOriginField.tsx
@@ -227,6 +227,7 @@ export const TimelineTransformOriginField: React.FC<{
 				formatter={formatter}
 				rightAlign={false}
 				snapToStep={false}
+				dragDecimalPlaces={decimalPlaces}
 			/>
 			<div style={{marginLeft: -6, marginRight: -6}} />
 			<InputDragger
@@ -244,6 +245,7 @@ export const TimelineTransformOriginField: React.FC<{
 				formatter={formatter}
 				rightAlign={false}
 				snapToStep={false}
+				dragDecimalPlaces={decimalPlaces}
 			/>
 		</span>
 	);

--- a/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
@@ -178,6 +178,7 @@ export const TimelineTranslateField: React.FC<{
 				formatter={formatter}
 				rightAlign={false}
 				snapToStep={false}
+				dragDecimalPlaces={decimalPlaces}
 			/>
 			<div style={{marginLeft: -6, marginRight: -6}} />
 			<InputDragger
@@ -195,6 +196,7 @@ export const TimelineTranslateField: React.FC<{
 				formatter={formatter}
 				rightAlign={false}
 				snapToStep={false}
+				dragDecimalPlaces={decimalPlaces}
 			/>
 		</span>
 	);

--- a/packages/studio/src/components/Timeline/TimelineUvCoordinateField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineUvCoordinateField.tsx
@@ -209,6 +209,7 @@ export const TimelineUvCoordinateField: React.FC<{
 				formatter={formatter}
 				rightAlign={false}
 				snapToStep={false}
+				dragDecimalPlaces={decimalPlaces}
 			/>
 			<div style={{marginLeft: -6, marginRight: -6}} />
 			<InputDragger
@@ -226,6 +227,7 @@ export const TimelineUvCoordinateField: React.FC<{
 				formatter={formatter}
 				rightAlign={false}
 				snapToStep={false}
+				dragDecimalPlaces={decimalPlaces}
 			/>
 		</span>
 	);

--- a/packages/studio/src/components/Timeline/timeline-rotation-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-rotation-utils.ts
@@ -27,6 +27,11 @@ export const parseCssRotationToDegrees = (value: string): number => {
 	}
 };
 
-export const serializeCssRotation = (value: number): string => {
-	return `${normalizeTimelineNumber(value)}deg`;
+export const serializeCssRotation = (
+	value: number,
+	decimalPlaces = 6,
+): string => {
+	const factor = 10 ** decimalPlaces;
+	const rounded = Math.round(normalizeTimelineNumber(value) * factor) / factor;
+	return `${Object.is(rounded, -0) ? 0 : rounded}deg`;
 };

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -2124,6 +2124,41 @@ test('Selected outline edge dragging scales one axis when scale is unlinked', ()
 	expect(negativeValues.get(dragStates[0].key)).toBe('-1 3');
 });
 
+test('Selected outline edge dragging rounds scale values', () => {
+	const schema = {
+		'style.scale': {type: 'scale', default: 1, max: 100},
+	} satisfies SequenceSchema;
+	const nodePath = makeKey(['body', 0]);
+	const dragStates = [
+		{
+			defaultValue: JSON.stringify(1),
+			key: Internals.makeSequencePropsSubscriptionKey(nodePath),
+			sourceFrame: 0,
+			startX: 2,
+			startY: 3,
+			startZ: 1,
+			target: {
+				clientId: 'client',
+				propStatus: {status: 'static', codeValue: '2 3'},
+				fieldDefault: 1,
+				fieldSchema: schema['style.scale'],
+				keyframeDisplayOffset: 0,
+				linked: false,
+				nodePath,
+				schema,
+			},
+		},
+	] satisfies SelectedOutlineScaleDragState[];
+
+	const lastValues = getSelectedOutlineScaleDragValues({
+		dragStates,
+		axis: 'x',
+		scaleFactor: 1 / 3,
+	});
+
+	expect(lastValues.get(dragStates[0].key)).toBe('0.667 3');
+});
+
 test('Selected outline edge dragging preserves aspect ratio when scale is linked', () => {
 	const schema = {
 		'style.scale': {type: 'scale', default: 1, max: 100},
@@ -2232,6 +2267,38 @@ test('Selected outline corner dragging rotates selected sequences', () => {
 			schema,
 		},
 	]);
+});
+
+test('Selected outline corner dragging rounds rotation values', () => {
+	const schema = {
+		'style.rotate': {type: 'rotation-css', default: '0deg'},
+	} satisfies SequenceSchema;
+	const nodePath = makeKey(['body', 0]);
+	const dragStates = [
+		{
+			defaultValue: JSON.stringify('0deg'),
+			key: Internals.makeSequencePropsSubscriptionKey(nodePath),
+			sourceFrame: 12,
+			startDegrees: 32,
+			target: {
+				clientId: 'client',
+				propStatus: {status: 'static', codeValue: '32deg'},
+				fieldDefault: '0deg',
+				fieldSchema: schema['style.rotate'],
+				keyframeDisplayOffset: 30,
+				nodePath,
+				schema,
+				transformOriginValue: '50% 50%',
+			},
+		},
+	] satisfies SelectedOutlineRotationDragState[];
+
+	const lastValues = getSelectedOutlineRotationDragValues({
+		dragStates,
+		rotationDeltaDegrees: 0.480832,
+	});
+
+	expect(lastValues.get(dragStates[0].key)).toBe('32.5deg');
 });
 
 test('Selected outline corner dragging keyframed rotation adds a keyframe at the source frame', () => {


### PR DESCRIPTION
## Summary
- Round smooth Studio input-dragger values to caller-provided display precision
- Round selected outline scale and rotation drag values according to the field schema step/default precision
- Add regression tests for repeating-decimal outline scale drags and outline rotation drags

Fixes #8352.

## Test plan
- bun run build
- bun test packages/studio/src/test/timeline-selection.test.ts
- bun run stylecheck
