### PR TITLE
`remotion`: Hide native video controls

### DIFF
--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -352,6 +352,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	return (
 		<video
+			{...nativeProps}
 			ref={videoRef}
 			muted={muted || mediaMuted || userPreferredVolume <= 0}
 			playsInline
@@ -360,7 +361,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 			style={actualStyle}
 			disableRemotePlayback
 			crossOrigin={crossOriginValue}
-			{...nativeProps}
+			controls={false}
 		/>
 	);
 };


### PR DESCRIPTION
## Summary

- Force the preview `<video>` element used by `<Html5Video>` to render with `controls={false}`
- Keep native props spread before the explicit controls override so browser media controls cannot be enabled accidentally in fallback paths

## Testing

- `bunx oxfmt src --write` in `packages/core`
- `bun run build`
- `bun test packages/core/src/test/media-validation.test.tsx`
- `bun run stylecheck` *(fails because pre-existing unrelated `packages/example/src/KeyframedPropsTest.tsx` has formatting issues)*
