### PR TITLE
`@remotion/studio`: Replace keyframes on drag collision

### DIFF
--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -681,6 +681,59 @@ const normalizeEasingAfterRemovingKeyframe = ({
 	};
 };
 
+const normalizeEasingAfterRemovingKeyframes = ({
+	extraArgs,
+	previousSegmentCount,
+	nextSegmentCount,
+	removedKeyframeIndexes,
+}: {
+	extraArgs: (ExpressionKind | SpreadElementKind)[];
+	previousSegmentCount: number;
+	nextSegmentCount: number;
+	removedKeyframeIndexes: number[];
+}): {
+	extraArgs: (ExpressionKind | SpreadElementKind)[];
+	needsEasingImport: boolean;
+} => {
+	const options = getInlineOptionsFromExtraArgs(extraArgs);
+	if (!options) {
+		return {extraArgs, needsEasingImport: false};
+	}
+
+	const easing = getExistingEasingArrayOrNull({
+		options,
+		segmentCount: previousSegmentCount,
+	});
+	if (easing === null) {
+		return {extraArgs, needsEasingImport: false};
+	}
+
+	for (const removedKeyframeIndex of [...removedKeyframeIndexes].sort(
+		(first, second) => second - first,
+	)) {
+		if (easing.length === 0) {
+			break;
+		}
+
+		const easingIndexToRemove =
+			removedKeyframeIndex === 0 ? 0 : removedKeyframeIndex - 1;
+		easing.splice(easingIndexToRemove, 1);
+	}
+
+	while (easing.length > nextSegmentCount) {
+		easing.pop();
+	}
+
+	while (easing.length < nextSegmentCount) {
+		easing.push('linear');
+	}
+
+	return {
+		extraArgs: getExtraArgsWithOptions({extraArgs, options}),
+		needsEasingImport: setEasingOption({options, easing}),
+	};
+};
+
 const validatePosterize = (posterize: number | undefined) => {
 	if (posterize === undefined) {
 		return;
@@ -1057,32 +1110,48 @@ const moveKeyframes = ({
 	}
 
 	const movedFromFrames = new Set(moveMap.keys());
+	const movedToFrames = new Set(moveMap.values());
+	const removedKeyframeIndexes: number[] = [];
+	const nextKeyframes = existing.keyframes.flatMap((keyframe, index) => {
+		const movedFrame = moveMap.get(keyframe.frame);
+		if (movedFrame !== undefined) {
+			return [{...keyframe, frame: movedFrame}];
+		}
+
+		if (
+			movedToFrames.has(keyframe.frame) &&
+			!movedFromFrames.has(keyframe.frame)
+		) {
+			removedKeyframeIndexes.push(index);
+			return [];
+		}
+
+		return [keyframe];
+	});
+
 	const nextFrames = new Set<number>();
-	for (const keyframe of existing.keyframes) {
-		const nextFrame = moveMap.get(keyframe.frame) ?? keyframe.frame;
-		if (nextFrames.has(nextFrame)) {
+	for (const keyframe of nextKeyframes) {
+		if (nextFrames.has(keyframe.frame)) {
 			throw new Error(
-				`Cannot move keyframe to frame ${nextFrame}: frame already exists`,
+				`Cannot move keyframe to frame ${keyframe.frame}: frame already exists`,
 			);
 		}
 
-		if (!movedFromFrames.has(keyframe.frame) && moveMap.has(nextFrame)) {
-			throw new Error(
-				`Cannot move keyframe to frame ${nextFrame}: frame already exists`,
-			);
-		}
-
-		nextFrames.add(nextFrame);
+		nextFrames.add(keyframe.frame);
 	}
+
+	const normalizedEasing = normalizeEasingAfterRemovingKeyframes({
+		extraArgs: existing.extraArgs,
+		previousSegmentCount: Math.max(existing.keyframes.length - 1, 0),
+		nextSegmentCount: Math.max(nextKeyframes.length - 1, 0),
+		removedKeyframeIndexes,
+	});
 
 	return createInterpolateExpression({
 		callee: existing.callee,
 		input: existing.input,
-		extraArgs: existing.extraArgs,
-		keyframes: existing.keyframes.map((keyframe) => ({
-			...keyframe,
-			frame: moveMap.get(keyframe.frame) ?? keyframe.frame,
-		})),
+		extraArgs: normalizedEasing.extraArgs,
+		keyframes: nextKeyframes,
 	});
 };
 

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -933,6 +933,41 @@ test('updateSequenceKeyframes resorts keyframes when moving past an adjacent key
 	);
 });
 
+test('updateSequenceKeyframes replaces an existing keyframe when moving onto it', async () => {
+	const input = sequenceInput
+		.replace(
+			"import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';",
+			"import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';",
+		)
+		.replace(
+			'interpolate(frame, [0, 100], [2, 4])',
+			'interpolate(frame, [0, 50, 100], [2, 3, 4], {easing: [Easing.linear, Easing.bezier(0.42, 0, 1, 1)]})',
+		);
+	const {output, oldValueStrings, newValueStrings} =
+		await updateSequenceKeyframes({
+			input,
+			nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+			updates: [
+				{
+					key: 'style.scale',
+					operation: {
+						type: 'move',
+						moves: [{fromFrame: 0, toFrame: 50}],
+					},
+				},
+			],
+		});
+
+	expect(oldValueStrings).toEqual([
+		'interpolate(frame, [0, 50, 100], [2, 3, 4], {easing: [Easing.linear, Easing.bezier(0.42, 0, 1, 1)]})',
+	]);
+	expect(newValueStrings).toEqual([
+		'interpolate(frame, [50, 100], [2, 4], {easing: [Easing.bezier(0.42, 0, 1, 1)]})',
+	]);
+	expect(output).toContain('scale: interpolate(frame, [50, 100], [2, 4], {');
+	expect(output).toContain('easing: [Easing.bezier(0.42, 0, 1, 1)]');
+});
+
 test('updateSequenceKeyframes allows moving keyframes outside the sequence range', async () => {
 	const input = sequenceInput.replace(
 		'interpolate(frame, [0, 100], [2, 4])',
@@ -1149,6 +1184,33 @@ test('updateEffectKeyframes allows moving keyframes outside the sequence range',
 	]);
 	expect(serialized).toContain(
 		'amount: interpolate(frame, [-20, 50, 150], [0.2, 0.5, 0.8])',
+	);
+});
+
+test('updateEffectKeyframes replaces an existing keyframe when moving onto it', () => {
+	const {serialized, newValueStrings} = updateEffectKeyframesAst({
+		input: effectInput,
+		sequenceNodePath: lineColumnToNodePath(
+			effectInput,
+			getLine(effectInput, '<HtmlInCanvas'),
+		),
+		effectIndex: 0,
+		updates: [
+			{
+				key: 'amount',
+				operation: {
+					type: 'move',
+					moves: [{fromFrame: 0, toFrame: 50}],
+				},
+			},
+		],
+	});
+
+	expect(newValueStrings).toEqual([
+		'interpolate(frame, [50, 100], [0.2, 0.8])',
+	]);
+	expect(serialized).toContain(
+		'amount: interpolate(frame, [50, 100], [0.2, 0.8])',
 	);
 });
 

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -250,6 +250,7 @@ export {
 } from './optimistic-delete-keyframe';
 export {
 	canMoveKeyframesWithoutCollisions,
+	moveKeyframesInPropStatus,
 	optimisticMoveEffectKeyframes,
 	optimisticMoveSequenceKeyframes,
 	type OptimisticKeyframeMove,

--- a/packages/studio-shared/src/optimistic-move-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-move-keyframe.ts
@@ -28,6 +28,97 @@ const getMoveMap = (
 	return moveMap;
 };
 
+const getMovedKeyframes = ({
+	status,
+	moves,
+}: {
+	status: CanUpdateSequencePropStatus;
+	moves: readonly {fromFrame: number; toFrame: number}[];
+}): {
+	keyframes: Extract<
+		CanUpdateSequencePropStatus,
+		{status: 'keyframed'}
+	>['keyframes'];
+	removedKeyframeIndexes: number[];
+} | null => {
+	if (status.status !== 'keyframed') {
+		return null;
+	}
+
+	const moveMap = getMoveMap(moves);
+	if (moveMap === null) {
+		return null;
+	}
+
+	if (moveMap.size === 0) {
+		return {keyframes: status.keyframes, removedKeyframeIndexes: []};
+	}
+
+	const frames = new Set(status.keyframes.map((keyframe) => keyframe.frame));
+	for (const fromFrame of moveMap.keys()) {
+		if (!frames.has(fromFrame)) {
+			return null;
+		}
+	}
+
+	const movedFromFrames = new Set(moveMap.keys());
+	const movedToFrames = new Set(moveMap.values());
+	const removedKeyframeIndexes: number[] = [];
+	const nextKeyframes = status.keyframes.flatMap((keyframe, index) => {
+		const movedFrame = moveMap.get(keyframe.frame);
+		if (movedFrame !== undefined) {
+			return [{...keyframe, frame: movedFrame}];
+		}
+
+		if (
+			movedToFrames.has(keyframe.frame) &&
+			!movedFromFrames.has(keyframe.frame)
+		) {
+			removedKeyframeIndexes.push(index);
+			return [];
+		}
+
+		return [keyframe];
+	});
+
+	const nextFrames = new Set<number>();
+	for (const keyframe of nextKeyframes) {
+		if (nextFrames.has(keyframe.frame)) {
+			return null;
+		}
+
+		nextFrames.add(keyframe.frame);
+	}
+
+	return {
+		keyframes: nextKeyframes.sort((a, b) => a.frame - b.frame),
+		removedKeyframeIndexes,
+	};
+};
+
+const removeEasingForRemovedKeyframes = ({
+	easing,
+	removedKeyframeIndexes,
+}: {
+	easing: Extract<CanUpdateSequencePropStatus, {status: 'keyframed'}>['easing'];
+	removedKeyframeIndexes: number[];
+}) => {
+	const nextEasing = [...easing];
+	for (const removedKeyframeIndex of [...removedKeyframeIndexes].sort(
+		(a, b) => b - a,
+	)) {
+		if (nextEasing.length === 0) {
+			break;
+		}
+
+		const easingIndexToRemove =
+			removedKeyframeIndex === 0 ? 0 : removedKeyframeIndex - 1;
+		nextEasing.splice(easingIndexToRemove, 1);
+	}
+
+	return nextEasing;
+};
+
 export const canMoveKeyframesWithoutCollisions = ({
 	status,
 	moves,
@@ -35,40 +126,10 @@ export const canMoveKeyframesWithoutCollisions = ({
 	status: CanUpdateSequencePropStatus;
 	moves: readonly {fromFrame: number; toFrame: number}[];
 }): boolean => {
-	if (status.status !== 'keyframed') {
-		return false;
-	}
-
-	const moveMap = getMoveMap(moves);
-	if (moveMap === null) {
-		return false;
-	}
-
-	if (moveMap.size === 0) {
-		return true;
-	}
-
-	const frames = new Set(status.keyframes.map((keyframe) => keyframe.frame));
-	for (const fromFrame of moveMap.keys()) {
-		if (!frames.has(fromFrame)) {
-			return false;
-		}
-	}
-
-	const nextFrames = new Set<number>();
-	for (const keyframe of status.keyframes) {
-		const frame = moveMap.get(keyframe.frame) ?? keyframe.frame;
-		if (nextFrames.has(frame)) {
-			return false;
-		}
-
-		nextFrames.add(frame);
-	}
-
-	return true;
+	return getMovedKeyframes({status, moves}) !== null;
 };
 
-const moveKeyframesInPropStatus = ({
+export const moveKeyframesInPropStatus = ({
 	status,
 	moves,
 }: {
@@ -79,27 +140,24 @@ const moveKeyframesInPropStatus = ({
 		return status;
 	}
 
-	if (!canMoveKeyframesWithoutCollisions({status, moves})) {
+	const moved = getMovedKeyframes({status, moves});
+	if (
+		moved === null ||
+		(moved.removedKeyframeIndexes.length === 0 &&
+			moved.keyframes === status.keyframes)
+	) {
 		return status;
 	}
 
-	const moveMap = getMoveMap(moves);
-	if (moveMap === null) {
-		return status;
-	}
-
-	if (moveMap.size === 0) {
-		return status;
-	}
+	const easing = removeEasingForRemovedKeyframes({
+		easing: status.easing,
+		removedKeyframeIndexes: moved.removedKeyframeIndexes,
+	});
 
 	return {
 		...status,
-		keyframes: status.keyframes
-			.map((keyframe) => ({
-				...keyframe,
-				frame: moveMap.get(keyframe.frame) ?? keyframe.frame,
-			}))
-			.sort((a, b) => a.frame - b.frame),
+		keyframes: moved.keyframes,
+		easing,
 	};
 };
 

--- a/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
@@ -94,7 +94,7 @@ test('optimisticMoveSequenceKeyframes resorts when moving past an adjacent keyfr
 	expect(status.easing).toEqual(['linear', 'linear']);
 });
 
-test('optimisticMoveSequenceKeyframes no-ops when moving onto an existing keyframe', () => {
+test('optimisticMoveSequenceKeyframes replaces an existing keyframe', () => {
 	const updated = optimisticMoveSequenceKeyframes({
 		previous,
 		keyframes: [{fieldKey: 'scale', fromFrame: 0, toFrame: 20}],
@@ -110,10 +110,10 @@ test('optimisticMoveSequenceKeyframes no-ops when moving onto an existing keyfra
 	}
 
 	expect(status.keyframes).toEqual([
-		{frame: 0, value: 1},
-		{frame: 20, value: 2},
+		{frame: 20, value: 1},
 		{frame: 40, value: 3},
 	]);
+	expect(status.easing).toEqual(['linear']);
 });
 
 test('canMoveKeyframesWithoutCollisions allows moving onto a frame vacated by another selected keyframe', () => {
@@ -183,7 +183,7 @@ test('optimisticMoveEffectKeyframes moves effect keyframes', () => {
 	]);
 });
 
-test('optimisticMoveEffectKeyframes no-ops when moving onto an existing keyframe', () => {
+test('optimisticMoveEffectKeyframes replaces an existing keyframe', () => {
 	const updated = optimisticMoveEffectKeyframes({
 		previous,
 		keyframes: [
@@ -205,10 +205,8 @@ test('optimisticMoveEffectKeyframes no-ops when moving onto an existing keyframe
 		throw new Error('expected keyframed status');
 	}
 
-	expect(status.keyframes).toEqual([
-		{frame: 0, value: 0.2},
-		{frame: 20, value: 0.5},
-	]);
+	expect(status.keyframes).toEqual([{frame: 20, value: 0.2}]);
+	expect(status.easing).toEqual([]);
 });
 
 test('optimisticMoveEffectKeyframes allows moving keyframes beyond the sequence range', () => {

--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -1,4 +1,7 @@
-import {canMoveKeyframesWithoutCollisions} from '@remotion/studio-shared';
+import {
+	canMoveKeyframesWithoutCollisions,
+	moveKeyframesInPropStatus,
+} from '@remotion/studio-shared';
 import type React from 'react';
 import {useCallback, useContext} from 'react';
 import type {
@@ -224,23 +227,17 @@ const makeMovedKeyframedDragOverride = ({
 		throw new Error('Expected a keyframe drag target');
 	}
 
-	const moves = new Map(
-		getMovesForGroup({group, delta}).map(
-			(move) => [move.fromFrame, move.toFrame] as const,
-		),
-	);
+	const movedStatus = moveKeyframesInPropStatus({
+		status: first.propStatus,
+		moves: getMovesForGroup({group, delta}),
+	});
+	if (movedStatus.status !== 'keyframed') {
+		throw new Error('Expected keyframed status');
+	}
 
 	return {
 		type: 'keyframed',
-		status: {
-			...first.propStatus,
-			keyframes: first.propStatus.keyframes
-				.map((keyframe) => ({
-					...keyframe,
-					frame: moves.get(keyframe.frame) ?? keyframe.frame,
-				}))
-				.sort((a, b) => a.frame - b.frame),
-		},
+		status: movedStatus,
 	};
 };
 


### PR DESCRIPTION
## Summary

- Replace an existing keyframe when dragging another keyframe onto the same frame
- Reuse the shared optimistic move logic for the Studio drag preview
- Keep persisted keyframe updates in sync and trim easing metadata when a keyframe is replaced

Fixes #8317.

## Testing

- `bun test packages/studio-shared/src/test/optimistic-move-keyframe.test.ts`
- `bun test packages/studio-server/src/test/update-keyframes.test.ts`
- `bun run build`
- `bun run stylecheck`
