### PR TITLE
`@remotion/studio`: Align outline toggle icons

### DIFF
--- a/packages/studio/src/components/ControlButton.tsx
+++ b/packages/studio/src/components/ControlButton.tsx
@@ -15,6 +15,8 @@ export const ControlButton = (
 		return {
 			opacity: props.disabled ? 0.5 : 1,
 			display: 'inline-flex',
+			alignItems: 'center',
+			justifyContent: 'center',
 			background: 'none',
 			border: 'none',
 			padding: CONTROL_BUTTON_PADDING,

--- a/packages/studio/src/components/ControlButton.tsx
+++ b/packages/studio/src/components/ControlButton.tsx
@@ -2,6 +2,7 @@ import React, {useMemo} from 'react';
 import {useZIndex} from '../state/z-index';
 
 export const CONTROL_BUTTON_PADDING = 6;
+export const CONTROL_BUTTON_SIZE = 30;
 
 export const ControlButton = (
 	props: React.DetailedHTMLProps<
@@ -17,9 +18,11 @@ export const ControlButton = (
 			display: 'inline-flex',
 			alignItems: 'center',
 			justifyContent: 'center',
+			width: CONTROL_BUTTON_SIZE,
+			height: CONTROL_BUTTON_SIZE,
 			background: 'none',
 			border: 'none',
-			padding: CONTROL_BUTTON_PADDING,
+			padding: 0,
 		};
 	}, [props.disabled]);
 

--- a/packages/studio/src/components/OutlineToggle.tsx
+++ b/packages/studio/src/components/OutlineToggle.tsx
@@ -24,7 +24,7 @@ export const OutlineToggle: React.FC = () => {
 			onClick={onClick}
 		>
 			<svg
-				style={{width: 16, height: 16}}
+				style={{width: 18, height: 18}}
 				viewBox="0 0 512 512"
 				fill={color}
 				aria-hidden="true"


### PR DESCRIPTION
## What does this fix?

Fixes #8309

The outline toggle icon was not visually aligned with the other toolbar controls.

## What did I change?

- Centered the contents of the shared `ControlButton`
- Kept the fix minimal so it applies consistently to the toolbar toggles

## How to verify

1. Open Remotion Studio.
2. Compare the outline toggle with the nearby toolbar buttons.
3. Confirm the icon is vertically centered.