### PR TITLE
Docs: add @remotion/shapes to effects API supported list

### DIFF
--- a/packages/docs/docs/effects/index.mdx
+++ b/packages/docs/docs/effects/index.mdx
@@ -25,6 +25,15 @@ Pass effects through the `effects` prop of these components:
 - [`<AnimatedImage>`](/docs/animatedimage)
 - [`<Gif>`](/docs/gif/gif)
 - [`<RemotionRiveCanvas>`](/docs/rive/remotionrivecanvas)
+- [`<Rect>`](/docs/shapes/rect)
+- [`<Circle>`](/docs/shapes/circle)
+- [`<Triangle>`](/docs/shapes/triangle)
+- [`<Star>`](/docs/shapes/star)
+- [`<Ellipse>`](/docs/shapes/ellipse)
+- [`<Pie>`](/docs/shapes/pie)
+- [`<Polygon>`](/docs/shapes/polygon)
+- [`<Heart>`](/docs/shapes/heart)
+- [`<Arrow>`](/docs/shapes/arrow)
 
 ## Effects
 


### PR DESCRIPTION
## What does this fix?

Fixes #8280

The `/docs/effects/api` page lists which components support the `effects` prop, but it was missing all the `@remotion/shapes` components (`<Rect>`, `<Circle>`, `<Triangle>`, etc.).

## What did I change?

Added the following shape components to the "Supported components" section in `packages/docs/docs/effects/index.mdx`:

- `<Rect>`
- `<Circle>`
- `<Triangle>`
- `<Star>`
- `<Ellipse>`
- `<Pie>`
- `<Polygon>`
- `<Heart>`
- `<Arrow>`

Each entry follows the same format as the existing entries and links to the correct docs page.

## How to verify

Visit https://www.remotion.dev/docs/effects/api (after merge) and confirm the shapes appear under "Supported components".