### PR TITLE
`@remotion/studio`: Make guides selectable

### DIFF
--- a/packages/studio/src/components/EditorGuides/Guide.tsx
+++ b/packages/studio/src/components/EditorGuides/Guide.tsx
@@ -1,6 +1,6 @@
 import {memo, useCallback, useContext, useMemo} from 'react';
 import {NoReactInternals} from 'remotion/no-react';
-import {SELECTED_GUIDE, UNSELECTED_GUIDE} from '../../helpers/colors';
+import {BLUE, SELECTED_GUIDE, UNSELECTED_GUIDE} from '../../helpers/colors';
 import type {Guide} from '../../state/editor-guides';
 import {
 	EditorShowGuidesContext,
@@ -10,6 +10,7 @@ import {RULER_WIDTH} from '../../state/editor-rulers';
 import {ContextMenu} from '../ContextMenu';
 import {forceSpecificCursor} from '../ForceSpecificCursor';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {useTimelineSelection} from '../Timeline/TimelineSelection';
 
 const PADDING_FOR_EASY_DRAG = 4;
 
@@ -27,10 +28,12 @@ const GuideComp: React.FC<{
 		shouldCreateGuideRef,
 		setGuidesList,
 		setSelectedGuideId,
+		setDraggingGuideId,
 		selectedGuideId,
 		setHoveredGuideId,
 		hoveredGuideId,
 	} = useContext(EditorShowGuidesContext);
+	const {clearSelection} = useTimelineSelection();
 
 	const onPointerEnter = useCallback(() => {
 		setHoveredGuideId(() => guide.id);
@@ -69,9 +72,11 @@ const GuideComp: React.FC<{
 			left: `${isVerticalGuide ? '0px' : `-${RULER_WIDTH}px`}`,
 			display: guide.show ? 'block' : 'none',
 			backgroundColor:
-				selectedGuideId === guide.id || hoveredGuideId === guide.id
-					? SELECTED_GUIDE
-					: UNSELECTED_GUIDE,
+				selectedGuideId === guide.id
+					? BLUE
+					: hoveredGuideId === guide.id
+						? SELECTED_GUIDE
+						: UNSELECTED_GUIDE,
 		};
 	}, [isVerticalGuide, guide.show, guide.id, selectedGuideId, hoveredGuideId]);
 
@@ -84,9 +89,17 @@ const GuideComp: React.FC<{
 
 			shouldCreateGuideRef.current = true;
 			forceSpecificCursor('no-drop');
+			clearSelection();
 			setSelectedGuideId(() => guide.id);
+			setDraggingGuideId(() => guide.id);
 		},
-		[shouldCreateGuideRef, setSelectedGuideId, guide.id],
+		[
+			shouldCreateGuideRef,
+			clearSelection,
+			setDraggingGuideId,
+			setSelectedGuideId,
+			guide.id,
+		],
 	);
 
 	const values = useMemo((): ComboboxValue[] => {

--- a/packages/studio/src/components/EditorRuler/Ruler.tsx
+++ b/packages/studio/src/components/EditorRuler/Ruler.tsx
@@ -13,6 +13,7 @@ import {drawMarkingOnRulerCanvas} from '../../helpers/editor-ruler';
 import {EditorShowGuidesContext} from '../../state/editor-guides';
 import {RULER_WIDTH} from '../../state/editor-rulers';
 import {forceSpecificCursor} from '../ForceSpecificCursor';
+import {useTimelineSelection} from '../Timeline/TimelineSelection';
 
 interface Point {
 	value: number;
@@ -50,9 +51,12 @@ const Ruler: React.FC<RulerProps> = ({
 		selectedGuideId,
 		hoveredGuideId,
 		setSelectedGuideId,
+		draggingGuideId,
+		setDraggingGuideId,
 		guidesList,
 		setEditorShowGuides,
 	} = useContext(EditorShowGuidesContext);
+	const {clearSelection} = useTimelineSelection();
 	const unsafeVideoConfig = Internals.useUnsafeVideoConfig();
 
 	if (!unsafeVideoConfig) {
@@ -70,6 +74,9 @@ const Ruler: React.FC<RulerProps> = ({
 			null
 		);
 	}, [guidesList, hoveredGuideId, selectedGuideId]);
+	const selectedOrHoveredGuideIsSelected =
+		selectedOrHoveredGuide !== null &&
+		selectedOrHoveredGuide.id === selectedGuideId;
 
 	const rulerWidth = isVerticalRuler ? RULER_WIDTH : size.width - RULER_WIDTH;
 	const rulerHeight = isVerticalRuler ? size.height - RULER_WIDTH : RULER_WIDTH;
@@ -84,6 +91,7 @@ const Ruler: React.FC<RulerProps> = ({
 			orientation,
 			rulerCanvasRef,
 			selectedGuide: selectedOrHoveredGuide,
+			selectedGuideIsSelected: selectedOrHoveredGuideIsSelected,
 			canvasHeight: rulerHeight * window.devicePixelRatio,
 			canvasWidth: rulerWidth * window.devicePixelRatio,
 		});
@@ -95,6 +103,7 @@ const Ruler: React.FC<RulerProps> = ({
 		markingGaps,
 		orientation,
 		selectedOrHoveredGuide,
+		selectedOrHoveredGuideIsSelected,
 		size,
 		rulerHeight,
 		rulerWidth,
@@ -128,7 +137,9 @@ const Ruler: React.FC<RulerProps> = ({
 			forceSpecificCursor('no-drop');
 			const guideId = makeGuideId();
 			setEditorShowGuides(() => true);
+			clearSelection();
 			setSelectedGuideId(() => guideId);
+			setDraggingGuideId(() => guideId);
 			setGuidesList((prevState) => {
 				return [
 					...prevState,
@@ -145,7 +156,9 @@ const Ruler: React.FC<RulerProps> = ({
 		[
 			shouldCreateGuideRef,
 			setEditorShowGuides,
+			clearSelection,
 			setSelectedGuideId,
+			setDraggingGuideId,
 			setGuidesList,
 			orientation,
 			originOffset,
@@ -156,18 +169,18 @@ const Ruler: React.FC<RulerProps> = ({
 	const changeCursor = useCallback(
 		(e: React.MouseEvent<HTMLCanvasElement, MouseEvent>) => {
 			e.preventDefault();
-			if (selectedGuideId !== null) {
+			if (draggingGuideId !== null) {
 				setCursor('no-drop');
 			}
 		},
-		[setCursor, selectedGuideId],
+		[setCursor, draggingGuideId],
 	);
 
 	useEffect(() => {
-		if (selectedGuideId === null) {
+		if (draggingGuideId === null) {
 			setCursor(isVerticalRuler ? 'ew-resize' : 'ns-resize');
 		}
-	}, [selectedGuideId, isVerticalRuler]);
+	}, [draggingGuideId, isVerticalRuler]);
 
 	return (
 		<canvas

--- a/packages/studio/src/components/EditorRuler/index.tsx
+++ b/packages/studio/src/components/EditorRuler/index.tsx
@@ -54,8 +54,9 @@ export const EditorRulers: React.FC<{
 		shouldCreateGuideRef,
 		shouldDeleteGuideRef,
 		setGuidesList,
-		selectedGuideId,
 		setSelectedGuideId,
+		draggingGuideId,
+		setDraggingGuideId,
 	} = useContext(EditorShowGuidesContext);
 
 	const rulerMarkingGaps = useMemo(() => {
@@ -141,7 +142,7 @@ export const EditorRulers: React.FC<{
 
 					setGuidesList((prevState) => {
 						const newGuides = prevState.map((guide) => {
-							if (guide.id !== selectedGuideId) {
+							if (guide.id !== draggingGuideId) {
 								return guide;
 							}
 
@@ -161,7 +162,7 @@ export const EditorRulers: React.FC<{
 					setGuidesList((prevState) => {
 						// Intentionally no persist, only persist on mouse up
 						return prevState.map((guide) => {
-							if (guide.id !== selectedGuideId) {
+							if (guide.id !== draggingGuideId) {
 								return guide;
 							}
 
@@ -190,7 +191,7 @@ export const EditorRulers: React.FC<{
 			containerRef,
 			shouldDeleteGuideRef,
 			setGuidesList,
-			selectedGuideId,
+			draggingGuideId,
 			scale,
 			canvasPosition.left,
 			canvasPosition.top,
@@ -204,29 +205,35 @@ export const EditorRulers: React.FC<{
 					return true;
 				}
 
-				return selected.id !== selectedGuideId;
+				return selected.id !== draggingGuideId;
 			});
 			persistGuidesList(newGuides);
 			return newGuides;
 		});
 
+		const shouldDeleteGuide = shouldDeleteGuideRef.current;
 		shouldDeleteGuideRef.current = false;
 		stopForcingSpecificCursor();
 		shouldCreateGuideRef.current = false;
-		setSelectedGuideId(() => null);
+		setDraggingGuideId(() => null);
+		if (shouldDeleteGuide) {
+			setSelectedGuideId(() => null);
+		}
+
 		document.removeEventListener('pointerup', onMouseUp);
 		document.removeEventListener('pointermove', onMouseMove);
 	}, [
-		selectedGuideId,
+		draggingGuideId,
 		shouldCreateGuideRef,
 		shouldDeleteGuideRef,
+		setDraggingGuideId,
 		setSelectedGuideId,
 		setGuidesList,
 		onMouseMove,
 	]);
 
 	useEffect(() => {
-		if (selectedGuideId !== null) {
+		if (draggingGuideId !== null) {
 			document.addEventListener('pointermove', onMouseMove);
 			document.addEventListener('pointerup', onMouseUp);
 		}
@@ -238,7 +245,7 @@ export const EditorRulers: React.FC<{
 				cancelAnimationFrame(requestAnimationFrameRef.current);
 			}
 		};
-	}, [selectedGuideId, onMouseMove, onMouseUp]);
+	}, [draggingGuideId, onMouseMove, onMouseUp]);
 
 	return (
 		<>

--- a/packages/studio/src/components/ShowGuidesProvider.tsx
+++ b/packages/studio/src/components/ShowGuidesProvider.tsx
@@ -1,10 +1,12 @@
-import React, {useCallback, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useKeybinding} from '../helpers/use-keybinding';
 import type {Guide, GuideState} from '../state/editor-guides';
 import {
 	EditorShowGuidesContext,
 	loadEditorShowGuidesOption,
 	loadGuidesList,
 	persistEditorShowGuidesOption,
+	persistGuidesList,
 } from '../state/editor-guides';
 
 export const ShowGuidesProvider: React.FC<{
@@ -12,12 +14,14 @@ export const ShowGuidesProvider: React.FC<{
 }> = ({children}) => {
 	const [guidesList, setGuidesList] = useState<Guide[]>(() => loadGuidesList());
 	const [selectedGuideId, setSelectedGuideId] = useState<string | null>(null);
+	const [draggingGuideId, setDraggingGuideId] = useState<string | null>(null);
 	const [hoveredGuideId, setHoveredGuideId] = useState<string | null>(null);
 	const [editorShowGuides, setEditorShowGuidesState] = useState(() =>
 		loadEditorShowGuidesOption(),
 	);
 	const shouldCreateGuideRef = useRef(false);
 	const shouldDeleteGuideRef = useRef(false);
+	const keybindings = useKeybinding();
 
 	const setEditorShowGuides = useCallback(
 		(newValue: (prevState: boolean) => boolean) => {
@@ -30,6 +34,59 @@ export const ShowGuidesProvider: React.FC<{
 		[],
 	);
 
+	useEffect(() => {
+		if (
+			selectedGuideId === null ||
+			guidesList.some((guide) => guide.id === selectedGuideId)
+		) {
+			return;
+		}
+
+		setSelectedGuideId(() => null);
+	}, [guidesList, selectedGuideId]);
+
+	useEffect(() => {
+		if (selectedGuideId === null) {
+			return;
+		}
+
+		const removeSelectedGuide = () => {
+			setGuidesList((prevState) => {
+				const newGuides = prevState.filter((guide) => {
+					return guide.id !== selectedGuideId;
+				});
+				persistGuidesList(newGuides);
+				return newGuides;
+			});
+			setSelectedGuideId(() => null);
+			setDraggingGuideId(() => null);
+		};
+
+		const backspace = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'Backspace',
+			callback: removeSelectedGuide,
+			commandCtrlKey: false,
+			preventDefault: true,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+		const deleteKey = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'Delete',
+			callback: removeSelectedGuide,
+			commandCtrlKey: false,
+			preventDefault: true,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+
+		return () => {
+			backspace.unregister();
+			deleteKey.unregister();
+		};
+	}, [keybindings, selectedGuideId]);
+
 	const editorShowGuidesCtx = useMemo((): GuideState => {
 		return {
 			editorShowGuides,
@@ -38,6 +95,8 @@ export const ShowGuidesProvider: React.FC<{
 			setGuidesList,
 			selectedGuideId,
 			setSelectedGuideId,
+			draggingGuideId,
+			setDraggingGuideId,
 			shouldCreateGuideRef,
 			shouldDeleteGuideRef,
 			hoveredGuideId,
@@ -48,6 +107,7 @@ export const ShowGuidesProvider: React.FC<{
 		setEditorShowGuides,
 		guidesList,
 		selectedGuideId,
+		draggingGuideId,
 		hoveredGuideId,
 	]);
 

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -18,6 +18,7 @@ import type {
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
 import {useKeybinding} from '../../helpers/use-keybinding';
+import {EditorShowGuidesContext} from '../../state/editor-guides';
 import {useZIndex} from '../../state/z-index';
 import {TimelineClipboardKeybindings} from './TimelineClipboardKeybindings';
 import {TimelineDeleteKeybindings} from './TimelineDeleteKeybindings';
@@ -649,6 +650,9 @@ export const TimelineSelectionProvider: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {setSelectedGuideId, setDraggingGuideId} = useContext(
+		EditorShowGuidesContext,
+	);
 	const canSelect =
 		previewServerState.type === 'connected' &&
 		!window.remotion_isReadOnlyStudio;
@@ -710,6 +714,8 @@ export const TimelineSelectionProvider: React.FC<{
 				return;
 			}
 
+			setSelectedGuideId(() => null);
+			setDraggingGuideId(() => null);
 			setSelectedItems((currentSelectedItems) => {
 				const orderedSelectableItems = [
 					...selectableItems.current.values(),
@@ -734,7 +740,7 @@ export const TimelineSelectionProvider: React.FC<{
 				return nextState.selectedItems;
 			});
 		},
-		[canSelectItem],
+		[canSelectItem, setDraggingGuideId, setSelectedGuideId],
 	);
 
 	const selectItems = useCallback(
@@ -743,11 +749,13 @@ export const TimelineSelectionProvider: React.FC<{
 				return;
 			}
 
+			setSelectedGuideId(() => null);
+			setDraggingGuideId(() => null);
 			selectionAnchor.current =
 				items.length === 0 ? null : items[items.length - 1];
 			setSelectedItems(items);
 		},
-		[canSelectItem],
+		[canSelectItem, setDraggingGuideId, setSelectedGuideId],
 	);
 
 	const registerSelectableItem = useCallback((item: TimelineSelection) => {
@@ -820,8 +828,10 @@ export const TimelineSelectionProvider: React.FC<{
 
 	const clearSelection = useCallback(() => {
 		selectionAnchor.current = null;
+		setSelectedGuideId(() => null);
+		setDraggingGuideId(() => null);
 		setSelectedItems([]);
-	}, []);
+	}, [setDraggingGuideId, setSelectedGuideId]);
 
 	const containsSelection = useCallback(
 		(nodePathInfo: SequenceNodePathInfo) => {

--- a/packages/studio/src/helpers/editor-ruler.ts
+++ b/packages/studio/src/helpers/editor-ruler.ts
@@ -6,6 +6,7 @@ import {
 	BACKGROUND__TRANSPARENT,
 	RULER_COLOR,
 	SELECTED_GUIDE,
+	BLUE,
 } from './colors';
 
 type Orientation = 'horizontal' | 'vertical';
@@ -72,6 +73,7 @@ const drawGuide = ({
 	canvasWidth,
 	orientation,
 	originOffset,
+	selected,
 }: {
 	selectedGuide: Guide;
 	scale: number;
@@ -81,6 +83,7 @@ const drawGuide = ({
 	canvasWidth: number;
 	orientation: Orientation;
 	originOffset: number;
+	selected: boolean;
 }) => {
 	const originDistance =
 		rulerValueToPosition({
@@ -97,7 +100,8 @@ const drawGuide = ({
 		originDistance,
 		canvasWidth,
 	});
-	context.strokeStyle = SELECTED_GUIDE;
+	const guideColor = selected ? BLUE : SELECTED_GUIDE;
+	context.strokeStyle = guideColor;
 	context.lineWidth = 1;
 	context.beginPath();
 	if (
@@ -122,7 +126,7 @@ const drawGuide = ({
 			label: selectedGuide.position.toString(),
 			originDistance,
 			orientation,
-			color: SELECTED_GUIDE,
+			color: guideColor,
 		});
 	} else if (
 		orientation === 'horizontal' &&
@@ -135,7 +139,7 @@ const drawGuide = ({
 			label: selectedGuide.position.toString(),
 			originDistance,
 			orientation,
-			color: SELECTED_GUIDE,
+			color: guideColor,
 		});
 	}
 
@@ -151,6 +155,7 @@ export const drawMarkingOnRulerCanvas = ({
 	orientation,
 	rulerCanvasRef,
 	selectedGuide,
+	selectedGuideIsSelected,
 	canvasHeight,
 	canvasWidth,
 }: {
@@ -162,6 +167,7 @@ export const drawMarkingOnRulerCanvas = ({
 	orientation: 'horizontal' | 'vertical';
 	rulerCanvasRef: React.RefObject<HTMLCanvasElement | null>;
 	selectedGuide: Guide | null;
+	selectedGuideIsSelected: boolean;
 	canvasWidth: number;
 	canvasHeight: number;
 }) => {
@@ -229,6 +235,7 @@ export const drawMarkingOnRulerCanvas = ({
 			originOffset,
 			scale,
 			selectedGuide,
+			selected: selectedGuideIsSelected,
 			startMarking,
 		});
 	}

--- a/packages/studio/src/state/editor-guides.ts
+++ b/packages/studio/src/state/editor-guides.ts
@@ -15,6 +15,8 @@ export type GuideState = {
 	setGuidesList: (cb: (prevState: Guide[]) => Guide[]) => void;
 	selectedGuideId: string | null;
 	setSelectedGuideId: (cb: (prevState: string | null) => string | null) => void;
+	draggingGuideId: string | null;
+	setDraggingGuideId: (cb: (prevState: string | null) => string | null) => void;
 	setHoveredGuideId: (cb: (prevState: string | null) => string | null) => void;
 	hoveredGuideId: string | null;
 	shouldCreateGuideRef: React.MutableRefObject<boolean>;
@@ -46,6 +48,8 @@ export const EditorShowGuidesContext = createContext<GuideState>({
 	setGuidesList: () => undefined,
 	selectedGuideId: null,
 	setSelectedGuideId: () => undefined,
+	draggingGuideId: null,
+	setDraggingGuideId: () => undefined,
 	shouldCreateGuideRef: {current: false},
 	shouldDeleteGuideRef: {current: false},
 	hoveredGuideId: null,


### PR DESCRIPTION
Fixes #8343.

## Summary

- Make Studio guides persist as an exclusive selectable element after click/drag.
- Clear timeline selection when a guide is selected, and clear guide selection when timeline selection changes.
- Delete the selected guide with Backspace/Delete without entering the visual controls undo stack.
- Render selected guides in Studio blue while retaining the existing hover accent.

## Testing

- `bun run build`
- `bun run stylecheck`
