### PR TITLE
Preserve runtime props when source status is missing

### DIFF
--- a/packages/core/src/test/drag-override-value.test.ts
+++ b/packages/core/src/test/drag-override-value.test.ts
@@ -96,6 +96,30 @@ test('computeEffectiveSchemaValuesDotNotation resolves keyframed drag overrides 
 	expect(merged.opacity).toBe(3);
 });
 
+test('computeEffectiveSchemaValuesDotNotation preserves runtime props missing from source status', () => {
+	const {merged, propsToDelete} = computeEffectiveSchemaValuesDotNotation({
+		schema: {
+			points: {
+				type: 'number',
+				default: 5,
+				hiddenFromList: false,
+			},
+		},
+		currentValue: {points: 20},
+		overrideValues: {},
+		propStatus: {
+			points: {
+				status: 'static',
+				codeValue: undefined,
+			},
+		},
+		frame: null,
+	});
+
+	expect(merged.points).toBe(20);
+	expect(propsToDelete.has('points')).toBe(false);
+});
+
 test('getEffectiveVisualModeValue resolves keyframed drag overrides at the source frame', () => {
 	const status = makeKeyframedStatus();
 

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -224,6 +224,12 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 			}
 		} else if (status.status === 'computed') {
 			value = currentValue[key];
+		} else if (
+			status.codeValue === undefined &&
+			currentValue[key] !== undefined &&
+			overrideValues[key] === undefined
+		) {
+			value = currentValue[key];
 		} else {
 			value = getEffectiveVisualModeValue({
 				propStatus: status,


### PR DESCRIPTION
## Summary

Preserve the current runtime prop value when Studio receives a static undefined status for a prop that is still present at runtime. This avoids clearing valid component props when a stale node path points at a different JSX element after a refactor.

Closes #8338