### PR TITLE
`@remotion/studio`: Add selectable guides

### DIFF
--- a/packages/studio/src/components/EditorGuides/Guide.tsx
+++ b/packages/studio/src/components/EditorGuides/Guide.tsx
@@ -10,6 +10,7 @@ import {RULER_WIDTH} from '../../state/editor-rulers';
 import {ContextMenu} from '../ContextMenu';
 import {forceSpecificCursor} from '../ForceSpecificCursor';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {useTimelineGuideSelection} from '../Timeline/TimelineSelection';
 
 const PADDING_FOR_EASY_DRAG = 4;
 
@@ -26,11 +27,13 @@ const GuideComp: React.FC<{
 	const {
 		shouldCreateGuideRef,
 		setGuidesList,
-		setSelectedGuideId,
-		selectedGuideId,
+		setDraggingGuideId,
 		setHoveredGuideId,
 		hoveredGuideId,
 	} = useContext(EditorShowGuidesContext);
+	const {clearSelection, onSelect, selected} = useTimelineGuideSelection(
+		guide.id,
+	);
 
 	const onPointerEnter = useCallback(() => {
 		setHoveredGuideId(() => guide.id);
@@ -69,11 +72,11 @@ const GuideComp: React.FC<{
 			left: `${isVerticalGuide ? '0px' : `-${RULER_WIDTH}px`}`,
 			display: guide.show ? 'block' : 'none',
 			backgroundColor:
-				selectedGuideId === guide.id || hoveredGuideId === guide.id
+				selected || hoveredGuideId === guide.id
 					? SELECTED_GUIDE
 					: UNSELECTED_GUIDE,
 		};
-	}, [isVerticalGuide, guide.show, guide.id, selectedGuideId, hoveredGuideId]);
+	}, [isVerticalGuide, guide.show, hoveredGuideId, guide.id, selected]);
 
 	const onMouseDown = useCallback(
 		(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
@@ -82,11 +85,13 @@ const GuideComp: React.FC<{
 				return;
 			}
 
+			e.stopPropagation();
 			shouldCreateGuideRef.current = true;
 			forceSpecificCursor('no-drop');
-			setSelectedGuideId(() => guide.id);
+			setDraggingGuideId(() => guide.id);
+			onSelect();
 		},
-		[shouldCreateGuideRef, setSelectedGuideId, guide.id],
+		[guide.id, onSelect, setDraggingGuideId, shouldCreateGuideRef],
 	);
 
 	const values = useMemo((): ComboboxValue[] => {
@@ -98,12 +103,15 @@ const GuideComp: React.FC<{
 				leftItem: null,
 				onClick: () => {
 					setGuidesList((prevState) => {
-						const newGuides = prevState.filter((selected) => {
-							return selected.id !== guide.id;
+						const newGuides = prevState.filter((candidate) => {
+							return candidate.id !== guide.id;
 						});
 						persistGuidesList(newGuides);
 						return newGuides;
 					});
+					if (selected) {
+						clearSelection();
+					}
 				},
 				quickSwitcherLabel: null,
 				subMenu: null,
@@ -111,7 +119,7 @@ const GuideComp: React.FC<{
 				value: 'remove',
 			},
 		];
-	}, [guide.id, setGuidesList]);
+	}, [clearSelection, guide.id, selected, setGuidesList]);
 
 	return (
 		<ContextMenu values={values} onOpen={null}>
@@ -126,7 +134,7 @@ const GuideComp: React.FC<{
 					style={guideContentStyle}
 					className={[
 						'__remotion_editor_guide_content',
-						selectedGuideId === guide.id || hoveredGuideId === guide.id
+						selected || hoveredGuideId === guide.id
 							? '__remotion_editor_guide_selected'
 							: null,
 					]

--- a/packages/studio/src/components/EditorRuler/Ruler.tsx
+++ b/packages/studio/src/components/EditorRuler/Ruler.tsx
@@ -13,6 +13,7 @@ import {drawMarkingOnRulerCanvas} from '../../helpers/editor-ruler';
 import {EditorShowGuidesContext} from '../../state/editor-guides';
 import {RULER_WIDTH} from '../../state/editor-rulers';
 import {forceSpecificCursor} from '../ForceSpecificCursor';
+import {useTimelineSelection} from '../Timeline/TimelineSelection';
 
 interface Point {
 	value: number;
@@ -47,12 +48,13 @@ const Ruler: React.FC<RulerProps> = ({
 	const {
 		shouldCreateGuideRef,
 		setGuidesList,
-		selectedGuideId,
+		draggingGuideId,
 		hoveredGuideId,
-		setSelectedGuideId,
+		setDraggingGuideId,
 		guidesList,
 		setEditorShowGuides,
 	} = useContext(EditorShowGuidesContext);
+	const {selectedItems, selectItem} = useTimelineSelection();
 	const unsafeVideoConfig = Internals.useUnsafeVideoConfig();
 
 	if (!unsafeVideoConfig) {
@@ -64,12 +66,16 @@ const Ruler: React.FC<RulerProps> = ({
 	);
 
 	const selectedOrHoveredGuide = useMemo(() => {
+		const selectedGuideId =
+			selectedItems.length === 1 && selectedItems[0]?.type === 'guide'
+				? selectedItems[0].guideId
+				: null;
 		return (
 			guidesList.find((guide) => guide.id === selectedGuideId) ??
 			guidesList.find((guide) => guide.id === hoveredGuideId) ??
 			null
 		);
-	}, [guidesList, hoveredGuideId, selectedGuideId]);
+	}, [guidesList, hoveredGuideId, selectedItems]);
 
 	const rulerWidth = isVerticalRuler ? RULER_WIDTH : size.width - RULER_WIDTH;
 	const rulerHeight = isVerticalRuler ? size.height - RULER_WIDTH : RULER_WIDTH;
@@ -128,7 +134,8 @@ const Ruler: React.FC<RulerProps> = ({
 			forceSpecificCursor('no-drop');
 			const guideId = makeGuideId();
 			setEditorShowGuides(() => true);
-			setSelectedGuideId(() => guideId);
+			setDraggingGuideId(() => guideId);
+			selectItem({type: 'guide', guideId});
 			setGuidesList((prevState) => {
 				return [
 					...prevState,
@@ -145,7 +152,8 @@ const Ruler: React.FC<RulerProps> = ({
 		[
 			shouldCreateGuideRef,
 			setEditorShowGuides,
-			setSelectedGuideId,
+			setDraggingGuideId,
+			selectItem,
 			setGuidesList,
 			orientation,
 			originOffset,
@@ -156,18 +164,18 @@ const Ruler: React.FC<RulerProps> = ({
 	const changeCursor = useCallback(
 		(e: React.MouseEvent<HTMLCanvasElement, MouseEvent>) => {
 			e.preventDefault();
-			if (selectedGuideId !== null) {
+			if (draggingGuideId !== null) {
 				setCursor('no-drop');
 			}
 		},
-		[setCursor, selectedGuideId],
+		[setCursor, draggingGuideId],
 	);
 
 	useEffect(() => {
-		if (selectedGuideId === null) {
+		if (draggingGuideId === null) {
 			setCursor(isVerticalRuler ? 'ew-resize' : 'ns-resize');
 		}
-	}, [selectedGuideId, isVerticalRuler]);
+	}, [draggingGuideId, isVerticalRuler]);
 
 	return (
 		<canvas

--- a/packages/studio/src/components/EditorRuler/index.tsx
+++ b/packages/studio/src/components/EditorRuler/index.tsx
@@ -25,6 +25,7 @@ import {
 	forceSpecificCursor,
 	stopForcingSpecificCursor,
 } from '../ForceSpecificCursor';
+import {useTimelineSelection} from '../Timeline/TimelineSelection';
 import Ruler from './Ruler';
 
 const originBlockStyles: React.CSSProperties = {
@@ -54,9 +55,10 @@ export const EditorRulers: React.FC<{
 		shouldCreateGuideRef,
 		shouldDeleteGuideRef,
 		setGuidesList,
-		selectedGuideId,
-		setSelectedGuideId,
+		draggingGuideId,
+		setDraggingGuideId,
 	} = useContext(EditorShowGuidesContext);
+	const {clearSelection} = useTimelineSelection();
 
 	const rulerMarkingGaps = useMemo(() => {
 		const minimumGap = MINIMUM_RULER_MARKING_GAP_PX;
@@ -141,7 +143,7 @@ export const EditorRulers: React.FC<{
 
 					setGuidesList((prevState) => {
 						const newGuides = prevState.map((guide) => {
-							if (guide.id !== selectedGuideId) {
+							if (guide.id !== draggingGuideId) {
 								return guide;
 							}
 
@@ -161,7 +163,7 @@ export const EditorRulers: React.FC<{
 					setGuidesList((prevState) => {
 						// Intentionally no persist, only persist on mouse up
 						return prevState.map((guide) => {
-							if (guide.id !== selectedGuideId) {
+							if (guide.id !== draggingGuideId) {
 								return guide;
 							}
 
@@ -190,7 +192,7 @@ export const EditorRulers: React.FC<{
 			containerRef,
 			shouldDeleteGuideRef,
 			setGuidesList,
-			selectedGuideId,
+			draggingGuideId,
 			scale,
 			canvasPosition.left,
 			canvasPosition.top,
@@ -204,29 +206,34 @@ export const EditorRulers: React.FC<{
 					return true;
 				}
 
-				return selected.id !== selectedGuideId;
+				return selected.id !== draggingGuideId;
 			});
 			persistGuidesList(newGuides);
 			return newGuides;
 		});
 
+		if (shouldDeleteGuideRef.current) {
+			clearSelection();
+		}
+
 		shouldDeleteGuideRef.current = false;
 		stopForcingSpecificCursor();
 		shouldCreateGuideRef.current = false;
-		setSelectedGuideId(() => null);
+		setDraggingGuideId(() => null);
 		document.removeEventListener('pointerup', onMouseUp);
 		document.removeEventListener('pointermove', onMouseMove);
 	}, [
-		selectedGuideId,
+		clearSelection,
+		draggingGuideId,
 		shouldCreateGuideRef,
 		shouldDeleteGuideRef,
-		setSelectedGuideId,
+		setDraggingGuideId,
 		setGuidesList,
 		onMouseMove,
 	]);
 
 	useEffect(() => {
-		if (selectedGuideId !== null) {
+		if (draggingGuideId !== null) {
 			document.addEventListener('pointermove', onMouseMove);
 			document.addEventListener('pointerup', onMouseUp);
 		}
@@ -238,7 +245,7 @@ export const EditorRulers: React.FC<{
 				cancelAnimationFrame(requestAnimationFrameRef.current);
 			}
 		};
-	}, [selectedGuideId, onMouseMove, onMouseUp]);
+	}, [draggingGuideId, onMouseMove, onMouseUp]);
 
 	return (
 		<>

--- a/packages/studio/src/components/ShowGuidesProvider.tsx
+++ b/packages/studio/src/components/ShowGuidesProvider.tsx
@@ -11,7 +11,7 @@ export const ShowGuidesProvider: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
 	const [guidesList, setGuidesList] = useState<Guide[]>(() => loadGuidesList());
-	const [selectedGuideId, setSelectedGuideId] = useState<string | null>(null);
+	const [draggingGuideId, setDraggingGuideId] = useState<string | null>(null);
 	const [hoveredGuideId, setHoveredGuideId] = useState<string | null>(null);
 	const [editorShowGuides, setEditorShowGuidesState] = useState(() =>
 		loadEditorShowGuidesOption(),
@@ -36,8 +36,8 @@ export const ShowGuidesProvider: React.FC<{
 			setEditorShowGuides,
 			guidesList,
 			setGuidesList,
-			selectedGuideId,
-			setSelectedGuideId,
+			draggingGuideId,
+			setDraggingGuideId,
 			shouldCreateGuideRef,
 			shouldDeleteGuideRef,
 			hoveredGuideId,
@@ -47,7 +47,7 @@ export const ShowGuidesProvider: React.FC<{
 		editorShowGuides,
 		setEditorShowGuides,
 		guidesList,
-		selectedGuideId,
+		draggingGuideId,
 		hoveredGuideId,
 	]);
 

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -362,8 +362,11 @@ export const getPasteEffectPropTarget = ({
 		return {type: 'none'};
 	}
 
-	if (!selection.nodePathInfo.supportsEffects) {
-		return {type: 'unsupported'};
+	if (
+		selection.type !== 'sequence-effect-prop' &&
+		selection.type !== 'sequence-effect'
+	) {
+		return {type: 'none'};
 	}
 
 	const target =
@@ -372,15 +375,13 @@ export const getPasteEffectPropTarget = ({
 					effectIndex: selection.i,
 					fieldKey: selection.key,
 				}
-			: selection.type === 'sequence-effect'
-				? {
-						effectIndex: selection.i,
-						fieldKey: payload.key,
-					}
-				: null;
+			: {
+					effectIndex: selection.i,
+					fieldKey: payload.key,
+				};
 
-	if (target === null) {
-		return {type: 'none'};
+	if (!selection.nodePathInfo.supportsEffects) {
+		return {type: 'unsupported'};
 	}
 
 	if (

--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -3,6 +3,10 @@ import {useContext, useEffect} from 'react';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {useKeybinding} from '../../helpers/use-keybinding';
+import {
+	EditorShowGuidesContext,
+	persistGuidesList,
+} from '../../state/editor-guides';
 import {useConfirmationDialog} from '../ConfirmationDialog';
 import {deleteSelectedTimelineItems} from './delete-selected-timeline-item';
 import {duplicateSelectedTimelineItems} from './duplicate-selected-timeline-item';
@@ -27,6 +31,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		Internals.VisualModePropStatusesRefContext,
 	);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
+	const {setGuidesList} = useContext(EditorShowGuidesContext);
 	const {canSelect} = useTimelineSelection();
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 	const confirm = useConfirmationDialog();
@@ -42,6 +47,19 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 			const sequences = sequencesRef.current;
 			const propStatuses = propStatusesRef.current;
 			if (selectedItems.length === 0) {
+				return;
+			}
+
+			const selectedGuide = selectedItems.find((item) => item.type === 'guide');
+			if (selectedGuide) {
+				setGuidesList((prevGuides) => {
+					const newGuides = prevGuides.filter(
+						(guide) => guide.id !== selectedGuide.guideId,
+					);
+					persistGuidesList(newGuides);
+					return newGuides;
+				});
+				clearSelection();
 				return;
 			}
 
@@ -155,6 +173,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		propStatusesRef,
 		previewServerState,
 		sequencesRef,
+		setGuidesList,
 		setPropStatuses,
 	]);
 

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -65,40 +65,47 @@ export const getTimelineSelectedTrackHighlightStyle = (
 export const TIMELINE_BACKGROUND = '#0F1113';
 export const TIMELINE_TICKS_BACKGROUND = BACKGROUND;
 
-type TimelineSelectionBase = {
-	readonly nodePathInfo: SequenceNodePathInfo;
-};
-
 export type TimelineSelection =
-	| (TimelineSelectionBase & {
+	| {
+			readonly type: 'guide';
+			readonly guideId: string;
+	  }
+	| {
 			readonly type: 'sequence';
-	  })
-	| (TimelineSelectionBase & {
+			readonly nodePathInfo: SequenceNodePathInfo;
+	  }
+	| {
 			readonly type: 'sequence-prop';
+			readonly nodePathInfo: SequenceNodePathInfo;
 			readonly key: string;
-	  })
-	| (TimelineSelectionBase & {
+	  }
+	| {
 			readonly type: 'sequence-all-effects';
-	  })
-	| (TimelineSelectionBase & {
+			readonly nodePathInfo: SequenceNodePathInfo;
+	  }
+	| {
 			readonly type: 'sequence-effect';
+			readonly nodePathInfo: SequenceNodePathInfo;
 			readonly i: number;
-	  })
-	| (TimelineSelectionBase & {
+	  }
+	| {
 			readonly type: 'sequence-effect-prop';
+			readonly nodePathInfo: SequenceNodePathInfo;
 			readonly i: number;
 			readonly key: string;
-	  })
-	| (TimelineSelectionBase & {
+	  }
+	| {
 			readonly type: 'keyframe';
+			readonly nodePathInfo: SequenceNodePathInfo;
 			readonly frame: number;
-	  })
-	| (TimelineSelectionBase & {
+	  }
+	| {
 			readonly type: 'easing';
+			readonly nodePathInfo: SequenceNodePathInfo;
 			readonly fromFrame: number;
 			readonly toFrame: number;
 			readonly segmentIndex: number;
-	  });
+	  };
 
 export type TimelineEasingSelection = Extract<
 	TimelineSelection,
@@ -247,6 +254,13 @@ export const getTimelineSelectionAfterInteraction = ({
 }): TimelineSelectionState => {
 	const {selectedItems, anchor: previousAnchor} = currentState;
 	const clickedType = getTimelineSelectionType(clickedItem);
+	if (clickedType === 'guide') {
+		return {
+			selectedItems: [clickedItem],
+			anchor: clickedItem,
+		};
+	}
+
 	const nextAnchor = getTimelineSelectionAnchor(
 		selectedItems,
 		previousAnchor,
@@ -525,18 +539,27 @@ export const getTimelineSelectionFromNodePathInfo = (
 };
 
 export const getTimelineSelectionKey = (item: TimelineSelection): string => {
-	const sequenceKey = getTimelineSequenceSelectionKey(item.nodePathInfo);
 	switch (item.type) {
+		case 'guide':
+			return `guide.${item.guideId}`;
 		case 'sequence':
-			return `${sequenceKey}.sequence`;
+			return `${getTimelineSequenceSelectionKey(item.nodePathInfo)}.sequence`;
 		case 'sequence-prop':
-			return `${sequenceKey}.sequence-prop.${item.key}`;
+			return `${getTimelineSequenceSelectionKey(
+				item.nodePathInfo,
+			)}.sequence-prop.${item.key}`;
 		case 'sequence-all-effects':
-			return `${sequenceKey}.sequence-all-effects`;
+			return `${getTimelineSequenceSelectionKey(
+				item.nodePathInfo,
+			)}.sequence-all-effects`;
 		case 'sequence-effect':
-			return `${sequenceKey}.sequence-effect.${item.i}`;
+			return `${getTimelineSequenceSelectionKey(
+				item.nodePathInfo,
+			)}.sequence-effect.${item.i}`;
 		case 'sequence-effect-prop':
-			return `${sequenceKey}.sequence-effect-prop.${item.i}.${item.key}`;
+			return `${getTimelineSequenceSelectionKey(
+				item.nodePathInfo,
+			)}.sequence-effect-prop.${item.i}.${item.key}`;
 		case 'keyframe':
 			return `${timelineNodePathInfoToKey(item.nodePathInfo)}.keyframe.${
 				item.frame
@@ -819,8 +842,10 @@ export const TimelineSelectionProvider: React.FC<{
 
 	const containsSelection = useCallback(
 		(nodePathInfo: SequenceNodePathInfo) => {
-			return selectedItems.some((selected) =>
-				nodePathDescendsFrom(selected.nodePathInfo, nodePathInfo),
+			return selectedItems.some(
+				(selected) =>
+					selected.type !== 'guide' &&
+					nodePathDescendsFrom(selected.nodePathInfo, nodePathInfo),
 			);
 		},
 		[selectedItems],
@@ -1138,6 +1163,41 @@ export const useTimelineEasingSelection = ({
 	);
 
 	return {
+		onSelect,
+		selectable: canSelect,
+		selected,
+		selectionItem,
+	};
+};
+
+export const useTimelineGuideSelection = (guideId: string) => {
+	const {
+		canSelect,
+		clearSelection,
+		isSelected,
+		selectItem,
+		registerSelectableItem,
+	} = useTimelineSelection();
+	const selectionItem = useMemo(
+		(): TimelineSelection => ({
+			type: 'guide',
+			guideId,
+		}),
+		[guideId],
+	);
+
+	useEffect(() => {
+		return registerSelectableItem(selectionItem);
+	}, [registerSelectableItem, selectionItem]);
+
+	const selected = isSelected(selectionItem);
+
+	const onSelect = useCallback(() => {
+		selectItem(selectionItem);
+	}, [selectItem, selectionItem]);
+
+	return {
+		clearSelection,
 		onSelect,
 		selectable: canSelect,
 		selected,

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -166,6 +166,8 @@ export const deleteSelectedTimelineItem = ({
 	}
 
 	switch (selection.type) {
+		case 'guide':
+			return null;
 		case 'sequence':
 			return deleteSequences([selection.nodePathInfo], confirm);
 		case 'sequence-effect':
@@ -290,6 +292,8 @@ export const deleteSelectedTimelineItems = ({
 	assertTimelineSelectionsHaveSameType(selections);
 
 	switch (firstSelection.type) {
+		case 'guide':
+			return null;
 		case 'sequence':
 			return deleteSequences(
 				selections

--- a/packages/studio/src/components/selected-outline-measurement.ts
+++ b/packages/studio/src/components/selected-outline-measurement.ts
@@ -323,9 +323,9 @@ export const getSequenceKeysContainingSelection = (
 	selectedItems: readonly TimelineSelection[],
 ): Set<string> => {
 	return new Set(
-		selectedItems.map((item) =>
-			getTimelineSequenceSelectionKey(item.nodePathInfo),
-		),
+		selectedItems
+			.filter((item) => item.type !== 'guide')
+			.map((item) => getTimelineSequenceSelectionKey(item.nodePathInfo)),
 	);
 };
 

--- a/packages/studio/src/state/editor-guides.ts
+++ b/packages/studio/src/state/editor-guides.ts
@@ -13,8 +13,8 @@ export type GuideState = {
 	setEditorShowGuides: (cb: (prevState: boolean) => boolean) => void;
 	guidesList: Guide[];
 	setGuidesList: (cb: (prevState: Guide[]) => Guide[]) => void;
-	selectedGuideId: string | null;
-	setSelectedGuideId: (cb: (prevState: string | null) => string | null) => void;
+	draggingGuideId: string | null;
+	setDraggingGuideId: (cb: (prevState: string | null) => string | null) => void;
 	setHoveredGuideId: (cb: (prevState: string | null) => string | null) => void;
 	hoveredGuideId: string | null;
 	shouldCreateGuideRef: React.MutableRefObject<boolean>;
@@ -44,8 +44,8 @@ export const EditorShowGuidesContext = createContext<GuideState>({
 	setEditorShowGuides: () => undefined,
 	guidesList: [],
 	setGuidesList: () => undefined,
-	selectedGuideId: null,
-	setSelectedGuideId: () => undefined,
+	draggingGuideId: null,
+	setDraggingGuideId: () => undefined,
 	shouldCreateGuideRef: {current: false},
 	shouldDeleteGuideRef: {current: false},
 	hoveredGuideId: null,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -3229,6 +3229,45 @@ test('Cmd/Ctrl+click replaces incompatible mixed selections', () => {
 	});
 });
 
+test('Guide selections are single selections and incompatible with timeline items', () => {
+	const guideA = {type: 'guide' as const, guideId: 'guide-a'};
+	const guideB = {type: 'guide' as const, guideId: 'guide-b'};
+	const rowA = {
+		type: 'sequence' as const,
+		nodePathInfo: makeNodePathInfo(['body', 0], []),
+	};
+
+	expect(getTimelineSelectionKey(guideA)).toBe('guide.guide-a');
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [rowA],
+				anchor: rowA,
+			},
+			clickedItem: guideA,
+			interaction: {shiftKey: false, toggleKey: true},
+			allSelectableItems: [rowA, guideA, guideB],
+		}),
+	).toEqual({
+		selectedItems: [guideA],
+		anchor: guideA,
+	});
+	expect(
+		getTimelineSelectionAfterInteraction({
+			currentState: {
+				selectedItems: [guideA],
+				anchor: guideA,
+			},
+			clickedItem: guideB,
+			interaction: {shiftKey: true, toggleKey: false},
+			allSelectableItems: [rowA, guideA, guideB],
+		}),
+	).toEqual({
+		selectedItems: [guideB],
+		anchor: guideB,
+	});
+});
+
 test('Shift+click selects a contiguous row range from the anchor', () => {
 	const rowA = {
 		type: 'sequence' as const,


### PR DESCRIPTION
## Summary

- Add guides as a `TimelineSelection` variant so they share the existing Studio selection model
- Keep guide dragging as separate interaction state while preserving selected guide highlighting
- Delete selected guides with Backspace/Delete without going through timeline undo helpers
- Guard timeline-only helpers from guide selections and add selection tests

Closes #8343.

## Test plan

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`
