### PR TITLE
Docs: Add RemotionUI to resources page

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -121,6 +121,7 @@ This list tries to compile all templates, libraries, building blocks and example
 
 - Free Remotion Animations & Effects ([Source Code](https://github.com/reactvideoeditor/remotion-templates), [Preview](https://www.reactvideoeditor.com/remotion-templates?utm_source=remotion))
 - [Onda](https://onda.video/) - Open-source Remotion component library with 70 components and 18 transitions ([Source Code](https://github.com/degueba/onda), [NPM](https://www.npmjs.com/package/ondajs))
+- [RemotionUI](https://remotionui.com) - Production-ready motion components for Remotion with CLI, docs previews, and AI agent indexes ([Source code](https://github.com/riaz37/remotion-ui), [NPM](https://www.npmjs.com/package/remotion-ui))
 - [TikTok Text Box](https://github.com/KyleTryon/TikTokTextBox)
 
 ## Videos


### PR DESCRIPTION
## Summary

Follow-up to #8380 — that merge landed without file changes. This PR adds the RemotionUI entry to the resources page under **Components**.

RemotionUI is a registry-first component kit for Remotion — install primitives, scenes, and compositions as source with `npx remotion-ui add`. Includes live docs previews and AI-readable component/recipe indexes.

- Site: https://remotionui.com
- GitHub: https://github.com/riaz37/remotion-ui
- npm: https://www.npmjs.com/package/remotion-ui

## Test plan

- [ ] RemotionUI link appears under Components on the resources page
- [ ] Site, GitHub, and npm links resolve correctly

Made with [Cursor](https://cursor.com)