### PR TITLE
Docs: Update jump cuts snippet to recommend premounting pattern

### DIFF
--- a/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
+++ b/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
@@ -7,13 +7,14 @@ crumb: 'Snippets'
 
 Sometimes you want to implement a "jump cut" to skip parts of a video (for example to cut out the "uhm"s).
 
-## Recommended: Pre-mounting multiple video tags
+## Best practice: Pre-mounting multiple video tags
 
-The recommended approach for smooth jump-cut playback in the browser is to pre-mount a separate `<OffthreadVideo>` tag for each section using [`<Series>`](/docs/series) with a `premountFor` prop. This gives the browser time to preload each segment before it starts playing.
+The recommended approach for smooth jump-cut playback in the browser is to pre-mount a separate [`<Video>` from `@remotion/media`](/docs/media/video) tag for each section using [`<Series>`](/docs/series) with a `premountFor` prop. This gives the browser time to preload each segment before it starts playing.
 
 ```tsx twoslash title="JumpCuts.tsx"
+import {Video} from '@remotion/media';
 import React from 'react';
-import {CalculateMetadataFunction, OffthreadVideo, Series, staticFile, useVideoConfig} from 'remotion';
+import {CalculateMetadataFunction, Series, staticFile, useVideoConfig} from 'remotion';
 
 const fps = 30;
 
@@ -55,12 +56,7 @@ export const JumpCuts: React.FC<Props> = ({sections}) => {
           key={i}
           durationInFrames={section.trimAfter - section.trimBefore}
         >
-          <OffthreadVideo
-            pauseWhenBuffering
-            trimBefore={section.trimBefore}
-            trimAfter={section.trimAfter}
-            src={staticFile('time.mp4')}
-          />
+          <Video pauseWhenBuffering trimBefore={section.trimBefore} trimAfter={section.trimAfter} src={staticFile('time.mp4')} />
         </Series.Sequence>
       ))}
     </Series>
@@ -72,90 +68,6 @@ export const JumpCuts: React.FC<Props> = ({sections}) => {
 These considerations apply only to smooth previews in the browser.  
 During rendering, videos will be frame-perfect regardless of the approach you use.
 :::
-
-## Alternative: Re-using the same video tag
-
-If the jump is small (around 1-2 seconds), the browser may have already preloaded the target position. In this case, reusing the same video tag can work well.
-
-For tiny jumps (&lt;0.45sec), Remotion might not seek due to the [`acceptableTimeshiftInSeconds`](/docs/offthreadvideo#acceptabletimeshiftinseconds) prop. Temporarily setting it to a very small value forces a seek.
-
-```tsx twoslash
-import React, {useMemo} from 'react';
-import {CalculateMetadataFunction, OffthreadVideo, staticFile, useCurrentFrame} from 'remotion';
-
-const fps = 30;
-
-type Section = {
-  trimBefore: number;
-  trimAfter: number;
-};
-
-export const SAMPLE_SECTIONS: Section[] = [
-  {trimBefore: 0, trimAfter: 5 * fps},
-  {
-    trimBefore: 7 * fps,
-    trimAfter: 10 * fps,
-  },
-  {
-    trimBefore: 13 * fps,
-    trimAfter: 18 * fps,
-  },
-];
-
-type Props = {
-  sections: Section[];
-};
-
-export const calculateMetadata: CalculateMetadataFunction<Props> = ({props}) => {
-  const durationInFrames = props.sections.reduce((acc, section) => {
-    return acc + section.trimAfter - section.trimBefore;
-  }, 0);
-
-  return {
-    fps,
-    durationInFrames,
-  };
-};
-
-export const JumpCuts: React.FC<Props> = ({sections}) => {
-  const frame = useCurrentFrame();
-
-  const cut = useMemo(() => {
-    let summedUpDurations = 0;
-    for (const section of sections) {
-      summedUpDurations += section.trimAfter - section.trimBefore;
-      if (summedUpDurations > frame) {
-        const trimBefore = section.trimAfter - summedUpDurations;
-        const offset = section.trimBefore - frame - trimBefore;
-
-        return {
-          trimBefore,
-          firstFrameOfSection: offset === 0,
-        };
-      }
-    }
-
-    return null;
-  }, [frame, sections]);
-
-  if (cut === null) {
-    return null;
-  }
-
-  return (
-    <OffthreadVideo
-      pauseWhenBuffering
-      trimBefore={cut.trimBefore}
-      // Remotion will automatically add a time fragment to the end of the video URL
-      // based on `trimBefore` and `trimAfter`. Opt out of this by adding one yourself.
-      // https://www.remotion.dev/docs/media-fragments
-      src={`${staticFile('time.mp4')}#t=0,`}
-      // Force Remotion to seek when it jumps even just a tiny bit
-      acceptableTimeShiftInSeconds={cut.firstFrameOfSection ? 0.000001 : undefined}
-    />
-  );
-};
-```
 
 ## See also
 

--- a/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
+++ b/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
@@ -56,7 +56,7 @@ export const JumpCuts: React.FC<Props> = ({sections}) => {
           key={i}
           durationInFrames={section.trimAfter - section.trimBefore}
         >
-          <Video pauseWhenBuffering trimBefore={section.trimBefore} trimAfter={section.trimAfter} src={staticFile('time.mp4')} />
+          <Video trimBefore={section.trimBefore} trimAfter={section.trimAfter} src={staticFile('time.mp4')} />
         </Series.Sequence>
       ))}
     </Series>

--- a/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
+++ b/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
@@ -5,32 +5,79 @@ sidebar_label: Jump Cuts
 crumb: 'Snippets'
 ---
 
-Sometimes you want to implement a "jump cut" to skip parts of a video (for example to cut out the "uhm"s).  
-You have the following considerations to make:
+Sometimes you want to implement a "jump cut" to skip parts of a video (for example to cut out the "uhm"s).
 
-<div>
-  <div>
-    <Step>1</Step> The browser might have already preloaded a small portion of the future of the video (around 1-2 seconds). In this case, it would be useful to reuse the same video tag.
-  </div>
-  <div>
-    <Step>2</Step> A jump far into the future will not be loaded yet. In this case, the video tag should not be re-used, rather a second one should be [premounted](/docs/player/premounting) so it can preload.
-  </div>
-  <div>
-    <Step>3</Step> If the jump is tiny (&lt;0.45sec), Remotion might not seek due to the [`acceptableTimeshiftInSeconds`](/docs/offthreadvideo#acceptabletimeshiftinseconds) prop. You might have to decrease it temporarily.
-  </div>
-</div>
+## Recommended: Pre-mounting multiple video tags
+
+The recommended approach for smooth jump-cut playback in the browser is to pre-mount a separate `<OffthreadVideo>` tag for each section using [`<Series>`](/docs/series) with a `premountFor` prop. This gives the browser time to preload each segment before it starts playing.
+
+```tsx twoslash title="JumpCuts.tsx"
+import React from 'react';
+import {CalculateMetadataFunction, OffthreadVideo, Series, staticFile, useVideoConfig} from 'remotion';
+
+const fps = 30;
+
+type Section = {
+  trimBefore: number;
+  trimAfter: number;
+};
+
+export const SAMPLE_SECTIONS: Section[] = [
+  {trimBefore: 0, trimAfter: 5 * fps},
+  {trimBefore: 7 * fps, trimAfter: 10 * fps},
+  {trimBefore: 13 * fps, trimAfter: 18 * fps},
+];
+
+type Props = {
+  sections: Section[];
+};
+
+export const calculateMetadata: CalculateMetadataFunction<Props> = ({props}) => {
+  const durationInFrames = props.sections.reduce((acc, section) => {
+    return acc + section.trimAfter - section.trimBefore;
+  }, 0);
+
+  return {
+    fps,
+    durationInFrames,
+  };
+};
+
+export const JumpCuts: React.FC<Props> = ({sections}) => {
+  const {fps: videoFps} = useVideoConfig();
+
+  return (
+    <Series>
+      {sections.map((section, i) => (
+        <Series.Sequence
+          // Premount the next segment so it can preload before it starts playing
+          premountFor={4 * videoFps}
+          key={i}
+          durationInFrames={section.trimAfter - section.trimBefore}
+        >
+          <OffthreadVideo
+            pauseWhenBuffering
+            trimBefore={section.trimBefore}
+            trimAfter={section.trimAfter}
+            src={staticFile('time.mp4')}
+          />
+        </Series.Sequence>
+      ))}
+    </Series>
+  );
+};
+```
 
 :::note
-These considerations are only for smooth previews in the browser.  
-During rendering, videos will be frame-perfect even if you do not follow these considerations.
+These considerations apply only to smooth previews in the browser.  
+During rendering, videos will be frame-perfect regardless of the approach you use.
 :::
 
-## Re-using the same video tag
+## Alternative: Re-using the same video tag
 
-For case <InlineStep style={{marginLeft: 5}}>1</InlineStep> where you make a small jump, it makes sense to re-use the same video tag.  
-The following snippet shows how to do this.
+If the jump is small (around 1-2 seconds), the browser may have already preloaded the target position. In this case, reusing the same video tag can work well.
 
-In case of <InlineStep style={{marginLeft: 5}}>3</InlineStep> we are temporarily disabling the [`acceptableTimeshiftInSeconds`](/docs/offthreadvideo#acceptabletimeshiftinseconds) prop for force a seek even if it is a tiny jump.
+For tiny jumps (&lt;0.45sec), Remotion might not seek due to the [`acceptableTimeshiftInSeconds`](/docs/offthreadvideo#acceptabletimeshiftinseconds) prop. Temporarily setting it to a very small value forces a seek.
 
 ```tsx twoslash
 import React, {useMemo} from 'react';
@@ -110,12 +157,9 @@ export const JumpCuts: React.FC<Props> = ({sections}) => {
 };
 ```
 
-## Pre-mounting a second video tag
-
-In case <InlineStep style={{marginLeft: 5}}>2</InlineStep> where you make a large jump, it makes sense to pre-mount a second video tag.  
-See [Playing videos in sequence](/docs/videos/sequence) for how to do this.
-
 ## See also
 
+- [Playing videos in sequence](/docs/videos/sequence)
+- [Premounting](/docs/player/premounting)
 - [Different segments at different speeds](/docs/miscellaneous/snippets/different-segments-at-different-speeds)
 - [Change the speed of a video over time](/docs/miscellaneous/snippets/accelerated-video)

--- a/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
+++ b/packages/docs/docs/miscellaneous/snippets/jumpcuts.mdx
@@ -51,8 +51,8 @@ export const JumpCuts: React.FC<Props> = ({sections}) => {
     <Series>
       {sections.map((section, i) => (
         <Series.Sequence
-          // Premount the next segment so it can preload before it starts playing
-          premountFor={4 * videoFps}
+          // Premount the next segment for 1.5 seconds so it can preload before it starts playing
+          premountFor={Math.round(1.5 * videoFps)}
           key={i}
           durationInFrames={section.trimAfter - section.trimBefore}
         >
@@ -66,7 +66,7 @@ export const JumpCuts: React.FC<Props> = ({sections}) => {
 
 :::note
 These considerations apply only to smooth previews in the browser.  
-During rendering, videos will be frame-perfect regardless of the approach you use.
+During rendering, video frames are selected exactly, so premounting is only needed for smoother browser preview playback.
 :::
 
 ## See also


### PR DESCRIPTION
## Summary

The jump cuts snippet now leads with the recommended premounting approach: using `<Series>` with `premountFor` and a separate `<OffthreadVideo>` per section. This is the pattern JonnyBurger flagged as current best practice in the issue. The original single-tag approach is kept as a secondary option for small jumps, with a note explaining when it applies. Added links to the premounting and "Playing videos in sequence" docs in the See also section.

Fixes #8012
