### PR TITLE
`@remotion/studio`: Tune selectable guides

### DIFF
--- a/packages/studio/src/components/EditorGuides/Guide.tsx
+++ b/packages/studio/src/components/EditorGuides/Guide.tsx
@@ -1,6 +1,10 @@
-import {memo, useCallback, useContext, useMemo} from 'react';
+import {memo, useCallback, useContext, useMemo, useRef} from 'react';
 import {NoReactInternals} from 'remotion/no-react';
-import {SELECTED_GUIDE, UNSELECTED_GUIDE} from '../../helpers/colors';
+import {
+	getEditorGuideColor,
+	isGuidePointerUpAClick,
+	type GuidePointerDownPosition,
+} from '../../helpers/editor-guide-selection';
 import type {Guide} from '../../state/editor-guides';
 import {
 	EditorShowGuidesContext,
@@ -10,6 +14,7 @@ import {RULER_WIDTH} from '../../state/editor-rulers';
 import {ContextMenu} from '../ContextMenu';
 import {forceSpecificCursor} from '../ForceSpecificCursor';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR} from '../Timeline/should-clear-selection-on-pointer-down';
 import {useTimelineGuideSelection} from '../Timeline/TimelineSelection';
 
 const PADDING_FOR_EASY_DRAG = 4;
@@ -26,14 +31,17 @@ const GuideComp: React.FC<{
 }> = ({guide, canvasDimensions, scale}) => {
 	const {
 		shouldCreateGuideRef,
+		shouldDeleteGuideRef,
 		setGuidesList,
 		setDraggingGuideId,
 		setHoveredGuideId,
 		hoveredGuideId,
+		draggingGuideId,
 	} = useContext(EditorShowGuidesContext);
 	const {clearSelection, onSelect, selected} = useTimelineGuideSelection(
 		guide.id,
 	);
+	const pointerDownPositionRef = useRef<GuidePointerDownPosition | null>(null);
 
 	const onPointerEnter = useCallback(() => {
 		setHoveredGuideId(() => guide.id);
@@ -71,28 +79,74 @@ const GuideComp: React.FC<{
 			top: `${isVerticalGuide ? `-${RULER_WIDTH}px` : '0px'}`,
 			left: `${isVerticalGuide ? '0px' : `-${RULER_WIDTH}px`}`,
 			display: guide.show ? 'block' : 'none',
-			backgroundColor:
-				selected || hoveredGuideId === guide.id
-					? SELECTED_GUIDE
-					: UNSELECTED_GUIDE,
+			backgroundColor: getEditorGuideColor({
+				selected,
+				active: hoveredGuideId === guide.id || draggingGuideId === guide.id,
+			}),
 		};
-	}, [isVerticalGuide, guide.show, hoveredGuideId, guide.id, selected]);
+	}, [
+		isVerticalGuide,
+		guide.show,
+		hoveredGuideId,
+		guide.id,
+		selected,
+		draggingGuideId,
+	]);
 
-	const onMouseDown = useCallback(
-		(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-			e.preventDefault();
+	const onPointerDown = useCallback(
+		(e: React.PointerEvent<HTMLDivElement>) => {
 			if (e.button !== 0) {
 				return;
 			}
 
+			e.preventDefault();
 			e.stopPropagation();
+			pointerDownPositionRef.current = {
+				guideId: guide.id,
+				clientX: e.clientX,
+				clientY: e.clientY,
+			};
 			shouldCreateGuideRef.current = true;
 			forceSpecificCursor('no-drop');
 			setDraggingGuideId(() => guide.id);
-			onSelect();
 		},
-		[guide.id, onSelect, setDraggingGuideId, shouldCreateGuideRef],
+		[guide.id, setDraggingGuideId, shouldCreateGuideRef],
 	);
+
+	const onPointerUp = useCallback(
+		(e: React.PointerEvent<HTMLDivElement>) => {
+			const pointerDownPosition = pointerDownPositionRef.current;
+			pointerDownPositionRef.current = null;
+			if (shouldDeleteGuideRef.current) {
+				return;
+			}
+
+			if (
+				isGuidePointerUpAClick({
+					pointerDownPosition,
+					guideId: guide.id,
+					clientX: e.clientX,
+					clientY: e.clientY,
+				})
+			) {
+				onSelect();
+			}
+		},
+		[guide.id, onSelect, shouldDeleteGuideRef],
+	);
+
+	const onPointerCancel = useCallback(() => {
+		pointerDownPositionRef.current = null;
+	}, []);
+
+	const isActive = selected || hoveredGuideId === guide.id;
+	const activeClassName = isActive ? '__remotion_editor_guide_selected' : null;
+
+	const guideClassName = useMemo(() => {
+		return ['__remotion_editor_guide_content', activeClassName]
+			.filter(NoReactInternals.truthy)
+			.join(' ');
+	}, [activeClassName]);
 
 	const values = useMemo((): ComboboxValue[] => {
 		return [
@@ -125,22 +179,15 @@ const GuideComp: React.FC<{
 		<ContextMenu values={values} onOpen={null}>
 			<div
 				style={guideStyle}
-				onMouseDown={onMouseDown}
+				onPointerDown={onPointerDown}
+				onPointerUp={onPointerUp}
+				onPointerCancel={onPointerCancel}
 				className="__remotion_editor_guide"
+				{...{[PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR]: 'true'}}
 				onPointerEnter={onPointerEnter}
 				onPointerLeave={onPointerLeave}
 			>
-				<div
-					style={guideContentStyle}
-					className={[
-						'__remotion_editor_guide_content',
-						selected || hoveredGuideId === guide.id
-							? '__remotion_editor_guide_selected'
-							: null,
-					]
-						.filter(NoReactInternals.truthy)
-						.join(' ')}
-				/>
+				<div style={guideContentStyle} className={guideClassName} />
 			</div>
 		</ContextMenu>
 	);

--- a/packages/studio/src/components/EditorRuler/Ruler.tsx
+++ b/packages/studio/src/components/EditorRuler/Ruler.tsx
@@ -9,10 +9,12 @@ import React, {
 } from 'react';
 import {Internals} from 'remotion';
 import {BACKGROUND, RULER_COLOR} from '../../helpers/colors';
+import {getRulerGuideHighlight} from '../../helpers/editor-guide-selection';
 import {drawMarkingOnRulerCanvas} from '../../helpers/editor-ruler';
 import {EditorShowGuidesContext} from '../../state/editor-guides';
 import {RULER_WIDTH} from '../../state/editor-rulers';
 import {forceSpecificCursor} from '../ForceSpecificCursor';
+import {PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR} from '../Timeline/should-clear-selection-on-pointer-down';
 import {useTimelineSelection} from '../Timeline/TimelineSelection';
 
 interface Point {
@@ -54,7 +56,7 @@ const Ruler: React.FC<RulerProps> = ({
 		guidesList,
 		setEditorShowGuides,
 	} = useContext(EditorShowGuidesContext);
-	const {selectedItems, selectItem} = useTimelineSelection();
+	const {selectedItems} = useTimelineSelection();
 	const unsafeVideoConfig = Internals.useUnsafeVideoConfig();
 
 	if (!unsafeVideoConfig) {
@@ -65,17 +67,16 @@ const Ruler: React.FC<RulerProps> = ({
 		isVerticalRuler ? 'ew-resize' : 'ns-resize',
 	);
 
-	const selectedOrHoveredGuide = useMemo(() => {
-		const selectedGuideId =
-			selectedItems.length === 1 && selectedItems[0]?.type === 'guide'
-				? selectedItems[0].guideId
-				: null;
-		return (
-			guidesList.find((guide) => guide.id === selectedGuideId) ??
-			guidesList.find((guide) => guide.id === hoveredGuideId) ??
-			null
-		);
-	}, [guidesList, hoveredGuideId, selectedItems]);
+	const guideHighlight = useMemo(
+		() =>
+			getRulerGuideHighlight({
+				guidesList,
+				selectedItems,
+				hoveredGuideId,
+				draggingGuideId,
+			}),
+		[draggingGuideId, guidesList, hoveredGuideId, selectedItems],
+	);
 
 	const rulerWidth = isVerticalRuler ? RULER_WIDTH : size.width - RULER_WIDTH;
 	const rulerHeight = isVerticalRuler ? size.height - RULER_WIDTH : RULER_WIDTH;
@@ -89,7 +90,7 @@ const Ruler: React.FC<RulerProps> = ({
 			markingGaps,
 			orientation,
 			rulerCanvasRef,
-			selectedGuide: selectedOrHoveredGuide,
+			guideHighlight,
 			canvasHeight: rulerHeight * window.devicePixelRatio,
 			canvasWidth: rulerWidth * window.devicePixelRatio,
 		});
@@ -100,7 +101,7 @@ const Ruler: React.FC<RulerProps> = ({
 		originOffset,
 		markingGaps,
 		orientation,
-		selectedOrHoveredGuide,
+		guideHighlight,
 		size,
 		rulerHeight,
 		rulerWidth,
@@ -121,48 +122,47 @@ const Ruler: React.FC<RulerProps> = ({
 		[rulerWidth, rulerHeight, cursor, isVerticalRuler],
 	);
 
-	const onMouseDown: React.PointerEventHandler<HTMLCanvasElement> = useCallback(
-		(e: React.MouseEvent<HTMLCanvasElement, MouseEvent>) => {
-			if (e.button !== 0) {
-				return;
-			}
+	const onPointerDown: React.PointerEventHandler<HTMLCanvasElement> =
+		useCallback(
+			(e: React.PointerEvent<HTMLCanvasElement>) => {
+				if (e.button !== 0) {
+					return;
+				}
 
-			e.preventDefault();
-			// Prevent deselection of currently selected items
-			e.stopPropagation();
-			shouldCreateGuideRef.current = true;
-			forceSpecificCursor('no-drop');
-			const guideId = makeGuideId();
-			setEditorShowGuides(() => true);
-			setDraggingGuideId(() => guideId);
-			selectItem({type: 'guide', guideId});
-			setGuidesList((prevState) => {
-				return [
-					...prevState,
-					{
-						orientation,
-						position: -originOffset,
-						show: false,
-						id: guideId,
-						compositionId: unsafeVideoConfig.id,
-					},
-				];
-			});
-		},
-		[
-			shouldCreateGuideRef,
-			setEditorShowGuides,
-			setDraggingGuideId,
-			selectItem,
-			setGuidesList,
-			orientation,
-			originOffset,
-			unsafeVideoConfig.id,
-		],
-	);
+				e.preventDefault();
+				// Prevent deselection of currently selected items
+				e.stopPropagation();
+				shouldCreateGuideRef.current = true;
+				forceSpecificCursor('no-drop');
+				const guideId = makeGuideId();
+				setEditorShowGuides(() => true);
+				setDraggingGuideId(() => guideId);
+				setGuidesList((prevState) => {
+					return [
+						...prevState,
+						{
+							orientation,
+							position: -originOffset,
+							show: false,
+							id: guideId,
+							compositionId: unsafeVideoConfig.id,
+						},
+					];
+				});
+			},
+			[
+				shouldCreateGuideRef,
+				setEditorShowGuides,
+				setDraggingGuideId,
+				setGuidesList,
+				orientation,
+				originOffset,
+				unsafeVideoConfig.id,
+			],
+		);
 
 	const changeCursor = useCallback(
-		(e: React.MouseEvent<HTMLCanvasElement, MouseEvent>) => {
+		(e: React.PointerEvent<HTMLCanvasElement>) => {
 			e.preventDefault();
 			if (draggingGuideId !== null) {
 				setCursor('no-drop');
@@ -183,7 +183,8 @@ const Ruler: React.FC<RulerProps> = ({
 			width={rulerWidth * window.devicePixelRatio}
 			height={rulerHeight * window.devicePixelRatio}
 			style={rulerStyle}
-			onPointerDown={onMouseDown}
+			{...{[PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR]: 'true'}}
+			onPointerDown={onPointerDown}
 			onPointerEnter={changeCursor}
 			onPointerLeave={changeCursor}
 		/>

--- a/packages/studio/src/components/EditorRuler/index.tsx
+++ b/packages/studio/src/components/EditorRuler/index.tsx
@@ -58,7 +58,7 @@ export const EditorRulers: React.FC<{
 		draggingGuideId,
 		setDraggingGuideId,
 	} = useContext(EditorShowGuidesContext);
-	const {clearSelection} = useTimelineSelection();
+	const {clearSelection, selectedItems} = useTimelineSelection();
 
 	const rulerMarkingGaps = useMemo(() => {
 		const minimumGap = MINIMUM_RULER_MARKING_GAP_PX;
@@ -212,7 +212,10 @@ export const EditorRulers: React.FC<{
 			return newGuides;
 		});
 
-		if (shouldDeleteGuideRef.current) {
+		const deletedGuideWasSelected = selectedItems.some(
+			(item) => item.type === 'guide' && item.guideId === draggingGuideId,
+		);
+		if (shouldDeleteGuideRef.current && deletedGuideWasSelected) {
 			clearSelection();
 		}
 
@@ -230,6 +233,7 @@ export const EditorRulers: React.FC<{
 		setDraggingGuideId,
 		setGuidesList,
 		onMouseMove,
+		selectedItems,
 	]);
 
 	useEffect(() => {

--- a/packages/studio/src/components/Timeline/should-clear-selection-on-pointer-down.ts
+++ b/packages/studio/src/components/Timeline/should-clear-selection-on-pointer-down.ts
@@ -1,5 +1,29 @@
+export const PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR =
+	'data-remotion-prevent-selection-clear';
+
+const isSelectionClearBlocked = (target: EventTarget | null | undefined) => {
+	if (
+		target === null ||
+		target === undefined ||
+		typeof target !== 'object' ||
+		!('closest' in target) ||
+		typeof target.closest !== 'function'
+	) {
+		return false;
+	}
+
+	return (
+		target.closest(`[${PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR}]`) !== null
+	);
+};
+
 export const shouldClearSelectionOnPointerDown = (event: {
 	readonly button: number;
+	readonly target?: EventTarget | null;
 }) => {
-	return event.button === 0;
+	if (event.button !== 0) {
+		return false;
+	}
+
+	return !isSelectionClearBlocked(event.target);
 };

--- a/packages/studio/src/helpers/editor-guide-selection.ts
+++ b/packages/studio/src/helpers/editor-guide-selection.ts
@@ -1,0 +1,106 @@
+import type {Guide} from '../state/editor-guides';
+import {BLUE, SELECTED_GUIDE, UNSELECTED_GUIDE} from './colors';
+
+const GUIDE_CLICK_THRESHOLD_PX = 3;
+
+export type GuidePointerDownPosition = {
+	readonly guideId: string;
+	readonly clientX: number;
+	readonly clientY: number;
+};
+
+export type RulerGuideHighlight = {
+	readonly guide: Guide;
+	readonly color: string;
+};
+
+type SelectedTimelineItem = {
+	readonly type: string;
+	readonly guideId?: string;
+};
+
+export const isGuidePointerUpAClick = ({
+	pointerDownPosition,
+	guideId,
+	clientX,
+	clientY,
+}: {
+	readonly pointerDownPosition: GuidePointerDownPosition | null;
+	readonly guideId: string;
+	readonly clientX: number;
+	readonly clientY: number;
+}) => {
+	if (pointerDownPosition === null || pointerDownPosition.guideId !== guideId) {
+		return false;
+	}
+
+	return (
+		Math.abs(clientX - pointerDownPosition.clientX) <=
+			GUIDE_CLICK_THRESHOLD_PX &&
+		Math.abs(clientY - pointerDownPosition.clientY) <= GUIDE_CLICK_THRESHOLD_PX
+	);
+};
+
+export const getEditorGuideColor = ({
+	selected,
+	active,
+}: {
+	readonly selected: boolean;
+	readonly active: boolean;
+}) => {
+	if (selected) {
+		return BLUE;
+	}
+
+	return active ? SELECTED_GUIDE : UNSELECTED_GUIDE;
+};
+
+const findGuide = (guidesList: readonly Guide[], guideId: string | null) => {
+	if (guideId === null) {
+		return null;
+	}
+
+	return guidesList.find((guide) => guide.id === guideId) ?? null;
+};
+
+export const getRulerGuideHighlight = ({
+	guidesList,
+	selectedItems,
+	hoveredGuideId,
+	draggingGuideId,
+}: {
+	readonly guidesList: readonly Guide[];
+	readonly selectedItems: readonly SelectedTimelineItem[];
+	readonly hoveredGuideId: string | null;
+	readonly draggingGuideId: string | null;
+}): RulerGuideHighlight | null => {
+	const selectedGuideId =
+		selectedItems.length === 1 && selectedItems[0]?.type === 'guide'
+			? (selectedItems[0].guideId ?? null)
+			: null;
+	const selectedGuide = findGuide(guidesList, selectedGuideId);
+	if (selectedGuide) {
+		return {
+			guide: selectedGuide,
+			color: BLUE,
+		};
+	}
+
+	const draggingGuide = findGuide(guidesList, draggingGuideId);
+	if (draggingGuide) {
+		return {
+			guide: draggingGuide,
+			color: SELECTED_GUIDE,
+		};
+	}
+
+	const hoveredGuide = findGuide(guidesList, hoveredGuideId);
+	if (hoveredGuide) {
+		return {
+			guide: hoveredGuide,
+			color: SELECTED_GUIDE,
+		};
+	}
+
+	return null;
+};

--- a/packages/studio/src/helpers/editor-ruler.ts
+++ b/packages/studio/src/helpers/editor-ruler.ts
@@ -1,12 +1,7 @@
 import type {Size} from '@remotion/player';
-import type {Guide} from '../state/editor-guides';
 import {MINIMUM_VISIBLE_CANVAS_SIZE} from '../state/editor-rulers';
-import {
-	BACKGROUND,
-	BACKGROUND__TRANSPARENT,
-	RULER_COLOR,
-	SELECTED_GUIDE,
-} from './colors';
+import {BACKGROUND, BACKGROUND__TRANSPARENT, RULER_COLOR} from './colors';
+import type {RulerGuideHighlight} from './editor-guide-selection';
 
 type Orientation = 'horizontal' | 'vertical';
 
@@ -64,7 +59,7 @@ const drawGradient = ({
 };
 
 const drawGuide = ({
-	selectedGuide,
+	guideHighlight,
 	scale,
 	startMarking,
 	context,
@@ -73,7 +68,7 @@ const drawGuide = ({
 	orientation,
 	originOffset,
 }: {
-	selectedGuide: Guide;
+	guideHighlight: RulerGuideHighlight;
 	scale: number;
 	startMarking: number;
 	context: CanvasRenderingContext2D;
@@ -82,9 +77,10 @@ const drawGuide = ({
 	orientation: Orientation;
 	originOffset: number;
 }) => {
+	const {guide, color} = guideHighlight;
 	const originDistance =
 		rulerValueToPosition({
-			value: selectedGuide.position,
+			value: guide.position,
 			startMarking,
 			scale,
 		}) +
@@ -97,45 +93,36 @@ const drawGuide = ({
 		originDistance,
 		canvasWidth,
 	});
-	context.strokeStyle = SELECTED_GUIDE;
+	context.strokeStyle = color;
 	context.lineWidth = 1;
 	context.beginPath();
-	if (
-		orientation === 'horizontal' &&
-		selectedGuide.orientation === 'horizontal'
-	) {
+	if (orientation === 'horizontal' && guide.orientation === 'horizontal') {
 		return;
 	}
 
-	if (orientation === 'vertical' && selectedGuide.orientation === 'vertical') {
+	if (orientation === 'vertical' && guide.orientation === 'vertical') {
 		return;
 	}
 
-	if (
-		orientation === 'vertical' &&
-		selectedGuide.orientation === 'horizontal'
-	) {
+	if (orientation === 'vertical' && guide.orientation === 'horizontal') {
 		context.moveTo(0, originDistance);
 		context.lineTo(canvasWidth, originDistance);
 		drawLabel({
 			context,
-			label: selectedGuide.position.toString(),
+			label: guide.position.toString(),
 			originDistance,
 			orientation,
-			color: SELECTED_GUIDE,
+			color,
 		});
-	} else if (
-		orientation === 'horizontal' &&
-		selectedGuide.orientation === 'vertical'
-	) {
+	} else if (orientation === 'horizontal' && guide.orientation === 'vertical') {
 		context.moveTo(originDistance, 0);
 		context.lineTo(originDistance, canvasHeight);
 		drawLabel({
 			context,
-			label: selectedGuide.position.toString(),
+			label: guide.position.toString(),
 			originDistance,
 			orientation,
-			color: SELECTED_GUIDE,
+			color,
 		});
 	}
 
@@ -150,7 +137,7 @@ export const drawMarkingOnRulerCanvas = ({
 	markingGaps,
 	orientation,
 	rulerCanvasRef,
-	selectedGuide,
+	guideHighlight,
 	canvasHeight,
 	canvasWidth,
 }: {
@@ -161,7 +148,7 @@ export const drawMarkingOnRulerCanvas = ({
 	markingGaps: number;
 	orientation: 'horizontal' | 'vertical';
 	rulerCanvasRef: React.RefObject<HTMLCanvasElement | null>;
-	selectedGuide: Guide | null;
+	guideHighlight: RulerGuideHighlight | null;
 	canvasWidth: number;
 	canvasHeight: number;
 }) => {
@@ -220,15 +207,15 @@ export const drawMarkingOnRulerCanvas = ({
 		});
 	});
 
-	if (selectedGuide && orientation !== selectedGuide.orientation) {
+	if (guideHighlight && orientation !== guideHighlight.guide.orientation) {
 		drawGuide({
 			canvasHeight,
 			canvasWidth,
 			context,
-			orientation,
+			guideHighlight,
 			originOffset,
 			scale,
-			selectedGuide,
+			orientation,
 			startMarking,
 		});
 	}

--- a/packages/studio/src/test/clear-selection-on-pointer-down.test.ts
+++ b/packages/studio/src/test/clear-selection-on-pointer-down.test.ts
@@ -1,5 +1,8 @@
 import {expect, test} from 'bun:test';
-import {shouldClearSelectionOnPointerDown} from '../components/Timeline/should-clear-selection-on-pointer-down';
+import {
+	PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR,
+	shouldClearSelectionOnPointerDown,
+} from '../components/Timeline/should-clear-selection-on-pointer-down';
 
 test('left pointer down clears Studio selection', () => {
 	expect(shouldClearSelectionOnPointerDown({button: 0})).toBe(true);
@@ -8,4 +11,21 @@ test('left pointer down clears Studio selection', () => {
 test('non-left pointer down does not clear Studio selection', () => {
 	expect(shouldClearSelectionOnPointerDown({button: 1})).toBe(false);
 	expect(shouldClearSelectionOnPointerDown({button: 2})).toBe(false);
+});
+
+test('pointer down from a selection-clear blocker does not clear Studio selection', () => {
+	const target = {
+		closest: (selector: string) => {
+			return selector === `[${PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR}]`
+				? target
+				: null;
+		},
+	};
+
+	expect(
+		shouldClearSelectionOnPointerDown({
+			button: 0,
+			target: target as unknown as EventTarget,
+		}),
+	).toBe(false);
 });

--- a/packages/studio/src/test/editor-guides.test.ts
+++ b/packages/studio/src/test/editor-guides.test.ts
@@ -1,0 +1,101 @@
+import {expect, test} from 'bun:test';
+import {BLUE, SELECTED_GUIDE, UNSELECTED_GUIDE} from '../helpers/colors';
+import {
+	getEditorGuideColor,
+	getRulerGuideHighlight,
+	isGuidePointerUpAClick,
+	type GuidePointerDownPosition,
+} from '../helpers/editor-guide-selection';
+import type {Guide} from '../state/editor-guides';
+
+const guideA: Guide = {
+	compositionId: 'comp',
+	id: 'guide-a',
+	orientation: 'vertical',
+	position: 100,
+	show: true,
+};
+
+const guideB: Guide = {
+	compositionId: 'comp',
+	id: 'guide-b',
+	orientation: 'horizontal',
+	position: 200,
+	show: true,
+};
+
+test('guide pointer-up only selects after a click on the same guide', () => {
+	const pointerDownPosition: GuidePointerDownPosition = {
+		guideId: 'guide-a',
+		clientX: 120,
+		clientY: 30,
+	};
+
+	expect(
+		isGuidePointerUpAClick({
+			pointerDownPosition: null,
+			guideId: 'guide-a',
+			clientX: 120,
+			clientY: 30,
+		}),
+	).toBe(false);
+	expect(
+		isGuidePointerUpAClick({
+			pointerDownPosition,
+			guideId: 'guide-b',
+			clientX: 120,
+			clientY: 30,
+		}),
+	).toBe(false);
+	expect(
+		isGuidePointerUpAClick({
+			pointerDownPosition,
+			guideId: 'guide-a',
+			clientX: 125,
+			clientY: 30,
+		}),
+	).toBe(false);
+	expect(
+		isGuidePointerUpAClick({
+			pointerDownPosition,
+			guideId: 'guide-a',
+			clientX: 122,
+			clientY: 32,
+		}),
+	).toBe(true);
+});
+
+test('selected guides use blue while hovered or dragged guides keep the guide accent', () => {
+	expect(getEditorGuideColor({selected: true, active: true})).toBe(BLUE);
+	expect(getEditorGuideColor({selected: false, active: true})).toBe(
+		SELECTED_GUIDE,
+	);
+	expect(getEditorGuideColor({selected: false, active: false})).toBe(
+		UNSELECTED_GUIDE,
+	);
+});
+
+test('ruler shows dragged guide numbers without requiring guide selection', () => {
+	expect(
+		getRulerGuideHighlight({
+			guidesList: [guideA, guideB],
+			selectedItems: [{type: 'sequence'}],
+			hoveredGuideId: null,
+			draggingGuideId: 'guide-a',
+		}),
+	).toEqual({
+		guide: guideA,
+		color: SELECTED_GUIDE,
+	});
+	expect(
+		getRulerGuideHighlight({
+			guidesList: [guideA, guideB],
+			selectedItems: [{type: 'guide', guideId: 'guide-b'}],
+			hoveredGuideId: null,
+			draggingGuideId: 'guide-a',
+		}),
+	).toEqual({
+		guide: guideB,
+		color: BLUE,
+	});
+});


### PR DESCRIPTION
## Summary

- Keep guide creation and dragging selection-neutral so existing timeline selections stay selected.
- Select guides only from a click/pointer-up on an existing guide, and render selected guides in Studio blue.
- Keep ruler gutter guide labels visible for dragged, hovered, and selected guides, with focused test coverage.

## Testing

- `bun test src/test/editor-guides.test.ts src/test/clear-selection-on-pointer-down.test.ts`
- `bun run test` from `packages/studio`
- `bun run build`
- `bun run stylecheck`
- Browser smoke check on the worktree Studio at `http://localhost:3100`: dragging from the ruler kept a selected timeline row selected and did not blue-select the guide.

Closes #8386
