### PR TITLE
`@remotion/effects`: Fix UV origin for center-based effects

### DIFF
--- a/packages/effects/src/fisheye/fisheye-runtime.ts
+++ b/packages/effects/src/fisheye/fisheye-runtime.ts
@@ -1,4 +1,5 @@
 import {Internals} from 'remotion';
+import {publicUvToShaderUv} from '../uv-coordinate.js';
 import {FISHEYE_FS, FISHEYE_VS} from './fisheye-shaders.js';
 
 const {createWebGL2ContextError} = Internals;
@@ -206,7 +207,11 @@ export const applyFisheye = ({
 
 	gl.useProgram(program);
 	if (uniforms.uSource) gl.uniform1i(uniforms.uSource, 0);
-	if (uniforms.uCenter) gl.uniform2f(uniforms.uCenter, center[0], center[1]);
+	if (uniforms.uCenter) {
+		const shaderCenter = publicUvToShaderUv(center);
+		gl.uniform2f(uniforms.uCenter, shaderCenter[0], shaderCenter[1]);
+	}
+
 	if (uniforms.uFieldOfView) gl.uniform1f(uniforms.uFieldOfView, fieldOfView);
 	if (uniforms.uRadius) gl.uniform1f(uniforms.uRadius, radius);
 	if (uniforms.uZoom) gl.uniform1f(uniforms.uZoom, zoom);

--- a/packages/effects/src/rings.ts
+++ b/packages/effects/src/rings.ts
@@ -6,6 +6,7 @@ import {
 	validateUnitInterval,
 	type ParsedColorRgba,
 } from './color-utils.js';
+import {publicUvToShaderUv} from './uv-coordinate.js';
 import {
 	assertEffectParamsObject,
 	assertOptionalBoolean,
@@ -501,8 +502,11 @@ export const rings = createEffect<RingsParams, RingsState>({
 		if (uniforms.uPalette) gl.uniform1i(uniforms.uPalette, 1);
 		if (uniforms.uResolution) gl.uniform2f(uniforms.uResolution, width, height);
 		if (uniforms.uNumColors) gl.uniform1f(uniforms.uNumColors, r.colors.length);
-		if (uniforms.uCenter)
-			gl.uniform2f(uniforms.uCenter, r.center[0], r.center[1]);
+		if (uniforms.uCenter) {
+			const shaderCenter = publicUvToShaderUv(r.center);
+			gl.uniform2f(uniforms.uCenter, shaderCenter[0], shaderCenter[1]);
+		}
+
 		if (uniforms.uThickness) gl.uniform1f(uniforms.uThickness, r.thickness);
 		if (uniforms.uSpacing) gl.uniform1f(uniforms.uSpacing, r.spacing);
 		if (uniforms.uOffset) gl.uniform1f(uniforms.uOffset, r.offset);

--- a/packages/effects/src/test/effect-params.test.ts
+++ b/packages/effects/src/test/effect-params.test.ts
@@ -34,6 +34,7 @@ import {speckle} from '../speckle.js';
 import {tint} from '../tint.js';
 import {uvTranslate, xyTranslate} from '../translate.js';
 import {tvSignalOff} from '../tv-signal-off.js';
+import {publicUvToShaderUv} from '../uv-coordinate.js';
 import {vignette} from '../vignette.js';
 import {wave} from '../wave/index.js';
 import {waves} from '../waves.js';
@@ -55,6 +56,11 @@ const expectDefaultBlueColorArrayControl = (schema: {
 		keyframable: false,
 	});
 };
+
+test('public UV coordinates convert to shader UV coordinates', () => {
+	expect(publicUvToShaderUv([0, 0])).toEqual([0, 1]);
+	expect(publicUvToShaderUv([0.25, 0.75])).toEqual([0.25, 0.25]);
+});
 
 test('@remotion/effects expose documentation links', () => {
 	expect(barrelDistortion().definition.documentationLink).toBe(

--- a/packages/effects/src/uv-coordinate.ts
+++ b/packages/effects/src/uv-coordinate.ts
@@ -1,0 +1,7 @@
+export type UvCoordinate = readonly [number, number];
+
+export const publicUvToShaderUv = (
+	uv: UvCoordinate,
+): readonly [number, number] => {
+	return [uv[0], 1 - uv[1]];
+};

--- a/packages/effects/src/vignette.ts
+++ b/packages/effects/src/vignette.ts
@@ -6,6 +6,7 @@ import {
 	type ParsedColorRgba,
 	validateUnitInterval,
 } from './color-utils.js';
+import {publicUvToShaderUv} from './uv-coordinate.js';
 import {
 	assertEffectParamsObject,
 	assertOptionalColor,
@@ -464,8 +465,10 @@ export const vignette = createEffect<VignetteParams, VignetteState>({
 		if (uniforms.uColor) gl.uniform4f(uniforms.uColor, red, green, blue, alpha);
 		if (uniforms.uMode)
 			gl.uniform1i(uniforms.uMode, r.mode === 'alpha' ? 1 : 0);
-		if (uniforms.uCenter)
-			gl.uniform2f(uniforms.uCenter, r.center[0], r.center[1]);
+		if (uniforms.uCenter) {
+			const shaderCenter = publicUvToShaderUv(r.center);
+			gl.uniform2f(uniforms.uCenter, shaderCenter[0], shaderCenter[1]);
+		}
 
 		gl.bindVertexArray(vao);
 		gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);


### PR DESCRIPTION
## Summary

- Fix public UV coordinates for `rings()`, `fisheye()`, and `vignette()` so `(0, 0)` maps to the top-left corner.
- Add a shared helper for converting public UV coordinates into WebGL shader UV space.
- Add a unit test covering the UV origin conversion.

Fixes #8397.

## Testing

- `bun test src/test/effect-params.test.ts` in `packages/effects`
- `bun run make` in `packages/effects`
- `bun run build`
- `bun run stylecheck`
