### PR TITLE
`@remotion/studio`: Improve selected outline controls

### DIFF
--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import React, {
 	forwardRef,
+	useCallback,
 	useContext,
 	useEffect,
 	useMemo,
@@ -133,7 +134,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		_remotionInternalPremountDisplay: premountDisplay,
 		_remotionInternalPostmountDisplay: postmountDisplay,
 		_remotionInternalIsMedia: isMedia,
-		_remotionInternalRefForOutline: refForOutline,
+		_remotionInternalRefForOutline: passedRefForOutline,
 		...other
 	},
 	ref,
@@ -219,6 +220,11 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		Math.min(videoConfig.durationInFrames - from, parentSequenceDuration),
 	);
 	const {registerSequence, unregisterSequence} = useContext(SequenceManager);
+	const wrapperRefForOutline = useRef<HTMLDivElement | null>(null);
+	const refForOutline =
+		other.layout === 'none'
+			? (passedRefForOutline ?? null)
+			: (passedRefForOutline ?? wrapperRefForOutline);
 
 	const premounting = useMemo(() => {
 		// || is intentional, ?? would not trigger on `false`
@@ -435,6 +441,19 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	const styleIfThere = other.layout === 'none' ? undefined : other.style;
 
+	const sequenceRef = useCallback(
+		(node: HTMLDivElement | null) => {
+			wrapperRefForOutline.current = node;
+
+			if (typeof ref === 'function') {
+				ref(node);
+			} else if (ref) {
+				ref.current = node;
+			}
+		},
+		[ref],
+	);
+
 	const defaultStyle: React.CSSProperties = useMemo(() => {
 		return {
 			flexDirection: undefined,
@@ -460,7 +479,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 				frozenContent
 			) : (
 				<AbsoluteFill
-					ref={ref}
+					ref={sequenceRef}
 					style={defaultStyle}
 					className={other.className}
 				>

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -140,6 +140,24 @@ test('Sequence registers its documentation link', () => {
 	);
 });
 
+test('Sequence registers its wrapper element for Studio outlines', () => {
+	const registeredSequences: TSequence[] = [];
+	const ref = React.createRef<HTMLDivElement>();
+
+	render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Sequence ref={ref}>hi</Sequence>
+		</SequenceTestWrapper>,
+	);
+
+	expect(registeredSequences[0]?.refForOutline?.current?.tagName).toBe('DIV');
+	expect(registeredSequences[0]?.refForOutline?.current).toBe(ref.current);
+});
+
 test('Series.Sequence registers without visual controls', () => {
 	const registeredSequences: TSequence[] = [];
 

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -7,6 +7,7 @@ import {
 	getUvCoordinateForPoint,
 	getUvHandleConnectionLines,
 	getUvHandlePosition,
+	roundUvCoordinate,
 	tuplesEqual,
 	type SelectedOutlineUvHandle,
 	type UvCoordinate,
@@ -96,8 +97,11 @@ const SelectedUvHandleCircle: React.FC<{
 					event: pointerEvent,
 					rect: svgRect,
 				});
-				const nextValue = constrainUv(
-					getUvCoordinateForPoint(outline.points, point),
+				const nextValue = roundUvCoordinate(
+					constrainUv(
+						getUvCoordinateForPoint(outline.points, point),
+						handle.fieldSchema,
+					),
 					handle.fieldSchema,
 				);
 				lastValue = nextValue;

--- a/packages/studio/src/components/selected-outline-drag.ts
+++ b/packages/studio/src/components/selected-outline-drag.ts
@@ -260,6 +260,26 @@ type SelectedOutlineScaleEdgeInfo = {
 	readonly start: OutlinePoint;
 };
 
+const getScaleCursor = (normal: OutlinePoint): string => {
+	const degrees = Math.atan2(normal.y, normal.x) * (180 / Math.PI);
+	const normalizedDegrees = ((degrees % 180) + 180) % 180;
+	const snappedDegrees = Math.round(normalizedDegrees / 45) * 45;
+
+	if (snappedDegrees === 0 || snappedDegrees === 180) {
+		return 'ew-resize';
+	}
+
+	if (snappedDegrees === 45) {
+		return 'nwse-resize';
+	}
+
+	if (snappedDegrees === 90) {
+		return 'ns-resize';
+	}
+
+	return 'nesw-resize';
+};
+
 export const getSelectedOutlineScaleEdgeInfo = (
 	points: SelectedOutline['points'],
 	edge: SelectedOutlineScaleEdge,
@@ -285,7 +305,7 @@ export const getSelectedOutlineScaleEdgeInfo = (
 
 	return {
 		axis: edge === 'left' || edge === 'right' ? 'x' : 'y',
-		cursor: edge === 'left' || edge === 'right' ? 'ew-resize' : 'ns-resize',
+		cursor: getScaleCursor(outward),
 		end: edgePoints.end,
 		extent: length,
 		normal: {x: outward.x / length, y: outward.y / length},

--- a/packages/studio/src/components/selected-outline-uv.ts
+++ b/packages/studio/src/components/selected-outline-uv.ts
@@ -16,6 +16,10 @@ import {
 	type OutlinePoint,
 	type SelectedOutline,
 } from './selected-outline-geometry';
+import {
+	getTimelineDisplayDecimalPlaces,
+	roundToDecimalPlaces,
+} from './Timeline/timeline-field-utils';
 
 export type UvCoordinate = readonly [number, number];
 
@@ -284,6 +288,21 @@ export function constrainUv(
 	const min = schema.min ?? -Infinity;
 	const max = schema.max ?? Infinity;
 	return [clamp(value[0], min, max), clamp(value[1], min, max)];
+}
+
+export function roundUvCoordinate(
+	value: UvCoordinate,
+	schema: UvCoordinateFieldSchema,
+): UvCoordinate {
+	const decimalPlaces = getTimelineDisplayDecimalPlaces({
+		defaultDecimalPlaces: 3,
+		step: schema.step,
+	});
+
+	return [
+		roundToDecimalPlaces(value[0], decimalPlaces),
+		roundToDecimalPlaces(value[1], decimalPlaces),
+	];
 }
 
 export const getSelectedUvHandles = ({

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -15,6 +15,7 @@ import {
 	getUvCoordinateForPoint,
 	getUvHandleConnectionLines,
 	getUvHandlePosition,
+	roundUvCoordinate,
 } from '../components/selected-outline-uv';
 import {
 	applySelectedOutlineDragAxisLock,
@@ -1404,6 +1405,26 @@ test('UV coordinate constraints still clamp to schema min and max', () => {
 	).toEqual([0, 1]);
 });
 
+test('UV coordinates round to three decimals by default when dragging', () => {
+	expect(
+		roundUvCoordinate([0.123456, 0.987654], {
+			type: 'uv-coordinate',
+			default: [0.5, 0.5],
+			step: 0.01,
+		}),
+	).toEqual([0.123, 0.988]);
+});
+
+test('UV coordinates allow finer configured steps when dragging', () => {
+	expect(
+		roundUvCoordinate([0.123456, 0.987654], {
+			type: 'uv-coordinate',
+			default: [0.5, 0.5],
+			step: 0.0001,
+		}),
+	).toEqual([0.1235, 0.9877]);
+});
+
 test('SVG viewport outline points are projected through the screen CTM', () => {
 	const points = getTransformedSvgViewportPoints({
 		viewport: {x: 0, y: 0, width: 100, height: 50},
@@ -2622,11 +2643,41 @@ test('Selected outline scale edges project pointer movement onto the edge normal
 	const top = getSelectedOutlineScaleEdgeInfo(points, 'top');
 
 	expect(right?.axis).toBe('x');
+	expect(right?.cursor).toBe('ew-resize');
 	expect(right?.extent).toBe(100);
 	expect(right?.normal).toEqual({x: 1, y: 0});
 	expect(top?.axis).toBe('y');
+	expect(top?.cursor).toBe('ns-resize');
 	expect(top?.extent).toBe(50);
 	expect(top?.normal).toEqual({x: 0, y: -1});
+});
+
+test('Selected outline scale edge cursors follow rotated outlines', () => {
+	const rotated90Degrees = [
+		{x: 0, y: 0},
+		{x: 0, y: 100},
+		{x: -50, y: 100},
+		{x: -50, y: 0},
+	] as const;
+	const rotated45Degrees = [
+		{x: 0, y: 0},
+		{x: 100, y: 100},
+		{x: 50, y: 150},
+		{x: -50, y: 50},
+	] as const;
+
+	expect(
+		getSelectedOutlineScaleEdgeInfo(rotated90Degrees, 'right')?.cursor,
+	).toBe('ns-resize');
+	expect(getSelectedOutlineScaleEdgeInfo(rotated90Degrees, 'top')?.cursor).toBe(
+		'ew-resize',
+	);
+	expect(
+		getSelectedOutlineScaleEdgeInfo(rotated45Degrees, 'right')?.cursor,
+	).toBe('nwse-resize');
+	expect(getSelectedOutlineScaleEdgeInfo(rotated45Degrees, 'top')?.cursor).toBe(
+		'nesw-resize',
+	);
 });
 
 test('Backspace reset targets selected effect props', () => {


### PR DESCRIPTION
## Summary

- register a default `refForOutline` for raw `<Sequence>` wrappers in Studio
- preserve internal outline refs from media and `Interactive` components
- limit dragged UV coordinates to the displayed decimal precision
- make selected outline resize cursors follow the rendered outline rotation

Fixes #8399.
Fixes #8401.

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bunx oxfmt src --write` from `packages/studio`
- `bun run build`
- `bun run stylecheck`
