### PR TITLE
`@remotion/studio`: Limit dragged UV coordinate decimals

### DIFF
--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -7,6 +7,7 @@ import {
 	getUvCoordinateForPoint,
 	getUvHandleConnectionLines,
 	getUvHandlePosition,
+	roundUvCoordinate,
 	tuplesEqual,
 	type SelectedOutlineUvHandle,
 	type UvCoordinate,
@@ -96,8 +97,11 @@ const SelectedUvHandleCircle: React.FC<{
 					event: pointerEvent,
 					rect: svgRect,
 				});
-				const nextValue = constrainUv(
-					getUvCoordinateForPoint(outline.points, point),
+				const nextValue = roundUvCoordinate(
+					constrainUv(
+						getUvCoordinateForPoint(outline.points, point),
+						handle.fieldSchema,
+					),
 					handle.fieldSchema,
 				);
 				lastValue = nextValue;

--- a/packages/studio/src/components/selected-outline-uv.ts
+++ b/packages/studio/src/components/selected-outline-uv.ts
@@ -16,6 +16,10 @@ import {
 	type OutlinePoint,
 	type SelectedOutline,
 } from './selected-outline-geometry';
+import {
+	getTimelineDisplayDecimalPlaces,
+	roundToDecimalPlaces,
+} from './Timeline/timeline-field-utils';
 
 export type UvCoordinate = readonly [number, number];
 
@@ -284,6 +288,21 @@ export function constrainUv(
 	const min = schema.min ?? -Infinity;
 	const max = schema.max ?? Infinity;
 	return [clamp(value[0], min, max), clamp(value[1], min, max)];
+}
+
+export function roundUvCoordinate(
+	value: UvCoordinate,
+	schema: UvCoordinateFieldSchema,
+): UvCoordinate {
+	const decimalPlaces = getTimelineDisplayDecimalPlaces({
+		defaultDecimalPlaces: 3,
+		step: schema.step,
+	});
+
+	return [
+		roundToDecimalPlaces(value[0], decimalPlaces),
+		roundToDecimalPlaces(value[1], decimalPlaces),
+	];
 }
 
 export const getSelectedUvHandles = ({

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -15,6 +15,7 @@ import {
 	getUvCoordinateForPoint,
 	getUvHandleConnectionLines,
 	getUvHandlePosition,
+	roundUvCoordinate,
 } from '../components/selected-outline-uv';
 import {
 	applySelectedOutlineDragAxisLock,
@@ -1402,6 +1403,26 @@ test('UV coordinate constraints still clamp to schema min and max', () => {
 			step: 0.01,
 		}),
 	).toEqual([0, 1]);
+});
+
+test('UV coordinates round to three decimals by default when dragging', () => {
+	expect(
+		roundUvCoordinate([0.123456, 0.987654], {
+			type: 'uv-coordinate',
+			default: [0.5, 0.5],
+			step: 0.01,
+		}),
+	).toEqual([0.123, 0.988]);
+});
+
+test('UV coordinates allow finer configured steps when dragging', () => {
+	expect(
+		roundUvCoordinate([0.123456, 0.987654], {
+			type: 'uv-coordinate',
+			default: [0.5, 0.5],
+			step: 0.0001,
+		}),
+	).toEqual([0.1235, 0.9877]);
 });
 
 test('SVG viewport outline points are projected through the screen CTM', () => {


### PR DESCRIPTION
Fixes #8403.

## Summary
- Round dragged UV coordinates to 3 decimals by default before applying drag overrides or saving.

- Respect finer configured UV steps when they require more precision.
## Testing
- bun test src/test/timeline-selection.test.ts
- bun run build
- bun run stylecheck








