### PR TITLE
`@remotion/studio-server`: Parse String-wrapped visual prop interpolations

### DIFF
--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -488,6 +488,32 @@ const getInterpolationKeyframes = (
 		return getInterpolationKeyframes(node.expression as Expression, ast);
 	}
 
+	if (
+		node.type === 'CallExpression' &&
+		node.callee.type === 'Identifier' &&
+		node.callee.name === 'String' &&
+		node.arguments.length === 1 &&
+		node.arguments[0].type !== 'ArgumentPlaceholder' &&
+		node.arguments[0].type !== 'JSXNamespacedName' &&
+		node.arguments[0].type !== 'SpreadElement'
+	) {
+		const interpolation = getInterpolationKeyframes(
+			node.arguments[0] as Expression,
+			ast,
+		);
+		if (!interpolation) {
+			return undefined;
+		}
+
+		return {
+			...interpolation,
+			keyframes: interpolation.keyframes.map((keyframe) => ({
+				...keyframe,
+				value: String(keyframe.value),
+			})),
+		};
+	}
+
 	if (node.type !== 'CallExpression') {
 		return undefined;
 	}

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -219,6 +219,52 @@ export const Example: React.FC = () => {
 	});
 });
 
+test('computeSequencePropsStatus should return keyframes for String-wrapped interpolated translate props', () => {
+	const input = `import React from 'react';
+import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<Sequence style={{translate: String(interpolate(frame, [0, 16, 30], ['0px 59px', '100px 20px', '124px 40px'], {
+\t\t\textrapolateLeft: 'clamp',
+\t\t\textrapolateRight: 'clamp',
+\t\t\teasing: [
+\t\t\t\tEasing.bezier(0, 0, 0.58, 1),
+\t\t\t\tEasing.bezier(0.42, 0, 0.6308, 1.1405),
+\t\t\t],
+\t\t}))}} />
+\t);
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 7),
+		componentIdentity: null,
+		keys: ['style.translate'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.translate']).toEqual({
+		status: 'keyframed',
+		interpolationFunction: 'interpolate',
+		keyframes: [
+			{frame: 0, value: '0px 59px'},
+			{frame: 16, value: '100px 20px'},
+			{frame: 30, value: '124px 40px'},
+		],
+		easing: [
+			[0, 0, 0.58, 1],
+			[0.42, 0, 0.6308, 1.1405],
+		],
+		clamping: {left: 'clamp', right: 'clamp'},
+		posterize: undefined,
+	});
+});
+
 test('computeSequencePropsStatus should flag interpolations over computed values as computed', () => {
 	const input = `import React from 'react';
 import {Sequence, interpolate, useCurrentFrame} from 'remotion';
@@ -433,6 +479,60 @@ test('computeSequencePropsStatus should return keyframes for interpolated style 
 		],
 		easing: ['linear'],
 		clamping: {left: 'extend', right: 'extend'},
+		posterize: undefined,
+	});
+});
+
+test('computeSequencePropsStatus should return keyframes for String-wrapped interpolated scale props', () => {
+	const input = `import React from 'react';
+import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<Sequence style={{scale: String(
+\t\t\tinterpolate(
+\t\t\t\tframe,
+\t\t\t\t[0, 16, 30],
+\t\t\t\t['1.105 1.105', '1.37 0.77', '1.611 1.611'],
+\t\t\t\t{
+\t\t\t\t\textrapolateLeft: 'clamp',
+\t\t\t\t\textrapolateRight: 'clamp',
+\t\t\t\t\teasing: [
+\t\t\t\t\t\tEasing.bezier(0, 0, 0.58, 1),
+\t\t\t\t\t\tEasing.bezier(0.42, 0, 0.6308, 1.1405),
+\t\t\t\t\t],
+\t\t\t\t},
+\t\t\t),
+\t\t)}} />
+\t);
+};
+`;
+
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 7),
+		componentIdentity: null,
+		keys: ['style.scale'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.scale']).toEqual({
+		status: 'keyframed',
+		interpolationFunction: 'interpolate',
+		keyframes: [
+			{frame: 0, value: '1.105 1.105'},
+			{frame: 16, value: '1.37 0.77'},
+			{frame: 30, value: '1.611 1.611'},
+		],
+		easing: [
+			[0, 0, 0.58, 1],
+			[0.42, 0, 0.6308, 1.1405],
+		],
+		clamping: {left: 'clamp', right: 'clamp'},
 		posterize: undefined,
 	});
 });


### PR DESCRIPTION
## Summary
- Parse `String(interpolate(...))` as keyframed visual props instead of computed.
- Preserve runtime string coercion for extracted keyframe values.
- Add regression coverage for `style.translate` and `style.scale`.

Closes #8402.

## Tests
- `bun test packages/studio-server/src/test/compute-sequence-props-status.test.ts`
- `bun run build`
- `bun run stylecheck`
