### PR TITLE
`@remotion/effects`: Allow negative gaps in pattern()

### DIFF
--- a/packages/effects/src/pattern.ts
+++ b/packages/effects/src/pattern.ts
@@ -258,14 +258,6 @@ const validateAtLeast = (value: number, min: number, name: string): void => {
 	}
 };
 
-const validateNonNegative = (value: number, name: string): void => {
-	if (value < 0) {
-		throw new TypeError(
-			`"${name}" must be >= 0, but got ${JSON.stringify(value)}`,
-		);
-	}
-};
-
 const validatePatternParams = (params: PatternParams): void => {
 	assertEffectParamsObject(params, 'Pattern');
 	assertOptionalFiniteNumber(params.scale, 'scale');
@@ -288,8 +280,6 @@ const validatePatternParams = (params: PatternParams): void => {
 
 	const r = resolve(params);
 	validatePositive(r.scale, 'scale');
-	validateNonNegative(r.gapX, 'gapX');
-	validateNonNegative(r.gapY, 'gapY');
 	validateAtLeast(r.rowOffsetEvery, 0, 'rowOffsetEvery');
 	validateAtLeast(r.columnOffsetEvery, 0, 'columnOffsetEvery');
 	validateUnitInterval(r.origin[0], 'origin[0]');

--- a/packages/effects/src/test/effect-params.test.ts
+++ b/packages/effects/src/test/effect-params.test.ts
@@ -1676,9 +1676,9 @@ test('pattern() rejects invalid generic offsets', () => {
 	);
 });
 
-test('pattern() rejects overlapping gaps', () => {
-	expect(() => pattern({gapX: -1})).toThrow('"gapX" must be >= 0');
-	expect(() => pattern({gapY: -1})).toThrow('"gapY" must be >= 0');
+test('pattern() allows negative gaps', () => {
+	expect(() => pattern({gapX: -1})).not.toThrow();
+	expect(() => pattern({gapY: -1})).not.toThrow();
 });
 
 test('pattern() parameters produce distinct effect keys', () => {


### PR DESCRIPTION
Fixes #8416

## Changes
- Removed `validateNonNegative` validation for `gapX` and `gapY` in `pattern.ts`
- Removed unused `validateNonNegative` function from `pattern.ts`
- Updated test to reflect that negative gaps are now allowed

## Why
Negative gaps cause tiles to overlap, which is a valid and useful visual effect.