### PR TITLE
`@remotion/effects`: Make pixelDissolve progress 1 hide the source

### DIFF
--- a/packages/effects/src/pixel-dissolve.ts
+++ b/packages/effects/src/pixel-dissolve.ts
@@ -168,6 +168,7 @@ float hash21(vec2 p) {
 }
 
 float dissolveMask(float noise, float threshold, float feather) {
+	if (threshold <= 0.0) return 0.0;
 	float edge = max(feather, 0.0);
 	if (edge <= 0.0001) {
 		return step(noise, threshold);


### PR DESCRIPTION
### Problem

When `progress=1` was passed to `pixelDissolve`, the source layer was not becoming fully invisible.

**Root cause:** When `progress=1`, `threshold` becomes `0.0`. The `step(noise, 0.0)` call returns `1.0` only when `noise <= 0.0`, but `hash21` always returns a value between `0` and `1`, never exactly `0`. So every cell remained visible.

### Before

```glsl
float dissolveMask(float noise, float threshold, float feather) {
	float edge = max(feather, 0.0);
	if (edge <= 0.0001) {
		return step(noise, threshold);
	}

	return 1.0 - smoothstep(threshold, min(threshold + edge, 1.0), noise);
}
```

### After

```glsl
float dissolveMask(float noise, float threshold, float feather) {
	if (threshold <= 0.0) return 0.0;
	float edge = max(feather, 0.0);
	if (edge <= 0.0001) {
		return step(noise, threshold);
	}

	return 1.0 - smoothstep(threshold, min(threshold + edge, 1.0), noise);
}
```

### What changed

Added an early return at the top of `dissolveMask` — when `threshold <= 0.0` (i.e. `progress=1`), immediately return `0.0` (fully transparent) for every pixel, bypassing the broken math entirely.

Fixes #8415