### PR TITLE
`@remotion/studio`: Adjust undo and redo icon sizing

### DIFF
--- a/packages/studio/src/components/UndoRedoButtons.tsx
+++ b/packages/studio/src/components/UndoRedoButtons.tsx
@@ -19,8 +19,8 @@ import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 
 const iconStyle: React.CSSProperties = {
-	width: 16,
-	height: 16,
+	width: 20,
+	height: 20,
 };
 
 export const UndoRedoButtons: React.FC = () => {


### PR DESCRIPTION
## Summary

Fixes #8410

The undo and redo icons appeared visually smaller than adjacent toolbar controls in Studio.

Although the icons were rendered with the same width and height as nearby controls, the SVG path geometry contains additional internal padding, causing the glyphs to occupy less visual space within the button.

This change increases the rendered size of the undo and redo icons to better match the visual footprint of surrounding toolbar icons.

## Changes

* Increased the rendered size of the Undo icon.
* Increased the rendered size of the Redo icon.
* Improved visual consistency across Studio toolbar controls.

## Testing

* Verified the Studio toolbar locally.
* Compared the undo/redo icons against adjacent toolbar controls.
* Confirmed that the icons now have a more consistent visual size and alignment.
