### PR TITLE
`@remotion/studio`: Fix stuck guide cursor

### DIFF
--- a/packages/studio/src/components/EditorGuides/Guide.tsx
+++ b/packages/studio/src/components/EditorGuides/Guide.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../state/editor-guides';
 import {RULER_WIDTH} from '../../state/editor-rulers';
 import {ContextMenu} from '../ContextMenu';
-import {forceSpecificCursor} from '../ForceSpecificCursor';
+import {stopForcingSpecificCursor} from '../ForceSpecificCursor';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR} from '../Timeline/should-clear-selection-on-pointer-down';
 import {useTimelineGuideSelection} from '../Timeline/TimelineSelection';
@@ -108,8 +108,7 @@ const GuideComp: React.FC<{
 				clientX: e.clientX,
 				clientY: e.clientY,
 			};
-			shouldCreateGuideRef.current = true;
-			forceSpecificCursor('no-drop');
+			shouldCreateGuideRef.current = false;
 			setDraggingGuideId(() => guide.id);
 		},
 		[guide.id, setDraggingGuideId, shouldCreateGuideRef],
@@ -129,8 +128,7 @@ const GuideComp: React.FC<{
 				clientX: e.clientX,
 				clientY: e.clientY,
 			};
-			shouldCreateGuideRef.current = true;
-			forceSpecificCursor('no-drop');
+			shouldCreateGuideRef.current = false;
 			setDraggingGuideId(() => guide.id);
 		},
 		[guide.id, setDraggingGuideId, shouldCreateGuideRef],
@@ -171,6 +169,35 @@ const GuideComp: React.FC<{
 		[updateHasMovedGuide],
 	);
 
+	const finishGuideInteraction = useCallback(() => {
+		const shouldDeleteGuide = shouldDeleteGuideRef.current;
+
+		setGuidesList((prevState) => {
+			const newGuides = shouldDeleteGuide
+				? prevState.filter((candidate) => candidate.id !== guide.id)
+				: prevState;
+			persistGuidesList(newGuides);
+			return newGuides;
+		});
+
+		if (shouldDeleteGuide && selected) {
+			clearSelection();
+		}
+
+		shouldDeleteGuideRef.current = false;
+		shouldCreateGuideRef.current = false;
+		stopForcingSpecificCursor();
+		setDraggingGuideId(() => null);
+	}, [
+		clearSelection,
+		guide.id,
+		selected,
+		setDraggingGuideId,
+		setGuidesList,
+		shouldCreateGuideRef,
+		shouldDeleteGuideRef,
+	]);
+
 	const onPointerUp = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
 			if (e.currentTarget.hasPointerCapture(e.pointerId)) {
@@ -179,7 +206,9 @@ const GuideComp: React.FC<{
 
 			const pointerDownPosition = pointerDownPositionRef.current;
 			pointerDownPositionRef.current = null;
-			if (shouldDeleteGuideRef.current) {
+			const shouldDeleteGuide = shouldDeleteGuideRef.current;
+			finishGuideInteraction();
+			if (shouldDeleteGuide) {
 				return;
 			}
 
@@ -194,14 +223,16 @@ const GuideComp: React.FC<{
 				onSelect();
 			}
 		},
-		[guide.id, onSelect, shouldDeleteGuideRef],
+		[finishGuideInteraction, guide.id, onSelect, shouldDeleteGuideRef],
 	);
 
 	const onMouseUp = useCallback(
 		(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
 			const pointerDownPosition = pointerDownPositionRef.current;
 			pointerDownPositionRef.current = null;
-			if (shouldDeleteGuideRef.current) {
+			const shouldDeleteGuide = shouldDeleteGuideRef.current;
+			finishGuideInteraction();
+			if (shouldDeleteGuide) {
 				return;
 			}
 
@@ -216,7 +247,7 @@ const GuideComp: React.FC<{
 				onSelect();
 			}
 		},
-		[guide.id, onSelect, shouldDeleteGuideRef],
+		[finishGuideInteraction, guide.id, onSelect, shouldDeleteGuideRef],
 	);
 
 	const onClick = useCallback(
@@ -233,7 +264,8 @@ const GuideComp: React.FC<{
 
 	const onPointerCancel = useCallback(() => {
 		pointerDownPositionRef.current = null;
-	}, []);
+		finishGuideInteraction();
+	}, [finishGuideInteraction]);
 
 	const isActive = selected || hoveredGuideId === guide.id;
 	const activeClassName = isActive ? '__remotion_editor_guide_selected' : null;

--- a/packages/studio/src/components/EditorRuler/Ruler.tsx
+++ b/packages/studio/src/components/EditorRuler/Ruler.tsx
@@ -5,7 +5,6 @@ import React, {
 	useEffect,
 	useMemo,
 	useRef,
-	useState,
 } from 'react';
 import {Internals} from 'remotion';
 import {BACKGROUND, RULER_COLOR} from '../../helpers/colors';
@@ -63,9 +62,7 @@ const Ruler: React.FC<RulerProps> = ({
 		throw new Error('Video config not set');
 	}
 
-	const [cursor, setCursor] = useState<'ew-resize' | 'ns-resize' | 'no-drop'>(
-		isVerticalRuler ? 'ew-resize' : 'ns-resize',
-	);
+	const cursor = isVerticalRuler ? 'ew-resize' : 'ns-resize';
 
 	const guideHighlight = useMemo(
 		() =>
@@ -133,7 +130,7 @@ const Ruler: React.FC<RulerProps> = ({
 				// Prevent deselection of currently selected items
 				e.stopPropagation();
 				shouldCreateGuideRef.current = true;
-				forceSpecificCursor('no-drop');
+				forceSpecificCursor(cursor);
 				const guideId = makeGuideId();
 				setEditorShowGuides(() => true);
 				setDraggingGuideId(() => guideId);
@@ -158,24 +155,9 @@ const Ruler: React.FC<RulerProps> = ({
 				orientation,
 				originOffset,
 				unsafeVideoConfig.id,
+				cursor,
 			],
 		);
-
-	const changeCursor = useCallback(
-		(e: React.PointerEvent<HTMLCanvasElement>) => {
-			e.preventDefault();
-			if (draggingGuideId !== null) {
-				setCursor('no-drop');
-			}
-		},
-		[setCursor, draggingGuideId],
-	);
-
-	useEffect(() => {
-		if (draggingGuideId === null) {
-			setCursor(isVerticalRuler ? 'ew-resize' : 'ns-resize');
-		}
-	}, [draggingGuideId, isVerticalRuler]);
 
 	return (
 		<canvas
@@ -185,8 +167,6 @@ const Ruler: React.FC<RulerProps> = ({
 			style={rulerStyle}
 			{...{[PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR]: 'true'}}
 			onPointerDown={onPointerDown}
-			onPointerEnter={changeCursor}
-			onPointerLeave={changeCursor}
 		/>
 	);
 };

--- a/packages/studio/src/components/EditorRuler/index.tsx
+++ b/packages/studio/src/components/EditorRuler/index.tsx
@@ -2,7 +2,7 @@ import {type Size} from '@remotion/player';
 import React, {
 	useCallback,
 	useContext,
-	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 } from 'react';
@@ -139,13 +139,15 @@ export const EditorRulers: React.FC<{
 						shouldDeleteGuideRef.current = true;
 					}
 
-					forceSpecificCursor('no-drop');
-
 					setGuidesList((prevState) => {
 						const newGuides = prevState.map((guide) => {
 							if (guide.id !== draggingGuideId) {
 								return guide;
 							}
+
+							const desiredCursor =
+								guide.orientation === 'vertical' ? 'ew-resize' : 'ns-resize';
+							forceSpecificCursor(desiredCursor);
 
 							return {
 								...guide,
@@ -200,9 +202,11 @@ export const EditorRulers: React.FC<{
 	);
 
 	const onMouseUp = useCallback(() => {
+		const shouldDeleteGuide = shouldDeleteGuideRef.current;
+
 		setGuidesList((prevState) => {
 			const newGuides = prevState.filter((selected) => {
-				if (!shouldDeleteGuideRef.current) {
+				if (!shouldDeleteGuide) {
 					return true;
 				}
 
@@ -215,7 +219,7 @@ export const EditorRulers: React.FC<{
 		const deletedGuideWasSelected = selectedItems.some(
 			(item) => item.type === 'guide' && item.guideId === draggingGuideId,
 		);
-		if (shouldDeleteGuideRef.current && deletedGuideWasSelected) {
+		if (shouldDeleteGuide && deletedGuideWasSelected) {
 			clearSelection();
 		}
 
@@ -224,6 +228,7 @@ export const EditorRulers: React.FC<{
 		shouldCreateGuideRef.current = false;
 		setDraggingGuideId(() => null);
 		document.removeEventListener('pointerup', onMouseUp);
+		document.removeEventListener('pointercancel', onMouseUp);
 		document.removeEventListener('pointermove', onMouseMove);
 	}, [
 		clearSelection,
@@ -236,15 +241,17 @@ export const EditorRulers: React.FC<{
 		selectedItems,
 	]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (draggingGuideId !== null) {
 			document.addEventListener('pointermove', onMouseMove);
 			document.addEventListener('pointerup', onMouseUp);
+			document.addEventListener('pointercancel', onMouseUp);
 		}
 
 		return () => {
 			document.removeEventListener('pointermove', onMouseMove);
 			document.removeEventListener('pointerup', onMouseUp);
+			document.removeEventListener('pointercancel', onMouseUp);
 			if (requestAnimationFrameRef.current) {
 				cancelAnimationFrame(requestAnimationFrameRef.current);
 			}

--- a/packages/studio/src/helpers/editor-guide-selection.ts
+++ b/packages/studio/src/helpers/editor-guide-selection.ts
@@ -60,7 +60,7 @@ const findGuide = (guidesList: readonly Guide[], guideId: string | null) => {
 		return null;
 	}
 
-	return guidesList.find((guide) => guide.id === guideId) ?? null;
+	return guidesList.find((guide) => guide.id === guideId && guide.show) ?? null;
 };
 
 export const getRulerGuideHighlight = ({

--- a/packages/studio/src/test/editor-guides.test.ts
+++ b/packages/studio/src/test/editor-guides.test.ts
@@ -24,6 +24,14 @@ const guideB: Guide = {
 	show: true,
 };
 
+const hiddenGuide: Guide = {
+	compositionId: 'comp',
+	id: 'hidden-guide',
+	orientation: 'vertical',
+	position: 300,
+	show: false,
+};
+
 test('guide pointer-up only selects after a click on the same guide', () => {
 	const pointerDownPosition: GuidePointerDownPosition = {
 		guideId: 'guide-a',
@@ -98,4 +106,31 @@ test('ruler shows dragged guide numbers without requiring guide selection', () =
 		guide: guideB,
 		color: BLUE,
 	});
+});
+
+test('ruler does not show hidden guide numbers while a guide is being removed', () => {
+	expect(
+		getRulerGuideHighlight({
+			guidesList: [guideA, hiddenGuide],
+			selectedItems: [{type: 'guide', guideId: 'hidden-guide'}],
+			hoveredGuideId: null,
+			draggingGuideId: null,
+		}),
+	).toBe(null);
+	expect(
+		getRulerGuideHighlight({
+			guidesList: [guideA, hiddenGuide],
+			selectedItems: [{type: 'sequence'}],
+			hoveredGuideId: null,
+			draggingGuideId: 'hidden-guide',
+		}),
+	).toBe(null);
+	expect(
+		getRulerGuideHighlight({
+			guidesList: [guideA, hiddenGuide],
+			selectedItems: [{type: 'sequence'}],
+			hoveredGuideId: 'hidden-guide',
+			draggingGuideId: null,
+		}),
+	).toBe(null);
 });


### PR DESCRIPTION
## Summary

- Remove the `no-drop` cursor from the Studio guide/ruler interaction entirely.
- Keep guide creation and existing guide drags on resize cursors throughout the interaction.
- Preserve dragging guides outside the canvas to remove them.
- Hide ruler gutter highlights for guides while they are dragged outside the canvas for removal.
- Clean up the forced cursor directly on guide pointer end/cancel and keep document-level cleanup as a fallback.

Closes #8429.

## Testing

- `bun test src/test/editor-guides.test.ts` in `packages/studio`
- `bun run lint` in `packages/studio`
- `bun run make` in `packages/studio`
- `bun run test` in `packages/studio`
- `bun run build`
- `bun run stylecheck`

## Notes

- Tried to open the example Studio for a browser smoke test, but the local process failed while creating watchers with `EMFILE: too many open files, watch`.
