### PR TITLE
`@remotion/studio`: Keep error overlay below menu toolbar

### DIFF
--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -11,13 +11,17 @@ import {SidebarCollapserControls} from './SidebarCollapserControls';
 import {UndoRedoButtons} from './UndoRedoButtons';
 import {UpdateCheck} from './UpdateCheck';
 
+export const MENU_TOOLBAR_HEIGHT = 30;
+
 const row: React.CSSProperties = {
 	alignItems: 'center',
 	flexDirection: 'row',
 	display: 'flex',
 	color: 'white',
 	borderBottom: '1px solid black',
+	boxSizing: 'border-box',
 	fontSize: 13,
+	height: MENU_TOOLBAR_HEIGHT,
 	paddingLeft: 6,
 	paddingRight: 10,
 	backgroundColor: BACKGROUND,

--- a/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
@@ -5,6 +5,7 @@ import React, {
 	useState,
 } from 'react';
 import {AbsoluteFill} from 'remotion';
+import {MENU_TOOLBAR_HEIGHT} from '../../components/MenuToolbar';
 import {KeybindingContextProvider} from '../../state/keybindings';
 import {ErrorLoader} from './ErrorLoader';
 
@@ -71,6 +72,8 @@ export const Overlay: React.FC = () => {
 					backgroundColor: BACKGROUND_COLOR,
 					overflow: 'auto',
 					color: 'white',
+					top: MENU_TOOLBAR_HEIGHT,
+					height: `calc(100% - ${MENU_TOOLBAR_HEIGHT}px)`,
 				}}
 			>
 				{errors.errors.map((err, i) => {


### PR DESCRIPTION
## Summary

- Keep the Studio error overlay below the top menu toolbar
- Export the toolbar height constant so the overlay uses the same offset

## Testing

- `bun run build`
- `bun run stylecheck`
