### PR TITLE
`@remotion/studio`: Snap transform origin to outline points

### DIFF
--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -39,6 +39,7 @@ import {
 	getSelectedOutlineScaleEdgeInfo,
 	isSelectedOutlineDragPastThreshold,
 	parseCssRotationToRadians,
+	snapSelectedOutlineTransformOriginUv,
 	uvsEqual,
 	type SelectedOutlineKeyframedDragChange,
 	type SelectedOutlineScaleEdge,
@@ -194,7 +195,11 @@ const SelectedOutlineTransformOriginHandle: React.FC<{
 					x: pointerEvent.clientX - svgRect.left,
 					y: pointerEvent.clientY - svgRect.top,
 				};
-				const nextUv = getUvCoordinateForPoint(outline.points, point);
+				const nextUv = snapSelectedOutlineTransformOriginUv({
+					point,
+					points: outline.points,
+					uv: getUvCoordinateForPoint(outline.points, point),
+				});
 				const deltaOrigin = [
 					(nextUv[0] - uv[0]) * dimensions.width,
 					(nextUv[1] - uv[1]) * dimensions.height,

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -23,6 +23,7 @@ import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
 import {
 	applySelectedOutlineDragAxisLock,
+	applySelectedOutlineTransformOriginAxisLock,
 	clearSelectedOutlineDragOverrides,
 	clearSelectedOutlineRotationDragOverrides,
 	clearSelectedOutlineScaleDragOverrides,
@@ -37,6 +38,7 @@ import {
 	getSelectedOutlineScaleDragStates,
 	getSelectedOutlineScaleDragValues,
 	getSelectedOutlineScaleEdgeInfo,
+	getSelectedOutlineTransformOriginLockedAxis,
 	isSelectedOutlineDragPastThreshold,
 	parseCssRotationToRadians,
 	snapSelectedOutlineTransformOriginUv,
@@ -184,21 +186,43 @@ const SelectedOutlineTransformOriginHandle: React.FC<{
 				readonly origin: string;
 				readonly translate: string;
 			} | null = null;
+			let currentPointerX = event.clientX;
+			let currentPointerY = event.clientY;
+			let axisLocked = event.shiftKey;
 
 			onDraggingChange(true);
 			forceSpecificCursor('crosshair');
 
-			const updateFromPointerEvent = (
-				pointerEvent: PointerEvent | React.PointerEvent<SVGGElement>,
-			) => {
+			const updateFromPointerPosition = () => {
 				const point = {
-					x: pointerEvent.clientX - svgRect.left,
-					y: pointerEvent.clientY - svgRect.top,
+					x: currentPointerX - svgRect.left,
+					y: currentPointerY - svgRect.top,
 				};
-				const nextUv = snapSelectedOutlineTransformOriginUv({
-					point,
+				const rawUv = getUvCoordinateForPoint(outline.points, point);
+				const lockedAxis = getSelectedOutlineTransformOriginLockedAxis({
+					axisLocked,
+					dimensions,
+					startUv: uv,
+					uv: rawUv,
+				});
+				const axisLockedUv = applySelectedOutlineTransformOriginAxisLock({
+					lockedAxis,
+					startUv: uv,
+					uv: rawUv,
+				});
+				const snapPoint =
+					lockedAxis === null
+						? point
+						: getUvHandlePosition(outline.points, axisLockedUv);
+				const snappedUv = snapSelectedOutlineTransformOriginUv({
+					point: snapPoint,
 					points: outline.points,
-					uv: getUvCoordinateForPoint(outline.points, point),
+					uv: axisLockedUv,
+				});
+				const nextUv = applySelectedOutlineTransformOriginAxisLock({
+					lockedAxis,
+					startUv: uv,
+					uv: snappedUv,
 				});
 				const deltaOrigin = [
 					(nextUv[0] - uv[0]) * dimensions.width,
@@ -242,17 +266,36 @@ const SelectedOutlineTransformOriginHandle: React.FC<{
 				);
 			};
 
-			updateFromPointerEvent(event);
+			updateFromPointerPosition();
 
 			const onPointerMove = (moveEvent: PointerEvent) => {
 				moveEvent.preventDefault();
-				updateFromPointerEvent(moveEvent);
+				currentPointerX = moveEvent.clientX;
+				currentPointerY = moveEvent.clientY;
+				axisLocked = moveEvent.shiftKey;
+				updateFromPointerPosition();
+			};
+
+			const onKeyChange = (keyEvent: KeyboardEvent) => {
+				if (keyEvent.key !== 'Shift') {
+					return;
+				}
+
+				const nextAxisLocked = keyEvent.type === 'keydown';
+				if (nextAxisLocked === axisLocked) {
+					return;
+				}
+
+				axisLocked = nextAxisLocked;
+				updateFromPointerPosition();
 			};
 
 			const onPointerUp = () => {
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
+				window.removeEventListener('keydown', onKeyChange);
+				window.removeEventListener('keyup', onKeyChange);
 				stopForcingSpecificCursor();
 				onDraggingChange(false);
 
@@ -349,6 +392,8 @@ const SelectedOutlineTransformOriginHandle: React.FC<{
 			window.addEventListener('pointermove', onPointerMove);
 			window.addEventListener('pointerup', onPointerUp);
 			window.addEventListener('pointercancel', onPointerUp);
+			window.addEventListener('keydown', onKeyChange);
+			window.addEventListener('keyup', onKeyChange);
 		},
 		[
 			clearDragOverrides,

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -57,6 +57,7 @@ import {useTimelineSelection} from './Timeline/TimelineSelection';
 
 export {
 	applySelectedOutlineDragAxisLock,
+	applySelectedOutlineTransformOriginAxisLock,
 	compensateTranslateForTransformOrigin,
 	getSelectedOutlineDragChanges,
 	getSelectedOutlineDragValues,
@@ -69,6 +70,7 @@ export {
 	getSelectedOutlineScaleDragStates,
 	getSelectedOutlineScaleDragValues,
 	getSelectedOutlineScaleEdgeInfo,
+	getSelectedOutlineTransformOriginLockedAxis,
 	isSelectedOutlineDragPastThreshold,
 	selectedOutlineTransformOriginSnapThresholdPx,
 	snapSelectedOutlineTransformOriginUv,

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -70,6 +70,8 @@ export {
 	getSelectedOutlineScaleDragValues,
 	getSelectedOutlineScaleEdgeInfo,
 	isSelectedOutlineDragPastThreshold,
+	selectedOutlineTransformOriginSnapThresholdPx,
+	snapSelectedOutlineTransformOriginUv,
 } from './selected-outline-drag';
 export {
 	getOutlineSelectionInteraction,

--- a/packages/studio/src/components/selected-outline-drag.ts
+++ b/packages/studio/src/components/selected-outline-drag.ts
@@ -29,6 +29,7 @@ import {
 	selectedOutlineDragThresholdPx,
 	translateFieldKey,
 } from './selected-outline-types';
+import {getUvHandlePosition, type UvCoordinate} from './selected-outline-uv';
 import type {SaveSequencePropChange} from './Timeline/save-sequence-prop';
 import {
 	getTimelineDisplayDecimalPlaces,
@@ -704,3 +705,48 @@ export const uvsEqual = (
 ): boolean =>
 	Math.abs(left[0] - right[0]) < 0.000001 &&
 	Math.abs(left[1] - right[1]) < 0.000001;
+
+const transformOriginSnapTargets = [
+	[0, 0],
+	[0.5, 0],
+	[1, 0],
+	[1, 0.5],
+	[1, 1],
+	[0.5, 1],
+	[0, 1],
+	[0, 0.5],
+	[0.5, 0.5],
+] as const satisfies readonly UvCoordinate[];
+
+export const selectedOutlineTransformOriginSnapThresholdPx = 10;
+
+export const snapSelectedOutlineTransformOriginUv = ({
+	point,
+	points,
+	thresholdPx = selectedOutlineTransformOriginSnapThresholdPx,
+	uv,
+}: {
+	readonly point: OutlinePoint;
+	readonly points: SelectedOutline['points'];
+	readonly thresholdPx?: number;
+	readonly uv: UvCoordinate;
+}): UvCoordinate => {
+	let best: {
+		readonly distance: number;
+		readonly uv: UvCoordinate;
+	} | null = null;
+
+	for (const snapUv of transformOriginSnapTargets) {
+		const snapPoint = getUvHandlePosition(points, snapUv);
+		const distance = Math.hypot(point.x - snapPoint.x, point.y - snapPoint.y);
+		if (distance > thresholdPx) {
+			continue;
+		}
+
+		if (best === null || distance < best.distance) {
+			best = {distance, uv: snapUv};
+		}
+	}
+
+	return best?.uv ?? uv;
+};

--- a/packages/studio/src/components/selected-outline-drag.ts
+++ b/packages/studio/src/components/selected-outline-drag.ts
@@ -706,6 +706,48 @@ export const uvsEqual = (
 	Math.abs(left[0] - right[0]) < 0.000001 &&
 	Math.abs(left[1] - right[1]) < 0.000001;
 
+export type SelectedOutlineTransformOriginLockedAxis = 'x' | 'y' | null;
+
+export const getSelectedOutlineTransformOriginLockedAxis = ({
+	axisLocked,
+	dimensions,
+	startUv,
+	uv,
+}: {
+	readonly axisLocked: boolean;
+	readonly dimensions: NonNullable<SelectedOutline['dimensions']>;
+	readonly startUv: UvCoordinate;
+	readonly uv: UvCoordinate;
+}): SelectedOutlineTransformOriginLockedAxis => {
+	if (!axisLocked) {
+		return null;
+	}
+
+	const deltaX = (uv[0] - startUv[0]) * dimensions.width;
+	const deltaY = (uv[1] - startUv[1]) * dimensions.height;
+	return Math.abs(deltaX) >= Math.abs(deltaY) ? 'x' : 'y';
+};
+
+export const applySelectedOutlineTransformOriginAxisLock = ({
+	lockedAxis,
+	startUv,
+	uv,
+}: {
+	readonly lockedAxis: SelectedOutlineTransformOriginLockedAxis;
+	readonly startUv: UvCoordinate;
+	readonly uv: UvCoordinate;
+}): UvCoordinate => {
+	if (lockedAxis === 'x') {
+		return [uv[0], startUv[1]];
+	}
+
+	if (lockedAxis === 'y') {
+		return [startUv[0], uv[1]];
+	}
+
+	return uv;
+};
+
 const transformOriginSnapTargets = [
 	[0, 0],
 	[0.5, 0],

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -38,7 +38,9 @@ import {
 	getSequencesWithSelectableOutlines,
 	getTransformedSvgViewportPoints,
 	isSelectedOutlineDragPastThreshold,
+	snapSelectedOutlineTransformOriginUv,
 	selectedOutlineDragThresholdPx,
+	selectedOutlineTransformOriginSnapThresholdPx,
 	type SelectedOutlineDragState,
 	type SelectedOutlineRotationDragState,
 	type SelectedOutlineScaleDragState,
@@ -1381,6 +1383,85 @@ test('Transform origin compensation keeps rotated and scaled elements in place',
 
 	expect(next[0]).toBeCloseTo(-5, 5);
 	expect(next[1]).toBeCloseTo(45, 5);
+});
+
+test('Transform origin drag snaps to center, edge midpoints and corners', () => {
+	const points = [
+		{x: 0, y: 0},
+		{x: 100, y: 0},
+		{x: 100, y: 100},
+		{x: 0, y: 100},
+	] as const;
+
+	expect(
+		snapSelectedOutlineTransformOriginUv({
+			point: {x: 47, y: 53},
+			points,
+			uv: getUvCoordinateForPoint(points, {x: 47, y: 53}),
+		}),
+	).toEqual([0.5, 0.5]);
+	expect(
+		snapSelectedOutlineTransformOriginUv({
+			point: {x: 52, y: 4},
+			points,
+			uv: getUvCoordinateForPoint(points, {x: 52, y: 4}),
+		}),
+	).toEqual([0.5, 0]);
+	expect(
+		snapSelectedOutlineTransformOriginUv({
+			point: {x: 96, y: 49},
+			points,
+			uv: getUvCoordinateForPoint(points, {x: 96, y: 49}),
+		}),
+	).toEqual([1, 0.5]);
+	expect(
+		snapSelectedOutlineTransformOriginUv({
+			point: {x: 3, y: 96},
+			points,
+			uv: getUvCoordinateForPoint(points, {x: 3, y: 96}),
+		}),
+	).toEqual([0, 1]);
+});
+
+test('Transform origin drag snaps to rotated outline anchors', () => {
+	const points = [
+		{x: 10, y: 20},
+		{x: 90, y: 50},
+		{x: 70, y: 110},
+		{x: -10, y: 80},
+	] as const;
+	const topMiddle = getUvHandlePosition(points, [0.5, 0]);
+	const pointer = {x: topMiddle.x + 4, y: topMiddle.y - 3};
+
+	expect(
+		snapSelectedOutlineTransformOriginUv({
+			point: pointer,
+			points,
+			uv: getUvCoordinateForPoint(points, pointer),
+		}),
+	).toEqual([0.5, 0]);
+});
+
+test('Transform origin drag does not snap outside the magnetic threshold', () => {
+	const points = [
+		{x: 0, y: 0},
+		{x: 100, y: 0},
+		{x: 100, y: 100},
+		{x: 0, y: 100},
+	] as const;
+	const pointer = {
+		x: 50,
+		y: selectedOutlineTransformOriginSnapThresholdPx + 1,
+	};
+	const uv = getUvCoordinateForPoint(points, pointer);
+	const snapped = snapSelectedOutlineTransformOriginUv({
+		point: pointer,
+		points,
+		uv,
+	});
+
+	expect(snapped[0]).toBeCloseTo(uv[0], 5);
+	expect(snapped[1]).toBeCloseTo(uv[1], 5);
 });
 
 test('UV coordinate constraints preserve precision despite schema step', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../components/selected-outline-uv';
 import {
 	applySelectedOutlineDragAxisLock,
+	applySelectedOutlineTransformOriginAxisLock,
 	compensateTranslateForTransformOrigin,
 	getOutlineSelectionInteraction,
 	getSelectedEffectFieldsBySequenceKey,
@@ -34,6 +35,7 @@ import {
 	getSelectedOutlineScaleDragChanges,
 	getSelectedOutlineScaleDragValues,
 	getSelectedOutlineScaleEdgeInfo,
+	getSelectedOutlineTransformOriginLockedAxis,
 	getSelectedSequenceKeys,
 	getSequencesWithSelectableOutlines,
 	getTransformedSvgViewportPoints,
@@ -1462,6 +1464,67 @@ test('Transform origin drag does not snap outside the magnetic threshold', () =>
 
 	expect(snapped[0]).toBeCloseTo(uv[0], 5);
 	expect(snapped[1]).toBeCloseTo(uv[1], 5);
+});
+
+test('Transform origin axis locking keeps one UV axis fixed', () => {
+	const dimensions = {width: 200, height: 100};
+	const startUv = [0.25, 0.5] as const;
+	const mostlyHorizontal = [0.5, 0.75] as const;
+	const mostlyVertical = [0.35, 0.9] as const;
+
+	expect(
+		getSelectedOutlineTransformOriginLockedAxis({
+			axisLocked: true,
+			dimensions,
+			startUv,
+			uv: mostlyHorizontal,
+		}),
+	).toBe('x');
+	expect(
+		applySelectedOutlineTransformOriginAxisLock({
+			lockedAxis: 'x',
+			startUv,
+			uv: mostlyHorizontal,
+		}),
+	).toEqual([0.5, 0.5]);
+	expect(
+		getSelectedOutlineTransformOriginLockedAxis({
+			axisLocked: true,
+			dimensions,
+			startUv,
+			uv: mostlyVertical,
+		}),
+	).toBe('y');
+	expect(
+		applySelectedOutlineTransformOriginAxisLock({
+			lockedAxis: 'y',
+			startUv,
+			uv: mostlyVertical,
+		}),
+	).toEqual([0.25, 0.9]);
+	expect(
+		getSelectedOutlineTransformOriginLockedAxis({
+			axisLocked: false,
+			dimensions,
+			startUv,
+			uv: mostlyVertical,
+		}),
+	).toBeNull();
+	expect(
+		applySelectedOutlineTransformOriginAxisLock({
+			lockedAxis: null,
+			startUv,
+			uv: mostlyVertical,
+		}),
+	).toBe(mostlyVertical);
+	expect(
+		getSelectedOutlineTransformOriginLockedAxis({
+			axisLocked: true,
+			dimensions,
+			startUv,
+			uv: mostlyVertical,
+		}),
+	).toBe('y');
 });
 
 test('UV coordinate constraints preserve precision despite schema step', () => {


### PR DESCRIPTION
## Summary

- Add magnetic snapping for Studio transform-origin dragging to the outline center, corners, and edge midpoints
- Allow holding Shift while dragging the transform-origin handle to lock movement to the X or Y axis, including releasing and holding Shift again mid-drag
- Keep the existing translate compensation path so snapping and axis locking preserve the element position while moving the origin
- Split the original combined issue by tracking UV-coordinate snapping separately in #8436

Closes #8387.

## Tests

- `~/.bun/bin/bun test packages/studio/src/test/timeline-selection.test.ts`
- `~/.bun/bin/bun run build`
- `cd packages/studio && ~/.bun/bin/bun run lint`
- `cd packages/studio && ~/.bun/bin/bun run formatting`
- `~/.bun/bin/bun run stylecheck` currently fails locally because of unrelated uncommitted formatting changes in `packages/example/src/KeyframedPropsTest.tsx`
