### PR TITLE
Docs: Decrease Vercel build timeout

### DIFF
--- a/packages/docs/build-docs.ts
+++ b/packages/docs/build-docs.ts
@@ -25,11 +25,15 @@ const run = (
 			stdio: 'inherit',
 		});
 
-		child.on('close', (code) => {
+		child.on('close', (code, signal) => {
 			if (code === 0) {
 				resolve();
 			} else {
-				reject(new Error(`${command} ${args.join(' ')} exited with ${code}`));
+				reject(
+					new Error(
+						`${command} ${args.join(' ')} exited with code ${code}, signal ${signal}`,
+					),
+				);
 			}
 		});
 

--- a/packages/docs/vercel.ts
+++ b/packages/docs/vercel.ts
@@ -1,6 +1,7 @@
 import {routes, type VercelConfig} from '@vercel/config/v1';
 
 export const config: VercelConfig = {
+	buildCommand: 'cd .. && timeout 20m pnpm build-docs',
 	headers: [
 		routes.cacheControl('/assets/(.*)', {
 			public: true,


### PR DESCRIPTION
## Summary

- Fail docs Vercel builds after 20 minutes by wrapping the existing docs build command with `timeout`.
- Keep the docs project build command versioned in `packages/docs/vercel.ts`.

## Testing

- `bunx oxfmt src --write` from `packages/docs`
- `bun run build`
- `bun run stylecheck`
