### PR TITLE
`@remotion/studio`: Detect animated PNGs

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -1188,6 +1188,15 @@ const ensureImgImport = (ast: File) => {
 	});
 };
 
+const ensureAnimatedImageImport = (ast: File) => {
+	return ensureOfficialNamedImport({
+		ast,
+		importedName: 'AnimatedImage',
+		sourcePath: 'remotion',
+		label: '<AnimatedImage>',
+	});
+};
+
 const ensureVideoImport = (ast: File) => {
 	return ensureOfficialNamedImport({
 		ast,
@@ -1630,6 +1639,8 @@ const createInsertableJsxElement = ({
 			localName = ensureVideoImport(ast);
 		} else if (element.assetType === 'gif') {
 			localName = ensureGifImport(ast);
+		} else if (element.assetType === 'animated-image') {
+			localName = ensureAnimatedImageImport(ast);
 		} else if (element.assetType === 'audio') {
 			localName = ensureAudioImport(ast);
 		} else {

--- a/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
+++ b/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
@@ -17,10 +17,11 @@ const maxRemoteAssetSize = 50 * 1024 * 1024;
 const remoteAssetDownloadTimeout = 15000;
 const maxRemoteAssetRedirects = 5;
 const remoteAssetAcceptHeader =
-	'image/png,image/jpeg,image/webp,image/bmp,image/gif';
+	'image/png,image/apng,image/jpeg,image/webp,image/bmp,image/gif';
 
 const extensionsForFileType: Record<ImageFileType['type'], string[]> = {
 	png: ['png'],
+	apng: ['png', 'apng'],
 	jpeg: ['jpg', 'jpeg'],
 	webp: ['webp'],
 	bmp: ['bmp'],
@@ -335,7 +336,12 @@ export const downloadRemoteAssetHandler: ApiHandler<
 
 	const element: InsertableCompositionElement = {
 		type: 'asset',
-		assetType: fileType.type === 'gif' ? 'gif' : 'image',
+		assetType:
+			fileType.type === 'gif'
+				? 'gif'
+				: fileType.type === 'apng'
+					? 'animated-image'
+					: 'image',
 		src: assetPath,
 		srcType: 'static',
 		dimensions: fileType.dimensions,

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -106,6 +106,10 @@ const getElementLabel = (element: InsertableCompositionElement) => {
 			return '<Gif>';
 		}
 
+		if (element.assetType === 'animated-image') {
+			return '<AnimatedImage>';
+		}
+
 		if (element.assetType === 'audio') {
 			return '<Audio>';
 		}

--- a/packages/studio-server/src/test/download-remote-asset.test.ts
+++ b/packages/studio-server/src/test/download-remote-asset.test.ts
@@ -22,6 +22,13 @@ test('sanitizes remote asset filenames and uses detected extensions', () => {
 			url: new URL('https://example.com/photos/image'),
 		}),
 	).toBe('image.jpg');
+
+	expect(
+		getRemoteAssetFilename({
+			fileType: {type: 'apng', dimensions: null},
+			url: new URL('https://example.com/animation'),
+		}),
+	).toBe('animation.png');
 });
 
 test('follows validated redirects for remote assets', async () => {

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -822,6 +822,62 @@ test('inserts an Img asset with a translate style', async () => {
 	}
 });
 
+test('inserts an AnimatedImage asset into the resolved composition component', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				"import {AbsoluteFill} from 'remotion';",
+				'',
+				'export const MyComp: React.FC = () => {',
+				'\treturn <AbsoluteFill>hello</AbsoluteFill>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const result = await insertJsxElementIntoComposition({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+			element: {
+				type: 'asset',
+				assetType: 'animated-image',
+				src: 'animated-png.png',
+				srcType: 'static',
+				dimensions: {
+					width: 320,
+					height: 180,
+				},
+				position: null,
+			},
+			prettierConfigOverride: {singleQuote: true, useTabs: true},
+		});
+
+		expect(result.output).toContain(
+			"import { AbsoluteFill, staticFile, AnimatedImage } from 'remotion';",
+		);
+		expect(result.output).toContain('<AnimatedImage');
+		expect(result.output).toContain("src={staticFile('animated-png.png')}");
+		expect(result.output).toContain('width={320}');
+		expect(result.output).toContain('height={180}');
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('rejects inserting a Video asset if Video is already defined', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -639,7 +639,7 @@ export type InsertableCompositionElement =
 	  }
 	| {
 			type: 'asset';
-			assetType: 'image' | 'video' | 'gif' | 'audio';
+			assetType: 'image' | 'video' | 'gif' | 'animated-image' | 'audio';
 			src: string;
 			srcType: 'static' | 'remote';
 			dimensions: {

--- a/packages/studio-shared/src/detect-file-type.ts
+++ b/packages/studio-shared/src/detect-file-type.ts
@@ -80,13 +80,17 @@ export const isM3u = (data: Uint8Array) => {
 	return new TextDecoder('utf-8').decode(data.slice(0, 7)) === '#EXTM3U';
 };
 
+const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
+const acTLChunkType = new Uint8Array([0x61, 0x63, 0x54, 0x4c]);
+const idatChunkType = new Uint8Array([0x49, 0x44, 0x41, 0x54]);
+const iendChunkType = new Uint8Array([0x49, 0x45, 0x4e, 0x44]);
+
 const getPngDimensions = (pngData: Uint8Array): FileDimensions | null => {
 	if (pngData.length < 24) {
 		return null;
 	}
 
 	const view = new DataView(pngData.buffer, pngData.byteOffset);
-	const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
 	for (let i = 0; i < 8; i++) {
 		if (pngData[i] !== pngSignature[i]) {
 			return null;
@@ -99,12 +103,52 @@ const getPngDimensions = (pngData: Uint8Array): FileDimensions | null => {
 	};
 };
 
-const isPng = (data: Uint8Array): PngType | null => {
+const hasApngAnimationControlChunk = (pngData: Uint8Array): boolean => {
+	if (pngData.length < 16) {
+		return false;
+	}
+
+	const view = new DataView(
+		pngData.buffer,
+		pngData.byteOffset,
+		pngData.byteLength,
+	);
+	let offset = 8;
+
+	while (offset + 8 <= pngData.length) {
+		const chunkLength = view.getUint32(offset, false);
+		const chunkType = pngData.subarray(offset + 4, offset + 8);
+		if (matchesPattern(acTLChunkType)(chunkType)) {
+			return true;
+		}
+
+		if (
+			matchesPattern(idatChunkType)(chunkType) ||
+			matchesPattern(iendChunkType)(chunkType)
+		) {
+			return false;
+		}
+
+		const nextOffset = offset + 12 + chunkLength;
+		if (nextOffset <= offset) {
+			return false;
+		}
+
+		offset = nextOffset;
+	}
+
+	return false;
+};
+
+const isPng = (data: Uint8Array): PngType | ApngType | null => {
 	const pngPattern = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
 
 	if (matchesPattern(pngPattern)(data.subarray(0, 4))) {
 		const png = getPngDimensions(data);
-		return {dimensions: png, type: 'png'};
+		return {
+			dimensions: png,
+			type: hasApngAnimationControlChunk(data) ? 'apng' : 'png',
+		};
 	}
 
 	return null;
@@ -336,6 +380,11 @@ export type PngType = {
 	dimensions: FileDimensions | null;
 };
 
+export type ApngType = {
+	type: 'apng';
+	dimensions: FileDimensions | null;
+};
+
 export type JpegType = {
 	type: 'jpeg';
 	dimensions: FileDimensions | null;
@@ -372,13 +421,20 @@ export type FileType =
 	| Mp3Type
 	| GifType
 	| PngType
+	| ApngType
 	| BmpType
 	| AacType
 	| FlacType
 	| M3uType
 	| UnknownType;
 
-export type ImageFileType = JpegType | WebpType | GifType | PngType | BmpType;
+export type ImageFileType =
+	| JpegType
+	| WebpType
+	| GifType
+	| PngType
+	| ApngType
+	| BmpType;
 
 export const isImageFileType = (
 	fileType: FileType,
@@ -388,6 +444,7 @@ export const isImageFileType = (
 		fileType.type === 'webp' ||
 		fileType.type === 'gif' ||
 		fileType.type === 'png' ||
+		fileType.type === 'apng' ||
 		fileType.type === 'bmp'
 	);
 };

--- a/packages/studio-shared/src/required-package.ts
+++ b/packages/studio-shared/src/required-package.ts
@@ -35,6 +35,10 @@ export const getRequiredPackageForInsertableElement = (
 		return '@remotion/gif';
 	}
 
+	if (element.assetType === 'animated-image') {
+		return null;
+	}
+
 	return null;
 };
 

--- a/packages/studio-shared/src/test/detect-file-type.test.ts
+++ b/packages/studio-shared/src/test/detect-file-type.test.ts
@@ -18,6 +18,25 @@ test('detects PNG dimensions', () => {
 	});
 });
 
+test('detects animated PNG dimensions', () => {
+	const apng = new Uint8Array(53);
+	apng.set([0x89, 0x50, 0x4e, 0x47, 13, 10, 26, 10], 0);
+	apng.set([0, 0, 0, 13], 8);
+	apng.set([0x49, 0x48, 0x44, 0x52], 12);
+	apng.set([0, 0, 1, 64], 16);
+	apng.set([0, 0, 0, 180], 20);
+	apng.set([0, 0, 0, 8], 33);
+	apng.set([0x61, 0x63, 0x54, 0x4c], 37);
+
+	expect(detectFileType(apng)).toEqual({
+		type: 'apng',
+		dimensions: {
+			width: 320,
+			height: 180,
+		},
+	});
+});
+
 test('detects GIF dimensions', () => {
 	const gif = new Uint8Array([
 		0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x20, 0x03, 0x58, 0x02,

--- a/packages/studio-shared/src/test/required-package.test.ts
+++ b/packages/studio-shared/src/test/required-package.test.ts
@@ -55,6 +55,16 @@ test('gets required package for insertable elements', () => {
 	).toBe('@remotion/gif');
 	expect(
 		getRequiredPackageForInsertableElement({
+			type: 'asset',
+			assetType: 'animated-image',
+			src: 'animated.png',
+			srcType: 'static',
+			dimensions: null,
+			position: null,
+		}),
+	).toBe(null);
+	expect(
+		getRequiredPackageForInsertableElement({
 			type: 'component',
 			componentName: 'Circle',
 			importName: 'Circle',

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -51,6 +51,17 @@ export const getAssetElement = ({
 		};
 	}
 
+	if (fileType.type === 'apng') {
+		return {
+			type: 'asset',
+			assetType: 'animated-image',
+			src,
+			srcType: 'static',
+			dimensions: fileType.dimensions,
+			position: null,
+		};
+	}
+
 	if (fileType.type === 'gif') {
 		return {
 			type: 'asset',
@@ -120,6 +131,17 @@ export const getAssetElementFromPath = (
 		};
 	}
 
+	if (extension === 'apng') {
+		return {
+			type: 'asset',
+			assetType: 'animated-image',
+			src: assetPath,
+			srcType: 'static',
+			dimensions: null,
+			position: null,
+		};
+	}
+
 	if (extension === 'gif') {
 		return {
 			type: 'asset',
@@ -171,6 +193,10 @@ const getAssetLabel = (element: InsertableCompositionElement) => {
 
 	if (element.assetType === 'gif') {
 		return '<Gif>';
+	}
+
+	if (element.assetType === 'animated-image') {
+		return '<AnimatedImage>';
 	}
 
 	if (element.assetType === 'audio') {
@@ -285,6 +311,7 @@ const getFileDimensions = async ({
 		fileType.type === 'jpeg' ||
 		fileType.type === 'webp' ||
 		fileType.type === 'bmp' ||
+		fileType.type === 'apng' ||
 		fileType.type === 'gif'
 	) {
 		if (fileType.dimensions) {
@@ -320,7 +347,7 @@ const getStaticAssetDimensions = (
 
 	if (
 		extension &&
-		['png', 'jpg', 'jpeg', 'webp', 'bmp', 'gif'].includes(extension)
+		['png', 'jpg', 'jpeg', 'webp', 'bmp', 'gif', 'apng'].includes(extension)
 	) {
 		return getImageDimensions({revokeObjectUrl: false, src});
 	}
@@ -357,6 +384,40 @@ const getStaticAssetDimensionsOrNull = async (
 	} catch {
 		return null;
 	}
+};
+
+const getStaticAssetFileType = async (
+	assetPath: string,
+): Promise<FileType | null> => {
+	const extension = assetPath.split('.').pop()?.toLowerCase();
+	if (extension !== 'png' && extension !== 'apng') {
+		return null;
+	}
+
+	try {
+		const response = await fetch(staticFile(assetPath));
+		if (!response.ok) {
+			return null;
+		}
+
+		return detectFileType(new Uint8Array(await response.arrayBuffer()));
+	} catch {
+		return null;
+	}
+};
+
+const getAssetElementFromStaticAsset = async (
+	assetPath: string,
+): Promise<InsertableAssetElement | null> => {
+	const fileType = await getStaticAssetFileType(assetPath);
+	if (fileType) {
+		const element = getAssetElement({fileType, src: assetPath});
+		if (element) {
+			return element;
+		}
+	}
+
+	return getAssetElementFromPath(assetPath);
 };
 
 export const pickFilesToImport = (): Promise<File[]> => {
@@ -672,20 +733,21 @@ export const insertExistingAssets = async ({
 
 	try {
 		for (const assetPath of assetPaths) {
-			const element = getAssetElementFromPath(assetPath);
+			const element = await getAssetElementFromStaticAsset(assetPath);
 			if (element === null) {
 				unsupportedFiles.push(assetPath);
 				continue;
 			}
 
-			const dimensions = await getStaticAssetDimensionsOrNull(assetPath);
+			const dimensions =
+				element.dimensions ?? (await getStaticAssetDimensionsOrNull(assetPath));
 
 			const inserted = await insertAssetElement({
 				compositionFile,
 				compositionId,
 				element: {
 					...element,
-					dimensions: element.dimensions ?? dimensions,
+					dimensions,
 					position: getCenteredPosition({
 						dimensions,
 						dropPosition,

--- a/packages/studio/src/helpers/get-preview-file-type.ts
+++ b/packages/studio/src/helpers/get-preview-file-type.ts
@@ -13,7 +13,7 @@ export const getPreviewFileType = (fileName: string | null): AssetFileType => {
 
 	const audioExtensions = ['mp3', 'wav', 'ogg', 'aac'];
 	const videoExtensions = ['mp4', 'avi', 'mkv', 'mov', 'webm'];
-	const imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp'];
+	const imageExtensions = ['jpg', 'jpeg', 'png', 'apng', 'gif', 'bmp'];
 
 	const fileExtension = fileName.split('.').pop()?.toLowerCase();
 	if (fileExtension === undefined) {

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -31,6 +31,25 @@ test('does not map M3U playlists to Audio assets', () => {
 	).toBe(null);
 });
 
+test('maps animated PNG file types to AnimatedImage assets', () => {
+	expect(
+		getAssetElement({
+			fileType: {
+				type: 'apng',
+				dimensions: {width: 320, height: 180},
+			},
+			src: 'animated-png.png',
+		}),
+	).toEqual({
+		type: 'asset',
+		assetType: 'animated-image',
+		src: 'animated-png.png',
+		srcType: 'static',
+		dimensions: {width: 320, height: 180},
+		position: null,
+	});
+});
+
 test('maps existing static file paths to insertable assets', () => {
 	expect(getAssetElementFromPath('nested/photo.JPG')).toEqual({
 		type: 'asset',
@@ -52,6 +71,14 @@ test('maps existing static file paths to insertable assets', () => {
 		type: 'asset',
 		assetType: 'audio',
 		src: 'audio.flac',
+		srcType: 'static',
+		dimensions: null,
+		position: null,
+	});
+	expect(getAssetElementFromPath('animation.apng')).toEqual({
+		type: 'asset',
+		assetType: 'animated-image',
+		src: 'animation.apng',
 		srcType: 'static',
 		dimensions: null,
 		position: null,


### PR DESCRIPTION
## Summary

- Detect APNGs by parsing PNG chunks for the animation control chunk.
- Map animated PNG assets to `<AnimatedImage>` instead of `<Img>`, including existing public-folder assets and remote downloads.
- Add focused coverage for detection, asset mapping, package requirements, remote filenames, and JSX insertion.

Fixes #8388

## Test plan

- `bun test packages/studio-shared/src/test/detect-file-type.test.ts packages/studio-shared/src/test/required-package.test.ts packages/studio/src/test/import-assets.test.ts packages/studio-server/src/test/download-remote-asset.test.ts packages/studio-server/src/test/resolve-composition-component.test.ts`
- `bun -e "import {readFileSync} from 'node:fs'; import {detectFileType} from './packages/studio-shared/src/detect-file-type.ts'; console.log(JSON.stringify(detectFileType(new Uint8Array(readFileSync('packages/example/public/animated-png.png')))));"`
- `bun run build`
- `bun run stylecheck`
