### PR TITLE
`@remotion/studio`: Fix inline action icon sizing

### DIFF
--- a/packages/studio/src/components/InlineAction.tsx
+++ b/packages/studio/src/components/InlineAction.tsx
@@ -37,6 +37,7 @@ export const InlineAction = ({
 				: getBackgroundFromHoverState({hovered, selected: false}),
 			height: 24,
 			width: 24,
+			padding: 0,
 			display: 'inline-flex',
 			justifyContent: 'center',
 			alignItems: 'center',


### PR DESCRIPTION
## Summary

- Reset native button padding for Studio inline action buttons so 16px SVG icons are not flex-shrunk to 12px.

## Testing

- `bunx oxfmt src --write` in `packages/studio`
- `bun run build`
- `bun run stylecheck`

Closes #8410
