### PR TITLE
remotion.dev/convert: Allow encoding to .mp3, .aac, .flac, AC3

### DIFF
--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -335,6 +335,8 @@ const ConvertUI = ({
 						}
 
 						return {
+							codec: operation.audioCodec,
+							forceTranscode: true,
 							sampleRate: operation.sampleRate ?? undefined,
 							process(sample) {
 								if (!progress.hasVideo) {

--- a/packages/convert/app/lib/can-transcode-or-copy.ts
+++ b/packages/convert/app/lib/can-transcode-or-copy.ts
@@ -6,6 +6,35 @@ import {
 	normalizeVideoRotation,
 } from './calculate-new-dimensions-from-dimensions';
 import type {MediabunnyResize} from './mediabunny-calculate-resize-option';
+import {ensureAudioEncoderRegistered} from './register-audio-encoder';
+
+const canEncodeAudioCodec = async ({
+	codec,
+	sampleRate,
+	allowFallbackSampleRate,
+}: {
+	codec: InputAudioTrack['codec'];
+	sampleRate: number;
+	allowFallbackSampleRate: boolean;
+}) => {
+	if (codec === null) {
+		return false;
+	}
+
+	await ensureAudioEncoderRegistered(codec);
+
+	const codecs = await getEncodableAudioCodecs([codec], {sampleRate});
+	if (codecs.includes(codec)) {
+		return true;
+	}
+
+	if (!allowFallbackSampleRate) {
+		return false;
+	}
+
+	const codecsWithDefaultParams = await getEncodableAudioCodecs([codec]);
+	return codecsWithDefaultParams.includes(codec);
+};
 
 export const getAudioTranscodingOptions = async ({
 	inputTrack,
@@ -27,13 +56,17 @@ export const getAudioTranscodingOptions = async ({
 	const supportedCodecsByContainer = outputContainer.getSupportedAudioCodecs();
 
 	const configs: AudioOperation[] = [];
+	const inputSampleRate = await inputTrack.getSampleRate();
+	const audioEncoderSampleRate = sampleRate ?? inputSampleRate;
 
 	for (const codec of supportedCodecsByContainer) {
-		const codecs = await getEncodableAudioCodecs([codec], {
-			sampleRate: await inputTrack.getSampleRate(),
+		const canEncode = await canEncodeAudioCodec({
+			codec,
+			sampleRate: audioEncoderSampleRate,
+			allowFallbackSampleRate: sampleRate === null,
 		});
 
-		if (codecs.includes(codec)) {
+		if (canEncode) {
 			configs.push({
 				type: 'reencode',
 				audioCodec: codec,

--- a/packages/convert/app/lib/register-audio-encoder.ts
+++ b/packages/convert/app/lib/register-audio-encoder.ts
@@ -1,0 +1,39 @@
+import type {AudioCodec} from 'mediabunny';
+
+const registrationPromises = new Map<AudioCodec, Promise<void>>();
+
+const registerAudioEncoder = async (codec: AudioCodec) => {
+	if (codec === 'mp3') {
+		const {registerMp3Encoder} = await import('@mediabunny/mp3-encoder');
+		registerMp3Encoder();
+		return;
+	}
+
+	if (codec === 'aac') {
+		const {registerAacEncoder} = await import('@mediabunny/aac-encoder');
+		registerAacEncoder();
+		return;
+	}
+
+	if (codec === 'flac') {
+		const {registerFlacEncoder} = await import('@mediabunny/flac-encoder');
+		registerFlacEncoder();
+		return;
+	}
+
+	if (codec === 'ac3' || codec === 'eac3') {
+		const {registerAc3Encoder} = await import('@mediabunny/ac3');
+		registerAc3Encoder();
+	}
+};
+
+export const ensureAudioEncoderRegistered = (codec: AudioCodec) => {
+	const existingPromise = registrationPromises.get(codec);
+	if (existingPromise) {
+		return existingPromise;
+	}
+
+	const promise = registerAudioEncoder(codec);
+	registrationPromises.set(codec, promise);
+	return promise;
+};

--- a/packages/convert/test/audio-transcoding-options.test.ts
+++ b/packages/convert/test/audio-transcoding-options.test.ts
@@ -1,0 +1,58 @@
+import {expect, test} from 'bun:test';
+import type {InputAudioTrack} from 'mediabunny';
+import {Mp3OutputFormat, Mp4OutputFormat} from 'mediabunny';
+import {getAudioTranscodingOptions} from '../app/lib/can-transcode-or-copy';
+
+const makeAudioTrack = (sampleRate: number) =>
+	({
+		codec: 'pcm-s16',
+		canDecode: () => Promise.resolve(true),
+		getSampleRate: () => Promise.resolve(sampleRate),
+	}) as unknown as InputAudioTrack;
+
+test('allows MP3 encoding when Mediabunny can resample to default encoder params', async () => {
+	const options = await getAudioTranscodingOptions({
+		inputTrack: makeAudioTrack(96000),
+		outputContainer: new Mp3OutputFormat(),
+		sampleRate: null,
+	});
+
+	expect(options).toEqual([
+		{
+			type: 'reencode',
+			audioCodec: 'mp3',
+			sampleRate: null,
+		},
+	]);
+});
+
+test('does not use fallback encoder params for an explicit sample rate', async () => {
+	const options = await getAudioTranscodingOptions({
+		inputTrack: makeAudioTrack(96000),
+		outputContainer: new Mp3OutputFormat(),
+		sampleRate: 96000,
+	});
+
+	expect(options).toEqual([]);
+});
+
+test('registers extension-backed audio encoders for supported containers', async () => {
+	const options = await getAudioTranscodingOptions({
+		inputTrack: makeAudioTrack(48000),
+		outputContainer: new Mp4OutputFormat(),
+		sampleRate: null,
+	});
+	const codecs = options.map((option) => {
+		if (option.type !== 'reencode') {
+			throw new Error('Expected only re-encoding options');
+		}
+
+		return option.audioCodec;
+	});
+
+	expect(codecs).toContain('mp3');
+	expect(codecs).toContain('aac');
+	expect(codecs).toContain('flac');
+	expect(codecs).toContain('ac3');
+	expect(codecs).toContain('eac3');
+});


### PR DESCRIPTION
## Summary

- Enable Mediabunny extension-backed audio encoders during Remotion Convert codec discovery.
- Allow MP3 to be offered for high-sample-rate audio when Mediabunny can resample to default encoder parameters.
- Pass the selected audio codec into the actual conversion options.

Fixes #8446.

## Testing

- `bun test test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run stylecheck`
- Browser sanity check on a local 96 kHz WAV served with CORS: `.mp3` output showed `Audio Codec: MP3`.
