### PR TITLE
Docs: Fix low-memory docs builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.turbo
+.cache
+node_modules
+packages/**/.turbo
+packages/**/node_modules
+packages/**/dist
+packages/**/build
+packages/**/.docusaurus
+packages/**/tsconfig.tsbuildinfo
+packages/**/target
+out
+.DS_Store

--- a/Dockerfile.docs-oom-repro
+++ b/Dockerfile.docs-oom-repro
@@ -1,0 +1,44 @@
+FROM oven/bun:1.3.12-debian AS base
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	bash \
+	ca-certificates \
+	coreutils \
+	curl \
+	g++ \
+	git \
+	make \
+	nodejs \
+	npm \
+	procps \
+	python3 \
+	time \
+	unzip \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /vercel/path0
+
+COPY . .
+
+RUN git config --global --add safe.directory /vercel/path0
+
+ENV CI=1 \
+	DO_NOT_TRACK=1 \
+	NO_COLOR=1 \
+	TURBO_TELEMETRY_DISABLED=1 \
+	VERCEL=1 \
+	VERCEL_ENV=preview
+
+FROM base AS fresh
+
+CMD ["bash", "scripts/repro-docs-build-oom.sh"]
+
+FROM base AS deps
+
+RUN git init -q \
+	&& git config --global --add safe.directory /vercel/path0 \
+	&& bun install
+
+ENV DOCS_REPRO_SKIP_INSTALL=1
+
+CMD ["bash", "scripts/repro-docs-build-oom.sh"]

--- a/packages/docs/build-docs.ts
+++ b/packages/docs/build-docs.ts
@@ -31,6 +31,12 @@ const appendNodeOption = (value: string) => {
 	return [current, value].filter(Boolean).join(' ');
 };
 
+const nodeOldSpaceSize = process.env.REMOTION_DOCS_NODE_OLD_SPACE_MB
+	? parseInt(process.env.REMOTION_DOCS_NODE_OLD_SPACE_MB, 10)
+	: lowMemoryBuild
+		? 3072
+		: 4096;
+
 const run = (
 	label: string,
 	command: string,
@@ -89,17 +95,21 @@ const run = (
 
 const docusaurusEnv = {
 	DOCUSAURUS_IGNORE_SSG_WARNINGS: 'true',
+	DOCUSAURUS_NO_PERSISTENT_CACHE: lowMemoryBuild ? 'true' : undefined,
 	DOCUSAURUS_PERF_LOGGER:
 		process.env.DOCUSAURUS_PERF_LOGGER ?? (isVercel ? 'true' : undefined),
-	NODE_OPTIONS: appendNodeOption('--max-old-space-size=4096'),
+	NODE_OPTIONS: appendNodeOption(`--max-old-space-size=${nodeOldSpaceSize}`),
 	...(lowMemoryBuild
 		? {
 				DOCUSAURUS_SSG_WORKER_THREAD_COUNT:
-					process.env.DOCUSAURUS_SSG_WORKER_THREAD_COUNT ?? '2',
+					process.env.DOCUSAURUS_SSG_WORKER_THREAD_COUNT ?? '1',
+				DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY:
+					process.env.DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY ??
+					String(512 * 1024 * 1024),
 				DOCUSAURUS_SSG_WORKER_THREAD_TASK_SIZE:
-					process.env.DOCUSAURUS_SSG_WORKER_THREAD_TASK_SIZE ?? '5',
+					process.env.DOCUSAURUS_SSG_WORKER_THREAD_TASK_SIZE ?? '1',
 				DOCUSAURUS_SSR_CONCURRENCY:
-					process.env.DOCUSAURUS_SSR_CONCURRENCY ?? '8',
+					process.env.DOCUSAURUS_SSR_CONCURRENCY ?? '2',
 			}
 		: null),
 };
@@ -111,10 +121,24 @@ const twoslashEnv = lowMemoryBuild
 				process.env.TWOSLASH_RECYCLE_LIMIT_BYTES ?? String(1024 * 1024 * 1024),
 		}
 	: {};
+const docusaurusBuild = lowMemoryBuild
+	? {
+			command: 'node',
+			args: ['build-docusaurus-low-memory.cjs'],
+		}
+	: {
+			command: 'bunx',
+			args: ['docusaurus', 'build'],
+		};
 
 await run('copy raw docs', 'bun', ['copy-raw-docs.ts']);
 await run('fetch prompt submissions', 'bun', ['fetch-prompt-submissions.ts']);
 await run('prewarm twoslash', 'bun', ['prewarm-twoslash.ts'], twoslashEnv);
-await run('Docusaurus build', 'bunx', ['docusaurus', 'build'], docusaurusEnv);
+await run(
+	'Docusaurus build',
+	docusaurusBuild.command,
+	docusaurusBuild.args,
+	docusaurusEnv,
+);
 await run('copy convert assets', 'bun', ['copy-convert.ts']);
 await run('count generated pages', 'bun', ['count-pages.ts']);

--- a/packages/docs/build-docusaurus-low-memory.cjs
+++ b/packages/docs/build-docusaurus-low-memory.cjs
@@ -1,0 +1,375 @@
+const fs = require('fs/promises');
+const {spawn} = require('child_process');
+const {createRequire} = require('module');
+const path = require('path');
+
+const docusaurusRequire = createRequire(
+	require.resolve('@docusaurus/core/lib/commands/build/buildLocale'),
+);
+
+const logger = docusaurusRequire('@docusaurus/logger').default;
+const {PerfLogger} = docusaurusRequire('@docusaurus/logger');
+const {compile, registerBundlerTracing} = docusaurusRequire(
+	'@docusaurus/bundler',
+);
+const {loadSite} = docusaurusRequire('@docusaurus/core/lib/server/site');
+const {createConfigureWebpackUtils, executePluginsConfigureWebpack} =
+	docusaurusRequire('@docusaurus/core/lib/webpack/configure');
+const {createBuildClientConfig} = docusaurusRequire(
+	'@docusaurus/core/lib/webpack/client',
+);
+const createServerConfig = docusaurusRequire(
+	'@docusaurus/core/lib/webpack/server',
+).default;
+const {executeSSG} = docusaurusRequire('@docusaurus/core/lib/ssg/ssgExecutor');
+const clearPath = docusaurusRequire(
+	'@docusaurus/core/lib/commands/utils/clearPath',
+).default;
+const {handleBrokenLinks} = docusaurusRequire(
+	'@docusaurus/core/lib/server/brokenLinks',
+);
+
+const locale = 'en';
+const phases = ['client', 'server', 'ssg'];
+
+const mapValues = (object, mapper) =>
+	Object.fromEntries(
+		Object.entries(object).map(([key, value]) => [key, mapper(value)]),
+	);
+
+const configureDocusaurusEnv = () => {
+	process.env.BABEL_ENV = 'production';
+	process.env.NODE_ENV = 'production';
+	process.env.DOCUSAURUS_CURRENT_LOCALE = locale;
+};
+
+const getBuildPaths = (props) => {
+	const router = props.siteConfig.future.experimental_router;
+
+	return {
+		clientManifestPath: path.join(
+			props.generatedFilesDir,
+			'client-manifest.json',
+		),
+		router,
+		serverBundlePath:
+			router === 'hash'
+				? undefined
+				: path.join(props.outDir, '__server', 'server.bundle.js'),
+	};
+};
+
+const loadLowMemorySite = async () => {
+	const siteDir = await fs.realpath(process.cwd());
+
+	return PerfLogger.async('Load site', () =>
+		loadSite({
+			siteDir,
+			locale,
+			automaticBaseUrlLocalizationDisabled: false,
+		}),
+	);
+};
+
+const createConfigureUtils = async (props) => {
+	return createConfigureWebpackUtils({siteConfig: props.siteConfig});
+};
+
+const createClientConfig = async ({props, configureWebpackUtils}) => {
+	const {plugins} = props;
+	const result = await createBuildClientConfig({
+		props,
+		minify: true,
+		faster: props.siteConfig.future.faster,
+		configureWebpackUtils,
+		bundleAnalyzer: false,
+	});
+
+	return {
+		clientConfig: executePluginsConfigureWebpack({
+			plugins,
+			config: result.config,
+			isServer: false,
+			configureWebpackUtils,
+		}),
+		clientManifestPath: result.clientManifestPath,
+	};
+};
+
+const createServerBuild = async ({props, configureWebpackUtils}) => {
+	const {plugins} = props;
+	const result = await createServerConfig({
+		props,
+		configureWebpackUtils,
+	});
+	const serverConfig = executePluginsConfigureWebpack({
+		plugins,
+		config: result.config,
+		isServer: true,
+		configureWebpackUtils,
+	});
+
+	return {
+		serverBundlePath: result.serverBundlePath,
+		serverConfig: tuneServerConfigForLowMemory(serverConfig),
+	};
+};
+
+const tuneServerConfigForLowMemory = (config) => {
+	return {
+		...config,
+		cache: false,
+		devtool: false,
+		mode: 'none',
+		parallelism: Number(
+			process.env.REMOTION_DOCS_WEBPACK_SERVER_PARALLELISM ?? 1,
+		),
+		optimization: {
+			...config.optimization,
+			chunkIds: 'named',
+			concatenateModules: false,
+			flagIncludedChunks: false,
+			innerGraph: false,
+			mangleExports: false,
+			mergeDuplicateChunks: false,
+			minimize: false,
+			moduleIds: 'named',
+			providedExports: false,
+			realContentHash: false,
+			removeAvailableModules: false,
+			removeEmptyChunks: false,
+			sideEffects: false,
+			splitChunks: false,
+			usedExports: false,
+		},
+	};
+};
+
+const compileConfigs = async ({
+	label,
+	props,
+	configureWebpackUtils,
+	configs,
+}) => {
+	const cleanupBundlerTracing = await registerBundlerTracing({
+		currentBundler: props.currentBundler,
+	});
+
+	try {
+		await PerfLogger.async(
+			`Bundling ${label} with ${props.currentBundler.name}`,
+			() =>
+				compile({
+					configs,
+					currentBundler: configureWebpackUtils.currentBundler,
+				}),
+		);
+	} finally {
+		await cleanupBundlerTracing();
+	}
+};
+
+const runClientPhase = async () => {
+	logger.info`name=${`[${locale}]`} Building client bundle in low-memory mode...`;
+
+	const site = await loadLowMemorySite();
+	const {props} = site;
+	const configureWebpackUtils = await createConfigureUtils(props);
+	const {clientConfig} = await PerfLogger.async(
+		`Creating ${props.currentBundler.name} client bundler config`,
+		() =>
+			Promise.all([
+				createClientConfig({props, configureWebpackUtils}),
+				clearPath(props.outDir),
+			]).then(([client]) => client),
+	);
+
+	await compileConfigs({
+		label: 'client',
+		props,
+		configureWebpackUtils,
+		configs: [clientConfig],
+	});
+};
+
+const runServerPhase = async () => {
+	const site = await loadLowMemorySite();
+	const {props} = site;
+	const {router} = getBuildPaths(props);
+
+	if (router === 'hash') {
+		logger.info`Skipping server bundle for hash router.`;
+		return;
+	}
+
+	logger.info`name=${`[${locale}]`} Building server bundle in low-memory mode...`;
+
+	const configureWebpackUtils = await createConfigureUtils(props);
+	const {serverConfig} = await PerfLogger.async(
+		`Creating ${props.currentBundler.name} server bundler config`,
+		() => createServerBuild({props, configureWebpackUtils}),
+	);
+
+	await compileConfigs({
+		label: 'server',
+		props,
+		configureWebpackUtils,
+		configs: [serverConfig],
+	});
+};
+
+const cleanupServerBundle = async (serverBundlePath) => {
+	if (!serverBundlePath) {
+		return;
+	}
+
+	if (process.env.DOCUSAURUS_KEEP_SERVER_BUNDLE === 'true') {
+		logger.warn(
+			"Will NOT delete server bundle because DOCUSAURUS_KEEP_SERVER_BUNDLE='true'",
+		);
+		return;
+	}
+
+	await PerfLogger.async('Deleting server bundle', async () => {
+		await fs.rm(path.dirname(serverBundlePath), {
+			recursive: true,
+			force: true,
+		});
+	});
+};
+
+const executePluginsPostBuild = async ({plugins, props, collectedData}) => {
+	const head = props.siteConfig.future.v4.removeLegacyPostBuildHeadAttribute
+		? {}
+		: mapValues(collectedData, (data) => data.metadata.helmet);
+	const routesBuildMetadata = mapValues(
+		collectedData,
+		(data) => data.metadata.public,
+	);
+
+	await Promise.all(
+		plugins.map(async (plugin) => {
+			if (!plugin.postBuild) {
+				return;
+			}
+
+			await plugin.postBuild({
+				...props,
+				head,
+				routesBuildMetadata,
+				content: plugin.content,
+			});
+		}),
+	);
+};
+
+const executeBrokenLinksCheck = async ({props, collectedData}) => {
+	const collectedLinks = mapValues(collectedData, (data) => ({
+		links: data.links,
+		anchors: data.anchors,
+	}));
+
+	await handleBrokenLinks({
+		collectedLinks,
+		routes: props.routes,
+		onBrokenLinks: props.siteConfig.onBrokenLinks,
+		onBrokenAnchors: props.siteConfig.onBrokenAnchors,
+	});
+};
+
+const runSsgPhase = async () => {
+	logger.info`name=${`[${locale}]`} Generating static HTML in low-memory mode...`;
+
+	const site = await loadLowMemorySite();
+	const {props} = site;
+	const {clientManifestPath, router, serverBundlePath} = getBuildPaths(props);
+
+	const {collectedData} = await PerfLogger.async('SSG', () =>
+		executeSSG({
+			props,
+			serverBundlePath,
+			clientManifestPath,
+			router,
+		}),
+	);
+
+	await cleanupServerBundle(serverBundlePath);
+
+	await PerfLogger.async('postBuild()', () =>
+		executePluginsPostBuild({plugins: props.plugins, props, collectedData}),
+	);
+	await PerfLogger.async('Broken links checker', () =>
+		executeBrokenLinksCheck({props, collectedData}),
+	);
+
+	logger.success`Generated static files in path=${path.relative(
+		process.cwd(),
+		props.outDir,
+	)}.`;
+	logger.info`Use code=${'npm run serve'} command to test your build locally.`;
+};
+
+const runPhaseInSubprocess = (phase) => {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, ['--expose-gc', __filename, phase], {
+			env: process.env,
+			stdio: 'inherit',
+		});
+
+		child.on('error', reject);
+		child.on('exit', (code, signal) => {
+			if (code === 0) {
+				resolve();
+				return;
+			}
+
+			reject(
+				new Error(
+					`Docusaurus low-memory ${phase} phase exited with code ${code}, signal ${signal}`,
+				),
+			);
+		});
+	});
+};
+
+const runAllPhases = async () => {
+	logger.info`name=${`[${locale}]`} Creating an optimized production build...`;
+
+	for (const phase of phases) {
+		await runPhaseInSubprocess(phase);
+	}
+};
+
+const main = async () => {
+	configureDocusaurusEnv();
+
+	const phase = process.argv[2] ?? 'all';
+
+	if (phase === 'all') {
+		await runAllPhases();
+		return;
+	}
+
+	switch (phase) {
+		case 'client':
+			await runClientPhase();
+			return;
+		case 'server':
+			await runServerPhase();
+			return;
+		case 'ssg':
+			await runSsgPhase();
+			return;
+		default:
+			throw new Error(
+				`Unknown low-memory Docusaurus phase "${phase}". Expected all, ${phases.join(
+					', ',
+				)}.`,
+			);
+	}
+};
+
+main().catch((err) => {
+	console.error(err);
+	process.exitCode = 1;
+});

--- a/packages/docs/copy-convert.ts
+++ b/packages/docs/copy-convert.ts
@@ -8,6 +8,8 @@ const dir = path.join(__dirname, '../convert/spa-dist/client');
 const brandDir = path.join(__dirname, '../brand/build');
 const testbedDir = path.join(__dirname, '../example/build-testbed');
 const isVercel = process.env.VERCEL === '1' || process.env.VERCEL === 'true';
+const lowMemoryBuild =
+	isVercel || process.env.REMOTION_DOCS_LOW_MEMORY_BUILD === '1';
 const prebuiltAssetsExist = [dir, brandDir, testbedDir].every((assetDir) =>
 	fs.existsSync(assetDir),
 );
@@ -16,6 +18,8 @@ if (isVercel && prebuiltAssetsExist) {
 	console.log(
 		'[docs build] Reusing prebuilt convert, brand, and testbed assets.',
 	);
+} else if (lowMemoryBuild) {
+	await $`bunx turbo "@remotion/convert#build-spa" "@remotion/brand#bundle" "@remotion/example#bundle-testbed" --concurrency=1`;
 } else {
 	await $`bunx turbo "@remotion/convert#build-spa" "@remotion/brand#bundle" "@remotion/example#bundle-testbed"`;
 }

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -1,6 +1,28 @@
 import type {Config} from '@docusaurus/types';
 import remarkExportRaw from './plugins/remark-export-raw.js';
 
+const lowMemoryBuild =
+	process.env.VERCEL === '1' ||
+	process.env.VERCEL === 'true' ||
+	process.env.REMOTION_DOCS_LOW_MEMORY_BUILD === '1';
+
+const fasterConfig = lowMemoryBuild
+	? {
+			swcJsLoader: true,
+			swcJsMinimizer: true,
+			swcHtmlMinimizer: true,
+			lightningCssMinimizer: true,
+			mdxCrossCompilerCache: false,
+			rspackBundler: false,
+			rspackPersistentCache: false,
+			ssgWorkerThreads: false,
+			gitEagerVcs: false,
+		}
+	: true;
+
+const showGitLastUpdate =
+	process.env.REMOTION_DOCS_DISABLE_GIT_LAST_UPDATE !== '1';
+
 const config: Config = {
 	title: 'Remotion | Make videos programmatically',
 	tagline: 'Make videos programmatically',
@@ -17,7 +39,7 @@ const config: Config = {
 	organizationName: 'remotion-dev', // Usually your GitHub org/user name.
 	projectName: 'remotion', // Usually your repo name.
 	future: {
-		faster: true,
+		faster: fasterConfig,
 		v4: {
 			removeLegacyPostBuildHeadAttribute: true,
 		},
@@ -270,7 +292,7 @@ const config: Config = {
 					sidebarPath: './sidebars.ts',
 					editUrl:
 						'https://github.com/remotion-dev/remotion/edit/main/packages/docs/',
-					showLastUpdateTime: true,
+					showLastUpdateTime: showGitLastUpdate,
 					remarkPlugins: [remarkExportRaw],
 				},
 				blog: {
@@ -284,9 +306,7 @@ const config: Config = {
 				theme: {
 					customCss: [
 						require.resolve('./src/css/custom.css'),
-						require.resolve(
-							'./docusaurus-theme-shiki-twoslash/theme/CodeBlock/styles.css',
-						),
+						require.resolve('./docusaurus-theme-shiki-twoslash/theme/CodeBlock/styles.css'),
 					],
 				},
 			},
@@ -312,7 +332,7 @@ const config: Config = {
 				sidebarPath: './examples-sidebars.ts',
 				editUrl:
 					'https://github.com/remotion-dev/remotion/edit/main/packages/docs/',
-				showLastUpdateTime: true,
+				showLastUpdateTime: showGitLastUpdate,
 				remarkPlugins: [remarkExportRaw],
 			},
 		],

--- a/packages/docs/vercel.ts
+++ b/packages/docs/vercel.ts
@@ -1,7 +1,8 @@
 import {routes, type VercelConfig} from '@vercel/config/v1';
 
 export const config: VercelConfig = {
-	buildCommand: 'cd .. && timeout 20m pnpm build-docs',
+	buildCommand:
+		'cd .. && timeout 20m bunx turbo run build-docs --no-update-notifier --concurrency=2',
 	headers: [
 		routes.cacheControl('/assets/(.*)', {
 			public: true,

--- a/scripts/repro-docs-build-oom.sh
+++ b/scripts/repro-docs-build-oom.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+monitor_interval="${DOCS_REPRO_MONITOR_INTERVAL_SECONDS:-20}"
+turbo_cache_dir="${DOCS_REPRO_TURBO_CACHE_DIR:-/tmp/remotion-turbo-cache}"
+build_command="${DOCS_REPRO_BUILD_COMMAND:-bunx turbo run build-docs --no-update-notifier --force --cache-dir=/tmp/remotion-turbo-cache --summarize}"
+export REMOTION_DOCS_DISABLE_GIT_LAST_UPDATE="${REMOTION_DOCS_DISABLE_GIT_LAST_UPDATE:-1}"
+
+print_cgroup_file() {
+	local label="$1"
+	local file="$2"
+	if [[ -f "$file" ]]; then
+		printf '%s=%s\n' "$label" "$(cat "$file")"
+	fi
+}
+
+print_limits() {
+	echo "== Environment =="
+	echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+	echo "bun=$(bun --version)"
+	echo "node=$(node --version 2>/dev/null || true)"
+	echo "pwd=$(pwd)"
+	print_cgroup_file "cgroup.memory.max" "/sys/fs/cgroup/memory.max"
+	print_cgroup_file "cgroup.memory.current" "/sys/fs/cgroup/memory.current"
+	print_cgroup_file "cgroup.memory.swap.max" "/sys/fs/cgroup/memory.swap.max"
+	print_cgroup_file "cgroup.cpu.max" "/sys/fs/cgroup/cpu.max"
+	echo
+}
+
+monitor_memory() {
+	while true; do
+		echo
+		echo "== Memory sample $(date -u +"%Y-%m-%dT%H:%M:%SZ") =="
+		print_cgroup_file "cgroup.memory.current" "/sys/fs/cgroup/memory.current"
+		free -m || true
+		ps -eo pid,ppid,rss,vsz,comm,args --sort=-rss | head -16 || true
+		sleep "$monitor_interval"
+	done
+}
+
+cleanup_outputs() {
+	rm -rf \
+		"$turbo_cache_dir" \
+		.turbo \
+		packages/*/.turbo \
+		packages/*/dist \
+		packages/*/tsconfig.tsbuildinfo \
+		packages/docs/.docusaurus \
+		packages/docs/build \
+		packages/docs/node_modules/.cache/twoslash \
+		packages/convert/spa-dist \
+		packages/brand/build \
+		packages/example/build-testbed
+}
+
+print_limits
+if [[ ! -d .git ]]; then
+	git init -q
+fi
+git config --global --add safe.directory "$(pwd)"
+cleanup_outputs
+
+monitor_memory &
+monitor_pid="$!"
+trap 'kill "$monitor_pid" 2>/dev/null || true' EXIT
+
+echo "== Installing dependencies =="
+if [[ "${DOCS_REPRO_SKIP_INSTALL:-0}" == "1" ]]; then
+	echo "Skipping dependency install; image already contains node_modules."
+else
+	bun install
+fi
+
+echo
+echo "== Building docs =="
+echo "$build_command"
+mkdir -p "$turbo_cache_dir"
+/usr/bin/time -v bash -lc "$build_command"


### PR DESCRIPTION
## Summary

- add a low-memory Docusaurus build path for Vercel docs builds
- split Docusaurus client, server, and SSG phases into separate Node processes
- tune the server bundle and docs asset-copy step to stay below constrained build memory
- add a Docker repro harness for 4GB / 4 CPU docs builds

## Test plan

- `cd packages/docs && bunx oxfmt src --write`
- `bunx oxfmt packages/docs/build-docs.ts packages/docs/copy-convert.ts packages/docs/docusaurus.config.ts packages/docs/vercel.ts packages/docs/build-docusaurus-low-memory.cjs --write`
- `bun run build`
- `bun run stylecheck`
- Docker repro: `docker run --rm --memory=4g --memory-swap=4g --cpus=4 ... remotion-docs-oom-repro:lowmem-deps`
