### PR TITLE
`@remotion/studio`: Show connected UV controls for effect children

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -813,6 +813,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				<SelectedOutlineUvHandleCircleLayer
 					key={`${outline.key}-uv-handles`}
 					onDraggingChange={onDraggingChange}
+					onSelect={selectItem}
 					outline={outline}
 					target={targetsByKey.get(outline.key)}
 				/>

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -72,7 +72,9 @@ export {
 	getSelectedOutlineScaleEdgeInfo,
 	getSelectedOutlineTransformOriginLockedAxis,
 	isSelectedOutlineDragPastThreshold,
+	selectedOutlineUvSnapThresholdPx,
 	selectedOutlineTransformOriginSnapThresholdPx,
+	snapSelectedOutlineUv,
 	snapSelectedOutlineTransformOriginUv,
 } from './selected-outline-drag';
 export {

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -113,7 +113,7 @@ const SelectedUvHandleCircle: React.FC<{
 		() => getUvHandlePosition(outline.points, handle.value),
 		[handle.value, outline.points],
 	);
-	const outlined = handle.isSelected || hovered;
+	const highlighted = handle.isSelected || hovered;
 
 	const onPointerDown = React.useCallback(
 		(event: React.PointerEvent<SVGCircleElement>) => {
@@ -291,8 +291,8 @@ const SelectedUvHandleCircle: React.FC<{
 			cy={position.y}
 			r={handle.isSelected ? selectedUvHandleRadius : uvHandleRadius}
 			fill="white"
-			stroke={outlined ? BLUE : 'transparent'}
-			strokeWidth={2}
+			stroke={BLUE}
+			strokeWidth={highlighted ? 2 : 1}
 			style={uvHandleStyle}
 			vectorEffect="non-scaling-stroke"
 			pointerEvents="all"

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useMemo, useState} from 'react';
+import React, {useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {BLUE} from '../helpers/colors';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
@@ -108,12 +108,10 @@ const SelectedUvHandleCircle: React.FC<{
 }> = ({handle, nodePathInfo, onDraggingChange, onSelect, outline}) => {
 	const {setEffectDragOverrides, clearEffectDragOverrides, setPropStatuses} =
 		useContext(Internals.VisualModeSettersContext);
-	const [hovered, setHovered] = useState(false);
 	const position = useMemo(
 		() => getUvHandlePosition(outline.points, handle.value),
 		[handle.value, outline.points],
 	);
-	const highlighted = handle.isSelected || hovered;
 
 	const onPointerDown = React.useCallback(
 		(event: React.PointerEvent<SVGCircleElement>) => {
@@ -292,13 +290,11 @@ const SelectedUvHandleCircle: React.FC<{
 			r={handle.isSelected ? selectedUvHandleRadius : uvHandleRadius}
 			fill="white"
 			stroke={BLUE}
-			strokeWidth={highlighted ? 2 : 1}
+			strokeWidth={2}
 			style={uvHandleStyle}
 			vectorEffect="non-scaling-stroke"
 			pointerEvents="all"
 			cursor="default"
-			onPointerEnter={() => setHovered(true)}
-			onPointerLeave={() => setHovered(false)}
 			onPointerDown={onPointerDown}
 		/>
 	);

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -3,6 +3,10 @@ import {Internals} from 'remotion';
 import {BLUE} from '../helpers/colors';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {
+	forceSpecificCursor,
+	stopForcingSpecificCursor,
+} from './ForceSpecificCursor';
+import {
 	isSelectedOutlineDragPastThreshold,
 	snapSelectedOutlineUv,
 } from './selected-outline-drag';
@@ -185,6 +189,7 @@ const SelectedUvHandleCircle: React.FC<{
 					}
 
 					dragging = true;
+					forceSpecificCursor('default');
 					onDraggingChange(true);
 				}
 
@@ -201,6 +206,7 @@ const SelectedUvHandleCircle: React.FC<{
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
 				if (dragging) {
+					stopForcingSpecificCursor();
 					onDraggingChange(false);
 				}
 

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -28,6 +28,9 @@ const getSvgPointFromPointerEvent = ({
 	};
 };
 
+const uvHandleRadius = 6;
+const selectedUvHandleRadius = 8;
+
 const SelectedUvHandleConnectionLines: React.FC<{
 	readonly handles: readonly SelectedOutlineUvHandle[];
 	readonly outline: SelectedOutline;
@@ -204,7 +207,7 @@ const SelectedUvHandleCircle: React.FC<{
 		<circle
 			cx={position.x}
 			cy={position.y}
-			r={6}
+			r={handle.isSelected ? selectedUvHandleRadius : uvHandleRadius}
 			fill="white"
 			stroke={BLUE}
 			strokeWidth={2}

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -28,7 +28,7 @@ const getSvgPointFromPointerEvent = ({
 	};
 };
 
-const uvHandleRadius = 6;
+const uvHandleRadius = 5;
 const selectedUvHandleRadius = 8;
 
 const SelectedUvHandleConnectionLines: React.FC<{

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -42,8 +42,8 @@ const getSvgPointFromPointerEvent = ({
 	};
 };
 
-const uvHandleRadius = 3.5;
-const selectedUvHandleRadius = 5.6;
+const uvHandleRadius = 4.25;
+const selectedUvHandleRadius = 6.8;
 const uvHandleStyle: React.CSSProperties = {
 	filter: 'drop-shadow(0 1px 2px rgba(0, 0, 0, 0.28))',
 };

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -42,8 +42,8 @@ const getSvgPointFromPointerEvent = ({
 	};
 };
 
-const uvHandleRadius = 5;
-const selectedUvHandleRadius = 8;
+const uvHandleRadius = 3.5;
+const selectedUvHandleRadius = 5.6;
 const uvHandleStyle: React.CSSProperties = {
 	filter: 'drop-shadow(0 1px 2px rgba(0, 0, 0, 0.28))',
 };

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useMemo} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 import {Internals} from 'remotion';
 import {BLUE} from '../helpers/colors';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
@@ -44,6 +44,9 @@ const getSvgPointFromPointerEvent = ({
 
 const uvHandleRadius = 5;
 const selectedUvHandleRadius = 8;
+const uvHandleStyle: React.CSSProperties = {
+	filter: 'drop-shadow(0 1px 2px rgba(0, 0, 0, 0.28))',
+};
 
 export const getSelectedOutlineUvHandleTimelineSelection = ({
 	effectIndex,
@@ -105,10 +108,12 @@ const SelectedUvHandleCircle: React.FC<{
 }> = ({handle, nodePathInfo, onDraggingChange, onSelect, outline}) => {
 	const {setEffectDragOverrides, clearEffectDragOverrides, setPropStatuses} =
 		useContext(Internals.VisualModeSettersContext);
+	const [hovered, setHovered] = useState(false);
 	const position = useMemo(
 		() => getUvHandlePosition(outline.points, handle.value),
 		[handle.value, outline.points],
 	);
+	const outlined = handle.isSelected || hovered;
 
 	const onPointerDown = React.useCallback(
 		(event: React.PointerEvent<SVGCircleElement>) => {
@@ -286,11 +291,14 @@ const SelectedUvHandleCircle: React.FC<{
 			cy={position.y}
 			r={handle.isSelected ? selectedUvHandleRadius : uvHandleRadius}
 			fill="white"
-			stroke={BLUE}
+			stroke={outlined ? BLUE : 'transparent'}
 			strokeWidth={2}
+			style={uvHandleStyle}
 			vectorEffect="non-scaling-stroke"
 			pointerEvents="all"
 			cursor="default"
+			onPointerEnter={() => setHovered(true)}
+			onPointerLeave={() => setHovered(false)}
 			onPointerDown={onPointerDown}
 		/>
 	);

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -1,7 +1,10 @@
 import React, {useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {BLUE} from '../helpers/colors';
+import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+import {isSelectedOutlineDragPastThreshold} from './selected-outline-drag';
 import type {OutlinePoint, SelectedOutline} from './selected-outline-geometry';
+import {getOutlineSelectionInteraction} from './selected-outline-measurement';
 import {
 	constrainUv,
 	getUvCoordinateForPoint,
@@ -14,6 +17,10 @@ import {
 } from './selected-outline-uv';
 import {callAddEffectKeyframe} from './Timeline/call-add-keyframe';
 import {saveEffectProp} from './Timeline/save-effect-prop';
+import type {
+	TimelineSelection,
+	TimelineSelectionInteraction,
+} from './Timeline/TimelineSelection';
 
 const getSvgPointFromPointerEvent = ({
 	event,
@@ -30,6 +37,26 @@ const getSvgPointFromPointerEvent = ({
 
 const uvHandleRadius = 5;
 const selectedUvHandleRadius = 8;
+
+export const getSelectedOutlineUvHandleTimelineSelection = ({
+	effectIndex,
+	fieldKey,
+	nodePathInfo,
+}: {
+	readonly effectIndex: number;
+	readonly fieldKey: string;
+	readonly nodePathInfo: SequenceNodePathInfo;
+}): TimelineSelection => {
+	return {
+		type: 'sequence-effect-prop',
+		nodePathInfo: {
+			...nodePathInfo,
+			auxiliaryKeys: ['effects', String(effectIndex), fieldKey],
+		},
+		i: effectIndex,
+		key: fieldKey,
+	};
+};
 
 const SelectedUvHandleConnectionLines: React.FC<{
 	readonly handles: readonly SelectedOutlineUvHandle[];
@@ -61,9 +88,14 @@ const SelectedUvHandleConnectionLines: React.FC<{
 
 const SelectedUvHandleCircle: React.FC<{
 	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly onSelect: (
+		item: TimelineSelection,
+		interaction?: TimelineSelectionInteraction,
+	) => void;
 	readonly handle: SelectedOutlineUvHandle;
+	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly outline: SelectedOutline;
-}> = ({handle, onDraggingChange, outline}) => {
+}> = ({handle, nodePathInfo, onDraggingChange, onSelect, outline}) => {
 	const {setEffectDragOverrides, clearEffectDragOverrides, setPropStatuses} =
 		useContext(Internals.VisualModeSettersContext);
 	const position = useMemo(
@@ -80,14 +112,30 @@ const SelectedUvHandleCircle: React.FC<{
 			event.preventDefault();
 			event.stopPropagation();
 
+			const interaction = getOutlineSelectionInteraction(event);
+			onSelect(
+				getSelectedOutlineUvHandleTimelineSelection({
+					effectIndex: handle.effectIndex,
+					fieldKey: handle.fieldKey,
+					nodePathInfo,
+				}),
+				interaction,
+			);
+
+			if (interaction.shiftKey || interaction.toggleKey) {
+				return;
+			}
+
 			const svg = event.currentTarget.ownerSVGElement;
 			if (svg === null) {
 				return;
 			}
 
 			const svgRect = svg.getBoundingClientRect();
+			const startPointerX = event.clientX;
+			const startPointerY = event.clientY;
 			let lastValue: UvCoordinate | null = null;
-			onDraggingChange(true);
+			let dragging = false;
 			const defaultValue =
 				handle.fieldDefault !== undefined
 					? JSON.stringify(handle.fieldDefault)
@@ -122,18 +170,33 @@ const SelectedUvHandleCircle: React.FC<{
 				);
 			};
 
-			updateFromPointerEvent(event);
+			const updateDragFromPointerEvent = (pointerEvent: PointerEvent) => {
+				if (!dragging) {
+					const deltaX = pointerEvent.clientX - startPointerX;
+					const deltaY = pointerEvent.clientY - startPointerY;
+					if (!isSelectedOutlineDragPastThreshold({deltaX, deltaY})) {
+						return;
+					}
+
+					dragging = true;
+					onDraggingChange(true);
+				}
+
+				updateFromPointerEvent(pointerEvent);
+			};
 
 			const onPointerMove = (moveEvent: PointerEvent) => {
 				moveEvent.preventDefault();
-				updateFromPointerEvent(moveEvent);
+				updateDragFromPointerEvent(moveEvent);
 			};
 
 			const onPointerUp = () => {
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
-				onDraggingChange(false);
+				if (dragging) {
+					onDraggingChange(false);
+				}
 
 				const stringifiedValue =
 					lastValue === null ? null : JSON.stringify(lastValue);
@@ -196,7 +259,9 @@ const SelectedUvHandleCircle: React.FC<{
 		[
 			clearEffectDragOverrides,
 			handle,
+			nodePathInfo,
 			onDraggingChange,
+			onSelect,
 			outline.points,
 			setPropStatuses,
 			setEffectDragOverrides,
@@ -221,6 +286,7 @@ const SelectedUvHandleCircle: React.FC<{
 
 type UvTarget = {
 	readonly containsSelection: boolean;
+	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly uvHandles: readonly SelectedOutlineUvHandle[];
 };
 
@@ -242,9 +308,13 @@ export const SelectedOutlineUvHandleConnectionLayer: React.FC<{
 
 export const SelectedOutlineUvHandleCircleLayer: React.FC<{
 	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly onSelect: (
+		item: TimelineSelection,
+		interaction?: TimelineSelectionInteraction,
+	) => void;
 	readonly outline: SelectedOutline;
 	readonly target: UvTarget | undefined;
-}> = ({onDraggingChange, outline, target}) => {
+}> = ({onDraggingChange, onSelect, outline, target}) => {
 	if (!target?.containsSelection || target.uvHandles.length === 0) {
 		return null;
 	}
@@ -255,7 +325,9 @@ export const SelectedOutlineUvHandleCircleLayer: React.FC<{
 				<SelectedUvHandleCircle
 					key={`${handle.effectIndex}-${handle.fieldKey}`}
 					handle={handle}
+					nodePathInfo={target.nodePathInfo}
 					onDraggingChange={onDraggingChange}
+					onSelect={onSelect}
 					outline={outline}
 				/>
 			))}

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -2,7 +2,10 @@ import React, {useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {BLUE} from '../helpers/colors';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
-import {isSelectedOutlineDragPastThreshold} from './selected-outline-drag';
+import {
+	isSelectedOutlineDragPastThreshold,
+	snapSelectedOutlineUv,
+} from './selected-outline-drag';
 import type {OutlinePoint, SelectedOutline} from './selected-outline-geometry';
 import {getOutlineSelectionInteraction} from './selected-outline-measurement';
 import {
@@ -148,11 +151,14 @@ const SelectedUvHandleCircle: React.FC<{
 					event: pointerEvent,
 					rect: svgRect,
 				});
+				const rawUv = getUvCoordinateForPoint(outline.points, point);
+				const snappedUv = snapSelectedOutlineUv({
+					point,
+					points: outline.points,
+					uv: rawUv,
+				});
 				const nextValue = roundUvCoordinate(
-					constrainUv(
-						getUvCoordinateForPoint(outline.points, point),
-						handle.fieldSchema,
-					),
+					constrainUv(snappedUv, handle.fieldSchema),
 					handle.fieldSchema,
 				);
 				lastValue = nextValue;

--- a/packages/studio/src/components/selected-outline-drag.ts
+++ b/packages/studio/src/components/selected-outline-drag.ts
@@ -748,7 +748,7 @@ export const applySelectedOutlineTransformOriginAxisLock = ({
 	return uv;
 };
 
-const transformOriginSnapTargets = [
+const selectedOutlineUvSnapTargets = [
 	[0, 0],
 	[0.5, 0],
 	[1, 0],
@@ -760,12 +760,12 @@ const transformOriginSnapTargets = [
 	[0.5, 0.5],
 ] as const satisfies readonly UvCoordinate[];
 
-export const selectedOutlineTransformOriginSnapThresholdPx = 10;
+export const selectedOutlineUvSnapThresholdPx = 10;
 
-export const snapSelectedOutlineTransformOriginUv = ({
+export const snapSelectedOutlineUv = ({
 	point,
 	points,
-	thresholdPx = selectedOutlineTransformOriginSnapThresholdPx,
+	thresholdPx = selectedOutlineUvSnapThresholdPx,
 	uv,
 }: {
 	readonly point: OutlinePoint;
@@ -778,7 +778,7 @@ export const snapSelectedOutlineTransformOriginUv = ({
 		readonly uv: UvCoordinate;
 	} | null = null;
 
-	for (const snapUv of transformOriginSnapTargets) {
+	for (const snapUv of selectedOutlineUvSnapTargets) {
 		const snapPoint = getUvHandlePosition(points, snapUv);
 		const distance = Math.hypot(point.x - snapPoint.x, point.y - snapPoint.y);
 		if (distance > thresholdPx) {
@@ -792,3 +792,8 @@ export const snapSelectedOutlineTransformOriginUv = ({
 
 	return best?.uv ?? uv;
 };
+
+export const selectedOutlineTransformOriginSnapThresholdPx =
+	selectedOutlineUvSnapThresholdPx;
+
+export const snapSelectedOutlineTransformOriginUv = snapSelectedOutlineUv;

--- a/packages/studio/src/components/selected-outline-uv.ts
+++ b/packages/studio/src/components/selected-outline-uv.ts
@@ -37,6 +37,7 @@ export type SelectedOutlineUvHandle = {
 	readonly fieldDefault: UvCoordinate | undefined;
 	readonly fieldKey: string;
 	readonly fieldSchema: UvCoordinateFieldSchema;
+	readonly isSelected: boolean;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: SequenceSchema;
 	readonly sourceFrame: number;
@@ -343,6 +344,12 @@ export const getSelectedUvHandles = ({
 			continue;
 		}
 
+		const shouldShowUvHandles =
+			selectedFields.allFields || selectedFields.fieldKeys.size > 0;
+		if (!shouldShowUvHandles) {
+			continue;
+		}
+
 		const dragOverrides = getEffectDragOverrides(nodePath, effectIndex);
 		const activeSchema = Internals.flattenActiveSchema(effect.schema, (key) => {
 			const propStatus = effectStatus.props[key];
@@ -363,10 +370,7 @@ export const getSelectedUvHandles = ({
 		});
 
 		for (const [fieldKey, fieldSchema] of Object.entries(activeSchema)) {
-			if (
-				fieldSchema.type !== 'uv-coordinate' ||
-				(!selectedFields.allFields && !selectedFields.fieldKeys.has(fieldKey))
-			) {
+			if (fieldSchema.type !== 'uv-coordinate') {
 				continue;
 			}
 
@@ -398,6 +402,7 @@ export const getSelectedUvHandles = ({
 				fieldDefault: fieldSchema.default,
 				fieldKey,
 				fieldSchema,
+				isSelected: selectedFields.fieldKeys.has(fieldKey),
 				nodePath,
 				schema: effect.schema,
 				sourceFrame,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -40,8 +40,10 @@ import {
 	getSequencesWithSelectableOutlines,
 	getTransformedSvgViewportPoints,
 	isSelectedOutlineDragPastThreshold,
+	snapSelectedOutlineUv,
 	snapSelectedOutlineTransformOriginUv,
 	selectedOutlineDragThresholdPx,
+	selectedOutlineUvSnapThresholdPx,
 	selectedOutlineTransformOriginSnapThresholdPx,
 	type SelectedOutlineDragState,
 	type SelectedOutlineRotationDragState,
@@ -1462,6 +1464,44 @@ test('Transform origin drag does not snap outside the magnetic threshold', () =>
 	};
 	const uv = getUvCoordinateForPoint(points, pointer);
 	const snapped = snapSelectedOutlineTransformOriginUv({
+		point: pointer,
+		points,
+		uv,
+	});
+
+	expect(snapped[0]).toBeCloseTo(uv[0], 5);
+	expect(snapped[1]).toBeCloseTo(uv[1], 5);
+});
+
+test('UV coordinate drag snaps to outline anchors', () => {
+	const points = [
+		{x: 0, y: 0},
+		{x: 100, y: 0},
+		{x: 100, y: 100},
+		{x: 0, y: 100},
+	] as const;
+
+	expect(
+		snapSelectedOutlineUv({
+			point: {x: 47, y: 53},
+			points,
+			uv: getUvCoordinateForPoint(points, {x: 47, y: 53}),
+		}),
+	).toEqual([0.5, 0.5]);
+	expect(
+		snapSelectedOutlineUv({
+			point: {x: 96, y: 49},
+			points,
+			uv: getUvCoordinateForPoint(points, {x: 96, y: 49}),
+		}),
+	).toEqual([1, 0.5]);
+
+	const pointer = {
+		x: 50,
+		y: selectedOutlineUvSnapThresholdPx + 1,
+	};
+	const uv = getUvCoordinateForPoint(points, pointer);
+	const snapped = snapSelectedOutlineUv({
 		point: pointer,
 		points,
 		uv,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -47,6 +47,7 @@ import {
 	type SelectedOutlineRotationDragState,
 	type SelectedOutlineScaleDragState,
 } from '../components/SelectedOutlineOverlay';
+import {getSelectedOutlineUvHandleTimelineSelection} from '../components/SelectedOutlineUvControls';
 import {deleteSelectedTimelineItems} from '../components/Timeline/delete-selected-timeline-item';
 import {
 	isDuplicatableEffectSelection,
@@ -1796,6 +1797,26 @@ test('UV handles show for selected non-coordinate effect children', () => {
 		{fieldKey: 'start', isSelected: false},
 		{fieldKey: 'end', isSelected: false},
 	]);
+});
+
+test('UV handle selection targets the matching effect property', () => {
+	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
+
+	expect(
+		getSelectedOutlineUvHandleTimelineSelection({
+			effectIndex: 1,
+			fieldKey: 'end',
+			nodePathInfo: sequenceNodePathInfo,
+		}),
+	).toEqual({
+		type: 'sequence-effect-prop',
+		nodePathInfo: {
+			...sequenceNodePathInfo,
+			auxiliaryKeys: ['effects', '1', 'end'],
+		},
+		i: 1,
+		key: 'end',
+	});
 });
 
 test('UV handles are requested for selected effect children', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1686,6 +1686,118 @@ test('UV handle connection lines stay within the same effect instance', () => {
 	expect(lines.map((line) => line.key)).toEqual(['2-start-end']);
 });
 
+const getUvHandlesForSelectedEffectChild = (selectedFieldKey: string) => {
+	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', selectedFieldKey],
+	);
+	const nodePath = sequenceNodePathInfo.sequenceSubscriptionKey;
+	const effectSchema = {
+		start: {
+			type: 'uv-coordinate',
+			default: [0, 0],
+			lineTo: 'end',
+		},
+		end: {
+			type: 'uv-coordinate',
+			default: [1, 1],
+		},
+		dotSize: {
+			type: 'number',
+			default: 10,
+			hiddenFromList: false,
+		},
+	} as const satisfies SequenceSchema;
+	const propStatuses: PropStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					effectIndex: 0,
+					callee: 'testEffect',
+					importPath: null,
+					props: {
+						start: {
+							status: 'static',
+							codeValue: [0.2, 0.3],
+						},
+						end: {
+							status: 'static',
+							codeValue: [0.8, 0.7],
+						},
+						dotSize: {
+							status: 'static',
+							codeValue: 10,
+						},
+					},
+				},
+			],
+		},
+	};
+
+	return getSelectedUvHandles({
+		propStatuses,
+		clientId: 'client-id',
+		getEffectDragOverrides: () => ({}),
+		nodePath,
+		selectedEffects: getSelectedEffectFieldsBySequenceKey([
+			{
+				type: 'sequence-effect-prop',
+				nodePathInfo: effectPropNodePathInfo,
+				i: 0,
+				key: selectedFieldKey,
+			},
+		]).get(getTimelineSequenceSelectionKey(sequenceNodePathInfo)),
+		sequence: {
+			effects: [{schema: effectSchema}],
+		} as unknown as TSequence,
+		sourceFrame: 0,
+	});
+};
+
+test('UV handles include connected coordinates when selecting one coordinate', () => {
+	const handles = getUvHandlesForSelectedEffectChild('start');
+
+	expect(
+		handles.map((handle) => ({
+			fieldKey: handle.fieldKey,
+			isSelected: handle.isSelected,
+			value: handle.value,
+		})),
+	).toEqual([
+		{fieldKey: 'start', isSelected: true, value: [0.2, 0.3]},
+		{fieldKey: 'end', isSelected: false, value: [0.8, 0.7]},
+	]);
+	expect(
+		getUvHandleConnectionLines({
+			points: [
+				{x: 0, y: 0},
+				{x: 100, y: 0},
+				{x: 100, y: 100},
+				{x: 0, y: 100},
+			],
+			handles,
+		}).map((line) => line.key),
+	).toEqual(['0-start-end']);
+});
+
+test('UV handles show for selected non-coordinate effect children', () => {
+	const handles = getUvHandlesForSelectedEffectChild('dotSize');
+
+	expect(
+		handles.map((handle) => ({
+			fieldKey: handle.fieldKey,
+			isSelected: handle.isSelected,
+		})),
+	).toEqual([
+		{fieldKey: 'start', isSelected: false},
+		{fieldKey: 'end', isSelected: false},
+	]);
+});
+
 test('UV handles are requested for selected effect children', () => {
 	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
 	const effectNodePathInfo = makeNodePathInfo(['body', 0], ['effects', '1']);


### PR DESCRIPTION
## Summary
- Show all active UV coordinate handles for an effect when the effect or one of its children is selected.
- Mark the exact selected UV coordinate on each handle so the selected knob renders larger than its peers.
- Add regression coverage for selected connected coordinates and selected non-coordinate effect children.

## Tests
- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Fixes #8408
