### PR TITLE
`@remotion/transitions`: Improve linear blur quality

### DIFF
--- a/packages/transitions/src/presentations/linear-blur.tsx
+++ b/packages/transitions/src/presentations/linear-blur.tsx
@@ -26,7 +26,7 @@ uniform float u_intensity;
 in vec2 v_uv;
 out vec4 outColor;
 
-const int PASSES = 6;
+const int PASSES = 20;
 
 vec4 transition(vec2 uv, float progress) {
 	vec4 c1 = vec4(0.0);


### PR DESCRIPTION
## Summary

- Increase the linear blur shader sample count from 6 to 20 passes.
- Improves the visual quality of the `linearBlur()` transition, especially at higher blur intensities.

## Test plan

- `bunx oxfmt src --write` in `packages/transitions`
- `bun run build`
- `bun run stylecheck`
- `bun run test` in `packages/transitions`

## Visual check

Rendered the HTML-in-canvas all-effects showcase videos with the updated shader:

- `out/html-in-canvas-all-effects-widescreen.mp4`
- `out/html-in-canvas-all-effects-instagram.mp4`
