### PR TITLE
`@remotion/studio`: Allow copy-pasting easings

### DIFF
--- a/packages/docs/docs/studio/interactivity.mdx
+++ b/packages/docs/docs/studio/interactivity.mdx
@@ -51,6 +51,7 @@ Edits can be undone with <kbd>⌘/Ctrl</kbd> + <kbd>Z</kbd> and redone with <kbd
 - Select easing segments between keyframes.
 - Open the easing context menu to set `Linear`, choose a preset or open the custom easing editor.
 - Apply easing edits to all selected easing segments.
+- Copy one selected easing segment with <kbd>⌘/Ctrl</kbd> + <kbd>C</kbd> and paste it onto selected easing segments with <kbd>⌘/Ctrl</kbd> + <kbd>V</kbd>.
 - Press <kbd>Delete</kbd> or <kbd>Backspace</kbd> to reset selected easing segments to linear when only easing segments are selected.
 
 ## Deleting, resetting and duplicating

--- a/packages/studio-shared/src/easing-clipboard-data.ts
+++ b/packages/studio-shared/src/easing-clipboard-data.ts
@@ -30,10 +30,18 @@ const isFiniteNumber = (value: unknown): value is number => {
 
 const isEasing = (value: unknown): value is KeyframeEasing => {
 	return (
-		value === 'linear' ||
-		(Array.isArray(value) &&
-			value.length === 4 &&
-			value.every((item) => isFiniteNumber(item)))
+		isRecord(value) &&
+		(value.type === 'linear' ||
+			(value.type === 'bezier' &&
+				isFiniteNumber(value.x1) &&
+				isFiniteNumber(value.y1) &&
+				isFiniteNumber(value.x2) &&
+				isFiniteNumber(value.y2)) ||
+			(value.type === 'spring' &&
+				isFiniteNumber(value.damping) &&
+				isFiniteNumber(value.mass) &&
+				isFiniteNumber(value.stiffness) &&
+				typeof value.overshootClamping === 'boolean'))
 	);
 };
 

--- a/packages/studio-shared/src/easing-clipboard-data.ts
+++ b/packages/studio-shared/src/easing-clipboard-data.ts
@@ -1,0 +1,87 @@
+import type {KeyframeEasing} from './keyframe-easing-presets';
+
+export type EasingClipboardData = {
+	readonly type: 'easing';
+	readonly version: 1;
+	readonly remotionClipboard: 'easing';
+	readonly easing: KeyframeEasing;
+};
+
+export type EasingClipboardDataParseResult =
+	| {
+			readonly status: 'valid';
+			readonly data: EasingClipboardData;
+	  }
+	| {
+			readonly status: 'unsupported-version';
+			readonly version: unknown;
+	  }
+	| {
+			readonly status: 'invalid';
+	  };
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isFiniteNumber = (value: unknown): value is number => {
+	return typeof value === 'number' && Number.isFinite(value);
+};
+
+const isEasing = (value: unknown): value is KeyframeEasing => {
+	return (
+		value === 'linear' ||
+		(Array.isArray(value) &&
+			value.length === 4 &&
+			value.every((item) => isFiniteNumber(item)))
+	);
+};
+
+export const parseEasingClipboardDataResult = (
+	value: string,
+): EasingClipboardDataParseResult => {
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!isRecord(parsed)) {
+			return {status: 'invalid'};
+		}
+
+		if (parsed.remotionClipboard !== 'easing') {
+			return {status: 'invalid'};
+		}
+
+		if (parsed.version !== 1) {
+			return {
+				status: 'unsupported-version',
+				version: parsed.version,
+			};
+		}
+
+		if (parsed.type !== 'easing' || !isEasing(parsed.easing)) {
+			return {status: 'invalid'};
+		}
+
+		return {
+			status: 'valid',
+			data: {
+				type: 'easing',
+				version: 1,
+				remotionClipboard: 'easing',
+				easing: parsed.easing,
+			},
+		};
+	} catch {
+		return {status: 'invalid'};
+	}
+};
+
+export const parseEasingClipboardData = (
+	value: string,
+): EasingClipboardData | null => {
+	const result = parseEasingClipboardDataResult(value);
+	if (result.status !== 'valid') {
+		return null;
+	}
+
+	return result.data;
+};

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -123,6 +123,7 @@ export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state
 export {
 	KEYFRAME_EASING_PRESETS,
 	LINEAR_KEYFRAME_EASING,
+	type KeyframeEasing,
 	type KeyframeEasingPreset,
 } from './keyframe-easing-presets';
 export {
@@ -132,6 +133,12 @@ export {
 	type FileType,
 	type ImageFileType,
 } from './detect-file-type';
+export {
+	parseEasingClipboardData,
+	parseEasingClipboardDataResult,
+	type EasingClipboardData,
+	type EasingClipboardDataParseResult,
+} from './easing-clipboard-data';
 export {
 	parseEffectClipboardData,
 	parseEffectClipboardDataResult,

--- a/packages/studio-shared/src/test/effect-clipboard-data.test.ts
+++ b/packages/studio-shared/src/test/effect-clipboard-data.test.ts
@@ -1,10 +1,70 @@
 import {expect, test} from 'bun:test';
 import {
+	parseEasingClipboardData,
+	parseEasingClipboardDataResult,
+} from '../easing-clipboard-data';
+import {
 	parseEffectClipboardData,
 	parseEffectClipboardDataResult,
 	parseEffectPropClipboardData,
 	parseEffectPropClipboardDataResult,
 } from '../effect-clipboard-data';
+
+test('parseEasingClipboardData accepts easing payloads', () => {
+	expect(
+		parseEasingClipboardData(
+			JSON.stringify({
+				type: 'easing',
+				version: 1,
+				remotionClipboard: 'easing',
+				easing: [0.42, 0, 0.58, 1],
+			}),
+		),
+	).toEqual({
+		type: 'easing',
+		version: 1,
+		remotionClipboard: 'easing',
+		easing: [0.42, 0, 0.58, 1],
+	});
+	expect(
+		parseEasingClipboardData(
+			JSON.stringify({
+				type: 'easing',
+				version: 1,
+				remotionClipboard: 'easing',
+				easing: 'linear',
+			}),
+		)?.easing,
+	).toBe('linear');
+});
+
+test('parseEasingClipboardData reports old easing payloads as unsupported', () => {
+	const payload = JSON.stringify({
+		type: 'easing',
+		version: 0,
+		remotionClipboard: 'easing',
+		easing: 'linear',
+	});
+
+	expect(parseEasingClipboardData(payload)).toBe(null);
+	expect(parseEasingClipboardDataResult(payload)).toEqual({
+		status: 'unsupported-version',
+		version: 0,
+	});
+});
+
+test('parseEasingClipboardData rejects malformed easing payloads', () => {
+	expect(
+		parseEasingClipboardData(
+			JSON.stringify({
+				type: 'easing',
+				version: 1,
+				remotionClipboard: 'easing',
+				easing: [0.42, 0, 0.58],
+			}),
+		),
+	).toBe(null);
+});
 
 test('parseEffectClipboardData accepts keyframed v3 effect payloads', () => {
 	const parsed = parseEffectClipboardData(

--- a/packages/studio-shared/src/test/effect-clipboard-data.test.ts
+++ b/packages/studio-shared/src/test/effect-clipboard-data.test.ts
@@ -17,14 +17,14 @@ test('parseEasingClipboardData accepts easing payloads', () => {
 				type: 'easing',
 				version: 1,
 				remotionClipboard: 'easing',
-				easing: [0.42, 0, 0.58, 1],
+				easing: {type: 'bezier', x1: 0.42, y1: 0, x2: 0.58, y2: 1},
 			}),
 		),
 	).toEqual({
 		type: 'easing',
 		version: 1,
 		remotionClipboard: 'easing',
-		easing: [0.42, 0, 0.58, 1],
+		easing: {type: 'bezier', x1: 0.42, y1: 0, x2: 0.58, y2: 1},
 	});
 	expect(
 		parseEasingClipboardData(
@@ -32,10 +32,32 @@ test('parseEasingClipboardData accepts easing payloads', () => {
 				type: 'easing',
 				version: 1,
 				remotionClipboard: 'easing',
-				easing: 'linear',
+				easing: {type: 'linear'},
 			}),
 		)?.easing,
-	).toBe('linear');
+	).toEqual({type: 'linear'});
+	expect(
+		parseEasingClipboardData(
+			JSON.stringify({
+				type: 'easing',
+				version: 1,
+				remotionClipboard: 'easing',
+				easing: {
+					type: 'spring',
+					damping: 12,
+					mass: 1.5,
+					stiffness: 180,
+					overshootClamping: true,
+				},
+			}),
+		)?.easing,
+	).toEqual({
+		type: 'spring',
+		damping: 12,
+		mass: 1.5,
+		stiffness: 180,
+		overshootClamping: true,
+	});
 });
 
 test('parseEasingClipboardData reports old easing payloads as unsupported', () => {
@@ -60,7 +82,7 @@ test('parseEasingClipboardData rejects malformed easing payloads', () => {
 				type: 'easing',
 				version: 1,
 				remotionClipboard: 'easing',
-				easing: [0.42, 0, 0.58],
+				easing: [0.42, 0, 0.58, 1],
 			}),
 		),
 	).toBe(null);

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -1,7 +1,9 @@
 import {
 	isKeyframeInterpolationFunction,
+	parseEasingClipboardDataResult,
 	parseEffectClipboardDataResult,
 	parseEffectPropClipboardDataResult,
+	type EasingClipboardData,
 	type EffectClipboardData,
 	type EffectClipboardInterpolationFunction,
 	type EffectClipboardParam,
@@ -32,9 +34,15 @@ import {
 	useTimelineSelection,
 	type TimelineSelection,
 } from './TimelineSelection';
+import {
+	getEasingSelections,
+	getTimelineEasingValueForSelection,
+	updateSelectedTimelineEasings,
+	type EasingSelection,
+} from './update-selected-easing';
 
 const makeClipboardText = (
-	payload: EffectClipboardData | EffectPropClipboardData,
+	payload: EffectClipboardData | EffectPropClipboardData | EasingClipboardData,
 ) => JSON.stringify(payload);
 
 const makeTargetKey = (nodePath: SequencePropsSubscriptionKey): string => {
@@ -336,6 +344,35 @@ export const getEffectPropClipboardDataFromSelection = ({
 	};
 };
 
+export const getEasingClipboardDataFromSelection = ({
+	selection,
+	sequences,
+	overrideIdsToNodePaths,
+	propStatuses,
+}: {
+	selection: EasingSelection;
+	sequences: TSequence[];
+	overrideIdsToNodePaths: OverrideIdToNodePaths;
+	propStatuses: PropStatuses;
+}): EasingClipboardData | null => {
+	const easing = getTimelineEasingValueForSelection({
+		selection,
+		sequences,
+		overrideIdsToNodePaths,
+		propStatuses,
+	});
+	if (easing === null) {
+		return null;
+	}
+
+	return {
+		type: 'easing',
+		version: 1,
+		remotionClipboard: 'easing',
+		easing,
+	};
+};
+
 export const getPasteEffectPropTarget = ({
 	selectedItems,
 	payload,
@@ -471,7 +508,47 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 			callback: (e) => {
 				const {selectedItems} = currentSelection.current;
 				const propStatuses = propStatusesRef.current;
+				const sequences = sequencesRef.current;
 				if (selectedItems.length === 0) {
+					return;
+				}
+
+				const easingSelections = getEasingSelections(selectedItems);
+				if (easingSelections.length > 0) {
+					e.preventDefault();
+					if (
+						easingSelections.length !== 1 ||
+						easingSelections.length !== selectedItems.length
+					) {
+						showNotification('Select one easing to copy', 3000);
+						return;
+					}
+
+					const payload = getEasingClipboardDataFromSelection({
+						selection: easingSelections[0],
+						sequences,
+						overrideIdsToNodePaths: overrideIdToNodePathMappings,
+						propStatuses,
+					});
+					if (payload === null) {
+						showNotification(
+							'Cannot copy easing because it cannot be read',
+							3000,
+						);
+						return;
+					}
+
+					navigator.clipboard
+						.writeText(makeClipboardText(payload))
+						.then(() => {
+							showNotification('Copied easing to clipboard', 1000);
+						})
+						.catch((err) => {
+							showNotification(
+								`Could not copy easing: ${(err as Error).message}`,
+								2000,
+							);
+						});
 					return;
 				}
 
@@ -594,6 +671,61 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 					.then((text) => {
 						const propStatuses = propStatusesRef.current;
 						const sequences = sequencesRef.current;
+						const easingResult = parseEasingClipboardDataResult(text);
+						if (easingResult.status !== 'invalid') {
+							e.preventDefault();
+							if (easingResult.status === 'unsupported-version') {
+								showNotification(
+									'Cannot paste easing copied from a different Remotion Studio version',
+									4000,
+								);
+								return;
+							}
+
+							const easingSelections = getEasingSelections(selectedItems);
+							if (
+								easingSelections.length === 0 ||
+								easingSelections.length !== selectedItems.length
+							) {
+								showNotification('Select an easing to paste onto', 3000);
+								return;
+							}
+
+							const updatePromise = updateSelectedTimelineEasings({
+								selections: easingSelections,
+								sequences,
+								overrideIdsToNodePaths: overrideIdToNodePathMappings,
+								propStatuses,
+								setPropStatuses,
+								clientId,
+								easing: easingResult.data.easing,
+							});
+
+							if (updatePromise === null) {
+								showNotification(
+									'Cannot paste onto an easing that cannot be updated',
+									3000,
+								);
+								return;
+							}
+
+							return updatePromise
+								.then(() => {
+									showNotification(
+										easingSelections.length === 1
+											? 'Pasted easing'
+											: 'Pasted easing to selected segments',
+										2000,
+									);
+								})
+								.catch((err) => {
+									showNotification(
+										`Could not paste easing: ${(err as Error).message}`,
+										3000,
+									);
+								});
+						}
+
 						const effectPropResult = parseEffectPropClipboardDataResult(text);
 						if (effectPropResult.status !== 'invalid') {
 							e.preventDefault();

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -638,7 +638,13 @@ test('copying a selected sequence easing creates an easing payload', () => {
 		['controls', 'opacity'],
 	);
 	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
-	const easing: [number, number, number, number] = [0.42, 0, 0.58, 1];
+	const easing = {
+		type: 'bezier',
+		x1: 0.42,
+		y1: 0,
+		x2: 0.58,
+		y2: 1,
+	} as const;
 	const schema = {
 		opacity: {type: 'number', default: 1, hiddenFromList: false},
 	} satisfies SequenceSchema;
@@ -713,7 +719,7 @@ test('copying a selected effect easing creates an easing payload', () => {
 								{frame: 0, value: 10},
 								{frame: 100, value: 20},
 							],
-							easing: ['linear'],
+							easing: [{type: 'linear'}],
 							clamping: {left: 'clamp', right: 'clamp'},
 							posterize: undefined,
 						},
@@ -745,7 +751,7 @@ test('copying a selected effect easing creates an easing payload', () => {
 		type: 'easing',
 		version: 1,
 		remotionClipboard: 'easing',
-		easing: 'linear',
+		easing: {type: 'linear'},
 	});
 });
 

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -57,6 +57,7 @@ import {
 } from '../components/Timeline/duplicate-selected-timeline-item';
 import {getTimelinePropResetTargets} from '../components/Timeline/reset-selected-timeline-props';
 import {
+	getEasingClipboardDataFromSelection,
 	getEffectPropClipboardDataFromSelection,
 	getPasteEffectPropTarget,
 	getPasteEffectsTarget,
@@ -627,6 +628,123 @@ test('copying a selected effect prop creates an effect prop payload', () => {
 			easing: [{type: 'linear'}],
 			clamping: {left: 'clamp', right: 'clamp'},
 		},
+	});
+});
+
+test('copying a selected sequence easing creates an easing payload', () => {
+	const opacityNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
+	const easing: [number, number, number, number] = [0.42, 0, 0.58, 1];
+	const schema = {
+		opacity: {type: 'number', default: 1, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {
+				opacity: {
+					status: 'keyframed',
+					interpolationFunction: 'interpolate',
+					keyframes: [
+						{frame: 0, value: 0},
+						{frame: 100, value: 1},
+					],
+					easing: [easing],
+					clamping: {left: 'clamp', right: 'clamp'},
+					posterize: undefined,
+				},
+			},
+			effects: [],
+		},
+	} satisfies PropStatuses;
+
+	expect(
+		getEasingClipboardDataFromSelection({
+			selection: {
+				type: 'easing',
+				nodePathInfo: opacityNodePathInfo,
+				fromFrame: 0,
+				toFrame: 100,
+				segmentIndex: 0,
+			},
+			sequences: [makeTimelineSequence({schema})],
+			overrideIdsToNodePaths: {override: nodePath},
+			propStatuses,
+		}),
+	).toEqual({
+		type: 'easing',
+		version: 1,
+		remotionClipboard: 'easing',
+		easing,
+	});
+});
+
+test('copying a selected effect easing creates an easing payload', () => {
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'intensity'],
+		true,
+		[['0', 'intensity']],
+	);
+	const nodePath = effectPropNodePathInfo.sequenceSubscriptionKey;
+	const schema = {} satisfies SequenceSchema;
+	const effectSchema = {
+		intensity: {type: 'number', default: 0, hiddenFromList: false},
+	} satisfies SequenceSchema;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'halftone',
+					importPath: '@remotion/effects/halftone',
+					effectIndex: 0,
+					props: {
+						intensity: {
+							status: 'keyframed',
+							interpolationFunction: 'interpolateColors',
+							keyframes: [
+								{frame: 0, value: 10},
+								{frame: 100, value: 20},
+							],
+							easing: ['linear'],
+							clamping: {left: 'clamp', right: 'clamp'},
+							posterize: undefined,
+						},
+					},
+				},
+			],
+		},
+	} satisfies PropStatuses;
+
+	expect(
+		getEasingClipboardDataFromSelection({
+			selection: {
+				type: 'easing',
+				nodePathInfo: effectPropNodePathInfo,
+				fromFrame: 0,
+				toFrame: 100,
+				segmentIndex: 0,
+			},
+			sequences: [
+				makeTimelineSequence({
+					schema,
+					effects: [{schema: effectSchema}],
+				}),
+			],
+			overrideIdsToNodePaths: {override: nodePath},
+			propStatuses,
+		}),
+	).toEqual({
+		type: 'easing',
+		version: 1,
+		remotionClipboard: 'easing',
+		easing: 'linear',
 	});
 });
 


### PR DESCRIPTION
## Summary

- Add a typed Studio clipboard payload for easing segments
- Copy one selected easing segment with Cmd/Ctrl+C and paste it onto selected easing segments with Cmd/Ctrl+V
- Document easing copy/paste in the Studio interactivity docs

Fixes #8485.

## Testing

- `bun test src/test/effect-clipboard-data.test.ts` in `packages/studio-shared`
- `bun test src/test/timeline-selection.test.ts` in `packages/studio`
- `bunx turbo run make --filter='@remotion/studio'`
- `bun run build`
- `bunx turbo run lint formatting --filter='@remotion/studio' --filter='@remotion/studio-shared' --filter='docs'`
