### PR TITLE
`@remotion/studio`: Snap rotation drags with Shift

### DIFF
--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -41,6 +41,7 @@ import {
 	getSelectedOutlineTransformOriginLockedAxis,
 	isSelectedOutlineDragPastThreshold,
 	parseCssRotationToRadians,
+	snapSelectedOutlineRotationDeltaDegrees,
 	snapSelectedOutlineTransformOriginUv,
 	uvsEqual,
 	type SelectedOutlineKeyframedDragChange,
@@ -1129,13 +1130,15 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 			}
 
 			const interaction = getOutlineSelectionInteraction(event);
-			const shouldUpdateSelection =
-				!selected || interaction.shiftKey || interaction.toggleKey;
+			const shouldUpdateSelection = !selected || interaction.toggleKey;
 			if (shouldUpdateSelection && target !== undefined) {
-				onSelect(target.selection, interaction);
+				onSelect(target.selection, {
+					shiftKey: false,
+					toggleKey: interaction.toggleKey,
+				});
 			}
 
-			if (interaction.shiftKey || interaction.toggleKey) {
+			if (interaction.toggleKey) {
 				return;
 			}
 
@@ -1159,42 +1162,23 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 				y: event.clientY,
 			});
 			let accumulatedDelta = 0;
+			let rotationLocked = event.shiftKey;
 			let lastValues = new Map<string, string>();
 			let dragStarted = false;
 
-			const onPointerMove = (moveEvent: PointerEvent) => {
-				moveEvent.preventDefault();
-				const screenDeltaX = moveEvent.clientX - startPointer.x;
-				const screenDeltaY = moveEvent.clientY - startPointer.y;
-				if (!dragStarted) {
-					if (
-						!isSelectedOutlineDragPastThreshold({
-							deltaX: screenDeltaX,
-							deltaY: screenDeltaY,
+			const updateRotationDragOverrides = () => {
+				const rotationDeltaDegrees = rotationLocked
+					? snapSelectedOutlineRotationDeltaDegrees({
+							dragStates,
+							rotationDeltaDegrees: accumulatedDelta,
 						})
-					) {
-						return;
-					}
-
-					dragStarted = true;
-					onDraggingChange(true);
-				}
-
-				const nextAngle = getAngleDegrees(center, {
-					x: moveEvent.clientX,
-					y: moveEvent.clientY,
-				});
-				accumulatedDelta += getSelectedOutlineRotationDeltaDegrees({
-					from: previousAngle,
-					to: nextAngle,
-				});
-				previousAngle = nextAngle;
+					: accumulatedDelta;
 				lastValues = getSelectedOutlineRotationDragValues({
 					dragStates,
-					rotationDeltaDegrees: accumulatedDelta,
+					rotationDeltaDegrees,
 				});
 				forceSpecificCursor(
-					getRotationCursor(cornerInfo.cursorDegrees + accumulatedDelta),
+					getRotationCursor(cornerInfo.cursorDegrees + rotationDeltaDegrees),
 				);
 
 				for (const dragState of dragStates) {
@@ -1223,10 +1207,59 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 				}
 			};
 
+			const onPointerMove = (moveEvent: PointerEvent) => {
+				moveEvent.preventDefault();
+				const screenDeltaX = moveEvent.clientX - startPointer.x;
+				const screenDeltaY = moveEvent.clientY - startPointer.y;
+				if (!dragStarted) {
+					if (
+						!isSelectedOutlineDragPastThreshold({
+							deltaX: screenDeltaX,
+							deltaY: screenDeltaY,
+						})
+					) {
+						return;
+					}
+
+					dragStarted = true;
+					onDraggingChange(true);
+				}
+
+				const nextAngle = getAngleDegrees(center, {
+					x: moveEvent.clientX,
+					y: moveEvent.clientY,
+				});
+				accumulatedDelta += getSelectedOutlineRotationDeltaDegrees({
+					from: previousAngle,
+					to: nextAngle,
+				});
+				previousAngle = nextAngle;
+				rotationLocked = moveEvent.shiftKey;
+				updateRotationDragOverrides();
+			};
+
+			const onKeyChange = (keyEvent: KeyboardEvent) => {
+				if (keyEvent.key !== 'Shift') {
+					return;
+				}
+
+				const nextRotationLocked = keyEvent.type === 'keydown';
+				if (nextRotationLocked === rotationLocked) {
+					return;
+				}
+
+				rotationLocked = nextRotationLocked;
+				if (dragStarted) {
+					updateRotationDragOverrides();
+				}
+			};
+
 			const onPointerUp = () => {
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerUp);
+				window.removeEventListener('keydown', onKeyChange);
+				window.removeEventListener('keyup', onKeyChange);
 				if (dragStarted) {
 					stopForcingSpecificCursor();
 					onDraggingChange(false);
@@ -1302,6 +1335,8 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 			window.addEventListener('pointermove', onPointerMove);
 			window.addEventListener('pointerup', onPointerUp);
 			window.addEventListener('pointercancel', onPointerUp);
+			window.addEventListener('keydown', onKeyChange);
+			window.addEventListener('keyup', onKeyChange);
 		},
 		[
 			allRotationDragTargets,

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -74,6 +74,7 @@ export {
 	isSelectedOutlineDragPastThreshold,
 	selectedOutlineUvSnapThresholdPx,
 	selectedOutlineTransformOriginSnapThresholdPx,
+	snapSelectedOutlineRotationDeltaDegrees,
 	snapSelectedOutlineUv,
 	snapSelectedOutlineTransformOriginUv,
 } from './selected-outline-drag';

--- a/packages/studio/src/components/selected-outline-drag.ts
+++ b/packages/studio/src/components/selected-outline-drag.ts
@@ -521,6 +521,30 @@ export const getSelectedOutlineRotationDragValues = ({
 	);
 };
 
+export const selectedOutlineRotationSnapStepDegrees = 15;
+
+export const snapSelectedOutlineRotationDeltaDegrees = ({
+	dragStates,
+	rotationDeltaDegrees,
+}: {
+	readonly dragStates: readonly SelectedOutlineRotationDragState[];
+	readonly rotationDeltaDegrees: number;
+}) => {
+	const anchor = dragStates[0];
+	if (anchor === undefined) {
+		return rotationDeltaDegrees;
+	}
+
+	return (
+		Math.round(
+			(anchor.startDegrees + rotationDeltaDegrees) /
+				selectedOutlineRotationSnapStepDegrees,
+		) *
+			selectedOutlineRotationSnapStepDegrees -
+		anchor.startDegrees
+	);
+};
+
 export const getSelectedOutlineRotationDragChanges = ({
 	dragStates,
 	lastValues,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -40,6 +40,7 @@ import {
 	getSequencesWithSelectableOutlines,
 	getTransformedSvgViewportPoints,
 	isSelectedOutlineDragPastThreshold,
+	snapSelectedOutlineRotationDeltaDegrees,
 	snapSelectedOutlineUv,
 	snapSelectedOutlineTransformOriginUv,
 	selectedOutlineDragThresholdPx,
@@ -2840,6 +2841,98 @@ test('Selected outline corner dragging rounds rotation values', () => {
 	});
 
 	expect(lastValues.get(dragStates[0].key)).toBe('32.5deg');
+});
+
+test('Selected outline corner dragging snaps rotation to 15 degree increments', () => {
+	const schema = {
+		'style.rotate': {type: 'rotation-css', default: '0deg'},
+	} satisfies SequenceSchema;
+	const nodePath = makeKey(['body', 0]);
+	const dragStates = [
+		{
+			defaultValue: JSON.stringify('0deg'),
+			key: Internals.makeSequencePropsSubscriptionKey(nodePath),
+			sourceFrame: 12,
+			startDegrees: 32,
+			target: {
+				clientId: 'client',
+				propStatus: {status: 'static', codeValue: '32deg'},
+				fieldDefault: '0deg',
+				fieldSchema: schema['style.rotate'],
+				keyframeDisplayOffset: 30,
+				nodePath,
+				schema,
+				transformOriginValue: '50% 50%',
+			},
+		},
+	] satisfies SelectedOutlineRotationDragState[];
+
+	const rotationDeltaDegrees = snapSelectedOutlineRotationDeltaDegrees({
+		dragStates,
+		rotationDeltaDegrees: 8,
+	});
+	const lastValues = getSelectedOutlineRotationDragValues({
+		dragStates,
+		rotationDeltaDegrees,
+	});
+
+	expect(rotationDeltaDegrees).toBe(13);
+	expect(lastValues.get(dragStates[0].key)).toBe('45deg');
+});
+
+test('Selected outline corner dragging snaps selected rotations from the first drag state', () => {
+	const schema = {
+		'style.rotate': {type: 'rotation-css', default: '0deg'},
+	} satisfies SequenceSchema;
+	const firstNodePath = makeKey(['body', 0]);
+	const secondNodePath = makeKey(['body', 1]);
+	const dragStates = [
+		{
+			defaultValue: JSON.stringify('0deg'),
+			key: Internals.makeSequencePropsSubscriptionKey(firstNodePath),
+			sourceFrame: 12,
+			startDegrees: 32,
+			target: {
+				clientId: 'client',
+				propStatus: {status: 'static', codeValue: '32deg'},
+				fieldDefault: '0deg',
+				fieldSchema: schema['style.rotate'],
+				keyframeDisplayOffset: 30,
+				nodePath: firstNodePath,
+				schema,
+				transformOriginValue: '50% 50%',
+			},
+		},
+		{
+			defaultValue: JSON.stringify('0deg'),
+			key: Internals.makeSequencePropsSubscriptionKey(secondNodePath),
+			sourceFrame: 12,
+			startDegrees: -10,
+			target: {
+				clientId: 'client',
+				propStatus: {status: 'static', codeValue: '-10deg'},
+				fieldDefault: '0deg',
+				fieldSchema: schema['style.rotate'],
+				keyframeDisplayOffset: 30,
+				nodePath: secondNodePath,
+				schema,
+				transformOriginValue: '50% 50%',
+			},
+		},
+	] satisfies SelectedOutlineRotationDragState[];
+
+	const rotationDeltaDegrees = snapSelectedOutlineRotationDeltaDegrees({
+		dragStates,
+		rotationDeltaDegrees: 8,
+	});
+	const lastValues = getSelectedOutlineRotationDragValues({
+		dragStates,
+		rotationDeltaDegrees,
+	});
+
+	expect(rotationDeltaDegrees).toBe(13);
+	expect(lastValues.get(dragStates[0].key)).toBe('45deg');
+	expect(lastValues.get(dragStates[1].key)).toBe('3deg');
 });
 
 test('Selected outline corner dragging keyframed rotation adds a keyframe at the source frame', () => {


### PR DESCRIPTION
## Summary

- Allow Shift-held selected outline rotation drags to snap to 15-degree increments
- Keep Ctrl/Cmd as the rotation-handle selection toggle modifier
- Add tests for snapped single and multi-selection rotation deltas

Fixes #8445.

## Testing

- `bun run build`
- `bun test src/test/timeline-selection.test.ts` in `packages/studio`
- `bun run stylecheck`
