### PR TITLE
fix(studio): select effect prop rows before inner pointer handlers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1589,6 +1589,7 @@
         "zod": "catalog:",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "14.5.1",
         "@remotion/eslint-config-internal": "workspace:*",
         "@types/semver": "7.5.3",
         "@typescript/native-preview": "catalog:",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -41,12 +41,13 @@
 		"zod": "catalog:"
 	},
 	"devDependencies": {
-		"react": "catalog:",
-		"react-dom": "catalog:",
-		"@types/semver": "7.5.3",
+		"@happy-dom/global-registrator": "14.5.1",
 		"@remotion/eslint-config-internal": "workspace:*",
+		"@typescript/native-preview": "catalog:",
+		"@types/semver": "7.5.3",
 		"eslint": "catalog:",
-		"@typescript/native-preview": "catalog:"
+		"react": "catalog:",
+		"react-dom": "catalog:"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -90,7 +90,6 @@ export const TimelineRowChrome: React.FC<{
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
 			if (e.button === 0) {
-				e.stopPropagation();
 				onSelect({
 					shiftKey: e.shiftKey,
 					toggleKey: e.metaKey || e.ctrlKey,

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -162,7 +162,9 @@ export const TimelineRowChrome: React.FC<{
 				onDragLeave={onDragLeave}
 				onDragOver={onDragOver}
 				onDrop={onDrop}
-				onPointerDown={selectable ? onPointerDown : undefined}
+				// Use capture so row selection still updates when inner controls
+				// stop propagation on pointerdown (for example InputDragger).
+				onPointerDownCapture={selectable ? onPointerDown : undefined}
 				onContextMenu={selectable ? onContextMenu : undefined}
 				onDoubleClick={onDoubleClick}
 			>
@@ -176,7 +178,9 @@ export const TimelineRowChrome: React.FC<{
 			onDragLeave={onDragLeave}
 			onDragOver={onDragOver}
 			onDrop={onDrop}
-			onPointerDown={selectable ? onPointerDown : undefined}
+			// Use capture so row selection still updates when inner controls
+			// stop propagation on pointerdown (for example InputDragger).
+			onPointerDownCapture={selectable ? onPointerDown : undefined}
 			onContextMenu={selectable ? onContextMenu : undefined}
 			onDoubleClick={onDoubleClick}
 			style={innerRowStyle}

--- a/packages/studio/src/test/timeline-row-chrome.test.tsx
+++ b/packages/studio/src/test/timeline-row-chrome.test.tsx
@@ -1,0 +1,70 @@
+import {afterEach, expect, test} from 'bun:test';
+import React, {act} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import '../../../core/happydom';
+import {TimelineRowChrome} from '../components/Timeline/TimelineRowChrome';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(() => {
+	if (root) {
+		act(() => {
+			root?.unmount();
+		});
+	}
+
+	container?.remove();
+	root = null;
+	container = null;
+});
+
+test('TimelineRowChrome selects on pointer down before inner controls stop propagation', () => {
+	const interactions: Array<{shiftKey: boolean; toggleKey: boolean}> = [];
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+
+	act(() => {
+		root?.render(
+			<TimelineRowChrome
+				depth={0}
+				eye={null}
+				arrow={null}
+				style={{height: 24}}
+				selected={false}
+				selectable
+				onSelect={(interaction) => {
+					if (interaction) {
+						interactions.push(interaction);
+					}
+				}}
+				showSelectedBackground
+				containsSelection={false}
+				outerHeight={null}
+			>
+				<button
+					type="button"
+					onPointerDown={(event) => {
+						event.stopPropagation();
+					}}
+				>
+					Value control
+				</button>
+			</TimelineRowChrome>,
+		);
+	});
+
+	const button = container.querySelector('button');
+	expect(button).not.toBeNull();
+
+	act(() => {
+		button?.dispatchEvent(
+			new PointerEvent('pointerdown', {button: 0, bubbles: true}),
+		);
+	});
+
+	expect(interactions).toEqual([{shiftKey: false, toggleKey: false}]);
+});

--- a/packages/studio/src/test/timeline-row-chrome.test.tsx
+++ b/packages/studio/src/test/timeline-row-chrome.test.tsx
@@ -1,10 +1,21 @@
 import {afterEach, expect, test} from 'bun:test';
-import React, {act} from 'react';
+import {GlobalRegistrator} from '@happy-dom/global-registrator';
+import {act} from 'react';
 import {createRoot, type Root} from 'react-dom/client';
-import '../../../core/happydom';
 import {TimelineRowChrome} from '../components/Timeline/TimelineRowChrome';
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+(
+	globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT: boolean}
+).IS_REACT_ACT_ENVIRONMENT = true;
+GlobalRegistrator.register();
+Object.defineProperty(window, 'origin', {
+	value: 'http://localhost:3000',
+	configurable: true,
+});
+Object.defineProperty(window, 'remotion_staticBase', {
+	value: '/static-abcdef',
+	configurable: true,
+});
 
 let container: HTMLDivElement | null = null;
 let root: Root | null = null;


### PR DESCRIPTION
Fixes #8473.\n\nBackspace reset already supports effect props once the prop row is the active selection. The bug was that TimelineRowChrome selected rows on bubbling pointerdown, so inner controls such as InputDragger could stop propagation before the effect prop row was selected in the inspector.\n\nThis switches row selection to pointerdown capture so the row becomes active before inner controls handle the event, and adds a regression test that covers a child control stopping propagation.\n\nTests:\n- bun test src/test/timeline-row-chrome.test.tsx\n- bun test src/test/timeline-selection.test.ts --filter "Backspace reset targets selected effect props|Selected timeline rows do not reselect on pointer down without modifiers"\n- bun x oxfmt packages/studio/src/components/Timeline/TimelineRowChrome.tsx packages/studio/src/test/timeline-row-chrome.test.tsx --check