### PR TITLE
fix(studio): align disconnected server banner in preview UI

### DIFF
--- a/packages/studio/src/components/RenderPreview.tsx
+++ b/packages/studio/src/components/RenderPreview.tsx
@@ -11,7 +11,9 @@ const msgStyle: React.CSSProperties = {
 	color: 'white',
 	fontFamily: 'sans-serif',
 	display: 'flex',
-	justifyContent: 'center',
+	justifyContent: 'flex-start',
+	textAlign: 'left',
+	padding: '8px 10px',
 };
 
 const errMsgStyle: React.CSSProperties = {

--- a/packages/studio/src/components/StaticFilePreview.tsx
+++ b/packages/studio/src/components/StaticFilePreview.tsx
@@ -12,7 +12,9 @@ const msgStyle: React.CSSProperties = {
 	color: 'white',
 	fontFamily: 'sans-serif',
 	display: 'flex',
-	justifyContent: 'center',
+	justifyContent: 'flex-start',
+	textAlign: 'left',
+	padding: '8px 10px',
 };
 
 const errMsgStyle: React.CSSProperties = {


### PR DESCRIPTION
Fixes #8504

This PR updates the UI styling for the “Studio server disconnected” state to improve consistency and layout alignment across preview components.

Changes
Updated msgStyle and errMsgStyle in RenderPreview.tsx and StaticFilePreview.tsx
Adjusted layout alignment from centered to left-aligned (justifyContent: 'flex-start')
Added padding for better spacing (padding: '8px 10px')
Ensured consistent typography and message layout across preview error states
Before

Disconnected message was centered and visually inconsistent with surrounding UI components.

After

Message is left-aligned and visually aligned with other preview states (loading, error, missing file).
Improved readability and consistency across preview components.

Reason for change

Improves UX consistency in preview panels when the Studio server is disconnected.