### PR TITLE
`@remotion/studio-server`: Add missing effect props before keyframing

### DIFF
--- a/packages/example/e2e/constants.mts
+++ b/packages/example/e2e/constants.mts
@@ -18,6 +18,11 @@ export const visualControlsFile = path.join(
 	'VisualControls',
 	'index.tsx',
 );
+export const effectKeyframeE2eFile = path.join(
+	exampleDir,
+	'src',
+	'EffectKeyframeE2e.tsx',
+);
 export const lostNodePathE2eFile = path.join(
 	exampleDir,
 	'src',
@@ -55,6 +60,10 @@ export const ORIGINAL_CONTENT_FILE = path.join(
 export const ORIGINAL_VISUAL_CONTROLS_FILE = path.join(
 	os.tmpdir(),
 	'remotion-e2e-original-visual-controls.tsx',
+);
+export const ORIGINAL_EFFECT_KEYFRAME_E2E_FILE = path.join(
+	os.tmpdir(),
+	'remotion-e2e-original-effect-keyframe-e2e.tsx',
 );
 export const ORIGINAL_LOST_NODE_PATH_E2E_FILE = path.join(
 	os.tmpdir(),

--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -1,0 +1,98 @@
+import fs from 'fs';
+import assert from 'node:assert';
+import {expect, test} from '@playwright/test';
+import {wave} from '@remotion/effects/wave';
+import {getAllSchemaKeys} from '@remotion/studio-shared';
+import {apiCall} from './api-call.mts';
+import {effectKeyframeE2eFile} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+const getLine = (input: string, search: string) => {
+	const line = input.split('\n').findIndex((l) => l.includes(search));
+	if (line === -1) {
+		throw new Error(`Could not find line containing ${search}`);
+	}
+
+	return line + 1;
+};
+
+test.describe('effect keyframes', () => {
+	test.beforeEach(async () => {
+		await startStudio();
+	});
+
+	test.afterEach(async () => {
+		await stopStudio();
+	});
+
+	test('adds the effect prop before adding a keyframe', async () => {
+		const schema = wave().definition.schema;
+		const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+		const solidLine = getLine(content, '<Solid');
+
+		const subscription = await apiCall('/api/subscribe-to-sequence-props', {
+			fileName: 'src/EffectKeyframeE2e.tsx',
+			line: solidLine,
+			column: 0,
+			nodePath: null,
+			componentIdentity: 'dev.remotion.remotion.Solid',
+			keys: [],
+			effects: [getAllSchemaKeys(schema)],
+			clientId: 'effect-keyframe-subscribe',
+		});
+		expect(subscription.success).toBe(true);
+		assert(subscription.success);
+		expect(subscription.data.success).toBe(true);
+		assert(subscription.data.success);
+		expect(subscription.data.status.canUpdate).toBe(true);
+		assert(subscription.data.status.canUpdate);
+		const [effectStatus] = subscription.data.status.effects;
+		assert(effectStatus);
+		expect(effectStatus.canUpdate).toBe(true);
+		assert(effectStatus.canUpdate);
+		expect(effectStatus.props.phase).toEqual({
+			status: 'static',
+			codeValue: undefined,
+		});
+
+		const keyframe = await apiCall('/api/add-effect-keyframe', {
+			fileName: 'src/EffectKeyframeE2e.tsx',
+			sequenceNodePath: subscription.data.nodePath,
+			effectIndex: 0,
+			key: 'phase',
+			frame: 30,
+			value: JSON.stringify(90),
+			schema,
+			clientId: 'effect-keyframe-add',
+		});
+		expect(keyframe.success).toBe(true);
+		assert(keyframe.success);
+		expect(keyframe.data.canUpdate).toBe(true);
+		assert(keyframe.data.canUpdate);
+		expect(keyframe.data.props.phase).toEqual({
+			status: 'keyframed',
+			interpolationFunction: 'interpolate',
+			keyframes: [{frame: 30, value: 90}],
+			easing: [],
+			clamping: {left: 'clamp', right: 'clamp'},
+			posterize: undefined,
+		});
+
+		await expect
+			.poll(
+				() => {
+					const output = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+					return (
+						output.includes('const frame = useCurrentFrame();') &&
+						output.includes('phase: interpolate(frame, [30], [90], {')
+					);
+				},
+				{
+					message:
+						'Expected EffectKeyframeE2e.tsx to contain the inserted phase keyframe',
+					timeout: 10_000,
+				},
+			)
+			.toBe(true);
+	});
+});

--- a/packages/example/e2e/studio-server.mts
+++ b/packages/example/e2e/studio-server.mts
@@ -5,6 +5,7 @@ import {
 	EXPANDED_SIDEBAR_STATE,
 	LOGS_FILE,
 	ORIGINAL_CONTENT_FILE,
+	ORIGINAL_EFFECT_KEYFRAME_E2E_FILE,
 	ORIGINAL_ERROR_OVERLAY_E2E_FILE,
 	ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE,
 	ORIGINAL_LOST_NODE_PATH_E2E_FILE,
@@ -12,6 +13,7 @@ import {
 	STUDIO_PORT,
 	STUDIO_URL,
 	e2eEntryPoint,
+	effectKeyframeE2eFile,
 	errorOverlayE2eFile,
 	exampleDir,
 	hookOrderChangeE2eFile,
@@ -57,6 +59,13 @@ export async function startStudio(): Promise<void> {
 		);
 	}
 
+	if (!fs.existsSync(ORIGINAL_EFFECT_KEYFRAME_E2E_FILE)) {
+		fs.writeFileSync(
+			ORIGINAL_EFFECT_KEYFRAME_E2E_FILE,
+			fs.readFileSync(effectKeyframeE2eFile, 'utf-8'),
+		);
+	}
+
 	if (!fs.existsSync(ORIGINAL_LOST_NODE_PATH_E2E_FILE)) {
 		fs.writeFileSync(
 			ORIGINAL_LOST_NODE_PATH_E2E_FILE,
@@ -83,6 +92,10 @@ export async function startStudio(): Promise<void> {
 	fs.writeFileSync(
 		visualControlsFile,
 		fs.readFileSync(ORIGINAL_VISUAL_CONTROLS_FILE, 'utf-8'),
+	);
+	fs.writeFileSync(
+		effectKeyframeE2eFile,
+		fs.readFileSync(ORIGINAL_EFFECT_KEYFRAME_E2E_FILE, 'utf-8'),
 	);
 	fs.writeFileSync(
 		lostNodePathE2eFile,
@@ -218,6 +231,13 @@ export async function stopStudio(): Promise<void> {
 		fs.writeFileSync(
 			visualControlsFile,
 			fs.readFileSync(ORIGINAL_VISUAL_CONTROLS_FILE, 'utf-8'),
+		);
+	}
+
+	if (fs.existsSync(ORIGINAL_EFFECT_KEYFRAME_E2E_FILE)) {
+		fs.writeFileSync(
+			effectKeyframeE2eFile,
+			fs.readFileSync(ORIGINAL_EFFECT_KEYFRAME_E2E_FILE, 'utf-8'),
 		);
 	}
 

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Composition, Folder} from 'remotion';
+import {EffectKeyframeE2e} from './EffectKeyframeE2e';
 import {ErrorOverlayRepro} from './ErrorOverlayE2e/ErrorOverlayRepro';
 import {HookOrderChangeE2e} from './HookOrderChangeE2e/HookOrderChangeRepro';
 import {Issue8216} from './Issue8216/Issue8216';
@@ -46,6 +47,14 @@ export const E2eTestRoot: React.FC = () => {
 					height={2400}
 					fps={30}
 					durationInFrames={900}
+				/>
+				<Composition
+					id="effect-keyframe-e2e"
+					component={EffectKeyframeE2e}
+					width={1920}
+					height={1080}
+					fps={30}
+					durationInFrames={90}
 				/>
 			</Folder>
 			<Folder name="lost-node-path">

--- a/packages/example/src/EffectKeyframeE2e.tsx
+++ b/packages/example/src/EffectKeyframeE2e.tsx
@@ -1,0 +1,11 @@
+import {wave} from '@remotion/effects/wave';
+import React from 'react';
+import {AbsoluteFill, Solid} from 'remotion';
+
+export const EffectKeyframeE2e: React.FC = () => {
+	return (
+		<AbsoluteFill>
+			<Solid width={1080} height={1080} color="#1f2429" effects={[wave({})]} />
+		</AbsoluteFill>
+	);
+};

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -1518,6 +1518,55 @@ const getSequenceWritableProp = ({
 	};
 };
 
+const getEffectWritableProp = ({
+	objExpr,
+	key,
+	missingPropInitialValue,
+}: {
+	objExpr: ObjectExpression;
+	key: string;
+	missingPropInitialValue: MissingPropInitialValue | null;
+}): WritableProp => {
+	const {prop} = findObjectProperty(objExpr, key);
+	if (!prop) {
+		if (missingPropInitialValue) {
+			return {
+				expression: createMissingPropExpression(missingPropInitialValue),
+				setExpression: (nextExpression) => {
+					objExpr.properties.push(
+						createObjectProperty(key, nextExpression) as ObjectProperty,
+					);
+				},
+			};
+		}
+
+		throw new Error(`Cannot update keyframes: "${key}" is not set`);
+	}
+
+	return {
+		expression: prop.value as Expression,
+		setExpression: (nextExpression) => {
+			prop.value = nextExpression as ObjectProperty['value'];
+		},
+	};
+};
+
+const getEffectPropsObjectExpression = (
+	call: CallExpression,
+): ObjectExpression => {
+	if (call.arguments.length === 0) {
+		const objExpr = b.objectExpression([]) as ObjectExpression;
+		call.arguments.push(objExpr);
+		return objExpr;
+	}
+
+	if (call.arguments[0].type !== 'ObjectExpression') {
+		throw new Error('Cannot update effect keyframe: computed');
+	}
+
+	return call.arguments[0] as ObjectExpression;
+};
+
 export const updateSequenceKeyframesAst = ({
 	input,
 	nodePath,
@@ -1711,33 +1760,35 @@ export const updateEffectKeyframesAst = ({
 	}
 
 	const {call, callee: effectCallee} = found;
-	if (
-		call.arguments.length === 0 ||
-		call.arguments[0].type !== 'ObjectExpression'
-	) {
-		throw new Error('Cannot update effect keyframe: computed');
-	}
-
-	const objExpr = call.arguments[0] as ObjectExpression;
+	const objExpr = getEffectPropsObjectExpression(call);
 	const oldValueStrings: string[] = [];
 	const newValueStrings: string[] = [];
 	const requiredImports = new Set<string>();
 	let needsFrameHook = false;
 	for (const update of updates) {
-		const {prop} = findObjectProperty(objExpr, update.key);
-		if (!prop) {
-			throw new Error(`Cannot update keyframes: "${update.key}" is not set`);
-		}
-
-		oldValueStrings.push(recast.print(prop.value).code);
+		const prop = getEffectWritableProp({
+			objExpr,
+			key: update.key,
+			missingPropInitialValue:
+				update.operation.type === 'add'
+					? {
+							value: getInitialValueForMissingProp({
+								schema: schema ?? null,
+								key: update.key,
+								newValue: update.operation.value,
+							}),
+						}
+					: null,
+		});
+		oldValueStrings.push(recast.print(prop.expression).code);
 		const {expression: nextExpression, introduced} = applyKeyframeOperation({
-			expression: prop.value as Expression,
+			expression: prop.expression,
 			key: update.key,
 			operation: update.operation,
 			schema: schema ?? null,
 		});
 		newValueStrings.push(recast.print(nextExpression).code);
-		prop.value = nextExpression as ObjectProperty['value'];
+		prop.setExpression(nextExpression);
 
 		if (introduced.calleeName) {
 			requiredImports.add(introduced.calleeName);

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -87,6 +87,29 @@ export const Comp = () => {
 };
 `;
 
+const waveEffectInput = `import {wave} from '@remotion/effects/wave';
+import {Solid} from 'remotion';
+
+export const Comp = () => {
+\treturn (
+\t\t<Solid
+\t\t\twidth={100}
+\t\t\theight={100}
+\t\t\tcolor="red"
+\t\t\teffects={[wave({})]}
+\t\t/>
+\t);
+};
+`;
+
+const waveSchema = {
+	phase: {
+		type: 'number',
+		default: 0,
+		hiddenFromList: false,
+	},
+} satisfies InteractivitySchema;
+
 const getLine = (input: string, needle: string): number => {
 	const lineIndex = input
 		.split('\n')
@@ -1118,6 +1141,51 @@ test('updateEffectKeyframes converts a static value to a clamped interpolation',
 	expect(serialized).toContain('amount: interpolate(frame, [40], [0.6], {');
 	expect(serialized).toContain('extrapolateLeft: "clamp"');
 	expect(serialized).toContain('extrapolateRight: "clamp"');
+});
+
+test('updateEffectKeyframes adds a missing prop before keyframing it', () => {
+	const {serialized, oldValueStrings} = updateEffectKeyframesAst({
+		input: waveEffectInput,
+		sequenceNodePath: lineColumnToNodePath(
+			waveEffectInput,
+			getLine(waveEffectInput, '<Solid'),
+		),
+		effectIndex: 0,
+		schema: waveSchema,
+		updates: [
+			{
+				key: 'phase',
+				operation: {type: 'add', frame: 30, value: 90},
+			},
+		],
+	});
+
+	expect(oldValueStrings).toEqual(['0']);
+	expect(serialized).toContain('useCurrentFrame');
+	expect(serialized).toContain('const frame = useCurrentFrame();');
+	expect(serialized).toContain('phase: interpolate(frame, [30], [90], {');
+	expect(serialized).toContain('extrapolateLeft: "clamp"');
+	expect(serialized).toContain('extrapolateRight: "clamp"');
+});
+
+test('updateEffectKeyframes adds props to a zero-argument effect', () => {
+	const input = waveEffectInput.replace('wave({})', 'wave()');
+	const {serialized, oldValueStrings} = updateEffectKeyframesAst({
+		input,
+		sequenceNodePath: lineColumnToNodePath(input, getLine(input, '<Solid')),
+		effectIndex: 0,
+		schema: waveSchema,
+		updates: [
+			{
+				key: 'phase',
+				operation: {type: 'add', frame: 15, value: 45},
+			},
+		],
+	});
+
+	expect(oldValueStrings).toEqual(['0']);
+	expect(serialized).toContain('wave({');
+	expect(serialized).toContain('phase: interpolate(frame, [15], [45], {');
 });
 
 test('updateEffectKeyframes sets one easing segment and fills linear segments', () => {


### PR DESCRIPTION
## Summary

- Add missing effect props before applying effect keyframe updates, using schema defaults when available
- Support keyframing zero-argument effects by inserting an empty props object first
- Add unit and Studio e2e coverage for keyframing the missing `wave` `phase` prop

Fixes #8510.

## Testing

- `bun install`
- `bun run build`
- `bun test packages/studio-server/src/test/update-keyframes.test.ts`
- `cd packages/example && bun run test:e2e e2e/effect-keyframes.test.mts`
- `bun run stylecheck`
