### PR TITLE
`@remotion/studio`: Show media details for current asset

### DIFF
--- a/packages/studio/src/components/CurrentAsset.tsx
+++ b/packages/studio/src/components/CurrentAsset.tsx
@@ -3,6 +3,11 @@ import React, {useContext, useMemo} from 'react';
 import {Internals, staticFile} from 'remotion';
 import {formatMediaDuration} from '../helpers/format-media-duration';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
+import {
+	renderHumanReadableAudioCodec,
+	renderHumanReadableVideoCodec,
+} from '../helpers/render-codec-label';
+import type {MediaMetadata} from '../helpers/use-media-metadata';
 import {useMediaMetadata} from '../helpers/use-media-metadata';
 import {
 	INSPECTOR_INFO_HEADER_MIN_HEIGHT,
@@ -23,6 +28,46 @@ export const getCurrentAssetMetadataSource = (assetName: string | null) => {
 	return fileType === 'audio' || fileType === 'video'
 		? staticFile(assetName)
 		: null;
+};
+
+const formatFps = (fps: number) => `${fps.toFixed(2)} FPS`;
+
+export const getCurrentAssetMediaDetailLines = (
+	mediaMetadata: MediaMetadata,
+) => {
+	const detailLines: string[] = [];
+
+	if (mediaMetadata.hasVideoTrack === true) {
+		const videoParts = [
+			renderHumanReadableVideoCodec(mediaMetadata.videoCodec),
+		];
+
+		if (mediaMetadata.fps !== null) {
+			videoParts.push(formatFps(mediaMetadata.fps));
+		}
+
+		if (mediaMetadata.isHdr !== null) {
+			videoParts.push(`HDR: ${mediaMetadata.isHdr ? 'Yes' : 'No'}`);
+		}
+
+		detailLines.push(`Video: ${videoParts.join(' · ')}`);
+	}
+
+	if (mediaMetadata.hasAudioTrack === true) {
+		const audioParts = [
+			renderHumanReadableAudioCodec(mediaMetadata.audioCodec),
+		];
+
+		if (mediaMetadata.sampleRate !== null) {
+			audioParts.push(`${mediaMetadata.sampleRate} Hz`);
+		}
+
+		detailLines.push(`Audio: ${audioParts.join(' · ')}`);
+	} else if (mediaMetadata.hasAudioTrack === false) {
+		detailLines.push('Audio: No audio');
+	}
+
+	return detailLines;
 };
 
 export const CurrentAsset: React.FC = () => {
@@ -66,6 +111,10 @@ export const CurrentAsset: React.FC = () => {
 		}
 	}
 
+	const mediaDetailLines = mediaMetadata
+		? getCurrentAssetMediaDetailLines(mediaMetadata)
+		: [];
+
 	return (
 		<InspectorInfoHeader>
 			<InspectorInfoTitle>{fileName}</InspectorInfoTitle>
@@ -79,6 +128,9 @@ export const CurrentAsset: React.FC = () => {
 					{formatMediaDuration(mediaMetadata.duration)}
 				</InspectorInfoSubtitle>
 			) : null}
+			{mediaDetailLines.map((line) => {
+				return <InspectorInfoSubtitle key={line}>{line}</InspectorInfoSubtitle>;
+			})}
 		</InspectorInfoHeader>
 	);
 };

--- a/packages/studio/src/helpers/render-codec-label.ts
+++ b/packages/studio/src/helpers/render-codec-label.ts
@@ -1,0 +1,57 @@
+import type {InputAudioTrack, InputVideoTrack} from 'mediabunny';
+
+const audioCodecLabels: Partial<
+	Record<NonNullable<InputAudioTrack['codec']>, string>
+> = {
+	aac: 'AAC',
+	ac3: 'AC3',
+	alaw: 'A-law',
+	eac3: 'E-AC3',
+	flac: 'FLAC',
+	mp3: 'MP3',
+	opus: 'Opus',
+	'pcm-f32': 'PCM 32-bit float',
+	'pcm-f32be': 'PCM 32-bit big-endian float',
+	'pcm-f64': 'PCM 64-bit little-endian float',
+	'pcm-f64be': 'PCM 64-bit big-endian float',
+	'pcm-s16': 'PCM 16-bit signed integer',
+	'pcm-s16be': 'PCM 16-bit big-endian signed integer',
+	'pcm-s24': 'PCM 24-bit signed integer',
+	'pcm-s24be': 'PCM 24-bit big-endian signed integer',
+	'pcm-s32': 'PCM 32-bit signed integer',
+	'pcm-s32be': 'PCM 32-bit big-endian signed integer',
+	'pcm-s8': 'PCM 8-bit signed integer',
+	'pcm-u8': 'PCM 8-bit unsigned integer',
+	ulaw: 'u-law',
+	vorbis: 'Vorbis',
+};
+
+export const renderHumanReadableAudioCodec = (
+	codec: InputAudioTrack['codec'] | null,
+) => {
+	if (codec === null) {
+		return 'Unknown';
+	}
+
+	return audioCodecLabels[codec] ?? codec;
+};
+
+const videoCodecLabels: Partial<
+	Record<NonNullable<InputVideoTrack['codec']>, string>
+> = {
+	av1: 'AV1',
+	avc: 'H.264',
+	hevc: 'H.265',
+	vp8: 'VP8',
+	vp9: 'VP9',
+};
+
+export const renderHumanReadableVideoCodec = (
+	codec: InputVideoTrack['codec'] | null,
+) => {
+	if (codec === null) {
+		return 'Unknown';
+	}
+
+	return videoCodecLabels[codec] ?? codec;
+};

--- a/packages/studio/src/helpers/use-media-metadata.ts
+++ b/packages/studio/src/helpers/use-media-metadata.ts
@@ -1,4 +1,5 @@
 import {getVideoMetadata} from '@remotion/media-utils';
+import type {InputAudioTrack, InputVideoTrack} from 'mediabunny';
 import {ALL_FORMATS, Input, UrlSource} from 'mediabunny';
 import {useEffect, useState} from 'react';
 import {getDurationOrCompute} from './get-duration-or-compute';
@@ -8,8 +9,13 @@ export type MediaMetadata = {
 	format: string | null;
 	width: number | null;
 	height: number | null;
-	videoCodec: string | null;
-	audioCodec: string | null;
+	videoCodec: InputVideoTrack['codec'] | null;
+	audioCodec: InputAudioTrack['codec'] | null;
+	fps: number | null;
+	isHdr: boolean | null;
+	sampleRate: number | null;
+	hasVideoTrack: boolean | null;
+	hasAudioTrack: boolean | null;
 };
 
 const cache = new Map<string, MediaMetadata>();
@@ -49,11 +55,22 @@ const getMediabunnyMetadata = async (
 			return null;
 		}
 
-		const [width, height, videoCodec, audioCodec] = await Promise.all([
+		const [
+			width,
+			height,
+			videoCodec,
+			packetStats,
+			isHdr,
+			audioCodec,
+			sampleRate,
+		] = await Promise.all([
 			videoTrack ? safeCall(() => videoTrack.getDisplayWidth()) : null,
 			videoTrack ? safeCall(() => videoTrack.getDisplayHeight()) : null,
 			videoTrack ? safeCall(() => videoTrack.getCodec()) : null,
+			videoTrack ? safeCall(() => videoTrack.computePacketStats(50)) : null,
+			videoTrack ? safeCall(() => videoTrack.hasHighDynamicRange()) : null,
 			audioTrack ? safeCall(() => audioTrack.getCodec()) : null,
+			audioTrack ? safeCall(() => audioTrack.getSampleRate()) : null,
 		]);
 
 		return {
@@ -63,6 +80,11 @@ const getMediabunnyMetadata = async (
 			height,
 			videoCodec,
 			audioCodec,
+			fps: packetStats?.averagePacketRate ?? null,
+			isHdr,
+			sampleRate,
+			hasVideoTrack: Boolean(videoTrack),
+			hasAudioTrack: Boolean(audioTrack),
 		};
 	} finally {
 		try {
@@ -86,6 +108,11 @@ const getFallbackVideoMetadata = async (
 			height: metadata.height,
 			videoCodec: null,
 			audioCodec: null,
+			fps: null,
+			isHdr: null,
+			sampleRate: null,
+			hasVideoTrack: null,
+			hasAudioTrack: null,
 		};
 	} catch {
 		return null;

--- a/packages/studio/src/test/current-asset.test.ts
+++ b/packages/studio/src/test/current-asset.test.ts
@@ -1,5 +1,8 @@
 import {expect, test} from 'bun:test';
-import {getCurrentAssetMetadataSource} from '../components/CurrentAsset';
+import {
+	getCurrentAssetMediaDetailLines,
+	getCurrentAssetMetadataSource,
+} from '../components/CurrentAsset';
 
 test('does not request media metadata for image assets', () => {
 	expect(getCurrentAssetMetadataSource('1.jpg')).toBe(null);
@@ -12,4 +15,40 @@ test('requests media metadata for audio and video assets', () => {
 	expect(getCurrentAssetMetadataSource('nested/audio.mp3')).toBe(
 		'/nested/audio.mp3',
 	);
+});
+
+test('formats multimedia details for current assets', () => {
+	expect(
+		getCurrentAssetMediaDetailLines({
+			duration: 10,
+			format: 'QuickTime / MOV',
+			width: 1920,
+			height: 1080,
+			videoCodec: 'avc',
+			audioCodec: 'aac',
+			fps: 29.97002997002997,
+			isHdr: false,
+			sampleRate: 48000,
+			hasVideoTrack: true,
+			hasAudioTrack: true,
+		}),
+	).toEqual(['Video: H.264 · 29.97 FPS · HDR: No', 'Audio: AAC · 48000 Hz']);
+});
+
+test('formats missing audio for current asset videos', () => {
+	expect(
+		getCurrentAssetMediaDetailLines({
+			duration: 10,
+			format: 'MP4',
+			width: 1920,
+			height: 1080,
+			videoCodec: 'avc',
+			audioCodec: null,
+			fps: 30,
+			isHdr: true,
+			sampleRate: null,
+			hasVideoTrack: true,
+			hasAudioTrack: false,
+		}),
+	).toEqual(['Video: H.264 · 30.00 FPS · HDR: Yes', 'Audio: No audio']);
 });


### PR DESCRIPTION
## Summary

- Add FPS, HDR, audio codec, sample rate, and missing-audio details to the Studio CurrentAsset header for media assets
- Extend the existing Mediabunny metadata lookup to expose the extra media details
- Add CurrentAsset unit coverage for formatting video/audio details

## Tests

- `bunx oxfmt src --write` in `packages/studio`
- `bun test src/test/current-asset.test.ts` in `packages/studio`
- `bun run build`
- `bun run stylecheck`
