### PR TITLE
`@remotion/studio`: Fix Sequence arrow key nudging

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -16,6 +16,7 @@ import {ScaleLockContext} from '../state/scale-lock';
 import {showNotification} from './Notifications/NotificationCenter';
 import {
 	clearSelectedOutlineDragOverrides,
+	getSelectedOutlineActiveSchema,
 	getSelectedOutlineDragChanges,
 	getSelectedOutlineDragStates,
 	getSelectedOutlineDragValues,
@@ -59,6 +60,7 @@ export {
 	applySelectedOutlineDragAxisLock,
 	applySelectedOutlineTransformOriginAxisLock,
 	compensateTranslateForTransformOrigin,
+	getSelectedOutlineActiveSchema,
 	getSelectedOutlineDragChanges,
 	getSelectedOutlineDragValues,
 	getSelectedOutlineKeyboardNudgeDelta,
@@ -170,24 +172,32 @@ export const SelectedOutlineOverlay: React.FC<{
 			const containsSelection = sequenceKeysContainingSelection.has(key);
 			const nodePath = nodePathInfo.sequenceSubscriptionKey;
 			const {controls} = sequence;
-			const fieldSchema = controls?.schema[translateFieldKey];
 			const nodePropStatuses = Internals.getPropStatusesCtx(
 				propStatuses,
 				nodePath,
 			);
+			const sourceFrame = timelinePosition - keyframeDisplayOffset;
+			const dragOverrides = getDragOverrides(nodePath) ?? {};
+			const activeSchema = controls
+				? getSelectedOutlineActiveSchema({
+						schema: controls.schema,
+						currentRuntimeValueDotNotation:
+							controls.currentRuntimeValueDotNotation,
+						dragOverrides,
+						propStatus: nodePropStatuses,
+						frame: sourceFrame,
+					})
+				: null;
+			const fieldSchema = activeSchema?.[translateFieldKey];
 			const propStatus = nodePropStatuses?.[translateFieldKey];
-			const scaleFieldSchema = controls?.schema[scaleFieldKey];
+			const scaleFieldSchema = activeSchema?.[scaleFieldKey];
 			const scalePropStatus = nodePropStatuses?.[scaleFieldKey];
-			const rotationFieldSchema = controls?.schema[rotateFieldKey];
-			const rotationPropStatus = Internals.getPropStatusesCtx(
-				propStatuses,
-				nodePath,
-			)?.[rotateFieldKey];
+			const rotationFieldSchema = activeSchema?.[rotateFieldKey];
+			const rotationPropStatus = nodePropStatuses?.[rotateFieldKey];
 			const transformOriginFieldSchema =
-				controls?.schema[transformOriginFieldKey];
+				activeSchema?.[transformOriginFieldKey];
 			const transformOriginPropStatus =
 				nodePropStatuses?.[transformOriginFieldKey];
-			const rotationSourceFrame = timelinePosition - keyframeDisplayOffset;
 			const transformOriginValueForRotation =
 				transformOriginFieldSchema?.type === 'transform-origin' &&
 				(transformOriginPropStatus?.status === 'static' ||
@@ -195,11 +205,9 @@ export const SelectedOutlineOverlay: React.FC<{
 					? String(
 							Internals.getEffectiveVisualModeValue({
 								propStatus: transformOriginPropStatus,
-								dragOverrideValue: (getDragOverrides(nodePath) ?? {})[
-									transformOriginFieldKey
-								],
+								dragOverrideValue: dragOverrides[transformOriginFieldKey],
 								defaultValue: transformOriginFieldSchema.default,
-								frame: rotationSourceFrame,
+								frame: sourceFrame,
 								shouldResortToDefaultValueIfUndefined: true,
 							}) ?? transformOriginFieldSchema.default,
 						)
@@ -236,7 +244,7 @@ export const SelectedOutlineOverlay: React.FC<{
 			const transformOriginSourceFrame =
 				selectedTransformOriginInfo?.displayFrame === null ||
 				selectedTransformOriginInfo?.displayFrame === undefined
-					? timelinePosition - keyframeDisplayOffset
+					? sourceFrame
 					: selectedTransformOriginInfo.displayFrame - keyframeDisplayOffset;
 			const canTransformOriginStatus =
 				transformOriginPropStatus?.status === 'static' ||
@@ -294,9 +302,7 @@ export const SelectedOutlineOverlay: React.FC<{
 								nodePath,
 								fieldKey: scaleFieldKey,
 								defaultValue: (() => {
-									const dragOverrideValue = (getDragOverrides(nodePath) ?? {})[
-										scaleFieldKey
-									];
+									const dragOverrideValue = dragOverrides[scaleFieldKey];
 									const effectiveValue = Internals.getEffectiveVisualModeValue({
 										propStatus: scalePropStatus,
 										dragOverrideValue,
@@ -334,9 +340,7 @@ export const SelectedOutlineOverlay: React.FC<{
 							originValue: String(
 								Internals.getEffectiveVisualModeValue({
 									propStatus: transformOriginPropStatus,
-									dragOverrideValue: (getDragOverrides(nodePath) ?? {})[
-										transformOriginFieldKey
-									],
+									dragOverrideValue: dragOverrides[transformOriginFieldKey],
 									defaultValue: transformOriginFieldSchema.default,
 									frame: transformOriginSourceFrame,
 									shouldResortToDefaultValueIfUndefined: true,
@@ -347,9 +351,7 @@ export const SelectedOutlineOverlay: React.FC<{
 									rotationPropStatus?.status === 'keyframed'
 									? (Internals.getEffectiveVisualModeValue({
 											propStatus: rotationPropStatus,
-											dragOverrideValue: (getDragOverrides(nodePath) ?? {})[
-												rotateFieldKey
-											],
+											dragOverrideValue: dragOverrides[rotateFieldKey],
 											defaultValue:
 												rotationFieldSchema?.type === 'rotation-css'
 													? rotationFieldSchema.default
@@ -365,9 +367,7 @@ export const SelectedOutlineOverlay: React.FC<{
 									? String(
 											Internals.getEffectiveVisualModeValue({
 												propStatus: scalePropStatus,
-												dragOverrideValue: (getDragOverrides(nodePath) ?? {})[
-													scaleFieldKey
-												],
+												dragOverrideValue: dragOverrides[scaleFieldKey],
 												defaultValue:
 													scaleFieldSchema?.type === 'scale'
 														? scaleFieldSchema.default
@@ -384,9 +384,7 @@ export const SelectedOutlineOverlay: React.FC<{
 							translateValue: String(
 								Internals.getEffectiveVisualModeValue({
 									propStatus,
-									dragOverrideValue: (getDragOverrides(nodePath) ?? {})[
-										translateFieldKey
-									],
+									dragOverrideValue: dragOverrides[translateFieldKey],
 									defaultValue: fieldSchema.default,
 									frame: transformOriginSourceFrame,
 									shouldResortToDefaultValueIfUndefined: true,

--- a/packages/studio/src/components/selected-outline-drag.ts
+++ b/packages/studio/src/components/selected-outline-drag.ts
@@ -1,4 +1,6 @@
 import type {
+	CanUpdateSequencePropStatus,
+	DragOverrideValue,
 	GetDragOverrides,
 	SequencePropsSubscriptionKey,
 	InteractivitySchema,
@@ -44,6 +46,31 @@ import {
 	serializeTranslate,
 } from './Timeline/timeline-translate-utils';
 import {getLinkedScale} from './Timeline/TimelineScaleField';
+
+export const getSelectedOutlineActiveSchema = ({
+	schema,
+	currentRuntimeValueDotNotation,
+	dragOverrides,
+	propStatus,
+	frame,
+}: {
+	readonly schema: InteractivitySchema;
+	readonly currentRuntimeValueDotNotation: Record<string, unknown>;
+	readonly dragOverrides: Record<string, DragOverrideValue>;
+	readonly propStatus: Record<string, CanUpdateSequencePropStatus> | undefined;
+	readonly frame: number | null;
+}): InteractivitySchema => {
+	const {merged: valuesDotNotation} =
+		Internals.computeEffectiveSchemaValuesDotNotation({
+			schema,
+			currentValue: currentRuntimeValueDotNotation,
+			overrideValues: dragOverrides,
+			propStatus,
+			frame,
+		});
+
+	return Internals.flattenActiveSchema(schema, (key) => valuesDotNotation[key]);
+};
 
 export const getSelectedOutlineDragStates = ({
 	dragTargets,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -23,6 +23,7 @@ import {
 	compensateTranslateForTransformOrigin,
 	getOutlineSelectionInteraction,
 	getSelectedEffectFieldsBySequenceKey,
+	getSelectedOutlineActiveSchema,
 	getSelectedOutlineDragChanges,
 	getSelectedOutlineDragValues,
 	getSelectedOutlineKeyboardNudgeDelta,
@@ -2500,6 +2501,30 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			schema,
 		},
 	]);
+});
+
+test('Selected outline active schema exposes default Sequence translate controls', () => {
+	const activeSchema = getSelectedOutlineActiveSchema({
+		schema: NoReactInternals.sequenceSchema,
+		currentRuntimeValueDotNotation: {
+			layout: undefined,
+			'style.translate': undefined,
+		},
+		dragOverrides: {},
+		propStatus: {
+			layout: {status: 'static', codeValue: undefined},
+			'style.translate': {status: 'static', codeValue: undefined},
+		},
+		frame: 0,
+	});
+
+	const translateField = activeSchema['style.translate'];
+	expect(translateField?.type).toBe('translate');
+	if (translateField?.type !== 'translate') {
+		throw new Error('Expected style.translate to be active');
+	}
+
+	expect(translateField.default).toBe('0px 0px');
 });
 
 test('Selected outline dragging can lock movement to the dominant axis', () => {


### PR DESCRIPTION
## Summary

- Fix selected outline controls to resolve active schema fields, so built-in `Sequence` style controls from the `layout="absolute-fill"` variant are available for arrow-key nudging.
- Reuse the same active-schema lookup for translate, scale, rotate, and transform-origin outline controls.
- Add a regression test covering default `Sequence` access to `style.translate`.

Closes #8440.

## Tests

- `bun test src/test/timeline-selection.test.ts` from `packages/studio`
- `bunx turbo run make --filter='@remotion/studio' --no-update-notifier`
- `bun run build`
- `bun run stylecheck`
- Browser smoke test on `packages/example` Studio at `http://localhost:3001`: selected a Sequence with `style.scale` and pressed `ArrowLeft`, which added `translate: '-1px 0px'`
