### PR TITLE
`@remotion/studio`: Add freeze frame action to timeline layers

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -41,6 +41,7 @@ import {
 import {TimelineVideoInfo} from './TimelineVideoInfo';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 import {useResolveStackAndReactToChange} from './use-resolved-stack-react-to-change';
+import {useSequenceFreezeFrameMenuItem} from './use-sequence-freeze-frame-menu-item';
 
 const AUDIO_GRADIENT = 'linear-gradient(rgb(16 171 58), rgb(43 165 63) 60%)';
 const VIDEO_GRADIENT = 'linear-gradient(to top, #8e44ad, #9b59b6)';
@@ -268,6 +269,7 @@ const TimelineSequenceInner: React.FC<{
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewConnected = previewServerState.type === 'connected';
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const selectAsset = useSelectAsset();
 	const confirm = useConfirmationDialog();
 	const {onSelect, selectable} = useTimelineRowSelection(nodePathInfo);
@@ -383,6 +385,19 @@ const TimelineSequenceInner: React.FC<{
 		setPropStatuses,
 		validatedLocation?.source,
 	]);
+	const freezeFrameMenuItem = useSequenceFreezeFrameMenuItem({
+		clientId:
+			previewServerState.type === 'connected'
+				? previewServerState.clientId
+				: null,
+		nodePath,
+		propStatusesForOverride,
+		sequence: s,
+		sequenceFrameOffset,
+		setPropStatuses,
+		timelinePosition,
+		validatedSource: validatedLocation?.source ?? null,
+	});
 	const contextMenuValues = useMemo(() => {
 		if (!previewConnected) {
 			return [];
@@ -403,6 +418,7 @@ const TimelineSequenceInner: React.FC<{
 			originalLocation,
 			selectAsset,
 			sequence: s,
+			sourceActions: [freezeFrameMenuItem],
 		});
 	}, [
 		assetLinkInfo,
@@ -411,6 +427,7 @@ const TimelineSequenceInner: React.FC<{
 		disableInteractivityDisabled,
 		duplicateDisabled,
 		fileLocation,
+		freezeFrameMenuItem,
 		onDeleteSequenceFromSource,
 		onDisableSequenceInteractivity,
 		onDuplicateSequenceFromSource,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -49,6 +49,7 @@ import {
 } from './TimelineSelection';
 import {TimelineSequenceName} from './TimelineSequenceName';
 import {useOpenSequenceInEditor} from './use-open-sequence-in-editor';
+import {useSequenceFreezeFrameMenuItem} from './use-sequence-freeze-frame-menu-item';
 
 const labelContainerStyle: React.CSSProperties = {
 	alignItems: 'center',
@@ -810,69 +811,19 @@ export const TimelineSequenceItem: React.FC<{
 		setIsRenaming(true);
 	}, [canRenameThisSequence]);
 
-	const freezeStatus = propStatusesForOverride?.freeze;
-	const isFrozen =
-		freezeStatus?.status === 'static' &&
-		typeof freezeStatus.codeValue === 'number';
-
-	const canToggleFreeze =
-		previewConnected &&
-		Boolean(sequence.controls) &&
-		nodePath !== null &&
-		validatedLocation !== null &&
-		freezeStatus !== undefined &&
-		freezeStatus !== null &&
-		freezeStatus.status === 'static';
-
-	const onToggleFreezeFrame = useCallback(() => {
-		if (
-			!canToggleFreeze ||
-			!sequence.controls ||
-			!nodePath ||
-			!validatedLocation ||
-			previewServerState.type !== 'connected'
-		) {
-			return;
-		}
-
-		const rawFreezeFrame = Math.round(
-			timelinePosition - sequence.from + sequenceFrameOffset,
-		);
-		const maxFrame = Number.isFinite(sequence.duration)
-			? Math.max(0, sequence.duration - 1)
-			: rawFreezeFrame;
-		const freezeFrame = Math.min(Math.max(0, rawFreezeFrame), maxFrame);
-		const remove = isFrozen;
-
-		saveSequenceProps({
-			changes: [
-				{
-					fileName: validatedLocation.source,
-					nodePath,
-					fieldKey: 'freeze',
-					value: remove ? null : freezeFrame,
-					defaultValue: null,
-					schema: sequence.controls.schema,
-				},
-			],
-			setPropStatuses,
-			clientId: previewServerState.clientId,
-			undoLabel: remove ? 'Unfreeze sequence' : 'Freeze sequence',
-			redoLabel: remove ? 'Freeze sequence again' : 'Unfreeze sequence again',
-		});
-	}, [
-		canToggleFreeze,
-		isFrozen,
+	const freezeFrameMenuItem = useSequenceFreezeFrameMenuItem({
+		clientId:
+			previewServerState.type === 'connected'
+				? previewServerState.clientId
+				: null,
 		nodePath,
-		previewServerState,
-		sequence.controls,
-		sequence.duration,
-		sequence.from,
+		propStatusesForOverride,
+		sequence,
 		sequenceFrameOffset,
 		setPropStatuses,
 		timelinePosition,
-		validatedLocation,
-	]);
+		validatedSource: validatedLocation?.source ?? null,
+	});
 
 	const contextMenuValues = useMemo(() => {
 		if (!previewConnected) {
@@ -909,37 +860,22 @@ export const TimelineSequenceItem: React.FC<{
 					subMenu: null,
 					value: 'rename-sequence',
 				},
-				{
-					type: 'item' as const,
-					id: 'toggle-freeze-frame',
-					keyHint: null,
-					label: isFrozen ? 'Unfreeze frame' : 'Freeze frame',
-					leftItem: null,
-					disabled: !canToggleFreeze,
-					onClick: () => {
-						onToggleFreezeFrame();
-					},
-					quickSwitcherLabel: null,
-					subMenu: null,
-					value: 'toggle-freeze-frame',
-				},
+				freezeFrameMenuItem,
 			],
 		});
 	}, [
 		assetLinkInfo,
 		canOpenInEditor,
 		canRenameThisSequence,
-		canToggleFreeze,
 		deleteDisabled,
 		disableInteractivityDisabled,
 		duplicateDisabled,
 		fileLocation,
-		isFrozen,
+		freezeFrameMenuItem,
 		onDeleteSequenceFromSource,
 		onDisableSequenceInteractivity,
 		onDuplicateSequenceFromSource,
 		onRenameSequence,
-		onToggleFreezeFrame,
 		openInEditor,
 		originalLocation,
 		previewConnected,

--- a/packages/studio/src/components/Timeline/use-sequence-freeze-frame-menu-item.ts
+++ b/packages/studio/src/components/Timeline/use-sequence-freeze-frame-menu-item.ts
@@ -1,0 +1,110 @@
+import {useCallback, useMemo} from 'react';
+import type {
+	CanUpdateSequencePropStatus,
+	SequencePropsSubscriptionKey,
+	TSequence,
+} from 'remotion';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {saveSequenceProps, type SetPropStatuses} from './save-sequence-prop';
+
+export const useSequenceFreezeFrameMenuItem = ({
+	clientId,
+	nodePath,
+	propStatusesForOverride,
+	sequence,
+	sequenceFrameOffset,
+	setPropStatuses,
+	timelinePosition,
+	validatedSource,
+}: {
+	readonly clientId: string | null;
+	readonly nodePath: SequencePropsSubscriptionKey | null;
+	readonly propStatusesForOverride:
+		| Record<string, CanUpdateSequencePropStatus>
+		| undefined;
+	readonly sequence: TSequence;
+	readonly sequenceFrameOffset: number;
+	readonly setPropStatuses: SetPropStatuses;
+	readonly timelinePosition: number;
+	readonly validatedSource: string | null;
+}): ComboboxValue => {
+	const freezeStatus = propStatusesForOverride?.freeze;
+	const isFrozen =
+		freezeStatus?.status === 'static' &&
+		typeof freezeStatus.codeValue === 'number';
+
+	const canToggleFreeze =
+		clientId !== null &&
+		Boolean(sequence.controls) &&
+		nodePath !== null &&
+		validatedSource !== null &&
+		freezeStatus !== undefined &&
+		freezeStatus !== null &&
+		freezeStatus.status === 'static';
+
+	const onToggleFreezeFrame = useCallback(() => {
+		if (
+			!canToggleFreeze ||
+			!sequence.controls ||
+			nodePath === null ||
+			validatedSource === null ||
+			clientId === null
+		) {
+			return;
+		}
+
+		const rawFreezeFrame = Math.round(
+			timelinePosition - sequence.from + sequenceFrameOffset,
+		);
+		const maxFrame = Number.isFinite(sequence.duration)
+			? Math.max(0, sequence.duration - 1)
+			: rawFreezeFrame;
+		const freezeFrame = Math.min(Math.max(0, rawFreezeFrame), maxFrame);
+		const remove = isFrozen;
+
+		saveSequenceProps({
+			changes: [
+				{
+					fileName: validatedSource,
+					nodePath,
+					fieldKey: 'freeze',
+					value: remove ? null : freezeFrame,
+					defaultValue: null,
+					schema: sequence.controls.schema,
+				},
+			],
+			setPropStatuses,
+			clientId,
+			undoLabel: remove ? 'Unfreeze sequence' : 'Freeze sequence',
+			redoLabel: remove ? 'Freeze sequence again' : 'Unfreeze sequence again',
+		});
+	}, [
+		canToggleFreeze,
+		clientId,
+		isFrozen,
+		nodePath,
+		sequence.controls,
+		sequence.duration,
+		sequence.from,
+		sequenceFrameOffset,
+		setPropStatuses,
+		timelinePosition,
+		validatedSource,
+	]);
+
+	return useMemo(
+		() => ({
+			type: 'item' as const,
+			id: 'toggle-freeze-frame',
+			keyHint: null,
+			label: isFrozen ? 'Unfreeze frame' : 'Freeze frame',
+			leftItem: null,
+			disabled: !canToggleFreeze,
+			onClick: onToggleFreezeFrame,
+			quickSwitcherLabel: null,
+			subMenu: null,
+			value: 'toggle-freeze-frame',
+		}),
+		[canToggleFreeze, isFrozen, onToggleFreezeFrame],
+	);
+};


### PR DESCRIPTION
## Summary

- Add a timeline-only freeze frame menu item hook
- Reuse the hook from the timeline list row and the timeline layer block
- Keep the canvas selected-outline context menu unchanged

Fixes #8458.

## Testing

- `bun test packages/studio/src/test/sequence-context-menu-items.test.ts`
- `bunx tsc --noEmit --project packages/studio/tsconfig.json`
- `bunx oxfmt src --write` in `packages/studio`
- `bun run build`
- `bun run stylecheck`
