### PR TITLE
`@remotion/studio`: Add easing editor presets

### DIFF
--- a/packages/studio-shared/src/keyframe-easing-presets.ts
+++ b/packages/studio-shared/src/keyframe-easing-presets.ts
@@ -3,7 +3,12 @@ import type {CanUpdateSequencePropStatusEasing} from 'remotion';
 export type KeyframeEasing = CanUpdateSequencePropStatusEasing;
 
 export type KeyframeEasingPreset = {
-	readonly id: 'ease-in' | 'ease-out' | 'ease-in-out';
+	readonly id:
+		| 'ease-in'
+		| 'ease-out'
+		| 'ease-in-out'
+		| 'spring'
+		| 'bouncy-spring';
 	readonly label: string;
 	readonly easing: KeyframeEasing;
 };
@@ -25,5 +30,27 @@ export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [
 		id: 'ease-in-out',
 		label: 'Ease in-out',
 		easing: {type: 'bezier', x1: 0.42, y1: 0, x2: 0.58, y2: 1},
+	},
+	{
+		id: 'spring',
+		label: 'Spring',
+		easing: {
+			type: 'spring',
+			damping: 10,
+			mass: 1,
+			overshootClamping: false,
+			stiffness: 100,
+		},
+	},
+	{
+		id: 'bouncy-spring',
+		label: 'Bouncy spring',
+		easing: {
+			type: 'spring',
+			damping: 5,
+			mass: 1,
+			overshootClamping: false,
+			stiffness: 120,
+		},
 	},
 ];

--- a/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
@@ -1,6 +1,8 @@
-import React, {useContext, useMemo} from 'react';
+import React, {useCallback, useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
+import type {SegmentedControlItem} from '../SegmentedControl';
+import {SegmentedControl} from '../SegmentedControl';
 import {EasingEditor} from '../Timeline/EasingEditorModal';
 import {getTimelineSelectionKey} from '../Timeline/TimelineSelection';
 import {
@@ -8,7 +10,12 @@ import {
 	type EasingSelection,
 } from '../Timeline/update-selected-easing';
 import {InspectorMessage, InspectorSectionHeader} from './common';
-import {selectedContainer} from './styles';
+import {
+	sectionHeaderRow,
+	sectionHeaderStart,
+	sectionHeaderTitle,
+	selectedContainer,
+} from './styles';
 
 export const EasingInspector: React.FC<{
 	readonly selection: EasingSelection;
@@ -41,14 +48,35 @@ export const EasingInspector: React.FC<{
 		};
 	}, [initialEasing, selection]);
 
+	const renderHeader = useCallback(
+		(modeItems: SegmentedControlItem[]) => (
+			<InspectorSectionHeader>
+				<div style={sectionHeaderRow}>
+					<div style={sectionHeaderStart}>
+						<span style={sectionHeaderTitle}>Easing</span>
+						<SegmentedControl
+							items={modeItems}
+							needsWrapping={false}
+							size="compact"
+						/>
+					</div>
+				</div>
+			</InspectorSectionHeader>
+		),
+		[],
+	);
+
 	if (state === null) {
 		return <InspectorMessage>Easing unavailable</InspectorMessage>;
 	}
 
 	return (
 		<div style={selectedContainer} className={VERTICAL_SCROLLBAR_CLASSNAME}>
-			<InspectorSectionHeader>Easing</InspectorSectionHeader>
-			<EasingEditor key={getTimelineSelectionKey(selection)} state={state} />
+			<EasingEditor
+				key={getTimelineSelectionKey(selection)}
+				state={state}
+				renderHeader={renderHeader}
+			/>
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -1,3 +1,7 @@
+import {
+	KEYFRAME_EASING_PRESETS,
+	LINEAR_KEYFRAME_EASING,
+} from '@remotion/studio-shared';
 import React, {
 	useCallback,
 	useContext,
@@ -36,6 +40,11 @@ type HandleIndex = 0 | 1;
 type Coordinate = 'x' | 'y';
 type EditorMode = 'bezier' | 'spring';
 type SpringNumberKey = 'damping' | 'mass' | 'stiffness';
+type EasingPreset = {
+	readonly id: string;
+	readonly label: string;
+	readonly easing: TimelineEasingValue;
+};
 
 const SVG_WIDTH = 560;
 const SVG_HEIGHT = 320;
@@ -47,6 +56,11 @@ const Y_MIN = -2;
 const Y_MAX = 3;
 const LINEAR_EASING: TimelineEasingValue = {type: 'linear'};
 const LINEAR_BEZIER: CubicBezierTuple = [0.25, 0.25, 0.75, 0.75];
+const PRESET_PREVIEW_WIDTH = 48;
+const PRESET_PREVIEW_HEIGHT = 30;
+const PRESET_PREVIEW_PADDING = 5;
+const PRESET_PREVIEW_Y_MIN = -0.35;
+const PRESET_PREVIEW_Y_MAX = 1.45;
 const DEFAULT_SPRING_EASING: SpringEasing = {
 	type: 'spring',
 	damping: 10,
@@ -54,6 +68,14 @@ const DEFAULT_SPRING_EASING: SpringEasing = {
 	overshootClamping: false,
 	stiffness: 100,
 };
+const EDITOR_EASING_PRESETS: readonly EasingPreset[] = [
+	{
+		id: 'linear',
+		label: 'Linear',
+		easing: LINEAR_KEYFRAME_EASING,
+	},
+	...KEYFRAME_EASING_PRESETS,
+];
 
 const SPRING_LIMITS: Record<
 	SpringNumberKey,
@@ -84,6 +106,33 @@ const segmentedControlWrapper: React.CSSProperties = {
 	justifyContent: 'center',
 	padding: '0 12px',
 	marginBottom: 8,
+};
+
+const presetButtonsWrapper: React.CSSProperties = {
+	display: 'flex',
+	flexWrap: 'wrap',
+	gap: 6,
+	justifyContent: 'center',
+	marginBottom: 10,
+	padding: '0 12px',
+};
+
+const presetButtonBase: React.CSSProperties = {
+	alignItems: 'center',
+	backgroundColor: INPUT_BACKGROUND,
+	border: `1px solid ${INPUT_BORDER_COLOR_HOVERED}`,
+	borderRadius: 4,
+	display: 'inline-flex',
+	height: 34,
+	justifyContent: 'center',
+	padding: 0,
+	width: 52,
+};
+
+const presetPreviewSvgStyle: React.CSSProperties = {
+	display: 'block',
+	height: PRESET_PREVIEW_HEIGHT,
+	width: PRESET_PREVIEW_WIDTH,
 };
 
 const coordinatesGridBase: React.CSSProperties = {
@@ -307,6 +356,55 @@ const getEasingUpdateTargetKey = (update: SelectedEasingUpdate) => {
 const xToSvg = (value: number) => PLOT_LEFT + value * PLOT_WIDTH;
 const yToSvg = (value: number) =>
 	PLOT_TOP + ((Y_MAX - value) / (Y_MAX - Y_MIN)) * PLOT_HEIGHT;
+const presetPreviewXToSvg = (value: number) =>
+	PRESET_PREVIEW_PADDING +
+	value * (PRESET_PREVIEW_WIDTH - PRESET_PREVIEW_PADDING * 2);
+const presetPreviewYToSvg = (value: number) =>
+	PRESET_PREVIEW_PADDING +
+	((PRESET_PREVIEW_Y_MAX - value) /
+		(PRESET_PREVIEW_Y_MAX - PRESET_PREVIEW_Y_MIN)) *
+		(PRESET_PREVIEW_HEIGHT - PRESET_PREVIEW_PADDING * 2);
+
+const getEasingFunction = (easing: TimelineEasingValue) => {
+	switch (easing.type) {
+		case 'linear':
+			return Easing.linear;
+		case 'bezier':
+			return Easing.bezier(easing.x1, easing.y1, easing.x2, easing.y2);
+		case 'spring':
+			return Easing.spring({
+				damping: easing.damping,
+				mass: easing.mass,
+				overshootClamping: easing.overshootClamping,
+				stiffness: easing.stiffness,
+			});
+		default:
+			throw new Error(
+				`Unsupported easing: ${JSON.stringify(easing satisfies never)}`,
+			);
+	}
+};
+
+const getPresetPreviewPath = (easing: TimelineEasingValue) => {
+	const easingFunction = getEasingFunction(easing);
+	const samples = 36;
+	const points: string[] = [];
+
+	for (let i = 0; i <= samples; i++) {
+		const progress = i / samples;
+		const x = presetPreviewXToSvg(progress);
+		const y = presetPreviewYToSvg(
+			clamp(
+				easingFunction(progress),
+				PRESET_PREVIEW_Y_MIN,
+				PRESET_PREVIEW_Y_MAX,
+			),
+		);
+		points.push(`${i === 0 ? 'M' : 'L'} ${x} ${y}`);
+	}
+
+	return points.join(' ');
+};
 
 const pointFromBezier = (bezier: CubicBezierTuple, handle: HandleIndex) => {
 	const x = handle === 0 ? bezier[0] : bezier[2];
@@ -345,6 +443,61 @@ const EasingGraphScaffold: React.FC = () => {
 				1
 			</text>
 		</>
+	);
+};
+
+const EasingPresetButton: React.FC<{
+	readonly currentEasing: TimelineEasingValue;
+	readonly disabled: boolean;
+	readonly onClick: (easing: TimelineEasingValue) => void;
+	readonly preset: EasingPreset;
+}> = ({currentEasing, disabled, onClick, preset}) => {
+	const selected = areEasingsEqual(currentEasing, preset.easing);
+	const path = useMemo(
+		() => getPresetPreviewPath(preset.easing),
+		[preset.easing],
+	);
+	const style = useMemo(
+		(): React.CSSProperties => ({
+			...presetButtonBase,
+			backgroundColor: selected ? 'rgba(11, 132, 243, 0.18)' : INPUT_BACKGROUND,
+			borderColor: selected ? BLUE : INPUT_BORDER_COLOR_HOVERED,
+			cursor: disabled ? 'not-allowed' : 'pointer',
+			opacity: disabled ? 0.45 : 1,
+		}),
+		[disabled, selected],
+	);
+	const handleClick = useCallback(() => {
+		onClick(preset.easing);
+	}, [onClick, preset.easing]);
+
+	return (
+		<button
+			type="button"
+			style={style}
+			title={preset.label}
+			aria-label={`Apply ${preset.label} easing`}
+			disabled={disabled}
+			onClick={handleClick}
+		>
+			<svg
+				width={PRESET_PREVIEW_WIDTH}
+				height={PRESET_PREVIEW_HEIGHT}
+				viewBox={`0 0 ${PRESET_PREVIEW_WIDTH} ${PRESET_PREVIEW_HEIGHT}`}
+				style={presetPreviewSvgStyle}
+				aria-hidden="true"
+				focusable={false}
+			>
+				<path
+					d={path}
+					fill="none"
+					stroke={selected ? 'white' : BLUE}
+					strokeWidth={2}
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+			</svg>
+		</button>
 	);
 };
 
@@ -626,6 +779,33 @@ export const EasingEditor: React.FC<{
 		[applyLiveEasing, commitEasing, mode, previewServerState.type],
 	);
 
+	const applyPreset = useCallback(
+		(easing: TimelineEasingValue) => {
+			if (previewServerState.type !== 'connected') {
+				return;
+			}
+
+			if (isSpringEasing(easing)) {
+				const nextSpring = sanitizeSpring(easing);
+				setMode('spring');
+				const springVersion = setSpringAndPreview(nextSpring);
+				commitEasing(serializeSpring(nextSpring), springVersion);
+				return;
+			}
+
+			const nextBezier = easingToBezier(easing);
+			setMode('bezier');
+			const bezierVersion = setBezierAndPreview(nextBezier);
+			commitEasing(serializeBezier(nextBezier), bezierVersion);
+		},
+		[
+			commitEasing,
+			previewServerState.type,
+			setBezierAndPreview,
+			setSpringAndPreview,
+		],
+	);
+
 	const getValueFromPointer = useCallback(
 		(event: {clientX: number; clientY: number}) => {
 			const svg = svgRef.current;
@@ -742,6 +922,11 @@ export const EasingEditor: React.FC<{
 	}, [spring]);
 
 	const disabled = previewServerState.type !== 'connected';
+	const currentEasing = useMemo(
+		() =>
+			mode === 'spring' ? serializeSpring(spring) : serializeBezier(bezier),
+		[bezier, mode, spring],
+	);
 	const modeItems = useMemo((): SegmentedControlItem[] => {
 		return [
 			{
@@ -771,6 +956,17 @@ export const EasingEditor: React.FC<{
 		<div style={inlineContainer}>
 			<div style={segmentedControlWrapper}>
 				<SegmentedControl items={modeItems} needsWrapping={false} />
+			</div>
+			<div style={presetButtonsWrapper}>
+				{EDITOR_EASING_PRESETS.map((preset) => (
+					<EasingPresetButton
+						key={preset.id}
+						currentEasing={currentEasing}
+						disabled={disabled}
+						onClick={applyPreset}
+						preset={preset}
+					/>
+				))}
 			</div>
 			{mode === 'bezier' ? (
 				<>

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -103,7 +103,7 @@ const inlineContainer: React.CSSProperties = {
 
 const segmentedControlWrapper: React.CSSProperties = {
 	display: 'flex',
-	justifyContent: 'center',
+	justifyContent: 'flex-start',
 	padding: '0 12px',
 	marginBottom: 10,
 };

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -490,7 +490,7 @@ const EasingPresetButton: React.FC<{
 				<path
 					d={path}
 					fill="none"
-					stroke={selected ? 'white' : BLUE}
+					stroke="white"
 					strokeWidth={2}
 					strokeLinecap="round"
 					strokeLinejoin="round"

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -24,6 +24,12 @@ import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import {InputDragger} from '../NewComposition/InputDragger';
 import type {SegmentedControlItem} from '../SegmentedControl';
 import {SegmentedControl} from '../SegmentedControl';
+import {
+	formatTimelineNumber,
+	getTimelineDisplayDecimalPlaces,
+	normalizeTimelineNumber,
+} from './timeline-field-utils';
+import {parseCssRotationToDegrees} from './timeline-rotation-utils';
 import type {TimelineSelection} from './TimelineSelection';
 import type {
 	SelectedEasingUpdate,
@@ -367,7 +373,84 @@ const getEasingUpdateTargetKey = (update: SelectedEasingUpdate) => {
 	return `effect:${nodePathKey}:${update.effectIndex}:${update.fieldKey}:${update.segmentIndex}`;
 };
 
-const formatEasingGraphLabel = (value: unknown): string => {
+const formatRotationEasingGraphLabel = ({
+	update,
+	value,
+}: {
+	readonly update: SelectedEasingUpdate;
+	readonly value: unknown;
+}) => {
+	const fieldSchema = update.schema[update.fieldKey];
+	const configuredStep =
+		fieldSchema.type === 'rotation-css' ||
+		fieldSchema.type === 'rotation-degrees'
+			? fieldSchema.step
+			: undefined;
+	const decimalPlaces = getTimelineDisplayDecimalPlaces({
+		defaultDecimalPlaces: 1,
+		step: configuredStep,
+	});
+	const degrees =
+		fieldSchema.type === 'rotation-css'
+			? parseCssRotationToDegrees(String(value ?? '0deg'))
+			: typeof value === 'number'
+				? value
+				: Number(value);
+
+	if (!Number.isFinite(degrees)) {
+		return null;
+	}
+
+	return `${formatTimelineNumber({
+		decimalPlaces,
+		fixed: false,
+		value: normalizeTimelineNumber(degrees),
+	})}\u00B0`;
+};
+
+const formatNumberEasingGraphLabel = ({
+	update,
+	value,
+}: {
+	readonly update: SelectedEasingUpdate;
+	readonly value: unknown;
+}) => {
+	const fieldSchema = update.schema[update.fieldKey];
+	if (fieldSchema.type !== 'number' || typeof value !== 'number') {
+		return null;
+	}
+
+	if (fieldSchema.step === undefined) {
+		return String(value);
+	}
+
+	return formatTimelineNumber({
+		decimalPlaces: getTimelineDisplayDecimalPlaces({
+			defaultDecimalPlaces: 0,
+			step: fieldSchema.step,
+		}),
+		fixed: true,
+		value,
+	});
+};
+
+const formatEasingGraphLabel = (
+	value: unknown,
+	update: SelectedEasingUpdate,
+): string => {
+	const fieldSchema = update.schema[update.fieldKey];
+	if (
+		fieldSchema.type === 'rotation-css' ||
+		fieldSchema.type === 'rotation-degrees'
+	) {
+		return formatRotationEasingGraphLabel({update, value}) ?? String(value);
+	}
+
+	const numberLabel = formatNumberEasingGraphLabel({update, value});
+	if (numberLabel !== null) {
+		return numberLabel;
+	}
+
 	if (
 		value === null ||
 		typeof value === 'number' ||
@@ -400,8 +483,8 @@ const getEasingGraphLabelsFromUpdate = (
 	}
 
 	return {
-		start: formatEasingGraphLabel(startKeyframe.value),
-		end: formatEasingGraphLabel(endKeyframe.value),
+		start: formatEasingGraphLabel(startKeyframe.value, update),
+		end: formatEasingGraphLabel(endKeyframe.value, update),
 	};
 };
 

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -114,7 +114,6 @@ const presetButtonsWrapper: React.CSSProperties = {
 	gap: 6,
 	justifyContent: 'center',
 	marginBottom: 8,
-	padding: '0 12px',
 };
 
 const presetButtonBase: React.CSSProperties = {

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -41,6 +41,10 @@ type HandleIndex = 0 | 1;
 type Coordinate = 'x' | 'y';
 type EditorMode = 'bezier' | 'spring';
 type SpringNumberKey = 'damping' | 'mass' | 'stiffness';
+type EasingGraphLabels = {
+	readonly start: string;
+	readonly end: string;
+};
 type EasingPreset = {
 	readonly id: string;
 	readonly label: string;
@@ -57,6 +61,10 @@ const Y_MIN = -2;
 const Y_MAX = 3;
 const LINEAR_EASING: TimelineEasingValue = {type: 'linear'};
 const LINEAR_BEZIER: CubicBezierTuple = [0.25, 0.25, 0.75, 0.75];
+const DEFAULT_EASING_GRAPH_LABELS: EasingGraphLabels = {
+	start: '0',
+	end: '1',
+};
 const EASING_GRAPH_GUIDE_COLOR = 'rgba(255, 255, 255, 0.12)';
 const PRESET_PREVIEW_WIDTH = 48;
 const PRESET_PREVIEW_HEIGHT = 30;
@@ -355,6 +363,67 @@ const getEasingUpdateTargetKey = (update: SelectedEasingUpdate) => {
 	return `effect:${nodePathKey}:${update.effectIndex}:${update.fieldKey}:${update.segmentIndex}`;
 };
 
+const formatEasingGraphLabel = (value: unknown): string => {
+	if (
+		value === null ||
+		typeof value === 'number' ||
+		typeof value === 'string' ||
+		typeof value === 'boolean' ||
+		typeof value === 'bigint'
+	) {
+		return String(value);
+	}
+
+	if (value === undefined) {
+		return 'undefined';
+	}
+
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return String(value);
+	}
+};
+
+const getEasingGraphLabelsFromUpdate = (
+	update: SelectedEasingUpdate,
+): EasingGraphLabels | null => {
+	const startKeyframe = update.propStatus.keyframes[update.segmentIndex];
+	const endKeyframe = update.propStatus.keyframes[update.segmentIndex + 1];
+
+	if (!startKeyframe || !endKeyframe) {
+		return null;
+	}
+
+	return {
+		start: formatEasingGraphLabel(startKeyframe.value),
+		end: formatEasingGraphLabel(endKeyframe.value),
+	};
+};
+
+const areEasingGraphLabelsEqual = (
+	first: EasingGraphLabels,
+	second: EasingGraphLabels,
+) => first.start === second.start && first.end === second.end;
+
+const getEasingGraphLabels = (
+	updates: readonly SelectedEasingUpdate[],
+): EasingGraphLabels => {
+	const firstLabels =
+		updates.length === 0 ? null : getEasingGraphLabelsFromUpdate(updates[0]);
+
+	if (firstLabels === null) {
+		return DEFAULT_EASING_GRAPH_LABELS;
+	}
+
+	return updates.every((update) => {
+		const labels = getEasingGraphLabelsFromUpdate(update);
+		return labels !== null && areEasingGraphLabelsEqual(labels, firstLabels);
+	})
+		? firstLabels
+		: DEFAULT_EASING_GRAPH_LABELS;
+};
+
 const xToSvg = (value: number) => PLOT_LEFT + value * PLOT_WIDTH;
 const yToSvg = (value: number) =>
 	PLOT_TOP + ((Y_MAX - value) / (Y_MAX - Y_MIN)) * PLOT_HEIGHT;
@@ -414,7 +483,9 @@ const pointFromBezier = (bezier: CubicBezierTuple, handle: HandleIndex) => {
 	return {x: xToSvg(x), y: yToSvg(y)};
 };
 
-const EasingGraphScaffold: React.FC = () => {
+const EasingGraphScaffold: React.FC<{
+	readonly labels: EasingGraphLabels;
+}> = ({labels}) => {
 	const yZero = yToSvg(0);
 	const yOne = yToSvg(1);
 	const yZeroLabel = clamp(yZero + 3, 10, SVG_HEIGHT - 4);
@@ -438,11 +509,23 @@ const EasingGraphScaffold: React.FC = () => {
 				stroke={EASING_GRAPH_GUIDE_COLOR}
 				strokeWidth={1}
 			/>
-			<text x={PLOT_LEFT - 22} y={yZeroLabel} fill={LIGHT_TEXT} fontSize={9}>
-				0
+			<text
+				x={PLOT_LEFT - 8}
+				y={yZeroLabel}
+				fill={LIGHT_TEXT}
+				fontSize={9}
+				textAnchor="end"
+			>
+				{labels.start}
 			</text>
-			<text x={PLOT_LEFT - 22} y={yOneLabel} fill={LIGHT_TEXT} fontSize={9}>
-				1
+			<text
+				x={PLOT_LEFT - 8}
+				y={yOneLabel}
+				fill={LIGHT_TEXT}
+				fontSize={9}
+				textAnchor="end"
+			>
+				{labels.end}
 			</text>
 		</>
 	);
@@ -924,6 +1007,7 @@ export const EasingEditor: React.FC<{
 	}, [spring]);
 
 	const disabled = previewServerState.type !== 'connected';
+	const graphLabels = getEasingGraphLabels(getCurrentEasingUpdates());
 	const currentEasing = useMemo(
 		() =>
 			mode === 'spring' ? serializeSpring(spring) : serializeBezier(bezier),
@@ -980,7 +1064,7 @@ export const EasingEditor: React.FC<{
 						style={svgStyle}
 						aria-label="Bezier curve editor"
 					>
-						<EasingGraphScaffold />
+						<EasingGraphScaffold labels={graphLabels} />
 						<line
 							x1={startPoint.x}
 							y1={startPoint.y}
@@ -1129,7 +1213,7 @@ export const EasingEditor: React.FC<{
 						style={svgStyle}
 						aria-label="Spring easing curve"
 					>
-						<EasingGraphScaffold />
+						<EasingGraphScaffold labels={graphLabels} />
 						<path d={springPath} fill="none" stroke={BLUE} strokeWidth={3} />
 						<circle cx={xToSvg(0)} cy={yToSvg(0)} r={4} fill="white" />
 						<circle cx={xToSvg(1)} cy={yToSvg(1)} r={4} fill="white" />

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -57,6 +57,7 @@ const Y_MIN = -2;
 const Y_MAX = 3;
 const LINEAR_EASING: TimelineEasingValue = {type: 'linear'};
 const LINEAR_BEZIER: CubicBezierTuple = [0.25, 0.25, 0.75, 0.75];
+const EASING_GRAPH_GUIDE_COLOR = 'rgba(255, 255, 255, 0.12)';
 const PRESET_PREVIEW_WIDTH = 48;
 const PRESET_PREVIEW_HEIGHT = 30;
 const PRESET_PREVIEW_PADDING = 5;
@@ -426,7 +427,7 @@ const EasingGraphScaffold: React.FC = () => {
 				y1={yZero}
 				x2={PLOT_LEFT + PLOT_WIDTH}
 				y2={yZero}
-				stroke={INPUT_BORDER_COLOR_HOVERED}
+				stroke={EASING_GRAPH_GUIDE_COLOR}
 				strokeWidth={1}
 			/>
 			<line
@@ -434,7 +435,7 @@ const EasingGraphScaffold: React.FC = () => {
 				y1={yOne}
 				x2={PLOT_LEFT + PLOT_WIDTH}
 				y2={yOne}
-				stroke={INPUT_BORDER_COLOR_HOVERED}
+				stroke={EASING_GRAPH_GUIDE_COLOR}
 				strokeWidth={1}
 			/>
 			<text x={PLOT_LEFT - 22} y={yZeroLabel} fill={LIGHT_TEXT} fontSize={9}>

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -73,7 +73,8 @@ const DEFAULT_EASING_GRAPH_LABELS: EasingGraphLabels = {
 	end: '1',
 };
 const EASING_GRAPH_GUIDE_COLOR = 'rgba(255, 255, 255, 0.12)';
-const EASING_GRAPH_LABEL_HEIGHT = 14;
+const EASING_GRAPH_LABEL_FONT_SIZE = 11;
+const EASING_GRAPH_LABEL_HEIGHT = 16;
 const EASING_GRAPH_LABEL_HORIZONTAL_PADDING = 4;
 const EASING_GRAPH_LABEL_MAX_WIDTH = PLOT_WIDTH / 2;
 const PRESET_PREVIEW_WIDTH = 48;
@@ -572,7 +573,7 @@ const pointFromBezier = (bezier: CubicBezierTuple, handle: HandleIndex) => {
 
 const getEasingGraphLabelWidth = (label: string) => {
 	return clamp(
-		label.length * 5.5 + EASING_GRAPH_LABEL_HORIZONTAL_PADDING * 2,
+		label.length * 6.5 + EASING_GRAPH_LABEL_HORIZONTAL_PADDING * 2,
 		24,
 		EASING_GRAPH_LABEL_MAX_WIDTH,
 	);
@@ -585,7 +586,7 @@ const getEasingGraphLabelStyle = (
 	backgroundColor: BACKGROUND,
 	color: LIGHT_TEXT,
 	display: 'flex',
-	fontSize: 9,
+	fontSize: EASING_GRAPH_LABEL_FONT_SIZE,
 	height: '100%',
 	justifyContent: textAlign === 'left' ? 'flex-start' : 'flex-end',
 	lineHeight: `${EASING_GRAPH_LABEL_HEIGHT}px`,

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -10,7 +10,9 @@ import React, {
 	useRef,
 	useState,
 } from 'react';
+import type {InteractivitySchemaField} from 'remotion';
 import {Easing, Internals} from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {
 	BACKGROUND,
@@ -26,11 +28,14 @@ import type {SegmentedControlItem} from '../SegmentedControl';
 import {SegmentedControl} from '../SegmentedControl';
 import {
 	formatTimelineNumber,
+	getDecimalPlaces,
 	getTimelineDisplayDecimalPlaces,
 	normalizeTimelineNumber,
 } from './timeline-field-utils';
 import {parseCssRotationToDegrees} from './timeline-rotation-utils';
+import {parseTranslate, serializeTranslate} from './timeline-translate-utils';
 import type {TimelineSelection} from './TimelineSelection';
+import {parseTransformOrigin} from './transform-origin-utils';
 import type {
 	SelectedEasingUpdate,
 	TimelineEasingValue,
@@ -374,22 +379,82 @@ const getEasingUpdateTargetKey = (update: SelectedEasingUpdate) => {
 	return `effect:${nodePathKey}:${update.effectIndex}:${update.fieldKey}:${update.segmentIndex}`;
 };
 
-const formatRotationEasingGraphLabel = ({
-	update,
-	value,
-}: {
-	readonly update: SelectedEasingUpdate;
-	readonly value: unknown;
-}) => {
-	const fieldSchema = update.schema[update.fieldKey];
-	if (
-		!fieldSchema ||
-		(fieldSchema.type !== 'rotation-css' &&
-			fieldSchema.type !== 'rotation-degrees')
-	) {
-		return null;
+const EASING_GRAPH_FALLBACK_DECIMAL_PLACES = 3;
+
+const formatGenericNumberEasingGraphLabel = (value: number) => {
+	if (!Number.isFinite(value)) {
+		return String(value);
 	}
 
+	return formatTimelineNumber({
+		decimalPlaces: EASING_GRAPH_FALLBACK_DECIMAL_PLACES,
+		fixed: false,
+		value: normalizeTimelineNumber(value),
+	});
+};
+
+const normalizeUnknownForEasingGraphLabel = (value: unknown): unknown => {
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return roundToDecimalPlaces(
+			normalizeTimelineNumber(value),
+			EASING_GRAPH_FALLBACK_DECIMAL_PLACES,
+		);
+	}
+
+	if (Array.isArray(value)) {
+		return value.map(normalizeUnknownForEasingGraphLabel);
+	}
+
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, item]) => [
+				key,
+				normalizeUnknownForEasingGraphLabel(item),
+			]),
+		);
+	}
+
+	return value;
+};
+
+const formatUnknownEasingGraphLabel = (value: unknown): string => {
+	if (typeof value === 'number') {
+		return formatGenericNumberEasingGraphLabel(value);
+	}
+
+	if (
+		value === null ||
+		typeof value === 'string' ||
+		typeof value === 'boolean' ||
+		typeof value === 'bigint'
+	) {
+		return String(value);
+	}
+
+	if (value === undefined) {
+		return 'undefined';
+	}
+
+	try {
+		return (
+			JSON.stringify(normalizeUnknownForEasingGraphLabel(value)) ??
+			String(value)
+		);
+	} catch {
+		return String(value);
+	}
+};
+
+const formatRotationEasingGraphLabel = ({
+	fieldSchema,
+	value,
+}: {
+	readonly fieldSchema: Extract<
+		InteractivitySchemaField,
+		{type: 'rotation-css'} | {type: 'rotation-degrees'}
+	>;
+	readonly value: unknown;
+}) => {
 	const configuredStep =
 		fieldSchema.type === 'rotation-css' ||
 		fieldSchema.type === 'rotation-degrees'
@@ -418,69 +483,241 @@ const formatRotationEasingGraphLabel = ({
 };
 
 const formatNumberEasingGraphLabel = ({
-	update,
+	fieldSchema,
 	value,
 }: {
-	readonly update: SelectedEasingUpdate;
+	readonly fieldSchema: Extract<InteractivitySchemaField, {type: 'number'}>;
 	readonly value: unknown;
 }) => {
-	const fieldSchema = update.schema[update.fieldKey];
-	if (
-		!fieldSchema ||
-		fieldSchema.type !== 'number' ||
-		typeof value !== 'number'
-	) {
+	if (typeof value !== 'number') {
 		return null;
 	}
 
-	if (fieldSchema.step === undefined) {
-		return String(value);
+	const stepDecimals =
+		fieldSchema.step === undefined ? null : getDecimalPlaces(fieldSchema.step);
+
+	if (stepDecimals === null) {
+		const digits = getDecimalPlaces(value);
+		return digits === 0 ? String(value) : value.toFixed(digits);
 	}
 
 	return formatTimelineNumber({
-		decimalPlaces: getTimelineDisplayDecimalPlaces({
-			defaultDecimalPlaces: 0,
-			step: fieldSchema.step,
-		}),
+		decimalPlaces: stepDecimals,
 		fixed: true,
 		value,
 	});
 };
 
+const formatScaleEasingGraphLabel = ({
+	fieldSchema,
+	value,
+}: {
+	readonly fieldSchema: Extract<InteractivitySchemaField, {type: 'scale'}>;
+	readonly value: unknown;
+}) => {
+	const decimalPlaces = getTimelineDisplayDecimalPlaces({
+		defaultDecimalPlaces: 3,
+		step: fieldSchema.step,
+	});
+	const formatScalePart = (part: number) =>
+		formatTimelineNumber({
+			decimalPlaces,
+			fixed: true,
+			value: part,
+		});
+	const [x, y, z] = NoReactInternals.parseScaleValue(value);
+	const parts = x === y && z === 1 ? [x] : z === 1 ? [x, y] : [x, y, z];
+
+	return parts.map(formatScalePart).join(' ');
+};
+
+const formatTranslateEasingGraphLabel = ({
+	fieldSchema,
+	value,
+}: {
+	readonly fieldSchema: Extract<InteractivitySchemaField, {type: 'translate'}>;
+	readonly value: unknown;
+}) => {
+	const decimalPlaces = getTimelineDisplayDecimalPlaces({
+		defaultDecimalPlaces: 1,
+		step: fieldSchema.step,
+	});
+	const [x, y] = parseTranslate(String(value ?? '0px 0px'));
+
+	return serializeTranslate(x, y, decimalPlaces);
+};
+
+const formatTransformOriginAxisValue = ({
+	decimalPlaces,
+	unit,
+	value,
+}: {
+	readonly decimalPlaces: number;
+	readonly unit: '%' | 'px';
+	readonly value: number;
+}) => {
+	return `${formatTimelineNumber({
+		decimalPlaces,
+		fixed: false,
+		value,
+	})}${unit}`;
+};
+
+const formatTransformOriginEasingGraphLabel = ({
+	fieldSchema,
+	value,
+}: {
+	readonly fieldSchema: Extract<
+		InteractivitySchemaField,
+		{type: 'transform-origin'}
+	>;
+	readonly value: unknown;
+}) => {
+	const parsed = parseTransformOrigin(value);
+	if (parsed === null) {
+		return null;
+	}
+
+	const decimalPlaces = getTimelineDisplayDecimalPlaces({
+		defaultDecimalPlaces: 2,
+		step: fieldSchema.step,
+	});
+	const xy = `${formatTransformOriginAxisValue({
+		decimalPlaces,
+		unit: parsed.x.unit,
+		value: parsed.x.value,
+	})} ${formatTransformOriginAxisValue({
+		decimalPlaces,
+		unit: parsed.y.unit,
+		value: parsed.y.value,
+	})}`;
+
+	return parsed.z === null ? xy : `${xy} ${parsed.z}`;
+};
+
+const formatUvCoordinateEasingGraphLabel = ({
+	fieldSchema,
+	value,
+}: {
+	readonly fieldSchema: Extract<
+		InteractivitySchemaField,
+		{type: 'uv-coordinate'}
+	>;
+	readonly value: unknown;
+}) => {
+	if (
+		!Array.isArray(value) ||
+		value.length !== 2 ||
+		!value.every((item) => typeof item === 'number' && Number.isFinite(item))
+	) {
+		return null;
+	}
+
+	const decimalPlaces = getTimelineDisplayDecimalPlaces({
+		defaultDecimalPlaces: 2,
+		step: fieldSchema.step,
+	});
+	const formatPart = (part: number) =>
+		formatTimelineNumber({
+			decimalPlaces,
+			fixed: true,
+			value: part,
+		});
+
+	return `${formatPart(value[0])}, ${formatPart(value[1])}`;
+};
+
+const formatSchemaEasingGraphLabel = ({
+	fieldSchema,
+	value,
+}: {
+	readonly fieldSchema: InteractivitySchemaField | undefined;
+	readonly value: unknown;
+}) => {
+	if (!fieldSchema) {
+		return formatUnknownEasingGraphLabel(value);
+	}
+
+	switch (fieldSchema.type) {
+		case 'number': {
+			return (
+				formatNumberEasingGraphLabel({fieldSchema, value}) ??
+				formatUnknownEasingGraphLabel(value)
+			);
+		}
+
+		case 'rotation-css':
+		case 'rotation-degrees': {
+			return (
+				formatRotationEasingGraphLabel({fieldSchema, value}) ??
+				formatUnknownEasingGraphLabel(value)
+			);
+		}
+
+		case 'scale':
+			return formatScaleEasingGraphLabel({fieldSchema, value});
+
+		case 'translate':
+			return formatTranslateEasingGraphLabel({fieldSchema, value});
+
+		case 'transform-origin':
+			return (
+				formatTransformOriginEasingGraphLabel({fieldSchema, value}) ??
+				formatUnknownEasingGraphLabel(value)
+			);
+
+		case 'uv-coordinate':
+			return (
+				formatUvCoordinateEasingGraphLabel({fieldSchema, value}) ??
+				formatUnknownEasingGraphLabel(value)
+			);
+
+		case 'array':
+		case 'boolean':
+		case 'color':
+		case 'enum':
+		case 'hidden':
+			return formatUnknownEasingGraphLabel(value);
+
+		default:
+			return formatUnknownEasingGraphLabel(value);
+	}
+};
+
+const getBuiltInVisualStyleFieldSchema = (
+	fieldKey: string,
+): InteractivitySchemaField | undefined => {
+	const transformSchema = Internals.transformSchema as Record<
+		string,
+		InteractivitySchemaField
+	>;
+	const directField = transformSchema[fieldKey];
+	if (directField) {
+		return directField;
+	}
+
+	return transformSchema[
+		fieldKey.startsWith('style.') ? fieldKey : `style.${fieldKey}`
+	];
+};
+
+const getEasingGraphFieldSchema = (
+	update: SelectedEasingUpdate,
+): InteractivitySchemaField | undefined => {
+	return (
+		update.schema[update.fieldKey] ??
+		getBuiltInVisualStyleFieldSchema(update.fieldKey)
+	);
+};
+
 const formatEasingGraphLabel = (
 	value: unknown,
 	update: SelectedEasingUpdate,
-): string => {
-	const rotationLabel = formatRotationEasingGraphLabel({update, value});
-	if (rotationLabel !== null) {
-		return rotationLabel;
-	}
-
-	const numberLabel = formatNumberEasingGraphLabel({update, value});
-	if (numberLabel !== null) {
-		return numberLabel;
-	}
-
-	if (
-		value === null ||
-		typeof value === 'number' ||
-		typeof value === 'string' ||
-		typeof value === 'boolean' ||
-		typeof value === 'bigint'
-	) {
-		return String(value);
-	}
-
-	if (value === undefined) {
-		return 'undefined';
-	}
-
-	try {
-		return JSON.stringify(value) ?? String(value);
-	} catch {
-		return String(value);
-	}
-};
+): string =>
+	formatSchemaEasingGraphLabel({
+		fieldSchema: getEasingGraphFieldSchema(update),
+		value,
+	});
 
 const getEasingGraphLabelsFromUpdate = (
 	update: SelectedEasingUpdate,

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -623,7 +623,7 @@ const EasingGraphScaffold: React.FC<{
 				strokeWidth={1}
 			/>
 			<foreignObject
-				x={PLOT_LEFT}
+				x={PLOT_LEFT - EASING_GRAPH_LABEL_HORIZONTAL_PADDING}
 				y={yOne - EASING_GRAPH_LABEL_HEIGHT / 2}
 				width={topLabelWidth}
 				height={EASING_GRAPH_LABEL_HEIGHT}
@@ -633,7 +633,12 @@ const EasingGraphScaffold: React.FC<{
 				</div>
 			</foreignObject>
 			<foreignObject
-				x={PLOT_LEFT + PLOT_WIDTH - bottomLabelWidth}
+				x={
+					PLOT_LEFT +
+					PLOT_WIDTH -
+					bottomLabelWidth +
+					EASING_GRAPH_LABEL_HORIZONTAL_PADDING
+				}
 				y={yZero - EASING_GRAPH_LABEL_HEIGHT / 2}
 				width={bottomLabelWidth}
 				height={EASING_GRAPH_LABEL_HEIGHT}

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -13,6 +13,7 @@ import React, {
 import {Easing, Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {
+	BACKGROUND,
 	BLUE,
 	INPUT_BACKGROUND,
 	INPUT_BORDER_COLOR_HOVERED,
@@ -66,6 +67,9 @@ const DEFAULT_EASING_GRAPH_LABELS: EasingGraphLabels = {
 	end: '1',
 };
 const EASING_GRAPH_GUIDE_COLOR = 'rgba(255, 255, 255, 0.12)';
+const EASING_GRAPH_LABEL_HEIGHT = 14;
+const EASING_GRAPH_LABEL_HORIZONTAL_PADDING = 4;
+const EASING_GRAPH_LABEL_MAX_WIDTH = PLOT_WIDTH / 2;
 const PRESET_PREVIEW_WIDTH = 48;
 const PRESET_PREVIEW_HEIGHT = 30;
 const PRESET_PREVIEW_PADDING = 5;
@@ -483,13 +487,39 @@ const pointFromBezier = (bezier: CubicBezierTuple, handle: HandleIndex) => {
 	return {x: xToSvg(x), y: yToSvg(y)};
 };
 
+const getEasingGraphLabelWidth = (label: string) => {
+	return clamp(
+		label.length * 5.5 + EASING_GRAPH_LABEL_HORIZONTAL_PADDING * 2,
+		24,
+		EASING_GRAPH_LABEL_MAX_WIDTH,
+	);
+};
+
+const getEasingGraphLabelStyle = (
+	textAlign: 'left' | 'right',
+): React.CSSProperties => ({
+	alignItems: 'center',
+	backgroundColor: BACKGROUND,
+	color: LIGHT_TEXT,
+	display: 'flex',
+	fontSize: 9,
+	height: '100%',
+	justifyContent: textAlign === 'left' ? 'flex-start' : 'flex-end',
+	lineHeight: `${EASING_GRAPH_LABEL_HEIGHT}px`,
+	overflow: 'hidden',
+	padding: `0 ${EASING_GRAPH_LABEL_HORIZONTAL_PADDING}px`,
+	textAlign,
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+});
+
 const EasingGraphScaffold: React.FC<{
 	readonly labels: EasingGraphLabels;
 }> = ({labels}) => {
 	const yZero = yToSvg(0);
 	const yOne = yToSvg(1);
-	const yZeroLabel = clamp(yZero + 3, 10, SVG_HEIGHT - 4);
-	const yOneLabel = clamp(yOne + 3, 10, SVG_HEIGHT - 4);
+	const bottomLabelWidth = getEasingGraphLabelWidth(labels.start);
+	const topLabelWidth = getEasingGraphLabelWidth(labels.end);
 
 	return (
 		<>
@@ -509,24 +539,26 @@ const EasingGraphScaffold: React.FC<{
 				stroke={EASING_GRAPH_GUIDE_COLOR}
 				strokeWidth={1}
 			/>
-			<text
-				x={PLOT_LEFT - 8}
-				y={yZeroLabel}
-				fill={LIGHT_TEXT}
-				fontSize={9}
-				textAnchor="end"
+			<foreignObject
+				x={PLOT_LEFT}
+				y={yOne - EASING_GRAPH_LABEL_HEIGHT / 2}
+				width={topLabelWidth}
+				height={EASING_GRAPH_LABEL_HEIGHT}
 			>
-				{labels.start}
-			</text>
-			<text
-				x={PLOT_LEFT - 8}
-				y={yOneLabel}
-				fill={LIGHT_TEXT}
-				fontSize={9}
-				textAnchor="end"
+				<div style={getEasingGraphLabelStyle('left')} title={labels.end}>
+					{labels.end}
+				</div>
+			</foreignObject>
+			<foreignObject
+				x={PLOT_LEFT + PLOT_WIDTH - bottomLabelWidth}
+				y={yZero - EASING_GRAPH_LABEL_HEIGHT / 2}
+				width={bottomLabelWidth}
+				height={EASING_GRAPH_LABEL_HEIGHT}
 			>
-				{labels.end}
-			</text>
+				<div style={getEasingGraphLabelStyle('right')} title={labels.start}>
+					{labels.start}
+				</div>
+			</foreignObject>
 		</>
 	);
 };

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -73,8 +73,8 @@ const DEFAULT_EASING_GRAPH_LABELS: EasingGraphLabels = {
 	end: '1',
 };
 const EASING_GRAPH_GUIDE_COLOR = 'rgba(255, 255, 255, 0.12)';
-const EASING_GRAPH_LABEL_FONT_SIZE = 11;
-const EASING_GRAPH_LABEL_HEIGHT = 16;
+const EASING_GRAPH_LABEL_FONT_SIZE = 13;
+const EASING_GRAPH_LABEL_HEIGHT = 20;
 const EASING_GRAPH_LABEL_HORIZONTAL_PADDING = 4;
 const EASING_GRAPH_LABEL_MAX_WIDTH = PLOT_WIDTH / 2;
 const PRESET_PREVIEW_WIDTH = 48;
@@ -382,6 +382,14 @@ const formatRotationEasingGraphLabel = ({
 	readonly value: unknown;
 }) => {
 	const fieldSchema = update.schema[update.fieldKey];
+	if (
+		!fieldSchema ||
+		(fieldSchema.type !== 'rotation-css' &&
+			fieldSchema.type !== 'rotation-degrees')
+	) {
+		return null;
+	}
+
 	const configuredStep =
 		fieldSchema.type === 'rotation-css' ||
 		fieldSchema.type === 'rotation-degrees'
@@ -417,7 +425,11 @@ const formatNumberEasingGraphLabel = ({
 	readonly value: unknown;
 }) => {
 	const fieldSchema = update.schema[update.fieldKey];
-	if (fieldSchema.type !== 'number' || typeof value !== 'number') {
+	if (
+		!fieldSchema ||
+		fieldSchema.type !== 'number' ||
+		typeof value !== 'number'
+	) {
 		return null;
 	}
 
@@ -439,12 +451,9 @@ const formatEasingGraphLabel = (
 	value: unknown,
 	update: SelectedEasingUpdate,
 ): string => {
-	const fieldSchema = update.schema[update.fieldKey];
-	if (
-		fieldSchema.type === 'rotation-css' ||
-		fieldSchema.type === 'rotation-degrees'
-	) {
-		return formatRotationEasingGraphLabel({update, value}) ?? String(value);
+	const rotationLabel = formatRotationEasingGraphLabel({update, value});
+	if (rotationLabel !== null) {
+		return rotationLabel;
 	}
 
 	const numberLabel = formatNumberEasingGraphLabel({update, value});
@@ -573,7 +582,7 @@ const pointFromBezier = (bezier: CubicBezierTuple, handle: HandleIndex) => {
 
 const getEasingGraphLabelWidth = (label: string) => {
 	return clamp(
-		label.length * 6.5 + EASING_GRAPH_LABEL_HORIZONTAL_PADDING * 2,
+		label.length * 7.8 + EASING_GRAPH_LABEL_HORIZONTAL_PADDING * 2,
 		24,
 		EASING_GRAPH_LABEL_MAX_WIDTH,
 	);
@@ -714,7 +723,10 @@ export type EasingEditorState = {
 
 export const EasingEditor: React.FC<{
 	readonly state: EasingEditorState;
-}> = ({state}) => {
+	readonly renderHeader?: (
+		modeItems: SegmentedControlItem[],
+	) => React.ReactNode;
+}> = ({state, renderHeader}) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const sequencesRef = useContext(Internals.SequenceManagerRefContext);
 	const propStatusesRef = useContext(
@@ -1161,6 +1173,17 @@ export const EasingEditor: React.FC<{
 
 	return (
 		<div style={inlineContainer}>
+			{renderHeader ? (
+				renderHeader(modeItems)
+			) : (
+				<div style={segmentedControlWrapper}>
+					<SegmentedControl
+						items={modeItems}
+						needsWrapping={false}
+						size="compact"
+					/>
+				</div>
+			)}
 			<div style={presetButtonsWrapper}>
 				{EDITOR_EASING_PRESETS.map((preset) => (
 					<EasingPresetButton
@@ -1171,9 +1194,6 @@ export const EasingEditor: React.FC<{
 						preset={preset}
 					/>
 				))}
-			</div>
-			<div style={segmentedControlWrapper}>
-				<SegmentedControl items={modeItems} needsWrapping={false} />
 			</div>
 			{mode === 'bezier' ? (
 				<>

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -105,7 +105,7 @@ const segmentedControlWrapper: React.CSSProperties = {
 	display: 'flex',
 	justifyContent: 'center',
 	padding: '0 12px',
-	marginBottom: 8,
+	marginBottom: 10,
 };
 
 const presetButtonsWrapper: React.CSSProperties = {
@@ -113,7 +113,7 @@ const presetButtonsWrapper: React.CSSProperties = {
 	flexWrap: 'wrap',
 	gap: 6,
 	justifyContent: 'center',
-	marginBottom: 10,
+	marginBottom: 8,
 	padding: '0 12px',
 };
 
@@ -954,9 +954,6 @@ export const EasingEditor: React.FC<{
 
 	return (
 		<div style={inlineContainer}>
-			<div style={segmentedControlWrapper}>
-				<SegmentedControl items={modeItems} needsWrapping={false} />
-			</div>
 			<div style={presetButtonsWrapper}>
 				{EDITOR_EASING_PRESETS.map((preset) => (
 					<EasingPresetButton
@@ -967,6 +964,9 @@ export const EasingEditor: React.FC<{
 						preset={preset}
 					/>
 				))}
+			</div>
+			<div style={segmentedControlWrapper}>
+				<SegmentedControl items={modeItems} needsWrapping={false} />
 			</div>
 			{mode === 'bezier' ? (
 				<>

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -19,6 +19,7 @@ import {
 	LIGHT_TEXT,
 } from '../../helpers/colors';
 import {Checkbox} from '../Checkbox';
+import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import {InputDragger} from '../NewComposition/InputDragger';
 import type {SegmentedControlItem} from '../SegmentedControl';
 import {SegmentedControl} from '../SegmentedControl';
@@ -104,7 +105,7 @@ const inlineContainer: React.CSSProperties = {
 const segmentedControlWrapper: React.CSSProperties = {
 	display: 'flex',
 	justifyContent: 'flex-start',
-	padding: '0 12px',
+	padding: `0 ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
 	marginBottom: 10,
 };
 
@@ -112,8 +113,9 @@ const presetButtonsWrapper: React.CSSProperties = {
 	display: 'flex',
 	flexWrap: 'wrap',
 	gap: 6,
-	justifyContent: 'center',
+	justifyContent: 'flex-start',
 	marginBottom: 8,
+	padding: `0 ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
 };
 
 const presetButtonBase: React.CSSProperties = {

--- a/packages/studio/src/components/Timeline/parse-keyframe-field-from-node-path.ts
+++ b/packages/studio/src/components/Timeline/parse-keyframe-field-from-node-path.ts
@@ -15,7 +15,7 @@ export const parseKeyframeFieldFromNodePath = (
 	if (auxiliaryKeys[0] === 'controls' && auxiliaryKeys.length >= 2) {
 		return {
 			type: 'sequence',
-			fieldKey: auxiliaryKeys[1],
+			fieldKey: auxiliaryKeys.slice(1).join('.'),
 		};
 	}
 
@@ -29,7 +29,7 @@ export const parseKeyframeFieldFromNodePath = (
 		return {
 			type: 'effect',
 			effectIndex,
-			fieldKey: auxiliaryKeys[2],
+			fieldKey: auxiliaryKeys.slice(2).join('.'),
 		};
 	}
 


### PR DESCRIPTION
## Summary

- Add curve-only preset buttons to the easing editor
- Include linear, Bezier, and spring-based easing presets
- Apply preset clicks through the same live preview and commit path as manual edits
- Label easing graphs with the selected segment's actual start and end keyframe values

Fixes #8434.
Fixes #8480.

## Testing

- `bunx turbo run make --filter='@remotion/studio' --filter='@remotion/studio-shared'`
- Browser smoke check at `http://localhost:3000/`
- `bun run stylecheck`
- `bun run build`
- `bunx turbo run lint formatting make --filter='@remotion/studio' --filter='@remotion/studio-shared'`
