### PR TITLE
`@remotion/studio`: Hide default props warning without schema

### DIFF
--- a/packages/studio/src/components/InspectorPanel/DefaultInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/DefaultInspector.tsx
@@ -94,6 +94,7 @@ export const DefaultInspector: React.FC<{
 		defaultProps: currentDefaultProps,
 		mode: defaultPropsMode,
 		propsEditType: 'default-props',
+		showCannotSaveDefaultPropsWarning: canShowDefaultPropsMode,
 	});
 
 	if (hasSelectedAsset) {

--- a/packages/studio/src/components/RenderModal/DataEditor.tsx
+++ b/packages/studio/src/components/RenderModal/DataEditor.tsx
@@ -135,11 +135,13 @@ export const useDataEditorWarnings = ({
 	defaultProps,
 	mode,
 	propsEditType,
+	showCannotSaveDefaultPropsWarning,
 }: {
 	readonly canSaveDefaultProps: TypeCanSaveState | null;
 	readonly defaultProps: Record<string, unknown>;
 	readonly mode: DataEditorMode;
 	readonly propsEditType: PropsEditType;
+	readonly showCannotSaveDefaultPropsWarning: boolean;
 }) => {
 	const inJSONEditor = mode === 'json';
 	const serializedJSON: SerializedJSONWithCustomFields | null = useMemo(() => {
@@ -166,6 +168,7 @@ export const useDataEditorWarnings = ({
 			propsEditType,
 			jsMapUsed: serializedJSON ? serializedJSON.mapUsed : false,
 			jsSetUsed: serializedJSON ? serializedJSON.setUsed : false,
+			showCannotSaveDefaultPropsWarning,
 		});
 	}, [
 		cliProps,
@@ -173,6 +176,7 @@ export const useDataEditorWarnings = ({
 		inJSONEditor,
 		propsEditType,
 		serializedJSON,
+		showCannotSaveDefaultPropsWarning,
 	]);
 
 	return {serializedJSON, warnings};
@@ -259,6 +263,7 @@ export const DataEditor: React.FC<{
 		defaultProps,
 		mode,
 		propsEditType,
+		showCannotSaveDefaultPropsWarning: true,
 	});
 	const warnings = controlledWarnings ?? computedWarnings;
 

--- a/packages/studio/src/components/RenderModal/get-render-modal-warnings.ts
+++ b/packages/studio/src/components/RenderModal/get-render-modal-warnings.ts
@@ -53,7 +53,12 @@ const getInputPropsWarning = ({
 
 const getCannotSaveDefaultProps = (
 	canSaveDefaultProps: TypeCanSaveState | null,
+	showCannotSaveDefaultPropsWarning: boolean,
 ): RenderModalWarning | null => {
+	if (!showCannotSaveDefaultPropsWarning) {
+		return null;
+	}
+
 	if (canSaveDefaultProps === null) {
 		return null;
 	}
@@ -114,6 +119,7 @@ export const getRenderModalWarnings = ({
 	jsSetUsed,
 	inJSONEditor,
 	propsEditType,
+	showCannotSaveDefaultPropsWarning,
 }: {
 	cliProps: unknown;
 	canSaveDefaultProps: TypeCanSaveState | null;
@@ -123,13 +129,17 @@ export const getRenderModalWarnings = ({
 	jsSetUsed: boolean;
 	inJSONEditor: boolean;
 	propsEditType: PropsEditType;
+	showCannotSaveDefaultPropsWarning: boolean;
 }): RenderModalWarning[] => {
 	return [
 		warningOrNull(
 			'input-props-override',
 			getInputPropsWarning({cliProps, propsEditType}),
 		),
-		getCannotSaveDefaultProps(canSaveDefaultProps),
+		getCannotSaveDefaultProps(
+			canSaveDefaultProps,
+			showCannotSaveDefaultPropsWarning,
+		),
 		warningOrNull(
 			'custom-date-used',
 			customDateUsed(isCustomDateUsed, inJSONEditor),

--- a/packages/studio/src/test/render-modal-warnings.test.ts
+++ b/packages/studio/src/test/render-modal-warnings.test.ts
@@ -18,6 +18,7 @@ test('Adds a Resolve link to the cannot save default props warning', () => {
 		jsSetUsed: false,
 		inJSONEditor: false,
 		propsEditType: 'default-props',
+		showCannotSaveDefaultPropsWarning: true,
 	});
 
 	expect(warnings).toStrictEqual([
@@ -28,6 +29,26 @@ test('Adds a Resolve link to the cannot save default props warning', () => {
 			resolveLink: CANNOT_SAVE_DEFAULT_PROPS_DOCS,
 		},
 	]);
+});
+
+test('Does not add the cannot save default props warning if the editor does not apply', () => {
+	const warnings = getRenderModalWarnings({
+		cliProps: {},
+		canSaveDefaultProps: {
+			canUpdate: false,
+			determined: true,
+			reason: 'Could not find or extract defaultProps for composition "Demo"',
+		},
+		isCustomDateUsed: false,
+		customFileUsed: false,
+		jsMapUsed: false,
+		jsSetUsed: false,
+		inJSONEditor: false,
+		propsEditType: 'default-props',
+		showCannotSaveDefaultPropsWarning: false,
+	});
+
+	expect(warnings).toStrictEqual([]);
 });
 
 test('Does not add warnings before default props saveability is determined', () => {
@@ -44,6 +65,7 @@ test('Does not add warnings before default props saveability is determined', () 
 		jsSetUsed: false,
 		inJSONEditor: false,
 		propsEditType: 'default-props',
+		showCannotSaveDefaultPropsWarning: true,
 	});
 
 	expect(warnings).toStrictEqual([]);
@@ -61,6 +83,7 @@ test('Keeps other warnings as stable entries without Resolve links', () => {
 		jsSetUsed: true,
 		inJSONEditor: true,
 		propsEditType: 'default-props',
+		showCannotSaveDefaultPropsWarning: true,
 	});
 
 	expect(warnings).toStrictEqual([


### PR DESCRIPTION
Fixes #8508.

## Summary
- Hide the default-props saveability warning when the default props editor does not apply, such as compositions without a schema.
- Keep the warning for schema-enabled compositions whose defaultProps cannot be extracted.

## Testing
- bun test src/test/render-modal-warnings.test.ts (packages/studio)
- bun run build
- bunx turbo run lint formatting --filter=@remotion/studio --no-update-notifier

Note: `bun run stylecheck` was run and failed because of pre-existing unstaged changes in `packages/example/src/Empty.tsx` with unused imports; those files are not part of this PR.
