### PR TITLE
`@remotion/studio`: Hide empty inspector sections

### DIFF
--- a/packages/studio/src/components/InspectorPanel/DefaultInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/DefaultInspector.tsx
@@ -1,6 +1,7 @@
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
+import {VisualControlsContext} from '../../visual-controls/VisualControls';
 import {CurrentAsset} from '../CurrentAsset';
 import {CurrentComposition} from '../CurrentComposition';
 import {DefaultPropsEditor} from '../DefaultPropsEditor';
@@ -43,9 +44,11 @@ export const DefaultInspector: React.FC<{
 	const hasSelectedAsset = canvasContent?.type === 'asset';
 	const z = useZodIfPossible();
 	const canSaveDefaultProps = useContext(ObserveDefaultPropsContext);
+	const {handles: visualControlHandles} = useContext(VisualControlsContext);
 	const [defaultPropsMode, setDefaultPropsMode] =
 		useState<DataEditorMode>('schema');
 	const compositionId = composition?.id ?? null;
+	const hasVisualControls = Object.keys(visualControlHandles).length > 0;
 
 	useEffect(() => {
 		setDefaultPropsMode('schema');
@@ -72,7 +75,7 @@ export const DefaultInspector: React.FC<{
 		];
 	}, [defaultPropsMode]);
 
-	const canShowDefaultPropsMode = useMemo(() => {
+	const canShowDefaultPropsSection = useMemo(() => {
 		if (!z || !composition?.schema || !composition.defaultProps) {
 			return false;
 		}
@@ -94,7 +97,7 @@ export const DefaultInspector: React.FC<{
 		defaultProps: currentDefaultProps,
 		mode: defaultPropsMode,
 		propsEditType: 'default-props',
-		showCannotSaveDefaultPropsWarning: canShowDefaultPropsMode,
+		showCannotSaveDefaultPropsWarning: canShowDefaultPropsSection,
 	});
 
 	if (hasSelectedAsset) {
@@ -116,59 +119,67 @@ export const DefaultInspector: React.FC<{
 			<div style={compositionSection}>
 				<CurrentComposition />
 			</div>
-			<div style={inspectorSectionDivider} />
-			<div style={defaultPropsSection}>
-				<InspectorSectionHeader>
-					<div style={sectionHeaderRow}>
-						<div style={sectionHeaderStart}>
-							<span style={sectionHeaderTitle}>Default Props</span>
-							{canShowDefaultPropsMode ? (
-								<SegmentedControl
-									items={defaultPropsModeItems}
-									needsWrapping={false}
-									size="compact"
+			{canShowDefaultPropsSection ? (
+				<>
+					<div style={inspectorSectionDivider} />
+					<div style={defaultPropsSection}>
+						<InspectorSectionHeader>
+							<div style={sectionHeaderRow}>
+								<div style={sectionHeaderStart}>
+									<span style={sectionHeaderTitle}>Default Props</span>
+									<SegmentedControl
+										items={defaultPropsModeItems}
+										needsWrapping={false}
+										size="compact"
+									/>
+								</div>
+								<div style={sectionHeaderEnd}>
+									{defaultPropsWarnings.length > 0 ? (
+										<WarningIndicatorButton
+											setShowWarning={setShowWarning}
+											showWarning={showWarning}
+											warningCount={defaultPropsWarnings.length}
+											size="compact"
+										/>
+									) : null}
+								</div>
+							</div>
+						</InspectorSectionHeader>
+						{defaultPropsWarnings.length > 0 && showWarning ? (
+							<div style={defaultPropsWarningContainer}>
+								<InspectorDefaultPropsWarnings
+									warnings={defaultPropsWarnings}
 								/>
-							) : null}
-						</div>
-						<div style={sectionHeaderEnd}>
-							{defaultPropsWarnings.length > 0 ? (
-								<WarningIndicatorButton
-									setShowWarning={setShowWarning}
-									showWarning={showWarning}
-									warningCount={defaultPropsWarnings.length}
-									size="compact"
-								/>
-							) : null}
-						</div>
+							</div>
+						) : null}
+						<DefaultPropsEditor
+							key={composition.id}
+							unresolvedComposition={composition}
+							defaultProps={currentDefaultProps}
+							setDefaultProps={setDefaultProps}
+							propsEditType="default-props"
+							schemaErrorMode="compact"
+							layout="inspector"
+							mode={defaultPropsMode}
+							onModeChange={setDefaultPropsMode}
+							hideModeControls={canShowDefaultPropsSection}
+							warnings={defaultPropsWarnings}
+							showWarning={false}
+							setShowWarning={setShowWarning}
+							hideWarningButton
+						/>
 					</div>
-				</InspectorSectionHeader>
-				{defaultPropsWarnings.length > 0 && showWarning ? (
-					<div style={defaultPropsWarningContainer}>
-						<InspectorDefaultPropsWarnings warnings={defaultPropsWarnings} />
+				</>
+			) : null}
+			{hasVisualControls ? (
+				<>
+					<div style={inspectorSectionDivider} />
+					<div style={visualControlsSection}>
+						<InspectorSectionHeader>Visual Controls</InspectorSectionHeader>
+						<VisualControlsContent />
 					</div>
-				) : null}
-				<DefaultPropsEditor
-					key={composition.id}
-					unresolvedComposition={composition}
-					defaultProps={currentDefaultProps}
-					setDefaultProps={setDefaultProps}
-					propsEditType="default-props"
-					schemaErrorMode="compact"
-					layout="inspector"
-					mode={defaultPropsMode}
-					onModeChange={setDefaultPropsMode}
-					hideModeControls={canShowDefaultPropsMode}
-					warnings={defaultPropsWarnings}
-					showWarning={false}
-					setShowWarning={setShowWarning}
-					hideWarningButton
-				/>
-			</div>
-			<div style={inspectorSectionDivider} />
-			<div style={visualControlsSection}>
-				<InspectorSectionHeader>Visual Controls</InspectorSectionHeader>
-				<VisualControlsContent />
-			</div>
+				</>
+			) : null}
 		</div>
 	);
 };

--- a/packages/studio/src/components/VisualControls/VisualControlsContent.tsx
+++ b/packages/studio/src/components/VisualControls/VisualControlsContent.tsx
@@ -1,6 +1,5 @@
 import React, {useContext} from 'react';
 import {VisualControlsContext} from '../../visual-controls/VisualControls';
-import {CompactNotSetUp} from '../CompactExplanation';
 import {SchemaSeparationLine} from '../RenderModal/SchemaEditor/SchemaSeparationLine';
 import {VisualControlHandle} from './VisualControlHandle';
 
@@ -10,12 +9,7 @@ export const VisualControlsContent = () => {
 	const entries = Object.entries(handles);
 
 	if (entries.length === 0) {
-		return (
-			<CompactNotSetUp
-				learnMoreHref="https://www.remotion.dev/docs/studio/visual-control"
-				learnMoreAriaLabel="Learn more about visual controls"
-			/>
-		);
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
Fixes #8509

## Summary
- Hide the Default Props inspector section when the compact editor would only show "Not set up".
- Hide the Visual Controls inspector section when no visual control handles exist.
- Render inspector section dividers only before visible optional sections.

## Tests
- `bun run build`
- `bun run stylecheck`
