### PR TITLE
`@remotion/studio`: Add inspector sequence rename

### DIFF
--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -1,13 +1,26 @@
-import React, {useCallback, useContext, useMemo} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
+import {PencilIcon} from '../../icons/pencil';
 import {
 	hasSequenceControls,
 	InspectorSequenceSection,
 } from '../InspectorSequenceSection';
 import {InspectorSourceLocation} from '../InspectorSourceLocation';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
+import {saveSequenceProps} from '../Timeline/save-sequence-prop';
+import {
+	canRenameSequence,
+	getSequenceDisplayName,
+} from '../Timeline/sequence-name-editing';
 import {
 	getTimelineSelectionKey,
 	type TimelineSelection,
@@ -19,7 +32,50 @@ import type {SequenceSectionSelection} from './inspector-selection';
 import {selectedContainer, sequenceHeader, sequenceHeaderTitle} from './styles';
 import {useTrackForSelection} from './use-track-for-selection';
 
-const useSequenceDisplayName = (track: TrackWithHash) => {
+const RENAME_INPUT_CLASS_NAME = 'remotion-inspector-sequence-name-input';
+
+const titleRow: React.CSSProperties = {
+	alignItems: 'center',
+	alignSelf: 'flex-start',
+	display: 'flex',
+	maxWidth: '100%',
+	minWidth: 0,
+};
+
+const editButton: React.CSSProperties = {
+	alignItems: 'center',
+	backgroundColor: 'transparent',
+	border: 0,
+	color: 'white',
+	cursor: 'pointer',
+	display: 'inline-flex',
+	flexShrink: 0,
+	height: 18,
+	justifyContent: 'center',
+	marginLeft: 4,
+	padding: 0,
+	width: 18,
+};
+
+const iconStyle: React.CSSProperties = {
+	height: 11,
+	width: 11,
+};
+
+const titleInputStyle: React.CSSProperties = {
+	...sequenceHeaderTitle,
+	backgroundColor: 'rgba(255, 255, 255, 0.08)',
+	border: '1px solid rgba(255, 255, 255, 0.28)',
+	borderRadius: 3,
+	boxSizing: 'border-box',
+	height: 20,
+	outline: 'none',
+	padding: '0 4px',
+	userSelect: 'text',
+	WebkitUserSelect: 'text',
+};
+
+const useSequenceNameInfo = (track: TrackWithHash) => {
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const nodePath = track.nodePathInfo?.sequenceSubscriptionKey ?? null;
 
@@ -28,15 +84,179 @@ const useSequenceDisplayName = (track: TrackWithHash) => {
 			? Internals.getPropStatusesCtx(propStatuses, nodePath)
 			: undefined;
 		const codeNameStatus = propStatusesForOverride?.name;
-		const displayName =
-			codeNameStatus &&
-			codeNameStatus.status === 'static' &&
-			typeof codeNameStatus.codeValue === 'string'
-				? codeNameStatus.codeValue
-				: track.sequence.displayName;
+		const displayName = getSequenceDisplayName({
+			codeNameStatus,
+			fallbackName: track.sequence.displayName,
+		});
 
-		return displayName || '<Sequence>';
+		return {codeNameStatus, displayName};
 	}, [nodePath, propStatuses, track.sequence.displayName]);
+};
+
+const InspectorSequenceTitle: React.FC<{
+	readonly canRename: boolean;
+	readonly displayName: string;
+	readonly documentationLink: string | null;
+	readonly onOpenDocumentationLink: () => void;
+	readonly onSaveName: (name: string) => Promise<void>;
+}> = ({
+	canRename,
+	displayName,
+	documentationLink,
+	onOpenDocumentationLink,
+	onSaveName,
+}) => {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const cancelNextBlurRef = useRef(false);
+	const [draftName, setDraftName] = useState(displayName);
+	const [editing, setEditing] = useState(false);
+	const [hovered, setHovered] = useState(false);
+	const [focusWithin, setFocusWithin] = useState(false);
+	const titleText = displayName || '<Sequence>';
+	const showEditButton = canRename && (hovered || focusWithin);
+
+	useEffect(() => {
+		if (!canRename) {
+			setEditing(false);
+		}
+	}, [canRename]);
+
+	useEffect(() => {
+		if (!editing) {
+			setDraftName(displayName);
+			return;
+		}
+
+		const input = inputRef.current;
+		if (!input) {
+			return;
+		}
+
+		input.focus();
+		const basenameIndex = displayName.lastIndexOf('.');
+		const selectionEnd = basenameIndex > 0 ? basenameIndex : displayName.length;
+		input.setSelectionRange(0, selectionEnd);
+	}, [displayName, editing]);
+
+	const startEditing = useCallback(() => {
+		if (!canRename) {
+			return;
+		}
+
+		setDraftName(displayName);
+		setEditing(true);
+	}, [canRename, displayName]);
+
+	const save = useCallback(() => {
+		setEditing(false);
+		onSaveName(draftName).catch(() => undefined);
+	}, [draftName, onSaveName]);
+
+	const onKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLInputElement>) => {
+			if (e.key === 'Escape') {
+				cancelNextBlurRef.current = true;
+				e.preventDefault();
+				setEditing(false);
+				return;
+			}
+
+			if (e.key === 'Enter') {
+				cancelNextBlurRef.current = true;
+				e.preventDefault();
+				save();
+			}
+		},
+		[save],
+	);
+
+	const onBlurInput = useCallback(() => {
+		if (cancelNextBlurRef.current) {
+			cancelNextBlurRef.current = false;
+			return;
+		}
+
+		save();
+	}, [save]);
+
+	const onBlurRow = useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+		if (e.currentTarget.contains(e.relatedTarget as Node | null)) {
+			return;
+		}
+
+		setFocusWithin(false);
+	}, []);
+
+	const titleStyle = useMemo((): React.CSSProperties => {
+		return {
+			...sequenceHeaderTitle,
+			cursor: documentationLink ? 'pointer' : canRename ? 'text' : 'default',
+		};
+	}, [canRename, documentationLink]);
+
+	if (editing) {
+		return (
+			<div style={titleRow}>
+				<style>
+					{`.${RENAME_INPUT_CLASS_NAME}::selection { background: rgba(255, 255, 255, 0.72); color: black; }`}
+				</style>
+				<input
+					ref={inputRef}
+					className={RENAME_INPUT_CLASS_NAME}
+					value={draftName}
+					onChange={(e) => setDraftName(e.target.value)}
+					onBlur={onBlurInput}
+					onKeyDown={onKeyDown}
+					size={Math.max(1, draftName.length)}
+					style={titleInputStyle}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			style={titleRow}
+			onPointerEnter={() => setHovered(true)}
+			onPointerLeave={() => setHovered(false)}
+			onFocus={() => setFocusWithin(true)}
+			onBlur={onBlurRow}
+		>
+			{documentationLink ? (
+				<button
+					type="button"
+					style={titleStyle}
+					title="Open component docs"
+					onClick={onOpenDocumentationLink}
+				>
+					{titleText}
+				</button>
+			) : (
+				<div
+					style={titleStyle}
+					title={titleText}
+					onDoubleClick={canRename ? startEditing : undefined}
+				>
+					{titleText}
+				</div>
+			)}
+			{canRename ? (
+				<button
+					type="button"
+					aria-label="Rename sequence"
+					title="Rename sequence"
+					onClick={startEditing}
+					style={{
+						...editButton,
+						opacity: showEditButton ? 1 : 0,
+					}}
+					tabIndex={showEditButton ? 0 : -1}
+				>
+					<PencilIcon style={iconStyle} />
+				</button>
+			) : null}
+		</div>
+	);
 };
 
 const SequenceExpandedInspector: React.FC<{
@@ -44,10 +264,12 @@ const SequenceExpandedInspector: React.FC<{
 }> = ({track}) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {selectedItems, selectItems} = useTimelineSelection();
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {canOpenInEditor, openInEditor, originalLocation} =
 		useOpenSequenceInEditor(track.sequence);
-	const sequenceDisplayName = useSequenceDisplayName(track);
+	const {codeNameStatus, displayName} = useSequenceNameInfo(track);
 	const {documentationLink} = track.sequence;
+	const nodePath = track.nodePathInfo?.sequenceSubscriptionKey ?? null;
 
 	const validatedLocation = useMemo(() => {
 		if (
@@ -77,12 +299,6 @@ const SequenceExpandedInspector: React.FC<{
 		}
 
 		window.open(documentationLink, '_blank', 'noopener,noreferrer');
-	}, [documentationLink]);
-	const titleStyle = useMemo((): React.CSSProperties => {
-		return {
-			...sequenceHeaderTitle,
-			cursor: documentationLink ? 'pointer' : 'default',
-		};
 	}, [documentationLink]);
 	const sequenceSelection = useMemo((): TimelineSelection | null => {
 		if (!track.nodePathInfo) {
@@ -119,6 +335,57 @@ const SequenceExpandedInspector: React.FC<{
 		},
 		[selectItems, sequenceSelected, sequenceSelection],
 	);
+	const canRenameThisSequence = canRenameSequence({
+		codeNameStatus,
+		nodePath,
+		previewConnected: previewServerState.type === 'connected',
+		readOnlyStudio: window.remotion_isReadOnlyStudio,
+		sequence: track.sequence,
+		validatedLocation,
+	});
+	const onSaveName = useCallback(
+		async (name: string) => {
+			if (
+				!canRenameThisSequence ||
+				previewServerState.type !== 'connected' ||
+				!track.sequence.controls ||
+				!nodePath ||
+				!validatedLocation
+			) {
+				return;
+			}
+
+			if (name === displayName) {
+				return;
+			}
+
+			await saveSequenceProps({
+				changes: [
+					{
+						fileName: validatedLocation.source,
+						nodePath,
+						fieldKey: 'name',
+						value: name,
+						defaultValue: null,
+						schema: track.sequence.controls.schema,
+					},
+				],
+				setPropStatuses,
+				clientId: previewServerState.clientId,
+				undoLabel: 'Rename sequence',
+				redoLabel: 'Rename sequence again',
+			});
+		},
+		[
+			canRenameThisSequence,
+			displayName,
+			nodePath,
+			previewServerState,
+			setPropStatuses,
+			track.sequence.controls,
+			validatedLocation,
+		],
+	);
 
 	if (previewServerState.type !== 'connected') {
 		return <InspectorMessage>Studio server disconnected</InspectorMessage>;
@@ -139,18 +406,13 @@ const SequenceExpandedInspector: React.FC<{
 			onPointerDown={selectSequenceOnInspectorPointerDown}
 		>
 			<div style={sequenceHeader}>
-				{documentationLink ? (
-					<button
-						type="button"
-						style={titleStyle}
-						title="Open component docs"
-						onClick={openDocumentationLink}
-					>
-						{sequenceDisplayName}
-					</button>
-				) : (
-					<div style={titleStyle}>{sequenceDisplayName}</div>
-				)}
+				<InspectorSequenceTitle
+					canRename={canRenameThisSequence}
+					displayName={displayName}
+					documentationLink={documentationLink}
+					onOpenDocumentationLink={openDocumentationLink}
+					onSaveName={onSaveName}
+				/>
 				<InspectorSourceLocation
 					location={validatedLocation}
 					canOpen={canOpenInEditor}

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -31,6 +31,10 @@ import {disableSequenceInteractivity} from './disable-sequence-interactivity';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
 import {getSequenceContextMenuItems} from './get-sequence-context-menu-items';
 import {saveSequenceProps} from './save-sequence-prop';
+import {
+	canRenameSequence,
+	getSequenceDisplayName,
+} from './sequence-name-editing';
 import {getTimelineAssetLinkInfo} from './timeline-asset-link';
 import {
 	TimelineExpandArrowButton,
@@ -597,15 +601,10 @@ export const TimelineSequenceItem: React.FC<{
 	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
 
 	const displayName = useMemo(() => {
-		if (
-			codeNameStatus &&
-			codeNameStatus.status === 'static' &&
-			typeof codeNameStatus.codeValue === 'string'
-		) {
-			return codeNameStatus.codeValue;
-		}
-
-		return sequence.displayName;
+		return getSequenceDisplayName({
+			codeNameStatus,
+			fallbackName: sequence.displayName,
+		});
 	}, [codeNameStatus, sequence.displayName]);
 
 	const onToggleVisibility = useCallback(
@@ -696,15 +695,14 @@ export const TimelineSequenceItem: React.FC<{
 		codeHiddenStatus !== null &&
 		codeHiddenStatus.status === 'static';
 
-	const canRenameThisSequence =
-		previewServerState.type === 'connected' &&
-		!window.remotion_isReadOnlyStudio &&
-		Boolean(sequence.controls) &&
-		nodePath !== null &&
-		validatedLocation !== null &&
-		codeNameStatus !== undefined &&
-		codeNameStatus !== null &&
-		codeNameStatus.status === 'static';
+	const canRenameThisSequence = canRenameSequence({
+		codeNameStatus,
+		nodePath,
+		previewConnected: previewServerState.type === 'connected',
+		readOnlyStudio: window.remotion_isReadOnlyStudio,
+		sequence,
+		validatedLocation,
+	});
 
 	const canRenameSelectedSequence =
 		canRenameThisSequence &&

--- a/packages/studio/src/components/Timeline/sequence-name-editing.ts
+++ b/packages/studio/src/components/Timeline/sequence-name-editing.ts
@@ -1,0 +1,54 @@
+import type {
+	CanUpdateSequencePropStatus,
+	CanUpdateSequencePropStatusStatic,
+	SequencePropsSubscriptionKey,
+	TSequence,
+} from 'remotion';
+
+const isStaticSequenceNameStatus = (
+	status: CanUpdateSequencePropStatus | null | undefined,
+): status is CanUpdateSequencePropStatusStatic => {
+	return status !== undefined && status !== null && status.status === 'static';
+};
+
+export const getSequenceDisplayName = ({
+	codeNameStatus,
+	fallbackName,
+}: {
+	readonly codeNameStatus: CanUpdateSequencePropStatus | null | undefined;
+	readonly fallbackName: string;
+}) => {
+	if (
+		isStaticSequenceNameStatus(codeNameStatus) &&
+		typeof codeNameStatus.codeValue === 'string'
+	) {
+		return codeNameStatus.codeValue;
+	}
+
+	return fallbackName;
+};
+
+export const canRenameSequence = ({
+	codeNameStatus,
+	nodePath,
+	previewConnected,
+	readOnlyStudio,
+	sequence,
+	validatedLocation,
+}: {
+	readonly codeNameStatus: CanUpdateSequencePropStatus | null | undefined;
+	readonly nodePath: SequencePropsSubscriptionKey | null;
+	readonly previewConnected: boolean;
+	readonly readOnlyStudio: boolean;
+	readonly sequence: TSequence;
+	readonly validatedLocation: unknown | null;
+}) => {
+	return (
+		previewConnected &&
+		!readOnlyStudio &&
+		Boolean(sequence.controls) &&
+		nodePath !== null &&
+		validatedLocation !== null &&
+		isStaticSequenceNameStatus(codeNameStatus)
+	);
+};

--- a/packages/studio/src/icons/pencil.tsx
+++ b/packages/studio/src/icons/pencil.tsx
@@ -1,0 +1,10 @@
+import type {SVGProps} from 'react';
+
+export const PencilIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => (
+	<svg viewBox="0 0 512 512" {...props}>
+		<path
+			fill="currentColor"
+			d="M471.6 21.7c-28.9-28.9-75.8-28.9-104.7 0L48.3 340.3c-8.4 8.4-14.4 18.9-17.3 30.4L.9 491.1c-1.5 6.1.3 12.5 4.8 17s10.9 6.3 17 4.8l120.4-30.1c11.5-2.9 22-8.9 30.4-17.3L492.1 146.8c28.9-28.9 28.9-75.8 0-104.7L471.6 21.7zM124.1 448.4 42.8 468.7l20.3-81.3 243-243 61.9 61.9-243.9 242.1z"
+		/>
+	</svg>
+);


### PR DESCRIPTION
## Summary

- Adds inline sequence name editing to the Sequence inspector header.
- Shows a pencil affordance beside the title only when the same rename conditions used by the timeline are met.
- Shares sequence display/editability helpers with the timeline rename path.

## Testing

- bun run test (packages/studio)
- bun run make (packages/studio)
- bun run build
- bunx turbo run lint formatting --filter=@remotion/studio --no-update-notifier
- Browser smoke test on packages/example Studio at localhost:3007: selected a sequence, opened inspector rename input, canceled with Escape.

## Note

- bun run stylecheck was also run, but it failed due to pre-existing unstaged edits in packages/example/src/Empty.tsx adding unused imports. Those files are not part of this PR.
