### PR TITLE
remotion.dev/convert: hide crop option for audio-only convert inputs

### DIFF
--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -19,7 +19,11 @@ import type {
 	ConvertSections,
 	RotateOrMirrorOrCropState,
 } from '~/lib/default-ui';
-import {getOrderOfSections, isConvertEnabledByDefault} from '~/lib/default-ui';
+import {
+	getOrderOfSections,
+	isConvertEnabledByDefault,
+	isVideoOnlySection,
+} from '~/lib/default-ui';
 import {getNewName} from '~/lib/generate-new-name';
 import {
 	getActualAudioOperation,
@@ -594,6 +598,10 @@ const ConvertUI = ({
 		<>
 			<div className="w-full gap-4 flex flex-col">
 				{order.map((section) => {
+					if (inputIsAudioExclusively && isVideoOnlySection(section)) {
+						return null;
+					}
+
 					if (section === 'convert') {
 						return (
 							<div key="convert">
@@ -630,10 +638,6 @@ const ConvertUI = ({
 					}
 
 					if (section === 'mirror') {
-						if (inputIsAudioExclusively) {
-							return null;
-						}
-
 						return (
 							<div key="mirror">
 								<ConvertUiSection
@@ -656,10 +660,6 @@ const ConvertUI = ({
 					}
 
 					if (section === 'rotate') {
-						if (inputIsAudioExclusively) {
-							return null;
-						}
-
 						return (
 							<div key="rotate">
 								<ConvertUiSection
@@ -719,10 +719,6 @@ const ConvertUI = ({
 					}
 
 					if (section === 'resize') {
-						if (inputIsAudioExclusively) {
-							return null;
-						}
-
 						return (
 							<div key="resize">
 								<ConvertUiSection

--- a/packages/convert/app/lib/default-ui.ts
+++ b/packages/convert/app/lib/default-ui.ts
@@ -136,6 +136,23 @@ export type ConvertSections =
 	| 'crop'
 	| 'resample';
 
+export const isVideoOnlySection = (section: ConvertSections): boolean => {
+	if (
+		section === 'rotate' ||
+		section === 'mirror' ||
+		section === 'resize' ||
+		section === 'crop'
+	) {
+		return true;
+	}
+
+	if (section === 'convert' || section === 'resample') {
+		return false;
+	}
+
+	throw new Error(section satisfies never);
+};
+
 export const getOrderOfSections = (
 	action: RouteAction,
 ): {[key in ConvertSections]: number} => {

--- a/packages/convert/test/default-ui.test.ts
+++ b/packages/convert/test/default-ui.test.ts
@@ -5,6 +5,12 @@ test('treats crop as a video-only operation section', () => {
 	expect(isVideoOnlySection('crop')).toBe(true);
 });
 
+test('treats rotate, mirror, and resize as video-only operation sections', () => {
+	expect(isVideoOnlySection('rotate')).toBe(true);
+	expect(isVideoOnlySection('mirror')).toBe(true);
+	expect(isVideoOnlySection('resize')).toBe(true);
+});
+
 test('keeps conversion and resampling available for audio-only files', () => {
 	expect(isVideoOnlySection('convert')).toBe(false);
 	expect(isVideoOnlySection('resample')).toBe(false);

--- a/packages/convert/test/default-ui.test.ts
+++ b/packages/convert/test/default-ui.test.ts
@@ -1,0 +1,11 @@
+import {expect, test} from 'bun:test';
+import {isVideoOnlySection} from '../app/lib/default-ui';
+
+test('treats crop as a video-only operation section', () => {
+	expect(isVideoOnlySection('crop')).toBe(true);
+});
+
+test('keeps conversion and resampling available for audio-only files', () => {
+	expect(isVideoOnlySection('convert')).toBe(false);
+	expect(isVideoOnlySection('resample')).toBe(false);
+});


### PR DESCRIPTION
Fixes #8447.

This hides video-only operation sections for audio-only inputs in Remotion Convert. Crop now follows the same availability rule as Rotate, Mirror, and Resize when the probed input has no video tracks, so a `.wav` file no longer offers a Crop option.

The change keeps Convert and Resample available for audio-only files and does not touch the conversion or crop execution path.

Verification:

- `/Users/mac/.bun/bin/bun test packages/convert/test/default-ui.test.ts`
- `/Users/mac/.bun/bin/bun test packages/convert/test`
- `env PATH=/Users/mac/.bun/bin:/Users/mac/.nvm/versions/node/v22.17.0/bin:/usr/local/bin:/usr/bin:/bin /Users/mac/.bun/bin/bunx turbo run make --filter='@remotion/convert' --no-update-notifier`
- `env PATH=/Users/mac/.bun/bin:/Users/mac/.nvm/versions/node/v22.17.0/bin:/usr/local/bin:/usr/bin:/bin /Users/mac/.bun/bin/bun run lint` from `packages/convert`
- `env PATH=/Users/mac/.bun/bin:/Users/mac/.nvm/versions/node/v22.17.0/bin:/usr/local/bin:/usr/bin:/bin /Users/mac/.bun/bin/bun run build-page` from `packages/convert`

Tradeoff:

- This centralizes the existing audio-only filtering for video operations instead of adding a one-off check only around Crop.
