### PR TITLE
`@remotion/lambda`: allow custom s3 provider regions

### DIFF
--- a/packages/lambda-client/src/get-service-client.ts
+++ b/packages/lambda-client/src/get-service-client.ts
@@ -29,7 +29,7 @@ const getCredentialsHash = ({
 	forcePathStyle,
 	requestHandler,
 }: {
-	region: AwsRegion;
+	region: string;
 	customCredentials: CustomCredentials<AwsProvider> | null;
 	service: keyof ServiceMapping;
 	forcePathStyle: boolean;
@@ -95,7 +95,7 @@ export function getServiceClient<T extends keyof ServiceMapping>({
 	forcePathStyle,
 	requestHandler,
 }: {
-	region: AwsRegion;
+	region: string;
 	service: T;
 	customCredentials: CustomCredentials<AwsProvider> | null;
 	forcePathStyle: boolean;

--- a/packages/lambda-client/src/get-service-client.ts
+++ b/packages/lambda-client/src/get-service-client.ts
@@ -10,7 +10,6 @@ import type {AwsProvider} from './aws-provider';
 import {checkCredentials} from './check-credentials';
 import {getCredentials} from './get-credentials';
 import {getEnvVariable} from './get-env-variable';
-import type {AwsRegion} from './regions';
 import type {RequestHandler} from './types';
 
 export type ServiceMapping = {

--- a/packages/serverless-client/src/constants.ts
+++ b/packages/serverless-client/src/constants.ts
@@ -46,7 +46,7 @@ export type CustomCredentials<Provider extends CloudProvider> =
 	CustomCredentialsWithoutSensitiveData & {
 		accessKeyId: string | null;
 		secretAccessKey: string | null;
-		region?: Provider['region'];
+		region?: Provider['region'] | (string & {});
 		forcePathStyle?: boolean;
 	};
 

--- a/packages/serverless-client/src/test/expected-out-name.test.ts
+++ b/packages/serverless-client/src/test/expected-out-name.test.ts
@@ -92,6 +92,45 @@ test('Should save to a different outname', () => {
 	});
 });
 
+test('Should preserve custom provider regions outside the built-in AWS list', () => {
+	const newRenderMetadata: RenderMetadata<MockProvider> = {
+		...testRenderMetadata,
+		outName: {
+			bucketName: 'my-bucket',
+			key: 'my-key',
+			s3OutputProvider: {
+				endpoint: 'https://fly.storage.tigris.dev',
+			},
+		},
+		privacy: 'private',
+	};
+
+	expect(
+		getExpectedOutName({
+			renderMetadata: newRenderMetadata,
+			bucketName,
+			customCredentials: {
+				endpoint: 'https://fly.storage.tigris.dev',
+				accessKeyId: 'access-key',
+				secretAccessKey: 'secret-key',
+				region: 'auto',
+				forcePathStyle: false,
+			},
+			bucketNamePrefix: 'remotionlambda-',
+		}),
+	).toEqual({
+		customCredentials: {
+			endpoint: 'https://fly.storage.tigris.dev',
+			accessKeyId: 'access-key',
+			secretAccessKey: 'secret-key',
+			region: 'auto',
+			forcePathStyle: false,
+		},
+		renderBucketName: 'my-bucket',
+		key: 'my-key',
+	});
+});
+
 test('For stills', () => {
 	const newRenderMetadata: RenderMetadata<MockProvider> = {
 		...testRenderMetadata,


### PR DESCRIPTION
## Problem

Custom S3-compatible output providers can require region values that are not in the built-in AWS region union. Tigris, for example, documents `auto`, but `s3OutputProvider.region` was typed as the Lambda provider region and forced users to suppress TypeScript even though the AWS SDK client accepts a plain string for custom endpoints.

## Solution

I widened the custom credential region type while keeping the provider region relationship intact, and adjusted the Lambda service client helper so custom S3 clients can be keyed with that string region. I also added coverage that preserves a custom provider region such as `auto` when resolving the expected output name and credentials.

## Testing

- `oxfmt packages/serverless-client/src/constants.ts packages/lambda-client/src/get-service-client.ts packages/serverless-client/src/test/expected-out-name.test.ts --check`
- `git diff --check`

I also attempted the targeted Bun test and a serverless-client typecheck, but the local monorepo install could not complete in this Windows environment. `bun install --frozen-lockfile` timed out after 15 minutes, leaving workspace packages unresolved, so those commands failed on missing local modules like `@remotion/renderer/pure` and `remotion/no-react` before exercising this change.