### PR TITLE
Revert layout changes in the showcase page + update items

### DIFF
--- a/packages/docs/src/data/showcase-videos.tsx
+++ b/packages/docs/src/data/showcase-videos.tsx
@@ -228,31 +228,6 @@ export const showcaseVideos: ShowcaseVideo[] = [
 		},
 	},
 	{
-		title: 'HeyGen - Video Agent',
-		type: 'mux_video',
-		time: '75.5',
-		muxId: 'pKHRj00yo6eV1nHaXWSsjzvP1rBjQkey68qAp8gFy8Wk',
-		description:
-			"Fully made with HeyGen's Video Agent, powered by Remotion. Avatar, script, motion graphics, and final edits were all created just by prompting.",
-		height: 1080,
-		width: 1920,
-		submittedOn: new Date('01-29-2026'),
-		links: [
-			{
-				type: 'website',
-				url: 'https://www.heygen.com/',
-			},
-			{
-				type: 'video',
-				url: 'https://x.com/joshua_xu_/status/2016714990242439600',
-			},
-		],
-		author: {
-			url: 'https://x.com/joshua_xu_',
-			name: 'Joshua Xu',
-		},
-	},
-	{
 		title: 'Hello Météo - Weather app',
 		type: 'mux_video',
 		time: '5',

--- a/packages/docs/src/pages/showcase/index.tsx
+++ b/packages/docs/src/pages/showcase/index.tsx
@@ -117,17 +117,18 @@ const Showcase = () => {
 				<main>
 					<section className={styles.gallerySection}>
 						<div className={styles.container}>
-							<div className={styles.videosGrid}>
+							<div className={styles.videosMasonry}>
 								{shuffledShowcaseVideos.map((vid) => {
 									return (
-										<VideoPreview
-											key={vid.muxId}
-											onClick={() => {
-												setVideo(vid);
-												setUserHasInteractedWithPage(true);
-											}}
-											{...vid}
-										/>
+										<div key={vid.muxId} className={styles.videosMasonryItem}>
+											<VideoPreview
+												onClick={() => {
+													setVideo(vid);
+													setUserHasInteractedWithPage(true);
+												}}
+												{...vid}
+											/>
+										</div>
 									);
 								})}
 							</div>

--- a/packages/docs/src/pages/showcase/styles.module.css
+++ b/packages/docs/src/pages/showcase/styles.module.css
@@ -43,15 +43,20 @@
 	padding: 20px 0 80px;
 }
 
-.videosGrid {
-	display: grid;
-	gap: 24px;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
+.videosMasonry {
+	column-count: 3;
+	column-gap: 24px;
+}
+
+.videosMasonryItem {
+	break-inside: avoid;
+	margin-bottom: 24px;
+	width: 100%;
 }
 
 @media screen and (max-width: 996px) {
-	.videosGrid {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
+	.videosMasonry {
+		column-count: 2;
 	}
 }
 
@@ -60,8 +65,8 @@
 		padding: 44px 0 28px;
 	}
 
-	.videosGrid {
-		grid-template-columns: 1fr;
+	.videosMasonry {
+		column-count: 1;
 	}
 
 	.lede {


### PR DESCRIPTION
There was PR #7979 removing the masonry layout which doesn't look 
I'm reverting some of the changes made in PR #7979 because it a consistent card grid doesn't consider the different aspect ratios of the videos on that page. I'm in favor of keeping the masonry layout.

@samohovets hope you don't mind that I'm doing this. 

<img width="1214" height="1414" alt="CleanShot 2026-06-17 at 10 36 29" src="https://github.com/user-attachments/assets/358a203e-50ba-439c-9a65-8cdee3fa8da1" />
