### PR TITLE
`@remotion/studio`: Keep dragged keyframes unselected

### DIFF
--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -526,8 +526,10 @@ export const useTimelineKeyframeDrag = ({
 			};
 			const shouldDragExistingSelection =
 				selected && !interaction.shiftKey && !interaction.toggleKey;
+			const shouldSelectOnPointerUp =
+				!selected && !interaction.shiftKey && !interaction.toggleKey;
 
-			if (!shouldDragExistingSelection) {
+			if (!shouldDragExistingSelection && !shouldSelectOnPointerUp) {
 				onSelect(interaction);
 			}
 
@@ -645,6 +647,10 @@ export const useTimelineKeyframeDrag = ({
 
 				const targets = dragTargets;
 				if (!hasDragged || lastDelta === 0 || targets === null) {
+					if (shouldSelectOnPointerUp) {
+						onSelect(interaction);
+					}
+
 					clearActiveOverrides();
 					clearDraggedKeyframes();
 					return;
@@ -661,13 +667,15 @@ export const useTimelineKeyframeDrag = ({
 					return;
 				}
 
-				currentSelection.current.selectItems(
-					targets.map((target) => ({
-						type: 'keyframe',
-						nodePathInfo: target.nodePathInfo,
-						frame: target.displayFrame + lastDelta,
-					})),
-				);
+				if (shouldDragExistingSelection) {
+					currentSelection.current.selectItems(
+						targets.map((target) => ({
+							type: 'keyframe',
+							nodePathInfo: target.nodePathInfo,
+							frame: target.displayFrame + lastDelta,
+						})),
+					);
+				}
 
 				clearActiveOverrides();
 				clearDraggedKeyframes();


### PR DESCRIPTION
## Summary

- Allow unselected timeline keyframes to be dragged without selecting them on pointer-down or release
- Keep click-to-select behavior by selecting unselected keyframes only on pointer-up when no drag occurred
- Preserve selection updates for drags that start from already-selected keyframes

## Testing

- bunx oxfmt src --write (in packages/studio)
- bun run build
- bun run stylecheck
- bun test packages/studio/src/test/timeline-selection.test.ts packages/studio/src/test/timeline-keyframes.test.ts packages/studio/src/test/editor-guides.test.ts
