### PR TITLE
`@remotion/studio`: Reset effect props with defaults

### DIFF
--- a/packages/effects/src/blur/index.ts
+++ b/packages/effects/src/blur/index.ts
@@ -39,7 +39,7 @@ const blurSchema = {
 		min: 0,
 		max: 100,
 		step: 1,
-		default: undefined,
+		default: 40,
 		description: 'Radius',
 		hiddenFromList: false,
 	},

--- a/packages/effects/src/test/effect-params.test.ts
+++ b/packages/effects/src/test/effect-params.test.ts
@@ -488,6 +488,12 @@ test('blur() accepts valid params', () => {
 	expect(() => blur({radius: 4})).not.toThrow();
 });
 
+test('blur() radius has a resettable default', () => {
+	expect(blur({radius: 4}).definition.schema.radius).toMatchObject({
+		default: 40,
+	});
+});
+
 test('blur() accepts horizontal-only blur', () => {
 	expect(() =>
 		blur({radius: 4, horizontal: true, vertical: false}),

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -1,3 +1,4 @@
+import {getEffectFieldsToShow} from '@remotion/studio-shared';
 import type {
 	CanUpdateSequencePropStatus,
 	OverrideIdToNodePaths,
@@ -88,8 +89,12 @@ const isResettablePropStatus = ({
 		return false;
 	}
 
-	if (propStatus.status === 'keyframed' || propStatus.status === 'computed') {
+	if (propStatus.status === 'keyframed') {
 		return true;
+	}
+
+	if (propStatus.status === 'computed') {
+		return false;
 	}
 
 	return isNonDefaultCodeValue({
@@ -198,7 +203,16 @@ export const getTimelinePropResetTargets = ({
 		}
 
 		const effect = sequence.effects[selection.i];
-		const fieldSchema = effect?.schema[selection.key];
+		const field = effect
+			? getEffectFieldsToShow({
+					effect,
+					effectIndex: selection.i,
+					nodePath,
+					propStatuses,
+					getEffectDragOverrides: () => ({}),
+				}).find((candidate) => candidate.key === selection.key)
+			: null;
+		const fieldSchema = field?.fieldSchema;
 		const effectStatus = Internals.getEffectPropStatusesCtx({
 			propStatuses,
 			nodePath,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -2291,7 +2291,7 @@ test('Backspace reset targets selected keyframed sequence props', () => {
 	]);
 });
 
-test('Backspace reset targets selected computed sequence props with defaults', () => {
+test('Backspace reset skips selected computed sequence props with defaults', () => {
 	const schema = {
 		'style.scale': {type: 'scale', default: 1, max: 100},
 	} satisfies InteractivitySchema;
@@ -2325,20 +2325,10 @@ test('Backspace reset targets selected computed sequence props with defaults', (
 		propStatuses,
 	});
 
-	expect(resetTargets).toEqual([
-		{
-			type: 'sequence-prop',
-			fileName: '/project/src/Comp.tsx',
-			nodePath,
-			fieldKey: 'style.scale',
-			value: 1,
-			defaultValue: '1',
-			schema,
-		},
-	]);
+	expect(resetTargets).toEqual([]);
 });
 
-test('Backspace reset targets flattened built-in sequence style props', () => {
+test('Backspace reset targets flattened built-in keyframed sequence style props', () => {
 	const opacityNodePathInfo = makeNodePathInfo(
 		['body', 0],
 		['controls', 'style.opacity'],
@@ -2349,7 +2339,15 @@ test('Backspace reset targets flattened built-in sequence style props', () => {
 			canUpdate: true,
 			props: {
 				'style.opacity': {
-					status: 'computed',
+					status: 'keyframed',
+					interpolationFunction: 'interpolate',
+					keyframes: [
+						{frame: 0, value: 0},
+						{frame: 20, value: 0.5},
+					],
+					easing: [{type: 'linear'}],
+					clamping: {left: 'extend', right: 'extend'},
+					posterize: undefined,
 				},
 			},
 			effects: [],
@@ -3371,6 +3369,141 @@ test('Backspace reset targets selected effect props', () => {
 			fieldKey: 'intensity',
 			value: 0,
 			defaultValue: '0',
+			schema: effectSchema,
+		},
+	]);
+});
+
+test('Backspace reset targets active enum variant effect props', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const effectSchema = {
+		colorMode: {
+			type: 'enum',
+			default: 'solid' as const,
+			variants: {
+				solid: {
+					dotColor: {
+						type: 'color',
+						default: 'red',
+					},
+				},
+				source: {},
+			},
+		},
+	} satisfies InteractivitySchema;
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'dotColor'],
+	);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'effect',
+					importPath: null,
+					effectIndex: 0,
+					props: {
+						colorMode: {status: 'static', codeValue: 'solid'},
+						dotColor: {status: 'static', codeValue: 'blue'},
+					},
+				},
+			],
+		},
+	} satisfies PropStatuses;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-effect-prop',
+				nodePathInfo,
+				i: 0,
+				key: 'dotColor',
+			},
+		],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				effects: [{schema: effectSchema}],
+			}),
+		],
+		overrideIdsToNodePaths: {override: nodePath},
+		propStatuses,
+	});
+
+	expect(resetTargets).toEqual([
+		{
+			type: 'effect-prop',
+			fileName: '/project/src/Comp.tsx',
+			nodePath,
+			effectIndex: 0,
+			fieldKey: 'dotColor',
+			value: 'red',
+			defaultValue: '"red"',
+			schema: effectSchema,
+		},
+	]);
+});
+
+test('Backspace reset targets selected static blur radius with default', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const effectSchema = {
+		radius: {type: 'number', default: 40, hiddenFromList: false},
+	} satisfies InteractivitySchema;
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'radius'],
+	);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'blur',
+					importPath: null,
+					effectIndex: 0,
+					props: {
+						radius: {status: 'static', codeValue: 24},
+					},
+				},
+			],
+		},
+	} satisfies PropStatuses;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-effect-prop',
+				nodePathInfo,
+				i: 0,
+				key: 'radius',
+			},
+		],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				effects: [{schema: effectSchema}],
+			}),
+		],
+		overrideIdsToNodePaths: {override: nodePath},
+		propStatuses,
+	});
+
+	expect(resetTargets).toEqual([
+		{
+			type: 'effect-prop',
+			fileName: '/project/src/Comp.tsx',
+			nodePath,
+			effectIndex: 0,
+			fieldKey: 'radius',
+			value: 40,
+			defaultValue: '40',
 			schema: effectSchema,
 		},
 	]);


### PR DESCRIPTION
## Summary

- Reset effect props through the same active schema field lookup used by timeline rows
- Allow static and keyframed effect props with defaults to reset; computed props remain non-resettable
- Give blur radius a schema default of `40`, making static and keyframed blur radii resettable

Fixes #8473

## Testing

- bun test packages/studio/src/test/timeline-selection.test.ts
- bun test packages/effects/src/test/effect-params.test.ts
- bun run build
- bun run stylecheck
