### PR TITLE
`@remotion/skills`: Add custom effect skill guidance

### DIFF
--- a/packages/example/src/EffectsTestbed/CustomEffectsSample.tsx
+++ b/packages/example/src/EffectsTestbed/CustomEffectsSample.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {AbsoluteFill, CanvasImage} from 'remotion';
+import {samplePosterize2d} from './sample-posterize-2d';
+import {sampleRgbShiftWebgl} from './sample-rgb-shift-webgl';
+
+const SAMPLE_IMAGE = 'https://remotion.media/transition-bg-blue.jpg';
+
+const tileStyle: React.CSSProperties = {
+	flex: 1,
+	minWidth: 0,
+	border: '1px solid #334155',
+	backgroundColor: '#020617',
+	overflow: 'hidden',
+};
+
+const labelStyle: React.CSSProperties = {
+	position: 'absolute',
+	left: 24,
+	bottom: 24,
+	fontFamily: 'monospace',
+	fontSize: 32,
+	fontWeight: 700,
+	color: 'white',
+	textShadow: '0 2px 12px black',
+};
+
+const Tile: React.FC<{
+	readonly label: string;
+	readonly children: React.ReactNode;
+}> = ({label, children}) => {
+	return (
+		<div style={tileStyle}>
+			<div style={{position: 'relative', width: '100%', height: '100%'}}>
+				{children}
+				<div style={labelStyle}>{label}</div>
+			</div>
+		</div>
+	);
+};
+
+export const CustomEffectsSample: React.FC = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: '#0f172a',
+				display: 'flex',
+				flexDirection: 'row',
+				gap: 24,
+				padding: 24,
+			}}
+		>
+			<Tile label="custom 2D: posterize">
+				<CanvasImage
+					src={SAMPLE_IMAGE}
+					width={960}
+					height={1080}
+					fit="cover"
+					style={{width: '100%', height: '100%'}}
+					effects={[samplePosterize2d({levels: 16, amount: 1})]}
+				/>
+			</Tile>
+			<Tile label="custom WebGL2: RGB shift">
+				<CanvasImage
+					src={SAMPLE_IMAGE}
+					width={960}
+					height={1080}
+					fit="cover"
+					style={{width: '100%', height: '100%'}}
+					effects={[sampleRgbShiftWebgl({amount: 80})]}
+				/>
+			</Tile>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/EffectsTestbed/sample-posterize-2d.ts
+++ b/packages/example/src/EffectsTestbed/sample-posterize-2d.ts
@@ -1,0 +1,95 @@
+import {createEffect, type InteractivitySchema} from 'remotion';
+
+export type SamplePosterize2dParams = {
+	readonly levels?: number;
+	readonly amount?: number;
+};
+
+const DEFAULT_LEVELS = 5;
+const DEFAULT_AMOUNT = 1;
+
+const samplePosterize2dSchema = {
+	levels: {
+		type: 'number',
+		min: 2,
+		max: 16,
+		step: 1,
+		default: DEFAULT_LEVELS,
+		description: 'Levels',
+		hiddenFromList: false,
+	},
+	amount: {
+		type: 'number',
+		min: 0,
+		max: 1,
+		step: 0.01,
+		default: DEFAULT_AMOUNT,
+		description: 'Amount',
+		hiddenFromList: false,
+	},
+} as const satisfies InteractivitySchema;
+
+const resolve = (params: SamplePosterize2dParams) => ({
+	levels: params.levels ?? DEFAULT_LEVELS,
+	amount: params.amount ?? DEFAULT_AMOUNT,
+});
+
+const quantize = (value: number, levels: number): number => {
+	const step = 255 / (levels - 1);
+	return Math.round(value / step) * step;
+};
+
+export const samplePosterize2d = createEffect<SamplePosterize2dParams, null>({
+	type: 'dev.remotion.example.samplePosterize2d',
+	label: 'samplePosterize2d()',
+	documentationLink: 'https://www.remotion.dev/docs/create-effect',
+	backend: '2d',
+	calculateKey: (params) => {
+		const {levels, amount} = resolve(params);
+		return `sample-posterize-2d-${levels}-${amount}`;
+	},
+	setup: () => null,
+	apply: ({source, target, width, height, params}) => {
+		const ctx = target.getContext('2d');
+		if (!ctx) {
+			throw new Error('Could not get a 2D context for samplePosterize2d().');
+		}
+
+		const {levels, amount} = resolve(params);
+
+		ctx.clearRect(0, 0, width, height);
+		ctx.drawImage(source, 0, 0, width, height);
+
+		const imageData = ctx.getImageData(0, 0, width, height);
+		const {data} = imageData;
+
+		for (let i = 0; i < data.length; i += 4) {
+			data[i] += (quantize(data[i], levels) - data[i]) * amount;
+			data[i + 1] += (quantize(data[i + 1], levels) - data[i + 1]) * amount;
+			data[i + 2] += (quantize(data[i + 2], levels) - data[i + 2]) * amount;
+		}
+
+		ctx.putImageData(imageData, 0, 0);
+	},
+	cleanup: () => undefined,
+	schema: samplePosterize2dSchema,
+	validateParams: ({levels = DEFAULT_LEVELS, amount = DEFAULT_AMOUNT}) => {
+		if (
+			typeof levels !== 'number' ||
+			!Number.isFinite(levels) ||
+			levels < 2 ||
+			levels > 16
+		) {
+			throw new TypeError('levels must be a number between 2 and 16');
+		}
+
+		if (
+			typeof amount !== 'number' ||
+			!Number.isFinite(amount) ||
+			amount < 0 ||
+			amount > 1
+		) {
+			throw new TypeError('amount must be a number between 0 and 1');
+		}
+	},
+});

--- a/packages/example/src/EffectsTestbed/sample-rgb-shift-webgl.ts
+++ b/packages/example/src/EffectsTestbed/sample-rgb-shift-webgl.ts
@@ -1,0 +1,253 @@
+import {createEffect, type InteractivitySchema} from 'remotion';
+
+export type SampleRgbShiftWebglParams = {
+	readonly amount?: number;
+};
+
+type SampleRgbShiftWebglState = {
+	readonly gl: WebGL2RenderingContext;
+	readonly program: WebGLProgram;
+	readonly vao: WebGLVertexArrayObject;
+	readonly vbo: WebGLBuffer;
+	readonly texture: WebGLTexture;
+	readonly uSource: WebGLUniformLocation | null;
+	readonly uOffset: WebGLUniformLocation | null;
+};
+
+const DEFAULT_AMOUNT = 12;
+
+const sampleRgbShiftWebglSchema = {
+	amount: {
+		type: 'number',
+		min: 0,
+		max: 80,
+		step: 1,
+		default: DEFAULT_AMOUNT,
+		description: 'Amount',
+		hiddenFromList: false,
+	},
+} as const satisfies InteractivitySchema;
+
+const VERTEX_SHADER = `#version 300 es
+layout(location = 0) in vec2 aPosition;
+layout(location = 1) in vec2 aUv;
+out vec2 vUv;
+
+void main() {
+  vUv = aUv;
+  gl_Position = vec4(aPosition, 0.0, 1.0);
+}
+`;
+
+const FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+
+uniform sampler2D uSource;
+uniform vec2 uOffset;
+
+in vec2 vUv;
+out vec4 fragColor;
+
+void main() {
+  vec2 redUv = clamp(vUv + uOffset, vec2(0.0), vec2(1.0));
+  vec2 blueUv = clamp(vUv - uOffset, vec2(0.0), vec2(1.0));
+  vec4 base = texture(uSource, vUv);
+  float red = texture(uSource, redUv).r;
+  float blue = texture(uSource, blueUv).b;
+
+  fragColor = vec4(red, base.g, blue, base.a);
+}
+`;
+
+const compileShader = (
+	gl: WebGL2RenderingContext,
+	type: number,
+	source: string,
+): WebGLShader => {
+	const shader = gl.createShader(type);
+	if (!shader) {
+		throw new Error('Could not create WebGL shader for sampleRgbShiftWebgl().');
+	}
+
+	gl.shaderSource(shader, source);
+	gl.compileShader(shader);
+	if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+		const log = gl.getShaderInfoLog(shader);
+		gl.deleteShader(shader);
+		throw new Error(`sampleRgbShiftWebgl() shader compile failed: ${log}`);
+	}
+
+	return shader;
+};
+
+const createProgram = (
+	gl: WebGL2RenderingContext,
+	vertexSource: string,
+	fragmentSource: string,
+): WebGLProgram => {
+	const vertexShader = compileShader(gl, gl.VERTEX_SHADER, vertexSource);
+	const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
+	const program = gl.createProgram();
+	if (!program) {
+		throw new Error(
+			'Could not create WebGL program for sampleRgbShiftWebgl().',
+		);
+	}
+
+	gl.attachShader(program, vertexShader);
+	gl.attachShader(program, fragmentShader);
+	gl.linkProgram(program);
+	gl.deleteShader(vertexShader);
+	gl.deleteShader(fragmentShader);
+
+	if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+		const log = gl.getProgramInfoLog(program);
+		gl.deleteProgram(program);
+		throw new Error(`sampleRgbShiftWebgl() program link failed: ${log}`);
+	}
+
+	return program;
+};
+
+const createTexture = (gl: WebGL2RenderingContext): WebGLTexture => {
+	const texture = gl.createTexture();
+	if (!texture) {
+		throw new Error(
+			'Could not create WebGL texture for sampleRgbShiftWebgl().',
+		);
+	}
+
+	gl.bindTexture(gl.TEXTURE_2D, texture);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+	gl.bindTexture(gl.TEXTURE_2D, null);
+
+	return texture;
+};
+
+const setupSampleRgbShiftWebgl = (
+	target: HTMLCanvasElement,
+): SampleRgbShiftWebglState => {
+	const gl = target.getContext('webgl2', {
+		premultipliedAlpha: true,
+		alpha: true,
+		preserveDrawingBuffer: true,
+	});
+	if (!gl) {
+		throw new Error(
+			'Could not get a WebGL2 context for sampleRgbShiftWebgl().',
+		);
+	}
+
+	gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
+
+	const program = createProgram(gl, VERTEX_SHADER, FRAGMENT_SHADER);
+	const vao = gl.createVertexArray();
+	if (!vao) {
+		throw new Error(
+			'Could not create WebGL vertex array for sampleRgbShiftWebgl().',
+		);
+	}
+
+	const vbo = gl.createBuffer();
+	if (!vbo) {
+		throw new Error('Could not create WebGL buffer for sampleRgbShiftWebgl().');
+	}
+
+	gl.bindVertexArray(vao);
+	gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+	gl.bufferData(
+		gl.ARRAY_BUFFER,
+		new Float32Array([-1, -1, 0, 0, 1, -1, 1, 0, -1, 1, 0, 1, 1, 1, 1, 1]),
+		gl.STATIC_DRAW,
+	);
+	gl.enableVertexAttribArray(0);
+	gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 16, 0);
+	gl.enableVertexAttribArray(1);
+	gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 16, 8);
+	gl.bindVertexArray(null);
+
+	return {
+		gl,
+		program,
+		vao,
+		vbo,
+		texture: createTexture(gl),
+		uSource: gl.getUniformLocation(program, 'uSource'),
+		uOffset: gl.getUniformLocation(program, 'uOffset'),
+	};
+};
+
+const resolve = (params: SampleRgbShiftWebglParams) => ({
+	amount: params.amount ?? DEFAULT_AMOUNT,
+});
+
+export const sampleRgbShiftWebgl = createEffect<
+	SampleRgbShiftWebglParams,
+	SampleRgbShiftWebglState
+>({
+	type: 'dev.remotion.example.sampleRgbShiftWebgl',
+	label: 'sampleRgbShiftWebgl()',
+	documentationLink: 'https://www.remotion.dev/docs/create-effect',
+	backend: 'webgl2',
+	calculateKey: (params) => {
+		const {amount} = resolve(params);
+		return `sample-rgb-shift-webgl-${amount}`;
+	},
+	setup: (target) => setupSampleRgbShiftWebgl(target),
+	apply: ({source, width, height, params, state, flipSourceY}) => {
+		const {gl} = state;
+		const {amount} = resolve(params);
+		const offset = amount / width;
+
+		gl.viewport(0, 0, width, height);
+		gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipSourceY);
+		gl.activeTexture(gl.TEXTURE0);
+		gl.bindTexture(gl.TEXTURE_2D, state.texture);
+		gl.texImage2D(
+			gl.TEXTURE_2D,
+			0,
+			gl.RGBA,
+			gl.RGBA,
+			gl.UNSIGNED_BYTE,
+			source as TexImageSource,
+		);
+
+		gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+		gl.clearColor(0, 0, 0, 0);
+		gl.clear(gl.COLOR_BUFFER_BIT);
+		gl.useProgram(state.program);
+		if (state.uSource) {
+			gl.uniform1i(state.uSource, 0);
+		}
+
+		if (state.uOffset) {
+			gl.uniform2f(state.uOffset, offset, 0);
+		}
+
+		gl.bindVertexArray(state.vao);
+		gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+		gl.bindVertexArray(null);
+		gl.bindTexture(gl.TEXTURE_2D, null);
+		gl.useProgram(null);
+	},
+	cleanup: ({gl, program, vao, vbo, texture}) => {
+		gl.deleteTexture(texture);
+		gl.deleteBuffer(vbo);
+		gl.deleteProgram(program);
+		gl.deleteVertexArray(vao);
+	},
+	schema: sampleRgbShiftWebglSchema,
+	validateParams: ({amount = DEFAULT_AMOUNT}) => {
+		if (
+			typeof amount !== 'number' ||
+			!Number.isFinite(amount) ||
+			amount < 0 ||
+			amount > 80
+		) {
+			throw new TypeError('amount must be a number between 0 and 80');
+		}
+	},
+});

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -189,6 +189,7 @@ import {
 	canvasCapturePreviewDefaultProps,
 } from './CanvasCapturePreview';
 import {EdgeBlur} from './EdgeBlur/EdgeBlur';
+import {CustomEffectsSample} from './EffectsTestbed/CustomEffectsSample';
 import {EffectsTestbed} from './EffectsTestbed/EffectsTestbed';
 import {HalftoneGradient} from './EffectsTestbed/HalftoneGradient';
 import {NoiseDisplacementText} from './EffectsTestbed/NoiseDisplacementText';
@@ -1983,6 +1984,14 @@ export const Index: React.FC = () => {
 				<Composition
 					id="palette-map-effect"
 					component={PaletteMapEffect}
+					width={1920}
+					height={1080}
+					fps={30}
+					durationInFrames={150}
+				/>
+				<Composition
+					id="custom-effects-sample"
+					component={CustomEffectsSample}
 					width={1920}
 					height={1080}
 					fps={30}

--- a/packages/skills/skills/remotion/SKILL.md
+++ b/packages/skills/skills/remotion/SKILL.md
@@ -256,7 +256,7 @@ When needing to use sound effects, load the [./rules/sfx.md](./rules/sfx.md) fil
 
 ## Visual and pixel effects
 
-When creating a visual effect, prefer: 1. normal Remotion/HTML/CSS/SVG/filter/blend/mask animation, 2. a listed effect via [rules/effects.md](rules/effects.md), including on HTML rendered through `<HtmlInCanvas>`, 3. custom `<HtmlInCanvas onPaint>` via [rules/html-in-canvas.md](rules/html-in-canvas.md) only if no listed effect fits.
+When creating a visual effect, prefer: 1. normal Remotion/HTML/CSS/SVG/filter/blend/mask animation, 2. a listed effect via [rules/effects.md](rules/effects.md), including on HTML rendered through `<HtmlInCanvas>`, 3. a custom `createEffect()` via [rules/effects.md](rules/effects.md) when the user asks for a reusable/project-specific effect, 4. custom `<HtmlInCanvas onPaint>` via [rules/html-in-canvas.md](rules/html-in-canvas.md) only if no effect fits.
 
 For light leak overlays, see [rules/light-leaks.md](rules/light-leaks.md). Docs: https://www.remotion.dev/docs/effects
 

--- a/packages/skills/skills/remotion/rules/effects.md
+++ b/packages/skills/skills/remotion/rules/effects.md
@@ -1,13 +1,14 @@
 ---
 name: effects
-description: Canvas/WebGL visual effects for Remotion using effects arrays.
+description: Canvas/WebGL visual effects for Remotion using effects arrays and createEffect().
 metadata:
-  tags: effects, visual-effects, webgl, canvas, video
+  tags: effects, visual-effects, webgl, canvas, video, create-effect
 ---
 
-Use this rule only when the top-level skill lists an effect that matches the requested look.
+Use this rule only when the top-level skill lists an effect that matches the requested look, or when the user asks to create a reusable custom effect.
 
 Docs: https://www.remotion.dev/docs/effects
+Custom effect docs: https://www.remotion.dev/docs/create-effect
 
 ## Usage
 
@@ -37,3 +38,198 @@ import {Config} from '@remotion/cli/config';
 
 Config.setChromiumOpenGlRenderer('angle');
 ```
+
+## Custom effects
+
+Use `createEffect()` from `remotion` when the user wants a reusable effect factory that works in the same `effects` array as `@remotion/effects`.
+
+Prefer a custom effect over `<HtmlInCanvas onPaint>` when the transformation should be reusable, parameterized, editable in Studio, or stackable with other effects.
+
+For quick project-specific effects, keep the effect next to the composition, for example `src/effects/palette-map.ts`. For library effects intended for `@remotion/effects`, follow the repository's `add-effect` skill instead.
+
+`createEffect()` expects:
+
+- `type`: stable reverse-DNS identifier, for example `com.example.paletteMap`.
+- `label`: Studio label, commonly `paletteMap()`.
+- `documentationLink`: URL or `null`.
+- `backend`: `"2d"`, `"webgl2"` or `"webgpu"`.
+- `calculateKey(params)`: stable string containing every resolved parameter that changes output.
+- `setup(target)`: create reusable backend state, or return `null`.
+- `apply({source, target, width, height, params, state, flipSourceY})`: draw the transformed result into `target`.
+- `cleanup(state)`: free resources created by `setup()`.
+- `schema`: an `InteractivitySchema` for Studio controls. `disabled` is added automatically.
+- `validateParams(params)`: throw on missing or invalid values.
+
+Use `backend: "2d"` for simple pixel, filter, drawImage, or image-data effects. Use WebGL2 only when shader math or GPU performance is needed; during renders, enable WebGL as shown above.
+
+```ts
+import {createEffect, type InteractivitySchema} from 'remotion';
+
+type MyEffectParams = {
+  readonly amount?: number;
+};
+
+const myEffectSchema = {
+  amount: {
+    type: 'number',
+    min: 0,
+    max: 1,
+    step: 0.01,
+    default: 1,
+    description: 'Amount',
+  },
+} as const satisfies InteractivitySchema;
+
+const resolve = (params: MyEffectParams) => ({
+  amount: params.amount ?? 1,
+});
+
+export const myEffect = createEffect<MyEffectParams, null>({
+  type: 'com.example.myEffect',
+  label: 'myEffect()',
+  documentationLink: null,
+  backend: '2d',
+  calculateKey: (params) => {
+    const {amount} = resolve(params);
+    return `my-effect-${amount}`;
+  },
+  setup: () => null,
+  apply: ({source, target, width, height, params}) => {
+    const ctx = target.getContext('2d');
+    if (!ctx) {
+      throw new Error('Could not get a 2D context for myEffect().');
+    }
+
+    const {amount} = resolve(params);
+
+    ctx.clearRect(0, 0, width, height);
+    ctx.filter = `opacity(${amount * 100}%)`;
+    ctx.drawImage(source, 0, 0, width, height);
+    ctx.filter = 'none';
+  },
+  cleanup: () => undefined,
+  schema: myEffectSchema,
+  validateParams: ({amount = 1}) => {
+    if (typeof amount !== 'number' || !Number.isFinite(amount) || amount < 0 || amount > 1) {
+      throw new TypeError('amount must be a number between 0 and 1');
+    }
+  },
+});
+```
+
+For a WebGL2 effect, compile/link shaders in `setup()`, keep the program, fullscreen quad, texture, and uniform locations in state, upload `source` in `apply()`, and free GPU resources in `cleanup()`. Minimal shape:
+
+```ts
+import {createEffect, type InteractivitySchema} from 'remotion';
+
+type RgbShiftParams = {
+  readonly amount?: number;
+};
+
+type RgbShiftState = {
+  readonly gl: WebGL2RenderingContext;
+  readonly program: WebGLProgram;
+  readonly vao: WebGLVertexArrayObject;
+  readonly vbo: WebGLBuffer;
+  readonly texture: WebGLTexture;
+  readonly uSource: WebGLUniformLocation | null;
+  readonly uOffset: WebGLUniformLocation | null;
+};
+
+const rgbShiftSchema = {
+  amount: {
+    type: 'number',
+    min: 0,
+    max: 80,
+    step: 1,
+    default: 12,
+    description: 'Amount',
+  },
+} as const satisfies InteractivitySchema;
+
+export const rgbShift = createEffect<RgbShiftParams, RgbShiftState>({
+  type: 'com.example.rgbShift',
+  label: 'rgbShift()',
+  documentationLink: null,
+  backend: 'webgl2',
+  calculateKey: ({amount = 12}) => `rgb-shift-${amount}`,
+  setup: (target) => {
+    const gl = target.getContext('webgl2', {
+      premultipliedAlpha: true,
+      alpha: true,
+      preserveDrawingBuffer: true,
+    });
+    if (!gl) {
+      throw new Error('Could not get a WebGL2 context for rgbShift().');
+    }
+
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
+
+    // Compile/link shaders, create a fullscreen quad VAO/VBO, create a
+    // CLAMP_TO_EDGE RGBA texture, and get uSource/uOffset uniform locations.
+    return createRgbShiftState(gl);
+  },
+  apply: ({source, width, height, params, state, flipSourceY}) => {
+    const amount = params.amount ?? 12;
+    const {gl} = state;
+
+    gl.viewport(0, 0, width, height);
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipSourceY);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, state.texture);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      source as TexImageSource,
+    );
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.useProgram(state.program);
+    if (state.uSource) gl.uniform1i(state.uSource, 0);
+    if (state.uOffset) gl.uniform2f(state.uOffset, amount / width, 0);
+    gl.bindVertexArray(state.vao);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+  },
+  cleanup: ({gl, program, vao, vbo, texture}) => {
+    gl.deleteTexture(texture);
+    gl.deleteBuffer(vbo);
+    gl.deleteProgram(program);
+    gl.deleteVertexArray(vao);
+  },
+  schema: rgbShiftSchema,
+  validateParams: ({amount = 12}) => {
+    if (typeof amount !== 'number' || !Number.isFinite(amount) || amount < 0 || amount > 80) {
+      throw new TypeError('amount must be a number between 0 and 80');
+    }
+  },
+});
+```
+
+For a complete 2D and WebGL2 pair, see `packages/example/src/EffectsTestbed/sample-posterize-2d.ts` and `packages/example/src/EffectsTestbed/sample-rgb-shift-webgl.ts`.
+
+Use the returned factory in an `effects` array:
+
+```tsx
+import {CanvasImage, staticFile} from 'remotion';
+import {myEffect} from './effects/my-effect';
+
+export const MyComp: React.FC = () => {
+  return (
+    <CanvasImage
+      src={staticFile('image.png')}
+      effects={[myEffect({amount: 0.8})]}
+    />
+  );
+};
+```
+
+When generating a custom effect, also:
+
+- Include `disabled?: boolean` only through the returned factory; do not add it to the custom params type or schema.
+- Validate required parameters at factory-call time with `validateParams`.
+- Include all defaults in both `schema` and the `resolve()` helper.
+- Reset mutable 2D context state such as `filter`, `globalAlpha`, transforms, and compositing after drawing.
+- Preserve alpha unless the requested effect intentionally changes transparency.


### PR DESCRIPTION
## Summary

- Add lazy-loaded Remotion skill guidance for project-specific `createEffect()` effects
- Add a WebGL2 custom-effect example to the skill alongside the 2D example
- Add `packages/example` samples for a custom 2D posterize effect and custom WebGL2 RGB-shift effect
- Register `custom-effects-sample` in the example Studio `Effects` folder

Closes #8513.
Closes #7190.
Closes #7476.

## Testing

- `bunx turbo run make --filter='@remotion/example'`
- `cd packages/example && bunx tsc --noEmit`
- `cd packages/example && bunx remotion still custom-effects-sample ../../out/custom-effects-sample.png --frame=30 --gl=angle --overwrite`
- `cd packages/example && bun run formatting`
- `cd packages/example && bun run lint`
- `bun run build`
- `bun run stylecheck`
