### PR TITLE
`@remotion/studio`: Show component name in sequence inspector

### DIFF
--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -105,6 +105,7 @@ export type SequenceControls = {
 	overrideId: string;
 	supportsEffects: boolean;
 	componentIdentity: JsxComponentIdentity | null;
+	componentName: string;
 };
 
 export type TSequence = {

--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -684,6 +684,7 @@ const htmlInCanvasSchema = {
 
 const HtmlInCanvasWrapped = withInteractivitySchema({
 	Component: HtmlInCanvasInner,
+	componentName: '<HtmlInCanvas>',
 	componentIdentity: 'dev.remotion.remotion.HtmlInCanvas',
 	schema: htmlInCanvasSchema,
 	supportsEffects: true,

--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -547,6 +547,7 @@ const ImgInner: React.FC<
  */
 export const Img = withInteractivitySchema({
 	Component: ImgInner,
+	componentName: '<Img>',
 	componentIdentity: 'dev.remotion.remotion.Img',
 	schema: imgSchema,
 	supportsEffects: true,

--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -170,6 +170,7 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 
 	const Wrapped = withInteractivitySchema({
 		Component: Inner,
+		componentName: displayName,
 		componentIdentity: `dev.remotion.remotion.${displayName.slice(1, -1)}`,
 		schema: interactiveElementSchema,
 		supportsEffects: false,

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -634,6 +634,7 @@ export const SequenceWithoutSchema = SequenceInner;
  */
 export const Sequence = withInteractivitySchema({
 	Component: SequenceInner,
+	componentName: '<Sequence>',
 	componentIdentity: 'dev.remotion.remotion.Sequence',
 	schema: sequenceSchema,
 	supportsEffects: false,
@@ -641,6 +642,7 @@ export const Sequence = withInteractivitySchema({
 
 export const SequenceWithoutFrom = withInteractivitySchema({
 	Component: SequenceInner,
+	componentName: '<Sequence>',
 	componentIdentity: null,
 	schema: sequenceSchemaWithoutFrom,
 	supportsEffects: false,

--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -292,6 +292,7 @@ const AnimatedImageInner = ({
 
 export const AnimatedImage = withInteractivitySchema({
 	Component: AnimatedImageInner,
+	componentName: '<AnimatedImage>',
 	componentIdentity: 'dev.remotion.remotion.AnimatedImage',
 	schema: animatedImageSchema,
 	supportsEffects: true,

--- a/packages/core/src/canvas-image/CanvasImage.tsx
+++ b/packages/core/src/canvas-image/CanvasImage.tsx
@@ -536,6 +536,7 @@ const CanvasImageInner = forwardRef<
  */
 export const CanvasImage = withInteractivitySchema({
 	Component: CanvasImageInner,
+	componentName: '<CanvasImage>',
 	componentIdentity: 'dev.remotion.remotion.CanvasImage',
 	schema: canvasImageSchema,
 	supportsEffects: true,

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -296,6 +296,7 @@ const SolidOuter = forwardRef<
 
 export const Solid = withInteractivitySchema({
 	Component: SolidOuter,
+	componentName: '<Solid>',
 	componentIdentity: 'dev.remotion.remotion.Solid',
 	schema: solidSchema,
 	supportsEffects: true,

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -160,6 +160,7 @@ const Series: React.ComponentType<SeriesProps> & {
 } = Object.assign(
 	withInteractivitySchema({
 		Component: SeriesInner,
+		componentName: '<Series>',
 		componentIdentity: 'dev.remotion.remotion.Series',
 		schema: sequenceSchemaDefaultLayoutNone,
 		supportsEffects: false,

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -112,6 +112,7 @@ export const withInteractivitySchema = <
 	Props extends object,
 >({
 	Component,
+	componentName,
 	componentIdentity,
 	schema,
 	supportsEffects,
@@ -119,6 +120,7 @@ export const withInteractivitySchema = <
 	Component: React.ComponentType<
 		Props & {readonly controls: SequenceControls | undefined}
 	>;
+	componentName: string;
 	componentIdentity: JsxComponentIdentity | null;
 	schema: S;
 	supportsEffects: boolean;
@@ -204,6 +206,7 @@ export const withInteractivitySchema = <
 				overrideId,
 				supportsEffects,
 				componentIdentity,
+				componentName,
 			};
 		}, [currentRuntimeValueDotNotation, overrideId]);
 

--- a/packages/docs/docs/interactive-with-schema.mdx
+++ b/packages/docs/docs/interactive-with-schema.mdx
@@ -94,6 +94,7 @@ const CircleInner = forwardRef<
 
 export const Circle = Interactive.withSchema({
   Component: CircleInner,
+  componentName: '<Circle>',
   componentIdentity: 'com.example.Circle',
   schema: circleSchema,
   supportsEffects: false,

--- a/packages/docs/docs/studio/make-component-interactive.mdx
+++ b/packages/docs/docs/studio/make-component-interactive.mdx
@@ -240,6 +240,7 @@ const BadgeInner = forwardRef<
 // ---cut---
 export const Badge = Interactive.withSchema({
   Component: BadgeInner,
+  componentName: '<Badge>',
   componentIdentity: 'com.example.Badge',
   schema: badgeSchema,
   supportsEffects: false,

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -121,6 +121,7 @@ const GifInner = ({
 
 export const Gif = Interactive.withSchema({
 	Component: GifInner,
+	componentName: '<Gif>',
 	componentIdentity: 'dev.remotion.gif.Gif',
 	schema: gifSchema,
 	supportsEffects: true,

--- a/packages/light-leaks/src/LightLeak.tsx
+++ b/packages/light-leaks/src/LightLeak.tsx
@@ -303,6 +303,7 @@ const LightLeakInner: React.FC<
 
 export const LightLeak = Interactive.withSchema({
 	Component: LightLeakInner,
+	componentName: '<LightLeak>',
 	componentIdentity: 'dev.remotion.lightLeaks.LightLeak',
 	schema: lightLeakSchema,
 	supportsEffects: false,

--- a/packages/media/src/audio/audio.tsx
+++ b/packages/media/src/audio/audio.tsx
@@ -167,6 +167,7 @@ const AudioInner: React.FC<
 
 export const Audio = Interactive.withSchema({
 	Component: AudioInner,
+	componentName: '<Audio>',
 	componentIdentity: 'dev.remotion.media.Audio',
 	schema: audioSchema,
 	supportsEffects: false,

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -359,6 +359,7 @@ const VideoInner: React.FC<
 
 export const Video = Interactive.withSchema({
 	Component: VideoInner,
+	componentName: '<Video>',
 	componentIdentity: 'dev.remotion.media.Video',
 	schema: videoSchema,
 	supportsEffects: true,

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -493,6 +493,7 @@ export const RemotionRiveCanvas = Interactive.withSchema({
 			readonly controls: SequenceControls | undefined;
 		}
 	>,
+	componentName: '<RemotionRiveCanvas>',
 	componentIdentity: 'dev.remotion.rive.RemotionRiveCanvas',
 	schema: riveCanvasSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/arrow.tsx
+++ b/packages/shapes/src/components/arrow.tsx
@@ -79,6 +79,7 @@ const ArrowInner: React.FC<ArrowProps> = ({
 
 export const Arrow = Interactive.withSchema({
 	Component: ArrowInner,
+	componentName: '<Arrow>',
 	componentIdentity: 'dev.remotion.shapes.Arrow',
 	schema: arrowSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/callout.tsx
+++ b/packages/shapes/src/components/callout.tsx
@@ -92,6 +92,7 @@ const CalloutInner: React.FC<CalloutProps> = ({
 
 export const Callout = Interactive.withSchema({
 	Component: CalloutInner,
+	componentName: '<Callout>',
 	componentIdentity: 'dev.remotion.shapes.Callout',
 	schema: calloutSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/circle.tsx
+++ b/packages/shapes/src/components/circle.tsx
@@ -34,6 +34,7 @@ const CircleInner: React.FC<CircleProps> = ({radius, ...props}) => {
 
 export const Circle = Interactive.withSchema({
 	Component: CircleInner,
+	componentName: '<Circle>',
 	componentIdentity: 'dev.remotion.shapes.Circle',
 	schema: circleSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/ellipse.tsx
+++ b/packages/shapes/src/components/ellipse.tsx
@@ -41,6 +41,7 @@ const EllipseInner: React.FC<EllipseProps> = ({rx, ry, ...props}) => {
 
 export const Ellipse = Interactive.withSchema({
 	Component: EllipseInner,
+	componentName: '<Ellipse>',
 	componentIdentity: 'dev.remotion.shapes.Ellipse',
 	schema: ellipseSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/heart.tsx
+++ b/packages/shapes/src/components/heart.tsx
@@ -61,6 +61,7 @@ const HeartInner: React.FC<HeartProps> = ({
 
 export const Heart = Interactive.withSchema({
 	Component: HeartInner,
+	componentName: '<Heart>',
 	componentIdentity: 'dev.remotion.shapes.Heart',
 	schema: heartSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/pie.tsx
+++ b/packages/shapes/src/components/pie.tsx
@@ -66,6 +66,7 @@ const PieInner: React.FC<PieProps> = ({
 
 export const Pie = Interactive.withSchema({
 	Component: PieInner,
+	componentName: '<Pie>',
 	componentIdentity: 'dev.remotion.shapes.Pie',
 	schema: pieSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/polygon.tsx
+++ b/packages/shapes/src/components/polygon.tsx
@@ -51,6 +51,7 @@ const PolygonInner: React.FC<PolygonProps> = ({
 
 export const Polygon = Interactive.withSchema({
 	Component: PolygonInner,
+	componentName: '<Polygon>',
 	componentIdentity: 'dev.remotion.shapes.Polygon',
 	schema: polygonSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/rect.tsx
+++ b/packages/shapes/src/components/rect.tsx
@@ -53,6 +53,7 @@ const RectInner: React.FC<RectProps> = ({
 
 export const Rect = Interactive.withSchema({
 	Component: RectInner,
+	componentName: '<Rect>',
 	componentIdentity: 'dev.remotion.shapes.Rect',
 	schema: rectSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/spark.tsx
+++ b/packages/shapes/src/components/spark.tsx
@@ -59,6 +59,7 @@ const SparkInner: React.FC<SparkProps> = ({
 
 export const Spark = Interactive.withSchema({
 	Component: SparkInner,
+	componentName: '<Spark>',
 	componentIdentity: 'dev.remotion.shapes.Spark',
 	schema: sparkSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/star.tsx
+++ b/packages/shapes/src/components/star.tsx
@@ -68,6 +68,7 @@ const StarInner: React.FC<StarProps> = ({
 
 export const Star = Interactive.withSchema({
 	Component: StarInner,
+	componentName: '<Star>',
 	componentIdentity: 'dev.remotion.shapes.Star',
 	schema: starSchema,
 	supportsEffects: true,

--- a/packages/shapes/src/components/triangle.tsx
+++ b/packages/shapes/src/components/triangle.tsx
@@ -53,6 +53,7 @@ const TriangleInner: React.FC<TriangleProps> = ({
 
 export const Triangle = Interactive.withSchema({
 	Component: TriangleInner,
+	componentName: '<Triangle>',
 	componentIdentity: 'dev.remotion.shapes.Triangle',
 	schema: triangleSchema,
 	supportsEffects: true,

--- a/packages/starburst/src/Starburst.tsx
+++ b/packages/starburst/src/Starburst.tsx
@@ -437,6 +437,7 @@ const StarburstInner: React.FC<
 
 export const Starburst = Interactive.withSchema({
 	Component: StarburstInner,
+	componentName: '<Starburst>',
 	componentIdentity: 'dev.remotion.starburst.Starburst',
 	schema: starburstSchema,
 	supportsEffects: false,

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -16,7 +16,12 @@ import {
 import {useOpenSequenceInEditor} from '../Timeline/use-open-sequence-in-editor';
 import {InspectorMessage, InspectorSectionHeader} from './common';
 import type {SequenceSectionSelection} from './inspector-selection';
-import {selectedContainer, sequenceHeader, sequenceHeaderTitle} from './styles';
+import {
+	selectedContainer,
+	sequenceHeader,
+	sequenceHeaderSubtitle,
+	sequenceHeaderTitle,
+} from './styles';
 import {useTrackForSelection} from './use-track-for-selection';
 
 const useSequenceDisplayName = (track: TrackWithHash) => {
@@ -78,9 +83,9 @@ const SequenceExpandedInspector: React.FC<{
 
 		window.open(documentationLink, '_blank', 'noopener,noreferrer');
 	}, [documentationLink]);
-	const titleStyle = useMemo((): React.CSSProperties => {
+	const subtitleStyle = useMemo((): React.CSSProperties => {
 		return {
-			...sequenceHeaderTitle,
+			...sequenceHeaderSubtitle,
 			cursor: documentationLink ? 'pointer' : 'default',
 		};
 	}, [documentationLink]);
@@ -139,17 +144,20 @@ const SequenceExpandedInspector: React.FC<{
 			onPointerDown={selectSequenceOnInspectorPointerDown}
 		>
 			<div style={sequenceHeader}>
+				<div style={sequenceHeaderTitle}>{sequenceDisplayName}</div>
 				{documentationLink ? (
 					<button
 						type="button"
-						style={titleStyle}
+						style={subtitleStyle}
 						title="Open component docs"
 						onClick={openDocumentationLink}
 					>
-						{sequenceDisplayName}
+						{track.sequence.controls.componentName}
 					</button>
 				) : (
-					<div style={titleStyle}>{sequenceDisplayName}</div>
+					<div style={subtitleStyle}>
+						{track.sequence.controls.componentName}
+					</div>
 				)}
 				<InspectorSourceLocation
 					location={validatedLocation}

--- a/packages/studio/src/components/InspectorPanel/styles.ts
+++ b/packages/studio/src/components/InspectorPanel/styles.ts
@@ -70,6 +70,25 @@ export const sequenceHeaderTitle: React.CSSProperties = {
 	whiteSpace: 'nowrap',
 };
 
+export const sequenceHeaderSubtitle: React.CSSProperties = {
+	alignSelf: 'flex-start',
+	backgroundColor: BACKGROUND,
+	border: 'none',
+	color: LIGHT_TEXT,
+	display: 'inline-flex',
+	fontFamily: 'sans-serif',
+	fontSize: 12,
+	lineHeight: '18px',
+	margin: 0,
+	maxWidth: '100%',
+	minWidth: 0,
+	overflow: 'hidden',
+	padding: 0,
+	textAlign: 'left',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+};
+
 export const sectionHeaderRow: React.CSSProperties = {
 	alignItems: 'center',
 	display: 'flex',

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -30,6 +30,7 @@ const makeControls = (
 	overrideId,
 	supportsEffects: false,
 	componentIdentity: null,
+	componentName: '<Sequence>',
 });
 
 const makeSequence = ({

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -209,6 +209,7 @@ const makeTimelineSequence = ({
 			overrideId,
 			supportsEffects: true,
 			componentIdentity: null,
+			componentName: '<Sequence>',
 		},
 		refForOutline,
 		isInsideSeries: false,

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -717,6 +717,7 @@ const TransitionSeriesInner: FC<SequencePropsWithoutDuration> = (props) => {
 
 const TransitionSeries = Interactive.withSchema({
 	Component: TransitionSeriesInner,
+	componentName: '<TransitionSeries>',
 	componentIdentity: 'dev.remotion.transitions.TransitionSeries',
 	schema: transitionSeriesSchema,
 	supportsEffects: false,


### PR DESCRIPTION
## Summary

- Add mandatory `componentName` metadata to interactivity schemas and propagate it to sequence controls.
- Show the component name as the docs link subtitle in the sequence inspector while keeping the sequence name plain text.
- Update built-in interactive components and docs examples for the new required metadata.

## Testing

- `bun run build`
- `bun run stylecheck`
