### PR TITLE
`@remotion/studio`: Stop reset zoom pointerdown propagation

### DIFF
--- a/packages/studio/src/components/Button.tsx
+++ b/packages/studio/src/components/Button.tsx
@@ -24,6 +24,7 @@ export type ButtonProps = {
 	readonly autoFocus?: boolean;
 	readonly title?: string;
 	readonly id?: string;
+	readonly onPointerDown?: React.PointerEventHandler<HTMLButtonElement>;
 };
 
 const ButtonRefForwardFunction: React.ForwardRefRenderFunction<
@@ -40,6 +41,7 @@ const ButtonRefForwardFunction: React.ForwardRefRenderFunction<
 		id,
 		autoFocus,
 		buttonContainerStyle,
+		onPointerDown,
 	},
 	ref,
 ) => {
@@ -72,6 +74,7 @@ const ButtonRefForwardFunction: React.ForwardRefRenderFunction<
 			type="button"
 			disabled={disabled}
 			onClick={onClick}
+			onPointerDown={onPointerDown}
 			autoFocus={autoFocus}
 			title={title}
 		>

--- a/packages/studio/src/components/ResetZoomButton.tsx
+++ b/packages/studio/src/components/ResetZoomButton.tsx
@@ -1,7 +1,19 @@
+import React, {useCallback} from 'react';
 import {Button} from './Button';
 
 export const ResetZoomButton: React.FC<{
-	onClick: () => void;
+	readonly onClick: () => void;
 }> = ({onClick}) => {
-	return <Button onClick={onClick}>Reset zoom</Button>;
+	const onPointerDown = useCallback(
+		(event: React.PointerEvent<HTMLButtonElement>) => {
+			event.stopPropagation();
+		},
+		[],
+	);
+
+	return (
+		<Button onClick={onClick} onPointerDown={onPointerDown}>
+			Reset zoom
+		</Button>
+	);
 };


### PR DESCRIPTION
Fixes #8554.

## Summary
- Stop `pointerdown` from bubbling from the canvas reset zoom button.
- Allow the shared Studio `Button` component to receive an `onPointerDown` handler.

## Testing
- `bun run build`
- `bun run stylecheck`
