### PR TITLE
`@remotion/studio`: Show visual handles for selected easings

### DIFF
--- a/packages/studio/src/components/selected-outline-measurement.ts
+++ b/packages/studio/src/components/selected-outline-measurement.ts
@@ -347,16 +347,21 @@ type SelectedEffectFields = {
 	fieldKeys: Set<string>;
 };
 
+const getKeyframeOrEasingField = (item: TimelineSelection) => {
+	if (item.type !== 'keyframe' && item.type !== 'easing') {
+		return null;
+	}
+
+	return parseKeyframeFieldFromNodePath(item.nodePathInfo.auxiliaryKeys);
+};
+
 export const getSelectedEffectFieldsBySequenceKey = (
 	selectedItems: readonly TimelineSelection[],
 ): Map<string, Map<number, SelectedEffectFields>> => {
 	const selectedEffects = new Map<string, Map<number, SelectedEffectFields>>();
 
 	for (const item of selectedItems) {
-		if (
-			item.type !== 'sequence-effect' &&
-			item.type !== 'sequence-effect-prop'
-		) {
+		if (item.type === 'guide') {
 			continue;
 		}
 
@@ -364,19 +369,57 @@ export const getSelectedEffectFieldsBySequenceKey = (
 		const effectsForSequence =
 			selectedEffects.get(sequenceKey) ??
 			new Map<number, SelectedEffectFields>();
-		const selectedFields = effectsForSequence.get(item.i) ?? {
-			allFields: false,
-			fieldKeys: new Set<string>(),
+
+		const addSelectedFields = ({
+			effectIndex,
+			fieldKey,
+			allFields,
+		}: {
+			readonly effectIndex: number;
+			readonly fieldKey: string | null;
+			readonly allFields: boolean;
+		}) => {
+			const selectedFields = effectsForSequence.get(effectIndex) ?? {
+				allFields: false,
+				fieldKeys: new Set<string>(),
+			};
+
+			if (allFields) {
+				selectedFields.allFields = true;
+			} else if (fieldKey !== null) {
+				selectedFields.fieldKeys.add(fieldKey);
+			}
+
+			effectsForSequence.set(effectIndex, selectedFields);
+			selectedEffects.set(sequenceKey, effectsForSequence);
 		};
 
 		if (item.type === 'sequence-effect') {
-			selectedFields.allFields = true;
-		} else {
-			selectedFields.fieldKeys.add(item.key);
+			addSelectedFields({
+				effectIndex: item.i,
+				fieldKey: null,
+				allFields: true,
+			});
+			continue;
 		}
 
-		effectsForSequence.set(item.i, selectedFields);
-		selectedEffects.set(sequenceKey, effectsForSequence);
+		if (item.type === 'sequence-effect-prop') {
+			addSelectedFields({
+				effectIndex: item.i,
+				fieldKey: item.key,
+				allFields: false,
+			});
+			continue;
+		}
+
+		const keyframedField = getKeyframeOrEasingField(item);
+		if (keyframedField?.type === 'effect') {
+			addSelectedFields({
+				effectIndex: keyframedField.effectIndex,
+				fieldKey: keyframedField.fieldKey,
+				allFields: false,
+			});
+		}
 	}
 
 	return selectedEffects;
@@ -405,13 +448,11 @@ export const getSelectedTransformOriginInfo = (
 		};
 	}
 
-	if (selectedItem.type !== 'keyframe') {
+	if (selectedItem.type !== 'keyframe' && selectedItem.type !== 'easing') {
 		return null;
 	}
 
-	const field = parseKeyframeFieldFromNodePath(
-		selectedItem.nodePathInfo.auxiliaryKeys,
-	);
+	const field = getKeyframeOrEasingField(selectedItem);
 	if (
 		field?.type !== 'sequence' ||
 		field.fieldKey !== transformOriginFieldKey
@@ -421,7 +462,10 @@ export const getSelectedTransformOriginInfo = (
 
 	return {
 		sequenceKey: getTimelineSequenceSelectionKey(selectedItem.nodePathInfo),
-		displayFrame: selectedItem.frame,
+		displayFrame:
+			selectedItem.type === 'keyframe'
+				? selectedItem.frame
+				: selectedItem.fromFrame,
 	};
 };
 

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -3,12 +3,13 @@ import type {RefObject} from 'react';
 import {
 	Internals,
 	type PropStatuses,
+	type InteractivitySchema,
 	type SequenceNodePath,
 	type SequencePropsSubscriptionKey,
-	type InteractivitySchema,
 	type TSequence,
 } from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
+import {getSelectedTransformOriginInfo} from '../components/selected-outline-measurement';
 import {
 	constrainUv,
 	getSelectedUvHandles,
@@ -2029,6 +2030,34 @@ test('UV handles are requested for selected effect children', () => {
 	});
 });
 
+test('UV handles are requested for selected effect keyframes and easings', () => {
+	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const effectPropNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '1', 'rays'],
+	);
+	const sequenceKey = getTimelineSequenceSelectionKey(sequenceNodePathInfo);
+	const selectedEffects = getSelectedEffectFieldsBySequenceKey([
+		{
+			type: 'keyframe',
+			nodePathInfo: effectPropNodePathInfo,
+			frame: 10,
+		},
+		{
+			type: 'easing',
+			nodePathInfo: effectPropNodePathInfo,
+			fromFrame: 10,
+			toFrame: 20,
+			segmentIndex: 0,
+		},
+	]);
+
+	expect(selectedEffects.get(sequenceKey)?.get(1)).toEqual({
+		allFields: false,
+		fieldKeys: new Set(['rays']),
+	});
+});
+
 test('UV handles are requested for keyframed selected effect props', () => {
 	const sequenceNodePathInfo = makeNodePathInfo(['body', 0], []);
 	const effectPropNodePathInfo = makeNodePathInfo(
@@ -2093,6 +2122,28 @@ test('UV handles are requested for keyframed selected effect props', () => {
 	expect(handles[0].propStatus.status).toBe('keyframed');
 	expect(handles[0].sourceFrame).toBe(50);
 	expect(handles[0].value).toEqual([0.5, 0.5]);
+});
+
+test('Transform origin easing selection targets the transform origin handle', () => {
+	const transformOriginNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'style', 'transformOrigin'],
+	);
+
+	expect(
+		getSelectedTransformOriginInfo([
+			{
+				type: 'easing',
+				nodePathInfo: transformOriginNodePathInfo,
+				fromFrame: 12,
+				toFrame: 24,
+				segmentIndex: 0,
+			},
+		]),
+	).toEqual({
+		sequenceKey: getTimelineSequenceSelectionKey(transformOriginNodePathInfo),
+		displayFrame: 12,
+	});
 });
 
 test('selected sequence keys only include exact sequence selections', () => {


### PR DESCRIPTION
## Summary

- Resolve selected keyframes and easings back to their visual effect fields so UV handles and connection lines stay visible
- Let transform origin easings target the transform origin canvas handle
- Add regression coverage for selected effect keyframes/easings and transform origin easing selections

Fixes #8555.

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bunx turbo run make --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`
