### PR TITLE
`@remotion/studio`: Keep inspector for same-sequence effects

### DIFF
--- a/packages/studio/src/components/InspectorPanel.tsx
+++ b/packages/studio/src/components/InspectorPanel.tsx
@@ -2,7 +2,7 @@ import React, {useMemo} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {InspectorMessage} from './InspectorPanel/common';
 import {DefaultInspector} from './InspectorPanel/DefaultInspector';
-import {getSameSequencePropInspectorSelection} from './InspectorPanel/inspector-selection';
+import {getSameSequenceInspectorSelection} from './InspectorPanel/inspector-selection';
 import {SelectedInspector} from './InspectorPanel/SelectedInspector';
 import {container} from './InspectorPanel/styles';
 import type {UpdaterFunction} from './RenderModal/SchemaEditor/ZodSwitch';
@@ -14,8 +14,8 @@ export const InspectorPanel: React.FC<{
 	readonly setDefaultProps: UpdaterFunction<Record<string, unknown>>;
 }> = ({composition, currentDefaultProps, setDefaultProps}) => {
 	const {selectedItems} = useTimelineSelection();
-	const sameSequencePropInspectorSelection = useMemo(
-		() => getSameSequencePropInspectorSelection(selectedItems),
+	const sameSequenceInspectorSelection = useMemo(
+		() => getSameSequenceInspectorSelection(selectedItems),
 		[selectedItems],
 	);
 
@@ -30,10 +30,10 @@ export const InspectorPanel: React.FC<{
 	}
 
 	if (selectedItems.length > 1) {
-		if (sameSequencePropInspectorSelection) {
+		if (sameSequenceInspectorSelection) {
 			return (
 				<div style={container}>
-					<SelectedInspector selection={sameSequencePropInspectorSelection} />
+					<SelectedInspector selection={sameSequenceInspectorSelection} />
 				</div>
 			);
 		}

--- a/packages/studio/src/components/InspectorPanel/inspector-selection.ts
+++ b/packages/studio/src/components/InspectorPanel/inspector-selection.ts
@@ -27,25 +27,26 @@ export const isSequenceSectionSelection = (
 	);
 };
 
-type SequencePropSelection = Extract<
+type SameSequenceInspectorSelection = Extract<
 	TimelineSelection,
-	{type: 'sequence-prop' | 'sequence-effect-prop'}
+	{type: 'sequence-prop' | 'sequence-effect' | 'sequence-effect-prop'}
 >;
 
-const isSequencePropSelection = (
+const isSameSequenceInspectorSelection = (
 	selection: TimelineSelection,
-): selection is SequencePropSelection => {
+): selection is SameSequenceInspectorSelection => {
 	return (
 		selection.type === 'sequence-prop' ||
+		selection.type === 'sequence-effect' ||
 		selection.type === 'sequence-effect-prop'
 	);
 };
 
-export const getSameSequencePropInspectorSelection = (
+export const getSameSequenceInspectorSelection = (
 	selections: readonly TimelineSelection[],
-): SequencePropSelection | null => {
+): SameSequenceInspectorSelection | null => {
 	const firstSelection = selections[0];
-	if (!firstSelection || !isSequencePropSelection(firstSelection)) {
+	if (!firstSelection || !isSameSequenceInspectorSelection(firstSelection)) {
 		return null;
 	}
 
@@ -53,7 +54,7 @@ export const getSameSequencePropInspectorSelection = (
 		firstSelection.nodePathInfo,
 	);
 	for (const selection of selections) {
-		if (!isSequencePropSelection(selection)) {
+		if (!isSameSequenceInspectorSelection(selection)) {
 			return null;
 		}
 

--- a/packages/studio/src/test/inspector-selection.test.ts
+++ b/packages/studio/src/test/inspector-selection.test.ts
@@ -1,0 +1,57 @@
+import {expect, test} from 'bun:test';
+import type {SequenceNodePath, SequencePropsSubscriptionKey} from 'remotion';
+import {getSameSequenceInspectorSelection} from '../components/InspectorPanel/inspector-selection';
+import type {TimelineSelection} from '../components/Timeline/TimelineSelection';
+import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+
+const makeKey = (nodePath: SequenceNodePath): SequencePropsSubscriptionKey => ({
+	absolutePath: '/project/src/Comp.tsx',
+	effectKeys: [],
+	nodePath,
+	sequenceKeys: ['from', 'durationInFrames'],
+});
+
+const makeNodePathInfo = (
+	nodePath: SequenceNodePath,
+	auxiliaryKeys: string[],
+): SequenceNodePathInfo => ({
+	auxiliaryKeys,
+	index: 0,
+	numberOfSequencesWithThisNodePath: 1,
+	sequenceSubscriptionKey: makeKey(nodePath),
+	supportsEffects: true,
+});
+
+test('keeps the sequence inspector for multiple effects from the same sequence', () => {
+	const firstEffect: TimelineSelection = {
+		i: 0,
+		nodePathInfo: makeNodePathInfo(['Root', 'Child'], ['effects', '0']),
+		type: 'sequence-effect',
+	};
+	const secondEffect: TimelineSelection = {
+		i: 1,
+		nodePathInfo: makeNodePathInfo(['Root', 'Child'], ['effects', '1']),
+		type: 'sequence-effect',
+	};
+
+	expect(getSameSequenceInspectorSelection([firstEffect, secondEffect])).toBe(
+		firstEffect,
+	);
+});
+
+test('does not keep the sequence inspector for effects from different sequences', () => {
+	const firstEffect: TimelineSelection = {
+		i: 0,
+		nodePathInfo: makeNodePathInfo(['Root', 'First'], ['effects', '0']),
+		type: 'sequence-effect',
+	};
+	const secondEffect: TimelineSelection = {
+		i: 0,
+		nodePathInfo: makeNodePathInfo(['Root', 'Second'], ['effects', '0']),
+		type: 'sequence-effect',
+	};
+
+	expect(getSameSequenceInspectorSelection([firstEffect, secondEffect])).toBe(
+		null,
+	);
+});


### PR DESCRIPTION
Fixes #8559.

## Summary

- keep the sequence inspector visible when multiple selected effect rows belong to the same sequence
- keep the existing same-sequence prop inspector behavior
- add a regression test for same-sequence and cross-sequence effect selections

## Tests

- `bun test src/test/inspector-selection.test.ts` from `packages/studio`
- `bun run build`
- `bun run stylecheck`
