### PR TITLE
`@remotion/studio`: Add sequence property shortcuts

### DIFF
--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -350,13 +350,42 @@ Pause and return to where playback started
     <td>
       <kbd>R</kbd>
     </td>
-    <td>Render composition</td>
+    <td>Render composition, unless a sequence or prop is selected</td>
   </tr>
   <tr>
     <td>
       <kbd>T</kbd>
     </td>
-    <td>Toggle checkerboard background</td>
+    <td>Toggle checkerboard background, unless a sequence or prop is selected</td>
+  </tr>
+</table>
+
+### Selected sequence or prop
+
+<table>
+  <tr>
+    <td>
+      <kbd>P</kbd>
+    </td>
+    <td>Select the `style.translate` prop</td>
+  </tr>
+  <tr>
+    <td>
+      <kbd>T</kbd>
+    </td>
+    <td>Select the `style.opacity` prop</td>
+  </tr>
+  <tr>
+    <td>
+      <kbd>R</kbd>
+    </td>
+    <td>Select the `style.rotate` prop</td>
+  </tr>
+  <tr>
+    <td>
+      <kbd>S</kbd>
+    </td>
+    <td>Select the `style.scale` prop</td>
   </tr>
 </table>
 

--- a/packages/studio/src/components/CurrentCompositionSideEffects.tsx
+++ b/packages/studio/src/components/CurrentCompositionSideEffects.tsx
@@ -1,14 +1,10 @@
 import type React from 'react';
-import {useCallback, useContext, useEffect} from 'react';
+import {useContext, useEffect} from 'react';
 import {Internals} from 'remotion';
-import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {
 	setCurrentCanvasContentId,
 	setRenderJobs,
 } from '../helpers/document-title';
-import {SHOW_BROWSER_RENDERING} from '../helpers/show-browser-rendering';
-import {useKeybinding} from '../helpers/use-keybinding';
-import {showNotification} from './Notifications/NotificationCenter';
 import {RenderQueueContext} from './RenderQueue/context';
 
 export const TitleUpdater: React.FC = () => {
@@ -43,49 +39,6 @@ export const TitleUpdater: React.FC = () => {
 	useEffect(() => {
 		setRenderJobs(jobs);
 	}, [jobs]);
-
-	return null;
-};
-
-export const CurrentCompositionKeybindings: React.FC<{
-	readonly readOnlyStudio: boolean;
-}> = ({readOnlyStudio}) => {
-	const keybindings = useKeybinding();
-	const video = Internals.useVideo();
-	const {type} = useContext(StudioServerConnectionCtx).previewServerState;
-
-	const openRenderModal = useCallback(() => {
-		if (!video) {
-			return;
-		}
-
-		if (type !== 'connected' && !SHOW_BROWSER_RENDERING && !readOnlyStudio) {
-			showNotification('Studio server is offline', 2000);
-			return;
-		}
-
-		const renderButton = document.getElementById(
-			'render-modal-button',
-		) as HTMLDivElement;
-
-		renderButton.click();
-	}, [readOnlyStudio, type, video]);
-
-	useEffect(() => {
-		const binding = keybindings.registerKeybinding({
-			event: 'keydown',
-			key: 'r',
-			commandCtrlKey: false,
-			callback: openRenderModal,
-			preventDefault: true,
-			triggerIfInputFieldFocused: false,
-			keepRegisteredWhenNotHighestContext: false,
-		});
-
-		return () => {
-			binding.unregister();
-		};
-	}, [keybindings, openRenderModal]);
 
 	return null;
 };

--- a/packages/studio/src/components/Editor.tsx
+++ b/packages/studio/src/components/Editor.tsx
@@ -11,7 +11,6 @@ import {HigherZIndex} from '../state/z-index';
 import {CANVAS_CAPTURE_ENABLED} from './canvas-capture-enabled';
 import {EditorContent} from './EditorContent';
 import {ForceSpecificCursor} from './ForceSpecificCursor';
-import {GlobalKeybindings} from './GlobalKeybindings';
 import {Modals} from './Modals';
 import {NotificationCenter} from './Notifications/NotificationCenter';
 import {RenderErrorContext} from './RenderErrorContext';
@@ -116,7 +115,6 @@ export const Editor: React.FC<{
 											/>
 										</EditorContent>
 									</RenderErrorContext.Provider>
-									<GlobalKeybindings />
 								</Internals.CanUseRemotionHooksProvider>
 							</div>
 						</ScaleLockProvider>

--- a/packages/studio/src/components/EditorContent.tsx
+++ b/packages/studio/src/components/EditorContent.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useContext} from 'react';
 import {Internals} from 'remotion';
+import {GlobalKeybindings} from './GlobalKeybindings';
 import {InitialCompositionLoader} from './InitialCompositionLoader';
 import {MenuToolbar} from './MenuToolbar';
 import {SplitterContainer} from './Splitter/SplitterContainer';
@@ -78,6 +79,7 @@ export const EditorContent: React.FC<{
 			<StudioClearSelectionArea>
 				<InitialCompositionLoader />
 				<MenuToolbar readOnlyStudio={readOnlyStudio} />
+				<GlobalKeybindings readOnlyStudio={readOnlyStudio} />
 				<TimelineKeyframeDragStateProvider>
 					{content}
 				</TimelineKeyframeDragStateProvider>

--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -1,20 +1,149 @@
 import type React from 'react';
-import {useContext, useEffect} from 'react';
+import {useCallback, useContext, useEffect, useMemo} from 'react';
+import {Internals} from 'remotion';
+import {calculateTimeline} from '../helpers/calculate-timeline';
+import {StudioServerConnectionCtx} from '../helpers/client-id';
+import {SHOW_BROWSER_RENDERING} from '../helpers/show-browser-rendering';
+import {timelineNodePathInfoToKey} from '../helpers/timeline-node-path-key';
 import {useKeybinding} from '../helpers/use-keybinding';
 import {CheckerboardContext} from '../state/checkerboard';
 import {ModalsContext} from '../state/modals';
 import {askAiModalRef} from './AskAiModal';
 import {useCompositionNavigation} from './CompositionSelector';
 import {showNotification} from './Notifications/NotificationCenter';
+import {
+	getTimelineSequenceSelectionKey,
+	useCurrentTimelineSelectionStateAsRef,
+} from './Timeline/TimelineSelection';
 
-export const GlobalKeybindings: React.FC = () => {
+const sequencePropShortcuts: Record<string, string> = {
+	p: 'style.translate',
+	r: 'style.rotate',
+	s: 'style.scale',
+	t: 'style.opacity',
+};
+
+const hasOwnProperty = (obj: object, key: string) =>
+	Object.prototype.hasOwnProperty.call(obj, key);
+
+export const GlobalKeybindings: React.FC<{
+	readonly readOnlyStudio: boolean;
+}> = ({readOnlyStudio}) => {
 	const keybindings = useKeybinding();
 	const {setSelectedModal} = useContext(ModalsContext);
 	const {setCheckerboard} = useContext(CheckerboardContext);
+	const currentSelection = useCurrentTimelineSelectionStateAsRef();
+	const {sequences} = useContext(Internals.SequenceManager);
+	const videoConfig = Internals.useUnsafeVideoConfig();
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
+	const {type} = useContext(StudioServerConnectionCtx).previewServerState;
 	const {navigateToNextComposition, navigateToPreviousComposition} =
 		useCompositionNavigation();
+	const video = Internals.useVideo();
+	const timeline = useMemo(() => {
+		if (videoConfig === null) {
+			return [];
+		}
+
+		return calculateTimeline({
+			sequences,
+			overrideIdsToNodePaths: overrideIdToNodePathMappings,
+		});
+	}, [overrideIdToNodePathMappings, sequences, videoConfig]);
+
+	const selectSequenceProp = useCallback(
+		(fieldKey: string) => {
+			const {selectedItems, selectItems} = currentSelection.current;
+			if (selectedItems.length !== 1) {
+				return false;
+			}
+
+			const [selection] = selectedItems;
+			if (selection.type !== 'sequence' && selection.type !== 'sequence-prop') {
+				return false;
+			}
+
+			const selectedTrackKey = getTimelineSequenceSelectionKey(
+				selection.nodePathInfo,
+			);
+			const track = timeline.find(
+				(candidate) =>
+					candidate.nodePathInfo !== null &&
+					timelineNodePathInfoToKey(candidate.nodePathInfo) ===
+						selectedTrackKey,
+			);
+
+			if (!track?.sequence.controls) {
+				return false;
+			}
+
+			const {schema, currentRuntimeValueDotNotation} = track.sequence.controls;
+			if (
+				!hasOwnProperty(schema, fieldKey) &&
+				!hasOwnProperty(currentRuntimeValueDotNotation, fieldKey)
+			) {
+				return false;
+			}
+
+			selectItems([
+				{
+					type: 'sequence-prop',
+					nodePathInfo: {
+						...selection.nodePathInfo,
+						auxiliaryKeys: ['controls', fieldKey],
+					},
+					key: fieldKey,
+				},
+			]);
+			return true;
+		},
+		[currentSelection, timeline],
+	);
+
+	const openRenderModal = useCallback(() => {
+		if (!video) {
+			return;
+		}
+
+		if (type !== 'connected' && !SHOW_BROWSER_RENDERING && !readOnlyStudio) {
+			showNotification('Studio server is offline', 2000);
+			return;
+		}
+
+		const renderButton = document.getElementById(
+			'render-modal-button',
+		) as HTMLDivElement;
+
+		renderButton.click();
+	}, [readOnlyStudio, type, video]);
 
 	useEffect(() => {
+		const onSequencePropKey = (event: KeyboardEvent) => {
+			const key = event.key.toLowerCase();
+			const fieldKey = sequencePropShortcuts[key];
+			if (!fieldKey) {
+				return;
+			}
+
+			if (selectSequenceProp(fieldKey)) {
+				event.preventDefault();
+				return;
+			}
+
+			if (key === 't') {
+				setCheckerboard((c) => !c);
+				event.preventDefault();
+				return;
+			}
+
+			if (key === 'r') {
+				openRenderModal();
+				event.preventDefault();
+			}
+		};
+
 		const nKey = keybindings.registerKeybinding({
 			event: 'keypress',
 			key: 'n',
@@ -69,17 +198,17 @@ export const GlobalKeybindings: React.FC = () => {
 				})
 			: null;
 
-		const cKey = keybindings.registerKeybinding({
-			event: 'keypress',
-			key: 't',
-			callback: () => {
-				setCheckerboard((c) => !c);
-			},
-			commandCtrlKey: false,
-			preventDefault: true,
-			triggerIfInputFieldFocused: false,
-			keepRegisteredWhenNotHighestContext: false,
-		});
+		const sequencePropKeys = Object.keys(sequencePropShortcuts).map((key) =>
+			keybindings.registerKeybinding({
+				event: 'keydown',
+				key,
+				callback: onSequencePropKey,
+				commandCtrlKey: false,
+				preventDefault: false,
+				triggerIfInputFieldFocused: false,
+				keepRegisteredWhenNotHighestContext: false,
+			}),
+		);
 		const questionMark = keybindings.registerKeybinding({
 			event: 'keypress',
 			key: '?',
@@ -118,7 +247,10 @@ export const GlobalKeybindings: React.FC = () => {
 
 		return () => {
 			nKey.unregister();
-			cKey.unregister();
+			for (const sequencePropKey of sequencePropKeys) {
+				sequencePropKey.unregister();
+			}
+
 			questionMark.unregister();
 			cmdKKey.unregister();
 			cmdSKey.unregister();
@@ -128,6 +260,8 @@ export const GlobalKeybindings: React.FC = () => {
 		};
 	}, [
 		keybindings,
+		openRenderModal,
+		selectSequenceProp,
 		setCheckerboard,
 		setSelectedModal,
 		navigateToNextComposition,

--- a/packages/studio/src/components/KeyboardShortcutsExplainer.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsExplainer.tsx
@@ -226,13 +226,17 @@ export const KeyboardShortcutsExplainer: React.FC = () => {
 						<div style={left}>
 							<kbd style={key}>R</kbd>
 						</div>
-						<div style={right}>Render composition</div>
+						<div style={right}>
+							Render, unless a sequence or prop is selected
+						</div>
 					</Row>
 					<Row align="center">
 						<div style={left}>
 							<kbd style={key}>T</kbd>
 						</div>
-						<div style={right}>Toggle checkerboard background</div>
+						<div style={right}>
+							Checkerboard, unless a sequence or prop is selected
+						</div>
 					</Row>
 					<Row align="center">
 						<div style={left}>
@@ -327,6 +331,30 @@ export const KeyboardShortcutsExplainer: React.FC = () => {
 							<kbd style={key}>A</kbd>
 						</div>
 						<div style={right}>Select sequence rows</div>
+					</Row>
+					<Row align="center">
+						<div style={left}>
+							<kbd style={key}>P</kbd>
+						</div>
+						<div style={right}>Select translate prop</div>
+					</Row>
+					<Row align="center">
+						<div style={left}>
+							<kbd style={key}>T</kbd>
+						</div>
+						<div style={right}>Select opacity prop</div>
+					</Row>
+					<Row align="center">
+						<div style={left}>
+							<kbd style={key}>R</kbd>
+						</div>
+						<div style={right}>Select rotate prop</div>
+					</Row>
+					<Row align="center">
+						<div style={left}>
+							<kbd style={key}>S</kbd>
+						</div>
+						<div style={right}>Select scale prop</div>
 					</Row>
 					<Row align="center">
 						<div style={left}>

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -432,7 +432,9 @@ export const SelectedOutlineOverlay: React.FC<{
 	}, [outlineTargets]);
 	const allDragTargets = useMemo(() => {
 		return outlineTargets.flatMap((target) =>
-			target.selected && target.drag !== null ? [target.drag] : [],
+			(target.selected || target.containsSelection) && target.drag !== null
+				? [target.drag]
+				: [],
 		);
 	}, [outlineTargets]);
 	const allScaleDragTargets = useMemo(() => {

--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -466,6 +466,7 @@ export const TimelineEffectItem: React.FC<{
 			style={rowStyle}
 			selected={selection.selected}
 			selectable={selection.selectable}
+			selectionItem={selection.selectionItem}
 			onSelect={selection.onSelect}
 			showSelectedBackground
 			containsSelection={false}

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -539,6 +539,7 @@ export const TimelineEffectPropItem: React.FC<{
 			style={style}
 			selected={selection.selected}
 			selectable={selection.selectable}
+			selectionItem={selection.selectionItem}
 			onSelect={selection.onSelect}
 			showSelectedBackground
 			containsSelection={false}

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -113,6 +113,7 @@ export const TimelineExpandedRow: React.FC<{
 				}}
 				selected={selection.selected}
 				selectable={selection.selectable}
+				selectionItem={selection.selectionItem}
 				onSelect={selection.onSelect}
 				showSelectedBackground
 				containsSelection={false}
@@ -168,6 +169,7 @@ export const TimelineExpandedRow: React.FC<{
 			}}
 			selected={selection.selected}
 			selectable={selection.selectable}
+			selectionItem={selection.selectionItem}
 			onSelect={selection.onSelect}
 			showSelectedBackground
 			containsSelection={false}

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback, useMemo, useRef} from 'react';
 import {TIMELINE_TRACK_SEPARATOR} from '../../helpers/colors';
 import {Padder} from './Padder';
 import {
@@ -7,7 +7,11 @@ import {
 	getTimelineRowLeftChromeWidth,
 } from './timeline-row-layout';
 import type {TimelineSelectionInteraction} from './TimelineSelection';
-import {TIMELINE_SELECTED_BACKGROUND} from './TimelineSelection';
+import {
+	TIMELINE_SELECTED_BACKGROUND,
+	type TimelineSelection,
+	useTimelineFocusableItem,
+} from './TimelineSelection';
 
 const rowBase: React.CSSProperties = {
 	alignItems: 'stretch',
@@ -37,6 +41,7 @@ export const TimelineRowChrome: React.FC<{
 	readonly style: React.CSSProperties;
 	readonly selected: boolean;
 	readonly selectable: boolean;
+	readonly selectionItem: TimelineSelection | null;
 	readonly onSelect: (interaction?: TimelineSelectionInteraction) => void;
 	readonly showSelectedBackground: boolean;
 	readonly containsSelection: boolean;
@@ -57,6 +62,7 @@ export const TimelineRowChrome: React.FC<{
 	style,
 	selected,
 	selectable,
+	selectionItem,
 	onSelect,
 	showSelectedBackground,
 	containsSelection,
@@ -66,7 +72,9 @@ export const TimelineRowChrome: React.FC<{
 	onDrop,
 	onDoubleClick,
 }) => {
+	const ref = useRef<HTMLDivElement>(null);
 	const indentWidth = getTimelineRowIndentWidth(depth);
+	useTimelineFocusableItem(selectionItem, ref);
 
 	const keyframeControlsColumnStyle = useMemo(
 		(): React.CSSProperties => ({
@@ -158,6 +166,7 @@ export const TimelineRowChrome: React.FC<{
 	if (outerStyle) {
 		return (
 			<div
+				ref={ref}
 				style={outerStyle}
 				onDragLeave={onDragLeave}
 				onDragOver={onDragOver}
@@ -173,6 +182,7 @@ export const TimelineRowChrome: React.FC<{
 
 	return (
 		<div
+			ref={ref}
 			onDragLeave={onDragLeave}
 			onDragOver={onDragOver}
 			onDrop={onDrop}

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -42,6 +42,7 @@ import {
 	getSelectedTimelineExpandedRowKeys,
 	isTimelineExpandedNodeSelected,
 } from './timeline-expanded-filter';
+import {timelineVerticalScroll} from './timeline-refs';
 import {TimelineClipboardKeybindings} from './TimelineClipboardKeybindings';
 import {TimelineDeleteKeybindings} from './TimelineDeleteKeybindings';
 
@@ -520,6 +521,10 @@ type TimelineSelectionContextValue = {
 		item: TimelineSelection,
 		getRect: () => DOMRect | null,
 	) => () => void;
+	readonly registerFocusableItem: (
+		item: TimelineSelection,
+		getRect: () => DOMRect | null,
+	) => () => void;
 	readonly getMarqueeSelection: (
 		marqueeRect: TimelineMarqueeRect,
 		lockedSelectionKind: TimelineMarqueeSelectionKind | null,
@@ -538,6 +543,7 @@ const defaultTimelineSelectionContextValue: TimelineSelectionContextValue = {
 	selectItem: () => undefined,
 	selectItems: () => undefined,
 	registerMarqueeSelectableItem: () => () => undefined,
+	registerFocusableItem: () => () => undefined,
 	getMarqueeSelection: () => ({
 		lockedSelectionKind: null,
 		selectedItems: [],
@@ -572,6 +578,8 @@ export const TimelineSelectionOrderProvider: React.FC<{
 
 const CurrentTimelineSelectionContext =
 	createContext<React.RefObject<TimelineSelectionContextValue> | null>(null);
+
+const TIMELINE_SELECTION_FOCUS_PADDING = 8;
 
 const parseEffectIndex = (effectIndex: string): number | null => {
 	const parsed = Number(effectIndex);
@@ -912,6 +920,37 @@ export const TimelineSelectAllKeybindings: React.FC<{
 	return null;
 };
 
+const TimelineEscapeKeybindings: React.FC = () => {
+	const keybindings = useKeybinding();
+	const currentSelection = useCurrentTimelineSelectionStateAsRef();
+
+	useEffect(() => {
+		const escape = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'Escape',
+			callback: (event) => {
+				const {selectedItems, clearSelection} = currentSelection.current;
+				if (selectedItems.length === 0) {
+					return;
+				}
+
+				clearSelection();
+				event.preventDefault();
+			},
+			commandCtrlKey: false,
+			preventDefault: false,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+
+		return () => {
+			escape.unregister();
+		};
+	}, [currentSelection, keybindings]);
+
+	return null;
+};
+
 export const TimelineSelectableItemsProvider: React.FC<{
 	readonly children: React.ReactNode;
 	readonly timeline: readonly TrackWithHash[];
@@ -979,6 +1018,15 @@ export const TimelineSelectionProvider: React.FC<{
 		>(),
 	);
 	const marqueeRegistrationCounter = useRef(0);
+	const focusableItems = useRef(
+		new Map<
+			string,
+			{
+				readonly getRect: () => DOMRect | null;
+			}
+		>(),
+	);
+	const previousSingleSelectionKey = useRef<string | null>(null);
 
 	useEffect(() => {
 		if (!canSelect) {
@@ -1010,6 +1058,46 @@ export const TimelineSelectionProvider: React.FC<{
 	const availableSelectionState =
 		getCurrentAvailableSelectionState(selectedItems);
 	const availableSelectedItems = availableSelectionState.selectedItems;
+
+	useEffect(() => {
+		if (availableSelectedItems.length !== 1) {
+			previousSingleSelectionKey.current = null;
+			return;
+		}
+
+		const selectedKey = getTimelineSelectionKey(availableSelectedItems[0]);
+		if (previousSingleSelectionKey.current === selectedKey) {
+			return;
+		}
+
+		previousSingleSelectionKey.current = selectedKey;
+
+		const animationFrame = requestAnimationFrame(() => {
+			const registered =
+				focusableItems.current.get(selectedKey) ??
+				marqueeSelectableItems.current.get(selectedKey);
+			const scrollParent = timelineVerticalScroll.current;
+			const rect = registered?.getRect();
+
+			if (!scrollParent || !rect) {
+				return;
+			}
+
+			const parentRect = scrollParent.getBoundingClientRect();
+			if (rect.top < parentRect.top) {
+				scrollParent.scrollTop -=
+					parentRect.top - rect.top + TIMELINE_SELECTION_FOCUS_PADDING;
+				return;
+			}
+
+			if (rect.bottom > parentRect.bottom) {
+				scrollParent.scrollTop +=
+					rect.bottom - parentRect.bottom + TIMELINE_SELECTION_FOCUS_PADDING;
+			}
+		});
+
+		return () => cancelAnimationFrame(animationFrame);
+	}, [availableSelectedItems]);
 
 	const expandParentsForSelectionItems = useCallback(
 		(items: readonly TimelineSelection[]) => {
@@ -1146,6 +1234,19 @@ export const TimelineSelectionProvider: React.FC<{
 		[],
 	);
 
+	const registerFocusableItem = useCallback(
+		(item: TimelineSelection, getRect: () => DOMRect | null) => {
+			const key = getTimelineSelectionKey(item);
+			focusableItems.current.set(key, {
+				getRect,
+			});
+			return () => {
+				focusableItems.current.delete(key);
+			};
+		},
+		[],
+	);
+
 	const getMarqueeSelectionForRect = useCallback(
 		(
 			marqueeRect: TimelineMarqueeRect,
@@ -1210,6 +1311,7 @@ export const TimelineSelectionProvider: React.FC<{
 			selectItem,
 			selectItems,
 			registerMarqueeSelectableItem,
+			registerFocusableItem,
 			getMarqueeSelection: getMarqueeSelectionForRect,
 			containsSelection,
 			clearSelection,
@@ -1221,6 +1323,7 @@ export const TimelineSelectionProvider: React.FC<{
 			selectItem,
 			selectItems,
 			registerMarqueeSelectableItem,
+			registerFocusableItem,
 			getMarqueeSelectionForRect,
 			containsSelection,
 			clearSelection,
@@ -1233,6 +1336,7 @@ export const TimelineSelectionProvider: React.FC<{
 		<CurrentTimelineSelectionContext.Provider value={currentSelection}>
 			<TimelineSelectionContext.Provider value={value}>
 				{children}
+				<TimelineEscapeKeybindings />
 				<TimelineClipboardKeybindings />
 				<TimelineDeleteKeybindings />
 			</TimelineSelectionContext.Provider>
@@ -1396,6 +1500,24 @@ export const useTimelineMarqueeSelectableItem = (
 			() => ref.current?.getBoundingClientRect() ?? null,
 		);
 	}, [item, ref, registerMarqueeSelectableItem]);
+};
+
+export const useTimelineFocusableItem = (
+	item: TimelineSelection | null,
+	ref: React.RefObject<Element | null>,
+) => {
+	const {registerFocusableItem} = useTimelineSelection();
+
+	useEffect(() => {
+		if (item === null) {
+			return;
+		}
+
+		return registerFocusableItem(
+			item,
+			() => ref.current?.getBoundingClientRect() ?? null,
+		);
+	}, [item, ref, registerFocusableItem]);
 };
 
 export const useTimelineRowSelection = (

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -220,7 +220,7 @@ export const TimelineSequenceItem: React.FC<{
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {isHighestContext} = useKeybinding();
 	const selectAsset = useSelectAsset();
-	const {onSelect, selectable, selected} =
+	const {onSelect, selectable, selected, selectionItem} =
 		useTimelineRowSelection(nodePathInfo);
 	const {selectedItems} = useTimelineSelection();
 	const containsSelection = useTimelineRowContainsSelection(nodePathInfo);
@@ -1023,6 +1023,7 @@ export const TimelineSequenceItem: React.FC<{
 			style={rowStyle}
 			selected={selected}
 			selectable={selectable}
+			selectionItem={selectionItem}
 			onSelect={onSelect}
 			showSelectedBackground
 			containsSelection={containsSelection}

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -490,6 +490,7 @@ export const TimelineSequencePropItem: React.FC<{
 			style={style}
 			selected={selection.selected}
 			selectable={selection.selectable}
+			selectionItem={selection.selectionItem}
 			onSelect={selection.onSelect}
 			showSelectedBackground
 			containsSelection={false}

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -5,10 +5,7 @@ import {useBreakpoint} from '../helpers/use-breakpoint';
 import {RULER_WIDTH} from '../state/editor-rulers';
 import {SidebarContext} from '../state/sidebar';
 import {CanvasIfSizeIsAvailable} from './CanvasIfSizeIsAvailable';
-import {
-	CurrentCompositionKeybindings,
-	TitleUpdater,
-} from './CurrentCompositionSideEffects';
+import {TitleUpdater} from './CurrentCompositionSideEffects';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
 import {ExplorerPanel} from './ExplorerPanel';
 import MobilePanel from './MobilePanel';
@@ -172,7 +169,6 @@ const TopPanelInner: React.FC<{
 					bufferStateDelayInMilliseconds={bufferStateDelayInMilliseconds}
 					readOnlyStudio={readOnlyStudio}
 				/>
-				<CurrentCompositionKeybindings readOnlyStudio={readOnlyStudio} />
 				<TitleUpdater />
 			</div>
 		</ObserveDefaultProps>


### PR DESCRIPTION
## Summary

- Add After Effects-style sequence property shortcuts in Studio: P/T/R/S for translate/opacity/rotate/scale
- Preserve existing R/T fallbacks when no matching sequence selection can handle them
- Add Escape-to-clear selection and auto-scroll newly selected single items into view
- Let arrow-key position nudging work when a child of a sequence is selected

## Testing

- `bun run build`
- `bun run stylecheck`

Closes #8568
