### PR TITLE
`remotion`: Add pixelDensity controls

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -18,7 +18,11 @@ import {
 } from './effects/use-memoized-effects.js';
 import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
 import type {InteractiveBaseProps} from './Interactive.js';
-import {baseSchema, transformSchema} from './interactivity-schema.js';
+import {
+	baseSchema,
+	transformSchema,
+	type InteractivitySchema,
+} from './interactivity-schema.js';
 import type {AbsoluteFillLayout} from './Sequence.js';
 import {Sequence} from './Sequence.js';
 import {useDelayRender} from './use-delay-render.js';
@@ -677,10 +681,19 @@ const HtmlInCanvasInner = forwardRef<
 
 HtmlInCanvasInner.displayName = 'HtmlInCanvas';
 
-const htmlInCanvasSchema = {
+export const htmlInCanvasSchema = {
 	...baseSchema,
+	pixelDensity: {
+		type: 'number',
+		min: 1,
+		max: 3,
+		step: 0.1,
+		default: 1,
+		description: 'Pixel density',
+		hiddenFromList: false,
+	},
 	...transformSchema,
-};
+} as const satisfies InteractivitySchema;
 
 const HtmlInCanvasWrapped = withInteractivitySchema({
 	Component: HtmlInCanvasInner,

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -63,7 +63,7 @@ type InnerSolidProps = MandatoryProps &
 	};
 export type SolidProps = MandatoryProps & Partial<OptionalProps>;
 
-const solidSchema = {
+export const solidSchema = {
 	...baseSchema,
 	color: {
 		type: 'color',
@@ -84,6 +84,15 @@ const solidSchema = {
 		step: 1,
 		default: 1080,
 		description: 'Height',
+		hiddenFromList: false,
+	},
+	pixelDensity: {
+		type: 'number',
+		min: 1,
+		max: 3,
+		step: 0.1,
+		default: 1,
+		description: 'Pixel density',
 		hiddenFromList: false,
 	},
 	...transformSchema,

--- a/packages/core/src/test/with-interactivity-schema-helpers.test.ts
+++ b/packages/core/src/test/with-interactivity-schema-helpers.test.ts
@@ -1,5 +1,8 @@
 import {expect, test} from 'bun:test';
+import {solidSchema} from '../effects/Solid.js';
 import {getFlatSchemaWithAllKeys} from '../flatten-schema.js';
+import {htmlInCanvasSchema} from '../HtmlInCanvas.js';
+import {Interactive} from '../Interactive.js';
 import {
 	baseSchema,
 	extendSchemaWithSequenceName,
@@ -33,6 +36,23 @@ test('baseSchema exposes common timeline fields', () => {
 			'showInTimeline',
 		].sort(),
 	);
+});
+
+test('pixelDensity is exposed only by canvas-backed component schemas', () => {
+	const pixelDensitySchema = {
+		type: 'number',
+		min: 1,
+		max: 3,
+		step: 0.1,
+		default: 1,
+		description: 'Pixel density',
+		hiddenFromList: false,
+	} as const;
+
+	expect(htmlInCanvasSchema.pixelDensity).toEqual(pixelDensitySchema);
+	expect(solidSchema.pixelDensity).toEqual(pixelDensitySchema);
+	expect('pixelDensity' in baseSchema).toBe(false);
+	expect('pixelDensity' in Interactive.baseSchema).toBe(false);
 });
 
 test('getFlatSchema(sequenceSchema) exposes every variant key', () => {


### PR DESCRIPTION
## Summary

- Add `pixelDensity` controls to `<HtmlInCanvas>` and `<Solid>` schemas with min 1, max 3, and step 0.1
- Keep `pixelDensity` out of the shared `Interactive` base schema
- Add a schema test covering the component-specific controls

Fixes #8570

## Testing

- `bun test src/test/with-interactivity-schema-helpers.test.ts src/test/solid.test.tsx src/test/html-in-canvas.test.tsx`
- `bun run build`
- `bun run stylecheck`
