### PR TITLE
`@remotion/studio-server`: Use credentialless COEP policy

### DIFF
--- a/packages/docs/docs/miscellaneous/cross-origin-isolation.mdx
+++ b/packages/docs/docs/miscellaneous/cross-origin-isolation.mdx
@@ -27,6 +27,15 @@ Cross-origin isolation is disabled by default.
 To enable cross-origin isolation on your page, the server must send the following HTTP headers:
 
 ```
+Cross-Origin-Embedder-Policy: credentialless
+Cross-Origin-Opener-Policy: same-origin
+```
+
+`credentialless` is preferred over `require-corp` because it still enables `SharedArrayBuffer` while allowing cross-origin resources (images, videos, audio) to load without requiring them to send `Cross-Origin-Resource-Policy` headers. The tradeoff is that cross-origin requests are made without credentials (cookies, HTTP authentication).
+
+If you need credentials for cross-origin resources, use `require-corp` instead:
+
+```
 Cross-Origin-Embedder-Policy: require-corp
 Cross-Origin-Opener-Policy: same-origin
 ```
@@ -34,6 +43,7 @@ Cross-Origin-Opener-Policy: same-origin
 See also:
 
 - [Enabling Cross-origin isolation in Next.js](https://vercel.com/guides/fix-shared-array-buffer-not-defined-nextjs-react#enable-cross-origin-isolation)
+- [COEP: credentialless on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#credentialless)
 
 ### In the Remotion Studio
 

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -143,7 +143,7 @@ export const startServer = async (options: {
 	const server = http.createServer((request, response) => {
 		if (options.enableCrossSiteIsolation) {
 			response.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-			response.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+			response.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
 		}
 
 		new Promise<void>((resolve) => {

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -129,7 +129,7 @@ const handleFallback = async ({
 	response.setHeader('content-type', 'text/html');
 	if (enableCrossSiteIsolation) {
 		response.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-		response.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+		response.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
 	}
 
 	const packageManager = getPackageManager({

--- a/packages/whisper-web/src/can-use-whisper-web.ts
+++ b/packages/whisper-web/src/can-use-whisper-web.ts
@@ -36,7 +36,7 @@ export const canUseWhisperWeb = async (
 			supported: false,
 			reason: WhisperWebUnsupportedReason.NotCrossOriginIsolated,
 			detailedReason:
-				'The document is not cross-origin isolated (window.crossOriginIsolated = false). This prevents the usage of SharedArrayBuffer, which is required by `@remotion/whisper-web`. Make sure the document is served with the HTTP header `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`: https://remotion.dev/docs/miscellaneous/cross-origin-isolation',
+				'The document is not cross-origin isolated (window.crossOriginIsolated = false). This prevents the usage of SharedArrayBuffer, which is required by `@remotion/whisper-web`. Make sure the document is served with the HTTP header `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: credentialless` (or `require-corp`): https://remotion.dev/docs/miscellaneous/cross-origin-isolation',
 		};
 	}
 


### PR DESCRIPTION
## Summary

Switches the Studio dev server's `Cross-Origin-Embedder-Policy` header from `require-corp` to `credentialless`. Both values enable `SharedArrayBuffer`, but `credentialless` allows cross-origin resources (images, video, audio) to load without requiring them to send `Cross-Origin-Resource-Policy` headers — a common pain point during development where users load assets from CDNs, external URLs, etc.

Also updates:
- The `@remotion/whisper-web` error message to mention `credentialless`
- The cross-origin isolation docs to recommend `credentialless` as the default, with `require-corp` documented as an alternative when credentials are needed

## Testing

- `bunx oxfmt src --check` passes on all changed packages
- Pre-commit hook (`bun pre-commit.ts`) passes
- Existing unit tests are unrelated to header configuration

## Tradeoff

`credentialless` makes cross-origin requests without credentials (cookies, HTTP authentication). Users who need authenticated cross-origin resources can still set `require-corp` manually on their production server. The Studio dev server benefits from the more permissive policy since development often involves loading assets from various origins.

Fixes #8389