### PR TITLE
`@remotion/studio`: Refresh inspector stack on selection change

### DIFF
--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -187,5 +187,12 @@ export const SequenceSelectionInspector: React.FC<{
 		return <InspectorMessage>Sequence inspector unavailable</InspectorMessage>;
 	}
 
-	return <SequenceExpandedInspector track={track} />;
+	const stackKey = track.sequence.getStack();
+
+	return (
+		<SequenceExpandedInspector
+			key={stackKey ?? track.sequence.id}
+			track={track}
+		/>
+	);
 };


### PR DESCRIPTION
## Summary
- Remount the sequence inspector details when the selected sequence stack changes.
- Prevent the inspector source location from staying on the initially selected sequence.

## Testing
- bunx oxfmt src --write (packages/studio)
- bun test packages/studio/src/test/timeline-selection.test.ts packages/studio/src/test/inspector-selection.test.ts packages/studio/src/test/timeline-keyframes.test.ts
- bunx tsc --noEmit --pretty false --project packages/studio/tsconfig.json
- bun run build
- bun run stylecheck
