### PR TITLE
`@remotion/media`: Use CPU alpha decode without WebGL2

### DIFF
--- a/packages/media/src/get-sink.ts
+++ b/packages/media/src/get-sink.ts
@@ -46,7 +46,7 @@ export const getSink = (
 			},
 			`Sink for ${src} was not found, creating new sink`,
 		);
-		promise = getSinks(src, credentials, normalizedRequestInit);
+		promise = getSinks(src, logLevel, credentials, normalizedRequestInit);
 		sinkPromises[cacheKey] = promise;
 	}
 

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -9,6 +9,8 @@ import {
 	VideoSampleSink,
 	WEBM,
 } from 'mediabunny';
+import type {LogLevel} from 'remotion';
+import {Internals} from 'remotion';
 import {canBrowserUseWebGl2} from '../browser-can-use-webgl2';
 import {getDurationOrCompute} from '../get-duration-or-compute';
 import {resolveAudioTrack} from '../helpers/resolve-audio-track';
@@ -59,6 +61,7 @@ const getFormatOrNullOrNetworkError = async (
 
 export const getSinks = async (
 	src: string,
+	logLevel: LogLevel,
 	credentials: RequestCredentials | undefined,
 	requestInit?: MediaRequestInit,
 ) => {
@@ -120,7 +123,10 @@ export const getSinks = async (
 
 		const hasAlpha = startPacket?.sideData.alpha;
 		if (hasAlpha && !canBrowserUseWebGl2()) {
-			return 'cannot-decode-alpha';
+			Internals.Log.warn(
+				{logLevel, tag: '@remotion/media'},
+				`WebGL2 is not available, using the non-fast CPU path to decode alpha for ${src}.`,
+			);
 		}
 
 		return {


### PR DESCRIPTION
## Summary

- Keep using Mediabunny for alpha video extraction when WebGL2 is unavailable
- Log a warning that the non-fast CPU alpha decode path is being used instead of falling back to OffthreadVideo

## Testing

- bunx oxfmt src --write (packages/media)
- bun run build
- bun run stylecheck
