### PR TITLE
`remotion`: Cancel in-progress prefetch downloads on `free()`

### DIFF
--- a/packages/core/src/prefetch.ts
+++ b/packages/core/src/prefetch.ts
@@ -145,16 +145,16 @@ export const prefetch = (
 		resolve = res;
 		reject = rej;
 	});
+	void waitUntilDone.catch(() => undefined);
 
 	const controller = new AbortController();
-	let canBeAborted = true;
+	let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
 
 	fetch(srcWithoutHash, {
 		signal: controller.signal,
 		credentials: options?.credentials ?? undefined,
 	})
 		.then((res) => {
-			canBeAborted = false;
 			if (canceled) {
 				return null;
 			}
@@ -183,10 +183,11 @@ export const prefetch = (
 				throw new Error(`HTTP response of ${srcWithoutHash} has no body`);
 			}
 
-			const reader = res.body.getReader();
+			const responseReader = res.body.getReader();
+			reader = responseReader;
 
 			return getBlobFromReader({
-				reader,
+				reader: responseReader,
 				contentType: options?.contentType ?? headerContentType ?? null,
 				contentLength: res.headers.get('Content-Length')
 					? parseInt(res.headers.get('Content-Length')!, 10)
@@ -195,7 +196,7 @@ export const prefetch = (
 			});
 		})
 		.then((buf) => {
-			if (!buf) {
+			if (!buf || canceled) {
 				return;
 			}
 
@@ -256,12 +257,18 @@ export const prefetch = (
 					return copy;
 				});
 			} else {
-				canceled = true;
-				if (canBeAborted) {
-					try {
-						controller.abort(new Error('free() called'));
-					} catch {}
+				if (canceled) {
+					return;
 				}
+
+				canceled = true;
+				const cancellationError = new Error('free() called');
+				reject(cancellationError);
+				try {
+					controller.abort(cancellationError);
+				} catch {}
+
+				reader?.cancel(cancellationError).catch(() => undefined);
 			}
 		},
 		waitUntilDone: () => {

--- a/packages/core/src/prefetch.ts
+++ b/packages/core/src/prefetch.ts
@@ -145,7 +145,7 @@ export const prefetch = (
 		resolve = res;
 		reject = rej;
 	});
-	void waitUntilDone.catch(() => undefined);
+	waitUntilDone.catch(() => undefined);
 
 	const controller = new AbortController();
 	let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;

--- a/packages/core/src/test/prefetch.test.ts
+++ b/packages/core/src/test/prefetch.test.ts
@@ -15,7 +15,7 @@ describe('prefetch cancellation', () => {
 				request.signal = init?.signal ?? null;
 				return new Promise<Response>(() => undefined);
 			},
-		) as typeof fetch;
+		) as unknown as typeof fetch;
 
 		const prefetchHandle = prefetch('https://example.com/video.mp4');
 		const waitUntilDone = prefetchHandle.waitUntilDone();
@@ -28,7 +28,7 @@ describe('prefetch cancellation', () => {
 	test('cancels the response body after receiving the response', async () => {
 		const request: {signal: AbortSignal | null} = {signal: null};
 		let bodyWasCanceled = false;
-		let reportProgress = () => undefined;
+		let reportProgress: () => void = () => undefined;
 		const progressReported = new Promise<void>((resolve) => {
 			reportProgress = resolve;
 		});
@@ -57,7 +57,7 @@ describe('prefetch cancellation', () => {
 					}),
 				);
 			},
-		) as typeof fetch;
+		) as unknown as typeof fetch;
 
 		const prefetchHandle = prefetch('https://example.com/video.mp4', {
 			onProgress: () => reportProgress(),

--- a/packages/core/src/test/prefetch.test.ts
+++ b/packages/core/src/test/prefetch.test.ts
@@ -1,0 +1,73 @@
+import {afterEach, describe, expect, mock, test} from 'bun:test';
+import {prefetch} from '../prefetch.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe('prefetch cancellation', () => {
+	test('aborts before receiving the response', async () => {
+		const request: {signal: AbortSignal | null} = {signal: null};
+		globalThis.fetch = mock(
+			(_input: RequestInfo | URL, init?: RequestInit) => {
+				request.signal = init?.signal ?? null;
+				return new Promise<Response>(() => undefined);
+			},
+		) as typeof fetch;
+
+		const prefetchHandle = prefetch('https://example.com/video.mp4');
+		const waitUntilDone = prefetchHandle.waitUntilDone();
+		prefetchHandle.free();
+
+		expect(request.signal?.aborted).toBe(true);
+		await expect(waitUntilDone).rejects.toThrow('free() called');
+	});
+
+	test('cancels the response body after receiving the response', async () => {
+		const request: {signal: AbortSignal | null} = {signal: null};
+		let bodyWasCanceled = false;
+		let reportProgress = () => undefined;
+		const progressReported = new Promise<void>((resolve) => {
+			reportProgress = resolve;
+		});
+		let sentFirstChunk = false;
+		const body = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				if (!sentFirstChunk) {
+					sentFirstChunk = true;
+					controller.enqueue(new Uint8Array([1, 2, 3]));
+				}
+			},
+			cancel() {
+				bodyWasCanceled = true;
+			},
+		});
+
+		globalThis.fetch = mock(
+			(_input: RequestInfo | URL, init?: RequestInit) => {
+				request.signal = init?.signal ?? null;
+				return Promise.resolve(
+					new Response(body, {
+						headers: {
+							'Content-Length': '6',
+							'Content-Type': 'video/mp4',
+						},
+					}),
+				);
+			},
+		) as typeof fetch;
+
+		const prefetchHandle = prefetch('https://example.com/video.mp4', {
+			onProgress: () => reportProgress(),
+		});
+		const waitUntilDone = prefetchHandle.waitUntilDone();
+		await progressReported;
+		prefetchHandle.free();
+
+		expect(request.signal?.aborted).toBe(true);
+		await expect(waitUntilDone).rejects.toThrow('free() called');
+		expect(bodyWasCanceled).toBe(true);
+	});
+});

--- a/packages/core/src/test/prefetch.test.ts
+++ b/packages/core/src/test/prefetch.test.ts
@@ -1,21 +1,25 @@
-import {afterEach, describe, expect, mock, test} from 'bun:test';
+import {afterEach, beforeEach, describe, expect, mock, test} from 'bun:test';
 import {prefetch} from '../prefetch.js';
 
 const originalFetch = globalThis.fetch;
+const originalNodeEnv = window.process.env.NODE_ENV;
+
+beforeEach(() => {
+	window.process.env.NODE_ENV = 'development';
+});
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
+	window.process.env.NODE_ENV = originalNodeEnv;
 });
 
 describe('prefetch cancellation', () => {
 	test('aborts before receiving the response', async () => {
 		const request: {signal: AbortSignal | null} = {signal: null};
-		globalThis.fetch = mock(
-			(_input: RequestInfo | URL, init?: RequestInit) => {
-				request.signal = init?.signal ?? null;
-				return new Promise<Response>(() => undefined);
-			},
-		) as unknown as typeof fetch;
+		globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+			request.signal = init?.signal ?? null;
+			return new Promise<Response>(() => undefined);
+		}) as unknown as typeof fetch;
 
 		const prefetchHandle = prefetch('https://example.com/video.mp4');
 		const waitUntilDone = prefetchHandle.waitUntilDone();
@@ -45,19 +49,17 @@ describe('prefetch cancellation', () => {
 			},
 		});
 
-		globalThis.fetch = mock(
-			(_input: RequestInfo | URL, init?: RequestInit) => {
-				request.signal = init?.signal ?? null;
-				return Promise.resolve(
-					new Response(body, {
-						headers: {
-							'Content-Length': '6',
-							'Content-Type': 'video/mp4',
-						},
-					}),
-				);
-			},
-		) as unknown as typeof fetch;
+		globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+			request.signal = init?.signal ?? null;
+			return Promise.resolve(
+				new Response(body, {
+					headers: {
+						'Content-Length': '6',
+						'Content-Type': 'video/mp4',
+					},
+				}),
+			);
+		}) as unknown as typeof fetch;
 
 		const prefetchHandle = prefetch('https://example.com/video.mp4', {
 			onProgress: () => reportProgress(),


### PR DESCRIPTION
## Summary

- Abort prefetch requests even after response headers have arrived
- Cancel the active response body reader to stop downloading
- Reject `waitUntilDone()` when `free()` cancels the prefetch
- Prevent creating a Blob URL from a partial response
- Make repeated cancellation idempotent

## Testing

Added regression tests covering cancellation:

- Before receiving the response
- While reading the response body

Tests were not run locally because dependencies are unavailable and the installed Bun version is 1.0.0 instead of the required 1.3.3.

## Documentation

No documentation change is required. The existing `free()` documentation already states that an ongoing prefetch is aborted; this PR makes the implementation match that behavior.

## Tradeoffs

Downloaded partial data is discarded. A subsequent `prefetch()` call starts a new request rather than resuming the previous download.