### PR TITLE
Docs: Add WebKit WebCodecs visibleRect bug

### DIFF
--- a/packages/docs/docs/mediabunny/webcodecs-bugs.mdx
+++ b/packages/docs/docs/mediabunny/webcodecs-bugs.mdx
@@ -15,6 +15,7 @@ It serves as a tracker for overall progress and known issues.
 | [H.264 VideoDecoder key frame detection fails for packets with an AUD not at the start](https://issues.chromium.org/issues/519012430)                     | Chrome  | @Vanilagy     | No        |
 | [YUV VideoFrame draws onto a canvas are 5-10x slower when resized](https://issues.chromium.org/issues/463233709)                                         | Chrome  | @Vanilagy     | Yes       |
 | [AAC AudioEncoder produces incorrect decoder config description](https://bugs.webkit.org/show_bug.cgi?id=302253)                                         | Safari  | @Vanilagy     | No        |
+| [ArrayBuffer-backed YUV VideoFrame with visibleRect is rendered incorrectly (chroma channels are offset)](https://bugs.webkit.org/show_bug.cgi?id=317524) | Safari  | @Vanilagy     | No        |
 | [AudioData.copyTo() crashes the tab with valid conversion](https://bugs.webkit.org/show_bug.cgi?id=302521)                                               | Safari  | @JonnyBurger  | Yes       |
 | [AudioEncoder emits humorous AAC bitrate suggestions in error message](https://issues.chromium.org/issues/459832207)                                     | Chrome  | @Vanilagy     | Yes       |
 | [VideoEncoder encodeQueueSize behaves unpredictably after calling encode()](https://issues.chromium.org/issues/459838287)                                | Chrome  | @Vanilagy     | Won't fix |


### PR DESCRIPTION
## Summary

- Add WebKit bug 317524 to the Mediabunny WebCodecs bug tracker docs
- Mark it as a Safari issue filed by @Vanilagy with fixed state `No`

## Verification

- `bunx oxfmt src --write` in `packages/docs`
- `bun run build`
- `bun run stylecheck`
