### PR TITLE
`@remotion/studio-server`: Validate API route origins

### DIFF
--- a/packages/studio-server/src/preview-server/handler.ts
+++ b/packages/studio-server/src/preview-server/handler.ts
@@ -2,6 +2,7 @@ import type {IncomingMessage, ServerResponse} from 'node:http';
 import type {LogLevel} from '@remotion/renderer';
 import type {ApiHandler, QueueMethods} from './api-types';
 import {parseRequestBody} from './parse-body';
+import {validateSameOrigin} from './validate-same-origin';
 
 export const handleRequest = async <Req, Res>({
 	remotionRoot,
@@ -29,6 +30,8 @@ export const handleRequest = async <Req, Res>({
 		response.end();
 		return;
 	}
+
+	validateSameOrigin(request);
 
 	response.setHeader('content-type', 'application/json');
 	response.writeHead(200);

--- a/packages/studio-server/src/test/handler.test.ts
+++ b/packages/studio-server/src/test/handler.test.ts
@@ -1,0 +1,113 @@
+import {expect, test} from 'bun:test';
+import type {IncomingMessage, ServerResponse} from 'node:http';
+import {Readable} from 'node:stream';
+import {handleRequest} from '../preview-server/handler';
+
+const makeRequest = ({
+	body,
+	host,
+	origin,
+}: {
+	body: unknown;
+	host: string;
+	origin: string;
+}) => {
+	const request = Readable.from([JSON.stringify(body)]) as IncomingMessage;
+	request.method = 'POST';
+	request.headers = {
+		host,
+		origin,
+	};
+
+	return request;
+};
+
+const makeResponse = () => {
+	const response = {
+		body: '',
+		headers: {} as Record<string, string>,
+		statusCode: 0,
+		end(chunk?: string) {
+			if (chunk) {
+				this.body += chunk;
+			}
+		},
+		setHeader(key: string, value: string) {
+			this.headers[key] = value;
+		},
+		writeHead(statusCode: number) {
+			this.statusCode = statusCode;
+		},
+	};
+
+	return response as ServerResponse & typeof response;
+};
+
+test('rejects cross-origin API requests before calling the handler', async () => {
+	const response = makeResponse();
+	let didCallHandler = false;
+
+	await expect(
+		handleRequest({
+			binariesDirectory: null,
+			entryPoint: '',
+			handler: () => {
+				didCallHandler = true;
+				return Promise.resolve({});
+			},
+			logLevel: 'info',
+			methods: {
+				addJob: () => undefined,
+				cancelJob: () => undefined,
+				removeJob: () => undefined,
+			},
+			publicDir: '',
+			remotionRoot: '',
+			request: makeRequest({
+				body: {relativePath: 'logo.png'},
+				host: 'localhost:3000',
+				origin: 'https://attacker.example',
+			}),
+			response,
+		}),
+	).rejects.toThrow('Request from different origin not allowed');
+
+	expect(didCallHandler).toBe(false);
+	expect(response.statusCode).toBe(0);
+});
+
+test('allows same-origin API requests', async () => {
+	const response = makeResponse();
+
+	await handleRequest({
+		binariesDirectory: null,
+		entryPoint: '',
+		handler: ({input}) => {
+			return Promise.resolve({input});
+		},
+		logLevel: 'info',
+		methods: {
+			addJob: () => undefined,
+			cancelJob: () => undefined,
+			removeJob: () => undefined,
+		},
+		publicDir: '',
+		remotionRoot: '',
+		request: makeRequest({
+			body: {relativePath: 'logo.png'},
+			host: 'localhost:3000',
+			origin: 'http://localhost:3000',
+		}),
+		response,
+	});
+
+	expect(response.statusCode).toBe(200);
+	expect(JSON.parse(response.body)).toEqual({
+		data: {
+			input: {
+				relativePath: 'logo.png',
+			},
+		},
+		success: true,
+	});
+});


### PR DESCRIPTION
## Summary

- Validate same-origin requests in the shared Studio server API handler
- Cover rejected cross-origin API requests and allowed same-origin requests with tests

## Test plan

- `bun test src/test/handler.test.ts` in `packages/studio-server`
- `bun run build`
- `bun run stylecheck`
