### PR TITLE
`@remotion/studio-shared`: Support keyframes for missing props

### DIFF
--- a/packages/studio-server/src/test/add-keyframes.test.ts
+++ b/packages/studio-server/src/test/add-keyframes.test.ts
@@ -40,6 +40,49 @@ const effectSchema = {
 	},
 } satisfies InteractivitySchema;
 
+const linearProgressiveBlurInput = `import {linearProgressiveBlur} from '@remotion/effects/linear-progressive-blur';
+import {HtmlInCanvas} from '@remotion/html-in-canvas';
+import {Solid} from 'remotion';
+
+export const Comp = () => {
+\treturn (
+\t\t<HtmlInCanvas
+\t\t\twidth={1280}
+\t\t\theight={720}
+\t\t\teffects={[
+\t\t\t\tlinearProgressiveBlur({
+\t\t\t\t\tstart: [0.5, 0.5],
+\t\t\t\t\tend: [0.816, -0.06],
+\t\t\t\t}),
+\t\t\t]}
+\t\t>
+\t\t\t<Solid width={1280} height={720} color="white" />
+\t\t</HtmlInCanvas>
+\t);
+};
+`;
+
+const linearProgressiveBlurSchema = {
+	start: {
+		type: 'uv-coordinate',
+		default: [0, 0.5],
+	},
+	end: {
+		type: 'uv-coordinate',
+		default: [1, 0.5],
+	},
+	startBlur: {
+		type: 'number',
+		default: 0,
+		hiddenFromList: false,
+	},
+	endBlur: {
+		type: 'number',
+		default: 50,
+		hiddenFromList: false,
+	},
+} satisfies InteractivitySchema;
+
 test('addKeyframes batches sequence and effect adds into one undo entry', async () => {
 	const cleanupFileWatcher = setFileWatcherRegistry(
 		createFileWatcherRegistry(),
@@ -105,6 +148,60 @@ test('addKeyframes batches sequence and effect adds into one undo entry', async 
 
 		expect(popRedo()).toEqual({success: true});
 		expect(readFileSync(filePath, 'utf-8')).toBe(output);
+	} finally {
+		clearUndoStackForTests();
+		cleanupLiveEvents();
+		cleanupFileWatcher();
+		rmSync(dir, {force: true, recursive: true});
+	}
+});
+
+test('addKeyframes adds a missing effect prop before keyframing it', async () => {
+	const cleanupFileWatcher = setFileWatcherRegistry(
+		createFileWatcherRegistry(),
+	);
+	const cleanupLiveEvents = setLiveEventsListener({
+		addNewClientListener: () => () => undefined,
+		closeConnections: () => Promise.resolve(),
+		router: () => Promise.resolve(),
+		sendEventToClient: () => undefined,
+		sendEventToClientId: () => undefined,
+	});
+	const dir = mkdtempSync(join(tmpdir(), 'remotion-add-missing-effect-'));
+	const fileName = 'Comp.tsx';
+	const filePath = join(dir, fileName);
+	const nodePath = {
+		absolutePath: fileName,
+		nodePath: lineColumnToNodePath(linearProgressiveBlurInput, 7),
+		sequenceKeys: [],
+		effectKeys: [['start', 'end', 'startBlur', 'endBlur']],
+	};
+
+	try {
+		writeFileSync(filePath, linearProgressiveBlurInput);
+
+		await addKeyframes({
+			sequenceKeyframes: [],
+			effectKeyframes: [
+				{
+					fileName,
+					sequenceNodePath: nodePath,
+					effectIndex: 0,
+					key: 'startBlur',
+					frame: 55,
+					value: JSON.stringify(12),
+					schema: linearProgressiveBlurSchema,
+				},
+			],
+			clientId: 'test-client',
+			remotionRoot: dir,
+			logLevel: 'error',
+		});
+
+		const output = readFileSync(filePath, 'utf-8');
+		expect(output).toContain('startBlur: interpolate(frame, [55], [12], {');
+		expect(output).toContain("extrapolateLeft: 'clamp'");
+		expect(output).toContain("extrapolateRight: 'clamp'");
 	} finally {
 		clearUndoStackForTests();
 		cleanupLiveEvents();

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -1,6 +1,7 @@
 import {
 	type CanUpdateSequencePropStatus,
 	type CanUpdateSequencePropsResponse,
+	type InteractivitySchemaField,
 	type InteractivitySchema,
 } from 'remotion';
 import {LINEAR_KEYFRAME_EASING} from './keyframe-easing-presets';
@@ -73,6 +74,51 @@ const addKeyframeToPropStatus = ({
 	return status;
 };
 
+const findFieldInSchema = (
+	schema: InteractivitySchema,
+	key: string,
+): InteractivitySchemaField | undefined => {
+	if (key in schema) {
+		return schema[key];
+	}
+
+	for (const field of Object.values(schema)) {
+		if (field.type !== 'enum') {
+			continue;
+		}
+
+		for (const variant of Object.values(field.variants)) {
+			const found = findFieldInSchema(variant, key);
+			if (found) {
+				return found;
+			}
+		}
+	}
+
+	return undefined;
+};
+
+const getMissingPropStatus = ({
+	schema,
+	fieldKey,
+}: {
+	schema: InteractivitySchema | null;
+	fieldKey: string;
+}): CanUpdateSequencePropStatus => {
+	const field = schema ? findFieldInSchema(schema, fieldKey) : undefined;
+	if (field && field.type !== 'hidden' && field.default !== undefined) {
+		return {
+			status: 'static',
+			codeValue: field.default,
+		};
+	}
+
+	return {
+		status: 'static',
+		codeValue: undefined,
+	};
+};
+
 export const optimisticAddSequenceKeyframe = ({
 	previous,
 	fieldKey,
@@ -94,10 +140,9 @@ export const optimisticAddSequenceKeyframe = ({
 		return previous;
 	}
 
-	const status = previous.props[fieldKey];
-	if (!status) {
-		return previous;
-	}
+	const status =
+		previous.props[fieldKey] ??
+		getMissingPropStatus({schema: schema ?? null, fieldKey});
 
 	return {
 		...previous,
@@ -149,10 +194,9 @@ export const optimisticAddEffectKeyframe = ({
 		return previous;
 	}
 
-	const status = target.props[fieldKey];
-	if (!status) {
-		return previous;
-	}
+	const status =
+		target.props[fieldKey] ??
+		getMissingPropStatus({schema: schema ?? null, fieldKey});
 
 	const updatedEffect = {
 		...target,

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -41,6 +41,41 @@ test('optimisticAddSequenceKeyframe converts a static prop to a single keyframe'
 	expect(status.clamping).toEqual({left: 'clamp', right: 'clamp'});
 });
 
+test('optimisticAddSequenceKeyframe adds a missing prop before keyframing it', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {},
+		effects: [],
+	};
+	const schema = {
+		opacity: {
+			type: 'number',
+			default: 1,
+			hiddenFromList: false,
+		},
+	} satisfies InteractivitySchema;
+
+	const updated = optimisticAddSequenceKeyframe({
+		previous,
+		fieldKey: 'opacity',
+		frame: 25,
+		value: 0.75,
+		schema,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const status = updated.props.opacity;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([{frame: 25, value: 0.75}]);
+	expect(status.interpolationFunction).toBe('interpolate');
+});
+
 test('optimisticAddSequenceKeyframe uses interpolate for translate fields', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,
@@ -367,4 +402,53 @@ test('optimisticAddEffectKeyframe converts a static prop to a single keyframe', 
 	expect(status.keyframes).toEqual([{frame: 30, value: 0.5}]);
 	expect(status.easing).toEqual([]);
 	expect(status.clamping).toEqual({left: 'clamp', right: 'clamp'});
+});
+
+test('optimisticAddEffectKeyframe adds a missing prop before keyframing it', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {},
+		effects: [
+			{
+				canUpdate: true,
+				effectIndex: 0,
+				callee: 'linearProgressiveBlur',
+				importPath: '@remotion/effects/linear-progressive-blur',
+				props: {},
+			},
+		],
+	};
+	const schema = {
+		startBlur: {
+			type: 'number',
+			default: 0,
+			hiddenFromList: false,
+		},
+	} satisfies InteractivitySchema;
+
+	const updated = optimisticAddEffectKeyframe({
+		previous,
+		effectIndex: 0,
+		fieldKey: 'startBlur',
+		frame: 55,
+		value: 12,
+		schema,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const effect = updated.effects[0];
+	if (!effect.canUpdate) {
+		throw new Error('expected updateable effect');
+	}
+
+	const status = effect.props.startBlur;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.keyframes).toEqual([{frame: 55, value: 12}]);
+	expect(status.interpolationFunction).toBe('interpolate');
 });


### PR DESCRIPTION
Fixes #8558.

## Summary

- Treat omitted sequence/effect props as editable static values in optimistic keyframe additions
- Use schema defaults for missing props when available, matching the Studio server codemod behavior
- Add regression coverage for adding a `startBlur` keyframe to `linearProgressiveBlur({ start, end })`

## Testing

- `bun test packages/studio-shared/src/test/optimistic-add-keyframe.test.ts packages/studio-server/src/test/add-keyframes.test.ts`
- `bun run build`
- `bunx turbo run lint formatting --filter='@remotion/studio-shared' --filter='@remotion/studio-server' --no-update-notifier`

`bun run stylecheck` was also attempted, but the full monorepo run failed in unrelated `@remotion/lambda-php#lint` because this machine is missing PHP `ext-iconv`.
