### PR TITLE
`@remotion/studio`: Render active outline last

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -104,6 +104,21 @@ const outlineContainer: React.CSSProperties = {
 	overflow: 'visible',
 };
 
+export const orderOutlinesForRendering = ({
+	outlines,
+	targetsByKey,
+}: {
+	readonly outlines: readonly SelectedOutline[];
+	readonly targetsByKey: ReadonlyMap<string, SelectedOutlineTarget>;
+}): readonly SelectedOutline[] => {
+	return [...outlines].sort((a, b) => {
+		const aSelected = targetsByKey.get(a.key)?.selected ?? false;
+		const bSelected = targetsByKey.get(b.key)?.selected ?? false;
+
+		return Number(aSelected) - Number(bSelected);
+	});
+};
+
 export const SelectedOutlineOverlay: React.FC<{
 	readonly scale: number;
 }> = ({scale}) => {
@@ -430,6 +445,9 @@ export const SelectedOutlineOverlay: React.FC<{
 	const targetsByKey = useMemo(() => {
 		return new Map(outlineTargets.map((target) => [target.key, target]));
 	}, [outlineTargets]);
+	const outlinesForRendering = useMemo(() => {
+		return orderOutlinesForRendering({outlines, targetsByKey});
+	}, [outlines, targetsByKey]);
 	const allDragTargets = useMemo(() => {
 		return outlineTargets.flatMap((target) =>
 			(target.selected || target.containsSelection) && target.drag !== null
@@ -788,7 +806,7 @@ export const SelectedOutlineOverlay: React.FC<{
 			height="100%"
 			aria-hidden="true"
 		>
-			{outlines.map((outline) => (
+			{outlinesForRendering.map((outline) => (
 				<SelectedOutlineElement
 					key={outline.key}
 					allDragTargets={allDragTargets}
@@ -805,14 +823,14 @@ export const SelectedOutlineOverlay: React.FC<{
 				/>
 			))}
 			{/* Keep UV controls above every transparent outline polygon so SVG hit-testing reaches the handles first. */}
-			{outlines.map((outline) => (
+			{outlinesForRendering.map((outline) => (
 				<SelectedOutlineUvHandleConnectionLayer
 					key={`${outline.key}-uv-connection-lines`}
 					outline={outline}
 					target={targetsByKey.get(outline.key)}
 				/>
 			))}
-			{outlines.map((outline) => (
+			{outlinesForRendering.map((outline) => (
 				<SelectedOutlineUvHandleCircleLayer
 					key={`${outline.key}-uv-handles`}
 					onDraggingChange={onDraggingChange}

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -10,7 +10,9 @@ import {
 } from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {getInspectorSelectableItems} from '../components/InspectorSequenceSection';
+import type {SelectedOutline} from '../components/selected-outline-geometry';
 import {getSelectedTransformOriginInfo} from '../components/selected-outline-measurement';
+import type {SelectedOutlineTarget} from '../components/selected-outline-types';
 import {
 	constrainUv,
 	getSelectedUvHandles,
@@ -43,6 +45,7 @@ import {
 	getSequencesWithSelectableOutlines,
 	getTransformedSvgViewportPoints,
 	isSelectedOutlineDragPastThreshold,
+	orderOutlinesForRendering,
 	snapSelectedOutlineRotationDeltaDegrees,
 	snapSelectedOutlineUv,
 	snapSelectedOutlineTransformOriginUv,
@@ -1398,6 +1401,40 @@ test('Canvas outline hit targets render nested sequences above parents', () => {
 	expect(outlines.map((outline) => outline.key)).toEqual([
 		getTimelineSequenceSelectionKey(parentNodePathInfo),
 		getTimelineSequenceSelectionKey(childNodePathInfo),
+	]);
+});
+
+test('Canvas outline rendering puts selected outlines last', () => {
+	const makeOutline = (key: string): SelectedOutline => ({
+		key,
+		dimensions: null,
+		points: [
+			{x: 0, y: 0},
+			{x: 10, y: 0},
+			{x: 10, y: 10},
+			{x: 0, y: 10},
+		],
+	});
+	const makeTarget = (selected: boolean): SelectedOutlineTarget =>
+		({selected}) as SelectedOutlineTarget;
+
+	const orderedOutlines = orderOutlinesForRendering({
+		outlines: [
+			makeOutline('parent'),
+			makeOutline('child'),
+			makeOutline('sibling'),
+		],
+		targetsByKey: new Map([
+			['parent', makeTarget(true)],
+			['child', makeTarget(false)],
+			['sibling', makeTarget(false)],
+		]),
+	});
+
+	expect(orderedOutlines.map((outline) => outline.key)).toEqual([
+		'child',
+		'sibling',
+		'parent',
 	]);
 });
 


### PR DESCRIPTION
## Summary

- Render selected Studio canvas outlines after inactive outlines so the active selection paints in the foreground
- Reuse the selected-last order for outline polygons and UV handle layers
- Add a regression test for selected outline render order

Fixes #8551.

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run --cwd packages/studio formatting`
- `bun run --cwd packages/studio lint`
- `bun run build`
- `bun run stylecheck` *(fails locally in `@remotion/lambda-php` because PHP is missing the `iconv` extension; Studio formatting passed before that failure)*
