### PR TITLE
`@remotion/player`: Avoid AudioContext for muted players

### DIFF
--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -19,7 +19,7 @@ import {useMediaInTimeline} from '../use-media-in-timeline.js';
 import {useMediaPlayback} from '../use-media-playback.js';
 import {useMediaTag} from '../use-media-tag.js';
 import {
-	useMediaMutedState,
+	usePlayerMutedState,
 	useMediaVolumeState,
 } from '../volume-position-state.js';
 import {evaluateVolume} from '../volume-prop.js';
@@ -94,7 +94,7 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 	}
 
 	const [mediaVolume] = useMediaVolumeState();
-	const [mediaMuted] = useMediaMutedState();
+	const [playerMuted] = usePlayerMutedState();
 
 	const volumePropFrame = useFrameForVolumeProp(
 		loopVolumeCurveBehavior ?? 'repeat',
@@ -126,7 +126,7 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 
 	const propsToPass = useMemo((): AudioHTMLAttributes<HTMLAudioElement> => {
 		return {
-			muted: muted || mediaMuted || userPreferredVolume <= 0,
+			muted: muted || playerMuted || userPreferredVolume <= 0,
 			src: preloadedSrc,
 			loop: _remotionInternalNativeLoopPassed,
 			crossOrigin: crossOriginValue,
@@ -134,7 +134,7 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		};
 	}, [
 		_remotionInternalNativeLoopPassed,
-		mediaMuted,
+		playerMuted,
 		muted,
 		nativeProps,
 		preloadedSrc,

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -247,7 +247,7 @@ import type {
 import {
 	MediaVolumeContext,
 	SetMediaVolumeContext,
-	useMediaMutedState,
+	usePlayerMutedState,
 	useMediaVolumeState,
 } from './volume-position-state.js';
 import {evaluateVolume} from './volume-prop.js';
@@ -308,7 +308,7 @@ export const Internals = {
 	useVideo,
 	getRoot,
 	useMediaVolumeState,
-	useMediaMutedState,
+	usePlayerMutedState,
 	useMediaInTimeline,
 	useLazyComponent,
 	truthy,

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -24,7 +24,7 @@ import {useMediaTag} from '../use-media-tag.js';
 import {useVideoConfig} from '../use-video-config.js';
 import {VERSION} from '../version.js';
 import {
-	useMediaMutedState,
+	usePlayerMutedState,
 	useMediaVolumeState,
 } from '../volume-position-state.js';
 import {evaluateVolume} from '../volume-prop.js';
@@ -146,7 +146,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 	}
 
 	const [mediaVolume] = useMediaVolumeState();
-	const [mediaMuted] = useMediaMutedState();
+	const [playerMuted] = usePlayerMutedState();
 
 	const userPreferredVolume = evaluateVolume({
 		frame: volumePropFrame,
@@ -354,7 +354,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		<video
 			{...nativeProps}
 			ref={videoRef}
-			muted={muted || mediaMuted || userPreferredVolume <= 0}
+			muted={muted || playerMuted || userPreferredVolume <= 0}
 			playsInline
 			src={actualSrc}
 			loop={_remotionInternalNativeLoopPassed}

--- a/packages/core/src/volume-position-state.ts
+++ b/packages/core/src/volume-position-state.ts
@@ -1,22 +1,22 @@
 import {createContext, useContext, useMemo} from 'react';
 
 export type MediaVolumeContextValue = {
-	mediaMuted: boolean;
+	playerMuted: boolean;
 	mediaVolume: number;
 };
 
 export type SetMediaVolumeContextValue = {
-	setMediaMuted: (u: React.SetStateAction<boolean>) => void;
+	setPlayerMuted: (u: React.SetStateAction<boolean>) => void;
 	setMediaVolume: (u: number) => void;
 };
 
 export const MediaVolumeContext = createContext<MediaVolumeContextValue>({
-	mediaMuted: false,
+	playerMuted: false,
 	mediaVolume: 1,
 });
 
 export const SetMediaVolumeContext = createContext<SetMediaVolumeContextValue>({
-	setMediaMuted: () => {
+	setPlayerMuted: () => {
 		throw new Error('default');
 	},
 	setMediaVolume: () => {
@@ -34,16 +34,16 @@ export const useMediaVolumeState = (): MediaVolumeReturnType => {
 	}, [mediaVolume, setMediaVolume]);
 };
 
-type MediaMutedReturnType = readonly [
+type PlayerMutedReturnType = readonly [
 	boolean,
 	(u: React.SetStateAction<boolean>) => void,
 ];
 
-export const useMediaMutedState = (): MediaMutedReturnType => {
-	const {mediaMuted} = useContext(MediaVolumeContext);
-	const {setMediaMuted} = useContext(SetMediaVolumeContext);
+export const usePlayerMutedState = (): PlayerMutedReturnType => {
+	const {playerMuted} = useContext(MediaVolumeContext);
+	const {setPlayerMuted} = useContext(SetMediaVolumeContext);
 
 	return useMemo(() => {
-		return [mediaMuted, setMediaMuted];
-	}, [mediaMuted, setMediaMuted]);
+		return [playerMuted, setPlayerMuted];
+	}, [playerMuted, setPlayerMuted]);
 };

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -18,7 +18,7 @@ const {
 	useUnsafeVideoConfig,
 	Timeline,
 	SharedAudioContext,
-	useMediaMutedState,
+	usePlayerMutedState,
 	useMediaVolumeState,
 	useFrameForVolumeProp,
 	evaluateVolume,
@@ -88,7 +88,7 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 	const sharedAudioContext = useContext(SharedAudioContext);
 	const buffer = useBufferState();
 
-	const [mediaMuted] = useMediaMutedState();
+	const [playerMuted] = usePlayerMutedState();
 	const [mediaVolume] = useMediaVolumeState();
 
 	const volumePropFrame = useFrameForVolumeProp(
@@ -131,7 +131,7 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 		);
 	}
 
-	const effectiveMuted = muted || mediaMuted || userPreferredVolume <= 0;
+	const effectiveMuted = muted || playerMuted || userPreferredVolume <= 0;
 
 	const isPlayerBuffering = Internals.useIsPlayerBuffering(bufferingContext);
 	const initialPlaying = useRef(playing && !isPlayerBuffering);

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -38,7 +38,7 @@ const {
 	useUnsafeVideoConfig,
 	Timeline,
 	SharedAudioContext,
-	useMediaMutedState,
+	usePlayerMutedState,
 	useMediaVolumeState,
 	useFrameForVolumeProp,
 	evaluateVolume,
@@ -147,7 +147,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 		[refForOutline],
 	);
 
-	const [mediaMuted] = useMediaMutedState();
+	const [playerMuted] = usePlayerMutedState();
 	const [mediaVolume] = useMediaVolumeState();
 
 	const volumePropFrame = useFrameForVolumeProp(loopVolumeCurveBehavior);
@@ -192,7 +192,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 	}
 
 	// TODO: Consider Sequence hidden
-	const effectiveMuted = muted || mediaMuted || userPreferredVolume <= 0;
+	const effectiveMuted = muted || playerMuted || userPreferredVolume <= 0;
 
 	const isPlayerBuffering = Internals.useIsPlayerBuffering(buffering);
 	const initialPlaying = useRef(playing && !isPlayerBuffering);

--- a/packages/player-example/pages/autoplay-muted-video.tsx
+++ b/packages/player-example/pages/autoplay-muted-video.tsx
@@ -1,0 +1,48 @@
+import {Video} from '@remotion/media';
+import {Player} from '@remotion/player';
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+const AutoplayMutedVideo: React.FC = () => {
+	return (
+		<AbsoluteFill style={{backgroundColor: 'black'}}>
+			<Video
+				objectFit="cover"
+				src="https://remotion.media/video.mp4"
+				style={{
+					width: '100%',
+					height: '100%',
+				}}
+			/>
+		</AbsoluteFill>
+	);
+};
+
+const Page: React.FC = () => {
+	return (
+		<div
+			style={{
+				fontFamily: 'sans-serif',
+				margin: 40,
+			}}
+		>
+			<h1>Autoplay muted video</h1>
+			<Player
+				component={AutoplayMutedVideo}
+				compositionWidth={1280}
+				compositionHeight={720}
+				controls
+				durationInFrames={300}
+				fps={30}
+				initiallyMuted
+				autoPlay
+				style={{
+					width: 640,
+					maxWidth: '100%',
+				}}
+			/>
+		</div>
+	);
+};
+
+export default Page;

--- a/packages/player/src/MediaVolumeSlider.tsx
+++ b/packages/player/src/MediaVolumeSlider.tsx
@@ -17,7 +17,7 @@ export const MediaVolumeSlider: React.FC<{
 	readonly renderMuteButton: RenderMuteButton | null;
 	readonly renderVolumeSlider: RenderVolumeSlider | null;
 }> = ({displayVerticalVolumeSlider, renderMuteButton, renderVolumeSlider}) => {
-	const [mediaMuted, setMediaMuted] = Internals.useMediaMutedState();
+	const [playerMuted, setPlayerMuted] = Internals.usePlayerMutedState();
 	const [mediaVolume, setMediaVolume] = Internals.useMediaVolumeState();
 	const [focused, setFocused] = useState<boolean>(false);
 	const parentDivRef = useRef<HTMLDivElement>(null);
@@ -38,12 +38,12 @@ export const MediaVolumeSlider: React.FC<{
 	const onClick = useCallback(() => {
 		if (isVolume0) {
 			setMediaVolume(1);
-			setMediaMuted(false);
+			setPlayerMuted(false);
 			return;
 		}
 
-		setMediaMuted((mute) => !mute);
-	}, [isVolume0, setMediaMuted, setMediaVolume]);
+		setPlayerMuted((mute) => !mute);
+	}, [isVolume0, setPlayerMuted, setMediaVolume]);
 
 	const parentDivStyle: React.CSSProperties = useMemo(() => {
 		return {
@@ -92,12 +92,12 @@ export const MediaVolumeSlider: React.FC<{
 
 	const muteButton = useMemo(() => {
 		return renderMuteButton
-			? renderMuteButton({muted: mediaMuted, volume: mediaVolume})
-			: renderDefaultMuteButton({muted: mediaMuted, volume: mediaVolume});
-	}, [mediaMuted, mediaVolume, renderDefaultMuteButton, renderMuteButton]);
+			? renderMuteButton({muted: playerMuted, volume: mediaVolume})
+			: renderDefaultMuteButton({muted: playerMuted, volume: mediaVolume});
+	}, [playerMuted, mediaVolume, renderDefaultMuteButton, renderMuteButton]);
 
 	const volumeSlider = useMemo(() => {
-		return (focused || hover) && !mediaMuted && !Internals.isIosSafari()
+		return (focused || hover) && !playerMuted && !Internals.isIosSafari()
 			? (renderVolumeSlider ?? renderDefaultVolumeSlider)({
 					isVertical: displayVerticalVolumeSlider,
 					volume: mediaVolume,
@@ -110,7 +110,7 @@ export const MediaVolumeSlider: React.FC<{
 		displayVerticalVolumeSlider,
 		focused,
 		hover,
-		mediaMuted,
+		playerMuted,
 		mediaVolume,
 		renderVolumeSlider,
 		setMediaVolume,

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -170,13 +170,13 @@ const PlayerUI: React.ForwardRefRenderFunction<
 	const player = usePlayer();
 	const playerToggle = player.toggle;
 
-	const {mediaMuted, mediaVolume} = useContext(Internals.MediaVolumeContext);
+	const {playerMuted, mediaVolume} = useContext(Internals.MediaVolumeContext);
 
 	useEffect(() => {
 		player.emitter.dispatchVolumeChange(mediaVolume);
 	}, [player.emitter, mediaVolume]);
 
-	const isMuted = mediaMuted || mediaVolume === 0;
+	const isMuted = playerMuted || mediaVolume === 0;
 	useEffect(() => {
 		player.emitter.dispatchMuteChange({
 			isMuted,
@@ -327,7 +327,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		player.emitter.dispatchScaleChange(scale);
 	}, [player.emitter, scale]);
 
-	const {setMediaVolume, setMediaMuted} = useContext(
+	const {setMediaVolume, setPlayerMuted} = useContext(
 		Internals.SetMediaVolumeContext,
 	);
 	const [showBufferIndicator, setShowBufferState] = useState<boolean>(false);
@@ -422,7 +422,7 @@ const PlayerUI: React.ForwardRefRenderFunction<
 			requestFullscreen,
 			exitFullscreen,
 			getVolume: () => {
-				if (mediaMuted) {
+				if (playerMuted) {
 					return 0;
 				}
 
@@ -451,10 +451,10 @@ const PlayerUI: React.ForwardRefRenderFunction<
 			},
 			isMuted: () => isMuted,
 			mute: () => {
-				setMediaMuted(true);
+				setPlayerMuted(true);
 			},
 			unmute: () => {
-				setMediaMuted(false);
+				setPlayerMuted(false);
 			},
 			getScale: () => scale,
 			pauseAndReturnToPlayStart: () => {
@@ -466,12 +466,12 @@ const PlayerUI: React.ForwardRefRenderFunction<
 		durationInFrames,
 		exitFullscreen,
 		loop,
-		mediaMuted,
+		playerMuted,
 		isMuted,
 		mediaVolume,
 		player,
 		requestFullscreen,
-		setMediaMuted,
+		setPlayerMuted,
 		setMediaVolume,
 		toggle,
 		scale,

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -115,6 +115,9 @@ export const SharedPlayerContexts: React.FC<{
 		};
 	}, [mediaMuted, mediaVolume]);
 
+	const shouldCreateAudioContext =
+		audioEnabled && !mediaMuted && mediaVolume > 0;
+
 	const setMediaVolumeAndPersist = useCallback(
 		(vol: number) => {
 			setMediaVolume(vol);
@@ -170,7 +173,7 @@ export const SharedPlayerContexts: React.FC<{
 													<Internals.BufferingProvider>
 														<Internals.SharedAudioContextProvider
 															audioLatencyHint={audioLatencyHint}
-															audioEnabled={audioEnabled}
+															audioEnabled={shouldCreateAudioContext}
 															previewSampleRate={sampleRate}
 														>
 															<Internals.SharedAudioTagsContextProvider

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -101,7 +101,7 @@ export const SharedPlayerContexts: React.FC<{
 		inputProps,
 	]);
 
-	const [mediaMuted, setMediaMuted] = useState<boolean>(() => initiallyMuted);
+	const [playerMuted, setPlayerMuted] = useState<boolean>(() => initiallyMuted);
 	const [mediaVolume, setMediaVolume] = useState<number>(() =>
 		persistVolumeToStorage
 			? getPreferredVolume(volumePersistenceKey ?? null)
@@ -110,13 +110,13 @@ export const SharedPlayerContexts: React.FC<{
 
 	const mediaVolumeContextValue = useMemo((): MediaVolumeContextValue => {
 		return {
-			mediaMuted,
+			playerMuted,
 			mediaVolume,
 		};
-	}, [mediaMuted, mediaVolume]);
+	}, [playerMuted, mediaVolume]);
 
 	const shouldCreateAudioContext =
-		audioEnabled && !mediaMuted && mediaVolume > 0;
+		audioEnabled && !playerMuted && mediaVolume > 0;
 
 	const setMediaVolumeAndPersist = useCallback(
 		(vol: number) => {
@@ -130,7 +130,7 @@ export const SharedPlayerContexts: React.FC<{
 
 	const setMediaVolumeContextValue = useMemo((): SetMediaVolumeContextValue => {
 		return {
-			setMediaMuted,
+			setPlayerMuted,
 			setMediaVolume: setMediaVolumeAndPersist,
 		};
 	}, [setMediaVolumeAndPersist]);

--- a/packages/player/src/test/validate-prop.test.tsx
+++ b/packages/player/src/test/validate-prop.test.tsx
@@ -1,8 +1,55 @@
-import {expect, test} from 'bun:test';
+import {afterEach, expect, test} from 'bun:test';
 import type {ComponentType} from 'react';
 import {Composition} from 'remotion';
 import {Player} from '../index.js';
-import {HelloWorld, render} from './test-utils.js';
+import {cleanup, HelloWorld, render} from './test-utils.js';
+
+const originalAudioContext = globalThis.AudioContext;
+
+const mockAudioContext = () => {
+	let createdAudioContexts = 0;
+
+	class MockAudioContext {
+		state = 'suspended';
+		destination = {};
+
+		constructor() {
+			createdAudioContexts++;
+		}
+
+		createGain() {
+			return {
+				connect: () => undefined,
+			};
+		}
+
+		resume() {
+			return Promise.resolve();
+		}
+
+		suspend() {
+			return Promise.resolve();
+		}
+
+		addEventListener() {
+			return undefined;
+		}
+
+		removeEventListener() {
+			return undefined;
+		}
+	}
+
+	globalThis.AudioContext =
+		MockAudioContext as unknown as typeof globalThis.AudioContext;
+
+	return () => createdAudioContexts;
+};
+
+afterEach(() => {
+	cleanup();
+	globalThis.AudioContext = originalAudioContext;
+});
 
 test('no compositionWidth should give errors', () => {
 	try {
@@ -222,6 +269,63 @@ test('initialVolume should be okay', () => {
 		/>,
 	);
 	expect(true).toBe(true);
+});
+
+test('muted Player should not create an AudioContext', () => {
+	const getCreatedAudioContexts = mockAudioContext();
+
+	render(
+		<Player
+			compositionWidth={500}
+			compositionHeight={400}
+			fps={30}
+			durationInFrames={500}
+			component={HelloWorld}
+			controls
+			showVolumeControls
+			initiallyMuted
+		/>,
+	);
+
+	expect(getCreatedAudioContexts()).toBe(0);
+});
+
+test('Player with initialVolume 0 should not create an AudioContext', () => {
+	const getCreatedAudioContexts = mockAudioContext();
+
+	render(
+		<Player
+			compositionWidth={500}
+			compositionHeight={400}
+			fps={30}
+			durationInFrames={500}
+			component={HelloWorld}
+			controls
+			showVolumeControls
+			initialVolume={0}
+		/>,
+	);
+
+	expect(getCreatedAudioContexts()).toBe(0);
+});
+
+test('Player with audible audio should create an AudioContext', () => {
+	const getCreatedAudioContexts = mockAudioContext();
+
+	render(
+		<Player
+			compositionWidth={500}
+			compositionHeight={400}
+			fps={30}
+			durationInFrames={500}
+			component={HelloWorld}
+			controls
+			showVolumeControls
+			initialVolume={1}
+		/>,
+	);
+
+	expect(getCreatedAudioContexts()).toBe(1);
 });
 
 test('invalid initialVolume type should give errors', () => {

--- a/packages/studio/src/components/MediaVolumeProvider.tsx
+++ b/packages/studio/src/components/MediaVolumeProvider.tsx
@@ -9,19 +9,21 @@ import {loadMuteOption} from '../state/mute';
 export const MediaVolumeProvider: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
-	const [mediaMuted, setMediaMuted] = useState<boolean>(() => loadMuteOption());
+	const [playerMuted, setPlayerMuted] = useState<boolean>(() =>
+		loadMuteOption(),
+	);
 	const [mediaVolume, setMediaVolume] = useState<number>(1);
 
 	const mediaVolumeContextValue = useMemo((): MediaVolumeContextValue => {
 		return {
-			mediaMuted,
+			playerMuted,
 			mediaVolume,
 		};
-	}, [mediaMuted, mediaVolume]);
+	}, [playerMuted, mediaVolume]);
 
 	const setMediaVolumeContextValue = useMemo((): SetMediaVolumeContextValue => {
 		return {
-			setMediaMuted,
+			setPlayerMuted,
 			setMediaVolume,
 		};
 	}, []);

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -108,8 +108,8 @@ export const PreviewToolbar: React.FC<{
 }> = ({readOnlyStudio, bufferStateDelayInMilliseconds}) => {
 	const {playbackRate, setPlaybackRate} = Internals.usePlaybackRate();
 
-	const {mediaMuted} = useContext(Internals.MediaVolumeContext);
-	const {setMediaMuted} = useContext(Internals.SetMediaVolumeContext);
+	const {playerMuted} = useContext(Internals.MediaVolumeContext);
+	const {setPlayerMuted} = useContext(Internals.SetMediaVolumeContext);
 	const {canvasContent} = useContext(Internals.CompositionManager);
 	const isVideoComposition = useIsVideoComposition();
 	const previewToolbarRef = useRef<HTMLDivElement | null>(null);
@@ -233,7 +233,7 @@ export const PreviewToolbar: React.FC<{
 							bufferStateDelayInMilliseconds={bufferStateDelayInMilliseconds}
 							loop={loop}
 							playbackRate={playbackRate}
-							muted={mediaMuted}
+							muted={playerMuted}
 						/>
 					</PreviewToolbarControl>
 					<Spacing x={2} />
@@ -241,7 +241,7 @@ export const PreviewToolbar: React.FC<{
 						<LoopToggle loop={loop} setLoop={setLoop} />
 					</PreviewToolbarControl>
 					<PreviewToolbarControl>
-						<MuteToggle muted={mediaMuted} setMuted={setMediaMuted} />
+						<MuteToggle muted={playerMuted} setMuted={setPlayerMuted} />
 					</PreviewToolbarControl>
 					<Spacing x={2} />
 					<PreviewToolbarControl>


### PR DESCRIPTION
## Summary
- Avoid creating a shared AudioContext while the Player is muted or at volume 0.
- Add tests covering muted, zero-volume, and audible Player mounts.
- Rename the internal Player mute state from `mediaMuted` to `playerMuted` across core/media/player/studio internals.

## Testing
- `bun run --filter @remotion/player test`
- `bun run --filter @remotion/player formatting && bun run --filter @remotion/player lint`
- `bun run build`
- `bun run stylecheck` attempted, but local `@remotion/lambda-php` lint failed because PHP is missing `ext-iconv`; affected package formatting/lint passed.
