### PR TITLE
Docs: Clarify effects and skills docs

### DIFF
--- a/packages/docs/docs/effects.mdx
+++ b/packages/docs/docs/effects.mdx
@@ -34,6 +34,10 @@ The following components support effects:
 
 ## Usage
 
+Effects can be added programmatically, interactively or agentically.
+
+### Programmatically
+
 Pass effects through the `effects` prop as an array of effect functions:
 
 ```tsx twoslash title="MyComp.tsx"
@@ -48,6 +52,20 @@ export const MyComp: React.FC = () => {
     />
   );
 };
+```
+
+### Interactively
+
+In [Remotion Studio](/docs/studio), first add an element that supports effects. Drag a video into the canvas, or add a [`<Solid>`](/docs/solid) by right-clicking an empty space in the timeline.
+
+Then drag an effect from the table of contents below into the element.
+
+### Agentically
+
+Ask an agent with [Remotion Skills](/docs/ai/skills) installed to add an effect while following Remotion conventions:
+
+```txt title="Prompt"
+Use Remotion best practices. Add a blur effect to the video.
 ```
 
 ## Multipass
@@ -68,7 +86,7 @@ When you select a component with effects in [Remotion Studio](/docs/studio), you
 
 ## Custom effects
 
-Use [`createEffect()`](/docs/create-effect) to create your own effects based on 2D Canvas APIs, WebGL2 or WebGPU and pass them to an `effects` array.
+To build your own effect, use [`createEffect()`](/docs/create-effect). It supports 2D Canvas APIs, WebGL2 and WebGPU, and creates an effect factory that can be passed to an `effects` array.
 
 ## See also
 

--- a/packages/docs/docs/effects/index.mdx
+++ b/packages/docs/docs/effects/index.mdx
@@ -41,7 +41,7 @@ Pass effects through the `effects` prop of these components:
 
 ## Creating custom effects
 
-Use [`createEffect()`](/docs/create-effect) from `remotion` to create a custom effect factory. The schema for effect controls uses [`InteractivitySchema`](/docs/interactivity-schema).
+To build your own effect, use [`createEffect()`](/docs/create-effect) from `remotion`. It creates a custom effect factory and uses [`InteractivitySchema`](/docs/interactivity-schema) for Studio controls.
 
 ## License
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,5 +1,32 @@
 # @remotion/skills
 
+Agent Skills for Remotion projects.
+
+Skills are instruction files for AI agents such as Claude Code, Codex and Cursor. They define Remotion-specific best practices, conventions and examples that an agent can load while working in a Remotion project.
+
 ## Usage
 
-This is an internal package and has no documentation.
+Install the skills in a Remotion project:
+
+```bash
+npx remotion skills add
+```
+
+Update installed skills:
+
+```bash
+npx remotion skills update
+```
+
+New Remotion projects created with `bun create video` are also offered the option to add skills.
+
+## Included skill
+
+The Remotion skill lives in [`skills/remotion/SKILL.md`](./skills/remotion/SKILL.md). It covers composition structure, animation patterns, media handling, effects and other Remotion workflows.
+
+For visual and pixel effects, the skill points agents to [`skills/remotion/rules/effects.md`](./skills/remotion/rules/effects.md), which explains how to use `@remotion/effects` and how to create a reusable custom effect with `createEffect()`.
+
+## Documentation
+
+- [Agent Skills](https://www.remotion.dev/docs/ai/skills)
+- [`npx remotion skills`](https://www.remotion.dev/docs/cli/skills)


### PR DESCRIPTION
## Summary

- Clarify that effects can be added programmatically, interactively and agentically.
- Add a sample agent prompt for applying a blur effect.
- Document the `@remotion/skills` package README with install/update instructions and the effects skill reference.

## Testing

- `cd packages/docs && bunx oxfmt src --write`
- `cd packages/skills && bunx oxfmt src --write`
- `bun run build`
- `bunx turbo run lint formatting --filter=docs --filter=@remotion/skills`

`bun run stylecheck` was also run, but failed in `@remotion/lambda-php` because the local PHP installation is missing the `ext-iconv` extension. The affected docs and skills checks passed separately.
