### PR TITLE
`@remotion/studio`: Highlight effect when child prop is selected

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -20,6 +20,8 @@ import {TimelineRowChrome} from './TimelineRowChrome';
 import {
 	getTimelineColor,
 	getTimelineSelectedLabelStyle,
+	TIMELINE_SELECTED_LABEL_BACKGROUND,
+	useTimelineRowContainsSelection,
 	useTimelineRowSelection,
 } from './TimelineSelection';
 
@@ -126,6 +128,7 @@ export const TimelineEffectItem: React.FC<{
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const selection = useTimelineRowSelection(nodePathInfo);
+	const containsSelection = useTimelineRowContainsSelection(nodePathInfo);
 	const [dropIndicator, setDropIndicator] = useState<'before' | 'after' | null>(
 		null,
 	);
@@ -295,12 +298,15 @@ export const TimelineEffectItem: React.FC<{
 			alignSelf: 'stretch',
 			alignItems: 'center',
 			color: getTimelineColor(selection.selected, true),
-			display: 'flex',
-			flex: 1,
+			display: 'inline-flex',
+			marginRight: EXPANDED_SECTION_PADDING_RIGHT,
 			minWidth: 0,
-			paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
+			boxShadow:
+				containsSelection && !selection.selected
+					? `inset 0 0 0 2px ${TIMELINE_SELECTED_LABEL_BACKGROUND}`
+					: undefined,
 		};
-	}, [selection.selected]);
+	}, [containsSelection, selection.selected]);
 
 	const getDropTarget = useCallback(
 		(e: React.DragEvent<HTMLDivElement>) => {
@@ -469,7 +475,7 @@ export const TimelineEffectItem: React.FC<{
 			selectionItem={selection.selectionItem}
 			onSelect={selection.onSelect}
 			showSelectedBackground
-			containsSelection={false}
+			containsSelection={containsSelection}
 			outerHeight={null}
 		>
 			<span title={label} style={labelStyle}>

--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -7,7 +7,7 @@ import {TimelineKeyframeDiamond} from './TimelineKeyframeDiamond';
 import {TimelineKeyframeEasingLine} from './TimelineKeyframeEasingLine';
 import {
 	getTimelineSelectedTrackHighlightStyle,
-	useTimelineRowSelection,
+	useTimelineRowHighlightBackground,
 } from './TimelineSelection';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
@@ -27,7 +27,8 @@ const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
 	readonly showSeparator: boolean;
 }> = ({height, keyframes, canEditEasing, nodePathInfo, showSeparator}) => {
 	const timelineWidth = useContext(TimelineWidthContext);
-	const {selected: rowSelected} = useTimelineRowSelection(nodePathInfo);
+	const rowHighlightBackground =
+		useTimelineRowHighlightBackground(nodePathInfo);
 	const easingSegments = canEditEasing
 		? getTimelineEasingSegments(keyframes)
 		: [];
@@ -36,8 +37,13 @@ const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
 		<>
 			{showSeparator ? <div style={rowSeparator} /> : null}
 			<div style={{...row, height}}>
-				{rowSelected && timelineWidth !== null ? (
-					<div style={getTimelineSelectedTrackHighlightStyle(timelineWidth)} />
+				{rowHighlightBackground && timelineWidth !== null ? (
+					<div
+						style={getTimelineSelectedTrackHighlightStyle(
+							timelineWidth,
+							rowHighlightBackground,
+						)}
+					/>
 				) : null}
 				{easingSegments.map((segment) => (
 					<TimelineKeyframeEasingLine

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -8,7 +8,7 @@ import {
 } from './timeline-row-layout';
 import type {TimelineSelectionInteraction} from './TimelineSelection';
 import {
-	TIMELINE_SELECTED_BACKGROUND,
+	getTimelineRowHighlightBackground,
 	type TimelineSelection,
 	useTimelineFocusableItem,
 } from './TimelineSelection';
@@ -116,17 +116,17 @@ export const TimelineRowChrome: React.FC<{
 		[onSelect],
 	);
 
-	const highlightBackground =
-		showSelectedBackground && (selected || containsSelection)
-			? TIMELINE_SELECTED_BACKGROUND
-			: undefined;
+	const highlightBackground = getTimelineRowHighlightBackground({
+		showSelectedBackground,
+		selected,
+		containsSelection,
+	});
 
 	const innerRowStyle = useMemo(
 		(): React.CSSProperties => ({
 			...rowBase,
 			...style,
-			backgroundColor:
-				outerHeight === undefined ? highlightBackground : undefined,
+			backgroundColor: outerHeight === null ? highlightBackground : undefined,
 		}),
 		[style, outerHeight, highlightBackground],
 	);

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -76,8 +76,9 @@ export const getTimelineColor = (selected: boolean, subcategory: boolean) => {
 
 export const getTimelineSelectedTrackHighlightStyle = (
 	timelineWidth: number,
+	backgroundColor: string = TIMELINE_SELECTED_BACKGROUND,
 ): CSSProperties => ({
-	backgroundColor: TIMELINE_SELECTED_BACKGROUND,
+	backgroundColor,
 	bottom: 0,
 	left: -TIMELINE_PADDING,
 	pointerEvents: 'none',
@@ -85,6 +86,20 @@ export const getTimelineSelectedTrackHighlightStyle = (
 	top: 0,
 	width: timelineWidth,
 });
+
+export const getTimelineRowHighlightBackground = ({
+	showSelectedBackground,
+	selected,
+	containsSelection,
+}: {
+	readonly showSelectedBackground: boolean;
+	readonly selected: boolean;
+	readonly containsSelection: boolean;
+}): string | undefined => {
+	return showSelectedBackground && (selected || containsSelection)
+		? TIMELINE_SELECTED_BACKGROUND
+		: undefined;
+};
 
 export const TIMELINE_BACKGROUND = '#0F1113';
 export const TIMELINE_TICKS_BACKGROUND = BACKGROUND;
@@ -1743,4 +1758,16 @@ export const useTimelineRowContainsSelection = (
 	}
 
 	return containsSelection(nodePathInfo);
+};
+
+export const useTimelineRowHighlightBackground = (
+	nodePathInfo: SequenceNodePathInfo | null,
+): string | undefined => {
+	const {selected} = useTimelineRowSelection(nodePathInfo);
+	const containsSelection = useTimelineRowContainsSelection(nodePathInfo);
+	return getTimelineRowHighlightBackground({
+		showSelectedBackground: true,
+		selected,
+		containsSelection,
+	});
 };

--- a/packages/studio/src/components/Timeline/TimelineTrack.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTrack.tsx
@@ -9,8 +9,7 @@ import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {TimelineExpandedTrackKeyframes} from './TimelineExpandedTrackKeyframes';
 import {
 	getTimelineSelectedTrackHighlightStyle,
-	useTimelineRowContainsSelection,
-	useTimelineRowSelection,
+	useTimelineRowHighlightBackground,
 } from './TimelineSelection';
 import {TimelineSequence} from './TimelineSequence';
 import {TimelineWidthContext} from './TimelineWidthProvider';
@@ -22,8 +21,9 @@ const TimelineTrackUnmemoized: React.FC<{
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewServerConnected = previewServerState.type === 'connected';
 	const timelineWidth = useContext(TimelineWidthContext);
-	const {selected: rowSelected} = useTimelineRowSelection(track.nodePathInfo);
-	const containsSelection = useTimelineRowContainsSelection(track.nodePathInfo);
+	const rowHighlightBackground = useTimelineRowHighlightBackground(
+		track.nodePathInfo,
+	);
 
 	const layerStyle = useMemo(
 		(): React.CSSProperties => ({
@@ -39,14 +39,16 @@ const TimelineTrackUnmemoized: React.FC<{
 		previewServerConnected &&
 		getIsExpanded(track.nodePathInfo);
 
-	const showRowHighlight =
-		track.nodePathInfo !== null && (rowSelected || containsSelection);
-
 	return (
 		<div>
 			<div style={layerStyle}>
-				{showRowHighlight && timelineWidth !== null ? (
-					<div style={getTimelineSelectedTrackHighlightStyle(timelineWidth)} />
+				{rowHighlightBackground && timelineWidth !== null ? (
+					<div
+						style={getTimelineSelectedTrackHighlightStyle(
+							timelineWidth,
+							rowHighlightBackground,
+						)}
+					/>
 				) : null}
 				<TimelineSequence
 					s={track.sequence}


### PR DESCRIPTION
Fixes #8553.

## Summary

- Highlight an effect row when one of its child effect prop rows is selected
- Reuse the existing timeline selection containment state for effect rows

## Testing

- `bunx oxfmt src --write` in `packages/studio`
- `bun run build`
- `bun run lint` in `packages/studio`
- `bun run formatting` in `packages/studio`
- `git diff --check`

`bun run stylecheck` was also run, but it failed in unrelated `@remotion/lambda-php#lint` because the local PHP installation is missing `ext-iconv`.
