### PR TITLE
`@remotion/studio-shared`: Disable boolean keyframes

### DIFF
--- a/packages/studio-shared/src/keyframe-interpolation-function.ts
+++ b/packages/studio-shared/src/keyframe-interpolation-function.ts
@@ -23,7 +23,11 @@ export const isInteractivitySchemaFieldKeyframable = (
 		return true;
 	}
 
-	if (field.type === 'array' || field.type === 'enum') {
+	if (
+		field.type === 'array' ||
+		field.type === 'boolean' ||
+		field.type === 'enum'
+	) {
 		return false;
 	}
 

--- a/packages/studio-shared/src/test/keyframe-interpolation-function.test.ts
+++ b/packages/studio-shared/src/test/keyframe-interpolation-function.test.ts
@@ -34,6 +34,37 @@ test('isSchemaFieldKeyframable rejects explicitly disabled fields', () => {
 	expect(isSchemaFieldKeyframable({schema, key: 'playbackRate'})).toBe(false);
 });
 
+test('isSchemaFieldKeyframable rejects boolean fields', () => {
+	const schema = {
+		loop: {
+			type: 'boolean',
+			default: false,
+		},
+	} satisfies InteractivitySchema;
+
+	expect(isSchemaFieldKeyframable({schema, key: 'loop'})).toBe(false);
+});
+
+test('isSchemaFieldKeyframable rejects boolean fields in enum variants', () => {
+	const schema = {
+		layout: {
+			type: 'enum',
+			default: 'absolute-fill',
+			variants: {
+				'absolute-fill': {
+					horizontal: {
+						type: 'boolean',
+						default: true,
+					},
+				},
+				none: {},
+			},
+		},
+	} satisfies InteractivitySchema;
+
+	expect(isSchemaFieldKeyframable({schema, key: 'horizontal'})).toBe(false);
+});
+
 test('isSchemaFieldKeyframable finds keyframable fields in enum variants', () => {
 	const schema = {
 		layout: {


### PR DESCRIPTION
## Summary

- Treat boolean interactivity schema fields as not keyframable
- Add regression coverage for top-level boolean fields and boolean fields inside enum variants

Closes #8612.

## Testing

- `bun test src` in `packages/studio-shared`
- `bun run formatting` in `packages/studio-shared`
- `bun run lint` in `packages/studio-shared`
- `bun run build`
- `bun run stylecheck` fails in `@remotion/lambda-php` because the local PHP installation is missing `ext-iconv`
