### PR TITLE
Docs: Update Elements submission guidelines

### DIFF
--- a/packages/docs/elements-template/element.tsx
+++ b/packages/docs/elements-template/element.tsx
@@ -1,39 +1,23 @@
 import React from 'react';
-import {AbsoluteFill, Composition} from 'remotion';
-
-export const width = 1920;
-export const height = 1080;
-export const fps = 30;
-export const durationInFrames = 120;
+import {AbsoluteFill, Sequence} from 'remotion';
 
 export const ElementComponent: React.FC = () => {
 	return (
-		<AbsoluteFill
-			style={{
-				alignItems: 'center',
-				backgroundColor: '#111827',
-				color: 'white',
-				display: 'flex',
-				fontFamily: 'Inter, system-ui, sans-serif',
-				fontSize: 96,
-				fontWeight: 700,
-				justifyContent: 'center',
-			}}
-		>
-			Element
-		</AbsoluteFill>
-	);
-};
-
-export const RemotionRoot: React.FC = () => {
-	return (
-		<Composition
-			id="Element"
-			component={ElementComponent}
-			durationInFrames={durationInFrames}
-			fps={fps}
-			height={height}
-			width={width}
-		/>
+		<Sequence width={1080} height={1080}>
+			<AbsoluteFill
+				style={{
+					alignItems: 'center',
+					backgroundColor: '#111827',
+					color: 'white',
+					display: 'flex',
+					fontFamily: 'Inter, system-ui, sans-serif',
+					fontSize: 96,
+					fontWeight: 700,
+					justifyContent: 'center',
+				}}
+			>
+				Element
+			</AbsoluteFill>
+		</Sequence>
 	);
 };

--- a/packages/docs/elements-template/index.mdx
+++ b/packages/docs/elements-template/index.mdx
@@ -4,64 +4,36 @@ description: One sentence describing what this element shows.
 ---
 
 import {ElementPage} from '@site/src/components/Elements/ElementPage';
-import {
-	ElementComponent,
-	durationInFrames,
-	fps,
-	height,
-	width,
-} from './element';
+import {ElementComponent} from './element';
 
 # Element title
 
 One short paragraph explaining what this element demonstrates and when to use it.
 
-<ElementPage
-	component={ElementComponent}
-	durationInFrames={durationInFrames}
-	fps={fps}
-	height={height}
-	width={width}
->
+<ElementPage component={ElementComponent}>
 
 ```tsx twoslash title="element.tsx"
 import React from 'react';
-import {AbsoluteFill, Composition} from 'remotion';
-
-export const width = 1920;
-export const height = 1080;
-export const fps = 30;
-export const durationInFrames = 120;
+import {AbsoluteFill, Sequence} from 'remotion';
 
 export const ElementComponent: React.FC = () => {
 	return (
-		<AbsoluteFill
-			style={{
-				alignItems: 'center',
-				backgroundColor: '#111827',
-				color: 'white',
-				display: 'flex',
-				fontFamily: 'Inter, system-ui, sans-serif',
-				fontSize: 96,
-				fontWeight: 700,
-				justifyContent: 'center',
-			}}
-		>
-			Element
-		</AbsoluteFill>
-	);
-};
-
-export const RemotionRoot: React.FC = () => {
-	return (
-		<Composition
-			id="Element"
-			component={ElementComponent}
-			durationInFrames={durationInFrames}
-			fps={fps}
-			height={height}
-			width={width}
-		/>
+		<Sequence width={1080} height={1080}>
+			<AbsoluteFill
+				style={{
+					alignItems: 'center',
+					backgroundColor: '#111827',
+					color: 'white',
+					display: 'flex',
+					fontFamily: 'Inter, system-ui, sans-serif',
+					fontSize: 96,
+					fontWeight: 700,
+					justifyContent: 'center',
+				}}
+			>
+				Element
+			</AbsoluteFill>
+		</Sequence>
 	);
 };
 ```

--- a/packages/docs/elements/index.mdx
+++ b/packages/docs/elements/index.mdx
@@ -20,11 +20,11 @@ They are practical video building blocks: captions, lower thirds, overlays, call
 
 An Element should be:
 
-- Small, focused, and useful in real videos
+- Building block for a video: an overlay, transition, motion graphic, data animation, etc.
 - Designed to live inside one `<Sequence>`
-- Remixable source code that users can edit, not a black-box dependency
-- HTML, CSS, and React-first for the first version
-- Zero-dependency where possible, with Remotion Effects as an exception
+- Free of specific colors or branding, so users can easily remix it
+- HTML, CSS, and React-first
+- Zero-dependency where possible, with [Remotion Effects](/docs/effects) as an exception
 - Safe to compose in Studio with normal z-layering
 - Free of unexpected global styles, layout side effects, and fullscreen assumptions unless it is explicitly a background
 

--- a/packages/docs/elements/overlays/lower-third/index.mdx
+++ b/packages/docs/elements/overlays/lower-third/index.mdx
@@ -1,48 +1,31 @@
 ---
-title: Lower third
-description: Create a reusable lower-third title animation.
+title: Lower Third
+description: A clean animated lower third for names and titles.
 ---
 
 import {ElementPage} from '@site/src/components/Elements/ElementPage';
-import {
-	LowerThird,
-	durationInFrames,
-	fps,
-	height,
-	width,
-} from './lower-third';
+import {LowerThird} from './lower-third';
 
-# Lower third
+# Lower Third
 
-Create a reusable lower-third title animation.
+A clean animated lower third for introducing a speaker, guest, or section.
 
-<ElementPage
-	component={LowerThird}
-	durationInFrames={durationInFrames}
-	fps={fps}
-	height={height}
-	width={width}
->
+<ElementPage component={LowerThird}>
 
 ```tsx twoslash title="lower-third.tsx"
 import React from 'react';
 import {
 	AbsoluteFill,
-	Composition,
+	Sequence,
 	interpolate,
 	spring,
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
 
-export const durationInFrames = 120;
-export const fps = 30;
-export const width = 1920;
-export const height = 1080;
-
 export const LowerThird: React.FC = () => {
 	const frame = useCurrentFrame();
-	const {fps: videoFps} = useVideoConfig();
+	const {durationInFrames, fps: videoFps} = useVideoConfig();
 
 	const entrance = spring({
 		frame,
@@ -53,7 +36,10 @@ export const LowerThird: React.FC = () => {
 		},
 	});
 
-	const exit = interpolate(frame, [95, 115], [1, 0], {
+	const exitStart = Math.max(0, durationInFrames - 25);
+	const exitEnd = Math.max(exitStart + 1, durationInFrames - 5);
+
+	const exit = interpolate(frame, [exitStart, exitEnd], [1, 0], {
 		extrapolateLeft: 'clamp',
 		extrapolateRight: 'clamp',
 	});
@@ -61,75 +47,64 @@ export const LowerThird: React.FC = () => {
 	const progress = entrance * exit;
 
 	return (
-		<AbsoluteFill
-			style={{
-				fontFamily: 'Inter, system-ui, sans-serif',
-				pointerEvents: 'none',
-			}}
-		>
-			<div
+		<Sequence width={900} height={260}>
+			<AbsoluteFill
 				style={{
-					position: 'absolute',
-					left: 120,
-					bottom: 130,
-					transform: `translateX(${interpolate(progress, [0, 1], [-90, 0])}px)`,
-					opacity: progress,
+					fontFamily: 'Inter, system-ui, sans-serif',
+					pointerEvents: 'none',
 				}}
 			>
 				<div
 					style={{
-						width: 660,
-						padding: '34px 42px',
-						borderRadius: 28,
-						background: 'rgba(255, 255, 255, 0.92)',
-						boxShadow: '0 24px 80px rgba(0, 0, 0, 0.3)',
+						position: 'absolute',
+						left: 0,
+						bottom: 0,
+						transform: `translateX(${interpolate(progress, [0, 1], [-90, 0])}px)`,
+						opacity: progress,
 					}}
 				>
 					<div
 						style={{
-							fontSize: 54,
-							fontWeight: 800,
-							color: '#111827',
-							letterSpacing: -1.5,
+							width: 660,
+							padding: '34px 42px',
+							borderRadius: 28,
+							background: 'rgba(255, 255, 255, 0.92)',
+							boxShadow: '0 24px 80px rgba(0, 0, 0, 0.3)',
 						}}
 					>
-						Alex Morgan
+						<div
+							style={{
+								fontSize: 54,
+								fontWeight: 800,
+								color: '#111827',
+								letterSpacing: -1.5,
+							}}
+						>
+							Alex Morgan
+						</div>
+						<div
+							style={{
+								fontSize: 30,
+								fontWeight: 600,
+								color: '#2563eb',
+								marginTop: 10,
+							}}
+						>
+							Creative Developer
+						</div>
 					</div>
 					<div
 						style={{
-							fontSize: 30,
-							fontWeight: 600,
-							color: '#2563eb',
-							marginTop: 10,
+							width: interpolate(progress, [0, 1], [0, 520]),
+							height: 10,
+							borderRadius: 999,
+							background: '#60a5fa',
+							marginTop: 18,
 						}}
-					>
-						Creative Developer
-					</div>
+					/>
 				</div>
-				<div
-					style={{
-						width: interpolate(progress, [0, 1], [0, 520]),
-						height: 10,
-						borderRadius: 999,
-						background: '#60a5fa',
-						marginTop: 18,
-					}}
-				/>
-			</div>
-		</AbsoluteFill>
-	);
-};
-
-export const RemotionRoot: React.FC = () => {
-	return (
-		<Composition
-			id="LowerThird"
-			component={LowerThird}
-			durationInFrames={durationInFrames}
-			fps={fps}
-			height={height}
-			width={width}
-		/>
+			</AbsoluteFill>
+		</Sequence>
 	);
 };
 ```

--- a/packages/docs/elements/overlays/lower-third/lower-third.tsx
+++ b/packages/docs/elements/overlays/lower-third/lower-third.tsx
@@ -1,21 +1,16 @@
 import React from 'react';
 import {
 	AbsoluteFill,
-	Composition,
+	Sequence,
 	interpolate,
 	spring,
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
 
-export const durationInFrames = 120;
-export const fps = 30;
-export const width = 1920;
-export const height = 1080;
-
 export const LowerThird: React.FC = () => {
 	const frame = useCurrentFrame();
-	const {fps: videoFps} = useVideoConfig();
+	const {durationInFrames, fps: videoFps} = useVideoConfig();
 
 	const entrance = spring({
 		frame,
@@ -26,7 +21,10 @@ export const LowerThird: React.FC = () => {
 		},
 	});
 
-	const exit = interpolate(frame, [95, 115], [1, 0], {
+	const exitStart = Math.max(0, durationInFrames - 25);
+	const exitEnd = Math.max(exitStart + 1, durationInFrames - 5);
+
+	const exit = interpolate(frame, [exitStart, exitEnd], [1, 0], {
 		extrapolateLeft: 'clamp',
 		extrapolateRight: 'clamp',
 	});
@@ -34,74 +32,63 @@ export const LowerThird: React.FC = () => {
 	const progress = entrance * exit;
 
 	return (
-		<AbsoluteFill
-			style={{
-				fontFamily: 'Inter, system-ui, sans-serif',
-				pointerEvents: 'none',
-			}}
-		>
-			<div
+		<Sequence width={900} height={260}>
+			<AbsoluteFill
 				style={{
-					position: 'absolute',
-					left: 120,
-					bottom: 130,
-					transform: `translateX(${interpolate(progress, [0, 1], [-90, 0])}px)`,
-					opacity: progress,
+					fontFamily: 'Inter, system-ui, sans-serif',
+					pointerEvents: 'none',
 				}}
 			>
 				<div
 					style={{
-						width: 660,
-						padding: '34px 42px',
-						borderRadius: 28,
-						background: 'rgba(255, 255, 255, 0.92)',
-						boxShadow: '0 24px 80px rgba(0, 0, 0, 0.3)',
+						position: 'absolute',
+						left: 0,
+						bottom: 0,
+						transform: `translateX(${interpolate(progress, [0, 1], [-90, 0])}px)`,
+						opacity: progress,
 					}}
 				>
 					<div
 						style={{
-							fontSize: 54,
-							fontWeight: 800,
-							color: '#111827',
-							letterSpacing: -1.5,
+							width: 660,
+							padding: '34px 42px',
+							borderRadius: 28,
+							background: 'rgba(255, 255, 255, 0.92)',
+							boxShadow: '0 24px 80px rgba(0, 0, 0, 0.3)',
 						}}
 					>
-						Alex Morgan
+						<div
+							style={{
+								fontSize: 54,
+								fontWeight: 800,
+								color: '#111827',
+								letterSpacing: -1.5,
+							}}
+						>
+							Alex Morgan
+						</div>
+						<div
+							style={{
+								fontSize: 30,
+								fontWeight: 600,
+								color: '#2563eb',
+								marginTop: 10,
+							}}
+						>
+							Creative Developer
+						</div>
 					</div>
 					<div
 						style={{
-							fontSize: 30,
-							fontWeight: 600,
-							color: '#2563eb',
-							marginTop: 10,
+							width: interpolate(progress, [0, 1], [0, 520]),
+							height: 10,
+							borderRadius: 999,
+							background: '#60a5fa',
+							marginTop: 18,
 						}}
-					>
-						Creative Developer
-					</div>
+					/>
 				</div>
-				<div
-					style={{
-						width: interpolate(progress, [0, 1], [0, 520]),
-						height: 10,
-						borderRadius: 999,
-						background: '#60a5fa',
-						marginTop: 18,
-					}}
-				/>
-			</div>
-		</AbsoluteFill>
-	);
-};
-
-export const RemotionRoot: React.FC = () => {
-	return (
-		<Composition
-			id="LowerThird"
-			component={LowerThird}
-			durationInFrames={durationInFrames}
-			fps={fps}
-			height={height}
-			width={width}
-		/>
+			</AbsoluteFill>
+		</Sequence>
 	);
 };

--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -7,90 +7,77 @@ description: Submit a Remotion Element for the Elements gallery.
 
 Have a small, remixable Remotion Element? We'd like to see it.
 
-A strong Element is easy to preview, easy to copy into a Remotion project, and useful as a building block inside a [`<Sequence>`](/docs/sequence).
+A strong Element is easy to preview, easy to copy into a Remotion project, and useful as a video building block.
 
 ## Preferred Element format
 
 An Element should ideally be a single, self-contained TSX file.
 
-Each Element should live in its own folder: `packages/docs/elements/<category>/<slug>/`.
-Put the MDX page at `packages/docs/elements/<category>/<slug>/index.mdx` and the TSX source next to it.
-
 Start from the reusable template in `packages/docs/elements-template/`.
-
-The MDX page imports that TSX file for the live preview, and shows the exact same code in a fenced `tsx` code block. Keeping the displayed code inline means both readers in the browser and AI agents reading the served Markdown see the full source. A test (`src/test/elements.test.ts`) enforces that the code block stays identical to the source file.
 
 The preferred format is:
 
-- Export the Element component
-- Export fixed `width`, `height`, `fps`, and `durationInFrames`
-- Define the Remotion [`<Composition>`](/docs/composition) directly in the file
-- No local imports, except from npm packages
-- No multiple files required to understand or use the Element
-- Copy-pastable into a Remotion project
+- One self-contained TSX file exporting a React component
+- Copy-pastable and useful in more than one Remotion project
 - HTML, CSS, and React-first
-- Zero-dependency where possible
-- Binary assets use remote URLs only
-- Remote assets are publicly accessible and stable
+- Focused on one visual idea, technique, or workflow
+- Easy to remix
+- Works as-is when dragged or copied into a project
+- **Building block, not a composition:** The hosted docs page provides the preview size, frame rate, and duration. A user's active composition may have a different width, height, FPS, or duration than the preview.
+- [Interactivity-friendly](/docs/studio/interactivity): inline editable values so they can show up in the Studio inspector. See also [Make a component interactive](/docs/studio/make-component-interactive).
+- If two variants are worth showing, make two separate Element pages instead of adding a variant prop.
 
 For example:
 
 ```tsx twoslash title="Element.tsx"
-import {Composition} from 'remotion';
-
-export const width = 1920;
-export const height = 1080;
-export const fps = 30;
-export const durationInFrames = 120;
+import {Sequence} from 'remotion';
 
 export const MyElement = () => {
-	return <div>...</div>;
-};
-
-export const RemotionRoot = () => {
-	return (
-		<Composition
-			id="MyElement"
-			component={MyElement}
-			width={width}
-			height={height}
-			fps={fps}
-			durationInFrames={durationInFrames}
-		/>
-	);
+  return (
+    <Sequence width={1080} height={1080}>
+      <div>...</div>
+    </Sequence>
+  );
 };
 ```
 
-The MDX page can then use the shared page template, which renders a preview, a "Use it" section, and the source code:
+For animation, keep the timing inside the component but let the surrounding project decide how long the Element appears:
 
-````mdx title="index.mdx"
-import {ElementPage} from '@site/src/components/Elements/ElementPage';
-import {
-	MyElement,
-	durationInFrames,
-	fps,
-	height,
-	width,
-} from './my-element';
+```tsx twoslash title="AnimatedElement.tsx"
+import {Interactive, Sequence, interpolate, useCurrentFrame} from 'remotion';
 
-<ElementPage
-	component={MyElement}
-	durationInFrames={durationInFrames}
-	fps={fps}
-	height={height}
-	width={width}
->
+export const AnimatedElement = () => {
+  const frame = useCurrentFrame();
 
-```tsx twoslash title="my-element.tsx"
-// Paste the full contents of my-element.tsx here.
-// It must match the file exactly — a test enforces this.
+  return (
+    <Sequence width={1080} height={1080}>
+      <Interactive.Div
+        style={{
+          opacity: interpolate(frame, [0, 20], [0, 1]),
+          translate: interpolate(frame, [0, 20], ['0px 40px', '0px 0px']),
+        }}
+      >
+        Hello
+      </Interactive.Div>
+    </Sequence>
+  );
+};
 ```
 
-</ElementPage>
-````
+## Sizing Elements
 
-The fenced code block must be an exact copy of the colocated TSX file. This is intentional: it keeps the source visible in the served Markdown for agents while the imported module powers the live preview.
+For object-like Elements, use a [`<Sequence>`](/docs/sequence) with `width` and `height`.
+This is useful for overlays, lower thirds, callouts, motion graphics, cards, badges, and data animations.
 
+The Sequence acts as the Element's isolated container.
+It is absolutely positioned by default, gives Remotion Studio a selectable outline and transform target, and makes [`useVideoConfig()`](/docs/use-video-config) return the Element's own `width` and `height` to children.
+
+For full-frame backgrounds, usually do not set `width` or `height`.
+Let the Element inherit the host composition size instead.
+
+## Assets and dependencies
+
+Prefer zero dependencies.
 If an Element needs binary assets, reference them by URL:
 
 ```tsx twoslash title="Remote assets"
@@ -98,17 +85,7 @@ const imageUrl = 'https://remotion.media/element-image.png';
 const videoUrl = 'https://remotion.media/element-video.mp4';
 ```
 
-## What makes a good Element?
-
-A good Element is:
-
-- Small enough to understand quickly
-- Useful in more than one project
-- Easy to remix
-- Focused on one visual idea, technique, or workflow
-- Designed to be placed inside a `<Sequence>`
-- Possible to preview with a short rendered video or still image
-- Actionable for a Remotion user
+Remote assets should be publicly accessible and stable.
 
 ## What to include
 
@@ -116,10 +93,8 @@ When submitting an Element as a pull request, include:
 
 - An Element folder in `packages/docs/elements/<category>/<slug>/`
 - An `index.mdx` page and the single-file TSX source code in that folder
-- What the viewer should see
 - A rendered preview, if available
 - What makes it useful
-- Required npm dependencies or remote asset URLs
 - Links to inspiration, if any
 
 ## Not a great fit

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -3,20 +3,20 @@ import {ElementPreview} from './ElementPreview';
 
 type ElementPageProps = {
 	readonly component: ComponentType<Record<string, never>>;
-	readonly durationInFrames: number;
-	readonly fps: number;
-	readonly height: number;
-	readonly width: number;
+	readonly durationInFrames?: number;
+	readonly fps?: number;
+	readonly height?: number;
+	readonly width?: number;
 	readonly children: ReactNode;
 };
 
 export const ElementPage: React.FC<ElementPageProps> = ({
 	children,
 	component,
-	durationInFrames,
-	fps,
-	height,
-	width,
+	durationInFrames = 120,
+	fps = 30,
+	height = 1080,
+	width = 1920,
 }) => {
 	return (
 		<>
@@ -32,9 +32,8 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 			<h2>Use it</h2>
 			<p>
 				Copy the source code into your Remotion project. The file exports the
-				component, dimensions, frame rate, duration, and a{' '}
-				<code>RemotionRoot</code>
-				composition.
+				Element component. Preview dimensions, frame rate, and duration are
+				supplied by the gallery.
 			</p>
 
 			<h2>Source</h2>

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -5,16 +5,6 @@ import path from 'path';
 const elementsRoot = path.join(__dirname, '..', '..', 'elements');
 const templateRoot = path.join(__dirname, '..', '..', 'elements-template');
 
-// Exports every element source file must define so that the colocated MDX page
-// can import them and pass them to <Player>.
-const requiredExports = [
-	'durationInFrames',
-	'fps',
-	'width',
-	'height',
-	'RemotionRoot',
-];
-
 type Element = {
 	name: string;
 	mdxPath: string;
@@ -73,12 +63,13 @@ describe('Elements must follow the colocated single-file format', () => {
 			const tsx = readFileSync(element.tsxPath, 'utf8');
 			const mdx = readFileSync(element.mdxPath, 'utf8');
 
-			test('source file defines the required exports', () => {
-				for (const exp of requiredExports) {
-					expect(tsx).toContain(`export const ${exp}`);
-				}
-
-				expect(tsx).toContain('<Composition');
+			test('source file is an Element, not a composition', () => {
+				expect(tsx).not.toContain('export const durationInFrames');
+				expect(tsx).not.toContain('export const fps');
+				expect(tsx).not.toContain('export const width');
+				expect(tsx).not.toContain('export const height');
+				expect(tsx).not.toContain('export const RemotionRoot');
+				expect(tsx).not.toContain('<Composition');
 			});
 
 			test('MDX uses the ElementPage template', () => {
@@ -92,8 +83,7 @@ describe('Elements must follow the colocated single-file format', () => {
 			test('displayed code block matches the source file', () => {
 				const block = extractTsxBlock(mdx);
 				expect(block).not.toBeNull();
-				// The fenced code block is the single source of truth shown to both
-				// humans and agents; it must be identical to the runnable .tsx file.
+				// The fenced code block must be identical to the runnable .tsx file.
 				expect(block?.trim()).toBe(tsx.trim());
 			});
 		});


### PR DESCRIPTION
## Summary

- Rework Elements submission guidelines around Elements as Studio-friendly building blocks instead of full compositions
- Move preview dimensions/FPS/duration into the hosted docs page defaults
- Update the Elements template, lower-third example, and format tests to match the building-block model

## Validation

- `cd packages/docs && bunx oxfmt src --write`
- `bun test packages/docs/src/test/elements.test.ts`
- `bun run build`
- `bun run stylecheck` *(fails in existing `template-react-router#lint` generated types: `Generic type 'GetAnnotations' requires 1 type argument(s)`)*
