### PR TITLE
`@remotion/media`: Fix scrubbing wedging the audio scheduler

### DIFF
--- a/packages/media/src/audio/sort-by-priority.ts
+++ b/packages/media/src/audio/sort-by-priority.ts
@@ -16,14 +16,18 @@ const CONCURRENCY = 1;
 
 const waiters: Waiter[] = [];
 let running = 0;
-let runningEntry: {waiter: Waiter; settle: () => void} | null = null;
+let runningEntry: {
+	waiter: Waiter;
+	cancel: () => void;
+	settle: () => void;
+} | null = null;
 
 export const processNext = (): void => {
 	if (running >= CONCURRENCY) {
 		if (runningEntry?.waiter.getPriority() === null) {
 			// Running entry went stale: free its slot so a fresh waiter can run
 			// instead of deadlocking behind work nobody needs anymore.
-			runningEntry.settle();
+			runningEntry.cancel();
 		} else {
 			return;
 		}
@@ -76,8 +80,13 @@ export const processNext = (): void => {
 	running++;
 
 	let settled = false;
+	let cancelled = false;
 	const entry = {
 		waiter: next,
+		cancel: () => {
+			cancelled = true;
+			entry.settle();
+		},
 		settle: () => {
 			if (settled) {
 				return;
@@ -95,10 +104,18 @@ export const processNext = (): void => {
 	next.fn().then(
 		(value) => {
 			entry.settle();
+			if (cancelled) {
+				return;
+			}
+
 			next.onDone(value, processNext);
 		},
 		(err) => {
 			entry.settle();
+			if (cancelled) {
+				return;
+			}
+
 			next.onError(err);
 		},
 	);

--- a/packages/media/src/audio/sort-by-priority.ts
+++ b/packages/media/src/audio/sort-by-priority.ts
@@ -16,10 +16,17 @@ const CONCURRENCY = 1;
 
 const waiters: Waiter[] = [];
 let running = 0;
+let runningEntry: {waiter: Waiter; settle: () => void} | null = null;
 
 export const processNext = (): void => {
 	if (running >= CONCURRENCY) {
-		return;
+		if (runningEntry?.waiter.getPriority() === null) {
+			// Running entry went stale: free its slot so a fresh waiter can run
+			// instead of deadlocking behind work nobody needs anymore.
+			runningEntry.settle();
+		} else {
+			return;
+		}
 	}
 
 	// Collect stale waiters first, remove them from the queue,
@@ -68,13 +75,30 @@ export const processNext = (): void => {
 	const [next] = waiters.splice(bestIndex, 1);
 	running++;
 
+	let settled = false;
+	const entry = {
+		waiter: next,
+		settle: () => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			running--;
+			if (runningEntry === entry) {
+				runningEntry = null;
+			}
+		},
+	};
+	runningEntry = entry;
+
 	next.fn().then(
 		(value) => {
-			running--;
+			entry.settle();
 			next.onDone(value, processNext);
 		},
 		(err) => {
-			running--;
+			entry.settle();
 			next.onError(err);
 		},
 	);

--- a/packages/media/src/test/sort-by-priority.test.ts
+++ b/packages/media/src/test/sort-by-priority.test.ts
@@ -1,0 +1,49 @@
+import {expect, test} from 'vitest';
+import {waitForTurn} from '../audio/sort-by-priority';
+
+test('does not resolve a running waiter after it got cancelled for being stale', async () => {
+	const events: string[] = [];
+	let firstPriority: number | null = 0;
+	const first = {
+		resolve: null as ((value: string) => void) | null,
+	};
+
+	waitForTurn({
+		getPriority: () => firstPriority,
+		fn: () =>
+			new Promise<string>((resolve) => {
+				first.resolve = resolve;
+			}),
+		onDone: () => {
+			events.push('first done');
+		},
+		onError: () => {
+			events.push('first error');
+		},
+	});
+
+	firstPriority = null;
+
+	waitForTurn({
+		getPriority: () => 0,
+		fn: () => Promise.resolve('second'),
+		onDone: () => {
+			events.push('second done');
+		},
+		onError: () => {
+			events.push('second error');
+		},
+	});
+
+	await Promise.resolve();
+	expect(events).toEqual(['second done']);
+
+	if (!first.resolve) {
+		throw new Error('First waiter did not start');
+	}
+
+	first.resolve('first');
+	await Promise.resolve();
+
+	expect(events).toEqual(['second done']);
+});


### PR DESCRIPTION
## Problem
When a task of the audio sample scheduler was in flight and its source went stale (e.g. the user scrubbed away before it resolved), `processNext` would bail out early at the `running >= CONCURRENCY` guard. Because the in-flight task could never resolve for work nobody needed anymore, the single slot was never released and every subsequent waiter queued behind it forever, leading to an infinite loading state.

Here's a recording reproducing the problem in Remotion Studio:

https://github.com/user-attachments/assets/137805c0-5624-4833-ae96-2b87a3c3cb82

This is the code used for setting up the above composition:

```Jsx
import React from 'react';
import { Video } from '@remotion/media';
import { AbsoluteFill, Composition, Sequence } from 'remotion';

const VIDEOS = [
	'https://res.cloudinary.com/demo/video/upload/dog.mp4',
	'https://res.cloudinary.com/demo/video/upload/outdoors.mp4'
];

const ScrubChurn: React.FC = () => (
	<AbsoluteFill>
		{VIDEOS.map((src, i) => (
			<Sequence key={i} from={i * 30} durationInFrames={30} premountFor={15}>
				<Video src={src} objectFit="cover" />
			</Sequence>
		))}
	</AbsoluteFill>
);

export const Root: React.FC = () => (
	<Composition
		id="ScrubChurn"
		component={ScrubChurn}
		durationInFrames={VIDEOS.length * 30}
		fps={30}
		width={1280}
		height={720}
	/>
);
```

## Fix
`processNext` now checks whether the currently running entry has gone stale. If so, it frees the slot immediately so a fresh waiter can run instead of deadlocking.
