### PR TITLE
`remotion`: Add spring easing rest threshold

### DIFF
--- a/packages/core/src/easing.ts
+++ b/packages/core/src/easing.ts
@@ -6,7 +6,9 @@ import type {SpringConfig} from './spring/spring-utils.js';
 
 export type EasingSpringConfig = Partial<
 	Pick<SpringConfig, 'damping' | 'mass' | 'stiffness' | 'overshootClamping'>
->;
+> & {
+	readonly durationRestThreshold?: number;
+};
 
 // Some easing curves are only defined on [0, 1] (e.g. quarter circle, bounce segments).
 // `interpolate(..., { extrapolate: 'extend' })` can pass values outside that interval; clamp
@@ -70,7 +72,9 @@ export class Easing {
 		return (t): number => t * t * ((s + 1) * t - s);
 	}
 
-	static spring(config: EasingSpringConfig = {}): (t: number) => number {
+	static spring({durationRestThreshold, ...config}: EasingSpringConfig = {}): (
+		t: number,
+	) => number {
 		return (t): number => {
 			if (t <= 0) {
 				return 0;
@@ -85,6 +89,7 @@ export class Easing {
 				frame: t * springEasingDurationInFrames,
 				config,
 				durationInFrames: springEasingDurationInFrames,
+				durationRestThreshold,
 			});
 		};
 	}

--- a/packages/core/src/interpolate-keyframed-status.ts
+++ b/packages/core/src/interpolate-keyframed-status.ts
@@ -21,6 +21,7 @@ const easingToFn = (e: CanUpdateSequencePropStatusEasing): EasingFunction => {
 		case 'spring':
 			return Easing.spring({
 				damping: e.damping,
+				durationRestThreshold: e.durationRestThreshold ?? undefined,
 				mass: e.mass,
 				overshootClamping: e.overshootClamping,
 				stiffness: e.stiffness,

--- a/packages/core/src/test/easing.test.ts
+++ b/packages/core/src/test/easing.test.ts
@@ -260,6 +260,28 @@ describe('Easing spring', () => {
 		}
 	});
 
+	test('supports a custom rest threshold', () => {
+		const config = {
+			damping: 200,
+			mass: 1,
+			stiffness: 100,
+		};
+		const durationRestThreshold = 0.1;
+		const easing = Easing.spring({...config, durationRestThreshold});
+
+		for (const t of [0.1, 0.25, 0.5, 0.75, 0.9]) {
+			expect(easing(t)).toBe(
+				spring({
+					fps: 30,
+					frame: t * 30,
+					durationInFrames: 30,
+					durationRestThreshold,
+					config,
+				}),
+			);
+		}
+	});
+
 	test('clamps the endpoints', () => {
 		const easing = Easing.spring();
 

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -42,6 +42,7 @@ export type CanUpdateSequencePropStatusSpringEasing = {
 	mass: number;
 	stiffness: number;
 	overshootClamping: boolean;
+	durationRestThreshold: number | null;
 };
 
 export type CanUpdateSequencePropStatusEasing =

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -122,7 +122,11 @@ import StarTest from './Shapes/StarTest';
 import TriangleTest from './Shapes/TriangleTest';
 import {SimpleImg} from './SimpleImg';
 import {SkipZeroFrame} from './SkipZeroFrame';
-import {BaseSpring, SpringWithDuration} from './Spring/base-spring';
+import {
+	BaseSpring,
+	RestThresholdSpringSquare,
+	SpringWithDuration,
+} from './Spring/base-spring';
 import {SeriesTesting} from './StaggerTesting';
 import {StaticDemo} from './StaticServer';
 import {StillHelloWorld} from './StillHelloWorld';
@@ -597,6 +601,22 @@ export const Index: React.FC = () => {
 					height={1080}
 					fps={30}
 					durationInFrames={100}
+				/>
+				<Composition
+					id="rest-threshold-spring-square"
+					component={RestThresholdSpringSquare}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={90}
+				/>
+				<Composition
+					id="tail-spring-square"
+					component={RestThresholdSpringSquare}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={90}
 				/>
 			</Folder>
 			<Folder name="documentation">

--- a/packages/example/src/Spring/base-spring.tsx
+++ b/packages/example/src/Spring/base-spring.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {
+	AbsoluteFill,
+	Easing,
+	Interactive,
+	interpolate,
+	spring,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
 
 export const BaseSpring: React.FC = () => {
 	const frame = useCurrentFrame();
@@ -51,6 +59,47 @@ export const SpringWithDuration: React.FC = () => {
 						config: {},
 						durationInFrames: 90,
 					})})`,
+				}}
+			/>
+		</AbsoluteFill>
+	);
+};
+
+export const RestThresholdSpringSquare: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	return (
+		<AbsoluteFill
+			style={{
+				justifyContent: 'center',
+				alignItems: 'center',
+				backgroundColor: '#10131a',
+			}}
+		>
+			<div
+				style={{
+					position: 'absolute',
+					height: 240,
+					width: 240,
+					border: '3px solid rgba(255, 255, 255, 0.28)',
+				}}
+			/>
+			<Interactive.Div
+				style={{
+					height: 240,
+					width: 240,
+					backgroundColor: '#0b84f3',
+					boxShadow: '0 24px 70px rgba(11, 132, 243, 0.35)',
+					scale: interpolate(frame, [0, 16], [0, 1], {
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'extend',
+						easing: [Easing.bezier(0, 0, 0.276, 1.0297)],
+					}),
+					translate: interpolate(frame, [0, 16], ['0px 1464.4px', '0px 0px'], {
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+						easing: [Easing.bezier(0, 0, 0.58, 1)],
+					}),
 				}}
 			/>
 		</AbsoluteFill>

--- a/packages/studio-shared/src/easing-clipboard-data.ts
+++ b/packages/studio-shared/src/easing-clipboard-data.ts
@@ -41,8 +41,22 @@ const isEasing = (value: unknown): value is KeyframeEasing => {
 				isFiniteNumber(value.damping) &&
 				isFiniteNumber(value.mass) &&
 				isFiniteNumber(value.stiffness) &&
+				(value.durationRestThreshold === undefined ||
+					value.durationRestThreshold === null ||
+					isFiniteNumber(value.durationRestThreshold)) &&
 				typeof value.overshootClamping === 'boolean'))
 	);
+};
+
+const normalizeEasing = (easing: KeyframeEasing): KeyframeEasing => {
+	if (easing.type !== 'spring') {
+		return easing;
+	}
+
+	return {
+		...easing,
+		durationRestThreshold: easing.durationRestThreshold ?? null,
+	};
 };
 
 export const parseEasingClipboardDataResult = (
@@ -75,7 +89,7 @@ export const parseEasingClipboardDataResult = (
 				type: 'easing',
 				version: 1,
 				remotionClipboard: 'easing',
-				easing: parsed.easing,
+				easing: normalizeEasing(parsed.easing),
 			},
 		};
 	} catch {

--- a/packages/studio-shared/src/effect-clipboard-data.ts
+++ b/packages/studio-shared/src/effect-clipboard-data.ts
@@ -119,8 +119,49 @@ const isEasing = (value: unknown): value is EffectClipboardEasing => {
 				isFiniteNumber(value.damping) &&
 				isFiniteNumber(value.mass) &&
 				isFiniteNumber(value.stiffness) &&
+				(value.durationRestThreshold === undefined ||
+					value.durationRestThreshold === null ||
+					isFiniteNumber(value.durationRestThreshold)) &&
 				typeof value.overshootClamping === 'boolean'))
 	);
+};
+
+const normalizeEasing = (
+	easing: EffectClipboardEasing,
+): EffectClipboardEasing => {
+	if (easing.type !== 'spring') {
+		return easing;
+	}
+
+	return {
+		...easing,
+		durationRestThreshold: easing.durationRestThreshold ?? null,
+	};
+};
+
+const normalizeParam = (param: EffectClipboardParam): EffectClipboardParam => {
+	if (param.type === 'static') {
+		return param;
+	}
+
+	return {
+		...param,
+		easing: param.easing.map(normalizeEasing),
+	};
+};
+
+const normalizeSnapshot = (
+	snapshot: EffectClipboardSnapshot,
+): EffectClipboardSnapshot => {
+	return {
+		...snapshot,
+		params: Object.fromEntries(
+			Object.entries(snapshot.params).map(([key, param]) => [
+				key,
+				normalizeParam(param),
+			]),
+		),
+	};
 };
 
 const isKeyframe = (value: unknown): value is EffectClipboardKeyframe => {
@@ -223,7 +264,7 @@ export const parseEffectClipboardDataResult = (
 				return {status: 'invalid'};
 			}
 
-			effects.push(effect);
+			effects.push(normalizeSnapshot(effect));
 		}
 
 		return {
@@ -305,7 +346,7 @@ export const parseEffectPropClipboardDataResult = (
 					importPath: parsed.effect.importPath,
 				},
 				key: parsed.key,
-				param: parsed.param,
+				param: normalizeParam(parsed.param),
 			},
 		};
 	} catch {

--- a/packages/studio-shared/src/keyframe-easing-presets.ts
+++ b/packages/studio-shared/src/keyframe-easing-presets.ts
@@ -37,6 +37,7 @@ export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [
 		easing: {
 			type: 'spring',
 			damping: 10,
+			durationRestThreshold: null,
 			mass: 1,
 			overshootClamping: false,
 			stiffness: 100,
@@ -48,6 +49,7 @@ export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [
 		easing: {
 			type: 'spring',
 			damping: 5,
+			durationRestThreshold: null,
 			mass: 1,
 			overshootClamping: false,
 			stiffness: 120,

--- a/packages/studio-shared/src/parse-spring-easing-config.ts
+++ b/packages/studio-shared/src/parse-spring-easing-config.ts
@@ -1,6 +1,7 @@
 export type SpringKeyframeEasing = {
 	readonly type: 'spring';
 	damping: number;
+	durationRestThreshold: number | null;
 	mass: number;
 	overshootClamping: boolean;
 	stiffness: number;
@@ -9,6 +10,7 @@ export type SpringKeyframeEasing = {
 export const DEFAULT_SPRING_EASING: SpringKeyframeEasing = {
 	type: 'spring',
 	damping: 10,
+	durationRestThreshold: null,
 	mass: 1,
 	overshootClamping: false,
 	stiffness: 100,
@@ -107,7 +109,12 @@ export const parseSpringEasingConfig = (
 			return null;
 		}
 
-		if (key === 'damping' || key === 'mass' || key === 'stiffness') {
+		if (
+			key === 'damping' ||
+			key === 'mass' ||
+			key === 'stiffness' ||
+			key === 'durationRestThreshold'
+		) {
 			const numericValue = getNumericValue(prop.value);
 			if (
 				numericValue === null ||

--- a/packages/studio-shared/src/test/effect-clipboard-data.test.ts
+++ b/packages/studio-shared/src/test/effect-clipboard-data.test.ts
@@ -54,6 +54,7 @@ test('parseEasingClipboardData accepts easing payloads', () => {
 	).toEqual({
 		type: 'spring',
 		damping: 12,
+		durationRestThreshold: null,
 		mass: 1.5,
 		stiffness: 180,
 		overshootClamping: true,
@@ -186,6 +187,7 @@ test('parseEffectClipboardData accepts spring easing payloads', () => {
 			{
 				type: 'spring',
 				damping: 12,
+				durationRestThreshold: null,
 				mass: 1.5,
 				stiffness: 180,
 				overshootClamping: true,

--- a/packages/studio-shared/src/test/parse-spring-easing-config.test.ts
+++ b/packages/studio-shared/src/test/parse-spring-easing-config.test.ts
@@ -41,11 +41,18 @@ test('parseSpringEasingConfig parses a static spring config object', () => {
 					key: {type: 'Identifier', name: 'overshootClamping'},
 					value: {type: 'BooleanLiteral', value: true},
 				},
+				{
+					type: 'ObjectProperty',
+					computed: false,
+					key: {type: 'Identifier', name: 'durationRestThreshold'},
+					value: {type: 'NumericLiteral', value: 0.1},
+				},
 			],
 		}),
 	).toEqual({
 		type: 'spring',
 		damping: 12,
+		durationRestThreshold: 0.1,
 		mass: 1.5,
 		stiffness: 180,
 		overshootClamping: true,

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -43,7 +43,11 @@ type SpringEasing = Extract<TimelineEasingValue, {type: 'spring'}>;
 type HandleIndex = 0 | 1;
 type Coordinate = 'x' | 'y';
 type EditorMode = 'bezier' | 'spring';
-type SpringNumberKey = 'damping' | 'mass' | 'stiffness';
+type SpringNumberKey =
+	| 'damping'
+	| 'durationRestThreshold'
+	| 'mass'
+	| 'stiffness';
 type EasingGraphLabels = {
 	readonly start: string;
 	readonly end: string;
@@ -78,9 +82,11 @@ const PRESET_PREVIEW_HEIGHT = 30;
 const PRESET_PREVIEW_PADDING = 5;
 const PRESET_PREVIEW_Y_MIN = -0.35;
 const PRESET_PREVIEW_Y_MAX = 1.45;
+const DEFAULT_DURATION_REST_THRESHOLD = 0.005;
 const DEFAULT_SPRING_EASING: SpringEasing = {
 	type: 'spring',
 	damping: 10,
+	durationRestThreshold: null,
 	mass: 1,
 	overshootClamping: false,
 	stiffness: 100,
@@ -103,14 +109,23 @@ const SPRING_LIMITS: Record<
 	}
 > = {
 	damping: {min: 1, max: 200, step: 1},
+	durationRestThreshold: {min: 0.001, max: 0.5, step: 0.001},
 	mass: {min: 0.1, max: 20, step: 0.1},
 	stiffness: {min: 1, max: 1000, step: 1},
 };
 
 const SPRING_DECIMAL_PLACES: Record<SpringNumberKey, number> = {
 	damping: 0,
+	durationRestThreshold: 3,
 	mass: 2,
 	stiffness: 0,
+};
+
+const SPRING_FALLBACKS: Record<SpringNumberKey, number> = {
+	damping: DEFAULT_SPRING_EASING.damping,
+	durationRestThreshold: DEFAULT_DURATION_REST_THRESHOLD,
+	mass: DEFAULT_SPRING_EASING.mass,
+	stiffness: DEFAULT_SPRING_EASING.stiffness,
 };
 
 const inlineContainer: React.CSSProperties = {
@@ -280,6 +295,14 @@ const sanitizeSpring = (spring: SpringEasing): SpringEasing => ({
 		'damping',
 		DEFAULT_SPRING_EASING.damping,
 	),
+	durationRestThreshold:
+		spring.durationRestThreshold === null
+			? null
+			: sanitizeSpringValue(
+					spring.durationRestThreshold,
+					'durationRestThreshold',
+					DEFAULT_DURATION_REST_THRESHOLD,
+				),
 	mass: sanitizeSpringValue(spring.mass, 'mass', DEFAULT_SPRING_EASING.mass),
 	overshootClamping: spring.overshootClamping,
 	stiffness: sanitizeSpringValue(
@@ -317,6 +340,9 @@ const springFormatters: Record<
 	(value: number | string) => string
 > = {
 	damping: formatNumberWithDecimalPlaces(SPRING_DECIMAL_PLACES.damping),
+	durationRestThreshold: formatNumberWithDecimalPlaces(
+		SPRING_DECIMAL_PLACES.durationRestThreshold,
+	),
 	mass: formatNumberWithDecimalPlaces(SPRING_DECIMAL_PLACES.mass),
 	stiffness: formatNumberWithDecimalPlaces(SPRING_DECIMAL_PLACES.stiffness),
 };
@@ -340,6 +366,7 @@ const areEasingsEqual = (
 			return (
 				second.type === 'spring' &&
 				first.damping === second.damping &&
+				first.durationRestThreshold === second.durationRestThreshold &&
 				first.mass === second.mass &&
 				first.overshootClamping === second.overshootClamping &&
 				first.stiffness === second.stiffness
@@ -465,6 +492,7 @@ const getEasingFunction = (easing: TimelineEasingValue) => {
 		case 'spring':
 			return Easing.spring({
 				damping: easing.damping,
+				durationRestThreshold: easing.durationRestThreshold ?? undefined,
 				mass: easing.mass,
 				overshootClamping: easing.overshootClamping,
 				stiffness: easing.stiffness,
@@ -883,7 +911,7 @@ export const EasingEditor: React.FC<{
 		(key: SpringNumberKey, value: number, commit: boolean) => {
 			const next = {
 				...springRef.current,
-				[key]: sanitizeSpringValue(value, key, DEFAULT_SPRING_EASING[key]),
+				[key]: sanitizeSpringValue(value, key, SPRING_FALLBACKS[key]),
 			};
 			const version = setSpringAndPreview(next);
 
@@ -1046,6 +1074,7 @@ export const EasingEditor: React.FC<{
 	const springPath = useMemo(() => {
 		const easing = Easing.spring({
 			damping: spring.damping,
+			durationRestThreshold: spring.durationRestThreshold ?? undefined,
 			mass: spring.mass,
 			overshootClamping: spring.overshootClamping,
 			stiffness: spring.stiffness,
@@ -1357,6 +1386,37 @@ export const EasingEditor: React.FC<{
 									style={numberInputStyle}
 									snapToStep={false}
 									dragDecimalPlaces={SPRING_DECIMAL_PLACES.stiffness}
+									disabled={disabled}
+								/>
+							</div>
+						</div>
+						<div style={coordinateRow}>
+							<div style={coordinateLabel}>Rest threshold</div>
+							<div style={coordinateInputWrapper}>
+								<InputDragger
+									type="number"
+									value={
+										spring.durationRestThreshold ??
+										DEFAULT_DURATION_REST_THRESHOLD
+									}
+									status="ok"
+									onValueChange={(value) =>
+										setSpringNumber('durationRestThreshold', value, false)
+									}
+									onValueChangeEnd={(value) =>
+										setSpringNumber('durationRestThreshold', value, true)
+									}
+									onTextChange={() => undefined}
+									min={SPRING_LIMITS.durationRestThreshold.min}
+									max={SPRING_LIMITS.durationRestThreshold.max}
+									step={SPRING_LIMITS.durationRestThreshold.step}
+									formatter={springFormatters.durationRestThreshold}
+									rightAlign={false}
+									style={numberInputStyle}
+									snapToStep={false}
+									dragDecimalPlaces={
+										SPRING_DECIMAL_PLACES.durationRestThreshold
+									}
 									disabled={disabled}
 								/>
 							</div>


### PR DESCRIPTION
## Summary

- Add `durationRestThreshold` support to `Easing.spring()`
- Thread spring easing rest thresholds through keyframed prop status, Studio shared parsing, clipboard data, presets, and the Studio easing editor
- Add an interactive example composition for the rest-threshold spring square

## Testing

- `bunx oxfmt src --write` in affected packages
- `bun run build`
- `bun run stylecheck`
