### PR TITLE
`remotion`: Add spring easing tail support

### DIFF
--- a/packages/core/src/easing.ts
+++ b/packages/core/src/easing.ts
@@ -1,12 +1,14 @@
 // Taken from https://github.com/facebook/react-native/blob/0b9ea60b4fee8cacc36e7160e31b91fc114dbc0d/Libraries/Animated/src/Easing.js
 
 import {bezier} from './bezier.js';
-import {spring} from './spring/index.js';
+import type {EasingFunction} from './interpolate.js';
+import {measureSpring, spring} from './spring/index.js';
 import type {SpringConfig} from './spring/spring-utils.js';
 
 export type EasingSpringConfig = Partial<
 	Pick<SpringConfig, 'damping' | 'mass' | 'stiffness' | 'overshootClamping'>
 > & {
+	readonly allowTail?: boolean;
 	readonly durationRestThreshold?: number;
 };
 
@@ -72,16 +74,32 @@ export class Easing {
 		return (t): number => t * t * ((s + 1) * t - s);
 	}
 
-	static spring({durationRestThreshold, ...config}: EasingSpringConfig = {}): (
-		t: number,
-	) => number {
-		return (t): number => {
+	static spring({
+		allowTail = false,
+		durationRestThreshold,
+		...config
+	}: EasingSpringConfig = {}): (t: number) => number {
+		const easing: EasingFunction = (t): number => {
 			if (t <= 0) {
 				return 0;
 			}
 
-			if (t >= 1) {
+			if (!allowTail && t >= 1) {
 				return 1;
+			}
+
+			if (allowTail) {
+				return spring({
+					fps: springEasingDurationInFrames,
+					frame:
+						t *
+						measureSpring({
+							fps: springEasingDurationInFrames,
+							config,
+							threshold: durationRestThreshold,
+						}),
+					config,
+				});
 			}
 
 			return spring({
@@ -92,6 +110,10 @@ export class Easing {
 				durationRestThreshold,
 			});
 		};
+
+		return Object.assign(easing, {
+			remotionShouldExtendRight: allowTail,
+		});
 	}
 
 	static bounce(t: number): number {

--- a/packages/core/src/easing.ts
+++ b/packages/core/src/easing.ts
@@ -6,7 +6,9 @@ import type {SpringConfig} from './spring/spring-utils.js';
 
 export type EasingSpringConfig = Partial<
 	Pick<SpringConfig, 'damping' | 'mass' | 'stiffness' | 'overshootClamping'>
->;
+> & {
+	readonly durationRestThreshold?: number;
+};
 
 // Some easing curves are only defined on [0, 1] (e.g. quarter circle, bounce segments).
 // `interpolate(..., { extrapolate: 'extend' })` can pass values outside that interval; clamp
@@ -70,7 +72,9 @@ export class Easing {
 		return (t): number => t * t * ((s + 1) * t - s);
 	}
 
-	static spring(config: EasingSpringConfig = {}): (t: number) => number {
+	static spring({durationRestThreshold, ...config}: EasingSpringConfig = {}): (
+		t: number,
+	) => number {
 		return (t): number => {
 			if (t <= 0) {
 				return 0;
@@ -85,6 +89,7 @@ export class Easing {
 				frame: t * springEasingDurationInFrames,
 				config,
 				durationInFrames: springEasingDurationInFrames,
+				durationRestThreshold,
 			});
 		};
 	}

--- a/packages/core/src/effects/use-memoized-effects.ts
+++ b/packages/core/src/effects/use-memoized-effects.ts
@@ -88,6 +88,7 @@ const resolvePropStatusOverrides = (
 
 		if (status.status === 'keyframed') {
 			const value = interpolateKeyframedStatus({
+				forceSpringAllowTail: null,
 				frame,
 				status,
 			});

--- a/packages/core/src/get-effective-visual-mode-value.ts
+++ b/packages/core/src/get-effective-visual-mode-value.ts
@@ -34,6 +34,7 @@ export const resolveDragOverrideValue = ({
 	}
 
 	const interpolated = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame,
 		status: dragOverrideValue.status,
 	});
@@ -70,6 +71,7 @@ export const getEffectiveVisualModeValue = ({
 	if (propStatus.status === 'keyframed') {
 		if (frame !== null) {
 			return interpolateKeyframedStatus({
+				forceSpringAllowTail: null,
 				frame,
 				status: propStatus,
 			});

--- a/packages/core/src/interpolate-keyframed-status.ts
+++ b/packages/core/src/interpolate-keyframed-status.ts
@@ -14,32 +14,41 @@ type InterpolateKeyframedStatusResult =
 	| readonly number[]
 	| null;
 
-const easingToFn = (e: CanUpdateSequencePropStatusEasing): EasingFunction => {
-	switch (e.type) {
+const easingToFn = ({
+	easing,
+	forceSpringAllowTail,
+}: {
+	easing: CanUpdateSequencePropStatusEasing;
+	forceSpringAllowTail: boolean | null;
+}): EasingFunction => {
+	switch (easing.type) {
 		case 'linear':
 			return Easing.linear;
 		case 'spring':
 			return Easing.spring({
-				damping: e.damping,
-				durationRestThreshold: e.durationRestThreshold ?? undefined,
-				mass: e.mass,
-				overshootClamping: e.overshootClamping,
-				stiffness: e.stiffness,
+				allowTail: forceSpringAllowTail ?? easing.allowTail ?? undefined,
+				damping: easing.damping,
+				durationRestThreshold: easing.durationRestThreshold ?? undefined,
+				mass: easing.mass,
+				overshootClamping: easing.overshootClamping,
+				stiffness: easing.stiffness,
 			});
 		case 'bezier':
-			return bezier(e.x1, e.y1, e.x2, e.y2);
+			return bezier(easing.x1, easing.y1, easing.x2, easing.y2);
 		default:
 			throw new TypeError(
-				`Unsupported easing: ${JSON.stringify(e satisfies never)}`,
+				`Unsupported easing: ${JSON.stringify(easing satisfies never)}`,
 			);
 	}
 };
 
 export const interpolateKeyframedStatus = ({
 	frame,
+	forceSpringAllowTail,
 	status,
 }: {
 	frame: number;
+	forceSpringAllowTail: boolean | null;
 	status: CanUpdateSequencePropStatusKeyframed;
 }): InterpolateKeyframedStatusResult => {
 	const {keyframes, easing, clamping, interpolationFunction} = status;
@@ -62,7 +71,9 @@ export const interpolateKeyframedStatus = ({
 
 		try {
 			return interpolateColors(frame, inputRange, outputs as string[], {
-				easing: easing.map(easingToFn),
+				easing: easing.map((e) =>
+					easingToFn({easing: e, forceSpringAllowTail}),
+				),
 				posterize: status.posterize,
 			});
 		} catch {
@@ -80,7 +91,9 @@ export const interpolateKeyframedStatus = ({
 			inputRange,
 			outputs as (number | string | number[])[],
 			{
-				easing: easing.map(easingToFn),
+				easing: easing.map((e) =>
+					easingToFn({easing: e, forceSpringAllowTail}),
+				),
 				extrapolateLeft: clamping.left,
 				extrapolateRight: clamping.right,
 				posterize: status.posterize,

--- a/packages/core/src/interpolate-keyframed-status.ts
+++ b/packages/core/src/interpolate-keyframed-status.ts
@@ -21,6 +21,7 @@ const easingToFn = (e: CanUpdateSequencePropStatusEasing): EasingFunction => {
 		case 'spring':
 			return Easing.spring({
 				damping: e.damping,
+				durationRestThreshold: e.durationRestThreshold ?? undefined,
 				mass: e.mass,
 				overshootClamping: e.overshootClamping,
 				stiffness: e.stiffness,

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -9,7 +9,9 @@ export type ExtrapolateType = 'extend' | 'identity' | 'clamp' | 'wrap';
  * @see [Documentation](https://www.remotion.dev/docs/interpolate)
  */
 
-export type EasingFunction = (input: number) => number;
+export type EasingFunction = ((input: number) => number) & {
+	readonly remotionShouldExtendRight?: boolean;
+};
 
 export type InterpolateOptions = Partial<{
 	easing: EasingFunction | readonly EasingFunction[];
@@ -507,6 +509,56 @@ function findRange(input: number, inputRange: readonly number[]) {
 
 const defaultEasing = (num: number): number => num;
 
+const shouldExtendRightForEasing = (easing: EasingFunction): boolean => {
+	return easing.remotionShouldExtendRight === true;
+};
+
+const resolveEasingForSegment = ({
+	easing,
+	segmentIndex,
+}: {
+	easing: InterpolateOptions['easing'];
+	segmentIndex: number;
+}): EasingFunction => {
+	if (easing === undefined) {
+		return defaultEasing;
+	}
+
+	if (typeof easing === 'function') {
+		return easing;
+	}
+
+	// `segmentIndex` is in [0, inputRange.length - 2]; array length was validated above.
+	return easing[segmentIndex] as EasingFunction;
+};
+
+const interpolateSegment = ({
+	input,
+	inputRange,
+	outputRange,
+	easing,
+	extrapolateLeft,
+	extrapolateRight,
+}: {
+	input: number;
+	inputRange: [number, number];
+	outputRange: [number, number];
+	easing: EasingFunction;
+	extrapolateLeft: ExtrapolateType;
+	extrapolateRight: ExtrapolateType;
+}): number => {
+	return interpolateFunction(input, inputRange, outputRange, {
+		easing,
+		extrapolateLeft,
+		extrapolateRight:
+			input > inputRange[1] &&
+			extrapolateRight === 'clamp' &&
+			shouldExtendRightForEasing(easing)
+				? 'extend'
+				: extrapolateRight,
+	});
+};
+
 const interpolateNumber = ({
 	input,
 	inputRange,
@@ -523,18 +575,6 @@ const interpolateNumber = ({
 	}
 
 	const easingOption = options?.easing;
-	const resolveEasingForSegment = (segmentIndex: number): EasingFunction => {
-		if (easingOption === undefined) {
-			return defaultEasing;
-		}
-
-		if (typeof easingOption === 'function') {
-			return easingOption;
-		}
-
-		// `segmentIndex` is in [0, inputRange.length - 2]; array length was validated above.
-		return easingOption[segmentIndex] as EasingFunction;
-	};
 
 	let extrapolateLeft: ExtrapolateType = 'extend';
 	if (options?.extrapolateLeft !== undefined) {
@@ -551,16 +591,45 @@ const interpolateNumber = ({
 			? input
 			: Math.floor(input / options.posterize) * options.posterize;
 	const range = findRange(posterizedInput, inputRange);
-	return interpolateFunction(
-		posterizedInput,
-		[inputRange[range], inputRange[range + 1]],
-		[outputRange[range], outputRange[range + 1]],
-		{
-			easing: resolveEasingForSegment(range),
+	const easing = resolveEasingForSegment({
+		easing: easingOption,
+		segmentIndex: range,
+	});
+	let result = interpolateSegment({
+		input: posterizedInput,
+		inputRange: [inputRange[range], inputRange[range + 1]],
+		outputRange: [outputRange[range], outputRange[range + 1]],
+		easing,
+		extrapolateLeft,
+		extrapolateRight,
+	});
+
+	for (let segmentIndex = 0; segmentIndex < range; segmentIndex++) {
+		const previousEasing = resolveEasingForSegment({
+			easing: easingOption,
+			segmentIndex,
+		});
+		if (!shouldExtendRightForEasing(previousEasing)) {
+			continue;
+		}
+
+		const previousSegmentEnd = inputRange[segmentIndex + 1];
+		if (posterizedInput <= previousSegmentEnd) {
+			continue;
+		}
+
+		const continuedSegmentValue = interpolateSegment({
+			input: posterizedInput,
+			inputRange: [inputRange[segmentIndex], previousSegmentEnd],
+			outputRange: [outputRange[segmentIndex], outputRange[segmentIndex + 1]],
+			easing: previousEasing,
 			extrapolateLeft,
-			extrapolateRight,
-		},
-	);
+			extrapolateRight: 'extend',
+		});
+		result += continuedSegmentValue - outputRange[segmentIndex + 1];
+	}
+
+	return result;
 };
 
 const interpolateString = ({

--- a/packages/core/src/test/easing.test.ts
+++ b/packages/core/src/test/easing.test.ts
@@ -260,6 +260,28 @@ describe('Easing spring', () => {
 		}
 	});
 
+	test('supports a custom rest threshold', () => {
+		const config = {
+			damping: 200,
+			mass: 1,
+			stiffness: 100,
+		};
+		const durationRestThreshold = 0.1;
+		const easing = Easing.spring({...config, durationRestThreshold});
+
+		for (const t of [0.1, 0.25, 0.5, 0.75, 0.9]) {
+			expect(easing(t)).toBe(
+				spring({
+					fps: 30,
+					frame: t * 30,
+					durationInFrames: 30,
+					durationRestThreshold,
+					config,
+				}),
+			);
+		}
+	});
+
 	test('clamps the endpoints', () => {
 		const easing = Easing.spring();
 

--- a/packages/core/src/test/easing.test.ts
+++ b/packages/core/src/test/easing.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from 'bun:test';
 import {Easing} from '../easing.js';
-import {spring} from '../spring/index.js';
+import {measureSpring, spring} from '../spring/index.js';
 
 const numbersToTest = [-0.5, 0, 0.4, 0.5, 0.7, 1, 1.5];
 
@@ -280,6 +280,36 @@ describe('Easing spring', () => {
 				}),
 			);
 		}
+	});
+
+	test('can leave a spring tail after the easing duration', () => {
+		const config = {
+			damping: 200,
+			mass: 1,
+			stiffness: 100,
+		};
+		const durationRestThreshold = 0.1;
+		const easing = Easing.spring({
+			...config,
+			allowTail: true,
+			durationRestThreshold,
+		});
+		const naturalDuration = measureSpring({
+			fps: 30,
+			config,
+			threshold: durationRestThreshold,
+		});
+
+		expect(easing(0.5)).toBe(
+			spring({
+				fps: 30,
+				frame: naturalDuration * 0.5,
+				config,
+			}),
+		);
+		expect(easing(1)).toBeLessThan(1);
+		expect(easing(1.5)).toBeGreaterThan(easing(1));
+		expect(easing(2)).toBeLessThanOrEqual(1);
 	});
 
 	test('clamps the endpoints', () => {

--- a/packages/core/src/test/interpolate-keyframed-status.test.ts
+++ b/packages/core/src/test/interpolate-keyframed-status.test.ts
@@ -1,8 +1,10 @@
 import {expect, test} from 'bun:test';
 import {interpolateKeyframedStatus} from '../interpolate-keyframed-status';
+import type {CanUpdateSequencePropStatusKeyframed} from '../use-schema';
 
 test('interpolates linear numeric keyframes', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 30,
 		status: {
 			status: 'keyframed',
@@ -21,6 +23,7 @@ test('interpolates linear numeric keyframes', () => {
 
 test('interpolates linear tuple keyframes', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 30,
 		status: {
 			status: 'keyframed',
@@ -39,6 +42,7 @@ test('interpolates linear tuple keyframes', () => {
 
 test('sorts keyframes before interpolating numeric values', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 75,
 		status: {
 			status: 'keyframed',
@@ -58,6 +62,7 @@ test('sorts keyframes before interpolating numeric values', () => {
 
 test('clamps when extrapolation is clamp', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 120,
 		status: {
 			status: 'keyframed',
@@ -76,6 +81,7 @@ test('clamps when extrapolation is clamp', () => {
 
 test('posterizes the frame before interpolating numeric keyframes', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 17,
 		status: {
 			status: 'keyframed',
@@ -94,6 +100,7 @@ test('posterizes the frame before interpolating numeric keyframes', () => {
 
 test('returns single keyframe value', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 100,
 		status: {
 			status: 'keyframed',
@@ -109,6 +116,7 @@ test('returns single keyframe value', () => {
 
 test('interpolates colors', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 30,
 		status: {
 			status: 'keyframed',
@@ -128,6 +136,7 @@ test('interpolates colors', () => {
 
 test('interpolates color keyframes with easing', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 30,
 		status: {
 			status: 'keyframed',
@@ -146,6 +155,7 @@ test('interpolates color keyframes with easing', () => {
 
 test('posterizes the frame before interpolating color keyframes', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 17,
 		status: {
 			status: 'keyframed',
@@ -164,6 +174,7 @@ test('posterizes the frame before interpolating color keyframes', () => {
 
 test('interpolates translate keyframes', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 30,
 		status: {
 			status: 'keyframed',
@@ -180,8 +191,71 @@ test('interpolates translate keyframes', () => {
 	expect(result).toBe('60px 30px');
 });
 
+test('can force spring allowTail off for timeline value previews', () => {
+	const parseTranslate = (value: string): [number, number] => {
+		const [x, y] = value.split(' ');
+		return [Number(x.replace('px', '')), Number(y.replace('px', ''))];
+	};
+
+	const status: CanUpdateSequencePropStatusKeyframed = {
+		status: 'keyframed',
+		interpolationFunction: 'interpolate',
+		keyframes: [
+			{frame: 0, value: '0px 1000px'},
+			{frame: 30, value: '0px 0px'},
+			{frame: 60, value: '1000px 0px'},
+		],
+		easing: [
+			{
+				type: 'spring',
+				allowTail: true,
+				damping: 200,
+				durationRestThreshold: 0.03,
+				mass: 1,
+				overshootClamping: false,
+				stiffness: 100,
+			},
+			{
+				type: 'spring',
+				allowTail: true,
+				damping: 200,
+				durationRestThreshold: 0.03,
+				mass: 1,
+				overshootClamping: false,
+				stiffness: 100,
+			},
+		],
+		clamping: {left: 'clamp', right: 'extend'},
+		posterize: undefined,
+	};
+
+	const preserved = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
+		frame: 45,
+		status,
+	});
+	const forcedOff = interpolateKeyframedStatus({
+		forceSpringAllowTail: false,
+		frame: 45,
+		status,
+	});
+
+	if (typeof preserved !== 'string' || typeof forcedOff !== 'string') {
+		throw new Error('Expected string interpolation result');
+	}
+
+	const [preservedX, preservedY] = parseTranslate(preserved);
+	const [forcedOffX, forcedOffY] = parseTranslate(forcedOff);
+
+	expect(preservedX).toBeGreaterThan(0);
+	expect(forcedOffX).toBeGreaterThan(0);
+	expect(preservedY).toBeGreaterThan(0);
+	expect(forcedOffY).toBe(0);
+});
+
 test('interpolates rotate keyframes', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 30,
 		status: {
 			status: 'keyframed',
@@ -200,6 +274,7 @@ test('interpolates rotate keyframes', () => {
 
 test('uses bezier easing', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 30,
 		status: {
 			status: 'keyframed',
@@ -219,6 +294,7 @@ test('uses bezier easing', () => {
 
 test('interpolates scale strings component-wise', () => {
 	const result = interpolateKeyframedStatus({
+		forceSpringAllowTail: null,
 		frame: 30,
 		status: {
 			status: 'keyframed',

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -505,6 +505,101 @@ test('Clamp right test', () => {
 	).toEqual(-1000);
 });
 
+test('Allow tail spring extends right extrapolation', () => {
+	const tailValue = interpolate(60, [0, 30], [1000, 0], {
+		extrapolateRight: 'clamp',
+		easing: Easing.spring({
+			allowTail: true,
+			damping: 200,
+			durationRestThreshold: 0.1,
+			mass: 1,
+			stiffness: 100,
+		}),
+	});
+
+	expect(tailValue).toBeGreaterThan(0);
+	expect(tailValue).toBeLessThan(10);
+
+	expect(
+		interpolate(60, [0, 30], [1000, 0], {
+			extrapolateRight: 'clamp',
+			easing: Easing.spring({
+				damping: 200,
+				durationRestThreshold: 0.1,
+				mass: 1,
+				stiffness: 100,
+			}),
+		}),
+	).toBe(0);
+});
+
+test('Allow tail spring keeps previous string segment settling while the next segment starts', () => {
+	const parseTranslate = (value: string): [number, number] => {
+		const [x, y] = value.split(' ');
+		return [Number(x.replace('px', '')), Number(y.replace('px', ''))];
+	};
+
+	const withoutTail = interpolate(
+		45,
+		[0, 30, 60],
+		['0px 1000px', '0px 0px', '1000px 0px'],
+		{
+			extrapolateLeft: 'clamp',
+			extrapolateRight: 'extend',
+			easing: [
+				Easing.spring({
+					damping: 200,
+					durationRestThreshold: 0.03,
+					mass: 1,
+					stiffness: 100,
+				}),
+				Easing.spring({
+					damping: 200,
+					durationRestThreshold: 0.03,
+					mass: 1,
+					stiffness: 100,
+				}),
+			],
+		},
+	);
+	const withTail = interpolate(
+		45,
+		[0, 30, 60],
+		['0px 1000px', '0px 0px', '1000px 0px'],
+		{
+			extrapolateLeft: 'clamp',
+			extrapolateRight: 'extend',
+			easing: [
+				Easing.spring({
+					allowTail: true,
+					damping: 200,
+					durationRestThreshold: 0.03,
+					mass: 1,
+					stiffness: 100,
+					overshootClamping: false,
+				}),
+				Easing.spring({
+					allowTail: true,
+					damping: 200,
+					durationRestThreshold: 0.03,
+					mass: 1,
+					stiffness: 100,
+					overshootClamping: false,
+				}),
+			],
+		},
+	);
+
+	const [xWithoutTail, yWithoutTail] = parseTranslate(withoutTail);
+	const [xWithTail, yWithTail] = parseTranslate(withTail);
+
+	expect(xWithoutTail).toBeGreaterThan(0);
+	expect(xWithTail).toBeGreaterThan(0);
+	expect(yWithoutTail).toBe(0);
+	expect(yWithTail).toBeGreaterThan(0);
+	expect(yWithTail).toBeLessThan(10);
+});
+
 test('Clamp left test', () => {
 	expect(
 		interpolate(-2000, [0, 1, 1000], [Math.PI, 1, -1000], {

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -38,6 +38,7 @@ export type CanUpdateSequencePropStatusBezierEasing = {
 
 export type CanUpdateSequencePropStatusSpringEasing = {
 	type: 'spring';
+	allowTail: boolean | null;
 	damping: number;
 	mass: number;
 	stiffness: number;
@@ -240,6 +241,7 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 					value = dragOverride.value;
 				} else if (frame !== null) {
 					const interpolated = interpolateKeyframedStatus({
+						forceSpringAllowTail: null,
 						frame,
 						status,
 					});

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -42,6 +42,7 @@ export type CanUpdateSequencePropStatusSpringEasing = {
 	mass: number;
 	stiffness: number;
 	overshootClamping: boolean;
+	durationRestThreshold: number | null;
 };
 
 export type CanUpdateSequencePropStatusEasing =

--- a/packages/docs/docs/easing.mdx
+++ b/packages/docs/docs/easing.mdx
@@ -220,11 +220,67 @@ import {Easing, interpolate} from 'remotion';
 const scale = interpolate(30, [0, 60], [0, 1], {
   easing: Easing.spring({
     damping: 200,
+    durationRestThreshold: 0.03,
   }),
 });
 ```
 
-The supported config fields are `damping`, `mass`, `stiffness` and `overshootClamping`.
+The spring is measured as if it takes 30 frames.
+
+The supported config fields are `damping`, `mass`, `stiffness`, `overshootClamping`, `durationRestThreshold` and `allowTail`.
+
+#### `damping?`
+
+How hard the spring decelerates. Default: `10`.
+
+#### `mass?`
+
+The weight of the spring. Default: `1`.
+
+#### `stiffness?`
+
+Spring stiffness coefficient. Default: `100`.
+
+#### `overshootClamping?`
+
+Determines whether the spring can overshoot the end value. Default: `false`.
+
+#### `durationRestThreshold?`<AvailableFrom v="4.0.483" />
+
+How close the spring should get to the end value during the 30-frame easing duration. Default: same as [`spring()`](/docs/spring#durationrestthreshold).
+
+A lower value makes the spring get closer to the end value within the interpolation segment.
+A higher value leaves more of the movement for the end of the segment.
+
+#### `allowTail?`<AvailableFrom v="4.0.483" />
+
+Allows the spring to continue past the end of the interpolation segment. Default: `false`.
+
+When enabled, `interpolate()` lets the spring tail continue after the segment end. In multi-keyframe interpolations, the previous spring tail can keep settling while the next segment already starts.
+
+```tsx twoslash title="MyComponent.tsx"
+import {Easing, interpolate} from 'remotion';
+// ---cut---
+const translate = interpolate(
+  45,
+  [0, 30, 60],
+  ['0px 1000px', '0px 0px', '1000px 0px'],
+  {
+    easing: [
+      Easing.spring({
+        allowTail: true,
+        damping: 200,
+        durationRestThreshold: 0.03,
+      }),
+      Easing.spring({
+        allowTail: true,
+        damping: 200,
+        durationRestThreshold: 0.03,
+      }),
+    ],
+  },
+);
+```
 
 ---
 

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -122,7 +122,11 @@ import StarTest from './Shapes/StarTest';
 import TriangleTest from './Shapes/TriangleTest';
 import {SimpleImg} from './SimpleImg';
 import {SkipZeroFrame} from './SkipZeroFrame';
-import {BaseSpring, SpringWithDuration} from './Spring/base-spring';
+import {
+	BaseSpring,
+	RestThresholdSpringSquare,
+	SpringWithDuration,
+} from './Spring/base-spring';
 import {SeriesTesting} from './StaggerTesting';
 import {StaticDemo} from './StaticServer';
 import {StillHelloWorld} from './StillHelloWorld';
@@ -597,6 +601,22 @@ export const Index: React.FC = () => {
 					height={1080}
 					fps={30}
 					durationInFrames={100}
+				/>
+				<Composition
+					id="rest-threshold-spring-square"
+					component={RestThresholdSpringSquare}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={90}
+				/>
+				<Composition
+					id="tail-spring-square"
+					component={RestThresholdSpringSquare}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={90}
 				/>
 			</Folder>
 			<Folder name="documentation">

--- a/packages/example/src/Spring/base-spring.tsx
+++ b/packages/example/src/Spring/base-spring.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {
+	AbsoluteFill,
+	Easing,
+	Interactive,
+	interpolate,
+	spring,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
 
 export const BaseSpring: React.FC = () => {
 	const frame = useCurrentFrame();
@@ -51,6 +59,47 @@ export const SpringWithDuration: React.FC = () => {
 						config: {},
 						durationInFrames: 90,
 					})})`,
+				}}
+			/>
+		</AbsoluteFill>
+	);
+};
+
+export const RestThresholdSpringSquare: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	return (
+		<AbsoluteFill
+			style={{
+				justifyContent: 'center',
+				alignItems: 'center',
+				backgroundColor: '#10131a',
+			}}
+		>
+			<div
+				style={{
+					position: 'absolute',
+					height: 240,
+					width: 240,
+					border: '3px solid rgba(255, 255, 255, 0.28)',
+				}}
+			/>
+			<Interactive.Div
+				style={{
+					height: 240,
+					width: 240,
+					backgroundColor: '#0b84f3',
+					boxShadow: '0 24px 70px rgba(11, 132, 243, 0.35)',
+					scale: interpolate(frame, [0, 16], [0, 1], {
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'extend',
+						easing: [Easing.bezier(0, 0, 0.276, 1.0297)],
+					}),
+					translate: interpolate(frame, [0, 16], ['0px 1464.4px', '0px 0px'], {
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+						easing: [Easing.bezier(0, 0, 0.58, 1)],
+					}),
 				}}
 			/>
 		</AbsoluteFill>

--- a/packages/example/src/Spring/base-spring.tsx
+++ b/packages/example/src/Spring/base-spring.tsx
@@ -90,16 +90,33 @@ export const RestThresholdSpringSquare: React.FC = () => {
 					width: 240,
 					backgroundColor: '#0b84f3',
 					boxShadow: '0 24px 70px rgba(11, 132, 243, 0.35)',
-					scale: interpolate(frame, [0, 16], [0, 1], {
-						extrapolateLeft: 'clamp',
-						extrapolateRight: 'extend',
-						easing: [Easing.bezier(0, 0, 0.276, 1.0297)],
-					}),
-					translate: interpolate(frame, [0, 16], ['0px 1464.4px', '0px 0px'], {
-						extrapolateLeft: 'clamp',
-						extrapolateRight: 'clamp',
-						easing: [Easing.bezier(0, 0, 0.58, 1)],
-					}),
+					translate: interpolate(
+						frame,
+						[0, 30, 60],
+						['0px 1000px', '0px 0px', '1000px 0px'],
+						{
+							extrapolateLeft: 'clamp',
+							extrapolateRight: 'extend',
+							easing: [
+								Easing.spring({
+									damping: 200,
+									mass: 1,
+									stiffness: 100,
+									allowTail: true,
+									durationRestThreshold: 0.03,
+									overshootClamping: false,
+								}),
+								Easing.spring({
+									damping: 200,
+									mass: 1,
+									stiffness: 100,
+									allowTail: true,
+									durationRestThreshold: 0.03,
+									overshootClamping: false,
+								}),
+							],
+						},
+					),
 				}}
 			/>
 		</AbsoluteFill>

--- a/packages/studio-server/src/codemods/effect-param-expression.ts
+++ b/packages/studio-server/src/codemods/effect-param-expression.ts
@@ -108,6 +108,22 @@ const makeEasingExpression = ({
 							b.identifier('stiffness'),
 							parseValueExpression(easing.stiffness),
 						),
+						...(easing.allowTail === null
+							? []
+							: [
+									b.objectProperty(
+										b.identifier('allowTail'),
+										b.booleanLiteral(easing.allowTail),
+									),
+								]),
+						...(easing.durationRestThreshold === null
+							? []
+							: [
+									b.objectProperty(
+										b.identifier('durationRestThreshold'),
+										parseValueExpression(easing.durationRestThreshold),
+									),
+								]),
 						b.objectProperty(
 							b.identifier('overshootClamping'),
 							b.booleanLiteral(easing.overshootClamping),

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -583,6 +583,22 @@ const createEasingExpression = (easing: KeyframeEasing): ExpressionKind => {
 							b.identifier('stiffness'),
 							parseValueExpression(easing.stiffness),
 						),
+						...(easing.allowTail === null
+							? []
+							: [
+									b.objectProperty(
+										b.identifier('allowTail'),
+										b.booleanLiteral(easing.allowTail),
+									),
+								]),
+						...(easing.durationRestThreshold === null
+							? []
+							: [
+									b.objectProperty(
+										b.identifier('durationRestThreshold'),
+										parseValueExpression(easing.durationRestThreshold),
+									),
+								]),
 						b.objectProperty(
 							b.identifier('overshootClamping'),
 							b.booleanLiteral(easing.overshootClamping),

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -191,7 +191,7 @@ import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';
 export const Example: React.FC = () => {
 \tconst frame = useCurrentFrame();
 \treturn (
-\t\t<Sequence style={{opacity: interpolate(frame, [0, 100], [0, 1], {easing: Easing.spring({damping: 12, mass: 1.5, stiffness: 180, overshootClamping: true})})}} />
+\t\t<Sequence style={{opacity: interpolate(frame, [0, 100], [0, 1], {easing: Easing.spring({damping: 12, mass: 1.5, stiffness: 180, allowTail: true, durationRestThreshold: 0.1, overshootClamping: true})})}} />
 \t);
 };
 `;
@@ -216,7 +216,9 @@ export const Example: React.FC = () => {
 		easing: [
 			{
 				type: 'spring',
+				allowTail: true,
 				damping: 12,
+				durationRestThreshold: 0.1,
 				mass: 1.5,
 				stiffness: 180,
 				overshootClamping: true,

--- a/packages/studio-server/src/test/paste-effects.test.ts
+++ b/packages/studio-server/src/test/paste-effects.test.ts
@@ -247,7 +247,9 @@ export const Comp = () => {
 						easing: [
 							{
 								type: 'spring',
+								allowTail: true,
 								damping: 12,
+								durationRestThreshold: 0.1,
 								mass: 1.5,
 								stiffness: 180,
 								overshootClamping: true,
@@ -264,6 +266,8 @@ export const Comp = () => {
 	expect(output).toContain('damping: 12');
 	expect(output).toContain('mass: 1.5');
 	expect(output).toContain('stiffness: 180');
+	expect(output).toContain('allowTail: true');
+	expect(output).toContain('durationRestThreshold: 0.1');
 	expect(output).toContain('overshootClamping: true');
 });
 

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -285,7 +285,9 @@ export const Example: React.FC = () => {
 					segmentIndex: 0,
 					easing: {
 						type: 'spring',
+						allowTail: true,
 						damping: 12,
+						durationRestThreshold: 0.1,
 						mass: 1.5,
 						stiffness: 180,
 						overshootClamping: true,
@@ -301,6 +303,8 @@ export const Example: React.FC = () => {
 	expect(output).toContain('damping: 12');
 	expect(output).toContain('mass: 1.5');
 	expect(output).toContain('stiffness: 180');
+	expect(output).toContain('allowTail: true');
+	expect(output).toContain('durationRestThreshold: 0.1');
 	expect(output).toContain('overshootClamping: true');
 });
 

--- a/packages/studio-shared/src/easing-clipboard-data.ts
+++ b/packages/studio-shared/src/easing-clipboard-data.ts
@@ -41,6 +41,9 @@ const isEasing = (value: unknown): value is KeyframeEasing => {
 				isFiniteNumber(value.damping) &&
 				isFiniteNumber(value.mass) &&
 				isFiniteNumber(value.stiffness) &&
+				(value.allowTail === undefined ||
+					value.allowTail === null ||
+					typeof value.allowTail === 'boolean') &&
 				(value.durationRestThreshold === undefined ||
 					value.durationRestThreshold === null ||
 					isFiniteNumber(value.durationRestThreshold)) &&
@@ -55,6 +58,7 @@ const normalizeEasing = (easing: KeyframeEasing): KeyframeEasing => {
 
 	return {
 		...easing,
+		allowTail: easing.allowTail ?? null,
 		durationRestThreshold: easing.durationRestThreshold ?? null,
 	};
 };

--- a/packages/studio-shared/src/easing-clipboard-data.ts
+++ b/packages/studio-shared/src/easing-clipboard-data.ts
@@ -41,8 +41,22 @@ const isEasing = (value: unknown): value is KeyframeEasing => {
 				isFiniteNumber(value.damping) &&
 				isFiniteNumber(value.mass) &&
 				isFiniteNumber(value.stiffness) &&
+				(value.durationRestThreshold === undefined ||
+					value.durationRestThreshold === null ||
+					isFiniteNumber(value.durationRestThreshold)) &&
 				typeof value.overshootClamping === 'boolean'))
 	);
+};
+
+const normalizeEasing = (easing: KeyframeEasing): KeyframeEasing => {
+	if (easing.type !== 'spring') {
+		return easing;
+	}
+
+	return {
+		...easing,
+		durationRestThreshold: easing.durationRestThreshold ?? null,
+	};
 };
 
 export const parseEasingClipboardDataResult = (
@@ -75,7 +89,7 @@ export const parseEasingClipboardDataResult = (
 				type: 'easing',
 				version: 1,
 				remotionClipboard: 'easing',
-				easing: parsed.easing,
+				easing: normalizeEasing(parsed.easing),
 			},
 		};
 	} catch {

--- a/packages/studio-shared/src/effect-clipboard-data.ts
+++ b/packages/studio-shared/src/effect-clipboard-data.ts
@@ -119,6 +119,9 @@ const isEasing = (value: unknown): value is EffectClipboardEasing => {
 				isFiniteNumber(value.damping) &&
 				isFiniteNumber(value.mass) &&
 				isFiniteNumber(value.stiffness) &&
+				(value.allowTail === undefined ||
+					value.allowTail === null ||
+					typeof value.allowTail === 'boolean') &&
 				(value.durationRestThreshold === undefined ||
 					value.durationRestThreshold === null ||
 					isFiniteNumber(value.durationRestThreshold)) &&
@@ -135,6 +138,7 @@ const normalizeEasing = (
 
 	return {
 		...easing,
+		allowTail: easing.allowTail ?? null,
 		durationRestThreshold: easing.durationRestThreshold ?? null,
 	};
 };

--- a/packages/studio-shared/src/effect-clipboard-data.ts
+++ b/packages/studio-shared/src/effect-clipboard-data.ts
@@ -119,8 +119,49 @@ const isEasing = (value: unknown): value is EffectClipboardEasing => {
 				isFiniteNumber(value.damping) &&
 				isFiniteNumber(value.mass) &&
 				isFiniteNumber(value.stiffness) &&
+				(value.durationRestThreshold === undefined ||
+					value.durationRestThreshold === null ||
+					isFiniteNumber(value.durationRestThreshold)) &&
 				typeof value.overshootClamping === 'boolean'))
 	);
+};
+
+const normalizeEasing = (
+	easing: EffectClipboardEasing,
+): EffectClipboardEasing => {
+	if (easing.type !== 'spring') {
+		return easing;
+	}
+
+	return {
+		...easing,
+		durationRestThreshold: easing.durationRestThreshold ?? null,
+	};
+};
+
+const normalizeParam = (param: EffectClipboardParam): EffectClipboardParam => {
+	if (param.type === 'static') {
+		return param;
+	}
+
+	return {
+		...param,
+		easing: param.easing.map(normalizeEasing),
+	};
+};
+
+const normalizeSnapshot = (
+	snapshot: EffectClipboardSnapshot,
+): EffectClipboardSnapshot => {
+	return {
+		...snapshot,
+		params: Object.fromEntries(
+			Object.entries(snapshot.params).map(([key, param]) => [
+				key,
+				normalizeParam(param),
+			]),
+		),
+	};
 };
 
 const isKeyframe = (value: unknown): value is EffectClipboardKeyframe => {
@@ -223,7 +264,7 @@ export const parseEffectClipboardDataResult = (
 				return {status: 'invalid'};
 			}
 
-			effects.push(effect);
+			effects.push(normalizeSnapshot(effect));
 		}
 
 		return {
@@ -305,7 +346,7 @@ export const parseEffectPropClipboardDataResult = (
 					importPath: parsed.effect.importPath,
 				},
 				key: parsed.key,
-				param: parsed.param,
+				param: normalizeParam(parsed.param),
 			},
 		};
 	} catch {

--- a/packages/studio-shared/src/keyframe-easing-presets.ts
+++ b/packages/studio-shared/src/keyframe-easing-presets.ts
@@ -8,7 +8,8 @@ export type KeyframeEasingPreset = {
 		| 'ease-out'
 		| 'ease-in-out'
 		| 'spring'
-		| 'bouncy-spring';
+		| 'bouncy-spring'
+		| 'tail-spring';
 	readonly label: string;
 	readonly easing: KeyframeEasing;
 };
@@ -32,12 +33,26 @@ export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [
 		easing: {type: 'bezier', x1: 0.42, y1: 0, x2: 0.58, y2: 1},
 	},
 	{
+		id: 'tail-spring',
+		label: 'Tail spring',
+		easing: {
+			type: 'spring',
+			allowTail: true,
+			damping: 200,
+			durationRestThreshold: 0.02,
+			mass: 1,
+			overshootClamping: false,
+			stiffness: 100,
+		},
+	},
+	{
 		id: 'spring',
 		label: 'Spring',
 		easing: {
 			type: 'spring',
+			allowTail: true,
 			damping: 10,
-			durationRestThreshold: null,
+			durationRestThreshold: 0.02,
 			mass: 1,
 			overshootClamping: false,
 			stiffness: 100,
@@ -48,8 +63,9 @@ export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [
 		label: 'Bouncy spring',
 		easing: {
 			type: 'spring',
+			allowTail: true,
 			damping: 5,
-			durationRestThreshold: null,
+			durationRestThreshold: 0.02,
 			mass: 1,
 			overshootClamping: false,
 			stiffness: 120,

--- a/packages/studio-shared/src/keyframe-easing-presets.ts
+++ b/packages/studio-shared/src/keyframe-easing-presets.ts
@@ -37,6 +37,7 @@ export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [
 		easing: {
 			type: 'spring',
 			damping: 10,
+			durationRestThreshold: null,
 			mass: 1,
 			overshootClamping: false,
 			stiffness: 100,
@@ -48,6 +49,7 @@ export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [
 		easing: {
 			type: 'spring',
 			damping: 5,
+			durationRestThreshold: null,
 			mass: 1,
 			overshootClamping: false,
 			stiffness: 120,

--- a/packages/studio-shared/src/parse-spring-easing-config.ts
+++ b/packages/studio-shared/src/parse-spring-easing-config.ts
@@ -1,6 +1,7 @@
 export type SpringKeyframeEasing = {
 	readonly type: 'spring';
 	damping: number;
+	durationRestThreshold: number | null;
 	mass: number;
 	overshootClamping: boolean;
 	stiffness: number;
@@ -9,6 +10,7 @@ export type SpringKeyframeEasing = {
 export const DEFAULT_SPRING_EASING: SpringKeyframeEasing = {
 	type: 'spring',
 	damping: 10,
+	durationRestThreshold: null,
 	mass: 1,
 	overshootClamping: false,
 	stiffness: 100,
@@ -107,7 +109,12 @@ export const parseSpringEasingConfig = (
 			return null;
 		}
 
-		if (key === 'damping' || key === 'mass' || key === 'stiffness') {
+		if (
+			key === 'damping' ||
+			key === 'mass' ||
+			key === 'stiffness' ||
+			key === 'durationRestThreshold'
+		) {
 			const numericValue = getNumericValue(prop.value);
 			if (
 				numericValue === null ||

--- a/packages/studio-shared/src/parse-spring-easing-config.ts
+++ b/packages/studio-shared/src/parse-spring-easing-config.ts
@@ -1,5 +1,6 @@
 export type SpringKeyframeEasing = {
 	readonly type: 'spring';
+	allowTail: boolean | null;
 	damping: number;
 	durationRestThreshold: number | null;
 	mass: number;
@@ -9,6 +10,7 @@ export type SpringKeyframeEasing = {
 
 export const DEFAULT_SPRING_EASING: SpringKeyframeEasing = {
 	type: 'spring',
+	allowTail: null,
 	damping: 10,
 	durationRestThreshold: null,
 	mass: 1,
@@ -128,13 +130,13 @@ export const parseSpringEasingConfig = (
 			continue;
 		}
 
-		if (key === 'overshootClamping') {
+		if (key === 'overshootClamping' || key === 'allowTail') {
 			const booleanValue = getBooleanValue(prop.value);
 			if (booleanValue === null) {
 				return null;
 			}
 
-			spring.overshootClamping = booleanValue;
+			spring[key] = booleanValue;
 			continue;
 		}
 

--- a/packages/studio-shared/src/test/effect-clipboard-data.test.ts
+++ b/packages/studio-shared/src/test/effect-clipboard-data.test.ts
@@ -54,6 +54,7 @@ test('parseEasingClipboardData accepts easing payloads', () => {
 	).toEqual({
 		type: 'spring',
 		damping: 12,
+		durationRestThreshold: null,
 		mass: 1.5,
 		stiffness: 180,
 		overshootClamping: true,
@@ -186,6 +187,7 @@ test('parseEffectClipboardData accepts spring easing payloads', () => {
 			{
 				type: 'spring',
 				damping: 12,
+				durationRestThreshold: null,
 				mass: 1.5,
 				stiffness: 180,
 				overshootClamping: true,

--- a/packages/studio-shared/src/test/effect-clipboard-data.test.ts
+++ b/packages/studio-shared/src/test/effect-clipboard-data.test.ts
@@ -53,6 +53,7 @@ test('parseEasingClipboardData accepts easing payloads', () => {
 		)?.easing,
 	).toEqual({
 		type: 'spring',
+		allowTail: null,
 		damping: 12,
 		durationRestThreshold: null,
 		mass: 1.5,
@@ -186,6 +187,7 @@ test('parseEffectClipboardData accepts spring easing payloads', () => {
 		easing: [
 			{
 				type: 'spring',
+				allowTail: null,
 				damping: 12,
 				durationRestThreshold: null,
 				mass: 1.5,

--- a/packages/studio-shared/src/test/parse-spring-easing-config.test.ts
+++ b/packages/studio-shared/src/test/parse-spring-easing-config.test.ts
@@ -41,11 +41,18 @@ test('parseSpringEasingConfig parses a static spring config object', () => {
 					key: {type: 'Identifier', name: 'overshootClamping'},
 					value: {type: 'BooleanLiteral', value: true},
 				},
+				{
+					type: 'ObjectProperty',
+					computed: false,
+					key: {type: 'Identifier', name: 'durationRestThreshold'},
+					value: {type: 'NumericLiteral', value: 0.1},
+				},
 			],
 		}),
 	).toEqual({
 		type: 'spring',
 		damping: 12,
+		durationRestThreshold: 0.1,
 		mass: 1.5,
 		stiffness: 180,
 		overshootClamping: true,

--- a/packages/studio-shared/src/test/parse-spring-easing-config.test.ts
+++ b/packages/studio-shared/src/test/parse-spring-easing-config.test.ts
@@ -44,6 +44,12 @@ test('parseSpringEasingConfig parses a static spring config object', () => {
 				{
 					type: 'ObjectProperty',
 					computed: false,
+					key: {type: 'Identifier', name: 'allowTail'},
+					value: {type: 'BooleanLiteral', value: true},
+				},
+				{
+					type: 'ObjectProperty',
+					computed: false,
 					key: {type: 'Identifier', name: 'durationRestThreshold'},
 					value: {type: 'NumericLiteral', value: 0.1},
 				},
@@ -51,6 +57,7 @@ test('parseSpringEasingConfig parses a static spring config object', () => {
 		}),
 	).toEqual({
 		type: 'spring',
+		allowTail: true,
 		damping: 12,
 		durationRestThreshold: 0.1,
 		mass: 1.5,

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -82,11 +82,12 @@ const PRESET_PREVIEW_HEIGHT = 30;
 const PRESET_PREVIEW_PADDING = 5;
 const PRESET_PREVIEW_Y_MIN = -0.35;
 const PRESET_PREVIEW_Y_MAX = 1.45;
-const DEFAULT_DURATION_REST_THRESHOLD = 0.005;
+const DEFAULT_DURATION_REST_THRESHOLD = 0.02;
 const DEFAULT_SPRING_EASING: SpringEasing = {
 	type: 'spring',
+	allowTail: true,
 	damping: 10,
-	durationRestThreshold: null,
+	durationRestThreshold: DEFAULT_DURATION_REST_THRESHOLD,
 	mass: 1,
 	overshootClamping: false,
 	stiffness: 100,
@@ -290,6 +291,7 @@ const sanitizeSpringValue = (
 
 const sanitizeSpring = (spring: SpringEasing): SpringEasing => ({
 	type: 'spring',
+	allowTail: spring.allowTail,
 	damping: sanitizeSpringValue(
 		spring.damping,
 		'damping',
@@ -365,6 +367,7 @@ const areEasingsEqual = (
 		case 'spring':
 			return (
 				second.type === 'spring' &&
+				first.allowTail === second.allowTail &&
 				first.damping === second.damping &&
 				first.durationRestThreshold === second.durationRestThreshold &&
 				first.mass === second.mass &&
@@ -491,6 +494,7 @@ const getEasingFunction = (easing: TimelineEasingValue) => {
 			return Easing.bezier(easing.x1, easing.y1, easing.x2, easing.y2);
 		case 'spring':
 			return Easing.spring({
+				allowTail: easing.allowTail ?? undefined,
 				damping: easing.damping,
 				durationRestThreshold: easing.durationRestThreshold ?? undefined,
 				mass: easing.mass,
@@ -931,6 +935,15 @@ export const EasingEditor: React.FC<{
 		commitEasing(serializeSpring(next), version);
 	}, [commitEasing, setSpringAndPreview]);
 
+	const setAllowTail = useCallback(() => {
+		const next = {
+			...springRef.current,
+			allowTail: !(springRef.current.allowTail ?? false),
+		};
+		const version = setSpringAndPreview(next);
+		commitEasing(serializeSpring(next), version);
+	}, [commitEasing, setSpringAndPreview]);
+
 	const switchMode = useCallback(
 		(nextMode: EditorMode) => {
 			setMode(nextMode);
@@ -1073,6 +1086,7 @@ export const EasingEditor: React.FC<{
 	}, [endPoint, firstHandle, secondHandle, startPoint]);
 	const springPath = useMemo(() => {
 		const easing = Easing.spring({
+			allowTail: spring.allowTail ?? undefined,
 			damping: spring.damping,
 			durationRestThreshold: spring.durationRestThreshold ?? undefined,
 			mass: spring.mass,
@@ -1428,6 +1442,18 @@ export const EasingEditor: React.FC<{
 									checked={spring.overshootClamping}
 									onChange={setOvershootClamping}
 									name="spring-overshoot-clamping"
+									disabled={disabled}
+									variant="small"
+								/>
+							</div>
+						</div>
+						<div style={coordinateRow}>
+							<div style={coordinateLabel}>Allow tail</div>
+							<div style={checkboxWrapper}>
+								<Checkbox
+									checked={spring.allowTail ?? false}
+									onChange={setAllowTail}
+									name="spring-allow-tail"
 									disabled={disabled}
 									variant="small"
 								/>

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -43,7 +43,11 @@ type SpringEasing = Extract<TimelineEasingValue, {type: 'spring'}>;
 type HandleIndex = 0 | 1;
 type Coordinate = 'x' | 'y';
 type EditorMode = 'bezier' | 'spring';
-type SpringNumberKey = 'damping' | 'mass' | 'stiffness';
+type SpringNumberKey =
+	| 'damping'
+	| 'durationRestThreshold'
+	| 'mass'
+	| 'stiffness';
 type EasingGraphLabels = {
 	readonly start: string;
 	readonly end: string;
@@ -78,9 +82,11 @@ const PRESET_PREVIEW_HEIGHT = 30;
 const PRESET_PREVIEW_PADDING = 5;
 const PRESET_PREVIEW_Y_MIN = -0.35;
 const PRESET_PREVIEW_Y_MAX = 1.45;
+const DEFAULT_DURATION_REST_THRESHOLD = 0.005;
 const DEFAULT_SPRING_EASING: SpringEasing = {
 	type: 'spring',
 	damping: 10,
+	durationRestThreshold: null,
 	mass: 1,
 	overshootClamping: false,
 	stiffness: 100,
@@ -103,14 +109,23 @@ const SPRING_LIMITS: Record<
 	}
 > = {
 	damping: {min: 1, max: 200, step: 1},
+	durationRestThreshold: {min: 0.001, max: 0.5, step: 0.001},
 	mass: {min: 0.1, max: 20, step: 0.1},
 	stiffness: {min: 1, max: 1000, step: 1},
 };
 
 const SPRING_DECIMAL_PLACES: Record<SpringNumberKey, number> = {
 	damping: 0,
+	durationRestThreshold: 3,
 	mass: 2,
 	stiffness: 0,
+};
+
+const SPRING_FALLBACKS: Record<SpringNumberKey, number> = {
+	damping: DEFAULT_SPRING_EASING.damping,
+	durationRestThreshold: DEFAULT_DURATION_REST_THRESHOLD,
+	mass: DEFAULT_SPRING_EASING.mass,
+	stiffness: DEFAULT_SPRING_EASING.stiffness,
 };
 
 const inlineContainer: React.CSSProperties = {
@@ -280,6 +295,14 @@ const sanitizeSpring = (spring: SpringEasing): SpringEasing => ({
 		'damping',
 		DEFAULT_SPRING_EASING.damping,
 	),
+	durationRestThreshold:
+		spring.durationRestThreshold === null
+			? null
+			: sanitizeSpringValue(
+					spring.durationRestThreshold,
+					'durationRestThreshold',
+					DEFAULT_DURATION_REST_THRESHOLD,
+				),
 	mass: sanitizeSpringValue(spring.mass, 'mass', DEFAULT_SPRING_EASING.mass),
 	overshootClamping: spring.overshootClamping,
 	stiffness: sanitizeSpringValue(
@@ -317,6 +340,9 @@ const springFormatters: Record<
 	(value: number | string) => string
 > = {
 	damping: formatNumberWithDecimalPlaces(SPRING_DECIMAL_PLACES.damping),
+	durationRestThreshold: formatNumberWithDecimalPlaces(
+		SPRING_DECIMAL_PLACES.durationRestThreshold,
+	),
 	mass: formatNumberWithDecimalPlaces(SPRING_DECIMAL_PLACES.mass),
 	stiffness: formatNumberWithDecimalPlaces(SPRING_DECIMAL_PLACES.stiffness),
 };
@@ -340,6 +366,7 @@ const areEasingsEqual = (
 			return (
 				second.type === 'spring' &&
 				first.damping === second.damping &&
+				first.durationRestThreshold === second.durationRestThreshold &&
 				first.mass === second.mass &&
 				first.overshootClamping === second.overshootClamping &&
 				first.stiffness === second.stiffness
@@ -465,6 +492,7 @@ const getEasingFunction = (easing: TimelineEasingValue) => {
 		case 'spring':
 			return Easing.spring({
 				damping: easing.damping,
+				durationRestThreshold: easing.durationRestThreshold ?? undefined,
 				mass: easing.mass,
 				overshootClamping: easing.overshootClamping,
 				stiffness: easing.stiffness,
@@ -883,7 +911,7 @@ export const EasingEditor: React.FC<{
 		(key: SpringNumberKey, value: number, commit: boolean) => {
 			const next = {
 				...springRef.current,
-				[key]: sanitizeSpringValue(value, key, DEFAULT_SPRING_EASING[key]),
+				[key]: sanitizeSpringValue(value, key, SPRING_FALLBACKS[key]),
 			};
 			const version = setSpringAndPreview(next);
 
@@ -1046,6 +1074,7 @@ export const EasingEditor: React.FC<{
 	const springPath = useMemo(() => {
 		const easing = Easing.spring({
 			damping: spring.damping,
+			durationRestThreshold: spring.durationRestThreshold ?? undefined,
 			mass: spring.mass,
 			overshootClamping: spring.overshootClamping,
 			stiffness: spring.stiffness,
@@ -1357,6 +1386,37 @@ export const EasingEditor: React.FC<{
 									style={numberInputStyle}
 									snapToStep={false}
 									dragDecimalPlaces={SPRING_DECIMAL_PLACES.stiffness}
+									disabled={disabled}
+								/>
+							</div>
+						</div>
+						<div style={coordinateRow}>
+							<div style={coordinateLabel}>Rest threshold</div>
+							<div style={coordinateInputWrapper}>
+								<InputDragger
+									type="number"
+									value={
+										spring.durationRestThreshold ??
+										DEFAULT_DURATION_REST_THRESHOLD
+									}
+									status="ok"
+									onValueChange={(value) =>
+										setSpringNumber('durationRestThreshold', value, false)
+									}
+									onValueChangeEnd={(value) =>
+										setSpringNumber('durationRestThreshold', value, true)
+									}
+									onTextChange={() => undefined}
+									min={SPRING_LIMITS.durationRestThreshold.min}
+									max={SPRING_LIMITS.durationRestThreshold.max}
+									step={SPRING_LIMITS.durationRestThreshold.step}
+									formatter={springFormatters.durationRestThreshold}
+									rightAlign={false}
+									style={numberInputStyle}
+									snapToStep={false}
+									dragDecimalPlaces={
+										SPRING_DECIMAL_PLACES.durationRestThreshold
+									}
 									disabled={disabled}
 								/>
 							</div>

--- a/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
@@ -38,6 +38,7 @@ export const TimelineKeyframedValue: React.FC<{
 }) => {
 	const computedValue = useMemo(() => {
 		const raw = Internals.interpolateKeyframedStatus({
+			forceSpringAllowTail: false,
 			frame: sourceFrame,
 			status: propStatus,
 		});


### PR DESCRIPTION
## Summary

- add `durationRestThreshold` support for `Easing.spring()` so spring easing can use a custom measured duration
- add opt-in `allowTail` support so spring easing can continue settling past the segment end
- compose previous `allowTail` spring segment tails while later segments start, for more physical multi-keyframe motion
- expose and persist the new spring easing fields in Studio, code writeback, clipboard payloads, and the easing editor
- default Studio spring easing presets to `allowTail: true` and `durationRestThreshold: 0.02`
- add a Tail spring easing editor preset
- add an interactive example square that demonstrates the tail spring motion
- document the new `Easing.spring()` options

## Compatibility

This is an enhancement, not a breaking change. Runtime defaults for `Easing.spring()` keep `allowTail` off unless explicitly set; the Studio easing editor spring presets opt into the new tail behavior.

## Testing

- `bun test packages/core/src/test/interpolate-keyframed-status.test.ts packages/core/src/test/interpolate.test.ts packages/core/src/test/easing.test.ts`
- `bun test packages/studio-shared/src/test/parse-spring-easing-config.test.ts packages/studio-shared/src/test/effect-clipboard-data.test.ts`
- `bun run make` in `packages/studio-shared`
- `bun run make` in `packages/studio`
- `bun run build`
- `bun run stylecheck`
- `bun run build-docs`
