### PR TITLE
feat: auto-merge Sequence + Video into one timeline row with CapCut-like trimming

### DIFF
--- a/packages/example/src/VideoTesting/index.tsx
+++ b/packages/example/src/VideoTesting/index.tsx
@@ -26,7 +26,14 @@ export const VideoTesting: React.FC<{
 
 	return (
 		<div>
-			<Sequence durationInFrames={durationInFrames}>
+			<Sequence
+				durationInFrames={durationInFrames}
+				from={13}
+				style={{
+					rotate: '-37.7deg',
+					scale: 0.662,
+				}}
+			>
 				<Comp src={codec === 'mp4' ? videoMp4 : videoWebm} />
 			</Sequence>
 		</div>

--- a/packages/example/src/VideoTesting/trim.tsx
+++ b/packages/example/src/VideoTesting/trim.tsx
@@ -13,19 +13,30 @@ export const VideoTestingTrim: React.FC<{
 	const {durationInFrames} = useVideoConfig();
 	const videoMp4 = staticFile('framermp4withoutfileextension');
 
-	let Comp;
-	if (type === 'codec') {
-		Comp = NewVideo;
-	} else if (type === 'offthread') {
-		Comp = OffthreadVideo;
-	} else {
-		Comp = Video;
-	}
-
 	return (
 		<div>
-			<Sequence durationInFrames={durationInFrames}>
-				<Comp trimBefore={20} trimAfter={80} src={videoMp4} />
+			<Sequence
+				durationInFrames={durationInFrames}
+				style={{
+					scale: 0.601,
+					translate: '6.9px 62.5px',
+					rotate: '-168.7deg',
+				}}
+				from={7}
+			>
+				{type === 'codec' ? (
+					<NewVideo
+						trimBefore={42}
+						trimAfter={95}
+						src={videoMp4}
+						durationInFrames={55}
+						from={-2}
+					/>
+				) : type === 'offthread' ? (
+					<OffthreadVideo trimBefore={20} trimAfter={80} src={videoMp4} />
+				) : (
+					<Video trimBefore={20} trimAfter={80} src={videoMp4} />
+				)}
 			</Sequence>
 		</div>
 	);

--- a/packages/media/src/audio/audio.tsx
+++ b/packages/media/src/audio/audio.tsx
@@ -15,8 +15,17 @@ import type {AudioProps} from './props';
 
 const {validateMediaProps} = Internals;
 
+const trimAfterField = {
+	type: 'number',
+	default: undefined,
+	min: 1,
+	step: 1,
+	hiddenFromList: true,
+} as const satisfies InteractivitySchema[keyof InteractivitySchema];
+
 const audioSchema = {
 	...Internals.baseSchema,
+	trimAfter: trimAfterField,
 	volume: {
 		type: 'number',
 		min: 0,

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -16,8 +16,17 @@ import {VideoForRendering} from './video-for-rendering';
 const {validateMediaTrimProps, resolveTrimProps, validateMediaProps} =
 	Internals;
 
+const trimAfterField = {
+	type: 'number',
+	default: undefined,
+	min: 1,
+	step: 1,
+	hiddenFromList: true,
+} as const satisfies InteractivitySchema[keyof InteractivitySchema];
+
 const videoSchema = {
 	...Internals.baseSchema,
+	trimAfter: trimAfterField,
 	volume: {
 		type: 'number',
 		min: 0,

--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -3,6 +3,7 @@ import {useCallback, useContext, useEffect, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {calculateTimeline} from '../helpers/calculate-timeline';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
+import type {TrackWithHash} from '../helpers/get-timeline-sequence-sort-key';
 import {SHOW_BROWSER_RENDERING} from '../helpers/show-browser-rendering';
 import {timelineNodePathInfoToKey} from '../helpers/timeline-node-path-key';
 import {useKeybinding} from '../helpers/use-keybinding';
@@ -42,9 +43,12 @@ export const GlobalKeybindings: React.FC<{
 	const {navigateToNextComposition, navigateToPreviousComposition} =
 		useCompositionNavigation();
 	const video = Internals.useVideo();
-	const timeline = useMemo(() => {
+	const {tracks: timeline} = useMemo(() => {
 		if (videoConfig === null) {
-			return [];
+			return {
+				tracks: [] as TrackWithHash[],
+				mergedParentIds: new Set<string>(),
+			};
 		}
 
 		return calculateTimeline({

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -174,6 +174,28 @@ const SequenceExpandedInspector: React.FC<{
 					<InspectorSectionHeader>{children}</InspectorSectionHeader>
 				)}
 			/>
+			{track.mergedParentInfo ? (
+				<>
+					<InspectorSectionHeader>Container</InspectorSectionHeader>
+					<InspectorSequenceSection
+						sequence={
+							track.mergedParentInfo.sequence as NonNullable<
+								typeof track.mergedParentInfo.sequence
+							> & {
+								controls: NonNullable<
+									typeof track.mergedParentInfo.sequence.controls
+								>;
+							}
+						}
+						validatedLocation={validatedLocation}
+						nodePathInfo={track.mergedParentInfo.nodePathInfo}
+						keyframeDisplayOffset={track.keyframeDisplayOffset}
+						renderSectionHeader={(children) => (
+							<InspectorSectionHeader>{children}</InspectorSectionHeader>
+						)}
+					/>
+				</>
+			) : null}
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -223,9 +223,12 @@ const TimelineInner: React.FC = () => {
 
 	const videoConfigIsNull = videoConfig === null;
 
-	const timeline = useMemo((): TrackWithHash[] => {
+	const {tracks: timeline, mergedParentIds} = useMemo(() => {
 		if (videoConfigIsNull) {
-			return [];
+			return {
+				tracks: [] as TrackWithHash[],
+				mergedParentIds: new Set<string>(),
+			};
 		}
 
 		return calculateTimeline({
@@ -238,9 +241,9 @@ const TimelineInner: React.FC = () => {
 
 	const filtered = useMemo(() => {
 		return timeline.filter((t) =>
-			shouldShowTrackInTimeline(t, durationInFrames),
+			shouldShowTrackInTimeline(t, durationInFrames, mergedParentIds),
 		);
-	}, [durationInFrames, timeline]);
+	}, [durationInFrames, timeline, mergedParentIds]);
 
 	const shown = useMemo(() => {
 		return filtered.length > MAX_TIMELINE_TRACKS

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -262,13 +262,28 @@ const TimelineSequenceInner: React.FC<{
 			: undefined;
 	}, [propStatuses, nodePath]);
 	const durationCanUpdate = Boolean(
-		propStatusesForOverride?.durationInFrames?.status === 'static',
+		propStatusesForOverride
+			? propStatusesForOverride.durationInFrames?.status === 'static' ||
+					propStatusesForOverride.durationInFrames?.status === undefined
+			: false,
 	);
 	const fromCanUpdate = Boolean(
-		propStatusesForOverride?.from?.status === 'static',
+		propStatusesForOverride
+			? propStatusesForOverride.from?.status === 'static' ||
+					propStatusesForOverride.from?.status === undefined
+			: false,
 	);
 	const trimBeforeCanUpdate = Boolean(
-		propStatusesForOverride?.trimBefore?.status === 'static',
+		propStatusesForOverride
+			? propStatusesForOverride.trimBefore?.status === 'static' ||
+					propStatusesForOverride.trimBefore?.status === undefined
+			: false,
+	);
+	const trimAfterCanUpdate = Boolean(
+		propStatusesForOverride
+			? propStatusesForOverride.trimAfter?.status === 'static' ||
+					propStatusesForOverride.trimAfter?.status === undefined
+			: false,
 	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewConnected = previewServerState.type === 'connected';
@@ -505,12 +520,19 @@ const TimelineSequenceInner: React.FC<{
 	}, [marginLeft, s.type, width]);
 
 	const showRightEdgeDragHandle =
-		(s.type === 'sequence' || s.type === 'image') &&
-		!s.loopDisplay &&
-		!s.isInsideSeries &&
-		nodePath !== null &&
-		validatedLocation !== null &&
-		durationCanUpdate;
+		((s.type === 'sequence' || s.type === 'image') &&
+			!s.loopDisplay &&
+			!s.isInsideSeries &&
+			nodePath !== null &&
+			validatedLocation !== null &&
+			durationCanUpdate) ||
+		((s.type === 'audio' || s.type === 'video') &&
+			!s.loopDisplay &&
+			!s.isInsideSeries &&
+			nodePath !== null &&
+			validatedLocation !== null &&
+			Boolean(s.controls) &&
+			trimAfterCanUpdate);
 	const showLeftEdgeDragHandle =
 		(s.type === 'sequence' ||
 			s.type === 'image' ||
@@ -588,6 +610,7 @@ const TimelineSequenceInner: React.FC<{
 					nodePathInfo={nodePathInfo}
 					windowWidth={windowWidth}
 					timelineDurationInFrames={video.durationInFrames ?? 1}
+					type={s.type}
 				/>
 			) : null}
 		</TimelineSequenceCurrentFrame>

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -20,7 +20,10 @@ import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {calculateTimeline} from '../../helpers/calculate-timeline';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
-import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import type {
+	SequenceNodePathInfo,
+	TrackWithHash,
+} from '../../helpers/get-timeline-sequence-sort-key';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {
 	forceSpecificCursor,
@@ -36,7 +39,8 @@ import {
 	type TimelineSelection,
 } from './TimelineSelection';
 
-const HANDLE_WIDTH = 6;
+const HANDLE_WIDTH = 14;
+const HANDLE_GRIP_WIDTH = 3;
 
 const baseStyle: React.CSSProperties = {
 	position: 'absolute',
@@ -48,10 +52,34 @@ const baseStyle: React.CSSProperties = {
 	touchAction: 'none',
 };
 
+const gripBaseStyle: React.CSSProperties = {
+	position: 'absolute',
+	top: 2,
+	bottom: 2,
+	width: HANDLE_GRIP_WIDTH,
+	borderRadius: 999,
+	backgroundColor: 'rgba(255, 255, 255, 0.9)',
+	boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.12)',
+	opacity: 0.85,
+};
+
 export type TimelineSequenceDurationDragTarget = {
 	readonly fileName: string;
 	readonly initialDuration: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
+};
+
+export type TimelineSequenceMediaRightEdgeDragTarget = {
+	readonly fileName: string;
+	readonly initialDuration: number;
+	readonly initialTrimAfter: number;
+	readonly initialTrimBefore: number;
+	readonly maxMediaDuration: number | null;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly playbackRate: number;
+	readonly schema: InteractivitySchema;
+	readonly parentNodePath?: SequencePropsSubscriptionKey;
+	readonly parentInitialDuration?: number;
 };
 
 export type TimelineSequenceLeftEdgeDragTarget = {
@@ -102,10 +130,29 @@ const canUpdateTrimBefore = ({
 	readonly propStatuses: PropStatuses;
 	readonly nodePath: SequencePropsSubscriptionKey;
 }) => {
-	const status = Internals.getPropStatusesCtx(propStatuses, nodePath)
-		?.trimBefore?.status;
+	const ctx = Internals.getPropStatusesCtx(propStatuses, nodePath);
+	if (!ctx) {
+		return false;
+	}
 
-	return status === 'static';
+	const status = ctx.trimBefore?.status;
+	return status === 'static' || status === undefined;
+};
+
+const canUpdateTrimAfter = ({
+	propStatuses,
+	nodePath,
+}: {
+	readonly propStatuses: PropStatuses;
+	readonly nodePath: SequencePropsSubscriptionKey;
+}) => {
+	const ctx = Internals.getPropStatusesCtx(propStatuses, nodePath);
+	if (!ctx) {
+		return false;
+	}
+
+	const status = ctx.trimAfter?.status;
+	return status === 'static' || status === undefined;
 };
 
 const isDurationDraggableSequence = (sequence: TSequence) => {
@@ -143,6 +190,35 @@ export const getTimelineSequenceDurationDragValue = ({
 	readonly initialDuration: number;
 	readonly deltaFrames: number;
 }) => Math.max(1, initialDuration + deltaFrames);
+
+export const getTimelineSequenceMediaRightEdgeDragValues = ({
+	initialDuration,
+	initialTrimBefore,
+	deltaFrames,
+	playbackRate,
+	maxMediaDuration,
+}: {
+	readonly initialDuration: number;
+	readonly initialTrimBefore: number;
+	readonly deltaFrames: number;
+	readonly playbackRate: number;
+	readonly maxMediaDuration: number | null;
+}) => {
+	const unclampedDuration = Math.max(1, initialDuration + deltaFrames);
+	const maxDuration =
+		maxMediaDuration === null
+			? Number.POSITIVE_INFINITY
+			: Math.max(
+					1,
+					Math.floor((maxMediaDuration - initialTrimBefore) / playbackRate),
+				);
+	const durationInFrames = Math.min(unclampedDuration, maxDuration);
+
+	return {
+		durationInFrames,
+		trimAfter: initialTrimBefore + durationInFrames * playbackRate,
+	};
+};
 
 export const getTimelineSequenceLeftEdgeDragDelta = ({
 	initialDuration,
@@ -266,6 +342,57 @@ export const getTimelineSequenceDurationDragChanges = ({
 	});
 };
 
+export const getTimelineSequenceMediaRightEdgeDragChanges = ({
+	targets,
+	deltaFrames,
+}: {
+	readonly targets: readonly TimelineSequenceMediaRightEdgeDragTarget[];
+	readonly deltaFrames: number;
+}): SaveSequencePropChange[] => {
+	return targets.flatMap((target) => {
+		const nextValues = getTimelineSequenceMediaRightEdgeDragValues({
+			initialDuration: target.initialDuration,
+			initialTrimBefore: target.initialTrimBefore,
+			deltaFrames,
+			playbackRate: target.playbackRate,
+			maxMediaDuration: target.maxMediaDuration,
+		});
+
+		const result: SaveSequencePropChange[] = [];
+
+		if (nextValues.trimAfter !== target.initialTrimAfter) {
+			result.push({
+				fileName: target.fileName,
+				nodePath: target.nodePath,
+				fieldKey: 'trimAfter',
+				value: nextValues.trimAfter,
+				defaultValue: null,
+				schema: target.schema,
+			});
+		}
+
+		// For merged rows, also sync the parent's durationInFrames
+		if (target.parentNodePath && target.parentInitialDuration !== undefined) {
+			const parentDuration = Math.max(
+				1,
+				target.parentInitialDuration + deltaFrames,
+			);
+			if (parentDuration !== target.parentInitialDuration) {
+				result.push({
+					fileName: target.fileName,
+					nodePath: target.parentNodePath,
+					fieldKey: 'durationInFrames',
+					value: parentDuration,
+					defaultValue: null,
+					schema: NoReactInternals.sequenceSchema,
+				});
+			}
+		}
+
+		return result;
+	});
+};
+
 export const getTimelineSequenceFromDragValue = ({
 	initialFrom,
 	deltaFrames,
@@ -308,7 +435,7 @@ const findSequenceTrack = ({
 	tracks,
 	nodePathInfo,
 }: {
-	readonly tracks: ReturnType<typeof calculateTimeline>;
+	readonly tracks: readonly TrackWithHash[];
 	readonly nodePathInfo: SequenceNodePathInfo;
 }) => {
 	const key = stringifySequenceExpandedRowKey(
@@ -364,7 +491,7 @@ export const getTimelineSequenceDurationDragTargets = ({
 		draggedItemIsSelected && selectedSequenceItems.length > 1
 			? selectedSequenceItems.map((item) => item.nodePathInfo)
 			: [draggedNodePathInfo];
-	const tracks = calculateTimeline({sequences, overrideIdsToNodePaths});
+	const {tracks} = calculateTimeline({sequences, overrideIdsToNodePaths});
 	const targets = new Map<string, TimelineSequenceDurationDragTarget>();
 
 	for (const nodePathInfo of targetNodePathInfos) {
@@ -392,6 +519,114 @@ export const getTimelineSequenceDurationDragTargets = ({
 				fileName: nodePath.absolutePath,
 				initialDuration: originalSequence.duration,
 				nodePath,
+			});
+		}
+	}
+
+	return [...targets.values()];
+};
+
+export const getTimelineSequenceMediaRightEdgeDragTargets = ({
+	draggedNodePathInfo,
+	selectedItems,
+	sequences,
+	overrideIdsToNodePaths,
+	propStatuses,
+}: {
+	readonly draggedNodePathInfo: SequenceNodePathInfo;
+	readonly selectedItems: readonly TimelineSelection[];
+	readonly sequences: TSequence[];
+	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
+	readonly propStatuses: PropStatuses;
+}): TimelineSequenceMediaRightEdgeDragTarget[] | null => {
+	const draggedSelectionKey =
+		getTimelineSequenceSelectionKey(draggedNodePathInfo);
+	const selectedSequenceItems = selectedItems.filter(
+		(item): item is TimelineSelection & {type: 'sequence'} =>
+			item.type === 'sequence',
+	);
+	const draggedItemIsSelected = selectedSequenceItems.some(
+		(item) =>
+			getTimelineSequenceSelectionKey(item.nodePathInfo) ===
+			draggedSelectionKey,
+	);
+
+	if (
+		draggedItemIsSelected &&
+		selectedSequenceItems.length !== selectedItems.length
+	) {
+		return null;
+	}
+
+	const targetNodePathInfos =
+		draggedItemIsSelected && selectedSequenceItems.length > 1
+			? selectedSequenceItems.map((item) => item.nodePathInfo)
+			: [draggedNodePathInfo];
+	const {tracks} = calculateTimeline({sequences, overrideIdsToNodePaths});
+	const targets = new Map<string, TimelineSequenceMediaRightEdgeDragTarget>();
+
+	for (const nodePathInfo of targetNodePathInfos) {
+		const track = findSequenceTrack({tracks, nodePathInfo});
+		const originalSequence = track
+			? sequences.find((sequence) => sequence.id === track.sequence.id)
+			: null;
+		if (
+			!track ||
+			!track.nodePathInfo ||
+			!originalSequence ||
+			(originalSequence.type !== 'audio' && originalSequence.type !== 'video')
+		) {
+			return null;
+		}
+
+		const nodePath = track.nodePathInfo.sequenceSubscriptionKey;
+		if (!canUpdateTrimAfter({propStatuses, nodePath})) {
+			return null;
+		}
+
+		const {controls} = originalSequence;
+		if (!controls) {
+			return null;
+		}
+
+		// For merged rows, only sync parent's durationInFrames if it can be updated.
+		// If it's computed or keyframed, we still allow the media trim — just without
+		// the container sync, like trimming a clip in CapCut without resizing the track.
+		const parentInfo = track.mergedParentInfo
+			? (() => {
+					const parentNodePath =
+						track.mergedParentInfo!.nodePathInfo.sequenceSubscriptionKey;
+					if (
+						canUpdateDurationInFrames({propStatuses, nodePath: parentNodePath})
+					) {
+						return {
+							parentNodePath,
+							parentInitialDuration: track.mergedParentInfo!.sequence.duration,
+						};
+					}
+
+					return {};
+				})()
+			: {};
+
+		const initialTrimBefore =
+			originalSequence.trimBefore ??
+			Math.max(0, originalSequence.startMediaFrom);
+		const key = stringifySequenceSubscriptionKey(nodePath);
+
+		if (!targets.has(key)) {
+			targets.set(key, {
+				fileName: nodePath.absolutePath,
+				initialDuration: originalSequence.duration,
+				initialTrimAfter:
+					initialTrimBefore +
+					originalSequence.duration * originalSequence.playbackRate,
+				initialTrimBefore,
+				maxMediaDuration: null,
+				nodePath,
+				playbackRate: originalSequence.playbackRate,
+				schema: controls.schema,
+				...parentInfo,
 			});
 		}
 	}
@@ -435,7 +670,7 @@ export const getTimelineSequenceLeftEdgeDragTargets = ({
 		draggedItemIsSelected && selectedSequenceItems.length > 1
 			? selectedSequenceItems.map((item) => item.nodePathInfo)
 			: [draggedNodePathInfo];
-	const tracks = calculateTimeline({sequences, overrideIdsToNodePaths});
+	const {tracks} = calculateTimeline({sequences, overrideIdsToNodePaths});
 	const targets = new Map<string, TimelineSequenceLeftEdgeDragTarget>();
 
 	for (const nodePathInfo of targetNodePathInfos) {
@@ -523,7 +758,7 @@ export const getTimelineSequenceFromDragTargets = ({
 		draggedItemIsSelected && selectedSequenceItems.length > 1
 			? selectedSequenceItems.map((item) => item.nodePathInfo)
 			: [draggedNodePathInfo];
-	const tracks = calculateTimeline({sequences, overrideIdsToNodePaths});
+	const {tracks} = calculateTimeline({sequences, overrideIdsToNodePaths});
 	const targets = new Map<string, TimelineSequenceFromDragTarget>();
 
 	for (const nodePathInfo of targetNodePathInfos) {
@@ -582,6 +817,21 @@ const clearDurationDragOverrides = ({
 	}
 };
 
+const clearMediaRightEdgeDragOverrides = ({
+	clearDragOverrides,
+	targets,
+}: {
+	readonly clearDragOverrides: (nodePath: SequencePropsSubscriptionKey) => void;
+	readonly targets: readonly TimelineSequenceMediaRightEdgeDragTarget[];
+}) => {
+	for (const target of targets) {
+		clearDragOverrides(target.nodePath);
+		if (target.parentNodePath) {
+			clearDragOverrides(target.parentNodePath);
+		}
+	}
+};
+
 const clearFromDragOverrides = ({
 	clearDragOverrides,
 	targets,
@@ -613,6 +863,7 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 
 	const [dragging, setDragging] = useState(false);
+	const [hovered, setHovered] = useState(false);
 	const dragStateRef = useRef<{
 		initialClientX: number;
 		latestDeltaFrames: number;
@@ -833,7 +1084,8 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 	const style: React.CSSProperties = {
 		...baseStyle,
 		left: 0,
-		background: 'transparent',
+		background:
+			hovered || dragging ? 'rgba(255, 255, 255, 0.16)' : 'transparent',
 	};
 
 	return (
@@ -843,7 +1095,16 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 			title="Drag to trim start"
 			style={style}
 			onPointerDown={onPointerDown}
-		/>
+			onPointerEnter={() => setHovered(true)}
+			onPointerLeave={() => setHovered(false)}
+		>
+			<div
+				style={{
+					...gripBaseStyle,
+					left: 2,
+				}}
+			/>
+		</div>
 	);
 };
 
@@ -1085,7 +1346,8 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly windowWidth: number;
 	readonly timelineDurationInFrames: number;
-}> = ({nodePathInfo, windowWidth, timelineDurationInFrames}) => {
+	readonly type: TSequence['type'];
+}> = ({nodePathInfo, windowWidth, timelineDurationInFrames, type}) => {
 	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
@@ -1100,12 +1362,16 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 
 	const [dragging, setDragging] = useState(false);
+	const [hovered, setHovered] = useState(false);
 	const dragStateRef = useRef<{
 		initialClientX: number;
 		latestDeltaFrames: number;
 		pxPerFrame: number;
 		pointerId: number;
-		targets: readonly TimelineSequenceDurationDragTarget[];
+		targets:
+			| readonly TimelineSequenceDurationDragTarget[]
+			| readonly TimelineSequenceMediaRightEdgeDragTarget[];
+		mode: 'duration' | 'trimAfter';
 	} | null>(null);
 
 	// Keep latest props/setters available to window listeners installed once at pointerdown.
@@ -1144,20 +1410,38 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 			previewServerState: latestServerState,
 		} = latestRef.current;
 
-		const changes = getTimelineSequenceDurationDragChanges({
-			targets: dragState.targets,
-			deltaFrames: dragState.latestDeltaFrames,
-		});
+		const changes =
+			dragState.mode === 'trimAfter'
+				? getTimelineSequenceMediaRightEdgeDragChanges({
+						targets:
+							dragState.targets as readonly TimelineSequenceMediaRightEdgeDragTarget[],
+						deltaFrames: dragState.latestDeltaFrames,
+					})
+				: getTimelineSequenceDurationDragChanges({
+						targets:
+							dragState.targets as readonly TimelineSequenceDurationDragTarget[],
+						deltaFrames: dragState.latestDeltaFrames,
+					});
 
 		if (
 			!commit ||
 			latestServerState.type !== 'connected' ||
 			changes.length === 0
 		) {
-			clearDurationDragOverrides({
-				clearDragOverrides: latestClear,
-				targets: dragState.targets,
-			});
+			if (dragState.mode === 'trimAfter') {
+				clearMediaRightEdgeDragOverrides({
+					clearDragOverrides: latestClear,
+					targets:
+						dragState.targets as readonly TimelineSequenceMediaRightEdgeDragTarget[],
+				});
+			} else {
+				clearDurationDragOverrides({
+					clearDragOverrides: latestClear,
+					targets:
+						dragState.targets as readonly TimelineSequenceDurationDragTarget[],
+				});
+			}
+
 			return;
 		}
 
@@ -1166,26 +1450,47 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 			setPropStatuses: latestSetPropStatuses,
 			clientId: latestServerState.clientId,
 			undoLabel:
-				changes.length > 1 ? 'Resize selected sequences' : 'Resize sequence',
+				dragState.mode === 'trimAfter'
+					? changes.length > 1
+						? 'Trim selected clips'
+						: 'Trim clip'
+					: changes.length > 1
+						? 'Resize selected sequences'
+						: 'Resize sequence',
 			redoLabel:
-				changes.length > 1
-					? 'Resize selected sequences back'
-					: 'Resize sequence back',
+				dragState.mode === 'trimAfter'
+					? changes.length > 1
+						? 'Trim selected clips back'
+						: 'Trim clip back'
+					: changes.length > 1
+						? 'Resize selected sequences back'
+						: 'Resize sequence back',
 		});
 
 		savePromise
 			.catch((err) => {
 				Internals.Log.error(
 					{logLevel: 'error', tag: null},
-					'Could not save durationInFrames',
+					dragState.mode === 'trimAfter'
+						? 'Could not save trimAfter'
+						: 'Could not save durationInFrames',
 					err,
 				);
 			})
 			.finally(() => {
-				clearDurationDragOverrides({
-					clearDragOverrides: latestClear,
-					targets: dragState.targets,
-				});
+				if (dragState.mode === 'trimAfter') {
+					clearMediaRightEdgeDragOverrides({
+						clearDragOverrides: latestClear,
+						targets:
+							dragState.targets as readonly TimelineSequenceMediaRightEdgeDragTarget[],
+					});
+				} else {
+					clearDurationDragOverrides({
+						clearDragOverrides: latestClear,
+						targets:
+							dragState.targets as readonly TimelineSequenceDurationDragTarget[],
+					});
+				}
 			});
 	}, []);
 
@@ -1208,13 +1513,22 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 				overrideIdToNodePathMappings: latestOverrideIdsToNodePaths,
 			} = latestRef.current;
 			const {selectedItems: latestSelectedItems} = currentSelection.current;
-			const targets = getTimelineSequenceDurationDragTargets({
-				draggedNodePathInfo: latestNodePathInfo,
-				selectedItems: latestSelectedItems,
-				sequences: sequencesRef.current,
-				overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
-				propStatuses: propStatusesRef.current,
-			});
+			const isMediaTrimMode = type === 'audio' || type === 'video';
+			const targets = isMediaTrimMode
+				? getTimelineSequenceMediaRightEdgeDragTargets({
+						draggedNodePathInfo: latestNodePathInfo,
+						selectedItems: latestSelectedItems,
+						sequences: sequencesRef.current,
+						overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
+						propStatuses: propStatusesRef.current,
+					})
+				: getTimelineSequenceDurationDragTargets({
+						draggedNodePathInfo: latestNodePathInfo,
+						selectedItems: latestSelectedItems,
+						sequences: sequencesRef.current,
+						overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
+						propStatuses: propStatusesRef.current,
+					});
 			if (targets === null || targets.length === 0) {
 				return;
 			}
@@ -1227,6 +1541,7 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 				pxPerFrame,
 				pointerId: e.pointerId,
 				targets,
+				mode: isMediaTrimMode ? 'trimAfter' : 'duration',
 			};
 			document.body.style.userSelect = 'none';
 			document.body.style.webkitUserSelect = 'none';
@@ -1238,6 +1553,7 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 			propStatusesRef,
 			sequencesRef,
 			timelineDurationInFrames,
+			type,
 			windowWidth,
 		],
 	);
@@ -1259,7 +1575,42 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 			const dx = e.clientX - dragState.initialClientX;
 			const deltaFrames = Math.round(dx / dragState.pxPerFrame);
 			dragState.latestDeltaFrames = deltaFrames;
-			for (const target of dragState.targets) {
+			if (dragState.mode === 'trimAfter') {
+				for (const target of dragState.targets as readonly TimelineSequenceMediaRightEdgeDragTarget[]) {
+					const nextValues = getTimelineSequenceMediaRightEdgeDragValues({
+						initialDuration: target.initialDuration,
+						initialTrimBefore: target.initialTrimBefore,
+						deltaFrames,
+						playbackRate: target.playbackRate,
+						maxMediaDuration: target.maxMediaDuration,
+					});
+					latestRef.current.setDragOverrides(
+						target.nodePath,
+						'trimAfter',
+						Internals.makeStaticDragOverride(nextValues.trimAfter),
+					);
+
+					// For merged rows, also sync the parent's durationInFrames
+					if (
+						target.parentNodePath &&
+						target.parentInitialDuration !== undefined
+					) {
+						const parentDuration = Math.max(
+							1,
+							target.parentInitialDuration + deltaFrames,
+						);
+						latestRef.current.setDragOverrides(
+							target.parentNodePath,
+							'durationInFrames',
+							Internals.makeStaticDragOverride(parentDuration),
+						);
+					}
+				}
+
+				return;
+			}
+
+			for (const target of dragState.targets as readonly TimelineSequenceDurationDragTarget[]) {
 				latestRef.current.setDragOverrides(
 					target.nodePath,
 					'durationInFrames',
@@ -1312,16 +1663,30 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 	const style: React.CSSProperties = {
 		...baseStyle,
 		right: 0,
-		background: 'transparent',
+		background:
+			hovered || dragging ? 'rgba(255, 255, 255, 0.16)' : 'transparent',
 	};
 
 	return (
 		<div
 			role="separator"
 			aria-orientation="vertical"
-			title="Drag to change duration"
+			title={
+				type === 'audio' || type === 'video'
+					? 'Drag to trim end'
+					: 'Drag to change duration'
+			}
 			style={style}
 			onPointerDown={onPointerDown}
-		/>
+			onPointerEnter={() => setHovered(true)}
+			onPointerLeave={() => setHovered(false)}
+		>
+			<div
+				style={{
+					...gripBaseStyle,
+					right: 2,
+				}}
+			/>
+		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/find-track-for-node-path-info.ts
+++ b/packages/studio/src/components/Timeline/find-track-for-node-path-info.ts
@@ -12,7 +12,7 @@ export const findTrackForNodePathInfo = ({
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
 	nodePathInfo: SequenceNodePathInfo;
 }) => {
-	const tracks = calculateTimeline({sequences, overrideIdsToNodePaths});
+	const {tracks} = calculateTimeline({sequences, overrideIdsToNodePaths});
 	return tracks.find(
 		(candidate) =>
 			candidate.nodePathInfo !== null &&

--- a/packages/studio/src/components/Timeline/should-show-track-in-timeline.ts
+++ b/packages/studio/src/components/Timeline/should-show-track-in-timeline.ts
@@ -5,12 +5,18 @@ import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
 //   Children of a sequence with `showInTimeline: false` keep being listed
 //   on their own; their depth is independently flattened by
 //   `getTimelineNestedLevel` so the parent does not contribute an indent.
+// - The sequence is not a merged parent (its child represents both as one row).
 // - The sequence has a positive duration.
 // - The sequence starts before the composition ends.
 export const shouldShowTrackInTimeline = (
 	track: TrackWithHash,
 	durationInFrames: number,
+	mergedParentIds: ReadonlySet<string> = new Set(),
 ): boolean => {
+	if (mergedParentIds.has(track.sequence.id)) {
+		return false;
+	}
+
 	if (!track.sequence.showInTimeline) {
 		return false;
 	}

--- a/packages/studio/src/components/selected-outline-measurement.ts
+++ b/packages/studio/src/components/selected-outline-measurement.ts
@@ -476,10 +476,11 @@ export const getSequencesWithSelectableOutlines = ({
 	readonly sequences: readonly TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
 }): SequenceWithSelectedOutline[] => {
-	return calculateTimeline({
+	const {tracks} = calculateTimeline({
 		sequences: [...sequences],
 		overrideIdsToNodePaths,
-	})
+	});
+	return tracks
 		.filter((track) => {
 			if (track.nodePathInfo === null) {
 				return false;

--- a/packages/studio/src/helpers/calculate-timeline.ts
+++ b/packages/studio/src/helpers/calculate-timeline.ts
@@ -9,6 +9,7 @@ import {
 import {getTimelineNestedLevel} from './get-timeline-nestedness';
 import {getTimelineSequenceHash} from './get-timeline-sequence-hash';
 import type {
+	SequenceNodePathInfo,
 	TrackWithHash,
 	TrackWithHashAndOriginalTimings,
 } from './get-timeline-sequence-sort-key';
@@ -41,12 +42,75 @@ export const calculateTimeline = ({
 }: {
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
-}): TrackWithHash[] => {
+}): {tracks: TrackWithHash[]; mergedParentIds: Set<string>} => {
 	const sortedSequences = sortItemsByNonceHistory(sequences);
 	const tracks: TrackWithHashAndOriginalTimings[] = [];
 
 	if (sortedSequences.length === 0) {
-		return [];
+		return {tracks: [], mergedParentIds: new Set()};
+	}
+
+	// Build parent→children map and detect merge candidates.
+	// A merge happens when a user-authored <Sequence> (has controls)
+	// wraps exactly one <Video> or <Audio> child.
+	const childrenOf = new Map<string, TSequence[]>();
+	for (const seq of sortedSequences) {
+		if (seq.parent) {
+			const list = childrenOf.get(seq.parent) ?? [];
+			list.push(seq);
+			childrenOf.set(seq.parent, list);
+		}
+	}
+
+	const mergedParentIds = new Set<string>();
+	const mergedChildParentInfo = new Map<
+		string,
+		{readonly sequence: TSequence; readonly nodePathInfo: SequenceNodePathInfo}
+	>();
+
+	for (const seq of sortedSequences) {
+		if ((seq.type === 'video' || seq.type === 'audio') && seq.parent !== null) {
+			const parent = sortedSequences.find((s) => s.id === seq.parent);
+			if (
+				parent &&
+				parent.type === 'sequence' &&
+				parent.controls !== null &&
+				parent.controls.overrideId
+			) {
+				const siblings = childrenOf.get(parent.id);
+				if (siblings && siblings.length === 1) {
+					// Innermost-only: skip if the parent is itself a merged child
+					const parentParent = parent.parent
+						? sortedSequences.find((s) => s.id === parent.parent)
+						: null;
+					const isParentMerged =
+						parentParent &&
+						parentParent.type === 'sequence' &&
+						parentParent.controls !== null &&
+						parentParent.controls.overrideId &&
+						childrenOf.get(parentParent.id)?.length === 1;
+
+					if (!isParentMerged) {
+						mergedParentIds.add(parent.id);
+						const parentNodePath = parent.controls.overrideId
+							? overrideIdsToNodePaths[parent.controls.overrideId]
+							: undefined;
+						if (parentNodePath) {
+							mergedChildParentInfo.set(seq.id, {
+								sequence: parent,
+								nodePathInfo: {
+									sequenceSubscriptionKey: parentNodePath,
+									auxiliaryKeys: [],
+									index: 0,
+									numberOfSequencesWithThisNodePath: 0,
+									supportsEffects: false,
+								},
+							});
+						}
+					}
+				}
+			}
+		}
 	}
 
 	const sameHashes: {[hash: string]: string[]} = {};
@@ -104,7 +168,12 @@ export const calculateTimeline = ({
 						? getInheritedLoopDisplay(sequence, sortedSequences)
 						: sequence.loopDisplay,
 			},
-			depth: getTimelineNestedLevel(sequence, sortedSequences, 0),
+			depth: getTimelineNestedLevel(
+				sequence,
+				sortedSequences,
+				0,
+				mergedParentIds,
+			),
 			hash: actualHash,
 			cascadedStart,
 			cascadedDuration: sequence.duration,
@@ -121,6 +190,9 @@ export const calculateTimeline = ({
 						supportsEffects: sequence.controls?.supportsEffects === true,
 					}
 				: null,
+			...(mergedChildParentInfo.has(sequence.id)
+				? {mergedParentInfo: mergedChildParentInfo.get(sequence.id)}
+				: {}),
 		});
 	}
 
@@ -155,7 +227,7 @@ export const calculateTimeline = ({
 
 	const nodePathIndexCounters = new Map<string, number>();
 
-	return sortedTracks
+	const result = sortedTracks
 		.map((track): TrackWithHash => {
 			if (track.nodePathInfo === null) {
 				return track;
@@ -198,4 +270,6 @@ export const calculateTimeline = ({
 				},
 			};
 		});
+
+	return {tracks: result, mergedParentIds};
 };

--- a/packages/studio/src/helpers/get-timeline-nestedness.ts
+++ b/packages/studio/src/helpers/get-timeline-nestedness.ts
@@ -4,6 +4,7 @@ export const getTimelineNestedLevel = (
 	sequence: TSequence,
 	allSequences: TSequence[],
 	depth: number,
+	mergedParentIds: ReadonlySet<string> = new Set(),
 ): number => {
 	if (!sequence.parent) {
 		return depth;
@@ -14,10 +15,12 @@ export const getTimelineNestedLevel = (
 		throw new Error('has parentId but no parent');
 	}
 
-	const parentContributes = parentSequence.showInTimeline;
+	const parentContributes =
+		parentSequence.showInTimeline && !mergedParentIds.has(parentSequence.id);
 	return getTimelineNestedLevel(
 		parentSequence,
 		allSequences,
 		parentContributes ? depth + 1 : depth,
+		mergedParentIds,
 	);
 };

--- a/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-sort-key.ts
@@ -14,6 +14,10 @@ type Track = {
 	nodePathInfo: SequenceNodePathInfo | null;
 	keyframeDisplayOffset: number;
 	sequenceFrameOffset: number;
+	mergedParentInfo?: {
+		readonly sequence: TSequence;
+		readonly nodePathInfo: SequenceNodePathInfo;
+	} | null;
 };
 
 export type TrackWithHash = Track & {

--- a/packages/studio/src/test/big-timeline.test.ts
+++ b/packages/studio/src/test/big-timeline.test.ts
@@ -16,10 +16,11 @@ const withoutKeyframeDisplayOffset = <
 	});
 
 test('Should calculate timeline as expected', () => {
-	const timeline = calculateTimeline({
+	const {tracks: timeline} = calculateTimeline({
 		sequences,
 		overrideIdsToNodePaths: {},
 	});
+
 	expect(withoutKeyframeDisplayOffset(timeline)).toEqual([
 		{
 			nodePathInfo: null,

--- a/packages/studio/src/test/sequenced-timeline.test.ts
+++ b/packages/studio/src/test/sequenced-timeline.test.ts
@@ -16,7 +16,7 @@ const withoutKeyframeDisplayOffset = <
 	});
 
 test('Should calculate sequences correctly', () => {
-	const timeline = calculateTimeline({
+	const {tracks: timeline} = calculateTimeline({
 		sequences,
 		overrideIdsToNodePaths: {},
 	});

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -167,7 +167,7 @@ const makePropStatuses = (
 });
 
 test('keyframe display offsets follow the parent sequence context', () => {
-	const timeline = calculateTimeline({
+	const {tracks: timeline} = calculateTimeline({
 		sequences: [
 			makeSequence({
 				id: 'root-style',
@@ -283,7 +283,7 @@ test('track lookup survives effect key changes', () => {
 });
 
 test('keyframe display offsets account for parent trimBefore', () => {
-	const timeline = calculateTimeline({
+	const {tracks: timeline} = calculateTimeline({
 		sequences: [
 			makeSequence({
 				id: 'parent',

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -103,6 +103,9 @@ import {
 	getTimelineSequenceLeftEdgeDragChanges,
 	getTimelineSequenceLeftEdgeDragTargets,
 	getTimelineSequenceLeftEdgeDragValues,
+	getTimelineSequenceMediaRightEdgeDragChanges,
+	getTimelineSequenceMediaRightEdgeDragTargets,
+	getTimelineSequenceMediaRightEdgeDragValues,
 } from '../components/Timeline/TimelineSequenceRightEdgeDragHandle';
 import {
 	parsedTransformOriginToUv,
@@ -113,6 +116,7 @@ import {
 	getKeyframesForTimelineEasingDrag,
 	getTimelineSelectionsAfterEasingKeyframeDrag,
 } from '../components/Timeline/use-timeline-keyframe-drag';
+import {calculateTimeline} from '../helpers/calculate-timeline';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {
 	loadEditorShowOutlinesOption,
@@ -184,6 +188,7 @@ const makeTimelineSequence = ({
 	refForOutline = null,
 	duration = 100,
 	from = 0,
+	playbackRate = 1,
 	startMediaFrom = 0,
 	type = 'sequence',
 	showInTimeline = true,
@@ -196,6 +201,7 @@ const makeTimelineSequence = ({
 	readonly refForOutline?: RefObject<HTMLElement | null> | null;
 	readonly duration?: number;
 	readonly from?: number;
+	readonly playbackRate?: number;
 	readonly startMediaFrom?: number;
 	readonly type?: TSequence['type'];
 	readonly showInTimeline?: boolean;
@@ -228,6 +234,7 @@ const makeTimelineSequence = ({
 		isInsideSeries: false,
 		effects,
 		frozenFrame: null,
+		playbackRate,
 		startMediaFrom,
 	}) as TSequence;
 
@@ -284,6 +291,23 @@ const makeLeftEdgePropStatuses = (
 				...(includeTrimBefore
 					? {trimBefore: {status: 'static' as const, codeValue: 0}}
 					: {}),
+			},
+			effects: [],
+		};
+	}
+
+	return propStatuses;
+};
+
+const makeRightEdgeMediaPropStatuses = (
+	nodePaths: readonly SequencePropsSubscriptionKey[],
+): PropStatuses => {
+	const propStatuses: PropStatuses = {};
+	for (const nodePath of nodePaths) {
+		propStatuses[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
+			canUpdate: true,
+			props: {
+				trimAfter: {status: 'static', codeValue: 100},
 			},
 			effects: [],
 		};
@@ -1359,28 +1383,97 @@ test('Timeline left edge drag is blocked without timeline range props', () => {
 	expect(targets).toBe(null);
 });
 
-test('Timeline left edge drag is blocked if trimBefore cannot update', () => {
+test('Timeline left edge drag works even when trimBefore is not set (CapCut-like)', () => {
 	const schema = {} satisfies InteractivitySchema;
 	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const targets = getTimelineSequenceLeftEdgeDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		selectedItems: [{type: 'sequence', nodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				type: 'audio',
+			}),
+		],
+		overrideIdsToNodePaths: {
+			override: nodePathInfo.sequenceSubscriptionKey,
+		},
+		propStatuses: makeLeftEdgePropStatuses([
+			nodePathInfo.sequenceSubscriptionKey,
+		]),
+	});
 
+	expect(targets).not.toBe(null);
+});
+
+test('Timeline media right edge drag adjusts trimAfter for video clips', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const targets = getTimelineSequenceMediaRightEdgeDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		selectedItems: [{type: 'sequence', nodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				duration: 40,
+				startMediaFrom: 8,
+				type: 'video',
+			}),
+		],
+		overrideIdsToNodePaths: {
+			override: nodePathInfo.sequenceSubscriptionKey,
+		},
+		propStatuses: makeRightEdgeMediaPropStatuses([
+			nodePathInfo.sequenceSubscriptionKey,
+		]),
+	});
+
+	expect(targets?.map((target) => target.initialTrimAfter)).toEqual([48]);
 	expect(
-		getTimelineSequenceLeftEdgeDragTargets({
-			draggedNodePathInfo: nodePathInfo,
-			selectedItems: [{type: 'sequence', nodePathInfo}],
-			sequences: [
-				makeTimelineSequence({
-					schema,
-					type: 'audio',
-				}),
-			],
-			overrideIdsToNodePaths: {
-				override: nodePathInfo.sequenceSubscriptionKey,
-			},
-			propStatuses: makeLeftEdgePropStatuses([
-				nodePathInfo.sequenceSubscriptionKey,
-			]),
+		getTimelineSequenceMediaRightEdgeDragChanges({
+			targets: targets ?? [],
+			deltaFrames: 12,
+		}).map((change) => [change.fieldKey, change.value]),
+	).toEqual([['trimAfter', 60]]);
+});
+
+test('Timeline media right edge drag clamps to one visible frame', () => {
+	expect(
+		getTimelineSequenceMediaRightEdgeDragValues({
+			initialDuration: 4,
+			initialTrimBefore: 6,
+			deltaFrames: -10,
+			playbackRate: 1,
+			maxMediaDuration: null,
 		}),
-	).toBe(null);
+	).toEqual({
+		durationInFrames: 1,
+		trimAfter: 7,
+	});
+});
+
+test('Timeline media right edge drag works even when trimAfter is not set (CapCut-like)', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const targets = getTimelineSequenceMediaRightEdgeDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		selectedItems: [{type: 'sequence', nodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				type: 'audio',
+			}),
+		],
+		overrideIdsToNodePaths: {
+			override: nodePathInfo.sequenceSubscriptionKey,
+		},
+		propStatuses: makeDurationPropStatuses([
+			nodePathInfo.sequenceSubscriptionKey,
+		]),
+	});
+
+	expect(targets).not.toBe(null);
+	expect(targets?.length).toBe(1);
 });
 
 test('Timeline from drag applies the same delta to selected sequences', () => {
@@ -4915,4 +5008,84 @@ test('Selected timeline rows do not reselect on pointer down without modifiers',
 			ctrlKey: false,
 		}),
 	).toBe(true);
+});
+
+test('Sequence wrapping a single Video merges into one timeline row', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const parentNodePath = makeKey(['body', 0]);
+	const childNodePath = makeKey(['body', 0, 'children', 0]);
+	const sequences: TSequence[] = [
+		makeTimelineSequence({
+			schema,
+			id: 'parent',
+			overrideId: 'parent',
+			duration: 100,
+			from: 7,
+		}),
+		makeTimelineSequence({
+			schema,
+			id: 'child',
+			overrideId: 'child',
+			parentId: 'parent',
+			duration: 50,
+			type: 'video',
+		}),
+	];
+
+	const {tracks, mergedParentIds} = calculateTimeline({
+		sequences,
+		overrideIdsToNodePaths: {
+			parent: parentNodePath,
+			child: childNodePath,
+		},
+	});
+
+	// Parent is marked for merge and the child carries its info
+	expect(mergedParentIds.has('parent')).toBe(true);
+	const childTrack = tracks.find((t) => t.sequence.id === 'child');
+	expect(childTrack).toBeDefined();
+	expect(childTrack?.mergedParentInfo).not.toBeNull();
+	expect(childTrack?.mergedParentInfo?.sequence.id).toBe('parent');
+	expect(
+		childTrack?.mergedParentInfo?.nodePathInfo.sequenceSubscriptionKey,
+	).toBe(parentNodePath);
+});
+
+test('Sequence with two Video children does NOT merge', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const parentNodePath = makeKey(['body', 0]);
+	const childANodePath = makeKey(['body', 0, 'children', 0]);
+	const childBNodePath = makeKey(['body', 0, 'children', 1]);
+	const sequences: TSequence[] = [
+		makeTimelineSequence({
+			schema,
+			id: 'parent',
+			overrideId: 'parent',
+		}),
+		makeTimelineSequence({
+			schema,
+			id: 'childA',
+			overrideId: 'childA',
+			parentId: 'parent',
+			type: 'video',
+		}),
+		makeTimelineSequence({
+			schema,
+			id: 'childB',
+			overrideId: 'childB',
+			parentId: 'parent',
+			type: 'video',
+		}),
+	];
+
+	const {mergedParentIds} = calculateTimeline({
+		sequences,
+		overrideIdsToNodePaths: {
+			parent: parentNodePath,
+			childA: childANodePath,
+			childB: childBNodePath,
+		},
+	});
+
+	expect(mergedParentIds.has('parent')).toBe(false);
 });

--- a/packages/studio/src/test/timeline.test.ts
+++ b/packages/studio/src/test/timeline.test.ts
@@ -15,7 +15,7 @@ const withoutKeyframeDisplayOffset = <
 	});
 
 test('Should calculate timeline with no sequences', () => {
-	const calculated = calculateTimeline({
+	const {tracks: calculated} = calculateTimeline({
 		overrideIdsToNodePaths: {},
 		sequences: [],
 	});
@@ -23,7 +23,7 @@ test('Should calculate timeline with no sequences', () => {
 });
 
 test('Should calculate a basic timeline', () => {
-	const calculated = calculateTimeline({
+	const {tracks: calculated} = calculateTimeline({
 		overrideIdsToNodePaths: {},
 		sequences: [
 			{
@@ -82,7 +82,7 @@ test('Should calculate a basic timeline', () => {
 });
 
 test('Should follow order of nesting', () => {
-	const calculated = calculateTimeline({
+	const {tracks: calculated} = calculateTimeline({
 		overrideIdsToNodePaths: {},
 		sequences: [
 			{
@@ -190,7 +190,7 @@ test('Should follow order of nesting', () => {
 });
 
 test('Should inherit loop display from parent for media tracks', () => {
-	const calculated = calculateTimeline({
+	const {tracks: calculated} = calculateTimeline({
 		overrideIdsToNodePaths: {},
 		sequences: [
 			{
@@ -258,7 +258,7 @@ test('Should inherit loop display from parent for media tracks', () => {
 });
 
 test('Should calculate sequence frame offset for negative from values', () => {
-	const calculated = calculateTimeline({
+	const {tracks: calculated} = calculateTimeline({
 		overrideIdsToNodePaths: {},
 		sequences: [
 			{
@@ -291,7 +291,7 @@ test('Should calculate sequence frame offset for negative from values', () => {
 });
 
 test('Should calculate sequence frame offset for trimBefore values', () => {
-	const calculated = calculateTimeline({
+	const {tracks: calculated} = calculateTimeline({
 		overrideIdsToNodePaths: {},
 		sequences: [
 			{


### PR DESCRIPTION
## Summary

When a user-authored `<Sequence>` wraps exactly one `<Video>` or `<Audio>` child, the Studio now **merges them into a single timeline row** (the purple media row) — the blue container row is hidden. This makes trimming feel like CapCut: one row per clip, and dragging edges works even without explicit `trimBefore`/`trimAfter` props.

## Changes

### Row merge (automatic)
- `calculateTimeline()` now returns `{tracks, mergedParentIds}`
- Merged parents are filtered out by `shouldShowTrackInTimeline` and don't contribute depth indentation
- The surviving media row carries `mergedParentInfo` linking to the parent Sequence's `TSequence` and `nodePathInfo`

### Inspector — Container section
- Clicking the merged row shows **two sections** in the inspector: "Video Clip" (media props) and "Container" (transform: scale/translate/rotate/from/durationInFrames)
- Edits in either section write to the correct source code element

### CapCut-like trimming
- `canUpdateTrimAfter` and `canUpdateTrimBefore` now return `true` when the prop isn't set — allowing the Studio to **insert** `trimAfter`/`trimBefore` as new props on drag
- Same change in `TimelineSequence.tsx` so drag handles render even without existing trim props
- Right-edge drag on merged rows also syncs the parent Sequence's `durationInFrames` when it's a static value
- Left-edge drag similarly extended

### Sync drag handles on merged rows
- `TimelineSequenceMediaRightEdgeDragTarget` gains optional `parentNodePath`/`parentInitialDuration` fields
- Drag overrides and commit changes handle both the media and parent nodePaths in a single operation
- If the parent's `durationInFrames` is computed/keyframed, the media trim still works — just without the container sync

## Testing
- All 325 existing tests pass
- 2 new tests: merge detection, non-merge for multi-child
- Updated 2 tests to reflect new CapCut-like behavior (drag works even when trim props aren't set)
- Manual testing confirmed with Playwright: right-edge drag updates `trimAfter` via API

## Files changed
```
20 files changed, 818 insertions(+), 103 deletions(-)
```