### PR TITLE
`@remotion/studio-server`: Name inserted Element sequences

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -931,11 +931,13 @@ const createComponentElement = ({
 const createSequenceWrappedElement = ({
 	child,
 	dimensions,
+	name,
 	position,
 	sequenceLocalName,
 }: {
 	child: namedTypes.JSXElement;
 	dimensions: {width: number; height: number};
+	name: string | null;
 	position: InsertableCompositionElementPosition | null;
 	sequenceLocalName: string;
 }): namedTypes.JSXElement => {
@@ -943,6 +945,7 @@ const createSequenceWrappedElement = ({
 		recast.types.builders.jsxOpeningElement(
 			recast.types.builders.jsxIdentifier(sequenceLocalName),
 			[
+				...(name === null ? [] : [createStringAttribute('name', name)]),
 				createNumberAttribute('width', dimensions.width),
 				createNumberAttribute('height', dimensions.height),
 				createPositionAbsoluteStyleAttribute(position),
@@ -1773,6 +1776,7 @@ export const insertJsxElementIntoComposition = async ({
 	prettierConfigOverride: Record<string, unknown> | null;
 	wrapInSequence?: {
 		dimensions: {width: number; height: number};
+		name: string | null;
 		position: InsertableCompositionElementPosition | null;
 	} | null;
 }): Promise<{
@@ -1808,6 +1812,7 @@ export const insertJsxElementIntoComposition = async ({
 		? createSequenceWrappedElement({
 				child: elementToInsert,
 				dimensions: wrapInSequence.dimensions,
+				name: wrapInSequence.name,
 				position: wrapInSequence.position,
 				sequenceLocalName: ensureSequenceImport(ast),
 			})

--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -207,6 +207,7 @@ export const insertElementHandler: ApiHandler<
 				prettierConfigOverride: null,
 				wrapInSequence: {
 					dimensions: element.dimensions,
+					name: element.displayName,
 					position,
 				},
 			});


### PR DESCRIPTION
## Summary

- Add a `name` prop to the wrapper `<Sequence>` created when inserting a dragged Element into Studio
- Use the Element display name, so inserted Elements are easier to identify in Studio

## Tests

- `bun run build`
- `bun run stylecheck` *(fails in unrelated `template-react-router#lint` generated `.react-router/types` files with `Generic type 'GetAnnotations' requires 1 type argument(s)`)*
- `cd packages/studio-server && bunx oxfmt src --write && bun run make && bun run lint`
