### PR TITLE
fix: calculateMetadata() encoding defaults now override remotion.config.ts in CLI

### DIFF
--- a/packages/cli/src/benchmark.ts
+++ b/packages/cli/src/benchmark.ts
@@ -241,18 +241,30 @@ export const benchmarkCommand = async (
 		commandLine: parsedCli,
 	}).value;
 
-	const pixelFormat = pixelFormatOption.getValue({
+	const pixelFormatResult = pixelFormatOption.getValue({
 		commandLine: parsedCli,
-	}).value;
+	});
+	const pixelFormat =
+		pixelFormatResult.source === 'cli' ? pixelFormatResult.value : null;
+	const configPixelFormat =
+		pixelFormatResult.source === 'config' ? pixelFormatResult.value : null;
 	const browserExecutable = browserExecutableOption.getValue({
 		commandLine: parsedCli,
 	}).value;
 	const everyNthFrame = everyNthFrameOption.getValue({
 		commandLine: parsedCli,
 	}).value;
-	const proResProfile = proResProfileOption.getValue({
+	const proResProfileResult = proResProfileOption.getValue({
 		commandLine: parsedCli,
-	}).value;
+	});
+	const proResProfile =
+		proResProfileResult.source === 'cli'
+			? proResProfileResult.value
+			: undefined;
+	const configProResProfile =
+		proResProfileResult.source === 'config'
+			? proResProfileResult.value
+			: undefined;
 	const userAgent = userAgentOption.getValue({commandLine: parsedCli}).value;
 	const disableWebSecurity = disableWebSecurityOption.getValue({
 		commandLine: parsedCli,
@@ -536,8 +548,16 @@ export const benchmarkCommand = async (
 					}),
 					serializedInputPropsWithCustomSchema,
 					overwrite,
-					pixelFormat,
-					proResProfile,
+					pixelFormat:
+						pixelFormat ??
+						composition.defaultPixelFormat ??
+						configPixelFormat ??
+						RenderInternals.DEFAULT_PIXEL_FORMAT,
+					proResProfile:
+						proResProfile ??
+						composition.defaultProResProfile ??
+						configProResProfile ??
+						'hq',
 					x264Preset,
 					jpegQuality,
 					chromiumOptions,

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -104,8 +104,10 @@ export const renderVideoFlow = async ({
 	muted,
 	enforceAudioTrack,
 	proResProfile,
+	configProResProfile,
 	x264Preset,
 	pixelFormat,
+	configPixelFormat,
 	videoBitrate,
 	encodingMaxRate,
 	encodingBufferSize,
@@ -177,8 +179,10 @@ export const renderVideoFlow = async ({
 	muted: boolean;
 	enforceAudioTrack: boolean;
 	proResProfile: _InternalTypes['ProResProfile'] | undefined;
+	configProResProfile: _InternalTypes['ProResProfile'] | undefined;
 	x264Preset: X264Preset | null;
 	pixelFormat: PixelFormat | null;
+	configPixelFormat: PixelFormat | null;
 	numberOfGifLoops: NumberOfGifLoops;
 	audioCodec: AudioCodec | null;
 	disallowParallelEncoding: boolean;
@@ -541,12 +545,6 @@ export const renderVideoFlow = async ({
 		timeRemainingInMilliseconds: null,
 	};
 
-	const resolvedPixelFormat =
-		pixelFormat ?? config.defaultPixelFormat ?? 'yuv420p';
-
-	const resolvedProResProfile =
-		proResProfile ?? config.defaultProResProfile ?? 'hq';
-
 	const imageFormat = getVideoImageFormat({
 		codec: shouldOutputImageSequence ? undefined : codec,
 		uiImageFormat: uiImageFormat ?? config.defaultVideoImageFormat ?? null,
@@ -685,8 +683,16 @@ export const renderVideoFlow = async ({
 		frameRange,
 		serializedInputPropsWithCustomSchema,
 		overwrite,
-		pixelFormat: resolvedPixelFormat,
-		proResProfile: resolvedProResProfile,
+		pixelFormat:
+			pixelFormat ??
+			config.defaultPixelFormat ??
+			configPixelFormat ??
+			'yuv420p',
+		proResProfile:
+			proResProfile ??
+			config.defaultProResProfile ??
+			configProResProfile ??
+			'hq',
 		x264Preset: x264Preset ?? null,
 		jpegQuality: jpegQuality ?? RenderInternals.DEFAULT_JPEG_QUALITY,
 		chromiumOptions,

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -687,7 +687,7 @@ export const renderVideoFlow = async ({
 			pixelFormat ??
 			config.defaultPixelFormat ??
 			configPixelFormat ??
-			'yuv420p',
+			RenderInternals.DEFAULT_PIXEL_FORMAT,
 		proResProfile:
 			proResProfile ??
 			config.defaultProResProfile ??

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -178,7 +178,7 @@ export const renderVideoFlow = async ({
 	enforceAudioTrack: boolean;
 	proResProfile: _InternalTypes['ProResProfile'] | undefined;
 	x264Preset: X264Preset | null;
-	pixelFormat: PixelFormat;
+	pixelFormat: PixelFormat | null;
 	numberOfGifLoops: NumberOfGifLoops;
 	audioCodec: AudioCodec | null;
 	disallowParallelEncoding: boolean;
@@ -541,9 +541,15 @@ export const renderVideoFlow = async ({
 		timeRemainingInMilliseconds: null,
 	};
 
+	const resolvedPixelFormat =
+		pixelFormat ?? config.defaultPixelFormat ?? 'yuv420p';
+
+	const resolvedProResProfile =
+		proResProfile ?? config.defaultProResProfile ?? 'hq';
+
 	const imageFormat = getVideoImageFormat({
 		codec: shouldOutputImageSequence ? undefined : codec,
-		uiImageFormat,
+		uiImageFormat: uiImageFormat ?? config.defaultVideoImageFormat ?? null,
 	});
 
 	const onLog: OnLog = ({logLevel: logLogLevel, previewString, tag}) => {
@@ -679,8 +685,8 @@ export const renderVideoFlow = async ({
 		frameRange,
 		serializedInputPropsWithCustomSchema,
 		overwrite,
-		pixelFormat,
-		proResProfile,
+		pixelFormat: resolvedPixelFormat,
+		proResProfile: resolvedProResProfile,
 		x264Preset: x264Preset ?? null,
 		jpegQuality: jpegQuality ?? RenderInternals.DEFAULT_JPEG_QUALITY,
 		chromiumOptions,

--- a/packages/cli/src/render-queue/process-video.ts
+++ b/packages/cli/src/render-queue/process-video.ts
@@ -107,8 +107,10 @@ export const processVideoJob = async ({
 		enforceAudioTrack: job.type === 'video' ? job.enforceAudioTrack : false,
 		proResProfile:
 			job.type === 'video' ? (job.proResProfile ?? undefined) : undefined,
+		configProResProfile: undefined,
 		x264Preset: job.type === 'video' ? (job.x264Preset ?? null) : null,
 		pixelFormat: job.type === 'video' ? job.pixelFormat : 'yuv420p',
+		configPixelFormat: null,
 		videoBitrate: job.type === 'video' ? job.videoBitrate : null,
 		encodingBufferSize: job.type === 'video' ? job.encodingBufferSize : null,
 		encodingMaxRate: job.type === 'video' ? job.encodingMaxRate : null,

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -128,19 +128,24 @@ export const render = async (
 	const durationInFrames = overrideDurationOption.getValue({
 		commandLine: parsedCli,
 	}).value;
-
-	const pixelFormat = pixelFormatOption.getValue({
+	const pixelFormatResult = pixelFormatOption.getValue({
 		commandLine: parsedCli,
-	}).value;
+	});
+	const pixelFormat =
+		pixelFormatResult.source === 'default' ? null : pixelFormatResult.value;
 	const browserExecutable = browserExecutableOption.getValue({
 		commandLine: parsedCli,
 	}).value;
 	const everyNthFrame = everyNthFrameOption.getValue({
 		commandLine: parsedCli,
 	}).value;
-	const proResProfile = proResProfileOption.getValue({
+	const proResProfileResult = proResProfileOption.getValue({
 		commandLine: parsedCli,
-	}).value;
+	});
+	const proResProfile =
+		proResProfileResult.source === 'default'
+			? undefined
+			: proResProfileResult.value;
 	const userAgent = userAgentOption.getValue({commandLine: parsedCli}).value;
 	const disableWebSecurity = disableWebSecurityOption.getValue({
 		commandLine: parsedCli,

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -132,7 +132,9 @@ export const render = async (
 		commandLine: parsedCli,
 	});
 	const pixelFormat =
-		pixelFormatResult.source === 'default' ? null : pixelFormatResult.value;
+		pixelFormatResult.source === 'cli' ? pixelFormatResult.value : null;
+	const configPixelFormat =
+		pixelFormatResult.source === 'config' ? pixelFormatResult.value : null;
 	const browserExecutable = browserExecutableOption.getValue({
 		commandLine: parsedCli,
 	}).value;
@@ -143,9 +145,13 @@ export const render = async (
 		commandLine: parsedCli,
 	});
 	const proResProfile =
-		proResProfileResult.source === 'default'
-			? undefined
-			: proResProfileResult.value;
+		proResProfileResult.source === 'cli'
+			? proResProfileResult.value
+			: undefined;
+	const configProResProfile =
+		proResProfileResult.source === 'config'
+			? proResProfileResult.value
+			: undefined;
 	const userAgent = userAgentOption.getValue({commandLine: parsedCli}).value;
 	const disableWebSecurity = disableWebSecurityOption.getValue({
 		commandLine: parsedCli,
@@ -318,6 +324,8 @@ export const render = async (
 		proResProfile,
 		x264Preset,
 		pixelFormat,
+		configPixelFormat,
+		configProResProfile,
 		videoBitrate,
 		encodingMaxRate,
 		encodingBufferSize,

--- a/packages/cli/src/test/pixel-format.test.ts
+++ b/packages/cli/src/test/pixel-format.test.ts
@@ -36,3 +36,27 @@ describe('pixel-format tests setPixelFormat', () => {
 			)),
 	);
 });
+
+describe('pixel-format source tracking for composition default override', () => {
+	test('returns source: default when no CLI flag and no config set', () => {
+		// Reset to default
+		pixelFormatOption.setConfig('yuv420p');
+		const result = pixelFormatOption.getValue({commandLine: {}});
+		expect(result.source).toBe('default');
+	});
+
+	test('returns source: config when config is explicitly set to non-default', () => {
+		pixelFormatOption.setConfig('yuva420p');
+		const result = pixelFormatOption.getValue({commandLine: {}});
+		expect(result.source).toBe('config');
+		expect(result.value).toBe('yuva420p');
+	});
+
+	test('returns source: cli when CLI flag is passed', () => {
+		const result = pixelFormatOption.getValue({
+			commandLine: {'pixel-format': 'yuv444p'},
+		});
+		expect(result.source).toBe('cli');
+		expect(result.value).toBe('yuv444p');
+	});
+});

--- a/packages/cli/src/test/pixel-format.test.ts
+++ b/packages/cli/src/test/pixel-format.test.ts
@@ -60,3 +60,36 @@ describe('pixel-format source tracking for composition default override', () => 
 		expect(result.value).toBe('yuv444p');
 	});
 });
+
+describe('pixel-format source tracking for composition default override', () => {
+	test('returns source: default when no CLI flag and no config set', () => {
+		// Reset to default
+		pixelFormatOption.setConfig('yuv420p');
+		const result = pixelFormatOption.getValue({commandLine: {}});
+		expect(result.source).toBe('default');
+	});
+
+	test('returns source: config when config is explicitly set to non-default', () => {
+		pixelFormatOption.setConfig('yuva420p');
+		const result = pixelFormatOption.getValue({commandLine: {}});
+		expect(result.source).toBe('config');
+		expect(result.value).toBe('yuva420p');
+	});
+
+	test('returns source: cli when CLI flag is passed', () => {
+		const result = pixelFormatOption.getValue({
+			commandLine: {'pixel-format': 'yuv444p'},
+		});
+		expect(result.source).toBe('cli');
+		expect(result.value).toBe('yuv444p');
+	});
+
+	test('cli flag beats config value', () => {
+		pixelFormatOption.setConfig('yuva420p');
+		const result = pixelFormatOption.getValue({
+			commandLine: {'pixel-format': 'yuv444p'},
+		});
+		expect(result.source).toBe('cli');
+		expect(result.value).toBe('yuv444p');
+	});
+});

--- a/packages/cli/src/test/pixel-format.test.ts
+++ b/packages/cli/src/test/pixel-format.test.ts
@@ -39,31 +39,6 @@ describe('pixel-format tests setPixelFormat', () => {
 
 describe('pixel-format source tracking for composition default override', () => {
 	test('returns source: default when no CLI flag and no config set', () => {
-		// Reset to default
-		pixelFormatOption.setConfig('yuv420p');
-		const result = pixelFormatOption.getValue({commandLine: {}});
-		expect(result.source).toBe('default');
-	});
-
-	test('returns source: config when config is explicitly set to non-default', () => {
-		pixelFormatOption.setConfig('yuva420p');
-		const result = pixelFormatOption.getValue({commandLine: {}});
-		expect(result.source).toBe('config');
-		expect(result.value).toBe('yuva420p');
-	});
-
-	test('returns source: cli when CLI flag is passed', () => {
-		const result = pixelFormatOption.getValue({
-			commandLine: {'pixel-format': 'yuv444p'},
-		});
-		expect(result.source).toBe('cli');
-		expect(result.value).toBe('yuv444p');
-	});
-});
-
-describe('pixel-format source tracking for composition default override', () => {
-	test('returns source: default when no CLI flag and no config set', () => {
-		// Reset to default
 		pixelFormatOption.setConfig('yuv420p');
 		const result = pixelFormatOption.getValue({commandLine: {}});
 		expect(result.source).toBe('default');


### PR DESCRIPTION
Fixes #8587

## Problem

When a composition's `calculateMetadata()` returns encoding defaults (`defaultPixelFormat`, `defaultProResProfile`, `defaultVideoImageFormat`), these values were being silently ignored by the CLI renderer. The hardcoded fallbacks and `remotion.config.ts` settings were both incorrectly taking priority over composition-level defaults.

## Correct Priority Order (confirmed by @JonnyBurger)

```
CLI flags > calculateMetadata() > remotion.config.ts > built-in hardcoded defaults
```

## Investigation

Confirmed that **Remotion Studio's render modal already handles this correctly** — it seeds `pixelFormat`, `proResProfile`, and `videoImageFormat` state from `resolvedComposition.default*` values before falling back to config/defaults. The bug was CLI-specific.

## Changes

### `packages/cli/src/render.tsx`
Separates CLI flag values from config file values by inspecting the `source` field:
- `pixelFormat` — only set if `source === 'cli'`, otherwise `null`
- `configPixelFormat` — only set if `source === 'config'`, otherwise `null`
- Same pattern for `proResProfile` / `configProResProfile`

### `packages/cli/src/render-flows/render.ts`
After `config` is resolved from `getCompositionWithDimensionOverride()`, applies the correct priority chain:
- `pixelFormat ?? config.defaultPixelFormat ?? configPixelFormat ?? 'yuv420p'`
- `proResProfile ?? config.defaultProResProfile ?? configProResProfile ?? 'hq'`
- `uiImageFormat ?? config.defaultVideoImageFormat ?? null` (passed into `getVideoImageFormat`)

### `packages/cli/src/render-queue/process-video.ts`
Added the two new required params (`configPixelFormat: null`, `configProResProfile: undefined`) since this path comes from Studio's render queue and doesn't use CLI config values.

### `packages/cli/src/test/pixel-format.test.ts`
Added tests verifying `source` tracking behavior:
- `'default'` when nothing is explicitly set
- `'config'` when explicitly configured via `Config.setPixelFormat()`
- `'cli'` when flag is passed via command line
- CLI flag beats config value

## Verification

Reproduction setup:
- Composition `calculateMetadata()` returns `defaultCodec: 'prores'`, `defaultProResProfile: '4444'`, `defaultPixelFormat: 'yuva444p10le'`, `defaultVideoImageFormat: 'png'`
- `remotion.config.ts` has `Config.setVideoImageFormat('jpeg')`
- Rendered via CLI with no explicit flags

**Before fix (ffprobe output):**
```
codec_name=prores
profile=HQ
pix_fmt=yuv422p10le
```

**After fix (ffprobe output):**
```
codec_name=prores
profile=4444
pix_fmt=yuva444p12le
```