### PR TITLE
`@remotion/studio`: Rename sequence on double click

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -588,23 +588,6 @@ export const TimelineSequenceItem: React.FC<{
 		toggleTrack(nodePathInfo);
 	}, [nodePathInfo, toggleTrack]);
 
-	const onShowInEditorDoubleClick = useCallback(
-		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!canOpenInEditor) {
-				return;
-			}
-
-			if (isTimelineSelectionModifierEvent(e)) {
-				e.stopPropagation();
-				return;
-			}
-
-			e.stopPropagation();
-			openInEditor();
-		},
-		[canOpenInEditor, openInEditor],
-	);
-
 	const propStatusesForOverride = useMemo(() => {
 		return nodePath
 			? Internals.getPropStatusesCtx(propStatuses, nodePath)
@@ -734,6 +717,24 @@ export const TimelineSequenceItem: React.FC<{
 		codeNameStatus !== undefined &&
 		codeNameStatus !== null &&
 		codeNameStatus.status === 'static';
+
+	const onSequenceDoubleClick = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (isTimelineSelectionModifierEvent(e)) {
+				e.stopPropagation();
+				return;
+			}
+
+			e.stopPropagation();
+			if (canRenameThisSequence) {
+				setIsRenaming(true);
+				return;
+			}
+
+			openInEditor();
+		},
+		[canRenameThisSequence, openInEditor],
+	);
 
 	const canRenameSelectedSequence =
 		canRenameThisSequence &&
@@ -1084,7 +1085,11 @@ export const TimelineSequenceItem: React.FC<{
 			onDragLeave={canDropEffect ? onEffectDragLeave : undefined}
 			onDragOver={canDropEffect ? onEffectDragOver : undefined}
 			onDrop={canDropEffect ? onEffectDrop : undefined}
-			onDoubleClick={canOpenInEditor ? onShowInEditorDoubleClick : undefined}
+			onDoubleClick={
+				canRenameThisSequence || canOpenInEditor
+					? onSequenceDoubleClick
+					: undefined
+			}
 		>
 			<div style={labelContainerStyle}>
 				<TimelineSequenceName


### PR DESCRIPTION
## Summary

- Make double-clicking a renameable sequence in the Studio timeline start inline renaming
- Keep the previous open-in-editor behavior as a fallback when the sequence cannot be renamed
- Preserve modifier double-click handling

## Validation

- `cd packages/studio && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck` *(fails in unrelated `template-react-router#lint` generated React Router types: `Generic type 'GetAnnotations' requires 1 type argument(s)`)*
