### PR TITLE
`@remotion/studio`: Handle empty sequence renames

### DIFF
--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -82,6 +82,30 @@ test('updateSequenceProps should remove attribute when value equals default', as
 	expect(output.split('\n')[7]).toContain('hueShift={30}');
 });
 
+test('updateSequenceProps should remove name when value is empty string default', async () => {
+	const input = `import {Sequence} from 'remotion';
+
+export const Example: React.FC = () => {
+	return (
+		<Sequence name="Intro">
+			<div />
+		</Sequence>
+	);
+};
+`;
+
+	const {output, oldValueStrings} = await updateSequenceProps({
+		input,
+		nodePath: lineColumnToNodePath(input, 5),
+		updates: [{key: 'name', value: '', defaultValue: ''}],
+		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
+	});
+
+	expect(oldValueStrings[0]).toBe('"Intro"');
+	expect(output).not.toContain('name=');
+});
+
 test('updateSequenceProps should set optional attribute to null', async () => {
 	const input = `import {Sequence} from 'remotion';
 

--- a/packages/studio-shared/src/optimistic-update-for-prop-statuses.ts
+++ b/packages/studio-shared/src/optimistic-update-for-prop-statuses.ts
@@ -9,20 +9,28 @@ export const optimisticUpdateForPropStatuses = ({
 	previous,
 	fieldKey,
 	value,
+	defaultValue,
 	schema,
 }: {
 	previous: CanUpdateSequencePropsResponse;
 	fieldKey: string;
 	value: unknown;
+	defaultValue?: string | null;
 	schema: InteractivitySchema;
 }): CanUpdateSequencePropsResponse => {
 	if (!previous.canUpdate) {
 		return previous;
 	}
 
+	const serializedValue = JSON.stringify(value);
+	const optimisticValue =
+		defaultValue !== null && defaultValue === serializedValue
+			? undefined
+			: value;
+
 	const props: Record<string, CanUpdateSequencePropStatus> = {
 		...previous.props,
-		[fieldKey]: {status: 'static', codeValue: value},
+		[fieldKey]: {status: 'static', codeValue: optimisticValue},
 	};
 
 	if (schema[fieldKey]?.type === 'enum') {

--- a/packages/studio-shared/src/test/optimistic-update-for-prop-statuses.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-for-prop-statuses.test.ts
@@ -49,3 +49,35 @@ test('optimisticUpdateForPropStatuses should return the correct response', () =>
 		effects: [],
 	});
 });
+
+test('optimisticUpdateForPropStatuses should use undefined for removed default values', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			name: {
+				status: 'static',
+				codeValue: 'hehe',
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticUpdateForPropStatuses({
+		previous,
+		fieldKey: 'name',
+		value: '',
+		defaultValue: JSON.stringify(''),
+		schema: NoReactInternals.sequenceSchema,
+	});
+
+	expect(updated).toEqual({
+		canUpdate: true,
+		props: {
+			name: {
+				status: 'static',
+				codeValue: undefined,
+			},
+		},
+		effects: [],
+	});
+});

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -32,16 +32,28 @@ const useSequenceDisplayName = (track: TrackWithHash) => {
 		const propStatusesForOverride = nodePath
 			? Internals.getPropStatusesCtx(propStatuses, nodePath)
 			: undefined;
+		const fallbackDisplayName =
+			track.sequence.controls?.componentName || '<Sequence>';
 		const codeNameStatus = propStatusesForOverride?.name;
-		const displayName =
-			codeNameStatus &&
-			codeNameStatus.status === 'static' &&
-			typeof codeNameStatus.codeValue === 'string'
-				? codeNameStatus.codeValue
-				: track.sequence.displayName;
 
-		return displayName || '<Sequence>';
-	}, [nodePath, propStatuses, track.sequence.displayName]);
+		if (
+			codeNameStatus?.status === 'static' &&
+			typeof codeNameStatus.codeValue === 'string'
+		) {
+			return codeNameStatus.codeValue;
+		}
+
+		if (codeNameStatus?.status === 'static') {
+			return fallbackDisplayName;
+		}
+
+		return track.sequence.displayName || fallbackDisplayName;
+	}, [
+		nodePath,
+		propStatuses,
+		track.sequence.controls?.componentName,
+		track.sequence.displayName,
+	]);
 };
 
 const SequenceExpandedInspector: React.FC<{

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -645,6 +645,7 @@ export const TimelineSequenceItem: React.FC<{
 		return effective ?? false;
 	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
 
+	const fallbackDisplayName = sequence.controls?.componentName ?? '<Sequence>';
 	const staticNamePropValue =
 		codeNameStatus?.status === 'static' &&
 		typeof codeNameStatus.codeValue === 'string'
@@ -654,10 +655,21 @@ export const TimelineSequenceItem: React.FC<{
 	const hasStaticNameProp = staticNamePropValue !== null;
 
 	const displayName = useMemo(() => {
-		return staticNamePropValue ?? sequence.displayName;
-	}, [sequence.displayName, staticNamePropValue]);
+		if (staticNamePropValue !== null) {
+			return staticNamePropValue;
+		}
 
-	const fallbackDisplayName = sequence.controls?.componentName ?? '<Sequence>';
+		if (codeNameStatus?.status === 'static') {
+			return fallbackDisplayName;
+		}
+
+		return sequence.displayName;
+	}, [
+		codeNameStatus?.status,
+		fallbackDisplayName,
+		sequence.displayName,
+		staticNamePropValue,
+	]);
 
 	const onToggleVisibility = useCallback(
 		(type: 'enable' | 'disable') => {

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -68,6 +68,43 @@ const effectDropHighlight: React.CSSProperties = {
 
 const SEQUENCE_REORDER_MIME_TYPE = 'application/remotion-sequence-reorder';
 
+type SequenceNameSaveAction =
+	| {
+			type: 'noop';
+	  }
+	| {
+			type: 'save';
+			defaultValue: string | null;
+	  };
+
+const getSequenceNameSaveAction = ({
+	editedName,
+	currentDisplayName,
+	fallbackDisplayName,
+	hasStaticNameProp,
+}: {
+	editedName: string;
+	currentDisplayName: string;
+	fallbackDisplayName: string;
+	hasStaticNameProp: boolean;
+}): SequenceNameSaveAction => {
+	if (
+		!hasStaticNameProp &&
+		(editedName === '' || editedName === fallbackDisplayName)
+	) {
+		return {type: 'noop'};
+	}
+
+	if (hasStaticNameProp && editedName === currentDisplayName) {
+		return {type: 'noop'};
+	}
+
+	return {
+		type: 'save',
+		defaultValue: editedName === '' ? JSON.stringify('') : null,
+	};
+};
+
 type SequenceReorderDragData = {
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly nodePathKey: string;
@@ -625,17 +662,19 @@ export const TimelineSequenceItem: React.FC<{
 		return effective ?? false;
 	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
 
-	const displayName = useMemo(() => {
-		if (
-			codeNameStatus &&
-			codeNameStatus.status === 'static' &&
-			typeof codeNameStatus.codeValue === 'string'
-		) {
-			return codeNameStatus.codeValue;
-		}
+	const staticNamePropValue =
+		codeNameStatus?.status === 'static' &&
+		typeof codeNameStatus.codeValue === 'string'
+			? codeNameStatus.codeValue
+			: null;
 
-		return sequence.displayName;
-	}, [codeNameStatus, sequence.displayName]);
+	const hasStaticNameProp = staticNamePropValue !== null;
+
+	const displayName = useMemo(() => {
+		return staticNamePropValue ?? sequence.displayName;
+	}, [sequence.displayName, staticNamePropValue]);
+
+	const fallbackDisplayName = sequence.controls?.componentName ?? '<Sequence>';
 
 	const onToggleVisibility = useCallback(
 		(type: 'enable' | 'disable') => {
@@ -758,7 +797,14 @@ export const TimelineSequenceItem: React.FC<{
 				return;
 			}
 
-			if (name === displayName) {
+			const action = getSequenceNameSaveAction({
+				editedName: name,
+				currentDisplayName: displayName,
+				fallbackDisplayName,
+				hasStaticNameProp,
+			});
+
+			if (action.type === 'noop') {
 				setIsRenaming(false);
 				return;
 			}
@@ -770,7 +816,7 @@ export const TimelineSequenceItem: React.FC<{
 						nodePath,
 						fieldKey: 'name',
 						value: name,
-						defaultValue: null,
+						defaultValue: action.defaultValue,
 						schema: sequence.controls.schema,
 					},
 				],
@@ -785,6 +831,8 @@ export const TimelineSequenceItem: React.FC<{
 		[
 			canRenameThisSequence,
 			displayName,
+			fallbackDisplayName,
+			hasStaticNameProp,
 			nodePath,
 			previewServerState,
 			sequence.controls,
@@ -1089,6 +1137,7 @@ export const TimelineSequenceItem: React.FC<{
 			<div style={labelContainerStyle}>
 				<TimelineSequenceName
 					displayName={displayName}
+					fallbackDisplayName={fallbackDisplayName}
 					selected={selected}
 					containsSelection={containsSelection}
 					editing={isRenaming}

--- a/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
@@ -19,6 +19,7 @@ const getTruncatedDisplayName = (displayName: string): string => {
 
 export const TimelineSequenceName: React.FC<{
 	readonly displayName: string;
+	readonly fallbackDisplayName: string;
 	readonly selected: boolean;
 	readonly containsSelection: boolean;
 	readonly editing: boolean;
@@ -26,6 +27,7 @@ export const TimelineSequenceName: React.FC<{
 	readonly onSaveName: (name: string) => Promise<void>;
 }> = ({
 	displayName,
+	fallbackDisplayName,
 	selected,
 	containsSelection,
 	editing,
@@ -74,11 +76,12 @@ export const TimelineSequenceName: React.FC<{
 		};
 	}, [style]);
 
-	const text = getTruncatedDisplayName(displayName) || '<Sequence>';
+	const editableDisplayName = displayName || fallbackDisplayName;
+	const text = getTruncatedDisplayName(editableDisplayName);
 
 	useEffect(() => {
 		if (!editing) {
-			setDraftName(displayName);
+			setDraftName(editableDisplayName);
 			return;
 		}
 
@@ -88,10 +91,11 @@ export const TimelineSequenceName: React.FC<{
 		}
 
 		input.focus();
-		const basenameIndex = displayName.lastIndexOf('.');
-		const selectionEnd = basenameIndex > 0 ? basenameIndex : displayName.length;
+		const basenameIndex = editableDisplayName.lastIndexOf('.');
+		const selectionEnd =
+			basenameIndex > 0 ? basenameIndex : editableDisplayName.length;
 		input.setSelectionRange(0, selectionEnd);
-	}, [displayName, editing]);
+	}, [editableDisplayName, editing]);
 
 	const save = useCallback(() => {
 		onSaveName(draftName).catch(() => undefined);

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -56,6 +56,7 @@ export const saveSequenceProps = ({
 					previous: prev,
 					fieldKey: change.fieldKey,
 					value: change.value,
+					defaultValue: change.defaultValue,
 					schema: change.schema,
 				}),
 			apiCall: () =>
@@ -84,6 +85,7 @@ export const saveSequenceProps = ({
 				previous: prev,
 				fieldKey: change.fieldKey,
 				value: change.value,
+				defaultValue: change.defaultValue,
 				schema: change.schema,
 			}),
 		);


### PR DESCRIPTION
## Summary

- Remove the `name` prop when a sequence is renamed to an empty value
- Use the sequence component name (for example `<Sequence>` or `<Solid>`) as the inline rename fallback for nameless sequences
- Avoid writing the fallback component name as a `name` prop when the user leaves it unchanged
- Add coverage for removing `name` when the empty string is treated as the default

## Validation

- `cd packages/studio && bunx oxfmt src --write`
- `cd packages/studio-server && bunx oxfmt src --write`
- `bun run build`
- `cd packages/studio-server && bun test src/test/update-sequence-props.test.ts`
- `bun run stylecheck` *(fails in unrelated `template-react-router#lint` generated React Router types: `Generic type 'GetAnnotations' requires 1 type argument(s)`)*
