### PR TITLE
`@remotion/cli`: Respect composition encoding defaults

### DIFF
--- a/packages/cli/src/benchmark.ts
+++ b/packages/cli/src/benchmark.ts
@@ -533,6 +533,8 @@ export const benchmarkCommand = async (
 					imageFormat: getVideoImageFormat({
 						codec: videoCodec,
 						uiImageFormat: null,
+						compositionDefaultVideoImageFormat:
+							composition.defaultVideoImageFormat,
 					}),
 					serializedInputPropsWithCustomSchema,
 					overwrite,

--- a/packages/cli/src/image-formats.ts
+++ b/packages/cli/src/image-formats.ts
@@ -7,20 +7,30 @@ import {parsedCli} from './parsed-cli';
 export const getVideoImageFormat = ({
 	codec,
 	uiImageFormat,
+	compositionDefaultVideoImageFormat,
 }: {
 	codec: ReturnType<typeof ConfigInternals.getOutputCodecOrUndefined>;
 	uiImageFormat: VideoImageFormat | null;
+	compositionDefaultVideoImageFormat: VideoImageFormat | null;
 }): VideoImageFormat => {
 	if (uiImageFormat !== null) {
 		return uiImageFormat;
 	}
 
-	const configured = BrowserSafeApis.options.videoImageFormatOption.getValue({
+	const imageFormatOption = BrowserSafeApis.options.videoImageFormatOption.getValue({
 		commandLine: parsedCli,
-	}).value;
+	});
 
-	if (configured !== null) {
-		return configured;
+	if (imageFormatOption.source === 'cli' && imageFormatOption.value !== null) {
+		return imageFormatOption.value;
+	}
+
+	if (compositionDefaultVideoImageFormat !== null) {
+		return compositionDefaultVideoImageFormat;
+	}
+
+	if (imageFormatOption.value !== null) {
+		return imageFormatOption.value;
 	}
 
 	if (NoReactAPIs.isAudioCodec(codec)) {

--- a/packages/cli/src/image-formats.ts
+++ b/packages/cli/src/image-formats.ts
@@ -17,9 +17,10 @@ export const getVideoImageFormat = ({
 		return uiImageFormat;
 	}
 
-	const imageFormatOption = BrowserSafeApis.options.videoImageFormatOption.getValue({
-		commandLine: parsedCli,
-	});
+	const imageFormatOption =
+		BrowserSafeApis.options.videoImageFormatOption.getValue({
+			commandLine: parsedCli,
+		});
 
 	if (imageFormatOption.source === 'cli' && imageFormatOption.value !== null) {
 		return imageFormatOption.value;

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -546,17 +546,19 @@ export const renderVideoFlow = async ({
 		uiImageFormat,
 		compositionDefaultVideoImageFormat: config.defaultVideoImageFormat,
 	});
-	const pixelFormatOptionValue = pixelFormatOption.getValue({
-		commandLine: parsedCli,
-	});
+	const pixelFormatOptionValue =
+		BrowserSafeApis.options.pixelFormatOption.getValue({
+			commandLine: parsedCli,
+		});
 	const resolvedPixelFormat =
 		pixelFormatOptionValue.source === 'default' &&
 		config.defaultPixelFormat !== null
 			? config.defaultPixelFormat
 			: pixelFormat;
-	const proResProfileOptionValue = proResProfileOption.getValue({
-		commandLine: parsedCli,
-	});
+	const proResProfileOptionValue =
+		BrowserSafeApis.options.proResProfileOption.getValue({
+			commandLine: parsedCli,
+		});
 	const resolvedProResProfile =
 		proResProfileOptionValue.source === 'default' &&
 		config.defaultProResProfile !== null

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -544,7 +544,24 @@ export const renderVideoFlow = async ({
 	const imageFormat = getVideoImageFormat({
 		codec: shouldOutputImageSequence ? undefined : codec,
 		uiImageFormat,
+		compositionDefaultVideoImageFormat: config.defaultVideoImageFormat,
 	});
+	const pixelFormatOptionValue = pixelFormatOption.getValue({
+		commandLine: parsedCli,
+	});
+	const resolvedPixelFormat =
+		pixelFormatOptionValue.source === 'default' &&
+		config.defaultPixelFormat !== null
+			? config.defaultPixelFormat
+			: pixelFormat;
+	const proResProfileOptionValue = proResProfileOption.getValue({
+		commandLine: parsedCli,
+	});
+	const resolvedProResProfile =
+		proResProfileOptionValue.source === 'default' &&
+		config.defaultProResProfile !== null
+			? config.defaultProResProfile
+			: proResProfile;
 
 	const onLog: OnLog = ({logLevel: logLogLevel, previewString, tag}) => {
 		addLogToAggregateProgress({
@@ -679,8 +696,8 @@ export const renderVideoFlow = async ({
 		frameRange,
 		serializedInputPropsWithCustomSchema,
 		overwrite,
-		pixelFormat,
-		proResProfile,
+		pixelFormat: resolvedPixelFormat,
+		proResProfile: resolvedProResProfile ?? undefined,
 		x264Preset: x264Preset ?? null,
 		jpegQuality: jpegQuality ?? RenderInternals.DEFAULT_JPEG_QUALITY,
 		chromiumOptions,

--- a/packages/cli/src/test/image-formats.test.ts
+++ b/packages/cli/src/test/image-formats.test.ts
@@ -2,11 +2,31 @@ import {expect, test} from 'bun:test';
 import {getVideoImageFormat} from '../image-formats';
 
 test('returns jpeg for av1 codec', () => {
-	expect(getVideoImageFormat({codec: 'av1', uiImageFormat: null})).toBe('jpeg');
+	expect(
+		getVideoImageFormat({
+			codec: 'av1',
+			uiImageFormat: null,
+			compositionDefaultVideoImageFormat: null,
+		}),
+	).toBe('jpeg');
 });
 
 test('returns png if codec is undefined', () => {
-	expect(getVideoImageFormat({codec: undefined, uiImageFormat: null})).toBe(
-		'png',
-	);
+	expect(
+		getVideoImageFormat({
+			codec: undefined,
+			uiImageFormat: null,
+			compositionDefaultVideoImageFormat: null,
+		}),
+	).toBe('png');
+});
+
+test('uses composition default image format before built-in codec default', () => {
+	expect(
+		getVideoImageFormat({
+			codec: 'prores',
+			uiImageFormat: null,
+			compositionDefaultVideoImageFormat: 'png',
+		}),
+	).toBe('png');
 });

--- a/packages/lambda/src/cli/commands/render/render.ts
+++ b/packages/lambda/src/cli/commands/render/render.ts
@@ -327,6 +327,7 @@ export const renderCommand = async ({
 	const imageFormat = CliInternals.getVideoImageFormat({
 		codec,
 		uiImageFormat: null,
+		compositionDefaultVideoImageFormat: null,
 	});
 
 	const functionName = await findFunctionName({logLevel, providerSpecifics});


### PR DESCRIPTION
## Summary
- Use composition-level `defaultVideoImageFormat` from `calculateMetadata()` before built-in codec fallbacks when resolving CLI render image format
- Apply composition-level `defaultPixelFormat` and `defaultProResProfile` in the render flow unless explicit CLI flags are provided
- Add coverage for ProRes using a composition default image format

Fixes #8587