### PR TITLE
Gracefully close renderer browser process

### DIFF
--- a/packages/renderer/src/browser/Browser.ts
+++ b/packages/renderer/src/browser/Browser.ts
@@ -306,7 +306,12 @@ export class HeadlessBrowser extends EventEmitter {
 	}
 
 	async close({silent}: {silent: boolean}): Promise<void> {
-		await this.runner.closeProcess();
+		this.connection.send('Browser.close').catch(() => undefined);
+		const exitedGracefully = await this.runner.waitForProcessExit(2000);
+		if (!exitedGracefully) {
+			await this.runner.closeProcess();
+		}
+
 		(await this.pages()).forEach((page) => {
 			page.emit(PageEmittedEvents.Disposed);
 			page.closed = true;

--- a/packages/renderer/src/browser/BrowserRunner.ts
+++ b/packages/renderer/src/browser/BrowserRunner.ts
@@ -164,6 +164,30 @@ export const makeBrowserRunner = async ({
 		return processClosing;
 	};
 
+	const waitForProcessExit = (
+		timeoutInMilliseconds: number,
+	): Promise<boolean> => {
+		if (closed) {
+			return Promise.resolve(true);
+		}
+
+		return new Promise((resolve) => {
+			const timeoutId = setTimeout(() => {
+				resolve(false);
+			}, timeoutInMilliseconds);
+
+			processClosing
+				.then(() => {
+					clearTimeout(timeoutId);
+					resolve(true);
+				})
+				.catch(() => {
+					clearTimeout(timeoutId);
+					resolve(false);
+				});
+		});
+	};
+
 	if (dumpio) {
 		proc.stdout?.on('data', (d) => {
 			const message = d.toString('utf8').trim();
@@ -261,6 +285,7 @@ export const makeBrowserRunner = async ({
 		rememberEventLoop,
 		connection,
 		closeProcess,
+		waitForProcessExit,
 	};
 };
 


### PR DESCRIPTION
Fixes remotion-dev/remotion#7065.

This changes the renderer browser shutdown flow to ask Chrome to close through the DevTools `Browser.close` command first. The existing process-group kill remains as a fallback if Chrome does not exit within the timeout.

The goal is to let Chrome reap its own child processes during normal render cleanup, which should reduce lingering `chrome-headless` defunct processes in containerized Linux environments.

Validation:
- `bun run formatting` in `packages/renderer`
- `bunx turbo run make --filter=remotion --filter=@remotion/streaming --filter=@remotion/licensing --filter=@remotion/renderer --no-update-notifier`
- `bun run lint` in `packages/renderer` (completed with existing warnings, no errors)
- local `openBrowser()` / `browser.close({silent: true})` smoke test against `packages/renderer/dist/index.js`
