### PR TITLE
`remotion`: Prevent freezing audio

### DIFF
--- a/packages/core/src/audio/html5-audio.tsx
+++ b/packages/core/src/audio/html5-audio.tsx
@@ -31,6 +31,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 		}
 > = (props, ref) => {
 	const audioTagsContext = useContext(SharedAudioTagsContext);
+	const propsWithFreeze = props as typeof props & {readonly freeze?: unknown};
 	const {
 		startFrom,
 		endAt,
@@ -41,15 +42,22 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 		pauseWhenBuffering,
 		showInTimeline,
 		onError: onRemotionError,
+		freeze,
 		...otherProps
-	} = props;
-	const {loop, ...propsOtherThanLoop} = props;
+	} = propsWithFreeze;
+	const {loop, freeze: _freeze, ...propsOtherThanLoop} = propsWithFreeze;
 	const {fps} = useVideoConfig();
 	const environment = useRemotionEnvironment();
 
 	if (environment.isClientSideRendering) {
 		throw new Error(
 			'<Html5Audio> is not supported in @remotion/web-renderer. Use <Audio> from @remotion/media instead. See https://remotion.dev/docs/client-side-rendering/limitations',
+		);
+	}
+
+	if (typeof freeze !== 'undefined') {
+		throw new TypeError(
+			'The "freeze" prop is not supported on <Html5Audio />. Use <Sequence freeze={...}> to freeze media playback.',
 		);
 	}
 

--- a/packages/core/src/test/audio.test.tsx
+++ b/packages/core/src/test/audio.test.tsx
@@ -133,3 +133,20 @@ test('It should reject invalid preservePitch values on Audio', () => {
 		/'preservePitch' must be a boolean or undefined but got 'string' instead/,
 	);
 });
+
+test('It should reject freeze on Audio', () => {
+	expect(() =>
+		render(
+			<WrapSequenceContext>
+				<Html5Audio
+					// @ts-expect-error
+					freeze={10}
+					src="test"
+					volume={1}
+				/>
+			</WrapSequenceContext>,
+		),
+	).toThrow(
+		'The "freeze" prop is not supported on <Html5Audio />. Use <Sequence freeze={...}> to freeze media playback.',
+	);
+});

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -422,7 +422,7 @@ const TimelineSequenceInner: React.FC<{
 			originalLocation,
 			selectAsset,
 			sequence: s,
-			sourceActions: [freezeFrameMenuItem],
+			sourceActions: freezeFrameMenuItem ? [freezeFrameMenuItem] : [],
 		});
 	}, [
 		assetLinkInfo,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -938,7 +938,7 @@ export const TimelineSequenceItem: React.FC<{
 					subMenu: null,
 					value: 'rename-sequence',
 				},
-				freezeFrameMenuItem,
+				...(freezeFrameMenuItem ? [freezeFrameMenuItem] : []),
 			],
 		});
 	}, [

--- a/packages/studio/src/components/Timeline/use-sequence-freeze-frame-menu-item.ts
+++ b/packages/studio/src/components/Timeline/use-sequence-freeze-frame-menu-item.ts
@@ -7,6 +7,10 @@ import type {
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {saveSequenceProps, type SetPropStatuses} from './save-sequence-prop';
 
+export const shouldShowFreezeFrameMenuItem = (sequence: TSequence): boolean => {
+	return sequence.type !== 'audio';
+};
+
 export const useSequenceFreezeFrameMenuItem = ({
 	clientId,
 	nodePath,
@@ -27,7 +31,7 @@ export const useSequenceFreezeFrameMenuItem = ({
 	readonly setPropStatuses: SetPropStatuses;
 	readonly timelinePosition: number;
 	readonly validatedSource: string | null;
-}): ComboboxValue => {
+}): ComboboxValue | null => {
 	const freezeStatus = propStatusesForOverride?.freeze;
 	const isFrozen =
 		freezeStatus?.status === 'static' &&
@@ -93,18 +97,21 @@ export const useSequenceFreezeFrameMenuItem = ({
 	]);
 
 	return useMemo(
-		() => ({
-			type: 'item' as const,
-			id: 'toggle-freeze-frame',
-			keyHint: null,
-			label: isFrozen ? 'Unfreeze frame' : 'Freeze frame',
-			leftItem: null,
-			disabled: !canToggleFreeze,
-			onClick: onToggleFreezeFrame,
-			quickSwitcherLabel: null,
-			subMenu: null,
-			value: 'toggle-freeze-frame',
-		}),
-		[canToggleFreeze, isFrozen, onToggleFreezeFrame],
+		() =>
+			shouldShowFreezeFrameMenuItem(sequence)
+				? {
+						type: 'item' as const,
+						id: 'toggle-freeze-frame',
+						keyHint: null,
+						label: isFrozen ? 'Unfreeze frame' : 'Freeze frame',
+						leftItem: null,
+						disabled: !canToggleFreeze,
+						onClick: onToggleFreezeFrame,
+						quickSwitcherLabel: null,
+						subMenu: null,
+						value: 'toggle-freeze-frame',
+					}
+				: null,
+		[canToggleFreeze, isFrozen, onToggleFreezeFrame, sequence],
 	);
 };

--- a/packages/studio/src/test/sequence-context-menu-items.test.ts
+++ b/packages/studio/src/test/sequence-context-menu-items.test.ts
@@ -2,6 +2,7 @@ import {afterEach, expect, test} from 'bun:test';
 import type {TSequence} from 'remotion';
 import type {ComboboxValue} from '../components/NewComposition/ComboBox';
 import {getSequenceContextMenuItems} from '../components/Timeline/get-sequence-context-menu-items';
+import {shouldShowFreezeFrameMenuItem} from '../components/Timeline/use-sequence-freeze-frame-menu-item';
 
 const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
 	globalThis,
@@ -89,4 +90,16 @@ test('sequence context menu does not put two dividers between docs and rename', 
 	expect(
 		items.slice(docsIndex + 1, renameIndex).map((item) => item.type),
 	).toEqual(['divider']);
+});
+
+test('sequence freeze context menu item is hidden for audio', () => {
+	expect(shouldShowFreezeFrameMenuItem({type: 'audio'} as TSequence)).toBe(
+		false,
+	);
+	expect(shouldShowFreezeFrameMenuItem({type: 'video'} as TSequence)).toBe(
+		true,
+	);
+	expect(shouldShowFreezeFrameMenuItem({type: 'sequence'} as TSequence)).toBe(
+		true,
+	);
 });


### PR DESCRIPTION
## Summary
- Reject `freeze` when passed to `<Html5Audio />` / `<Audio />` at runtime.
- Hide the Studio freeze-frame context-menu action for audio sequences.
- Add focused coverage for both the runtime guard and Studio menu predicate.

Fixes #8384.

## Testing
- `bun test src/test/audio.test.tsx` from `packages/core`
- `bun test src/test/sequence-context-menu-items.test.ts` from `packages/studio`
- `bun run build`
- `bun run stylecheck`
