### PR TITLE
`@remotion/studio`: Group inspector controls

### DIFF
--- a/packages/studio-server/src/test/discriminated-union-update.test.ts
+++ b/packages/studio-server/src/test/discriminated-union-update.test.ts
@@ -44,12 +44,12 @@ test('Should expose absolute-fill variant fields when active', () => {
 	});
 	expect(schemaFields?.map((s) => s.key)).toEqual([
 		'layout',
+		'premountFor',
 		'style.transformOrigin',
 		'style.translate',
 		'style.scale',
 		'style.rotate',
 		'style.opacity',
-		'premountFor',
 	]);
 });
 

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -251,9 +251,11 @@ export {
 	getRequiredPackageForInsertableElement,
 } from './required-package';
 export {
+	SCHEMA_FIELD_GROUPS,
 	SCHEMA_FIELD_ROW_HEIGHT,
 	getEffectFieldsToShow,
 	getFieldsToShow,
+	getSchemaFieldGroup,
 } from './schema-field-info';
 export type {
 	AnySchemaFieldInfo,
@@ -261,6 +263,8 @@ export type {
 	EffectSchemaFieldInfo,
 	InteractivitySchemaFieldInfo,
 	PropStatuses,
+	SchemaFieldGroup,
+	SchemaFieldGroupInfo,
 	SchemaFieldInfo,
 	SequenceControls,
 } from './schema-field-info';

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -21,6 +21,7 @@ export type SchemaFieldInfo = {
 	typeName: SupportedSchemaType;
 	rowHeight: number;
 	fieldSchema: VisibleFieldSchema;
+	group: SchemaFieldGroup;
 };
 
 export type InteractivitySchemaFieldInfo = SchemaFieldInfo & {
@@ -38,6 +39,69 @@ export type AnySchemaFieldInfo =
 	| EffectSchemaFieldInfo;
 
 export const SCHEMA_FIELD_ROW_HEIGHT = 22;
+
+export type SchemaFieldGroup = 'controls' | 'transforms' | 'text';
+
+export type SchemaFieldGroupInfo = {
+	readonly id: SchemaFieldGroup;
+	readonly label: string;
+};
+
+export const SCHEMA_FIELD_GROUPS = [
+	{id: 'controls', label: 'Controls'},
+	{id: 'transforms', label: 'Transform'},
+	{id: 'text', label: 'Text'},
+] as const satisfies readonly SchemaFieldGroupInfo[];
+
+const schemaFieldGroupOrder = SCHEMA_FIELD_GROUPS.reduce(
+	(acc, group, index) => {
+		acc[group.id] = index;
+		return acc;
+	},
+	{} as Record<SchemaFieldGroup, number>,
+);
+
+const TRANSFORM_FIELD_KEYS = new Set([
+	'style.transformOrigin',
+	'style.translate',
+	'style.scale',
+	'style.rotate',
+	'style.opacity',
+]);
+
+const TEXT_FIELD_KEYS = new Set([
+	'style.color',
+	'style.fontSize',
+	'style.lineHeight',
+	'style.fontWeight',
+	'style.fontStyle',
+	'style.letterSpacing',
+	'style.textAlign',
+]);
+
+export const getSchemaFieldGroup = (key: string): SchemaFieldGroup => {
+	if (TRANSFORM_FIELD_KEYS.has(key)) {
+		return 'transforms';
+	}
+
+	if (TEXT_FIELD_KEYS.has(key)) {
+		return 'text';
+	}
+
+	return 'controls';
+};
+
+const sortSchemaFields = <T extends SchemaFieldInfo>(fields: T[]): T[] => {
+	return fields
+		.map((field, index) => ({field, index}))
+		.sort((a, b) => {
+			const groupDiff =
+				schemaFieldGroupOrder[a.field.group] -
+				schemaFieldGroupOrder[b.field.group];
+			return groupDiff === 0 ? a.index - b.index : groupDiff;
+		})
+		.map(({field}) => field);
+};
 
 const SUPPORTED_SCHEMA_TYPES = [
 	'number',
@@ -145,7 +209,7 @@ export const getFieldsToShow = ({
 		(key) => valuesDotNotation[key],
 	);
 
-	return Object.entries(activeSchema)
+	const fields = Object.entries(activeSchema)
 		.map(([key, fieldSchema]): InteractivitySchemaFieldInfo | null => {
 			const typeName = fieldSchema.type;
 			if (SUPPORTED_SCHEMA_TYPES.indexOf(typeName) === -1) {
@@ -176,9 +240,12 @@ export const getFieldsToShow = ({
 					value: valuesDotNotation[key],
 				}),
 				fieldSchema,
+				group: getSchemaFieldGroup(key),
 			};
 		})
 		.filter(NoReactInternals.truthy);
+
+	return sortSchemaFields(fields);
 };
 
 export const getEffectFieldsToShow = ({
@@ -208,7 +275,7 @@ export const getEffectFieldsToShow = ({
 		return getEffectFieldValue({key, dragOverrides, effectStatus});
 	});
 
-	return Object.entries(activeSchema)
+	const fields = Object.entries(activeSchema)
 		.map(([key, fieldSchema]): EffectSchemaFieldInfo | null => {
 			const typeName = fieldSchema.type;
 			if (typeName === 'hidden') {
@@ -241,7 +308,10 @@ export const getEffectFieldsToShow = ({
 				fieldSchema,
 				effectSchema: effect.schema,
 				effectIndex,
+				group: getSchemaFieldGroup(key),
 			};
 		})
 		.filter(NoReactInternals.truthy);
+
+	return sortSchemaFields(fields);
 };

--- a/packages/studio-shared/src/test/schema-field-info.test.ts
+++ b/packages/studio-shared/src/test/schema-field-info.test.ts
@@ -7,6 +7,7 @@ import {
 import {
 	SCHEMA_FIELD_ROW_HEIGHT,
 	getEffectFieldsToShow,
+	getFieldsToShow,
 } from '../schema-field-info';
 
 const effect = {
@@ -155,4 +156,125 @@ test('getEffectFieldsToShow sizes array fields from the current value', () => {
 
 	const colors = fields.find((field) => field.key === 'colors');
 	expect(colors?.rowHeight).toBe(SCHEMA_FIELD_ROW_HEIGHT * 4);
+});
+
+test('getFieldsToShow sorts fields by inspector group order', () => {
+	const fields = getFieldsToShow({
+		schema: {
+			'style.translate': {
+				type: 'translate',
+				default: '0px 0px',
+			},
+			playbackRate: {
+				type: 'number',
+				default: 1,
+				hiddenFromList: false,
+			},
+			'style.fontSize': {
+				type: 'number',
+				default: undefined,
+				hiddenFromList: false,
+			},
+			'style.color': {
+				type: 'color',
+				default: undefined,
+			},
+			'style.rotate': {
+				type: 'rotation-css',
+				default: '0deg',
+			},
+			'style.opacity': {
+				type: 'number',
+				default: 1,
+				hiddenFromList: false,
+			},
+			volume: {
+				type: 'number',
+				default: 1,
+				hiddenFromList: false,
+			},
+			'style.letterSpacing': {
+				type: 'number',
+				default: undefined,
+				hiddenFromList: false,
+			},
+			'style.textAlign': {
+				type: 'enum',
+				default: 'left',
+				variants: {
+					left: {},
+					center: {},
+				},
+			},
+		},
+		currentRuntimeValueDotNotation: {},
+		getDragOverrides: () => ({}),
+		propStatuses: {},
+		nodePath,
+	});
+
+	expect(fields?.map((field) => field.key)).toEqual([
+		'playbackRate',
+		'volume',
+		'style.translate',
+		'style.rotate',
+		'style.opacity',
+		'style.fontSize',
+		'style.color',
+		'style.letterSpacing',
+		'style.textAlign',
+	]);
+	expect(fields?.map((field) => field.group)).toEqual([
+		'controls',
+		'controls',
+		'transforms',
+		'transforms',
+		'transforms',
+		'text',
+		'text',
+		'text',
+		'text',
+	]);
+});
+
+test('getEffectFieldsToShow sorts fields by inspector group order', () => {
+	const fields = getEffectFieldsToShow({
+		effect: {
+			...effect,
+			schema: {
+				'style.scale': {
+					type: 'scale',
+					default: 1,
+				},
+				intensity: {
+					type: 'number',
+					default: 1,
+					hiddenFromList: false,
+				},
+				'style.fontWeight': {
+					type: 'enum',
+					default: '400',
+					variants: {
+						'400': {},
+						'700': {},
+					},
+				},
+				'style.translate': {
+					type: 'translate',
+					default: '0px 0px',
+				},
+			},
+		},
+		effectIndex: 0,
+		nodePath: null,
+		propStatuses: {},
+		getEffectDragOverrides: () => ({}),
+	});
+
+	expect(fields.map((field) => field.key)).toEqual([
+		'intensity',
+		'style.scale',
+		'style.translate',
+		'style.fontWeight',
+	]);
 });

--- a/packages/studio/src/components/InspectorPanel/styles.ts
+++ b/packages/studio/src/components/InspectorPanel/styles.ts
@@ -41,6 +41,7 @@ export const sectionHeader: React.CSSProperties = {
 	fontSize: 12,
 	fontWeight: 'bold',
 	padding: `8px ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
+	userSelect: 'none',
 };
 
 export const sequenceHeader: React.CSSProperties = {
@@ -106,6 +107,7 @@ export const sectionHeaderTitle: React.CSSProperties = {
 	minWidth: 0,
 	overflow: 'hidden',
 	textOverflow: 'ellipsis',
+	userSelect: 'none',
 	whiteSpace: 'nowrap',
 };
 

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -5,8 +5,10 @@ import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {LIGHT_TEXT, LINE_COLOR} from '../helpers/colors';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {
+	SCHEMA_FIELD_GROUPS,
 	flattenVisibleTreeNodes,
 	type FlatTreeRow,
+	type SchemaFieldGroupInfo,
 	type TimelineTreeNode,
 } from '../helpers/timeline-layout';
 import {Plus} from '../icons/plus';
@@ -76,6 +78,21 @@ const getInspectorExpansionKey = (nodePathInfo: SequenceNodePathInfo) => {
 
 type SequenceWithControls = TSequence & {
 	readonly controls: NonNullable<TSequence['controls']>;
+};
+
+type InspectorControlGroup = SchemaFieldGroupInfo & {
+	readonly rows: FlatTreeRow[];
+};
+
+const getInspectorControlGroups = (
+	rows: readonly FlatTreeRow[],
+): InspectorControlGroup[] => {
+	return SCHEMA_FIELD_GROUPS.map((group) => ({
+		...group,
+		rows: rows.filter(({node}) => {
+			return node.kind === 'field' && node.field?.group === group.id;
+		}),
+	})).filter((group) => group.rows.length > 0);
 };
 
 export const getInspectorSelectableItems = (
@@ -172,6 +189,10 @@ export const InspectorSequenceSection: React.FC<{
 		() => getInspectorSelectableItems(effectRows),
 		[effectRows],
 	);
+	const controlGroups = useMemo(
+		() => getInspectorControlGroups(controlRows),
+		[controlRows],
+	);
 
 	const {schema} = sequence.controls;
 	const showEffectsSection =
@@ -247,10 +268,17 @@ export const InspectorSequenceSection: React.FC<{
 	return (
 		<div style={container}>
 			<div style={divider} />
-			{controlRows.length > 0 ? renderSectionHeader('Controls') : null}
-			<TimelineSelectionOrderProvider items={controlSelectableItems}>
-				{controlRows.map(renderRow)}
-			</TimelineSelectionOrderProvider>
+			{controlRows.length > 0 ? (
+				<TimelineSelectionOrderProvider items={controlSelectableItems}>
+					{controlGroups.map((group, i) => (
+						<React.Fragment key={group.id}>
+							{i === 0 ? null : <div style={controlsEffectsDivider} />}
+							{renderSectionHeader(group.label)}
+							{group.rows.map(renderRow)}
+						</React.Fragment>
+					))}
+				</TimelineSelectionOrderProvider>
+			) : null}
 			{showEffectsSection ? (
 				<>
 					{showControlsEffectsDivider ? (

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -4,6 +4,8 @@ import {
 	type AnySchemaFieldInfo,
 	type DragOverrides,
 	type EffectSchemaFieldInfo,
+	type SchemaFieldGroup,
+	type SchemaFieldGroupInfo,
 	type PropStatuses,
 	type SchemaFieldInfo,
 	type SequenceControls,
@@ -19,8 +21,10 @@ import type {GetIsExpanded} from '../components/ExpandedTracksProvider';
 import type {SequenceNodePathInfo} from './get-timeline-sequence-sort-key';
 
 export {
+	SCHEMA_FIELD_GROUPS,
 	getEffectFieldsToShow,
 	getFieldsToShow,
+	getSchemaFieldGroup,
 	SCHEMA_FIELD_ROW_HEIGHT,
 } from '@remotion/studio-shared';
 export type {
@@ -28,6 +32,8 @@ export type {
 	DragOverrides,
 	EffectSchemaFieldInfo,
 	PropStatuses,
+	SchemaFieldGroup,
+	SchemaFieldGroupInfo,
 	SchemaFieldInfo,
 	SequenceControls,
 	InteractivitySchemaFieldInfo,

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -12,7 +12,10 @@ import {getTimelineEasingSegments} from '../components/Timeline/get-timeline-eas
 import {getTimelineKeyframes} from '../components/Timeline/get-timeline-keyframes';
 import {getTimelineKeyframeDragKey} from '../components/Timeline/TimelineKeyframeDragState';
 import {calculateTimeline} from '../helpers/calculate-timeline';
-import type {TimelineTreeNode} from '../helpers/timeline-layout';
+import {
+	getSchemaFieldGroup,
+	type TimelineTreeNode,
+} from '../helpers/timeline-layout';
 
 const getStack = () => null;
 
@@ -114,6 +117,7 @@ const makeSequenceFieldNode = (key: string): TimelineTreeNode => ({
 		typeName: 'number',
 		rowHeight: 22,
 		fieldSchema: numberFieldSchema,
+		group: getSchemaFieldGroup(key),
 	},
 });
 
@@ -141,6 +145,7 @@ const makeEffectFieldNode = (
 		effectSchema: {
 			[key]: numberFieldSchema,
 		},
+		group: getSchemaFieldGroup(key),
 	},
 });
 


### PR DESCRIPTION
## Summary

- Add shared schema field grouping metadata for Controls, Transforms, and Font.
- Sort inspector/timeline fields by that group order while preserving order within each group.
- Render grouped headings in the Studio inspector while keeping timeline rows flat.

Closes #8627

## Testing

- bun test packages/studio-shared/src/test/schema-field-info.test.ts packages/studio/src/test/timeline-keyframes.test.ts
- bunx tsc --noEmit --project packages/studio/tsconfig.json
- bun run build
- bun run stylecheck
