### PR TITLE
`@remotion/studio-server`: Preserve easing when splitting keyframes

### DIFF
--- a/packages/core/src/test/drag-override-value.test.ts
+++ b/packages/core/src/test/drag-override-value.test.ts
@@ -84,6 +84,34 @@ test('makeKeyframedDragOverride duplicates the split segment easing', () => {
 	});
 });
 
+test('makeKeyframedDragOverride uses linear easing outside the keyframe range', () => {
+	const status: CanUpdateSequencePropStatusKeyframed = {
+		...makeKeyframedStatus(),
+		easing: [{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1}],
+	};
+	const override = makeKeyframedDragOverride({
+		status,
+		frame: 90,
+		value: 5,
+	});
+
+	expect(override).toEqual({
+		type: 'keyframed',
+		status: {
+			...status,
+			keyframes: [
+				{frame: 0, value: 2},
+				{frame: 60, value: 4},
+				{frame: 90, value: 5},
+			],
+			easing: [
+				{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+				{type: 'linear'},
+			],
+		},
+	});
+});
+
 test('makeKeyframedDragOverride replaces an existing keyframe without changing easing length', () => {
 	const override = makeKeyframedDragOverride({
 		status: makeKeyframedStatus(),

--- a/packages/core/src/test/drag-override-value.test.ts
+++ b/packages/core/src/test/drag-override-value.test.ts
@@ -49,6 +49,41 @@ test('makeKeyframedDragOverride inserts a new keyframe and preserves easing leng
 	});
 });
 
+test('makeKeyframedDragOverride duplicates the split segment easing', () => {
+	const status: CanUpdateSequencePropStatusKeyframed = {
+		...makeKeyframedStatus(),
+		keyframes: [
+			{frame: 0, value: 2},
+			{frame: 31, value: 3},
+			{frame: 60, value: 4},
+		],
+		easing: [{type: 'linear'}, {type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1}],
+	};
+	const override = makeKeyframedDragOverride({
+		status,
+		frame: 38,
+		value: 3.5,
+	});
+
+	expect(override).toEqual({
+		type: 'keyframed',
+		status: {
+			...status,
+			keyframes: [
+				{frame: 0, value: 2},
+				{frame: 31, value: 3},
+				{frame: 38, value: 3.5},
+				{frame: 60, value: 4},
+			],
+			easing: [
+				{type: 'linear'},
+				{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+				{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+			],
+		},
+	});
+});
+
 test('makeKeyframedDragOverride replaces an existing keyframe without changing easing length', () => {
 	const override = makeKeyframedDragOverride({
 		status: makeKeyframedStatus(),

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -55,6 +55,20 @@ export const DEFAULT_LINEAR_EASING: CanUpdateSequencePropStatusLinearEasing = {
 	type: 'linear',
 };
 
+const getEasingIndexToDuplicate = ({
+	insertedKeyframeIndex,
+	easingLength,
+}: {
+	insertedKeyframeIndex: number;
+	easingLength: number;
+}) => {
+	if (easingLength === 0 || insertedKeyframeIndex === 0) {
+		return 0;
+	}
+
+	return Math.min(insertedKeyframeIndex - 1, easingLength - 1);
+};
+
 export type CanUpdateSequencePropStatusClamping = {
 	left: ExtrapolateType;
 	right: ExtrapolateType;
@@ -145,6 +159,20 @@ export const makeKeyframedDragOverride = ({
 					index === existingIndex ? {frame, value} : keyframe,
 				);
 	const easing = [...status.easing];
+	if (existingIndex === -1) {
+		const insertedKeyframeIndex = keyframes.findIndex(
+			(keyframe) => keyframe.frame === frame,
+		);
+		const easingToDuplicate =
+			easing[
+				getEasingIndexToDuplicate({
+					insertedKeyframeIndex,
+					easingLength: easing.length,
+				})
+			] ?? DEFAULT_LINEAR_EASING;
+		easing.splice(insertedKeyframeIndex, 0, easingToDuplicate);
+	}
+
 	while (easing.length < keyframes.length - 1) {
 		easing.push(DEFAULT_LINEAR_EASING);
 	}

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -58,12 +58,17 @@ export const DEFAULT_LINEAR_EASING: CanUpdateSequencePropStatusLinearEasing = {
 const getEasingIndexToDuplicate = ({
 	insertedKeyframeIndex,
 	easingLength,
+	keyframeCount,
 }: {
 	insertedKeyframeIndex: number;
 	easingLength: number;
-}) => {
-	if (easingLength === 0 || insertedKeyframeIndex === 0) {
-		return 0;
+	keyframeCount: number;
+}): number | null => {
+	const isSplittingExistingSegment =
+		insertedKeyframeIndex > 0 && insertedKeyframeIndex < keyframeCount - 1;
+
+	if (!isSplittingExistingSegment || easingLength === 0) {
+		return null;
 	}
 
 	return Math.min(insertedKeyframeIndex - 1, easingLength - 1);
@@ -163,13 +168,15 @@ export const makeKeyframedDragOverride = ({
 		const insertedKeyframeIndex = keyframes.findIndex(
 			(keyframe) => keyframe.frame === frame,
 		);
+		const easingIndexToDuplicate = getEasingIndexToDuplicate({
+			insertedKeyframeIndex,
+			easingLength: easing.length,
+			keyframeCount: keyframes.length,
+		});
 		const easingToDuplicate =
-			easing[
-				getEasingIndexToDuplicate({
-					insertedKeyframeIndex,
-					easingLength: easing.length,
-				})
-			] ?? DEFAULT_LINEAR_EASING;
+			easingIndexToDuplicate === null
+				? DEFAULT_LINEAR_EASING
+				: easing[easingIndexToDuplicate];
 		easing.splice(insertedKeyframeIndex, 0, easingToDuplicate);
 	}
 

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -673,11 +673,13 @@ const normalizeEasingAfterAddingKeyframe = ({
 	previousSegmentCount,
 	nextSegmentCount,
 	insertedKeyframeIndex,
+	nextKeyframeCount,
 }: {
 	extraArgs: (ExpressionKind | SpreadElementKind)[];
 	previousSegmentCount: number;
 	nextSegmentCount: number;
 	insertedKeyframeIndex: number;
+	nextKeyframeCount: number;
 }): {
 	extraArgs: (ExpressionKind | SpreadElementKind)[];
 	needsEasingImport: boolean;
@@ -696,14 +698,19 @@ const normalizeEasingAfterAddingKeyframe = ({
 	}
 
 	if (easing.length < nextSegmentCount) {
+		const isSplittingExistingSegment =
+			insertedKeyframeIndex > 0 &&
+			insertedKeyframeIndex < nextKeyframeCount - 1;
 		const easingIndexToDuplicate =
-			easing.length === 0 || insertedKeyframeIndex === 0
-				? 0
-				: Math.min(insertedKeyframeIndex - 1, easing.length - 1);
+			isSplittingExistingSegment && easing.length > 0
+				? Math.min(insertedKeyframeIndex - 1, easing.length - 1)
+				: null;
 		easing.splice(
 			insertedKeyframeIndex,
 			0,
-			easing[easingIndexToDuplicate] ?? LINEAR_KEYFRAME_EASING,
+			easingIndexToDuplicate === null
+				? LINEAR_KEYFRAME_EASING
+				: easing[easingIndexToDuplicate],
 		);
 	}
 
@@ -1075,6 +1082,7 @@ const addKeyframe = ({
 						insertedKeyframeIndex: [...nextKeyframes]
 							.sort((first, second) => first.frame - second.frame)
 							.findIndex((keyframe) => keyframe.frame === frame),
+						nextKeyframeCount: nextKeyframes.length,
 					})
 				: {extraArgs: existing.extraArgs, needsEasingImport: false};
 

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -672,10 +672,12 @@ const normalizeEasingAfterAddingKeyframe = ({
 	extraArgs,
 	previousSegmentCount,
 	nextSegmentCount,
+	insertedKeyframeIndex,
 }: {
 	extraArgs: (ExpressionKind | SpreadElementKind)[];
 	previousSegmentCount: number;
 	nextSegmentCount: number;
+	insertedKeyframeIndex: number;
 }): {
 	extraArgs: (ExpressionKind | SpreadElementKind)[];
 	needsEasingImport: boolean;
@@ -693,6 +695,18 @@ const normalizeEasingAfterAddingKeyframe = ({
 		return {extraArgs, needsEasingImport: false};
 	}
 
+	if (easing.length < nextSegmentCount) {
+		const easingIndexToDuplicate =
+			easing.length === 0 || insertedKeyframeIndex === 0
+				? 0
+				: Math.min(insertedKeyframeIndex - 1, easing.length - 1);
+		easing.splice(
+			insertedKeyframeIndex,
+			0,
+			easing[easingIndexToDuplicate] ?? LINEAR_KEYFRAME_EASING,
+		);
+	}
+
 	while (easing.length < nextSegmentCount) {
 		easing.push(LINEAR_KEYFRAME_EASING);
 	}
@@ -701,6 +715,24 @@ const normalizeEasingAfterAddingKeyframe = ({
 		extraArgs: getExtraArgsWithOptions({extraArgs, options}),
 		needsEasingImport: setEasingOption({options, easing}),
 	};
+};
+
+const getEasingIndexToRemove = ({
+	removedKeyframeIndex,
+	keyframeCountBeforeRemoval,
+}: {
+	removedKeyframeIndex: number;
+	keyframeCountBeforeRemoval: number;
+}) => {
+	if (removedKeyframeIndex === 0) {
+		return 0;
+	}
+
+	if (removedKeyframeIndex === keyframeCountBeforeRemoval - 1) {
+		return removedKeyframeIndex - 1;
+	}
+
+	return removedKeyframeIndex;
 };
 
 const normalizeEasingAfterRemovingKeyframe = ({
@@ -731,8 +763,10 @@ const normalizeEasingAfterRemovingKeyframe = ({
 	}
 
 	if (easing.length > 0) {
-		const easingIndexToRemove =
-			removedKeyframeIndex === 0 ? 0 : removedKeyframeIndex - 1;
+		const easingIndexToRemove = getEasingIndexToRemove({
+			removedKeyframeIndex,
+			keyframeCountBeforeRemoval: previousSegmentCount + 1,
+		});
 		easing.splice(easingIndexToRemove, 1);
 	}
 
@@ -777,15 +811,22 @@ const normalizeEasingAfterRemovingKeyframes = ({
 		return {extraArgs, needsEasingImport: false};
 	}
 
-	for (const removedKeyframeIndex of [...removedKeyframeIndexes].sort(
-		(first, second) => second - first,
-	)) {
+	for (const {removedKeyframeIndex, keyframeCountBeforeRemoval} of [
+		...removedKeyframeIndexes,
+	]
+		.sort((first, second) => second - first)
+		.map((keyframeIndex, index) => ({
+			removedKeyframeIndex: keyframeIndex,
+			keyframeCountBeforeRemoval: previousSegmentCount + 1 - index,
+		}))) {
 		if (easing.length === 0) {
 			break;
 		}
 
-		const easingIndexToRemove =
-			removedKeyframeIndex === 0 ? 0 : removedKeyframeIndex - 1;
+		const easingIndexToRemove = getEasingIndexToRemove({
+			removedKeyframeIndex,
+			keyframeCountBeforeRemoval,
+		});
 		easing.splice(easingIndexToRemove, 1);
 	}
 
@@ -1031,6 +1072,9 @@ const addKeyframe = ({
 						extraArgs: existing.extraArgs,
 						previousSegmentCount: Math.max(existing.keyframes.length - 1, 0),
 						nextSegmentCount: Math.max(nextKeyframes.length - 1, 0),
+						insertedKeyframeIndex: [...nextKeyframes]
+							.sort((first, second) => first.frame - second.frame)
+							.findIndex((keyframe) => keyframe.frame === frame),
 					})
 				: {extraArgs: existing.extraArgs, needsEasingImport: false};
 

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -142,7 +142,7 @@ test('updateSequenceKeyframes adds a keyframe to an existing interpolation', asy
 	);
 });
 
-test('updateSequenceKeyframes duplicates the previous easing when appending keyframes', async () => {
+test('updateSequenceKeyframes uses linear easing when appending keyframes', async () => {
 	const input = `import React from 'react';
 import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
 
@@ -167,7 +167,8 @@ export const Example: React.FC = () => {
 	});
 
 	expect(output).toContain('interpolate(frame, [91, 126, 134]');
-	expect(output.match(/Easing\.bezier\(0\.42, 0, 1, 1\)/g)?.length).toBe(2);
+	expect(output).toContain('Easing.linear');
+	expect(output.match(/Easing\.bezier\(0\.42, 0, 1, 1\)/g)?.length).toBe(1);
 });
 
 test('updateSequenceKeyframes duplicates the split segment easing when adding keyframes', async () => {

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -142,7 +142,7 @@ test('updateSequenceKeyframes adds a keyframe to an existing interpolation', asy
 	);
 });
 
-test('updateSequenceKeyframes pads easing arrays when adding keyframes', async () => {
+test('updateSequenceKeyframes duplicates the previous easing when appending keyframes', async () => {
 	const input = `import React from 'react';
 import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
 
@@ -167,9 +167,36 @@ export const Example: React.FC = () => {
 	});
 
 	expect(output).toContain('interpolate(frame, [91, 126, 134]');
-	expect(output).toContain(
-		'easing: [Easing.bezier(0.42, 0, 1, 1), Easing.linear]',
-	);
+	expect(output.match(/Easing\.bezier\(0\.42, 0, 1, 1\)/g)?.length).toBe(2);
+});
+
+test('updateSequenceKeyframes duplicates the split segment easing when adding keyframes', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [0, 31, 60], [0, 1, 2], {easing: [Easing.linear, Easing.bezier(0.42, 0, 1, 1)]})}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {type: 'add', frame: 38, value: 1.5},
+			},
+		],
+	});
+
+	expect(output).toContain('interpolate(frame, [0, 31, 38, 60]');
+	expect(output).toContain('Easing.linear');
+	expect(output.match(/Easing\.bezier\(0\.42, 0, 1, 1\)/g)?.length).toBe(2);
 });
 
 test('updateSequenceKeyframes updates a keyframe at the same frame', async () => {
@@ -940,6 +967,36 @@ export const Example: React.FC = () => {
 	expect(output).toContain('easing: [Easing.bezier(0.42, 0, 1, 1)]');
 });
 
+test('updateSequenceKeyframes preserves the left segment easing when deleting a middle keyframe', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [0, 31, 38, 60], [0, 1, 1.5, 2], {easing: [Easing.linear, Easing.bezier(0.42, 0, 1, 1), Easing.bezier(0.42, 0, 1, 1)]})}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {type: 'remove', frame: 38},
+			},
+		],
+	});
+
+	expect(output).toContain('interpolate(frame, [0, 31, 60]');
+	expect(output).toContain(
+		'easing: [Easing.linear, Easing.bezier(0.42, 0, 1, 1)]',
+	);
+});
+
 test('updateSequenceKeyframes moves overlapping selected keyframes together', async () => {
 	const input = sequenceInput.replace(
 		'interpolate(frame, [0, 100], [2, 4])',
@@ -1034,10 +1091,9 @@ test('updateSequenceKeyframes replaces an existing keyframe when moving onto it'
 		'interpolate(frame, [0, 50, 100], [2, 3, 4], {easing: [Easing.linear, Easing.bezier(0.42, 0, 1, 1)]})',
 	]);
 	expect(newValueStrings).toEqual([
-		'interpolate(frame, [50, 100], [2, 4], {easing: [Easing.bezier(0.42, 0, 1, 1)]})',
+		'interpolate(frame, [50, 100], [2, 4], {})',
 	]);
-	expect(output).toContain('scale: interpolate(frame, [50, 100], [2, 4], {');
-	expect(output).toContain('easing: [Easing.bezier(0.42, 0, 1, 1)]');
+	expect(output).toContain('scale: interpolate(frame, [50, 100], [2, 4], {})');
 });
 
 test('updateSequenceKeyframes allows moving keyframes outside the sequence range', async () => {

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -10,6 +10,20 @@ import {
 	isSchemaFieldKeyframable,
 } from './keyframe-interpolation-function';
 
+const getEasingIndexToDuplicate = ({
+	insertedKeyframeIndex,
+	easingLength,
+}: {
+	insertedKeyframeIndex: number;
+	easingLength: number;
+}) => {
+	if (easingLength === 0 || insertedKeyframeIndex === 0) {
+		return 0;
+	}
+
+	return Math.min(insertedKeyframeIndex - 1, easingLength - 1);
+};
+
 const addKeyframeToPropStatus = ({
 	status,
 	fieldKey,
@@ -42,6 +56,17 @@ const addKeyframeToPropStatus = ({
 			(first, second) => first.frame - second.frame,
 		);
 		const easing = [...status.easing];
+		const insertedKeyframeIndex = keyframes.findIndex(
+			(keyframe) => keyframe.frame === frame,
+		);
+		const easingToDuplicate =
+			easing[
+				getEasingIndexToDuplicate({
+					insertedKeyframeIndex,
+					easingLength: easing.length,
+				})
+			] ?? LINEAR_KEYFRAME_EASING;
+		easing.splice(insertedKeyframeIndex, 0, easingToDuplicate);
 		while (easing.length < keyframes.length - 1) {
 			easing.push(LINEAR_KEYFRAME_EASING);
 		}

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -13,12 +13,17 @@ import {
 const getEasingIndexToDuplicate = ({
 	insertedKeyframeIndex,
 	easingLength,
+	keyframeCount,
 }: {
 	insertedKeyframeIndex: number;
 	easingLength: number;
-}) => {
-	if (easingLength === 0 || insertedKeyframeIndex === 0) {
-		return 0;
+	keyframeCount: number;
+}): number | null => {
+	const isSplittingExistingSegment =
+		insertedKeyframeIndex > 0 && insertedKeyframeIndex < keyframeCount - 1;
+
+	if (!isSplittingExistingSegment || easingLength === 0) {
+		return null;
 	}
 
 	return Math.min(insertedKeyframeIndex - 1, easingLength - 1);
@@ -59,13 +64,15 @@ const addKeyframeToPropStatus = ({
 		const insertedKeyframeIndex = keyframes.findIndex(
 			(keyframe) => keyframe.frame === frame,
 		);
+		const easingIndexToDuplicate = getEasingIndexToDuplicate({
+			insertedKeyframeIndex,
+			easingLength: easing.length,
+			keyframeCount: keyframes.length,
+		});
 		const easingToDuplicate =
-			easing[
-				getEasingIndexToDuplicate({
-					insertedKeyframeIndex,
-					easingLength: easing.length,
-				})
-			] ?? LINEAR_KEYFRAME_EASING;
+			easingIndexToDuplicate === null
+				? LINEAR_KEYFRAME_EASING
+				: easing[easingIndexToDuplicate];
 		easing.splice(insertedKeyframeIndex, 0, easingToDuplicate);
 		while (easing.length < keyframes.length - 1) {
 			easing.push(LINEAR_KEYFRAME_EASING);

--- a/packages/studio-shared/src/optimistic-delete-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-delete-keyframe.ts
@@ -3,6 +3,24 @@ import {
 	type CanUpdateSequencePropStatus,
 } from 'remotion';
 
+const getEasingIndexToRemove = ({
+	removedKeyframeIndex,
+	keyframeCountBeforeRemoval,
+}: {
+	removedKeyframeIndex: number;
+	keyframeCountBeforeRemoval: number;
+}) => {
+	if (removedKeyframeIndex === 0) {
+		return 0;
+	}
+
+	if (removedKeyframeIndex === keyframeCountBeforeRemoval - 1) {
+		return removedKeyframeIndex - 1;
+	}
+
+	return removedKeyframeIndex;
+};
+
 const removeKeyframeFromPropStatus = ({
 	status,
 	frame,
@@ -32,7 +50,10 @@ const removeKeyframeFromPropStatus = ({
 	// keyframe so the invariant keeps holding until the server responds.
 	const easing = [...status.easing];
 	if (easing.length > 0) {
-		const easingIndexToRemove = index === 0 ? 0 : index - 1;
+		const easingIndexToRemove = getEasingIndexToRemove({
+			removedKeyframeIndex: index,
+			keyframeCountBeforeRemoval: status.keyframes.length,
+		});
 		easing.splice(easingIndexToRemove, 1);
 	}
 

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -263,6 +263,52 @@ test('optimisticAddSequenceKeyframe appends a keyframe to an existing interpolat
 	expect(status.easing).toEqual([{type: 'linear'}, {type: 'linear'}]);
 });
 
+test('optimisticAddSequenceKeyframe duplicates the easing for the split segment', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			scale: {
+				status: 'keyframed',
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 1},
+					{frame: 31, value: 2},
+					{frame: 60, value: 3},
+				],
+				easing: [
+					{type: 'linear'},
+					{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+				],
+				clamping: {left: 'extend', right: 'extend'},
+				posterize: undefined,
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticAddSequenceKeyframe({
+		previous,
+		fieldKey: 'scale',
+		frame: 38,
+		value: 2.5,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const status = updated.props.scale;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.easing).toEqual([
+		{type: 'linear'},
+		{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+		{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+	]);
+});
+
 test('optimisticAddSequenceKeyframe updates an existing keyframe at the same frame', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -309,6 +309,47 @@ test('optimisticAddSequenceKeyframe duplicates the easing for the split segment'
 	]);
 });
 
+test('optimisticAddSequenceKeyframe uses linear easing outside the keyframe range', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			scale: {
+				status: 'keyframed',
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 1},
+					{frame: 60, value: 3},
+				],
+				easing: [{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1}],
+				clamping: {left: 'extend', right: 'extend'},
+				posterize: undefined,
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticAddSequenceKeyframe({
+		previous,
+		fieldKey: 'scale',
+		frame: 90,
+		value: 4,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const status = updated.props.scale;
+	if (!status || status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.easing).toEqual([
+		{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+		{type: 'linear'},
+	]);
+});
+
 test('optimisticAddSequenceKeyframe updates an existing keyframe at the same frame', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,

--- a/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
@@ -49,6 +49,52 @@ test('optimisticDeleteSequenceKeyframe removes the matching keyframe and an easi
 	expect(status.easing).toEqual([{type: 'linear'}]);
 });
 
+test('optimisticDeleteSequenceKeyframe preserves the left segment easing when removing a middle keyframe', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			'style.opacity': {
+				status: 'keyframed',
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 0},
+					{frame: 31, value: 0.5},
+					{frame: 38, value: 0.75},
+					{frame: 60, value: 1},
+				],
+				easing: [
+					{type: 'linear'},
+					{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+					{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+				],
+				clamping: {left: 'extend', right: 'extend'},
+				posterize: undefined,
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticDeleteSequenceKeyframe({
+		previous,
+		fieldKey: 'style.opacity',
+		frame: 38,
+	});
+
+	if (!updated.canUpdate) {
+		throw new Error('expected canUpdate true');
+	}
+
+	const status = updated.props['style.opacity'];
+	if (status.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(status.easing).toEqual([
+		{type: 'linear'},
+		{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+	]);
+});
+
 test('optimisticDeleteSequenceKeyframe converts the last keyframe to a static value', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,


### PR DESCRIPTION
## Summary

- Duplicate the easing from the segment that is split when inserting a keyframe
- Preserve the left segment easing when deleting a middle keyframe
- Keep optimistic timeline state, drag overrides, and the source codemod aligned

Fixes #8637.

## Tests

- bun test packages/core/src/test/drag-override-value.test.ts
- bun test packages/studio-shared/src/test/optimistic-add-keyframe.test.ts packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
- bun test packages/studio-server/src/test/update-keyframes.test.ts
- bun run build
- bun run stylecheck
