### PR TITLE
fix: preserve collapsed effect rows on selection

### DIFF
--- a/packages/studio/src/components/ExpandedTracksProvider.tsx
+++ b/packages/studio/src/components/ExpandedTracksProvider.tsx
@@ -1,5 +1,6 @@
 import React, {createContext, useCallback, useMemo, useState} from 'react';
 import type {SequencePropsSubscriptionKey} from 'remotion';
+import {getExpandedTrackParentKeys} from '../helpers/get-expanded-track-parent-keys';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {migrateExpandedTracksForSubscriptionKey} from '../helpers/migrate-expanded-tracks-for-subscription-key';
 import {timelineNodePathInfoToKey} from '../helpers/timeline-node-path-key';
@@ -100,16 +101,7 @@ export const ExpandedTracksProvider: React.FC<{
 
 	const expandParentTracks = useCallback(
 		(nodePathInfo: SequenceNodePathInfo) => {
-			const keysToExpand: string[] = [];
-
-			for (let i = 0; i < nodePathInfo.auxiliaryKeys.length; i++) {
-				keysToExpand.push(
-					timelineNodePathInfoToKey({
-						...nodePathInfo,
-						auxiliaryKeys: nodePathInfo.auxiliaryKeys.slice(0, i),
-					}),
-				);
-			}
+			const keysToExpand = getExpandedTrackParentKeys(nodePathInfo);
 
 			if (keysToExpand.length === 0) {
 				return;

--- a/packages/studio/src/helpers/get-expanded-track-parent-keys.ts
+++ b/packages/studio/src/helpers/get-expanded-track-parent-keys.ts
@@ -1,0 +1,24 @@
+import type {SequenceNodePathInfo} from './get-timeline-sequence-sort-key';
+import {timelineNodePathInfoToKey} from './timeline-node-path-key';
+
+export const getExpandedTrackParentKeys = (
+	nodePathInfo: SequenceNodePathInfo,
+): string[] => {
+	const keysToExpand: string[] = [];
+	const parentDepth =
+		nodePathInfo.auxiliaryKeys[0] === 'effects' &&
+		nodePathInfo.auxiliaryKeys.length > 2
+			? 2
+			: nodePathInfo.auxiliaryKeys.length;
+
+	for (let i = 0; i < parentDepth; i++) {
+		keysToExpand.push(
+			timelineNodePathInfoToKey({
+				...nodePathInfo,
+				auxiliaryKeys: nodePathInfo.auxiliaryKeys.slice(0, i),
+			}),
+		);
+	}
+
+	return keysToExpand;
+};

--- a/packages/studio/src/test/get-expanded-track-parent-keys.test.ts
+++ b/packages/studio/src/test/get-expanded-track-parent-keys.test.ts
@@ -1,0 +1,58 @@
+import {expect, test} from 'bun:test';
+import {stringifySequenceExpandedRowKey} from '@remotion/studio-shared';
+import type {SequenceNodePath, SequencePropsSubscriptionKey} from 'remotion';
+import {getExpandedTrackParentKeys} from '../helpers/get-expanded-track-parent-keys';
+import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+
+const makeKey = (nodePath: SequenceNodePath): SequencePropsSubscriptionKey => ({
+	absolutePath: '/project/src/Comp.tsx',
+	nodePath,
+	sequenceKeys: ['from', 'durationInFrames'],
+	effectKeys: [],
+});
+
+const makeNodePathInfo = (
+	nodePath: SequenceNodePath,
+	auxiliaryKeys: string[],
+): SequenceNodePathInfo => ({
+	sequenceSubscriptionKey: makeKey(nodePath),
+	auxiliaryKeys,
+	index: 0,
+	numberOfSequencesWithThisNodePath: 1,
+	supportsEffects: true,
+});
+
+const expandedKey = (
+	subscriptionKey: SequencePropsSubscriptionKey,
+	auxiliaryKeys: string[],
+) =>
+	[
+		stringifySequenceExpandedRowKey(subscriptionKey),
+		auxiliaryKeys.join('.'),
+		0,
+	].join('.');
+
+test('expands regular parent rows for nested sequence props', () => {
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['layout', 'position', 'x'],
+	);
+
+	expect(getExpandedTrackParentKeys(nodePathInfo)).toEqual([
+		expandedKey(nodePathInfo.sequenceSubscriptionKey, []),
+		expandedKey(nodePathInfo.sequenceSubscriptionKey, ['layout']),
+		expandedKey(nodePathInfo.sequenceSubscriptionKey, ['layout', 'position']),
+	]);
+});
+
+test('preserves a collapsed effect row when selecting one of its props', () => {
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0', 'intensity'],
+	);
+
+	expect(getExpandedTrackParentKeys(nodePathInfo)).toEqual([
+		expandedKey(nodePathInfo.sequenceSubscriptionKey, []),
+		expandedKey(nodePathInfo.sequenceSubscriptionKey, ['effects']),
+	]);
+});


### PR DESCRIPTION
Fixes #8548.

Selecting an effect prop now expands the sequence row and the Effects container, but no longer clears the collapsed state for the specific effect row. Regular nested sequence props keep the previous parent-expansion behavior.

Verification:
- `PATH=/Users/mac/.bun/bin:$PATH bun run build`
- `PATH=/Users/mac/.bun/bin:$PATH bun test packages/studio/src/test/get-expanded-track-parent-keys.test.ts packages/studio/src/test/timeline-selection.test.ts`
- `PATH=/Users/mac/.bun/bin:$PATH bun run stylecheck`