### PR TITLE
Docs: Document R2 cache rules for Lambda assets

### DIFF
--- a/packages/docs/docs/lambda/data-transfer-cost.mdx
+++ b/packages/docs/docs/lambda/data-transfer-cost.mdx
@@ -23,6 +23,20 @@ This is easy to achieve - simply put the assets in a Cloudflare R2 bucket and re
 
 Cloudflare does not charge for data transfer, so this is a great way to reduce the cost.
 
+### Enable Cloudflare Cache for R2 assets
+
+If you serve videos or audio files from R2, also make sure that Cloudflare Cache is enabled for the bucket.
+Cold reads from R2 can be slower than cached reads, especially when [`@remotion/media`](/docs/media) fetches a video through byte range requests.
+
+Use a [custom domain for the R2 bucket](https://developers.cloudflare.com/cache/interaction-cloudflare-products/r2/) and configure a Cloudflare Cache Rule for the asset URLs. The `r2.dev` development URL does not support caching.
+
+After enabling the rule, inspect the response headers for your media URL:
+
+- `CF-Cache-Status: HIT` or `MISS` means the request went through Cloudflare Cache.
+- `CF-Cache-Status: DYNAMIC` means the request was not served from cache.
+
+See Cloudflare's [cache response documentation](https://developers.cloudflare.com/cache/concepts/cache-responses/) for the possible values.
+
 Make sure to disable the Bot fight mode for R2:
 
 - Go to Security of your domain -> Settings -> disable "Bot fight mode"

--- a/packages/docs/docs/lambda/r2.mdx
+++ b/packages/docs/docs/lambda/r2.mdx
@@ -47,6 +47,9 @@ const {bucketName, renderId, cloudWatchMainLogs} = await renderMediaOnLambda({
 
 [Many Remotion users store](/docs/lambda/data-transfer-cost#option-1-use-an-alternate-cdn-for-storing-assets) their [bundle](/docs/terminology/bundle) and any assets such as input videos in R2, in order to avoid [S3 bandwidth costs](/docs/lambda/data-transfer-cost).
 
+If you store input videos or audio files in R2, serve them through a custom domain with Cloudflare Cache enabled and configure a Cache Rule for those URLs.
+This can reduce slow cold range requests when using [`@remotion/media`](/docs/media), and the `r2.dev` development URL does not support caching.
+
 ## See also
 
 - [Using Remotion Lambda with Supabase](/docs/lambda/supabase)

--- a/packages/docs/docs/lambda/troubleshooting/debug.mdx
+++ b/packages/docs/docs/lambda/troubleshooting/debug.mdx
@@ -105,7 +105,7 @@ The chunks that are missing are the ones that failed to render.
 
 After you've identified which chunks are missing, [inspect the logs](#inspecting-the-logs) for that chunk to find the cause of the error.
 
-### Stuck chunks while loading remote media
+### Stuck chunks while loading media from Cloudflare R2
 
 If one chunk remains running much longer than the others, check whether it is loading a remote video or audio file.
 

--- a/packages/docs/docs/lambda/troubleshooting/debug.mdx
+++ b/packages/docs/docs/lambda/troubleshooting/debug.mdx
@@ -105,6 +105,22 @@ The chunks that are missing are the ones that failed to render.
 
 After you've identified which chunks are missing, [inspect the logs](#inspecting-the-logs) for that chunk to find the cause of the error.
 
+### Stuck chunks while loading remote media
+
+If one chunk remains running much longer than the others, check whether it is loading a remote video or audio file.
+
+When using [`<Video>`](/docs/media/video) or [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media), Remotion may load only the required byte ranges from the source file. This reduces data transfer, but a slow or uncached range request can make one chunk wait much longer than the rest of the render.
+
+If your assets are served from Cloudflare R2:
+
+- Serve the assets through a custom domain with Cloudflare Cache enabled. The `r2.dev` development URL does not support caching.
+- Configure a Cloudflare Cache Rule for the media URLs. If the response header is `CF-Cache-Status: DYNAMIC`, the request was not served from Cloudflare Cache.
+- If the source video has long intervals between keyframes, consider re-encoding it with a shorter keyframe interval so seeking requires less data.
+
+See [Data transfer cost: Use an alternate CDN for storing assets](/docs/lambda/data-transfer-cost#option-1-use-an-alternate-cdn-for-storing-assets) for details.
+
+To make a stalled media load fail before the Lambda function reaches its execution timeout, set [`delayRenderTimeoutInMilliseconds`](/docs/media/video#delayrendertimeoutinmilliseconds) on the media component to a value below the Lambda function timeout. Use [`delayRenderRetries`](/docs/media/video#delayrenderretries) if the load should be retried.
+
 ### Increasing the timeout
 
 Note that two types of timeouts come into play in Remotion:


### PR DESCRIPTION
## Summary

- Document enabling Cloudflare Cache Rules for R2-hosted video and audio assets
- Add Lambda troubleshooting guidance for stuck chunks caused by slow or uncached remote media range requests
- Cross-link the R2 docs to the Lambda data-transfer-cost guidance

## Testing

- `bunx oxfmt src --write` from `packages/docs`
- `bun run build`
- `bun run stylecheck`
- `bun run build-docs`
- `bun run render-cards`
