### PR TITLE
docs(skills): fix "this skills" typo + sharpen the remotion skill description for triggering

### DIFF
--- a/packages/skills/skills/remotion/SKILL.md
+++ b/packages/skills/skills/remotion/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: remotion-best-practices
-description: Best practices for Remotion - Video creation in React
+description: Best practices and domain knowledge for building videos programmatically with Remotion (videos in React/TypeScript, rendered to MP4). Use whenever writing or editing Remotion code — scaffolding a video project, animating with interpolate/spring over useCurrentFrame(), sequencing scenes and transitions, captions/subtitles, audio, GIFs/Lottie/3D, charts, visual effects, dynamic duration via calculateMetadata, or rendering. Consult before reaching for a Remotion API, since its components and props evolve (e.g. @remotion/media).
 metadata:
   tags: remotion, video, react, animation, composition
 ---
 
 ## When to use
 
-Use this skills whenever you are dealing with Remotion code to obtain the domain-specific knowledge.
+Use this skill whenever you are dealing with Remotion code to obtain the domain-specific knowledge.
 
 ## New project setup
 


### PR DESCRIPTION
Two small docs changes to `packages/skills/skills/remotion/SKILL.md`:

### 1. Typo fix
> Use this **skills** whenever you are dealing with Remotion code…

→ `this skill` (singular).

### 2. More trigger-effective `description`

The frontmatter `description` is the primary signal a model uses to decide whether to consult a skill, and the current one is terse/passive:

> Best practices for Remotion - Video creation in React

In testing on an installed copy of this skill, that phrasing **under-triggers**: clear Remotion coding requests that don't literally say "Remotion" (e.g. *"add word-by-word TikTok captions to my programmatic video in React"*, *"generate an animated bar-chart MP4 from this data array via code"*) often don't cause the model to consult the skill, because a strong model assumes it can answer directly. Enumerating the concrete capabilities + nudging "consult before reaching for an API" measurably improves recall on those phrasings.

Proposed:

> Best practices and domain knowledge for building videos programmatically with Remotion (videos in React/TypeScript, rendered to MP4). Use whenever writing or editing Remotion code — scaffolding a video project, animating with interpolate/spring over useCurrentFrame(), sequencing scenes and transitions, captions/subtitles, audio, GIFs/Lottie/3D, charts, visual effects, dynamic duration via calculateMetadata, or rendering. Consult before reaching for a Remotion API, since its components and props evolve (e.g. @remotion/media).

Only the frontmatter `description` and the one typo line change; all rules/ and body content are untouched. Happy to tweak the wording to your preference.