### PR TITLE
`@remotion/media`: Add media extraction timeout recovery

### DIFF
--- a/packages/media/src/audio-extraction/audio-iterator.ts
+++ b/packages/media/src/audio-extraction/audio-iterator.ts
@@ -1,5 +1,7 @@
 import type {AudioSample, AudioSampleSink} from 'mediabunny';
 import {Internals, type LogLevel} from 'remotion';
+import type {MediaExtractionTrace} from '../media-extraction-trace';
+import {traceMediaOperation} from '../media-extraction-trace';
 import type {RememberActualMatroskaTimestamps} from '../video-extraction/remember-actual-matroska-timestamps';
 import {makeAudioCache} from './audio-cache';
 
@@ -60,10 +62,14 @@ export const makeAudioIterator = ({
 
 	let lastUsed = Date.now();
 
-	const getNextSample = async () => {
+	const getNextSample = async (trace?: MediaExtractionTrace) => {
 		lastUsed = Date.now();
 
-		const {value: sample, done} = await sampleIterator.next();
+		const {value: sample, done} = await traceMediaOperation({
+			trace,
+			label: 'audio:sampleIterator.next',
+			operation: () => sampleIterator.next(),
+		});
 		if (done) {
 			fullDuration = cache.getNewestTimestamp();
 			return null;
@@ -87,7 +93,11 @@ export const makeAudioIterator = ({
 		return sample;
 	};
 
-	const getSamples = async (timestamp: number, durationInSeconds: number) => {
+	const getSamples = async (
+		timestamp: number,
+		durationInSeconds: number,
+		trace?: MediaExtractionTrace,
+	) => {
 		lastUsed = Date.now();
 
 		if (fullDuration !== null && timestamp > fullDuration) {
@@ -111,7 +121,7 @@ export const makeAudioIterator = ({
 		}
 
 		while (true) {
-			const sample = await getNextSample();
+			const sample = await getNextSample(trace);
 
 			// Clear all samples before the timestamp
 			// Do this in the while loop because samples might start from 0
@@ -189,8 +199,8 @@ export const makeAudioIterator = ({
 
 	return {
 		src,
-		getSamples: (ts: number, dur: number) => {
-			op = op.then(() => getSamples(ts, dur));
+		getSamples: (ts: number, dur: number, trace?: MediaExtractionTrace) => {
+			op = op.then(() => getSamples(ts, dur, trace));
 			return op;
 		},
 		waitForCompletion: async () => {

--- a/packages/media/src/audio-extraction/audio-manager.ts
+++ b/packages/media/src/audio-extraction/audio-manager.ts
@@ -1,6 +1,8 @@
 import type {AudioSampleSink} from 'mediabunny';
 import {Internals, type LogLevel} from 'remotion';
 import {getTotalCacheStats} from '../caches';
+import type {MediaExtractionTrace} from '../media-extraction-trace';
+import {traceMediaOperation} from '../media-extraction-trace';
 import type {RememberActualMatroskaTimestamps} from '../video-extraction/remember-actual-matroska-timestamps';
 import type {AudioSampleIterator} from './audio-iterator';
 import {makeAudioIterator} from './audio-iterator';
@@ -86,6 +88,7 @@ export const makeAudioManager = () => {
 		actualMatroskaTimestamps,
 		logLevel,
 		maxCacheSize,
+		trace,
 	}: {
 		src: string;
 		timeInSeconds: number;
@@ -94,6 +97,7 @@ export const makeAudioManager = () => {
 		actualMatroskaTimestamps: RememberActualMatroskaTimestamps;
 		logLevel: LogLevel;
 		maxCacheSize: number;
+		trace?: MediaExtractionTrace;
 	}) => {
 		let attempts = 0;
 		const maxAttempts = 3;
@@ -118,7 +122,11 @@ export const makeAudioManager = () => {
 		for (const iterator of iterators) {
 			if (
 				iterator.src === src &&
-				(await iterator.waitForCompletion()) &&
+				(await traceMediaOperation({
+					trace,
+					label: 'audio:iterator.waitForCompletion',
+					operation: () => iterator.waitForCompletion(),
+				})) &&
 				iterator.canSatisfyRequestedTime(timeInSeconds)
 			) {
 				return iterator;
@@ -166,6 +174,18 @@ export const makeAudioManager = () => {
 
 	let queue = Promise.resolve<unknown>(undefined);
 
+	const resetQueue = () => {
+		queue = Promise.resolve<unknown>(undefined);
+	};
+
+	const clearAll = () => {
+		for (const iterator of iterators) {
+			iterator.prepareForDeletion();
+		}
+
+		iterators.length = 0;
+	};
+
 	return {
 		getIterator: ({
 			src,
@@ -175,6 +195,7 @@ export const makeAudioManager = () => {
 			actualMatroskaTimestamps,
 			logLevel,
 			maxCacheSize,
+			trace,
 		}: {
 			src: string;
 			timeInSeconds: number;
@@ -183,6 +204,7 @@ export const makeAudioManager = () => {
 			actualMatroskaTimestamps: RememberActualMatroskaTimestamps;
 			logLevel: LogLevel;
 			maxCacheSize: number;
+			trace?: MediaExtractionTrace;
 		}) => {
 			queue = queue.then(() =>
 				getIterator({
@@ -193,6 +215,7 @@ export const makeAudioManager = () => {
 					actualMatroskaTimestamps,
 					logLevel,
 					maxCacheSize,
+					trace,
 				}),
 			);
 			return queue as Promise<AudioSampleIterator>;
@@ -201,5 +224,7 @@ export const makeAudioManager = () => {
 		getIteratorMostInThePast,
 		logOpenFrames,
 		deleteDuplicateIterators,
+		clearAll,
+		resetQueue,
 	};
 };

--- a/packages/media/src/audio-extraction/extract-audio.ts
+++ b/packages/media/src/audio-extraction/extract-audio.ts
@@ -16,6 +16,8 @@ import {
 	isNetworkError,
 	isUnsupportedConfigurationError,
 } from '../is-type-of-error';
+import type {MediaExtractionTrace} from '../media-extraction-trace';
+import {traceMediaOperation} from '../media-extraction-trace';
 import type {MediaRequestInit} from '../request-init';
 
 type ExtractAudioReturnType = Awaited<ReturnType<typeof extractAudioInternal>>;
@@ -34,6 +36,7 @@ type ExtractAudioParams = {
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	trace?: MediaExtractionTrace;
 };
 
 const extractAudioInternal = async ({
@@ -50,6 +53,7 @@ const extractAudioInternal = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	trace,
 }: ExtractAudioParams): Promise<
 	| {
 			data: PcmS16AudioData | null;
@@ -60,14 +64,26 @@ const extractAudioInternal = async ({
 	| 'network-error'
 > => {
 	const {getAudio, actualMatroskaTimestamps, isMatroska, getDuration} =
-		await getSink(src, logLevel, credentials, requestInit);
+		await traceMediaOperation({
+			trace,
+			label: 'audio:getSink',
+			operation: () => getSink(src, logLevel, credentials, requestInit),
+		});
 
 	let mediaDurationInSeconds: number | null = null;
 	if (loop) {
-		mediaDurationInSeconds = await getDuration();
+		mediaDurationInSeconds = await traceMediaOperation({
+			trace,
+			label: 'audio:sink.getDuration',
+			operation: () => getDuration(),
+		});
 	}
 
-	const audio = await getAudio(audioStreamIndex);
+	const audio = await traceMediaOperation({
+		trace,
+		label: 'audio:sink.getAudio',
+		operation: () => getAudio(audioStreamIndex),
+	});
 
 	if (audio === 'network-error') {
 		return 'network-error';
@@ -101,22 +117,30 @@ const extractAudioInternal = async ({
 	}
 
 	try {
-		const sampleIterator = await audioManager.getIterator({
-			src,
-			timeInSeconds,
-			audioSampleSink: audio.sampleSink,
-			isMatroska,
-			actualMatroskaTimestamps,
-			logLevel,
-			maxCacheSize,
+		const sampleIterator = await traceMediaOperation({
+			trace,
+			label: 'audio:audioManager.getIterator',
+			operation: () =>
+				audioManager.getIterator({
+					src,
+					timeInSeconds,
+					audioSampleSink: audio.sampleSink,
+					isMatroska,
+					actualMatroskaTimestamps,
+					logLevel,
+					maxCacheSize,
+					trace,
+				}),
 		});
 
 		const durationInSeconds = durationNotYetApplyingPlaybackRate * playbackRate;
 
-		const samples = await sampleIterator.getSamples(
-			timeInSeconds,
-			durationInSeconds,
-		);
+		const samples = await traceMediaOperation({
+			trace,
+			label: 'audio:sampleIterator.getSamples',
+			operation: () =>
+				sampleIterator.getSamples(timeInSeconds, durationInSeconds, trace),
+		});
 
 		audioManager.logOpenFrames();
 
@@ -141,7 +165,11 @@ const extractAudioInternal = async ({
 			const isFirstSample = i === 0;
 			const isLastSample = i === samples.length - 1;
 
-			const audioDataRaw = sample.toAudioData();
+			const audioDataRaw = await traceMediaOperation({
+				trace,
+				label: 'audio:sample.toAudioData',
+				operation: () => sample.toAudioData(),
+			});
 
 			// amount of samples to shave from start and end
 			let trimStartInSeconds = 0;
@@ -220,6 +248,10 @@ const extractAudioInternal = async ({
 };
 
 let queue = Promise.resolve<ExtractAudioReturnType | undefined>(undefined);
+
+export const resetExtractAudioQueue = () => {
+	queue = Promise.resolve<ExtractAudioReturnType | undefined>(undefined);
+};
 
 export const extractAudio = (
 	params: ExtractAudioParams,

--- a/packages/media/src/audio/audio-for-rendering.tsx
+++ b/packages/media/src/audio/audio-for-rendering.tsx
@@ -13,6 +13,7 @@ import {useMaxMediaCacheSize} from '../caches';
 import {applyVolume} from '../convert-audiodata/apply-volume';
 import {getTargetSampleRate} from '../convert-audiodata/resample-audiodata';
 import {frameForVolumeProp} from '../looped-frame';
+import {makeMediaExtractionTrace} from '../media-extraction-trace';
 import {callOnErrorAndResolve} from '../on-error';
 import {extractFrameViaBroadcastChannel} from '../video-extraction/extract-frame-via-broadcast-channel';
 import type {AudioProps} from './props';
@@ -91,6 +92,10 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 	useLayoutEffect(() => {
 		const timestamp = frame / fps;
 		const durationInSeconds = 1 / fps;
+		const trace = makeMediaExtractionTrace({
+			src,
+			timeInSeconds: timestamp,
+		});
 
 		const shouldRenderAudio = (() => {
 			if (!audioEnabled) {
@@ -134,6 +139,7 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 			maxCacheSize,
 			credentials,
 			requestInit: initialRequestInit,
+			trace,
 		})
 			.then((result) => {
 				const handleError = (

--- a/packages/media/src/extract-frame-and-audio.ts
+++ b/packages/media/src/extract-frame-and-audio.ts
@@ -1,6 +1,8 @@
 import type {LogLevel} from 'remotion';
 import {extractAudio} from './audio-extraction/extract-audio';
 import {isNetworkError} from './is-type-of-error';
+import type {MediaExtractionTrace} from './media-extraction-trace';
+import {traceMediaOperation} from './media-extraction-trace';
 import type {MediaRequestInit} from './request-init';
 import {extractFrame} from './video-extraction/extract-frame';
 import type {ExtractFrameViaBroadcastChannelResult} from './video-extraction/extract-frame-via-broadcast-channel';
@@ -22,6 +24,7 @@ export const extractFrameAndAudio = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	trace,
 }: {
 	src: string;
 	timeInSeconds: number;
@@ -38,39 +41,52 @@ export const extractFrameAndAudio = async ({
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	trace?: MediaExtractionTrace;
 }): Promise<ExtractFrameViaBroadcastChannelResult> => {
 	try {
 		const [video, audio] = await Promise.all([
 			includeVideo
-				? extractFrame({
-						src,
-						timeInSeconds,
-						logLevel,
-						loop,
-						trimAfter,
-						playbackRate,
-						trimBefore,
-						fps,
-						maxCacheSize,
-						credentials,
-						requestInit,
+				? traceMediaOperation({
+						trace,
+						label: 'video:extractFrame',
+						operation: () =>
+							extractFrame({
+								src,
+								timeInSeconds,
+								logLevel,
+								loop,
+								trimAfter,
+								playbackRate,
+								trimBefore,
+								fps,
+								maxCacheSize,
+								credentials,
+								requestInit,
+								trace,
+							}),
 					})
 				: null,
 			includeAudio
-				? extractAudio({
-						src,
-						timeInSeconds,
-						durationInSeconds,
-						logLevel,
-						loop,
-						playbackRate,
-						audioStreamIndex,
-						trimAfter,
-						fps,
-						trimBefore,
-						maxCacheSize,
-						credentials,
-						requestInit,
+				? traceMediaOperation({
+						trace,
+						label: 'audio:extractAudio',
+						operation: () =>
+							extractAudio({
+								src,
+								timeInSeconds,
+								durationInSeconds,
+								logLevel,
+								loop,
+								playbackRate,
+								audioStreamIndex,
+								trimAfter,
+								fps,
+								trimBefore,
+								maxCacheSize,
+								credentials,
+								requestInit,
+								trace,
+							}),
 					})
 				: null,
 		]);

--- a/packages/media/src/media-extraction-trace.ts
+++ b/packages/media/src/media-extraction-trace.ts
@@ -1,0 +1,184 @@
+const MAX_RECENT_STEPS = 20;
+
+type ActiveStep = {
+	id: number;
+	label: string;
+	startedAt: number;
+};
+
+type CompletedStep = {
+	label: string;
+	durationInMilliseconds: number;
+};
+
+export type MediaExtractionTrace = {
+	completeStep: (id: number) => void;
+	failStep: (id: number) => void;
+	getSummary: () => string;
+	startStep: (label: string) => number;
+};
+
+export const makeMediaExtractionTrace = ({
+	src,
+	timeInSeconds,
+}: {
+	src: string;
+	timeInSeconds: number;
+}): MediaExtractionTrace => {
+	let nextId = 0;
+	const activeSteps: ActiveStep[] = [];
+	const completedSteps: CompletedStep[] = [];
+
+	const removeActiveStep = (id: number) => {
+		const index = activeSteps.findIndex((activeStep) => activeStep.id === id);
+		if (index === -1) {
+			return null;
+		}
+
+		const [removedStep] = activeSteps.splice(index, 1);
+		return removedStep;
+	};
+
+	const addCompletedStep = (completedStep: CompletedStep) => {
+		completedSteps.push(completedStep);
+		if (completedSteps.length > MAX_RECENT_STEPS) {
+			completedSteps.shift();
+		}
+	};
+
+	return {
+		startStep: (label: string) => {
+			const id = nextId++;
+			activeSteps.push({
+				id,
+				label,
+				startedAt: Date.now(),
+			});
+			return id;
+		},
+		completeStep: (id: number) => {
+			const step = removeActiveStep(id);
+			if (!step) {
+				return;
+			}
+
+			addCompletedStep({
+				label: step.label,
+				durationInMilliseconds: Date.now() - step.startedAt,
+			});
+		},
+		failStep: (id: number) => {
+			removeActiveStep(id);
+		},
+		getSummary: () => {
+			const now = Date.now();
+			const lines = [`Media extraction trace for ${src} at ${timeInSeconds}s:`];
+
+			if (activeSteps.length === 0) {
+				lines.push('No active media extraction step.');
+			} else {
+				lines.push('Active media extraction steps:');
+				for (const step of activeSteps) {
+					lines.push(`- ${step.label} running for ${now - step.startedAt}ms`);
+				}
+			}
+
+			if (completedSteps.length > 0) {
+				lines.push('Recent completed media extraction steps:');
+				for (const step of completedSteps) {
+					lines.push(
+						`- ${step.label} completed in ${step.durationInMilliseconds}ms`,
+					);
+				}
+			}
+
+			return lines.join('\n');
+		},
+	};
+};
+
+export const traceMediaOperation = async <T>({
+	trace,
+	label,
+	operation,
+}: {
+	trace: MediaExtractionTrace | null | undefined;
+	label: string;
+	operation: () => Promise<T> | T;
+}): Promise<T> => {
+	if (!trace) {
+		return operation();
+	}
+
+	const stepId = trace.startStep(label);
+	try {
+		const result = await operation();
+		trace.completeStep(stepId);
+		return result;
+	} catch (err) {
+		trace.failStep(stepId);
+		throw err;
+	}
+};
+
+export const getMediaExtractionTimeoutInMilliseconds = () => {
+	const timeout =
+		typeof window === 'undefined'
+			? 30_000
+			: (window.remotion_puppeteerTimeout ?? 30_000);
+
+	return Math.max(3_000, timeout - 5_000);
+};
+
+export const withMediaExtractionTimeout = <T>({
+	promise,
+	trace,
+	src,
+	timeInSeconds,
+	timeoutInMilliseconds,
+	onTimeout,
+}: {
+	promise: Promise<T>;
+	trace: MediaExtractionTrace | null | undefined;
+	src: string;
+	timeInSeconds: number;
+	timeoutInMilliseconds: number;
+	onTimeout?: () => void;
+}): Promise<T> => {
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+	const clear = () => {
+		if (timeoutId) {
+			clearTimeout(timeoutId);
+			timeoutId = null;
+		}
+	};
+
+	return Promise.race([
+		promise.finally(clear),
+		new Promise<never>((_, reject) => {
+			timeoutId = setTimeout(() => {
+				let timeoutHookError: unknown = null;
+				try {
+					onTimeout?.();
+				} catch (err) {
+					timeoutHookError = err;
+				}
+
+				const lines = [
+					`Timed out extracting media from ${src} at ${timeInSeconds}s after ${timeoutInMilliseconds}ms.`,
+					trace ? trace.getSummary() : null,
+					timeoutHookError
+						? `The media extraction timeout cleanup failed: ${
+								timeoutHookError instanceof Error
+									? (timeoutHookError.stack ?? timeoutHookError.message)
+									: String(timeoutHookError)
+							}`
+						: null,
+				].filter(Boolean);
+
+				reject(new Error(lines.join('\n\n')));
+			}, timeoutInMilliseconds);
+		}),
+	]);
+};

--- a/packages/media/src/reset-media-extraction-state.ts
+++ b/packages/media/src/reset-media-extraction-state.ts
@@ -1,0 +1,24 @@
+import {Internals, type LogLevel} from 'remotion';
+import {resetExtractAudioQueue} from './audio-extraction/extract-audio';
+import {audioManager, keyframeManager} from './caches';
+import {resetExtractFrameQueue} from './video-extraction/extract-frame';
+
+export const resetMediaExtractionState = ({
+	logLevel,
+	reason,
+}: {
+	logLevel: LogLevel;
+	reason: string;
+}) => {
+	Internals.Log.warn(
+		{logLevel, tag: '@remotion/media'},
+		`Resetting media extraction queues because ${reason}`,
+	);
+
+	resetExtractFrameQueue();
+	resetExtractAudioQueue();
+	keyframeManager.resetQueue();
+	audioManager.resetQueue();
+	keyframeManager.clearAll(logLevel);
+	audioManager.clearAll();
+};

--- a/packages/media/src/test/media-extraction-trace.test.ts
+++ b/packages/media/src/test/media-extraction-trace.test.ts
@@ -1,0 +1,58 @@
+import {expect, test, vi} from 'vitest';
+import {
+	makeMediaExtractionTrace,
+	traceMediaOperation,
+	withMediaExtractionTimeout,
+} from '../media-extraction-trace';
+
+test('media extraction timeout contains active and completed trace steps', async () => {
+	const trace = makeMediaExtractionTrace({
+		src: 'blob:http://localhost/example',
+		timeInSeconds: 0.13333333333333333,
+	});
+
+	await traceMediaOperation({
+		trace,
+		label: 'video:getSink',
+		operation: () => undefined,
+	});
+
+	const stuckOperation = traceMediaOperation({
+		trace,
+		label: 'video:keyframeBank.getFrameFromTimestamp',
+		operation: () => new Promise<never>(() => undefined),
+	});
+
+	await expect(
+		withMediaExtractionTimeout({
+			promise: stuckOperation,
+			trace,
+			src: 'blob:http://localhost/example',
+			timeInSeconds: 0.13333333333333333,
+			timeoutInMilliseconds: 1,
+		}),
+	).rejects.toThrow(
+		/Active media extraction steps:\n- video:keyframeBank\.getFrameFromTimestamp running for \d+ms/,
+	);
+
+	expect(trace.getSummary()).toContain('- video:getSink completed in');
+});
+
+test('media extraction timeout calls its recovery hook', async () => {
+	const onTimeout = vi.fn();
+
+	await expect(
+		withMediaExtractionTimeout({
+			promise: new Promise<never>(() => undefined),
+			trace: null,
+			src: 'blob:http://localhost/example',
+			timeInSeconds: 0,
+			timeoutInMilliseconds: 1,
+			onTimeout,
+		}),
+	).rejects.toThrow(
+		'Timed out extracting media from blob:http://localhost/example at 0s after 1ms.',
+	);
+
+	expect(onTimeout).toHaveBeenCalledTimes(1);
+});

--- a/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
+++ b/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
@@ -1,7 +1,13 @@
 import type {LogLevel} from 'remotion';
 import type {PcmS16AudioData} from '../convert-audiodata/convert-audiodata';
 import {extractFrameAndAudio} from '../extract-frame-and-audio';
+import {
+	getMediaExtractionTimeoutInMilliseconds,
+	makeMediaExtractionTrace,
+	withMediaExtractionTimeout,
+} from '../media-extraction-trace';
 import type {MediaRequestInit} from '../request-init';
+import {resetMediaExtractionState} from '../reset-media-extraction-state';
 
 export type MessageFromMainTab =
 	| {
@@ -90,23 +96,40 @@ export const addBroadcastChannelListener = () => {
 		async (event) => {
 			const data = event.data as ExtractFrameRequest;
 			if (data.type === 'request') {
+				const trace = makeMediaExtractionTrace({
+					src: data.src,
+					timeInSeconds: data.timeInSeconds,
+				});
+
 				try {
-					const result = await extractFrameAndAudio({
+					const result = await withMediaExtractionTimeout({
 						src: data.src,
 						timeInSeconds: data.timeInSeconds,
-						logLevel: data.logLevel,
-						durationInSeconds: data.durationInSeconds,
-						playbackRate: data.playbackRate,
-						includeAudio: data.includeAudio,
-						includeVideo: data.includeVideo,
-						loop: data.loop,
-						audioStreamIndex: data.audioStreamIndex,
-						trimAfter: data.trimAfter,
-						trimBefore: data.trimBefore,
-						fps: data.fps,
-						maxCacheSize: data.maxCacheSize,
-						credentials: data.credentials,
-						requestInit: data.requestInit,
+						trace,
+						timeoutInMilliseconds: getMediaExtractionTimeoutInMilliseconds(),
+						onTimeout: () =>
+							resetMediaExtractionState({
+								logLevel: data.logLevel,
+								reason: `extracting media from ${data.src} at ${data.timeInSeconds}s timed out`,
+							}),
+						promise: extractFrameAndAudio({
+							src: data.src,
+							timeInSeconds: data.timeInSeconds,
+							logLevel: data.logLevel,
+							durationInSeconds: data.durationInSeconds,
+							playbackRate: data.playbackRate,
+							includeAudio: data.includeAudio,
+							includeVideo: data.includeVideo,
+							loop: data.loop,
+							audioStreamIndex: data.audioStreamIndex,
+							trimAfter: data.trimAfter,
+							trimBefore: data.trimBefore,
+							fps: data.fps,
+							maxCacheSize: data.maxCacheSize,
+							credentials: data.credentials,
+							requestInit: data.requestInit,
+							trace,
+						}),
 					});
 
 					if (result.type === 'cannot-decode') {
@@ -172,10 +195,12 @@ export const addBroadcastChannelListener = () => {
 
 					window.remotion_broadcastChannel!.postMessage(response);
 				} catch (error) {
+					const err = error as Error;
+					const stack = err.stack ?? 'No stack trace';
 					const response: MessageFromMainTab = {
 						type: 'response-error',
 						id: data.id,
-						errorStack: (error as Error).stack ?? 'No stack trace',
+						errorStack: `${stack}\n\n${trace.getSummary()}`,
 					};
 
 					window.remotion_broadcastChannel!.postMessage(response);

--- a/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
+++ b/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
@@ -1,10 +1,17 @@
 import {type LogLevel} from 'remotion';
 import type {PcmS16AudioData} from '../convert-audiodata/convert-audiodata';
 import {extractFrameAndAudio} from '../extract-frame-and-audio';
+import type {MediaExtractionTrace} from '../media-extraction-trace';
+import {
+	getMediaExtractionTimeoutInMilliseconds,
+	traceMediaOperation,
+	withMediaExtractionTimeout,
+} from '../media-extraction-trace';
 import {
 	normalizeMediaRequestInit,
 	type MediaRequestInit,
 } from '../request-init';
+import {resetMediaExtractionState} from '../reset-media-extraction-state';
 import type {
 	ExtractFrameRequest,
 	MessageFromMainTab,
@@ -45,6 +52,7 @@ export const extractFrameViaBroadcastChannel = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	trace,
 }: {
 	src: string;
 	timeInSeconds: number;
@@ -62,28 +70,45 @@ export const extractFrameViaBroadcastChannel = async ({
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	trace?: MediaExtractionTrace;
 }): Promise<ExtractFrameViaBroadcastChannelResult> => {
 	if (isClientSideRendering || window.remotion_isMainTab) {
-		return extractFrameAndAudio({
-			logLevel,
+		return withMediaExtractionTimeout({
 			src,
 			timeInSeconds,
-			durationInSeconds,
-			playbackRate,
-			includeAudio,
-			includeVideo,
-			loop,
-			audioStreamIndex,
-			trimAfter,
-			trimBefore,
-			fps,
-			maxCacheSize,
-			credentials,
-			requestInit,
+			trace,
+			timeoutInMilliseconds: getMediaExtractionTimeoutInMilliseconds(),
+			onTimeout: () =>
+				resetMediaExtractionState({
+					logLevel,
+					reason: `extracting media from ${src} at ${timeInSeconds}s timed out`,
+				}),
+			promise: extractFrameAndAudio({
+				logLevel,
+				src,
+				timeInSeconds,
+				durationInSeconds,
+				playbackRate,
+				includeAudio,
+				includeVideo,
+				loop,
+				audioStreamIndex,
+				trimAfter,
+				trimBefore,
+				fps,
+				maxCacheSize,
+				credentials,
+				requestInit,
+				trace,
+			}),
 		});
 	}
 
-	await waitForMainTabToBeReady(window.remotion_broadcastChannel!);
+	await traceMediaOperation({
+		trace,
+		label: 'broadcast:waitForMainTabToBeReady',
+		operation: () => waitForMainTabToBeReady(window.remotion_broadcastChannel!),
+	});
 
 	const requestId = crypto.randomUUID();
 
@@ -219,16 +244,18 @@ export const extractFrameViaBroadcastChannel = async ({
 			return res;
 		}),
 		new Promise<never>((_, reject) => {
-			timeoutId = setTimeout(
-				() => {
-					reject(
-						new Error(
+			timeoutId = setTimeout(() => {
+				reject(
+					new Error(
+						[
 							`Timeout while extracting frame at time ${timeInSeconds}sec from ${src}`,
-						),
-					);
-				},
-				Math.max(3_000, window.remotion_puppeteerTimeout - 5_000),
-			);
+							trace ? trace.getSummary() : null,
+						]
+							.filter(Boolean)
+							.join('\n\n'),
+					),
+				);
+			}, getMediaExtractionTimeoutInMilliseconds());
 		}),
 	]);
 };

--- a/packages/media/src/video-extraction/extract-frame.ts
+++ b/packages/media/src/video-extraction/extract-frame.ts
@@ -2,6 +2,8 @@ import {Internals, type LogLevel} from 'remotion';
 import {keyframeManager} from '../caches';
 import {getSink} from '../get-sink';
 import {getTimeInSeconds} from '../get-time-in-seconds';
+import type {MediaExtractionTrace} from '../media-extraction-trace';
+import {traceMediaOperation} from '../media-extraction-trace';
 import type {MediaRequestInit} from '../request-init';
 
 type ExtractFrameResult =
@@ -28,6 +30,7 @@ type ExtractFrameParams = {
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	trace?: MediaExtractionTrace;
 };
 
 const extractFrameInternal = async ({
@@ -42,12 +45,27 @@ const extractFrameInternal = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	trace,
 }: ExtractFrameParams): Promise<ExtractFrameResult> => {
-	const sink = await getSink(src, logLevel, credentials, requestInit);
+	const sink = await traceMediaOperation({
+		trace,
+		label: 'video:getSink',
+		operation: () => getSink(src, logLevel, credentials, requestInit),
+	});
 
 	const [video, mediaDurationInSecondsRaw] = await Promise.all([
-		sink.getVideo(),
-		loop ? sink.getDuration() : Promise.resolve(null),
+		traceMediaOperation({
+			trace,
+			label: 'video:sink.getVideo',
+			operation: () => sink.getVideo(),
+		}),
+		loop
+			? traceMediaOperation({
+					trace,
+					label: 'video:sink.getDuration',
+					operation: () => sink.getDuration(),
+				})
+			: Promise.resolve(null),
 	]);
 
 	const mediaDurationInSeconds: number | null = loop
@@ -94,7 +112,11 @@ const extractFrameInternal = async ({
 			type: 'success',
 			frame: null,
 			rotation: 0,
-			durationInSeconds: await sink.getDuration(),
+			durationInSeconds: await traceMediaOperation({
+				trace,
+				label: 'video:sink.getDuration',
+				operation: () => sink.getDuration(),
+			}),
 		};
 	}
 
@@ -102,13 +124,19 @@ const extractFrameInternal = async ({
 	// https://discord.com/channels/@me/1127949286789881897/1455728482150518906
 	// Should be able to remove once upgraded to Chrome 145
 	try {
-		const keyframeBank = await keyframeManager.requestKeyframeBank({
-			videoSampleSink: video.sampleSink,
-			timestamp: timeInSeconds,
-			src,
-			logLevel,
-			maxCacheSize,
-			fps,
+		const keyframeBank = await traceMediaOperation({
+			trace,
+			label: 'video:keyframeManager.requestKeyframeBank',
+			operation: () =>
+				keyframeManager.requestKeyframeBank({
+					videoSampleSink: video.sampleSink,
+					timestamp: timeInSeconds,
+					src,
+					logLevel,
+					maxCacheSize,
+					fps,
+					trace,
+				}),
 		});
 
 		if (!keyframeBank) {
@@ -116,18 +144,36 @@ const extractFrameInternal = async ({
 				type: 'success',
 				frame: null,
 				rotation: 0,
-				durationInSeconds: await sink.getDuration(),
+				durationInSeconds: await traceMediaOperation({
+					trace,
+					label: 'video:sink.getDuration',
+					operation: () => sink.getDuration(),
+				}),
 			};
 		}
 
-		const frame = await keyframeBank.getFrameFromTimestamp(timeInSeconds, fps);
+		const frame = await traceMediaOperation({
+			trace,
+			label: 'video:keyframeBank.getFrameFromTimestamp',
+			operation: () =>
+				keyframeBank.getFrameFromTimestamp(timeInSeconds, fps, trace),
+		});
 		const rotation = frame?.rotation ?? 0;
 
 		return {
 			type: 'success',
-			frame: frame?.toVideoFrame() ?? null,
+			frame:
+				(await traceMediaOperation({
+					trace,
+					label: 'video:sample.toVideoFrame',
+					operation: () => frame?.toVideoFrame() ?? null,
+				})) ?? null,
 			rotation,
-			durationInSeconds: await sink.getDuration(),
+			durationInSeconds: await traceMediaOperation({
+				trace,
+				label: 'video:sink.getDuration',
+				operation: () => sink.getDuration(),
+			}),
 		};
 	} catch (err) {
 		Internals.Log.info(
@@ -142,6 +188,10 @@ const extractFrameInternal = async ({
 type ExtractFrameReturnType = Awaited<ReturnType<typeof extractFrameInternal>>;
 
 let queue = Promise.resolve<ExtractFrameReturnType | undefined>(undefined);
+
+export const resetExtractFrameQueue = () => {
+	queue = Promise.resolve<ExtractFrameReturnType | undefined>(undefined);
+};
 
 export const extractFrame = (
 	params: ExtractFrameParams,

--- a/packages/media/src/video-extraction/keyframe-bank.ts
+++ b/packages/media/src/video-extraction/keyframe-bank.ts
@@ -2,6 +2,8 @@ import type {VideoSample, VideoSampleSink} from 'mediabunny';
 import {Internals, type LogLevel} from 'remotion';
 import {getSafeWindowOfMonotonicity} from '../caches';
 import {roundTo4Digits} from '../helpers/round-to-4-digits';
+import type {MediaExtractionTrace} from '../media-extraction-trace';
+import {traceMediaOperation} from '../media-extraction-trace';
 import {renderTimestampRange} from '../render-timestamp-range';
 import {getAllocationSize} from './get-allocation-size';
 
@@ -14,6 +16,7 @@ export type KeyframeBank = {
 	getFrameFromTimestamp: (
 		timestamp: number,
 		fps: number,
+		trace?: MediaExtractionTrace,
 	) => Promise<VideoSampleWithoutDuration | null>;
 	prepareForDeletion: (
 		logLevel: LogLevel,
@@ -26,7 +29,11 @@ export type KeyframeBank = {
 		timestampInSeconds: number;
 		logLevel: LogLevel;
 	}) => void;
-	hasTimestampInSecond: (timestamp: number, fps: number) => Promise<boolean>;
+	hasTimestampInSecond: (
+		timestamp: number,
+		fps: number,
+		trace?: MediaExtractionTrace,
+	) => Promise<boolean>;
 	addFrame: (frame: VideoSample, logLevel: LogLevel) => void;
 	getOpenFrameCount: () => {
 		size: number;
@@ -47,11 +54,13 @@ export const makeKeyframeBank = async ({
 	src,
 	videoSampleSink,
 	initialTimestampRequest,
+	trace: initialTrace,
 }: {
 	logLevel: LogLevel;
 	src: string;
 	videoSampleSink: VideoSampleSink;
 	initialTimestampRequest: number;
+	trace?: MediaExtractionTrace;
 }) => {
 	const sampleIterator = videoSampleSink.samples(
 		roundTo4Digits(initialTimestampRequest),
@@ -168,9 +177,14 @@ export const makeKeyframeBank = async ({
 		timestampInSeconds: number,
 		logLevel: LogLevel,
 		fps: number,
+		trace?: MediaExtractionTrace,
 	) => {
 		while (!hasDecodedEnoughForTimestamp(timestampInSeconds)) {
-			const sample = await sampleIterator.next();
+			const sample = await traceMediaOperation({
+				trace,
+				label: 'video:keyframeBank.sampleIterator.next',
+				operation: () => sampleIterator.next(),
+			});
 
 			if (sample.value) {
 				addFrame(sample.value, logLevel);
@@ -195,6 +209,7 @@ export const makeKeyframeBank = async ({
 	const getFrameFromTimestamp = async (
 		timestampInSeconds: number,
 		fps: number,
+		trace?: MediaExtractionTrace,
 	): Promise<VideoSampleWithoutDuration | null> => {
 		lastUsed = Date.now();
 
@@ -219,6 +234,7 @@ export const makeKeyframeBank = async ({
 			adjustedTimestamp,
 			parentLogLevel,
 			fps,
+			trace,
 		);
 
 		for (let i = frameTimestamps.length - 1; i >= 0; i--) {
@@ -241,8 +257,12 @@ export const makeKeyframeBank = async ({
 		return frames[frameTimestamps[0]] ?? null;
 	};
 
-	const hasTimestampInSecond = async (timestamp: number, fps: number) => {
-		return (await getFrameFromTimestamp(timestamp, fps)) !== null;
+	const hasTimestampInSecond = async (
+		timestamp: number,
+		fps: number,
+		trace?: MediaExtractionTrace,
+	) => {
+		return (await getFrameFromTimestamp(timestamp, fps, trace)) !== null;
 	};
 
 	const getOpenFrameCount = () => {
@@ -258,7 +278,11 @@ export const makeKeyframeBank = async ({
 
 	let queue = Promise.resolve<unknown>(undefined);
 
-	const firstFrame = await sampleIterator.next();
+	const firstFrame = await traceMediaOperation({
+		trace: initialTrace,
+		label: 'video:keyframeBank.firstFrame',
+		operation: () => sampleIterator.next(),
+	});
 	if (!firstFrame.value) {
 		throw new Error('No first frame found');
 	}
@@ -363,13 +387,21 @@ export const makeKeyframeBank = async ({
 	};
 
 	const keyframeBank: KeyframeBank = {
-		getFrameFromTimestamp: (timestamp: number, fps: number) => {
-			queue = queue.then(() => getFrameFromTimestamp(timestamp, fps));
+		getFrameFromTimestamp: (
+			timestamp: number,
+			fps: number,
+			trace?: MediaExtractionTrace,
+		) => {
+			queue = queue.then(() => getFrameFromTimestamp(timestamp, fps, trace));
 			return queue as Promise<VideoSample | null>;
 		},
 		prepareForDeletion,
-		hasTimestampInSecond: (timestamp: number, fps: number) => {
-			queue = queue.then(() => hasTimestampInSecond(timestamp, fps));
+		hasTimestampInSecond: (
+			timestamp: number,
+			fps: number,
+			trace?: MediaExtractionTrace,
+		) => {
+			queue = queue.then(() => hasTimestampInSecond(timestamp, fps, trace));
 			return queue as Promise<boolean>;
 		},
 		addFrame,

--- a/packages/media/src/video-extraction/keyframe-manager.ts
+++ b/packages/media/src/video-extraction/keyframe-manager.ts
@@ -1,6 +1,8 @@
 import type {VideoSampleSink} from 'mediabunny';
 import {Internals, type LogLevel} from 'remotion';
 import {getSafeWindowOfMonotonicity, getTotalCacheStats} from '../caches';
+import type {MediaExtractionTrace} from '../media-extraction-trace';
+import {traceMediaOperation} from '../media-extraction-trace';
 import {renderTimestampRange} from '../render-timestamp-range';
 import {type KeyframeBank, makeKeyframeBank} from './keyframe-bank';
 
@@ -203,11 +205,13 @@ export const makeKeyframeManager = () => {
 		videoSampleSink,
 		src,
 		logLevel,
+		trace,
 	}: {
 		timestamp: number;
 		videoSampleSink: VideoSampleSink;
 		src: string;
 		logLevel: LogLevel;
+		trace?: MediaExtractionTrace;
 	}): Promise<KeyframeBank | null> => {
 		// The start packet timestamp can be higher than the packets following it
 		// https://discord.com/channels/809501355504959528/1001500302375125055/1456710188865159343
@@ -223,11 +227,17 @@ export const makeKeyframeManager = () => {
 				{logLevel, tag: '@remotion/media'},
 				`Creating new keyframe bank for src ${src} at timestamp ${timestamp}`,
 			);
-			const newKeyframeBank = await makeKeyframeBank({
-				videoSampleSink,
-				logLevel,
-				src,
-				initialTimestampRequest: timestamp,
+			const newKeyframeBank = await traceMediaOperation({
+				trace,
+				label: 'video:makeKeyframeBank',
+				operation: () =>
+					makeKeyframeBank({
+						videoSampleSink,
+						logLevel,
+						src,
+						initialTimestampRequest: timestamp,
+						trace,
+					}),
 			});
 
 			addKeyframeBank({src, bank: newKeyframeBank});
@@ -255,11 +265,17 @@ export const makeKeyframeManager = () => {
 		sources[src] = sources[src].filter((bank) => bank !== existingBank);
 
 		// Then refetch
-		const replacementKeybank = await makeKeyframeBank({
-			videoSampleSink,
-			initialTimestampRequest: timestamp,
-			logLevel,
-			src,
+		const replacementKeybank = await traceMediaOperation({
+			trace,
+			label: 'video:makeReplacementKeyframeBank',
+			operation: () =>
+				makeKeyframeBank({
+					videoSampleSink,
+					initialTimestampRequest: timestamp,
+					logLevel,
+					src,
+					trace,
+				}),
 		});
 
 		addKeyframeBank({src, bank: replacementKeybank});
@@ -274,6 +290,7 @@ export const makeKeyframeManager = () => {
 		logLevel,
 		maxCacheSize,
 		fps,
+		trace,
 	}: {
 		timestamp: number;
 		videoSampleSink: VideoSampleSink;
@@ -281,6 +298,7 @@ export const makeKeyframeManager = () => {
 		logLevel: LogLevel;
 		maxCacheSize: number;
 		fps: number;
+		trace?: MediaExtractionTrace;
 	}) => {
 		ensureToStayUnderMaxCacheSize(logLevel, maxCacheSize);
 
@@ -296,6 +314,7 @@ export const makeKeyframeManager = () => {
 			videoSampleSink,
 			src,
 			logLevel,
+			trace,
 		});
 
 		return keyframeBank;
@@ -318,6 +337,10 @@ export const makeKeyframeManager = () => {
 
 	let queue = Promise.resolve<unknown>(undefined);
 
+	const resetQueue = () => {
+		queue = Promise.resolve<unknown>(undefined);
+	};
+
 	return {
 		requestKeyframeBank: ({
 			timestamp,
@@ -326,6 +349,7 @@ export const makeKeyframeManager = () => {
 			logLevel,
 			maxCacheSize,
 			fps,
+			trace,
 		}: {
 			timestamp: number;
 			videoSampleSink: VideoSampleSink;
@@ -333,6 +357,7 @@ export const makeKeyframeManager = () => {
 			logLevel: LogLevel;
 			maxCacheSize: number;
 			fps: number;
+			trace?: MediaExtractionTrace;
 		}) => {
 			queue = queue.then(() =>
 				requestKeyframeBank({
@@ -342,12 +367,14 @@ export const makeKeyframeManager = () => {
 					logLevel,
 					maxCacheSize,
 					fps,
+					trace,
 				}),
 			);
 			return queue as Promise<KeyframeBank>;
 		},
 		getCacheStats,
 		clearAll,
+		resetQueue,
 	};
 };
 

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -25,6 +25,7 @@ import {useMaxMediaCacheSize} from '../caches';
 import {applyVolume} from '../convert-audiodata/apply-volume';
 import {getTargetSampleRate} from '../convert-audiodata/resample-audiodata';
 import {frameForVolumeProp} from '../looped-frame';
+import {makeMediaExtractionTrace} from '../media-extraction-trace';
 import {type MediaOnError, callOnErrorAndResolve} from '../on-error';
 import type {MediaRequestInit} from '../request-init';
 import {extractFrameViaBroadcastChannel} from '../video-extraction/extract-frame-via-broadcast-channel';
@@ -164,6 +165,10 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 
 		const timestamp = frame / fps;
 		const durationInSeconds = 1 / fps;
+		const trace = makeMediaExtractionTrace({
+			src,
+			timeInSeconds: timestamp,
+		});
 
 		const newHandle = delayRender(
 			`Extracting frame at time ${timestamp} from ${src}`,
@@ -202,6 +207,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 			maxCacheSize,
 			credentials,
 			requestInit: initialRequestInit,
+			trace,
 		})
 			.then(async (result) => {
 				const handleError = (


### PR DESCRIPTION
## Summary

- Add media extraction traces so timeout errors include active and recently completed extraction steps
- Add an internal timeout around same-tab and main-tab media extraction paths
- Reset media extraction queues and cached extraction state on timeout so later retries are not stuck behind a wedged promise

## Testing

- `cd packages/media && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/media && bunx vitest src/test/media-extraction-trace.test.ts --browser --run`
- `cd packages/media && bunx vitest src/test/browser.test.ts --browser --run`
