### PR TITLE
`@remotion/studio`: Keep selection outlines in sync

### DIFF
--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -238,7 +238,11 @@ const CompWhenItHasDimensions: React.FC<{
 				xCorrection={xCorrection}
 				yCorrection={yCorrection}
 			/>
-			<SelectedOutlineOverlay scale={scale} />
+			<SelectedOutlineOverlay
+				scale={scale}
+				translationX={previewSize.translation.x}
+				translationY={previewSize.translation.y}
+			/>
 		</div>
 	);
 };

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -3,6 +3,7 @@ import React, {
 	useCallback,
 	useContext,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -125,7 +126,9 @@ export const orderOutlinesForRendering = ({
 
 export const SelectedOutlineOverlay: React.FC<{
 	readonly scale: number;
-}> = ({scale}) => {
+	readonly translationX: number;
+	readonly translationY: number;
+}> = ({scale, translationX, translationY}) => {
 	const {selectedItems, selectItem} = useTimelineSelection();
 	const {sequences} = useContext(Internals.SequenceManager);
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
@@ -769,7 +772,7 @@ export const SelectedOutlineOverlay: React.FC<{
 		};
 	}, [keybindings, onArrowKeyDown, onArrowKeyUp, saveKeyboardNudgeSession]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (outlineTargets.length === 0) {
 			setOutlines((prevOutlines) =>
 				prevOutlines.length === 0 ? prevOutlines : [],
@@ -802,7 +805,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				cancelAnimationFrame(animationFrame);
 			}
 		};
-	}, [outlineTargets]);
+	}, [outlineTargets, scale, translationX, translationY]);
 
 	if (outlineTargets.length === 0) {
 		return null;

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -772,40 +772,63 @@ export const SelectedOutlineOverlay: React.FC<{
 		};
 	}, [keybindings, onArrowKeyDown, onArrowKeyUp, saveKeyboardNudgeSession]);
 
-	useLayoutEffect(() => {
-		if (outlineTargets.length === 0) {
+	const updateOutlines = useCallback(() => {
+		if (overlayRef.current === null || outlineTargets.length === 0) {
 			setOutlines((prevOutlines) =>
 				prevOutlines.length === 0 ? prevOutlines : [],
 			);
 			return;
 		}
 
+		const nextOutlines = measureOutlines(overlayRef.current, outlineTargets);
+		setOutlines((prevOutlines) =>
+			outlinesAreEqual(prevOutlines, nextOutlines)
+				? prevOutlines
+				: nextOutlines,
+		);
+	}, [outlineTargets]);
+
+	useLayoutEffect(() => {
+		updateOutlines();
+	}, [outlineTargets, scale, translationX, translationY, updateOutlines]);
+
+	useLayoutEffect(() => {
+		if (outlineTargets.length === 0 || typeof ResizeObserver === 'undefined') {
+			return;
+		}
+
 		let animationFrame: number | null = null;
 
-		const updateOutlines = () => {
-			if (overlayRef.current) {
-				const nextOutlines = measureOutlines(
-					overlayRef.current,
-					outlineTargets,
-				);
-				setOutlines((prevOutlines) =>
-					outlinesAreEqual(prevOutlines, nextOutlines)
-						? prevOutlines
-						: nextOutlines,
-				);
+		const scheduleUpdate = () => {
+			if (animationFrame !== null) {
+				return;
 			}
 
-			animationFrame = requestAnimationFrame(updateOutlines);
+			animationFrame = requestAnimationFrame(() => {
+				animationFrame = null;
+				updateOutlines();
+			});
 		};
 
-		updateOutlines();
+		const resizeObserver = new ResizeObserver(scheduleUpdate);
+		if (overlayRef.current !== null) {
+			resizeObserver.observe(overlayRef.current);
+		}
+
+		for (const target of outlineTargets) {
+			if (target.ref.current !== null) {
+				resizeObserver.observe(target.ref.current);
+			}
+		}
 
 		return () => {
 			if (animationFrame !== null) {
 				cancelAnimationFrame(animationFrame);
 			}
+
+			resizeObserver.disconnect();
 		};
-	}, [outlineTargets, scale, translationX, translationY]);
+	}, [outlineTargets, updateOutlines]);
 
 	if (outlineTargets.length === 0) {
 		return null;


### PR DESCRIPTION
## Summary

- Measure Studio selection outlines in a layout effect so viewport transform changes are reflected before paint.
- Pass the canvas viewport translation into the outline overlay so pan and zoom changes both trigger same-frame outline measurement.

Fixes #8647.

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun test packages/studio/src/test/canvas-rulers.test.ts packages/studio/src/test/smooth-zoom.test.ts`
- `bunx turbo run make --filter='@remotion/studio'`
- `bun run --cwd packages/studio lint` *(passes with 7 existing warnings outside this change)*
- `git diff --check`

## Notes

`bun run --cwd packages/studio formatting` / direct `oxfmt --check` reports formatting differences across existing Studio files in this local checkout and would rewrite whole files, so I did not include broad formatting churn in this PR.
