### PR TITLE
`@remotion/studio`: Make Interactive text editable in visual mode

### DIFF
--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -5,6 +5,7 @@ import {
 	baseSchema,
 	premountSchema,
 	sequenceSchema,
+	textContentSchema,
 	textSchema,
 	transformSchema,
 	type InteractivitySchema,
@@ -104,6 +105,7 @@ const interactiveElementSchema = {
 	...baseSchema,
 	...transformSchema,
 	...textSchema,
+	...textContentSchema,
 } as const satisfies InteractivitySchema;
 
 const setRef = <ElementType,>(

--- a/packages/core/src/interactivity-schema.ts
+++ b/packages/core/src/interactivity-schema.ts
@@ -94,6 +94,13 @@ export type ColorFieldSchema = {
 	keyframable?: boolean;
 };
 
+export type TextContentFieldSchema = {
+	type: 'text-content';
+	default: string;
+	description?: string;
+	keyframable?: false;
+};
+
 export type EnumFieldSchema = {
 	type: 'enum';
 	default: string;
@@ -173,6 +180,7 @@ export type VisibleFieldSchema =
 	| ScaleFieldSchema
 	| UvCoordinateFieldSchema
 	| ColorFieldSchema
+	| TextContentFieldSchema
 	| ArrayFieldSchema
 	| EnumFieldSchema;
 
@@ -291,6 +299,15 @@ export const textSchema = {
 		step: 0.1,
 		description: 'Letter spacing',
 		hiddenFromList: false,
+	},
+} as const satisfies InteractivitySchema;
+
+export const textContentSchema = {
+	children: {
+		type: 'text-content',
+		default: '',
+		description: 'Text',
+		keyframable: false,
 	},
 } as const satisfies InteractivitySchema;
 

--- a/packages/core/src/test/with-interactivity-schema-helpers.test.ts
+++ b/packages/core/src/test/with-interactivity-schema-helpers.test.ts
@@ -10,6 +10,7 @@ import {
 	sequenceSchema,
 	sequenceSchemaWithoutFrom,
 	sequenceStyleSchema,
+	textContentSchema,
 	textSchema,
 	transformSchema,
 } from '../interactivity-schema.js';
@@ -183,6 +184,22 @@ test('readValuesFromProps reads dot-notation keys via getNestedValue', () => {
 	expect(values['style.scale']).toBe(1.74);
 	expect(values['style.opacity']).toBe(0.5);
 	expect(values['style.rotate']).toBeUndefined();
+});
+
+test('readValuesFromProps ignores non-string text content runtime values', () => {
+	const props = {
+		children: {type: 'span'},
+	};
+	const flatSchema = getFlatSchemaWithAllKeys(textContentSchema);
+	const values = readValuesFromProps(props, ['children'], flatSchema);
+	expect(values.children).toBeUndefined();
+
+	const stringValues = readValuesFromProps(
+		{children: 'Hello'},
+		['children'],
+		flatSchema,
+	);
+	expect(stringValues.children).toBe('Hello');
 });
 
 test('selectActiveKeys returns only the hidden + layout keys when layout=none', () => {

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -41,13 +41,34 @@ export const getNestedValue = (
 	return current;
 };
 
+export const getRuntimeValueForSchemaKey = ({
+	flatSchema,
+	key,
+	props,
+}: {
+	flatSchema: InteractivitySchema;
+	key: string;
+	props: Record<string, unknown>;
+}): unknown => {
+	const value = getNestedValue(props, key);
+
+	if (flatSchema[key]?.type === 'text-content' && typeof value !== 'string') {
+		return undefined;
+	}
+
+	return value;
+};
+
 export const readValuesFromProps = (
 	props: Record<string, unknown>,
 	keys: string[],
+	flatSchema?: InteractivitySchema,
 ): Record<string, unknown> => {
 	const out: Record<string, unknown> = {};
 	for (const key of keys) {
-		out[key] = getNestedValue(props, key);
+		out[key] = flatSchema
+			? getRuntimeValueForSchemaKey({flatSchema, key, props})
+			: getNestedValue(props, key);
 	}
 
 	return out;
@@ -188,12 +209,21 @@ export const withInteractivitySchema = <
 		// memoized on the leaf values so the object reference is stable
 		// when nothing changed — otherwise downstream `useMemo`s churn and
 		// effects (e.g. Sequence registration) re-fire every render.
-		const runtimeValues = flatKeys.map((k) =>
-			getNestedValue(props as Record<string, unknown>, k),
+		const runtimeValues = flatKeys.map((key) =>
+			getRuntimeValueForSchemaKey({
+				flatSchema,
+				key,
+				props: props as Record<string, unknown>,
+			}),
 		);
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const currentRuntimeValueDotNotation = useMemo(
-			() => readValuesFromProps(props as Record<string, unknown>, flatKeys),
+			() =>
+				readValuesFromProps(
+					props as Record<string, unknown>,
+					flatKeys,
+					flatSchema,
+				),
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 			runtimeValues,
 		);

--- a/packages/studio-server/src/codemods/update-sequence-props/update-sequence-props.ts
+++ b/packages/studio-server/src/codemods/update-sequence-props/update-sequence-props.ts
@@ -7,9 +7,12 @@ import type {
 	StringLiteral,
 } from '@babel/types';
 import * as recast from 'recast';
-import type {SequenceNodePath, InteractivitySchema} from 'remotion';
+import type {InteractivitySchema, SequenceNodePath} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
-import {findJsxElementAtNodePath} from '../../preview-server/routes/can-update-sequence-props';
+import {
+	findJsxElementNodeAtNodePath,
+	getStaticJsxTextContent,
+} from '../../preview-server/routes/can-update-sequence-props';
 import {formatFileContent} from '../format-file-content';
 import {parseAst, serializeAst} from '../parse-ast';
 import {parseValueExpression, updateNestedProp} from '../update-nested-prop';
@@ -115,16 +118,54 @@ const snapshotTopLevelAttrs = (
 	return result;
 };
 
-type JSXOpeningElementLike = NonNullable<
-	ReturnType<typeof findJsxElementAtNodePath>
+type JSXElementLike = NonNullable<
+	ReturnType<typeof findJsxElementNodeAtNodePath>
 >;
+type JSXOpeningElementLike = JSXElementLike['openingElement'];
+
+const escapeJsxText = (value: string): string => {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/{/g, '&#123;')
+		.replace(/}/g, '&#125;');
+};
+
+const updateJsxTextContent = ({
+	jsxElement,
+	value,
+}: {
+	jsxElement: JSXElementLike;
+	value: unknown;
+}): string => {
+	const staticTextContent = getStaticJsxTextContent(jsxElement);
+	if (!staticTextContent) {
+		throw new Error(
+			'Cannot update text content because JSX children are not static text',
+		);
+	}
+
+	const nextValue = String(value ?? '');
+	if (staticTextContent.kind === 'jsx-text' && !nextValue.includes('\n')) {
+		jsxElement.children = [
+			b.jsxText(escapeJsxText(nextValue)),
+		] as unknown as JSXElementLike['children'];
+	} else {
+		jsxElement.children = [
+			b.jsxExpressionContainer(b.stringLiteral(nextValue)),
+		] as unknown as JSXElementLike['children'];
+	}
+
+	return staticTextContent.value;
+};
 
 const updateSequencePropsNode = ({
-	node,
+	jsxElement,
 	updates,
 	schema,
 }: {
-	node: JSXOpeningElementLike;
+	jsxElement: JSXElementLike;
 	updates: SequencePropUpdate[];
 	schema: InteractivitySchema;
 }): {
@@ -132,6 +173,7 @@ const updateSequencePropsNode = ({
 	logLine: number;
 	removedProps: RemovedProp[];
 } => {
+	const node = jsxElement.openingElement;
 	const logLine = node.loc?.start.line ?? 1;
 
 	const oldValueStrings: string[] = [];
@@ -145,6 +187,12 @@ const updateSequencePropsNode = ({
 
 	for (const {key, value, defaultValue} of updates) {
 		let oldValueString = '';
+
+		if (key === 'children') {
+			oldValueString = updateJsxTextContent({jsxElement, value});
+			oldValueStrings.push(oldValueString);
+			continue;
+		}
 
 		const isDefault =
 			defaultValue !== null &&
@@ -284,15 +332,15 @@ export const updateSequencePropsAst = ({
 } => {
 	const ast = parseAst(input);
 
-	const node = findJsxElementAtNodePath(ast, nodePath);
-	if (!node) {
+	const jsxElement = findJsxElementNodeAtNodePath(ast, nodePath);
+	if (!jsxElement) {
 		throw new Error(
 			'Could not find a JSX element at the specified line to update',
 		);
 	}
 
 	const {oldValueStrings, logLine, removedProps} = updateSequencePropsNode({
-		node,
+		jsxElement,
 		updates,
 		schema,
 	});
@@ -316,14 +364,14 @@ export const updateMultipleSequenceProps = async ({
 }): Promise<UpdateMultipleSequencePropsResult> => {
 	const ast = parseAst(input);
 	const results = changes.map(({nodePath, updates, schema}) => {
-		const node = findJsxElementAtNodePath(ast, nodePath);
-		if (!node) {
+		const jsxElement = findJsxElementNodeAtNodePath(ast, nodePath);
+		if (!jsxElement) {
 			throw new Error(
 				'Could not find a JSX element at the specified line to update',
 			);
 		}
 
-		return updateSequencePropsNode({node, updates, schema});
+		return updateSequencePropsNode({jsxElement, updates, schema});
 	});
 
 	const {output, formatted} = await formatFileContent({

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -4,6 +4,7 @@ import type {
 	Expression,
 	File,
 	JSXAttribute,
+	JSXElement,
 	JSXOpeningElement,
 	NewExpression,
 	ObjectExpression,
@@ -34,8 +35,8 @@ import {toImportAgnosticNodePath} from '../../helpers/import-agnostic-node-path'
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import {
 	getJsxComponentIdentity,
-	JsxElementIdentityMismatchError,
 	jsxComponentIdentitiesMatch,
+	JsxElementIdentityMismatchError,
 } from '../jsx-component-identity';
 import {JsxElementNotFoundAtLocationError} from '../jsx-element-not-found-at-location-error';
 import {computeEffectPropStatus} from './can-update-effect-props';
@@ -749,17 +750,74 @@ const getNodePathForRecastPath = (
 	return toImportAgnosticNodePath({ast, nodePath: segments});
 };
 
-export const findJsxElementAtNodePath = (
+export const findJsxElementPathAtNodePath = (
 	ast: File,
 	nodePath: SequenceNodePath,
-): JSXOpeningElement | null => {
+) => {
 	const current = getAstNodePath(ast, nodePath);
 	if (!current) {
 		return null;
 	}
 
 	if (recast.types.namedTypes.JSXOpeningElement.check(current.value)) {
-		return current.value as unknown as JSXOpeningElement;
+		return current;
+	}
+
+	return null;
+};
+
+export const findJsxElementAtNodePath = (
+	ast: File,
+	nodePath: SequenceNodePath,
+): JSXOpeningElement | null => {
+	const current = findJsxElementPathAtNodePath(ast, nodePath);
+	return current ? (current.value as unknown as JSXOpeningElement) : null;
+};
+
+export const findJsxElementNodeAtNodePath = (
+	ast: File,
+	nodePath: SequenceNodePath,
+): JSXElement | null => {
+	const current = findJsxElementPathAtNodePath(ast, nodePath);
+	if (!current) {
+		return null;
+	}
+
+	if (recast.types.namedTypes.JSXElement.check(current.parentPath?.value)) {
+		return current.parentPath.value as unknown as JSXElement;
+	}
+
+	return null;
+};
+
+export type StaticJsxTextContent =
+	| {kind: 'jsx-text'; value: string}
+	| {kind: 'string-expression'; value: string};
+
+export const getStaticJsxTextContent = (
+	jsxElement: JSXElement,
+): StaticJsxTextContent | null => {
+	const meaningfulChildren = jsxElement.children.filter((candidate) => {
+		return !(candidate.type === 'JSXText' && candidate.value.trim() === '');
+	});
+
+	if (meaningfulChildren.length !== 1) {
+		return null;
+	}
+
+	const child = meaningfulChildren[0];
+	if (child.type === 'JSXText') {
+		return {
+			kind: 'jsx-text',
+			value: child.value.includes('\n') ? child.value.trim() : child.value,
+		};
+	}
+
+	if (
+		child.type === 'JSXExpressionContainer' &&
+		child.expression.type === 'StringLiteral'
+	) {
+		return {kind: 'string-expression', value: child.expression.value};
 	}
 
 	return null;
@@ -903,16 +961,26 @@ const computeEffectsForJsx = ({
 
 const computeSequenceOnlyPropsRecord = ({
 	jsxElement,
+	jsxElementNode,
 	ast,
 	keys,
 }: {
 	jsxElement: JSXOpeningElement;
+	jsxElementNode: JSXElement;
 	ast: File;
 	keys: string[];
 }): Record<string, CanUpdatePropStatus> => {
 	const allProps = getPropsStatus(jsxElement, ast);
 	const filteredProps: Record<string, CanUpdatePropStatus> = {};
 	for (const key of keys) {
+		if (key === 'children') {
+			const staticTextContent = getStaticJsxTextContent(jsxElementNode);
+			filteredProps[key] = staticTextContent
+				? staticStatus(staticTextContent.value)
+				: computedStatus();
+			continue;
+		}
+
 		const dotIndex = key.indexOf('.');
 		if (dotIndex !== -1) {
 			filteredProps[key] = getNestedPropStatus(
@@ -946,9 +1014,10 @@ export const computeSequencePropsStatusFromContent = ({
 }): CanUpdateSequencePropsResponseTrue => {
 	const ast = parseAst(fileContents);
 
-	const jsxElement = findJsxElementAtNodePath(ast, nodePath);
+	const jsxElementNode = findJsxElementNodeAtNodePath(ast, nodePath);
+	const jsxElement = jsxElementNode?.openingElement ?? null;
 
-	if (!jsxElement) {
+	if (!jsxElement || !jsxElementNode) {
 		throw new JsxElementNotFoundAtLocationError();
 	}
 
@@ -961,7 +1030,12 @@ export const computeSequencePropsStatusFromContent = ({
 		throw new JsxElementIdentityMismatchError();
 	}
 
-	const filteredProps = computeSequenceOnlyPropsRecord({jsxElement, ast, keys});
+	const filteredProps = computeSequenceOnlyPropsRecord({
+		jsxElement,
+		jsxElementNode,
+		ast,
+		keys,
+	});
 	const effectsStatuses = computeEffectsForJsx({ast, jsxElement, effects});
 
 	return {

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -759,3 +759,41 @@ export const Example: React.FC = () => {
 		status: 'computed',
 	});
 });
+
+test('computeSequencePropsStatus should detect static JSX text children', () => {
+	const input = `import React from 'react';
+import {Interactive} from 'remotion';
+
+export const Example: React.FC = () => {
+	return <Interactive.P>Hello</Interactive.P>;
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 5),
+		componentIdentity: null,
+		keys: ['children'],
+		effects: [],
+	});
+
+	expect(result.props.children).toEqual({status: 'static', codeValue: 'Hello'});
+});
+
+test('computeSequencePropsStatus should reject non-static text children', () => {
+	const input = `import React from 'react';
+import {Interactive} from 'remotion';
+
+export const Example: React.FC<{text: string}> = ({text}) => {
+	return <Interactive.P>{text}</Interactive.P>;
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 5),
+		componentIdentity: null,
+		keys: ['children'],
+		effects: [],
+	});
+
+	expect(result.props.children).toEqual({status: 'computed'});
+});

--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -220,3 +220,50 @@ test('updateMultipleSequenceProps should update multiple nodes in one format pas
 	expect(output.split('\n')[7]).toContain('hueShift={90}');
 	expect(output.split('\n')[8]).toContain('durationInFrames={120}');
 });
+
+test('updateSequenceProps should update JSX text children', async () => {
+	const input = `import React from 'react';
+import {Interactive} from 'remotion';
+
+export const Example: React.FC = () => {
+	return <Interactive.P>Hello</Interactive.P>;
+};
+`;
+
+	const {output, oldValueStrings} = await updateSequenceProps({
+		input,
+		nodePath: lineColumnToNodePath(input, 5),
+		updates: [{key: 'children', value: 'Goodbye', defaultValue: ''}],
+		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
+	});
+
+	expect(oldValueStrings[0]).toBe('Hello');
+	expect(output).toContain('<Interactive.P>Goodbye</Interactive.P>');
+});
+
+test('updateSequenceProps should refuse complex children', async () => {
+	const input = `import React from 'react';
+import {Interactive} from 'remotion';
+
+export const Example: React.FC = () => {
+	return (
+		<Interactive.P>
+			Hello <Interactive.Strong>world</Interactive.Strong>
+		</Interactive.P>
+	);
+};
+`;
+
+	await expect(
+		updateSequenceProps({
+			input,
+			nodePath: lineColumnToNodePath(input, 6),
+			updates: [{key: 'children', value: 'Goodbye', defaultValue: ''}],
+			schema: NoReactInternals.sequenceSchema,
+			prettierConfigOverride: null,
+		}),
+	).rejects.toThrow(
+		'Cannot update text content because JSX children are not static text',
+	);
+});

--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -82,6 +82,30 @@ test('updateSequenceProps should remove attribute when value equals default', as
 	expect(output.split('\n')[7]).toContain('hueShift={30}');
 });
 
+test('updateSequenceProps should remove name when value is empty string default', async () => {
+	const input = `import {Sequence} from 'remotion';
+
+export const Example: React.FC = () => {
+	return (
+		<Sequence name="Intro">
+			<div />
+		</Sequence>
+	);
+};
+`;
+
+	const {output, oldValueStrings} = await updateSequenceProps({
+		input,
+		nodePath: lineColumnToNodePath(input, 5),
+		updates: [{key: 'name', value: '', defaultValue: ''}],
+		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
+	});
+
+	expect(oldValueStrings[0]).toBe('"Intro"');
+	expect(output).not.toContain('name=');
+});
+
 test('updateSequenceProps should set optional attribute to null', async () => {
 	const input = `import {Sequence} from 'remotion';
 

--- a/packages/studio-shared/src/optimistic-update-for-prop-statuses.ts
+++ b/packages/studio-shared/src/optimistic-update-for-prop-statuses.ts
@@ -9,20 +9,28 @@ export const optimisticUpdateForPropStatuses = ({
 	previous,
 	fieldKey,
 	value,
+	defaultValue,
 	schema,
 }: {
 	previous: CanUpdateSequencePropsResponse;
 	fieldKey: string;
 	value: unknown;
+	defaultValue?: string | null;
 	schema: InteractivitySchema;
 }): CanUpdateSequencePropsResponse => {
 	if (!previous.canUpdate) {
 		return previous;
 	}
 
+	const serializedValue = JSON.stringify(value);
+	const optimisticValue =
+		defaultValue !== null && defaultValue === serializedValue
+			? undefined
+			: value;
+
 	const props: Record<string, CanUpdateSequencePropStatus> = {
 		...previous.props,
-		[fieldKey]: {status: 'static', codeValue: value},
+		[fieldKey]: {status: 'static', codeValue: optimisticValue},
 	};
 
 	if (schema[fieldKey]?.type === 'enum') {

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -4,10 +4,10 @@ import type {
 	EffectDefinition,
 	GetDragOverrides,
 	GetEffectDragOverrides,
+	InteractivitySchema,
 	PropStatuses,
 	SequenceControls,
 	SequencePropsSubscriptionKey,
-	InteractivitySchema,
 	VisibleFieldSchema,
 } from 'remotion';
 import {Internals} from 'remotion';
@@ -49,6 +49,7 @@ const SUPPORTED_SCHEMA_TYPES = [
 	'scale',
 	'uv-coordinate',
 	'color',
+	'text-content',
 	'array',
 	'enum',
 	'hidden',
@@ -89,6 +90,10 @@ const getSchemaFieldRowHeight = ({
 		);
 	}
 
+	if (fieldSchema.type === 'text-content') {
+		return SCHEMA_FIELD_ROW_HEIGHT * 2;
+	}
+
 	return SCHEMA_FIELD_ROW_HEIGHT;
 };
 
@@ -124,12 +129,14 @@ export const getFieldsToShow = ({
 	nodePath,
 	schema,
 	currentRuntimeValueDotNotation,
+	includeTextContent,
 }: {
 	schema: InteractivitySchema;
 	currentRuntimeValueDotNotation: Record<string, unknown>;
 	getDragOverrides: GetDragOverrides;
 	propStatuses: PropStatuses;
 	nodePath: SequencePropsSubscriptionKey;
+	includeTextContent?: boolean;
 }): InteractivitySchemaFieldInfo[] | null => {
 	const {merged: valuesDotNotation} =
 		Internals.computeEffectiveSchemaValuesDotNotation({
@@ -139,7 +146,6 @@ export const getFieldsToShow = ({
 			propStatus: Internals.getPropStatusesCtx(propStatuses, nodePath),
 			frame: null,
 		});
-
 	const activeSchema = Internals.flattenActiveSchema(
 		schema,
 		(key) => valuesDotNotation[key],
@@ -157,6 +163,10 @@ export const getFieldsToShow = ({
 			}
 
 			if (fieldSchema.type === 'number' && fieldSchema.hiddenFromList) {
+				return null;
+			}
+
+			if (fieldSchema.type === 'text-content' && !includeTextContent) {
 				return null;
 			}
 

--- a/packages/studio-shared/src/test/optimistic-update-for-prop-statuses.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-for-prop-statuses.test.ts
@@ -49,3 +49,35 @@ test('optimisticUpdateForPropStatuses should return the correct response', () =>
 		effects: [],
 	});
 });
+
+test('optimisticUpdateForPropStatuses should use undefined for removed default values', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			name: {
+				status: 'static',
+				codeValue: 'hehe',
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticUpdateForPropStatuses({
+		previous,
+		fieldKey: 'name',
+		value: '',
+		defaultValue: JSON.stringify(''),
+		schema: NoReactInternals.sequenceSchema,
+	});
+
+	expect(updated).toEqual({
+		canUpdate: true,
+		props: {
+			name: {
+				status: 'static',
+				codeValue: undefined,
+			},
+		},
+		effects: [],
+	});
+});

--- a/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
@@ -1,8 +1,8 @@
 import React, {useContext, useMemo} from 'react';
 import type {
 	CanUpdateSequencePropStatusKeyframed,
-	SequencePropsSubscriptionKey,
 	InteractivitySchema,
+	SequencePropsSubscriptionKey,
 } from 'remotion';
 import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
@@ -84,6 +84,7 @@ export const KeyframeInspector: React.FC<{
 				getDragOverrides,
 				propStatuses,
 				nodePath,
+				includeTextContent: false,
 			});
 			const sequenceField =
 				sequenceFields?.find(

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -32,16 +32,28 @@ const useSequenceDisplayName = (track: TrackWithHash) => {
 		const propStatusesForOverride = nodePath
 			? Internals.getPropStatusesCtx(propStatuses, nodePath)
 			: undefined;
+		const fallbackDisplayName =
+			track.sequence.controls?.componentName || '<Sequence>';
 		const codeNameStatus = propStatusesForOverride?.name;
-		const displayName =
-			codeNameStatus &&
-			codeNameStatus.status === 'static' &&
-			typeof codeNameStatus.codeValue === 'string'
-				? codeNameStatus.codeValue
-				: track.sequence.displayName;
 
-		return displayName || '<Sequence>';
-	}, [nodePath, propStatuses, track.sequence.displayName]);
+		if (
+			codeNameStatus?.status === 'static' &&
+			typeof codeNameStatus.codeValue === 'string'
+		) {
+			return codeNameStatus.codeValue;
+		}
+
+		if (codeNameStatus?.status === 'static') {
+			return fallbackDisplayName;
+		}
+
+		return track.sequence.displayName || fallbackDisplayName;
+	}, [
+		nodePath,
+		propStatuses,
+		track.sequence.controls?.componentName,
+		track.sequence.displayName,
+	]);
 };
 
 const SequenceExpandedInspector: React.FC<{

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -109,6 +109,7 @@ export const InspectorSequenceSection: React.FC<{
 	const {tree} = useTimelineExpandedTree({
 		sequence,
 		nodePathInfo,
+		includeTextContent: true,
 	});
 	const [collapsedKeys, setCollapsedKeys] = useState<ReadonlySet<string>>(
 		() => new Set(),

--- a/packages/studio/src/components/OptionsPanel.tsx
+++ b/packages/studio/src/components/OptionsPanel.tsx
@@ -52,6 +52,7 @@ export const persistSelectedOptionsSidebarPanel = (
 };
 
 export const optionsSidebarTabs = createRef<{
+	selectInspectorPanel: () => void;
 	selectRendersPanel: () => void;
 }>();
 
@@ -91,6 +92,10 @@ export const OptionsPanel: React.FC<{
 
 	useImperativeHandle(optionsSidebarTabs, () => {
 		return {
+			selectInspectorPanel: () => {
+				setPanel('inspector');
+				persistSelectedOptionsSidebarPanel('inspector');
+			},
 			selectRendersPanel: () => {
 				setPanel('renders');
 				persistSelectedOptionsSidebarPanel('renders');

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -1,4 +1,5 @@
 import React, {useContext, useMemo, useRef, useState} from 'react';
+import {flushSync} from 'react-dom';
 import type {ResolvedStackLocation} from 'remotion';
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
@@ -22,6 +23,7 @@ import {
 } from './ForceSpecificCursor';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
+import {optionsSidebarTabs} from './OptionsPanel';
 import {
 	applySelectedOutlineDragAxisLock,
 	applySelectedOutlineTransformOriginAxisLock,
@@ -83,6 +85,7 @@ import {
 } from './Timeline/call-add-keyframe';
 import {disableSequenceInteractivity} from './Timeline/disable-sequence-interactivity';
 import {duplicateSequencesFromSource} from './Timeline/duplicate-selected-timeline-item';
+import {requestFocusInspectorField} from './Timeline/focus-inspector-field';
 import {getSequenceContextMenuItems} from './Timeline/get-sequence-context-menu-items';
 import {saveSequenceProps} from './Timeline/save-sequence-prop';
 import {getTimelineAssetLinkInfo} from './Timeline/timeline-asset-link';
@@ -472,6 +475,7 @@ const SelectedOutlinePolygon: React.FC<{
 		item: TimelineSelection,
 		interaction: TimelineSelectionInteraction,
 	) => void;
+	readonly onTextEditStart: (target: SelectedOutlineTarget) => void;
 	readonly scale: number;
 	readonly target: SelectedOutlineTarget | undefined;
 }> = ({
@@ -484,6 +488,7 @@ const SelectedOutlinePolygon: React.FC<{
 	onDraggingChange,
 	onHoverChange,
 	onSelect,
+	onTextEditStart,
 	scale,
 	target,
 }) => {
@@ -709,6 +714,19 @@ const SelectedOutlinePolygon: React.FC<{
 		],
 	);
 
+	const onDoubleClick = React.useCallback(
+		(event: React.MouseEvent<SVGPolygonElement>) => {
+			if (target === undefined) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			onTextEditStart(target);
+		},
+		[onTextEditStart, target],
+	);
+
 	const onEffectDragOver = React.useCallback(
 		(event: React.DragEvent<SVGPolygonElement>) => {
 			if (effectDrop === null || !hasEffectDragType(event.dataTransfer)) {
@@ -788,6 +806,7 @@ const SelectedOutlinePolygon: React.FC<{
 					}
 				}}
 				onPointerDown={onPointerDown}
+				onDoubleClick={onDoubleClick}
 				onDragOver={effectDrop === null ? undefined : onEffectDragOver}
 				onDragLeave={effectDrop === null ? undefined : onEffectDragLeave}
 				onDrop={effectDrop === null ? undefined : onEffectDrop}
@@ -1433,6 +1452,40 @@ export const SelectedOutlineElement: React.FC<{
 	const selectAsset = useSelectAsset();
 	const {setSelectedModal} = useContext(ModalsContext);
 
+	const onTextEditStart = React.useCallback(
+		(editTarget: SelectedOutlineTarget) => {
+			const {textEdit} = editTarget;
+			if (textEdit === null) {
+				return;
+			}
+
+			if (
+				textEdit.propStatus.status !== 'static' ||
+				typeof textEdit.propStatus.codeValue !== 'string'
+			) {
+				showNotification(
+					'This text is computed and cannot be edited visually',
+					3000,
+				);
+				return;
+			}
+
+			flushSync(() => {
+				if (!editTarget.selected) {
+					onSelect(editTarget.selection, {shiftKey: false, toggleKey: false});
+				}
+
+				optionsSidebarTabs.current?.selectInspectorPanel();
+			});
+
+			requestFocusInspectorField({
+				fieldKey: 'children',
+				nodePath: textEdit.nodePath,
+			});
+		},
+		[onSelect],
+	);
+
 	const onContextMenuOpen = React.useCallback(async () => {
 		if (target === undefined || previewServerState.type !== 'connected') {
 			return false;
@@ -1623,6 +1676,7 @@ export const SelectedOutlineElement: React.FC<{
 				onDraggingChange={onDraggingChange}
 				onHoverChange={onHoverChange}
 				onSelect={onSelect}
+				onTextEditStart={onTextEditStart}
 				scale={scale}
 				target={target}
 			/>

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -22,8 +22,8 @@ import {
 	getSelectedOutlineDragValues,
 	getSelectedOutlineKeyboardNudgeDeltas,
 	getSelectedOutlineKeyboardNudgeDirection,
-	type SelectedOutlineKeyframedDragChange,
 	type SelectedOutlineKeyboardNudgeDirection,
+	type SelectedOutlineKeyframedDragChange,
 	type SelectedOutlineStaticDragChange,
 } from './selected-outline-drag';
 import {type SelectedOutline} from './selected-outline-geometry';
@@ -55,9 +55,9 @@ import {getCurrentDuration, getCurrentFps} from './Timeline/imperative-state';
 import {saveSequenceProps} from './Timeline/save-sequence-prop';
 import {ensureFrameIsInViewport} from './Timeline/timeline-scroll-logic';
 import {
+	useTimelineSelection,
 	type TimelineSelection,
 	type TimelineSelectionInteraction,
-	useTimelineSelection,
 } from './Timeline/TimelineSelection';
 
 export {
@@ -78,11 +78,11 @@ export {
 	getSelectedOutlineScaleEdgeInfo,
 	getSelectedOutlineTransformOriginLockedAxis,
 	isSelectedOutlineDragPastThreshold,
-	selectedOutlineUvSnapThresholdPx,
 	selectedOutlineTransformOriginSnapThresholdPx,
+	selectedOutlineUvSnapThresholdPx,
 	snapSelectedOutlineRotationDeltaDegrees,
-	snapSelectedOutlineUv,
 	snapSelectedOutlineTransformOriginUv,
+	snapSelectedOutlineUv,
 } from './selected-outline-drag';
 export {
 	getOutlineSelectionInteraction,
@@ -223,6 +223,8 @@ export const SelectedOutlineOverlay: React.FC<{
 				activeSchema?.[transformOriginFieldKey];
 			const transformOriginPropStatus =
 				nodePropStatuses?.[transformOriginFieldKey];
+			const textContentFieldSchema = activeSchema?.children;
+			const textContentPropStatus = nodePropStatuses?.children;
 			const transformOriginValueForRotation =
 				transformOriginFieldSchema?.type === 'transform-origin' &&
 				(transformOriginPropStatus?.status === 'static' ||
@@ -290,6 +292,11 @@ export const SelectedOutlineOverlay: React.FC<{
 			const canDropEffect =
 				previewServerState.type === 'connected' &&
 				controls?.supportsEffects === true;
+			const canTextEdit =
+				previewServerState.type === 'connected' &&
+				controls !== null &&
+				textContentFieldSchema?.type === 'text-content' &&
+				textContentPropStatus !== undefined;
 
 			return {
 				key,
@@ -415,6 +422,12 @@ export const SelectedOutlineOverlay: React.FC<{
 									shouldResortToDefaultValueIfUndefined: true,
 								}) ?? fieldSchema.default,
 							),
+						}
+					: null,
+				textEdit: canTextEdit
+					? {
+							nodePath,
+							propStatus: textContentPropStatus,
 						}
 					: null,
 				uvHandles: containsSelection

--- a/packages/studio/src/components/Timeline/TimelineExpandedSection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedSection.tsx
@@ -40,6 +40,7 @@ export const TimelineExpandedSection: React.FC<{
 	const {filteredTree, getIsExpanded, toggleTrack} = useTimelineExpandedTree({
 		sequence,
 		nodePathInfo,
+		includeTextContent: false,
 	});
 
 	const flat = useMemo(

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -6,9 +6,9 @@ import type {
 	DragOverrideValue,
 	GetDragOverrides,
 	GetEffectDragOverrides,
+	InteractivitySchema,
 	PropStatuses,
 	SequencePropsSubscriptionKey,
-	InteractivitySchema,
 } from 'remotion';
 import {Internals, useVideoConfig} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
@@ -218,6 +218,7 @@ const resolveKeyframeControlTarget = ({
 		getDragOverrides,
 		getEffectDragOverrides,
 		propStatuses,
+		includeTextContent: false,
 	});
 	const fieldNode = findFieldNode(
 		tree,

--- a/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
@@ -16,6 +16,7 @@ import {TimelineEnumField} from './TimelineEnumField';
 import {TimelineNumberField} from './TimelineNumberField';
 import {TimelineRotationField} from './TimelineRotationField';
 import {TimelineScaleField} from './TimelineScaleField';
+import {TimelineTextContentField} from './TimelineTextContentField';
 import {TimelineTransformOriginField} from './TimelineTransformOriginField';
 import {TimelineTranslateField} from './TimelineTranslateField';
 import {TimelineUvCoordinateField} from './TimelineUvCoordinateField';
@@ -193,6 +194,20 @@ export const TimelinePrimitiveFieldValue: React.FC<{
 					field={field}
 					onDragEnd={onDragEnd}
 					onDragValueChange={onDragValueChange}
+					onSave={onSave}
+					propStatus={propStatus}
+				/>
+			</span>
+		);
+	}
+
+	if (field.typeName === 'text-content') {
+		return (
+			<span style={inlineWrapper}>
+				<TimelineTextContentField
+					effectiveValue={effectiveValue}
+					field={field}
+					nodePath={scaleLockNodePath}
 					onSave={onSave}
 					propStatus={propStatus}
 				/>

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -833,6 +833,7 @@ export const getSelectableTimelineItems = ({
 			getDragOverrides,
 			getEffectDragOverrides,
 			propStatuses,
+			includeTextContent: false,
 		});
 		const filteredTree = filterTimelineExpandedTree({
 			nodes: tree,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -645,6 +645,7 @@ export const TimelineSequenceItem: React.FC<{
 		return effective ?? false;
 	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
 
+	const fallbackDisplayName = sequence.controls?.componentName ?? '<Sequence>';
 	const staticNamePropValue =
 		codeNameStatus?.status === 'static' &&
 		typeof codeNameStatus.codeValue === 'string'
@@ -654,10 +655,21 @@ export const TimelineSequenceItem: React.FC<{
 	const hasStaticNameProp = staticNamePropValue !== null;
 
 	const displayName = useMemo(() => {
-		return staticNamePropValue ?? sequence.displayName;
-	}, [sequence.displayName, staticNamePropValue]);
+		if (staticNamePropValue !== null) {
+			return staticNamePropValue;
+		}
 
-	const fallbackDisplayName = sequence.controls?.componentName ?? '<Sequence>';
+		if (codeNameStatus?.status === 'static') {
+			return fallbackDisplayName;
+		}
+
+		return sequence.displayName;
+	}, [
+		codeNameStatus?.status,
+		fallbackDisplayName,
+		sequence.displayName,
+		staticNamePropValue,
+	]);
 
 	const onToggleVisibility = useCallback(
 		(type: 'enable' | 'disable') => {

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -125,6 +125,7 @@ const TimelineSequenceExpandArrow: React.FC<{
 	const {filteredTree} = useTimelineExpandedTree({
 		sequence,
 		nodePathInfo,
+		includeTextContent: false,
 	});
 
 	if (filteredTree.length === 0) {

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -68,6 +68,43 @@ const effectDropHighlight: React.CSSProperties = {
 
 const SEQUENCE_REORDER_MIME_TYPE = 'application/remotion-sequence-reorder';
 
+type SequenceNameSaveAction =
+	| {
+			type: 'noop';
+	  }
+	| {
+			type: 'save';
+			defaultValue: string | null;
+	  };
+
+const getSequenceNameSaveAction = ({
+	editedName,
+	currentDisplayName,
+	fallbackDisplayName,
+	hasStaticNameProp,
+}: {
+	editedName: string;
+	currentDisplayName: string;
+	fallbackDisplayName: string;
+	hasStaticNameProp: boolean;
+}): SequenceNameSaveAction => {
+	if (
+		!hasStaticNameProp &&
+		(editedName === '' || editedName === fallbackDisplayName)
+	) {
+		return {type: 'noop'};
+	}
+
+	if (hasStaticNameProp && editedName === currentDisplayName) {
+		return {type: 'noop'};
+	}
+
+	return {
+		type: 'save',
+		defaultValue: editedName === '' ? JSON.stringify('') : null,
+	};
+};
+
 type SequenceReorderDragData = {
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly nodePathKey: string;
@@ -625,17 +662,19 @@ export const TimelineSequenceItem: React.FC<{
 		return effective ?? false;
 	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
 
-	const displayName = useMemo(() => {
-		if (
-			codeNameStatus &&
-			codeNameStatus.status === 'static' &&
-			typeof codeNameStatus.codeValue === 'string'
-		) {
-			return codeNameStatus.codeValue;
-		}
+	const staticNamePropValue =
+		codeNameStatus?.status === 'static' &&
+		typeof codeNameStatus.codeValue === 'string'
+			? codeNameStatus.codeValue
+			: null;
 
-		return sequence.displayName;
-	}, [codeNameStatus, sequence.displayName]);
+	const hasStaticNameProp = staticNamePropValue !== null;
+
+	const displayName = useMemo(() => {
+		return staticNamePropValue ?? sequence.displayName;
+	}, [sequence.displayName, staticNamePropValue]);
+
+	const fallbackDisplayName = sequence.controls?.componentName ?? '<Sequence>';
 
 	const onToggleVisibility = useCallback(
 		(type: 'enable' | 'disable') => {
@@ -758,7 +797,14 @@ export const TimelineSequenceItem: React.FC<{
 				return;
 			}
 
-			if (name === displayName) {
+			const action = getSequenceNameSaveAction({
+				editedName: name,
+				currentDisplayName: displayName,
+				fallbackDisplayName,
+				hasStaticNameProp,
+			});
+
+			if (action.type === 'noop') {
 				setIsRenaming(false);
 				return;
 			}
@@ -770,7 +816,7 @@ export const TimelineSequenceItem: React.FC<{
 						nodePath,
 						fieldKey: 'name',
 						value: name,
-						defaultValue: null,
+						defaultValue: action.defaultValue,
 						schema: sequence.controls.schema,
 					},
 				],
@@ -785,6 +831,8 @@ export const TimelineSequenceItem: React.FC<{
 		[
 			canRenameThisSequence,
 			displayName,
+			fallbackDisplayName,
+			hasStaticNameProp,
 			nodePath,
 			previewServerState,
 			sequence.controls,
@@ -1089,6 +1137,7 @@ export const TimelineSequenceItem: React.FC<{
 			<div style={labelContainerStyle}>
 				<TimelineSequenceName
 					displayName={displayName}
+					fallbackDisplayName={fallbackDisplayName}
 					selected={selected}
 					containsSelection={containsSelection}
 					editing={isRenaming}

--- a/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
@@ -19,6 +19,7 @@ const getTruncatedDisplayName = (displayName: string): string => {
 
 export const TimelineSequenceName: React.FC<{
 	readonly displayName: string;
+	readonly fallbackDisplayName: string;
 	readonly selected: boolean;
 	readonly containsSelection: boolean;
 	readonly editing: boolean;
@@ -26,6 +27,7 @@ export const TimelineSequenceName: React.FC<{
 	readonly onSaveName: (name: string) => Promise<void>;
 }> = ({
 	displayName,
+	fallbackDisplayName,
 	selected,
 	containsSelection,
 	editing,
@@ -74,11 +76,12 @@ export const TimelineSequenceName: React.FC<{
 		};
 	}, [style]);
 
-	const text = getTruncatedDisplayName(displayName) || '<Sequence>';
+	const editableDisplayName = displayName || fallbackDisplayName;
+	const text = getTruncatedDisplayName(editableDisplayName);
 
 	useEffect(() => {
 		if (!editing) {
-			setDraftName(displayName);
+			setDraftName(editableDisplayName);
 			return;
 		}
 
@@ -88,10 +91,11 @@ export const TimelineSequenceName: React.FC<{
 		}
 
 		input.focus();
-		const basenameIndex = displayName.lastIndexOf('.');
-		const selectionEnd = basenameIndex > 0 ? basenameIndex : displayName.length;
+		const basenameIndex = editableDisplayName.lastIndexOf('.');
+		const selectionEnd =
+			basenameIndex > 0 ? basenameIndex : editableDisplayName.length;
 		input.setSelectionRange(0, selectionEnd);
-	}, [displayName, editing]);
+	}, [editableDisplayName, editing]);
 
 	const save = useCallback(() => {
 		onSaveName(draftName).catch(() => undefined);

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -4,8 +4,8 @@ import type {
 	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
-	SequencePropsSubscriptionKey,
 	InteractivitySchema,
+	SequencePropsSubscriptionKey,
 } from 'remotion';
 import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
@@ -109,9 +109,11 @@ const Value: React.FC<{
 			}
 
 			const defaultValue =
-				field.fieldSchema.default !== undefined
-					? JSON.stringify(field.fieldSchema.default)
-					: null;
+				field.fieldSchema.type === 'text-content'
+					? null
+					: field.fieldSchema.default !== undefined
+						? JSON.stringify(field.fieldSchema.default)
+						: null;
 
 			const stringifiedValue = JSON.stringify(value);
 			const fieldLabel = field.description ?? field.key;
@@ -149,6 +151,7 @@ const Value: React.FC<{
 			clientId,
 			field.description,
 			field.fieldSchema.default,
+			field.fieldSchema.type,
 			field.key,
 			nodePath,
 			schema,

--- a/packages/studio/src/components/Timeline/TimelineTextContentField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTextContentField.tsx
@@ -1,0 +1,85 @@
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import type {
+	CanUpdateSequencePropStatusStatic,
+	SequencePropsSubscriptionKey,
+} from 'remotion';
+import type {
+	SchemaFieldInfo,
+	TimelineFieldOnSave,
+} from '../../helpers/timeline-layout';
+import {RemTextarea} from '../NewComposition/RemTextarea';
+import {
+	subscribeToFocusInspectorFieldRequests,
+	type FocusInspectorFieldRequest,
+} from './focus-inspector-field';
+
+export const TimelineTextContentField: React.FC<{
+	readonly field: SchemaFieldInfo;
+	readonly effectiveValue: unknown;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
+	readonly nodePath: SequencePropsSubscriptionKey | null;
+	readonly onSave: TimelineFieldOnSave;
+}> = ({effectiveValue, field, nodePath, onSave, propStatus}) => {
+	const [value, setValue] = useState(String(effectiveValue ?? ''));
+	const inputRef = useRef<HTMLTextAreaElement>(null);
+
+	const commit = useCallback(() => {
+		if (value !== propStatus.codeValue) {
+			onSave(value).catch(() => undefined);
+		}
+	}, [onSave, propStatus.codeValue, value]);
+
+	const focusIfMatchingRequest = useCallback(
+		(request: FocusInspectorFieldRequest) => {
+			if (
+				nodePath === null ||
+				request.fieldKey !== field.key ||
+				JSON.stringify(request.nodePath) !== JSON.stringify(nodePath)
+			) {
+				return;
+			}
+
+			requestAnimationFrame(() => {
+				inputRef.current?.scrollIntoView({block: 'center'});
+				inputRef.current?.focus();
+				inputRef.current?.select();
+			});
+		},
+		[field.key, nodePath],
+	);
+
+	useEffect(() => {
+		return subscribeToFocusInspectorFieldRequests(focusIfMatchingRequest);
+	}, [focusIfMatchingRequest]);
+
+	useEffect(() => {
+		setValue(String(effectiveValue ?? ''));
+	}, [effectiveValue]);
+
+	const onKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+			if (event.key === 'Escape') {
+				setValue(String(propStatus.codeValue ?? ''));
+				event.currentTarget.blur();
+			}
+		},
+		[propStatus.codeValue],
+	);
+
+	return (
+		<RemTextarea
+			ref={inputRef}
+			status="ok"
+			small
+			value={value}
+			onChange={(event) => setValue(event.target.value)}
+			onBlur={commit}
+			onKeyDown={onKeyDown}
+			style={{
+				boxSizing: 'border-box',
+				height: 40,
+				width: 160,
+			}}
+		/>
+	);
+};

--- a/packages/studio/src/components/Timeline/focus-inspector-field.ts
+++ b/packages/studio/src/components/Timeline/focus-inspector-field.ts
@@ -1,0 +1,36 @@
+import type {SequencePropsSubscriptionKey} from 'remotion';
+
+export type FocusInspectorFieldRequest = {
+	readonly fieldKey: string;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly requestId: number;
+};
+
+const listeners = new Set<(request: FocusInspectorFieldRequest) => void>();
+
+export const requestFocusInspectorField = ({
+	fieldKey,
+	nodePath,
+}: {
+	readonly fieldKey: string;
+	readonly nodePath: SequencePropsSubscriptionKey;
+}) => {
+	const request = {
+		fieldKey,
+		nodePath,
+		requestId: Date.now(),
+	};
+
+	for (const listener of listeners) {
+		listener(request);
+	}
+};
+
+export const subscribeToFocusInspectorFieldRequests = (
+	listener: (request: FocusInspectorFieldRequest) => void,
+) => {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+};

--- a/packages/studio/src/components/Timeline/save-sequence-prop.ts
+++ b/packages/studio/src/components/Timeline/save-sequence-prop.ts
@@ -56,6 +56,7 @@ export const saveSequenceProps = ({
 					previous: prev,
 					fieldKey: change.fieldKey,
 					value: change.value,
+					defaultValue: change.defaultValue,
 					schema: change.schema,
 				}),
 			apiCall: () =>
@@ -84,6 +85,7 @@ export const saveSequenceProps = ({
 				previous: prev,
 				fieldKey: change.fieldKey,
 				value: change.value,
+				defaultValue: change.defaultValue,
 				schema: change.schema,
 			}),
 		);

--- a/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
@@ -387,6 +387,9 @@ export const formatTimelineFieldValueForDisplay = ({
 				formatUnknownTimelineValueForDisplay(value)
 			);
 
+		case 'text-content':
+			return String(value);
+
 		case 'array':
 		case 'boolean':
 		case 'color':

--- a/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
+++ b/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
@@ -102,6 +102,7 @@ export const useExpandedTrackKeyframeRows = ({
 				getDragOverrides,
 				getEffectDragOverrides,
 				propStatuses,
+				includeTextContent: false,
 			}),
 		[
 			propStatuses,

--- a/packages/studio/src/components/Timeline/use-timeline-expanded-tree.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-expanded-tree.ts
@@ -17,9 +17,11 @@ import {useTimelineSelection} from './TimelineSelection';
 export const useTimelineExpandedTree = ({
 	sequence,
 	nodePathInfo,
+	includeTextContent,
 }: {
 	readonly sequence: TSequence;
 	readonly nodePathInfo: SequenceNodePathInfo;
+	readonly includeTextContent: boolean;
 }) => {
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {toggleTrack} = useContext(ExpandedTracksSetterContext);
@@ -39,6 +41,7 @@ export const useTimelineExpandedTree = ({
 				getDragOverrides,
 				getEffectDragOverrides,
 				propStatuses: visualModePropStatuses,
+				includeTextContent,
 			}),
 		[
 			sequence,
@@ -46,6 +49,7 @@ export const useTimelineExpandedTree = ({
 			getDragOverrides,
 			getEffectDragOverrides,
 			visualModePropStatuses,
+			includeTextContent,
 		],
 	);
 	const selectedRowKeys = useMemo(

--- a/packages/studio/src/components/Timeline/use-timeline-height.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-height.ts
@@ -5,8 +5,8 @@ import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
 import {
 	buildTimelineTree,
 	flattenVisibleTreeNodes,
-	getTreeRowHeight,
 	getTimelineLayerHeight,
+	getTreeRowHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
 } from '../../helpers/timeline-layout';
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
@@ -62,6 +62,7 @@ export const useTimelineHeight = ({
 					getDragOverrides,
 					getEffectDragOverrides,
 					propStatuses,
+					includeTextContent: false,
 				});
 				const filteredTree = filterTimelineExpandedTree({
 					nodes: tree,

--- a/packages/studio/src/components/selected-outline-types.ts
+++ b/packages/studio/src/components/selected-outline-types.ts
@@ -1,9 +1,10 @@
 import type {
+	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
+	InteractivitySchema,
 	InteractivitySchemaField,
 	SequencePropsSubscriptionKey,
-	InteractivitySchema,
 	TSequence,
 } from 'remotion';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
@@ -33,6 +34,7 @@ export type SelectedOutlineTarget = {
 	readonly scaleDrag: SelectedOutlineScaleDragTarget | null;
 	readonly rotationDrag: SelectedOutlineRotationDragTarget | null;
 	readonly transformOriginDrag: SelectedOutlineTransformOriginDragTarget | null;
+	readonly textEdit: SelectedOutlineTextEditTarget | null;
 	readonly uvHandles: readonly SelectedOutlineUvHandle[];
 };
 
@@ -40,6 +42,11 @@ export type SelectedOutlineEffectDropTarget = {
 	readonly clientId: string;
 	readonly fileName: string;
 	readonly nodePath: SequencePropsSubscriptionKey;
+};
+
+export type SelectedOutlineTextEditTarget = {
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly propStatus: CanUpdateSequencePropStatus;
 };
 
 export type SelectedOutlineDragTarget = {

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -4,10 +4,10 @@ import {
 	type AnySchemaFieldInfo,
 	type DragOverrides,
 	type EffectSchemaFieldInfo,
+	type InteractivitySchemaFieldInfo,
 	type PropStatuses,
 	type SchemaFieldInfo,
 	type SequenceControls,
-	type InteractivitySchemaFieldInfo,
 } from '@remotion/studio-shared';
 import type {
 	GetDragOverrides,
@@ -27,10 +27,10 @@ export type {
 	AnySchemaFieldInfo,
 	DragOverrides,
 	EffectSchemaFieldInfo,
+	InteractivitySchemaFieldInfo,
 	PropStatuses,
 	SchemaFieldInfo,
 	SequenceControls,
-	InteractivitySchemaFieldInfo,
 };
 
 export const TIMELINE_PADDING = 16;
@@ -75,12 +75,14 @@ export const buildTimelineTree = ({
 	getDragOverrides,
 	getEffectDragOverrides,
 	propStatuses,
+	includeTextContent,
 }: {
 	sequence: TSequence;
 	nodePathInfo: SequenceNodePathInfo;
 	getDragOverrides: GetDragOverrides;
 	getEffectDragOverrides: GetEffectDragOverrides;
 	propStatuses: PropStatuses;
+	includeTextContent: boolean;
 }): TimelineTreeNode[] => {
 	const roots: TimelineTreeNode[] = [];
 	const {sequenceSubscriptionKey, index, auxiliaryKeys, supportsEffects} =
@@ -93,6 +95,7 @@ export const buildTimelineTree = ({
 		getDragOverrides,
 		propStatuses,
 		nodePath: sequenceSubscriptionKey,
+		includeTextContent,
 	});
 
 	if (controlFields && controlFields.length > 0) {
@@ -231,6 +234,7 @@ export const getExpandedTrackHeight = ({
 		getDragOverrides: () => ({}),
 		getEffectDragOverrides: () => ({}),
 		propStatuses,
+		includeTextContent: false,
 	});
 	const flat = flattenVisibleTreeNodes({nodes: tree, getIsExpanded});
 


### PR DESCRIPTION
## Summary
- Add safe Visual Mode editing for static `Interactive.*` text children through the Inspector
- Reuse the existing sequence prop save flow for `children` text content
- Keep computed, mixed, and nested children non-editable while still showing them as computed

Fixes #8625

## Test plan
- `bun test packages/core/src/test/with-interactivity-schema-helpers.test.ts packages/studio-server/src/test/compute-sequence-props-status.test.ts packages/studio-server/src/test/update-sequence-props.test.ts`
- `bun run build`
- `bun run stylecheck` *(fails in unrelated `template-react-router` generated types: `Generic type 'GetAnnotations' requires 1 type argument(s)`)*
