### PR TITLE
Internal: Add Zed worktree setup hook

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,11 @@
+[
+	{
+		"label": "setup new worktree",
+		"command": "bash",
+		"args": ["-lc", "bun install && bun run build"],
+		"hooks": ["create_worktree"],
+		"cwd": "$ZED_WORKTREE_ROOT",
+		"reveal": "no_focus",
+		"hide": "on_success"
+	}
+]


### PR DESCRIPTION
## Summary

- Add a Zed `create_worktree` hook for new linked worktrees
- Run `bun install && bun run build` from the new worktree root

## Testing

- `bun --print "JSON.stringify(require('./.zed/tasks.json'))"`
- `bun run build`
- `bun run stylecheck`
