### PR TITLE
`@remotion/media`: Fix video initialization in initially muted Player

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1089,6 +1089,7 @@
       },
       "devDependencies": {
         "@remotion/eslint-config-internal": "workspace:*",
+        "@remotion/player": "workspace:*",
         "@typescript/native-preview": "catalog:",
         "@vitest/browser-webdriverio": "4.0.9",
         "eslint": "catalog:",

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -32,6 +32,7 @@
 	},
 	"devDependencies": {
 		"@remotion/eslint-config-internal": "workspace:*",
+		"@remotion/player": "workspace:*",
 		"@vitest/browser-webdriverio": "4.0.9",
 		"eslint": "catalog:",
 		"react": "catalog:",

--- a/packages/media/src/test/player-muted-video.test.tsx
+++ b/packages/media/src/test/player-muted-video.test.tsx
@@ -1,0 +1,55 @@
+import {Player} from '@remotion/player';
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+import {expect, test} from 'vitest';
+import {Video} from '../video/video';
+
+const waitFor = async (predicate: () => boolean) => {
+	const started = Date.now();
+	while (Date.now() - started < 10000) {
+		if (predicate()) {
+			return;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+
+	throw new Error('Timed out waiting for condition');
+};
+
+const VideoComposition: React.FC = () => {
+	return <Video src="/bigbuckbunny.mp4" />;
+};
+
+test('renders a video in an initially muted Player', async () => {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+
+	const root = createRoot(container);
+	root.render(
+		<Player
+			acknowledgeRemotionLicense
+			component={VideoComposition}
+			compositionHeight={720}
+			compositionWidth={1280}
+			durationInFrames={100}
+			fps={30}
+			initiallyMuted
+			inputProps={{}}
+		/>,
+	);
+
+	try {
+		await waitFor(() => {
+			const renderedCanvas = container.querySelector('canvas');
+			return renderedCanvas?.width === 1280 && renderedCanvas.height === 720;
+		});
+
+		const canvas = container.querySelector('canvas');
+		expect(canvas?.width).toBe(1280);
+		expect(canvas?.height).toBe(720);
+	} finally {
+		root.unmount();
+		container.remove();
+	}
+});

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -256,33 +256,23 @@ const VideoForPreviewAssertedShowing: React.FC<
 	}, [_experimentalInitiallyDrawCachedFrame, src]);
 
 	useEffect(() => {
-		if (!sharedAudioContext) return;
-		if (!sharedAudioContext.audioContext) return;
-
-		const {
-			audioContext,
-			gainNode,
-			audioSyncAnchor,
-			scheduleAudioNode,
-			unscheduleAudioNode,
-		} = sharedAudioContext;
-
-		if (!gainNode) {
-			return;
-		}
+		const sharedAudioContextForMediaPlayer =
+			sharedAudioContext?.audioContext && sharedAudioContext.gainNode
+				? {
+						audioContext: sharedAudioContext.audioContext,
+						gainNode: sharedAudioContext.gainNode,
+						audioSyncAnchor: sharedAudioContext.audioSyncAnchor,
+						scheduleAudioNode: sharedAudioContext.scheduleAudioNode,
+						unscheduleAudioNode: sharedAudioContext.unscheduleAudioNode,
+					}
+				: null;
 
 		try {
 			const player = new MediaPlayer({
 				canvas: canvasRef.current,
 				src: preloadedSrc,
 				logLevel,
-				sharedAudioContext: {
-					audioContext,
-					gainNode,
-					audioSyncAnchor,
-					scheduleAudioNode,
-					unscheduleAudioNode,
-				},
+				sharedAudioContext: sharedAudioContextForMediaPlayer,
 				loop,
 				trimAfter: initialTrimAfterRef.current,
 				trimBefore: initialTrimBeforeRef.current,


### PR DESCRIPTION
## Summary

- Fix a regression from #8611 where `@remotion/media` preview videos did not initialize inside an initially muted `<Player>`
- Keep the intended behavior of avoiding `AudioContext` creation for muted players
- Allow video-only preview rendering to initialize `MediaPlayer` with `sharedAudioContext: null`
- Add a browser integration test that renders `@remotion/media`'s `<Video>` inside an initially muted `@remotion/player` `<Player>`

## Root cause

#8611 intentionally changed the Player to avoid creating a shared `AudioContext` while muted or at volume 0. `VideoForPreview` unintentionally still treated the shared audio context as required before constructing `MediaPlayer`, so `initiallyMuted` caused the video tag/canvas path to never initialize.

## Testing

- `cd packages/media && bunx vitest src/test/player-muted-video.test.tsx --browser --run`
- Temporarily reverted the fix and confirmed the new test fails by timeout
- `cd packages/media && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
