### PR TITLE
`@remotion/gif`: Reuse cached GIF instead of re-decoding on every remount

### DIFF
--- a/packages/gif/src/GifForDevelopment.tsx
+++ b/packages/gif/src/GifForDevelopment.tsx
@@ -61,6 +61,14 @@ export const GifForDevelopment = forwardRef<
 		currentOnError.current = onError;
 
 		useEffect(() => {
+			const parsedGif =
+				volatileGifCache.get(cacheKey) ?? manuallyManagedGifCache.get(cacheKey);
+			if (parsedGif !== undefined) {
+				update(parsedGif as GifState);
+				currentOnLoad.current?.(parsedGif as GifState);
+				return;
+			}
+
 			let done = false;
 			let aborted = false;
 			const {prom, cancel} = parseWithWorker({

--- a/packages/gif/src/test/Gif.test.tsx
+++ b/packages/gif/src/test/Gif.test.tsx
@@ -5,12 +5,19 @@ import {Internals} from 'remotion';
 import {Gif} from '../Gif';
 import {manuallyManagedGifCache} from '../gif-cache';
 import type {GifState} from '../props';
+import {getGifCacheKey} from '../request-init';
+import {resolveGifSource} from '../resolve-gif-source';
 
 type RegisteredSequence = {
 	readonly refForOutline: React.RefObject<HTMLElement | null> | null;
 };
 
 class MockWorker {
+	public static instances = 0;
+	public constructor() {
+		MockWorker.instances++;
+	}
+
 	public addEventListener = () => undefined;
 	public removeEventListener = () => undefined;
 	public postMessage = () => undefined;
@@ -199,4 +206,29 @@ test('<Gif> registers its canvas as the outline ref', async () => {
 	const refForOutline = registeredSequences[0]
 		.refForOutline as React.RefObject<HTMLCanvasElement | null>;
 	expect(ref.current).toBe(refForOutline.current);
+});
+
+test('reuses a cached GIF without spawning a decode worker', async () => {
+	// The GIF is already decoded and cached, so mounting must reuse it instead of
+	// re-spawning the parse worker. Without this, every remount re-decodes the GIF
+	// (a fresh ImageData per frame); repeated remounts while scrubbing accumulate
+	// memory until the tab runs out of memory.
+	const cacheKey = getGifCacheKey({
+		resolvedSrc: resolveGifSource('test.gif'),
+		requestInit: undefined,
+	});
+	manuallyManagedGifCache.set(cacheKey, gifState);
+	MockWorker.instances = 0;
+
+	render(
+		<SequenceRegistrationWrapper onRegisterSequence={() => undefined}>
+			<Gif src="test.gif" />
+		</SequenceRegistrationWrapper>,
+	);
+
+	await waitFor(() => {
+		expect(document.querySelector('canvas')).toBeInstanceOf(HTMLCanvasElement);
+	});
+
+	expect(MockWorker.instances).toBe(0);
 });


### PR DESCRIPTION
## Problem

`GifForDevelopment` reads the decoded GIF from `volatileGifCache` / `manuallyManagedGifCache` in its `useState` initializer, but the `useEffect` then **re-runs the decode worker unconditionally on every mount**, even when that GIF is already cached. Each parse rebuilds an `ImageData` per frame.

In the Player/Studio this bites during **seeking/scrubbing**: an overlay's `<Sequence>` mounts and unmounts as the playhead crosses its boundary, so `<Gif>` remounts repeatedly and re-decodes the whole GIF each time. The freshly-allocated frame sets churn memory, and over a long editing session with GIF overlays the heap can grow until the renderer is OOM-killed. (Found in a video editor built on Remotion: scrubbing over a GIF overlay would peg CPU on GC and crash the tab; a heap diff showed `ImageData` / `Uint8ClampedArray` / `ArrayBuffer` growth, and instrumentation confirmed the worker was re-spawned on every remount.)

## Fix

If the GIF is already in either cache, reuse it (mirroring the `useState` initializer) and skip the worker:

```ts
useEffect(() => {
  const parsedGif =
    volatileGifCache.get(cacheKey) ?? manuallyManagedGifCache.get(cacheKey);
  if (parsedGif !== undefined) {
    update(parsedGif as GifState);
    currentOnLoad.current?.(parsedGif as GifState);
    return;
  }
  // …existing parse path
}, [cacheKey, resolvedSrc]);
```

## Test

Adds a test that seeds the cache and asserts no `Worker` is constructed when `<Gif>` mounts with the GIF already cached. Verified locally (`bun run makecore` + `bun test src/test`): red without the guard (worker spawned), green with it; the existing test is unaffected; `oxfmt --check` and `eslint` pass.

## Tradeoff / open question

On a cache hit `onLoad` now fires synchronously inside the effect rather than asynchronously after a worker round-trip. If you'd rather preserve the async timing, the cache branch can resolve through a microtask (`Promise.resolve(parsed).then(...)` with an abort guard) — happy to switch. Also open to *not* firing `onLoad` on reuse if you consider it a one-time event.
