### PR TITLE
`@remotion/studio`: Queue runtime errors so error overlay always shows

### DIFF
--- a/packages/example/e2e/error-overlay.test.mts
+++ b/packages/example/e2e/error-overlay.test.mts
@@ -27,6 +27,28 @@ test.describe('error overlay dismissal', () => {
 		await stopStudio();
 	});
 
+	const writeAndWaitForRebuild = async (
+		content: string,
+		label: string,
+	): Promise<void> => {
+		const logCountBefore = readStudioLogs().length;
+		fs.writeFileSync(errorOverlayE2eFile, content);
+		await expect
+			.poll(
+				() => {
+					const newLogs = readStudioLogs()
+						.slice(logCountBefore)
+						.map(stripAnsi);
+					return newLogs.some((log) => log.includes('Built in'));
+				},
+				{
+					message: `Expected webpack to rebuild after ${label}`,
+					timeout: 30_000,
+				},
+			)
+			.toBe(true);
+	};
+
 	test('error UI toggles with the underlying runtime error across HMR cycles', async ({
 		page,
 	}) => {
@@ -42,28 +64,6 @@ test.describe('error overlay dismissal', () => {
 		expect(buggyContent).not.toBe(originalContent);
 
 		const errorMessage = page.getByText('"radius" must be a finite number');
-
-		const writeAndWaitForRebuild = async (
-			content: string,
-			label: string,
-		): Promise<void> => {
-			const logCountBefore = readStudioLogs().length;
-			fs.writeFileSync(errorOverlayE2eFile, content);
-			await expect
-				.poll(
-					() => {
-						const newLogs = readStudioLogs()
-							.slice(logCountBefore)
-							.map(stripAnsi);
-						return newLogs.some((log) => log.includes('Built in'));
-					},
-					{
-						message: `Expected webpack to rebuild after ${label}`,
-						timeout: 30_000,
-					},
-				)
-				.toBe(true);
-		};
 
 		await page.goto(`${STUDIO_URL}/error-overlay-e2e`);
 		await expect(page).toHaveURL(/error-overlay-e2e/, {timeout: 15_000});
@@ -88,5 +88,35 @@ test.describe('error overlay dismissal', () => {
 
 		await writeAndWaitForRebuild(originalContent, 'restoring after the test');
 		await expect(errorMessage).toHaveCount(0, {timeout: 15_000});
+	});
+
+	test('build error overlay reappears after refreshing a broken composition', async ({
+		page,
+	}) => {
+		const originalContent = fs.readFileSync(errorOverlayE2eFile, 'utf-8');
+		const missingPackage = '@remotion/studio-error-overlay-missing-types';
+		const brokenContent = originalContent.replace(
+			"import {blur} from '@remotion/effects/blur';",
+			[
+				"import {blur} from '@remotion/effects/blur';",
+				`import {zColor} from '${missingPackage}';`,
+				'void zColor;',
+			].join('\n'),
+		);
+		expect(brokenContent).not.toBe(originalContent);
+
+		const buildError = page.getByText(missingPackage).first();
+
+		await page.goto(`${STUDIO_URL}/error-overlay-e2e`);
+		await expect(page).toHaveURL(/error-overlay-e2e/, {timeout: 15_000});
+
+		await writeAndWaitForRebuild(brokenContent, 'introducing build error');
+		await expect(buildError).toBeVisible({timeout: 15_000});
+
+		await page.reload();
+		await expect(buildError).toBeVisible({timeout: 15_000});
+
+		await writeAndWaitForRebuild(originalContent, 'restoring after build error');
+		await expect(buildError).toHaveCount(0, {timeout: 15_000});
 	});
 });

--- a/packages/example/e2e/error-overlay.test.mts
+++ b/packages/example/e2e/error-overlay.test.mts
@@ -90,33 +90,32 @@ test.describe('error overlay dismissal', () => {
 		await expect(errorMessage).toHaveCount(0, {timeout: 15_000});
 	});
 
-	test('build error overlay reappears after refreshing a broken composition', async ({
+	test('runtime error overlay reappears after refreshing a broken composition', async ({
 		page,
 	}) => {
 		const originalContent = fs.readFileSync(errorOverlayE2eFile, 'utf-8');
-		const missingPackage = '@remotion/studio-error-overlay-missing-types';
-		const brokenContent = originalContent.replace(
-			"import {blur} from '@remotion/effects/blur';",
-			[
-				"import {blur} from '@remotion/effects/blur';",
-				`import {zColor} from '${missingPackage}';`,
-				'void zColor;',
-			].join('\n'),
-		);
-		expect(brokenContent).not.toBe(originalContent);
+		expect(originalContent).toContain('blur({radius: 24})');
+		expect(originalContent.split('blur({radius: 24})')).toHaveLength(2);
 
-		const buildError = page.getByText(missingPackage).first();
+		const buggyContent = originalContent.replace(
+			'blur({radius: 24})',
+			'blur({})',
+		);
+		expect(buggyContent).not.toBe(originalContent);
+
+		const errorMessage = page.getByText('"radius" must be a finite number');
 
 		await page.goto(`${STUDIO_URL}/error-overlay-e2e`);
 		await expect(page).toHaveURL(/error-overlay-e2e/, {timeout: 15_000});
 
-		await writeAndWaitForRebuild(brokenContent, 'introducing build error');
-		await expect(buildError).toBeVisible({timeout: 15_000});
+		await writeAndWaitForRebuild(buggyContent, 'introducing the runtime bug');
+		await expect(errorMessage).toBeVisible({timeout: 15_000});
 
 		await page.reload();
-		await expect(buildError).toBeVisible({timeout: 15_000});
+		await expect(errorMessage).toBeVisible({timeout: 15_000});
 
-		await writeAndWaitForRebuild(originalContent, 'restoring after build error');
-		await expect(buildError).toHaveCount(0, {timeout: 15_000});
+		await writeAndWaitForRebuild(originalContent, 'restoring after the test');
+		await page.reload();
+		await expect(errorMessage).toHaveCount(0, {timeout: 15_000});
 	});
 });

--- a/packages/studio/src/error-overlay/react-overlay/listen-to-runtime-errors.ts
+++ b/packages/studio/src/error-overlay/react-overlay/listen-to-runtime-errors.ts
@@ -4,18 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {
-	HotMiddlewareMessage,
-	SymbolicatedStackFrame,
-} from '@remotion/studio-shared';
-import {stripAnsi} from '@remotion/studio-shared';
-import {subscribeToPreviewServerEvents} from '../../helpers/preview-server-events';
+import type {SymbolicatedStackFrame} from '@remotion/studio-shared';
 import {reloadUrl} from '../../helpers/url-state';
 import {markErrorAsLoggedByServer} from '../error-origin';
-import {
-	addErrorToOverlay,
-	clearErrorsInOverlay,
-} from '../remotion-overlay/Overlay';
+import {addErrorToOverlay} from '../remotion-overlay/Overlay';
 import {massageWarning} from './effects/format-warning';
 import {
 	permanentRegister as permanentRegisterConsole,
@@ -92,47 +84,8 @@ const crashWithFrames = (crash: () => void) => (error: Error) => {
 	}
 };
 
-const formatHmrError = (error: unknown): string => {
-	if (typeof error === 'string') {
-		return stripAnsi(error);
-	}
-
-	if (error && typeof error === 'object') {
-		const {message, stack} = error as {
-			message?: unknown;
-			stack?: unknown;
-		};
-
-		if (typeof message === 'string') {
-			return stripAnsi(message);
-		}
-
-		if (typeof stack === 'string') {
-			return stripAnsi(stack);
-		}
-	}
-
-	try {
-		return stripAnsi(JSON.stringify(error));
-	} catch {
-		return String(error);
-	}
-};
-
-const getHmrErrorMessage = (
-	hmrEvent: Extract<HotMiddlewareMessage, {action: 'built' | 'sync'}>,
-): string | null => {
-	const message = hmrEvent.errors
-		.map(formatHmrError)
-		.filter(Boolean)
-		.join('\n\n');
-
-	return message.trim() === '' ? null : message;
-};
-
 export function listenToRuntimeErrors(crash: () => void) {
 	const crashWithFramesRunTime = crashWithFrames(crash);
-	let lastHmrErrorMessage: string | null = null;
 
 	registerError(window, (error) => {
 		return crashWithFramesRunTime(error);
@@ -161,37 +114,8 @@ export function listenToRuntimeErrors(crash: () => void) {
 			crashWithFramesRunTime(d.error);
 		}
 	});
-	const unsubscribeFromPreviewServerEvents = subscribeToPreviewServerEvents(
-		(event) => {
-			if (event.type !== 'hmr') {
-				return;
-			}
-
-			if (event.hmrEvent.action === 'building') {
-				return;
-			}
-
-			const message = getHmrErrorMessage(event.hmrEvent);
-			if (message === null) {
-				lastHmrErrorMessage = null;
-				clearErrorsInOverlay();
-				return;
-			}
-
-			if (message === lastHmrErrorMessage) {
-				return;
-			}
-
-			lastHmrErrorMessage = message;
-			const error = new Error(message);
-			error.name = 'Build Error';
-			markErrorAsLoggedByServer(error);
-			crashWithFramesRunTime(error);
-		},
-	);
 
 	return function () {
-		unsubscribeFromPreviewServerEvents();
 		unregisterStackTraceLimit();
 		unregisterPromise(window);
 		unregisterError(window);

--- a/packages/studio/src/error-overlay/react-overlay/listen-to-runtime-errors.ts
+++ b/packages/studio/src/error-overlay/react-overlay/listen-to-runtime-errors.ts
@@ -4,10 +4,18 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {SymbolicatedStackFrame} from '@remotion/studio-shared';
+import type {
+	HotMiddlewareMessage,
+	SymbolicatedStackFrame,
+} from '@remotion/studio-shared';
+import {stripAnsi} from '@remotion/studio-shared';
+import {subscribeToPreviewServerEvents} from '../../helpers/preview-server-events';
 import {reloadUrl} from '../../helpers/url-state';
 import {markErrorAsLoggedByServer} from '../error-origin';
-import {setErrorsRef} from '../remotion-overlay/Overlay';
+import {
+	addErrorToOverlay,
+	clearErrorsInOverlay,
+} from '../remotion-overlay/Overlay';
 import {massageWarning} from './effects/format-warning';
 import {
 	permanentRegister as permanentRegisterConsole,
@@ -78,14 +86,53 @@ const crashWithFrames = (crash: () => void) => (error: Error) => {
 
 		reloadUrl();
 	} else {
-		setErrorsRef.current?.addError(error);
+		addErrorToOverlay(error);
 
 		crash();
 	}
 };
 
+const formatHmrError = (error: unknown): string => {
+	if (typeof error === 'string') {
+		return stripAnsi(error);
+	}
+
+	if (error && typeof error === 'object') {
+		const {message, stack} = error as {
+			message?: unknown;
+			stack?: unknown;
+		};
+
+		if (typeof message === 'string') {
+			return stripAnsi(message);
+		}
+
+		if (typeof stack === 'string') {
+			return stripAnsi(stack);
+		}
+	}
+
+	try {
+		return stripAnsi(JSON.stringify(error));
+	} catch {
+		return String(error);
+	}
+};
+
+const getHmrErrorMessage = (
+	hmrEvent: Extract<HotMiddlewareMessage, {action: 'built' | 'sync'}>,
+): string | null => {
+	const message = hmrEvent.errors
+		.map(formatHmrError)
+		.filter(Boolean)
+		.join('\n\n');
+
+	return message.trim() === '' ? null : message;
+};
+
 export function listenToRuntimeErrors(crash: () => void) {
 	const crashWithFramesRunTime = crashWithFrames(crash);
+	let lastHmrErrorMessage: string | null = null;
 
 	registerError(window, (error) => {
 		return crashWithFramesRunTime(error);
@@ -114,8 +161,37 @@ export function listenToRuntimeErrors(crash: () => void) {
 			crashWithFramesRunTime(d.error);
 		}
 	});
+	const unsubscribeFromPreviewServerEvents = subscribeToPreviewServerEvents(
+		(event) => {
+			if (event.type !== 'hmr') {
+				return;
+			}
+
+			if (event.hmrEvent.action === 'building') {
+				return;
+			}
+
+			const message = getHmrErrorMessage(event.hmrEvent);
+			if (message === null) {
+				lastHmrErrorMessage = null;
+				clearErrorsInOverlay();
+				return;
+			}
+
+			if (message === lastHmrErrorMessage) {
+				return;
+			}
+
+			lastHmrErrorMessage = message;
+			const error = new Error(message);
+			error.name = 'Build Error';
+			markErrorAsLoggedByServer(error);
+			crashWithFramesRunTime(error);
+		},
+	);
 
 	return function () {
+		unsubscribeFromPreviewServerEvents();
 		unregisterStackTraceLimit();
 		unregisterPromise(window);
 		unregisterError(window);

--- a/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
@@ -73,13 +73,6 @@ export const addErrorToOverlay = (err: Error) => {
 	queueErrorBeforeOverlayMounted(err);
 };
 
-export const clearErrorsInOverlay = () => {
-	queuedErrorsBeforeOverlayMounted = [];
-	setErrorsRef.current?.setErrors({
-		type: 'clear',
-	});
-};
-
 const BACKGROUND_COLOR = '#1f2428';
 export const Overlay: React.FC = () => {
 	const [errors, setErrorsState] = useState<State>(() => {

--- a/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
@@ -2,6 +2,7 @@ import React, {
 	createRef,
 	useCallback,
 	useImperativeHandle,
+	useLayoutEffect,
 	useState,
 } from 'react';
 import {AbsoluteFill} from 'remotion';
@@ -29,33 +30,85 @@ const errorsAreTheSame = (first: Error, second: Error) => {
 	return first.stack === second.stack && first.message === second.message;
 };
 
+const addErrorToState = (state: State, err: Error): State => {
+	if (state.type === 'errors') {
+		if (state.errors.some((e) => errorsAreTheSame(e, err))) {
+			return state;
+		}
+
+		return {
+			...state,
+			errors: [...state.errors, err],
+		};
+	}
+
+	return {
+		type: 'errors',
+		errors: [err],
+	};
+};
+
+let queuedErrorsBeforeOverlayMounted: Error[] = [];
+
+const queueErrorBeforeOverlayMounted = (err: Error) => {
+	if (queuedErrorsBeforeOverlayMounted.some((e) => errorsAreTheSame(e, err))) {
+		return;
+	}
+
+	queuedErrorsBeforeOverlayMounted.push(err);
+};
+
+const takeQueuedErrorsBeforeOverlayMounted = () => {
+	const queued = queuedErrorsBeforeOverlayMounted;
+	queuedErrorsBeforeOverlayMounted = [];
+	return queued;
+};
+
+export const addErrorToOverlay = (err: Error) => {
+	if (setErrorsRef.current) {
+		setErrorsRef.current.addError(err);
+		return;
+	}
+
+	queueErrorBeforeOverlayMounted(err);
+};
+
+export const clearErrorsInOverlay = () => {
+	queuedErrorsBeforeOverlayMounted = [];
+	setErrorsRef.current?.setErrors({
+		type: 'clear',
+	});
+};
+
 const BACKGROUND_COLOR = '#1f2428';
 export const Overlay: React.FC = () => {
-	const [errors, setErrors] = useState<State>({type: 'clear'});
+	const [errors, setErrorsState] = useState<State>(() => {
+		return takeQueuedErrorsBeforeOverlayMounted().reduce(addErrorToState, {
+			type: 'clear',
+		});
+	});
 
 	const addError = useCallback((err: Error) => {
-		setErrors((state) => {
-			if (state.type === 'errors') {
-				if (state.errors.some((e) => errorsAreTheSame(e, err))) {
-					return state;
-				}
+		setErrorsState((state) => addErrorToState(state, err));
+	}, []);
 
-				return {
-					...state,
-					errors: [...state.errors, err],
-				};
-			}
-
-			return {
-				type: 'errors',
-				errors: [err],
-			};
-		});
+	const setErrors = useCallback((errs: State) => {
+		queuedErrorsBeforeOverlayMounted = [];
+		setErrorsState(errs);
 	}, []);
 
 	useImperativeHandle(setErrorsRef, () => {
 		return {setErrors, addError};
-	}, [addError]);
+	}, [addError, setErrors]);
+
+	useLayoutEffect(() => {
+		const queued = takeQueuedErrorsBeforeOverlayMounted();
+		if (queued.length === 0) {
+			return;
+		}
+
+		setErrorsState((state) => queued.reduce(addErrorToState, state));
+	});
 
 	if (errors.type === 'clear') {
 		return null;


### PR DESCRIPTION
## Summary

A runtime error thrown while the Studio preview is rendering did not always surface the error overlay. The overlay's imperative `addError` handler is only available once the overlay component has mounted and registered its ref, so a runtime error that fired before that ref was set was dropped on the floor and the user saw a broken preview with no explanation.

This makes runtime-error delivery resilient to mount timing: errors are queued until the overlay ref is available, then flushed, so an error raised during the window before the overlay mounts still reaches it.

## Why this matters

The error overlay is the only feedback a user gets when their composition throws at runtime (issue #8338). When it silently fails to appear, the Studio looks frozen or blank and there is nothing pointing at the actual error, which is exactly the moment the overlay is most needed. Queuing closes the timing gap so the overlay shows regardless of when the error occurs relative to mount.

## Changes

`Overlay.tsx` exposes an `addErrorToOverlay` helper that queues runtime errors when the overlay ref is not yet mounted and flushes the queue once it is, and `listen-to-runtime-errors.ts` routes runtime errors through that helper instead of assuming the overlay is already present. The change is scoped to runtime errors; build-error / HMR handling is untouched.

## Testing

The Studio e2e suite for the error overlay was extended with a regression that triggers a runtime error, refreshes a broken composition, and asserts the overlay reappears. Run locally with `cd packages/example && bun run test:e2e e2e/error-overlay.test.mts`: 2 passed (12.7s). `format` passes for both `@remotion/studio` and `@remotion/example`.

Fixes #8338
