### PR TITLE
`@remotion/studio`: Align timeline playhead with keyframes

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSlider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSlider.tsx
@@ -21,11 +21,33 @@ const container: React.CSSProperties = {
 	pointerEvents: 'none',
 };
 
+const PLAYHEAD_LINE_WIDTH = 1;
+
 const line: React.CSSProperties = {
 	height: '100vh',
-	width: 1,
+	width: PLAYHEAD_LINE_WIDTH,
 	position: 'fixed',
 	backgroundColor: '#f02c00',
+};
+
+const PLAYHEAD_CENTER_OFFSET = PLAYHEAD_LINE_WIDTH / 2;
+
+const getTimelineSliderTransform = ({
+	durationInFrames,
+	frame,
+	width,
+}: {
+	durationInFrames: number;
+	frame: number;
+	width: number;
+}) => {
+	const left = getXPositionOfItemInTimelineImperatively(
+		frame,
+		durationInFrames,
+		width,
+	);
+
+	return `translateX(${left - PLAYHEAD_CENTER_OFFSET}px)`;
 };
 
 export const redrawTimelineSliderFast = createRef<{
@@ -66,11 +88,11 @@ const TimelineSliderInner: React.FC = () => {
 			return;
 		}
 
-		el.style.transform = `translateX(${getXPositionOfItemInTimelineImperatively(
-			timelinePosition,
-			videoConfig.durationInFrames,
-			measuredWidth,
-		)}px)`;
+		el.style.transform = getTimelineSliderTransform({
+			durationInFrames: videoConfig.durationInFrames,
+			frame: timelinePosition,
+			width: measuredWidth,
+		});
 	}, [
 		timelinePosition,
 		videoConfig.durationInFrames,
@@ -86,11 +108,11 @@ const TimelineSliderInner: React.FC = () => {
 					throw new Error('unexpectedly did not have ref to timelineslider');
 				}
 
-				current.style.transform = `translateX(${getXPositionOfItemInTimelineImperatively(
+				current.style.transform = getTimelineSliderTransform({
+					durationInFrames: getCurrentDuration(),
 					frame,
-					getCurrentDuration(),
-					width ?? (sliderAreaRef.current?.clientWidth as number) ?? 0,
-				)}px)`;
+					width: width ?? (sliderAreaRef.current?.clientWidth as number) ?? 0,
+				});
 			},
 		};
 	}, []);


### PR DESCRIPTION
## Summary

- Center the Studio timeline playhead line on the computed frame position
- Keep normal playhead rendering and imperative redraws using the same transform helper

Fixes #8233.

## Test Plan

- `bunx oxfmt src --write` in `packages/studio`
- `bun run build`
- `bun run stylecheck`
