### PR TITLE
`@remotion/zod-types`: Remove Zod peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2576,7 +2576,7 @@
         "zod": "catalog:",
       },
       "peerDependencies": {
-        "zod": "catalog:",
+        "zod": ">=4.0.0 <5.0.0",
       },
     },
     "packages/zod-types-v3": {

--- a/bun.lock
+++ b/bun.lock
@@ -2575,9 +2575,6 @@
         "eslint": "catalog:",
         "zod": "catalog:",
       },
-      "peerDependencies": {
-        "zod": ">=4.0.0 <5.0.0",
-      },
     },
     "packages/zod-types-v3": {
       "name": "@remotion/zod-types-v3",

--- a/packages/zod-types/package.json
+++ b/packages/zod-types/package.json
@@ -24,7 +24,7 @@
 		"remotion": "workspace:*"
 	},
 	"peerDependencies": {
-		"zod": "catalog:"
+		"zod": ">=4.0.0 <5.0.0"
 	},
 	"devDependencies": {
 		"zod": "catalog:",

--- a/packages/zod-types/package.json
+++ b/packages/zod-types/package.json
@@ -23,9 +23,6 @@
 	"dependencies": {
 		"remotion": "workspace:*"
 	},
-	"peerDependencies": {
-		"zod": ">=4.0.0 <5.0.0"
-	},
 	"devDependencies": {
 		"zod": "catalog:",
 		"@remotion/eslint-config-internal": "workspace:*",


### PR DESCRIPTION
Upgrading from older versions is hard due to this.