### PR TITLE
`@remotion/cli`: Link Zod mismatch warning to docs

### DIFF
--- a/packages/cli/src/extra-packages.ts
+++ b/packages/cli/src/extra-packages.ts
@@ -15,5 +15,5 @@ export const EXTRA_PACKAGES_DOCS: Record<string, string> = {
 	'@mediabunny/aac-encoder': 'https://www.remotion.dev/docs/mediabunny/version',
 	'@mediabunny/flac-encoder':
 		'https://www.remotion.dev/docs/mediabunny/version',
-	zod: 'https://zod.dev',
+	zod: 'https://www.remotion.dev/docs/zod-types/',
 };


### PR DESCRIPTION
## Summary
- Link the Zod extra-package mismatch warning to the Remotion Zod Types docs page

## Tests
- bun run build
- bun run stylecheck