### PR TITLE
[MERGE AFTER VACATION] `@remotion/renderer`: Update Chrome to 151

### DIFF
--- a/.agents/skills/remotion-chromium-binary-release/SKILL.md
+++ b/.agents/skills/remotion-chromium-binary-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remotion-chromium-binary-release
-description: Release Remotion Chromium headless-shell binaries after chrome-compile builds. Use when uploading Chromium/Chrome headless shell zips to remotion.media, validating BrowserFetcher-compatible zip layout, mapping chrome-compile artifact names to get-chrome-download-url.ts URL names, comparing or handing off Chromium binary updates between remotion-dev/chrome-compile and remotion-dev/remotion, or documenting the final release flow.
+description: Release Remotion Chromium headless-shell binaries after chrome-compile builds. Use when uploading Chromium/Chrome headless shell zips to remotion.media, validating BrowserFetcher-compatible zip layout, mapping chrome-compile artifact names to get-chrome-download-url.ts URL names, updating Remotion downloader or Lambda layer rollout code, comparing or handing off Chromium binary updates between remotion-dev/chrome-compile and remotion-dev/remotion, or documenting the final release flow.
 ---
 
 # Remotion Chromium Binary Release
@@ -28,6 +28,7 @@ that same skill from the checkout so credential paths match the machine.
 1. Determine the Remotion downloader contract.
    - Read the target `packages/renderer/src/browser/get-chrome-download-url.ts`.
    - Read the matching `BrowserFetcher.ts` extraction logic.
+   - If continuing an existing Remotion PR, inspect the PR diff before editing.
    - Do not infer URL names from chrome-compile output names alone.
 
 2. Validate local artifacts before upload.
@@ -61,7 +62,9 @@ that same skill from the checkout so credential paths match the machine.
 7. Handoff to `remotion-dev/remotion`.
    State the exact uploaded URLs and note that implementation work may continue
    in `remotion-dev/remotion`, typically by bumping `TESTED_VERSION`,
-   `PLAYWRIGHT_VERSION` if needed, and any Amazon Linux custom URL branches.
+   `PLAYWRIGHT_VERSION` if needed, Amazon Linux custom URL branches,
+   `BrowserFetcher.ts` subdir normalization, Lambda layer S3 keys,
+   `hosted-layers.ts`, docs, and runtime tests.
 
 ## Guardrails
 

--- a/.agents/skills/remotion-chromium-binary-release/SKILL.md
+++ b/.agents/skills/remotion-chromium-binary-release/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: remotion-chromium-binary-release
+description: Release Remotion Chromium headless-shell binaries after chrome-compile builds. Use when uploading Chromium/Chrome headless shell zips to remotion.media, validating BrowserFetcher-compatible zip layout, mapping chrome-compile artifact names to get-chrome-download-url.ts URL names, comparing or handing off Chromium binary updates between remotion-dev/chrome-compile and remotion-dev/remotion, or documenting the final release flow.
+---
+
+# Remotion Chromium Binary Release
+
+Use this after `remotion-dev/chrome-compile` has produced Chromium
+`headless_shell` zips and the user wants them usable by `remotion-dev/remotion`.
+The fragile parts are the public object names, zip internal folders, and R2
+upload verification.
+
+## Required Context
+
+Read `references/release-checklist.md` before uploading or declaring a release
+complete.
+
+If the task mentions R2, `remotion.media`, or large asset upload, also use the
+canonical Remotion upload skill from GitHub:
+
+https://github.com/remotion-dev/remotion/blob/main/.agents/skills/upload-r2/SKILL.md
+
+When a local `remotion-dev/remotion` checkout is available, prefer the copy of
+that same skill from the checkout so credential paths match the machine.
+
+## Workflow
+
+1. Determine the Remotion downloader contract.
+   - Read the target `packages/renderer/src/browser/get-chrome-download-url.ts`.
+   - Read the matching `BrowserFetcher.ts` extraction logic.
+   - Do not infer URL names from chrome-compile output names alone.
+
+2. Validate local artifacts before upload.
+   - Check all required zips exist.
+   - Run zip integrity checks.
+   - Verify exactly one top-level folder per zip.
+   - Verify the expected executable filename inside each folder.
+   - Verify Amazon Linux packages include required runtime libraries.
+
+3. Map build output names to public object names.
+   - `output/chromium-headless-shell-linux64.zip`
+     -> `chromium-headless-shell-linux-x64-<version>.zip`
+   - `output/chromium-headless-shell-linux-arm64.zip`
+     -> `chromium-headless-shell-linux-arm64-<version>.zip`
+   - `output/chromium-headless-shell-amazon-linux2023-x64.zip`
+     -> `chromium-headless-shell-amazon-linux-x64-<version>.zip`
+   - `output/chromium-headless-shell-amazon-linux2023-arm64.zip`
+     -> `chromium-headless-shell-amazon-linux-arm64-<version>.zip`
+
+4. Verify public objects do not already exist unless overwriting is intended.
+   Use `curl -I` on `https://remotion.media/<key>`.
+
+5. Upload via R2 using the Remotion checkout's `packages/remotion-media/.env`.
+   Never print credential values.
+
+6. Verify each public URL after upload.
+   - Require `HTTP 200`.
+   - Check `content-length` equals the local file size.
+   - Also check the `?clear` URL form if `get-chrome-download-url.ts` uses it.
+
+7. Handoff to `remotion-dev/remotion`.
+   State the exact uploaded URLs and note that implementation work may continue
+   in `remotion-dev/remotion`, typically by bumping `TESTED_VERSION`,
+   `PLAYWRIGHT_VERSION` if needed, and any Amazon Linux custom URL branches.
+
+## Guardrails
+
+- Do not upload until the local zip layout matches `BrowserFetcher`.
+- Do not expose R2 secrets.
+- Do not claim runtime compatibility from zip checks alone; say whether a
+  downstream Remotion run actually tested the binaries.
+- Remember that `chrome-compile` docs/build scripts and `remotion` downloader
+  code can be updated in separate PRs.

--- a/.agents/skills/remotion-chromium-binary-release/agents/openai.yaml
+++ b/.agents/skills/remotion-chromium-binary-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Remotion Chromium Release"
+  short_description: "Upload and verify Remotion Chromium headless-shell binaries."
+  default_prompt: "Upload and verify Chromium headless-shell binaries for Remotion."

--- a/.agents/skills/remotion-chromium-binary-release/references/release-checklist.md
+++ b/.agents/skills/remotion-chromium-binary-release/references/release-checklist.md
@@ -1,0 +1,124 @@
+# Remotion Chromium Binary Release Checklist
+
+## What Was Missing From The Normal Docs
+
+- `chrome-compile` emits short local artifact names, but
+  `get-chrome-download-url.ts` uses version-suffixed `remotion.media` object
+  names.
+- `BrowserFetcher.ts` cares about internal zip folders and executable names,
+  not just whether a zip exists.
+- R2 upload uses the `parser-media` bucket behind `https://remotion.media/`,
+  with credentials in the Remotion checkout's `packages/remotion-media/.env`.
+- The implementation may continue in `remotion-dev/remotion` after binaries are
+  uploaded; do not assume the `chrome-compile` PR is the only handoff.
+- Chromium 151 can produce zero-byte `libEGL.so` and `libGLESv2.so`; this is
+  expected for these artifacts, and strip must skip empty files.
+
+## Current v151 Artifact Mapping
+
+For Chromium `151.0.7893.0`:
+
+| Local chrome-compile zip | Public remotion.media key |
+| --- | --- |
+| `output/chromium-headless-shell-linux64.zip` | `chromium-headless-shell-linux-x64-151.0.7893.0.zip` |
+| `output/chromium-headless-shell-linux-arm64.zip` | `chromium-headless-shell-linux-arm64-151.0.7893.0.zip` |
+| `output/chromium-headless-shell-amazon-linux2023-x64.zip` | `chromium-headless-shell-amazon-linux-x64-151.0.7893.0.zip` |
+| `output/chromium-headless-shell-amazon-linux2023-arm64.zip` | `chromium-headless-shell-amazon-linux-arm64-151.0.7893.0.zip` |
+
+## Expected Zip Layout
+
+| Variant | Top-level folder | Executable |
+| --- | --- | --- |
+| Linux x64 | `chrome-headless-shell-linux64/` | `chrome-headless-shell` |
+| Linux ARM64 | `chrome-headless-shell-linux-arm64/` | `headless_shell` |
+| Amazon Linux x64 | `chromium-headless-shell-amazon-linux2023-x64/` | `headless_shell` |
+| Amazon Linux ARM64 | `chromium-headless-shell-amazon-linux2023-arm64/` | `headless_shell` |
+
+Amazon Linux zips must bundle runtime libraries. At minimum:
+
+- x64: `libnss3.so`, `libnssutil3.so`, `libsoftokn3.so`, `libnspr4.so`,
+  `libplc4.so`, `libplds4.so`, `libfreebl3.so`, `libfreeblpriv3.so`,
+  `libexpat.so.1`, `libdbus-1.so.3`, `libsystemd.so.0`, `libgcc_s.so.1`.
+- ARM64: `libnss3.so`, `libnssutil3.so`, `libsoftokn3.so`, `libnspr4.so`,
+  `libplc4.so`, `libplds4.so`, `libgcc_s-14-20250110.so.1`,
+  `libdbus-1.so.3`, `libsystemd.so.0`.
+
+## Validation Command
+
+Run from `remotion-dev/chrome-compile`:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import zipfile
+
+version = "151.0.7893.0"
+artifacts = [
+    ("linux-x64", "output/chromium-headless-shell-linux64.zip",
+     f"chromium-headless-shell-linux-x64-{version}.zip",
+     "chrome-headless-shell-linux64/", "chrome-headless-shell",
+     ["libEGL.so", "libGLESv2.so", "libvk_swiftshader.so", "libvulkan.so.1", "vk_swiftshader_icd.json"]),
+    ("linux-arm64", "output/chromium-headless-shell-linux-arm64.zip",
+     f"chromium-headless-shell-linux-arm64-{version}.zip",
+     "chrome-headless-shell-linux-arm64/", "headless_shell",
+     ["libEGL.so", "libGLESv2.so", "libvk_swiftshader.so", "libvulkan.so.1", "vk_swiftshader_icd.json"]),
+    ("amazon-linux-x64", "output/chromium-headless-shell-amazon-linux2023-x64.zip",
+     f"chromium-headless-shell-amazon-linux-x64-{version}.zip",
+     "chromium-headless-shell-amazon-linux2023-x64/", "headless_shell",
+     ["libEGL.so", "libGLESv2.so", "libvk_swiftshader.so", "libvulkan.so.1", "vk_swiftshader_icd.json",
+      "libnss3.so", "libnssutil3.so", "libsoftokn3.so", "libnspr4.so", "libplc4.so", "libplds4.so",
+      "libfreebl3.so", "libfreeblpriv3.so", "libexpat.so.1", "libdbus-1.so.3", "libsystemd.so.0", "libgcc_s.so.1"]),
+    ("amazon-linux-arm64", "output/chromium-headless-shell-amazon-linux2023-arm64.zip",
+     f"chromium-headless-shell-amazon-linux-arm64-{version}.zip",
+     "chromium-headless-shell-amazon-linux2023-arm64/", "headless_shell",
+     ["libEGL.so", "libGLESv2.so", "libvk_swiftshader.so", "libvulkan.so.1", "vk_swiftshader_icd.json",
+      "libnss3.so", "libnssutil3.so", "libsoftokn3.so", "libnspr4.so", "libplc4.so", "libplds4.so",
+      "libgcc_s-14-20250110.so.1", "libdbus-1.so.3", "libsystemd.so.0"]),
+]
+
+for variant, local, key, folder, binary, required in artifacts:
+    path = Path(local)
+    if not path.exists():
+        raise SystemExit(f"missing {local}")
+    with zipfile.ZipFile(path) as z:
+        bad = z.testzip()
+        if bad:
+            raise SystemExit(f"{variant}: bad zip member {bad}")
+        names = set(z.namelist())
+        top = sorted({n.split("/")[0] for n in names if n})
+        if top != [folder.rstrip("/")]:
+            raise SystemExit(f"{variant}: unexpected top folders {top}")
+        missing = [folder + name for name in [binary, *required] if folder + name not in names]
+        if missing:
+            raise SystemExit(f"{variant}: missing {missing}")
+    print("ok", variant, local, "->", key)
+PY
+```
+
+## R2 Upload Pattern
+
+Use the upload-r2 skill when available. The key operational details are:
+
+```bash
+bun --env-file=<remotion-checkout>/packages/remotion-media/.env -e "<S3Client upload script>"
+```
+
+S3-compatible settings:
+
+- Endpoint: `https://2fe488b3b0f4deee223aef7464784c46.r2.cloudflarestorage.com`
+- Bucket: `parser-media`
+- Required env vars: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+
+Before upload, `curl -I https://remotion.media/<key>` should usually be `404`
+for a new version. After upload, require `HTTP 200` and matching
+`content-length`.
+
+## Remotion Handoff Notes
+
+When handing off to `remotion-dev/remotion`, include:
+
+- All uploaded URLs.
+- The Chrome version.
+- Whether `get-chrome-download-url.ts` was updated to point to them.
+- Whether `BrowserFetcher.ts` needs new `possibleSubdirs` entries.
+- Whether runtime testing passed in Remotion, not only zip validation.

--- a/.agents/skills/remotion-chromium-binary-release/references/release-checklist.md
+++ b/.agents/skills/remotion-chromium-binary-release/references/release-checklist.md
@@ -5,14 +5,59 @@
 - `chrome-compile` emits short local artifact names, but
   `get-chrome-download-url.ts` uses version-suffixed `remotion.media` object
   names.
+- The downloader diff is not only a version bump: it also routes Amazon Linux
+  2023 to custom `remotion.media` builds and falls back for older glibc.
 - `BrowserFetcher.ts` cares about internal zip folders and executable names,
-  not just whether a zip exists.
+  not just whether a zip exists. Custom Amazon Linux zip folders must be listed
+  in `possibleSubdirs` so extraction renames them into the cache path.
 - R2 upload uses the `parser-media` bucket behind `https://remotion.media/`,
   with credentials in the Remotion checkout's `packages/remotion-media/.env`.
 - The implementation may continue in `remotion-dev/remotion` after binaries are
   uploaded; do not assume the `chrome-compile` PR is the only handoff.
 - Chromium 151 can produce zero-byte `libEGL.so` and `libGLESv2.so`; this is
   expected for these artifacts, and strip must skip empty files.
+- Lambda layer rollout is a separate continuation track: update the layer
+  archive key, publish layers from the layer-hosting account, copy the emitted
+  region map into `hosted-layers.ts`, then test rendering from the consumer
+  account.
+
+## Current PR Continuation Handoff
+
+For Remotion PR 8697, continue from these touched areas:
+
+- `packages/renderer/src/browser/get-chrome-download-url.ts`
+  - `TESTED_VERSION` is `151.0.7893.0`.
+  - `PLAYWRIGHT_VERSION` is `1433`, matching Playwright's Chromium 151 entry.
+  - Amazon Linux 2023 `headless-shell` downloads use custom `remotion.media`
+    URLs for both `linux64` and `linux-arm64`.
+  - Non-Amazon Linux uses the custom Remotion binaries only when glibc is at
+    least `2.35`; older glibc falls back to Playwright or Chrome for Testing.
+- `packages/renderer/src/browser/BrowserFetcher.ts`
+  - `possibleSubdirs` must include the custom Amazon Linux zip folders:
+    `chromium-headless-shell-amazon-linux2023-arm64` and
+    `chromium-headless-shell-amazon-linux2023-x64`.
+  - Extraction should normalize those folders into
+    `chrome-headless-shell-<platform>` in the browser cache.
+- `packages/lambda/src/admin/make-layer-public.ts`
+  - The layer artifact key is `remotion-layer-${layer}-v20-arm64.zip`.
+  - Chromium license text should name `151.0.7893.0`.
+  - Publishing targets runtime `nodejs24.x`.
+- `packages/lambda/build.ts`
+  - Keep the esbuild target at `node24`; this was needed to keep the Lambda
+    function plus layers under AWS size limits for the v20 layer set.
+- `packages/lambda/src/shared/hosted-layers.ts`
+  - Do not hand-edit version increments. Replace it with the JSON emitted by
+    `make-layer-public.ts` after publishing.
+- `packages/example/testlambdaintegrations.mjs`
+  - Python still-render test uses `uv run testclient_render_still.py`.
+- Docs in `packages/docs/docs/lambda/*`,
+  `packages/docs/docs/miscellaneous/chrome-headless-shell.mdx`, and
+  `packages/docs/docs/renderer/ensure-browser.mdx` should describe the new
+  version and hosted binary behavior consistently.
+
+Before handing off, say which of these items are already complete, which still
+need validation, and which AWS account/region was used for the latest Lambda
+test.
 
 ## Current v151 Artifact Mapping
 

--- a/.agents/skills/update-chrome-binaries-test-region/SKILL.md
+++ b/.agents/skills/update-chrome-binaries-test-region/SKILL.md
@@ -9,9 +9,20 @@ description: Publish Remotion Lambda Chrome binaries to the eu-central-1 test re
 
 - Confirm the AWS CLI is logged into account `678892195805` by running `aws sts get-caller-identity`. If not, ask the user to log in.
 - Export AWS credentials into the shell by running `eval "$(aws configure export-credentials --format env)"`. The Lambda client checks for `AWS_ACCESS_KEY_ID` and does not pick up SSO or Identity Center credentials on its own.
+- Before publishing, update the `S3Key` in `packages/lambda/src/admin/make-layer-public.ts` to the uploaded layer artifact version, such as `remotion-layer-${layer}-v19-arm64.zip`.
 - From `packages/lambda`, run `bun src/admin/make-layer-public.ts --region=eu-central-1` to publish all 5 layers: fonts, chromium, emoji-apple, emoji-google, cjk.
 - The `eval` and the `bun` command must run in the same shell invocation because the env vars do not persist across shell calls.
 - Verify the output prints a `LayerArn` and `Version` for each of the 5 layers and a final JSON dump with the published regions populated.
+
+## Full regional rollout
+
+After the eu-central-1 Lambda render verification passes and the layer artifacts have been uploaded to every regional bucket, run the publisher from `packages/lambda` without `--region` to publish every supported region:
+
+```bash
+eval "$(aws configure export-credentials --format env)" && bun src/admin/make-layer-public.ts
+```
+
+Use the layer-hosting AWS account `678892195805` for publishing layers. If a single region must be skipped, use `--skip=<region>` and leave that region unchanged in `hosted-layers.ts`.
 
 ## Update hosted layers
 
@@ -50,5 +61,19 @@ The Dockerfiles install the local workspace build of `@remotion/cli` plus transi
 If a new composition is added to the Docker test matrix, register it in `packages/example/src/BrowserTestRoot.tsx` and add a corresponding `RUN remotion render /usr/app/bundle <id> /usr/app/<filename>.mp4` line plus `docker cp` extraction in `run.sh`.
 
 The `html-in-canvas` composition's runtime check in `packages/example/src/HtmlInCanvas/html-in-canvas.tsx` requires both `ctx.drawElementImage` and `canvas.requestPaint`, which Chrome 149+ exposes when `--enable-features=CanvasDrawElement` is passed. If `html-in-canvas` renders fail with `"HTML in Canvas is not supported"` while `browser-test` passes, the most likely cause is a Chrome version mismatch.
+
+## Lambda render verification
+
+Run `packages/example/runlambda.sh` after rebuilding the Lambda package/runtime. For the test-region render, explicitly use `--region=eu-central-1` and deploy the function with the largest current hosted-layer combination. For Chrome 151 v20, the default `cjk` combination is larger than `apple-emojis`; also run `apple-emojis` when validating emoji-specific layer coverage.
+
+The Lambda render test should run in the consumer/test AWS account, not the `678892195805` layer-hosting account. Load the AWS credentials from the main worktree's `packages/example/.env` before running `runlambda.sh`, and confirm `aws sts get-caller-identity` prints the expected consumer account.
+
+Make the test composition print `navigator.userAgent` into the video so the rendered output visibly confirms which Chrome version Lambda used.
+
+Because the Lambda function runs on `nodejs24.x`, keep the esbuild target in `packages/lambda/build.ts` aligned with Node 24. During the Chrome 151 test, targeting Node 16 made even the CJK layer combination exceed AWS's unzipped size limit by 3,067 bytes; targeting Node 24 saved enough for CJK to deploy. v20 layers also allowed the Apple emoji runtime preference to deploy and render successfully.
+
+If the Apple emoji preference fails at deploy time with AWS's `Function code combined with layers exceeds the maximum allowed size` error, record the exact overage as a release blocker for the largest layer combination. You can still rerun the same render with `RUNTIME_PREFERENCE=cjk` to verify the new Chrome layer itself.
+
+If site upload fails with `BlockPublicAcls`, verify the Lambda render test is using the consumer/test AWS account from the main worktree's `.env`. During the Chrome 151 test, this error happened when the render accidentally ran in the `678892195805` layer-hosting account and tried to upload a test site through that account's bucket ACL path.
 
 Do not proceed to publishing all regions until the test region has been verified end-to-end.

--- a/.agents/skills/update-chrome-binaries-test-region/SKILL.md
+++ b/.agents/skills/update-chrome-binaries-test-region/SKILL.md
@@ -9,7 +9,7 @@ description: Publish Remotion Lambda Chrome binaries to the eu-central-1 test re
 
 - Confirm the AWS CLI is logged into account `678892195805` by running `aws sts get-caller-identity`. If not, ask the user to log in.
 - Export AWS credentials into the shell by running `eval "$(aws configure export-credentials --format env)"`. The Lambda client checks for `AWS_ACCESS_KEY_ID` and does not pick up SSO or Identity Center credentials on its own.
-- Before publishing, update the `S3Key` in `packages/lambda/src/admin/make-layer-public.ts` to the uploaded layer artifact version, such as `remotion-layer-${layer}-v19-arm64.zip`.
+- Before publishing, update the `S3Key` in `packages/lambda/src/admin/make-layer-public.ts` to the uploaded layer artifact version, such as `remotion-layer-${layer}-v20-arm64.zip`.
 - From `packages/lambda`, run `bun src/admin/make-layer-public.ts --region=eu-central-1` to publish all 5 layers: fonts, chromium, emoji-apple, emoji-google, cjk.
 - The `eval` and the `bun` command must run in the same shell invocation because the env vars do not persist across shell calls.
 - Verify the output prints a `LayerArn` and `Version` for each of the 5 layers and a final JSON dump with the published regions populated.
@@ -64,7 +64,21 @@ The `html-in-canvas` composition's runtime check in `packages/example/src/HtmlIn
 
 ## Lambda render verification
 
-Run `packages/example/runlambda.sh` after rebuilding the Lambda package/runtime. For the test-region render, explicitly use `--region=eu-central-1` and deploy the function with the largest current hosted-layer combination. For Chrome 151 v20, the default `cjk` combination is larger than `apple-emojis`; also run `apple-emojis` when validating emoji-specific layer coverage.
+Use `packages/example/runlambda.sh` as the reference flow, but run the Lambda commands manually so the region and runtime preference are explicit. Rebuild the Lambda package/runtime, then deploy and render in the test region:
+
+```bash
+cd packages/example
+bunx turbo run make --filter=@remotion/lambda
+cd ../lambda
+bun run makeruntime
+cd ../example
+bunx remotion lambda functions rmall -f --region=eu-central-1
+bunx remotion lambda functions deploy --memory=2048 --disk=10000 --runtime-preference=cjk --region=eu-central-1
+bunx remotion lambda sites create --site-name=testbed-v6 --log=verbose --enable-folder-expiry --region=eu-central-1
+bunx remotion lambda render testbed-v6 NewVideo --log=verbose --delete-after="1-day" --region=eu-central-1
+```
+
+For Chrome 151 v20, the default `cjk` combination is larger than `apple-emojis`; also run a second deploy/render with `--runtime-preference=apple-emojis` when validating emoji-specific layer coverage.
 
 The Lambda render test should run in the consumer/test AWS account, not the `678892195805` layer-hosting account. Load the AWS credentials from the main worktree's `packages/example/.env` before running `runlambda.sh`, and confirm `aws sts get-caller-identity` prints the expected consumer account.
 

--- a/packages/docs/docs/lambda/custom-layers.mdx
+++ b/packages/docs/docs/lambda/custom-layers.mdx
@@ -29,24 +29,20 @@ With the default option (`--runtime-preference=cjk` or no option):
 
 | Item         | Size     |
 | ------------ | -------- |
-| chromium     | 196 MB   |
-| emoji-google | 9.9 MB   |
+| chromium     | 212.8 MB |
+| emoji-google | 4.8 MB   |
 | fonts        | 1.9 MB   |
-| cjk          | 16 MB    |
-| **Total**    | 223.8 MB |
+| cjk          | 14.1 MB  |
+| **Total**    | 233.6 MB |
 
 With the option [`--runtime-preference=apple-emojis`](/docs/lambda/deployfunction#runtimepreference):
 
 | Item        | Size     |
 | ----------- | -------- |
-| chromium    | 196 MB   |
-| emoji-apple | 45 MB    |
+| chromium    | 212.8 MB |
+| emoji-apple | 8.6 MB   |
 | fonts       | 1.9 MB   |
-| **Total**   | 242.9 MB |
-
-:::note
-Numbers are currently outdated since the last Chromium update.
-:::
+| **Total**   | 223.3 MB |
 
 :::note
 Note that by enabling the Apple Emojis, to stay under the 250 MB limit, support for CJK (Chinese, Japanese, Korean) characters will be removed.  

--- a/packages/docs/docs/lambda/runtime.mdx
+++ b/packages/docs/docs/lambda/runtime.mdx
@@ -63,6 +63,7 @@ The browser was compiled including the proprietary codecs, so you can include MP
 
 | Remotion version | Chrome version |
 | ---------------- | -------------- |
+| From 4.0.484     | 151.0.7893.0   |
 | From 4.0.452     | 149.0.7790.0   |
 | From 4.0.415     | 144.0.7559.20  |
 | From 4.0.274     | 133.0.6943.141 |

--- a/packages/docs/docs/miscellaneous/chrome-headless-shell.mdx
+++ b/packages/docs/docs/miscellaneous/chrome-headless-shell.mdx
@@ -82,7 +82,7 @@ node_modules/.remotion/chrome-headless-shell/VERSION
 node_modules/.remotion/chrome-for-testing/VERSION
 ```
 
-The file contains the Chrome version string, e.g. `149.0.7790.0`.
+The file contains the Chrome version string, e.g. `151.0.7893.0`.
 
 If the `VERSION` file is missing (e.g. when upgrading from an older version of Remotion) or does not match the expected version, Remotion will delete the existing browser and download the correct version.
 
@@ -138,6 +138,7 @@ Remotion will download a well-tested Chrome version:
 
 | Remotion version | Chrome version                    |
 | ---------------- | --------------------------------- |
+| From 4.0.484     | 151.0.7893.0                      |
 | From 4.0.452     | 149.0.7790.0                      |
 | From 4.0.414     | 144.0.7559.97                     |
 | From 4.0.315     | 134.0.6998.35 (skipped on Lambda) |

--- a/packages/docs/docs/renderer/ensure-browser.mdx
+++ b/packages/docs/docs/renderer/ensure-browser.mdx
@@ -23,7 +23,7 @@ await ensureBrowser({
     console.log('Downloading browser');
 
     return {
-      version: '149.0.7790.0',
+      version: '151.0.7893.0',
       onProgress: ({percent}) => {
         console.log(`${Math.round(percent * 100)}% downloaded`);
       },
@@ -67,7 +67,7 @@ const onBrowserDownload: OnBrowserDownload = () => {
 
   return {
     // Pass `null` to use Remotion's recommendation.
-    version: '149.0.7790.0',
+    version: '151.0.7893.0',
     onProgress,
   };
 };

--- a/packages/example/testlambdaintegrations.mjs
+++ b/packages/example/testlambdaintegrations.mjs
@@ -79,7 +79,7 @@ execSync(`php src/render.php`, {
 });
 
 console.log('=== Python(render still) ===');
-execSync(`python testclient_render_still.py`, {
+execSync(`uv run testclient_render_still.py`, {
 	env: {
 		// eslint-disable-next-line no-undef
 		...process.env,

--- a/packages/it-tests/src/monorepo/go-package.test.ts
+++ b/packages/it-tests/src/monorepo/go-package.test.ts
@@ -60,7 +60,7 @@ test(
 				logLevel: 'info',
 				maxRetries: 1,
 				muted: false,
-				numberOfGifLoops: 0,
+				numberOfGifLoops: null,
 				offthreadVideoCacheSizeInBytes: null,
 				offthreadVideoThreads: null,
 				outName: null,

--- a/packages/it-tests/src/monorepo/ruby-package.test.ts
+++ b/packages/it-tests/src/monorepo/ruby-package.test.ts
@@ -109,7 +109,7 @@ test('Render Media payload', async () => {
 			logLevel: 'info',
 			maxRetries: 1,
 			muted: false,
-			numberOfGifLoops: 0,
+			numberOfGifLoops: null,
 			offthreadVideoCacheSizeInBytes: null,
 			offthreadVideoThreads: null,
 			outName: null,

--- a/packages/lambda-go/internalops.go
+++ b/packages/lambda-go/internalops.go
@@ -134,7 +134,9 @@ func constructRenderInternals(options *RemotionOptions) (*renderInternalOptions,
 	} else {
 		internalParams.TimeoutInMilliseconds = options.TimeoutInMilliseconds
 	}
-	internalParams.NumberOfGifLoops = options.NumberOfGifLoops
+	if options.NumberOfGifLoops != 0 {
+		internalParams.NumberOfGifLoops = &options.NumberOfGifLoops
+	}
 
 	if options.DownloadBehavior == nil {
 		internalParams.DownloadBehavior = map[string]interface{}{

--- a/packages/lambda-go/models.go
+++ b/packages/lambda-go/models.go
@@ -82,7 +82,7 @@ type renderInternalOptions struct {
 	ChromiumOptions                interface{}            `json:"chromiumOptions"`
 	Scale                          int                    `json:"scale"`
 	EveryNthFrame                  int                    `json:"everyNthFrame"`
-	NumberOfGifLoops               int                    `json:"numberOfGifLoops"`
+	NumberOfGifLoops               *int                   `json:"numberOfGifLoops"`
 	ConcurrencyPerLambda           int                    `json:"concurrencyPerLambda"`
 	Concurrency                    *int                   `json:"concurrency"`
 	DownloadBehavior               map[string]interface{} `json:"downloadBehavior"`

--- a/packages/lambda-php-example/composer.lock
+++ b/packages/lambda-php-example/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22deb5d185d60acf68618421dd4e6b94",
+    "content-hash": "65c8b94ef94526833518bbee62e1942f",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -897,11 +897,11 @@
         },
         {
             "name": "remotion/lambda",
-            "version": "4.0.481",
+            "version": "4.0.483",
             "dist": {
                 "type": "path",
                 "url": "../lambda-php",
-                "reference": "44d1150a0318485a9370187c928e18988f9fb391"
+                "reference": "1a905ae7dd64153959f1e052e81e8542e87fd335"
             },
             "require": {
                 "aws/aws-sdk-php": "^3.269"
@@ -1340,5 +1340,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/packages/lambda-php-example/src/render.php
+++ b/packages/lambda-php-example/src/render.php
@@ -11,7 +11,7 @@ use Remotion\LambdaPhp\RenderParams;
 // Load environment variables
 // Use "unsafe" because AWS reads environment variables from getenv(), not $_ENV
 $dotenv = Dotenv::createUnsafeImmutable(__DIR__);
-$dotenv->load();
+$dotenv->safeLoad();
 
 // Specify the region you deployed to, for example "us-east-1"
 $region = getenv('REMOTION_APP_REGION');

--- a/packages/lambda-ruby/lib/remotion_lambda/render_media_on_lambda_payload.rb
+++ b/packages/lambda-ruby/lib/remotion_lambda/render_media_on_lambda_payload.rb
@@ -33,7 +33,7 @@ def get_render_media_on_lambda_payload(
   max_retries: 1,
   metadata: {},
   muted: false,
-  number_of_gif_loops: 0,
+  number_of_gif_loops: nil,
   offthread_video_cache_size_in_bytes: nil,
   media_cache_size_in_bytes: nil,
   offthread_video_threads: nil,

--- a/packages/lambda/build.ts
+++ b/packages/lambda/build.ts
@@ -1,8 +1,8 @@
-import fs, {cpSync, readdirSync} from 'node:fs';
-import path from 'node:path';
 import {BundlerInternals} from '@remotion/bundler';
 import {dir} from '@remotion/compositor-linux-arm64-gnu';
 import {$} from 'bun';
+import fs, {cpSync, readdirSync} from 'node:fs';
+import path from 'node:path';
 import {FUNCTION_ZIP_ARM64} from './src/shared/function-zip-path';
 
 const outdir = path.join(__dirname, `build-render`);
@@ -19,7 +19,7 @@ const template = require.resolve(
 
 await BundlerInternals.esbuild.build({
 	platform: 'node',
-	target: 'node16',
+	target: 'node24',
 	bundle: true,
 	outfile,
 	minify: true,

--- a/packages/lambda/src/admin/make-layer-public.ts
+++ b/packages/lambda/src/admin/make-layer-public.ts
@@ -102,12 +102,12 @@ const makeLayerPublic = async () => {
 				new PublishLayerVersionCommand({
 					Content: {
 						S3Bucket: getBucketName(region),
-						S3Key: `remotion-layer-${layer}-v18-arm64.zip`,
+						S3Key: `remotion-layer-${layer}-v20-arm64.zip`,
 					},
 					LayerName: layerName,
 					LicenseInfo:
 						layer === 'chromium'
-							? 'Chromium 149.0.7790.0, compiled from source. Read Chromium License: https://chromium.googlesource.com/chromium/src/+/refs/heads/main/LICENSE'
+							? 'Chromium 151.0.7893.0, compiled from source. Read Chromium License: https://chromium.googlesource.com/chromium/src/+/refs/heads/main/LICENSE'
 							: layer === 'emoji-apple'
 								? 'Apple Emojis (https://github.com/samuelngs/apple-emoji-linux). For educational purposes only - Apple is a trademark of Apple Inc., registered in the U.S. and other countries.'
 								: layer === 'emoji-google'

--- a/packages/lambda/src/shared/hosted-layers.ts
+++ b/packages/lambda/src/shared/hosted-layers.ts
@@ -16,621 +16,621 @@ export const hostedLayers: HostedLayers = {
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 26,
+			version: 27,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 30,
+			version: 31,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'ap-south-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 26,
+			version: 27,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 30,
+			version: 31,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-south-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'ap-southeast-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 26,
+			version: 27,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 30,
+			version: 31,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'ap-southeast-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 26,
+			version: 27,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 30,
+			version: 31,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'eu-central-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 64,
+			version: 67,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 64,
+			version: 67,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 26,
+			version: 29,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 26,
+			version: 29,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 26,
+			version: 29,
 		},
 	],
 	'eu-west-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 27,
+			version: 28,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 30,
+			version: 31,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'eu-west-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 26,
+			version: 27,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 30,
+			version: 31,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'us-east-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 31,
+			version: 32,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 39,
+			version: 40,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'us-east-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 26,
+			version: 27,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 30,
+			version: 31,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-east-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'us-west-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 26,
+			version: 27,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 30,
+			version: 31,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'af-south-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:af-south-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'ap-east-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-east-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'ap-northeast-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'ap-northeast-3': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-northeast-3:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'ca-central-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 22,
+			version: 23,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 22,
+			version: 23,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 13,
+			version: 14,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 13,
+			version: 14,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ca-central-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 13,
+			version: 14,
 		},
 	],
 	'eu-north-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-north-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'eu-south-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-south-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'eu-west-3': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-west-3:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'sa-east-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 22,
+			version: 23,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 22,
+			version: 23,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 13,
+			version: 14,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 13,
+			version: 14,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:sa-east-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 13,
+			version: 14,
 		},
 	],
 	'us-west-1': [
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 23,
+			version: 24,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 14,
+			version: 15,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:us-west-1:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 14,
+			version: 15,
 		},
 	],
 	'ap-southeast-4': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 11,
+			version: 12,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-4:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 10,
+			version: 11,
 		},
 	],
 	'ap-southeast-5': [
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:ap-southeast-5:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 10,
+			version: 11,
 		},
 	],
 	'eu-central-2': [
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-fonts-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-chromium-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-emoji-apple-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-emoji-google-arm64',
-			version: 10,
+			version: 11,
 		},
 		{
 			layerArn:
 				'arn:aws:lambda:eu-central-2:678892195805:layer:remotion-binaries-cjk-arm64',
-			version: 10,
+			version: 11,
 		},
 	],
 };

--- a/packages/renderer/src/browser/get-chrome-download-url.ts
+++ b/packages/renderer/src/browser/get-chrome-download-url.ts
@@ -4,10 +4,10 @@ import type {LogLevel} from '../log-level';
 import {Log} from '../logger';
 import type {ChromeMode} from '../options/chrome-mode';
 
-export const TESTED_VERSION = '149.0.7790.0';
-// https://github.com/microsoft/playwright/blame/e76ca6cba40c26bf22c19cf37398d2b9da9ed465/packages/playwright-core/browsers.json
+export const TESTED_VERSION = '151.0.7893.0';
+// https://github.com/microsoft/playwright/blob/main/packages/playwright-core/browsers.json
 // packages/playwright-core/browsers.json
-const PLAYWRIGHT_VERSION = '1421'; // 149.0.7790.0
+const PLAYWRIGHT_VERSION = '1433'; // 151.0.7893.0
 
 export type Platform =
 	| 'linux64'
@@ -108,7 +108,7 @@ export function getChromeDownloadUrl({
 		// Amazon Linux 2023 on arm64 needs a special build.
 		// This binary is compatible with older glibc (no 2.35 requirement).
 		if (isAmazonLinux2023() && chromeMode === 'headless-shell' && !version) {
-			return 'https://remotion.media/chromium-headless-shell-amazon-linux-arm64-149.0.7790.0.zip?clear';
+			return 'https://remotion.media/chromium-headless-shell-amazon-linux-arm64-151.0.7893.0.zip?clear';
 		}
 
 		if (chromeMode === 'chrome-for-testing') {
@@ -132,7 +132,7 @@ export function getChromeDownloadUrl({
 		// Amazon Linux 2023 needs a special build.
 		// This binary is compatible with older glibc (no 2.35 requirement).
 		if (isAmazonLinux2023() && platform === 'linux64' && !version) {
-			return `https://remotion.media/chromium-headless-shell-amazon-linux-x64-149.0.7790.0.zip?clear`;
+			return `https://remotion.media/chromium-headless-shell-amazon-linux-x64-151.0.7893.0.zip?clear`;
 		}
 
 		if (platform === 'linux64' && version === null) {


### PR DESCRIPTION
Stupid to merge this as I am going to vacation!
Let's wait. But it is fully ready.


## Summary

- Update Remotion's general Chrome Headless Shell download target to Chrome `151.0.7893.0` with Playwright revision `1433`
- Point the Linux and Amazon Linux 2023 browser download URLs at the uploaded `remotion.media` Chrome 151 binaries
- Update hosted Lambda layer versions to the Chrome 151 v20 layers across all supported regions
- Update the layer publisher metadata, Lambda Chrome runtime docs, custom layer size docs, Chrome Headless Shell docs, and `ensureBrowser()` examples
- Document the full regional rollout flow and the correct consumer-account Lambda render verification notes in the upgrade skill
- Target the Lambda runtime bundle at Node 24 to match the deployed Lambda runtime
- Fix Lambda integration test setup uncovered by the full `testlambda.mjs` run: Go/Ruby no longer send an unset GIF-only option for h264 renders, PHP example env loading works without a local `.env`, PHP lockfile matches the current package version, and Python still uses `uv run`

## Testing

- `curl -sI` for all four Chrome 151 `remotion.media` browser zips; each returned HTTP 200 with the expected content length
- `bun -e "import {TESTED_VERSION} from './packages/renderer/src/browser/get-chrome-download-url.ts'; console.log(TESTED_VERSION);"`
- `bunx turbo run make --filter=@remotion/renderer`
- `bunx oxfmt packages/renderer/src/browser/get-chrome-download-url.ts --check`
- `bunx prettier --check packages/docs/docs/miscellaneous/chrome-headless-shell.mdx packages/docs/docs/renderer/ensure-browser.mdx`
- `bunx oxfmt src --write` in `packages/lambda`
- `bun run build`
- `bun run stylecheck`
- `bunx prettier --check packages/docs/docs/lambda/runtime.mdx packages/docs/docs/lambda/custom-layers.mdx .agents/skills/update-chrome-binaries-test-region/SKILL.md`
- `git diff --check`
- `go test ./...` in `packages/lambda-go`
- `ruby -c packages/lambda-ruby/lib/remotion_lambda/render_media_on_lambda_payload.rb`
- `php -l packages/lambda-php-example/src/render.php`
- `php composer.phar validate --no-check-publish` in `packages/lambda-php-example` (passes with existing metadata warnings)
- `bun testlambda.mjs` in `packages/example` with the consumer AWS account from `/Users/jonathanburger/remotion/packages/example/.env`; completed all renders/integrations/performance runs. Performance timings: `[22615, 15278, 13216, 14009, 13912]` ms
- `bunx remotion lambda render testbed-v6 browser-test --log=verbose --delete-after="1-day" --region=us-east-1` in `packages/example` with the consumer AWS account; completed the WebGL/Three.js browser smoke render. Output: `https://s3.us-east-1.amazonaws.com/remotionlambda-sd60tlwje7/renders/1-day-zpipa5quwi/out.mp4`
- GitHub `Install and Test` run `28248289788` passed on latest PR head `8dbf32cda0`

## Notes

The four standalone Chrome 151 browser zips are now uploaded to `remotion.media` and wired into `@remotion/renderer` where applicable. The Linux x64/arm64 URLs are used for compatible glibc environments, and the Amazon Linux 2023 x64/arm64 URLs are used for the AL2023 special-case builds.
