### PR TITLE
`@remotion/studio`: Prevent marquee selection while dragging timeline handles

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineInOutPointerHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineInOutPointerHandle.tsx
@@ -2,6 +2,7 @@ import React, {createRef, useContext, useMemo} from 'react';
 import {useVideoConfig} from 'remotion';
 import {LIGHT_TRANSPARENT} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
+import {TIMELINE_SCRUBBER_ATTR} from './TimelineSelection';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
 const line: React.CSSProperties = {
@@ -51,6 +52,7 @@ const InnerTimelineInOutPointerHandle: React.FC<
 			ref={type === 'in' ? inPointerHandle : outPointerHandle}
 			style={style}
 			onPointerDown={onPointerDown}
+			{...{[TIMELINE_SCRUBBER_ATTR]: true}}
 		/>
 	);
 };


### PR DESCRIPTION
## Summary
- Mark timeline in/out drag handles as scrubber elements so marquee selection ignores pointer-downs on them
- Prevent marquee selection from starting while moving the active working area handles

## Testing
- `cd packages/studio && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck` *(fails in unrelated `template-react-router#lint`: generated React Router types require a `GetAnnotations` type argument)*
