### PR TITLE
`@remotion/studio`: Add color picker eyedropper shortcut

### DIFF
--- a/packages/studio/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/studio/src/components/ColorPicker/ColorPicker.tsx
@@ -1,6 +1,9 @@
 import {PlayerInternals} from '@remotion/player';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
+import {formatRgba} from '../../helpers/color-conversion';
+import {LIGHT_TEXT} from '../../helpers/colors';
+import {EyedropperIcon} from '../../icons/eyedropper';
 import {HigherZIndex, useZIndex} from '../../state/z-index';
 import {MENU_INITIATOR_CLASSNAME} from '../Menu/is-menu-item';
 import {getPortal} from '../Menu/portals';
@@ -17,7 +20,12 @@ import {
 	CHECKER_BACKGROUND_POSITION,
 	CHECKER_BACKGROUND_SIZE,
 } from './checker';
-import {ColorPickerPopup, POPUP_WIDTH} from './ColorPickerPopup';
+import {
+	ColorPickerPopup,
+	POPUP_WIDTH,
+	hasEyeDropper,
+	parseEyeDropperColor,
+} from './ColorPickerPopup';
 
 // Class name used to opt the swatch button out of the global
 // `button:focus` inset box-shadow defined in inject-css.ts.
@@ -42,6 +50,25 @@ const fillStyle: React.CSSProperties = {
 	position: 'absolute',
 	inset: 0,
 	display: 'block',
+};
+
+const controlStyle: React.CSSProperties = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: 3,
+	flex: '0 0 auto',
+};
+
+const eyedropperButtonBaseStyle: React.CSSProperties = {
+	background: 'transparent',
+	border: 'none',
+	padding: 0,
+	margin: 0,
+	color: LIGHT_TEXT,
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	flex: '0 0 auto',
 };
 
 type Props = {
@@ -105,6 +132,30 @@ export const ColorPicker: React.FC<Props> = ({
 		};
 	}, [borderRadius, customStyle, disabled, height, width]);
 
+	const eyedropperButtonSize = Math.max(15, Math.min(28, height));
+	const eyedropperIconSize = Math.max(
+		12,
+		Math.min(18, eyedropperButtonSize - 2),
+	);
+
+	const eyedropperButtonStyle: React.CSSProperties = useMemo(() => {
+		return {
+			...eyedropperButtonBaseStyle,
+			width: eyedropperButtonSize,
+			height: eyedropperButtonSize,
+			cursor: disabled ? 'not-allowed' : 'pointer',
+			opacity: disabled ? 0.5 : 1,
+		};
+	}, [disabled, eyedropperButtonSize]);
+
+	const eyedropperIconStyle: React.CSSProperties = useMemo(() => {
+		return {
+			width: eyedropperIconSize,
+			height: eyedropperIconSize,
+			pointerEvents: 'none',
+		};
+	}, [eyedropperIconSize]);
+
 	// Toggle on pointerdown (matches Combobox) so the state flips before the
 	// HigherZIndex outside-click detection runs on pointerup. If we toggled in
 	// onClick, the popup would close in pointerup and immediately re-open in
@@ -146,6 +197,39 @@ export const ColorPicker: React.FC<Props> = ({
 			});
 		},
 		[disabled, refresh],
+	);
+
+	const onPickWithEyeDropper = useCallback(() => {
+		if (disabled) {
+			return;
+		}
+
+		const Ctor = (
+			window as unknown as {
+				EyeDropper?: new () => {open: () => Promise<{sRGBHex: string}>};
+			}
+		).EyeDropper;
+		if (!Ctor) {
+			return;
+		}
+
+		setOpened(false);
+		const dropper = new Ctor();
+		dropper
+			.open()
+			.then((result) => {
+				onChangeComplete(formatRgba(parseEyeDropperColor(result.sRGBHex)));
+			})
+			.catch(() => {
+				// Aborted; ignore.
+			});
+	}, [disabled, onChangeComplete]);
+
+	const onEyeDropperPointerDown = useCallback(
+		(e: React.PointerEvent<HTMLButtonElement>) => {
+			e.stopPropagation();
+		},
+		[],
 	);
 
 	const portalStyle = useMemo((): React.CSSProperties | null => {
@@ -199,24 +283,42 @@ export const ColorPicker: React.FC<Props> = ({
 		return () => window.removeEventListener('blur', onWindowBlur);
 	}, [opened]);
 
+	const showEyeDropper = hasEyeDropper();
+
 	return (
 		<>
-			<button
-				ref={triggerRef}
-				type="button"
-				className={[MENU_INITIATOR_CLASSNAME, SWATCH_CLASSNAME, className]
-					.filter(Boolean)
-					.join(' ')}
-				disabled={disabled}
-				name={name}
-				title={title ?? value}
-				tabIndex={tabIndex}
-				style={swatchStyle}
-				onPointerDown={onTriggerPointerDown}
-				onClick={onTriggerClick}
-			>
-				<span style={swatchFill} />
-			</button>
+			<span style={controlStyle}>
+				<button
+					ref={triggerRef}
+					type="button"
+					className={[MENU_INITIATOR_CLASSNAME, SWATCH_CLASSNAME, className]
+						.filter(Boolean)
+						.join(' ')}
+					disabled={disabled}
+					name={name}
+					title={title ?? value}
+					tabIndex={tabIndex}
+					style={swatchStyle}
+					onPointerDown={onTriggerPointerDown}
+					onClick={onTriggerClick}
+				>
+					<span style={swatchFill} />
+				</button>
+				{showEyeDropper ? (
+					<button
+						type="button"
+						disabled={disabled}
+						style={eyedropperButtonStyle}
+						onPointerDown={onEyeDropperPointerDown}
+						onClick={onPickWithEyeDropper}
+						tabIndex={tabIndex}
+						title="Pick color from screen"
+						aria-label="Pick color from screen"
+					>
+						<EyedropperIcon style={eyedropperIconStyle} color="currentColor" />
+					</button>
+				) : null}
+			</span>
 			{portalStyle
 				? ReactDOM.createPortal(
 						<div style={fullScreenOverlay}>

--- a/packages/studio/src/components/ColorPicker/ColorPickerPopup.tsx
+++ b/packages/studio/src/components/ColorPicker/ColorPickerPopup.tsx
@@ -118,7 +118,7 @@ const eyedropperButtonStyle: React.CSSProperties = {
 	flex: '0 0 auto',
 };
 
-const hasEyeDropper = (): boolean =>
+export const hasEyeDropper = (): boolean =>
 	typeof window !== 'undefined' && 'EyeDropper' in window;
 
 export const parseEyeDropperColor = (pickedColor: string) => {


### PR DESCRIPTION
## Summary

- Adds a direct eyedropper button next to Studio color picker swatches.
- Reuses the existing color picker EyeDropper parsing path and keeps picked colors fully opaque.
- Stops pointerdown propagation on the shortcut button so selecting a color does not deselect the current Studio item.

Closes #8426.

## Test plan

- `bunx oxfmt src --write` in `packages/studio`
- `bun run build`
- `bun run stylecheck`
