### PR TITLE
`@remotion/studio`: Remove Timing Editor shortcuts

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -100,7 +100,6 @@ const config: Config = {
 						{to: 'blog', label: 'Blog'},
 						{to: 'showcase', label: 'Showcase'},
 						{to: 'https://remotion.dev/convert', label: 'Convert a video'},
-						{to: 'https://remotion.dev/timing-editor', label: 'Timing Editor'},
 						{to: '/docs/support', label: 'Support'},
 						{to: '/templates', label: 'Templates'},
 					],

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -745,20 +745,6 @@ export const useMenuStructure = (
 								quickSwitcherLabel: 'Show Color Picker',
 							}
 						: null,
-					{
-						id: 'spring-editor',
-						value: 'spring-editor',
-						label: 'Timing Editor',
-						onClick: () => {
-							closeMenu();
-							window.open('https://www.remotion.dev/timing-editor', '_blank');
-						},
-						leftItem: null,
-						keyHint: null,
-						subMenu: null,
-						type: 'item' as const,
-						quickSwitcherLabel: 'Open spring() Editor',
-					},
 					readOnlyStudio || remotion_packageManager === 'unknown'
 						? null
 						: {


### PR DESCRIPTION
## Summary

- remove the Timing Editor item from the Studio menu / quick switcher
- remove the Timing Editor link from the docs Resources navbar dropdown

## Testing

- `bunx oxfmt packages/studio/src/helpers/use-menu-structure.tsx packages/docs/docusaurus.config.ts --write`
- `bun run build`
- `bun run stylecheck`
