### PR TITLE
`@remotion/studio`: Add inline composition renaming in the inspector

### DIFF
--- a/packages/studio/src/components/CurrentComposition.tsx
+++ b/packages/studio/src/components/CurrentComposition.tsx
@@ -4,11 +4,11 @@ import type {OriginalPosition} from '../error-overlay/react-overlay/utils/get-so
 import {isCompositionStill} from '../helpers/is-composition-still';
 import {openOriginalPositionInEditor} from '../helpers/open-in-editor';
 import {renderFrame} from '../state/render-frame';
+import {InlineCompositionName} from './InlineCompositionName';
 import {
 	INSPECTOR_INFO_HEADER_MIN_HEIGHT,
 	InspectorInfoHeader,
 	InspectorInfoSubtitle,
-	InspectorInfoTitle,
 } from './InspectorInfoHeader';
 import {InspectorSourceLocation} from './InspectorSourceLocation';
 import {showNotification} from './Notifications/NotificationCenter';
@@ -60,7 +60,12 @@ export const CurrentComposition = () => {
 		<InspectorInfoHeader>
 			{video ? (
 				<>
-					<InspectorInfoTitle>{video.id}</InspectorInfoTitle>
+					<InlineCompositionName
+						key={video.id}
+						compositionId={video.id}
+						stack={currentComposition?.stack ?? null}
+						compositions={compositions}
+					/>
 					<InspectorSourceLocation
 						location={validatedLocation}
 						canOpen={validatedLocation !== null}

--- a/packages/studio/src/components/InlineCompositionName.tsx
+++ b/packages/studio/src/components/InlineCompositionName.tsx
@@ -135,7 +135,16 @@ export const InlineCompositionName: React.FC<{
 				signal: new AbortController().signal,
 				symbolicatedStack,
 			})
-				.then(() => {
+				.then((result) => {
+					if (!result.success) {
+						setValue(compositionId);
+						notification.replaceContent(
+							`Could not rename composition: ${result.reason}`,
+							2000,
+						);
+						return;
+					}
+
 					notification.replaceContent(`Renamed to ${newId}`, 2000);
 				})
 				.catch((err) => {

--- a/packages/studio/src/components/InlineCompositionName.tsx
+++ b/packages/studio/src/components/InlineCompositionName.tsx
@@ -1,0 +1,258 @@
+import type * as React from 'react';
+import type {ChangeEventHandler, KeyboardEventHandler} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import type {_InternalTypes} from 'remotion';
+import {CLEAR_HOVER, INPUT_BACKGROUND} from '../helpers/colors';
+import {resolvedStackToSymbolicated} from '../helpers/resolved-stack-to-symbolicated';
+import {useRenameComposition} from '../helpers/use-rename-composition';
+import {showNotification} from './Notifications/NotificationCenter';
+import {useResolvedStack} from './Timeline/use-resolved-stack';
+
+const titleWrapper: React.CSSProperties = {
+	boxSizing: 'border-box',
+	color: 'white',
+	fontSize: 12,
+	height: 18,
+	lineHeight: '18px',
+	marginLeft: -4,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+	width: 'calc(100% + 4px)',
+};
+
+const titleInner: React.CSSProperties = {
+	borderRadius: 4,
+	boxSizing: 'border-box',
+	display: 'inline-grid',
+	fontSize: 12,
+	lineHeight: '18px',
+	maxWidth: '100%',
+	paddingLeft: 4,
+	paddingRight: 4,
+	verticalAlign: 'top',
+};
+
+const titleGridItem: React.CSSProperties = {
+	fontSize: 12,
+	gridArea: '1 / 1',
+	minWidth: 0,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+};
+
+const titleInput: React.CSSProperties = {
+	appearance: 'none',
+	backgroundColor: 'transparent',
+	border: 'none',
+	boxShadow: 'none',
+	color: 'white',
+	fontFamily: 'inherit',
+	fontSize: 12,
+	height: 18,
+	lineHeight: '18px',
+	margin: 0,
+	minWidth: 0,
+	outline: 'none',
+	overflow: 'hidden',
+	padding: 0,
+	WebkitAppearance: 'none',
+	width: '100%',
+};
+
+export const InlineCompositionName: React.FC<{
+	readonly compositionId: string;
+	readonly stack: string | null;
+	readonly compositions: _InternalTypes['AnyComposition'][];
+}> = ({compositionId, stack, compositions}) => {
+	const [isEditing, setIsEditing] = useState(false);
+	const [isHovered, setIsHovered] = useState(false);
+	const canRename = !window.remotion_isReadOnlyStudio;
+	const [value, setValue] = useState(compositionId);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const valueRef = useRef(value);
+	const isEditingRef = useRef(isEditing);
+	const isCommittingRef = useRef(false);
+	const cancelledRef = useRef(false);
+	const resolvedLocation = useResolvedStack(stack);
+	const symbolicatedStack = useMemo(
+		() => resolvedStackToSymbolicated(resolvedLocation),
+		[resolvedLocation],
+	);
+	const {getValidationMessage, renameComposition} = useRenameComposition({
+		compositions,
+		currentId: compositionId,
+		newId: value,
+	});
+
+	useEffect(() => {
+		valueRef.current = value;
+	}, [value]);
+
+	useEffect(() => {
+		isEditingRef.current = isEditing;
+	}, [isEditing]);
+
+	useEffect(() => {
+		if (isEditing) {
+			return;
+		}
+
+		setValue(compositionId);
+	}, [compositionId, isEditing]);
+
+	useEffect(() => {
+		if (!isEditing) {
+			return;
+		}
+
+		const input = inputRef.current;
+		if (!input) {
+			return;
+		}
+
+		input.focus();
+		input.select();
+	}, [isEditing]);
+
+	const commit = useCallback(() => {
+		if (
+			!isEditingRef.current ||
+			cancelledRef.current ||
+			isCommittingRef.current
+		) {
+			return;
+		}
+
+		const newId = valueRef.current;
+		isEditingRef.current = false;
+		setIsEditing(false);
+
+		if (newId === compositionId) {
+			return;
+		}
+
+		const compNameErrMessage = getValidationMessage(newId);
+		if (compNameErrMessage) {
+			showNotification(compNameErrMessage, 2000);
+			setValue(compositionId);
+
+			return;
+		}
+
+		if (!stack || !symbolicatedStack) {
+			showNotification(
+				'Could not determine where this composition is defined',
+				2000,
+			);
+			setValue(compositionId);
+
+			return;
+		}
+
+		isCommittingRef.current = true;
+		const notification = showNotification('Renaming...', null);
+
+		renameComposition({
+			newCompositionId: newId,
+			signal: new AbortController().signal,
+			symbolicatedStack,
+		})
+			.then(() => {
+				notification.replaceContent(`Renamed to ${newId}`, 2000);
+			})
+			.catch((err) => {
+				isCommittingRef.current = false;
+				setValue(compositionId);
+
+				notification.replaceContent(
+					`Could not rename composition: ${(err as Error).message}`,
+					2000,
+				);
+			});
+	}, [
+		compositionId,
+		getValidationMessage,
+		renameComposition,
+		stack,
+		symbolicatedStack,
+	]);
+
+	const startEditing = useCallback(() => {
+		if (!canRename) {
+			return;
+		}
+
+		cancelledRef.current = false;
+		isCommittingRef.current = false;
+		setValue(compositionId);
+		setIsEditing(true);
+	}, [canRename, compositionId]);
+
+	const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
+		valueRef.current = e.target.value;
+		setValue(e.target.value);
+	}, []);
+
+	const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+		(e) => {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				inputRef.current?.blur();
+			}
+
+			if (e.key === 'Escape') {
+				e.preventDefault();
+				cancelledRef.current = true;
+				isEditingRef.current = false;
+				setValue(compositionId);
+				setIsEditing(false);
+			}
+		},
+		[compositionId],
+	);
+
+	const backgroundColor = isEditing
+		? INPUT_BACKGROUND
+		: isHovered && canRename
+			? CLEAR_HOVER
+			: 'transparent';
+
+	return (
+		<div style={titleWrapper} title={compositionId}>
+			<span
+				style={{
+					...titleInner,
+					backgroundColor,
+					cursor: isEditing ? 'text' : 'default',
+					userSelect: isEditing ? 'text' : 'none',
+					width: isEditing ? '100%' : undefined,
+				}}
+				onMouseEnter={() => setIsHovered(true)}
+				onMouseLeave={() => setIsHovered(false)}
+				onClick={isEditing || !canRename ? undefined : startEditing}
+			>
+				<span
+					aria-hidden={isEditing}
+					style={{
+						...titleGridItem,
+						visibility: isEditing ? 'hidden' : 'visible',
+					}}
+				>
+					{compositionId}
+				</span>
+				{isEditing ? (
+					<input
+						ref={inputRef}
+						style={{...titleGridItem, ...titleInput}}
+						value={value}
+						onChange={onChange}
+						onBlur={commit}
+						onKeyDown={onKeyDown}
+					/>
+				) : null}
+			</span>
+		</div>
+	);
+};

--- a/packages/studio/src/components/InlineCompositionName.tsx
+++ b/packages/studio/src/components/InlineCompositionName.tsx
@@ -1,6 +1,10 @@
 import type * as React from 'react';
-import type {ChangeEventHandler, KeyboardEventHandler} from 'react';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import type {
+	ChangeEventHandler,
+	FocusEventHandler,
+	KeyboardEventHandler,
+} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {CLEAR_HOVER, INPUT_BACKGROUND} from '../helpers/colors';
 import {resolvedStackToSymbolicated} from '../helpers/resolved-stack-to-symbolicated';
@@ -71,9 +75,6 @@ export const InlineCompositionName: React.FC<{
 	const canRename = !window.remotion_isReadOnlyStudio;
 	const [value, setValue] = useState(compositionId);
 	const inputRef = useRef<HTMLInputElement>(null);
-	const valueRef = useRef(value);
-	const isEditingRef = useRef(isEditing);
-	const isCommittingRef = useRef(false);
 	const cancelledRef = useRef(false);
 	const resolvedLocation = useResolvedStack(stack);
 	const symbolicatedStack = useMemo(
@@ -86,98 +87,74 @@ export const InlineCompositionName: React.FC<{
 		newId: value,
 	});
 
-	useEffect(() => {
-		valueRef.current = value;
-	}, [value]);
+	const focusInput = useCallback((input: HTMLInputElement | null) => {
+		inputRef.current = input;
 
-	useEffect(() => {
-		isEditingRef.current = isEditing;
-	}, [isEditing]);
-
-	useEffect(() => {
-		if (isEditing) {
-			return;
-		}
-
-		setValue(compositionId);
-	}, [compositionId, isEditing]);
-
-	useEffect(() => {
-		if (!isEditing) {
-			return;
-		}
-
-		const input = inputRef.current;
 		if (!input) {
 			return;
 		}
 
 		input.focus();
 		input.select();
-	}, [isEditing]);
+	}, []);
 
-	const commit = useCallback(() => {
-		if (
-			!isEditingRef.current ||
-			cancelledRef.current ||
-			isCommittingRef.current
-		) {
-			return;
-		}
+	const commit = useCallback(
+		(newId: string) => {
+			if (cancelledRef.current) {
+				return;
+			}
 
-		const newId = valueRef.current;
-		isEditingRef.current = false;
-		setIsEditing(false);
+			setIsEditing(false);
 
-		if (newId === compositionId) {
-			return;
-		}
+			if (newId === compositionId) {
+				return;
+			}
 
-		const compNameErrMessage = getValidationMessage(newId);
-		if (compNameErrMessage) {
-			showNotification(compNameErrMessage, 2000);
-			setValue(compositionId);
-
-			return;
-		}
-
-		if (!stack || !symbolicatedStack) {
-			showNotification(
-				'Could not determine where this composition is defined',
-				2000,
-			);
-			setValue(compositionId);
-
-			return;
-		}
-
-		isCommittingRef.current = true;
-		const notification = showNotification('Renaming...', null);
-
-		renameComposition({
-			newCompositionId: newId,
-			signal: new AbortController().signal,
-			symbolicatedStack,
-		})
-			.then(() => {
-				notification.replaceContent(`Renamed to ${newId}`, 2000);
-			})
-			.catch((err) => {
-				isCommittingRef.current = false;
+			const compNameErrMessage = getValidationMessage(newId);
+			if (compNameErrMessage) {
+				showNotification(compNameErrMessage, 2000);
 				setValue(compositionId);
 
-				notification.replaceContent(
-					`Could not rename composition: ${(err as Error).message}`,
+				return;
+			}
+
+			if (!stack || !symbolicatedStack) {
+				showNotification(
+					'Could not determine where this composition is defined',
 					2000,
 				);
-			});
-	}, [
-		compositionId,
-		getValidationMessage,
-		renameComposition,
-		stack,
-		symbolicatedStack,
-	]);
+				setValue(compositionId);
+
+				return;
+			}
+
+			const notification = showNotification('Renaming...', null);
+
+			renameComposition({
+				newCompositionId: newId,
+				signal: new AbortController().signal,
+				symbolicatedStack,
+			})
+				.then(() => {
+					notification.replaceContent(`Renamed to ${newId}`, 2000);
+				})
+				.catch((err) => {
+					setValue(compositionId);
+
+					notification.replaceContent(
+						`Could not rename composition: ${(err as Error).message}`,
+						2000,
+					);
+				});
+		},
+		[
+			compositionId,
+			getValidationMessage,
+			renameComposition,
+			stack,
+			symbolicatedStack,
+		],
+	);
 
 	const startEditing = useCallback(() => {
 		if (!canRename) {
@@ -185,15 +162,20 @@ export const InlineCompositionName: React.FC<{
 		}
 
 		cancelledRef.current = false;
-		isCommittingRef.current = false;
 		setValue(compositionId);
 		setIsEditing(true);
 	}, [canRename, compositionId]);
 
 	const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
-		valueRef.current = e.target.value;
 		setValue(e.target.value);
 	}, []);
+
+	const onBlur: FocusEventHandler<HTMLInputElement> = useCallback(
+		(e) => {
+			commit(e.currentTarget.value);
+		},
+		[commit],
+	);
 
 	const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
 		(e) => {
@@ -205,7 +187,6 @@ export const InlineCompositionName: React.FC<{
 			if (e.key === 'Escape') {
 				e.preventDefault();
 				cancelledRef.current = true;
-				isEditingRef.current = false;
 				setValue(compositionId);
 				setIsEditing(false);
 			}
@@ -244,11 +225,11 @@ export const InlineCompositionName: React.FC<{
 				</span>
 				{isEditing ? (
 					<input
-						ref={inputRef}
+						ref={focusInput}
 						style={{...titleGridItem, ...titleInput}}
 						value={value}
 						onChange={onChange}
-						onBlur={commit}
+						onBlur={onBlur}
 						onKeyDown={onKeyDown}
 					/>
 				) : null}

--- a/packages/studio/src/components/NewComposition/RenameComposition.tsx
+++ b/packages/studio/src/components/NewComposition/RenameComposition.tsx
@@ -1,15 +1,13 @@
-import type {RecastCodemod} from '@remotion/studio-shared';
 import type {ChangeEventHandler} from 'react';
 import React, {
 	useCallback,
 	useContext,
 	useEffect,
-	useMemo,
 	useRef,
 	useState,
 } from 'react';
 import {Internals} from 'remotion';
-import {validateCompositionName} from '../../helpers/validate-new-comp-data';
+import {useRenameComposition} from '../../helpers/use-rename-composition';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
 import {ModalHeader} from '../ModalHeader';
@@ -59,20 +57,15 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 		[],
 	);
 
-	const compNameErrMessage =
-		newId === resolved.result.id
-			? null
-			: validateCompositionName(newId, compositions);
-
-	const valid = compNameErrMessage === null && resolved.result.id !== newId;
-
-	const codemod: RecastCodemod = useMemo(() => {
-		return {
-			type: 'rename-composition',
-			idToRename: resolved.result.id,
-			newId,
-		};
-	}, [newId, resolved.result.id]);
+	const {
+		codemod,
+		valid,
+		validationMessage: compNameErrMessage,
+	} = useRenameComposition({
+		compositions,
+		currentId: resolved.result.id,
+		newId,
+	});
 
 	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((e) => {
 		e.preventDefault();

--- a/packages/studio/src/helpers/use-rename-composition.ts
+++ b/packages/studio/src/helpers/use-rename-composition.ts
@@ -1,0 +1,78 @@
+import type {
+	RecastCodemod,
+	SymbolicatedStackFrame,
+} from '@remotion/studio-shared';
+import {useCallback, useMemo} from 'react';
+import type {_InternalTypes} from 'remotion';
+import {applyCodemod} from '../components/RenderQueue/actions';
+import {validateCompositionName} from './validate-new-comp-data';
+
+export const useRenameComposition = ({
+	compositions,
+	currentId,
+	newId,
+}: {
+	compositions: _InternalTypes['AnyComposition'][];
+	currentId: string;
+	newId: string;
+}) => {
+	const getValidationMessage = useCallback(
+		(value: string) => {
+			if (value === currentId) {
+				return null;
+			}
+
+			return validateCompositionName(value, compositions);
+		},
+		[compositions, currentId],
+	);
+
+	const getCodemod = useCallback(
+		(value: string): RecastCodemod => {
+			return {
+				type: 'rename-composition',
+				idToRename: currentId,
+				newId: value,
+			};
+		},
+		[currentId],
+	);
+
+	const validationMessage = useMemo(() => {
+		return getValidationMessage(newId);
+	}, [getValidationMessage, newId]);
+
+	const codemod = useMemo(() => {
+		return getCodemod(newId);
+	}, [getCodemod, newId]);
+
+	const valid = validationMessage === null && currentId !== newId;
+
+	const renameComposition = useCallback(
+		({
+			newCompositionId,
+			signal,
+			symbolicatedStack,
+		}: {
+			newCompositionId: string;
+			signal: AbortSignal;
+			symbolicatedStack: SymbolicatedStackFrame | null;
+		}) => {
+			return applyCodemod({
+				codemod: getCodemod(newCompositionId),
+				dryRun: false,
+				signal,
+				symbolicatedStack,
+			});
+		},
+		[getCodemod],
+	);
+
+	return {
+		codemod,
+		getValidationMessage,
+		renameComposition,
+		valid,
+		validationMessage,
+	};
+};


### PR DESCRIPTION
## Summary
- Add inline renaming for the current composition title in the Studio inspector
- Share composition rename validation/codemod/apply logic through `useRenameComposition`
- Reuse the shared rename logic in the existing rename composition modal

Fixes #8460

## Testing
- `bunx oxfmt packages/studio/src --write`
- `bun run build`
- `bun run stylecheck`
