### PR TITLE
`@remotion/studio`: Redirect after renaming composition

### DIFF
--- a/packages/studio/src/components/NewComposition/CodemodFooter.tsx
+++ b/packages/studio/src/components/NewComposition/CodemodFooter.tsx
@@ -1,4 +1,8 @@
-import type {RecastCodemod} from '@remotion/studio-shared';
+import type {
+	ApplyCodemodResponse,
+	RecastCodemod,
+	SymbolicatedStackFrame,
+} from '@remotion/studio-shared';
 import React, {
 	useCallback,
 	useContext,
@@ -13,13 +17,48 @@ import {ModalsContext} from '../../state/modals';
 import {Flex, Row, Spacing} from '../layout';
 import {ModalButton} from '../ModalButton';
 import {showNotification} from '../Notifications/NotificationCenter';
-import {applyCodemod} from '../RenderQueue/actions';
+import {applyCodemod as applyCodemodApi} from '../RenderQueue/actions';
 import {
 	hasResolvedStack,
 	useResolvedStack,
 } from '../Timeline/use-resolved-stack';
 import type {CodemodStatus} from './DiffPreview';
 import {CodemodDiffPreview} from './DiffPreview';
+
+type ApplyCodemodAction = (options: {
+	signal: AbortSignal;
+	symbolicatedStack: SymbolicatedStackFrame | null;
+}) => Promise<ApplyCodemodResponse>;
+
+const CodemodFooterPresentation: React.FC<{
+	readonly codemodStatus: CodemodStatus;
+	readonly disabled: boolean;
+	readonly genericSubmitLabel: string;
+	readonly relativeFilePath: string | null;
+	readonly submitLabel: (options: {relativeRootPath: string}) => string;
+	readonly trigger: () => void;
+}> = ({
+	codemodStatus,
+	disabled,
+	genericSubmitLabel,
+	relativeFilePath,
+	submitLabel,
+	trigger,
+}) => {
+	return (
+		<Row align="center">
+			<CodemodDiffPreview status={codemodStatus} />
+			<Flex />
+			<Spacing block x={2} />
+			<ModalButton onClick={trigger} disabled={disabled}>
+				{relativeFilePath
+					? submitLabel({relativeRootPath: relativeFilePath})
+					: genericSubmitLabel}
+				<ShortcutHint keyToPress="↵" cmdOrCtrl={false} />
+			</ModalButton>
+		</Row>
+	);
+};
 
 export const CodemodFooter: React.FC<{
 	readonly valid: boolean;
@@ -32,6 +71,7 @@ export const CodemodFooter: React.FC<{
 	readonly submitLabel: (options: {relativeRootPath: string}) => string;
 	readonly onSuccess: (() => void) | null;
 	readonly fallbackToRootFile?: boolean;
+	readonly applyCodemod: ApplyCodemodAction;
 }> = ({
 	codemod,
 	stack,
@@ -43,6 +83,7 @@ export const CodemodFooter: React.FC<{
 	submitLabel,
 	onSuccess,
 	fallbackToRootFile = false,
+	applyCodemod,
 }) => {
 	const [submitting, setSubmitting] = useState(false);
 	const {setSelectedModal} = useContext(ModalsContext);
@@ -64,23 +105,29 @@ export const CodemodFooter: React.FC<{
 		const notification = showNotification(loadingNotification, null);
 
 		applyCodemod({
-			codemod,
-			dryRun: false,
 			symbolicatedStack,
 			signal: new AbortController().signal,
 		})
-			.then(() => {
+			.then((result) => {
+				if (!result.success) {
+					notification.replaceContent(
+						`${errorNotification}: ${result.reason}`,
+						2000,
+					);
+					return;
+				}
+
 				notification.replaceContent(successNotification, 2000);
 				onSuccess?.();
 			})
 			.catch((err) => {
 				notification.replaceContent(
-					`${errorNotification}: ${err.message}`,
+					`${errorNotification}: ${(err as Error).message}`,
 					2000,
 				);
 			});
 	}, [
-		codemod,
+		applyCodemod,
 		errorNotification,
 		loadingNotification,
 		onSuccess,
@@ -91,7 +138,7 @@ export const CodemodFooter: React.FC<{
 
 	const getCanApplyCodemod = useCallback(
 		async (signal: AbortSignal) => {
-			const res = await applyCodemod({
+			const res = await applyCodemodApi({
 				codemod,
 				dryRun: true,
 				symbolicatedStack,
@@ -122,7 +169,10 @@ export const CodemodFooter: React.FC<{
 							return;
 						}
 
-						showNotification(`${errorNotification}: ${err.message}`, 3000);
+						showNotification(
+							`${errorNotification}: ${(err as Error).message}`,
+							3000,
+						);
 					});
 
 				return () => {
@@ -159,7 +209,10 @@ export const CodemodFooter: React.FC<{
 					return;
 				}
 
-				showNotification(`${errorNotification}: ${err.message}`, 3000);
+				showNotification(
+					`${errorNotification}: ${(err as Error).message}`,
+					3000,
+				);
 			});
 
 		return () => {
@@ -204,16 +257,13 @@ export const CodemodFooter: React.FC<{
 	}, [disabled, registerKeybinding, trigger, valid]);
 
 	return (
-		<Row align="center">
-			<CodemodDiffPreview status={codemodStatus} />
-			<Flex />
-			<Spacing block x={2} />
-			<ModalButton onClick={trigger} disabled={disabled}>
-				{relativeFilePath
-					? submitLabel({relativeRootPath: relativeFilePath})
-					: genericSubmitLabel}
-				<ShortcutHint keyToPress="↵" cmdOrCtrl={false} />
-			</ModalButton>
-		</Row>
+		<CodemodFooterPresentation
+			codemodStatus={codemodStatus}
+			disabled={disabled}
+			genericSubmitLabel={genericSubmitLabel}
+			relativeFilePath={relativeFilePath}
+			submitLabel={submitLabel}
+			trigger={trigger}
+		/>
 	);
 };

--- a/packages/studio/src/components/NewComposition/DeleteComposition.tsx
+++ b/packages/studio/src/components/NewComposition/DeleteComposition.tsx
@@ -7,6 +7,7 @@ import {
 	ResolveCompositionBeforeModal,
 	ResolvedCompositionContext,
 } from '../RenderModal/ResolveCompositionBeforeModal';
+import {applyCodemod} from '../RenderQueue/actions';
 import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
 
@@ -68,6 +69,14 @@ const DeleteCompositionLoaded: React.FC<{
 						stack={compositionStack}
 						valid
 						onSuccess={null}
+						applyCodemod={({signal, symbolicatedStack}) =>
+							applyCodemod({
+								codemod,
+								dryRun: false,
+								signal,
+								symbolicatedStack,
+							})
+						}
 					/>
 				</ModalFooterContainer>
 			</form>

--- a/packages/studio/src/components/NewComposition/DeleteFolder.tsx
+++ b/packages/studio/src/components/NewComposition/DeleteFolder.tsx
@@ -4,6 +4,7 @@ import {getFolderId} from '../../helpers/get-folder-id';
 import {inlineCodeSnippet} from '../Menu/styles';
 import {ModalFooterContainer} from '../ModalFooter';
 import {ModalHeader} from '../ModalHeader';
+import {applyCodemod} from '../RenderQueue/actions';
 import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
 
@@ -58,6 +59,14 @@ export const DeleteFolder: React.FC<{
 						stack={stack}
 						valid
 						onSuccess={null}
+						applyCodemod={({signal, symbolicatedStack}) =>
+							applyCodemod({
+								codemod,
+								dryRun: false,
+								signal,
+								symbolicatedStack,
+							})
+						}
 					/>
 				</ModalFooterContainer>
 			</form>

--- a/packages/studio/src/components/NewComposition/DuplicateComposition.tsx
+++ b/packages/studio/src/components/NewComposition/DuplicateComposition.tsx
@@ -15,6 +15,7 @@ import {
 	ResolveCompositionBeforeModal,
 	ResolvedCompositionContext,
 } from '../RenderModal/ResolveCompositionBeforeModal';
+import {applyCodemod} from '../RenderQueue/actions';
 import {CodemodFooter} from './CodemodFooter';
 import type {ComboboxValue} from './ComboBox';
 import {Combobox} from './ComboBox';
@@ -371,6 +372,14 @@ const DuplicateCompositionLoaded: React.FC<{
 						stack={compositionStack}
 						valid={valid}
 						onSuccess={onDuplicateSuccess}
+						applyCodemod={({signal, symbolicatedStack}) =>
+							applyCodemod({
+								codemod,
+								dryRun: false,
+								signal,
+								symbolicatedStack,
+							})
+						}
 					/>
 				</ModalFooterContainer>
 			</form>

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -11,6 +11,7 @@ import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
 import {ModalHeader} from '../ModalHeader';
 import {label, optionRow, rightRow} from '../RenderModal/layout';
+import {applyCodemod} from '../RenderQueue/actions';
 import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
 import {InputDragger} from './InputDragger';
@@ -307,6 +308,14 @@ const NewCompositionLoaded: React.FC = () => {
 						stack={null}
 						valid={valid}
 						onSuccess={onSuccess}
+						applyCodemod={({signal, symbolicatedStack}) =>
+							applyCodemod({
+								codemod,
+								dryRun: false,
+								signal,
+								symbolicatedStack,
+							})
+						}
 						fallbackToRootFile
 					/>
 				</ModalFooterContainer>

--- a/packages/studio/src/components/NewComposition/RenameComposition.tsx
+++ b/packages/studio/src/components/NewComposition/RenameComposition.tsx
@@ -59,6 +59,7 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 
 	const {
 		codemod,
+		renameComposition,
 		valid,
 		validationMessage: compNameErrMessage,
 	} = useRenameComposition({
@@ -115,6 +116,13 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 						stack={compositionStack}
 						valid={valid}
 						onSuccess={null}
+						applyCodemod={({signal, symbolicatedStack}) =>
+							renameComposition({
+								newCompositionId: newId,
+								signal,
+								symbolicatedStack,
+							})
+						}
 					/>
 				</ModalFooterContainer>
 			</form>

--- a/packages/studio/src/components/NewComposition/RenameFolder.tsx
+++ b/packages/studio/src/components/NewComposition/RenameFolder.tsx
@@ -15,6 +15,7 @@ import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
 import {ModalHeader} from '../ModalHeader';
 import {label, optionRow, rightRow} from '../RenderModal/layout';
+import {applyCodemod} from '../RenderQueue/actions';
 import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
 import {RemotionInput} from './RemInput';
@@ -118,6 +119,14 @@ export const RenameFolder: React.FC<{
 						stack={stack}
 						valid={valid}
 						onSuccess={null}
+						applyCodemod={({signal, symbolicatedStack}) =>
+							applyCodemod({
+								codemod,
+								dryRun: false,
+								signal,
+								symbolicatedStack,
+							})
+						}
 					/>
 				</ModalFooterContainer>
 			</form>

--- a/packages/studio/src/helpers/use-rename-composition.ts
+++ b/packages/studio/src/helpers/use-rename-composition.ts
@@ -5,6 +5,7 @@ import type {
 import {useCallback, useMemo} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {applyCodemod} from '../components/RenderQueue/actions';
+import {pushUrl} from './url-state';
 import {validateCompositionName} from './validate-new-comp-data';
 
 export const useRenameComposition = ({
@@ -49,7 +50,7 @@ export const useRenameComposition = ({
 	const valid = validationMessage === null && currentId !== newId;
 
 	const renameComposition = useCallback(
-		({
+		async ({
 			newCompositionId,
 			signal,
 			symbolicatedStack,
@@ -58,12 +59,18 @@ export const useRenameComposition = ({
 			signal: AbortSignal;
 			symbolicatedStack: SymbolicatedStackFrame | null;
 		}) => {
-			return applyCodemod({
+			const result = await applyCodemod({
 				codemod: getCodemod(newCompositionId),
 				dryRun: false,
 				signal,
 				symbolicatedStack,
 			});
+
+			if (result.success) {
+				pushUrl(`/${newCompositionId}`);
+			}
+
+			return result;
 		},
 		[getCodemod],
 	);


### PR DESCRIPTION
## Summary

- Redirect to the renamed composition after a successful composition rename
- Route the rename modal through `renameComposition()` so inline and modal renames share the same behavior
- Make `CodemodFooter` accept an explicit apply function while keeping the dry-run preview logic generic

## Testing

- `cd packages/studio && bunx oxfmt src --write`
- `bunx tsc --noEmit --pretty false -p packages/studio/tsconfig.json`
- `bun run build`
- `bunx turbo run lint formatting --filter=@remotion/studio`
- `bun run stylecheck` *(fails in unrelated `template-react-router#lint` generated `.react-router` types: `Generic type 'GetAnnotations' requires 1 type argument(s)`)*
