### PR TITLE
`@remotion/eslint-plugin`: Add valid composition name rule

### DIFF
--- a/packages/eslint-config-flat/src/index.ts
+++ b/packages/eslint-config-flat/src/index.ts
@@ -61,7 +61,10 @@ export const makeConfig = ({
 			plugins: {
 				'@remotion': remotionPlugin,
 			},
-			rules: remotionPlugin.configs.recommended.rules,
+			rules: {
+				...remotionPlugin.configs.recommended.rules,
+				'@remotion/valid-composition-and-folder-name': 'error',
+			},
 			...(remotionDir ? {files: [remotionDir]} : {}),
 		},
 	) as Linter.Config[];

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -467,6 +467,7 @@ const getRules = (typescript: boolean) => {
 
 		'react-hooks/rules-of-hooks': 'error',
 		'react-hooks/exhaustive-deps': 'warn',
+		'@remotion/valid-composition-and-folder-name': 'error',
 		// Turning off rules that are too strict or don't apply to Remotion
 		'react/jsx-no-constructed-context-values': 'off',
 		'no-console': 'off',

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -11,6 +11,7 @@ import staticFileNoRelative from './rules/staticfile-no-relative';
 import staticFileNoRemote from './rules/staticfile-no-remote';
 import useGifComponent from './rules/use-gif-component';
 import v4Import from './rules/v4-import';
+import validCompositionAndFolderName from './rules/valid-composition-and-folder-name';
 import volumeCallback from './rules/volume-callback';
 import warnNativeMediaTag from './rules/warn-native-media-tag';
 
@@ -30,6 +31,7 @@ const rules = {
 	'slow-css-property': slowCssProperty,
 	'v4-config-import': v4Import,
 	'no-object-fit-on-media-video': noObjectFitOnMediaVideo,
+	'valid-composition-and-folder-name': validCompositionAndFolderName,
 };
 
 const recommendedRuleConfig = {
@@ -47,6 +49,7 @@ const recommendedRuleConfig = {
 	'@remotion/non-pure-animation': 'warn',
 	'@remotion/v4-config-import': 'error',
 	'@remotion/no-object-fit-on-media-video': 'warn',
+	'@remotion/valid-composition-and-folder-name': 'error',
 } as const;
 
 const configs = {

--- a/packages/eslint-plugin/src/rules/no-object-fit-on-media-video.ts
+++ b/packages/eslint-plugin/src/rules/no-object-fit-on-media-video.ts
@@ -19,8 +19,7 @@ const NoObjectFitInClassName = [
 	'See: https://remotion.dev/docs/media/video#objectfit',
 ].join('\n');
 
-const objectFitClassPattern =
-	/\bobject-(contain|cover|fill|none|scale-down)\b/;
+const objectFitClassPattern = /\bobject-(contain|cover|fill|none|scale-down)\b/;
 
 export default createRule<Options, MessageIds>({
 	name: 'no-object-fit-on-media-video',

--- a/packages/eslint-plugin/src/rules/valid-composition-and-folder-name.ts
+++ b/packages/eslint-plugin/src/rules/valid-composition-and-folder-name.ts
@@ -1,0 +1,124 @@
+import {ESLintUtils} from '@typescript-eslint/utils';
+import type {TSESTree} from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(() => {
+	return `https://github.com/remotion-dev/remotion`;
+});
+
+type Options = [];
+
+type MessageIds = 'InvalidCompositionId' | 'InvalidFolderName';
+
+const validNameRegex = /^([a-zA-Z0-9-\u4E00-\u9FFF])+$/;
+
+const InvalidCompositionId =
+	'Composition IDs can only contain a-z, A-Z, 0-9, CJK characters and -.';
+
+const InvalidFolderName =
+	'Folder names can only contain a-z, A-Z, 0-9, CJK characters and -.';
+
+const getStringValue = (
+	value: TSESTree.JSXAttribute['value'],
+): string | null => {
+	if (!value) {
+		return null;
+	}
+
+	if (value.type === 'Literal') {
+		return typeof value.value === 'string' ? value.value : null;
+	}
+
+	if (value.type !== 'JSXExpressionContainer') {
+		return null;
+	}
+
+	const {expression} = value;
+
+	if (expression.type === 'Literal') {
+		return typeof expression.value === 'string' ? expression.value : null;
+	}
+
+	if (
+		expression.type === 'TemplateLiteral' &&
+		expression.expressions.length === 0
+	) {
+		return expression.quasis[0].value.cooked;
+	}
+
+	return null;
+};
+
+const getJsxElementName = (
+	node: TSESTree.JSXTagNameExpression,
+): string | null => {
+	if (node.type !== 'JSXIdentifier') {
+		return null;
+	}
+
+	return node.name;
+};
+
+export default createRule<Options, MessageIds>({
+	name: 'valid-composition-and-folder-name',
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Warns about invalid Remotion composition IDs and folder names.',
+			recommended: 'warn',
+		},
+		fixable: undefined,
+		schema: [],
+		messages: {
+			InvalidCompositionId,
+			InvalidFolderName,
+		},
+	},
+	defaultOptions: [],
+	create: (context) => {
+		return {
+			JSXAttribute: (node) => {
+				if (node.type !== 'JSXAttribute') {
+					return;
+				}
+
+				if (node.name.type !== 'JSXIdentifier') {
+					return;
+				}
+
+				const parent = node.parent;
+				if (!parent || parent.type !== 'JSXOpeningElement') {
+					return;
+				}
+
+				const elementName = getJsxElementName(parent.name);
+				if (elementName === null) {
+					return;
+				}
+
+				const propName = node.name.name;
+				const value = getStringValue(node.value);
+				if (value === null || validNameRegex.test(value)) {
+					return;
+				}
+
+				if (
+					(elementName === 'Composition' || elementName === 'Still') &&
+					propName === 'id'
+				) {
+					context.report({
+						messageId: 'InvalidCompositionId',
+						node,
+					});
+				}
+
+				if (elementName === 'Folder' && propName === 'name') {
+					context.report({
+						messageId: 'InvalidFolderName',
+						node,
+					});
+				}
+			},
+		};
+	},
+});

--- a/packages/eslint-plugin/src/tests/valid-composition-and-folder-name.test.ts
+++ b/packages/eslint-plugin/src/tests/valid-composition-and-folder-name.test.ts
@@ -1,0 +1,176 @@
+import {ESLintUtils} from '@typescript-eslint/utils';
+import rule from '../rules/valid-composition-and-folder-name';
+
+const ruleTester = new ESLintUtils.RuleTester({
+	parser: '@typescript-eslint/parser',
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+});
+
+ruleTester.run('valid-composition-and-folder-name', rule, {
+	valid: [
+		`
+import {Composition} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Composition id="valid-id-123" />
+  );
+}
+          `,
+		`
+import {Still} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Still id={"valid-id"} />
+  );
+}
+          `,
+		`
+import {Composition} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Composition id={\`valid-id\`} />
+  );
+}
+          `,
+		`
+import {Folder} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Folder name="valid-folder">
+      <Composition id="valid-id" />
+    </Folder>
+  );
+}
+          `,
+		`
+import {Composition, Folder} from 'remotion';
+
+export const Re = () => {
+  const id = "dynamic id";
+  const name = "dynamic folder";
+  return (
+    <Folder name={name}>
+      <Composition id={id} />
+    </Folder>
+  );
+}
+          `,
+		`
+import {Composition, Folder} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Folder name="中文">
+      <Composition id="中文" />
+    </Folder>
+  );
+}
+          `,
+	],
+	invalid: [
+		{
+			code: `
+import {Composition} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Composition id="invalid id" />
+  );
+}
+      `,
+			errors: [
+				{
+					messageId: 'InvalidCompositionId',
+				},
+			],
+		},
+		{
+			code: `
+import {Composition} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Composition id={"invalid/id"} />
+  );
+}
+      `,
+			errors: [
+				{
+					messageId: 'InvalidCompositionId',
+				},
+			],
+		},
+		{
+			code: `
+import {Still} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Still id="invalid_id" />
+  );
+}
+      `,
+			errors: [
+				{
+					messageId: 'InvalidCompositionId',
+				},
+			],
+		},
+		{
+			code: `
+import {Composition} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Composition id={\`invalid id\`} />
+  );
+}
+      `,
+			errors: [
+				{
+					messageId: 'InvalidCompositionId',
+				},
+			],
+		},
+		{
+			code: `
+import {Folder} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Folder name="invalid folder" />
+  );
+}
+      `,
+			errors: [
+				{
+					messageId: 'InvalidFolderName',
+				},
+			],
+		},
+		{
+			code: `
+import {Folder} from 'remotion';
+
+export const Re = () => {
+  return (
+    <Folder name={"invalid/folder"} />
+  );
+}
+      `,
+			errors: [
+				{
+					messageId: 'InvalidFolderName',
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
## Summary

- Add an ESLint rule that flags invalid literal `<Composition />`, `<Still />`, and `<Folder />` names
- Register `@remotion/valid-composition-and-folder-name` in the recommended plugin config
- Cover JSX string literals, string expression literals, static template literals, CJK names, and dynamic values in tests

## Checks

- `bunx oxfmt src --write` in `packages/eslint-plugin`
- `bun run build`
- `bun run test` in `packages/eslint-plugin`
- `bun run stylecheck --filter=@remotion/eslint-plugin`

## Note

`bun run stylecheck` was also run from the repository root, but the local environment failed in `@remotion/lambda-php` because PHP is missing the `ext-iconv` extension required by Composer.
