### PR TITLE
`@remotion/studio`: Fix timeline zoom flicker

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
@@ -1,6 +1,8 @@
 import {PlayerInternals} from '@remotion/player';
-import {createContext} from 'react';
-import {sliderAreaRef} from './timeline-refs';
+import {createContext, useContext, useMemo} from 'react';
+import {Internals} from 'remotion';
+import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
+import {scrollableRef, sliderAreaRef} from './timeline-refs';
 
 type TimelineWidthContextType = number | null;
 
@@ -10,13 +12,29 @@ export const TimelineWidthContext =
 export const TimelineWidthProvider: React.FC<{
 	children: React.ReactNode;
 }> = ({children}) => {
-	const size = PlayerInternals.useElementSize(sliderAreaRef, {
+	const size = PlayerInternals.useElementSize(scrollableRef, {
 		triggerOnWindowResize: false,
 		shouldApplyCssTransforms: true,
 	});
+	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
+	const {canvasContent} = useContext(Internals.CompositionManager);
+
+	const width = useMemo(() => {
+		const zoom =
+			canvasContent?.type === 'composition'
+				? (zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM)
+				: TIMELINE_MIN_ZOOM;
+
+		const scrollableWidth = size?.width ?? scrollableRef.current?.clientWidth;
+		if (scrollableWidth === undefined) {
+			return sliderAreaRef.current?.clientWidth ?? null;
+		}
+
+		return scrollableWidth * zoom;
+	}, [canvasContent, size?.width, zoomMap]);
 
 	return (
-		<TimelineWidthContext.Provider value={size?.width ?? null}>
+		<TimelineWidthContext.Provider value={width}>
 			{children}
 		</TimelineWidthContext.Provider>
 	);

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -1,4 +1,5 @@
 import React, {createContext, useCallback, useMemo, useState} from 'react';
+import {flushSync} from 'react-dom';
 import {
 	getCurrentDuration,
 	getCurrentFrame,
@@ -41,28 +42,30 @@ export const TimelineZoomContext: React.FC<{
 			callback: (prevZoomLevel: number) => number,
 			options?: TimelineSetZoomOptions,
 		) => {
-			setZoomState((prevZoomMap) => {
-				const newZoomWithFloatingPointErrors = Math.min(
-					TIMELINE_MAX_ZOOM,
-					Math.max(
-						TIMELINE_MIN_ZOOM,
-						callback(prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM),
-					),
-				);
-				const newZoom = Math.round(newZoomWithFloatingPointErrors * 10) / 10;
+			flushSync(() => {
+				setZoomState((prevZoomMap) => {
+					const newZoomWithFloatingPointErrors = Math.min(
+						TIMELINE_MAX_ZOOM,
+						Math.max(
+							TIMELINE_MIN_ZOOM,
+							callback(prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM),
+						),
+					);
+					const newZoom = Math.round(newZoomWithFloatingPointErrors * 10) / 10;
 
-				const anchorFrame = options?.anchorFrame ?? null;
-				const anchorContentX = options?.anchorContentX ?? null;
+					const anchorFrame = options?.anchorFrame ?? null;
+					const anchorContentX = options?.anchorContentX ?? null;
 
-				zoomAndPreserveCursor({
-					oldZoom: prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM,
-					newZoom,
-					currentDurationInFrames: getCurrentDuration(),
-					currentFrame: getCurrentFrame(),
-					anchorFrame,
-					anchorContentX,
+					zoomAndPreserveCursor({
+						oldZoom: prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM,
+						newZoom,
+						currentDurationInFrames: getCurrentDuration(),
+						currentFrame: getCurrentFrame(),
+						anchorFrame,
+						anchorContentX,
+					});
+					return {...prevZoomMap, [compositionId]: newZoom};
 				});
-				return {...prevZoomMap, [compositionId]: newZoom};
 			});
 		},
 		[],


### PR DESCRIPTION
## Summary

- Re-introduce `flushSync` for timeline zoom state updates only
- Derive timeline width from the visible scroll area and zoom state so tick labels update in the same render
- Keep timeline seeking paths on their existing async `seek` / `setFrame` flow

Fixes #8332.

## Testing

- `bunx oxfmt src --write` in `packages/studio`
- `bun run build`
- `bunx turbo run lint formatting --filter='@remotion/studio'`
- `bun run stylecheck` *(fails in unrelated `@remotion/lambda-php#lint`: local PHP is missing the `iconv` extension required by Composer)*
