### PR TITLE
`@remotion/promo-pages`: Fix docs stat layout

### DIFF
--- a/packages/promo-pages/src/components/homepage/CommunityStatsItems.tsx
+++ b/packages/promo-pages/src/components/homepage/CommunityStatsItems.tsx
@@ -102,7 +102,7 @@ export const InstallsPerMonth: React.FC = () => {
 export const PagesOfDocs: React.FC = () => {
 	return (
 		<Pill className="flex-col">
-			<div style={{display: 'flex', alignItems: 'center'}}>
+			<div style={{display: 'flex', alignItems: 'center', gap: 8}}>
 				<StatItemContent
 					content={
 						<svg
@@ -118,12 +118,11 @@ export const PagesOfDocs: React.FC = () => {
 							/>
 						</svg>
 					}
-					width="40px"
+					width="32px"
 				/>
 				<StatItemContent
 					content="1000"
-					width="85px"
-					maxWidth="100px"
+					width="112px"
 					fontSize="2.5rem"
 					fontWeight="bold"
 				/>


### PR DESCRIPTION
## Summary

- Move the docs stat book icon into a smaller left slot with explicit spacing.
- Widen the `1000` number slot so the icon no longer overlaps the four-digit count.

## Testing

- `bun run build`
- `bunx turbo run lint formatting --filter=@remotion/promo-pages`

Full `bun run stylecheck` was attempted, but this machine's PHP installation is missing `ext-iconv`, causing the unrelated `@remotion/lambda-php` lint step to fail during `composer install`.
