### PR TITLE
`@remotion/studio`: Auto-select newly created composition

### DIFF
--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -1,17 +1,14 @@
-import type {RecastCodemod} from '@remotion/studio-shared';
 import type {ChangeEventHandler} from 'react';
-import React, {useCallback, useContext, useMemo, useState} from 'react';
-import {Internals, type _InternalTypes} from 'remotion';
-import {pushUrl} from '../../helpers/url-state';
+import React, {useCallback, useContext, useState} from 'react';
+import {Internals} from 'remotion';
 import {
-	validateCompositionDimension,
-	validateCompositionName,
-} from '../../helpers/validate-new-comp-data';
+	getUniqueCompositionName,
+	useCreateComposition,
+} from '../../helpers/use-create-composition';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
 import {ModalHeader} from '../ModalHeader';
 import {label, optionRow, rightRow} from '../RenderModal/layout';
-import {applyCodemod} from '../RenderQueue/actions';
 import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
 import {InputDragger} from './InputDragger';
@@ -25,55 +22,6 @@ const content: React.CSSProperties = {
 	flex: 1,
 	fontSize: 13,
 	minWidth: 500,
-};
-
-const toPascalCase = (value: string) => {
-	const words = value.match(/[a-zA-Z0-9]+/g) ?? [];
-	const candidate = words
-		.map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
-		.join('');
-
-	if (!candidate) {
-		return 'NewComposition';
-	}
-
-	if (/^[0-9]/.test(candidate)) {
-		return `Composition${candidate}`;
-	}
-
-	return candidate;
-};
-
-const waitForComposition = (compositionId: string) => {
-	return new Promise<void>((resolve) => {
-		const started = Date.now();
-		const interval = window.setInterval(() => {
-			const compositionNames = window.remotion_getCompositionNames?.() ?? [];
-			if (
-				compositionNames.includes(compositionId) ||
-				Date.now() - started > 10000
-			) {
-				window.clearInterval(interval);
-				resolve();
-			}
-		}, 100);
-	});
-};
-
-const getUniqueCompositionName = (
-	compositions: _InternalTypes['AnyComposition'][],
-) => {
-	let counter = 1;
-
-	while (true) {
-		const name = counter === 1 ? 'NewComposition' : `NewComposition${counter}`;
-		const err = validateCompositionName(name, compositions);
-		if (!err) {
-			return name;
-		}
-
-		counter++;
-	}
 };
 
 const NewCompositionLoaded: React.FC = () => {
@@ -139,44 +87,20 @@ const NewCompositionLoaded: React.FC = () => {
 		setFrameRate(newFps);
 	}, []);
 
-	const compNameErrMessage = validateCompositionName(newId, compositions);
-	const compWidthErrMessage = validateCompositionDimension('Width', size.width);
-	const compHeightErrMessage = validateCompositionDimension(
-		'Height',
-		size.height,
-	);
-	const componentName = toPascalCase(newId);
-
-	const valid =
-		compNameErrMessage === null &&
-		compWidthErrMessage === null &&
-		compHeightErrMessage === null;
-
-	const codemod: RecastCodemod = useMemo(() => {
-		return {
-			type: 'new-composition',
-			newDurationInFrames: Number(durationInFrames),
-			newFps: Number(selectedFrameRate),
-			newHeight: Number(size.height),
-			newWidth: Number(size.width),
-			newId,
-			componentName,
-			componentImportPath: `./${componentName}`,
-		};
-	}, [
-		componentName,
+	const {
+		codemod,
+		createComposition,
+		heightValidationMessage: compHeightErrMessage,
+		nameValidationMessage: compNameErrMessage,
+		valid,
+		widthValidationMessage: compWidthErrMessage,
+	} = useCreateComposition({
+		compositions,
 		durationInFrames,
 		newId,
 		selectedFrameRate,
-		size.height,
-		size.width,
-	]);
-
-	const onSuccess = useCallback(() => {
-		waitForComposition(newId).then(() => {
-			pushUrl(`/${newId}`);
-		});
-	}, [newId]);
+		size,
+	});
 
 	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((e) => {
 		e.preventDefault();
@@ -307,11 +231,9 @@ const NewCompositionLoaded: React.FC = () => {
 						codemod={codemod}
 						stack={null}
 						valid={valid}
-						onSuccess={onSuccess}
+						onSuccess={null}
 						applyCodemod={({signal, symbolicatedStack}) =>
-							applyCodemod({
-								codemod,
-								dryRun: false,
+							createComposition({
 								signal,
 								symbolicatedStack,
 							})

--- a/packages/studio/src/helpers/use-create-composition.ts
+++ b/packages/studio/src/helpers/use-create-composition.ts
@@ -1,0 +1,153 @@
+import type {
+	RecastCodemod,
+	SymbolicatedStackFrame,
+} from '@remotion/studio-shared';
+import {useCallback, useContext, useMemo} from 'react';
+import {Internals, type _InternalTypes} from 'remotion';
+import {applyCodemod} from '../components/RenderQueue/actions';
+import {pushUrl} from './url-state';
+import {
+	validateCompositionDimension,
+	validateCompositionName,
+} from './validate-new-comp-data';
+
+const toPascalCase = (value: string) => {
+	const words = value.match(/[a-zA-Z0-9]+/g) ?? [];
+	const candidate = words
+		.map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+		.join('');
+
+	if (!candidate) {
+		return 'NewComposition';
+	}
+
+	if (/^[0-9]/.test(candidate)) {
+		return `Composition${candidate}`;
+	}
+
+	return candidate;
+};
+
+const waitForComposition = (compositionId: string) => {
+	return new Promise<void>((resolve) => {
+		const started = Date.now();
+		const interval = window.setInterval(() => {
+			const compositionNames = window.remotion_getCompositionNames?.() ?? [];
+			if (
+				compositionNames.includes(compositionId) ||
+				Date.now() - started > 10000
+			) {
+				window.clearInterval(interval);
+				resolve();
+			}
+		}, 100);
+	});
+};
+
+export const getUniqueCompositionName = (
+	compositions: _InternalTypes['AnyComposition'][],
+) => {
+	let counter = 1;
+
+	while (true) {
+		const name = counter === 1 ? 'NewComposition' : `NewComposition${counter}`;
+		const err = validateCompositionName(name, compositions);
+		if (!err) {
+			return name;
+		}
+
+		counter++;
+	}
+};
+
+export const useCreateComposition = ({
+	compositions,
+	durationInFrames,
+	newId,
+	selectedFrameRate,
+	size,
+}: {
+	compositions: _InternalTypes['AnyComposition'][];
+	durationInFrames: number;
+	newId: string;
+	selectedFrameRate: number;
+	size: {
+		width: number;
+		height: number;
+	};
+}) => {
+	const {setCanvasContent} = useContext(Internals.CompositionSetters);
+	const componentName = useMemo(() => toPascalCase(newId), [newId]);
+
+	const nameValidationMessage = useMemo(() => {
+		return validateCompositionName(newId, compositions);
+	}, [compositions, newId]);
+
+	const widthValidationMessage = useMemo(() => {
+		return validateCompositionDimension('Width', size.width);
+	}, [size.width]);
+
+	const heightValidationMessage = useMemo(() => {
+		return validateCompositionDimension('Height', size.height);
+	}, [size.height]);
+
+	const codemod: RecastCodemod = useMemo(() => {
+		return {
+			type: 'new-composition',
+			newDurationInFrames: Number(durationInFrames),
+			newFps: Number(selectedFrameRate),
+			newHeight: Number(size.height),
+			newWidth: Number(size.width),
+			newId,
+			componentName,
+			componentImportPath: `./${componentName}`,
+		};
+	}, [
+		componentName,
+		durationInFrames,
+		newId,
+		selectedFrameRate,
+		size.height,
+		size.width,
+	]);
+
+	const valid =
+		nameValidationMessage === null &&
+		widthValidationMessage === null &&
+		heightValidationMessage === null;
+
+	const createComposition = useCallback(
+		async ({
+			signal,
+			symbolicatedStack,
+		}: {
+			signal: AbortSignal;
+			symbolicatedStack: SymbolicatedStackFrame | null;
+		}) => {
+			const result = await applyCodemod({
+				codemod,
+				dryRun: false,
+				signal,
+				symbolicatedStack,
+			});
+
+			if (result.success) {
+				await waitForComposition(newId);
+				setCanvasContent({type: 'composition', compositionId: newId});
+				pushUrl(`/${newId}`);
+			}
+
+			return result;
+		},
+		[codemod, newId, setCanvasContent],
+	);
+
+	return {
+		codemod,
+		createComposition,
+		heightValidationMessage,
+		nameValidationMessage,
+		valid,
+		widthValidationMessage,
+	};
+};


### PR DESCRIPTION
## Summary

- Fixes #8676
- Extracts new composition creation into a `useCreateComposition()` helper, mirroring the rename composition flow
- Selects the newly created composition after it has registered and updates the URL

## Testing

- `cd packages/studio && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck` *(fails in existing `template-react-router#lint` generated `.react-router` types: `Generic type 'GetAnnotations' requires 1 type argument(s)`)*
