### PR TITLE
`remotion-monorepo`: Fix Zed worktree setup hook

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,9 +1,10 @@
 [
 	{
 		"label": "setup new worktree",
-		"command": "bash",
-		"args": ["-lc", "bun install && bun run build"],
-		"hooks": ["create_worktree"],
+		"command": "bun install && bun run build",
+		"hooks": [
+			"create_worktree"
+		],
 		"cwd": "$ZED_WORKTREE_ROOT",
 		"reveal": "no_focus",
 		"hide": "on_success"


### PR DESCRIPTION
## Summary

- Put the Zed worktree setup command directly in `command`
- Remove `args`, which did not get applied when the `create_worktree` hook ran

## Testing

- `bun --print "JSON.stringify(require('./.zed/tasks.json'))"`
- `bun install`
- `bun run build`
- `bun run stylecheck`
