### PR TITLE
`@remotion/studio`: Create compositions in folders

### DIFF
--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -441,7 +441,9 @@ export const Index: React.FC = () => {
 					defaultProps={canvasCapturePreviewDefaultProps}
 					calculateMetadata={calculateCanvasCapturePreviewMetadata}
 				/>
-				<Folder name="nested-copilot-tests" />
+				<Folder name="nested-copilot-tests">
+					<></>
+				</Folder>
 			</Folder>
 			<Folder name="dynamic-parameters">
 				<Composition

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -441,9 +441,6 @@ export const Index: React.FC = () => {
 					defaultProps={canvasCapturePreviewDefaultProps}
 					calculateMetadata={calculateCanvasCapturePreviewMetadata}
 				/>
-				<Folder name="nested-copilot-tests">
-					<></>
-				</Folder>
 			</Folder>
 			<Folder name="dynamic-parameters">
 				<Composition

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -441,6 +441,7 @@ export const Index: React.FC = () => {
 					defaultProps={canvasCapturePreviewDefaultProps}
 					calculateMetadata={calculateCanvasCapturePreviewMetadata}
 				/>
+				<Folder name="nested-copilot-tests" />
 			</Folder>
 			<Folder name="dynamic-parameters">
 				<Composition

--- a/packages/studio-server/src/codemods/recast-mods.ts
+++ b/packages/studio-server/src/codemods/recast-mods.ts
@@ -148,6 +148,7 @@ const mapReturnStatement = (
 
 	if (
 		transformation.type === 'new-composition' &&
+		transformation.folderName === null &&
 		(statement.argument.type === 'JSXElement' ||
 			statement.argument.type === 'JSXFragment')
 	) {
@@ -309,6 +310,36 @@ const addNewCompositionToRootJsx = <T extends JSXElement | JSXFragment>(
 	return wrapInJsxFragment([root, newCompositionElement(transformation)]);
 };
 
+const addNewCompositionToFolder = (
+	folderElement: JSXElement,
+	transformation: Extract<RecastCodemod, {type: 'new-composition'}>,
+	changesMade: Change[],
+): JSXElement => {
+	if (changesMade.length > 0) {
+		return folderElement;
+	}
+
+	changesMade.push({
+		description: 'Added new composition',
+	});
+
+	return {
+		...folderElement,
+		openingElement: {
+			...folderElement.openingElement,
+			selfClosing: false,
+		},
+		closingElement: folderElement.closingElement ?? {
+			type: 'JSXClosingElement',
+			name: folderElement.openingElement.name,
+		},
+		children: [
+			...folderElement.children,
+			newCompositionElement(transformation),
+		],
+	};
+};
+
 // When a <Composition> JSX element appears in a position where it cannot
 // simply be removed from a parent's children list (e.g. as the sole return
 // value of a wrapper component or as the concise body of an arrow function),
@@ -334,6 +365,9 @@ const transformLoneJsxElement = (
 				parentFolderName === transformation.parentName) ||
 				(transformation.type === 'rename-folder' &&
 					folderName === transformation.folderName &&
+					parentFolderName === transformation.parentName) ||
+				(transformation.type === 'new-composition' &&
+					folderName === transformation.folderName &&
 					parentFolderName === transformation.parentName));
 
 		if (!isFolderMatch) {
@@ -352,6 +386,9 @@ const transformLoneJsxElement = (
 			folderName === transformation.folderName &&
 			parentFolderName === transformation.parentName) ||
 		(transformation.type === 'rename-folder' &&
+			folderName === transformation.folderName &&
+			parentFolderName === transformation.parentName) ||
+		(transformation.type === 'new-composition' &&
 			folderName === transformation.folderName &&
 			parentFolderName === transformation.parentName);
 
@@ -493,6 +530,14 @@ const mapJsxChild = (
 		return c.children;
 	}
 
+	if (
+		transformation.type === 'new-composition' &&
+		folderName === transformation.folderName &&
+		parentFolderName === transformation.parentName
+	) {
+		return [addNewCompositionToFolder(c, transformation, changesMade)];
+	}
+
 	const childParentFolderName = folderName
 		? getChildFolderParentName({folderName, parentFolderName})
 		: parentFolderName;
@@ -521,6 +566,7 @@ const mapRecognizedType = <T extends RecognizedType>(
 	) {
 		if (
 			transformation.type === 'new-composition' &&
+			transformation.folderName === null &&
 			(expression.body.type === 'JSXElement' ||
 				expression.body.type === 'JSXFragment')
 		) {

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -264,6 +264,8 @@ test('applyCodemodHandler creates new composition files with undo and redo', asy
 						newId: 'FreshVideo',
 						componentName: 'FreshVideo',
 						componentImportPath: './FreshVideo',
+						folderName: null,
+						parentName: null,
 						newDurationInFrames: 150,
 						newFps: 30,
 						newHeight: 1080,
@@ -313,6 +315,61 @@ test('applyCodemodHandler creates new composition files with undo and redo', asy
 		cleanupFileWatcher();
 		rmSync(remotionRoot, {recursive: true, force: true});
 	}
+});
+
+test('creates a composition in a top-level folder', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: folderRootContents,
+		codeMod: {
+			type: 'new-composition',
+			newId: 'FreshVideo',
+			componentName: 'FreshVideo',
+			componentImportPath: './FreshVideo',
+			folderName: 'Parent',
+			parentName: null,
+			newDurationInFrames: 150,
+			newFps: 30,
+			newHeight: 1080,
+			newWidth: 1920,
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents).toContain('id="FreshVideo"');
+	expect(newContents).toContain('component={FreshVideo}');
+	expect(newContents.indexOf('<Folder name="Parent">')).toBeLessThan(
+		newContents.indexOf('id="FreshVideo"'),
+	);
+	expect(newContents.indexOf('id="FreshVideo"')).toBeLessThan(
+		newContents.indexOf('<Folder name="Other">'),
+	);
+});
+
+test('creates a composition in a nested folder by parent path', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: folderRootContents,
+		codeMod: {
+			type: 'new-composition',
+			newId: 'FreshVideo',
+			componentName: 'FreshVideo',
+			componentImportPath: './FreshVideo',
+			folderName: 'Shared',
+			parentName: 'Other',
+			newDurationInFrames: 150,
+			newFps: 30,
+			newHeight: 1080,
+			newWidth: 1920,
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents).toContain('id="FreshVideo"');
+	expect(newContents.indexOf('id="NestedB"')).toBeLessThan(
+		newContents.indexOf('id="FreshVideo"'),
+	);
+	expect(newContents.indexOf('id="NestedA"')).toBeLessThan(
+		newContents.indexOf('id="NestedB"'),
+	);
 });
 
 test('renames a nested folder by parent path', () => {

--- a/packages/studio-server/src/test/recast-mods.test.ts
+++ b/packages/studio-server/src/test/recast-mods.test.ts
@@ -240,6 +240,8 @@ test('New composition appends to root and adds imports', () => {
 			newId: 'FreshVideo',
 			componentName: 'FreshVideo',
 			componentImportPath: './FreshVideo',
+			folderName: null,
+			parentName: null,
 			newDurationInFrames: 150,
 			newFps: 30,
 			newHeight: 1080,

--- a/packages/studio-shared/src/codemods.ts
+++ b/packages/studio-shared/src/codemods.ts
@@ -18,6 +18,8 @@ export type RecastCodemod =
 			newId: string;
 			componentName: string;
 			componentImportPath: string;
+			folderName: string | null;
+			parentName: string | null;
 			newHeight: number;
 			newWidth: number;
 			newFps: number;

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -31,7 +31,11 @@ export const Modals: React.FC<{
 	return (
 		<>
 			{modalContextType && modalContextType.type === 'new-comp' && (
-				<NewComposition />
+				<NewComposition
+					folderName={modalContextType.folderName}
+					parentName={modalContextType.parentName}
+					stack={modalContextType.stack}
+				/>
 			)}
 			{modalContextType && modalContextType.type === 'duplicate-comp' && (
 				<DuplicateComposition

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -24,7 +24,11 @@ const content: React.CSSProperties = {
 	minWidth: 500,
 };
 
-const NewCompositionLoaded: React.FC = () => {
+const NewCompositionLoaded: React.FC<{
+	readonly folderName: string | null;
+	readonly parentName: string | null;
+	readonly stack: string | null;
+}> = ({folderName, parentName, stack}) => {
 	const {compositions} = useContext(Internals.CompositionManager);
 	const [newId, setName] = useState(() =>
 		getUniqueCompositionName(compositions),
@@ -97,7 +101,9 @@ const NewCompositionLoaded: React.FC = () => {
 	} = useCreateComposition({
 		compositions,
 		durationInFrames,
+		folderName,
 		newId,
+		parentName,
 		selectedFrameRate,
 		size,
 	});
@@ -106,11 +112,19 @@ const NewCompositionLoaded: React.FC = () => {
 		e.preventDefault();
 	}, []);
 
+	const folderPath = [parentName, folderName].filter(Boolean).join('/');
+
 	return (
 		<>
 			<ModalHeader title="New composition" />
 			<form onSubmit={onSubmit}>
 				<div style={content}>
+					{folderPath ? (
+						<div style={optionRow}>
+							<div style={label}>Folder</div>
+							<div style={rightRow}>{folderPath}</div>
+						</div>
+					) : null}
 					<div style={optionRow}>
 						<div style={label}>ID</div>
 						<div style={rightRow}>
@@ -229,7 +243,7 @@ const NewCompositionLoaded: React.FC = () => {
 						genericSubmitLabel="Add to root file"
 						submitLabel={({relativeRootPath}) => `Add to ${relativeRootPath}`}
 						codemod={codemod}
-						stack={null}
+						stack={stack}
 						valid={valid}
 						onSuccess={null}
 						applyCodemod={({signal, symbolicatedStack}) =>
@@ -246,10 +260,18 @@ const NewCompositionLoaded: React.FC = () => {
 	);
 };
 
-export const NewComposition: React.FC = () => {
+export const NewComposition: React.FC<{
+	readonly folderName: string | null;
+	readonly parentName: string | null;
+	readonly stack: string | null;
+}> = ({folderName, parentName, stack}) => {
 	return (
 		<DismissableModal>
-			<NewCompositionLoaded />
+			<NewCompositionLoaded
+				folderName={folderName}
+				parentName={parentName}
+				stack={stack}
+			/>
 		</DismissableModal>
 	);
 };

--- a/packages/studio/src/components/composition-menu-items.ts
+++ b/packages/studio/src/components/composition-menu-items.ts
@@ -135,6 +135,9 @@ export const getCompositionMenuItems = ({
 				closeMenu();
 				setSelectedModal({
 					type: 'new-comp',
+					folderName: null,
+					parentName: null,
+					stack: null,
 				});
 			},
 			quickSwitcherLabel: 'New composition...',

--- a/packages/studio/src/components/folder-menu-items.ts
+++ b/packages/studio/src/components/folder-menu-items.ts
@@ -100,6 +100,26 @@ export const getFolderMenuItems = ({
 				}
 			: null,
 		{
+			id: 'new-composition-in-folder',
+			keyHint: null,
+			label: `New composition...`,
+			leftItem: null,
+			onClick: () => {
+				closeMenu();
+				setSelectedModal({
+					type: 'new-comp',
+					folderName: folder.name,
+					parentName: folder.parent,
+					stack: folder.stack,
+				});
+			},
+			quickSwitcherLabel: 'New composition in folder...',
+			subMenu: null,
+			type: 'item' as const,
+			value: 'new-composition-in-folder',
+			disabled: codemodDisabled,
+		},
+		{
 			id: 'rename-folder',
 			keyHint: null,
 			label: `Rename...`,

--- a/packages/studio/src/helpers/use-create-composition.ts
+++ b/packages/studio/src/helpers/use-create-composition.ts
@@ -63,13 +63,17 @@ export const getUniqueCompositionName = (
 export const useCreateComposition = ({
 	compositions,
 	durationInFrames,
+	folderName,
 	newId,
+	parentName,
 	selectedFrameRate,
 	size,
 }: {
 	compositions: _InternalTypes['AnyComposition'][];
 	durationInFrames: number;
+	folderName: string | null;
 	newId: string;
+	parentName: string | null;
 	selectedFrameRate: number;
 	size: {
 		width: number;
@@ -101,11 +105,15 @@ export const useCreateComposition = ({
 			newId,
 			componentName,
 			componentImportPath: `./${componentName}`,
+			folderName,
+			parentName,
 		};
 	}, [
 		componentName,
 		durationInFrames,
+		folderName,
 		newId,
+		parentName,
 		selectedFrameRate,
 		size.height,
 		size.width,

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -130,6 +130,9 @@ export type AddEffectModalState = {
 export type ModalState =
 	| {
 			type: 'new-comp';
+			folderName: string | null;
+			parentName: string | null;
+			stack: string | null;
 	  }
 	| {
 			type: 'duplicate-comp';


### PR DESCRIPTION
## Summary

- Fixes #8675
- Adds `New composition...` to Remotion Studio folder context menus
- Extends the new composition codemod to target a specific logical Remotion folder using `folderName` and `parentName`
- Adds an example nested folder under `copilot-tests` for manual testing

## Testing

- `bun test packages/studio-server/src/test/apply-codemod.test.ts packages/studio-server/src/test/recast-mods.test.ts`
- `bunx tsc --noEmit --project packages/studio/tsconfig.json`
- `bunx tsc --noEmit --project packages/studio-server/tsconfig.json`
- `bunx tsc --noEmit --project packages/example/tsconfig.json`
- `bun run build`
- `bun run stylecheck` *(fails in existing `template-react-router#lint` generated `.react-router` types: `Generic type 'GetAnnotations' requires 1 type argument(s)`)*
