### PR TITLE
`@remotion/studio`: Prevent dialog validation messages widening modals

### DIFF
--- a/packages/studio/src/components/NewComposition/DuplicateComposition.tsx
+++ b/packages/studio/src/components/NewComposition/DuplicateComposition.tsx
@@ -20,6 +20,7 @@ import {CodemodFooter} from './CodemodFooter';
 import type {ComboboxValue} from './ComboBox';
 import {Combobox} from './ComboBox';
 import {DismissableModal} from './DismissableModal';
+import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {InputDragger} from './InputDragger';
 import {NewCompDuration} from './NewCompDuration';
 import {RemotionInput} from './RemInput';
@@ -245,7 +246,7 @@ const DuplicateCompositionLoaded: React.FC<{
 					<div style={optionRow}>
 						<div style={label}>ID</div>
 						<div style={rightRow}>
-							<div>
+							<InputAndValidationContainer>
 								<RemotionInput
 									value={newId}
 									onChange={onNameChange}
@@ -265,7 +266,7 @@ const DuplicateCompositionLoaded: React.FC<{
 										/>
 									</>
 								) : null}
-							</div>
+							</InputAndValidationContainer>
 						</div>
 					</div>
 
@@ -274,61 +275,65 @@ const DuplicateCompositionLoaded: React.FC<{
 							<div style={optionRow}>
 								<div style={label}>Width</div>
 								<div style={rightRow}>
-									<InputDragger
-										type="number"
-										value={size.width}
-										placeholder="Width"
-										onTextChange={onWidthChanged}
-										name="width"
-										step={2}
-										min={2}
-										required
-										status="ok"
-										formatter={(w) => `${w}px`}
-										max={100000000}
-										onValueChange={onWidthDirectlyChanged}
-										rightAlign={false}
-									/>
-									{compWidthErrMessage ? (
-										<>
-											<Spacing y={1} block />
-											<ValidationMessage
-												align="flex-start"
-												message={compWidthErrMessage}
-												type="error"
-											/>
-										</>
-									) : null}
+									<InputAndValidationContainer>
+										<InputDragger
+											type="number"
+											value={size.width}
+											placeholder="Width"
+											onTextChange={onWidthChanged}
+											name="width"
+											step={2}
+											min={2}
+											required
+											status="ok"
+											formatter={(w) => `${w}px`}
+											max={100000000}
+											onValueChange={onWidthDirectlyChanged}
+											rightAlign={false}
+										/>
+										{compWidthErrMessage ? (
+											<>
+												<Spacing y={1} block />
+												<ValidationMessage
+													align="flex-start"
+													message={compWidthErrMessage}
+													type="error"
+												/>
+											</>
+										) : null}
+									</InputAndValidationContainer>
 								</div>
 							</div>
 							<div style={optionRow}>
 								<div style={label}>Height</div>
 								<div style={rightRow}>
-									<InputDragger
-										type="number"
-										value={size.height}
-										onTextChange={onHeightChanged}
-										placeholder="Height"
-										name="height"
-										step={2}
-										required
-										formatter={(h) => `${h}px`}
-										min={2}
-										status="ok"
-										max={100000000}
-										onValueChange={onHeightDirectlyChanged}
-										rightAlign={false}
-									/>
-									{compHeightErrMessage ? (
-										<>
-											<Spacing y={1} block />
-											<ValidationMessage
-												align="flex-start"
-												message={compHeightErrMessage}
-												type="error"
-											/>
-										</>
-									) : null}
+									<InputAndValidationContainer>
+										<InputDragger
+											type="number"
+											value={size.height}
+											onTextChange={onHeightChanged}
+											placeholder="Height"
+											name="height"
+											step={2}
+											required
+											formatter={(h) => `${h}px`}
+											min={2}
+											status="ok"
+											max={100000000}
+											onValueChange={onHeightDirectlyChanged}
+											rightAlign={false}
+										/>
+										{compHeightErrMessage ? (
+											<>
+												<Spacing y={1} block />
+												<ValidationMessage
+													align="flex-start"
+													message={compHeightErrMessage}
+													type="error"
+												/>
+											</>
+										) : null}
+									</InputAndValidationContainer>
 								</div>
 							</div>
 						</>

--- a/packages/studio/src/components/NewComposition/InputAndValidationContainer.tsx
+++ b/packages/studio/src/components/NewComposition/InputAndValidationContainer.tsx
@@ -1,0 +1,16 @@
+import type {PropsWithChildren} from 'react';
+import React from 'react';
+
+const container: React.CSSProperties = {
+	width: 250,
+	minWidth: 0,
+	display: 'flex',
+	flexDirection: 'column',
+	alignItems: 'flex-end',
+};
+
+export const InputAndValidationContainer: React.FC<PropsWithChildren> = ({
+	children,
+}) => {
+	return <div style={container}>{children}</div>;
+};

--- a/packages/studio/src/components/NewComposition/NewCompDuration.tsx
+++ b/packages/studio/src/components/NewComposition/NewCompDuration.tsx
@@ -2,6 +2,7 @@ import React, {useCallback} from 'react';
 import {validateCompositionDuration} from '../../helpers/validate-new-comp-data';
 import {Spacing} from '../layout';
 import {label, optionRow, rightRow} from '../RenderModal/layout';
+import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {InputDragger} from './InputDragger';
 import {ValidationMessage} from './ValidationMessage';
 
@@ -29,31 +30,33 @@ export const NewCompDuration: React.FC<{
 		<div style={optionRow}>
 			<div style={label}>Duration in frames</div>
 			<div style={rightRow}>
-				<InputDragger
-					type="number"
-					value={durationInFrames}
-					onTextChange={onDurationInFramesChanged}
-					placeholder="Duration (frames)"
-					name="durationInFrames"
-					min={1}
-					step={1}
-					required
-					status="ok"
-					// Hitting Promise.all() limit in Chrome
-					max={300_000}
-					onValueChange={onDurationChangedDirectly}
-					rightAlign={false}
-				/>
-				{compDurationErrMessage ? (
-					<>
-						<Spacing y={1} block />
-						<ValidationMessage
-							align="flex-start"
-							message={compDurationErrMessage}
-							type="error"
-						/>
-					</>
-				) : null}
+				<InputAndValidationContainer>
+					<InputDragger
+						type="number"
+						value={durationInFrames}
+						onTextChange={onDurationInFramesChanged}
+						placeholder="Duration (frames)"
+						name="durationInFrames"
+						min={1}
+						step={1}
+						required
+						status="ok"
+						// Hitting Promise.all() limit in Chrome
+						max={300_000}
+						onValueChange={onDurationChangedDirectly}
+						rightAlign={false}
+					/>
+					{compDurationErrMessage ? (
+						<>
+							<Spacing y={1} block />
+							<ValidationMessage
+								align="flex-start"
+								message={compDurationErrMessage}
+								type="error"
+							/>
+						</>
+					) : null}
+				</InputAndValidationContainer>
 			</div>
 		</div>
 	);

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -11,6 +11,7 @@ import {ModalHeader} from '../ModalHeader';
 import {label, optionRow, rightRow} from '../RenderModal/layout';
 import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
+import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {InputDragger} from './InputDragger';
 import {NewCompDuration} from './NewCompDuration';
 import {RemotionInput} from './RemInput';
@@ -114,7 +115,7 @@ const NewCompositionLoaded: React.FC = () => {
 					<div style={optionRow}>
 						<div style={label}>ID</div>
 						<div style={rightRow}>
-							<div>
+							<InputAndValidationContainer>
 								<RemotionInput
 									value={newId}
 									onChange={onNameChange}
@@ -134,67 +135,71 @@ const NewCompositionLoaded: React.FC = () => {
 										/>
 									</>
 								) : null}
-							</div>
+							</InputAndValidationContainer>
 						</div>
 					</div>
 					<div style={optionRow}>
 						<div style={label}>Width</div>
 						<div style={rightRow}>
-							<InputDragger
-								type="number"
-								value={size.width}
-								placeholder="Width"
-								onTextChange={onWidthChanged}
-								name="width"
-								step={2}
-								min={2}
-								required
-								status="ok"
-								formatter={(w) => `${w}px`}
-								max={100000000}
-								onValueChange={onWidthDirectlyChanged}
-								rightAlign={false}
-							/>
-							{compWidthErrMessage ? (
-								<>
-									<Spacing y={1} block />
-									<ValidationMessage
-										align="flex-start"
-										message={compWidthErrMessage}
-										type="error"
-									/>
-								</>
-							) : null}
+							<InputAndValidationContainer>
+								<InputDragger
+									type="number"
+									value={size.width}
+									placeholder="Width"
+									onTextChange={onWidthChanged}
+									name="width"
+									step={2}
+									min={2}
+									required
+									status="ok"
+									formatter={(w) => `${w}px`}
+									max={100000000}
+									onValueChange={onWidthDirectlyChanged}
+									rightAlign={false}
+								/>
+								{compWidthErrMessage ? (
+									<>
+										<Spacing y={1} block />
+										<ValidationMessage
+											align="flex-start"
+											message={compWidthErrMessage}
+											type="error"
+										/>
+									</>
+								) : null}
+							</InputAndValidationContainer>
 						</div>
 					</div>
 					<div style={optionRow}>
 						<div style={label}>Height</div>
 						<div style={rightRow}>
-							<InputDragger
-								type="number"
-								value={size.height}
-								onTextChange={onHeightChanged}
-								placeholder="Height"
-								name="height"
-								step={2}
-								required
-								formatter={(h) => `${h}px`}
-								min={2}
-								status="ok"
-								max={100000000}
-								onValueChange={onHeightDirectlyChanged}
-								rightAlign={false}
-							/>
-							{compHeightErrMessage ? (
-								<>
-									<Spacing y={1} block />
-									<ValidationMessage
-										align="flex-start"
-										message={compHeightErrMessage}
-										type="error"
-									/>
-								</>
-							) : null}
+							<InputAndValidationContainer>
+								<InputDragger
+									type="number"
+									value={size.height}
+									onTextChange={onHeightChanged}
+									placeholder="Height"
+									name="height"
+									step={2}
+									required
+									formatter={(h) => `${h}px`}
+									min={2}
+									status="ok"
+									max={100000000}
+									onValueChange={onHeightDirectlyChanged}
+									rightAlign={false}
+								/>
+								{compHeightErrMessage ? (
+									<>
+										<Spacing y={1} block />
+										<ValidationMessage
+											align="flex-start"
+											message={compHeightErrMessage}
+											type="error"
+										/>
+									</>
+								) : null}
+							</InputAndValidationContainer>
 						</div>
 					</div>
 					<NewCompDuration

--- a/packages/studio/src/components/NewComposition/RenameComposition.tsx
+++ b/packages/studio/src/components/NewComposition/RenameComposition.tsx
@@ -18,6 +18,7 @@ import {
 } from '../RenderModal/ResolveCompositionBeforeModal';
 import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
+import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {RemotionInput} from './RemInput';
 import {ValidationMessage} from './ValidationMessage';
 
@@ -80,7 +81,7 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 					<div style={optionRow}>
 						<div style={label}>ID</div>
 						<div style={rightRow}>
-							<div>
+							<InputAndValidationContainer>
 								<RemotionInput
 									ref={inputRef}
 									value={newId}
@@ -101,7 +102,7 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 										/>
 									</>
 								) : null}
-							</div>
+							</InputAndValidationContainer>
 						</div>
 					</div>
 				</div>

--- a/packages/studio/src/components/NewComposition/RenameFolder.tsx
+++ b/packages/studio/src/components/NewComposition/RenameFolder.tsx
@@ -18,6 +18,7 @@ import {label, optionRow, rightRow} from '../RenderModal/layout';
 import {applyCodemod} from '../RenderQueue/actions';
 import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
+import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {RemotionInput} from './RemInput';
 import {ValidationMessage} from './ValidationMessage';
 
@@ -83,7 +84,7 @@ export const RenameFolder: React.FC<{
 					<div style={optionRow}>
 						<div style={label}>Name</div>
 						<div style={rightRow}>
-							<div>
+							<InputAndValidationContainer>
 								<RemotionInput
 									ref={inputRef}
 									value={newName}
@@ -104,7 +105,7 @@ export const RenameFolder: React.FC<{
 										/>
 									</>
 								) : null}
-							</div>
+							</InputAndValidationContainer>
 						</div>
 					</div>
 				</div>

--- a/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
+++ b/packages/studio/src/components/NewComposition/RenameStaticFile.tsx
@@ -19,6 +19,7 @@ import {showNotification} from '../Notifications/NotificationCenter';
 import {label, optionRow, rightRow} from '../RenderModal/layout';
 import {useStaticFiles} from '../use-static-files';
 import {DismissableModal} from './DismissableModal';
+import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {RemotionInput} from './RemInput';
 import {ValidationMessage} from './ValidationMessage';
 
@@ -156,7 +157,7 @@ export const RenameStaticFileModal: React.FC<{
 					<div style={optionRow}>
 						<div style={label}>Name</div>
 						<div style={rightRow}>
-							<div>
+							<InputAndValidationContainer>
 								<RemotionInput
 									ref={inputRef}
 									value={newName}
@@ -179,7 +180,7 @@ export const RenameStaticFileModal: React.FC<{
 										/>
 									</>
 								) : null}
-							</div>
+							</InputAndValidationContainer>
 						</div>
 					</div>
 				</div>

--- a/packages/studio/src/components/NewComposition/ValidationMessage.tsx
+++ b/packages/studio/src/components/NewComposition/ValidationMessage.tsx
@@ -24,13 +24,22 @@ const compactStyle: React.CSSProperties = {
 };
 
 const container: React.CSSProperties = {
+	width: '100%',
 	maxWidth: 500,
+	minWidth: 0,
+};
+
+const row: React.CSSProperties = {
+	minWidth: 0,
 };
 
 const label: React.CSSProperties = {
 	fontSize: 13,
 	color: 'white',
 	fontFamily: 'sans-serif',
+	minWidth: 0,
+	whiteSpace: 'normal',
+	overflowWrap: 'anywhere',
 };
 
 const compactLabel: React.CSSProperties = {
@@ -58,7 +67,7 @@ export const ValidationMessage: React.FC<{
 
 	return (
 		<div style={container}>
-			<Row align="center" justify={align}>
+			<Row align="center" justify={align} style={row}>
 				<WarningTriangle style={finalStyle} />
 				<Spacing x={size === 'compact' ? 0.75 : 1} />
 				<div style={labelStyle}>{message}</div>


### PR DESCRIPTION
## Summary

- Constrain validation messages so create, duplicate, rename, and related Studio dialogs keep a stable width
- Add a shared input/validation wrapper for NewComposition dialogs
- Allow validation text to wrap instead of widening the modal

Fixes #8717.

## Testing

- `cd packages/studio && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
