### PR TITLE
`@remotion/studio`: Fix context menu retriggering

### DIFF
--- a/packages/studio/src/components/ContextMenu.tsx
+++ b/packages/studio/src/components/ContextMenu.tsx
@@ -50,6 +50,27 @@ type ContextMenuProps = {
 	readonly onPointerDown?: React.PointerEventHandler<HTMLDivElement>;
 };
 
+const contextMenuFullScreenOverlay: React.CSSProperties = {
+	...fullScreenOverlay,
+	pointerEvents: 'none',
+};
+
+const contextMenuOuterPortal: React.CSSProperties = {
+	...outerPortal,
+	pointerEvents: 'auto',
+};
+
+const contextMenuOpenedEvent = 'remotion-context-menu-opened';
+let nextContextMenuId = 0;
+
+const notifyContextMenuOpened = (id: number) => {
+	window.dispatchEvent(
+		new CustomEvent(contextMenuOpenedEvent, {
+			detail: id,
+		}),
+	);
+};
+
 const ContextMenuPortal: React.FC<{
 	readonly sizeSource: ContextMenuSizeSource;
 	readonly currentZIndex: number;
@@ -57,6 +78,7 @@ const ContextMenuPortal: React.FC<{
 	readonly opened: OpenedState;
 	readonly values: ComboboxValue[];
 }> = ({sizeSource, currentZIndex, onHide, opened, values}) => {
+	const menuRef = useRef<HTMLDivElement>(null);
 	const size = PlayerInternals.useElementSize(sizeSource, {
 		triggerOnWindowResize: true,
 		shouldApplyCssTransforms: true,
@@ -122,6 +144,45 @@ const ContextMenuPortal: React.FC<{
 		spaceToBottom,
 	]);
 
+	useEffect(() => {
+		const preventNativeContextMenu = (event: MouseEvent) => {
+			event.preventDefault();
+		};
+
+		window.addEventListener('contextmenu', preventNativeContextMenu, true);
+
+		return () => {
+			window.removeEventListener('contextmenu', preventNativeContextMenu, true);
+		};
+	}, []);
+
+	useEffect(() => {
+		const dismissWithoutClickThrough = (event: PointerEvent) => {
+			if (event.button !== 0) {
+				return;
+			}
+
+			if (menuRef.current?.contains(event.target as Node)) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			event.stopImmediatePropagation();
+			onHide();
+		};
+
+		window.addEventListener('pointerdown', dismissWithoutClickThrough, true);
+
+		return () => {
+			window.removeEventListener(
+				'pointerdown',
+				dismissWithoutClickThrough,
+				true,
+			);
+		};
+	}, [onHide]);
+
 	// Prevent deselection of a selected item
 	const onMenuPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
@@ -135,10 +196,18 @@ const ContextMenuPortal: React.FC<{
 	}
 
 	return ReactDOM.createPortal(
-		<div style={fullScreenOverlay}>
-			<div style={outerPortal} className="css-reset">
-				<HigherZIndex onOutsideClick={onHide} onEscape={onHide}>
-					<div style={portalStyle} onPointerDown={onMenuPointerDown}>
+		<div style={contextMenuFullScreenOverlay}>
+			<div style={contextMenuOuterPortal} className="css-reset">
+				<HigherZIndex
+					onOutsideClick={onHide}
+					onEscape={onHide}
+					outsideClickButton="primary"
+				>
+					<div
+						ref={menuRef}
+						style={portalStyle}
+						onPointerDown={onMenuPointerDown}
+					>
 						<MenuContent
 							onNextMenu={noop}
 							onPreviousMenu={noop}
@@ -170,6 +239,7 @@ export const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
 		forwardedRef,
 	) => {
 		const ref = useRef<HTMLDivElement>(null);
+		const idRef = useRef(nextContextMenuId++);
 		const [opened, setOpened] = useState<OpenState>({type: 'not-open'});
 		const {currentZIndex} = useZIndex();
 
@@ -203,6 +273,7 @@ export const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
 					return false;
 				}
 
+				notifyContextMenuOpened(idRef.current);
 				setOpened({type: 'open', left: e.clientX, top: e.clientY});
 
 				return false;
@@ -218,6 +289,25 @@ export const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
 		const onHide = useCallback(() => {
 			setOpened({type: 'not-open'});
 		}, []);
+
+		useEffect(() => {
+			const onOtherContextMenuOpened = (event: Event) => {
+				if ((event as CustomEvent<number>).detail === idRef.current) {
+					return;
+				}
+
+				onHide();
+			};
+
+			window.addEventListener(contextMenuOpenedEvent, onOtherContextMenuOpened);
+
+			return () => {
+				window.removeEventListener(
+					contextMenuOpenedEvent,
+					onOtherContextMenuOpened,
+				);
+			};
+		}, [onHide]);
 
 		return (
 			<>
@@ -251,6 +341,7 @@ export const ContextMenuForTarget: React.FC<{
 	readonly values: ComboboxValue[];
 	readonly onOpen: ContextMenuTargetOpenHandler | null;
 }> = ({triggerRef, values, onOpen}) => {
+	const idRef = useRef(nextContextMenuId++);
 	const [opened, setOpened] = useState<OpenState>({type: 'not-open'});
 	const [openedValues, setOpenedValues] =
 		useState<readonly ComboboxValue[]>(values);
@@ -284,6 +375,7 @@ export const ContextMenuForTarget: React.FC<{
 				return false;
 			}
 
+			notifyContextMenuOpened(idRef.current);
 			setOpenedValues(nextValues);
 			setOpened({type: 'open', left: e.clientX, top: e.clientY});
 
@@ -300,6 +392,25 @@ export const ContextMenuForTarget: React.FC<{
 	const onHide = useCallback(() => {
 		setOpened({type: 'not-open'});
 	}, []);
+
+	useEffect(() => {
+		const onOtherContextMenuOpened = (event: Event) => {
+			if ((event as CustomEvent<number>).detail === idRef.current) {
+				return;
+			}
+
+			onHide();
+		};
+
+		window.addEventListener(contextMenuOpenedEvent, onOtherContextMenuOpened);
+
+		return () => {
+			window.removeEventListener(
+				contextMenuOpenedEvent,
+				onOtherContextMenuOpened,
+			);
+		};
+	}, [onHide]);
 
 	return opened.type === 'open' ? (
 		<ContextMenuPortal

--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -51,7 +51,14 @@ export const HigherZIndex: React.FC<{
 	readonly onOutsideClick: (target: Node) => void;
 	readonly children: React.ReactNode;
 	readonly disabled?: boolean;
-}> = ({children, onEscape, onOutsideClick, disabled}) => {
+	readonly outsideClickButton?: 'any' | 'primary';
+}> = ({
+	children,
+	onEscape,
+	onOutsideClick,
+	disabled,
+	outsideClickButton = 'any',
+}) => {
 	const context = useContext(ZIndexContext);
 	const highestContext = useContext(HighestZIndexContext);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -77,6 +84,10 @@ export const HigherZIndex: React.FC<{
 		let onUp: ((upEvent: MouseEvent) => void) | null = null;
 
 		const listener = (downEvent: MouseEvent) => {
+			if (outsideClickButton === 'primary' && downEvent.button !== 0) {
+				return;
+			}
+
 			const outsideClick = !containerRef.current?.contains(
 				downEvent.target as Node,
 			);
@@ -117,7 +128,13 @@ export const HigherZIndex: React.FC<{
 
 			return window.removeEventListener('pointerdown', listener, true);
 		};
-	}, [currentIndex, disabled, highestContext.highestIndex, onOutsideClick]);
+	}, [
+		currentIndex,
+		disabled,
+		highestContext.highestIndex,
+		onOutsideClick,
+		outsideClickButton,
+	]);
 
 	const value = useMemo((): ZIndex => {
 		return {


### PR DESCRIPTION
## Summary

Fixes #7755 

- Allow right-clicks to pass through an open Studio context menu overlay so another context menu target can handle them
- Prevent the native browser context menu while a Studio context menu is open
- Avoid treating secondary-button pointer downs as outside clicks, so retriggered context menus are not immediately closed on pointerup

## Testing
- `cd packages/studio && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
