### PR TITLE
`@remotion/studio`: Preserve inspector collapsed effects

### DIFF
--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -69,8 +69,50 @@ const isEffectsRoot = (
 	return auxiliaryKeys[auxiliaryKeys.length - 1] === 'effects';
 };
 
+const INSPECTOR_COLLAPSED_ROWS_SESSION_STORAGE_KEY =
+	'remotion.editor.inspectorCollapsedRows';
+
 const getInspectorExpansionKey = (nodePathInfo: SequenceNodePathInfo) => {
 	return JSON.stringify(nodePathInfo);
+};
+
+const loadInspectorCollapsedKeys = (): ReadonlySet<string> => {
+	if (typeof window === 'undefined') {
+		return new Set();
+	}
+
+	try {
+		const raw = window.sessionStorage.getItem(
+			INSPECTOR_COLLAPSED_ROWS_SESSION_STORAGE_KEY,
+		);
+		if (raw === null) {
+			return new Set();
+		}
+
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed)) {
+			return new Set();
+		}
+
+		return new Set(parsed.filter((key) => typeof key === 'string'));
+	} catch {
+		return new Set();
+	}
+};
+
+const persistInspectorCollapsedKeys = (keys: ReadonlySet<string>): void => {
+	if (typeof window === 'undefined') {
+		return;
+	}
+
+	try {
+		window.sessionStorage.setItem(
+			INSPECTOR_COLLAPSED_ROWS_SESSION_STORAGE_KEY,
+			JSON.stringify([...keys]),
+		);
+	} catch {
+		// Ignore quota errors or disabled storage.
+	}
 };
 
 type SequenceWithControls = TSequence & {
@@ -125,7 +167,7 @@ export const InspectorSequenceSection: React.FC<{
 		nodePathInfo,
 	});
 	const [collapsedKeys, setCollapsedKeys] = useState<ReadonlySet<string>>(
-		() => new Set(),
+		loadInspectorCollapsedKeys,
 	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {setSelectedModal} = useContext(ModalsContext);
@@ -147,6 +189,7 @@ export const InspectorSequenceSection: React.FC<{
 				next.add(key);
 			}
 
+			persistInspectorCollapsedKeys(next);
 			return next;
 		});
 	}, []);


### PR DESCRIPTION
## Summary

- Preserve collapsed rows in the Studio inspector across inspector unmounts/reselection
- Store inspector collapse state separately from timeline expanded-track state
- Keep effect row identity based on the existing inspector node path info rather than effect labels

Fixes #8548.

## Verification

- `cd packages/studio && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`

Note: The first `bun run stylecheck` failed because an untracked `packages/template-react-router/.react-router` generated directory contained stale types. I removed that untracked generated directory and reran `bun run stylecheck`, which passed.
