### PR TITLE
`@remotion/media`: Fix `<Video>` reinitializing MediaPlayer when onError identity changes

### DIFF
--- a/packages/media/src/test/video-onerror-stable.test.tsx
+++ b/packages/media/src/test/video-onerror-stable.test.tsx
@@ -1,0 +1,83 @@
+import {Player} from '@remotion/player';
+import React, {useEffect, useState} from 'react';
+import {createRoot} from 'react-dom/client';
+import {expect, test, vi} from 'vitest';
+import {MediaPlayer} from '../media-player';
+import {Video} from '../video/video';
+
+const waitFor = async (predicate: () => boolean) => {
+	const started = Date.now();
+	while (Date.now() - started < 10000) {
+		if (predicate()) {
+			return;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+
+	throw new Error('Timed out waiting for condition');
+};
+
+test('does not reinitialize MediaPlayer when onError identity changes', async () => {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+
+	const initSpy = vi.spyOn(MediaPlayer.prototype, 'initialize');
+	const root = createRoot(container);
+	let committedRerenders = 0;
+
+	const VideoComposition: React.FC = () => {
+		const [rerenders, setRerenders] = useState(0);
+
+		useEffect(() => {
+			const interval = window.setInterval(() => {
+				setRerenders((current) => {
+					if (current >= 4) {
+						window.clearInterval(interval);
+						return current;
+					}
+
+					return current + 1;
+				});
+			}, 50);
+
+			return () => window.clearInterval(interval);
+		}, []);
+
+		useEffect(() => {
+			committedRerenders = rerenders;
+		}, [rerenders]);
+
+		return <Video src="/bigbuckbunny.mp4" onError={() => {}} />;
+	};
+
+	root.render(
+		<Player
+			acknowledgeRemotionLicense
+			component={VideoComposition}
+			compositionHeight={720}
+			compositionWidth={1280}
+			durationInFrames={100}
+			fps={30}
+			initiallyMuted
+			inputProps={{}}
+		/>,
+	);
+
+	try {
+		await waitFor(() => {
+			const renderedCanvas = container.querySelector('canvas');
+			return (
+				renderedCanvas?.width === 1280 &&
+				renderedCanvas.height === 720 &&
+				committedRerenders >= 4
+			);
+		});
+
+		expect(initSpy.mock.calls.length).toBe(1);
+	} finally {
+		root.unmount();
+		container.remove();
+		initSpy.mockRestore();
+	}
+});

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -169,6 +169,9 @@ const VideoForPreviewAssertedShowing: React.FC<
 	const effectsRef = useRef(effects);
 	effectsRef.current = effects;
 
+	const onErrorRef = useRef(onError);
+	onErrorRef.current = onError;
+
 	const effectChainStateRef = useRef(effectChainState);
 	effectChainStateRef.current = effectChainState;
 
@@ -306,7 +309,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 
 					const handleError = (error: Error, fallbackMessage: string) => {
 						const [action, errorToUse] = callOnErrorAndResolve({
-							onError,
+							onError: onErrorRef.current,
 							error,
 							disallowFallback: disallowFallbackToOffthreadVideo,
 							isClientSideRendering: false,
@@ -365,7 +368,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 				})
 				.catch((error) => {
 					const [action, errorToUse] = callOnErrorAndResolve({
-						onError,
+						onError: onErrorRef.current,
 						error,
 						disallowFallback: disallowFallbackToOffthreadVideo,
 						isClientSideRendering: false,
@@ -385,7 +388,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 		} catch (error) {
 			const [action, errorToUse] = callOnErrorAndResolve({
 				error: error as Error,
-				onError,
+				onError: onErrorRef.current,
 				disallowFallback: disallowFallbackToOffthreadVideo,
 				isClientSideRendering: false,
 				clientSideError: error as Error,
@@ -426,7 +429,6 @@ const VideoForPreviewAssertedShowing: React.FC<
 		preloadedSrc,
 		sharedAudioContext,
 		videoConfig.fps,
-		onError,
 		credentials,
 		initialRequestInit,
 		setMediaDurationInSeconds,


### PR DESCRIPTION
## Summary

Passing an inline `onError` callback to `<Video>` from `@remotion/media` no longer tears down and rebuilds the preview `MediaPlayer` on every frame. `onError` is now read through a ref instead of being a dependency of the player-initialization effect, so a changing callback identity does not restart playback.

## Why this matters

The `MediaPlayer`-init `useEffect` in `packages/media/src/video/video-for-preview.tsx` listed `onError` in its dependency array. When a caller passed a non-memoized `onError` (a new function each render), the effect re-ran every frame during preview playback: it disposed the player, recreated it, and re-opened the `UrlSource`. That produced one Range request per displayed frame plus repeated re-decodes, saturating the decoder and causing preview stutter and audio drop-outs. Memoizing `onError` with `useCallback` made the symptom disappear, which pointed at the dependency array as the root cause.

The fix mirrors the ref pattern already used in the same file for other per-render callbacks (for example `effectsRef`):

- `onErrorRef = useRef(onError)` kept current on every render.
- The three call sites inside the init effect now read `onErrorRef.current` instead of `onError`.
- `onError` is removed from the init effect dependency array.

Behavior for stable callbacks is unchanged, and the most recent `onError` is still the one invoked when an error fires. The scope is limited to the `<Video>` preview path named in the issue; the audio preview path is untouched.

## Testing

- Added `packages/media/src/test/video-onerror-stable.test.tsx`: it spies on `MediaPlayer.prototype.initialize`, renders `<Video>` with a fresh inline `onError` identity on every render across several forced re-renders, and asserts the player initializes exactly once.
- `oxfmt src --check`, `eslint src`, and a `tsgo` typecheck pass for `@remotion/media`.
- The package build (`turbo run make` for `@remotion/media`) passes.
- The vitest browser suite could not be launched in my environment (the WebdriverIO chromedriver download returned 404 for the local Chrome version), so the new test was not executed here; it follows the existing `player-muted-video.test.tsx` pattern.

Fixes #8722
