### PR TITLE
`@remotion/studio`: Cut effects (Cmd+X)

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -313,6 +313,128 @@ export type EffectClipboardDataFromSelections =
 			readonly type: 'uncopyable';
 	  };
 
+export type PendingEffectCut = {
+	readonly payload: EffectClipboardData;
+	readonly sourceTargetKey: string | null;
+	readonly selectedEffects:
+		| readonly {
+				readonly effectIndex: number;
+				readonly effect: EffectClipboardSnapshot;
+		  }[]
+		| null;
+};
+
+const getPendingEffectCut = ({
+	selectedItems,
+	payload,
+}: {
+	readonly selectedItems: readonly TimelineSelection[];
+	readonly payload: EffectClipboardData;
+}): PendingEffectCut => {
+	const effectSelections = selectedItems.filter(
+		(
+			selection,
+		): selection is Extract<TimelineSelection, {type: 'sequence-effect'}> =>
+			selection.type === 'sequence-effect',
+	);
+	if (
+		effectSelections.length !== selectedItems.length ||
+		effectSelections.length !== payload.effects.length
+	) {
+		return {
+			payload,
+			sourceTargetKey: null,
+			selectedEffects: null,
+		};
+	}
+
+	const firstEffectSelection = effectSelections[0];
+	if (!firstEffectSelection) {
+		return {
+			payload,
+			sourceTargetKey: null,
+			selectedEffects: null,
+		};
+	}
+
+	const sourceTargetKey = makeTargetKey(
+		firstEffectSelection.nodePathInfo.sequenceSubscriptionKey,
+	);
+	if (
+		effectSelections.some(
+			(selection) =>
+				makeTargetKey(selection.nodePathInfo.sequenceSubscriptionKey) !==
+				sourceTargetKey,
+		)
+	) {
+		return {
+			payload,
+			sourceTargetKey: null,
+			selectedEffects: null,
+		};
+	}
+
+	const selectedEffects = effectSelections.map((selection, index) => {
+		const effect = payload.effects[index];
+		if (!effect) {
+			throw new Error('Expected copied effect for selection');
+		}
+
+		return {
+			effectIndex: selection.i,
+			effect,
+		};
+	});
+
+	return {
+		payload,
+		sourceTargetKey,
+		selectedEffects: selectedEffects.sort(
+			(a, b) => a.effectIndex - b.effectIndex,
+		),
+	};
+};
+
+export const getPendingEffectCutPastePayload = ({
+	pendingCut,
+	targetNodePathInfo,
+	propStatuses,
+}: {
+	readonly pendingCut: PendingEffectCut;
+	readonly targetNodePathInfo: SequenceNodePathInfo;
+	readonly propStatuses: PropStatuses;
+}): EffectClipboardData => {
+	if (
+		pendingCut.selectedEffects === null ||
+		pendingCut.sourceTargetKey !==
+			makeTargetKey(targetNodePathInfo.sequenceSubscriptionKey)
+	) {
+		return pendingCut.payload;
+	}
+
+	const currentSnapshots = getSnapshotsFromSelection({
+		selection: {
+			type: 'sequence-all-effects',
+			nodePathInfo: targetNodePathInfo,
+		},
+		propStatuses,
+	});
+	if (currentSnapshots === null) {
+		return pendingCut.payload;
+	}
+
+	const effects = [...currentSnapshots];
+	for (const {effectIndex, effect} of pendingCut.selectedEffects) {
+		effects.splice(Math.min(effectIndex, effects.length), 0, effect);
+	}
+
+	return {
+		...pendingCut.payload,
+		type: 'effects-replacing',
+		effects,
+	};
+};
+
 export const getEffectClipboardDataFromSelections = ({
 	selectedItems,
 	propStatuses,
@@ -557,6 +679,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 	const confirm = useConfirmationDialog();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const timelinePositionRef = useRef(timelinePosition);
+	const pendingEffectCutRef = useRef<PendingEffectCut | null>(null);
 
 	useEffect(() => {
 		timelinePositionRef.current = timelinePosition;
@@ -608,6 +731,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 					navigator.clipboard
 						.writeText(makeClipboardText(payload))
 						.then(() => {
+							pendingEffectCutRef.current = null;
 							showNotification('Copied easing to clipboard', 1000);
 						})
 						.catch((err) => {
@@ -648,6 +772,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 					navigator.clipboard
 						.writeText(makeClipboardText(payload))
 						.then(() => {
+							pendingEffectCutRef.current = null;
 							showNotification('Copied effect prop to clipboard', 1000);
 						})
 						.catch((err) => {
@@ -690,6 +815,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 				navigator.clipboard
 					.writeText(makeClipboardText(effectClipboardData.payload))
 					.then(() => {
+						pendingEffectCutRef.current = null;
 						showNotification(
 							effectClipboardData.payload.effects.length === 1
 								? 'Copied effect to clipboard'
@@ -749,36 +875,39 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 					return;
 				}
 
-				navigator.clipboard
-					.writeText(makeClipboardText(effectClipboardData.payload))
-					.then(() => {
-						const deletePromise = deleteSelectedTimelineItems({
+				const pendingCut = getPendingEffectCut({
+					selectedItems,
+					payload: effectClipboardData.payload,
+				});
+
+				const deletePromise = deleteSelectedTimelineItems({
+					selections: selectedItems,
+					sequences,
+					overrideIdsToNodePaths: overrideIdToNodePathMappings,
+					setPropStatuses,
+					clientId,
+					confirm,
+				});
+
+				return deletePromise
+					?.then((deleted) => {
+						if (!deleted) {
+							return;
+						}
+
+						pendingEffectCutRef.current = pendingCut;
+						const nextSelection = getTimelineSelectionAfterDeletingItems({
 							selections: selectedItems,
 							sequences,
 							overrideIdsToNodePaths: overrideIdToNodePathMappings,
-							setPropStatuses,
-							clientId,
-							confirm,
+							propStatuses,
+							timelinePosition: timelinePositionRef.current,
 						});
-
-						return deletePromise?.then((deleted) => {
-							if (!deleted) {
-								return;
-							}
-
-							const nextSelection = getTimelineSelectionAfterDeletingItems({
-								selections: selectedItems,
-								sequences,
-								overrideIdsToNodePaths: overrideIdToNodePathMappings,
-								propStatuses,
-								timelinePosition: timelinePositionRef.current,
-							});
-							if (nextSelection.length === 0) {
-								clearSelection();
-							} else {
-								selectItems(nextSelection);
-							}
-						});
+						if (nextSelection.length === 0) {
+							clearSelection();
+						} else {
+							selectItems(nextSelection);
+						}
 					})
 					.catch((err) => {
 						showNotification(
@@ -800,6 +929,62 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 				const {selectedItems} = currentSelection.current;
 				if (selectedItems.length === 0) {
 					return;
+				}
+
+				const pendingCut = pendingEffectCutRef.current;
+				if (pendingCut !== null) {
+					const propStatuses = propStatusesRef.current;
+					const target = getPasteEffectsTarget(selectedItems);
+					if (target.type === 'multiple') {
+						e.preventDefault();
+						showNotification(
+							'Select one target sequence to paste effects',
+							3000,
+						);
+						return;
+					}
+
+					if (target.type === 'none') {
+						e.preventDefault();
+						showNotification('Select a sequence to paste effects onto', 3000);
+						return;
+					}
+
+					if (target.type === 'unsupported') {
+						e.preventDefault();
+						showNotification('This sequence does not support effects', 3000);
+						return;
+					}
+
+					e.preventDefault();
+					const {sequenceSubscriptionKey: targetSequenceNodePath} =
+						target.nodePathInfo;
+					const payload = getPendingEffectCutPastePayload({
+						pendingCut,
+						targetNodePathInfo: target.nodePathInfo,
+						propStatuses,
+					});
+					return callApi('/api/paste-effects', {
+						targetFileName: targetSequenceNodePath.absolutePath,
+						targetSequenceNodePath,
+						type: payload.type,
+						effects: payload.effects,
+						clientId,
+					})
+						.then((pasteResult) => {
+							if (pasteResult.success) {
+								pendingEffectCutRef.current = null;
+								showNotification('Pasted effects', 2000);
+							} else {
+								showNotification(pasteResult.reason, 4000);
+							}
+						})
+						.catch((err) => {
+							showNotification(
+								`Could not paste effects: ${(err as Error).message}`,
+								3000,
+							);
+						});
 				}
 
 				navigator.clipboard

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -12,7 +12,7 @@ import {
 	type EffectPropClipboardData,
 } from '@remotion/studio-shared';
 import type React from 'react';
-import {useContext, useEffect} from 'react';
+import {useContext, useEffect, useRef} from 'react';
 import {
 	Internals,
 	type OverrideIdToNodePaths,
@@ -26,7 +26,12 @@ import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {useKeybinding} from '../../helpers/use-keybinding';
 import {callApi} from '../call-api';
+import {useConfirmationDialog} from '../ConfirmationDialog';
 import {showNotification} from '../Notifications/NotificationCenter';
+import {
+	deleteSelectedTimelineItems,
+	getTimelineSelectionAfterDeletingItems,
+} from './delete-selected-timeline-item';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
 import {saveEffectProp} from './save-effect-prop';
 import {
@@ -293,6 +298,61 @@ export const getSnapshotsFromSelection = ({
 	return snapshots;
 };
 
+export type EffectClipboardDataFromSelections =
+	| {
+			readonly type: 'valid';
+			readonly payload: EffectClipboardData;
+	  }
+	| {
+			readonly type: 'none';
+	  }
+	| {
+			readonly type: 'mixed';
+	  }
+	| {
+			readonly type: 'uncopyable';
+	  };
+
+export const getEffectClipboardDataFromSelections = ({
+	selectedItems,
+	propStatuses,
+}: {
+	selectedItems: readonly TimelineSelection[];
+	propStatuses: PropStatuses;
+}): EffectClipboardDataFromSelections => {
+	const firstSelection = selectedItems[0];
+	const type = firstSelection ? getCopyType(firstSelection) : null;
+
+	if (type === null) {
+		return {type: 'none'};
+	}
+
+	if (selectedItems.some((selection) => getCopyType(selection) !== type)) {
+		return {type: 'mixed'};
+	}
+
+	const snapshots = selectedItems.flatMap((selection) => {
+		const itemSnapshots = getSnapshotsFromSelection({
+			selection,
+			propStatuses,
+		});
+		return itemSnapshots ?? [null];
+	});
+	if (snapshots.some((snapshot) => snapshot === null)) {
+		return {type: 'uncopyable'};
+	}
+
+	return {
+		type: 'valid',
+		payload: {
+			type,
+			version: 3,
+			remotionClipboard: 'effects',
+			effects: snapshots as EffectClipboardSnapshot[],
+		},
+	};
+};
+
 export const getEffectPropClipboardDataFromSelection = ({
 	selection,
 	propStatuses,
@@ -494,6 +554,13 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 	const {overrideIdToNodePathMappings} = useContext(
 		Internals.OverrideIdsToNodePathsGettersContext,
 	);
+	const confirm = useConfirmationDialog();
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const timelinePositionRef = useRef(timelinePosition);
+
+	useEffect(() => {
+		timelinePositionRef.current = timelinePosition;
+	}, [timelinePosition]);
 
 	useEffect(() => {
 		if (!canSelect || previewServerState.type !== 'connected') {
@@ -592,16 +659,16 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 					return;
 				}
 
-				const firstSelection = selectedItems[0];
-				const type = firstSelection ? getCopyType(firstSelection) : null;
+				const effectClipboardData = getEffectClipboardDataFromSelections({
+					selectedItems,
+					propStatuses,
+				});
 
-				if (type === null) {
+				if (effectClipboardData.type === 'none') {
 					return;
 				}
 
-				if (
-					selectedItems.some((selection) => getCopyType(selection) !== type)
-				) {
+				if (effectClipboardData.type === 'mixed') {
 					e.preventDefault();
 					showNotification(
 						'Cannot copy individual effects together with all effects',
@@ -610,14 +677,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 					return;
 				}
 
-				const snapshots = selectedItems.flatMap((selection) => {
-					const itemSnapshots = getSnapshotsFromSelection({
-						selection,
-						propStatuses,
-					});
-					return itemSnapshots ?? [null];
-				});
-				if (snapshots.some((snapshot) => snapshot === null)) {
+				if (effectClipboardData.type === 'uncopyable') {
 					e.preventDefault();
 					showNotification(
 						'Cannot copy effects because one of them contains values that cannot be copied',
@@ -628,17 +688,10 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 
 				e.preventDefault();
 				navigator.clipboard
-					.writeText(
-						makeClipboardText({
-							type,
-							version: 3,
-							remotionClipboard: 'effects',
-							effects: snapshots as EffectClipboardSnapshot[],
-						}),
-					)
+					.writeText(makeClipboardText(effectClipboardData.payload))
 					.then(() => {
 						showNotification(
-							snapshots.length === 1
+							effectClipboardData.payload.effects.length === 1
 								? 'Copied effect to clipboard'
 								: 'Copied effects to clipboard',
 							1000,
@@ -647,6 +700,89 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 					.catch((err) => {
 						showNotification(
 							`Could not copy effects: ${(err as Error).message}`,
+							2000,
+						);
+					});
+			},
+			commandCtrlKey: true,
+			preventDefault: false,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+
+		const cut = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'x',
+			callback: (e) => {
+				const {selectedItems, clearSelection, selectItems} =
+					currentSelection.current;
+				const propStatuses = propStatusesRef.current;
+				const sequences = sequencesRef.current;
+				if (selectedItems.length === 0) {
+					return;
+				}
+
+				const effectClipboardData = getEffectClipboardDataFromSelections({
+					selectedItems,
+					propStatuses,
+				});
+
+				if (effectClipboardData.type === 'none') {
+					return;
+				}
+
+				e.preventDefault();
+
+				if (effectClipboardData.type === 'mixed') {
+					showNotification(
+						'Cannot cut individual effects together with all effects',
+						3000,
+					);
+					return;
+				}
+
+				if (effectClipboardData.type === 'uncopyable') {
+					showNotification(
+						'Cannot cut effects because one of them contains values that cannot be copied',
+						3000,
+					);
+					return;
+				}
+
+				navigator.clipboard
+					.writeText(makeClipboardText(effectClipboardData.payload))
+					.then(() => {
+						const deletePromise = deleteSelectedTimelineItems({
+							selections: selectedItems,
+							sequences,
+							overrideIdsToNodePaths: overrideIdToNodePathMappings,
+							setPropStatuses,
+							clientId,
+							confirm,
+						});
+
+						return deletePromise?.then((deleted) => {
+							if (!deleted) {
+								return;
+							}
+
+							const nextSelection = getTimelineSelectionAfterDeletingItems({
+								selections: selectedItems,
+								sequences,
+								overrideIdsToNodePaths: overrideIdToNodePathMappings,
+								propStatuses,
+								timelinePosition: timelinePositionRef.current,
+							});
+							if (nextSelection.length === 0) {
+								clearSelection();
+							} else {
+								selectItems(nextSelection);
+							}
+						});
+					})
+					.catch((err) => {
+						showNotification(
+							`Could not cut effects: ${(err as Error).message}`,
 							2000,
 						);
 					});
@@ -879,10 +1015,12 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 
 		return () => {
 			copy.unregister();
+			cut.unregister();
 			paste.unregister();
 		};
 	}, [
 		canSelect,
+		confirm,
 		currentSelection,
 		keybindings,
 		overrideIdToNodePathMappings,
@@ -890,6 +1028,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 		previewServerState,
 		sequencesRef,
 		setPropStatuses,
+		timelinePositionRef,
 	]);
 
 	return null;

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -74,9 +74,11 @@ import {
 	getEasingClipboardDataFromSelection,
 	getEffectClipboardDataFromSelections,
 	getEffectPropClipboardDataFromSelection,
+	getPendingEffectCutPastePayload,
 	getPasteEffectPropTarget,
 	getPasteEffectsTarget,
 	getSnapshotsFromSelection,
+	type PendingEffectCut,
 	type PasteEffectPropTarget,
 	type PasteEffectsTarget,
 } from '../components/Timeline/TimelineClipboardKeybindings';
@@ -706,6 +708,83 @@ test('selected effects produce a reusable clipboard payload', () => {
 			propStatuses,
 		}),
 	).toEqual({type: 'mixed'});
+});
+
+test('pasting a cut effect into the same sequence preserves its original order', () => {
+	const effectNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0'],
+		true,
+		[['0']],
+	);
+	const nodePath = effectNodePathInfo.sequenceSubscriptionKey;
+	const brightness = {
+		callee: 'brightness',
+		importPath: '@remotion/effects',
+		params: {
+			amount: {
+				type: 'static' as const,
+				value: 1,
+			},
+		},
+	};
+	const blur = {
+		callee: 'blur',
+		importPath: '@remotion/effects',
+		params: {
+			amount: {
+				type: 'static' as const,
+				value: 2,
+			},
+		},
+	};
+	const pendingCut = {
+		payload: {
+			type: 'effects-additive',
+			version: 3,
+			remotionClipboard: 'effects',
+			effects: [brightness],
+		},
+		sourceTargetKey: JSON.stringify({
+			absolutePath: nodePath.absolutePath,
+			nodePath: nodePath.nodePath,
+			sequenceKeys: nodePath.sequenceKeys,
+		}),
+		selectedEffects: [{effectIndex: 0, effect: brightness}],
+	} satisfies PendingEffectCut;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'blur',
+					importPath: '@remotion/effects',
+					effectIndex: 0,
+					props: {
+						amount: {
+							status: 'static',
+							codeValue: 2,
+						},
+					},
+				},
+			],
+		},
+	} satisfies PropStatuses;
+
+	expect(
+		getPendingEffectCutPastePayload({
+			pendingCut,
+			targetNodePathInfo: effectNodePathInfo,
+			propStatuses,
+		}),
+	).toEqual({
+		type: 'effects-replacing',
+		version: 3,
+		remotionClipboard: 'effects',
+		effects: [brightness, blur],
+	});
 });
 
 test('copying a selected effect prop creates an effect prop payload', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -72,6 +72,7 @@ import {getTimelinePropResetTargets} from '../components/Timeline/reset-selected
 import {shouldSubscribeToSequenceProps} from '../components/Timeline/should-subscribe-to-sequence-props';
 import {
 	getEasingClipboardDataFromSelection,
+	getEffectClipboardDataFromSelections,
 	getEffectPropClipboardDataFromSelection,
 	getPasteEffectPropTarget,
 	getPasteEffectsTarget,
@@ -626,6 +627,85 @@ test('copying a keyframed effect creates a structured snapshot', () => {
 			},
 		},
 	]);
+});
+
+test('selected effects produce a reusable clipboard payload', () => {
+	const effectNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['effects', '0'],
+		true,
+		[['0']],
+	);
+	const nodePath = effectNodePathInfo.sequenceSubscriptionKey;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {},
+			effects: [
+				{
+					canUpdate: true,
+					callee: 'effect',
+					importPath: '@remotion/effect',
+					effectIndex: 0,
+					props: {
+						intensity: {
+							status: 'static',
+							codeValue: 10,
+						},
+					},
+				},
+			],
+		},
+	} satisfies PropStatuses;
+
+	expect(
+		getEffectClipboardDataFromSelections({
+			selectedItems: [
+				{
+					type: 'sequence-effect',
+					nodePathInfo: effectNodePathInfo,
+					i: 0,
+				},
+			],
+			propStatuses,
+		}),
+	).toEqual({
+		type: 'valid',
+		payload: {
+			type: 'effects-additive',
+			version: 3,
+			remotionClipboard: 'effects',
+			effects: [
+				{
+					callee: 'effect',
+					importPath: '@remotion/effect',
+					params: {
+						intensity: {
+							type: 'static',
+							value: 10,
+						},
+					},
+				},
+			],
+		},
+	});
+
+	expect(
+		getEffectClipboardDataFromSelections({
+			selectedItems: [
+				{
+					type: 'sequence-effect',
+					nodePathInfo: effectNodePathInfo,
+					i: 0,
+				},
+				{
+					type: 'sequence-all-effects',
+					nodePathInfo: effectNodePathInfo,
+				},
+			],
+			propStatuses,
+		}),
+	).toEqual({type: 'mixed'});
 });
 
 test('copying a selected effect prop creates an effect prop payload', () => {


### PR DESCRIPTION
Fixes #8581.

This adds a narrow Cmd/Ctrl+X path for selected effect rows. It reuses the same effect clipboard payload used by copy, then calls the existing timeline delete flow so selection cleanup and delete behavior stay shared.

Verification:
- bun test packages/studio/src/test/timeline-selection.test.ts
- bun run lint (packages/studio; existing warnings only)
- bun run formatting (packages/studio)
- bun run make (packages/studio)