### PR TITLE
`@remotion/studio`: Keep context menus above splitters

### DIFF
--- a/packages/studio/src/components/ContextMenu.tsx
+++ b/packages/studio/src/components/ContextMenu.tsx
@@ -50,9 +50,12 @@ type ContextMenuProps = {
 	readonly onPointerDown?: React.PointerEventHandler<HTMLDivElement>;
 };
 
+const CONTEXT_MENU_Z_INDEX = 1001;
+
 const contextMenuFullScreenOverlay: React.CSSProperties = {
 	...fullScreenOverlay,
 	pointerEvents: 'none',
+	zIndex: CONTEXT_MENU_Z_INDEX,
 };
 
 const contextMenuOuterPortal: React.CSSProperties = {


### PR DESCRIPTION
## Summary

- Keep Studio context menus above hovered panel splitters by assigning the context menu overlay a higher z-index than splitter hover states.

Fixes #8724.

## Testing

- `cd packages/studio && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
