### PR TITLE
Improve `pr` skill boundaries

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -3,7 +3,13 @@ name: pr
 description: Open a pull request for the current feature
 ---
 
+This skill is only for opening the initial pull request from finished local work.
+
+If a PR already exists for the current branch, stop: do not format, commit, push, amend, or rebase unless the user explicitly asks for that Git action. Leave follow-up changes uncommitted by default.
+
 Ensure we are not on the main branch, make a branch if necessary.  
+Check whether a PR already exists for the current branch with `gh pr status` or `gh pr view`. If it exists, report it and stop.
+
 For all packages affected, run Oxfmt to format the code:
 
 ```
@@ -20,9 +26,9 @@ bun run stylecheck
 
 to ensure we compile and CI linting/formatting passes.
 
-Commit the changes. The title of the PR must be according to the [`pr-name`](../pr-name/SKILL.md) skill.
+Commit the changes once. The title of the PR must be according to the [`pr-name`](../pr-name/SKILL.md) skill.
 
-Push the changes to the remote branch.  
+Push the changes to the remote branch once, using `git push -u origin HEAD`.  
 Use the `gh` CLI to create a pull request and use the same format as above for the title.
 
 When creating the PR, do not pass the PR body inline through a shell command (for example, avoid `--body "..."` or heredocs in `bash`). Instead:


### PR DESCRIPTION
## Summary

- Clarify that the PR skill is only for opening the initial pull request
- Stop the skill early when a PR already exists for the current branch
- Make follow-up changes stay uncommitted by default unless the user asks for a Git action

## Testing

- `bun run build`
- `bun run stylecheck`
