### PR TITLE
`remotion-monorepo`: Add Zed tasks for monorepo build, watch, starting an example app

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -8,5 +8,29 @@
 		"cwd": "$ZED_WORKTREE_ROOT",
 		"reveal": "no_focus",
 		"hide": "on_success"
+	},
+	{
+		"label": "build monorepo",
+		"command": "bun run build",
+		"cwd": "$ZED_WORKTREE_ROOT",
+		"reveal": "always",
+		"hide": "never",
+		"save": "all"
+	},
+	{
+		"label": "watch monorepo",
+		"command": "bun run watch",
+		"cwd": "$ZED_WORKTREE_ROOT",
+		"reveal": "always",
+		"hide": "never",
+		"save": "all"
+	},
+	{
+		"label": "start example app",
+		"command": "bun run dev",
+		"cwd": "$ZED_WORKTREE_ROOT/packages/example",
+		"reveal": "always",
+		"hide": "never",
+		"save": "all"
 	}
 ]


### PR DESCRIPTION
## Summary
- Add Zed task for building the monorepo
- Add Zed task for watching the monorepo
- Add Zed task for starting the example app

## Testing
- bun run build
- bun run stylecheck
