### PR TITLE
`@remotion/web-renderer`: Fix package license metadata

### DIFF
--- a/packages/web-renderer/package.json
+++ b/packages/web-renderer/package.json
@@ -17,7 +17,7 @@
 		"remotion": "cd ../example && bunx remotion studio ../web-renderer/src/test/studio.ts --public-dir=../example-videos/videos"
 	},
 	"author": "Remotion <jonny@remotion.dev>",
-	"license": "UNLICENSED",
+	"license": "SEE LICENSE IN LICENSE.md",
 	"dependencies": {
 		"@mediabunny/mp3-encoder": "catalog:",
 		"@mediabunny/aac-encoder": "catalog:",


### PR DESCRIPTION
## Summary

- Change `@remotion/web-renderer` package license metadata from `UNLICENSED` to `SEE LICENSE IN LICENSE.md`
- Align license metadata with core Remotion rendering packages

Addresses #8734.

## Testing

- `cd packages/web-renderer && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
