### PR TITLE
`@remotion/media`: Fix frame stepping in preview

### DIFF
--- a/packages/media/src/test/variable-fps-issue-8303.test.ts
+++ b/packages/media/src/test/variable-fps-issue-8303.test.ts
@@ -27,7 +27,7 @@ test('variable FPS video can be sought forward one frame at a time', async () =>
 		height: 160,
 		fit: 'contain',
 		alpha: true,
-		poolSize: 2,
+		poolSize: 3,
 	});
 	const cache = makePrewarmedVideoIteratorCache(canvasSink);
 	const iterator = await createVideoIterator(0, cache);

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -68,7 +68,9 @@ export const videoIteratorManager = async ({
 	}
 
 	const canvasSink = new CanvasSink(videoTrack, {
-		poolSize: 2,
+		// Keep one canvas each for the initial frame, the last returned frame
+		// and the next frame while iterating.
+		poolSize: 3,
 		fit: 'contain',
 		alpha: true,
 	});


### PR DESCRIPTION
## Summary

Fixes #8729.

Fixes frame stepping in the `@remotion/media` preview by increasing the `CanvasSink` pool size from 2 to 3.

While debugging a Studio repro with a 24fps video in a 24fps composition, stepping frame-by-frame could show identical pixels for adjacent frames even though the decoded timestamp advanced correctly.

The preview iterator can hold up to three live `WrappedCanvas` references at once:

1. the initial frame
2. the last returned frame
3. the next frame while iterating

Keeping one canvas for each prevents a canvas from being reused while it is still referenced by the iterator.

## Validation

- `bunx oxfmt packages/media/src/video-iterator-manager.ts --check`
- `bunx turbo run test --filter=@remotion/media -- packages/media/src/video-iterator-manager.ts`
- `bun run build`
- `bun run stylecheck`

**Before fix**: frames 25 and 26 are identical

https://github.com/user-attachments/assets/b728b1a0-154d-4fbe-bdb8-94316134c045

After fix: frames 25 and 26 differ, frame 26 is not dropped anymore.

https://github.com/user-attachments/assets/ad9a513d-c147-4c10-9218-1e6b856f0cf7


