### PR TITLE
`@remotion/studio`: Add sequence rename in Inspector

### DIFF
--- a/packages/studio/src/components/InlineCompositionName.tsx
+++ b/packages/studio/src/components/InlineCompositionName.tsx
@@ -1,81 +1,18 @@
 import type * as React from 'react';
-import type {
-	ChangeEventHandler,
-	FocusEventHandler,
-	KeyboardEventHandler,
-} from 'react';
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useMemo} from 'react';
 import type {_InternalTypes} from 'remotion';
-import {CLEAR_HOVER, INPUT_BACKGROUND} from '../helpers/colors';
 import {resolvedStackToSymbolicated} from '../helpers/resolved-stack-to-symbolicated';
 import {useRenameComposition} from '../helpers/use-rename-composition';
+import {InlineEditableTitle} from './InlineEditableTitle';
 import {showNotification} from './Notifications/NotificationCenter';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
-
-const titleWrapper: React.CSSProperties = {
-	boxSizing: 'border-box',
-	color: 'white',
-	fontSize: 12,
-	height: 18,
-	lineHeight: '18px',
-	marginLeft: -4,
-	overflow: 'hidden',
-	textOverflow: 'ellipsis',
-	whiteSpace: 'nowrap',
-	width: 'calc(100% + 4px)',
-};
-
-const titleInner: React.CSSProperties = {
-	borderRadius: 4,
-	boxSizing: 'border-box',
-	display: 'inline-grid',
-	fontSize: 12,
-	lineHeight: '18px',
-	maxWidth: '100%',
-	paddingLeft: 4,
-	paddingRight: 4,
-	verticalAlign: 'top',
-};
-
-const titleGridItem: React.CSSProperties = {
-	fontSize: 12,
-	gridArea: '1 / 1',
-	minWidth: 0,
-	overflow: 'hidden',
-	textOverflow: 'ellipsis',
-	whiteSpace: 'nowrap',
-};
-
-const titleInput: React.CSSProperties = {
-	appearance: 'none',
-	backgroundColor: 'transparent',
-	border: 'none',
-	boxShadow: 'none',
-	color: 'white',
-	fontFamily: 'inherit',
-	fontSize: 12,
-	height: 18,
-	lineHeight: '18px',
-	margin: 0,
-	minWidth: 0,
-	outline: 'none',
-	overflow: 'hidden',
-	padding: 0,
-	WebkitAppearance: 'none',
-	width: '100%',
-};
 
 export const InlineCompositionName: React.FC<{
 	readonly compositionId: string;
 	readonly stack: string | null;
 	readonly compositions: _InternalTypes['AnyComposition'][];
 }> = ({compositionId, stack, compositions}) => {
-	const [isEditing, setIsEditing] = useState(false);
-	const [isHovered, setIsHovered] = useState(false);
 	const canRename = !window.remotion_isReadOnlyStudio;
-	const [value, setValue] = useState(compositionId);
-	const inputRef = useRef<HTMLInputElement>(null);
-	const cancelledRef = useRef(false);
 	const resolvedLocation = useResolvedStack(stack);
 	const symbolicatedStack = useMemo(
 		() => resolvedStackToSymbolicated(resolvedLocation),
@@ -84,28 +21,11 @@ export const InlineCompositionName: React.FC<{
 	const {getValidationMessage, renameComposition} = useRenameComposition({
 		compositions,
 		currentId: compositionId,
-		newId: value,
+		newId: compositionId,
 	});
-
-	const focusInput = useCallback((input: HTMLInputElement | null) => {
-		inputRef.current = input;
-
-		if (!input) {
-			return;
-		}
-
-		input.focus();
-		input.select();
-	}, []);
 
 	const commit = useCallback(
 		(newId: string) => {
-			if (cancelledRef.current) {
-				return;
-			}
-
-			setIsEditing(false);
-
 			if (newId === compositionId) {
 				return;
 			}
@@ -113,7 +33,6 @@ export const InlineCompositionName: React.FC<{
 			const compNameErrMessage = getValidationMessage(newId);
 			if (compNameErrMessage) {
 				showNotification(compNameErrMessage, 2000);
-				setValue(compositionId);
 
 				return;
 			}
@@ -123,7 +42,6 @@ export const InlineCompositionName: React.FC<{
 					'Could not determine where this composition is defined',
 					2000,
 				);
-				setValue(compositionId);
 
 				return;
 			}
@@ -137,7 +55,6 @@ export const InlineCompositionName: React.FC<{
 			})
 				.then((result) => {
 					if (!result.success) {
-						setValue(compositionId);
 						notification.replaceContent(
 							`Could not rename composition: ${result.reason}`,
 							2000,
@@ -148,8 +65,6 @@ export const InlineCompositionName: React.FC<{
 					notification.replaceContent(`Renamed to ${newId}`, 2000);
 				})
 				.catch((err) => {
-					setValue(compositionId);
-
 					notification.replaceContent(
 						`Could not rename composition: ${(err as Error).message}`,
 						2000,
@@ -165,84 +80,11 @@ export const InlineCompositionName: React.FC<{
 		],
 	);
 
-	const startEditing = useCallback(() => {
-		if (!canRename) {
-			return;
-		}
-
-		cancelledRef.current = false;
-		setValue(compositionId);
-		setIsEditing(true);
-	}, [canRename, compositionId]);
-
-	const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
-		setValue(e.target.value);
-	}, []);
-
-	const onBlur: FocusEventHandler<HTMLInputElement> = useCallback(
-		(e) => {
-			commit(e.currentTarget.value);
-		},
-		[commit],
-	);
-
-	const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
-		(e) => {
-			if (e.key === 'Enter') {
-				e.preventDefault();
-				inputRef.current?.blur();
-			}
-
-			if (e.key === 'Escape') {
-				e.preventDefault();
-				cancelledRef.current = true;
-				setValue(compositionId);
-				setIsEditing(false);
-			}
-		},
-		[compositionId],
-	);
-
-	const backgroundColor = isEditing
-		? INPUT_BACKGROUND
-		: isHovered && canRename
-			? CLEAR_HOVER
-			: 'transparent';
-
 	return (
-		<div style={titleWrapper} title={compositionId}>
-			<span
-				style={{
-					...titleInner,
-					backgroundColor,
-					cursor: isEditing ? 'text' : 'default',
-					userSelect: isEditing ? 'text' : 'none',
-					width: isEditing ? '100%' : undefined,
-				}}
-				onMouseEnter={() => setIsHovered(true)}
-				onMouseLeave={() => setIsHovered(false)}
-				onClick={isEditing || !canRename ? undefined : startEditing}
-			>
-				<span
-					aria-hidden={isEditing}
-					style={{
-						...titleGridItem,
-						visibility: isEditing ? 'hidden' : 'visible',
-					}}
-				>
-					{compositionId}
-				</span>
-				{isEditing ? (
-					<input
-						ref={focusInput}
-						style={{...titleGridItem, ...titleInput}}
-						value={value}
-						onChange={onChange}
-						onBlur={onBlur}
-						onKeyDown={onKeyDown}
-					/>
-				) : null}
-			</span>
-		</div>
+		<InlineEditableTitle
+			value={compositionId}
+			canRename={canRename}
+			onCommit={commit}
+		/>
 	);
 };

--- a/packages/studio/src/components/InlineEditableTitle.tsx
+++ b/packages/studio/src/components/InlineEditableTitle.tsx
@@ -1,0 +1,188 @@
+import type * as React from 'react';
+import type {
+	ChangeEventHandler,
+	FocusEventHandler,
+	KeyboardEventHandler,
+} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {CLEAR_HOVER, INPUT_BACKGROUND} from '../helpers/colors';
+
+const titleWrapper: React.CSSProperties = {
+	boxSizing: 'border-box',
+	color: 'white',
+	fontSize: 12,
+	height: 18,
+	lineHeight: '18px',
+	marginLeft: -4,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+	width: 'calc(100% + 4px)',
+};
+
+const titleInner: React.CSSProperties = {
+	borderRadius: 4,
+	boxSizing: 'border-box',
+	display: 'inline-grid',
+	fontSize: 12,
+	lineHeight: '18px',
+	maxWidth: '100%',
+	paddingLeft: 4,
+	paddingRight: 4,
+	verticalAlign: 'top',
+};
+
+const titleGridItem: React.CSSProperties = {
+	fontSize: 12,
+	gridArea: '1 / 1',
+	minWidth: 0,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+};
+
+const titleInput: React.CSSProperties = {
+	appearance: 'none',
+	backgroundColor: 'transparent',
+	border: 'none',
+	boxShadow: 'none',
+	color: 'white',
+	fontFamily: 'inherit',
+	fontSize: 12,
+	height: 18,
+	lineHeight: '18px',
+	margin: 0,
+	minWidth: 0,
+	outline: 'none',
+	overflow: 'hidden',
+	padding: 0,
+	WebkitAppearance: 'none',
+	width: '100%',
+};
+
+export const InlineEditableTitle: React.FC<{
+	readonly value: string;
+	readonly canRename: boolean;
+	readonly onCommit: (newValue: string) => void;
+	readonly title?: string;
+}> = ({value, canRename, onCommit, title}) => {
+	const [isEditing, setIsEditing] = useState(false);
+	const [isHovered, setIsHovered] = useState(false);
+	const [draftValue, setDraftValue] = useState(value);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const cancelledRef = useRef(false);
+
+	useEffect(() => {
+		if (!isEditing) {
+			setDraftValue(value);
+		}
+	}, [isEditing, value]);
+
+	const focusInput = useCallback((input: HTMLInputElement | null) => {
+		inputRef.current = input;
+
+		if (!input) {
+			return;
+		}
+
+		input.focus();
+		input.select();
+	}, []);
+
+	const commit = useCallback(
+		(newValue: string) => {
+			if (cancelledRef.current) {
+				return;
+			}
+
+			setIsEditing(false);
+			onCommit(newValue);
+		},
+		[onCommit],
+	);
+
+	const startEditing = useCallback(() => {
+		if (!canRename) {
+			return;
+		}
+
+		cancelledRef.current = false;
+		setDraftValue(value);
+		setIsEditing(true);
+	}, [canRename, value]);
+
+	const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
+		setDraftValue(e.target.value);
+	}, []);
+
+	const onBlur: FocusEventHandler<HTMLInputElement> = useCallback(
+		(e) => {
+			commit(e.currentTarget.value);
+		},
+		[commit],
+	);
+
+	const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+		(e) => {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				inputRef.current?.blur();
+			}
+
+			if (e.key === 'Escape') {
+				e.preventDefault();
+				cancelledRef.current = true;
+				setDraftValue(value);
+				setIsEditing(false);
+			}
+		},
+		[value],
+	);
+
+	const backgroundColor = isEditing
+		? INPUT_BACKGROUND
+		: isHovered && canRename
+			? CLEAR_HOVER
+			: 'transparent';
+
+	const innerStyle = useMemo((): React.CSSProperties => {
+		return {
+			...titleInner,
+			backgroundColor,
+			cursor: isEditing ? 'text' : canRename ? 'pointer' : 'default',
+			userSelect: isEditing ? 'text' : 'none',
+			width: isEditing ? '100%' : undefined,
+		};
+	}, [backgroundColor, canRename, isEditing]);
+
+	return (
+		<div style={titleWrapper} title={title ?? value}>
+			<span
+				style={innerStyle}
+				onMouseEnter={() => setIsHovered(true)}
+				onMouseLeave={() => setIsHovered(false)}
+				onClick={isEditing || !canRename ? undefined : startEditing}
+			>
+				<span
+					aria-hidden={isEditing}
+					style={{
+						...titleGridItem,
+						visibility: isEditing ? 'hidden' : 'visible',
+					}}
+				>
+					{value}
+				</span>
+				{isEditing ? (
+					<input
+						ref={focusInput}
+						style={{...titleGridItem, ...titleInput}}
+						value={draftValue}
+						onChange={onChange}
+						onBlur={onBlur}
+						onKeyDown={onKeyDown}
+					/>
+				) : null}
+			</span>
+		</div>
+	);
+};

--- a/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
@@ -1,9 +1,11 @@
 import React, {useCallback, useContext, useMemo} from 'react';
-import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
+import {InlineEditableTitle} from '../InlineEditableTitle';
 import {InspectorSourceLocation} from '../InspectorSourceLocation';
 import {useOpenSequenceInEditor} from '../Timeline/use-open-sequence-in-editor';
+import {useRenameSequence} from '../Timeline/use-rename-sequence';
 import {
 	sequenceHeader,
 	sequenceHeaderDivider,
@@ -54,43 +56,22 @@ export const useSequenceInspectorSourceLocation = (
 	};
 };
 
-const useSequenceDisplayName = (track: TrackWithHash) => {
-	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
-	const nodePath = track.nodePathInfo?.sequenceSubscriptionKey ?? null;
-
-	return useMemo(() => {
-		const propStatusesForOverride = nodePath
-			? Internals.getPropStatusesCtx(propStatuses, nodePath)
-			: undefined;
-		const codeNameStatus = propStatusesForOverride?.name;
-		const fallbackDisplayName =
-			track.sequence.controls?.componentName || '<Sequence>';
-
-		if (
-			codeNameStatus?.status === 'static' &&
-			typeof codeNameStatus.codeValue === 'string'
-		) {
-			return codeNameStatus.codeValue;
-		}
-
-		if (codeNameStatus?.status === 'static') {
-			return fallbackDisplayName;
-		}
-
-		return track.sequence.displayName || fallbackDisplayName;
-	}, [
-		nodePath,
-		propStatuses,
-		track.sequence.controls?.componentName,
-		track.sequence.displayName,
-	]);
-};
-
 export const SequenceInspectorHeader: React.FC<{
 	readonly sourceLocation: SequenceInspectorSourceLocation;
 	readonly track: TrackWithHash;
 }> = ({sourceLocation, track}) => {
-	const sequenceDisplayName = useSequenceDisplayName(track);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {canRename, displayName, fallbackDisplayName, saveName} =
+		useRenameSequence({
+			clientId:
+				previewServerState.type === 'connected'
+					? previewServerState.clientId
+					: null,
+			nodePathInfo: track.nodePathInfo,
+			sequence: track.sequence,
+			validatedLocation: sourceLocation.validatedLocation,
+		});
+	const sequenceDisplayName = displayName || fallbackDisplayName;
 	const {documentationLink} = track.sequence;
 
 	const openDocumentationLink = useCallback(() => {
@@ -110,9 +91,22 @@ export const SequenceInspectorHeader: React.FC<{
 
 	const componentName = track.sequence.controls?.componentName;
 
+	const onRename = useCallback(
+		(newName: string) => {
+			saveName(newName).catch(() => undefined);
+		},
+		[saveName],
+	);
+
 	return (
 		<div style={sequenceHeader}>
-			<div style={sequenceHeaderTitle}>{sequenceDisplayName}</div>
+			<div style={sequenceHeaderTitle}>
+				<InlineEditableTitle
+					value={sequenceDisplayName}
+					canRename={canRename}
+					onCommit={onRename}
+				/>
+			</div>
 			{documentationLink ? (
 				<button
 					type="button"

--- a/packages/studio/src/components/InspectorPanel/styles.ts
+++ b/packages/studio/src/components/InspectorPanel/styles.ts
@@ -60,11 +60,11 @@ export const sequenceHeader: React.CSSProperties = {
 };
 
 export const sequenceHeaderTitle: React.CSSProperties = {
-	alignSelf: 'flex-start',
+	alignSelf: 'stretch',
 	backgroundColor: BACKGROUND,
 	border: 'none',
 	color: 'white',
-	display: 'inline-flex',
+	display: 'flex',
 	fontFamily: 'sans-serif',
 	fontSize: 12,
 	lineHeight: '18px',

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -49,6 +49,7 @@ import {
 } from './TimelineSelection';
 import {TimelineSequenceName} from './TimelineSequenceName';
 import {useOpenSequenceInEditor} from './use-open-sequence-in-editor';
+import {useRenameSequence} from './use-rename-sequence';
 import {useSequenceFreezeFrameMenuItem} from './use-sequence-freeze-frame-menu-item';
 import {useTimelineExpandedTree} from './use-timeline-expanded-tree';
 
@@ -67,43 +68,6 @@ const effectDropHighlight: React.CSSProperties = {
 };
 
 const SEQUENCE_REORDER_MIME_TYPE = 'application/remotion-sequence-reorder';
-
-type SequenceNameSaveAction =
-	| {
-			type: 'noop';
-	  }
-	| {
-			type: 'save';
-			defaultValue: string | null;
-	  };
-
-const getSequenceNameSaveAction = ({
-	editedName,
-	currentDisplayName,
-	fallbackDisplayName,
-	hasStaticNameProp,
-}: {
-	editedName: string;
-	currentDisplayName: string;
-	fallbackDisplayName: string;
-	hasStaticNameProp: boolean;
-}): SequenceNameSaveAction => {
-	if (
-		!hasStaticNameProp &&
-		(editedName === '' || editedName === fallbackDisplayName)
-	) {
-		return {type: 'noop'};
-	}
-
-	if (hasStaticNameProp && editedName === currentDisplayName) {
-		return {type: 'noop'};
-	}
-
-	return {
-		type: 'save',
-		defaultValue: editedName === '' ? JSON.stringify('') : null,
-	};
-};
 
 type SequenceReorderDragData = {
 	readonly nodePath: SequencePropsSubscriptionKey;
@@ -254,7 +218,6 @@ export const TimelineSequenceItem: React.FC<{
 	const previewConnected = previewServerState.type === 'connected';
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {toggleTrack} = useContext(ExpandedTracksSetterContext);
-	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {setSelectedModal} = useContext(ModalsContext);
 	const {isHighestContext} = useKeybinding();
@@ -298,6 +261,22 @@ export const TimelineSequenceItem: React.FC<{
 			column: originalLocation.column ?? 0,
 		};
 	}, [originalLocation]);
+
+	const {
+		canRename: canRenameThisSequence,
+		displayName,
+		fallbackDisplayName,
+		propStatusesForOverride,
+		saveName,
+	} = useRenameSequence({
+		clientId:
+			previewServerState.type === 'connected'
+				? previewServerState.clientId
+				: null,
+		nodePathInfo,
+		sequence,
+		validatedLocation,
+	});
 
 	const canDeleteFromSource = Boolean(nodePath && validatedLocation?.source);
 	const nodePathKey = useMemo(
@@ -626,14 +605,7 @@ export const TimelineSequenceItem: React.FC<{
 		toggleTrack(nodePathInfo);
 	}, [nodePathInfo, toggleTrack]);
 
-	const propStatusesForOverride = useMemo(() => {
-		return nodePath
-			? Internals.getPropStatusesCtx(propStatuses, nodePath)
-			: undefined;
-	}, [propStatuses, nodePath]);
-
 	const codeHiddenStatus = propStatusesForOverride?.hidden;
-	const codeNameStatus = propStatusesForOverride?.name;
 
 	const isItemHidden = useMemo(() => {
 		const propStatus =
@@ -645,32 +617,6 @@ export const TimelineSequenceItem: React.FC<{
 		const effective = (propStatus ?? runtimeValue) as boolean | undefined;
 		return effective ?? false;
 	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
-
-	const fallbackDisplayName = sequence.controls?.componentName ?? '<Sequence>';
-	const staticNamePropValue =
-		codeNameStatus?.status === 'static' &&
-		typeof codeNameStatus.codeValue === 'string'
-			? codeNameStatus.codeValue
-			: null;
-
-	const hasStaticNameProp = staticNamePropValue !== null;
-
-	const displayName = useMemo(() => {
-		if (staticNamePropValue !== null) {
-			return staticNamePropValue;
-		}
-
-		if (codeNameStatus?.status === 'static') {
-			return fallbackDisplayName;
-		}
-
-		return sequence.displayName;
-	}, [
-		codeNameStatus?.status,
-		fallbackDisplayName,
-		sequence.displayName,
-		staticNamePropValue,
-	]);
 
 	const onToggleVisibility = useCallback(
 		(type: 'enable' | 'disable') => {
@@ -760,16 +706,6 @@ export const TimelineSequenceItem: React.FC<{
 		codeHiddenStatus !== null &&
 		codeHiddenStatus.status === 'static';
 
-	const canRenameThisSequence =
-		previewServerState.type === 'connected' &&
-		!window.remotion_isReadOnlyStudio &&
-		Boolean(sequence.controls) &&
-		nodePath !== null &&
-		validatedLocation !== null &&
-		codeNameStatus !== undefined &&
-		codeNameStatus !== null &&
-		codeNameStatus.status === 'static';
-
 	const onSequenceDoubleClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
 			if (isTimelineSelectionModifierEvent(e)) {
@@ -800,59 +736,10 @@ export const TimelineSequenceItem: React.FC<{
 
 	const onSaveName = useCallback(
 		async (name: string) => {
-			if (
-				!canRenameThisSequence ||
-				previewServerState.type !== 'connected' ||
-				!sequence.controls ||
-				!nodePath ||
-				!validatedLocation
-			) {
-				setIsRenaming(false);
-				return;
-			}
-
-			const action = getSequenceNameSaveAction({
-				editedName: name,
-				currentDisplayName: displayName,
-				fallbackDisplayName,
-				hasStaticNameProp,
-			});
-
-			if (action.type === 'noop') {
-				setIsRenaming(false);
-				return;
-			}
-
-			const savePromise = saveSequenceProps({
-				changes: [
-					{
-						fileName: validatedLocation.source,
-						nodePath,
-						fieldKey: 'name',
-						value: name,
-						defaultValue: action.defaultValue,
-						schema: sequence.controls.schema,
-					},
-				],
-				setPropStatuses,
-				clientId: previewServerState.clientId,
-				undoLabel: 'Rename sequence',
-				redoLabel: 'Rename sequence again',
-			});
 			setIsRenaming(false);
-			await savePromise;
+			await saveName(name);
 		},
-		[
-			canRenameThisSequence,
-			displayName,
-			fallbackDisplayName,
-			hasStaticNameProp,
-			nodePath,
-			previewServerState,
-			sequence.controls,
-			setPropStatuses,
-			validatedLocation,
-		],
+		[saveName],
 	);
 
 	React.useEffect(() => {

--- a/packages/studio/src/components/Timeline/use-rename-sequence.ts
+++ b/packages/studio/src/components/Timeline/use-rename-sequence.ts
@@ -1,0 +1,164 @@
+import {useCallback, useContext, useMemo} from 'react';
+import type {TSequence} from 'remotion';
+import {Internals} from 'remotion';
+import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
+import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {saveSequenceProps} from './save-sequence-prop';
+
+type SequenceNameSaveAction =
+	| {
+			type: 'noop';
+	  }
+	| {
+			type: 'save';
+			defaultValue: string | null;
+	  };
+
+export const getSequenceNameSaveAction = ({
+	editedName,
+	currentDisplayName,
+	fallbackDisplayName,
+	hasStaticNameProp,
+}: {
+	editedName: string;
+	currentDisplayName: string;
+	fallbackDisplayName: string;
+	hasStaticNameProp: boolean;
+}): SequenceNameSaveAction => {
+	if (
+		!hasStaticNameProp &&
+		(editedName === '' || editedName === fallbackDisplayName)
+	) {
+		return {type: 'noop'};
+	}
+
+	if (hasStaticNameProp && editedName === currentDisplayName) {
+		return {type: 'noop'};
+	}
+
+	return {
+		type: 'save',
+		defaultValue: editedName === '' ? JSON.stringify('') : null,
+	};
+};
+
+export const useRenameSequence = ({
+	clientId,
+	nodePathInfo,
+	sequence,
+	validatedLocation,
+}: {
+	readonly clientId: string | null;
+	readonly nodePathInfo: SequenceNodePathInfo | null;
+	readonly sequence: TSequence;
+	readonly validatedLocation: CodePosition | null;
+}) => {
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
+	const nodePath = nodePathInfo?.sequenceSubscriptionKey ?? null;
+
+	const propStatusesForOverride = useMemo(() => {
+		return nodePath
+			? Internals.getPropStatusesCtx(propStatuses, nodePath)
+			: undefined;
+	}, [propStatuses, nodePath]);
+
+	const codeNameStatus = propStatusesForOverride?.name;
+	const fallbackDisplayName = sequence.controls?.componentName ?? '<Sequence>';
+	const staticNamePropValue =
+		codeNameStatus?.status === 'static' &&
+		typeof codeNameStatus.codeValue === 'string'
+			? codeNameStatus.codeValue
+			: null;
+	const hasStaticNameProp = staticNamePropValue !== null;
+
+	const displayName = useMemo(() => {
+		if (staticNamePropValue !== null) {
+			return staticNamePropValue;
+		}
+
+		if (codeNameStatus?.status === 'static') {
+			return fallbackDisplayName;
+		}
+
+		return sequence.displayName;
+	}, [
+		codeNameStatus?.status,
+		fallbackDisplayName,
+		sequence.displayName,
+		staticNamePropValue,
+	]);
+
+	const canRename =
+		clientId !== null &&
+		!window.remotion_isReadOnlyStudio &&
+		Boolean(sequence.controls) &&
+		nodePath !== null &&
+		validatedLocation !== null &&
+		codeNameStatus !== undefined &&
+		codeNameStatus !== null &&
+		codeNameStatus.status === 'static';
+
+	const saveName = useCallback(
+		async (name: string) => {
+			if (
+				!canRename ||
+				clientId === null ||
+				!sequence.controls ||
+				!nodePath ||
+				!validatedLocation
+			) {
+				return;
+			}
+
+			const action = getSequenceNameSaveAction({
+				editedName: name,
+				currentDisplayName: displayName,
+				fallbackDisplayName,
+				hasStaticNameProp,
+			});
+
+			if (action.type === 'noop') {
+				return;
+			}
+
+			await saveSequenceProps({
+				changes: [
+					{
+						fileName: validatedLocation.source,
+						nodePath,
+						fieldKey: 'name',
+						value: name,
+						defaultValue: action.defaultValue,
+						schema: sequence.controls.schema,
+					},
+				],
+				setPropStatuses,
+				clientId,
+				undoLabel: 'Rename sequence',
+				redoLabel: 'Rename sequence again',
+			});
+		},
+		[
+			canRename,
+			clientId,
+			displayName,
+			fallbackDisplayName,
+			hasStaticNameProp,
+			nodePath,
+			sequence.controls,
+			setPropStatuses,
+			validatedLocation,
+		],
+	);
+
+	return {
+		canRename,
+		codeNameStatus,
+		displayName,
+		fallbackDisplayName,
+		hasStaticNameProp,
+		propStatusesForOverride,
+		saveName,
+	};
+};


### PR DESCRIPTION
## Summary

- Add click-to-rename support for selected Sequence titles in the Inspector panel
- Extract the composition-style inline title editor for reuse
- Share sequence rename state/save logic between the Timeline and Inspector

Fixes #8461

## Validation

- `bun run build`
- `bun run stylecheck`
- `bunx tsc --noEmit --pretty false -p packages/studio/tsconfig.json`
- Browser validation in `packages/example` with `bun dev` and `agent-browser`
