### PR TITLE
Docs: Redesign lower third element

### DIFF
--- a/packages/docs/elements/overlays/lower-third/lower-third.tsx
+++ b/packages/docs/elements/overlays/lower-third/lower-third.tsx
@@ -1,34 +1,19 @@
 import React from 'react';
 import {
 	AbsoluteFill,
+	Easing,
+	Interactive,
 	interpolate,
-	spring,
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
 
 export const LowerThird: React.FC = () => {
 	const frame = useCurrentFrame();
-	const {durationInFrames, fps: videoFps} = useVideoConfig();
+	const {durationInFrames} = useVideoConfig();
 
-	const entrance = spring({
-		frame,
-		fps: videoFps,
-		config: {
-			damping: 18,
-			stiffness: 120,
-		},
-	});
-
-	const exitStart = Math.max(0, durationInFrames - 25);
-	const exitEnd = Math.max(exitStart + 1, durationInFrames - 5);
-
-	const exit = interpolate(frame, [exitStart, exitEnd], [1, 0], {
-		extrapolateLeft: 'clamp',
-		extrapolateRight: 'clamp',
-	});
-
-	const progress = entrance * exit;
+	const exitStart = Math.max(0, durationInFrames - 28);
+	const exitEnd = Math.max(exitStart + 1, durationInFrames - 8);
 
 	return (
 		<AbsoluteFill
@@ -37,55 +22,100 @@ export const LowerThird: React.FC = () => {
 				pointerEvents: 'none',
 			}}
 		>
-			<div
+			<Interactive.Div
+				name="Lower third position"
 				style={{
 					position: 'absolute',
-					left: 0,
-					bottom: 0,
-					transform: `translateX(${interpolate(progress, [0, 1], [-90, 0])}px)`,
-					opacity: progress,
+					left: 140,
+					bottom: 120,
+					width: 680,
+					opacity:
+						interpolate(frame, [0, 18], [0, 1], {
+							extrapolateRight: 'clamp',
+							easing: Easing.out(Easing.cubic),
+						}) *
+						interpolate(frame, [exitStart, exitEnd], [1, 0], {
+							extrapolateLeft: 'clamp',
+							extrapolateRight: 'clamp',
+						}),
+					translate: interpolate(frame, [0, 24], ['-72px 0px', '0px 0px'], {
+						extrapolateRight: 'clamp',
+						easing: Easing.spring({
+							damping: 180,
+							stiffness: 120,
+						}),
+					}),
+					scale: interpolate(frame, [0, 22], [0.96, 1], {
+						extrapolateRight: 'clamp',
+						easing: Easing.out(Easing.cubic),
+					}),
+					transformOrigin: 'left bottom',
 				}}
 			>
-				<div
+				<Interactive.Div
+					name="Lower third card"
 					style={{
-						width: 660,
-						padding: '34px 42px',
-						borderRadius: 28,
-						background: 'rgba(255, 255, 255, 0.92)',
-						boxShadow: '0 24px 80px rgba(0, 0, 0, 0.3)',
+						display: 'flex',
+						alignItems: 'center',
+						gap: 24,
+						padding: 24,
+						borderRadius: 24,
+						backgroundColor: 'rgba(255, 255, 255, 0.94)',
+						boxShadow: '0 6px 12px rgba(24, 24, 27, 0.2)',
+						border: '1px solid rgba(24, 24, 27, 0.08)',
 					}}
 				>
-					<div
+					<Interactive.Div
+						name="Initials badge"
 						style={{
-							fontSize: 54,
-							fontWeight: 800,
-							color: '#111827',
-							letterSpacing: -1.5,
-						}}
-					>
-						Alex Morgan
-					</div>
-					<div
-						style={{
-							fontSize: 30,
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+							width: 88,
+							height: 88,
+							borderRadius: 20,
+							background: 'linear-gradient(135deg, #2563eb, #60a5fa)',
+							color: 'white',
+							fontSize: 34,
 							fontWeight: 600,
-							color: '#2563eb',
-							marginTop: 10,
+							letterSpacing: -1,
+							boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.3)',
 						}}
 					>
-						Creative Developer
+						AM
+					</Interactive.Div>
+					<div
+						style={{
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 2,
+							minWidth: 0,
+						}}
+					>
+						<Interactive.Div
+							name="Name"
+							style={{
+								color: '#18181b',
+								fontSize: 48,
+								fontWeight: 650,
+								letterSpacing: -1.6,
+							}}
+						>
+							Alex Morgan
+						</Interactive.Div>
+						<Interactive.Div
+							name="Title"
+							style={{
+								color: '#52525b',
+								fontSize: 26,
+								fontWeight: 500,
+							}}
+						>
+							Creative Developer
+						</Interactive.Div>
 					</div>
-				</div>
-				<div
-					style={{
-						width: interpolate(progress, [0, 1], [0, 520]),
-						height: 10,
-						borderRadius: 999,
-						background: '#60a5fa',
-						marginTop: 18,
-					}}
-				/>
-			</div>
+				</Interactive.Div>
+			</Interactive.Div>
 		</AbsoluteFill>
 	);
 };


### PR DESCRIPTION
## Summary

- Redesign the docs lower third overlay with a more professional broadcast-style card
- Position it properly in the lower third with balanced left and bottom padding
- Use named `Interactive.Div` elements and Studio-friendly transform properties

## Testing

- `bun run build`
- `bun run stylecheck`
