### PR TITLE
Docs: Autoplay muted element previews

### DIFF
--- a/packages/docs/src/components/Elements/ElementPreview.tsx
+++ b/packages/docs/src/components/Elements/ElementPreview.tsx
@@ -36,6 +36,7 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 				compositionHeight={height}
 				controls
 				initiallyMuted
+				loop
 				style={{
 					width: '100%',
 				}}

--- a/packages/docs/src/components/Elements/ElementPreview.tsx
+++ b/packages/docs/src/components/Elements/ElementPreview.tsx
@@ -28,12 +28,14 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 		>
 			<Player
 				acknowledgeRemotionLicense
+				autoPlay
 				component={component}
 				durationInFrames={durationInFrames}
 				fps={fps}
 				compositionWidth={width}
 				compositionHeight={height}
 				controls
+				initiallyMuted
 				style={{
 					width: '100%',
 				}}


### PR DESCRIPTION
## Summary

- Autoplay Remotion Elements previews
- Start Elements preview players muted by default

## Testing

- `cd packages/docs && bunx oxfmt src/components/Elements/ElementPreview.tsx --write`
- `bun run build`
- `bun run stylecheck`
