### PR TITLE
`remotion`: Fix media playbackRate duration in loops

### DIFF
--- a/packages/core/src/get-timeline-duration.ts
+++ b/packages/core/src/get-timeline-duration.ts
@@ -29,7 +29,7 @@ export const getTimelineDuration = ({
 
 	if (parentSequenceDurationInFrames !== null) {
 		const cappedDuration = Math.min(
-			parentSequenceDurationInFrames * playbackRate,
+			parentSequenceDurationInFrames,
 			mediaDuration,
 		);
 		return Number(cappedDuration.toFixed(10));

--- a/packages/core/src/test/get-media-duration.test.ts
+++ b/packages/core/src/test/get-media-duration.test.ts
@@ -79,7 +79,7 @@ test('subframe sequence duration is not truncated', () => {
 	expect(duration).toBe(10.92);
 });
 
-test('parentSequence with playbackRate 2.45 caps correctly', () => {
+test('parentSequence with playbackRate 2.45 caps to the visual duration', () => {
 	const duration = getTimelineDuration({
 		compositionDurationInFrames: 300,
 		playbackRate: 2.45,
@@ -89,7 +89,20 @@ test('parentSequence with playbackRate 2.45 caps correctly', () => {
 		loop: false,
 	});
 
-	expect(duration).toBe(245);
+	expect(duration).toBe(100);
+});
+
+test('parentSequence with playbackRate 0.5 caps to the visual duration', () => {
+	const duration = getTimelineDuration({
+		compositionDurationInFrames: 1200,
+		playbackRate: 0.5,
+		trimBefore: undefined,
+		trimAfter: undefined,
+		parentSequenceDurationInFrames: 1200,
+		loop: false,
+	});
+
+	expect(duration).toBe(1200);
 });
 
 test('trimBefore is accounted for', () => {


### PR DESCRIPTION
## Summary

- Fix media timeline duration for videos/audio inside parent sequences when `playbackRate` is not 1
- Stop applying `playbackRate` to the parent sequence duration cap, so slowed-down media stays mounted for the full visual parent duration
- Add regression coverage for `playbackRate={0.5}` and update the existing fast playback-rate expectation

This fixes an issue reported by Fliki today.

## Validation

- `bun test packages/core/src/test/get-media-duration.test.ts`
- `bunx turbo run make --filter=remotion`
- `bun run build`
- `bun run stylecheck`
