### PR TITLE
`@remotion/zod-types`: Declare zod as a runtime dependency

### DIFF
--- a/packages/zod-types/package.json
+++ b/packages/zod-types/package.json
@@ -21,10 +21,10 @@
 		"url": "https://github.com/remotion-dev/remotion/issues"
 	},
 	"dependencies": {
-		"remotion": "workspace:*"
+		"remotion": "workspace:*",
+		"zod": "catalog:"
 	},
 	"devDependencies": {
-		"zod": "catalog:",
 		"@remotion/eslint-config-internal": "workspace:*",
 		"eslint": "catalog:",
 		"@typescript/native-preview": "catalog:"


### PR DESCRIPTION
## Problem

A clean install of `@remotion/zod-types` can't be imported:

```bash
mkdir t && cd t && npm init -y
npm i @remotion/zod-types
node -e "require('@remotion/zod-types')"
# Error: Cannot find module 'zod'
```

The shipped `dist` imports `zod`, but `zod` is declared only in `devDependencies`, so consumers never receive it.

## Fix

Move `zod` (`catalog:`) from `devDependencies` to `dependencies`. This matches `@remotion/studio`, which already declares `zod` as a runtime dependency. No code change.

## Verification

`npm i @remotion/zod-types zod` + import succeeds (4 exports resolve). The only thing missing on a bare install was `zod` itself.
