### PR TITLE
Docs: Add Webpack config mutation example

### DIFF
--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -31,7 +31,7 @@ Allows you to insert your custom Webpack config. [See the page about custom Webp
 import {Config} from '@remotion/cli/config';
 // ---cut---
 Config.overrideWebpackConfig((currentConfiguration) => {
-  // Return a new Webpack configuration
+  // Return a new Webpack configuration or mutate this one and return it
   return {
     ...currentConfiguration,
     // new configuration

--- a/packages/docs/docs/overwriting-webpack-config.mdx
+++ b/packages/docs/docs/overwriting-webpack-config.mdx
@@ -8,9 +8,9 @@ crumb: 'How To'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Remotion ships with [it's own Webpack configuration](https://github.com/remotion-dev/remotion/blob/main/packages/bundler/src/webpack-config.ts).
+Remotion ships with [its own Webpack configuration](https://github.com/remotion-dev/remotion/blob/main/packages/bundler/src/webpack-config.ts).
 
-You can override it reducer-style by creating a function that takes the previous Webpack configuration and returns the the new one.
+You can override it reducer-style by creating a function that takes the previous Webpack configuration and returns the next one.
 
 ## When rendering using the command line
 
@@ -30,6 +30,24 @@ Config.overrideWebpackConfig((currentConfiguration) => {
       ],
     },
   };
+});
+```
+
+You may also mutate the configuration object. Return the same object after mutating it:
+
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+
+Config.overrideWebpackConfig((config) => {
+  config.module ??= {};
+  config.module.rules ??= [];
+
+  config.module.rules.push({
+    test: /\.txt$/,
+    type: 'asset/source',
+  });
+
+  return config;
 });
 ```
 


### PR DESCRIPTION
## Summary

- Document that `Config.overrideWebpackConfig()` may return the same mutated config object.
- Add a minimal mutation example to the custom Webpack config page.
- Adjust the config API example so it does not imply a new object is required.

Fixes #8764.

## Test plan

- `cd packages/docs && bunx oxfmt src --write`
- `cd packages/docs && bun render-cards.ts`
- `bun run build`
- `bun run stylecheck`
- `bun run build-docs`
