### PR TITLE
`@remotion/studio`: Fix CSS rotate display

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineRotationField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRotationField.tsx
@@ -6,12 +6,12 @@ import type {
 	TimelineFieldOnSave,
 } from '../../helpers/timeline-layout';
 import {InputDragger} from '../NewComposition/InputDragger';
-import {formatTimelineFieldValueForDisplay} from './timeline-field-display-utils';
 import {
 	draggerStyle,
 	getTimelineDisplayDecimalPlaces,
 	normalizeTimelineNumber,
 } from './timeline-field-utils';
+import {formatTimelineRotationFieldValue} from './timeline-rotation-field-utils';
 import {
 	parseCssRotationToDegrees,
 	serializeCssRotation,
@@ -118,12 +118,13 @@ export const TimelineRotationField: React.FC<{
 
 	const formatter = useCallback(
 		(v: number | string) => {
-			return formatTimelineFieldValueForDisplay({
+			return formatTimelineRotationFieldValue({
+				decimalPlaces,
 				fieldSchema: field.fieldSchema,
 				value: v,
 			});
 		},
-		[field.fieldSchema],
+		[decimalPlaces, field.fieldSchema],
 	);
 
 	return (

--- a/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
@@ -165,7 +165,9 @@ const formatRotationTimelineFieldValueForDisplay = ({
 	});
 	const degrees =
 		fieldSchema.type === 'rotation-css'
-			? parseCssRotationToDegrees(String(value ?? '0deg'))
+			? typeof value === 'number' && Number.isFinite(value)
+				? value
+				: parseCssRotationToDegrees(String(value ?? '0deg'))
 			: getFiniteNumericValue(value);
 
 	if (degrees === null || !Number.isFinite(degrees)) {

--- a/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
@@ -165,9 +165,7 @@ const formatRotationTimelineFieldValueForDisplay = ({
 	});
 	const degrees =
 		fieldSchema.type === 'rotation-css'
-			? typeof value === 'number' && Number.isFinite(value)
-				? value
-				: parseCssRotationToDegrees(String(value ?? '0deg'))
+			? parseCssRotationToDegrees(String(value ?? '0deg'))
 			: getFiniteNumericValue(value);
 
 	if (degrees === null || !Number.isFinite(degrees)) {

--- a/packages/studio/src/components/Timeline/timeline-rotation-field-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-rotation-field-utils.ts
@@ -1,0 +1,23 @@
+import type {SchemaFieldInfo} from '../../helpers/timeline-layout';
+import {formatTimelineFieldValueForDisplay} from './timeline-field-display-utils';
+import {serializeCssRotation} from './timeline-rotation-utils';
+
+export const formatTimelineRotationFieldValue = ({
+	decimalPlaces,
+	fieldSchema,
+	value,
+}: {
+	readonly decimalPlaces: number;
+	readonly fieldSchema: SchemaFieldInfo['fieldSchema'];
+	readonly value: number | string;
+}) => {
+	return formatTimelineFieldValueForDisplay({
+		fieldSchema,
+		value:
+			fieldSchema.type === 'rotation-css' &&
+			typeof value === 'number' &&
+			Number.isFinite(value)
+				? serializeCssRotation(value, decimalPlaces)
+				: value,
+	});
+};

--- a/packages/studio/src/test/timeline-field-utils.test.ts
+++ b/packages/studio/src/test/timeline-field-utils.test.ts
@@ -88,6 +88,17 @@ test('formatTimelineFieldValueForDisplay formats rotation fields as degrees', ()
 			value: '0.7853981633974483rad',
 		}),
 	).toBe('45°');
+
+	expect(
+		formatTimelineFieldValueForDisplay({
+			fieldSchema: {
+				type: 'rotation-css',
+				default: '0deg',
+				step: 1,
+			},
+			value: 12,
+		}),
+	).toBe('12°');
 });
 
 test('formatTimelineFieldValueForDisplay formats translate fields as pixels', () => {

--- a/packages/studio/src/test/timeline-field-utils.test.ts
+++ b/packages/studio/src/test/timeline-field-utils.test.ts
@@ -5,6 +5,7 @@ import {
 	getDecimalPlaces,
 	getTimelineDisplayDecimalPlaces,
 } from '../components/Timeline/timeline-field-utils';
+import {formatTimelineRotationFieldValue} from '../components/Timeline/timeline-rotation-field-utils';
 
 test('getDecimalPlaces supports scientific notation', () => {
 	expect(getDecimalPlaces(1e-7)).toBe(7);
@@ -88,9 +89,12 @@ test('formatTimelineFieldValueForDisplay formats rotation fields as degrees', ()
 			value: '0.7853981633974483rad',
 		}),
 	).toBe('45°');
+});
 
+test('formatTimelineRotationFieldValue formats numeric CSS rotations as degrees', () => {
 	expect(
-		formatTimelineFieldValueForDisplay({
+		formatTimelineRotationFieldValue({
+			decimalPlaces: 1,
 			fieldSchema: {
 				type: 'rotation-css',
 				default: '0deg',


### PR DESCRIPTION
## Summary

- Fix Studio timeline formatting for numeric CSS rotation values
- Add a regression test so `style.rotate` values converted to degree numbers display correctly

Fixes #8774.

## Test plan

- `~/.bun/bin/bun test packages/studio/src/test/timeline-field-utils.test.ts`
- `~/.bun/bin/bun test packages/studio-server/src/test/compute-sequence-props-status.test.ts`
- `~/.bun/bin/bunx oxfmt src --write` from `packages/studio`
- `~/.bun/bin/bun run build`
- `~/.bun/bin/bun run stylecheck`
