### PR TITLE
`@remotion/studio`: Remove N shortcut

### DIFF
--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -147,20 +147,6 @@ export const GlobalKeybindings: React.FC<{
 			}
 		};
 
-		const nKey = keybindings.registerKeybinding({
-			event: 'keypress',
-			key: 'n',
-			callback: () => {
-				showNotification(
-					`To make a new composition, right-click an existing one and select "Duplicate"`,
-					5000,
-				);
-			},
-			commandCtrlKey: false,
-			preventDefault: true,
-			triggerIfInputFieldFocused: false,
-			keepRegisteredWhenNotHighestContext: false,
-		});
 		const cmdKKey = keybindings.registerKeybinding({
 			event: 'keydown',
 			key: 'k',
@@ -249,7 +235,6 @@ export const GlobalKeybindings: React.FC<{
 		});
 
 		return () => {
-			nKey.unregister();
 			for (const sequencePropKey of sequencePropKeys) {
 				sequencePropKey.unregister();
 			}


### PR DESCRIPTION
## Summary

- Removed the bare `N` Studio keybinding that showed the outdated new composition notification.
- Verified no Studio docs or shortcut listings document `N` for this behavior.

Fixes #8769

## Tests

- `bunx oxfmt src --write` in `packages/studio`
- `bun run build`
- `bun run stylecheck`
