### PR TITLE
Docs: Add paper texture element

### DIFF
--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -13,6 +13,13 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: 'category',
+			label: 'Backgrounds',
+			link: {type: 'doc', id: 'backgrounds/index'},
+			collapsed: false,
+			items: ['backgrounds/paper-texture/index'],
+		},
+		{
+			type: 'category',
 			label: 'Overlays',
 			link: {type: 'doc', id: 'overlays/index'},
 			collapsed: false,

--- a/packages/docs/elements/backgrounds/index.mdx
+++ b/packages/docs/elements/backgrounds/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Backgrounds
+description: Drop-in background Elements for Remotion videos.
+---
+
+# Backgrounds
+
+Elements:
+
+- [Paper texture](/elements/backgrounds/paper-texture/)

--- a/packages/docs/elements/backgrounds/paper-texture/index.mdx
+++ b/packages/docs/elements/backgrounds/paper-texture/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Paper Texture
+description: A white animated paper texture background.
+---
+
+import {ElementPage} from '@site/src/components/Elements/ElementPage';
+import {PaperTexture} from './paper-texture';
+
+# Paper Texture
+
+A white paper texture background with a slowly changing posterized seed.
+
+<ElementPage component={PaperTexture} displayName="Paper Texture" elementHeight={1080} elementWidth={1920} slug="backgrounds/paper-texture" sourceFile="./paper-texture.tsx" />

--- a/packages/docs/elements/backgrounds/paper-texture/paper-texture.tsx
+++ b/packages/docs/elements/backgrounds/paper-texture/paper-texture.tsx
@@ -1,0 +1,26 @@
+import {paper} from '@remotion/effects/paper';
+import React from 'react';
+import {interpolate, Solid, useCurrentFrame} from 'remotion';
+
+export const PaperTexture: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	return (
+		<Solid
+			color="white"
+			width={1920}
+			height={1080}
+			effects={[
+				paper({
+					colorFront: 'white',
+					colorBack: 'white',
+					seed: interpolate(frame, [0, 120], [0, 1000], {
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+						posterize: 30,
+					}),
+				}),
+			]}
+		/>
+	);
+};


### PR DESCRIPTION
## Summary

- Add a Backgrounds category to Remotion Elements
- Add a white 1920x1080 Paper Texture element using `<Solid>` and `paper()`
- Interpolate the `paper()` seed inline with `posterize: 30` for Studio interactivity

## Checks

- `bunx oxfmt packages/docs/elements-sidebars.ts packages/docs/elements/backgrounds/paper-texture/paper-texture.tsx --write`
- `bun run build`
- `bun run stylecheck`
- `bun test packages/docs/src/test/elements.test.ts`
