### PR TITLE
`@remotion/studio`: Link computed values to interactivity docs

### DIFF
--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -67,7 +67,7 @@ Use standalone [`spring()`](/docs/spring) only when the animation needs a frame-
 Use individual CSS transform properties such as `scale`, `rotate` and `translate` instead of composing a `transform` string.
 
 ```txt title="Prompt"
-/remotion-best-practices Fix computed values in Remotion Studio. Move editable values into the JSX style object, keep interpolate() keyframes inline, use Easing.spring() as easing, and replace transform strings with scale/rotate/translate.
+/remotion-best-practices Fix computed values in Remotion Studio. Follow https://www.remotion.dev/docs/studio/interactivity-best-practices#keep-editable-values-visible. Move editable values into the JSX style object, keep interpolate() keyframes inline, use Easing.spring() as easing, and replace transform strings with scale/rotate/translate.
 ```
 
 ## Keep composition metadata inline {#keep-composition-metadata-inline}

--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -10,7 +10,7 @@ Write editable Remotion components so the [Studio interactivity](/docs/studio/in
 
 When a value is shown as computed in the Studio, it often means that the value is hidden behind a variable, helper function, conditional expression or transform string.
 
-## Use `Interactive.*` for tweakable elements
+## Use `Interactive.*` for tweakable elements {#use-interactive-for-tweakable-elements}
 
 Use the [`Interactive`](/docs/interactive) namespace when an HTML or SVG element should be selected, moved or edited in the Studio.
 
@@ -24,7 +24,11 @@ Use the [`Interactive`](/docs/interactive) namespace when an HTML or SVG element
 
 For a custom component, see [Make a component interactive](/docs/studio/make-component-interactive).
 
-## Keep editable values visible
+```txt title="Prompt"
+/remotion-best-practices Make this element editable in Remotion Studio. Use Interactive.* for tweakable HTML/SVG elements and keep editable style values inline.
+```
+
+## Keep editable values visible {#keep-editable-values-visible}
 
 Put values that should be edited in the Studio directly into the JSX.
 This applies to static style values, keyframes, easing and transform props.
@@ -62,7 +66,11 @@ const rotation = interpolate(frame, [0, 30], [0, 20]);
 Use standalone [`spring()`](/docs/spring) only when the animation needs a frame-driven physical spring simulation.
 Use individual CSS transform properties such as `scale`, `rotate` and `translate` instead of composing a `transform` string.
 
-## Keep composition metadata inline
+```txt title="Prompt"
+/remotion-best-practices Fix computed values in Remotion Studio. Move editable values into the JSX style object, keep interpolate() keyframes inline, use Easing.spring() as easing, and replace transform strings with scale/rotate/translate.
+```
+
+## Keep composition metadata inline {#keep-composition-metadata-inline}
 
 When scaffolding a composition, keep the component and its [`<Composition>`](/docs/composition) registration in the same file.
 Keep static `width`, `height`, `fps`, `durationInFrames` and [`defaultProps`](/docs/composition#defaultprops) inline.
@@ -100,7 +108,11 @@ const calculateMetadata = () => {
 
 Use [`calculateMetadata()`](/docs/calculate-metadata) when metadata depends on dynamic input props, fetched data or asset metadata.
 
-## Keep effects editable
+```txt title="Prompt"
+/remotion-best-practices Fix Composition metadata for Remotion Studio. Keep defaultProps, width, height, fps, and durationInFrames inline on the Composition unless calculateMetadata needs dynamic data.
+```
+
+## Keep effects editable {#keep-effects-editable}
 
 Keep editable effect parameters inline in the effect call and keep the effect array shape unconditional.
 
@@ -135,12 +147,8 @@ const center = [0.5, 0.5] as const;
 
 Render separate elements if one version should have effects and another should not.
 
-## AI agent prompt
-
-If a component is not editable enough in the Studio, give your coding agent a targeted prompt:
-
-```txt
-/remotion-best-practices Make this component interactive for Remotion Studio. Use Interactive.* for tweakable elements, keep editable style values and effect params inline, keep defaultProps inline on the Composition, prefer interpolate() keyframes, and use scale/rotate/translate instead of transform strings.
+```txt title="Prompt"
+/remotion-best-practices Fix computed effect controls in Remotion Studio. Keep effect parameters inline in the effect call and keep the effects array shape unconditional.
 ```
 
 ## See also

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -33,7 +33,11 @@ import {
 import {TimelineKeyframedValue} from './TimelineKeyframedValue';
 import {TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
-import {TimelineFieldValue, UnsupportedStatus} from './TimelineSchemaField';
+import {
+	TIMELINE_COMPUTED_EFFECT_FIX_LINK,
+	TimelineFieldValue,
+	UnsupportedStatus,
+} from './TimelineSchemaField';
 import {
 	useTimelineRowSelection,
 	useTimelineSelection,
@@ -256,7 +260,12 @@ export const TimelineEffectPropValue: React.FC<{
 
 	if (effectStatus.type === 'cannot-update-effect') {
 		if (effectStatus.reason === 'computed') {
-			return <UnsupportedStatus label="computed" />;
+			return (
+				<UnsupportedStatus
+					label="computed"
+					fixHref={TIMELINE_COMPUTED_EFFECT_FIX_LINK}
+				/>
+			);
 		}
 
 		if (effectStatus.reason === 'not-call-expression') {
@@ -306,7 +315,12 @@ export const TimelineEffectPropValue: React.FC<{
 	}
 
 	if (propStatus.status === 'computed') {
-		return <UnsupportedStatus label={getComputedStatusLabel(propStatus)} />;
+		return (
+			<UnsupportedStatus
+				label={getComputedStatusLabel(propStatus)}
+				fixHref={TIMELINE_COMPUTED_EFFECT_FIX_LINK}
+			/>
+		);
 	}
 
 	const effectiveValue = Internals.getEffectiveVisualModeValue({

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -4,6 +4,7 @@ import type {
 	CanUpdateSequencePropStatusStatic,
 	SequencePropsSubscriptionKey,
 } from 'remotion';
+import {BLUE} from '../../helpers/colors';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -16,18 +17,92 @@ import {
 	TimelinePrimitiveFieldValue,
 } from './TimelinePrimitiveFieldValue';
 
-const unsupportedLabel: React.CSSProperties = {
-	color: 'rgba(255, 255, 255, 0.4)',
-	fontSize: 12,
-	fontStyle: 'italic',
+const INTERACTIVITY_BEST_PRACTICES_DOCS =
+	'https://www.remotion.dev/docs/studio/interactivity-best-practices';
+
+const TIMELINE_COMPUTED_VALUE_FIX_LINK = `${INTERACTIVITY_BEST_PRACTICES_DOCS}#keep-editable-values-visible`;
+
+export const TIMELINE_COMPUTED_EFFECT_FIX_LINK = `${INTERACTIVITY_BEST_PRACTICES_DOCS}#keep-effects-editable`;
+
+const unsupportedStatusWrapper: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'inline-flex',
+	gap: 4,
 	userSelect: 'none',
 	WebkitUserSelect: 'none',
 };
 
+const unsupportedLabel: React.CSSProperties = {
+	color: 'rgba(255, 255, 255, 0.4)',
+	fontSize: 12,
+	fontStyle: 'italic',
+};
+
+const fixLinkBase: React.CSSProperties = {
+	color: BLUE,
+	display: 'inline-block',
+	fontSize: 10,
+	fontStyle: 'normal',
+	fontWeight: 600,
+	lineHeight: 1,
+	textDecoration: 'none',
+	width: 17,
+};
+
 export const UnsupportedStatus: React.FC<{
 	readonly label: string;
-}> = ({label}) => {
-	return <span style={unsupportedLabel}>{label}</span>;
+	readonly fixHref?: string;
+}> = ({label, fixHref}) => {
+	const [hovered, setHovered] = React.useState(false);
+	const [focused, setFocused] = React.useState(false);
+	const visible = hovered || focused;
+
+	const fixLink: React.CSSProperties = React.useMemo(() => {
+		return {
+			...fixLinkBase,
+			opacity: visible ? 1 : 0,
+			pointerEvents: visible ? 'auto' : 'none',
+		};
+	}, [visible]);
+
+	const stopMousePropagation: React.MouseEventHandler<HTMLAnchorElement> = (
+		event,
+	) => {
+		event.stopPropagation();
+	};
+
+	const stopPointerPropagation: React.PointerEventHandler<HTMLAnchorElement> = (
+		event,
+	) => {
+		event.stopPropagation();
+	};
+
+	return (
+		<span
+			style={unsupportedStatusWrapper}
+			onPointerEnter={() => setHovered(true)}
+			onPointerLeave={() => setHovered(false)}
+		>
+			<span style={unsupportedLabel}>{label}</span>
+			{fixHref ? (
+				<a
+					href={fixHref}
+					target="_blank"
+					rel="noreferrer"
+					style={fixLink}
+					title="Open docs to fix computed Studio values"
+					onClick={stopMousePropagation}
+					onDoubleClick={stopMousePropagation}
+					onPointerDown={stopPointerPropagation}
+					onFocus={() => setFocused(true)}
+					onBlur={() => setFocused(false)}
+					tabIndex={visible ? 0 : -1}
+				>
+					Fix
+				</a>
+			) : null}
+		</span>
+	);
 };
 
 export const TimelineNonEditableStatus: React.FC<{
@@ -35,7 +110,10 @@ export const TimelineNonEditableStatus: React.FC<{
 }> = ({propStatus}) => {
 	if (propStatus.status === 'computed') {
 		return (
-			<span style={unsupportedLabel}>{getComputedStatusLabel(propStatus)}</span>
+			<UnsupportedStatus
+				label={getComputedStatusLabel(propStatus)}
+				fixHref={TIMELINE_COMPUTED_VALUE_FIX_LINK}
+			/>
 		);
 	}
 };

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -4,7 +4,7 @@ import type {
 	CanUpdateSequencePropStatusStatic,
 	SequencePropsSubscriptionKey,
 } from 'remotion';
-import {BLUE} from '../../helpers/colors';
+import {LIGHT_TEXT} from '../../helpers/colors';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -39,7 +39,7 @@ const unsupportedLabel: React.CSSProperties = {
 };
 
 const fixLinkBase: React.CSSProperties = {
-	color: BLUE,
+	color: LIGHT_TEXT,
 	display: 'inline-block',
 	fontSize: 10,
 	fontStyle: 'normal',


### PR DESCRIPTION
## Summary

- Shows a hover-only "Fix" link next to computed Timeline values in Studio
- Links sequence computed values to the editable-values best-practice section
- Links effect computed values to the effects best-practice section
- Adds section-specific AI prompts to the interactivity best practices page

Closes #8771

## Tests

- `bunx oxfmt src --write` in `packages/studio`
- `bunx oxfmt src --write` in `packages/docs`
- `bun run build`
- `bun run stylecheck`
- `bun run build-docs`
