### PR TITLE
`remotion`: Delay CanvasImage render until canvas is presented

### DIFF
--- a/packages/core/src/canvas-image/CanvasImage.tsx
+++ b/packages/core/src/canvas-image/CanvasImage.tsx
@@ -2,8 +2,8 @@ import {
 	forwardRef,
 	useCallback,
 	useContext,
-	useEffect,
 	useImperativeHandle,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -52,6 +52,12 @@ type LoadedImage = {
 	readonly element: HTMLImageElement;
 	readonly width: number;
 	readonly height: number;
+};
+
+type PendingLoadDelay = {
+	readonly handle: number;
+	readonly unblock: () => void;
+	continued: boolean;
 };
 
 const makeAbortError = () => {
@@ -144,6 +150,20 @@ function exponentialBackoff(errorCount: number): number {
 	return 1000 * 2 ** (errorCount - 1);
 }
 
+const waitForNextFrame = ({
+	onFrame,
+}: {
+	readonly onFrame: () => void;
+}): (() => void) => {
+	if (typeof requestAnimationFrame === 'undefined') {
+		onFrame();
+		return () => undefined;
+	}
+
+	const frame = requestAnimationFrame(onFrame);
+	return () => cancelAnimationFrame(frame);
+};
+
 type CanvasImageContentProps = Pick<
 	CanvasImageProps,
 	| 'className'
@@ -202,6 +222,19 @@ const CanvasImageContent = forwardRef<
 			overrideId: controls?.overrideId ?? null,
 		});
 		const sequenceContext = useContext(SequenceContext);
+		const pendingLoadDelayRef = useRef<PendingLoadDelay | null>(null);
+
+		const continuePendingLoadDelay = useCallback(() => {
+			const pending = pendingLoadDelayRef.current;
+			if (!pending || pending.continued) {
+				return;
+			}
+
+			pending.continued = true;
+			pending.unblock();
+			continueRender(pending.handle);
+			pendingLoadDelayRef.current = null;
+		}, [continueRender]);
 
 		const sourceCanvas = useMemo(() => {
 			if (typeof document === 'undefined') {
@@ -227,7 +260,7 @@ const CanvasImageContent = forwardRef<
 			[ref, refForOutline],
 		);
 
-		useEffect(() => {
+		useLayoutEffect(() => {
 			const isPremounting = Boolean(sequenceContext?.premounting);
 			const isPostmounting = Boolean(sequenceContext?.postmounting);
 
@@ -245,20 +278,14 @@ const CanvasImageContent = forwardRef<
 
 			const controller = new AbortController();
 			let cancelled = false;
-			let continued = false;
 			let errorCount = 0;
 			let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
 			setLoadedImage(null);
-
-			const continueRenderOnce = () => {
-				if (continued) {
-					return;
-				}
-
-				continued = true;
-				unblock();
-				continueRender(handle);
+			pendingLoadDelayRef.current = {
+				handle,
+				unblock,
+				continued: false,
 			};
 
 			const attemptLoad = () => {
@@ -270,14 +297,9 @@ const CanvasImageContent = forwardRef<
 
 						setLoadedImage(image);
 					})
-					.then(() => {
-						if (!cancelled) {
-							continueRenderOnce();
-						}
-					})
 					.catch((err) => {
 						if ((err as Error).name === 'AbortError') {
-							continueRenderOnce();
+							continuePendingLoadDelay();
 							return;
 						}
 
@@ -295,7 +317,7 @@ const CanvasImageContent = forwardRef<
 							}, backoff);
 						} else if (onError) {
 							onError(err as Error);
-							continueRenderOnce();
+							continuePendingLoadDelay();
 						} else {
 							cancelRender(err);
 						}
@@ -311,12 +333,12 @@ const CanvasImageContent = forwardRef<
 				}
 
 				controller.abort();
-				continueRenderOnce();
+				continuePendingLoadDelay();
 			};
 		}, [
 			actualSrc,
 			cancelRender,
-			continueRender,
+			continuePendingLoadDelay,
 			delayPlayback,
 			delayRender,
 			delayRenderRetries,
@@ -328,7 +350,7 @@ const CanvasImageContent = forwardRef<
 			sequenceContext?.premounting,
 		]);
 
-		useEffect(() => {
+		useLayoutEffect(() => {
 			if (!loadedImage || !outputCanvas || !sourceCanvas) {
 				return;
 			}
@@ -339,6 +361,7 @@ const CanvasImageContent = forwardRef<
 
 			let cancelled = false;
 			let continued = false;
+			let cancelWaitForNextFrame: () => void = () => undefined;
 
 			const continueRenderOnce = () => {
 				if (continued) {
@@ -390,7 +413,16 @@ const CanvasImageContent = forwardRef<
 			})
 				.then((completed) => {
 					if (completed && !cancelled) {
-						continueRenderOnce();
+						cancelWaitForNextFrame = waitForNextFrame({
+							onFrame: () => {
+								if (cancelled) {
+									return;
+								}
+
+								continueRenderOnce();
+								continuePendingLoadDelay();
+							},
+						});
 					}
 				})
 				.catch((err) => {
@@ -401,6 +433,7 @@ const CanvasImageContent = forwardRef<
 					if (onError) {
 						onError(err as Error);
 						continueRenderOnce();
+						continuePendingLoadDelay();
 					} else {
 						cancelRender(err);
 					}
@@ -408,6 +441,7 @@ const CanvasImageContent = forwardRef<
 
 			return () => {
 				cancelled = true;
+				cancelWaitForNextFrame();
 				continueRenderOnce();
 			};
 		}, [
@@ -415,6 +449,7 @@ const CanvasImageContent = forwardRef<
 			cancelRender,
 			chainState,
 			continueRender,
+			continuePendingLoadDelay,
 			delayRender,
 			fit,
 			height,

--- a/packages/core/src/test/canvas-image.test.tsx
+++ b/packages/core/src/test/canvas-image.test.tsx
@@ -73,6 +73,31 @@ class MockImage {
 }
 
 const OriginalImage = globalThis.Image;
+const OriginalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const OriginalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+const getDelayRenderState = () =>
+	window as unknown as {
+		remotion_cancelledError?: string;
+		remotion_delayRenderHandles: number[];
+		remotion_delayRenderTimeouts: Record<
+			string,
+			{timeout: ReturnType<typeof setTimeout>}
+		>;
+		remotion_renderReady: boolean;
+	};
+
+const resetDelayRenderState = () => {
+	const w = getDelayRenderState();
+	for (const {timeout} of Object.values(w.remotion_delayRenderTimeouts ?? {})) {
+		clearTimeout(timeout);
+	}
+
+	w.remotion_cancelledError = undefined;
+	w.remotion_delayRenderHandles = [];
+	w.remotion_delayRenderTimeouts = {};
+	w.remotion_renderReady = false;
+};
 
 const studioEnv = {
 	isRendering: false,
@@ -117,11 +142,15 @@ beforeEach(() => {
 	drawImageCalls.length = 0;
 	imageLoadCount = 0;
 	globalThis.Image = MockImage as unknown as typeof Image;
+	resetDelayRenderState();
 });
 
 afterEach(() => {
 	cleanup();
 	globalThis.Image = OriginalImage;
+	globalThis.requestAnimationFrame = OriginalRequestAnimationFrame;
+	globalThis.cancelAnimationFrame = OriginalCancelAnimationFrame;
+	resetDelayRenderState();
 });
 
 test('<CanvasImage> renders a canvas element with the decoded image dimensions', async () => {
@@ -247,6 +276,119 @@ test('<CanvasImage> runs static images through an effect chain', async () => {
 	expect(applyCalls[0].width).toBe(100);
 	expect(applyCalls[0].height).toBe(50);
 	expect(applyCalls[0].source).toBeInstanceOf(HTMLCanvasElement);
+});
+
+test('<CanvasImage> keeps rendering delayed until the image is drawn into the canvas', async () => {
+	const decodeResolver: {current: (() => void) | null} = {current: null};
+	class DeferredDecodeImage extends MockImage {
+		public decode = () =>
+			new Promise<void>((resolve) => {
+				decodeResolver.current = resolve;
+			});
+	}
+
+	globalThis.Image = DeferredDecodeImage as unknown as typeof Image;
+
+	const applyCalls: EffectApplyParams<unknown, unknown>[] = [];
+	const definition: EffectDefinition<unknown> = {
+		type: 'test-effect',
+		label: 'Test effect',
+		documentationLink: null,
+		backend: '2d',
+		calculateKey: () => 'test-effect',
+		setup: () => ({}),
+		apply: (params) => {
+			applyCalls.push(params);
+			params.target
+				.getContext('2d')
+				?.drawImage(params.source, 0, 0, params.width, params.height);
+		},
+		cleanup: () => undefined,
+		schema: {},
+		validateParams: () => undefined,
+	};
+	const effect: EffectDescriptor<unknown> = {
+		definition,
+		effectKey: 'test-effect',
+		params: {},
+		memoized: false,
+	};
+
+	render(
+		<WrapSequenceContext>
+			<CanvasImage src="test.png" width={100} height={50} effects={[effect]} />
+		</WrapSequenceContext>,
+	);
+
+	await waitFor(() => {
+		expect(decodeResolver.current).not.toBeNull();
+	});
+	expect(getDelayRenderState().remotion_renderReady).toBe(false);
+
+	decodeResolver.current?.();
+	await Promise.resolve();
+	await Promise.resolve();
+
+	expect(getDelayRenderState().remotion_renderReady).toBe(false);
+
+	await waitFor(() => {
+		expect(applyCalls).toHaveLength(1);
+		expect(getDelayRenderState().remotion_renderReady).toBe(true);
+	});
+});
+
+test('<CanvasImage> keeps rendering delayed until the drawn canvas is presented', async () => {
+	const animationFrameCallbacks: FrameRequestCallback[] = [];
+	globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+		animationFrameCallbacks.push(callback);
+		return animationFrameCallbacks.length;
+	}) as typeof requestAnimationFrame;
+	globalThis.cancelAnimationFrame = ((handle: number) => {
+		animationFrameCallbacks[handle - 1] = () => undefined;
+	}) as typeof cancelAnimationFrame;
+
+	const applyCalls: EffectApplyParams<unknown, unknown>[] = [];
+	const definition: EffectDefinition<unknown> = {
+		type: 'test-effect',
+		label: 'Test effect',
+		documentationLink: null,
+		backend: '2d',
+		calculateKey: () => 'test-effect',
+		setup: () => ({}),
+		apply: (params) => {
+			applyCalls.push(params);
+			params.target
+				.getContext('2d')
+				?.drawImage(params.source, 0, 0, params.width, params.height);
+		},
+		cleanup: () => undefined,
+		schema: {},
+		validateParams: () => undefined,
+	};
+	const effect: EffectDescriptor<unknown> = {
+		definition,
+		effectKey: 'test-effect',
+		params: {},
+		memoized: false,
+	};
+
+	render(
+		<WrapSequenceContext>
+			<CanvasImage src="test.png" width={100} height={50} effects={[effect]} />
+		</WrapSequenceContext>,
+	);
+
+	await waitFor(() => {
+		expect(applyCalls).toHaveLength(1);
+		expect(animationFrameCallbacks).toHaveLength(1);
+	});
+
+	expect(getDelayRenderState().remotion_renderReady).toBe(false);
+
+	animationFrameCallbacks[0](performance.now());
+	await Promise.resolve();
+
+	expect(getDelayRenderState().remotion_renderReady).toBe(true);
 });
 
 test('<CanvasImage> does not reload the source image when effect keys change', async () => {


### PR DESCRIPTION
## Summary

- Delay <CanvasImage> rendering until the decoded image has been drawn into the canvas.
- Wait one animation frame after drawing before releasing the render delay, so the canvas presentation has landed.
- Add tests covering the decode-to-draw delay and the next-frame presentation delay.

## Tests

- bun test src/test/canvas-image.test.tsx (from packages/core)
- bun run build
- bun run stylecheck
