### PR TITLE
`@remotion/studio`: Add new folder dialog

### DIFF
--- a/packages/core/src/Folder.tsx
+++ b/packages/core/src/Folder.tsx
@@ -1,4 +1,4 @@
-import type {FC} from 'react';
+import type {FC, ReactNode} from 'react';
 import {createContext, useContext, useEffect, useMemo} from 'react';
 import {CompositionSetters} from './CompositionManagerContext.js';
 import type {NonceHistory} from './nonce.js';
@@ -29,7 +29,7 @@ export const FolderContext = createContext<FolderContextType>({
  */
 export const Folder: FC<{
 	readonly name: string;
-	readonly children: React.ReactNode;
+	readonly children?: ReactNode;
 }> = (props) => {
 	const {name, children} = props;
 	const parent = useContext(FolderContext);

--- a/packages/studio-server/src/codemods/duplicate-composition.ts
+++ b/packages/studio-server/src/codemods/duplicate-composition.ts
@@ -83,6 +83,15 @@ export const parseAndApplyCodemod = ({
 		});
 	}
 
+	if (codeMod.type === 'new-folder') {
+		ensureNamedImport({
+			ast: newAst,
+			importedName: 'Folder',
+			sourcePath: 'remotion',
+			localName: 'Folder',
+		});
+	}
+
 	const output = serializeAst(newAst);
 
 	return {changesMade, newContents: output};

--- a/packages/studio-server/src/codemods/recast-mods.ts
+++ b/packages/studio-server/src/codemods/recast-mods.ts
@@ -162,6 +162,22 @@ const mapReturnStatement = (
 		};
 	}
 
+	if (
+		transformation.type === 'new-folder' &&
+		transformation.parentName === null &&
+		(statement.argument.type === 'JSXElement' ||
+			statement.argument.type === 'JSXFragment')
+	) {
+		return {
+			...statement,
+			argument: addNewFolderToRootJsx(
+				statement.argument,
+				transformation,
+				changesMade,
+			),
+		};
+	}
+
 	const replacement = transformLoneJsxElement(
 		statement.argument,
 		transformation,
@@ -287,6 +303,30 @@ const newCompositionElement = (
 	};
 };
 
+const newFolderElement = (
+	transformation: Extract<RecastCodemod, {type: 'new-folder'}>,
+): JSXElement => {
+	return {
+		type: 'JSXElement',
+		openingElement: {
+			type: 'JSXOpeningElement',
+			name: jsxId('Folder'),
+			attributes: [jsxAttributeWithString('name', transformation.folderName)],
+			selfClosing: false,
+		},
+		closingElement: {
+			type: 'JSXClosingElement',
+			name: jsxId('Folder'),
+		},
+		children: [
+			{
+				type: 'JSXExpressionContainer',
+				expression: nullLiteral(),
+			},
+		],
+	};
+};
+
 const addNewCompositionToRootJsx = <T extends JSXElement | JSXFragment>(
 	root: T,
 	transformation: Extract<RecastCodemod, {type: 'new-composition'}>,
@@ -308,6 +348,29 @@ const addNewCompositionToRootJsx = <T extends JSXElement | JSXFragment>(
 	}
 
 	return wrapInJsxFragment([root, newCompositionElement(transformation)]);
+};
+
+const addNewFolderToRootJsx = <T extends JSXElement | JSXFragment>(
+	root: T,
+	transformation: Extract<RecastCodemod, {type: 'new-folder'}>,
+	changesMade: Change[],
+): JSXElement | JSXFragment => {
+	if (changesMade.length > 0) {
+		return root;
+	}
+
+	changesMade.push({
+		description: 'Added new folder',
+	});
+
+	if (root.type === 'JSXFragment') {
+		return {
+			...root,
+			children: [...root.children, newFolderElement(transformation)],
+		};
+	}
+
+	return wrapInJsxFragment([root, newFolderElement(transformation)]);
 };
 
 const addNewCompositionToFolder = (
@@ -340,6 +403,43 @@ const addNewCompositionToFolder = (
 	};
 };
 
+const addNewFolderToFolder = (
+	folderElement: JSXElement,
+	transformation: Extract<RecastCodemod, {type: 'new-folder'}>,
+	changesMade: Change[],
+): JSXElement => {
+	if (changesMade.length > 0) {
+		return folderElement;
+	}
+
+	changesMade.push({
+		description: 'Added new folder',
+	});
+
+	return {
+		...folderElement,
+		openingElement: {
+			...folderElement.openingElement,
+			selfClosing: false,
+		},
+		closingElement: folderElement.closingElement ?? {
+			type: 'JSXClosingElement',
+			name: folderElement.openingElement.name,
+		},
+		children: [...folderElement.children, newFolderElement(transformation)],
+	};
+};
+
+const getChildFolderParentName = ({
+	folderName,
+	parentFolderName,
+}: {
+	folderName: string;
+	parentFolderName: string | null;
+}) => {
+	return [parentFolderName, folderName].filter(Boolean).join('/');
+};
+
 // When a <Composition> JSX element appears in a position where it cannot
 // simply be removed from a parent's children list (e.g. as the sole return
 // value of a wrapper component or as the concise body of an arrow function),
@@ -368,7 +468,10 @@ const transformLoneJsxElement = (
 					parentFolderName === transformation.parentName) ||
 				(transformation.type === 'new-composition' &&
 					folderName === transformation.folderName &&
-					parentFolderName === transformation.parentName));
+					parentFolderName === transformation.parentName) ||
+				(transformation.type === 'new-folder' &&
+					getChildFolderParentName({folderName, parentFolderName}) ===
+						transformation.parentName));
 
 		if (!isFolderMatch) {
 			return null;
@@ -390,7 +493,11 @@ const transformLoneJsxElement = (
 			parentFolderName === transformation.parentName) ||
 		(transformation.type === 'new-composition' &&
 			folderName === transformation.folderName &&
-			parentFolderName === transformation.parentName);
+			parentFolderName === transformation.parentName) ||
+		(transformation.type === 'new-folder' &&
+			folderName !== null &&
+			getChildFolderParentName({folderName, parentFolderName}) ===
+				transformation.parentName);
 
 	if (!isMatch) {
 		return null;
@@ -433,16 +540,6 @@ const mapJsxElementOrFragment = <T extends JSXFragment | JSXElement>(
 			})
 			.flat(1),
 	};
-};
-
-const getChildFolderParentName = ({
-	folderName,
-	parentFolderName,
-}: {
-	folderName: string;
-	parentFolderName: string | null;
-}) => {
-	return [parentFolderName, folderName].filter(Boolean).join('/');
 };
 
 const mapJsxChild = (
@@ -538,6 +635,15 @@ const mapJsxChild = (
 		return [addNewCompositionToFolder(c, transformation, changesMade)];
 	}
 
+	if (
+		transformation.type === 'new-folder' &&
+		folderName !== null &&
+		getChildFolderParentName({folderName, parentFolderName}) ===
+			transformation.parentName
+	) {
+		return [addNewFolderToFolder(c, transformation, changesMade)];
+	}
+
 	const childParentFolderName = folderName
 		? getChildFolderParentName({folderName, parentFolderName})
 		: parentFolderName;
@@ -573,6 +679,22 @@ const mapRecognizedType = <T extends RecognizedType>(
 			return {
 				...expression,
 				body: addNewCompositionToRootJsx(
+					expression.body,
+					transformation,
+					changesMade,
+				),
+			};
+		}
+
+		if (
+			transformation.type === 'new-folder' &&
+			transformation.parentName === null &&
+			(expression.body.type === 'JSXElement' ||
+				expression.body.type === 'JSXFragment')
+		) {
+			return {
+				...expression,
+				body: addNewFolderToRootJsx(
 					expression.body,
 					transformation,
 					changesMade,

--- a/packages/studio-server/src/codemods/recast-mods.ts
+++ b/packages/studio-server/src/codemods/recast-mods.ts
@@ -312,18 +312,10 @@ const newFolderElement = (
 			type: 'JSXOpeningElement',
 			name: jsxId('Folder'),
 			attributes: [jsxAttributeWithString('name', transformation.folderName)],
-			selfClosing: false,
+			selfClosing: true,
 		},
-		closingElement: {
-			type: 'JSXClosingElement',
-			name: jsxId('Folder'),
-		},
-		children: [
-			{
-				type: 'JSXExpressionContainer',
-				expression: nullLiteral(),
-			},
-		],
+		closingElement: null,
+		children: [],
 	};
 };
 

--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -76,6 +76,15 @@ const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
 		};
 	}
 
+	if (codemod.type === 'new-folder') {
+		const label = `folder "${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}"`;
+		return {
+			undoMessage: `↩️  Creation of ${label}`,
+			redoMessage: `↪️  Creation of ${label}`,
+			entryType: codemod.type,
+		};
+	}
+
 	if (codemod.type === 'rename-folder') {
 		const oldName = `${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}`;
 		const newName = `${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.newName}`;

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -39,6 +39,7 @@ type UndoEntryType =
 	| 'rename-composition'
 	| 'new-composition'
 	| 'duplicate-composition'
+	| 'new-folder'
 	| 'delete-folder'
 	| 'rename-folder';
 
@@ -79,6 +80,7 @@ type UndoEntry = {
 	| {entryType: 'rename-composition'}
 	| {entryType: 'new-composition'}
 	| {entryType: 'duplicate-composition'}
+	| {entryType: 'new-folder'}
 	| {entryType: 'delete-folder'}
 	| {entryType: 'rename-folder'}
 );

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -237,6 +237,21 @@ test('applyCodemodHandler pushes composition duplications to undo and redo stack
 	});
 });
 
+test('applyCodemodHandler pushes folder creations to undo and redo stacks', async () => {
+	await runCompositionCodemodUndoRedoTest({
+		codemod: {
+			type: 'new-folder',
+			folderName: 'FreshFolder',
+			parentName: null,
+		},
+		assertApplied: (contents) => {
+			expect(contents).toContain('<Folder name="FreshFolder">{null}</Folder>');
+			expect(contents).toContain('id="KeepMe"');
+		},
+		expectedUndoMessage: '↩️  Creation of folder "FreshFolder"',
+	});
+});
+
 test('applyCodemodHandler creates new composition files with undo and redo', async () => {
 	const remotionRoot = mkdtempSync(path.join(tmpdir(), 'remotion-codemod-'));
 	const cleanupFileWatcher = setFileWatcherRegistry(
@@ -370,6 +385,46 @@ test('creates a composition in a nested folder by parent path', () => {
 	expect(newContents.indexOf('id="NestedA"')).toBeLessThan(
 		newContents.indexOf('id="NestedB"'),
 	);
+});
+
+test('creates a top-level folder', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: rootContents,
+		codeMod: {
+			type: 'new-folder',
+			folderName: 'FreshFolder',
+			parentName: null,
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents).toMatch(
+		/import\s*\{[^}]*Folder[^}]*\}\s*from\s*['"]remotion['"]/,
+	);
+	expect(newContents).toContain('<Folder name="FreshFolder">{null}</Folder>');
+	expect(newContents.indexOf('id="KeepMe"')).toBeLessThan(
+		newContents.indexOf('<Folder name="FreshFolder">{null}</Folder>'),
+	);
+});
+
+test('creates a folder in a nested folder by parent path', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: folderRootContents,
+		codeMod: {
+			type: 'new-folder',
+			folderName: 'FreshFolder',
+			parentName: 'Parent/Shared',
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents).toContain('<Folder name="FreshFolder">{null}</Folder>');
+	expect(newContents.indexOf('id="NestedA"')).toBeLessThan(
+		newContents.indexOf('<Folder name="FreshFolder">{null}</Folder>'),
+	);
+	expect(
+		newContents.indexOf('<Folder name="FreshFolder">{null}</Folder>'),
+	).toBeLessThan(newContents.indexOf('<Folder name="Other">'));
 });
 
 test('renames a nested folder by parent path', () => {

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -86,6 +86,28 @@ export const RemotionRoot: React.FC = () => {
 };
 `;
 
+const selfClosingFolderRootContents = `import React from 'react';
+import {Composition, Folder} from 'remotion';
+
+const Component = () => null;
+
+export const RemotionRoot: React.FC = () => {
+	return (
+		<>
+			<Folder name="Empty" />
+			<Composition
+				id="KeepMe"
+				component={Component}
+				durationInFrames={120}
+				fps={30}
+				width={1280}
+				height={720}
+			/>
+		</>
+	);
+};
+`;
+
 const clearUndoRedoStacks = () => {
 	(getUndoStack() as unknown as unknown[]).length = 0;
 	(getRedoStack() as unknown as unknown[]).length = 0;
@@ -245,7 +267,7 @@ test('applyCodemodHandler pushes folder creations to undo and redo stacks', asyn
 			parentName: null,
 		},
 		assertApplied: (contents) => {
-			expect(contents).toContain('<Folder name="FreshFolder">{null}</Folder>');
+			expect(contents).toContain('<Folder name="FreshFolder" />');
 			expect(contents).toContain('id="KeepMe"');
 		},
 		expectedUndoMessage: '↩️  Creation of folder "FreshFolder"',
@@ -401,9 +423,9 @@ test('creates a top-level folder', () => {
 	expect(newContents).toMatch(
 		/import\s*\{[^}]*Folder[^}]*\}\s*from\s*['"]remotion['"]/,
 	);
-	expect(newContents).toContain('<Folder name="FreshFolder">{null}</Folder>');
+	expect(newContents).toContain('<Folder name="FreshFolder" />');
 	expect(newContents.indexOf('id="KeepMe"')).toBeLessThan(
-		newContents.indexOf('<Folder name="FreshFolder">{null}</Folder>'),
+		newContents.indexOf('<Folder name="FreshFolder" />'),
 	);
 });
 
@@ -418,13 +440,62 @@ test('creates a folder in a nested folder by parent path', () => {
 	});
 
 	expect(changesMade.length).toBe(1);
-	expect(newContents).toContain('<Folder name="FreshFolder">{null}</Folder>');
+	expect(newContents).toContain('<Folder name="FreshFolder" />');
 	expect(newContents.indexOf('id="NestedA"')).toBeLessThan(
-		newContents.indexOf('<Folder name="FreshFolder">{null}</Folder>'),
+		newContents.indexOf('<Folder name="FreshFolder" />'),
 	);
-	expect(
-		newContents.indexOf('<Folder name="FreshFolder">{null}</Folder>'),
-	).toBeLessThan(newContents.indexOf('<Folder name="Other">'));
+	expect(newContents.indexOf('<Folder name="FreshFolder" />')).toBeLessThan(
+		newContents.indexOf('<Folder name="Other">'),
+	);
+});
+
+test('creates a composition in a self-closing folder', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: selfClosingFolderRootContents,
+		codeMod: {
+			type: 'new-composition',
+			newId: 'FreshVideo',
+			componentName: 'FreshVideo',
+			componentImportPath: './FreshVideo',
+			folderName: 'Empty',
+			parentName: null,
+			newDurationInFrames: 150,
+			newFps: 30,
+			newHeight: 1080,
+			newWidth: 1920,
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents).toContain('<Folder name="Empty">');
+	expect(newContents).toContain('id="FreshVideo"');
+	expect(newContents.indexOf('<Folder name="Empty">')).toBeLessThan(
+		newContents.indexOf('id="FreshVideo"'),
+	);
+	expect(newContents.indexOf('id="FreshVideo"')).toBeLessThan(
+		newContents.indexOf('id="KeepMe"'),
+	);
+});
+
+test('creates a folder in a self-closing folder', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: selfClosingFolderRootContents,
+		codeMod: {
+			type: 'new-folder',
+			folderName: 'Nested',
+			parentName: 'Empty',
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents).toContain('<Folder name="Empty">');
+	expect(newContents).toContain('<Folder name="Nested" />');
+	expect(newContents.indexOf('<Folder name="Empty">')).toBeLessThan(
+		newContents.indexOf('<Folder name="Nested" />'),
+	);
+	expect(newContents.indexOf('<Folder name="Nested" />')).toBeLessThan(
+		newContents.indexOf('id="KeepMe"'),
+	);
 });
 
 test('renames a nested folder by parent path', () => {

--- a/packages/studio-shared/src/codemods.ts
+++ b/packages/studio-shared/src/codemods.ts
@@ -51,6 +51,11 @@ export type RecastCodemod =
 			newName: string;
 	  }
 	| {
+			type: 'new-folder';
+			folderName: string;
+			parentName: string | null;
+	  }
+	| {
 			type: 'delete-folder';
 			folderName: string;
 			parentName: string | null;

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -9,6 +9,7 @@ import {DeleteComposition} from './NewComposition/DeleteComposition';
 import {DeleteFolder} from './NewComposition/DeleteFolder';
 import {DuplicateComposition} from './NewComposition/DuplicateComposition';
 import {NewComposition} from './NewComposition/NewComposition';
+import {NewFolder} from './NewComposition/NewFolder';
 import {RenameComposition} from './NewComposition/RenameComposition';
 import {RenameFolder} from './NewComposition/RenameFolder';
 import {RenameStaticFileModal} from './NewComposition/RenameStaticFile';
@@ -33,6 +34,12 @@ export const Modals: React.FC<{
 			{modalContextType && modalContextType.type === 'new-comp' && (
 				<NewComposition
 					folderName={modalContextType.folderName}
+					parentName={modalContextType.parentName}
+					stack={modalContextType.stack}
+				/>
+			)}
+			{modalContextType && modalContextType.type === 'new-folder' && (
+				<NewFolder
 					parentName={modalContextType.parentName}
 					stack={modalContextType.stack}
 				/>

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -25,6 +25,10 @@ const content: React.CSSProperties = {
 	minWidth: 500,
 };
 
+const folderPathStyle: React.CSSProperties = {
+	fontSize: 14,
+};
+
 const NewCompositionLoaded: React.FC<{
 	readonly folderName: string | null;
 	readonly parentName: string | null;
@@ -123,7 +127,9 @@ const NewCompositionLoaded: React.FC<{
 					{folderPath ? (
 						<div style={optionRow}>
 							<div style={label}>Folder</div>
-							<div style={rightRow}>{folderPath}</div>
+							<div style={rightRow}>
+								<span style={folderPathStyle}>{folderPath}</span>
+							</div>
 						</div>
 					) : null}
 					<div style={optionRow}>

--- a/packages/studio/src/components/NewComposition/NewFolder.tsx
+++ b/packages/studio/src/components/NewComposition/NewFolder.tsx
@@ -1,0 +1,161 @@
+import type {RecastCodemod} from '@remotion/studio-shared';
+import type {ChangeEventHandler} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
+import {Internals, type _InternalTypes} from 'remotion';
+import {getFolderId} from '../../helpers/get-folder-id';
+import {validateNewFolderName} from '../../helpers/validate-new-folder-name';
+import {Spacing} from '../layout';
+import {ModalFooterContainer} from '../ModalFooter';
+import {ModalHeader} from '../ModalHeader';
+import {label, optionRow, rightRow} from '../RenderModal/layout';
+import {applyCodemod} from '../RenderQueue/actions';
+import {CodemodFooter} from './CodemodFooter';
+import {DismissableModal} from './DismissableModal';
+import {InputAndValidationContainer} from './InputAndValidationContainer';
+import {RemotionInput} from './RemInput';
+import {ValidationMessage} from './ValidationMessage';
+
+const content: React.CSSProperties = {
+	padding: 12,
+	paddingRight: 12,
+	flex: 1,
+	fontSize: 13,
+	minWidth: 500,
+};
+
+const getUniqueFolderName = ({
+	folders,
+	parentName,
+}: {
+	folders: _InternalTypes['TFolder'][];
+	parentName: string | null;
+}) => {
+	let counter = 1;
+
+	while (true) {
+		const name = counter === 1 ? 'NewFolder' : `NewFolder${counter}`;
+		const err = validateNewFolderName({folders, newName: name, parentName});
+		if (!err) {
+			return name;
+		}
+
+		counter++;
+	}
+};
+
+export const NewFolder: React.FC<{
+	readonly parentName: string | null;
+	readonly stack: string | null;
+}> = ({parentName, stack}) => {
+	const {folders} = useContext(Internals.CompositionManager);
+	const [newName, setName] = useState(() =>
+		getUniqueFolderName({folders, parentName}),
+	);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		const input = inputRef.current;
+		if (!input) return;
+		input.select();
+	}, []);
+
+	const onNameChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+		(e) => {
+			setName(e.target.value);
+		},
+		[],
+	);
+
+	const folderNameErrMessage = validateNewFolderName({
+		folders,
+		newName,
+		parentName,
+	});
+	const valid = folderNameErrMessage === null;
+
+	const codemod: RecastCodemod = useMemo(() => {
+		return {
+			type: 'new-folder',
+			folderName: newName,
+			parentName,
+		};
+	}, [newName, parentName]);
+
+	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((e) => {
+		e.preventDefault();
+	}, []);
+
+	const folderId = getFolderId({folderName: newName, parentName});
+
+	return (
+		<DismissableModal>
+			<ModalHeader title="New folder" />
+			<form onSubmit={onSubmit}>
+				<div style={content}>
+					{parentName ? (
+						<div style={optionRow}>
+							<div style={label}>Parent</div>
+							<div style={rightRow}>{parentName}</div>
+						</div>
+					) : null}
+					<div style={optionRow}>
+						<div style={label}>Name</div>
+						<div style={rightRow}>
+							<InputAndValidationContainer>
+								<RemotionInput
+									ref={inputRef}
+									value={newName}
+									onChange={onNameChange}
+									type="text"
+									autoFocus
+									placeholder="Folder name"
+									status="ok"
+									rightAlign
+								/>
+								{folderNameErrMessage ? (
+									<>
+										<Spacing y={1} block />
+										<ValidationMessage
+											align="flex-start"
+											message={folderNameErrMessage}
+											type="error"
+										/>
+									</>
+								) : null}
+							</InputAndValidationContainer>
+						</div>
+					</div>
+				</div>
+				<ModalFooterContainer>
+					<CodemodFooter
+						loadingNotification={'Creating folder...'}
+						errorNotification={'Could not create folder'}
+						successNotification={`Created folder ${folderId}`}
+						genericSubmitLabel={'Add to root file'}
+						submitLabel={({relativeRootPath}) => `Add to ${relativeRootPath}`}
+						codemod={codemod}
+						stack={stack}
+						valid={valid}
+						onSuccess={null}
+						fallbackToRootFile
+						applyCodemod={({signal, symbolicatedStack}) =>
+							applyCodemod({
+								codemod,
+								dryRun: false,
+								signal,
+								symbolicatedStack,
+							})
+						}
+					/>
+				</ModalFooterContainer>
+			</form>
+		</DismissableModal>
+	);
+};

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -78,6 +78,7 @@ const getFileMenu = ({
 					leftItem: null,
 					subMenu: null,
 					quickSwitcherLabel: 'New folder...',
+					disabled: previewServerState !== 'connected',
 				},
 		readOnlyStudio
 			? null

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -59,6 +59,26 @@ const getFileMenu = ({
 	setSelectedModal: (value: React.SetStateAction<ModalState | null>) => void;
 }) => {
 	const items: ComboboxValue[] = [
+		readOnlyStudio
+			? null
+			: {
+					id: 'new-folder',
+					value: 'new-folder',
+					label: 'New Folder...',
+					onClick: () => {
+						closeMenu();
+						setSelectedModal({
+							type: 'new-folder',
+							parentName: null,
+							stack: null,
+						});
+					},
+					type: 'item' as const,
+					keyHint: null,
+					leftItem: null,
+					subMenu: null,
+					quickSwitcherLabel: 'New folder...',
+				},
 		window.remotion_isReadOnlyStudio
 			? {
 					id: 'input-props-override',

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -79,6 +79,12 @@ const getFileMenu = ({
 					subMenu: null,
 					quickSwitcherLabel: 'New folder...',
 				},
+		readOnlyStudio
+			? null
+			: {
+					type: 'divider' as const,
+					id: 'new-folder-divider',
+				},
 		window.remotion_isReadOnlyStudio
 			? {
 					id: 'input-props-override',

--- a/packages/studio/src/helpers/validate-folder-rename.ts
+++ b/packages/studio/src/helpers/validate-folder-rename.ts
@@ -1,5 +1,5 @@
 import type {_InternalTypes} from 'remotion';
-import {Internals} from 'remotion';
+import {validateNewFolderName} from './validate-new-folder-name';
 
 export const validateFolderRename = ({
 	folders,
@@ -12,21 +12,9 @@ export const validateFolderRename = ({
 	originalName: string;
 	parentName: string | null;
 }): string | null => {
-	if (!Internals.isFolderNameValid(newName)) {
-		return Internals.invalidFolderNameErrorMessage;
-	}
-
 	if (newName === originalName) {
 		return null;
 	}
 
-	if (
-		folders.find((folder) => {
-			return folder.name === newName && folder.parent === parentName;
-		})
-	) {
-		return `A folder with that name already exists.`;
-	}
-
-	return null;
+	return validateNewFolderName({folders, newName, parentName});
 };

--- a/packages/studio/src/helpers/validate-new-folder-name.ts
+++ b/packages/studio/src/helpers/validate-new-folder-name.ts
@@ -1,0 +1,26 @@
+import type {_InternalTypes} from 'remotion';
+import {Internals} from 'remotion';
+
+export const validateNewFolderName = ({
+	folders,
+	newName,
+	parentName,
+}: {
+	folders: _InternalTypes['TFolder'][];
+	newName: string;
+	parentName: string | null;
+}): string | null => {
+	if (!Internals.isFolderNameValid(newName)) {
+		return Internals.invalidFolderNameErrorMessage;
+	}
+
+	if (
+		folders.find((folder) => {
+			return folder.name === newName && folder.parent === parentName;
+		})
+	) {
+		return `A folder with that name already exists.`;
+	}
+
+	return null;
+};

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -135,6 +135,11 @@ export type ModalState =
 			stack: string | null;
 	  }
 	| {
+			type: 'new-folder';
+			parentName: string | null;
+			stack: string | null;
+	  }
+	| {
 			type: 'duplicate-comp';
 			compositionId: string;
 			compositionType: CompType;


### PR DESCRIPTION
## Summary
- Add a Studio `File` -> `New Folder...` action and modal.
- Add an undoable `new-folder` codemod that inserts `<Folder>` at the root or inside a folder.
- Reuse folder-name validation and add codemod tests for folder creation.

## Test plan
- `bun test packages/studio-server/src/test/apply-codemod.test.ts packages/studio-server/src/test/recast-mods.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #8796
