### PR TITLE
Docs: Add Sequence freeze recommendation

### DIFF
--- a/packages/docs/docs/freeze.mdx
+++ b/packages/docs/docs/freeze.mdx
@@ -7,12 +7,12 @@ crumb: 'API'
 
 import {FreezeExample} from '../components/FreezeExample/FreezeExample';
 
+# &lt;Freeze&gt;<AvailableFrom v="2.2.0" />
+
 ```twoslash include example
 const BlueSquare: React.FC = () => <div></div>
 // - BlueSquare
 ```
-
-<AvailableFrom v="2.2.0" />
 
 For new code, prefer [`<Sequence freeze>`](/docs/sequence#freeze) if you want to freeze a timeline item.
 The `freeze` prop is supported by Studio [interactivity](/docs/interactive), so it can be edited visually.

--- a/packages/docs/docs/freeze.mdx
+++ b/packages/docs/docs/freeze.mdx
@@ -14,6 +14,8 @@ const BlueSquare: React.FC = () => <div></div>
 // - BlueSquare
 ```
 
+## Recommendation: &lt;Sequence freeze&gt;
+
 For new code, prefer [`<Sequence freeze>`](/docs/sequence#freeze) if you want to freeze a timeline item.
 The `freeze` prop is supported by Studio [interactivity](/docs/interactive), so it can be edited visually.
 
@@ -30,6 +32,8 @@ const MyVideo = () => {
   );
 };
 ```
+
+---
 
 When using the `<Freeze/>` component, all of its children will freeze to the frame that you specify as a prop.
 

--- a/packages/docs/docs/freeze.mdx
+++ b/packages/docs/docs/freeze.mdx
@@ -14,6 +14,23 @@ const BlueSquare: React.FC = () => <div></div>
 
 <AvailableFrom v="2.2.0" />
 
+For new code, prefer [`<Sequence freeze>`](/docs/sequence#freeze) if you want to freeze a timeline item.
+The `freeze` prop is supported by Studio [interactivity](/docs/interactive), so it can be edited visually.
+
+```tsx twoslash title="MyComp.tsx"
+// @include: example-BlueSquare
+// ---cut---
+import {Sequence} from 'remotion';
+
+const MyVideo = () => {
+  return (
+    <Sequence freeze={30}>
+      <BlueSquare />
+    </Sequence>
+  );
+};
+```
+
 When using the `<Freeze/>` component, all of its children will freeze to the frame that you specify as a prop.
 
 If a component is a child of `<Freeze/>`, calling the [`useCurrentFrame()`](/docs/use-current-frame) hook will always return the frame number you specify, irrespective of any [`<Sequence>`](/docs/sequence).


### PR DESCRIPTION
## Summary

- Recommend `<Sequence freeze>` at the top of the `<Freeze>` docs page
- Add a twoslash snippet using `<Sequence freeze={30}>`
- Link the recommendation to the Studio interactivity docs

## Testing

- `cd packages/docs && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
- `bun run build-docs`
