### PR TITLE
`docs`: Store raw Markdown carrier outside scripts

### DIFF
--- a/packages/docs/src/test/raw-markdown-carrier.test.ts
+++ b/packages/docs/src/test/raw-markdown-carrier.test.ts
@@ -1,10 +1,15 @@
 import {expect, test} from 'bun:test';
-import {serializeRawMarkdownForScript} from '../theme/RawMarkdownCarrier';
+import {
+	decodeRawMarkdownFromCarrier,
+	encodeRawMarkdownForCarrier,
+} from '../theme/RawMarkdownCarrier';
 
-test('escapes raw markdown so it can be embedded in a script tag', () => {
+test('encodes raw markdown so it can be embedded in an HTML attribute', () => {
 	const raw = '```svelte\n<script>console.log("hi")</script>\n```';
-	const serialized = serializeRawMarkdownForScript(raw);
+	const encoded = encodeRawMarkdownForCarrier(raw);
 
-	expect(serialized).not.toContain('</script>');
-	expect(JSON.parse(serialized)).toBe(raw);
+	expect(encoded).not.toContain('<');
+	expect(encoded).not.toContain('>');
+	expect(encoded).not.toContain('</script>');
+	expect(decodeRawMarkdownFromCarrier(encoded)).toBe(raw);
 });

--- a/packages/docs/src/test/raw-markdown-carrier.test.ts
+++ b/packages/docs/src/test/raw-markdown-carrier.test.ts
@@ -1,0 +1,10 @@
+import {expect, test} from 'bun:test';
+import {serializeRawMarkdownForScript} from '../theme/RawMarkdownCarrier';
+
+test('escapes raw markdown so it can be embedded in a script tag', () => {
+	const raw = '```svelte\n<script>console.log("hi")</script>\n```';
+	const serialized = serializeRawMarkdownForScript(raw);
+
+	expect(serialized).not.toContain('</script>');
+	expect(JSON.parse(serialized)).toBe(raw);
+});

--- a/packages/docs/src/theme/DocBreadcrumbs/index.tsx
+++ b/packages/docs/src/theme/DocBreadcrumbs/index.tsx
@@ -3,6 +3,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import type DocBreadcrumbsType from '@theme-original/DocBreadcrumbs';
 import DocBreadcrumbs from '@theme-original/DocBreadcrumbs';
 import React, {type ReactNode, useCallback, useState} from 'react';
+import {decodeRawMarkdownFromCarrier} from '../RawMarkdownCarrier';
 import {
 	AnthropicIcon,
 	CursorIcon,
@@ -122,7 +123,10 @@ export default function DocBreadcrumbsWrapper(props: Props): ReactNode {
 		try {
 			const el = document.getElementById('__doc_raw');
 			let raw = '';
-			if (el?.textContent) {
+			const encodedRaw = el?.getAttribute('data-raw-markdown');
+			if (encodedRaw) {
+				raw = decodeRawMarkdownFromCarrier(encodedRaw);
+			} else if (el?.textContent) {
 				raw = JSON.parse(el.textContent);
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			} else if ((window as any).__DOC_RAW) {

--- a/packages/docs/src/theme/RawMarkdownCarrier/index.tsx
+++ b/packages/docs/src/theme/RawMarkdownCarrier/index.tsx
@@ -1,7 +1,11 @@
 import React, {useEffect} from 'react';
 
-export const serializeRawMarkdownForScript = (raw: string) => {
-	return JSON.stringify(raw).replace(/</g, '\\u003c');
+export const encodeRawMarkdownForCarrier = (raw: string) => {
+	return encodeURIComponent(raw);
+};
+
+export const decodeRawMarkdownFromCarrier = (encoded: string) => {
+	return decodeURIComponent(encoded);
 };
 
 export default function RawMarkdownCarrier({raw}: {readonly raw: string}) {
@@ -11,11 +15,10 @@ export default function RawMarkdownCarrier({raw}: {readonly raw: string}) {
 	}, [raw]);
 
 	return (
-		<script
-			// eslint-disable-next-line react/no-danger
-			dangerouslySetInnerHTML={{__html: serializeRawMarkdownForScript(raw)}}
+		<span
+			data-raw-markdown={encodeRawMarkdownForCarrier(raw)}
+			hidden
 			id="__doc_raw"
-			type="application/json"
 		/>
 	);
 }

--- a/packages/docs/src/theme/RawMarkdownCarrier/index.tsx
+++ b/packages/docs/src/theme/RawMarkdownCarrier/index.tsx
@@ -1,5 +1,9 @@
 import React, {useEffect} from 'react';
 
+export const serializeRawMarkdownForScript = (raw: string) => {
+	return JSON.stringify(raw).replace(/</g, '\\u003c');
+};
+
 export default function RawMarkdownCarrier({raw}: {readonly raw: string}) {
 	useEffect(() => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -9,7 +13,7 @@ export default function RawMarkdownCarrier({raw}: {readonly raw: string}) {
 	return (
 		<script
 			// eslint-disable-next-line react/no-danger
-			dangerouslySetInnerHTML={{__html: JSON.stringify(raw)}}
+			dangerouslySetInnerHTML={{__html: serializeRawMarkdownForScript(raw)}}
 			id="__doc_raw"
 			type="application/json"
 		/>


### PR DESCRIPTION
## Summary

- Store raw Markdown in a hidden carrier attribute instead of a script body
- Decode the carrier attribute when copying Markdown, with the previous script text path kept as a fallback
- Add a regression test for script-safe carrier encoding

Fixes #8786.

## Testing

- `bun test packages/docs/src/test/raw-markdown-carrier.test.ts`
- `bun test packages/docs/src/test`
- `bunx oxfmt src --write` from `packages/docs`
- `bun run clear && REMOTION_DOCS_LOW_MEMORY_BUILD=1 REMOTION_DOCS_DISABLE_GIT_LAST_UPDATE=1 bun run build-docs` from `packages/docs`
- inspected generated `docs/svelte`, `docs/vue`, and `docs/angular` HTML: carrier is a hidden span with encoded Markdown, no script close before the H1
- `bun run build`
- `bun run stylecheck`
