### PR TITLE
`@remotion/studio`: Implement composition dragging

### DIFF
--- a/packages/core/src/ResolveCompositionConfig.tsx
+++ b/packages/core/src/ResolveCompositionConfig.tsx
@@ -20,6 +20,7 @@ export const ResolveCompositionContext =
 export const resolveCompositionsRef = createRef<{
 	setCurrentRenderModalComposition: (compositionId: string | null) => void;
 	reloadCurrentlySelectedComposition: () => void;
+	resolveComposition: (compositionId: string) => Promise<VideoConfig>;
 }>();
 
 type VideoConfigState =

--- a/packages/studio-server/src/codemods/recast-mods.ts
+++ b/packages/studio-server/src/codemods/recast-mods.ts
@@ -456,6 +456,48 @@ const appendCompositionToFolder = ({
 	folderElement.children.push(stripParenthesizedExtra(compositionElement));
 };
 
+const appendCompositionToRoot = ({
+	compositionElement,
+	file,
+}: {
+	compositionElement: JSXElement;
+	file: File;
+}) => {
+	let appended = false;
+
+	recast.types.visit(file, {
+		visitReturnStatement(astPath) {
+			if (appended) {
+				return false;
+			}
+
+			const {argument} = astPath.node;
+			if (argument?.type !== 'JSXFragment' && argument?.type !== 'JSXElement') {
+				this.traverse(astPath);
+				return undefined;
+			}
+
+			if (argument.type === 'JSXFragment') {
+				(argument.children as JSXFragment['children']).push(
+					stripParenthesizedExtra(compositionElement),
+				);
+			} else {
+				astPath.node.argument = wrapInJsxFragment([
+					argument as unknown as JSXElement,
+					compositionElement,
+				]) as never;
+			}
+
+			appended = true;
+			return false;
+		},
+	});
+
+	if (!appended) {
+		throw new Error('Could not find a root JSX element');
+	}
+};
+
 const moveCompositionToFolder = ({
 	file,
 	transformation,
@@ -466,6 +508,7 @@ const moveCompositionToFolder = ({
 	changesMade: Change[];
 }): ApplyCodeModReturnType => {
 	let sourcePath: recast.types.NodePath | null = null;
+	let sourceParentFolderName: string | null = null;
 	let targetFolder: JSXElement | null = null;
 	const folderStack: string[] = [];
 
@@ -475,11 +518,13 @@ const moveCompositionToFolder = ({
 			const compositionId = getCompositionIdFromJSXElement(node);
 			if (compositionId === transformation.idToMove) {
 				sourcePath = astPath as unknown as recast.types.NodePath;
+				sourceParentFolderName = folderStack.join('/') || null;
 			}
 
 			const folderName = getFolderNameFromJSXElement(node);
 			const parentName = folderStack.join('/') || null;
 			if (
+				transformation.folderName !== null &&
 				folderName === transformation.folderName &&
 				parentName === transformation.parentName
 			) {
@@ -504,7 +549,11 @@ const moveCompositionToFolder = ({
 		throw new Error(`Could not find composition "${transformation.idToMove}"`);
 	}
 
-	if (!targetFolder) {
+	if (transformation.folderName === null && sourceParentFolderName === null) {
+		return {newAst: file, changesMade};
+	}
+
+	if (transformation.folderName !== null && !targetFolder) {
 		const folderLabel = `${transformation.parentName ? `${transformation.parentName}/` : ''}${transformation.folderName}`;
 		throw new Error(`Could not find folder "${folderLabel}"`);
 	}
@@ -512,11 +561,20 @@ const moveCompositionToFolder = ({
 	const compositionElement = (sourcePath as recast.types.NodePath)
 		.node as JSXElement;
 	deleteJsxElementAtPath(sourcePath);
-	appendCompositionToFolder({
-		compositionElement,
-		folderElement: targetFolder,
-	});
-	changesMade.push({description: 'Moved composition into folder'});
+	if (transformation.folderName === null) {
+		appendCompositionToRoot({compositionElement, file});
+		changesMade.push({description: 'Moved composition to root'});
+	} else {
+		if (targetFolder === null) {
+			throw new Error('Could not find target folder');
+		}
+
+		appendCompositionToFolder({
+			compositionElement,
+			folderElement: targetFolder,
+		});
+		changesMade.push({description: 'Moved composition into folder'});
+	}
 
 	return {newAst: file, changesMade};
 };

--- a/packages/studio-server/src/codemods/recast-mods.ts
+++ b/packages/studio-server/src/codemods/recast-mods.ts
@@ -20,6 +20,7 @@ import type {
 import type {RecastCodemod} from '@remotion/studio-shared';
 import * as recast from 'recast';
 import {applyVisualControl} from './apply-visual-control';
+import {deleteJsxElementAtPath} from './delete-jsx-node';
 
 export type Change = {
 	description: string;
@@ -40,6 +41,14 @@ export const applyCodemod = ({
 
 	if (codeMod.type === 'apply-visual-control') {
 		return applyVisualControl({file, transformation: codeMod, changesMade});
+	}
+
+	if (codeMod.type === 'move-composition-to-folder') {
+		return moveCompositionToFolder({
+			file,
+			transformation: codeMod,
+			changesMade,
+		});
 	}
 
 	const body = file.program.body.map((node) => {
@@ -430,6 +439,86 @@ const getChildFolderParentName = ({
 	parentFolderName: string | null;
 }) => {
 	return [parentFolderName, folderName].filter(Boolean).join('/');
+};
+
+const appendCompositionToFolder = ({
+	compositionElement,
+	folderElement,
+}: {
+	compositionElement: JSXElement;
+	folderElement: JSXElement;
+}) => {
+	folderElement.openingElement.selfClosing = false;
+	folderElement.closingElement = folderElement.closingElement ?? {
+		type: 'JSXClosingElement',
+		name: folderElement.openingElement.name,
+	};
+	folderElement.children.push(stripParenthesizedExtra(compositionElement));
+};
+
+const moveCompositionToFolder = ({
+	file,
+	transformation,
+	changesMade,
+}: {
+	file: File;
+	transformation: Extract<RecastCodemod, {type: 'move-composition-to-folder'}>;
+	changesMade: Change[];
+}): ApplyCodeModReturnType => {
+	let sourcePath: recast.types.NodePath | null = null;
+	let targetFolder: JSXElement | null = null;
+	const folderStack: string[] = [];
+
+	recast.types.visit(file, {
+		visitJSXElement(astPath) {
+			const node = astPath.node as JSXElement;
+			const compositionId = getCompositionIdFromJSXElement(node);
+			if (compositionId === transformation.idToMove) {
+				sourcePath = astPath as unknown as recast.types.NodePath;
+			}
+
+			const folderName = getFolderNameFromJSXElement(node);
+			const parentName = folderStack.join('/') || null;
+			if (
+				folderName === transformation.folderName &&
+				parentName === transformation.parentName
+			) {
+				targetFolder = node;
+			}
+
+			if (folderName) {
+				folderStack.push(folderName);
+			}
+
+			this.traverse(astPath);
+
+			if (folderName) {
+				folderStack.pop();
+			}
+
+			return undefined;
+		},
+	});
+
+	if (!sourcePath) {
+		throw new Error(`Could not find composition "${transformation.idToMove}"`);
+	}
+
+	if (!targetFolder) {
+		const folderLabel = `${transformation.parentName ? `${transformation.parentName}/` : ''}${transformation.folderName}`;
+		throw new Error(`Could not find folder "${folderLabel}"`);
+	}
+
+	const compositionElement = (sourcePath as recast.types.NodePath)
+		.node as JSXElement;
+	deleteJsxElementAtPath(sourcePath);
+	appendCompositionToFolder({
+		compositionElement,
+		folderElement: targetFolder,
+	});
+	changesMade.push({description: 'Moved composition into folder'});
+
+	return {newAst: file, changesMade};
 };
 
 // When a <Composition> JSX element appears in a position where it cannot

--- a/packages/studio-server/src/codemods/recast-mods.ts
+++ b/packages/studio-server/src/codemods/recast-mods.ts
@@ -509,44 +509,73 @@ const moveCompositionToFolder = ({
 }): ApplyCodeModReturnType => {
 	let sourcePath: recast.types.NodePath | null = null;
 	let sourceParentFolderName: string | null = null;
+	let sourceIsDirectJsxChild = false;
 	let targetFolder: JSXElement | null = null;
 	const folderStack: string[] = [];
 
+	const isDirectJsxChild = (astPath: recast.types.NodePath) => {
+		const parent = astPath.parentPath?.node;
+		return (
+			(parent?.type === 'JSXElement' || parent?.type === 'JSXFragment') &&
+			parent.children.includes(astPath.node as JSXElement)
+		);
+	};
+
+	const visitJsxElementWithFolderContext = (astPath: recast.types.NodePath) => {
+		const node = astPath.node as JSXElement;
+		const compositionId = getCompositionIdFromJSXElement(node);
+		if (compositionId === transformation.idToMove) {
+			sourcePath = astPath;
+			sourceParentFolderName = folderStack.join('/') || null;
+			sourceIsDirectJsxChild = isDirectJsxChild(astPath);
+		}
+
+		const folderName = getFolderNameFromJSXElement(node);
+		const parentName = folderStack.join('/') || null;
+		if (
+			transformation.folderName !== null &&
+			folderName === transformation.folderName &&
+			parentName === transformation.parentName
+		) {
+			targetFolder = node;
+		}
+
+		if (folderName) {
+			folderStack.push(folderName);
+		}
+
+		for (let i = 0; i < node.children.length; i++) {
+			if (node.children[i].type !== 'JSXElement') {
+				continue;
+			}
+
+			visitJsxElementWithFolderContext(
+				astPath.get('children', i) as recast.types.NodePath,
+			);
+		}
+
+		if (folderName) {
+			folderStack.pop();
+		}
+	};
+
 	recast.types.visit(file, {
 		visitJSXElement(astPath) {
-			const node = astPath.node as JSXElement;
-			const compositionId = getCompositionIdFromJSXElement(node);
-			if (compositionId === transformation.idToMove) {
-				sourcePath = astPath as unknown as recast.types.NodePath;
-				sourceParentFolderName = folderStack.join('/') || null;
-			}
-
-			const folderName = getFolderNameFromJSXElement(node);
-			const parentName = folderStack.join('/') || null;
-			if (
-				transformation.folderName !== null &&
-				folderName === transformation.folderName &&
-				parentName === transformation.parentName
-			) {
-				targetFolder = node;
-			}
-
-			if (folderName) {
-				folderStack.push(folderName);
-			}
-
-			this.traverse(astPath);
-
-			if (folderName) {
-				folderStack.pop();
-			}
-
-			return undefined;
+			visitJsxElementWithFolderContext(
+				astPath as unknown as recast.types.NodePath,
+			);
+			return false;
 		},
 	});
 
 	if (!sourcePath) {
 		throw new Error(`Could not find composition "${transformation.idToMove}"`);
+	}
+
+	if (!sourceIsDirectJsxChild) {
+		throw new Error(
+			`Cannot move composition "${transformation.idToMove}" because it is not a direct JSX child`,
+		);
 	}
 
 	if (transformation.folderName === null && sourceParentFolderName === null) {

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -190,7 +190,7 @@ const getComponentIdentifier = (element: JSXElement) => {
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
-	return typeof value === 'object' && value !== null;
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
 
 const findDynamicImportPath = (value: unknown): string | null => {
@@ -1478,7 +1478,13 @@ const ensureDefaultImport = ({
 	const importSpecifier = recast.types.builders.importDefaultSpecifier(
 		recast.types.builders.identifier(localName),
 	) as unknown as ImportDefaultSpecifier;
-	const existingImport = getImportDeclarations({ast, sourcePath})[0];
+	const existingImport = getImportDeclarations({ast, sourcePath}).find(
+		(declaration) => {
+			return !declaration.specifiers?.some(
+				(specifier) => specifier.type === 'ImportNamespaceSpecifier',
+			);
+		},
+	);
 
 	if (existingImport) {
 		existingImport.specifiers = [

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -7,10 +7,13 @@ import type {
 	ExportSpecifier,
 	File,
 	FunctionDeclaration,
+	ImportDefaultSpecifier,
 	ImportDeclaration,
 	ImportSpecifier,
 	JSXAttribute,
 	JSXElement,
+	JSXSpreadAttribute,
+	ObjectProperty,
 	VariableDeclaration,
 } from '@babel/types';
 import {
@@ -21,8 +24,10 @@ import {
 } from '@remotion/studio-shared';
 import type {namedTypes} from 'ast-types';
 import * as recast from 'recast';
+import {NoReactInternals} from 'remotion/no-react';
 import {formatFileContent} from '../codemods/format-file-content';
 import {parseAst, serializeAst} from '../codemods/parse-ast';
+import {parseValueExpression} from '../codemods/update-nested-prop';
 import {
 	ensureNamedImport,
 	getImportedName,
@@ -931,12 +936,14 @@ const createComponentElement = ({
 const createSequenceWrappedElement = ({
 	child,
 	dimensions,
+	durationInFrames,
 	name,
 	position,
 	sequenceLocalName,
 }: {
 	child: namedTypes.JSXElement;
 	dimensions: {width: number; height: number};
+	durationInFrames: number | null;
 	name: string | null;
 	position: InsertableCompositionElementPosition | null;
 	sequenceLocalName: string;
@@ -948,6 +955,9 @@ const createSequenceWrappedElement = ({
 				...(name === null ? [] : [createStringAttribute('name', name)]),
 				createNumberAttribute('width', dimensions.width),
 				createNumberAttribute('height', dimensions.height),
+				...(durationInFrames === null
+					? []
+					: [createNumberAttribute('durationInFrames', durationInFrames)]),
 				createPositionAbsoluteStyleAttribute(position),
 			],
 			false,
@@ -1383,6 +1393,285 @@ const ensureComponentImport = ({
 	});
 };
 
+const identifierRegex = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
+
+const toPascalCaseIdentifier = (value: string) => {
+	const words = value.match(/[a-zA-Z0-9]+/g) ?? [];
+	const candidate = words
+		.map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+		.join('');
+
+	if (!candidate) {
+		return 'CompositionComponent';
+	}
+
+	if (/^[0-9]/.test(candidate)) {
+		return `Composition${candidate}`;
+	}
+
+	return identifierRegex.test(candidate) ? candidate : 'CompositionComponent';
+};
+
+const getAvailableLocalName = ({
+	ast,
+	baseName,
+}: {
+	ast: File;
+	baseName: string;
+}) => {
+	if (!hasTopLevelBinding({ast, name: baseName})) {
+		return baseName;
+	}
+
+	const suffixed = `${baseName}Composition`;
+	if (!hasTopLevelBinding({ast, name: suffixed})) {
+		return suffixed;
+	}
+
+	for (let i = 2; i < 100; i++) {
+		const candidate = `${suffixed}${i}`;
+		if (!hasTopLevelBinding({ast, name: candidate})) {
+			return candidate;
+		}
+	}
+
+	throw new Error(`Cannot find a local name for ${baseName}`);
+};
+
+const getImportPathBetweenFiles = ({
+	fromFile,
+	toFile,
+}: {
+	fromFile: string;
+	toFile: string;
+}) => {
+	let relativeImport = path
+		.relative(path.dirname(fromFile), toFile)
+		.replaceAll(path.sep, '/')
+		.replace(/\.(tsx|ts|jsx|js)$/, '');
+
+	if (!relativeImport.startsWith('.')) {
+		relativeImport = `./${relativeImport}`;
+	}
+
+	return relativeImport;
+};
+
+const ensureDefaultImport = ({
+	ast,
+	localName,
+	sourcePath,
+}: {
+	ast: File;
+	localName: string;
+	sourcePath: string;
+}) => {
+	for (const declaration of getImportDeclarations({ast, sourcePath})) {
+		const defaultSpecifier = declaration.specifiers?.find(
+			(specifier) => specifier.type === 'ImportDefaultSpecifier',
+		);
+		if (defaultSpecifier?.local?.name) {
+			return defaultSpecifier.local.name;
+		}
+	}
+
+	const importSpecifier = recast.types.builders.importDefaultSpecifier(
+		recast.types.builders.identifier(localName),
+	) as unknown as ImportDefaultSpecifier;
+	const existingImport = getImportDeclarations({ast, sourcePath})[0];
+
+	if (existingImport) {
+		existingImport.specifiers = [
+			importSpecifier,
+			...(existingImport.specifiers ?? []),
+		];
+		return localName;
+	}
+
+	const importDeclaration = recast.types.builders.importDeclaration(
+		[importSpecifier as never],
+		recast.types.builders.stringLiteral(sourcePath),
+	) as unknown as ImportDeclaration;
+	insertImportDeclaration(ast, importDeclaration);
+	return localName;
+};
+
+const ensureCompositionComponentImport = async ({
+	ast,
+	compositionFile,
+	compositionId,
+	destinationFileName,
+	remotionRoot,
+}: {
+	ast: File;
+	compositionFile: string;
+	compositionId: string;
+	destinationFileName: string;
+	remotionRoot: string;
+}) => {
+	const sourceLocation = await resolveCompositionComponentWithFile({
+		remotionRoot,
+		compositionFile,
+		compositionId,
+	});
+
+	if (sourceLocation.fileName === destinationFileName) {
+		if (sourceLocation.exportName === 'default') {
+			throw new Error(
+				'Cannot insert a composition whose component is a default export in the same file',
+			);
+		}
+
+		if (!hasTopLevelBinding({ast, name: sourceLocation.exportName})) {
+			throw new Error(
+				`Cannot find component "${sourceLocation.exportName}" in this file`,
+			);
+		}
+
+		return sourceLocation.exportName;
+	}
+
+	const sourcePath = getImportPathBetweenFiles({
+		fromFile: destinationFileName,
+		toFile: sourceLocation.fileName,
+	});
+
+	if (sourceLocation.exportName === 'default') {
+		return ensureDefaultImport({
+			ast,
+			localName: getAvailableLocalName({
+				ast,
+				baseName: toPascalCaseIdentifier(compositionId),
+			}),
+			sourcePath,
+		});
+	}
+
+	return ensureNamedImport({
+		ast,
+		importedName: sourceLocation.exportName,
+		sourcePath,
+		localName: getAvailableLocalName({
+			ast,
+			baseName: sourceLocation.exportName,
+		}),
+	});
+};
+
+const parseSerializedCompositionProps = (
+	serializedResolvedPropsWithCustomSchema: string,
+) => {
+	const parsed: unknown = JSON.parse(serializedResolvedPropsWithCustomSchema);
+	if (!isRecord(parsed)) {
+		throw new Error('Resolved composition props must be an object');
+	}
+
+	return parsed;
+};
+
+const containsFileToken = (value: unknown): boolean => {
+	if (typeof value === 'string') {
+		return value.startsWith(NoReactInternals.FILE_TOKEN);
+	}
+
+	if (Array.isArray(value)) {
+		return value.some(containsFileToken);
+	}
+
+	if (isRecord(value)) {
+		return Object.values(value).some(containsFileToken);
+	}
+
+	return false;
+};
+
+const createExpressionAttribute = (
+	name: string,
+	value: unknown,
+): namedTypes.JSXAttribute => {
+	return recast.types.builders.jsxAttribute(
+		recast.types.builders.jsxIdentifier(name),
+		recast.types.builders.jsxExpressionContainer(
+			parseValueExpression(value) as never,
+		),
+	) as unknown as namedTypes.JSXAttribute;
+};
+
+const createCompositionPropAttribute = ({
+	name,
+	value,
+}: {
+	name: string;
+	value: unknown;
+}): namedTypes.JSXAttribute => {
+	if (
+		typeof value === 'string' &&
+		!value.startsWith(NoReactInternals.FILE_TOKEN) &&
+		!value.startsWith(NoReactInternals.DATE_TOKEN)
+	) {
+		return createStringAttribute(name, value) as namedTypes.JSXAttribute;
+	}
+
+	return createExpressionAttribute(name, value);
+};
+
+const createCompositionObjectProperty = ({
+	name,
+	value,
+}: {
+	name: string;
+	value: unknown;
+}): ObjectProperty => {
+	return recast.types.builders.objectProperty(
+		identifierRegex.test(name)
+			? recast.types.builders.identifier(name)
+			: recast.types.builders.stringLiteral(name),
+		parseValueExpression(value) as never,
+	) as unknown as ObjectProperty;
+};
+
+const createCompositionComponentElement = ({
+	localName,
+	props,
+}: {
+	localName: string;
+	props: Record<string, unknown>;
+}) => {
+	const directAttributes: namedTypes.JSXAttribute[] = [];
+	const spreadProperties: ObjectProperty[] = [];
+
+	for (const [name, value] of Object.entries(props)) {
+		if (identifierRegex.test(name)) {
+			directAttributes.push(createCompositionPropAttribute({name, value}));
+		} else {
+			spreadProperties.push(createCompositionObjectProperty({name, value}));
+		}
+	}
+
+	const attributes: (JSXAttribute | JSXSpreadAttribute)[] = [
+		...(directAttributes as unknown as JSXAttribute[]),
+		...(spreadProperties.length === 0
+			? []
+			: [
+					recast.types.builders.jsxSpreadAttribute(
+						recast.types.builders.objectExpression(
+							spreadProperties as never,
+						) as never,
+					) as unknown as JSXSpreadAttribute,
+				]),
+	];
+
+	return recast.types.builders.jsxElement(
+		recast.types.builders.jsxOpeningElement(
+			recast.types.builders.jsxIdentifier(localName),
+			attributes as never,
+			true,
+		),
+		null,
+		[],
+	);
+};
+
 const addElementToComponentRoot = ({
 	ast,
 	exportName,
@@ -1693,12 +1982,16 @@ export const resolveCompositionComponent = async ({
 const createInsertableJsxElement = ({
 	addPositionStyleToComponent,
 	ast,
+	destinationFileName,
 	element,
+	remotionRoot,
 }: {
 	addPositionStyleToComponent: boolean;
 	ast: File;
+	destinationFileName: string;
 	element: InsertableCompositionElement;
-}) => {
+	remotionRoot: string;
+}): Promise<namedTypes.JSXElement> | namedTypes.JSXElement => {
 	if (element.type === 'solid') {
 		const solidLocalName = ensureSolidImport(ast);
 
@@ -1723,6 +2016,27 @@ const createInsertableJsxElement = ({
 			localName: componentLocalName,
 			props: element.props,
 			position: element.position,
+		});
+	}
+
+	if (element.type === 'composition') {
+		return Promise.resolve(
+			ensureCompositionComponentImport({
+				ast,
+				compositionFile: element.compositionFile,
+				compositionId: element.compositionId,
+				destinationFileName,
+				remotionRoot,
+			}),
+		).then((localName) => {
+			const props = parseSerializedCompositionProps(
+				element.serializedResolvedPropsWithCustomSchema,
+			);
+			if (containsFileToken(props)) {
+				ensureStaticFileImport(ast);
+			}
+
+			return createCompositionComponentElement({localName, props});
 		});
 	}
 
@@ -1776,6 +2090,7 @@ export const insertJsxElementIntoComposition = async ({
 	prettierConfigOverride: Record<string, unknown> | null;
 	wrapInSequence?: {
 		dimensions: {width: number; height: number};
+		durationInFrames?: number | null;
 		name: string | null;
 		position: InsertableCompositionElementPosition | null;
 	} | null;
@@ -1803,17 +2118,36 @@ export const insertJsxElementIntoComposition = async ({
 		fileName: location.fileName,
 	});
 	const ast = parseAst(input);
-	const elementToInsert = createInsertableJsxElement({
-		addPositionStyleToComponent: wrapInSequence === null,
+	if (
+		element.type === 'composition' &&
+		element.compositionId === compositionId
+	) {
+		throw new Error('Cannot insert a composition into itself');
+	}
+
+	const sequenceWrapper =
+		element.type === 'composition'
+			? {
+					dimensions: {width: element.width, height: element.height},
+					durationInFrames: element.durationInFrames,
+					name: null,
+					position: element.position,
+				}
+			: wrapInSequence;
+	const elementToInsert = await createInsertableJsxElement({
+		addPositionStyleToComponent: sequenceWrapper === null,
 		ast,
+		destinationFileName: location.fileName,
 		element,
+		remotionRoot,
 	});
-	const finalElementToInsert = wrapInSequence
+	const finalElementToInsert = sequenceWrapper
 		? createSequenceWrappedElement({
 				child: elementToInsert,
-				dimensions: wrapInSequence.dimensions,
-				name: wrapInSequence.name,
-				position: wrapInSequence.position,
+				dimensions: sequenceWrapper.dimensions,
+				durationInFrames: sequenceWrapper.durationInFrames ?? null,
+				name: sequenceWrapper.name,
+				position: sequenceWrapper.position,
 				sequenceLocalName: ensureSequenceImport(ast),
 			})
 		: elementToInsert;

--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -59,6 +59,16 @@ const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
 		};
 	}
 
+	if (codemod.type === 'move-composition-to-folder') {
+		const folderLabel = `${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}`;
+		const label = `composition "${codemod.idToMove}" into folder "${folderLabel}"`;
+		return {
+			undoMessage: `↩️  Move of ${label}`,
+			redoMessage: `↪️  Move of ${label}`,
+			entryType: codemod.type,
+		};
+	}
+
 	if (codemod.type === 'new-composition') {
 		return {
 			undoMessage: `↩️  Creation of composition "${codemod.newId}"`,

--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -60,8 +60,11 @@ const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
 	}
 
 	if (codemod.type === 'move-composition-to-folder') {
-		const folderLabel = `${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}`;
-		const label = `composition "${codemod.idToMove}" into folder "${folderLabel}"`;
+		const destination =
+			codemod.folderName === null
+				? 'to root'
+				: `into folder "${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}"`;
+		const label = `composition "${codemod.idToMove}" ${destination}`;
 		return {
 			undoMessage: `↩️  Move of ${label}`,
 			redoMessage: `↪️  Move of ${label}`,

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {RenderInternals} from '@remotion/renderer';
 import {
 	areComponentProps,
@@ -39,7 +40,48 @@ const validatePosition = (
 	}
 };
 
-const validateElement = (element: InsertableCompositionElement) => {
+const isInsideRemotionRoot = ({
+	fileName,
+	remotionRoot,
+}: {
+	fileName: string;
+	remotionRoot: string;
+}) => {
+	const relativePath = path.relative(remotionRoot, fileName);
+	return !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+};
+
+const hasParentDirectorySegment = (fileName: string) => {
+	return fileName.split('/').includes('..');
+};
+
+const validateCompositionFile = ({
+	compositionFile,
+	remotionRoot,
+}: {
+	compositionFile: string;
+	remotionRoot: string;
+}) => {
+	if (
+		!compositionFile ||
+		compositionFile.includes('\0') ||
+		compositionFile.includes('\\') ||
+		compositionFile.startsWith('/') ||
+		hasParentDirectorySegment(compositionFile)
+	) {
+		throw new Error('Unsupported composition file');
+	}
+
+	const resolved = path.resolve(remotionRoot, compositionFile);
+	if (!isInsideRemotionRoot({fileName: resolved, remotionRoot})) {
+		throw new Error('Unsupported composition file');
+	}
+};
+
+const validateElement = (
+	element: InsertableCompositionElement,
+	remotionRoot: string,
+) => {
 	validatePosition(element.position);
 
 	if (element.type === 'solid') {
@@ -90,15 +132,14 @@ const validateElement = (element: InsertableCompositionElement) => {
 			throw new Error('Unsupported composition ID');
 		}
 
-		if (
-			typeof element.compositionFile !== 'string' ||
-			!element.compositionFile ||
-			element.compositionFile.includes('\0') ||
-			element.compositionFile.includes('\\') ||
-			element.compositionFile.startsWith('/')
-		) {
+		if (typeof element.compositionFile !== 'string') {
 			throw new Error('Unsupported composition file');
 		}
+
+		validateCompositionFile({
+			compositionFile: element.compositionFile,
+			remotionRoot,
+		});
 
 		validateDimension('width', element.width);
 		validateDimension('height', element.height);
@@ -169,7 +210,7 @@ export const insertJsxElementHandler: ApiHandler<
 }) =>
 	withSourceFileWriteQueue(async () => {
 		try {
-			validateElement(element);
+			validateElement(element, remotionRoot);
 			const elementLabel = getElementLabel(element);
 
 			RenderInternals.Log.trace(

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -85,6 +85,39 @@ const validateElement = (element: InsertableCompositionElement) => {
 		return;
 	}
 
+	if (element.type === 'composition') {
+		if (typeof element.compositionId !== 'string' || !element.compositionId) {
+			throw new Error('Unsupported composition ID');
+		}
+
+		if (
+			typeof element.compositionFile !== 'string' ||
+			!element.compositionFile ||
+			element.compositionFile.includes('\0') ||
+			element.compositionFile.includes('\\') ||
+			element.compositionFile.startsWith('/')
+		) {
+			throw new Error('Unsupported composition file');
+		}
+
+		validateDimension('width', element.width);
+		validateDimension('height', element.height);
+		validateDimension('durationInFrames', element.durationInFrames);
+
+		const parsedProps: unknown = JSON.parse(
+			element.serializedResolvedPropsWithCustomSchema,
+		);
+		if (
+			typeof parsedProps !== 'object' ||
+			parsedProps === null ||
+			Array.isArray(parsedProps)
+		) {
+			throw new Error('Resolved composition props must be an object');
+		}
+
+		return;
+	}
+
 	throw new Error('Unsupported element type');
 };
 
@@ -117,6 +150,10 @@ const getElementLabel = (element: InsertableCompositionElement) => {
 
 	if (element.type === 'component') {
 		return `<${element.componentName}>`;
+	}
+
+	if (element.type === 'composition') {
+		return `composition "${element.compositionId}"`;
 	}
 
 	throw new Error('Unsupported element type');

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -39,6 +39,7 @@ type UndoEntryType =
 	| 'rename-composition'
 	| 'new-composition'
 	| 'duplicate-composition'
+	| 'move-composition-to-folder'
 	| 'new-folder'
 	| 'delete-folder'
 	| 'rename-folder';
@@ -80,6 +81,7 @@ type UndoEntry = {
 	| {entryType: 'rename-composition'}
 	| {entryType: 'new-composition'}
 	| {entryType: 'duplicate-composition'}
+	| {entryType: 'move-composition-to-folder'}
 	| {entryType: 'new-folder'}
 	| {entryType: 'delete-folder'}
 	| {entryType: 'rename-folder'}

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -108,6 +108,50 @@ export const RemotionRoot: React.FC = () => {
 };
 `;
 
+const attributeFolderRootContents = `import React from 'react';
+import {Composition, Folder} from 'remotion';
+
+const Component = () => null;
+
+export const RemotionRoot: React.FC = () => {
+	return (
+		<>
+			<Folder
+				name="Parent"
+				preview={<Folder name="Shared" />}
+			/>
+			<Composition
+				id="MoveMe"
+				component={Component}
+				durationInFrames={120}
+				fps={30}
+				width={1280}
+				height={720}
+			/>
+		</>
+	);
+};
+`;
+
+const standaloneCompositionRootContents = `import React from 'react';
+import {Composition} from 'remotion';
+
+const Component = () => null;
+
+export const RemotionRoot: React.FC = () => {
+	return (
+		<Composition
+			id="Standalone"
+			component={Component}
+			durationInFrames={120}
+			fps={30}
+			width={1280}
+			height={720}
+		/>
+	);
+};
+`;
+
 const clearUndoRedoStacks = () => {
 	(getUndoStack() as unknown as unknown[]).length = 0;
 	(getRedoStack() as unknown as unknown[]).length = 0;
@@ -640,6 +684,36 @@ test('moves a composition to root', () => {
 		newContents.indexOf('id="NestedA"'),
 	);
 	expect(newContents.match(/id="NestedA"/g)?.length).toBe(1);
+});
+
+test('does not use folders inside JSX attributes as move targets', () => {
+	expect(() =>
+		parseAndApplyCodemod({
+			input: attributeFolderRootContents,
+			codeMod: {
+				type: 'move-composition-to-folder',
+				idToMove: 'MoveMe',
+				folderName: 'Shared',
+				parentName: 'Parent',
+			},
+		}),
+	).toThrow('Could not find folder "Parent/Shared"');
+});
+
+test('rejects moving a composition from a standalone JSX position', () => {
+	expect(() =>
+		parseAndApplyCodemod({
+			input: standaloneCompositionRootContents,
+			codeMod: {
+				type: 'move-composition-to-folder',
+				idToMove: 'Standalone',
+				folderName: null,
+				parentName: null,
+			},
+		}),
+	).toThrow(
+		'Cannot move composition "Standalone" because it is not a direct JSX child',
+	);
 });
 
 test('moves a composition into a self-closing folder', () => {

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -337,6 +337,69 @@ test('applyCodemodHandler pushes composition moves to undo and redo stacks', asy
 	}
 });
 
+test('applyCodemodHandler pushes composition moves to root to undo and redo stacks', async () => {
+	const remotionRoot = mkdtempSync(path.join(tmpdir(), 'remotion-codemod-'));
+	const cleanupFileWatcher = setFileWatcherRegistry(
+		createFileWatcherRegistry(),
+	);
+	const cleanupLiveEvents = setLiveEventsListener({
+		sendEventToClient: () => undefined,
+		sendEventToClientId: () => undefined,
+		router: () => Promise.resolve(),
+		closeConnections: () => Promise.resolve(),
+		addNewClientListener: () => () => undefined,
+	});
+
+	try {
+		clearUndoRedoStacks();
+		const entryPoint = path.join(remotionRoot, 'Root.tsx');
+		writeFileSync(entryPoint, folderRootContents);
+
+		const applyResponse = await applyCodemodHandler(
+			getHandlerOptions({
+				input: {
+					codemod: {
+						type: 'move-composition-to-folder',
+						idToMove: 'NestedA',
+						folderName: null,
+						parentName: null,
+					} satisfies RecastCodemod,
+					dryRun: false,
+					symbolicatedStack: {
+						originalFunctionName: null,
+						originalFileName: 'Root.tsx',
+						originalLineNumber: 9,
+						originalColumnNumber: 4,
+						originalScriptCode: null,
+					},
+				},
+				entryPoint,
+				remotionRoot,
+			}),
+		);
+
+		expect(applyResponse.success).toBe(true);
+		const contents = readFileSync(entryPoint, 'utf-8');
+		expect(contents.indexOf('id="NestedB"')).toBeLessThan(
+			contents.indexOf('id="NestedA"'),
+		);
+		expect(getUndoStack()[0].description.undoMessage).toBe(
+			'↩️  Move of composition "NestedA" to root',
+		);
+
+		const undoResponse = await undoHandler(
+			getHandlerOptions({input: {}, entryPoint, remotionRoot}),
+		);
+		expect(undoResponse.success).toBe(true);
+		expect(readFileSync(entryPoint, 'utf-8')).toBe(folderRootContents);
+	} finally {
+		clearUndoRedoStacks();
+		cleanupLiveEvents();
+		cleanupFileWatcher();
+		rmSync(remotionRoot, {recursive: true, force: true});
+	}
+});
+
 test('applyCodemodHandler creates new composition files with undo and redo', async () => {
 	const remotionRoot = mkdtempSync(path.join(tmpdir(), 'remotion-codemod-'));
 	const cleanupFileWatcher = setFileWatcherRegistry(
@@ -559,6 +622,24 @@ test('moves a composition into a nested folder', () => {
 	expect(newContents.indexOf('<Folder name="Parent">')).toBeLessThan(
 		newContents.indexOf('<Folder name="Other">'),
 	);
+});
+
+test('moves a composition to root', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: folderRootContents,
+		codeMod: {
+			type: 'move-composition-to-folder',
+			idToMove: 'NestedA',
+			folderName: null,
+			parentName: null,
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents.indexOf('id="NestedB"')).toBeLessThan(
+		newContents.indexOf('id="NestedA"'),
+	);
+	expect(newContents.match(/id="NestedA"/g)?.length).toBe(1);
 });
 
 test('moves a composition into a self-closing folder', () => {

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -274,6 +274,69 @@ test('applyCodemodHandler pushes folder creations to undo and redo stacks', asyn
 	});
 });
 
+test('applyCodemodHandler pushes composition moves to undo and redo stacks', async () => {
+	const remotionRoot = mkdtempSync(path.join(tmpdir(), 'remotion-codemod-'));
+	const cleanupFileWatcher = setFileWatcherRegistry(
+		createFileWatcherRegistry(),
+	);
+	const cleanupLiveEvents = setLiveEventsListener({
+		sendEventToClient: () => undefined,
+		sendEventToClientId: () => undefined,
+		router: () => Promise.resolve(),
+		closeConnections: () => Promise.resolve(),
+		addNewClientListener: () => () => undefined,
+	});
+
+	try {
+		clearUndoRedoStacks();
+		const entryPoint = path.join(remotionRoot, 'Root.tsx');
+		writeFileSync(entryPoint, folderRootContents);
+
+		const applyResponse = await applyCodemodHandler(
+			getHandlerOptions({
+				input: {
+					codemod: {
+						type: 'move-composition-to-folder',
+						idToMove: 'NestedA',
+						folderName: 'Shared',
+						parentName: 'Other',
+					} satisfies RecastCodemod,
+					dryRun: false,
+					symbolicatedStack: {
+						originalFunctionName: null,
+						originalFileName: 'Root.tsx',
+						originalLineNumber: 9,
+						originalColumnNumber: 4,
+						originalScriptCode: null,
+					},
+				},
+				entryPoint,
+				remotionRoot,
+			}),
+		);
+
+		expect(applyResponse.success).toBe(true);
+		const contents = readFileSync(entryPoint, 'utf-8');
+		expect(contents.indexOf('id="NestedB"')).toBeLessThan(
+			contents.indexOf('id="NestedA"'),
+		);
+		expect(getUndoStack()[0].description.undoMessage).toBe(
+			'↩️  Move of composition "NestedA" into folder "Other/Shared"',
+		);
+
+		const undoResponse = await undoHandler(
+			getHandlerOptions({input: {}, entryPoint, remotionRoot}),
+		);
+		expect(undoResponse.success).toBe(true);
+		expect(readFileSync(entryPoint, 'utf-8')).toBe(folderRootContents);
+	} finally {
+		clearUndoRedoStacks();
+		cleanupLiveEvents();
+		cleanupFileWatcher();
+		rmSync(remotionRoot, {recursive: true, force: true});
+	}
+});
+
 test('applyCodemodHandler creates new composition files with undo and redo', async () => {
 	const remotionRoot = mkdtempSync(path.join(tmpdir(), 'remotion-codemod-'));
 	const cleanupFileWatcher = setFileWatcherRegistry(
@@ -475,6 +538,47 @@ test('creates a composition in a self-closing folder', () => {
 	expect(newContents.indexOf('id="FreshVideo"')).toBeLessThan(
 		newContents.indexOf('id="KeepMe"'),
 	);
+});
+
+test('moves a composition into a nested folder', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: folderRootContents,
+		codeMod: {
+			type: 'move-composition-to-folder',
+			idToMove: 'NestedA',
+			folderName: 'Shared',
+			parentName: 'Other',
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents.indexOf('id="NestedB"')).toBeLessThan(
+		newContents.indexOf('id="NestedA"'),
+	);
+	expect(newContents.match(/id="NestedA"/g)?.length).toBe(1);
+	expect(newContents.indexOf('<Folder name="Parent">')).toBeLessThan(
+		newContents.indexOf('<Folder name="Other">'),
+	);
+});
+
+test('moves a composition into a self-closing folder', () => {
+	const {changesMade, newContents} = parseAndApplyCodemod({
+		input: selfClosingFolderRootContents,
+		codeMod: {
+			type: 'move-composition-to-folder',
+			idToMove: 'KeepMe',
+			folderName: 'Empty',
+			parentName: null,
+		},
+	});
+
+	expect(changesMade.length).toBe(1);
+	expect(newContents).toContain('<Folder name="Empty">');
+	expect(newContents).toContain('</Folder>');
+	expect(newContents.indexOf('<Folder name="Empty">')).toBeLessThan(
+		newContents.indexOf('id="KeepMe"'),
+	);
+	expect(newContents.match(/id="KeepMe"/g)?.length).toBe(1);
 });
 
 test('creates a folder in a self-closing folder', () => {

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'bun:test';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import {NoReactInternals} from 'remotion/no-react';
 import {
 	insertJsxElementIntoComposition,
 	resolveCompositionComponent,
@@ -1307,6 +1308,90 @@ test('inserts a component into the resolved composition component', async () => 
 		expect(result.output).toContain('dataShapeIndex={1}');
 		expect(result.output).toContain('debug={false}');
 		expect(result.output).toContain("position: 'absolute'");
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('inserts a composition as a duration-aware Sequence', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {Source} from './Source';",
+				"import {Target} from './Target';",
+				'export const RemotionRoot = () => {',
+				'\treturn (',
+				'\t\t<>',
+				'\t\t\t<Composition id="source" component={Source} />',
+				'\t\t\t<Composition id="target" component={Target} />',
+				'\t\t</>',
+				'\t);',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Source.tsx'),
+			[
+				'export const Source: React.FC = () => {',
+				'\treturn <div>source</div>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Target.tsx'),
+			[
+				"import {AbsoluteFill} from 'remotion';",
+				'',
+				'export const Target: React.FC = () => {',
+				'\treturn <AbsoluteFill>target</AbsoluteFill>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const result = await insertJsxElementIntoComposition({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'target',
+			element: {
+				type: 'composition',
+				compositionId: 'source',
+				compositionFile: 'Root.tsx',
+				durationInFrames: 100,
+				width: 1080,
+				height: 540,
+				serializedResolvedPropsWithCustomSchema: JSON.stringify({
+					hi: 'there',
+					nested: {value: 1},
+					'dash-prop': 'ok',
+					img: `${NoReactInternals.FILE_TOKEN}image.png`,
+					date: `${NoReactInternals.DATE_TOKEN}2025-01-01T00:00:00.000Z`,
+				}),
+				position: null,
+			},
+			prettierConfigOverride: {singleQuote: true, useTabs: true},
+		});
+
+		expect(result.output).toContain("import { Source } from './Source';");
+		expect(result.output).toContain('Sequence');
+		expect(result.output).toContain('<Sequence');
+		expect(result.output).toContain('width={1080}');
+		expect(result.output).toContain('height={540}');
+		expect(result.output).toContain('durationInFrames={100}');
+		expect(result.output).toContain('<Source');
+		expect(result.output).toContain('hi="there"');
+		expect(result.output).toContain('nested={{');
+		expect(result.output).toContain('value: 1');
+		expect(result.output).toContain("'dash-prop': 'ok'");
+		expect(result.output).toContain("img={staticFile('image.png')}");
+		expect(result.output).toContain(
+			"date={new Date('2025-01-01T00:00:00.000Z')}",
+		);
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -7,6 +7,7 @@ import {
 	insertJsxElementIntoComposition,
 	resolveCompositionComponent,
 } from '../helpers/resolve-composition-component';
+import {insertJsxElementHandler} from '../preview-server/routes/insert-jsx-element';
 
 const remotionRoot = path.join(__dirname, '..', '..', '..', 'example');
 
@@ -1392,6 +1393,188 @@ test('inserts a composition as a duration-aware Sequence', async () => {
 		expect(result.output).toContain(
 			"date={new Date('2025-01-01T00:00:00.000Z')}",
 		);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('inserts a default-exported composition next to an existing namespace import', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import Source from './Source';",
+				"import {Target} from './Target';",
+				'export const RemotionRoot = () => {',
+				'\treturn (',
+				'\t\t<>',
+				'\t\t\t<Composition id="source" component={Source} />',
+				'\t\t\t<Composition id="target" component={Target} />',
+				'\t\t</>',
+				'\t);',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Source.tsx'),
+			[
+				'const Source: React.FC = () => {',
+				'\treturn <div>source</div>;',
+				'};',
+				'',
+				'export default Source;',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Target.tsx'),
+			[
+				"import {AbsoluteFill} from 'remotion';",
+				"import * as SourceModule from './Source';",
+				'',
+				'export const Target: React.FC = () => {',
+				'\treturn <AbsoluteFill>target</AbsoluteFill>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const result = await insertJsxElementIntoComposition({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'target',
+			element: {
+				type: 'composition',
+				compositionId: 'source',
+				compositionFile: 'Root.tsx',
+				durationInFrames: 100,
+				width: 1080,
+				height: 540,
+				serializedResolvedPropsWithCustomSchema: JSON.stringify({}),
+				position: null,
+			},
+			prettierConfigOverride: {singleQuote: true, useTabs: true},
+		});
+
+		expect(result.output).toContain(
+			"import * as SourceModule from './Source';",
+		);
+		expect(result.output).toContain("import Source from './Source';");
+		expect(result.output).not.toContain(
+			"import Source, * as SourceModule from './Source';",
+		);
+		expect(result.output).toContain('<Source');
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('rejects array payloads for resolved composition props', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {Source} from './Source';",
+				"import {Target} from './Target';",
+				'export const RemotionRoot = () => {',
+				'\treturn (',
+				'\t\t<>',
+				'\t\t\t<Composition id="source" component={Source} />',
+				'\t\t\t<Composition id="target" component={Target} />',
+				'\t\t</>',
+				'\t);',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Source.tsx'),
+			[
+				'export const Source: React.FC = () => {',
+				'\treturn <div>source</div>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Target.tsx'),
+			[
+				"import {AbsoluteFill} from 'remotion';",
+				'',
+				'export const Target: React.FC = () => {',
+				'\treturn <AbsoluteFill>target</AbsoluteFill>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		await expect(
+			insertJsxElementIntoComposition({
+				remotionRoot: tempDir,
+				compositionFile: 'Root.tsx',
+				compositionId: 'target',
+				element: {
+					type: 'composition',
+					compositionId: 'source',
+					compositionFile: 'Root.tsx',
+					durationInFrames: 100,
+					width: 1080,
+					height: 540,
+					serializedResolvedPropsWithCustomSchema: JSON.stringify([
+						'not',
+						'an object',
+					]),
+					position: null,
+				},
+				prettierConfigOverride: {singleQuote: true, useTabs: true},
+			}),
+		).rejects.toThrow('Resolved composition props must be an object');
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('rejects composition insertion requests that traverse out of the project root', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		const response = await insertJsxElementHandler({
+			input: {
+				compositionFile: 'Root.tsx',
+				compositionId: 'target',
+				element: {
+					type: 'composition',
+					compositionId: 'source',
+					compositionFile: '../Root.tsx',
+					durationInFrames: 100,
+					width: 1080,
+					height: 540,
+					serializedResolvedPropsWithCustomSchema: JSON.stringify({}),
+					position: null,
+				},
+			},
+			entryPoint: path.join(tempDir, 'Root.tsx'),
+			remotionRoot: tempDir,
+			request: {} as never,
+			response: {} as never,
+			logLevel: 'error',
+			methods: {
+				removeJob: () => undefined,
+				cancelJob: () => undefined,
+				addJob: () => undefined,
+			},
+			publicDir: tempDir,
+			binariesDirectory: null,
+		});
+
+		expect(response.success).toBe(false);
+		if (!response.success) {
+			expect(response.reason).toBe('Unsupported composition file');
+		}
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -682,6 +682,16 @@ export type InsertableCompositionElement =
 				height: number;
 			} | null;
 			position: InsertableCompositionElementPosition | null;
+	  }
+	| {
+			type: 'composition';
+			compositionId: string;
+			compositionFile: string;
+			durationInFrames: number;
+			width: number;
+			height: number;
+			serializedResolvedPropsWithCustomSchema: string;
+			position: InsertableCompositionElementPosition | null;
 	  };
 
 export type InsertableCompositionElementPosition = {

--- a/packages/studio-shared/src/codemods.ts
+++ b/packages/studio-shared/src/codemods.ts
@@ -45,6 +45,12 @@ export type RecastCodemod =
 			idToDelete: string;
 	  }
 	| {
+			type: 'move-composition-to-folder';
+			idToMove: string;
+			folderName: string;
+			parentName: string | null;
+	  }
+	| {
 			type: 'rename-folder';
 			folderName: string;
 			parentName: string | null;

--- a/packages/studio-shared/src/codemods.ts
+++ b/packages/studio-shared/src/codemods.ts
@@ -47,7 +47,7 @@ export type RecastCodemod =
 	| {
 			type: 'move-composition-to-folder';
 			idToMove: string;
-			folderName: string;
+			folderName: string | null;
 			parentName: string | null;
 	  }
 	| {

--- a/packages/studio-shared/src/composition-drag-data.ts
+++ b/packages/studio-shared/src/composition-drag-data.ts
@@ -1,0 +1,76 @@
+export const COMPOSITION_DRAG_MIME_TYPE =
+	'application/vnd.remotion.composition+json';
+
+export type CompositionDragData = {
+	type: 'remotion-composition';
+	version: 1;
+	compositionId: string;
+	compositionFile: string | null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isCompositionId = (value: unknown): value is string => {
+	return typeof value === 'string' && value.length > 0 && value.length < 500;
+};
+
+const isCompositionFile = (value: unknown): value is string | null => {
+	if (value === null) {
+		return true;
+	}
+
+	return (
+		typeof value === 'string' &&
+		value.length > 0 &&
+		value.length < 2000 &&
+		!value.includes('\0') &&
+		!value.includes('\\') &&
+		!value.startsWith('/')
+	);
+};
+
+export const makeCompositionDragData = ({
+	compositionFile,
+	compositionId,
+}: {
+	compositionFile: string | null;
+	compositionId: string;
+}): CompositionDragData => {
+	return {
+		type: 'remotion-composition',
+		version: 1,
+		compositionFile,
+		compositionId,
+	};
+};
+
+export const parseCompositionDragData = (
+	value: string,
+): CompositionDragData | null => {
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!isRecord(parsed)) {
+			return null;
+		}
+
+		if (parsed.type !== 'remotion-composition' || parsed.version !== 1) {
+			return null;
+		}
+
+		if (
+			!isCompositionId(parsed.compositionId) ||
+			!isCompositionFile(parsed.compositionFile)
+		) {
+			return null;
+		}
+
+		return makeCompositionDragData({
+			compositionFile: parsed.compositionFile,
+			compositionId: parsed.compositionId,
+		});
+	} catch {
+		return null;
+	}
+};

--- a/packages/studio-shared/src/composition-drag-data.ts
+++ b/packages/studio-shared/src/composition-drag-data.ts
@@ -13,7 +13,16 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
 };
 
 const isCompositionId = (value: unknown): value is string => {
-	return typeof value === 'string' && value.length > 0 && value.length < 500;
+	return (
+		typeof value === 'string' &&
+		value.length > 0 &&
+		value.length < 500 &&
+		/^([a-zA-Z0-9-\u4E00-\u9FFF])+$/.test(value)
+	);
+};
+
+const hasParentDirectorySegment = (value: string) => {
+	return value.split('/').includes('..');
 };
 
 const isCompositionFile = (value: unknown): value is string | null => {
@@ -27,7 +36,8 @@ const isCompositionFile = (value: unknown): value is string | null => {
 		value.length < 2000 &&
 		!value.includes('\0') &&
 		!value.includes('\\') &&
-		!value.startsWith('/')
+		!value.startsWith('/') &&
+		!hasParentDirectorySegment(value)
 	);
 };
 

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -123,6 +123,12 @@ export {
 	type ComponentDragData,
 	type ComponentProp,
 } from './component-drag-data';
+export {
+	COMPOSITION_DRAG_MIME_TYPE,
+	makeCompositionDragData,
+	parseCompositionDragData,
+	type CompositionDragData,
+} from './composition-drag-data';
 export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state-delay-in-milliseconds';
 export {getDefinePluginDefinitions} from './define-plugin-definitions';
 export {

--- a/packages/studio-shared/src/required-package.ts
+++ b/packages/studio-shared/src/required-package.ts
@@ -27,6 +27,10 @@ export const getRequiredPackageForInsertableElement = (
 		return getRequiredPackageForImportPath(element.importPath);
 	}
 
+	if (element.type === 'composition') {
+		return null;
+	}
+
 	if (element.assetType === 'video' || element.assetType === 'audio') {
 		return '@remotion/media';
 	}

--- a/packages/studio-shared/src/test/composition-drag-data.test.ts
+++ b/packages/studio-shared/src/test/composition-drag-data.test.ts
@@ -58,8 +58,28 @@ test('rejects invalid composition drag data', () => {
 			JSON.stringify({
 				type: 'remotion-composition',
 				version: 1,
+				compositionFile: '../Root.tsx',
+				compositionId: 'MyVideo',
+			}),
+		),
+	).toBe(null);
+	expect(
+		parseCompositionDragData(
+			JSON.stringify({
+				type: 'remotion-composition',
+				version: 1,
 				compositionFile: 'src/Root.tsx',
 				compositionId: '',
+			}),
+		),
+	).toBe(null);
+	expect(
+		parseCompositionDragData(
+			JSON.stringify({
+				type: 'remotion-composition',
+				version: 1,
+				compositionFile: 'src/Root.tsx',
+				compositionId: 'Invalid id',
 			}),
 		),
 	).toBe(null);

--- a/packages/studio-shared/src/test/composition-drag-data.test.ts
+++ b/packages/studio-shared/src/test/composition-drag-data.test.ts
@@ -1,0 +1,66 @@
+import {expect, test} from 'bun:test';
+import {
+	makeCompositionDragData,
+	parseCompositionDragData,
+} from '../composition-drag-data';
+
+test('parses composition drag data', () => {
+	expect(
+		parseCompositionDragData(
+			JSON.stringify(
+				makeCompositionDragData({
+					compositionFile: 'src/Root.tsx',
+					compositionId: 'MyVideo',
+				}),
+			),
+		),
+	).toEqual({
+		type: 'remotion-composition',
+		version: 1,
+		compositionFile: 'src/Root.tsx',
+		compositionId: 'MyVideo',
+	});
+});
+
+test('allows a missing composition file', () => {
+	expect(
+		parseCompositionDragData(
+			JSON.stringify(
+				makeCompositionDragData({
+					compositionFile: null,
+					compositionId: 'MyVideo',
+				}),
+			),
+		),
+	).toEqual({
+		type: 'remotion-composition',
+		version: 1,
+		compositionFile: null,
+		compositionId: 'MyVideo',
+	});
+});
+
+test('rejects invalid composition drag data', () => {
+	expect(parseCompositionDragData('')).toBe(null);
+	expect(parseCompositionDragData('{')).toBe(null);
+	expect(
+		parseCompositionDragData(
+			JSON.stringify({
+				type: 'remotion-composition',
+				version: 1,
+				compositionFile: '/tmp/Root.tsx',
+				compositionId: 'MyVideo',
+			}),
+		),
+	).toBe(null);
+	expect(
+		parseCompositionDragData(
+			JSON.stringify({
+				type: 'remotion-composition',
+				version: 1,
+				compositionFile: 'src/Root.tsx',
+				compositionId: '',
+			}),
+		),
+	).toBe(null);
+});

--- a/packages/studio/src/ResolveCompositionConfigInStudio.tsx
+++ b/packages/studio/src/ResolveCompositionConfigInStudio.tsx
@@ -7,7 +7,7 @@ import React, {
 	useMemo,
 	useState,
 } from 'react';
-import {getInputProps, Internals} from 'remotion';
+import {getInputProps, Internals, type VideoConfig} from 'remotion';
 import {FastRefreshContext} from './fast-refresh-context';
 
 type VideoConfigState =
@@ -204,6 +204,52 @@ export const ResolveCompositionConfigInStudio: React.FC<
 
 	const currentComposition =
 		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
+	const resolveComposition = useCallback(
+		async (compositionId: string): Promise<VideoConfig> => {
+			const composition = compositions.find((c) => c.id === compositionId);
+			if (!composition) {
+				throw new Error(`Could not find composition with id ${compositionId}`);
+			}
+
+			const editorProps = allEditorProps[composition.id] ?? {};
+			const defaultProps = {
+				...(composition.defaultProps ?? {}),
+				...(editorProps ?? {}),
+			};
+			const combinedProps = {
+				...defaultProps,
+				...(inputProps ?? {}),
+			};
+			const controller = new AbortController();
+			const result = Internals.resolveVideoConfigOrCatch({
+				compositionId: composition.id,
+				calculateMetadata: composition.calculateMetadata,
+				inputProps: combinedProps,
+				signal: controller.signal,
+				defaultProps,
+				compositionDurationInFrames: composition.durationInFrames ?? null,
+				compositionFps: composition.fps ?? null,
+				compositionHeight: composition.height ?? null,
+				compositionWidth: composition.width ?? null,
+			});
+
+			if (result.type === 'error') {
+				throw result.error;
+			}
+
+			const resolved = await Promise.resolve(result.result);
+			setResolvedConfigs((configs) => ({
+				...configs,
+				[composition.id]: {
+					type: 'success',
+					result: resolved,
+				},
+			}));
+
+			return resolved;
+		},
+		[allEditorProps, compositions, inputProps],
+	);
 
 	useImperativeHandle(
 		Internals.resolveCompositionsRef,
@@ -212,6 +258,7 @@ export const ResolveCompositionConfigInStudio: React.FC<
 				setCurrentRenderModalComposition: (id: string | null) => {
 					setCurrentRenderModalComposition(id);
 				},
+				resolveComposition,
 				reloadCurrentlySelectedComposition: () => {
 					if (!currentComposition) {
 						return;
@@ -258,6 +305,7 @@ export const ResolveCompositionConfigInStudio: React.FC<
 			currentComposition,
 			doResolution,
 			inputProps,
+			resolveComposition,
 		],
 	);
 

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1,12 +1,15 @@
 import type {Size} from '@remotion/player';
 import {
 	ASSET_DRAG_MIME_TYPE,
+	COMPOSITION_DRAG_MIME_TYPE,
 	COMPONENT_DRAG_MIME_TYPE,
 	ELEMENT_DRAG_MIME_TYPE,
 	parseAssetDragData,
+	parseCompositionDragData,
 	parseComponentDragData,
 	parseSfxDragData,
 	SFX_DRAG_MIME_TYPE,
+	type CompositionDragData,
 	type ComponentDragData,
 } from '@remotion/studio-shared';
 import React, {
@@ -51,6 +54,7 @@ import {getElementDragData} from './element-drag-and-drop';
 import {
 	importAssets,
 	importRemoteAsset,
+	insertComposition,
 	insertComponent,
 	insertElement,
 	insertExistingAssets,
@@ -103,6 +107,12 @@ const isComponentDragEvent = (event: DragEvent): boolean => {
 	);
 };
 
+const isCompositionDragEvent = (event: DragEvent): boolean => {
+	return Array.from(event.dataTransfer?.types ?? []).includes(
+		COMPOSITION_DRAG_MIME_TYPE,
+	);
+};
+
 const isElementDragEvent = (event: DragEvent): boolean => {
 	return Array.from(event.dataTransfer?.types ?? []).includes(
 		ELEMENT_DRAG_MIME_TYPE,
@@ -119,6 +129,7 @@ const isRemoteAssetDragEvent = (event: DragEvent): boolean => {
 	return (
 		!isFileDragEvent(event) &&
 		!isAssetDragEvent(event) &&
+		!isCompositionDragEvent(event) &&
 		!isComponentDragEvent(event) &&
 		!isElementDragEvent(event) &&
 		!isSfxDragEvent(event) &&
@@ -133,6 +144,17 @@ const getAssetDragPath = (event: DragEvent): string | null => {
 	}
 
 	return parseAssetDragData(value)?.assetPath ?? null;
+};
+
+const getCompositionDragData = (
+	event: DragEvent,
+): CompositionDragData | null => {
+	const value = event.dataTransfer?.getData(COMPOSITION_DRAG_MIME_TYPE);
+	if (!value) {
+		return null;
+	}
+
+	return parseCompositionDragData(value);
 };
 
 const getComponentDragData = (event: DragEvent): ComponentDragData | null => {
@@ -746,6 +768,7 @@ export const Canvas: React.FC<{
 				!canDropAssets ||
 				(!isFileDragEvent(event) &&
 					!isAssetDragEvent(event) &&
+					!isCompositionDragEvent(event) &&
 					!isComponentDragEvent(event) &&
 					!isElementDragEvent(event) &&
 					!isSfxDragEvent(event) &&
@@ -771,6 +794,7 @@ export const Canvas: React.FC<{
 				currentCompositionId === null ||
 				(!isFileDragEvent(event) &&
 					!isAssetDragEvent(event) &&
+					!isCompositionDragEvent(event) &&
 					!isComponentDragEvent(event) &&
 					!isElementDragEvent(event) &&
 					!isSfxDragEvent(event) &&
@@ -835,6 +859,18 @@ export const Canvas: React.FC<{
 						url,
 						compositionFile,
 						compositionId: currentCompositionId,
+					});
+				} else if (isCompositionDragEvent(event)) {
+					const compositionDragData = getCompositionDragData(event);
+					if (compositionDragData === null) {
+						return;
+					}
+
+					await insertComposition({
+						composition: compositionDragData,
+						compositionFile,
+						compositionId: currentCompositionId,
+						dropPosition,
 					});
 				} else {
 					const elementDragData = getElementDragData(event.dataTransfer);

--- a/packages/studio/src/components/CompositionSelector.tsx
+++ b/packages/studio/src/components/CompositionSelector.tsx
@@ -236,7 +236,7 @@ export const CompositionSelector: React.FC = () => {
 
 				notification.replaceContent(
 					result.success
-						? `Moved ${parsed.compositionId} to top level`
+						? `Moved ${parsed.compositionId} outside of folder`
 						: result.reason,
 					result.success ? 2000 : 4000,
 				);

--- a/packages/studio/src/components/CompositionSelector.tsx
+++ b/packages/studio/src/components/CompositionSelector.tsx
@@ -2,7 +2,14 @@ import {
 	COMPOSITION_DRAG_MIME_TYPE,
 	parseCompositionDragData,
 } from '@remotion/studio-shared';
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {Internals} from 'remotion';
 import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
 import {
@@ -114,6 +121,38 @@ const shortcutLabel: React.CSSProperties = {
 	opacity: 0.6,
 };
 
+const autoScrollThreshold = 70;
+const maxAutoScrollSpeed = 18;
+
+const getAutoScrollSpeed = ({
+	clientY,
+	element,
+}: {
+	clientY: number;
+	element: HTMLElement;
+}) => {
+	const {top, bottom} = element.getBoundingClientRect();
+	const threshold = Math.min(autoScrollThreshold, element.clientHeight / 2);
+	if (threshold <= 0) {
+		return 0;
+	}
+
+	const distanceToTop = clientY - top;
+	const distanceToBottom = bottom - clientY;
+
+	if (distanceToTop < threshold) {
+		const progress = Math.min(1, (threshold - distanceToTop) / threshold);
+		return -Math.ceil(progress * maxAutoScrollSpeed);
+	}
+
+	if (distanceToBottom < threshold) {
+		const progress = Math.min(1, (threshold - distanceToBottom) / threshold);
+		return Math.ceil(progress * maxAutoScrollSpeed);
+	}
+
+	return 0;
+};
+
 export const CompositionSelector: React.FC = () => {
 	const {compositions, canvasContent, folders} = useContext(
 		Internals.CompositionManager,
@@ -121,6 +160,9 @@ export const CompositionSelector: React.FC = () => {
 	const {foldersExpanded} = useContext(ExpandedFoldersContext);
 	const {setSelectedModal} = useContext(ModalsContext);
 	const [rootDragHovered, setRootDragHovered] = useState(false);
+	const listRef = useRef<HTMLDivElement>(null);
+	const autoScrollAnimation = useRef<number | null>(null);
+	const autoScrollSpeed = useRef(0);
 
 	const {tabIndex} = useZIndex();
 	const selectComposition = useSelectComposition();
@@ -167,6 +209,82 @@ export const CompositionSelector: React.FC = () => {
 		setRootDragHovered(false);
 	}, []);
 
+	const stopCompositionListAutoScroll = useCallback(() => {
+		autoScrollSpeed.current = 0;
+		if (autoScrollAnimation.current !== null) {
+			cancelAnimationFrame(autoScrollAnimation.current);
+			autoScrollAnimation.current = null;
+		}
+	}, []);
+
+	const runCompositionListAutoScroll = useCallback(() => {
+		const listElement = listRef.current;
+		const speed = autoScrollSpeed.current;
+
+		if (listElement === null || speed === 0) {
+			autoScrollAnimation.current = null;
+			return;
+		}
+
+		const scrollTopBefore = listElement.scrollTop;
+		listElement.scrollTop += speed;
+
+		if (listElement.scrollTop === scrollTopBefore) {
+			autoScrollAnimation.current = null;
+			return;
+		}
+
+		autoScrollAnimation.current = requestAnimationFrame(
+			runCompositionListAutoScroll,
+		);
+	}, []);
+
+	const setCompositionListAutoScrollSpeed = useCallback(
+		(speed: number) => {
+			if (speed === 0) {
+				stopCompositionListAutoScroll();
+				return;
+			}
+
+			autoScrollSpeed.current = speed;
+			if (autoScrollAnimation.current === null) {
+				autoScrollAnimation.current = requestAnimationFrame(
+					runCompositionListAutoScroll,
+				);
+			}
+		},
+		[runCompositionListAutoScroll, stopCompositionListAutoScroll],
+	);
+
+	const onCompositionListDragOverCapture = useCallback(
+		(event: React.DragEvent<HTMLElement>) => {
+			if (
+				window.remotion_isReadOnlyStudio ||
+				!Array.from(event.dataTransfer.types).includes(
+					COMPOSITION_DRAG_MIME_TYPE,
+				)
+			) {
+				stopCompositionListAutoScroll();
+				return;
+			}
+
+			const listElement = listRef.current;
+			if (listElement === null) {
+				stopCompositionListAutoScroll();
+				return;
+			}
+
+			setCompositionListAutoScrollSpeed(
+				getAutoScrollSpeed({clientY: event.clientY, element: listElement}),
+			);
+		},
+		[setCompositionListAutoScrollSpeed, stopCompositionListAutoScroll],
+	);
+
+	useEffect(() => {
+		return stopCompositionListAutoScroll;
+	}, [stopCompositionListAutoScroll]);
+
 	const onRootDragOver = useCallback((event: React.DragEvent<HTMLElement>) => {
 		if (
 			window.remotion_isReadOnlyStudio ||
@@ -180,17 +298,21 @@ export const CompositionSelector: React.FC = () => {
 		setRootDragHovered(true);
 	}, []);
 
-	const onRootDragLeave = useCallback((event: React.DragEvent<HTMLElement>) => {
-		const {relatedTarget} = event;
-		if (
-			relatedTarget instanceof Node &&
-			event.currentTarget.contains(relatedTarget)
-		) {
-			return;
-		}
+	const onRootDragLeave = useCallback(
+		(event: React.DragEvent<HTMLElement>) => {
+			const {relatedTarget} = event;
+			if (
+				relatedTarget instanceof Node &&
+				event.currentTarget.contains(relatedTarget)
+			) {
+				return;
+			}
 
-		setRootDragHovered(false);
-	}, []);
+			stopCompositionListAutoScroll();
+			setRootDragHovered(false);
+		},
+		[stopCompositionListAutoScroll],
+	);
 
 	const onRootDrop = useCallback(
 		async (event: React.DragEvent<HTMLElement>) => {
@@ -206,6 +328,7 @@ export const CompositionSelector: React.FC = () => {
 
 			event.preventDefault();
 			event.stopPropagation();
+			stopCompositionListAutoScroll();
 			setRootDragHovered(false);
 
 			const composition = compositions.find(
@@ -247,7 +370,7 @@ export const CompositionSelector: React.FC = () => {
 				);
 			}
 		},
-		[compositions],
+		[compositions, stopCompositionListAutoScroll],
 	);
 
 	return (
@@ -266,10 +389,14 @@ export const CompositionSelector: React.FC = () => {
 				</button>
 			</div>
 			<div
+				ref={listRef}
 				className="__remotion-vertical-scrollbar"
 				style={list}
+				onDragOverCapture={onCompositionListDragOverCapture}
+				onDragEndCapture={stopCompositionListAutoScroll}
 				onDragOver={onRootDragOver}
 				onDragLeave={onRootDragLeave}
+				onDropCapture={stopCompositionListAutoScroll}
 				onDrop={onRootDrop}
 			>
 				{items.map((c) => {

--- a/packages/studio/src/components/CompositionSelector.tsx
+++ b/packages/studio/src/components/CompositionSelector.tsx
@@ -1,10 +1,15 @@
-import React, {useCallback, useContext, useMemo} from 'react';
+import {
+	COMPOSITION_DRAG_MIME_TYPE,
+	parseCompositionDragData,
+} from '@remotion/studio-shared';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
 import {Internals} from 'remotion';
 import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
 import {
 	BACKGROUND,
 	BLACK_HEX,
 	LIGHT_TEXT,
+	WHITE_ALPHA_12,
 	WHITE_ALPHA_06,
 } from '../helpers/colors';
 import {createFolderTree} from '../helpers/create-folder-tree';
@@ -15,6 +20,8 @@ import {ModalsContext} from '../state/modals';
 import {useZIndex} from '../state/z-index';
 import {CompositionSelectorItem} from './CompositionSelectorItem';
 import {useSelectComposition} from './InitialCompositionLoader';
+import {showNotification} from './Notifications/NotificationCenter';
+import {applyCodemod} from './RenderQueue/actions';
 
 export const useCompositionNavigation = () => {
 	const {compositions, canvasContent} = useContext(
@@ -113,6 +120,7 @@ export const CompositionSelector: React.FC = () => {
 	);
 	const {foldersExpanded} = useContext(ExpandedFoldersContext);
 	const {setSelectedModal} = useContext(ModalsContext);
+	const [rootDragHovered, setRootDragHovered] = useState(false);
 
 	const {tabIndex} = useZIndex();
 	const selectComposition = useSelectComposition();
@@ -133,8 +141,9 @@ export const CompositionSelector: React.FC = () => {
 		return {
 			flex: 1,
 			overflowY: 'auto',
+			backgroundColor: rootDragHovered ? WHITE_ALPHA_12 : BACKGROUND,
 		};
-	}, []);
+	}, [rootDragHovered]);
 
 	const toggleFolder = useCallback(
 		(folderName: string, parentName: string | null) => {
@@ -154,6 +163,93 @@ export const CompositionSelector: React.FC = () => {
 		});
 	}, [setSelectedModal]);
 
+	const clearRootDragHover = useCallback(() => {
+		setRootDragHovered(false);
+	}, []);
+
+	const onRootDragOver = useCallback((event: React.DragEvent<HTMLElement>) => {
+		if (
+			window.remotion_isReadOnlyStudio ||
+			!Array.from(event.dataTransfer.types).includes(COMPOSITION_DRAG_MIME_TYPE)
+		) {
+			return;
+		}
+
+		event.preventDefault();
+		event.dataTransfer.dropEffect = 'move';
+		setRootDragHovered(true);
+	}, []);
+
+	const onRootDragLeave = useCallback((event: React.DragEvent<HTMLElement>) => {
+		const {relatedTarget} = event;
+		if (
+			relatedTarget instanceof Node &&
+			event.currentTarget.contains(relatedTarget)
+		) {
+			return;
+		}
+
+		setRootDragHovered(false);
+	}, []);
+
+	const onRootDrop = useCallback(
+		async (event: React.DragEvent<HTMLElement>) => {
+			if (window.remotion_isReadOnlyStudio) {
+				return;
+			}
+
+			const raw = event.dataTransfer.getData(COMPOSITION_DRAG_MIME_TYPE);
+			const parsed = raw ? parseCompositionDragData(raw) : null;
+			if (parsed === null) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			setRootDragHovered(false);
+
+			const composition = compositions.find(
+				(c) => c.id === parsed.compositionId,
+			);
+			if (!composition || composition.folderName === null) {
+				return;
+			}
+
+			const notification = showNotification(
+				`Moving ${parsed.compositionId}...`,
+				null,
+			);
+			const controller = new AbortController();
+
+			try {
+				const result = await applyCodemod({
+					codemod: {
+						type: 'move-composition-to-folder',
+						idToMove: parsed.compositionId,
+						folderName: null,
+						parentName: null,
+					},
+					dryRun: false,
+					signal: controller.signal,
+					symbolicatedStack: null,
+				});
+
+				notification.replaceContent(
+					result.success
+						? `Moved ${parsed.compositionId} to top level`
+						: result.reason,
+					result.success ? 2000 : 4000,
+				);
+			} catch (err) {
+				notification.replaceContent(
+					err instanceof Error ? err.message : String(err),
+					4000,
+				);
+			}
+		},
+		[compositions],
+	);
+
 	return (
 		<div style={container}>
 			<div style={quickSwitcherArea}>
@@ -169,7 +265,13 @@ export const CompositionSelector: React.FC = () => {
 					)}
 				</button>
 			</div>
-			<div className="__remotion-vertical-scrollbar" style={list}>
+			<div
+				className="__remotion-vertical-scrollbar"
+				style={list}
+				onDragOver={onRootDragOver}
+				onDragLeave={onRootDragLeave}
+				onDrop={onRootDrop}
+			>
 				{items.map((c) => {
 					return (
 						<CompositionSelectorItem
@@ -182,6 +284,7 @@ export const CompositionSelector: React.FC = () => {
 							}
 							selectComposition={selectComposition}
 							toggleFolder={toggleFolder}
+							clearRootDragHover={clearRootDragHover}
 							tabIndex={tabIndex}
 							item={c}
 						/>

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -265,6 +265,26 @@ export const CompositionSelectorItem: React.FC<{
 		setDragHovered(false);
 	}, []);
 
+	const onFolderChildListDragOver = useCallback(
+		(event: DragEvent<HTMLElement>) => {
+			if (
+				item.type !== 'folder' ||
+				window.remotion_isReadOnlyStudio ||
+				!Array.from(event.dataTransfer.types).includes(
+					COMPOSITION_DRAG_MIME_TYPE,
+				)
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			event.dataTransfer.dropEffect = 'move';
+			clearRootDragHover();
+		},
+		[clearRootDragHover, item],
+	);
+
 	const onFolderDrop = useCallback(
 		async (event: DragEvent<HTMLElement>) => {
 			if (item.type !== 'folder' || window.remotion_isReadOnlyStudio) {
@@ -373,8 +393,9 @@ export const CompositionSelectorItem: React.FC<{
 						</div>
 					</Row>
 				</ContextMenu>
-				{item.expanded
-					? item.items.map((childItem) => {
+				{item.expanded ? (
+					<div onDragOver={onFolderChildListDragOver} onDrop={onFolderDrop}>
+						{item.items.map((childItem) => {
 							return (
 								<CompositionSelectorItem
 									key={childItem.key + childItem.type}
@@ -387,8 +408,9 @@ export const CompositionSelectorItem: React.FC<{
 									clearRootDragHover={clearRootDragHover}
 								/>
 							);
-						})
-					: null}
+						})}
+					</div>
+				) : null}
 			</>
 		);
 	}

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -1,4 +1,9 @@
-import type {KeyboardEvent, MouseEvent} from 'react';
+import {
+	COMPOSITION_DRAG_MIME_TYPE,
+	makeCompositionDragData,
+	parseCompositionDragData,
+} from '@remotion/studio-shared';
+import type {DragEvent, KeyboardEvent, MouseEvent} from 'react';
 import React, {
 	useCallback,
 	useContext,
@@ -13,8 +18,10 @@ import {
 	BACKGROUND,
 	LIGHT_TEXT,
 	WHITE,
+	WHITE_ALPHA_12,
 	getBackgroundFromHoverState,
 } from '../helpers/colors';
+import {getFolderId} from '../helpers/get-folder-id';
 import {isCompositionStill} from '../helpers/is-composition-still';
 import {noop} from '../helpers/noop';
 import {
@@ -31,6 +38,8 @@ import {ContextMenu} from './ContextMenu';
 import {getFolderMenuItems} from './folder-menu-items';
 import {Row, Spacing} from './layout';
 import type {ComboboxValue} from './NewComposition/ComboBox';
+import {showNotification} from './Notifications/NotificationCenter';
+import {applyCodemod} from './RenderQueue/actions';
 import {SidebarRenderButton} from './SidebarRenderButton';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
 
@@ -123,6 +132,7 @@ export const CompositionSelectorItem: React.FC<{
 	const onPointerLeave = useCallback(() => {
 		setHovered(false);
 	}, []);
+	const [dragHovered, setDragHovered] = useState(false);
 
 	const compositionRowRef = useRef<HTMLAnchorElement>(null);
 	const compositionId =
@@ -142,10 +152,12 @@ export const CompositionSelectorItem: React.FC<{
 	const style: React.CSSProperties = useMemo(() => {
 		return {
 			...itemStyle,
-			backgroundColor: getBackgroundFromHoverState({hovered, selected}),
+			backgroundColor: dragHovered
+				? WHITE_ALPHA_12
+				: getBackgroundFromHoverState({hovered, selected}),
 			paddingLeft: 12 + level * 8,
 		};
-	}, [hovered, level, selected]);
+	}, [dragHovered, hovered, level, selected]);
 
 	const label = useMemo(() => {
 		return {
@@ -205,6 +217,118 @@ export const CompositionSelectorItem: React.FC<{
 		});
 	}, [connectionStatus, item, resolvedLocation, setSelectedModal]);
 
+	const onCompositionDragStart = useCallback(
+		(event: DragEvent<HTMLElement>) => {
+			if (item.type !== 'composition' || window.remotion_isReadOnlyStudio) {
+				event.preventDefault();
+				return;
+			}
+
+			event.dataTransfer.effectAllowed = 'copyMove';
+			event.dataTransfer.setData(
+				COMPOSITION_DRAG_MIME_TYPE,
+				JSON.stringify(
+					makeCompositionDragData({
+						compositionFile: resolvedLocation?.source ?? null,
+						compositionId: item.composition.id,
+					}),
+				),
+			);
+		},
+		[item, resolvedLocation?.source],
+	);
+
+	const onFolderDragOver = useCallback(
+		(event: DragEvent<HTMLElement>) => {
+			if (
+				item.type !== 'folder' ||
+				window.remotion_isReadOnlyStudio ||
+				!Array.from(event.dataTransfer.types).includes(
+					COMPOSITION_DRAG_MIME_TYPE,
+				)
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			event.dataTransfer.dropEffect = 'move';
+			setDragHovered(true);
+		},
+		[item],
+	);
+
+	const onFolderDragLeave = useCallback(() => {
+		setDragHovered(false);
+	}, []);
+
+	const onFolderDrop = useCallback(
+		async (event: DragEvent<HTMLElement>) => {
+			if (item.type !== 'folder' || window.remotion_isReadOnlyStudio) {
+				return;
+			}
+
+			const raw = event.dataTransfer.getData(COMPOSITION_DRAG_MIME_TYPE);
+			const parsed = raw ? parseCompositionDragData(raw) : null;
+			if (parsed === null) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			setDragHovered(false);
+
+			const isAlreadyDirectChild = item.items.some((child) => {
+				return (
+					child.type === 'composition' &&
+					child.composition.id === parsed.compositionId
+				);
+			});
+			if (isAlreadyDirectChild) {
+				return;
+			}
+
+			const folderId = getFolderId({
+				folderName: item.folderName,
+				parentName: item.parentName,
+			});
+			const notification = showNotification(
+				`Moving ${parsed.compositionId}...`,
+				null,
+			);
+			const controller = new AbortController();
+
+			try {
+				const result = await applyCodemod({
+					codemod: {
+						type: 'move-composition-to-folder',
+						idToMove: parsed.compositionId,
+						folderName: item.folderName,
+						parentName: item.parentName,
+					},
+					dryRun: false,
+					signal: controller.signal,
+					symbolicatedStack: null,
+				});
+
+				notification.replaceContent(
+					result.success
+						? `Moved ${parsed.compositionId} to ${folderId}`
+						: result.reason,
+					result.success ? 2000 : 4000,
+				);
+				if (result.success && !item.expanded) {
+					toggleFolder(item.folderName, item.parentName);
+				}
+			} catch (err) {
+				notification.replaceContent(
+					err instanceof Error ? err.message : String(err),
+					4000,
+				);
+			}
+		},
+		[item, toggleFolder],
+	);
+
 	if (item.type === 'folder') {
 		return (
 			<>
@@ -217,6 +341,9 @@ export const CompositionSelectorItem: React.FC<{
 							tabIndex={tabIndex}
 							onClick={onClick}
 							onKeyDown={onKeyDown}
+							onDragOver={onFolderDragOver}
+							onDragLeave={onFolderDragLeave}
+							onDrop={onFolderDrop}
 							title={item.folderName}
 							role="button"
 						>
@@ -271,6 +398,8 @@ export const CompositionSelectorItem: React.FC<{
 					tabIndex={tabIndex}
 					onClick={onClick}
 					onKeyDown={onKeyDown}
+					draggable={!window.remotion_isReadOnlyStudio}
+					onDragStart={onCompositionDragStart}
 					type="button"
 					title={item.composition.id}
 					className="__remotion-composition"

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -108,6 +108,7 @@ export const CompositionSelectorItem: React.FC<{
 		folderName: string,
 		parentName: string | null,
 	) => void;
+	readonly clearRootDragHover: () => void;
 	readonly level: number;
 }> = ({
 	item,
@@ -116,6 +117,7 @@ export const CompositionSelectorItem: React.FC<{
 	tabIndex,
 	selectComposition,
 	toggleFolder,
+	clearRootDragHover,
 }) => {
 	const selected = useMemo(() => {
 		if (item.type === 'composition') {
@@ -251,10 +253,12 @@ export const CompositionSelectorItem: React.FC<{
 			}
 
 			event.preventDefault();
+			event.stopPropagation();
 			event.dataTransfer.dropEffect = 'move';
+			clearRootDragHover();
 			setDragHovered(true);
 		},
-		[item],
+		[clearRootDragHover, item],
 	);
 
 	const onFolderDragLeave = useCallback(() => {
@@ -275,6 +279,7 @@ export const CompositionSelectorItem: React.FC<{
 
 			event.preventDefault();
 			event.stopPropagation();
+			clearRootDragHover();
 			setDragHovered(false);
 
 			const isAlreadyDirectChild = item.items.some((child) => {
@@ -326,7 +331,7 @@ export const CompositionSelectorItem: React.FC<{
 				);
 			}
 		},
-		[item, toggleFolder],
+		[clearRootDragHover, item, toggleFolder],
 	);
 
 	if (item.type === 'folder') {
@@ -379,6 +384,7 @@ export const CompositionSelectorItem: React.FC<{
 									tabIndex={tabIndex}
 									level={level + 1}
 									toggleFolder={toggleFolder}
+									clearRootDragHover={clearRootDragHover}
 								/>
 							);
 						})

--- a/packages/studio/src/components/effect-drag-and-drop.ts
+++ b/packages/studio/src/components/effect-drag-and-drop.ts
@@ -1,5 +1,6 @@
 import {
 	ASSET_DRAG_MIME_TYPE,
+	COMPOSITION_DRAG_MIME_TYPE,
 	COMPONENT_DRAG_MIME_TYPE,
 	EFFECT_DRAG_MIME_TYPE,
 	getRequiredPackageForEffectImportPath,
@@ -37,6 +38,7 @@ const hasImportableAssetDragType = (dataTransfer: DataTransfer) => {
 		(type) =>
 			type === 'Files' ||
 			type === ASSET_DRAG_MIME_TYPE ||
+			type === COMPOSITION_DRAG_MIME_TYPE ||
 			type === COMPONENT_DRAG_MIME_TYPE ||
 			type === SFX_DRAG_MIME_TYPE ||
 			type === 'text/uri-list' ||

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -3,6 +3,7 @@ import {
 	detectFileType,
 	getRequiredPackageForInsertableElement,
 	isUrl,
+	type CompositionDragData,
 	type ComponentDragData,
 	type ComponentProp,
 	type DownloadRemoteAssetResponse,
@@ -12,6 +13,7 @@ import {
 	type InsertableCompositionElementPosition,
 } from '@remotion/studio-shared';
 import {staticFile} from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
 import {getStaticFiles} from '../api/get-static-files';
 import {writeStaticFile} from '../api/write-static-file';
 import {installRequiredPackages} from '../helpers/install-required-package';
@@ -818,6 +820,85 @@ export const insertComponent = async ({
 	} catch (error) {
 		showNotification(
 			`Could not add component: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+			4000,
+		);
+	}
+};
+
+const serializeResolvedPropsForSourceCode = (
+	serializedResolvedPropsWithCustomSchema: string,
+) => {
+	const props = NoReactInternals.deserializeJSONWithSpecialTypes<
+		Record<string, unknown>
+	>(serializedResolvedPropsWithCustomSchema);
+
+	return NoReactInternals.serializeJSONWithSpecialTypes({
+		data: props,
+		indent: undefined,
+		staticBase: window.remotion_staticBase,
+	}).serializedString;
+};
+
+export const insertComposition = async ({
+	composition,
+	compositionFile,
+	compositionId,
+	dropPosition,
+}: {
+	composition: CompositionDragData;
+	compositionFile: string;
+	compositionId: string;
+	dropPosition: InsertElementDropPosition | null;
+}) => {
+	if (composition.compositionId === compositionId) {
+		showNotification('Cannot add a composition to itself', 3000);
+		return;
+	}
+
+	if (composition.compositionFile === null) {
+		showNotification('Could not find composition source file', 3000);
+		return;
+	}
+
+	try {
+		const calculated = await window.remotion_calculateComposition(
+			composition.compositionId,
+		);
+		const dimensions = {
+			width: calculated.width,
+			height: calculated.height,
+		};
+		const inserted = await insertAssetElement({
+			compositionFile,
+			compositionId,
+			element: {
+				type: 'composition',
+				compositionId: composition.compositionId,
+				compositionFile: composition.compositionFile,
+				durationInFrames: calculated.durationInFrames,
+				width: calculated.width,
+				height: calculated.height,
+				serializedResolvedPropsWithCustomSchema:
+					serializeResolvedPropsForSourceCode(
+						calculated.serializedResolvedPropsWithCustomSchema,
+					),
+				position: getCenteredPosition({
+					dimensions,
+					dropPosition,
+				}),
+			},
+		});
+
+		if (!inserted) {
+			return;
+		}
+
+		showNotification(`Added ${composition.compositionId} to source file`, 2000);
+	} catch (error) {
+		showNotification(
+			`Could not add composition: ${
 				error instanceof Error ? error.message : String(error)
 			}`,
 			4000,

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -12,7 +12,7 @@ import {
 	type InsertableCompositionElement,
 	type InsertableCompositionElementPosition,
 } from '@remotion/studio-shared';
-import {staticFile} from 'remotion';
+import {Internals, staticFile} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {getStaticFiles} from '../api/get-static-files';
 import {writeStaticFile} from '../api/write-static-file';
@@ -828,12 +828,8 @@ export const insertComponent = async ({
 };
 
 const serializeResolvedPropsForSourceCode = (
-	serializedResolvedPropsWithCustomSchema: string,
+	props: Record<string, unknown>,
 ) => {
-	const props = NoReactInternals.deserializeJSONWithSpecialTypes<
-		Record<string, unknown>
-	>(serializedResolvedPropsWithCustomSchema);
-
 	return NoReactInternals.serializeJSONWithSpecialTypes({
 		data: props,
 		indent: undefined,
@@ -863,7 +859,12 @@ export const insertComposition = async ({
 	}
 
 	try {
-		const calculated = await window.remotion_calculateComposition(
+		const resolver = Internals.resolveCompositionsRef.current;
+		if (!resolver) {
+			throw new Error('No composition resolver available');
+		}
+
+		const calculated = await resolver.resolveComposition(
 			composition.compositionId,
 		);
 		const dimensions = {
@@ -881,9 +882,7 @@ export const insertComposition = async ({
 				width: calculated.width,
 				height: calculated.height,
 				serializedResolvedPropsWithCustomSchema:
-					serializeResolvedPropsForSourceCode(
-						calculated.serializedResolvedPropsWithCustomSchema,
-					),
+					serializeResolvedPropsForSourceCode(calculated.props),
 				position: getCenteredPosition({
 					dimensions,
 					dropPosition,

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -894,7 +894,10 @@ export const insertComposition = async ({
 			return;
 		}
 
-		showNotification(`Added ${composition.compositionId} to source file`, 2000);
+		showNotification(
+			`Added ${composition.compositionId} to ${compositionId}`,
+			2000,
+		);
 	} catch (error) {
 		showNotification(
 			`Could not add composition: ${


### PR DESCRIPTION
## Summary

- Add Studio sidebar composition drag payloads for canvas drops and folder drops
- Insert dragged compositions into the canvas as duration-aware `<Sequence>` wrappers with resolved props
- Move compositions into dragged-over folders through a recast codemod with undo/redo support

Fixes #8679
Fixes #8795

## Testing

- `bun test packages/studio-server/src/test/apply-codemod.test.ts packages/studio-server/src/test/resolve-composition-component.test.ts packages/studio-shared/src/test/composition-drag-data.test.ts`
- `bun run build`
- `bun run stylecheck`
