### PR TITLE
`@remotion/studio-server`: Add composition name to dropped sequences

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -2136,7 +2136,7 @@ export const insertJsxElementIntoComposition = async ({
 			? {
 					dimensions: {width: element.width, height: element.height},
 					durationInFrames: element.durationInFrames,
-					name: null,
+					name: element.compositionId,
 					position: element.position,
 				}
 			: wrapInSequence;

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -1384,6 +1384,7 @@ test('inserts a composition as a duration-aware Sequence', async () => {
 		expect(result.output).toContain('width={1080}');
 		expect(result.output).toContain('height={540}');
 		expect(result.output).toContain('durationInFrames={100}');
+		expect(result.output).toContain('name="source"');
 		expect(result.output).toContain('<Source');
 		expect(result.output).toContain('hi="there"');
 		expect(result.output).toContain('nested={{');


### PR DESCRIPTION
## Summary

- Add the dragged composition ID as the `name` prop on generated `<Sequence>` wrappers
- Cover composition insertion with a regression assertion

Fixes #8819.

## Tests

- `bun test src/test/resolve-composition-component.test.ts`
- `bun run build`
- `bun run stylecheck`
