### PR TITLE
`@remotion/studio`: Prioritize transform origin handles

### DIFF
--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -115,7 +115,7 @@ import {useSelectAsset} from './use-select-asset';
 
 const emptyContextMenuValues: readonly ComboboxValue[] = [];
 
-const SelectedOutlineTransformOriginHandle: React.FC<{
+export const SelectedOutlineTransformOriginHandle: React.FC<{
 	readonly outline: SelectedOutline;
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly target: SelectedOutlineTarget | undefined;
@@ -1736,11 +1736,6 @@ export const SelectedOutlineElement: React.FC<{
 						/>
 					))
 				: null}
-			<SelectedOutlineTransformOriginHandle
-				outline={outline}
-				onDraggingChange={onDraggingChange}
-				target={target}
-			/>
 		</>
 	);
 };

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -46,7 +46,10 @@ import {
 	type SelectedOutlineTarget,
 } from './selected-outline-types';
 import {getSelectedUvHandles} from './selected-outline-uv';
-import {SelectedOutlineElement} from './SelectedOutlineElement';
+import {
+	SelectedOutlineElement,
+	SelectedOutlineTransformOriginHandle,
+} from './SelectedOutlineElement';
 import {
 	SelectedOutlineUvHandleCircleLayer,
 	SelectedOutlineUvHandleConnectionLayer,
@@ -868,6 +871,15 @@ export const SelectedOutlineOverlay: React.FC<{
 					onHoverChange={setHoveredOutlineKey}
 					onSelect={selectOutlineItem}
 					scale={scale}
+					target={targetsByKey.get(outline.key)}
+				/>
+			))}
+			{/* Keep transform-origin handles above every transparent outline polygon so SVG hit-testing reaches the selected knob first. */}
+			{outlinesForRendering.map((outline) => (
+				<SelectedOutlineTransformOriginHandle
+					key={`${outline.key}-transform-origin`}
+					outline={outline}
+					onDraggingChange={onDraggingChange}
 					target={targetsByKey.get(outline.key)}
 				/>
 			))}


### PR DESCRIPTION
## Summary

- Render transform-origin handles in a dedicated overlay pass above selectable outline polygons
- Keep the selected transform-origin knob draggable when another outline overlaps it

Fixes #8818.

## Test Plan

- `bun test src/test/timeline-selection.test.ts` in `packages/studio`
- `bun run build`
- `bun run stylecheck`
