### PR TITLE
`@remotion/studio`: Prevent collapsed timeline frame errors

### DIFF
--- a/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
+++ b/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
@@ -229,7 +229,11 @@ export const getFrameIncrementFromWidth = (
 	durationInFrames: number,
 	width: number,
 ) => {
-	return (width - TIMELINE_PADDING * 2) / durationInFrames;
+	return getUsableTimelineWidth(width) / durationInFrames;
+};
+
+const getUsableTimelineWidth = (width: number) => {
+	return Math.max(1, width - TIMELINE_PADDING * 2);
 };
 
 export const getFrameWhileScrollingRight = ({
@@ -272,7 +276,7 @@ export const getFrameFromX = ({
 		Math.round(
 			interpolate(
 				pos,
-				[0, width - TIMELINE_PADDING * 2],
+				[0, getUsableTimelineWidth(width)],
 				[0, durationInFrames],
 				{
 					extrapolateLeft: extrapolate,

--- a/packages/studio/src/test/timeline-scroll-logic.test.ts
+++ b/packages/studio/src/test/timeline-scroll-logic.test.ts
@@ -1,0 +1,20 @@
+import {expect, test} from 'bun:test';
+import {
+	getFrameFromX,
+	getFrameIncrementFromWidth,
+} from '../components/Timeline/timeline-scroll-logic';
+
+test('getFrameFromX handles collapsed timeline widths', () => {
+	expect(
+		getFrameFromX({
+			clientX: 0,
+			durationInFrames: 100,
+			extrapolate: 'clamp',
+			width: 0,
+		}),
+	).toBe(0);
+});
+
+test('getFrameIncrementFromWidth never returns a negative increment', () => {
+	expect(getFrameIncrementFromWidth(100, 0)).toBe(0.01);
+});


### PR DESCRIPTION
## Summary

- Clamp the usable Studio timeline width before converting x positions to frames
- Reuse the same guard for frame increment calculations so collapsed layouts cannot produce negative increments
- Add a regression test for collapsed timeline widths, matching the arrow-key stack from #8822

Fixes #8822

## Testing

- bun test packages/studio/src/test/timeline-scroll-logic.test.ts
- bun run build
- bun run stylecheck
