### PR TITLE
Docs: Link interactive component guide in skill

### DIFF
--- a/.agents/skills/interactivity-best-practices/SKILL.md
+++ b/.agents/skills/interactivity-best-practices/SKILL.md
@@ -7,3 +7,6 @@ description: Best practices for writing Remotion animations that stay intuitive 
 
 Use the canonical interactivity best-practices page instead:
 [packages/docs/docs/studio/interactivity-best-practices.mdx](../../../packages/docs/docs/studio/interactivity-best-practices.mdx)
+
+To make an element or custom component interactive, use:
+[packages/docs/docs/studio/make-component-interactive.mdx](../../../packages/docs/docs/studio/make-component-interactive.mdx)

--- a/packages/skills/skills/remotion/SKILL.md
+++ b/packages/skills/skills/remotion/SKILL.md
@@ -26,6 +26,7 @@ Before designing visual scenes, layouts, promos, motion graphics, or text-heavy 
 Animate properties using `useCurrentFrame()` and `interpolate()`. Prefer `interpolate()` over `spring()` unless physics-based motion is explicitly needed. Use `Easing.bezier()` to customize timing, including jumpy or overshooting motion.
 
 For animations that should be editable in Remotion Studio, keep the `interpolate()` call inline in the `style` prop and use individual CSS transform properties (`scale`, `translate`, `rotate`) instead of composing a `transform` string.
+To make an element or custom component interactive in Remotion Studio, follow https://www.remotion.dev/docs/studio/make-component-interactive.
 
 ```tsx
 import { useCurrentFrame, Easing, interpolate, useVideoConfig } from "remotion";


### PR DESCRIPTION
## Summary

- Link the public Remotion best-practices skill to the “Make a component interactive” documentation page.
- Mirror the same pointer in the local interactivity-best-practices skill.
- Closes #8811.

## Testing

- bun run build
- bun run stylecheck
