### PR TITLE
`@remotion/brand`: Make extrusions interactive

### DIFF
--- a/packages/brand/src/3DContext/Div3D.tsx
+++ b/packages/brand/src/3DContext/Div3D.tsx
@@ -1,69 +1,567 @@
-import {makeMatrix3dTransform} from '@remotion/svg-3d-engine';
+import {
+	aroundCenterPoint,
+	makeMatrix3dTransform,
+	reduceMatrices,
+	rotateX,
+	rotateY,
+	rotateZ,
+	scaled,
+	translateX,
+	translateY,
+	translateZ,
+} from '@remotion/svg-3d-engine';
 import React from 'react';
+import {
+	Interactive,
+	Internals,
+	Sequence,
+	type InteractiveBaseProps,
+	type InteractiveTransformProps,
+	type InteractivitySchema,
+	type InteractivitySchemaField,
+	type SequenceControls,
+} from 'remotion';
 import {DivExtrusion} from './DivExtrusion';
 import {Face} from './FrontFace';
 import {RectProvider} from './path-context';
 import {BottomSide, TopSide} from './TopSide';
-import {useTransformations} from './transformation-context';
+import {
+	CenterPointContext,
+	TransformContext,
+	transformPoint,
+	useTransformations,
+} from './transformation-context';
 import {isBacksideVisible} from './viewing-frontside';
 
-export const ExtrudeDiv: React.FC<{
-	readonly children: React.ReactNode;
+type ExtrudeDivOptionalProps = Partial<{
 	readonly width: number;
 	readonly height: number;
 	readonly depth: number;
 	readonly cornerRadius: number;
-	readonly backFace?: React.ReactNode;
-	readonly topFace?: React.ReactNode;
-	readonly bottomFace?: React.ReactNode;
-	readonly style?: React.CSSProperties;
-}> = ({
-	children,
-	width,
-	height,
-	depth,
-	cornerRadius,
-	backFace,
-	style,
-	topFace,
-	bottomFace,
-}) => {
-	const frontFace = isBacksideVisible(useTransformations());
+	readonly backFace: React.ReactNode;
+	readonly topFace: React.ReactNode;
+	readonly bottomFace: React.ReactNode;
+	readonly stack: string;
+}>;
 
-	return (
-		<RectProvider height={height} width={width} cornerRadius={cornerRadius}>
-			<div
-				style={{
-					width,
-					height,
-					position: 'relative',
-					...style,
-				}}
-			>
-				{depth > 0 ? <DivExtrusion depth={depth} /> : children}
-				{depth === 0 ? null : !frontFace ? (
-					<Face type="front" depth={depth}>
-						{children}
-					</Face>
-				) : (
-					<Face type="back" depth={depth}>
-						{backFace}
-					</Face>
-				)}
-				{topFace ? (
-					<TopSide depth={depth} width={width} height={height}>
-						{topFace}
-					</TopSide>
-				) : null}
-				{bottomFace ? (
-					<BottomSide depth={depth} width={width} height={height}>
-						{bottomFace}
-					</BottomSide>
-				) : null}
-			</div>
-		</RectProvider>
-	);
+type ExtrudeDivTransformProps = Partial<{
+	readonly translationX: number;
+	readonly translationY: number;
+	readonly translationZ: number;
+	readonly rotationX: number;
+	readonly rotationY: number;
+	readonly rotationZ: number;
+	readonly scaleX: number;
+	readonly scaleY: number;
+	readonly scaleZ: number;
+}>;
+
+type ExtrudeDivProps = InteractiveBaseProps &
+	InteractiveTransformProps &
+	ExtrudeDivTransformProps &
+	ExtrudeDivOptionalProps & {
+		readonly children: React.ReactNode;
+	};
+
+const pixelTransformField = (
+	description: string,
+): InteractivitySchemaField => ({
+	type: 'number',
+	step: 1,
+	default: 0,
+	description,
+	hiddenFromList: false,
+});
+
+const radiansTransformField = (
+	description: string,
+): InteractivitySchemaField => ({
+	type: 'number',
+	step: 0.01,
+	default: 0,
+	description,
+	hiddenFromList: false,
+});
+
+const scaleTransformField = (
+	description: string,
+): InteractivitySchemaField => ({
+	type: 'number',
+	min: 0,
+	step: 0.01,
+	default: 1,
+	description,
+	hiddenFromList: false,
+});
+
+const extrudeDivSchema = {
+	...Interactive.baseSchema,
+	width: {
+		type: 'number',
+		min: 1,
+		step: 1,
+		default: 200,
+		description: 'Width',
+		hiddenFromList: false,
+	},
+	height: {
+		type: 'number',
+		min: 1,
+		step: 1,
+		default: 100,
+		description: 'Height',
+		hiddenFromList: false,
+	},
+	depth: {
+		type: 'number',
+		min: 0,
+		step: 1,
+		default: 40,
+		description: 'Depth',
+		hiddenFromList: false,
+	},
+	translationX: pixelTransformField('Translation X'),
+	translationY: pixelTransformField('Translation Y'),
+	translationZ: pixelTransformField('Translation Z'),
+	rotationX: radiansTransformField('Rotation X (radians)'),
+	rotationY: radiansTransformField('Rotation Y (radians)'),
+	rotationZ: radiansTransformField('Rotation Z (radians)'),
+	scaleX: scaleTransformField('Scale X'),
+	scaleY: scaleTransformField('Scale Y'),
+	scaleZ: scaleTransformField('Scale Z'),
+	...Interactive.transformSchema,
+} as const satisfies InteractivitySchema;
+
+const setRef = <ElementType,>(
+	ref: React.ForwardedRef<ElementType>,
+	value: ElementType | null,
+) => {
+	if (typeof ref === 'function') {
+		ref(value);
+	} else if (ref) {
+		ref.current = value;
+	}
 };
+
+const numberWithUnitPattern =
+	/^([+-]?(?:\d+\.?\d*|\.\d+))(px|%|deg|rad|turn|grad)$/i;
+const numberPattern = /^[+-]?(?:\d+\.?\d*|\.\d+)$/;
+
+const parsePixelValue = (value: unknown): number | null => {
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? value : null;
+	}
+
+	if (typeof value !== 'string') {
+		return null;
+	}
+
+	const trimmed = value.trim();
+	if (trimmed === '0') {
+		return 0;
+	}
+
+	const match = trimmed.match(numberWithUnitPattern);
+	if (!match || match[2].toLowerCase() !== 'px') {
+		return null;
+	}
+
+	const parsed = Number(match[1]);
+	return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseTranslateValue = (
+	value: React.CSSProperties['translate'] | undefined,
+): readonly [number, number, number] => {
+	if (value === undefined || value === null || value === 'none') {
+		return [0, 0, 0];
+	}
+
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? [value, 0, 0] : [0, 0, 0];
+	}
+
+	const parts = String(value).trim().split(/\s+/);
+	const x = parsePixelValue(parts[0]) ?? 0;
+	const y = parts[1] === undefined ? 0 : (parsePixelValue(parts[1]) ?? 0);
+	const z = parts[2] === undefined ? 0 : (parsePixelValue(parts[2]) ?? 0);
+
+	return [x, y, z];
+};
+
+const parseScaleValue = (
+	value: React.CSSProperties['scale'] | undefined,
+): readonly [number, number, number] => {
+	if (value === undefined || value === null || value === 'none') {
+		return [1, 1, 1];
+	}
+
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? [value, value, 1] : [1, 1, 1];
+	}
+
+	const parts = String(value).trim().split(/\s+/);
+	if (parts.length < 1 || parts.length > 3 || parts[0] === '') {
+		return [1, 1, 1];
+	}
+
+	const parsed = parts.map((part) => Number(part));
+	if (!parsed.every((part) => Number.isFinite(part))) {
+		return [1, 1, 1];
+	}
+
+	return [parsed[0], parsed[1] ?? parsed[0], parsed[2] ?? 1];
+};
+
+const rotationUnitToRadians: Record<string, number> = {
+	deg: Math.PI / 180,
+	grad: Math.PI / 200,
+	rad: 1,
+	turn: Math.PI * 2,
+};
+
+const parseRotationValue = (
+	value: React.CSSProperties['rotate'] | undefined,
+): number => {
+	if (value === undefined || value === null || value === 'none') {
+		return 0;
+	}
+
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? value * rotationUnitToRadians.deg : 0;
+	}
+
+	const trimmed = String(value).trim();
+	const unitMatch = trimmed.match(numberWithUnitPattern);
+	if (unitMatch) {
+		const amount = Number(unitMatch[1]);
+		const unit = unitMatch[2].toLowerCase();
+		const factor = rotationUnitToRadians[unit];
+		return Number.isFinite(amount) && factor !== undefined
+			? amount * factor
+			: 0;
+	}
+
+	if (numberPattern.test(trimmed)) {
+		return Number(trimmed) * rotationUnitToRadians.deg;
+	}
+
+	return 0;
+};
+
+type OriginAxis = {
+	readonly value: number;
+	readonly unit: '%' | 'px';
+};
+
+const centerOrigin: OriginAxis = {value: 50, unit: '%'};
+
+const parseOriginAxis = (value: string): OriginAxis | null => {
+	const lower = value.toLowerCase();
+	if (lower === 'center') {
+		return centerOrigin;
+	}
+
+	if (lower === 'left' || lower === 'top') {
+		return {value: 0, unit: '%'};
+	}
+
+	if (lower === 'right' || lower === 'bottom') {
+		return {value: 100, unit: '%'};
+	}
+
+	const match = value.match(numberWithUnitPattern);
+	if (!match) {
+		return null;
+	}
+
+	const unit = match[2].toLowerCase();
+	if (unit !== 'px' && unit !== '%') {
+		return null;
+	}
+
+	const parsed = Number(match[1]);
+	return Number.isFinite(parsed) ? {value: parsed, unit} : null;
+};
+
+const originAxisToPixels = (axis: OriginAxis, size: number): number => {
+	return axis.unit === '%' ? (axis.value / 100) * size : axis.value;
+};
+
+const parseTransformOriginValue = ({
+	height,
+	value,
+	width,
+}: {
+	readonly height: number;
+	readonly value: React.CSSProperties['transformOrigin'] | undefined;
+	readonly width: number;
+}): readonly [number, number, number] => {
+	if (value === undefined || value === null) {
+		return [width / 2, height / 2, 0];
+	}
+
+	const parts = String(value).trim().split(/\s+/);
+	if (parts.length < 1 || parts.length > 3 || parts[0] === '') {
+		return [width / 2, height / 2, 0];
+	}
+
+	const first = parseOriginAxis(parts[0]) ?? centerOrigin;
+	const second =
+		parts[1] === undefined
+			? centerOrigin
+			: (parseOriginAxis(parts[1]) ?? centerOrigin);
+	const z = parts[2] === undefined ? 0 : (parsePixelValue(parts[2]) ?? 0);
+
+	return [
+		originAxisToPixels(first, width),
+		originAxisToPixels(second, height),
+		z,
+	];
+};
+
+const getTransformStyle = ({
+	height,
+	rotate,
+	rotationX,
+	rotationY,
+	rotationZ,
+	scale,
+	scaleX: localScaleX,
+	scaleY: localScaleY,
+	scaleZ: localScaleZ,
+	transformOrigin,
+	translate,
+	translationX,
+	translationY,
+	translationZ,
+	width,
+}: {
+	readonly height: number;
+	readonly rotate: React.CSSProperties['rotate'] | undefined;
+	readonly rotationX: number;
+	readonly rotationY: number;
+	readonly rotationZ: number;
+	readonly scale: React.CSSProperties['scale'] | undefined;
+	readonly scaleX: number;
+	readonly scaleY: number;
+	readonly scaleZ: number;
+	readonly transformOrigin: React.CSSProperties['transformOrigin'] | undefined;
+	readonly translate: React.CSSProperties['translate'] | undefined;
+	readonly translationX: number;
+	readonly translationY: number;
+	readonly translationZ: number;
+	readonly width: number;
+}) => {
+	const [translateXPx, translateYPx, translateZPx] =
+		parseTranslateValue(translate);
+	const [styleScaleX, styleScaleY, styleScaleZ] = parseScaleValue(scale);
+	const rotateRadians = parseRotationValue(rotate);
+	const [originX, originY, originZ] = parseTransformOriginValue({
+		height,
+		value: transformOrigin,
+		width,
+	});
+
+	return aroundCenterPoint({
+		matrix: reduceMatrices([
+			translateX(translateXPx + translationX),
+			translateY(translateYPx + translationY),
+			translateZ(translateZPx + translationZ),
+			rotateX(rotationX),
+			rotateY(rotationY),
+			rotateZ(rotateRadians + rotationZ),
+			scaled([
+				styleScaleX * localScaleX,
+				styleScaleY * localScaleY,
+				styleScaleZ * localScaleZ,
+			]),
+		]),
+		x: originX,
+		y: originY,
+		z: originZ,
+	});
+};
+
+const ExtrudeDivInner = React.forwardRef<
+	HTMLDivElement,
+	ExtrudeDivProps & {
+		readonly controls: SequenceControls | undefined;
+	}
+>(
+	(
+		{
+			children,
+			width = 200,
+			height = 100,
+			depth = 40,
+			cornerRadius = 0,
+			backFace,
+			style,
+			translationX = 0,
+			translationY = 0,
+			translationZ = 0,
+			rotationX = 0,
+			rotationY = 0,
+			rotationZ = 0,
+			scaleX = 1,
+			scaleY = 1,
+			scaleZ = 1,
+			topFace,
+			bottomFace,
+			durationInFrames,
+			from,
+			trimBefore,
+			freeze,
+			hidden,
+			name,
+			showInTimeline,
+			stack,
+			controls,
+		},
+		ref,
+	) => {
+		const parentTransform = useTransformations();
+		const parentCenterPoint = React.useContext(CenterPointContext);
+		const localTranslate = style?.translate;
+		const localScale = style?.scale;
+		const localRotate = style?.rotate;
+		const localTransformOrigin = style?.transformOrigin;
+		const localTransform = React.useMemo(() => {
+			return getTransformStyle({
+				height,
+				rotate: localRotate,
+				rotationX,
+				rotationY,
+				rotationZ,
+				scale: localScale,
+				scaleX,
+				scaleY,
+				scaleZ,
+				transformOrigin: localTransformOrigin,
+				translate: localTranslate,
+				translationX,
+				translationY,
+				translationZ,
+				width,
+			});
+		}, [
+			height,
+			localRotate,
+			localScale,
+			localTransformOrigin,
+			localTranslate,
+			rotationX,
+			rotationY,
+			rotationZ,
+			scaleX,
+			scaleY,
+			scaleZ,
+			translationX,
+			translationY,
+			translationZ,
+			width,
+		]);
+		const combinedTransform = React.useMemo(() => {
+			return reduceMatrices([parentTransform, localTransform]);
+		}, [localTransform, parentTransform]);
+		const combinedCenterPoint = React.useMemo(() => {
+			return transformPoint({matrix: localTransform, point: parentCenterPoint});
+		}, [localTransform, parentCenterPoint]);
+		const frontFace = isBacksideVisible(combinedTransform);
+		const outlineRef = React.useRef<HTMLDivElement | null>(null);
+		const callbackRef = React.useCallback(
+			(element: HTMLDivElement | null) => {
+				if (depth === 0) {
+					outlineRef.current = element;
+				}
+
+				setRef(ref, element);
+			},
+			[depth, ref],
+		);
+
+		return (
+			<Sequence
+				layout="none"
+				from={from ?? 0}
+				trimBefore={trimBefore}
+				durationInFrames={durationInFrames ?? Infinity}
+				freeze={freeze}
+				hidden={hidden}
+				name={name ?? '<ExtrudeDiv>'}
+				showInTimeline={showInTimeline ?? true}
+				controls={controls ?? undefined}
+				_remotionInternalStack={stack}
+				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/studio/make-component-interactive"
+				outlineRef={outlineRef}
+			>
+				<TransformContext.Provider value={combinedTransform}>
+					<CenterPointContext.Provider value={combinedCenterPoint}>
+						<RectProvider
+							height={height}
+							width={width}
+							cornerRadius={cornerRadius}
+						>
+							<div
+								ref={callbackRef}
+								style={{
+									...style,
+									width,
+									height,
+									position: 'relative',
+									transform:
+										depth === 0
+											? makeMatrix3dTransform(combinedTransform)
+											: undefined,
+									transformOrigin: undefined,
+									translate: undefined,
+									rotate: undefined,
+									scale: undefined,
+								}}
+							>
+								{depth > 0 ? <DivExtrusion depth={depth} /> : children}
+								{depth === 0 ? null : !frontFace ? (
+									<Face type="front" depth={depth} outlineRef={outlineRef}>
+										{children}
+									</Face>
+								) : (
+									<Face type="back" depth={depth} outlineRef={outlineRef}>
+										{backFace}
+									</Face>
+								)}
+								{topFace ? (
+									<TopSide depth={depth} width={width} height={height}>
+										{topFace}
+									</TopSide>
+								) : null}
+								{bottomFace ? (
+									<BottomSide depth={depth} width={width} height={height}>
+										{bottomFace}
+									</BottomSide>
+								) : null}
+							</div>
+						</RectProvider>
+					</CenterPointContext.Provider>
+				</TransformContext.Provider>
+			</Sequence>
+		);
+	},
+);
+
+ExtrudeDivInner.displayName = '<ExtrudeDiv>';
+
+export const ExtrudeDiv = Interactive.withSchema({
+	Component: ExtrudeDivInner,
+	componentName: '<ExtrudeDiv>',
+	componentIdentity: null,
+	schema: extrudeDivSchema,
+	supportsEffects: false,
+});
+
+ExtrudeDiv.displayName = 'ExtrudeDiv';
+
+Internals.addSequenceStackTraces(ExtrudeDiv);
 
 export const ThreeDiv: React.FC<React.HtmlHTMLAttributes<HTMLDivElement>> = ({
 	style,

--- a/packages/brand/src/3DContext/FrontFace.tsx
+++ b/packages/brand/src/3DContext/FrontFace.tsx
@@ -10,8 +10,9 @@ import {useTransformations} from './transformation-context';
 export const Face: React.FC<{
 	children: React.ReactNode;
 	depth: number;
+	outlineRef?: React.RefObject<HTMLDivElement | null>;
 	type: 'front' | 'back';
-}> = ({children, depth, type}) => {
+}> = ({children, depth, outlineRef, type}) => {
 	const {width, height} = useRect();
 
 	const frontFace = reduceMatrices([
@@ -22,6 +23,7 @@ export const Face: React.FC<{
 
 	return (
 		<div
+			ref={outlineRef}
 			style={{
 				transform: makeMatrix3dTransform(frontFace),
 				display: 'flex',

--- a/packages/brand/src/3DContext/transformation-context.tsx
+++ b/packages/brand/src/3DContext/transformation-context.tsx
@@ -10,6 +10,15 @@ import {
 	translateZ,
 } from '@remotion/svg-3d-engine';
 import React, {useContext, useMemo} from 'react';
+import {
+	Interactive,
+	Internals,
+	Sequence,
+	type InteractiveBaseProps,
+	type InteractivitySchema,
+	type InteractivitySchemaField,
+	type SequenceControls,
+} from 'remotion';
 
 type Context = MatrixTransform4D;
 
@@ -87,82 +96,192 @@ export const NewTransform: React.FC<{
 	);
 };
 
-export const RotateX: React.FC<{
+type TransformBaseProps = InteractiveBaseProps & {
 	readonly children: React.ReactNode;
-	readonly radians: number;
-}> = ({children, radians}) => {
-	return (
-		<NewTransform transform={useMemo(() => rotateX(radians), [radians])}>
-			{children}
-		</NewTransform>
+} & Partial<{
+		readonly stack: string;
+	}>;
+
+type TransformInnerProps<ValueKey extends string> = TransformBaseProps &
+	Readonly<Record<ValueKey, number>> & {
+		readonly controls: SequenceControls | undefined;
+	};
+
+const transformDocumentationLink =
+	'https://www.remotion.dev/docs/studio/make-component-interactive';
+
+const make3DTransform = <ValueKey extends string>({
+	componentName,
+	valueKey,
+	schemaField,
+	makeTransform,
+	defaultValue,
+}: {
+	componentName: string;
+	valueKey: ValueKey;
+	schemaField: InteractivitySchemaField;
+	makeTransform: (value: number) => MatrixTransform4D;
+	defaultValue: number;
+}) => {
+	type Props = TransformBaseProps & Readonly<Record<ValueKey, number>>;
+
+	const schema = {
+		...Interactive.baseSchema,
+		[valueKey]: schemaField,
+	} as const satisfies InteractivitySchema;
+
+	const Inner = React.forwardRef<never, TransformInnerProps<ValueKey>>(
+		(rawProps, _ref) => {
+			const props = rawProps as TransformInnerProps<ValueKey>;
+			const {
+				children,
+				durationInFrames,
+				from,
+				trimBefore,
+				freeze,
+				hidden,
+				name,
+				showInTimeline,
+				stack,
+				controls,
+			} = props;
+			const value = props[valueKey] ?? defaultValue;
+			const transform = useMemo(() => makeTransform(value), [value]);
+
+			return (
+				<Sequence
+					layout="none"
+					from={from ?? 0}
+					trimBefore={trimBefore}
+					durationInFrames={durationInFrames ?? Infinity}
+					freeze={freeze}
+					hidden={hidden}
+					name={name ?? componentName}
+					showInTimeline={showInTimeline ?? true}
+					controls={controls ?? undefined}
+					_remotionInternalStack={stack}
+					_remotionInternalDocumentationLink={transformDocumentationLink}
+				>
+					<NewTransform transform={transform}>{children}</NewTransform>
+				</Sequence>
+			);
+		},
 	);
+
+	Inner.displayName = componentName;
+
+	const Wrapped = Interactive.withSchema({
+		Component: Inner,
+		componentName,
+		componentIdentity: null,
+		schema,
+		supportsEffects: false,
+	}) as unknown as React.FC<Props>;
+
+	Wrapped.displayName = componentName.slice(1, -1);
+	Internals.addSequenceStackTraces(Wrapped);
+
+	return Wrapped;
 };
 
-export const RotateZ: React.FC<{
-	readonly children: React.ReactNode;
-	readonly radians: number;
-}> = ({children, radians}) => {
-	return (
-		<NewTransform transform={useMemo(() => rotateZ(radians), [radians])}>
-			{children}
-		</NewTransform>
-	);
-};
+export const RotateX = make3DTransform({
+	componentName: '<RotateX>',
+	valueKey: 'radians',
+	defaultValue: 0,
+	schemaField: {
+		type: 'number',
+		step: 0.01,
+		default: 0,
+		description: 'Radians',
+		hiddenFromList: false,
+	},
+	makeTransform: rotateX,
+});
 
-export const TranslateY: React.FC<{
-	readonly children: React.ReactNode;
-	readonly px: number;
-}> = ({children, px}) => {
-	return (
-		<NewTransform transform={useMemo(() => translateY(px), [px])}>
-			{children}
-		</NewTransform>
-	);
-};
+export const RotateZ = make3DTransform({
+	componentName: '<RotateZ>',
+	valueKey: 'radians',
+	defaultValue: 0,
+	schemaField: {
+		type: 'number',
+		step: 0.01,
+		default: 0,
+		description: 'Radians',
+		hiddenFromList: false,
+	},
+	makeTransform: rotateZ,
+});
 
-export const TranslateX: React.FC<{
-	readonly children: React.ReactNode;
-	readonly px: number;
-}> = ({children, px}) => {
-	return (
-		<NewTransform transform={useMemo(() => translateX(px), [px])}>
-			{children}
-		</NewTransform>
-	);
-};
+export const TranslateY = make3DTransform({
+	componentName: '<TranslateY>',
+	valueKey: 'px',
+	defaultValue: 0,
+	schemaField: {
+		type: 'number',
+		step: 1,
+		default: 0,
+		description: 'Pixels',
+		hiddenFromList: false,
+	},
+	makeTransform: translateY,
+});
 
-export const TranslateZ: React.FC<{
-	readonly children: React.ReactNode;
-	readonly px: number;
-}> = ({children, px}) => {
-	return (
-		<NewTransform transform={useMemo(() => translateZ(px), [px])}>
-			{children}
-		</NewTransform>
-	);
-};
+export const TranslateX = make3DTransform({
+	componentName: '<TranslateX>',
+	valueKey: 'px',
+	defaultValue: 0,
+	schemaField: {
+		type: 'number',
+		step: 1,
+		default: 0,
+		description: 'Pixels',
+		hiddenFromList: false,
+	},
+	makeTransform: translateX,
+});
 
-export const RotateY: React.FC<{
-	readonly children: React.ReactNode;
-	readonly radians: number;
-}> = ({children, radians}) => {
-	return (
-		<NewTransform transform={useMemo(() => rotateY(radians), [radians])}>
-			{children}
-		</NewTransform>
-	);
-};
+export const TranslateZ = make3DTransform({
+	componentName: '<TranslateZ>',
+	valueKey: 'px',
+	defaultValue: 0,
+	schemaField: {
+		type: 'number',
+		step: 1,
+		default: 0,
+		description: 'Pixels',
+		hiddenFromList: false,
+	},
+	makeTransform: translateZ,
+});
 
-export const Scale: React.FC<{
-	readonly children: React.ReactNode;
-	readonly factor: number;
-}> = ({children, factor}) => {
-	return (
-		<NewTransform transform={useMemo(() => scaled(factor), [factor])}>
-			{children}
-		</NewTransform>
-	);
-};
+export const RotateY = make3DTransform({
+	componentName: '<RotateY>',
+	valueKey: 'radians',
+	defaultValue: 0,
+	schemaField: {
+		type: 'number',
+		step: 0.01,
+		default: 0,
+		description: 'Radians',
+		hiddenFromList: false,
+	},
+	makeTransform: rotateY,
+});
+
+export const Scale = make3DTransform({
+	componentName: '<Scale>',
+	valueKey: 'factor',
+	defaultValue: 1,
+	schemaField: {
+		type: 'number',
+		min: 0,
+		step: 0.01,
+		default: 1,
+		description: 'Factor',
+		hiddenFromList: false,
+	},
+	makeTransform: scaled,
+});
 
 export const useTransformations = () => {
 	return useContext(TransformContext);

--- a/packages/brand/src/3DEngine/Faces.tsx
+++ b/packages/brand/src/3DEngine/Faces.tsx
@@ -5,13 +5,20 @@ import React from 'react';
 export const Faces: React.FC<{
 	readonly elements: FaceType[];
 }> = ({elements, ...svgProps}) => {
+	const usedKeys = new Map<string, number>();
+
 	return (
 		<>
 			{elements.map(({points, color, crispEdges}) => {
+				const path = threeDIntoSvgPath(points);
+				const keyBase = `${path}-${color}`;
+				const occurrence = usedKeys.get(keyBase) ?? 0;
+				usedKeys.set(keyBase, occurrence + 1);
+
 				return (
 					<path
-						key={`${threeDIntoSvgPath(points)}-${color}`}
-						d={threeDIntoSvgPath(points)}
+						key={`${keyBase}-${occurrence}`}
+						d={path}
 						fill={color}
 						shapeRendering={crispEdges ? 'crispEdges' : undefined}
 						{...svgProps}

--- a/packages/brand/src/Compose/AtRemotionButton.tsx
+++ b/packages/brand/src/Compose/AtRemotionButton.tsx
@@ -6,11 +6,11 @@ export const AtRemotionButton: React.FC<{progress: number}> = () => {
 			<div
 				className="text-black text-[42px] font-brand"
 				style={{
-					fontFamily: 'Helvetica',
+					fontFamily: 'GT Planar',
 					fontWeight: 'bold',
 				}}
 			>
-				Follow @JNYBGR
+				@remotion
 			</div>
 		</AbsoluteFill>
 	);

--- a/packages/brand/src/Compose/WhatIsRemotion.tsx
+++ b/packages/brand/src/Compose/WhatIsRemotion.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import type {CalculateMetadataFunction} from 'remotion';
 import {
-	AbsoluteFill,
 	Easing,
 	interpolate,
+	Interactive,
+	Internals,
 	measureSpring,
 	OffthreadVideo,
 	Sequence,
 	spring,
 	staticFile,
+	type InteractiveBaseProps,
+	type InteractiveTransformProps,
+	type InteractivitySchema,
+	type SequenceControls,
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
@@ -27,163 +32,118 @@ import {EndCard} from './EndCard';
 import {LabelOpacityContext, useLabelOpacity} from './LabelOpacity';
 import {Rotations} from './Rotations';
 
-const height = 700;
-const width = (height / 16) * 9;
-const cornerRadius = 10;
-const depth = 60;
-const animationStart = 55;
-
-const Label: React.FC<React.HTMLAttributes<HTMLDivElement>> = (rest) => {
-	const opacity = useLabelOpacity();
-	return (
-		<div
-			className="text-white "
-			style={{
-				fontFamily: 'GT Planar',
-				height: '100%',
-				display: 'flex',
-				flexDirection: 'column',
-				justifyContent: 'center',
-				paddingLeft: 20,
-				fontSize: 24,
-				opacity,
-			}}
-			{...rest}
-		/>
-	);
-};
-
-const getActualLayerWidth = (progress: number) => {
-	return {
-		width: interpolate(progress, [0, 1], [width * 1.5, width]),
-		height: interpolate(progress, [0, 1], [height, height]),
+type LabelProps = InteractiveBaseProps &
+	InteractiveTransformProps &
+	Partial<{
+		readonly stack: string;
+	}> & {
+		readonly children: string;
 	};
+
+const labelSchema = {
+	...Interactive.baseSchema,
+	...Interactive.transformSchema,
+	...Interactive.textSchema,
+	children: {
+		type: 'text-content',
+		default: '',
+		description: 'Text',
+		keyframable: false,
+	},
+} as const satisfies InteractivitySchema;
+
+const setRef = <ElementType,>(
+	ref: React.ForwardedRef<ElementType>,
+	value: ElementType | null,
+) => {
+	if (typeof ref === 'function') {
+		ref(value);
+	} else if (ref) {
+		ref.current = value;
+	}
 };
 
-const VideoLayers: React.FC<{
-	readonly label: string;
-	readonly delay: number;
-	readonly footage?: boolean;
-	readonly bRoll?: boolean;
-	readonly boxWidth: number;
-	readonly boxHeight: number;
-	readonly codeFrame?: boolean;
-	readonly endCard?: boolean;
-}> = ({
-	label,
-	delay,
-	footage,
-	boxHeight,
-	boxWidth,
-	codeFrame,
-	bRoll,
-	endCard,
-}) => {
-	return (
-		<Rotations zIndexHack={false} delay={delay}>
-			<ExtrudeDiv
-				width={boxWidth}
-				height={boxHeight}
-				depth={depth}
-				cornerRadius={10}
-				backFace={
-					<AbsoluteFill
-						className="bg-gray-700"
-						style={{
-							borderRadius: cornerRadius,
-							border: '3px solid black',
-						}}
-					>
-						{codeFrame && <CodeFrame />}
-					</AbsoluteFill>
-				}
-				bottomFace={<Label>{label}</Label>}
-			>
-				<div
-					style={{
-						borderRadius: cornerRadius,
-						overflow: 'hidden',
-						fontFamily: 'GT Planar',
-						backgroundColor: 'black',
-						border: '3px solid black',
-					}}
-					className="text-black flex justify-center items-center font-sans text-2xl font-bold flex-1"
-				>
-					<div
-						style={{
-							backgroundColor: 'black',
-							width: '100%',
-							height: '100%',
-							overflow: 'hidden',
-						}}
-					>
-						{footage ? (
-							<Sequence from={animationStart} layout="none">
-								<OffthreadVideo
-									muted
-									style={{width: '100%', height: '100%', objectFit: 'cover'}}
-									src={staticFile('video.mp4')}
-								/>
-							</Sequence>
-						) : null}
-						{bRoll ? (
-							<Sequence from={animationStart} layout="none">
-								<OffthreadVideo
-									muted
-									style={{width: '100%', height: '100%', objectFit: 'cover'}}
-									src={staticFile('spiral_.mp4')}
-								/>
-							</Sequence>
-						) : null}
-						{endCard ? (
-							<AbsoluteFill
-								className="bg-white"
-								style={{borderRadius: cornerRadius, border: '3px solid black'}}
-							/>
-						) : null}
-					</div>
-				</div>
-			</ExtrudeDiv>
-		</Rotations>
-	);
-};
+const LabelInner = React.forwardRef<
+	HTMLDivElement,
+	LabelProps & {
+		readonly controls: SequenceControls | undefined;
+	}
+>(
+	(
+		{
+			children,
+			durationInFrames,
+			from,
+			trimBefore,
+			freeze,
+			hidden,
+			name,
+			showInTimeline,
+			stack,
+			controls,
+			style,
+		},
+		ref,
+	) => {
+		const opacity = useLabelOpacity();
+		const outlineRef = React.useRef<HTMLDivElement | null>(null);
+		const callbackRef = React.useCallback(
+			(element: HTMLDivElement | null) => {
+				outlineRef.current = element;
+				setRef(ref, element);
+			},
+			[ref],
+		);
 
-const CaptionLayers: React.FC<{
-	readonly delay: number;
-}> = ({delay}) => {
-	return (
-		<Rotations zIndexHack delay={1 + delay}>
-			<ExtrudeDiv
-				width={300}
-				height={60}
-				depth={depth}
-				cornerRadius={10}
-				bottomFace={<Label>&lt;Captions /&gt;</Label>}
-				backFace={
-					<AbsoluteFill
-						className="bg-black"
-						style={{borderRadius: cornerRadius, overflow: 'hidden'}}
-					/>
-				}
+		return (
+			<Sequence
+				layout="none"
+				from={from ?? 0}
+				trimBefore={trimBefore}
+				durationInFrames={durationInFrames ?? Infinity}
+				freeze={freeze}
+				hidden={hidden}
+				name={name ?? '<Label>'}
+				showInTimeline={showInTimeline ?? true}
+				controls={controls ?? undefined}
+				_remotionInternalStack={stack}
+				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/studio/make-component-interactive"
+				outlineRef={outlineRef}
 			>
 				<div
+					ref={callbackRef}
+					className="text-white "
 					style={{
-						borderRadius: cornerRadius,
-						overflow: 'hidden',
 						fontFamily: 'GT Planar',
-						backgroundColor: 'white',
-						border: '3px solid black',
+						height: '100%',
+						display: 'flex',
+						flexDirection: 'column',
+						justifyContent: 'center',
+						paddingLeft: 20,
+						fontSize: 24,
+						opacity,
+						...style,
 					}}
-					className="text-black flex justify-center items-center font-sans text-2xl font-bold flex-1"
 				>
-					<Sequence from={animationStart}>
-						<Captions />
-					</Sequence>
+					{children}
 				</div>
-			</ExtrudeDiv>
-		</Rotations>
-	);
-};
+			</Sequence>
+		);
+	},
+);
+
+LabelInner.displayName = '<Label>';
+
+const Label = Interactive.withSchema({
+	Component: LabelInner,
+	componentName: '<Label>',
+	componentIdentity: null,
+	schema: labelSchema,
+	supportsEffects: false,
+});
+
+Label.displayName = 'Label';
+Internals.addSequenceStackTraces(Label);
 
 export const whatIsRemotionSchema = z.object({
 	fade: z.boolean(),
@@ -195,6 +155,7 @@ export const whatIsRemotionCalculateMetadata: CalculateMetadataFunction<
 	z.infer<typeof whatIsRemotionSchema>
 > = ({props}) => {
 	return {
+		width: props.reel ? 1080 : 1080,
 		height: props.reel ? 1920 : 1080,
 		durationInFrames: props.reel ? 276 : 273,
 		props,
@@ -208,109 +169,153 @@ export const WhatIsRemotion = ({
 }: z.infer<typeof whatIsRemotionSchema>) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
-	const bRollEnter = spring({
-		fps,
-		frame,
-		config: {
-			damping: 200,
-		},
-		delay: 50 + animationStart,
-		durationInFrames: 25,
-		durationRestThreshold: 0.0001,
-	});
-	const bRollExit = spring({
-		fps,
-		frame,
-		config: {
-			damping: 200,
-		},
-		delay: 90 + animationStart,
-		durationInFrames: 25,
-		durationRestThreshold: 0.0001,
-	});
-
-	const endCard = interpolate(
-		frame,
-		[120 + animationStart, 145 + animationStart],
-		[0, 1],
-		{
-			extrapolateLeft: 'clamp',
-			extrapolateRight: 'clamp',
-			easing: Easing.bezier(0.42, 0, 0.58, 1),
-		},
-	);
-
-	const layerDownProgress =
-		interpolate(bRollEnter, [0, 0.5], [0, 1], {
-			extrapolateRight: 'clamp',
-		}) -
-		interpolate(bRollExit, [0.5, 1], [0, 1], {
-			extrapolateLeft: 'clamp',
-		});
-
-	const firstX = interpolate(endCard, [0.7, 1], [0, -1500], {
-		extrapolateLeft: 'clamp',
-	});
-	const secondX = interpolate(endCard, [0, 1], [1500, 0], {
-		extrapolateLeft: 'clamp',
-	});
-
-	const liftCaptions = interpolate(endCard, [0, 1], [0, -2000]);
-
-	const outAnimation = spring({
-		fps,
-		frame,
-		config: {
-			damping: 200,
-		},
-		delay: 250,
-		durationInFrames: 20,
-	});
-
-	const spr = spring({
-		fps,
-		frame,
-		delay: animationStart,
-		config: {
-			damping: 200,
-		},
-		durationInFrames: measureSpring({fps, config: {}}),
-	});
-	const actual = getActualLayerWidth(spr);
-
-	const outActual = getActualLayerWidth(1 - outAnimation);
 
 	return (
-		<AbsoluteFill
+		<Sequence
 			style={{
 				backgroundColor: whiteBackground ? 'white' : undefined,
+				scale: 1.13,
 			}}
 			className="flex justify-center items-center"
 		>
 			<Scale factor={reel ? 1.3 : 1.1}>
-				<AbsoluteFill
+				<Interactive.Div
 					style={{
+						position: 'absolute',
+						inset: 0,
 						maskImage:
 							frame > 100 && fade
 								? 'linear-gradient( -98deg, transparent 5%, red 15%, red 80%, transparent 90%)'
 								: 'none',
 					}}
 				>
-					<TranslateX px={firstX}>
-						<TranslateZ px={1.5 * depth * layerDownProgress}>
-							<VideoLayers
-								footage
-								codeFrame
-								delay={animationStart}
-								boxHeight={actual.height}
-								boxWidth={actual.width}
-								label="<Video />"
-							/>
+					<TranslateX
+						px={interpolate(
+							interpolate(frame, [175, 200], [0, 1], {
+								extrapolateLeft: 'clamp',
+								extrapolateRight: 'clamp',
+								easing: Easing.bezier(0.42, 0, 0.58, 1),
+							}),
+							[0.7, 1],
+							[0, -1500],
+							{
+								extrapolateLeft: 'clamp',
+							},
+						)}
+					>
+						<TranslateZ
+							px={
+								1.5 *
+								60 *
+								(interpolate(
+									spring({
+										fps,
+										frame,
+										config: {
+											damping: 200,
+										},
+										delay: 105,
+										durationInFrames: 25,
+										durationRestThreshold: 0.0001,
+									}),
+									[0, 0.5],
+									[0, 1],
+									{
+										extrapolateRight: 'clamp',
+									},
+								) -
+									interpolate(
+										spring({
+											fps,
+											frame,
+											config: {
+												damping: 200,
+											},
+											delay: 145,
+											durationInFrames: 25,
+											durationRestThreshold: 0.0001,
+										}),
+										[0.5, 1],
+										[0, 1],
+										{
+											extrapolateLeft: 'clamp',
+										},
+									))
+							}
+						>
+							<Rotations zIndexHack={false} delay={55}>
+								<ExtrudeDiv
+									width={interpolate(
+										spring({
+											fps,
+											frame,
+											delay: 55,
+											config: {
+												damping: 200,
+											},
+											durationInFrames: measureSpring({fps, config: {}}),
+										}),
+										[0, 1],
+										[590.625, 393.75],
+									)}
+									height={700}
+									depth={60}
+									cornerRadius={10}
+									backFace={
+										<Interactive.Div
+											className="bg-gray-700"
+											style={{
+												position: 'absolute',
+												inset: 0,
+												borderRadius: 10,
+												border: '3px solid black',
+											}}
+										>
+											<CodeFrame />
+										</Interactive.Div>
+									}
+									bottomFace={<Label>&lt;Video /&gt;</Label>}
+								>
+									<Interactive.Div
+										style={{
+											borderRadius: 10,
+											overflow: 'hidden',
+											fontFamily: 'GT Planar',
+											backgroundColor: 'black',
+											border: '3px solid black',
+										}}
+										className="text-black flex justify-center items-center font-sans text-2xl font-bold flex-1"
+									>
+										<Interactive.Div
+											style={{
+												backgroundColor: 'black',
+												width: '100%',
+												height: '100%',
+												overflow: 'hidden',
+											}}
+										>
+											<Sequence from={55} layout="none">
+												<OffthreadVideo
+													muted
+													style={{
+														width: '100%',
+														height: '100%',
+														objectFit: 'cover',
+													}}
+													src={staticFile('video.mp4')}
+												/>
+											</Sequence>
+										</Interactive.Div>
+									</Interactive.Div>
+								</ExtrudeDiv>
+							</Rotations>
 						</TranslateZ>
 					</TranslateX>
-				</AbsoluteFill>
-				<AbsoluteFill
+				</Interactive.Div>
+				<Interactive.Div
 					style={{
+						position: 'absolute',
+						inset: 0,
 						maskImage: fade
 							? 'linear-gradient( -7deg, transparent 6%, red 15%, red 84%, transparent 94%)'
 							: 'none',
@@ -318,78 +323,292 @@ export const WhatIsRemotion = ({
 				>
 					<TranslateY
 						px={interpolate(
-							bRollEnter + bRollExit,
+							spring({
+								fps,
+								frame,
+								config: {
+									damping: 200,
+								},
+								delay: 105,
+								durationInFrames: 25,
+								durationRestThreshold: 0.0001,
+							}) +
+								spring({
+									fps,
+									frame,
+									config: {
+										damping: 200,
+									},
+									delay: 145,
+									durationInFrames: 25,
+									durationRestThreshold: 0.0001,
+								}),
 							[0, 1, 2],
 							[1900, 0, -1900],
 						)}
 					>
-						<VideoLayers
-							bRoll
-							boxWidth={width}
-							boxHeight={height}
-							delay={animationStart}
-							label="<BRoll />"
-						/>
+						<Rotations zIndexHack={false} delay={55}>
+							<ExtrudeDiv
+								width={393.75}
+								height={700}
+								depth={60}
+								cornerRadius={10}
+								backFace={
+									<Interactive.Div
+										className="bg-gray-700"
+										style={{
+											position: 'absolute',
+											inset: 0,
+											borderRadius: 10,
+											border: '3px solid black',
+										}}
+									/>
+								}
+								bottomFace={<Label>&lt;BRoll /&gt;</Label>}
+							>
+								<Interactive.Div
+									style={{
+										borderRadius: 10,
+										overflow: 'hidden',
+										fontFamily: 'GT Planar',
+										backgroundColor: 'black',
+										border: '3px solid black',
+									}}
+									className="text-black flex justify-center items-center font-sans text-2xl font-bold flex-1"
+								>
+									<Interactive.Div
+										style={{
+											backgroundColor: 'black',
+											width: '100%',
+											height: '100%',
+											overflow: 'hidden',
+										}}
+									>
+										<Sequence from={55} layout="none">
+											<OffthreadVideo
+												muted
+												style={{
+													width: '100%',
+													height: '100%',
+													objectFit: 'cover',
+												}}
+												src={staticFile('spiral_.mp4')}
+											/>
+										</Sequence>
+									</Interactive.Div>
+								</Interactive.Div>
+							</ExtrudeDiv>
+						</Rotations>
 					</TranslateY>
-				</AbsoluteFill>
-				<AbsoluteFill
+				</Interactive.Div>
+				<Interactive.Div
 					style={{
+						position: 'absolute',
+						inset: 0,
 						maskImage:
 							frame > 100 && fade
 								? 'linear-gradient( -98deg, transparent 10%, red 18%, red 80%, transparent 90%)'
 								: 'none',
 					}}
 				>
-					{endCard > 0 && (
-						<TranslateX px={secondX}>
-							<RotateY radians={Math.PI * outAnimation}>
-								<LabelOpacityContext.Provider value={1 - outAnimation}>
-									<VideoLayers
-										boxHeight={outActual.height}
-										boxWidth={outActual.width}
-										delay={animationStart}
-										label="<EndCard />"
-										endCard
-									/>
+					{interpolate(frame, [175, 200], [0, 1], {
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+						easing: Easing.bezier(0.42, 0, 0.58, 1),
+					}) > 0 && (
+						<TranslateX
+							px={interpolate(frame, [175, 200], [1500, 0], {
+								extrapolateLeft: 'clamp',
+								extrapolateRight: 'clamp',
+								easing: Easing.bezier(0.42, 0, 0.58, 1),
+							})}
+						>
+							<RotateY
+								radians={interpolate(
+									spring({
+										fps,
+										frame,
+										config: {
+											damping: 200,
+										},
+										delay: 250,
+										durationInFrames: 20,
+									}),
+									[0, 1],
+									[0, Math.PI],
+								)}
+							>
+								<LabelOpacityContext.Provider
+									value={
+										1 -
+										spring({
+											fps,
+											frame,
+											config: {
+												damping: 200,
+											},
+											delay: 250,
+											durationInFrames: 20,
+										})
+									}
+								>
+									<Rotations zIndexHack={false} delay={55}>
+										<ExtrudeDiv
+											width={interpolate(
+												spring({
+													fps,
+													frame,
+													config: {
+														damping: 200,
+													},
+													delay: 250,
+													durationInFrames: 20,
+												}),
+												[0, 1],
+												[393.75, 590.625],
+											)}
+											height={700}
+											depth={60}
+											cornerRadius={10}
+											backFace={
+												<Interactive.Div
+													className="bg-gray-700"
+													style={{
+														position: 'absolute',
+														inset: 0,
+														borderRadius: 10,
+														border: '3px solid black',
+													}}
+												/>
+											}
+											bottomFace={<Label>&lt;EndCard /&gt;</Label>}
+										>
+											<Interactive.Div
+												style={{
+													borderRadius: 10,
+													overflow: 'hidden',
+													fontFamily: 'GT Planar',
+													backgroundColor: 'black',
+													border: '3px solid black',
+												}}
+												className="text-black flex justify-center items-center font-sans text-2xl font-bold flex-1"
+											>
+												<Interactive.Div
+													style={{
+														backgroundColor: 'black',
+														width: '100%',
+														height: '100%',
+														overflow: 'hidden',
+													}}
+												>
+													<Interactive.Div
+														className="bg-white"
+														style={{
+															position: 'absolute',
+															inset: 0,
+															borderRadius: 10,
+															border: '3px solid black',
+														}}
+													/>
+												</Interactive.Div>
+											</Interactive.Div>
+										</ExtrudeDiv>
+									</Rotations>
 								</LabelOpacityContext.Provider>
 							</RotateY>
 						</TranslateX>
 					)}
-					<AbsoluteFill
+					<Interactive.Div
 						style={{
+							position: 'absolute',
+							inset: 0,
 							maskImage: fade
 								? 'linear-gradient(to bottom, transparent , black 10%)'
 								: undefined,
 						}}
 					>
-						<TranslateX px={secondX}>
-							<AbsoluteFill
+						<TranslateX
+							px={interpolate(frame, [175, 200], [1500, 0], {
+								extrapolateLeft: 'clamp',
+								extrapolateRight: 'clamp',
+								easing: Easing.bezier(0.42, 0, 0.58, 1),
+							})}
+						>
+							<Interactive.Div
 								style={{
+									position: 'absolute',
+									inset: 0,
 									justifyContent: 'center',
 									alignItems: 'center',
 								}}
 							>
 								<Sequence layout="none" from={100}>
-									<div
+									<Interactive.Div
 										style={{
-											width,
-											height,
+											width: 393.75,
+											height: 700,
 											position: 'relative',
 										}}
 									>
-										{endCard ? <EndCard cornerRadius={cornerRadius} /> : null}
-									</div>
+										{interpolate(frame, [175, 200], [0, 1], {
+											extrapolateLeft: 'clamp',
+											extrapolateRight: 'clamp',
+											easing: Easing.bezier(0.42, 0, 0.58, 1),
+										}) ? (
+											<EndCard cornerRadius={10} />
+										) : null}
+									</Interactive.Div>
 								</Sequence>
-							</AbsoluteFill>
+							</Interactive.Div>
 						</TranslateX>
-					</AbsoluteFill>
-				</AbsoluteFill>
+					</Interactive.Div>
+				</Interactive.Div>
 				<TranslateY px={190}>
-					<TranslateZ px={-depth * 2 + liftCaptions}>
-						<CaptionLayers delay={animationStart} />
+					<TranslateZ
+						px={interpolate(frame, [175, 200], [-120, -2120], {
+							extrapolateLeft: 'clamp',
+							extrapolateRight: 'clamp',
+							easing: Easing.bezier(0.42, 0, 0.58, 1),
+						})}
+					>
+						<Rotations zIndexHack delay={56}>
+							<ExtrudeDiv
+								width={300}
+								height={60}
+								depth={60}
+								cornerRadius={10}
+								bottomFace={<Label>&lt;Captions /&gt;</Label>}
+								backFace={
+									<Interactive.Div
+										className="bg-black"
+										style={{
+											position: 'absolute',
+											inset: 0,
+											borderRadius: 10,
+											overflow: 'hidden',
+										}}
+									/>
+								}
+							>
+								<Interactive.Div
+									style={{
+										borderRadius: 10,
+										overflow: 'hidden',
+										fontFamily: 'GT Planar',
+										backgroundColor: 'white',
+										border: '3px solid black',
+									}}
+									className="text-black flex justify-center items-center font-sans text-2xl font-bold flex-1"
+								>
+									<Sequence from={55}>
+										<Captions />
+									</Sequence>
+								</Interactive.Div>
+							</ExtrudeDiv>
+						</Rotations>
 					</TranslateZ>
 				</TranslateY>
 			</Scale>
-		</AbsoluteFill>
+		</Sequence>
 	);
 };


### PR DESCRIPTION
## Summary
- Make `ExtrudeDiv` editable in Studio visual mode with schema fields for dimensions and 3D transforms.
- Compose direct transform props with CSS transform props and parent 3D context transforms.
- Register front/back faces for Studio outlines and fix duplicate SVG face keys.
- Make the `WhatIsRemotion` brand composition more interactive.

## Tests
- `bun run build`
- `bun run stylecheck`
