### PR TITLE
Docs: Fix restartStudio step list styling

### DIFF
--- a/packages/docs/components/InlineStep.tsx
+++ b/packages/docs/components/InlineStep.tsx
@@ -73,6 +73,7 @@ export const Step: React.FC<{
 				marginBottom: 4,
 				cursor: 'pointer',
 				textDecoration: 'none',
+				color: 'white',
 			}}
 			href={`#${children!.toString()}`}
 		>

--- a/packages/docs/docs/studio/restart-studio.mdx
+++ b/packages/docs/docs/studio/restart-studio.mdx
@@ -32,10 +32,8 @@ const MyComp: React.FC = () => {
 
 In order to use this function:
 
-<Step>1</Step> You need to be inside the Remotion Studio.
-<br />
-<Step>2</Step> The Studio must be running (no static deployment)
-<br />
+<Step>1</Step> You need to be inside the Remotion Studio. <br />
+<Step>2</Step> The Studio must be running (no static deployment) <br />
 <br />
 
 Otherwise, the function will throw.

--- a/packages/docs/docs/studio/restart-studio.mdx
+++ b/packages/docs/docs/studio/restart-studio.mdx
@@ -34,7 +34,6 @@ In order to use this function:
 
 <Step>1</Step> You need to be inside the Remotion Studio. <br />
 <Step>2</Step> The Studio must be running (no static deployment) <br />
-<br />
 
 Otherwise, the function will throw.
 


### PR DESCRIPTION
## Summary

- Fix the restartStudio() docs requirement list spacing by matching the neighboring Step markup pattern.
- Keep Step badge numbers white even though Step renders as an anchor.

## Testing

- bunx oxfmt src --write (packages/docs)
- bunx oxfmt components --write (packages/docs, unrelated formatter output dropped)
- bun run build
- bun run stylecheck
