### PR TITLE
Docs: Document interactive element names

### DIFF
--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -40,19 +40,6 @@ The name is shown in the Studio timeline and helps agents identify the correct e
 <Interactive.Div name="Hero title" style={{fontSize: 80}}>
   Launch day
 </Interactive.Div>
-
-// 👎 Hard to identify in larger compositions
-<Interactive.Div name="" style={{fontSize: 80}}>
-  Launch day
-</Interactive.Div>
-```
-
-For reusable components, keep `name` overrideable and provide a meaningful fallback:
-
-```tsx title="Custom component name"
-<Sequence name={name ?? '<Badge>'} controls={controls}>
-  <div ref={outlineRef}>New</div>
-</Sequence>
 ```
 
 ## Keep editable values visible {#keep-editable-values-visible}

--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -28,6 +28,33 @@ For a custom component, see [Make a component interactive](/docs/studio/make-com
 /remotion-best-practices Make this element editable in Remotion Studio. Use Interactive.* for tweakable HTML/SVG elements and keep editable style values inline.
 ```
 
+## Give interactive elements a descriptive name {#give-interactive-elements-a-descriptive-name}
+
+Add a `name` prop to interactive elements and custom interactive components.
+Use a short label that describes the element in the scene, not an empty string.
+
+The name is shown in the Studio timeline and helps agents identify the correct element when making visual edits.
+
+```tsx title="Interactive names"
+// 👍 Easy to find in the Studio timeline and by agents
+<Interactive.Div name="Hero title" style={{fontSize: 80}}>
+  Launch day
+</Interactive.Div>
+
+// 👎 Hard to identify in larger compositions
+<Interactive.Div name="" style={{fontSize: 80}}>
+  Launch day
+</Interactive.Div>
+```
+
+For reusable components, keep `name` overrideable and provide a meaningful fallback:
+
+```tsx title="Custom component name"
+<Sequence name={name ?? '<Badge>'} controls={controls}>
+  <div ref={outlineRef}>New</div>
+</Sequence>
+```
+
 ## Keep editable values visible {#keep-editable-values-visible}
 
 Put values that should be edited in the Studio directly into the JSX.

--- a/packages/skills/skills/remotion/SKILL.md
+++ b/packages/skills/skills/remotion/SKILL.md
@@ -27,6 +27,7 @@ Animate properties using `useCurrentFrame()` and `interpolate()`. Prefer `interp
 
 For animations that should be editable in Remotion Studio, keep the `interpolate()` call inline in the `style` prop and use individual CSS transform properties (`scale`, `translate`, `rotate`) instead of composing a `transform` string.
 To make an element or custom component interactive in Remotion Studio, follow https://www.remotion.dev/docs/studio/make-component-interactive.
+When using `Interactive.*` or custom interactive components, set a descriptive `name` prop such as `name="Hero title"` so the element is identifiable in the Studio timeline and by agents. Do not use `name=""`.
 
 ```tsx
 import { useCurrentFrame, Easing, interpolate, useVideoConfig } from "remotion";


### PR DESCRIPTION
## Summary

- Document that interactive elements should use descriptive `name` props instead of empty strings.
- Add the same guidance to the packaged Remotion best-practices skill.

## Testing

- `bun run build-docs`
- `bun run build`
- `bun run stylecheck`
