### PR TITLE
`docs`: Clarify Mediabunny FPS estimates

### DIFF
--- a/packages/docs/docs/mediabunny/metadata.mdx
+++ b/packages/docs/docs/mediabunny/metadata.mdx
@@ -18,6 +18,21 @@ then [Mediabunny](https://mediabunny.dev) is the ideal library for doing so.
 ```tsx twoslash title="get-media-metadata.ts"
 import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 
+const commonFpsValues = [
+  24000 / 1001,
+  24,
+  25,
+  30000 / 1001,
+  30,
+  50,
+  60000 / 1001,
+  60,
+];
+
+const snapToCommonFps = (fps: number) => {
+  return commonFpsValues.find((commonFps) => Math.abs(fps - commonFps) < 0.01) ?? fps;
+};
+
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
@@ -35,7 +50,9 @@ export const getMediaMetadata = async (src: string) => {
       }
     : null;
   const packetStats = await videoTrack?.computePacketStats(50);
-  const fps = packetStats ? Math.round(packetStats.averagePacketRate) : null;
+  const fps = packetStats
+    ? snapToCommonFps(packetStats.averagePacketRate)
+    : null;
 
   return {
     durationInSeconds,
@@ -52,12 +69,27 @@ export const getMediaMetadata = async (src: string) => {
   <p>By setting `getRetryDelay` to `() => null`, we prevent Mediabunny from infinitely retrying if the request fails.</p>
   <p>We compute the duration, the dimensions and the frame rate. If the media file is an audio file, we return `null` for the dimensions and the frame rate.</p>
   <p>To avoid reading the entire file, we at most read 50 packets to compute the frame rate.</p>
-  <p>The FPS is an estimate based on packet timestamps. We round it because container timestamp rounding can return values such as `29.999` or `30.006` for videos that are nominally 30 FPS.</p>
+  <p>The FPS is an estimate based on packet timestamps. We snap it to common FPS values because container timestamp rounding can return values such as `29.999` or `30.006` for videos that are nominally 30 FPS. Values like `29.97` and `59.94` are represented exactly as `30000 / 1001` and `60000 / 1001`.</p>
 </details>
 
 ```tsx twoslash title="Usage example"
 // @filename: get-media-metadata.ts
 import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
+
+const commonFpsValues = [
+  24000 / 1001,
+  24,
+  25,
+  30000 / 1001,
+  30,
+  50,
+  60000 / 1001,
+  60,
+];
+
+const snapToCommonFps = (fps: number) => {
+  return commonFpsValues.find((commonFps) => Math.abs(fps - commonFps) < 0.01) ?? fps;
+};
 
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
@@ -76,7 +108,9 @@ export const getMediaMetadata = async (src: string) => {
       }
     : null;
   const packetStats = await videoTrack?.computePacketStats(50);
-  const fps = packetStats ? Math.round(packetStats.averagePacketRate) : null;
+  const fps = packetStats
+    ? snapToCommonFps(packetStats.averagePacketRate)
+    : null;
 
   return {
     durationInSeconds,

--- a/packages/docs/docs/mediabunny/metadata.mdx
+++ b/packages/docs/docs/mediabunny/metadata.mdx
@@ -35,7 +35,7 @@ export const getMediaMetadata = async (src: string) => {
       }
     : null;
   const packetStats = await videoTrack?.computePacketStats(50);
-  const fps = packetStats?.averagePacketRate ?? null;
+  const fps = packetStats ? Math.round(packetStats.averagePacketRate) : null;
 
   return {
     durationInSeconds,
@@ -52,6 +52,7 @@ export const getMediaMetadata = async (src: string) => {
   <p>By setting `getRetryDelay` to `() => null`, we prevent Mediabunny from infinitely retrying if the request fails.</p>
   <p>We compute the duration, the dimensions and the frame rate. If the media file is an audio file, we return `null` for the dimensions and the frame rate.</p>
   <p>To avoid reading the entire file, we at most read 50 packets to compute the frame rate.</p>
+  <p>The FPS is an estimate based on packet timestamps. We round it because container timestamp rounding can return values such as `29.999` or `30.006` for videos that are nominally 30 FPS.</p>
 </details>
 
 ```tsx twoslash title="Usage example"
@@ -75,7 +76,7 @@ export const getMediaMetadata = async (src: string) => {
       }
     : null;
   const packetStats = await videoTrack?.computePacketStats(50);
-  const fps = packetStats?.averagePacketRate ?? null;
+  const fps = packetStats ? Math.round(packetStats.averagePacketRate) : null;
 
   return {
     durationInSeconds,


### PR DESCRIPTION
## Summary
- Snap estimated Mediabunny FPS values in the metadata docs example to common frame rates
- Clarify that packet timestamp rounding can produce near-integer values such as `29.999` or `30.006`
- Preserve exact NTSC-style rates such as `30000 / 1001` and `60000 / 1001`

## Testing
- `cd packages/docs && bun run format`
