### PR TITLE
`@remotion/studio`: Add canvas snapping for outlines

### DIFF
--- a/packages/studio/src/components/EditorContexts.tsx
+++ b/packages/studio/src/components/EditorContexts.tsx
@@ -18,6 +18,7 @@ import {SetTimelineInOutProvider} from './SetTimelineInOutProvider';
 import {ShowGuidesProvider} from './ShowGuidesProvider';
 import {ShowOutlinesProvider} from './ShowOutlinesProvider';
 import {ShowRulersProvider} from './ShowRulersProvider';
+import {SnappingProvider} from './SnappingProvider';
 import {VisualControlsUndoSync} from './VisualControls/VisualControlsUndoSync';
 import {ZoomGesturesProvider} from './ZoomGesturesProvider';
 
@@ -38,27 +39,29 @@ export const EditorContexts: React.FC<{
 									<ShowRulersProvider>
 										<ShowGuidesProvider>
 											<ShowOutlinesProvider>
-												<PreviewSizeProvider>
-													<ModalsProvider>
-														<MediaVolumeProvider>
-															<PlayerInternals.PlayerEmitterProvider
-																currentPlaybackRate={null}
-															>
-																<SidebarContextProvider>
-																	<FolderContextProvider>
-																		<HighestZIndexProvider>
-																			<SetTimelineInOutProvider>
-																				<ExpandedTracksProvider>
-																					{children}
-																				</ExpandedTracksProvider>
-																			</SetTimelineInOutProvider>
-																		</HighestZIndexProvider>
-																	</FolderContextProvider>
-																</SidebarContextProvider>
-															</PlayerInternals.PlayerEmitterProvider>
-														</MediaVolumeProvider>
-													</ModalsProvider>
-												</PreviewSizeProvider>
+												<SnappingProvider>
+													<PreviewSizeProvider>
+														<ModalsProvider>
+															<MediaVolumeProvider>
+																<PlayerInternals.PlayerEmitterProvider
+																	currentPlaybackRate={null}
+																>
+																	<SidebarContextProvider>
+																		<FolderContextProvider>
+																			<HighestZIndexProvider>
+																				<SetTimelineInOutProvider>
+																					<ExpandedTracksProvider>
+																						{children}
+																					</ExpandedTracksProvider>
+																				</SetTimelineInOutProvider>
+																			</HighestZIndexProvider>
+																		</FolderContextProvider>
+																	</SidebarContextProvider>
+																</PlayerInternals.PlayerEmitterProvider>
+															</MediaVolumeProvider>
+														</ModalsProvider>
+													</PreviewSizeProvider>
+												</SnappingProvider>
 											</ShowOutlinesProvider>
 										</ShowGuidesProvider>
 									</ShowRulersProvider>

--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -7,6 +7,7 @@ import {SHOW_BROWSER_RENDERING} from '../helpers/show-browser-rendering';
 import {timelineNodePathInfoToKey} from '../helpers/timeline-node-path-key';
 import {useKeybinding} from '../helpers/use-keybinding';
 import {CheckerboardContext} from '../state/checkerboard';
+import {EditorSnappingContext} from '../state/editor-snapping';
 import {ModalsContext} from '../state/modals';
 import {askAiModalRef} from './AskAiModal';
 import {useCompositionNavigation} from './CompositionSelector';
@@ -32,6 +33,7 @@ export const GlobalKeybindings: React.FC<{
 	const keybindings = useKeybinding();
 	const {setSelectedModal} = useContext(ModalsContext);
 	const {setCheckerboard} = useContext(CheckerboardContext);
+	const {setEditorSnapping} = useContext(EditorSnappingContext);
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 	const {sequences} = useContext(Internals.SequenceManager);
 	const videoConfig = Internals.useUnsafeVideoConfig();
@@ -234,6 +236,23 @@ export const GlobalKeybindings: React.FC<{
 			keepRegisteredWhenNotHighestContext: false,
 		});
 
+		const shiftMKey = keybindings.registerKeybinding({
+			event: 'keydown',
+			key: 'm',
+			callback: (event) => {
+				if (!event.shiftKey) {
+					return;
+				}
+
+				setEditorSnapping((current) => !current);
+				event.preventDefault();
+			},
+			commandCtrlKey: false,
+			preventDefault: false,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+
 		return () => {
 			for (const sequencePropKey of sequencePropKeys) {
 				sequencePropKey.unregister();
@@ -245,12 +264,14 @@ export const GlobalKeybindings: React.FC<{
 			cmdIKey?.unregister();
 			pageDown.unregister();
 			pageUp.unregister();
+			shiftMKey.unregister();
 		};
 	}, [
 		keybindings,
 		openRenderModal,
 		selectSequenceProp,
 		setCheckerboard,
+		setEditorSnapping,
 		setSelectedModal,
 		navigateToNextComposition,
 		navigateToPreviousComposition,

--- a/packages/studio/src/components/KeyboardShortcutsExplainer.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsExplainer.tsx
@@ -209,6 +209,16 @@ export const KeyboardShortcutsExplainer: React.FC = () => {
 						</div>
 						<div style={right}>Exit fullscreen</div>
 					</Row>
+					<Row align="center">
+						<div style={left}>
+							<kbd style={key}>
+								<ShiftIcon />
+							</kbd>
+							<Spacing x={0.3} />
+							<kbd style={key}>M</kbd>
+						</div>
+						<div style={right}>Enable snapping</div>
+					</Row>
 				</Column>
 				<Spacing x={8} />
 				<Column>

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -239,6 +239,8 @@ const CompWhenItHasDimensions: React.FC<{
 				yCorrection={yCorrection}
 			/>
 			<SelectedOutlineOverlay
+				compositionHeight={(contentDimensions as Dimensions).height}
+				compositionWidth={(contentDimensions as Dimensions).width}
 				scale={scale}
 				translationX={previewSize.translation.x}
 				translationY={previewSize.translation.y}

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -32,6 +32,7 @@ import {PlaybackRateSelector} from './PlaybackRateSelector';
 import {PlayPause} from './PlayPause';
 import {RenderButton} from './RenderButton';
 import {SizeSelector} from './SizeSelector';
+import {SnappingToggle} from './SnappingToggle';
 import {TimelineZoomControls} from './Timeline/TimelineZoomControls';
 import {TimelineInOutPointToggle} from './TimelineInOutToggle';
 
@@ -261,6 +262,9 @@ export const PreviewToolbar: React.FC<{
 					</PreviewToolbarControl>
 					<PreviewToolbarControl>
 						<OutlineToggle />
+					</PreviewToolbarControl>
+					<PreviewToolbarControl>
+						<SnappingToggle />
 					</PreviewToolbarControl>
 				</>
 			) : null}

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -12,6 +12,7 @@ import {
 } from '../helpers/colors';
 import {formatFileLocation} from '../helpers/format-file-location';
 import {openOriginalPositionInEditor} from '../helpers/open-in-editor';
+import {EditorSnappingContext} from '../state/editor-snapping';
 import {ModalsContext} from '../state/modals';
 import {callApi} from './call-api';
 import {useConfirmationDialog} from './ConfirmationDialog';
@@ -128,6 +129,7 @@ export const SelectedOutlineTransformOriginHandle: React.FC<{
 	const {setDragOverrides, clearDragOverrides, setPropStatuses} = useContext(
 		Internals.VisualModeSettersContext,
 	);
+	const {editorSnapping} = useContext(EditorSnappingContext);
 	const transformOriginDrag = target?.transformOriginDrag ?? null;
 
 	const parsed = useMemo(
@@ -232,11 +234,13 @@ export const SelectedOutlineTransformOriginHandle: React.FC<{
 					lockedAxis === null
 						? point
 						: getUvHandlePosition(outline.points, axisLockedUv);
-				const snappedUv = snapSelectedOutlineTransformOriginUv({
-					point: snapPoint,
-					points: outline.points,
-					uv: axisLockedUv,
-				});
+				const snappedUv = editorSnapping
+					? snapSelectedOutlineTransformOriginUv({
+							point: snapPoint,
+							points: outline.points,
+							uv: axisLockedUv,
+						})
+					: axisLockedUv;
 				const nextUv = applySelectedOutlineTransformOriginAxisLock({
 					lockedAxis,
 					startUv: uv,
@@ -415,6 +419,7 @@ export const SelectedOutlineTransformOriginHandle: React.FC<{
 		},
 		[
 			clearDragOverrides,
+			editorSnapping,
 			onDraggingChange,
 			outline,
 			parsed,
@@ -519,6 +524,7 @@ const SelectedOutlinePolygon: React.FC<{
 	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
+	const {editorSnapping} = useContext(EditorSnappingContext);
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const timelinePositionRef = useRef(timelinePosition);
 	timelinePositionRef.current = timelinePosition;
@@ -570,7 +576,7 @@ const SelectedOutlinePolygon: React.FC<{
 			let currentPointerY = startPointerY;
 			let axisLocked = false;
 			let dragStarted = false;
-			let snappingDisabled = event.ctrlKey;
+			let snappingDisabled = event.metaKey || event.ctrlKey;
 
 			const updateDragOverrides = () => {
 				const screenDeltaX = currentPointerX - startPointerX;
@@ -601,7 +607,7 @@ const SelectedOutlinePolygon: React.FC<{
 				});
 				let {deltaX, deltaY} = dragDelta;
 
-				if (!snappingDisabled) {
+				if (editorSnapping && !snappingDisabled) {
 					const snapResult = findSelectedOutlineSnap({
 						allowX: axisLockedDirection !== 'vertical',
 						allowY: axisLockedDirection !== 'horizontal',
@@ -661,7 +667,7 @@ const SelectedOutlinePolygon: React.FC<{
 				currentPointerX = moveEvent.clientX;
 				currentPointerY = moveEvent.clientY;
 				axisLocked = moveEvent.shiftKey;
-				snappingDisabled = moveEvent.ctrlKey;
+				snappingDisabled = moveEvent.metaKey || moveEvent.ctrlKey;
 				updateDragOverrides();
 			};
 
@@ -761,6 +767,7 @@ const SelectedOutlinePolygon: React.FC<{
 			allDragOutlines,
 			clearDragOverrides,
 			drag,
+			editorSnapping,
 			getDragOverrides,
 			onDraggingChange,
 			onSelect,
@@ -1192,6 +1199,7 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
 		Internals.VisualModeSettersContext,
 	);
+	const {editorSnapping} = useContext(EditorSnappingContext);
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const timelinePositionRef = useRef(timelinePosition);
 	timelinePositionRef.current = timelinePosition;
@@ -1259,12 +1267,13 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 			let dragStarted = false;
 
 			const updateRotationDragOverrides = () => {
-				const rotationDeltaDegrees = rotationLocked
-					? snapSelectedOutlineRotationDeltaDegrees({
-							dragStates,
-							rotationDeltaDegrees: accumulatedDelta,
-						})
-					: accumulatedDelta;
+				const rotationDeltaDegrees =
+					rotationLocked && editorSnapping
+						? snapSelectedOutlineRotationDeltaDegrees({
+								dragStates,
+								rotationDeltaDegrees: accumulatedDelta,
+							})
+						: accumulatedDelta;
 				lastValues = getSelectedOutlineRotationDragValues({
 					dragStates,
 					rotationDeltaDegrees,
@@ -1434,6 +1443,7 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 			allRotationDragTargets,
 			clearDragOverrides,
 			cornerInfo,
+			editorSnapping,
 			getDragOverrides,
 			onDraggingChange,
 			outline.dimensions,

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -69,6 +69,11 @@ import {
 	type SelectedOutlineRotationCorner,
 } from './selected-outline-measurement';
 import {
+	findSelectedOutlineSnap,
+	type SelectedOutlineSnapPoint,
+	type SelectedOutlineSnapTarget,
+} from './selected-outline-snap';
+import {
 	rotateFieldKey,
 	scaleFieldKey,
 	transformOriginFieldKey,
@@ -472,6 +477,7 @@ export const SelectedOutlineTransformOriginHandle: React.FC<{
 
 const SelectedOutlinePolygon: React.FC<{
 	readonly allDragTargets: readonly SelectedOutlineDragTarget[];
+	readonly allDragOutlines: readonly SelectedOutline[];
 	readonly contextMenuValues: readonly ComboboxValue[];
 	readonly dragging: boolean;
 	readonly hovered: boolean;
@@ -479,15 +485,20 @@ const SelectedOutlinePolygon: React.FC<{
 	readonly outline: SelectedOutline;
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onHoverChange: (key: string | null) => void;
+	readonly onSnapPointsChange: (
+		snapPoints: readonly SelectedOutlineSnapPoint[],
+	) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
 		interaction: TimelineSelectionInteraction,
 	) => void;
 	readonly onTextEditStart: (target: SelectedOutlineTarget) => void;
 	readonly scale: number;
+	readonly snapTargets: readonly SelectedOutlineSnapTarget[];
 	readonly target: SelectedOutlineTarget | undefined;
 }> = ({
 	allDragTargets,
+	allDragOutlines,
 	contextMenuValues,
 	dragging,
 	hovered,
@@ -495,9 +506,11 @@ const SelectedOutlinePolygon: React.FC<{
 	outline,
 	onDraggingChange,
 	onHoverChange,
+	onSnapPointsChange,
 	onSelect,
 	onTextEditStart,
 	scale,
+	snapTargets,
 	target,
 }) => {
 	const {getDragOverrides} = useContext(
@@ -557,6 +570,7 @@ const SelectedOutlinePolygon: React.FC<{
 			let currentPointerY = startPointerY;
 			let axisLocked = false;
 			let dragStarted = false;
+			let snappingDisabled = event.ctrlKey;
 
 			const updateDragOverrides = () => {
 				const screenDeltaX = currentPointerX - startPointerX;
@@ -575,16 +589,46 @@ const SelectedOutlinePolygon: React.FC<{
 					onDraggingChange(true);
 				}
 
+				const axisLockedDirection = axisLocked
+					? Math.abs(screenDeltaX) >= Math.abs(screenDeltaY)
+						? 'horizontal'
+						: 'vertical'
+					: null;
 				const dragDelta = applySelectedOutlineDragAxisLock({
 					deltaX: screenDeltaX / scale,
 					deltaY: screenDeltaY / scale,
 					axisLocked,
 				});
+				let {deltaX, deltaY} = dragDelta;
+
+				if (!snappingDisabled) {
+					const snapResult = findSelectedOutlineSnap({
+						allowX: axisLockedDirection !== 'vertical',
+						allowY: axisLockedDirection !== 'horizontal',
+						deltaX,
+						deltaY,
+						outlines: selected ? allDragOutlines : [outline],
+						scale,
+						targets: snapTargets,
+					});
+
+					if (snapResult.snapOffsetX !== null) {
+						deltaX += snapResult.snapOffsetX;
+					}
+
+					if (snapResult.snapOffsetY !== null) {
+						deltaY += snapResult.snapOffsetY;
+					}
+
+					onSnapPointsChange(snapResult.activeSnapPoints);
+				} else {
+					onSnapPointsChange([]);
+				}
 
 				lastValues = getSelectedOutlineDragValues({
 					dragStates,
-					deltaX: dragDelta.deltaX,
-					deltaY: dragDelta.deltaY,
+					deltaX,
+					deltaY,
 				});
 				for (const dragState of dragStates) {
 					const value = lastValues.get(dragState.key);
@@ -617,6 +661,7 @@ const SelectedOutlinePolygon: React.FC<{
 				currentPointerX = moveEvent.clientX;
 				currentPointerY = moveEvent.clientY;
 				axisLocked = moveEvent.shiftKey;
+				snappingDisabled = moveEvent.ctrlKey;
 				updateDragOverrides();
 			};
 
@@ -713,15 +758,19 @@ const SelectedOutlinePolygon: React.FC<{
 		},
 		[
 			allDragTargets,
+			allDragOutlines,
 			clearDragOverrides,
 			drag,
 			getDragOverrides,
 			onDraggingChange,
 			onSelect,
+			onSnapPointsChange,
+			outline,
 			scale,
 			selected,
 			setPropStatuses,
 			setDragOverrides,
+			snapTargets,
 			target,
 		],
 	);
@@ -1437,6 +1486,7 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 
 export const SelectedOutlineElement: React.FC<{
 	readonly allDragTargets: readonly SelectedOutlineDragTarget[];
+	readonly allDragOutlines: readonly SelectedOutline[];
 	readonly allRotationDragTargets: readonly SelectedOutlineRotationDragTarget[];
 	readonly allScaleDragTargets: readonly SelectedOutlineScaleDragTarget[];
 	readonly dragging: boolean;
@@ -1444,14 +1494,19 @@ export const SelectedOutlineElement: React.FC<{
 	readonly outline: SelectedOutline;
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onHoverChange: (key: string | null) => void;
+	readonly onSnapPointsChange: (
+		snapPoints: readonly SelectedOutlineSnapPoint[],
+	) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
 		interaction: TimelineSelectionInteraction,
 	) => void;
 	readonly scale: number;
+	readonly snapTargets: readonly SelectedOutlineSnapTarget[];
 	readonly target: SelectedOutlineTarget | undefined;
 }> = ({
 	allDragTargets,
+	allDragOutlines,
 	allRotationDragTargets,
 	allScaleDragTargets,
 	dragging,
@@ -1459,8 +1514,10 @@ export const SelectedOutlineElement: React.FC<{
 	outline,
 	onDraggingChange,
 	onHoverChange,
+	onSnapPointsChange,
 	onSelect,
 	scale,
+	snapTargets,
 	target,
 }) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
@@ -1688,6 +1745,7 @@ export const SelectedOutlineElement: React.FC<{
 		<>
 			<SelectedOutlinePolygon
 				allDragTargets={allDragTargets}
+				allDragOutlines={allDragOutlines}
 				contextMenuValues={emptyContextMenuValues}
 				dragging={dragging}
 				hovered={hovered}
@@ -1695,9 +1753,11 @@ export const SelectedOutlineElement: React.FC<{
 				onContextMenuOpen={onContextMenuOpen}
 				onDraggingChange={onDraggingChange}
 				onHoverChange={onHoverChange}
+				onSnapPointsChange={onSnapPointsChange}
 				onSelect={onSelect}
 				onTextEditStart={onTextEditStart}
 				scale={scale}
+				snapTargets={snapTargets}
 				target={target}
 			/>
 			{target?.containsSelection || hovered

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -12,6 +12,7 @@ import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {useKeybinding} from '../helpers/use-keybinding';
+import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ScaleLockContext} from '../state/scale-lock';
 import {showNotification} from './Notifications/NotificationCenter';
@@ -37,6 +38,11 @@ import {
 	measureOutlines,
 	outlinesAreEqual,
 } from './selected-outline-measurement';
+import {
+	getSelectedOutlineSnapTargets,
+	selectedOutlineSnapIndicatorColor,
+	type SelectedOutlineSnapPoint,
+} from './selected-outline-snap';
 import {
 	rotateFieldKey,
 	scaleFieldKey,
@@ -112,6 +118,53 @@ const outlineContainer: React.CSSProperties = {
 	overflow: 'visible',
 };
 
+const SelectedOutlineSnapIndicators: React.FC<{
+	readonly activeSnapPoints: readonly SelectedOutlineSnapPoint[];
+	readonly compositionHeight: number;
+	readonly compositionWidth: number;
+	readonly scale: number;
+}> = ({activeSnapPoints, compositionHeight, compositionWidth, scale}) => {
+	if (activeSnapPoints.length === 0) {
+		return null;
+	}
+
+	return (
+		<g pointerEvents="none">
+			{activeSnapPoints.map((snapPoint) => {
+				if (snapPoint.target.axis === 'x') {
+					const x = snapPoint.target.position * scale;
+					return (
+						<line
+							key={`${snapPoint.target.axis}-${snapPoint.target.type}-${snapPoint.target.position}-${snapPoint.edge}`}
+							x1={x}
+							x2={x}
+							y1={0}
+							y2={compositionHeight * scale}
+							stroke={selectedOutlineSnapIndicatorColor}
+							strokeWidth={1}
+							vectorEffect="non-scaling-stroke"
+						/>
+					);
+				}
+
+				const y = snapPoint.target.position * scale;
+				return (
+					<line
+						key={`${snapPoint.target.axis}-${snapPoint.target.type}-${snapPoint.target.position}-${snapPoint.edge}`}
+						x1={0}
+						x2={compositionWidth * scale}
+						y1={y}
+						y2={y}
+						stroke={selectedOutlineSnapIndicatorColor}
+						strokeWidth={1}
+						vectorEffect="non-scaling-stroke"
+					/>
+				);
+			})}
+		</g>
+	);
+};
+
 export const orderOutlinesForRendering = ({
 	outlines,
 	targetsByKey,
@@ -128,12 +181,21 @@ export const orderOutlinesForRendering = ({
 };
 
 export const SelectedOutlineOverlay: React.FC<{
+	readonly compositionHeight: number;
+	readonly compositionWidth: number;
 	readonly scale: number;
 	readonly translationX: number;
 	readonly translationY: number;
-}> = ({scale, translationX, translationY}) => {
+}> = ({
+	compositionHeight,
+	compositionWidth,
+	scale,
+	translationX,
+	translationY,
+}) => {
 	const {selectedItems, selectItem} = useTimelineSelection();
 	const {sequences} = useContext(Internals.SequenceManager);
+	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {overrideIdToNodePathMappings} = useContext(
@@ -147,6 +209,7 @@ export const SelectedOutlineOverlay: React.FC<{
 	);
 	const {getScaleLockState} = useContext(ScaleLockContext);
 	const {editorShowOutlines} = useContext(EditorShowOutlinesContext);
+	const {editorShowGuides, guidesList} = useContext(EditorShowGuidesContext);
 	const {frameBack, frameForward, getCurrentFrame, seek} =
 		PlayerInternals.usePlayer();
 	const keybindings = useKeybinding();
@@ -156,6 +219,9 @@ export const SelectedOutlineOverlay: React.FC<{
 		null,
 	);
 	const [draggingOutline, setDraggingOutline] = useState(false);
+	const [activeSnapPoints, setActiveSnapPoints] = useState<
+		readonly SelectedOutlineSnapPoint[]
+	>([]);
 	const overlayRef = useRef<SVGSVGElement>(null);
 	const keyboardNudgeSessionRef =
 		useRef<SelectedOutlineKeyboardNudgeSession | null>(null);
@@ -165,8 +231,16 @@ export const SelectedOutlineOverlay: React.FC<{
 		setDraggingOutline(dragging);
 		if (dragging) {
 			setHoveredOutlineKey(null);
+		} else {
+			setActiveSnapPoints([]);
 		}
 	}, []);
+	const onSnapPointsChange = useCallback(
+		(snapPoints: readonly SelectedOutlineSnapPoint[]) => {
+			setActiveSnapPoints(snapPoints);
+		},
+		[],
+	);
 	const selectOutlineItem = useCallback(
 		(item: TimelineSelection, interaction?: TimelineSelectionInteraction) => {
 			selectItem(item, interaction, undefined, {reveal: true});
@@ -477,6 +551,9 @@ export const SelectedOutlineOverlay: React.FC<{
 	const outlinesForRendering = useMemo(() => {
 		return orderOutlinesForRendering({outlines, targetsByKey});
 	}, [outlines, targetsByKey]);
+	const outlinesByKey = useMemo(() => {
+		return new Map(outlines.map((outline) => [outline.key, outline]));
+	}, [outlines]);
 	const allDragTargets = useMemo(() => {
 		return outlineTargets.flatMap((target) =>
 			(target.selected || target.containsSelection) && target.drag !== null
@@ -484,6 +561,19 @@ export const SelectedOutlineOverlay: React.FC<{
 				: [],
 		);
 	}, [outlineTargets]);
+	const allDragOutlines = useMemo(() => {
+		return outlineTargets.flatMap((target) => {
+			if (
+				(!target.selected && !target.containsSelection) ||
+				target.drag === null
+			) {
+				return [];
+			}
+
+			const outline = outlinesByKey.get(target.key);
+			return outline === undefined ? [] : [outline];
+		});
+	}, [outlineTargets, outlinesByKey]);
 	const allScaleDragTargets = useMemo(() => {
 		return outlineTargets.flatMap((target) =>
 			target.selected && target.scaleDrag !== null ? [target.scaleDrag] : [],
@@ -496,6 +586,22 @@ export const SelectedOutlineOverlay: React.FC<{
 				: [],
 		);
 	}, [outlineTargets]);
+	const guidesForSnap = useMemo(() => {
+		if (!editorShowGuides || canvasContent?.type !== 'composition') {
+			return [];
+		}
+
+		return guidesList.filter(
+			(guide) => guide.compositionId === canvasContent.compositionId,
+		);
+	}, [canvasContent, editorShowGuides, guidesList]);
+	const snapTargets = useMemo(() => {
+		return getSelectedOutlineSnapTargets({
+			compositionHeight,
+			compositionWidth,
+			guides: guidesForSnap,
+		});
+	}, [compositionHeight, compositionWidth, guidesForSnap]);
 
 	const saveKeyboardNudgeSession = useCallback(() => {
 		const session = keyboardNudgeSessionRef.current;
@@ -858,10 +964,17 @@ export const SelectedOutlineOverlay: React.FC<{
 			height="100%"
 			aria-hidden="true"
 		>
+			<SelectedOutlineSnapIndicators
+				activeSnapPoints={activeSnapPoints}
+				compositionHeight={compositionHeight}
+				compositionWidth={compositionWidth}
+				scale={scale}
+			/>
 			{outlinesForRendering.map((outline) => (
 				<SelectedOutlineElement
 					key={outline.key}
 					allDragTargets={allDragTargets}
+					allDragOutlines={allDragOutlines}
 					allRotationDragTargets={allRotationDragTargets}
 					allScaleDragTargets={allScaleDragTargets}
 					dragging={draggingOutline}
@@ -869,8 +982,10 @@ export const SelectedOutlineOverlay: React.FC<{
 					outline={outline}
 					onDraggingChange={onDraggingChange}
 					onHoverChange={setHoveredOutlineKey}
+					onSnapPointsChange={onSnapPointsChange}
 					onSelect={selectOutlineItem}
 					scale={scale}
+					snapTargets={snapTargets}
 					target={targetsByKey.get(outline.key)}
 				/>
 			))}

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -2,6 +2,7 @@ import React, {useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {BLUE, SELECTED_OUTLINE_UV_DROP_SHADOW, WHITE} from '../helpers/colors';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+import {EditorSnappingContext} from '../state/editor-snapping';
 import {
 	forceSpecificCursor,
 	stopForcingSpecificCursor,
@@ -624,6 +625,7 @@ const SelectedUvEllipseRotationHandle: React.FC<{
 }> = ({control, onDraggingChange}) => {
 	const {setEffectDragOverrides, clearEffectDragOverrides, setPropStatuses} =
 		useContext(Internals.VisualModeSettersContext);
+	const {editorSnapping} = useContext(EditorSnappingContext);
 	const {rotationControl} = control;
 	const field = rotationControl?.field;
 
@@ -660,9 +662,10 @@ const SelectedUvEllipseRotationHandle: React.FC<{
 
 			const updateRotationDragOverride = () => {
 				const rawValue = control.rotation + accumulatedDelta;
-				const snappedValue = rotationLocked
-					? snapRotationDegrees(rawValue)
-					: rawValue;
+				const snappedValue =
+					rotationLocked && editorSnapping
+						? snapRotationDegrees(rawValue)
+						: rawValue;
 				const nextValue = roundNumericUvEllipseValue(
 					snappedValue,
 					field.fieldSchema,
@@ -764,6 +767,7 @@ const SelectedUvEllipseRotationHandle: React.FC<{
 		[
 			clearEffectDragOverrides,
 			control,
+			editorSnapping,
 			field,
 			onDraggingChange,
 			rotationControl,
@@ -831,6 +835,7 @@ const SelectedUvHandleCircle: React.FC<{
 }> = ({handle, nodePathInfo, onDraggingChange, onSelect, outline}) => {
 	const {setEffectDragOverrides, clearEffectDragOverrides, setPropStatuses} =
 		useContext(Internals.VisualModeSettersContext);
+	const {editorSnapping} = useContext(EditorSnappingContext);
 	const position = useMemo(
 		() => getUvHandlePosition(outline.points, handle.value),
 		[handle.value, outline.points],
@@ -882,11 +887,13 @@ const SelectedUvHandleCircle: React.FC<{
 					rect: svgRect,
 				});
 				const rawUv = getUvCoordinateForPoint(outline.points, point);
-				const snappedUv = snapSelectedOutlineUv({
-					point,
-					points: outline.points,
-					uv: rawUv,
-				});
+				const snappedUv = editorSnapping
+					? snapSelectedOutlineUv({
+							point,
+							points: outline.points,
+							uv: rawUv,
+						})
+					: rawUv;
 				const nextValue = roundUvCoordinate(
 					constrainUv(snappedUv, handle.fieldSchema),
 					handle.fieldSchema,
@@ -996,6 +1003,7 @@ const SelectedUvHandleCircle: React.FC<{
 		},
 		[
 			clearEffectDragOverrides,
+			editorSnapping,
 			handle,
 			nodePathInfo,
 			onDraggingChange,

--- a/packages/studio/src/components/SnappingProvider.tsx
+++ b/packages/studio/src/components/SnappingProvider.tsx
@@ -1,0 +1,38 @@
+import React, {useCallback, useMemo, useState} from 'react';
+import {
+	EditorSnappingContext,
+	loadEditorSnappingOption,
+	persistEditorSnappingOption,
+} from '../state/editor-snapping';
+
+export const SnappingProvider: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	const [editorSnapping, setEditorSnappingState] = useState(() =>
+		loadEditorSnappingOption(),
+	);
+
+	const setEditorSnapping = useCallback(
+		(newValue: (prevState: boolean) => boolean) => {
+			setEditorSnappingState((prevState) => {
+				const newVal = newValue(prevState);
+				persistEditorSnappingOption(newVal);
+				return newVal;
+			});
+		},
+		[],
+	);
+
+	const editorSnappingCtx = useMemo(() => {
+		return {
+			editorSnapping,
+			setEditorSnapping,
+		};
+	}, [editorSnapping, setEditorSnapping]);
+
+	return (
+		<EditorSnappingContext.Provider value={editorSnappingCtx}>
+			{children}
+		</EditorSnappingContext.Provider>
+	);
+};

--- a/packages/studio/src/components/SnappingToggle.tsx
+++ b/packages/studio/src/components/SnappingToggle.tsx
@@ -1,0 +1,40 @@
+import React, {useCallback, useContext} from 'react';
+import {NoReactInternals} from 'remotion/no-react';
+import {BLUE, WHITE} from '../helpers/colors';
+import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {MagnetIcon} from '../icons/magnet';
+import {EditorSnappingContext} from '../state/editor-snapping';
+import {ControlButton} from './ControlButton';
+
+export const SnappingToggle: React.FC = () => {
+	const {editorSnapping, setEditorSnapping} = useContext(EditorSnappingContext);
+
+	const onClick = useCallback(() => {
+		setEditorSnapping((current) => !current);
+	}, [setEditorSnapping]);
+
+	const color = editorSnapping ? BLUE : WHITE;
+	const accessibilityLabel = [
+		editorSnapping ? 'Disable snapping' : 'Enable snapping',
+		areKeyboardShortcutsDisabled() ? null : '(Shift+M)',
+	]
+		.filter(NoReactInternals.truthy)
+		.join(' ');
+
+	return (
+		<ControlButton
+			title={accessibilityLabel}
+			aria-label={accessibilityLabel}
+			aria-pressed={editorSnapping}
+			aria-keyshortcuts="Shift+M"
+			onClick={onClick}
+		>
+			<MagnetIcon
+				style={{width: 17, height: 17}}
+				fill={color}
+				aria-hidden="true"
+				focusable="false"
+			/>
+		</ControlButton>
+	);
+};

--- a/packages/studio/src/components/selected-outline-snap.ts
+++ b/packages/studio/src/components/selected-outline-snap.ts
@@ -1,0 +1,282 @@
+import type {Guide} from '../state/editor-guides';
+import type {SelectedOutline} from './selected-outline-geometry';
+
+export const selectedOutlineSnapThresholdPx = 10;
+export const selectedOutlineSnapIndicatorColor = '#ff00ff';
+
+export type SelectedOutlineSnapAxis = 'x' | 'y';
+
+export type SelectedOutlineSnapTargetType =
+	| 'canvas-left'
+	| 'canvas-right'
+	| 'canvas-top'
+	| 'canvas-bottom'
+	| 'canvas-horizontal-center'
+	| 'canvas-vertical-center'
+	| 'guide-vertical'
+	| 'guide-horizontal';
+
+export type SelectedOutlineSnapTarget = {
+	readonly axis: SelectedOutlineSnapAxis;
+	readonly position: number;
+	readonly type: SelectedOutlineSnapTargetType;
+};
+
+export type SelectedOutlineSnapEdge =
+	| 'left'
+	| 'right'
+	| 'center-x'
+	| 'top'
+	| 'bottom'
+	| 'center-y';
+
+export type SelectedOutlineSnapPoint = {
+	readonly distance: number;
+	readonly edge: SelectedOutlineSnapEdge;
+	readonly target: SelectedOutlineSnapTarget;
+};
+
+export type SelectedOutlineSnapResult = {
+	readonly activeSnapPoints: readonly SelectedOutlineSnapPoint[];
+	readonly snapOffsetX: number | null;
+	readonly snapOffsetY: number | null;
+};
+
+type SelectedOutlineBounds = {
+	readonly left: number;
+	readonly right: number;
+	readonly top: number;
+	readonly bottom: number;
+	readonly centerX: number;
+	readonly centerY: number;
+};
+
+type EdgeCheck = {
+	readonly edge: SelectedOutlineSnapEdge;
+	readonly position: number;
+};
+
+const EPSILON = 0.000001;
+
+export const getSelectedOutlineSnapTargets = ({
+	compositionHeight,
+	compositionWidth,
+	guides,
+}: {
+	readonly compositionHeight: number;
+	readonly compositionWidth: number;
+	readonly guides: readonly Guide[];
+}): readonly SelectedOutlineSnapTarget[] => {
+	return [
+		{axis: 'x', position: 0, type: 'canvas-left'},
+		{
+			axis: 'x',
+			position: compositionWidth / 2,
+			type: 'canvas-horizontal-center',
+		},
+		{axis: 'x', position: compositionWidth, type: 'canvas-right'},
+		{axis: 'y', position: 0, type: 'canvas-top'},
+		{
+			axis: 'y',
+			position: compositionHeight / 2,
+			type: 'canvas-vertical-center',
+		},
+		{axis: 'y', position: compositionHeight, type: 'canvas-bottom'},
+		...guides.flatMap((guide): SelectedOutlineSnapTarget[] => {
+			if (!guide.show) {
+				return [];
+			}
+
+			return [
+				guide.orientation === 'vertical'
+					? {
+							axis: 'x',
+							position: guide.position,
+							type: 'guide-vertical',
+						}
+					: {
+							axis: 'y',
+							position: guide.position,
+							type: 'guide-horizontal',
+						},
+			];
+		}),
+	];
+};
+
+const getSelectedOutlineBounds = ({
+	deltaX,
+	deltaY,
+	outlines,
+	scale,
+}: {
+	readonly deltaX: number;
+	readonly deltaY: number;
+	readonly outlines: readonly SelectedOutline[];
+	readonly scale: number;
+}): SelectedOutlineBounds | null => {
+	if (outlines.length === 0) {
+		return null;
+	}
+
+	const points = outlines.flatMap((outline) => outline.points);
+	const left = Math.min(...points.map((point) => point.x)) / scale + deltaX;
+	const right = Math.max(...points.map((point) => point.x)) / scale + deltaX;
+	const top = Math.min(...points.map((point) => point.y)) / scale + deltaY;
+	const bottom = Math.max(...points.map((point) => point.y)) / scale + deltaY;
+
+	return {
+		left,
+		right,
+		top,
+		bottom,
+		centerX: left + (right - left) / 2,
+		centerY: top + (bottom - top) / 2,
+	};
+};
+
+const canSnapEdgeToTarget = (
+	edge: SelectedOutlineSnapEdge,
+	target: SelectedOutlineSnapTarget,
+): boolean => {
+	if (target.type === 'canvas-horizontal-center') {
+		return edge === 'center-x';
+	}
+
+	if (target.type === 'canvas-vertical-center') {
+		return edge === 'center-y';
+	}
+
+	if (target.type === 'canvas-left' || target.type === 'canvas-right') {
+		return edge === 'left' || edge === 'right';
+	}
+
+	if (target.type === 'guide-vertical') {
+		return edge === 'left' || edge === 'right' || edge === 'center-x';
+	}
+
+	if (target.type === 'canvas-top' || target.type === 'canvas-bottom') {
+		return edge === 'top' || edge === 'bottom';
+	}
+
+	return edge === 'top' || edge === 'bottom' || edge === 'center-y';
+};
+
+const findBestSnapForAxis = ({
+	edges,
+	targets,
+	threshold,
+}: {
+	readonly edges: readonly EdgeCheck[];
+	readonly targets: readonly SelectedOutlineSnapTarget[];
+	readonly threshold: number;
+}): {
+	readonly offset: number;
+	readonly snapPoint: SelectedOutlineSnapPoint;
+} | null => {
+	let bestDistance = Infinity;
+	let bestSnaps: {
+		readonly offset: number;
+		readonly snapPoint: SelectedOutlineSnapPoint;
+	}[] = [];
+
+	for (const target of targets) {
+		for (const edge of edges) {
+			if (!canSnapEdgeToTarget(edge.edge, target)) {
+				continue;
+			}
+
+			const distance = Math.abs(edge.position - target.position);
+			if (distance > threshold || distance > bestDistance + EPSILON) {
+				continue;
+			}
+
+			if (distance < bestDistance - EPSILON) {
+				bestSnaps = [];
+				bestDistance = distance;
+			}
+
+			bestSnaps.push({
+				offset: target.position - edge.position,
+				snapPoint: {
+					distance,
+					edge: edge.edge,
+					target,
+				},
+			});
+		}
+	}
+
+	if (bestSnaps.length > 1) {
+		const centerSnap = bestSnaps.find(
+			(snap) =>
+				snap.snapPoint.target.type === 'canvas-horizontal-center' ||
+				snap.snapPoint.target.type === 'canvas-vertical-center',
+		);
+		if (centerSnap) {
+			return centerSnap;
+		}
+	}
+
+	return bestSnaps[0] ?? null;
+};
+
+export const findSelectedOutlineSnap = ({
+	allowX,
+	allowY,
+	deltaX,
+	deltaY,
+	outlines,
+	scale,
+	targets,
+}: {
+	readonly allowX: boolean;
+	readonly allowY: boolean;
+	readonly deltaX: number;
+	readonly deltaY: number;
+	readonly outlines: readonly SelectedOutline[];
+	readonly scale: number;
+	readonly targets: readonly SelectedOutlineSnapTarget[];
+}): SelectedOutlineSnapResult => {
+	const bounds = getSelectedOutlineBounds({deltaX, deltaY, outlines, scale});
+	if (bounds === null) {
+		return {
+			activeSnapPoints: [],
+			snapOffsetX: null,
+			snapOffsetY: null,
+		};
+	}
+
+	const threshold = selectedOutlineSnapThresholdPx / scale;
+	const snapX = allowX
+		? findBestSnapForAxis({
+				edges: [
+					{edge: 'left', position: bounds.left},
+					{edge: 'center-x', position: bounds.centerX},
+					{edge: 'right', position: bounds.right},
+				],
+				targets: targets.filter((target) => target.axis === 'x'),
+				threshold,
+			})
+		: null;
+	const snapY = allowY
+		? findBestSnapForAxis({
+				edges: [
+					{edge: 'top', position: bounds.top},
+					{edge: 'center-y', position: bounds.centerY},
+					{edge: 'bottom', position: bounds.bottom},
+				],
+				targets: targets.filter((target) => target.axis === 'y'),
+				threshold,
+			})
+		: null;
+
+	return {
+		activeSnapPoints: [
+			snapX?.snapPoint ?? null,
+			snapY?.snapPoint ?? null,
+		].filter((snapPoint) => snapPoint !== null),
+		snapOffsetX: snapX?.offset ?? null,
+		snapOffsetY: snapY?.offset ?? null,
+	};
+};

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -21,6 +21,7 @@ import {drawRef} from '../state/canvas-ref';
 import {CheckerboardContext} from '../state/checkerboard';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowRulersContext} from '../state/editor-rulers';
+import {EditorSnappingContext} from '../state/editor-snapping';
 import {EditorZoomGesturesContext} from '../state/editor-zoom-gestures';
 import type {ModalState} from '../state/modals';
 import {ModalsContext} from '../state/modals';
@@ -224,6 +225,7 @@ export const useMenuStructure = (
 	const {editorShowGuides, setEditorShowGuides} = useContext(
 		EditorShowGuidesContext,
 	);
+	const {editorSnapping, setEditorSnapping} = useContext(EditorSnappingContext);
 	const {size, setSize} = useContext(Internals.PreviewSizeContext);
 	const {canvasContent, compositions} = useContext(
 		Internals.CompositionManager,
@@ -467,6 +469,22 @@ export const useMenuStructure = (
 						quickSwitcherLabel: editorShowGuides
 							? 'Hide Guides'
 							: 'Show Guides',
+					},
+					{
+						id: 'enable-snapping',
+						keyHint: areKeyboardShortcutsDisabled() ? null : 'Shift+M',
+						label: 'Enable Snapping',
+						onClick: () => {
+							closeMenu();
+							setEditorSnapping((c) => !c);
+						},
+						type: 'item' as const,
+						value: 'enable-snapping',
+						leftItem: editorSnapping ? <Checkmark /> : null,
+						subMenu: null,
+						quickSwitcherLabel: editorSnapping
+							? 'Disable Snapping'
+							: 'Enable Snapping',
 					},
 					{
 						id: 'timeline-divider-1',
@@ -983,6 +1001,7 @@ export const useMenuStructure = (
 		editorZoomGestures,
 		editorShowRulers,
 		editorShowGuides,
+		editorSnapping,
 		sidebarCollapsedStateLeft,
 		sidebarCollapsedStateRight,
 		checkerboard,
@@ -994,6 +1013,7 @@ export const useMenuStructure = (
 		setEditorZoomGestures,
 		setEditorShowRulers,
 		setEditorShowGuides,
+		setEditorSnapping,
 		setSidebarCollapsedState,
 		setCheckerboard,
 		setSelectedModal,

--- a/packages/studio/src/icons/magnet.tsx
+++ b/packages/studio/src/icons/magnet.tsx
@@ -1,0 +1,13 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+export const MagnetIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" {...props}>
+			<path
+				transform="rotate(180 256 256)"
+				d="M32 176v112c0 123.7 100.3 224 224 224s224-100.3 224-224V176H352v112c0 53-43 96-96 96s-96-43-96-96V176H32zm0-48h128V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64v64zm320 0h128V64c0-17.7-14.3-32-32-32h-64c-17.7 0-32 14.3-32 32v64z"
+			/>
+		</svg>
+	);
+};

--- a/packages/studio/src/state/editor-snapping.ts
+++ b/packages/studio/src/state/editor-snapping.ts
@@ -1,0 +1,22 @@
+import {createContext} from 'react';
+
+type State = {
+	editorSnapping: boolean;
+	setEditorSnapping: (cb: (prevState: boolean) => boolean) => void;
+};
+
+const key = 'remotion.editorSnapping';
+
+export const persistEditorSnappingOption = (option: boolean) => {
+	localStorage.setItem(key, String(option));
+};
+
+export const loadEditorSnappingOption = (): boolean => {
+	const item = localStorage.getItem(key);
+	return item !== 'false';
+};
+
+export const EditorSnappingContext = createContext<State>({
+	editorSnapping: true,
+	setEditorSnapping: () => undefined,
+});

--- a/packages/studio/src/test/selected-outline-snap.test.ts
+++ b/packages/studio/src/test/selected-outline-snap.test.ts
@@ -1,0 +1,175 @@
+import {expect, test} from 'bun:test';
+import type {SelectedOutline} from '../components/selected-outline-geometry';
+import {
+	findSelectedOutlineSnap,
+	getSelectedOutlineSnapTargets,
+	type SelectedOutlineSnapTarget,
+} from '../components/selected-outline-snap';
+import type {Guide} from '../state/editor-guides';
+
+const makeOutline = ({
+	height,
+	left,
+	scale = 1,
+	top,
+	width,
+}: {
+	readonly height: number;
+	readonly left: number;
+	readonly scale?: number;
+	readonly top: number;
+	readonly width: number;
+}): SelectedOutline => {
+	const right = left + width;
+	const bottom = top + height;
+
+	return {
+		key: 'outline',
+		dimensions: {width, height},
+		points: [
+			{x: left * scale, y: top * scale},
+			{x: right * scale, y: top * scale},
+			{x: right * scale, y: bottom * scale},
+			{x: left * scale, y: bottom * scale},
+		],
+	};
+};
+
+const getTargets = (
+	guides: readonly Guide[] = [],
+): readonly SelectedOutlineSnapTarget[] => {
+	return getSelectedOutlineSnapTargets({
+		compositionHeight: 600,
+		compositionWidth: 1000,
+		guides,
+	});
+};
+
+test('selected outlines snap to the horizontal and vertical canvas center', () => {
+	const result = findSelectedOutlineSnap({
+		allowX: true,
+		allowY: true,
+		deltaX: 0,
+		deltaY: 0,
+		outlines: [makeOutline({left: 455, top: 245, width: 100, height: 110})],
+		scale: 1,
+		targets: getTargets(),
+	});
+
+	expect(result.snapOffsetX).toBe(-5);
+	expect(result.snapOffsetY).toBe(0);
+	expect(result.activeSnapPoints.map((point) => point.target.type)).toEqual([
+		'canvas-horizontal-center',
+		'canvas-vertical-center',
+	]);
+});
+
+test('selected outlines snap their edges to canvas edges', () => {
+	const result = findSelectedOutlineSnap({
+		allowX: true,
+		allowY: true,
+		deltaX: 0,
+		deltaY: 0,
+		outlines: [makeOutline({left: 892, top: 6, width: 100, height: 100})],
+		scale: 1,
+		targets: getTargets(),
+	});
+
+	expect(result.snapOffsetX).toBe(8);
+	expect(result.snapOffsetY).toBe(-6);
+	expect(result.activeSnapPoints.map((point) => point.edge)).toEqual([
+		'right',
+		'top',
+	]);
+});
+
+test('snap threshold is measured in screen pixels', () => {
+	const result = findSelectedOutlineSnap({
+		allowX: true,
+		allowY: true,
+		deltaX: 0,
+		deltaY: 0,
+		outlines: [
+			makeOutline({left: 456, top: 245, width: 100, height: 110, scale: 2}),
+		],
+		scale: 2,
+		targets: getTargets(),
+	});
+
+	expect(result.snapOffsetX).toBe(null);
+	expect(result.snapOffsetY).toBe(0);
+	expect(result.activeSnapPoints.map((point) => point.target.type)).toEqual([
+		'canvas-vertical-center',
+	]);
+});
+
+test('visible guides become snap targets for item edges and centers', () => {
+	const guides: Guide[] = [
+		{
+			compositionId: 'comp',
+			id: 'vertical-guide',
+			orientation: 'vertical',
+			position: 300,
+			show: true,
+		},
+		{
+			compositionId: 'comp',
+			id: 'hidden-guide',
+			orientation: 'horizontal',
+			position: 240,
+			show: false,
+		},
+	];
+	const result = findSelectedOutlineSnap({
+		allowX: true,
+		allowY: true,
+		deltaX: 0,
+		deltaY: 0,
+		outlines: [makeOutline({left: 245, top: 125, width: 100, height: 100})],
+		scale: 1,
+		targets: getTargets(guides),
+	});
+
+	expect(result.snapOffsetX).toBe(5);
+	expect(result.snapOffsetY).toBe(null);
+	expect(result.activeSnapPoints).toHaveLength(1);
+	expect(result.activeSnapPoints[0].edge).toBe('center-x');
+	expect(result.activeSnapPoints[0].target.type).toBe('guide-vertical');
+});
+
+test('axis lock prevents snapping along the locked axis', () => {
+	const result = findSelectedOutlineSnap({
+		allowX: false,
+		allowY: true,
+		deltaX: 0,
+		deltaY: 0,
+		outlines: [makeOutline({left: 455, top: 245, width: 100, height: 110})],
+		scale: 1,
+		targets: getTargets(),
+	});
+
+	expect(result.snapOffsetX).toBe(null);
+	expect(result.snapOffsetY).toBe(0);
+	expect(result.activeSnapPoints.map((point) => point.target.type)).toEqual([
+		'canvas-vertical-center',
+	]);
+});
+
+test('full-canvas selections prefer center snap when edges tie', () => {
+	const result = findSelectedOutlineSnap({
+		allowX: true,
+		allowY: true,
+		deltaX: 0,
+		deltaY: 0,
+		outlines: [makeOutline({left: 0, top: 0, width: 1000, height: 600})],
+		scale: 1,
+		targets: getTargets(),
+	});
+
+	expect(result.snapOffsetX).toBe(0);
+	expect(result.snapOffsetY).toBe(0);
+	expect(result.activeSnapPoints.map((point) => point.target.type)).toEqual([
+		'canvas-horizontal-center',
+		'canvas-vertical-center',
+	]);
+});


### PR DESCRIPTION
## Summary

- Add canvas snapping for dragged Studio outlines to canvas centers, canvas edges, and visible guides.
- Render magenta snap indicators in the selected-outline SVG overlay while snapping.
- Add focused snap calculator coverage for centers, edges, guides, zoom thresholds, axis locking, and tie handling.

## Test plan

- `cd packages/studio && bunx oxfmt src --write`
- `cd packages/studio && bun run test`
- `bun run build`
- `bun run stylecheck`
