### PR TITLE
`@remotion/example`: Snap media FPS to common values

### DIFF
--- a/packages/example/src/get-media-metadata.ts
+++ b/packages/example/src/get-media-metadata.ts
@@ -1,5 +1,22 @@
 import {ALL_FORMATS, Input, UrlSource} from 'mediabunny';
 
+const commonFpsValues = [
+	24000 / 1001,
+	24,
+	25,
+	30000 / 1001,
+	30,
+	50,
+	60000 / 1001,
+	60,
+];
+
+const snapToCommonFps = (fps: number) => {
+	return (
+		commonFpsValues.find((commonFps) => Math.abs(fps - commonFps) < 0.01) ?? fps
+	);
+};
+
 export const getMediaMetadata = async (src: string) => {
 	const input = new Input({
 		formats: ALL_FORMATS,
@@ -17,7 +34,9 @@ export const getMediaMetadata = async (src: string) => {
 			}
 		: null;
 	const packetStats = await videoTrack?.computePacketStats(50);
-	const fps = packetStats?.averagePacketRate ?? null;
+	const fps = packetStats
+		? snapToCommonFps(packetStats.averagePacketRate)
+		: null;
 
 	return {
 		durationInSeconds,


### PR DESCRIPTION
## Summary
- Snap estimated media FPS values in the example metadata helper to common frame rates
- Preserve exact NTSC-style rates such as `30000 / 1001` and `60000 / 1001` instead of rounding them to integers

## Testing
- `cd packages/example && bun run format`
