### PR TITLE
Docs: Improve interactivity best practices

### DIFF
--- a/.agents/skills/interactivity-best-practices/SKILL.md
+++ b/.agents/skills/interactivity-best-practices/SKILL.md
@@ -10,3 +10,12 @@ Use the canonical interactivity best-practices page instead:
 
 To make an element or custom component interactive, use:
 [packages/docs/docs/studio/make-component-interactive.mdx](../../../packages/docs/docs/studio/make-component-interactive.mdx)
+
+When applying this skill, do not stop after wrapping elements in `Interactive.*`.
+Also enforce the practices that keep Studio values editable:
+
+- Give editable elements and components a descriptive `name`.
+- Keep editable and keyframed values inline at the JSX prop the Studio edits.
+- Use `style.translate`, `style.scale`, `style.rotate`, `style.transformOrigin` and `style.opacity` directly.
+- Replace `transform` strings such as `` `scale(${value})` `` with individual style props.
+- Use `translate` for animated movement and canvas dragging. Keep `top`, `left`, `right` and `bottom` for static anchoring.

--- a/.agents/skills/interactivity-best-practices/SKILL.md
+++ b/.agents/skills/interactivity-best-practices/SKILL.md
@@ -16,6 +16,8 @@ Also enforce the practices that keep Studio values editable:
 
 - Give editable elements and components a descriptive `name`.
 - Keep editable and keyframed values inline at the JSX prop the Studio edits.
+- Use hardcoded numeric `interpolate()` input ranges such as `[30, 50]`; do not use variables or expressions such as `[startFrame, startFrame + duration]`.
+- Put easing in the same `interpolate()` call options instead of nesting `interpolate()` calls around an eased progress value.
 - Use `style.translate`, `style.scale`, `style.rotate`, `style.transformOrigin` and `style.opacity` directly.
 - Replace `transform` strings such as `` `scale(${value})` `` with individual style props.
 - Use `translate` for animated movement and canvas dragging. Keep `top`, `left`, `right` and `bottom` for static anchoring.

--- a/.agents/skills/interactivity-best-practices/SKILL.md
+++ b/.agents/skills/interactivity-best-practices/SKILL.md
@@ -10,14 +10,3 @@ Use the canonical interactivity best-practices page instead:
 
 To make an element or custom component interactive, use:
 [packages/docs/docs/studio/make-component-interactive.mdx](../../../packages/docs/docs/studio/make-component-interactive.mdx)
-
-When applying this skill, do not stop after wrapping elements in `Interactive.*`.
-Also enforce the practices that keep Studio values editable:
-
-- Give editable elements and components a descriptive `name`.
-- Keep editable and keyframed values inline at the JSX prop the Studio edits.
-- Use hardcoded numeric `interpolate()` input ranges such as `[30, 50]`; do not use variables or expressions such as `[startFrame, startFrame + duration]`.
-- Put easing in the same `interpolate()` call options instead of nesting `interpolate()` calls around an eased progress value.
-- Use `style.translate`, `style.scale`, `style.rotate`, `style.transformOrigin` and `style.opacity` directly.
-- Replace `transform` strings such as `` `scale(${value})` `` with individual style props.
-- Use `translate` for animated movement and canvas dragging. Keep `top`, `left`, `right` and `bottom` for static anchoring.

--- a/packages/docs/docs/interactive-with-schema.mdx
+++ b/packages/docs/docs/interactive-with-schema.mdx
@@ -130,7 +130,7 @@ Forward it to the `<Sequence>` that registers the component in the timeline.
 An [`InteractivitySchema`](/docs/interactivity-schema) that describes which props are editable in Remotion Studio.
 
 Use [`Interactive.baseSchema`](/docs/interactive#interactivebaseschema) for Sequence-like timeline props. Use [`Interactive.transformSchema`](/docs/interactive#interactivetransformschema) if the component accepts a `style` prop and should expose transform controls.
-For reliable source updates, follow [Interactivity best practices](/docs/studio/interactivity-best-practices): Keep editable values inline, use `translate`, `scale`, `rotate` and `opacity` directly, and avoid animated layout props or `transform` strings.
+For reliable source updates, follow [Interactivity best practices](/docs/studio/interactivity-best-practices): Keep editable values inline, use hardcoded `interpolate()` keyframe arrays, use `translate`, `scale`, `rotate` and `opacity` directly, and avoid animated layout props or `transform` strings.
 
 ### `componentIdentity`
 

--- a/packages/docs/docs/interactive-with-schema.mdx
+++ b/packages/docs/docs/interactive-with-schema.mdx
@@ -130,6 +130,7 @@ Forward it to the `<Sequence>` that registers the component in the timeline.
 An [`InteractivitySchema`](/docs/interactivity-schema) that describes which props are editable in Remotion Studio.
 
 Use [`Interactive.baseSchema`](/docs/interactive#interactivebaseschema) for Sequence-like timeline props. Use [`Interactive.transformSchema`](/docs/interactive#interactivetransformschema) if the component accepts a `style` prop and should expose transform controls.
+For reliable source updates, follow [Interactivity best practices](/docs/studio/interactivity-best-practices): Keep editable values inline, use `translate`, `scale`, `rotate` and `opacity` directly, and avoid animated layout props or `transform` strings.
 
 ### `componentIdentity`
 
@@ -155,6 +156,7 @@ In editable Studio sessions, it reads the current prop values, applies timeline 
 
 - [`InteractivitySchema`](/docs/interactivity-schema)
 - [`Interactive`](/docs/interactive)
+- [Interactivity best practices](/docs/studio/interactivity-best-practices)
 - [`createEffect()`](/docs/create-effect)
 - [`<Sequence>`](/docs/sequence)
 - [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/core/src/Interactive.tsx)

--- a/packages/docs/docs/interactive.mdx
+++ b/packages/docs/docs/interactive.mdx
@@ -26,7 +26,7 @@ export const MyComp: React.FC = () => {
 ```
 
 For code that stays editable in the Studio, follow [Interactivity best practices](/docs/studio/interactivity-best-practices):
-Keep editable values inline, use `translate`, `scale`, `rotate` and `opacity` directly, and avoid animated `top`/`left` values or `transform` strings.
+Keep editable values inline, use hardcoded `interpolate()` keyframe arrays, use `translate`, `scale`, `rotate` and `opacity` directly, and avoid animated `top`/`left` values or `transform` strings.
 
 ## Components
 

--- a/packages/docs/docs/interactive.mdx
+++ b/packages/docs/docs/interactive.mdx
@@ -25,6 +25,9 @@ export const MyComp: React.FC = () => {
 };
 ```
 
+For code that stays editable in the Studio, follow [Interactivity best practices](/docs/studio/interactivity-best-practices):
+Keep editable values inline, use `translate`, `scale`, `rotate` and `opacity` directly, and avoid animated `top`/`left` values or `transform` strings.
+
 ## Components
 
 The component name is the PascalCase version of the underlying element:
@@ -87,6 +90,7 @@ Controls for transform-related style props:
 `style.transformOrigin`, `style.translate`, `style.scale`, `style.rotate` and `style.opacity`.
 
 Use it for components that accept a `style` prop and apply it to the rendered element.
+Keep these values inline in JSX if the Studio should edit or keyframe them.
 
 ### `Interactive.textSchema`<AvailableFrom v="4.0.481" />
 
@@ -178,4 +182,6 @@ For example, `<Interactive.Div>` accepts `<div>` props, and `<Interactive.Svg>` 
 ## See also
 
 - [Source code for this API](https://github.com/remotion-dev/remotion/blob/main/packages/core/src/Interactive.tsx)
+- [Interactivity best practices](/docs/studio/interactivity-best-practices)
+- [Studio interactivity](/docs/studio/interactivity)
 - [`<Sequence>`](/docs/sequence)

--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -17,6 +17,7 @@ When converting a component for Studio interactivity, apply all of these rules t
 - Use `Interactive.*` for editable HTML or SVG elements, or [`Interactive.withSchema()`](/docs/interactive-with-schema) for custom components.
 - Add a descriptive `name` prop to the editable element or custom component.
 - Keep every editable or keyframed value inline at the JSX prop that the Studio edits.
+- Keep `interpolate()` keyframe arrays as hardcoded numeric arrays, such as `[0, 30]`.
 - Use Studio-editable style props such as `translate`, `scale`, `rotate`, `transformOrigin` and `opacity` instead of hiding values in a `transform` string.
 - Use `translate` for animated movement and canvas dragging. Keep `top`, `left`, `right` and `bottom` for static anchoring.
 - Keep `<Composition>` metadata and `defaultProps` inline unless the value is truly dynamic.
@@ -60,6 +61,8 @@ This applies to static style values, keyframes, easing and transform props.
 
 If the Studio should expose a property such as `opacity`, `translate`, `scale` or `rotate`, keep the `interpolate()` call on that exact style property.
 Do not calculate the value in a local variable and pass the variable into `style`.
+Keep the input range and output range directly in that `interpolate()` call.
+The input range must use hardcoded numbers, not variables or expressions such as `[sendStartFrame, sendStartFrame + duration]`.
 
 ```tsx title="Inline values"
 // 👍 Inline values can be standardized and keyframed
@@ -93,6 +96,7 @@ const rotation = interpolate(frame, [0, 30], [0, 20]);
 
 Use standalone [`spring()`](/docs/spring) only when the animation needs a frame-driven physical spring simulation.
 Use individual CSS transform properties such as `scale`, `rotate` and `translate` instead of composing a `transform` string.
+Pass easing to the same `interpolate()` call instead of nesting another `interpolate()` call to create an eased progress value.
 
 ```tsx title="Animated position"
 // 👍 Motion, opacity and scale are visible to the Studio
@@ -102,17 +106,35 @@ Use individual CSS transform properties such as `scale`, `rotate` and `translate
     position: 'absolute',
     right: 56,
     top: 96,
-    opacity: interpolate(frame, [0, 20], [0, 1]),
-    translate: interpolate(frame, [0, 20], ['0px 32px', '0px 0px']),
-    scale: interpolate(frame, [0, 20], [0.92, 1]),
+    opacity: interpolate(frame, [30, 50], [0, 1], {
+      extrapolateLeft: 'clamp',
+      extrapolateRight: 'clamp',
+    }),
+    translate: interpolate(frame, [30, 50], ['0px 32px', '0px 0px'], {
+      easing: Easing.out(Easing.cubic),
+      extrapolateLeft: 'clamp',
+      extrapolateRight: 'clamp',
+    }),
+    scale: interpolate(frame, [30, 50], [0.92, 1], {
+      extrapolateLeft: 'clamp',
+      extrapolateRight: 'clamp',
+    }),
     transformOrigin: '100% 100%',
   }}
 />
 
 // 👎 The Studio sees computed values instead of editable props
-const promptBubbleTop = interpolate(frame, [0, 20], [128, 96]);
-const promptBubbleOpacity = interpolate(frame, [0, 20], [0, 1]);
-const promptBubbleScale = interpolate(frame, [0, 20], [0.92, 1]);
+const sendStartFrame = 30;
+const promptTravelDurationInFrames = 20;
+const promptBubbleTop = interpolate(frame, [30, 50], [128, 96]);
+const promptBubbleOpacity = interpolate(frame, [30, 50], [0, 1]);
+const easedProgress = Easing.out(Easing.cubic)(
+  interpolate(
+    frame,
+    [sendStartFrame, sendStartFrame + promptTravelDurationInFrames],
+    [0, 1],
+  ),
+);
 
 <Interactive.Div
   style={{
@@ -120,7 +142,7 @@ const promptBubbleScale = interpolate(frame, [0, 20], [0.92, 1]);
     right: 56,
     top: promptBubbleTop,
     opacity: promptBubbleOpacity,
-    transform: `scale(${promptBubbleScale})`,
+    translate: interpolate(easedProgress, [0, 1], ['0px 32px', '0px 0px']),
     transformOrigin: '100% 100%',
   }}
 />
@@ -130,7 +152,7 @@ Use `top`, `left`, `right` and `bottom` for static layout anchors.
 When the value changes over time or should be draggable/keyframable in the Studio, put the moving part into `translate`.
 
 ```txt title="Prompt"
-/remotion-best-practices Fix computed values in Remotion Studio. Follow https://www.remotion.dev/docs/studio/interactivity-best-practices#keep-editable-values-visible. Move editable values into the JSX style object, keep interpolate() keyframes inline, inline opacity/scale/rotate/translate values, use Easing.spring() as easing, replace transform strings with scale/rotate/translate, and use translate instead of animated top/left/right/bottom.
+/remotion-best-practices Fix computed values in Remotion Studio. Follow https://www.remotion.dev/docs/studio/interactivity-best-practices#keep-editable-values-visible. Move editable values into the JSX style object, inline opacity/scale/rotate/translate values, use hardcoded numeric interpolate() keyframe arrays such as [30, 50], pass easing in the interpolate() options, replace transform strings with scale/rotate/translate, and use translate instead of animated top/left/right/bottom.
 ```
 
 ## Keep composition metadata inline {#keep-composition-metadata-inline}

--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -10,6 +10,17 @@ Write editable Remotion components so the [Studio interactivity](/docs/studio/in
 
 When a value is shown as computed in the Studio, it often means that the value is hidden behind a variable, helper function, conditional expression or transform string.
 
+## Quick checklist {#quick-checklist}
+
+When converting a component for Studio interactivity, apply all of these rules together:
+
+- Use `Interactive.*` for editable HTML or SVG elements, or [`Interactive.withSchema()`](/docs/interactive-with-schema) for custom components.
+- Add a descriptive `name` prop to the editable element or custom component.
+- Keep every editable or keyframed value inline at the JSX prop that the Studio edits.
+- Use Studio-editable style props such as `translate`, `scale`, `rotate`, `transformOrigin` and `opacity` instead of hiding values in a `transform` string.
+- Use `translate` for animated movement and canvas dragging. Keep `top`, `left`, `right` and `bottom` for static anchoring.
+- Keep `<Composition>` metadata and `defaultProps` inline unless the value is truly dynamic.
+
 ## Use `Interactive.*` for tweakable elements {#use-interactive-for-tweakable-elements}
 
 Use the [`Interactive`](/docs/interactive) namespace when an HTML or SVG element should be selected, moved or edited in the Studio.
@@ -47,6 +58,9 @@ The name is shown in the Studio timeline and helps agents identify the correct e
 Put values that should be edited in the Studio directly into the JSX.
 This applies to static style values, keyframes, easing and transform props.
 
+If the Studio should expose a property such as `opacity`, `translate`, `scale` or `rotate`, keep the `interpolate()` call on that exact style property.
+Do not calculate the value in a local variable and pass the variable into `style`.
+
 ```tsx title="Inline values"
 // 👍 Inline values can be standardized and keyframed
 <Interactive.Div
@@ -80,8 +94,43 @@ const rotation = interpolate(frame, [0, 30], [0, 20]);
 Use standalone [`spring()`](/docs/spring) only when the animation needs a frame-driven physical spring simulation.
 Use individual CSS transform properties such as `scale`, `rotate` and `translate` instead of composing a `transform` string.
 
+```tsx title="Animated position"
+// 👍 Motion, opacity and scale are visible to the Studio
+<Interactive.Div
+  name="Prompt bubble"
+  style={{
+    position: 'absolute',
+    right: 56,
+    top: 96,
+    opacity: interpolate(frame, [0, 20], [0, 1]),
+    translate: interpolate(frame, [0, 20], ['0px 32px', '0px 0px']),
+    scale: interpolate(frame, [0, 20], [0.92, 1]),
+    transformOrigin: '100% 100%',
+  }}
+/>
+
+// 👎 The Studio sees computed values instead of editable props
+const promptBubbleTop = interpolate(frame, [0, 20], [128, 96]);
+const promptBubbleOpacity = interpolate(frame, [0, 20], [0, 1]);
+const promptBubbleScale = interpolate(frame, [0, 20], [0.92, 1]);
+
+<Interactive.Div
+  style={{
+    position: 'absolute',
+    right: 56,
+    top: promptBubbleTop,
+    opacity: promptBubbleOpacity,
+    transform: `scale(${promptBubbleScale})`,
+    transformOrigin: '100% 100%',
+  }}
+/>
+```
+
+Use `top`, `left`, `right` and `bottom` for static layout anchors.
+When the value changes over time or should be draggable/keyframable in the Studio, put the moving part into `translate`.
+
 ```txt title="Prompt"
-/remotion-best-practices Fix computed values in Remotion Studio. Follow https://www.remotion.dev/docs/studio/interactivity-best-practices#keep-editable-values-visible. Move editable values into the JSX style object, keep interpolate() keyframes inline, use Easing.spring() as easing, and replace transform strings with scale/rotate/translate.
+/remotion-best-practices Fix computed values in Remotion Studio. Follow https://www.remotion.dev/docs/studio/interactivity-best-practices#keep-editable-values-visible. Move editable values into the JSX style object, keep interpolate() keyframes inline, inline opacity/scale/rotate/translate values, use Easing.spring() as easing, replace transform strings with scale/rotate/translate, and use translate instead of animated top/left/right/bottom.
 ```
 
 ## Keep composition metadata inline {#keep-composition-metadata-inline}

--- a/packages/docs/docs/studio/interactivity.mdx
+++ b/packages/docs/docs/studio/interactivity.mdx
@@ -10,6 +10,7 @@ Studio interactivity means visual edits that are written back to your codebase.
 
 Edits can be undone with <kbd>⌘/Ctrl</kbd> + <kbd>Z</kbd> and redone with <kbd>⌘/Ctrl</kbd> + <kbd>Y</kbd>.
 
+To write code that remains editable, see [Interactivity best practices](/docs/studio/interactivity-best-practices).
 To make a custom component selectable and editable, see [Make a component interactive](/docs/studio/make-component-interactive).
 
 ## Selecting edit targets
@@ -61,3 +62,9 @@ To make a custom component selectable and editable, see [Make a component intera
 - Press <kbd>Delete</kbd> or <kbd>Backspace</kbd> to delete selected keyframes, sequences, effects or all effects where supported.
 - Reset selected sequence or effect props to their defaults with <kbd>Delete</kbd> or <kbd>Backspace</kbd> when deletion does not apply.
 - Press <kbd>⌘/Ctrl</kbd> + <kbd>D</kbd> to duplicate selected sequences.
+
+## See also
+
+- [Interactivity best practices](/docs/studio/interactivity-best-practices)
+- [Make a component interactive](/docs/studio/make-component-interactive)
+- [`Interactive`](/docs/interactive)

--- a/packages/docs/docs/studio/make-component-interactive.mdx
+++ b/packages/docs/docs/studio/make-component-interactive.mdx
@@ -9,6 +9,7 @@ crumb: "Remotion Studio"
 Interactive components can be selected in the Remotion Studio timeline and can expose editable props.
 
 If you only need an editable HTML or SVG element, use [`Interactive`](/docs/interactive). For a custom component, wrap it with [`Interactive.withSchema()`](/docs/interactive-with-schema).
+For code that remains editable after visual changes, follow [Interactivity best practices](/docs/studio/interactivity-best-practices).
 
 ## Create a schema
 
@@ -287,6 +288,7 @@ Use it when the component forwards `premountFor`, `postmountFor`, `styleWhilePre
 
 ## See also
 
+- [Interactivity best practices](/docs/studio/interactivity-best-practices)
 - [`Interactive.withSchema()`](/docs/interactive-with-schema)
 - [`InteractivitySchema`](/docs/interactivity-schema)
 - [`Interactive`](/docs/interactive)


### PR DESCRIPTION
## Summary

- Improve Studio interactivity best practices with a quick checklist and a focused animated-position example.
- Clarify that editable `opacity`, `translate`, `scale` and `rotate` values should stay inline on the Studio-editable style props.
- Cross-link the best-practices page from the main interactivity, `Interactive`, `Interactive.withSchema()` and custom-component docs.
- Strengthen the interactivity-best-practices agent skill checklist.

## Testing

- `bunx oxfmt src --write` in `packages/docs`
- `bun run build`
- `bun run stylecheck`
- `bun render-cards.ts`
- `bun run build-docs`

Closes #8856
