### PR TITLE
`@remotion/convert`: Preserve edit output container

### DIFF
--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -29,7 +29,10 @@ import {
 	getActualAudioOperation,
 	getActualVideoOperation,
 } from '~/lib/get-audio-video-config-index';
-import {getDefaultOutputFormat} from '~/lib/get-default-output-format';
+import {
+	getDefaultConvertOutputFormat,
+	getDefaultEditOutputFormat,
+} from '~/lib/get-default-output-format';
 import {getDurationOrCompute} from '~/lib/get-duration-or-compute';
 import {getInitialResizeSuggestion} from '~/lib/get-initial-resize-suggestion';
 import {isReencoding} from '~/lib/is-reencoding';
@@ -116,9 +119,20 @@ const ConvertUI = ({
 	readonly sampleRate: number | null;
 	readonly cropRect: CropRectangle;
 }) => {
-	const [outputContainer, setOutputContainer] = useState<OutputContainer>(() =>
-		getDefaultOutputFormat({inputContainer, action}),
+	const [enableConvert, setEnableConvert] = useState(() =>
+		isConvertEnabledByDefault(action),
 	);
+	const editOutputContainer = useMemo(
+		() => getDefaultEditOutputFormat(inputContainer),
+		[inputContainer],
+	);
+	const [convertOutputContainer, setConvertOutputContainer] =
+		useState<OutputContainer>(() =>
+			getDefaultConvertOutputFormat({inputContainer, action}),
+		);
+	const actualOutputContainer = enableConvert
+		? convertOutputContainer
+		: editOutputContainer;
 	const [videoOperationSelection, setVideoOperationKey] = useState<
 		Record<number, string>
 	>({});
@@ -127,9 +141,6 @@ const ConvertUI = ({
 	>({});
 	const [state, setState] = useState<ConvertState>({type: 'idle'});
 	useState<number | null>(null);
-	const [enableConvert, setEnableConvert] = useState(() =>
-		isConvertEnabledByDefault(action),
-	);
 	const [resizeOperation, setResizeOperation] =
 		useState<MediabunnyResize | null>(() => {
 			return (action.type === 'resize-format' ||
@@ -168,7 +179,7 @@ const ConvertUI = ({
 	}, [resampleRate, canResample, resampleUserPreferenceActive]);
 
 	const supportedConfigs = useSupportedConfigs({
-		outputContainer,
+		outputContainer: actualOutputContainer,
 		tracks,
 		action,
 		userRotation,
@@ -219,7 +230,7 @@ const ConvertUI = ({
 			onWaveformBars,
 		});
 
-		const format = getMediabunnyOutput(outputContainer);
+		const format = getMediabunnyOutput(actualOutputContainer);
 
 		let cancelConversion = () => {};
 
@@ -432,6 +443,7 @@ const ConvertUI = ({
 		};
 	}, [
 		audioOperationSelection,
+		actualOutputContainer,
 		dimensions,
 		enableConvert,
 		enableRotateOrMirror,
@@ -440,7 +452,6 @@ const ConvertUI = ({
 		input,
 		name,
 		onWaveformBars,
-		outputContainer,
 		resizeOperation,
 		supportedConfigs,
 		fps,
@@ -598,7 +609,7 @@ const ConvertUI = ({
 				/>
 				<div className="h-2" />
 				<ConversionDone
-					{...{container: outputContainer, name, setState, state, setSrc}}
+					{...{container: actualOutputContainer, name, setState, state, setSrc}}
 				/>
 			</>
 		);
@@ -641,8 +652,8 @@ const ConvertUI = ({
 										<div className="h-2" />
 										<ConvertForm
 											{...{
-												container: outputContainer,
-												setContainer: setOutputContainer,
+												container: convertOutputContainer,
+												setContainer: setConvertOutputContainer,
 												flipHorizontal,
 												flipVertical,
 												setFlipHorizontal,

--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -117,7 +117,7 @@ const ConvertUI = ({
 	readonly cropRect: CropRectangle;
 }) => {
 	const [outputContainer, setOutputContainer] = useState<OutputContainer>(() =>
-		getDefaultOutputFormat(inputContainer),
+		getDefaultOutputFormat({inputContainer, action}),
 	);
 	const [videoOperationSelection, setVideoOperationKey] = useState<
 		Record<number, string>

--- a/packages/convert/app/components/get-supported-configs.tsx
+++ b/packages/convert/app/components/get-supported-configs.tsx
@@ -79,11 +79,11 @@ const shouldPrioritizeVideoCopyOverReencode = (routeAction: RouteAction) => {
 	}
 
 	if (routeAction.type === 'generic-trim') {
-		return false;
+		return true;
 	}
 
 	if (routeAction.type === 'trim-format') {
-		return false;
+		return true;
 	}
 
 	if (routeAction.type === 'timing-editor') {

--- a/packages/convert/app/lib/default-ui.ts
+++ b/packages/convert/app/lib/default-ui.ts
@@ -80,7 +80,7 @@ export const isConvertEnabledByDefault = (action: RouteAction) => {
 	}
 
 	if (action.type === 'generic-probe') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'generic-convert') {
@@ -88,55 +88,55 @@ export const isConvertEnabledByDefault = (action: RouteAction) => {
 	}
 
 	if (action.type === 'generic-rotate') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'rotate-format') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'mirror-format') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'generic-mirror') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'generic-resize') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'resize-format') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'report') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'transcribe') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'generic-crop') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'crop-format') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'generic-trim') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'trim-format') {
-		return true;
+		return false;
 	}
 
 	if (action.type === 'timing-editor') {
-		return true;
+		return false;
 	}
 
 	throw new Error(

--- a/packages/convert/app/lib/get-default-output-format.ts
+++ b/packages/convert/app/lib/get-default-output-format.ts
@@ -73,34 +73,16 @@ const getSameOutputFormat = (
 	return null;
 };
 
-const shouldKeepInputContainerByDefault = (action: RouteAction) => {
-	if (action.type === 'convert' || action.type === 'generic-convert') {
-		return false;
-	}
-
-	if (
-		action.type === 'generic-rotate' ||
-		action.type === 'rotate-format' ||
-		action.type === 'generic-mirror' ||
-		action.type === 'mirror-format' ||
-		action.type === 'generic-resize' ||
-		action.type === 'resize-format' ||
-		action.type === 'generic-crop' ||
-		action.type === 'crop-format' ||
-		action.type === 'generic-trim' ||
-		action.type === 'trim-format' ||
-		action.type === 'generic-probe' ||
-		action.type === 'report' ||
-		action.type === 'transcribe' ||
-		action.type === 'timing-editor'
-	) {
-		return true;
-	}
-
-	throw new Error('Unsupported action: ' + (action satisfies never));
+export const getDefaultEditOutputFormat = (
+	inputContainer: InputFormat,
+): OutputContainer => {
+	return (
+		getSameOutputFormat(inputContainer) ??
+		getDefaultConversionFormat(inputContainer)
+	);
 };
 
-export const getDefaultOutputFormat = ({
+export const getDefaultConvertOutputFormat = ({
 	inputContainer,
 	action,
 }: {
@@ -109,13 +91,6 @@ export const getDefaultOutputFormat = ({
 }): OutputContainer => {
 	if (action.type === 'convert') {
 		return action.output;
-	}
-
-	if (shouldKeepInputContainerByDefault(action)) {
-		const sameFormat = getSameOutputFormat(inputContainer);
-		if (sameFormat) {
-			return sameFormat;
-		}
 	}
 
 	return getDefaultConversionFormat(inputContainer);

--- a/packages/convert/app/lib/get-default-output-format.ts
+++ b/packages/convert/app/lib/get-default-output-format.ts
@@ -10,9 +10,9 @@ import {
 	WAVE,
 	WEBM,
 } from 'mediabunny';
-import type {OutputContainer} from '~/seo';
+import type {OutputContainer, RouteAction} from '~/seo';
 
-export const getDefaultOutputFormat = (
+const getDefaultConversionFormat = (
 	inputContainer: InputFormat,
 ): OutputContainer => {
 	if (inputContainer === MP4 || inputContainer === QTFF) {
@@ -37,4 +37,86 @@ export const getDefaultOutputFormat = (
 	}
 
 	throw new Error('not all input formats handled: ' + inputContainer.name);
+};
+
+const getSameOutputFormat = (
+	inputContainer: InputFormat,
+): OutputContainer | null => {
+	if (inputContainer === MP4) {
+		return 'mp4';
+	}
+
+	if (inputContainer === QTFF) {
+		return 'mov';
+	}
+
+	if (inputContainer === WEBM) {
+		return 'webm';
+	}
+
+	if (inputContainer === MATROSKA) {
+		return 'mkv';
+	}
+
+	if (inputContainer === WAVE) {
+		return 'wav';
+	}
+
+	if (inputContainer === ADTS) {
+		return 'aac';
+	}
+
+	if (inputContainer === MP3) {
+		return 'mp3';
+	}
+
+	return null;
+};
+
+const shouldKeepInputContainerByDefault = (action: RouteAction) => {
+	if (action.type === 'convert' || action.type === 'generic-convert') {
+		return false;
+	}
+
+	if (
+		action.type === 'generic-rotate' ||
+		action.type === 'rotate-format' ||
+		action.type === 'generic-mirror' ||
+		action.type === 'mirror-format' ||
+		action.type === 'generic-resize' ||
+		action.type === 'resize-format' ||
+		action.type === 'generic-crop' ||
+		action.type === 'crop-format' ||
+		action.type === 'generic-trim' ||
+		action.type === 'trim-format' ||
+		action.type === 'generic-probe' ||
+		action.type === 'report' ||
+		action.type === 'transcribe' ||
+		action.type === 'timing-editor'
+	) {
+		return true;
+	}
+
+	throw new Error('Unsupported action: ' + (action satisfies never));
+};
+
+export const getDefaultOutputFormat = ({
+	inputContainer,
+	action,
+}: {
+	inputContainer: InputFormat;
+	action: RouteAction;
+}): OutputContainer => {
+	if (action.type === 'convert') {
+		return action.output;
+	}
+
+	if (shouldKeepInputContainerByDefault(action)) {
+		const sameFormat = getSameOutputFormat(inputContainer);
+		if (sameFormat) {
+			return sameFormat;
+		}
+	}
+
+	return getDefaultConversionFormat(inputContainer);
 };

--- a/packages/convert/test/default-ui.test.ts
+++ b/packages/convert/test/default-ui.test.ts
@@ -4,7 +4,10 @@ import {
 	isConvertEnabledByDefault,
 	isVideoOnlySection,
 } from '../app/lib/default-ui';
-import {getDefaultOutputFormat} from '../app/lib/get-default-output-format';
+import {
+	getDefaultConvertOutputFormat,
+	getDefaultEditOutputFormat,
+} from '../app/lib/get-default-output-format';
 
 test('treats crop as a video-only operation section', () => {
 	expect(isVideoOnlySection('crop')).toBe(true);
@@ -45,37 +48,31 @@ test('only enables the convert controls by default on conversion pages', () => {
 });
 
 test('keeps the input container by default on editing pages', () => {
+	expect(getDefaultEditOutputFormat(MP4)).toBe('mp4');
+	expect(getDefaultEditOutputFormat(WEBM)).toBe('webm');
+	expect(getDefaultEditOutputFormat(QTFF)).toBe('mov');
+});
+
+test('uses conversion defaults when enabling convert controls', () => {
 	expect(
-		getDefaultOutputFormat({
+		getDefaultConvertOutputFormat({
 			inputContainer: MP4,
 			action: {type: 'generic-trim'},
 		}),
-	).toBe('mp4');
-	expect(
-		getDefaultOutputFormat({
-			inputContainer: WEBM,
-			action: {type: 'generic-crop'},
-		}),
 	).toBe('webm');
 	expect(
-		getDefaultOutputFormat({
-			inputContainer: QTFF,
-			action: {type: 'generic-resize'},
+		getDefaultConvertOutputFormat({
+			inputContainer: MP4,
+			action: {type: 'convert', input: 'mp4', output: 'mov'},
 		}),
 	).toBe('mov');
 });
 
 test('uses conversion defaults on conversion pages', () => {
 	expect(
-		getDefaultOutputFormat({
+		getDefaultConvertOutputFormat({
 			inputContainer: MP4,
 			action: {type: 'generic-convert'},
 		}),
 	).toBe('webm');
-	expect(
-		getDefaultOutputFormat({
-			inputContainer: MP4,
-			action: {type: 'convert', input: 'mp4', output: 'mov'},
-		}),
-	).toBe('mov');
 });

--- a/packages/convert/test/default-ui.test.ts
+++ b/packages/convert/test/default-ui.test.ts
@@ -1,5 +1,10 @@
 import {expect, test} from 'bun:test';
-import {isVideoOnlySection} from '../app/lib/default-ui';
+import {MP4, QTFF, WEBM} from 'mediabunny';
+import {
+	isConvertEnabledByDefault,
+	isVideoOnlySection,
+} from '../app/lib/default-ui';
+import {getDefaultOutputFormat} from '../app/lib/get-default-output-format';
 
 test('treats crop as a video-only operation section', () => {
 	expect(isVideoOnlySection('crop')).toBe(true);
@@ -18,4 +23,59 @@ test('treats rotate, mirror, and resize as video-only operation sections', () =>
 test('keeps conversion and resampling available for audio-only files', () => {
 	expect(isVideoOnlySection('convert')).toBe(false);
 	expect(isVideoOnlySection('resample')).toBe(false);
+});
+
+test('only enables the convert controls by default on conversion pages', () => {
+	expect(
+		isConvertEnabledByDefault({
+			type: 'convert',
+			input: 'mp4',
+			output: 'webm',
+		}),
+	).toBe(true);
+	expect(isConvertEnabledByDefault({type: 'generic-convert'})).toBe(true);
+	expect(isConvertEnabledByDefault({type: 'generic-trim'})).toBe(false);
+	expect(isConvertEnabledByDefault({type: 'trim-format', format: 'mp4'})).toBe(
+		false,
+	);
+	expect(isConvertEnabledByDefault({type: 'generic-crop'})).toBe(false);
+	expect(isConvertEnabledByDefault({type: 'generic-resize'})).toBe(false);
+	expect(isConvertEnabledByDefault({type: 'generic-rotate'})).toBe(false);
+	expect(isConvertEnabledByDefault({type: 'generic-mirror'})).toBe(false);
+});
+
+test('keeps the input container by default on editing pages', () => {
+	expect(
+		getDefaultOutputFormat({
+			inputContainer: MP4,
+			action: {type: 'generic-trim'},
+		}),
+	).toBe('mp4');
+	expect(
+		getDefaultOutputFormat({
+			inputContainer: WEBM,
+			action: {type: 'generic-crop'},
+		}),
+	).toBe('webm');
+	expect(
+		getDefaultOutputFormat({
+			inputContainer: QTFF,
+			action: {type: 'generic-resize'},
+		}),
+	).toBe('mov');
+});
+
+test('uses conversion defaults on conversion pages', () => {
+	expect(
+		getDefaultOutputFormat({
+			inputContainer: MP4,
+			action: {type: 'generic-convert'},
+		}),
+	).toBe('webm');
+	expect(
+		getDefaultOutputFormat({
+			inputContainer: MP4,
+			action: {type: 'convert', input: 'mp4', output: 'mov'},
+		}),
+	).toBe('mov');
 });


### PR DESCRIPTION
## Summary
- Keep edit-first routes like trim, crop, resize, rotate, and mirror in the source container by default.
- Leave the Convert controls enabled by default only on actual conversion routes.
- Add tests for conversion defaults and source-container preservation.

## Testing
- bunx oxfmt app test --write (in packages/convert)
- bun run build
- bun run stylecheck

Closes https://github.com/remotion-dev/remotion/issues/8840
