### PR TITLE
Docs: Add FAQ on signing up for a Remotion license/account

### DIFF
--- a/packages/docs/docs/licensing/index.mdx
+++ b/packages/docs/docs/licensing/index.mdx
@@ -41,6 +41,20 @@ From Remotion 5.0, telemetry reporting using the `licenseKey` option is **mandat
 
 For Remotion for Creators (seat-based licensing), telemetry reporting is optional. Remotion for Creators is meant for low-volume rendering within and for your own company, not to serve (personalized) videos to your end users.
 
+### How do I sign up for a Remotion license/account?
+
+Signing up is only required if you fall under the requirements of the [Company License](/docs/pricing). If you are eligible for the Free License, you do not need an account.
+
+To create an account:
+
+1. Go to the Remotion licensing platform at [remotion.pro/license](https://www.remotion.pro/license).
+2. Create an account using either email, Google, or GitHub.
+3. Once signed up, create a new project/workspace associated with your account. You will be asked to link the project to your company and use case.
+4. After the project/workspace is created, configure your license according to your use case and expected usage.
+5. Invite team members to the project so they can help manage the license.
+
+Holding a Company License also comes with perks such as **priority support** and access to **Remotion templates**.
+
 ### Can I use this package to count renders if I am eligible for the Free License?
 
 Yes, you may still create a project on [remotion.pro](https://remotion.pro) and use this package to count renders.  

--- a/packages/docs/docs/licensing/index.mdx
+++ b/packages/docs/docs/licensing/index.mdx
@@ -26,7 +26,7 @@ Not directly - pass the `licenseKey` option in the renderer package you use.
 
 - [`@remotion/cloudrun`](/docs/cloudrun): No telemetry is implemented. Use [`@remotion/licensing`](/docs/licensing) directly to track usage.
 - [`@remotion/webcodecs`](/docs/webcodecs): Telemetry was removed in v4.0.399 because this package is no longer monetized.
-  </details>
+</details>
 
 On your Company License dashboard on [remotion.pro](https://remotion.pro), you can find your license keys on the License keys page.
 

--- a/packages/docs/docs/licensing/index.mdx
+++ b/packages/docs/docs/licensing/index.mdx
@@ -26,7 +26,7 @@ Not directly - pass the `licenseKey` option in the renderer package you use.
 
 - [`@remotion/cloudrun`](/docs/cloudrun): No telemetry is implemented. Use [`@remotion/licensing`](/docs/licensing) directly to track usage.
 - [`@remotion/webcodecs`](/docs/webcodecs): Telemetry was removed in v4.0.399 because this package is no longer monetized.
-</details>
+  </details>
 
 On your Company License dashboard on [remotion.pro](https://remotion.pro), you can find your license keys on the License keys page.
 
@@ -53,7 +53,7 @@ To create an account:
 4. After the project/workspace is created, configure your license according to your use case and expected usage.
 5. Invite team members to the project so they can help manage the license.
 
-Holding a Company License also comes with perks such as **priority support** and access to **Remotion templates**.
+Holding a Company License also comes with perks such as **priority support** and access to **Remotion templates**, which are available through the licensing platform within your created project.
 
 ### Can I use this package to count renders if I am eligible for the Free License?
 


### PR DESCRIPTION
## Summary

- Add a new FAQ item to the `@remotion/licensing` docs: "How do I sign up for a Remotion license/account?"
- Explains that sign-up is only required for users who fall under the Remotion Company License requirement, and walks through the account creation flow on the licensing platform at https://www.remotion.pro/license (email / Google / GitHub).
- Documents the project/workspace creation tied to account, company, and use case, license configuration based on usage, and inviting team members to manage the license.
- Mentions Company License perks: priority support and Remotion templates.

## Test plan

- [ ] Visit the [licensing docs page](/docs/licensing) locally and confirm the new FAQ renders correctly with proper formatting and links.
- [ ] Verify the `remotion.pro/license` link resolves to the licensing platform.
