### PR TITLE
`@remotion/studio-server`: Support Easing.cubic in interactivity

### DIFF
--- a/packages/docs/docs/studio/interactivity.mdx
+++ b/packages/docs/docs/studio/interactivity.mdx
@@ -56,6 +56,22 @@ To make a custom component selectable and editable, see [Make a component intera
 - Copy one selected easing segment with <kbd>⌘/Ctrl</kbd> + <kbd>C</kbd> and paste it onto selected easing segments with <kbd>⌘/Ctrl</kbd> + <kbd>V</kbd>.
 - Press <kbd>Delete</kbd> or <kbd>Backspace</kbd> to reset selected easing segments to linear when only easing segments are selected.
 
+### Supported source easing expressions
+
+Studio can edit easing segments when the [`interpolate()`](/docs/interpolate) or [`interpolateColors()`](/docs/interpolate-colors) `easing` option is inline and uses one of these expressions:
+
+- [`Easing.linear`](/docs/easing#linear)
+- [`Easing.bezier(x1, y1, x2, y2)`](/docs/easing#bezier) with numeric arguments
+- [`Easing.spring()`](/docs/easing#spring) with an inline static config
+- Exact Bezier-compatible helpers<AvailableFrom v="4.0.487" inline />: [`Easing.ease`](/docs/easing#ease), [`Easing.quad`](/docs/easing#quad), [`Easing.cubic`](/docs/easing#cubic), [`Easing.back()`](/docs/easing#back), `Easing.back(s)` with a numeric argument, `Easing.poly(1)`, `Easing.poly(2)` and `Easing.poly(3)`
+- `Easing.in(...)` around a supported easing
+- `Easing.out(...)` around a supported Bezier or linear easing
+- `Easing.inOut(Easing.linear)`
+
+When editing exact Bezier-compatible helpers, Studio writes the easing back as an explicit `Easing.bezier(...)`.
+
+Other helpers such as `Easing.sin`, `Easing.circle`, `Easing.exp`, `Easing.bounce`, `Easing.elastic`, `Easing.poly(4)` and non-linear `Easing.inOut(...)` calls are shown as computed values because they cannot be represented exactly as a single cubic Bezier easing segment.
+
 ## Deleting, resetting and duplicating
 
 - Press <kbd>Delete</kbd> or <kbd>Backspace</kbd> to delete selected keyframes, sequences, effects or all effects where supported.

--- a/packages/example/src/CubicEasingInterpolationTest.tsx
+++ b/packages/example/src/CubicEasingInterpolationTest.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+	AbsoluteFill,
+	Easing,
+	Sequence,
+	interpolate,
+	useCurrentFrame,
+} from 'remotion';
+
+const CubicEasingInterpolationTest: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	return (
+		<AbsoluteFill
+			style={{
+				alignItems: 'center',
+				backgroundColor: 'white',
+				justifyContent: 'center',
+			}}
+		>
+			<Sequence
+				durationInFrames={120}
+				name="Easing.cubic keyframes should be shown at 0 and 100"
+				style={{
+					scale: interpolate(frame, [0, 100], [0.4, 1.6], {
+						easing: Easing.cubic,
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+					}),
+				}}
+			>
+				<div
+					style={{
+						backgroundColor: '#0b84f3',
+						borderRadius: 24,
+						height: 220,
+						width: 220,
+					}}
+				/>
+			</Sequence>
+		</AbsoluteFill>
+	);
+};
+
+export default CubicEasingInterpolationTest;

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -392,6 +392,14 @@ export const Index: React.FC = () => {
 					durationInFrames={120}
 				/>
 				<Composition
+					id="cubic-easing-interpolation-test"
+					lazyComponent={() => import('./CubicEasingInterpolationTest')}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={120}
+				/>
+				<Composition
 					id="trim-before-support-test"
 					lazyComponent={() => import('./TrimBeforeSupportTest')}
 					width={1280}

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -15,6 +15,7 @@ import {
 	getKeyframeInterpolationFunctionForSchemaField,
 	isKeyframeInterpolationFunction,
 	isSchemaFieldKeyframable,
+	CUBIC_KEYFRAME_EASING,
 	LINEAR_KEYFRAME_EASING,
 	parseSpringEasingConfig,
 	type KeyframeInterpolationFunction,
@@ -412,10 +413,15 @@ const getKeyframeEasing = (node: Expression): KeyframeEasing | null => {
 		node.object.type === 'Identifier' &&
 		node.object.name === 'Easing' &&
 		node.property.type === 'Identifier' &&
-		node.property.name === 'linear' &&
 		node.computed === false
 	) {
-		return {type: 'linear'};
+		if (node.property.name === 'linear') {
+			return {type: 'linear'};
+		}
+
+		if (node.property.name === 'cubic') {
+			return CUBIC_KEYFRAME_EASING;
+		}
 	}
 
 	if (

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -15,9 +15,7 @@ import {
 	getKeyframeInterpolationFunctionForSchemaField,
 	isKeyframeInterpolationFunction,
 	isSchemaFieldKeyframable,
-	CUBIC_KEYFRAME_EASING,
 	LINEAR_KEYFRAME_EASING,
-	parseSpringEasingConfig,
 	type KeyframeInterpolationFunction,
 } from '@remotion/studio-shared';
 import type {ExpressionKind, SpreadElementKind} from 'ast-types/lib/gen/kinds';
@@ -30,6 +28,7 @@ import type {
 	InteractivitySchema,
 } from 'remotion';
 import {getAstNodePath} from '../../helpers/get-ast-node-path';
+import {parseKeyframeEasingExpression} from '../../helpers/parse-keyframe-easing-expression';
 import {
 	extractStaticValue,
 	findJsxElementAtNodePath,
@@ -403,78 +402,8 @@ const setOptionsProperty = ({
 
 const isLinearEasing = (easing: KeyframeEasing) => easing.type === 'linear';
 
-const getKeyframeEasing = (node: Expression): KeyframeEasing | null => {
-	if (node.type === 'TSAsExpression') {
-		return getKeyframeEasing(node.expression as Expression);
-	}
-
-	if (
-		node.type === 'MemberExpression' &&
-		node.object.type === 'Identifier' &&
-		node.object.name === 'Easing' &&
-		node.property.type === 'Identifier' &&
-		node.computed === false
-	) {
-		if (node.property.name === 'linear') {
-			return {type: 'linear'};
-		}
-
-		if (node.property.name === 'cubic') {
-			return CUBIC_KEYFRAME_EASING;
-		}
-	}
-
-	if (
-		node.type !== 'CallExpression' ||
-		node.callee.type !== 'MemberExpression' ||
-		node.callee.object.type !== 'Identifier' ||
-		node.callee.object.name !== 'Easing' ||
-		node.callee.property.type !== 'Identifier' ||
-		node.callee.computed
-	) {
-		return null;
-	}
-
-	if (node.callee.property.name === 'spring') {
-		if (node.arguments.length > 1) {
-			return null;
-		}
-
-		const springConfig = node.arguments[0];
-		if (
-			springConfig?.type === 'ArgumentPlaceholder' ||
-			springConfig?.type === 'JSXNamespacedName' ||
-			springConfig?.type === 'SpreadElement'
-		) {
-			return null;
-		}
-
-		return parseSpringEasingConfig(springConfig);
-	}
-
-	if (node.callee.property.name !== 'bezier' || node.arguments.length !== 4) {
-		return null;
-	}
-
-	const values = node.arguments.map((arg) => {
-		if (
-			arg.type === 'ArgumentPlaceholder' ||
-			arg.type === 'JSXNamespacedName' ||
-			arg.type === 'SpreadElement'
-		) {
-			return null;
-		}
-
-		return getNumericValue(arg as Expression);
-	});
-
-	if (values.some((value) => value === null)) {
-		return null;
-	}
-
-	const [x1, y1, x2, y2] = values as [number, number, number, number];
-	return {type: 'bezier', x1, y1, x2, y2};
-};
+const getKeyframeEasing = (node: Expression): KeyframeEasing | null =>
+	parseKeyframeEasingExpression(node);
 
 const getKeyframeEasingArray = ({
 	easingNode,

--- a/packages/studio-server/src/helpers/parse-keyframe-easing-expression.ts
+++ b/packages/studio-server/src/helpers/parse-keyframe-easing-expression.ts
@@ -1,0 +1,198 @@
+import type {CallExpression, Expression} from '@babel/types';
+import {
+	CUBIC_KEYFRAME_EASING,
+	EASE_KEYFRAME_EASING,
+	getBackKeyframeEasing,
+	getOutKeyframeEasing,
+	getPolyKeyframeEasing,
+	LINEAR_KEYFRAME_EASING,
+	parseSpringEasingConfig,
+	QUAD_KEYFRAME_EASING,
+} from '@remotion/studio-shared';
+import type {CanUpdateSequencePropStatusEasing} from 'remotion';
+
+const getNumericValue = (node: Expression): number | null => {
+	if (node.type === 'NumericLiteral') {
+		return node.value;
+	}
+
+	if (
+		node.type === 'UnaryExpression' &&
+		(node.operator === '-' || node.operator === '+') &&
+		node.argument.type === 'NumericLiteral'
+	) {
+		return node.operator === '-' ? -node.argument.value : node.argument.value;
+	}
+
+	if (node.type === 'TSAsExpression') {
+		return getNumericValue(node.expression as Expression);
+	}
+
+	return null;
+};
+
+const getExpressionArgument = (
+	arg: CallExpression['arguments'][number] | undefined,
+): Expression | null => {
+	if (
+		arg === undefined ||
+		arg.type === 'ArgumentPlaceholder' ||
+		arg.type === 'JSXNamespacedName' ||
+		arg.type === 'SpreadElement'
+	) {
+		return null;
+	}
+
+	return arg as Expression;
+};
+
+const getMemberExpressionKeyframeEasing = (
+	name: string,
+): CanUpdateSequencePropStatusEasing | null => {
+	if (name === 'linear') {
+		return LINEAR_KEYFRAME_EASING;
+	}
+
+	if (name === 'ease') {
+		return EASE_KEYFRAME_EASING;
+	}
+
+	if (name === 'quad') {
+		return QUAD_KEYFRAME_EASING;
+	}
+
+	if (name === 'cubic') {
+		return CUBIC_KEYFRAME_EASING;
+	}
+
+	return null;
+};
+
+export const parseKeyframeEasingExpression = (
+	node: Expression,
+): CanUpdateSequencePropStatusEasing | null => {
+	if (node.type === 'TSAsExpression') {
+		return parseKeyframeEasingExpression(node.expression as Expression);
+	}
+
+	if (
+		node.type === 'MemberExpression' &&
+		node.object.type === 'Identifier' &&
+		node.object.name === 'Easing' &&
+		node.property.type === 'Identifier' &&
+		node.computed === false
+	) {
+		return getMemberExpressionKeyframeEasing(node.property.name);
+	}
+
+	if (
+		node.type !== 'CallExpression' ||
+		node.callee.type !== 'MemberExpression' ||
+		node.callee.object.type !== 'Identifier' ||
+		node.callee.object.name !== 'Easing' ||
+		node.callee.property.type !== 'Identifier' ||
+		node.callee.computed
+	) {
+		return null;
+	}
+
+	const propertyName = node.callee.property.name;
+
+	if (propertyName === 'spring') {
+		if (node.arguments.length > 1) {
+			return null;
+		}
+
+		if (node.arguments.length === 0) {
+			return parseSpringEasingConfig(undefined);
+		}
+
+		const springConfig = getExpressionArgument(node.arguments[0]);
+		return springConfig ? parseSpringEasingConfig(springConfig) : null;
+	}
+
+	if (propertyName === 'bezier') {
+		if (node.arguments.length !== 4) {
+			return null;
+		}
+
+		const values = node.arguments.map((arg) => {
+			const expression = getExpressionArgument(arg);
+			return expression ? getNumericValue(expression) : null;
+		});
+
+		if (values.some((value) => value === null)) {
+			return null;
+		}
+
+		const [x1, y1, x2, y2] = values as [number, number, number, number];
+		return {type: 'bezier', x1, y1, x2, y2};
+	}
+
+	if (propertyName === 'back') {
+		if (node.arguments.length > 1) {
+			return null;
+		}
+
+		if (node.arguments.length === 0) {
+			return getBackKeyframeEasing();
+		}
+
+		const expression = getExpressionArgument(node.arguments[0]);
+		if (!expression) {
+			return null;
+		}
+
+		const s = getNumericValue(expression);
+		if (s === null) {
+			return null;
+		}
+
+		return getBackKeyframeEasing(s);
+	}
+
+	if (propertyName === 'poly') {
+		if (node.arguments.length !== 1) {
+			return null;
+		}
+
+		const expression = getExpressionArgument(node.arguments[0]);
+		const n = expression ? getNumericValue(expression) : null;
+		return n === null ? null : getPolyKeyframeEasing(n);
+	}
+
+	if (propertyName === 'in') {
+		if (node.arguments.length !== 1) {
+			return null;
+		}
+
+		const expression = getExpressionArgument(node.arguments[0]);
+		return expression ? parseKeyframeEasingExpression(expression) : null;
+	}
+
+	if (propertyName === 'out') {
+		if (node.arguments.length !== 1) {
+			return null;
+		}
+
+		const expression = getExpressionArgument(node.arguments[0]);
+		const easing = expression
+			? parseKeyframeEasingExpression(expression)
+			: null;
+		return easing ? getOutKeyframeEasing(easing) : null;
+	}
+
+	if (propertyName === 'inOut') {
+		if (node.arguments.length !== 1) {
+			return null;
+		}
+
+		const expression = getExpressionArgument(node.arguments[0]);
+		const easing = expression
+			? parseKeyframeEasingExpression(expression)
+			: null;
+		return easing?.type === 'linear' ? easing : null;
+	}
+
+	return null;
+};

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -15,6 +15,7 @@ import type {
 import {RenderInternals} from '@remotion/renderer';
 import type {SubscribeToSequencePropsResponse} from '@remotion/studio-shared';
 import {
+	CUBIC_KEYFRAME_EASING,
 	isKeyframeInterpolationFunction,
 	LINEAR_KEYFRAME_EASING,
 	parseSpringEasingConfig,
@@ -279,10 +280,15 @@ const getKeyframeEasing = (node: Expression): PropEasing[number] | null => {
 		node.object.type === 'Identifier' &&
 		node.object.name === 'Easing' &&
 		node.property.type === 'Identifier' &&
-		node.property.name === 'linear' &&
 		node.computed === false
 	) {
-		return {type: 'linear'};
+		if (node.property.name === 'linear') {
+			return {type: 'linear'};
+		}
+
+		if (node.property.name === 'cubic') {
+			return CUBIC_KEYFRAME_EASING;
+		}
 	}
 
 	if (

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -15,10 +15,8 @@ import type {
 import {RenderInternals} from '@remotion/renderer';
 import type {SubscribeToSequencePropsResponse} from '@remotion/studio-shared';
 import {
-	CUBIC_KEYFRAME_EASING,
 	isKeyframeInterpolationFunction,
 	LINEAR_KEYFRAME_EASING,
-	parseSpringEasingConfig,
 } from '@remotion/studio-shared';
 import * as recast from 'recast';
 import type {
@@ -33,6 +31,7 @@ import {NoReactInternals} from 'remotion/no-react';
 import {parseAst} from '../../codemods/parse-ast';
 import {getAstNodePath} from '../../helpers/get-ast-node-path';
 import {toImportAgnosticNodePath} from '../../helpers/import-agnostic-node-path';
+import {parseKeyframeEasingExpression} from '../../helpers/parse-keyframe-easing-expression';
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import {
 	getJsxComponentIdentity,
@@ -270,78 +269,8 @@ const getExtrapolateType = (node: Expression): ExtrapolateType | null => {
 	return null;
 };
 
-const getKeyframeEasing = (node: Expression): PropEasing[number] | null => {
-	if (node.type === 'TSAsExpression') {
-		return getKeyframeEasing(node.expression as Expression);
-	}
-
-	if (
-		node.type === 'MemberExpression' &&
-		node.object.type === 'Identifier' &&
-		node.object.name === 'Easing' &&
-		node.property.type === 'Identifier' &&
-		node.computed === false
-	) {
-		if (node.property.name === 'linear') {
-			return {type: 'linear'};
-		}
-
-		if (node.property.name === 'cubic') {
-			return CUBIC_KEYFRAME_EASING;
-		}
-	}
-
-	if (
-		node.type !== 'CallExpression' ||
-		node.callee.type !== 'MemberExpression' ||
-		node.callee.object.type !== 'Identifier' ||
-		node.callee.object.name !== 'Easing' ||
-		node.callee.property.type !== 'Identifier' ||
-		node.callee.computed
-	) {
-		return null;
-	}
-
-	if (node.callee.property.name === 'spring') {
-		if (node.arguments.length > 1) {
-			return null;
-		}
-
-		const springConfig = node.arguments[0];
-		if (
-			springConfig?.type === 'ArgumentPlaceholder' ||
-			springConfig?.type === 'JSXNamespacedName' ||
-			springConfig?.type === 'SpreadElement'
-		) {
-			return null;
-		}
-
-		return parseSpringEasingConfig(springConfig);
-	}
-
-	if (node.callee.property.name !== 'bezier' || node.arguments.length !== 4) {
-		return null;
-	}
-
-	const values = node.arguments.map((arg) => {
-		if (
-			arg.type === 'ArgumentPlaceholder' ||
-			arg.type === 'JSXNamespacedName' ||
-			arg.type === 'SpreadElement'
-		) {
-			return null;
-		}
-
-		return getNumericValue(arg as Expression);
-	});
-
-	if (values.some((v) => v === null)) {
-		return null;
-	}
-
-	const [x1, y1, x2, y2] = values as [number, number, number, number];
-	return {type: 'bezier', x1, y1, x2, y2};
-};
+const getKeyframeEasing = (node: Expression): PropEasing[number] | null =>
+	parseKeyframeEasingExpression(node);
 
 const getKeyframeEasingArray = ({
 	easingNode,

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -730,6 +730,44 @@ export const Example: React.FC = () => {
 	});
 });
 
+test('computeSequencePropsStatus should represent Easing.cubic as bezier easing metadata', () => {
+	const input = `import React from 'react';
+import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<Sequence style={{scale: interpolate(frame, [0, 100], [1, 3], {
+\t\t\teasing: Easing.cubic,
+\t\t})}} />
+\t);
+};
+`;
+
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 7),
+		componentIdentity: null,
+		keys: ['style.scale'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.scale']).toEqual({
+		status: 'keyframed',
+		interpolationFunction: 'interpolate',
+		keyframes: [
+			{frame: 0, value: 1},
+			{frame: 100, value: 3},
+		],
+		easing: [{type: 'bezier', x1: 1 / 3, y1: 0, x2: 2 / 3, y2: 0}],
+		clamping: {left: 'extend', right: 'extend'},
+		posterize: undefined,
+	});
+});
+
 test('computeSequencePropsStatus should bail on unsupported easing expressions', () => {
 	const input = `import React from 'react';
 import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -768,6 +768,52 @@ export const Example: React.FC = () => {
 	});
 });
 
+test('computeSequencePropsStatus should represent supported Easing helpers as bezier easing metadata', () => {
+	const input = `import React from 'react';
+import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<Sequence style={{scale: interpolate(frame, [0, 20, 40, 60, 80, 100, 120, 140, 160], [0, 1, 2, 3, 4, 5, 6, 7, 8], {
+\t\t\teasing: [Easing.ease, Easing.quad, Easing.back(), Easing.back(2), Easing.poly(2), Easing.in(Easing.cubic), Easing.out(Easing.quad), Easing.out(Easing.ease)],
+\t\t})}} />
+\t);
+};
+`;
+
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 7),
+		componentIdentity: null,
+		keys: ['style.scale'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.scale']).toMatchObject({
+		status: 'keyframed',
+		easing: [
+			{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
+			{type: 'bezier', x1: 1 / 3, y1: 0, x2: 2 / 3, y2: 1 / 3},
+			{type: 'bezier', x1: 1 / 3, y1: 0, x2: 2 / 3, y2: -1.70158 / 3},
+			{type: 'bezier', x1: 1 / 3, y1: 0, x2: 2 / 3, y2: -2 / 3},
+			{type: 'bezier', x1: 1 / 3, y1: 0, x2: 2 / 3, y2: 1 / 3},
+			{type: 'bezier', x1: 1 / 3, y1: 0, x2: 2 / 3, y2: 0},
+			{
+				type: 'bezier',
+				x1: 1 - 2 / 3,
+				y1: 1 - 1 / 3,
+				x2: 1 - 1 / 3,
+				y2: 1,
+			},
+			{type: 'bezier', x1: 0, y1: 0, x2: 1 - 0.42, y2: 1},
+		],
+	});
+});
+
 test('computeSequencePropsStatus should bail on unsupported easing expressions', () => {
 	const input = `import React from 'react';
 import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';
@@ -776,7 +822,7 @@ export const Example: React.FC = () => {
 \tconst frame = useCurrentFrame();
 \treturn (
 \t\t<Sequence style={{scale: interpolate(frame, [0, 100], [1, 3], {
-\t\t\teasing: Easing.inOut(Easing.linear),
+\t\t\teasing: Easing.inOut(Easing.quad),
 \t\t})}} />
 \t);
 };

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -232,6 +232,35 @@ export const Example: React.FC = () => {
 	).toBe(2);
 });
 
+test('updateSequenceKeyframes represents Easing.back as bezier when editing keyframes', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [0, 100], [0, 1], {easing: Easing.back(2)})}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {type: 'add', frame: 50, value: 0.25},
+			},
+		],
+	});
+
+	expect(output).toContain('interpolate(frame, [0, 50, 100]');
+	expect(output.match(/Easing\.bezier\(/g)?.length).toBe(2);
+	expect(output.match(/-0\.6666666666666666/g)?.length).toBe(2);
+});
+
 test('updateSequenceKeyframes updates a keyframe at the same frame', async () => {
 	const {output, oldValueStrings, newValueStrings} =
 		await updateSequenceKeyframes({

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -200,6 +200,38 @@ export const Example: React.FC = () => {
 	expect(output.match(/Easing\.bezier\(0\.42, 0, 1, 1\)/g)?.length).toBe(2);
 });
 
+test('updateSequenceKeyframes represents Easing.cubic as bezier when editing keyframes', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, Easing, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+\tconst frame = useCurrentFrame();
+\treturn (
+\t\t<AbsoluteFill>
+\t\t\t<div style={{scale: interpolate(frame, [0, 100], [0, 1], {easing: Easing.cubic})}} />
+\t\t</AbsoluteFill>
+\t);
+};
+`;
+	const {output} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'scale')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {type: 'add', frame: 50, value: 0.25},
+			},
+		],
+	});
+
+	expect(output).toContain('interpolate(frame, [0, 50, 100]');
+	expect(
+		output.match(
+			/Easing\.bezier\(0\.3333333333333333, 0, 0\.6666666666666666, 0\)/g,
+		)?.length,
+	).toBe(2);
+});
+
 test('updateSequenceKeyframes updates a keyframe at the same frame', async () => {
 	const {output, oldValueStrings, newValueStrings} =
 		await updateSequenceKeyframes({

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -208,6 +208,7 @@ export {
 	hotMiddlewareOptions,
 } from './hot-middleware';
 export {
+	CUBIC_KEYFRAME_EASING,
 	KEYFRAME_EASING_PRESETS,
 	LINEAR_KEYFRAME_EASING,
 	type KeyframeEasing,

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -209,8 +209,13 @@ export {
 } from './hot-middleware';
 export {
 	CUBIC_KEYFRAME_EASING,
+	EASE_KEYFRAME_EASING,
+	getBackKeyframeEasing,
+	getOutKeyframeEasing,
+	getPolyKeyframeEasing,
 	KEYFRAME_EASING_PRESETS,
 	LINEAR_KEYFRAME_EASING,
+	QUAD_KEYFRAME_EASING,
 	type KeyframeEasing,
 	type KeyframeEasingPreset,
 } from './keyframe-easing-presets';

--- a/packages/studio-shared/src/keyframe-easing-presets.ts
+++ b/packages/studio-shared/src/keyframe-easing-presets.ts
@@ -16,6 +16,14 @@ export type KeyframeEasingPreset = {
 
 export const LINEAR_KEYFRAME_EASING: KeyframeEasing = {type: 'linear'};
 
+export const CUBIC_KEYFRAME_EASING: KeyframeEasing = {
+	type: 'bezier',
+	x1: 1 / 3,
+	y1: 0,
+	x2: 2 / 3,
+	y2: 0,
+};
+
 export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [
 	{
 		id: 'ease-in',

--- a/packages/studio-shared/src/keyframe-easing-presets.ts
+++ b/packages/studio-shared/src/keyframe-easing-presets.ts
@@ -16,12 +16,72 @@ export type KeyframeEasingPreset = {
 
 export const LINEAR_KEYFRAME_EASING: KeyframeEasing = {type: 'linear'};
 
+export const EASE_KEYFRAME_EASING: KeyframeEasing = {
+	type: 'bezier',
+	x1: 0.42,
+	y1: 0,
+	x2: 1,
+	y2: 1,
+};
+
+export const QUAD_KEYFRAME_EASING: KeyframeEasing = {
+	type: 'bezier',
+	x1: 1 / 3,
+	y1: 0,
+	x2: 2 / 3,
+	y2: 1 / 3,
+};
+
 export const CUBIC_KEYFRAME_EASING: KeyframeEasing = {
 	type: 'bezier',
 	x1: 1 / 3,
 	y1: 0,
 	x2: 2 / 3,
 	y2: 0,
+};
+
+export const getBackKeyframeEasing = (s = 1.70158): KeyframeEasing => ({
+	type: 'bezier',
+	x1: 1 / 3,
+	y1: 0,
+	x2: 2 / 3,
+	y2: -s / 3,
+});
+
+export const getPolyKeyframeEasing = (n: number): KeyframeEasing | null => {
+	if (n === 1) {
+		return LINEAR_KEYFRAME_EASING;
+	}
+
+	if (n === 2) {
+		return QUAD_KEYFRAME_EASING;
+	}
+
+	if (n === 3) {
+		return CUBIC_KEYFRAME_EASING;
+	}
+
+	return null;
+};
+
+export const getOutKeyframeEasing = (
+	easing: KeyframeEasing,
+): KeyframeEasing | null => {
+	if (easing.type === 'linear') {
+		return LINEAR_KEYFRAME_EASING;
+	}
+
+	if (easing.type !== 'bezier') {
+		return null;
+	}
+
+	return {
+		type: 'bezier',
+		x1: 1 - easing.x2,
+		y1: 1 - easing.y2,
+		x2: 1 - easing.x1,
+		y2: 1 - easing.y1,
+	};
 };
 
 export const KEYFRAME_EASING_PRESETS: KeyframeEasingPreset[] = [


### PR DESCRIPTION
## Summary

- Represent exact Bezier-compatible `Easing` helpers as Bezier metadata in Studio interactivity parsing
- Preserve that representation when keyframe edits rewrite easing arrays
- Add a test composition in `packages/example` that uses `Easing.cubic`
- Document supported Studio source easing expressions

Closes #8863

## Tests

- `bunx oxfmt src --write` in `packages/example`, `packages/studio-server`, and `packages/studio-shared`
- `bun run build`
- `bun run stylecheck`
- `bun run build-docs`
