### PR TITLE
`@remotion/studio`: Select inspector on Studio selection

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -43,6 +43,7 @@ import {
 	ExpandedTracksSetterContext,
 	type GetIsExpanded,
 } from '../ExpandedTracksProvider';
+import {selectOptionsSidebarInspectorPanel} from '../options-sidebar-tabs';
 import {getNodeHasKeyframes, getNodeKeyframes} from './get-node-keyframes';
 import {getTimelineEasingSegments} from './get-timeline-easing-segments';
 import {
@@ -1245,6 +1246,7 @@ export const TimelineSelectionProvider: React.FC<{
 				return;
 			}
 
+			selectOptionsSidebarInspectorPanel();
 			expandParentsForSelectionItem(item);
 			if (options.reveal) {
 				requestRevealSelectionItem(item);
@@ -1284,6 +1286,10 @@ export const TimelineSelectionProvider: React.FC<{
 		) => {
 			if (!items.every(canSelectItem)) {
 				return;
+			}
+
+			if (items.length > 0) {
+				selectOptionsSidebarInspectorPanel();
 			}
 
 			selectionScope.current = timelineSelectionScope;

--- a/packages/studio/src/components/options-sidebar-tabs.ts
+++ b/packages/studio/src/components/options-sidebar-tabs.ts
@@ -4,3 +4,7 @@ export const optionsSidebarTabs = createRef<{
 	selectInspectorPanel: () => void;
 	selectRendersPanel: () => void;
 }>();
+
+export const selectOptionsSidebarInspectorPanel = () => {
+	optionsSidebarTabs.current?.selectInspectorPanel();
+};


### PR DESCRIPTION
## Summary

- switch the Studio options sidebar back to Inspector when a timeline/canvas selection is made
- keep empty selection updates from changing the selected sidebar tab

Closes https://github.com/remotion-dev/remotion/issues/8868

## Test plan

- bun test src/test/timeline-selection.test.ts
- bun run build
- bun run stylecheck
