### PR TITLE
`@remotion/studio`: Preserve outline drag cursor

### DIFF
--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -593,7 +593,7 @@ const SelectedOutlinePolygon: React.FC<{
 
 					dragStarted = true;
 					onDraggingChange(true);
-					forceSpecificCursor('move');
+					forceSpecificCursor('default');
 				}
 
 				const axisLockedDirection = axisLocked

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -593,6 +593,7 @@ const SelectedOutlinePolygon: React.FC<{
 
 					dragStarted = true;
 					onDraggingChange(true);
+					forceSpecificCursor('move');
 				}
 
 				const axisLockedDirection = axisLocked
@@ -692,6 +693,7 @@ const SelectedOutlinePolygon: React.FC<{
 				window.removeEventListener('keydown', onKeyChange);
 				window.removeEventListener('keyup', onKeyChange);
 				if (dragStarted) {
+					stopForcingSpecificCursor();
 					onDraggingChange(false);
 				}
 


### PR DESCRIPTION
## Summary

- keep the existing default cursor active while dragging selected Studio outlines
- prevent guide hover cursors from taking over during the drag
- release the forced cursor when the drag finishes

Closes #8849

## Testing

- `bunx oxfmt src --write` in `packages/studio`
- `bunx turbo run make --filter='@remotion/studio' --no-update-notifier`
- `bun run build`
- `bun run stylecheck`
