### PR TITLE
Docs: Sync llms.txt system prompt

### DIFF
--- a/packages/docs/static/llms.txt
+++ b/packages/docs/static/llms.txt
@@ -167,11 +167,11 @@ export const MyComp: React.FC = () => {
 ```
 
 A Sequence has a "from" prop that specifies the frame number where the element should appear.
-The "from" prop can be negative, in which case the Sequence will start immediately but cut off the first "from" frames.
+A Sequence has a "trimBefore" prop that trims the start of the child timeline by a number of frames.
 
 A Sequence has a "durationInFrames" prop that specifies how long the element should appear.
 
-If a child component of Sequence calls "useCurrentFrame()", the enumeration starts from the first frame the Sequence appears and starts at 0.
+If a child component of Sequence calls "useCurrentFrame()", the enumeration starts from the first frame the Sequence appears and starts at "trimBefore".
 
 ```tsx
 import {Sequence} from 'remotion';


### PR DESCRIPTION
## Summary

- Update `packages/docs/static/llms.txt` so the `Sequence` guidance matches the generated `system-prompt.ts` helper.
- Keep the source prompt aligned with the existing `trimBefore` wording.

## Testing

- `bunx oxfmt src --write` in `packages/docs`
- `bun run build`
- `bun run stylecheck`
- generated prompt comparison: `IN_SYNC`
