### PR TITLE
Docs: Add interactive element name guidance

### DIFF
--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -15,7 +15,7 @@ When a value is shown as computed in the Studio, it often means that the value i
 When converting a component for Studio interactivity, apply all of these rules together:
 
 - Use `Interactive.*` for editable HTML or SVG elements, or [`Interactive.withSchema()`](/docs/interactive-with-schema) for custom components.
-- Add a non-empty, descriptive `name` prop to the editable element or custom component.
+- Add a descriptive `name` prop to the editable element or custom component.
 - Keep every editable or keyframed value inline at the JSX prop that the Studio edits.
 - Keep `interpolate()` keyframe arrays as hardcoded numeric arrays, such as `[0, 30]`.
 - Use Studio-editable style props such as `translate`, `scale`, `rotate`, `transformOrigin` and `opacity` instead of hiding values in a `transform` string.
@@ -39,13 +39,13 @@ Use the [`Interactive`](/docs/interactive) namespace when an HTML or SVG element
 For a custom component, see [Make a component interactive](/docs/studio/make-component-interactive).
 
 ```txt title="Prompt"
-/remotion-best-practices Make this element editable in Remotion Studio. Use Interactive.* for tweakable HTML/SVG elements, add a non-empty name prop and keep editable style values inline.
+/remotion-best-practices Make this element editable in Remotion Studio. Use Interactive.* for tweakable HTML/SVG elements, add a descriptive name prop and keep editable style values inline.
 ```
 
 ## Give interactive elements a descriptive name {#give-interactive-elements-a-descriptive-name}
 
-Add a non-empty `name` prop to interactive elements and custom interactive components.
-Use a short label that describes the element in the scene, not an empty string.
+Add a `name` prop to interactive elements and custom interactive components.
+Use a short label that describes the element in the scene.
 
 The name is shown in the Studio timeline and helps agents identify the correct element when making visual edits.
 
@@ -55,8 +55,8 @@ The name is shown in the Studio timeline and helps agents identify the correct e
   Launch day
 </Interactive.Div>
 
-// 👎 Empty names are hard to identify in the Studio timeline and by agents
-<Interactive.Div name="" style={{fontSize: 80}}>
+// 👎 Omitted names are hard to identify in the Studio timeline and by agents
+<Interactive.Div style={{fontSize: 80}}>
   Launch day
 </Interactive.Div>
 ```

--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -15,7 +15,7 @@ When a value is shown as computed in the Studio, it often means that the value i
 When converting a component for Studio interactivity, apply all of these rules together:
 
 - Use `Interactive.*` for editable HTML or SVG elements, or [`Interactive.withSchema()`](/docs/interactive-with-schema) for custom components.
-- Add a descriptive `name` prop to the editable element or custom component.
+- Add a non-empty, descriptive `name` prop to the editable element or custom component.
 - Keep every editable or keyframed value inline at the JSX prop that the Studio edits.
 - Keep `interpolate()` keyframe arrays as hardcoded numeric arrays, such as `[0, 30]`.
 - Use Studio-editable style props such as `translate`, `scale`, `rotate`, `transformOrigin` and `opacity` instead of hiding values in a `transform` string.
@@ -28,7 +28,9 @@ Use the [`Interactive`](/docs/interactive) namespace when an HTML or SVG element
 
 ```tsx title="Interactive elements"
 // 👍 Selectable and editable in the Studio
-<Interactive.Div style={{fontSize: 80, padding: 24}}>Hello</Interactive.Div>
+<Interactive.Div name="Greeting card" style={{fontSize: 80, padding: 24}}>
+  Hello
+</Interactive.Div>
 
 // 👎 A regular element is not Studio-editable
 <div style={{fontSize: 80, padding: 24}}>Hello</div>
@@ -37,12 +39,12 @@ Use the [`Interactive`](/docs/interactive) namespace when an HTML or SVG element
 For a custom component, see [Make a component interactive](/docs/studio/make-component-interactive).
 
 ```txt title="Prompt"
-/remotion-best-practices Make this element editable in Remotion Studio. Use Interactive.* for tweakable HTML/SVG elements and keep editable style values inline.
+/remotion-best-practices Make this element editable in Remotion Studio. Use Interactive.* for tweakable HTML/SVG elements, add a non-empty name prop and keep editable style values inline.
 ```
 
 ## Give interactive elements a descriptive name {#give-interactive-elements-a-descriptive-name}
 
-Add a `name` prop to interactive elements and custom interactive components.
+Add a non-empty `name` prop to interactive elements and custom interactive components.
 Use a short label that describes the element in the scene, not an empty string.
 
 The name is shown in the Studio timeline and helps agents identify the correct element when making visual edits.
@@ -50,6 +52,11 @@ The name is shown in the Studio timeline and helps agents identify the correct e
 ```tsx title="Interactive names"
 // 👍 Easy to find in the Studio timeline and by agents
 <Interactive.Div name="Hero title" style={{fontSize: 80}}>
+  Launch day
+</Interactive.Div>
+
+// 👎 Empty names are hard to identify in the Studio timeline and by agents
+<Interactive.Div name="" style={{fontSize: 80}}>
   Launch day
 </Interactive.Div>
 ```
@@ -67,6 +74,7 @@ The input range must use hardcoded numbers, not variables or expressions such as
 ```tsx title="Inline values"
 // 👍 Inline values can be standardized and keyframed
 <Interactive.Div
+  name="Product card"
   style={{
     color: 'white',
     fontSize: 80,
@@ -87,6 +95,7 @@ const translateY = interpolate(frame, [0, 30], [0, 120]);
 const rotation = interpolate(frame, [0, 30], [0, 20]);
 
 <Interactive.Div
+  name="Product card"
   style={{
     ...container,
     transform: `translateY(${translateY}px) rotate(${rotation}deg)`,
@@ -137,6 +146,7 @@ const easedProgress = Easing.out(Easing.cubic)(
 );
 
 <Interactive.Div
+  name="Prompt bubble"
   style={{
     position: 'absolute',
     right: 56,

--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -39,7 +39,7 @@ Use the [`Interactive`](/docs/interactive) namespace when an HTML or SVG element
 For a custom component, see [Make a component interactive](/docs/studio/make-component-interactive).
 
 ```txt title="Prompt"
-/remotion-best-practices Make this element editable in Remotion Studio. Use Interactive.* for tweakable HTML/SVG elements, add a descriptive name prop and keep editable style values inline.
+Make this interactive in the Remotion Studio: https://www.remotion.dev/docs/studio/interactivity-best-practices.md
 ```
 
 ## Give interactive elements a descriptive name {#give-interactive-elements-a-descriptive-name}
@@ -162,7 +162,7 @@ Use `top`, `left`, `right` and `bottom` for static layout anchors.
 When the value changes over time or should be draggable/keyframable in the Studio, put the moving part into `translate`.
 
 ```txt title="Prompt"
-/remotion-best-practices Fix computed values in Remotion Studio. Follow https://www.remotion.dev/docs/studio/interactivity-best-practices#keep-editable-values-visible. Move editable values into the JSX style object, inline opacity/scale/rotate/translate values, use hardcoded numeric interpolate() keyframe arrays such as [30, 50], pass easing in the interpolate() options, replace transform strings with scale/rotate/translate, and use translate instead of animated top/left/right/bottom.
+Make this interactive in the Remotion Studio: https://www.remotion.dev/docs/studio/interactivity-best-practices.md
 ```
 
 ## Keep composition metadata inline {#keep-composition-metadata-inline}
@@ -204,7 +204,7 @@ const calculateMetadata = () => {
 Use [`calculateMetadata()`](/docs/calculate-metadata) when metadata depends on dynamic input props, fetched data or asset metadata.
 
 ```txt title="Prompt"
-/remotion-best-practices Fix Composition metadata for Remotion Studio. Keep defaultProps, width, height, fps, and durationInFrames inline on the Composition unless calculateMetadata needs dynamic data.
+Make this interactive in the Remotion Studio: https://www.remotion.dev/docs/studio/interactivity-best-practices.md
 ```
 
 ## Keep effects editable {#keep-effects-editable}
@@ -243,7 +243,7 @@ const center = [0.5, 0.5] as const;
 Render separate elements if one version should have effects and another should not.
 
 ```txt title="Prompt"
-/remotion-best-practices Fix computed effect controls in Remotion Studio. Keep effect parameters inline in the effect call and keep the effects array shape unconditional.
+Make this interactive in the Remotion Studio: https://www.remotion.dev/docs/studio/interactivity-best-practices.md
 ```
 
 ## See also


### PR DESCRIPTION
## Summary

- Clarify that interactive elements need a non-empty, descriptive `name` prop.
- Update the interactivity best-practices examples and prompt to model named `Interactive.*` elements.
- Add an explicit bad example for `name=""`.

## Testing

- `bunx oxfmt src --write` in `packages/docs`
- `bun render-cards.ts` in `packages/docs`
- `bun run build-docs`
- `bun run build`
- `bun run stylecheck`

Closes #8814
