### PR TITLE
Docs: Clean up Lower Third element

### DIFF
--- a/packages/docs/elements/index.mdx
+++ b/packages/docs/elements/index.mdx
@@ -27,6 +27,7 @@ An Element should be:
 - Zero-dependency where possible, with [Remotion Effects](/docs/effects) as an exception
 - Safe to compose in Studio with normal z-layering
 - Free of unexpected global styles, layout side effects, and fullscreen assumptions unless it is explicitly a background
+- Sized to the smallest useful bounding box; placement in a video should come from the surrounding `<Sequence>`, not from internal padding or fullscreen wrappers
 
 Heavier Maps, Three.js, WebGL, Canvas, and R3F Elements can come later as separate batches of work.
 

--- a/packages/docs/elements/overlays/lower-third/index.mdx
+++ b/packages/docs/elements/overlays/lower-third/index.mdx
@@ -10,4 +10,4 @@ import {LowerThird} from './lower-third';
 
 A clean animated lower third for introducing a speaker, guest, or section.
 
-<ElementPage component={LowerThird} displayName="Lower Third" elementHeight={138} elementWidth={680} height={160} slug="overlays/lower-third" sourceFile="./lower-third.tsx" width={720} />
+<ElementPage component={LowerThird} displayName="Lower Third" elementHeight={138} elementWidth={680} previewPadding={48} slug="overlays/lower-third" sourceFile="./lower-third.tsx" />

--- a/packages/docs/elements/overlays/lower-third/index.mdx
+++ b/packages/docs/elements/overlays/lower-third/index.mdx
@@ -10,4 +10,4 @@ import {LowerThird} from './lower-third';
 
 A clean animated lower third for introducing a speaker, guest, or section.
 
-<ElementPage component={LowerThird} displayName="Lower Third" elementHeight={138} elementWidth={680} previewPadding={48} slug="overlays/lower-third" sourceFile="./lower-third.tsx" />
+<ElementPage component={LowerThird} displayName="Lower Third" elementHeight={138} elementWidth={680} previewPadding={300} slug="overlays/lower-third" sourceFile="./lower-third.tsx" />

--- a/packages/docs/elements/overlays/lower-third/index.mdx
+++ b/packages/docs/elements/overlays/lower-third/index.mdx
@@ -10,4 +10,4 @@ import {LowerThird} from './lower-third';
 
 A clean animated lower third for introducing a speaker, guest, or section.
 
-<ElementPage component={LowerThird} displayName="Lower Third" elementHeight={1080} elementWidth={1920} slug="overlays/lower-third" sourceFile="./lower-third.tsx" />
+<ElementPage component={LowerThird} displayName="Lower Third" elementHeight={138} elementWidth={680} height={160} slug="overlays/lower-third" sourceFile="./lower-third.tsx" width={720} />

--- a/packages/docs/elements/overlays/lower-third/lower-third.tsx
+++ b/packages/docs/elements/overlays/lower-third/lower-third.tsx
@@ -14,8 +14,17 @@ export const LowerThird: React.FC = () => {
 		<Interactive.Div
 			name="Lower third"
 			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 24,
 				width: 680,
+				boxSizing: 'border-box',
+				padding: 24,
+				borderRadius: 24,
 				fontFamily: 'Inter',
+				backgroundColor: 'rgba(255, 255, 255, 0.94)',
+				boxShadow: '0 6px 12px rgba(24, 24, 27, 0.2)',
+				border: '1px solid rgba(24, 24, 27, 0.08)',
 				opacity: interpolate(frame, [0, 18], [0, 1], {
 					extrapolateRight: 'clamp',
 				}),
@@ -34,71 +43,55 @@ export const LowerThird: React.FC = () => {
 			}}
 		>
 			<Interactive.Div
-				name="Lower third card"
+				name="Initials badge"
 				style={{
 					display: 'flex',
 					alignItems: 'center',
-					gap: 24,
-					width: '100%',
-					boxSizing: 'border-box',
-					padding: 24,
-					borderRadius: 24,
-					backgroundColor: 'rgba(255, 255, 255, 0.94)',
-					boxShadow: '0 6px 12px rgba(24, 24, 27, 0.2)',
-					border: '1px solid rgba(24, 24, 27, 0.08)',
+					justifyContent: 'center',
+					width: 88,
+					height: 88,
+					borderRadius: 20,
+					background: 'linear-gradient(135deg, #2563eb, #60a5fa)',
+					color: 'white',
+					fontSize: 34,
+					fontWeight: 600,
+					lineHeight: 1,
+					boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.3)',
+				}}
+			>
+				AM
+			</Interactive.Div>
+			<div
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					gap: 2,
+					minWidth: 0,
 				}}
 			>
 				<Interactive.Div
-					name="Initials badge"
+					name="Name"
 					style={{
-						display: 'flex',
-						alignItems: 'center',
-						justifyContent: 'center',
-						width: 88,
-						height: 88,
-						borderRadius: 20,
-						background: 'linear-gradient(135deg, #2563eb, #60a5fa)',
-						color: 'white',
-						fontSize: 34,
-						fontWeight: 600,
+						color: '#18181b',
+						fontSize: 48,
+						fontWeight: 700,
 						lineHeight: 1,
-						boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.3)',
 					}}
 				>
-					AM
+					Alex Morgan
 				</Interactive.Div>
-				<div
+				<Interactive.Div
+					name="Title"
 					style={{
-						display: 'flex',
-						flexDirection: 'column',
-						gap: 2,
-						minWidth: 0,
+						color: '#52525b',
+						fontSize: 26,
+						fontWeight: 500,
+						lineHeight: 1,
 					}}
 				>
-					<Interactive.Div
-						name="Name"
-						style={{
-							color: '#18181b',
-							fontSize: 48,
-							fontWeight: 700,
-							lineHeight: 1,
-						}}
-					>
-						Alex Morgan
-					</Interactive.Div>
-					<Interactive.Div
-						name="Title"
-						style={{
-							color: '#52525b',
-							fontSize: 26,
-							fontWeight: 500,
-							lineHeight: 1,
-						}}
-					>
-						Creative Developer
-					</Interactive.Div>
-				</div>
-			</Interactive.Div>
+					Creative Developer
+				</Interactive.Div>
+			</div>
 		</Interactive.Div>
 	);
 };

--- a/packages/docs/elements/overlays/lower-third/lower-third.tsx
+++ b/packages/docs/elements/overlays/lower-third/lower-third.tsx
@@ -1,121 +1,104 @@
+import {loadFont} from '@remotion/google-fonts/Inter';
 import React from 'react';
-import {
-	AbsoluteFill,
-	Easing,
-	Interactive,
-	interpolate,
-	useCurrentFrame,
-	useVideoConfig,
-} from 'remotion';
+import {Easing, Interactive, interpolate, useCurrentFrame} from 'remotion';
+
+loadFont('normal', {
+	subsets: ['latin'],
+	weights: ['500', '600', '700'],
+});
 
 export const LowerThird: React.FC = () => {
 	const frame = useCurrentFrame();
-	const {durationInFrames} = useVideoConfig();
-
-	const exitStart = Math.max(0, durationInFrames - 28);
-	const exitEnd = Math.max(exitStart + 1, durationInFrames - 8);
 
 	return (
-		<AbsoluteFill
+		<Interactive.Div
+			name="Lower third"
 			style={{
-				fontFamily: 'Inter, system-ui, sans-serif',
-				pointerEvents: 'none',
+				width: 680,
+				fontFamily: 'Inter',
+				opacity: interpolate(frame, [0, 18], [0, 1], {
+					extrapolateRight: 'clamp',
+				}),
+				translate: interpolate(frame, [0, 24], ['32px 0px', '0px 0px'], {
+					extrapolateRight: 'clamp',
+					easing: Easing.spring({
+						damping: 180,
+						stiffness: 120,
+					}),
+				}),
+				scale: interpolate(frame, [0, 22], [0.96, 1], {
+					extrapolateRight: 'clamp',
+					easing: Easing.bezier(0.33, 1, 0.68, 1),
+				}),
+				transformOrigin: 'left bottom',
 			}}
 		>
 			<Interactive.Div
-				name="Lower third position"
+				name="Lower third card"
 				style={{
-					position: 'absolute',
-					left: 140,
-					bottom: 120,
-					width: 680,
-					opacity:
-						interpolate(frame, [0, 18], [0, 1], {
-							extrapolateRight: 'clamp',
-							easing: Easing.out(Easing.cubic),
-						}) *
-						interpolate(frame, [exitStart, exitEnd], [1, 0], {
-							extrapolateLeft: 'clamp',
-							extrapolateRight: 'clamp',
-						}),
-					translate: interpolate(frame, [0, 24], ['-72px 0px', '0px 0px'], {
-						extrapolateRight: 'clamp',
-						easing: Easing.spring({
-							damping: 180,
-							stiffness: 120,
-						}),
-					}),
-					scale: interpolate(frame, [0, 22], [0.96, 1], {
-						extrapolateRight: 'clamp',
-						easing: Easing.out(Easing.cubic),
-					}),
-					transformOrigin: 'left bottom',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 24,
+					width: '100%',
+					boxSizing: 'border-box',
+					padding: 24,
+					borderRadius: 24,
+					backgroundColor: 'rgba(255, 255, 255, 0.94)',
+					boxShadow: '0 6px 12px rgba(24, 24, 27, 0.2)',
+					border: '1px solid rgba(24, 24, 27, 0.08)',
 				}}
 			>
 				<Interactive.Div
-					name="Lower third card"
+					name="Initials badge"
 					style={{
 						display: 'flex',
 						alignItems: 'center',
-						gap: 24,
-						padding: 24,
-						borderRadius: 24,
-						backgroundColor: 'rgba(255, 255, 255, 0.94)',
-						boxShadow: '0 6px 12px rgba(24, 24, 27, 0.2)',
-						border: '1px solid rgba(24, 24, 27, 0.08)',
+						justifyContent: 'center',
+						width: 88,
+						height: 88,
+						borderRadius: 20,
+						background: 'linear-gradient(135deg, #2563eb, #60a5fa)',
+						color: 'white',
+						fontSize: 34,
+						fontWeight: 600,
+						lineHeight: 1,
+						boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.3)',
+					}}
+				>
+					AM
+				</Interactive.Div>
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 2,
+						minWidth: 0,
 					}}
 				>
 					<Interactive.Div
-						name="Initials badge"
+						name="Name"
 						style={{
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-							width: 88,
-							height: 88,
-							borderRadius: 20,
-							background: 'linear-gradient(135deg, #2563eb, #60a5fa)',
-							color: 'white',
-							fontSize: 34,
-							fontWeight: 600,
-							letterSpacing: -1,
-							boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.3)',
+							color: '#18181b',
+							fontSize: 48,
+							fontWeight: 700,
+							lineHeight: 1,
 						}}
 					>
-						AM
+						Alex Morgan
 					</Interactive.Div>
-					<div
+					<Interactive.Div
+						name="Title"
 						style={{
-							display: 'flex',
-							flexDirection: 'column',
-							gap: 2,
-							minWidth: 0,
+							color: '#52525b',
+							fontSize: 26,
+							fontWeight: 500,
+							lineHeight: 1,
 						}}
 					>
-						<Interactive.Div
-							name="Name"
-							style={{
-								color: '#18181b',
-								fontSize: 48,
-								fontWeight: 650,
-								letterSpacing: -1.6,
-							}}
-						>
-							Alex Morgan
-						</Interactive.Div>
-						<Interactive.Div
-							name="Title"
-							style={{
-								color: '#52525b',
-								fontSize: 26,
-								fontWeight: 500,
-							}}
-						>
-							Creative Developer
-						</Interactive.Div>
-					</div>
-				</Interactive.Div>
+						Creative Developer
+					</Interactive.Div>
+				</div>
 			</Interactive.Div>
-		</AbsoluteFill>
+		</Interactive.Div>
 	);
 };

--- a/packages/docs/elements/overlays/lower-third/lower-third.tsx
+++ b/packages/docs/elements/overlays/lower-third/lower-third.tsx
@@ -12,7 +12,7 @@ export const LowerThird: React.FC = () => {
 
 	return (
 		<Interactive.Div
-			name="Lower third"
+			name="Container"
 			style={{
 				display: 'flex',
 				alignItems: 'center',

--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -94,6 +94,7 @@ Avoid redundant nested `Interactive.*` wrappers that represent the same visual o
 Every `Interactive.*` wrapper should have a descriptive `name`.
 Avoid repeating the Element display name inside source names; the dragged wrapper already gets named from `displayName`.
 For the main inner editable element, use a generic name such as `Container`.
+For broader rules on editable styles and animation values, see [Interactivity best practices](/docs/studio/interactivity-best-practices).
 
 For a single editable object, use one named wrapper:
 

--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -82,6 +82,7 @@ export const MyElement = () => {
 
 Use this for overlays, lower thirds, callouts, motion graphics, cards, badges, and data animations.
 Size the Element to the smallest useful bounding box. Avoid using a full-video canvas, internal placement padding, or fullscreen wrappers unless the Element is a background.
+Use `previewPadding` on the `ElementPage` if the docs preview needs more breathing room without changing the Element's drag dimensions.
 Do not put the wrapper [`<Sequence>`](/docs/sequence) into the Element source file.
 
 ## Assets and dependencies

--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -95,6 +95,61 @@ Every `Interactive.*` wrapper should have a descriptive `name`.
 Avoid repeating the Element display name inside source names; the dragged wrapper already gets named from `displayName`.
 For the main inner editable element, use a generic name such as `Container`.
 
+For a single editable object, use one named wrapper:
+
+```tsx twoslash title="Single editable object"
+import {Interactive, interpolate, useCurrentFrame} from 'remotion';
+
+export const Badge = () => {
+  const frame = useCurrentFrame();
+
+  return (
+    <Interactive.Div
+      name="Container"
+      style={{
+        opacity: interpolate(frame, [0, 20], [0, 1]),
+        translate: interpolate(frame, [0, 20], ['0px 24px', '0px 0px']),
+        padding: 24,
+        borderRadius: 16,
+        backgroundColor: 'white',
+      }}
+    >
+      Launch day
+    </Interactive.Div>
+  );
+};
+```
+
+If a child has separate useful controls, make the child interactive and name it:
+
+```tsx twoslash title="Named child controls"
+import {Interactive} from 'remotion';
+
+export const Badge = () => {
+  return (
+    <Interactive.Div
+      name="Container"
+      style={{
+        padding: 24,
+        borderRadius: 16,
+        backgroundColor: 'white',
+      }}
+    >
+      <Interactive.Div
+        name="Title"
+        style={{
+          color: 'black',
+          fontSize: 44,
+          fontWeight: 700,
+        }}
+      >
+        Launch day
+      </Interactive.Div>
+    </Interactive.Div>
+  );
+};
+```
+
 ## Assets and dependencies
 
 Prefer zero dependencies.

--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -42,26 +42,16 @@ export const MyElement = () => {
 };
 ```
 
-## 3. Keep the source file portable
+## 3. Ensure portability
 
 The source file should work when dragged or copied into a project.
 
-Prefer:
+- Must be a self-contained TSX file
+- Assets must be remote with stable public URLs, no local ones
+- Non-websafe fonts must be loaded through Google Fonts
+- No highly branded videos
 
-- One self-contained TSX file
-- Zero dependencies
-- Remote assets with stable public URLs
-- Explicit font loading if a specific font is used
-
-Avoid:
-
-- Private APIs or private assets
-- Large apps with many moving parts
-- Highly specific branded videos
-- Full video templates with many unrelated parts
-- Maps, Three.js, WebGL, Canvas, or R3F-heavy Elements for the first batch
-
-## 4. Set the import bounds
+## 4. Define size
 
 To give an Element a fixed size, set `elementWidth` and `elementHeight` on the `ElementPage` in `index.mdx`:
 
@@ -83,10 +73,7 @@ export const MyElement = () => {
 };
 ```
 
-Use fixed bounds for overlays, lower thirds, callouts, motion graphics, cards, badges, and data animations.
-
 Size the Element to the smallest useful bounding box.
-`elementWidth` and `elementHeight` should describe the useful import bounds, not the decorative preview bounds.
 
 Use `previewPadding` on the `ElementPage` if the docs preview needs more breathing room without changing the Element's drag dimensions or adding source padding.
 
@@ -95,9 +82,8 @@ Do not put the wrapper [`<Sequence>`](/docs/sequence) into the Element source fi
 ## 5. Separate placement from animation
 
 Let the Studio-inserted [`<Sequence>`](/docs/sequence) handle placement in the video.
-Avoid static `left`, `right`, `top`, and `bottom` placement inside the Element source unless it is intrinsic to the visual.
+Don't use `left`, `right`, `top`, and `bottom`, etc. to position your element.
 
-The outer placement shell can position the Element in a video.
 Inner Element styles can animate entrance values such as `translate`, `scale`, and `opacity`.
 
 For animation, keep the timing inside the component but let the surrounding project decide how long the Element appears:
@@ -136,7 +122,7 @@ Avoid:
 
 For the main inner editable element, use a generic name such as `Container`.
 
-For broader rules on editable styles and animation values, see [Interactivity best practices](/docs/studio/interactivity-best-practices).
+You should follow [Interactivity best practices](/docs/studio/interactivity-best-practices).
 
 For a single editable object, use one named wrapper:
 
@@ -193,19 +179,7 @@ export const Badge = () => {
 };
 ```
 
-## 7. Reference assets by URL
-
-Prefer zero dependencies.
-If an Element needs binary assets, reference them by URL:
-
-```tsx twoslash title="Remote assets"
-const imageUrl = 'https://remotion.media/element-image.png';
-const videoUrl = 'https://remotion.media/element-video.mp4';
-```
-
-Remote assets should be publicly accessible and stable.
-
-## 8. Open the pull request
+## 7. Open the pull request
 
 When submitting an Element as a pull request, include:
 

--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -81,9 +81,19 @@ export const MyElement = () => {
 ```
 
 Use this for overlays, lower thirds, callouts, motion graphics, cards, badges, and data animations.
-Size the Element to the smallest useful bounding box. Avoid using a full-video canvas, internal placement padding, or fullscreen wrappers unless the Element is a background.
-Use `previewPadding` on the `ElementPage` if the docs preview needs more breathing room without changing the Element's drag dimensions.
+Size the Element to the smallest useful bounding box. `elementWidth` and `elementHeight` should describe the useful import bounds, not the decorative preview bounds.
+Use `previewPadding` on the `ElementPage` if the docs preview needs more breathing room without changing the Element's drag dimensions or adding source padding.
+Let the Studio-inserted [`<Sequence>`](/docs/sequence) handle placement in the video. Avoid static `left`, `right`, `top`, and `bottom` placement inside the Element source unless it is intrinsic to the visual.
+Separate placement from animation: the outer placement shell can position the Element in a video, while inner Element styles can animate entrance values such as `translate`, `scale`, and `opacity`.
 Do not put the wrapper [`<Sequence>`](/docs/sequence) into the Element source file.
+
+## Interactivity
+
+Only add `Interactive.*` wrappers when they expose useful Studio controls.
+Avoid redundant nested `Interactive.*` wrappers that represent the same visual object.
+Every `Interactive.*` wrapper should have a descriptive `name`.
+Avoid repeating the Element display name inside source names; the dragged wrapper already gets named from `displayName`.
+For the main inner editable element, use a generic name such as `Container`.
 
 ## Assets and dependencies
 

--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -81,6 +81,7 @@ export const MyElement = () => {
 ```
 
 Use this for overlays, lower thirds, callouts, motion graphics, cards, badges, and data animations.
+Size the Element to the smallest useful bounding box. Avoid using a full-video canvas, internal placement padding, or fullscreen wrappers unless the Element is a background.
 Do not put the wrapper [`<Sequence>`](/docs/sequence) into the Element source file.
 
 ## Assets and dependencies

--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -7,25 +7,32 @@ description: Submit a Remotion Element for the Elements gallery.
 
 Have a small, remixable Remotion Element? We'd like to see it.
 
-A strong Element is easy to preview, easy to copy into a Remotion project, and useful as a video building block.
+Follow this checklist from top to bottom when preparing an Element.
 
-## Preferred Element format
+## 1. Choose a focused idea
 
-An Element should ideally be a single, self-contained TSX file.
+A strong Element can be previewed, copied into a Remotion project, and used as a video building block.
+
+Good Elements are:
+
+- Focused on one visual idea, technique, or workflow
+- Copy-pastable and useful in more than one Remotion project
+- Remixable
+- HTML, CSS, and React-first
+- Free of unexpected global styles, layout side effects, and fullscreen assumptions unless it is explicitly a background
+- **Building blocks, not compositions:** The hosted docs page provides the preview size, frame rate, and duration.
+
+If two variants are worth showing, make two separate Element pages instead of adding a variant prop.
+
+## 2. Create the Element files
 
 Start from the reusable template in `packages/docs/elements-template/`.
 
-The preferred format is:
+Add:
 
-- One self-contained TSX file exporting a React component
-- Copy-pastable and useful in more than one Remotion project
-- HTML, CSS, and React-first
-- Focused on one visual idea, technique, or workflow
-- Easy to remix
-- Works as-is when dragged or copied into a project
-- **Building block, not a composition:** The hosted docs page provides the preview size, frame rate, and duration.
-- [Interactivity-friendly](/docs/studio/interactivity): inline editable values so they can show up in the Studio inspector. See also [Make a component interactive](/docs/studio/make-component-interactive).
-- If two variants are worth showing, make two separate Element pages instead of adding a variant prop.
+- An Element folder in `packages/docs/elements/<category>/<slug>/`
+- An `index.mdx` page
+- One self-contained TSX source file exporting a React component
 
 For example:
 
@@ -35,30 +42,26 @@ export const MyElement = () => {
 };
 ```
 
-For animation, keep the timing inside the component but let the surrounding project decide how long the Element appears:
+## 3. Keep the source file portable
 
-```tsx twoslash title="AnimatedElement.tsx"
-import {Interactive, interpolate, useCurrentFrame} from 'remotion';
+The source file should work when dragged or copied into a project.
 
-export const AnimatedElement = () => {
-  const frame = useCurrentFrame();
+Prefer:
 
-  return (
-    <Interactive.Div
-      style={{
-        width: '100%',
-        height: '100%',
-        opacity: interpolate(frame, [0, 20], [0, 1]),
-        translate: interpolate(frame, [0, 20], ['0px 40px', '0px 0px']),
-      }}
-    >
-      Hello
-    </Interactive.Div>
-  );
-};
-```
+- One self-contained TSX file
+- Zero dependencies
+- Remote assets with stable public URLs
+- Explicit font loading if a specific font is used
 
-## Sizing Elements
+Avoid:
+
+- Private APIs or private assets
+- Large apps with many moving parts
+- Highly specific branded videos
+- Full video templates with many unrelated parts
+- Maps, Three.js, WebGL, Canvas, or R3F-heavy Elements for the first batch
+
+## 4. Set the import bounds
 
 To give an Element a fixed size, set `elementWidth` and `elementHeight` on the `ElementPage` in `index.mdx`:
 
@@ -80,20 +83,59 @@ export const MyElement = () => {
 };
 ```
 
-Use this for overlays, lower thirds, callouts, motion graphics, cards, badges, and data animations.
-Size the Element to the smallest useful bounding box. `elementWidth` and `elementHeight` should describe the useful import bounds, not the decorative preview bounds.
+Use fixed bounds for overlays, lower thirds, callouts, motion graphics, cards, badges, and data animations.
+
+Size the Element to the smallest useful bounding box.
+`elementWidth` and `elementHeight` should describe the useful import bounds, not the decorative preview bounds.
+
 Use `previewPadding` on the `ElementPage` if the docs preview needs more breathing room without changing the Element's drag dimensions or adding source padding.
-Let the Studio-inserted [`<Sequence>`](/docs/sequence) handle placement in the video. Avoid static `left`, `right`, `top`, and `bottom` placement inside the Element source unless it is intrinsic to the visual.
-Separate placement from animation: the outer placement shell can position the Element in a video, while inner Element styles can animate entrance values such as `translate`, `scale`, and `opacity`.
+
 Do not put the wrapper [`<Sequence>`](/docs/sequence) into the Element source file.
 
-## Interactivity
+## 5. Separate placement from animation
+
+Let the Studio-inserted [`<Sequence>`](/docs/sequence) handle placement in the video.
+Avoid static `left`, `right`, `top`, and `bottom` placement inside the Element source unless it is intrinsic to the visual.
+
+The outer placement shell can position the Element in a video.
+Inner Element styles can animate entrance values such as `translate`, `scale`, and `opacity`.
+
+For animation, keep the timing inside the component but let the surrounding project decide how long the Element appears:
+
+```tsx twoslash title="AnimatedElement.tsx"
+import {Interactive, interpolate, useCurrentFrame} from 'remotion';
+
+export const AnimatedElement = () => {
+  const frame = useCurrentFrame();
+
+  return (
+    <Interactive.Div
+      name="Container"
+      style={{
+        width: '100%',
+        height: '100%',
+        opacity: interpolate(frame, [0, 20], [0, 1]),
+        translate: interpolate(frame, [0, 20], ['0px 40px', '0px 0px']),
+      }}
+    >
+      Hello
+    </Interactive.Div>
+  );
+};
+```
+
+## 6. Add interactivity where useful
 
 Only add `Interactive.*` wrappers when they expose useful Studio controls.
-Avoid redundant nested `Interactive.*` wrappers that represent the same visual object.
 Every `Interactive.*` wrapper should have a descriptive `name`.
-Avoid repeating the Element display name inside source names; the dragged wrapper already gets named from `displayName`.
+
+Avoid:
+
+- Redundant nested `Interactive.*` wrappers that represent the same visual object
+- Repeating the Element display name inside source names; the dragged wrapper already gets named from `displayName`
+
 For the main inner editable element, use a generic name such as `Container`.
+
 For broader rules on editable styles and animation values, see [Interactivity best practices](/docs/studio/interactivity-best-practices).
 
 For a single editable object, use one named wrapper:
@@ -151,7 +193,7 @@ export const Badge = () => {
 };
 ```
 
-## Assets and dependencies
+## 7. Reference assets by URL
 
 Prefer zero dependencies.
 If an Element needs binary assets, reference them by URL:
@@ -163,30 +205,13 @@ const videoUrl = 'https://remotion.media/element-video.mp4';
 
 Remote assets should be publicly accessible and stable.
 
-## What to include
+## 8. Open the pull request
 
 When submitting an Element as a pull request, include:
 
-- An Element folder in `packages/docs/elements/<category>/<slug>/`
-- An `index.mdx` page and the single-file TSX source code in that folder
-- A rendered preview, if available
+- The Element folder
 - What makes it useful
+- A rendered preview, if available
 - Links to inspiration, if any
-
-## Not a great fit
-
-These are usually less suitable:
-
-- Full video templates with many unrelated parts
-- Highly specific branded videos
-- Elements requiring private APIs or private assets
-- Large apps with many moving parts
-- Maps, Three.js, WebGL, Canvas, or R3F-heavy Elements for the first batch
-- Elements with unexpected global styles or layout side effects
-- Elements that cannot be previewed meaningfully
-
-## Submit your Element
-
-Submit Elements by opening a pull request against the Remotion repository.
 
 [Open a pull request on GitHub](https://github.com/remotion-dev/remotion/compare)

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -3,7 +3,7 @@ import {
 	type ComponentDimensions,
 } from '@remotion/studio-shared';
 import React, {useMemo, type ComponentType, type ReactNode} from 'react';
-import {Sequence} from 'remotion';
+import {AbsoluteFill, Sequence} from 'remotion';
 import {setElementDragData, setElementDragImage} from './element-drag-data';
 import {ElementPreview} from './ElementPreview';
 
@@ -16,6 +16,7 @@ type ElementPageProps = {
 	readonly elementWidth?: number;
 	readonly fps?: number;
 	readonly height?: number;
+	readonly previewPadding?: number;
 	readonly slug?: string;
 	readonly sourceCode?: string;
 	readonly width?: number;
@@ -44,10 +45,22 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	elementWidth,
 	fps = 30,
 	height = 1080,
+	previewPadding = 0,
 	slug,
 	sourceCode,
 	width = 1920,
 }) => {
+	const hasElementDimensions =
+		elementWidth !== undefined && elementHeight !== undefined;
+	const previewWidth =
+		hasElementDimensions && previewPadding > 0
+			? elementWidth + previewPadding * 2
+			: width;
+	const previewHeight =
+		hasElementDimensions && previewPadding > 0
+			? elementHeight + previewPadding * 2
+			: height;
+
 	const dragData = useMemo(() => {
 		if (
 			!slug ||
@@ -73,20 +86,49 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	}, [displayName, elementHeight, elementWidth, slug, sourceCode]);
 
 	const PreviewComponent = useMemo(() => {
-		if (elementWidth === undefined || elementHeight === undefined) {
+		if (!hasElementDimensions) {
 			return component;
 		}
 
 		const Component = component;
 
 		return () => {
+			if (previewPadding > 0) {
+				return (
+					<AbsoluteFill
+						style={{
+							alignItems: 'center',
+							justifyContent: 'center',
+						}}
+					>
+						<Sequence height={elementHeight} layout="none" width={elementWidth}>
+							<div
+								style={{
+									height: elementHeight,
+									position: 'relative',
+									width: elementWidth,
+								}}
+							>
+								<Component />
+							</div>
+						</Sequence>
+					</AbsoluteFill>
+				);
+			}
+
 			return (
 				<Sequence height={elementHeight} width={elementWidth}>
 					<Component />
 				</Sequence>
 			);
 		};
-	}, [component, elementHeight, elementWidth]);
+	}, [
+		component,
+		elementHeight,
+		elementWidth,
+		hasElementDimensions,
+		previewPadding,
+	]);
 
 	return (
 		<>
@@ -95,8 +137,8 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 				component={PreviewComponent}
 				durationInFrames={durationInFrames}
 				fps={fps}
-				height={height}
-				width={width}
+				height={previewHeight}
+				width={previewWidth}
 			/>
 
 			<h2>Use it</h2>


### PR DESCRIPTION
## Summary

- Tighten the Lower Third Element from a full-frame drag footprint to its actual card-sized bounds.
- Load Inter explicitly, remove font fallbacks, remove the fullscreen wrapper, and simplify the animation values for Studio Interactivity.
- Add Elements guidance to keep Element bounding boxes as small as useful and let the surrounding `<Sequence>` handle placement.

## Notes

Closes #8826
Closes #8829

## Testing

- `bunx oxfmt packages/docs/elements/overlays/lower-third/lower-third.tsx --write`
- `bunx prettier packages/docs/elements/overlays/lower-third/index.mdx packages/docs/elements/index.mdx packages/docs/elements/submit-an-element.mdx --write`
- `bun test packages/docs/src/test/elements.test.ts`
- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun run build-docs`
