### PR TITLE
Docs: Use @remotion/media in docs examples

### DIFF
--- a/packages/docs/docs/absolute-fill.mdx
+++ b/packages/docs/docs/absolute-fill.mdx
@@ -26,13 +26,14 @@ const style: React.CSSProperties = {
 This component is useful for layering content on top of each other. For example, you can use it to create a full-screen video background:
 
 ```tsx twoslash title="Layer example"
-import {AbsoluteFill, OffthreadVideo} from 'remotion';
+import {AbsoluteFill} from 'remotion';
+import {Video} from '@remotion/media';
 
 const MyComp = () => {
   return (
     <AbsoluteFill>
       <AbsoluteFill>
-        <OffthreadVideo src="https://example.com/video.mp4" />
+        <Video src="https://example.com/video.mp4" />
       </AbsoluteFill>
       <AbsoluteFill>
         <h1>This text is written on top!</h1>

--- a/packages/docs/docs/audio/delaying.mdx
+++ b/packages/docs/docs/audio/delaying.mdx
@@ -14,13 +14,14 @@ Use a [`<Sequence>`](/docs/sequence) with a positive [`from`](/docs/sequence#fro
 In the following example, the audio will start playing after 100 frames.
 
 ```tsx twoslash {6-8}
-import {AbsoluteFill, Html5Audio, Sequence, staticFile} from 'remotion';
+import {AbsoluteFill, Sequence, staticFile} from 'remotion';
+import {Audio} from '@remotion/media';
 
 export const MyComposition = () => {
   return (
     <AbsoluteFill>
       <Sequence from={100}>
-        <Html5Audio src={staticFile('audio.mp3')} />
+        <Audio src={staticFile('audio.mp3')} />
       </Sequence>
     </AbsoluteFill>
   );

--- a/packages/docs/docs/audio/from-video.mdx
+++ b/packages/docs/docs/audio/from-video.mdx
@@ -14,12 +14,13 @@ Audio from [`<Video>`](/docs/media/video), [`<Html5Video>`](/docs/html5-video) a
 The same principles apply as for audio - you may [trim](/docs/audio/trimming), [delay](/docs/audio/delaying), [mute](/docs/audio/muting), [speed up](/docs/audio/speed) and [reduce the volume](/docs/audio/volume) of your videos.
 
 ```tsx twoslash {6} title="MyComp.tsx"
-import {AbsoluteFill, OffthreadVideo, staticFile} from 'remotion';
+import {AbsoluteFill, staticFile} from 'remotion';
+import {Video} from '@remotion/media';
 
 export const MyComposition = () => {
   return (
     <AbsoluteFill>
-      <OffthreadVideo src={staticFile('video.mp4')} playbackRate={2} volume={0.5} />
+      <Video src={staticFile('video.mp4')} playbackRate={2} volume={0.5} />
     </AbsoluteFill>
   );
 };

--- a/packages/docs/docs/audio/importing.mdx
+++ b/packages/docs/docs/audio/importing.mdx
@@ -10,15 +10,16 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 [Put an audio file into the `public/` folder](/docs/assets) and use [`staticFile()`](/docs/staticfile) to reference it.  
-Add an [`<Html5Audio/>`](/docs/html5-audio) tag to your component to add sound to it.
+Add an [`<Audio/>`](/docs/media/audio) tag to your component to add sound to it.
 
 ```tsx twoslash title="MyComp.tsx"
-import {AbsoluteFill, Html5Audio, staticFile} from 'remotion';
+import {AbsoluteFill, staticFile} from 'remotion';
+import {Audio} from '@remotion/media';
 
 export const MyComposition = () => {
   return (
     <AbsoluteFill>
-      <Html5Audio src={staticFile('audio.mp3')} />
+      <Audio src={staticFile('audio.mp3')} />
     </AbsoluteFill>
   );
 };
@@ -27,12 +28,13 @@ export const MyComposition = () => {
 You can also add remote audio by passing a URL:
 
 ```tsx twoslash title="MyComp.tsx"
-import {AbsoluteFill, Html5Audio} from 'remotion';
+import {AbsoluteFill} from 'remotion';
+import {Audio} from '@remotion/media';
 
 export const MyComposition = () => {
   return (
     <AbsoluteFill>
-      <Html5Audio src="https://example.com/audio.mp3" />
+      <Audio src="https://example.com/audio.mp3" />
     </AbsoluteFill>
   );
 };

--- a/packages/docs/docs/audio/muting.mdx
+++ b/packages/docs/docs/audio/muting.mdx
@@ -10,13 +10,13 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {AvailableFrom} from '../../src/components/AvailableFrom';
 
-You may pass in the [`muted`](/docs/html5-audio#muted) prop to [`<Audio>`](/docs/media/audio), [`<Video>`](/docs/media/video), [`<OffthreadVideo>`](/docs/offthreadvideo), [`<Html5Audio>`](/docs/html5-audio) and [`<Html5Video>`](/docs/html5-video) and even change it over time.
+You may pass in the [`muted`](/docs/media/audio#muted) prop to [`<Audio>`](/docs/media/audio), [`<Video>`](/docs/media/video), [`<OffthreadVideo>`](/docs/offthreadvideo), [`<Html5Audio>`](/docs/html5-audio) and [`<Html5Video>`](/docs/html5-video) and even change it over time.
 
-When [`muted`](/docs/html5-audio#muted) is true, audio will be omitted at that time. In the following example, we are muting the track between seconds 2 and 4.
+When [`muted`](/docs/media/audio#muted) is true, audio will be omitted at that time. In the following example, we are muting the track between seconds 2 and 4.
 
 ```tsx twoslash {9}
 import {AbsoluteFill, staticFile, useCurrentFrame, useVideoConfig} from 'remotion';
-import {Html5Audio} from 'remotion';
+import {Audio} from '@remotion/media';
 
 export const MyComposition = () => {
   const frame = useCurrentFrame();
@@ -24,7 +24,7 @@ export const MyComposition = () => {
 
   return (
     <AbsoluteFill>
-      <Html5Audio src={staticFile('audio.mp3')} muted={frame >= 2 * fps && frame <= 4 * fps} />
+      <Audio src={staticFile('audio.mp3')} muted={frame >= 2 * fps && frame <= 4 * fps} />
     </AbsoluteFill>
   );
 };

--- a/packages/docs/docs/audio/trimming.mdx
+++ b/packages/docs/docs/audio/trimming.mdx
@@ -9,27 +9,24 @@ crumb: 'Audio'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The [`<Html5Audio />`](/docs/html5-audio) tag supports the [`trimBefore`](/docs/html5-audio#trimbefore--trimafter) and [`trimAfter`](/docs/html5-audio#trimbefore--trimafter) props.  
-With it, you can trim off parts of the audio.
+The [`<Audio />`](/docs/media/audio) and [`<Video />`](/docs/media/video) tags support the [`trimBefore`](/docs/media/audio#trimbefore) and [`trimAfter`](/docs/media/audio#trimafter) props.  
+[`<Html5Audio />`](/docs/html5-audio) also supports these props.
 
 ```tsx twoslash {8} title="MyComp.tsx"
-import {AbsoluteFill, Html5Audio, staticFile, useVideoConfig} from 'remotion';
+import {AbsoluteFill, staticFile, useVideoConfig} from 'remotion';
+import {Video} from '@remotion/media';
 
 export const MyComposition = () => {
   const {fps} = useVideoConfig();
 
   return (
     <AbsoluteFill>
-      <Html5Audio src={staticFile('audio.mp3')} trimBefore={2 * fps} trimAfter={4 * fps} />
+      <Video src={staticFile('video.mp4')} trimBefore={2 * fps} trimAfter={4 * fps} />
     </AbsoluteFill>
   );
 };
 ```
 
-This will result the audio to play the range from `00:02:00` to `00:04:00`, meaning the audio will play for 2 seconds.
+This makes the media play the range from `00:02:00` to `00:04:00`, meaning it will play for 2 seconds.
 
 The audio will still play immediately at the beginning - to see how to shift the audio to appear later in the composition, see the [next article](/docs/audio/delaying).
-
-:::note Legacy props
-You can also use the deprecated `startFrom` and `endAt` props, but the new `trimBefore` and `trimAfter` props are preferred.
-:::

--- a/packages/docs/docs/flickering.mdx
+++ b/packages/docs/docs/flickering.mdx
@@ -52,57 +52,11 @@ Otherwise, it will take a screenshot of a loading state.
 
 ### Solution
 
-<Step>1</Step> Use the
-<a>
-  <code>&lt;Img&gt;</code>
-</a>
-,
-<a>
-  <code>&lt;Video&gt;</code>
-</a>
-,
-<a>
-  <code>&lt;OffthreadVideo&gt;</code>
-</a>
-,
-<a>
-  <code>&lt;Audio&gt;</code>
-</a>
-,
-<a>
-  <code>&lt;Iframe&gt;</code>
-</a>
-and
-<a>
-  <code>&lt;Gif&gt;</code>
-</a>
-as they wait for the assets to be loaded. <br />
-<Step>2</Step> When loading data, use the
-<a href="/docs/delay-render">
-  <code>delayRender()</code>
-</a>
-function.
-<br />
-<Step>3</Step> Ensure you correctly wait <a href="/docs/fonts">for fonts to load</a>.<br />
-<Step>4</Step> Only call
-<a href="/docs/layout-utils/fit-text">
-  <code>fitText()</code>
-</a>
-,
-<a href="/docs/layout-utils/fill-text-box">
-  <code>fillTextBox()</code>
-</a>
-and
-<a href="/docs/layout-utils/measure-text">
-  <code>measureText()</code>
-</a>
-once fonts are loaded.
-<br />
-<Step>5</Step> Avoid using the
-<a href="/docs/troubleshooting/background-image">
-  <code>background-image</code> and <code>mask-image</code> CSS properties
-</a>
-.
+- <Step>1</Step> Use [`<Video>`](/docs/media/video), [`<Audio>`](/docs/media/audio), [`<Img>`](/docs/img), [`<OffthreadVideo>`](/docs/offthreadvideo), [`<IFrame>`](/docs/iframe), and [`<Gif>`](/docs/gif) as they wait for assets to be loaded.
+- <Step>2</Step> When loading data, use [`delayRender()`](/docs/delay-render).
+- <Step>3</Step> Ensure you correctly wait [for fonts to load](/docs/fonts).
+- <Step>4</Step> Only call [`fitText()`](/docs/layout-utils/fit-text), [`fillTextBox()`](/docs/layout-utils/fill-text-box), and [`measureText()`](/docs/layout-utils/measure-text) once fonts are loaded.
+- <Step>5</Step> Avoid using the [`background-image` and `mask-image` CSS properties](/docs/troubleshooting/background-image).
 
 ## Flickering `<Html5Video>` tag
 


### PR DESCRIPTION
## Summary

- Update selected docs snippets to prefer `@remotion/media`'s `<Video>` and `<Audio>` tags.
- Clean up the flickering troubleshooting asset-loading list to avoid broken line wrapping.
- Remove the legacy trimming props notice from the audio trimming guide.

## Verification

- `bun run build-docs`
- `bun run stylecheck`

Refs #8882
