### PR TITLE
`@remotion/studio`: Add Remotion Convert asset handoff

### DIFF
--- a/packages/convert/app/components/ConversionDone.tsx
+++ b/packages/convert/app/components/ConversionDone.tsx
@@ -1,6 +1,8 @@
 import {Button, Button as RemotionButton} from '@remotion/design';
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import type {ConvertState, Source} from '~/lib/convert-state';
+import type {StudioBridgeSession} from '~/lib/studio-bridge';
+import {saveFileToStudio} from '~/lib/studio-bridge';
 import {CloneIcon} from './icons/clone';
 import {UndoIcon} from './icons/undo';
 
@@ -8,10 +10,28 @@ export const ConversionDone: React.FC<{
 	readonly state: ConvertState;
 	readonly setState: React.Dispatch<React.SetStateAction<ConvertState>>;
 	readonly setSrc: React.Dispatch<React.SetStateAction<Source | null>>;
-}> = ({state, setState, setSrc}) => {
+	readonly studioBridgeSession: StudioBridgeSession | null;
+}> = ({state, setState, setSrc, studioBridgeSession}) => {
 	if (state.type !== 'done') {
 		throw new Error('Expected state to be done');
 	}
+
+	const [saveToStudioState, setSaveToStudioState] = useState<
+		| {
+				type: 'idle';
+		  }
+		| {
+				type: 'saving';
+		  }
+		| {
+				type: 'saved';
+				filename: string;
+		  }
+		| {
+				type: 'error';
+				message: string;
+		  }
+	>({type: 'idle'});
 
 	const onDownload = useCallback(async () => {
 		try {
@@ -28,6 +48,28 @@ export const ConversionDone: React.FC<{
 		}
 	}, [setState, state]);
 
+	const onSaveToStudio = useCallback(async () => {
+		if (!studioBridgeSession) {
+			return;
+		}
+
+		setSaveToStudioState({type: 'saving'});
+		try {
+			const file = await state.download();
+			const filename = await saveFileToStudio({
+				file,
+				filename: state.newName,
+				session: studioBridgeSession,
+			});
+			setSaveToStudioState({type: 'saved', filename});
+		} catch (err) {
+			setSaveToStudioState({
+				type: 'error',
+				message: (err as Error).message,
+			});
+		}
+	}, [state, studioBridgeSession]);
+
 	const useAsInput = useCallback(async () => {
 		const file = await state.download();
 
@@ -43,6 +85,27 @@ export const ConversionDone: React.FC<{
 
 	return (
 		<>
+			{studioBridgeSession ? (
+				<>
+					<RemotionButton
+						className="block w-full"
+						onClick={onSaveToStudio}
+						disabled={saveToStudioState.type === 'saving'}
+					>
+						{saveToStudioState.type === 'saving'
+							? 'Saving to Studio...'
+							: saveToStudioState.type === 'saved'
+								? 'Saved to Studio'
+								: 'Save to Studio'}
+					</RemotionButton>
+					{saveToStudioState.type === 'error' ? (
+						<div className="text-sm text-red-600 mt-2">
+							{saveToStudioState.message}
+						</div>
+					) : null}
+					<div className="h-2" />
+				</>
+			) : null}
 			<RemotionButton className="block w-full" onClick={onDownload}>
 				Download
 			</RemotionButton>

--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -41,6 +41,7 @@ import type {MediabunnyResize} from '~/lib/mediabunny-calculate-resize-option';
 import {calculateMediabunnyResizeOption} from '~/lib/mediabunny-calculate-resize-option';
 import {getMediabunnyOutput} from '~/lib/output-container';
 import type {ConvertProgressType} from '~/lib/progress';
+import type {StudioBridgeSession} from '~/lib/studio-bridge';
 import {makeWaveformVisualizer} from '~/lib/waveform-visualizer';
 import {makeWebFsTarget} from '~/lib/web-fs-target';
 import type {OutputContainer, RouteAction} from '~/seo';
@@ -87,6 +88,7 @@ const ConvertUI = ({
 	input,
 	crop,
 	cropRect,
+	studioBridgeSession,
 }: {
 	readonly setSrc: React.Dispatch<React.SetStateAction<Source | null>>;
 	readonly currentAudioCodec: InputAudioTrack['codec'] | null;
@@ -118,6 +120,7 @@ const ConvertUI = ({
 	readonly crop: boolean;
 	readonly sampleRate: number | null;
 	readonly cropRect: CropRectangle;
+	readonly studioBridgeSession: StudioBridgeSession | null;
 }) => {
 	const [enableConvert, setEnableConvert] = useState(() =>
 		isConvertEnabledByDefault(action),
@@ -609,7 +612,10 @@ const ConvertUI = ({
 				/>
 				<div className="h-2" />
 				<ConversionDone
-					{...{container: actualOutputContainer, name, setState, state, setSrc}}
+					setState={setState}
+					state={state}
+					setSrc={setSrc}
+					studioBridgeSession={studioBridgeSession}
 				/>
 			</>
 		);

--- a/packages/convert/app/components/FileAvailable.tsx
+++ b/packages/convert/app/components/FileAvailable.tsx
@@ -5,6 +5,7 @@ import type {Source} from '~/lib/convert-state';
 import type {RotateOrMirrorOrCropState} from '~/lib/default-ui';
 import {defaultRotateOrMirorState} from '~/lib/default-ui';
 import {isAudioOnly} from '~/lib/is-audio-container';
+import type {StudioBridgeSession} from '~/lib/studio-bridge';
 import type {RouteAction} from '~/seo';
 import {BackButton} from './BackButton';
 import ConvertUI from './ConvertUi';
@@ -21,7 +22,8 @@ export const FileAvailable: React.FC<{
 	readonly src: Source;
 	readonly setSrc: React.Dispatch<React.SetStateAction<Source | null>>;
 	readonly routeAction: RouteAction;
-}> = ({src, setSrc, routeAction}) => {
+	readonly studioBridgeSession: StudioBridgeSession | null;
+}> = ({src, setSrc, routeAction, studioBridgeSession}) => {
 	const [probeDetails, setProbeDetails] = useState(
 		() => routeAction.type === 'generic-probe',
 	);
@@ -156,6 +158,7 @@ export const FileAvailable: React.FC<{
 											name={probeResult.name}
 											input={probeResult.input}
 											cropRect={cropOperation}
+											studioBridgeSession={studioBridgeSession}
 										/>
 									</div>
 								) : null}

--- a/packages/convert/app/components/Main.tsx
+++ b/packages/convert/app/components/Main.tsx
@@ -1,6 +1,7 @@
 import {useLocation} from '@remix-run/react';
 import React, {useState} from 'react';
 import type {Source} from '~/lib/convert-state';
+import {getStudioBridgeSession} from '~/lib/studio-bridge';
 import {TitleProvider} from '~/lib/title-context';
 import type {RouteAction} from '~/seo';
 import {getHeaderTitle} from '~/seo';
@@ -16,6 +17,7 @@ export const Main: React.FC<{
 	const [src, setSrc] = useState<Source | null>(() => {
 		return url.has('url') ? {type: 'url', url: url.get('url') as string} : null;
 	});
+	const [studioBridgeSession] = useState(() => getStudioBridgeSession(url));
 
 	return (
 		<TitleProvider routeAction={routeAction}>
@@ -26,6 +28,7 @@ export const Main: React.FC<{
 						routeAction={routeAction}
 						src={src}
 						setSrc={setSrc}
+						studioBridgeSession={studioBridgeSession}
 					/>
 				) : (
 					<PickFile

--- a/packages/convert/app/lib/studio-bridge.ts
+++ b/packages/convert/app/lib/studio-bridge.ts
@@ -1,0 +1,118 @@
+export type StudioBridgeSession = {
+	origin: string;
+	sourceAsset: string | null;
+	token: string;
+};
+
+const saveToStudioMessageType = 'remotion-convert-output';
+const saveToStudioResultMessageType = 'remotion-convert-output-result';
+
+type SaveToStudioResultMessage = {
+	type: typeof saveToStudioResultMessageType;
+	token: string;
+	error: string | null;
+	filename: string;
+};
+
+export const getStudioBridgeSession = (
+	searchParams: URLSearchParams,
+): StudioBridgeSession | null => {
+	const origin = searchParams.get('studioOrigin');
+	const token = searchParams.get('studioToken');
+	if (!origin || !token) {
+		return null;
+	}
+
+	try {
+		const parsed = new URL(origin);
+		if (parsed.origin !== origin) {
+			return null;
+		}
+	} catch {
+		return null;
+	}
+
+	return {
+		origin,
+		sourceAsset: searchParams.get('sourceAsset'),
+		token,
+	};
+};
+
+const isSaveToStudioResultMessage = (
+	data: unknown,
+): data is SaveToStudioResultMessage => {
+	if (typeof data !== 'object' || data === null) {
+		return false;
+	}
+
+	const candidate = data as SaveToStudioResultMessage;
+	return (
+		candidate.type === saveToStudioResultMessageType &&
+		typeof candidate.token === 'string' &&
+		typeof candidate.filename === 'string' &&
+		(candidate.error === null || typeof candidate.error === 'string')
+	);
+};
+
+export const saveFileToStudio = ({
+	file,
+	filename,
+	session,
+}: {
+	file: File;
+	filename: string;
+	session: StudioBridgeSession;
+}) => {
+	if (!window.opener) {
+		return Promise.reject(
+			new Error('The Studio window is no longer connected'),
+		);
+	}
+
+	return new Promise<string>((resolve, reject) => {
+		const controller = new AbortController();
+		const timeout = window.setTimeout(() => {
+			controller.abort();
+			reject(new Error('Timed out waiting for Studio'));
+		}, 30000);
+		const cleanup = () => {
+			window.clearTimeout(timeout);
+			controller.abort();
+		};
+
+		function onMessage(event: MessageEvent) {
+			if (event.origin !== session.origin) {
+				return;
+			}
+
+			if (!isSaveToStudioResultMessage(event.data)) {
+				return;
+			}
+
+			if (event.data.token !== session.token) {
+				return;
+			}
+
+			cleanup();
+
+			if (event.data.error) {
+				reject(new Error(event.data.error));
+				return;
+			}
+
+			resolve(event.data.filename);
+		}
+
+		window.addEventListener('message', onMessage, {signal: controller.signal});
+		window.opener.postMessage(
+			{
+				type: saveToStudioMessageType,
+				token: session.token,
+				filename,
+				file,
+			},
+			session.origin,
+		);
+	});
+};

--- a/packages/studio-server/src/preview-server/serve-static.ts
+++ b/packages/studio-server/src/preview-server/serve-static.ts
@@ -12,6 +12,49 @@ import {RenderInternals} from '@remotion/renderer';
 import {getValueContentRangeHeader} from './dev-middleware/middleware';
 import {parseRange} from './dev-middleware/range-parser';
 
+const isAllowedStaticCorsOrigin = (origin: string): boolean => {
+	try {
+		const url = new URL(origin);
+		return (
+			url.hostname === 'localhost' ||
+			url.hostname === '127.0.0.1' ||
+			url.hostname === '[::1]' ||
+			url.hostname === 'www.remotion.dev' ||
+			url.hostname === 'convert.remotion.dev'
+		);
+	} catch {
+		return false;
+	}
+};
+
+const applyStaticCorsHeaders = ({
+	req,
+	res,
+}: {
+	req: IncomingMessage;
+	res: ServerResponse;
+}) => {
+	const {origin} = req.headers;
+	if (!origin || !isAllowedStaticCorsOrigin(origin)) {
+		return false;
+	}
+
+	res.setHeader('Access-Control-Allow-Origin', origin);
+	res.setHeader('Vary', 'Origin');
+	res.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
+	res.setHeader('Access-Control-Allow-Headers', 'Range, Content-Type');
+	res.setHeader(
+		'Access-Control-Expose-Headers',
+		'Accept-Ranges, Content-Length, Content-Range',
+	);
+
+	if (req.headers['access-control-request-private-network']) {
+		res.setHeader('Access-Control-Allow-Private-Network', 'true');
+	}
+
+	return true;
+};
+
 export const serveStatic = async function ({
 	root,
 	path,
@@ -25,6 +68,14 @@ export const serveStatic = async function ({
 	res: ServerResponse;
 	allowOutsidePublicFolder: boolean;
 }): Promise<void> {
+	applyStaticCorsHeaders({req, res});
+
+	if (req.method === 'OPTIONS') {
+		res.statusCode = 204;
+		res.end();
+		return;
+	}
+
 	if (req.method !== 'GET' && req.method !== 'HEAD') {
 		// method not allowed
 		res.statusCode = 405;

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -23,6 +23,7 @@ import {
 import {copyText} from '../helpers/copy-text';
 import type {AssetFolder, AssetStructure} from '../helpers/create-folder-tree';
 import {useMobileLayout} from '../helpers/mobile-layout';
+import {openInRemotionConvert} from '../helpers/open-in-remotion-convert';
 import {
 	markAssetSidebarScrollFromRowClick,
 	maybeScrollAssetSidebarRowIntoView,
@@ -422,6 +423,10 @@ const AssetSelectorItem: React.FC<{
 		});
 	}, [relativePath]);
 
+	const openAssetInConvert = useCallback(() => {
+		openInRemotionConvert({relativePath});
+	}, [relativePath]);
+
 	const serverActionDisabled =
 		readOnlyStudio || connectionStatus !== 'connected';
 
@@ -495,6 +500,18 @@ const AssetSelectorItem: React.FC<{
 				id: 'asset-file-actions-divider',
 			},
 			{
+				id: 'open-asset-in-convert',
+				keyHint: null,
+				label: 'Open in Remotion Convert',
+				leftItem: null,
+				onClick: openAssetInConvert,
+				quickSwitcherLabel: 'Open asset in Remotion Convert',
+				subMenu: null,
+				type: 'item',
+				value: 'open-asset-in-convert',
+				disabled: serverActionDisabled,
+			},
+			{
 				id: 'open-asset-in-explorer',
 				keyHint: null,
 				label: 'Open in Explorer',
@@ -540,6 +557,7 @@ const AssetSelectorItem: React.FC<{
 	}, [
 		copyFileName,
 		copyStaticFilePath,
+		openAssetInConvert,
 		openAssetInExplorer,
 		deleteAsset,
 		relativePath,

--- a/packages/studio/src/components/CurrentAsset.tsx
+++ b/packages/studio/src/components/CurrentAsset.tsx
@@ -4,12 +4,14 @@ import {Internals, staticFile} from 'remotion';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {formatMediaDuration} from '../helpers/format-media-duration';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
+import {openInRemotionConvert} from '../helpers/open-in-remotion-convert';
 import {
 	renderHumanReadableAudioCodec,
 	renderHumanReadableVideoCodec,
 } from '../helpers/render-codec-label';
 import type {MediaMetadata} from '../helpers/use-media-metadata';
 import {useMediaMetadata} from '../helpers/use-media-metadata';
+import {Button} from './Button';
 import {InlineEditableTitle} from './InlineEditableTitle';
 import {
 	INSPECTOR_INFO_HEADER_MIN_HEIGHT,
@@ -23,6 +25,14 @@ import {
 import {useStaticFiles} from './use-static-files';
 
 export const CURRENT_ASSET_HEIGHT = INSPECTOR_INFO_HEADER_MIN_HEIGHT;
+
+const convertButtonContainer: React.CSSProperties = {
+	marginTop: 12,
+};
+
+const convertButtonStyle: React.CSSProperties = {
+	width: '100%',
+};
 
 export const getCurrentAssetMetadataSource = (assetName: string | null) => {
 	if (!assetName) {
@@ -103,12 +113,20 @@ export const CurrentAsset: React.FC<{
 	const src = getCurrentAssetMetadataSource(assetName);
 	const mediaMetadata = useMediaMetadata(src);
 	const canRename = connectionStatus === 'connected' && !readOnlyStudio;
+	const canOpenConvert = connectionStatus === 'connected' && !readOnlyStudio;
 	const onRename = useCallback(
 		(newName: string) => {
 			renameFile(newName).catch(() => undefined);
 		},
 		[renameFile],
 	);
+	const onOpenConvert = useCallback(() => {
+		if (!assetName) {
+			return;
+		}
+
+		openInRemotionConvert({relativePath: assetName});
+	}, [assetName]);
 
 	if (!assetName) {
 		return <InspectorInfoHeader />;
@@ -157,6 +175,18 @@ export const CurrentAsset: React.FC<{
 			{mediaDetailLines.map((line) => {
 				return <InspectorInfoSubtitle key={line}>{line}</InspectorInfoSubtitle>;
 			})}
+			{src ? (
+				<div style={convertButtonContainer}>
+					<Button
+						onClick={onOpenConvert}
+						disabled={!canOpenConvert}
+						size="compact"
+						style={convertButtonStyle}
+					>
+						Open in Remotion Convert
+					</Button>
+				</div>
+			) : null}
 		</InspectorInfoHeader>
 	);
 };

--- a/packages/studio/src/helpers/open-in-remotion-convert.ts
+++ b/packages/studio/src/helpers/open-in-remotion-convert.ts
@@ -1,0 +1,141 @@
+import {staticFile} from 'remotion';
+import {writeStaticFile} from '../api/write-static-file';
+import {showNotification} from '../components/Notifications/NotificationCenter';
+
+const convertDevUrl = 'http://localhost:5173/convert';
+const saveToStudioMessageType = 'remotion-convert-output';
+const saveToStudioResultMessageType = 'remotion-convert-output-result';
+
+type SaveToStudioMessage = {
+	type: typeof saveToStudioMessageType;
+	token: string;
+	filename: string;
+	file: File;
+};
+
+const getRandomToken = () => {
+	if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+		return crypto.randomUUID();
+	}
+
+	return String(Math.random()).replace('0.', '');
+};
+
+const getOutputPath = ({
+	filename,
+	sourceRelativePath,
+}: {
+	filename: string;
+	sourceRelativePath: string;
+}) => {
+	const basename = filename.split(/[\\/]/).pop()?.trim();
+	if (!basename || basename === '.' || basename === '..') {
+		throw new Error(
+			'Received an invalid output filename from Remotion Convert',
+		);
+	}
+
+	const parentDir = sourceRelativePath.split('/').slice(0, -1).join('/');
+	return parentDir ? `${parentDir}/${basename}` : basename;
+};
+
+const isSaveToStudioMessage = (data: unknown): data is SaveToStudioMessage => {
+	if (typeof data !== 'object' || data === null) {
+		return false;
+	}
+
+	const candidate = data as SaveToStudioMessage;
+	return (
+		candidate.type === saveToStudioMessageType &&
+		typeof candidate.token === 'string' &&
+		typeof candidate.filename === 'string' &&
+		candidate.file instanceof File
+	);
+};
+
+export const openInRemotionConvert = ({
+	relativePath,
+}: {
+	relativePath: string;
+}) => {
+	const token = getRandomToken();
+	const convertUrl = new URL(convertDevUrl);
+	const convertOrigin = convertUrl.origin;
+	const assetUrl = new URL(staticFile(relativePath), window.location.origin);
+
+	convertUrl.searchParams.set('url', assetUrl.toString());
+	convertUrl.searchParams.set('studioOrigin', window.location.origin);
+	convertUrl.searchParams.set('studioToken', token);
+	convertUrl.searchParams.set('sourceAsset', relativePath);
+
+	const convertWindow = window.open(convertUrl.toString(), '_blank');
+	if (!convertWindow) {
+		showNotification('Could not open Remotion Convert', 2000);
+		return;
+	}
+
+	function closeListener() {
+		window.removeEventListener('message', onMessage);
+		window.clearInterval(closePoll);
+	}
+
+	const postResult = ({
+		error,
+		filename,
+	}: {
+		error: string | null;
+		filename: string;
+	}) => {
+		convertWindow.postMessage(
+			{
+				type: saveToStudioResultMessageType,
+				token,
+				error,
+				filename,
+			},
+			convertOrigin,
+		);
+	};
+
+	async function onMessage(event: MessageEvent) {
+		if (event.origin !== convertOrigin) {
+			return;
+		}
+
+		if (!isSaveToStudioMessage(event.data)) {
+			return;
+		}
+
+		if (event.data.token !== token) {
+			return;
+		}
+
+		const notification = showNotification('Saving converted file...', null);
+		try {
+			const filePath = getOutputPath({
+				filename: event.data.filename,
+				sourceRelativePath: relativePath,
+			});
+			await writeStaticFile({
+				contents: await event.data.file.arrayBuffer(),
+				filePath,
+			});
+			notification.replaceContent(`Saved ${filePath}`, 3000);
+			postResult({error: null, filename: filePath});
+			closeListener();
+		} catch (err) {
+			const {message} = err as Error;
+			notification.replaceContent(`Could not save file: ${message}`, 3000);
+			postResult({error: message, filename: event.data.filename});
+		}
+	}
+
+	const closePoll = window.setInterval(() => {
+		if (convertWindow.closed) {
+			closeListener();
+		}
+	}, 1000);
+
+	window.addEventListener('message', onMessage);
+	showNotification('Opened Remotion Convert', 2000);
+};


### PR DESCRIPTION
## Summary

- Add a Studio asset action that opens audio/video public assets in a local Remotion Convert tab.
- Add a token-based postMessage bridge so Convert can save finished files back into Studio.
- Allow Studio static asset reads from local Convert origins while keeping writes same-origin through Studio.

Closes #8884

## Testing

- bun run build
- bun run stylecheck
