### PR TITLE
`remotion`: Replace deprecated `MutableRefObject` with `RefObject`

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -384,8 +384,7 @@ const HtmlInCanvasContent = forwardRef<
 				if (typeof ref === 'function') {
 					ref(node);
 				} else if (ref) {
-					(ref as React.MutableRefObject<HTMLCanvasElement | null>).current =
-						node;
+					(ref as React.RefObject<HTMLCanvasElement | null>).current = node;
 				}
 			},
 			[ref],
@@ -676,8 +675,7 @@ const HtmlInCanvasInner = forwardRef<
 				if (typeof ref === 'function') {
 					ref(node);
 				} else if (ref) {
-					(ref as React.MutableRefObject<HTMLCanvasElement | null>).current =
-						node;
+					(ref as React.RefObject<HTMLCanvasElement | null>).current = node;
 				}
 			},
 			[ref],

--- a/packages/core/src/TimelineContext.tsx
+++ b/packages/core/src/TimelineContext.tsx
@@ -1,4 +1,4 @@
-import type {MutableRefObject} from 'react';
+import type {RefObject} from 'react';
 import React, {
 	createContext,
 	useLayoutEffect,
@@ -17,8 +17,8 @@ export type TimelineContextValue = {
 	frame: Record<string, number>;
 	playing: boolean;
 	rootId: string;
-	imperativePlaying: MutableRefObject<boolean>;
-	audioAndVideoTags: MutableRefObject<PlayableMediaTag[]>;
+	imperativePlaying: RefObject<boolean>;
+	audioAndVideoTags: RefObject<PlayableMediaTag[]>;
 };
 
 export type PlaybackRateContextValue = {

--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -35,7 +35,7 @@ type BufferManager = {
 	addBlock: AddBlock;
 	listenForBuffering: ListenForBuffering;
 	listenForResume: ListenForResume;
-	buffering: React.MutableRefObject<boolean>;
+	buffering: React.RefObject<boolean>;
 };
 
 const useBufferManager = (

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -57,7 +57,7 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 				| {
 						props: SeriesSequenceProps;
 						type: typeof SeriesSequence;
-						ref: React.MutableRefObject<HTMLDivElement>;
+						ref: React.RefObject<HTMLDivElement>;
 				  }
 				| string;
 			if (typeof castedChild === 'string') {

--- a/packages/core/src/timeline-position-state.ts
+++ b/packages/core/src/timeline-position-state.ts
@@ -1,4 +1,4 @@
-import type {MutableRefObject} from 'react';
+import type {RefObject} from 'react';
 import {useContext, useMemo} from 'react';
 import {
 	AbsoluteTimeContext,
@@ -121,7 +121,7 @@ export const useTimelineSetFrame = (): ((
 type PlayingReturnType = readonly [
 	boolean,
 	(u: React.SetStateAction<boolean>) => void,
-	MutableRefObject<boolean>,
+	RefObject<boolean>,
 ];
 
 export const usePlayingState = (): PlayingReturnType => {

--- a/packages/core/src/use-request-video-callback-time.ts
+++ b/packages/core/src/use-request-video-callback-time.ts
@@ -9,7 +9,7 @@ export const useRequestVideoCallbackTime = ({
 }: {
 	mediaRef: RefObject<HTMLVideoElement | HTMLAudioElement | null>;
 	mediaType: 'video' | 'audio';
-	lastSeek: React.MutableRefObject<number | null>;
+	lastSeek: React.RefObject<number | null>;
 	onVariableFpsVideoDetected: () => void;
 }) => {
 	const currentTime = useRef<{

--- a/packages/docs/docs/use-video-texture.mdx
+++ b/packages/docs/docs/use-video-texture.mdx
@@ -31,7 +31,7 @@ To convert the video to a video texture, place the `useVideoTexture()` hook in t
 
 ```tsx twoslash
 import React from 'react';
-const videoRef: React.MutableRefObject<HTMLVideoElement | null> = React.useRef(null);
+const videoRef: React.RefObject<HTMLVideoElement | null> = React.useRef(null);
 // ---cut---
 import {useVideoTexture} from '@remotion/three';
 
@@ -45,7 +45,7 @@ The return type of it is a `THREE.VideoTexture | null` which you can assign as a
 ```tsx twoslash
 import React from 'react';
 import {useVideoTexture} from '@remotion/three';
-const videoRef: React.MutableRefObject<HTMLVideoElement | null> = React.useRef(null);
+const videoRef: React.RefObject<HTMLVideoElement | null> = React.useRef(null);
 const videoTexture = useVideoTexture(videoRef);
 // ---cut---
 {

--- a/packages/docs/src/components/VideoPlayerWithControls.tsx
+++ b/packages/docs/src/components/VideoPlayerWithControls.tsx
@@ -2,7 +2,7 @@ import Hls from 'hls.js';
 import type Plyr from 'plyr';
 // eslint-disable-next-line no-restricted-imports
 import 'plyr/dist/plyr.css';
-import type {MutableRefObject} from 'react';
+import type {RefObject} from 'react';
 import React, {
 	forwardRef,
 	useCallback,
@@ -19,10 +19,10 @@ export interface HTMLVideoElementWithPlyr extends HTMLVideoElement {
 const useCombinedRefs = function (
 	...refs: (
 		| ((instance: HTMLVideoElementWithPlyr | null) => void)
-		| MutableRefObject<HTMLVideoElementWithPlyr | null>
+		| RefObject<HTMLVideoElementWithPlyr | null>
 		| null
 	)[]
-): MutableRefObject<HTMLVideoElementWithPlyr | null> {
+): RefObject<HTMLVideoElementWithPlyr | null> {
 	const targetRef = useRef(null);
 
 	useEffect(() => {

--- a/packages/example/src/ThreeHtml/ThreeHtml.tsx
+++ b/packages/example/src/ThreeHtml/ThreeHtml.tsx
@@ -13,7 +13,7 @@ const Content = () => {
 };
 
 const Box: React.FC<{
-	readonly portalTarget: React.MutableRefObject<HTMLDivElement>;
+	readonly portalTarget: React.RefObject<HTMLDivElement>;
 }> = ({portalTarget}) => {
 	const frame = useCurrentFrame();
 	const rotation = interpolate(frame, [0, 1_000], [0, -5], {
@@ -42,7 +42,7 @@ const Box: React.FC<{
 export const ThreeHtml = () => {
 	const portalRef = useRef<HTMLDivElement | null>(
 		null,
-	) as React.MutableRefObject<HTMLDivElement>;
+	) as React.RefObject<HTMLDivElement>;
 
 	const {width, height} = useVideoConfig();
 

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -1,4 +1,4 @@
-import type {ComponentType, LazyExoticComponent, MutableRefObject} from 'react';
+import type {ComponentType, LazyExoticComponent, RefObject} from 'react';
 import React, {
 	forwardRef,
 	useEffect,
@@ -174,7 +174,7 @@ const PlayerFn = <
 		initialVolume,
 		...componentProps
 	}: PlayerProps<Schema, Props>,
-	ref: MutableRefObject<PlayerRef>,
+	ref: RefObject<PlayerRef>,
 ) => {
 	if (typeof window !== 'undefined') {
 		window.remotion_isPlayer = true;
@@ -517,10 +517,7 @@ const PlayerFn = <
 };
 
 const forward = forwardRef as <T, P = {}>(
-	render: (
-		props: P,
-		ref: React.MutableRefObject<T>,
-	) => React.ReactElement | null,
+	render: (props: P, ref: React.RefObject<T>) => React.ReactElement | null,
 ) => (props: P & React.RefAttributes<T>) => React.ReactElement | null;
 
 /*

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -2,7 +2,7 @@ import type {
 	ComponentType,
 	CSSProperties,
 	LazyExoticComponent,
-	MutableRefObject,
+	RefObject,
 } from 'react';
 import {
 	forwardRef,
@@ -72,7 +72,7 @@ const ThumbnailFn = <
 		noSuspense,
 		...componentProps
 	}: ThumbnailProps<Schema, Props>,
-	ref: MutableRefObject<ThumbnailMethods>,
+	ref: RefObject<ThumbnailMethods>,
 ) => {
 	if (typeof window !== 'undefined') {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -160,10 +160,7 @@ const ThumbnailFn = <
 };
 
 const forward = forwardRef as <T, P = {}>(
-	render: (
-		props: P,
-		ref: React.MutableRefObject<T>,
-	) => React.ReactElement | null,
+	render: (props: P, ref: React.RefObject<T>) => React.ReactElement | null,
 ) => (props: P & React.RefAttributes<T>) => React.ReactElement | null;
 
 /*

--- a/packages/promo-pages/src/components/homepage/Demo/Card.tsx
+++ b/packages/promo-pages/src/components/homepage/Demo/Card.tsx
@@ -18,11 +18,11 @@ const arePositionsEqual = (a: Position[], b: Position[]) => {
 
 export const Card: React.FC<{
 	readonly index: number;
-	readonly refsToUse: React.MutableRefObject<HTMLDivElement>[];
+	readonly refsToUse: React.RefObject<HTMLDivElement>[];
 	readonly onUpdate: (newIndices: number[]) => void;
 	readonly content: React.ReactNode;
-	readonly positions: React.MutableRefObject<Position[]>;
-	readonly shouldBePositions: React.MutableRefObject<Position[]>;
+	readonly positions: React.RefObject<Position[]>;
+	readonly shouldBePositions: React.RefObject<Position[]>;
 	readonly indices: number[];
 	readonly theme: 'dark' | 'light';
 	readonly withSwitcher: boolean;

--- a/packages/promo-pages/src/components/homepage/VideoPlayerWithControls.tsx
+++ b/packages/promo-pages/src/components/homepage/VideoPlayerWithControls.tsx
@@ -4,7 +4,7 @@ import Hls from 'hls.js';
 import type Plyr from 'plyr';
 // eslint-disable-next-line no-restricted-imports
 import 'plyr/dist/plyr.css';
-import type {MutableRefObject} from 'react';
+import type {RefObject} from 'react';
 import {forwardRef, useCallback, useEffect, useRef, useState} from 'react';
 import './video-player.css';
 
@@ -15,10 +15,10 @@ export interface HTMLVideoElementWithPlyr extends HTMLVideoElement {
 const useCombinedRefs = function (
 	...refs: (
 		| ((instance: HTMLVideoElementWithPlyr | null) => void)
-		| MutableRefObject<HTMLVideoElementWithPlyr | null>
+		| RefObject<HTMLVideoElementWithPlyr | null>
 		| null
 	)[]
-): MutableRefObject<HTMLVideoElementWithPlyr | null> {
+): RefObject<HTMLVideoElementWithPlyr | null> {
 	const targetRef = useRef(null);
 
 	useEffect(() => {

--- a/packages/studio/src/components/ContextMenu.tsx
+++ b/packages/studio/src/components/ContextMenu.tsx
@@ -255,9 +255,8 @@ export const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
 				}
 
 				if (forwardedRef) {
-					(
-						forwardedRef as React.MutableRefObject<HTMLDivElement | null>
-					).current = node;
+					(forwardedRef as React.RefObject<HTMLDivElement | null>).current =
+						node;
 				}
 			},
 			[forwardedRef],

--- a/packages/studio/src/components/Splitter/SplitterContext.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContext.tsx
@@ -14,7 +14,7 @@ export type TSplitterContext = {
 	defaultFlex: number;
 	id: string;
 	persistFlex: (value: number) => void;
-	isDragging: React.MutableRefObject<
+	isDragging: React.RefObject<
 		| false
 		| {
 				x: number;

--- a/packages/studio/src/state/editor-guides.ts
+++ b/packages/studio/src/state/editor-guides.ts
@@ -17,8 +17,8 @@ export type GuideState = {
 	setDraggingGuideId: (cb: (prevState: string | null) => string | null) => void;
 	setHoveredGuideId: (cb: (prevState: string | null) => string | null) => void;
 	hoveredGuideId: string | null;
-	shouldCreateGuideRef: React.MutableRefObject<boolean>;
-	shouldDeleteGuideRef: React.MutableRefObject<boolean>;
+	shouldCreateGuideRef: React.RefObject<boolean>;
+	shouldDeleteGuideRef: React.RefObject<boolean>;
 };
 
 export const persistEditorShowGuidesOption = (option: boolean) => {


### PR DESCRIPTION
## Summary

React 19's `@types/react` deprecates `MutableRefObject<T>` and makes `RefObject<T>` mutable (`{ current: T }`), so the two types are now equivalent.

This replaces all remaining `MutableRefObject` usages with `RefObject` across the affected packages:

- `remotion` (core)
- `@remotion/player`
- `@remotion/studio`
- docs, promo-pages, example

The change is **type-only** and has no runtime effect. It type-checks against the installed `@types/react@19`, where writes to `.current` remain valid.
