### PR TITLE
`remotion`: Fix player buffering subscription leak and report state synchronously

### DIFF
--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -2,7 +2,6 @@ import React, {
 	useCallback,
 	useContext,
 	useEffect,
-	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -42,18 +41,49 @@ const useBufferManager = (
 	logLevel: LogLevel,
 	mountTime: number | null,
 ): BufferManager => {
-	const [blocks, setBlocks] = useState<Block[]>([]);
-	const [onBufferingCallbacks, setOnBufferingCallbacks] = useState<
-		OnBufferingCallback[]
-	>([]);
-	const [onResumeCallbacks, setOnResumeCallbacks] = useState<
-		OnBufferingCallback[]
-	>([]);
+	const blocks = useRef<Block[]>([]);
+	const onBufferingCallbacks = useRef<OnBufferingCallback[]>([]);
+	const onResumeCallbacks = useRef<OnResumeCallback[]>([]);
 
 	const env = useRemotionEnvironment();
 	const rendering = env.isRendering;
 
 	const buffering = useRef(false);
+
+	// Fire callbacks only on the `0 <-> >0` blocks transition.
+	// `buffering` holds the last reported state, so intermediate changes
+	// (e.g. 2 -> 3 blocks) are no-ops and never re-notify listeners.
+	const checkBuffering = useCallback(() => {
+		if (rendering) {
+			return;
+		}
+
+		const isBuffering = blocks.current.length > 0;
+		if (isBuffering === buffering.current) {
+			return;
+		}
+
+		buffering.current = isBuffering;
+
+		if (isBuffering) {
+			// Iterate a copy: a callback may remove itself while being called.
+			[...onBufferingCallbacks.current].forEach((c) => c());
+			playbackLogging({
+				logLevel,
+				message: 'Player is entering buffer state',
+				mountTime,
+				tag: 'player',
+			});
+		} else {
+			[...onResumeCallbacks.current].forEach((c) => c());
+			playbackLogging({
+				logLevel,
+				message: 'Player is exiting buffer state',
+				mountTime,
+				tag: 'player',
+			});
+		}
+	}, [logLevel, mountTime, rendering]);
 
 	const addBlock: AddBlock = useCallback(
 		(block: Block) => {
@@ -65,7 +95,8 @@ const useBufferManager = (
 
 			let unblocked = false;
 
-			setBlocks((b) => [...b, block]);
+			blocks.current.push(block);
+			checkBuffering();
 			return {
 				unblock: () => {
 					if (unblocked) {
@@ -73,27 +104,23 @@ const useBufferManager = (
 					}
 
 					unblocked = true;
-					setBlocks((b) => {
-						const newArr = b.filter((bx) => bx !== block);
-						if (newArr.length === b.length) {
-							return b;
-						}
-
-						return newArr;
-					});
+					blocks.current = blocks.current.filter((bx) => bx !== block);
+					checkBuffering();
 				},
 			};
 		},
-		[rendering],
+		[checkBuffering, rendering],
 	);
 
 	const listenForBuffering: ListenForBuffering = useCallback(
 		(callback: OnBufferingCallback) => {
-			setOnBufferingCallbacks((c) => [...c, callback]);
+			onBufferingCallbacks.current.push(callback);
 
 			return {
 				remove: () => {
-					setOnBufferingCallbacks((c) => c.filter((cb) => cb !== callback));
+					onBufferingCallbacks.current = onBufferingCallbacks.current.filter(
+						(cb) => cb !== callback,
+					);
 				},
 			};
 		},
@@ -102,61 +129,18 @@ const useBufferManager = (
 
 	const listenForResume: ListenForResume = useCallback(
 		(callback: OnResumeCallback) => {
-			setOnResumeCallbacks((c) => [...c, callback]);
+			onResumeCallbacks.current.push(callback);
 
 			return {
 				remove: () => {
-					setOnResumeCallbacks((c) => c.filter((cb) => cb !== callback));
+					onResumeCallbacks.current = onResumeCallbacks.current.filter(
+						(cb) => cb !== callback,
+					);
 				},
 			};
 		},
 		[],
 	);
-
-	useEffect(() => {
-		if (rendering) {
-			return;
-		}
-
-		if (blocks.length > 0) {
-			onBufferingCallbacks.forEach((c) => c());
-			playbackLogging({
-				logLevel,
-				message: 'Player is entering buffer state',
-				mountTime,
-				tag: 'player',
-			});
-		}
-
-		// Intentionally only firing when blocks change, not the callbacks
-		// otherwise a buffering callback might remove itself after being called
-		// and trigger again
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [blocks]);
-
-	if (typeof window !== 'undefined') {
-		// eslint-disable-next-line react-hooks/rules-of-hooks
-		useLayoutEffect(() => {
-			if (rendering) {
-				return;
-			}
-
-			if (blocks.length === 0) {
-				onResumeCallbacks.forEach((c) => c());
-				playbackLogging({
-					logLevel,
-					message: 'Player is exiting buffer state',
-					mountTime,
-					tag: 'player',
-				});
-			}
-			// Intentionally only firing when blocks change, not the callbacks
-			// otherwise a resume callback might remove itself after being called
-			// and trigger again
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [blocks]);
-	}
 
 	return useMemo(() => {
 		return {addBlock, listenForBuffering, listenForResume, buffering};
@@ -194,12 +178,16 @@ export const useIsPlayerBuffering = (bufferManager: BufferManager) => {
 			setIsBuffering(false);
 		};
 
-		bufferManager.listenForBuffering(onBuffer);
-		bufferManager.listenForResume(onResume);
+		const buffer = bufferManager.listenForBuffering(onBuffer);
+		const resume = bufferManager.listenForResume(onResume);
+
+		// Sync in case the buffer state flipped between the initial render and
+		// this subscription (e.g. a media element blocked before we listened).
+		setIsBuffering(bufferManager.buffering.current);
 
 		return () => {
-			bufferManager.listenForBuffering(() => undefined);
-			bufferManager.listenForResume(() => undefined);
+			buffer.remove();
+			resume.remove();
 		};
 	}, [bufferManager]);
 

--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -50,11 +50,22 @@ const useBufferManager = (
 
 	const buffering = useRef(false);
 
+	// Keep the latest context values in refs so `checkBuffering` and `addBlock`
+	// stay referentially stable and the memoized manager is created only once.
+	// They are only read inside event handlers / effects, never during render,
+	// so reading the current value at call-time is what we want.
+	const logLevelRef = useRef(logLevel);
+	logLevelRef.current = logLevel;
+	const mountTimeRef = useRef(mountTime);
+	mountTimeRef.current = mountTime;
+	const renderingRef = useRef(rendering);
+	renderingRef.current = rendering;
+
 	// Fire callbacks only on the `0 <-> >0` blocks transition.
 	// `buffering` holds the last reported state, so intermediate changes
 	// (e.g. 2 -> 3 blocks) are no-ops and never re-notify listeners.
 	const checkBuffering = useCallback(() => {
-		if (rendering) {
+		if (renderingRef.current) {
 			return;
 		}
 
@@ -69,25 +80,25 @@ const useBufferManager = (
 			// Iterate a copy: a callback may remove itself while being called.
 			[...onBufferingCallbacks.current].forEach((c) => c());
 			playbackLogging({
-				logLevel,
+				logLevel: logLevelRef.current,
 				message: 'Player is entering buffer state',
-				mountTime,
+				mountTime: mountTimeRef.current,
 				tag: 'player',
 			});
 		} else {
 			[...onResumeCallbacks.current].forEach((c) => c());
 			playbackLogging({
-				logLevel,
+				logLevel: logLevelRef.current,
 				message: 'Player is exiting buffer state',
-				mountTime,
+				mountTime: mountTimeRef.current,
 				tag: 'player',
 			});
 		}
-	}, [logLevel, mountTime, rendering]);
+	}, []);
 
 	const addBlock: AddBlock = useCallback(
 		(block: Block) => {
-			if (rendering) {
+			if (renderingRef.current) {
 				return {
 					unblock: () => undefined,
 				};
@@ -109,7 +120,7 @@ const useBufferManager = (
 				},
 			};
 		},
-		[checkBuffering, rendering],
+		[checkBuffering],
 	);
 
 	const listenForBuffering: ListenForBuffering = useCallback(

--- a/packages/player/src/use-buffer-state-emitter.ts
+++ b/packages/player/src/use-buffer-state-emitter.ts
@@ -13,11 +13,9 @@ export const useBufferStateEmitter = (
 
 	useLayoutEffect(() => {
 		const clear1 = bufferManager.listenForBuffering(() => {
-			bufferManager.buffering.current = true;
 			emitter.dispatchWaiting({});
 		});
 		const clear2 = bufferManager.listenForResume(() => {
-			bufferManager.buffering.current = false;
 			emitter.dispatchResume({});
 		});
 


### PR DESCRIPTION
## Summary

Reworks the player buffer manager to track blocks and listeners in refs and report buffering state synchronously, and fixes a subscription leak in `useIsPlayerBuffering`.

## Changes

- **Track buffering state in refs instead of `useState`.** `blocks`, `onBufferingCallbacks`, and `onResumeCallbacks` are now refs. Adding/removing a block calls `checkBuffering()` directly, so buffer/resume listeners fire synchronously on the `0 <-> >0` blocks transition without waiting for a render + effect.
- **Fire callbacks only on the actual transition.** `checkBuffering` compares against the last reported state (`buffering.current`), so intermediate changes (e.g. `2 -> 3` blocks) no longer re-notify listeners. Callbacks are iterated over a copy so a callback can remove itself while being called. This preserves the behavior the old `useEffect`/`useLayoutEffect` pair was working around, without the extra renders.
- **Fix subscription leak in `useIsPlayerBuffering`.** The cleanup previously called `listenForBuffering(() => undefined)` / `listenForResume(() => undefined)`, which *registered a new no-op listener* instead of removing the original ones — leaking a subscription on every re-subscribe. It now keeps the returned handles and calls `.remove()`.
- **Sync state after subscribing.** `setIsBuffering(bufferManager.buffering.current)` runs right after subscribing, so a buffer state that flipped between the initial render and effect setup (e.g. a media element that blocked before we listened) is not missed.
