### PR TITLE
`@remotion/convert`: Disable video copy for edits

### DIFF
--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -178,6 +178,9 @@ const ConvertUI = ({
 		return resampleRate;
 	}, [resampleRate, canResample, resampleUserPreferenceActive]);
 
+	const disableVideoCopy =
+		enableRotateOrMirror !== null || trim || resizeOperation !== null;
+
 	const supportedConfigs = useSupportedConfigs({
 		outputContainer: actualOutputContainer,
 		tracks,
@@ -186,6 +189,7 @@ const ConvertUI = ({
 		inputContainer,
 		resizeOperation,
 		sampleRate: actualResampleRate,
+		disableVideoCopy,
 	});
 
 	const isH264Reencode = supportedConfigs?.videoTrackOptions.some((o) => {

--- a/packages/convert/app/components/get-supported-configs.tsx
+++ b/packages/convert/app/components/get-supported-configs.tsx
@@ -100,6 +100,7 @@ export const getSupportedConfigs = async ({
 	userRotation,
 	resizeOperation,
 	sampleRate,
+	disableVideoCopy,
 }: {
 	tracks: InputTrack[];
 	container: OutputFormat;
@@ -107,6 +108,7 @@ export const getSupportedConfigs = async ({
 	userRotation: number;
 	resizeOperation: MediabunnyResize | null;
 	sampleRate: number | null;
+	disableVideoCopy: boolean;
 }): Promise<SupportedConfigs> => {
 	const audioTrackOptions: AudioTrackOption[] = [];
 	const videoTrackOptions: VideoTrackOption[] = [];
@@ -117,12 +119,15 @@ export const getSupportedConfigs = async ({
 	for (const track of tracks) {
 		if (track.isVideoTrack()) {
 			const options: VideoOperation[] = [];
-			const canCopy = canCopyVideoTrack({
-				inputTrack: track,
-				outputContainer: container,
-				rotationToApply: userRotation,
-				resizeOperation,
-			});
+			const canCopy =
+				!disableVideoCopy &&
+				canCopyVideoTrack({
+					inputTrack: track,
+					outputContainer: container,
+					rotationToApply: userRotation,
+					resizeOperation,
+				}) &&
+				!disableVideoCopy;
 			if (canCopy && prioritizeCopyOverReencode) {
 				options.push({
 					type: 'copy',

--- a/packages/convert/app/components/use-supported-configs.ts
+++ b/packages/convert/app/components/use-supported-configs.ts
@@ -15,6 +15,7 @@ export const useSupportedConfigs = ({
 	inputContainer,
 	resizeOperation,
 	sampleRate,
+	disableVideoCopy,
 }: {
 	outputContainer: OutputContainer;
 	tracks: InputTrack[] | null;
@@ -23,6 +24,7 @@ export const useSupportedConfigs = ({
 	resizeOperation: MediabunnyResize | null;
 	inputContainer: InputFormat | null;
 	sampleRate: number | null;
+	disableVideoCopy: boolean;
 }) => {
 	const [state, setState] = useState<
 		Record<OutputFormat['mimeType'], SupportedConfigs | null | undefined>
@@ -44,6 +46,7 @@ export const useSupportedConfigs = ({
 			userRotation,
 			resizeOperation,
 			sampleRate,
+			disableVideoCopy,
 		}).then((supportedConfigs) => {
 			setState((prev) => ({
 				...prev,
@@ -59,7 +62,28 @@ export const useSupportedConfigs = ({
 		tracks,
 		userRotation,
 		sampleRate,
+		disableVideoCopy,
 	]);
 
-	return state[outputContainer] ?? null;
+	const cachedSupportedConfigs = state[outputContainer] ?? null;
+
+	return useMemo(() => {
+		if (!disableVideoCopy || cachedSupportedConfigs === null) {
+			return cachedSupportedConfigs;
+		}
+
+		return {
+			...cachedSupportedConfigs,
+			videoTrackOptions: cachedSupportedConfigs.videoTrackOptions.map(
+				(track) => {
+					return {
+						...track,
+						operations: track.operations.filter((operation) => {
+							return operation.type !== 'copy';
+						}),
+					};
+				},
+			),
+		};
+	}, [cachedSupportedConfigs, disableVideoCopy]);
 };

--- a/packages/convert/test/video-transcoding-options.test.ts
+++ b/packages/convert/test/video-transcoding-options.test.ts
@@ -1,0 +1,50 @@
+import {expect, test} from 'bun:test';
+import type {InputTrack} from 'mediabunny';
+import {Mp4OutputFormat} from 'mediabunny';
+import {getSupportedConfigs} from '../app/components/get-supported-configs';
+
+const makeVideoTrack = () =>
+	({
+		id: 0,
+		codec: 'avc',
+		rotation: 0,
+		displayHeight: 1080,
+		displayWidth: 1920,
+		canDecode: () => Promise.resolve(true),
+		isVideoTrack: () => true,
+		isAudioTrack: () => false,
+	}) as unknown as InputTrack;
+
+test('offers video copy when no video edit is enabled', async () => {
+	const configs = await getSupportedConfigs({
+		tracks: [makeVideoTrack()],
+		container: new Mp4OutputFormat(),
+		action: {type: 'generic-convert'},
+		userRotation: 0,
+		resizeOperation: null,
+		sampleRate: null,
+		disableVideoCopy: false,
+	});
+
+	expect(configs.videoTrackOptions[0].operations).toContainEqual({
+		type: 'copy',
+	});
+});
+
+test('disables video copy when a video edit is enabled', async () => {
+	const configs = await getSupportedConfigs({
+		tracks: [makeVideoTrack()],
+		container: new Mp4OutputFormat(),
+		action: {type: 'generic-trim'},
+		userRotation: 0,
+		resizeOperation: null,
+		sampleRate: null,
+		disableVideoCopy: true,
+	});
+
+	expect(
+		configs.videoTrackOptions[0].operations.some((operation) => {
+			return operation.type === 'copy';
+		}),
+	).toBe(false);
+});


### PR DESCRIPTION
## Summary
- Disable video copy options whenever a crop, trim, resize, rotate, or mirror edit is active.
- Filter cached supported configs immediately so stale copy options disappear on toggle.
- Add regression coverage for video copy availability.

## Tests
- `bun run --cwd packages/convert lint`
- `bun run --cwd packages/convert test`
- `bun run build`
- `bun run stylecheck`

Closes #8889
