### PR TITLE
`@remotion/convert`: Rename same-codec action to Re-encode

### DIFF
--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -29,6 +29,7 @@ import {
 	getActualAudioOperation,
 	getActualVideoOperation,
 } from '~/lib/get-audio-video-config-index';
+import {getConvertActionLabel} from '~/lib/get-convert-action-label';
 import {
 	getDefaultConvertOutputFormat,
 	getDefaultEditOutputFormat,
@@ -634,6 +635,16 @@ const ConvertUI = ({
 		enableConvert,
 	});
 
+	const convertActionLabel = getConvertActionLabel({
+		audioConfigIndexSelection: audioOperationSelection,
+		enableConvert,
+		inputContainer,
+		outputContainer: actualOutputContainer,
+		supportedConfigs,
+		tracks,
+		videoConfigIndexSelection: videoOperationSelection,
+	});
+
 	return (
 		<>
 			<div className="w-full gap-4 flex flex-col">
@@ -649,7 +660,7 @@ const ConvertUI = ({
 									active={enableConvert}
 									setActive={setEnableConvert}
 								>
-									Convert
+									{convertActionLabel}
 								</ConvertUiSection>
 								{enableConvert ? (
 									<>
@@ -817,7 +828,7 @@ const ConvertUI = ({
 				disabled={disableSubmit}
 				onClick={onClick}
 			>
-				Convert
+				{convertActionLabel}
 			</Button>
 		</>
 	);

--- a/packages/convert/app/lib/get-convert-action-label.ts
+++ b/packages/convert/app/lib/get-convert-action-label.ts
@@ -43,7 +43,7 @@ export const getConvertActionLabel = ({
 	readonly supportedConfigs: SupportedConfigs | null;
 	readonly tracks: InputTrack[] | null;
 	readonly videoConfigIndexSelection: Record<number, string>;
-}): 'Convert' | 'Re-encode' => {
+}): 'Convert' | 'Remux' | 'Re-encode' => {
 	if (!enableConvert || supportedConfigs === null || tracks === null) {
 		return 'Convert';
 	}
@@ -53,6 +53,7 @@ export const getConvertActionLabel = ({
 	}
 
 	let hasReencodeOperation = false;
+	let hasTrackOperation = false;
 
 	for (const option of supportedConfigs.videoTrackOptions) {
 		const operation = getActualVideoOperation({
@@ -62,7 +63,8 @@ export const getConvertActionLabel = ({
 			operations: option.operations,
 		});
 
-		if (operation.type === 'copy') {
+		if (operation.type === 'copy' || operation.type === 'drop') {
+			hasTrackOperation = true;
 			continue;
 		}
 
@@ -75,6 +77,7 @@ export const getConvertActionLabel = ({
 			return 'Convert';
 		}
 
+		hasTrackOperation = true;
 		hasReencodeOperation = true;
 	}
 
@@ -86,7 +89,8 @@ export const getConvertActionLabel = ({
 			operations: option.operations,
 		});
 
-		if (operation.type === 'copy') {
+		if (operation.type === 'copy' || operation.type === 'drop') {
+			hasTrackOperation = true;
 			continue;
 		}
 
@@ -99,8 +103,13 @@ export const getConvertActionLabel = ({
 			return 'Convert';
 		}
 
+		hasTrackOperation = true;
 		hasReencodeOperation = true;
 	}
 
-	return hasReencodeOperation ? 'Re-encode' : 'Convert';
+	if (hasReencodeOperation) {
+		return 'Re-encode';
+	}
+
+	return hasTrackOperation ? 'Remux' : 'Convert';
 };

--- a/packages/convert/app/lib/get-convert-action-label.ts
+++ b/packages/convert/app/lib/get-convert-action-label.ts
@@ -1,0 +1,106 @@
+import type {InputFormat, InputTrack} from 'mediabunny';
+import type {SupportedConfigs} from '~/components/get-supported-configs';
+import type {OutputContainer} from '~/seo';
+import {
+	getActualAudioOperation,
+	getActualVideoOperation,
+} from './get-audio-video-config-index';
+import {getSameOutputFormat} from './get-default-output-format';
+
+const getInputVideoCodec = (tracks: InputTrack[], trackId: number) => {
+	for (const track of tracks) {
+		if (track.id === trackId && track.isVideoTrack()) {
+			return track.codec;
+		}
+	}
+
+	return null;
+};
+
+const getInputAudioCodec = (tracks: InputTrack[], trackId: number) => {
+	for (const track of tracks) {
+		if (track.id === trackId && track.isAudioTrack()) {
+			return track.codec;
+		}
+	}
+
+	return null;
+};
+
+export const getConvertActionLabel = ({
+	audioConfigIndexSelection,
+	enableConvert,
+	inputContainer,
+	outputContainer,
+	supportedConfigs,
+	tracks,
+	videoConfigIndexSelection,
+}: {
+	readonly audioConfigIndexSelection: Record<number, string>;
+	readonly enableConvert: boolean;
+	readonly inputContainer: InputFormat;
+	readonly outputContainer: OutputContainer;
+	readonly supportedConfigs: SupportedConfigs | null;
+	readonly tracks: InputTrack[] | null;
+	readonly videoConfigIndexSelection: Record<number, string>;
+}): 'Convert' | 'Re-encode' => {
+	if (!enableConvert || supportedConfigs === null || tracks === null) {
+		return 'Convert';
+	}
+
+	if (getSameOutputFormat(inputContainer) !== outputContainer) {
+		return 'Convert';
+	}
+
+	let hasReencodeOperation = false;
+
+	for (const option of supportedConfigs.videoTrackOptions) {
+		const operation = getActualVideoOperation({
+			enableConvert,
+			trackNumber: option.trackId,
+			videoConfigIndexSelection,
+			operations: option.operations,
+		});
+
+		if (operation.type === 'copy') {
+			continue;
+		}
+
+		if (operation.type !== 'reencode') {
+			return 'Convert';
+		}
+
+		const inputVideoCodec = getInputVideoCodec(tracks, option.trackId);
+		if (inputVideoCodec !== operation.videoCodec) {
+			return 'Convert';
+		}
+
+		hasReencodeOperation = true;
+	}
+
+	for (const option of supportedConfigs.audioTrackOptions) {
+		const operation = getActualAudioOperation({
+			audioConfigIndexSelection,
+			enableConvert,
+			trackNumber: option.trackId,
+			operations: option.operations,
+		});
+
+		if (operation.type === 'copy') {
+			continue;
+		}
+
+		if (operation.type !== 'reencode') {
+			return 'Convert';
+		}
+
+		const inputAudioCodec = getInputAudioCodec(tracks, option.trackId);
+		if (inputAudioCodec !== operation.audioCodec) {
+			return 'Convert';
+		}
+
+		hasReencodeOperation = true;
+	}
+
+	return hasReencodeOperation ? 'Re-encode' : 'Convert';
+};

--- a/packages/convert/app/lib/get-default-output-format.ts
+++ b/packages/convert/app/lib/get-default-output-format.ts
@@ -39,7 +39,7 @@ const getDefaultConversionFormat = (
 	throw new Error('not all input formats handled: ' + inputContainer.name);
 };
 
-const getSameOutputFormat = (
+export const getSameOutputFormat = (
 	inputContainer: InputFormat,
 ): OutputContainer | null => {
 	if (inputContainer === MP4) {

--- a/packages/convert/test/convert-action-label.test.ts
+++ b/packages/convert/test/convert-action-label.test.ts
@@ -129,7 +129,7 @@ test('labels same-container same-codec audio re-encoding as re-encode', () => {
 	).toBe('Re-encode');
 });
 
-test('keeps convert label if tracks are only copied', () => {
+test('labels same-container copy-only operations as remux', () => {
 	const operation = {type: 'copy'} as const;
 	const supportedConfigs: SupportedConfigs = {
 		videoTrackOptions: [
@@ -151,5 +151,5 @@ test('keeps convert label if tracks are only copied', () => {
 			tracks: [videoTrack(1, 'avc')],
 			videoConfigIndexSelection: {1: getVideoOperationId(operation)},
 		}),
-	).toBe('Convert');
+	).toBe('Remux');
 });

--- a/packages/convert/test/convert-action-label.test.ts
+++ b/packages/convert/test/convert-action-label.test.ts
@@ -1,0 +1,155 @@
+import {expect, test} from 'bun:test';
+import type {InputTrack} from 'mediabunny';
+import {MP3, MP4, WEBM} from 'mediabunny';
+import type {SupportedConfigs} from '../app/components/get-supported-configs';
+import {getConvertActionLabel} from '../app/lib/get-convert-action-label';
+import {
+	getAudioOperationId,
+	getVideoOperationId,
+} from '../app/lib/operation-key';
+
+const videoTrack = (id: number, codec: string) =>
+	({
+		codec,
+		id,
+		isAudioTrack: () => false,
+		isVideoTrack: () => true,
+	}) as unknown as InputTrack;
+
+const audioTrack = (id: number, codec: string) =>
+	({
+		codec,
+		id,
+		isAudioTrack: () => true,
+		isVideoTrack: () => false,
+	}) as unknown as InputTrack;
+
+test('labels same-container same-codec video re-encoding as re-encode', () => {
+	const operation = {type: 'reencode', videoCodec: 'avc'} as const;
+	const supportedConfigs: SupportedConfigs = {
+		videoTrackOptions: [
+			{
+				trackId: 1,
+				operations: [operation],
+			},
+		],
+		audioTrackOptions: [],
+	};
+
+	expect(
+		getConvertActionLabel({
+			audioConfigIndexSelection: {},
+			enableConvert: true,
+			inputContainer: MP4,
+			outputContainer: 'mp4',
+			supportedConfigs,
+			tracks: [videoTrack(1, 'avc')],
+			videoConfigIndexSelection: {1: getVideoOperationId(operation)},
+		}),
+	).toBe('Re-encode');
+});
+
+test('keeps convert label when the output container changes', () => {
+	const operation = {type: 'reencode', videoCodec: 'avc'} as const;
+	const supportedConfigs: SupportedConfigs = {
+		videoTrackOptions: [
+			{
+				trackId: 1,
+				operations: [operation],
+			},
+		],
+		audioTrackOptions: [],
+	};
+
+	expect(
+		getConvertActionLabel({
+			audioConfigIndexSelection: {},
+			enableConvert: true,
+			inputContainer: MP4,
+			outputContainer: 'webm',
+			supportedConfigs,
+			tracks: [videoTrack(1, 'avc')],
+			videoConfigIndexSelection: {1: getVideoOperationId(operation)},
+		}),
+	).toBe('Convert');
+});
+
+test('keeps convert label when the selected codec changes', () => {
+	const operation = {type: 'reencode', videoCodec: 'vp9'} as const;
+	const supportedConfigs: SupportedConfigs = {
+		videoTrackOptions: [
+			{
+				trackId: 1,
+				operations: [operation],
+			},
+		],
+		audioTrackOptions: [],
+	};
+
+	expect(
+		getConvertActionLabel({
+			audioConfigIndexSelection: {},
+			enableConvert: true,
+			inputContainer: WEBM,
+			outputContainer: 'webm',
+			supportedConfigs,
+			tracks: [videoTrack(1, 'vp8')],
+			videoConfigIndexSelection: {1: getVideoOperationId(operation)},
+		}),
+	).toBe('Convert');
+});
+
+test('labels same-container same-codec audio re-encoding as re-encode', () => {
+	const operation = {
+		type: 'reencode',
+		audioCodec: 'mp3',
+		sampleRate: null,
+	} as const;
+	const supportedConfigs: SupportedConfigs = {
+		videoTrackOptions: [],
+		audioTrackOptions: [
+			{
+				audioCodec: 'mp3',
+				trackId: 1,
+				operations: [operation],
+			},
+		],
+	};
+
+	expect(
+		getConvertActionLabel({
+			audioConfigIndexSelection: {1: getAudioOperationId(operation)},
+			enableConvert: true,
+			inputContainer: MP3,
+			outputContainer: 'mp3',
+			supportedConfigs,
+			tracks: [audioTrack(1, 'mp3')],
+			videoConfigIndexSelection: {},
+		}),
+	).toBe('Re-encode');
+});
+
+test('keeps convert label if tracks are only copied', () => {
+	const operation = {type: 'copy'} as const;
+	const supportedConfigs: SupportedConfigs = {
+		videoTrackOptions: [
+			{
+				trackId: 1,
+				operations: [operation],
+			},
+		],
+		audioTrackOptions: [],
+	};
+
+	expect(
+		getConvertActionLabel({
+			audioConfigIndexSelection: {},
+			enableConvert: true,
+			inputContainer: MP4,
+			outputContainer: 'mp4',
+			supportedConfigs,
+			tracks: [videoTrack(1, 'avc')],
+			videoConfigIndexSelection: {1: getVideoOperationId(operation)},
+		}),
+	).toBe('Convert');
+});


### PR DESCRIPTION
## Summary

- Show `Re-encode` instead of `Convert` when the selected output keeps the same container and codecs while re-encoding.
- Add converter tests for the action label decision.

Closes https://github.com/remotion-dev/remotion/issues/8850

## Testing

- `bun test packages/convert/test`
- `bun run build`
- `bun run stylecheck`
