### PR TITLE
Docs: Add rotating starburst element

### DIFF
--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -17,7 +17,8 @@ When converting a component for Studio interactivity, apply all of these rules t
 - Use `Interactive.*` for editable HTML or SVG elements, or [`Interactive.withSchema()`](/docs/interactive-with-schema) for custom components.
 - Add a descriptive `name` prop to the editable element or custom component.
 - Keep every editable or keyframed value inline at the JSX prop that the Studio edits.
-- Keep `interpolate()` keyframe arrays as hardcoded numeric arrays, such as `[0, 30]`.
+- Write animations as inline `interpolate()` calls.
+- Keep `interpolate()` input and output ranges as hardcoded arrays, such as `[0, 30]`.
 - Use Studio-editable style props such as `translate`, `scale`, `rotate`, `transformOrigin` and `opacity` instead of hiding values in a `transform` string.
 - Use `translate` for animated movement and canvas dragging. Keep `top`, `left`, `right` and `bottom` for static anchoring.
 - Keep `<Composition>` metadata and `defaultProps` inline unless the value is truly dynamic.
@@ -66,9 +67,10 @@ The name is shown in the Studio timeline and helps agents identify the correct e
 Put values that should be edited in the Studio directly into the JSX.
 This applies to static style values, keyframes, easing and transform props.
 
-If the Studio should expose a property such as `opacity`, `translate`, `scale` or `rotate`, keep the `interpolate()` call on that exact style property.
+Write animations as inline `interpolate()` calls on the property that changes.
 Do not calculate the value in a local variable and pass the variable into `style`.
-Keep the input range and output range directly in that `interpolate()` call.
+Do not animate with frame math such as `frame * 2`, modulo expressions, helper functions or transform strings.
+Keep the input range and output range directly in the `interpolate()` call.
 The input range must use hardcoded numbers, not variables or expressions such as `[sendStartFrame, sendStartFrame + duration]`.
 
 ```tsx title="Inline values"
@@ -210,6 +212,7 @@ Make this interactive in the Remotion Studio: https://www.remotion.dev/docs/stud
 ## Keep effects editable {#keep-effects-editable}
 
 Keep editable effect parameters inline in the effect call and keep the effect array shape unconditional.
+If an effect parameter is animated, write it as an inline `interpolate()` call in the effect call.
 
 ```tsx title="Effects"
 // 👍 Parameters are inline and the array shape is stable
@@ -220,14 +223,17 @@ Keep editable effect parameters inline in the effect call and keep the effect ar
   effects={[
     radialProgressiveBlur({
       center: [0.5, 0.5],
-      point1: [0.86, 0.36],
-      point2: [0.68, 0.84],
+      width: 1.2,
+      height: 0.8,
+      start: 0.2,
+      rotation: interpolate(frame, [0, 120], [0, 180]),
     }),
   ]}
 />
 
 // 👎 Values are hidden and the effect only exists conditionally
 const center = [0.5, 0.5] as const;
+const rotation = frame * 1.5;
 <CanvasImage
   src={src}
   width={1280}
@@ -235,6 +241,7 @@ const center = [0.5, 0.5] as const;
   effects={enabled ? [
     radialProgressiveBlur({
       center,
+      rotation,
     }),
   ] : []}
 />

--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -16,7 +16,10 @@ const sidebars: SidebarsConfig = {
 			label: 'Backgrounds',
 			link: {type: 'doc', id: 'backgrounds/index'},
 			collapsed: false,
-			items: ['backgrounds/paper-texture/index'],
+			items: [
+				'backgrounds/paper-texture/index',
+				'backgrounds/rotating-starburst/index',
+			],
 		},
 		{
 			type: 'category',

--- a/packages/docs/elements/backgrounds/index.mdx
+++ b/packages/docs/elements/backgrounds/index.mdx
@@ -8,3 +8,4 @@ description: Drop-in background Elements for Remotion videos.
 Elements:
 
 - [Paper texture](/elements/backgrounds/paper-texture/)
+- [Rotating starburst](/elements/backgrounds/rotating-starburst/)

--- a/packages/docs/elements/backgrounds/rotating-starburst/index.mdx
+++ b/packages/docs/elements/backgrounds/rotating-starburst/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Rotating Starburst
+description: A Solid background with a slowly rotating starburst effect.
+---
+
+import {ElementPage} from '@site/src/components/Elements/ElementPage';
+import {RotatingStarburst} from './rotating-starburst';
+
+# Rotating Starburst
+
+A `Solid` background with a slowly rotating `starburst()` effect.
+
+<ElementPage component={RotatingStarburst} displayName="Rotating Starburst" durationInFrames={240} elementHeight={1080} elementWidth={1920} slug="backgrounds/rotating-starburst" sourceFile="./rotating-starburst.tsx" />

--- a/packages/docs/elements/backgrounds/rotating-starburst/index.mdx
+++ b/packages/docs/elements/backgrounds/rotating-starburst/index.mdx
@@ -8,6 +8,6 @@ import {RotatingStarburst} from './rotating-starburst';
 
 # Rotating Starburst
 
-A `Solid` background with a slowly rotating `starburst()` effect.
+A [`<Solid>`](/docs/solid) background with a slowly rotating [`starburst()`](/docs/starburst/starburst-effect) effect.
 
 <ElementPage component={RotatingStarburst} displayName="Rotating Starburst" durationInFrames={240} elementHeight={1080} elementWidth={1920} slug="backgrounds/rotating-starburst" sourceFile="./rotating-starburst.tsx" />

--- a/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
+++ b/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
@@ -1,6 +1,6 @@
 import {starburst} from '@remotion/starburst';
 import React from 'react';
-import {Solid, useCurrentFrame} from 'remotion';
+import {interpolate, Solid, useCurrentFrame} from 'remotion';
 
 export const RotatingStarburst: React.FC = () => {
 	const frame = useCurrentFrame();
@@ -14,7 +14,7 @@ export const RotatingStarburst: React.FC = () => {
 				starburst({
 					rays: 28,
 					colors: ['#111827', '#f97316'],
-					rotation: (frame * 0.18) % 360,
+					rotation: interpolate(frame, [0, 2000], [0, 360]),
 					origin: [0.5, 0.5],
 				}),
 			]}

--- a/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
+++ b/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
@@ -4,7 +4,6 @@ import {Solid, useCurrentFrame} from 'remotion';
 
 export const RotatingStarburst: React.FC = () => {
 	const frame = useCurrentFrame();
-	const rotation = (frame * 0.18) % 360;
 
 	return (
 		<Solid
@@ -14,9 +13,8 @@ export const RotatingStarburst: React.FC = () => {
 			effects={[
 				starburst({
 					rays: 28,
-					colors: ['#111827', '#f97316', '#fde68a'],
-					rotation,
-					smoothness: 0.04,
+					colors: ['#111827', '#f97316'],
+					rotation: (frame * 0.18) % 360,
 					origin: [0.5, 0.5],
 				}),
 			]}

--- a/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
+++ b/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
@@ -7,13 +7,13 @@ export const RotatingStarburst: React.FC = () => {
 
 	return (
 		<Solid
-			color="#111827"
+			color="#dff4ff"
 			width={1920}
 			height={1080}
 			effects={[
 				starburst({
 					rays: 28,
-					colors: ['#111827', '#f97316'],
+					colors: ['#dff4ff', '#7cc6ff'],
 					rotation: interpolate(frame, [0, 2000], [0, 360]),
 					origin: [0.5, 0.5],
 				}),

--- a/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
+++ b/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
@@ -1,0 +1,25 @@
+import {starburst} from '@remotion/starburst';
+import React from 'react';
+import {Solid, useCurrentFrame} from 'remotion';
+
+export const RotatingStarburst: React.FC = () => {
+	const frame = useCurrentFrame();
+	const rotation = (frame * 0.18) % 360;
+
+	return (
+		<Solid
+			color="#111827"
+			width={1920}
+			height={1080}
+			effects={[
+				starburst({
+					rays: 28,
+					colors: ['#111827', '#f97316', '#fde68a'],
+					rotation,
+					smoothness: 0.04,
+					origin: [0.5, 0.5],
+				}),
+			]}
+		/>
+	);
+};


### PR DESCRIPTION
## Summary

- Adds a Rotating Starburst Element to the Backgrounds gallery
- Uses a `Solid` with a slowly rotating `starburst()` effect
- Registers the Element on the Backgrounds index and sidebar

## Testing

- `bun test packages/docs/src/test/elements.test.ts`
- `bunx oxfmt src --write`
- `bunx oxfmt packages/docs/elements-sidebars.ts packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx --write`
- `bun run build`
- `bun run stylecheck`
