### PR TITLE
`@remotion/player`: Respect focus-visible for play outline

### DIFF
--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -161,7 +161,6 @@ export const Controls: React.FC<{
 	renderCustomControls,
 }) => {
 	const playButtonRef = useRef<HTMLButtonElement | null>(null);
-	const didMountRef = useRef(false);
 	const [playButtonFocusVisible, setPlayButtonFocusVisible] = useState(false);
 	const [supportsFullscreen, setSupportsFullscreen] = useState(false);
 	const hovered = useHoverState(
@@ -227,11 +226,6 @@ export const Controls: React.FC<{
 	}, [buffering, playing, renderPlayPauseButton]);
 
 	useEffect(() => {
-		if (!didMountRef.current) {
-			didMountRef.current = true;
-			return;
-		}
-
 		if (playButtonRef.current && spaceKeyToPlayOrPause) {
 			// This switches focus to play button when player.playing flag changes
 			playButtonRef.current.focus({
@@ -327,11 +321,6 @@ export const Controls: React.FC<{
 			setPlayButtonFocusVisible(isFocusVisible(e.currentTarget));
 		}, []);
 
-	const onPlayButtonPointerDown: React.PointerEventHandler<HTMLButtonElement> =
-		useCallback(() => {
-			setPlayButtonFocusVisible(false);
-		}, []);
-
 	const onPlayButtonBlur = useCallback(() => {
 		setPlayButtonFocusVisible(false);
 	}, []);
@@ -351,7 +340,6 @@ export const Controls: React.FC<{
 						style={playPauseButtonStyle}
 						onClick={toggle}
 						onFocus={onPlayButtonFocus}
-						onPointerDown={onPlayButtonPointerDown}
 						onBlur={onPlayButtonBlur}
 						aria-label={playing ? 'Pause video' : 'Play video'}
 						title={playing ? 'Pause video' : 'Play video'}

--- a/packages/player/src/PlayerControls.tsx
+++ b/packages/player/src/PlayerControls.tsx
@@ -91,6 +91,14 @@ const flex1: React.CSSProperties = {
 
 const fullscreen: React.CSSProperties = {};
 
+const isFocusVisible = (element: HTMLElement): boolean => {
+	try {
+		return element.matches(':focus-visible');
+	} catch {
+		return true;
+	}
+};
+
 export const Controls: React.FC<{
 	readonly fps: number;
 	readonly durationInFrames: number;
@@ -153,7 +161,8 @@ export const Controls: React.FC<{
 	renderCustomControls,
 }) => {
 	const playButtonRef = useRef<HTMLButtonElement | null>(null);
-	const [playButtonFocused, setPlayButtonFocused] = useState(false);
+	const didMountRef = useRef(false);
+	const [playButtonFocusVisible, setPlayButtonFocusVisible] = useState(false);
 	const [supportsFullscreen, setSupportsFullscreen] = useState(false);
 	const hovered = useHoverState(
 		containerRef,
@@ -218,11 +227,17 @@ export const Controls: React.FC<{
 	}, [buffering, playing, renderPlayPauseButton]);
 
 	useEffect(() => {
+		if (!didMountRef.current) {
+			didMountRef.current = true;
+			return;
+		}
+
 		if (playButtonRef.current && spaceKeyToPlayOrPause) {
 			// This switches focus to play button when player.playing flag changes
 			playButtonRef.current.focus({
 				preventScroll: true,
 			});
+			setPlayButtonFocusVisible(isFocusVisible(playButtonRef.current));
 		}
 	}, [playing, spaceKeyToPlayOrPause]);
 
@@ -307,12 +322,18 @@ export const Controls: React.FC<{
 			[onDoubleClick],
 		);
 
-	const onPlayButtonFocus = useCallback(() => {
-		setPlayButtonFocused(true);
-	}, []);
+	const onPlayButtonFocus: React.FocusEventHandler<HTMLButtonElement> =
+		useCallback((e) => {
+			setPlayButtonFocusVisible(isFocusVisible(e.currentTarget));
+		}, []);
+
+	const onPlayButtonPointerDown: React.PointerEventHandler<HTMLButtonElement> =
+		useCallback(() => {
+			setPlayButtonFocusVisible(false);
+		}, []);
 
 	const onPlayButtonBlur = useCallback(() => {
-		setPlayButtonFocused(false);
+		setPlayButtonFocusVisible(false);
 	}, []);
 
 	return (
@@ -330,6 +351,7 @@ export const Controls: React.FC<{
 						style={playPauseButtonStyle}
 						onClick={toggle}
 						onFocus={onPlayButtonFocus}
+						onPointerDown={onPlayButtonPointerDown}
 						onBlur={onPlayButtonBlur}
 						aria-label={playing ? 'Pause video' : 'Play video'}
 						title={playing ? 'Pause video' : 'Play video'}
@@ -337,7 +359,7 @@ export const Controls: React.FC<{
 						{renderPlayPauseButton === null ? (
 							<DefaultPlayPauseButton
 								buffering={buffering}
-								focused={playButtonFocused}
+								focused={playButtonFocusVisible}
 								playing={playing}
 							/>
 						) : (


### PR DESCRIPTION
## Summary

- Show the custom play/pause SVG focus outline only when the button matches `:focus-visible`
- Clear the outline state on pointer interaction so touch and mouse activation do not leave a keyboard-style ring
- Avoid focusing the play button on the initial controls mount

Closes #8876

## Testing

- `bunx oxfmt src --write` in `packages/player`
- `bun run build`
- `bun run stylecheck`
