### PR TITLE
`@remotion/studio-server`: Add Studio reopen shortcut

### DIFF
--- a/packages/docs/docs/cli/studio.mdx
+++ b/packages/docs/docs/cli/studio.mdx
@@ -15,6 +15,13 @@ npx remotion studio <entry-point>?
 
 You may pass an [entry point](/docs/terminology/entry-point) as an argument, otherwise it will be [determined](/docs/terminology/entry-point#which-entry-point-is-being-used).
 
+## Reopen the Studio<AvailableFrom v="4.0.487" />
+
+While `npx remotion studio` is running, press <kbd>s</kbd> in the terminal to reopen the Studio in your browser.
+
+The shortcut uses the configured [`--browser`](#--browser) and [`--browser-args`](#--browser-args) values.
+If `BROWSER=none` is set, no browser will be opened.
+
 ## Flags
 
 ### `--props`

--- a/packages/docs/docs/cli/studio.mdx
+++ b/packages/docs/docs/cli/studio.mdx
@@ -19,9 +19,6 @@ You may pass an [entry point](/docs/terminology/entry-point) as an argument, oth
 
 While `npx remotion studio` is running, press <kbd>s</kbd> in the terminal to reopen the Studio in your browser.
 
-The shortcut uses the configured [`--browser`](#--browser) and [`--browser-args`](#--browser-args) values.
-If `BROWSER=none` is set, no browser will be opened.
-
 ## Flags
 
 ### `--props`

--- a/packages/studio-server/src/open-browser-shortcut.ts
+++ b/packages/studio-server/src/open-browser-shortcut.ts
@@ -61,11 +61,6 @@ export const registerOpenBrowserShortcut = ({
 
 		isOpeningBrowser = true;
 		onBeforeOpenBrowser();
-		RenderInternals.Log.info(
-			{indent: false, logLevel},
-			`Opening ${url} in browser...`,
-		);
-
 		maybeOpenBrowser({
 			browserArgs,
 			browserFlag,
@@ -73,6 +68,14 @@ export const registerOpenBrowserShortcut = ({
 			url,
 			logLevel,
 		})
+			.then((result) => {
+				if (result.didOpenBrowser) {
+					RenderInternals.Log.info(
+						{indent: false, logLevel},
+						`Opened ${url} in browser`,
+					);
+				}
+			})
 			.catch((err) => {
 				RenderInternals.Log.error(
 					{indent: false, logLevel},

--- a/packages/studio-server/src/open-browser-shortcut.ts
+++ b/packages/studio-server/src/open-browser-shortcut.ts
@@ -2,6 +2,7 @@ import * as readline from 'node:readline';
 import type {LogLevel} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import {maybeOpenBrowser} from './maybe-open-browser';
+import {clearPrintPortMessageTimeout} from './preview-server/live-events';
 
 type Key = {
 	name?: string;
@@ -14,13 +15,11 @@ export const registerOpenBrowserShortcut = ({
 	browserFlag,
 	url,
 	logLevel,
-	onBeforeOpenBrowser,
 }: {
 	browserArgs: string;
 	browserFlag: string;
 	url: string;
 	logLevel: LogLevel;
-	onBeforeOpenBrowser: () => void;
 }): {registered: boolean; cleanup: () => void} => {
 	if (!process.stdin.isTTY) {
 		return {registered: false, cleanup: () => undefined};
@@ -60,7 +59,7 @@ export const registerOpenBrowserShortcut = ({
 		}
 
 		isOpeningBrowser = true;
-		onBeforeOpenBrowser();
+		clearPrintPortMessageTimeout();
 		maybeOpenBrowser({
 			browserArgs,
 			browserFlag,

--- a/packages/studio-server/src/open-browser-shortcut.ts
+++ b/packages/studio-server/src/open-browser-shortcut.ts
@@ -1,0 +1,107 @@
+import * as readline from 'node:readline';
+import type {LogLevel} from '@remotion/renderer';
+import {RenderInternals} from '@remotion/renderer';
+import {maybeOpenBrowser} from './maybe-open-browser';
+
+type Key = {
+	name?: string;
+	ctrl?: boolean;
+	meta?: boolean;
+};
+
+export const registerOpenBrowserShortcut = ({
+	browserArgs,
+	browserFlag,
+	url,
+	logLevel,
+}: {
+	browserArgs: string;
+	browserFlag: string;
+	url: string;
+	logLevel: LogLevel;
+}): {registered: boolean; cleanup: () => void} => {
+	if (!process.stdin.isTTY) {
+		return {registered: false, cleanup: () => undefined};
+	}
+
+	if (typeof process.stdin.setRawMode !== 'function') {
+		return {registered: false, cleanup: () => undefined};
+	}
+
+	const wasRaw = process.stdin.isRaw;
+	const shouldPauseAfterCleanup = process.stdin.isPaused();
+	let cleanedUp = false;
+	let isOpeningBrowser = false;
+
+	const cleanup = () => {
+		if (cleanedUp) {
+			return;
+		}
+
+		cleanedUp = true;
+		process.stdin.removeListener('keypress', onKeypress);
+		process.removeListener('SIGINT', cleanup);
+		process.removeListener('exit', cleanup);
+
+		if (!wasRaw && process.stdin.isTTY) {
+			process.stdin.setRawMode(false);
+		}
+
+		if (shouldPauseAfterCleanup) {
+			process.stdin.pause();
+		}
+	};
+
+	const openStudio = () => {
+		if (isOpeningBrowser) {
+			return;
+		}
+
+		isOpeningBrowser = true;
+		RenderInternals.Log.info(
+			{indent: false, logLevel},
+			`Opening ${url} in browser...`,
+		);
+
+		maybeOpenBrowser({
+			browserArgs,
+			browserFlag,
+			shouldOpenBrowser: true,
+			url,
+			logLevel,
+		})
+			.catch((err) => {
+				RenderInternals.Log.error(
+					{indent: false, logLevel},
+					'Could not open browser:',
+					err,
+				);
+			})
+			.finally(() => {
+				isOpeningBrowser = false;
+			});
+	};
+
+	function onKeypress(_str: string, key: Key | undefined) {
+		if (key?.ctrl && key.name === 'c') {
+			cleanup();
+			process.kill(process.pid, 'SIGINT');
+			return;
+		}
+
+		if (key?.meta || key?.ctrl || key?.name !== 's') {
+			return;
+		}
+
+		openStudio();
+	}
+
+	readline.emitKeypressEvents(process.stdin);
+	process.stdin.setRawMode(true);
+	process.stdin.resume();
+	process.stdin.on('keypress', onKeypress);
+	process.once('SIGINT', cleanup);
+	process.once('exit', cleanup);
+
+	return {registered: true, cleanup};
+};

--- a/packages/studio-server/src/open-browser-shortcut.ts
+++ b/packages/studio-server/src/open-browser-shortcut.ts
@@ -14,11 +14,13 @@ export const registerOpenBrowserShortcut = ({
 	browserFlag,
 	url,
 	logLevel,
+	onBeforeOpenBrowser,
 }: {
 	browserArgs: string;
 	browserFlag: string;
 	url: string;
 	logLevel: LogLevel;
+	onBeforeOpenBrowser: () => void;
 }): {registered: boolean; cleanup: () => void} => {
 	if (!process.stdin.isTTY) {
 		return {registered: false, cleanup: () => undefined};
@@ -58,6 +60,7 @@ export const registerOpenBrowserShortcut = ({
 		}
 
 		isOpeningBrowser = true;
+		onBeforeOpenBrowser();
 		RenderInternals.Log.info(
 			{indent: false, logLevel},
 			`Opening ${url} in browser...`,

--- a/packages/studio-server/src/preview-server/live-events.ts
+++ b/packages/studio-server/src/preview-server/live-events.ts
@@ -29,6 +29,13 @@ const serializeMessage = (message: EventSourceEvent) => {
 
 let printPortMessageTimeout: Timer | null = null;
 
+export const clearPrintPortMessageTimeout = () => {
+	if (printPortMessageTimeout) {
+		clearTimeout(printPortMessageTimeout);
+		printPortMessageTimeout = null;
+	}
+};
+
 export type InitialUndoRedoState = {
 	undoFile: string | null;
 	redoFile: string | null;
@@ -70,9 +77,7 @@ export const makeLiveEventsRouter = (
 		};
 		clients.push(newClient);
 		newClientListeners.forEach((cb) => cb());
-		if (printPortMessageTimeout) {
-			clearTimeout(printPortMessageTimeout);
-		}
+		clearPrintPortMessageTimeout();
 
 		request.on('close', () => {
 			unsubscribeClientDefaultPropsWatchers(clientId);
@@ -82,9 +87,7 @@ export const makeLiveEventsRouter = (
 
 			// If all clients disconnected, print a comment so user can easily restart it.
 			if (clients.length === 0) {
-				if (printPortMessageTimeout) {
-					clearTimeout(printPortMessageTimeout);
-				}
+				clearPrintPortMessageTimeout();
 
 				printPortMessageTimeout = setTimeout(() => {
 					printServerReadyComment('To restart', logLevel);

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -17,6 +17,7 @@ import type {QueueMethods} from './preview-server/api-types';
 import {noOpUntilRestart} from './preview-server/close-and-restart';
 import {getAbsolutePublicDir} from './preview-server/get-absolute-public-dir';
 import {
+	clearPrintPortMessageTimeout,
 	setLiveEventsListener,
 	waitForLiveEventsListener,
 } from './preview-server/live-events';
@@ -217,6 +218,7 @@ export const startStudio = async ({
 		browserFlag,
 		url: studioUrl,
 		logLevel,
+		onBeforeOpenBrowser: clearPrintPortMessageTimeout,
 	});
 	if (openBrowserShortcut.registered) {
 		RenderInternals.Log.info(

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -12,6 +12,7 @@ import type {
 import {getFileWatcherRegistry} from './file-watcher';
 import {getNetworkAddress} from './get-network-address';
 import {maybeOpenBrowser} from './maybe-open-browser';
+import {registerOpenBrowserShortcut} from './open-browser-shortcut';
 import type {QueueMethods} from './preview-server/api-types';
 import {noOpUntilRestart} from './preview-server/close-and-restart';
 import {getAbsolutePublicDir} from './preview-server/get-absolute-public-dir';
@@ -210,16 +211,34 @@ export const startStudio = async ({
 
 	printServerReadyComment('Server ready', logLevel);
 	RenderInternals.Log.info({indent: false, logLevel}, 'Building...');
-
-	await maybeOpenBrowser({
+	const studioUrl = `http://localhost:${port}`;
+	const openBrowserShortcut = registerOpenBrowserShortcut({
 		browserArgs,
 		browserFlag,
-		shouldOpenBrowser,
-		url: `http://localhost:${port}`,
+		url: studioUrl,
 		logLevel,
 	});
+	if (openBrowserShortcut.registered) {
+		RenderInternals.Log.info(
+			{indent: false, logLevel},
+			'Press "s" to open the Studio in your browser.',
+		);
+	}
 
-	await noOpUntilRestart();
+	try {
+		await maybeOpenBrowser({
+			browserArgs,
+			browserFlag,
+			shouldOpenBrowser,
+			url: studioUrl,
+			logLevel,
+		});
+
+		await noOpUntilRestart();
+	} finally {
+		openBrowserShortcut.cleanup();
+	}
+
 	RenderInternals.Log.info(
 		{indent: false, logLevel},
 		'Closing server to restart...',

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -17,7 +17,6 @@ import type {QueueMethods} from './preview-server/api-types';
 import {noOpUntilRestart} from './preview-server/close-and-restart';
 import {getAbsolutePublicDir} from './preview-server/get-absolute-public-dir';
 import {
-	clearPrintPortMessageTimeout,
 	setLiveEventsListener,
 	waitForLiveEventsListener,
 } from './preview-server/live-events';
@@ -218,7 +217,6 @@ export const startStudio = async ({
 		browserFlag,
 		url: studioUrl,
 		logLevel,
-		onBeforeOpenBrowser: clearPrintPortMessageTimeout,
 	});
 
 	try {

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -220,12 +220,6 @@ export const startStudio = async ({
 		logLevel,
 		onBeforeOpenBrowser: clearPrintPortMessageTimeout,
 	});
-	if (openBrowserShortcut.registered) {
-		RenderInternals.Log.info(
-			{indent: false, logLevel},
-			'Press "s" to open the Studio in your browser.',
-		);
-	}
 
 	try {
 		await maybeOpenBrowser({


### PR DESCRIPTION
## Summary

- Add a terminal `s` shortcut while the Studio server is running to reopen the Studio URL in the browser.
- Reuse the existing browser-opening flow and clean up terminal raw mode on restart or exit.
- Document the shortcut on the `npx remotion studio` CLI page.

Closes #8903

## Testing

- `bunx oxfmt src --write` in `packages/studio-server`
- `bunx oxfmt src --write` in `packages/docs`
- `bun run build`
- `bun run stylecheck`
