### PR TITLE
Docs: Reframe media reference pages

### DIFF
--- a/packages/docs/docs/html5-audio.mdx
+++ b/packages/docs/docs/html5-audio.mdx
@@ -7,7 +7,9 @@ crumb: 'API - remotion'
 
 [_previously called `<Audio>`_](/docs/mediabunny/new-video)
 
-Using this component, you can add audio to your video. All audio formats which are supported by Chrome are supported by the component.
+This is the HTML5 audio component from the [`remotion`](/docs/remotion) package. For new audio usage, prefer [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media).
+
+Use this component when you specifically need direct HTML5 audio behavior or fallback props for [`<Audio>`](/docs/media/audio). All audio formats supported by Chrome are supported by the component.
 
 :::warning Not supported in client-side rendering
 `<Html5Audio>` is not supported in [`@remotion/web-renderer`](/docs/client-side-rendering). Use [`<Audio>`](/docs/media/audio) from `@remotion/media` instead.
@@ -252,8 +254,8 @@ To prevent synthetic amplification, set a volume not higher than 1.
 - [Source code for this component](https://github.com/remotion-dev/remotion/blob/main/packages/core/src/audio/html5-audio.tsx)
 - [Using audio](/docs/using-audio)
 - [Audio visualization](/docs/audio/visualization)
-- [`<Html5Video />`](/docs/html5-video)
 - [`<Audio />` (from `@remotion/media`)](/docs/media/audio)
+- [`<Html5Video />`](/docs/html5-video)
 
 <Credits
   contributors={[

--- a/packages/docs/docs/html5-video.mdx
+++ b/packages/docs/docs/html5-video.mdx
@@ -10,7 +10,7 @@ crumb: 'API - remotion'
 Wraps the native [`<video>`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement) element to include video in your component that is synchronized with Remotion's time.
 
 :::note
-Prefer [one of the other video tags](/docs/video-tags) which perform better.
+For new video usage, prefer [`<Video>`](/docs/media/video) from [`@remotion/media`](/docs/media). Use `<Html5Video>` when you specifically need native HTML5 `<video>` behavior.
 :::
 
 :::warning Not supported in client-side rendering
@@ -327,10 +327,11 @@ Remotion will download the whole video during render in order to mix its audio. 
 
 See: [Which video formats does Remotion support?](/docs/miscellaneous/video-formats)
 
-## Alternatives: `<OffthreadVideo>` and `@remotion/media`
+## Alternatives: `@remotion/media` and `<OffthreadVideo>`
 
-[`<OffthreadVideo>`](/docs/offthreadvideo) is a Rust-based alternative to `<Html5Video>`.  
-[`@remotion/media`](/docs/media/video) is an experimental component that will replace `<Html5Video>` at some point.
+[`<Video>` from `@remotion/media`](/docs/media/video) is the recommended video component for new code.
+
+[`<OffthreadVideo>`](/docs/offthreadvideo) is an alternative for direct server-side frame extraction and can also be used as a fallback target by `@remotion/media`.
 
 To decide which tag to use, see: [Comparison of video tags](/docs/video-tags)
 
@@ -341,8 +342,8 @@ To decide which tag to use, see: [Comparison of video tags](/docs/video-tags)
 ## See also
 
 - [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/core/src/video/html5-video.tsx)
+- [`<Video />` (from `@remotion/media`)](/docs/media/video)
 - [`<Html5Audio />`](/docs/html5-audio)
 - [`<OffthreadVideo />`](/docs/offthreadvideo)
-- [`<Video />` (from `@remotion/media`)](/docs/media/video)
 - [Comparison of video tags](/docs/video-tags)
 - [`Change the speed of a video over time`](/docs/miscellaneous/snippets/accelerated-video)

--- a/packages/docs/docs/media/fallback.mdx
+++ b/packages/docs/docs/media/fallback.mdx
@@ -1,12 +1,15 @@
 ---
 image: /generated/articles-docs-media-fallback.png
-title: 'Fallback from @remotion/media to <OffthreadVideo> or <Html5Audio>'
-sidebar_label: 'Fallback to <OffthreadVideo>'
+title: 'Fallback behavior in @remotion/media'
+sidebar_label: 'Fallback behavior'
 crumb: '@remotion/media'
 ---
 
-Sometimes, a media file cannot be embedded using [`@remotion/media`](/docs/media)'s [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) tags.  
-In such cases, a fallback to [`<OffthreadVideo>`](/docs/offthreadvideo) or [`<Html5Audio>`](/docs/html5-audio) from the `remotion` package is attempted.
+Use [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media) as the primary tags for media.
+
+If a media file cannot be embedded using these tags, Remotion may automatically fall back to [`<OffthreadVideo>`](/docs/offthreadvideo) for video or [`<Html5Audio>`](/docs/html5-audio) for audio from the [`remotion`](/docs/remotion) package.
+
+You usually do not need to choose these fallback tags manually. Configure them only when you need to prevent or customize fallback behavior.
 
 ## When a fallback is attempted
 

--- a/packages/docs/docs/media/index.mdx
+++ b/packages/docs/docs/media/index.mdx
@@ -10,7 +10,7 @@ import {TableOfContents} from './table-of-contents';
 
 This package provides the recommended [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) tags for embedding video and audio in Remotion.
 
-Use these tags for new projects instead of the legacy media tags from the [`remotion`](/docs/remotion) package.
+Use these tags for new projects. The media tags from the [`remotion`](/docs/remotion) package remain available for direct use and fallback-specific behavior.
 
 ## Components
 

--- a/packages/docs/docs/media/support.mdx
+++ b/packages/docs/docs/media/support.mdx
@@ -5,7 +5,7 @@ sidebar_label: Supported media
 crumb: '@remotion/media'
 ---
 
-The new [`<Audio>`](/docs/media/audio) and [`<Video>`](/docs/media/video) tags from `@remotion/media` are based on [Mediabunny](https://mediabunny.dev) and WebCodecs.
+The [`<Audio>`](/docs/media/audio) and [`<Video>`](/docs/media/video) tags from `@remotion/media` are based on [Mediabunny](https://mediabunny.dev) and WebCodecs.
 
 ## CORS
 
@@ -23,8 +23,10 @@ For example: If you want to render the third minute of a 10 minute audio, the fi
 
 Prefer non-Matroska-based files (`.mp4`, `.mov`, `.m4a`) when you are doing distributed rendering (e.g. on Lambda) if possible.
 
-## Fallback to `<OffthreadVideo>`
+## Automatic fallback
 
-If a media file cannot be decoded, be it because of an unsupported codec or because it does not support CORS, or it has an alpha channel and the browser does not support WebGL which is required to decode the alpha channel, then `@remotion/media` automatically falls back to [`<OffthreadVideo>`](/docs/offthreadvideo) or [`<Html5Audio>`](/docs/html5-audio) from the [`remotion`](/docs/remotion) package.
+If a media file cannot be decoded because of an unsupported codec, missing CORS support, or an alpha channel without browser WebGL support, then `@remotion/media` may automatically use fallback tags from the [`remotion`](/docs/remotion) package: [`<OffthreadVideo>`](/docs/offthreadvideo) for video and [`<Html5Audio>`](/docs/html5-audio) for audio.
 
-See: [Fallback from `@remotion/media` to `<OffthreadVideo>` or `<Html5Audio>`](/docs/media/fallback)
+This is automatic fallback behavior, not the default API choice for new code.
+
+See: [Fallback behavior in `@remotion/media`](/docs/media/fallback)

--- a/packages/docs/docs/mediabunny/new-video.mdx
+++ b/packages/docs/docs/mediabunny/new-video.mdx
@@ -1,40 +1,43 @@
 ---
 image: /generated/articles-docs-mediabunny-new-video.png
-title: New <Video> and <Audio> tags
+title: Recommended <Video> and <Audio> tags
 crumb: 'Mediabunny'
-sidebar_label: New <Video> and <Audio> tags
+sidebar_label: Recommended <Video> and <Audio> tags
 ---
 
-We are making new [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) tags for Remotion.  
-Our goal is to create a new default for embedding videos and audio into your Remotion that is best-in-class:
+[`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media) are the recommended tags for embedding video and audio in Remotion.
 
-- absolute frame-accuracy
-- fastest
+They are based on [Mediabunny](/docs/mediabunny) and WebCodecs and are designed for:
+
+- frame-accurate video rendering
+- fast media extraction
 - minimal data fetching
 
-## Renaming old `<Video>` and `<Audio>` tags
+## Renamed tags from `remotion`
 
-We want the tags that are called `<Video>` and `<Audio>` to be the best choice for users, because users will reach for those first.
-
-Therefore, we are renaming the old tags:
+The tags that were previously called `<Video>` and `<Audio>` in the [`remotion`](/docs/remotion) package have been renamed:
 
 - `<Video>` from `remotion` → [`<Html5Video>`](/docs/html5-video)
 - `<Audio>` from `remotion` → [`<Html5Audio>`](/docs/html5-audio)
 
-This reflects the fact that the new tags are based on the HTML5 `<video>` and `<audio>` tags.
+This makes the HTML5-based tags explicit and leaves `<Video>` and `<Audio>` for the recommended `@remotion/media` tags.
 
 ## Which tag am I using?
 
-The old tags are imported from the [`remotion`](/docs/remotion) package, the new tags are imported from the [`@remotion/media`](/docs/media) package.
+The HTML5-based tags are imported from the [`remotion`](/docs/remotion) package.
+
+The recommended tags are imported from the [`@remotion/media`](/docs/media) package.
 
 ## Why are we renaming the tags?
 
-Users and AIs are intuitively going to reach for `<Video>` and `<Audio>` first, because they are the easiest to find.  
-Because of this, we want to make sure the best default is the one that is easiest to find.
+Users and AIs are intuitively going to reach for `<Video>` and `<Audio>` first because they are the easiest to find.
+
+The best default should therefore be the one that is easiest to find.
 
 ## Should I migrate to `@remotion/media`?
 
-Currently, our recommendation is still to use [`<OffthreadVideo>`](/docs/offthreadvideo) for videos and [`<Html5Audio>`](/docs/html5-audio) for audio.  
-`@remotion/media` is still experimental, but once it is stable, we will recommend it as the default.
+Use [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media) for new code.
+
+[`<OffthreadVideo>`](/docs/offthreadvideo), [`<Html5Video>`](/docs/html5-video), and [`<Html5Audio>`](/docs/html5-audio) remain documented for direct use, migration, and fallback-specific behavior.
 
 See: [Comparison of video tags](/docs/video-tags)

--- a/packages/docs/docs/mediabunny/new-video.mdx
+++ b/packages/docs/docs/mediabunny/new-video.mdx
@@ -1,8 +1,8 @@
 ---
 image: /generated/articles-docs-mediabunny-new-video.png
-title: Recommended <Video> and <Audio> tags
+title: <Video> and <Audio> tags
 crumb: 'Mediabunny'
-sidebar_label: Recommended <Video> and <Audio> tags
+sidebar_label: <Video> and <Audio> tags
 ---
 
 [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media) are the recommended tags for embedding video and audio in Remotion.

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -9,7 +9,9 @@ crumb: 'API'
 
 This component imports and displays a video, similar to [`<Html5Video/>`](/docs/html5-video), but during rendering, extracts the exact frame from the video and displays it in a [`<Img>`](/docs/img) tag. This extraction process happens outside the browser using FFmpeg.
 
-This component was designed to combat limitations of the default `<Html5Video>` element. See: [Comparison of video tags](/docs/video-tags).
+This component was designed to combat limitations of the `<Html5Video>` element. See: [Comparison of video tags](/docs/video-tags).
+
+For new video usage, prefer [`<Video>`](/docs/media/video) from [`@remotion/media`](/docs/media). Use this page when you need to configure `<OffthreadVideo>` directly or understand the fallback behavior used by `<Video>`.
 
 :::warning Not supported in client-side rendering
 `<OffthreadVideo>` is not supported in [`@remotion/web-renderer`](/docs/client-side-rendering). Use [`<Video>`](/docs/media/video) from `@remotion/media` instead.

--- a/packages/docs/src/data/articles.ts
+++ b/packages/docs/src/data/articles.ts
@@ -4348,7 +4348,7 @@ export const articles = [
 	},
 	{
 		id: 'mediabunny/new-video',
-		title: 'Recommended <Video> and <Audio> tags',
+		title: '<Video> and <Audio> tags',
 		relativePath: 'docs/mediabunny/new-video.mdx',
 		compId: 'articles-docs-mediabunny-new-video',
 		crumb: 'Mediabunny',

--- a/packages/docs/src/data/articles.ts
+++ b/packages/docs/src/data/articles.ts
@@ -4258,7 +4258,7 @@ export const articles = [
 	},
 	{
 		id: 'media/fallback',
-		title: 'Fallback from @remotion/media to <OffthreadVideo> or <Html5Audio>',
+		title: 'Fallback behavior in @remotion/media',
 		relativePath: 'docs/media/fallback.mdx',
 		compId: 'articles-docs-media-fallback',
 		crumb: '@remotion/media',
@@ -4348,7 +4348,7 @@ export const articles = [
 	},
 	{
 		id: 'mediabunny/new-video',
-		title: 'New <Video> and <Audio> tags',
+		title: 'Recommended <Video> and <Audio> tags',
 		relativePath: 'docs/mediabunny/new-video.mdx',
 		compId: 'articles-docs-mediabunny-new-video',
 		crumb: 'Mediabunny',
@@ -7947,7 +7947,7 @@ export const articles = [
 		title: 'Comparison of video tags',
 		relativePath: 'docs/video-tags.mdx',
 		compId: 'articles-docs-video-tags',
-		crumb: '<Video>, <Html5Video>, <OffthreadVideo>',
+		crumb: '<Video>, <OffthreadVideo>, <Html5Video>',
 		noAi: false,
 		slug: 'video-tags',
 	},


### PR DESCRIPTION
## Summary

- Recommend `@remotion/media` from the Mediabunny media tag page
- Reframe fallback/support docs so fallback tags are automatic/reference behavior, not the primary destination
- Reframe `<OffthreadVideo>`, `<Html5Audio>`, and `<Html5Video>` reference pages toward `<Video>` / `<Audio>` for new code
- Update generated article metadata for renamed docs pages

## Testing

- `cd packages/docs && bunx oxfmt src --write`
- `cd packages/docs && bun render-cards.ts`
- `bun run build`
- `bun run stylecheck`

Part of #8882
