### PR TITLE
Docs: Add documentation writing guidelines

### DIFF
--- a/.agents/skills/writing-docs/SKILL.md
+++ b/.agents/skills/writing-docs/SKILL.md
@@ -32,7 +32,7 @@ crumb: '@remotion/my-package'
 
 **Use headings for all fields**: When documenting API options or return values, each property should be its own heading. Use `###` for top-level properties and `####` for nested properties within an options object. Do not use bullet points for individual fields.
 
-**Version indicators**: If an API, feature, parameter, or behavior was added in a specific version, add `<AvailableFrom>` at the page, section, or field where the reader first needs to know it.
+**Version indicators**: If an API, feature, parameter, or behavior was added in a specific version, add `<AvailableFrom>` at the page, section, or field where the reader first needs to know it. For example: `# prefetch()<AvailableFrom v="4.0.0" />`.
 
 **Compatibility tables**: API pages should ideally include a `## Compatibility` section with `<CompatibilityTable>` before `## See also`.
 

--- a/.agents/skills/writing-docs/SKILL.md
+++ b/.agents/skills/writing-docs/SKILL.md
@@ -28,7 +28,13 @@ crumb: '@remotion/my-package'
 
 **Public API only**: Documentation is for public APIs only. Do not mention, reference, or compare against internal/private APIs or implementation details.
 
+**API names in prose**: Put API names in backticks, and link them if a docs page exists. Function and hook names should include `()`, for example [`useVideoConfig()`](/docs/use-video-config), not `useVideoConfig` or useVideoConfig. Components should include angle brackets, for example [`<Player>`](/docs/player/player) or [`<Audio>`](/docs/media/audio).
+
 **Use headings for all fields**: When documenting API options or return values, each property should be its own heading. Use `###` for top-level properties and `####` for nested properties within an options object. Do not use bullet points for individual fields.
+
+**Version indicators**: If an API, feature, parameter, or behavior was added in a specific version, add `<AvailableFrom>` at the page, section, or field where the reader first needs to know it.
+
+**Compatibility tables**: API pages should ideally include a `## Compatibility` section with `<CompatibilityTable>` before `## See also`.
 
 ## Language guidelines
 
@@ -86,6 +92,8 @@ console.log('Hello');
 ## Special components
 
 ### Steps
+
+Formatting around `<Step>` is delicate. Keep one step per line, add a space after `</Step>`, and preserve an explicit line break (`<br/>` or `<br />`) when the steps are written as a compact inline list. Do not write `<Step>1</Step>Add...` without a space.
 
 ```md
 - <Step>1</Step> First step
@@ -195,3 +203,13 @@ After adding or editing a page, generate social media preview cards:
 ```bash
 cd packages/docs && bun render-cards.ts
 ```
+
+## Streamlining existing docs
+
+When asked to audit or streamline docs, scan for:
+
+- Missing `<AvailableFrom>` indicators for APIs, features, options, parameters, or behaviors introduced in a specific version
+- API names that are not formatted as code spans or linked to their docs page
+- Function and hook references missing `()`
+- API pages that should have a `## Compatibility` section with `<CompatibilityTable>`
+- Fragile or broken `<Step>` formatting

--- a/packages/docs/docs/contributing/docs.mdx
+++ b/packages/docs/docs/contributing/docs.mdx
@@ -16,11 +16,13 @@ At the bottom of each page, the `Improve this page` button is the easiest way to
 
 ## Submitting a new page
 
-<Step>1</Step> Set up the Remotion repository <a href="/docs/contributing">according the instructions here</a>. <br/>
-<Step>2</Step> Create a new <code>.mdx</code> document in the <code>packages/docs/docs</code> folder. <br/>
-<Step>3</Step> Add the document to <code>packages/docs/sidebars.ts</code>.<br/>
-<Step>4</Step> Write what you have to say!<br/>
-<Step>5</Step> Run <code>bun render-cards.ts</code> in <code>packages/docs</code> to generate preview cards that will show up if the documentation page is shared on social media.<br/>
+<Step>1</Step> Set up the Remotion repository <a href="/docs/contributing">according the instructions here</a>. <br />
+<Step>2</Step> Create a new <code>.mdx</code> document in the <code>packages/docs/docs</code> folder. <br />
+<Step>3</Step> Add the document to <code>packages/docs/sidebars.ts</code>.<br />
+<Step>4</Step> Write what you have to say!
+<br />
+<Step>5</Step> Run <code>bun render-cards.ts</code> in <code>packages/docs</code> to generate preview cards that will show up if the documentation page is shared on social media.
+<br />
 
 ## Language guidelines
 
@@ -32,22 +34,32 @@ At the bottom of each page, the `Improve this page` button is the easiest way to
 - **Don't blame the user**: Instead of "You have provided the wrong input", say "The input is invalid" or "the wrong input was provided".
 - **Don't assume it is easy**: Avoid using the words "simply" and "just" as beginners might not find it as simple as you do.
 
+## API documentation
+
+- **Format API names as code**: Write [`useVideoConfig()`](/docs/use-video-config), not useVideoConfig().
+- **Include parentheses for functions**: Write [`useVideoConfig()`](/docs/use-video-config), not `useVideoConfig`.
+- **Link API names** if a docs page exists for them.
+- **Mention the version** if an API, feature, option, parameter or behavior was added in a specific Remotion version.
+- **Add a compatibility table** to API reference pages when browser, runtime or rendering-mode support matters.
+
 ## Adding code snippets
 
 You can add codesnippets by beginning a paragraph with three backticks: <code>```</code>. The code will be highlighted according to the language you specify after the backticks.
 
 <p>
-<code>```ts</code> will highlight the code as TypeScript.
+  <code>```ts</code> will highlight the code as TypeScript.
 </p>
 
 ### Type safe snippets
 
 <p>
-<code>```ts twoslash</code> will make a snippet type-safe - it will be checked against the TypeScript compiler. This is the preferred way of writing docs, but if it is too hard, you don't have to do it.
+  <code>```ts twoslash</code> will make a snippet type-safe - it will be checked against the TypeScript compiler. This is the preferred way of writing docs, but if it is too hard, you don't have to do it.
 </p>
 
 <p>
-When writing typesafe snippets, sometimes it does not make sense to list all import statements at the top.<br />You can add a line stating <code>// ---cut---</code> and only the content below will be displayed.
+  When writing typesafe snippets, sometimes it does not make sense to list all import statements at the top.
+  <br />
+  You can add a line stating <code>// ---cut---</code> and only the content below will be displayed.
 </p>
 
 ### Titles
@@ -55,7 +67,7 @@ When writing typesafe snippets, sometimes it does not make sense to list all imp
 Add a title to a code snippet by adding a line with <code>```ts twoslash title="file.ts"</code>:<br/>
 
 ```ts twoslash title="file.ts"
-console.log("Hello World");
+console.log('Hello World');
 ```
 
 ## Special formatting
@@ -72,6 +84,32 @@ Use `<Step>` to create lists:
 - <Step>1</Step> Step 1
 - <Step>2</Step> Step 2
 
+The formatting around `<Step>` is delicate. Keep one step per line, add a space after `</Step>`, and preserve an explicit line break (`<br/>` or `<br />`) when the steps are written as a compact inline list.
+
+### AvailableFrom
+
+Use `<AvailableFrom>` if an API, feature, option, parameter or behavior was added in a specific Remotion version:
+
+```md
+# prefetch()<AvailableFrom v="4.0.0" />
+```
+
+For section headings:
+
+```md
+## Saving to another cloud<AvailableFrom v="3.2.23" />
+```
+
+### CompatibilityTable
+
+API reference pages should ideally have a compatibility table before `## See also`:
+
+```md
+## Compatibility
+
+<CompatibilityTable chrome firefox safari nodejs bun serverlessFunctions clientSideRendering={false} serverSideRendering player studio />
+```
+
 ### Mark as experimental
 
 Use `<ExperimentalBadge />` to mark something as experimental:
@@ -83,7 +121,7 @@ Use `<ExperimentalBadge />` to mark something as experimental:
 ```
 
 <ExperimentalBadge>
-<p>This feature is still experimental.</p>
+  <p>This feature is still experimental.</p>
 </ExperimentalBadge>
 
 ### Demos
@@ -94,7 +132,7 @@ Using `<Demo type="[demo-name]" />` you can render a [Remotion Player](/docs/ter
 <Demo type="rect"/>
 ```
 
-<Demo type="rect"/>
+<Demo type="rect" />
 
 The demo needs to be implemented in `packages/docs/components/demos/index.tsx`.
 


### PR DESCRIPTION
## Summary

- Add the documentation-streamlining rules from issue #8895 to the internal `writing-docs` skill
- Add contributor-facing guidance for API formatting, version indicators, compatibility tables, and step formatting

Closes #8895

## Tests

- `cd packages/docs && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
