### PR TITLE
Docs: Move Convert link to Products navbar

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -84,6 +84,7 @@ const config: Config = {
 						{to: '/docs/editor-starter', label: 'Editor Starter'},
 						{to: '/docs/timeline', label: 'Timeline'},
 						{to: '/docs/recorder', label: 'Recorder'},
+						{to: 'https://remotion.dev/convert', label: 'Convert'},
 					],
 				},
 				{
@@ -100,7 +101,6 @@ const config: Config = {
 						},
 						{to: 'blog', label: 'Blog'},
 						{to: 'showcase', label: 'Showcase'},
-						{to: 'https://remotion.dev/convert', label: 'Convert a video'},
 						{to: '/docs/support', label: 'Support'},
 					],
 				},


### PR DESCRIPTION
## Summary

- Move the Convert navbar link from Resources to Products
- Rename the navbar item from "Convert a video" to "Convert"

## Testing

- `bunx oxfmt packages/docs/docusaurus.config.ts --write`
- `cd packages/docs && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
