### PR TITLE
`docs`: Update Player media loading guidance

### DIFF
--- a/packages/docs/docs/player/autoplay.mdx
+++ b/packages/docs/docs/player/autoplay.mdx
@@ -15,7 +15,7 @@ If your composition plays well there, you should have no problems elsewhere.
 
 ## Trigger the play from a user event
 
-If you autoplay audio (through an `<Audio>`, `<Html5Audio>`, `<Video>`, `<OffthreadVideo>`, or `<Html5Video>` tag) on site load, browsers will block the audio.
+If you autoplay audio (through a `<Video>`, `<Audio>`, `<Html5Audio>`, `<Html5Video>`, or `<OffthreadVideo>` tag) on site load, browsers will block the audio.
 
 The [`autoPlay`](/docs/player/player#autoplay) prop of the [`<Player>`](/docs/player/player) is therefore discouraged if your video contains any audio.
 
@@ -64,18 +64,19 @@ Media that contains audio and that plays without user interaction requires speci
 Consider the following scenario:
 
 ```tsx twoslash
-import {AbsoluteFill, Html5Audio, OffthreadVideo, Sequence, staticFile} from 'remotion';
+import {Audio, Video} from '@remotion/media';
+import {AbsoluteFill, Sequence, staticFile} from 'remotion';
 
 // ---cut---
 export const MyComp = () => {
   return (
     <AbsoluteFill>
-      <Html5Audio src={staticFile('audio.mp3')} />
+      <Audio src={staticFile('audio.mp3')} />
       <Sequence from={120}>
-        <Html5Audio src={staticFile('audio2.mp3')} />
+        <Audio src={staticFile('audio2.mp3')} />
       </Sequence>
       <Sequence from={120}>
-        <OffthreadVideo src={staticFile('video.mp4')} />
+        <Video src={staticFile('video.mp4')} />
       </Sequence>
     </AbsoluteFill>
   );
@@ -84,12 +85,12 @@ export const MyComp = () => {
 
 There are three different cases here:
 
-<Step>1</Step> An `<Html5Audio>` tag that plays immediately.  ✅ This is fine because we have user interaction.
+<Step>1</Step> An `<Audio>` tag that plays immediately.  ✅ This is fine because we have user interaction.
 <div style={{marginTop: -14}} />
-<Step>2</Step> An `<Html5Audio>` tag that plays after 120 frames. ⚠️ May be subject to browser autoplay policies, but there is a workaround
+<Step>2</Step> An `<Audio>` tag that plays after 120 frames. ⚠️ May be subject to browser autoplay policies. If you are using `<Html5Audio>`, there is a workaround:
 → [Using the `numberOfSharedAudioTags` prop](/docs/player/autoplay#using-the-numberofsharedaudiotags-prop)
 <div style={{marginTop: -14}} />
-<Step>3</Step> A `<OffthreadVideo>` tag that plays after 120 frames. ⛔ May be subject to browser autoplay policies, which might restrict the video from playing with audio → [Dealing with an autoplay failure](/docs/player/autoplay#dealing-with-an-autoplay-failure)
+<Step>3</Step> A `<Video>` tag that plays after 120 frames. ⛔ May be subject to browser autoplay policies, which might restrict the video from playing with audio → [Dealing with an autoplay failure](/docs/player/autoplay#dealing-with-an-autoplay-failure)
 
 ## Using the `numberOfSharedAudioTags` prop
 
@@ -104,20 +105,23 @@ If the browser blocks a video from being autoplayed due to it having sound and n
 
 **By default**: The video will be muted, and played without audio. A console message will be printed.
 
-**Custom behavior**: You may handle an autoplay failure using the [`onAutoPlayError`](/docs/offthreadvideo#onautoplayerror) prop of `<OffthreadVideo>` and `<Video>`:
+**Custom behavior**: You may handle an autoplay failure using the [`onAutoPlayError`](/docs/offthreadvideo#onautoplayerror) prop of `<OffthreadVideo>`. For [`<Video>` from `@remotion/media`](/docs/media/video), use [`fallbackOffthreadVideoProps.onAutoPlayError`](/docs/media/video#onautoplayerror):
 
 ```tsx twoslash
-import {OffthreadVideo, staticFile} from 'remotion';
+import {Video} from '@remotion/media';
+import {staticFile} from 'remotion';
 import type {PlayerRef} from '@remotion/player';
 
 export const MyComp: React.FC<{
   playerRef: React.RefObject<PlayerRef>;
 }> = ({playerRef}) => {
   return (
-    <OffthreadVideo
+    <Video
       src={staticFile('video.mp4')}
-      onAutoPlayError={() => {
-        playerRef.current?.pause();
+      fallbackOffthreadVideoProps={{
+        onAutoPlayError: () => {
+          playerRef.current?.pause();
+        },
       }}
     />
   );

--- a/packages/docs/docs/player/buffer-state.mdx
+++ b/packages/docs/docs/player/buffer-state.mdx
@@ -15,10 +15,11 @@ Remotion has a native buffer state, which can be used to pause the video when th
 
 ## TL;DR
 
-You can add a `pauseWhenBuffering` prop to your [`<Html5Video>`](/docs/html5-video/#pausewhenbuffering), [`<OffthreadVideo>`](/docs/offthreadvideo/#pausewhenbuffering), [`<Html5Audio>`](/docs/html5-audio/#pausewhenbuffering) tags.  
-The prop is called `pauseWhenLoading` for [`<Img>`](/docs/img/#pausewhenloading) tags.  
 For [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media), the buffer state is enabled by default.
-By doing so, the Player will briefly pause until your media is loaded.
+
+For [`<Html5Video>`](/docs/html5-video/#pausewhenbuffering), [`<OffthreadVideo>`](/docs/offthreadvideo/#pausewhenbuffering), and [`<Html5Audio>`](/docs/html5-audio/#pausewhenbuffering), add `pauseWhenBuffering`. For [`<Img>`](/docs/img/#pausewhenloading), add `pauseWhenLoading`.
+
+By using the buffer state, the Player will briefly pause until your media is loaded.
 
 ## Mechanism
 
@@ -216,8 +217,8 @@ export const App: React.FC = () => {
 
 You can enable buffering on the following components:
 
-- [`<Audio>`](/docs/media/audio) - enabled by default
 - [`<Video>`](/docs/media/video) - enabled by default
+- [`<Audio>`](/docs/media/audio) - enabled by default
 - [`<Html5Audio>`](/docs/html5-audio#pausewhenbuffering) - add the `pauseWhenBuffering` prop
 - [`<Html5Video>`](/docs/html5-video#pausewhenbuffering) - add the `pauseWhenBuffering` prop
 - [`<OffthreadVideo>`](/docs/offthreadvideo#pausewhenbuffering) - add the `pauseWhenBuffering` prop
@@ -320,7 +321,7 @@ const MyApp: React.FC = () => {
 
 ## Upcoming changes in Remotion 5.0
 
-In Remotion 4.0, the tags `<Html5Audio>`, `<Html5Video>`, `<OffthreadVideo>` will need to opt-in to use the buffer state.
+In Remotion 4.0, [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media) already use the buffer state by default. The tags `<Html5Audio>`, `<Html5Video>`, and `<OffthreadVideo>` need to opt in.
 
 In Remotion 5.0, it is planned that `<Html5Audio>`, `<Html5Video>` and `<OffthreadVideo>` will automatically use the buffer state, but they can opt out of it.
 

--- a/packages/docs/docs/player/buffer-state.mdx
+++ b/packages/docs/docs/player/buffer-state.mdx
@@ -321,9 +321,9 @@ const MyApp: React.FC = () => {
 
 ## Upcoming changes in Remotion 5.0
 
-In Remotion 4.0, [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media) already use the buffer state by default. The tags `<Html5Audio>`, `<Html5Video>`, and `<OffthreadVideo>` need to opt in.
+In Remotion 5.0, it is planned that `<Html5Audio>`, `<Html5Video>`, and `<OffthreadVideo>` will automatically use the buffer state, but they can opt out of it.
 
-In Remotion 5.0, it is planned that `<Html5Audio>`, `<Html5Video>` and `<OffthreadVideo>` will automatically use the buffer state, but they can opt out of it.
+This does not change the behavior of [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media), which already use the buffer state by default in Remotion 4.0.
 
 ## See also
 

--- a/packages/docs/docs/player/playback-issues.mdx
+++ b/packages/docs/docs/player/playback-issues.mdx
@@ -16,7 +16,7 @@ Read this page if you encounter issues with media playback in the Player such as
 ## Ensure best practices
 
 <div>
-<Step>1</Step> <span>Add <a href="/docs/player/buffer-state">`pauseWhenBuffering`</a> to `<Html5Audio>`, `<Html5Video>`, `<OffthreadVideo>` and `<Img>` components.</span>
+<Step>1</Step> <span>Use `<Video>` and `<Audio>` from <a href="/docs/media">`@remotion/media`</a> where possible; they use the <a href="/docs/player/buffer-state">buffer state</a> by default. For `<Html5Audio>`, `<Html5Video>`, and `<OffthreadVideo>`, add `pauseWhenBuffering`. For `<Img>`, add `pauseWhenLoading`.</span>
 </div>
 <div>
 <Step>2</Step> <span>For seamless transitions, use the <a href="/docs/player/premounting">`premountFor`</a> prop for `<Sequence>`'s.</span>

--- a/packages/docs/docs/player/preloading.mdx
+++ b/packages/docs/docs/player/preloading.mdx
@@ -37,7 +37,7 @@ Prefetch is not recommended for most cases. [See recommendations](/docs/troubles
 :::
 
 By prefetching, the full media is downloaded and turned into a Blob URL using [`URL.createObjectURL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL).  
-If you pass the original URL into either an [`<Video>`](/docs/media/video), [`<Audio>`](/docs/media/audio), [`<Html5Audio>`](/docs/html5-audio), [`<Html5Video>`](/docs/html5-video), [`<OffthreadVideo>`](/docs/offthreadvideo), or [`<Img>`](/docs/img) tag and the asset is prefetched, those components will use Blob URL instead.
+If you pass the original URL into a [`<Video>`](/docs/media/video), [`<Audio>`](/docs/media/audio), [`<Img>`](/docs/img), or a media tag from [`remotion`](/docs/remotion) such as [`<Html5Audio>`](/docs/html5-audio), [`<Html5Video>`](/docs/html5-video), or [`<OffthreadVideo>`](/docs/offthreadvideo), and the asset is prefetched, those components will use Blob URL instead.
 
 ```tsx twoslash
 import {prefetch} from 'remotion';
@@ -80,7 +80,7 @@ free();
   </tr>
   <tr>
     <td>Works with</td>
-    <td>HTML5 audio/video tags, images and fonts</td>
+    <td>HTML5 audio/video tags, images, and fonts</td>
     <td>
       <a href="/docs/media/video">
         <code>{'<Video/>'}</code>
@@ -89,10 +89,11 @@ free();
       <a href="/docs/media/audio">
         <code>{'<Audio/>'}</code>
       </a>
-      , legacy media tags and{' '}
+      ,{' '}
       <a href="/docs/img">
         <code>{'<Img/>'}</code>
       </a>
+      , and media tags from <code>remotion</code>
     </td>
   </tr>
   <tr>

--- a/packages/docs/docs/prefetch.mdx
+++ b/packages/docs/docs/prefetch.mdx
@@ -13,7 +13,7 @@ Prefetch is not recommended for most cases. [See recommendations](/docs/troubles
 
 By calling `prefetch()`, an asset will be fetched and kept in memory so it is ready when you want to play it in a [`<Player>`](/docs/player).
 
-If you pass the original URL into either a [`<Video>`](/docs/media/video), [`<Audio>`](/docs/media/audio), [`<Html5Audio>`](/docs/html5-audio), [`<Html5Video>`](/docs/html5-video), [`<OffthreadVideo>`](/docs/offthreadvideo) or [`<Img>`](/docs/img) tag and the asset is fully fetched, those components will use Blob URL instead.
+If you pass the original URL into a [`<Video>`](/docs/media/video), [`<Audio>`](/docs/media/audio), [`<Img>`](/docs/img), or a media tag from [`remotion`](/docs/remotion) such as [`<Html5Audio>`](/docs/html5-audio), [`<Html5Video>`](/docs/html5-video), or [`<OffthreadVideo>`](/docs/offthreadvideo), and the asset is fully fetched, those components will use Blob URL instead.
 
 :::note
 Remote assets need to support [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
@@ -122,9 +122,9 @@ The `string` that is being returned is either:
 - A `blob:` URL or `data:` Base 64 data respectively
 - The same `src` you passed as input, if in a rendering environment.
 
-You don't need to use this URL in [`<Video>`](/docs/media/video), [`<Audio>`](/docs/media/audio), [`<Html5Audio>`](/docs/html5-audio), [`<Html5Video>`](/docs/html5-video), [`<OffthreadVideo>`](/docs/offthreadvideo) or [`<Img>`](/docs/img), which will automatically use it.
+You don't need to use this URL in [`<Video>`](/docs/media/video), [`<Audio>`](/docs/media/audio), [`<Img>`](/docs/img), or a media tag from [`remotion`](/docs/remotion) such as [`<Html5Audio>`](/docs/html5-audio), [`<Html5Video>`](/docs/html5-video), or [`<OffthreadVideo>`](/docs/offthreadvideo), which will automatically use it.
 
-If you neeed the URL somewhere (like for [`mask-image`](/docs/troubleshooting/background-image)), you can grab it from `waitUntilDone()`.
+If you need the URL somewhere (like for [`mask-image`](/docs/troubleshooting/background-image)), you can grab it from `waitUntilDone()`.
 
 ## `blob-url` or `base64`?
 


### PR DESCRIPTION
## Summary
- Start Player buffer-state guidance with @remotion/media defaults
- Reorder prefetch, preloading, and autoplay media tag mentions so <Video>/<Audio> lead
- Update Player autoplay examples to use @remotion/media and document the fallback onAutoPlayError prop

## Testing
- cd packages/docs && bunx oxfmt src --write
- bun run build
- bun run stylecheck

Part of #8882
