### PR TITLE
Docs: Clarify media tag docs

### DIFF
--- a/packages/docs/docs/freeze.mdx
+++ b/packages/docs/docs/freeze.mdx
@@ -39,7 +39,7 @@ When using the `<Freeze/>` component, all of its children will freeze to the fra
 
 If a component is a child of `<Freeze/>`, calling the [`useCurrentFrame()`](/docs/use-current-frame) hook will always return the frame number you specify, irrespective of any [`<Sequence>`](/docs/sequence).
 
-[`<Html5Video />`](/docs/html5-video), [`<Video>`](/docs/media/video) and [`<OffthreadVideo />`](/docs/offthreadvideo) elements will be paused and [`<Html5Audio />`](/docs/html5-audio) and [`<Audio>`](/docs/media/audio) elements will render muted.
+[`<Video>`](/docs/media/video), [`<OffthreadVideo />`](/docs/offthreadvideo) and [`<Html5Video />`](/docs/html5-video) elements will be paused and [`<Audio>`](/docs/media/audio) and [`<Html5Audio />`](/docs/html5-audio) elements will render muted.
 
 ## Example
 

--- a/packages/docs/docs/media-fragments.mdx
+++ b/packages/docs/docs/media-fragments.mdx
@@ -5,7 +5,7 @@ title: '#t= Media Fragments'
 slug: media-fragments
 ---
 
-Remotion by default adds [Media fragment](https://www.w3.org/TR/media-frags/) hashes to video URLs.
+For [`<OffthreadVideo>`](/docs/offthreadvideo) and [`<Html5Video>`](/docs/html5-video), Remotion by default adds [Media fragment](https://www.w3.org/TR/media-frags/) hashes to video URLs.
 
 ## Behavior
 
@@ -66,13 +66,14 @@ There are valid scenarios where we recommend disabling the media fragment hints:
 
 - Changing the `from` and `durationInFrames` values of a `<Sequence>` dynamically
 - Changing the `trimBefore` and `trimAfter` values of a `<Html5Video>` or `<OffthreadVideo>` dynamically
-- Changing the `playbackRate` of a `<Html5Video>`, `<OffthreadVideo>` or `<Video>` over time.
+- Changing the `playbackRate` of a `<OffthreadVideo>` or `<Html5Video>` over time.
 
 Normally you would not do this, but there are exceptions, like: [Changing the speed of a video over time](/docs/miscellaneous/snippets/accelerated-video)
 
 ## Recommendation
 
-Use the automatic media fragment hints as a default because they are helpful with playback performance.  
+Use the automatic media fragment hints for `<OffthreadVideo>` and `<Html5Video>` as a default because they are helpful with playback performance.
+
 If you find a valid scenario where you need to disable the media fragment hints, you can do so.
 
 If the playback performance suffers, you can also provide your own media fragment hint to the URL.


### PR DESCRIPTION
## Summary

- Put `<Video>` and `<Audio>` first in the `<Freeze>` media tag list.
- Scope media fragment docs to `<OffthreadVideo>` and `<Html5Video>`.
- Remove `<Video>` from the media fragment caveat list.

Part of https://github.com/remotion-dev/remotion/issues/8882.

## Testing

- `bunx oxfmt src --write` from `packages/docs`
- `bun run build`
- `bun run stylecheck`
- `bun run build-docs` from `packages/docs`
