### PR TITLE
`remotion`: Fix buffering listener leak and only emit `waiting`/`resume` on transitions

### DIFF
--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -118,7 +118,11 @@ const useBufferManager = (
 			return;
 		}
 
-		if (blocks.length > 0) {
+		// Only fire on the `false -> true` transition: adding a block while
+		// already buffering (e.g. a second media element starts loading) must
+		// not re-dispatch `waiting` to listeners.
+		if (blocks.length > 0 && !buffering.current) {
+			buffering.current = true;
 			onBufferingCallbacks.forEach((c) => c());
 			playbackLogging({
 				logLevel,
@@ -142,7 +146,11 @@ const useBufferManager = (
 				return;
 			}
 
-			if (blocks.length === 0) {
+			// Only fire on the `true -> false` transition: the initial mount and
+			// a block that was added and removed within the same commit must not
+			// dispatch `resume` to listeners.
+			if (blocks.length === 0 && buffering.current) {
+				buffering.current = false;
 				onResumeCallbacks.forEach((c) => c());
 				playbackLogging({
 					logLevel,

--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -194,12 +194,12 @@ export const useIsPlayerBuffering = (bufferManager: BufferManager) => {
 			setIsBuffering(false);
 		};
 
-		bufferManager.listenForBuffering(onBuffer);
-		bufferManager.listenForResume(onResume);
+		const buffer = bufferManager.listenForBuffering(onBuffer);
+		const resume = bufferManager.listenForResume(onResume);
 
 		return () => {
-			bufferManager.listenForBuffering(() => undefined);
-			bufferManager.listenForResume(() => undefined);
+			buffer.remove();
+			resume.remove();
 		};
 	}, [bufferManager]);
 

--- a/packages/core/src/test/buffering.test.tsx
+++ b/packages/core/src/test/buffering.test.tsx
@@ -1,0 +1,105 @@
+import {beforeEach, expect, test} from 'bun:test';
+import {act, render} from '@testing-library/react';
+import React, {useContext, useLayoutEffect} from 'react';
+import {BufferingContextReact, BufferingProvider} from '../buffering.js';
+import type {RemotionEnvironment} from '../remotion-environment-context.js';
+import {RemotionEnvironmentContext} from '../remotion-environment-context.js';
+
+const previewEnvironment: RemotionEnvironment = {
+	isStudio: false,
+	isRendering: false,
+	isPlayer: true,
+	isReadOnlyStudio: false,
+	isClientSideRendering: false,
+};
+
+let manager: React.ContextType<typeof BufferingContextReact> = null;
+let events: string[] = [];
+
+const Harness: React.FC = () => {
+	const context = useContext(BufferingContextReact);
+	manager = context;
+
+	// Subscribe in a layout effect like `useBufferStateEmitter` does, so that
+	// listeners are registered before the provider's effects run on mount.
+	useLayoutEffect(() => {
+		const buffer = context!.listenForBuffering(() => {
+			events.push('waiting');
+		});
+		const resume = context!.listenForResume(() => {
+			events.push('resume');
+		});
+
+		return () => {
+			buffer.remove();
+			resume.remove();
+		};
+	}, [context]);
+
+	return null;
+};
+
+const renderProvider = () => {
+	return render(
+		<RemotionEnvironmentContext.Provider value={previewEnvironment}>
+			<BufferingProvider>
+				<Harness />
+			</BufferingProvider>
+		</RemotionEnvironmentContext.Provider>,
+	);
+};
+
+beforeEach(() => {
+	manager = null;
+	events = [];
+});
+
+test('does not emit "resume" on mount', () => {
+	renderProvider();
+
+	expect(events).toEqual([]);
+});
+
+test('emits "waiting" and "resume" only on empty <-> non-empty transitions', () => {
+	renderProvider();
+
+	let firstBlock: {unblock: () => void} | null = null;
+	let secondBlock: {unblock: () => void} | null = null;
+
+	act(() => {
+		firstBlock = manager!.addBlock({id: 'first'});
+	});
+	expect(events).toEqual(['waiting']);
+	expect(manager!.buffering.current).toBe(true);
+
+	// A second block while already buffering must not re-dispatch "waiting"
+	act(() => {
+		secondBlock = manager!.addBlock({id: 'second'});
+	});
+	expect(events).toEqual(['waiting']);
+
+	// Going from 2 -> 1 blocks is not a transition
+	act(() => {
+		firstBlock!.unblock();
+	});
+	expect(events).toEqual(['waiting']);
+	expect(manager!.buffering.current).toBe(true);
+
+	act(() => {
+		secondBlock!.unblock();
+	});
+	expect(events).toEqual(['waiting', 'resume']);
+	expect(manager!.buffering.current).toBe(false);
+});
+
+test('a block added and removed within the same commit emits no events', () => {
+	renderProvider();
+
+	act(() => {
+		const block = manager!.addBlock({id: 'transient'});
+		block.unblock();
+	});
+
+	expect(events).toEqual([]);
+	expect(manager!.buffering.current).toBe(false);
+});


### PR DESCRIPTION
## Summary

Two minimal fixes to the buffer manager event contract, keeping the existing state-based design (no refactor):

### 1. Fix listener leak in `useIsPlayerBuffering`

The effect cleanup called `listenForBuffering(() => undefined)` / `listenForResume(() => undefined)`, which _registered new no-op listeners_ instead of removing the original ones. Every mount/unmount of a media element permanently grew both callback arrays and left stale `setIsBuffering` closures behind.

The cleanup now retains the `{remove}` handles returned by `listenForBuffering`/`listenForResume` and calls `.remove()`, matching how `useBufferStateEmitter` and `use-playback.ts` already use the API.

### 2. Only emit `waiting`/`resume` on actual buffering transitions

Previously the effects fired on every `blocks` identity change:

- Going from 1 → 2 blocks (e.g. a second media element starts loading) re-dispatched `waiting` to all Player event listeners.
- The initial mount and a block that was added and removed within the same commit dispatched a spurious `resume` (the layout effect ran with `blocks.length === 0`).

Both effects are now guarded by the `buffering` ref, so `waiting` fires only on the `false → true` transition and `resume` only on `true → false`. As a side effect, `buffering.current` is now maintained by core itself instead of relying on the Player's emitter listener, so it no longer lags or stays stale in contexts without an emitter.

Event timing is unchanged (`waiting` post-commit via `useEffect`, `resume` pre-paint via `useLayoutEffect`), and rapid block changes within one commit still coalesce.

Adds tests for the event contract (`packages/core/src/test/buffering.test.tsx`).

This is the minimal, low-risk part of the fix proposed in #8892 (see discussion there), extracted without the buffer manager refactor.

Related: #8894
