### PR TITLE
Docs: Fix starburst effect preview colors

### DIFF
--- a/packages/docs/components/effects-demos/registry.ts
+++ b/packages/docs/components/effects-demos/registry.ts
@@ -117,7 +117,10 @@ import {
 	SHRINKWRAP_PREVIEW_PARAMS,
 } from '../effects/effects-shrinkwrap-preview';
 import {EffectsSpecklePreview} from '../effects/effects-speckle-preview';
-import {EffectsStarburstPreview} from '../effects/effects-starburst-preview';
+import {
+	EffectsStarburstPreview,
+	STARBURST_PREVIEW_PARAMS,
+} from '../effects/effects-starburst-preview';
 import {EffectsThermalVisionPreview} from '../effects/effects-thermal-vision-preview';
 import {EffectsTintPreview} from '../effects/effects-tint-preview';
 import {
@@ -626,10 +629,7 @@ export const effectsDemos: EffectsDemoType[] = [
 		effectImportPath: '@remotion/starburst',
 		comp: EffectsStarburstPreview,
 		schema: starburstEffectSchema,
-		initialValues: {
-			rays: 16,
-			colors: ['#ff6600', '#ffff00'],
-		},
+		initialValues: STARBURST_PREVIEW_PARAMS,
 	},
 	{
 		...defaults,

--- a/packages/docs/components/effects/effects-starburst-preview.tsx
+++ b/packages/docs/components/effects/effects-starburst-preview.tsx
@@ -8,12 +8,21 @@ const fullSize: React.CSSProperties = {
 	height: '100%',
 };
 
+export const STARBURST_PREVIEW_PARAMS = {
+	rays: 16,
+	colors: ['#ff6600', '#ffff00'],
+	rotation: 0,
+	smoothness: 0,
+	origin: [0.5, 0.5] as const,
+} as const;
+
 export const EffectsStarburstPreview: React.FC<{
 	readonly rays: number;
+	readonly colors: readonly string[];
 	readonly rotation: number;
 	readonly smoothness: number;
 	readonly origin: readonly [number, number];
-}> = ({rays, rotation, smoothness, origin}) => {
+}> = ({rays, colors, rotation, smoothness, origin}) => {
 	return (
 		<CanvasImage
 			src={EFFECTS_PREVIEW_IMAGE_SRC}
@@ -24,7 +33,7 @@ export const EffectsStarburstPreview: React.FC<{
 			effects={[
 				starburst({
 					rays,
-					colors: ['#dff4ff', '#7cc6ff'],
+					colors,
 					rotation,
 					smoothness,
 					origin,

--- a/packages/docs/src/remotion/Root.tsx
+++ b/packages/docs/src/remotion/Root.tsx
@@ -63,7 +63,10 @@ import {
 	SHRINKWRAP_PREVIEW_PARAMS,
 } from '../../components/effects/effects-shrinkwrap-preview';
 import {EffectsSpecklePreview} from '../../components/effects/effects-speckle-preview';
-import {EffectsStarburstPreview} from '../../components/effects/effects-starburst-preview';
+import {
+	EffectsStarburstPreview,
+	STARBURST_PREVIEW_PARAMS,
+} from '../../components/effects/effects-starburst-preview';
 import {EffectsThermalVisionPreview} from '../../components/effects/effects-thermal-vision-preview';
 import {EffectsTintPreview} from '../../components/effects/effects-tint-preview';
 import {
@@ -762,12 +765,7 @@ export const RemotionRoot: React.FC = () => {
 					component={EffectsStarburstPreview}
 					width={1280}
 					height={720}
-					defaultProps={{
-						rays: 16,
-						rotation: 0,
-						smoothness: 0,
-						origin: [0.5, 0.5],
-					}}
+					defaultProps={STARBURST_PREVIEW_PARAMS}
 				/>
 				<Still
 					id="effects-light-leak-preview"


### PR DESCRIPTION
## Summary

- Make the `starburst()` docs preview use the colors from its controls.
- Share the starburst preview defaults between the live docs demo and generated preview still.

## Testing

- `bun run build`
- `bun run stylecheck`

Closes https://github.com/remotion-dev/remotion/issues/8907
