### PR TITLE
`@remotion/studio`: Fix render dialog tooltips

### DIFF
--- a/packages/studio/src/components/RenderModal/OptionExplainer.tsx
+++ b/packages/studio/src/components/RenderModal/OptionExplainer.tsx
@@ -1,15 +1,23 @@
 import type {AnyRemotionOption} from '@remotion/renderer';
 import React from 'react';
-import {BLUE, INPUT_BACKGROUND, WHITE} from '../../helpers/colors';
+import {BLUE, INPUT_BACKGROUND, LIGHT_TEXT, WHITE} from '../../helpers/colors';
 import {Spacing} from '../layout';
 import {MenuDivider} from '../Menu/MenuDivider';
 import {CliCopyButton} from './CliCopyButton';
+
+export type OptionExplainerOption = Pick<
+	AnyRemotionOption<unknown>,
+	'name' | 'description' | 'docLink' | 'ssrName'
+> & {
+	readonly cliFlag?: string;
+};
 
 const container: React.CSSProperties = {
 	fontSize: 14,
 	paddingTop: 10,
 	paddingBottom: 10,
 	backgroundColor: INPUT_BACKGROUND,
+	color: WHITE,
 };
 
 const padding: React.CSSProperties = {
@@ -24,7 +32,9 @@ const title: React.CSSProperties = {
 const DESCRIPTION_FONT_SIZE_PX = 14;
 
 const description: React.CSSProperties = {
+	color: LIGHT_TEXT,
 	fontSize: DESCRIPTION_FONT_SIZE_PX,
+	lineHeight: 1.5,
 	maxWidth: 400,
 };
 
@@ -60,9 +70,27 @@ const copyWrapper: React.CSSProperties = {
 	justifyContent: 'flex-end',
 };
 
+export type OptionExplainerInfoRow = {
+	readonly label: string;
+	readonly value: string;
+};
+
 export const OptionExplainer: React.FC<{
-	readonly option: AnyRemotionOption<unknown>;
-}> = ({option}) => {
+	readonly option: OptionExplainerOption;
+	readonly extraInfoRows?: readonly OptionExplainerInfoRow[];
+	readonly showApiOption?: boolean;
+	readonly showCliFlag?: boolean;
+}> = ({
+	option,
+	extraInfoRows = [],
+	showApiOption = true,
+	showCliFlag = true,
+}) => {
+	const shouldShowApiOption = showApiOption && option.ssrName !== null;
+	const shouldShowCliFlag = showCliFlag && option.cliFlag !== undefined;
+	const hasInfoRows =
+		extraInfoRows.length > 0 || shouldShowCliFlag || shouldShowApiOption;
+
 	return (
 		<div style={container} className="__remotion-info-button-container">
 			<div style={padding}>
@@ -80,9 +108,21 @@ export const OptionExplainer: React.FC<{
 				<div style={description}>
 					<style>
 						{`
-							.__remotion-option-explainer-description a,
-							.__remotion-option-explainer-description code {
+							.__remotion-option-explainer-description,
+							.__remotion-option-explainer-description * {
+								color: inherit;
 								font-size: ${DESCRIPTION_FONT_SIZE_PX}px;
+								line-height: inherit;
+							}
+
+							.__remotion-option-explainer-description a {
+								color: ${BLUE};
+								text-decoration: none;
+							}
+
+							.__remotion-option-explainer-description code {
+								color: ${BLUE};
+								font-family: monospace;
 							}
 						`}
 					</style>
@@ -91,28 +131,44 @@ export const OptionExplainer: React.FC<{
 					</div>
 				</div>
 			</div>
-			<Spacing y={0.5} block />
-			<MenuDivider />
-			<Spacing y={0.5} block />
-			<div>
-				<div style={infoRow}>
-					<div style={infoRowLabel}>CLI flag</div>
-					<div style={flexSpacer} />
-					<code>--{option.cliFlag}</code>
-					<div style={copyWrapper}>
-						<CliCopyButton valueToCopy={option.cliFlag} />
+			{hasInfoRows ? (
+				<>
+					<Spacing y={0.5} block />
+					<MenuDivider />
+					<Spacing y={0.5} block />
+					<div>
+						{extraInfoRows.map((row) => (
+							<div key={row.label} style={infoRow}>
+								<div style={infoRowLabel}>{row.label}</div>
+								<div style={flexSpacer} />
+								<code>{row.value}</code>
+								<div style={copyWrapper}>
+									<CliCopyButton valueToCopy={row.value} />
+								</div>
+							</div>
+						))}
+						{shouldShowCliFlag ? (
+							<div style={infoRow}>
+								<div style={infoRowLabel}>CLI flag</div>
+								<div style={flexSpacer} />
+								<code>--{option.cliFlag}</code>
+								<div style={copyWrapper}>
+									<CliCopyButton valueToCopy={option.cliFlag} />
+								</div>
+							</div>
+						) : null}
+						{shouldShowApiOption ? (
+							<div style={infoRow}>
+								<div style={infoRowLabel}>API option</div>
+								<div style={flexSpacer} />
+								<code>{option.ssrName}</code>
+								<Spacing x={3.75} />
+							</div>
+						) : null}
+						<div style={infoRow} />
 					</div>
-				</div>
-				{option.ssrName ? (
-					<div style={infoRow}>
-						<div style={infoRowLabel}>Node.JS option</div>
-						<div style={flexSpacer} />
-						<code>{option.ssrName}</code>
-						<Spacing x={3.75} />
-					</div>
-				) : null}
-				<div style={infoRow} />
-			</div>
+				</>
+			) : null}
 		</div>
 	);
 };

--- a/packages/studio/src/components/RenderModal/OptionExplainerBubble.tsx
+++ b/packages/studio/src/components/RenderModal/OptionExplainerBubble.tsx
@@ -2,16 +2,67 @@ import type {AnyRemotionOption} from '@remotion/renderer';
 import type {AvailableOptions} from '@remotion/renderer/client';
 import {BrowserSafeApis} from '@remotion/renderer/client';
 import {InfoBubble} from './InfoBubble';
-import {OptionExplainer} from './OptionExplainer';
+import {
+	OptionExplainer,
+	type OptionExplainerInfoRow,
+	type OptionExplainerOption,
+} from './OptionExplainer';
 
 export const OptionExplainerBubble: React.FC<{
-	id: AvailableOptions;
-}> = ({id}) => {
+	readonly id: AvailableOptions;
+	readonly extraInfoRows?: readonly OptionExplainerInfoRow[];
+	readonly showApiOption?: boolean;
+	readonly showCliFlag?: boolean;
+}> = ({id, extraInfoRows, showApiOption, showCliFlag}) => {
 	const option = BrowserSafeApis.options[id] as AnyRemotionOption<unknown>;
 
 	return (
 		<InfoBubble title="Learn more about this option">
-			<OptionExplainer option={option} />
+			<OptionExplainer
+				extraInfoRows={extraInfoRows}
+				option={option}
+				showApiOption={showApiOption}
+				showCliFlag={showCliFlag}
+			/>
+		</InfoBubble>
+	);
+};
+
+export const WebRendererOptionExplainerBubble: React.FC<{
+	readonly id: AvailableOptions;
+	readonly apiName: string;
+}> = ({id, apiName}) => {
+	return (
+		<OptionExplainerBubble
+			extraInfoRows={[{label: 'API option', value: apiName}]}
+			id={id}
+			showApiOption={false}
+			showCliFlag={false}
+		/>
+	);
+};
+
+export const WebRendererCustomOptionExplainerBubble: React.FC<{
+	readonly apiName: string;
+	readonly description: React.ReactNode;
+	readonly docLink: string | null;
+	readonly name: string;
+}> = ({apiName, description, docLink, name}) => {
+	const option: OptionExplainerOption = {
+		description: () => description,
+		docLink,
+		name,
+		ssrName: null,
+	};
+
+	return (
+		<InfoBubble title="Learn more about this option">
+			<OptionExplainer
+				extraInfoRows={[{label: 'API option', value: apiName}]}
+				option={option}
+				showApiOption={false}
+				showCliFlag={false}
+			/>
 		</InfoBubble>
 	);
 };

--- a/packages/studio/src/components/RenderModal/WebRenderModalAdvanced.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModalAdvanced.tsx
@@ -1,16 +1,17 @@
 import type {WebRendererPageResponsiveness} from '@remotion/web-renderer';
 import type React from 'react';
 import {useCallback, useMemo} from 'react';
-import {BLUE} from '../../helpers/colors';
 import {Checkmark} from '../../icons/Checkmark';
 import {Checkbox} from '../Checkbox';
 import {Spacing} from '../layout';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {Combobox} from '../NewComposition/ComboBox';
-import {InfoBubble} from './InfoBubble';
 import {label, optionRow, rightRow} from './layout';
 import {NumberSetting} from './NumberSetting';
-import {OptionExplainerBubble} from './OptionExplainerBubble';
+import {
+	WebRendererCustomOptionExplainerBubble,
+	WebRendererOptionExplainerBubble,
+} from './OptionExplainerBubble';
 import type {RenderType} from './WebRenderModal';
 
 type WebRenderModalAdvancedProps = {
@@ -40,12 +41,6 @@ const tabContainer: React.CSSProperties = {
 	flex: 1,
 };
 
-const explainerContainer: React.CSSProperties = {
-	fontSize: 14,
-	maxWidth: 420,
-	padding: '10px 20px',
-};
-
 const paragraph: React.CSSProperties = {
 	margin: 0,
 	marginBottom: 8,
@@ -55,14 +50,9 @@ const lastParagraph: React.CSSProperties = {
 	margin: 0,
 };
 
-const link: React.CSSProperties = {
-	color: BLUE,
-	textDecoration: 'none',
-};
-
-const PageResponsivenessExplainer: React.FC = () => {
+const PageResponsivenessDescription: React.FC = () => {
 	return (
-		<div style={explainerContainer}>
+		<>
 			<p style={paragraph}>
 				The Web Renderer runs in the same browser tab as the Studio. Rendering
 				can block the tab while Remotion captures frames.
@@ -74,16 +64,9 @@ const PageResponsivenessExplainer: React.FC = () => {
 			</p>
 			<p style={lastParagraph}>
 				Choose <code>Disabled</code> to prioritize render speed, or{' '}
-				<code>High</code> to give the browser more chances to update.{' '}
-				<a
-					href="https://www.remotion.dev/docs/web-renderer/page-responsiveness"
-					style={link}
-					target="_blank"
-				>
-					Docs
-				</a>
+				<code>High</code> to give the browser more chances to update.
 			</p>
-		</div>
+		</>
 	);
 };
 
@@ -270,7 +253,10 @@ export const WebRenderModalAdvanced: React.FC<WebRenderModalAdvancedProps> = ({
 			<div style={optionRow}>
 				<div style={label}>
 					Custom @remotion/media cache size <Spacing x={0.5} />
-					<OptionExplainerBubble id="mediaCacheSizeInBytesOption" />
+					<WebRendererOptionExplainerBubble
+						apiName="mediaCacheSizeInBytes"
+						id="mediaCacheSizeInBytesOption"
+					/>
 				</div>
 				<div style={rightRow}>
 					<Checkbox
@@ -309,7 +295,10 @@ export const WebRenderModalAdvanced: React.FC<WebRenderModalAdvancedProps> = ({
 			<div style={optionRow}>
 				<div style={label}>
 					Allow HTML-in-canvas <Spacing x={0.5} />
-					<OptionExplainerBubble id="allowHtmlInCanvasOption" />
+					<WebRendererOptionExplainerBubble
+						apiName="allowHtmlInCanvas"
+						id="allowHtmlInCanvasOption"
+					/>
 				</div>
 				<div style={rightRow}>
 					<Checkbox
@@ -325,9 +314,12 @@ export const WebRenderModalAdvanced: React.FC<WebRenderModalAdvancedProps> = ({
 					<div style={optionRow}>
 						<div style={label}>
 							Page Responsiveness <Spacing x={0.5} />
-							<InfoBubble title="Learn more about page responsiveness">
-								<PageResponsivenessExplainer />
-							</InfoBubble>
+							<WebRendererCustomOptionExplainerBubble
+								apiName="pageResponsiveness"
+								description={<PageResponsivenessDescription />}
+								docLink="https://www.remotion.dev/docs/client-side-rendering/page-responsiveness"
+								name="Page responsiveness"
+							/>
 						</div>
 						<div style={rightRow}>
 							<Combobox

--- a/packages/studio/src/components/RenderModal/WebRenderModalBasic.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModalBasic.tsx
@@ -18,7 +18,7 @@ import {SegmentedControl} from '../SegmentedControl';
 import {FrameRangeSetting} from './FrameRangeSetting';
 import {humanReadableLogLevel} from './human-readable-loglevel';
 import {input, label, optionRow, rightRow} from './layout';
-import {OptionExplainerBubble} from './OptionExplainerBubble';
+import {WebRendererOptionExplainerBubble} from './OptionExplainerBubble';
 import {RenderModalOutputName} from './RenderModalOutputName';
 import type {RenderType} from './WebRenderModal';
 
@@ -225,7 +225,10 @@ export const WebRenderModalBasic: React.FC<WebRenderModalBasicProps> = ({
 							<div style={label}>
 								Codec
 								<Spacing x={0.5} />
-								<OptionExplainerBubble id="videoCodecOption" />
+								<WebRendererOptionExplainerBubble
+									apiName="codec"
+									id="videoCodecOption"
+								/>
 							</div>
 							<div style={rightRow}>
 								<Combobox
@@ -258,7 +261,10 @@ export const WebRenderModalBasic: React.FC<WebRenderModalBasicProps> = ({
 			<div style={optionRow}>
 				<div style={label}>
 					Log Level <Spacing x={0.5} />
-					<OptionExplainerBubble id="logLevelOption" />
+					<WebRendererOptionExplainerBubble
+						apiName="logLevel"
+						id="logLevelOption"
+					/>
 				</div>
 				<div style={rightRow}>
 					<Combobox


### PR DESCRIPTION
## Summary

- Fix render dialog option tooltip typography so description text and links keep Studio styling despite the CSS reset
- Show a single API option row for web renderer settings instead of CLI or duplicated Node.JS option rows
- Align the Page Responsiveness tooltip with the other option explainers

Closes #8877

## Testing

- bunx oxfmt src --write
- bun run build
- bun run stylecheck
