### PR TITLE
`@remotion/media`: Keep looped audio after mid-loop seeks

### DIFF
--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -361,7 +361,9 @@ export const audioIteratorManager = ({
 			return;
 		}
 
-		const maximumTimestamp = getMediaEndTimestamp();
+		const maximumTimestamp = loop
+			? Math.min(getMediaEndTimestamp(), getSequenceEndTimestamp())
+			: getMediaEndTimestamp();
 		if (startFromSecond >= maximumTimestamp) {
 			return;
 		}
@@ -375,6 +377,7 @@ export const audioIteratorManager = ({
 		const iterator = makeAudioIterator({
 			startFromSecond,
 			maximumTimestamp,
+			loopStartInSeconds: getStartTime(),
 			audioSink,
 			logLevel,
 			loop,

--- a/packages/media/src/audio/audio-preview-iterator.ts
+++ b/packages/media/src/audio/audio-preview-iterator.ts
@@ -22,6 +22,7 @@ export type QueuedPeriod = {
 export const makeAudioIterator = ({
 	startFromSecond,
 	maximumTimestamp,
+	loopStartInSeconds,
 	audioSink,
 	loop,
 	playbackRate,
@@ -30,6 +31,7 @@ export const makeAudioIterator = ({
 }: {
 	startFromSecond: number;
 	maximumTimestamp: number;
+	loopStartInSeconds?: number;
 	logLevel: LogLevel;
 	audioSink: AudioBufferSink;
 	loop: boolean;
@@ -42,6 +44,7 @@ export const makeAudioIterator = ({
 		audioSink,
 		timeToSeek: startFromSecond,
 		maximumTimestamp,
+		loopStartInSeconds,
 		loop,
 		playbackRate,
 		sequenceDurationInSeconds,

--- a/packages/media/src/audio/audio-preview-iterator.ts
+++ b/packages/media/src/audio/audio-preview-iterator.ts
@@ -31,7 +31,7 @@ export const makeAudioIterator = ({
 }: {
 	startFromSecond: number;
 	maximumTimestamp: number;
-	loopStartInSeconds?: number;
+	loopStartInSeconds: number;
 	logLevel: LogLevel;
 	audioSink: AudioBufferSink;
 	loop: boolean;

--- a/packages/media/src/make-iterator-with-priming.ts
+++ b/packages/media/src/make-iterator-with-priming.ts
@@ -29,45 +29,46 @@ async function* makeIteratorWithPrimingInner(
 
 async function* makeLoopingIterator({
 	audioSink,
+	timeToSeek,
 	segmentStartInSeconds,
 	segmentEndInSeconds,
 	playbackRate,
 	sequenceDurationInSeconds,
 }: {
 	audioSink: AudioBufferSink;
+	timeToSeek: number;
 	segmentStartInSeconds: number;
 	segmentEndInSeconds: number;
 	playbackRate: number;
 	sequenceDurationInSeconds: number;
 }): AsyncGenerator<BufferWithMediaTimestamp, void, unknown> {
 	const duration = segmentEndInSeconds - segmentStartInSeconds;
+	if (duration <= 0) {
+		return;
+	}
+
 	let iteration = 0;
 
-	let broken = false;
 	while (true) {
+		const startTimestamp = iteration === 0 ? timeToSeek : segmentStartInSeconds;
+		const timestampOffset = iteration === 0 ? 0 : iteration * duration;
 		for await (const item of makeIteratorWithPrimingInner(
 			audioSink,
-			segmentStartInSeconds,
+			startTimestamp,
 			segmentEndInSeconds,
 		)) {
-			const timestamp = item.timestamp + iteration * duration;
+			const timestamp = item.timestamp + timestampOffset;
 
 			const endTimestamp =
-				duration * iteration +
-				(item.timestamp - segmentStartInSeconds + item.buffer.duration);
+				timestamp - segmentStartInSeconds + item.buffer.duration;
 			if (endTimestamp > sequenceDurationInSeconds * playbackRate) {
-				broken = true;
-				break;
+				return;
 			}
 
 			yield {
 				buffer: item.buffer,
 				timestamp,
 			};
-		}
-
-		if (broken) {
-			break;
 		}
 
 		iteration++;
@@ -78,6 +79,7 @@ export const makeIteratorWithPriming = ({
 	audioSink,
 	timeToSeek,
 	maximumTimestamp,
+	loopStartInSeconds,
 	loop,
 	playbackRate,
 	sequenceDurationInSeconds,
@@ -85,6 +87,7 @@ export const makeIteratorWithPriming = ({
 	audioSink: AudioBufferSink;
 	timeToSeek: number;
 	maximumTimestamp: number;
+	loopStartInSeconds?: number;
 	loop: boolean;
 	playbackRate: number;
 	sequenceDurationInSeconds: number;
@@ -92,7 +95,8 @@ export const makeIteratorWithPriming = ({
 	if (loop) {
 		return makeLoopingIterator({
 			audioSink,
-			segmentStartInSeconds: timeToSeek,
+			timeToSeek,
+			segmentStartInSeconds: loopStartInSeconds ?? timeToSeek,
 			segmentEndInSeconds: maximumTimestamp,
 			playbackRate,
 			sequenceDurationInSeconds,

--- a/packages/media/src/make-iterator-with-priming.ts
+++ b/packages/media/src/make-iterator-with-priming.ts
@@ -87,7 +87,7 @@ export const makeIteratorWithPriming = ({
 	audioSink: AudioBufferSink;
 	timeToSeek: number;
 	maximumTimestamp: number;
-	loopStartInSeconds?: number;
+	loopStartInSeconds: number;
 	loop: boolean;
 	playbackRate: number;
 	sequenceDurationInSeconds: number;
@@ -96,7 +96,7 @@ export const makeIteratorWithPriming = ({
 		return makeLoopingIterator({
 			audioSink,
 			timeToSeek,
-			segmentStartInSeconds: loopStartInSeconds ?? timeToSeek,
+			segmentStartInSeconds: loopStartInSeconds,
 			segmentEndInSeconds: maximumTimestamp,
 			playbackRate,
 			sequenceDurationInSeconds,

--- a/packages/media/src/test/audio-cleanup-on-seek.test.ts
+++ b/packages/media/src/test/audio-cleanup-on-seek.test.ts
@@ -42,6 +42,7 @@ test('destroy should stop nodes when the audio anchor changed (seek to different
 	const iterator = makeAudioIterator({
 		startFromSecond: 0,
 		maximumTimestamp: Infinity,
+		loopStartInSeconds: 0,
 		audioSink: audioBufferSink,
 		logLevel: 'info',
 		loop: false,

--- a/packages/media/src/test/audio-iterator.test.ts
+++ b/packages/media/src/test/audio-iterator.test.ts
@@ -6,14 +6,18 @@ import {makeNonceManager} from '../nonce-manager';
 
 const prepare = async (options?: {
 	fps?: number;
+	loop?: boolean;
 	playbackRate?: number;
 	mediaEndTimestamp?: number;
+	sequenceDurationInSeconds?: number;
 	sequenceEndTimestamp?: number;
 }) => {
 	const {
 		fps = 30,
+		loop = false,
 		playbackRate = 1,
 		mediaEndTimestamp = Infinity,
+		sequenceDurationInSeconds = 10,
 		sequenceEndTimestamp = Infinity,
 	} = options ?? {};
 	const input = new Input({
@@ -56,7 +60,7 @@ const prepare = async (options?: {
 		},
 		getMediaEndTimestamp: () => mediaEndTimestamp,
 		getSequenceEndTimestamp: () => sequenceEndTimestamp,
-		getSequenceDurationInSeconds: () => 10,
+		getSequenceDurationInSeconds: () => sequenceDurationInSeconds,
 		getStartTime: () => 0,
 		initialMuted: false,
 		drawDebugOverlay: () => {},
@@ -65,18 +69,27 @@ const prepare = async (options?: {
 		initialTrimAfter: undefined,
 		initialSequenceOffset: 0,
 		initialSequenceDurationInFrames: 10,
-		initialLoop: false,
+		initialLoop: loop,
 		initialFps: 30,
 	});
 
 	const scheduledChunks: number[] = [];
+	const scheduledNodes: {
+		mediaTimestamp: number;
+		originalUnloopedMediaTimestamp: number;
+	}[] = [];
 	const waiters: {count: number; resolve: () => void}[] = [];
 
 	const scheduleAudioNode = (
 		_node: AudioBufferSourceNode,
 		mediaTimestamp: number,
+		originalUnloopedMediaTimestamp: number,
 	): ScheduleAudioNodeResult => {
 		scheduledChunks.push(mediaTimestamp);
+		scheduledNodes.push({
+			mediaTimestamp,
+			originalUnloopedMediaTimestamp,
+		});
 		for (let i = waiters.length - 1; i >= 0; i--) {
 			if (scheduledChunks.length >= waiters[i].count) {
 				waiters[i].resolve();
@@ -98,7 +111,7 @@ const prepare = async (options?: {
 			playbackRate,
 			getTargetTime: (mediaTimestamp: number) => mediaTimestamp,
 			logLevel: 'info',
-			loop: false,
+			loop,
 			trimBefore: undefined,
 			trimAfter: undefined,
 			sequenceOffset: 0,
@@ -113,6 +126,7 @@ const prepare = async (options?: {
 		manager,
 		fps,
 		scheduledChunks,
+		scheduledNodes,
 		seek,
 		audioContextCurrentTime,
 	};
@@ -295,4 +309,28 @@ test('should not decode + schedule audio chunks beyond the end time', async () =
 	}
 
 	expect(scheduledChunks.length).toBe(23);
+});
+
+test('should keep looped audio scheduling from the true loop start after a mid-loop seek', async () => {
+	const {seek, manager, scheduledNodes, audioContextCurrentTime} =
+		await prepare({
+			loop: true,
+			mediaEndTimestamp: 1,
+			sequenceDurationInSeconds: 3,
+			sequenceEndTimestamp: 3,
+		});
+
+	audioContextCurrentTime.current = 0.8;
+	seek({
+		time: 0.8,
+	});
+
+	await manager.waitForNScheduledNodes(70);
+
+	const thirdLoopStart = scheduledNodes.find(
+		(node) => node.mediaTimestamp >= 2,
+	);
+
+	expect(thirdLoopStart).toBeDefined();
+	expect(thirdLoopStart?.originalUnloopedMediaTimestamp).toBeLessThan(0.1);
 });


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Summary

- Looped preview audio keeps playing after a seek lands inside an already-progressed loop segment instead of going silent on later loop iterations.
- The first post-seek iterator pass still starts at the current seek time, while later loop passes restart from the actual loop segment start.
- Added a browser regression that seeks into a one-second loop and verifies audio scheduled for the third loop iteration starts reading from the beginning of the source segment again.

## Related issue

Fixes #8922.

## Tests

- `cd packages/media && bunx vitest src/test/audio-iterator.test.ts --browser --run`
- `cd packages/media && bunx vitest src/test/audio-cleanup-on-seek.test.ts src/test/media-player.test.ts src/test/browser.test.ts src/test/looping.test.ts src/test/loop-trim-time-calculation.test.ts --browser --run`
- `cd packages/media && bun run test`
- `bunx turbo run make --filter='@remotion/media'`
- `cd packages/media && bun run formatting`
- `bun run build`
- `bun run stylecheck`
- `git diff --check`

## Scope

- This is limited to preview audio iterator scheduling for looped media.
- It does not change media decoding, player sharing, or the example composition.

## Caveats

- The regression covers the scheduling path that caused audio to disappear after repeated loops. The real `LoopedNewVideo` Studio composition was verified through the third-loop boundary: a slight audible reset/pause occurs at the loop point, then audio continues instead of disappearing.
