### PR TITLE
Docs: Use @remotion/media in more examples

### DIFF
--- a/packages/docs/docs/preload/resolve-redirect.mdx
+++ b/packages/docs/docs/preload/resolve-redirect.mdx
@@ -26,7 +26,7 @@ This snippet tries to preload a video on a best-effort basis. If the redirect ca
 
 ```tsx twoslash
 import {preloadVideo, resolveRedirect} from '@remotion/preload';
-import {OffthreadVideo} from 'remotion';
+import {Video} from '@remotion/media';
 
 // This code gets executed immediately once the page loads
 let urlToLoad = 'https://player.vimeo.com/external/291648067.hd.mp4?s=94998971682c6a3267e4cbd19d16a7b6c720f345&profile_id=175&oauth2_token_id=57447761';
@@ -51,7 +51,7 @@ const MyComp: React.FC = () => {
 
   // If the component mounted immediately, this will be the original URL.
   // In that case preloading is ineffective anyway.
-  return <OffthreadVideo src={urlToLoad}></OffthreadVideo>;
+  return <Video src={urlToLoad}></Video>;
 };
 ```
 

--- a/packages/docs/docs/transitions/audio-transitions.mdx
+++ b/packages/docs/docs/transitions/audio-transitions.mdx
@@ -11,7 +11,7 @@ To add sound to a transition, you may use this function to wrap any [presentatio
 
 ```tsx twoslash title="add-sound.tsx"
 import {TransitionPresentation, TransitionPresentationComponentProps} from '@remotion/transitions';
-import {Html5Audio} from 'remotion';
+import {Audio} from '@remotion/media';
 
 export function addSound<T extends Record<string, unknown>>(transition: TransitionPresentation<T>, src: string): TransitionPresentation<T> {
   const {component: Component, ...other} = transition;
@@ -21,7 +21,7 @@ export function addSound<T extends Record<string, unknown>>(transition: Transiti
   const NewComponent: React.FC<TransitionPresentationComponentProps<T>> = (p) => {
     return (
       <>
-        {p.presentationDirection === 'entering' ? <Html5Audio src={src} /> : null}
+        {p.presentationDirection === 'entering' ? <Audio src={src} /> : null}
         <C {...p} />
       </>
     );
@@ -34,13 +34,13 @@ export function addSound<T extends Record<string, unknown>>(transition: Transiti
 }
 ```
 
-Customize the volume, offset, playback rate, and other properties of the [`<Html5Audio>`](/docs/html5-audio) component as you wish.
+Customize the volume, offset, playback rate, and other properties of the [`<Audio>`](/docs/media/audio) component as you wish.
 
 You may use it like this:
 
 ```tsx twoslash title="example.tsx"
 import {TransitionPresentation, TransitionPresentationComponentProps} from '@remotion/transitions';
-import {Html5Audio} from 'remotion';
+import {Audio} from '@remotion/media';
 
 export function addSound<T extends Record<string, unknown>>(transition: TransitionPresentation<T>, src: string): TransitionPresentation<T> {
   const {component: Component, ...other} = transition;
@@ -50,7 +50,7 @@ export function addSound<T extends Record<string, unknown>>(transition: Transiti
   const NewComponent: React.FC<TransitionPresentationComponentProps<T>> = (p) => {
     return (
       <>
-        {p.presentationDirection === 'entering' ? <Html5Audio src={src} /> : null}
+        {p.presentationDirection === 'entering' ? <Audio src={src} /> : null}
         <C {...p} />
       </>
     );
@@ -75,5 +75,5 @@ Now you can use `withSound` in place of `presentation`.
 
 ## See also
 
-- [`<Html5Audio>`](/docs/html5-audio)
+- [`<Audio>`](/docs/media/audio)
 - [Using audio](/docs/using-audio)

--- a/packages/docs/docs/troubleshooting/video-flicker.mdx
+++ b/packages/docs/docs/troubleshooting/video-flicker.mdx
@@ -9,16 +9,17 @@ crumb: 'Frame-perfection'
 Consider the following markup:
 
 ```tsx twoslash title="MyComponent.tsx"
-import {AbsoluteFill, Sequence, OffthreadVideo} from 'remotion';
+import {Video} from '@remotion/media';
+import {AbsoluteFill, Sequence} from 'remotion';
 
 const MyComponent: React.FC = () => {
   return (
     <AbsoluteFill>
       <Sequence from={0} durationInFrames={120}>
-        <OffthreadVideo src="https://example.com/video1.mp4" />
+        <Video src="https://example.com/video1.mp4" />
       </Sequence>
       <Sequence from={120} durationInFrames={120}>
-        <OffthreadVideo src="https://example.com/video2.mp4" />
+        <Video src="https://example.com/video2.mp4" />
       </Sequence>
     </AbsoluteFill>
   );
@@ -37,15 +38,11 @@ This effect is only happening in the Remotion Studio and the Remotion Player, an
 
 ### Option 2: Pause the `<Player />` when media is buffering
 
-<strong style={{color: 'var(--ifm-color-primary)'}}>Recommended</strong>: This will become the default behavior in Remotion 5.0
+<strong style={{color: 'var(--ifm-color-primary)'}}>Recommended</strong>: This behavior is enabled by default for [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media).
 
 You may want to pause the `<Player>` temporarily to allow loading of the assets and resume once the assets are ready for playback.
 
-You can do so by adding a `pauseWhenBuffering` prop to your [`<Html5Video>`](/docs/html5-video/#pausewhenbuffering), [`<OffthreadVideo>`](/docs/offthreadvideo/#pausewhenbuffering), [`<Html5Audio>`](/docs/html5-audio/#pausewhenbuffering) and [`<Img>`](/docs/img#pausewhenloading) tags. [Learn more about the buffer state.](/docs/player/buffer-state)
-
-:::note
-The `pauseWhenBuffering` prop is enabled by default for [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media).
-:::
+If you use older media tags, add a `pauseWhenBuffering` prop to your [`<Html5Video>`](/docs/html5-video/#pausewhenbuffering), [`<OffthreadVideo>`](/docs/offthreadvideo/#pausewhenbuffering), or [`<Html5Audio>`](/docs/html5-audio/#pausewhenbuffering) tags. For images, add [`pauseWhenLoading`](/docs/img#pausewhenloading) to [`<Img>`](/docs/img). [Learn more about the buffer state.](/docs/player/buffer-state)
 
 ### Option 3: Premounting the video<AvailableFrom v="4.0.140"/>
 

--- a/packages/docs/docs/video-uploads.mdx
+++ b/packages/docs/docs/video-uploads.mdx
@@ -5,18 +5,19 @@ title: Handling user video uploads
 crumb: 'Building video apps'
 ---
 
-In an app where users can upload videos and edit them, we can create a better user experience by loading the video into a player even before the upload is finished. Good news: This can be done pretty easily!
+In an app where users can upload videos and edit them, we can create a better user experience by loading the video into a player even before the upload is finished.
 
 ## Allowing user uploads
 
-We have a component which returns a [`<OffthreadVideo>`](/docs/offthreadvideo) tag that includes an URL as source.
+Start with a component that renders a [`<Video>`](/docs/media/video) from [`@remotion/media`](/docs/media) and accepts a URL as its source.
 
 ```tsx twoslash title="MyComposition.tsx"
 const upload = async (file: File) => {
   return 'https://example.com';
 };
 // ---cut---
-import {AbsoluteFill, OffthreadVideo} from 'remotion';
+import {Video} from '@remotion/media';
+import {AbsoluteFill} from 'remotion';
 
 type VideoProps = {
   videoURL: string;
@@ -25,7 +26,7 @@ type VideoProps = {
 export const MyComponent: React.FC<VideoProps> = ({videoURL}) => {
   return (
     <AbsoluteFill>
-      <OffthreadVideo src={videoURL} />
+      <Video src={videoURL} />
     </AbsoluteFill>
   );
 };
@@ -73,11 +74,11 @@ export const RemotionPlayer: React.FC = () => {
 };
 ```
 
-The implementation of the `upload()` function is provider-specific and we do not show an implementation in this article. We assume it is a function that takes a file, uploads it and returns an URL.
+The implementation of the `upload()` function is provider-specific and we do not show an implementation in this article. We assume it is a function that takes a file, uploads it and returns a URL.
 
 ## Optimistic updates
 
-When we start the upload of the file, we can create a blob URL using `URL.createObjectURL()` which can be used to display the local file in a [`<Video>`](/docs/media/video) tag. When the file is done uploading and we get the remote URL, the component shall use remote URL as source.
+When we start the upload of the file, we can create a blob URL using `URL.createObjectURL()` which can be used to display the local file in a [`<Video>`](/docs/media/video) tag. When the file is done uploading and we get the remote URL, the component should use the remote URL as its source.
 
 ```tsx twoslash title="App.tsx"
 const MyComposition: React.FC<{videoUrl: string}> = ({videoUrl}) => {


### PR DESCRIPTION
## Summary

- Update the linked docs examples to use `<Video>` and `<Audio>` from `@remotion/media`
- Reframe the Player flicker guidance so `@remotion/media` buffering behavior is the recommended path
- Keep older media tags mentioned only where they are relevant as alternatives

Part of #8882.

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run build-docs --filter=docs --no-update-notifier`
