### PR TITLE
`@remotion/convert`: Add homepage tool links

### DIFF
--- a/packages/convert/app/components/Footer.tsx
+++ b/packages/convert/app/components/Footer.tsx
@@ -38,64 +38,66 @@ export const Footer: React.FC<{
 	readonly routeAction: RouteAction;
 }> = ({routeAction}) => {
 	return (
-		<div className="lg:flex flex-row items-center">
-			<a
-				className="hidden group lg:flex flex-row items-center ml-[-8px]"
-				target="_blank"
-				href="https://remotion.dev/?utm_source=convert"
-			>
-				<Logo />
-				<div className="w-1" />
-				<div className="opacity-0 transition-opacity duration-200 font-brand text-sm text-muted-foreground group-hover:opacity-100">
-					Remotion
-				</div>
-			</a>
-			<a
-				className="lg:hidden font-medium"
-				target="_blank"
-				href="https://remotion.dev/?utm_source=convert"
-			>
-				<div className="text-sm text-muted-foreground hover:text-foreground">
-					A Remotion Product
-				</div>
-			</a>
-			<div className="flex-1" />
-			{routeAction.type === 'transcribe' ? (
+		<footer className="w-full">
+			<div className="flex flex-col gap-5 lg:flex-row lg:items-center">
 				<a
+					className="hidden group lg:flex flex-row items-center ml-[-8px] shrink-0"
 					target="_blank"
-					href="https://remotion.dev/docs/whisper-web"
-					className="text-sm text-muted-foreground font-medium hover:text-foreground"
+					href="https://remotion.dev/?utm_source=convert"
 				>
-					Powered by @remotion/whisper-web
+					<Logo />
+					<div className="w-1" />
+					<div className="opacity-0 transition-opacity duration-200 font-brand text-sm text-muted-foreground group-hover:opacity-100">
+						Remotion
+					</div>
 				</a>
-			) : (
-				<div className="row flex items-center">
+				<a
+					className="lg:hidden font-medium"
+					target="_blank"
+					href="https://remotion.dev/?utm_source=convert"
+				>
+					<div className="text-sm text-muted-foreground hover:text-foreground">
+						A Remotion Product
+					</div>
+				</a>
+				<div className="hidden lg:block lg:flex-1" />
+				<div className="flex flex-wrap items-center gap-x-5 gap-y-2 lg:justify-end">
+					{routeAction.type === 'transcribe' ? (
+						<a
+							target="_blank"
+							href="https://remotion.dev/docs/whisper-web"
+							className="text-sm text-muted-foreground font-medium hover:text-foreground"
+						>
+							Powered by @remotion/whisper-web
+						</a>
+					) : (
+						<div className="row flex items-center">
+							<a
+								target="_blank"
+								href="https://mediabunny.dev"
+								className="text-sm text-pink-500 font-medium"
+							>
+								Powered by Mediabunny
+							</a>
+							<MediabunnyLogo />
+						</div>
+					)}
 					<a
 						target="_blank"
-						href="https://mediabunny.dev"
-						className="text-sm text-pink-500 font-medium"
+						href="https://remotion.dev/report"
+						className="text-sm text-muted-foreground font-medium hover:text-foreground"
 					>
-						Powered by Mediabunny
+						Report bug
 					</a>
-					<MediabunnyLogo />
+					<a
+						target="_blank"
+						href="https://github.com/remotion-dev/remotion/tree/main/packages/convert"
+						className="text-sm text-muted-foreground font-medium hover:text-foreground"
+					>
+						Source Code
+					</a>
 				</div>
-			)}
-			<div className="w-6" />
-			<a
-				target="_blank"
-				href="https://remotion.dev/report"
-				className="text-sm text-muted-foreground font-medium hover:text-foreground"
-			>
-				Report bug
-			</a>
-			<div className="w-6" />
-			<a
-				target="_blank"
-				href="https://github.com/remotion-dev/remotion/tree/main/packages/convert"
-				className="text-sm text-muted-foreground font-medium hover:text-foreground"
-			>
-				Source Code
-			</a>
-		</div>
+			</div>
+		</footer>
 	);
 };

--- a/packages/convert/app/components/PickFile.tsx
+++ b/packages/convert/app/components/PickFile.tsx
@@ -55,6 +55,11 @@ export const PickFile: React.FC<{
 						{title}
 					</h1>
 				</div>
+				<p className="m-auto max-w-[720px] px-4 font-brand text-base text-slate-600 text-balance">
+					Load MP4, WebM, MOV/ProRes, MKV, MP3, WAV, AAC, FLAC, or HLS streams,
+					then convert, trim, crop, resize, rotate, mirror, probe, or transcribe
+					locally in your browser.
+				</p>
 				<div className="h-4" />
 				<div className="p-4 w-full text-center">
 					<DropFileBox setSrc={setSrc} />
@@ -65,7 +70,7 @@ export const PickFile: React.FC<{
 				<div className="h-10" />
 			</div>
 			<div className="w-full bg-slate-50">
-				<WhyRemotionConvert />
+				<WhyRemotionConvert routeAction={action} />
 			</div>
 		</div>
 	);

--- a/packages/convert/app/components/WhyRemotionConvert.tsx
+++ b/packages/convert/app/components/WhyRemotionConvert.tsx
@@ -1,11 +1,18 @@
 import {Card} from '@remotion/design';
+import clsx from 'clsx';
 import React from 'react';
+import {convertTools, getActiveConvertTool} from '~/lib/convert-tools';
+import type {RouteAction} from '~/seo';
 import {AwesomeIcon} from './AwesomeIcon';
 import {BoltIcon} from './BoltIcon';
 import {Footer} from './Footer';
 import {LockIcon} from './LockIcon';
 
-export const WhyRemotionConvert: React.FC = () => {
+export const WhyRemotionConvert: React.FC<{
+	readonly routeAction: RouteAction;
+}> = ({routeAction}) => {
+	const activeTool = getActiveConvertTool(routeAction);
+
 	return (
 		<div className="text-left lg:text-center px-8 block m-auto">
 			<h2 className="font-brand text-xl font-bold mt-14">
@@ -60,8 +67,50 @@ export const WhyRemotionConvert: React.FC = () => {
 						</div>
 					</Card>
 				</div>
+				<div className="h-14" />
+				<div className="m-auto max-w-[760px] text-left">
+					<nav aria-label="Remotion tools" className="grid grid-cols-1 gap-y-2">
+						<div>
+							<a
+								href="https://remotion.dev/?utm_source=convert"
+								target="_blank"
+								className="font-brand text-sm leading-6 text-slate-600 transition-colors hover:text-brand"
+							>
+								<span className="font-bold text-foreground">remotion.dev</span>
+								{' - '}Make videos programmatically
+							</a>
+						</div>
+						{convertTools.map((tool) => {
+							const active = tool.key === activeTool;
+
+							return (
+								<div key={tool.key}>
+									<a
+										href={tool.href}
+										aria-current={active ? 'page' : undefined}
+										className={clsx(
+											'font-brand text-sm leading-6 text-slate-600 transition-colors hover:text-brand',
+											active && 'text-brand',
+										)}
+									>
+										<span
+											className={clsx(
+												'font-bold',
+												active ? 'text-brand' : 'text-foreground',
+											)}
+										>
+											{tool.displayUrl}
+										</span>
+										{' - '}
+										{tool.description}
+									</a>
+								</div>
+							);
+						})}
+					</nav>
+				</div>
 				<div className="h-20" />
-				<Footer routeAction={{type: 'generic-convert'}} />
+				<Footer routeAction={routeAction} />
 			</div>
 			<div className="h-10" />
 		</div>

--- a/packages/convert/app/lib/convert-tools.ts
+++ b/packages/convert/app/lib/convert-tools.ts
@@ -1,0 +1,136 @@
+import type {RouteAction} from '~/seo';
+
+export type ConvertToolKey =
+	| 'convert'
+	| 'trim'
+	| 'crop'
+	| 'resize'
+	| 'rotate'
+	| 'mirror'
+	| 'probe'
+	| 'transcribe';
+
+export const convertTools: {
+	readonly key: ConvertToolKey;
+	readonly label: string;
+	readonly displayUrl: string;
+	readonly href: string;
+	readonly description: string;
+}[] = [
+	{
+		key: 'convert',
+		label: 'Convert',
+		displayUrl: 'remotion.dev/convert',
+		href: '/convert',
+		description: 'Convert videos in the browser',
+	},
+	{
+		key: 'trim',
+		label: 'Trim',
+		displayUrl: 'remotion.dev/trim',
+		href: '/trim',
+		description: 'Trim videos in the browser',
+	},
+	{
+		key: 'crop',
+		label: 'Crop',
+		displayUrl: 'remotion.dev/crop',
+		href: '/crop',
+		description: 'Crop videos in the browser',
+	},
+	{
+		key: 'resize',
+		label: 'Resize',
+		displayUrl: 'remotion.dev/resize',
+		href: '/resize',
+		description: 'Resize videos in the browser',
+	},
+	{
+		key: 'rotate',
+		label: 'Rotate',
+		displayUrl: 'remotion.dev/rotate',
+		href: '/rotate',
+		description: 'Rotate videos in the browser',
+	},
+	{
+		key: 'mirror',
+		label: 'Mirror',
+		displayUrl: 'remotion.dev/mirror',
+		href: '/mirror',
+		description: 'Mirror videos in the browser',
+	},
+	{
+		key: 'probe',
+		label: 'Probe',
+		displayUrl: 'remotion.dev/probe',
+		href: '/probe',
+		description: 'Inspect video metadata in the browser',
+	},
+	{
+		key: 'transcribe',
+		label: 'Transcribe',
+		displayUrl: 'remotion.dev/transcribe',
+		href: '/transcribe',
+		description: 'Transcribe audio and video in the browser',
+	},
+];
+
+export const getActiveConvertTool = (
+	routeAction: RouteAction,
+): ConvertToolKey | null => {
+	if (
+		routeAction.type === 'convert' ||
+		routeAction.type === 'generic-convert'
+	) {
+		return 'convert';
+	}
+
+	if (
+		routeAction.type === 'generic-trim' ||
+		routeAction.type === 'trim-format'
+	) {
+		return 'trim';
+	}
+
+	if (
+		routeAction.type === 'generic-crop' ||
+		routeAction.type === 'crop-format'
+	) {
+		return 'crop';
+	}
+
+	if (
+		routeAction.type === 'generic-resize' ||
+		routeAction.type === 'resize-format'
+	) {
+		return 'resize';
+	}
+
+	if (
+		routeAction.type === 'generic-rotate' ||
+		routeAction.type === 'rotate-format'
+	) {
+		return 'rotate';
+	}
+
+	if (
+		routeAction.type === 'generic-mirror' ||
+		routeAction.type === 'mirror-format'
+	) {
+		return 'mirror';
+	}
+
+	if (routeAction.type === 'generic-probe') {
+		return 'probe';
+	}
+
+	if (routeAction.type === 'transcribe') {
+		return 'transcribe';
+	}
+
+	if (routeAction.type === 'report' || routeAction.type === 'timing-editor') {
+		return null;
+	}
+
+	throw new Error(`Invalid route action ${routeAction satisfies never}`);
+};

--- a/packages/convert/app/root.tsx
+++ b/packages/convert/app/root.tsx
@@ -2,6 +2,9 @@ import {Links, Outlet, Scripts, ScrollRestoration} from '@remix-run/react';
 import {ForceSpecificCursor} from './components/crop-ui/force-specific-cursor';
 import './tailwind.css';
 import {DEFAULT_FAVICON} from './lib/default-favicon';
+import {getDescription} from './seo';
+
+const defaultDescription = getDescription({type: 'generic-convert'});
 
 export const Layout = ({children}: {readonly children: React.ReactNode}) => {
 	return (
@@ -10,7 +13,7 @@ export const Layout = ({children}: {readonly children: React.ReactNode}) => {
 				<meta charSet="utf-8" />
 				<meta name="viewport" content="width=device-width, initial-scale=1" />
 				<title>Remotion Convert</title>
-				<meta name="description" content="Remotion Convert" />
+				<meta name="description" content={defaultDescription} />
 				<link rel="icon" href={DEFAULT_FAVICON} />
 				<link
 					rel="manifest"

--- a/packages/convert/app/seo.ts
+++ b/packages/convert/app/seo.ts
@@ -225,7 +225,7 @@ export const getPageTitle = (routeAction: RouteAction) => {
 
 export const getDescription = (routeAction: RouteAction) => {
 	if (routeAction.type === 'generic-convert') {
-		return 'The fastest online video converter, powered by WebCodecs. No upload required, no watermarks, no limits.';
+		return 'Convert MP4, WebM, MOV, MKV, ProRes, HLS streams, MP3, WAV, AAC, and FLAC in your browser. No upload required, no watermarks, no limits.';
 	}
 
 	if (routeAction.type === 'convert') {

--- a/packages/convert/test/convert-tools.test.ts
+++ b/packages/convert/test/convert-tools.test.ts
@@ -1,0 +1,49 @@
+import {expect, test} from 'bun:test';
+import {convertTools, getActiveConvertTool} from '../app/lib/convert-tools';
+
+test('lists every public Remotion Convert tool in the tool directory', () => {
+	expect(convertTools.map((tool) => tool.href)).toEqual([
+		'/convert',
+		'/trim',
+		'/crop',
+		'/resize',
+		'/rotate',
+		'/mirror',
+		'/probe',
+		'/transcribe',
+	]);
+});
+
+test('marks generic and format-specific tool routes as active', () => {
+	expect(getActiveConvertTool({type: 'generic-convert'})).toBe('convert');
+	expect(
+		getActiveConvertTool({type: 'convert', input: 'mp4', output: 'webm'}),
+	).toBe('convert');
+	expect(getActiveConvertTool({type: 'generic-trim'})).toBe('trim');
+	expect(getActiveConvertTool({type: 'trim-format', format: 'mp4'})).toBe(
+		'trim',
+	);
+	expect(getActiveConvertTool({type: 'generic-crop'})).toBe('crop');
+	expect(getActiveConvertTool({type: 'crop-format', format: 'mov'})).toBe(
+		'crop',
+	);
+	expect(getActiveConvertTool({type: 'generic-resize'})).toBe('resize');
+	expect(getActiveConvertTool({type: 'resize-format', format: 'mp3'})).toBe(
+		'resize',
+	);
+	expect(getActiveConvertTool({type: 'generic-rotate'})).toBe('rotate');
+	expect(getActiveConvertTool({type: 'rotate-format', format: 'webm'})).toBe(
+		'rotate',
+	);
+	expect(getActiveConvertTool({type: 'generic-mirror'})).toBe('mirror');
+	expect(getActiveConvertTool({type: 'mirror-format', format: 'mkv'})).toBe(
+		'mirror',
+	);
+	expect(getActiveConvertTool({type: 'generic-probe'})).toBe('probe');
+	expect(getActiveConvertTool({type: 'transcribe'})).toBe('transcribe');
+});
+
+test('does not mark utility routes as active tools', () => {
+	expect(getActiveConvertTool({type: 'report'})).toBe(null);
+	expect(getActiveConvertTool({type: 'timing-editor'})).toBe(null);
+});

--- a/packages/docs/copy-convert.ts
+++ b/packages/docs/copy-convert.ts
@@ -85,8 +85,7 @@ const getContentWithTitle = (title: string, description: string) => {
 		throw new Error('Could not find title');
 	}
 
-	const descriptionMatcher =
-		'<meta name="description" content="Remotion Convert"/>';
+	const descriptionMatcher = `<meta name="description" content="${seo.getDescription({type: 'generic-convert'})}"/>`;
 	if (!c.includes(descriptionMatcher)) {
 		throw new Error('Could not find description');
 	}


### PR DESCRIPTION
## Summary

- Add a plain-link tool directory to the Remotion Convert homepage
- Highlight the active Convert tool route in the directory
- Mention supported input formats such as HLS streams and ProRes MOVs in homepage/meta copy

Closes #8842
Closes #8843

## Tests

- `bunx oxfmt app test --write` in `packages/convert`
- `bun run build`
- `bun run stylecheck`
