### PR TITLE
`@remotion/skills`: Add dev surface launch skills

### DIFF
--- a/.agents/skills/convert/SKILL.md
+++ b/.agents/skills/convert/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: convert
+description: Start the local @remotion/convert app and open it in the Codex browser. Use when the user invokes /convert or $convert, asks to launch convert.remotion.dev locally, or wants to inspect the Convert package UI.
+---
+
+# Convert App
+
+## Overview
+
+Prepare the Remotion monorepo, launch the Convert app, and open the served URL in the Codex in-app browser.
+
+## Workflow
+
+1. From the repository root, run:
+
+```bash
+bun i && bun run build
+```
+
+2. Start the Convert app:
+
+```bash
+cd packages/convert && bun run dev
+```
+
+3. Keep the server process running and read its output for the local URL. The expected default is `http://localhost:5173`, but follow the printed URL if Vite chooses another port.
+4. Open the URL in the Codex in-app browser. If no browser tool is available yet, use `tool_search` for the in-app browser control tool, then navigate to the local URL.
+5. Tell the user the Convert URL and whether this is a newly started or already running server.

--- a/.agents/skills/convert/agents/openai.yaml
+++ b/.agents/skills/convert/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Convert App"
+  short_description: "Run convert.remotion.dev locally"
+  default_prompt: "Use $convert to build Remotion and open the Convert app locally."

--- a/.agents/skills/docs/SKILL.md
+++ b/.agents/skills/docs/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: docs
+description: Start the Remotion docs site and open it in the Codex browser. Use when the user invokes /docs or $docs, asks to launch the local documentation site, or wants to preview docs changes in Docusaurus.
+---
+
+# Docs Site
+
+## Overview
+
+Prepare the Remotion monorepo, launch the Docusaurus docs site, and open the served URL in the Codex in-app browser.
+
+## Workflow
+
+1. From the repository root, run:
+
+```bash
+bun i && bun run build
+```
+
+2. Start the docs site:
+
+```bash
+cd packages/docs && bun run start
+```
+
+3. Keep the server process running and read its output for the local URL. The expected default is `http://localhost:3000`, but follow the printed URL if Docusaurus chooses or reports another port.
+4. Open the URL in the Codex in-app browser. If no browser tool is available yet, use `tool_search` for the in-app browser control tool, then navigate to the local URL.
+5. Tell the user the docs URL and whether this is a newly started or already running server.

--- a/.agents/skills/docs/agents/openai.yaml
+++ b/.agents/skills/docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Docs Site"
+  short_description: "Run the Remotion docs locally"
+  default_prompt: "Use $docs to build Remotion and open the docs site locally."

--- a/.agents/skills/player-example/SKILL.md
+++ b/.agents/skills/player-example/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: player-example
+description: Start the @remotion/player example app and open it in the Codex browser. Use when the user invokes /player-example or $player-example, asks to launch the player testbed, or wants to inspect @remotion/player locally.
+---
+
+# Player Example
+
+## Overview
+
+Prepare the Remotion monorepo, launch the player example app, and open the served URL in the Codex in-app browser.
+
+## Workflow
+
+1. From the repository root, run:
+
+```bash
+bun i && bun run build
+```
+
+2. Start the player example:
+
+```bash
+cd packages/player-example && bun run dev
+```
+
+3. Keep the server process running and read its output for the local URL. The expected default is `http://localhost:3000`, but follow the printed URL if Next.js chooses another port.
+4. Open the URL in the Codex in-app browser. If no browser tool is available yet, use `tool_search` for the in-app browser control tool, then navigate to the local URL.
+5. Tell the user the player example URL and whether this is a newly started or already running server.

--- a/.agents/skills/player-example/agents/openai.yaml
+++ b/.agents/skills/player-example/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Player Example"
+  short_description: "Run the player example locally"
+  default_prompt: "Use $player-example to build Remotion and open the player example locally."

--- a/.agents/skills/studio/SKILL.md
+++ b/.agents/skills/studio/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: studio
+description: Start Remotion Studio from packages/example and open it in the Codex browser. Use when the user invokes /studio or $studio, asks to launch the example Studio, or wants the Remotion Studio dev UI available locally.
+---
+
+# Remotion Studio
+
+## Overview
+
+Prepare the Remotion monorepo, launch the example Studio, and open the served URL in the Codex in-app browser.
+
+## Workflow
+
+1. From the repository root, run:
+
+```bash
+bun i && bun run build
+```
+
+2. Start Studio from the example package:
+
+```bash
+cd packages/example && bunx remotion studio
+```
+
+Use `bunx`, not `npx`.
+
+3. Keep the server process running and read its output for the local URL. The expected default is `http://localhost:3000`, but follow the printed URL if Remotion chooses another port.
+4. If the output says the server is already running on port 3000, confirm it with `curl http://localhost:3000` and open that URL if it responds.
+5. Open the URL in the Codex in-app browser. If no browser tool is available yet, use `tool_search` for the in-app browser control tool, then navigate to the local URL.
+6. Tell the user the Studio URL and whether this is a newly started or already running server.

--- a/.agents/skills/studio/agents/openai.yaml
+++ b/.agents/skills/studio/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Remotion Studio"
+  short_description: "Start example Studio in browser"
+  default_prompt: "Use $studio to build Remotion and open the example Studio."


### PR DESCRIPTION
## Summary

- Add `/studio`, `/convert`, `/player-example`, and `/docs` repo-local Codex skills
- Include `agents/openai.yaml` metadata for each new skill
- Document the install, build, server startup, and Codex browser-opening workflow for each surface

## Testing

- `python3 /Users/jonathanburger/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/studio`
- `python3 /Users/jonathanburger/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/convert`
- `python3 /Users/jonathanburger/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/player-example`
- `python3 /Users/jonathanburger/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/docs`
- `bun run build`
- `bun run stylecheck`
