### PR TITLE
`@remotion/studio`: Type drag MIME classifications

### DIFF
--- a/packages/studio-shared/src/asset-drag-data.ts
+++ b/packages/studio-shared/src/asset-drag-data.ts
@@ -1,4 +1,4 @@
-export const ASSET_DRAG_MIME_TYPE = 'application/vnd.remotion.asset+json';
+export {ASSET_DRAG_MIME_TYPE} from './drag-mime-types';
 
 export type AssetDragData = {
 	type: 'remotion-asset';

--- a/packages/studio-shared/src/component-drag-data.ts
+++ b/packages/studio-shared/src/component-drag-data.ts
@@ -1,5 +1,4 @@
-export const COMPONENT_DRAG_MIME_TYPE =
-	'application/vnd.remotion.component+json';
+export {COMPONENT_DRAG_MIME_TYPE} from './drag-mime-types';
 
 export type ComponentProp = {
 	name: string;

--- a/packages/studio-shared/src/composition-drag-data.ts
+++ b/packages/studio-shared/src/composition-drag-data.ts
@@ -1,5 +1,4 @@
-export const COMPOSITION_DRAG_MIME_TYPE =
-	'application/vnd.remotion.composition+json';
+export {COMPOSITION_DRAG_MIME_TYPE} from './drag-mime-types';
 
 export type CompositionDragData = {
 	type: 'remotion-composition';

--- a/packages/studio-shared/src/drag-mime-types.ts
+++ b/packages/studio-shared/src/drag-mime-types.ts
@@ -1,0 +1,25 @@
+export const ASSET_DRAG_MIME_TYPE = 'application/vnd.remotion.asset+json';
+export const COMPONENT_DRAG_MIME_TYPE =
+	'application/vnd.remotion.component+json';
+export const COMPOSITION_DRAG_MIME_TYPE =
+	'application/vnd.remotion.composition+json';
+export const EFFECT_DRAG_MIME_TYPE = 'application/vnd.remotion.effect+json';
+export const ELEMENT_DRAG_MIME_TYPE = 'application/vnd.remotion.element+json';
+export const SFX_DRAG_MIME_TYPE = 'application/vnd.remotion.sfx+json';
+
+export const REMOTION_DRAG_MIME_TYPES = [
+	ASSET_DRAG_MIME_TYPE,
+	COMPONENT_DRAG_MIME_TYPE,
+	COMPOSITION_DRAG_MIME_TYPE,
+	EFFECT_DRAG_MIME_TYPE,
+	ELEMENT_DRAG_MIME_TYPE,
+	SFX_DRAG_MIME_TYPE,
+] as const;
+
+export type RemotionDragMimeType = (typeof REMOTION_DRAG_MIME_TYPES)[number];
+
+export const isRemotionDragMimeType = (
+	type: string,
+): type is RemotionDragMimeType => {
+	return REMOTION_DRAG_MIME_TYPES.some((mimeType) => mimeType === type);
+};

--- a/packages/studio-shared/src/effect-drag-data.ts
+++ b/packages/studio-shared/src/effect-drag-data.ts
@@ -1,4 +1,4 @@
-export const EFFECT_DRAG_MIME_TYPE = 'application/vnd.remotion.effect+json';
+export {EFFECT_DRAG_MIME_TYPE} from './drag-mime-types';
 
 export type EffectDragData = {
 	type: 'remotion-effect';

--- a/packages/studio-shared/src/element-drag-data.ts
+++ b/packages/studio-shared/src/element-drag-data.ts
@@ -3,7 +3,7 @@ import {
 	type ComponentDimensions,
 } from './component-drag-data';
 
-export const ELEMENT_DRAG_MIME_TYPE = 'application/vnd.remotion.element+json';
+export {ELEMENT_DRAG_MIME_TYPE} from './drag-mime-types';
 
 export type ElementDragData = {
 	type: 'remotion-element';

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -141,6 +141,11 @@ export {
 	type ImageFileType,
 } from './detect-file-type';
 export {
+	isRemotionDragMimeType,
+	REMOTION_DRAG_MIME_TYPES,
+	type RemotionDragMimeType,
+} from './drag-mime-types';
+export {
 	parseEasingClipboardData,
 	parseEasingClipboardDataResult,
 	type EasingClipboardData,

--- a/packages/studio-shared/src/sfx-drag-data.ts
+++ b/packages/studio-shared/src/sfx-drag-data.ts
@@ -1,6 +1,6 @@
 import {isUrl} from './url';
 
-export const SFX_DRAG_MIME_TYPE = 'application/vnd.remotion.sfx+json';
+export {SFX_DRAG_MIME_TYPE} from './drag-mime-types';
 
 export type SfxDragData = {
 	type: 'remotion-sfx';

--- a/packages/studio/src/components/effect-drag-and-drop.ts
+++ b/packages/studio/src/components/effect-drag-and-drop.ts
@@ -3,6 +3,7 @@ import {
 	COMPOSITION_DRAG_MIME_TYPE,
 	COMPONENT_DRAG_MIME_TYPE,
 	EFFECT_DRAG_MIME_TYPE,
+	ELEMENT_DRAG_MIME_TYPE,
 	getRequiredPackageForEffectImportPath,
 	parseEffectDragData,
 	SFX_DRAG_MIME_TYPE,
@@ -40,6 +41,7 @@ const hasImportableAssetDragType = (dataTransfer: DataTransfer) => {
 			type === ASSET_DRAG_MIME_TYPE ||
 			type === COMPOSITION_DRAG_MIME_TYPE ||
 			type === COMPONENT_DRAG_MIME_TYPE ||
+			type === ELEMENT_DRAG_MIME_TYPE ||
 			type === SFX_DRAG_MIME_TYPE ||
 			type === 'text/uri-list' ||
 			type === 'text/html',

--- a/packages/studio/src/components/effect-drag-and-drop.ts
+++ b/packages/studio/src/components/effect-drag-and-drop.ts
@@ -5,9 +5,11 @@ import {
 	EFFECT_DRAG_MIME_TYPE,
 	ELEMENT_DRAG_MIME_TYPE,
 	getRequiredPackageForEffectImportPath,
+	isRemotionDragMimeType,
 	parseEffectDragData,
 	SFX_DRAG_MIME_TYPE,
 	type EffectDragData,
+	type RemotionDragMimeType,
 } from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey} from 'remotion';
 import {installRequiredPackages} from '../helpers/install-required-package';
@@ -17,7 +19,11 @@ import {showNotification} from './Notifications/NotificationCenter';
 export const hasEffectDragType = (dataTransfer: DataTransfer) => {
 	const types = Array.from(dataTransfer.types);
 	const hasExplicitEffectType = types.includes(EFFECT_DRAG_MIME_TYPE);
-	if (!hasExplicitEffectType && hasImportableAssetDragType(dataTransfer)) {
+	if (
+		!hasExplicitEffectType &&
+		(hasNonEffectRemotionDragType(dataTransfer) ||
+			hasNonRemotionImportableAssetDragType(dataTransfer))
+	) {
 		return false;
 	}
 
@@ -34,18 +40,36 @@ const isGenericDragType = (type: string) => {
 	return type === 'application/json' || type === 'text/plain';
 };
 
-const hasImportableAssetDragType = (dataTransfer: DataTransfer) => {
-	return Array.from(dataTransfer.types).some(
-		(type) =>
-			type === 'Files' ||
-			type === ASSET_DRAG_MIME_TYPE ||
-			type === COMPOSITION_DRAG_MIME_TYPE ||
-			type === COMPONENT_DRAG_MIME_TYPE ||
-			type === ELEMENT_DRAG_MIME_TYPE ||
-			type === SFX_DRAG_MIME_TYPE ||
-			type === 'text/uri-list' ||
-			type === 'text/html',
-	);
+const isNonEffectRemotionDragType = (mimeType: RemotionDragMimeType) => {
+	switch (mimeType) {
+		case EFFECT_DRAG_MIME_TYPE:
+			return false;
+		case ASSET_DRAG_MIME_TYPE:
+		case COMPOSITION_DRAG_MIME_TYPE:
+		case COMPONENT_DRAG_MIME_TYPE:
+		case ELEMENT_DRAG_MIME_TYPE:
+		case SFX_DRAG_MIME_TYPE:
+			return true;
+		default:
+			mimeType satisfies never;
+			throw new Error(`Unhandled Remotion drag MIME type: ${mimeType}`);
+	}
+};
+
+const hasNonEffectRemotionDragType = (dataTransfer: DataTransfer) => {
+	return Array.from(dataTransfer.types).some((type) => {
+		if (!isRemotionDragMimeType(type)) {
+			return false;
+		}
+
+		return isNonEffectRemotionDragType(type);
+	});
+};
+
+const hasNonRemotionImportableAssetDragType = (dataTransfer: DataTransfer) => {
+	return Array.from(dataTransfer.types).some((type) => {
+		return type === 'Files' || type === 'text/uri-list' || type === 'text/html';
+	});
 };
 
 export const getEffectDragData = (

--- a/packages/studio/src/test/effect-drag-and-drop.test.ts
+++ b/packages/studio/src/test/effect-drag-and-drop.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'bun:test';
 import {
 	ASSET_DRAG_MIME_TYPE,
 	EFFECT_DRAG_MIME_TYPE,
+	ELEMENT_DRAG_MIME_TYPE,
 	type EffectDragData,
 } from '@remotion/studio-shared';
 import {
@@ -61,6 +62,16 @@ test('does not treat asset imports as effect drags', () => {
 		hasEffectDragType(
 			makeDataTransfer({
 				types: [ASSET_DRAG_MIME_TYPE, 'application/json', 'text/plain'],
+			}),
+		),
+	).toBe(false);
+});
+
+test('does not treat element imports as effect drags', () => {
+	expect(
+		hasEffectDragType(
+			makeDataTransfer({
+				types: [ELEMENT_DRAG_MIME_TYPE, 'application/json', 'text/plain'],
 			}),
 		),
 	).toBe(false);

--- a/packages/studio/src/test/effect-drag-and-drop.test.ts
+++ b/packages/studio/src/test/effect-drag-and-drop.test.ts
@@ -1,9 +1,13 @@
 import {expect, test} from 'bun:test';
 import {
 	ASSET_DRAG_MIME_TYPE,
+	COMPOSITION_DRAG_MIME_TYPE,
+	COMPONENT_DRAG_MIME_TYPE,
 	EFFECT_DRAG_MIME_TYPE,
 	ELEMENT_DRAG_MIME_TYPE,
+	SFX_DRAG_MIME_TYPE,
 	type EffectDragData,
+	type RemotionDragMimeType,
 } from '@remotion/studio-shared';
 import {
 	getEffectDragData,
@@ -57,25 +61,25 @@ test('keeps generic effect drag fallback', () => {
 	expect(getEffectDragData(dataTransfer)).toEqual(effectDragData);
 });
 
-test('does not treat asset imports as effect drags', () => {
-	expect(
-		hasEffectDragType(
-			makeDataTransfer({
-				types: [ASSET_DRAG_MIME_TYPE, 'application/json', 'text/plain'],
-			}),
-		),
-	).toBe(false);
-});
+const nonEffectRemotionDragMimeTypes = [
+	['asset', ASSET_DRAG_MIME_TYPE],
+	['component', COMPONENT_DRAG_MIME_TYPE],
+	['composition', COMPOSITION_DRAG_MIME_TYPE],
+	['element', ELEMENT_DRAG_MIME_TYPE],
+	['sfx', SFX_DRAG_MIME_TYPE],
+] satisfies readonly (readonly [string, RemotionDragMimeType])[];
 
-test('does not treat element imports as effect drags', () => {
-	expect(
-		hasEffectDragType(
-			makeDataTransfer({
-				types: [ELEMENT_DRAG_MIME_TYPE, 'application/json', 'text/plain'],
-			}),
-		),
-	).toBe(false);
-});
+for (const [label, mimeType] of nonEffectRemotionDragMimeTypes) {
+	test(`does not treat ${label} imports as effect drags`, () => {
+		expect(
+			hasEffectDragType(
+				makeDataTransfer({
+					types: [mimeType, 'application/json', 'text/plain'],
+				}),
+			),
+		).toBe(false);
+	});
+}
 
 test('does not treat remote asset imports as effect drags', () => {
 	expect(


### PR DESCRIPTION
## Summary

- Add a typed source of truth for Remotion drag MIME types
- Make effect drag classification exhaustively handle every Remotion drag MIME type
- Cover all non-effect Remotion drags that also carry generic JSON/plaintext types

## Testing

- `bun test src/test/effect-drag-and-drop.test.ts`
- `bunx turbo run make --filter='@remotion/studio-shared' --filter='@remotion/studio'`
- `bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`

Closes #8794
