### PR TITLE
`@remotion/studio`: Align visual controls in inspector

### DIFF
--- a/packages/docs/docs/licensing/index.mdx
+++ b/packages/docs/docs/licensing/index.mdx
@@ -44,7 +44,7 @@ For Remotion for Creators (seat-based licensing), telemetry reporting is optiona
 
 ### How do I sign up for a Remotion license/account?
 
-Signing up is only required if you fall under the requirements of the [Company License](/docs/pricing). If you are eligible for the Free License, you do not need an account.
+Signing up is only required if you fall under the requirements of the [Company License](/docs/license/pricing). If you are eligible for the Free License, you do not need an account.
 
 To create an account:
 

--- a/packages/studio/src/components/RenderModal/SchemaEditor/Fieldset.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/Fieldset.tsx
@@ -6,6 +6,11 @@ export const getSchemaEditorFieldsetPadding = () => {
 	return SCHEMA_EDITOR_FIELDSET_PADDING;
 };
 
+export const getSchemaEditorRootInset = (contentInset: number) => {
+	const fieldsetPadding = getSchemaEditorFieldsetPadding();
+	return Math.max(0, contentInset - fieldsetPadding);
+};
+
 type AlreadyPaddedContext = boolean;
 
 const AlreadyPaddedRightContext = createContext<AlreadyPaddedContext>(false);

--- a/packages/studio/src/components/RenderModal/SchemaEditor/SchemaEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/SchemaEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {useZodIfPossible} from '../../get-zod-if-possible';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../../Menu/is-menu-item';
-import {getSchemaEditorFieldsetPadding} from './Fieldset';
+import {getSchemaEditorRootInset} from './Fieldset';
 import {TopLevelZodValue, type SchemaErrorMode} from './SchemaErrorMessages';
 import {defaultPropsEditorScrollableAreaRef} from './scroll-to-default-props-path';
 import type {AnyZodSchema} from './zod-schema-type';
@@ -33,8 +33,7 @@ const getContainerStyle = ({
 		return base;
 	}
 
-	const fieldsetPadding = getSchemaEditorFieldsetPadding();
-	const rootInset = Math.max(0, contentInset - fieldsetPadding);
+	const rootInset = getSchemaEditorRootInset(contentInset);
 
 	return {
 		...base,

--- a/packages/studio/src/components/VisualControls/ClickableFileName.tsx
+++ b/packages/studio/src/components/VisualControls/ClickableFileName.tsx
@@ -2,7 +2,7 @@ import {useCallback, useMemo, useState} from 'react';
 import type {OriginalPosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {BORDER_WHITE, LIGHT_COLOR, WHITE_HEX} from '../../helpers/colors';
 import {openOriginalPositionInEditor} from '../../helpers/open-in-editor';
-import {SCHEMA_EDITOR_FIELDSET_PADDING} from '../RenderModal/SchemaEditor/Fieldset';
+import {getSchemaEditorFieldsetPadding} from '../RenderModal/SchemaEditor/Fieldset';
 import {getOriginalSourceAttribution} from '../Timeline/TimelineStack/source-attribution';
 
 export type OriginalFileNameState =
@@ -19,8 +19,8 @@ export type OriginalFileNameState =
 	  };
 
 const container: React.CSSProperties = {
-	paddingLeft: SCHEMA_EDITOR_FIELDSET_PADDING,
-	paddingTop: SCHEMA_EDITOR_FIELDSET_PADDING / 2,
+	paddingLeft: getSchemaEditorFieldsetPadding(),
+	paddingTop: getSchemaEditorFieldsetPadding() / 2,
 };
 
 export const ClickableFileName = ({

--- a/packages/studio/src/components/VisualControls/VisualControlsContent.tsx
+++ b/packages/studio/src/components/VisualControls/VisualControlsContent.tsx
@@ -1,7 +1,17 @@
 import React, {useContext} from 'react';
 import {VisualControlsContext} from '../../visual-controls/VisualControls';
+import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
+import {getSchemaEditorRootInset} from '../RenderModal/SchemaEditor/Fieldset';
 import {SchemaSeparationLine} from '../RenderModal/SchemaEditor/SchemaSeparationLine';
 import {VisualControlHandle} from './VisualControlHandle';
+
+const rootInset = getSchemaEditorRootInset(INSPECTOR_PANEL_HORIZONTAL_PADDING);
+
+const container: React.CSSProperties = {
+	boxSizing: 'border-box',
+	paddingLeft: rootInset,
+	paddingRight: rootInset,
+};
 
 export const VisualControlsContent = () => {
 	const {handles} = useContext(VisualControlsContext);
@@ -13,7 +23,7 @@ export const VisualControlsContent = () => {
 	}
 
 	return (
-		<div>
+		<div style={container}>
 			{entries.map(([key, value], i) => {
 				return (
 					<React.Fragment key={key}>


### PR DESCRIPTION
## Summary

- Align the Visual Controls inspector content with the Default Props editor.
- Share the schema editor root inset calculation so the two sections stay in sync when field padding changes.

## Testing

- `cd packages/studio && bunx oxfmt src --write`
- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`
