### PR TITLE
`@remotion/cli`: Migrate more options to option system

### DIFF
--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -1,5 +1,8 @@
+import {BrowserSafeApis} from '@remotion/renderer/client';
 import {Config} from './config';
 import {parsedCli} from './parsed-cli';
+
+const {licenseKeyOption} = BrowserSafeApis.options;
 
 export const parseCommandLine = () => {
 	if (parsedCli.png) {
@@ -8,10 +11,10 @@ export const parseCommandLine = () => {
 		);
 	}
 
-	if (
-		parsedCli['license-key'] &&
-		parsedCli['license-key'].startsWith('rm_pub_')
-	) {
-		Config.setPublicLicenseKey(parsedCli['license-key']);
+	const {value: licenseKey, source} = licenseKeyOption.getValue({
+		commandLine: parsedCli,
+	});
+	if (source === 'cli' && licenseKey?.startsWith('rm_pub_')) {
+		Config.setPublicLicenseKey(licenseKey);
 	}
 };

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -62,6 +62,7 @@ const {
 	overrideDurationOption,
 	bundleCacheOption,
 	sampleRateOption,
+	stillFrameOption,
 } = BrowserSafeApis.options;
 
 export const render = async (
@@ -93,7 +94,7 @@ export const render = async (
 
 	const fullEntryPoint = convertEntryPointToServeUrl(file);
 
-	if (parsedCli.frame) {
+	if (stillFrameOption.getValue({commandLine: parsedCli}).source === 'cli') {
 		Log.error(
 			{indent: false, logLevel},
 			'--frame flag was passed to the `render` command. This flag only works with the `still` command. Did you mean `--frames`? See reference: https://www.remotion.dev/docs/cli/',

--- a/packages/cli/src/still.ts
+++ b/packages/cli/src/still.ts
@@ -40,6 +40,7 @@ const {
 	overrideFpsOption,
 	overrideDurationOption,
 	bundleCacheOption,
+	framesOption,
 } = BrowserSafeApis.options;
 
 export const still = async (
@@ -71,7 +72,7 @@ export const still = async (
 
 	const fullEntryPoint = convertEntryPointToServeUrl(file);
 
-	if (parsedCli.frames) {
+	if (framesOption.getValue({commandLine: parsedCli}).source === 'cli') {
 		Log.error(
 			{indent: false, logLevel},
 			'--frames flag was passed to the `still` command. This flag only works with the `render` command. Did you mean `--frame`? See reference: https://www.remotion.dev/docs/cli/',

--- a/packages/cloudrun/src/cli/commands/render/index.ts
+++ b/packages/cloudrun/src/cli/commands/render/index.ts
@@ -51,6 +51,7 @@ const {
 	overrideFpsOption,
 	overrideDurationOption,
 	sampleRateOption,
+	concurrencyOption,
 } = BrowserSafeApis.options;
 
 export const renderCommand = async (
@@ -108,6 +109,9 @@ export const renderCommand = async (
 	const durationInFrames = overrideDurationOption.getValue({
 		commandLine: CliInternals.parsedCli,
 	}).value;
+	const concurrency = concurrencyOption.getValue({
+		commandLine: CliInternals.parsedCli,
+	});
 
 	const pixelFormat = pixelFormatOption.getValue({
 		commandLine: CliInternals.parsedCli,
@@ -385,7 +389,7 @@ ${downloadName ? `		Downloaded File = ${downloadName}` : ''}
 		delayRenderTimeoutInMilliseconds: puppeteerTimeout,
 		// Special case: Should not use default local concurrency, or from
 		// config file, just when explicitly set
-		concurrency: CliInternals.parsedCli.concurrency ?? null,
+		concurrency: concurrency.source === 'cli' ? concurrency.value : null,
 		enforceAudioTrack,
 		preferLossless: false,
 		offthreadVideoCacheSizeInBytes,


### PR DESCRIPTION
## Summary

- Route the `render`/`still` wrong-command flag checks through existing option objects.
- Resolve legacy `--license-key=rm_pub_...` handling through `licenseKeyOption`.
- Use `concurrencyOption` for Cloud Run render while preserving the existing CLI-only behavior.

## Validation

- `bunx oxfmt src --write` in `packages/cli`
- `bunx oxfmt src --write` in `packages/cloudrun`
- `bun run build`
- `bun run stylecheck`

Refs #8940
