### PR TITLE
Docs: Keep effects demo preview sticky

### DIFF
--- a/packages/docs/components/effects-demos/index.tsx
+++ b/packages/docs/components/effects-demos/index.tsx
@@ -2,6 +2,7 @@ import {useColorMode} from '@docusaurus/theme-common';
 import {Player} from '@remotion/player';
 import React, {useCallback, useMemo, useState} from 'react';
 import {AbsoluteFill} from 'remotion';
+import controlStyles from '../demos/styles.module.css';
 import {
 	makeEffectDragData,
 	setEffectDragData,
@@ -14,27 +15,7 @@ import {
 } from './get-default-props-from-schema';
 import {effectsDemos} from './registry';
 import {SchemaControl} from './schema-control';
-import styles from '../demos/styles.module.css';
-
-const container: React.CSSProperties = {
-	overflow: 'hidden',
-	width: '100%',
-	border: '1px solid var(--ifm-color-emphasis-300)',
-	borderRadius: 'var(--ifm-pre-border-radius)',
-	marginBottom: 40,
-};
-
-const dragHandle: React.CSSProperties = {
-	alignItems: 'center',
-	borderBottom: '1px solid var(--ifm-color-emphasis-300)',
-	cursor: 'grab',
-	display: 'flex',
-	fontSize: 13,
-	fontWeight: 600,
-	gap: 6,
-	padding: '8px 10px',
-	userSelect: 'none',
-};
+import styles from './styles.module.css';
 
 export const EffectsDemo: React.FC<{
 	readonly type: string;
@@ -87,65 +68,73 @@ export const EffectsDemo: React.FC<{
 	);
 
 	return (
-		<div style={container}>
-			<Player
-				key={key}
-				acknowledgeRemotionLicense
-				component={demo.comp}
-				compositionWidth={demo.compWidth}
-				compositionHeight={demo.compHeight}
-				durationInFrames={demo.durationInFrames}
-				fps={demo.fps}
-				style={{
-					width: '100%',
-					aspectRatio: demo.compWidth / demo.compHeight,
-					borderBottom:
-						activeFields.length > 0
-							? '1px solid var(--ifm-color-emphasis-300)'
-							: 0,
-				}}
-				logLevel={demo.logLevel}
-				errorFallback={({error}) => {
-					return (
-						<AbsoluteFill
-							style={{
-								justifyContent: 'center',
-								alignItems: 'center',
-								fontSize: 30,
-								textAlign: 'center',
-								lineHeight: 1.5,
-							}}
-						>
-							{error.message}
-							<br />
-							<button
-								style={{
-									fontSize: 30,
-								}}
-								onClick={restart}
-								type="button"
-							>
-								Restart
-							</button>
-						</AbsoluteFill>
-					);
-				}}
-				inputProps={{...state, darkMode: colorMode === 'dark'}}
-				autoPlay={demo.autoPlay}
-				controls={demo.controls}
-				initiallyMuted
-				loop
-			/>
-			<div
-				draggable
-				onDragStart={onDragStart}
-				style={dragHandle}
-				title="Drag this effect into Remotion Studio"
-			>
-				<span aria-hidden="true">::</span>
-				<span>Drag current effect onto a layer in the Studio</span>
+		<div className={styles.container}>
+			<div className={styles.preview}>
+				<div
+					className={styles.playerShell}
+					style={{
+						borderBottom:
+							activeFields.length > 0
+								? '1px solid var(--ifm-color-emphasis-300)'
+								: 0,
+					}}
+				>
+					<Player
+						key={key}
+						acknowledgeRemotionLicense
+						component={demo.comp}
+						compositionWidth={demo.compWidth}
+						compositionHeight={demo.compHeight}
+						durationInFrames={demo.durationInFrames}
+						fps={demo.fps}
+						style={{
+							width: '100%',
+							aspectRatio: demo.compWidth / demo.compHeight,
+						}}
+						logLevel={demo.logLevel}
+						errorFallback={({error}) => {
+							return (
+								<AbsoluteFill
+									style={{
+										justifyContent: 'center',
+										alignItems: 'center',
+										fontSize: 30,
+										textAlign: 'center',
+										lineHeight: 1.5,
+									}}
+								>
+									{error.message}
+									<br />
+									<button
+										style={{
+											fontSize: 30,
+										}}
+										onClick={restart}
+										type="button"
+									>
+										Restart
+									</button>
+								</AbsoluteFill>
+							);
+						}}
+						inputProps={{...state, darkMode: colorMode === 'dark'}}
+						autoPlay={demo.autoPlay}
+						controls={demo.controls}
+						initiallyMuted
+						loop
+					/>
+				</div>
+				<div
+					draggable
+					onDragStart={onDragStart}
+					className={styles.dragHandle}
+					title="Drag this effect into Remotion Studio"
+				>
+					<span aria-hidden="true">::</span>
+					<span>Drag current effect onto a layer in the Studio</span>
+				</div>
 			</div>
-			<div className={styles.containerrow}>
+			<div className={`${controlStyles.containerrow} ${styles.controls}`}>
 				{activeFields.map(([fieldKey, field]) => {
 					return (
 						<SchemaControl

--- a/packages/docs/components/effects-demos/styles.module.css
+++ b/packages/docs/components/effects-demos/styles.module.css
@@ -1,0 +1,71 @@
+.container {
+	container-type: inline-size;
+	margin-bottom: 40px;
+	overflow: visible;
+	width: 100%;
+}
+
+.preview {
+	position: sticky;
+	top: calc(var(--ifm-navbar-height, 60px) + 12px);
+	z-index: 1;
+}
+
+.playerShell {
+	background: var(--ifm-background-surface-color);
+	border-top-left-radius: var(--ifm-pre-border-radius);
+	border-top-right-radius: var(--ifm-pre-border-radius);
+	line-height: 0;
+	overflow: hidden;
+}
+
+.dragHandle {
+	align-items: center;
+	background: var(--ifm-background-surface-color);
+	border-bottom: 1px solid var(--ifm-color-emphasis-300);
+	border-left: 1px solid var(--ifm-color-emphasis-300);
+	border-right: 1px solid var(--ifm-color-emphasis-300);
+	border-radius: 0;
+	cursor: grab;
+	display: flex;
+	font-size: 13px;
+	font-weight: 600;
+	gap: 6px;
+	padding: 8px 10px;
+	user-select: none;
+}
+
+.controls {
+	border: 1px solid var(--ifm-color-emphasis-300);
+	border-top: 0;
+	min-width: 0;
+}
+
+@container (min-width: 760px) {
+	.container {
+		align-items: start;
+		display: grid;
+		grid-template-columns: minmax(280px, 52%) minmax(260px, 1fr);
+	}
+
+	.preview {
+		border-right: 1px solid var(--ifm-color-emphasis-300);
+	}
+
+	.dragHandle {
+		border-bottom: 0;
+		border-left: 0;
+		border-right: 0;
+	}
+
+	.controls {
+		border-left: 0;
+		border-top: 1px solid var(--ifm-color-emphasis-300);
+	}
+}
+
+@media screen and (max-width: 996px) {
+	.preview {
+		position: static;
+	}
+}

--- a/packages/docs/components/effects-demos/styles.module.css
+++ b/packages/docs/components/effects-demos/styles.module.css
@@ -48,10 +48,6 @@
 		grid-template-columns: minmax(280px, 52%) minmax(260px, 1fr);
 	}
 
-	.dragHandle {
-		border-bottom: 0;
-	}
-
 	.controls {
 		border-top: 1px solid var(--ifm-color-emphasis-300);
 	}

--- a/packages/docs/components/effects-demos/styles.module.css
+++ b/packages/docs/components/effects-demos/styles.module.css
@@ -48,18 +48,11 @@
 		grid-template-columns: minmax(280px, 52%) minmax(260px, 1fr);
 	}
 
-	.preview {
-		border-right: 1px solid var(--ifm-color-emphasis-300);
-	}
-
 	.dragHandle {
 		border-bottom: 0;
-		border-left: 0;
-		border-right: 0;
 	}
 
 	.controls {
-		border-left: 0;
 		border-top: 1px solid var(--ifm-color-emphasis-300);
 	}
 }


### PR DESCRIPTION
## Summary

- Keep the effects demo preview sticky while scrolling longer controls
- Move the demo frame styling into a CSS module so the preview, drag handle, and controls can be framed independently
- Keep the preview top corners rounded, make the drag handle square, and match the docs surface background

Closes https://github.com/remotion-dev/remotion/issues/8890

## Testing

- `cd packages/docs && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
