### PR TITLE
Docs: Document transparent WebM Lambda artifacts

### DIFF
--- a/packages/docs/docs/lambda/cli/render.mdx
+++ b/packages/docs/docs/lambda/cli/render.mdx
@@ -112,6 +112,10 @@ Minimum value: <MinimumFramesPerLambda />
 The `framesPerLambda` parameter cannot result in more than 200 functions being spawned. See: [Concurrency](/docs/lambda/concurrency)
 :::
 
+:::note
+When rendering [transparent WebM videos](/docs/transparent-videos#rendering-transparent-webm-on-lambda), chunk boundaries can be visible in the alpha channel. Increase `--frames-per-lambda` to reduce boundaries, or render WebM in one pass if the artifact appears.
+:::
+
 ### `--concurrency`<AvailableFrom v="4.0.322" />
 
 Specify the number of Lambda functions to use for rendering. This is an alternative to `--frames-per-lambda` that allows you to set the concurrency directly without needing to know the video duration.

--- a/packages/docs/docs/lambda/cli/render.mdx
+++ b/packages/docs/docs/lambda/cli/render.mdx
@@ -113,7 +113,7 @@ The `framesPerLambda` parameter cannot result in more than 200 functions being s
 :::
 
 :::note
-When rendering [transparent WebM videos](/docs/transparent-videos#rendering-transparent-webm-on-lambda), chunk boundaries can be visible in the alpha channel. Increase `--frames-per-lambda` to reduce boundaries, or render WebM in one pass if the artifact appears.
+When rendering transparent WebM videos, chunk boundaries can be visible in the alpha channel. See [Known problem: Rendering transparent WebM on Lambda](/docs/transparent-videos#known-problem-rendering-transparent-webm-on-lambda). Increase `--frames-per-lambda` to reduce boundaries, or render WebM in one pass if the artifact appears.
 :::
 
 ### `--concurrency`<AvailableFrom v="4.0.322" />

--- a/packages/docs/docs/lambda/rendermediaonlambda.mdx
+++ b/packages/docs/docs/lambda/rendermediaonlambda.mdx
@@ -66,7 +66,7 @@ The `framesPerLambda` parameter cannot result in more than 200 functions being s
 :::
 
 :::note
-When rendering [transparent WebM videos](/docs/transparent-videos#rendering-transparent-webm-on-lambda), chunk boundaries can be visible in the alpha channel. Increase `framesPerLambda` to reduce boundaries, or render WebM in one pass if the artifact appears.
+When rendering transparent WebM videos, chunk boundaries can be visible in the alpha channel. See [Known problem: Rendering transparent WebM on Lambda](/docs/transparent-videos#known-problem-rendering-transparent-webm-on-lambda). Increase `framesPerLambda` to reduce boundaries, or render WebM in one pass if the artifact appears.
 :::
 
 ### `concurrency?`<AvailableFrom v="4.0.322" />

--- a/packages/docs/docs/lambda/rendermediaonlambda.mdx
+++ b/packages/docs/docs/lambda/rendermediaonlambda.mdx
@@ -65,6 +65,10 @@ Minimum value: <MinimumFramesPerLambda />
 The `framesPerLambda` parameter cannot result in more than 200 functions being spawned. See: [Concurrency](/docs/lambda/concurrency)
 :::
 
+:::note
+When rendering [transparent WebM videos](/docs/transparent-videos#rendering-transparent-webm-on-lambda), chunk boundaries can be visible in the alpha channel. Increase `framesPerLambda` to reduce boundaries, or render WebM in one pass if the artifact appears.
+:::
+
 ### `concurrency?`<AvailableFrom v="4.0.322" />
 
 Specify the number of Lambda functions to use for rendering. This is an alternative to `framesPerLambda` that allows you to set the concurrency directly without needing to know the video duration.

--- a/packages/docs/docs/transparent-videos.mdx
+++ b/packages/docs/docs/transparent-videos.mdx
@@ -86,15 +86,13 @@ const calculateMetadata: CalculateMetadataFunction<Props> = async ({
 />;
 ```
 
-### Rendering transparent WebM on Lambda
+### Known problem: Rendering transparent WebM on Lambda
 
-:::warning
-Transparent WebM videos (`vp8` or `vp9` with `yuva420p`) can flicker at Lambda chunk boundaries.
+Transparent WebM videos (`vp8` or `vp9` with `yuva420p`) can flicker at chunk boundaries.
 
 Lambda renders chunks independently and stitches them together. VP8 and VP9 alpha encoding can depend on previous frames, so the alpha channel can look different at the beginning of each chunk.
 
 For transparent videos on Lambda, prefer ProRes with alpha if your workflow supports it. If you need WebM, render it in one pass locally. Increasing [`framesPerLambda`](/docs/lambda/rendermediaonlambda#framesperlambda) can reduce the number of chunk boundaries, at the cost of less parallelism.
-:::
 
 ## Creating a ProRes video with Alpha channels
 

--- a/packages/docs/docs/transparent-videos.mdx
+++ b/packages/docs/docs/transparent-videos.mdx
@@ -86,6 +86,16 @@ const calculateMetadata: CalculateMetadataFunction<Props> = async ({
 />;
 ```
 
+### Rendering transparent WebM on Lambda
+
+:::warning
+Transparent WebM videos (`vp8` or `vp9` with `yuva420p`) can flicker at Lambda chunk boundaries.
+
+Lambda renders chunks independently and stitches them together. VP8 and VP9 alpha encoding can depend on previous frames, so the alpha channel can look different at the beginning of each chunk.
+
+For transparent videos on Lambda, prefer ProRes with alpha if your workflow supports it. If you need WebM, render it in one pass locally. Increasing [`framesPerLambda`](/docs/lambda/rendermediaonlambda#framesperlambda) can reduce the number of chunk boundaries, at the cost of less parallelism.
+:::
+
 ## Creating a ProRes video with Alpha channels
 
 If you want to export a transparent video for use in another video editing program, Apple ProRes is a more suitable option.


### PR DESCRIPTION
## Summary

- Document that transparent VP8/VP9 WebM renders can flicker at Lambda chunk boundaries
- Add notes to the `framesPerLambda` docs and Lambda CLI option docs that point to the transparent video warning

## Testing

- `bunx oxfmt src --write`
- `bun render-cards.ts`
- `bun run build`
- `bun run stylecheck`

Closes #3234
