### PR TITLE
`@remotion/studio`: Add global interactivity killswitch

### DIFF
--- a/packages/browser-studio/src/browser-studio-worker.ts
+++ b/packages/browser-studio/src/browser-studio-worker.ts
@@ -231,6 +231,7 @@ const compileProject = async ({
 						askAIEnabled: false,
 						bufferStateDelayInMilliseconds: null,
 						experimentalClientSideRenderingEnabled: false,
+						interactivityEnabled: true,
 						keyboardShortcutsEnabled: true,
 						maxTimelineTracks: null,
 					}),

--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -71,6 +71,7 @@ export type MandatoryLegacyBundleOptions = {
 	onSymlinkDetected: (path: string) => void;
 	keyboardShortcutsEnabled: boolean;
 	askAIEnabled: boolean;
+	interactivityEnabled: boolean;
 	rspack: boolean;
 	/**
 	 * If true, the public directory is symlinked into the bundle output instead of copied.
@@ -124,6 +125,7 @@ export const getConfig = ({
 		poll: null,
 		experimentalClientSideRenderingEnabled,
 		askAIEnabled: options?.askAIEnabled ?? true,
+		interactivityEnabled: options?.interactivityEnabled ?? true,
 		extraPlugins: [],
 	};
 
@@ -458,6 +460,7 @@ export async function bundle(...args: Arguments): Promise<string> {
 			actualArgs.experimentalClientSideRenderingEnabled ?? false,
 		renderDefaults: actualArgs.renderDefaults ?? null,
 		askAIEnabled: actualArgs.askAIEnabled ?? true,
+		interactivityEnabled: actualArgs.interactivityEnabled ?? true,
 		keyboardShortcutsEnabled: actualArgs.keyboardShortcutsEnabled ?? true,
 		rspack: actualArgs.rspack ?? false,
 		symlinkPublicDir: actualArgs.symlinkPublicDir ?? false,

--- a/packages/bundler/src/rspack-config.ts
+++ b/packages/bundler/src/rspack-config.ts
@@ -29,6 +29,7 @@ export const rspackConfig = async ({
 	poll,
 	experimentalClientSideRenderingEnabled,
 	askAIEnabled,
+	interactivityEnabled,
 	extraPlugins,
 }: {
 	entry: string;
@@ -44,6 +45,7 @@ export const rspackConfig = async ({
 	remotionRoot: string;
 	poll: number | null;
 	askAIEnabled: boolean;
+	interactivityEnabled: boolean;
 	experimentalClientSideRenderingEnabled: boolean;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	extraPlugins: any[];
@@ -54,6 +56,7 @@ export const rspackConfig = async ({
 		getDefinePluginDefinitions({
 			maxTimelineTracks,
 			askAIEnabled,
+			interactivityEnabled,
 			keyboardShortcutsEnabled,
 			bufferStateDelayInMilliseconds,
 			experimentalClientSideRenderingEnabled,

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -43,6 +43,7 @@ export const webpackConfig = async ({
 	poll,
 	experimentalClientSideRenderingEnabled,
 	askAIEnabled,
+	interactivityEnabled,
 	extraPlugins,
 }: {
 	entry: string;
@@ -58,6 +59,7 @@ export const webpackConfig = async ({
 	remotionRoot: string;
 	poll: number | null;
 	askAIEnabled: boolean;
+	interactivityEnabled: boolean;
 	experimentalClientSideRenderingEnabled: boolean;
 	extraPlugins: webpack.WebpackPluginInstance[];
 }): Promise<[string, WebpackConfiguration]> => {
@@ -74,6 +76,7 @@ export const webpackConfig = async ({
 		getDefinePluginDefinitions({
 			maxTimelineTracks,
 			askAIEnabled,
+			interactivityEnabled,
 			keyboardShortcutsEnabled,
 			bufferStateDelayInMilliseconds,
 			experimentalClientSideRenderingEnabled,

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -96,6 +96,7 @@ const {
 	askAIOption,
 	publicLicenseKeyOption,
 	experimentalClientSideRenderingOption,
+	interactivityOption,
 	keyboardShortcutsOption,
 	forceNewStudioOption,
 	numberOfSharedAudioTagsOption,
@@ -179,6 +180,12 @@ declare global {
 		 * @default true
 		 */
 		readonly setKeyboardShortcutsEnabled: (enableShortcuts: boolean) => void;
+		/**
+		 * Enable interactive editing in the Remotion Studio.
+		 * @param enabled Boolean whether to enable interactive editing
+		 * @default true
+		 */
+		readonly setInteractivityEnabled: (enabled: boolean) => void;
 		/**
 		 * Enable WIP client-side rendering in the Remotion Studio.
 		 * See https://www.remotion.dev/docs/client-side-rendering/ for notes.
@@ -704,6 +711,7 @@ export const Config: FlatConfig = {
 	},
 	setMaxTimelineTracks: StudioServerInternals.setMaxTimelineTracks,
 	setKeyboardShortcutsEnabled: keyboardShortcutsOption.setConfig,
+	setInteractivityEnabled: interactivityOption.setConfig,
 	setExperimentalClientSideRenderingEnabled:
 		experimentalClientSideRenderingOption.setConfig,
 	setAllowHtmlInCanvasEnabled: allowHtmlInCanvasOption.setConfig,

--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -50,6 +50,7 @@ const {
 	webpackPollOption,
 	keyboardShortcutsOption,
 	experimentalClientSideRenderingOption,
+	interactivityOption,
 	imageSequencePatternOption,
 	scaleOption,
 	overwriteOption,
@@ -156,6 +157,9 @@ export type CommandLineOptions = {
 	[experimentalClientSideRenderingOption.cliFlag]: TypeOfOption<
 		typeof experimentalClientSideRenderingOption
 	>;
+	[interactivityOption.cliFlag]: TypeOfOption<
+		typeof interactivityOption
+	> | null;
 	[mutedOption.cliFlag]: TypeOfOption<typeof mutedOption>;
 	[overrideHeightOption.cliFlag]: TypeOfOption<typeof overrideHeightOption>;
 	[overrideWidthOption.cliFlag]: TypeOfOption<typeof overrideWidthOption>;
@@ -210,6 +214,7 @@ export const BooleanFlags = [
 	ignoreCertificateErrorsOption.cliFlag,
 	headlessOption.cliFlag,
 	keyboardShortcutsOption.cliFlag,
+	interactivityOption.cliFlag,
 	allowHtmlInCanvasOption.cliFlag,
 	experimentalClientSideRenderingOption.cliFlag,
 	ipv4Option.cliFlag,
@@ -236,6 +241,7 @@ export const parsedCli = minimist<CommandLineOptions>(process.argv.slice(2), {
 		[ignoreCertificateErrorsOption.cliFlag]: null,
 		[headlessOption.cliFlag]: null,
 		[keyboardShortcutsOption.cliFlag]: null,
+		[interactivityOption.cliFlag]: null,
 		[ipv4Option.cliFlag]: null,
 		[beepOnFinishOption.cliFlag]: null,
 		[disallowParallelEncodingOption.cliFlag]: null,

--- a/packages/cli/src/setup-cache.ts
+++ b/packages/cli/src/setup-cache.ts
@@ -221,6 +221,7 @@ export const bundleOnCli = async ({
 		outDir: outDir ?? null,
 		publicPath,
 		askAIEnabled,
+		interactivityEnabled: true,
 		keyboardShortcutsEnabled,
 		rspack,
 		// Ephemeral CLI bundles (render/still/compositions/benchmark) use a temp dir; symlink avoids copying huge public folders. `npx remotion bundle` passes a fixed outDir and keeps deep copy for deployable output.

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -23,6 +23,7 @@ const {
 	disableGitSourceOption,
 	enableCrossSiteIsolationOption,
 	askAIOption,
+	interactivityOption,
 	experimentalClientSideRenderingOption,
 	keyboardShortcutsOption,
 	forceNewStudioOption,
@@ -139,6 +140,9 @@ export const studioCommand = async (
 	const askAIEnabled = askAIOption.getValue({
 		commandLine: parsedCli,
 	}).value;
+	const interactivityEnabled = interactivityOption.getValue({
+		commandLine: parsedCli,
+	}).value;
 
 	const gitSource = getGitSource({remotionRoot, disableGitSource, logLevel});
 
@@ -191,6 +195,7 @@ export const studioCommand = async (
 		}).value,
 		enableCrossSiteIsolation,
 		askAIEnabled,
+		interactivityEnabled,
 		forceNew: forceNewStudioOption.getValue({commandLine: parsedCli}).value,
 		rspack: useRspack,
 	});

--- a/packages/cloudrun/src/api/deploy-site.ts
+++ b/packages/cloudrun/src/api/deploy-site.ts
@@ -30,6 +30,7 @@ type Options = {
 	gitSource?: GitSource | null;
 	keyboardShortcutsEnabled?: boolean;
 	askAIEnabled?: boolean;
+	interactivityEnabled?: boolean;
 	experimentalClientSideRenderingEnabled?: boolean;
 	rspack?: boolean;
 };
@@ -110,6 +111,7 @@ export const internalDeploySiteRaw = async ({
 				options?.experimentalClientSideRenderingEnabled ?? false,
 			renderDefaults: null,
 			askAIEnabled: options?.askAIEnabled ?? true,
+			interactivityEnabled: options?.interactivityEnabled ?? true,
 			keyboardShortcutsEnabled: options?.keyboardShortcutsEnabled ?? true,
 			rspack: options?.rspack ?? false,
 			symlinkPublicDir: false,

--- a/packages/docs/docs/cli/studio.mdx
+++ b/packages/docs/docs/cli/studio.mdx
@@ -53,6 +53,10 @@ Inline JSON string isn't supported on Windows shells because it removes the `"` 
 
 <Options id="disable-keyboard-shortcuts" />
 
+### `--disable-interactivity`<AvailableFrom v="4.0.487" />
+
+<Options id="disable-interactivity" />
+
 ### `--enable-experimental-client-side-rendering`<AvailableFrom v="4.0.387" />
 
 <Options id="enable-experimental-client-side-rendering" />

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -177,6 +177,18 @@ Config.setKeyboardShortcutsEnabled(false);
 
 The [command line flag](/docs/cli/studio#--disable-keyboard-shortcuts) `--disable-keyboard-shortcuts` will take precedence over this option.
 
+## `setInteractivityEnabled()`<AvailableFrom v="4.0.487" />
+
+<Options id="disable-interactivity" />
+
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+// ---cut---
+Config.setInteractivityEnabled(false);
+```
+
+The [command line flag](/docs/cli/studio#--disable-interactivity) `--disable-interactivity` will take precedence over this option.
+
 ## `setExperimentalClientSideRenderingEnabled()`<AvailableFrom v="4.0.387" />
 
 <Options id="enable-experimental-client-side-rendering" />

--- a/packages/lambda/src/api/deploy-site.ts
+++ b/packages/lambda/src/api/deploy-site.ts
@@ -39,6 +39,7 @@ type OptionalParameters = {
 		bypassBucketNameValidation?: boolean;
 		keyboardShortcutsEnabled?: boolean;
 		askAIEnabled?: boolean;
+		interactivityEnabled?: boolean;
 		experimentalClientSideRenderingEnabled?: boolean;
 		rspack?: boolean;
 	};
@@ -133,6 +134,7 @@ const mandatoryDeploySite = async ({
 			onSymlinkDetected: () => undefined,
 			outDir: null,
 			askAIEnabled: options?.askAIEnabled ?? true,
+			interactivityEnabled: options?.interactivityEnabled ?? true,
 			audioLatencyHint: null,
 			experimentalClientSideRenderingEnabled:
 				options?.experimentalClientSideRenderingEnabled ?? false,

--- a/packages/renderer/src/options/index.tsx
+++ b/packages/renderer/src/options/index.tsx
@@ -39,6 +39,7 @@ import {headlessOption} from './headless';
 import {ignoreCertificateErrorsOption} from './ignore-certificate-errors';
 import {imageSequenceOption} from './image-sequence';
 import {imageSequencePatternOption} from './image-sequence-pattern';
+import {interactivityOption} from './interactivity';
 import {ipv4Option} from './ipv4';
 import {isProductionOption} from './is-production';
 import {jpegQualityOption} from './jpeg-quality';
@@ -156,6 +157,7 @@ export const allOptions = {
 	publicLicenseKeyOption,
 	isProductionOption,
 	askAIOption,
+	interactivityOption,
 	experimentalClientSideRenderingOption,
 	keyboardShortcutsOption,
 	framesOption,

--- a/packages/renderer/src/options/interactivity.tsx
+++ b/packages/renderer/src/options/interactivity.tsx
@@ -1,0 +1,39 @@
+import type {AnyRemotionOption} from './option';
+
+let interactivityEnabled = true;
+
+const cliFlag = 'disable-interactivity' as const;
+
+export const interactivityOption = {
+	name: 'Disable or enable Studio interactivity',
+	cliFlag,
+	description: () => (
+		<>
+			Enable or disable interactive editing in the Remotion Studio. When
+			disabled, the Studio keeps previewing and source navigation available, but
+			disables preview outlines, the sequence inspector, visual controls,
+			timeline selection and timeline editing gestures.
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/config#setinteractivityenabled',
+	type: false as boolean,
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
+			interactivityEnabled = commandLine[cliFlag] === false;
+			return {
+				value: interactivityEnabled,
+				source: 'cli',
+			};
+		}
+
+		return {
+			value: interactivityEnabled,
+			source: 'config',
+		};
+	},
+	setConfig(value) {
+		interactivityEnabled = value;
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<boolean>;

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -66,6 +66,7 @@ export const startServer = async (options: {
 	previewSampleRate: number | null;
 	enableCrossSiteIsolation: boolean;
 	askAIEnabled: boolean;
+	interactivityEnabled: boolean;
 	forceNew: boolean;
 	rspack: boolean;
 }): Promise<StartServerResult> => {
@@ -108,6 +109,7 @@ export const startServer = async (options: {
 		poll: options.poll,
 		bufferStateDelayInMilliseconds: options.bufferStateDelayInMilliseconds,
 		askAIEnabled: options.askAIEnabled,
+		interactivityEnabled: options.interactivityEnabled,
 		extraPlugins: [watchIgnorePlugin],
 	};
 

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -56,6 +56,7 @@ export const startStudio = async ({
 	previewSampleRate,
 	enableCrossSiteIsolation,
 	askAIEnabled,
+	interactivityEnabled,
 	forceNew,
 	rspack,
 }: {
@@ -87,6 +88,7 @@ export const startStudio = async ({
 	binariesDirectory: string | null;
 	forceIPv4: boolean;
 	askAIEnabled: boolean;
+	interactivityEnabled: boolean;
 	forceNew: boolean;
 	rspack: boolean;
 }): Promise<StartStudioResult> => {
@@ -167,6 +169,7 @@ export const startStudio = async ({
 		previewSampleRate,
 		enableCrossSiteIsolation,
 		askAIEnabled,
+		interactivityEnabled,
 		forceNew,
 		rspack,
 	});

--- a/packages/studio-shared/src/define-plugin-definitions.ts
+++ b/packages/studio-shared/src/define-plugin-definitions.ts
@@ -1,18 +1,21 @@
 export const getDefinePluginDefinitions = ({
 	maxTimelineTracks,
 	askAIEnabled,
+	interactivityEnabled,
 	keyboardShortcutsEnabled,
 	bufferStateDelayInMilliseconds,
 	experimentalClientSideRenderingEnabled,
 }: {
 	maxTimelineTracks: number | null;
 	askAIEnabled: boolean;
+	interactivityEnabled: boolean;
 	keyboardShortcutsEnabled: boolean;
 	bufferStateDelayInMilliseconds: number | null;
 	experimentalClientSideRenderingEnabled: boolean;
 }) => ({
 	'process.env.MAX_TIMELINE_TRACKS': maxTimelineTracks,
 	'process.env.ASK_AI_ENABLED': askAIEnabled,
+	'process.env.INTERACTIVITY_ENABLED': interactivityEnabled,
 	'process.env.KEYBOARD_SHORTCUTS_ENABLED': keyboardShortcutsEnabled,
 	'process.env.BUFFER_STATE_DELAY_IN_MILLISECONDS':
 		bufferStateDelayInMilliseconds,

--- a/packages/studio/src/components/InspectorPanel/DefaultInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/DefaultInspector.tsx
@@ -1,6 +1,7 @@
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
+import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {VisualControlsContext} from '../../visual-controls/VisualControls';
 import {CurrentAsset} from '../CurrentAsset';
 import {CurrentComposition} from '../CurrentComposition';
@@ -49,7 +50,8 @@ export const DefaultInspector: React.FC<{
 	const [defaultPropsMode, setDefaultPropsMode] =
 		useState<DataEditorMode>('schema');
 	const compositionId = composition?.id ?? null;
-	const hasVisualControls = Object.keys(visualControlHandles).length > 0;
+	const hasVisualControls =
+		studioInteractivityEnabled && Object.keys(visualControlHandles).length > 0;
 
 	useEffect(() => {
 		setDefaultPropsMode('schema');

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -11,6 +11,7 @@ import React, {
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
+import {studioInteractivityEnabled} from '../helpers/interactivity-enabled';
 import {useKeybinding} from '../helpers/use-keybinding';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
@@ -249,7 +250,7 @@ export const SelectedOutlineOverlay: React.FC<{
 	);
 
 	const outlineTargets = useMemo((): SelectedOutlineTarget[] => {
-		if (!editorShowOutlines) {
+		if (!studioInteractivityEnabled || !editorShowOutlines) {
 			return [];
 		}
 

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -4,6 +4,7 @@ import {calculateTimeline} from '../../helpers/calculate-timeline';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {BACKGROUND} from '../../helpers/colors';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
+import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {useIsStill} from '../../helpers/is-current-selected-still';
 import {useCachedCompositionComponentInfo} from '../../helpers/open-in-editor';
 import {callApi} from '../call-api';
@@ -65,6 +66,7 @@ const TimelineContextMenuArea: React.FC<{
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewConnected = previewServerState.type === 'connected';
+	const previewInteractive = previewConnected && studioInteractivityEnabled;
 
 	const currentCompositionId =
 		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
@@ -89,7 +91,7 @@ const TimelineContextMenuArea: React.FC<{
 	});
 
 	const canInsertSolid =
-		previewConnected &&
+		previewInteractive &&
 		compositionComponentInfo?.canAddSequence === true &&
 		currentCompositionId !== null &&
 		compositionFile !== null &&
@@ -97,7 +99,7 @@ const TimelineContextMenuArea: React.FC<{
 		!isAddingSolid;
 
 	const canInsertAsset =
-		previewConnected &&
+		previewInteractive &&
 		!window.remotion_isReadOnlyStudio &&
 		compositionComponentInfo?.canAddSequence === true &&
 		currentCompositionId !== null &&
@@ -220,6 +222,7 @@ const TimelineInner: React.FC = () => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 
 	const previewConnected = previewServerState.type === 'connected';
+	const previewInteractive = previewConnected && studioInteractivityEnabled;
 
 	const videoConfigIsNull = videoConfig === null;
 
@@ -253,7 +256,7 @@ const TimelineInner: React.FC = () => {
 	return (
 		<TimelineContextMenuArea>
 			{sequences.map((sequence) => {
-				if (!shouldSubscribeToSequenceProps(sequence, previewConnected)) {
+				if (!shouldSubscribeToSequenceProps(sequence, previewInteractive)) {
 					return null;
 				}
 
@@ -268,10 +271,12 @@ const TimelineInner: React.FC = () => {
 					/>
 				);
 			})}
-			<SequencePropsObserver />
+			{studioInteractivityEnabled ? <SequencePropsObserver /> : null}
 			<TimelineKeyframeTracksProvider tracks={filtered}>
 				<TimelineSelectableItemsProvider timeline={shown}>
-					<TimelineSelectAllKeybindings timeline={shown} />
+					{studioInteractivityEnabled ? (
+						<TimelineSelectAllKeybindings timeline={shown} />
+					) : null}
 					<TimelineHeightContainer shown={shown} hasBeenCut={hasBeenCut}>
 						{isStill ? (
 							<TimelineList timeline={shown} />
@@ -302,7 +307,9 @@ const TimelineInner: React.FC = () => {
 											<TimelineInOutPointer />
 											<TimelineTimeIndicators />
 											<TimelineDragHandler />
-											<TimelineInOutDragHandler />
+											{studioInteractivityEnabled ? (
+												<TimelineInOutDragHandler />
+											) : null}
 											<TimelineSlider />
 										</TimelineScrollable>
 									</SplitterElement>

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -8,6 +8,7 @@ import React, {
 	useState,
 } from 'react';
 import {Internals, useVideoConfig} from 'remotion';
+import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
@@ -84,7 +85,9 @@ export const TimelineDragHandler: React.FC = () => {
 			style={containerStyle}
 			{...{[TIMELINE_SCRUBBER_ATTR]: true}}
 		>
-			{video ? <TimelineDragHandlerInnerMemo /> : null}
+			{video && studioInteractivityEnabled ? (
+				<TimelineDragHandlerInnerMemo />
+			) : null}
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -29,6 +29,7 @@ import type {
 	SequenceNodePathInfo,
 	TrackWithHash,
 } from '../../helpers/get-timeline-sequence-sort-key';
+import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {
 	buildTimelineTree,
 	flattenVisibleTreeNodes,
@@ -1044,6 +1045,7 @@ export const TimelineSelectionProvider: React.FC<{
 		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
 	const {expandParentTracks} = useContext(ExpandedTracksSetterContext);
 	const canSelect =
+		studioInteractivityEnabled &&
 		previewServerState.type === 'connected' &&
 		!window.remotion_isReadOnlyStudio;
 	const [selectedItems, setSelectedItems] = useState<

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -18,6 +18,7 @@ import {
 	SEQUENCE_BORDER_WIDTH,
 } from '../../helpers/get-timeline-sequence-layout';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {openOriginalPositionInEditor} from '../../helpers/open-in-editor';
 import {
 	getTimelineLayerHeight,
@@ -267,16 +268,20 @@ const TimelineSequenceInner: React.FC<{
 			: undefined;
 	}, [propStatuses, nodePath]);
 	const durationCanUpdate = Boolean(
+		studioInteractivityEnabled &&
 		propStatusesForOverride?.durationInFrames?.status === 'static',
 	);
 	const fromCanUpdate = Boolean(
+		studioInteractivityEnabled &&
 		propStatusesForOverride?.from?.status === 'static',
 	);
 	const trimBeforeCanUpdate = Boolean(
+		studioInteractivityEnabled &&
 		propStatusesForOverride?.trimBefore?.status === 'static',
 	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewConnected = previewServerState.type === 'connected';
+	const previewInteractive = previewConnected && studioInteractivityEnabled;
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const selectAsset = useSelectAsset();
@@ -304,10 +309,10 @@ const TimelineSequenceInner: React.FC<{
 	}, [canOpenInEditor, originalLocation]);
 	const canDeleteFromSource = Boolean(nodePath && validatedLocation?.source);
 	const deleteDisabled =
-		!previewConnected || !s.controls || !canDeleteFromSource;
+		!previewInteractive || !s.controls || !canDeleteFromSource;
 	const duplicateDisabled = deleteDisabled;
 	const disableInteractivityDisabled =
-		!previewConnected ||
+		!previewInteractive ||
 		!s.showInTimeline ||
 		!nodePath ||
 		!validatedLocation?.source;
@@ -396,7 +401,7 @@ const TimelineSequenceInner: React.FC<{
 	]);
 	const freezeFrameMenuItem = useSequenceFreezeFrameMenuItem({
 		clientId:
-			previewServerState.type === 'connected'
+			previewInteractive && previewServerState.type === 'connected'
 				? previewServerState.clientId
 				: null,
 		nodePath,
@@ -419,7 +424,7 @@ const TimelineSequenceInner: React.FC<{
 			disableInteractivityDisabled,
 			duplicateDisabled,
 			fileLocation,
-			includeSourceEditItems: true,
+			includeSourceEditItems: studioInteractivityEnabled,
 			onDeleteSequenceFromSource,
 			onDisableSequenceInteractivity,
 			onDuplicateSequenceFromSource,
@@ -427,7 +432,10 @@ const TimelineSequenceInner: React.FC<{
 			originalLocation,
 			selectAsset,
 			sequence: s,
-			sourceActions: freezeFrameMenuItem ? [freezeFrameMenuItem] : [],
+			sourceActions:
+				studioInteractivityEnabled && freezeFrameMenuItem
+					? [freezeFrameMenuItem]
+					: [],
 		});
 	}, [
 		assetLinkInfo,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../helpers/colors';
 import {formatFileLocation} from '../../helpers/format-file-location';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {
 	getTimelineLayerHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
@@ -224,6 +225,7 @@ export const TimelineSequenceItem: React.FC<{
 	const nodePath = nodePathInfo?.sequenceSubscriptionKey ?? null;
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewConnected = previewServerState.type === 'connected';
+	const previewInteractive = previewConnected && studioInteractivityEnabled;
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {toggleTrack} = useContext(ExpandedTracksSetterContext);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
@@ -278,7 +280,7 @@ export const TimelineSequenceItem: React.FC<{
 		saveName,
 	} = useRenameSequence({
 		clientId:
-			previewServerState.type === 'connected'
+			previewInteractive && previewServerState.type === 'connected'
 				? previewServerState.clientId
 				: null,
 		nodePathInfo,
@@ -294,36 +296,36 @@ export const TimelineSequenceItem: React.FC<{
 	);
 	const parentId = sequence.parent ?? null;
 	const canReorderSequence =
-		previewConnected &&
+		previewInteractive &&
 		Boolean(nodePath && nodePathKey && validatedLocation?.source) &&
 		nodePathInfo?.numberOfSequencesWithThisNodePath === 1;
-	const canHandleSequenceDrag = previewConnected;
+	const canHandleSequenceDrag = previewInteractive;
 	const confirm = useConfirmationDialog();
 
 	const deleteDisabled = useMemo(
-		() => !previewConnected || !sequence.controls || !canDeleteFromSource,
-		[previewConnected, sequence.controls, canDeleteFromSource],
+		() => !previewInteractive || !sequence.controls || !canDeleteFromSource,
+		[previewInteractive, sequence.controls, canDeleteFromSource],
 	);
 
 	const duplicateDisabled = deleteDisabled;
 	const disableInteractivityDisabled =
-		!previewConnected ||
+		!previewInteractive ||
 		!sequence.showInTimeline ||
 		!nodePath ||
 		!validatedLocation?.source;
 
 	const onDuplicateSequenceFromSource = useCallback(() => {
-		if (!validatedLocation?.source || !nodePathInfo) {
+		if (duplicateDisabled || !validatedLocation?.source || !nodePathInfo) {
 			return;
 		}
 
 		duplicateSequencesFromSource([nodePathInfo], confirm).catch(
 			() => undefined,
 		);
-	}, [confirm, nodePathInfo, validatedLocation?.source]);
+	}, [confirm, duplicateDisabled, nodePathInfo, validatedLocation?.source]);
 
 	const onDeleteSequenceFromSource = useCallback(async () => {
-		if (!validatedLocation?.source || !nodePath) {
+		if (deleteDisabled || !validatedLocation?.source || !nodePath) {
 			return;
 		}
 
@@ -358,7 +360,13 @@ export const TimelineSequenceItem: React.FC<{
 		} catch (err) {
 			showNotification((err as Error).message, 4000);
 		}
-	}, [confirm, nodePath, validatedLocation?.source, nodePathInfo]);
+	}, [
+		confirm,
+		deleteDisabled,
+		nodePath,
+		validatedLocation?.source,
+		nodePathInfo,
+	]);
 
 	const onDisableSequenceInteractivity = useCallback(() => {
 		if (
@@ -703,10 +711,11 @@ export const TimelineSequenceItem: React.FC<{
 	}, [effectDropHovered, inner]);
 
 	const hasExpandableContent =
-		Boolean(sequence.controls) || sequence.effects.length > 0;
+		studioInteractivityEnabled &&
+		(Boolean(sequence.controls) || sequence.effects.length > 0);
 
 	const canToggleVisibility =
-		previewConnected &&
+		previewInteractive &&
 		Boolean(sequence.controls) &&
 		nodePath !== null &&
 		validatedLocation !== null &&
@@ -798,7 +807,7 @@ export const TimelineSequenceItem: React.FC<{
 
 	const freezeFrameMenuItem = useSequenceFreezeFrameMenuItem({
 		clientId:
-			previewServerState.type === 'connected'
+			previewInteractive && previewServerState.type === 'connected'
 				? previewServerState.clientId
 				: null,
 		nodePath,
@@ -812,7 +821,7 @@ export const TimelineSequenceItem: React.FC<{
 
 	const canAddEffect =
 		nodePathInfo?.supportsEffects === true &&
-		previewServerState.type === 'connected' &&
+		previewInteractive &&
 		Boolean(validatedLocation?.source);
 
 	const onAddEffect = useCallback(() => {
@@ -851,7 +860,7 @@ export const TimelineSequenceItem: React.FC<{
 			disableInteractivityDisabled,
 			duplicateDisabled,
 			fileLocation,
-			includeSourceEditItems: true,
+			includeSourceEditItems: studioInteractivityEnabled,
 			onDeleteSequenceFromSource,
 			onDisableSequenceInteractivity,
 			onDuplicateSequenceFromSource,
@@ -859,43 +868,45 @@ export const TimelineSequenceItem: React.FC<{
 			originalLocation,
 			selectAsset,
 			sequence,
-			sourceActions: [
-				...(nodePathInfo?.supportsEffects
-					? [
-							{
-								type: 'item' as const,
-								id: 'add-effect',
-								keyHint: null,
-								label: 'Add effect...',
-								leftItem: null,
-								disabled: !canAddEffect,
-								onClick: onAddEffect,
-								quickSwitcherLabel: null,
-								subMenu: null,
-								value: 'add-effect',
+			sourceActions: studioInteractivityEnabled
+				? [
+						...(nodePathInfo?.supportsEffects
+							? [
+									{
+										type: 'item' as const,
+										id: 'add-effect',
+										keyHint: null,
+										label: 'Add effect...',
+										leftItem: null,
+										disabled: !canAddEffect,
+										onClick: onAddEffect,
+										quickSwitcherLabel: null,
+										subMenu: null,
+										value: 'add-effect',
+									},
+									{
+										type: 'divider' as const,
+										id: 'add-effect-divider',
+									},
+								]
+							: []),
+						{
+							type: 'item' as const,
+							id: 'rename-sequence',
+							keyHint: null,
+							label: 'Rename...',
+							leftItem: null,
+							disabled: !canRenameThisSequence,
+							onClick: () => {
+								onRenameSequence();
 							},
-							{
-								type: 'divider' as const,
-								id: 'add-effect-divider',
-							},
-						]
-					: []),
-				{
-					type: 'item' as const,
-					id: 'rename-sequence',
-					keyHint: null,
-					label: 'Rename...',
-					leftItem: null,
-					disabled: !canRenameThisSequence,
-					onClick: () => {
-						onRenameSequence();
-					},
-					quickSwitcherLabel: null,
-					subMenu: null,
-					value: 'rename-sequence',
-				},
-				...(freezeFrameMenuItem ? [freezeFrameMenuItem] : []),
-			],
+							quickSwitcherLabel: null,
+							subMenu: null,
+							value: 'rename-sequence',
+						},
+						...(freezeFrameMenuItem ? [freezeFrameMenuItem] : []),
+					]
+				: [],
 		});
 	}, [
 		assetLinkInfo,
@@ -920,7 +931,7 @@ export const TimelineSequenceItem: React.FC<{
 		sequence,
 	]);
 	const canDropEffect =
-		previewServerState.type === 'connected' &&
+		previewInteractive &&
 		nodePath !== null &&
 		validatedLocation !== null &&
 		sequence.controls?.supportsEffects === true;
@@ -1020,7 +1031,7 @@ export const TimelineSequenceItem: React.FC<{
 			arrow={
 				hasExpandableContent && nodePathInfo !== null ? (
 					<TimelineSequenceExpandArrow
-						disabled={!previewConnected}
+						disabled={!previewInteractive}
 						isExpanded={isExpanded}
 						nodePathInfo={nodePathInfo}
 						onToggleExpand={onToggleExpand}
@@ -1101,6 +1112,7 @@ export const TimelineSequenceItem: React.FC<{
 				draggableTrackRow
 			)}
 			{previewConnected &&
+			studioInteractivityEnabled &&
 			isExpanded &&
 			hasExpandableContent &&
 			nodePathInfo &&

--- a/packages/studio/src/helpers/interactivity-enabled.ts
+++ b/packages/studio/src/helpers/interactivity-enabled.ts
@@ -1,0 +1,6 @@
+const interactivityEnabled = process.env.INTERACTIVITY_ENABLED as unknown;
+
+export const studioInteractivityEnabled =
+	interactivityEnabled === undefined || interactivityEnabled === null
+		? true
+		: interactivityEnabled !== false && interactivityEnabled !== 'false';

--- a/packages/studio/src/visual-controls/VisualControls.tsx
+++ b/packages/studio/src/visual-controls/VisualControls.tsx
@@ -12,6 +12,7 @@ import {useRemotionEnvironment} from 'remotion';
 import {getZodSchemaFromPrimitive} from '../api/get-zod-schema-from-primitive';
 import {useZodIfPossible} from '../components/get-zod-if-possible';
 import type {AnyZodSchema} from '../components/RenderModal/SchemaEditor/zod-schema-type';
+import {studioInteractivityEnabled} from '../helpers/interactivity-enabled';
 import {getVisualControlEditedValue} from './get-current-edited-value';
 import {visualControlStore} from './visual-control-store';
 
@@ -127,6 +128,10 @@ export const VisualControlsProvider: React.FC<{
 			}
 
 			if (!env.isStudio) {
+				return value;
+			}
+
+			if (!studioInteractivityEnabled) {
 				return value;
 			}
 

--- a/packages/template-recorder/remotion.config.ts
+++ b/packages/template-recorder/remotion.config.ts
@@ -3,3 +3,4 @@ import { Config } from "@remotion/cli/config";
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);
 Config.setAskAIEnabled(false);
+Config.setInteractivityEnabled(false);


### PR DESCRIPTION
## Summary
- Add `--disable-interactivity` and `Config.setInteractivityEnabled(false)`.
- Pipe the option through Studio bundle defines and disable Studio editing affordances when off.
- Document the new Studio CLI flag and config option.

## Testing
- `bun run build`
- `bun run stylecheck`

Closes #8858
