### PR TITLE
`@remotion/media`: Fall back for untagged SD H.264 videos

### DIFF
--- a/packages/docs/docs/media/fallback.mdx
+++ b/packages/docs/docs/media/fallback.mdx
@@ -18,6 +18,7 @@ Here are some cases where [`@remotion/media`](/docs/media) may fall back to [`<O
 - The resource fails to load due to [CORS restrictions](/docs/cors-issues)
 - The container format is not supported by [Mediabunny](/docs/mediabunny/formats)
 - The codec cannot be decoded by WebCodecs (e.g. a H.265 stream during rendering)
+- The video is an untagged SD H.264 file where WebCodecs may infer a different color matrix than native decoders <AvailableFrom v="4.0.487" inline />
 - The video has an alpha channel and the browser does not support WebGL which is required to decode the alpha channel. The default configuration of the headless browser does not have WebGL enabled.
 
 ## Observing when a fallback happens

--- a/packages/media/src/audio/audio-for-rendering.tsx
+++ b/packages/media/src/audio/audio-for-rendering.tsx
@@ -188,6 +188,12 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 					);
 				}
 
+				if (result.type === 'fallback-untagged-sd-h264') {
+					throw new Error(
+						`Cannot safely decode ${src}, and 'disallowFallbackToHtml5Audio' was set. But this should never happen, since you used the <Audio> tag. Please report this as a bug.`,
+					);
+				}
+
 				if (result.type === 'network-error') {
 					handleError(
 						new Error(`Network error fetching ${src}.`),

--- a/packages/media/src/extract-frame-and-audio.ts
+++ b/packages/media/src/extract-frame-and-audio.ts
@@ -22,6 +22,7 @@ export const extractFrameAndAudio = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	fallbackForUntaggedSdH264 = false,
 }: {
 	src: string;
 	timeInSeconds: number;
@@ -38,6 +39,7 @@ export const extractFrameAndAudio = async ({
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	fallbackForUntaggedSdH264?: boolean;
 }): Promise<ExtractFrameViaBroadcastChannelResult> => {
 	try {
 		const [video, audio] = await Promise.all([
@@ -54,6 +56,7 @@ export const extractFrameAndAudio = async ({
 						maxCacheSize,
 						credentials,
 						requestInit,
+						fallbackForUntaggedSdH264,
 					})
 				: null,
 			includeAudio
@@ -89,6 +92,13 @@ export const extractFrameAndAudio = async ({
 		if (video?.type === 'cannot-decode-alpha') {
 			return {
 				type: 'cannot-decode-alpha',
+				durationInSeconds: video.durationInSeconds,
+			};
+		}
+
+		if (video?.type === 'fallback-untagged-sd-h264') {
+			return {
+				type: 'fallback-untagged-sd-h264',
 				durationInSeconds: video.durationInSeconds,
 			};
 		}

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -27,6 +27,7 @@ import {PremountAwareDelayPlayback} from './premount-aware-delay-playback';
 import type {MediaRequestInit} from './request-init';
 import {resolveRequestInit} from './request-init';
 import type {SharedAudioContextForMediaPlayer} from './shared-audio-context-for-media-player';
+import {shouldFallbackForUntaggedSdH264} from './should-fallback-for-untagged-sd-h264';
 import type {VideoIteratorManager} from './video-iterator-manager';
 import {videoIteratorManager} from './video-iterator-manager';
 
@@ -34,6 +35,7 @@ export type MediaPlayerInitResult =
 	| {type: 'success'; durationInSeconds: number}
 	| {type: 'unknown-container-format'}
 	| {type: 'cannot-decode'}
+	| {type: 'fallback-untagged-sd-h264'}
 	| {type: 'network-error'}
 	| {type: 'no-tracks'}
 	| {type: 'disposed'};
@@ -310,6 +312,10 @@ export class MediaPlayer {
 						'Streams with UNIX timestamps are not currently supported by Remotion. Sorry! Source: ' +
 							this.src,
 					);
+				}
+
+				if (await shouldFallbackForUntaggedSdH264(videoTrack)) {
+					return {type: 'fallback-untagged-sd-h264'};
 				}
 
 				const canDecode = await videoTrack.canDecode();

--- a/packages/media/src/should-fallback-for-untagged-sd-h264.ts
+++ b/packages/media/src/should-fallback-for-untagged-sd-h264.ts
@@ -1,0 +1,33 @@
+import type {InputVideoTrack} from 'mediabunny';
+
+const isPresent = <T>(value: T | null | undefined) => {
+	return value !== undefined && value !== null;
+};
+
+const hasColorSpaceMetadata = (colorSpace: VideoColorSpaceInit) => {
+	return (
+		isPresent(colorSpace.matrix) ||
+		isPresent(colorSpace.primaries) ||
+		isPresent(colorSpace.transfer) ||
+		isPresent(colorSpace.fullRange)
+	);
+};
+
+export const shouldFallbackForUntaggedSdH264 = async (
+	videoTrack: InputVideoTrack,
+) => {
+	if ((await videoTrack.getCodec()) !== 'avc') {
+		return false;
+	}
+
+	if (hasColorSpaceMetadata(await videoTrack.getColorSpace())) {
+		return false;
+	}
+
+	const [width, height] = await Promise.all([
+		videoTrack.getSquarePixelWidth(),
+		videoTrack.getSquarePixelHeight(),
+	]);
+
+	return Math.min(width, height) <= 576 && Math.max(width, height) <= 1024;
+};

--- a/packages/media/src/test/browser.test.ts
+++ b/packages/media/src/test/browser.test.ts
@@ -39,6 +39,10 @@ test('Should be able to extract a frame', async () => {
 		throw new Error('Cannot decode alpha');
 	}
 
+	if (result.type === 'fallback-untagged-sd-h264') {
+		throw new Error('Fallback for untagged SD H.264');
+	}
+
 	const {audio, frame} = result;
 	assert(audio);
 	assert(frame);
@@ -89,6 +93,10 @@ test('Should be able to extract the last frame', async () => {
 
 	if (result.type === 'cannot-decode-alpha') {
 		throw new Error('Cannot decode alpha');
+	}
+
+	if (result.type === 'fallback-untagged-sd-h264') {
+		throw new Error('Fallback for untagged SD H.264');
 	}
 
 	const {audio, frame} = result;
@@ -172,6 +180,10 @@ test('Should be apply volume correctly', async () => {
 		throw new Error('Cannot decode alpha');
 	}
 
+	if (result.type === 'fallback-untagged-sd-h264') {
+		throw new Error('Fallback for untagged SD H.264');
+	}
+
 	const {audio: audioAtFullVolume, frame} = result;
 
 	const totalAudioAtFullVolume = audioAtFullVolume?.data.reduce((acc, curr) => {
@@ -225,6 +237,10 @@ test('Should be able to loop', async () => {
 
 	if (result.type === 'cannot-decode-alpha') {
 		throw new Error('Cannot decode alpha');
+	}
+
+	if (result.type === 'fallback-untagged-sd-h264') {
+		throw new Error('Fallback for untagged SD H.264');
 	}
 
 	const {frame} = result;

--- a/packages/media/src/test/should-fallback-for-untagged-sd-h264.test.ts
+++ b/packages/media/src/test/should-fallback-for-untagged-sd-h264.test.ts
@@ -1,0 +1,76 @@
+import type {InputVideoTrack} from 'mediabunny';
+import {expect, test} from 'vitest';
+import {shouldFallbackForUntaggedSdH264} from '../should-fallback-for-untagged-sd-h264';
+
+type Codec = Awaited<ReturnType<InputVideoTrack['getCodec']>>;
+
+const makeTrack = ({
+	codec,
+	colorSpace,
+	height,
+	width,
+}: {
+	codec: Codec;
+	colorSpace: VideoColorSpaceInit;
+	height: number;
+	width: number;
+}) => {
+	return {
+		getCodec: () => Promise.resolve(codec),
+		getColorSpace: () => Promise.resolve(colorSpace),
+		getSquarePixelHeight: () => Promise.resolve(height),
+		getSquarePixelWidth: () => Promise.resolve(width),
+	} as unknown as InputVideoTrack;
+};
+
+test('falls back for untagged SD H.264', async () => {
+	await expect(
+		shouldFallbackForUntaggedSdH264(
+			makeTrack({
+				codec: 'avc',
+				colorSpace: {},
+				height: 480,
+				width: 854,
+			}),
+		),
+	).resolves.toBe(true);
+});
+
+test('does not fall back if color metadata is present', async () => {
+	await expect(
+		shouldFallbackForUntaggedSdH264(
+			makeTrack({
+				codec: 'avc',
+				colorSpace: {matrix: 'bt709'},
+				height: 480,
+				width: 854,
+			}),
+		),
+	).resolves.toBe(false);
+});
+
+test('does not fall back for HD H.264', async () => {
+	await expect(
+		shouldFallbackForUntaggedSdH264(
+			makeTrack({
+				codec: 'avc',
+				colorSpace: {},
+				height: 720,
+				width: 1280,
+			}),
+		),
+	).resolves.toBe(false);
+});
+
+test('does not fall back for non-H.264 codecs', async () => {
+	await expect(
+		shouldFallbackForUntaggedSdH264(
+			makeTrack({
+				codec: 'vp9',
+				colorSpace: {},
+				height: 480,
+				width: 854,
+			}),
+		),
+	).resolves.toBe(false);
+});

--- a/packages/media/src/test/video-non-zero-start.test.ts
+++ b/packages/media/src/test/video-non-zero-start.test.ts
@@ -47,3 +47,25 @@ test('Should render first frame for videos starting after timestamp 0', async ()
 
 	keyframeManager.clearAll('info');
 });
+
+test('can opt into fallback for untagged SD H.264', async () => {
+	keyframeManager.clearAll('info');
+
+	const result = await extractFrame({
+		src: '/video-start-offset.mp4',
+		timeInSeconds: 0,
+		logLevel: 'info',
+		loop: false,
+		trimAfter: undefined,
+		trimBefore: undefined,
+		playbackRate: 1,
+		fps: 30,
+		maxCacheSize: getMaxVideoCacheSize('info'),
+		credentials: undefined,
+		fallbackForUntaggedSdH264: true,
+	});
+
+	expect(result.type).toBe('fallback-untagged-sd-h264');
+
+	keyframeManager.clearAll('info');
+});

--- a/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
+++ b/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
@@ -27,6 +27,11 @@ export type MessageFromMainTab =
 			durationInSeconds: number | null;
 	  }
 	| {
+			type: 'response-fallback-untagged-sd-h264';
+			id: string;
+			durationInSeconds: number | null;
+	  }
+	| {
 			type: 'response-network-error';
 			id: string;
 	  }
@@ -56,6 +61,7 @@ export type ExtractFrameRequest = {
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	fallbackForUntaggedSdH264?: boolean;
 };
 
 // Send to other channels a message to let them know that the
@@ -107,6 +113,7 @@ export const addBroadcastChannelListener = () => {
 						maxCacheSize: data.maxCacheSize,
 						credentials: data.credentials,
 						requestInit: data.requestInit,
+						fallbackForUntaggedSdH264: data.fallbackForUntaggedSdH264 ?? false,
 					});
 
 					if (result.type === 'cannot-decode') {
@@ -129,6 +136,19 @@ export const addBroadcastChannelListener = () => {
 
 						window.remotion_broadcastChannel!.postMessage(
 							cannotDecodeAlphaResponse,
+						);
+						return;
+					}
+
+					if (result.type === 'fallback-untagged-sd-h264') {
+						const fallbackUntaggedSdH264Response: MessageFromMainTab = {
+							type: 'response-fallback-untagged-sd-h264',
+							id: data.id,
+							durationInSeconds: result.durationInSeconds,
+						};
+
+						window.remotion_broadcastChannel!.postMessage(
+							fallbackUntaggedSdH264Response,
 						);
 						return;
 					}

--- a/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
+++ b/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
@@ -23,6 +23,7 @@ export type ExtractFrameViaBroadcastChannelResult =
 	  }
 	| {type: 'cannot-decode'; durationInSeconds: number | null}
 	| {type: 'cannot-decode-alpha'; durationInSeconds: number | null}
+	| {type: 'fallback-untagged-sd-h264'; durationInSeconds: number | null}
 	| {type: 'network-error'}
 	| {type: 'unknown-container-format'};
 
@@ -45,6 +46,7 @@ export const extractFrameViaBroadcastChannel = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	fallbackForUntaggedSdH264 = false,
 }: {
 	src: string;
 	timeInSeconds: number;
@@ -62,6 +64,7 @@ export const extractFrameViaBroadcastChannel = async ({
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	fallbackForUntaggedSdH264?: boolean;
 }): Promise<ExtractFrameViaBroadcastChannelResult> => {
 	if (isClientSideRendering || window.remotion_isMainTab) {
 		return extractFrameAndAudio({
@@ -80,6 +83,7 @@ export const extractFrameViaBroadcastChannel = async ({
 			maxCacheSize,
 			credentials,
 			requestInit,
+			fallbackForUntaggedSdH264,
 		});
 	}
 
@@ -96,6 +100,10 @@ export const extractFrameViaBroadcastChannel = async ({
 		  }
 		| {type: 'cannot-decode'; durationInSeconds: number | null}
 		| {type: 'cannot-decode-alpha'; durationInSeconds: number | null}
+		| {
+				type: 'fallback-untagged-sd-h264';
+				durationInSeconds: number | null;
+		  }
 		| {type: 'network-error'}
 		| {type: 'unknown-container-format'}
 	>((resolve, reject) => {
@@ -181,6 +189,18 @@ export const extractFrameViaBroadcastChannel = async ({
 				return;
 			}
 
+			if (data.type === 'response-fallback-untagged-sd-h264') {
+				resolve({
+					type: 'fallback-untagged-sd-h264',
+					durationInSeconds: data.durationInSeconds,
+				});
+				window.remotion_broadcastChannel!.removeEventListener(
+					'message',
+					onMessage,
+				);
+				return;
+			}
+
 			throw new Error(
 				`Invalid message: ${JSON.stringify(data satisfies never)}`,
 			);
@@ -207,6 +227,7 @@ export const extractFrameViaBroadcastChannel = async ({
 		maxCacheSize,
 		credentials,
 		requestInit: normalizeMediaRequestInit(requestInit),
+		fallbackForUntaggedSdH264,
 	};
 
 	window.remotion_broadcastChannel!.postMessage(request);

--- a/packages/media/src/video-extraction/extract-frame.ts
+++ b/packages/media/src/video-extraction/extract-frame.ts
@@ -13,6 +13,7 @@ type ExtractFrameResult =
 	  }
 	| {type: 'cannot-decode'; durationInSeconds: number | null}
 	| {type: 'cannot-decode-alpha'; durationInSeconds: number | null}
+	| {type: 'fallback-untagged-sd-h264'; durationInSeconds: number | null}
 	| {type: 'unknown-container-format'}
 	| {type: 'network-error'};
 
@@ -28,6 +29,7 @@ type ExtractFrameParams = {
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	fallbackForUntaggedSdH264?: boolean;
 };
 
 const extractFrameInternal = async ({
@@ -42,17 +44,25 @@ const extractFrameInternal = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	fallbackForUntaggedSdH264 = false,
 }: ExtractFrameParams): Promise<ExtractFrameResult> => {
 	const sink = await getSink(src, logLevel, credentials, requestInit);
 
-	const [video, mediaDurationInSecondsRaw] = await Promise.all([
-		sink.getVideo(),
-		loop ? sink.getDuration() : Promise.resolve(null),
-	]);
-
 	const mediaDurationInSeconds: number | null = loop
-		? mediaDurationInSecondsRaw
+		? await sink.getDuration()
 		: null;
+
+	if (
+		fallbackForUntaggedSdH264 &&
+		(await sink.shouldFallbackForUntaggedSdH264())
+	) {
+		return {
+			type: 'fallback-untagged-sd-h264',
+			durationInSeconds: mediaDurationInSeconds,
+		};
+	}
+
+	const video = await sink.getVideo();
 
 	if (video === 'no-video-track') {
 		throw new Error(`No video track found for ${src}`);

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -17,6 +17,7 @@ import {resolveAudioTrack} from '../helpers/resolve-audio-track';
 import {isNetworkError} from '../is-type-of-error';
 import type {MediaRequestInit} from '../request-init';
 import {resolveRequestInit} from '../request-init';
+import {shouldFallbackForUntaggedSdH264} from '../should-fallback-for-untagged-sd-h264';
 import {rememberActualMatroskaTimestamps} from './remember-actual-matroska-timestamps';
 
 type VideoSinks = {
@@ -134,6 +135,15 @@ export const getSinks = async (
 		};
 	};
 
+	const getShouldFallbackForUntaggedSdH264 = async () => {
+		if (format === 'network-error' || format === null) {
+			return false;
+		}
+
+		const videoTrack = await input.getPrimaryVideoTrack();
+		return videoTrack ? shouldFallbackForUntaggedSdH264(videoTrack) : false;
+	};
+
 	let videoSinksPromise: Promise<VideoSinkResult> | null = null;
 	const getVideoSinksPromise = () => {
 		if (videoSinksPromise) {
@@ -142,6 +152,17 @@ export const getSinks = async (
 
 		videoSinksPromise = getVideoSinks();
 		return videoSinksPromise;
+	};
+
+	let shouldFallbackForUntaggedSdH264Promise: Promise<boolean> | null = null;
+	const getShouldFallbackForUntaggedSdH264Promise = () => {
+		if (shouldFallbackForUntaggedSdH264Promise) {
+			return shouldFallbackForUntaggedSdH264Promise;
+		}
+
+		shouldFallbackForUntaggedSdH264Promise =
+			getShouldFallbackForUntaggedSdH264();
+		return shouldFallbackForUntaggedSdH264Promise;
 	};
 
 	// audioSinksPromise is now a record indexed by audio track index
@@ -205,6 +226,8 @@ export const getSinks = async (
 		getDuration: () => {
 			return getDurationOrCompute(input);
 		},
+		shouldFallbackForUntaggedSdH264: () =>
+			getShouldFallbackForUntaggedSdH264Promise(),
 	};
 };
 

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -351,6 +351,16 @@ const VideoForPreviewAssertedShowing: React.FC<
 						return;
 					}
 
+					if (result.type === 'fallback-untagged-sd-h264') {
+						handleError(
+							new Error(
+								`Cannot safely decode ${preloadedSrc}: The H.264 video has no color-space metadata and SD dimensions, which can cause browsers to infer the wrong color matrix.`,
+							),
+							`${preloadedSrc} is an untagged SD H.264 video, falling back to <Html5Video> to preserve colors`,
+						);
+						return;
+					}
+
 					if (result.type === 'no-tracks') {
 						handleError(
 							new Error(`No video or audio tracks found for ${preloadedSrc}.`),

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -202,6 +202,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 			maxCacheSize,
 			credentials,
 			requestInit: initialRequestInit,
+			fallbackForUntaggedSdH264: true,
 		})
 			.then(async (result) => {
 				const handleError = (
@@ -272,6 +273,20 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 							`Cannot render video "${src}": The alpha channel could not be decoded by the browser.`,
 						),
 						`Cannot decode alpha component for ${src}, falling back to <OffthreadVideo>`,
+						result.durationInSeconds,
+					);
+					return;
+				}
+
+				if (result.type === 'fallback-untagged-sd-h264') {
+					handleError(
+						new Error(
+							`Cannot safely decode ${src}: The H.264 video has no color-space metadata and SD dimensions, which can cause browsers to infer the wrong color matrix.`,
+						),
+						new Error(
+							`Cannot render video "${src}": The H.264 video has no color-space metadata and SD dimensions, which can cause browsers to infer the wrong color matrix.`,
+						),
+						`${src} is an untagged SD H.264 video, falling back to <OffthreadVideo> to preserve colors`,
 						result.durationInSeconds,
 					);
 					return;


### PR DESCRIPTION
## Summary

- Fall back for untagged SD H.264 videos in `@remotion/media` to preserve native decoder colors
- Route the fallback signal through rendering, preview, and broadcast-channel extraction
- Add detector coverage, integration coverage, and document the fallback behavior

## Test plan

- `cd packages/media && bunx oxfmt src --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/media && bun run test`
- Manual repro: rendered the provided `preview_10s.mp4`; patched `@remotion/media` output matched `<OffthreadVideo>` pixel-for-pixel
