### PR TITLE
`@remotion/studio`: Add docs Element install button

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -2,7 +2,13 @@ import {
 	makeElementDragData,
 	type ComponentDimensions,
 } from '@remotion/studio-shared';
-import React, {useMemo, type ComponentType, type ReactNode} from 'react';
+import React, {
+	useCallback,
+	useMemo,
+	useState,
+	type ComponentType,
+	type ReactNode,
+} from 'react';
 import {AbsoluteFill, Sequence} from 'remotion';
 import {setElementDragData, setElementDragImage} from './element-drag-data';
 import {ElementPreview} from './ElementPreview';
@@ -22,7 +28,7 @@ type ElementPageProps = {
 	readonly width?: number;
 };
 
-const dragButtonStyle: React.CSSProperties = {
+const actionButtonStyle: React.CSSProperties = {
 	display: 'inline-flex',
 	alignItems: 'center',
 	gap: 10,
@@ -31,9 +37,101 @@ const dragButtonStyle: React.CSSProperties = {
 	border: '1px solid var(--ifm-color-emphasis-300)',
 	background: 'var(--ifm-background-surface-color)',
 	boxShadow: '0 6px 20px rgba(0, 0, 0, 0.08)',
-	cursor: 'grab',
 	fontWeight: 700,
 	userSelect: 'none',
+};
+
+const dragButtonStyle: React.CSSProperties = {
+	...actionButtonStyle,
+	cursor: 'grab',
+};
+
+const installButtonStyle: React.CSSProperties = {
+	...actionButtonStyle,
+	cursor: 'pointer',
+};
+
+const disabledInstallButtonStyle: React.CSSProperties = {
+	...installButtonStyle,
+	cursor: 'not-allowed',
+	opacity: 0.65,
+};
+
+const actionRowStyle: React.CSSProperties = {
+	display: 'flex',
+	flexWrap: 'wrap',
+	gap: 12,
+	alignItems: 'center',
+};
+
+type ElementInstallTarget = {
+	type: 'remotion-studio';
+	projectName: string | null;
+	port: number | null;
+	lastFocusedAt: number | null;
+	canInstall: boolean;
+	activeCompositionId: string | null;
+	readOnly: boolean;
+};
+
+type InstallStatus =
+	| {type: 'idle'}
+	| {type: 'installing'}
+	| {type: 'success'; message: string; studioUrl: string}
+	| {type: 'error'; message: string};
+
+const probePorts = [3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009];
+const focusedStudioMaxAge = 5 * 60 * 1000;
+
+const fetchWithTimeout = async (url: string, options: RequestInit = {}) => {
+	const controller = new AbortController();
+	const timeout = window.setTimeout(() => controller.abort(), 700);
+	try {
+		return await fetch(url, {...options, signal: controller.signal});
+	} finally {
+		window.clearTimeout(timeout);
+	}
+};
+
+const findBestInstallTarget = async (): Promise<
+	(ElementInstallTarget & {origin: string}) | null
+> => {
+	const targets = await Promise.all(
+		probePorts.map(async (port) => {
+			const origin = `http://localhost:${port}`;
+			try {
+				const response = await fetchWithTimeout(
+					`${origin}/api/element-install-target`,
+				);
+				if (!response.ok) {
+					return null;
+				}
+
+				const target = (await response.json()) as ElementInstallTarget;
+				if (target.type !== 'remotion-studio') {
+					return null;
+				}
+
+				return {...target, origin};
+			} catch {
+				return null;
+			}
+		}),
+	);
+
+	const now = Date.now();
+	const installableTargets = targets.filter(
+		(target): target is ElementInstallTarget & {origin: string} =>
+			target !== null &&
+			target.canInstall &&
+			target.lastFocusedAt !== null &&
+			now - target.lastFocusedAt < focusedStudioMaxAge,
+	);
+
+	return (
+		installableTargets.sort((a, b) => b.lastFocusedAt! - a.lastFocusedAt!)[0] ??
+		null
+	);
 };
 
 export const ElementPage: React.FC<ElementPageProps> = ({
@@ -50,6 +148,9 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	sourceCode,
 	width = 1920,
 }) => {
+	const [installStatus, setInstallStatus] = useState<InstallStatus>({
+		type: 'idle',
+	});
 	const hasElementDimensions =
 		elementWidth !== undefined && elementHeight !== undefined;
 	const previewWidth =
@@ -81,6 +182,61 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 			sourceCode,
 		});
 	}, [displayName, elementHeight, elementWidth, slug, sourceCode]);
+
+	const installElement = useCallback(async () => {
+		if (dragData === null) {
+			return;
+		}
+
+		setInstallStatus({type: 'installing'});
+		try {
+			const target = await findBestInstallTarget();
+			if (target === null) {
+				setInstallStatus({
+					type: 'error',
+					message:
+						'Focus the Remotion Studio you want to install into, then click again.',
+				});
+				return;
+			}
+
+			const response = await fetchWithTimeout(
+				`${target.origin}/api/request-element-install`,
+				{
+					method: 'POST',
+					headers: {'Content-Type': 'application/json'},
+					body: JSON.stringify({element: dragData.element}),
+				},
+			);
+			const result = (await response.json()) as
+				| {success: true; status: 'sent'}
+				| {success: false; reason: string};
+
+			if (!response.ok || !result.success) {
+				setInstallStatus({
+					type: 'error',
+					message:
+						'success' in result && result.success === false
+							? result.reason
+							: 'Could not send Element to Remotion Studio.',
+				});
+				return;
+			}
+
+			setInstallStatus({
+				type: 'success',
+				message: `Sent to ${target.projectName ?? 'Remotion Studio'}${
+					target.activeCompositionId ? ` / ${target.activeCompositionId}` : ''
+				}. Confirm the install in Studio.`,
+				studioUrl: target.origin,
+			});
+		} catch (err) {
+			setInstallStatus({
+				type: 'error',
+				message: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}, [dragData]);
 
 	const PreviewComponent = useMemo(() => {
 		if (!hasElementDimensions) {
@@ -145,24 +301,64 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 				supplied by the gallery.
 			</p>
 			{dragData === null ? null : (
-				<p>
-					<button
-						draggable
-						onDragStart={(event) => {
-							setElementDragData({
-								dataTransfer: event.dataTransfer,
-								dragData,
-							});
-							setElementDragImage(event.dataTransfer);
-						}}
-						style={dragButtonStyle}
-						title="Drag into Remotion Studio"
-						type="button"
-					>
-						<span aria-hidden="true">↘</span>
-						Drag into Remotion Studio
-					</button>
-				</p>
+				<>
+					<p style={actionRowStyle}>
+						<button
+							disabled={installStatus.type === 'installing'}
+							onClick={installElement}
+							style={
+								installStatus.type === 'installing'
+									? disabledInstallButtonStyle
+									: installButtonStyle
+							}
+							title="Install into the most recently focused Remotion Studio"
+							type="button"
+						>
+							<span aria-hidden="true">＋</span>
+							{installStatus.type === 'installing'
+								? 'Finding Studio…'
+								: 'Install Element'}
+						</button>
+						<button
+							draggable
+							onDragStart={(event) => {
+								setElementDragData({
+									dataTransfer: event.dataTransfer,
+									dragData,
+								});
+								setElementDragImage(event.dataTransfer);
+							}}
+							style={dragButtonStyle}
+							title="Drag into Remotion Studio"
+							type="button"
+						>
+							<span aria-hidden="true">↘</span>
+							Drag into Remotion Studio
+						</button>
+					</p>
+					{installStatus.type === 'success' ||
+					installStatus.type === 'error' ? (
+						<p
+							style={{
+								color:
+									installStatus.type === 'success'
+										? 'var(--ifm-color-success-dark)'
+										: 'var(--ifm-color-danger-dark)',
+							}}
+						>
+							{installStatus.message}{' '}
+							{installStatus.type === 'success' ? (
+								<a
+									href={installStatus.studioUrl}
+									rel="noreferrer"
+									target="_blank"
+								>
+									Open Studio
+								</a>
+							) : null}
+						</p>
+					) : null}
+				</>
 			)}
 
 			<h2>Source</h2>

--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -46,6 +46,7 @@ import {unsubscribeFromSequenceProps} from './routes/unsubscribe-from-sequence-p
 import {handleUpdate} from './routes/update-available';
 import {updateDefaultPropsHandler} from './routes/update-default-props';
 import {updateEffectKeyframeSettingsHandler} from './routes/update-effect-keyframe-settings';
+import {updateElementInstallTargetHandler} from './routes/update-element-install-target';
 import {updateSequenceKeyframeSettingsHandler} from './routes/update-sequence-keyframe-settings';
 
 export const allApiRoutes: {
@@ -98,6 +99,7 @@ export const allApiRoutes: {
 	'/api/install-package': handleInstallPackage,
 	'/api/insert-jsx-element': insertJsxElementHandler,
 	'/api/insert-element': insertElementHandler,
+	'/api/update-element-install-target': updateElementInstallTargetHandler,
 	'/api/download-remote-asset': downloadRemoteAssetHandler,
 	'/api/undo': undoHandler,
 	'/api/redo': redoHandler,

--- a/packages/studio-server/src/preview-server/element-install-state.ts
+++ b/packages/studio-server/src/preview-server/element-install-state.ts
@@ -1,0 +1,55 @@
+export const ELEMENT_INSTALL_TARGET_MAX_AGE = 5000;
+
+export type ElementInstallTarget = {
+	clientId: string;
+	compositionFile: string | null;
+	compositionId: string | null;
+	canInstall: boolean;
+	lastFocusedAt: number | null;
+	readOnly: boolean;
+	updatedAt: number;
+};
+
+const targetsByClientId = new Map<string, ElementInstallTarget>();
+
+const compareTargets = (a: ElementInstallTarget, b: ElementInstallTarget) => {
+	const aFocusedAt = a.lastFocusedAt ?? 0;
+	const bFocusedAt = b.lastFocusedAt ?? 0;
+
+	if (aFocusedAt !== bFocusedAt) {
+		return aFocusedAt - bFocusedAt;
+	}
+
+	return a.updatedAt - b.updatedAt;
+};
+
+export const updateElementInstallTarget = (
+	newTarget: Omit<ElementInstallTarget, 'updatedAt'>,
+) => {
+	targetsByClientId.set(newTarget.clientId, {
+		...newTarget,
+		updatedAt: Date.now(),
+	});
+};
+
+export const getElementInstallTarget = () => {
+	const now = Date.now();
+	let bestTarget: ElementInstallTarget | null = null;
+
+	for (const [clientId, currentTarget] of targetsByClientId) {
+		if (now - currentTarget.updatedAt >= ELEMENT_INSTALL_TARGET_MAX_AGE) {
+			targetsByClientId.delete(clientId);
+			continue;
+		}
+
+		if (bestTarget === null || compareTargets(currentTarget, bestTarget) > 0) {
+			bestTarget = currentTarget;
+		}
+	}
+
+	return bestTarget;
+};
+
+export const clearElementInstallStateForTests = () => {
+	targetsByClientId.clear();
+};

--- a/packages/studio-server/src/preview-server/live-events.ts
+++ b/packages/studio-server/src/preview-server/live-events.ts
@@ -17,7 +17,7 @@ type Client = {
 
 export type LiveEventsServer = {
 	sendEventToClient: (event: EventSourceEvent) => void;
-	sendEventToClientId: (clientId: string, event: EventSourceEvent) => void;
+	sendEventToClientId: (clientId: string, event: EventSourceEvent) => boolean;
 	router: (request: IncomingMessage, response: ServerResponse) => Promise<void>;
 	closeConnections: () => Promise<void>;
 	addNewClientListener: (cb: () => void) => () => void;
@@ -106,9 +106,12 @@ export const makeLiveEventsRouter = (
 
 	const sendEventToClientId = (clientId: string, event: EventSourceEvent) => {
 		const client = clients.find((c) => c.id === clientId);
-		if (client) {
-			client.response.write(serializeMessage(event));
+		if (!client) {
+			return false;
 		}
+
+		client.response.write(serializeMessage(event));
+		return true;
 	};
 
 	const addNewClientListener = (cb: () => void) => {

--- a/packages/studio-server/src/preview-server/routes/update-element-install-target.ts
+++ b/packages/studio-server/src/preview-server/routes/update-element-install-target.ts
@@ -1,0 +1,38 @@
+import type {
+	UpdateElementInstallTargetRequest,
+	UpdateElementInstallTargetResponse,
+} from '@remotion/studio-shared';
+import type {ApiHandler} from '../api-types';
+import {updateElementInstallTarget} from '../element-install-state';
+
+const isFiniteTimestamp = (value: number | null) => {
+	return value === null || (Number.isFinite(value) && value > 0);
+};
+
+export const updateElementInstallTargetHandler: ApiHandler<
+	UpdateElementInstallTargetRequest,
+	UpdateElementInstallTargetResponse
+> = ({input}) => {
+	if (typeof input.clientId !== 'string' || input.clientId.length === 0) {
+		throw new Error('Invalid client ID');
+	}
+
+	if (!isFiniteTimestamp(input.lastFocusedAt)) {
+		throw new Error('Invalid focus timestamp');
+	}
+
+	if (
+		input.compositionFile !== null &&
+		typeof input.compositionFile !== 'string'
+	) {
+		throw new Error('Invalid composition file');
+	}
+
+	if (input.compositionId !== null && typeof input.compositionId !== 'string') {
+		throw new Error('Invalid composition ID');
+	}
+
+	updateElementInstallTarget(input);
+
+	return Promise.resolve({});
+};

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -8,21 +8,27 @@ import type {LogLevel} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	ApiRoutes,
+	ElementInstallRequest,
 	GitSource,
 	RenderDefaults,
 	RenderJob,
 } from '@remotion/studio-shared';
-import {getProjectName} from '@remotion/studio-shared';
+import {getProjectName, parseElementDragData} from '@remotion/studio-shared';
 import {getCompletedClientRenders} from './client-render-queue';
 import {getFileSource} from './helpers/get-file-source';
 import {getInstalledInstallablePackages} from './helpers/get-installed-installable-packages';
 import {resolveOutputPath} from './helpers/resolve-output-path';
 import {allApiRoutes} from './preview-server/api-routes';
 import type {ApiHandler, QueueMethods} from './preview-server/api-types';
+import {
+	ELEMENT_INSTALL_TARGET_MAX_AGE,
+	getElementInstallTarget,
+} from './preview-server/element-install-state';
 import {getPackageManager} from './preview-server/get-package-manager';
 import {getStaticFileFallbackHint} from './preview-server/get-static-file-fallback-hint';
 import {handleRequest} from './preview-server/handler';
 import type {LiveEventsServer} from './preview-server/live-events';
+import {parseRequestBody} from './preview-server/parse-body';
 import {fetchFolder, getFiles} from './preview-server/public-folder';
 import {getEditorName} from './preview-server/routes/open-in-editor';
 import {serveStatic} from './preview-server/serve-static';
@@ -30,6 +36,7 @@ import {validateSameOrigin} from './preview-server/validate-same-origin';
 import {reloadPreviouslySuppressedFiles} from './preview-server/watch-ignore-next-change';
 import type {RemotionConfigResponse} from './remotion-config-response';
 const loggedStaticFileHints = new Set<string>();
+const ELEMENT_INSTALL_FOCUS_MAX_AGE = 5 * 60 * 1000;
 
 const static404 = (response: ServerResponse): Promise<void> => {
 	response.writeHead(404);
@@ -61,6 +68,204 @@ const handleRemotionConfig = (
 	};
 	response.end(JSON.stringify(body));
 	return Promise.resolve();
+};
+
+const isAllowedElementInstallOrigin = (origin: string | undefined) => {
+	if (!origin) {
+		return false;
+	}
+
+	try {
+		const url = new URL(origin);
+		return (
+			(url.protocol === 'https:' &&
+				(url.hostname === 'remotion.dev' ||
+					url.hostname === 'www.remotion.dev')) ||
+			(url.protocol === 'http:' &&
+				(url.hostname === 'localhost' || url.hostname === '127.0.0.1'))
+		);
+	} catch {
+		return false;
+	}
+};
+
+const setElementInstallCorsHeaders = ({
+	request,
+	response,
+}: {
+	request: IncomingMessage;
+	response: ServerResponse;
+}) => {
+	const {origin} = request.headers;
+	if (isAllowedElementInstallOrigin(origin)) {
+		response.setHeader('Access-Control-Allow-Origin', origin as string);
+		response.setHeader('Vary', 'Origin');
+		response.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+		response.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+		response.setHeader('Access-Control-Max-Age', '600');
+		response.setHeader('Access-Control-Allow-Private-Network', 'true');
+	}
+};
+
+const handleElementInstallOptions = ({
+	request,
+	response,
+}: {
+	request: IncomingMessage;
+	response: ServerResponse;
+}) => {
+	setElementInstallCorsHeaders({request, response});
+	response.writeHead(
+		isAllowedElementInstallOrigin(request.headers.origin) ? 204 : 403,
+	);
+	response.end();
+	return Promise.resolve();
+};
+
+const handleElementInstallTarget = ({
+	request,
+	response,
+	remotionRoot,
+	gitSource,
+}: {
+	request: IncomingMessage;
+	response: ServerResponse;
+	remotionRoot: string;
+	gitSource: GitSource | null;
+}) => {
+	if (!isAllowedElementInstallOrigin(request.headers.origin)) {
+		response.writeHead(403);
+		response.end(
+			JSON.stringify({success: false, reason: 'Origin not allowed'}),
+		);
+		return Promise.resolve();
+	}
+
+	const target = getElementInstallTarget();
+	const now = Date.now();
+	const targetIsLive =
+		target !== null && now - target.updatedAt < ELEMENT_INSTALL_TARGET_MAX_AGE;
+	const host = request.headers.host ?? null;
+	const port = host?.split(':').at(-1) ?? null;
+	setElementInstallCorsHeaders({request, response});
+	response.writeHead(200, {'Content-Type': 'application/json'});
+	response.end(
+		JSON.stringify({
+			type: 'remotion-studio',
+			projectName: getProjectName({
+				basename: path.basename,
+				gitSource,
+				resolvedRemotionRoot: remotionRoot,
+			}),
+			port: port === null ? null : Number(port),
+			lastFocusedAt: target?.lastFocusedAt ?? null,
+			canInstall: target !== null && target.canInstall && targetIsLive,
+			activeCompositionId: target?.compositionId ?? null,
+			readOnly: target?.readOnly ?? false,
+		}),
+	);
+	return Promise.resolve();
+};
+
+const handleRequestElementInstall = async ({
+	liveEventsServer,
+	request,
+	response,
+}: {
+	liveEventsServer: LiveEventsServer;
+	request: IncomingMessage;
+	response: ServerResponse;
+}) => {
+	if (!isAllowedElementInstallOrigin(request.headers.origin)) {
+		response.writeHead(403);
+		response.end(
+			JSON.stringify({success: false, reason: 'Origin not allowed'}),
+		);
+		return;
+	}
+
+	setElementInstallCorsHeaders({request, response});
+	response.setHeader('Content-Type', 'application/json');
+
+	try {
+		const body = await parseRequestBody(request);
+		const parsed = parseElementDragData(
+			JSON.stringify({
+				type: 'remotion-element',
+				version: 1,
+				element: (body as {element?: unknown}).element,
+			}),
+		);
+
+		if (parsed === null) {
+			response.writeHead(400);
+			response.end(
+				JSON.stringify({success: false, reason: 'Invalid Element payload'}),
+			);
+			return;
+		}
+
+		const target = getElementInstallTarget();
+		const now = Date.now();
+		const targetIsLive =
+			target !== null &&
+			now - target.updatedAt < ELEMENT_INSTALL_TARGET_MAX_AGE;
+		const targetWasRecentlyFocused =
+			target !== null &&
+			target.lastFocusedAt !== null &&
+			now - target.lastFocusedAt < ELEMENT_INSTALL_FOCUS_MAX_AGE;
+		if (
+			target === null ||
+			!target.canInstall ||
+			target.compositionFile === null ||
+			target.compositionId === null ||
+			!targetIsLive ||
+			!targetWasRecentlyFocused
+		) {
+			response.writeHead(409);
+			response.end(
+				JSON.stringify({
+					success: false,
+					reason: 'No focused writable Remotion Studio composition',
+				}),
+			);
+			return;
+		}
+
+		const installRequest: ElementInstallRequest = {
+			id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+			clientId: target.clientId,
+			createdAt: Date.now(),
+			compositionFile: target.compositionFile,
+			compositionId: target.compositionId,
+			element: parsed.element,
+			position: null,
+		};
+
+		const delivered = liveEventsServer.sendEventToClientId(target.clientId, {
+			type: 'element-install-request',
+			request: installRequest,
+		});
+
+		if (delivered === false) {
+			response.writeHead(409);
+			response.end(
+				JSON.stringify({
+					success: false,
+					reason: 'The selected Remotion Studio tab is no longer connected',
+				}),
+			);
+			return;
+		}
+
+		response.writeHead(200);
+		response.end(JSON.stringify({success: true, status: 'sent'}));
+	} catch (err) {
+		response.writeHead(500);
+		response.end(
+			JSON.stringify({success: false, reason: (err as Error).message}),
+		);
+	}
 };
 
 const handleFallback = async ({
@@ -412,6 +617,30 @@ export const handleRoutes = ({
 			res: response,
 			search: url.search,
 			remotionRoot,
+		});
+	}
+
+	if (
+		url.pathname === '/api/element-install-target' ||
+		url.pathname === '/api/request-element-install'
+	) {
+		if (request.method === 'OPTIONS') {
+			return handleElementInstallOptions({request, response});
+		}
+
+		if (url.pathname === '/api/element-install-target') {
+			return handleElementInstallTarget({
+				request,
+				response,
+				remotionRoot,
+				gitSource,
+			});
+		}
+
+		return handleRequestElementInstall({
+			liveEventsServer,
+			request,
+			response,
 		});
 	}
 

--- a/packages/studio-server/src/test/add-keyframes.test.ts
+++ b/packages/studio-server/src/test/add-keyframes.test.ts
@@ -93,7 +93,7 @@ test('addKeyframes batches sequence and effect adds into one undo entry', async 
 		closeConnections: () => Promise.resolve(),
 		router: () => Promise.resolve(),
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 	});
 	const dir = mkdtempSync(join(tmpdir(), 'remotion-add-keyframes-'));
 	const fileName = 'Comp.tsx';
@@ -167,7 +167,7 @@ test('addKeyframes adds a missing effect prop before keyframing it', async () =>
 		closeConnections: () => Promise.resolve(),
 		router: () => Promise.resolve(),
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 	});
 	const dir = mkdtempSync(join(tmpdir(), 'remotion-add-missing-effect-'));
 	const fileName = 'Comp.tsx';

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -196,7 +196,7 @@ const runCompositionCodemodUndoRedoTest = async ({
 	);
 	const cleanupLiveEvents = setLiveEventsListener({
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 		router: () => Promise.resolve(),
 		closeConnections: () => Promise.resolve(),
 		addNewClientListener: () => () => undefined,
@@ -325,7 +325,7 @@ test('applyCodemodHandler pushes composition moves to undo and redo stacks', asy
 	);
 	const cleanupLiveEvents = setLiveEventsListener({
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 		router: () => Promise.resolve(),
 		closeConnections: () => Promise.resolve(),
 		addNewClientListener: () => () => undefined,
@@ -388,7 +388,7 @@ test('applyCodemodHandler pushes composition moves to root to undo and redo stac
 	);
 	const cleanupLiveEvents = setLiveEventsListener({
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 		router: () => Promise.resolve(),
 		closeConnections: () => Promise.resolve(),
 		addNewClientListener: () => () => undefined,
@@ -451,7 +451,7 @@ test('applyCodemodHandler creates new composition files with undo and redo', asy
 	);
 	const cleanupLiveEvents = setLiveEventsListener({
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 		router: () => Promise.resolve(),
 		closeConnections: () => Promise.resolve(),
 		addNewClientListener: () => () => undefined,

--- a/packages/studio-server/src/test/delete-keyframes.test.ts
+++ b/packages/studio-server/src/test/delete-keyframes.test.ts
@@ -40,7 +40,7 @@ test('deleteKeyframes batches sequence and effect deletes into one undo entry', 
 		closeConnections: () => Promise.resolve(),
 		router: () => Promise.resolve(),
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 	});
 	const dir = mkdtempSync(join(tmpdir(), 'remotion-delete-keyframes-'));
 	const fileName = 'Comp.tsx';

--- a/packages/studio-server/src/test/element-install-state.test.ts
+++ b/packages/studio-server/src/test/element-install-state.test.ts
@@ -1,0 +1,63 @@
+import {expect, test} from 'bun:test';
+import {
+	clearElementInstallStateForTests,
+	getElementInstallTarget,
+	updateElementInstallTarget,
+} from '../preview-server/element-install-state';
+
+test('uses the most recently focused Studio target even when older tabs keep updating', () => {
+	clearElementInstallStateForTests();
+
+	updateElementInstallTarget({
+		clientId: 'older-tab',
+		compositionFile: '/project/src/older.tsx',
+		compositionId: 'older-composition',
+		canInstall: true,
+		lastFocusedAt: 1000,
+		readOnly: false,
+	});
+	updateElementInstallTarget({
+		clientId: 'focused-tab',
+		compositionFile: '/project/src/focused.tsx',
+		compositionId: 'focused-composition',
+		canInstall: true,
+		lastFocusedAt: 2000,
+		readOnly: false,
+	});
+	updateElementInstallTarget({
+		clientId: 'older-tab',
+		compositionFile: '/project/src/older.tsx',
+		compositionId: 'older-composition',
+		canInstall: true,
+		lastFocusedAt: 1000,
+		readOnly: false,
+	});
+
+	expect(getElementInstallTarget()?.clientId).toBe('focused-tab');
+});
+
+test('falls back to update recency when focus timestamps match', async () => {
+	clearElementInstallStateForTests();
+
+	updateElementInstallTarget({
+		clientId: 'first-tab',
+		compositionFile: '/project/src/first.tsx',
+		compositionId: 'first-composition',
+		canInstall: true,
+		lastFocusedAt: 1000,
+		readOnly: false,
+	});
+
+	await new Promise((resolve) => setTimeout(resolve, 2));
+
+	updateElementInstallTarget({
+		clientId: 'second-tab',
+		compositionFile: '/project/src/second.tsx',
+		compositionId: 'second-composition',
+		canInstall: true,
+		lastFocusedAt: 1000,
+		readOnly: false,
+	});
+
+	expect(getElementInstallTarget()?.clientId).toBe('second-tab');
+});

--- a/packages/studio-server/src/test/save-sequence-props.test.ts
+++ b/packages/studio-server/src/test/save-sequence-props.test.ts
@@ -107,7 +107,7 @@ test('saveSequenceProps batches sequence movement and keyframe movement into one
 		closeConnections: () => Promise.resolve(),
 		router: () => Promise.resolve(),
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 	});
 	const dir = mkdtempSync(join(tmpdir(), 'remotion-save-sequence-props-'));
 	const fileName = 'Comp.tsx';

--- a/packages/studio-server/src/test/split-jsx-sequence.test.ts
+++ b/packages/studio-server/src/test/split-jsx-sequence.test.ts
@@ -180,7 +180,7 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 	);
 	const cleanupLiveEvents = setLiveEventsListener({
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 		router: () => Promise.resolve(),
 		closeConnections: () => Promise.resolve(),
 		addNewClientListener: () => () => undefined,

--- a/packages/studio-server/src/test/undo-stack.test.ts
+++ b/packages/studio-server/src/test/undo-stack.test.ts
@@ -23,7 +23,7 @@ test('undo and redo restore every file in a transaction', () => {
 		closeConnections: () => Promise.resolve(),
 		router: () => Promise.resolve(),
 		sendEventToClient: () => undefined,
-		sendEventToClientId: () => undefined,
+		sendEventToClientId: () => true,
 	});
 	const dir = mkdtempSync(join(tmpdir(), 'remotion-undo-stack-'));
 	const firstFile = join(dir, 'first.tsx');

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -18,10 +18,10 @@ import type {
 	CanUpdateSequencePropsResponseTrue,
 	CanUpdateSequencePropStatus,
 	ExtrapolateType,
+	InteractivitySchema,
 	JsxComponentIdentity,
 	SequenceNodePath,
 	SequencePropsSubscriptionKey,
-	InteractivitySchema,
 } from 'remotion';
 import type {RecastCodemod, VisualControlChange} from './codemods';
 import type {ComponentProp} from './component-drag-data';
@@ -757,6 +757,27 @@ export type InsertElementResponse =
 			stack: string;
 	  };
 
+export type ElementInstallRequest = {
+	id: string;
+	clientId: string;
+	createdAt: number;
+	compositionFile: string;
+	compositionId: string;
+	element: ElementDragData['element'];
+	position: InsertableCompositionElementPosition | null;
+};
+
+export type UpdateElementInstallTargetRequest = {
+	clientId: string;
+	compositionFile: string | null;
+	compositionId: string | null;
+	canInstall: boolean;
+	lastFocusedAt: number | null;
+	readOnly: boolean;
+};
+
+export type UpdateElementInstallTargetResponse = {};
+
 export type DownloadRemoteAssetRequest = {
 	url: string;
 };
@@ -921,6 +942,10 @@ export type ApiRoutes = {
 		InsertJsxElementResponse
 	>;
 	'/api/insert-element': ReqAndRes<InsertElementRequest, InsertElementResponse>;
+	'/api/update-element-install-target': ReqAndRes<
+		UpdateElementInstallTargetRequest,
+		UpdateElementInstallTargetResponse
+	>;
 	'/api/download-remote-asset': ReqAndRes<
 		DownloadRemoteAssetRequest,
 		DownloadRemoteAssetResponse

--- a/packages/studio-shared/src/event-source-event.ts
+++ b/packages/studio-shared/src/event-source-event.ts
@@ -3,7 +3,10 @@ import type {
 	CanUpdateSequencePropsResponse,
 	SequencePropsSubscriptionKey,
 } from 'remotion';
-import type {CanUpdateDefaultPropsResponse} from './api-requests';
+import type {
+	CanUpdateDefaultPropsResponse,
+	ElementInstallRequest,
+} from './api-requests';
 import type {HotMiddlewareMessage} from './hot-middleware';
 import type {CompletedClientRender, RenderJob} from './render-job';
 
@@ -72,6 +75,10 @@ export type EventSourceEvent =
 			type: 'undo-redo-stack-changed';
 			undoFile: string | null;
 			redoFile: string | null;
+	  }
+	| {
+			type: 'element-install-request';
+			request: ElementInstallRequest;
 	  }
 	| {
 			type: 'visual-control-values-changed';

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -40,6 +40,8 @@ export {
 	DuplicateEffectResponse,
 	DuplicateJsxNodeRequest,
 	DuplicateJsxNodeResponse,
+	ElementInstallRequest,
+	GoogleFontSourceEdit,
 	InsertElementRequest,
 	InsertElementResponse,
 	InsertJsxElementRequest,
@@ -73,11 +75,10 @@ export {
 	ReorderSequenceResponse,
 	RestartStudioRequest,
 	RestartStudioResponse,
-	GoogleFontSourceEdit,
-	SaveSequencePropSourceEdit,
 	SaveEffectPropsRequest,
 	SaveEffectPropsResponse,
 	SaveSequencePropEdit,
+	SaveSequencePropSourceEdit,
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse,
 	SaveSequencePropsResult,
@@ -101,6 +102,8 @@ export {
 	UpdateDefaultPropsResponse,
 	UpdateEffectKeyframeSettingsRequest,
 	UpdateEffectKeyframeSettingsResponse,
+	UpdateElementInstallTargetRequest,
+	UpdateElementInstallTargetResponse,
 	UpdateSequenceKeyframeSettingsRequest,
 	UpdateSequenceKeyframeSettingsResponse,
 	type AddEffectKeyframe,
@@ -141,8 +144,8 @@ export {
 	type ImageFileType,
 } from './detect-file-type';
 export {
-	isRemotionDragMimeType,
 	REMOTION_DRAG_MIME_TYPES,
+	isRemotionDragMimeType,
 	type RemotionDragMimeType,
 } from './drag-mime-types';
 export {
@@ -215,12 +218,12 @@ export {
 export {
 	CUBIC_KEYFRAME_EASING,
 	EASE_KEYFRAME_EASING,
-	getBackKeyframeEasing,
-	getOutKeyframeEasing,
-	getPolyKeyframeEasing,
 	KEYFRAME_EASING_PRESETS,
 	LINEAR_KEYFRAME_EASING,
 	QUAD_KEYFRAME_EASING,
+	getBackKeyframeEasing,
+	getOutKeyframeEasing,
+	getPolyKeyframeEasing,
 	type KeyframeEasing,
 	type KeyframeEasingPreset,
 } from './keyframe-easing-presets';
@@ -301,12 +304,12 @@ export {
 	StackFrame,
 	SymbolicatedStackFrame,
 } from './stack-types';
+export {EnumPath, stringifyDefaultProps} from './stringify-default-props';
 export {
 	getStudioEntryPoints,
 	type StudioEntryPointPaths,
 } from './studio-entry-points';
 export {studioHtml, type StudioHtmlOptions} from './studio-html';
-export {EnumPath, stringifyDefaultProps} from './stringify-default-props';
 
 export type {VisualControlChange} from './codemods';
 export {

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1,16 +1,17 @@
 import type {Size} from '@remotion/player';
 import {
 	ASSET_DRAG_MIME_TYPE,
-	COMPOSITION_DRAG_MIME_TYPE,
 	COMPONENT_DRAG_MIME_TYPE,
+	COMPOSITION_DRAG_MIME_TYPE,
 	ELEMENT_DRAG_MIME_TYPE,
 	parseAssetDragData,
-	parseCompositionDragData,
 	parseComponentDragData,
+	parseCompositionDragData,
 	parseSfxDragData,
 	SFX_DRAG_MIME_TYPE,
-	type CompositionDragData,
 	type ComponentDragData,
+	type CompositionDragData,
+	type ElementInstallRequest,
 } from '@remotion/studio-shared';
 import React, {
 	useCallback,
@@ -46,6 +47,8 @@ import {useKeybinding} from '../helpers/use-keybinding';
 import {canvasRef} from '../state/canvas-ref';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorZoomGesturesContext} from '../state/editor-zoom-gestures';
+import {callApi} from './call-api';
+import {useConfirmationDialog} from './ConfirmationDialog';
 import EditorGuides from './EditorGuides';
 import {EditorRulers} from './EditorRuler';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
@@ -54,8 +57,8 @@ import {getElementDragData} from './element-drag-and-drop';
 import {
 	importAssets,
 	importRemoteAsset,
-	insertComposition,
 	insertComponent,
+	insertComposition,
 	insertElement,
 	insertExistingAssets,
 	insertRemoteAudio,
@@ -65,6 +68,35 @@ import {SPACING_UNIT} from './layout';
 import {VideoPreview} from './Preview';
 import {ResetZoomButton} from './ResetZoomButton';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
+
+const elementInstallCompositionIdStyle: React.CSSProperties = {
+	fontFamily: 'monospace',
+	fontSize: 13,
+};
+
+const elementInstallCodeDetailsStyle: React.CSSProperties = {
+	marginTop: 12,
+	fontSize: 13,
+};
+
+const elementInstallCodeSummaryStyle: React.CSSProperties = {
+	cursor: 'pointer',
+	fontSize: 13,
+	fontWeight: 500,
+};
+
+const elementInstallCodeBlockStyle: React.CSSProperties = {
+	marginTop: 8,
+	marginBottom: 0,
+	maxHeight: 240,
+	overflow: 'auto',
+	padding: 12,
+	borderRadius: 6,
+	backgroundColor: 'rgba(255, 255, 255, 0.06)',
+	fontSize: 12,
+	lineHeight: 1.5,
+	whiteSpace: 'pre',
+};
 
 const getContainerStyle = (
 	editorZoomGestures: boolean,
@@ -272,12 +304,29 @@ export const Canvas: React.FC<{
 		initialZoom: number;
 	} | null>(null);
 	const keybindings = useKeybinding();
+	const confirm = useConfirmationDialog();
 	const config = Internals.useUnsafeVideoConfig();
 	const areRulersVisible = useIsRulerVisible();
 	const {editorShowGuides} = useContext(EditorShowGuidesContext);
 	const {compositions} = useContext(Internals.CompositionManager);
-	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {previewServerState, subscribeToEvent} = useContext(
+		StudioServerConnectionCtx,
+	);
+	const previewServerClientId =
+		previewServerState.type === 'connected'
+			? previewServerState.clientId
+			: null;
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
+	const [installingElementName, setInstallingElementName] = useState<
+		string | null
+	>(null);
+	const [pendingElementInstallRequests, setPendingElementInstallRequests] =
+		useState<ElementInstallRequest[]>([]);
+	const [activeElementInstallRequest, setActiveElementInstallRequest] =
+		useState<ElementInstallRequest | null>(null);
+	const lastFocusedAtRef = useRef<number | null>(
+		typeof document === 'undefined' || document.hasFocus() ? Date.now() : null,
+	);
 
 	const [assetResolution, setAssetResolution] = useState<AssetMetadata | null>(
 		null,
@@ -304,13 +353,13 @@ export const Canvas: React.FC<{
 		compositionFile,
 		compositionId: currentCompositionId,
 	});
-	const canDropAssets =
-		previewServerState.type === 'connected' &&
+	const canInstallElements =
+		previewServerClientId !== null &&
 		!window.remotion_isReadOnlyStudio &&
 		compositionComponentInfo?.canAddSequence === true &&
 		currentCompositionId !== null &&
-		compositionFile !== null &&
-		!isAddingAsset;
+		compositionFile !== null;
+	const canDropAssets = canInstallElements && !isAddingAsset;
 
 	const contentDimensions = useMemo(() => {
 		if (
@@ -761,6 +810,163 @@ export const Canvas: React.FC<{
 	useEffect(() => {
 		fetchMetadata();
 	}, [fetchMetadata]);
+
+	const updateElementInstallTarget = useCallback(() => {
+		if (previewServerClientId === null) {
+			return;
+		}
+
+		callApi('/api/update-element-install-target', {
+			clientId: previewServerClientId,
+			compositionFile: canInstallElements ? compositionFile : null,
+			compositionId: canInstallElements ? currentCompositionId : null,
+			canInstall: canInstallElements,
+			lastFocusedAt: lastFocusedAtRef.current,
+			readOnly: window.remotion_isReadOnlyStudio,
+		}).catch(() => undefined);
+	}, [
+		canInstallElements,
+		compositionFile,
+		currentCompositionId,
+		previewServerClientId,
+	]);
+
+	useEffect(() => {
+		updateElementInstallTarget();
+		const interval = window.setInterval(updateElementInstallTarget, 2000);
+
+		return () => {
+			window.clearInterval(interval);
+		};
+	}, [updateElementInstallTarget]);
+
+	useEffect(() => {
+		const markFocused = () => {
+			lastFocusedAtRef.current = Date.now();
+			updateElementInstallTarget();
+		};
+
+		window.addEventListener('focus', markFocused);
+		document.addEventListener('pointerdown', markFocused, {capture: true});
+
+		return () => {
+			window.removeEventListener('focus', markFocused);
+			document.removeEventListener('pointerdown', markFocused, {capture: true});
+		};
+	}, [updateElementInstallTarget]);
+
+	useEffect(() => {
+		if (installingElementName === null) {
+			return;
+		}
+
+		const previousTitle = document.title;
+		document.title = `📦 Install ${installingElementName} - Remotion Studio`;
+
+		return () => {
+			document.title = previousTitle;
+		};
+	}, [installingElementName]);
+
+	useEffect(() => {
+		if (previewServerClientId === null) {
+			return;
+		}
+
+		return subscribeToEvent('element-install-request', (event) => {
+			if (
+				event.type !== 'element-install-request' ||
+				event.request.clientId !== previewServerClientId
+			) {
+				return;
+			}
+
+			setPendingElementInstallRequests((requests) => [
+				...requests,
+				event.request,
+			]);
+		});
+	}, [previewServerClientId, subscribeToEvent]);
+
+	useEffect(() => {
+		if (
+			activeElementInstallRequest !== null ||
+			pendingElementInstallRequests.length === 0
+		) {
+			return;
+		}
+
+		const [nextRequest, ...remainingRequests] = pendingElementInstallRequests;
+		if (!nextRequest) {
+			throw new Error('Expected pending Element install request');
+		}
+
+		setActiveElementInstallRequest(nextRequest);
+		setPendingElementInstallRequests(remainingRequests);
+	}, [activeElementInstallRequest, pendingElementInstallRequests]);
+
+	useEffect(() => {
+		if (activeElementInstallRequest === null) {
+			return;
+		}
+
+		let canceled = false;
+
+		const handleInstallRequest = async () => {
+			setInstallingElementName(activeElementInstallRequest.element.displayName);
+			const accepted = await confirm({
+				title: 'Install Element',
+				message: (
+					<>
+						Install “{activeElementInstallRequest.element.displayName}” into{' '}
+						<code style={elementInstallCompositionIdStyle}>
+							{activeElementInstallRequest.compositionId}
+						</code>{' '}
+						composition? This will create an Element source file and update the
+						composition source.
+						<details style={elementInstallCodeDetailsStyle}>
+							<summary style={elementInstallCodeSummaryStyle}>
+								Preview Element source
+							</summary>
+							<pre style={elementInstallCodeBlockStyle}>
+								<code>{activeElementInstallRequest.element.sourceCode}</code>
+							</pre>
+						</details>
+					</>
+				),
+				confirmLabel: 'Install',
+				cancelLabel: 'Cancel',
+			});
+
+			if (accepted && !canceled) {
+				await insertElement({
+					element: activeElementInstallRequest.element,
+					compositionFile: activeElementInstallRequest.compositionFile,
+					compositionId: activeElementInstallRequest.compositionId,
+					dropPosition: null,
+				});
+			}
+		};
+
+		handleInstallRequest()
+			.finally(() => {
+				if (canceled) {
+					return;
+				}
+
+				setInstallingElementName(null);
+				setActiveElementInstallRequest(null);
+			})
+			.catch((err) => {
+				setTimeout(() => {
+					throw err;
+				}, 0);
+			});
+
+		return () => {
+			canceled = true;
+		};
+	}, [activeElementInstallRequest, confirm]);
 
 	const onDragOver = useCallback(
 		(event: DragEvent) => {


### PR DESCRIPTION
## Summary
- add an Install Element button to docs Element pages that targets the most recently focused Studio
- expose Studio discovery/request endpoints and deliver install requests via targeted SSE
- show a Studio confirmation dialog with a collapsed source-code preview before writing files
- track install targets per Studio client to avoid background tab targeting issues

Related to #7698 

## Validation
- `cd packages/studio-server && bun test src/test/element-install-state.test.ts`
- `bun run build`
- `bun run stylecheck`
