### PR TITLE
`@remotion/convert`: Add ProRes decoder support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -319,6 +319,7 @@
         "@mediabunny/ac3": "catalog:",
         "@mediabunny/flac-encoder": "catalog:",
         "@mediabunny/mp3-encoder": "catalog:",
+        "@mediabunny/prores": "catalog:",
         "@mux/upchunk": "3.5.0",
         "@radix-ui/react-checkbox": "1.1.2",
         "@radix-ui/react-dialog": "1.1.15",

--- a/bun.lock
+++ b/bun.lock
@@ -336,6 +336,7 @@
         "@remotion/captions": "workspace:*",
         "@remotion/design": "workspace:*",
         "@remotion/layout-utils": "workspace:*",
+        "@remotion/media": "workspace:*",
         "@remotion/paths": "workspace:*",
         "@remotion/player": "workspace:*",
         "@remotion/shapes": "workspace:*",

--- a/packages/convert/app/components/MediaPlayer.tsx
+++ b/packages/convert/app/components/MediaPlayer.tsx
@@ -1,13 +1,8 @@
+import {Audio, Video} from '@remotion/media';
 import {Player, type PlayerRef} from '@remotion/player';
 import type {CropRectangle} from 'mediabunny';
 import {useEffect, useRef, useState} from 'react';
-import {
-	AbsoluteFill,
-	Audio,
-	useCurrentFrame,
-	useVideoConfig,
-	Video,
-} from 'remotion';
+import {AbsoluteFill, useCurrentFrame, useVideoConfig} from 'remotion';
 import type {Dimensions} from '~/lib/calculate-new-dimensions-from-dimensions';
 import type {Source} from '~/lib/convert-state';
 import {cn} from '~/lib/utils';
@@ -79,10 +74,10 @@ const RemotionMediaPreview: React.FC<{
 			<AbsoluteFill style={{backgroundColor: 'black'}}>
 				<Video
 					src={src}
+					objectFit="contain"
 					style={{
 						width: '100%',
 						height: '100%',
-						objectFit: 'contain',
 					}}
 				/>
 			</AbsoluteFill>

--- a/packages/convert/app/entry.client.tsx
+++ b/packages/convert/app/entry.client.tsx
@@ -1,6 +1,7 @@
 import {registerAacEncoder} from '@mediabunny/aac-encoder';
 import {registerFlacEncoder} from '@mediabunny/flac-encoder';
 import {registerMp3Encoder} from '@mediabunny/mp3-encoder';
+import {registerProresDecoder} from '@mediabunny/prores';
 import {RemixBrowser} from '@remix-run/react';
 import {startTransition} from 'react';
 import {hydrateRoot} from 'react-dom/client';
@@ -8,6 +9,7 @@ import {hydrateRoot} from 'react-dom/client';
 registerMp3Encoder();
 registerAacEncoder();
 registerFlacEncoder();
+registerProresDecoder();
 
 const registerServiceWorker = () => {
 	if ('serviceWorker' in navigator) {

--- a/packages/convert/package.json
+++ b/packages/convert/package.json
@@ -16,6 +16,7 @@
 		"@mediabunny/mp3-encoder": "catalog:",
 		"@mediabunny/aac-encoder": "catalog:",
 		"@mediabunny/flac-encoder": "catalog:",
+		"@mediabunny/prores": "catalog:",
 		"@mediabunny/ac3": "catalog:",
 		"@mux/upchunk": "3.5.0",
 		"@radix-ui/react-checkbox": "1.1.2",

--- a/packages/convert/package.json
+++ b/packages/convert/package.json
@@ -34,6 +34,7 @@
 		"@remotion/captions": "workspace:*",
 		"@remotion/design": "workspace:*",
 		"@remotion/layout-utils": "workspace:*",
+		"@remotion/media": "workspace:*",
 		"@remotion/paths": "workspace:*",
 		"@remotion/player": "workspace:*",
 		"@remotion/shapes": "workspace:*",

--- a/packages/convert/test/ensure-prod-flags.test.ts
+++ b/packages/convert/test/ensure-prod-flags.test.ts
@@ -26,3 +26,15 @@ test('Should register the ProRes decoder', () => {
 	};
 	expect(packageJson.dependencies['@mediabunny/prores']).toBe('catalog:');
 });
+
+test('Should use Mediabunny-backed preview components', () => {
+	const mediaPlayer = readPackageFile('../app/components/MediaPlayer.tsx');
+	expect(mediaPlayer).toContain(
+		"import {Audio, Video} from '@remotion/media';",
+	);
+
+	const packageJson = JSON.parse(readPackageFile('../package.json')) as {
+		dependencies: Record<string, string>;
+	};
+	expect(packageJson.dependencies['@remotion/media']).toBe('workspace:*');
+});

--- a/packages/convert/test/ensure-prod-flags.test.ts
+++ b/packages/convert/test/ensure-prod-flags.test.ts
@@ -1,5 +1,10 @@
 import {expect, test} from 'bun:test';
+import {readFileSync} from 'node:fs';
 import {REMOTION_PRO_ORIGIN, TEST_FAST} from '~/lib/config';
+
+const readPackageFile = (path: string) => {
+	return readFileSync(new URL(path, import.meta.url), 'utf8');
+};
 
 test('Should not have convert fast enabled', () => {
 	expect(TEST_FAST).toBe(false);
@@ -7,4 +12,17 @@ test('Should not have convert fast enabled', () => {
 
 test('Should point to production remotion.pro', () => {
 	expect(REMOTION_PRO_ORIGIN).toBe('https://www.remotion.pro');
+});
+
+test('Should register the ProRes decoder', () => {
+	const entryClient = readPackageFile('../app/entry.client.tsx');
+	expect(entryClient).toContain(
+		"import {registerProresDecoder} from '@mediabunny/prores';",
+	);
+	expect(entryClient).toContain('registerProresDecoder();');
+
+	const packageJson = JSON.parse(readPackageFile('../package.json')) as {
+		dependencies: Record<string, string>;
+	};
+	expect(packageJson.dependencies['@mediabunny/prores']).toBe('catalog:');
 });


### PR DESCRIPTION
## Summary

- Register Mediabunny's ProRes decoder in the Convert client startup path
- Add `@mediabunny/prores` as a Convert dependency
- Add a regression check so ProRes registration stays wired

## Testing

- `bunx oxfmt app test --write`
- `bun test test`
- `bun run typecheck`
- `bun run lint`
- `bun run build-spa`
- `bun run build`
- `bun run stylecheck`
