### PR TITLE
`@remotion/remotion-media`: Add HLS test media

### DIFF
--- a/packages/convert/app/lib/get-default-output-format.ts
+++ b/packages/convert/app/lib/get-default-output-format.ts
@@ -2,6 +2,7 @@ import type {InputFormat} from 'mediabunny';
 import {
 	ADTS,
 	FLAC,
+	HLS,
 	MATROSKA,
 	MP3,
 	MP4,
@@ -20,6 +21,10 @@ const getDefaultConversionFormat = (
 	}
 
 	if (inputContainer === WEBM || inputContainer === MATROSKA) {
+		return 'mp4';
+	}
+
+	if (inputContainer === HLS) {
 		return 'mp4';
 	}
 

--- a/packages/convert/test/default-ui.test.ts
+++ b/packages/convert/test/default-ui.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'bun:test';
-import {MP4, QTFF, WEBM} from 'mediabunny';
+import {HLS, MP4, QTFF, WEBM} from 'mediabunny';
 import {
 	isConvertEnabledByDefault,
 	isVideoOnlySection,
@@ -51,6 +51,7 @@ test('keeps the input container by default on editing pages', () => {
 	expect(getDefaultEditOutputFormat(MP4)).toBe('mp4');
 	expect(getDefaultEditOutputFormat(WEBM)).toBe('webm');
 	expect(getDefaultEditOutputFormat(QTFF)).toBe('mov');
+	expect(getDefaultEditOutputFormat(HLS)).toBe('mp4');
 });
 
 test('uses conversion defaults when enabling convert controls', () => {
@@ -60,6 +61,12 @@ test('uses conversion defaults when enabling convert controls', () => {
 			action: {type: 'generic-trim'},
 		}),
 	).toBe('webm');
+	expect(
+		getDefaultConvertOutputFormat({
+			inputContainer: HLS,
+			action: {type: 'generic-trim'},
+		}),
+	).toBe('mp4');
 	expect(
 		getDefaultConvertOutputFormat({
 			inputContainer: MP4,
@@ -75,4 +82,10 @@ test('uses conversion defaults on conversion pages', () => {
 			action: {type: 'generic-convert'},
 		}),
 	).toBe('webm');
+	expect(
+		getDefaultConvertOutputFormat({
+			inputContainer: HLS,
+			action: {type: 'generic-convert'},
+		}),
+	).toBe('mp4');
 });

--- a/packages/remotion-media/README.md
+++ b/packages/remotion-media/README.md
@@ -27,3 +27,5 @@ Bundles the catalog UI and uploads to Cloudflare R2 when `AWS_ACCESS_KEY_ID` and
 ```bash
 bun run build
 ```
+
+HLS files are uploaded through the AWS CLI so their MIME types are preserved.

--- a/packages/remotion-media/build.ts
+++ b/packages/remotion-media/build.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
-import {build, S3Client, type BuildConfig} from 'bun';
-import plugin from 'bun-plugin-tailwind';
 import {cpSync, existsSync, readdirSync} from 'fs';
 import {rm} from 'fs/promises';
 import path from 'path';
+import {$, build, S3Client, type BuildConfig} from 'bun';
+import plugin from 'bun-plugin-tailwind';
 
 // Print help text if requested
 if (process.argv.includes('--help') || process.argv.includes('-h')) {
@@ -124,6 +124,20 @@ const formatFileSize = (bytes: number): string => {
 	return `${size.toFixed(2)} ${units[unitIndex]}`;
 };
 
+const hlsContentTypes: Record<string, string> = {
+	'.m3u8': 'application/vnd.apple.mpegurl',
+	'.m4s': 'video/iso.segment',
+	'.ts': 'video/mp2t',
+};
+
+const getContentType = (file: string) => {
+	return hlsContentTypes[path.extname(file)];
+};
+
+const r2Endpoint =
+	'https://2fe488b3b0f4deee223aef7464784c46.r2.cloudflarestorage.com';
+const r2Bucket = 'parser-media';
+
 console.log('\n🚀 Starting build process...\n');
 
 // Parse CLI arguments with our magical parser
@@ -199,22 +213,29 @@ if (!Bun.env.AWS_ACCESS_KEY_ID || !Bun.env.AWS_SECRET_ACCESS_KEY) {
 	const client = new S3Client({
 		accessKeyId: Bun.env.AWS_ACCESS_KEY_ID,
 		secretAccessKey: Bun.env.AWS_SECRET_ACCESS_KEY,
-		endpoint:
-			'https://2fe488b3b0f4deee223aef7464784c46.r2.cloudflarestorage.com',
-		bucket: 'parser-media',
+		endpoint: r2Endpoint,
+		bucket: r2Bucket,
 	});
 
 	for (const file of readdirSync(filesDir)) {
+		const filePath = path.join(filesDir, file);
 		const exists = await client.exists(file);
-		const fileToUpload = Bun.file(path.join(filesDir, file));
+		const contentType = getContentType(file);
+		const fileToUpload = Bun.file(filePath);
 		if (exists) {
 			const stat = await client.stat(file);
-			if (stat.size === fileToUpload.size) {
+			if (stat.size === fileToUpload.size && !contentType) {
 				console.log(
 					`Skipping ${file} because it already exists and is the same size`,
 				);
 				continue;
 			}
+		}
+
+		if (contentType) {
+			await $`AWS_DEFAULT_REGION=auto AWS_EC2_METADATA_DISABLED=true aws --endpoint-url ${r2Endpoint} s3 cp ${filePath} ${`s3://${r2Bucket}/${file}`} --content-type ${contentType} --only-show-errors`;
+			console.log(`Uploaded ${file}`);
+			continue;
 		}
 
 		await client.write(file, fileToUpload);

--- a/packages/remotion-media/generate.ts
+++ b/packages/remotion-media/generate.ts
@@ -788,6 +788,11 @@ for (const preset of hlsPresets) {
 		}
 	}
 
+	const playlistAliases = preset.label === 'ts' ? ['video.m3u8'] : [];
+	for (const playlistAlias of playlistAliases) {
+		copyFileSync(targetPath, path.join(outDir, playlistAlias));
+	}
+
 	const segmentFiles: string[] = [];
 	for await (const segFile of new Bun.Glob(
 		`hls-${preset.label}-*.${preset.segmentExt}`,
@@ -806,10 +811,34 @@ for (const preset of hlsPresets) {
 		videoCodec: 'h264',
 		audioCodec: 'aac',
 		container: 'm3u8',
-		fileNames: [outputName, ...segmentFiles.sort()],
+		fileNames: [...playlistAliases, outputName, ...segmentFiles.sort()],
 		size: stat.size,
 		category: 'hls',
 	});
 }
+
+const audioHlsName = 'audio.m3u8';
+const audioHlsTargetPath = path.join(outDir, audioHlsName);
+const audioHlsSegmentPattern = path.join(outDir, 'audio-%d.ts');
+
+if (!(await Bun.file(audioHlsTargetPath).exists())) {
+	console.log(`Generating ${audioHlsName}`);
+	await $`ffmpeg -i ${tonePath} -t 10 -vn -c:a aac -hls_time 2 -hls_playlist_type vod -hls_segment_type mpegts -hls_segment_filename ${audioHlsSegmentPattern} ${audioHlsTargetPath} -y`;
+}
+
+const audioSegmentFiles: string[] = [];
+for await (const segFile of new Bun.Glob('audio-*.ts').scan(outDir)) {
+	audioSegmentFiles.push(segFile);
+}
+
+const audioHlsStat = await Bun.file(audioHlsTargetPath).stat();
+variants.push({
+	videoCodec: 'none',
+	audioCodec: 'aac',
+	container: 'm3u8',
+	fileNames: [audioHlsName, ...audioSegmentFiles.sort()],
+	size: audioHlsStat.size,
+	category: 'hls',
+});
 
 await Bun.write('variants.json', JSON.stringify(variants, null, 2));

--- a/packages/remotion-media/variants.json
+++ b/packages/remotion-media/variants.json
@@ -1332,5 +1332,47 @@
     "size": 122958,
     "category": "sound-effects",
     "attribution": "Triggered -- https://www.myinstants.com/en/instant/core-sound-effect-57998/"
+  },
+  {
+    "videoCodec": "h264",
+    "audioCodec": "aac",
+    "container": "m3u8",
+    "fileNames": [
+      "video.m3u8",
+      "hls-ts.m3u8",
+      "hls-ts-0.ts",
+      "hls-ts-1.ts"
+    ],
+    "size": 173,
+    "category": "hls"
+  },
+  {
+    "videoCodec": "h264",
+    "audioCodec": "aac",
+    "container": "m3u8",
+    "fileNames": [
+      "hls-fmp4.m3u8",
+      "hls-fmp4-0.m4s",
+      "hls-fmp4-1.m4s",
+      "hls-fmp4-init.mp4"
+    ],
+    "size": 214,
+    "category": "hls"
+  },
+  {
+    "videoCodec": "none",
+    "audioCodec": "aac",
+    "container": "m3u8",
+    "fileNames": [
+      "audio.m3u8",
+      "audio-0.ts",
+      "audio-1.ts",
+      "audio-2.ts",
+      "audio-3.ts",
+      "audio-4.ts",
+      "audio-5.ts"
+    ],
+    "size": 287,
+    "category": "hls"
   }
 ]


### PR DESCRIPTION
## Summary

- Add HLS fixtures to remotion.media, including `video.m3u8` and `audio.m3u8` aliases
- Preserve HLS MIME types during R2 uploads
- Fix Remotion Convert default output handling for HLS inputs

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test test && bun run lint` in `packages/convert`
- `bun run lint` in `packages/remotion-media`
- `ffmpeg -v error -i https://remotion.media/video.m3u8 -f null -`
- `ffmpeg -v error -i https://remotion.media/audio.m3u8 -f null -`

Closes #8939
