### PR TITLE
Docs: Add Element contributors

### DIFF
--- a/packages/docs/elements/data/number-counter/index.mdx
+++ b/packages/docs/elements/data/number-counter/index.mdx
@@ -10,4 +10,18 @@ import {NumberCounter} from './number-counter';
 
 A simple animated counter that smoothly counts from a start value to an end value.
 
-<ElementPage component={NumberCounter} displayName="Number Counter" elementHeight={200} elementWidth={640} previewPadding={120} slug="data/number-counter" sourceFile="./number-counter.tsx" />
+<ElementPage
+  component={NumberCounter}
+  contributors={[
+    {
+      username: 'KapishDima',
+      contribution: 'Author',
+    },
+  ]}
+  displayName="Number Counter"
+  elementHeight={200}
+  elementWidth={640}
+  previewPadding={120}
+  slug="data/number-counter"
+  sourceFile="./number-counter.tsx"
+/>

--- a/packages/docs/plugins/remark-element-source.js
+++ b/packages/docs/plugins/remark-element-source.js
@@ -74,7 +74,7 @@ const getSourceCodeNode = ({node, sourceFilePath}) => {
 	};
 };
 
-const insertElementPageSourceNodes = ({node, sourceFilePath}) => {
+const attachElementPageSourceNodes = ({node, sourceFilePath}) => {
 	if (!node.children) {
 		return;
 	}
@@ -82,13 +82,14 @@ const insertElementPageSourceNodes = ({node, sourceFilePath}) => {
 	const children = [];
 
 	for (const child of node.children) {
-		insertElementPageSourceNodes({node: child, sourceFilePath});
-		children.push(child);
+		attachElementPageSourceNodes({node: child, sourceFilePath});
 
 		const sourceCodeNode = getSourceCodeNode({node: child, sourceFilePath});
 		if (sourceCodeNode) {
-			children.push(sourceCodeNode);
+			child.children = [...(child.children ?? []), sourceCodeNode];
 		}
+
+		children.push(child);
 	}
 
 	node.children = children;
@@ -96,7 +97,7 @@ const insertElementPageSourceNodes = ({node, sourceFilePath}) => {
 
 export default function remarkElementSource() {
 	return (tree, file) => {
-		insertElementPageSourceNodes({
+		attachElementPageSourceNodes({
 			node: tree,
 			sourceFilePath: file.path,
 		});

--- a/packages/docs/src/components/Credits.tsx
+++ b/packages/docs/src/components/Credits.tsx
@@ -21,7 +21,7 @@ const linkStyle: React.CSSProperties = {
 	color: '#000000',
 };
 
-interface Contributor {
+export interface Contributor {
 	username: string;
 	contribution: string;
 }

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -364,10 +364,10 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 				</>
 			)}
 
-			{contributors?.length ? <Credits contributors={contributors} /> : null}
-
 			<h2>Source</h2>
 			{children}
+
+			{contributors?.length ? <Credits contributors={contributors} /> : null}
 		</>
 	);
 };

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -10,12 +10,14 @@ import React, {
 	type ReactNode,
 } from 'react';
 import {AbsoluteFill, Sequence} from 'remotion';
+import {Credits, type Contributor} from '../Credits';
 import {setElementDragData, setElementDragImage} from './element-drag-data';
 import {ElementPreview} from './ElementPreview';
 
 type ElementPageProps = {
 	readonly children?: ReactNode;
 	readonly component: ComponentType<Record<string, never>>;
+	readonly contributors?: Contributor[];
 	readonly displayName?: string;
 	readonly durationInFrames?: number;
 	readonly elementHeight?: number;
@@ -137,6 +139,7 @@ const findBestInstallTarget = async (): Promise<
 export const ElementPage: React.FC<ElementPageProps> = ({
 	children,
 	component,
+	contributors,
 	displayName,
 	durationInFrames = 120,
 	elementHeight,
@@ -360,6 +363,8 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 					) : null}
 				</>
 			)}
+
+			{contributors?.length ? <Credits contributors={contributors} /> : null}
 
 			<h2>Source</h2>
 			{children}

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, test} from 'bun:test';
 import {existsSync, readdirSync, readFileSync, statSync} from 'fs';
 import path from 'path';
 import {expandElementSourceReferences} from '../../plugins/element-source-utils';
+import remarkElementSource from '../../plugins/remark-element-source';
 
 const elementsRoot = path.join(__dirname, '..', '..', 'elements');
 const templateRoot = path.join(__dirname, '..', '..', 'elements-template');
@@ -56,6 +57,39 @@ const allElements = [
 describe('Elements must follow the colocated single-file format', () => {
 	test('at least one element exists', () => {
 		expect(allElements.length).toBeGreaterThan(0);
+	});
+
+	test('remark plugin nests source inside ElementPage', () => {
+		const element = allElements[0];
+		const sourceFile = getRelativeTsxPath(element.tsxPath, element.mdxPath);
+		const elementPage = {
+			type: 'mdxJsxFlowElement',
+			name: 'ElementPage',
+			attributes: [
+				{
+					type: 'mdxJsxAttribute',
+					name: 'sourceFile',
+					value: sourceFile,
+				},
+			],
+			children: [],
+		};
+		const tree = {type: 'root', children: [elementPage]};
+
+		remarkElementSource()(tree, {path: element.mdxPath});
+
+		expect(tree.children).toHaveLength(1);
+		expect(elementPage.children).toHaveLength(1);
+		expect(elementPage.children[0]).toMatchObject({
+			type: 'code',
+			lang: 'tsx',
+		});
+		expect(
+			elementPage.attributes.some((attr) => attr.name === 'sourceFile'),
+		).toBe(false);
+		expect(
+			elementPage.attributes.some((attr) => attr.name === 'sourceCode'),
+		).toBe(true);
 	});
 
 	for (const element of allElements) {


### PR DESCRIPTION
## Summary

- Add optional contributors support to `ElementPage`
- Reuse the existing docs `Credits` component for Element pages
- Credit the external Number Counter Element author

Closes #8934

## Tests

- `bun test packages/docs/src/test/elements.test.ts`
- `cd packages/docs && bun run lint`
- `cd packages/docs && bun run formatting`
- `bun run build`
- `bun run stylecheck`
