### PR TITLE
`@remotion/studio`: Add alignment controls to inspector

### DIFF
--- a/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
+++ b/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
@@ -1,0 +1,338 @@
+import React, {useCallback, useContext, useMemo} from 'react';
+import {Internals} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
+import {AlignBottomIcon} from '../../icons/align-bottom';
+import {AlignCenterHorizontalIcon} from '../../icons/align-center-horizontal';
+import {AlignCenterVerticalIcon} from '../../icons/align-center-vertical';
+import {AlignLeftIcon} from '../../icons/align-left';
+import {AlignRightIcon} from '../../icons/align-right';
+import {AlignTopIcon} from '../../icons/align-top';
+import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
+import {getSelectedOutlineActiveSchema} from '../selected-outline-drag';
+import {translateFieldKey} from '../selected-outline-types';
+import {callAddSequenceKeyframe} from '../Timeline/call-add-keyframe';
+import {saveSequenceProps} from '../Timeline/save-sequence-prop';
+import {
+	parseTranslate,
+	serializeTranslate,
+} from '../Timeline/timeline-translate-utils';
+import {computeAlignedTranslate} from './alignment-controls';
+import {InspectorSectionHeader} from './common';
+import {inspectorSectionDivider} from './styles';
+
+const isPropStatusDraggable = (
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	propStatus: any,
+) => {
+	return (
+		!propStatus ||
+		propStatus.status === 'static' ||
+		(propStatus.status === 'keyframed' &&
+			propStatus.interpolationFunction === 'interpolate')
+	);
+};
+
+const container: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'row',
+	gap: 4,
+	padding: `0 ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px 12px`,
+	alignItems: 'center',
+};
+
+const iconStyle: React.CSSProperties = {
+	width: 22,
+	height: 22,
+};
+
+const verticalDivider: React.CSSProperties = {
+	width: 1,
+	height: 16,
+	backgroundColor: 'rgba(255, 255, 255, 0.1)',
+	margin: '0 8px',
+};
+
+const AlignmentButton: React.FC<{
+	readonly onClick: () => void;
+	readonly title: string;
+	readonly children: React.ReactNode;
+}> = ({onClick, title, children}) => {
+	const [hover, setHover] = React.useState(false);
+	return (
+		<button
+			title={title}
+			onClick={onClick}
+			onMouseEnter={() => setHover(true)}
+			onMouseLeave={() => setHover(false)}
+			type="button"
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				width: 30,
+				height: 30,
+				background: 'none',
+				border: '1px solid',
+				borderColor: hover ? 'rgba(128, 128, 128, 0.5)' : 'transparent',
+				borderRadius: 4,
+				padding: 0,
+				color: 'currentColor',
+				cursor: 'pointer',
+			}}
+		>
+			{children}
+		</button>
+	);
+};
+
+export const AlignmentControls: React.FC<{
+	readonly track: TrackWithHash;
+}> = ({track}) => {
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {getDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
+	const {canvasContent, compositions} = useContext(
+		Internals.CompositionManager,
+	);
+	const currentCompositionMetadata = useMemo(() => {
+		if (canvasContent?.type !== 'composition') return null;
+		return (
+			compositions.find((c) => c.id === canvasContent.compositionId) ?? null
+		);
+	}, [canvasContent, compositions]);
+
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
+
+	const handleAlign = useCallback(
+		(
+			direction: 'left' | 'center-h' | 'right' | 'top' | 'center-v' | 'bottom',
+		) => {
+			if (
+				previewServerState.type !== 'connected' ||
+				!track.nodePathInfo ||
+				!track.sequence.controls
+			) {
+				return;
+			}
+
+			const ref = track.sequence.refForOutline?.current;
+			if (!ref) {
+				return;
+			}
+
+			const nodePath = track.nodePathInfo.sequenceSubscriptionKey;
+			const nodePropStatuses = Internals.getPropStatusesCtx(
+				propStatuses,
+				nodePath,
+			);
+			const sourceFrame = timelinePosition - track.keyframeDisplayOffset;
+			const dragOverrides = getDragOverrides(nodePath) ?? {};
+
+			const activeSchema = getSelectedOutlineActiveSchema({
+				schema: track.sequence.controls.schema,
+				currentRuntimeValueDotNotation:
+					track.sequence.controls.currentRuntimeValueDotNotation,
+				dragOverrides,
+				propStatus: nodePropStatuses,
+				frame: sourceFrame,
+			});
+
+			const fieldSchema = activeSchema?.[translateFieldKey];
+			const propStatus = nodePropStatuses?.[translateFieldKey];
+
+			if (fieldSchema?.type !== 'translate') {
+				return;
+			}
+
+			if (!isPropStatusDraggable(propStatus)) {
+				return;
+			}
+
+			let elementRect: DOMRect;
+			try {
+				elementRect = ref.getBoundingClientRect();
+			} catch {
+				return;
+			}
+
+			if (!currentCompositionMetadata?.width) {
+				return;
+			}
+
+			const r = ref as Element;
+			const compositionContainer =
+				typeof r.closest === 'function'
+					? r.closest('.remotion-studio-composition-container')
+					: null;
+			if (!compositionContainer) {
+				return;
+			}
+
+			const compositionRect = compositionContainer.getBoundingClientRect();
+
+			const scale = compositionRect.width / currentCompositionMetadata.width;
+
+			const currentTranslate = propStatus
+				? String(
+						Internals.getEffectiveVisualModeValue({
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							propStatus: propStatus as any,
+							dragOverrideValue: dragOverrides[translateFieldKey],
+							defaultValue: fieldSchema.default,
+							frame: sourceFrame,
+							shouldResortToDefaultValueIfUndefined: true,
+						}) ??
+							fieldSchema.default ??
+							'0px 0px',
+					)
+				: String(fieldSchema.default ?? '0px 0px');
+
+			const [currentX, currentY] = parseTranslate(currentTranslate);
+
+			const {x: newX, y: newY} = computeAlignedTranslate({
+				direction,
+				elementRect,
+				compositionRect,
+				currentTranslateX: currentX,
+				currentTranslateY: currentY,
+				scale,
+			});
+
+			const newValue = serializeTranslate(newX, newY);
+
+			const undoLabels = {
+				left: 'Align left',
+				'center-h': 'Align center horizontally',
+				right: 'Align right',
+				top: 'Align top',
+				'center-v': 'Align center vertically',
+				bottom: 'Align bottom',
+			};
+
+			const label = undoLabels[direction];
+
+			if (!propStatus || propStatus.status === 'static') {
+				saveSequenceProps({
+					changes: [
+						{
+							fileName: nodePath.absolutePath,
+							nodePath,
+							fieldKey: translateFieldKey,
+							value: newValue,
+							defaultValue:
+								fieldSchema.default !== undefined
+									? JSON.stringify(fieldSchema.default)
+									: null,
+							schema: track.sequence.controls.schema,
+						},
+					],
+					setPropStatuses,
+					clientId: previewServerState.clientId,
+					undoLabel: label,
+					redoLabel: label,
+				});
+			} else {
+				callAddSequenceKeyframe({
+					fileName: nodePath.absolutePath,
+					nodePath,
+					fieldKey: translateFieldKey,
+					sourceFrame,
+					value: newValue,
+					schema: track.sequence.controls.schema,
+					setPropStatuses,
+					clientId: previewServerState.clientId,
+				});
+			}
+		},
+		[
+			previewServerState,
+			track,
+			currentCompositionMetadata,
+			timelinePosition,
+			propStatuses,
+			getDragOverrides,
+			setPropStatuses,
+		],
+	);
+
+	if (
+		previewServerState.type !== 'connected' ||
+		!track.nodePathInfo ||
+		!track.sequence.controls ||
+		!currentCompositionMetadata
+	) {
+		return null;
+	}
+
+	const renderNodePath = track.nodePathInfo.sequenceSubscriptionKey;
+	const renderNodePropStatuses = Internals.getPropStatusesCtx(
+		propStatuses,
+		renderNodePath,
+	);
+	const renderSourceFrame = timelinePosition - track.keyframeDisplayOffset;
+	const renderDragOverrides = getDragOverrides(renderNodePath) ?? {};
+
+	const renderActiveSchema = getSelectedOutlineActiveSchema({
+		schema: track.sequence.controls.schema,
+		currentRuntimeValueDotNotation:
+			track.sequence.controls.currentRuntimeValueDotNotation,
+		dragOverrides: renderDragOverrides,
+		propStatus: renderNodePropStatuses,
+		frame: renderSourceFrame,
+	});
+
+	const renderFieldSchema = renderActiveSchema?.[translateFieldKey];
+	const renderPropStatus = renderNodePropStatuses?.[translateFieldKey];
+
+	if (renderFieldSchema?.type !== 'translate') {
+		return null;
+	}
+
+	if (!isPropStatusDraggable(renderPropStatus)) {
+		return null;
+	}
+
+	return (
+		<>
+			<InspectorSectionHeader>Alignment</InspectorSectionHeader>
+			<div style={container}>
+				<AlignmentButton title="Align left" onClick={() => handleAlign('left')}>
+					<AlignLeftIcon style={iconStyle} />
+				</AlignmentButton>
+				<AlignmentButton
+					title="Align center horizontally"
+					onClick={() => handleAlign('center-h')}
+				>
+					<AlignCenterHorizontalIcon style={iconStyle} />
+				</AlignmentButton>
+				<AlignmentButton
+					title="Align right"
+					onClick={() => handleAlign('right')}
+				>
+					<AlignRightIcon style={iconStyle} />
+				</AlignmentButton>
+				<div style={verticalDivider} />
+				<AlignmentButton title="Align top" onClick={() => handleAlign('top')}>
+					<AlignTopIcon style={iconStyle} />
+				</AlignmentButton>
+				<AlignmentButton
+					title="Align center vertically"
+					onClick={() => handleAlign('center-v')}
+				>
+					<AlignCenterVerticalIcon style={iconStyle} />
+				</AlignmentButton>
+				<AlignmentButton
+					title="Align bottom"
+					onClick={() => handleAlign('bottom')}
+				>
+					<AlignBottomIcon style={iconStyle} />
+				</AlignmentButton>
+			</div>
+			<div style={inspectorSectionDivider} />
+		</>
+	);
+};

--- a/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
+++ b/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
@@ -8,6 +8,7 @@ import {AlignCenterVerticalIcon} from '../../icons/align-center-vertical';
 import {AlignLeftIcon} from '../../icons/align-left';
 import {AlignRightIcon} from '../../icons/align-right';
 import {AlignTopIcon} from '../../icons/align-top';
+import {InlineAction} from '../InlineAction';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import {getSelectedOutlineActiveSchema} from '../selected-outline-drag';
 import {translateFieldKey} from '../selected-outline-types';
@@ -18,8 +19,6 @@ import {
 	serializeTranslate,
 } from '../Timeline/timeline-translate-utils';
 import {computeAlignedTranslate} from './alignment-controls';
-import {InspectorSectionHeader} from './common';
-import {inspectorSectionDivider} from './styles';
 
 const isPropStatusDraggable = (
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,8 +41,8 @@ const container: React.CSSProperties = {
 };
 
 const iconStyle: React.CSSProperties = {
-	width: 22,
-	height: 22,
+	width: 16,
+	height: 16,
 };
 
 const verticalDivider: React.CSSProperties = {
@@ -56,33 +55,14 @@ const verticalDivider: React.CSSProperties = {
 const AlignmentButton: React.FC<{
 	readonly onClick: () => void;
 	readonly title: string;
-	readonly children: React.ReactNode;
-}> = ({onClick, title, children}) => {
-	const [hover, setHover] = React.useState(false);
+	readonly Icon: React.FC<React.SVGProps<SVGSVGElement>>;
+}> = ({onClick, title, Icon}) => {
 	return (
-		<button
+		<InlineAction
 			title={title}
 			onClick={onClick}
-			onMouseEnter={() => setHover(true)}
-			onMouseLeave={() => setHover(false)}
-			type="button"
-			style={{
-				display: 'inline-flex',
-				alignItems: 'center',
-				justifyContent: 'center',
-				width: 30,
-				height: 30,
-				background: 'none',
-				border: '1px solid',
-				borderColor: hover ? 'rgba(128, 128, 128, 0.5)' : 'transparent',
-				borderRadius: 4,
-				padding: 0,
-				color: 'currentColor',
-				cursor: 'pointer',
-			}}
-		>
-			{children}
-		</button>
+			renderAction={(color) => <Icon style={iconStyle} color={color} />}
+		/>
 	);
 };
 
@@ -297,42 +277,38 @@ export const AlignmentControls: React.FC<{
 	}
 
 	return (
-		<>
-			<InspectorSectionHeader>Alignment</InspectorSectionHeader>
-			<div style={container}>
-				<AlignmentButton title="Align left" onClick={() => handleAlign('left')}>
-					<AlignLeftIcon style={iconStyle} />
-				</AlignmentButton>
-				<AlignmentButton
-					title="Align center horizontally"
-					onClick={() => handleAlign('center-h')}
-				>
-					<AlignCenterHorizontalIcon style={iconStyle} />
-				</AlignmentButton>
-				<AlignmentButton
-					title="Align right"
-					onClick={() => handleAlign('right')}
-				>
-					<AlignRightIcon style={iconStyle} />
-				</AlignmentButton>
-				<div style={verticalDivider} />
-				<AlignmentButton title="Align top" onClick={() => handleAlign('top')}>
-					<AlignTopIcon style={iconStyle} />
-				</AlignmentButton>
-				<AlignmentButton
-					title="Align center vertically"
-					onClick={() => handleAlign('center-v')}
-				>
-					<AlignCenterVerticalIcon style={iconStyle} />
-				</AlignmentButton>
-				<AlignmentButton
-					title="Align bottom"
-					onClick={() => handleAlign('bottom')}
-				>
-					<AlignBottomIcon style={iconStyle} />
-				</AlignmentButton>
-			</div>
-			<div style={inspectorSectionDivider} />
-		</>
+		<div style={container}>
+			<AlignmentButton
+				title="Align left"
+				onClick={() => handleAlign('left')}
+				Icon={AlignLeftIcon}
+			/>
+			<AlignmentButton
+				title="Align center horizontally"
+				onClick={() => handleAlign('center-h')}
+				Icon={AlignCenterHorizontalIcon}
+			/>
+			<AlignmentButton
+				title="Align right"
+				onClick={() => handleAlign('right')}
+				Icon={AlignRightIcon}
+			/>
+			<div style={verticalDivider} />
+			<AlignmentButton
+				title="Align top"
+				onClick={() => handleAlign('top')}
+				Icon={AlignTopIcon}
+			/>
+			<AlignmentButton
+				title="Align center vertically"
+				onClick={() => handleAlign('center-v')}
+				Icon={AlignCenterVerticalIcon}
+			/>
+			<AlignmentButton
+				title="Align bottom"
+				onClick={() => handleAlign('bottom')}
+				Icon={AlignBottomIcon}
+			/>
+		</div>
 	);
 };

--- a/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
+++ b/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useContext, useMemo} from 'react';
-import {Internals} from 'remotion';
+import {Internals, type CanUpdateSequencePropStatus} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
 import {AlignBottomIcon} from '../../icons/align-bottom';
@@ -21,8 +21,7 @@ import {
 import {computeAlignedTranslate} from './alignment-controls';
 
 const isPropStatusDraggable = (
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	propStatus: any,
+	propStatus: CanUpdateSequencePropStatus | undefined,
 ) => {
 	return (
 		!propStatus ||
@@ -56,12 +55,14 @@ const AlignmentButton: React.FC<{
 	readonly onClick: () => void;
 	readonly title: string;
 	readonly Icon: React.FC<React.SVGProps<SVGSVGElement>>;
-}> = ({onClick, title, Icon}) => {
+	readonly disabled: boolean;
+}> = ({onClick, title, Icon, disabled}) => {
 	return (
 		<InlineAction
 			title={title}
 			onClick={onClick}
 			renderAction={(color) => <Icon style={iconStyle} color={color} />}
+			disabled={disabled}
 		/>
 	);
 };
@@ -143,16 +144,10 @@ export const AlignmentControls: React.FC<{
 				return;
 			}
 
-			const r = ref as Element;
-			const compositionContainer =
-				typeof r.closest === 'function'
-					? r.closest('.remotion-studio-composition-container')
-					: null;
-			if (!compositionContainer) {
+			const compositionRect = Internals.portalNode().getBoundingClientRect();
+			if (compositionRect.width === 0 || compositionRect.height === 0) {
 				return;
 			}
-
-			const compositionRect = compositionContainer.getBoundingClientRect();
 
 			const scale = compositionRect.width / currentCompositionMetadata.width;
 
@@ -272,9 +267,7 @@ export const AlignmentControls: React.FC<{
 		return null;
 	}
 
-	if (!isPropStatusDraggable(renderPropStatus)) {
-		return null;
-	}
+	const alignmentDisabled = !isPropStatusDraggable(renderPropStatus);
 
 	return (
 		<div style={container}>
@@ -282,32 +275,38 @@ export const AlignmentControls: React.FC<{
 				title="Align left"
 				onClick={() => handleAlign('left')}
 				Icon={AlignLeftIcon}
+				disabled={alignmentDisabled}
 			/>
 			<AlignmentButton
 				title="Align center horizontally"
 				onClick={() => handleAlign('center-h')}
 				Icon={AlignCenterHorizontalIcon}
+				disabled={alignmentDisabled}
 			/>
 			<AlignmentButton
 				title="Align right"
 				onClick={() => handleAlign('right')}
 				Icon={AlignRightIcon}
+				disabled={alignmentDisabled}
 			/>
 			<div style={verticalDivider} />
 			<AlignmentButton
 				title="Align top"
 				onClick={() => handleAlign('top')}
 				Icon={AlignTopIcon}
+				disabled={alignmentDisabled}
 			/>
 			<AlignmentButton
 				title="Align center vertically"
 				onClick={() => handleAlign('center-v')}
 				Icon={AlignCenterVerticalIcon}
+				disabled={alignmentDisabled}
 			/>
 			<AlignmentButton
 				title="Align bottom"
 				onClick={() => handleAlign('bottom')}
 				Icon={AlignBottomIcon}
+				disabled={alignmentDisabled}
 			/>
 		</div>
 	);

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -11,6 +11,7 @@ import {
 	type TimelineSelection,
 	useTimelineSelection,
 } from '../Timeline/TimelineSelection';
+import {AlignmentControls} from './AlignmentControls';
 import {InspectorMessage, InspectorSectionHeader} from './common';
 import type {SequenceSectionSelection} from './inspector-selection';
 import {
@@ -82,6 +83,7 @@ const SequenceExpandedInspector: React.FC<{
 			onPointerDown={selectSequenceOnInspectorPointerDown}
 		>
 			<SequenceInspectorHeader sourceLocation={sourceLocation} track={track} />
+			<AlignmentControls track={track} />
 			<InspectorSequenceSection
 				sequence={track.sequence}
 				validatedLocation={validatedLocation}

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -83,7 +83,6 @@ const SequenceExpandedInspector: React.FC<{
 			onPointerDown={selectSequenceOnInspectorPointerDown}
 		>
 			<SequenceInspectorHeader sourceLocation={sourceLocation} track={track} />
-			<AlignmentControls track={track} />
 			<InspectorSequenceSection
 				sequence={track.sequence}
 				validatedLocation={validatedLocation}
@@ -92,6 +91,7 @@ const SequenceExpandedInspector: React.FC<{
 				renderSectionHeader={(children) => (
 					<InspectorSectionHeader>{children}</InspectorSectionHeader>
 				)}
+				renderTransformControls={() => <AlignmentControls track={track} />}
 			/>
 		</div>
 	);

--- a/packages/studio/src/components/InspectorPanel/alignment-controls.ts
+++ b/packages/studio/src/components/InspectorPanel/alignment-controls.ts
@@ -1,0 +1,65 @@
+export type AlignmentDirection =
+	| 'left'
+	| 'center-h'
+	| 'right'
+	| 'top'
+	| 'center-v'
+	| 'bottom';
+
+export const computeAlignedTranslate = ({
+	direction,
+	elementRect,
+	compositionRect,
+	currentTranslateX,
+	currentTranslateY,
+	scale,
+}: {
+	readonly direction: AlignmentDirection;
+	readonly elementRect: DOMRect;
+	readonly compositionRect: DOMRect;
+	readonly currentTranslateX: number;
+	readonly currentTranslateY: number;
+	readonly scale: number;
+}): {x: number; y: number} => {
+	let deltaX = 0;
+	let deltaY = 0;
+
+	// Note: elementRect and compositionRect are in screen space (pixels).
+	// We divide by scale to convert back to composition space.
+
+	switch (direction) {
+		case 'left':
+			deltaX = compositionRect.left - elementRect.left;
+			break;
+		case 'center-h': {
+			const compCenter = compositionRect.left + compositionRect.width / 2;
+			const elemCenter = elementRect.left + elementRect.width / 2;
+			deltaX = compCenter - elemCenter;
+			break;
+		}
+
+		case 'right':
+			deltaX = compositionRect.right - elementRect.right;
+			break;
+		case 'top':
+			deltaY = compositionRect.top - elementRect.top;
+			break;
+		case 'center-v': {
+			const compCenter = compositionRect.top + compositionRect.height / 2;
+			const elemCenter = elementRect.top + elementRect.height / 2;
+			deltaY = compCenter - elemCenter;
+			break;
+		}
+
+		case 'bottom':
+			deltaY = compositionRect.bottom - elementRect.bottom;
+			break;
+		default:
+			break;
+	}
+
+	return {
+		x: currentTranslateX + deltaX / scale,
+		y: currentTranslateY + deltaY / scale,
+	};
+};

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -155,12 +155,14 @@ export const InspectorSequenceSection: React.FC<{
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly keyframeDisplayOffset: number;
 	readonly renderSectionHeader: (children: React.ReactNode) => React.ReactNode;
+	readonly renderTransformControls: () => React.ReactNode;
 }> = ({
 	sequence,
 	validatedLocation,
 	nodePathInfo,
 	keyframeDisplayOffset,
 	renderSectionHeader,
+	renderTransformControls,
 }) => {
 	const {tree} = useTimelineExpandedTree({
 		sequence,
@@ -315,6 +317,7 @@ export const InspectorSequenceSection: React.FC<{
 						<React.Fragment key={group.id}>
 							{i === 0 ? null : <div style={controlsEffectsDivider} />}
 							{renderSectionHeader(group.label)}
+							{group.id === 'transforms' ? renderTransformControls() : null}
 							{group.rows.map(renderRow)}
 						</React.Fragment>
 					))}

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -231,7 +231,7 @@ const CompWhenItHasDimensions: React.FC<{
 	}
 
 	return (
-		<div style={outer}>
+		<div className="remotion-studio-composition-container" style={outer}>
 			<PortalContainer
 				contentDimensions={contentDimensions as Dimensions}
 				scale={scale}

--- a/packages/studio/src/icons/align-bottom.tsx
+++ b/packages/studio/src/icons/align-bottom.tsx
@@ -1,12 +1,15 @@
 import type {SVGProps} from 'react';
 import React from 'react';
+import {AlignRightIcon} from './align-right';
 
 export const AlignBottomIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
-			<rect fill="currentColor" x="1" y="13" width="14" height="1" rx="0.5" />
-			<rect fill="currentColor" x="4" y="2" width="2.5" height="9.5" rx="1" />
-			<rect fill="currentColor" x="9.5" y="6" width="2.5" height="5.5" rx="1" />
-		</svg>
+		<AlignRightIcon
+			{...props}
+			style={{
+				...props.style,
+				transform: 'rotate(90deg)',
+			}}
+		/>
 	);
 };

--- a/packages/studio/src/icons/align-bottom.tsx
+++ b/packages/studio/src/icons/align-bottom.tsx
@@ -1,0 +1,12 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+export const AlignBottomIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
+			<rect fill="currentColor" x="1" y="13" width="14" height="1" rx="0.5" />
+			<rect fill="currentColor" x="4" y="2" width="2.5" height="9.5" rx="1" />
+			<rect fill="currentColor" x="9.5" y="6" width="2.5" height="5.5" rx="1" />
+		</svg>
+	);
+};

--- a/packages/studio/src/icons/align-center-horizontal.tsx
+++ b/packages/studio/src/icons/align-center-horizontal.tsx
@@ -4,11 +4,23 @@ import React from 'react';
 export const AlignCenterHorizontalIcon: React.FC<SVGProps<SVGSVGElement>> = (
 	props,
 ) => {
+	const color = props.color ?? 'currentColor';
+
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
-			<rect fill="currentColor" x="7.5" y="1" width="1" height="14" rx="0.5" />
-			<rect fill="currentColor" x="3" y="4" width="10" height="2.5" rx="1" />
-			<rect fill="currentColor" x="5" y="9.5" width="6" height="2.5" rx="1" />
+		<svg
+			{...props}
+			viewBox="0 0 16 16"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				d="M8 2V14"
+				stroke={color}
+				strokeOpacity="0.5"
+				strokeLinecap="square"
+			/>
+			<line x1="3" y1="6" x2="12" y2="6" stroke={color} strokeWidth="2" />
+			<line x1="4" y1="10" x2="11" y2="10" stroke={color} strokeWidth="2" />
 		</svg>
 	);
 };

--- a/packages/studio/src/icons/align-center-horizontal.tsx
+++ b/packages/studio/src/icons/align-center-horizontal.tsx
@@ -1,0 +1,14 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+export const AlignCenterHorizontalIcon: React.FC<SVGProps<SVGSVGElement>> = (
+	props,
+) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
+			<rect fill="currentColor" x="7.5" y="1" width="1" height="14" rx="0.5" />
+			<rect fill="currentColor" x="3" y="4" width="10" height="2.5" rx="1" />
+			<rect fill="currentColor" x="5" y="9.5" width="6" height="2.5" rx="1" />
+		</svg>
+	);
+};

--- a/packages/studio/src/icons/align-center-vertical.tsx
+++ b/packages/studio/src/icons/align-center-vertical.tsx
@@ -1,0 +1,14 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+export const AlignCenterVerticalIcon: React.FC<SVGProps<SVGSVGElement>> = (
+	props,
+) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
+			<rect fill="currentColor" x="1" y="7.5" width="14" height="1" rx="0.5" />
+			<rect fill="currentColor" x="4" y="3" width="2.5" height="10" rx="1" />
+			<rect fill="currentColor" x="9.5" y="5" width="2.5" height="6" rx="1" />
+		</svg>
+	);
+};

--- a/packages/studio/src/icons/align-center-vertical.tsx
+++ b/packages/studio/src/icons/align-center-vertical.tsx
@@ -1,14 +1,17 @@
 import type {SVGProps} from 'react';
 import React from 'react';
+import {AlignCenterHorizontalIcon} from './align-center-horizontal';
 
 export const AlignCenterVerticalIcon: React.FC<SVGProps<SVGSVGElement>> = (
 	props,
 ) => {
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
-			<rect fill="currentColor" x="1" y="7.5" width="14" height="1" rx="0.5" />
-			<rect fill="currentColor" x="4" y="3" width="2.5" height="10" rx="1" />
-			<rect fill="currentColor" x="9.5" y="5" width="2.5" height="6" rx="1" />
-		</svg>
+		<AlignCenterHorizontalIcon
+			{...props}
+			style={{
+				...props.style,
+				transform: 'rotate(90deg)',
+			}}
+		/>
 	);
 };

--- a/packages/studio/src/icons/align-left.tsx
+++ b/packages/studio/src/icons/align-left.tsx
@@ -2,18 +2,18 @@ import type {SVGProps} from 'react';
 import React from 'react';
 
 export const AlignLeftIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
+	const color = props.color ?? 'currentColor';
+
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
-			<rect fill="currentColor" x="2" y="1" width="1" height="14" rx="0.5" />
-			<rect fill="currentColor" x="4.5" y="4" width="9.5" height="2.5" rx="1" />
-			<rect
-				fill="currentColor"
-				x="4.5"
-				y="9.5"
-				width="5.5"
-				height="2.5"
-				rx="1"
+		<svg {...props} viewBox="0 0 16 16" fill="none">
+			<path
+				d="M2 2L2 14"
+				stroke={color}
+				strokeOpacity="0.5"
+				strokeLinecap="square"
 			/>
+			<line x1="4" y1="6" x2="13" y2="6" stroke={color} strokeWidth="2" />
+			<line x1="4" y1="10" x2="11" y2="10" stroke={color} strokeWidth="2" />
 		</svg>
 	);
 };

--- a/packages/studio/src/icons/align-left.tsx
+++ b/packages/studio/src/icons/align-left.tsx
@@ -1,0 +1,19 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+export const AlignLeftIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
+			<rect fill="currentColor" x="2" y="1" width="1" height="14" rx="0.5" />
+			<rect fill="currentColor" x="4.5" y="4" width="9.5" height="2.5" rx="1" />
+			<rect
+				fill="currentColor"
+				x="4.5"
+				y="9.5"
+				width="5.5"
+				height="2.5"
+				rx="1"
+			/>
+		</svg>
+	);
+};

--- a/packages/studio/src/icons/align-right.tsx
+++ b/packages/studio/src/icons/align-right.tsx
@@ -1,0 +1,12 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+export const AlignRightIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
+			<rect fill="currentColor" x="13" y="1" width="1" height="14" rx="0.5" />
+			<rect fill="currentColor" x="2" y="4" width="9.5" height="2.5" rx="1" />
+			<rect fill="currentColor" x="6" y="9.5" width="5.5" height="2.5" rx="1" />
+		</svg>
+	);
+};

--- a/packages/studio/src/icons/align-right.tsx
+++ b/packages/studio/src/icons/align-right.tsx
@@ -2,11 +2,18 @@ import type {SVGProps} from 'react';
 import React from 'react';
 
 export const AlignRightIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
+	const color = props.color ?? 'currentColor';
+
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
-			<rect fill="currentColor" x="13" y="1" width="1" height="14" rx="0.5" />
-			<rect fill="currentColor" x="2" y="4" width="9.5" height="2.5" rx="1" />
-			<rect fill="currentColor" x="6" y="9.5" width="5.5" height="2.5" rx="1" />
+		<svg {...props} viewBox="0 0 16 16" fill="none">
+			<path
+				d="M14 2V14"
+				stroke={color}
+				strokeOpacity="0.5"
+				strokeLinecap="square"
+			/>
+			<line x1="3" y1="6" x2="12" y2="6" stroke={color} strokeWidth="2" />
+			<line x1="5" y1="10" x2="12" y2="10" stroke={color} strokeWidth="2" />
 		</svg>
 	);
 };

--- a/packages/studio/src/icons/align-top.tsx
+++ b/packages/studio/src/icons/align-top.tsx
@@ -1,19 +1,15 @@
 import type {SVGProps} from 'react';
 import React from 'react';
+import {AlignLeftIcon} from './align-left';
 
 export const AlignTopIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
-			<rect fill="currentColor" x="1" y="2" width="14" height="1" rx="0.5" />
-			<rect fill="currentColor" x="4" y="4.5" width="2.5" height="9.5" rx="1" />
-			<rect
-				fill="currentColor"
-				x="9.5"
-				y="4.5"
-				width="2.5"
-				height="5.5"
-				rx="1"
-			/>
-		</svg>
+		<AlignLeftIcon
+			{...props}
+			style={{
+				...props.style,
+				transform: 'rotate(90deg)',
+			}}
+		/>
 	);
 };

--- a/packages/studio/src/icons/align-top.tsx
+++ b/packages/studio/src/icons/align-top.tsx
@@ -1,0 +1,19 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+export const AlignTopIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
+			<rect fill="currentColor" x="1" y="2" width="14" height="1" rx="0.5" />
+			<rect fill="currentColor" x="4" y="4.5" width="2.5" height="9.5" rx="1" />
+			<rect
+				fill="currentColor"
+				x="9.5"
+				y="4.5"
+				width="2.5"
+				height="5.5"
+				rx="1"
+			/>
+		</svg>
+	);
+};


### PR DESCRIPTION
### Summary
- Add six alignment buttons to the Studio inspector panel for quick layout adjustments
- Compute the required translate delta in composition-space coordinates by comparing bounding rects
- Wire the computed offsets into the existing `saveSequenceProps` and `callAddSequenceKeyframe` helpers
- Clean up unreachable fallbacks and missing metadata guards to enforce correct scale computation
- Remove stray debug console logs to prevent noise during normal Studio navigation

 Closes #8803

### Tests
- `cd packages/studio && bun run formatting`
- `bun run stylecheck`
- `bun run build`