### PR TITLE
`@remotion/convert`: Resolve HLS audio codecs

### DIFF
--- a/packages/convert/app/components/AudioCodecSelection.tsx
+++ b/packages/convert/app/components/AudioCodecSelection.tsx
@@ -19,10 +19,6 @@ export const AudioCodecSelection: React.FC<{
 	readonly setIndex: (v: string) => void;
 	readonly currentAudioCodec: InputAudioTrack['codec'];
 }> = ({audioTrackOptions, index, setIndex, currentAudioCodec}) => {
-	if (!currentAudioCodec) {
-		throw new Error('No current audio codec, should not render this component');
-	}
-
 	const disabled = audioTrackOptions.length < 2;
 
 	return (

--- a/packages/convert/app/components/ConvertForm.tsx
+++ b/packages/convert/app/components/ConvertForm.tsx
@@ -6,7 +6,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@remotion/design';
-import type {InputAudioTrack, InputVideoTrack} from 'mediabunny';
+import type {InputVideoTrack} from 'mediabunny';
 import React from 'react';
 import {
 	getActualAudioOperation,
@@ -30,7 +30,6 @@ export const ConvertForm: React.FC<{
 	readonly audioConfigIndexSelection: Record<number, string>;
 	readonly setAudioConfigIndex: (trackId: number, key: string) => void;
 	readonly setVideoConfigIndex: (trackId: number, key: string) => void;
-	readonly currentAudioCodec: InputAudioTrack['codec'] | null;
 	readonly currentVideoCodec: InputVideoTrack['codec'] | null;
 }> = ({
 	container,
@@ -40,7 +39,6 @@ export const ConvertForm: React.FC<{
 	setAudioConfigIndex,
 	videoConfigIndexSelection,
 	setVideoConfigIndex,
-	currentAudioCodec,
 	currentVideoCodec,
 }) => {
 	return (
@@ -118,7 +116,7 @@ export const ConvertForm: React.FC<{
 									setAudioConfigIndex(track.trackId, i);
 								}}
 								audioTrackOptions={track.operations}
-								currentAudioCodec={currentAudioCodec}
+								currentAudioCodec={track.audioCodec}
 							/>
 						</div>
 					);

--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -2,7 +2,6 @@ import {Button} from '@remotion/design';
 import type {
 	CropRectangle,
 	Input,
-	InputAudioTrack,
 	InputFormat,
 	InputTrack,
 	InputVideoTrack,
@@ -60,7 +59,6 @@ import {useSupportedConfigs} from './use-supported-configs';
 import type {VideoThumbnailRef} from './VideoThumbnail';
 
 const ConvertUI = ({
-	currentAudioCodec,
 	currentVideoCodec,
 	tracks,
 	setSrc,
@@ -90,7 +88,6 @@ const ConvertUI = ({
 	cropRect,
 }: {
 	readonly setSrc: React.Dispatch<React.SetStateAction<Source | null>>;
-	readonly currentAudioCodec: InputAudioTrack['codec'] | null;
 	readonly currentVideoCodec: InputVideoTrack['codec'] | null;
 	readonly tracks: InputTrack[] | null;
 	readonly videoThumbnailRef: React.RefObject<VideoThumbnailRef | null>;
@@ -678,7 +675,6 @@ const ConvertUI = ({
 												videoConfigIndexSelection: videoOperationSelection,
 												setAudioConfigIndex,
 												setVideoConfigIndex,
-												currentAudioCodec,
 												currentVideoCodec,
 											}}
 										/>

--- a/packages/convert/app/components/FileAvailable.tsx
+++ b/packages/convert/app/components/FileAvailable.tsx
@@ -130,7 +130,6 @@ export const FileAvailable: React.FC<{
 										<ConvertUI
 											crop={enableRotateOrMirrow === 'crop'}
 											inputContainer={probeResult.container}
-											currentAudioCodec={probeResult.audioCodec ?? null}
 											currentVideoCodec={probeResult.videoCodec ?? null}
 											tracks={probeResult.tracks}
 											setSrc={setSrc}

--- a/packages/convert/app/components/get-supported-configs.tsx
+++ b/packages/convert/app/components/get-supported-configs.tsx
@@ -121,13 +121,12 @@ export const getSupportedConfigs = async ({
 			const options: VideoOperation[] = [];
 			const canCopy =
 				!disableVideoCopy &&
-				canCopyVideoTrack({
+				(await canCopyVideoTrack({
 					inputTrack: track,
 					outputContainer: container,
 					rotationToApply: userRotation,
 					resizeOperation,
-				}) &&
-				!disableVideoCopy;
+				}));
 			if (canCopy && prioritizeCopyOverReencode) {
 				options.push({
 					type: 'copy',
@@ -159,6 +158,7 @@ export const getSupportedConfigs = async ({
 
 		if (track.isAudioTrack()) {
 			const audioTrackOperations: AudioOperation[] = [];
+			const audioCodec = await track.getCodec();
 
 			const canCopy = await canCopyAudioTrack({
 				outputContainer: container,
@@ -183,7 +183,7 @@ export const getSupportedConfigs = async ({
 			audioTrackOptions.push({
 				trackId: track.id,
 				operations: audioTrackOperations,
-				audioCodec: track.codec,
+				audioCodec,
 			});
 		}
 	}

--- a/packages/convert/app/components/use-probe.ts
+++ b/packages/convert/app/components/use-probe.ts
@@ -59,7 +59,7 @@ export const useProbe = ({src}: {src: Source}) => {
 			input.getMetadataTags().then((tags) => setMetadata(tags));
 
 			const trx = await input.getTracks();
-			trx.forEach(async (track) => {
+			for (const track of trx) {
 				if (await track.isLive()) {
 					throw new Error(
 						'Live streams are not currently supported by Remotion. Sorry!',
@@ -71,30 +71,39 @@ export const useProbe = ({src}: {src: Source}) => {
 						'Streams with UNIX timestamps are not currently supported by Remotion. Sorry!',
 					);
 				}
-			});
-			setTracks(trx);
+			}
+
 			let hasAudioTrack = false;
 			let hasVideoTrack = false;
 			for (const track of trx) {
 				if (track.isVideoTrack()) {
 					hasVideoTrack = true;
-					const {codec} = track;
+					const codec = await track.getCodec();
 					setVideoCodec(codec);
 					track
 						.computePacketStats(50)
 						.then((stats) => setFps(stats.averagePacketRate));
+					const [displayWidth, displayHeight, trackRotation] =
+						await Promise.all([
+							track.getDisplayWidth(),
+							track.getDisplayHeight(),
+							track.getRotation(),
+						]);
 					setDimensions({
-						width: track.displayWidth,
-						height: track.displayHeight,
+						width: displayWidth,
+						height: displayHeight,
 					});
-					setRotation(track.rotation);
+					setRotation(trackRotation);
 					track.hasHighDynamicRange().then((hdr) => setHdr(hdr));
 				} else if (track.isAudioTrack()) {
 					hasAudioTrack = true;
-					setAudioCodec(track.codec);
+					const codec = await track.getCodec();
+					setAudioCodec(codec);
 					track.getSampleRate().then((sr) => setSampleRate(sr));
 				}
 			}
+
+			setTracks(trx);
 
 			if (!hasAudioTrack) {
 				setAudioCodec(null);

--- a/packages/convert/app/lib/can-transcode-or-copy.ts
+++ b/packages/convert/app/lib/can-transcode-or-copy.ts
@@ -1,4 +1,9 @@
-import type {InputAudioTrack, InputVideoTrack, OutputFormat} from 'mediabunny';
+import type {
+	AudioCodec,
+	InputAudioTrack,
+	InputVideoTrack,
+	OutputFormat,
+} from 'mediabunny';
 import {getEncodableAudioCodecs, getEncodableVideoCodecs} from 'mediabunny';
 import type {AudioOperation, VideoOperation} from './audio-operation';
 import {
@@ -13,14 +18,10 @@ const canEncodeAudioCodec = async ({
 	sampleRate,
 	allowFallbackSampleRate,
 }: {
-	codec: InputAudioTrack['codec'];
+	codec: AudioCodec;
 	sampleRate: number;
 	allowFallbackSampleRate: boolean;
 }) => {
-	if (codec === null) {
-		return false;
-	}
-
 	await ensureAudioEncoderRegistered(codec);
 
 	const codecs = await getEncodableAudioCodecs([codec], {sampleRate});
@@ -45,7 +46,8 @@ export const getAudioTranscodingOptions = async ({
 	outputContainer: OutputFormat;
 	sampleRate: number | null;
 }): Promise<AudioOperation[]> => {
-	if (inputTrack.codec === null) {
+	const inputAudioCodec = await inputTrack.getCodec();
+	if (inputAudioCodec === null) {
 		return [];
 	}
 
@@ -89,7 +91,8 @@ export const getVideoTranscodingOptions = async ({
 	resizeOperation: MediabunnyResize | null;
 	rotate: number | null;
 }): Promise<VideoOperation[]> => {
-	if (inputTrack.codec === null) {
+	const inputVideoCodec = await inputTrack.getCodec();
+	if (inputVideoCodec === null) {
 		return [];
 	}
 
@@ -101,7 +104,7 @@ export const getVideoTranscodingOptions = async ({
 		height: inputTrack.displayHeight,
 		resizeOperation,
 		rotation: rotate ?? 0,
-		needsToBeMultipleOfTwo: inputTrack.codec === 'avc',
+		needsToBeMultipleOfTwo: inputVideoCodec === 'avc',
 		width: inputTrack.displayWidth,
 	});
 
@@ -127,7 +130,7 @@ export const getVideoTranscodingOptions = async ({
 	return configs;
 };
 
-export const canCopyVideoTrack = ({
+export const canCopyVideoTrack = async ({
 	outputContainer,
 	rotationToApply,
 	resizeOperation,
@@ -138,6 +141,11 @@ export const canCopyVideoTrack = ({
 	outputContainer: OutputFormat;
 	resizeOperation: MediabunnyResize | null;
 }) => {
+	const inputVideoCodec = await inputTrack.getCodec();
+	if (!inputVideoCodec) {
+		return false;
+	}
+
 	if (
 		normalizeVideoRotation(inputTrack.rotation) !==
 		normalizeVideoRotation(rotationToApply)
@@ -145,12 +153,8 @@ export const canCopyVideoTrack = ({
 		return false;
 	}
 
-	if (!inputTrack.codec) {
-		return false;
-	}
-
 	const needsToBeMultipleOfTwo =
-		inputTrack.codec === 'avc' || inputTrack.codec === 'hevc';
+		inputVideoCodec === 'avc' || inputVideoCodec === 'hevc';
 
 	const newDimensions = calculateNewDimensionsFromRotateAndScale({
 		height: inputTrack.displayHeight,
@@ -166,7 +170,7 @@ export const canCopyVideoTrack = ({
 		return false;
 	}
 
-	return outputContainer.getSupportedCodecs().includes(inputTrack.codec);
+	return outputContainer.getSupportedCodecs().includes(inputVideoCodec);
 };
 
 export const canCopyAudioTrack = async ({
@@ -178,7 +182,8 @@ export const canCopyAudioTrack = async ({
 	outputContainer: OutputFormat;
 	sampleRate: number | null;
 }) => {
-	if (!inputTrack.codec) {
+	const inputAudioCodec = await inputTrack.getCodec();
+	if (!inputAudioCodec) {
 		return false;
 	}
 
@@ -186,5 +191,5 @@ export const canCopyAudioTrack = async ({
 		return false;
 	}
 
-	return outputContainer.getSupportedCodecs().includes(inputTrack.codec);
+	return outputContainer.getSupportedCodecs().includes(inputAudioCodec);
 };

--- a/packages/convert/test/audio-codec-selection.test.tsx
+++ b/packages/convert/test/audio-codec-selection.test.tsx
@@ -1,0 +1,19 @@
+import {expect, test} from 'bun:test';
+import {renderToString} from 'react-dom/server';
+import {AudioCodecSelection} from '../app/components/AudioCodecSelection';
+import {getAudioOperationId} from '../app/lib/operation-key';
+
+test('renders unknown-codec audio tracks without crashing', () => {
+	const operation = {type: 'drop'} as const;
+
+	expect(() => {
+		renderToString(
+			<AudioCodecSelection
+				audioTrackOptions={[operation]}
+				currentAudioCodec={null}
+				index={getAudioOperationId(operation)}
+				setIndex={() => undefined}
+			/>,
+		);
+	}).not.toThrow();
+});

--- a/packages/convert/test/audio-transcoding-options.test.ts
+++ b/packages/convert/test/audio-transcoding-options.test.ts
@@ -7,6 +7,7 @@ import {getAudioTranscodingOptions} from '../app/lib/can-transcode-or-copy';
 const makeAudioTrack = (sampleRate: number) =>
 	({
 		codec: 'pcm-s16',
+		getCodec: () => Promise.resolve('pcm-s16'),
 		canDecode: () => Promise.resolve(true),
 		getSampleRate: () => Promise.resolve(sampleRate),
 	}) as unknown as InputAudioTrack;
@@ -64,6 +65,7 @@ test('offers only drop for audio tracks with unknown codecs', async () => {
 			{
 				id: 0,
 				codec: null,
+				getCodec: () => Promise.resolve(null),
 				isAudioTrack: () => true,
 				isVideoTrack: () => false,
 			} as unknown as InputTrack,
@@ -81,6 +83,38 @@ test('offers only drop for audio tracks with unknown codecs', async () => {
 			trackId: 0,
 			audioCodec: null,
 			operations: [{type: 'drop'}],
+		},
+	]);
+});
+
+test('uses async codec resolution for audio copy checks', async () => {
+	const configs = await getSupportedConfigs({
+		tracks: [
+			{
+				id: 0,
+				get codec(): never {
+					throw new Error('Use getCodec() instead');
+				},
+				getCodec: () => Promise.resolve('aac'),
+				getSampleRate: () => Promise.resolve(48000),
+				canDecode: () => Promise.resolve(false),
+				isAudioTrack: () => true,
+				isVideoTrack: () => false,
+			} as unknown as InputTrack,
+		],
+		container: new Mp4OutputFormat(),
+		action: {type: 'generic-convert'},
+		userRotation: 0,
+		resizeOperation: null,
+		sampleRate: null,
+		disableVideoCopy: false,
+	});
+
+	expect(configs.audioTrackOptions).toEqual([
+		{
+			trackId: 0,
+			audioCodec: 'aac',
+			operations: [{type: 'copy'}, {type: 'drop'}],
 		},
 	]);
 });

--- a/packages/convert/test/audio-transcoding-options.test.ts
+++ b/packages/convert/test/audio-transcoding-options.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
-import type {InputAudioTrack} from 'mediabunny';
+import type {InputAudioTrack, InputTrack} from 'mediabunny';
 import {Mp3OutputFormat, Mp4OutputFormat} from 'mediabunny';
+import {getSupportedConfigs} from '../app/components/get-supported-configs';
 import {getAudioTranscodingOptions} from '../app/lib/can-transcode-or-copy';
 
 const makeAudioTrack = (sampleRate: number) =>
@@ -55,4 +56,31 @@ test('registers extension-backed audio encoders for supported containers', async
 	expect(codecs).toContain('flac');
 	expect(codecs).toContain('ac3');
 	expect(codecs).toContain('eac3');
+});
+
+test('offers only drop for audio tracks with unknown codecs', async () => {
+	const configs = await getSupportedConfigs({
+		tracks: [
+			{
+				id: 0,
+				codec: null,
+				isAudioTrack: () => true,
+				isVideoTrack: () => false,
+			} as unknown as InputTrack,
+		],
+		container: new Mp4OutputFormat(),
+		action: {type: 'generic-convert'},
+		userRotation: 0,
+		resizeOperation: null,
+		sampleRate: null,
+		disableVideoCopy: false,
+	});
+
+	expect(configs.audioTrackOptions).toEqual([
+		{
+			trackId: 0,
+			audioCodec: null,
+			operations: [{type: 'drop'}],
+		},
+	]);
 });

--- a/packages/convert/test/video-transcoding-options.test.ts
+++ b/packages/convert/test/video-transcoding-options.test.ts
@@ -7,6 +7,7 @@ const makeVideoTrack = () =>
 	({
 		id: 0,
 		codec: 'avc',
+		getCodec: () => Promise.resolve('avc'),
 		rotation: 0,
 		displayHeight: 1080,
 		displayWidth: 1920,


### PR DESCRIPTION
## Summary

- resolve HLS track codecs through Mediabunny's async `getCodec()` API before rendering Convert controls
- handle the reported HLS stream's AAC audio track instead of treating it as unknown
- use each audio track's codec when rendering audio operation labels
- add regression coverage for async-only codec resolution and truly unknown-codec drop-only audio operations

Closes #8967.

## Testing

- `bun test test/audio-transcoding-options.test.ts test/audio-codec-selection.test.tsx` from `packages/convert`
- `bun run lint` from `packages/convert`
- `bun run test` from `packages/convert`
- `bun run build`
- `bun run stylecheck`
