### PR TITLE
Forward AnimatedImage data attributes to canvas

### DIFF
--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -29,7 +29,11 @@ import type {AnimatedImageCanvasRef} from './canvas';
 import {Canvas} from './canvas';
 import type {RemotionImageDecoder} from './decode-image.js';
 import {decodeImage} from './decode-image.js';
-import type {AnimatedImageProps, RemotionAnimatedImageProps} from './props';
+import type {
+	AnimatedImageCanvasProps,
+	AnimatedImageProps,
+	RemotionAnimatedImageProps,
+} from './props';
 import {serializeRequestInit} from './request-init';
 import {resolveAnimatedImageSource} from './resolve-image-source';
 
@@ -47,6 +51,24 @@ const animatedImageSchema = {
 	},
 	...transformSchema,
 } as const satisfies InteractivitySchema;
+
+const getCanvasPropsFromSequenceProps = (
+	props: Record<string, unknown>,
+): AnimatedImageCanvasProps => {
+	const canvasProps: AnimatedImageCanvasProps = {};
+	const mutableCanvasProps = canvasProps as Record<string, unknown>;
+
+	for (const key in props) {
+		if (
+			Object.prototype.hasOwnProperty.call(props, key) &&
+			(key.startsWith('data-') || key.startsWith('aria-'))
+		) {
+			mutableCanvasProps[key] = props[key];
+		}
+	}
+
+	return canvasProps;
+};
 
 type AnimatedImageContentProps = RemotionAnimatedImageProps & {
 	readonly effects: EffectsProp;
@@ -255,6 +277,8 @@ const AnimatedImageInner = ({
 		return actualRef.current as HTMLCanvasElement;
 	}, []);
 
+	const canvasProps = getCanvasPropsFromSequenceProps(sequenceProps);
+
 	const animatedImageProps: RemotionAnimatedImageProps = {
 		src,
 		width,
@@ -267,6 +291,7 @@ const AnimatedImageInner = ({
 		className,
 		style,
 		requestInit,
+		...canvasProps,
 	};
 
 	return (

--- a/packages/core/src/animated-image/canvas.tsx
+++ b/packages/core/src/animated-image/canvas.tsx
@@ -3,7 +3,7 @@ import {calculateImageFit} from '../calculate-image-fit.js';
 import type {EffectDefinitionAndStack} from '../effects/effect-types.js';
 import {runEffectChain} from '../effects/run-effect-chain.js';
 import {useEffectChainState} from '../effects/use-effect-chain-state.js';
-import type {AnimatedImageFillMode} from './props';
+import type {AnimatedImageCanvasProps, AnimatedImageFillMode} from './props';
 
 type Props = {
 	readonly width?: number;
@@ -15,7 +15,7 @@ type Props = {
 
 	readonly style?: React.CSSProperties;
 	readonly effects: EffectDefinitionAndStack<unknown>[];
-};
+} & AnimatedImageCanvasProps;
 
 export type AnimatedImageCanvasRef = {
 	readonly draw: (imageData: VideoFrame) => Promise<boolean>;
@@ -26,7 +26,7 @@ export type AnimatedImageCanvasRef = {
 const CanvasRefForwardingFunction: React.ForwardRefRenderFunction<
 	AnimatedImageCanvasRef,
 	Props
-> = ({width, height, fit, className, style, effects}, ref) => {
+> = ({width, height, fit, className, style, effects, ...props}, ref) => {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const chainState = useEffectChainState();
 
@@ -116,7 +116,9 @@ const CanvasRefForwardingFunction: React.ForwardRefRenderFunction<
 		};
 	}, [draw]);
 
-	return <canvas ref={canvasRef} className={className} style={style} />;
+	return (
+		<canvas ref={canvasRef} className={className} style={style} {...props} />
+	);
 };
 
 export const Canvas = React.forwardRef(CanvasRefForwardingFunction);

--- a/packages/core/src/animated-image/props.ts
+++ b/packages/core/src/animated-image/props.ts
@@ -7,6 +7,9 @@ export type RemotionAnimatedImageLoopBehavior =
 	| 'pause-after-finish'
 	| 'clear-after-finish';
 
+export type AnimatedImageCanvasProps = React.AriaAttributes &
+	Record<`data-${string}`, string | undefined>;
+
 export type RemotionAnimatedImageProps = {
 	src: string;
 	width?: number;
@@ -19,7 +22,7 @@ export type RemotionAnimatedImageProps = {
 	id?: string;
 	className?: string;
 	requestInit?: RequestInit;
-};
+} & AnimatedImageCanvasProps;
 
 export type AnimatedImageProps = InteractiveBaseProps &
 	RemotionAnimatedImageProps & {

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -304,6 +304,24 @@ test('AnimatedImage registers its canvas ref for the Studio outline', () => {
 	expect(ref.current).toBe(refForOutline.current);
 });
 
+test('AnimatedImage forwards data and aria attributes to its canvas', () => {
+	const {container} = render(
+		<SequenceTestWrapper onRegisterSequence={() => undefined}>
+			<AnimatedImage
+				aria-label="Animated image preview"
+				data-testid="animated-image-canvas"
+				onError={() => undefined}
+				src="test.gif"
+			/>
+		</SequenceTestWrapper>,
+	);
+
+	const canvas = container.querySelector('canvas');
+
+	expect(canvas?.getAttribute('aria-label')).toBe('Animated image preview');
+	expect(canvas?.getAttribute('data-testid')).toBe('animated-image-canvas');
+});
+
 test('Video media registration accounts for its own negative from', () => {
 	const registeredSequences: TSequence[] = [];
 


### PR DESCRIPTION
## Summary
- Forward `data-*` and `aria-*` props from `<AnimatedImage>` to its rendered canvas despite the internal `layout=\"none\"` Sequence wrapper.
- Add a regression test covering `aria-label` and `data-testid` on the rendered canvas.

## Test plan
- `cd packages/core && bun test src/test/sequence-register-once.test.tsx`
- `cd packages/core && bun run lint`
- `cd packages/core && bun run formatting`
- `cd packages/core && bun run make`


Made with [Cursor](https://cursor.com)