### PR TITLE
`@remotion/example`: Add timeline interactivity compositions

### DIFF
--- a/packages/example/src/Issue8974TimelineInteractivity/index.tsx
+++ b/packages/example/src/Issue8974TimelineInteractivity/index.tsx
@@ -1,0 +1,129 @@
+import {Video} from '@remotion/media';
+import {linearTiming, TransitionSeries} from '@remotion/transitions';
+import {fade} from '@remotion/transitions/fade';
+import React from 'react';
+import {Sequence} from 'remotion';
+
+export const Issue8974TransitionSeriesTimeline: React.FC = () => {
+	return (
+		<TransitionSeries name="Linked timeline TransitionSeries">
+			<TransitionSeries.Sequence name="Linked clip 01" durationInFrames={42}>
+				<Video
+					name="Linked video 01"
+					src="https://remotion.media/video.mp4"
+					trimBefore={0}
+					trimAfter={42}
+					muted
+				/>
+			</TransitionSeries.Sequence>
+			<TransitionSeries.Transition
+				timing={linearTiming({durationInFrames: 8})}
+				presentation={fade()}
+			/>
+			<TransitionSeries.Sequence name="Linked clip 02" durationInFrames={50}>
+				<Video
+					name="Linked video 02"
+					src="https://remotion.media/video.webm"
+					trimBefore={8}
+					trimAfter={58}
+					muted
+				/>
+			</TransitionSeries.Sequence>
+			<TransitionSeries.Transition
+				timing={linearTiming({durationInFrames: 8})}
+				presentation={fade()}
+			/>
+			<TransitionSeries.Sequence name="Linked clip 03" durationInFrames={36}>
+				<Video
+					name="Linked video 03"
+					src="https://remotion.media/video.mp4"
+					trimBefore={60}
+					trimAfter={96}
+					muted
+				/>
+			</TransitionSeries.Sequence>
+			<TransitionSeries.Transition
+				timing={linearTiming({durationInFrames: 8})}
+				presentation={fade()}
+			/>
+			<TransitionSeries.Sequence name="Linked clip 04" durationInFrames={46}>
+				<Video
+					name="Linked video 04"
+					src="https://remotion.media/video.webm"
+					trimBefore={70}
+					trimAfter={116}
+					muted
+				/>
+			</TransitionSeries.Sequence>
+			<TransitionSeries.Transition
+				timing={linearTiming({durationInFrames: 8})}
+				presentation={fade()}
+			/>
+			<TransitionSeries.Sequence name="Linked clip 05" durationInFrames={56}>
+				<Video
+					name="Linked video 05"
+					src="https://remotion.media/video.mp4"
+					trimBefore={120}
+					trimAfter={176}
+					muted
+				/>
+			</TransitionSeries.Sequence>
+		</TransitionSeries>
+	);
+};
+
+export const Issue8974IndependentVideosTimeline: React.FC = () => {
+	return (
+		<>
+			<Sequence name="Independent clip 01" durationInFrames={78}>
+				<Video
+					name="Independent video 01"
+					src="https://remotion.media/video.mp4"
+					trimBefore={0}
+					trimAfter={78}
+					muted
+				/>
+			</Sequence>
+
+			<Sequence name="Independent clip 02" from={78} durationInFrames={66}>
+				<Video
+					name="Independent video 02"
+					src="https://remotion.media/video.webm"
+					trimBefore={12}
+					trimAfter={78}
+					muted
+				/>
+			</Sequence>
+
+			<Sequence name="Independent clip 03" from={144} durationInFrames={90}>
+				<Video
+					name="Independent video 03"
+					src="https://remotion.media/video.mp4"
+					trimBefore={72}
+					trimAfter={162}
+					muted
+				/>
+			</Sequence>
+
+			<Sequence name="Independent clip 04" from={234} durationInFrames={72}>
+				<Video
+					name="Independent video 04"
+					src="https://remotion.media/video.webm"
+					trimBefore={58}
+					trimAfter={130}
+					muted
+				/>
+			</Sequence>
+
+			<Sequence name="Independent clip 05" from={306} durationInFrames={60}>
+				<Video
+					name="Independent video 05"
+					src="https://remotion.media/video.mp4"
+					trimBefore={180}
+					trimAfter={240}
+					muted
+				/>
+			</Sequence>
+		</>
+	);
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -205,6 +205,10 @@ import {PaletteMapEffect} from './EffectsTestbed/PaletteMapEffect';
 import {RadialProgressiveBlurTest} from './EffectsTestbed/RadialProgressiveBlur';
 import {VideoEffectsFastRefresh} from './EffectsTestbed/VideoEffectsFastRefresh';
 import {Empty} from './Empty';
+import {
+	Issue8974IndependentVideosTimeline,
+	Issue8974TransitionSeriesTimeline,
+} from './Issue8974TimelineInteractivity';
 import {JumpCuts, SAMPLE_SECTIONS, calculateMetadataJumpCuts} from './JumpCuts';
 import {LightLeakExample} from './LightLeak';
 import {LightLeakAnimatedSize} from './LightLeak/AnimatedSize';
@@ -2589,6 +2593,24 @@ export const Index: React.FC = () => {
 					height={1080}
 					fps={30}
 					durationInFrames={165}
+				/>
+			</Folder>
+			<Folder name="Issue8974">
+				<Composition
+					id="issue-8974-transition-series-timeline"
+					component={Issue8974TransitionSeriesTimeline}
+					width={1920}
+					height={1080}
+					fps={30}
+					durationInFrames={210}
+				/>
+				<Composition
+					id="issue-8974-independent-videos-timeline"
+					component={Issue8974IndependentVideosTimeline}
+					width={1920}
+					height={1080}
+					fps={30}
+					durationInFrames={366}
 				/>
 			</Folder>
 			<Folder name="VisualModeTests">


### PR DESCRIPTION
## Summary

- add a TransitionSeries-based timeline composition for linked clip trimming
- add a plain Sequence-based timeline composition for independent video clips
- register both under the Issue8974 folder in the example project

Refs #8974

## Testing

- `bunx oxfmt src --write` from `packages/example`
- `bun run build`
- `bun run stylecheck`
- `bunx remotion compositions | rg "issue-8974"` from `packages/example`
