### PR TITLE
`create-video`: Add help output

### DIFF
--- a/packages/create-video/src/help.ts
+++ b/packages/create-video/src/help.ts
@@ -1,7 +1,19 @@
 import {FEATURED_TEMPLATES} from './templates';
 
+const formatOption = ({
+	flag,
+	description,
+}: {
+	flag: string;
+	description: string;
+}) => {
+	return `  ${flag.padEnd(18)}${description}`;
+};
+
 const formatTemplateFlags = () => {
-	return FEATURED_TEMPLATES.map((template) => `--${template.cliId}`).join(', ');
+	return FEATURED_TEMPLATES.map((template) => `  --${template.cliId}`).join(
+		'\n',
+	);
 };
 
 export const getCreateVideoHelp = () => {
@@ -18,13 +30,26 @@ export const getCreateVideoHelp = () => {
 		'  directory       Directory in which the project should be created.',
 		'',
 		'Options:',
-		'  --yes, -y       Enable non-interactive mode. Requires a template flag and a directory, unless --tmp is used.',
-		'  --no-tailwind  Skip installing TailwindCSS when used with --yes.',
-		'  --tmp          Create the project in a temporary directory.',
-		'  --help, -h     Show this help.',
+		formatOption({
+			flag: '--yes, -y',
+			description:
+				'Enable non-interactive mode. Requires a template flag and a directory, unless --tmp is used.',
+		}),
+		formatOption({
+			flag: '--no-tailwind',
+			description: 'Skip installing TailwindCSS when used with --yes.',
+		}),
+		formatOption({
+			flag: '--tmp',
+			description: 'Create the project in a temporary directory.',
+		}),
+		formatOption({
+			flag: '--help, -h',
+			description: 'Show this help.',
+		}),
 		'',
 		'Template flags:',
-		`  ${formatTemplateFlags()}`,
+		formatTemplateFlags(),
 		'',
 		'Full documentation: https://www.remotion.dev/docs/cli/create-video',
 	].join('\n');

--- a/packages/create-video/src/help.ts
+++ b/packages/create-video/src/help.ts
@@ -1,0 +1,31 @@
+import {FEATURED_TEMPLATES} from './templates';
+
+const formatTemplateFlags = () => {
+	return FEATURED_TEMPLATES.map((template) => `--${template.cliId}`).join(', ');
+};
+
+export const getCreateVideoHelp = () => {
+	return [
+		'create-video',
+		'',
+		'Scaffold a new Remotion project.',
+		'',
+		'Usage:',
+		'  npx create-video --yes --blank my-video',
+		'  npx create-video [options] [directory]',
+		'',
+		'Arguments:',
+		'  directory       Directory in which the project should be created.',
+		'',
+		'Options:',
+		'  --yes, -y       Enable non-interactive mode. Requires a template flag and a directory, unless --tmp is used.',
+		'  --no-tailwind  Skip installing TailwindCSS when used with --yes.',
+		'  --tmp          Create the project in a temporary directory.',
+		'  --help, -h     Show this help.',
+		'',
+		'Template flags:',
+		`  ${formatTemplateFlags()}`,
+		'',
+		'Full documentation: https://www.remotion.dev/docs/cli/create-video',
+	].join('\n');
+};

--- a/packages/create-video/src/init.ts
+++ b/packages/create-video/src/init.ts
@@ -7,6 +7,7 @@ import {askSkills} from './ask-skills';
 import {askTailwind} from './ask-tailwind';
 import {createPublicFolder} from './create-public-folder';
 import {degit} from './degit';
+import {getCreateVideoHelp} from './help';
 import {makeHyperlink} from './hyperlinks/make-link';
 import {installSkills} from './install-skills';
 import {getLatestRemotionVersion} from './latest-remotion-version';
@@ -25,6 +26,7 @@ import prompts from './prompts';
 import {resolveProjectRoot} from './resolve-project-root';
 import {
 	getDirectoryArgument,
+	isHelpFlagSelected,
 	isNoTailwindFlagSelected,
 	isTmpFlagSelected,
 	isYesFlagSelected,
@@ -86,6 +88,11 @@ const getGitStatus = async (root: string): Promise<void> => {
 };
 
 export const init = async () => {
+	if (isHelpFlagSelected()) {
+		Log.info(getCreateVideoHelp());
+		return;
+	}
+
 	Log.info(`Welcome to ${chalk.blue('Remotion')}!`);
 
 	// Get directory argument if provided

--- a/packages/create-video/src/select-template.ts
+++ b/packages/create-video/src/select-template.ts
@@ -11,12 +11,19 @@ type Options = {
 	tmp: boolean;
 	yes: boolean;
 	'no-tailwind': boolean;
+	help: boolean;
 };
 
 const parsed = minimist<Options>(process.argv.slice(2), {
-	boolean: [...ALL_TEMPLATES.map((f) => f.cliId), 'tmp', 'yes', 'no-tailwind'],
+	boolean: [
+		...ALL_TEMPLATES.map((f) => f.cliId),
+		'tmp',
+		'yes',
+		'no-tailwind',
+		'help',
+	],
 	string: ['_'],
-	alias: {y: 'yes'},
+	alias: {y: 'yes', h: 'help'},
 });
 
 export const isTmpFlagSelected = () => parsed.tmp;
@@ -24,6 +31,8 @@ export const isTmpFlagSelected = () => parsed.tmp;
 export const isYesFlagSelected = () => parsed.yes;
 
 export const isNoTailwindFlagSelected = () => parsed['no-tailwind'];
+
+export const isHelpFlagSelected = () => parsed.help;
 
 export const getPositionalArguments = () => parsed._;
 

--- a/packages/create-video/src/test/help.test.ts
+++ b/packages/create-video/src/test/help.test.ts
@@ -11,8 +11,9 @@ test('prints a concise help output for create-video', () => {
 	expect(help).toContain('--tmp');
 	expect(help).toContain('--help, -h');
 	expect(help).toContain('https://www.remotion.dev/docs/cli/create-video');
+	expect(help).toContain('Template flags:\n  --blank\n  --hello-world');
 
 	for (const template of FEATURED_TEMPLATES) {
-		expect(help).toContain(`--${template.cliId}`);
+		expect(help).toContain(`\n  --${template.cliId}`);
 	}
 });

--- a/packages/create-video/src/test/help.test.ts
+++ b/packages/create-video/src/test/help.test.ts
@@ -1,0 +1,18 @@
+import {expect, test} from 'bun:test';
+import {getCreateVideoHelp} from '../help';
+import {FEATURED_TEMPLATES} from '../templates';
+
+test('prints a concise help output for create-video', () => {
+	const help = getCreateVideoHelp();
+
+	expect(help).toContain('npx create-video --yes --blank my-video');
+	expect(help).toContain('--yes, -y');
+	expect(help).toContain('--no-tailwind');
+	expect(help).toContain('--tmp');
+	expect(help).toContain('--help, -h');
+	expect(help).toContain('https://www.remotion.dev/docs/cli/create-video');
+
+	for (const template of FEATURED_TEMPLATES) {
+		expect(help).toContain(`--${template.cliId}`);
+	}
+});

--- a/packages/docs/docs/ai/coding-agents.mdx
+++ b/packages/docs/docs/ai/coding-agents.mdx
@@ -22,14 +22,10 @@ Most coding agents require a paid subscription.
 Create a new project using the following command:
 
 ```bash
-npx create-video@latest
+npx create-video --yes --blank my-video
 ```
 
-This will create a new project - we recommend the following settings:
-
-- Select the [Blank](https://remotion.dev/templates/blank) template
-- Say yes to use [TailwindCSS](/docs/tailwind)
-- Say yes to install [Skills](/docs/ai/skills)
+This creates a [Blank](https://remotion.dev/templates/blank) project in the `my-video` directory.
 
 ## Start the preview
 

--- a/packages/docs/docs/cli/create-video.mdx
+++ b/packages/docs/docs/cli/create-video.mdx
@@ -65,7 +65,7 @@ Create the project in a temporary directory instead of specifying a directory na
 npx create-video --yes --blank --tmp
 ```
 
-### `--help`
+### `--help`<AvailableFrom v="4.0.488" />
 
 Print a short overview of the arguments, flags and template flags.
 
@@ -73,7 +73,7 @@ Print a short overview of the arguments, flags and template flags.
 npx create-video --help
 ```
 
-### `-h`
+### `-h`<AvailableFrom v="4.0.488" />
 
 Alias for `--help`.
 

--- a/packages/docs/docs/cli/create-video.mdx
+++ b/packages/docs/docs/cli/create-video.mdx
@@ -10,7 +10,7 @@ import {CreateVideoTemplateFlags} from '../../components/CreateVideoTemplateFlag
 Scaffold a new Remotion project.
 
 ```bash
-npx create-video <directory>
+npx create-video --yes --blank my-video
 ```
 
 If no arguments are passed, an interactive TUI will guide you through the setup.
@@ -20,6 +20,12 @@ If no arguments are passed, an interactive TUI will guide you through the setup.
 ### `<directory>`
 
 The directory in which the project should be created.
+
+The recommended starter command creates a blank project in the `my-video` directory:
+
+```bash
+npx create-video --yes --blank my-video
+```
 
 ## Flags
 
@@ -58,6 +64,18 @@ Create the project in a temporary directory instead of specifying a directory na
 ```bash
 npx create-video --yes --blank --tmp
 ```
+
+### `--help`
+
+Print a short overview of the arguments, flags and template flags.
+
+```bash
+npx create-video --help
+```
+
+### `-h`
+
+Alias for `--help`.
 
 ### Template flags
 

--- a/packages/docs/src/helpers/system-prompt.ts
+++ b/packages/docs/src/helpers/system-prompt.ts
@@ -9,7 +9,7 @@ It is based on React.js. All output should be valid React code and be written in
 # Project structure
 
 A Remotion Project consists of an entry file, a Root file and any number of React component files.
-A project can be scaffolded using the "npx create-video@latest --blank" command.
+A project can be scaffolded using the "npx create-video --yes --blank my-video" command.
 The entry file is usually named "src/index.ts" and looks like this:
 
 \`\`\`ts

--- a/packages/docs/static/llms.txt
+++ b/packages/docs/static/llms.txt
@@ -6,7 +6,7 @@ It is based on React.js. All output should be valid React code and be written in
 # Project structure
 
 A Remotion Project consists of an entry file, a Root file and any number of React component files.
-A project can be scaffolded using the "npx create-video@latest --blank" command.
+A project can be scaffolded using the "npx create-video --yes --blank my-video" command.
 The entry file is usually named "src/index.ts" and looks like this:
 
 ```ts

--- a/packages/promo-pages/src/components/homepage/GetStartedStrip.tsx
+++ b/packages/promo-pages/src/components/homepage/GetStartedStrip.tsx
@@ -24,13 +24,15 @@ export const GetStarted: React.FC = () => {
 					<Button
 						className="bg-[#333] text-white rounded-lg px-4 font-mono hover:[#444] cursor-pointer w-full"
 						onClick={() => {
-							navigator.clipboard.writeText('npx create-video@latest');
+							navigator.clipboard.writeText(
+								'npx create-video --yes --blank my-video',
+							);
 
 							setClicked(Date.now());
 						}}
 						title="Click to copy"
 					>
-						$ npx create-video@latest
+						$ npx create-video --yes --blank my-video
 					</Button>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

- Add `--help` / `-h` output for `create-video` before the interactive wizard starts.
- Update create-video docs and agent-facing starter commands to recommend `npx create-video --yes --blank my-video`.
- Update the homepage get-started copy button and generated system prompt source.

Closes #8982

## Tests

- `bunx oxfmt src --write` in `packages/create-video`, `packages/docs`, and `packages/promo-pages`
- `bun run build`
- `bun run stylecheck`
- `node packages/create-video/bin.js --help`
