### PR TITLE
`remotion-monorepo`: Document skill locations

### DIFF
--- a/.agents/skills/skill-locations/SKILL.md
+++ b/.agents/skills/skill-locations/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: skill-locations
+description: Document Remotion skill placement. Use when adding, moving, or editing Remotion skills to decide whether a skill belongs in .agents/skills as an internal skill or packages/skills as a public skill.
+---
+
+# Remotion Skill Locations
+
+Place internal agent-only skills in `.agents/skills/<skill-name>/SKILL.md`.
+
+Place public, redistributable skills in `packages/skills/skills/<skill-name>/SKILL.md`.
+
+When in doubt, ask whether the skill is internal or public before moving it between these roots.


### PR DESCRIPTION
## Summary

- Add an internal skill documenting where Remotion internal and public skills live

## Testing

- `python3 /Users/jonathanburger/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/skill-locations`
- `bun run build`
- `bun run stylecheck`
