### PR TITLE
`@remotion/studio-server`: Fix browser process detection

### DIFF
--- a/packages/studio-server/src/better-opn/index.ts
+++ b/packages/studio-server/src/better-opn/index.ts
@@ -4,6 +4,29 @@ import {exec} from 'node:child_process';
 import type {Writable} from 'stream';
 import open = require('open');
 
+const supportedChromiumBrowsers = [
+	'Google Chrome',
+	'Google Chrome Canary',
+	'Microsoft Edge',
+	'Brave Browser',
+	'Vivaldi',
+	'Chromium',
+	'Arc',
+] as const;
+
+export const getChromiumBrowsersToTry = (processes: string) => {
+	const processNames = new Set(
+		processes
+			.split('\n')
+			.map((line) => line.trim())
+			.filter(Boolean),
+	);
+
+	return supportedChromiumBrowsers.filter((browser) =>
+		processNames.has(browser),
+	);
+};
+
 const normalizeURLToMatch = (target: string) => {
 	// We may encounter URL parse error but want to fallback to default behavior
 	try {
@@ -39,17 +62,8 @@ const startBrowserProcess = async ({
 		let appleScriptDenied = false;
 
 		// Will use the first open browser found from list
-		const supportedChromiumBrowsers = [
-			'Google Chrome',
-			'Google Chrome Canary',
-			'Microsoft Edge',
-			'Brave Browser',
-			'Vivaldi',
-			'Chromium',
-			'Arc',
-		] as const;
 		const processes = await new Promise<string>((resolve, reject) => {
-			exec('ps cax', (err, stdout) => {
+			exec('ps -cax -o comm=', (err, stdout) => {
 				if (err) {
 					reject(err);
 				} else {
@@ -58,9 +72,7 @@ const startBrowserProcess = async ({
 			});
 		});
 
-		const browsersToTry = supportedChromiumBrowsers.filter((b) =>
-			processes.includes(b),
-		);
+		const browsersToTry = getChromiumBrowsersToTry(processes);
 
 		for (const chromiumBrowser of browsersToTry) {
 			if (appleScriptDenied) {

--- a/packages/studio-server/src/test/better-opn.test.ts
+++ b/packages/studio-server/src/test/better-opn.test.ts
@@ -1,0 +1,27 @@
+import {expect, test} from 'bun:test';
+import {getChromiumBrowsersToTry} from '../better-opn';
+
+test('matches running Chromium browsers by exact process name', () => {
+	const processes = `
+Google Chrome
+Microsoft Edge
+Brave Browser
+`;
+
+	expect(getChromiumBrowsersToTry(processes)).toEqual([
+		'Google Chrome',
+		'Microsoft Edge',
+		'Brave Browser',
+	]);
+});
+
+test('does not match browser names as substrings of other processes', () => {
+	const processes = `
+TrialArchivingService
+FooArcBar
+Vivaldi Updater
+Google Chrome Helper
+`;
+
+	expect(getChromiumBrowsersToTry(processes)).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- Match running Chromium browser process names exactly before trying macOS AppleScript tab reuse
- Use `ps -cax -o comm=` so process detection receives one bare command name per line
- Add regression coverage for substring false positives like `TrialArchivingService`

Closes https://github.com/remotion-dev/remotion/issues/8969

## Testing

- `bun test packages/studio-server/src/test/better-opn.test.ts`
- `bun run build`
- `bun run stylecheck`
