### PR TITLE
Docs: Improve Elements page layout

### DIFF
--- a/packages/docs/components/layout/Button.tsx
+++ b/packages/docs/components/layout/Button.tsx
@@ -44,7 +44,7 @@ export const Button: React.FC<Props> = (props) => {
 					props.style?.padding ??
 					(props.size === 'sm' ? '10px 16px' : '16px 22px'),
 				color: props.color,
-				cursor: props.disabled ? 'default' : 'pointer',
+				cursor: actualDisabled ? 'default' : (props.style?.cursor ?? 'pointer'),
 				backgroundColor: props.background,
 				// @ts-expect-error
 				'--hover-color': props.hoverColor ?? props.background,

--- a/packages/docs/components/layout/button.module.css
+++ b/packages/docs/components/layout/button.module.css
@@ -16,3 +16,7 @@
 .buttoncontainer:not([disabled]):hover {
 	background-color: var(--hover-color) !important;
 }
+
+.buttoncontainer[draggable='true']:active {
+	cursor: grabbing !important;
+}

--- a/packages/docs/elements-template/index.mdx
+++ b/packages/docs/elements-template/index.mdx
@@ -8,6 +8,4 @@ import {ElementComponent} from './element';
 
 # Element title
 
-One short paragraph explaining what this element demonstrates and when to use it.
-
-<ElementPage component={ElementComponent} sourceFile="./element.tsx" />
+<ElementPage component={ElementComponent} description="One short sentence explaining what this element demonstrates and when to use it." sourceFile="./element.tsx" />

--- a/packages/docs/elements/backgrounds/paper-texture/index.mdx
+++ b/packages/docs/elements/backgrounds/paper-texture/index.mdx
@@ -8,6 +8,4 @@ import {PaperTexture} from './paper-texture';
 
 # Paper Texture
 
-A white paper texture background with a slowly changing posterized seed.
-
-<ElementPage component={PaperTexture} displayName="Paper Texture" slug="backgrounds/paper-texture" sourceFile="./paper-texture.tsx" />
+<ElementPage component={PaperTexture} description="A white paper texture background with a slowly changing posterized seed." displayName="Paper Texture" slug="backgrounds/paper-texture" sourceFile="./paper-texture.tsx" />

--- a/packages/docs/elements/backgrounds/rotating-starburst/index.mdx
+++ b/packages/docs/elements/backgrounds/rotating-starburst/index.mdx
@@ -8,6 +8,11 @@ import {RotatingStarburst} from './rotating-starburst';
 
 # Rotating Starburst
 
-A [`<Solid>`](/docs/solid) background with a slowly rotating [`starburst()`](/docs/starburst/starburst-effect) effect.
-
-<ElementPage component={RotatingStarburst} displayName="Rotating Starburst" durationInFrames={240} slug="backgrounds/rotating-starburst" sourceFile="./rotating-starburst.tsx" />
+<ElementPage
+  component={RotatingStarburst}
+  description="A Solid background with a slowly rotating starburst effect."
+  displayName="Rotating Starburst"
+  durationInFrames={240}
+  slug="backgrounds/rotating-starburst"
+  sourceFile="./rotating-starburst.tsx"
+/>

--- a/packages/docs/elements/data/number-counter/index.mdx
+++ b/packages/docs/elements/data/number-counter/index.mdx
@@ -8,8 +8,6 @@ import {NumberCounter} from './number-counter';
 
 # Number Counter
 
-A simple animated counter that smoothly counts from a start value to an end value.
-
 <ElementPage
   component={NumberCounter}
   contributors={[
@@ -18,6 +16,7 @@ A simple animated counter that smoothly counts from a start value to an end valu
       contribution: 'Author',
     },
   ]}
+  description="A simple animated counter that smoothly counts from a start value to an end value."
   displayName="Number Counter"
   elementHeight={200}
   elementWidth={640}

--- a/packages/docs/elements/overlays/lower-third/index.mdx
+++ b/packages/docs/elements/overlays/lower-third/index.mdx
@@ -8,6 +8,4 @@ import {LowerThird} from './lower-third';
 
 # Lower Third
 
-A clean animated lower third for introducing a speaker, guest, or section.
-
-<ElementPage component={LowerThird} displayName="Lower Third" elementHeight={138} elementWidth={680} previewPadding={300} slug="overlays/lower-third" sourceFile="./lower-third.tsx" />
+<ElementPage component={LowerThird} description="A clean animated lower third for introducing a speaker, guest, or section." displayName="Lower Third" elementHeight={138} elementWidth={680} previewPadding={300} slug="overlays/lower-third" sourceFile="./lower-third.tsx" />

--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -1,0 +1,256 @@
+.workbench {
+	margin-top: 28px;
+	margin-bottom: 28px;
+}
+
+.previewColumn,
+.actionsColumn {
+	min-width: 0;
+}
+
+.previewAndSource {
+	overflow: hidden;
+	border: 1px solid var(--ifm-color-emphasis-300);
+	border-radius: 12px;
+	background: var(--ifm-background-surface-color);
+}
+
+.sourceArea {
+	position: relative;
+	border-top: 1px solid var(--ifm-color-emphasis-300);
+	background: #282a36;
+}
+
+.sourceToggle {
+	border-radius: 8px;
+	font: inherit;
+	font-weight: 700;
+	min-height: 34px;
+	padding: 5px 10px;
+	font-size: 0.875rem;
+	border: 1px solid #4b4d57;
+	background: #18191f;
+	box-shadow: 0 2px 10px rgb(0 0 0 / 35%);
+	color: #fff;
+	cursor: pointer;
+}
+
+.sourceToggle:hover {
+	background: #23242c;
+}
+
+.sourceToggle:focus-visible,
+.contributor:focus-visible {
+	outline: 2px solid var(--ifm-color-primary);
+	outline-offset: 2px;
+}
+
+.sourceViewport {
+	height: 360px;
+	overflow: auto;
+	overscroll-behavior: contain;
+	background: #282a36;
+}
+
+.sourceViewportCollapsed {
+	height: 180px;
+	overflow: hidden;
+	pointer-events: none;
+	user-select: none;
+}
+
+.sourceReveal {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: linear-gradient(
+		to bottom,
+		rgb(40 42 54 / 5%) 0%,
+		rgb(40 42 54 / 72%) 58%,
+		#282a36 100%
+	);
+}
+
+.sourceViewport :global(.theme-code-block),
+.sourceViewport :global([class*='codeBlockContainer']) {
+	margin: 0 !important;
+	border-radius: 0 !important;
+	box-shadow: none !important;
+}
+
+.sourceViewport :global(pre) {
+	min-height: 100%;
+	max-height: none !important;
+	margin: 0 !important;
+	border: 0 !important;
+	border-radius: 0 !important;
+}
+
+.useIt {
+	padding: 12px;
+	border: 1px solid var(--ifm-color-emphasis-300);
+	border-radius: 12px;
+	background: var(--ifm-background-surface-color);
+}
+
+.actionRow {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 10px;
+}
+
+.successStatus,
+.errorStatus {
+	margin: 12px 0 0;
+	font-size: 0.875rem;
+}
+
+.successStatus {
+	color: var(--ifm-color-success-dark);
+}
+
+.errorStatus {
+	color: var(--ifm-color-danger-dark);
+}
+
+.details {
+	margin-top: 16px;
+	padding-top: 16px;
+	border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.description {
+	margin: 0;
+	font-size: 0.875rem;
+	line-height: 1.5;
+	color: var(--ifm-color-emphasis-800);
+}
+
+.metadata {
+	margin: 14px 0 0;
+	font-size: 0.8125rem;
+}
+
+.metadata > div {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.metadata dt {
+	font-weight: 600;
+	color: var(--ifm-color-emphasis-700);
+}
+
+.metadata dd {
+	margin: 0;
+	font-variant-numeric: tabular-nums;
+	font-weight: 600;
+}
+
+.contributors {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 0;
+}
+
+.contributors:not(:first-child) {
+	margin-top: 16px;
+	padding-top: 16px;
+	border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.contributorsLabel {
+	flex: none;
+	font-size: 0.8125rem;
+	font-weight: 600;
+	color: var(--ifm-color-emphasis-700);
+}
+
+.contributorList {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	min-width: 0;
+}
+
+.contributors .contributor {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+	padding: 4px 6px;
+	border-radius: 8px;
+	color: var(--ifm-font-color-base);
+	text-decoration: none;
+}
+
+.contributors .contributor:hover {
+	background: var(--ifm-color-emphasis-100);
+	color: var(--ifm-color-primary);
+	text-decoration: none;
+}
+
+.contributorAvatar {
+	width: 28px;
+	height: 28px;
+	flex: none;
+	border-radius: 50%;
+	outline: 1px solid
+		color-mix(in srgb, var(--ifm-font-color-base) 10%, transparent);
+	outline-offset: -1px;
+}
+
+.contributorText {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	font-size: 0.8125rem;
+	line-height: 1.25;
+}
+
+.contributorText > span {
+	color: var(--ifm-color-emphasis-700);
+}
+
+@media (min-width: 1200px) {
+	.workbench {
+		display: grid;
+		grid-template-columns: minmax(0, 3fr) minmax(260px, 1fr);
+		align-items: start;
+		gap: 24px;
+	}
+
+	.actionsColumn .actionRow,
+	.actionsColumn .contributors,
+	.actionsColumn .contributorList {
+		align-items: stretch;
+		flex-direction: column;
+	}
+}
+
+@media (max-width: 600px) {
+	.sourceViewport {
+		height: 320px;
+	}
+
+	.sourceViewportCollapsed {
+		height: 160px;
+	}
+
+	.actionRow {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.contributors {
+		align-items: flex-start;
+		flex-direction: column;
+		gap: 10px;
+	}
+}

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -4,20 +4,24 @@ import {
 } from '@remotion/studio-shared';
 import React, {
 	useCallback,
+	useId,
 	useMemo,
 	useState,
 	type ComponentType,
 	type ReactNode,
 } from 'react';
 import {AbsoluteFill, Sequence} from 'remotion';
-import {Credits, type Contributor} from '../Credits';
+import {BlueButton, PlainButton} from '../../../components/layout/Button';
+import {type Contributor} from '../Credits';
 import {setElementDragData, setElementDragImage} from './element-drag-data';
 import {ElementPreview} from './ElementPreview';
+import styles from './ElementPage.module.css';
 
 type ElementPageProps = {
 	readonly children?: ReactNode;
 	readonly component: ComponentType<Record<string, never>>;
 	readonly contributors?: Contributor[];
+	readonly description: ReactNode;
 	readonly displayName?: string;
 	readonly durationInFrames?: number;
 	readonly elementHeight?: number;
@@ -28,42 +32,6 @@ type ElementPageProps = {
 	readonly slug?: string;
 	readonly sourceCode?: string;
 	readonly width?: number;
-};
-
-const actionButtonStyle: React.CSSProperties = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	gap: 10,
-	padding: '12px 16px',
-	borderRadius: 10,
-	border: '1px solid var(--ifm-color-emphasis-300)',
-	background: 'var(--ifm-background-surface-color)',
-	boxShadow: '0 6px 20px rgba(0, 0, 0, 0.08)',
-	fontWeight: 700,
-	userSelect: 'none',
-};
-
-const dragButtonStyle: React.CSSProperties = {
-	...actionButtonStyle,
-	cursor: 'grab',
-};
-
-const installButtonStyle: React.CSSProperties = {
-	...actionButtonStyle,
-	cursor: 'pointer',
-};
-
-const disabledInstallButtonStyle: React.CSSProperties = {
-	...installButtonStyle,
-	cursor: 'not-allowed',
-	opacity: 0.65,
-};
-
-const actionRowStyle: React.CSSProperties = {
-	display: 'flex',
-	flexWrap: 'wrap',
-	gap: 12,
-	alignItems: 'center',
 };
 
 type ElementInstallTarget = {
@@ -140,6 +108,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	children,
 	component,
 	contributors,
+	description,
 	displayName,
 	durationInFrames = 120,
 	elementHeight,
@@ -154,6 +123,8 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	const [installStatus, setInstallStatus] = useState<InstallStatus>({
 		type: 'idle',
 	});
+	const [isSourceVisible, setIsSourceVisible] = useState(false);
+	const sourceId = useId();
 	const hasElementDimensions =
 		elementWidth !== undefined && elementHeight !== undefined;
 	const previewWidth =
@@ -287,87 +258,152 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	]);
 
 	return (
-		<>
-			<h2>Preview</h2>
-			<ElementPreview
-				component={PreviewComponent}
-				durationInFrames={durationInFrames}
-				fps={fps}
-				height={previewHeight}
-				width={previewWidth}
-			/>
-
-			<h2>Use it</h2>
-			<p>
-				Copy the source code into your Remotion project. The file exports the
-				Element component. Preview dimensions, frame rate, and duration are
-				supplied by the gallery.
-			</p>
-			{dragData === null ? null : (
-				<>
-					<p style={actionRowStyle}>
-						<button
-							disabled={installStatus.type === 'installing'}
-							onClick={installElement}
-							style={
-								installStatus.type === 'installing'
-									? disabledInstallButtonStyle
-									: installButtonStyle
-							}
-							title="Install into the most recently focused Remotion Studio"
-							type="button"
-						>
-							<span aria-hidden="true">＋</span>
-							{installStatus.type === 'installing'
-								? 'Finding Studio…'
-								: 'Install Element'}
-						</button>
-						<button
-							draggable
-							onDragStart={(event) => {
-								setElementDragData({
-									dataTransfer: event.dataTransfer,
-									dragData,
-								});
-								setElementDragImage(event.dataTransfer);
-							}}
-							style={dragButtonStyle}
-							title="Drag into Remotion Studio"
-							type="button"
-						>
-							<span aria-hidden="true">↘</span>
-							Drag into Remotion Studio
-						</button>
-					</p>
-					{installStatus.type === 'success' ||
-					installStatus.type === 'error' ? (
-						<p
-							style={{
-								color:
-									installStatus.type === 'success'
-										? 'var(--ifm-color-success-dark)'
-										: 'var(--ifm-color-danger-dark)',
-							}}
-						>
-							{installStatus.message}{' '}
-							{installStatus.type === 'success' ? (
-								<a
-									href={installStatus.studioUrl}
-									rel="noreferrer"
-									target="_blank"
-								>
-									Open Studio
-								</a>
-							) : null}
-						</p>
+		<div className={styles.workbench}>
+			<section aria-label="Preview" className={styles.previewColumn}>
+				<div className={styles.previewAndSource}>
+					<ElementPreview
+						component={PreviewComponent}
+						durationInFrames={durationInFrames}
+						fps={fps}
+						height={previewHeight}
+						width={previewWidth}
+					/>
+					{children ? (
+						<div className={styles.sourceArea}>
+							<div
+								aria-label="Element source code"
+								className={`${styles.sourceViewport} ${
+									isSourceVisible ? '' : styles.sourceViewportCollapsed
+								}`}
+								id={sourceId}
+								inert={!isSourceVisible}
+								role="region"
+							>
+								{children}
+							</div>
+							{isSourceVisible ? null : (
+								<div className={styles.sourceReveal}>
+									<button
+										aria-controls={sourceId}
+										aria-expanded={isSourceVisible}
+										className={styles.sourceToggle}
+										onClick={() => setIsSourceVisible(true)}
+										type="button"
+									>
+										View code
+									</button>
+								</div>
+							)}
+						</div>
 					) : null}
-				</>
-			)}
+				</div>
+			</section>
 
-			<h2>Source</h2>
-			{children}
+			<aside
+				aria-label="Element details and actions"
+				className={styles.actionsColumn}
+			>
+				<div className={styles.useIt}>
+					{dragData === null ? null : (
+						<>
+							<div className={styles.actionRow}>
+								<BlueButton
+									fullWidth
+									loading={installStatus.type === 'installing'}
+									onClick={installElement}
+									size="sm"
+									style={{padding: '7px 12px'}}
+									title="Install into the most recently focused Remotion Studio"
+								>
+									{installStatus.type === 'installing'
+										? 'Finding Studio…'
+										: 'Install Element'}
+								</BlueButton>
+								<PlainButton
+									draggable
+									fullWidth
+									loading={false}
+									onDragStart={(event) => {
+										setElementDragData({
+											dataTransfer: event.dataTransfer,
+											dragData,
+										});
+										setElementDragImage(event.dataTransfer);
+									}}
+									size="sm"
+									style={{cursor: 'grab', padding: '7px 12px'}}
+									title="Drag into Remotion Studio"
+								>
+									Drag into Studio
+								</PlainButton>
+							</div>
+							{installStatus.type === 'success' ||
+							installStatus.type === 'error' ? (
+								<p
+									aria-live="polite"
+									className={
+										installStatus.type === 'success'
+											? styles.successStatus
+											: styles.errorStatus
+									}
+								>
+									{installStatus.message}{' '}
+									{installStatus.type === 'success' ? (
+										<a
+											href={installStatus.studioUrl}
+											rel="noreferrer"
+											target="_blank"
+										>
+											Open Studio
+										</a>
+									) : null}
+								</p>
+							) : null}
+						</>
+					)}
 
-			{contributors?.length ? <Credits contributors={contributors} /> : null}
-		</>
+					<div className={styles.details}>
+						<p className={styles.description}>{description}</p>
+						<dl className={styles.metadata}>
+							<div>
+								<dt>Dimensions</dt>
+								<dd>
+									{elementWidth ?? width} × {elementHeight ?? height}px
+								</dd>
+							</div>
+						</dl>
+					</div>
+
+					{contributors?.length ? (
+						<div aria-label="Contributors" className={styles.contributors}>
+							<span className={styles.contributorsLabel}>Created by</span>
+							<div className={styles.contributorList}>
+								{contributors.map((contributor) => (
+									<a
+										key={contributor.username}
+										className={styles.contributor}
+										href={`https://github.com/${contributor.username}`}
+										rel="noopener noreferrer"
+										target="_blank"
+									>
+										<img
+											alt=""
+											className={styles.contributorAvatar}
+											src={`https://github.com/${contributor.username}.png`}
+										/>
+										<span className={styles.contributorText}>
+											<strong>@{contributor.username}</strong>
+											{contributor.contribution === 'Author' ? null : (
+												<span>{contributor.contribution}</span>
+											)}
+										</span>
+									</a>
+								))}
+							</div>
+						</div>
+					) : null}
+				</div>
+			</aside>
+		</div>
 	);
 };

--- a/packages/docs/src/components/Elements/ElementPreview.tsx
+++ b/packages/docs/src/components/Elements/ElementPreview.tsx
@@ -19,11 +19,8 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 	return (
 		<div
 			style={{
-				border: '1px solid var(--ifm-color-emphasis-300)',
-				borderRadius: 12,
-				overflow: 'hidden',
 				backgroundColor: 'var(--ifm-color-emphasis-100)',
-				marginBottom: 24,
+				overflow: 'hidden',
 			}}
 		>
 			<Player

--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -63,6 +63,20 @@ h6 {
 	display: none;
 }
 
+@media (min-width: 1200px) {
+	.plugin-id-elements main > .container {
+		max-width: 1440px;
+	}
+
+	.plugin-id-elements main > .container > .row > .col {
+		max-width: 100% !important;
+	}
+}
+
+.plugin-id-elements .theme-doc-markdown > h1:first-child {
+	margin-bottom: 0.75rem;
+}
+
 :root {
 	--ifm-color-primary: #0b84f3;
 	--ifm-color-primary-dark: #0a77db;


### PR DESCRIPTION
## Summary

- redesign Element pages as a responsive preview-and-actions workbench
- join a collapsed source preview to the Player with a compact “View code” disclosure
- use branded install and drag actions, compact contributor attribution, and Element metadata
- widen the documentation canvas specifically for Elements pages
- move Element descriptions into the details rail and update the Element template

## Validation

- `bun run build`
- `bun run stylecheck`
- `bun test packages/docs/src/test/elements.test.ts`
- docs production build
