### PR TITLE
`docs`: Fix CrawlChat embed causing hydration errors and duplicate script execution

### DIFF
--- a/packages/docs/src/theme/Layout/index.tsx
+++ b/packages/docs/src/theme/Layout/index.tsx
@@ -4,29 +4,44 @@ import '@remotion/promo-pages/dist/tailwind.css';
 import Layout from '@theme-original/Layout';
 import type LayoutType from '@theme/Layout';
 import {useCrawlChatSidePanel} from 'crawlchat-client';
-import React, {type ReactNode} from 'react';
+import React, {useEffect, type ReactNode} from 'react';
 
 type Props = WrapperProps<typeof LayoutType>;
 
 const isStandaloneRoute = (pathname: string) =>
 	pathname === '/experimental_new' || pathname.startsWith('/experimental_new/');
 
+const CRAWLCHAT_SCRIPT_ID = 'crawlchat-script';
+
+// The script must be injected imperatively rather than rendered as JSX:
+// embed.js declares a top-level `class CrawlChatEmbed` and mutates the DOM
+// on load, so having it in the server-rendered HTML breaks hydration
+// (React error #418) and any re-render of the <script> element executes it
+// a second time ("Identifier 'CrawlChatEmbed' has already been declared").
+const useCrawlChatScript = () => {
+	useEffect(() => {
+		if (document.getElementById(CRAWLCHAT_SCRIPT_ID)) {
+			return;
+		}
+
+		const script = document.createElement('script');
+		script.src = 'https://crawlchat.app/embed.js';
+		script.async = true;
+		script.id = CRAWLCHAT_SCRIPT_ID;
+		script.dataset.id = '67c0a28c5b075f0bb35e5366';
+		script.dataset.sidepanel = 'true';
+		script.dataset.small = 'true';
+		document.body.appendChild(script);
+		// No cleanup: removing the tag would not undo the global declaration,
+		// and re-inserting it later would throw.
+	}, []);
+};
+
 const LayoutWithCrawlChat = (props: Props): ReactNode => {
 	useCrawlChatSidePanel({history: useHistory()});
+	useCrawlChatScript();
 
-	return (
-		<>
-			<Layout {...props} />
-			<script
-				src="https://crawlchat.app/embed.js"
-				async
-				id="crawlchat-script"
-				data-id="67c0a28c5b075f0bb35e5366"
-				data-sidepanel="true"
-				data-small="true"
-			/>
-		</>
-	);
+	return <Layout {...props} />;
 };
 
 const LayoutWrapper = (props: Props): ReactNode => {


### PR DESCRIPTION
Fixes #8790

## What's happening

The CrawlChat embed is rendered as a raw `<script>` tag inside JSX in `packages/docs/src/theme/Layout/index.tsx`. That tag ends up in the server-rendered HTML of every page, which causes two of the three errors from the issue:

1. The browser executes `embed.js` before React hydrates. The script mounts the widget and restyles the TOC column right away, so the DOM no longer matches the server HTML when hydration runs → minified React error #418 from the Docusaurus root.
2. When hydration fails, React falls back to client-rendering the tree, which inserts a *fresh* `<script>` element — and freshly inserted scripts execute. `embed.js` declares a top-level `class CrawlChatEmbed`, so the second run throws `Identifier 'CrawlChatEmbed' has already been declared`. Remounting the layout wrapper (e.g. navigating to/from `/experimental_new`) can trigger the same thing.

You can see the "before" state on production right now — `curl https://www.remotion.dev/docs/the-fundamentals` has the embed script tag in the SSR HTML.

## The fix

Inject the script from a `useEffect`, guarded by a `getElementById` check so it only ever runs once. It never appears in the SSR HTML (nothing executes before hydration) and never lives in the React tree (nothing can re-create it). No cleanup on unmount on purpose: removing the tag wouldn't undo the global class declaration, and re-inserting it later would throw again.

The element keeps the same id and data attributes, so `getScrapeId()` in `embed.js` and the `#crawlchat-script` CSS on `/experimental_new` keep working.

FWIW, `crawlchat-client`'s own `<CrawlChatScript>` component renders the same JSX `<script>` tag, so switching to it wouldn't have helped — probably worth reporting upstream.

## What this doesn't fix

The third error in the issue (`entry.client-BrT_nwts.js` / `chat-box-*.js`) is a hydration error *inside* CrawlChat's iframe, thrown by their own app bundle on crawlchat.app. I confirmed it still fires with a stack pointing entirely at their assets — nothing in this repo can fix that one, it needs a report to CrawlChat.

## Tradeoffs

The embed now loads strictly after hydration instead of in parallel with it, so the widget button appears marginally later. Since `embed.js` is `async` and waits for `window.onload` anyway, the difference is negligible.

## How I tested

- `bun run build-docs`, then grepped the output: zero HTML files contain the embed script tag (all 1016 pages had it before)
- Served the build and drove it with headless Chrome: no React #418 from the docs bundle, no duplicate-identifier error, `window.crawlchatEmbed` mounts, widget container in the DOM, and exactly one script tag after initial load, after client-side navigation, and after an `/experimental_new` roundtrip
- `bun test src`, `eslint`, `oxfmt --check` all pass

If this regressed, the symptom would be the widget not appearing on docs pages — no impact outside the docs site.
