### PR TITLE
fix(renderer): apply backpressure to parallel encoding

### DIFF
--- a/packages/renderer/src/race-with-frame-error.ts
+++ b/packages/renderer/src/race-with-frame-error.ts
@@ -1,0 +1,16 @@
+export const raceWithFrameError = async <T>({
+	cleanup,
+	frameError,
+	operation,
+}: {
+	cleanup: () => void;
+	frameError: Promise<never>;
+	operation: () => Promise<T> | T;
+}): Promise<T> => {
+	try {
+		return await Promise.race([Promise.resolve().then(operation), frameError]);
+	} catch (error) {
+		cleanup();
+		throw error;
+	}
+};

--- a/packages/renderer/src/render-frame-and-retry-target-close.ts
+++ b/packages/renderer/src/render-frame-and-retry-target-close.ts
@@ -11,11 +11,11 @@ import {getRetriesLeftFromError} from './is-delay-render-error-with-retry';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
 import type {CancelSignal} from './make-cancel-signal';
-import {cancelErrorMessages, isUserCancelledRender} from './make-cancel-signal';
+import {isUserCancelledRender} from './make-cancel-signal';
 import type {NextFrameToRender} from './next-frame-to-render';
 import type {Pool} from './pool';
 import {renderFrame} from './render-frame';
-import type {FrameAndAssets, OnArtifact} from './render-frames';
+import type {FrameAndAssets, OnArtifact, OnFrameBuffer} from './render-frames';
 import type {BrowserReplacer} from './replace-browser';
 
 export const renderFrameAndRetryTargetClose = async ({
@@ -54,6 +54,7 @@ export const renderFrameAndRetryTargetClose = async ({
 	trimLeftOffset,
 	trimRightOffset,
 	allFramesAndExtraFrames,
+	cancelPromise,
 }: {
 	retriesLeft: number;
 	attempt: number;
@@ -83,7 +84,7 @@ export const renderFrameAndRetryTargetClose = async ({
 	concurrencyOrFramesToRender: number;
 	lastFrame: number;
 	framesRenderedObj: {count: number};
-	onFrameBuffer: null | ((buffer: Buffer, frame: number) => void) | undefined;
+	onFrameBuffer: OnFrameBuffer | null | undefined;
 	onFrameUpdate:
 		| null
 		| ((
@@ -96,6 +97,7 @@ export const renderFrameAndRetryTargetClose = async ({
 	trimLeftOffset: number;
 	trimRightOffset: number;
 	allFramesAndExtraFrames: number[];
+	cancelPromise: Promise<never> | null;
 }): Promise<void> => {
 	const currentPool = await poolPromise;
 
@@ -104,50 +106,49 @@ export const renderFrameAndRetryTargetClose = async ({
 	}
 
 	const freePage = await currentPool.acquire();
+	if (stoppedSignal.stopped) {
+		return;
+	}
 
 	const frame = nextFrameToRender.getNextFrame(freePage.pageIndex);
 
 	try {
-		await Promise.race([
-			renderFrame({
-				trimLeftOffset,
-				trimRightOffset,
-				allFramesAndExtraFrames,
-				attempt,
-				assets,
-				binariesDirectory,
-				cancelSignal,
-				countType,
-				downloadMap,
-				frameDir,
-				framesToRender,
-				imageFormat,
-				indent,
-				jpegQuality,
-				logLevel,
-				onArtifact,
-				onDownload,
-				scale,
-				composition,
-				framesRenderedObj,
-				lastFrame,
-				onError,
-				onFrameBuffer,
-				onFrameUpdate,
-				outputDir,
-				stoppedSignal,
-				timeoutInMilliseconds,
-				nextFrameToRender,
-				frame,
-				page: freePage,
-				imageSequencePattern,
-			}),
-			new Promise((_, reject) => {
-				cancelSignal?.(() => {
-					reject(new Error(cancelErrorMessages.renderFrames));
-				});
-			}),
-		]);
+		const renderFrameTask = renderFrame({
+			trimLeftOffset,
+			trimRightOffset,
+			allFramesAndExtraFrames,
+			attempt,
+			assets,
+			binariesDirectory,
+			cancelSignal,
+			countType,
+			downloadMap,
+			frameDir,
+			framesToRender,
+			imageFormat,
+			indent,
+			jpegQuality,
+			logLevel,
+			onArtifact,
+			onDownload,
+			scale,
+			composition,
+			framesRenderedObj,
+			lastFrame,
+			onError,
+			onFrameBuffer,
+			onFrameUpdate,
+			outputDir,
+			stoppedSignal,
+			timeoutInMilliseconds,
+			nextFrameToRender,
+			frame,
+			page: freePage,
+			imageSequencePattern,
+		});
+		await (cancelPromise
+			? Promise.race([renderFrameTask, cancelPromise])
+			: renderFrameTask);
 		currentPool.release(freePage);
 	} catch (err) {
 		const isTargetClosedError = isTargetClosedErr(err as Error);
@@ -227,6 +228,7 @@ export const renderFrameAndRetryTargetClose = async ({
 				trimLeftOffset,
 				trimRightOffset,
 				allFramesAndExtraFrames,
+				cancelPromise,
 			});
 		}
 
@@ -284,6 +286,7 @@ export const renderFrameAndRetryTargetClose = async ({
 			trimLeftOffset,
 			trimRightOffset,
 			allFramesAndExtraFrames,
+			cancelPromise,
 		});
 	}
 };

--- a/packages/renderer/src/render-frame-with-option-to-reject.ts
+++ b/packages/renderer/src/render-frame-with-option-to-reject.ts
@@ -17,7 +17,8 @@ import type {VideoImageFormat} from './image-format';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
 import type {CancelSignal} from './make-cancel-signal';
-import type {FrameAndAssets, OnArtifact} from './render-frames';
+import {raceWithFrameError} from './race-with-frame-error';
+import type {FrameAndAssets, OnArtifact, OnFrameBuffer} from './render-frames';
 import {seekToFrame} from './seek-to-frame';
 import {takeFrame} from './take-frame';
 import {truthy} from './truthy';
@@ -68,7 +69,7 @@ export const renderFrameWithOptionToReject = async ({
 	indent: boolean;
 	logLevel: LogLevel;
 	outputDir: string | null;
-	onFrameBuffer: null | ((buffer: Buffer, frame: number) => void) | undefined;
+	onFrameBuffer: OnFrameBuffer | null | undefined;
 	imageFormat: VideoImageFormat;
 	onError: (err: Error) => void;
 	lastFrame: number;
@@ -108,8 +109,14 @@ export const renderFrameWithOptionToReject = async ({
 		return Promise.reject(new Error('Render was stopped'));
 	}
 
+	let rejectFrameError = (_error: Error): void => undefined;
+	const frameError = new Promise<never>((_resolve, rejectError) => {
+		rejectFrameError = rejectError;
+	});
+	frameError.catch(() => undefined);
 	const errorCallbackOnFrame = (err: Error) => {
 		reject(err);
+		rejectFrameError(err);
 	};
 
 	const cleanupPageError = handleJavascriptException({
@@ -118,17 +125,32 @@ export const renderFrameWithOptionToReject = async ({
 		frame,
 	});
 	page.on('error', errorCallbackOnFrame);
+	let pageErrorCleanedUp = false;
+	const cleanupPageErrors = () => {
+		if (pageErrorCleanedUp) {
+			return;
+		}
+
+		pageErrorCleanedUp = true;
+		cleanupPageError();
+		page.off('error', errorCallbackOnFrame);
+	};
 
 	const startSeeking = Date.now();
 
-	await seekToFrame({
-		frame,
-		page,
-		composition: compId,
-		timeoutInMilliseconds,
-		indent,
-		logLevel,
-		attempt,
+	await raceWithFrameError({
+		cleanup: cleanupPageErrors,
+		frameError,
+		operation: () =>
+			seekToFrame({
+				frame,
+				page,
+				composition: compId,
+				timeoutInMilliseconds,
+				indent,
+				logLevel,
+				attempt,
+			}),
 	});
 
 	const timeToSeek = Date.now() - startSeeking;
@@ -151,44 +173,53 @@ export const renderFrameWithOptionToReject = async ({
 		);
 	}
 
-	const [buffer, collectedAssets] = await Promise.all([
-		takeFrame({
-			freePage: page,
-			height,
-			imageFormat: assetsOnly ? 'none' : imageFormat,
-			output:
-				index === null
-					? null
-					: path.join(
-							frameDir,
-							getFrameOutputFileName({
-								frame,
-								imageFormat,
-								index,
-								countType,
-								lastFrame,
-								totalFrames: framesToRender.length,
-								imageSequencePattern,
-							}),
-						),
-			jpegQuality,
-			width,
-			scale,
-			wantsBuffer: Boolean(onFrameBuffer),
-			timeoutInMilliseconds,
-		}),
-		collectAssets({
-			frame,
-			freePage: page,
-			timeoutInMilliseconds,
-		}),
-	]);
+	const [buffer, collectedAssets] = await raceWithFrameError({
+		cleanup: cleanupPageErrors,
+		frameError,
+		operation: () =>
+			Promise.all([
+				takeFrame({
+					freePage: page,
+					height,
+					imageFormat: assetsOnly ? 'none' : imageFormat,
+					output:
+						index === null
+							? null
+							: path.join(
+									frameDir,
+									getFrameOutputFileName({
+										frame,
+										imageFormat,
+										index,
+										countType,
+										lastFrame,
+										totalFrames: framesToRender.length,
+										imageSequencePattern,
+									}),
+								),
+					jpegQuality,
+					width,
+					scale,
+					wantsBuffer: Boolean(onFrameBuffer),
+					timeoutInMilliseconds,
+				}),
+				collectAssets({
+					frame,
+					freePage: page,
+					timeoutInMilliseconds,
+				}),
+			]),
+	});
 	if (onFrameBuffer && !assetsOnly) {
 		if (!buffer) {
 			throw new Error('unexpected null buffer');
 		}
 
-		onFrameBuffer(buffer, frame);
+		await raceWithFrameError({
+			cleanup: cleanupPageErrors,
+			frameError,
+			operation: () => onFrameBuffer(buffer, frame),
+		});
 	}
 
 	const onlyAvailableAssets = assets.filter(truthy);
@@ -272,8 +303,7 @@ export const renderFrameWithOptionToReject = async ({
 		});
 	}
 
-	cleanupPageError();
-	page.off('error', errorCallbackOnFrame);
+	cleanupPageErrors();
 
 	if (!assetsOnly) {
 		framesRenderedObj.count++;

--- a/packages/renderer/src/render-frame.ts
+++ b/packages/renderer/src/render-frame.ts
@@ -8,7 +8,7 @@ import type {LogLevel} from './log-level';
 import type {CancelSignal} from './make-cancel-signal';
 import type {NextFrameToRender} from './next-frame-to-render';
 import {renderFrameWithOptionToReject} from './render-frame-with-option-to-reject';
-import type {FrameAndAssets, OnArtifact} from './render-frames';
+import type {FrameAndAssets, OnArtifact, OnFrameBuffer} from './render-frames';
 
 export const renderFrame = ({
 	attempt,
@@ -62,7 +62,7 @@ export const renderFrame = ({
 	stoppedSignal: {stopped: boolean};
 	timeoutInMilliseconds: number;
 	outputDir: string | null;
-	onFrameBuffer: null | ((buffer: Buffer, frame: number) => void) | undefined;
+	onFrameBuffer: OnFrameBuffer | null | undefined;
 	lastFrame: number;
 	onFrameUpdate:
 		| null

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -63,6 +63,10 @@ import {wrapWithErrorHandling} from './wrap-with-error-handling';
 const MAX_RETRIES_PER_FRAME = 1;
 
 export type OnArtifact = (asset: EmittedArtifact) => void;
+export type OnFrameBuffer = (
+	buffer: Buffer,
+	frame: number,
+) => void | Promise<void>;
 
 type InternalRenderFramesOptions = {
 	onStart: null | ((data: OnStartData) => void);
@@ -82,7 +86,7 @@ type InternalRenderFramesOptions = {
 	puppeteerInstance: HeadlessBrowser | undefined;
 	browserExecutable: BrowserExecutable | null;
 	onBrowserLog: null | ((log: BrowserLog) => void);
-	onFrameBuffer: null | ((buffer: Buffer, frame: number) => void);
+	onFrameBuffer: OnFrameBuffer | null;
 	onDownload: RenderMediaOnDownload | null;
 	chromiumOptions: ChromiumOptions;
 	scale: number;
@@ -117,7 +121,7 @@ type InnerRenderFramesOptions = {
 	frameRange: FrameRange | null;
 	everyNthFrame: number;
 	onBrowserLog: null | ((log: BrowserLog) => void);
-	onFrameBuffer: null | ((buffer: Buffer, frame: number) => void);
+	onFrameBuffer: OnFrameBuffer | null;
 	onArtifact: OnArtifact | null;
 	onDownload: RenderMediaOnDownload | null;
 	timeoutInMilliseconds: number;
@@ -189,7 +193,7 @@ export type RenderFramesOptions = Prettify<
 		puppeteerInstance?: HeadlessBrowser;
 		browserExecutable?: BrowserExecutable;
 		onBrowserLog?: (log: BrowserLog) => void;
-		onFrameBuffer?: (buffer: Buffer, frame: number) => void;
+		onFrameBuffer?: OnFrameBuffer;
 		onDownload?: RenderMediaOnDownload;
 		timeoutInMilliseconds?: number;
 		chromiumOptions?: ChromiumOptions;
@@ -347,9 +351,25 @@ const innerRenderFrames = async ({
 
 	const assets: FrameAndAssets[] = [];
 	const stoppedSignal = {stopped: false};
+	let rejectCancellation = (_error: Error): void => undefined;
+	const cancelPromise = cancelSignal
+		? new Promise<never>((_resolve, reject) => {
+				rejectCancellation = reject;
+			})
+		: null;
+	cancelPromise?.catch(() => undefined);
 	cancelSignal?.(() => {
 		stoppedSignal.stopped = true;
+		rejectCancellation(new Error(cancelErrorMessages.renderFrames));
 	});
+	const onFrameBufferWithCancellation =
+		onFrameBuffer && cancelPromise
+			? (buffer: Buffer, frame: number) =>
+					Promise.race([
+						Promise.resolve(onFrameBuffer(buffer, frame)),
+						cancelPromise,
+					])
+			: onFrameBuffer;
 
 	const frameDir = outputDir ?? downloadMap.compositingDir;
 
@@ -420,13 +440,14 @@ const innerRenderFrames = async ({
 				framesRenderedObj,
 				lastFrame,
 				makeNewPage,
-				onFrameBuffer,
+				onFrameBuffer: onFrameBufferWithCancellation,
 				onFrameUpdate,
 				nextFrameToRender,
 				imageSequencePattern: pattern,
 				trimLeftOffset,
 				trimRightOffset,
 				allFramesAndExtraFrames,
+				cancelPromise,
 			});
 		}),
 	);

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -80,6 +80,7 @@ import {validateOutputFilename} from './validate-output-filename';
 import {validateScale} from './validate-scale';
 import {validateBitrate} from './validate-videobitrate';
 import {wrapWithErrorHandling} from './wrap-with-error-handling';
+import {writeToStitcher} from './write-to-stitcher';
 
 export type StitchingState = 'encoding' | 'muxing';
 
@@ -369,16 +370,13 @@ const internalRenderMediaRaw = ({
 
 	const renderStart = Date.now();
 
-	const {estimatedUsage, freeMemory, hasEnoughMemory} =
-		shouldUseParallelEncoding({
-			height: compositionWithPossibleUnevenDimensions.height,
-			width: compositionWithPossibleUnevenDimensions.width,
-			logLevel,
-		});
+	const {estimatedUsage, freeMemory} = shouldUseParallelEncoding({
+		height: compositionWithPossibleUnevenDimensions.height,
+		width: compositionWithPossibleUnevenDimensions.width,
+		logLevel,
+	});
 	const parallelEncoding =
-		!disallowParallelEncoding &&
-		hasEnoughMemory &&
-		canUseParallelEncoding(codec);
+		!disallowParallelEncoding && canUseParallelEncoding(codec);
 
 	Log.verbose(
 		{
@@ -529,6 +527,7 @@ const internalRenderMediaRaw = ({
 	const cancelStitcher = makeCancelSignal();
 
 	cancelSignal?.(() => {
+		cancelled = true;
 		cancelRenderFrames.cancel();
 	});
 
@@ -717,8 +716,19 @@ const internalRenderMediaRaw = ({
 									);
 								}
 
-								stitcherFfmpeg?.stdin?.write(buffer);
-								stopPerfMeasure(id);
+								const stdin = stitcherFfmpeg?.stdin;
+								if (!stdin) {
+									throw new Error('ERR_STREAM_PREMATURE_CLOSE');
+								}
+
+								try {
+									await writeToStitcher({
+										buffer,
+										stdin,
+									});
+								} finally {
+									stopPerfMeasure(id);
+								}
 
 								setFrameToStitch(
 									Math.min(realFrameRange[1] + 1, frame + everyNthFrame),

--- a/packages/renderer/src/test/write-to-stitcher.test.ts
+++ b/packages/renderer/src/test/write-to-stitcher.test.ts
@@ -1,0 +1,142 @@
+import {expect, test} from 'bun:test';
+import {EventEmitter} from 'node:events';
+import type {Writable} from 'node:stream';
+import {raceWithFrameError} from '../race-with-frame-error';
+import {writeToStitcher} from '../write-to-stitcher';
+
+class ControlledWritable extends EventEmitter {
+	destroyed = false;
+	writable = true;
+
+	constructor(private readonly writeResult: boolean | Error) {
+		super();
+	}
+
+	write() {
+		if (this.writeResult instanceof Error) {
+			throw this.writeResult;
+		}
+
+		return this.writeResult;
+	}
+}
+
+const asWritable = (stream: ControlledWritable) =>
+	stream as unknown as Writable;
+
+const expectNoTemporaryListeners = (stream: ControlledWritable) => {
+	expect(stream.listenerCount('drain')).toBe(0);
+	expect(stream.listenerCount('error')).toBe(0);
+	expect(stream.listenerCount('close')).toBe(0);
+};
+
+test('resolves immediately when the stream accepts the write', async () => {
+	const stream = new ControlledWritable(true);
+
+	await writeToStitcher({
+		buffer: Buffer.from('frame'),
+		stdin: asWritable(stream),
+	});
+
+	expectNoTemporaryListeners(stream);
+});
+
+test('waits for drain after a backpressured write', async () => {
+	const stream = new ControlledWritable(false);
+	let resolved = false;
+	const write = writeToStitcher({
+		buffer: Buffer.from('frame'),
+		stdin: asWritable(stream),
+	}).then(() => {
+		resolved = true;
+	});
+
+	await Promise.resolve();
+	expect(resolved).toBe(false);
+	stream.emit('drain');
+	await write;
+
+	expectNoTemporaryListeners(stream);
+});
+
+test('rejects an asynchronous stream error', async () => {
+	const stream = new ControlledWritable(false);
+	const error = Object.assign(new Error('write failed'), {code: 'EIO'});
+	const write = writeToStitcher({
+		buffer: Buffer.from('frame'),
+		stdin: asWritable(stream),
+	});
+
+	stream.emit('error', error);
+
+	await expect(write).rejects.toBe(error);
+	expectNoTemporaryListeners(stream);
+});
+
+test('rejects when the stream closes before drain', async () => {
+	const stream = new ControlledWritable(false);
+	const write = writeToStitcher({
+		buffer: Buffer.from('frame'),
+		stdin: asWritable(stream),
+	});
+
+	stream.emit('close');
+
+	await expect(write).rejects.toThrow('ERR_STREAM_PREMATURE_CLOSE');
+	expectNoTemporaryListeners(stream);
+});
+
+test('rejects a synchronous write error', async () => {
+	const error = Object.assign(new Error('broken pipe'), {code: 'EPIPE'});
+	const stream = new ControlledWritable(error);
+
+	await expect(
+		writeToStitcher({buffer: Buffer.from('frame'), stdin: asWritable(stream)}),
+	).rejects.toBe(error);
+	expectNoTemporaryListeners(stream);
+});
+
+test('rejects a stream that is already closed', async () => {
+	const stream = new ControlledWritable(true);
+	stream.destroyed = true;
+	stream.writable = false;
+
+	await expect(
+		writeToStitcher({buffer: Buffer.from('frame'), stdin: asWritable(stream)}),
+	).rejects.toThrow('ERR_STREAM_PREMATURE_CLOSE');
+	expectNoTemporaryListeners(stream);
+});
+
+test('stops waiting when the frame fails', async () => {
+	let rejectFrame = (_error: Error): void => undefined;
+	const frameError = new Promise<never>((_resolve, reject) => {
+		rejectFrame = reject;
+	});
+	let releaseOperation = (): void => undefined;
+	const operation = new Promise<void>((resolve) => {
+		releaseOperation = resolve;
+	});
+	let cleanupCalls = 0;
+	let operationFinished = false;
+	const wait = raceWithFrameError({
+		cleanup: () => {
+			cleanupCalls++;
+		},
+		frameError,
+		operation: () =>
+			operation.then(() => {
+				operationFinished = true;
+			}),
+	});
+	const error = new Error('Page crashed during frame callback');
+
+	rejectFrame(error);
+
+	await expect(wait).rejects.toBe(error);
+	expect(cleanupCalls).toBe(1);
+	expect(operationFinished).toBe(false);
+	releaseOperation();
+	await operation;
+	expect(operationFinished).toBe(true);
+	expect(cleanupCalls).toBe(1);
+});

--- a/packages/renderer/src/write-to-stitcher.ts
+++ b/packages/renderer/src/write-to-stitcher.ts
@@ -1,0 +1,53 @@
+import type {Writable} from 'node:stream';
+
+export const writeToStitcher = ({
+	buffer,
+	stdin,
+}: {
+	buffer: Buffer;
+	stdin: Writable;
+}): Promise<void> => {
+	if (stdin.destroyed || !stdin.writable) {
+		return Promise.reject(new Error('ERR_STREAM_PREMATURE_CLOSE'));
+	}
+
+	return new Promise<void>((resolve, reject) => {
+		let settled = false;
+
+		const cleanup = () => {
+			stdin.removeListener('drain', onDrain);
+			stdin.removeListener('error', onError);
+			stdin.removeListener('close', onClose);
+		};
+
+		const settle = (error?: unknown) => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			cleanup();
+			if (error) {
+				reject(error);
+			} else {
+				resolve();
+			}
+		};
+
+		const onDrain = () => settle();
+		const onError = (error: Error) => settle(error);
+		const onClose = () => settle(new Error('ERR_STREAM_PREMATURE_CLOSE'));
+
+		stdin.on('drain', onDrain);
+		stdin.on('error', onError);
+		stdin.on('close', onClose);
+
+		try {
+			if (stdin.write(buffer)) {
+				settle();
+			}
+		} catch (error) {
+			settle(error);
+		}
+	});
+};


### PR DESCRIPTION
Fixes #6041.

## Summary

- Await the prestitcher stream's `drain` event when `stdin.write()` applies
  backpressure, so frame rendering cannot outrun FFmpeg.
- Use the bounded streaming path for supported codecs even when the memory
  estimate is low, avoiding the temporary PNG/JPEG frame spool.
- Propagate stream, cancellation, and page errors while cleaning temporary
  listeners on every path.
- Add focused coverage for drain, close, async error, synchronous `EPIPE`,
  callback awaiting/rejection, and page-error races.

## Measurements

The strict production-path evaluator reduced pending frame plus Writable queue
bytes from `9,437,184` to `196,608` (`-97.9%`) while preserving exact frame order
and content hashes.

An eight-schedulable-CPU real-render follow-up produced:

| Profile | Temporary frames | Runtime | Full process-tree RSS |
| --- | ---: | ---: | ---: |
| 1080p, 600 frames | 72.1 MiB -> 0 B | 25.8 s -> 19.0 s | 1.30 GiB -> 2.07 GiB |
| 4K, 240 frames | 57.5 MiB -> 0 B | 34.1 s -> 23.8 s | 2.80 GiB -> 4.60 GiB |

Both profiles kept exact frame counts and durations, matching output sizes, and
matching elementary H.264 hashes. No child processes survived.

This fixes the unbounded disk spool and bounds the producer queue; it is not a
claim of lower process RSS. Running Chromium and FFmpeg concurrently increased
tree RSS by 59.7% at 1080p and 64.0% at 4K in this hardware-sensitive test.

Autoresearch with Weco explored the drain, error, and cancellation variants that
shaped this patch. The final diff was manually reduced and hardened against the
strict evaluator: https://dashboard.weco.ai/share/Ksvw4gVC2CZXsxBN8WbPPN5NUy9nxH06

## Validation

- Strict order/hash, bounded-queue, low-memory, cancellation, page-error,
  stream-error, close, `EPIPE`, and listener-cleanup gates pass.
- Seven focused helper and frame-error tests pass.
- Renderer ESLint, TypeScript build, `oxfmt --check`, and `git diff --check`
  pass.
- On latest main `f1a07cd164`, the full renderer suite reports 294 pass / 43
  fail for the candidate versus 287 pass / 43 fail for baseline. The normalized
  failure set is identical; the seven additional passes are the new tests.
