### PR TITLE
Docs: Recommend `@remotion/media` in more places

### DIFF
--- a/packages/docs/docs/miscellaneous/absolute-paths.mdx
+++ b/packages/docs/docs/miscellaneous/absolute-paths.mdx
@@ -75,7 +75,7 @@ npx serve --cors C://Users/Joe/Documents
 ```
 
 You will get a URL that you can use to access the folder via HTTP.  
-Pass URLs of assets to `<Img>`, `<Video>`, `<OffthreadVideo>`, `<Audio>`, `<Gif>`, `<Html5Video>`, `<Html5Audio>` tags to use them in Remotion.
+Pass URLs of assets to [`<Video>`](/docs/media/video), [`<Audio>`](/docs/media/audio), `<Img>`, `<Gif>`, `<OffthreadVideo>`, `<Html5Video>`, `<Html5Audio>` tags to use them in Remotion.
 
 If you need to spawn a server programmatically, use [`serve-handler`](https://www.npmjs.com/package/serve-handler).
 

--- a/packages/docs/docs/multiple-fps.mdx
+++ b/packages/docs/docs/multiple-fps.mdx
@@ -106,7 +106,7 @@ export const Root: React.FC = () => {
 ## FPS Convert is discouraged
 
 Previously, this page showed a FPS converter snippet.  
-It's usage is not recommended because it does not work with media tags (`<Html5Video>`, `<Audio>`, `<OffthreadVideo>`, etc.).
+It's usage is not recommended because it does not work with media tags ([`<Video>`](/docs/media/video), [`<Audio>`](/docs/media/audio), `<OffthreadVideo>`, `<Html5Video>`, etc.).
 
 ## See also
 

--- a/packages/docs/docs/non-seekable-media.mdx
+++ b/packages/docs/docs/non-seekable-media.mdx
@@ -80,7 +80,7 @@ Consider one of these solutions:
 
 - Serve the media from a webhost that supports the `Range` header and returns a `Content-Length` and `Content-Range` header.
 - Download the media and import it locally using an `import` or `require()` statement.
-- Use the [`<OffthreadVideo>`](/docs/offthreadvideo) component which will render the video fine. You may still see problems during playback in the Remotion Studio or the [`<Player>`](/docs/player).
+- Use the [`<Video>`](/docs/media/video) component from `@remotion/media`, which will render the video fine. You may still see problems during playback in the Remotion Studio or the [`<Player>`](/docs/player).
 
 ## See also
 

--- a/packages/docs/docs/performance.mdx
+++ b/packages/docs/docs/performance.mdx
@@ -10,6 +10,14 @@ Video rendering is one of the most heavy workloads a computer can take on. Remot
 
 Your experience is also dependent on your code and the hardware you run it on. Review the following performance insights to find opportunities for speeding up your render.
 
+## Videos
+
+Use [`<Video>`](/docs/media/video) from `@remotion/media` for the best video rendering performance.
+
+Both [`<Html5Video>`](/docs/html5-video) (formerly just called `<Video>`, from the `remotion` package) and [`<OffthreadVideo>`](/docs/offthreadvideo) are not optimized. Consider migrating if you are still using one of the old video tags.
+
+See: [Comparison of video tags](/docs/video-tags)
+
 ## Concurrency
 
 The `--concurrency` flag you set can influence the rendering speed both positively and negatively. A concurrency too high and a concurrency too low can both be coutnerproductive. Use the [`npx remotion benchmark`](/docs/cli/benchmark) command to find the optimal concurrency.
@@ -27,14 +35,6 @@ Compute instances in the cloud do not have a GPU and may take a long time to ren
 Consider replacing those effects with a precomputed image for the best performance.
 
 Read the [considerations about using the GPU](/docs/gpu).
-
-## Videos
-
-Both [`<Html5Video>`](/docs/html5-video) (formerly just called `<Video>`, from the `remotion` package) and [`<OffthreadVideo>`](/docs/offthreadvideo) are not optimized.
-
-We made a new [`<Video>`](/docs/media/video) tag that has the optimal performance. Consider using it if you are still using one of the old video tags.
-
-See: [Comparison of video tags](/docs/video-tags)
 
 ## Slow JavaScript code
 

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -635,7 +635,6 @@ const sidebars: SidebarsConfig = {
 				'renderer/make-cancel-signal',
 				'renderer/ensure-ffmpeg',
 				'renderer/ensure-ffprobe',
-				'renderer/get-can-extract-frames-fast',
 				'renderer/get-video-metadata',
 				'renderer/get-silent-parts',
 				'renderer/combine-chunks',


### PR DESCRIPTION
## Summary

- remove the removed `getCanExtractFramesFast()` renderer page from the docs sidebar
- move the `/docs/performance` video guidance near the top and make `<Video>` from `@remotion/media` the first recommendation
- recommend `<Video>` from `@remotion/media` on `/docs/non-seekable-media`
- list `<Video>` and `<Audio>` before older tags on `/docs/multiple-fps`
- link `<Video>` and `<Audio>` first on `/docs/miscellaneous/absolute-paths`

Part of #8882

## Testing

- `bun run build`
- `bunx turbo run lint formatting --filter=docs --no-update-notifier`
- `bunx turbo run make --filter=docs --no-update-notifier`
- `cd packages/docs && bun run build-docs`

Note: `bun run stylecheck` was attempted, but this local environment is missing PHP `ext-iconv`, causing `@remotion/lambda-php#lint` to fail before the full monorepo stylecheck could finish.



