### PR TITLE
`@remotion/studio`: Request element install targets on demand

### DIFF
--- a/packages/studio-server/src/preview-server/element-install-state.ts
+++ b/packages/studio-server/src/preview-server/element-install-state.ts
@@ -33,7 +33,7 @@ export const updateElementInstallTarget = (
 	});
 };
 
-export const getElementInstallTarget = (requestId?: string) => {
+export const getElementInstallTarget = (requestId: string | null) => {
 	const now = Date.now();
 	let bestTarget: ElementInstallTarget | null = null;
 
@@ -43,7 +43,7 @@ export const getElementInstallTarget = (requestId?: string) => {
 			continue;
 		}
 
-		if (requestId !== undefined && currentTarget.requestId !== requestId) {
+		if (requestId !== null && currentTarget.requestId !== requestId) {
 			continue;
 		}
 

--- a/packages/studio-server/src/preview-server/element-install-state.ts
+++ b/packages/studio-server/src/preview-server/element-install-state.ts
@@ -1,6 +1,7 @@
-export const ELEMENT_INSTALL_TARGET_MAX_AGE = 5 * 60 * 1000;
+export const ELEMENT_INSTALL_TARGET_MAX_AGE = 5000;
 
 export type ElementInstallTarget = {
+	requestId: string | null;
 	clientId: string;
 	compositionFile: string | null;
 	compositionId: string | null;
@@ -32,13 +33,17 @@ export const updateElementInstallTarget = (
 	});
 };
 
-export const getElementInstallTarget = () => {
+export const getElementInstallTarget = (requestId?: string) => {
 	const now = Date.now();
 	let bestTarget: ElementInstallTarget | null = null;
 
 	for (const [clientId, currentTarget] of targetsByClientId) {
 		if (now - currentTarget.updatedAt >= ELEMENT_INSTALL_TARGET_MAX_AGE) {
 			targetsByClientId.delete(clientId);
+			continue;
+		}
+
+		if (requestId !== undefined && currentTarget.requestId !== requestId) {
 			continue;
 		}
 

--- a/packages/studio-server/src/preview-server/element-install-state.ts
+++ b/packages/studio-server/src/preview-server/element-install-state.ts
@@ -1,4 +1,4 @@
-export const ELEMENT_INSTALL_TARGET_MAX_AGE = 5000;
+export const ELEMENT_INSTALL_TARGET_MAX_AGE = 5 * 60 * 1000;
 
 export type ElementInstallTarget = {
 	clientId: string;

--- a/packages/studio-server/src/preview-server/routes/update-element-install-target.ts
+++ b/packages/studio-server/src/preview-server/routes/update-element-install-target.ts
@@ -17,6 +17,10 @@ export const updateElementInstallTargetHandler: ApiHandler<
 		throw new Error('Invalid client ID');
 	}
 
+	if (input.requestId !== null && typeof input.requestId !== 'string') {
+		throw new Error('Invalid request ID');
+	}
+
 	if (!isFiniteTimestamp(input.lastFocusedAt)) {
 		throw new Error('Invalid focus timestamp');
 	}

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -37,6 +37,7 @@ import {reloadPreviouslySuppressedFiles} from './preview-server/watch-ignore-nex
 import type {RemotionConfigResponse} from './remotion-config-response';
 const loggedStaticFileHints = new Set<string>();
 const ELEMENT_INSTALL_FOCUS_MAX_AGE = 5 * 60 * 1000;
+const ELEMENT_INSTALL_TARGET_RESPONSE_WAIT = 250;
 
 const static404 = (response: ServerResponse): Promise<void> => {
 	response.writeHead(404);
@@ -123,11 +124,13 @@ const handleElementInstallOptions = ({
 };
 
 const handleElementInstallTarget = ({
+	liveEventsServer,
 	request,
 	response,
 	remotionRoot,
 	gitSource,
 }: {
+	liveEventsServer: LiveEventsServer;
 	request: IncomingMessage;
 	response: ServerResponse;
 	remotionRoot: string;
@@ -141,30 +144,42 @@ const handleElementInstallTarget = ({
 		return Promise.resolve();
 	}
 
-	const target = getElementInstallTarget();
-	const now = Date.now();
-	const targetIsLive =
-		target !== null && now - target.updatedAt < ELEMENT_INSTALL_TARGET_MAX_AGE;
-	const host = request.headers.host ?? null;
-	const port = host?.split(':').at(-1) ?? null;
-	setElementInstallCorsHeaders({request, response});
-	response.writeHead(200, {'Content-Type': 'application/json'});
-	response.end(
-		JSON.stringify({
-			type: 'remotion-studio',
-			projectName: getProjectName({
-				basename: path.basename,
-				gitSource,
-				resolvedRemotionRoot: remotionRoot,
-			}),
-			port: port === null ? null : Number(port),
-			lastFocusedAt: target?.lastFocusedAt ?? null,
-			canInstall: target !== null && target.canInstall && targetIsLive,
-			activeCompositionId: target?.compositionId ?? null,
-			readOnly: target?.readOnly ?? false,
-		}),
-	);
-	return Promise.resolve();
+	const requestId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+	liveEventsServer.sendEventToClient({
+		type: 'request-element-install-target',
+		requestId,
+	});
+
+	return new Promise<void>((resolve) => {
+		setTimeout(() => {
+			const target = getElementInstallTarget(requestId);
+			const now = Date.now();
+			const targetIsLive =
+				target !== null &&
+				now - target.updatedAt < ELEMENT_INSTALL_TARGET_MAX_AGE;
+			const host = request.headers.host ?? null;
+			const port = host?.split(':').at(-1) ?? null;
+			setElementInstallCorsHeaders({request, response});
+			response.writeHead(200, {'Content-Type': 'application/json'});
+			response.end(
+				JSON.stringify({
+					type: 'remotion-studio',
+					projectName: getProjectName({
+						basename: path.basename,
+						gitSource,
+						resolvedRemotionRoot: remotionRoot,
+					}),
+					port: port === null ? null : Number(port),
+					lastFocusedAt: target?.lastFocusedAt ?? null,
+					canInstall: target !== null && target.canInstall && targetIsLive,
+					activeCompositionId: target?.compositionId ?? null,
+					readOnly: target?.readOnly ?? false,
+				}),
+			);
+			resolve();
+		}, ELEMENT_INSTALL_TARGET_RESPONSE_WAIT);
+	});
 };
 
 const handleRequestElementInstall = async ({
@@ -635,6 +650,7 @@ export const handleRoutes = ({
 
 		if (url.pathname === '/api/element-install-target') {
 			return handleElementInstallTarget({
+				liveEventsServer,
 				request,
 				response,
 				remotionRoot,

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -220,7 +220,7 @@ const handleRequestElementInstall = async ({
 			return;
 		}
 
-		const target = getElementInstallTarget();
+		const target = getElementInstallTarget(null);
 		const now = Date.now();
 		const targetIsLive =
 			target !== null &&

--- a/packages/studio-server/src/test/element-install-state.test.ts
+++ b/packages/studio-server/src/test/element-install-state.test.ts
@@ -36,7 +36,7 @@ test('uses the most recently focused Studio target even when older tabs keep upd
 		readOnly: false,
 	});
 
-	expect(getElementInstallTarget()?.clientId).toBe('focused-tab');
+	expect(getElementInstallTarget(null)?.clientId).toBe('focused-tab');
 });
 
 test('falls back to update recency when focus timestamps match', async () => {
@@ -64,7 +64,7 @@ test('falls back to update recency when focus timestamps match', async () => {
 		readOnly: false,
 	});
 
-	expect(getElementInstallTarget()?.clientId).toBe('second-tab');
+	expect(getElementInstallTarget(null)?.clientId).toBe('second-tab');
 });
 
 test('can select a target for a specific request', () => {

--- a/packages/studio-server/src/test/element-install-state.test.ts
+++ b/packages/studio-server/src/test/element-install-state.test.ts
@@ -9,6 +9,7 @@ test('uses the most recently focused Studio target even when older tabs keep upd
 	clearElementInstallStateForTests();
 
 	updateElementInstallTarget({
+		requestId: null,
 		clientId: 'older-tab',
 		compositionFile: '/project/src/older.tsx',
 		compositionId: 'older-composition',
@@ -17,6 +18,7 @@ test('uses the most recently focused Studio target even when older tabs keep upd
 		readOnly: false,
 	});
 	updateElementInstallTarget({
+		requestId: null,
 		clientId: 'focused-tab',
 		compositionFile: '/project/src/focused.tsx',
 		compositionId: 'focused-composition',
@@ -25,6 +27,7 @@ test('uses the most recently focused Studio target even when older tabs keep upd
 		readOnly: false,
 	});
 	updateElementInstallTarget({
+		requestId: null,
 		clientId: 'older-tab',
 		compositionFile: '/project/src/older.tsx',
 		compositionId: 'older-composition',
@@ -40,6 +43,7 @@ test('falls back to update recency when focus timestamps match', async () => {
 	clearElementInstallStateForTests();
 
 	updateElementInstallTarget({
+		requestId: null,
 		clientId: 'first-tab',
 		compositionFile: '/project/src/first.tsx',
 		compositionId: 'first-composition',
@@ -51,6 +55,7 @@ test('falls back to update recency when focus timestamps match', async () => {
 	await new Promise((resolve) => setTimeout(resolve, 2));
 
 	updateElementInstallTarget({
+		requestId: null,
 		clientId: 'second-tab',
 		compositionFile: '/project/src/second.tsx',
 		compositionId: 'second-composition',
@@ -60,4 +65,32 @@ test('falls back to update recency when focus timestamps match', async () => {
 	});
 
 	expect(getElementInstallTarget()?.clientId).toBe('second-tab');
+});
+
+test('can select a target for a specific request', () => {
+	clearElementInstallStateForTests();
+
+	updateElementInstallTarget({
+		requestId: 'first-request',
+		clientId: 'first-tab',
+		compositionFile: '/project/src/first.tsx',
+		compositionId: 'first-composition',
+		canInstall: true,
+		lastFocusedAt: 1000,
+		readOnly: false,
+	});
+	updateElementInstallTarget({
+		requestId: 'second-request',
+		clientId: 'second-tab',
+		compositionFile: '/project/src/second.tsx',
+		compositionId: 'second-composition',
+		canInstall: true,
+		lastFocusedAt: 2000,
+		readOnly: false,
+	});
+
+	expect(getElementInstallTarget('first-request')?.clientId).toBe('first-tab');
+	expect(getElementInstallTarget('second-request')?.clientId).toBe(
+		'second-tab',
+	);
 });

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -768,6 +768,7 @@ export type ElementInstallRequest = {
 };
 
 export type UpdateElementInstallTargetRequest = {
+	requestId: string | null;
 	clientId: string;
 	compositionFile: string | null;
 	compositionId: string | null;

--- a/packages/studio-shared/src/event-source-event.ts
+++ b/packages/studio-shared/src/event-source-event.ts
@@ -77,6 +77,10 @@ export type EventSourceEvent =
 			redoFile: string | null;
 	  }
 	| {
+			type: 'request-element-install-target';
+			requestId: string;
+	  }
+	| {
 			type: 'element-install-request';
 			request: ElementInstallRequest;
 	  }

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -12,7 +12,6 @@ import {
 	type ComponentDragData,
 	type CompositionDragData,
 	type ElementInstallRequest,
-	type UpdateElementInstallTargetRequest,
 } from '@remotion/studio-shared';
 import React, {
 	useCallback,
@@ -78,21 +77,6 @@ const elementInstallCompositionIdStyle: React.CSSProperties = {
 const elementInstallCodeDetailsStyle: React.CSSProperties = {
 	marginTop: 12,
 	fontSize: 13,
-};
-
-const areElementInstallTargetsEqual = (
-	a: UpdateElementInstallTargetRequest | null,
-	b: UpdateElementInstallTargetRequest,
-) => {
-	return (
-		a !== null &&
-		a.clientId === b.clientId &&
-		a.compositionFile === b.compositionFile &&
-		a.compositionId === b.compositionId &&
-		a.canInstall === b.canInstall &&
-		a.lastFocusedAt === b.lastFocusedAt &&
-		a.readOnly === b.readOnly
-	);
 };
 
 const elementInstallCodeSummaryStyle: React.CSSProperties = {
@@ -343,8 +327,6 @@ export const Canvas: React.FC<{
 	const lastFocusedAtRef = useRef<number | null>(
 		typeof document === 'undefined' || document.hasFocus() ? Date.now() : null,
 	);
-	const lastSentElementInstallTargetRef =
-		useRef<UpdateElementInstallTargetRequest | null>(null);
 
 	const [assetResolution, setAssetResolution] = useState<AssetMetadata | null>(
 		null,
@@ -829,49 +811,33 @@ export const Canvas: React.FC<{
 		fetchMetadata();
 	}, [fetchMetadata]);
 
-	const updateElementInstallTarget = useCallback(() => {
-		if (previewServerClientId === null) {
-			lastSentElementInstallTargetRef.current = null;
-			return;
-		}
+	const updateElementInstallTarget = useCallback(
+		(requestId: string) => {
+			if (previewServerClientId === null) {
+				return;
+			}
 
-		const target: UpdateElementInstallTargetRequest = {
-			clientId: previewServerClientId,
-			compositionFile: canInstallElements ? compositionFile : null,
-			compositionId: canInstallElements ? currentCompositionId : null,
-			canInstall: canInstallElements,
-			lastFocusedAt: lastFocusedAtRef.current,
-			readOnly: window.remotion_isReadOnlyStudio,
-		};
-
-		if (
-			areElementInstallTargetsEqual(
-				lastSentElementInstallTargetRef.current,
-				target,
-			)
-		) {
-			return;
-		}
-
-		lastSentElementInstallTargetRef.current = target;
-		callApi('/api/update-element-install-target', target).catch(() => {
-			lastSentElementInstallTargetRef.current = null;
-		});
-	}, [
-		canInstallElements,
-		compositionFile,
-		currentCompositionId,
-		previewServerClientId,
-	]);
-
-	useEffect(() => {
-		updateElementInstallTarget();
-	}, [updateElementInstallTarget]);
+			callApi('/api/update-element-install-target', {
+				requestId,
+				clientId: previewServerClientId,
+				compositionFile: canInstallElements ? compositionFile : null,
+				compositionId: canInstallElements ? currentCompositionId : null,
+				canInstall: canInstallElements,
+				lastFocusedAt: lastFocusedAtRef.current,
+				readOnly: window.remotion_isReadOnlyStudio,
+			}).catch(() => undefined);
+		},
+		[
+			canInstallElements,
+			compositionFile,
+			currentCompositionId,
+			previewServerClientId,
+		],
+	);
 
 	useEffect(() => {
 		const markFocused = () => {
 			lastFocusedAtRef.current = Date.now();
-			updateElementInstallTarget();
 		};
 
 		window.addEventListener('focus', markFocused);
@@ -881,7 +847,17 @@ export const Canvas: React.FC<{
 			window.removeEventListener('focus', markFocused);
 			document.removeEventListener('pointerdown', markFocused, {capture: true});
 		};
-	}, [updateElementInstallTarget]);
+	}, []);
+
+	useEffect(() => {
+		return subscribeToEvent('request-element-install-target', (event) => {
+			if (event.type !== 'request-element-install-target') {
+				return;
+			}
+
+			updateElementInstallTarget(event.requestId);
+		});
+	}, [subscribeToEvent, updateElementInstallTarget]);
 
 	useEffect(() => {
 		if (installingElementName === null) {

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -12,6 +12,7 @@ import {
 	type ComponentDragData,
 	type CompositionDragData,
 	type ElementInstallRequest,
+	type UpdateElementInstallTargetRequest,
 } from '@remotion/studio-shared';
 import React, {
 	useCallback,
@@ -77,6 +78,21 @@ const elementInstallCompositionIdStyle: React.CSSProperties = {
 const elementInstallCodeDetailsStyle: React.CSSProperties = {
 	marginTop: 12,
 	fontSize: 13,
+};
+
+const areElementInstallTargetsEqual = (
+	a: UpdateElementInstallTargetRequest | null,
+	b: UpdateElementInstallTargetRequest,
+) => {
+	return (
+		a !== null &&
+		a.clientId === b.clientId &&
+		a.compositionFile === b.compositionFile &&
+		a.compositionId === b.compositionId &&
+		a.canInstall === b.canInstall &&
+		a.lastFocusedAt === b.lastFocusedAt &&
+		a.readOnly === b.readOnly
+	);
 };
 
 const elementInstallCodeSummaryStyle: React.CSSProperties = {
@@ -327,6 +343,8 @@ export const Canvas: React.FC<{
 	const lastFocusedAtRef = useRef<number | null>(
 		typeof document === 'undefined' || document.hasFocus() ? Date.now() : null,
 	);
+	const lastSentElementInstallTargetRef =
+		useRef<UpdateElementInstallTargetRequest | null>(null);
 
 	const [assetResolution, setAssetResolution] = useState<AssetMetadata | null>(
 		null,
@@ -813,17 +831,32 @@ export const Canvas: React.FC<{
 
 	const updateElementInstallTarget = useCallback(() => {
 		if (previewServerClientId === null) {
+			lastSentElementInstallTargetRef.current = null;
 			return;
 		}
 
-		callApi('/api/update-element-install-target', {
+		const target: UpdateElementInstallTargetRequest = {
 			clientId: previewServerClientId,
 			compositionFile: canInstallElements ? compositionFile : null,
 			compositionId: canInstallElements ? currentCompositionId : null,
 			canInstall: canInstallElements,
 			lastFocusedAt: lastFocusedAtRef.current,
 			readOnly: window.remotion_isReadOnlyStudio,
-		}).catch(() => undefined);
+		};
+
+		if (
+			areElementInstallTargetsEqual(
+				lastSentElementInstallTargetRef.current,
+				target,
+			)
+		) {
+			return;
+		}
+
+		lastSentElementInstallTargetRef.current = target;
+		callApi('/api/update-element-install-target', target).catch(() => {
+			lastSentElementInstallTargetRef.current = null;
+		});
 	}, [
 		canInstallElements,
 		compositionFile,
@@ -833,11 +866,6 @@ export const Canvas: React.FC<{
 
 	useEffect(() => {
 		updateElementInstallTarget();
-		const interval = window.setInterval(updateElementInstallTarget, 2000);
-
-		return () => {
-			window.clearInterval(interval);
-		};
 	}, [updateElementInstallTarget]);
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary

- Stop polling `/api/update-element-install-target` from Studio
- Let `/api/element-install-target` request the current target from connected Studio clients over EventSource
- Have Studio clients POST the target only in response to that request
- Keep target replies request-scoped so concurrent probes do not reuse stale target data

## Testing

- `bun test packages/studio-server/src/test/element-install-state.test.ts`
- `bun run --cwd packages/studio-shared make`
- `bun run --cwd packages/studio-server make`
- `bun run --cwd packages/studio make`
- `bun run build`
- `bun run stylecheck`
- `bun run --cwd packages/studio formatting`
- `bun run --cwd packages/studio make`

Closes #9023
