### PR TITLE
`@remotion/player`: Fix mute crash with mounted Html5Audio

### DIFF
--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -1,7 +1,7 @@
 // Contexts shared between <Player> and <Thumbnail>
 
 import type {ComponentType, LazyExoticComponent} from 'react';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import type {
 	CompositionManagerContext,
 	LoggingContextValue,
@@ -115,8 +115,15 @@ export const SharedPlayerContexts: React.FC<{
 		};
 	}, [playerMuted, mediaVolume]);
 
-	const shouldCreateAudioContext =
-		audioEnabled && !playerMuted && mediaVolume > 0;
+	const [shouldCreateAudioContext, setShouldCreateAudioContext] = useState(
+		() => audioEnabled && !playerMuted && mediaVolume > 0,
+	);
+
+	useEffect(() => {
+		if (audioEnabled && !playerMuted && mediaVolume > 0) {
+			setShouldCreateAudioContext(true);
+		}
+	}, [audioEnabled, mediaVolume, playerMuted]);
 
 	const setMediaVolumeAndPersist = useCallback(
 		(vol: number) => {

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -1,7 +1,7 @@
 // Contexts shared between <Player> and <Thumbnail>
 
 import type {ComponentType, LazyExoticComponent} from 'react';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 import type {
 	CompositionManagerContext,
 	LoggingContextValue,
@@ -115,15 +115,11 @@ export const SharedPlayerContexts: React.FC<{
 		};
 	}, [playerMuted, mediaVolume]);
 
-	const [shouldCreateAudioContext, setShouldCreateAudioContext] = useState(
-		() => audioEnabled && !playerMuted && mediaVolume > 0,
-	);
-
-	useEffect(() => {
-		if (audioEnabled && !playerMuted && mediaVolume > 0) {
-			setShouldCreateAudioContext(true);
-		}
-	}, [audioEnabled, mediaVolume, playerMuted]);
+	const audioContextWasCreated = useRef(false);
+	const shouldCreateAudioContext =
+		audioContextWasCreated.current ||
+		(audioEnabled && !playerMuted && mediaVolume > 0);
+	audioContextWasCreated.current = shouldCreateAudioContext;
 
 	const setMediaVolumeAndPersist = useCallback(
 		(vol: number) => {

--- a/packages/player/src/test/index.test.ts
+++ b/packages/player/src/test/index.test.ts
@@ -1,8 +1,127 @@
-import {expect, test} from 'bun:test';
+import {afterEach, expect, test} from 'bun:test';
+import React, {useRef} from 'react';
+import {Html5Audio, Internals} from 'remotion';
+import type {PlayerRef} from '../player-methods.js';
+import {Player} from '../Player.js';
 import {usePlayer} from '../use-player.js';
+import {act, cleanup, render} from './test-utils.js';
+
+afterEach(() => {
+	cleanup();
+});
 
 test('It should throw an error if not being used inside a RemotionRoot', () => {
 	expect(() => {
 		usePlayer();
 	}).toThrow();
+});
+
+class MockAudioContext {
+	public state = 'suspended' as AudioContextState;
+	public baseLatency = 0;
+	public outputLatency = 0;
+	public currentTime = 0;
+	public destination = {};
+
+	addEventListener() {
+		return undefined;
+	}
+
+	removeEventListener() {
+		return undefined;
+	}
+
+	createGain() {
+		return {
+			connect: () => undefined,
+			gain: {
+				cancelScheduledValues: () => undefined,
+				linearRampToValueAtTime: () => undefined,
+				setValueAtTime: () => undefined,
+			},
+		};
+	}
+
+	suspend() {
+		this.state = 'suspended';
+		return Promise.resolve();
+	}
+
+	resume() {
+		this.state = 'running';
+		return Promise.resolve();
+	}
+
+	createMediaElementSource() {
+		return {
+			connect: () => undefined,
+			disconnect: () => undefined,
+		};
+	}
+}
+
+const AudioComposition = () => {
+	return React.createElement(
+		Internals.SequenceManager.Provider,
+		{
+			value: {
+				registerSequence: () => undefined,
+				unregisterSequence: () => undefined,
+				sequences: [],
+			},
+		},
+		React.createElement(Html5Audio, {src: 'audio.mp3'}),
+	);
+};
+
+const PlayerWithMuteButton = ({
+	onError,
+}: {
+	readonly onError: (error: Error) => void;
+}) => {
+	const playerRef = useRef<PlayerRef>(null);
+
+	return React.createElement(
+		React.Fragment,
+		null,
+		React.createElement(Player, {
+			ref: playerRef,
+			component: AudioComposition,
+			durationInFrames: 300,
+			compositionWidth: 1920,
+			compositionHeight: 1080,
+			fps: 30,
+			errorFallback: ({error}) => {
+				onError(error);
+				return null;
+			},
+		}),
+		React.createElement(
+			'button',
+			{type: 'button', onClick: () => playerRef.current?.mute()},
+			'Mute',
+		),
+	);
+};
+
+test('It does not crash when muting a Player with a mounted Html5Audio tag', () => {
+	const originalAudioContext = globalThis.AudioContext;
+	globalThis.AudioContext = MockAudioContext as unknown as typeof AudioContext;
+	const errors: Error[] = [];
+
+	try {
+		const {getByText} = render(
+			React.createElement(PlayerWithMuteButton, {
+				onError: (error) => errors.push(error),
+			}),
+		);
+
+		act(() => {
+			getByText('Mute').click();
+		});
+
+		expect(errors).toEqual([]);
+	} finally {
+		globalThis.AudioContext = originalAudioContext;
+	}
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

Fixes #9032.

## Summary
- Keep the Player AudioContext enabled after it has been created once, so muting or setting volume to zero does not recreate shared audio tags for mounted `<Html5Audio>` elements.
- Preserve the existing optimization that initially muted or zero-volume players do not create an AudioContext until they become audible.
- Avoid adding a `useEffect`; the AudioContext-enabled flag is derived synchronously and remembered once it becomes true.
- Add a regression test that mounts a Player with `<Html5Audio>` and calls `mute()` through the Player ref.

## Testing
- `bun test src/test/index.test.ts` from `packages/player`
- `bun run test` from `packages/player`
- `bun run lint` from `packages/player`
- `bun run formatting` from `packages/player`
- `bun run build` from repo root
- `bun run stylecheck` from repo root

## Tradeoffs
- The AudioContext is kept alive after a Player has been audible once, which avoids invalidating the shared audio tag pool during dynamic mute/volume changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5697-c78c-7d8e-b164-6155dda7449a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5697-c78c-7d8e-b164-6155dda7449a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

