### PR TITLE
`@remotion/renderer`: Make calculateAssetPositions() faster 

### DIFF
--- a/packages/renderer/src/assets/calculate-asset-positions.ts
+++ b/packages/renderer/src/assets/calculate-asset-positions.ts
@@ -5,28 +5,16 @@ import {convertAssetToFlattenedVolume} from './flatten-volume-array';
 import type {Assets, MediaAsset, UnsafeAsset} from './types';
 import {uncompressMediaAsset} from './types';
 
-const areEqual = (a: TRenderAsset | UnsafeAsset, b: TRenderAsset) => {
-	return a.id === b.id;
-};
-
-const findFrom = (target: TRenderAsset[], renderAsset: TRenderAsset) => {
-	const index = target.findIndex((a) => areEqual(a, renderAsset));
-	if (index === -1) {
-		return false;
-	}
-
-	target.splice(index, 1);
-	return true;
-};
-
-const copyAndDeduplicateAssets = (
+const deduplicateAssets = (
 	renderAssets: TRenderAsset[],
 ): AudioOrVideoAsset[] => {
 	const onlyAudioAndVideo = onlyAudioAndVideoAssets(renderAssets);
+	const seenIds = new Set<string>();
 	const deduplicated: AudioOrVideoAsset[] = [];
 
 	for (const renderAsset of onlyAudioAndVideo) {
-		if (!deduplicated.find((d) => d.id === renderAsset.id)) {
+		if (!seenIds.has(renderAsset.id)) {
+			seenIds.add(renderAsset.id);
 			deduplicated.push(renderAsset);
 		}
 	}
@@ -34,21 +22,72 @@ const copyAndDeduplicateAssets = (
 	return deduplicated;
 };
 
+const indexUncompressedAssets = (renderAssets: AudioOrVideoAsset[]) => {
+	const referencedAssets = new Set<string>();
+	for (const renderAsset of renderAssets) {
+		if (renderAsset.src.startsWith('same-as')) {
+			referencedAssets.add(renderAsset.src);
+		}
+	}
+
+	const assetsByReference = new Map<string, AudioOrVideoAsset>();
+
+	for (const renderAsset of renderAssets) {
+		if (referencedAssets.size === 0) {
+			break;
+		}
+
+		if (renderAsset.src.startsWith('same-as')) {
+			continue;
+		}
+
+		const reference = `same-as-${renderAsset.id}-${renderAsset.frame}`;
+		if (referencedAssets.has(reference)) {
+			assetsByReference.set(reference, renderAsset);
+			referencedAssets.delete(reference);
+		}
+	}
+
+	return assetsByReference;
+};
+
 export const calculateAssetPositions = (
 	frames: AudioOrVideoAsset[][],
 ): Assets => {
 	const assets: UnsafeAsset[] = [];
+	// Assets that have started but not yet ended, keyed by asset id.
+	// Since assets are deduplicated by id within a frame, at most one
+	// asset per id is open at a time.
+	const openAssets = new Map<string, UnsafeAsset>();
 
 	const flattened = frames.flat(1);
+	const uncompressedAssets = indexUncompressedAssets(flattened);
 	for (let frame = 0; frame < frames.length; frame++) {
-		const prev = copyAndDeduplicateAssets(frames[frame - 1] ?? []);
-		const current = copyAndDeduplicateAssets(frames[frame]);
-		const next = copyAndDeduplicateAssets(frames[frame + 1] ?? []);
+		const current = deduplicateAssets(frames[frame]);
+		const currentIds = new Set(current.map((a) => a.id));
+
+		for (const [id, openAsset] of openAssets) {
+			if (!currentIds.has(id)) {
+				// The asset was last present on the previous frame.
+				// Duration calculation:
+				// start 0, present for frames 0-59, gone at frame 60:
+				// 60 - 0 ==> 60 frames duration
+				openAsset.duration = frame - openAsset.startInVideo;
+				openAssets.delete(id);
+			}
+		}
 
 		for (const asset of current) {
-			if (!findFrom(prev, asset)) {
-				assets.push({
-					src: resolveAssetSrc(uncompressMediaAsset(flattened, asset).src),
+			let openAsset = openAssets.get(asset.id);
+			if (openAsset === undefined) {
+				const uncompressedAsset = uncompressedAssets.get(asset.src);
+				openAsset = {
+					src: resolveAssetSrc(
+						uncompressMediaAsset(
+							uncompressedAsset ? [uncompressedAsset] : flattened,
+							asset,
+						).src,
+					),
 					type: asset.type,
 					duration: null,
 					id: asset.id,
@@ -59,22 +98,18 @@ export const calculateAssetPositions = (
 					toneFrequency: asset.toneFrequency,
 					audioStartFrame: asset.audioStartFrame,
 					audioStreamIndex: asset.audioStreamIndex,
-				});
+				};
+				assets.push(openAsset);
+				openAssets.set(asset.id, openAsset);
 			}
 
-			const found = assets.find(
-				(a) => a.duration === null && areEqual(a, asset),
-			);
-			if (!found) throw new Error('something wrong');
-			if (!findFrom(next, asset)) {
-				// Duration calculation:
-				// start 0, range 0-59:
-				// 59 - 0 + 1 ==> 60 frames duration
-				found.duration = frame - found.startInVideo + 1;
-			}
-
-			found.volume.push(asset.volume);
+			openAsset.volume.push(asset.volume);
 		}
+	}
+
+	// Assets that lasted until the end of the video.
+	for (const openAsset of openAssets.values()) {
+		openAsset.duration = frames.length - openAsset.startInVideo;
 	}
 
 	for (const asset of assets) {

--- a/packages/renderer/src/test/calculate-asset-positions.test.ts
+++ b/packages/renderer/src/test/calculate-asset-positions.test.ts
@@ -1,0 +1,212 @@
+import {expect, test} from 'bun:test';
+import type {AudioOrVideoAsset} from 'remotion/no-react';
+import {calculateAssetPositions} from '../assets/calculate-asset-positions';
+import {compressAsset} from '../compress-assets';
+
+const makeAsset = ({
+	id,
+	frame,
+	src,
+	volume = 1,
+	mediaFrame,
+}: {
+	id: string;
+	frame: number;
+	src: string;
+	volume?: number;
+	mediaFrame?: number;
+}): AudioOrVideoAsset => {
+	return {
+		type: 'audio' as const,
+		src,
+		id,
+		frame,
+		volume,
+		playbackRate: 1,
+		mediaFrame: mediaFrame ?? frame,
+		toneFrequency: 1,
+		audioStartFrame: 0,
+		audioStreamIndex: 0,
+	};
+};
+
+test('An asset that re-appears after a gap gets two positions', () => {
+	const frames = new Array(8).fill(true).map((_, frame) => {
+		const inFirstRange = frame < 3;
+		const inSecondRange = frame >= 5;
+		if (!inFirstRange && !inSecondRange) {
+			return [];
+		}
+
+		return [
+			makeAsset({
+				id: 'audio-1',
+				frame,
+				src: 'http://localhost:3000/music.mp3',
+				volume: frame,
+			}),
+		];
+	});
+
+	const positions = calculateAssetPositions(frames);
+
+	expect(positions).toEqual([
+		{
+			src: 'http://localhost:3000/music.mp3',
+			type: 'audio',
+			duration: 3,
+			id: 'audio-1',
+			startInVideo: 0,
+			trimLeft: 0,
+			volume: [0, 1, 2],
+			playbackRate: 1,
+			toneFrequency: 1,
+			audioStartFrame: 0,
+			audioStreamIndex: 0,
+		},
+		{
+			src: 'http://localhost:3000/music.mp3',
+			type: 'audio',
+			duration: 3,
+			id: 'audio-1',
+			startInVideo: 5,
+			trimLeft: 5,
+			volume: [5, 6, 7],
+			playbackRate: 1,
+			toneFrequency: 1,
+			audioStartFrame: 0,
+			audioStreamIndex: 0,
+		},
+	]);
+});
+
+test('A compressed asset resolves its src from the first occurrence', () => {
+	const longSrc = `data:audio/mp3;base64,${'A'.repeat(500)}`;
+
+	const frames = [
+		[makeAsset({id: 'audio-a', frame: 0, src: longSrc})],
+		[makeAsset({id: 'audio-a', frame: 1, src: 'same-as-audio-a-0'})],
+		[
+			makeAsset({id: 'audio-a', frame: 2, src: 'same-as-audio-a-0'}),
+			// A different tag playing the same media gets compressed
+			// cross-asset by `compressAsset()`
+			makeAsset({id: 'audio-b', frame: 2, src: 'same-as-audio-a-0'}),
+		],
+	];
+
+	const positions = calculateAssetPositions(frames);
+
+	expect(positions.length).toBe(2);
+	expect(positions[0].id).toBe('audio-a');
+	expect(positions[0].src).toBe(longSrc);
+	expect(positions[1].id).toBe('audio-b');
+	expect(positions[1].src).toBe(longSrc);
+	expect(positions[1].startInVideo).toBe(2);
+});
+
+test('A compressed asset uses the first matching uncompressed entry', () => {
+	const firstSrc = `data:audio/mp3;base64,${'A'.repeat(500)}`;
+	const secondSrc = `data:audio/mp3;base64,${'B'.repeat(500)}`;
+	const frames = [
+		[
+			makeAsset({id: 'audio-source', frame: 0, src: firstSrc}),
+			makeAsset({id: 'audio-source', frame: 0, src: secondSrc}),
+		],
+		[],
+		[
+			makeAsset({
+				id: 'audio-reference',
+				frame: 2,
+				src: 'same-as-audio-source-0',
+			}),
+		],
+	];
+
+	const positions = calculateAssetPositions(frames);
+
+	expect(positions[1].src).toBe(firstSrc);
+});
+
+test('Assets are returned in order of first appearance', () => {
+	const frames = [
+		[
+			makeAsset({id: 'audio-x', frame: 0, src: 'http://localhost/x.mp3'}),
+			makeAsset({id: 'audio-y', frame: 0, src: 'http://localhost/y.mp3'}),
+		],
+		[
+			makeAsset({id: 'audio-y', frame: 1, src: 'http://localhost/y.mp3'}),
+			makeAsset({id: 'audio-z', frame: 1, src: 'http://localhost/z.mp3'}),
+		],
+	];
+
+	const positions = calculateAssetPositions(frames);
+	expect(positions.map((p) => p.id)).toEqual(['audio-x', 'audio-y', 'audio-z']);
+	expect(positions.map((p) => p.duration)).toEqual([1, 2, 1]);
+});
+
+test('Duplicate ids within a frame are deduplicated', () => {
+	const frames = [
+		[
+			makeAsset({id: 'audio-dup', frame: 0, src: 'http://localhost/a.mp3'}),
+			makeAsset({id: 'audio-dup', frame: 0, src: 'http://localhost/a.mp3'}),
+		],
+	];
+
+	const positions = calculateAssetPositions(frames);
+	expect(positions.length).toBe(1);
+	expect(positions[0].volume).toBe(1);
+	expect(positions[0].duration).toBe(1);
+});
+
+test('A late compressed asset can repeatedly close and reopen', () => {
+	const numFrames = 4000;
+	const sourceStart = 3000;
+	const longSrc = `data:audio/mp3;base64,${'A'.repeat(500)}`;
+	const previousAssets: AudioOrVideoAsset[] = [];
+
+	const frames = new Array(numFrames).fill(true).map((_, frame) => {
+		const uncompressed = [
+			makeAsset({
+				id: 'audio-background',
+				frame,
+				src: 'http://localhost:3000/background.mp3',
+			}),
+		];
+
+		if (frame >= sourceStart && (frame - sourceStart) % 2 === 0) {
+			uncompressed.push(
+				makeAsset({
+					id: 'audio-late',
+					frame,
+					src: longSrc,
+					mediaFrame: frame - sourceStart,
+				}),
+			);
+		}
+
+		const compressed = uncompressed.map((asset) => {
+			return compressAsset(previousAssets, asset);
+		});
+		previousAssets.push(...compressed);
+		return compressed;
+	});
+
+	expect(frames[sourceStart][1].src).toBe(longSrc);
+	expect(frames[sourceStart + 2][1].src).toBe(
+		`same-as-audio-late-${sourceStart}`,
+	);
+
+	const inputBefore = structuredClone(frames);
+	const positions = calculateAssetPositions(frames);
+	const reopened = positions.slice(1);
+
+	expect(frames).toEqual(inputBefore);
+	expect(positions[0].duration).toBe(numFrames);
+	expect(reopened.length).toBe((numFrames - sourceStart) / 2);
+	for (let i = 0; i < reopened.length; i++) {
+		expect(reopened[i].src).toBe(longSrc);
+		expect(reopened[i].startInVideo).toBe(sourceStart + i * 2);
+		expect(reopened[i].duration).toBe(1);
+		expect(reopened[i].trimLeft).toBe(i * 2);
+	}
+});


### PR DESCRIPTION
## Why

`calculateAssetPositions()` converts per-frame audio/video entries into positioned segments for stitching. PR #4575 removed one repeated flattening cost, but the remaining path still scanned previous/next frames, every open segment, and the flattened list for compressed references.

On long renders with many short or reopened assets, that work grows quadratically.

## What

- deduplicate each frame with a `Set`;
- track open segments by asset id in a `Map`;
- pre-index only compressed references that actually occur, preserving the first eligible source match;
- close segments when an id disappears and close remaining segments after the final frame.

The function remains behavior-compatible with corrupt compressed references by falling back to the existing diagnostic/error path. No public API changes.

## Performance

Measured against `main` at `69d5a16b`; the relevant baseline source is unchanged on the rebased current main. Seven alternating runs on the same pinned CPU used an unchanged 40,000-frame workload with 172,156 entries and 6,005 output segments. Every output matched the same full-result SHA-256.

| Implementation | Median | MAD |
|---|---:|---:|
| Current `main` | 937.182 ms | 1.157 ms |
| This change | 70.084 ms | 5.015 ms |

Median speedup: **13.372x**.

The late-source/reopened compressed fixture also scaled from `80.449 -> 3.338 ms` at 8,000 frames, `249.909 -> 6.470 ms` at 16,000, and `918.214 -> 13.641 ms` at 32,000.

## Correctness

- 1,204 differential cases matched current `main` exactly;
- 2,408 checks found no input mutation;
- tests cover gaps/reopening, durations, `trimLeft`, compressed cross-id sources, first-match behavior, output ordering, and within-frame deduplication;
- focused asset tests: 18 passed;
- `bun run build`: 71/71 tasks passed;
- `bun run stylecheck`: 233/233 tasks passed;
- full renderer suite on the rebased head: 318 passed; 18 environment/setup failures were unrelated to this patch;
- `git diff --check` passed.

Weco identified the open-segment map direction. A stronger scaling review then found repeated compressed-reference lookup in that first result; the final patch adds the reference index and revalidates the complete algorithm. [Public autoresearch trajectory](https://dashboard.weco.ai/share/3drdEMvQWxlFgajm2b47ijbmw2EiWgyW)

## Tradeoff

The function now allocates a `Set` of distinct compressed references and a `Map` containing their first eligible source entries. Auxiliary memory is proportional to distinct referenced assets.