### PR TITLE
`remotion`: Support shared enum schema keys

### DIFF
--- a/packages/core/src/flatten-schema.ts
+++ b/packages/core/src/flatten-schema.ts
@@ -33,9 +33,7 @@ export const getFlatSchemaWithAllKeys = (
 
 	const addKey = (key: string, field: InteractivitySchema[string]) => {
 		if (key in out) {
-			throw new Error(
-				`Duplicate key "${key}" in schema: discriminated union variants must not share keys`,
-			);
+			return;
 		}
 
 		out[key] = field;

--- a/packages/core/src/test/with-interactivity-schema-helpers.test.ts
+++ b/packages/core/src/test/with-interactivity-schema-helpers.test.ts
@@ -1,6 +1,9 @@
 import {expect, test} from 'bun:test';
 import {solidSchema} from '../effects/Solid.js';
-import {getFlatSchemaWithAllKeys} from '../flatten-schema.js';
+import {
+	flattenActiveSchema,
+	getFlatSchemaWithAllKeys,
+} from '../flatten-schema.js';
 import {htmlInCanvasSchema} from '../HtmlInCanvas.js';
 import {Interactive} from '../Interactive.js';
 import {
@@ -81,6 +84,72 @@ test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 			'trimBefore',
 		].sort(),
 	);
+});
+
+test('getFlatSchema allows enum variants to share prop keys', () => {
+	const schema = {
+		type: {
+			type: 'enum',
+			default: 'underline',
+			description: 'Type',
+			variants: {
+				underline: {
+					color: {
+						type: 'color',
+						default: '#111111',
+						description: 'Underline color',
+					},
+				},
+				highlight: {
+					color: {
+						type: 'color',
+						default: '#eeee00',
+						description: 'Highlight color',
+					},
+				},
+				bracket: {},
+			},
+		},
+	} as const;
+
+	const flat = getFlatSchemaWithAllKeys(schema);
+	expect(Object.keys(flat).sort()).toEqual(['color', 'type']);
+	expect(flat.color.type).toBe('color');
+});
+
+test('flattenActiveSchema resolves shared keys from the selected enum variant', () => {
+	const schema = {
+		type: {
+			type: 'enum',
+			default: 'underline',
+			description: 'Type',
+			variants: {
+				underline: {
+					color: {
+						type: 'color',
+						default: '#111111',
+						description: 'Underline color',
+					},
+				},
+				highlight: {
+					color: {
+						type: 'color',
+						default: '#eeee00',
+						description: 'Highlight color',
+					},
+				},
+			},
+		},
+	} as const;
+
+	const active = flattenActiveSchema(schema, (key) =>
+		key === 'type' ? 'highlight' : undefined,
+	);
+	expect(active.color).toEqual({
+		type: 'color',
+		default: '#eeee00',
+		description: 'Highlight color',
+	});
 });
 
 test('extendSchemaWithSequenceName adds hidden name to wrapped schemas', () => {

--- a/packages/studio-server/src/test/get-all-schema-keys.test.ts
+++ b/packages/studio-server/src/test/get-all-schema-keys.test.ts
@@ -31,8 +31,8 @@ test('getAllSchemaKeys returns every key across all enum variants', () => {
 	);
 });
 
-test('getFlatSchema throws when discriminated union variants share a key', () => {
-	const conflictingSchema: InteractivitySchema = {
+test('getFlatSchema dedupes keys shared by discriminated union variants', () => {
+	const schema: InteractivitySchema = {
 		mode: {
 			type: 'enum',
 			default: 'a',
@@ -56,7 +56,8 @@ test('getFlatSchema throws when discriminated union variants share a key', () =>
 		},
 	};
 
-	expect(() => getFlatSchemaWithAllKeys(conflictingSchema)).toThrow(
-		'Duplicate key "shared"',
-	);
+	expect(Object.keys(getFlatSchemaWithAllKeys(schema)).sort()).toEqual([
+		'mode',
+		'shared',
+	]);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #9021

## Summary
- Allow enum schema variants to share prop keys when collecting all schema keys.
- Add regression coverage for shared variant keys and active variant field resolution.

## Testing
- bun test src/test/with-interactivity-schema-helpers.test.ts (from packages/core)
- bun test src/test/get-all-schema-keys.test.ts (from packages/studio-server)
- bun run build
- bun run stylecheck

## Tradeoffs
- When collecting all keys, repeated keys keep the first discovered field metadata; active schema flattening continues to resolve metadata from the selected enum variant.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f56cd-7a4b-79d4-90e5-4d2f76b6da11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f56cd-7a4b-79d4-90e5-4d2f76b6da11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

