### PR TITLE
`@remotion/studio`: Install element dependencies before insert

### DIFF
--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -274,6 +274,7 @@ export type {CompletedClientRender} from './render-job';
 export {
 	getRequiredPackageForEffectImportPath,
 	getRequiredPackageForInsertableElement,
+	getRequiredPackagesForElementSourceCode,
 } from './required-package';
 export {
 	SCHEMA_FIELD_GROUPS,

--- a/packages/studio-shared/src/required-package.ts
+++ b/packages/studio-shared/src/required-package.ts
@@ -1,4 +1,38 @@
 import type {InsertableCompositionElement} from './api-requests';
+import {extraPackages, packages} from './package-info';
+
+const firstPartyPackageNames = new Set(
+	packages.map((pkg) => `@remotion/${pkg}`),
+);
+const extraPackageNames = new Set(extraPackages.map((pkg) => pkg.name));
+
+const isInstallableElementPackage = (packageName: string): boolean => {
+	return (
+		firstPartyPackageNames.has(packageName) ||
+		extraPackageNames.has(packageName)
+	);
+};
+
+const extractImportPaths = (sourceCode: string): string[] => {
+	const importPaths = new Set<string>();
+	const staticImportRegex =
+		/\b(?:import|export)\s+(?:type\s+)?(?:[^'";]*?\s+from\s*)?['"]([^'"]+)['"]/g;
+	const dynamicImportRegex = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+	for (const match of sourceCode.matchAll(staticImportRegex)) {
+		if (match[1]) {
+			importPaths.add(match[1]);
+		}
+	}
+
+	for (const match of sourceCode.matchAll(dynamicImportRegex)) {
+		if (match[1]) {
+			importPaths.add(match[1]);
+		}
+	}
+
+	return [...importPaths];
+};
 
 export const getRequiredPackageForImportPath = (
 	importPath: string,
@@ -61,4 +95,19 @@ export const getRequiredPackageForEffectImportPath = (
 	}
 
 	return null;
+};
+
+export const getRequiredPackagesForElementSourceCode = (
+	sourceCode: string,
+): string[] => {
+	const requiredPackages = new Set<string>();
+
+	for (const importPath of extractImportPaths(sourceCode)) {
+		const requiredPackage = getRequiredPackageForImportPath(importPath);
+		if (requiredPackage && isInstallableElementPackage(requiredPackage)) {
+			requiredPackages.add(requiredPackage);
+		}
+	}
+
+	return [...requiredPackages];
 };

--- a/packages/studio-shared/src/test/required-package.test.ts
+++ b/packages/studio-shared/src/test/required-package.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'bun:test';
 import {
 	getRequiredPackageForEffectImportPath,
 	getRequiredPackageForInsertableElement,
+	getRequiredPackagesForElementSourceCode,
 } from '../required-package';
 
 test('gets required package for insertable elements', () => {
@@ -96,4 +97,47 @@ test('gets required package for effect import paths', () => {
 		'@remotion/starburst',
 	);
 	expect(getRequiredPackageForEffectImportPath('remotion')).toBe(null);
+});
+
+test('gets required packages for element source code', () => {
+	expect(
+		getRequiredPackagesForElementSourceCode(`
+			import {loadFont} from '@remotion/google-fonts/Inter';
+			import {AbsoluteFill} from 'remotion';
+			import React from 'react';
+			import './style.css';
+
+			export const LowerThird = () => null;
+		`),
+	).toEqual(['@remotion/google-fonts']);
+
+	expect(
+		getRequiredPackagesForElementSourceCode(`
+			import {paper} from '@remotion/effects/paper';
+			import {starburst} from '@remotion/starburst';
+			import {z} from 'zod';
+			import {Input} from 'lodash';
+			import {Output} from '@acme/video';
+			import {read} from 'mediabunny';
+			import '@mediabunny/prores';
+
+			export const Element = () => null;
+		`),
+	).toEqual([
+		'@remotion/effects',
+		'@remotion/starburst',
+		'zod',
+		'mediabunny',
+		'@mediabunny/prores',
+	]);
+
+	expect(
+		getRequiredPackagesForElementSourceCode(`
+			import {loadFont} from '@remotion/google-fonts/Inter';
+			import {loadFont as loadFontAgain} from '@remotion/google-fonts/Roboto';
+			const module = import('@remotion/media');
+
+			export const Element = () => null;
+		`),
+	).toEqual(['@remotion/google-fonts', '@remotion/media']);
 });

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -2,6 +2,7 @@ import {getVideoMetadata} from '@remotion/media-utils';
 import {
 	detectFileType,
 	getRequiredPackageForInsertableElement,
+	getRequiredPackagesForElementSourceCode,
 	isUrl,
 	type CompositionDragData,
 	type ComponentDragData,
@@ -920,6 +921,10 @@ export const insertElement = async ({
 	element: ElementDragData['element'];
 }) => {
 	try {
+		await installRequiredPackages(
+			getRequiredPackagesForElementSourceCode(element.sourceCode),
+		);
+
 		const response = await callApi('/api/insert-element', {
 			compositionFile,
 			compositionId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Summary
- Install dependencies declared by Remotion Element source before inserting the element into Studio.
- Resolve only first-party Remotion packages and the existing extra-package allowlist (`mediabunny`, `@mediabunny/*`, `zod`) from element imports.
- Add coverage for Google Fonts, effects, starburst, extra packages, third-party filtering, and deduplication.

## Testing
- `bun run build`
- `bun test packages/studio-shared/src/test/required-package.test.ts`
- `bun test packages/studio/src/test/import-assets.test.ts`
- `bun run stylecheck`

Closes #9035
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f56d2-1de3-7489-a776-7bb1e92a0cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f56d2-1de3-7489-a776-7bb1e92a0cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

