### PR TITLE
`@remotion/studio`: Install dependencies for dragged Elements

### DIFF
--- a/packages/docs/elements/backgrounds/paper-texture/index.mdx
+++ b/packages/docs/elements/backgrounds/paper-texture/index.mdx
@@ -8,4 +8,11 @@ import {PaperTexture} from './paper-texture';
 
 # Paper Texture
 
-<ElementPage component={PaperTexture} description="A white paper texture background with a slowly changing posterized seed." displayName="Paper Texture" slug="backgrounds/paper-texture" sourceFile="./paper-texture.tsx" />
+<ElementPage
+  component={PaperTexture}
+  dependencies={['@remotion/effects']}
+  description="A white paper texture background with a slowly changing posterized seed."
+  displayName="Paper Texture"
+  slug="backgrounds/paper-texture"
+  sourceFile="./paper-texture.tsx"
+/>

--- a/packages/docs/elements/backgrounds/rotating-starburst/index.mdx
+++ b/packages/docs/elements/backgrounds/rotating-starburst/index.mdx
@@ -10,6 +10,7 @@ import {RotatingStarburst} from './rotating-starburst';
 
 <ElementPage
   component={RotatingStarburst}
+  dependencies={['@remotion/starburst']}
   description="A Solid background with a slowly rotating starburst effect."
   displayName="Rotating Starburst"
   durationInFrames={240}

--- a/packages/docs/elements/data/number-counter/index.mdx
+++ b/packages/docs/elements/data/number-counter/index.mdx
@@ -16,6 +16,7 @@ import {NumberCounter} from './number-counter';
       contribution: 'Author',
     },
   ]}
+  dependencies={['@remotion/google-fonts']}
   description="A simple animated counter that smoothly counts from a start value to an end value."
   displayName="Number Counter"
   elementHeight={200}

--- a/packages/docs/elements/overlays/lower-third/index.mdx
+++ b/packages/docs/elements/overlays/lower-third/index.mdx
@@ -8,4 +8,14 @@ import {LowerThird} from './lower-third';
 
 # Lower Third
 
-<ElementPage component={LowerThird} description="A clean animated lower third for introducing a speaker, guest, or section." displayName="Lower Third" elementHeight={138} elementWidth={680} previewPadding={300} slug="overlays/lower-third" sourceFile="./lower-third.tsx" />
+<ElementPage
+  component={LowerThird}
+  dependencies={['@remotion/google-fonts']}
+  description="A clean animated lower third for introducing a speaker, guest, or section."
+  displayName="Lower Third"
+  elementHeight={138}
+  elementWidth={680}
+  previewPadding={300}
+  slug="overlays/lower-third"
+  sourceFile="./lower-third.tsx"
+/>

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -21,6 +21,7 @@ type ElementPageProps = {
 	readonly children?: ReactNode;
 	readonly component: ComponentType<Record<string, never>>;
 	readonly contributors?: Contributor[];
+	readonly dependencies?: readonly string[];
 	readonly description: ReactNode;
 	readonly displayName?: string;
 	readonly durationInFrames?: number;
@@ -108,6 +109,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	children,
 	component,
 	contributors,
+	dependencies,
 	description,
 	displayName,
 	durationInFrames = 120,
@@ -150,12 +152,20 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 				: null;
 
 		return makeElementDragData({
+			dependencies,
 			dimensions,
 			displayName,
 			slug,
 			sourceCode,
 		});
-	}, [displayName, elementHeight, elementWidth, slug, sourceCode]);
+	}, [
+		dependencies,
+		displayName,
+		elementHeight,
+		elementWidth,
+		slug,
+		sourceCode,
+	]);
 
 	const installElement = useCallback(async () => {
 		if (dragData === null) {

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, test} from 'bun:test';
 import {existsSync, readdirSync, readFileSync, statSync} from 'fs';
 import path from 'path';
+import {getRequiredPackagesForElementSourceCode} from '@remotion/studio-shared';
 import {expandElementSourceReferences} from '../../plugins/element-source-utils';
 import remarkElementSource from '../../plugins/remark-element-source';
 
@@ -144,6 +145,14 @@ describe('Elements must follow the colocated single-file format', () => {
 				expect(mdx).not.toContain('sourceCode=');
 				expect(mdx).not.toContain('componentName=');
 				expect(mdx).not.toMatch(/export const \w+Source = /);
+			});
+
+			test('MDX declares dependencies imported by the Element', () => {
+				const requiredPackages = getRequiredPackagesForElementSourceCode(tsx);
+
+				for (const requiredPackage of requiredPackages) {
+					expect(mdx).toContain(`'${requiredPackage}'`);
+				}
 			});
 
 			test('Element drag file name is derived from the slug', () => {

--- a/packages/studio-shared/src/element-drag-data.ts
+++ b/packages/studio-shared/src/element-drag-data.ts
@@ -2,6 +2,10 @@ import {
 	isComponentIdentifier,
 	type ComponentDimensions,
 } from './component-drag-data';
+import {
+	getRequiredPackagesForElementSourceCode,
+	isAllowedElementDependencyPackage,
+} from './required-package';
 
 export {ELEMENT_DRAG_MIME_TYPE} from './drag-mime-types';
 
@@ -13,7 +17,15 @@ export type ElementDragData = {
 		displayName: string;
 		sourceCode: string;
 		dimensions: ComponentDimensions | null;
+		dependencies: readonly string[];
 	};
+};
+
+type MakeElementDragDataInput = Omit<
+	ElementDragData['element'],
+	'dependencies'
+> & {
+	readonly dependencies?: readonly string[];
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
@@ -87,6 +99,44 @@ const isDimensions = (value: unknown): value is ComponentDimensions => {
 	);
 };
 
+const isDependencyList = (value: unknown): value is string[] => {
+	if (typeof value === 'undefined') {
+		return true;
+	}
+
+	if (!Array.isArray(value) || value.length > 30) {
+		return false;
+	}
+
+	const seen = new Set<string>();
+	for (const dependency of value) {
+		if (
+			typeof dependency !== 'string' ||
+			dependency.length > 200 ||
+			seen.has(dependency) ||
+			!isAllowedElementDependencyPackage(dependency)
+		) {
+			return false;
+		}
+
+		seen.add(dependency);
+	}
+
+	return true;
+};
+
+const mergeDependencies = (
+	sourceCode: string,
+	dependencies: readonly string[] | undefined,
+) => {
+	return Array.from(
+		new Set([
+			...getRequiredPackagesForElementSourceCode(sourceCode),
+			...(dependencies ?? []),
+		]),
+	);
+};
+
 export const getElementComponentNameFromSourceCode = (sourceCode: string) => {
 	const componentNames = Array.from(
 		sourceCode.matchAll(
@@ -106,10 +156,11 @@ export const getElementComponentNameFromSourceCode = (sourceCode: string) => {
 
 export const makeElementDragData = ({
 	dimensions,
+	dependencies,
 	displayName,
 	slug,
 	sourceCode,
-}: ElementDragData['element']): ElementDragData => {
+}: MakeElementDragDataInput): ElementDragData => {
 	return {
 		type: 'remotion-element',
 		version: 1,
@@ -118,6 +169,7 @@ export const makeElementDragData = ({
 			displayName,
 			sourceCode,
 			dimensions,
+			dependencies: mergeDependencies(sourceCode, dependencies),
 		},
 	};
 };
@@ -137,7 +189,8 @@ export const parseElementDragData = (value: string): ElementDragData | null => {
 			return null;
 		}
 
-		const {dimensions, displayName, slug, sourceCode} = parsed.element;
+		const {dependencies, dimensions, displayName, slug, sourceCode} =
+			parsed.element;
 
 		if (
 			!isSlug(slug) ||
@@ -147,7 +200,8 @@ export const parseElementDragData = (value: string): ElementDragData | null => {
 			makeElementFileNameFromSlug(slug) === null ||
 			(dimensions !== undefined &&
 				dimensions !== null &&
-				!isDimensions(dimensions))
+				!isDimensions(dimensions)) ||
+			!isDependencyList(dependencies)
 		) {
 			return null;
 		}
@@ -157,6 +211,7 @@ export const parseElementDragData = (value: string): ElementDragData | null => {
 			displayName,
 			sourceCode,
 			dimensions: dimensions ?? null,
+			dependencies: mergeDependencies(sourceCode, dependencies),
 		});
 	} catch {
 		return null;

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -274,6 +274,7 @@ export type {CompletedClientRender} from './render-job';
 export {
 	getRequiredPackageForEffectImportPath,
 	getRequiredPackageForInsertableElement,
+	getRequiredPackagesForElementSourceCode,
 } from './required-package';
 export {
 	SCHEMA_FIELD_GROUPS,

--- a/packages/studio-shared/src/required-package.ts
+++ b/packages/studio-shared/src/required-package.ts
@@ -1,4 +1,5 @@
 import type {InsertableCompositionElement} from './api-requests';
+import {extraPackages, installableMap, packages} from './package-info';
 
 export const getRequiredPackageForImportPath = (
 	importPath: string,
@@ -14,6 +15,48 @@ export const getRequiredPackageForImportPath = (
 
 	const [packageName] = importPath.split('/');
 	return packageName || null;
+};
+
+const firstPartyPackages = new Set(
+	packages
+		.filter((pkg) => installableMap[pkg])
+		.map((pkg) => `@remotion/${pkg}`),
+);
+
+const extraPackageNames = new Set(extraPackages.map((pkg) => pkg.name));
+
+export const isAllowedElementDependencyPackage = (packageName: string) => {
+	return (
+		firstPartyPackages.has(packageName) || extraPackageNames.has(packageName)
+	);
+};
+
+const fromImportPathRegex =
+	/^(?:import|export)\s+(?:type\s+)?.+\s+from\s+['"]([^'"]+)['"]/;
+const sideEffectImportPathRegex = /^import\s+['"]([^'"]+)['"]/;
+
+export const getRequiredPackagesForElementSourceCode = (sourceCode: string) => {
+	const requiredPackages: string[] = [];
+
+	for (const line of sourceCode.split('\n')) {
+		const trimmed = line.trim();
+		const match =
+			trimmed.match(fromImportPathRegex) ??
+			trimmed.match(sideEffectImportPathRegex);
+		const importPath = match?.[1] ?? null;
+		const requiredPackage =
+			importPath === null ? null : getRequiredPackageForImportPath(importPath);
+
+		if (
+			requiredPackage !== null &&
+			isAllowedElementDependencyPackage(requiredPackage) &&
+			!requiredPackages.includes(requiredPackage)
+		) {
+			requiredPackages.push(requiredPackage);
+		}
+	}
+
+	return requiredPackages;
 };
 
 export const getRequiredPackageForInsertableElement = (

--- a/packages/studio-shared/src/test/element-drag-data.test.ts
+++ b/packages/studio-shared/src/test/element-drag-data.test.ts
@@ -12,13 +12,18 @@ const validElement = {
 	dimensions: {width: 900, height: 260},
 };
 
+const validElementWithDependencies = {
+	...validElement,
+	dependencies: [],
+};
+
 test('parses element drag data', () => {
 	expect(
 		parseElementDragData(JSON.stringify(makeElementDragData(validElement))),
 	).toEqual({
 		type: 'remotion-element',
 		version: 1,
-		element: validElement,
+		element: validElementWithDependencies,
 	});
 });
 
@@ -31,8 +36,40 @@ test('accepts element drag data with null dimensions', () => {
 	).toEqual({
 		type: 'remotion-element',
 		version: 1,
-		element: elementWithoutDimensions,
+		element: {...elementWithoutDimensions, dependencies: []},
 	});
+});
+
+test('derives element dependencies from source code imports', () => {
+	const element = {
+		...validElement,
+		sourceCode: [
+			"import React from 'react';",
+			"import {loadFont} from '@remotion/google-fonts/Inter';",
+			"import {paper} from '@remotion/effects/paper';",
+			"import {z} from 'zod';",
+			"import {AbsoluteFill} from 'remotion';",
+			'export const LowerThird = () => null;',
+		].join('\n'),
+	};
+
+	expect(makeElementDragData(element).element.dependencies).toEqual([
+		'@remotion/google-fonts',
+		'@remotion/effects',
+		'zod',
+	]);
+});
+
+test('parses old element drag data without dependencies', () => {
+	expect(
+		parseElementDragData(
+			JSON.stringify({
+				type: 'remotion-element',
+				version: 1,
+				element: validElement,
+			}),
+		)?.element.dependencies,
+	).toEqual([]);
 });
 
 test('derives element file name from slug', () => {
@@ -109,6 +146,15 @@ test('rejects invalid element drag data', () => {
 				type: 'remotion-element',
 				version: 1,
 				element: {...validElement, dimensions: {width: 0, height: 260}},
+			}),
+		),
+	).toBe(null);
+	expect(
+		parseElementDragData(
+			JSON.stringify({
+				type: 'remotion-element',
+				version: 1,
+				element: {...validElement, dependencies: ['left-pad']},
 			}),
 		),
 	).toBe(null);

--- a/packages/studio-shared/src/test/required-package.test.ts
+++ b/packages/studio-shared/src/test/required-package.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
 import {
 	getRequiredPackageForEffectImportPath,
+	getRequiredPackagesForElementSourceCode,
 	getRequiredPackageForInsertableElement,
 } from '../required-package';
 
@@ -96,4 +97,25 @@ test('gets required package for effect import paths', () => {
 		'@remotion/starburst',
 	);
 	expect(getRequiredPackageForEffectImportPath('remotion')).toBe(null);
+});
+
+test('gets required packages for element source code', () => {
+	expect(
+		getRequiredPackagesForElementSourceCode(
+			[
+				"import React from 'react';",
+				"import {loadFont} from '@remotion/google-fonts/Inter';",
+				"import {starburst} from '@remotion/starburst';",
+				"import '@remotion/effects/paper';",
+				"import {z} from 'zod';",
+				"import {AbsoluteFill} from 'remotion';",
+				"import ignored from 'left-pad';",
+			].join('\n'),
+		),
+	).toEqual([
+		'@remotion/google-fonts',
+		'@remotion/starburst',
+		'@remotion/effects',
+		'zod',
+	]);
 });

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -920,6 +920,8 @@ export const insertElement = async ({
 	element: ElementDragData['element'];
 }) => {
 	try {
+		await installRequiredPackages([...element.dependencies]);
+
 		const response = await callApi('/api/insert-element', {
 			compositionFile,
 			compositionId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Derive allowed Element dependencies from Element source imports and include them in the drag payload.
- Install Element dependencies through the existing Studio package install queue before inserting the Element.
- Add explicit dependency declarations to the current docs Elements that use first-party packages.
- Add parser and docs tests for dependency derivation, legacy payloads, third-party rejection, and Element MDX dependency declarations.

## Testing
- `bun test src/test/element-drag-data.test.ts src/test/required-package.test.ts`
- `bun test src/test/elements.test.ts`
- `bunx turbo run make --filter='@remotion/studio-shared'`
- `bunx turbo run make --filter='@remotion/studio-shared' --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='docs' --filter='@remotion/studio-shared' --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`

Closes #9035
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f56d1-ecac-72a6-94cb-fdf45f3e5949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f56d1-ecac-72a6-94cb-fdf45f3e5949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

