### PR TITLE
`@remotion/player`: Fix audio hiccups on rapid play/pause toggling

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -364,22 +364,30 @@ export const SharedAudioContextProvider: React.FC<{
 
 		audioContextIsPlayingEventually.current = true;
 
-		ctxAndGain.gainNode.gain.cancelScheduledValues(
-			ctxAndGain.audioContext.currentTime,
-		);
-		ctxAndGain.gainNode.gain.setValueAtTime(
-			0,
-			ctxAndGain.audioContext.currentTime,
-		);
-		ctxAndGain.gainNode.gain.linearRampToValueAtTime(
-			1,
-			ctxAndGain.audioContext.currentTime + 0.03,
-		);
+		// Nodes that were scheduled while the context was not running start
+		// mid-waveform, which can produce an audible click - mask it with a
+		// short fade-in. If there are no nodes to start, resume() merely
+		// unfreezes the nodes that suspend() froze in place, which continues
+		// sample-exact - fading would cause an audible dip on every
+		// play/pause toggle.
+		if (nodesToResume.current.size > 0) {
+			ctxAndGain.gainNode.gain.cancelScheduledValues(
+				ctxAndGain.audioContext.currentTime,
+			);
+			ctxAndGain.gainNode.gain.setValueAtTime(
+				0,
+				ctxAndGain.audioContext.currentTime,
+			);
+			ctxAndGain.gainNode.gain.linearRampToValueAtTime(
+				1,
+				ctxAndGain.audioContext.currentTime + 0.03,
+			);
 
-		nodesToResume.current.forEach((r, node) => {
-			node.start(r.scheduledTime, r.offset, r.duration);
-		});
-		nodesToResume.current.clear();
+			nodesToResume.current.forEach((r, node) => {
+				node.start(r.scheduledTime, r.offset, r.duration);
+			});
+			nodesToResume.current.clear();
+		}
 
 		const resumePromise = ctxAndGain.resume();
 

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -90,21 +90,21 @@ type SharedAudioContextValue = {
 	unscheduleAudioNode: (node: AudioBufferSourceNode) => void;
 };
 
+type RegisterAudioOptions = {
+	aud: AudioHTMLAttributes<HTMLAudioElement>;
+	audioId: string;
+	premounting: boolean;
+	postmounting: boolean;
+};
+
+type UpdateAudioOptions = RegisterAudioOptions & {
+	id: number;
+};
+
 type SharedAudioTagsContextValue = {
-	registerAudio: (options: {
-		aud: AudioHTMLAttributes<HTMLAudioElement>;
-		audioId: string;
-		premounting: boolean;
-		postmounting: boolean;
-	}) => AudioElem;
+	registerAudio: (options: RegisterAudioOptions) => AudioElem;
 	unregisterAudio: (id: number) => void;
-	updateAudio: (options: {
-		id: number;
-		aud: AudioHTMLAttributes<HTMLAudioElement>;
-		audioId: string;
-		premounting: boolean;
-		postmounting: boolean;
-	}) => void;
+	updateAudio: (options: UpdateAudioOptions) => void;
 	playAllAudios: () => void;
 	numberOfAudioTags: number;
 };
@@ -191,12 +191,16 @@ const shouldSaveForLater = (
 	throw new Error(`Unexpected audio context state: ${state satisfies never}`);
 };
 
-export const SharedAudioContextProvider: React.FC<{
+type SharedAudioContextProviderProps = {
 	readonly children: React.ReactNode;
 	readonly audioLatencyHint: AudioContextLatencyCategory;
 	readonly audioEnabled: boolean;
 	readonly previewSampleRate: number | null;
-}> = ({children, audioLatencyHint, audioEnabled, previewSampleRate}) => {
+};
+
+export const SharedAudioContextProvider: React.FC<
+	SharedAudioContextProviderProps
+> = ({children, audioLatencyHint, audioEnabled, previewSampleRate}) => {
 	const logLevel = useLogLevel();
 	const sampleRate = previewSampleRate ?? 48000;
 
@@ -459,10 +463,14 @@ export const SharedAudioContextProvider: React.FC<{
 	);
 };
 
-export const SharedAudioTagsContextProvider: React.FC<{
+type SharedAudioTagsContextProviderProps = {
 	readonly numberOfAudioTags: number;
 	readonly children: React.ReactNode;
-}> = ({children, numberOfAudioTags}) => {
+};
+
+export const SharedAudioTagsContextProvider: React.FC<
+	SharedAudioTagsContextProviderProps
+> = ({children, numberOfAudioTags}) => {
 	const audios = useRef<AudioElem[]>([]);
 	const [initialNumberOfAudioTags] = useState(numberOfAudioTags);
 
@@ -552,12 +560,7 @@ export const SharedAudioTagsContextProvider: React.FC<{
 	}, [refs]);
 
 	const registerAudio = useCallback(
-		(options: {
-			aud: AudioHTMLAttributes<HTMLAudioElement>;
-			audioId: string;
-			premounting: boolean;
-			postmounting: boolean;
-		}) => {
+		(options: RegisterAudioOptions) => {
 			const {aud, audioId, premounting, postmounting} = options;
 			const found = audios.current?.find((a) => a.audioId === audioId);
 			if (found) {
@@ -617,19 +620,7 @@ export const SharedAudioTagsContextProvider: React.FC<{
 	);
 
 	const updateAudio = useCallback(
-		({
-			aud,
-			audioId,
-			id,
-			premounting,
-			postmounting,
-		}: {
-			id: number;
-			aud: AudioHTMLAttributes<HTMLAudioElement>;
-			audioId: string;
-			premounting: boolean;
-			postmounting: boolean;
-		}) => {
+		({aud, audioId, id, premounting, postmounting}: UpdateAudioOptions) => {
 			let changed = false;
 
 			audios.current = audios.current?.map((prevA): AudioElem => {
@@ -728,12 +719,7 @@ export const useSharedAudio = ({
 	audioId,
 	premounting,
 	postmounting,
-}: {
-	aud: AudioHTMLAttributes<HTMLAudioElement>;
-	audioId: string;
-	premounting: boolean;
-	postmounting: boolean;
-}) => {
+}: RegisterAudioOptions) => {
 	const audioCtx = useContext(SharedAudioContext);
 	const tagsCtx = useContext(SharedAudioTagsContext);
 

--- a/packages/player/src/set-global-time-anchor.ts
+++ b/packages/player/src/set-global-time-anchor.ts
@@ -2,19 +2,21 @@ import {Internals, type LogLevel} from 'remotion';
 
 export const ALLOWED_GLOBAL_TIME_ANCHOR_SHIFT = 0.1;
 
+type SetGlobalTimeAnchorOptions = {
+	audioContext: AudioContext;
+	audioSyncAnchor: {value: number};
+	absoluteTimeInSeconds: number;
+	globalPlaybackRate: number;
+	logLevel: LogLevel;
+};
+
 export const setGlobalTimeAnchor = ({
 	audioContext,
 	audioSyncAnchor,
 	absoluteTimeInSeconds,
 	globalPlaybackRate,
 	logLevel,
-}: {
-	audioContext: AudioContext;
-	audioSyncAnchor: {value: number};
-	absoluteTimeInSeconds: number;
-	globalPlaybackRate: number;
-	logLevel: LogLevel;
-}): boolean => {
+}: SetGlobalTimeAnchorOptions): boolean => {
 	const newAnchor =
 		audioContext.currentTime - absoluteTimeInSeconds / globalPlaybackRate;
 	const shift = newAnchor - audioSyncAnchor.value;

--- a/packages/player/src/set-global-time-anchor.ts
+++ b/packages/player/src/set-global-time-anchor.ts
@@ -8,14 +8,12 @@ export const setGlobalTimeAnchor = ({
 	absoluteTimeInSeconds,
 	globalPlaybackRate,
 	logLevel,
-	force,
 }: {
 	audioContext: AudioContext;
 	audioSyncAnchor: {value: number};
 	absoluteTimeInSeconds: number;
 	globalPlaybackRate: number;
 	logLevel: LogLevel;
-	force: boolean;
 }): boolean => {
 	const newAnchor =
 		audioContext.currentTime - absoluteTimeInSeconds / globalPlaybackRate;
@@ -25,20 +23,13 @@ export const setGlobalTimeAnchor = ({
 	const latency = audioContext.baseLatency + safeOutputLatency;
 
 	// Skip small shifts to avoid audio glitches from frame-quantized re-anchoring
-	if (Math.abs(shift) < ALLOWED_GLOBAL_TIME_ANCHOR_SHIFT + latency && !force) {
-		return false;
-	}
-
-	// If force is true, but shift is zero, no change is needed
-	if (Math.abs(shift) < Number.EPSILON) {
+	if (Math.abs(shift) < ALLOWED_GLOBAL_TIME_ANCHOR_SHIFT + latency) {
 		return false;
 	}
 
 	Internals.Log.verbose(
 		{logLevel, tag: 'audio-scheduling'},
-		'Anchor ' +
-			(force ? 'forcibly ' : '') +
-			'changed from %s to %s with shift %s',
+		'Anchor changed from %s to %s with shift %s',
 		audioSyncAnchor.value,
 		newAnchor,
 		shift,

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -10,7 +10,7 @@ import {useIsBackgrounded} from './is-backgrounded.js';
 import {setGlobalTimeAnchor} from './set-global-time-anchor.js';
 import {usePlayer} from './use-player.js';
 
-const shouldForceAnchorChange = (newState: RemotionAudioContextState) => {
+const shouldReanchorOnStateChange = (newState: RemotionAudioContextState) => {
 	if (newState === 'suspended' || newState === 'running-to-suspended') {
 		return true;
 	}
@@ -108,7 +108,11 @@ export const usePlayback = ({
 	}, [config, frame, logLevel, playbackRate, sharedAudioContext, muted]);
 
 	// When the audio context is suspended, we use the opportunity to
-	// re-anchor the time to be exact.
+	// re-anchor the time if it has drifted beyond the allowed shift.
+	// Small drifts are left alone on purpose: suspend() freezes the
+	// scheduled audio nodes in place and resume() unfreezes them
+	// sample-exact, so keeping the anchor lets a plain pause/play cycle
+	// reuse the queued nodes without tearing them down.
 	useLayoutEffect(() => {
 		const audioContext = sharedAudioContext?.audioContext;
 		if (!audioContext) {
@@ -125,15 +129,20 @@ export const usePlayback = ({
 
 		const callback = () => {
 			const newState = sharedAudioContext?.getAudioContextState();
-			if (newState && shouldForceAnchorChange(newState)) {
-				setGlobalTimeAnchor({
+			if (newState && shouldReanchorOnStateChange(newState)) {
+				const changed = setGlobalTimeAnchor({
 					audioContext,
 					audioSyncAnchor: sharedAudioContext.audioSyncAnchor,
 					absoluteTimeInSeconds: getCurrentFrame() / config.fps,
 					globalPlaybackRate: playbackRate,
 					logLevel,
-					force: true,
+					force: false,
 				});
+				// The nodes queued so far were scheduled against the old anchor,
+				// so they have to be rebuilt if the anchor moved.
+				if (changed) {
+					sharedAudioContext.audioSyncAnchorEmitter.dispatch('changed');
+				}
 			}
 		};
 

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -100,7 +100,6 @@ export const usePlayback = ({
 			absoluteTimeInSeconds: frame / config.fps,
 			globalPlaybackRate: playbackRate,
 			logLevel,
-			force: false,
 		});
 		if (changed) {
 			sharedAudioContext.audioSyncAnchorEmitter.dispatch('changed');
@@ -136,7 +135,6 @@ export const usePlayback = ({
 					absoluteTimeInSeconds: getCurrentFrame() / config.fps,
 					globalPlaybackRate: playbackRate,
 					logLevel,
-					force: false,
 				});
 				// The nodes queued so far were scheduled against the old anchor,
 				// so they have to be rebuilt if the anchor moved.

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -74,6 +74,12 @@ export const usePlayback = ({
 
 	const lastTimeUpdateTimestamp = useRef<number>(0);
 
+	// The frame at which suspend() was last requested. The suspended audio
+	// nodes were scheduled against this frame, so the statechange handler
+	// must re-anchor against it rather than reading the live frame at the
+	// (async) moment the 'statechange' event fires.
+	const suspendRequestFrame = useRef<number | null>(null);
+
 	const context = useContext(Internals.BufferingContextReact);
 	if (!context) {
 		throw new Error(
@@ -144,7 +150,8 @@ export const usePlayback = ({
 				const changed = setGlobalTimeAnchor({
 					audioContext,
 					audioSyncAnchor: sharedAudioContext.audioSyncAnchor,
-					absoluteTimeInSeconds: getCurrentFrame() / config.fps,
+					absoluteTimeInSeconds:
+						(suspendRequestFrame.current ?? getCurrentFrame()) / config.fps,
 					globalPlaybackRate: playbackRate,
 					logLevel,
 				});
@@ -175,6 +182,7 @@ export const usePlayback = ({
 		}
 
 		if (!playing) {
+			suspendRequestFrame.current = getCurrentFrame();
 			sharedAudioContext?.suspend?.();
 			return;
 		}
@@ -205,6 +213,7 @@ export const usePlayback = ({
 			}
 
 			if (!isPlaying()) {
+				suspendRequestFrame.current = getCurrentFrame();
 				sharedAudioContext?.suspend?.();
 				return;
 			}
@@ -264,6 +273,7 @@ export const usePlayback = ({
 
 			if (context.buffering.current) {
 				if (!muted) {
+					suspendRequestFrame.current = getCurrentFrame();
 					sharedAudioContext?.suspend?.();
 				}
 

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -29,6 +29,27 @@ const shouldReanchorOnStateChange = (newState: RemotionAudioContextState) => {
 	);
 };
 
+type QueuedFrameCall =
+	| {
+			type: 'raf';
+			id: number;
+	  }
+	| {
+			type: 'timeout';
+			id: Timer;
+	  };
+
+type UsePlaybackOptions = {
+	loop: boolean;
+	playbackRate: number;
+	moveToBeginningWhenEnded: boolean;
+	inFrame: number | null;
+	outFrame: number | null;
+	browserMediaControlsBehavior: BrowserMediaControlsBehavior;
+	getCurrentFrame: ReturnType<typeof usePlayer>['getCurrentFrame'];
+	muted: boolean;
+};
+
 export const usePlayback = ({
 	loop,
 	playbackRate,
@@ -38,16 +59,7 @@ export const usePlayback = ({
 	browserMediaControlsBehavior,
 	getCurrentFrame,
 	muted,
-}: {
-	loop: boolean;
-	playbackRate: number;
-	moveToBeginningWhenEnded: boolean;
-	inFrame: number | null;
-	outFrame: number | null;
-	browserMediaControlsBehavior: BrowserMediaControlsBehavior;
-	getCurrentFrame: ReturnType<typeof usePlayer>['getCurrentFrame'];
-	muted: boolean;
-}) => {
+}: UsePlaybackOptions) => {
 	const config = Internals.useUnsafeVideoConfig();
 	const frame = Internals.Timeline.useTimelinePosition();
 	const {playing, pause, emitter, isPlaying} = usePlayer();
@@ -168,16 +180,7 @@ export const usePlayback = ({
 		}
 
 		let hasBeenStopped = false;
-		let reqAnimFrameCall:
-			| {
-					type: 'raf';
-					id: number;
-			  }
-			| {
-					type: 'timeout';
-					id: Timer;
-			  }
-			| null = null;
+		let reqAnimFrameCall: QueuedFrameCall | null = null;
 		let startedTime = performance.now();
 		let framesAdvanced = 0;
 


### PR DESCRIPTION
Fixes #8984

## Problem

Rapidly toggling play/pause in the Player caused audible audio hiccups: the sound stopped and restarted stepwise instead of settling to the final state, and every restart faded in.

Two independent mechanisms caused this:

1. `resume()` in `shared-audio-tags.tsx` ramped the master gain 0 to 1 over 30 ms on every resume, so every play toggle produced an audible dip - even when the context merely unfroze nodes that `suspend()` had frozen in place sample-exact.
2. The `statechange` listener in `use-playback.ts` force-moved the audio sync anchor on every suspend. It never notified the media players, so the already-queued (frozen) nodes stayed scheduled against the old anchor and were misaligned by the shift after resume.

## Changes

- `remotion`: `resume()` only applies the fade-in when there are nodes in `nodesToResume` that need to be started. Those begin mid-waveform and can click, which is what the fade is for. A plain unfreeze is sample-exact and no longer fades.
- `@remotion/player`: the suspend re-anchor now goes through the normal drift guard (`ALLOWED_GLOBAL_TIME_ANCHOR_SHIFT + latency`) instead of `force: true`. On a plain pause the drift is below the guard, so the anchor stays put and pause/play becomes a pure freeze/unfreeze of the same scheduled nodes - no teardown, no re-prime. If the drift does exceed the guard, the anchor is corrected and `'changed'` is dispatched so the media players rebuild their queue against the new anchor (previously the anchor moved silently, leaving the frozen queue misaligned).
- `@remotion/player`: removed the now-unused `force` option from `setGlobalTimeAnchor`.
- Type cleanups: extracted the inline option types in `shared-audio-tags.tsx`, `set-global-time-anchor.ts` and `use-playback.ts` into named types. No behavior change.

## Tradeoffs

- Small drift (below the guard) is no longer zeroed on every pause. It can accumulate across many toggles until the guard trips, which then triggers one clean re-anchor + rebuild. The maximum tolerated A/V drift is unchanged - it is the same guard the seek path already applies during playback. The old per-pause "correction" was itself defective, since it de-synced the frozen queue by the shift.
- A pure resume no longer fades in, so sound starts instantly at a non-zero-crossing - the same kind of step as the existing abrupt stop on pause (there was never a fade-out). Browsers apply their own short ramp on context suspend/resume, so I expect this to be inaudible, but it is the one thing that needs a listen test.

## Testing

- `tsgo` clean on `core`, `player` and `media`; `oxfmt` and `eslint` clean on the changed files.
- `bun test`: 557 pass in `core`, 30 pass in `player`; the `media` browser suite passes (70 tests, 29 files).
- Still open: before/after measurement of the queued-ahead value from the debug overlay while mashing play/pause, as described in #8984.
