### PR TITLE
`remotion`: Tidy up delayRender internals

### DIFF
--- a/packages/core/src/delay-render.ts
+++ b/packages/core/src/delay-render.ts
@@ -163,33 +163,23 @@ export const continueRenderInternal = ({
 		);
 	}
 
+	const timeoutEntry = scope.remotion_delayRenderTimeouts[handle];
+	if (environment.isRendering && timeoutEntry) {
+		const {label, startTime, timeout} = timeoutEntry;
+		clearTimeout(timeout);
+		const message = [
+			label ? `"${label}"` : 'A handle',
+			DELAY_RENDER_CLEAR_TOKEN,
+			`${Date.now() - startTime}ms`,
+		]
+			.filter(truthy)
+			.join(' ');
+		Log.verbose({logLevel, tag: 'delayRender()'}, message);
+		delete scope.remotion_delayRenderTimeouts[handle];
+	}
+
 	scope.remotion_delayRenderHandles = scope.remotion_delayRenderHandles.filter(
-		(h) => {
-			if (h === handle) {
-				if (environment.isRendering && scope !== undefined) {
-					if (!scope.remotion_delayRenderTimeouts[handle]) {
-						return false;
-					}
-
-					const {label, startTime, timeout} =
-						scope.remotion_delayRenderTimeouts[handle];
-					clearTimeout(timeout);
-					const message = [
-						label ? `"${label}"` : 'A handle',
-						DELAY_RENDER_CLEAR_TOKEN,
-						`${Date.now() - startTime}ms`,
-					]
-						.filter(truthy)
-						.join(' ');
-					Log.verbose({logLevel, tag: 'delayRender()'}, message);
-					delete scope.remotion_delayRenderTimeouts[handle];
-				}
-
-				return false;
-			}
-
-			return true;
-		},
+		(h) => h !== handle,
 	);
 
 	if (scope.remotion_delayRenderHandles.length === 0) {

--- a/packages/core/src/delay-render.ts
+++ b/packages/core/src/delay-render.ts
@@ -163,8 +163,9 @@ export const continueRenderInternal = ({
 		);
 	}
 
+	const handleExists = scope.remotion_delayRenderHandles.includes(handle);
 	const timeoutEntry = scope.remotion_delayRenderTimeouts[handle];
-	if (environment.isRendering && timeoutEntry) {
+	if (handleExists && environment.isRendering && timeoutEntry) {
 		const {label, startTime, timeout} = timeoutEntry;
 		clearTimeout(timeout);
 		const message = [

--- a/packages/core/src/delay-render.ts
+++ b/packages/core/src/delay-render.ts
@@ -50,17 +50,19 @@ export type DelayRenderOptions = {
  * This allows useDelayRender to control its own environment source.
  * @private
  */
+type DelayRenderInternalOptions = {
+	scope: DelayRenderScope;
+	environment: RemotionEnvironment;
+	label: string | null;
+	options: DelayRenderOptions;
+};
+
 export const delayRenderInternal = ({
 	scope,
 	environment,
 	label,
 	options,
-}: {
-	scope: DelayRenderScope;
-	environment: RemotionEnvironment;
-	label: string | null;
-	options: DelayRenderOptions;
-}): number => {
+}: DelayRenderInternalOptions): number => {
 	if (typeof label !== 'string' && label !== null) {
 		throw new Error(
 			'The label parameter of delayRender() must be a string or undefined, got: ' +
@@ -135,17 +137,19 @@ export const delayRender = (
  * Internal function that accepts environment as parameter.
  * @private
  */
+type ContinueRenderInternalOptions = {
+	scope: DelayRenderScope;
+	handle: number;
+	environment: RemotionEnvironment;
+	logLevel: LogLevel;
+};
+
 export const continueRenderInternal = ({
 	scope,
 	handle,
 	environment,
 	logLevel,
-}: {
-	scope: DelayRenderScope;
-	handle: number;
-	environment: RemotionEnvironment;
-	logLevel: LogLevel;
-}): void => {
+}: ContinueRenderInternalOptions): void => {
 	if (typeof handle === 'undefined') {
 		throw new TypeError(
 			'The continueRender() method must be called with a parameter that is the return value of delayRender(). No value was passed.',

--- a/packages/core/src/test/ready-manager.test.ts
+++ b/packages/core/src/test/ready-manager.test.ts
@@ -1,5 +1,10 @@
 import {describe, expect, test} from 'bun:test';
-import {continueRender, delayRender} from '../delay-render.js';
+import type {DelayRenderScope} from '../delay-render.js';
+import {
+	continueRender,
+	continueRenderInternal,
+	delayRender,
+} from '../delay-render.js';
 
 describe('Ready Manager tests', () => {
 	let handle: number;
@@ -24,5 +29,39 @@ describe('Ready Manager tests', () => {
 		expect(window.remotion_renderReady).toBe(false);
 		continueRender(handle2);
 		expect(window.remotion_renderReady).toBe(true);
+	});
+
+	test('Does not clear a timeout if the handle does not exist', () => {
+		const unknownHandle = 1;
+		const timeout = setTimeout(() => undefined, 10_000);
+		const scope: DelayRenderScope = {
+			remotion_attempt: 1,
+			remotion_delayRenderHandles: [],
+			remotion_delayRenderTimeouts: {
+				[unknownHandle]: {
+					label: null,
+					startTime: Date.now(),
+					timeout,
+				},
+			},
+			remotion_puppeteerTimeout: 30_000,
+			remotion_renderReady: false,
+		};
+
+		continueRenderInternal({
+			environment: {
+				isClientSideRendering: false,
+				isPlayer: false,
+				isReadOnlyStudio: false,
+				isRendering: true,
+				isStudio: false,
+			},
+			handle: unknownHandle,
+			logLevel: 'info',
+			scope,
+		});
+
+		expect(scope.remotion_delayRenderTimeouts[unknownHandle]).toBeDefined();
+		clearTimeout(timeout);
 	});
 });


### PR DESCRIPTION
## Summary

- Extract the inline object parameter types of `delayRenderInternal` and `continueRenderInternal` into named `DelayRenderInternalOptions` and `ContinueRenderInternalOptions` types.
- Simplify `continueRenderInternal`: move the timeout cleanup out of the `.filter()` predicate so the filter only removes the matching handle, and drop the dead `scope !== undefined` check.

No behavior change; internal refactor only.
