### PR TITLE
`@remotion/studio`: Open layer in editor on double-click

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -724,22 +724,21 @@ export const TimelineSequenceItem: React.FC<{
 		codeHiddenStatus !== null &&
 		codeHiddenStatus.status === 'static';
 
-	const onSequenceDoubleClick = useCallback(
+	const onShowInEditorDoubleClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (!canOpenInEditor) {
+				return;
+			}
+
 			if (isTimelineSelectionModifierEvent(e)) {
 				e.stopPropagation();
 				return;
 			}
 
 			e.stopPropagation();
-			if (canRenameThisSequence) {
-				setIsRenaming(true);
-				return;
-			}
-
 			openInEditor();
 		},
-		[canRenameThisSequence, openInEditor],
+		[canOpenInEditor, openInEditor],
 	);
 
 	const canRenameSelectedSequence =
@@ -1053,11 +1052,7 @@ export const TimelineSequenceItem: React.FC<{
 			onDragLeave={canDropEffect ? onEffectDragLeave : undefined}
 			onDragOver={canDropEffect ? onEffectDragOver : undefined}
 			onDrop={canDropEffect ? onEffectDrop : undefined}
-			onDoubleClick={
-				canRenameThisSequence || canOpenInEditor
-					? onSequenceDoubleClick
-					: undefined
-			}
+			onDoubleClick={canOpenInEditor ? onShowInEditorDoubleClick : undefined}
 		>
 			<div style={labelContainerStyle}>
 				<TimelineSequenceName


### PR DESCRIPTION
## Summary

- Restore opening a timeline layer in the configured editor on double-click
- Keep modifier-key double-click handling unchanged
- Keep sequence renaming available through its existing dedicated actions

## Validation

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`

Closes #9057
