### PR TITLE
`@remotion/studio-server`: Default scale keyframes to perceptual output

### DIFF
--- a/packages/core/src/interactivity-schema.ts
+++ b/packages/core/src/interactivity-schema.ts
@@ -1,3 +1,5 @@
+import type {InterpolateOutputOption} from './interpolate.js';
+
 export type HiddenFieldSchema = {
 	type: 'hidden';
 	keyframable?: boolean;
@@ -12,6 +14,7 @@ export type NumberFieldSchema = {
 	description?: string;
 	hiddenFromList: boolean;
 	keyframable?: boolean;
+	defaultKeyframeOutput?: InterpolateOutputOption;
 };
 
 export type BooleanFieldSchema = {
@@ -63,6 +66,7 @@ export type ScaleFieldSchema = {
 	default: number | string | undefined;
 	description?: string;
 	keyframable?: boolean;
+	defaultKeyframeOutput?: InterpolateOutputOption;
 };
 
 export type UvCoordinateFieldSchema = {
@@ -118,7 +122,11 @@ export type EnumFieldSchema = {
 
 export type NumberArrayItemSchema = Omit<
 	NumberFieldSchema,
-	'default' | 'description' | 'hiddenFromList' | 'keyframable'
+	| 'default'
+	| 'description'
+	| 'hiddenFromList'
+	| 'keyframable'
+	| 'defaultKeyframeOutput'
 >;
 
 export type BooleanArrayItemSchema = Omit<
@@ -218,6 +226,7 @@ export const transformSchema = {
 		step: 0.01,
 		default: 1,
 		description: 'Scale',
+		defaultKeyframeOutput: 'perceptual-scale',
 	},
 	'style.rotate': {
 		type: 'rotation-css',

--- a/packages/docs/docs/interactivity-schema.mdx
+++ b/packages/docs/docs/interactivity-schema.mdx
@@ -205,6 +205,14 @@ Default: `true` for `number`, `boolean`, `rotation-css`, `rotation-degrees`, `tr
 
 Set `keyframable: false` on a keyframable field to show a static control.
 
+### `defaultKeyframeOutput?`<AvailableFrom v="4.0.490" />
+
+Applies to `number` and `scale` fields.
+
+Controls the [`output`](/docs/interpolate#output) option used when Remotion Studio turns a static value into an [`interpolate()`](/docs/interpolate) call. Default: `'linear'`.
+
+Set it to `'perceptual-scale'` for values representing scale. Existing interpolations keep their current output setting.
+
 ### `min?`
 
 The minimum value for numeric controls.

--- a/packages/effects/src/scale/index.ts
+++ b/packages/effects/src/scale/index.ts
@@ -16,6 +16,7 @@ const scaleSchema = {
 		default: 1,
 		description: 'Factor',
 		hiddenFromList: false,
+		defaultKeyframeOutput: 'perceptual-scale',
 	},
 	horizontal: {
 		type: 'boolean',

--- a/packages/effects/src/test/scale.test.ts
+++ b/packages/effects/src/test/scale.test.ts
@@ -12,6 +12,12 @@ describe('scale', () => {
 		).not.toThrow();
 	});
 
+	it('should default keyframes to perceptual scale output', () => {
+		expect(scale({scale: 1}).definition.schema.scale).toMatchObject({
+			defaultKeyframeOutput: 'perceptual-scale',
+		});
+	});
+
 	it('should accept valid params with non-uniform scaling', () => {
 		expect(() =>
 			scale({scale: 0.5, horizontal: false, vertical: true}),

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -340,14 +340,25 @@ const createFrameExpression = (frame: number): ExpressionKind => {
 	return parseValueExpression(frame);
 };
 
-const createClampOptionsExpression = (): ExpressionKind => {
-	return b.objectExpression([
+const createClampOptionsExpression = ({key}: {key: string}): ExpressionKind => {
+	const properties = [
 		b.objectProperty(b.identifier('extrapolateLeft'), b.stringLiteral('clamp')),
 		b.objectProperty(
 			b.identifier('extrapolateRight'),
 			b.stringLiteral('clamp'),
 		),
-	]) as ExpressionKind;
+	];
+
+	if (key === 'style.scale') {
+		properties.push(
+			b.objectProperty(
+				b.identifier('output'),
+				b.stringLiteral('perceptual-scale'),
+			),
+		);
+	}
+
+	return b.objectExpression(properties) as ExpressionKind;
 };
 
 const createEmptyOptionsExpression = (): ObjectExpression =>
@@ -1083,7 +1094,7 @@ const addKeyframe = ({
 	const extraArgs =
 		callee.type === 'Identifier' && callee.name === 'interpolateColors'
 			? []
-			: [createClampOptionsExpression()];
+			: [createClampOptionsExpression({key})];
 
 	return {
 		expression: createInterpolateExpression({

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -340,7 +340,11 @@ const createFrameExpression = (frame: number): ExpressionKind => {
 	return parseValueExpression(frame);
 };
 
-const createClampOptionsExpression = ({key}: {key: string}): ExpressionKind => {
+const createClampOptionsExpression = ({
+	defaultOutput,
+}: {
+	defaultOutput: InterpolateOutputOption | null;
+}): ExpressionKind => {
 	const properties = [
 		b.objectProperty(b.identifier('extrapolateLeft'), b.stringLiteral('clamp')),
 		b.objectProperty(
@@ -349,12 +353,9 @@ const createClampOptionsExpression = ({key}: {key: string}): ExpressionKind => {
 		),
 	];
 
-	if (key === 'style.scale') {
+	if (defaultOutput !== null && defaultOutput !== 'linear') {
 		properties.push(
-			b.objectProperty(
-				b.identifier('output'),
-				b.stringLiteral('perceptual-scale'),
-			),
+			b.objectProperty(b.identifier('output'), b.stringLiteral(defaultOutput)),
 		);
 	}
 
@@ -1094,7 +1095,11 @@ const addKeyframe = ({
 	const extraArgs =
 		callee.type === 'Identifier' && callee.name === 'interpolateColors'
 			? []
-			: [createClampOptionsExpression({key})];
+			: [
+					createClampOptionsExpression({
+						defaultOutput: getDefaultKeyframeOutput({schema, key}),
+					}),
+				];
 
 	return {
 		expression: createInterpolateExpression({
@@ -1399,6 +1404,24 @@ const findFieldInSchema = (
 	}
 
 	return undefined;
+};
+
+const getDefaultKeyframeOutput = ({
+	schema,
+	key,
+}: {
+	schema: InteractivitySchema | null;
+	key: string;
+}): InterpolateOutputOption | null => {
+	const field = schema ? findFieldInSchema(schema, key) : undefined;
+	if (
+		(field?.type === 'number' || field?.type === 'scale') &&
+		field.defaultKeyframeOutput !== undefined
+	) {
+		return field.defaultKeyframeOutput;
+	}
+
+	return key === 'style.scale' ? 'perceptual-scale' : null;
 };
 
 const getInitialValueForMissingProp = ({

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -756,6 +756,7 @@ test('updateSequenceKeyframes converts a static value to a single-keyframe inter
 	expect(output).toContain('opacity: interpolate(frame, [0], [0.75], {');
 	expect(output).toContain("extrapolateLeft: 'clamp'");
 	expect(output).toContain("extrapolateRight: 'clamp'");
+	expect(output).not.toContain('perceptual-scale');
 });
 
 test('updateSequenceKeyframes adds a missing nested prop before keyframing it', async () => {
@@ -787,6 +788,7 @@ export const Example: React.FC = () => {
 	expect(output).toContain('scale: interpolate(frame, [30], [2], {');
 	expect(output).toContain("extrapolateLeft: 'clamp'");
 	expect(output).toContain("extrapolateRight: 'clamp'");
+	expect(output).toContain("output: 'perceptual-scale'");
 });
 
 test('updateSequenceKeyframes adds a keyframe to an existing color interpolation', async () => {

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -102,6 +102,27 @@ export const Comp = () => {
 };
 `;
 
+const scaleEffectInput = `import {scale} from '@remotion/effects/scale';
+import {HtmlInCanvas} from '@remotion/html-in-canvas';
+
+export const Comp = () => {
+	return (
+		<HtmlInCanvas effects={[scale({scale: 1})]}>
+			hi
+		</HtmlInCanvas>
+	);
+};
+`;
+
+const scaleEffectSchema = {
+	scale: {
+		type: 'number',
+		default: 1,
+		hiddenFromList: false,
+		defaultKeyframeOutput: 'perceptual-scale',
+	},
+} satisfies InteractivitySchema;
+
 const waveSchema = {
 	phase: {
 		type: 'number',
@@ -1333,6 +1354,28 @@ test('updateEffectKeyframes converts a static value to a clamped interpolation',
 	expect(serialized).toContain('amount: interpolate(frame, [40], [0.6], {');
 	expect(serialized).toContain('extrapolateLeft: "clamp"');
 	expect(serialized).toContain('extrapolateRight: "clamp"');
+	expect(serialized).not.toContain('perceptual-scale');
+});
+
+test('updateEffectKeyframes uses the schema keyframe output default', () => {
+	const {serialized} = updateEffectKeyframesAst({
+		input: scaleEffectInput,
+		sequenceNodePath: lineColumnToNodePath(
+			scaleEffectInput,
+			getLine(scaleEffectInput, '<HtmlInCanvas'),
+		),
+		effectIndex: 0,
+		schema: scaleEffectSchema,
+		updates: [
+			{
+				key: 'scale',
+				operation: {type: 'add', frame: 40, value: 2},
+			},
+		],
+	});
+
+	expect(serialized).toContain('scale: interpolate(frame, [40], [2], {');
+	expect(serialized).toContain('output: "perceptual-scale"');
 });
 
 test('updateEffectKeyframes adds a missing prop before keyframing it', () => {


### PR DESCRIPTION
## Summary

- default newly created `style.scale` keyframes to perceptual scale output
- allow numeric and scale schema fields to define `defaultKeyframeOutput`
- opt the `scale()` effect into perceptual scale keyframes
- keep existing scale interpolations and other numeric style properties unchanged
- cover effect and style perceptual defaults plus linear controls with regression assertions
- document `defaultKeyframeOutput` in the `InteractivitySchema` reference

## Testing

- `bun test packages/effects/src/test/scale.test.ts packages/studio-server/src/test/update-keyframes.test.ts`
- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun run lint`

Closes #8995
