### PR TITLE
`@remotion/it-tests`: Retry flaky AAC rendering test

### DIFF
--- a/packages/it-tests/src/rendering/rendering.test.ts
+++ b/packages/it-tests/src/rendering/rendering.test.ts
@@ -358,6 +358,7 @@ test(
 	},
 	{
 		timeout: 30000,
+		retry: 3,
 	},
 );
 


### PR DESCRIPTION
## Summary

Adds three retries to the AAC rendering integration test, matching the neighboring MP3 test.

The test has intermittently exceeded its 30-second timeout on Windows while succeeding on rerun.

## Testing

- `bun test src/rendering/rendering.test.ts --run --timeout 60000 --test-name-pattern 'Should be able to render a AAC audio file'`
- `bun run build`
- `bun run stylecheck`


References #8375.
