### PR TITLE
`@remotion/studio-server`: Default inserted Solids to gray

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -897,6 +897,7 @@ const createSolidElement = ({
 			[
 				createNumberAttribute('width', width),
 				createNumberAttribute('height', height),
+				createStringAttribute('color', 'gray'),
 				createPositionAbsoluteStyleAttribute(position),
 			],
 			true,

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -537,6 +537,7 @@ test('inserts a Solid into the resolved composition component', async () => {
 		expect(result.output).toContain('<Solid');
 		expect(result.output).toContain('width={1280}');
 		expect(result.output).toContain('height={720}');
+		expect(result.output).toContain('color="gray"');
 		expect(result.output).toContain("position: 'absolute'");
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});


### PR DESCRIPTION
## Summary

- make solids inserted from the Studio context menu visible by default
- generate `color="gray"` for newly inserted `<Solid>` elements
- cover the generated color in the insertion test

## Validation

- `bun test src/test/resolve-composition-component.test.ts` in `packages/studio-server`
- `bun run build`
- `bun run stylecheck`

Closes #9056
