### PR TITLE
`@remotion/media`: Throw a helpful error when ProRes decoding is not …

### DIFF
--- a/packages/media/src/audio/audio-for-rendering.tsx
+++ b/packages/media/src/audio/audio-for-rendering.tsx
@@ -188,6 +188,12 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 					);
 				}
 
+				if (result.type === 'cannot-decode-prores') {
+					throw new Error(
+						`Encountered ProRes media for ${src}. But this should never happen, since you used the <Audio> tag. Please report this as a bug.`,
+					);
+				}
+
 				if (result.type === 'network-error') {
 					handleError(
 						new Error(`Network error fetching ${src}.`),

--- a/packages/media/src/extract-frame-and-audio.ts
+++ b/packages/media/src/extract-frame-and-audio.ts
@@ -82,6 +82,13 @@ export const extractFrameAndAudio = async ({
 			};
 		}
 
+		if (video?.type === 'cannot-decode-prores') {
+			return {
+				type: 'cannot-decode-prores',
+				durationInSeconds: video.durationInSeconds,
+			};
+		}
+
 		if (video?.type === 'unknown-container-format') {
 			return {type: 'unknown-container-format'};
 		}

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -35,6 +35,7 @@ export type MediaPlayerInitResult =
 	| {type: 'success'; durationInSeconds: number}
 	| {type: 'unknown-container-format'}
 	| {type: 'cannot-decode'}
+	| {type: 'cannot-decode-prores'}
 	| {type: 'network-error'}
 	| {type: 'no-tracks'}
 	| {type: 'disposed'};
@@ -321,6 +322,10 @@ export class MediaPlayer {
 				const canDecode = await videoTrack.canDecode();
 
 				if (!canDecode) {
+					if (videoTrack.codec === 'prores') {
+						return {type: 'cannot-decode-prores'};
+					}
+
 					return {type: 'cannot-decode'};
 				}
 

--- a/packages/media/src/prores-error.ts
+++ b/packages/media/src/prores-error.ts
@@ -1,0 +1,14 @@
+const PRORES_DOCS_URL = 'https://www.remotion.dev/docs/videos/prores';
+
+// Message shown when @remotion/media encounters a ProRes source but the
+// ProRes decoder has not been registered. Kept specific so users don't
+// confuse decoding a ProRes *source* (this case) with exporting to ProRes.
+export const proresDecoderNotEnabledMessage = (src: string) => {
+	return (
+		`Cannot decode "${src}": it is encoded with Apple ProRes, which WebCodecs does not support natively. ` +
+		`ProRes decoding is not enabled by default. Register the ProRes decoder by calling ` +
+		`registerProresDecoder() from "@mediabunny/prores" in your entry point, before registerRoot(). ` +
+		`See ${PRORES_DOCS_URL}. ` +
+		`(This is required to decode a ProRes source for both preview and rendering — it is unrelated to exporting a video as ProRes.)`
+	);
+};

--- a/packages/media/src/test/browser.test.ts
+++ b/packages/media/src/test/browser.test.ts
@@ -27,6 +27,10 @@ test('Should be able to extract a frame', async () => {
 		throw new Error('Cannot decode');
 	}
 
+	if (result.type === 'cannot-decode-prores') {
+		throw new Error('Cannot decode ProRes');
+	}
+
 	if (result.type === 'network-error') {
 		throw new Error('Network error');
 	}
@@ -77,6 +81,10 @@ test('Should be able to extract the last frame', async () => {
 
 	if (result.type === 'cannot-decode') {
 		throw new Error('Cannot decode');
+	}
+
+	if (result.type === 'cannot-decode-prores') {
+		throw new Error('Cannot decode ProRes');
 	}
 
 	if (result.type === 'network-error') {
@@ -160,6 +168,10 @@ test('Should be apply volume correctly', async () => {
 		throw new Error('Cannot decode');
 	}
 
+	if (result.type === 'cannot-decode-prores') {
+		throw new Error('Cannot decode ProRes');
+	}
+
 	if (result.type === 'network-error') {
 		throw new Error('Network error');
 	}
@@ -213,6 +225,10 @@ test('Should be able to loop', async () => {
 
 	if (result.type === 'cannot-decode') {
 		throw new Error('Cannot decode');
+	}
+
+	if (result.type === 'cannot-decode-prores') {
+		throw new Error('Cannot decode ProRes');
 	}
 
 	if (result.type === 'network-error') {

--- a/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
+++ b/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
@@ -22,6 +22,11 @@ export type MessageFromMainTab =
 			durationInSeconds: number | null;
 	  }
 	| {
+			type: 'response-cannot-decode-prores';
+			id: string;
+			durationInSeconds: number | null;
+	  }
+	| {
 			type: 'response-cannot-decode-alpha';
 			id: string;
 			durationInSeconds: number | null;
@@ -117,6 +122,19 @@ export const addBroadcastChannelListener = () => {
 						};
 
 						window.remotion_broadcastChannel!.postMessage(cannotDecodeResponse);
+						return;
+					}
+
+					if (result.type === 'cannot-decode-prores') {
+						const cannotDecodeProresResponse: MessageFromMainTab = {
+							type: 'response-cannot-decode-prores',
+							id: data.id,
+							durationInSeconds: result.durationInSeconds,
+						};
+
+						window.remotion_broadcastChannel!.postMessage(
+							cannotDecodeProresResponse,
+						);
 						return;
 					}
 

--- a/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
+++ b/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
@@ -22,6 +22,7 @@ export type ExtractFrameViaBroadcastChannelResult =
 			durationInSeconds: number | null;
 	  }
 	| {type: 'cannot-decode'; durationInSeconds: number | null}
+	| {type: 'cannot-decode-prores'; durationInSeconds: number | null}
 	| {type: 'cannot-decode-alpha'; durationInSeconds: number | null}
 	| {type: 'network-error'}
 	| {type: 'unknown-container-format'};
@@ -95,6 +96,7 @@ export const extractFrameViaBroadcastChannel = async ({
 				durationInSeconds: number | null;
 		  }
 		| {type: 'cannot-decode'; durationInSeconds: number | null}
+		| {type: 'cannot-decode-prores'; durationInSeconds: number | null}
 		| {type: 'cannot-decode-alpha'; durationInSeconds: number | null}
 		| {type: 'network-error'}
 		| {type: 'unknown-container-format'}
@@ -142,6 +144,18 @@ export const extractFrameViaBroadcastChannel = async ({
 			if (data.type === 'response-cannot-decode') {
 				resolve({
 					type: 'cannot-decode',
+					durationInSeconds: data.durationInSeconds,
+				});
+				window.remotion_broadcastChannel!.removeEventListener(
+					'message',
+					onMessage,
+				);
+				return;
+			}
+
+			if (data.type === 'response-cannot-decode-prores') {
+				resolve({
+					type: 'cannot-decode-prores',
 					durationInSeconds: data.durationInSeconds,
 				});
 				window.remotion_broadcastChannel!.removeEventListener(

--- a/packages/media/src/video-extraction/extract-frame.ts
+++ b/packages/media/src/video-extraction/extract-frame.ts
@@ -12,6 +12,7 @@ type ExtractFrameResult =
 			durationInSeconds: number | null;
 	  }
 	| {type: 'cannot-decode'; durationInSeconds: number | null}
+	| {type: 'cannot-decode-prores'; durationInSeconds: number | null}
 	| {type: 'cannot-decode-alpha'; durationInSeconds: number | null}
 	| {type: 'unknown-container-format'}
 	| {type: 'network-error'};
@@ -60,6 +61,13 @@ const extractFrameInternal = async ({
 
 	if (video === 'cannot-decode') {
 		return {type: 'cannot-decode', durationInSeconds: mediaDurationInSeconds};
+	}
+
+	if (video === 'cannot-decode-prores') {
+		return {
+			type: 'cannot-decode-prores',
+			durationInSeconds: mediaDurationInSeconds,
+		};
 	}
 
 	if (video === 'unknown-container-format') {

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -37,6 +37,7 @@ export type VideoSinkResult =
 	| VideoSinks
 	| 'no-video-track'
 	| 'cannot-decode'
+	| 'cannot-decode-prores'
 	| 'cannot-decode-alpha'
 	| 'unknown-container-format'
 	| 'network-error';
@@ -108,6 +109,10 @@ export const getSinks = async (
 		const canDecode = await videoTrack.canDecode();
 
 		if (!canDecode) {
+			if (videoTrack.codec === 'prores') {
+				return 'cannot-decode-prores';
+			}
+
 			return 'cannot-decode';
 		}
 

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -24,6 +24,7 @@ import {
 import {getTimeInSeconds} from '../get-time-in-seconds';
 import {MediaPlayer} from '../media-player';
 import {type MediaOnError, callOnErrorAndResolve} from '../on-error';
+import {proresDecoderNotEnabledMessage} from '../prores-error';
 import type {MediaRequestInit} from '../request-init';
 import {useCommonEffects} from '../use-common-effects';
 import type {
@@ -307,11 +308,18 @@ const VideoForPreviewAssertedShowing: React.FC<
 						return;
 					}
 
-					const handleError = (error: Error, fallbackMessage: string) => {
+					const handleError = (
+						error: Error,
+						fallbackMessage: string,
+						// ProRes forces this to true so it hard-fails by default instead
+						// of silently falling back, while still honoring an explicit
+						// onError override.
+						disallowFallback: boolean = disallowFallbackToOffthreadVideo,
+					) => {
 						const [action, errorToUse] = callOnErrorAndResolve({
 							onError: onErrorRef.current,
 							error,
-							disallowFallback: disallowFallbackToOffthreadVideo,
+							disallowFallback,
 							isClientSideRendering: false,
 							clientSideError: error,
 						});
@@ -347,6 +355,17 @@ const VideoForPreviewAssertedShowing: React.FC<
 						handleError(
 							new Error(`Cannot decode ${preloadedSrc}.`),
 							`Cannot decode ${preloadedSrc}, falling back to <OffthreadVideo>`,
+						);
+						return;
+					}
+
+					if (result.type === 'cannot-decode-prores') {
+						// ProRes defaults to a hard error (registering the decoder is the
+						// actionable fix), regardless of disallowFallbackToOffthreadVideo.
+						handleError(
+							new Error(proresDecoderNotEnabledMessage(preloadedSrc)),
+							`${proresDecoderNotEnabledMessage(preloadedSrc)} Falling back to <OffthreadVideo>.`,
+							true,
 						);
 						return;
 					}

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -26,6 +26,7 @@ import {applyVolume} from '../convert-audiodata/apply-volume';
 import {getTargetSampleRate} from '../convert-audiodata/resample-audiodata';
 import {frameForVolumeProp} from '../looped-frame';
 import {type MediaOnError, callOnErrorAndResolve} from '../on-error';
+import {proresDecoderNotEnabledMessage} from '../prores-error';
 import type {MediaRequestInit} from '../request-init';
 import {extractFrameViaBroadcastChannel} from '../video-extraction/extract-frame-via-broadcast-channel';
 import type {
@@ -209,6 +210,10 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 					clientSideError: Error,
 					fallbackMessage: string,
 					mediaDurationInSeconds: number | null,
+					// ProRes forces this to true so it hard-fails by default instead
+					// of silently falling back, while still honoring an explicit
+					// onError override.
+					disallowFallback: boolean = disallowFallbackToOffthreadVideo,
 				) => {
 					if (environment.isClientSideRendering) {
 						cancelRender(clientSideError);
@@ -218,7 +223,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 					const [action, errorToUse] = callOnErrorAndResolve({
 						onError,
 						error: err,
-						disallowFallback: disallowFallbackToOffthreadVideo,
+						disallowFallback,
 						isClientSideRendering: environment.isClientSideRendering,
 						clientSideError: err,
 					});
@@ -261,6 +266,21 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 						),
 						`Cannot decode ${src}, falling back to <OffthreadVideo>`,
 						result.durationInSeconds,
+					);
+					return;
+				}
+
+				if (result.type === 'cannot-decode-prores') {
+					// ProRes defaults to a hard error (registering the decoder is the
+					// actionable fix), regardless of disallowFallbackToOffthreadVideo.
+					// An explicit onError returning 'fallback' can still opt into
+					// <OffthreadVideo>, which decodes ProRes via the compositor.
+					handleError(
+						new Error(proresDecoderNotEnabledMessage(src)),
+						new Error(proresDecoderNotEnabledMessage(src)),
+						`${proresDecoderNotEnabledMessage(src)} Falling back to <OffthreadVideo>.`,
+						result.durationInSeconds,
+						true,
 					);
 					return;
 				}


### PR DESCRIPTION
## Summary
- Detects ProRes sources (`videoTrack.codec === 'prores'`) that the browser can't decode, at both decode sites — preview (`media-player.ts`) and render (`get-frames-since-keyframe.ts`).
- Replaces the generic "could not be decoded" fallback with a targeted error naming `registerProresDecoder()` from `@mediabunny/prores` and linking to `/docs/videos/prores`.
- Message explicitly distinguishes decoding a ProRes *source* from *exporting* ProRes, so playback support isn't confused with export support.
- ProRes now **hard-fails by default** (throws in preview, `cancelRender` in render), ignoring `disallowFallbackToOffthreadVideo`.
- Routed through the standard error pipeline, so `onError` still fires and an explicit `onError` returning `'fallback'` can opt back into `<OffthreadVideo>`.
- New `cannot-decode-prores` result threaded as a typed message across the broadcast channel (survives the worker→main-tab hop, unlike an error class).
- Breaking: renders that silently relied on the OffthreadVideo/FFmpeg fallback for ProRes now throw until the decoder is registered.

## Verification
- `tsc --noEmit` on `@remotion/media` passes with no new errors (3 remaining are pre-existing on `main`).
- `oxfmt src` reports formatting clean.
- `eslint src` reports 0 errors (1 non-blocking max-params warning, consistent with existing code in this package).
- Both preview and render paths verified to detect and hard-throw independently.