### PR TITLE
`@remotion/media`: Throw a helpful error when ProRes decoding is not enabled

### DIFF
--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -277,6 +277,14 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 						return;
 					}
 
+					if (result.type === 'cannot-decode-prores') {
+						// ProRes is video-only, so the MediaPlayer never returns this for
+						// an audio track. Guard it to keep the union exhaustive.
+						throw new Error(
+							`Encountered ProRes media for ${preloadedSrc}. But this should never happen, since you used the <Audio> tag. Please report this as a bug.`,
+						);
+					}
+
 					if (result.type === 'success') {
 						setMediaPlayerReady(true);
 						setMediaDurationInSeconds(result.durationInSeconds);

--- a/packages/media/src/audio/audio-for-rendering.tsx
+++ b/packages/media/src/audio/audio-for-rendering.tsx
@@ -188,6 +188,12 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 					);
 				}
 
+				if (result.type === 'cannot-decode-prores') {
+					throw new Error(
+						`Encountered ProRes media for ${src}. But this should never happen, since you used the <Audio> tag. Please report this as a bug.`,
+					);
+				}
+
 				if (result.type === 'network-error') {
 					handleError(
 						new Error(`Network error fetching ${src}.`),

--- a/packages/media/src/extract-frame-and-audio.ts
+++ b/packages/media/src/extract-frame-and-audio.ts
@@ -82,6 +82,13 @@ export const extractFrameAndAudio = async ({
 			};
 		}
 
+		if (video?.type === 'cannot-decode-prores') {
+			return {
+				type: 'cannot-decode-prores',
+				durationInSeconds: video.durationInSeconds,
+			};
+		}
+
 		if (video?.type === 'unknown-container-format') {
 			return {type: 'unknown-container-format'};
 		}

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -35,6 +35,7 @@ export type MediaPlayerInitResult =
 	| {type: 'success'; durationInSeconds: number}
 	| {type: 'unknown-container-format'}
 	| {type: 'cannot-decode'}
+	| {type: 'cannot-decode-prores'}
 	| {type: 'network-error'}
 	| {type: 'no-tracks'}
 	| {type: 'disposed'};
@@ -321,6 +322,10 @@ export class MediaPlayer {
 				const canDecode = await videoTrack.canDecode();
 
 				if (!canDecode) {
+					if (videoTrack.codec === 'prores') {
+						return {type: 'cannot-decode-prores'};
+					}
+
 					return {type: 'cannot-decode'};
 				}
 

--- a/packages/media/src/prores-error.ts
+++ b/packages/media/src/prores-error.ts
@@ -1,0 +1,27 @@
+const PRORES_DOCS_URL = 'https://www.remotion.dev/docs/videos/prores';
+
+// Message shown when @remotion/media encounters a ProRes source but the
+// ProRes decoder has not been registered. Kept specific so users don't
+// confuse decoding a ProRes *source* (this case) with exporting to ProRes.
+export const proresDecoderNotEnabledMessage = (src: string) => {
+	return (
+		`Cannot decode "${src}": it is encoded with Apple ProRes, which WebCodecs does not support natively. ` +
+		`ProRes decoding is not enabled by default. Register the ProRes decoder by calling ` +
+		`registerProresDecoder() from "@mediabunny/prores" in your entry point, before registerRoot(). ` +
+		`See ${PRORES_DOCS_URL}. ` +
+		`(This is required to decode a ProRes source for both preview and rendering — it is unrelated to exporting a video as ProRes.)`
+	);
+};
+
+// Thrown when @remotion/media cannot decode a ProRes source because the decoder
+// is not registered. This is an unrecoverable error: unlike a generic decode
+// failure it must NOT fall back to <OffthreadVideo> (rendering) or a native
+// <video> (preview), because neither can decode ProRes. Registering the decoder
+// is the only fix. The error type lets the fallback handlers recognize it and
+// rethrow instead of silently falling back.
+export class ProResDecoderNotEnabledError extends Error {
+	constructor(src: string) {
+		super(proresDecoderNotEnabledMessage(src));
+		this.name = 'ProResDecoderNotEnabledError';
+	}
+}

--- a/packages/media/src/test/browser.test.ts
+++ b/packages/media/src/test/browser.test.ts
@@ -27,6 +27,10 @@ test('Should be able to extract a frame', async () => {
 		throw new Error('Cannot decode');
 	}
 
+	if (result.type === 'cannot-decode-prores') {
+		throw new Error('Cannot decode ProRes');
+	}
+
 	if (result.type === 'network-error') {
 		throw new Error('Network error');
 	}
@@ -77,6 +81,10 @@ test('Should be able to extract the last frame', async () => {
 
 	if (result.type === 'cannot-decode') {
 		throw new Error('Cannot decode');
+	}
+
+	if (result.type === 'cannot-decode-prores') {
+		throw new Error('Cannot decode ProRes');
 	}
 
 	if (result.type === 'network-error') {
@@ -160,6 +168,10 @@ test('Should be apply volume correctly', async () => {
 		throw new Error('Cannot decode');
 	}
 
+	if (result.type === 'cannot-decode-prores') {
+		throw new Error('Cannot decode ProRes');
+	}
+
 	if (result.type === 'network-error') {
 		throw new Error('Network error');
 	}
@@ -213,6 +225,10 @@ test('Should be able to loop', async () => {
 
 	if (result.type === 'cannot-decode') {
 		throw new Error('Cannot decode');
+	}
+
+	if (result.type === 'cannot-decode-prores') {
+		throw new Error('Cannot decode ProRes');
 	}
 
 	if (result.type === 'network-error') {

--- a/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
+++ b/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
@@ -22,6 +22,11 @@ export type MessageFromMainTab =
 			durationInSeconds: number | null;
 	  }
 	| {
+			type: 'response-cannot-decode-prores';
+			id: string;
+			durationInSeconds: number | null;
+	  }
+	| {
 			type: 'response-cannot-decode-alpha';
 			id: string;
 			durationInSeconds: number | null;
@@ -117,6 +122,19 @@ export const addBroadcastChannelListener = () => {
 						};
 
 						window.remotion_broadcastChannel!.postMessage(cannotDecodeResponse);
+						return;
+					}
+
+					if (result.type === 'cannot-decode-prores') {
+						const cannotDecodeProresResponse: MessageFromMainTab = {
+							type: 'response-cannot-decode-prores',
+							id: data.id,
+							durationInSeconds: result.durationInSeconds,
+						};
+
+						window.remotion_broadcastChannel!.postMessage(
+							cannotDecodeProresResponse,
+						);
 						return;
 					}
 

--- a/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
+++ b/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
@@ -22,6 +22,7 @@ export type ExtractFrameViaBroadcastChannelResult =
 			durationInSeconds: number | null;
 	  }
 	| {type: 'cannot-decode'; durationInSeconds: number | null}
+	| {type: 'cannot-decode-prores'; durationInSeconds: number | null}
 	| {type: 'cannot-decode-alpha'; durationInSeconds: number | null}
 	| {type: 'network-error'}
 	| {type: 'unknown-container-format'};
@@ -95,6 +96,7 @@ export const extractFrameViaBroadcastChannel = async ({
 				durationInSeconds: number | null;
 		  }
 		| {type: 'cannot-decode'; durationInSeconds: number | null}
+		| {type: 'cannot-decode-prores'; durationInSeconds: number | null}
 		| {type: 'cannot-decode-alpha'; durationInSeconds: number | null}
 		| {type: 'network-error'}
 		| {type: 'unknown-container-format'}
@@ -142,6 +144,18 @@ export const extractFrameViaBroadcastChannel = async ({
 			if (data.type === 'response-cannot-decode') {
 				resolve({
 					type: 'cannot-decode',
+					durationInSeconds: data.durationInSeconds,
+				});
+				window.remotion_broadcastChannel!.removeEventListener(
+					'message',
+					onMessage,
+				);
+				return;
+			}
+
+			if (data.type === 'response-cannot-decode-prores') {
+				resolve({
+					type: 'cannot-decode-prores',
 					durationInSeconds: data.durationInSeconds,
 				});
 				window.remotion_broadcastChannel!.removeEventListener(

--- a/packages/media/src/video-extraction/extract-frame.ts
+++ b/packages/media/src/video-extraction/extract-frame.ts
@@ -12,6 +12,7 @@ type ExtractFrameResult =
 			durationInSeconds: number | null;
 	  }
 	| {type: 'cannot-decode'; durationInSeconds: number | null}
+	| {type: 'cannot-decode-prores'; durationInSeconds: number | null}
 	| {type: 'cannot-decode-alpha'; durationInSeconds: number | null}
 	| {type: 'unknown-container-format'}
 	| {type: 'network-error'};
@@ -60,6 +61,13 @@ const extractFrameInternal = async ({
 
 	if (video === 'cannot-decode') {
 		return {type: 'cannot-decode', durationInSeconds: mediaDurationInSeconds};
+	}
+
+	if (video === 'cannot-decode-prores') {
+		return {
+			type: 'cannot-decode-prores',
+			durationInSeconds: mediaDurationInSeconds,
+		};
 	}
 
 	if (video === 'unknown-container-format') {

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -37,6 +37,7 @@ export type VideoSinkResult =
 	| VideoSinks
 	| 'no-video-track'
 	| 'cannot-decode'
+	| 'cannot-decode-prores'
 	| 'cannot-decode-alpha'
 	| 'unknown-container-format'
 	| 'network-error';
@@ -108,6 +109,10 @@ export const getSinks = async (
 		const canDecode = await videoTrack.canDecode();
 
 		if (!canDecode) {
+			if (videoTrack.codec === 'prores') {
+				return 'cannot-decode-prores';
+			}
+
 			return 'cannot-decode';
 		}
 

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -24,6 +24,7 @@ import {
 import {getTimeInSeconds} from '../get-time-in-seconds';
 import {MediaPlayer} from '../media-player';
 import {type MediaOnError, callOnErrorAndResolve} from '../on-error';
+import {ProResDecoderNotEnabledError} from '../prores-error';
 import type {MediaRequestInit} from '../request-init';
 import {useCommonEffects} from '../use-common-effects';
 import type {
@@ -351,6 +352,13 @@ const VideoForPreviewAssertedShowing: React.FC<
 						return;
 					}
 
+					if (result.type === 'cannot-decode-prores') {
+						// Unrecoverable: a native <video> can't decode ProRes either, so
+						// we must not fall back. The .catch below notifies onError and
+						// rethrows without falling back.
+						throw new ProResDecoderNotEnabledError(preloadedSrc);
+					}
+
 					if (result.type === 'no-tracks') {
 						handleError(
 							new Error(`No video or audio tracks found for ${preloadedSrc}.`),
@@ -367,6 +375,14 @@ const VideoForPreviewAssertedShowing: React.FC<
 					}
 				})
 				.catch((error) => {
+					// ProRes without a registered decoder is unrecoverable and must not
+					// fall back to a native <video> (which cannot decode it either).
+					// Notify onError once for observability, then rethrow.
+					if (error instanceof ProResDecoderNotEnabledError) {
+						onErrorRef.current?.(error);
+						throw error;
+					}
+
 					const [action, errorToUse] = callOnErrorAndResolve({
 						onError: onErrorRef.current,
 						error,

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -26,6 +26,7 @@ import {applyVolume} from '../convert-audiodata/apply-volume';
 import {getTargetSampleRate} from '../convert-audiodata/resample-audiodata';
 import {frameForVolumeProp} from '../looped-frame';
 import {type MediaOnError, callOnErrorAndResolve} from '../on-error';
+import {ProResDecoderNotEnabledError} from '../prores-error';
 import type {MediaRequestInit} from '../request-init';
 import {extractFrameViaBroadcastChannel} from '../video-extraction/extract-frame-via-broadcast-channel';
 import type {
@@ -262,6 +263,16 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 						`Cannot decode ${src}, falling back to <OffthreadVideo>`,
 						result.durationInSeconds,
 					);
+					return;
+				}
+
+				if (result.type === 'cannot-decode-prores') {
+					// Unrecoverable: ProRes must not silently fall back to
+					// <OffthreadVideo>. Registering the decoder is the only fix.
+					// Notify onError once for observability, then hard-fail.
+					const proresError = new ProResDecoderNotEnabledError(src);
+					onError?.(proresError);
+					cancelRender(proresError);
 					return;
 				}
 


### PR DESCRIPTION
## Summary
- Detects ProRes sources (`videoTrack.codec === 'prores'`) the browser can't decode, at both decode sites preview (`media-player.ts`) and render (`get-frames-since-keyframe.ts`).
- Replaces the generic "could not be decoded" fallback with a targeted error naming `registerProresDecoder()` from `@mediabunny/prores` and linking to `/docs/videos/prores`.
- Message explicitly distinguishes decoding a ProRes *source* from *exporting* ProRes, so playback support isn't confused with export support.
- ProRes is treated as an **unrecoverable** error: it **never** falls back to `<OffthreadVideo>` (render) or a native `<video>` (preview), since neither can decode ProRes  registering the decoder is the only fix.
- Preview throws a dedicated `ProResDecoderNotEnabledError` that the `.catch` recognizes and rethrows (surfacing via the Studio error overlay) instead of resolving to a fallback; render calls `cancelRender`. `onError` is still notified exactly once.
- New `cannot-decode-prores` result threaded as a typed message across the broadcast channel (survives the worker→main-tab hop, unlike an error class).
- renders that previously relied on the silent OffthreadVideo fallback for ProRes now fail until the decoder is registered.

## Verification
- `tsc --noEmit` on `@remotion/media` passes with no new errors.
- `oxfmt src` clean; `eslint src` reports 0 errors.
- Confirmed no error boundary wraps the video components, so the thrown error can't be silently converted back into a fallback.

### Fixes - #8955