### PR TITLE
`@remotion/studio`: Add editable border control to Visual Mode

### DIFF
--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -6,6 +6,7 @@ import type {
 import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
 import {
 	baseSchema,
+	borderSchema,
 	premountSchema,
 	sequenceSchema,
 	textContentSchema,
@@ -139,6 +140,7 @@ const makeRemotionComponentIdentity = ({
 const interactiveElementSchema = {
 	...baseSchema,
 	...transformSchema,
+	...borderSchema,
 	...textSchema,
 	...textContentSchema,
 } as const satisfies InteractivitySchema;
@@ -247,6 +249,7 @@ export const Interactive = {
 	baseSchema,
 	transformSchema,
 	textSchema,
+	borderSchema,
 	premountSchema,
 	sequenceSchema,
 	withSchema,

--- a/packages/core/src/interactivity-schema.ts
+++ b/packages/core/src/interactivity-schema.ts
@@ -98,6 +98,13 @@ export type ColorFieldSchema = {
 	keyframable?: boolean;
 };
 
+export type BorderFieldSchema = {
+	type: 'border';
+	default: string | undefined;
+	description?: string;
+	keyframable?: false;
+};
+
 export type TextContentFieldSchema = {
 	type: 'text-content';
 	default: string;
@@ -195,6 +202,7 @@ export type VisibleFieldSchema =
 	| ScaleFieldSchema
 	| UvCoordinateFieldSchema
 	| ColorFieldSchema
+	| BorderFieldSchema
 	| TextContentFieldSchema
 	| FontFamilyFieldSchema
 	| ArrayFieldSchema
@@ -322,6 +330,15 @@ export const textSchema = {
 		step: 0.1,
 		description: 'Letter spacing',
 		hiddenFromList: false,
+	},
+} as const satisfies InteractivitySchema;
+
+export const borderSchema = {
+	'style.border': {
+		type: 'border',
+		default: undefined,
+		description: 'Border',
+		keyframable: false,
 	},
 } as const satisfies InteractivitySchema;
 

--- a/packages/studio-shared/src/keyframe-interpolation-function.ts
+++ b/packages/studio-shared/src/keyframe-interpolation-function.ts
@@ -27,7 +27,8 @@ export const isInteractivitySchemaFieldKeyframable = (
 		field.type === 'array' ||
 		field.type === 'boolean' ||
 		field.type === 'enum' ||
-		field.type === 'font-family'
+		field.type === 'font-family' ||
+		field.type === 'border'
 	) {
 		return false;
 	}

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -115,6 +115,7 @@ const SUPPORTED_SCHEMA_TYPES = [
 	'scale',
 	'uv-coordinate',
 	'color',
+	'border',
 	'text-content',
 	'font-family',
 	'array',

--- a/packages/studio/src/components/Timeline/TimelineBorderField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineBorderField.tsx
@@ -1,0 +1,196 @@
+import React, {useCallback, useMemo, useState} from 'react';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
+import type {
+	SchemaFieldInfo,
+	TimelineFieldOnDragValueChange,
+	TimelineFieldOnSave,
+} from '../../helpers/timeline-layout';
+import {ColorPicker} from '../ColorPicker/ColorPicker';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {Combobox} from '../NewComposition/ComboBox';
+import {InputDragger} from '../NewComposition/InputDragger';
+import {
+	BORDER_STYLE_KEYWORDS,
+	parseBorder,
+	serializeBorder,
+	type ParsedBorder,
+} from './timeline-border-utils';
+
+const containerStyle: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: 4,
+};
+
+const widthDraggerStyle: React.CSSProperties = {
+	paddingLeft: 0,
+	width: 44,
+};
+
+const comboboxStyle: React.CSSProperties = {
+	marginLeft: 0,
+};
+
+const swatchStyle: React.CSSProperties = {
+	marginLeft: 2,
+};
+
+const SWATCH_WIDTH = 20;
+const SWATCH_HEIGHT = 15;
+
+export const TimelineBorderField: React.FC<{
+	readonly field: SchemaFieldInfo;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
+	readonly effectiveValue: unknown;
+	readonly onSave: TimelineFieldOnSave;
+	readonly onDragValueChange: TimelineFieldOnDragValueChange;
+	readonly onDragEnd: () => void;
+}> = ({
+	field,
+	propStatus,
+	effectiveValue,
+	onSave,
+	onDragValueChange,
+	onDragEnd,
+}) => {
+	const parsed = useMemo(() => parseBorder(effectiveValue), [effectiveValue]);
+	const [dragWidth, setDragWidth] = useState<number | null>(null);
+
+	const serialize = useCallback(
+		(overrides: Partial<ParsedBorder>): string => {
+			return serializeBorder({...parsed, ...overrides});
+		},
+		[parsed],
+	);
+
+	const saveIfChanged = useCallback(
+		(value: string) => {
+			if (value !== propStatus.codeValue) {
+				return onSave(value);
+			}
+
+			return Promise.resolve();
+		},
+		[onSave, propStatus.codeValue],
+	);
+
+	const widthFormatter = useCallback(
+		(value: number | string) => `${value}${parsed.widthUnit}`,
+		[parsed.widthUnit],
+	);
+
+	const onWidthChange = useCallback(
+		(newVal: number) => {
+			setDragWidth(newVal);
+			onDragValueChange(serialize({width: newVal}));
+		},
+		[onDragValueChange, serialize],
+	);
+
+	const onWidthChangeEnd = useCallback(
+		(newVal: number) => {
+			saveIfChanged(serialize({width: newVal})).finally(() => {
+				setDragWidth(null);
+				onDragEnd();
+			});
+		},
+		[onDragEnd, saveIfChanged, serialize],
+	);
+
+	const onWidthTextChange = useCallback(
+		(newVal: string) => {
+			const parsedValue = Number(newVal);
+			if (Number.isNaN(parsedValue)) {
+				return;
+			}
+
+			setDragWidth(parsedValue);
+			saveIfChanged(serialize({width: parsedValue})).finally(() => {
+				setDragWidth(null);
+			});
+		},
+		[saveIfChanged, serialize],
+	);
+
+	const onStyleSelect = useCallback(
+		(newStyle: string) => {
+			const value = serialize({style: newStyle as ParsedBorder['style']});
+			onDragValueChange(value);
+			saveIfChanged(value).finally(() => {
+				onDragEnd();
+			});
+		},
+		[onDragEnd, onDragValueChange, saveIfChanged, serialize],
+	);
+
+	const styleItems = useMemo<ComboboxValue[]>(() => {
+		return BORDER_STYLE_KEYWORDS.map((keyword) => ({
+			type: 'item',
+			id: keyword,
+			value: keyword,
+			label: keyword,
+			onClick: () => onStyleSelect(keyword),
+			keyHint: null,
+			leftItem: null,
+			subMenu: null,
+			quickSwitcherLabel: null,
+			disabled: false,
+		}));
+	}, [onStyleSelect]);
+
+	const onColorChange = useCallback(
+		(next: string) => {
+			onDragValueChange(serialize({color: next}));
+		},
+		[onDragValueChange, serialize],
+	);
+
+	const onColorChangeComplete = useCallback(
+		(next: string) => {
+			saveIfChanged(serialize({color: next}));
+			onDragEnd();
+		},
+		[onDragEnd, saveIfChanged, serialize],
+	);
+
+	return (
+		<span style={containerStyle}>
+			<InputDragger
+				type="number"
+				value={dragWidth ?? parsed.width}
+				style={widthDraggerStyle}
+				status="ok"
+				small
+				onValueChange={onWidthChange}
+				onValueChangeEnd={onWidthChangeEnd}
+				onTextChange={onWidthTextChange}
+				min={0}
+				max={Infinity}
+				step={1}
+				formatter={widthFormatter}
+				rightAlign={false}
+				snapToStep={false}
+				dragDecimalPlaces={2}
+			/>
+			<Combobox
+				small
+				title={`${field.key} style`}
+				selectedId={parsed.style}
+				values={styleItems}
+				style={comboboxStyle}
+			/>
+			<ColorPicker
+				value={parsed.color}
+				status="ok"
+				onChange={onColorChange}
+				onChangeComplete={onColorChangeComplete}
+				width={SWATCH_WIDTH}
+				height={SWATCH_HEIGHT}
+				disabled={false}
+				name={field.key}
+				title={parsed.color}
+				style={swatchStyle}
+			/>
+		</span>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
@@ -11,6 +11,7 @@ import type {
 	TimelineFieldOnSave,
 } from '../../helpers/timeline-layout';
 import {TimelineBooleanField} from './TimelineBooleanField';
+import {TimelineBorderField} from './TimelineBorderField';
 import {TimelineColorField} from './TimelineColorField';
 import {TimelineEnumField} from './TimelineEnumField';
 import {TimelineFontFamilyField} from './TimelineFontFamilyField';
@@ -176,6 +177,21 @@ export const TimelinePrimitiveFieldValue: React.FC<{
 		return (
 			<span>
 				<TimelineColorField
+					effectiveValue={effectiveValue}
+					field={field}
+					onDragEnd={onDragEnd}
+					onDragValueChange={onDragValueChange}
+					onSave={onSave}
+					propStatus={propStatus}
+				/>
+			</span>
+		);
+	}
+
+	if (field.typeName === 'border') {
+		return (
+			<span>
+				<TimelineBorderField
 					effectiveValue={effectiveValue}
 					field={field}
 					onDragEnd={onDragEnd}

--- a/packages/studio/src/components/Timeline/timeline-border-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-border-utils.ts
@@ -1,0 +1,137 @@
+import {
+	normalizeTimelineNumber,
+	roundToDecimalPlaces,
+} from './timeline-field-utils';
+
+export const BORDER_STYLE_KEYWORDS = [
+	'none',
+	'hidden',
+	'solid',
+	'dashed',
+	'dotted',
+	'double',
+	'groove',
+	'ridge',
+	'inset',
+	'outset',
+] as const;
+
+export type BorderStyleKeyword = (typeof BORDER_STYLE_KEYWORDS)[number];
+
+export type ParsedBorder = {
+	readonly width: number;
+	readonly widthUnit: string;
+	readonly style: BorderStyleKeyword;
+	readonly color: string;
+};
+
+const borderStyleKeywordSet = new Set<string>(BORDER_STYLE_KEYWORDS);
+
+const WIDTH_PATTERN = /^(-?\d*\.?\d+)([a-z%]*)$/i;
+
+// CSS line-width keywords resolve to fixed pixel widths so they can be shown
+// in the numeric width control.
+const LINE_WIDTH_KEYWORDS: Record<string, number> = {
+	thin: 1,
+	medium: 3,
+	thick: 5,
+};
+const borderDecimalPlaces = 2;
+
+export const DEFAULT_BORDER: ParsedBorder = {
+	width: 1,
+	widthUnit: 'px',
+	style: 'solid',
+	color: '#000000',
+};
+
+// Split on whitespace, but keep parenthesized groups (e.g. rgba(24, 24, 27, 0.08))
+// together so the color token is not broken apart.
+const tokenizeBorder = (value: string): string[] => {
+	const tokens: string[] = [];
+	let depth = 0;
+	let current = '';
+
+	for (const char of value.trim()) {
+		if (char === '(') {
+			depth++;
+		} else if (char === ')') {
+			depth = Math.max(0, depth - 1);
+		}
+
+		if (/\s/.test(char) && depth === 0) {
+			if (current !== '') {
+				tokens.push(current);
+				current = '';
+			}
+		} else {
+			current += char;
+		}
+	}
+
+	if (current !== '') {
+		tokens.push(current);
+	}
+
+	return tokens;
+};
+
+export const parseBorder = (value: unknown): ParsedBorder => {
+	if (typeof value !== 'string') {
+		return DEFAULT_BORDER;
+	}
+
+	const tokens = tokenizeBorder(value);
+	if (tokens.length === 0) {
+		return DEFAULT_BORDER;
+	}
+
+	let {width, widthUnit, style} = DEFAULT_BORDER;
+	let styleFound = false;
+	let widthFound = false;
+	const colorTokens: string[] = [];
+
+	for (const token of tokens) {
+		if (!styleFound && borderStyleKeywordSet.has(token.toLowerCase())) {
+			style = token.toLowerCase() as BorderStyleKeyword;
+			styleFound = true;
+			continue;
+		}
+
+		const keywordWidth = LINE_WIDTH_KEYWORDS[token.toLowerCase()];
+		if (!widthFound && keywordWidth !== undefined) {
+			width = keywordWidth;
+			widthUnit = 'px';
+			widthFound = true;
+			continue;
+		}
+
+		const widthMatch = token.match(WIDTH_PATTERN);
+		if (!widthFound && widthMatch) {
+			width = normalizeTimelineNumber(Number(widthMatch[1]));
+			widthUnit = widthMatch[2] === '' ? 'px' : widthMatch[2];
+			widthFound = true;
+			continue;
+		}
+
+		colorTokens.push(token);
+	}
+
+	return {
+		width,
+		widthUnit,
+		style,
+		color:
+			colorTokens.length === 0 ? DEFAULT_BORDER.color : colorTokens.join(' '),
+	};
+};
+
+const formatBorderWidth = (width: number, unit: string): string => {
+	const normalized = normalizeTimelineNumber(width);
+	const rounded = roundToDecimalPlaces(normalized, borderDecimalPlaces);
+	return `${Object.is(rounded, -0) ? 0 : rounded}${unit}`;
+};
+
+export const serializeBorder = (parsed: ParsedBorder): string => {
+	return `${formatBorderWidth(parsed.width, parsed.widthUnit)} ${parsed.style} ${parsed.color}`;
+};

--- a/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
@@ -390,6 +390,11 @@ export const formatTimelineFieldValueForDisplay = ({
 		case 'text-content':
 			return String(value);
 
+		case 'border':
+			return typeof value === 'string'
+				? value
+				: formatUnknownTimelineValueForDisplay(value);
+
 		case 'array':
 		case 'boolean':
 		case 'color':

--- a/packages/studio/src/test/timeline-border-utils.test.ts
+++ b/packages/studio/src/test/timeline-border-utils.test.ts
@@ -1,0 +1,70 @@
+import {expect, test} from 'bun:test';
+import {
+	DEFAULT_BORDER,
+	parseBorder,
+	serializeBorder,
+} from '../components/Timeline/timeline-border-utils';
+
+test('parseBorder parses width, style and rgba color', () => {
+	expect(parseBorder('1px solid rgba(24, 24, 27, 0.08)')).toEqual({
+		width: 1,
+		widthUnit: 'px',
+		style: 'solid',
+		color: 'rgba(24, 24, 27, 0.08)',
+	});
+});
+
+test('parseBorder handles hex color and non-px unit', () => {
+	expect(parseBorder('2.5rem dashed #ff0000')).toEqual({
+		width: 2.5,
+		widthUnit: 'rem',
+		style: 'dashed',
+		color: '#ff0000',
+	});
+});
+
+test('parseBorder resolves line-width keywords to pixel widths', () => {
+	expect(parseBorder('thin solid black')).toEqual({
+		width: 1,
+		widthUnit: 'px',
+		style: 'solid',
+		color: 'black',
+	});
+	expect(parseBorder('medium dashed red')).toEqual({
+		width: 3,
+		widthUnit: 'px',
+		style: 'dashed',
+		color: 'red',
+	});
+	expect(parseBorder('thick solid #fff').width).toBe(5);
+});
+
+test('parseBorder falls back to defaults for non-strings', () => {
+	expect(parseBorder(undefined)).toEqual(DEFAULT_BORDER);
+	expect(parseBorder(42)).toEqual(DEFAULT_BORDER);
+});
+
+test('parseBorder keeps a unitless width', () => {
+	expect(parseBorder('0 solid black')).toEqual({
+		width: 0,
+		widthUnit: 'px',
+		style: 'solid',
+		color: 'black',
+	});
+});
+
+test('serializeBorder round-trips a parsed border', () => {
+	const value = '1px solid rgba(24, 24, 27, 0.08)';
+	expect(serializeBorder(parseBorder(value))).toBe(value);
+});
+
+test('serializeBorder normalizes floating point noise', () => {
+	expect(
+		serializeBorder({
+			width: 0.1 + 0.2,
+			widthUnit: 'px',
+			style: 'solid',
+			color: '#000000',
+		}),
+	).toBe('0.3px solid #000000');
+});


### PR DESCRIPTION
## Summary
- Adds a `border` field type so the CSS `border` shorthand is editable in Studio Visual Mode
- Control decomposes the shorthand into width (draggable), style (dropdown), and color (picker)
- Re-serializes edits to a single string saved back to source  inserts a `border` on elements that don't have one yet
- `remotion`: `BorderFieldSchema` + `borderSchema`, wired into the interactive element schema
- `@remotion/studio-shared`: registers the `border` type, marks it non-keyframable
- `@remotion/studio`: `TimelineBorderField` + parse/serialize utils, display formatting, and routing

## Verification
- Typecheck clean (core/studio-shared/studio) + unit tests pass, and live in Studio the width/style/color edits round-tripped to source (incl. inserting a border where none existed).

## Fixes - #8806