### PR TITLE
`@remotion/lambda-client`: Avoid retrying consumed upload streams

### DIFF
--- a/packages/lambda-client/src/test/write-file.test.ts
+++ b/packages/lambda-client/src/test/write-file.test.ts
@@ -1,0 +1,52 @@
+import {beforeAll, expect, mock, test} from 'bun:test';
+import {Readable} from 'node:stream';
+import type {lambdaWriteFileImplementation as LambdaWriteFileImplementation} from '../write-file';
+
+const uploadDone = mock();
+
+mock.module('@aws-sdk/lib-storage', () => ({
+	Upload: class {
+		done = uploadDone;
+	},
+}));
+
+mock.module('../get-s3-client', () => ({
+	getS3Client: () => ({
+		send: mock(),
+	}),
+}));
+
+let lambdaWriteFileImplementation: typeof LambdaWriteFileImplementation;
+
+beforeAll(async () => {
+	const mod = await import('../write-file');
+	lambdaWriteFileImplementation = mod.lambdaWriteFileImplementation;
+});
+
+test('does not retry a failed upload with a consumed Readable', async () => {
+	const originalError = new Error('The upload failed');
+	uploadDone.mockRejectedValueOnce(originalError);
+
+	let thrownError: unknown;
+	try {
+		await lambdaWriteFileImplementation({
+			body: Readable.from(['video']),
+			bucketName: 'bucket',
+			customCredentials: null,
+			downloadBehavior: null,
+			expectedBucketOwner: null,
+			forcePathStyle: false,
+			key: 'video.mp4',
+			privacy: 'private',
+			region: 'us-east-1',
+			requestHandler: null,
+			retries: 1,
+			storageClass: null,
+		});
+	} catch (err) {
+		thrownError = err;
+	}
+
+	expect(thrownError).toBe(originalError);
+	expect(uploadDone).toHaveBeenCalledTimes(1);
+});

--- a/packages/lambda-client/src/write-file.ts
+++ b/packages/lambda-client/src/write-file.ts
@@ -87,6 +87,8 @@ export const lambdaWriteFileImplementation = async (
 	try {
 		await tryLambdaWriteFile(params);
 	} catch (err) {
+		// A failed upload may have consumed a Readable, and we cannot recreate it here.
+		// Retrying it could upload an empty body and mask the original error.
 		const bodyCanBeRetried =
 			typeof params.body === 'string' || params.body instanceof Uint8Array;
 		if (remainingRetries === 0 || !bodyCanBeRetried) {

--- a/packages/lambda-client/src/write-file.ts
+++ b/packages/lambda-client/src/write-file.ts
@@ -87,7 +87,9 @@ export const lambdaWriteFileImplementation = async (
 	try {
 		await tryLambdaWriteFile(params);
 	} catch (err) {
-		if (remainingRetries === 0) {
+		const bodyCanBeRetried =
+			typeof params.body === 'string' || params.body instanceof Uint8Array;
+		if (remainingRetries === 0 || !bodyCanBeRetried) {
 			throw err;
 		}
 


### PR DESCRIPTION
## Summary

- avoid retrying failed uploads when the body is a `Readable` that may already be consumed
- keep retries for replayable string and `Uint8Array` bodies
- preserve the original multipart upload error and cover the behavior with a regression test

## Testing

- `bun test src` in `packages/lambda-client`
- `bun run build`
- `bun run stylecheck`

Closes #9087
