### PR TITLE
`remotion`: Add stack traces to Interactive.withSchema()

### DIFF
--- a/packages/brand/src/3DContext/Div3D.tsx
+++ b/packages/brand/src/3DContext/Div3D.tsx
@@ -13,7 +13,6 @@ import {
 import React from 'react';
 import {
 	Interactive,
-	Internals,
 	Sequence,
 	type InteractiveBaseProps,
 	type InteractiveTransformProps,
@@ -560,8 +559,6 @@ export const ExtrudeDiv = Interactive.withSchema({
 });
 
 ExtrudeDiv.displayName = 'ExtrudeDiv';
-
-Internals.addSequenceStackTraces(ExtrudeDiv);
 
 export const ThreeDiv: React.FC<React.HtmlHTMLAttributes<HTMLDivElement>> = ({
 	style,

--- a/packages/brand/src/3DContext/transformation-context.tsx
+++ b/packages/brand/src/3DContext/transformation-context.tsx
@@ -12,7 +12,6 @@ import {
 import React, {useContext, useMemo} from 'react';
 import {
 	Interactive,
-	Internals,
 	Sequence,
 	type InteractiveBaseProps,
 	type InteractivitySchema,
@@ -179,7 +178,6 @@ const make3DTransform = <ValueKey extends string>({
 	}) as unknown as React.FC<Props>;
 
 	Wrapped.displayName = componentName.slice(1, -1);
-	Internals.addSequenceStackTraces(Wrapped);
 
 	return Wrapped;
 };

--- a/packages/brand/src/Compose/WhatIsRemotion.tsx
+++ b/packages/brand/src/Compose/WhatIsRemotion.tsx
@@ -3,7 +3,6 @@ import type {CalculateMetadataFunction} from 'remotion';
 import {
 	Easing,
 	Interactive,
-	Internals,
 	interpolate,
 	measureSpring,
 	OffthreadVideo,
@@ -143,7 +142,6 @@ const Label = Interactive.withSchema({
 });
 
 Label.displayName = 'Label';
-Internals.addSequenceStackTraces(Label);
 
 export const whatIsRemotionSchema = z.object({
 	fade: z.boolean(),

--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -15,7 +15,10 @@ import {
 } from './interactivity-schema.js';
 import type {AbsoluteFillLayout, SequenceProps} from './Sequence.js';
 import {Sequence} from './Sequence.js';
-import {withInteractivitySchema} from './with-interactivity-schema.js';
+import {
+	withInteractivitySchema,
+	type WithInteractivitySchemaOptions,
+} from './with-interactivity-schema.js';
 
 type InteractiveHtmlTag =
 	| 'a'
@@ -151,6 +154,15 @@ const setRef = <ElementType,>(
 	}
 };
 
+const withSchema = <S extends InteractivitySchema, Props extends object>(
+	options: WithInteractivitySchemaOptions<S, Props>,
+): React.ComponentType<Props> => {
+	const Wrapped = withInteractivitySchema(options);
+	addSequenceStackTraces(Wrapped);
+
+	return Wrapped;
+};
+
 const makeInteractiveElement = <Tag extends InteractiveTag>(
 	tag: Tag,
 	displayName: string,
@@ -212,7 +224,7 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 
 	Inner.displayName = displayName;
 
-	const Wrapped = withInteractivitySchema({
+	const Wrapped = withSchema({
 		Component: Inner,
 		componentName: displayName,
 		componentIdentity: makeRemotionComponentIdentity({
@@ -224,7 +236,6 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 	}) as InteractiveElementComponent<Tag>;
 
 	Wrapped.displayName = displayName;
-	addSequenceStackTraces(Wrapped);
 
 	return Wrapped;
 };
@@ -238,7 +249,7 @@ export const Interactive = {
 	textSchema,
 	premountSchema,
 	sequenceSchema,
-	withSchema: withInteractivitySchema,
+	withSchema,
 	_internalMakeRemotionComponentIdentity: makeRemotionComponentIdentity,
 	A: makeInteractiveElement('a', '<Interactive.A>'),
 	Article: makeInteractiveElement('article', '<Interactive.Article>'),

--- a/packages/core/src/test/Img.test.tsx
+++ b/packages/core/src/test/Img.test.tsx
@@ -33,17 +33,16 @@ const stub2dContext = () => ({
 	putImageData: () => undefined,
 });
 
-(
-	HTMLCanvasElement.prototype as unknown as {
-		getContext: (kind: string) => unknown;
-	}
-).getContext = function (kind: string) {
-	if (kind === '2d') {
-		return stub2dContext();
-	}
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+	configurable: true,
+	value: (kind: string) => {
+		if (kind === '2d') {
+			return stub2dContext();
+		}
 
-	return null;
-};
+		return null;
+	},
+});
 
 class MockImage {
 	public onload: (() => void) | null = null;

--- a/packages/core/src/test/canvas-image.test.tsx
+++ b/packages/core/src/test/canvas-image.test.tsx
@@ -41,17 +41,16 @@ const stub2dContext = (canvas: HTMLCanvasElement) => ({
 	putImageData: () => undefined,
 });
 
-(
-	HTMLCanvasElement.prototype as unknown as {
-		getContext: (kind: string) => unknown;
-	}
-).getContext = function (kind: string) {
-	if (kind === '2d') {
-		return stub2dContext(this as HTMLCanvasElement);
-	}
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+	configurable: true,
+	value(this: HTMLCanvasElement, kind: string) {
+		if (kind === '2d') {
+			return stub2dContext(this);
+		}
 
-	return null;
-};
+		return null;
+	},
+});
 
 class MockImage {
 	public onload: (() => void) | null = null;

--- a/packages/core/src/test/solid.test.tsx
+++ b/packages/core/src/test/solid.test.tsx
@@ -20,19 +20,18 @@ const stub2dContext = () => ({
 	putImageData: () => undefined,
 });
 
-(
-	HTMLCanvasElement.prototype as unknown as {
-		getContext: (kind: string) => unknown;
-	}
-).getContext = function (kind: string) {
-	if (kind === '2d') {
-		const ctx = stub2dContext();
-		ctx.canvas = this as HTMLCanvasElement;
-		return ctx;
-	}
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+	configurable: true,
+	value(this: HTMLCanvasElement, kind: string) {
+		if (kind === '2d') {
+			const ctx = stub2dContext();
+			ctx.canvas = this;
+			return ctx;
+		}
 
-	return null;
-};
+		return null;
+	},
+});
 
 afterEach(() => {
 	cleanup();

--- a/packages/core/src/test/with-interactivity-schema-helpers.test.ts
+++ b/packages/core/src/test/with-interactivity-schema-helpers.test.ts
@@ -1,5 +1,7 @@
 import {expect, test} from 'bun:test';
+import type {SequenceControls} from '../CompositionManager.js';
 import {solidSchema} from '../effects/Solid.js';
+import {getComponentsToAddStacksTo} from '../enable-sequence-stack-traces.js';
 import {
 	flattenActiveSchema,
 	getFlatSchemaWithAllKeys,
@@ -80,6 +82,23 @@ test('_internalMakeRemotionComponentIdentity normalizes first-party package name
 			componentName: 'Highlight',
 		}),
 	).toBe('dev.remotion.roughNotation.Highlight');
+});
+
+test('Interactive.withSchema() adds Sequence stack traces automatically', () => {
+	const Component = (_props: {
+		readonly controls: SequenceControls | undefined;
+	}) => null;
+	const Wrapped = Interactive.withSchema({
+		Component,
+		componentName: '<Component>',
+		componentIdentity: 'com.example.Component',
+		schema: {},
+		supportsEffects: false,
+	});
+
+	expect(
+		getComponentsToAddStacksTo().filter((component) => component === Wrapped),
+	).toHaveLength(1);
 });
 
 test('getFlatSchema(sequenceSchema) exposes every variant key', () => {

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -143,6 +143,19 @@ export const mergeValues = ({
 
 const stackToOverrideMap: Record<string, string> = {};
 
+export type WithInteractivitySchemaOptions<
+	S extends InteractivitySchema,
+	Props extends object,
+> = {
+	Component: React.ComponentType<
+		Props & {readonly controls: SequenceControls | undefined}
+	>;
+	componentName: string;
+	componentIdentity: JsxComponentIdentity | null;
+	schema: S;
+	supportsEffects: boolean;
+};
+
 export const withInteractivitySchema = <
 	S extends InteractivitySchema,
 	Props extends object,
@@ -152,15 +165,7 @@ export const withInteractivitySchema = <
 	componentIdentity,
 	schema,
 	supportsEffects,
-}: {
-	Component: React.ComponentType<
-		Props & {readonly controls: SequenceControls | undefined}
-	>;
-	componentName: string;
-	componentIdentity: JsxComponentIdentity | null;
-	schema: S;
-	supportsEffects: boolean;
-}): React.ComponentType<Props> => {
+}: WithInteractivitySchemaOptions<S, Props>): React.ComponentType<Props> => {
 	// Schema is static for a component, so we move this outside
 	const schemaWithSequenceName = extendSchemaWithSequenceName(schema);
 	const flatSchema = getFlatSchemaWithAllKeys(schemaWithSequenceName);

--- a/packages/docs/docs/interactive-with-schema.mdx
+++ b/packages/docs/docs/interactive-with-schema.mdx
@@ -152,6 +152,8 @@ During rendering, in the Player and in read-only Studio sessions, `Interactive.w
 
 In editable Studio sessions, it reads the current prop values, applies timeline overrides and passes the merged props to the inner component.
 
+It also automatically associates Studio edits with the JSX element where the wrapped component is used. <AvailableFrom v="4.0.490" inline />
+
 ## See also
 
 - [`InteractivitySchema`](/docs/interactivity-schema)

--- a/packages/docs/docs/interactive-with-schema.mdx
+++ b/packages/docs/docs/interactive-with-schema.mdx
@@ -152,8 +152,6 @@ During rendering, in the Player and in read-only Studio sessions, `Interactive.w
 
 In editable Studio sessions, it reads the current prop values, applies timeline overrides and passes the merged props to the inner component.
 
-It also automatically associates Studio edits with the JSX element where the wrapped component is used. <AvailableFrom v="4.0.490" inline />
-
 ## See also
 
 - [`InteractivitySchema`](/docs/interactivity-schema)

--- a/packages/docs/docs/studio/make-component-interactive.mdx
+++ b/packages/docs/docs/studio/make-component-interactive.mdx
@@ -157,7 +157,6 @@ Use a stable `componentIdentity` so saved Studio edits can be associated with th
 ```tsx twoslash title="Badge.tsx"
 import React, {forwardRef, useImperativeHandle, useRef} from 'react';
 import {
-  Internals,
   Interactive,
   Sequence,
   type InteractiveBaseProps,
@@ -247,11 +246,9 @@ export const Badge = Interactive.withSchema({
   schema: badgeSchema,
   supportsEffects: false,
 });
-
-Internals.addSequenceStackTraces(Badge);
 ```
 
-Registering stack traces is currently an internal step. It lets the Studio find the JSX element where `<Badge>` is used, instead of the internal `<Sequence>` rendered by `BadgeInner`.
+`Interactive.withSchema()` automatically lets the Studio associate edits with the JSX element where `<Badge>` is used, instead of the internal `<Sequence>` rendered by `BadgeInner`. <AvailableFrom v="4.0.490" inline />
 
 ## Use the component
 

--- a/packages/docs/docs/studio/make-component-interactive.mdx
+++ b/packages/docs/docs/studio/make-component-interactive.mdx
@@ -248,8 +248,6 @@ export const Badge = Interactive.withSchema({
 });
 ```
 
-`Interactive.withSchema()` automatically lets the Studio associate edits with the JSX element where `<Badge>` is used, instead of the internal `<Sequence>` rendered by `BadgeInner`. <AvailableFrom v="4.0.490" inline />
-
 ## Use the component
 
 ```tsx title="MyComp.tsx"

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -15,11 +15,7 @@ import {GifForDevelopment} from './GifForDevelopment';
 import {GifForRendering} from './GifForRendering';
 import type {RemotionGifProps} from './props';
 
-const {
-	addSequenceStackTraces,
-	useMemoizedEffectDefinitions,
-	useMemoizedEffects,
-} = Internals;
+const {useMemoizedEffectDefinitions, useMemoizedEffects} = Internals;
 
 export type GifProps = InteractiveBaseProps &
 	InteractiveTransformProps &
@@ -128,5 +124,3 @@ export const Gif = Interactive.withSchema({
 });
 
 Gif.displayName = 'Gif';
-
-addSequenceStackTraces(Gif);

--- a/packages/light-leaks/src/LightLeak.tsx
+++ b/packages/light-leaks/src/LightLeak.tsx
@@ -310,5 +310,3 @@ export const LightLeak = Interactive.withSchema({
 });
 
 LightLeak.displayName = 'LightLeak';
-
-Internals.addSequenceStackTraces(LightLeak);

--- a/packages/media/src/audio/audio.tsx
+++ b/packages/media/src/audio/audio.tsx
@@ -172,5 +172,3 @@ export const Audio = Interactive.withSchema({
 	schema: audioSchema,
 	supportsEffects: false,
 });
-
-Internals.addSequenceStackTraces(Audio);

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -364,5 +364,3 @@ export const Video = Interactive.withSchema({
 	schema: videoSchema,
 	supportsEffects: true,
 });
-
-Internals.addSequenceStackTraces(Video);

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -36,7 +36,6 @@ import type {
 import {mapToAlignment, mapToFit} from './map-enums.js';
 
 const {
-	addSequenceStackTraces,
 	runEffectChain,
 	useEffectChainState,
 	useMemoizedEffectDefinitions,
@@ -502,8 +501,6 @@ export const RemotionRiveCanvas = Interactive.withSchema({
 }) as React.ForwardRefExoticComponent<
 	RemotionRiveCanvasProps & React.RefAttributes<RiveCanvasRef>
 >;
-
-addSequenceStackTraces(RemotionRiveCanvas);
 
 (RemotionRiveCanvas as unknown as {displayName: string}).displayName =
 	'RemotionRiveCanvas';

--- a/packages/rough-notation/src/Annotation.tsx
+++ b/packages/rough-notation/src/Annotation.tsx
@@ -1,6 +1,5 @@
 import React, {useMemo} from 'react';
 import {
-	Internals,
 	Interactive,
 	Sequence,
 	type InteractiveBaseProps,
@@ -437,7 +436,6 @@ const makeAnnotationComponent = ({
 	}) as React.FC<InternalAnnotationProps>;
 
 	Component.displayName = componentName;
-	Internals.addSequenceStackTraces(Component);
 	return Component;
 };
 

--- a/packages/shapes/src/components/arrow.tsx
+++ b/packages/shapes/src/components/arrow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakeArrowProps} from '../utils/make-arrow';
 import {makeArrow} from '../utils/make-arrow';
 import type {AllShapesProps} from './render-svg';
@@ -84,5 +84,3 @@ export const Arrow = Interactive.withSchema({
 	schema: arrowSchema,
 	supportsEffects: true,
 }) as React.FC<ArrowProps>;
-
-Internals.addSequenceStackTraces(Arrow);

--- a/packages/shapes/src/components/callout.tsx
+++ b/packages/shapes/src/components/callout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakeCalloutProps} from '../utils/make-callout';
 import {makeCallout} from '../utils/make-callout';
 import type {AllShapesProps} from './render-svg';
@@ -97,5 +97,3 @@ export const Callout = Interactive.withSchema({
 	schema: calloutSchema,
 	supportsEffects: true,
 }) as React.FC<CalloutProps>;
-
-Internals.addSequenceStackTraces(Callout);

--- a/packages/shapes/src/components/circle.tsx
+++ b/packages/shapes/src/components/circle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakeCircleProps} from '../utils/make-circle';
 import {makeCircle} from '../utils/make-circle';
 import type {AllShapesProps} from './render-svg';
@@ -39,5 +39,3 @@ export const Circle = Interactive.withSchema({
 	schema: circleSchema,
 	supportsEffects: true,
 }) as React.FC<CircleProps>;
-
-Internals.addSequenceStackTraces(Circle);

--- a/packages/shapes/src/components/ellipse.tsx
+++ b/packages/shapes/src/components/ellipse.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakeEllipseOptions} from '../utils/make-ellipse';
 import {makeEllipse} from '../utils/make-ellipse';
 import type {AllShapesProps} from './render-svg';
@@ -46,5 +46,3 @@ export const Ellipse = Interactive.withSchema({
 	schema: ellipseSchema,
 	supportsEffects: true,
 }) as React.FC<EllipseProps>;
-
-Internals.addSequenceStackTraces(Ellipse);

--- a/packages/shapes/src/components/heart.tsx
+++ b/packages/shapes/src/components/heart.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakeHeartProps} from '../utils/make-heart';
 import {makeHeart} from '../utils/make-heart';
 import type {AllShapesProps} from './render-svg';
@@ -66,5 +66,3 @@ export const Heart = Interactive.withSchema({
 	schema: heartSchema,
 	supportsEffects: true,
 }) as React.FC<HeartProps>;
-
-Internals.addSequenceStackTraces(Heart);

--- a/packages/shapes/src/components/pie.tsx
+++ b/packages/shapes/src/components/pie.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakePieProps} from '../utils/make-pie';
 import {makePie} from '../utils/make-pie';
 import type {AllShapesProps} from './render-svg';
@@ -71,5 +71,3 @@ export const Pie = Interactive.withSchema({
 	schema: pieSchema,
 	supportsEffects: true,
 }) as React.FC<PieProps>;
-
-Internals.addSequenceStackTraces(Pie);

--- a/packages/shapes/src/components/polygon.tsx
+++ b/packages/shapes/src/components/polygon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakePolygonProps} from '../utils/make-polygon';
 import {makePolygon} from '../utils/make-polygon';
 import type {AllShapesProps} from './render-svg';
@@ -56,5 +56,3 @@ export const Polygon = Interactive.withSchema({
 	schema: polygonSchema,
 	supportsEffects: true,
 }) as React.FC<PolygonProps>;
-
-Internals.addSequenceStackTraces(Polygon);

--- a/packages/shapes/src/components/rect.tsx
+++ b/packages/shapes/src/components/rect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakeRectOptions} from '../utils/make-rect';
 import {makeRect} from '../utils/make-rect';
 import type {AllShapesProps} from './render-svg';
@@ -58,5 +58,3 @@ export const Rect = Interactive.withSchema({
 	schema: rectSchema,
 	supportsEffects: true,
 }) as React.FC<RectProps>;
-
-Internals.addSequenceStackTraces(Rect);

--- a/packages/shapes/src/components/spark.tsx
+++ b/packages/shapes/src/components/spark.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakeSparkProps} from '../utils/make-spark';
 import {makeSpark} from '../utils/make-spark';
 import type {AllShapesProps} from './render-svg';
@@ -64,5 +64,3 @@ export const Spark = Interactive.withSchema({
 	schema: sparkSchema,
 	supportsEffects: true,
 }) as React.FC<SparkProps>;
-
-Internals.addSequenceStackTraces(Spark);

--- a/packages/shapes/src/components/star.tsx
+++ b/packages/shapes/src/components/star.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakeStarProps} from '../utils/make-star';
 import {makeStar} from '../utils/make-star';
 import type {AllShapesProps} from './render-svg';
@@ -73,5 +73,3 @@ export const Star = Interactive.withSchema({
 	schema: starSchema,
 	supportsEffects: true,
 }) as React.FC<StarProps>;
-
-Internals.addSequenceStackTraces(Star);

--- a/packages/shapes/src/components/triangle.tsx
+++ b/packages/shapes/src/components/triangle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Internals, Interactive} from 'remotion';
+import {Interactive} from 'remotion';
 import type {MakeTriangleProps} from '../utils/make-triangle';
 import {makeTriangle} from '../utils/make-triangle';
 import type {AllShapesProps} from './render-svg';
@@ -58,5 +58,3 @@ export const Triangle = Interactive.withSchema({
 	schema: triangleSchema,
 	supportsEffects: true,
 }) as React.FC<TriangleProps>;
-
-Internals.addSequenceStackTraces(Triangle);

--- a/packages/shapes/src/test/effects.test.tsx
+++ b/packages/shapes/src/test/effects.test.tsx
@@ -32,12 +32,8 @@ type SequenceCall = {
 
 const htmlInCanvasCalls: HtmlInCanvasCall[] = [];
 const sequenceCalls: SequenceCall[] = [];
-const stackTraceComponents: unknown[] = [];
 const effectDefinitions = [{type: 'effect-definition'}];
 let hasVideoConfig = true;
-const addSequenceStackTraces = mock((component: unknown) => {
-	stackTraceComponents.push(component);
-});
 
 mock.module('remotion', () => {
 	return {
@@ -77,7 +73,6 @@ mock.module('remotion', () => {
 			);
 		},
 		Internals: {
-			addSequenceStackTraces,
 			CanUseRemotionHooks: React.createContext(true),
 			CompositionManagerProvider: ({
 				children,

--- a/packages/starburst/src/Starburst.tsx
+++ b/packages/starburst/src/Starburst.tsx
@@ -444,5 +444,3 @@ export const Starburst = Interactive.withSchema({
 });
 
 Starburst.displayName = 'Starburst';
-
-Internals.addSequenceStackTraces(Starburst);

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -732,5 +732,3 @@ TransitionSeries.Transition = TransitionSeriesTransition;
 TransitionSeries.Overlay = SeriesOverlay;
 
 export {TransitionSeries};
-
-Internals.addSequenceStackTraces(TransitionSeries);


### PR DESCRIPTION
## Summary

- register components returned by `Interactive.withSchema()` for Sequence stack traces automatically
- remove redundant internal registration calls from wrapped components
- update the interactive component documentation and add a focused regression test

## Validation

- `bun run build`
- `bun run stylecheck`
- full docs build, including Twoslash validation

Closes https://github.com/remotion-dev/remotion/issues/9061
