### PR TITLE
`@remotion/studio`: Improve responsive sidebar close button

### DIFF
--- a/packages/studio/src/components/MobilePanel.tsx
+++ b/packages/studio/src/components/MobilePanel.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {BACKGROUND} from '../helpers/colors';
 import {useZIndex} from '../state/z-index';
+import type {RenderInlineAction} from './InlineAction';
+import {InlineAction} from './InlineAction';
 import {getPortal} from './Menu/portals';
-import {CancelButton} from './NewComposition/CancelButton';
+import {CancelIcon} from './NewComposition/CancelButton';
 
 const container: React.CSSProperties = {
 	position: 'fixed',
@@ -21,11 +23,17 @@ const buttonContainer: React.CSSProperties = {
 	alignItems: 'center',
 	display: 'flex',
 	justifyContent: 'flex-end',
+	paddingRight: 8,
 };
 
 const button: React.CSSProperties = {
-	height: 20,
-	width: 20,
+	height: 16,
+	width: 16,
+	flexShrink: 0,
+};
+
+const renderCloseIcon: RenderInlineAction = (color) => {
+	return <CancelIcon style={{...button, color}} />;
 };
 
 export default function MobilePanel({
@@ -40,7 +48,11 @@ export default function MobilePanel({
 	return ReactDOM.createPortal(
 		<div style={container}>
 			<div style={buttonContainer}>
-				<CancelButton style={button} onPress={onClose} />
+				<InlineAction
+					onClick={onClose}
+					renderAction={renderCloseIcon}
+					title="Close sidebar"
+				/>
 			</div>
 			{children}
 		</div>,

--- a/packages/studio/src/components/NewComposition/CancelButton.tsx
+++ b/packages/studio/src/components/NewComposition/CancelButton.tsx
@@ -14,6 +14,17 @@ const style: React.CSSProperties = {
 	alignItems: 'center',
 };
 
+export const CancelIcon: React.FC<SVGProps<SVGSVGElement>> = (props) => {
+	return (
+		<svg viewBox="0 0 320 512" {...props}>
+			<path
+				fill={CURRENT_COLOR}
+				d="M207.6 256l107.72-107.72c6.23-6.23 6.23-16.34 0-22.58l-25.03-25.03c-6.23-6.23-16.34-6.23-22.58 0L160 208.4 52.28 100.68c-6.23-6.23-16.34-6.23-22.58 0L4.68 125.7c-6.23 6.23-6.23 16.34 0 22.58L112.4 256 4.68 363.72c-6.23 6.23-6.23 16.34 0 22.58l25.03 25.03c6.23 6.23 16.34 6.23 22.58 0L160 303.6l107.72 107.72c6.23 6.23 16.34 6.23 22.58 0l25.03-25.03c6.23-6.23 6.23-16.34 0-22.58L207.6 256z"
+			/>
+		</svg>
+	);
+};
+
 export const CancelButton: React.FC<
 	SVGProps<SVGSVGElement> & {
 		readonly onPress: () => void;
@@ -22,12 +33,7 @@ export const CancelButton: React.FC<
 	const {tabIndex} = useZIndex();
 	return (
 		<button tabIndex={tabIndex} style={style} type="button" onClick={onPress}>
-			<svg viewBox="0 0 320 512" {...props}>
-				<path
-					fill={CURRENT_COLOR}
-					d="M207.6 256l107.72-107.72c6.23-6.23 6.23-16.34 0-22.58l-25.03-25.03c-6.23-6.23-16.34-6.23-22.58 0L160 208.4 52.28 100.68c-6.23-6.23-16.34-6.23-22.58 0L4.68 125.7c-6.23 6.23-6.23 16.34 0 22.58L112.4 256 4.68 363.72c-6.23 6.23-6.23 16.34 0 22.58l25.03 25.03c6.23 6.23 16.34 6.23 22.58 0L160 303.6l107.72 107.72c6.23 6.23 16.34 6.23 22.58 0l25.03-25.03c6.23-6.23 6.23-16.34 0-22.58L207.6 256z"
-				/>
-			</svg>
+			<CancelIcon {...props} />
 		</button>
 	);
 };


### PR DESCRIPTION
## Summary

- use the shared inline action styling for the responsive sidebar close button
- reduce and inset the close icon to match the Studio toolbar controls
- reuse the existing cancel icon across close button variants

## Validation

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`

Closes #9088
