### PR TITLE
Docs: Use @remotion/media in audio guides

### DIFF
--- a/packages/docs/docs/audio/speed.mdx
+++ b/packages/docs/docs/audio/speed.mdx
@@ -8,7 +8,7 @@ crumb: 'Audio'
 
 # Controlling playback speed<AvailableFrom v="2.2" />
 
-You can use the [`playbackRate`](/docs/html5-audio#playbackrate) prop to control the speed of the audio.
+You can use the [`playbackRate`](/docs/media/audio#playbackrate) prop to control the speed of the audio.
 
 - `1` is the default.
 - `0.5` slows down the audio so it's twice as long
@@ -16,12 +16,13 @@ You can use the [`playbackRate`](/docs/html5-audio#playbackrate) prop to control
 - Google Chrome supports playback rates between `0.0625` and `16`.
 
 ```tsx twoslash {6} title="MyComp.tsx"
-import {AbsoluteFill, Html5Audio, staticFile} from 'remotion';
+import {AbsoluteFill, staticFile} from 'remotion';
+import {Audio} from '@remotion/media';
 
 export const MyComposition = () => {
   return (
     <AbsoluteFill>
-      <Html5Audio src={staticFile('audio.mp3')} playbackRate={2} />
+      <Audio src={staticFile('audio.mp3')} playbackRate={2} />
     </AbsoluteFill>
   );
 };

--- a/packages/docs/docs/audio/visualization.mdx
+++ b/packages/docs/docs/audio/visualization.mdx
@@ -16,9 +16,10 @@ Using the [`visualizeAudio()`](/docs/visualize-audio) API, you can get an audio 
 
 Bar visualizations are ideal for visualizing music.
 
-```tsx twoslash
+```tsx twoslash title="MyComponent.tsx"
+import {Audio} from '@remotion/media';
 import {useAudioData, visualizeAudio} from '@remotion/media-utils';
-import {Html5Audio, staticFile, useCurrentFrame, useVideoConfig} from 'remotion';
+import {staticFile, useCurrentFrame, useVideoConfig} from 'remotion';
 
 const music = staticFile('music.mp3');
 
@@ -42,7 +43,7 @@ export const MyComponent: React.FC = () => {
   // the longer the bar
   return (
     <div>
-      <Html5Audio src={music} />
+      <Audio src={music} />
       {visualization.map((v) => {
         return <div style={{width: 1000 * v, height: 15, backgroundColor: 'blue'}} />;
       })}

--- a/packages/docs/docs/audio/volume.mdx
+++ b/packages/docs/docs/audio/volume.mdx
@@ -6,21 +6,19 @@ id: volume
 crumb: 'Audio'
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-You can use the [`volume`](/docs/html5-audio#volume) prop to control the volume.
+You can use the [`volume`](/docs/media/audio#volume) prop to control the volume.
 
 The simplest way is to pass a number between `0` and `1`.
 
-```tsx twoslash {7} title="MyComp.tsx"
-import {Html5Audio, staticFile, AbsoluteFill} from 'remotion';
+```tsx twoslash {9} title="MyComp.tsx"
+import {Audio} from '@remotion/media';
+import {AbsoluteFill, staticFile} from 'remotion';
 
 export const MyComposition = () => {
   return (
     <AbsoluteFill>
       <div>Hello World!</div>
-      <Html5Audio src={staticFile('audio.mp3')} volume={0.5} />
+      <Audio src={staticFile('audio.mp3')} volume={0.5} />
     </AbsoluteFill>
   );
 };
@@ -30,15 +28,16 @@ export const MyComposition = () => {
 
 You can also change volume over time by passing in a function that takes a frame number and returns the volume.
 
-```tsx twoslash {8}
-import {AbsoluteFill, Html5Audio, interpolate, staticFile, useVideoConfig} from 'remotion';
+```tsx twoslash {10} title="MyComp.tsx"
+import {Audio} from '@remotion/media';
+import {AbsoluteFill, interpolate, staticFile, useVideoConfig} from 'remotion';
 
 export const MyComposition = () => {
   const {fps} = useVideoConfig();
 
   return (
     <AbsoluteFill>
-      <Html5Audio src={staticFile('audio.mp3')} volume={(f) => interpolate(f, [0, 1 * fps], [0, 1], {extrapolateLeft: 'clamp'})} />
+      <Audio src={staticFile('audio.mp3')} volume={(f) => interpolate(f, [0, 1 * fps], [0, 1], {extrapolateLeft: 'clamp'})} />
     </AbsoluteFill>
   );
 };
@@ -52,32 +51,3 @@ Inside the callback function, the value of `f` starts always `0` when the audio 
 It is not the same as the value of [`useCurrentFrame()`](/docs/use-current-frame).
 
 Prefer using a callback function if the volume is changing. This will enable Remotion to draw a volume curve in the [Studio](/docs/studio) and is more performant.
-
-## Limitations<AvailableFrom v="4.0.306" />
-
-By default, you'll face 2 limitations by default regarding volume:
-
-<div>
-<div><Step>1</Step> It is not possible to set the volume to a value higher than 1.</div>
-<div><Step>2</Step> On iOS Safari, the volume will be set to 1.</div>
-</div><br/>
-You can work around these limitations by enabling the Web Audio API for your [`<Html5Audio>`](/docs/html5-audio#usewebaudioapi), [`<Html5Video>`](/docs/html5-video#usewebaudioapi) and [`<OffthreadVideo>`](/docs/offthreadvideo#usewebaudioapi) tags.
-
-```tsx twoslash
-import {Html5Audio, staticFile, AbsoluteFill} from 'remotion';
-// ---cut---
-
-<Html5Audio src="https://remotion.media/audio.wav" volume={2} useWebAudioApi crossOrigin="anonymous" />;
-```
-
-However, this comes with two caveats:
-
-<div>
-  <div>
-    <Step error>1</Step> You must set the `crossOrigin` prop to `anonymous` and the audio must support CORS.
-  </div>
-  <div>
-    <Step error>2</Step> On Safari, you cannot combine it with [`playbackRate`](/docs/html5-audio#playbackrate). If you do, the volume will be ignored.
-  </div>
-</div>
-<br />

--- a/packages/docs/docs/html5-audio.mdx
+++ b/packages/docs/docs/html5-audio.mdx
@@ -61,8 +61,7 @@ export const MyVideo = () => {
 };
 ```
 
-By default, volumes between 0 and 1 are supported, where in iOS Safari, the volume is always 1.  
-See [Volume Limitations](/docs/audio/volume#limitations) for more information.
+By default, volumes between `0` and `1` are supported, and iOS Safari always sets the volume to `1`. Set [`useWebAudioApi`](#usewebaudioapi) to `true` to remove these limitations. This requires `crossOrigin="anonymous"`, and the audio source must support CORS. On Safari, `useWebAudioApi` cannot be combined with [`playbackRate`](#playbackrate); otherwise, volume changes are ignored.
 
 ### `loopVolumeCurveBehavior?`<AvailableFrom v="4.0.142" />
 
@@ -227,7 +226,7 @@ Customize the [number of retries](/docs/delay-render#retrying) of the [`delayRen
 
 ### `useWebAudioApi?`<AvailableFrom v="4.0.306" />
 
-Enable the [Web Audio API](/docs/audio/volume#limitations) for the audio tag.
+Enables the Web Audio API for the audio tag, allowing volume values above `1` and volume control on iOS Safari. Set `crossOrigin="anonymous"` and ensure the audio source supports CORS. On Safari, this cannot be combined with [`playbackRate`](#playbackrate); otherwise, volume changes are ignored.
 
 ### `onError?`<AvailableFrom v="4.0.326" />
 

--- a/packages/docs/docs/html5-video.mdx
+++ b/packages/docs/docs/html5-video.mdx
@@ -144,8 +144,7 @@ export const MyComposition = () => {
 };
 ```
 
-By default, volumes between 0 and 1 are supported, where in iOS Safari, the volume is always 1.  
-See [Volume Limitations](/docs/audio/volume#limitations) for more information.
+By default, volumes between `0` and `1` are supported, and iOS Safari always sets the volume to `1`. Set [`useWebAudioApi`](#usewebaudioapi) to `true` to remove these limitations. This requires `crossOrigin="anonymous"`, and the video source must support CORS. On Safari, `useWebAudioApi` cannot be combined with [`playbackRate`](#playbackrate); otherwise, volume changes are ignored.
 
 ### `loopVolumeCurveBehavior?`<AvailableFrom v="4.0.142" />
 
@@ -310,7 +309,7 @@ Default: `"anonymous"` if `onVideoFrame` is specified, `undefined`, otherwise.
 
 ### `useWebAudioApi?`<AvailableFrom v="4.0.306" />
 
-Enable the [Web Audio API](/docs/audio/volume#limitations) for the video tag.
+Enables the Web Audio API for the video tag, allowing volume values above `1` and volume control on iOS Safari. Set `crossOrigin="anonymous"` and ensure the video source supports CORS. On Safari, this cannot be combined with [`playbackRate`](#playbackrate); otherwise, volume changes are ignored.
 
 ### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
 

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -129,8 +129,7 @@ export const MyComposition = () => {
 };
 ```
 
-By default, volumes between 0 and 1 are supported, where in iOS Safari, the volume is always 1.  
-See [Volume Limitations](/docs/audio/volume#limitations) for more information.
+By default, volumes between `0` and `1` are supported, and iOS Safari always sets the volume to `1`. Set [`useWebAudioApi`](#usewebaudioapi) to `true` to remove these limitations. This requires `crossOrigin="anonymous"`, and the video source must support CORS. On Safari, `useWebAudioApi` cannot be combined with [`playbackRate`](#playbackrate); otherwise, volume changes are ignored.
 
 ### `loopVolumeCurveBehavior?`<AvailableFrom v="4.0.142" />
 
@@ -307,7 +306,7 @@ Default: `"anonymous"` if `onVideoFrame` is specified, `undefined`, otherwise.
 
 ### `useWebAudioApi?`<AvailableFrom v="4.0.306" />
 
-Enable the [Web Audio API](/docs/audio/volume#limitations) for the video tag.
+Enables the Web Audio API for the video tag, allowing volume values above `1` and volume control on iOS Safari. Set `crossOrigin="anonymous"` and ensure the video source supports CORS. On Safari, this cannot be combined with [`playbackRate`](#playbackrate); otherwise, volume changes are ignored.
 
 ### ~~`imageFormat` <AvailableFrom v="3.0.22" />~~
 


### PR DESCRIPTION
## Summary

- migrate the audio speed, visualization, and volume guides to `<Audio>` from `@remotion/media`
- remove legacy-only volume limitations from the general volume guide
- document Web Audio volume limitations inline on `<Html5Audio>`, `<Html5Video>`, and `<OffthreadVideo>`

## Validation

- `bun run build`
- `bun run stylecheck`
- `bun run build-docs`

Part of #8882.
