### PR TITLE
`@remotion/studio`: Move textarea below its label

### DIFF
--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -157,10 +157,6 @@ const getSchemaFieldRowHeight = ({
 		);
 	}
 
-	if (fieldSchema.type === 'text-content') {
-		return SCHEMA_FIELD_ROW_HEIGHT * 3;
-	}
-
 	return SCHEMA_FIELD_ROW_HEIGHT;
 };
 

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -158,7 +158,7 @@ const getSchemaFieldRowHeight = ({
 	}
 
 	if (fieldSchema.type === 'text-content') {
-		return SCHEMA_FIELD_ROW_HEIGHT * 2;
+		return SCHEMA_FIELD_ROW_HEIGHT * 3;
 	}
 
 	return SCHEMA_FIELD_ROW_HEIGHT;

--- a/packages/studio-shared/src/test/schema-field-info.test.ts
+++ b/packages/studio-shared/src/test/schema-field-info.test.ts
@@ -244,7 +244,7 @@ test('getFieldsToShow sorts fields by inspector group order', () => {
 	]);
 });
 
-test('getFieldsToShow leaves room for a stacked text content field', () => {
+test('getFieldsToShow does not reserve extra height for text content fields', () => {
 	const fields = getFieldsToShow({
 		schema: {
 			children: {
@@ -259,7 +259,7 @@ test('getFieldsToShow leaves room for a stacked text content field', () => {
 		includeTextContent: true,
 	});
 
-	expect(fields?.[0].rowHeight).toBe(SCHEMA_FIELD_ROW_HEIGHT * 3);
+	expect(fields?.[0].rowHeight).toBe(SCHEMA_FIELD_ROW_HEIGHT);
 });
 
 test('getEffectFieldsToShow sorts fields by inspector group order', () => {

--- a/packages/studio-shared/src/test/schema-field-info.test.ts
+++ b/packages/studio-shared/src/test/schema-field-info.test.ts
@@ -244,6 +244,24 @@ test('getFieldsToShow sorts fields by inspector group order', () => {
 	]);
 });
 
+test('getFieldsToShow leaves room for a stacked text content field', () => {
+	const fields = getFieldsToShow({
+		schema: {
+			children: {
+				type: 'text-content',
+				default: '',
+			},
+		},
+		currentRuntimeValueDotNotation: {},
+		getDragOverrides: () => ({}),
+		propStatuses: {},
+		nodePath,
+		includeTextContent: true,
+	});
+
+	expect(fields?.[0].rowHeight).toBe(SCHEMA_FIELD_ROW_HEIGHT * 3);
+});
+
 test('getEffectFieldsToShow sorts fields by inspector group order', () => {
 	const fields = getEffectFieldsToShow({
 		effect: {

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -371,12 +371,14 @@ export const TimelineEffectPropItem: React.FC<{
 	const videoConfig = useVideoConfig();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const sourceFrame = timelinePosition - keyframeDisplayOffset;
-	const style = useMemo(() => {
+	const style = useMemo((): React.CSSProperties => {
 		return {
 			...fieldRowBase,
-			height: field.rowHeight,
+			...(field.typeName === 'text-content'
+				? {minHeight: field.rowHeight}
+				: {height: field.rowHeight}),
 		};
-	}, [field.rowHeight]);
+	}, [field.rowHeight, field.typeName]);
 
 	const effectStatus = useMemo(
 		() =>

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -372,12 +372,9 @@ export const TimelineEffectPropItem: React.FC<{
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const sourceFrame = timelinePosition - keyframeDisplayOffset;
 	const style = useMemo((): React.CSSProperties => {
-		return {
-			...fieldRowBase,
-			...(field.typeName === 'text-content'
-				? {minHeight: field.rowHeight}
-				: {height: field.rowHeight}),
-		};
+		return field.typeName === 'text-content'
+			? fieldRowBase
+			: {...fieldRowBase, height: field.rowHeight};
 	}, [field.rowHeight, field.typeName]);
 
 	const effectStatus = useMemo(

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -21,9 +21,8 @@ import {getAnimationItemSelectionForSourceFrame} from './get-animation-item-sele
 import {getComputedStatusLabel} from './get-timeline-keyframes';
 import {saveEffectProp} from './save-effect-prop';
 import {enqueueSavePropChange} from './save-prop-queue';
-import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
-import {TimelineFieldLabel} from './TimelineFieldLabel';
+import {TimelineFieldRowContent} from './TimelineFieldRowContent';
 import {
 	shouldShowTimelineKeyframeControls,
 	TimelineKeyframeControls,
@@ -612,19 +611,18 @@ export const TimelineEffectPropItem: React.FC<{
 			containsSelection={false}
 			outerHeight={null}
 		>
-			<TimelineFieldLabel
+			<TimelineFieldRowContent
+				field={field}
 				rowDepth={rowDepth}
 				selected={selection.selected}
-				label={field.description ?? field.key}
-			/>
-			<div style={timelineFieldValueColumnStyle}>
+			>
 				<TimelineEffectPropValue
 					field={field}
 					nodePath={nodePath}
 					validatedLocation={validatedLocation}
 					sourceFrame={sourceFrame}
 				/>
-			</div>
+			</TimelineFieldRowContent>
 		</TimelineRowChrome>
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineFieldLabel.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldLabel.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo} from 'react';
 import {WHITE_ALPHA_80} from '../../helpers/colors';
+import {SCHEMA_FIELD_ROW_HEIGHT} from '../../helpers/timeline-layout';
 import {getTimelineFieldLabelRowStyle} from './timeline-field-row-layout';
 import {
 	getTimelineColor,
@@ -21,14 +22,16 @@ export const TimelineFieldLabel: React.FC<{
 	readonly rowDepth: number;
 	readonly selected: boolean;
 	readonly label: string;
-}> = ({rowDepth, selected, label}) => {
+	readonly stacked?: boolean;
+}> = ({rowDepth, selected, label, stacked = false}) => {
 	const labelRowStyle = useMemo(
 		(): React.CSSProperties => ({
 			...getTimelineFieldLabelRowStyle(rowDepth),
 			...getTimelineSelectedLabelStyle(selected, true),
+			...(stacked ? {flex: `0 0 ${SCHEMA_FIELD_ROW_HEIGHT}px`} : null),
 			alignSelf: 'stretch',
 		}),
-		[rowDepth, selected],
+		[rowDepth, selected, stacked],
 	);
 
 	const fieldNameStyle = useMemo(

--- a/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type {SchemaFieldInfo} from '../../helpers/timeline-layout';
+import {
+	timelineFieldValueColumnStyle,
+	timelineStackedFieldContentStyle,
+} from './timeline-field-row-layout';
+import {TimelineFieldLabel} from './TimelineFieldLabel';
+
+export const TimelineFieldRowContent: React.FC<{
+	readonly field: SchemaFieldInfo;
+	readonly rowDepth: number;
+	readonly selected: boolean;
+	readonly children: React.ReactNode;
+}> = ({field, rowDepth, selected, children}) => {
+	const label = (
+		<TimelineFieldLabel
+			rowDepth={rowDepth}
+			selected={selected}
+			label={field.description ?? field.key}
+			stacked={field.typeName === 'text-content'}
+		/>
+	);
+	const value = <div style={timelineFieldValueColumnStyle}>{children}</div>;
+
+	if (field.typeName === 'text-content') {
+		return (
+			<div style={timelineStackedFieldContentStyle}>
+				{label}
+				{value}
+			</div>
+		);
+	}
+
+	return (
+		<>
+			{label}
+			{value}
+		</>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
@@ -204,17 +204,15 @@ export const TimelinePrimitiveFieldValue: React.FC<{
 
 	if (field.typeName === 'text-content') {
 		return (
-			<span style={inlineWrapper}>
-				<TimelineTextContentField
-					effectiveValue={effectiveValue}
-					field={field}
-					nodePath={scaleLockNodePath}
-					onDragEnd={onDragEnd}
-					onDragValueChange={onDragValueChange}
-					onSave={onSave}
-					propStatus={propStatus}
-				/>
-			</span>
+			<TimelineTextContentField
+				effectiveValue={effectiveValue}
+				field={field}
+				nodePath={scaleLockNodePath}
+				onDragEnd={onDragEnd}
+				onDragValueChange={onDragValueChange}
+				onSave={onSave}
+				propStatus={propStatus}
+			/>
 		);
 	}
 

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -21,9 +21,8 @@ import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {callAddSequenceKeyframe} from './call-add-keyframe';
 import {getAnimationItemSelectionForSourceFrame} from './get-animation-item-selection-for-frame';
 import {saveSequenceProps} from './save-sequence-prop';
-import {timelineFieldValueColumnStyle} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
-import {TimelineFieldLabel} from './TimelineFieldLabel';
+import {TimelineFieldRowContent} from './TimelineFieldRowContent';
 import {
 	shouldShowTimelineKeyframeControls,
 	TimelineKeyframeControls,
@@ -536,6 +535,27 @@ export const TimelineSequencePropItem: React.FC<{
 		return null;
 	}
 
+	const fieldValue = isKeyframedStatus(propStatus) ? (
+		<TimelineSequenceKeyframedValue
+			field={field}
+			fileName={validatedLocation.source}
+			nodePath={nodePath}
+			schema={schema}
+			propStatus={propStatus}
+			sourceFrame={sourceFrame}
+		/>
+	) : propStatus.status === 'static' ? (
+		<Value
+			field={field}
+			nodePath={nodePath}
+			validatedLocation={validatedLocation}
+			schema={schema}
+			propStatus={propStatus}
+		/>
+	) : (
+		<TimelineNonEditableStatus propStatus={propStatus} />
+	);
+
 	const row = (
 		<TimelineRowChrome
 			depth={rowDepth}
@@ -552,37 +572,13 @@ export const TimelineSequencePropItem: React.FC<{
 			containsSelection={false}
 			outerHeight={null}
 		>
-			<TimelineFieldLabel
+			<TimelineFieldRowContent
+				field={field}
 				rowDepth={rowDepth}
 				selected={selection.selected}
-				label={field.description ?? field.key}
-			/>
-			{isKeyframedStatus(propStatus) ? (
-				<div style={timelineFieldValueColumnStyle}>
-					<TimelineSequenceKeyframedValue
-						field={field}
-						fileName={validatedLocation.source}
-						nodePath={nodePath}
-						schema={schema}
-						propStatus={propStatus}
-						sourceFrame={sourceFrame}
-					/>
-				</div>
-			) : propStatus.status === 'static' ? (
-				<div style={timelineFieldValueColumnStyle}>
-					<Value
-						field={field}
-						nodePath={nodePath}
-						validatedLocation={validatedLocation}
-						schema={schema}
-						propStatus={propStatus}
-					/>
-				</div>
-			) : (
-				<div style={timelineFieldValueColumnStyle}>
-					<TimelineNonEditableStatus propStatus={propStatus} />
-				</div>
-			)}
+			>
+				{fieldValue}
+			</TimelineFieldRowContent>
 		</TimelineRowChrome>
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -350,12 +350,14 @@ export const TimelineSequencePropItem: React.FC<{
 			/>
 		) : null;
 
-	const style = useMemo(() => {
+	const style = useMemo((): React.CSSProperties => {
 		return {
 			...fieldRowBase,
-			height: field.rowHeight,
+			...(field.typeName === 'text-content'
+				? {minHeight: field.rowHeight}
+				: {height: field.rowHeight}),
 		};
-	}, [field.rowHeight]);
+	}, [field.rowHeight, field.typeName]);
 
 	const canResetToDefault = useMemo(() => {
 		if (!propStatus || propStatus.status === 'computed') {

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -351,12 +351,9 @@ export const TimelineSequencePropItem: React.FC<{
 		) : null;
 
 	const style = useMemo((): React.CSSProperties => {
-		return {
-			...fieldRowBase,
-			...(field.typeName === 'text-content'
-				? {minHeight: field.rowHeight}
-				: {height: field.rowHeight}),
-		};
+		return field.typeName === 'text-content'
+			? fieldRowBase
+			: {...fieldRowBase, height: field.rowHeight};
 	}, [field.rowHeight, field.typeName]);
 
 	const canResetToDefault = useMemo(() => {

--- a/packages/studio/src/components/Timeline/TimelineTextContentField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTextContentField.tsx
@@ -14,6 +14,18 @@ import {
 	registerFocusInspectorFieldElement,
 } from './focus-inspector-field';
 
+const textAreaStyle: React.CSSProperties = {
+	boxSizing: 'border-box',
+	maxHeight: 160,
+	minHeight: 40,
+	minWidth: 0,
+	overflowY: 'auto',
+	width: '100%',
+	...({
+		fieldSizing: 'content',
+	} satisfies React.CSSProperties & {fieldSizing: 'content'}),
+};
+
 export const TimelineTextContentField: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly effectiveValue: unknown;
@@ -143,12 +155,7 @@ export const TimelineTextContentField: React.FC<{
 			onBlur={commitPending}
 			onChange={onChange}
 			onKeyDownCapture={onKeyDownCapture}
-			style={{
-				boxSizing: 'border-box',
-				height: 40,
-				minWidth: 0,
-				width: '100%',
-			}}
+			style={textAreaStyle}
 		/>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineTextContentField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTextContentField.tsx
@@ -146,7 +146,8 @@ export const TimelineTextContentField: React.FC<{
 			style={{
 				boxSizing: 'border-box',
 				height: 40,
-				width: 160,
+				minWidth: 0,
+				width: '100%',
 			}}
 		/>
 	);

--- a/packages/studio/src/components/Timeline/timeline-field-row-layout.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-row-layout.ts
@@ -23,3 +23,11 @@ export const timelineFieldValueColumnStyle: React.CSSProperties = {
 	minWidth: 0,
 	paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 };
+
+export const timelineStackedFieldContentStyle: React.CSSProperties = {
+	alignSelf: 'stretch',
+	display: 'flex',
+	flex: 1,
+	flexDirection: 'column',
+	minWidth: 0,
+};


### PR DESCRIPTION
## Summary

- stack multiline text fields underneath their labels
- let the textarea fill the available inspector width
- increase the text field row height and cover it with a regression test

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
- visually verified at a 300px inspector width with no horizontal overflow

Closes #9029
