### PR TITLE
`@remotion/studio`: Add inspector location copy button

### DIFF
--- a/packages/studio/src/components/CurrentComposition.tsx
+++ b/packages/studio/src/components/CurrentComposition.tsx
@@ -23,6 +23,7 @@ import {
 	InspectorInfoHeader,
 	InspectorInfoSubtitle,
 } from './InspectorInfoHeader';
+import {InspectorLocationCopy} from './InspectorLocationCopy';
 import {InspectorSourceLocation} from './InspectorSourceLocation';
 import {showNotification} from './Notifications/NotificationCenter';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
@@ -126,24 +127,26 @@ export const CurrentComposition = () => {
 		<InspectorInfoHeader>
 			{video ? (
 				<>
-					<InlineCompositionName
-						key={video.id}
-						compositionId={video.id}
-						stack={currentComposition?.stack ?? null}
-						compositions={compositions}
-					/>
-					<InspectorSourceLocation
-						location={validatedLocation}
-						canOpen={validatedLocation !== null}
-						onOpen={openFileLocation}
-						renderIcon={renderCompositionIcon}
-					/>
-					<InspectorSourceLocation
-						location={componentLocation}
-						canOpen={componentLocation !== null}
-						onOpen={openComponentLocation}
-						renderIcon={renderReactIcon}
-					/>
+					<InspectorLocationCopy location={validatedLocation} name={video.id}>
+						<InlineCompositionName
+							key={video.id}
+							compositionId={video.id}
+							stack={currentComposition?.stack ?? null}
+							compositions={compositions}
+						/>
+						<InspectorSourceLocation
+							location={validatedLocation}
+							canOpen={validatedLocation !== null}
+							onOpen={openFileLocation}
+							renderIcon={renderCompositionIcon}
+						/>
+						<InspectorSourceLocation
+							location={componentLocation}
+							canOpen={componentLocation !== null}
+							onOpen={openComponentLocation}
+							renderIcon={renderReactIcon}
+						/>
+					</InspectorLocationCopy>
 					<InspectorInfoSubtitle>
 						{video.width}x{video.height}
 						{isCompositionStill(video) ? null : `, ${video.fps} FPS`}

--- a/packages/studio/src/components/InspectorLocationCopy.tsx
+++ b/packages/studio/src/components/InspectorLocationCopy.tsx
@@ -1,0 +1,106 @@
+import React, {useCallback, useMemo, useState} from 'react';
+import type {OriginalPosition} from '../error-overlay/react-overlay/utils/get-source-map';
+import {formatLocationForAgents} from '../helpers/format-file-location';
+import {ClipboardIcon} from '../icons/clipboard';
+import type {RenderInlineAction} from './InlineAction';
+import {InlineAction} from './InlineAction';
+import {showNotification} from './Notifications/NotificationCenter';
+
+const row: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	flexDirection: 'row',
+	minWidth: 0,
+	width: '100%',
+};
+
+const content: React.CSSProperties = {
+	display: 'flex',
+	flex: 1,
+	flexDirection: 'column',
+	minWidth: 0,
+	overflow: 'hidden',
+};
+
+const action: React.CSSProperties = {
+	flexShrink: 0,
+	height: 24,
+	marginLeft: 4,
+};
+
+const icon: React.CSSProperties = {
+	flexShrink: 0,
+	height: 12,
+	width: 12,
+};
+
+export const InspectorLocationCopy: React.FC<{
+	readonly children: React.ReactNode;
+	readonly location: OriginalPosition | null;
+	readonly name: string | null;
+}> = ({children, location, name}) => {
+	const [hovered, setHovered] = useState(false);
+	const [focusedWithin, setFocusedWithin] = useState(false);
+	const textToCopy = useMemo(() => {
+		return formatLocationForAgents({
+			location,
+			name,
+			root: window.remotion_cwd,
+		});
+	}, [location, name]);
+
+	const renderCopyAction: RenderInlineAction = useCallback((color) => {
+		return <ClipboardIcon style={icon} color={color} />;
+	}, []);
+
+	const onCopy: React.MouseEventHandler<HTMLButtonElement> = useCallback(
+		(event) => {
+			event.stopPropagation();
+			if (!textToCopy) {
+				return;
+			}
+
+			navigator.clipboard
+				.writeText(textToCopy)
+				.then(() => {
+					showNotification('Copied location for agents to clipboard', 1000);
+				})
+				.catch((err) => {
+					showNotification(
+						`Could not copy to clipboard: ${(err as Error).message}`,
+						2000,
+					);
+				});
+		},
+		[textToCopy],
+	);
+
+	const showAction = hovered || focusedWithin;
+
+	return (
+		<div
+			style={row}
+			onPointerEnter={() => setHovered(true)}
+			onPointerLeave={() => setHovered(false)}
+			onFocus={() => setFocusedWithin(true)}
+			onBlur={() => setFocusedWithin(false)}
+		>
+			<div style={content}>{children}</div>
+			{textToCopy ? (
+				<div
+					style={{
+						...action,
+						opacity: showAction ? 1 : 0,
+						pointerEvents: showAction ? 'auto' : 'none',
+					}}
+				>
+					<InlineAction
+						onClick={onCopy}
+						renderAction={renderCopyAction}
+						title="Copy location for agents"
+					/>
+				</div>
+			) : null}
+		</div>
+	);
+};

--- a/packages/studio/src/components/InspectorLocationCopy.tsx
+++ b/packages/studio/src/components/InspectorLocationCopy.tsx
@@ -26,6 +26,7 @@ const action: React.CSSProperties = {
 	flexShrink: 0,
 	height: 24,
 	marginLeft: 4,
+	marginRight: -4,
 };
 
 const icon: React.CSSProperties = {
@@ -60,17 +61,12 @@ export const InspectorLocationCopy: React.FC<{
 				return;
 			}
 
-			navigator.clipboard
-				.writeText(textToCopy)
-				.then(() => {
-					showNotification('Copied location for agents to clipboard', 1000);
-				})
-				.catch((err) => {
-					showNotification(
-						`Could not copy to clipboard: ${(err as Error).message}`,
-						2000,
-					);
-				});
+			navigator.clipboard.writeText(textToCopy).catch((err) => {
+				showNotification(
+					`Could not copy to clipboard: ${(err as Error).message}`,
+					2000,
+				);
+			});
 		},
 		[textToCopy],
 	);

--- a/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
@@ -3,6 +3,7 @@ import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-sou
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
 import {InlineEditableTitle} from '../InlineEditableTitle';
+import {InspectorLocationCopy} from '../InspectorLocationCopy';
 import {InspectorSourceLocation} from '../InspectorSourceLocation';
 import {useOpenSequenceInEditor} from '../Timeline/use-open-sequence-in-editor';
 import {useRenameSequence} from '../Timeline/use-rename-sequence';
@@ -100,30 +101,35 @@ export const SequenceInspectorHeader: React.FC<{
 
 	return (
 		<div style={sequenceHeader}>
-			<div style={sequenceHeaderTitle}>
-				<InlineEditableTitle
-					value={sequenceDisplayName}
-					canRename={canRename}
-					onCommit={onRename}
-				/>
-			</div>
-			{documentationLink ? (
-				<button
-					type="button"
-					style={subtitleStyle}
-					title="Open component docs"
-					onClick={openDocumentationLink}
-				>
-					{componentName}
-				</button>
-			) : (
-				<div style={subtitleStyle}>{componentName}</div>
-			)}
-			<InspectorSourceLocation
+			<InspectorLocationCopy
 				location={sourceLocation.validatedLocation}
-				canOpen={sourceLocation.canOpenInEditor}
-				onOpen={sourceLocation.openFileLocation}
-			/>
+				name={componentName ?? null}
+			>
+				<div style={sequenceHeaderTitle}>
+					<InlineEditableTitle
+						value={sequenceDisplayName}
+						canRename={canRename}
+						onCommit={onRename}
+					/>
+				</div>
+				{documentationLink ? (
+					<button
+						type="button"
+						style={subtitleStyle}
+						title="Open component docs"
+						onClick={openDocumentationLink}
+					>
+						{componentName}
+					</button>
+				) : (
+					<div style={subtitleStyle}>{componentName}</div>
+				)}
+				<InspectorSourceLocation
+					location={sourceLocation.validatedLocation}
+					canOpen={sourceLocation.canOpenInEditor}
+					onOpen={sourceLocation.openFileLocation}
+				/>
+			</InspectorLocationCopy>
 		</div>
 	);
 };

--- a/packages/studio/src/helpers/format-file-location.ts
+++ b/packages/studio/src/helpers/format-file-location.ts
@@ -39,3 +39,21 @@ export const formatFileLocation = ({
 
 	return `${stripLeadingDotSlash(relativeSource)}:${location.line}`;
 };
+
+export const formatLocationForAgents = ({
+	name,
+	location,
+	root,
+}: {
+	readonly name: string | null;
+	readonly location: FileLocation | null;
+	readonly root: string;
+}) => {
+	const fileLocation = formatFileLocation({location, root});
+
+	if (!name || !fileLocation) {
+		return null;
+	}
+
+	return `${name} in ${fileLocation}`;
+};

--- a/packages/studio/src/test/format-file-location.test.ts
+++ b/packages/studio/src/test/format-file-location.test.ts
@@ -1,5 +1,8 @@
 import {expect, test} from 'bun:test';
-import {formatFileLocation} from '../helpers/format-file-location';
+import {
+	formatFileLocation,
+	formatLocationForAgents,
+} from '../helpers/format-file-location';
 
 test('Should format file locations relative to the project root', () => {
 	expect(
@@ -68,4 +71,30 @@ test('Should not format missing file locations', () => {
 			root: '/Users/example/video',
 		}),
 	).toBe(null);
+});
+
+test('Should format composition locations for agents', () => {
+	expect(
+		formatLocationForAgents({
+			location: {
+				source: '/Users/example/video/src/Root.tsx',
+				line: 399,
+			},
+			name: 'keyframed-props-test',
+			root: '/Users/example/video',
+		}),
+	).toBe('keyframed-props-test in src/Root.tsx:399');
+});
+
+test('Should format component locations for agents', () => {
+	expect(
+		formatLocationForAgents({
+			location: {
+				source: '/Users/example/video/src/KeyframesPropsTest.tsx',
+				line: 67,
+			},
+			name: '<AnimatedImage>',
+			root: '/Users/example/video',
+		}),
+	).toBe('<AnimatedImage> in src/KeyframesPropsTest.tsx:67');
 });


### PR DESCRIPTION
## Summary

- add a hover-revealed copy action to composition and sequence inspector headers
- copy agent-friendly names with project-relative source locations
- keep long inspector labels truncated without shifting when the action appears

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- visually verified composition and sequence hover, overflow, centering, and copied text in Studio

Closes #9051
