### PR TITLE
`@remotion/example`: Improve independent timeline interactivity

### DIFF
--- a/packages/example/src/Issue8974TimelineInteractivity/index.tsx
+++ b/packages/example/src/Issue8974TimelineInteractivity/index.tsx
@@ -2,7 +2,6 @@ import {Video} from '@remotion/media';
 import {linearTiming, TransitionSeries} from '@remotion/transitions';
 import {fade} from '@remotion/transitions/fade';
 import React from 'react';
-import {Sequence} from 'remotion';
 
 export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 	return (
@@ -75,21 +74,35 @@ export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 export const Issue8974IndependentVideosTimeline: React.FC = () => {
 	return (
 		<>
-			<Sequence name="Independent clip 01" durationInFrames={78}>
-				<Video src="https://remotion.media/video.mp4" trimBefore={0} />
-			</Sequence>
-			<Sequence name="Independent clip 02" from={78} durationInFrames={66}>
-				<Video src="https://remotion.media/video.webm" trimBefore={12} />
-			</Sequence>
-			<Sequence name="Independent clip 03" from={144} durationInFrames={90}>
-				<Video src="https://remotion.media/video.mp4" trimBefore={72} />
-			</Sequence>
-			<Sequence name="Independent clip 04" from={234} durationInFrames={72}>
-				<Video src="https://remotion.media/video.webm" trimBefore={58} />
-			</Sequence>
-			<Sequence name="Independent clip 05" from={306} durationInFrames={60}>
-				<Video src="https://remotion.media/video.mp4" trimBefore={180} />
-			</Sequence>
+			<Video
+				src="https://remotion.media/video.mp4"
+				trimBefore={0}
+				durationInFrames={78}
+			/>
+			<Video
+				src="https://remotion.media/video.webm"
+				trimBefore={12}
+				from={78}
+				durationInFrames={66}
+			/>
+			<Video
+				src="https://remotion.media/video.mp4"
+				trimBefore={72}
+				from={144}
+				durationInFrames={90}
+			/>
+			<Video
+				src="https://remotion.media/video.webm"
+				trimBefore={58}
+				from={234}
+				durationInFrames={72}
+			/>
+			<Video
+				src="https://remotion.media/video.mp4"
+				trimBefore={180}
+				from={306}
+				durationInFrames={60}
+			/>
 		</>
 	);
 };

--- a/packages/example/src/Issue8974TimelineInteractivity/index.tsx
+++ b/packages/example/src/Issue8974TimelineInteractivity/index.tsx
@@ -76,53 +76,19 @@ export const Issue8974IndependentVideosTimeline: React.FC = () => {
 	return (
 		<>
 			<Sequence name="Independent clip 01" durationInFrames={78}>
-				<Video
-					name="Independent video 01"
-					src="https://remotion.media/video.mp4"
-					trimBefore={0}
-					trimAfter={78}
-					muted
-				/>
+				<Video src="https://remotion.media/video.mp4" trimBefore={0} />
 			</Sequence>
-
 			<Sequence name="Independent clip 02" from={78} durationInFrames={66}>
-				<Video
-					name="Independent video 02"
-					src="https://remotion.media/video.webm"
-					trimBefore={12}
-					trimAfter={78}
-					muted
-				/>
+				<Video src="https://remotion.media/video.webm" trimBefore={12} />
 			</Sequence>
-
 			<Sequence name="Independent clip 03" from={144} durationInFrames={90}>
-				<Video
-					name="Independent video 03"
-					src="https://remotion.media/video.mp4"
-					trimBefore={72}
-					trimAfter={162}
-					muted
-				/>
+				<Video src="https://remotion.media/video.mp4" trimBefore={72} />
 			</Sequence>
-
 			<Sequence name="Independent clip 04" from={234} durationInFrames={72}>
-				<Video
-					name="Independent video 04"
-					src="https://remotion.media/video.webm"
-					trimBefore={58}
-					trimAfter={130}
-					muted
-				/>
+				<Video src="https://remotion.media/video.webm" trimBefore={58} />
 			</Sequence>
-
 			<Sequence name="Independent clip 05" from={306} durationInFrames={60}>
-				<Video
-					name="Independent video 05"
-					src="https://remotion.media/video.mp4"
-					trimBefore={180}
-					trimAfter={240}
-					muted
-				/>
+				<Video src="https://remotion.media/video.mp4" trimBefore={180} />
 			</Sequence>
 		</>
 	);

--- a/packages/skills/skills/remotion-interactivity/SKILL.md
+++ b/packages/skills/skills/remotion-interactivity/SKILL.md
@@ -12,3 +12,7 @@ Use the canonical interactivity best-practices page instead:
 
 To make an element or custom component interactive, use:
 [Make a component interactive](https://www.remotion.dev/docs/studio/make-component-interactive.md)
+
+## Video editing
+
+If a Remotion component mainly consists of video and audio clips, see [Video editing](../remotion-markup/video-editing.md) for best practices on how to structure Remotion markup so the clips are interactively editable in the timeline.

--- a/packages/skills/skills/remotion-markup/SKILL.md
+++ b/packages/skills/skills/remotion-markup/SKILL.md
@@ -156,6 +156,10 @@ See [trimming.md](trimming.md) for trimming patterns - cutting the beginning or 
 
 See [embedding-videos.md](embedding-videos.md) for advanced knowledge about embedding videos - trimming, volume, speed, looping, pitch.
 
+## Video editing
+
+See [video-editing.md](video-editing.md) for structuring editable video timelines in Remotion Studio.
+
 ## Embedding Audio
 
 See [audio.md](audio.md) for advanced audio features like trimming, volume, speed, pitch.

--- a/packages/skills/skills/remotion-markup/video-editing.md
+++ b/packages/skills/skills/remotion-markup/video-editing.md
@@ -1,0 +1,19 @@
+Remotion can be used for barebones video editing. Layers can be dragged on the left side and right side to be trimmed, and layers can be moved around in the Studio.
+
+For this to work correctly, the markup must be structured like this:
+
+```tsx
+<Video src="https://remotion.media/video.mp4" trimBefore={0} durationInFrames={78}/>
+<Video src="https://remotion.media/video.webm" trimBefore={12} from={78} durationInFrames={66}/>
+<Video src="https://remotion.media/video.mp4" trimBefore={72}  from={144} durationInFrames={90}/>
+<Video src="https://remotion.media/video.webm" trimBefore={58} from={234} durationInFrames={72}/>
+<Video src="https://remotion.media/video.mp4" trimBefore={180} from={306} durationInFrames={60} />
+```
+
+`from` determines at which frame in the timeline the video starts.
+`durationInFrames` determines at which frame in the timeline the video ends.
+The video starts playing at 0 seconds, unless `trimBefore` (in frames) is set.
+
+- Each Video must be it's independent node in the source code, no programmatic iteration such as `.map`
+- `from`, `durationInFrames` and `trimBefore` must be hardcoded in frames. They cannot be computed.
+- `<Video>` must be imported from `@remotion/media`.


### PR DESCRIPTION
## Summary

- simplify the independent timeline example so each `Sequence` is the editable clip
- keep the source trim offset on each video while letting the sequence control clip duration

## Testing

- `bun run build`
- `bun run stylecheck`

Improves #8974
