### PR TITLE
`@remotion/studio`: Allow resizing media clips in the timeline

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -47,6 +47,7 @@ import {TimelineSequenceFrame} from './TimelineSequenceFrame';
 import {
 	TimelineSequenceLeftEdgeDragHandle,
 	TimelineSequenceRightEdgeDragHandle,
+	isTimelineSequenceDurationDraggable,
 	useTimelineSequenceFromDrag,
 } from './TimelineSequenceRightEdgeDragHandle';
 import {TimelineVideoInfo} from './TimelineVideoInfo';
@@ -518,9 +519,7 @@ const TimelineSequenceInner: React.FC<{
 	}, [marginLeft, s.type, width]);
 
 	const showRightEdgeDragHandle =
-		(s.type === 'sequence' || s.type === 'image') &&
-		!s.loopDisplay &&
-		!s.isInsideSeries &&
+		isTimelineSequenceDurationDraggable(s) &&
 		nodePath !== null &&
 		validatedLocation !== null &&
 		durationCanUpdate;

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -199,9 +199,12 @@ const canUpdateTrimBefore = ({
 	return status === 'static';
 };
 
-const isDurationDraggableSequence = (sequence: TSequence) => {
+export const isTimelineSequenceDurationDraggable = (sequence: TSequence) => {
 	return (
-		(sequence.type === 'sequence' || sequence.type === 'image') &&
+		(sequence.type === 'sequence' ||
+			sequence.type === 'image' ||
+			sequence.type === 'audio' ||
+			sequence.type === 'video') &&
 		!sequence.loopDisplay &&
 		!sequence.isInsideSeries &&
 		Boolean(sequence.controls)
@@ -510,7 +513,7 @@ export const getTimelineSequenceDurationDragTargets = ({
 			!track ||
 			!track.nodePathInfo ||
 			!originalSequence ||
-			!isDurationDraggableSequence(originalSequence)
+			!isTimelineSequenceDurationDraggable(originalSequence)
 		) {
 			return null;
 		}

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -107,6 +107,7 @@ import {
 	getTimelineSequenceLeftEdgeDragChanges,
 	getTimelineSequenceLeftEdgeDragTargets,
 	getTimelineSequenceLeftEdgeDragValues,
+	isTimelineSequenceDurationDraggable,
 } from '../components/Timeline/TimelineSequenceRightEdgeDragHandle';
 import {
 	parsedTransformOriginToUv,
@@ -1045,6 +1046,36 @@ test('Timeline duration drag uses the declared duration for negative from values
 			deltaFrames: 0,
 		}),
 	).toEqual([]);
+});
+
+test('Timeline duration drag supports interactive video clips', () => {
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const video = makeTimelineSequence({
+		schema: Internals.baseSchema,
+		type: 'video',
+		duration: 78,
+	});
+
+	expect(isTimelineSequenceDurationDraggable(video)).toBe(true);
+	expect(
+		getTimelineSequenceDurationDragTargets({
+			draggedNodePathInfo: nodePathInfo,
+			selectedItems: [{type: 'sequence', nodePathInfo}],
+			sequences: [video],
+			overrideIdsToNodePaths: {
+				override: nodePathInfo.sequenceSubscriptionKey,
+			},
+			propStatuses: makeDurationPropStatuses([
+				nodePathInfo.sequenceSubscriptionKey,
+			]),
+		}),
+	).toEqual([
+		{
+			fileName: nodePathInfo.sequenceSubscriptionKey.absolutePath,
+			initialDuration: 78,
+			nodePath: nodePathInfo.sequenceSubscriptionKey,
+		},
+	]);
 });
 
 test('Timeline duration drag clamps each selected sequence to one frame', () => {


### PR DESCRIPTION
## Summary

- enable right-edge duration resizing for interactive video and audio clips
- share duration-drag eligibility between timeline rendering and drag validation
- add regression coverage for interactive video clips

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9108
