### PR TITLE
`@remotion/studio`: Adapt dynamic Elements to compositions

### DIFF
--- a/packages/docs/elements/backgrounds/paper-texture/paper-texture.tsx
+++ b/packages/docs/elements/backgrounds/paper-texture/paper-texture.tsx
@@ -1,15 +1,16 @@
 import {paper} from '@remotion/effects/paper';
 import React from 'react';
-import {interpolate, Solid, useCurrentFrame} from 'remotion';
+import {interpolate, Solid, useCurrentFrame, useVideoConfig} from 'remotion';
 
 export const PaperTexture: React.FC = () => {
 	const frame = useCurrentFrame();
+	const {height, width} = useVideoConfig();
 
 	return (
 		<Solid
 			color="white"
-			width={1920}
-			height={1080}
+			width={width}
+			height={height}
 			effects={[
 				paper({
 					colorFront: 'white',

--- a/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
+++ b/packages/docs/elements/backgrounds/rotating-starburst/rotating-starburst.tsx
@@ -1,15 +1,16 @@
 import {starburst} from '@remotion/starburst';
 import React from 'react';
-import {interpolate, Solid, useCurrentFrame} from 'remotion';
+import {interpolate, Solid, useCurrentFrame, useVideoConfig} from 'remotion';
 
 export const RotatingStarburst: React.FC = () => {
 	const frame = useCurrentFrame();
+	const {height, width} = useVideoConfig();
 
 	return (
 		<Solid
 			color="#dff4ff"
-			width={1920}
-			height={1080}
+			width={width}
+			height={height}
 			effects={[
 				starburst({
 					rays: 28,

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -244,6 +244,26 @@ describe('Element preview definitions', () => {
 		}
 	});
 
+	test('dimensionless Solid backgrounds use composition dimensions', () => {
+		for (const slug of [
+			'backgrounds/paper-texture',
+			'backgrounds/rotating-starburst',
+		] as const) {
+			const definition = elementDefinitions[slug];
+			const element = productionElements.find((entry) => entry.name === slug);
+			if (!element) {
+				throw new Error(`Could not find Element source for ${slug}`);
+			}
+
+			const source = readFileSync(element.tsxPath, 'utf8');
+			expect(definition.elementWidth).toBe(null);
+			expect(definition.elementHeight).toBe(null);
+			expect(source).toContain('useVideoConfig()');
+			expect(source).not.toContain(`width={${definition.width}}`);
+			expect(source).not.toContain(`height={${definition.height}}`);
+		}
+	});
+
 	test('derives stable composition IDs and preview URLs', () => {
 		const compositionIds = elementDefinitionList.map((definition) =>
 			getElementCompositionId(definition.slug),

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -237,6 +237,20 @@ const getCenteredPosition = ({
 	};
 };
 
+export const getElementPositionForDrop = ({
+	dimensions,
+	dropPosition,
+}: {
+	dimensions: Dimensions | null;
+	dropPosition: InsertElementDropPosition | null;
+}): InsertableCompositionElementPosition | null => {
+	if (dimensions === null) {
+		return null;
+	}
+
+	return getCenteredPosition({dimensions, dropPosition});
+};
+
 const getComponentPropNumber = (props: ComponentProp[], name: string) => {
 	const prop = props.find((p) => p.name === name);
 	return typeof prop?.value === 'number' ? prop.value : null;
@@ -926,7 +940,7 @@ export const insertElement = async ({
 			compositionFile,
 			compositionId,
 			element,
-			position: getCenteredPosition({
+			position: getElementPositionForDrop({
 				dimensions: element.dimensions,
 				dropPosition,
 			}),

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -3,6 +3,7 @@ import {
 	getAssetElement,
 	getAssetElementFromPath,
 	getComponentDimensions,
+	getElementPositionForDrop,
 } from '../components/import-assets';
 
 test('maps audio file types to Audio assets', () => {
@@ -127,4 +128,31 @@ test('falls back to generic component dimensions', () => {
 			],
 		}),
 	).toEqual({width: 320, height: 180});
+});
+
+test('places dimensionless Elements at the composition origin', () => {
+	expect(
+		getElementPositionForDrop({
+			dimensions: null,
+			dropPosition: {centerX: 500, centerY: 300},
+		}),
+	).toBe(null);
+});
+
+test('centers fixed-size Elements at the drop position', () => {
+	expect(
+		getElementPositionForDrop({
+			dimensions: {width: 680, height: 138},
+			dropPosition: {centerX: 500, centerY: 300},
+		}),
+	).toEqual({x: 160, y: 231});
+});
+
+test('does not position Elements without a drop position', () => {
+	expect(
+		getElementPositionForDrop({
+			dimensions: {width: 680, height: 138},
+			dropPosition: null,
+		}),
+	).toBe(null);
 });


### PR DESCRIPTION
## Summary

- keep composition-sized Elements at the composition origin when they are dropped into Studio
- size Paper Texture and Rotating Starburst from the active composition dimensions
- preserve cursor-centered positioning for fixed-size Elements such as Lower Third
- add regression tests for dynamic Element positioning and dimensions

Closes #8886

## Testing

- `bun test packages/studio/src/test/import-assets.test.ts`
- `bun test packages/docs/src/test/elements.test.ts`
- `bunx turbo run lint test --filter='@remotion/studio' --filter='@remotion/studio-server' --filter='@remotion/studio-shared' --filter='docs'`
- `bun run build`
- `bun run stylecheck`
