### PR TITLE
`remotion-monorepo`: Add Element contribution skills

### DIFF
--- a/.agents/skills/new-element/SKILL.md
+++ b/.agents/skills/new-element/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: new-element
+description: Scaffold a new Remotion Element with a correctly configured preview composition for development in the docs Remotion Studio.
+---
+
+# Start a new Remotion Element
+
+The source of truth is the [Element contributor guide](../../../packages/docs/elements/submit-an-element.mdx). Read it completely before making changes and follow it for all design and implementation decisions. If this skill and the guide diverge, follow the guide.
+
+This skill prepares a development scaffold. Use the [`publish-element` skill](../publish-element/SKILL.md) when the Element is ready for the gallery.
+
+## 1. Plan the preview
+
+Choose an existing category and a kebab-case slug. Before creating files, determine the initial preview metadata needed for development:
+
+- Composition width, height, fps, and duration
+- Fixed Element width and height, or `null` for both
+- Preview padding
+- A provisional poster frame
+
+Inspect `packages/docs/elements-template/` and at least one existing Element in the same category. Do not create a new category unless the task explicitly requires one.
+
+## 2. Scaffold the files
+
+From the repository root, replace the placeholders and run:
+
+```bash
+cp -R packages/docs/elements-template \
+  packages/docs/elements/<category>/<slug>
+mv packages/docs/elements/<category>/<slug>/element.tsx \
+  packages/docs/elements/<category>/<slug>/<slug>.tsx
+```
+
+Adapt the copied `index.mdx` to the production pattern: import `elementDefinitions`, use its `'<category>/<slug>'` entry, and set `sourceFile="./<slug>.tsx"`.
+
+Implement only enough of the component to provide a visible starting point in the intended bounds. Follow the contributor guide for the component itself. When using Studio-editable controls, also follow the [interactivity best practices skill](../interactivity-best-practices/SKILL.md).
+
+## 3. Register the development composition
+
+Import and register the component in `packages/docs/src/components/Elements/element-definitions.ts` using the planned preview metadata.
+
+Do not edit `packages/docs/src/remotion/Root.tsx`. It automatically creates a composition for every central definition using the same sizing and wrapper used by published Elements.
+
+If the component imports a package that is not available to `packages/docs`, add it to `packages/docs/package.json`, run `bun install`, and include `bun.lock`.
+
+## 4. Check the scaffold
+
+Format the changed TypeScript and TSX files, then run the focused test:
+
+```bash
+bunx oxfmt \
+  packages/docs/elements/<category>/<slug>/<slug>.tsx \
+  packages/docs/src/components/Elements/element-definitions.ts \
+  --write
+
+cd packages/docs
+bun test src/test/elements.test.ts
+cd ../..
+```
+
+Do not add the category-index or sidebar entries and do not render final preview assets yet. Those belong to the publishing workflow.
+
+## 5. Hand off development
+
+Do not launch the Studio from this skill. Tell the developer to run:
+
+```bash
+bun run build
+cd packages/docs
+bun run remotion
+```
+
+Then tell them to open the `elements` folder and select `element-<category>-<slug>`. Development should start in that composition so the Element is always evaluated with its configured dimensions, duration, padding, and preview background.
+
+Report the created files, composition ID, focused test result, and that the next step after development is the [`publish-element` skill](../publish-element/SKILL.md).

--- a/.agents/skills/publish-element/SKILL.md
+++ b/.agents/skills/publish-element/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: publish-element
+description: Finalize a developed Remotion Element, add it to the docs gallery, render its previews, and run repository checks.
+---
+
+# Publish a Remotion Element
+
+The source of truth is the [Element contributor guide](../../../packages/docs/elements/submit-an-element.mdx). Read it completely before making changes and follow it for all acceptance criteria. If this skill and the guide diverge, follow the guide.
+
+This skill starts with an Element scaffold created by the [`new-element` skill](../new-element/SKILL.md). It does not create the initial development scaffold.
+
+## 1. Confirm the Element is ready
+
+Confirm these files and the matching entry in `packages/docs/src/components/Elements/element-definitions.ts` already exist:
+
+- `packages/docs/elements/<category>/<slug>/index.mdx`
+- `packages/docs/elements/<category>/<slug>/<slug>.tsx`
+
+Do not launch the Studio from this skill. Ask the developer to confirm that they developed and reviewed `element-<category>-<slug>` in the docs Remotion Studio. If more visual development is needed, give them these commands and stop the publishing workflow:
+
+```bash
+bun run build
+cd packages/docs
+bun run remotion
+```
+
+## 2. Perform the publication review
+
+Review the finished source, MDX page, and central definition against the contributor guide. Resolve placeholder content and finalize the description, display name, contributors, dimensions, duration, preview padding, and poster frame.
+
+When the Element has Studio-editable controls, also review it using the [interactivity best practices skill](../interactivity-best-practices/SKILL.md).
+
+If the Element imports a package that is not available to `packages/docs`, add it to `packages/docs/package.json`, run `bun install`, and include `bun.lock`.
+
+## 3. Add it to the gallery
+
+- Add the Element page to `packages/docs/elements/<category>/index.mdx`.
+- Add `'<category>/<slug>/index'` to the matching category in `packages/docs/elements-sidebars.ts`.
+
+Preserve the ordering used by the category page and sidebar. If the task explicitly introduces a new category, create its category index and sidebar group as part of this step.
+
+Do not edit `packages/docs/src/remotion/Root.tsx`; Element compositions are derived from the central definitions.
+
+## 4. Format and test
+
+Format the changed TypeScript and TSX files only. For the usual files:
+
+```bash
+bunx oxfmt \
+  packages/docs/elements/<category>/<slug>/<slug>.tsx \
+  packages/docs/src/components/Elements/element-definitions.ts \
+  packages/docs/elements-sidebars.ts \
+  --write
+
+cd packages/docs
+bun test src/test/elements.test.ts
+```
+
+## 5. Render and inspect the previews
+
+Perform the preview verification required by the contributor guide:
+
+```bash
+bun run render-element-previews
+```
+
+Inspect `.element-previews/<category>/<slug>/preview.png` and `preview.mp4`, and give those paths to the developer for review. This command renders every Element and clears the previous preview output. Do not commit the ignored output or pass `--upload` unless uploading was explicitly requested and maintainer R2 credentials are available.
+
+Return to the repository root:
+
+```bash
+cd ../..
+```
+
+## 6. Run final repository checks
+
+```bash
+bun run build
+bun run build-docs
+bun run stylecheck
+git diff --check
+git status --short
+```
+
+Before finishing, verify that the page is listed in its category and sidebar, all checks pass, and only intended files are part of the change. Report the commands run, their results, and the preview files inspected.

--- a/.agents/skills/publish-element/SKILL.md
+++ b/.agents/skills/publish-element/SKILL.md
@@ -61,16 +61,12 @@ bun test src/test/elements.test.ts
 Perform the preview verification required by the contributor guide:
 
 ```bash
+cd packages/docs
 bun run render-element-previews
-```
-
-Inspect `.element-previews/<category>/<slug>/preview.png` and `preview.mp4`, and give those paths to the developer for review. This command renders every Element and clears the previous preview output. Do not commit the ignored output or pass `--upload` unless uploading was explicitly requested and maintainer R2 credentials are available.
-
-Return to the repository root:
-
-```bash
 cd ../..
 ```
+
+Inspect `packages/docs/.element-previews/<category>/<slug>/preview.png` and `preview.mp4`, and give those paths to the developer for review. This command renders every Element and clears the previous preview output. Do not commit the ignored output or pass `--upload` unless uploading was explicitly requested and maintainer R2 credentials are available.
 
 ## 6. Run final repository checks
 

--- a/.claude/skills/new-element
+++ b/.claude/skills/new-element
@@ -1,0 +1,1 @@
+../../.agents/skills/new-element

--- a/.claude/skills/publish-element
+++ b/.claude/skills/publish-element
@@ -1,0 +1,1 @@
+../../.agents/skills/publish-element


### PR DESCRIPTION
## Summary

- add a `new-element` skill for scaffolding an Element with a Studio-ready preview composition
- add a `publish-element` skill for gallery integration, preview rendering, and final repository checks
- add Claude Code compatibility symlinks for both skills
- keep the existing Element contributor guide as the source of truth

## Verification

- `bun run build`
- `bun run stylecheck`
- `git diff --cached --check`

Closes #8158
