### PR TITLE
Docs: Show adaptive Element dimensions

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -12,6 +12,7 @@ import React, {
 import {BlueButton, PlainButton} from '../../../components/layout/Button';
 import type {ElementDefinition} from './element-definitions';
 import {setElementDragData, setElementDragImage} from './element-drag-data';
+import {getElementDimensionsLabel} from './element-utils';
 import {ElementPreview} from './ElementPreview';
 import {
 	ElementPreviewComposition,
@@ -318,10 +319,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 						<dl className={styles.metadata}>
 							<div>
 								<dt>Dimensions</dt>
-								<dd>
-									{elementWidth ?? definition.width} ×{' '}
-									{elementHeight ?? definition.height}px
-								</dd>
+								<dd>{getElementDimensionsLabel(definition)}</dd>
 							</div>
 						</dl>
 					</div>

--- a/packages/docs/src/components/Elements/element-utils.ts
+++ b/packages/docs/src/components/Elements/element-utils.ts
@@ -1,4 +1,15 @@
-import {elementDefinitions} from './element-definitions';
+import {
+	elementDefinitions,
+	type ElementDefinition,
+} from './element-definitions';
+
+export const getElementDimensionsLabel = (definition: ElementDefinition) => {
+	if (definition.elementWidth === null || definition.elementHeight === null) {
+		return 'Adapts to composition';
+	}
+
+	return `${definition.elementWidth} × ${definition.elementHeight}px`;
+};
 
 export const getElementCompositionId = (slug: string) => {
 	return `element-${slug.replaceAll('/', '-')}`;

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -9,6 +9,7 @@ import remarkElementSource from '../../plugins/remark-element-source';
 import {elementDefinitions} from '../components/Elements/element-definitions';
 import {
 	getElementCompositionId,
+	getElementDimensionsLabel,
 	getElementPreviewUrls,
 } from '../components/Elements/element-utils';
 import {getElementPreviewDimensions} from '../components/Elements/ElementPreviewComposition';
@@ -242,6 +243,24 @@ describe('Element preview definitions', () => {
 			expect(dimensions.width % 2).toBe(0);
 			expect(dimensions.height % 2).toBe(0);
 		}
+	});
+
+	test('keeps displayed Element dimensions separate from preview dimensions', () => {
+		const adaptiveDefinition = elementDefinitions['backgrounds/paper-texture'];
+		expect(getElementDimensionsLabel(adaptiveDefinition)).toBe(
+			'Adapts to composition',
+		);
+		expect(getElementPreviewDimensions(adaptiveDefinition)).toEqual({
+			height: 1080,
+			width: 1920,
+		});
+
+		const fixedDefinition = elementDefinitions['overlays/lower-third'];
+		expect(getElementDimensionsLabel(fixedDefinition)).toBe('680 × 138px');
+		expect(getElementPreviewDimensions(fixedDefinition)).toEqual({
+			height: 738,
+			width: 1280,
+		});
 	});
 
 	test('dimensionless Solid backgrounds use composition dimensions', () => {


### PR DESCRIPTION
## Summary

- show “Adapts to composition” for adaptive Elements in docs metadata
- keep fixed Element dimensions distinct from preview rendering dimensions
- add regression coverage for adaptive and fixed-size Elements

## Verification

- `bun test packages/docs/src/test/elements.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9117
