### PR TITLE
`remotion-monorepo`: Clarify PR naming conventions

### DIFF
--- a/.agents/skills/pr-name/SKILL.md
+++ b/.agents/skills/pr-name/SKILL.md
@@ -23,3 +23,15 @@ If the change is about docs only:
 ```
 Docs: Add page about heart shape
 ```
+
+If the change adds or modifies a skill, or is otherwise internal monorepo work, use the `remotion-monorepo` prefix:
+
+```
+`remotion-monorepo`: Add PR naming skill
+```
+
+If the change relates to Remotion Elements, use the `Elements:` prefix:
+
+```
+Elements: Add animated title element
+```

--- a/.agents/skills/pr-name/SKILL.md
+++ b/.agents/skills/pr-name/SKILL.md
@@ -3,7 +3,7 @@ name: pr-name
 description: Correct naming for a PR
 ---
 
-The following format must be used for the PR title:
+By default, use the affected package name from its `package.json` in the PR title:
 
 ```
 `[package-name]`: [commit-message]
@@ -15,8 +15,11 @@ For example:
 `@remotion/shapes`: Add heart shape
 ```
 
-The package name must be obtained from package.json.  
-If multiple packages are affected, use the one that you think if most relevant.
+If multiple packages are affected, use the one that you think is most relevant.
+
+## Special handling
+
+For changes that match one of the categories below, use its special prefix instead of a package name.
 
 If the change is about docs only:
 


### PR DESCRIPTION
## Summary

- use the `remotion-monorepo` PR title prefix for skills and other internal changes
- use the `Elements:` prefix for Remotion Elements changes

## Verification

- `bunx oxfmt .agents/skills/pr-name/SKILL.md --write`
- `bun run build`
- `bun run stylecheck`
- `git diff --check`
