### PR TITLE
Docs: Recommend @remotion/media in more guides

### DIFF
--- a/packages/docs/docs/audiobuffertodataurl.mdx
+++ b/packages/docs/docs/audiobuffertodataurl.mdx
@@ -7,7 +7,7 @@ crumb: '@remotion/media-utils'
 
 _Part of the `@remotion/media-utils` package of helper functions. Available from v2.5.7._
 
-This API takes an [`AudioBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer) instance and converts it to a Base 64 Data URL so it can be passed to an [`<Html5Audio />`](/docs/html5-audio) tag.
+This API takes an [`AudioBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer) instance and converts it to a Base 64 Data URL so it can be passed to an [`<Audio>`](/docs/media/audio) tag from `@remotion/media`.
 
 ## API Usage
 
@@ -25,8 +25,9 @@ The following composition will render a sine tone with a C4 pitch.
 
 ```tsx twoslash
 import {audioBufferToDataUrl} from '@remotion/media-utils';
+import {Audio} from '@remotion/media';
 import {useCallback, useEffect, useState} from 'react';
-import {Html5Audio, cancelRender, continueRender, delayRender, interpolate, useVideoConfig} from 'remotion';
+import {cancelRender, continueRender, delayRender, interpolate, useVideoConfig} from 'remotion';
 
 const C4_FREQUENCY = 261.63;
 const sampleRate = 44100;
@@ -67,7 +68,7 @@ export const OfflineAudioBufferExample: React.FC = () => {
   }, [renderAudio]);
 
   return audioBuffer ? (
-    <Html5Audio
+    <Audio
       src={audioBuffer}
       trimAfter={100}
       volume={(f) =>

--- a/packages/docs/docs/dynamic-metadata.mdx
+++ b/packages/docs/docs/dynamic-metadata.mdx
@@ -325,4 +325,4 @@ export const Index: React.FC = () => {
 
 - [How props get resolved](/docs/props-resolution)
 - [Data fetching](/docs/data-fetching)
-- [How do I make the composition the same duration as my video?](/docs/videos/align-duration)
+- [Match a composition's duration to a video using Mediabunny](/docs/videos/align-duration)

--- a/packages/docs/docs/miscellaneous/pexels.mdx
+++ b/packages/docs/docs/miscellaneous/pexels.mdx
@@ -26,4 +26,6 @@ These timeouts are not a problem from Remotion's side.
 
 ## Solution
 
-Instead of using direct links from services like Pexels, download and re-host the videos on your own servers, or in a S3 bucket.
+Use [`<Video>`](/docs/media/video) from [`@remotion/media`](/docs/media). It is the recommended option and gives a more precise error message for network failures.
+
+If you cannot use `@remotion/media`, avoid direct links from services like Pexels. Download and re-host the videos on your own servers, or in a S3 bucket.

--- a/packages/docs/docs/videos/align-duration.mdx
+++ b/packages/docs/docs/videos/align-duration.mdx
@@ -8,31 +8,32 @@ crumb: 'FAQ'
 If you have a component rendering a video:
 
 ```tsx twoslash title="MyComp.tsx"
+import {Video} from '@remotion/media';
 import React from 'react';
-import {OffthreadVideo, staticFile} from 'remotion';
+import {staticFile} from 'remotion';
 
 export const MyComp: React.FC = () => {
-  return <OffthreadVideo src={staticFile('video.mp4')} />;
+  return <Video src={staticFile('video.mp4')} />;
 };
 ```
 
 and you want to make the composition the same duration as the video, first make the video source a React prop:
 
 ```tsx twoslash title="MyComp.tsx"
+import {Video} from '@remotion/media';
 import React from 'react';
-import {OffthreadVideo, staticFile} from 'remotion';
 
 type MyCompProps = {
   src: string;
 };
 
 export const MyComp: React.FC<MyCompProps> = ({src}) => {
-  return <OffthreadVideo src={src} />;
+  return <Video src={src} />;
 };
 ```
 
 Then, define a [`calculateMetadata()`](/docs/calculate-metadata) function that calculates the duration of the composition based on the video.  
-[Install `@remotion/media-parser`](/docs/media-parser) if necessary.
+[Install Mediabunny](https://mediabunny.dev/guide/quick-start) if necessary.
 
 ```tsx twoslash title="MyComp.tsx"
 type MyCompProps = {
@@ -41,60 +42,65 @@ type MyCompProps = {
 
 // ---cut---
 
-import {CalculateMetadataFunction} from 'remotion';
-import {parseMedia} from '@remotion/media-parser';
+import {ALL_FORMATS, Input, UrlSource} from 'mediabunny';
+import type {CalculateMetadataFunction} from 'remotion';
 
 export const calculateMetadata: CalculateMetadataFunction<MyCompProps> = async ({props}) => {
-  const {slowDurationInSeconds, dimensions} = await parseMedia({
-    src: props.src,
-    fields: {
-      slowDurationInSeconds: true,
-      dimensions: true,
-    },
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(props.src, {
+      getRetryDelay: () => null,
+    }),
   });
 
-  if (dimensions === null) {
+  const [durationInSeconds, videoTrack] = await Promise.all([
+    input.computeDuration(),
+    input.getPrimaryVideoTrack(),
+  ]);
+
+  if (videoTrack === null) {
     // For example when passing an MP3 file:
     throw new Error('Not a video file');
   }
 
+  const [width, height] = await Promise.all([
+    videoTrack.getDisplayWidth(),
+    videoTrack.getDisplayHeight(),
+  ]);
   const fps = 30;
 
   return {
-    durationInFrames: Math.floor(slowDurationInSeconds * fps),
+    durationInFrames: Math.ceil(durationInSeconds * fps),
     fps,
-    width: dimensions.width,
-    height: dimensions.height,
+    width,
+    height,
   };
 };
 ```
 
-:::note
-If your asset is not CORS-enabled, you can use the [`getVideoMetadata`](/docs/get-video-metadata) function from [`@remotion/media-utils`](/docs/media-utils) instead of `parseMedia()`.
-:::
+Mediabunny loads the asset using `fetch()`. Remote URLs must be [CORS-enabled](/docs/cors-issues); files referenced with [`staticFile()`](/docs/staticfile) are served from the same origin.
 
-Finally, pass the `calculateMetadata` function to the `Composition` component and define the previously hardcoded `src` as a default prop:
+Finally, pass the `calculateMetadata()` function to the [`<Composition>`](/docs/composition) component and define the previously hardcoded `src` as a default prop:
 
 ```tsx twoslash title="Root.tsx"
 // @filename: MyComp.tsx
 import React from 'react';
-import {CalculateMetadataFunction} from 'remotion';
-import {getVideoMetadata} from '@remotion/media-utils';
 
 export const MyComp: React.FC<MyCompProps> = () => {
   return null;
 };
-type MyCompProps = {
+export type MyCompProps = {
   src: string;
 };
 
-export const calculateMetadata: CalculateMetadataFunction<MyCompProps> = async ({props}) => {
-  const data = await getVideoMetadata(props.src);
-  const fps = 30;
+// @filename: calculate-metadata.ts
+import type {CalculateMetadataFunction} from 'remotion';
+import type {MyCompProps} from './MyComp';
 
+export const calculateMetadata: CalculateMetadataFunction<MyCompProps> = async ({props}) => {
   return {
-    durationInFrames: Math.floor(data.durationInSeconds * fps),
-    fps,
+    durationInFrames: 300,
+    props,
   };
 };
 
@@ -103,7 +109,8 @@ export const calculateMetadata: CalculateMetadataFunction<MyCompProps> = async (
 
 import React from 'react';
 import {Composition} from 'remotion';
-import {MyComp, calculateMetadata} from './MyComp';
+import {calculateMetadata} from './calculate-metadata';
+import {MyComp} from './MyComp';
 
 export const Root: React.FC = () => {
   return (
@@ -125,7 +132,7 @@ export const Root: React.FC = () => {
 
 ## How do I make the composition the same duration as my audio?
 
-Follow the same steps, but instead of [`parseMedia()`](/docs/media-parser), use [`getAudioDurationInSeconds()`](/docs/get-audio-duration-in-seconds) from `@remotion/media-utils` to calculate the duration of the composition based on the audio file.
+Follow the same steps. Mediabunny's [`computeDuration()`](https://mediabunny.dev/api/Input#computeduration) also returns the duration of an audio file. Omit the video track check and the `width` and `height` fields from the returned metadata.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

- use `<Audio>` from `@remotion/media` in the audio buffer data URL guide
- recommend `<Video>` from `@remotion/media` for Pexels network failures while keeping the re-hosting fallback
- migrate the align-duration guide from `<OffthreadVideo>` and Media Parser to `<Video>` and Mediabunny
- align the dynamic metadata cross-reference with the Mediabunny workflow

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run build-docs`

Part of #8882.

