### PR TITLE
Docs: Prefer @remotion/media in more examples

### DIFF
--- a/packages/docs/components/AudioWaveformExamples.tsx
+++ b/packages/docs/components/AudioWaveformExamples.tsx
@@ -1,3 +1,4 @@
+import {Audio} from '@remotion/media';
 import {
 	createSmoothSvgPath,
 	useAudioData,
@@ -7,7 +8,6 @@ import {Player} from '@remotion/player';
 import React from 'react';
 import {
 	AbsoluteFill,
-	Html5Audio,
 	staticFile,
 	useCurrentFrame,
 	useVideoConfig,
@@ -46,7 +46,7 @@ const BaseExample: React.FC = () => {
 
 	return (
 		<div style={{flex: 1}}>
-			<Html5Audio src={src} />
+			<Audio src={src} />
 			<AbsoluteFill style={{justifyContent: 'center', alignItems: 'center'}}>
 				<svg
 					style={{backgroundColor: '#0B84F3'}}
@@ -92,7 +92,7 @@ const MovingExample: React.FC = () => {
 
 	return (
 		<div style={{flex: 1}}>
-			<Html5Audio src={src} />
+			<Audio src={src} />
 			<AbsoluteFill style={{justifyContent: 'center', alignItems: 'center'}}>
 				<svg
 					style={{backgroundColor: '#0B84F3'}}
@@ -138,7 +138,7 @@ const PosterizedExample: React.FC = () => {
 
 	return (
 		<div style={{flex: 1}}>
-			<Html5Audio src={src} />
+			<Audio src={src} />
 			<AbsoluteFill style={{justifyContent: 'center', alignItems: 'center'}}>
 				<svg
 					style={{backgroundColor: ' #0B84F3'}}

--- a/packages/docs/docs/building-a-timeline.mdx
+++ b/packages/docs/docs/building-a-timeline.mdx
@@ -100,8 +100,9 @@ export type Track = {
 // @filename: Main.tsx
 // ---cut---
 import type {Track, Item} from './types';
+import {Video} from '@remotion/media';
 import React from 'react';
-import {AbsoluteFill, Sequence, OffthreadVideo} from 'remotion';
+import {AbsoluteFill, Sequence} from 'remotion';
 
 const ItemComp: React.FC<{
   item: Item;
@@ -115,7 +116,7 @@ const ItemComp: React.FC<{
   }
 
   if (item.type === 'video') {
-    return <OffthreadVideo src={item.src} />;
+    return <Video src={item.src} />;
   }
 
   throw new Error(`Unknown item type: ${JSON.stringify(item)}`);

--- a/packages/docs/docs/media-playback-error.mdx
+++ b/packages/docs/docs/media-playback-error.mdx
@@ -18,7 +18,7 @@ or
 - Error: Could not play audio with src [source] [object MediaError]
 ```
 
-This error happens when you are trying to embed a [`<Html5Video/>`](/docs/html5-video) or [`<Html5Audio/>`](/docs/html5-audio) tag in your Remotion project but the browser is unable to load and play the media. Although the browser does not report the exact error, there are two common reasons for this error.
+This error can occur with [`<Html5Video>`](/docs/html5-video), [`<OffthreadVideo>`](/docs/offthreadvideo), or [`<Html5Audio>`](/docs/html5-audio) when the browser is unable to load and play the media. Although the browser does not report the exact error, there are several common reasons for this error.
 
 ## Codec not supported by Chrome
 
@@ -88,7 +88,7 @@ export default function SBSVideo() {
 }
 ```
 
-If you ruled out this possibility, use [`<OffthreadVideo>`](/docs/offthreadvideo) instead as it does not rely on a `<video>` tag.
+If you ruled out this possibility, use [`<Video>`](/docs/media/video) from [`@remotion/media`](/docs/media) instead. It decodes supported media using WebCodecs and does not create a native `<video>` element.
 
 ## Recover from this error<AvailableFrom v="3.3.89" />
 

--- a/packages/docs/docs/media-utils/visualize-audio-waveform.mdx
+++ b/packages/docs/docs/media-utils/visualize-audio-waveform.mdx
@@ -16,7 +16,7 @@ This function is suitable for visualizing voice. For visualizing music, use [`vi
 ```tsx twoslash title="Usage"
 import {createSmoothSvgPath, useAudioData, visualizeAudioWaveform, AudioData} from '@remotion/media-utils';
 import React from 'react';
-import {AbsoluteFill, Audio, useCurrentFrame, useVideoConfig, staticFile} from 'remotion';
+import {AbsoluteFill, useCurrentFrame, useVideoConfig, staticFile} from 'remotion';
 
 const frame = useCurrentFrame();
 const audioData = useAudioData(staticFile('podcast.wav')) as AudioData;
@@ -92,9 +92,10 @@ The array is of length defined by the `numberOfSamples` parameter.
 ### Basic example
 
 ```tsx twoslash
+import {Audio} from '@remotion/media';
 import {createSmoothSvgPath, useAudioData, visualizeAudioWaveform} from '@remotion/media-utils';
 import React from 'react';
-import {AbsoluteFill, Html5Audio, useCurrentFrame, useVideoConfig, staticFile} from 'remotion';
+import {AbsoluteFill, useCurrentFrame, useVideoConfig, staticFile} from 'remotion';
 
 const height = 300;
 
@@ -126,7 +127,7 @@ const BaseExample: React.FC = () => {
 
   return (
     <div style={{flex: 1}}>
-      <Html5Audio src={staticFile('podcast.wav')} />
+      <Audio src={staticFile('podcast.wav')} />
       <AbsoluteFill style={{justifyContent: 'center', alignItems: 'center'}}>
         <svg style={{backgroundColor: ' #0B84F3'}} viewBox={`0 0 ${width} ${height}`} width={width} height={height}>
           <path stroke="white" fill="none" strokeWidth={10} d={p as string} />
@@ -147,7 +148,7 @@ By increasing the `windowInSeconds` by tenfold, the audiogram starts moving to t
 ```tsx twoslash {6}
 import {createSmoothSvgPath, useAudioData, visualizeAudioWaveform, AudioData} from '@remotion/media-utils';
 import React from 'react';
-import {AbsoluteFill, Html5Audio, useCurrentFrame, useVideoConfig, staticFile} from 'remotion';
+import {AbsoluteFill, useCurrentFrame, useVideoConfig, staticFile} from 'remotion';
 
 const frame = useCurrentFrame();
 const audioDataVoice = useAudioData(staticFile('podcast.wav')) as AudioData;
@@ -173,7 +174,7 @@ By only calculating the waveform every third frame, we make the waveform calmer 
 ```tsx twoslash {3}
 import {createSmoothSvgPath, useAudioData, visualizeAudioWaveform, AudioData} from '@remotion/media-utils';
 import React from 'react';
-import {AbsoluteFill, Html5Audio, useCurrentFrame, useVideoConfig, staticFile} from 'remotion';
+import {AbsoluteFill, useCurrentFrame, useVideoConfig, staticFile} from 'remotion';
 
 const frame = useCurrentFrame();
 const audioDataVoice = useAudioData(staticFile('podcast.wav')) as AudioData;
@@ -197,5 +198,5 @@ const waveform = visualizeAudioWaveform({
 - [Audio visualization](/docs/audio/visualization)
 - [`useAudioData()`](/docs/use-audio-data)
 - [`getAudioData()`](/docs/get-audio-data)
-- [`<Html5Audio/>`](/docs/html5-audio)
+- [`<Audio>` from `@remotion/media`](/docs/media/audio)
 - [Using audio](/docs/using-audio)


### PR DESCRIPTION
## Summary

- migrate the timeline and audio waveform examples to `@remotion/media`
- update the media playback error guide to include `<OffthreadVideo>` and recommend `@remotion/media` for native video-tag limits
- point the waveform guide's related API link to `<Audio>` from `@remotion/media`

## Validation

- `bun run build`
- `bun run stylecheck`
- Twoslash validation for the changed timeline and waveform snippets

Part of #8882.
