### PR TITLE
`@remotion/web-renderer`: Improve client-side render performance

### DIFF
--- a/packages/web-renderer/src/compose.ts
+++ b/packages/web-renderer/src/compose.ts
@@ -1,4 +1,5 @@
 import type {LogLevel} from 'remotion';
+import type {TransformStyleCache} from './drawing/calculate-transforms';
 import type {InternalState} from './internal-state';
 import {createTreeWalkerCleanupAfterChildren} from './tree-walker-cleanup-after-children';
 import {walkOverNode} from './walk-over-node';
@@ -51,6 +52,7 @@ export const compose = async ({
 			: NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
 		getFilterFunction,
 	);
+	const transformStyleCache: TransformStyleCache = new WeakMap();
 
 	// Skip to the first text node
 	if (onlyBackgroundClipText) {
@@ -76,6 +78,7 @@ export const compose = async ({
 			onlyBackgroundClipText,
 			scale,
 			waitForPageResponsiveness,
+			transformStyleCache,
 		});
 		if (val.type === 'skip-children') {
 			if (!skipToNextNonDescendant(treeWalker)) {

--- a/packages/web-renderer/src/drawing/calculate-transforms.ts
+++ b/packages/web-renderer/src/drawing/calculate-transforms.ts
@@ -29,6 +29,25 @@ type Transform = {
 	boundingClientRect: DOMRect | null;
 };
 
+type TransformStyle = Pick<
+	CSSStyleDeclaration,
+	'display' | 'rotate' | 'scale' | 'transform' | 'transformOrigin'
+>;
+
+export type TransformStyleCache = WeakMap<Element, TransformStyle>;
+
+const snapshotTransformStyle = (
+	computedStyle: CSSStyleDeclaration,
+): TransformStyle => {
+	return {
+		display: computedStyle.display,
+		rotate: computedStyle.rotate,
+		scale: computedStyle.scale,
+		transform: computedStyle.transform,
+		transformOrigin: computedStyle.transformOrigin,
+	};
+};
+
 const isReplacedElement = (element: Element) => {
 	return (
 		element instanceof HTMLImageElement ||
@@ -48,7 +67,7 @@ const canApplyCssTransforms = ({
 	computedStyle,
 }: {
 	element: HTMLElement | SVGElement;
-	computedStyle: CSSStyleDeclaration;
+	computedStyle: Pick<CSSStyleDeclaration, 'display'>;
 }) => {
 	if (element instanceof SVGElement) {
 		return true;
@@ -105,9 +124,11 @@ const getGlobalTransformOrigin = ({transform}: {transform: Transform}) => {
 export const calculateTransforms = ({
 	element,
 	rootElement,
+	transformStyleCache,
 }: {
 	element: HTMLElement | SVGElement;
 	rootElement: HTMLElement | SVGElement;
+	transformStyleCache: TransformStyleCache;
 }) => {
 	// Compute the cumulative transform by traversing parent nodes
 	let parent: HTMLElement | SVGElement | null = element;
@@ -119,15 +140,35 @@ export const calculateTransforms = ({
 	let maskImageInfo: LinearGradientInfo | null = null;
 	let filterForPrecompositing: string | null = null;
 	while (parent) {
+		// Each node walks its ancestors, so reuse their immutable transform fields
+		// for the remainder of this composition.
+		const cachedTransformStyle = transformStyleCache.get(parent);
+		const shouldReadComputedStyle =
+			parent === element || cachedTransformStyle === undefined;
+
 		// Neutralize transition before reading computed style to prevent
 		// CSS transitions from returning intermediate (t=0) transform values
 		// when we set transform to 'none' for measurement
 		const originalTransition = parent.style.transition;
 		parent.style.transition = 'none';
 
-		const computedStyle = getComputedStyle(parent);
+		const computedStyle = shouldReadComputedStyle
+			? getComputedStyle(parent)
+			: null;
+		const transformStyle =
+			computedStyle === null
+				? cachedTransformStyle!
+				: snapshotTransformStyle(computedStyle);
+
+		if (computedStyle !== null) {
+			transformStyleCache.set(parent, transformStyle);
+		}
 
 		if (parent === element) {
+			if (computedStyle === null) {
+				throw new Error('Element computed style not found');
+			}
+
 			elementComputedStyle = computedStyle;
 			opacity = parseFloat(computedStyle.opacity);
 			const maskImageValue = getMaskImageValue(computedStyle);
@@ -159,13 +200,13 @@ export const calculateTransforms = ({
 		}
 
 		const hasApplicableTransformCssValue =
-			canApplyCssTransforms({computedStyle, element: parent}) &&
-			hasAnyTransformCssValue(computedStyle);
+			canApplyCssTransforms({computedStyle: transformStyle, element: parent}) &&
+			hasAnyTransformCssValue(transformStyle);
 
 		if (hasApplicableTransformCssValue || parent === element) {
 			const toParse =
-				hasApplicableTransformCssValue && hasTransformCssValue(computedStyle)
-					? computedStyle.transform
+				hasApplicableTransformCssValue && hasTransformCssValue(transformStyle)
+					? transformStyle.transform
 					: undefined;
 			const matrix = new DOMMatrix(toParse);
 
@@ -196,7 +237,7 @@ export const calculateTransforms = ({
 
 			transforms.push({
 				element: parent,
-				transformOrigin: computedStyle.transformOrigin,
+				transformOrigin: transformStyle.transformOrigin,
 				boundingClientRect: null,
 				matrices: additionalMatrices,
 			});

--- a/packages/web-renderer/src/drawing/has-transform.ts
+++ b/packages/web-renderer/src/drawing/has-transform.ts
@@ -1,16 +1,22 @@
-export const hasTransformCssValue = (style: CSSStyleDeclaration) => {
+export const hasTransformCssValue = (
+	style: Pick<CSSStyleDeclaration, 'transform'>,
+) => {
 	return style.transform !== 'none' && style.transform !== '';
 };
 
-export const hasRotateCssValue = (style: CSSStyleDeclaration) => {
+export const hasRotateCssValue = (
+	style: Pick<CSSStyleDeclaration, 'rotate'>,
+) => {
 	return style.rotate !== 'none' && style.rotate !== '';
 };
 
-export const hasScaleCssValue = (style: CSSStyleDeclaration) => {
+export const hasScaleCssValue = (style: Pick<CSSStyleDeclaration, 'scale'>) => {
 	return style.scale !== 'none' && style.scale !== '';
 };
 
-export const hasAnyTransformCssValue = (style: CSSStyleDeclaration) => {
+export const hasAnyTransformCssValue = (
+	style: Pick<CSSStyleDeclaration, 'rotate' | 'scale' | 'transform'>,
+) => {
 	return (
 		hasTransformCssValue(style) ||
 		hasRotateCssValue(style) ||

--- a/packages/web-renderer/src/drawing/process-node.ts
+++ b/packages/web-renderer/src/drawing/process-node.ts
@@ -1,7 +1,10 @@
 import {Internals, type LogLevel} from 'remotion';
 import type {InternalState} from '../internal-state';
 import {createLayer} from '../take-screenshot';
-import {calculateTransforms} from './calculate-transforms';
+import {
+	calculateTransforms,
+	type TransformStyleCache,
+} from './calculate-transforms';
 import {getWiderRectAndExpand} from './clamp-rect-to-parent-bounds';
 import {doRectsIntersect} from './do-rects-intersect';
 import {drawElement} from './draw-element';
@@ -33,6 +36,7 @@ export const processNode = async ({
 	rootElement,
 	scale,
 	waitForPageResponsiveness,
+	transformStyleCache,
 }: {
 	element: HTMLElement | SVGElement;
 	context: OffscreenCanvasRenderingContext2D;
@@ -43,10 +47,12 @@ export const processNode = async ({
 	rootElement: HTMLElement | SVGElement;
 	scale: number;
 	waitForPageResponsiveness: (() => Promise<void>) | null;
+	transformStyleCache: TransformStyleCache;
 }): Promise<ProcessNodeReturnValue> => {
 	using transforms = calculateTransforms({
 		element,
 		rootElement,
+		transformStyleCache,
 	});
 
 	const {opacity, computedStyle, totalMatrix, dimensions, precompositing} =

--- a/packages/web-renderer/src/drawing/text/draw-text.ts
+++ b/packages/web-renderer/src/drawing/text/draw-text.ts
@@ -108,12 +108,11 @@ export const drawText = ({
 		const blurScale = Math.hypot(ctm.a, ctm.b);
 
 		const {strokeFirst} = parsePaintOrder(paintOrder);
+		const measurements = contextToDraw.measureText(originalText);
+		const {fontBoundingBoxDescent, fontBoundingBoxAscent} = measurements;
+		const fontHeight = fontBoundingBoxAscent + fontBoundingBoxDescent;
 
 		for (const token of tokens) {
-			const measurements = contextToDraw.measureText(originalText);
-			const {fontBoundingBoxDescent, fontBoundingBoxAscent} = measurements;
-
-			const fontHeight = fontBoundingBoxAscent + fontBoundingBoxDescent;
 			// Calculate leading
 			const leading = token.rect.height - fontHeight;
 			const halfLeading = leading / 2;

--- a/packages/web-renderer/src/drawing/text/find-line-breaks.text.ts
+++ b/packages/web-renderer/src/drawing/text/find-line-breaks.text.ts
@@ -3,26 +3,22 @@ type Token = {
 	rect: DOMRect;
 };
 
+const wordSegmenter = new Intl.Segmenter('en', {granularity: 'word'});
+
 export const findWords = (span: HTMLSpanElement) => {
 	const originalText = span.textContent;
-	const segmenter = new Intl.Segmenter('en', {granularity: 'word'});
-	const segments = segmenter.segment(span.textContent);
-	const words = Array.from(segments).map((s) => s.segment);
+	const segments = Array.from(wordSegmenter.segment(originalText));
 
 	const tokens: Token[] = [];
 
-	for (let i = 0; i < words.length; i++) {
-		const wordsBefore = words.slice(0, i);
-		const wordsAfter = words.slice(i + 1);
-		const word = words[i];
-
-		const wordsBeforeText = wordsBefore.join('');
-		const wordsAfterText = wordsAfter.join('');
+	for (const {index, segment} of segments) {
+		const wordsBeforeText = originalText.slice(0, index);
+		const wordsAfterText = originalText.slice(index + segment.length);
 
 		const beforeNode = document.createTextNode(wordsBeforeText);
 		const afterNode = document.createTextNode(wordsAfterText);
 		const interstitialNode = document.createElement('span');
-		interstitialNode.textContent = word;
+		interstitialNode.textContent = segment;
 		span.textContent = '';
 		span.appendChild(beforeNode);
 		span.appendChild(interstitialNode);
@@ -30,7 +26,7 @@ export const findWords = (span: HTMLSpanElement) => {
 
 		const rect = interstitialNode.getBoundingClientRect();
 		span.textContent = originalText;
-		tokens.push({text: word, rect});
+		tokens.push({text: segment, rect});
 	}
 
 	return tokens;

--- a/packages/web-renderer/src/drawing/text/handle-text-node.ts
+++ b/packages/web-renderer/src/drawing/text/handle-text-node.ts
@@ -1,5 +1,6 @@
 import type {LogLevel} from 'remotion';
 import type {InternalState} from '../../internal-state';
+import type {TransformStyleCache} from '../calculate-transforms';
 import type {ProcessNodeReturnValue} from '../process-node';
 import {processNode} from '../process-node';
 import {drawText} from './draw-text';
@@ -14,6 +15,7 @@ export const handleTextNode = async ({
 	onlyBackgroundClipText,
 	scale,
 	waitForPageResponsiveness,
+	transformStyleCache,
 }: {
 	node: Text;
 	context: OffscreenCanvasRenderingContext2D;
@@ -24,6 +26,7 @@ export const handleTextNode = async ({
 	onlyBackgroundClipText: boolean;
 	scale: number;
 	waitForPageResponsiveness: (() => Promise<void>) | null;
+	transformStyleCache: TransformStyleCache;
 }): Promise<ProcessNodeReturnValue> => {
 	const span = document.createElement('span');
 
@@ -45,6 +48,7 @@ export const handleTextNode = async ({
 		rootElement,
 		scale,
 		waitForPageResponsiveness,
+		transformStyleCache,
 	});
 
 	// Undo the layout manipulation

--- a/packages/web-renderer/src/walk-over-node.ts
+++ b/packages/web-renderer/src/walk-over-node.ts
@@ -1,4 +1,5 @@
 import type {LogLevel} from 'remotion';
+import type {TransformStyleCache} from './drawing/calculate-transforms';
 import {drawDomElement} from './drawing/draw-dom-element';
 import type {ProcessNodeReturnValue} from './drawing/process-node';
 import {processNode} from './drawing/process-node';
@@ -15,6 +16,7 @@ export const walkOverNode = ({
 	onlyBackgroundClipText,
 	scale,
 	waitForPageResponsiveness,
+	transformStyleCache,
 }: {
 	node: Node;
 	context: OffscreenCanvasRenderingContext2D;
@@ -25,6 +27,7 @@ export const walkOverNode = ({
 	onlyBackgroundClipText: boolean;
 	scale: number;
 	waitForPageResponsiveness: (() => Promise<void>) | null;
+	transformStyleCache: TransformStyleCache;
 }): Promise<ProcessNodeReturnValue> => {
 	if (node instanceof HTMLElement || node instanceof SVGElement) {
 		return processNode({
@@ -37,6 +40,7 @@ export const walkOverNode = ({
 			rootElement,
 			scale,
 			waitForPageResponsiveness,
+			transformStyleCache,
 		});
 	}
 
@@ -51,6 +55,7 @@ export const walkOverNode = ({
 			onlyBackgroundClipText,
 			scale,
 			waitForPageResponsiveness,
+			transformStyleCache,
 		});
 	}
 


### PR DESCRIPTION
## Summary

- Cache transform-related computed style snapshots for each composition to avoid repeatedly reading the same ancestor styles.
- Reduce repeated text segmentation and string allocation, and measure shared font metrics once per text node.
- Preserve the existing page-responsiveness waits that free the event loop during client-side rendering.

## Benchmark

Tested the `template-recorder` welcome composition with 1,193 frames at 1080x1080, 30fps, H.264, and Medium page responsiveness. Two controlled runs per version:

- Total client-side render: 19.52s to 18.46s average (5.4% faster).
- DOM-to-canvas frame composition: 11.36s to 10.54s average (7.2% faster).

## Test plan

- `bun run build`
- `bun run stylecheck`
- Full web-renderer browser suite: 597 passed, 21 skipped
- Targeted text and transform browser tests: 78 passed
