### PR TITLE
`remotion-monorepo`: Republish templates during releases

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -17,6 +17,7 @@ description: Release a new Remotion version
 - Run `bun set-version.ts <version>`, where <version> is the current version plus 1. If the exit code is not 0, abort the entire release process immediately.
 - Run `cd packages/example && sh runlambda.sh && cd ../..`. If this fails, abort the release.
 - Run `NPM_CONFIG_TOKEN=<token> bun run release` where <token> is the NPM token we just created
+- Run `bun run publishtemplates` from the repository root to republish every template with the newly released packages. If any template fails to publish, stop the release workflow and report the failure.
 - Generate a changelog in markdown and save it to `/tmp/release-<version>.md`:
   - Run `git log v<previous_version>..v<new_version> --oneline` to get all commits
   - Extract PR numbers from merge commits


### PR DESCRIPTION
## Summary

- republish all Remotion templates after publishing a new release
- stop the release workflow and report the failure if template publication fails

## Validation

- `bun run build`
- `bun run stylecheck`
