### PR TITLE
`@remotion/studio`: Open canvas elements in editor on double-click

### DIFF
--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -1,5 +1,4 @@
 import React, {useContext, useMemo, useRef, useState} from 'react';
-import {flushSync} from 'react-dom';
 import type {ResolvedStackLocation} from 'remotion';
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
@@ -29,7 +28,6 @@ import {
 } from './ForceSpecificCursor';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
-import {optionsSidebarTabs} from './options-sidebar-tabs';
 import {
 	applySelectedOutlineDragAxisLock,
 	applySelectedOutlineTransformOriginAxisLock,
@@ -97,10 +95,7 @@ import {
 } from './Timeline/call-add-keyframe';
 import {disableSequenceInteractivity} from './Timeline/disable-sequence-interactivity';
 import {duplicateSequencesFromSource} from './Timeline/duplicate-selected-timeline-item';
-import {
-	commitPendingInspectorFields,
-	requestFocusInspectorField,
-} from './Timeline/focus-inspector-field';
+import {commitPendingInspectorFields} from './Timeline/focus-inspector-field';
 import {getSequenceContextMenuItems} from './Timeline/get-sequence-context-menu-items';
 import {saveSequenceProps} from './Timeline/save-sequence-prop';
 import {getTimelineAssetLinkInfo} from './Timeline/timeline-asset-link';
@@ -1548,40 +1543,6 @@ export const SelectedOutlineElement: React.FC<{
 	const selectAsset = useSelectAsset();
 	const {setSelectedModal} = useContext(ModalsContext);
 
-	const onTextEditStart = React.useCallback(
-		(editTarget: SelectedOutlineTarget) => {
-			const {textEdit} = editTarget;
-			if (textEdit === null) {
-				return;
-			}
-
-			if (
-				textEdit.propStatus.status !== 'static' ||
-				typeof textEdit.propStatus.codeValue !== 'string'
-			) {
-				showNotification(
-					'This text is computed and cannot be edited visually',
-					3000,
-				);
-				return;
-			}
-
-			flushSync(() => {
-				if (!editTarget.selected) {
-					onSelect(editTarget.selection, {shiftKey: false, toggleKey: false});
-				}
-
-				optionsSidebarTabs.current?.selectInspectorPanel();
-			});
-
-			requestFocusInspectorField({
-				fieldKey: 'children',
-				nodePath: textEdit.nodePath,
-			});
-		},
-		[onSelect],
-	);
-
 	const resolveOriginalLocation = React.useCallback(
 		async (resolveTarget: SelectedOutlineTarget) => {
 			const stack = resolveTarget.sequence.getStack();
@@ -1618,16 +1579,10 @@ export const SelectedOutlineElement: React.FC<{
 				return false;
 			}
 
-			if (action === 'edit-text') {
-				onTextEditStart(doubleClickTarget);
-				return true;
-			}
-
 			const openTargetInEditor = async () => {
 				const originalLocation =
 					await resolveOriginalLocation(doubleClickTarget);
 				if (originalLocation === null) {
-					onTextEditStart(doubleClickTarget);
 					return;
 				}
 
@@ -1640,7 +1595,7 @@ export const SelectedOutlineElement: React.FC<{
 
 			return true;
 		},
-		[onTextEditStart, previewServerState.type, resolveOriginalLocation],
+		[previewServerState.type, resolveOriginalLocation],
 	);
 
 	const onContextMenuOpen = React.useCallback(async () => {

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -61,6 +61,7 @@ import type {OutlinePoint, SelectedOutline} from './selected-outline-geometry';
 import {
 	dot,
 	getAngleDegrees,
+	getOutlineDoubleClickAction,
 	getOutlineSelectionInteraction,
 	getRotationCursor,
 	getSelectedOutlineRotationCornerInfo,
@@ -497,7 +498,10 @@ const SelectedOutlinePolygon: React.FC<{
 		item: TimelineSelection,
 		interaction: TimelineSelectionInteraction,
 	) => void;
-	readonly onTextEditStart: (target: SelectedOutlineTarget) => void;
+	readonly onDoubleClickTarget: (
+		target: SelectedOutlineTarget,
+		button: number,
+	) => boolean;
 	readonly scale: number;
 	readonly snapTargets: readonly SelectedOutlineSnapTarget[];
 	readonly target: SelectedOutlineTarget | undefined;
@@ -513,7 +517,7 @@ const SelectedOutlinePolygon: React.FC<{
 	onHoverChange,
 	onSnapPointsChange,
 	onSelect,
-	onTextEditStart,
+	onDoubleClickTarget,
 	scale,
 	snapTargets,
 	target,
@@ -790,11 +794,14 @@ const SelectedOutlinePolygon: React.FC<{
 				return;
 			}
 
+			if (!onDoubleClickTarget(target, event.button)) {
+				return;
+			}
+
 			event.preventDefault();
 			event.stopPropagation();
-			onTextEditStart(target);
 		},
-		[onTextEditStart, target],
+		[onDoubleClickTarget, target],
 	);
 
 	const onEffectDragOver = React.useCallback(
@@ -1575,6 +1582,67 @@ export const SelectedOutlineElement: React.FC<{
 		[onSelect],
 	);
 
+	const resolveOriginalLocation = React.useCallback(
+		async (resolveTarget: SelectedOutlineTarget) => {
+			const stack = resolveTarget.sequence.getStack();
+			if (!stack) {
+				return null;
+			}
+
+			let originalLocation: ResolvedStackLocation | null = null;
+			try {
+				originalLocation = await getOriginalLocationFromStack(
+					stack,
+					'sequence',
+				);
+			} catch (err) {
+				showNotification((err as Error).message, 2000);
+			}
+
+			updateResolvedStackTrace(stack, originalLocation);
+			return originalLocation;
+		},
+		[updateResolvedStackTrace],
+	);
+
+	const onDoubleClickTarget = React.useCallback(
+		(doubleClickTarget: SelectedOutlineTarget, button: number) => {
+			const action = getOutlineDoubleClickAction({
+				button,
+				canOpenInEditor:
+					previewServerState.type === 'connected' &&
+					Boolean(window.remotion_editorName),
+			});
+
+			if (action === null) {
+				return false;
+			}
+
+			if (action === 'edit-text') {
+				onTextEditStart(doubleClickTarget);
+				return true;
+			}
+
+			const openTargetInEditor = async () => {
+				const originalLocation =
+					await resolveOriginalLocation(doubleClickTarget);
+				if (originalLocation === null) {
+					onTextEditStart(doubleClickTarget);
+					return;
+				}
+
+				await openOriginalPositionInEditor(originalLocation);
+			};
+
+			openTargetInEditor().catch((err) => {
+				showNotification((err as Error).message, 2000);
+			});
+
+			return true;
+		},
+		[onTextEditStart, previewServerState.type, resolveOriginalLocation],
+	);
+
 	const onContextMenuOpen = React.useCallback(async () => {
 		if (target === undefined || previewServerState.type !== 'connected') {
 			return false;
@@ -1584,22 +1652,7 @@ export const SelectedOutlineElement: React.FC<{
 			onSelect(target.selection, {shiftKey: false, toggleKey: false});
 		}
 
-		const stack = target.sequence.getStack();
-		let originalLocation: ResolvedStackLocation | null = null;
-		if (stack) {
-			try {
-				originalLocation = await getOriginalLocationFromStack(
-					stack,
-					'sequence',
-				);
-			} catch (err) {
-				showNotification((err as Error).message, 2000);
-			}
-		}
-
-		if (stack) {
-			updateResolvedStackTrace(stack, originalLocation);
-		}
+		const originalLocation = await resolveOriginalLocation(target);
 
 		const fileLocation = formatFileLocation({
 			location: originalLocation,
@@ -1746,11 +1799,11 @@ export const SelectedOutlineElement: React.FC<{
 		confirm,
 		onSelect,
 		previewServerState,
+		resolveOriginalLocation,
 		selectAsset,
 		setSelectedModal,
 		setPropStatuses,
 		target,
-		updateResolvedStackTrace,
 	]);
 
 	return (
@@ -1767,7 +1820,7 @@ export const SelectedOutlineElement: React.FC<{
 				onHoverChange={onHoverChange}
 				onSnapPointsChange={onSnapPointsChange}
 				onSelect={onSelect}
-				onTextEditStart={onTextEditStart}
+				onDoubleClickTarget={onDoubleClickTarget}
 				scale={scale}
 				snapTargets={snapTargets}
 				target={target}

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -96,6 +96,7 @@ export {
 	snapSelectedOutlineUv,
 } from './selected-outline-drag';
 export {
+	getOutlineDoubleClickAction,
 	getOutlineSelectionInteraction,
 	getSelectedEffectFieldsBySequenceKey,
 	getSelectedOutlineRotationCornerInfo,

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -660,8 +660,6 @@ export const SelectedOutlineOverlay: React.FC<{
 				activeSchema?.[transformOriginFieldKey];
 			const transformOriginPropStatus =
 				nodePropStatuses?.[transformOriginFieldKey];
-			const textContentFieldSchema = activeSchema?.children;
-			const textContentPropStatus = nodePropStatuses?.children;
 			const transformOriginValueForRotation =
 				transformOriginFieldSchema?.type === 'transform-origin' &&
 				(transformOriginPropStatus?.status === 'static' ||
@@ -729,12 +727,6 @@ export const SelectedOutlineOverlay: React.FC<{
 			const canDropEffect =
 				previewServerState.type === 'connected' &&
 				controls?.supportsEffects === true;
-			const canTextEdit =
-				previewServerState.type === 'connected' &&
-				controls !== null &&
-				textContentFieldSchema?.type === 'text-content' &&
-				textContentPropStatus !== undefined;
-
 			return {
 				key,
 				containsSelection,
@@ -859,12 +851,6 @@ export const SelectedOutlineOverlay: React.FC<{
 									shouldResortToDefaultValueIfUndefined: true,
 								}) ?? fieldSchema.default,
 							),
-						}
-					: null,
-				textEdit: canTextEdit
-					? {
-							nodePath,
-							propStatus: textContentPropStatus,
 						}
 					: null,
 				uvHandles: containsSelection

--- a/packages/studio/src/components/selected-outline-measurement.ts
+++ b/packages/studio/src/components/selected-outline-measurement.ts
@@ -343,6 +343,20 @@ export const getOutlineSelectionInteraction = ({
 	toggleKey: metaKey || ctrlKey,
 });
 
+export const getOutlineDoubleClickAction = ({
+	button,
+	canOpenInEditor,
+}: {
+	readonly button: number;
+	readonly canOpenInEditor: boolean;
+}): 'open-in-editor' | 'edit-text' | null => {
+	if (button !== 0) {
+		return null;
+	}
+
+	return canOpenInEditor ? 'open-in-editor' : 'edit-text';
+};
+
 type SelectedEffectFields = {
 	allFields: boolean;
 	fieldKeys: Set<string>;

--- a/packages/studio/src/components/selected-outline-measurement.ts
+++ b/packages/studio/src/components/selected-outline-measurement.ts
@@ -349,13 +349,8 @@ export const getOutlineDoubleClickAction = ({
 }: {
 	readonly button: number;
 	readonly canOpenInEditor: boolean;
-}): 'open-in-editor' | 'edit-text' | null => {
-	if (button !== 0) {
-		return null;
-	}
-
-	return canOpenInEditor ? 'open-in-editor' : 'edit-text';
-};
+}): 'open-in-editor' | null =>
+	button === 0 && canOpenInEditor ? 'open-in-editor' : null;
 
 type SelectedEffectFields = {
 	allFields: boolean;

--- a/packages/studio/src/components/selected-outline-types.ts
+++ b/packages/studio/src/components/selected-outline-types.ts
@@ -1,5 +1,4 @@
 import type {
-	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusKeyframed,
 	CanUpdateSequencePropStatusStatic,
 	InteractivitySchema,
@@ -34,7 +33,6 @@ export type SelectedOutlineTarget = {
 	readonly scaleDrag: SelectedOutlineScaleDragTarget | null;
 	readonly rotationDrag: SelectedOutlineRotationDragTarget | null;
 	readonly transformOriginDrag: SelectedOutlineTransformOriginDragTarget | null;
-	readonly textEdit: SelectedOutlineTextEditTarget | null;
 	readonly uvHandles: readonly SelectedOutlineUvHandle[];
 };
 
@@ -42,11 +40,6 @@ export type SelectedOutlineEffectDropTarget = {
 	readonly clientId: string;
 	readonly fileName: string;
 	readonly nodePath: SequencePropsSubscriptionKey;
-};
-
-export type SelectedOutlineTextEditTarget = {
-	readonly nodePath: SequencePropsSubscriptionKey;
-	readonly propStatus: CanUpdateSequencePropStatus;
 };
 
 export type SelectedOutlineDragTarget = {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1805,12 +1805,12 @@ test('Canvas outline selection uses conventional modifier keys', () => {
 	).toEqual({shiftKey: false, toggleKey: true});
 });
 
-test('Canvas outline double-click preserves text editing as a fallback', () => {
+test('Canvas outline double-click only handles opening the editor', () => {
 	expect(getOutlineDoubleClickAction({button: 0, canOpenInEditor: true})).toBe(
 		'open-in-editor',
 	);
 	expect(getOutlineDoubleClickAction({button: 0, canOpenInEditor: false})).toBe(
-		'edit-text',
+		null,
 	);
 	expect(
 		getOutlineDoubleClickAction({button: 2, canOpenInEditor: true}),

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -28,6 +28,7 @@ import {
 	applySelectedOutlineDragAxisLock,
 	applySelectedOutlineTransformOriginAxisLock,
 	compensateTranslateForTransformOrigin,
+	getOutlineDoubleClickAction,
 	getOutlineSelectionInteraction,
 	getSelectedEffectFieldsBySequenceKey,
 	getSelectedOutlineActiveSchema,
@@ -1802,6 +1803,18 @@ test('Canvas outline selection uses conventional modifier keys', () => {
 			ctrlKey: true,
 		}),
 	).toEqual({shiftKey: false, toggleKey: true});
+});
+
+test('Canvas outline double-click preserves text editing as a fallback', () => {
+	expect(getOutlineDoubleClickAction({button: 0, canOpenInEditor: true})).toBe(
+		'open-in-editor',
+	);
+	expect(getOutlineDoubleClickAction({button: 0, canOpenInEditor: false})).toBe(
+		'edit-text',
+	);
+	expect(
+		getOutlineDoubleClickAction({button: 2, canOpenInEditor: true}),
+	).toBeNull();
 });
 
 test('Canvas outline hit targets render nested sequences above parents', () => {


### PR DESCRIPTION
## Summary

- open canvas elements in the configured editor on primary-button double-click
- remove the canvas double-click text-edit shortcut and its outline metadata
- leave single pointer-down, dragging, and right-click context-menu behavior unchanged
- share sequence source-location resolution between double-click and the context menu

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run make lint test --filter='@remotion/studio'`

Closes #9129
