### PR TITLE
`@remotion/studio-server`: Improve Studio codemod logs

### DIFF
--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -13,6 +13,7 @@ import {formatOutput} from '../../codemods/duplicate-composition';
 import {simpleDiff} from '../../codemods/simple-diff';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import type {ApiHandler} from '../api-types';
+import {formatLogFileLocation} from '../format-log-file-location';
 import {getProjectInfo} from '../project-info';
 import {
 	printUndoHint,
@@ -30,6 +31,14 @@ export const ${componentName}: React.FC = () => {
 	return null;
 };
 `);
+};
+
+const getCodemodLogMessage = (codemod: ApplyCodemodRequest['codemod']) => {
+	if (codemod.type === 'rename-composition') {
+		return `Renamed composition "${codemod.idToRename}" to "${codemod.newId}"`;
+	}
+
+	return null;
 };
 
 const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
@@ -128,6 +137,7 @@ export const applyCodemodHandler: ApiHandler<
 	return withSourceFileWriteQueue(async () => {
 		try {
 			const time = Date.now();
+			const logLine = symbolicatedStack?.originalLineNumber ?? 1;
 
 			const filePath = symbolicatedStack
 				? resolveFilePathFromSymbolicatedStack(remotionRoot, symbolicatedStack)
@@ -178,7 +188,7 @@ export const applyCodemodHandler: ApiHandler<
 						filePath,
 						oldContents: input,
 						newContents: null,
-						logLine: symbolicatedStack?.originalLineNumber ?? 1,
+						logLine,
 					},
 				];
 				let componentFilePath: string | null = null;
@@ -217,7 +227,7 @@ export const applyCodemodHandler: ApiHandler<
 						newContents: null,
 						logLevel,
 						remotionRoot,
-						logLine: symbolicatedStack?.originalLineNumber ?? 1,
+						logLine,
 						description: {
 							undoMessage,
 							redoMessage,
@@ -242,11 +252,19 @@ export const applyCodemodHandler: ApiHandler<
 				}
 
 				const end = Date.now() - time;
-				const relativePath = path.relative(remotionRoot, filePath);
-				RenderInternals.Log.info(
-					{indent: false, logLevel},
-					RenderInternals.chalk.blue(`Edited ${relativePath} in ${end}ms`),
-				);
+				const logMessage = getCodemodLogMessage(codemod);
+				const editMessage = logMessage
+					? `${RenderInternals.chalk.blueBright(
+							formatLogFileLocation({
+								remotionRoot,
+								absolutePath: filePath,
+								line: logLine,
+							}),
+						)} ${logMessage}`
+					: RenderInternals.chalk.blue(
+							`Edited ${path.relative(remotionRoot, filePath)} in ${end}ms`,
+						);
+				RenderInternals.Log.info({indent: false, logLevel}, editMessage);
 				printUndoHint(logLevel);
 			}
 

--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -33,12 +33,60 @@ export const ${componentName}: React.FC = () => {
 `);
 };
 
-const getCodemodLogMessage = (codemod: ApplyCodemodRequest['codemod']) => {
+const getFolderPath = (parentName: string | null, folderName: string) => {
+	return parentName ? `${parentName}/${folderName}` : folderName;
+};
+
+export const getCodemodLogMessage = (
+	codemod: ApplyCodemodRequest['codemod'],
+) => {
+	if (codemod.type === 'new-composition') {
+		const destination = codemod.folderName
+			? ` in folder "${getFolderPath(codemod.parentName, codemod.folderName)}"`
+			: '';
+		return `Created composition "${codemod.newId}"${destination}`;
+	}
+
+	if (codemod.type === 'duplicate-composition') {
+		return `Duplicated composition "${codemod.idToDuplicate}" to "${codemod.newId}"`;
+	}
+
 	if (codemod.type === 'rename-composition') {
 		return `Renamed composition "${codemod.idToRename}" to "${codemod.newId}"`;
 	}
 
-	return null;
+	if (codemod.type === 'delete-composition') {
+		return `Deleted composition "${codemod.idToDelete}"`;
+	}
+
+	if (codemod.type === 'move-composition-to-folder') {
+		const destination = codemod.folderName
+			? `into folder "${getFolderPath(codemod.parentName, codemod.folderName)}"`
+			: 'to root';
+		return `Moved composition "${codemod.idToMove}" ${destination}`;
+	}
+
+	if (codemod.type === 'rename-folder') {
+		const oldName = getFolderPath(codemod.parentName, codemod.folderName);
+		const newName = getFolderPath(codemod.parentName, codemod.newName);
+		return `Renamed folder "${oldName}" to "${newName}"`;
+	}
+
+	if (codemod.type === 'new-folder') {
+		return `Created folder "${getFolderPath(codemod.parentName, codemod.folderName)}"`;
+	}
+
+	if (codemod.type === 'delete-folder') {
+		return `Deleted folder "${getFolderPath(codemod.parentName, codemod.folderName)}"`;
+	}
+
+	if (codemod.changes.length === 1) {
+		return `Updated visual control "${codemod.changes[0].id}"`;
+	}
+
+	return `Updated visual controls ${codemod.changes
+		.map((change) => `"${change.id}"`)
+		.join(', ')}`;
 };
 
 const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
@@ -72,7 +120,7 @@ const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
 		const destination =
 			codemod.folderName === null
 				? 'to root'
-				: `into folder "${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}"`;
+				: `into folder "${getFolderPath(codemod.parentName, codemod.folderName)}"`;
 		const label = `composition "${codemod.idToMove}" ${destination}`;
 		return {
 			undoMessage: `↩️  Move of ${label}`,
@@ -90,7 +138,7 @@ const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
 	}
 
 	if (codemod.type === 'delete-folder') {
-		const label = `folder "${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}"`;
+		const label = `folder "${getFolderPath(codemod.parentName, codemod.folderName)}"`;
 		return {
 			undoMessage: `↩️  Deletion of ${label}`,
 			redoMessage: `↪️  Deletion of ${label}`,
@@ -99,7 +147,7 @@ const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
 	}
 
 	if (codemod.type === 'new-folder') {
-		const label = `folder "${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}"`;
+		const label = `folder "${getFolderPath(codemod.parentName, codemod.folderName)}"`;
 		return {
 			undoMessage: `↩️  Creation of ${label}`,
 			redoMessage: `↪️  Creation of ${label}`,
@@ -108,8 +156,8 @@ const getCodemodUndoDescription = (codemod: ApplyCodemodRequest['codemod']) => {
 	}
 
 	if (codemod.type === 'rename-folder') {
-		const oldName = `${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.folderName}`;
-		const newName = `${codemod.parentName ? `${codemod.parentName}/` : ''}${codemod.newName}`;
+		const oldName = getFolderPath(codemod.parentName, codemod.folderName);
+		const newName = getFolderPath(codemod.parentName, codemod.newName);
 		const label = `folder "${oldName}" to "${newName}"`;
 		return {
 			undoMessage: `↩️  Rename of ${label}`,
@@ -136,7 +184,6 @@ export const applyCodemodHandler: ApiHandler<
 }) => {
 	return withSourceFileWriteQueue(async () => {
 		try {
-			const time = Date.now();
 			const logLine = symbolicatedStack?.originalLineNumber ?? 1;
 
 			const filePath = symbolicatedStack
@@ -251,19 +298,14 @@ export const applyCodemodHandler: ApiHandler<
 					);
 				}
 
-				const end = Date.now() - time;
 				const logMessage = getCodemodLogMessage(codemod);
-				const editMessage = logMessage
-					? `${RenderInternals.chalk.blueBright(
-							formatLogFileLocation({
-								remotionRoot,
-								absolutePath: filePath,
-								line: logLine,
-							}),
-						)} ${logMessage}`
-					: RenderInternals.chalk.blue(
-							`Edited ${path.relative(remotionRoot, filePath)} in ${end}ms`,
-						);
+				const editMessage = `${RenderInternals.chalk.blueBright(
+					formatLogFileLocation({
+						remotionRoot,
+						absolutePath: filePath,
+						line: logLine,
+					}),
+				)} ${logMessage}`;
 				RenderInternals.Log.info({indent: false, logLevel}, editMessage);
 				printUndoHint(logLevel);
 			}

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -1,4 +1,4 @@
-import {expect, test} from 'bun:test';
+import {expect, spyOn, test} from 'bun:test';
 import {
 	existsSync,
 	mkdtempSync,
@@ -161,17 +161,19 @@ const getHandlerOptions = <T>({
 	input,
 	entryPoint,
 	remotionRoot,
+	logLevel = 'error',
 }: {
 	input: T;
 	entryPoint: string;
 	remotionRoot: string;
+	logLevel?: 'error' | 'info';
 }) => ({
 	input,
 	entryPoint,
 	remotionRoot,
 	request: {} as never,
 	response: {} as never,
-	logLevel: 'error' as const,
+	logLevel,
 	methods: {
 		removeJob: () => undefined,
 		cancelJob: () => undefined,
@@ -185,10 +187,12 @@ const runCompositionCodemodUndoRedoTest = async ({
 	codemod,
 	assertApplied,
 	expectedUndoMessage,
+	expectedLogMessage,
 }: {
 	codemod: RecastCodemod;
 	assertApplied: (contents: string) => void;
 	expectedUndoMessage: string;
+	expectedLogMessage?: string;
 }) => {
 	const remotionRoot = mkdtempSync(path.join(tmpdir(), 'remotion-codemod-'));
 	const cleanupFileWatcher = setFileWatcherRegistry(
@@ -201,6 +205,9 @@ const runCompositionCodemodUndoRedoTest = async ({
 		closeConnections: () => Promise.resolve(),
 		addNewClientListener: () => () => undefined,
 	});
+	const consoleSpy = expectedLogMessage
+		? spyOn(console, 'log').mockImplementation(() => undefined)
+		: null;
 
 	try {
 		clearUndoRedoStacks();
@@ -222,6 +229,7 @@ const runCompositionCodemodUndoRedoTest = async ({
 				},
 				entryPoint,
 				remotionRoot,
+				logLevel: expectedLogMessage ? 'info' : 'error',
 			}),
 		);
 
@@ -230,6 +238,11 @@ const runCompositionCodemodUndoRedoTest = async ({
 		expect(getUndoStack().length).toBe(1);
 		expect(getUndoStack()[0].description.undoMessage).toBe(expectedUndoMessage);
 		expect(getRedoStack().length).toBe(0);
+		if (expectedLogMessage) {
+			const logOutput = consoleSpy?.mock.calls.flat().join(' ');
+			expect(logOutput).toContain('Root.tsx:9');
+			expect(logOutput).toContain(expectedLogMessage);
+		}
 
 		const undoResponse = await undoHandler(
 			getHandlerOptions({input: {}, entryPoint, remotionRoot}),
@@ -250,6 +263,7 @@ const runCompositionCodemodUndoRedoTest = async ({
 		clearUndoRedoStacks();
 		cleanupLiveEvents();
 		cleanupFileWatcher();
+		consoleSpy?.mockRestore();
 		rmSync(remotionRoot, {recursive: true, force: true});
 	}
 };
@@ -265,7 +279,7 @@ test('applyCodemodHandler pushes composition deletions to undo and redo stacks',
 	});
 });
 
-test('applyCodemodHandler pushes composition renames to undo and redo stacks', async () => {
+test('applyCodemodHandler logs composition renames and pushes them to the undo and redo stacks', async () => {
 	await runCompositionCodemodUndoRedoTest({
 		codemod: {
 			type: 'rename-composition',
@@ -278,6 +292,7 @@ test('applyCodemodHandler pushes composition renames to undo and redo stacks', a
 			expect(contents).toContain('id="KeepMe"');
 		},
 		expectedUndoMessage: '↩️  Rename of composition "DeleteMe" to "Renamed"',
+		expectedLogMessage: 'Renamed composition "DeleteMe" to "Renamed"',
 	});
 });
 

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -15,7 +15,10 @@ import {
 	setFileWatcherRegistry,
 } from '../file-watcher';
 import {setLiveEventsListener} from '../preview-server/live-events';
-import {applyCodemodHandler} from '../preview-server/routes/apply-codemod';
+import {
+	applyCodemodHandler,
+	getCodemodLogMessage,
+} from '../preview-server/routes/apply-codemod';
 import {redoHandler} from '../preview-server/routes/redo';
 import {undoHandler} from '../preview-server/routes/undo';
 import {getRedoStack, getUndoStack} from '../preview-server/undo-stack';
@@ -156,6 +159,132 @@ const clearUndoRedoStacks = () => {
 	(getUndoStack() as unknown as unknown[]).length = 0;
 	(getRedoStack() as unknown as unknown[]).length = 0;
 };
+
+test('formats precise log messages for all codemods', () => {
+	const testCases: {codemod: RecastCodemod; expected: string}[] = [
+		{
+			codemod: {
+				type: 'new-composition',
+				newId: 'FreshVideo',
+				componentName: 'FreshVideo',
+				componentImportPath: './FreshVideo',
+				folderName: 'Shared',
+				parentName: 'Parent',
+				newDurationInFrames: 150,
+				newFps: 30,
+				newHeight: 1080,
+				newWidth: 1920,
+			},
+			expected: 'Created composition "FreshVideo" in folder "Parent/Shared"',
+		},
+		{
+			codemod: {
+				type: 'duplicate-composition',
+				idToDuplicate: 'Original',
+				newId: 'Copy',
+				newDurationInFrames: null,
+				newFps: null,
+				newHeight: null,
+				newWidth: null,
+				tag: 'Composition',
+			},
+			expected: 'Duplicated composition "Original" to "Copy"',
+		},
+		{
+			codemod: {
+				type: 'rename-composition',
+				idToRename: 'Original',
+				newId: 'Renamed',
+			},
+			expected: 'Renamed composition "Original" to "Renamed"',
+		},
+		{
+			codemod: {type: 'delete-composition', idToDelete: 'DeleteMe'},
+			expected: 'Deleted composition "DeleteMe"',
+		},
+		{
+			codemod: {
+				type: 'move-composition-to-folder',
+				idToMove: 'MoveMe',
+				folderName: 'Shared',
+				parentName: 'Parent',
+			},
+			expected: 'Moved composition "MoveMe" into folder "Parent/Shared"',
+		},
+		{
+			codemod: {
+				type: 'move-composition-to-folder',
+				idToMove: 'MoveMe',
+				folderName: null,
+				parentName: null,
+			},
+			expected: 'Moved composition "MoveMe" to root',
+		},
+		{
+			codemod: {
+				type: 'rename-folder',
+				folderName: 'Old',
+				parentName: 'Parent',
+				newName: 'New',
+			},
+			expected: 'Renamed folder "Parent/Old" to "Parent/New"',
+		},
+		{
+			codemod: {
+				type: 'new-folder',
+				folderName: 'New',
+				parentName: 'Parent',
+			},
+			expected: 'Created folder "Parent/New"',
+		},
+		{
+			codemod: {
+				type: 'delete-folder',
+				folderName: 'DeleteMe',
+				parentName: 'Parent',
+			},
+			expected: 'Deleted folder "Parent/DeleteMe"',
+		},
+		{
+			codemod: {
+				type: 'apply-visual-control',
+				changes: [
+					{
+						id: 'opacity',
+						newValueSerialized: '0.5',
+						newValueIsUndefined: false,
+						enumPaths: [],
+					},
+				],
+			},
+			expected: 'Updated visual control "opacity"',
+		},
+		{
+			codemod: {
+				type: 'apply-visual-control',
+				changes: [
+					{
+						id: 'opacity',
+						newValueSerialized: '0.5',
+						newValueIsUndefined: false,
+						enumPaths: [],
+					},
+					{
+						id: 'scale',
+						newValueSerialized: '2',
+						newValueIsUndefined: false,
+						enumPaths: [],
+					},
+				],
+			},
+			expected: 'Updated visual controls "opacity", "scale"',
+		},
+	];
+
+	for (const {codemod, expected} of testCases) {
+		expect(getCodemodLogMessage(codemod)).toBe(expected);
+	}
+});
 
 const getHandlerOptions = <T>({
 	input,


### PR DESCRIPTION
## Summary

- replace generic codemod success logs with the source path, line number, and specific action
- include composition IDs, folder paths, move destinations, and visual-control IDs where applicable
- cover every codemod variant with regression tests

Before:

`Edited src/Root.tsx in 217ms`

After:

`src/Root.tsx:9 Renamed composition "Old" to "New"`

Other examples:

- `src/Root.tsx:9 Created composition "Intro" in folder "Videos/Shorts"`
- `src/Root.tsx:9 Deleted composition "Intro"`
- `src/Root.tsx:9 Moved composition "Intro" to root`
- `src/Root.tsx:9 Renamed folder "Videos/Old" to "Videos/New"`
- `src/Root.tsx:9 Updated visual controls "opacity", "scale"`

## Test plan

- `bun test packages/studio-server/src/test/apply-codemod.test.ts` (22 passed)
- `bunx turbo run make --filter='@remotion/studio-server'`
- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio-server/src` (401 passed; 3 unrelated baseline failures in `log-effect-update.test.ts` and `log-update.test.ts`)

Closes #9114
