### PR TITLE
`@remotion/studio`: Increase timeline horizontal padding

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -27,9 +27,11 @@ const leftChromeStyle: React.CSSProperties = {
 
 const keyframeControlsColumnBaseStyle: React.CSSProperties = {
 	alignItems: 'center',
+	boxSizing: 'border-box',
 	display: 'flex',
 	flexShrink: 0,
 	justifyContent: 'flex-start',
+	paddingLeft: TIMELINE_ROW_BASE_PADDING,
 };
 
 export const TimelineRowChrome: React.FC<{

--- a/packages/studio/src/components/Timeline/timeline-row-layout.ts
+++ b/packages/studio/src/components/Timeline/timeline-row-layout.ts
@@ -1,6 +1,6 @@
 import {TIMELINE_INDENT} from './timeline-indent';
 
-export const TIMELINE_ROW_BASE_PADDING = 5;
+export const TIMELINE_ROW_BASE_PADDING = 10;
 export const TIMELINE_EYE_COLUMN_WIDTH = 22;
 export const TIMELINE_ARROW_COLUMN_WIDTH = 16;
 export const TIMELINE_KEYFRAME_CONTROLS_WIDTH = 38;


### PR DESCRIPTION
## Summary

- increase the timeline row inset from 5px to 10px
- apply the same inset to keyframe controls while preserving field label alignment

## Test plan

- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`

Closes #8667
