### PR TITLE
`@remotion/transitions`: Make series sequences interactive in Studio

### DIFF
--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -1,12 +1,16 @@
 import React, {
-	Children,
 	forwardRef,
 	useMemo,
 	type FC,
 	type PropsWithChildren,
 } from 'react';
+import type {SequenceControls} from '../CompositionManager.js';
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
-import {sequenceSchemaDefaultLayoutNone} from '../interactivity-schema.js';
+import {Interactive} from '../Interactive.js';
+import {
+	sequenceSchemaDefaultLayoutNone,
+	type InteractivitySchema,
+} from '../interactivity-schema.js';
 import type {LayoutAndStyle, SequenceProps} from '../Sequence.js';
 import {Sequence, SequenceWithoutSchema} from '../Sequence.js';
 import {validateDurationInFrames} from '../validation/validate-duration-in-frames.js';
@@ -18,6 +22,7 @@ import {
 	useRequireToBeInsideSeries,
 } from './is-inside-series.js';
 
+/* eslint-disable react/require-default-props -- public API props stay optional and are normalized by SeriesSequenceInner */
 type SeriesSequenceProps = PropsWithChildren<
 	{
 		readonly durationInFrames: number;
@@ -29,18 +34,72 @@ type SeriesSequenceProps = PropsWithChildren<
 	> &
 		LayoutAndStyle
 >;
+/* eslint-enable react/require-default-props */
 
-const SeriesSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
-	HTMLDivElement,
-	SeriesSequenceProps
-> = ({children}, _ref) => {
-	useRequireToBeInsideSeries();
-	// Discard ref
-
-	return <IsNotInsideSeriesProvider>{children}</IsNotInsideSeriesProvider>;
+type ResolvedSeriesSequenceProps = SeriesSequenceProps & {
+	readonly controls: SequenceControls | null | undefined;
+	readonly stack: string | null;
 };
 
-const SeriesSequence = forwardRef(SeriesSequenceRefForwardingFunction);
+type InternalSeriesSequenceProps = ResolvedSeriesSequenceProps & {
+	readonly _remotionInternalRender:
+		| ((
+				props: ResolvedSeriesSequenceProps,
+				ref: React.ForwardedRef<HTMLDivElement>,
+		  ) => React.ReactNode)
+		| null;
+};
+
+const seriesSequenceSchema = {
+	durationInFrames: Interactive.baseSchema.durationInFrames,
+	name: Interactive.sequenceSchema.name,
+	hidden: Interactive.sequenceSchema.hidden,
+	showInTimeline: Interactive.sequenceSchema.showInTimeline,
+	freeze: Interactive.baseSchema.freeze,
+	layout: Interactive.sequenceSchema.layout,
+} as const satisfies InteractivitySchema;
+
+const SeriesSequenceInner = forwardRef<
+	HTMLDivElement,
+	InternalSeriesSequenceProps
+>(
+	(
+		{
+			offset = 0,
+			className = '',
+			stack = null,
+			_remotionInternalRender = null,
+			...props
+		},
+		ref,
+	) => {
+		useRequireToBeInsideSeries();
+		if (_remotionInternalRender) {
+			return _remotionInternalRender(
+				{...props, offset, className: className || undefined, stack},
+				ref,
+			);
+		}
+
+		return (
+			<IsNotInsideSeriesProvider>{props.children}</IsNotInsideSeriesProvider>
+		);
+	},
+);
+
+const SeriesSequence = Interactive.withSchema({
+	Component: SeriesSequenceInner as unknown as React.ComponentType<
+		SeriesSequenceProps & {
+			readonly controls: SequenceControls | undefined;
+		}
+	>,
+	componentName: '<Series.Sequence>',
+	componentIdentity: 'dev.remotion.remotion.Series.Sequence',
+	schema: seriesSequenceSchema,
+	supportsEffects: false,
+}) as React.ForwardRefExoticComponent<
+	SeriesSequenceProps & React.RefAttributes<HTMLDivElement>
+>;
 
 type SeriesProps = SequenceProps;
 const SequenceWithoutSchemaWithRef =
@@ -48,22 +107,66 @@ const SequenceWithoutSchemaWithRef =
 		SequenceProps & {readonly ref?: React.Ref<HTMLDivElement>}
 	>;
 
+const validateSeriesSequenceProps = ({
+	durationInFrames,
+	offset: offsetProp,
+	index,
+	childrenLength,
+}: {
+	readonly durationInFrames: number;
+	readonly offset: number | undefined;
+	readonly index: number;
+	readonly childrenLength: number;
+}) => {
+	const debugInfo = `index = ${index}, duration = ${durationInFrames}`;
+	if (index !== childrenLength - 1 || durationInFrames !== Infinity) {
+		validateDurationInFrames(durationInFrames, {
+			component: `of a <Series.Sequence /> component`,
+			allowFloats: true,
+		});
+	}
+
+	const offset = offsetProp ?? 0;
+	if (Number.isNaN(offset)) {
+		throw new TypeError(
+			`The "offset" property of a <Series.Sequence /> must not be NaN, but got NaN (${debugInfo}).`,
+		);
+	}
+
+	if (!Number.isFinite(offset)) {
+		throw new TypeError(
+			`The "offset" property of a <Series.Sequence /> must be finite, but got ${offset} (${debugInfo}).`,
+		);
+	}
+
+	if (offset % 1 !== 0) {
+		throw new TypeError(
+			`The "offset" property of a <Series.Sequence /> must be finite, but got ${offset} (${debugInfo}).`,
+		);
+	}
+
+	return offset;
+};
+
 const SeriesInner: FC<SeriesProps> = (props) => {
 	const childrenValue = useMemo(() => {
-		let startFrame = 0;
 		const flattenedChildren = flattenChildren(props.children);
-		return Children.map(flattenedChildren, (child, i) => {
+		const renderChildren = (i: number, startFrame: number): React.ReactNode => {
+			if (i === flattenedChildren.length) {
+				return null;
+			}
+
+			const child = flattenedChildren[i];
 			const castedChild = child as unknown as
 				| {
-						props: SeriesSequenceProps;
+						props: InternalSeriesSequenceProps;
 						type: typeof SeriesSequence;
-						ref: React.RefObject<HTMLDivElement>;
 				  }
 				| string;
 			if (typeof castedChild === 'string') {
 				// Don't throw if it's just some accidential whitespace
 				if (castedChild.trim() === '') {
-					return null;
+					return renderChildren(i + 1, startFrame);
 				}
 
 				throw new TypeError(
@@ -77,64 +180,67 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 				);
 			}
 
-			const debugInfo = `index = ${i}, duration = ${castedChild.props.durationInFrames}`;
+			const castedElement = castedChild as React.ReactElement<
+				InternalSeriesSequenceProps,
+				typeof SeriesSequence
+			>;
+			validateSeriesSequenceProps({
+				durationInFrames: castedElement.props.durationInFrames,
+				offset: castedElement.props.offset,
+				index: i,
+				childrenLength: flattenedChildren.length,
+			});
 
-			const durationInFramesProp = castedChild.props.durationInFrames;
-			const {
-				durationInFrames,
-				children: _children,
-				from,
-				name,
-				...passedProps
-			} = castedChild.props as SeriesSequenceProps & {from: never}; // `from` is not accepted and must be filtered out if used in JS
+			return React.cloneElement(castedElement, {
+				_remotionInternalRender: (resolvedProps, ref) => {
+					const durationInFramesProp = resolvedProps.durationInFrames;
+					const {
+						durationInFrames: _durationInFrames,
+						children: sequenceChildren,
+						offset: offsetProp,
+						controls,
+						stack,
+						from: _from,
+						name,
+						...passedProps
+					} = resolvedProps as InternalSeriesSequenceProps & {from: never}; // `from` is not accepted and must be filtered out if used in JS
 
-			if (
-				i !== flattenedChildren.length - 1 ||
-				durationInFramesProp !== Infinity
-			) {
-				validateDurationInFrames(durationInFramesProp, {
-					component: `of a <Series.Sequence /> component`,
-					allowFloats: true,
-				});
-			}
+					const offset = validateSeriesSequenceProps({
+						durationInFrames: durationInFramesProp,
+						offset: offsetProp,
+						index: i,
+						childrenLength: flattenedChildren.length,
+					});
 
-			const offset = castedChild.props.offset ?? 0;
-			if (Number.isNaN(offset)) {
-				throw new TypeError(
-					`The "offset" property of a <Series.Sequence /> must not be NaN, but got NaN (${debugInfo}).`,
-				);
-			}
+					const currentStartFrame = startFrame + offset;
+					const nextStartFrame = startFrame + durationInFramesProp + offset;
 
-			if (!Number.isFinite(offset)) {
-				throw new TypeError(
-					`The "offset" property of a <Series.Sequence /> must be finite, but got ${offset} (${debugInfo}).`,
-				);
-			}
+					return (
+						<>
+							<SequenceWithoutSchemaWithRef
+								ref={ref}
+								name={name || '<Series.Sequence>'}
+								_remotionInternalDocumentationLink={
+									name ? undefined : 'https://www.remotion.dev/docs/series'
+								}
+								_remotionInternalStack={stack ?? undefined}
+								controls={controls ?? undefined}
+								from={currentStartFrame}
+								durationInFrames={durationInFramesProp}
+								{...passedProps}
+							>
+								<IsNotInsideSeriesProvider>
+									{sequenceChildren}
+								</IsNotInsideSeriesProvider>
+							</SequenceWithoutSchemaWithRef>
+							{renderChildren(i + 1, nextStartFrame)}
+						</>
+					);
+				},
+			});
+		};
 
-			if (offset % 1 !== 0) {
-				throw new TypeError(
-					`The "offset" property of a <Series.Sequence /> must be finite, but got ${offset} (${debugInfo}).`,
-				);
-			}
-
-			const currentStartFrame = startFrame + offset;
-			startFrame += durationInFramesProp + offset;
-
-			return (
-				<SequenceWithoutSchemaWithRef
-					ref={castedChild.ref}
-					name={name || '<Series.Sequence>'}
-					_remotionInternalDocumentationLink={
-						name ? undefined : 'https://www.remotion.dev/docs/series'
-					}
-					from={currentStartFrame}
-					durationInFrames={durationInFramesProp}
-					{...passedProps}
-				>
-					{child}
-				</SequenceWithoutSchemaWithRef>
-			);
-		});
+		return renderChildren(0, 0);
 	}, [props.children]);
 
 	return (

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -6,8 +6,13 @@ import type {TSequence} from '../CompositionManager.js';
 import {Img} from '../Img.js';
 import {Interactive} from '../Interactive.js';
 import {Internals} from '../internals.js';
+import type {OverrideIdToNodePaths} from '../sequence-node-path.js';
+import {OverrideIdsToNodePathsGettersContext} from '../sequence-node-path.js';
 import {Sequence} from '../Sequence.js';
-import type {SequenceManagerContext} from '../SequenceManager.js';
+import type {
+	SequenceManagerContext,
+	SequencePropsSubscriptionKey,
+} from '../SequenceManager.js';
 import {
 	SequenceManager,
 	SequenceManagerProvider,
@@ -20,15 +25,33 @@ import {
 import {Series} from '../series/index.js';
 import {useCurrentFrame} from '../use-current-frame.js';
 import type {BasicMediaInTimelineReturnType} from '../use-media-in-timeline.js';
+import type {DragOverrides, PropStatuses} from '../use-schema.js';
 import {WrapSequenceContext} from './wrap-sequence-context.js';
 
 afterEach(cleanup);
 
-const SequenceTestWrapper: React.FC<{
+type SequenceTestWrapperProps = {
 	readonly children: React.ReactNode;
 	readonly onRegisterSequence: (sequence: TSequence) => void;
 	readonly rerenderOnRegister?: boolean;
-}> = ({children, onRegisterSequence, rerenderOnRegister = false}) => {
+};
+
+type VisualModeOverrides = {
+	readonly overrideIdToNodePathMappings: OverrideIdToNodePaths;
+	readonly propStatuses: PropStatuses;
+	readonly dragOverrides: DragOverrides;
+};
+
+const SequenceTestWrapperWithVisualModeOverrides: React.FC<
+	SequenceTestWrapperProps & {
+		readonly visualModeOverrides: VisualModeOverrides | null;
+	}
+> = ({
+	children,
+	onRegisterSequence,
+	rerenderOnRegister = false,
+	visualModeOverrides,
+}) => {
 	const [, setTick] = useState(0);
 
 	const registerSequence = useCallback(
@@ -50,21 +73,28 @@ const SequenceTestWrapper: React.FC<{
 
 	const visualPropStatuses = useMemo(
 		() => ({
-			propStatuses: {},
+			propStatuses: visualModeOverrides?.propStatuses ?? {},
 		}),
-		[],
+		[visualModeOverrides],
 	);
 
 	const visualDragOverrides = useMemo(
 		() => ({
-			getDragOverrides: () => {
-				throw new Error('VisualModeDragOverridesContext not initialized');
-			},
-			getEffectDragOverrides: () => {
-				throw new Error('VisualModeDragOverridesContext not initialized');
-			},
+			getDragOverrides: (nodePath: SequencePropsSubscriptionKey) =>
+				visualModeOverrides?.dragOverrides[
+					Internals.makeSequencePropsSubscriptionKey(nodePath)
+				] ?? {},
+			getEffectDragOverrides: () => ({}),
 		}),
-		[],
+		[visualModeOverrides],
+	);
+
+	const overrideIdToNodePathContext = useMemo(
+		() => ({
+			overrideIdToNodePathMappings:
+				visualModeOverrides?.overrideIdToNodePathMappings ?? {},
+		}),
+		[visualModeOverrides],
 	);
 
 	const visualSetters = useMemo(
@@ -89,19 +119,39 @@ const SequenceTestWrapper: React.FC<{
 					isReadOnlyStudio: false,
 				}}
 			>
-				<SequenceManager.Provider value={ctx}>
-					<VisualModePropStatusesContext.Provider value={visualPropStatuses}>
-						<VisualModeDragOverridesContext.Provider
-							value={visualDragOverrides}
-						>
-							<VisualModeSettersContext.Provider value={visualSetters}>
-								{children}
-							</VisualModeSettersContext.Provider>
-						</VisualModeDragOverridesContext.Provider>
-					</VisualModePropStatusesContext.Provider>
-				</SequenceManager.Provider>
+				<OverrideIdsToNodePathsGettersContext.Provider
+					value={overrideIdToNodePathContext}
+				>
+					<SequenceManager.Provider value={ctx}>
+						<VisualModePropStatusesContext.Provider value={visualPropStatuses}>
+							<VisualModeDragOverridesContext.Provider
+								value={visualDragOverrides}
+							>
+								<VisualModeSettersContext.Provider value={visualSetters}>
+									{children}
+								</VisualModeSettersContext.Provider>
+							</VisualModeDragOverridesContext.Provider>
+						</VisualModePropStatusesContext.Provider>
+					</SequenceManager.Provider>
+				</OverrideIdsToNodePathsGettersContext.Provider>
 			</Internals.RemotionEnvironmentContext>
 		</WrapSequenceContext>
+	);
+};
+
+const SequenceTestWrapper: React.FC<SequenceTestWrapperProps> = ({
+	children,
+	onRegisterSequence,
+	rerenderOnRegister = false,
+}) => {
+	return (
+		<SequenceTestWrapperWithVisualModeOverrides
+			onRegisterSequence={onRegisterSequence}
+			rerenderOnRegister={rerenderOnRegister}
+			visualModeOverrides={null}
+		>
+			{children}
+		</SequenceTestWrapperWithVisualModeOverrides>
 	);
 };
 
@@ -219,8 +269,10 @@ test('Sequence layout="none" uses outlineRef for Studio outlines', () => {
 	expect(registeredSequences[0]?.refForOutline?.current?.tagName).toBe('DIV');
 });
 
-test('Series.Sequence registers without visual controls', () => {
+test('Series.Sequence registers with its own visual controls', () => {
 	const registeredSequences: TSequence[] = [];
+	const firstStack = 'Error\n    at FirstSeriesSequence';
+	const secondStack = 'Error\n    at SecondSeriesSequence';
 
 	render(
 		<SequenceTestWrapper
@@ -229,10 +281,19 @@ test('Series.Sequence registers without visual controls', () => {
 			}}
 		>
 			<Series>
-				<Series.Sequence durationInFrames={10} premountFor={30}>
+				<Series.Sequence
+					durationInFrames={10}
+					premountFor={30}
+					{...({stack: firstStack} as {readonly stack: string})}
+				>
 					First
 				</Series.Sequence>
-				<Series.Sequence durationInFrames={20}>Second</Series.Sequence>
+				<Series.Sequence
+					durationInFrames={20}
+					{...({stack: secondStack} as {readonly stack: string})}
+				>
+					Second
+				</Series.Sequence>
 			</Series>
 		</SequenceTestWrapper>,
 	);
@@ -243,8 +304,126 @@ test('Series.Sequence registers without visual controls', () => {
 
 	expect(seriesSequences).toHaveLength(2);
 	for (const sequence of seriesSequences) {
-		expect(sequence.controls).toBe(null);
+		expect(sequence.controls?.componentIdentity).toBe(
+			'dev.remotion.remotion.Series.Sequence',
+		);
+		expect(sequence.isInsideSeries).toBe(true);
 	}
+
+	expect(
+		seriesSequences.map(
+			(sequence) =>
+				sequence.controls?.currentRuntimeValueDotNotation.durationInFrames,
+		),
+	).toEqual([10, 20]);
+	expect(seriesSequences.map((sequence) => sequence.getStack())).toEqual([
+		firstStack,
+		secondStack,
+	]);
+});
+
+test('Series.Sequence duration overrides cascade to later sequences', async () => {
+	const registeredSequences: TSequence[] = [];
+	const onRegisterSequence = (sequence: TSequence) => {
+		registeredSequences.push(sequence);
+	};
+
+	const renderSeries = ({
+		overrideIdToNodePathMappings,
+		propStatuses,
+		dragOverrides,
+	}: {
+		overrideIdToNodePathMappings: OverrideIdToNodePaths;
+		propStatuses: PropStatuses;
+		dragOverrides: DragOverrides;
+	}) => (
+		<SequenceTestWrapperWithVisualModeOverrides
+			onRegisterSequence={onRegisterSequence}
+			visualModeOverrides={{
+				overrideIdToNodePathMappings,
+				propStatuses,
+				dragOverrides,
+			}}
+		>
+			<Series>
+				<Series.Sequence name="First" durationInFrames={10}>
+					First
+				</Series.Sequence>
+				<Series.Sequence name="Second" durationInFrames={20}>
+					Second
+				</Series.Sequence>
+			</Series>
+		</SequenceTestWrapperWithVisualModeOverrides>
+	);
+
+	const rendered = render(
+		renderSeries({
+			overrideIdToNodePathMappings: {},
+			propStatuses: {},
+			dragOverrides: {},
+		}),
+	);
+	const firstSequence = registeredSequences.find(
+		(sequence) => sequence.displayName === 'First',
+	);
+	if (!firstSequence?.controls) {
+		throw new Error('Expected the first Series.Sequence to be interactive');
+	}
+
+	const firstSequenceControls = firstSequence.controls;
+
+	const nodePath = {
+		absolutePath: '/src/Composition.tsx',
+		nodePath: ['body', 0],
+		sequenceKeys: [],
+		effectKeys: [],
+	};
+	const subscriptionKey = Internals.makeSequencePropsSubscriptionKey(nodePath);
+	const makeDurationOverride = (durationInFrames: number) => ({
+		overrideIdToNodePathMappings: {
+			[firstSequenceControls.overrideId]: nodePath,
+		},
+		propStatuses: {
+			[subscriptionKey]: {
+				canUpdate: true as const,
+				props: {
+					durationInFrames: {status: 'static' as const, codeValue: 10},
+				},
+				effects: [],
+			},
+		},
+		dragOverrides: {
+			[subscriptionKey]: {
+				durationInFrames: Internals.makeStaticDragOverride(durationInFrames),
+			},
+		},
+	});
+
+	registeredSequences.length = 0;
+	rendered.rerender(renderSeries(makeDurationOverride(15)));
+	await waitFor(() => {
+		expect(
+			registeredSequences.find((sequence) => sequence.displayName === 'First')
+				?.duration,
+		).toBe(15);
+		expect(
+			registeredSequences.find((sequence) => sequence.displayName === 'Second')
+				?.from,
+		).toBe(15);
+	});
+
+	registeredSequences.length = 0;
+	rendered.rerender(renderSeries(makeDurationOverride(18)));
+	await waitFor(() => {
+		expect(
+			registeredSequences.find((sequence) => sequence.displayName === 'First')
+				?.duration,
+		).toBe(18);
+		expect(
+			registeredSequences.find((sequence) => sequence.displayName === 'Second')
+				?.from,
+		).toBe(18);
+	});
 });
 
 test('Img registers its documentation link for default labels', () => {

--- a/packages/example/src/Issue8974TimelineInteractivity/index.tsx
+++ b/packages/example/src/Issue8974TimelineInteractivity/index.tsx
@@ -1,70 +1,45 @@
 import {Video} from '@remotion/media';
-import {linearTiming, TransitionSeries} from '@remotion/transitions';
-import {fade} from '@remotion/transitions/fade';
+import {TransitionSeries} from '@remotion/transitions';
 import React from 'react';
+import {Series} from 'remotion';
 
 export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 	return (
 		<TransitionSeries name="Linked timeline TransitionSeries">
-			<TransitionSeries.Sequence name="Linked clip 01" durationInFrames={42}>
+			<TransitionSeries.Sequence name="Linked clip 01" durationInFrames={39}>
 				<Video
 					name="Linked video 01"
 					src="https://remotion.media/video.mp4"
 					trimBefore={0}
-					trimAfter={42}
-					muted
+					durationInFrames={39}
 				/>
 			</TransitionSeries.Sequence>
-			<TransitionSeries.Transition
-				timing={linearTiming({durationInFrames: 8})}
-				presentation={fade()}
-			/>
-			<TransitionSeries.Sequence name="Linked clip 02" durationInFrames={50}>
+			<TransitionSeries.Sequence name="Linked clip 02" durationInFrames={84}>
 				<Video
 					name="Linked video 02"
 					src="https://remotion.media/video.webm"
 					trimBefore={8}
-					trimAfter={58}
-					muted
 				/>
 			</TransitionSeries.Sequence>
-			<TransitionSeries.Transition
-				timing={linearTiming({durationInFrames: 8})}
-				presentation={fade()}
-			/>
-			<TransitionSeries.Sequence name="Linked clip 03" durationInFrames={36}>
+			<TransitionSeries.Sequence name="Linked clip 03" durationInFrames={43}>
 				<Video
 					name="Linked video 03"
 					src="https://remotion.media/video.mp4"
 					trimBefore={60}
-					trimAfter={96}
-					muted
 				/>
 			</TransitionSeries.Sequence>
-			<TransitionSeries.Transition
-				timing={linearTiming({durationInFrames: 8})}
-				presentation={fade()}
-			/>
-			<TransitionSeries.Sequence name="Linked clip 04" durationInFrames={46}>
+			<TransitionSeries.Sequence name="Linked clip 04" durationInFrames={36}>
 				<Video
 					name="Linked video 04"
 					src="https://remotion.media/video.webm"
-					trimBefore={70}
-					trimAfter={116}
-					muted
+					trimBefore={80}
 				/>
 			</TransitionSeries.Sequence>
-			<TransitionSeries.Transition
-				timing={linearTiming({durationInFrames: 8})}
-				presentation={fade()}
-			/>
-			<TransitionSeries.Sequence name="Linked clip 05" durationInFrames={56}>
+			<TransitionSeries.Sequence name="Linked clip 05" durationInFrames={45}>
 				<Video
 					name="Linked video 05"
 					src="https://remotion.media/video.mp4"
 					trimBefore={120}
-					trimAfter={176}
-					muted
 				/>
 			</TransitionSeries.Sequence>
 		</TransitionSeries>
@@ -104,5 +79,52 @@ export const Issue8974IndependentVideosTimeline: React.FC = () => {
 				durationInFrames={60}
 			/>
 		</>
+	);
+};
+
+export const Issue8974SeriesTimeline: React.FC = () => {
+	return (
+		<Series name="Linked timeline Series">
+			<Series.Sequence name="Linked clip 01" durationInFrames={78}>
+				<Video
+					name="Linked video 01"
+					src="https://remotion.media/video.mp4"
+					trimBefore={0}
+					durationInFrames={78}
+				/>
+			</Series.Sequence>
+			<Series.Sequence name="Linked clip 02" durationInFrames={66}>
+				<Video
+					name="Linked video 02"
+					src="https://remotion.media/video.webm"
+					trimBefore={12}
+					durationInFrames={66}
+				/>
+			</Series.Sequence>
+			<Series.Sequence name="Linked clip 03" durationInFrames={90}>
+				<Video
+					name="Linked video 03"
+					src="https://remotion.media/video.mp4"
+					trimBefore={72}
+					durationInFrames={90}
+				/>
+			</Series.Sequence>
+			<Series.Sequence name="Linked clip 04" durationInFrames={72}>
+				<Video
+					name="Linked video 04"
+					src="https://remotion.media/video.webm"
+					trimBefore={58}
+					durationInFrames={72}
+				/>
+			</Series.Sequence>
+			<Series.Sequence name="Linked clip 05" durationInFrames={60}>
+				<Video
+					name="Linked video 05"
+					src="https://remotion.media/video.mp4"
+					trimBefore={180}
+					durationInFrames={60}
+				/>
+			</Series.Sequence>
+		</Series>
 	);
 };

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -208,6 +208,7 @@ import {VideoEffectsFastRefresh} from './EffectsTestbed/VideoEffectsFastRefresh'
 import {Empty} from './Empty';
 import {
 	Issue8974IndependentVideosTimeline,
+	Issue8974SeriesTimeline,
 	Issue8974TransitionSeriesTimeline,
 } from './Issue8974TimelineInteractivity';
 import {JumpCuts, SAMPLE_SECTIONS, calculateMetadataJumpCuts} from './JumpCuts';
@@ -2690,6 +2691,14 @@ export const Index: React.FC = () => {
 				<Composition
 					id="video-editing-independent"
 					component={Issue8974IndependentVideosTimeline}
+					width={1920}
+					height={1080}
+					fps={30}
+					durationInFrames={366}
+				/>
+				<Composition
+					id="video-editing-series"
+					component={Issue8974SeriesTimeline}
 					width={1920}
 					height={1080}
 					fps={30}

--- a/packages/skills/skills/remotion-markup/video-editing.md
+++ b/packages/skills/skills/remotion-markup/video-editing.md
@@ -1,19 +1,66 @@
-Remotion can be used for barebones video editing. Layers can be dragged on the left side and right side to be trimmed, and layers can be moved around in the Studio.
+Remotion can be used for bare-bones video editing in the Studio. Choose the source structure based on the editing behavior you want:
 
-For this to work correctly, the markup must be structured like this:
+- Use independently positioned clips when moving or resizing one clip should not affect any other clip.
+- Use ripple editing when changing one clip's duration should reposition every clip after it.
+
+Keep every editable clip as its own authored JSX node. Do not generate editable clips with `.map()` or another programmatic loop.
+
+## Independently positioned clips
+
+Place every `<Video>` directly in the composition and hardcode its timing props. `from={0}` may be omitted:
 
 ```tsx
-<Video src="https://remotion.media/video.mp4" trimBefore={0} durationInFrames={78}/>
-<Video src="https://remotion.media/video.webm" trimBefore={12} from={78} durationInFrames={66}/>
-<Video src="https://remotion.media/video.mp4" trimBefore={72}  from={144} durationInFrames={90}/>
-<Video src="https://remotion.media/video.webm" trimBefore={58} from={234} durationInFrames={72}/>
+<Video src="https://remotion.media/video.mp4" trimBefore={0} durationInFrames={78} />
+<Video src="https://remotion.media/video.webm" trimBefore={12} from={78} durationInFrames={66} />
+<Video src="https://remotion.media/video.mp4" trimBefore={72} from={144} durationInFrames={90} />
+<Video src="https://remotion.media/video.webm" trimBefore={58} from={234} durationInFrames={72} />
 <Video src="https://remotion.media/video.mp4" trimBefore={180} from={306} durationInFrames={60} />
 ```
 
-`from` determines at which frame in the timeline the video starts.
-`durationInFrames` determines at which frame in the timeline the video ends.
-The video starts playing at 0 seconds, unless `trimBefore` (in frames) is set.
+- `from` is the clip's absolute start frame in its parent timeline.
+- `durationInFrames` is how many frames the clip remains visible.
+- `trimBefore` is how many source frames are skipped before playback begins.
+- Each `<Video>` must be a separate JSX node. Add a descriptive `name` when useful in the Studio timeline.
+- `from`, `durationInFrames`, and `trimBefore` must be hardcoded frame values. Do not compute them.
+- Import `<Video>` from `@remotion/media`.
 
-- Each Video must be it's independent node in the source code, no programmatic iteration such as `.map`
-- `from`, `durationInFrames` and `trimBefore` must be hardcoded in frames. They cannot be computed.
-- `<Video>` must be imported from `@remotion/media`.
+Moving or resizing one of these clips does not reposition later clips. Gaps and overlaps are therefore allowed.
+
+## Ripple editing with `TransitionSeries`
+
+“Ripple editing” is the standard video-editing term for changing one clip and automatically shifting everything after it.
+In Remotion, a `<TransitionSeries>` provides this sequential, cascading timing model while also allowing transitions between clips.
+
+Read [transitions.md](transitions.md) for transition types, timing options, installation instructions, and composition-duration calculation.
+
+Keep the markup like this:
+
+```tsx
+<TransitionSeries name="Video timeline">
+  <TransitionSeries.Sequence name="Clip 1" durationInFrames={39}>
+    <Video
+      src="https://remotion.media/video.mp4"
+      trimBefore={0}
+    />
+  </TransitionSeries.Sequence>
+  <TransitionSeries.Sequence name="Clip 2" durationInFrames={45}>
+    <Video
+      src="https://remotion.media/video.webm"
+      trimBefore={8}
+    />
+  </TransitionSeries.Sequence>
+  <TransitionSeries.Sequence name="Clip 3" durationInFrames={43}>
+    <Video
+      src="https://remotion.media/video.mp4"
+      trimBefore={60}
+    />
+  </TransitionSeries.Sequence>
+</TransitionSeries>
+```
+
+- The `<TransitionSeries.Sequence>` is the editable clip row in the Studio timeline.
+- Dragging its right edge changes `durationInFrames` and repositions every later sequence.
+- Do not set `from` on `<TransitionSeries.Sequence>`; the series calculates each start frame.
+- Hardcode all numeric values.
+- Do not programmatically create multiple `<TransitionSeries.Sequence>` (no `.map`). Each instance must be hard-coded.
+- Import `<Video>` from `@remotion/media`. Import `<TransitionSeries>` from `@remotion/transitions`. If needing to install: `npx remotion add @remotion/media @remotion/transitions`

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -58,6 +58,7 @@ export type TimelineSequenceDurationDragTarget = {
 	readonly fileName: string;
 	readonly initialDuration: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly schema: InteractivitySchema;
 };
 
 export type TimelineSequenceLeftEdgeDragTarget = {
@@ -200,13 +201,17 @@ const canUpdateTrimBefore = ({
 };
 
 export const isTimelineSequenceDurationDraggable = (sequence: TSequence) => {
+	const isInteractiveSeriesSequence =
+		sequence.controls?.componentIdentity ===
+		'dev.remotion.remotion.Series.Sequence';
+
 	return (
 		(sequence.type === 'sequence' ||
 			sequence.type === 'image' ||
 			sequence.type === 'audio' ||
 			sequence.type === 'video') &&
 		!sequence.loopDisplay &&
-		!sequence.isInsideSeries &&
+		(!sequence.isInsideSeries || isInteractiveSeriesSequence) &&
 		Boolean(sequence.controls)
 	);
 };
@@ -354,7 +359,7 @@ export const getTimelineSequenceDurationDragChanges = ({
 				fieldKey: 'durationInFrames',
 				value: nextValue,
 				defaultValue: null,
-				schema: NoReactInternals.sequenceSchema,
+				schema: target.schema,
 			},
 		];
 	});
@@ -523,12 +528,18 @@ export const getTimelineSequenceDurationDragTargets = ({
 			return null;
 		}
 
+		const {controls} = originalSequence;
+		if (!controls) {
+			return null;
+		}
+
 		const key = stringifySequenceSubscriptionKey(nodePath);
 		if (!targets.has(key)) {
 			targets.set(key, {
 				fileName: nodePath.absolutePath,
 				initialDuration: originalSequence.duration,
 				nodePath,
+				schema: controls.schema,
 			});
 		}
 	}

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1049,6 +1049,12 @@ test('Timeline duration drag applies the same delta to selected sequences', () =
 			deltaFrames: -10,
 		}).map((change) => change.value),
 	).toEqual([30, 5]);
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: targets ?? [],
+			deltaFrames: -10,
+		}).map((change) => change.schema),
+	).toEqual([schema, schema]);
 });
 
 test('Timeline duration drag uses the declared duration for negative from values', () => {
@@ -1107,8 +1113,26 @@ test('Timeline duration drag supports interactive video clips', () => {
 			fileName: nodePathInfo.sequenceSubscriptionKey.absolutePath,
 			initialDuration: 78,
 			nodePath: nodePathInfo.sequenceSubscriptionKey,
+			schema: Internals.baseSchema,
 		},
 	]);
+});
+
+test('Timeline duration drag supports interactive Series.Sequence rows', () => {
+	const baseSequence = makeTimelineSequence({
+		schema: Internals.baseSchema,
+		duration: 78,
+	});
+	const seriesSequence = {
+		...baseSequence,
+		isInsideSeries: true,
+		controls: {
+			...baseSequence.controls!,
+			componentIdentity: 'dev.remotion.remotion.Series.Sequence',
+		},
+	} satisfies TSequence;
+
+	expect(isTimelineSequenceDurationDraggable(seriesSequence)).toBe(true);
 });
 
 test('Timeline duration drag clamps each selected sequence to one frame', () => {

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -1,5 +1,5 @@
 import type {FC, PropsWithChildren} from 'react';
-import React, {Children, useCallback, useMemo, useRef} from 'react';
+import React, {useCallback, useMemo, useRef} from 'react';
 import type {
 	AbsoluteFillLayout,
 	LayoutAndStyle,
@@ -50,13 +50,63 @@ type SeriesSequenceProps = PropsWithChildren<
 		readonly offset?: number;
 		readonly className?: string;
 	} & LayoutBasedProps &
-		Pick<SequencePropsWithoutDuration, 'name' | 'showInTimeline' | 'freeze'>
+		Pick<
+			SequencePropsWithoutDuration,
+			'name' | 'showInTimeline' | 'freeze' | 'hidden'
+		>
 >;
 
-const SeriesSequence = ({children}: SeriesSequenceProps) => {
-	// eslint-disable-next-line react/jsx-no-useless-fragment
-	return <>{children}</>;
+type ResolvedSeriesSequenceProps = SeriesSequenceProps & {
+	readonly controls: SequenceControls | null | undefined;
+	readonly stack: string | null;
 };
+
+type InternalSeriesSequenceProps = ResolvedSeriesSequenceProps & {
+	readonly _remotionInternalRender:
+		| ((props: ResolvedSeriesSequenceProps) => React.ReactNode)
+		| null;
+};
+
+const transitionSeriesSequenceSchema = {
+	durationInFrames: Internals.durationInFramesField,
+	name: Internals.sequenceSchema.name,
+	hidden: Internals.sequenceSchema.hidden,
+	showInTimeline: Internals.sequenceSchema.showInTimeline,
+	freeze: Internals.freezeField,
+	layout: Internals.sequenceSchema.layout,
+} as const satisfies InteractivitySchema;
+
+const SeriesSequenceInner: FC<InternalSeriesSequenceProps> = ({
+	offset = 0,
+	className = '',
+	stack = null,
+	_remotionInternalRender = null,
+	...props
+}) => {
+	if (_remotionInternalRender) {
+		return _remotionInternalRender({
+			...props,
+			offset,
+			className: className || undefined,
+			stack,
+		});
+	}
+
+	// eslint-disable-next-line react/jsx-no-useless-fragment
+	return <>{props.children}</>;
+};
+
+const SeriesSequence = Interactive.withSchema({
+	Component: SeriesSequenceInner as unknown as React.ComponentType<
+		SeriesSequenceProps & {
+			readonly controls: SequenceControls | undefined;
+		}
+	>,
+	componentName: '<TransitionSeries.Sequence>',
+	componentIdentity: 'dev.remotion.transitions.TransitionSeries.Sequence',
+	schema: transitionSeriesSequenceSchema,
+	supportsEffects: false,
+}) as FC<SeriesSequenceProps>;
 
 const transitionSeriesSchema = {
 	name: Internals.sequenceSchema.name,
@@ -171,22 +221,60 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 	);
 
 	const childrenValue = useMemo(() => {
-		let transitionOffsets = 0;
-		let startFrame = 0;
+		type OverlayRender = {
+			readonly cutPoint: number;
+			readonly overlayFrom: number;
+			readonly durationInFrames: number;
+			readonly overlayOffset: number;
+			readonly halfDuration: number;
+			readonly children: React.ReactNode;
+			readonly index: number;
+		};
 
-		// Collect overlay render info to emit after the main loop
-		const overlayRenders: React.ReactNode[] = [];
+		type RenderState = {
+			readonly index: number;
+			readonly transitionOffsets: number;
+			readonly startFrame: number;
+			readonly overlayRenders: readonly OverlayRender[];
+			readonly sequenceDurations: readonly number[];
+			readonly pendingOverlayValidation: boolean;
+		};
 
-		// Track sequence durations for overlay validation
-		const sequenceDurations: number[] = [];
-		let pendingOverlayValidation = false;
+		const renderChildren = (state: RenderState): React.ReactNode => {
+			const {
+				index: i,
+				transitionOffsets,
+				startFrame,
+				overlayRenders,
+				sequenceDurations,
+				pendingOverlayValidation,
+			} = state;
 
-		const mainChildren = Children.map(flattedChildren, (child, i) => {
+			if (i === flattedChildren.length) {
+				return overlayRenders.map((info) => (
+					<SequenceWithoutSchema
+						key={`overlay-${info.index}`}
+						from={Math.round(info.overlayFrom)}
+						durationInFrames={info.durationInFrames}
+						name="<TS.Overlay>"
+						_remotionInternalDocumentationLink="https://www.remotion.dev/docs/transitions/transitionseries"
+						layout="absolute-fill"
+					>
+						{info.children}
+					</SequenceWithoutSchema>
+				));
+			}
+
+			const child = flattedChildren[i];
 			const current = child as unknown as TypeChild<Record<string, unknown>>;
+			const renderNext = (overrides: Partial<RenderState> = {}) => {
+				return renderChildren({...state, ...overrides, index: i + 1});
+			};
+
 			if (typeof current === 'string') {
 				// Don't throw if it's just some accidential whitespace
 				if (current.trim() === '') {
-					return null;
+					return renderNext();
 				}
 
 				throw new TypeError(
@@ -291,10 +379,9 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					}
 				}
 
-				// We'll validate the next sequence side after we process it
-				pendingOverlayValidation = true;
-				// Store overlay info for deferred rendering
-				overlayRenders.push({
+				// Store overlay info for deferred rendering and validate the other
+				// side once the next sequence has resolved its interactive props.
+				const overlayRender: OverlayRender = {
 					cutPoint,
 					overlayFrom,
 					durationInFrames: overlayProps.durationInFrames,
@@ -302,9 +389,12 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					halfDuration,
 					children: overlayProps.children,
 					index: i,
-				} as unknown as React.ReactNode);
+				};
 
-				return null;
+				return renderNext({
+					overlayRenders: [...overlayRenders, overlayRender],
+					pendingOverlayValidation: true,
+				});
 			}
 
 			if (current.type === TransitionSeriesTransition) {
@@ -324,7 +414,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					);
 				}
 
-				return null;
+				return renderNext();
 			}
 
 			if (current.type !== SeriesSequence) {
@@ -347,163 +437,248 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 						? (nextPrev as TransitionType<Record<string, unknown>>)
 						: null;
 
-			const castedChildAgain = current as {
-				props: SeriesSequenceProps;
-				type: typeof SeriesSequence;
-			};
+			const castedChildAgain = current as React.ReactElement<
+				InternalSeriesSequenceProps,
+				typeof SeriesSequence
+			>;
 
-			const debugInfo = `index = ${i}, duration = ${castedChildAgain.props.durationInFrames}`;
+			return React.cloneElement(castedChildAgain, {
+				_remotionInternalRender: (resolvedProps) => {
+					const durationInFramesProp = resolvedProps.durationInFrames;
+					const debugInfo = `index = ${i}, duration = ${durationInFramesProp}`;
+					const {
+						durationInFrames,
+						children: sequenceChildren,
+						offset: offsetProp,
+						controls,
+						stack,
+						from: _from,
+						...passedProps
+					} = resolvedProps as InternalSeriesSequenceProps & {from: never};
+					validateDurationInFrames(durationInFramesProp, {
+						component: `of a <TransitionSeries.Sequence /> component`,
+						allowFloats: true,
+					});
+					const offset = offsetProp ?? 0;
+					if (Number.isNaN(offset)) {
+						throw new TypeError(
+							`The "offset" property of a <TransitionSeries.Sequence /> must not be NaN, but got NaN (${debugInfo}).`,
+						);
+					}
 
-			const durationInFramesProp = castedChildAgain.props.durationInFrames;
-			const {
-				durationInFrames,
-				children: _children,
-				from: _from,
-				...passedProps
-			} = castedChildAgain.props as SeriesSequenceProps & {from: never};
-			validateDurationInFrames(durationInFramesProp, {
-				component: `of a <TransitionSeries.Sequence /> component`,
-				allowFloats: true,
-			});
-			const offset = castedChildAgain.props.offset ?? 0;
-			if (Number.isNaN(offset)) {
-				throw new TypeError(
-					`The "offset" property of a <TransitionSeries.Sequence /> must not be NaN, but got NaN (${debugInfo}).`,
-				);
-			}
+					if (!Number.isFinite(offset)) {
+						throw new TypeError(
+							`The "offset" property of a <TransitionSeries.Sequence /> must be finite, but got ${offset} (${debugInfo}).`,
+						);
+					}
 
-			if (!Number.isFinite(offset)) {
-				throw new TypeError(
-					`The "offset" property of a <TransitionSeries.Sequence /> must be finite, but got ${offset} (${debugInfo}).`,
-				);
-			}
+					if (offset % 1 !== 0) {
+						throw new TypeError(
+							`The "offset" property of a <TransitionSeries.Sequence /> must be finite, but got ${offset} (${debugInfo}).`,
+						);
+					}
 
-			if (offset % 1 !== 0) {
-				throw new TypeError(
-					`The "offset" property of a <TransitionSeries.Sequence /> must be finite, but got ${offset} (${debugInfo}).`,
-				);
-			}
+					let resolvedTransitionOffsets = transitionOffsets;
+					let resolvedStartFrame = startFrame;
+					let resolvedPendingOverlayValidation = pendingOverlayValidation;
+					const currentStartFrame = resolvedStartFrame + offset;
 
-			const currentStartFrame = startFrame + offset;
+					let duration = 0;
 
-			let duration = 0;
+					if (prev) {
+						duration = prev.props.timing.getDurationInFrames({
+							fps,
+						});
+						resolvedTransitionOffsets -= duration;
+					}
 
-			if (prev) {
-				duration = prev.props.timing.getDurationInFrames({
-					fps,
-				});
-				transitionOffsets -= duration;
-			}
+					let actualStartFrame = currentStartFrame + resolvedTransitionOffsets;
 
-			let actualStartFrame = currentStartFrame + transitionOffsets;
+					resolvedStartFrame += durationInFramesProp + offset;
 
-			startFrame += durationInFramesProp + offset;
+					// Handle the case where the first item is a transition
+					if (actualStartFrame < 0) {
+						resolvedStartFrame -= actualStartFrame;
+						actualStartFrame = 0;
+					}
 
-			// Handle the case where the first item is a transition
-			if (actualStartFrame < 0) {
-				startFrame -= actualStartFrame;
-				actualStartFrame = 0;
-			}
+					// Track resolved durations so later sequences and overlay validation use
+					// the live Studio override instead of the original JSX value.
+					const nextSequenceDurations = [
+						...sequenceDurations,
+						durationInFramesProp,
+					];
 
-			// Track sequence durations for overlay validation
-			sequenceDurations.push(durationInFramesProp);
-
-			// Validate: check if a preceding overlay extends beyond this sequence
-			if (pendingOverlayValidation) {
-				pendingOverlayValidation = false;
-				const lastOverlay = overlayRenders[
-					overlayRenders.length - 1
-				] as unknown as {
-					halfDuration: number;
-					overlayOffset: number;
-					durationInFrames: number;
-				};
-				const framesAfterCut =
-					lastOverlay.halfDuration + lastOverlay.overlayOffset;
-				if (framesAfterCut > durationInFramesProp) {
-					throw new TypeError(
-						`A <TransitionSeries.Overlay /> extends beyond the next sequence. The overlay needs ${framesAfterCut} frames after the cut, but the next sequence is only ${durationInFramesProp} frames long.`,
-					);
-				}
-			}
-
-			const nextProgress = next
-				? next.props.timing.getProgress({
-						frame:
-							frame -
-							actualStartFrame -
-							durationInFrames +
-							next.props.timing.getDurationInFrames({fps}),
-						fps,
-					})
-				: null;
-
-			const prevProgress = prev
-				? prev.props.timing.getProgress({
-						frame: frame - actualStartFrame,
-						fps,
-					})
-				: null;
-
-			if (
-				next &&
-				durationInFramesProp < next.props.timing.getDurationInFrames({fps})
-			) {
-				throw new Error(
-					`The duration of a <TransitionSeries.Sequence /> must not be shorter than the duration of the next <TransitionSeries.Transition />. The transition is ${next.props.timing.getDurationInFrames(
-						{fps},
-					)} frames long, but the sequence is only ${durationInFramesProp} frames long (${debugInfo})`,
-				);
-			}
-
-			if (
-				prev &&
-				durationInFramesProp < prev.props.timing.getDurationInFrames({fps})
-			) {
-				throw new Error(
-					`The duration of a <TransitionSeries.Sequence /> must not be shorter than the duration of the previous <TransitionSeries.Transition />. The transition is ${prev.props.timing.getDurationInFrames(
-						{fps},
-					)} frames long, but the sequence is only ${durationInFramesProp} frames long (${debugInfo})`,
-				);
-			}
-
-			if (next && prev && nextProgress !== null && prevProgress !== null) {
-				const nextPresentation = next.props.presentation ?? slide();
-				const prevPresentation = prev.props.presentation ?? slide();
-
-				const UppercaseNextPresentation = nextPresentation.component;
-				const UppercasePrevPresentation = prevPresentation.component;
-
-				return (
-					<SequenceWithoutSchema
-						// eslint-disable-next-line react/no-array-index-key
-						key={i}
-						from={actualStartFrame}
-						durationInFrames={durationInFramesProp}
-						{...passedProps}
-						name={passedProps.name || '<TS.Sequence>'}
-						_remotionInternalDocumentationLink={
-							passedProps.name
-								? undefined
-								: 'https://www.remotion.dev/docs/transitions/transitionseries'
+					// Validate: check if a preceding overlay extends beyond this sequence
+					if (resolvedPendingOverlayValidation) {
+						resolvedPendingOverlayValidation = false;
+						const lastOverlay = overlayRenders[overlayRenders.length - 1];
+						if (!lastOverlay) {
+							throw new Error('Expected an overlay to validate');
 						}
-					>
-						<UppercaseNextPresentation
-							passedProps={nextPresentation.props ?? {}}
-							presentationDirection="exiting"
-							presentationProgress={nextProgress}
-							presentationDurationInFrames={next.props.timing.getDurationInFrames(
+
+						const framesAfterCut =
+							lastOverlay.halfDuration + lastOverlay.overlayOffset;
+						if (framesAfterCut > durationInFramesProp) {
+							throw new TypeError(
+								`A <TransitionSeries.Overlay /> extends beyond the next sequence. The overlay needs ${framesAfterCut} frames after the cut, but the next sequence is only ${durationInFramesProp} frames long.`,
+							);
+						}
+					}
+
+					const renderSequenceAndRest = (sequence: React.ReactNode) => {
+						return (
+							<>
+								{sequence}
+								{renderNext({
+									transitionOffsets: resolvedTransitionOffsets,
+									startFrame: resolvedStartFrame,
+									sequenceDurations: nextSequenceDurations,
+									pendingOverlayValidation: resolvedPendingOverlayValidation,
+								})}
+							</>
+						);
+					};
+
+					const nextProgress = next
+						? next.props.timing.getProgress({
+								frame:
+									frame -
+									actualStartFrame -
+									durationInFrames +
+									next.props.timing.getDurationInFrames({fps}),
+								fps,
+							})
+						: null;
+
+					const prevProgress = prev
+						? prev.props.timing.getProgress({
+								frame: frame - actualStartFrame,
+								fps,
+							})
+						: null;
+
+					if (
+						next &&
+						durationInFramesProp < next.props.timing.getDurationInFrames({fps})
+					) {
+						throw new Error(
+							`The duration of a <TransitionSeries.Sequence /> must not be shorter than the duration of the next <TransitionSeries.Transition />. The transition is ${next.props.timing.getDurationInFrames(
 								{fps},
-							)}
-							onElementImage={() => {
-								throw new Error('Should not call when exiting');
-							}}
-							onUnmount={() => {
-								throw new Error('Should not call when exiting');
-							}}
-							bothEnteringAndExiting
-						>
-							<WrapInExitingProgressContext presentationProgress={nextProgress}>
+							)} frames long, but the sequence is only ${durationInFramesProp} frames long (${debugInfo})`,
+						);
+					}
+
+					if (
+						prev &&
+						durationInFramesProp < prev.props.timing.getDurationInFrames({fps})
+					) {
+						throw new Error(
+							`The duration of a <TransitionSeries.Sequence /> must not be shorter than the duration of the previous <TransitionSeries.Transition />. The transition is ${prev.props.timing.getDurationInFrames(
+								{fps},
+							)} frames long, but the sequence is only ${durationInFramesProp} frames long (${debugInfo})`,
+						);
+					}
+
+					if (next && prev && nextProgress !== null && prevProgress !== null) {
+						const nextPresentation = next.props.presentation ?? slide();
+						const prevPresentation = prev.props.presentation ?? slide();
+
+						const UppercaseNextPresentation = nextPresentation.component;
+						const UppercasePrevPresentation = prevPresentation.component;
+
+						return renderSequenceAndRest(
+							<SequenceWithoutSchema
+								key={i}
+								from={actualStartFrame}
+								durationInFrames={durationInFramesProp}
+								{...passedProps}
+								name={passedProps.name || '<TS.Sequence>'}
+								_remotionInternalDocumentationLink={
+									passedProps.name
+										? undefined
+										: 'https://www.remotion.dev/docs/transitions/transitionseries'
+								}
+								_remotionInternalStack={stack ?? undefined}
+								controls={controls ?? undefined}
+							>
+								<UppercaseNextPresentation
+									passedProps={nextPresentation.props ?? {}}
+									presentationDirection="exiting"
+									presentationProgress={nextProgress}
+									presentationDurationInFrames={next.props.timing.getDurationInFrames(
+										{fps},
+									)}
+									onElementImage={() => {
+										throw new Error('Should not call when exiting');
+									}}
+									onUnmount={() => {
+										throw new Error('Should not call when exiting');
+									}}
+									bothEnteringAndExiting
+								>
+									<WrapInExitingProgressContext
+										presentationProgress={nextProgress}
+									>
+										<UppercasePrevPresentation
+											passedProps={prevPresentation.props ?? {}}
+											presentationDirection="entering"
+											presentationProgress={prevProgress}
+											presentationDurationInFrames={prev.props.timing.getDurationInFrames(
+												{fps},
+											)}
+											onElementImage={(elementImage, draw) => {
+												onPrevElementImage(
+													elementImage,
+													nextProgress,
+													draw,
+													i + 1,
+												);
+												onNextElementImage(
+													elementImage,
+													prevProgress,
+													draw,
+													i - 1,
+												);
+											}}
+											onUnmount={() => {
+												onPrevElementImage(null, null, null, i + 1);
+												onNextElementImage(null, null, null, i - 1);
+											}}
+											bothEnteringAndExiting
+										>
+											<WrapInEnteringProgressContext
+												presentationProgress={prevProgress}
+											>
+												{sequenceChildren}
+											</WrapInEnteringProgressContext>
+										</UppercasePrevPresentation>
+									</WrapInExitingProgressContext>
+								</UppercaseNextPresentation>
+							</SequenceWithoutSchema>,
+						);
+					}
+
+					if (prevProgress !== null && prev) {
+						const prevPresentation = prev.props.presentation ?? slide();
+
+						const UppercasePrevPresentation = prevPresentation.component;
+
+						return renderSequenceAndRest(
+							<SequenceWithoutSchema
+								key={i}
+								from={actualStartFrame}
+								durationInFrames={durationInFramesProp}
+								{...passedProps}
+								name={passedProps.name || '<TS.Sequence>'}
+								_remotionInternalDocumentationLink={
+									passedProps.name
+										? undefined
+										: 'https://www.remotion.dev/docs/transitions/transitionseries'
+								}
+								_remotionInternalStack={stack ?? undefined}
+								controls={controls ?? undefined}
+							>
 								<UppercasePrevPresentation
 									passedProps={prevPresentation.props ?? {}}
 									presentationDirection="entering"
@@ -511,158 +686,99 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 									presentationDurationInFrames={prev.props.timing.getDurationInFrames(
 										{fps},
 									)}
-									onElementImage={(elementImage, draw) => {
-										onPrevElementImage(elementImage, nextProgress, draw, i + 1);
-										onNextElementImage(elementImage, prevProgress, draw, i - 1);
-									}}
+									onElementImage={(elementImage, draw) =>
+										onNextElementImage(elementImage, prevProgress, draw, i - 1)
+									}
 									onUnmount={() => {
-										onPrevElementImage(null, null, null, i + 1);
 										onNextElementImage(null, null, null, i - 1);
 									}}
-									bothEnteringAndExiting
+									bothEnteringAndExiting={false}
 								>
 									<WrapInEnteringProgressContext
 										presentationProgress={prevProgress}
 									>
-										{child}
+										{sequenceChildren}
 									</WrapInEnteringProgressContext>
 								</UppercasePrevPresentation>
-							</WrapInExitingProgressContext>
-						</UppercaseNextPresentation>
-					</SequenceWithoutSchema>
-				);
-			}
-
-			if (prevProgress !== null && prev) {
-				const prevPresentation = prev.props.presentation ?? slide();
-
-				const UppercasePrevPresentation = prevPresentation.component;
-
-				return (
-					<SequenceWithoutSchema
-						// eslint-disable-next-line react/no-array-index-key
-						key={i}
-						from={actualStartFrame}
-						durationInFrames={durationInFramesProp}
-						{...passedProps}
-						name={passedProps.name || '<TS.Sequence>'}
-						_remotionInternalDocumentationLink={
-							passedProps.name
-								? undefined
-								: 'https://www.remotion.dev/docs/transitions/transitionseries'
-						}
-					>
-						<UppercasePrevPresentation
-							passedProps={prevPresentation.props ?? {}}
-							presentationDirection="entering"
-							presentationProgress={prevProgress}
-							presentationDurationInFrames={prev.props.timing.getDurationInFrames(
-								{fps},
-							)}
-							onElementImage={(elementImage, draw) =>
-								onNextElementImage(elementImage, prevProgress, draw, i - 1)
-							}
-							onUnmount={() => {
-								onNextElementImage(null, null, null, i - 1);
-							}}
-							bothEnteringAndExiting={false}
-						>
-							<WrapInEnteringProgressContext
-								presentationProgress={prevProgress}
-							>
-								{child}
-							</WrapInEnteringProgressContext>
-						</UppercasePrevPresentation>
-					</SequenceWithoutSchema>
-				);
-			}
-
-			if (nextProgress !== null && next) {
-				const nextPresentation = next.props.presentation ?? slide();
-
-				const UppercaseNextPresentation = nextPresentation.component;
-
-				return (
-					<SequenceWithoutSchema
-						// eslint-disable-next-line react/no-array-index-key
-						key={i}
-						from={actualStartFrame}
-						durationInFrames={durationInFramesProp}
-						{...passedProps}
-						name={passedProps.name || '<TS.Sequence>'}
-						_remotionInternalDocumentationLink={
-							passedProps.name
-								? undefined
-								: 'https://www.remotion.dev/docs/transitions/transitionseries'
-						}
-					>
-						<UppercaseNextPresentation
-							passedProps={nextPresentation.props ?? {}}
-							presentationDirection="exiting"
-							presentationProgress={nextProgress}
-							presentationDurationInFrames={next.props.timing.getDurationInFrames(
-								{fps},
-							)}
-							onElementImage={(elementImage, draw) =>
-								onPrevElementImage(elementImage, nextProgress, draw, i + 1)
-							}
-							onUnmount={() => {
-								onPrevElementImage(null, null, null, i + 1);
-							}}
-							bothEnteringAndExiting={false}
-						>
-							<WrapInExitingProgressContext presentationProgress={nextProgress}>
-								{child}
-							</WrapInExitingProgressContext>
-						</UppercaseNextPresentation>
-					</SequenceWithoutSchema>
-				);
-			}
-
-			return (
-				<SequenceWithoutSchema
-					// eslint-disable-next-line react/no-array-index-key
-					key={i}
-					from={actualStartFrame}
-					durationInFrames={durationInFramesProp}
-					{...passedProps}
-					name={passedProps.name || '<TS.Sequence>'}
-					_remotionInternalDocumentationLink={
-						passedProps.name
-							? undefined
-							: 'https://www.remotion.dev/docs/transitions/transitionseries'
+							</SequenceWithoutSchema>,
+						);
 					}
-				>
-					{child}
-				</SequenceWithoutSchema>
-			);
+
+					if (nextProgress !== null && next) {
+						const nextPresentation = next.props.presentation ?? slide();
+
+						const UppercaseNextPresentation = nextPresentation.component;
+
+						return renderSequenceAndRest(
+							<SequenceWithoutSchema
+								key={i}
+								from={actualStartFrame}
+								durationInFrames={durationInFramesProp}
+								{...passedProps}
+								name={passedProps.name || '<TS.Sequence>'}
+								_remotionInternalDocumentationLink={
+									passedProps.name
+										? undefined
+										: 'https://www.remotion.dev/docs/transitions/transitionseries'
+								}
+								_remotionInternalStack={stack ?? undefined}
+								controls={controls ?? undefined}
+							>
+								<UppercaseNextPresentation
+									passedProps={nextPresentation.props ?? {}}
+									presentationDirection="exiting"
+									presentationProgress={nextProgress}
+									presentationDurationInFrames={next.props.timing.getDurationInFrames(
+										{fps},
+									)}
+									onElementImage={(elementImage, draw) =>
+										onPrevElementImage(elementImage, nextProgress, draw, i + 1)
+									}
+									onUnmount={() => {
+										onPrevElementImage(null, null, null, i + 1);
+									}}
+									bothEnteringAndExiting={false}
+								>
+									<WrapInExitingProgressContext
+										presentationProgress={nextProgress}
+									>
+										{sequenceChildren}
+									</WrapInExitingProgressContext>
+								</UppercaseNextPresentation>
+							</SequenceWithoutSchema>,
+						);
+					}
+
+					return renderSequenceAndRest(
+						<SequenceWithoutSchema
+							key={i}
+							from={actualStartFrame}
+							durationInFrames={durationInFramesProp}
+							{...passedProps}
+							name={passedProps.name || '<TS.Sequence>'}
+							_remotionInternalDocumentationLink={
+								passedProps.name
+									? undefined
+									: 'https://www.remotion.dev/docs/transitions/transitionseries'
+							}
+							_remotionInternalStack={stack ?? undefined}
+							controls={controls ?? undefined}
+						>
+							{sequenceChildren}
+						</SequenceWithoutSchema>,
+					);
+				},
+			});
+		};
+
+		return renderChildren({
+			index: 0,
+			transitionOffsets: 0,
+			startFrame: 0,
+			overlayRenders: [],
+			sequenceDurations: [],
+			pendingOverlayValidation: false,
 		});
-
-		// Now render overlay sequences
-		const overlayElements = overlayRenders.map((overlayInfo) => {
-			const info = overlayInfo as unknown as {
-				cutPoint: number;
-				overlayFrom: number;
-				durationInFrames: number;
-				children: React.ReactNode;
-				index: number;
-			};
-
-			return (
-				<SequenceWithoutSchema
-					key={`overlay-${info.index}`}
-					from={Math.round(info.overlayFrom)}
-					durationInFrames={info.durationInFrames}
-					name="<TS.Overlay>"
-					_remotionInternalDocumentationLink="https://www.remotion.dev/docs/transitions/transitionseries"
-					layout="absolute-fill"
-				>
-					{info.children}
-				</SequenceWithoutSchema>
-			);
-		});
-
-		return [...(mainChildren || []), ...overlayElements];
 	}, [flattedChildren, fps, frame, onPrevElementImage, onNextElementImage]);
 
 	// eslint-disable-next-line react/jsx-no-useless-fragment

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -5,7 +5,14 @@ import {
 } from '@remotion/test-utils';
 import React, {useCallback, useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
-import {Internals, type SequenceControls} from 'remotion';
+import {
+	Internals,
+	type DragOverrides,
+	type OverrideIdToNodePaths,
+	type PropStatuses,
+	type SequenceControls,
+} from 'remotion';
+import {linearTiming} from '../timings/linear-timing.js';
 import {TransitionSeries} from '../TransitionSeries.js';
 
 afterEach(() => {
@@ -16,6 +23,8 @@ type RegisteredSequence = {
 	readonly displayName: string;
 	readonly getStack: () => string | null;
 	readonly controls: SequenceControls | null;
+	readonly duration: number;
+	readonly from: number;
 };
 
 const remotionEnvironment = {
@@ -28,11 +37,6 @@ const remotionEnvironment = {
 
 const compositionManagerContext = makeMockCompositionManagerContext();
 const timelineContext = makeTimelineContext(0);
-const visualModePropStatuses = {propStatuses: {}};
-const visualModeDragOverrides = {
-	getDragOverrides: () => ({}),
-	getEffectDragOverrides: () => ({}),
-};
 const visualModeSetters = {
 	setDragOverrides: () => undefined,
 	clearDragOverrides: () => undefined,
@@ -44,7 +48,16 @@ const visualModeSetters = {
 const SequenceTestWrapper: React.FC<{
 	readonly children: React.ReactNode;
 	readonly onRegisterSequence: (sequence: RegisteredSequence) => void;
-}> = ({children, onRegisterSequence}) => {
+	readonly overrideIdToNodePathMappings: OverrideIdToNodePaths;
+	readonly propStatuses: PropStatuses;
+	readonly dragOverrides: DragOverrides;
+}> = ({
+	children,
+	onRegisterSequence,
+	overrideIdToNodePathMappings,
+	propStatuses,
+	dragOverrides,
+}) => {
 	const registerSequence = useCallback(
 		(sequence: RegisteredSequence) => {
 			onRegisterSequence(sequence);
@@ -60,6 +73,27 @@ const SequenceTestWrapper: React.FC<{
 		}),
 		[registerSequence],
 	);
+	const visualModePropStatuses = useMemo(
+		() => ({propStatuses}),
+		[propStatuses],
+	);
+	const visualModeDragOverrides = useMemo(
+		() => ({
+			getDragOverrides: (
+				nodePath: Parameters<
+					typeof Internals.makeSequencePropsSubscriptionKey
+				>[0],
+			) =>
+				dragOverrides[Internals.makeSequencePropsSubscriptionKey(nodePath)] ??
+				{},
+			getEffectDragOverrides: () => ({}),
+		}),
+		[dragOverrides],
+	);
+	const overrideIdToNodePathContext = useMemo(
+		() => ({overrideIdToNodePathMappings}),
+		[overrideIdToNodePathMappings],
+	);
 
 	return (
 		<Internals.RemotionEnvironmentContext value={remotionEnvironment}>
@@ -68,21 +102,25 @@ const SequenceTestWrapper: React.FC<{
 					value={compositionManagerContext}
 				>
 					<Internals.TimelineContext.Provider value={timelineContext}>
-						<Internals.SequenceManager.Provider value={sequenceContext}>
-							<Internals.VisualModePropStatusesContext.Provider
-								value={visualModePropStatuses}
-							>
-								<Internals.VisualModeDragOverridesContext.Provider
-									value={visualModeDragOverrides}
+						<Internals.OverrideIdsToNodePathsGettersContext.Provider
+							value={overrideIdToNodePathContext}
+						>
+							<Internals.SequenceManager.Provider value={sequenceContext}>
+								<Internals.VisualModePropStatusesContext.Provider
+									value={visualModePropStatuses}
 								>
-									<Internals.VisualModeSettersContext.Provider
-										value={visualModeSetters}
+									<Internals.VisualModeDragOverridesContext.Provider
+										value={visualModeDragOverrides}
 									>
-										{children}
-									</Internals.VisualModeSettersContext.Provider>
-								</Internals.VisualModeDragOverridesContext.Provider>
-							</Internals.VisualModePropStatusesContext.Provider>
-						</Internals.SequenceManager.Provider>
+										<Internals.VisualModeSettersContext.Provider
+											value={visualModeSetters}
+										>
+											{children}
+										</Internals.VisualModeSettersContext.Provider>
+									</Internals.VisualModeDragOverridesContext.Provider>
+								</Internals.VisualModePropStatusesContext.Provider>
+							</Internals.SequenceManager.Provider>
+						</Internals.OverrideIdsToNodePathsGettersContext.Provider>
 					</Internals.TimelineContext.Provider>
 				</Internals.CompositionManager.Provider>
 			</Internals.CanUseRemotionHooksProvider>
@@ -103,6 +141,9 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 			onRegisterSequence={(sequence) => {
 				registeredSequences.push(sequence);
 			}}
+			overrideIdToNodePathMappings={{}}
+			propStatuses={{}}
+			dragOverrides={{}}
 		>
 			<TransitionSeries
 				{...({stack: transitionSeriesStack} as {readonly stack: string})}
@@ -142,7 +183,133 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 		registeredSequences.some(
 			(sequence) =>
 				sequence.displayName === '<TS.Sequence>' &&
-				sequence.getStack() === childSequenceStack,
+				sequence.getStack() === childSequenceStack &&
+				sequence.controls?.componentIdentity ===
+					'dev.remotion.transitions.TransitionSeries.Sequence' &&
+				sequence.controls.currentRuntimeValueDotNotation.durationInFrames ===
+					10,
 		),
 	).toBe(true);
+});
+
+test('TransitionSeries.Sequence duration overrides cascade to later sequences', async () => {
+	const registeredSequences: RegisteredSequence[] = [];
+	const div = document.createElement('div');
+	const root = createRoot(div);
+	const firstStack = 'Error\n    at FirstTransitionSeriesSequence';
+	const secondStack = 'Error\n    at SecondTransitionSeriesSequence';
+	const onRegisterSequence = (sequence: RegisteredSequence) => {
+		registeredSequences.push(sequence);
+	};
+
+	const renderTransitionSeries = ({
+		overrideIdToNodePathMappings,
+		propStatuses,
+		dragOverrides,
+	}: {
+		overrideIdToNodePathMappings: OverrideIdToNodePaths;
+		propStatuses: PropStatuses;
+		dragOverrides: DragOverrides;
+	}) => {
+		root.render(
+			<SequenceTestWrapper
+				onRegisterSequence={onRegisterSequence}
+				overrideIdToNodePathMappings={overrideIdToNodePathMappings}
+				propStatuses={propStatuses}
+				dragOverrides={dragOverrides}
+			>
+				<TransitionSeries>
+					<TransitionSeries.Sequence
+						durationInFrames={10}
+						{...({stack: firstStack} as {readonly stack: string})}
+					>
+						First
+					</TransitionSeries.Sequence>
+					<TransitionSeries.Transition
+						timing={linearTiming({durationInFrames: 5})}
+					/>
+					<TransitionSeries.Sequence
+						durationInFrames={20}
+						{...({stack: secondStack} as {readonly stack: string})}
+					>
+						Second
+					</TransitionSeries.Sequence>
+				</TransitionSeries>
+			</SequenceTestWrapper>,
+		);
+	};
+
+	renderTransitionSeries({
+		overrideIdToNodePathMappings: {},
+		propStatuses: {},
+		dragOverrides: {},
+	});
+	await new Promise((resolve) => setTimeout(resolve, 10));
+
+	const firstSequence = registeredSequences.find(
+		(sequence) => sequence.getStack() === firstStack,
+	);
+	if (!firstSequence?.controls) {
+		throw new Error('Expected the first sequence to be interactive');
+	}
+
+	const firstSequenceControls = firstSequence.controls;
+
+	const nodePath = {
+		absolutePath: '/src/Composition.tsx',
+		nodePath: ['body', 0],
+		sequenceKeys: [],
+		effectKeys: [],
+	};
+	const subscriptionKey = Internals.makeSequencePropsSubscriptionKey(nodePath);
+	const makeDurationOverride = (durationInFrames: number) => ({
+		overrideIdToNodePathMappings: {
+			[firstSequenceControls.overrideId]: nodePath,
+		},
+		propStatuses: {
+			[subscriptionKey]: {
+				canUpdate: true as const,
+				props: {
+					durationInFrames: {status: 'static' as const, codeValue: 10},
+				},
+				effects: [],
+			},
+		},
+		dragOverrides: {
+			[subscriptionKey]: {
+				durationInFrames: Internals.makeStaticDragOverride(durationInFrames),
+			},
+		},
+	});
+
+	registeredSequences.length = 0;
+	renderTransitionSeries(makeDurationOverride(15));
+	await new Promise((resolve) => setTimeout(resolve, 10));
+
+	const updatedFirstSequence = registeredSequences.find(
+		(sequence) => sequence.getStack() === firstStack,
+	);
+	const updatedSecondSequence = registeredSequences.find(
+		(sequence) => sequence.getStack() === secondStack,
+	);
+
+	expect(updatedFirstSequence?.duration).toBe(15);
+	expect(updatedFirstSequence?.from).toBe(0);
+	expect(updatedSecondSequence?.duration).toBe(20);
+	expect(updatedSecondSequence?.from).toBe(10);
+
+	registeredSequences.length = 0;
+	renderTransitionSeries(makeDurationOverride(18));
+	await new Promise((resolve) => setTimeout(resolve, 10));
+
+	const repeatedlyUpdatedFirstSequence = registeredSequences.find(
+		(sequence) => sequence.getStack() === firstStack,
+	);
+	const repeatedlyUpdatedSecondSequence = registeredSequences.find(
+		(sequence) => sequence.getStack() === secondStack,
+	);
+	expect(repeatedlyUpdatedFirstSequence?.duration).toBe(18);
+	expect(repeatedlyUpdatedSecondSequence?.from).toBe(13);
+
+	root.unmount();
 });


### PR DESCRIPTION
## Summary

- Make `<TransitionSeries.Sequence>` and `<Series.Sequence>` own their Visual Mode schema, source stack, and Studio controls.
- Allow right-edge duration dragging while recalculating every later sequence from the live overridden duration.
- Keep generated Series rows protected from split, move, and left-edge operations.
- Add `video-editing-series` and update the video-editing skill with independent and ripple-editing markup.

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/series.test.tsx src/test/sequence-register-once.test.tsx` in `packages/core`
- `bun test src/test/transition-series-stack.test.tsx` in `packages/transitions`
- `bun test src/test/timeline-selection.test.ts` in `packages/studio`

## Follow-up

- Support for `trimBefore` on `<TransitionSeries.Sequence>` is tracked in #9140.
