### PR TITLE
Docs: Clarify media preloading and premounting

### DIFF
--- a/packages/docs/docs/player/premounting.mdx
+++ b/packages/docs/docs/player/premounting.mdx
@@ -42,13 +42,14 @@ In v4, add the [`premountFor`](/docs/sequence#premountfor) prop to the [`<Sequen
 The number you pass is the number in frames you premount the component for.
 
 ```tsx twoslash title="Premounted.tsx"
-import {Sequence, staticFile, OffthreadVideo} from 'remotion';
+import {Video} from '@remotion/media';
+import {Sequence, staticFile} from 'remotion';
 
 // ---cut---
 const MyComp: React.FC = () => {
   return (
     <Sequence premountFor={100}>
-      <OffthreadVideo src={staticFile('bigbuckbunny.mp4')}></OffthreadVideo>
+      <Video src={staticFile('bigbuckbunny.mp4')} />
     </Sequence>
   );
 };
@@ -120,13 +121,13 @@ export const PremountedSequence = forwardRef(PremountedSequenceRefForwardingFunc
 
 :::note
 One caveat of this custom component: In a premounted sequence, the native buffer state can still be triggered.  
-It is your task to disable triggering the native buffer state (e.g set [`pauseWhenBuffering`](/docs/offthreadvideo#pausewhenbuffering) to false) when in a premounted sequence.  
+It is your task to disable triggering the native buffer state (e.g. set [`pauseWhenBuffering`](/docs/media/video#pausewhenbuffering) to `false`) when in a premounted sequence.
 You can achieve this for example by using a React context.
 :::
 
 ## Usage together with the buffer state
 
-If you also use the [buffer state](/docs/player/buffer-state), the [`<Html5Audio>`](/docs/html5-audio#pausewhenbuffering), [`<Html5Video>`](/docs/html5-video#pausewhenbuffering), [`<OffthreadVideo>`](/docs/offthreadvideo#pausewhenbuffering) and [`<Img>`](/docs/img#pausewhenloading) tags are aware of premounting and don't trigger the buffer state while in a premounted [`<Sequence>`](/docs/sequence).
+If you also use the [buffer state](/docs/player/buffer-state), [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media), as well as [`<Html5Audio>`](/docs/html5-audio#pausewhenbuffering), [`<Html5Video>`](/docs/html5-video#pausewhenbuffering), [`<OffthreadVideo>`](/docs/offthreadvideo#pausewhenbuffering), and [`<Img>`](/docs/img#pausewhenloading), are aware of premounting and don't trigger the buffer state while in a premounted [`<Sequence>`](/docs/sequence).
 
 Otherwise it would lead to pausing playback while a scene is not even visible yet.
 

--- a/packages/docs/docs/preload/preload-audio.mdx
+++ b/packages/docs/docs/preload/preload-audio.mdx
@@ -8,7 +8,9 @@ crumb: '@remotion/preload'
 
 _This function is part of the [`@remotion/preload`](/docs/preload) package._
 
-This function preloads audio in the DOM so that when a audio tag is mounted, it can play immediately.
+This function preloads audio in the DOM so that when an HTML5 `<audio>` element is mounted, it can play immediately.
+
+It only affects HTML5 audio elements such as [`<Html5Audio>`](/docs/html5-audio), not [`<Audio>` from `@remotion/media`](/docs/media/audio).
 
 While preload is not necessary for rendering, it can help with seamless playback in the [`<Player />`](/docs/player) and in the Studio.
 

--- a/packages/docs/docs/preload/preload-video.mdx
+++ b/packages/docs/docs/preload/preload-video.mdx
@@ -9,7 +9,9 @@ crumb: '@remotion/player'
 
 _This function is part of the [`@remotion/preload`](/docs/preload) package._
 
-This function preloads a video in the DOM so that when a video tag is mounted, it can play immediately.
+This function preloads a video in the DOM so that when an HTML5 `<video>` element is mounted, it can play immediately.
+
+It only affects HTML5 video elements such as [`<Html5Video>`](/docs/html5-video), not [`<Video>` from `@remotion/media`](/docs/media/video).
 
 While preload is not necessary for rendering, it can help with seamless playback in the [`<Player />`](/docs/player) and in the Studio.
 


### PR DESCRIPTION
## Summary

- use `<Video>` from `@remotion/media` in the premounting example
- list `@remotion/media` components first in the premounting buffer-state guidance
- clarify that `preloadAudio()` and `preloadVideo()` only affect HTML5 media elements

## Validation

- `bun run build`
- `bun run stylecheck`
- `bun run build-docs`

Closes #8882
