### PR TITLE
`@remotion/transitions`: Make transition items selectable in Studio

### DIFF
--- a/packages/example/src/Issue8974TimelineInteractivity/index.tsx
+++ b/packages/example/src/Issue8974TimelineInteractivity/index.tsx
@@ -1,5 +1,7 @@
 import {Video} from '@remotion/media';
-import {TransitionSeries} from '@remotion/transitions';
+import {linearTiming, TransitionSeries} from '@remotion/transitions';
+import {fade} from '@remotion/transitions/fade';
+import {slide} from '@remotion/transitions/slide';
 import React from 'react';
 import {Series} from 'remotion';
 
@@ -14,6 +16,10 @@ export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 					durationInFrames={39}
 				/>
 			</TransitionSeries.Sequence>
+			<TransitionSeries.Transition
+				presentation={fade()}
+				timing={linearTiming({durationInFrames: 15})}
+			/>
 			<TransitionSeries.Sequence name="Linked clip 02" durationInFrames={84}>
 				<Video
 					name="Linked video 02"
@@ -28,6 +34,10 @@ export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 					trimBefore={60}
 				/>
 			</TransitionSeries.Sequence>
+			<TransitionSeries.Transition
+				presentation={slide({direction: 'from-right'})}
+				timing={linearTiming({durationInFrames: 22})}
+			/>
 			<TransitionSeries.Sequence name="Linked clip 04" durationInFrames={36}>
 				<Video
 					name="Linked video 04"

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -29,15 +29,94 @@ import {validateDurationInFrames} from './validate.js';
 
 const {SequenceWithoutSchema} = Internals;
 
-const TransitionSeriesTransition = function <
+type ResolvedTransitionSeriesTransitionProps<
 	PresentationProps extends Record<string, unknown>,
->(_props: TransitionSeriesTransitionProps<PresentationProps>) {
+> = TransitionSeriesTransitionProps<PresentationProps> & {
+	readonly controls: SequenceControls | null | undefined;
+	readonly stack: string | null;
+};
+
+type InternalTransitionSeriesTransitionProps<
+	PresentationProps extends Record<string, unknown>,
+> = ResolvedTransitionSeriesTransitionProps<PresentationProps> & {
+	readonly _remotionInternalRender:
+		| ((
+				props: ResolvedTransitionSeriesTransitionProps<PresentationProps>,
+		  ) => React.ReactNode)
+		| null;
+};
+
+const TransitionSeriesTransitionInner = <
+	PresentationProps extends Record<string, unknown>,
+>({
+	stack = null,
+	_remotionInternalRender = null,
+	...props
+}: InternalTransitionSeriesTransitionProps<PresentationProps>) => {
+	if (_remotionInternalRender) {
+		return _remotionInternalRender({...props, stack});
+	}
+
 	return null;
 };
 
-const SeriesOverlay: FC<TransitionSeriesOverlayProps> = () => {
+type TransitionSeriesTransitionComponent = <
+	PresentationProps extends Record<string, unknown>,
+>(
+	props: TransitionSeriesTransitionProps<PresentationProps>,
+) => React.ReactNode;
+
+const transitionSeriesTransitionSchema = {} satisfies InteractivitySchema;
+
+const TransitionSeriesTransition = Interactive.withSchema({
+	Component: TransitionSeriesTransitionInner as unknown as React.ComponentType<
+		TransitionSeriesTransitionProps<Record<string, unknown>> & {
+			readonly controls: SequenceControls | undefined;
+		}
+	>,
+	componentName: '<TransitionSeries.Transition>',
+	componentIdentity: 'dev.remotion.transitions.TransitionSeries.Transition',
+	schema: transitionSeriesTransitionSchema,
+	supportsEffects: false,
+}) as TransitionSeriesTransitionComponent;
+
+type ResolvedTransitionSeriesOverlayProps = TransitionSeriesOverlayProps & {
+	readonly controls: SequenceControls | null | undefined;
+	readonly stack: string | null;
+};
+
+type InternalTransitionSeriesOverlayProps =
+	ResolvedTransitionSeriesOverlayProps & {
+		readonly _remotionInternalRender:
+			| ((props: ResolvedTransitionSeriesOverlayProps) => React.ReactNode)
+			| null;
+	};
+
+const SeriesOverlayInner: FC<InternalTransitionSeriesOverlayProps> = ({
+	stack = null,
+	_remotionInternalRender = null,
+	...props
+}) => {
+	if (_remotionInternalRender) {
+		return _remotionInternalRender({...props, stack});
+	}
+
 	return null;
 };
+
+const transitionSeriesOverlaySchema = {} satisfies InteractivitySchema;
+
+const SeriesOverlay = Interactive.withSchema({
+	Component: SeriesOverlayInner as unknown as React.ComponentType<
+		TransitionSeriesOverlayProps & {
+			readonly controls: SequenceControls | undefined;
+		}
+	>,
+	componentName: '<TransitionSeries.Overlay>',
+	componentIdentity: 'dev.remotion.transitions.TransitionSeries.Overlay',
+	schema: transitionSeriesOverlaySchema,
+	supportsEffects: false,
+}) as FC<TransitionSeriesOverlayProps>;
 
 type LayoutBasedProps =
 	true extends typeof NoReactInternals.ENABLE_V5_BREAKING_CHANGES
@@ -229,6 +308,8 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 			readonly halfDuration: number;
 			readonly children: React.ReactNode;
 			readonly index: number;
+			readonly controls: SequenceControls | null | undefined;
+			readonly stack: string | null;
 		};
 
 		type RenderState = {
@@ -258,6 +339,8 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 						durationInFrames={info.durationInFrames}
 						name="<TS.Overlay>"
 						_remotionInternalDocumentationLink="https://www.remotion.dev/docs/transitions/transitionseries"
+						_remotionInternalStack={info.stack ?? undefined}
+						controls={info.controls ?? undefined}
 						layout="absolute-fill"
 					>
 						{info.children}
@@ -331,69 +414,78 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					);
 				}
 
-				const overlayProps = (current as OverlayType).props;
+				const castedOverlay = current as React.ReactElement<
+					InternalTransitionSeriesOverlayProps,
+					typeof SeriesOverlay
+				>;
 
-				validateDurationInFrames(overlayProps.durationInFrames, {
-					component: `of a <TransitionSeries.Overlay /> component`,
-					allowFloats: false,
-				});
+				return React.cloneElement(castedOverlay, {
+					_remotionInternalRender: (overlayProps) => {
+						validateDurationInFrames(overlayProps.durationInFrames, {
+							component: `of a <TransitionSeries.Overlay /> component`,
+							allowFloats: false,
+						});
 
-				const overlayOffset = overlayProps.offset ?? 0;
-				if (Number.isNaN(overlayOffset)) {
-					throw new TypeError(
-						`The "offset" property of a <TransitionSeries.Overlay /> must not be NaN, but got NaN.`,
-					);
-				}
+						const overlayOffset = overlayProps.offset ?? 0;
+						if (Number.isNaN(overlayOffset)) {
+							throw new TypeError(
+								`The "offset" property of a <TransitionSeries.Overlay /> must not be NaN, but got NaN.`,
+							);
+						}
 
-				if (!Number.isFinite(overlayOffset)) {
-					throw new TypeError(
-						`The "offset" property of a <TransitionSeries.Overlay /> must be finite, but got ${overlayOffset}.`,
-					);
-				}
+						if (!Number.isFinite(overlayOffset)) {
+							throw new TypeError(
+								`The "offset" property of a <TransitionSeries.Overlay /> must be finite, but got ${overlayOffset}.`,
+							);
+						}
 
-				if (overlayOffset % 1 !== 0) {
-					throw new TypeError(
-						`The "offset" property of a <TransitionSeries.Overlay /> must be an integer, but got ${overlayOffset}.`,
-					);
-				}
+						if (overlayOffset % 1 !== 0) {
+							throw new TypeError(
+								`The "offset" property of a <TransitionSeries.Overlay /> must be an integer, but got ${overlayOffset}.`,
+							);
+						}
 
-				// Find the previous sequence (the cut point is at startFrame + transitionOffsets)
-				const cutPoint = startFrame + transitionOffsets;
-				const halfDuration = overlayProps.durationInFrames / 2;
-				const overlayFrom = cutPoint - halfDuration + overlayOffset;
+						// Find the previous sequence (the cut point is at startFrame + transitionOffsets)
+						const cutPoint = startFrame + transitionOffsets;
+						const halfDuration = overlayProps.durationInFrames / 2;
+						const overlayFrom = cutPoint - halfDuration + overlayOffset;
 
-				if (overlayFrom < 0) {
-					throw new TypeError(
-						`A <TransitionSeries.Overlay /> extends before frame 0. The overlay starts at frame ${overlayFrom}. Reduce the duration or adjust the offset.`,
-					);
-				}
+						if (overlayFrom < 0) {
+							throw new TypeError(
+								`A <TransitionSeries.Overlay /> extends before frame 0. The overlay starts at frame ${overlayFrom}. Reduce the duration or adjust the offset.`,
+							);
+						}
 
-				// Validate: overlay must not exceed the previous sequence duration
-				const prevSeqIdx = sequenceDurations.length - 1;
-				if (prevSeqIdx >= 0) {
-					const overlayStartInPrev = halfDuration - overlayOffset;
-					if (overlayStartInPrev > sequenceDurations[prevSeqIdx]) {
-						throw new TypeError(
-							`A <TransitionSeries.Overlay /> extends beyond the previous sequence. The overlay needs ${overlayStartInPrev} frames before the cut, but the previous sequence is only ${sequenceDurations[prevSeqIdx]} frames long.`,
-						);
-					}
-				}
+						// Validate: overlay must not exceed the previous sequence duration
+						const prevSeqIdx = sequenceDurations.length - 1;
+						if (prevSeqIdx >= 0) {
+							const overlayStartInPrev = halfDuration - overlayOffset;
+							if (overlayStartInPrev > sequenceDurations[prevSeqIdx]) {
+								throw new TypeError(
+									`A <TransitionSeries.Overlay /> extends beyond the previous sequence. The overlay needs ${overlayStartInPrev} frames before the cut, but the previous sequence is only ${sequenceDurations[prevSeqIdx]} frames long.`,
+								);
+							}
+						}
 
-				// Store overlay info for deferred rendering and validate the other
-				// side once the next sequence has resolved its interactive props.
-				const overlayRender: OverlayRender = {
-					cutPoint,
-					overlayFrom,
-					durationInFrames: overlayProps.durationInFrames,
-					overlayOffset,
-					halfDuration,
-					children: overlayProps.children,
-					index: i,
-				};
+						// Store overlay info for deferred rendering and validate the other
+						// side once the next sequence has resolved its interactive props.
+						const overlayRender: OverlayRender = {
+							cutPoint,
+							overlayFrom,
+							durationInFrames: overlayProps.durationInFrames,
+							overlayOffset,
+							halfDuration,
+							children: overlayProps.children,
+							index: i,
+							controls: overlayProps.controls,
+							stack: overlayProps.stack,
+						};
 
-				return renderNext({
-					overlayRenders: [...overlayRenders, overlayRender],
-					pendingOverlayValidation: true,
+						return renderNext({
+							overlayRenders: [...overlayRenders, overlayRender],
+							pendingOverlayValidation: true,
+						});
+					},
 				});
 			}
 
@@ -414,7 +506,36 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 					);
 				}
 
-				return renderNext();
+				const castedTransition = current as React.ReactElement<
+					InternalTransitionSeriesTransitionProps<Record<string, unknown>>,
+					typeof TransitionSeriesTransition
+				>;
+
+				return React.cloneElement(castedTransition, {
+					_remotionInternalRender: (transitionProps) => {
+						const transitionDuration =
+							transitionProps.timing.getDurationInFrames({fps});
+						const transitionFrom =
+							startFrame + transitionOffsets - transitionDuration;
+
+						return (
+							<>
+								{transitionDuration > 0 ? (
+									<SequenceWithoutSchema
+										from={transitionFrom}
+										durationInFrames={transitionDuration}
+										name="<TS.Transition>"
+										_remotionInternalDocumentationLink="https://www.remotion.dev/docs/transitions/transitionseries"
+										_remotionInternalStack={transitionProps.stack ?? undefined}
+										controls={transitionProps.controls ?? undefined}
+										layout="none"
+									/>
+								) : null}
+								{renderNext()}
+							</>
+						);
+					},
+				});
 			}
 
 			if (current.type !== SeriesSequence) {

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -192,12 +192,84 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 	).toBe(true);
 });
 
+test('TransitionSeries.Transition and Overlay register at their rendered timeline ranges', async () => {
+	const registeredSequences: RegisteredSequence[] = [];
+	const div = document.createElement('div');
+	const root = createRoot(div);
+	const transitionStack = 'Error\n    at UserAuthoredTransition';
+	const overlayStack = 'Error\n    at UserAuthoredOverlay';
+
+	root.render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+			overrideIdToNodePathMappings={{}}
+			propStatuses={{}}
+			dragOverrides={{}}
+		>
+			<TransitionSeries>
+				<TransitionSeries.Sequence durationInFrames={40}>
+					First
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Transition
+					timing={linearTiming({durationInFrames: 10})}
+					{...({stack: transitionStack} as {readonly stack: string})}
+				/>
+				<TransitionSeries.Sequence durationInFrames={30}>
+					Second
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Overlay
+					durationInFrames={12}
+					offset={2}
+					{...({stack: overlayStack} as {readonly stack: string})}
+				>
+					Overlay
+				</TransitionSeries.Overlay>
+				<TransitionSeries.Sequence durationInFrames={50}>
+					Third
+				</TransitionSeries.Sequence>
+			</TransitionSeries>
+		</SequenceTestWrapper>,
+	);
+
+	await new Promise((resolve) => setTimeout(resolve, 10));
+
+	const transition = registeredSequences.find(
+		(sequence) => sequence.getStack() === transitionStack,
+	);
+	const overlay = registeredSequences.find(
+		(sequence) => sequence.getStack() === overlayStack,
+	);
+
+	root.unmount();
+
+	expect(transition?.displayName).toBe('<TS.Transition>');
+	expect(transition?.controls?.componentIdentity).toBe(
+		'dev.remotion.transitions.TransitionSeries.Transition',
+	);
+	expect(transition?.from).toBe(30);
+	expect(transition?.duration).toBe(10);
+	expect((transition?.from ?? 0) + (transition?.duration ?? 0)).toBe(40);
+
+	expect(overlay?.displayName).toBe('<TS.Overlay>');
+	expect(overlay?.controls?.componentIdentity).toBe(
+		'dev.remotion.transitions.TransitionSeries.Overlay',
+	);
+	// The cut is at frame 60 after subtracting the 10-frame transition.
+	// A 12-frame overlay shifted by 2 frames therefore spans frames 56-68.
+	expect(overlay?.from).toBe(56);
+	expect(overlay?.duration).toBe(12);
+	expect((overlay?.from ?? 0) + (overlay?.duration ?? 0)).toBe(68);
+});
+
 test('TransitionSeries.Sequence duration overrides cascade to later sequences', async () => {
 	const registeredSequences: RegisteredSequence[] = [];
 	const div = document.createElement('div');
 	const root = createRoot(div);
 	const firstStack = 'Error\n    at FirstTransitionSeriesSequence';
 	const secondStack = 'Error\n    at SecondTransitionSeriesSequence';
+	const transitionStack = 'Error\n    at TransitionBetweenSequences';
 	const onRegisterSequence = (sequence: RegisteredSequence) => {
 		registeredSequences.push(sequence);
 	};
@@ -227,6 +299,7 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 					</TransitionSeries.Sequence>
 					<TransitionSeries.Transition
 						timing={linearTiming({durationInFrames: 5})}
+						{...({stack: transitionStack} as {readonly stack: string})}
 					/>
 					<TransitionSeries.Sequence
 						durationInFrames={20}
@@ -292,9 +365,14 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 	const updatedSecondSequence = registeredSequences.find(
 		(sequence) => sequence.getStack() === secondStack,
 	);
+	const updatedTransition = registeredSequences.find(
+		(sequence) => sequence.getStack() === transitionStack,
+	);
 
 	expect(updatedFirstSequence?.duration).toBe(15);
 	expect(updatedFirstSequence?.from).toBe(0);
+	expect(updatedTransition?.from).toBe(10);
+	expect(updatedTransition?.duration).toBe(5);
 	expect(updatedSecondSequence?.duration).toBe(20);
 	expect(updatedSecondSequence?.from).toBe(10);
 
@@ -308,7 +386,11 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 	const repeatedlyUpdatedSecondSequence = registeredSequences.find(
 		(sequence) => sequence.getStack() === secondStack,
 	);
+	const repeatedlyUpdatedTransition = registeredSequences.find(
+		(sequence) => sequence.getStack() === transitionStack,
+	);
 	expect(repeatedlyUpdatedFirstSequence?.duration).toBe(18);
+	expect(repeatedlyUpdatedTransition?.from).toBe(13);
 	expect(repeatedlyUpdatedSecondSequence?.from).toBe(13);
 
 	root.unmount();


### PR DESCRIPTION
## Summary

- register `TransitionSeries.Transition` and `TransitionSeries.Overlay` as selectable Studio timeline items
- derive their timeline ranges from the same transition cut-point math used for rendering
- keep transition ranges in sync with cascading sequence duration edits
- add fade and slide transitions to the cascading video-editing example

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/transitions && bun test src`

Closes #9137
