### PR TITLE
`@remotion/studio`: Disable toolbar toggles in read-only Studio

### DIFF
--- a/packages/studio/src/components/OutlineToggle.tsx
+++ b/packages/studio/src/components/OutlineToggle.tsx
@@ -3,7 +3,9 @@ import {BLUE, WHITE} from '../helpers/colors';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ControlButton} from './ControlButton';
 
-export const OutlineToggle: React.FC = () => {
+export const OutlineToggle: React.FC<{
+	readonly disabled: boolean;
+}> = ({disabled}) => {
 	const {editorShowOutlines, setEditorShowOutlines} = useContext(
 		EditorShowOutlinesContext,
 	);
@@ -21,6 +23,7 @@ export const OutlineToggle: React.FC = () => {
 		<ControlButton
 			title={accessibilityLabel}
 			aria-label={accessibilityLabel}
+			disabled={disabled}
 			onClick={onClick}
 		>
 			<svg

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -261,10 +261,10 @@ export const PreviewToolbar: React.FC<{
 						<CheckboardToggle />
 					</PreviewToolbarControl>
 					<PreviewToolbarControl>
-						<OutlineToggle />
+						<OutlineToggle disabled={readOnlyStudio} />
 					</PreviewToolbarControl>
 					<PreviewToolbarControl>
-						<SnappingToggle />
+						<SnappingToggle disabled={readOnlyStudio} />
 					</PreviewToolbarControl>
 				</>
 			) : null}

--- a/packages/studio/src/components/SnappingToggle.tsx
+++ b/packages/studio/src/components/SnappingToggle.tsx
@@ -6,7 +6,9 @@ import {MagnetIcon} from '../icons/magnet';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {ControlButton} from './ControlButton';
 
-export const SnappingToggle: React.FC = () => {
+export const SnappingToggle: React.FC<{
+	readonly disabled: boolean;
+}> = ({disabled}) => {
 	const {editorSnapping, setEditorSnapping} = useContext(EditorSnappingContext);
 
 	const onClick = useCallback(() => {
@@ -27,6 +29,7 @@ export const SnappingToggle: React.FC = () => {
 			aria-label={accessibilityLabel}
 			aria-pressed={editorSnapping}
 			aria-keyshortcuts="Shift+M"
+			disabled={disabled}
 			onClick={onClick}
 		>
 			<MagnetIcon


### PR DESCRIPTION
## Summary

- disable the outline toggle in read-only Studio
- disable the snapping toggle in read-only Studio
- preserve the existing enabled behavior in editable Studio sessions

## Validation

- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`
