### PR TITLE
`remotion`: Improve shared audio tag pool performance

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -525,7 +525,10 @@ export const SharedAudioTagsContextProvider: React.FC<{
 			}
 
 			if (data === undefined) {
-				current.src = EMPTY_AUDIO;
+				if (current.src !== EMPTY_AUDIO) {
+					current.src = EMPTY_AUDIO;
+				}
+
 				return;
 			}
 

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -699,17 +699,20 @@ export const SharedAudioTagsContextProvider: React.FC<{
 		unregisterAudio,
 		updateAudio,
 	]);
+	const sharedAudioTagElements = useMemo(() => {
+		return refs.map(({id, ref}) => {
+			return (
+				// Without preload="metadata", iOS will seek the time internally
+				// but not actually with sound. Adding `preload="metadata"` helps here.
+				// https://discord.com/channels/809501355504959528/817306414069710848/1130519583367888906
+				<audio key={id} ref={ref} preload="metadata" src={EMPTY_AUDIO} />
+			);
+		});
+	}, [refs]);
 
 	return (
 		<SharedAudioTagsContext.Provider value={audioTagsValue}>
-			{refs.map(({id, ref}) => {
-				return (
-					// Without preload="metadata", iOS will seek the time internally
-					// but not actually with sound. Adding `preload="metadata"` helps here.
-					// https://discord.com/channels/809501355504959528/817306414069710848/1130519583367888906
-					<audio key={id} ref={ref} preload="metadata" src={EMPTY_AUDIO} />
-				);
-			})}
+			{sharedAudioTagElements}
 			{children}
 		</SharedAudioTagsContext.Provider>
 	);

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -639,7 +639,9 @@ export const SharedAudioTagsContextProvider: React.FC<{
 						prevA.premounting === premounting &&
 						prevA.postmounting === postmounting;
 					if (isTheSame) {
-						return prevA;
+						return prevA.audioMounted === audioMounted
+							? prevA
+							: {...prevA, audioMounted};
 					}
 
 					changed = true;
@@ -654,7 +656,9 @@ export const SharedAudioTagsContextProvider: React.FC<{
 					};
 				}
 
-				return prevA;
+				return prevA.audioMounted === audioMounted
+					? prevA
+					: {...prevA, audioMounted};
 			});
 
 			if (changed) {


### PR DESCRIPTION
## Summary

Improves the shared audio tag pool in three independent ways:

- memoizes the pool's `<audio>` elements instead of recreating the element array whenever the provider rerenders
- persists refreshed `audioMounted` state for every pool record, avoiding repeated reconciliations after refs mount
- avoids assigning the empty audio data URL when an unused tag already has it

## Motivation

We found these while profiling a Remotion `<Player>` with `numberOfSharedAudioTags={64}` and premounted audio:

- 11,648 audio React element creations in 182 playback commits (64 tags per commit)
- 1,923 `emptied` events in a 15-second device trace
- repeated calls through the native media `src` setter from shared-audio reconciliation

The stale `audioMounted` flag and unconditional `src` assignment compound: once a mounted record's cached flag is stale, later updates keep reconciling the whole pool, and each reconciliation reloads every unused tag.

## Testing

- `cd packages/core && bun run make`
- `cd packages/core && bun run test` (576 passing)
- `cd packages/core && bun run lint` (passes with one pre-existing `use-lazy-component.ts` warning)
- `cd packages/core && bun run formatting`

## Tradeoffs

The memoized element array retains the same lifetime as `refs`, which is already memoized by audio context and pool size. No public API or rendered output changes.
