### PR TITLE
Fix typo in mediabunny SKILL.md (it's -> its)

### DIFF
--- a/packages/skills/skills/mediabunny/SKILL.md
+++ b/packages/skills/skills/mediabunny/SKILL.md
@@ -6,7 +6,7 @@ metadata:
 ---
 
 Mediabunny is a multimedia library for dealing with audio and video in the browser.
-Here is a compact overview of it's capabilities: https://mediabunny.dev/llms.txt
+Here is a compact overview of its capabilities: https://mediabunny.dev/llms.txt
 
 ## Getting audio duration
 


### PR DESCRIPTION
## Summary
- Fixes a contraction/possessive typo (it's -> its) in the capabilities overview sentence of `packages/skills/skills/mediabunny/SKILL.md`.

## Test plan
- Docs-only change, no functional impact.