### PR TITLE
`@remotion/studio`: Allow copying SVG when right-clicking `<Interactive.Svg>`

### DIFF
--- a/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
+++ b/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
@@ -26,6 +26,8 @@ const normalizeMenuDividers = (items: ComboboxValue[]): ComboboxValue[] => {
 	return normalized;
 };
 
+const interactiveSvgComponentIdentity = 'dev.remotion.remotion.Interactive.Svg';
+
 export const getSequenceContextMenuItems = ({
 	assetLinkInfo,
 	canOpenInEditor,
@@ -61,6 +63,8 @@ export const getSequenceContextMenuItems = ({
 }): ComboboxValue[] => {
 	const editorName = window.remotion_editorName;
 	const {documentationLink} = sequence;
+	const isInteractiveSvg =
+		sequence.controls?.componentIdentity === interactiveSvgComponentIdentity;
 
 	const items = [
 		editorName
@@ -105,6 +109,37 @@ export const getSequenceContextMenuItems = ({
 			subMenu: null,
 			value: 'copy-file-location',
 		},
+		isInteractiveSvg
+			? {
+					type: 'item' as const,
+					id: 'copy-svg',
+					keyHint: null,
+					label: 'Copy SVG',
+					leftItem: null,
+					disabled: !sequence.refForOutline?.current,
+					onClick: () => {
+						const svg = sequence.refForOutline?.current;
+						if (!svg) {
+							return;
+						}
+
+						navigator.clipboard
+							.writeText(svg.outerHTML)
+							.then(() => {
+								showNotification('Copied SVG to clipboard', 1000);
+							})
+							.catch((err) => {
+								showNotification(
+									`Could not copy to clipboard: ${(err as Error).message}`,
+									1000,
+								);
+							});
+					},
+					quickSwitcherLabel: null,
+					subMenu: null,
+					value: 'copy-svg',
+				}
+			: null,
 		documentationLink
 			? {
 					type: 'item' as const,

--- a/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
+++ b/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
@@ -109,37 +109,6 @@ export const getSequenceContextMenuItems = ({
 			subMenu: null,
 			value: 'copy-file-location',
 		},
-		isInteractiveSvg
-			? {
-					type: 'item' as const,
-					id: 'copy-svg',
-					keyHint: null,
-					label: 'Copy SVG',
-					leftItem: null,
-					disabled: !sequence.refForOutline?.current,
-					onClick: () => {
-						const svg = sequence.refForOutline?.current;
-						if (!svg) {
-							return;
-						}
-
-						navigator.clipboard
-							.writeText(svg.outerHTML)
-							.then(() => {
-								showNotification('Copied SVG to clipboard', 1000);
-							})
-							.catch((err) => {
-								showNotification(
-									`Could not copy to clipboard: ${(err as Error).message}`,
-									1000,
-								);
-							});
-					},
-					quickSwitcherLabel: null,
-					subMenu: null,
-					value: 'copy-svg',
-				}
-			: null,
 		documentationLink
 			? {
 					type: 'item' as const,
@@ -176,6 +145,43 @@ export const getSequenceContextMenuItems = ({
 			? {
 					type: 'divider' as const,
 					id: 'sequence-link-divider',
+				}
+			: null,
+		isInteractiveSvg
+			? {
+					type: 'item' as const,
+					id: 'copy-svg',
+					keyHint: null,
+					label: 'Copy SVG',
+					leftItem: null,
+					disabled: !sequence.refForOutline?.current,
+					onClick: () => {
+						const svg = sequence.refForOutline?.current;
+						if (!svg) {
+							return;
+						}
+
+						navigator.clipboard
+							.writeText(svg.outerHTML)
+							.then(() => {
+								showNotification('Copied SVG to clipboard', 1000);
+							})
+							.catch((err) => {
+								showNotification(
+									`Could not copy to clipboard: ${(err as Error).message}`,
+									1000,
+								);
+							});
+					},
+					quickSwitcherLabel: null,
+					subMenu: null,
+					value: 'copy-svg',
+				}
+			: null,
+		isInteractiveSvg
+			? {
+					type: 'divider' as const,
+					id: 'copy-svg-divider',
 				}
 			: null,
 		sourceActions.length > 0

--- a/packages/studio/src/test/sequence-context-menu-items.test.ts
+++ b/packages/studio/src/test/sequence-context-menu-items.test.ts
@@ -135,7 +135,7 @@ test('Interactive.Svg context menu can copy the rendered SVG', () => {
 			controls: {
 				componentIdentity: 'dev.remotion.remotion.Interactive.Svg',
 			},
-			documentationLink: null,
+			documentationLink: 'https://www.remotion.dev/docs/interactive',
 			refForOutline: {
 				current: {outerHTML: '<svg><circle /></svg>'},
 			},
@@ -149,6 +149,15 @@ test('Interactive.Svg context menu can copy the rendered SVG', () => {
 
 	copySvg.onClick('copy-svg', null);
 	expect(copiedTexts).toEqual(['<svg><circle /></svg>']);
+
+	const docsIndex = items.findIndex(
+		(item) => item.id === 'open-component-docs',
+	);
+	const copySvgIndex = items.findIndex((item) => item.id === 'copy-svg');
+	expect(
+		items.slice(docsIndex + 1, copySvgIndex).map((item) => item.type),
+	).toEqual(['divider']);
+	expect(items[copySvgIndex + 1]?.type).toBe('divider');
 });
 
 test('sequence freeze context menu item is hidden for audio', () => {

--- a/packages/studio/src/test/sequence-context-menu-items.test.ts
+++ b/packages/studio/src/test/sequence-context-menu-items.test.ts
@@ -8,14 +8,23 @@ const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
 	globalThis,
 	'window',
 );
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'navigator',
+);
 
 afterEach(() => {
 	if (originalWindowDescriptor) {
 		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
-		return;
+	} else {
+		Reflect.deleteProperty(globalThis, 'window');
 	}
 
-	Reflect.deleteProperty(globalThis, 'window');
+	if (originalNavigatorDescriptor) {
+		Object.defineProperty(globalThis, 'navigator', originalNavigatorDescriptor);
+	} else {
+		Reflect.deleteProperty(globalThis, 'navigator');
+	}
 });
 
 const installTestWindow = () => {
@@ -90,6 +99,56 @@ test('sequence context menu does not put two dividers between docs and rename', 
 	expect(
 		items.slice(docsIndex + 1, renameIndex).map((item) => item.type),
 	).toEqual(['divider']);
+});
+
+test('Interactive.Svg context menu can copy the rendered SVG', () => {
+	installTestWindow();
+
+	const copiedTexts: string[] = [];
+	Object.defineProperty(globalThis, 'navigator', {
+		configurable: true,
+		value: {
+			clipboard: {
+				writeText: (text: string) => {
+					copiedTexts.push(text);
+					return new Promise<void>(() => undefined);
+				},
+			},
+		},
+	});
+
+	const items = getSequenceContextMenuItems({
+		assetLinkInfo: null,
+		canOpenInEditor: false,
+		deleteDisabled: false,
+		disableInteractivityDisabled: false,
+		duplicateDisabled: false,
+		fileLocation: 'src/Video.tsx:10:2',
+		includeSourceEditItems: true,
+		onDeleteSequenceFromSource: noop,
+		onDisableSequenceInteractivity: noop,
+		onDuplicateSequenceFromSource: noop,
+		openInEditor: noop,
+		originalLocation: null,
+		selectAsset: noop,
+		sequence: {
+			controls: {
+				componentIdentity: 'dev.remotion.remotion.Interactive.Svg',
+			},
+			documentationLink: null,
+			refForOutline: {
+				current: {outerHTML: '<svg><circle /></svg>'},
+			},
+		} as unknown as TSequence,
+	});
+
+	const copySvg = items.find((item) => item.id === 'copy-svg');
+	if (copySvg?.type !== 'item') {
+		throw new Error('Expected copy SVG menu item');
+	}
+
+	copySvg.onClick('copy-svg', null);
+	expect(copiedTexts).toEqual(['<svg><circle /></svg>']);
 });
 
 test('sequence freeze context menu item is hidden for audio', () => {


### PR DESCRIPTION
## Summary

- add a `Copy SVG` action to the context menu for `Interactive.Svg`
- copy the rendered SVG markup from the outline ref
- show clipboard success and error notifications
- cover the copied markup with a focused Studio test

Closes #9163
