### PR TITLE
Elements: Require exit animations for animated Elements

### DIFF
--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -18,6 +18,7 @@ Good Elements are:
 - Focused on one visual idea, technique, or workflow
 - Copy-pastable and useful in more than one Remotion project
 - Remixable
+- Equipped with both entrance and exit animations, if animated
 - HTML, CSS, and React-first
 - Free of unexpected global styles, layout side effects, and fullscreen assumptions unless it is explicitly a background
 - **Building blocks, not compositions:** The hosted docs page provides the preview size, frame rate, and duration.
@@ -90,9 +91,11 @@ Do not put the wrapper [`<Sequence>`](/docs/sequence) into the Element source fi
 Let the Studio-inserted [`<Sequence>`](/docs/sequence) handle placement in the video.
 Don't use `left`, `right`, `top`, and `bottom`, etc. to position your element.
 
-Inner Element styles can animate entrance values such as `translate`, `scale`, and `opacity`.
+Inner Element styles can animate entrance and exit values such as `translate`, `scale`, and `opacity`.
 
-For animation, keep the timing inside the component but let the surrounding project decide how long the Element appears:
+For animation, keep the timing inside the component but let the surrounding project decide how long the Element appears.
+
+If an Element has an entrance animation, it must also have an exit animation. Keep both sets of keyframes inline on an `Interactive.*` element with hardcoded frame ranges, so users can adjust their timing in the Studio:
 
 ```tsx twoslash title="AnimatedElement.tsx"
 import {Interactive, interpolate, useCurrentFrame} from 'remotion';
@@ -106,8 +109,14 @@ export const AnimatedElement = () => {
       style={{
         width: '100%',
         height: '100%',
-        opacity: interpolate(frame, [0, 20], [0, 1]),
-        translate: interpolate(frame, [0, 20], ['0px 40px', '0px 0px']),
+        opacity: interpolate(frame, [0, 20, 70, 90], [0, 1, 1, 0], {
+          extrapolateLeft: 'clamp',
+          extrapolateRight: 'clamp',
+        }),
+        translate: interpolate(frame, [0, 20, 70, 90], ['0px 40px', '0px 0px', '0px 0px', '0px -40px'], {
+          extrapolateLeft: 'clamp',
+          extrapolateRight: 'clamp',
+        }),
       }}
     >
       Hello


### PR DESCRIPTION
## Summary

- require animated Elements to include both entrance and exit animations
- recommend inline, Studio-editable keyframes for both animation phases
- update the submission example to demonstrate entrance and exit timing

## Verification

- `bun run build`
- `bun run stylecheck`

Closes #9169
