### PR TITLE
`remotion`: Include source path in visual editing keys

### DIFF
--- a/packages/core/src/SequenceManager.tsx
+++ b/packages/core/src/SequenceManager.tsx
@@ -118,7 +118,7 @@ export type CanUpdateSequencePropsResponse =
 export const makeSequencePropsSubscriptionKey = (
 	key: SequencePropsSubscriptionKey,
 ): string => {
-	return `${key.nodePath.join('.')}.${key.sequenceKeys.join('.')}.${key.effectKeys.map((keys) => keys.join('.')).join('.')}`;
+	return `${key.absolutePath}\0${key.nodePath.join('.')}\0${key.sequenceKeys.join('.')}\0${key.effectKeys.map((keys) => keys.join('.')).join('.')}`;
 };
 
 export const VisualModePropStatusesContext =

--- a/packages/core/src/test/sequence-props-subscription-key.test.ts
+++ b/packages/core/src/test/sequence-props-subscription-key.test.ts
@@ -1,0 +1,20 @@
+import {expect, test} from 'bun:test';
+import type {SequencePropsSubscriptionKey} from '../SequenceManager.js';
+import {makeSequencePropsSubscriptionKey} from '../SequenceManager.js';
+
+const makeKey = (absolutePath: string): SequencePropsSubscriptionKey => ({
+	absolutePath,
+	nodePath: ['program', 'body', 0, 'openingElement'],
+	sequenceKeys: ['name', 'from'],
+	effectKeys: [],
+	videoConfigValues: null,
+});
+
+test('sequence prop subscription keys include the absolute file path', () => {
+	const first = makeSequencePropsSubscriptionKey(makeKey('/project/first.tsx'));
+	const second = makeSequencePropsSubscriptionKey(
+		makeKey('/project/second.tsx'),
+	);
+
+	expect(first).not.toBe(second);
+});


### PR DESCRIPTION
## Summary

- Include the absolute source path in visual editing subscription keys.
- Prevent identical AST node paths in different files from sharing prop statuses and drag overrides.
- Add a regression test for cross-file key collisions.

## Tests

- `bun test packages/core/src/test/sequence-props-subscription-key.test.ts`
- `bun run build`
- `bun run stylecheck`
