### PR TITLE
Elements: Add Lower Third exit animation

### DIFF
--- a/packages/docs/elements/overlays/lower-third/lower-third.tsx
+++ b/packages/docs/elements/overlays/lower-third/lower-third.tsx
@@ -25,7 +25,8 @@ export const LowerThird: React.FC = () => {
 				backgroundColor: 'rgba(255, 255, 255, 0.94)',
 				boxShadow: '0 6px 12px rgba(24, 24, 27, 0.2)',
 				border: '1px solid rgba(24, 24, 27, 0.08)',
-				opacity: interpolate(frame, [0, 18], [0, 1], {
+				opacity: interpolate(frame, [0, 18, 102, 119], [0, 1, 1, 0], {
+					extrapolateLeft: 'clamp',
 					extrapolateRight: 'clamp',
 				}),
 				translate: interpolate(frame, [0, 24], ['32px 0px', '0px 0px'], {


### PR DESCRIPTION
## Summary

- add an exit fade to the Lower Third element
- keep the exit timing inline and editable in Remotion Studio
- clamp opacity before the entrance and after the exit

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun test packages/docs/src/test/elements.test.ts`
- `bunx oxfmt packages/docs/elements/overlays/lower-third/lower-third.tsx --write`

Closes #9169
