### PR TITLE
Elements: Link to progress tracker

### DIFF
--- a/packages/docs/elements/index.mdx
+++ b/packages/docs/elements/index.mdx
@@ -8,7 +8,7 @@ description: Drop-in, remixable video building blocks for Remotion.
 
 :::warning Work in progress
 
-This section is being shaped. The format and Element list may change. You can track progress in [GitHub issue #9081](https://github.com/remotion-dev/remotion/issues/9081?issue=remotion-dev%7Cremotion%7C7698).
+This section is being shaped. The format and Element list may change. You can track progress in [GitHub issue #7698](https://github.com/remotion-dev/remotion/issues/7698).
 
 :::
 

--- a/packages/docs/elements/index.mdx
+++ b/packages/docs/elements/index.mdx
@@ -8,7 +8,7 @@ description: Drop-in, remixable video building blocks for Remotion.
 
 :::warning Work in progress
 
-This section is being shaped. The format and Element list may change.
+This section is being shaped. The format and Element list may change. You can track progress in [GitHub issue #9081](https://github.com/remotion-dev/remotion/issues/9081?issue=remotion-dev%7Cremotion%7C7698).
 
 :::
 


### PR DESCRIPTION
## Summary

- Link the Remotion Elements work-in-progress warning to the progress tracker.
- Direct users to #7698 for updates.

## Verification

- `bunx oxfmt packages/docs/elements/index.mdx --write`
- `bun run build`
- `bun run stylecheck`
