### PR TITLE
`@remotion/it-tests`: Retry flaky Windows rendering tests

### DIFF
--- a/packages/it-tests/src/rendering/rendering.test.ts
+++ b/packages/it-tests/src/rendering/rendering.test.ts
@@ -486,7 +486,7 @@ test(
 		expect(data).toContain('Audio: mp3, 48000 Hz');
 		fs.unlinkSync(out);
 	},
-	{timeout: 15000},
+	{timeout: 15000, retry: 3},
 );
 
 test(
@@ -517,7 +517,7 @@ test(
 		expect(task.exitCode).toBe(0);
 		fs.unlinkSync(out);
 	},
-	{timeout: 15000},
+	{timeout: 15000, retry: 3},
 );
 
 test(
@@ -609,7 +609,7 @@ test(
 		expect(task.exitCode).toBe(0);
 		fs.unlinkSync(outputPath.replace('.mp4', '.png'));
 	},
-	{timeout: 20000},
+	{timeout: 20000, retry: 3},
 );
 
 test(


### PR DESCRIPTION
## Summary

- retry three heavyweight rendering integration tests up to three times
- reduce intermittent Node 16 Windows failures without relaxing their timeout limits
- align these tests with nearby rendering tests that already retry transient failures

## Flake evidence

- Tracked in #8375
- Observed in https://github.com/remotion-dev/remotion/actions/runs/29573682702/job/87863151616?pr=9179

## Verification

- `bunx oxfmt packages/it-tests/src/rendering/rendering.test.ts --write`
- `cd packages/it-tests && bun run lint`
- `bun run build`
- `bun run stylecheck`
