### PR TITLE
Elements: Fix Agent Skills link

### DIFF
--- a/packages/docs/elements/submit-an-element.mdx
+++ b/packages/docs/elements/submit-an-element.mdx
@@ -11,7 +11,7 @@ Before starting, read the [Element Guidelines](/elements/guidelines). They descr
 
 ## Use the Agent Skills
 
-Two [Agent Skills](/docs/ai/skills) are available in the Remotion repository. They contain the technical workflow, including file layout, metadata, previews, and validation:
+Two [Agent Skills](https://agentskills.io/) are available in the Remotion repository. They contain the technical workflow, including file layout, metadata, previews, and validation:
 
 - Use the [`scaffold-element` Agent Skill](https://github.com/remotion-dev/remotion/blob/main/.agents/skills/scaffold-element/SKILL.md) to scaffold and register an Element for development.
 - Use the [`publish-element` Agent Skill](https://github.com/remotion-dev/remotion/blob/main/.agents/skills/publish-element/SKILL.md) after developing and reviewing the Element in Remotion Studio. It adds the Element to the gallery, renders its previews, and runs the final checks.


### PR DESCRIPTION
## Summary

- link the generic Agent Skills reference to agentskills.io
- avoid directing Element contributors to Remotion's public skills documentation

## Verification

- `bunx oxfmt packages/docs/elements/submit-an-element.mdx --write`
- `bun run build`
- `bun run stylecheck`
