### PR TITLE
Docs: Document text behind video

### DIFF
--- a/packages/docs/docs/greenscreen.mdx
+++ b/packages/docs/docs/greenscreen.mdx
@@ -43,6 +43,7 @@ export const Greenscreen: React.FC = () => {
 
 ## See also
 
+- [Text behind video](/docs/text-behind-video)
 - [`colorKey()`](/docs/effects/color-key)
 - [`@remotion/effects`](/docs/effects/api)
 - [Manipulating pixels](/docs/videos/video-manipulation)

--- a/packages/docs/docs/layers.mdx
+++ b/packages/docs/docs/layers.mdx
@@ -57,6 +57,7 @@ If you are aware of this behavior, you can use it to your advantage and avoid us
 
 ## See also
 
+- [Text behind video](/docs/text-behind-video)
 - [`<AbsoluteFill>`](/docs/absolute-fill)
 - [`<Sequence>`](/docs/sequence)
 - [Build a timeline-based video editor](/docs/building-a-timeline)

--- a/packages/docs/docs/text-behind-video.mdx
+++ b/packages/docs/docs/text-behind-video.mdx
@@ -1,0 +1,145 @@
+---
+image: /generated/articles-docs-text-behind-video.png
+id: text-behind-video
+title: Text behind video
+sidebar_label: Text behind video
+crumb: 'How To'
+---
+
+Make text appear behind a person or object by stacking three layers: an optional background, the text, then a foreground subject with transparency.
+
+In Remotion, elements that appear later in the tree render on top. Prefer that order over `z-index`. See [Layers](/docs/layers).
+
+## With a greenscreen video
+
+Film or use a clip with a solid green background, then remove the green with [`colorKey()`](/docs/effects/color-key):
+
+```tsx twoslash title="TextBehindVideo.tsx"
+import {colorKey} from '@remotion/effects/color-key';
+import {Video} from '@remotion/media';
+import React from 'react';
+import {AbsoluteFill} from 'remotion';
+
+export const TextBehindVideo: React.FC = () => {
+  return (
+    <AbsoluteFill style={{backgroundColor: '#0b1020'}}>
+      <AbsoluteFill
+        style={{
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 120,
+            fontWeight: 800,
+            color: 'white',
+            textAlign: 'center',
+          }}
+        >
+          HELLO
+        </div>
+      </AbsoluteFill>
+      <AbsoluteFill>
+        <Video
+          src="https://remotion.media/greenscreen.mp4"
+          effects={[
+            colorKey({
+              similarity: 0.45,
+            }),
+          ]}
+        />
+      </AbsoluteFill>
+    </AbsoluteFill>
+  );
+};
+```
+
+`colorKey()` uses WebGL2. During rendering, enable WebGL via [`Config.setChromiumOpenGlRenderer('angle')`](/docs/config#setchromiumopenglrenderer).
+
+## With a transparent video
+
+If the foreground already has an alpha channel, embed it with [`<Video>` from `@remotion/media`](/docs/media/video). No color key is needed:
+
+```tsx twoslash title="TextBehindTransparentVideo.tsx"
+import {Video} from '@remotion/media';
+import React from 'react';
+import {AbsoluteFill, staticFile} from 'remotion';
+
+export const TextBehindTransparentVideo: React.FC = () => {
+  return (
+    <AbsoluteFill style={{backgroundColor: '#0b1020'}}>
+      <AbsoluteFill
+        style={{
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 120,
+            fontWeight: 800,
+            color: 'white',
+          }}
+        >
+          HELLO
+        </div>
+      </AbsoluteFill>
+      <AbsoluteFill>
+        <Video src={staticFile('subject-with-alpha.webm')} />
+      </AbsoluteFill>
+    </AbsoluteFill>
+  );
+};
+```
+
+See [Embedding transparent videos](/docs/videos/transparency) for formats and [`<OffthreadVideo>`](/docs/offthreadvideo) options.
+
+## With a cutout image
+
+The same stacking works with a transparent PNG or WebP subject:
+
+```tsx twoslash title="TextBehindImage.tsx"
+import React from 'react';
+import {AbsoluteFill, Img, staticFile} from 'remotion';
+
+export const TextBehindImage: React.FC = () => {
+  return (
+    <AbsoluteFill style={{backgroundColor: '#292929'}}>
+      <AbsoluteFill
+        style={{
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 200,
+            fontWeight: 900,
+            color: '#ccc',
+          }}
+        >
+          GOAT
+        </div>
+      </AbsoluteFill>
+      <AbsoluteFill>
+        <Img src={staticFile('subject.png')} />
+      </AbsoluteFill>
+    </AbsoluteFill>
+  );
+};
+```
+
+## Tips
+
+- Keep the text layer under the subject in the JSX tree so the subject covers the letters where they overlap.
+- For a full-frame background video plus text behind a person, render the background first, then the text, then the keyed or transparent subject.
+- Avoid `z-index` unless you have a specific reason. Layer order is enough for this effect.
+
+## See also
+
+- [Layers](/docs/layers)
+- [Greenscreen](/docs/greenscreen)
+- [`colorKey()`](/docs/effects/color-key)
+- [Embedding transparent videos](/docs/videos/transparency)
+- [`<AbsoluteFill>`](/docs/absolute-fill)

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -1054,6 +1054,7 @@ const sidebars: SidebarsConfig = {
 			label: 'Designing visuals',
 			items: [
 				'layers',
+				'text-behind-video',
 				'transforms',
 				'assets',
 				'fonts',

--- a/packages/docs/src/data/articles.ts
+++ b/packages/docs/src/data/articles.ts
@@ -7175,6 +7175,15 @@ export const articles = [
 		slug: 'testing',
 	},
 	{
+		id: 'text-behind-video',
+		title: 'Text behind video',
+		relativePath: 'docs/text-behind-video.mdx',
+		compId: 'articles-docs-text-behind-video',
+		crumb: 'How To',
+		noAi: false,
+		slug: 'text-behind-video',
+	},
+	{
 		id: 'text-highlights',
 		title: 'Text highlights',
 		relativePath: 'docs/text-highlights.mdx',

--- a/packages/skills/skills/remotion-markup/SKILL.md
+++ b/packages/skills/skills/remotion-markup/SKILL.md
@@ -140,6 +140,10 @@ export const Subtitle = () => {
 
 See [map.md](map.md) for choosing between simple static maps, Mapbox maps, and MapLibre maps.
 
+## Text behind video
+
+See [text-behind-video.md](text-behind-video.md) for placing text behind a subject using layer order with a greenscreen or transparent foreground.
+
 ## Text highlights and annotations
 
 See [text-highlights.md](text-highlights.md) for text highlights (highlight markers), circles, underlines, strike-throughs, crossed-off text, boxes, and brackets.

--- a/packages/skills/skills/remotion-markup/text-behind-video.md
+++ b/packages/skills/skills/remotion-markup/text-behind-video.md
@@ -1,0 +1,45 @@
+---
+name: text-behind-video
+description: Put text behind a subject using AbsoluteFill layer order plus a transparent or greenscreen foreground.
+metadata:
+  tags: text, layers, greenscreen, transparent, color-key, absolute-fill
+---
+
+# Text behind video
+
+Stack layers so text sits under a subject with transparency: background (optional), text, then foreground.
+
+Docs: https://www.remotion.dev/docs/text-behind-video
+
+Use [`<AbsoluteFill>`](https://www.remotion.dev/docs/absolute-fill) and render later children on top. Prefer tree order over `z-index`.
+
+## Greenscreen subject
+
+Install `@remotion/effects` and remove the green with `colorKey()`:
+
+```tsx
+import {colorKey} from '@remotion/effects/color-key';
+import {Video} from '@remotion/media';
+import {AbsoluteFill} from 'remotion';
+
+export const TextBehindVideo = () => {
+  return (
+    <AbsoluteFill style={{backgroundColor: '#0b1020'}}>
+      <AbsoluteFill style={{justifyContent: 'center', alignItems: 'center'}}>
+        <div style={{fontSize: 120, fontWeight: 800, color: 'white'}}>HELLO</div>
+      </AbsoluteFill>
+      <AbsoluteFill>
+        <Video src="https://remotion.media/greenscreen.mp4" effects={[colorKey({similarity: 0.45})]} />
+      </AbsoluteFill>
+    </AbsoluteFill>
+  );
+};
+```
+
+`colorKey()` needs WebGL2. For renders, set `Config.setChromiumOpenGlRenderer('angle')`.
+
+## Transparent video or cutout image
+
+If the subject already has alpha, put `<Video>` or `<Img>` above the text with no color key.
+
+See also: [Layers](https://www.remotion.dev/docs/layers), [Greenscreen](https://www.remotion.dev/docs/greenscreen), [Embedding transparent videos](https://www.remotion.dev/docs/videos/transparency).


### PR DESCRIPTION
Closes #9144

Adds a documentation page for putting text behind a video subject, based on the usual Remotion layering pattern: background (optional), text, then a foreground with transparency.

The page covers three idiomatic approaches:

1. Greenscreen footage with [`colorKey()`](https://www.remotion.dev/docs/effects/color-key)
2. A transparent video with an alpha channel via [`<Video>` from `@remotion/media`](https://www.remotion.dev/docs/media/video)
3. A cutout image (`<Img>` with a transparent PNG/WebP)

It is linked from [Layers](https://www.remotion.dev/docs/layers) and [Greenscreen](https://www.remotion.dev/docs/greenscreen), wired into the Designing visuals sidebar, registered in `articles.ts`, and linked from the `remotion-markup` Agent Skill (`text-behind-video.md`).

Social preview card PNG was not regenerated locally (`bun render-cards.ts` needs a full docs install). The frontmatter points at `/generated/articles-docs-text-behind-video.png` so maintainers can generate it with the usual cards script.

## Verification

Prettier check with the version pinned in the root package.json (3.8.1) and the repo `.prettierrc.js` options:

```
$ prettier --config .prettierrc.js --check packages/docs/docs/text-behind-video.mdx packages/skills/skills/remotion-markup/text-behind-video.md
Checking formatting...
All matched files use Prettier code style!
```

MDX syntax check, compiling the new page with `@mdx-js/mdx` and `remark-gfm`:

```
MDX COMPILE OK
```

This change was developed with AI assistance (Cursor/Grok) and verified locally as shown above.
