### PR TITLE
Elements: Set up OG videos and images for Element pages

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -1,3 +1,5 @@
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {
 	makeElementDragData,
 	type ComponentDimensions,
@@ -10,8 +12,10 @@ import React, {
 	type ReactNode,
 } from 'react';
 import {BlueButton, PlainButton} from '../../../components/layout/Button';
+import {Seo} from '../Seo';
 import type {ElementDefinition} from './element-definitions';
 import {setElementDragData, setElementDragImage} from './element-drag-data';
+import {getElementOgMetadata} from './element-og';
 import {getElementDimensionsLabel} from './element-utils';
 import {ElementPreview} from './ElementPreview';
 import {
@@ -103,6 +107,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	dependencies,
 	sourceCode,
 }) => {
+	const context = useDocusaurusContext();
 	const {
 		contributors,
 		description,
@@ -120,6 +125,10 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	const sourceId = useId();
 	const {height: previewHeight, width: previewWidth} =
 		getElementPreviewDimensions(definition);
+	const ogMetadata = getElementOgMetadata({
+		definition,
+		previewDimensions: {height: previewHeight, width: previewWidth},
+	});
 
 	const dragData = useMemo(() => {
 		if (!sourceCode) {
@@ -211,6 +220,26 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 
 	return (
 		<div className={styles.workbench}>
+			<Head>
+				{Seo.renderImage(
+					ogMetadata.imageUrl,
+					context.siteConfig.url,
+					ogMetadata.width === null || ogMetadata.height === null
+						? undefined
+						: {height: ogMetadata.height, width: ogMetadata.width},
+				)}
+				{ogMetadata.videoUrl === null ||
+				ogMetadata.width === null ||
+				ogMetadata.height === null
+					? null
+					: Seo.renderVideo({
+							src: ogMetadata.videoUrl,
+							domain: context.siteConfig.url,
+							width: ogMetadata.width,
+							height: ogMetadata.height,
+							durationSeconds: ogMetadata.durationSeconds ?? undefined,
+						})}
+			</Head>
 			<section aria-label="Preview" className={styles.previewColumn}>
 				<div className={styles.previewAndSource}>
 					<ElementPreview

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -21,6 +21,12 @@ export type ElementDefinition = {
 	readonly elementHeight: number | null;
 	readonly elementWidth: number | null;
 	readonly fps: number;
+	/**
+	 * When false, Element pages fall back to the site social preview image and
+	 * omit OG video tags. Defaults to true for published Elements with preview
+	 * assets at remotion.media.
+	 */
+	readonly hasPreviewAssets?: boolean;
 	readonly height: number;
 	readonly posterFrame: number;
 	readonly previewPadding: number;

--- a/packages/docs/src/components/Elements/element-og.ts
+++ b/packages/docs/src/components/Elements/element-og.ts
@@ -1,0 +1,48 @@
+import type {ElementDefinition} from './element-definitions';
+
+export const ELEMENT_OG_FALLBACK_IMAGE = '/img/social-preview.png';
+
+export type ElementOgMetadata = {
+	readonly durationSeconds: number | null;
+	readonly height: number | null;
+	readonly imageUrl: string;
+	readonly videoUrl: string | null;
+	readonly width: number | null;
+};
+
+export const getElementPreviewUrls = (slug: string) => {
+	const base = `https://remotion.media/elements/${slug}`;
+
+	return {
+		mp4: `${base}/preview.mp4`,
+		png: `${base}/preview.png`,
+	};
+};
+
+export const getElementOgMetadata = ({
+	definition,
+	previewDimensions,
+}: {
+	readonly definition: ElementDefinition;
+	readonly previewDimensions: {readonly height: number; readonly width: number};
+}): ElementOgMetadata => {
+	if (definition.hasPreviewAssets === false) {
+		return {
+			durationSeconds: null,
+			height: null,
+			imageUrl: ELEMENT_OG_FALLBACK_IMAGE,
+			videoUrl: null,
+			width: null,
+		};
+	}
+
+	const urls = getElementPreviewUrls(definition.slug);
+
+	return {
+		durationSeconds: definition.durationInFrames / definition.fps,
+		height: previewDimensions.height,
+		imageUrl: urls.png,
+		videoUrl: urls.mp4,
+		width: previewDimensions.width,
+	};
+};

--- a/packages/docs/src/components/Elements/element-utils.ts
+++ b/packages/docs/src/components/Elements/element-utils.ts
@@ -3,6 +3,8 @@ import {
 	type ElementDefinition,
 } from './element-definitions';
 
+export {getElementPreviewUrls} from './element-og';
+
 export const getElementDimensionsLabel = (definition: ElementDefinition) => {
 	if (definition.elementWidth === null || definition.elementHeight === null) {
 		return 'Adapts to composition';
@@ -13,15 +15,6 @@ export const getElementDimensionsLabel = (definition: ElementDefinition) => {
 
 export const getElementCompositionId = (slug: string) => {
 	return `element-${slug.replaceAll('/', '-')}`;
-};
-
-export const getElementPreviewUrls = (slug: string) => {
-	const base = `https://remotion.media/elements/${slug}`;
-
-	return {
-		mp4: `${base}/preview.mp4`,
-		png: `${base}/preview.png`,
-	};
 };
 
 export const getElementDefinition = (slug: string) => {

--- a/packages/docs/src/components/Seo.tsx
+++ b/packages/docs/src/components/Seo.tsx
@@ -15,12 +15,66 @@ export const Seo = {
 			<meta key="desc2" property="og:description" content={title} />,
 		];
 	},
-	renderImage: (title: string, domain: string) => {
+	renderImage: (
+		title: string,
+		domain: string,
+		dimensions?: {readonly height: number; readonly width: number},
+	) => {
 		const imgSrc = new URL(title, domain).href;
-
-		return [
+		const tags = [
 			<meta key="img1" property="og:image" content={imgSrc} />,
 			<meta key="img2" name="twitter:image" content={imgSrc} />,
 		];
+
+		if (dimensions) {
+			tags.push(
+				<meta
+					key="imgw"
+					property="og:image:width"
+					content={String(dimensions.width)}
+				/>,
+				<meta
+					key="imgh"
+					property="og:image:height"
+					content={String(dimensions.height)}
+				/>,
+			);
+		}
+
+		return tags;
+	},
+	renderVideo: ({
+		src,
+		domain,
+		width,
+		height,
+		durationSeconds,
+	}: {
+		readonly src: string;
+		readonly domain: string;
+		readonly width: number;
+		readonly height: number;
+		readonly durationSeconds?: number;
+	}) => {
+		const videoSrc = new URL(src, domain).href;
+		const tags = [
+			<meta key="vid1" property="og:video" content={videoSrc} />,
+			<meta key="vid2" property="og:video:secure_url" content={videoSrc} />,
+			<meta key="vid3" property="og:video:type" content="video/mp4" />,
+			<meta key="vid4" property="og:video:width" content={String(width)} />,
+			<meta key="vid5" property="og:video:height" content={String(height)} />,
+		];
+
+		if (durationSeconds !== undefined) {
+			tags.push(
+				<meta
+					key="vid6"
+					property="og:video:duration"
+					content={String(Math.round(durationSeconds))}
+				/>,
+			);
+		}
+
+		return tags;
 	},
 };

--- a/packages/docs/src/test/element-og.test.ts
+++ b/packages/docs/src/test/element-og.test.ts
@@ -1,0 +1,130 @@
+import {describe, expect, test} from 'bun:test';
+import type {ElementDefinition} from '../components/Elements/element-definitions';
+import {
+	ELEMENT_OG_FALLBACK_IMAGE,
+	getElementOgMetadata,
+} from '../components/Elements/element-og';
+import {Seo} from '../components/Seo';
+
+const mockDefinition = {
+	category: 'overlays',
+	component: (() => null) as ElementDefinition['component'],
+	contributors: [],
+	description: 'A clean animated lower third.',
+	displayName: 'Lower Third',
+	durationInFrames: 120,
+	elementHeight: 138,
+	elementWidth: 680,
+	fps: 30,
+	height: 1080,
+	posterFrame: 60,
+	previewPadding: 300,
+	slug: 'overlays/lower-third',
+	width: 1920,
+} satisfies ElementDefinition;
+
+describe('Element OG metadata', () => {
+	test('resolves OG image and video metadata from Element preview assets', () => {
+		const previewDimensions = {height: 738, width: 1280};
+		const og = getElementOgMetadata({
+			definition: mockDefinition,
+			previewDimensions,
+		});
+		const siteUrl = 'https://www.remotion.dev';
+
+		expect(og).toEqual({
+			durationSeconds: 4,
+			height: 738,
+			imageUrl:
+				'https://remotion.media/elements/overlays/lower-third/preview.png',
+			videoUrl:
+				'https://remotion.media/elements/overlays/lower-third/preview.mp4',
+			width: 1280,
+		});
+
+		const imageTags = Seo.renderImage(og.imageUrl, siteUrl, {
+			height: og.height!,
+			width: og.width!,
+		});
+		expect(imageTags).toHaveLength(4);
+		expect(imageTags[0].props).toMatchObject({
+			property: 'og:image',
+			content:
+				'https://remotion.media/elements/overlays/lower-third/preview.png',
+		});
+		expect(imageTags[1].props).toMatchObject({
+			name: 'twitter:image',
+			content:
+				'https://remotion.media/elements/overlays/lower-third/preview.png',
+		});
+		expect(imageTags[2].props).toMatchObject({
+			property: 'og:image:width',
+			content: '1280',
+		});
+		expect(imageTags[3].props).toMatchObject({
+			property: 'og:image:height',
+			content: '738',
+		});
+
+		const videoTags = Seo.renderVideo({
+			src: og.videoUrl!,
+			domain: siteUrl,
+			width: og.width!,
+			height: og.height!,
+			durationSeconds: og.durationSeconds ?? undefined,
+		});
+		expect(videoTags).toHaveLength(6);
+		expect(videoTags[0].props).toMatchObject({
+			property: 'og:video',
+			content:
+				'https://remotion.media/elements/overlays/lower-third/preview.mp4',
+		});
+		expect(videoTags[2].props).toMatchObject({
+			property: 'og:video:type',
+			content: 'video/mp4',
+		});
+		expect(videoTags[3].props).toMatchObject({
+			property: 'og:video:width',
+			content: '1280',
+		});
+		expect(videoTags[4].props).toMatchObject({
+			property: 'og:video:height',
+			content: '738',
+		});
+		expect(videoTags[5].props).toMatchObject({
+			property: 'og:video:duration',
+			content: '4',
+		});
+	});
+
+	test('falls back to the site social preview when an Element has no dedicated assets', () => {
+		const definition = {
+			...mockDefinition,
+			hasPreviewAssets: false,
+		};
+		const og = getElementOgMetadata({
+			definition,
+			previewDimensions: {height: 738, width: 1280},
+		});
+		const siteUrl = 'https://www.remotion.dev';
+
+		expect(og).toEqual({
+			durationSeconds: null,
+			height: null,
+			imageUrl: ELEMENT_OG_FALLBACK_IMAGE,
+			videoUrl: null,
+			width: null,
+		});
+
+		const imageTags = Seo.renderImage(og.imageUrl, siteUrl);
+		expect(imageTags).toHaveLength(2);
+		expect(imageTags[0].props).toMatchObject({
+			property: 'og:image',
+			content: 'https://www.remotion.dev/img/social-preview.png',
+		});
+		expect(imageTags[1].props).toMatchObject({
+			name: 'twitter:image',
+			content: 'https://www.remotion.dev/img/social-preview.png',
+		});
+	});
+});


### PR DESCRIPTION
Closes #9136

## Summary

Element detail pages now emit dedicated Open Graph image and video metadata so shared links can preview the Element instead of the generic docs social card.

- Reuse the stable `remotion.media/elements/<slug>/preview.png` and `preview.mp4` URLs from the Element preview pipeline (#8908 / #9062)
- Set `og:image`, `twitter:image`, image dimensions, and `og:video*` tags (type, size, duration) from each Element definition
- Optional `hasPreviewAssets: false` falls back to `/img/social-preview.png` and omits video tags for Elements that do not have dedicated assets yet

## Tradeoffs

- Preview binaries are still generated/uploaded by `bun run render-element-previews` (optionally `--upload`). This PR wires the public URLs into page metadata; it does not upload assets.
- At the time of writing, HEAD requests to the remotion.media Element preview paths returned 404, so social crawlers will only show Element-specific previews after those assets are published to R2.

## Verification

```
$ cd packages/docs && bun test src/test/element-og.test.ts
bun test v1.3.11 (af24e281)

src\test\element-og.test.ts:
(pass) Element OG metadata > resolves OG image and video metadata from Element preview assets
(pass) Element OG metadata > falls back to the site social preview when an Element has no dedicated assets

 2 pass
 0 fail
 16 expect() calls
Ran 2 tests across 1 file. [125.00ms]
```

Example resolved metadata for `overlays/lower-third`:

- `og:image` / `twitter:image`: `https://remotion.media/elements/overlays/lower-third/preview.png`
- `og:image:width` / `og:image:height`: `1280` / `738`
- `og:video` / `og:video:secure_url`: `https://remotion.media/elements/overlays/lower-third/preview.mp4`
- `og:video:type`: `video/mp4`
- `og:video:duration`: `4`

Fallback when `hasPreviewAssets: false`:

- `og:image` / `twitter:image`: `https://www.remotion.dev/img/social-preview.png`
- no `og:video*` tags

This change was developed with AI assistance (Cursor / Grok) and verified locally as shown above.
