### PR TITLE
fix(studio-server): resolve composition location through local re-exports

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -403,6 +403,56 @@ const findReExportTargets = ({
 	return targets;
 };
 
+const findLocalExportImportTarget = ({
+	ast,
+	exportName,
+}: {
+	ast: File;
+	exportName: string | 'default';
+}): ImportTarget | null => {
+	if (exportName === 'default') {
+		return null;
+	}
+
+	let localName: string | null = null;
+
+	recast.types.visit(ast, {
+		visitExportNamedDeclaration(astPath) {
+			if (localName) {
+				return false;
+			}
+
+			const node = astPath.node as ExportNamedDeclaration;
+			// `export {X} from './mod'` is handled by findReExportTargets.
+			if (node.source) {
+				return false;
+			}
+
+			for (const specifier of node.specifiers) {
+				if (specifier.type !== 'ExportSpecifier') {
+					continue;
+				}
+
+				const exportedName = getExportedName(specifier.exported);
+				if (exportedName !== exportName) {
+					continue;
+				}
+
+				localName = getSpecifierLocalName(specifier);
+				return false;
+			}
+
+			return false;
+		},
+	});
+
+	if (!localName) {
+		return null;
+	}
+
+	return findImportTarget({ast, componentName: localName});
+};
+
 const resolveImportPath = ({
 	importPath,
 	fromFile,
@@ -445,6 +495,16 @@ const locationFromNode = (node: NodeWithLocation): SourceLocation | null => {
 	};
 };
 
+// Recast/babel-ts often leaves `loc` null on `export function` /
+// `export class` declarations while the identifier still has a location.
+const locationFromDeclaration = (
+	node: NodeWithLocation & {
+		id?: NodeWithLocation | null;
+	},
+): SourceLocation | null => {
+	return locationFromNode(node) ?? (node.id ? locationFromNode(node.id) : null);
+};
+
 const findLocalSymbolLocation = ({
 	ast,
 	name,
@@ -462,7 +522,7 @@ const findLocalSymbolLocation = ({
 
 			const {node} = astPath;
 			if (node.id.type === 'Identifier' && node.id.name === name) {
-				location = locationFromNode(node);
+				location = locationFromDeclaration(node);
 				return false;
 			}
 
@@ -476,7 +536,7 @@ const findLocalSymbolLocation = ({
 
 			const {node} = astPath;
 			if (node.id?.name === name) {
-				location = locationFromNode(node);
+				location = locationFromDeclaration(node);
 				return false;
 			}
 
@@ -490,7 +550,7 @@ const findLocalSymbolLocation = ({
 
 			const {node} = astPath;
 			if (node.id?.name === name) {
-				location = locationFromNode(node);
+				location = locationFromDeclaration(node);
 				return false;
 			}
 
@@ -518,7 +578,8 @@ const findDefaultExportLocation = (ast: File): SourceLocation | null => {
 				return false;
 			}
 
-			location = locationFromNode(node.declaration) ?? locationFromNode(node);
+			location =
+				locationFromDeclaration(node.declaration) ?? locationFromNode(node);
 			return false;
 		},
 	});
@@ -1891,6 +1952,26 @@ const getComponentLocationRecursively = async ({
 			throw new Error(
 				`Could not resolve component export "${exportName}" in ${path.relative(remotionRoot, fileName)}`,
 			);
+		}
+
+		// `import {X} from './X'; export {X};` (no `from` on the export).
+		// Without following the import, location falls back to line 1.
+		const localExportImportTarget = findLocalExportImportTarget({
+			ast,
+			exportName,
+		});
+		if (localExportImportTarget) {
+			const resolvedImportPath = resolveImportPath({
+				importPath: localExportImportTarget.importPath,
+				fromFile: fileName,
+			});
+
+			return await getComponentLocationRecursively({
+				remotionRoot,
+				fileName: resolvedImportPath,
+				exportName: localExportImportTarget.exportName,
+				visited,
+			});
 		}
 
 		return await getComponentLocationInFile({

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -85,6 +85,154 @@ test('resolves recursively through re-exported composition components', async ()
 	}
 });
 
+test('resolves local re-export of imported composition components', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {ApplicationSimpleApp, Applications} from './Applications';",
+				'export const RemotionRoot = () => {',
+				'\treturn (',
+				'\t\t<>',
+				'\t\t\t<Composition id="ApplicationSimpleApp" component={ApplicationSimpleApp} />',
+				'\t\t\t<Composition id="Applications" component={Applications} />',
+				'\t\t</>',
+				'\t);',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.mkdir(path.join(tempDir, 'Applications'), {recursive: true});
+		await fs.writeFile(
+			path.join(tempDir, 'Applications.tsx'),
+			[
+				"import {ApplicationSimpleApp} from './Applications/SimpleApp';",
+				'',
+				'export function Applications() {',
+				'\treturn <div>apps</div>;',
+				'}',
+				'',
+				'export {ApplicationSimpleApp};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Applications', 'SimpleApp.tsx'),
+			[
+				'export function ApplicationSimpleApp() {',
+				'\treturn <div>simple</div>;',
+				'}',
+				'',
+			].join('\n'),
+		);
+
+		const simpleAppLocation = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'ApplicationSimpleApp',
+		});
+		expect(simpleAppLocation.source).toBe(
+			path.join('Applications', 'SimpleApp.tsx'),
+		);
+		expect(simpleAppLocation.line).toBe(1);
+		expect(simpleAppLocation.canAddSequence).toBe(true);
+
+		const applicationsLocation = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'Applications',
+		});
+		expect(applicationsLocation.source).toBe('Applications.tsx');
+		expect(applicationsLocation.line).toBe(3);
+		expect(applicationsLocation.canAddSequence).toBe(true);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('resolves line of export function composition component', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				'export function MyComp() {',
+				'\treturn <div>hello</div>;',
+				'}',
+				'',
+			].join('\n'),
+		);
+
+		const location = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+		});
+		expect(location.source).toBe('MyComp.tsx');
+		expect(location.line).toBe(1);
+		expect(location.column).toBe(16);
+		expect(location.canAddSequence).toBe(true);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
+test('resolves renamed local re-export of imported composition components', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './barrel';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'barrel.tsx'),
+			["import {Inner as MyComp} from './Inner';", 'export {MyComp};', ''].join(
+				'\n',
+			),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Inner.tsx'),
+			[
+				'export const Inner: React.FC = () => {',
+				'\treturn <div>hello</div>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const location = await resolveCompositionComponent({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+		});
+		expect(location.source).toBe('Inner.tsx');
+		expect(location.line).toBe(1);
+		expect(location.canAddSequence).toBe(true);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('resolves through fallback re-export branch after cycle', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {


### PR DESCRIPTION
Closes #9172

## Summary

Studio was reporting the wrong source location for compositions that live behind a local re-export barrel, for example:

```ts
import {ApplicationSimpleApp} from './Applications/SimpleApp';
export function Applications() { /* ... */ }
export {ApplicationSimpleApp};
```

`ApplicationSimpleApp` resolved to `Applications.tsx:1` instead of `Applications/SimpleApp.tsx`, because the resolver understood `export {X} from './mod'` but not `import {X} from './mod'; export {X}`.

This change:

- Follows local `export {X}` specifiers (no `from`) back through their matching import
- Prefers the identifier `loc` when Recast leaves `loc` null on `export function` / `export class` nodes (so `Applications` lands on the real function line instead of line 1)

## Verification

```
$ bun test packages/studio-server/src/test/resolve-composition-component.test.ts
 37 pass
 0 fail
 155 expect() calls
Ran 37 tests across 1 file.
```

Includes a regression test that mirrors the Applications.tsx / Applications/SimpleApp.tsx layout from the issue.

This fix was developed with AI assistance (Cursor / Grok) and verified locally as shown above.
