### PR TITLE
@remotion/transitions: Add trimBefore to TransitionSeries.Sequence

### DIFF
--- a/packages/docs/docs/transitions/transitionseries.mdx
+++ b/packages/docs/docs/transitions/transitionseries.mdx
@@ -89,7 +89,7 @@ The `<TransitionSeries>` component can only contain `<TransitionSeries.Sequence>
 
 ### `<TransitionSeries.Sequence>`
 
-Inherits the [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`className`](/docs/sequence#classname), [`style`](/docs/sequence#style), [`showInTimeline`](/docs/sequence#showintimeline), [`freeze`](/docs/sequence#freeze), [`premountFor`](/docs/sequence#premountfor), [`postmountFor`](/docs/sequence#postmountfor) and [`layout`](/docs/sequence#layout) props from [`<Sequence>`](/docs/sequence).
+Inherits the [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`className`](/docs/sequence#classname), [`style`](/docs/sequence#style), [`showInTimeline`](/docs/sequence#showintimeline), [`freeze`](/docs/sequence#freeze), [`trimBefore`](/docs/sequence#trimbefore), [`premountFor`](/docs/sequence#premountfor), [`postmountFor`](/docs/sequence#postmountfor) and [`layout`](/docs/sequence#layout) props from [`<Sequence>`](/docs/sequence).
 
 As children, put the contents of your scene.
 

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -131,7 +131,7 @@ type SeriesSequenceProps = PropsWithChildren<
 	} & LayoutBasedProps &
 		Pick<
 			SequencePropsWithoutDuration,
-			'name' | 'showInTimeline' | 'freeze' | 'hidden'
+			'name' | 'showInTimeline' | 'freeze' | 'hidden' | 'trimBefore'
 		>
 >;
 
@@ -152,6 +152,7 @@ const transitionSeriesSequenceSchema = {
 	hidden: Internals.sequenceSchema.hidden,
 	showInTimeline: Internals.sequenceSchema.showInTimeline,
 	freeze: Internals.freezeField,
+	trimBefore: Internals.sequenceSchema.trimBefore,
 	layout: Internals.sequenceSchema.layout,
 } as const satisfies InteractivitySchema;
 

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -25,6 +25,23 @@ type RegisteredSequence = {
 	readonly controls: SequenceControls | null;
 	readonly duration: number;
 	readonly from: number;
+	readonly trimBefore: number | null;
+};
+
+const waitForRegistered = async (
+	registeredSequences: readonly RegisteredSequence[],
+	predicate: (sequences: readonly RegisteredSequence[]) => boolean,
+) => {
+	const deadline = Date.now() + 2000;
+	while (Date.now() < deadline) {
+		if (predicate(registeredSequences)) {
+			return;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+
+	throw new Error('Timed out waiting for sequence registration');
 };
 
 const remotionEnvironment = {
@@ -158,7 +175,13 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 		</SequenceTestWrapper>,
 	);
 
-	await new Promise((resolve) => setTimeout(resolve, 0));
+	await waitForRegistered(registeredSequences, (sequences) =>
+		sequences.some(
+			(sequence) =>
+				sequence.displayName === '<TS.Sequence>' &&
+				sequence.getStack() === childSequenceStack,
+		),
+	);
 
 	root.unmount();
 
@@ -233,7 +256,12 @@ test('TransitionSeries.Transition and Overlay register at their rendered timelin
 		</SequenceTestWrapper>,
 	);
 
-	await new Promise((resolve) => setTimeout(resolve, 10));
+	await waitForRegistered(
+		registeredSequences,
+		(sequences) =>
+			sequences.some((sequence) => sequence.getStack() === transitionStack) &&
+			sequences.some((sequence) => sequence.getStack() === overlayStack),
+	);
 
 	const transition = registeredSequences.find(
 		(sequence) => sequence.getStack() === transitionStack,
@@ -317,7 +345,12 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 		propStatuses: {},
 		dragOverrides: {},
 	});
-	await new Promise((resolve) => setTimeout(resolve, 10));
+	await waitForRegistered(registeredSequences, (sequences) =>
+		sequences.some(
+			(sequence) =>
+				sequence.getStack() === firstStack && sequence.controls !== null,
+		),
+	);
 
 	const firstSequence = registeredSequences.find(
 		(sequence) => sequence.getStack() === firstStack,
@@ -358,7 +391,14 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 
 	registeredSequences.length = 0;
 	renderTransitionSeries(makeDurationOverride(15));
-	await new Promise((resolve) => setTimeout(resolve, 10));
+	await waitForRegistered(
+		registeredSequences,
+		(sequences) =>
+			sequences.some(
+				(sequence) =>
+					sequence.getStack() === firstStack && sequence.duration === 15,
+			) && sequences.some((sequence) => sequence.getStack() === secondStack),
+	);
 
 	const updatedFirstSequence = registeredSequences.find(
 		(sequence) => sequence.getStack() === firstStack,
@@ -379,7 +419,12 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 
 	registeredSequences.length = 0;
 	renderTransitionSeries(makeDurationOverride(18));
-	await new Promise((resolve) => setTimeout(resolve, 10));
+	await waitForRegistered(registeredSequences, (sequences) =>
+		sequences.some(
+			(sequence) =>
+				sequence.getStack() === firstStack && sequence.duration === 18,
+		),
+	);
 
 	const repeatedlyUpdatedFirstSequence = registeredSequences.find(
 		(sequence) => sequence.getStack() === firstStack,
@@ -395,4 +440,87 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 	expect(repeatedlyUpdatedSecondSequence?.from).toBe(13);
 
 	root.unmount();
+});
+
+test('TransitionSeries.Sequence owns trimBefore without shifting later sequences', async () => {
+	const registeredSequences: RegisteredSequence[] = [];
+	const div = document.createElement('div');
+	const root = createRoot(div);
+	const firstStack = 'Error\n    at FirstTrimBeforeSequence';
+	const secondStack = 'Error\n    at SecondTrimBeforeSequence';
+	const transitionStack = 'Error\n    at TrimBeforeTransition';
+
+	root.render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+			overrideIdToNodePathMappings={{}}
+			propStatuses={{}}
+			dragOverrides={{}}
+		>
+			<TransitionSeries>
+				<TransitionSeries.Sequence
+					durationInFrames={40}
+					trimBefore={12}
+					{...({stack: firstStack} as {readonly stack: string})}
+				>
+					First
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Transition
+					timing={linearTiming({durationInFrames: 10})}
+					{...({stack: transitionStack} as {readonly stack: string})}
+				/>
+				<TransitionSeries.Sequence
+					durationInFrames={30}
+					{...({stack: secondStack} as {readonly stack: string})}
+				>
+					Second
+				</TransitionSeries.Sequence>
+			</TransitionSeries>
+		</SequenceTestWrapper>,
+	);
+
+	await waitForRegistered(
+		registeredSequences,
+		(sequences) =>
+			sequences.some(
+				(sequence) =>
+					sequence.getStack() === firstStack && sequence.trimBefore === 12,
+			) &&
+			sequences.some((sequence) => sequence.getStack() === secondStack) &&
+			sequences.some((sequence) => sequence.getStack() === transitionStack),
+	);
+
+	const firstSequence = registeredSequences.find(
+		(sequence) => sequence.getStack() === firstStack,
+	);
+	const secondSequence = registeredSequences.find(
+		(sequence) => sequence.getStack() === secondStack,
+	);
+	const transition = registeredSequences.find(
+		(sequence) => sequence.getStack() === transitionStack,
+	);
+
+	root.unmount();
+
+	expect(firstSequence?.displayName).toBe('<TS.Sequence>');
+	expect(firstSequence?.controls?.componentIdentity).toBe(
+		'dev.remotion.transitions.TransitionSeries.Sequence',
+	);
+	expect(firstSequence?.trimBefore).toBe(12);
+	expect(
+		firstSequence?.controls?.currentRuntimeValueDotNotation.trimBefore,
+	).toBe(12);
+	expect(firstSequence?.controls?.schema).toHaveProperty('trimBefore');
+	expect(firstSequence?.from).toBe(0);
+	expect(firstSequence?.duration).toBe(40);
+
+	// Sequential timing still follows durationInFrames and transition overlap,
+	// not the trimBefore source offset.
+	expect(transition?.from).toBe(30);
+	expect(transition?.duration).toBe(10);
+	expect(secondSequence?.from).toBe(30);
+	expect(secondSequence?.duration).toBe(30);
+	expect(secondSequence?.trimBefore).toBe(null);
 });

--- a/packages/transitions/src/test/transitions.test.tsx
+++ b/packages/transitions/src/test/transitions.test.tsx
@@ -1,5 +1,5 @@
 import {expect, test} from 'bun:test';
-import {AbsoluteFill} from 'remotion';
+import {AbsoluteFill, useCurrentFrame} from 'remotion';
 import {fade} from '../presentations/fade.js';
 import {linearTiming} from '../timings/linear-timing.js';
 import {TransitionSeries} from '../TransitionSeries.js';
@@ -89,4 +89,33 @@ test('TransitionSeries.Sequence ignores a from prop passed from JavaScript', () 
 	);
 
 	expect(outerHTML).toContain('D');
+});
+
+test('TransitionSeries.Sequence trimBefore shifts child frames without moving later sequences', () => {
+	const FrameLabel: React.FC<{readonly label: string}> = ({label}) => {
+		const frame = useCurrentFrame();
+		return <div>{`${label}${frame}`}</div>;
+	};
+
+	const content = (
+		<TransitionSeries>
+			<TransitionSeries.Sequence durationInFrames={40} trimBefore={12}>
+				<FrameLabel label="first" />
+			</TransitionSeries.Sequence>
+			<TransitionSeries.Transition
+				presentation={fade({})}
+				timing={linearTiming({durationInFrames: 10})}
+			/>
+			<TransitionSeries.Sequence durationInFrames={30}>
+				<FrameLabel label="second" />
+			</TransitionSeries.Sequence>
+		</TransitionSeries>
+	);
+
+	expect(renderForFrame(0, content)).toContain('first12');
+	expect(renderForFrame(1, content)).toContain('first13');
+	// Second sequence still starts at frame 30 after the 10-frame overlap.
+	expect(renderForFrame(29, content)).not.toContain('second');
+	expect(renderForFrame(30, content)).toContain('second0');
+	expect(renderForFrame(31, content)).toContain('second1');
 });


### PR DESCRIPTION
## Summary

Fixes #9140

`<TransitionSeries.Sequence>` now accepts `trimBefore`, forwards it to the underlying `<Sequence>`, and exposes it in the interactivity schema so Studio can edit it. Sequential timing and transition overlaps still follow `durationInFrames`.

## AI assistance

This PR was prepared with AI assistance (Cursor/Grok). I reviewed the change, ran the targeted tests below, and take responsibility for the result.

## Verification / Evidence

```text
cd packages/transitions
bun test src/test/transitions.test.tsx src/test/transition-series-stack.test.tsx

# three consecutive runs:
8 pass
0 fail
Ran 8 tests across 2 files.
```

Covering PR search before publish: no open PR for 9140 / "trimBefore TransitionSeries".

## Notes

- Left-edge drag behavior for TransitionSeries sequences (where `from` is computed by the series) is out of scope for this PR, as noted in the issue.
