### PR TITLE
Docs: Document Studio canvas snapping tricks

### DIFF
--- a/packages/docs/docs/studio/interactivity.mdx
+++ b/packages/docs/docs/studio/interactivity.mdx
@@ -1,7 +1,7 @@
 ---
 image: /generated/articles-docs-studio-interactivity.png
 title: Interactivity
-crumb: "Remotion Studio"
+crumb: 'Remotion Studio'
 ---
 
 # Interactivity<AvailableFrom v="4.0.475" />
@@ -28,6 +28,8 @@ To make a custom component selectable and editable, see [Make a component intera
 - Drag selected outlines to move sequences by updating `style.translate`.
 - Move multiple selected sequences together.
 - Hold <kbd>Shift</kbd> while dragging outlines to lock movement to one axis.
+- Toggle snapping with the magnet icon in the preview toolbar. When snapping is on, dragged outlines snap to helpful guides.
+- Hold <kbd>⌘/Ctrl</kbd> while dragging outlines to temporarily disable snapping (useful when snapping is enabled but you need free placement for one move).
 - Drag outline edges to scale selected sequences when `style.scale` is editable.
 - Drag outline corners to rotate selected sequences when `style.rotate` is editable.
 - Drag the transform-origin handle to move the transform origin. Studio compensates `style.translate` so the visual position stays stable.

--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -300,6 +300,12 @@ Pause and return to where playback started
   <tr>
     <td>
       <kbd>⌘/Ctrl</kbd>
+    </td>
+    <td>Temporarily disable snapping while dragging canvas outlines</td>
+  </tr>
+  <tr>
+    <td>
+      <kbd>⌘/Ctrl</kbd>
       <div style={{width: 2, display: 'inline-block'}} />
       <kbd>D</kbd>
     </td>

--- a/packages/docs/docs/visual-editing.mdx
+++ b/packages/docs/docs/visual-editing.mdx
@@ -21,6 +21,8 @@ Use the controls in the props editor to live-update the default props of your co
 
 When editing a `<Sequence>` visually in the timeline, the visual style controls include offset, scale, rotation, transform origin, and opacity. Select the transform origin row or one of its keyframes to drag the pivot handle in the canvas.
 
+For canvas dragging tricks (axis lock, temporary snap disable, and more), see [Interactivity](/docs/studio/interactivity).
+
 ## Supported controls
 
 Controls are implemented for:


### PR DESCRIPTION
Closes #8878

## Summary

Documents a couple of Studio canvas editing tricks that were easy to miss:

- Toggle snapping with the magnet icon in the preview toolbar
- Hold `Cmd/Ctrl` while dragging outlines to temporarily disable snapping when snapping is enabled
- Shortcut table entry for the same tip
- Cross-link from the visual editing page to Interactivity

## Verification

Confirmed in Studio source that canvas outline dragging sets `snappingDisabled` from `metaKey || ctrlKey` while `editorSnapping` is on (`SelectedOutlineElement.tsx`).

Prettier 3.8.1 (repo MDX options: `useTabs: false`, `printWidth: 300`):

```
Checking formatting...
All matched files use Prettier code style!
```

Touched files:

- `packages/docs/docs/studio/interactivity.mdx`
- `packages/docs/docs/studio/shortcuts.mdx`
- `packages/docs/docs/visual-editing.mdx`

Docs-only change; no package behavior changed.

This fix was developed with AI assistance (Cursor / Grok) and verified locally as shown above.