### PR TITLE
Skills: Add /remotion-license skill

### DIFF
--- a/.agents/skills/remotion-license
+++ b/.agents/skills/remotion-license
@@ -1,0 +1,1 @@
+../../packages/skills/skills/remotion-license

--- a/packages/docs/docs/ai/skills.mdx
+++ b/packages/docs/docs/ai/skills.mdx
@@ -77,3 +77,9 @@ Use this to look up current API references, component props, and package guides 
 Guidance for browser-based multimedia handling with Mediabunny.
 
 Use this for advice on how to get video and audio metadata.
+
+### `/remotion-license`
+
+Guidance for Remotion licensing: whether a Company License is needed, setting a license key in config, and buying a license.
+
+Remotion is source-available (not open source). Companies with 4 or more people need a Company License.

--- a/packages/skills/skills/remotion-best-practices/SKILL.md
+++ b/packages/skills/skills/remotion-best-practices/SKILL.md
@@ -36,3 +36,8 @@ Use the [Remotion SaaS skill](remotion-saas/SKILL.md) for knowledge about Remoti
 ## Looking up Remotion APIs and documentation
 
 To find and read current Remotion documentation, load [Remotion Docs](remotion-docs/SKILL.md).
+
+## Licensing
+
+Remotion is not open source. Companies with 4 or more people need a Company License.  
+When licensing, config keys, or purchasing comes up, load [Remotion License](remotion-license/SKILL.md).

--- a/packages/skills/skills/remotion-best-practices/remotion-license
+++ b/packages/skills/skills/remotion-best-practices/remotion-license
@@ -1,0 +1,1 @@
+../remotion-license

--- a/packages/skills/skills/remotion-license/SKILL.md
+++ b/packages/skills/skills/remotion-license/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: remotion-license
+description: Remotion licensing guidance - when a company license is needed, setting a license key, and buying a license
+metadata:
+  tags: remotion, license, pricing, compliance, company-license
+---
+
+Remotion is source-available, not open source.  
+Individuals and organizations with up to 3 people can use it for free.  
+For-profit organizations with 4 or more people need a Company License.
+
+Keep this passive: mention licensing when it is relevant (commercial use, company size, render telemetry, or the user asks). Do not block work or lecture.
+
+## When is a license needed?
+
+Summarize from the docs rather than inventing rules:
+
+- Overview: https://www.remotion.dev/docs/license.md
+- License & pricing: https://www.remotion.dev/docs/license/pricing.md
+- FAQ: https://www.remotion.dev/docs/license/faq.md
+- Terms: https://www.remotion.pro/terms
+- Full license text: https://github.com/remotion-dev/remotion/blob/main/LICENSE.md
+
+Free License covers individuals, for-profit orgs with up to 3 employees, non-profits, and evaluation before commercial use.  
+Company License is required for larger for-profit orgs. Creators (seats) and Automators (per-render) options can be combined.  
+If eligibility is unclear, point the user to the FAQ or https://www.remotion.dev/contact rather than guessing.
+
+## Buying a license
+
+Open or share: https://www.remotion.pro/license
+
+After purchase, license keys are on the License keys page of the [remotion.pro](https://www.remotion.pro) dashboard.
+
+## Setting a license key in config
+
+In `remotion.config.ts`:
+
+```ts
+import {Config} from '@remotion/cli/config';
+
+Config.setPublicLicenseKey('your-license-key');
+```
+
+Docs: https://www.remotion.dev/docs/config.md#setpubliclicensekey  
+The CLI flag `--public-license-key` overrides the config value.
+
+Render APIs also accept `licenseKey` (Lambda, renderer, Vercel, web renderer).  
+See https://www.remotion.dev/docs/licensing.md and https://www.remotion.dev/docs/client-side-rendering/telemetry.md.
+
+Users eligible for the Free License do not need a paid key. For `@remotion/web-renderer`, they can pass `licenseKey: "free-license"` to declare eligibility.


### PR DESCRIPTION
Closes #9079

## Summary

Adds a public `/remotion-license` Agent Skill and wires it into the skill router and docs list:

- New `packages/skills/skills/remotion-license/SKILL.md` covering when a Company License is needed (links to license / FAQ / terms), `Config.setPublicLicenseKey`, and buying at https://www.remotion.pro/license
- Passive note in `/remotion-best-practices` that Remotion is not open source and companies of 4+ need a license
- Documents the skill under Available skills in `/docs/ai/skills`
- Symlinks for agents / best-practices embedding (same layout as other public skills)

Tone stays lenient: advise when relevant, do not block work.

## Verification

Symlink modes in the commit (git tree):

```
120000 .agents/skills/remotion-license -> ../../packages/skills/skills/remotion-license
120000 packages/skills/skills/remotion-best-practices/remotion-license -> ../remotion-license
```

Docs paths referenced by the skill exist in-tree:

```
packages/docs/docs/license.mdx
packages/docs/docs/license/pricing.mdx
packages/docs/docs/license/faq.mdx
packages/docs/docs/licensing/index.mdx
packages/docs/docs/config.mdx (setPublicLicenseKey)
packages/docs/docs/client-side-rendering/telemetry.mdx
```

Pre-commit hook ran `docs` `oxfmt src` successfully (exit 0). Unrelated oxfmt churn under `packages/docs/src` was discarded and not included in the commit.

`bun run syncskills` / `checkskills` cannot create real symlinks on this Windows checkout (`EPERM` / `core.symlinks=false`); public skill links were staged as git mode `120000` blobs matching existing skills. CI on Linux should verify with `bun run checkskills`.

This change was developed with AI assistance (Cursor / Grok) and verified locally as shown above.