### PR TITLE
Docs: Document Element width, height, and duration

### DIFF
--- a/packages/docs/elements/guidelines.mdx
+++ b/packages/docs/elements/guidelines.mdx
@@ -16,7 +16,17 @@ An Element should demonstrate one visual idea, technique, or workflow. It should
 
 If two variants are worth showing, prefer two separate Elements over a variant prop.
 
-The Elements gallery provides the preview dimensions, frame rate, and duration. The Element itself should remain a building block.
+The Elements gallery provides the preview composition size, frame rate, and duration. The Element itself should remain a building block.
+
+## Width, height, and duration
+
+Each Element page lists width, height, and duration. All three can be omitted or set:
+
+- Omit a value to inherit from the composition. In the docs preview this means leaving that prop off the wrapping [`<Sequence>`](/docs/sequence), so children see [`useVideoConfig()`](/docs/use-video-config) values.
+- Set width and/or height when the Element needs a fixed bounding box.
+- Set duration when the Element has a finite timing (for example entrance and exit animations). Omit duration when the Element should stay mounted for as long as its surrounding sequence.
+
+Background Elements usually omit width, height, and duration. Overlay and text Elements usually set all three.
 
 ## Make it portable
 

--- a/packages/docs/elements/index.mdx
+++ b/packages/docs/elements/index.mdx
@@ -16,6 +16,8 @@ Remotion Elements are drop-in, HTML-first Remotion components designed to be pla
 
 They are practical video building blocks: captions, lower thirds, overlays, callouts, transitions, data cards, audio visuals, and title cards.
 
+Each Element page shows its width, height, and duration assumptions. Any of those can be omitted so the Element inherits from the composition through [`useVideoConfig()`](/docs/use-video-config), or set when the Element needs a fixed size or timing. See the [Element Guidelines](/elements/guidelines#width-height-and-duration) for details.
+
 Browse the categories in the sidebar to find an Element for your project.
 
 To learn what makes a useful, portable Element, read the [Element Guidelines](/elements/guidelines).

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -12,7 +12,11 @@ import React, {
 import {BlueButton, PlainButton} from '../../../components/layout/Button';
 import type {ElementDefinition} from './element-definitions';
 import {setElementDragData, setElementDragImage} from './element-drag-data';
-import {getElementDimensionsLabel} from './element-utils';
+import {
+	getElementDurationLabel,
+	getElementHeightLabel,
+	getElementWidthLabel,
+} from './element-utils';
 import {ElementPreview} from './ElementPreview';
 import {
 	ElementPreviewComposition,
@@ -318,8 +322,16 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 						<p className={styles.description}>{description}</p>
 						<dl className={styles.metadata}>
 							<div>
-								<dt>Dimensions</dt>
-								<dd>{getElementDimensionsLabel(definition)}</dd>
+								<dt>Width</dt>
+								<dd>{getElementWidthLabel(definition)}</dd>
+							</div>
+							<div>
+								<dt>Height</dt>
+								<dd>{getElementHeightLabel(definition)}</dd>
+							</div>
+							<div>
+								<dt>Duration</dt>
+								<dd>{getElementDurationLabel(definition)}</dd>
 							</div>
 						</dl>
 					</div>

--- a/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
+++ b/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
@@ -21,22 +21,37 @@ export const getElementPreviewDimensions = (definition: ElementDefinition) => {
 	};
 };
 
+const getElementSequenceProps = (definition: ElementDefinition) => {
+	const {elementDurationInFrames, elementHeight, elementWidth} = definition;
+
+	return {
+		...(elementWidth === null ? {} : {width: elementWidth}),
+		...(elementHeight === null ? {} : {height: elementHeight}),
+		...(elementDurationInFrames === null
+			? {}
+			: {durationInFrames: elementDurationInFrames}),
+	};
+};
+
 export const ElementPreviewComposition: React.FC<{
 	readonly definition: ElementDefinition;
 }> = ({definition}) => {
 	const {
 		component: Component,
+		elementDurationInFrames,
 		elementHeight,
 		elementWidth,
 		previewPadding,
 	} = definition;
 	const hasElementDimensions = elementWidth !== null && elementHeight !== null;
+	const hasElementDuration = elementDurationInFrames !== null;
+	const sequenceProps = getElementSequenceProps(definition);
 
-	if (!hasElementDimensions) {
+	if (!hasElementDimensions && !hasElementDuration) {
 		return <Component />;
 	}
 
-	if (previewPadding > 0) {
+	if (hasElementDimensions && previewPadding > 0) {
 		return (
 			<AbsoluteFill
 				style={{
@@ -44,12 +59,12 @@ export const ElementPreviewComposition: React.FC<{
 					justifyContent: 'center',
 				}}
 			>
-				<Sequence height={elementHeight} layout="none" width={elementWidth}>
+				<Sequence {...sequenceProps} layout="none">
 					<div
 						style={{
-							height: elementHeight,
+							height: elementHeight!,
 							position: 'relative',
-							width: elementWidth,
+							width: elementWidth!,
 						}}
 					>
 						<Component />
@@ -60,7 +75,7 @@ export const ElementPreviewComposition: React.FC<{
 	}
 
 	return (
-		<Sequence height={elementHeight} width={elementWidth}>
+		<Sequence {...sequenceProps}>
 			<Component />
 		</Sequence>
 	);

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -18,6 +18,7 @@ export type ElementDefinition = {
 	readonly description: string;
 	readonly displayName: string;
 	readonly durationInFrames: number;
+	readonly elementDurationInFrames: number | null;
 	readonly elementHeight: number | null;
 	readonly elementWidth: number | null;
 	readonly fps: number;
@@ -37,6 +38,7 @@ export const elementDefinitions = {
 			'A flowing two-color background made from animated liquid contour bands.',
 		displayName: 'Liquid Contours',
 		durationInFrames: 240,
+		elementDurationInFrames: null,
 		elementHeight: null,
 		elementWidth: null,
 		fps: 30,
@@ -53,6 +55,7 @@ export const elementDefinitions = {
 		description: 'A white paper background with subtle blue gridlines.',
 		displayName: 'Notebook Paper',
 		durationInFrames: 120,
+		elementDurationInFrames: null,
 		elementHeight: null,
 		elementWidth: null,
 		fps: 30,
@@ -70,6 +73,7 @@ export const elementDefinitions = {
 			'A white paper texture background with a slowly changing posterized seed.',
 		displayName: 'Paper Texture',
 		durationInFrames: 120,
+		elementDurationInFrames: null,
 		elementHeight: null,
 		elementWidth: null,
 		fps: 30,
@@ -86,6 +90,7 @@ export const elementDefinitions = {
 		description: 'A solid background with a slowly rotating starburst effect.',
 		displayName: 'Rotating Starburst',
 		durationInFrames: 240,
+		elementDurationInFrames: null,
 		elementHeight: null,
 		elementWidth: null,
 		fps: 30,
@@ -103,6 +108,7 @@ export const elementDefinitions = {
 			'A clean animated lower third for introducing a speaker, guest, or section.',
 		displayName: 'Lower Third',
 		durationInFrames: 120,
+		elementDurationInFrames: 120,
 		elementHeight: 138,
 		elementWidth: 680,
 		fps: 30,
@@ -125,6 +131,7 @@ export const elementDefinitions = {
 			'A simple animated counter that smoothly counts from a start value to an end value.',
 		displayName: 'Number Counter',
 		durationInFrames: 120,
+		elementDurationInFrames: 120,
 		elementHeight: 200,
 		elementWidth: 640,
 		fps: 30,
@@ -142,6 +149,7 @@ export const elementDefinitions = {
 			'An animated hand-drawn circle with posterized drawing progress and shape changes.',
 		displayName: 'Circle Marker',
 		durationInFrames: 120,
+		elementDurationInFrames: 120,
 		elementHeight: 220,
 		elementWidth: 900,
 		fps: 30,
@@ -159,6 +167,7 @@ export const elementDefinitions = {
 			'An animated hand-drawn cross for removing a word or phrase with emphasis.',
 		displayName: 'Crossed Off',
 		durationInFrames: 120,
+		elementDurationInFrames: 120,
 		elementHeight: 220,
 		elementWidth: 900,
 		fps: 30,
@@ -176,6 +185,7 @@ export const elementDefinitions = {
 			'An animated hand-drawn line for striking through a word or phrase.',
 		displayName: 'Strike Through',
 		durationInFrames: 120,
+		elementDurationInFrames: 120,
 		elementHeight: 220,
 		elementWidth: 900,
 		fps: 30,
@@ -193,6 +203,7 @@ export const elementDefinitions = {
 			'A hand-drawn animated text marker for calling attention to one phrase.',
 		displayName: 'Text Marker',
 		durationInFrames: 120,
+		elementDurationInFrames: 120,
 		elementHeight: 220,
 		elementWidth: 900,
 		fps: 30,

--- a/packages/docs/src/components/Elements/element-utils.ts
+++ b/packages/docs/src/components/Elements/element-utils.ts
@@ -3,12 +3,41 @@ import {
 	type ElementDefinition,
 } from './element-definitions';
 
+export const getElementWidthLabel = (definition: ElementDefinition) => {
+	if (definition.elementWidth === null) {
+		return 'Adapts to composition';
+	}
+
+	return `${definition.elementWidth}px`;
+};
+
+export const getElementHeightLabel = (definition: ElementDefinition) => {
+	if (definition.elementHeight === null) {
+		return 'Adapts to composition';
+	}
+
+	return `${definition.elementHeight}px`;
+};
+
 export const getElementDimensionsLabel = (definition: ElementDefinition) => {
 	if (definition.elementWidth === null || definition.elementHeight === null) {
 		return 'Adapts to composition';
 	}
 
 	return `${definition.elementWidth} × ${definition.elementHeight}px`;
+};
+
+export const getElementDurationLabel = (definition: ElementDefinition) => {
+	if (definition.elementDurationInFrames === null) {
+		return 'Adapts to composition';
+	}
+
+	const seconds = definition.elementDurationInFrames / definition.fps;
+	const secondsLabel = Number.isInteger(seconds)
+		? `${seconds}s`
+		: `${seconds.toFixed(2)}s`;
+
+	return `${definition.elementDurationInFrames} frames (${secondsLabel} at ${definition.fps}fps)`;
 };
 
 export const getElementCompositionId = (slug: string) => {

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -10,7 +10,10 @@ import {elementDefinitions} from '../components/Elements/element-definitions';
 import {
 	getElementCompositionId,
 	getElementDimensionsLabel,
+	getElementDurationLabel,
+	getElementHeightLabel,
 	getElementPreviewUrls,
+	getElementWidthLabel,
 } from '../components/Elements/element-utils';
 import {getElementPreviewDimensions} from '../components/Elements/ElementPreviewComposition';
 
@@ -238,6 +241,13 @@ describe('Element preview definitions', () => {
 			expect(definition.elementWidth === null).toBe(
 				definition.elementHeight === null,
 			);
+			if (definition.elementDurationInFrames !== null) {
+				expect(Number.isInteger(definition.elementDurationInFrames)).toBe(true);
+				expect(definition.elementDurationInFrames).toBeGreaterThan(0);
+				expect(definition.elementDurationInFrames).toBeLessThanOrEqual(
+					definition.durationInFrames,
+				);
+			}
 
 			const dimensions = getElementPreviewDimensions(definition);
 			expect(dimensions.width % 2).toBe(0);
@@ -250,6 +260,15 @@ describe('Element preview definitions', () => {
 		expect(getElementDimensionsLabel(adaptiveDefinition)).toBe(
 			'Adapts to composition',
 		);
+		expect(getElementWidthLabel(adaptiveDefinition)).toBe(
+			'Adapts to composition',
+		);
+		expect(getElementHeightLabel(adaptiveDefinition)).toBe(
+			'Adapts to composition',
+		);
+		expect(getElementDurationLabel(adaptiveDefinition)).toBe(
+			'Adapts to composition',
+		);
 		expect(getElementPreviewDimensions(adaptiveDefinition)).toEqual({
 			height: 1080,
 			width: 1920,
@@ -257,6 +276,11 @@ describe('Element preview definitions', () => {
 
 		const fixedDefinition = elementDefinitions['overlays/lower-third'];
 		expect(getElementDimensionsLabel(fixedDefinition)).toBe('680 × 138px');
+		expect(getElementWidthLabel(fixedDefinition)).toBe('680px');
+		expect(getElementHeightLabel(fixedDefinition)).toBe('138px');
+		expect(getElementDurationLabel(fixedDefinition)).toBe(
+			'120 frames (4s at 30fps)',
+		);
 		expect(getElementPreviewDimensions(fixedDefinition)).toEqual({
 			height: 738,
 			width: 1280,
@@ -277,6 +301,7 @@ describe('Element preview definitions', () => {
 			const source = readFileSync(element.tsxPath, 'utf8');
 			expect(definition.elementWidth).toBe(null);
 			expect(definition.elementHeight).toBe(null);
+			expect(definition.elementDurationInFrames).toBe(null);
 			expect(source).toContain('useVideoConfig()');
 			expect(source).not.toContain(`width={${definition.width}}`);
 			expect(source).not.toContain(`height={${definition.height}}`);


### PR DESCRIPTION
Closes #8828

## Summary

Documents width, height, and duration assumptions for Remotion Elements:

- Element pages show Width, Height, and Duration (or "Adapts to composition" when omitted)
- Guidelines explain that all three can be omitted (inherit via `useVideoConfig()` / omit props on the wrapping `<Sequence>`) or set when needed
- Preview compositions pass `durationInFrames` on the wrapping `<Sequence>` when `elementDurationInFrames` is set, matching the existing optional width/height behavior

## Verification

Prettier 3.8.1 (repo `.prettierrc.js`):

```
Checking formatting...
All matched files use Prettier code style!
```

MDX compile with `@mdx-js/mdx` + `remark-gfm`:

```
OK packages/docs/elements/guidelines.mdx
OK packages/docs/elements/index.mdx
MDX COMPILE OK
```

Focused checks for label strings and Sequence prop omission (adaptive vs fixed vs size-only):

```
LABEL TESTS OK
SEQUENCE PROPS OK
```

Full `bun test src/test/elements.test.ts` could not load in this worktree because `@remotion/google-fonts` dist is not built here (pre-existing; same failure on an unrelated sibling worktree). Updated assertions are in `packages/docs/src/test/elements.test.ts`.

Touched files:

- `packages/docs/elements/guidelines.mdx`
- `packages/docs/elements/index.mdx`
- `packages/docs/src/components/Elements/ElementPage.tsx`
- `packages/docs/src/components/Elements/ElementPreviewComposition.tsx`
- `packages/docs/src/components/Elements/element-definitions.ts`
- `packages/docs/src/components/Elements/element-utils.ts`
- `packages/docs/src/test/elements.test.ts`

This fix was developed with AI assistance (Cursor / Grok) and verified locally as shown above.
