### PR TITLE
@remotion/studio: Prevent filmstrip jitter while dragging the left edge

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
@@ -19,6 +19,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import type {LoopDisplay} from 'remotion';
 import {useVideoConfig} from 'remotion';
 import {BLACK_ALPHA_30} from '../../helpers/colors';
+import {getFilmstripLayoutWidth} from '../../helpers/filmstrip-layout-width';
 import {
 	TIMELINE_LAYER_FILMSTRIP_HEIGHT,
 	TIMELINE_VIDEO_INFO_WAVEFORM_HEIGHT,
@@ -79,6 +80,7 @@ export const TimelineVideoInfo: React.FC<{
 }) => {
 	const {fps} = useVideoConfig();
 	const ref = useRef<HTMLDivElement>(null);
+	const canvasRef = useRef<HTMLCanvasElement | null>(null);
 	const [error, setError] = useState<Error | null>(null);
 	const aspectRatio = useRef<number | null>(getAspectRatioFromCache(src));
 	const mediaStartFrame = getTimelineMediaStartFrame({
@@ -95,6 +97,20 @@ export const TimelineVideoInfo: React.FC<{
 			postmountWidth,
 		});
 	}, [naturalWidth, postmountWidth, premountWidth, visualizationWidth]);
+	const filmstripLayoutWidth = useMemo(() => {
+		return getFilmstripLayoutWidth(mediaNaturalWidth);
+	}, [mediaNaturalWidth]);
+
+	useEffect(() => {
+		return () => {
+			const canvas = canvasRef.current;
+			if (canvas?.parentNode) {
+				canvas.parentNode.removeChild(canvas);
+			}
+
+			canvasRef.current = null;
+		};
+	}, []);
 
 	// for rendering frames
 	useEffect(() => {
@@ -109,7 +125,13 @@ export const TimelineVideoInfo: React.FC<{
 
 		const controller = new AbortController();
 
-		const canvas = document.createElement('canvas');
+		let canvas = canvasRef.current;
+		if (!canvas || !current.contains(canvas)) {
+			canvas = document.createElement('canvas');
+			canvasRef.current = canvas;
+			current.appendChild(canvas);
+		}
+
 		canvas.width = mediaVisualizationWidth;
 		canvas.height = TIMELINE_LAYER_FILMSTRIP_HEIGHT;
 		const ctx = canvas.getContext('2d');
@@ -117,7 +139,7 @@ export const TimelineVideoInfo: React.FC<{
 			return;
 		}
 
-		current.appendChild(canvas);
+		ctx.clearRect(0, 0, canvas.width, canvas.height);
 
 		const drawRepeatedFrame = (frame: VideoFrame) => {
 			const thumbnailWidth = Math.max(
@@ -182,7 +204,7 @@ export const TimelineVideoInfo: React.FC<{
 				drawRepeatedFrame(cachedFrame);
 
 				return () => {
-					current.removeChild(canvas);
+					controller.abort();
 				};
 			}
 
@@ -241,12 +263,11 @@ export const TimelineVideoInfo: React.FC<{
 
 			return () => {
 				controller.abort();
-				current.removeChild(canvas);
 			};
 		}
 
 		const loopWidth = getLoopDisplayWidth({
-			visualizationWidth: mediaNaturalWidth,
+			visualizationWidth: filmstripLayoutWidth,
 			loopDisplay,
 		});
 		const shouldRepeatVideo = shouldTileLoopDisplay(loopDisplay);
@@ -259,7 +280,6 @@ export const TimelineVideoInfo: React.FC<{
 		targetCanvas.height = canvas.height;
 		const targetCtx = shouldRepeatVideo ? targetCanvas.getContext('2d') : ctx;
 		if (!targetCtx) {
-			current.removeChild(canvas);
 			return;
 		}
 
@@ -287,7 +307,7 @@ export const TimelineVideoInfo: React.FC<{
 		const {fromSeconds, toSeconds} = times;
 		const targetWidth = shouldRepeatVideo
 			? targetCanvas.width
-			: mediaNaturalWidth;
+			: filmstripLayoutWidth;
 
 		if (aspectRatio.current !== null) {
 			ensureSlots({
@@ -318,7 +338,7 @@ export const TimelineVideoInfo: React.FC<{
 			// Don't extract frames if all slots are filled
 			if (unfilled.length === 0) {
 				return () => {
-					current.removeChild(canvas);
+					controller.abort();
 				};
 			}
 		}
@@ -426,15 +446,14 @@ export const TimelineVideoInfo: React.FC<{
 
 		return () => {
 			controller.abort();
-			current.removeChild(canvas);
 		};
 	}, [
 		durationInFrames,
 		error,
+		filmstripLayoutWidth,
 		fps,
 		frozenMediaFrame,
 		loopDisplay,
-		mediaNaturalWidth,
 		mediaVisualizationWidth,
 		mediaStartFrame,
 		playbackRate,

--- a/packages/studio/src/helpers/filmstrip-layout-width.ts
+++ b/packages/studio/src/helpers/filmstrip-layout-width.ts
@@ -1,0 +1,14 @@
+import {SEQUENCE_BORDER_WIDTH} from './sequence-border-width';
+
+export {SEQUENCE_BORDER_WIDTH} from './sequence-border-width';
+
+// Filmstrip slot timing must stay proportional to media duration. Sequence
+// layout subtracts SEQUENCE_BORDER_WIDTH from track width, which would otherwise
+// make timestamp slots drift on every left-edge trim step.
+export const getFilmstripLayoutWidth = (mediaWidth: number) => {
+	if (mediaWidth <= 0) {
+		return 0;
+	}
+
+	return mediaWidth + SEQUENCE_BORDER_WIDTH;
+};

--- a/packages/studio/src/helpers/get-timeline-sequence-layout.ts
+++ b/packages/studio/src/helpers/get-timeline-sequence-layout.ts
@@ -1,7 +1,8 @@
 import type {VideoConfig} from 'remotion';
+import {SEQUENCE_BORDER_WIDTH} from './sequence-border-width';
 import {TIMELINE_PADDING} from './timeline-layout';
 
-export const SEQUENCE_BORDER_WIDTH = 1;
+export {SEQUENCE_BORDER_WIDTH} from './sequence-border-width';
 
 const getWidthOfTrack = ({
 	durationInFrames,

--- a/packages/studio/src/helpers/sequence-border-width.ts
+++ b/packages/studio/src/helpers/sequence-border-width.ts
@@ -1,0 +1,1 @@
+export const SEQUENCE_BORDER_WIDTH = 1;

--- a/packages/studio/src/test/filmstrip-layout-width.test.ts
+++ b/packages/studio/src/test/filmstrip-layout-width.test.ts
@@ -1,0 +1,28 @@
+import {expect, test} from 'bun:test';
+import {
+	getFilmstripLayoutWidth,
+	SEQUENCE_BORDER_WIDTH,
+} from '../helpers/filmstrip-layout-width';
+
+test('filmstrip layout width restores sequence border so slot timing stays proportional', () => {
+	const timelineDurationInFrames = 300;
+	const fullWidth = 1000;
+	const fps = 30;
+	const aspectRatio = 16 / 9;
+	const frameHeight = 50;
+
+	const slotDurationForTrim = (durationInFrames: number) => {
+		const mediaWidth =
+			(durationInFrames / timelineDurationInFrames) * fullWidth -
+			SEQUENCE_BORDER_WIDTH;
+		const filmstripWidth = getFilmstripLayoutWidth(mediaWidth);
+		const segmentDuration = durationInFrames / fps;
+		const framesFitInWidthUnrounded =
+			filmstripWidth / (frameHeight * aspectRatio);
+
+		return segmentDuration / framesFitInWidthUnrounded;
+	};
+
+	expect(slotDurationForTrim(47)).toBeCloseTo(slotDurationForTrim(46), 12);
+	expect(getFilmstripLayoutWidth(226)).toBe(226 + SEQUENCE_BORDER_WIDTH);
+});

--- a/packages/timeline-utils/src/index.ts
+++ b/packages/timeline-utils/src/index.ts
@@ -37,7 +37,9 @@ export {
 	ensureSlots,
 	fillFrameWhereItFits,
 	fillWithCachedFrames,
+	getBestCachedFrameKeyForTimestamp,
 	getDurationOfOneFrame,
+	MAX_TIME_DEVIATION,
 	WEBCODECS_TIMESCALE,
 } from './render-frame-strip';
 export {renderFrameStripToCanvas} from './render-frame-strip-to-canvas';

--- a/packages/timeline-utils/src/render-frame-strip.ts
+++ b/packages/timeline-utils/src/render-frame-strip.ts
@@ -6,7 +6,36 @@ import {
 } from './frame-database';
 
 export const WEBCODECS_TIMESCALE = 1_000_000;
-const MAX_TIME_DEVIATION = WEBCODECS_TIMESCALE * 0.05;
+export const MAX_TIME_DEVIATION = WEBCODECS_TIMESCALE * 0.05;
+
+export const getBestCachedFrameKeyForTimestamp = ({
+	keys,
+	timestamp,
+	maxDeviation = MAX_TIME_DEVIATION,
+}: {
+	keys: readonly FrameDatabaseKey[];
+	timestamp: number;
+	maxDeviation?: number;
+}): FrameDatabaseKey | null => {
+	let bestKey: FrameDatabaseKey | undefined;
+	let bestDistance = Infinity;
+
+	for (const key of keys) {
+		const distance = Math.abs(
+			getTimestampFromFrameDatabaseKey(key) - timestamp,
+		);
+		if (distance < bestDistance) {
+			bestDistance = distance;
+			bestKey = key;
+		}
+	}
+
+	if (!bestKey || bestDistance > maxDeviation) {
+		return null;
+	}
+
+	return bestKey;
+};
 
 export const getDurationOfOneFrame = ({
 	visualizationWidth,
@@ -171,17 +200,10 @@ export const fillWithCachedFrames = ({
 	const targets = Array.from(filledSlots.keys());
 
 	for (const timestamp of targets) {
-		let bestKey: FrameDatabaseKey | undefined;
-		let bestDistance = Infinity;
-		for (const key of keys) {
-			const distance = Math.abs(
-				getTimestampFromFrameDatabaseKey(key) - timestamp,
-			);
-			if (distance < bestDistance) {
-				bestDistance = distance;
-				bestKey = key;
-			}
-		}
+		const bestKey = getBestCachedFrameKeyForTimestamp({
+			keys,
+			timestamp,
+		});
 
 		if (!bestKey) {
 			continue;

--- a/packages/timeline-utils/src/test/render-frame-strip.test.ts
+++ b/packages/timeline-utils/src/test/render-frame-strip.test.ts
@@ -1,0 +1,98 @@
+import {expect, test} from 'bun:test';
+import {makeFrameDatabaseKey, type FrameDatabaseKey} from '../frame-database';
+import {
+	calculateTimestampSlots,
+	getBestCachedFrameKeyForTimestamp,
+	getDurationOfOneFrame,
+	MAX_TIME_DEVIATION,
+	WEBCODECS_TIMESCALE,
+} from '../render-frame-strip';
+
+test('getBestCachedFrameKeyForTimestamp rejects frames beyond the max deviation', () => {
+	const src = 'https://example.com/video.mp4';
+	const keys: FrameDatabaseKey[] = [
+		makeFrameDatabaseKey(src, 0),
+		makeFrameDatabaseKey(src, WEBCODECS_TIMESCALE),
+	];
+
+	expect(
+		getBestCachedFrameKeyForTimestamp({
+			keys,
+			timestamp: WEBCODECS_TIMESCALE * 0.5,
+		}),
+	).toBeNull();
+
+	expect(
+		getBestCachedFrameKeyForTimestamp({
+			keys,
+			timestamp: MAX_TIME_DEVIATION,
+		}),
+	).toBe(keys[0]);
+
+	expect(
+		getBestCachedFrameKeyForTimestamp({
+			keys,
+			timestamp: WEBCODECS_TIMESCALE + MAX_TIME_DEVIATION,
+		}),
+	).toBe(keys[1]);
+});
+
+test('getBestCachedFrameKeyForTimestamp picks the nearest frame within the threshold', () => {
+	const src = 'https://example.com/video.mp4';
+	const keys: FrameDatabaseKey[] = [
+		makeFrameDatabaseKey(src, WEBCODECS_TIMESCALE * 0.9),
+		makeFrameDatabaseKey(src, WEBCODECS_TIMESCALE * 1.02),
+	];
+
+	expect(
+		getBestCachedFrameKeyForTimestamp({
+			keys,
+			timestamp: WEBCODECS_TIMESCALE,
+		}),
+	).toBe(keys[1]);
+});
+
+test('timestamp slots stay anchored when width stays proportional to duration', () => {
+	const aspectRatio = 16 / 9;
+	const frameHeight = 50;
+	const pxPerSecond = 120;
+	const fromSeconds = 31 / 30;
+	const segmentDuration = 47 / 30;
+	const visualizationWidth = segmentDuration * pxPerSecond;
+
+	const slots = calculateTimestampSlots({
+		visualizationWidth,
+		fromSeconds,
+		segmentDuration,
+		aspectRatio,
+		frameHeight,
+	});
+
+	const nextFromSeconds = 32 / 30;
+	const nextSegmentDuration = 46 / 30;
+	const nextSlots = calculateTimestampSlots({
+		visualizationWidth: nextSegmentDuration * pxPerSecond,
+		fromSeconds: nextFromSeconds,
+		segmentDuration: nextSegmentDuration,
+		aspectRatio,
+		frameHeight,
+	});
+
+	const durationOfOneFrame = getDurationOfOneFrame({
+		visualizationWidth,
+		aspectRatio,
+		segmentDuration,
+		frameHeight,
+	});
+	const nextDurationOfOneFrame = getDurationOfOneFrame({
+		visualizationWidth: nextSegmentDuration * pxPerSecond,
+		aspectRatio,
+		segmentDuration: nextSegmentDuration,
+		frameHeight,
+	});
+
+	expect(nextDurationOfOneFrame).toBe(durationOfOneFrame);
+	expect(
+		nextSlots.filter((slot) => slots.includes(slot)).length,
+	).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary

- Keep filmstrip timestamp slots proportional when trimming the left edge by restoring the sequence border width before slot timing math
- Reject cached thumbnail frames that are farther than the existing 50ms max deviation (same rule as live sample fills)
- Reuse the filmstrip canvas across trim updates instead of tearing it down every drag step

Fixes #9118

## AI assistance

This change was written with AI assistance (Cursor/Grok). I reviewed the diff, ran the targeted tests below, and take responsibility for the patch.

## Verification

```text
bun test src/test/render-frame-strip.test.ts
# in packages/timeline-utils
# 3 pass

bun test src/test/filmstrip-layout-width.test.ts
# in packages/studio
# 1 pass
```

## Test plan

- [ ] Open `packages/example`, Studio composition `video-editing-independent`
- [ ] Drag the left edge of the first video clip
- [ ] Confirm filmstrip thumbnails stay anchored to source time without jumping while dragging