### PR TITLE
Docs: Finish motion design systems page for #8898

### DIFF
--- a/packages/docs/docs/design-systems.mdx
+++ b/packages/docs/docs/design-systems.mdx
@@ -18,6 +18,18 @@ Remotion's design system is hosted at [remotion.dev/brand](https://www.remotion.
 
 Use it as inspiration for your own motion design system.
 
+## What belongs in a motion design system?
+
+Treat compositions as reusable animated building blocks. Typical pieces include:
+
+- Logos, wordmarks, and brand marks (static and animated)
+- Lower thirds, upper thirds, title cards, and end cards
+- Transitions, stickers, and chapter markers
+- Shared colors, fonts, and timing conventions
+- Parameterized templates so text, images, and colors can change per render
+
+Organize them with [folders](/docs/folder) in the Studio so teammates can browse and export the same assets.
+
 ## Hosting the design system
 
 The Remotion Studio can be hosted as a [static deployment](/docs/studio/deploy-static) on many hosts, such as [Vercel](/docs/studio/deploy-static#deploy-to-vercel), Netlify, or Cloudflare.

--- a/packages/promo-pages/src/components/homepage/AutomationsSection.tsx
+++ b/packages/promo-pages/src/components/homepage/AutomationsSection.tsx
@@ -50,6 +50,13 @@ const appPipeline: Array<{
 
 const launchOptions = [
 	{
+		title: 'Build a motion design system',
+		description:
+			'Collect logos, lower thirds, and other animated brand assets in Remotion Studio, then host and export them.',
+		link: '/docs/design-systems',
+		buttonText: 'Motion design systems',
+	},
+	{
 		title: 'Start from a template',
 		description:
 			'Use starter projects for SaaS workflows, social videos, slideshows, captions, and repeatable video products.',


### PR DESCRIPTION
Closes #8898

## Summary

#9138 already shipped the Motion Design Systems docs page. This PR finishes the leftovers from #8898:

- Adds a short "What belongs in a motion design system?" section (logos, lower/upper thirds, transitions, shared tokens, parameterized templates)
- Links `/docs/design-systems` from the automators homepage Explore row

## Verification

Prettier 3.8.1 with the Remotion `.prettierrc.js` options (singleQuote, bracketSpacing false, MDX printWidth 300):

```
Checking formatting...
All matched files use Prettier code style!
```

MDX compile with `@mdx-js/mdx` and `remark-gfm`:

```
MDX COMPILE OK
```

Docs and homepage link only; no package runtime behavior changed.

This fix was developed with AI assistance (Cursor / Grok) and verified locally as shown above.
