### PR TITLE
@remotion/studio-server: Hot-reload public directory config changes

### DIFF
--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -116,9 +116,11 @@ export const studioCommand = async (
 		commandLine: parsedCli,
 	}).value;
 
-	const relativePublicDir = publicDirOption.getValue({
-		commandLine: parsedCli,
-	}).value;
+	const getRelativePublicDir = () => {
+		return publicDirOption.getValue({
+			commandLine: parsedCli,
+		}).value;
+	};
 
 	const enableCrossSiteIsolation = enableCrossSiteIsolationOption.getValue({
 		commandLine: parsedCli,
@@ -170,7 +172,7 @@ export const studioCommand = async (
 		keyboardShortcutsEnabled,
 		maxTimelineTracks: ConfigInternals.getMaxTimelineTracks(),
 		remotionRoot,
-		relativePublicDir,
+		getRelativePublicDir,
 		webpackOverride: ConfigInternals.getWebpackOverrideFn(),
 		poll: webpackPollOption.getValue({commandLine: parsedCli}).value,
 		getRenderDefaults,

--- a/packages/studio-server/src/preview-server/public-folder.ts
+++ b/packages/studio-server/src/preview-server/public-folder.ts
@@ -1,23 +1,67 @@
-import {existsSync, watch} from 'node:fs';
+import {existsSync, watch, type FSWatcher} from 'node:fs';
 import path from 'node:path';
 import {BundlerInternals} from '@remotion/bundler';
 import type {StaticFile} from 'remotion';
 import {envSupportsFsRecursive} from './env-supports-fs-recursive';
 
 let files: StaticFile[] = [];
+let activeWatcher: FSWatcher | null = null;
+let watchedPublicDir: string | null = null;
+let watchStaticHash: string | null = null;
+let watchOnUpdate: (() => void) | null = null;
+let getPublicDirFn: (() => string) | null = null;
 
 export const initPublicFolderWatch = ({
-	publicDir,
+	getPublicDir,
 	onUpdate,
 	staticHash,
 }: {
-	publicDir: string;
+	getPublicDir: () => string;
 	remotionRoot: string;
 	onUpdate: () => void;
 	staticHash: string;
 }) => {
-	fetchFolder({publicDir, staticHash});
-	watchPublicFolder({publicDir, onUpdate, staticHash});
+	getPublicDirFn = getPublicDir;
+	watchOnUpdate = onUpdate;
+	watchStaticHash = staticHash;
+	syncPublicFolderWatch();
+};
+
+export const syncPublicFolderWatch = () => {
+	if (!getPublicDirFn || !watchOnUpdate || !watchStaticHash) {
+		return;
+	}
+
+	const publicDir = getPublicDirFn();
+	if (publicDir === watchedPublicDir && activeWatcher) {
+		return;
+	}
+
+	const previousDir = watchedPublicDir;
+	closePublicFolderWatch();
+	watchedPublicDir = publicDir;
+	fetchFolder({publicDir, staticHash: watchStaticHash});
+	activeWatcher = watchPublicFolder({
+		publicDir,
+		onUpdate: watchOnUpdate,
+		staticHash: watchStaticHash,
+		setActiveWatcher: (watcher) => {
+			activeWatcher = watcher;
+		},
+	});
+
+	if (previousDir !== null && previousDir !== publicDir) {
+		watchOnUpdate();
+	}
+};
+
+const closePublicFolderWatch = () => {
+	if (activeWatcher) {
+		activeWatcher.close();
+		activeWatcher = null;
+	}
+
+	watchedPublicDir = null;
 };
 
 export const fetchFolder = ({
@@ -44,32 +88,36 @@ const watchPublicFolder = ({
 	publicDir,
 	onUpdate,
 	staticHash,
+	setActiveWatcher,
 }: {
 	publicDir: string;
 	onUpdate: () => void;
 	staticHash: string;
-}) => {
+	setActiveWatcher: (watcher: FSWatcher) => void;
+}): FSWatcher => {
 	if (!existsSync(publicDir)) {
 		const parentDir = path.dirname(publicDir);
 		const onDirChange = () => {
 			if (existsSync(publicDir)) {
-				watchPublicFolder({
+				watcher.close();
+				const nextWatcher = watchPublicFolder({
 					publicDir,
 					onUpdate,
 					staticHash,
+					setActiveWatcher,
 				});
+				setActiveWatcher(nextWatcher);
 				onUpdate();
-				watcher.close();
 			}
 		};
 
 		const watcher = watch(parentDir, {}, onDirChange);
-		return;
+		return watcher;
 	}
 
 	// Known bug: If whole public folder is deleted, this will not be called on macOS.
 	// This is not severe, so a wontfix for now.
-	watch(publicDir, {recursive: envSupportsFsRecursive()}, () => {
+	return watch(publicDir, {recursive: envSupportsFsRecursive()}, () => {
 		fetchFolder({publicDir, staticHash});
 		onUpdate();
 	});
@@ -77,4 +125,12 @@ const watchPublicFolder = ({
 
 export const getFiles = () => {
 	return files;
+};
+
+export const resetPublicFolderWatchForTests = () => {
+	closePublicFolderWatch();
+	files = [];
+	watchStaticHash = null;
+	watchOnUpdate = null;
+	getPublicDirFn = null;
 };

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -48,7 +48,7 @@ export const startServer = async (options: {
 	bufferStateDelayInMilliseconds: number | null;
 	remotionRoot: string;
 	keyboardShortcutsEnabled: boolean;
-	publicDir: string;
+	getPublicDir: () => string;
 	poll: number | null;
 	staticHash: string;
 	staticHashPrefix: string;
@@ -165,7 +165,7 @@ export const startServer = async (options: {
 					getEnvVariables: options.getEnvVariables,
 					remotionRoot: options.remotionRoot,
 					entryPoint: options.userDefinedComponent,
-					publicDir: options.publicDir,
+					getPublicDir: options.getPublicDir,
 					logLevel: options.logLevel,
 					getRenderQueue: options.getRenderQueue,
 					getRenderDefaults: options.getRenderDefaults,

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -31,7 +31,11 @@ import {getStaticFileFallbackHint} from './preview-server/get-static-file-fallba
 import {handleRequest} from './preview-server/handler';
 import type {LiveEventsServer} from './preview-server/live-events';
 import {parseRequestBody} from './preview-server/parse-body';
-import {fetchFolder, getFiles} from './preview-server/public-folder';
+import {
+	fetchFolder,
+	getFiles,
+	syncPublicFolderWatch,
+} from './preview-server/public-folder';
 import {getEditorName} from './preview-server/routes/open-in-editor';
 import {serveStatic} from './preview-server/serve-static';
 import {validateSameOrigin} from './preview-server/validate-same-origin';
@@ -582,7 +586,7 @@ export const handleRoutes = ({
 	getEnvVariables,
 	remotionRoot,
 	entryPoint,
-	publicDir,
+	getPublicDir,
 	logLevel,
 	getRenderQueue,
 	getRenderDefaults,
@@ -606,7 +610,7 @@ export const handleRoutes = ({
 	getEnvVariables: () => Record<string, string>;
 	remotionRoot: string;
 	entryPoint: string;
-	publicDir: string;
+	getPublicDir: () => string;
 	logLevel: LogLevel;
 	getRenderQueue: () => RenderJob[];
 	getRenderDefaults: () => RenderDefaults;
@@ -619,6 +623,8 @@ export const handleRoutes = ({
 	enableCrossSiteIsolation: boolean;
 	getStudioRuntimeConfig: () => StudioRuntimeConfig;
 }): Promise<void> => {
+	syncPublicFolderWatch();
+	const publicDir = getPublicDir();
 	const url = new URL(request.url as string, 'http://localhost');
 
 	if (url.pathname === '/api/file-source') {

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -40,7 +40,7 @@ export const startStudio = async ({
 	maxTimelineTracks,
 	remotionRoot,
 	keyboardShortcutsEnabled,
-	relativePublicDir,
+	getRelativePublicDir,
 	webpackOverride,
 	poll,
 	getRenderDefaults,
@@ -73,7 +73,7 @@ export const startStudio = async ({
 	bufferStateDelayInMilliseconds: number | null;
 	remotionRoot: string;
 	keyboardShortcutsEnabled: boolean;
-	relativePublicDir: string | null;
+	getRelativePublicDir: () => string | null;
 	webpackOverride: WebpackOverrideFn;
 	poll: number | null;
 	getRenderDefaults: () => RenderDefaults;
@@ -107,10 +107,13 @@ export const startStudio = async ({
 	getFileWatcherRegistry();
 
 	watchRootFile(remotionRoot, previewEntry);
-	const publicDir = getAbsolutePublicDir({
-		relativePublicDir,
-		remotionRoot,
-	});
+	const getPublicDir = () => {
+		return getAbsolutePublicDir({
+			relativePublicDir: getRelativePublicDir(),
+			remotionRoot,
+		});
+	};
+
 	const hash = crypto.randomBytes(6).toString('hex');
 
 	const outputHashPrefix = '/outputs-';
@@ -120,10 +123,11 @@ export const startStudio = async ({
 	const staticHash = `${staticHashPrefix}${hash}`;
 
 	initPublicFolderWatch({
-		publicDir,
+		getPublicDir,
 		remotionRoot,
 		onUpdate: () => {
 			waitForLiveEventsListener().then((listener) => {
+				const publicDir = getPublicDir();
 				const files = getFiles();
 				listener.sendEventToClient({
 					type: 'new-public-folder',
@@ -149,7 +153,7 @@ export const startStudio = async ({
 		maxTimelineTracks,
 		remotionRoot,
 		keyboardShortcutsEnabled,
-		publicDir,
+		getPublicDir,
 		webpackOverride,
 		poll,
 		staticHash,

--- a/packages/studio-server/src/test/file-source-route.test.ts
+++ b/packages/studio-server/src/test/file-source-route.test.ts
@@ -90,7 +90,7 @@ test('serves file source from an origin-less GET request', async () => {
 			outputHash: '/outputs',
 			outputHashPrefix: '/outputs',
 			previewSampleRate: null,
-			publicDir: remotionRoot,
+			getPublicDir: () => remotionRoot,
 			queueMethods: {
 				addJob: () => undefined,
 				cancelJob: () => undefined,

--- a/packages/studio-server/src/test/public-folder-hot-reload.test.ts
+++ b/packages/studio-server/src/test/public-folder-hot-reload.test.ts
@@ -1,0 +1,54 @@
+import {afterEach, expect, test} from 'bun:test';
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {
+	getFiles,
+	initPublicFolderWatch,
+	resetPublicFolderWatchForTests,
+	syncPublicFolderWatch,
+} from '../preview-server/public-folder';
+
+const makePublicDir = (name: string) => {
+	return mkdtempSync(path.join(tmpdir(), `remotion-public-${name}-`));
+};
+
+afterEach(() => {
+	resetPublicFolderWatchForTests();
+});
+
+test('public folder watch switches when getPublicDir resolves a new directory', () => {
+	const firstPublicDir = makePublicDir('first');
+	const secondPublicDir = makePublicDir('second');
+	writeFileSync(path.join(firstPublicDir, 'first.txt'), 'first');
+	writeFileSync(path.join(secondPublicDir, 'second.txt'), 'second');
+
+	let currentPublicDir = firstPublicDir;
+	let updateCount = 0;
+
+	try {
+		initPublicFolderWatch({
+			getPublicDir: () => currentPublicDir,
+			remotionRoot: path.dirname(firstPublicDir),
+			onUpdate: () => {
+				updateCount += 1;
+			},
+			staticHash: '/static-test',
+		});
+
+		expect(getFiles().map((file) => file.name)).toEqual(['first.txt']);
+		expect(updateCount).toBe(0);
+
+		currentPublicDir = secondPublicDir;
+		syncPublicFolderWatch();
+
+		expect(getFiles().map((file) => file.name)).toEqual(['second.txt']);
+		expect(updateCount).toBe(1);
+
+		syncPublicFolderWatch();
+		expect(updateCount).toBe(1);
+	} finally {
+		rmSync(firstPublicDir, {force: true, recursive: true});
+		rmSync(secondPublicDir, {force: true, recursive: true});
+	}
+});


### PR DESCRIPTION
## Summary

- Studio no longer captures `publicDir` once at process start. CLI passes `getRelativePublicDir()`, and the server resolves `getPublicDir()` on each request for static serving, asset write/delete/rename, and HTML fallback listing.
- `initPublicFolderWatch` tears down and recreates the filesystem watcher when the resolved directory changes, then emits `new-public-folder` so the Studio file tree refreshes.
- `handleRoutes` calls `syncPublicFolderWatch()` so a config reload that changes `Config.setPublicDir()` picks up the new directory without restarting Studio.

Closes #9015

Pairs with #9024 (config file reload / page refresh). That PR reloads option state; this one makes the server-side public-dir consumers follow the new value.

## AI assistance

Implemented with Cursor/Grok assistance. I reviewed the diff, ran the tests below, and own the PR.

## Verification

```
bunx turbo run make --filter='@remotion/bundler' --filter='@remotion/studio-shared' --filter='@remotion/studio-server' --filter='@remotion/cli'
# Tasks: 28 successful, 28 total

bun test packages/studio-server/src/test/public-folder-hot-reload.test.ts packages/studio-server/src/test/file-source-route.test.ts packages/studio-server/src/test/handler.test.ts packages/studio-server/src/test/get-static-file-fallback-hint.test.ts
# 14 pass, 0 fail

cd packages/studio-server && bun run lint
# 0 errors (9 pre-existing warnings unrelated to this change)

bunx oxfmt src/preview-server/public-folder.ts src/start-studio.ts src/routes.ts src/preview-server/start-server.ts src/test/public-folder-hot-reload.test.ts src/test/file-source-route.test.ts --check
# All matched files use the correct format
```