### PR TITLE
@remotion/media: Support premountFor on Video

### DIFF
--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -45,11 +45,13 @@ export type AbsoluteFillLayout = {
 	className?: string;
 };
 
-export type LayoutAndStyle =
-	| AbsoluteFillLayout
-	| {
-			layout: 'none';
-	  };
+export type NoneLayout = {
+	layout: 'none';
+	premountFor?: number;
+	postmountFor?: number;
+};
+
+export type LayoutAndStyle = AbsoluteFillLayout | NoneLayout;
 
 export type SequencePropsWithoutDuration = {
 	readonly children?: React.ReactNode;
@@ -570,22 +572,10 @@ const PremountedPostmountedSequenceRefForwardingFunction: React.ForwardRefRender
 	const frame =
 		useCurrentFrame() - parentPremountContext.premountFramesRemaining;
 
-	if (props.layout === 'none') {
-		throw new Error(
-			'`<Sequence>` with `premountFor` and `postmountFor` props does not support layout="none"',
-		);
-	}
-
-	const {
-		style: passedStyle,
-		from = 0,
-		durationInFrames = Infinity,
-		premountFor = 0,
-		postmountFor = 0,
-		styleWhilePremounted,
-		styleWhilePostmounted,
-		...otherProps
-	} = props;
+	const from = props.from ?? 0;
+	const durationInFrames = props.durationInFrames ?? Infinity;
+	const premountFor = props.premountFor ?? 0;
+	const postmountFor = props.postmountFor ?? 0;
 
 	const endThreshold = Math.ceil(from + durationInFrames - 1);
 	const premountingActive = frame < from && frame >= from - premountFor;
@@ -599,6 +589,12 @@ const PremountedPostmountedSequenceRefForwardingFunction: React.ForwardRefRender
 			? from + durationInFrames - 1
 			: 0;
 	const isFreezingActive = premountingActive || postmountingActive;
+
+	const passedStyle = props.layout === 'none' ? undefined : props.style;
+	const styleWhilePremounted =
+		props.layout === 'none' ? undefined : props.styleWhilePremounted;
+	const styleWhilePostmounted =
+		props.layout === 'none' ? undefined : props.styleWhilePostmounted;
 
 	const style = useMemo(() => {
 		return {
@@ -619,6 +615,43 @@ const PremountedPostmountedSequenceRefForwardingFunction: React.ForwardRefRender
 		styleWhilePostmounted,
 	]);
 
+	// layout="none" stays wrapperless: Sequence only controls the mount window and
+	// premounting flags. Media (e.g. <Video>) hide their own canvas/fallback.
+	if (props.layout === 'none') {
+		const {
+			from: _from,
+			durationInFrames: _durationInFrames,
+			premountFor: _premountFor,
+			postmountFor: _postmountFor,
+			...noneLayoutProps
+		} = props;
+
+		return (
+			<Freeze frame={freezeFrame} active={isFreezingActive}>
+				<SequenceInner
+					from={from}
+					durationInFrames={durationInFrames}
+					_remotionInternalPremountDisplay={premountFor}
+					_remotionInternalPostmountDisplay={postmountFor}
+					_remotionInternalIsPremounting={premountingActive}
+					_remotionInternalIsPostmounting={postmountingActive}
+					{...noneLayoutProps}
+				/>
+			</Freeze>
+		);
+	}
+
+	const {
+		style: _style,
+		from: _from,
+		durationInFrames: _durationInFrames,
+		premountFor: _premountFor,
+		postmountFor: _postmountFor,
+		styleWhilePremounted: _styleWhilePremounted,
+		styleWhilePostmounted: _styleWhilePostmounted,
+		...absoluteFillProps
+	} = props;
+
 	return (
 		<Freeze frame={freezeFrame} active={isFreezingActive}>
 			<SequenceInner
@@ -630,7 +663,7 @@ const PremountedPostmountedSequenceRefForwardingFunction: React.ForwardRefRender
 				_remotionInternalPostmountDisplay={postmountFor}
 				_remotionInternalIsPremounting={premountingActive}
 				_remotionInternalIsPostmounting={postmountingActive}
-				{...otherProps}
+				{...absoluteFillProps}
 			/>
 		</Freeze>
 	);
@@ -646,18 +679,25 @@ const SequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 > = (props, ref) => {
 	const env = useRemotionEnvironment();
 	const {fps} = useVideoConfig();
-	if (props.layout !== 'none' && !env.isRendering) {
-		const effectivePremountFor = ENABLE_V5_BREAKING_CHANGES
-			? (props.premountFor ?? fps)
-			: props.premountFor;
-		if (effectivePremountFor || props.postmountFor) {
-			return (
-				<PremountedPostmountedSequence
-					ref={ref}
-					{...props}
-					premountFor={effectivePremountFor}
-				/>
-			);
+	if (!env.isRendering) {
+		if (props.layout === 'none') {
+			// layout="none" never auto-premounts (v5 default applies only to laid-out sequences).
+			if (props.premountFor || props.postmountFor) {
+				return <PremountedPostmountedSequence {...props} />;
+			}
+		} else {
+			const effectivePremountFor = ENABLE_V5_BREAKING_CHANGES
+				? (props.premountFor ?? fps)
+				: props.premountFor;
+			if (effectivePremountFor || props.postmountFor) {
+				return (
+					<PremountedPostmountedSequence
+						ref={ref}
+						{...props}
+						premountFor={effectivePremountFor}
+					/>
+				);
+			}
 		}
 	}
 

--- a/packages/core/src/test/series.test.tsx
+++ b/packages/core/src/test/series.test.tsx
@@ -498,3 +498,68 @@ test('preserves the real sequence start while premounting', () => {
 		'frame <!-- -->0<!-- --> absoluteFrom <!-- -->106',
 	);
 });
+
+test('layout="none" premounts without an AbsoluteFill wrapper', () => {
+	const PremountFlagPrinter = () => {
+		const sequenceContext = React.useContext(Internals.SequenceContext);
+		return (
+			<div>
+				{sequenceContext?.premounting ? 'premounting' : 'active'} content
+			</div>
+		);
+	};
+
+	const premountHtml = renderForFrame(
+		40,
+		<WrapSequenceContext>
+			<Internals.RemotionEnvironmentContext
+				value={{
+					isRendering: false,
+					isClientSideRendering: false,
+					isPlayer: true,
+					isStudio: true,
+					isReadOnlyStudio: false,
+				}}
+			>
+				<Sequence
+					from={60}
+					durationInFrames={30}
+					layout="none"
+					premountFor={30}
+				>
+					<PremountFlagPrinter />
+				</Sequence>
+			</Internals.RemotionEnvironmentContext>
+		</WrapSequenceContext>,
+	);
+	expect(premountHtml).toContain('premounting');
+	expect(premountHtml).toContain('content');
+	expect(premountHtml).not.toContain('position:absolute');
+
+	const activeHtml = renderForFrame(
+		60,
+		<WrapSequenceContext>
+			<Internals.RemotionEnvironmentContext
+				value={{
+					isRendering: false,
+					isClientSideRendering: false,
+					isPlayer: true,
+					isStudio: true,
+					isReadOnlyStudio: false,
+				}}
+			>
+				<Sequence
+					from={60}
+					durationInFrames={30}
+					layout="none"
+					premountFor={30}
+				>
+					<PremountFlagPrinter />
+				</Sequence>
+			</Internals.RemotionEnvironmentContext>
+		</WrapSequenceContext>,
+	);
+	expect(activeHtml).toContain('active');
+	expect(activeHtml).toContain('content');
+	expect(activeHtml).not.toContain('position:absolute');
+});

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -75,6 +75,15 @@ At which frame this clip should start relative to the parent timeline. Default i
 
 For how many frames the clip stays mounted. Default is `Infinity`. Same meaning as [`durationInFrames`](/docs/sequence#durationinframes) on [`<Sequence>`](/docs/sequence).
 
+### `premountFor?`<AvailableFrom v="4.0.491" />
+
+[Premount](/docs/player/premounting) the video for a set number of frames so decoding can warm up before the clip becomes active.  
+Same meaning as [`premountFor`](/docs/sequence#premountfor) on [`<Sequence>`](/docs/sequence). While premounting, the canvas (or Html5 fallback) stays invisible.
+
+### `postmountFor?`<AvailableFrom v="4.0.491" />
+
+Same as `premountFor`, but keeps the video mounted after the clip has ended.
+
 :::note
 You can still wrap `<Video>` in an outer [`<Sequence>`](/docs/sequence). Timing [cascades](/docs/sequence#cascading) like nested sequences.
 :::

--- a/packages/docs/docs/player/premounting.mdx
+++ b/packages/docs/docs/player/premounting.mdx
@@ -61,9 +61,9 @@ In the [Remotion Studio](/docs/studio), a premounted component is indicated with
 <br />
 <br />
 
-A premounted [`<Sequence>`](/docs/sequence) does carry the styles `opacity: 0` and `pointer-events: none`.
+A premounted [`<Sequence>`](/docs/sequence) with `layout="absolute-fill"` (the default) carries the styles `opacity: 0` and `pointer-events: none` on its container.
 
-It is not possible to premount a [`<Sequence>`](/docs/sequence) with `layout="none"` because such a sequence does not have a container to apply the styles to.
+[`<Sequence layout="none">`](/docs/sequence) can also use `premountFor` / `postmountFor`. In that case Remotion keeps the sequence wrapperless and only controls the mount window plus premounting flags. Components that render media (for example [`<Video>`](/docs/media/video) from `@remotion/media`) hide their own canvas or fallback while premounting or postmounting.
 
 ## With `<Series>` and `<TransitionSeries>`
 

--- a/packages/docs/docs/sequence.mdx
+++ b/packages/docs/docs/sequence.mdx
@@ -287,7 +287,8 @@ A class name to be applied to the container. If `layout` is set to `none`, there
 ### `premountFor?`<AvailableFrom v="4.0.140" />
 
 [Premount](/docs/player/premounting) the sequence for a set number of frames.
-From [v5.0](/docs/5-0-migration), the default value changes from `0` to `fps` (1 second).
+From [v5.0](/docs/5-0-migration), the default value changes from `0` to `fps` (1 second) for `layout="absolute-fill"`.  
+`layout="none"` stays wrapperless and only premounts when you pass `premountFor` / `postmountFor` explicitly. Children that draw media should hide themselves while premounting.
 
 ### `postmountFor?`<AvailableFrom v="4.0.340" />
 
@@ -297,7 +298,8 @@ Use this only if you expect the user to frequently seek backwards in the timelin
 ### `styleWhilePremounted?`<AvailableFrom v="4.0.252" />
 
 CSS styles to be applied to the container while the sequence is premounted.  
-The `style` is still applied, but `styleWhilePremounted` can override properties.
+The `style` is still applied, but `styleWhilePremounted` can override properties.  
+Not available with `layout="none"` (there is no container).
 
 ### `showInTimeline?`<AvailableFrom v="4.0.110" />
 

--- a/packages/media/src/video/props.ts
+++ b/packages/media/src/video/props.ts
@@ -3,6 +3,7 @@ import type {
 	EffectDefinitionAndStack,
 	EffectsProp,
 	InteractiveBaseProps,
+	InteractivePremountProps,
 	LogLevel,
 	LoopVolumeCurveBehavior,
 	OnVideoFrame,
@@ -94,10 +95,13 @@ export type InnerVideoProps = MandatoryVideoProps &
 	Omit<OptionalVideoProps, 'effects'> &
 	NativeVideoProps & {
 		effects: EffectDefinitionAndStack<unknown>[];
+		styleWhilePremounted?: React.CSSProperties;
+		styleWhilePostmounted?: React.CSSProperties;
 	};
 
 export type VideoProps = MandatoryVideoProps &
 	Partial<OuterVideoProps> &
 	Partial<OptionalVideoProps> &
 	NativeVideoProps &
-	InteractiveBaseProps;
+	InteractiveBaseProps &
+	InteractivePremountProps;

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -77,6 +77,8 @@ type VideoForPreviewProps = NativeVideoProps & {
 	readonly _experimentalInitiallyDrawCachedFrame: boolean;
 	readonly effects: EffectDefinitionAndStack<unknown>[];
 	readonly refForOutline: React.RefObject<HTMLElement | null>;
+	readonly styleWhilePremounted: React.CSSProperties | undefined;
+	readonly styleWhilePostmounted: React.CSSProperties | undefined;
 };
 
 type VideoForPreviewAssertedShowingProps = VideoForPreviewProps;
@@ -111,6 +113,8 @@ const VideoForPreviewAssertedShowing: React.FC<
 	effects,
 	setMediaDurationInSeconds,
 	refForOutline,
+	styleWhilePremounted,
+	styleWhilePostmounted,
 	...props
 }) => {
 	const src = usePreload(unpreloadedSrc);
@@ -512,12 +516,30 @@ const VideoForPreviewAssertedShowing: React.FC<
 	}, [effects, mediaPlayerReady, mediaPlayerRef]);
 
 	const actualStyle: React.CSSProperties = useMemo(() => {
+		if (isPremounting || isPostmounting) {
+			return {
+				...style,
+				objectFit: objectFitProp,
+				opacity: 0,
+				pointerEvents: 'none',
+				...(isPremounting ? styleWhilePremounted : {}),
+				...(isPostmounting ? styleWhilePostmounted : {}),
+			};
+		}
+
 		return {
 			...style,
 			// TODO: Previousy we did hide on isSequenceHidden
 			objectFit: objectFitProp,
 		};
-	}, [objectFitProp, style]);
+	}, [
+		isPostmounting,
+		isPremounting,
+		objectFitProp,
+		style,
+		styleWhilePostmounted,
+		styleWhilePremounted,
+	]);
 
 	if (shouldFallbackToNativeVideo && !disallowFallbackToOffthreadVideo) {
 		// <Video> will fallback to <VideoForPreview> anyway

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -38,6 +38,7 @@ const videoSchema = {
 	},
 	loop: {type: 'boolean', default: false, description: 'Loop'},
 	...Internals.transformSchema,
+	...Internals.premountSchema,
 } as const satisfies InteractivitySchema;
 
 const InnerVideo: React.FC<
@@ -61,6 +62,8 @@ const InnerVideo: React.FC<
 	onVideoFrame,
 	playbackRate,
 	style,
+	styleWhilePremounted,
+	styleWhilePostmounted,
 	trimAfter,
 	trimBefore,
 	volume,
@@ -157,6 +160,8 @@ const InnerVideo: React.FC<
 			playbackRate={playbackRate}
 			src={src}
 			style={style}
+			styleWhilePremounted={styleWhilePremounted}
+			styleWhilePostmounted={styleWhilePostmounted}
 			volume={volume}
 			showInTimeline={showInTimeline}
 			trimAfter={trimAfterValue}
@@ -219,6 +224,10 @@ const VideoInner: React.FC<
 	from,
 	freeze,
 	hidden,
+	premountFor,
+	postmountFor,
+	styleWhilePremounted,
+	styleWhilePostmounted,
 	...props
 }) => {
 	const fallbackLogLevel = Internals.useLogLevel();
@@ -298,6 +307,8 @@ const VideoInner: React.FC<
 			from={from ?? 0}
 			durationInFrames={basicInfo.duration}
 			freeze={freeze}
+			premountFor={premountFor}
+			postmountFor={postmountFor}
 			_remotionInternalStack={stack}
 			_remotionInternalIsMedia={isMedia}
 			name={name ?? '<Video>'}
@@ -334,6 +345,8 @@ const VideoInner: React.FC<
 				showInTimeline={showInTimeline ?? true}
 				src={src}
 				style={style ?? {}}
+				styleWhilePremounted={styleWhilePremounted}
+				styleWhilePostmounted={styleWhilePostmounted}
 				trimAfter={trimAfter}
 				trimBefore={trimBefore}
 				volume={volume ?? 1}


### PR DESCRIPTION
## Summary

- Allow `<Sequence layout="none">` to use `premountFor` / `postmountFor` without adding a layout wrapper. Sequence only extends the mount window and sets premounting flags.
- Wire those props through `@remotion/media` `<Video>`, and hide the canvas (or Html5 fallback) with `opacity: 0` while premounting or postmounting.
- Update docs and add a regression test for wrapperless premount.

Fixes #9107

## Approach

Jonny noted that `<Video>` must stay layoutless, so simply forwarding `premountFor` onto an AbsoluteFill-style Sequence is the wrong shape. This PR adds wrapperless premount semantics: Freeze + mount window + context flags on `layout="none"`, and the media component hides itself.

`styleWhilePremounted` / `styleWhilePostmounted` stay AbsoluteFill-only (no container on `layout="none"`). `<Video>` still accepts them and applies them to its own canvas while hidden.

## AI assistance

This PR was written with AI assistance (Cursor/Grok). I reproduced the API gap against current main, ran the targeted test/build commands below, and reviewed the diff before opening.

## Verification

```text
cd packages/core
bun test src/test/series.test.tsx
# 23 pass, including layout="none" premounts without an AbsoluteFill wrapper

bun run make
# Done.

cd packages/player && bun run make
cd packages/media && bun run make
# Generated.
```

## Test plan

- [x] `bun test packages/core/src/test/series.test.tsx`
- [x] `packages/core` + `packages/media` `bun run make`
- [ ] Studio: `<Video premountFor={30} from={60} />` mounts early, canvas stays invisible until frame 60, then appears
- [ ] Confirm `layout="none"` Sequence with premount does not introduce an AbsoluteFill wrapper in the DOM
