### PR TITLE
@remotion/timeline-utils: Fix Studio waveform for playbackRate > 1

### DIFF
--- a/packages/timeline-utils/src/audio-waveform/slice-waveform-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/slice-waveform-peaks.ts
@@ -25,8 +25,23 @@ export const sliceWaveformPeaks = ({
 		(startTimeInSeconds + durationInSeconds) * TARGET_SAMPLE_RATE,
 	);
 
-	return peaks.subarray(
-		Math.max(0, startPeakIndex),
-		Math.min(peaks.length, endPeakIndex),
+	const startIndex = Math.max(0, startPeakIndex);
+	const availableEnd = Math.min(
+		peaks.length,
+		Math.max(startIndex, endPeakIndex),
 	);
+	const available = peaks.subarray(startIndex, availableEnd);
+
+	// Peak slots that represent this timeline window after clamping a negative
+	// start (same as before). When playbackRate > 1 asks for media past EOF,
+	// pad with silence so drawBars compresses the real peaks instead of
+	// stretching them across the full sequence width.
+	const expectedLength = Math.max(0, endPeakIndex - startIndex);
+	if (available.length === expectedLength) {
+		return available;
+	}
+
+	const padded = new Float32Array(expectedLength);
+	padded.set(available);
+	return padded;
 };

--- a/packages/timeline-utils/src/test/slice-waveform-peaks.test.ts
+++ b/packages/timeline-utils/src/test/slice-waveform-peaks.test.ts
@@ -30,3 +30,76 @@ test('Should return an empty waveform unchanged', () => {
 
 	expect(sliced).toBe(peaks);
 });
+
+test('Should stretch waveform peaks when playbackRate is below 1', () => {
+	const peaks = Float32Array.from({length: 1000}, (_, i) => i);
+
+	const sliced = sliceWaveformPeaks({
+		peaks,
+		startFrom: 0,
+		durationInFrames: 300,
+		fps: 30,
+		playbackRate: 0.5,
+	});
+
+	// 5s of media at 100 peaks/s
+	expect(sliced.length).toBe(500);
+	expect(sliced[0]).toBe(0);
+	expect(sliced[499]).toBe(499);
+});
+
+test('Should compress waveform peaks when playbackRate is above 1', () => {
+	const peaks = Float32Array.from({length: 2000}, (_, i) => i);
+
+	const sliced = sliceWaveformPeaks({
+		peaks,
+		startFrom: 0,
+		durationInFrames: 300,
+		fps: 30,
+		playbackRate: 2,
+	});
+
+	// 20s of media at 100 peaks/s, media is long enough
+	expect(sliced.length).toBe(2000);
+	expect(sliced[0]).toBe(0);
+	expect(sliced[1999]).toBe(1999);
+});
+
+test('Should pad silence past EOF so playbackRate above 1 still compresses', () => {
+	// Timeline is 10s of composition; media is only 10s. At rate 2 we need 20s
+	// of source peaks; without padding the slice would clamp to rate-1 length.
+	const peaks = Float32Array.from({length: 1000}, (_, i) => i + 1);
+
+	const sliced = sliceWaveformPeaks({
+		peaks,
+		startFrom: 0,
+		durationInFrames: 300,
+		fps: 30,
+		playbackRate: 2,
+	});
+
+	expect(sliced.length).toBe(2000);
+	expect(sliced[0]).toBe(1);
+	expect(sliced[999]).toBe(1000);
+	expect(sliced[1000]).toBe(0);
+	expect(sliced[1999]).toBe(0);
+});
+
+test('Should pad silence when a mid-media window runs past EOF', () => {
+	const peaks = Float32Array.from({length: 1000}, (_, i) => i + 1);
+
+	const sliced = sliceWaveformPeaks({
+		peaks,
+		startFrom: 150,
+		durationInFrames: 300,
+		fps: 30,
+		playbackRate: 2,
+	});
+
+	// start at 5s -> peak 500; need 20s -> 2000 peaks; only 500 remain
+	expect(sliced.length).toBe(2000);
+	expect(sliced[0]).toBe(501);
+	expect(sliced[499]).toBe(1000);
+	expect(sliced[500]).toBe(0);
+	expect(sliced[1999]).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Studio timeline waveforms already stretched for `playbackRate < 1`, but when `playbackRate > 1` asked for media past EOF, `sliceWaveformPeaks` clamped to the available peaks and `drawBars` stretched that shorter slice across the full sequence width. Visually that looked stuck at the slow-rate stretch.
- Pad the sliced peak buffer with silence up to the requested window length so the real peaks compress into the left portion of the clip (media ends early at faster rates).
- Add regression tests for rate `< 1`, rate `> 1` with enough media, and rate `> 1` past EOF.

Fixes #7353

## AI assistance

This PR was written with AI assistance (Cursor/Grok). I confirmed the EOF clamp against current main, added tests, ran the commands below, and reviewed the diff before opening.

## Verification

```text
cd packages/timeline-utils
bun test src/test/slice-waveform-peaks.test.ts
# 6 pass, 0 fail, 18 expect() calls
```

## Test plan

- [x] `bun test packages/timeline-utils/src/test/slice-waveform-peaks.test.ts`
- [ ] Studio: open a media clip whose sequence duration matches full media length; set `playbackRate` below 1 and confirm the waveform stretches; raise it above 1 and confirm the waveform compresses (content denser, silence/empty after media ends) instead of staying stretched