### PR TITLE
Docs: Avoid identity defaults in interactivity best practices

### DIFF
--- a/packages/docs/docs/studio/interactivity-best-practices.mdx
+++ b/packages/docs/docs/studio/interactivity-best-practices.mdx
@@ -19,7 +19,8 @@ When converting a component for Studio interactivity, apply all of these rules t
 - Keep every editable or keyframed value inline at the JSX prop that the Studio edits.
 - Write animations as inline `interpolate()` calls.
 - Keep `interpolate()` input and output ranges as hardcoded arrays, such as `[0, 30]`.
-- Use Studio-editable style props such as `translate`, `scale`, `rotate`, `transformOrigin` and `opacity` instead of hiding values in a `transform` string.
+- When a value is animated or should be Studio-editable, use style props such as `translate`, `scale`, `rotate`, `transformOrigin` and `opacity` instead of hiding it in a `transform` string.
+- Do not add identity defaults such as `opacity: 1`, `scale: 1`, `rotate: '0deg'` or `translate: '0px 0px'`. Only write those props when the element actually needs them.
 - Use `translate` for animated movement and canvas dragging. Keep `top`, `left`, `right` and `bottom` for static anchoring.
 - Keep `<Composition>` metadata and `defaultProps` inline unless the value is truly dynamic.
 
@@ -105,6 +106,24 @@ const rotation = interpolate(frame, [0, 30], [0, 20]);
 
 Use standalone [`spring()`](/docs/spring) only when the animation needs a frame-driven physical spring simulation.
 Use individual CSS transform properties such as `scale`, `rotate` and `translate` instead of composing a `transform` string.
+Only include `opacity`, `scale`, `rotate`, `translate` and `transformOrigin` when the element animates them or intentionally uses a non-default value.
+Do not seed styles with identity values just to follow these practices.
+
+```tsx title="No identity defaults"
+// 👍 Only the props that matter
+style={{fontSize: 80, color: 'white'}}
+
+// 👎 Identity defaults are not needed for interactivity
+style={{
+  fontSize: 80,
+  color: 'white',
+  opacity: 1,
+  scale: 1,
+  rotate: '0deg',
+  translate: '0px 0px',
+}}
+```
+
 Pass easing to the same `interpolate()` call instead of nesting another `interpolate()` call to create an eased progress value.
 
 ```tsx title="Animated position"

--- a/packages/skills/skills/remotion-markup/SKILL.md
+++ b/packages/skills/skills/remotion-markup/SKILL.md
@@ -44,7 +44,8 @@ export const FadeIn = () => {
 ```
 
 Keep the `interpolate()` call inline in the `style` prop.
-Prefer `scale`, `translate`, `rotate` CSS properties over `transform`.
+When animating transforms, prefer `scale`, `translate`, `rotate` CSS properties over `transform`.
+Do not add identity defaults such as `opacity: 1`, `scale: 1`, `rotate: "0deg"`, or `translate: "0px 0px"` unless the property is actually used.
 
 ```tsx
 // 👍 Inline editable keyframes and transform shorthands
@@ -59,6 +60,14 @@ const scale = interpolate(frame, [0, 100], [0, 1]);
 
 style={{
   transform: `scale(${scale})`,
+}}
+
+// 👎 Identity defaults are not needed for interactivity
+style={{
+  opacity: 1,
+  scale: 1,
+  rotate: "0deg",
+  translate: "0px 0px",
 }}
 ```
 


### PR DESCRIPTION
## Summary

Closes #8979

Invoking Interactivity best practices was causing agents to seed styles with identity values:

```
opacity: 1,
scale: 1,
rotate: '0deg',
translate: '0px 0px',
```

Those props should only be written when the element actually animates them or intentionally uses a non-default value.

This PR updates the canonical docs checklist plus a short 👎 example, and mirrors the guidance in `remotion-markup` skill.

## Verification

Pre-commit `docs format` (oxfmt) exited 0 on commit.

Focused diff only:
- `packages/docs/docs/studio/interactivity-best-practices.mdx`
- `packages/skills/skills/remotion-markup/SKILL.md`

This fix was developed with AI assistance (Cursor / Grok) and verified locally as shown above.

Made with [Cursor](https://cursor.com)