### PR TITLE
Studio: Configure License modal that writes public license key

### DIFF
--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -34,6 +34,7 @@ import {reorderSequenceHandler} from './routes/reorder-sequence';
 import {handleRestartStudio} from './routes/restart-studio';
 import {saveEffectPropsHandler} from './routes/save-effect-props';
 import {saveSequencePropsHandler} from './routes/save-sequence-props';
+import {handleSetPublicLicenseKey} from './routes/set-public-license-key';
 import {splitJsxSequenceHandler} from './routes/split-jsx-sequence';
 import {subscribeToDefaultProps} from './routes/subscribe-to-default-props';
 import {subscribeToFileExistence} from './routes/subscribe-to-file-existence';
@@ -97,6 +98,7 @@ export const allApiRoutes: {
 	'/api/rename-static-file': renameStaticFileHandler,
 	'/api/restart-studio': handleRestartStudio,
 	'/api/install-package': handleInstallPackage,
+	'/api/set-public-license-key': handleSetPublicLicenseKey,
 	'/api/insert-jsx-element': insertJsxElementHandler,
 	'/api/insert-element': insertElementHandler,
 	'/api/update-element-install-target': updateElementInstallTargetHandler,

--- a/packages/studio-server/src/preview-server/routes/set-public-license-key.ts
+++ b/packages/studio-server/src/preview-server/routes/set-public-license-key.ts
@@ -1,0 +1,18 @@
+import type {
+	SetPublicLicenseKeyRequest,
+	SetPublicLicenseKeyResponse,
+} from '@remotion/studio-shared';
+import {setPublicLicenseKeyInConfig} from '../../set-public-license-key-in-config';
+import type {ApiHandler} from '../api-types';
+
+export const handleSetPublicLicenseKey: ApiHandler<
+	SetPublicLicenseKeyRequest,
+	SetPublicLicenseKeyResponse
+> = ({remotionRoot, input: {licenseKey}}) => {
+	setPublicLicenseKeyInConfig({
+		remotionRoot,
+		licenseKey,
+	});
+
+	return Promise.resolve({});
+};

--- a/packages/studio-server/src/set-public-license-key-in-config.ts
+++ b/packages/studio-server/src/set-public-license-key-in-config.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CONFIG_IMPORT = `import {Config} from '@remotion/cli/config';`;
+const SETTER_REGEX = /Config\.setPublicLicenseKey\(\s*(['"])([\s\S]*?)\1\s*\)/;
+const CONFIG_IMPORT_REGEX =
+	/import\s*\{[^}]*\bConfig\b[^}]*\}\s*from\s*['"]@remotion\/cli\/config['"]/;
+
+export const validatePublicLicenseKey = (licenseKey: string | null) => {
+	if (
+		licenseKey !== null &&
+		licenseKey !== 'free-license' &&
+		!licenseKey.startsWith('rm_pub_')
+	) {
+		throw new Error(
+			'Invalid public license key. It must start with "rm_pub_" or be "free-license".',
+		);
+	}
+};
+
+const formatSetter = (licenseKey: string) => {
+	return `Config.setPublicLicenseKey('${licenseKey}');`;
+};
+
+const resolveConfigFile = (remotionRoot: string): string => {
+	const configFileTs = path.join(remotionRoot, 'remotion.config.ts');
+	const configFileJs = path.join(remotionRoot, 'remotion.config.js');
+
+	if (fs.existsSync(configFileTs)) {
+		return configFileTs;
+	}
+
+	if (fs.existsSync(configFileJs)) {
+		return configFileJs;
+	}
+
+	return configFileTs;
+};
+
+const ensureConfigImport = (lines: string[]): string[] => {
+	if (lines.some((line) => CONFIG_IMPORT_REGEX.test(line))) {
+		return lines;
+	}
+
+	let lastImportLine = -1;
+	for (let i = 0; i < lines.length; i++) {
+		if (lines[i].startsWith('import ')) {
+			lastImportLine = i;
+		}
+	}
+
+	if (lastImportLine === -1) {
+		if (lines.length === 0 || (lines.length === 1 && lines[0] === '')) {
+			return [CONFIG_IMPORT];
+		}
+
+		return [CONFIG_IMPORT, '', ...lines];
+	}
+
+	const headerLines = lines.slice(0, lastImportLine + 1);
+	const tailLines = lines.slice(lastImportLine + 1);
+	return [...headerLines, CONFIG_IMPORT, ...tailLines];
+};
+
+export const setPublicLicenseKeyInConfig = ({
+	remotionRoot,
+	licenseKey,
+}: {
+	remotionRoot: string;
+	licenseKey: string;
+}): {configFile: string} => {
+	validatePublicLicenseKey(licenseKey);
+
+	const configFile = resolveConfigFile(remotionRoot);
+	const setterLine = formatSetter(licenseKey);
+
+	if (!fs.existsSync(configFile)) {
+		fs.writeFileSync(configFile, `${CONFIG_IMPORT}\n\n${setterLine}\n`);
+		return {configFile};
+	}
+
+	const config = fs.readFileSync(configFile, 'utf-8');
+	const lines = config.replace(/\n$/, '').split('\n');
+
+	let replaced = false;
+	const updatedLines = lines.map((line) => {
+		const nextLine = line.replace(
+			SETTER_REGEX,
+			`Config.setPublicLicenseKey('${licenseKey}')`,
+		);
+		if (nextLine !== line) {
+			replaced = true;
+		}
+
+		return nextLine;
+	});
+
+	const nextLines = replaced
+		? updatedLines
+		: [...ensureConfigImport(updatedLines), setterLine];
+
+	fs.writeFileSync(configFile, `${nextLines.join('\n')}\n`);
+
+	return {configFile};
+};

--- a/packages/studio-server/src/set-public-license-key-in-config.ts
+++ b/packages/studio-server/src/set-public-license-key-in-config.ts
@@ -2,24 +2,46 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const CONFIG_IMPORT = `import {Config} from '@remotion/cli/config';`;
-const SETTER_REGEX = /Config\.setPublicLicenseKey\(\s*(['"])([\s\S]*?)\1\s*\)/;
+const LICENSE_KEY_PREFIX = 'rm_pub_';
+const LICENSE_KEY_LENGTH = 55;
+const SETTER_REGEX =
+	/Config\.setPublicLicenseKey\(\s*(['"`])([\s\S]*?)\1\s*\)/g;
+const COMPLEX_TEMPLATE_SETTER_REGEX =
+	/Config\.setPublicLicenseKey\(\s*`[^`]*\$\{/;
 const CONFIG_IMPORT_REGEX =
 	/import\s*\{[^}]*\bConfig\b[^}]*\}\s*from\s*['"]@remotion\/cli\/config['"]/;
 
 export const validatePublicLicenseKey = (licenseKey: string | null) => {
-	if (
-		licenseKey !== null &&
-		licenseKey !== 'free-license' &&
-		!licenseKey.startsWith('rm_pub_')
-	) {
+	if (licenseKey === null || licenseKey === 'free-license') {
+		return;
+	}
+
+	if (!licenseKey.startsWith(LICENSE_KEY_PREFIX)) {
 		throw new Error(
 			'Invalid public license key. It must start with "rm_pub_" or be "free-license".',
 		);
 	}
+
+	const afterPrefix = licenseKey.slice(LICENSE_KEY_PREFIX.length);
+	if (!/^[a-zA-Z0-9]+$/.test(afterPrefix)) {
+		throw new Error(
+			'Invalid public license key. After "rm_pub_" it must contain only alphanumeric characters.',
+		);
+	}
+
+	if (licenseKey.length !== LICENSE_KEY_LENGTH) {
+		throw new Error(
+			`Invalid public license key. It must be ${LICENSE_KEY_LENGTH} characters long.`,
+		);
+	}
+};
+
+const formatSetterCall = (licenseKey: string) => {
+	return `Config.setPublicLicenseKey(${JSON.stringify(licenseKey)})`;
 };
 
 const formatSetter = (licenseKey: string) => {
-	return `Config.setPublicLicenseKey('${licenseKey}');`;
+	return `${formatSetterCall(licenseKey)};`;
 };
 
 const resolveConfigFile = (remotionRoot: string): string => {
@@ -73,6 +95,7 @@ export const setPublicLicenseKeyInConfig = ({
 
 	const configFile = resolveConfigFile(remotionRoot);
 	const setterLine = formatSetter(licenseKey);
+	const setterCall = formatSetterCall(licenseKey);
 
 	if (!fs.existsSync(configFile)) {
 		fs.writeFileSync(configFile, `${CONFIG_IMPORT}\n\n${setterLine}\n`);
@@ -80,25 +103,26 @@ export const setPublicLicenseKeyInConfig = ({
 	}
 
 	const config = fs.readFileSync(configFile, 'utf-8');
-	const lines = config.replace(/\n$/, '').split('\n');
+
+	if (COMPLEX_TEMPLATE_SETTER_REGEX.test(config)) {
+		throw new Error(
+			'Found Config.setPublicLicenseKey() using a template literal with ${}. Replace it with a string literal manually, then try again.',
+		);
+	}
 
 	let replaced = false;
-	const updatedLines = lines.map((line) => {
-		const nextLine = line.replace(
-			SETTER_REGEX,
-			`Config.setPublicLicenseKey('${licenseKey}')`,
-		);
-		if (nextLine !== line) {
-			replaced = true;
-		}
-
-		return nextLine;
+	const replacedConfig = config.replace(SETTER_REGEX, () => {
+		replaced = true;
+		return setterCall;
 	});
 
-	const nextLines = replaced
-		? updatedLines
-		: [...ensureConfigImport(updatedLines), setterLine];
+	if (replaced) {
+		fs.writeFileSync(configFile, replacedConfig.replace(/\n?$/, '\n'));
+		return {configFile};
+	}
 
+	const lines = config.replace(/\n$/, '').split('\n');
+	const nextLines = [...ensureConfigImport(lines), setterLine];
 	fs.writeFileSync(configFile, `${nextLines.join('\n')}\n`);
 
 	return {configFile};

--- a/packages/studio-server/src/test/set-public-license-key-in-config.test.ts
+++ b/packages/studio-server/src/test/set-public-license-key-in-config.test.ts
@@ -4,6 +4,9 @@ import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {setPublicLicenseKeyInConfig} from '../set-public-license-key-in-config';
 
+const VALID_COMPANY_KEY =
+	'rm_pub_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV';
+
 const withTempDir = (fn: (dir: string) => void) => {
 	const dir = mkdtempSync(path.join(tmpdir(), 'remotion-license-config-'));
 	try {
@@ -22,7 +25,7 @@ test('creates remotion.config.ts when missing', () => {
 
 		expect(configFile).toBe(path.join(dir, 'remotion.config.ts'));
 		expect(readFileSync(configFile, 'utf-8')).toBe(
-			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey('free-license');\n`,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey("free-license");\n`,
 		);
 	});
 });
@@ -41,7 +44,7 @@ test('appends setter when config has no setPublicLicenseKey', () => {
 		});
 
 		expect(readFileSync(configFile, 'utf-8')).toBe(
-			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('jpeg');\nConfig.setPublicLicenseKey('free-license');\n`,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('jpeg');\nConfig.setPublicLicenseKey("free-license");\n`,
 		);
 	});
 });
@@ -57,7 +60,7 @@ test('adds Config import when appending setter', () => {
 		});
 
 		expect(readFileSync(configFile, 'utf-8')).toBe(
-			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('jpeg');\nConfig.setPublicLicenseKey('free-license');\n`,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('jpeg');\nConfig.setPublicLicenseKey("free-license");\n`,
 		);
 	});
 });
@@ -76,7 +79,7 @@ test('replaces existing setter with single quotes', () => {
 		});
 
 		expect(readFileSync(configFile, 'utf-8')).toBe(
-			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey('free-license');\n`,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey("free-license");\n`,
 		);
 	});
 });
@@ -91,11 +94,51 @@ test('replaces existing setter with double quotes', () => {
 
 		setPublicLicenseKeyInConfig({
 			remotionRoot: dir,
-			licenseKey: 'rm_pub_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV',
+			licenseKey: VALID_COMPANY_KEY,
 		});
 
 		expect(readFileSync(configFile, 'utf-8')).toBe(
-			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey('rm_pub_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV');\n`,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey(${JSON.stringify(VALID_COMPANY_KEY)});\n`,
+		);
+	});
+});
+
+test('replaces multiline existing setter without duplicating', () => {
+	withTempDir((dir) => {
+		const configFile = path.join(dir, 'remotion.config.ts');
+		writeFileSync(
+			configFile,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey(\n\t'old-key'\n);\n`,
+		);
+
+		setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: 'free-license',
+		});
+
+		const next = readFileSync(configFile, 'utf-8');
+		expect(next).toBe(
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey("free-license");\n`,
+		);
+		expect(next.match(/setPublicLicenseKey/g)?.length).toBe(1);
+	});
+});
+
+test('replaces existing backtick setter', () => {
+	withTempDir((dir) => {
+		const configFile = path.join(dir, 'remotion.config.ts');
+		writeFileSync(
+			configFile,
+			"import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey(`old-key`);\n",
+		);
+
+		setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: 'free-license',
+		});
+
+		expect(readFileSync(configFile, 'utf-8')).toBe(
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey("free-license");\n`,
 		);
 	});
 });
@@ -120,7 +163,7 @@ test('prefers remotion.config.ts over remotion.config.js', () => {
 
 		expect(configFile).toBe(tsFile);
 		expect(readFileSync(tsFile, 'utf-8')).toContain(
-			"Config.setPublicLicenseKey('free-license');",
+			'Config.setPublicLicenseKey("free-license");',
 		);
 		expect(readFileSync(jsFile, 'utf-8')).not.toContain('setPublicLicenseKey');
 	});
@@ -141,7 +184,22 @@ test('uses remotion.config.js when ts is missing', () => {
 
 		expect(configFile).toBe(jsFile);
 		expect(readFileSync(jsFile, 'utf-8')).toContain(
-			"Config.setPublicLicenseKey('free-license');",
+			'Config.setPublicLicenseKey("free-license");',
+		);
+	});
+});
+
+test('accepts a realistic 55-character company license key', () => {
+	withTempDir((dir) => {
+		expect(VALID_COMPANY_KEY.length).toBe(55);
+
+		const {configFile} = setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: VALID_COMPANY_KEY,
+		});
+
+		expect(readFileSync(configFile, 'utf-8')).toContain(
+			`Config.setPublicLicenseKey(${JSON.stringify(VALID_COMPANY_KEY)});`,
 		);
 	});
 });
@@ -154,5 +212,38 @@ test('rejects invalid license keys', () => {
 				licenseKey: 'not-a-valid-key',
 			}),
 		).toThrow(/Invalid public license key/);
+	});
+});
+
+test('rejects string breakout payload', () => {
+	withTempDir((dir) => {
+		expect(() =>
+			setPublicLicenseKeyInConfig({
+				remotionRoot: dir,
+				licenseKey: "rm_pub_'); console.log('PWNED'); //",
+			}),
+		).toThrow(/alphanumeric|Invalid public license key/);
+	});
+});
+
+test('rejects short rm_pub_ keys', () => {
+	withTempDir((dir) => {
+		expect(() =>
+			setPublicLicenseKeyInConfig({
+				remotionRoot: dir,
+				licenseKey: 'rm_pub_short',
+			}),
+		).toThrow(/55 characters/);
+	});
+});
+
+test('rejects non-alphanumeric characters after rm_pub_ prefix', () => {
+	withTempDir((dir) => {
+		expect(() =>
+			setPublicLicenseKeyInConfig({
+				remotionRoot: dir,
+				licenseKey: 'rm_pub_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST-V',
+			}),
+		).toThrow(/alphanumeric/);
 	});
 });

--- a/packages/studio-server/src/test/set-public-license-key-in-config.test.ts
+++ b/packages/studio-server/src/test/set-public-license-key-in-config.test.ts
@@ -1,0 +1,158 @@
+import {expect, test} from 'bun:test';
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {setPublicLicenseKeyInConfig} from '../set-public-license-key-in-config';
+
+const withTempDir = (fn: (dir: string) => void) => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'remotion-license-config-'));
+	try {
+		fn(dir);
+	} finally {
+		rmSync(dir, {recursive: true, force: true});
+	}
+};
+
+test('creates remotion.config.ts when missing', () => {
+	withTempDir((dir) => {
+		const {configFile} = setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: 'free-license',
+		});
+
+		expect(configFile).toBe(path.join(dir, 'remotion.config.ts'));
+		expect(readFileSync(configFile, 'utf-8')).toBe(
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey('free-license');\n`,
+		);
+	});
+});
+
+test('appends setter when config has no setPublicLicenseKey', () => {
+	withTempDir((dir) => {
+		const configFile = path.join(dir, 'remotion.config.ts');
+		writeFileSync(
+			configFile,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('jpeg');\n`,
+		);
+
+		setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: 'free-license',
+		});
+
+		expect(readFileSync(configFile, 'utf-8')).toBe(
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('jpeg');\nConfig.setPublicLicenseKey('free-license');\n`,
+		);
+	});
+});
+
+test('adds Config import when appending setter', () => {
+	withTempDir((dir) => {
+		const configFile = path.join(dir, 'remotion.config.ts');
+		writeFileSync(configFile, `Config.setVideoImageFormat('jpeg');\n`);
+
+		setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: 'free-license',
+		});
+
+		expect(readFileSync(configFile, 'utf-8')).toBe(
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('jpeg');\nConfig.setPublicLicenseKey('free-license');\n`,
+		);
+	});
+});
+
+test('replaces existing setter with single quotes', () => {
+	withTempDir((dir) => {
+		const configFile = path.join(dir, 'remotion.config.ts');
+		writeFileSync(
+			configFile,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey('old-key');\n`,
+		);
+
+		setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: 'free-license',
+		});
+
+		expect(readFileSync(configFile, 'utf-8')).toBe(
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey('free-license');\n`,
+		);
+	});
+});
+
+test('replaces existing setter with double quotes', () => {
+	withTempDir((dir) => {
+		const configFile = path.join(dir, 'remotion.config.ts');
+		writeFileSync(
+			configFile,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey("old-key");\n`,
+		);
+
+		setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: 'rm_pub_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV',
+		});
+
+		expect(readFileSync(configFile, 'utf-8')).toBe(
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setPublicLicenseKey('rm_pub_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV');\n`,
+		);
+	});
+});
+
+test('prefers remotion.config.ts over remotion.config.js', () => {
+	withTempDir((dir) => {
+		const tsFile = path.join(dir, 'remotion.config.ts');
+		const jsFile = path.join(dir, 'remotion.config.js');
+		writeFileSync(
+			tsFile,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('jpeg');\n`,
+		);
+		writeFileSync(
+			jsFile,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('png');\n`,
+		);
+
+		const {configFile} = setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: 'free-license',
+		});
+
+		expect(configFile).toBe(tsFile);
+		expect(readFileSync(tsFile, 'utf-8')).toContain(
+			"Config.setPublicLicenseKey('free-license');",
+		);
+		expect(readFileSync(jsFile, 'utf-8')).not.toContain('setPublicLicenseKey');
+	});
+});
+
+test('uses remotion.config.js when ts is missing', () => {
+	withTempDir((dir) => {
+		const jsFile = path.join(dir, 'remotion.config.js');
+		writeFileSync(
+			jsFile,
+			`import {Config} from '@remotion/cli/config';\n\nConfig.setVideoImageFormat('jpeg');\n`,
+		);
+
+		const {configFile} = setPublicLicenseKeyInConfig({
+			remotionRoot: dir,
+			licenseKey: 'free-license',
+		});
+
+		expect(configFile).toBe(jsFile);
+		expect(readFileSync(jsFile, 'utf-8')).toContain(
+			"Config.setPublicLicenseKey('free-license');",
+		);
+	});
+});
+
+test('rejects invalid license keys', () => {
+	withTempDir((dir) => {
+		expect(() =>
+			setPublicLicenseKeyInConfig({
+				remotionRoot: dir,
+				licenseKey: 'not-a-valid-key',
+			}),
+		).toThrow(/Invalid public license key/);
+	});
+});

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -818,6 +818,11 @@ export type InstallPackageRequest = {
 };
 export type InstallPackageResponse = {};
 
+export type SetPublicLicenseKeyRequest = {
+	licenseKey: string;
+};
+export type SetPublicLicenseKeyResponse = {};
+
 export type UndoRequest = {};
 export type UndoResponse =
 	| {
@@ -975,6 +980,10 @@ export type ApiRoutes = {
 	'/api/install-package': ReqAndRes<
 		InstallPackageRequest,
 		InstallPackageResponse
+	>;
+	'/api/set-public-license-key': ReqAndRes<
+		SetPublicLicenseKeyRequest,
+		SetPublicLicenseKeyResponse
 	>;
 	'/api/undo': ReqAndRes<UndoRequest, UndoResponse>;
 	'/api/redo': ReqAndRes<RedoRequest, RedoResponse>;

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -82,6 +82,8 @@ export {
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse,
 	SaveSequencePropsResult,
+	SetPublicLicenseKeyRequest,
+	SetPublicLicenseKeyResponse,
 	SimpleDiff,
 	SplitJsxSequenceRequest,
 	SplitJsxSequenceResponse,

--- a/packages/studio/src/api/set-public-license-key.ts
+++ b/packages/studio/src/api/set-public-license-key.ts
@@ -1,0 +1,19 @@
+import type {SetPublicLicenseKeyResponse} from '@remotion/studio-shared';
+import {getRemotionEnvironment} from 'remotion';
+import {callApi} from '../components/call-api';
+
+export const setPublicLicenseKey = (
+	licenseKey: string,
+): Promise<SetPublicLicenseKeyResponse> => {
+	if (!getRemotionEnvironment().isStudio) {
+		throw new Error('setPublicLicenseKey() is only available in the Studio');
+	}
+
+	if (window.remotion_isReadOnlyStudio) {
+		throw new Error(
+			'setPublicLicenseKey() is not available in Read-Only Studio',
+		);
+	}
+
+	return callApi('/api/set-public-license-key', {licenseKey});
+};

--- a/packages/studio/src/components/ConfigureLicenseModal.tsx
+++ b/packages/studio/src/components/ConfigureLicenseModal.tsx
@@ -1,0 +1,165 @@
+import React, {useCallback, useContext, useEffect, useMemo} from 'react';
+import {restartStudio} from '../api/restart-studio';
+import {setPublicLicenseKey} from '../api/set-public-license-key';
+import {ShortcutHint} from '../error-overlay/remotion-overlay/ShortcutHint';
+import {StudioServerConnectionCtx} from '../helpers/client-id';
+import {LIGHT_TEXT} from '../helpers/colors';
+import {useKeybinding} from '../helpers/use-keybinding';
+import {Flex, Row} from './layout';
+import {ModalButton} from './ModalButton';
+import {ModalFooterContainer} from './ModalFooter';
+import {ModalHeader} from './ModalHeader';
+import {DismissableModal} from './NewComposition/DismissableModal';
+import {WebRenderModalLicense} from './RenderModal/WebRenderModalLicense';
+
+const container: React.CSSProperties = {
+	maxHeight: 480,
+	overflowY: 'auto',
+	paddingBottom: 8,
+};
+
+const text: React.CSSProperties = {
+	fontSize: 14,
+	padding: 20,
+	color: LIGHT_TEXT,
+};
+
+const LICENSE_KEY_LENGTH = 55;
+const LICENSE_KEY_PREFIX = 'rm_pub_';
+
+const isValidCompanyLicenseKey = (key: string): boolean => {
+	if (!key.startsWith(LICENSE_KEY_PREFIX)) {
+		return false;
+	}
+
+	const afterPrefix = key.slice(LICENSE_KEY_PREFIX.length);
+	if (!/^[a-zA-Z0-9]*$/.test(afterPrefix)) {
+		return false;
+	}
+
+	return key.length === LICENSE_KEY_LENGTH;
+};
+
+type State =
+	| {
+			type: 'idle';
+	  }
+	| {
+			type: 'applying';
+	  }
+	| {
+			type: 'restarting';
+	  }
+	| {
+			type: 'error';
+			error: Error;
+	  };
+
+export const ConfigureLicenseModal: React.FC = () => {
+	const initialPublicLicenseKey =
+		window.remotion_renderDefaults?.publicLicenseKey ?? null;
+	const [licenseKey, setLicenseKey] = React.useState<string | null>(
+		initialPublicLicenseKey,
+	);
+	const [state, setState] = React.useState<State>({type: 'idle'});
+	const {previewServerState: ctx} = useContext(StudioServerConnectionCtx);
+
+	const canApply = useMemo(() => {
+		if (licenseKey === 'free-license') {
+			return true;
+		}
+
+		if (licenseKey === null) {
+			return false;
+		}
+
+		return isValidCompanyLicenseKey(licenseKey);
+	}, [licenseKey]);
+
+	const disabled =
+		!canApply ||
+		state.type === 'applying' ||
+		state.type === 'restarting' ||
+		ctx.type !== 'connected';
+
+	const onApply = useCallback(async () => {
+		if (disabled || licenseKey === null) {
+			return;
+		}
+
+		setState({type: 'applying'});
+		try {
+			await setPublicLicenseKey(licenseKey);
+			setState({type: 'restarting'});
+			restartStudio();
+		} catch (err) {
+			setState({type: 'error', error: err as Error});
+		}
+	}, [disabled, licenseKey]);
+
+	const {registerKeybinding} = useKeybinding();
+	useEffect(() => {
+		if (disabled) {
+			return;
+		}
+
+		const enter = registerKeybinding({
+			callback() {
+				onApply();
+			},
+			commandCtrlKey: true,
+			key: 'Enter',
+			event: 'keydown',
+			preventDefault: true,
+			triggerIfInputFieldFocused: true,
+			keepRegisteredWhenNotHighestContext: true,
+		});
+
+		return () => {
+			enter.unregister();
+		};
+	}, [disabled, onApply, registerKeybinding]);
+
+	return (
+		<DismissableModal>
+			<ModalHeader title="Configure License" />
+			{state.type === 'restarting' ? (
+				<div style={text}>Restarting the Studio server...</div>
+			) : state.type === 'applying' ? (
+				<div style={text}>Saving license key to remotion.config.ts...</div>
+			) : state.type === 'error' ? (
+				<div style={text}>
+					Could not save license key: {state.error.message}
+				</div>
+			) : (
+				<div style={container}>
+					<WebRenderModalLicense
+						licenseKey={licenseKey}
+						setLicenseKey={setLicenseKey}
+						initialPublicLicenseKey={initialPublicLicenseKey}
+					/>
+				</div>
+			)}
+			<ModalFooterContainer>
+				<Row align="center">
+					{state.type === 'idle' ? (
+						<span style={{color: LIGHT_TEXT, fontSize: 13, lineHeight: 1.2}}>
+							Writes Config.setPublicLicenseKey() into remotion.config.ts
+							<br />
+							and restarts the Studio
+						</span>
+					) : null}
+					<Flex />
+					<ModalButton onClick={onApply} disabled={disabled}>
+						{state.type === 'restarting'
+							? 'Restarting...'
+							: state.type === 'applying'
+								? 'Applying...'
+								: 'Apply'}
+						{disabled ? null : <ShortcutHint keyToPress="↵" cmdOrCtrl />}
+					</ModalButton>
+				</Row>
+			</ModalFooterContainer>
+		</DismissableModal>
+	);
+};

--- a/packages/studio/src/components/ConfigureLicenseNudge.tsx
+++ b/packages/studio/src/components/ConfigureLicenseNudge.tsx
@@ -1,0 +1,51 @@
+import React, {useCallback, useContext} from 'react';
+import {LIGHT_TEXT, TRANSPARENT} from '../helpers/colors';
+import {ModalsContext} from '../state/modals';
+import {useZIndex} from '../state/z-index';
+
+const buttonStyle: React.CSSProperties = {
+	appearance: 'none',
+	color: LIGHT_TEXT,
+	border: 'none',
+	fontWeight: 'bold',
+	backgroundColor: TRANSPARENT,
+	cursor: 'pointer',
+	fontSize: 14,
+	display: 'inline-flex',
+	justifyContent: 'center',
+	paddingLeft: 8,
+	paddingRight: 8,
+};
+
+export const ConfigureLicenseNudge: React.FC<{
+	readonly readOnlyStudio: boolean;
+}> = ({readOnlyStudio}) => {
+	const {setSelectedModal} = useContext(ModalsContext);
+	const {tabIndex} = useZIndex();
+
+	const openModal = useCallback(() => {
+		setSelectedModal({
+			type: 'configure-license',
+		});
+	}, [setSelectedModal]);
+
+	if (readOnlyStudio || window.remotion_isReadOnlyStudio) {
+		return null;
+	}
+
+	if (window.remotion_renderDefaults?.publicLicenseKey != null) {
+		return null;
+	}
+
+	return (
+		<button
+			tabIndex={tabIndex}
+			style={buttonStyle}
+			onClick={openModal}
+			type="button"
+			title="Configure License"
+		>
+			Configure License
+		</button>
+	);
+};

--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -3,6 +3,7 @@ import React, {useCallback, useMemo, useState} from 'react';
 import {BACKGROUND, BORDER_BLACK, WHITE} from '../helpers/colors';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import {useMenuStructure} from '../helpers/use-menu-structure';
+import {ConfigureLicenseNudge} from './ConfigureLicenseNudge';
 import {Row, Spacing} from './layout';
 import type {MenuId} from './Menu/MenuItem';
 import {MenuItem} from './Menu/MenuItem';
@@ -154,6 +155,9 @@ export const MenuToolbar: React.FC<{
 			<MenuBuildIndicator />
 			<div style={flex} />
 			<div style={fixedWidthRight}>
+				{readOnlyStudio ? null : (
+					<ConfigureLicenseNudge readOnlyStudio={readOnlyStudio} />
+				)}
 				{readOnlyStudio ? null : <UndoRedoButtons />}
 				<SidebarCollapserControls />
 			</div>

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -3,6 +3,7 @@ import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {getStudioAskAIEnabled} from '../helpers/studio-runtime-config';
 import {ModalsContext} from '../state/modals';
 import {AskAiModal} from './AskAiModal';
+import {ConfigureLicenseModal} from './ConfigureLicenseModal';
 import {ConfirmationDialog} from './ConfirmationDialog';
 import {EffectPickerModal} from './EffectPickerModal';
 import {InstallPackageModal} from './InstallPackage';
@@ -166,6 +167,9 @@ export const Modals: React.FC<{
 			)}
 			{modalContextType && modalContextType.type === 'install-packages' && (
 				<InstallPackageModal packageManager={modalContextType.packageManager} />
+			)}
+			{modalContextType && modalContextType.type === 'configure-license' && (
+				<ConfigureLicenseModal />
 			)}
 
 			{modalContextType && modalContextType.type === 'quick-switcher' && (

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -187,6 +187,9 @@ export type ModalState =
 			packageManager: PackageManager;
 	  }
 	| {
+			type: 'configure-license';
+	  }
+	| {
 			type: 'quick-switcher';
 			mode: QuickSwitcherMode;
 			invocationTimestamp: number;


### PR DESCRIPTION
## Summary

Closes #9012

Adds a subtle **Configure License** control in the Studio toolbar (top right). It opens a modal that reuses the existing web-render license education UI. Choosing the free license or pasting a valid company public key writes `Config.setPublicLicenseKey(...)` into `remotion.config.ts` (or `.js`) and restarts Studio so the key is picked up.

Previously, the License tab in the web-render modal only showed a copy-paste snippet. It never persisted the config for you.

### Behavior
- Nudge is hidden in read-only Studio and when `publicLicenseKey` is already set
- Free path writes `free-license`
- Company path requires a 55-character `rm_pub_` key (alphanumeric after the prefix), matching the existing Studio validation
- Server-side validation matches that shape; the writer uses `JSON.stringify` so the value cannot break out of the string literal
- Existing `Config.setPublicLicenseKey(...)` calls are replaced (including multiline / quote / backtick forms). Complex template literals with `${...} ` are rejected with a clear error instead of appending a second call
- Custom `--config` paths are not rewritten; only the default `remotion.config.ts` / `.js` under the project root

## Verification

`
$ bun test src/test/set-public-license-key-in-config.test.ts
bun test v1.3.11 (af24e281)

 14 pass
 0 fail
 20 expect() calls
Ran 14 tests across 1 file.
`

Covered: create missing config, append, replace single/double/backtick/multiline, prefer `.ts` over `.js`, accept realistic company key, reject breakout payload / short keys / non-alnum after prefix.

## Notes

Developed with AI assistance (Cursor / Grok). Independently re-checked after a first pass found that the initial writer accepted arbitrary `rm_pub_*` strings; that is tightened in the follow-up commit.

Made with [Cursor](https://cursor.com)