### PR TITLE
`@remotion/studio`: Use default cursor for inline rename control (#8767)

### DIFF
--- a/packages/studio/src/components/InlineEditableTitle.tsx
+++ b/packages/studio/src/components/InlineEditableTitle.tsx
@@ -164,11 +164,11 @@ export const InlineEditableTitle: React.FC<{
 		return {
 			...titleInner,
 			backgroundColor,
-			cursor: isEditing ? 'text' : canRename ? 'pointer' : 'default',
+			cursor: isEditing ? 'text' : 'default',
 			userSelect: isEditing ? 'text' : 'none',
 			width: isEditing ? '100%' : undefined,
 		};
-	}, [backgroundColor, canRename, isEditing]);
+	}, [backgroundColor, isEditing]);
 
 	return (
 		<div style={titleWrapper} title={title ?? value}>


### PR DESCRIPTION
# `@remotion/studio`: Use default cursor for inline rename control

Closes #8767

## What this changes

The inline rename control used for asset, composition and sequence rows in Studio showed `cursor: pointer` when hovering a renameable label. A pointer cursor signals that a click opens or navigates to a new thing, but this control renames in place, so it was misleading.

This switches the non-editing hover state to `cursor: default`, matching the maintainer's request in #8767. The `text` cursor while the input is actively being edited is kept, since that is the standard and expected cursor for a focused text field.

## Where

`packages/studio/src/components/InlineEditableTitle.tsx` is the single shared component behind all three inline rename entry points:

- assets, via `CurrentAsset.tsx`
- compositions, via `InlineCompositionName.tsx` (`CurrentComposition.tsx`)
- sequences, via `InspectorPanel/SequenceInspectorHeader.tsx`

Fixing it in one place covers all three row types. The change is scoped to the rename control's own style object, not the surrounding row.

## The change

Before:

```ts
cursor: isEditing ? 'text' : canRename ? 'pointer' : 'default',
```

After:

```ts
cursor: isEditing ? 'text' : 'default',
```

`canRename` is no longer read inside this `useMemo`, so it was dropped from the dependency array. It is still used elsewhere in the component for the hover background color, so nothing else changes.

## Verification

Code-level, before and after:

- Before: hovering a renameable inline title showed `cursor: pointer`. The non-renameable and read-only states already used `default`.
- After: the non-editing state always resolves to `default`; the active-edit state stays `text`.

Honest caveats:

- I did not run the Studio GUI to visually confirm the rendered cursor. This is a pure CSS cursor property change with no logic branch beyond the one edited, so the code-level before/after above is the basis for the claim. A running-Studio visual check was not performed.
- The studio package formats with `oxfmt` via a pre-commit hook. The `oxfmt` binary is not installed in my working environment, so the format hook could not run and the commit was made without it. The two edited lines follow the repo `.prettierrc.js` conventions (tabs, single quotes) and touch no imports.
- No targeted test exists for `InlineEditableTitle`; none was added for a one-line cursor value.

## Tradeoffs

None of note. The behavior of clicking to start a rename is unchanged; only the hover cursor differs.

## AI assistance disclosure

This change was prepared with AI assistance (Claude) and reviewed before submission.
