### PR TITLE
@remotion/studio: Show if client render is production or development

### DIFF
--- a/packages/studio/src/components/RenderModal/WebRenderModalLicense.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModalLicense.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {
 	BLUE,
 	INPUT_BACKGROUND,
@@ -6,6 +6,7 @@ import {
 	LIGHT_TEXT,
 	WHITE,
 } from '../../helpers/colors';
+import {getClientRenderBillingHint} from '../../helpers/is-development-render-host';
 import {Checkbox} from '../Checkbox';
 import {Spacing} from '../layout';
 import {RemotionInput} from '../NewComposition/RemInput';
@@ -212,8 +213,21 @@ export const WebRenderModalLicense: React.FC<WebRenderModalLicenseProps> = ({
 			[setLicenseKey],
 		);
 
+	const billingHint = useMemo(() => {
+		if (typeof window === 'undefined') {
+			return null;
+		}
+
+		return getClientRenderBillingHint(window.location.hostname);
+	}, []);
+
 	return (
 		<div style={tabContainer}>
+			{billingHint ? (
+				<div style={{...paddedDescriptionStyle, marginTop: 16}}>
+					{billingHint}
+				</div>
+			) : null}
 			<div style={descriptionStyle}>
 				Remotion is free if you are an individual or company with a headcount of
 				3 or less. See{' '}

--- a/packages/studio/src/components/RenderQueue/ClientRenderQueueProcessor.tsx
+++ b/packages/studio/src/components/RenderQueue/ClientRenderQueueProcessor.tsx
@@ -10,6 +10,7 @@ import {
 	registerClientRender,
 	saveOutputFile,
 } from '../../api/save-render-output';
+import {isDevelopmentRenderHost} from '../../helpers/is-development-render-host';
 import type {
 	ClientRenderJob,
 	ClientRenderJobProgress,
@@ -18,6 +19,14 @@ import type {
 	GetBlobCallback,
 } from './client-side-render-types';
 import {RenderQueueContext} from './context';
+
+const getIsProductionClientRender = (): boolean => {
+	if (typeof window === 'undefined') {
+		return true;
+	}
+
+	return !isDevelopmentRenderHost(window.location.hostname);
+};
 
 type RenderResult = {
 	getBlob: GetBlobCallback;
@@ -77,6 +86,7 @@ export const ClientRenderQueueProcessor: React.FC = () => {
 					mediaCacheSizeInBytes: job.mediaCacheSizeInBytes,
 					logLevel: job.logLevel,
 					licenseKey: job.licenseKey ?? undefined,
+					isProduction: getIsProductionClientRender(),
 					scale: job.scale,
 					signal,
 				})
@@ -145,6 +155,7 @@ export const ClientRenderQueueProcessor: React.FC = () => {
 				},
 				outputTarget: 'web-fs',
 				licenseKey: job.licenseKey ?? undefined,
+				isProduction: getIsProductionClientRender(),
 				pageResponsiveness: job.pageResponsiveness,
 			});
 

--- a/packages/studio/src/helpers/is-development-render-host.ts
+++ b/packages/studio/src/helpers/is-development-render-host.ts
@@ -1,0 +1,20 @@
+export const isDevelopmentRenderHost = (hostname: string): boolean => {
+	const host = hostname.trim().toLowerCase();
+	if (host === 'localhost' || host === '127.0.0.1' || host === '::1') {
+		return true;
+	}
+
+	if (host.startsWith('[') && host.endsWith(']')) {
+		return host.slice(1, -1) === '::1';
+	}
+
+	return host.endsWith('.localhost');
+};
+
+export const getClientRenderBillingHint = (hostname: string): string => {
+	if (isDevelopmentRenderHost(hostname)) {
+		return 'This is a development render (localhost) and will not be charged.';
+	}
+
+	return 'This is considered a production render and may count toward usage.';
+};

--- a/packages/studio/src/test/is-development-render-host.test.ts
+++ b/packages/studio/src/test/is-development-render-host.test.ts
@@ -1,0 +1,29 @@
+import {expect, test} from 'bun:test';
+import {
+	getClientRenderBillingHint,
+	isDevelopmentRenderHost,
+} from '../helpers/is-development-render-host';
+
+test('treats localhost-style hosts as development renders', () => {
+	expect(isDevelopmentRenderHost('localhost')).toBe(true);
+	expect(isDevelopmentRenderHost('LOCALHOST')).toBe(true);
+	expect(isDevelopmentRenderHost('127.0.0.1')).toBe(true);
+	expect(isDevelopmentRenderHost('::1')).toBe(true);
+	expect(isDevelopmentRenderHost('[::1]')).toBe(true);
+	expect(isDevelopmentRenderHost('app.localhost')).toBe(true);
+});
+
+test('treats public hosts as production renders', () => {
+	expect(isDevelopmentRenderHost('example.com')).toBe(false);
+	expect(isDevelopmentRenderHost('studio.remotion.dev')).toBe(false);
+	expect(isDevelopmentRenderHost('192.168.1.10')).toBe(false);
+});
+
+test('billing hint distinguishes development and production', () => {
+	expect(getClientRenderBillingHint('localhost')).toBe(
+		'This is a development render (localhost) and will not be charged.',
+	);
+	expect(getClientRenderBillingHint('example.com')).toBe(
+		'This is considered a production render and may count toward usage.',
+	);
+});


### PR DESCRIPTION
## Summary

- Client-side render License tab now states whether the current Studio host is treated as a development render (localhost / `127.0.0.1` / `::1` / `*.localhost`) or a production render.
- Studio passes `isProduction: false` for those development hosts when calling `renderMediaOnWeb` / `renderStillOnWeb`, matching Remotion licensing docs (localhost is non-billable).
- Unit tests cover host classification and the billing hint copy.

Fixes #6169

## AI assistance

This PR was written with AI assistance (Cursor/Grok). I confirmed the License tab had no production/development hint, added the host helper + tests, ran the commands below, and reviewed the diff before opening.

## Verification

```text
cd packages/studio
bun test src/test/is-development-render-host.test.ts
# 3 pass, 0 fail, 11 expect() calls
```

## Test plan

- [x] `bun test packages/studio/src/test/is-development-render-host.test.ts`
- [ ] Studio on localhost: open Client-side render modal, License tab shows development / not charged hint
- [ ] Hosted Studio (non-localhost): License tab shows production / may count toward usage hint
