### PR TITLE
Docs: Clarify client-side stacking vs browser paint order

### DIFF
--- a/packages/docs/docs/client-side-rendering/limitations.mdx
+++ b/packages/docs/docs/client-side-rendering/limitations.mdx
@@ -181,6 +181,49 @@ const MyComp = () => {
 };
 ```
 
+## Stacking context and paint order
+
+Client-side rendering paints elements in tree order (later siblings on top). That can differ from how a normal browser tab stacks the same markup, especially when an absolutely positioned label sits before an [`<Img>`](/docs/img) in the React tree.
+
+In the browser preview, the label may appear on top of the image. During client-side rendering, the image is painted after the label, so the image covers the text.
+
+```tsx twoslash title="Label before Img: browser may show text on top; client-side rendering paints Img last"
+import {Img, staticFile} from 'remotion';
+
+// ---cut---
+const ScaleDownPreview = () => {
+  return (
+    <div style={{backgroundColor: '#e0e0e0', position: 'relative'}}>
+      <div
+        style={{
+          position: 'absolute',
+          top: 5,
+          left: 5,
+          fontSize: 12,
+          fontWeight: 'bold',
+        }}
+      >
+        scale-down
+      </div>
+      <Img
+        src={staticFile('1.webp')}
+        style={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'scale-down',
+        }}
+      />
+    </div>
+  );
+};
+```
+
+Put overlays after the media they should cover (or wrap each layer in [`<AbsoluteFill>`](/docs/absolute-fill) in back-to-front order). See [Layers](/docs/layers).
+
+:::info
+Automatic [HTML-in-canvas capture](/docs/client-side-rendering/html-in-canvas) takes a full screenshot, so browser stacking applies there instead of this paint-order rule.
+:::
+
 ## Video and media constraints
 
 The limitations from [`@remotion/media`](/docs/media/support) apply.

--- a/packages/docs/docs/layers.mdx
+++ b/packages/docs/docs/layers.mdx
@@ -55,8 +55,11 @@ export const MyComp: React.FC = () => {
 The lower the absolutely positioned element is in the tree, the higher it will be in the layer stack.  
 If you are aware of this behavior, you can use it to your advantage and avoid using `z-index` in most cases.
 
+Client-side rendering follows the same back-to-front tree order and does not honor `z-index`. Browser stacking can still differ for some layouts (for example a label before an [`<Img>`](/docs/img)); see [Stacking context and paint order](/docs/client-side-rendering/limitations#stacking-context-and-paint-order).
+
 ## See also
 
 - [`<AbsoluteFill>`](/docs/absolute-fill)
 - [`<Sequence>`](/docs/sequence)
+- [Limitations of client-side rendering](/docs/client-side-rendering/limitations)
 - [Build a timeline-based video editor](/docs/building-a-timeline)


### PR DESCRIPTION
Closes #6205

## Summary

Documents that client-side rendering paints in tree order (later siblings on top), which can differ from browser stacking when an absolutely positioned label sits before an `<Img>` in the React tree.

- New "Stacking context and paint order" section on the client-side rendering limitations page, using the issue's scale-down overlay example
- Cross-link from the Layers page
- Notes that HTML-in-canvas capture still follows browser stacking

## Verification

Prettier 3.8.1 with Remotion MDX options (`useTabs: false`, `printWidth: 300`):

```
Checking formatting...
All matched files use Prettier code style!
```

MDX compile with `@mdx-js/mdx` and `remark-gfm`:

```
OK limitations.mdx
OK layers.mdx
MDX COMPILE OK
```

Docs only; no package runtime behavior changed.

This fix was developed with AI assistance (Cursor / Grok) and verified locally as shown above.
