### PR TITLE
Docs: Warn against matching composition FPS to video FPS

### DIFF
--- a/packages/docs/docs/mediabunny/metadata.mdx
+++ b/packages/docs/docs/mediabunny/metadata.mdx
@@ -18,16 +18,7 @@ then [Mediabunny](https://mediabunny.dev) is the ideal library for doing so.
 ```tsx twoslash title="get-media-metadata.ts"
 import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 
-const commonFpsValues = [
-  24000 / 1001,
-  24,
-  25,
-  30000 / 1001,
-  30,
-  50,
-  60000 / 1001,
-  60,
-];
+const commonFpsValues = [24000 / 1001, 24, 25, 30000 / 1001, 30, 50, 60000 / 1001, 60];
 
 const snapToCommonFps = (fps: number) => {
   return commonFpsValues.find((commonFps) => Math.abs(fps - commonFps) < 0.01) ?? fps;
@@ -50,9 +41,7 @@ export const getMediaMetadata = async (src: string) => {
       }
     : null;
   const packetStats = await videoTrack?.computePacketStats(50);
-  const fps = packetStats
-    ? snapToCommonFps(packetStats.averagePacketRate)
-    : null;
+  const fps = packetStats ? snapToCommonFps(packetStats.averagePacketRate) : null;
 
   return {
     durationInSeconds,
@@ -72,20 +61,17 @@ export const getMediaMetadata = async (src: string) => {
   <p>The FPS is an estimate based on packet timestamps. We snap it to common FPS values because container timestamp rounding can return values such as `29.999` or `30.006` for videos that are nominally 30 FPS. Values like `29.97` and `59.94` are represented exactly as `30000 / 1001` and `60000 / 1001`.</p>
 </details>
 
+:::warning Do not match composition FPS to the video FPS
+The estimated FPS is useful for display and diagnostics. It is generally a bad idea to set your Remotion composition [`fps`](/docs/composition#fps) from it so the composition "matches" the source video.
+
+Many real-world videos are variable frame rate (VFR), and container timestamps often only approximate a nominal rate. Remotion already samples `<Video>` / media by timeline time, so pick a standard composition FPS such as `24`, `25`, `30`, or `60` instead of copying the estimated value.
+:::
+
 ```tsx twoslash title="Usage example"
 // @filename: get-media-metadata.ts
 import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 
-const commonFpsValues = [
-  24000 / 1001,
-  24,
-  25,
-  30000 / 1001,
-  30,
-  50,
-  60000 / 1001,
-  60,
-];
+const commonFpsValues = [24000 / 1001, 24, 25, 30000 / 1001, 30, 50, 60000 / 1001, 60];
 
 const snapToCommonFps = (fps: number) => {
   return commonFpsValues.find((commonFps) => Math.abs(fps - commonFps) < 0.01) ?? fps;
@@ -108,9 +94,7 @@ export const getMediaMetadata = async (src: string) => {
       }
     : null;
   const packetStats = await videoTrack?.computePacketStats(50);
-  const fps = packetStats
-    ? snapToCommonFps(packetStats.averagePacketRate)
-    : null;
+  const fps = packetStats ? snapToCommonFps(packetStats.averagePacketRate) : null;
 
   return {
     durationInSeconds,


### PR DESCRIPTION
Closes #8815

## Summary

Adds a warning on the Mediabunny metadata docs page: do not set composition `fps` from the estimated video FPS to match the source.

Reasoning matches the issue: many videos are variable frame rate, and packet-based FPS is only an estimate (also affected by container timestamp rounding). Remotion samples media by timeline time, so a standard composition FPS (`24` / `25` / `30` / `60`) is the right default.

Upstream VFR detection in Mediabunny (Vanilagy/mediabunny#320) is left for a follow-up once that API exists.

## Verification

Prettier 3.x with repo MDX options (`useTabs: false`, `printWidth: 300`):

```
Checking formatting...
All matched files use Prettier code style!
```

Touched file:

- `packages/docs/docs/mediabunny/metadata.mdx`

Docs-only change; no package behavior changed.

This fix was developed with AI assistance (Cursor / Grok) and verified locally as shown above.
