### PR TITLE
Skills: Prefer TransitionSeries for multi-scene remotion-create

### DIFF
--- a/packages/skills/skills/remotion-create/SKILL.md
+++ b/packages/skills/skills/remotion-create/SKILL.md
@@ -27,6 +27,32 @@ Replace `my-video` with a suitable project name.
 
 Keep the scaffold and add React Markup. Follow [Remotion React Markup Best Practices](../remotion-markup/SKILL.md) and [Video Layout Rules](video-layout.md) for video-first layout and text sizing guidance.
 
+## Multi-scene videos
+
+If the brief implies more than one scene (promo, story, chapters, before/after, etc.), structure the composition with [`<TransitionSeries>`](../remotion-markup/transitions.md) rather than a flat tree of sibling sequences:
+
+```tsx
+import {TransitionSeries, linearTiming} from '@remotion/transitions';
+import {fade} from '@remotion/transitions/fade';
+
+<TransitionSeries>
+  <TransitionSeries.Sequence durationInFrames={90}>
+    <Scene1 />
+  </TransitionSeries.Sequence>
+  <TransitionSeries.Transition presentation={fade()} timing={linearTiming({durationInFrames: 15})} />
+  <TransitionSeries.Sequence durationInFrames={90}>
+    <Scene2 />
+  </TransitionSeries.Sequence>
+</TransitionSeries>;
+```
+
+Rules:
+
+- Put each scene in its own component (`Scene1`, `Scene2`, ...).
+- Keep transitions short. Prefer about `12`-`20` frames at 30fps (roughly 0.4-0.7s). Default to `fade()` with `linearTiming({durationInFrames: 15})` unless the brief asks for a different presentation.
+- Install the package when needed: `npx remotion add @remotion/transitions`.
+- See [transitions](../remotion-markup/transitions.md) for overlays and other presentation types.
+
 ## Interactivity Best Practices
 
 By structuring the React Markup following [Remotion Interactivity Best Practices](../remotion-interactivity/SKILL.md), you allow the user to make edits in the Studio which write back to code.


### PR DESCRIPTION
Closes #9066

## Summary

Updates `/remotion-create` so multi-scene briefs (promo, story, chapters, etc.) default to a `<TransitionSeries>` structure with short fade transitions between scene components.

- Scene components stay separate (`Scene1`, `Scene2`, ...)
- Default transition: `fade()` + `linearTiming({durationInFrames: 15})` (about 0.5s at 30fps; keep transitions in the 12-20 frame range)
- Points agents at the existing transitions skill and `@remotion/transitions` install command

Related interactivity/timeline workflows in #8974 are out of scope for this skill nudge.

## Verification

Prettier with repo markdown options:

```
Checking formatting...
All matched files use Prettier code style!
```

Touched file:

- `packages/skills/skills/remotion-create/SKILL.md`

(best-practices symlink `remotion-create` still points at this skill)

Docs/skills-only change; no package behavior changed.

This fix was developed with AI assistance (Cursor / Grok) and verified locally as shown above.
