### PR TITLE
@remotion/studio: Filter assets in the Assets panel

### DIFF
--- a/packages/studio/src/components/AssetSelector.tsx
+++ b/packages/studio/src/components/AssetSelector.tsx
@@ -3,6 +3,10 @@ import {writeStaticFile} from '../api/write-static-file';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {BACKGROUND, WHITE_ALPHA_06, LIGHT_TEXT} from '../helpers/colors';
 import {buildAssetFolderStructure} from '../helpers/create-folder-tree';
+import {
+	filterStaticFilesByQuery,
+	getExpandedFoldersForFilteredAssets,
+} from '../helpers/filter-static-files';
 import {toggleBooleanMapKey} from '../helpers/persist-boolean-map';
 import {persistExpandedFolders} from '../helpers/persist-open-folders';
 import useAssetDragEvents, {
@@ -12,6 +16,7 @@ import {FolderContext} from '../state/folders';
 import {useZIndex} from '../state/z-index';
 import {AssetFolderTree} from './AssetSelectorItem';
 import {inlineCodeSnippet} from './Menu/styles';
+import {RemotionInput} from './NewComposition/RemInput';
 import {showNotification} from './Notifications/NotificationCenter';
 import {useStaticFiles} from './use-static-files';
 
@@ -39,6 +44,15 @@ const label: React.CSSProperties = {
 	fontSize: 14,
 };
 
+const searchContainer: React.CSSProperties = {
+	padding: '8px 10px',
+	flexShrink: 0,
+};
+
+const searchInput: React.CSSProperties = {
+	width: '100%',
+};
+
 const baseList: React.CSSProperties = {
 	overflowY: 'auto',
 };
@@ -50,6 +64,7 @@ export const AssetSelector: React.FC<{
 	const {assetFoldersExpanded, setAssetFoldersExpanded} =
 		useContext(FolderContext);
 	const [dropLocation, setDropLocation] = useState<string | null>(null);
+	const [filterQuery, setFilterQuery] = useState('');
 	const connectionStatus = useContext(StudioServerConnectionCtx)
 		.previewServerState.type;
 	const shouldAllowUpload = connectionStatus === 'connected' && !readOnlyStudio;
@@ -63,10 +78,31 @@ export const AssetSelector: React.FC<{
 
 	const staticFiles = useStaticFiles();
 	const publicFolderExists = window.remotion_publicFolderExists;
+	const trimmedFilterQuery = filterQuery.trim();
+	const filteredFiles = useMemo(() => {
+		return filterStaticFilesByQuery(staticFiles, filterQuery);
+	}, [filterQuery, staticFiles]);
+
+	const foldersExpandedForTree = useMemo(() => {
+		if (trimmedFilterQuery.length === 0) {
+			return assetFoldersExpanded;
+		}
+
+		return getExpandedFoldersForFilteredAssets(filteredFiles);
+	}, [assetFoldersExpanded, filteredFiles, trimmedFilterQuery]);
 
 	const assetTree = useMemo(() => {
-		return buildAssetFolderStructure(staticFiles, null, assetFoldersExpanded);
-	}, [assetFoldersExpanded, staticFiles]);
+		return buildAssetFolderStructure(
+			filteredFiles,
+			null,
+			foldersExpandedForTree,
+		);
+	}, [filteredFiles, foldersExpandedForTree]);
+
+	const onFilterChange: React.ChangeEventHandler<HTMLInputElement> =
+		useCallback((event) => {
+			setFilterQuery(event.target.value);
+		}, []);
 
 	const toggleFolder = useCallback(
 		(folderName: string, parentName: string | null) => {
@@ -184,27 +220,48 @@ export const AssetSelector: React.FC<{
 					</div>
 				)
 			) : (
-				<div
-					className="__remotion-vertical-scrollbar"
-					style={{
-						...list,
-						backgroundColor: isDropDiv ? WHITE_ALPHA_06 : BACKGROUND,
-					}}
-					onDragEnter={onDragEnter}
-					onDragLeave={onDragLeave}
-				>
-					<AssetFolderTree
-						item={assetTree}
-						level={0}
-						parentFolder={null}
-						name={null}
-						tabIndex={tabIndex}
-						toggleFolder={toggleFolder}
-						dropLocation={dropLocation}
-						setDropLocation={setDropLocation}
-						readOnlyStudio={readOnlyStudio}
-					/>
-				</div>
+				<>
+					<div style={searchContainer}>
+						<RemotionInput
+							type="search"
+							style={searchInput}
+							status="ok"
+							value={filterQuery}
+							onChange={onFilterChange}
+							placeholder="Filter assets..."
+							rightAlign={false}
+							small
+							aria-label="Filter assets"
+						/>
+					</div>
+					{filteredFiles.length === 0 ? (
+						<div style={emptyState}>
+							<div style={label}>No assets match this filter.</div>
+						</div>
+					) : (
+						<div
+							className="__remotion-vertical-scrollbar"
+							style={{
+								...list,
+								backgroundColor: isDropDiv ? WHITE_ALPHA_06 : BACKGROUND,
+							}}
+							onDragEnter={onDragEnter}
+							onDragLeave={onDragLeave}
+						>
+							<AssetFolderTree
+								item={assetTree}
+								level={0}
+								parentFolder={null}
+								name={null}
+								tabIndex={tabIndex}
+								toggleFolder={toggleFolder}
+								dropLocation={dropLocation}
+								setDropLocation={setDropLocation}
+								readOnlyStudio={readOnlyStudio}
+							/>
+						</div>
+					)}
+				</>
 			)}
 		</div>
 	);

--- a/packages/studio/src/helpers/filter-static-files.ts
+++ b/packages/studio/src/helpers/filter-static-files.ts
@@ -1,0 +1,28 @@
+export const filterStaticFilesByQuery = <T extends {readonly name: string}>(
+	files: readonly T[],
+	query: string,
+): T[] => {
+	const normalized = query.trim().toLowerCase();
+	if (normalized.length === 0) {
+		return [...files];
+	}
+
+	return files.filter((file) => file.name.toLowerCase().includes(normalized));
+};
+
+export const getExpandedFoldersForFilteredAssets = (
+	files: readonly {readonly name: string}[],
+): Record<string, boolean> => {
+	const expanded: Record<string, boolean> = {};
+
+	for (const file of files) {
+		const parts = file.name.split('/');
+		let current = '';
+		for (let i = 0; i < parts.length - 1; i++) {
+			current = current ? `${current}/${parts[i]}` : parts[i];
+			expanded[current] = true;
+		}
+	}
+
+	return expanded;
+};

--- a/packages/studio/src/test/filter-static-files.test.ts
+++ b/packages/studio/src/test/filter-static-files.test.ts
@@ -1,0 +1,41 @@
+import {expect, test} from 'bun:test';
+import {
+	filterStaticFilesByQuery,
+	getExpandedFoldersForFilteredAssets,
+} from '../helpers/filter-static-files';
+
+test('filterStaticFilesByQuery returns all files for an empty query', () => {
+	const files = [{name: 'logo.png'}, {name: 'audio/theme.mp3'}];
+
+	expect(filterStaticFilesByQuery(files, '')).toEqual(files);
+	expect(filterStaticFilesByQuery(files, '   ')).toEqual(files);
+});
+
+test('filterStaticFilesByQuery matches path segments case-insensitively', () => {
+	const files = [
+		{name: 'logo.png'},
+		{name: 'audio/Theme.mp3'},
+		{name: 'images/hero/Logo.webp'},
+	];
+
+	expect(
+		filterStaticFilesByQuery(files, 'logo').map((file) => file.name),
+	).toEqual(['logo.png', 'images/hero/Logo.webp']);
+	expect(
+		filterStaticFilesByQuery(files, 'THEME').map((file) => file.name),
+	).toEqual(['audio/Theme.mp3']);
+});
+
+test('getExpandedFoldersForFilteredAssets expands every ancestor folder', () => {
+	expect(
+		getExpandedFoldersForFilteredAssets([
+			{name: 'images/hero/Logo.webp'},
+			{name: 'audio/Theme.mp3'},
+			{name: 'root.png'},
+		]),
+	).toEqual({
+		images: true,
+		'images/hero': true,
+		audio: true,
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a Filter assets search field above the Studio Assets tree
- Filters `public` files by path (case-insensitive substring)
- Expands ancestor folders for matches so nested hits stay visible
- Shows an empty state when nothing matches

Fixes #8427

## AI assistance

This PR was written with AI assistance (Cursor/Grok). I confirmed the Assets panel had no filter UI at HEAD, implemented the helper + Studio wiring, ran the commands below, and reviewed the diff before opening.

## Verification

```text
cd packages/studio
bun test src/test/filter-static-files.test.ts
# 3 pass, 0 fail, 5 expect() calls
```

## Test plan

- [x] `bun test packages/studio/src/test/filter-static-files.test.ts`
- [ ] Studio Assets panel: type a filename fragment and confirm only matching assets remain
- [ ] Nested path match expands parent folders
- [ ] Clearing the filter restores the full tree and prior expand state

Made with [Cursor](https://cursor.com)