### PR TITLE
Elements: Add Corner Channel Bug

### DIFF
--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -36,7 +36,10 @@ const sidebars: SidebarsConfig = {
 			label: 'Overlays',
 			link: {type: 'doc', id: 'overlays/index'},
 			collapsed: false,
-			items: ['overlays/lower-third/index'],
+			items: [
+				'overlays/corner-channel-bug/index',
+				'overlays/lower-third/index',
+			],
 		},
 		{
 			type: 'category',

--- a/packages/docs/elements/overlays/corner-channel-bug/corner-channel-bug.tsx
+++ b/packages/docs/elements/overlays/corner-channel-bug/corner-channel-bug.tsx
@@ -1,0 +1,101 @@
+import {loadFont} from '@remotion/google-fonts/Inter';
+import React from 'react';
+import {Easing, Interactive, interpolate, useCurrentFrame} from 'remotion';
+
+loadFont('normal', {
+	subsets: ['latin'],
+	weights: ['600', '700'],
+});
+
+export const CornerChannelBug: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	const enter = interpolate(frame, [0, 20], [0, 1], {
+		extrapolateLeft: 'clamp',
+		extrapolateRight: 'clamp',
+		easing: Easing.out(Easing.cubic),
+	});
+
+	const tilt = interpolate(frame, [0, 90, 180], [8, -4, 8], {
+		extrapolateLeft: 'clamp',
+		extrapolateRight: 'clamp',
+		easing: Easing.inOut(Easing.sin),
+	});
+
+	const livePulse = interpolate(frame % 45, [0, 22, 45], [1, 0.45, 1], {
+		extrapolateLeft: 'clamp',
+		extrapolateRight: 'clamp',
+	});
+
+	return (
+		<Interactive.Div
+			name="Container"
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: 12,
+				boxSizing: 'border-box',
+				padding: '10px 16px',
+				borderRadius: 999,
+				fontFamily: 'Inter',
+				backgroundColor: 'rgba(15, 23, 42, 0.86)',
+				border: '1px solid rgba(255, 255, 255, 0.14)',
+				boxShadow: '0 10px 30px rgba(15, 23, 42, 0.35)',
+				color: '#f8fafc',
+				opacity: enter,
+				transform: `perspective(600px) rotateY(${tilt}deg) translateY(${
+					(1 - enter) * 12
+				}px)`,
+				transformOrigin: 'right top',
+				backdropFilter: 'blur(10px)',
+			}}
+		>
+			<Interactive.Div
+				name="Live dot"
+				style={{
+					width: 10,
+					height: 10,
+					borderRadius: 999,
+					backgroundColor: '#ef4444',
+					boxShadow: '0 0 0 4px rgba(239, 68, 68, 0.18)',
+					opacity: livePulse,
+					flexShrink: 0,
+				}}
+			/>
+			<div
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					gap: 2,
+					minWidth: 0,
+				}}
+			>
+				<Interactive.Div
+					name="Label"
+					style={{
+						fontSize: 18,
+						fontWeight: 700,
+						letterSpacing: '0.08em',
+						lineHeight: 1.1,
+						textTransform: 'uppercase',
+					}}
+				>
+					Remotion
+				</Interactive.Div>
+				<Interactive.Div
+					name="Secondary label"
+					style={{
+						fontSize: 13,
+						fontWeight: 600,
+						letterSpacing: '0.14em',
+						lineHeight: 1.1,
+						color: '#94a3b8',
+						textTransform: 'uppercase',
+					}}
+				>
+					Live
+				</Interactive.Div>
+			</div>
+		</Interactive.Div>
+	);
+};

--- a/packages/docs/elements/overlays/corner-channel-bug/index.mdx
+++ b/packages/docs/elements/overlays/corner-channel-bug/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Corner Channel Bug
+description: A compact animated corner brand mark with an optional live indicator.
+---
+
+import {ElementPage} from '@site/src/components/Elements/ElementPage';
+import {elementDefinitions} from '@site/src/components/Elements/element-definitions';
+
+# Corner Channel Bug
+
+<ElementPage definition={elementDefinitions['overlays/corner-channel-bug']} sourceFile="./corner-channel-bug.tsx" />

--- a/packages/docs/elements/overlays/index.mdx
+++ b/packages/docs/elements/overlays/index.mdx
@@ -7,4 +7,5 @@ description: Drop-in overlay Elements for Remotion videos.
 
 Elements:
 
+- [Corner Channel Bug](/elements/overlays/corner-channel-bug/)
 - [Lower third](/elements/overlays/lower-third/)

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -4,6 +4,7 @@ import {NotebookPaper} from '../../../elements/backgrounds/notebook-paper/notebo
 import {PaperTexture} from '../../../elements/backgrounds/paper-texture/paper-texture';
 import {RotatingStarburst} from '../../../elements/backgrounds/rotating-starburst/rotating-starburst';
 import {NumberCounter} from '../../../elements/data/number-counter/number-counter';
+import {CornerChannelBug} from '../../../elements/overlays/corner-channel-bug/corner-channel-bug';
 import {LowerThird} from '../../../elements/overlays/lower-third/lower-third';
 import {CircleMarker} from '../../../elements/text/circle-marker/circle-marker';
 import {CrossedOffText} from '../../../elements/text/crossed-off/crossed-off';
@@ -93,6 +94,23 @@ export const elementDefinitions = {
 		posterFrame: 120,
 		previewPadding: 0,
 		slug: 'backgrounds/rotating-starburst',
+		width: 1920,
+	},
+	'overlays/corner-channel-bug': {
+		category: 'overlays',
+		component: CornerChannelBug,
+		contributors: [],
+		description:
+			'A small animated corner brand mark with a live indicator for channels and shows.',
+		displayName: 'Corner Channel Bug',
+		durationInFrames: 180,
+		elementHeight: 56,
+		elementWidth: 220,
+		fps: 30,
+		height: 1080,
+		posterFrame: 45,
+		previewPadding: 220,
+		slug: 'overlays/corner-channel-bug',
 		width: 1920,
 	},
 	'overlays/lower-third': {


### PR DESCRIPTION
## Summary

- Adds the Corner Channel Bug overlay Element (Identity and Attribution)
- Self-contained `.tsx` with inlined defaults: label, secondary label, and live dot
- Editable via `Interactive.Div` names (same pattern as Lower Third and other shipped Elements; Element previews are zero-prop components)
- Registers preview metadata, overlays index, and Elements sidebar entry

Fixes #8621

## AI assistance

This PR was written with AI assistance (Cursor/Grok). I followed the existing overlays Element layout (Lower Third), confirmed no covering PR, formatted with Prettier-compatible options, and reviewed the diff before opening.

## Verification

Prettier (repo style: single quotes, no bracket spacing, tabs for TS, printWidth 300 for MDX):

```text
Checking formatting...
All matched files use Prettier code style!
```

Touched files:

- `packages/docs/elements/overlays/corner-channel-bug/corner-channel-bug.tsx`
- `packages/docs/elements/overlays/corner-channel-bug/index.mdx`
- `packages/docs/elements/overlays/index.mdx`
- `packages/docs/src/components/Elements/element-definitions.ts`
- `packages/docs/elements-sidebars.ts`

Full `bun test src/test/elements.test.ts` needs a built docs workspace (`react` / `@remotion/google-fonts`); not available in this fresh worktree. The new Element follows the colocated single-file + ElementPage format used by existing overlays.

## Test plan

- [x] Prettier check on touched files
- [ ] Element page renders at `/elements/overlays/corner-channel-bug/`
- [ ] Studio drag/install path still works for the new slug
- [ ] Visual: compact corner mark with subtle 3D tilt and live pulse

Made with [Cursor](https://cursor.com)