### PR TITLE
Elements: Add Source / Credit Tag

### DIFF
--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -36,7 +36,7 @@ const sidebars: SidebarsConfig = {
 			label: 'Overlays',
 			link: {type: 'doc', id: 'overlays/index'},
 			collapsed: false,
-			items: ['overlays/lower-third/index'],
+			items: ['overlays/lower-third/index', 'overlays/source-credit-tag/index'],
 		},
 		{
 			type: 'category',

--- a/packages/docs/elements/overlays/index.mdx
+++ b/packages/docs/elements/overlays/index.mdx
@@ -8,3 +8,4 @@ description: Drop-in overlay Elements for Remotion videos.
 Elements:
 
 - [Lower third](/elements/overlays/lower-third/)
+- [Source / Credit Tag](/elements/overlays/source-credit-tag/)

--- a/packages/docs/elements/overlays/source-credit-tag/index.mdx
+++ b/packages/docs/elements/overlays/source-credit-tag/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Source / Credit Tag
+description: A compact attribution label for footage, images, and other third-party sources.
+---
+
+import {ElementPage} from '@site/src/components/Elements/ElementPage';
+import {elementDefinitions} from '@site/src/components/Elements/element-definitions';
+
+# Source / Credit Tag
+
+<ElementPage definition={elementDefinitions['overlays/source-credit-tag']} sourceFile="./source-credit-tag.tsx" />

--- a/packages/docs/elements/overlays/source-credit-tag/source-credit-tag.tsx
+++ b/packages/docs/elements/overlays/source-credit-tag/source-credit-tag.tsx
@@ -1,0 +1,62 @@
+import {loadFont} from '@remotion/google-fonts/Inter';
+import React from 'react';
+import {Easing, Interactive, interpolate, useCurrentFrame} from 'remotion';
+
+loadFont('normal', {
+	subsets: ['latin'],
+	weights: ['500', '600'],
+});
+
+export const SourceCreditTag: React.FC = () => {
+	const frame = useCurrentFrame();
+
+	const enter = interpolate(frame, [0, 16], [0, 1], {
+		extrapolateLeft: 'clamp',
+		extrapolateRight: 'clamp',
+		easing: Easing.out(Easing.cubic),
+	});
+
+	return (
+		<Interactive.Div
+			name="Container"
+			style={{
+				display: 'inline-flex',
+				alignItems: 'baseline',
+				gap: 8,
+				boxSizing: 'border-box',
+				padding: '8px 12px',
+				borderRadius: 8,
+				fontFamily: 'Inter',
+				backgroundColor: 'rgba(24, 24, 27, 0.72)',
+				border: '1px solid rgba(255, 255, 255, 0.1)',
+				color: '#fafafa',
+				opacity: enter,
+				transform: `translateY(${(1 - enter) * 8}px)`,
+				backdropFilter: 'blur(8px)',
+			}}
+		>
+			<Interactive.Div
+				name="Prefix"
+				style={{
+					fontSize: 16,
+					fontWeight: 500,
+					lineHeight: 1.2,
+					color: '#a1a1aa',
+				}}
+			>
+				Source:
+			</Interactive.Div>
+			<Interactive.Div
+				name="Source"
+				style={{
+					fontSize: 16,
+					fontWeight: 600,
+					lineHeight: 1.2,
+					color: '#fafafa',
+				}}
+			>
+				NASA
+			</Interactive.Div>
+		</Interactive.Div>
+	);
+};

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -5,6 +5,7 @@ import {PaperTexture} from '../../../elements/backgrounds/paper-texture/paper-te
 import {RotatingStarburst} from '../../../elements/backgrounds/rotating-starburst/rotating-starburst';
 import {NumberCounter} from '../../../elements/data/number-counter/number-counter';
 import {LowerThird} from '../../../elements/overlays/lower-third/lower-third';
+import {SourceCreditTag} from '../../../elements/overlays/source-credit-tag/source-credit-tag';
 import {CircleMarker} from '../../../elements/text/circle-marker/circle-marker';
 import {CrossedOffText} from '../../../elements/text/crossed-off/crossed-off';
 import {StrikeThroughText} from '../../../elements/text/strike-through/strike-through';
@@ -110,6 +111,23 @@ export const elementDefinitions = {
 		posterFrame: 60,
 		previewPadding: 300,
 		slug: 'overlays/lower-third',
+		width: 1920,
+	},
+	'overlays/source-credit-tag': {
+		category: 'overlays',
+		component: SourceCreditTag,
+		contributors: [],
+		description:
+			'A compact attribution label for crediting footage, images, and other sources.',
+		displayName: 'Source / Credit Tag',
+		durationInFrames: 90,
+		elementHeight: 40,
+		elementWidth: 180,
+		fps: 30,
+		height: 1080,
+		posterFrame: 30,
+		previewPadding: 200,
+		slug: 'overlays/source-credit-tag',
 		width: 1920,
 	},
 	'data/number-counter': {


### PR DESCRIPTION
## Summary

- Adds the Source / Credit Tag overlay Element (Identity and Attribution)
- Self-contained `.tsx` with inlined defaults demonstrating `Source: NASA`
- Editable prefix and source via `Interactive.Div` (same pattern as shipped Elements)
- Registers preview metadata, overlays index, and Elements sidebar entry

Fixes #8622

## AI assistance

This PR was written with AI assistance (Cursor/Grok). I followed the existing overlays Element layout, confirmed no covering PR, formatted with Prettier-compatible options, and reviewed the diff before opening.

## Verification

Prettier (repo style: single quotes, no bracket spacing, tabs for TS, printWidth 300 for MDX):

```text
Checking formatting...
All matched files use Prettier code style!
```

Touched files:

- `packages/docs/elements/overlays/source-credit-tag/source-credit-tag.tsx`
- `packages/docs/elements/overlays/source-credit-tag/index.mdx`
- `packages/docs/elements/overlays/index.mdx`
- `packages/docs/src/components/Elements/element-definitions.ts`
- `packages/docs/elements-sidebars.ts`

Full `bun test src/test/elements.test.ts` needs a built docs workspace; not available in this fresh worktree. The new Element follows the colocated single-file + ElementPage format used by existing overlays.

## Test plan

- [x] Prettier check on touched files
- [ ] Element page renders at `/elements/overlays/source-credit-tag/`
- [ ] Studio drag/install path still works for the new slug
- [ ] Visual: compact unobtrusive attribution chip