### PR TITLE
@remotion/studio: Support `durationInFrames - n` in Interactivity

### DIFF
--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -43,6 +43,14 @@ export type VideoConfigNumericExpression =
 			multiplicand: number;
 			factorPosition: 'left' | 'right';
 			value: number;
+	  }
+	| {
+			type: 'video-config-subtraction';
+			identifier: string;
+			amount: number;
+			configValue: number;
+			amountPosition: 'left' | 'right';
+			value: number;
 	  };
 
 export type CanUpdateSequencePropStatusLinearEasing = {

--- a/packages/studio-server/src/helpers/video-config-numeric-expression.ts
+++ b/packages/studio-server/src/helpers/video-config-numeric-expression.ts
@@ -54,36 +54,15 @@ const getVideoConfigValue = ({
 	return {identifier: node.name, value};
 };
 
-export const parseVideoConfigNumericExpression = ({
-	node,
+const parseMultiplication = ({
+	left,
+	right,
 	videoConfigValues,
 }: {
-	node: Expression;
+	left: Expression;
+	right: Expression;
 	videoConfigValues: VideoConfigIdentifierValues;
 }): VideoConfigNumericExpression | null => {
-	if (node.type === 'TSAsExpression') {
-		return parseVideoConfigNumericExpression({
-			node: node.expression as Expression,
-			videoConfigValues,
-		});
-	}
-
-	const literal = getNumericLiteral(node);
-	if (literal !== null) {
-		return {type: 'literal', value: literal};
-	}
-
-	const videoConfigValue = getVideoConfigValue({node, videoConfigValues});
-	if (videoConfigValue !== null) {
-		return {type: 'video-config-value', ...videoConfigValue};
-	}
-
-	if (node.type !== 'BinaryExpression' || node.operator !== '*') {
-		return null;
-	}
-
-	const left = node.left as Expression;
-	const right = node.right as Expression;
 	const leftNumber = getNumericLiteral(left);
 	const rightNumber = getNumericLiteral(right);
 	const leftVideoConfig = getVideoConfigValue({
@@ -123,6 +102,99 @@ export const parseVideoConfigNumericExpression = ({
 	};
 };
 
+const parseSubtraction = ({
+	left,
+	right,
+	videoConfigValues,
+}: {
+	left: Expression;
+	right: Expression;
+	videoConfigValues: VideoConfigIdentifierValues;
+}): VideoConfigNumericExpression | null => {
+	const leftNumber = getNumericLiteral(left);
+	const rightNumber = getNumericLiteral(right);
+	const leftVideoConfig = getVideoConfigValue({
+		node: left,
+		videoConfigValues,
+	});
+	const rightVideoConfig = getVideoConfigValue({
+		node: right,
+		videoConfigValues,
+	});
+
+	const amountPosition =
+		leftNumber !== null && rightVideoConfig !== null
+			? 'left'
+			: rightNumber !== null && leftVideoConfig !== null
+				? 'right'
+				: null;
+	if (amountPosition === null) {
+		return null;
+	}
+
+	const amount = amountPosition === 'left' ? leftNumber! : rightNumber!;
+	const configValue =
+		amountPosition === 'left' ? rightVideoConfig! : leftVideoConfig!;
+	const value =
+		amountPosition === 'left'
+			? amount - configValue.value
+			: configValue.value - amount;
+	if (!Number.isFinite(value)) {
+		return null;
+	}
+
+	return {
+		type: 'video-config-subtraction',
+		identifier: configValue.identifier,
+		amount,
+		configValue: configValue.value,
+		amountPosition,
+		value,
+	};
+};
+
+export const parseVideoConfigNumericExpression = ({
+	node,
+	videoConfigValues,
+}: {
+	node: Expression;
+	videoConfigValues: VideoConfigIdentifierValues;
+}): VideoConfigNumericExpression | null => {
+	if (node.type === 'TSAsExpression') {
+		return parseVideoConfigNumericExpression({
+			node: node.expression as Expression,
+			videoConfigValues,
+		});
+	}
+
+	const literal = getNumericLiteral(node);
+	if (literal !== null) {
+		return {type: 'literal', value: literal};
+	}
+
+	const videoConfigValue = getVideoConfigValue({node, videoConfigValues});
+	if (videoConfigValue !== null) {
+		return {type: 'video-config-value', ...videoConfigValue};
+	}
+
+	if (node.type !== 'BinaryExpression') {
+		return null;
+	}
+
+	const left = node.left as Expression;
+	const right = node.right as Expression;
+
+	if (node.operator === '*') {
+		return parseMultiplication({left, right, videoConfigValues});
+	}
+
+	if (node.operator === '-') {
+		return parseSubtraction({left, right, videoConfigValues});
+	}
+
+	return null;
+};
+
 const numericExpression = (value: number): ExpressionKind => {
 	if (value < 0) {
 		return b.unaryExpression('-', b.numericLiteral(-value), true);
@@ -148,18 +220,42 @@ export const updateVideoConfigNumericExpression = ({
 			: numericExpression(value);
 	}
 
-	if (expression.type !== 'video-config-multiplication' || value === 0) {
-		return numericExpression(value);
+	if (expression.type === 'video-config-multiplication') {
+		if (value === 0) {
+			return numericExpression(value);
+		}
+
+		const multiplier = value / expression.multiplicand;
+		if (!Number.isFinite(multiplier) || multiplier === 0) {
+			return numericExpression(value);
+		}
+
+		const factor = numericExpression(multiplier);
+		const identifier = b.identifier(expression.identifier);
+		return expression.factorPosition === 'left'
+			? b.binaryExpression('*', factor, identifier)
+			: b.binaryExpression('*', identifier, factor);
 	}
 
-	const multiplier = value / expression.multiplicand;
-	if (!Number.isFinite(multiplier) || multiplier === 0) {
-		return numericExpression(value);
+	if (expression.type === 'video-config-subtraction') {
+		const amount =
+			expression.amountPosition === 'left'
+				? value + expression.configValue
+				: expression.configValue - value;
+		if (!Number.isFinite(amount)) {
+			return numericExpression(value);
+		}
+
+		if (amount === 0 && expression.amountPosition === 'right') {
+			return b.identifier(expression.identifier);
+		}
+
+		const amountNode = numericExpression(amount);
+		const identifier = b.identifier(expression.identifier);
+		return expression.amountPosition === 'left'
+			? b.binaryExpression('-', amountNode, identifier)
+			: b.binaryExpression('-', identifier, amountNode);
 	}
 
-	const factor = numericExpression(multiplier);
-	const identifier = b.identifier(expression.identifier);
-	return expression.factorPosition === 'left'
-		? b.binaryExpression('*', factor, identifier)
-		: b.binaryExpression('*', identifier, factor);
+	return numericExpression(value);
 };

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -50,7 +50,7 @@ export const Example: React.FC = () => {
 			postmountFor={fps * 2.5}
 			offset={-1 * fps}
 			from={fps / 2}
-			style={{scale: interpolate(frame, [0, 3.33 * fps, durationInFrames], [2, 3, 4])}}
+			style={{scale: interpolate(frame, [0, 3.33 * fps, durationInFrames - 1], [2, 3, 4])}}
 		/>
 	);
 };
@@ -103,11 +103,15 @@ export const Example: React.FC = () => {
 				},
 			},
 			{
-				frame: 120,
+				frame: 119,
 				value: 4,
 				frameExpression: {
-					type: 'video-config-value',
+					type: 'video-config-subtraction',
 					identifier: 'durationInFrames',
+					amount: 1,
+					configValue: 120,
+					amountPosition: 'right',
+					value: 119,
 				},
 			},
 		],

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -139,6 +139,60 @@ export const Example: React.FC = () => {
 	});
 });
 
+test('updateSequenceKeyframes updates a durationInFrames subtraction when moving a keyframe', async () => {
+	const input = `import React from 'react';
+import {Sequence, interpolate, useCurrentFrame, useVideoConfig} from 'remotion';
+
+export const Example: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {durationInFrames} = useVideoConfig();
+	return (
+		<Sequence style={{opacity: interpolate(frame, [0, durationInFrames - 1], [0, 1])}} />
+	);
+};
+`;
+	const {output, updatedNodePath} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, 8),
+		updates: [
+			{
+				key: 'style.opacity',
+				operation: {
+					type: 'move',
+					moves: [{fromFrame: 119, toFrame: 100}],
+				},
+			},
+		],
+		videoConfigValues,
+	});
+
+	expect(output).toContain('[0, durationInFrames - 20]');
+	const status = computeSequencePropsStatusFromContent({
+		fileContents: output,
+		nodePath: updatedNodePath,
+		componentIdentity: null,
+		keys: ['style.opacity'],
+		effects: [],
+		videoConfigValues,
+	});
+	expect(status.props['style.opacity']).toMatchObject({
+		status: 'keyframed',
+		keyframes: [
+			{frame: 0, value: 0},
+			{
+				frame: 100,
+				value: 1,
+				frameExpression: {
+					type: 'video-config-subtraction',
+					identifier: 'durationInFrames',
+					amount: 20,
+					amountPosition: 'right',
+				},
+			},
+		],
+	});
+});
+
 const colorInput = `import React from 'react';
 import {Solid, interpolateColors, useCurrentFrame} from 'remotion';
 

--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -66,6 +66,35 @@ export const Example: React.FC = () => {
 	expect(output).toContain('opacity: 4 * fps');
 });
 
+test('updateSequenceProps preserves video config subtraction expressions', async () => {
+	const input = `import {Sequence, useVideoConfig} from 'remotion';
+
+export const Example: React.FC = () => {
+	const {durationInFrames} = useVideoConfig();
+	return (
+		<Sequence
+			from={durationInFrames - 10}
+			durationInFrames={(durationInFrames - 1) as number}
+		/>
+	);
+};
+`;
+	const {output} = await updateSequenceProps({
+		input,
+		nodePath: lineColumnToNodePath(input, 6),
+		updates: [
+			{key: 'from', value: 100, defaultValue: null},
+			{key: 'durationInFrames', value: 110, defaultValue: null},
+		],
+		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
+		videoConfigValues,
+	});
+
+	expect(output).toContain('from={durationInFrames - 20}');
+	expect(output).toContain('durationInFrames={durationInFrames - 10}');
+});
+
 test('updateSequenceProps should update a number value', async () => {
 	const {output, oldValueStrings} = await updateSequenceProps({
 		videoConfigValues: null,

--- a/packages/studio-server/src/test/video-config-numeric-expression.test.ts
+++ b/packages/studio-server/src/test/video-config-numeric-expression.test.ts
@@ -1,0 +1,71 @@
+import {expect, test} from 'bun:test';
+import * as recast from 'recast';
+import {
+	parseVideoConfigNumericExpression,
+	updateVideoConfigNumericExpression,
+} from '../helpers/video-config-numeric-expression';
+import {parseExpression} from './test-utils';
+
+const videoConfigValues = {
+	durationInFrames: 120,
+	fps: 30,
+	height: 1080,
+	width: 1920,
+};
+
+const printExpression = (
+	node: ReturnType<typeof updateVideoConfigNumericExpression>,
+) => recast.print(node).code;
+
+test('parseVideoConfigNumericExpression parses durationInFrames subtraction', () => {
+	expect(
+		parseVideoConfigNumericExpression({
+			node: parseExpression('durationInFrames - 1'),
+			videoConfigValues,
+		}),
+	).toEqual({
+		type: 'video-config-subtraction',
+		identifier: 'durationInFrames',
+		amount: 1,
+		configValue: 120,
+		amountPosition: 'right',
+		value: 119,
+	});
+
+	expect(
+		parseVideoConfigNumericExpression({
+			node: parseExpression('1 - durationInFrames'),
+			videoConfigValues,
+		}),
+	).toEqual({
+		type: 'video-config-subtraction',
+		identifier: 'durationInFrames',
+		amount: 1,
+		configValue: 120,
+		amountPosition: 'left',
+		value: -119,
+	});
+});
+
+test('updateVideoConfigNumericExpression preserves subtraction shape', () => {
+	const expression = parseVideoConfigNumericExpression({
+		node: parseExpression('durationInFrames - 1'),
+		videoConfigValues,
+	});
+	expect(expression?.type).toBe('video-config-subtraction');
+	if (expression?.type !== 'video-config-subtraction') {
+		throw new Error('expected subtraction');
+	}
+
+	expect(
+		printExpression(
+			updateVideoConfigNumericExpression({expression, value: 100}),
+		),
+	).toBe('durationInFrames - 20');
+
+	expect(
+		printExpression(
+			updateVideoConfigNumericExpression({expression, value: 120}),
+		),
+	).toBe('durationInFrames');
+});


### PR DESCRIPTION
Closes #9170

## Summary

Studio Interactivity already understands video-config multiplication such as `fps * 2` / `2 * fps` (#9139). This adds the subtraction form requested in #9170, so expressions like `durationInFrames - 1` stay editable in the timeline and inspector instead of falling back to a computed / non-editable value.

Parse and rewrite cover both operand orders (`durationInFrames - n` and `n - durationInFrames`). Moving a keyframe or updating a numeric prop keeps the subtraction shape when possible (for example dragging `durationInFrames - 1` to frame 100 becomes `durationInFrames - 20`).

## Verification

`bun test` in `packages/studio-server` for the related suites:

```
111 pass
0 fail
```

Files:

- `src/test/video-config-numeric-expression.test.ts`
- `src/test/update-keyframes.test.ts`
- `src/test/update-sequence-props.test.ts`
- `src/test/compute-sequence-props-status.test.ts`

This fix was developed with AI assistance (Cursor / Grok) and verified locally as shown above.