### PR TITLE
fix(eslint-config-internal): use fileURLToPath for __dirname on Windows

### DIFF
--- a/packages/eslint-config-internal/src/index.ts
+++ b/packages/eslint-config-internal/src/index.ts
@@ -1,11 +1,12 @@
 import {createRequire} from 'node:module';
+import {fileURLToPath} from 'node:url';
 import {FlatCompat} from '@eslint/eslintrc';
 import js from '@eslint/js';
 import typescriptPlugin from '@typescript-eslint/eslint-plugin';
 import parser from '@typescript-eslint/parser';
 
 const require = createRequire(import.meta.url);
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const {configs, rules: reactRules} = require('eslint-plugin-react');
 


### PR DESCRIPTION
## What

`@remotion/eslint-config-internal` builds `__dirname` from `new URL('.', import.meta.url).pathname`. On Windows that yields a leading-slash path like `/C:/Users/.../eslint-config-internal/src/`, which is not a valid native directory. It is passed straight into `FlatCompat({ baseDirectory: __dirname })`, so FlatCompat resolves configs against a broken base and the internal lint config fails for contributors running on Windows.

macOS and Linux are unaffected because their `file://` pathname has no leading-slash-before-drive quirk.

## Fix

Use `fileURLToPath()` from `node:url`, which converts the `file://` URL to a correct native path on every platform:

```diff
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
```

One import plus one line. `createRequire(import.meta.url)` on the line above already uses the URL directly and is fine.

## Verification

Reproduced on Windows 11, Node 24:

```
$ node --input-type=module -e "import{fileURLToPath}from'node:url';const u=new URL('./x/',import.meta.url);console.log('pathname:',u.pathname);console.log('fileURLToPath:',fileURLToPath(u));"
pathname: /C:/Users/stans/Projects/oss/x/
fileURLToPath: C:\Users\stans\Projects\oss\x\
```

The `.pathname` form (`/C:/...`) is the invalid `baseDirectory` FlatCompat received; `fileURLToPath` returns the correct native path. The change is formatting-consistent with the surrounding imports.

## Note

Found while checking Remotion for the same `import.meta.url` / `.pathname` Windows footgun. AI-assisted (Claude / Claude Code); a human reviewed the diff before submitting. No em dashes.
