### PR TITLE
Docs: Hot-reload Element TSX source in local docs

### DIFF
--- a/packages/docs/elements/guidelines.mdx
+++ b/packages/docs/elements/guidelines.mdx
@@ -56,4 +56,10 @@ Follow the [interactivity best practices](/docs/studio/interactivity-best-practi
 
 Choose a poster frame that shows the Element in a visible, representative state. The video preview should cover the complete configured duration, including entrance and exit animations.
 
+## Local docs development
+
+When you run the docs site locally, edits to an Element MDX page and its colocated `.tsx` source should refresh on the Elements route without restarting the server. The Element page wires the `.tsx` file through Webpack so the preview, displayed source, and Studio drag payload stay in sync.
+
+If Elements look stale after a production deploy, purge the Cloudflare cache for the Elements routes (or the whole zone). Manual cache intervention has been needed before when CDN HTML or assets served an older Elements build.
+
 When the Element satisfies these guidelines, see [Submit an Element](/elements/submit-an-element).

--- a/packages/docs/plugins/element-source-file-loader.cjs
+++ b/packages/docs/plugins/element-source-file-loader.cjs
@@ -1,0 +1,17 @@
+/**
+ * Webpack loader that exports an Element .tsx file as a trimmed string.
+ * Used so MDX modules depend on the Element source and hot-reload when it changes.
+ *
+ * @param {string | Buffer} source
+ * @returns {string}
+ */
+module.exports = function elementSourceFileLoader(source) {
+	if (this.cacheable) {
+		this.cacheable(true);
+	}
+
+	const text =
+		typeof source === 'string' ? source : Buffer.from(source).toString('utf8');
+
+	return `module.exports = ${JSON.stringify(text.trimEnd())}`;
+};

--- a/packages/docs/plugins/remark-element-source.js
+++ b/packages/docs/plugins/remark-element-source.js
@@ -1,7 +1,31 @@
+import path from 'path';
+import {fileURLToPath} from 'url';
 import {
 	getRemotionElementDependencies,
 	getRemotionElementSource,
 } from './element-source-utils.js';
+
+const ELEMENT_SOURCE_LOADER = path
+	.resolve(
+		path.dirname(fileURLToPath(import.meta.url)),
+		'element-source-file-loader.cjs',
+	)
+	.replaceAll('\\', '/');
+
+const toPosixPath = (filePath) => filePath.replaceAll('\\', '/');
+
+const getWebpackElementSourceRequest = ({file, sourceFilePath}) => {
+	const absoluteSourcePath = path.resolve(path.dirname(sourceFilePath), file);
+	const relativeSourcePath = toPosixPath(
+		path.relative(path.dirname(sourceFilePath), absoluteSourcePath),
+	);
+	const webpackResource = relativeSourcePath.startsWith('.')
+		? relativeSourcePath
+		: `./${relativeSourcePath}`;
+
+	// !! disables other loaders so .tsx is read as text, not compiled as JS.
+	return `!!${ELEMENT_SOURCE_LOADER}!${webpackResource}`;
+};
 
 const getAttributeValue = (node, name) => {
 	const attribute = node.attributes?.find((attr) => attr.name === name);
@@ -13,8 +37,8 @@ const getAttributeValue = (node, name) => {
 	return attribute.value;
 };
 
-const sourceCodeAttribute = (sourceCode) => {
-	const value = JSON.stringify(sourceCode);
+const sourceCodeAttribute = (webpackRequest) => {
+	const value = `require(${JSON.stringify(webpackRequest)})`;
 
 	return {
 		type: 'mdxJsxAttribute',
@@ -29,9 +53,19 @@ const sourceCodeAttribute = (sourceCode) => {
 						{
 							type: 'ExpressionStatement',
 							expression: {
-								type: 'Literal',
-								value: sourceCode,
-								raw: value,
+								type: 'CallExpression',
+								callee: {
+									type: 'Identifier',
+									name: 'require',
+								},
+								arguments: [
+									{
+										type: 'Literal',
+										value: webpackRequest,
+										raw: JSON.stringify(webpackRequest),
+									},
+								],
+								optional: false,
 							},
 						},
 					],
@@ -74,7 +108,7 @@ const dependenciesAttribute = (dependencies) => {
 	};
 };
 
-const setElementPageSource = ({dependencies, node, sourceCode}) => {
+const setElementPageSource = ({dependencies, node, webpackRequest}) => {
 	const attributesWithoutSourceFile = (node.attributes ?? []).filter(
 		(attribute) => attribute.name !== 'sourceFile',
 	);
@@ -85,7 +119,7 @@ const setElementPageSource = ({dependencies, node, sourceCode}) => {
 
 	node.attributes = [
 		...attributesWithoutGeneratedValues,
-		sourceCodeAttribute(sourceCode),
+		sourceCodeAttribute(webpackRequest),
 		dependenciesAttribute(dependencies),
 	];
 };
@@ -103,7 +137,8 @@ const getSourceCodeNode = ({node, sourceFilePath}) => {
 
 	const sourceCode = getRemotionElementSource({file, sourceFilePath});
 	const dependencies = getRemotionElementDependencies(sourceCode);
-	setElementPageSource({dependencies, node, sourceCode});
+	const webpackRequest = getWebpackElementSourceRequest({file, sourceFilePath});
+	setElementPageSource({dependencies, node, webpackRequest});
 
 	return {
 		type: 'code',
@@ -141,4 +176,4 @@ export default function remarkElementSource() {
 			sourceFilePath: file.path,
 		});
 	};
-}
+};

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -100,6 +100,12 @@ describe('Elements must follow the colocated single-file format', () => {
 		expect(
 			elementPage.attributes.some((attr) => attr.name === 'sourceCode'),
 		).toBe(true);
+		const sourceCode = elementPage.attributes.find(
+			(attribute) => attribute.name === 'sourceCode',
+		);
+		expect(sourceCode?.value.value).toContain('element-source-file-loader.cjs');
+		expect(sourceCode?.value.value).toContain(sourceFile.replaceAll('\\', '/'));
+		expect(sourceCode?.value.value).toMatch(/^require\(/);
 		const dependencies = elementPage.attributes.find(
 			(attribute) => attribute.name === 'dependencies',
 		);

--- a/packages/docs/src/test/remark-element-source.test.ts
+++ b/packages/docs/src/test/remark-element-source.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, test} from 'bun:test';
+import {existsSync, readdirSync, readFileSync, statSync} from 'fs';
+import path from 'path';
+import {getRemotionElementDependencies} from '../../plugins/element-source-utils';
+import remarkElementSource from '../../plugins/remark-element-source';
+
+const elementsRoot = path.join(__dirname, '..', '..', 'elements');
+
+type Element = {
+	mdxPath: string;
+	tsxPath: string;
+};
+
+const findFirstElement = (root: string): Element | null => {
+	let found: Element | null = null;
+
+	const walk = (dir: string) => {
+		if (found) {
+			return;
+		}
+
+		const indexMdx = path.join(dir, 'index.mdx');
+		if (existsSync(indexMdx)) {
+			const tsxFiles = readdirSync(dir).filter(
+				(f) => f.endsWith('.tsx') && !f.endsWith('.test.tsx'),
+			);
+			if (tsxFiles.length > 0) {
+				found = {
+					mdxPath: indexMdx,
+					tsxPath: path.join(dir, tsxFiles[0]),
+				};
+				return;
+			}
+		}
+
+		for (const entry of readdirSync(dir)) {
+			const full = path.join(dir, entry);
+			if (statSync(full).isDirectory()) {
+				walk(full);
+			}
+		}
+	};
+
+	walk(root);
+	return found;
+};
+
+const getRelativeTsxPath = (tsxPath: string, mdxPath: string) => {
+	const relative = path.relative(path.dirname(mdxPath), tsxPath);
+	return relative.startsWith('.') ? relative : `./${relative}`;
+};
+
+describe('remark-element-source Webpack dependency', () => {
+	test('sourceCode uses the Element source file loader for hot reload', () => {
+		const element = findFirstElement(elementsRoot);
+		expect(element).not.toBeNull();
+		if (!element) {
+			return;
+		}
+
+		const sourceFile = getRelativeTsxPath(element.tsxPath, element.mdxPath);
+		const elementPage = {
+			type: 'mdxJsxFlowElement',
+			name: 'ElementPage',
+			attributes: [
+				{
+					type: 'mdxJsxAttribute',
+					name: 'sourceFile',
+					value: sourceFile,
+				},
+			],
+			children: [] as Array<Record<string, unknown>>,
+		};
+		const tree = {type: 'root', children: [elementPage]};
+
+		remarkElementSource()(tree, {path: element.mdxPath});
+
+		const sourceCode = elementPage.attributes.find(
+			(attribute) => attribute.name === 'sourceCode',
+		);
+		expect(sourceCode?.value.value).toMatch(/^require\(/);
+		expect(sourceCode?.value.value).toContain('element-source-file-loader.cjs');
+		expect(sourceCode?.value.value).toContain(sourceFile.replaceAll('\\', '/'));
+
+		const dependencies = elementPage.attributes.find(
+			(attribute) => attribute.name === 'dependencies',
+		);
+		expect(dependencies?.value.value).toBe(
+			JSON.stringify(
+				getRemotionElementDependencies(readFileSync(element.tsxPath, 'utf8')),
+			),
+		);
+
+		expect(elementPage.children[0]).toMatchObject({
+			type: 'code',
+			lang: 'tsx',
+			value: readFileSync(element.tsxPath, 'utf8').trimEnd(),
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- `remark-element-source` now loads Element `sourceCode` through a small Webpack loader so the MDX module depends on the colocated `.tsx` file
- Editing an Element source file in local docs should refresh the Element page source, drag payload, and twoslash block without a server restart
- Guidelines note: if production Elements look stale after a deploy, purge the Cloudflare cache for Elements routes

Fixes #8789

## AI assistance

This PR was written with AI assistance (Cursor/Grok). I confirmed the bug shape at HEAD (`fs.readFileSync` in the remark plugin with no Webpack dependency), implemented the loader wiring, ran the focused test below, and reviewed the diff before opening.

## Verification

```text
cd packages/docs
bun test src/test/remark-element-source.test.ts
# 1 pass, 0 fail, 6 expect() calls
```

Full `elements.test.ts` needs a built monorepo workspace; the new focused test covers the Webpack `require` dependency shape without importing Element preview modules.

## Test plan

- [x] `bun test packages/docs/src/test/remark-element-source.test.ts`
- [ ] `bun start` in `packages/docs`, open an Element page, edit the colocated `.tsx`, confirm View code / drag payload update without restart
- [ ] Edit the Element MDX and confirm the route still hot-reloads

Made with [Cursor](https://cursor.com)