### PR TITLE
@remotion/studio-server: Fix Windows Explorer /select argv

### DIFF
--- a/packages/studio-server/src/open-directory-in-finder.ts
+++ b/packages/studio-server/src/open-directory-in-finder.ts
@@ -2,6 +2,7 @@ import {spawn} from 'node:child_process';
 import {platform} from 'node:os';
 import path from 'node:path';
 import {NoReactInternals} from 'remotion/no-react';
+import {getWindowsExplorerSelectArgs} from './windows-explorer-select';
 
 export const openDirectoryInFinder = (
 	dirToOpen: string,
@@ -15,7 +16,9 @@ export const openDirectoryInFinder = (
 	}
 
 	if (platform() === 'win32') {
-		const proc = spawn('explorer.exe', ['/select,', resolved]);
+		const proc = spawn('explorer.exe', getWindowsExplorerSelectArgs(resolved), {
+			windowsHide: true,
+		});
 
 		return new Promise<void>((resolve, reject) => {
 			proc.on('exit', (code) => {

--- a/packages/studio-server/src/test/open-directory-in-finder.test.ts
+++ b/packages/studio-server/src/test/open-directory-in-finder.test.ts
@@ -1,0 +1,20 @@
+import {expect, test} from 'bun:test';
+import {getWindowsExplorerSelectArgs} from '../windows-explorer-select';
+
+test('Windows explorer /select uses a single combined argv entry', () => {
+	const resolved = 'C:\\Users\\demo\\project\\src\\Root.tsx';
+	const args = getWindowsExplorerSelectArgs(resolved);
+
+	expect(args).toEqual([`/select,${resolved}`]);
+	expect(args).toHaveLength(1);
+	// Regression guard: must not be the broken two-arg form
+	expect(args).not.toEqual(['/select,', resolved]);
+});
+
+test('Windows explorer /select keeps spaces inside the path portion', () => {
+	const resolved = 'C:\\Users\\demo\\My Project\\file.tsx';
+	const args = getWindowsExplorerSelectArgs(resolved);
+
+	expect(args).toEqual(['/select,C:\\Users\\demo\\My Project\\file.tsx']);
+	expect(args).toHaveLength(1);
+});

--- a/packages/studio-server/src/windows-explorer-select.ts
+++ b/packages/studio-server/src/windows-explorer-select.ts
@@ -1,0 +1,7 @@
+// Explorer needs `/select,<path>` as one argv entry. Two args get quoted
+// separately on Windows and the selection target is ignored.
+export const getWindowsExplorerSelectArgs = (
+	resolvedPath: string,
+): string[] => {
+	return [`/select,${resolvedPath}`];
+};


### PR DESCRIPTION
## What

On Windows, "Reveal in Explorer" (Studio open-in-file-explorer) calls:

```ts
spawn('explorer.exe', ['/select,', resolved]);
```

Explorer expects a single `/select,<path>` token. With two argv entries, Node's Windows quoting separates them, so Explorer ignores the selection target (often opens a parent folder or Documents instead of highlighting the file).

## Fix

- Build one argv entry: `/select,` + resolved path
- Pass `windowsHide: true` so no console flash
- Extract `getWindowsExplorerSelectArgs` for a small unit test

## Verification

Unit tests (Windows 11, bun 1.3.11):

```
$ bun test src/test/open-directory-in-finder.test.ts
(pass) Windows explorer /select uses a single combined argv entry
(pass) Windows explorer /select keeps spaces inside the path portion
 2 pass
 0 fail
```

Windows spawn probe (Node v24.15.0): Win32 `CommandLine` for a path with spaces:

```
BROKEN two-arg form (current HEAD)
  spawn args: ["/select,","C:\\Users\\demo\\My Project\\Root.tsx"]
  Win32 CommandLine: ... /select, "C:\Users\demo\My Project\Root.tsx"

FIXED single-arg form
  spawn args: ["/select,C:\\Users\\demo\\My Project\\Root.tsx"]
  Win32 CommandLine: ... "/select,C:\Users\demo\My Project\Root.tsx"
```

Broken form leaves `/select,` and the path as separate tokens; fixed form is one quoted `/select,<path>` token.

## Note

Unfiled Windows footgun found while scouting Remotion on this machine. AI-assisted (Cursor / Grok); a human reviewed the diff before submitting. No em dashes.
