### PR TITLE
@remotion/studio: Preserve subframe media duration caps

### DIFF
--- a/packages/core/src/test/get-media-duration.test.ts
+++ b/packages/core/src/test/get-media-duration.test.ts
@@ -66,6 +66,21 @@ test('parentSequence with subframe duration caps without truncation', () => {
 	expect(duration).toBe(23.5);
 });
 
+// Nested <Audio> inside Series.Sequence: useVideoConfig() returns the parent
+// sequence duration (23.5), so both inputs are fractional. Must not floor to 23.
+test('nested media under subframe parent keeps fractional duration', () => {
+	const duration = getTimelineDuration({
+		compositionDurationInFrames: 23.5,
+		playbackRate: 1,
+		trimBefore: undefined,
+		trimAfter: undefined,
+		parentSequenceDurationInFrames: 23.5,
+		loop: false,
+	});
+
+	expect(duration).toBe(23.5);
+});
+
 test('subframe sequence duration is not truncated', () => {
 	const duration = getTimelineDuration({
 		compositionDurationInFrames: 10.920000000000016,

--- a/packages/studio/src/helpers/get-media-duration-in-frames.ts
+++ b/packages/studio/src/helpers/get-media-duration-in-frames.ts
@@ -1,0 +1,9 @@
+export const getMediaDurationInFrames = ({
+	durationInSeconds,
+	fps,
+}: {
+	durationInSeconds: number;
+	fps: number;
+}) => {
+	return Number((durationInSeconds * fps).toFixed(10));
+};

--- a/packages/studio/src/helpers/use-max-media-duration.ts
+++ b/packages/studio/src/helpers/use-max-media-duration.ts
@@ -1,6 +1,9 @@
 import {useEffect, useState} from 'react';
 import {type TSequence} from 'remotion';
+import {getMediaDurationInFrames} from './get-media-duration-in-frames';
 import {getMediaMetadata} from './use-media-metadata';
+
+export {getMediaDurationInFrames} from './get-media-duration-in-frames';
 
 const cache = new Map<string, number>();
 
@@ -46,7 +49,10 @@ export const useMaxMediaDuration = (s: TSequence, fps: number) => {
 					return;
 				}
 
-				const duration = Math.floor(metadata.duration * fps);
+				const duration = getMediaDurationInFrames({
+					durationInSeconds: metadata.duration,
+					fps,
+				});
 				cache.set(cacheKey, duration);
 				setMaxMediaDuration(duration);
 			})

--- a/packages/studio/src/test/get-media-duration-in-frames.test.ts
+++ b/packages/studio/src/test/get-media-duration-in-frames.test.ts
@@ -1,0 +1,20 @@
+import {expect, test} from 'bun:test';
+import {getMediaDurationInFrames} from '../helpers/get-media-duration-in-frames';
+
+test('max media duration keeps subframe durations', () => {
+	expect(
+		getMediaDurationInFrames({
+			durationInSeconds: 23.5 / 30,
+			fps: 30,
+		}),
+	).toBe(23.5);
+});
+
+test('does not floor fractional media durations', () => {
+	expect(
+		getMediaDurationInFrames({
+			durationInSeconds: 1.0166666667,
+			fps: 30,
+		}),
+	).toBeGreaterThan(30);
+});

--- a/packages/studio/src/test/timeline-sequence-layout.test.ts
+++ b/packages/studio/src/test/timeline-sequence-layout.test.ts
@@ -4,7 +4,6 @@ import {
 	SEQUENCE_BORDER_WIDTH,
 	getTimelineSequenceLayout,
 } from '../helpers/get-timeline-sequence-layout';
-
 const makeVideoConfig = (durationInFrames: number): VideoConfig => ({
 	durationInFrames,
 	fps: 30,
@@ -161,6 +160,32 @@ test('adjacent sequences have no visual gap', () => {
 	expect(first.marginLeft + first.width + SEQUENCE_BORDER_WIDTH).toBe(
 		second.marginLeft,
 	);
+});
+
+test('audio layer width uses fractional maxMediaDuration', () => {
+	const floored = getTimelineSequenceLayout({
+		durationInFrames: 30,
+		startFrom: 0,
+		startFromMedia: 0,
+		maxMediaDuration: 23,
+		premountDisplay: null,
+		postmountDisplay: null,
+		video: makeVideoConfig(120),
+		windowWidth: 1000,
+	});
+	const fractional = getTimelineSequenceLayout({
+		durationInFrames: 30,
+		startFrom: 0,
+		startFromMedia: 0,
+		maxMediaDuration: 23.5,
+		premountDisplay: null,
+		postmountDisplay: null,
+		video: makeVideoConfig(120),
+		windowWidth: 1000,
+	});
+
+	expect(fractional.width).toBeGreaterThan(floored.width);
+	expect(fractional.naturalWidth).toBeGreaterThan(floored.naturalWidth);
 });
 
 test('media trimmed past its duration has zero width', () => {


### PR DESCRIPTION
## Summary

- Timeline `maxMediaDuration` no longer uses `Math.floor` on `duration * fps`, so media layers can keep fractional widths (for example 23.5 frames)
- Extracted `getMediaDurationInFrames` (same `toFixed(10)` rounding as `getTimelineDuration`)
- Added regression tests for nested `<Audio>` under a subframe `Series.Sequence` and for fractional max-media clipping

Fixes #7672

## AI assistance

This PR was written with AI assistance (Cursor/Grok). I reproduced the remaining gap after #7673: core duration caps already keep 23.5, but Studio still floored asset metadata when computing `maxMediaDuration`. I re-applied that Studio fix, added tests, and reviewed the diff before opening.

## Verification

`	ext
cd packages/core
bun test src/test/get-media-duration.test.ts
# 10 pass, 0 fail

cd packages/studio
bun test src/test/get-media-duration-in-frames.test.ts
# 2 pass, 0 fail
`

`timeline-sequence-layout.test.ts` also gained a floored-vs-fractional width assertion; that file needs a built `@remotion/studio-shared` locally, so CI should cover it.

## Test plan

- [x] `bun test packages/core/src/test/get-media-duration.test.ts`
- [x] `bun test packages/studio/src/test/get-media-duration-in-frames.test.ts`
- [ ] Open `subframe-audio` in Studio and confirm the nested Audio layer extends to 23.5 frames (matches the parent Series.Sequence)
- [ ] Spot-check a normal integer-duration audio clip still lays out correctly

Made with [Cursor](https://cursor.com)