### PR TITLE
@remotion/studio-server + cli: Fix Windows package manager spawn for npm/yarn/pnpm/npx

### DIFF
--- a/packages/cli/src/add.ts
+++ b/packages/cli/src/add.ts
@@ -177,6 +177,7 @@ export const addCommand = async ({
 	);
 
 	const task = spawn(manager.manager, command, {
+		...StudioServerInternals.getPackageManagerSpawnOptions(manager.manager),
 		env: {
 			...process.env,
 			ADBLOCK: '1',

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -1,5 +1,6 @@
 import {spawn} from 'node:child_process';
 import type {LogLevel} from '@remotion/renderer';
+import {StudioServerInternals} from '@remotion/studio-server';
 import {chalk} from './chalk';
 import {Log} from './log';
 
@@ -34,7 +35,7 @@ export const skillsCommand = (args: string[], logLevel: LogLevel) => {
 		return;
 	}
 
-	const command = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+	const command = 'npx';
 	const fullArgs = [
 		'-y',
 		'--loglevel=error',
@@ -45,6 +46,7 @@ export const skillsCommand = (args: string[], logLevel: LogLevel) => {
 	];
 
 	const child = spawn(command, fullArgs, {
+		...StudioServerInternals.getPackageManagerSpawnOptions(command),
 		stdio: 'inherit',
 	});
 

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -252,6 +252,7 @@ const runPackageManagerCommand = async ({
 	logLevel: LogLevel;
 }) => {
 	const task = spawn(manager, command, {
+		...StudioServerInternals.getPackageManagerSpawnOptions(manager),
 		env: {
 			...process.env,
 			ADBLOCK: '1',

--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -51,6 +51,7 @@ import {
 	getMaxTimelineTracks,
 	setMaxTimelineTracks,
 } from './max-timeline-tracks';
+import {getPackageManagerSpawnOptions} from './package-manager-spawn';
 import {
 	getPackageManager,
 	lockFilePaths,
@@ -65,6 +66,7 @@ export const StudioServerInternals = {
 	waitForLiveEventsListener,
 	lockFilePaths,
 	getPackageManager,
+	getPackageManagerSpawnOptions,
 	getMaxTimelineTracks,
 	setMaxTimelineTracks,
 	getLatestRemotionVersion,

--- a/packages/studio-server/src/package-manager-spawn.ts
+++ b/packages/studio-server/src/package-manager-spawn.ts
@@ -1,0 +1,24 @@
+import type {SpawnOptions} from 'node:child_process';
+
+const WINDOWS_CMD_MANAGERS = new Set(['npm', 'yarn', 'pnpm']);
+
+/**
+ * On Windows, npm/yarn/pnpm resolve to .cmd shims. Node 20+ rejects
+ * shell:false spawn of those shims (ENOENT for the bare name, EINVAL for
+ * `.cmd`). Use shell + windowsHide so Studio can install packages.
+ * bun is a real .exe and only needs windowsHide.
+ */
+export const getPackageManagerSpawnOptions = (
+	manager: string,
+	platform: NodeJS.Platform = process.platform,
+): SpawnOptions => {
+	if (platform !== 'win32') {
+		return {};
+	}
+
+	if (WINDOWS_CMD_MANAGERS.has(manager)) {
+		return {shell: true, windowsHide: true};
+	}
+
+	return {windowsHide: true};
+};

--- a/packages/studio-server/src/package-manager-spawn.ts
+++ b/packages/studio-server/src/package-manager-spawn.ts
@@ -1,11 +1,11 @@
 import type {SpawnOptions} from 'node:child_process';
 
-const WINDOWS_CMD_MANAGERS = new Set(['npm', 'yarn', 'pnpm']);
+const WINDOWS_CMD_MANAGERS = new Set(['npm', 'npx', 'yarn', 'pnpm']);
 
 /**
- * On Windows, npm/yarn/pnpm resolve to .cmd shims. Node 20+ rejects
+ * On Windows, npm/npx/yarn/pnpm resolve to .cmd shims. Node 20+ rejects
  * shell:false spawn of those shims (ENOENT for the bare name, EINVAL for
- * `.cmd`). Use shell + windowsHide so Studio can install packages.
+ * `.cmd`). Use shell + windowsHide so Studio/CLI package manager calls work.
  * bun is a real .exe and only needs windowsHide.
  */
 export const getPackageManagerSpawnOptions = (

--- a/packages/studio-server/src/preview-server/routes/install-dependency.ts
+++ b/packages/studio-server/src/preview-server/routes/install-dependency.ts
@@ -8,6 +8,7 @@ import {
 } from '@remotion/studio-shared';
 import {VERSION} from 'remotion/version';
 import {getInstallCommand} from '../../helpers/install-command';
+import {getPackageManagerSpawnOptions} from '../../package-manager-spawn';
 import type {ApiHandler} from '../api-types';
 import {getPackageManager, lockFilePaths} from '../get-package-manager';
 
@@ -74,7 +75,12 @@ export const handleInstallPackage: ApiHandler<
 	const time = Date.now();
 	try {
 		await new Promise<void>((resolve, reject) => {
-			const cmd = spawn(manager.manager, command, {});
+			const cmd = spawn(
+				manager.manager,
+				command,
+				getPackageManagerSpawnOptions(manager.manager),
+			);
+			cmd.on('error', reject);
 			cmd.stdout.on('data', (d: Buffer) => {
 				const splitted = d.toString().trim().split('\n');
 				splitted.forEach((line) => {

--- a/packages/studio-server/src/test/package-manager-spawn.test.ts
+++ b/packages/studio-server/src/test/package-manager-spawn.test.ts
@@ -1,8 +1,12 @@
 import {expect, test} from 'bun:test';
 import {getPackageManagerSpawnOptions} from '../package-manager-spawn';
 
-test('Windows npm/yarn/pnpm need shell so .cmd shims can launch', () => {
+test('Windows npm/npx/yarn/pnpm need shell so .cmd shims can launch', () => {
 	expect(getPackageManagerSpawnOptions('npm', 'win32')).toEqual({
+		shell: true,
+		windowsHide: true,
+	});
+	expect(getPackageManagerSpawnOptions('npx', 'win32')).toEqual({
 		shell: true,
 		windowsHide: true,
 	});

--- a/packages/studio-server/src/test/package-manager-spawn.test.ts
+++ b/packages/studio-server/src/test/package-manager-spawn.test.ts
@@ -1,0 +1,29 @@
+import {expect, test} from 'bun:test';
+import {getPackageManagerSpawnOptions} from '../package-manager-spawn';
+
+test('Windows npm/yarn/pnpm need shell so .cmd shims can launch', () => {
+	expect(getPackageManagerSpawnOptions('npm', 'win32')).toEqual({
+		shell: true,
+		windowsHide: true,
+	});
+	expect(getPackageManagerSpawnOptions('yarn', 'win32')).toEqual({
+		shell: true,
+		windowsHide: true,
+	});
+	expect(getPackageManagerSpawnOptions('pnpm', 'win32')).toEqual({
+		shell: true,
+		windowsHide: true,
+	});
+});
+
+test('Windows bun is an .exe and only needs windowsHide', () => {
+	expect(getPackageManagerSpawnOptions('bun', 'win32')).toEqual({
+		windowsHide: true,
+	});
+});
+
+test('non-Windows package managers keep default spawn options', () => {
+	expect(getPackageManagerSpawnOptions('npm', 'linux')).toEqual({});
+	expect(getPackageManagerSpawnOptions('pnpm', 'darwin')).toEqual({});
+	expect(getPackageManagerSpawnOptions('bun', 'linux')).toEqual({});
+});


### PR DESCRIPTION
## Summary

Studio Install Package and CLI `remotion add` / `upgrade` / `skills` spawn `npm` / `npx` / `yarn` / `pnpm` with default `child_process.spawn` options. On Windows those resolve to `.cmd` shims; under Node 20+ a bare `shell: false` spawn fails (`ENOENT` for the bare name, `EINVAL` for `.cmd`).

This adds `getPackageManagerSpawnOptions` (exported via `StudioServerInternals`) so Windows uses `shell: true` + `windowsHide: true` for those managers. bun stays a real `.exe` with `windowsHide` only.

## AI assistance

Assisted by Cursor / Grok. Human author: Stan Shih (stantheman0128). I reviewed the diff and verification output.

## Verification / Evidence

`	ext
bun test src/test/package-manager-spawn.test.ts
# 3 pass, 0 fail

# Live Win32 Node 24.15.0 smoke (this machine):
# spawn('npm', ['--version'], {shell:false}) -> ENOENT
# spawn('npm', ['--version'], getPackageManagerSpawnOptions('npm')) -> exit 0, 11.8.0
`

## Test plan

- [x] Unit tests for spawn options by manager + platform
- [x] Live npm `--version` with the Windows options
- [ ] Manual: Studio Install Package and `remotion add` on Windows with an npm lockfile