### PR TITLE
Support numeric fontWeight (1 to 1000) in Interactivity (#8793)

### DIFF
--- a/packages/core/src/interactivity-schema.ts
+++ b/packages/core/src/interactivity-schema.ts
@@ -112,6 +112,19 @@ export type FontFamilyFieldSchema = {
 	keyframable?: false;
 };
 
+export type FontWeightFieldSchema = {
+	type: 'font-weight';
+	min?: number;
+	max?: number;
+	step?: number;
+	default: number | string | undefined;
+	description?: string;
+	// Quick-select presets. Strings like 'normal'/'bold' are saved as strings,
+	// numbers like 400 are saved as numbers.
+	presets: readonly (number | string)[];
+	keyframable?: false;
+};
+
 export type EnumFieldSchema = {
 	type: 'enum';
 	default: string;
@@ -197,6 +210,7 @@ export type VisibleFieldSchema =
 	| ColorFieldSchema
 	| TextContentFieldSchema
 	| FontFamilyFieldSchema
+	| FontWeightFieldSchema
 	| ArrayFieldSchema
 	| EnumFieldSchema;
 
@@ -276,22 +290,13 @@ export const textSchema = {
 		hiddenFromList: false,
 	},
 	'style.fontWeight': {
-		type: 'enum',
-		default: '400',
+		type: 'font-weight',
+		default: undefined,
 		description: 'Font weight',
-		variants: {
-			'100': {},
-			'200': {},
-			'300': {},
-			'400': {},
-			'500': {},
-			'600': {},
-			'700': {},
-			'800': {},
-			'900': {},
-			normal: {},
-			bold: {},
-		},
+		min: 1,
+		max: 1000,
+		step: 1,
+		presets: ['normal', 'bold', 100, 200, 300, 400, 500, 600, 700, 800, 900],
 	},
 	'style.fontStyle': {
 		type: 'enum',

--- a/packages/core/src/test/with-interactivity-schema-helpers.test.ts
+++ b/packages/core/src/test/with-interactivity-schema-helpers.test.ts
@@ -254,18 +254,25 @@ test('textSchema exposes common text style fields', () => {
 		step: 0.05,
 		hiddenFromList: false,
 	});
-	expect(Object.keys(textSchema['style.fontWeight'].variants)).toEqual([
-		'100',
-		'200',
-		'300',
-		'400',
-		'500',
-		'600',
-		'700',
-		'800',
-		'900',
+	expect(textSchema['style.fontWeight']).toMatchObject({
+		type: 'font-weight',
+		default: undefined,
+		min: 1,
+		max: 1000,
+		step: 1,
+	});
+	expect(textSchema['style.fontWeight'].presets).toEqual([
 		'normal',
 		'bold',
+		100,
+		200,
+		300,
+		400,
+		500,
+		600,
+		700,
+		800,
+		900,
 	]);
 	expect(Object.keys(textSchema['style.fontStyle'].variants)).toEqual([
 		'normal',
@@ -429,4 +436,74 @@ test('end-to-end: layout=none drops style.scale from active props', () => {
 test('getNestedValue returns undefined for missing nested keys', () => {
 	expect(getNestedValue({a: {}}, 'a.b.c')).toBeUndefined();
 	expect(getNestedValue({a: {b: 1}}, 'a.b')).toBe(1);
+});
+
+test('fontWeight is a numeric font-weight field, not a 100-step enum', () => {
+	const fontWeight = textSchema['style.fontWeight'];
+	expect(fontWeight.type).toBe('font-weight');
+	// step 1 (not 100) is what makes an arbitrary weight like 650 valid and
+	// prevents snapping to the nearest 100.
+	expect(fontWeight.step).toBe(1);
+	expect(fontWeight.min).toBe(1);
+	expect(fontWeight.max).toBe(1000);
+	// 650 is a valid weight but not a quick preset; it lives in the 1..1000 range.
+	expect(fontWeight.presets).not.toContain(650);
+	expect(fontWeight.presets).toContain(700);
+	expect(fontWeight.presets).toContain('normal');
+	expect(fontWeight.presets).toContain('bold');
+});
+
+test('fontWeight: 650 is read from props and preserved as a number', () => {
+	const props = {style: {fontWeight: 650}};
+	const values = readValuesFromProps(props, ['style.fontWeight']);
+	expect(values['style.fontWeight']).toBe(650);
+	expect(typeof values['style.fontWeight']).toBe('number');
+
+	const merged = mergeValues({
+		flatSchema: getFlatSchemaWithAllKeys(textSchema),
+		props,
+		valuesDotNotation: values,
+		schemaKeys: ['style.fontWeight'],
+		propsToDelete: new Set(),
+	});
+	// The exact numeric value is written back unchanged and stays a number.
+	expect((merged.style as {fontWeight: unknown}).fontWeight).toBe(650);
+	expect(typeof (merged.style as {fontWeight: unknown}).fontWeight).toBe(
+		'number',
+	);
+});
+
+test('fontWeight string presets normal and bold survive as strings', () => {
+	for (const weight of ['normal', 'bold'] as const) {
+		const props = {style: {fontWeight: weight}};
+		const values = readValuesFromProps(props, ['style.fontWeight']);
+		expect(values['style.fontWeight']).toBe(weight);
+
+		const merged = mergeValues({
+			flatSchema: getFlatSchemaWithAllKeys(textSchema),
+			props,
+			valuesDotNotation: values,
+			schemaKeys: ['style.fontWeight'],
+			propsToDelete: new Set(),
+		});
+		expect((merged.style as {fontWeight: unknown}).fontWeight).toBe(weight);
+		expect(typeof (merged.style as {fontWeight: unknown}).fontWeight).toBe(
+			'string',
+		);
+	}
+});
+
+test('editing fontWeight to a new number saves a number, not a string', () => {
+	const props = {style: {fontWeight: 650}};
+	const merged = mergeValues({
+		flatSchema: getFlatSchemaWithAllKeys(textSchema),
+		props,
+		valuesDotNotation: {'style.fontWeight': 725},
+		schemaKeys: ['style.fontWeight'],
+		propsToDelete: new Set(),
+	});
+	expect((merged.style as {fontWeight: unknown}).fontWeight).toBe(725);
+	expect(typeof (merged.style as {fontWeight: unknown}).fontWeight).toBe(
+		'number',
+	);
 });

--- a/packages/studio-shared/src/keyframe-interpolation-function.ts
+++ b/packages/studio-shared/src/keyframe-interpolation-function.ts
@@ -1,4 +1,4 @@
-import type {InteractivitySchemaField, InteractivitySchema} from 'remotion';
+import type {InteractivitySchema, InteractivitySchemaField} from 'remotion';
 
 export const keyframeInterpolationFunctions = [
 	'interpolate',
@@ -27,7 +27,8 @@ export const isInteractivitySchemaFieldKeyframable = (
 		field.type === 'array' ||
 		field.type === 'boolean' ||
 		field.type === 'enum' ||
-		field.type === 'font-family'
+		field.type === 'font-family' ||
+		field.type === 'font-weight'
 	) {
 		return false;
 	}

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -117,6 +117,7 @@ const SUPPORTED_SCHEMA_TYPES = [
 	'color',
 	'text-content',
 	'font-family',
+	'font-weight',
 	'array',
 	'enum',
 	'hidden',

--- a/packages/studio/src/components/Timeline/TimelineFontWeightField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFontWeightField.tsx
@@ -1,0 +1,158 @@
+import React, {useCallback, useMemo, useState} from 'react';
+import type {CanUpdateSequencePropStatusStatic} from 'remotion';
+import type {
+	SchemaFieldInfo,
+	TimelineFieldOnDragValueChange,
+	TimelineFieldOnSave,
+} from '../../helpers/timeline-layout';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {Combobox} from '../NewComposition/ComboBox';
+import {InputDragger} from '../NewComposition/InputDragger';
+import {
+	fontWeightToNumericValue,
+	resolveFontWeightSave,
+} from './font-weight-utils';
+import {draggerStyle} from './timeline-field-utils';
+
+const comboboxStyle: React.CSSProperties = {
+	marginLeft: 8,
+};
+
+export const TimelineFontWeightField: React.FC<{
+	readonly field: SchemaFieldInfo;
+	readonly effectiveValue: unknown;
+	readonly propStatus: CanUpdateSequencePropStatusStatic;
+	readonly onSave: TimelineFieldOnSave;
+	readonly onDragValueChange: TimelineFieldOnDragValueChange;
+	readonly onDragEnd: () => void;
+}> = ({
+	field,
+	effectiveValue,
+	propStatus,
+	onSave,
+	onDragValueChange,
+	onDragEnd,
+}) => {
+	const {fieldSchema} = field;
+	if (fieldSchema.type !== 'font-weight') {
+		throw new Error(
+			'TimelineFontWeightField rendered for non-font-weight field',
+		);
+	}
+
+	const [dragValue, setDragValue] = useState<number | null>(null);
+
+	const min = fieldSchema.min ?? 1;
+	const max = fieldSchema.max ?? 1000;
+	const step = fieldSchema.step ?? 1;
+
+	const displayNumber =
+		dragValue ??
+		fontWeightToNumericValue(effectiveValue) ??
+		fontWeightToNumericValue(fieldSchema.default);
+
+	const saveNumber = useCallback(
+		(newVal: number) => {
+			const decision = resolveFontWeightSave({
+				stored: propStatus.codeValue,
+				newValue: newVal,
+				min,
+				max,
+			});
+
+			if (decision.type === 'skip') {
+				setDragValue(null);
+				onDragEnd();
+				return;
+			}
+
+			onSave(decision.value).finally(() => {
+				setDragValue(null);
+				onDragEnd();
+			});
+		},
+		[max, min, onDragEnd, onSave, propStatus.codeValue],
+	);
+
+	const onValueChange = useCallback(
+		(newVal: number) => {
+			setDragValue(newVal);
+			onDragValueChange(newVal);
+		},
+		[onDragValueChange],
+	);
+
+	const onTextChange = useCallback(
+		(newVal: string) => {
+			const parsed = Number(newVal);
+			if (newVal.trim() !== '' && Number.isFinite(parsed)) {
+				saveNumber(parsed);
+			}
+		},
+		[saveNumber],
+	);
+
+	const onSelectPreset = useCallback(
+		(preset: number | string) => {
+			if (preset === propStatus.codeValue) {
+				return;
+			}
+
+			onDragValueChange(preset);
+			onSave(preset).finally(() => {
+				onDragEnd();
+			});
+		},
+		[onDragEnd, onDragValueChange, onSave, propStatus.codeValue],
+	);
+
+	const presetItems = useMemo<ComboboxValue[]>(() => {
+		return fieldSchema.presets.map((preset) => ({
+			type: 'item',
+			id: String(preset),
+			value: String(preset),
+			label: String(preset),
+			onClick: () => onSelectPreset(preset),
+			keyHint: null,
+			leftItem: null,
+			subMenu: null,
+			quickSwitcherLabel: null,
+			disabled: false,
+		}));
+	}, [fieldSchema.presets, onSelectPreset]);
+
+	const selectedPresetId =
+		effectiveValue === undefined ? '' : String(effectiveValue);
+
+	const formatter = useCallback((value: number | string) => {
+		const numeric = Number(value);
+		return Number.isFinite(numeric) ? String(numeric) : String(value);
+	}, []);
+
+	return (
+		<span>
+			<InputDragger
+				type="number"
+				value={displayNumber ?? ''}
+				style={draggerStyle}
+				status="ok"
+				small
+				onValueChange={onValueChange}
+				onValueChangeEnd={saveNumber}
+				onTextChange={onTextChange}
+				min={min}
+				max={max}
+				step={step}
+				formatter={formatter}
+				rightAlign={false}
+			/>
+			<Combobox
+				small
+				title={field.key}
+				selectedId={selectedPresetId}
+				values={presetItems}
+				style={comboboxStyle}
+			/>
+		</span>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
@@ -14,6 +14,7 @@ import {TimelineBooleanField} from './TimelineBooleanField';
 import {TimelineColorField} from './TimelineColorField';
 import {TimelineEnumField} from './TimelineEnumField';
 import {TimelineFontFamilyField} from './TimelineFontFamilyField';
+import {TimelineFontWeightField} from './TimelineFontWeightField';
 import {TimelineNumberField} from './TimelineNumberField';
 import {TimelineRotationField} from './TimelineRotationField';
 import {TimelineScaleField} from './TimelineScaleField';
@@ -220,6 +221,21 @@ export const TimelinePrimitiveFieldValue: React.FC<{
 		return (
 			<span style={inlineWrapper}>
 				<TimelineFontFamilyField
+					effectiveValue={effectiveValue}
+					field={field}
+					onDragEnd={onDragEnd}
+					onDragValueChange={onDragValueChange}
+					onSave={onSave}
+					propStatus={propStatus}
+				/>
+			</span>
+		);
+	}
+
+	if (field.typeName === 'font-weight') {
+		return (
+			<span style={inlineWrapper}>
+				<TimelineFontWeightField
 					effectiveValue={effectiveValue}
 					field={field}
 					onDragEnd={onDragEnd}

--- a/packages/studio/src/components/Timeline/font-weight-utils.ts
+++ b/packages/studio/src/components/Timeline/font-weight-utils.ts
@@ -1,0 +1,62 @@
+// Shared, DOM-free logic for the font-weight timeline field so it can be unit
+// tested without rendering the control.
+
+// CSS keyword weights map to these numbers. The mapping only decides what the
+// numeric field shows; the stored string is preserved until the user changes it.
+export const FONT_WEIGHT_STRING_PRESET_TO_NUMBER: Record<string, number> = {
+	normal: 400,
+	bold: 700,
+};
+
+export const fontWeightToNumericValue = (value: unknown): number | null => {
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? value : null;
+	}
+
+	if (typeof value === 'string') {
+		if (value in FONT_WEIGHT_STRING_PRESET_TO_NUMBER) {
+			return FONT_WEIGHT_STRING_PRESET_TO_NUMBER[value];
+		}
+
+		const parsed = Number(value);
+		if (value.trim() !== '' && Number.isFinite(parsed)) {
+			return parsed;
+		}
+	}
+
+	return null;
+};
+
+export type FontWeightSaveDecision =
+	| {readonly type: 'save'; readonly value: number}
+	| {readonly type: 'skip'};
+
+export const resolveFontWeightSave = ({
+	stored,
+	newValue,
+	min,
+	max,
+}: {
+	readonly stored: unknown;
+	readonly newValue: number;
+	readonly min: number;
+	readonly max: number;
+}): FontWeightSaveDecision => {
+	const clamped = Math.min(max, Math.max(min, newValue));
+
+	// Already the exact number that is written, nothing to do.
+	if (clamped === stored) {
+		return {type: 'skip'};
+	}
+
+	// Preserve a string preset like 'normal'/'bold' when the numeric field
+	// resolves to its CSS-equivalent number and the user did not change it.
+	if (
+		typeof stored === 'string' &&
+		clamped === fontWeightToNumericValue(stored)
+	) {
+		return {type: 'skip'};
+	}
+
+	return {type: 'save', value: clamped};
+};

--- a/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
@@ -394,6 +394,7 @@ export const formatTimelineFieldValueForDisplay = ({
 		case 'boolean':
 		case 'color':
 		case 'enum':
+		case 'font-weight':
 		case 'hidden':
 			return formatUnknownTimelineValueForDisplay(value);
 

--- a/packages/studio/src/test/font-weight-utils.test.ts
+++ b/packages/studio/src/test/font-weight-utils.test.ts
@@ -1,0 +1,60 @@
+import {expect, test} from 'bun:test';
+import {
+	fontWeightToNumericValue,
+	resolveFontWeightSave,
+} from '../components/Timeline/font-weight-utils';
+
+test('fontWeightToNumericValue keeps finite numbers as-is', () => {
+	expect(fontWeightToNumericValue(650)).toBe(650);
+	expect(fontWeightToNumericValue(400)).toBe(400);
+	expect(fontWeightToNumericValue(Number.NaN)).toBeNull();
+});
+
+test('fontWeightToNumericValue maps normal/bold to their CSS numbers', () => {
+	expect(fontWeightToNumericValue('normal')).toBe(400);
+	expect(fontWeightToNumericValue('bold')).toBe(700);
+});
+
+test('fontWeightToNumericValue parses numeric strings and rejects other text', () => {
+	expect(fontWeightToNumericValue('650')).toBe(650);
+	expect(fontWeightToNumericValue('lighter')).toBeNull();
+	expect(fontWeightToNumericValue('')).toBeNull();
+	expect(fontWeightToNumericValue(undefined)).toBeNull();
+});
+
+test('editing to an arbitrary weight saves it as an exact number (no snapping)', () => {
+	expect(
+		resolveFontWeightSave({stored: 400, newValue: 650, min: 1, max: 1000}),
+	).toEqual({type: 'save', value: 650});
+});
+
+test('choosing a value equal to the stored number does not re-save', () => {
+	expect(
+		resolveFontWeightSave({stored: 650, newValue: 650, min: 1, max: 1000}),
+	).toEqual({type: 'skip'});
+});
+
+test('normal/bold are not rewritten when the numeric field is left unchanged', () => {
+	// 'normal' shows as 400 in the numeric field; committing 400 keeps 'normal'.
+	expect(
+		resolveFontWeightSave({stored: 'normal', newValue: 400, min: 1, max: 1000}),
+	).toEqual({type: 'skip'});
+	expect(
+		resolveFontWeightSave({stored: 'bold', newValue: 700, min: 1, max: 1000}),
+	).toEqual({type: 'skip'});
+});
+
+test('changing away from a string preset saves the new number', () => {
+	expect(
+		resolveFontWeightSave({stored: 'normal', newValue: 650, min: 1, max: 1000}),
+	).toEqual({type: 'save', value: 650});
+});
+
+test('values outside 1..1000 are clamped to the field range', () => {
+	expect(
+		resolveFontWeightSave({stored: 400, newValue: 2000, min: 1, max: 1000}),
+	).toEqual({type: 'save', value: 1000});
+	expect(
+		resolveFontWeightSave({stored: 400, newValue: -5, min: 1, max: 1000}),
+	).toEqual({type: 'save', value: 1});
+});


### PR DESCRIPTION
`@remotion/studio`: Support numeric CSS font-weight values in Interactivity

Fixes #8793.

## Problem

In Interactivity, `style.fontWeight` was modeled as an enum whose only allowed values were the nine 100-step weights (100 to 900) plus `normal` and `bold`. A valid CSS weight such as `fontWeight: 650` was therefore not recognized: the Studio rendered an enum dropdown, 650 was not one of the options, and the value could not be edited without being changed to a 100-step value.

CSS Fonts Level 4 allows any numeric font-weight from 1 to 1000, so 650 is valid and should not be coerced to 600 or 700.

A previous attempt (#8800) hardcoded 650 into the enum and was closed. This PR instead follows the approach the maintainer described on the issue: make font-weight a real numeric field with the string keywords kept as presets.

## What changed

- Added a dedicated `font-weight` field type to the Interactivity schema (`packages/core/src/interactivity-schema.ts`). It carries a numeric range (`min: 1`, `max: 1000`, `step: 1`) and a `presets` list (`normal`, `bold`, and 100 to 900). `style.fontWeight` now uses this type instead of `enum`.
- Registered the new type in `@remotion/studio-shared` (`schema-field-info.ts`) and kept it non-keyframable alongside the enum and font-family fields (`keyframe-interpolation-function.ts`).
- Added a Studio control (`TimelineFontWeightField.tsx`) that renders a numeric `InputDragger` (min 1, max 1000, step 1) plus a compact preset dropdown for `normal`, `bold`, and 100 to 900. This replaces the enum-only dropdown for font-weight.
- Moved the value parsing and the save decision into a small DOM-free helper (`font-weight-utils.ts`) so they can be unit tested directly.

Numeric values are read from and written back to the source as numbers, so an existing `fontWeight: 650` round-trips as the number 650. The keywords `normal` and `bold` are read and written as strings. The numeric field shows `normal` as 400 and `bold` as 700 for editing convenience, but the stored string is left untouched unless the user actually changes the value.

## Acceptance criteria

- `fontWeight: 650` recognized by Interactivity and shown in Studio: the field is no longer an enum, so 650 is read from props and displayed in the numeric control. Covered by `fontWeight: 650 is read from props and preserved as a number` in the core test.
- User can type 650, drag/edit it, and save it back as a numeric value: the control uses `InputDragger` and calls `onSave` with a JS number, which the codemod serializes as a numeric literal. Covered by `editing fontWeight to a new number saves a number, not a string` (core) and `editing to an arbitrary weight saves it as an exact number` (studio util test).
- User can still choose normal, bold, and common 100-step values: the preset dropdown offers `normal`, `bold`, and 100 to 900. Presets are asserted in `fontWeight is a numeric font-weight field, not a 100-step enum` (core).
- Values outside 1..1000 rejected or clamped per the existing number-field behavior: the control clamps to the field min/max. Covered by `values outside 1..1000 are clamped to the field range` (studio util test).
- Studio does not normalize arbitrary valid values to the nearest 100: the field uses `step: 1`, and the save path writes the exact value. Covered by the `step` assertion and by `editing to an arbitrary weight saves it as an exact number (no snapping)`.
- normal/bold are not rewritten unless the value changes: covered by `normal/bold are not rewritten when the numeric field is left unchanged` and `fontWeight string presets normal and bold survive as strings`.

## Verification

Targeted tests, run with the repo's Bun test runner:

```
$ bun test src/test/with-interactivity-schema-helpers.test.ts   (packages/core)
 24 pass
 0 fail
 68 expect() calls

$ bun test src/test/font-weight-utils.test.ts   (packages/studio)
 8 pass
 0 fail
 16 expect() calls

$ bun test src/test/schema-field-info.test.ts src/test/keyframe-interpolation-function.test.ts   (packages/studio-shared)
 14 pass
 0 fail
```

Type checking passed by building the affected packages (`turbo run make` runs `tsgo -d`): `remotion`, `@remotion/studio-shared`, and `@remotion/studio` all built successfully.

Caveat: the `InputDragger` visual appearance and drag interaction cannot be exercised in a headless environment, so I did not add a rendering or drag test for the Studio control. The control logic that decides what value to save (parsing, clamping, string-preset preservation) is covered by the unit tests above; only the pointer-drag UI itself is unverified here.

## AI assistance

This change was implemented with AI assistance (Claude) and reviewed before submission.
