### PR TITLE
@remotion/renderer: Fix Windows repro ZIP Compress-Archive quoting

### DIFF
--- a/packages/renderer/src/repro.ts
+++ b/packages/renderer/src/repro.ts
@@ -1,4 +1,4 @@
-import {execSync} from 'node:child_process';
+import {execFileSync, execSync} from 'node:child_process';
 import fs, {rmSync} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -8,6 +8,7 @@ import {findRemotionRoot} from './find-closest-package-json';
 import {isServeUrl} from './is-serve-url';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
+import {getCompressArchivePowerShellCommand} from './windows-powershell-path';
 
 const REPRO_DIR = '.remotionrepro';
 const LOG_FILE_NAME = 'logs.txt';
@@ -47,8 +48,19 @@ const zipFolder = ({
 	try {
 		Log.info({indent, logLevel}, '+ Creating reproduction ZIP');
 		if (platform === 'win32') {
-			execSync(
-				`powershell.exe Compress-Archive -Path "${sourceFolder}" -DestinationPath "${targetZip}"`,
+			// execFile (not a shell string) + LiteralPath / single-quoted paths so
+			// apostrophes and spaces in user profile paths do not break Compress-Archive.
+			execFileSync(
+				'powershell.exe',
+				[
+					'-NoProfile',
+					'-NonInteractive',
+					'-ExecutionPolicy',
+					'Bypass',
+					'-Command',
+					getCompressArchivePowerShellCommand({sourceFolder, targetZip}),
+				],
+				{stdio: 'pipe'},
 			);
 		} else {
 			execSync(`zip -r "${targetZip}" "${sourceFolder}"`);

--- a/packages/renderer/src/test/windows-powershell-path.test.ts
+++ b/packages/renderer/src/test/windows-powershell-path.test.ts
@@ -1,0 +1,22 @@
+import {expect, test} from 'bun:test';
+import {
+	escapePowerShellSingleQuoted,
+	getCompressArchivePowerShellCommand,
+} from '../windows-powershell-path';
+
+test('escapePowerShellSingleQuoted doubles apostrophes', () => {
+	expect(escapePowerShellSingleQuoted("C:\\Users\\O'Brien\\bundle")).toBe(
+		"C:\\Users\\O''Brien\\bundle",
+	);
+});
+
+test('getCompressArchivePowerShellCommand uses LiteralPath and safe quoting', () => {
+	expect(
+		getCompressArchivePowerShellCommand({
+			sourceFolder: "C:\\Users\\O'Brien\\project\\.remotionrepro",
+			targetZip: "C:\\Users\\O'Brien\\out.zip",
+		}),
+	).toBe(
+		"Compress-Archive -Force -LiteralPath 'C:\\Users\\O''Brien\\project\\.remotionrepro' -DestinationPath 'C:\\Users\\O''Brien\\out.zip'",
+	);
+});

--- a/packages/renderer/src/windows-powershell-path.ts
+++ b/packages/renderer/src/windows-powershell-path.ts
@@ -1,0 +1,23 @@
+/**
+ * Escape a filesystem path for embedding inside a PowerShell single-quoted string.
+ * In PowerShell, the only escape inside '...' is doubling apostrophes.
+ */
+export const escapePowerShellSingleQuoted = (value: string): string => {
+	return value.replace(/'/g, "''");
+};
+
+/**
+ * Build a Compress-Archive command that survives spaces, brackets, and
+ * apostrophes in Windows paths (double-quoted -Path embedding does not).
+ */
+export const getCompressArchivePowerShellCommand = ({
+	sourceFolder,
+	targetZip,
+}: {
+	sourceFolder: string;
+	targetZip: string;
+}): string => {
+	const source = escapePowerShellSingleQuoted(sourceFolder);
+	const dest = escapePowerShellSingleQuoted(targetZip);
+	return `Compress-Archive -Force -LiteralPath '${source}' -DestinationPath '${dest}'`;
+};


### PR DESCRIPTION
## Summary

`--repro` ZIP creation on Windows shells out to `powershell.exe Compress-Archive` with double-quoted `-Path` values. Paths that contain an apostrophe (for example under `C:\Users\O'Brien\...`) break argument parsing, so the ZIP step fails even though the repro folder was written.

This switches to `execFileSync` with `-LiteralPath` and PowerShell single-quote escaping (apostrophes doubled).

## AI assistance

Assisted by Cursor / Grok. Human author: Stan Shih (stantheman0128). I reviewed the diff and verification output.

## Verification / Evidence

```
# Unit helper (bun import on this machine):
UNIT_OK
Compress-Archive -Force -LiteralPath 'C:\Users\O''Brien\p' -DestinationPath 'C:\Users\O''Brien\o.zip'

# Live Win11 smoke with apostrophe directory:
# CMD Compress-Archive -Force -LiteralPath '...O''Brien\bundle' ...
# zip exists true size 126
```

## Test plan

- [x] Helper unit checks for apostrophe escaping + LiteralPath command shape
- [x] Live Compress-Archive via execFileSync on a path containing an apostrophe
- [ ] Manual: `npx remotion render --repro` from a project under a user profile with an apostrophe
