### PR TITLE
Studio: route video media errors to preview panel

### DIFF
--- a/packages/core/src/test/video-studio-media-error.test.tsx
+++ b/packages/core/src/test/video-studio-media-error.test.tsx
@@ -1,0 +1,146 @@
+import {afterEach, expect, test} from 'bun:test';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import type React from 'react';
+import {SharedAudioContextProvider} from '../audio/shared-audio-tags.js';
+import {CompositionRenderErrorContext} from '../composition-render-error-context.js';
+import {RemotionEnvironmentContext} from '../remotion-environment-context.js';
+import {Html5Video} from '../video/index.js';
+import {MediaPlaybackError} from '../video/MediaPlaybackError.js';
+import {WrapSequenceContext} from './wrap-sequence-context.js';
+
+afterEach(() => {
+	cleanup();
+});
+
+const studioPreviewEnvironment = {
+	isClientSideRendering: false,
+	isPlayer: false,
+	isReadOnlyStudio: false,
+	isRendering: false,
+	isStudio: true,
+};
+
+const WrapStudioPreview: React.FC<{
+	readonly children: React.ReactNode;
+	readonly setError: (error: Error) => void;
+}> = ({children, setError}) => {
+	return (
+		<RemotionEnvironmentContext.Provider value={studioPreviewEnvironment}>
+			<CompositionRenderErrorContext.Provider
+				value={{
+					setError,
+					clearError: () => undefined,
+				}}
+			>
+				<WrapSequenceContext>
+					<SharedAudioContextProvider
+						audioEnabled={false}
+						audioLatencyHint="playback"
+						previewSampleRate={null}
+					>
+						{children}
+					</SharedAudioContextProvider>
+				</WrapSequenceContext>
+			</CompositionRenderErrorContext.Provider>
+		</RemotionEnvironmentContext.Provider>
+	);
+};
+
+test('Studio routes video media errors to CompositionRenderErrorContext', () => {
+	const reported: Error[] = [];
+
+	const {container} = render(
+		<WrapStudioPreview
+			setError={(error) => {
+				reported.push(error);
+			}}
+		>
+			<Html5Video src="https://example.com/missing.mp4" />
+		</WrapStudioPreview>,
+	);
+
+	const video = container.querySelector('video');
+	expect(video).not.toBeNull();
+
+	Object.defineProperty(video, 'error', {
+		configurable: true,
+		value: {
+			code: 4,
+			message: 'MEDIA_ELEMENT_ERROR: Format error',
+		},
+	});
+
+	expect(() => {
+		fireEvent.error(video as HTMLVideoElement);
+	}).not.toThrow();
+
+	expect(reported).toHaveLength(1);
+	expect(reported[0]).toBeInstanceOf(MediaPlaybackError);
+	expect(reported[0]?.message).toContain('Code 4');
+	expect((reported[0] as MediaPlaybackError).src).toBe(
+		'https://example.com/missing.mp4',
+	);
+});
+
+test('outside Studio, video media errors are not routed to CompositionRenderErrorContext', () => {
+	const previewEnvironment = {
+		...studioPreviewEnvironment,
+		isStudio: false,
+	};
+	const reported: Error[] = [];
+	const windowErrors: Error[] = [];
+	const onWindowError = (event: ErrorEvent) => {
+		if (event.error instanceof Error) {
+			windowErrors.push(event.error);
+		}
+
+		event.preventDefault();
+	};
+
+	window.addEventListener('error', onWindowError);
+
+	try {
+		const {container} = render(
+			<RemotionEnvironmentContext.Provider value={previewEnvironment}>
+				<CompositionRenderErrorContext.Provider
+					value={{
+						setError: (error) => {
+							reported.push(error);
+						},
+						clearError: () => undefined,
+					}}
+				>
+					<WrapSequenceContext>
+						<SharedAudioContextProvider
+							audioEnabled={false}
+							audioLatencyHint="playback"
+							previewSampleRate={null}
+						>
+							<Html5Video src="https://example.com/missing.mp4" />
+						</SharedAudioContextProvider>
+					</WrapSequenceContext>
+				</CompositionRenderErrorContext.Provider>
+			</RemotionEnvironmentContext.Provider>,
+		);
+
+		const video = container.querySelector('video');
+		expect(video).not.toBeNull();
+
+		Object.defineProperty(video, 'error', {
+			configurable: true,
+			value: {
+				code: 4,
+				message: 'MEDIA_ELEMENT_ERROR: Format error',
+			},
+		});
+
+		fireEvent.error(video as HTMLVideoElement);
+
+		expect(reported).toHaveLength(0);
+		expect(windowErrors.some((err) => err instanceof MediaPlaybackError)).toBe(
+			true,
+		);
+	} finally {
+		window.removeEventListener('error', onWindowError);
+	}
+});

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -12,6 +12,7 @@ import type {IsExact} from '../audio/props.js';
 import {SharedAudioContext} from '../audio/shared-audio-tags.js';
 import {makeSharedElementSourceNode} from '../audio/shared-element-source-node.js';
 import {useFrameForVolumeProp} from '../audio/use-audio-frame.js';
+import {CompositionRenderErrorContext} from '../composition-render-error-context.js';
 import {getCrossOriginValue} from '../get-cross-origin-value.js';
 import {useLogLevel, useMountTime} from '../log-level-context.js';
 import {playbackLogging} from '../playback-logging.js';
@@ -21,6 +22,7 @@ import {useVolume} from '../use-amplification.js';
 import {useMediaInTimeline} from '../use-media-in-timeline.js';
 import {useMediaPlayback} from '../use-media-playback.js';
 import {useMediaTag} from '../use-media-tag.js';
+import {useRemotionEnvironment} from '../use-remotion-environment.js';
 import {useVideoConfig} from '../use-video-config.js';
 import {VERSION} from '../version.js';
 import {
@@ -241,11 +243,29 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		}),
 	);
 
+	const {setError: setCompositionRenderError} = useContext(
+		CompositionRenderErrorContext,
+	);
+	const {isStudio} = useRemotionEnvironment();
+
 	useEffect(() => {
 		const {current} = videoRef;
 		if (!current) {
 			return;
 		}
+
+		const reportOrThrow = (err: MediaPlaybackError) => {
+			// Native media `error` events are not caught by React error boundaries.
+			// In Studio, route them through CompositionRenderErrorContext so they
+			// surface in the preview panel (ErrorLoader) instead of the fullscreen
+			// runtime overlay. See https://github.com/remotion-dev/remotion/issues/7000
+			if (isStudio) {
+				setCompositionRenderError(err);
+				return;
+			}
+
+			throw err;
+		};
 
 		const errorHandler = () => {
 			if (current.error) {
@@ -262,10 +282,12 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 					return;
 				}
 
-				throw new MediaPlaybackError({
-					message: `The browser threw an error while playing the video ${src}: Code ${current.error.code} - ${current?.error?.message}. See https://remotion.dev/docs/media-playback-error for help. Pass an onError() prop to handle the error.`,
-					src: src as string,
-				});
+				reportOrThrow(
+					new MediaPlaybackError({
+						message: `The browser threw an error while playing the video ${src}: Code ${current.error.code} - ${current?.error?.message}. See https://remotion.dev/docs/media-playback-error for help. Pass an onError() prop to handle the error.`,
+						src: src as string,
+					}),
+				);
 			} else {
 				// If user is handling the error, we don't cause an unhandled exception
 				if (onError) {
@@ -277,10 +299,12 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 					return;
 				}
 
-				throw new MediaPlaybackError({
-					message: 'The browser threw an error while playing the video',
-					src: src as string,
-				});
+				reportOrThrow(
+					new MediaPlaybackError({
+						message: 'The browser threw an error while playing the video',
+						src: src as string,
+					}),
+				);
 			}
 		};
 
@@ -288,7 +312,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 		return () => {
 			current.removeEventListener('error', errorHandler);
 		};
-	}, [onError, src]);
+	}, [isStudio, onError, setCompositionRenderError, src]);
 
 	const currentOnDurationCallback =
 		useRef<VideoForPreviewProps['onDuration']>(onDuration);


### PR DESCRIPTION
## Summary

Fixes #7000.

When a `<Video>` fails to load in Studio, the browser fires a native `error` event. Throwing `MediaPlaybackError` from that handler is not caught by React error boundaries, so Studio showed the fullscreen runtime overlay instead of the preview-panel `ErrorLoader`.

In Studio, report the error through `CompositionRenderErrorContext` (same path as `CompositionErrorBoundary`). Outside Studio, keep throwing so Player / non-Studio preview behavior is unchanged. `onError` still takes precedence when provided.

AI-assisted (Cursor/Grok). Authored for Stan Shih (stantheman0128).

## Verification

`
cd packages/core
bun test src/test/video-studio-media-error.test.tsx
`

Result: 2 pass, 0 fail.