### PR TITLE
@remotion/install-whisper-cpp: Fix Windows Expand-Archive path quoting

### DIFF
--- a/packages/install-whisper-cpp/src/install-whisper-cpp.ts
+++ b/packages/install-whisper-cpp/src/install-whisper-cpp.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import path from 'path';
 import {downloadFile} from './download';
 import {compareVersions} from './utils';
+import {getExpandArchivePowerShellCommand} from './windows-powershell-path';
 
 const getIsSemVer = (str: string) => {
 	return /^[\d]{1}\.[\d]{1,2}\.+/.test(str);
@@ -82,13 +83,42 @@ const installForWindows = async ({
 		signal,
 	});
 
-	await execute({
-		shell: 'powershell',
-		printOutput,
-		signal,
-		cwd: null,
-		bin: 'Expand-Archive',
-		args: ['-Force', filePath, to],
+	// execFile-style argv (no shell:powershell) + LiteralPath quoting so
+	// apostrophes and spaces in user paths do not break Expand-Archive.
+	const stdio: StdioOptions = printOutput ? 'inherit' : 'ignore';
+	await new Promise<void>((resolve, reject) => {
+		const child = spawn(
+			'powershell.exe',
+			[
+				'-NoProfile',
+				'-NonInteractive',
+				'-ExecutionPolicy',
+				'Bypass',
+				'-Command',
+				getExpandArchivePowerShellCommand({
+					zipPath: filePath,
+					destDir: to,
+				}),
+			],
+			{
+				stdio,
+				windowsHide: true,
+				signal: signal ?? undefined,
+			},
+		);
+
+		child.on('exit', (code, exitSignal) => {
+			if (code !== 0) {
+				reject(
+					new Error(
+						`Error while expanding whisper archive. Exit code: ${code}, signal: ${exitSignal}`,
+					),
+				);
+				return;
+			}
+
+			resolve();
+		});
 	});
 
 	rmSync(filePath);

--- a/packages/install-whisper-cpp/src/test/windows-powershell-path.test.ts
+++ b/packages/install-whisper-cpp/src/test/windows-powershell-path.test.ts
@@ -1,0 +1,33 @@
+import {expect, test} from 'bun:test';
+import {
+	escapePowerShellSingleQuoted,
+	getExpandArchivePowerShellCommand,
+} from '../windows-powershell-path';
+
+test('escapePowerShellSingleQuoted doubles apostrophes', () => {
+	expect(escapePowerShellSingleQuoted("C:\\Users\\O'Brien\\whisper.zip")).toBe(
+		"C:\\Users\\O''Brien\\whisper.zip",
+	);
+});
+
+test('getExpandArchivePowerShellCommand uses LiteralPath and safe quoting', () => {
+	expect(
+		getExpandArchivePowerShellCommand({
+			zipPath: "C:\\Users\\O'Brien\\whisper-bin-x64.zip",
+			destDir: "C:\\Users\\O'Brien\\whisper.cpp",
+		}),
+	).toBe(
+		"Expand-Archive -Force -LiteralPath 'C:\\Users\\O''Brien\\whisper-bin-x64.zip' -DestinationPath 'C:\\Users\\O''Brien\\whisper.cpp'",
+	);
+});
+
+test('getExpandArchivePowerShellCommand keeps spaces inside single quotes', () => {
+	expect(
+		getExpandArchivePowerShellCommand({
+			zipPath: 'C:\\Users\\Jane Doe\\whisper-bin-x64.zip',
+			destDir: 'C:\\Users\\Jane Doe\\whisper.cpp',
+		}),
+	).toBe(
+		"Expand-Archive -Force -LiteralPath 'C:\\Users\\Jane Doe\\whisper-bin-x64.zip' -DestinationPath 'C:\\Users\\Jane Doe\\whisper.cpp'",
+	);
+});

--- a/packages/install-whisper-cpp/src/windows-powershell-path.ts
+++ b/packages/install-whisper-cpp/src/windows-powershell-path.ts
@@ -1,0 +1,25 @@
+/**
+ * Escape a filesystem path for embedding inside a PowerShell single-quoted string.
+ * In PowerShell, the only escape inside '...' is doubling apostrophes.
+ */
+export const escapePowerShellSingleQuoted = (value: string): string => {
+	return value.replace(/'/g, "''");
+};
+
+/**
+ * Build an Expand-Archive command that survives spaces, brackets, and
+ * apostrophes in Windows paths. Passing Expand-Archive through
+ * `spawn(..., {shell: 'powershell'})` concatenates args without quoting, so
+ * paths like `C:\Users\O'Brien\...` or `C:\Users\Jane Doe\...` break.
+ */
+export const getExpandArchivePowerShellCommand = ({
+	zipPath,
+	destDir,
+}: {
+	zipPath: string;
+	destDir: string;
+}): string => {
+	const zip = escapePowerShellSingleQuoted(zipPath);
+	const dest = escapePowerShellSingleQuoted(destDir);
+	return `Expand-Archive -Force -LiteralPath '${zip}' -DestinationPath '${dest}'`;
+};


### PR DESCRIPTION
## Summary

On Windows, `@remotion/install-whisper-cpp` unpacked the Whisper binary zip with:

```ts
spawn('Expand-Archive', ['-Force', filePath, to], {shell: 'powershell'})
```

Node concatenates those args into a PowerShell command without quoting. Paths with spaces (`C:\Users\Jane Doe\...`) or apostrophes (`C:\Users\O'Brien\...`) fail Expand-Archive, so install breaks for common Windows user profile paths.

This switches to `powershell.exe` argv (`execFile`-style) with `-LiteralPath`, PowerShell single-quote escaping (doubled apostrophes), and `windowsHide: true`.

## AI assistance

Assisted by Cursor / Grok. Human author: Stan Shih (stantheman0128). I reviewed the diff and verification output.

## Verification / Evidence

```
bun test src/test/windows-powershell-path.test.ts
# 3 pass, 0 fail

# Live Win11: old shell:powershell Expand-Archive fails on O'Brien and "has space" paths
# New LiteralPath command extracts hello.txt with exit 0 on both
```

## Test plan

- [x] Unit tests for Expand-Archive command builder + apostrophe/space quoting
- [x] Live PowerShell Expand-Archive with apostrophe and space paths
- [ ] Manual: `installWhisperCpp` into a profile path that contains an apostrophe
