### PR TITLE
@remotion/studio-server + create-video: Hide Windows cmd.exe when opening editor

### DIFF
--- a/packages/create-video/src/open-in-editor.ts
+++ b/packages/create-video/src/open-in-editor.ts
@@ -610,7 +610,7 @@ export async function launchEditor({
 		_childProcess = child_process.spawn(
 			'cmd.exe',
 			['/C', binaryToUse].concat(args),
-			{stdio: 'inherit', detached: true},
+			{stdio: 'inherit', detached: true, windowsHide: true},
 		);
 	} else {
 		_childProcess = child_process.spawn(binaryToUse, args, {stdio: 'inherit'});

--- a/packages/studio-server/src/helpers/open-in-editor.ts
+++ b/packages/studio-server/src/helpers/open-in-editor.ts
@@ -652,7 +652,7 @@ export async function launchEditor({
 			_childProcess = child_process.spawn(
 				'cmd.exe',
 				['/C', binaryToUse].concat(args),
-				{stdio: 'inherit', detached: true},
+				{stdio: 'inherit', detached: true, windowsHide: true},
 			);
 		} else {
 			_childProcess = child_process.spawn(binaryToUse, args, {

--- a/packages/studio-server/src/test/open-in-editor-windows-hide.test.ts
+++ b/packages/studio-server/src/test/open-in-editor-windows-hide.test.ts
@@ -1,0 +1,24 @@
+import {expect, test} from 'bun:test';
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+
+const studioServerSource = readFileSync(
+	path.join(__dirname, '../helpers/open-in-editor.ts'),
+	'utf8',
+);
+const createVideoSource = readFileSync(
+	path.join(__dirname, '../../../create-video/src/open-in-editor.ts'),
+	'utf8',
+);
+
+test('Windows editor launch hides cmd.exe console window (studio-server)', () => {
+	expect(studioServerSource).toContain(
+		"{stdio: 'inherit', detached: true, windowsHide: true}",
+	);
+});
+
+test('Windows editor launch hides cmd.exe console window (create-video)', () => {
+	expect(createVideoSource).toContain(
+		"{stdio: 'inherit', detached: true, windowsHide: true}",
+	);
+});


### PR DESCRIPTION
## Summary
- Windows `launchEditor` path spawns `cmd.exe /C <editor>` without `windowsHide`.
- That can flash a console when opening a file from Studio or create-video on Windows.
- Set `windowsHide: true` in both `@remotion/studio-server` and `@remotion/create-video` copies of the helper.

## AI assistance
This PR was prepared with AI assistance (Cursor/Grok). Human author: Stan Shih (@stantheman0128). Please review carefully.

## Verification / Evidence
Focused tests:
```
cd packages/studio-server
bun test src/test/open-in-editor-windows-hide.test.ts
# 2 pass, 0 fail
```

## Test plan
- [x] Source regression for studio-server and create-video spawn options
- [ ] Maintainer: Open in editor from Studio on Windows and confirm no cmd flash
