### PR TITLE
`@remotion/studio`: Add creation menu to compositions panel

### DIFF
--- a/packages/studio/src/components/CompositionSelector.tsx
+++ b/packages/studio/src/components/CompositionSelector.tsx
@@ -12,6 +12,7 @@ import React, {
 } from 'react';
 import {Internals} from 'remotion';
 import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
+import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {
 	BACKGROUND,
 	BLACK_HEX,
@@ -26,9 +27,11 @@ import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
 import {ModalsContext} from '../state/modals';
 import {useZIndex} from '../state/z-index';
 import {CompositionSelectorItem} from './CompositionSelectorItem';
+import {ContextMenuForTarget} from './ContextMenu';
 import {useSelectComposition} from './InitialCompositionLoader';
 import {showNotification} from './Notifications/NotificationCenter';
 import {applyCodemod} from './RenderQueue/actions';
+import {getRootCompositionMenuItems} from './root-composition-menu-items';
 
 export const useCompositionNavigation = () => {
 	const {compositions, canvasContent} = useContext(
@@ -159,6 +162,15 @@ export const CompositionSelector: React.FC = () => {
 	);
 	const {foldersExpanded} = useContext(ExpandedFoldersContext);
 	const {setSelectedModal} = useContext(ModalsContext);
+	const connectionStatus = useContext(StudioServerConnectionCtx)
+		.previewServerState.type;
+	const rootContextMenuItems = useMemo(() => {
+		return getRootCompositionMenuItems({
+			connectionStatus,
+			readOnlyStudio: window.remotion_isReadOnlyStudio,
+			setSelectedModal,
+		});
+	}, [connectionStatus, setSelectedModal]);
 	const [rootDragHovered, setRootDragHovered] = useState(false);
 	const listRef = useRef<HTMLDivElement>(null);
 	const autoScrollAnimation = useRef<number | null>(null);
@@ -375,6 +387,11 @@ export const CompositionSelector: React.FC = () => {
 
 	return (
 		<div style={container}>
+			<ContextMenuForTarget
+				triggerRef={listRef}
+				values={rootContextMenuItems}
+				onOpen={null}
+			/>
 			<div style={quickSwitcherArea}>
 				<button
 					type="button"

--- a/packages/studio/src/components/root-composition-menu-items.ts
+++ b/packages/studio/src/components/root-composition-menu-items.ts
@@ -1,0 +1,54 @@
+import type {SetStateAction} from 'react';
+import type {PreviewServerConnectionState} from '../helpers/preview-server-events';
+import type {ModalState} from '../state/modals';
+import type {ComboboxValue} from './NewComposition/ComboBox';
+
+export const getRootCompositionMenuItems = ({
+	connectionStatus,
+	readOnlyStudio,
+	setSelectedModal,
+}: {
+	connectionStatus: PreviewServerConnectionState['type'];
+	readOnlyStudio: boolean;
+	setSelectedModal: (value: SetStateAction<ModalState | null>) => void;
+}): ComboboxValue[] => {
+	return [
+		{
+			id: 'new-root-composition',
+			keyHint: null,
+			label: 'New composition...',
+			leftItem: null,
+			onClick: () => {
+				setSelectedModal({
+					type: 'new-comp',
+					folderName: null,
+					parentName: null,
+					stack: null,
+				});
+			},
+			quickSwitcherLabel: 'New composition...',
+			subMenu: null,
+			type: 'item',
+			value: 'new-root-composition',
+			disabled: readOnlyStudio || connectionStatus !== 'connected',
+		},
+		{
+			id: 'new-root-folder',
+			keyHint: null,
+			label: 'New folder...',
+			leftItem: null,
+			onClick: () => {
+				setSelectedModal({
+					type: 'new-folder',
+					parentName: null,
+					stack: null,
+				});
+			},
+			quickSwitcherLabel: 'New folder...',
+			subMenu: null,
+			type: 'item',
+			value: 'new-root-folder',
+			disabled: readOnlyStudio || connectionStatus !== 'connected',
+		},
+	];
+};

--- a/packages/studio/src/test/root-composition-menu-items.test.ts
+++ b/packages/studio/src/test/root-composition-menu-items.test.ts
@@ -1,0 +1,65 @@
+import {expect, test} from 'bun:test';
+import {getRootCompositionMenuItems} from '../components/root-composition-menu-items';
+import type {ModalState} from '../state/modals';
+
+test('root composition menu creates compositions and folders at the root', () => {
+	const selectedModals: (ModalState | null)[] = [];
+	const items = getRootCompositionMenuItems({
+		connectionStatus: 'connected',
+		readOnlyStudio: false,
+		setSelectedModal: (modal) => {
+			if (typeof modal === 'function') {
+				selectedModals.push(modal(null));
+				return;
+			}
+
+			selectedModals.push(modal);
+		},
+	});
+
+	const newComposition = items.find(
+		(item) => item.id === 'new-root-composition',
+	);
+	const newFolder = items.find((item) => item.id === 'new-root-folder');
+
+	if (newComposition?.type !== 'item' || newFolder?.type !== 'item') {
+		throw new Error('Expected root creation menu items');
+	}
+
+	newComposition.onClick(newComposition.id, null);
+	newFolder.onClick(newFolder.id, null);
+
+	expect(selectedModals).toEqual([
+		{
+			type: 'new-comp',
+			folderName: null,
+			parentName: null,
+			stack: null,
+		},
+		{type: 'new-folder', parentName: null, stack: null},
+	]);
+});
+
+test('root creation menu is disabled in read-only Studio', () => {
+	const items = getRootCompositionMenuItems({
+		connectionStatus: 'connected',
+		readOnlyStudio: true,
+		setSelectedModal: () => undefined,
+	});
+
+	expect(
+		items.every((item) => item.type === 'item' && item.disabled === true),
+	).toBe(true);
+});
+
+test('root creation menu is disabled while the preview server is disconnected', () => {
+	const items = getRootCompositionMenuItems({
+		connectionStatus: 'disconnected',
+		readOnlyStudio: false,
+		setSelectedModal: () => undefined,
+	});
+
+	expect(
+		items.every((item) => item.type === 'item' && item.disabled === true),
+	).toBe(true);
+});


### PR DESCRIPTION
## Summary

- add a context menu to empty space in the Compositions panel
- allow creating root-level compositions and folders from the menu
- disable creation while Studio is read-only or the preview server is not connected
- cover the menu actions and availability states with tests

## Testing

- `bun run build`
- `bun test packages/studio/src/test/root-composition-menu-items.test.ts`
- `bunx turbo run lint formatting --filter='@remotion/studio'`

Closes #9237
