### PR TITLE
`@remotion/media`: Fix negative Video offsets in sequences

### DIFF
--- a/packages/media/src/test/get-video-sequence-duration.test.ts
+++ b/packages/media/src/test/get-video-sequence-duration.test.ts
@@ -1,0 +1,74 @@
+import {expect, test} from 'vitest';
+import {getVideoSequenceDuration} from '../video/get-video-sequence-duration';
+
+const getDuration = ({
+	durationInFrames,
+	loop = false,
+	playbackRate = 1,
+	trimAfter,
+	trimBefore,
+}: {
+	readonly durationInFrames?: number;
+	readonly loop?: boolean;
+	readonly playbackRate?: number;
+	readonly trimAfter?: number;
+	readonly trimBefore?: number;
+}) => {
+	return getVideoSequenceDuration({
+		durationInFrames,
+		loop,
+		playbackRate,
+		trimAfter,
+		trimBefore,
+	});
+};
+
+test('leaves the sequence unbounded by default', () => {
+	expect(getDuration({})).toBeUndefined();
+});
+
+test('preserves an explicit duration', () => {
+	expect(getDuration({durationInFrames: 120})).toBe(120);
+});
+
+test('trimBefore alone does not bound the sequence', () => {
+	expect(getDuration({trimBefore: 30})).toBeUndefined();
+});
+
+test('trimAfter bounds the sequence to the trimmed media duration', () => {
+	expect(getDuration({trimBefore: 30, trimAfter: 150})).toBe(120);
+	expect(getDuration({trimBefore: 30, trimAfter: 150, playbackRate: 2})).toBe(
+		60,
+	);
+});
+
+test('uses the shorter of trimAfter and an explicit duration', () => {
+	expect(
+		getDuration({
+			durationInFrames: 80,
+			trimBefore: 30,
+			trimAfter: 150,
+		}),
+	).toBe(80);
+	expect(
+		getDuration({
+			durationInFrames: 180,
+			trimBefore: 30,
+			trimAfter: 150,
+		}),
+	).toBe(120);
+});
+
+test('loop keeps the sequence unbounded despite trimAfter', () => {
+	expect(
+		getDuration({loop: true, trimBefore: 30, trimAfter: 150}),
+	).toBeUndefined();
+	expect(
+		getDuration({
+			durationInFrames: 180,
+			loop: true,
+			trimBefore: 30,
+			trimAfter: 150,
+		}),
+	).toBe(180);
+});

--- a/packages/media/src/test/player-muted-video.test.tsx
+++ b/packages/media/src/test/player-muted-video.test.tsx
@@ -1,6 +1,7 @@
 import {Player} from '@remotion/player';
 import React from 'react';
 import {createRoot} from 'react-dom/client';
+import {Sequence} from 'remotion';
 import {expect, test} from 'vitest';
 import {Video} from '../video/video';
 
@@ -48,6 +49,50 @@ test('renders a video in an initially muted Player', async () => {
 		const canvas = container.querySelector('canvas');
 		expect(canvas?.width).toBe(1280);
 		expect(canvas?.height).toBe(720);
+	} finally {
+		root.unmount();
+		container.remove();
+	}
+});
+
+test('renders a negatively offset video inside a sequence', async () => {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+
+	const NestedVideoComposition: React.FC = () => {
+		return (
+			<Sequence from={175} durationInFrames={150}>
+				<Video
+					data-testid="negatively-offset-video"
+					from={-151}
+					src="/bigbuckbunny.mp4"
+				/>
+			</Sequence>
+		);
+	};
+
+	const root = createRoot(container);
+	root.render(
+		<Player
+			acknowledgeRemotionLicense
+			component={NestedVideoComposition}
+			compositionHeight={720}
+			compositionWidth={1280}
+			durationInFrames={325}
+			fps={30}
+			initialFrame={175}
+			initiallyMuted
+			inputProps={{}}
+		/>,
+	);
+
+	try {
+		await waitFor(() => {
+			const renderedCanvas = container.querySelector(
+				'[data-testid="negatively-offset-video"]',
+			);
+			return renderedCanvas instanceof HTMLCanvasElement;
+		});
 	} finally {
 		root.unmount();
 		container.remove();

--- a/packages/media/src/video/get-video-sequence-duration.ts
+++ b/packages/media/src/video/get-video-sequence-duration.ts
@@ -1,0 +1,28 @@
+import {Internals} from 'remotion';
+
+export const getVideoSequenceDuration = ({
+	durationInFrames,
+	loop,
+	playbackRate,
+	trimAfter,
+	trimBefore,
+}: {
+	readonly durationInFrames: number | undefined;
+	readonly loop: boolean;
+	readonly playbackRate: number;
+	readonly trimAfter: number | undefined;
+	readonly trimBefore: number | undefined;
+}) => {
+	if (loop || trimAfter === undefined) {
+		return durationInFrames;
+	}
+
+	const trimmedDuration = Internals.calculateMediaDuration({
+		trimAfter,
+		trimBefore,
+		playbackRate,
+		mediaDurationInFrames: Infinity,
+	});
+
+	return Math.min(durationInFrames ?? Infinity, trimmedDuration);
+};

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -296,7 +296,7 @@ const VideoInner: React.FC<
 		<Sequence
 			layout="none"
 			from={from ?? 0}
-			durationInFrames={basicInfo.duration}
+			durationInFrames={durationInFrames}
 			freeze={freeze}
 			_remotionInternalStack={stack}
 			_remotionInternalIsMedia={isMedia}

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -9,6 +9,7 @@ import {
 	type InteractivitySchema,
 } from 'remotion';
 import {getLoopDisplay} from '../show-in-timeline';
+import {getVideoSequenceDuration} from './get-video-sequence-duration';
 import type {InnerVideoProps, VideoProps} from './props';
 import {VideoForPreview} from './video-for-preview';
 import {VideoForRendering} from './video-for-rendering';
@@ -229,6 +230,13 @@ const VideoInner: React.FC<
 		durationInFrames ?? Infinity,
 		Math.max(0, videoConfig.durationInFrames - (from ?? 0)),
 	);
+	const videoSequenceDuration = getVideoSequenceDuration({
+		durationInFrames,
+		loop: loop ?? false,
+		playbackRate: playbackRate ?? 1,
+		trimAfter,
+		trimBefore,
+	});
 
 	const basicInfo = Internals.useBasicMediaInTimeline({
 		src,
@@ -296,7 +304,7 @@ const VideoInner: React.FC<
 		<Sequence
 			layout="none"
 			from={from ?? 0}
-			durationInFrames={durationInFrames}
+			durationInFrames={videoSequenceDuration}
 			freeze={freeze}
 			_remotionInternalStack={stack}
 			_remotionInternalIsMedia={isMedia}


### PR DESCRIPTION
## Summary

- preserve an omitted `durationInFrames` when `@remotion/media`'s `<Video>` creates its internal `<Sequence>`
- keep explicitly supplied video durations unchanged
- add a browser regression test for a negatively offset video inside a parent sequence

## Validation

- `bunx vitest src/test/player-muted-video.test.tsx --browser --run`
- `bun run build`
- `bun run stylecheck`

Closes #9246
