### PR TITLE
`@remotion/studio`: Use selected composition values as defaults

### DIFF
--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -11,6 +11,7 @@ import {ModalHeader} from '../ModalHeader';
 import {label, optionRow, rightRow} from '../RenderModal/layout';
 import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
+import {getNewCompositionDefaults} from './get-new-composition-defaults';
 import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {InputDragger} from './InputDragger';
 import {NewCompDuration} from './NewCompDuration';
@@ -35,15 +36,24 @@ const NewCompositionLoaded: React.FC<{
 	readonly stack: string | null;
 }> = ({folderName, parentName, stack}) => {
 	const {compositions} = useContext(Internals.CompositionManager);
+	const resolvedComposition = Internals.useResolvedVideoConfig(null);
+	const initialComposition =
+		resolvedComposition?.type === 'success' ||
+		resolvedComposition?.type === 'success-and-refreshing'
+			? resolvedComposition.result
+			: null;
+	const initialDimensions = getNewCompositionDefaults(initialComposition);
 	const [newId, setName] = useState(() =>
 		getUniqueCompositionName(compositions),
 	);
-	const [selectedFrameRate, setFrameRate] = useState(30);
+	const [selectedFrameRate, setFrameRate] = useState(initialDimensions.fps);
 	const [size, setSize] = useState(() => ({
-		width: 1920,
-		height: 1080,
+		width: initialDimensions.width,
+		height: initialDimensions.height,
 	}));
-	const [durationInFrames, setDurationInFrames] = useState(150);
+	const [durationInFrames, setDurationInFrames] = useState(
+		initialDimensions.durationInFrames,
+	);
 
 	const onWidthChanged = useCallback((newValue: string) => {
 		setSize((s) => {

--- a/packages/studio/src/components/NewComposition/get-new-composition-defaults.ts
+++ b/packages/studio/src/components/NewComposition/get-new-composition-defaults.ts
@@ -1,0 +1,19 @@
+import type {VideoConfig} from 'remotion';
+
+type CompositionDimensions = Pick<
+	VideoConfig,
+	'width' | 'height' | 'fps' | 'durationInFrames'
+>;
+
+const defaultCompositionDimensions: CompositionDimensions = {
+	width: 1920,
+	height: 1080,
+	fps: 30,
+	durationInFrames: 150,
+};
+
+export const getNewCompositionDefaults = (
+	composition: CompositionDimensions | null,
+): CompositionDimensions => {
+	return composition ?? defaultCompositionDimensions;
+};

--- a/packages/studio/src/test/new-composition-defaults.test.ts
+++ b/packages/studio/src/test/new-composition-defaults.test.ts
@@ -1,0 +1,27 @@
+import {expect, test} from 'bun:test';
+import {getNewCompositionDefaults} from '../components/NewComposition/get-new-composition-defaults';
+
+test('uses the selected composition dimensions as defaults', () => {
+	expect(
+		getNewCompositionDefaults({
+			width: 1080,
+			height: 1920,
+			fps: 60,
+			durationInFrames: 600,
+		}),
+	).toEqual({
+		width: 1080,
+		height: 1920,
+		fps: 60,
+		durationInFrames: 600,
+	});
+});
+
+test('uses the existing defaults if no composition is selected', () => {
+	expect(getNewCompositionDefaults(null)).toEqual({
+		width: 1920,
+		height: 1080,
+		fps: 30,
+		durationInFrames: 150,
+	});
+});


### PR DESCRIPTION
## Summary

- initialize new composition dimensions, FPS, and duration from the currently selected composition
- use resolved metadata values when the selected composition has `calculateMetadata`
- preserve the existing defaults when no composition is selected

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run formatting lint test make --filter=@remotion/studio`

Closes #9244
