### PR TITLE
`@remotion/studio`: Align matching compositions on drop

### DIFF
--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1113,6 +1113,8 @@ export const Canvas: React.FC<{
 						composition: compositionDragData,
 						compositionFile,
 						compositionId: currentCompositionId,
+						destinationDimensions:
+							contentDimensions === 'none' ? null : contentDimensions,
 						dropPosition,
 					});
 				} else {

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -251,6 +251,29 @@ export const getElementPositionForDrop = ({
 	return getCenteredPosition({dimensions, dropPosition});
 };
 
+export const getCompositionPositionForDrop = ({
+	compositionDimensions,
+	destinationDimensions,
+	dropPosition,
+}: {
+	compositionDimensions: Dimensions;
+	destinationDimensions: Dimensions | null;
+	dropPosition: InsertElementDropPosition | null;
+}): InsertableCompositionElementPosition | null => {
+	if (
+		destinationDimensions !== null &&
+		compositionDimensions.width === destinationDimensions.width &&
+		compositionDimensions.height === destinationDimensions.height
+	) {
+		return null;
+	}
+
+	return getCenteredPosition({
+		dimensions: compositionDimensions,
+		dropPosition,
+	});
+};
+
 const getComponentPropNumber = (props: ComponentProp[], name: string) => {
 	const prop = props.find((p) => p.name === name);
 	return typeof prop?.value === 'number' ? prop.value : null;
@@ -855,11 +878,13 @@ export const insertComposition = async ({
 	composition,
 	compositionFile,
 	compositionId,
+	destinationDimensions,
 	dropPosition,
 }: {
 	composition: CompositionDragData;
 	compositionFile: string;
 	compositionId: string;
+	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
 }) => {
 	if (composition.compositionId === compositionId) {
@@ -897,8 +922,9 @@ export const insertComposition = async ({
 				height: calculated.height,
 				serializedResolvedPropsWithCustomSchema:
 					serializeResolvedPropsForSourceCode(calculated.props),
-				position: getCenteredPosition({
-					dimensions,
+				position: getCompositionPositionForDrop({
+					compositionDimensions: dimensions,
+					destinationDimensions,
 					dropPosition,
 				}),
 			},

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -260,6 +260,7 @@ export const getCompositionPositionForDrop = ({
 	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
 }): InsertableCompositionElementPosition | null => {
+	// No translation makes an equal-sized composition fill the destination.
 	if (
 		destinationDimensions !== null &&
 		compositionDimensions.width === destinationDimensions.width &&

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -3,6 +3,7 @@ import {
 	getAssetElement,
 	getAssetElementFromPath,
 	getComponentDimensions,
+	getCompositionPositionForDrop,
 	getElementPositionForDrop,
 } from '../components/import-assets';
 
@@ -155,4 +156,24 @@ test('does not position Elements without a drop position', () => {
 			dropPosition: null,
 		}),
 	).toBe(null);
+});
+
+test('aligns a composition with matching destination dimensions', () => {
+	expect(
+		getCompositionPositionForDrop({
+			compositionDimensions: {width: 1920, height: 1080},
+			destinationDimensions: {width: 1920, height: 1080},
+			dropPosition: {centerX: 400, centerY: 300},
+		}),
+	).toBe(null);
+});
+
+test('centers a composition with different destination dimensions', () => {
+	expect(
+		getCompositionPositionForDrop({
+			compositionDimensions: {width: 1280, height: 720},
+			destinationDimensions: {width: 1920, height: 1080},
+			dropPosition: {centerX: 400, centerY: 300},
+		}),
+	).toEqual({x: -240, y: -60});
 });


### PR DESCRIPTION
## Summary

- align a dropped composition to the destination origin when their dimensions match
- preserve pointer-centered placement when the dimensions differ
- add regression coverage for both behaviors

## Testing

- `bun test packages/studio/src/test/import-assets.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9245
