### PR TITLE
Docs: Add light backgrounds to text highlight examples

### DIFF
--- a/packages/docs/components/demos/RoughNotationAnimatedSeedDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationAnimatedSeedDemo.tsx
@@ -21,6 +21,7 @@ export const RoughNotationAnimatedSeedDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/components/demos/RoughNotationBoxDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationBoxDemo.tsx
@@ -21,6 +21,7 @@ export const RoughNotationBoxDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/components/demos/RoughNotationBracketDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationBracketDemo.tsx
@@ -21,6 +21,7 @@ export const RoughNotationBracketDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/components/demos/RoughNotationCircleDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationCircleDemo.tsx
@@ -22,6 +22,7 @@ export const RoughNotationCircleDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/components/demos/RoughNotationCrossedOffDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationCrossedOffDemo.tsx
@@ -21,6 +21,7 @@ export const RoughNotationCrossedOffDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/components/demos/RoughNotationHighlightDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationHighlightDemo.tsx
@@ -22,6 +22,7 @@ export const RoughNotationHighlightDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/components/demos/RoughNotationPosterizedProgressDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationPosterizedProgressDemo.tsx
@@ -21,6 +21,7 @@ export const RoughNotationPosterizedProgressDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/components/demos/RoughNotationPosterizedSeedDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationPosterizedSeedDemo.tsx
@@ -21,6 +21,7 @@ export const RoughNotationPosterizedSeedDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/components/demos/RoughNotationStrikeThroughDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationStrikeThroughDemo.tsx
@@ -21,6 +21,7 @@ export const RoughNotationStrikeThroughDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/components/demos/RoughNotationUnderlineDemo.tsx
+++ b/packages/docs/components/demos/RoughNotationUnderlineDemo.tsx
@@ -21,6 +21,7 @@ export const RoughNotationUnderlineDemo: React.FC = () => {
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
+				backgroundColor: '#fff',
 			}}
 		>
 			<Interactive.Div

--- a/packages/docs/docs/text-highlights.mdx
+++ b/packages/docs/docs/text-highlights.mdx
@@ -38,6 +38,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationHighlight: React.FC = () => {
@@ -120,6 +121,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationUnderline: React.FC = () => {
@@ -187,6 +189,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationStrikeThrough: React.FC = () => {
@@ -253,6 +256,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationCrossedOff: React.FC = () => {
@@ -321,6 +325,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationBox: React.FC = () => {
@@ -395,6 +400,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationBracket: React.FC = () => {
@@ -471,6 +477,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationCircle: React.FC = () => {
@@ -546,6 +553,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationAnimatedSeed: React.FC = () => {
@@ -613,6 +621,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationPosterizedSeed: React.FC = () => {
@@ -681,6 +690,7 @@ const {fontFamily} = loadFont('normal', {
 const containerStyle: React.CSSProperties = {
   justifyContent: 'center',
   alignItems: 'center',
+  backgroundColor: '#fff',
 };
 
 export const RoughNotationPosterizedProgress: React.FC = () => {


### PR DESCRIPTION
## Summary

- add a white background to every text highlight demo composition
- keep the copyable documentation snippets in sync with the rendered previews

## Validation

- `bun run build`
- `bun run stylecheck`
- `bun run build-docs` in `packages/docs`

Closes #9247
