### PR TITLE
`@remotion/studio`: Use contextual file manager labels

### DIFF
--- a/packages/browser-studio/src/BrowserStudio.tsx
+++ b/packages/browser-studio/src/BrowserStudio.tsx
@@ -137,6 +137,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 				projectName: 'template-blank',
 				publicFiles: makeStaticFiles(project.publicFiles),
 				publicFolderExists: null,
+				fileSystemPlatform: null,
 				publicPath: '',
 				readOnlyStudio: readOnly,
 				remotionRoot: project.rootDir,

--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -403,6 +403,7 @@ export const internalBundle = async (
 		title: 'Remotion Bundle',
 		renderDefaults: actualArgs.renderDefaults ?? undefined,
 		publicFolderExists: `${publicPath + (publicPath.endsWith('/') ? '' : '/')}public`,
+		fileSystemPlatform: null,
 		gitSource: actualArgs.gitSource ?? null,
 		projectName: getProjectName({
 			gitSource: actualArgs.gitSource ?? null,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,7 @@ declare global {
 		remotion_logLevel: LogLevel | undefined;
 		remotion_projectName: string;
 		remotion_cwd: string;
+		remotion_fileSystemPlatform: string | null;
 		remotion_studioServerCommand: string;
 		remotion_setFrame: (
 			frame: number,

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -386,6 +386,7 @@ const handleFallback = async ({
 			title: 'Remotion Studio',
 			renderDefaults: getRenderDefaults(),
 			publicFolderExists: existsSync(publicDir) ? publicDir : null,
+			fileSystemPlatform: process.platform,
 			gitSource,
 			projectName: getProjectName({
 				basename: path.basename,

--- a/packages/studio-shared/src/studio-html.ts
+++ b/packages/studio-shared/src/studio-html.ts
@@ -20,6 +20,7 @@ export type StudioHtmlOptions = {
 	sampleRate: number | null;
 	publicFiles: StaticFile[];
 	publicFolderExists: string | null;
+	fileSystemPlatform: string | null;
 	includeFavicon: boolean;
 	title: string;
 	renderDefaults: RenderDefaults | undefined;
@@ -50,6 +51,7 @@ export const studioHtml = ({
 	title,
 	renderDefaults,
 	publicFolderExists,
+	fileSystemPlatform,
 	gitSource,
 	projectName,
 	installedDependencies,
@@ -100,6 +102,7 @@ export const studioHtml = ({
 			renderDefaults,
 		)};</script>
 		<script>window.remotion_cwd = ${JSON.stringify(remotionRoot)};</script>
+		<script>window.remotion_fileSystemPlatform = ${JSON.stringify(fileSystemPlatform)};</script>
 		<script>window.remotion_studioServerCommand = ${
 			studioServerCommand ? JSON.stringify(studioServerCommand) : 'null'
 		};</script>

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -22,6 +22,7 @@ import {
 } from '../helpers/colors';
 import {copyText} from '../helpers/copy-text';
 import type {AssetFolder, AssetStructure} from '../helpers/create-folder-tree';
+import {getFileManagerName} from '../helpers/get-file-manager-name';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import {
 	markAssetSidebarScrollFromRowClick,
@@ -279,6 +280,9 @@ const AssetSelectorItem: React.FC<{
 	readonly parentFolder: string;
 	readonly readOnlyStudio: boolean;
 }> = ({item, tabIndex, level, parentFolder, readOnlyStudio}) => {
+	const fileManagerName = getFileManagerName(
+		window.remotion_fileSystemPlatform,
+	);
 	const isMobileLayout = useMobileLayout();
 	const [hovered, setHovered] = useState(false);
 	const [isDragging, setIsDragging] = useState(false);
@@ -497,10 +501,10 @@ const AssetSelectorItem: React.FC<{
 			{
 				id: 'open-asset-in-explorer',
 				keyHint: null,
-				label: 'Open in Explorer',
+				label: `Show in ${fileManagerName}`,
 				leftItem: null,
 				onClick: openAssetInExplorer,
-				quickSwitcherLabel: 'Open asset in Explorer',
+				quickSwitcherLabel: `Show asset in ${fileManagerName}`,
 				subMenu: null,
 				type: 'item',
 				value: 'open-asset-in-explorer',
@@ -540,8 +544,9 @@ const AssetSelectorItem: React.FC<{
 	}, [
 		copyFileName,
 		copyStaticFilePath,
-		openAssetInExplorer,
 		deleteAsset,
+		fileManagerName,
+		openAssetInExplorer,
 		relativePath,
 		serverActionDisabled,
 		setSelectedModal,
@@ -595,7 +600,7 @@ const AssetSelectorItem: React.FC<{
 								<>
 									<Spacing x={0.5} />
 									<InlineAction
-										title="Open in Explorer"
+										title={`Show in ${fileManagerName}`}
 										renderAction={renderFileExplorerAction}
 										onClick={revealInExplorer}
 									/>

--- a/packages/studio/src/helpers/get-file-manager-name.ts
+++ b/packages/studio/src/helpers/get-file-manager-name.ts
@@ -1,0 +1,11 @@
+export const getFileManagerName = (platform: string | null): string => {
+	if (platform === 'darwin') {
+		return 'Finder';
+	}
+
+	if (platform === 'win32') {
+		return 'File Explorer';
+	}
+
+	return 'File Manager';
+};

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -31,6 +31,7 @@ import {SidebarContext} from '../state/sidebar';
 import {checkFullscreenSupport} from './check-fullscreen-support';
 import {StudioServerConnectionCtx} from './client-id';
 import {WHITE_HEX} from './colors';
+import {getFileManagerName} from './get-file-manager-name';
 import {getGitMenuItem} from './get-git-menu-item';
 import {useMobileLayout} from './mobile-layout';
 import {openInEditor, preloadCompositionComponentInfo} from './open-in-editor';
@@ -60,6 +61,9 @@ const getFileMenu = ({
 	previewServerState: 'connected' | 'init' | 'disconnected';
 	setSelectedModal: (value: React.SetStateAction<ModalState | null>) => void;
 }) => {
+	const fileManagerName = getFileManagerName(
+		window.remotion_fileSystemPlatform,
+	);
 	const items: ComboboxValue[] = [
 		readOnlyStudio
 			? null
@@ -198,7 +202,7 @@ const getFileMenu = ({
 			? {
 					id: 'open-project-in-explorer',
 					value: 'open-project-in-explorer',
-					label: 'Open in Explorer',
+					label: `Open in ${fileManagerName}`,
 					onClick: () => {
 						closeMenu();
 						openInFileExplorer({directory: window.remotion_cwd}).catch(
@@ -214,7 +218,7 @@ const getFileMenu = ({
 					keyHint: null,
 					leftItem: null,
 					subMenu: null,
-					quickSwitcherLabel: 'Open project in Explorer',
+					quickSwitcherLabel: `Open project in ${fileManagerName}`,
 					disabled: previewServerState !== 'connected',
 				}
 			: null,

--- a/packages/studio/src/test/get-file-manager-name.test.ts
+++ b/packages/studio/src/test/get-file-manager-name.test.ts
@@ -1,0 +1,9 @@
+import {expect, test} from 'bun:test';
+import {getFileManagerName} from '../helpers/get-file-manager-name';
+
+test('returns the platform-specific file manager name', () => {
+	expect(getFileManagerName('darwin')).toBe('Finder');
+	expect(getFileManagerName('win32')).toBe('File Explorer');
+	expect(getFileManagerName('linux')).toBe('File Manager');
+	expect(getFileManagerName(null)).toBe('File Manager');
+});


### PR DESCRIPTION
## Summary

- pass the Studio server's filesystem platform to the client
- use Finder, File Explorer, or File Manager in filesystem action labels
- distinguish opening the project directory from showing a selected asset

## Validation

- `bun test packages/studio/src/test`
- `bun run build`
- `bun run stylecheck`

Closes #9242
