### PR TITLE
`@remotion/studio-server`: Allow splitting negative sequence offsets

### DIFF
--- a/packages/studio-server/src/codemods/split-jsx-sequence.ts
+++ b/packages/studio-server/src/codemods/split-jsx-sequence.ts
@@ -82,6 +82,14 @@ const getStaticNumber = (
 		return expression.value;
 	}
 
+	if (
+		expression.type === 'UnaryExpression' &&
+		expression.operator === '-' &&
+		expression.argument.type === 'NumericLiteral'
+	) {
+		return -expression.argument.value;
+	}
+
 	if (expression.type === 'Identifier' && expression.name === 'Infinity') {
 		return Infinity;
 	}

--- a/packages/studio-server/src/test/split-jsx-sequence.test.ts
+++ b/packages/studio-server/src/test/split-jsx-sequence.test.ts
@@ -80,6 +80,20 @@ test('splitJsxSequence splits finite duration and trimBefore', async () => {
 	);
 });
 
+test('splitJsxSequence splits a video with a negative from', async () => {
+	const output = await split(
+		'<Video src="video.mov" from={-2644} trimBefore={272} />',
+		100,
+	);
+
+	expect(output).toContain('from={-2644}');
+	expect(output).toContain('durationInFrames={2744}');
+	expect(output).toContain('trimBefore={272}');
+	expect(output).toContain(
+		'<Video src="video.mov" from={100} trimBefore={3016} />',
+	);
+});
+
 test('splitJsxSequence splits from-only sequence', async () => {
 	const output = await split('<Sequence from={10} />', 30);
 


### PR DESCRIPTION
## Summary

- recognize negative numeric JSX literals as static sequence timing values
- add a regression test for splitting a video with a negative `from`

## Testing

- `bun test packages/studio-server/src/test/split-jsx-sequence.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9234
