### PR TITLE
`@remotion/media`: Add muted to Video schema

### DIFF
--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -36,6 +36,7 @@ const videoSchema = {
 		hiddenFromList: false,
 		keyframable: false,
 	},
+	muted: {type: 'boolean', default: false, description: 'Muted'},
 	loop: {type: 'boolean', default: false, description: 'Loop'},
 	...Internals.transformSchema,
 } as const satisfies InteractivitySchema;


### PR DESCRIPTION
## Summary

- expose the `muted` prop in the `<Video>` interactivity schema
- default the visual control to `false`, matching the component runtime default

## Validation

- `bun run build`
- `bun run stylecheck`

Closes #9233
