### PR TITLE
`@remotion/studio`: Use Open in editor action wording

### DIFF
--- a/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
+++ b/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
@@ -70,15 +70,15 @@ export const getSequenceContextMenuItems = ({
 		editorName
 			? {
 					type: 'item' as const,
-					id: 'show-in-editor',
+					id: 'open-in-editor',
 					keyHint: null,
-					label: `Show in ${editorName}`,
+					label: `Open in ${editorName}`,
 					leftItem: null,
 					disabled: !canOpenInEditor || !originalLocation,
 					onClick: openInEditor,
 					quickSwitcherLabel: null,
 					subMenu: null,
-					value: 'show-in-editor',
+					value: 'open-in-editor',
 				}
 			: null,
 		{


### PR DESCRIPTION
## Summary

- rename the timeline source action from “Show in editor” to “Open in editor”
- align the action ID and value with the new wording

## Validation

- `bun run build`
- `bun run stylecheck`

Closes #9243
