### PR TITLE
`@remotion/studio`: Keep timeline row padding out of inspector

### DIFF
--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -21,6 +21,10 @@ import {
 } from './InspectorPanel/styles';
 import {TimelineExpandedRow} from './Timeline/TimelineExpandedRow';
 import {
+	INSPECTOR_TIMELINE_ROW_LAYOUT,
+	TimelineRowLayoutContext,
+} from './Timeline/TimelineRowLayoutContext';
+import {
 	getTimelineSelectionFromNodePathInfo,
 	TimelineSelectionOrderProvider,
 	type TimelineSelection,
@@ -282,20 +286,24 @@ export const InspectorSequenceSection: React.FC<{
 
 	const renderRow = ({node, depth}: FlatTreeRow) => {
 		return (
-			<TimelineExpandedRow
+			<TimelineRowLayoutContext.Provider
 				key={JSON.stringify(node.nodePathInfo)}
-				node={node}
-				depth={depth}
-				nestedDepth={0}
-				rowDepthBase={0}
-				getIsExpanded={getIsExpanded}
-				toggleTrack={toggleTrack}
-				validatedLocation={validatedLocation}
-				nodePath={nodePathInfo.sequenceSubscriptionKey}
-				schema={schema}
-				keyframeDisplayOffset={keyframeDisplayOffset}
-				keyframeControlsMode="inspector"
-			/>
+				value={INSPECTOR_TIMELINE_ROW_LAYOUT}
+			>
+				<TimelineExpandedRow
+					node={node}
+					depth={depth}
+					nestedDepth={0}
+					rowDepthBase={0}
+					getIsExpanded={getIsExpanded}
+					toggleTrack={toggleTrack}
+					validatedLocation={validatedLocation}
+					nodePath={nodePathInfo.sequenceSubscriptionKey}
+					schema={schema}
+					keyframeDisplayOffset={keyframeDisplayOffset}
+					keyframeControlsMode="inspector"
+				/>
+			</TimelineRowLayoutContext.Provider>
 		);
 	};
 

--- a/packages/studio/src/components/Timeline/TimelineFieldLabel.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldLabel.tsx
@@ -1,7 +1,8 @@
-import React, {useMemo} from 'react';
+import React, {useContext, useMemo} from 'react';
 import {WHITE_ALPHA_80} from '../../helpers/colors';
 import {SCHEMA_FIELD_ROW_HEIGHT} from '../../helpers/timeline-layout';
 import {getTimelineFieldLabelRowStyle} from './timeline-field-row-layout';
+import {TimelineRowLayoutContext} from './TimelineRowLayoutContext';
 import {
 	getTimelineColor,
 	getTimelineSelectedLabelStyle,
@@ -24,14 +25,15 @@ export const TimelineFieldLabel: React.FC<{
 	readonly label: string;
 	readonly stacked?: boolean;
 }> = ({rowDepth, selected, label, stacked = false}) => {
+	const {basePadding} = useContext(TimelineRowLayoutContext);
 	const labelRowStyle = useMemo(
 		(): React.CSSProperties => ({
-			...getTimelineFieldLabelRowStyle(rowDepth),
+			...getTimelineFieldLabelRowStyle(rowDepth, basePadding),
 			...getTimelineSelectedLabelStyle(selected, true),
 			...(stacked ? {flex: `0 0 ${SCHEMA_FIELD_ROW_HEIGHT}px`} : null),
 			alignSelf: 'stretch',
 		}),
-		[rowDepth, selected, stacked],
+		[basePadding, rowDepth, selected, stacked],
 	);
 
 	const fieldNameStyle = useMemo(

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -1,11 +1,11 @@
-import React, {useCallback, useMemo, useRef} from 'react';
+import React, {useCallback, useContext, useMemo, useRef} from 'react';
 import {TIMELINE_TRACK_SEPARATOR} from '../../helpers/colors';
 import {Padder} from './Padder';
 import {
-	TIMELINE_ROW_BASE_PADDING,
 	getTimelineRowIndentWidth,
 	getTimelineRowLeftChromeWidth,
 } from './timeline-row-layout';
+import {TimelineRowLayoutContext} from './TimelineRowLayoutContext';
 import type {TimelineSelectionInteraction} from './TimelineSelection';
 import {
 	getTimelineRowHighlightBackground,
@@ -27,11 +27,9 @@ const leftChromeStyle: React.CSSProperties = {
 
 const keyframeControlsColumnBaseStyle: React.CSSProperties = {
 	alignItems: 'center',
-	boxSizing: 'border-box',
 	display: 'flex',
 	flexShrink: 0,
 	justifyContent: 'flex-start',
-	paddingLeft: TIMELINE_ROW_BASE_PADDING,
 };
 
 export const TimelineRowChrome: React.FC<{
@@ -75,15 +73,20 @@ export const TimelineRowChrome: React.FC<{
 	onDoubleClick,
 }) => {
 	const ref = useRef<HTMLDivElement>(null);
+	const {basePadding, keyframeControlsPadding} = useContext(
+		TimelineRowLayoutContext,
+	);
 	const indentWidth = getTimelineRowIndentWidth(depth);
 	useTimelineFocusableItem(selectionItem, ref);
 
 	const keyframeControlsColumnStyle = useMemo(
 		(): React.CSSProperties => ({
 			...keyframeControlsColumnBaseStyle,
-			width: getTimelineRowLeftChromeWidth(depth),
+			boxSizing: keyframeControlsPadding === 0 ? undefined : 'border-box',
+			paddingLeft: keyframeControlsPadding,
+			width: getTimelineRowLeftChromeWidth(depth, basePadding),
 		}),
-		[depth],
+		[basePadding, depth, keyframeControlsPadding],
 	);
 
 	const chromeColumnStyle = useMemo(
@@ -92,9 +95,9 @@ export const TimelineRowChrome: React.FC<{
 			alignSelf: 'stretch',
 			display: 'flex',
 			flexShrink: 0,
-			paddingLeft: TIMELINE_ROW_BASE_PADDING,
+			paddingLeft: basePadding,
 		}),
-		[],
+		[basePadding],
 	);
 
 	const onPointerDown = useCallback(

--- a/packages/studio/src/components/Timeline/TimelineRowLayoutContext.ts
+++ b/packages/studio/src/components/Timeline/TimelineRowLayoutContext.ts
@@ -1,0 +1,20 @@
+import {createContext} from 'react';
+import {
+	INSPECTOR_ROW_BASE_PADDING,
+	TIMELINE_ROW_BASE_PADDING,
+} from './timeline-row-layout';
+
+type TimelineRowLayout = {
+	readonly basePadding: number;
+	readonly keyframeControlsPadding: number;
+};
+
+export const INSPECTOR_TIMELINE_ROW_LAYOUT: TimelineRowLayout = {
+	basePadding: INSPECTOR_ROW_BASE_PADDING,
+	keyframeControlsPadding: 0,
+};
+
+export const TimelineRowLayoutContext = createContext<TimelineRowLayout>({
+	basePadding: TIMELINE_ROW_BASE_PADDING,
+	keyframeControlsPadding: TIMELINE_ROW_BASE_PADDING,
+});

--- a/packages/studio/src/components/Timeline/timeline-field-row-layout.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-row-layout.ts
@@ -4,9 +4,10 @@ import {getTimelineFieldLabelFlexBasis} from './timeline-row-layout';
 
 export const getTimelineFieldLabelRowStyle = (
 	depth: number,
+	basePadding?: number,
 ): React.CSSProperties => {
 	return {
-		flex: `0 0 ${getTimelineFieldLabelFlexBasis(depth)}`,
+		flex: `0 0 ${getTimelineFieldLabelFlexBasis(depth, basePadding)}`,
 		minWidth: 0,
 		display: 'flex',
 		flexDirection: 'row',

--- a/packages/studio/src/components/Timeline/timeline-row-layout.ts
+++ b/packages/studio/src/components/Timeline/timeline-row-layout.ts
@@ -1,6 +1,7 @@
 import {TIMELINE_INDENT} from './timeline-indent';
 
 export const TIMELINE_ROW_BASE_PADDING = 10;
+export const INSPECTOR_ROW_BASE_PADDING = 5;
 export const TIMELINE_EYE_COLUMN_WIDTH = 22;
 export const TIMELINE_ARROW_COLUMN_WIDTH = 16;
 export const TIMELINE_KEYFRAME_CONTROLS_WIDTH = 38;
@@ -10,17 +11,23 @@ export const getTimelineRowIndentWidth = (depth: number): number => {
 	return depth * TIMELINE_INDENT;
 };
 
-export const getTimelineRowLeftChromeWidth = (depth: number): number => {
+export const getTimelineRowLeftChromeWidth = (
+	depth: number,
+	basePadding = TIMELINE_ROW_BASE_PADDING,
+): number => {
 	return (
-		TIMELINE_ROW_BASE_PADDING +
+		basePadding +
 		TIMELINE_EYE_COLUMN_WIDTH +
 		getTimelineRowIndentWidth(depth) +
 		TIMELINE_ARROW_COLUMN_WIDTH
 	);
 };
 
-export const getTimelineFieldLabelFlexBasis = (depth: number): string => {
-	return `calc(50% - ${getTimelineRowLeftChromeWidth(depth) - TIMELINE_FIELD_LABEL_EXTRA_WIDTH}px)`;
+export const getTimelineFieldLabelFlexBasis = (
+	depth: number,
+	basePadding = TIMELINE_ROW_BASE_PADDING,
+): string => {
+	return `calc(50% - ${getTimelineRowLeftChromeWidth(depth, basePadding) - TIMELINE_FIELD_LABEL_EXTRA_WIDTH}px)`;
 };
 
 export const getExpandedRowDepth = ({


### PR DESCRIPTION
## Summary

- keep the increased timeline row padding in the timeline
- restore the inspector's previous row and keyframe-control padding
- keep inspector field labels aligned with the restored row geometry

## Testing

- `bun run build`
- `bun run stylecheck`
