### PR TITLE
`@remotion/studio`: Hide empty effects placeholder

### DIFF
--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -329,13 +329,11 @@ export const InspectorSequenceSection: React.FC<{
 						<div style={controlsEffectsDivider} />
 					) : null}
 					{renderEffectsHeader()}
-					{effectRows.length === 0 ? (
-						<div style={emptyState}>None</div>
-					) : (
+					{effectRows.length > 0 ? (
 						<TimelineSelectionOrderProvider items={effectSelectableItems}>
 							{effectRows.map(renderRow)}
 						</TimelineSelectionOrderProvider>
-					)}
+					) : null}
 				</>
 			) : null}
 		</div>


### PR DESCRIPTION
## Summary

- Remove the "None" placeholder from an empty Effects section in the Studio inspector
- Keep the Effects header and add action available

## Verification

- `bun run build`
- `bun run stylecheck`
