### PR TITLE
`@remotion/studio`: Open compositions in popup windows

### DIFF
--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -28,6 +28,7 @@ import {
 	markCompositionSidebarScrollFromRowClick,
 	maybeScrollCompositionSidebarRowIntoView,
 } from '../helpers/sidebar-scroll-into-view';
+import {getUrlForRoute} from '../helpers/url-state';
 import {CollapsedFolderIcon, ExpandedFolderIcon} from '../icons/folder';
 import {StillIcon} from '../icons/still';
 import {FilmIcon} from '../icons/video';
@@ -199,7 +200,7 @@ export const CompositionSelectorItem: React.FC<{
 
 	const contextMenu = useMemo((): ComboboxValue[] => {
 		if (item.type === 'composition') {
-			return getCompositionMenuItems({
+			const compositionMenuItems = getCompositionMenuItems({
 				closeMenu: noop,
 				composition: item.composition,
 				connectionStatus,
@@ -207,6 +208,57 @@ export const CompositionSelectorItem: React.FC<{
 				setSelectedModal,
 				readOnlyStudio: window.remotion_isReadOnlyStudio,
 			});
+
+			return [
+				{
+					id: 'open-in-new-window',
+					keyHint: null,
+					label: 'Open in new window',
+					leftItem: null,
+					onClick: () => {
+						const screen = window.screen as Screen & {
+							availLeft?: number;
+							availTop?: number;
+						};
+						const width = Math.min(1200, Math.floor(screen.availWidth * 0.8));
+						const height = Math.min(800, Math.floor(screen.availHeight * 0.8));
+						const displayLeft = screen.availLeft ?? 0;
+						const displayTop = screen.availTop ?? 0;
+						const left = Math.round(
+							Math.min(
+								Math.max(
+									window.screenX + (window.outerWidth - width) / 2,
+									displayLeft,
+								),
+								displayLeft + screen.availWidth - width,
+							),
+						);
+						const top = Math.round(
+							Math.min(
+								Math.max(
+									window.screenY + (window.outerHeight - height) / 2,
+									displayTop,
+								),
+								displayTop + screen.availHeight - height,
+							),
+						);
+						window.open(
+							getUrlForRoute(`/${item.composition.id}`),
+							'_blank',
+							`popup,width=${width},height=${height},left=${left},top=${top}`,
+						);
+					},
+					quickSwitcherLabel: null,
+					subMenu: null,
+					type: 'item',
+					value: 'open-in-new-window',
+				},
+				{
+					type: 'divider',
+					id: 'open-in-new-window-divider',
+				},
+				...compositionMenuItems,
+			];
 		}
 
 		return getFolderMenuItems({

--- a/packages/studio/src/helpers/url-state.ts
+++ b/packages/studio/src/helpers/url-state.ts
@@ -8,16 +8,16 @@ const getUrlHandlingType = (): UrlHandling => {
 	return 'spa';
 };
 
-export const pushUrl = (url: string) => {
+export const getUrlForRoute = (route: string) => {
 	if (getUrlHandlingType() === 'query-string') {
-		window.history.pushState(
-			{},
-			'Studio',
-			`${window.location.pathname}?${url}`,
-		);
-	} else {
-		window.history.pushState({}, 'Studio', url);
+		return `${window.location.pathname}?${route}`;
 	}
+
+	return route;
+};
+
+export const pushUrl = (url: string) => {
+	window.history.pushState({}, 'Studio', getUrlForRoute(url));
 };
 
 export const clearUrl = () => {


### PR DESCRIPTION
## Summary

- add an "Open in new window" action to composition selector context menus
- open the selected composition in a popup sized for the current display
- center the popup over the originating Studio window and keep it within display bounds
- preserve both SPA and read-only Studio URL routing

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
