### PR TITLE
`@remotion/studio`: Link sequences to matching compositions

### DIFF
--- a/packages/browser-studio/src/virtual-files.ts
+++ b/packages/browser-studio/src/virtual-files.ts
@@ -21,23 +21,30 @@ import JsxRuntime from 'react/jsx-runtime';
 import {Internals} from 'remotion';
 
 const componentsToAddStacksTo = Internals.getComponentsToAddStacksTo();
+const sequenceComponent = Internals.getSequenceComponent();
 
 const originalCreateElement = React.createElement;
 const originalJsx = JsxRuntime.jsx;
 const originalJsxs = JsxRuntime.jsxs;
 const originalJsxDev = JsxRuntimeDev.jsxDEV;
 
-const enableProxy = (api) => {
+const enableProxy = (api, isCreateElement) => {
   return new Proxy(api, {
     apply(target, thisArg, argArray) {
       if (componentsToAddStacksTo.includes(argArray[0])) {
         const [first, props, ...rest] = argArray;
+        const children = isCreateElement
+          ? rest.length === 0
+            ? props?.children
+            : rest
+          : props?.children;
         const newProps = props?.stack
-          ? props
-          : {
-              ...(props ?? {}),
-              stack: new Error().stack,
-            };
+          ? {...props}
+          : {...(props ?? {}), stack: new Error().stack};
+        if (first === sequenceComponent) {
+          newProps._remotionInternalSingleChildComponent =
+            Internals.getSingleChildComponent(children);
+        }
 
         return Reflect.apply(target, thisArg, [first, newProps, ...rest]);
       }
@@ -47,10 +54,10 @@ const enableProxy = (api) => {
   });
 };
 
-React.createElement = enableProxy(originalCreateElement);
-JsxRuntime.jsx = enableProxy(originalJsx);
-JsxRuntime.jsxs = enableProxy(originalJsxs);
-JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev);
+React.createElement = enableProxy(originalCreateElement, true);
+JsxRuntime.jsx = enableProxy(originalJsx, false);
+JsxRuntime.jsxs = enableProxy(originalJsxs, false);
+JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev, false);
 `;
 
 const reactShim = `import * as React from 'react';

--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -4,6 +4,7 @@ import JsxRuntime from 'react/jsx-runtime';
 import {Internals} from 'remotion';
 
 const componentsToAddStacksTo = Internals.getComponentsToAddStacksTo();
+const sequenceComponent = Internals.getSequenceComponent();
 
 const originalCreateElement = React.createElement;
 const originalJsx = JsxRuntime.jsx;
@@ -17,17 +18,24 @@ const enableProxy = <
 		| typeof JsxRuntimeDev.jsxDEV,
 >(
 	api: T,
+	isCreateElement: boolean,
 ): T => {
 	return new Proxy(api, {
 		apply(target, thisArg, argArray) {
 			if (componentsToAddStacksTo.includes(argArray[0])) {
 				const [first, props, ...rest] = argArray;
+				const children = isCreateElement
+					? rest.length === 0
+						? props?.children
+						: rest
+					: props?.children;
 				const newProps = props?.stack
-					? props
-					: {
-							...(props ?? {}),
-							stack: new Error().stack,
-						};
+					? {...props}
+					: {...(props ?? {}), stack: new Error().stack};
+				if (first === sequenceComponent) {
+					newProps._remotionInternalSingleChildComponent =
+						Internals.getSingleChildComponent(children);
+				}
 
 				return Reflect.apply(target, thisArg, [first, newProps, ...rest]);
 			}
@@ -37,7 +45,7 @@ const enableProxy = <
 	});
 };
 
-React.createElement = enableProxy(originalCreateElement);
-JsxRuntime.jsx = enableProxy(originalJsx);
-JsxRuntime.jsxs = enableProxy(originalJsxs);
-JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev);
+React.createElement = enableProxy(originalCreateElement, true);
+JsxRuntime.jsx = enableProxy(originalJsx, false);
+JsxRuntime.jsxs = enableProxy(originalJsxs, false);
+JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev, false);

--- a/packages/core/src/Composition.tsx
+++ b/packages/core/src/Composition.tsx
@@ -180,6 +180,8 @@ const InnerComposition = <
 
 	const {folderName, parentName} = useContext(FolderContext);
 	const stack = (compProps as {stack?: string}).stack ?? null;
+	const componentFromProps =
+		'component' in compProps ? compProps.component : null;
 
 	useEffect(() => {
 		// Ensure it's a URL safe id
@@ -202,6 +204,7 @@ const InnerComposition = <
 			) as InferProps<Schema, Props>,
 			nonce: nonce.get(),
 			parentFolderName: parentName,
+			componentFromProps,
 			schema: schema ?? null,
 			calculateMetadata: compProps.calculateMetadata ?? null,
 			stack,
@@ -221,6 +224,7 @@ const InnerComposition = <
 		width,
 		nonce,
 		parentName,
+		componentFromProps,
 		schema,
 		compProps.calculateMetadata,
 		stack,

--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -20,6 +20,7 @@ export type TComposition<
 	folderName: string | null;
 	parentFolderName: string | null;
 	component: LazyExoticComponent<ComponentType<Props>> | ComponentType<Props>;
+	componentFromProps?: unknown;
 	nonce: NonceHistory;
 	schema: Schema | null;
 	calculateMetadata: CalculateMetadataFunction<
@@ -130,6 +131,7 @@ export type TSequence = {
 	effects: readonly EffectDefinition<unknown>[];
 	isInsideSeries: boolean;
 	frozenFrame: number | null;
+	singleChildComponent?: unknown;
 } & EnhancedTSequenceData;
 
 export type AudioOrVideoAsset = {

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -86,6 +86,10 @@ export type SequencePropsWithoutDuration = {
 	/**
 	 * @deprecated For internal use only.
 	 */
+	readonly _remotionInternalSingleChildComponent?: unknown;
+	/**
+	 * @deprecated For internal use only.
+	 */
 	readonly _remotionInternalIsPremounting?: boolean;
 	/**
 	 * @deprecated For internal use only.
@@ -134,6 +138,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		_remotionInternalLoopDisplay: loopDisplay,
 		_remotionInternalStack: stack,
 		_remotionInternalDocumentationLink: documentationLink,
+		_remotionInternalSingleChildComponent: singleChildComponent,
 		_remotionInternalPremountDisplay: premountDisplay,
 		_remotionInternalPostmountDisplay: postmountDisplay,
 		_remotionInternalIsMedia: isMedia,
@@ -399,6 +404,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 					refForOutline: refForOutline ?? null,
 					isInsideSeries,
 					frozenFrame: registeredFrozenFrame,
+					singleChildComponent: singleChildComponent ?? null,
 				});
 			} else {
 				registerSequence({
@@ -429,6 +435,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 					isInsideSeries,
 					frozenFrame: registeredFrozenFrame,
 					frozenMediaFrame,
+					singleChildComponent: singleChildComponent ?? null,
 				});
 			}
 
@@ -458,6 +465,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 			refForOutline: refForOutline ?? null,
 			isInsideSeries,
 			frozenFrame: registeredFrozenFrame,
+			singleChildComponent: singleChildComponent ?? null,
 		});
 		return () => {
 			unregisterSequence(id);
@@ -491,6 +499,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		startMediaFrom,
 		mediaFrameAtSequenceZero,
 		frozenMediaFrame,
+		singleChildComponent,
 	]);
 
 	// Ceil to support floats

--- a/packages/core/src/enable-sequence-stack-traces.ts
+++ b/packages/core/src/enable-sequence-stack-traces.ts
@@ -1,7 +1,34 @@
+import React from 'react';
+
 const componentsToAddStacksTo: unknown[] = [];
+let sequenceComponent: unknown = null;
 
 export const getComponentsToAddStacksTo = () => componentsToAddStacksTo;
 
 export const addSequenceStackTraces = (component: unknown) => {
 	componentsToAddStacksTo.push(component);
+};
+
+export const setSequenceComponent = (component: unknown) => {
+	sequenceComponent = component;
+};
+
+export const getSequenceComponent = () => sequenceComponent;
+
+export const getSingleChildComponent = (children: React.ReactNode): unknown => {
+	const mountedChildren = React.Children.toArray(children);
+	if (mountedChildren.length !== 1) {
+		return null;
+	}
+
+	const child = mountedChildren[0];
+	if (!React.isValidElement(child)) {
+		return null;
+	}
+
+	if (typeof child.type !== 'function' && typeof child.type !== 'object') {
+		return null;
+	}
+
+	return child.type;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,10 @@ import type {
 	TRenderAsset,
 } from './CompositionManager.js';
 import type {DelayRenderScope} from './delay-render.js';
-import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
+import {
+	addSequenceStackTraces,
+	setSequenceComponent,
+} from './enable-sequence-stack-traces.js';
 import {Folder, type TFolder} from './Folder.js';
 import type {StaticFile} from './get-static-files.js';
 import type {
@@ -316,6 +319,7 @@ export const Config = new Proxy(proxyObj, {
 
 Sequence.displayName = 'Sequence';
 addSequenceStackTraces(Sequence);
+setSequenceComponent(Sequence);
 addSequenceStackTraces(Composition);
 addSequenceStackTraces(Folder);
 

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -67,6 +67,8 @@ import {
 import {
 	addSequenceStackTraces,
 	getComponentsToAddStacksTo,
+	getSequenceComponent,
+	getSingleChildComponent,
 } from './enable-sequence-stack-traces.js';
 import {findPropsToDelete} from './find-props-to-delete.js';
 import {
@@ -365,6 +367,8 @@ export const Internals = {
 	BufferingProvider,
 	BufferingContextReact,
 	getComponentsToAddStacksTo,
+	getSequenceComponent,
+	getSingleChildComponent,
 	CurrentScaleContext,
 	PixelDensityContext,
 	PreviewSizeContext,

--- a/packages/core/src/test/single-child-component.test.tsx
+++ b/packages/core/src/test/single-child-component.test.tsx
@@ -1,0 +1,28 @@
+import {expect, test} from 'bun:test';
+import React from 'react';
+import {getSingleChildComponent} from '../enable-sequence-stack-traces';
+
+const Child: React.FC = () => null;
+const OtherChild: React.FC = () => null;
+
+test('detects one mounted child component', () => {
+	expect(getSingleChildComponent(<Child />)).toBe(Child);
+	expect(getSingleChildComponent([null, false, <Child key="child" />])).toBe(
+		Child,
+	);
+});
+
+test('does not detect host elements or multiple mounted children', () => {
+	expect(getSingleChildComponent(<div />)).toBe(null);
+	expect(
+		getSingleChildComponent(
+			<>
+				<Child />
+				<OtherChild />
+			</>,
+		),
+	).toBe(null);
+	expect(
+		getSingleChildComponent([<Child key="a" />, <OtherChild key="b" />]),
+	).toBe(null);
+});

--- a/packages/studio/src/components/CompositionOrStillIcon.tsx
+++ b/packages/studio/src/components/CompositionOrStillIcon.tsx
@@ -1,0 +1,17 @@
+import type React from 'react';
+import type {_InternalTypes} from 'remotion';
+import {isCompositionStill} from '../helpers/is-composition-still';
+import {StillIcon} from '../icons/still';
+import {FilmIcon} from '../icons/video';
+
+export const CompositionOrStillIcon: React.FC<{
+	readonly color: string;
+	readonly composition: _InternalTypes['AnyComposition'];
+	readonly style: React.CSSProperties;
+}> = ({color, composition, style}) => {
+	return isCompositionStill(composition) ? (
+		<StillIcon color={color} style={style} />
+	) : (
+		<FilmIcon color={color} style={style} />
+	);
+};

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -22,18 +22,16 @@ import {
 	getBackgroundFromHoverState,
 } from '../helpers/colors';
 import {getFolderId} from '../helpers/get-folder-id';
-import {isCompositionStill} from '../helpers/is-composition-still';
 import {noop} from '../helpers/noop';
 import {
 	markCompositionSidebarScrollFromRowClick,
 	maybeScrollCompositionSidebarRowIntoView,
 } from '../helpers/sidebar-scroll-into-view';
 import {CollapsedFolderIcon, ExpandedFolderIcon} from '../icons/folder';
-import {StillIcon} from '../icons/still';
-import {FilmIcon} from '../icons/video';
 import {ModalsContext} from '../state/modals';
 import {getCompositionMenuItems} from './composition-menu-items';
 import {CompositionContextButton} from './CompositionContextButton';
+import {CompositionOrStillIcon} from './CompositionOrStillIcon';
 import {ContextMenu} from './ContextMenu';
 import {getFolderMenuItems} from './folder-menu-items';
 import {Row, Spacing} from './layout';
@@ -433,17 +431,11 @@ export const CompositionSelectorItem: React.FC<{
 					className="__remotion-composition"
 					data-compname={item.composition.id}
 				>
-					{isCompositionStill(item.composition) ? (
-						<StillIcon
-							color={hovered || selected ? WHITE : LIGHT_TEXT}
-							style={iconStyle}
-						/>
-					) : (
-						<FilmIcon
-							color={hovered || selected ? WHITE : LIGHT_TEXT}
-							style={iconStyle}
-						/>
-					)}
+					<CompositionOrStillIcon
+						composition={item.composition}
+						color={hovered || selected ? WHITE : LIGHT_TEXT}
+						style={iconStyle}
+					/>
 					<Spacing x={1} />
 					<div style={label}>{item.composition.id}</div>
 					<Spacing x={0.5} />

--- a/packages/studio/src/components/InspectorPanel/SequenceCompositionsSection.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceCompositionsSection.tsx
@@ -1,0 +1,64 @@
+import React, {useContext, useMemo} from 'react';
+import {Internals} from 'remotion';
+import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
+import {CompositionOrStillIcon} from '../CompositionOrStillIcon';
+import {useSelectComposition} from '../InitialCompositionLoader';
+import {InspectorInlineAction} from './common';
+import {getCompositionsMatchingSingleChild} from './get-compositions-matching-single-child';
+import {detailsContainer, inspectorSectionDivider} from './styles';
+
+const compositionIconStyle: React.CSSProperties = {
+	height: 13,
+	width: 13,
+};
+
+const compositionListStyle: React.CSSProperties = {
+	...detailsContainer,
+	display: 'flex',
+	flexDirection: 'column',
+	paddingBottom: 6,
+	paddingTop: 6,
+};
+
+export const SequenceCompositionsSection: React.FC<{
+	readonly track: TrackWithHash;
+}> = ({track}) => {
+	const {compositions} = useContext(Internals.CompositionManager);
+	const selectComposition = useSelectComposition();
+	const matchingCompositions = useMemo(
+		() =>
+			getCompositionsMatchingSingleChild({
+				compositions,
+				singleChildComponent: track.sequence.singleChildComponent,
+			}),
+		[compositions, track.sequence.singleChildComponent],
+	);
+
+	if (matchingCompositions.length === 0) {
+		return null;
+	}
+
+	return (
+		<>
+			<div style={inspectorSectionDivider} />
+			<div style={compositionListStyle}>
+				{matchingCompositions.map((composition) => (
+					<InspectorInlineAction
+						key={composition.id}
+						disabled={false}
+						onClick={() => selectComposition(composition, true)}
+						renderIcon={(color) => (
+							<CompositionOrStillIcon
+								color={color}
+								composition={composition}
+								style={compositionIconStyle}
+							/>
+						)}
+					>
+						{composition.id}
+					</InspectorInlineAction>
+				))}
+			</div>
+		</>
+	);
+};

--- a/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
@@ -7,6 +7,7 @@ import {InspectorLocationCopy} from '../InspectorLocationCopy';
 import {InspectorSourceLocation} from '../InspectorSourceLocation';
 import {useOpenSequenceInEditor} from '../Timeline/use-open-sequence-in-editor';
 import {useRenameSequence} from '../Timeline/use-rename-sequence';
+import {SequenceCompositionsSection} from './SequenceCompositionsSection';
 import {
 	sequenceHeader,
 	sequenceHeaderDivider,
@@ -91,7 +92,6 @@ export const SequenceInspectorHeader: React.FC<{
 	}, [documentationLink]);
 
 	const componentName = track.sequence.controls?.componentName;
-
 	const onRename = useCallback(
 		(newName: string) => {
 			saveName(newName).catch(() => undefined);
@@ -142,6 +142,7 @@ export const SequenceInspectorHeaderWithDivider: React.FC<{
 	return (
 		<>
 			<SequenceInspectorHeader sourceLocation={sourceLocation} track={track} />
+			<SequenceCompositionsSection track={track} />
 			<div style={sequenceHeaderDivider} />
 		</>
 	);

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -14,6 +14,7 @@ import {
 import {AlignmentControls} from './AlignmentControls';
 import {InspectorMessage, InspectorSectionHeader} from './common';
 import type {SequenceSectionSelection} from './inspector-selection';
+import {SequenceCompositionsSection} from './SequenceCompositionsSection';
 import {
 	SequenceInspectorHeader,
 	useSequenceInspectorSourceLocation,
@@ -83,6 +84,7 @@ const SequenceExpandedInspector: React.FC<{
 			onPointerDown={selectSequenceOnInspectorPointerDown}
 		>
 			<SequenceInspectorHeader sourceLocation={sourceLocation} track={track} />
+			<SequenceCompositionsSection track={track} />
 			<InspectorSequenceSection
 				sequence={track.sequence}
 				validatedLocation={validatedLocation}

--- a/packages/studio/src/components/InspectorPanel/common.tsx
+++ b/packages/studio/src/components/InspectorPanel/common.tsx
@@ -98,7 +98,7 @@ const inlineLabelButton: React.CSSProperties = {
 	gap: 8,
 	lineHeight: '18px',
 	margin: 0,
-	padding: '10px 0 0',
+	padding: '5px 0',
 };
 
 const inlineLabelButtonDisabled: React.CSSProperties = {

--- a/packages/studio/src/components/InspectorPanel/get-compositions-matching-single-child.ts
+++ b/packages/studio/src/components/InspectorPanel/get-compositions-matching-single-child.ts
@@ -1,0 +1,20 @@
+export const getCompositionsMatchingSingleChild = <
+	Composition extends {readonly componentFromProps?: unknown},
+>({
+	compositions,
+	singleChildComponent,
+}: {
+	readonly compositions: readonly Composition[];
+	readonly singleChildComponent: unknown;
+}): Composition[] => {
+	if (
+		singleChildComponent === null ||
+		typeof singleChildComponent === 'undefined'
+	) {
+		return [];
+	}
+
+	return compositions.filter(
+		(composition) => composition.componentFromProps === singleChildComponent,
+	);
+};

--- a/packages/studio/src/test/get-compositions-matching-single-child.test.ts
+++ b/packages/studio/src/test/get-compositions-matching-single-child.test.ts
@@ -1,0 +1,28 @@
+import {expect, test} from 'bun:test';
+import {getCompositionsMatchingSingleChild} from '../components/InspectorPanel/get-compositions-matching-single-child';
+
+const Child = () => null;
+const OtherChild = () => null;
+const compositions = [
+	{id: 'first', componentFromProps: Child},
+	{id: 'second', componentFromProps: OtherChild},
+	{id: 'third', componentFromProps: Child},
+];
+
+test('returns all compositions with the same component identity', () => {
+	expect(
+		getCompositionsMatchingSingleChild({
+			compositions,
+			singleChildComponent: Child,
+		}).map((composition) => composition.id),
+	).toEqual(['first', 'third']);
+});
+
+test('does not match when no single child component was detected', () => {
+	expect(
+		getCompositionsMatchingSingleChild({
+			compositions,
+			singleChildComponent: null,
+		}),
+	).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- detect a Sequence with one mounted component child and retain that component identity in Studio
- match the child against registered composition component props and list every match in the Sequence inspector
- link composition and still rows using shared icon-selection logic and existing inspector action styling

## Testing

- `bun run build`
- `bun run stylecheck`
- Studio test suite (396 tests)

## Follow-up

- Context menus for connected compositions are tracked in #9264.
