### PR TITLE
`remotion-monorepo`: Avoid discovering nested skills

### DIFF
--- a/packages/claude-code-plugin/build.mts
+++ b/packages/claude-code-plugin/build.mts
@@ -4,6 +4,7 @@ import {
 	mkdirSync,
 	readdirSync,
 	readFileSync,
+	renameSync,
 	rmSync,
 	statSync,
 	writeFileSync,
@@ -14,6 +15,7 @@ const __dirname = new URL('.', import.meta.url).pathname;
 const skillsOut = resolve(__dirname, 'skills');
 
 const packagesSkillsDir = resolve(__dirname, '..', 'skills', 'skills');
+const embeddedSkillFilename = 'REFERENCE.md';
 
 if (existsSync(skillsOut)) {
 	rmSync(skillsOut, {recursive: true});
@@ -36,12 +38,24 @@ const copySkillDir = (src: string, destName: string) => {
 	console.log(`  Copied ${destName}`);
 };
 
-const rewriteEmbeddedBestPracticesLinks = () => {
+const prepareEmbeddedBestPractices = () => {
 	const embeddedRoot = join(skillsOut, 'remotion-best-practices');
 
 	if (!existsSync(embeddedRoot)) {
 		return;
 	}
+
+	const embeddedSkillNames = readdirSync(embeddedRoot, {withFileTypes: true})
+		.filter((entry) => {
+			const child = join(embeddedRoot, entry.name);
+			return (
+				entry.isDirectory() &&
+				entry.name !== 'rules' &&
+				existsSync(join(child, 'SKILL.md'))
+			);
+		})
+		.map((entry) => entry.name)
+		.sort();
 
 	const rewriteMarkdownFiles = (dir: string) => {
 		for (const entry of readdirSync(dir, {withFileTypes: true})) {
@@ -56,25 +70,24 @@ const rewriteEmbeddedBestPracticesLinks = () => {
 			}
 
 			const contents = readFileSync(file, 'utf-8');
-			const rewritten = contents.replaceAll(
-				'../remotion-best-practices/',
-				'../',
-			);
+			let rewritten = contents.replaceAll('../remotion-best-practices/', '../');
+			for (const skillName of embeddedSkillNames) {
+				rewritten = rewritten.replaceAll(
+					`${skillName}/SKILL.md`,
+					`${skillName}/${embeddedSkillFilename}`,
+				);
+			}
 			if (contents !== rewritten) {
 				writeFileSync(file, rewritten);
 			}
 		}
 	};
 
-	for (const entry of readdirSync(embeddedRoot, {withFileTypes: true})) {
-		const child = join(embeddedRoot, entry.name);
-		if (
-			entry.isDirectory() &&
-			entry.name !== 'rules' &&
-			existsSync(join(child, 'SKILL.md'))
-		) {
-			rewriteMarkdownFiles(child);
-		}
+	rewriteMarkdownFiles(embeddedRoot);
+
+	for (const skillName of embeddedSkillNames) {
+		const child = join(embeddedRoot, skillName);
+		renameSync(join(child, 'SKILL.md'), join(child, embeddedSkillFilename));
 	}
 };
 
@@ -89,7 +102,7 @@ if (existsSync(packagesSkillsDir)) {
 	for (const folder of skillFolders) {
 		copySkillDir(join(packagesSkillsDir, folder), folder);
 	}
-	rewriteEmbeddedBestPracticesLinks();
+	prepareEmbeddedBestPractices();
 } else {
 	console.warn('Warning: packages/skills/skills/ not found');
 }

--- a/packages/claude-code-plugin/build.mts
+++ b/packages/claude-code-plugin/build.mts
@@ -10,8 +10,9 @@ import {
 	writeFileSync,
 } from 'node:fs';
 import {join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const skillsOut = resolve(__dirname, 'skills');
 
 const packagesSkillsDir = resolve(__dirname, '..', 'skills', 'skills');

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -10,7 +10,8 @@
 		"formatting": "oxfmt . --check",
 		"format": "oxfmt .",
 		"lint": "eslint .",
-		"build": "bun build.mts"
+		"build": "bun build.mts",
+		"test": "bun build.mts && SKILLS_ROOT=skills bun ../skills/scripts/validate-links.ts && bun test test"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"license": "Remotion License",

--- a/packages/claude-code-plugin/test/plugin.test.ts
+++ b/packages/claude-code-plugin/test/plugin.test.ts
@@ -1,0 +1,62 @@
+import {expect, test} from 'bun:test';
+import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
+import path from 'node:path';
+
+const packageRoot = path.resolve(import.meta.dir, '..');
+const generatedSkillsRoot = path.join(packageRoot, 'skills');
+const embeddedRoot = path.join(generatedSkillsRoot, 'remotion-best-practices');
+
+const getDirectories = (directory: string) => {
+	return readdirSync(directory)
+		.filter((entry) => statSync(path.join(directory, entry)).isDirectory())
+		.sort();
+};
+
+const getMarkdownFiles = (directory: string): string[] => {
+	return readdirSync(directory).flatMap((entry) => {
+		const file = path.join(directory, entry);
+		if (statSync(file).isDirectory()) {
+			return getMarkdownFiles(file);
+		}
+
+		return file.endsWith('.md') ? [file] : [];
+	});
+};
+
+test('only top-level skills use the discovery filename', () => {
+	const topLevelSkillNames = getDirectories(generatedSkillsRoot);
+	for (const skillName of topLevelSkillNames) {
+		expect(
+			existsSync(path.join(generatedSkillsRoot, skillName, 'SKILL.md')),
+		).toBe(true);
+	}
+
+	const discoveredSkills = getMarkdownFiles(generatedSkillsRoot)
+		.filter((file) => path.basename(file) === 'SKILL.md')
+		.map((file) => path.relative(generatedSkillsRoot, file))
+		.sort();
+	expect(discoveredSkills).toEqual(
+		topLevelSkillNames.map((skillName) => path.join(skillName, 'SKILL.md')),
+	);
+
+	const embeddedSkillNames = getDirectories(embeddedRoot).filter((skillName) =>
+		topLevelSkillNames.includes(skillName),
+	);
+	for (const skillName of embeddedSkillNames) {
+		expect(existsSync(path.join(embeddedRoot, skillName, 'SKILL.md'))).toBe(
+			false,
+		);
+		expect(existsSync(path.join(embeddedRoot, skillName, 'REFERENCE.md'))).toBe(
+			true,
+		);
+	}
+});
+
+test('links to embedded skills use the renamed file', () => {
+	for (const file of getMarkdownFiles(embeddedRoot)) {
+		const contents = readFileSync(file, 'utf-8');
+		for (const skillName of getDirectories(embeddedRoot)) {
+			expect(contents).not.toContain(`${skillName}/SKILL.md`);
+		}
+	}
+});

--- a/packages/codex-plugin/build.mts
+++ b/packages/codex-plugin/build.mts
@@ -5,6 +5,7 @@ import {
 	mkdirSync,
 	readdirSync,
 	readFileSync,
+	renameSync,
 	rmSync,
 	statSync,
 	writeFileSync,
@@ -15,6 +16,7 @@ const __dirname = new URL('.', import.meta.url).pathname;
 const skillsOut = resolve(__dirname, 'skills');
 
 const packagesSkillsDir = resolve(__dirname, '..', 'skills', 'skills');
+const embeddedSkillFilename = 'REFERENCE.md';
 
 if (existsSync(skillsOut)) {
 	rmSync(skillsOut, {recursive: true});
@@ -36,12 +38,24 @@ function copySkillDir(src: string, destName: string) {
 	console.log(`  Copied ${destName}`);
 }
 
-const rewriteEmbeddedBestPracticesLinks = () => {
+const prepareEmbeddedBestPractices = () => {
 	const embeddedRoot = join(skillsOut, 'remotion-best-practices');
 
 	if (!existsSync(embeddedRoot)) {
 		return;
 	}
+
+	const embeddedSkillNames = readdirSync(embeddedRoot, {withFileTypes: true})
+		.filter((entry) => {
+			const child = join(embeddedRoot, entry.name);
+			return (
+				entry.isDirectory() &&
+				entry.name !== 'rules' &&
+				existsSync(join(child, 'SKILL.md'))
+			);
+		})
+		.map((entry) => entry.name)
+		.sort();
 
 	const rewriteMarkdownFiles = (dir: string) => {
 		for (const entry of readdirSync(dir, {withFileTypes: true})) {
@@ -56,25 +70,24 @@ const rewriteEmbeddedBestPracticesLinks = () => {
 			}
 
 			const contents = readFileSync(file, 'utf-8');
-			const rewritten = contents.replaceAll(
-				'../remotion-best-practices/',
-				'../',
-			);
+			let rewritten = contents.replaceAll('../remotion-best-practices/', '../');
+			for (const skillName of embeddedSkillNames) {
+				rewritten = rewritten.replaceAll(
+					`${skillName}/SKILL.md`,
+					`${skillName}/${embeddedSkillFilename}`,
+				);
+			}
 			if (contents !== rewritten) {
 				writeFileSync(file, rewritten);
 			}
 		}
 	};
 
-	for (const entry of readdirSync(embeddedRoot, {withFileTypes: true})) {
-		const child = join(embeddedRoot, entry.name);
-		if (
-			entry.isDirectory() &&
-			entry.name !== 'rules' &&
-			existsSync(join(child, 'SKILL.md'))
-		) {
-			rewriteMarkdownFiles(child);
-		}
+	rewriteMarkdownFiles(embeddedRoot);
+
+	for (const skillName of embeddedSkillNames) {
+		const child = join(embeddedRoot, skillName);
+		renameSync(join(child, 'SKILL.md'), join(child, embeddedSkillFilename));
 	}
 };
 
@@ -119,7 +132,7 @@ if (existsSync(packagesSkillsDir)) {
 	for (const folder of skillFolders) {
 		copySkillDir(join(packagesSkillsDir, folder), folder);
 	}
-	rewriteEmbeddedBestPracticesLinks();
+	prepareEmbeddedBestPractices();
 	addCodexOnlyInstructions();
 } else {
 	console.warn('Warning: packages/skills/skills/ not found');

--- a/packages/codex-plugin/build.mts
+++ b/packages/codex-plugin/build.mts
@@ -11,8 +11,9 @@ import {
 	writeFileSync,
 } from 'fs';
 import {join, resolve} from 'path';
+import {fileURLToPath} from 'url';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const skillsOut = resolve(__dirname, 'skills');
 
 const packagesSkillsDir = resolve(__dirname, '..', 'skills', 'skills');

--- a/packages/codex-plugin/package.json
+++ b/packages/codex-plugin/package.json
@@ -10,7 +10,8 @@
 		"formatting": "oxfmt . --check",
 		"format": "oxfmt .",
 		"lint": "eslint .",
-		"build": "bun build.mts"
+		"build": "bun build.mts",
+		"test": "bun build.mts && SKILLS_ROOT=skills bun ../skills/scripts/validate-links.ts && bun test test"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"license": "Remotion License",

--- a/packages/codex-plugin/test/plugin.test.ts
+++ b/packages/codex-plugin/test/plugin.test.ts
@@ -1,0 +1,62 @@
+import {expect, test} from 'bun:test';
+import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
+import path from 'node:path';
+
+const packageRoot = path.resolve(import.meta.dir, '..');
+const generatedSkillsRoot = path.join(packageRoot, 'skills');
+const embeddedRoot = path.join(generatedSkillsRoot, 'remotion-best-practices');
+
+const getDirectories = (directory: string) => {
+	return readdirSync(directory)
+		.filter((entry) => statSync(path.join(directory, entry)).isDirectory())
+		.sort();
+};
+
+const getMarkdownFiles = (directory: string): string[] => {
+	return readdirSync(directory).flatMap((entry) => {
+		const file = path.join(directory, entry);
+		if (statSync(file).isDirectory()) {
+			return getMarkdownFiles(file);
+		}
+
+		return file.endsWith('.md') ? [file] : [];
+	});
+};
+
+test('only top-level skills use the discovery filename', () => {
+	const topLevelSkillNames = getDirectories(generatedSkillsRoot);
+	for (const skillName of topLevelSkillNames) {
+		expect(
+			existsSync(path.join(generatedSkillsRoot, skillName, 'SKILL.md')),
+		).toBe(true);
+	}
+
+	const discoveredSkills = getMarkdownFiles(generatedSkillsRoot)
+		.filter((file) => path.basename(file) === 'SKILL.md')
+		.map((file) => path.relative(generatedSkillsRoot, file))
+		.sort();
+	expect(discoveredSkills).toEqual(
+		topLevelSkillNames.map((skillName) => path.join(skillName, 'SKILL.md')),
+	);
+
+	const embeddedSkillNames = getDirectories(embeddedRoot).filter((skillName) =>
+		topLevelSkillNames.includes(skillName),
+	);
+	for (const skillName of embeddedSkillNames) {
+		expect(existsSync(path.join(embeddedRoot, skillName, 'SKILL.md'))).toBe(
+			false,
+		);
+		expect(existsSync(path.join(embeddedRoot, skillName, 'REFERENCE.md'))).toBe(
+			true,
+		);
+	}
+});
+
+test('links to embedded skills use the renamed file', () => {
+	for (const file of getMarkdownFiles(embeddedRoot)) {
+		const contents = readFileSync(file, 'utf-8');
+		for (const skillName of getDirectories(embeddedRoot)) {
+			expect(contents).not.toContain(`${skillName}/SKILL.md`);
+		}
+	}
+});

--- a/packages/it-tests/src/templates/publish.ts
+++ b/packages/it-tests/src/templates/publish.ts
@@ -3,6 +3,7 @@ import {
 	existsSync,
 	readdirSync,
 	readFileSync,
+	renameSync,
 	statSync,
 	writeFileSync,
 } from 'node:fs';
@@ -33,12 +34,28 @@ const skillsTemplate: MinimalTemplate = {
 
 const templates = [skillsTemplate, ...folders];
 
-const rewriteEmbeddedBestPracticesLinks = (root: string) => {
+const embeddedSkillFilename = 'REFERENCE.md';
+
+const prepareEmbeddedBestPractices = (root: string) => {
 	const embeddedRoot = path.join(root, 'skills', 'remotion-best-practices');
 
 	if (!existsSync(embeddedRoot)) {
 		return;
 	}
+
+	const embeddedSkillNames = readdirSync(embeddedRoot, {withFileTypes: true})
+		.filter((entry) => {
+			const child = path.join(embeddedRoot, entry.name);
+			return (
+				entry.isDirectory() &&
+				entry.name !== 'rules' &&
+				statSync(path.join(child, 'SKILL.md'), {
+					throwIfNoEntry: false,
+				})?.isFile()
+			);
+		})
+		.map((entry) => entry.name)
+		.sort();
 
 	const rewriteMarkdownFiles = (dir: string) => {
 		for (const entry of readdirSync(dir, {withFileTypes: true})) {
@@ -53,25 +70,27 @@ const rewriteEmbeddedBestPracticesLinks = (root: string) => {
 			}
 
 			const contents = readFileSync(file, 'utf-8');
-			const rewritten = contents.replaceAll(
-				'../remotion-best-practices/',
-				'../',
-			);
+			let rewritten = contents.replaceAll('../remotion-best-practices/', '../');
+			for (const skillName of embeddedSkillNames) {
+				rewritten = rewritten.replaceAll(
+					`${skillName}/SKILL.md`,
+					`${skillName}/${embeddedSkillFilename}`,
+				);
+			}
 			if (contents !== rewritten) {
 				writeFileSync(file, rewritten);
 			}
 		}
 	};
 
-	for (const entry of readdirSync(embeddedRoot, {withFileTypes: true})) {
-		const child = path.join(embeddedRoot, entry.name);
-		if (
-			entry.isDirectory() &&
-			entry.name !== 'rules' &&
-			statSync(path.join(child, 'SKILL.md'), {throwIfNoEntry: false})?.isFile()
-		) {
-			rewriteMarkdownFiles(child);
-		}
+	rewriteMarkdownFiles(embeddedRoot);
+
+	for (const skillName of embeddedSkillNames) {
+		const child = path.join(embeddedRoot, skillName);
+		renameSync(
+			path.join(child, 'SKILL.md'),
+			path.join(child, embeddedSkillFilename),
+		);
 	}
 };
 
@@ -122,7 +141,7 @@ const publish = async (template: MinimalTemplate) => {
 	}
 
 	if (template.templateInMonorepo === 'skills') {
-		rewriteEmbeddedBestPracticesLinks(workingDir);
+		prepareEmbeddedBestPractices(workingDir);
 	}
 
 	await $`git add .`.cwd(workingDir).nothrow();

--- a/packages/kimi-code-plugin/build.mts
+++ b/packages/kimi-code-plugin/build.mts
@@ -4,6 +4,7 @@ import {
 	mkdirSync,
 	readdirSync,
 	readFileSync,
+	renameSync,
 	rmSync,
 	statSync,
 	writeFileSync,
@@ -15,6 +16,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const skillsOut = resolve(__dirname, 'skills');
 
 const packagesSkillsDir = resolve(__dirname, '..', 'skills', 'skills');
+const embeddedSkillFilename = 'REFERENCE.md';
 
 if (existsSync(skillsOut)) {
 	rmSync(skillsOut, {recursive: true});
@@ -37,12 +39,24 @@ const copySkillDir = (src: string, destName: string) => {
 	console.log(`  Copied ${destName}`);
 };
 
-const rewriteEmbeddedBestPracticesLinks = () => {
+const prepareEmbeddedBestPractices = () => {
 	const embeddedRoot = join(skillsOut, 'remotion-best-practices');
 
 	if (!existsSync(embeddedRoot)) {
 		return;
 	}
+
+	const embeddedSkillNames = readdirSync(embeddedRoot, {withFileTypes: true})
+		.filter((entry) => {
+			const child = join(embeddedRoot, entry.name);
+			return (
+				entry.isDirectory() &&
+				entry.name !== 'rules' &&
+				existsSync(join(child, 'SKILL.md'))
+			);
+		})
+		.map((entry) => entry.name)
+		.sort();
 
 	const rewriteMarkdownFiles = (dir: string) => {
 		for (const entry of readdirSync(dir, {withFileTypes: true})) {
@@ -57,25 +71,24 @@ const rewriteEmbeddedBestPracticesLinks = () => {
 			}
 
 			const contents = readFileSync(file, 'utf-8');
-			const rewritten = contents.replaceAll(
-				'../remotion-best-practices/',
-				'../',
-			);
+			let rewritten = contents.replaceAll('../remotion-best-practices/', '../');
+			for (const skillName of embeddedSkillNames) {
+				rewritten = rewritten.replaceAll(
+					`${skillName}/SKILL.md`,
+					`${skillName}/${embeddedSkillFilename}`,
+				);
+			}
 			if (contents !== rewritten) {
 				writeFileSync(file, rewritten);
 			}
 		}
 	};
 
-	for (const entry of readdirSync(embeddedRoot, {withFileTypes: true})) {
-		const child = join(embeddedRoot, entry.name);
-		if (
-			entry.isDirectory() &&
-			entry.name !== 'rules' &&
-			existsSync(join(child, 'SKILL.md'))
-		) {
-			rewriteMarkdownFiles(child);
-		}
+	rewriteMarkdownFiles(embeddedRoot);
+
+	for (const skillName of embeddedSkillNames) {
+		const child = join(embeddedRoot, skillName);
+		renameSync(join(child, 'SKILL.md'), join(child, embeddedSkillFilename));
 	}
 };
 
@@ -90,7 +103,7 @@ if (existsSync(packagesSkillsDir)) {
 	for (const folder of skillFolders) {
 		copySkillDir(join(packagesSkillsDir, folder), folder);
 	}
-	rewriteEmbeddedBestPracticesLinks();
+	prepareEmbeddedBestPractices();
 } else {
 	console.warn('Warning: packages/skills/skills/ not found');
 }

--- a/packages/kimi-code-plugin/package.json
+++ b/packages/kimi-code-plugin/package.json
@@ -11,7 +11,7 @@
 		"format": "oxfmt .",
 		"lint": "eslint .",
 		"build": "bun build.mts",
-		"test": "bun build.mts && bun test test"
+		"test": "bun build.mts && SKILLS_ROOT=skills bun ../skills/scripts/validate-links.ts && bun test test"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"license": "Remotion License",

--- a/packages/kimi-code-plugin/test/plugin.test.ts
+++ b/packages/kimi-code-plugin/test/plugin.test.ts
@@ -83,33 +83,61 @@ test('generated skills match the canonical skills', () => {
 	})
 		.filter((file) => !file.endsWith('.tsx'))
 		.map((file) => path.relative(canonicalSkillsRoot, file));
+	const embeddedSkillNames = getDirectories(
+		path.join(canonicalSkillsRoot, 'remotion-best-practices'),
+	).filter((skillName) =>
+		existsSync(
+			path.join(
+				canonicalSkillsRoot,
+				'remotion-best-practices',
+				skillName,
+				'SKILL.md',
+			),
+		),
+	);
+	const getGeneratedRelativeFile = (relativeFile: string) => {
+		const pathParts = relativeFile.split(path.sep);
+		if (
+			pathParts[0] === 'remotion-best-practices' &&
+			embeddedSkillNames.includes(pathParts[1]) &&
+			pathParts.at(-1) === 'SKILL.md'
+		) {
+			pathParts[pathParts.length - 1] = 'REFERENCE.md';
+		}
+
+		return pathParts.join(path.sep);
+	};
 	const generatedFiles = getFiles({
 		directory: generatedSkillsRoot,
 		expectNoSymlinks: true,
 	}).map((file) => path.relative(generatedSkillsRoot, file));
 
-	expect(generatedFiles).toEqual(canonicalFiles);
+	expect(generatedFiles).toEqual(
+		canonicalFiles.map(getGeneratedRelativeFile).sort(),
+	);
 
 	for (const relativeFile of canonicalFiles) {
 		const canonicalFile = path.join(canonicalSkillsRoot, relativeFile);
-		const generatedFile = path.join(generatedSkillsRoot, relativeFile);
+		const generatedFile = path.join(
+			generatedSkillsRoot,
+			getGeneratedRelativeFile(relativeFile),
+		);
 		if (relativeFile.endsWith('.md')) {
 			const pathParts = relativeFile.split(path.sep);
-			const shouldRewriteLinks =
-				pathParts[0] === 'remotion-best-practices' &&
-				pathParts[1] !== 'rules' &&
-				existsSync(
-					path.join(
-						canonicalSkillsRoot,
-						'remotion-best-practices',
-						pathParts[1],
-						'SKILL.md',
-					),
-				);
 			const canonicalContents = readFileSync(canonicalFile, 'utf-8');
-			const expectedContents = shouldRewriteLinks
-				? canonicalContents.replaceAll('../remotion-best-practices/', '../')
-				: canonicalContents;
+			let expectedContents = canonicalContents;
+			if (pathParts[0] === 'remotion-best-practices') {
+				expectedContents = expectedContents.replaceAll(
+					'../remotion-best-practices/',
+					'../',
+				);
+				for (const skillName of embeddedSkillNames) {
+					expectedContents = expectedContents.replaceAll(
+						`${skillName}/SKILL.md`,
+						`${skillName}/REFERENCE.md`,
+					);
+				}
+			}
 			expect(readFileSync(generatedFile, 'utf-8')).toBe(expectedContents);
 		} else {
 			expect(readFileSync(generatedFile)).toEqual(readFileSync(canonicalFile));


### PR DESCRIPTION
## Summary

- rename embedded `SKILL.md` files to `REFERENCE.md` in published skill bundles
- rewrite links to the renamed embedded references for Codex, Claude Code, Kimi Code, and the generic skills repository
- validate generated skill links and discovery structure in package tests

## Verification

- `bun run build`
- `bun run stylecheck`
- plugin package tests, including generated-output link validation

Closes #9269
