### PR TITLE
`remotion-monorepo`: Check gcloud authentication before releases

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -4,6 +4,7 @@ description: Release a new Remotion version
 ---
 
 - Kill any `turbo` processes that might be running with SIGKILL
+- Before beginning the release, verify that gcloud is logged in by running `gcloud auth print-access-token >/dev/null`. If it fails, run `gcloud auth login`, then repeat the check. Do not continue with the release until the check succeeds.
 - Codex-specific: Before running release commands, make sure rbenv wins over the macOS system Ruby. Codex may start non-interactive shells with `/usr/bin` before `~/.rbenv/shims`, causing Ruby 2.6 to be used even though the user's terminal uses Ruby 3.3.x. Run release commands that may invoke Ruby/Bundler with:
   `PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH" <command>`
   Verify with `PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH" ruby --version`; it should use the user's rbenv Ruby, not `/usr/bin/ruby`. This matters because the lambda Ruby package currently resolves gems such as `json` that require Ruby >= 2.7.


### PR DESCRIPTION
## Summary

- verify that gcloud can issue an access token before starting a release
- require `gcloud auth login` and a successful recheck when authentication has expired

## Checks

- `bun run build`
- `bun run stylecheck`
