### PR TITLE
`@remotion/example`: Add animated captions tester

### DIFF
--- a/packages/example/public/voiceover-captions.json
+++ b/packages/example/public/voiceover-captions.json
@@ -1,0 +1,1227 @@
+[
+	{
+		"confidence": null,
+		"startMs": 99,
+		"endMs": 199,
+		"text": "I",
+		"timestampMs": 149
+	},
+	{
+		"confidence": null,
+		"startMs": 199,
+		"endMs": 459,
+		"text": " vibe",
+		"timestampMs": 329
+	},
+	{
+		"confidence": null,
+		"startMs": 459,
+		"endMs": 799,
+		"text": " coded",
+		"timestampMs": 629
+	},
+	{
+		"confidence": null,
+		"startMs": 799,
+		"endMs": 1079,
+		"text": " my",
+		"timestampMs": 939
+	},
+	{
+		"confidence": null,
+		"startMs": 1079,
+		"endMs": 1279,
+		"text": " own",
+		"timestampMs": 1179
+	},
+	{
+		"confidence": null,
+		"startMs": 1279,
+		"endMs": 1620,
+		"text": " DJ",
+		"timestampMs": 1449.5
+	},
+	{
+		"confidence": null,
+		"startMs": 1620,
+		"endMs": 1839,
+		"text": " show",
+		"timestampMs": 1729.5
+	},
+	{
+		"confidence": null,
+		"startMs": 1839,
+		"endMs": 2039.0000000000002,
+		"text": " by",
+		"timestampMs": 1939
+	},
+	{
+		"confidence": null,
+		"startMs": 2039.0000000000002,
+		"endMs": 2539,
+		"text": " programming",
+		"timestampMs": 2289
+	},
+	{
+		"confidence": null,
+		"startMs": 2539,
+		"endMs": 2819,
+		"text": " lights",
+		"timestampMs": 2679
+	},
+	{
+		"confidence": null,
+		"startMs": 2819,
+		"endMs": 2960,
+		"text": " with",
+		"timestampMs": 2889.5
+	},
+	{
+		"confidence": null,
+		"startMs": 2960,
+		"endMs": 3279,
+		"text": " AI",
+		"timestampMs": 3119.5
+	},
+	{
+		"confidence": null,
+		"startMs": 3279,
+		"endMs": 3740,
+		"text": " agents",
+		"timestampMs": 3509.5
+	},
+	{
+		"confidence": null,
+		"startMs": 3740,
+		"endMs": 3919,
+		"text": " and",
+		"timestampMs": 3829.5
+	},
+	{
+		"confidence": null,
+		"startMs": 3919,
+		"endMs": 4279,
+		"text": " making",
+		"timestampMs": 4099
+	},
+	{
+		"confidence": null,
+		"startMs": 4279,
+		"endMs": 4699,
+		"text": " visuals",
+		"timestampMs": 4489
+	},
+	{
+		"confidence": null,
+		"startMs": 4699,
+		"endMs": 4839,
+		"text": " with",
+		"timestampMs": 4769
+	},
+	{
+		"confidence": null,
+		"startMs": 4839,
+		"endMs": 5440,
+		"text": " Remotion,",
+		"timestampMs": 5139.5
+	},
+	{
+		"confidence": null,
+		"startMs": 5440,
+		"endMs": 5960,
+		"text": " and",
+		"timestampMs": 5700
+	},
+	{
+		"confidence": null,
+		"startMs": 5960,
+		"endMs": 6039,
+		"text": " I",
+		"timestampMs": 5999.5
+	},
+	{
+		"confidence": null,
+		"startMs": 6039,
+		"endMs": 6159,
+		"text": " am",
+		"timestampMs": 6099
+	},
+	{
+		"confidence": null,
+		"startMs": 6159,
+		"endMs": 6440,
+		"text": " showing",
+		"timestampMs": 6299.5
+	},
+	{
+		"confidence": null,
+		"startMs": 6440,
+		"endMs": 6619,
+		"text": " you",
+		"timestampMs": 6529.5
+	},
+	{
+		"confidence": null,
+		"startMs": 6619,
+		"endMs": 6779,
+		"text": " how",
+		"timestampMs": 6699
+	},
+	{
+		"confidence": null,
+		"startMs": 6779,
+		"endMs": 6899,
+		"text": " you",
+		"timestampMs": 6839
+	},
+	{
+		"confidence": null,
+		"startMs": 6899,
+		"endMs": 7039,
+		"text": " can",
+		"timestampMs": 6969
+	},
+	{
+		"confidence": null,
+		"startMs": 7039,
+		"endMs": 7139,
+		"text": " do",
+		"timestampMs": 7089
+	},
+	{
+		"confidence": null,
+		"startMs": 7139,
+		"endMs": 7279,
+		"text": " it",
+		"timestampMs": 7209
+	},
+	{
+		"confidence": null,
+		"startMs": 7279,
+		"endMs": 7460,
+		"text": " as",
+		"timestampMs": 7369.5
+	},
+	{
+		"confidence": null,
+		"startMs": 7460,
+		"endMs": 7699,
+		"text": " well.",
+		"timestampMs": 7579.5
+	},
+	{
+		"confidence": null,
+		"startMs": 7699,
+		"endMs": 7919,
+		"text": " For",
+		"timestampMs": 7809
+	},
+	{
+		"confidence": null,
+		"startMs": 7919,
+		"endMs": 8099,
+		"text": " this",
+		"timestampMs": 8009
+	},
+	{
+		"confidence": null,
+		"startMs": 8099,
+		"endMs": 8380,
+		"text": " track,",
+		"timestampMs": 8239.5
+	},
+	{
+		"confidence": null,
+		"startMs": 8380,
+		"endMs": 8519,
+		"text": " I",
+		"timestampMs": 8449.5
+	},
+	{
+		"confidence": null,
+		"startMs": 8519,
+		"endMs": 8659,
+		"text": " took",
+		"timestampMs": 8589
+	},
+	{
+		"confidence": null,
+		"startMs": 8659,
+		"endMs": 8760,
+		"text": " the",
+		"timestampMs": 8709.5
+	},
+	{
+		"confidence": null,
+		"startMs": 8760,
+		"endMs": 9059,
+		"text": " music",
+		"timestampMs": 8909.5
+	},
+	{
+		"confidence": null,
+		"startMs": 9059,
+		"endMs": 9380,
+		"text": " video",
+		"timestampMs": 9219.5
+	},
+	{
+		"confidence": null,
+		"startMs": 9380,
+		"endMs": 9560,
+		"text": " and",
+		"timestampMs": 9470
+	},
+	{
+		"confidence": null,
+		"startMs": 9560,
+		"endMs": 10139,
+		"text": " inserted",
+		"timestampMs": 9849.5
+	},
+	{
+		"confidence": null,
+		"startMs": 10139,
+		"endMs": 10659,
+		"text": " animated",
+		"timestampMs": 10399
+	},
+	{
+		"confidence": null,
+		"startMs": 10659,
+		"endMs": 11199,
+		"text": " captions",
+		"timestampMs": 10929
+	},
+	{
+		"confidence": null,
+		"startMs": 11199,
+		"endMs": 11340,
+		"text": " in",
+		"timestampMs": 11269.5
+	},
+	{
+		"confidence": null,
+		"startMs": 11340,
+		"endMs": 11699,
+		"text": " between",
+		"timestampMs": 11519.5
+	},
+	{
+		"confidence": null,
+		"startMs": 11699,
+		"endMs": 11779,
+		"text": " the",
+		"timestampMs": 11739
+	},
+	{
+		"confidence": null,
+		"startMs": 11779,
+		"endMs": 12399,
+		"text": " foreground",
+		"timestampMs": 12089
+	},
+	{
+		"confidence": null,
+		"startMs": 12399,
+		"endMs": 12579,
+		"text": " and",
+		"timestampMs": 12489
+	},
+	{
+		"confidence": null,
+		"startMs": 12579,
+		"endMs": 12699,
+		"text": " the",
+		"timestampMs": 12639
+	},
+	{
+		"confidence": null,
+		"startMs": 12699,
+		"endMs": 13439,
+		"text": " background.",
+		"timestampMs": 13069
+	},
+	{
+		"confidence": null,
+		"startMs": 13439,
+		"endMs": 14019,
+		"text": " How",
+		"timestampMs": 13729
+	},
+	{
+		"confidence": null,
+		"startMs": 14019,
+		"endMs": 14179,
+		"text": " did",
+		"timestampMs": 14099
+	},
+	{
+		"confidence": null,
+		"startMs": 14179,
+		"endMs": 14300,
+		"text": " I",
+		"timestampMs": 14239.5
+	},
+	{
+		"confidence": null,
+		"startMs": 14300,
+		"endMs": 14460,
+		"text": " do",
+		"timestampMs": 14380
+	},
+	{
+		"confidence": null,
+		"startMs": 14460,
+		"endMs": 14819,
+		"text": " this?",
+		"timestampMs": 14639.5
+	},
+	{
+		"confidence": null,
+		"startMs": 14819,
+		"endMs": 15299,
+		"text": " I",
+		"timestampMs": 15059
+	},
+	{
+		"confidence": null,
+		"startMs": 15299,
+		"endMs": 15619,
+		"text": " found",
+		"timestampMs": 15459
+	},
+	{
+		"confidence": null,
+		"startMs": 15619,
+		"endMs": 15779,
+		"text": " this",
+		"timestampMs": 15699
+	},
+	{
+		"confidence": null,
+		"startMs": 15779,
+		"endMs": 16338.999999999998,
+		"text": " interesting",
+		"timestampMs": 16059
+	},
+	{
+		"confidence": null,
+		"startMs": 16338.999999999998,
+		"endMs": 16619,
+		"text": " text",
+		"timestampMs": 16479
+	},
+	{
+		"confidence": null,
+		"startMs": 16619,
+		"endMs": 16959,
+		"text": " behind",
+		"timestampMs": 16789
+	},
+	{
+		"confidence": null,
+		"startMs": 16959,
+		"endMs": 17260,
+		"text": " video",
+		"timestampMs": 17109.5
+	},
+	{
+		"confidence": null,
+		"startMs": 17260,
+		"endMs": 17559,
+		"text": " demo",
+		"timestampMs": 17409.5
+	},
+	{
+		"confidence": null,
+		"startMs": 17559,
+		"endMs": 17739,
+		"text": " from",
+		"timestampMs": 17649
+	},
+	{
+		"confidence": null,
+		"startMs": 17739,
+		"endMs": 18079,
+		"text": " Hugging",
+		"timestampMs": 17909
+	},
+	{
+		"confidence": null,
+		"startMs": 18079,
+		"endMs": 18440,
+		"text": " Face,",
+		"timestampMs": 18259.5
+	},
+	{
+		"confidence": null,
+		"startMs": 18440,
+		"endMs": 18680,
+		"text": " which",
+		"timestampMs": 18560
+	},
+	{
+		"confidence": null,
+		"startMs": 18680,
+		"endMs": 19059,
+		"text": " works",
+		"timestampMs": 18869.5
+	},
+	{
+		"confidence": null,
+		"startMs": 19059,
+		"endMs": 19579,
+		"text": " completely",
+		"timestampMs": 19319
+	},
+	{
+		"confidence": null,
+		"startMs": 19579,
+		"endMs": 19879,
+		"text": " client",
+		"timestampMs": 19729
+	},
+	{
+		"confidence": null,
+		"startMs": 19879,
+		"endMs": 20119,
+		"text": " side",
+		"timestampMs": 19999
+	},
+	{
+		"confidence": null,
+		"startMs": 20119,
+		"endMs": 20319,
+		"text": " using",
+		"timestampMs": 20219
+	},
+	{
+		"confidence": null,
+		"startMs": 20319,
+		"endMs": 21739,
+		"text": " Transformers.js",
+		"timestampMs": 21029
+	},
+	{
+		"confidence": null,
+		"startMs": 21739,
+		"endMs": 21899,
+		"text": " and",
+		"timestampMs": 21819
+	},
+	{
+		"confidence": null,
+		"startMs": 21899,
+		"endMs": 22020,
+		"text": " an",
+		"timestampMs": 21959.5
+	},
+	{
+		"confidence": null,
+		"startMs": 22020,
+		"endMs": 22319,
+		"text": " open",
+		"timestampMs": 22169.5
+	},
+	{
+		"confidence": null,
+		"startMs": 22319,
+		"endMs": 22600,
+		"text": " source",
+		"timestampMs": 22459.5
+	},
+	{
+		"confidence": null,
+		"startMs": 22600,
+		"endMs": 22979,
+		"text": " model.",
+		"timestampMs": 22789.5
+	},
+	{
+		"confidence": null,
+		"startMs": 22979,
+		"endMs": 23459,
+		"text": " However,",
+		"timestampMs": 23219
+	},
+	{
+		"confidence": null,
+		"startMs": 23459,
+		"endMs": 24119,
+		"text": " unfortunately,",
+		"timestampMs": 23789
+	},
+	{
+		"confidence": null,
+		"startMs": 24119,
+		"endMs": 24279,
+		"text": " the",
+		"timestampMs": 24199
+	},
+	{
+		"confidence": null,
+		"startMs": 24279,
+		"endMs": 24639,
+		"text": " features",
+		"timestampMs": 24459
+	},
+	{
+		"confidence": null,
+		"startMs": 24639,
+		"endMs": 24840,
+		"text": " are",
+		"timestampMs": 24739.5
+	},
+	{
+		"confidence": null,
+		"startMs": 24840,
+		"endMs": 25199,
+		"text": " very",
+		"timestampMs": 25019.5
+	},
+	{
+		"confidence": null,
+		"startMs": 25199,
+		"endMs": 25619,
+		"text": " limited,",
+		"timestampMs": 25409
+	},
+	{
+		"confidence": null,
+		"startMs": 25619,
+		"endMs": 25840,
+		"text": " and",
+		"timestampMs": 25729.5
+	},
+	{
+		"confidence": null,
+		"startMs": 25840,
+		"endMs": 25979,
+		"text": " we",
+		"timestampMs": 25909.5
+	},
+	{
+		"confidence": null,
+		"startMs": 25979,
+		"endMs": 26319,
+		"text": " cannot",
+		"timestampMs": 26149
+	},
+	{
+		"confidence": null,
+		"startMs": 26319,
+		"endMs": 26779,
+		"text": " insert",
+		"timestampMs": 26549
+	},
+	{
+		"confidence": null,
+		"startMs": 26779,
+		"endMs": 26939,
+		"text": " an",
+		"timestampMs": 26859
+	},
+	{
+		"confidence": null,
+		"startMs": 26939,
+		"endMs": 27459,
+		"text": " animated",
+		"timestampMs": 27199
+	},
+	{
+		"confidence": null,
+		"startMs": 27459,
+		"endMs": 27680,
+		"text": " video",
+		"timestampMs": 27569.5
+	},
+	{
+		"confidence": null,
+		"startMs": 27680,
+		"endMs": 28119,
+		"text": " layer.",
+		"timestampMs": 27899.5
+	},
+	{
+		"confidence": null,
+		"startMs": 28119,
+		"endMs": 28699,
+		"text": " So",
+		"timestampMs": 28409
+	},
+	{
+		"confidence": null,
+		"startMs": 28699,
+		"endMs": 28819,
+		"text": " I",
+		"timestampMs": 28759
+	},
+	{
+		"confidence": null,
+		"startMs": 28819,
+		"endMs": 29319,
+		"text": " forked",
+		"timestampMs": 29069
+	},
+	{
+		"confidence": null,
+		"startMs": 29319,
+		"endMs": 29459,
+		"text": " the",
+		"timestampMs": 29389
+	},
+	{
+		"confidence": null,
+		"startMs": 29459,
+		"endMs": 29959,
+		"text": " project",
+		"timestampMs": 29709
+	},
+	{
+		"confidence": null,
+		"startMs": 29959,
+		"endMs": 30119,
+		"text": " and",
+		"timestampMs": 30039
+	},
+	{
+		"confidence": null,
+		"startMs": 30119,
+		"endMs": 30379,
+		"text": " spun",
+		"timestampMs": 30249
+	},
+	{
+		"confidence": null,
+		"startMs": 30379,
+		"endMs": 30559,
+		"text": " up",
+		"timestampMs": 30469
+	},
+	{
+		"confidence": null,
+		"startMs": 30559,
+		"endMs": 30739,
+		"text": " my",
+		"timestampMs": 30649
+	},
+	{
+		"confidence": null,
+		"startMs": 30739,
+		"endMs": 30899,
+		"text": " own",
+		"timestampMs": 30819
+	},
+	{
+		"confidence": null,
+		"startMs": 30899,
+		"endMs": 31299,
+		"text": " version",
+		"timestampMs": 31099
+	},
+	{
+		"confidence": null,
+		"startMs": 31299,
+		"endMs": 31559,
+		"text": " that",
+		"timestampMs": 31429
+	},
+	{
+		"confidence": null,
+		"startMs": 31559,
+		"endMs": 31939,
+		"text": " instead",
+		"timestampMs": 31749
+	},
+	{
+		"confidence": null,
+		"startMs": 31939,
+		"endMs": 32219,
+		"text": " allows",
+		"timestampMs": 32079
+	},
+	{
+		"confidence": null,
+		"startMs": 32219,
+		"endMs": 32340.000000000004,
+		"text": " me",
+		"timestampMs": 32279.5
+	},
+	{
+		"confidence": null,
+		"startMs": 32340.000000000004,
+		"endMs": 32459.000000000004,
+		"text": " to",
+		"timestampMs": 32399.500000000004
+	},
+	{
+		"confidence": null,
+		"startMs": 32459.000000000004,
+		"endMs": 32880,
+		"text": " export",
+		"timestampMs": 32669.5
+	},
+	{
+		"confidence": null,
+		"startMs": 32880,
+		"endMs": 33020,
+		"text": " the",
+		"timestampMs": 32950
+	},
+	{
+		"confidence": null,
+		"startMs": 33020,
+		"endMs": 33520,
+		"text": " foreground",
+		"timestampMs": 33270
+	},
+	{
+		"confidence": null,
+		"startMs": 33520,
+		"endMs": 33680,
+		"text": " and",
+		"timestampMs": 33600
+	},
+	{
+		"confidence": null,
+		"startMs": 33680,
+		"endMs": 34719,
+		"text": " background",
+		"timestampMs": 34199.5
+	},
+	{
+		"confidence": null,
+		"startMs": 34719,
+		"endMs": 34899,
+		"text": " as",
+		"timestampMs": 34809
+	},
+	{
+		"confidence": null,
+		"startMs": 34899,
+		"endMs": 35680,
+		"text": " transparent",
+		"timestampMs": 35289.5
+	},
+	{
+		"confidence": null,
+		"startMs": 35680,
+		"endMs": 36479,
+		"text": " WebM",
+		"timestampMs": 36079.5
+	},
+	{
+		"confidence": null,
+		"startMs": 36479,
+		"endMs": 36759,
+		"text": " video",
+		"timestampMs": 36619
+	},
+	{
+		"confidence": null,
+		"startMs": 36759,
+		"endMs": 37119,
+		"text": " layers",
+		"timestampMs": 36939
+	},
+	{
+		"confidence": null,
+		"startMs": 37119,
+		"endMs": 37380,
+		"text": " using",
+		"timestampMs": 37249.5
+	},
+	{
+		"confidence": null,
+		"startMs": 37380,
+		"endMs": 37680,
+		"text": " Media",
+		"timestampMs": 37530
+	},
+	{
+		"confidence": null,
+		"startMs": 37680,
+		"endMs": 38219,
+		"text": " Bunny.",
+		"timestampMs": 37949.5
+	},
+	{
+		"confidence": null,
+		"startMs": 38219,
+		"endMs": 38439,
+		"text": " Now",
+		"timestampMs": 38329
+	},
+	{
+		"confidence": null,
+		"startMs": 38439,
+		"endMs": 38540,
+		"text": " I",
+		"timestampMs": 38489.5
+	},
+	{
+		"confidence": null,
+		"startMs": 38540,
+		"endMs": 38680,
+		"text": " can",
+		"timestampMs": 38610
+	},
+	{
+		"confidence": null,
+		"startMs": 38680,
+		"endMs": 39000,
+		"text": " drag",
+		"timestampMs": 38840
+	},
+	{
+		"confidence": null,
+		"startMs": 39000,
+		"endMs": 39239,
+		"text": " both",
+		"timestampMs": 39119.5
+	},
+	{
+		"confidence": null,
+		"startMs": 39239,
+		"endMs": 39579,
+		"text": " layers",
+		"timestampMs": 39409
+	},
+	{
+		"confidence": null,
+		"startMs": 39579,
+		"endMs": 39819,
+		"text": " into",
+		"timestampMs": 39699
+	},
+	{
+		"confidence": null,
+		"startMs": 39819,
+		"endMs": 40340,
+		"text": " Remotion",
+		"timestampMs": 40079.5
+	},
+	{
+		"confidence": null,
+		"startMs": 40340,
+		"endMs": 40520,
+		"text": " and",
+		"timestampMs": 40430
+	},
+	{
+		"confidence": null,
+		"startMs": 40520,
+		"endMs": 40639,
+		"text": " put",
+		"timestampMs": 40579.5
+	},
+	{
+		"confidence": null,
+		"startMs": 40639,
+		"endMs": 40759,
+		"text": " an",
+		"timestampMs": 40699
+	},
+	{
+		"confidence": null,
+		"startMs": 40759,
+		"endMs": 41319,
+		"text": " HTML",
+		"timestampMs": 41039
+	},
+	{
+		"confidence": null,
+		"startMs": 41319,
+		"endMs": 41639,
+		"text": " layer",
+		"timestampMs": 41479
+	},
+	{
+		"confidence": null,
+		"startMs": 41639,
+		"endMs": 41759,
+		"text": " in",
+		"timestampMs": 41699
+	},
+	{
+		"confidence": null,
+		"startMs": 41759,
+		"endMs": 42479,
+		"text": " between",
+		"timestampMs": 42119
+	},
+	{
+		"confidence": null,
+		"startMs": 42479,
+		"endMs": 42739,
+		"text": " using",
+		"timestampMs": 42609
+	},
+	{
+		"confidence": null,
+		"startMs": 42739,
+		"endMs": 42860,
+		"text": " an",
+		"timestampMs": 42799.5
+	},
+	{
+		"confidence": null,
+		"startMs": 42860,
+		"endMs": 43379,
+		"text": " agent",
+		"timestampMs": 43119.5
+	},
+	{
+		"confidence": null,
+		"startMs": 43379,
+		"endMs": 43659,
+		"text": " or",
+		"timestampMs": 43519
+	},
+	{
+		"confidence": null,
+		"startMs": 43659,
+		"endMs": 43840,
+		"text": " by",
+		"timestampMs": 43749.5
+	},
+	{
+		"confidence": null,
+		"startMs": 43840,
+		"endMs": 44079,
+		"text": " going",
+		"timestampMs": 43959.5
+	},
+	{
+		"confidence": null,
+		"startMs": 44079,
+		"endMs": 44299,
+		"text": " into",
+		"timestampMs": 44189
+	},
+	{
+		"confidence": null,
+		"startMs": 44299,
+		"endMs": 44419,
+		"text": " the",
+		"timestampMs": 44359
+	},
+	{
+		"confidence": null,
+		"startMs": 44419,
+		"endMs": 45219,
+		"text": " code.",
+		"timestampMs": 44819
+	},
+	{
+		"confidence": null,
+		"startMs": 45219,
+		"endMs": 45319,
+		"text": " The",
+		"timestampMs": 45269
+	},
+	{
+		"confidence": null,
+		"startMs": 45319,
+		"endMs": 45719,
+		"text": " result,",
+		"timestampMs": 45519
+	},
+	{
+		"confidence": null,
+		"startMs": 45719,
+		"endMs": 45819,
+		"text": " in",
+		"timestampMs": 45769
+	},
+	{
+		"confidence": null,
+		"startMs": 45819,
+		"endMs": 45959,
+		"text": " my",
+		"timestampMs": 45889
+	},
+	{
+		"confidence": null,
+		"startMs": 45959,
+		"endMs": 46459,
+		"text": " opinion,",
+		"timestampMs": 46209
+	},
+	{
+		"confidence": null,
+		"startMs": 46459,
+		"endMs": 46979,
+		"text": " is",
+		"timestampMs": 46719
+	},
+	{
+		"confidence": null,
+		"startMs": 46979,
+		"endMs": 47299,
+		"text": " super",
+		"timestampMs": 47139
+	},
+	{
+		"confidence": null,
+		"startMs": 47299,
+		"endMs": 47739,
+		"text": " fresh.",
+		"timestampMs": 47519
+	},
+	{
+		"confidence": null,
+		"startMs": 47739,
+		"endMs": 48259,
+		"text": " If",
+		"timestampMs": 47999
+	},
+	{
+		"confidence": null,
+		"startMs": 48259,
+		"endMs": 48360,
+		"text": " you",
+		"timestampMs": 48309.5
+	},
+	{
+		"confidence": null,
+		"startMs": 48360,
+		"endMs": 48619,
+		"text": " also",
+		"timestampMs": 48489.5
+	},
+	{
+		"confidence": null,
+		"startMs": 48619,
+		"endMs": 48799,
+		"text": " want",
+		"timestampMs": 48709
+	},
+	{
+		"confidence": null,
+		"startMs": 48799,
+		"endMs": 48919,
+		"text": " to",
+		"timestampMs": 48859
+	},
+	{
+		"confidence": null,
+		"startMs": 48919,
+		"endMs": 49000,
+		"text": " see",
+		"timestampMs": 48959.5
+	},
+	{
+		"confidence": null,
+		"startMs": 49000,
+		"endMs": 49099,
+		"text": " a",
+		"timestampMs": 49049.5
+	},
+	{
+		"confidence": null,
+		"startMs": 49099,
+		"endMs": 49599,
+		"text": " breakdown",
+		"timestampMs": 49349
+	},
+	{
+		"confidence": null,
+		"startMs": 49599,
+		"endMs": 49719,
+		"text": " of",
+		"timestampMs": 49659
+	},
+	{
+		"confidence": null,
+		"startMs": 49719,
+		"endMs": 49939,
+		"text": " how",
+		"timestampMs": 49829
+	},
+	{
+		"confidence": null,
+		"startMs": 49939,
+		"endMs": 50180,
+		"text": " I",
+		"timestampMs": 50059.5
+	},
+	{
+		"confidence": null,
+		"startMs": 50180,
+		"endMs": 50779,
+		"text": " animated",
+		"timestampMs": 50479.5
+	},
+	{
+		"confidence": null,
+		"startMs": 50779,
+		"endMs": 50939,
+		"text": " the",
+		"timestampMs": 50859
+	},
+	{
+		"confidence": null,
+		"startMs": 50939,
+		"endMs": 51340,
+		"text": " lyrics",
+		"timestampMs": 51139.5
+	},
+	{
+		"confidence": null,
+		"startMs": 51340,
+		"endMs": 51579,
+		"text": " using",
+		"timestampMs": 51459.5
+	},
+	{
+		"confidence": null,
+		"startMs": 51579,
+		"endMs": 51860,
+		"text": " vibe",
+		"timestampMs": 51719.5
+	},
+	{
+		"confidence": null,
+		"startMs": 51860,
+		"endMs": 52279,
+		"text": " coding,",
+		"timestampMs": 52069.5
+	},
+	{
+		"confidence": null,
+		"startMs": 52279,
+		"endMs": 52919,
+		"text": " follow",
+		"timestampMs": 52599
+	},
+	{
+		"confidence": null,
+		"startMs": 52919,
+		"endMs": 53159,
+		"text": " me",
+		"timestampMs": 53039
+	},
+	{
+		"confidence": null,
+		"startMs": 53159,
+		"endMs": 53279,
+		"text": " for",
+		"timestampMs": 53219
+	},
+	{
+		"confidence": null,
+		"startMs": 53279,
+		"endMs": 53659,
+		"text": " future",
+		"timestampMs": 53469
+	},
+	{
+		"confidence": null,
+		"startMs": 53659,
+		"endMs": 54139,
+		"text": " videos",
+		"timestampMs": 53899
+	}
+]

--- a/packages/example/src/CaptionsTester/AnimatedCaptions.tsx
+++ b/packages/example/src/CaptionsTester/AnimatedCaptions.tsx
@@ -1,0 +1,159 @@
+import type {Caption, TikTokPage} from '@remotion/captions';
+import {createTikTokStyleCaptions} from '@remotion/captions';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {
+	AbsoluteFill,
+	interpolate,
+	Sequence,
+	spring,
+	staticFile,
+	useCurrentFrame,
+	useDelayRender,
+	useVideoConfig,
+} from 'remotion';
+
+export const CAPTIONS_FILE = 'voiceover-captions.json';
+export const CAPTIONS_DURATION_IN_FRAMES = 1628;
+export const CAPTIONS_HEIGHT = 360;
+
+const SWITCH_CAPTIONS_EVERY_MS = 1100;
+const HIGHLIGHT_COLOR = '#6cf6ff';
+
+const CaptionPage: React.FC<{page: TikTokPage}> = ({page}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+	const absoluteTimeMs = page.startMs + (frame / fps) * 1000;
+	const enter = spring({
+		frame,
+		fps,
+		config: {damping: 14, mass: 0.55, stiffness: 180},
+	});
+	const exit = interpolate(
+		frame,
+		[
+			Math.max(0, (page.durationMs / 1000) * fps - 5),
+			(page.durationMs / 1000) * fps,
+		],
+		[1, 0],
+		{extrapolateLeft: 'clamp', extrapolateRight: 'clamp'},
+	);
+
+	return (
+		<AbsoluteFill
+			style={{
+				alignItems: 'center',
+				justifyContent: 'center',
+				padding: '42px 64px 48px',
+				pointerEvents: 'none',
+			}}
+		>
+			<div
+				style={{
+					opacity: exit,
+					transform: `translateY(${interpolate(enter, [0, 1], [50, 0])}px) scale(${interpolate(enter, [0, 1], [0.82, 1])})`,
+					transformOrigin: 'center bottom',
+					textAlign: 'center',
+					fontFamily: 'Arial Black, Arial, sans-serif',
+					fontSize: 76,
+					fontWeight: 900,
+					letterSpacing: -3.5,
+					lineHeight: 1.05,
+					textWrap: 'balance',
+					whiteSpace: 'pre-wrap',
+					filter:
+						'drop-shadow(0 8px 0 rgba(0, 0, 0, 0.82)) drop-shadow(0 16px 24px rgba(0, 0, 0, 0.55))',
+				}}
+			>
+				{page.tokens.map((token, tokenIndex) => {
+					const isActive =
+						token.fromMs <= absoluteTimeMs && token.toMs > absoluteTimeMs;
+					return (
+						<span
+							key={`${token.fromMs}-${tokenIndex}`}
+							style={{
+								color: isActive ? HIGHLIGHT_COLOR : '#ffffff',
+								display: 'inline-block',
+								marginLeft: tokenIndex === 0 ? 0 : 26,
+								WebkitTextStroke: isActive
+									? '3px rgba(0, 20, 28, 0.95)'
+									: '2px rgba(0, 0, 0, 0.85)',
+							}}
+						>
+							{token.text.trimStart()}
+						</span>
+					);
+				})}
+			</div>
+		</AbsoluteFill>
+	);
+};
+
+export const AnimatedCaptions: React.FC = () => {
+	const [captions, setCaptions] = useState<Caption[] | null>(null);
+	const {delayRender, continueRender, cancelRender} = useDelayRender();
+	const [handle] = useState(() => delayRender('Loading ElevenLabs captions'));
+	const {fps} = useVideoConfig();
+
+	const loadCaptions = useCallback(async () => {
+		try {
+			const response = await fetch(staticFile(CAPTIONS_FILE));
+			if (!response.ok) {
+				throw new Error(`Could not load captions (${response.status})`);
+			}
+
+			setCaptions((await response.json()) as Caption[]);
+			continueRender(handle);
+		} catch (error) {
+			cancelRender(error);
+		}
+	}, [cancelRender, continueRender, handle]);
+
+	useEffect(() => {
+		loadCaptions();
+	}, [loadCaptions]);
+
+	const pages = useMemo(() => {
+		if (!captions) {
+			return [];
+		}
+
+		return createTikTokStyleCaptions({
+			captions,
+			combineTokensWithinMilliseconds: SWITCH_CAPTIONS_EVERY_MS,
+		}).pages;
+	}, [captions]);
+
+	if (!captions) {
+		return null;
+	}
+
+	return (
+		<AbsoluteFill>
+			{pages.map((page, index) => {
+				const nextPage = pages[index + 1];
+				const startFrame = Math.round((page.startMs / 1000) * fps);
+				const naturalEndFrame = Math.ceil(
+					((page.startMs + page.durationMs) / 1000) * fps,
+				);
+				const endFrame = nextPage
+					? Math.min(
+							Math.round((nextPage.startMs / 1000) * fps),
+							naturalEndFrame,
+						)
+					: naturalEndFrame;
+				const durationInFrames = Math.max(1, endFrame - startFrame);
+
+				return (
+					<Sequence
+						key={`${page.startMs}-${index}`}
+						from={startFrame}
+						durationInFrames={durationInFrames}
+						premountFor={fps}
+					>
+						<CaptionPage page={page} />
+					</Sequence>
+				);
+			})}
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -16,6 +16,11 @@ import {NativeBufferStateForImage} from './BufferState/Image';
 import {NativeBufferState} from './BufferState/Simple';
 import {NativeBufferStateForVideo} from './BufferState/Video';
 import {CancelRender} from './CancelRender';
+import {
+	AnimatedCaptions,
+	CAPTIONS_DURATION_IN_FRAMES,
+	CAPTIONS_HEIGHT,
+} from './CaptionsTester/AnimatedCaptions';
 import {ClassSerialization} from './ClassSerialization';
 import {ColorInterpolation} from './ColorInterpolation';
 import {ComplexSounds} from './ComplexSounds';
@@ -406,6 +411,14 @@ export const Index: React.FC = () => {
 
 	return (
 		<>
+			<Composition
+				id="captions-tester"
+				component={AnimatedCaptions}
+				durationInFrames={CAPTIONS_DURATION_IN_FRAMES}
+				fps={30}
+				width={1080}
+				height={CAPTIONS_HEIGHT}
+			/>
 			<Folder name="copilot-tests">
 				<Composition
 					id="keyframed-props-test"


### PR DESCRIPTION
## Summary

- add the animated captions component from `jonnyBurger/disco-light-show`
- include the corresponding caption timing JSON
- register a dedicated `captions-tester` composition in the example project

## Testing

- `bun run build`
- `bun run stylecheck`
- enumerated compositions and rendered a still from `captions-tester`
