### PR TITLE
`@remotion/studio-server`: Support keyframing `durationInFrames - 1`

### DIFF
--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -44,6 +44,13 @@ export type VideoConfigNumericExpression =
 			multiplicand: number;
 			factorPosition: 'left' | 'right';
 			value: number;
+	  }
+	| {
+			type: 'video-config-subtraction';
+			identifier: string;
+			minuend: number;
+			subtrahend: number;
+			value: number;
 	  };
 
 export type CanUpdateSequencePropStatusLinearEasing = {

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -284,6 +284,7 @@ import {
 	InteractiveHtmlElements,
 	InteractiveSvgElements,
 } from './VisualModeTests/InteractiveComponents';
+import {Issue9170} from './VisualModeTests/Issue9170';
 import {VideoConfigExpressions} from './VisualModeTests/VideoConfigExpressions';
 import {VoiceVisualization} from './voice-visualization';
 import {WhisperWeb} from './WhisperWeb';
@@ -2759,6 +2760,14 @@ export const Index: React.FC = () => {
 					height={800}
 					fps={30}
 					durationInFrames={300}
+				/>
+				<Composition
+					id="issue-9170-duration-subtraction"
+					component={Issue9170}
+					width={1200}
+					height={800}
+					fps={30}
+					durationInFrames={120}
 				/>
 			</Folder>
 			<ChangingTrimBeforeValue />

--- a/packages/example/src/VisualModeTests/Issue9170.tsx
+++ b/packages/example/src/VisualModeTests/Issue9170.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {
+	AbsoluteFill,
+	interpolate,
+	Sequence,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+export const Issue9170: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {durationInFrames} = useVideoConfig();
+
+	return (
+		<AbsoluteFill style={{backgroundColor: '#0b1020'}}>
+			<Sequence
+				name="Opacity ending at durationInFrames - 1"
+				durationInFrames={durationInFrames}
+				style={{
+					opacity: interpolate(frame, [0, durationInFrames - 1], [0, 1]),
+				}}
+			>
+				<AbsoluteFill
+					style={{
+						alignItems: 'center',
+						background: 'linear-gradient(135deg, #2563eb, #7c3aed)',
+						color: 'white',
+						fontFamily: 'sans-serif',
+						justifyContent: 'center',
+					}}
+				>
+					<div style={{fontSize: 64, fontWeight: 700}}>Issue #9170</div>
+					<div style={{fontFamily: 'monospace', fontSize: 34, marginTop: 24}}>
+						[0, durationInFrames - 1]
+					</div>
+					<div style={{fontSize: 28, marginTop: 18}}>
+						Frame {frame} of {durationInFrames - 1}
+					</div>
+				</AbsoluteFill>
+			</Sequence>
+		</AbsoluteFill>
+	);
+};

--- a/packages/studio-server/src/helpers/video-config-numeric-expression.ts
+++ b/packages/studio-server/src/helpers/video-config-numeric-expression.ts
@@ -78,12 +78,40 @@ export const parseVideoConfigNumericExpression = ({
 		return {type: 'video-config-value', ...videoConfigValue};
 	}
 
-	if (node.type !== 'BinaryExpression' || node.operator !== '*') {
+	if (node.type !== 'BinaryExpression') {
 		return null;
 	}
 
 	const left = node.left as Expression;
 	const right = node.right as Expression;
+	if (node.operator === '-') {
+		const minuend = getVideoConfigValue({
+			node: left,
+			videoConfigValues,
+		});
+		const subtrahend = getNumericLiteral(right);
+		if (minuend === null || subtrahend === null) {
+			return null;
+		}
+
+		const resolvedValue = minuend.value - subtrahend;
+		if (!Number.isFinite(resolvedValue)) {
+			return null;
+		}
+
+		return {
+			type: 'video-config-subtraction',
+			identifier: minuend.identifier,
+			minuend: minuend.value,
+			subtrahend,
+			value: resolvedValue,
+		};
+	}
+
+	if (node.operator !== '*') {
+		return null;
+	}
+
 	const leftNumber = getNumericLiteral(left);
 	const rightNumber = getNumericLiteral(right);
 	const leftVideoConfig = getVideoConfigValue({
@@ -146,6 +174,19 @@ export const updateVideoConfigNumericExpression = ({
 		return value === expression.value
 			? b.identifier(expression.identifier)
 			: numericExpression(value);
+	}
+
+	if (expression.type === 'video-config-subtraction') {
+		const subtrahend = expression.minuend - value;
+		if (!Number.isFinite(subtrahend)) {
+			return numericExpression(value);
+		}
+
+		return b.binaryExpression(
+			'-',
+			b.identifier(expression.identifier),
+			numericExpression(subtrahend),
+		);
 	}
 
 	if (expression.type !== 'video-config-multiplication' || value === 0) {

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -139,6 +139,60 @@ export const Example: React.FC = () => {
 	});
 });
 
+test('updateSequenceKeyframes updates a durationInFrames subtraction when moving a keyframe', async () => {
+	const input = `import React from 'react';
+import {Sequence, interpolate, useCurrentFrame, useVideoConfig} from 'remotion';
+
+export const Example: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {durationInFrames} = useVideoConfig();
+	return (
+		<Sequence style={{opacity: interpolate(frame, [0, durationInFrames - 1], [0.35, 1])}} />
+	);
+};
+`;
+	const {output, updatedNodePath} = await updateSequenceKeyframes({
+		input,
+		nodePath: lineColumnToNodePath(input, 8),
+		updates: [
+			{
+				key: 'style.opacity',
+				operation: {
+					type: 'move',
+					moves: [{fromFrame: 119, toFrame: 118}],
+				},
+			},
+		],
+		videoConfigValues,
+	});
+
+	expect(output).toContain('[0, durationInFrames - 2]');
+	const status = computeSequencePropsStatusFromContent({
+		fileContents: output,
+		nodePath: updatedNodePath,
+		componentIdentity: null,
+		keys: ['style.opacity'],
+		effects: [],
+		videoConfigValues,
+	});
+	expect(status.props['style.opacity']).toMatchObject({
+		status: 'keyframed',
+		keyframes: [
+			{frame: 0, value: 0.35},
+			{
+				frame: 118,
+				value: 1,
+				frameExpression: {
+					type: 'video-config-subtraction',
+					identifier: 'durationInFrames',
+					minuend: 120,
+					subtrahend: 2,
+				},
+			},
+		],
+	});
+});
+
 const colorInput = `import React from 'react';
 import {Solid, interpolateColors, useCurrentFrame} from 'remotion';
 


### PR DESCRIPTION
## Summary

- recognize video config subtraction expressions such as `durationInFrames - 1` in Visual Mode keyframes
- preserve and update the subtraction expression when moving a keyframe
- add regression coverage and an example Studio composition for manual testing

## Testing

- `bun run build`
- `bun run stylecheck`

Closes #9170
