### PR TITLE
Skills: Replace Easing.inOut with Easing.bezier

### DIFF
--- a/packages/skills/skills/remotion-markup/mapbox.md
+++ b/packages/skills/skills/remotion-markup/mapbox.md
@@ -205,7 +205,7 @@ const getCameraOptions = (progress: number) => {
 		zoom: interpolate(progress, [0, 0.5, 1], [7, 2.4, 8], {
 			extrapolateLeft: 'clamp',
 			extrapolateRight: 'clamp',
-			easing: Easing.inOut(Easing.cubic),
+			easing: Easing.bezier(0.645, 0.045, 0.355, 1),
 		}),
 		bearing: interpolate(progress, [0, 1], [-20, 35], {
 			extrapolateLeft: 'clamp',
@@ -214,7 +214,7 @@ const getCameraOptions = (progress: number) => {
 		pitch: interpolate(progress, [0, 0.25, 0.75, 1], [25, 55, 55, 30], {
 			extrapolateLeft: 'clamp',
 			extrapolateRight: 'clamp',
-			easing: Easing.inOut(Easing.cubic),
+			easing: Easing.bezier(0.645, 0.045, 0.355, 1),
 		}),
 	};
 };
@@ -322,7 +322,7 @@ export const MyComposition = () => {
 		const travelProgress = interpolate(timelineProgress, [0.2, 0.82], [0, 1], {
 			extrapolateLeft: 'clamp',
 			extrapolateRight: 'clamp',
-			easing: Easing.inOut(Easing.cubic),
+			easing: Easing.bezier(0.645, 0.045, 0.355, 1),
 		});
 		const trace = map.getSource('trace') as GeoJSONSource | undefined;
 

--- a/packages/skills/skills/remotion-markup/maplibre.md
+++ b/packages/skills/skills/remotion-markup/maplibre.md
@@ -296,7 +296,7 @@ export const MyComposition = () => {
 		const travelProgress = interpolate(timelineProgress, [0.2, 0.82], [0, 1], {
 			extrapolateLeft: 'clamp',
 			extrapolateRight: 'clamp',
-			easing: Easing.inOut(Easing.cubic),
+			easing: Easing.bezier(0.645, 0.045, 0.355, 1),
 		});
 		const cameraAltitudeMeters = interpolate(
 			timelineProgress,
@@ -305,7 +305,7 @@ export const MyComposition = () => {
 			{
 				extrapolateLeft: 'clamp',
 				extrapolateRight: 'clamp',
-				easing: Easing.inOut(Easing.cubic),
+				easing: Easing.bezier(0.645, 0.045, 0.355, 1),
 			},
 		);
 		const cameraLatitudeOffset = interpolate(
@@ -315,7 +315,7 @@ export const MyComposition = () => {
 			{
 				extrapolateLeft: 'clamp',
 				extrapolateRight: 'clamp',
-				easing: Easing.inOut(Easing.cubic),
+				easing: Easing.bezier(0.645, 0.045, 0.355, 1),
 			},
 		);
 		const trace = map.getSource('trace') as GeoJSONSource | undefined;

--- a/packages/skills/skills/remotion-markup/timing.md
+++ b/packages/skills/skills/remotion-markup/timing.md
@@ -94,38 +94,25 @@ const pop = interpolate(frame, [0, 30], [0, 1], {
 });
 ```
 
-## Preset easings (`Easing.in` / `Easing.out` / named curves)
+## Studio-editable easing curves
 
-Easing can be added to the `interpolate` function without a custom cubic:
+Use an explicit `Easing.bezier()` curve instead of composed presets such as `Easing.inOut(Easing.cubic)`. Explicit Bézier control points remain editable in Remotion Studio.
 
 ```ts
 import { interpolate, Easing } from "remotion";
 
 const value1 = interpolate(frame, [0, 100], [0, 1], {
-  easing: Easing.inOut(Easing.cubic),
+  easing: Easing.bezier(0.645, 0.045, 0.355, 1),
   extrapolateLeft: "clamp",
   extrapolateRight: "clamp",
 });
 ```
 
-The default easing is `Easing.linear`.  
-Convexities:
-
-- `Easing.in` — starting slow and accelerating
-- `Easing.out` — starting fast and slowing down
-- `Easing.inOut`
-
-Named curves (from most linear to most curved):
-
-- `Easing.quad`
-- `Easing.cubic` (good default when you do not need a custom cubic)
-- `Easing.sin`
-- `Easing.exp`
-- `Easing.circle`
+The default easing is `Easing.linear`.
 
 ### Easing direction for enter/exit animations
 
-Use `Easing.out` for enter animations (starts fast, decelerates into place) and `Easing.in` for exit animations (starts slow, accelerates away). This feels natural because elements arrive with momentum and leave with gravity. When you need a specific curve from design, prefer a single `Easing.bezier(...)` instead of stacking presets.
+Use an ease-out Bézier curve for enter animations (starts fast, decelerates into place) and an ease-in Bézier curve for exit animations (starts slow, accelerates away). This feels natural because elements arrive with momentum and leave with gravity.
 
 ## Composing interpolations
 
@@ -146,7 +133,11 @@ const slideOut = interpolate(
   frame,
   [slideOutStart, slideOutStart + slideOutDuration],
   [0, 1],
-  { easing: Easing.in(Easing.cubic), extrapolateLeft: "clamp", extrapolateRight: "clamp" },
+  {
+    easing: Easing.bezier(0.333, 0, 0.667, 0),
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  },
 );
 const progress = slideIn - slideOut;
 


### PR DESCRIPTION
## Summary

- replace composed easing presets in skill examples with explicit Bézier curves
- explain that explicit Bézier control points remain editable in Remotion Studio
- update the Mapbox and MapLibre examples to follow the same guidance

## Testing

- `bun run build`
- `bun run stylecheck`

Closes #9282
