### PR TITLE
Skills: Add `/remotion-upgrade` skill

### DIFF
--- a/.agents/skills/remotion-upgrade
+++ b/.agents/skills/remotion-upgrade
@@ -1,0 +1,1 @@
+../../packages/skills/skills/remotion-upgrade

--- a/packages/docs/docs/ai/skills.mdx
+++ b/packages/docs/docs/ai/skills.mdx
@@ -72,6 +72,12 @@ Use this to look up current API references, component props, and package guides 
 
 <SuggestedPrompt prompt="/remotion-docs How to set up Remotion Lambda?" />
 
+### `/remotion-upgrade`
+
+Upgrade Remotion, related packages, compatible Mediabunny packages, and installed Remotion Agent Skills.
+
+<SuggestedPrompt prompt="/remotion-upgrade" />
+
 ### `/mediabunny`
 
 Guidance for browser-based multimedia handling with Mediabunny.

--- a/packages/skills/skills/remotion-best-practices/SKILL.md
+++ b/packages/skills/skills/remotion-best-practices/SKILL.md
@@ -9,6 +9,10 @@ metadata:
 
 If no Remotion project currently exists, load [Create a new Remotion project](remotion-create/SKILL.md)
 
+## Upgrading
+
+To upgrade Remotion, related packages, compatible Mediabunny packages, and installed Remotion Agent Skills, load [Remotion Upgrade](remotion-upgrade/SKILL.md).
+
 ## React Markup Best Practices
 
 If you are writing Remotion React Markup, load [Remotion Markup Best Practices](remotion-markup/SKILL.md)

--- a/packages/skills/skills/remotion-best-practices/SKILL.md
+++ b/packages/skills/skills/remotion-best-practices/SKILL.md
@@ -9,10 +9,6 @@ metadata:
 
 If no Remotion project currently exists, load [Create a new Remotion project](remotion-create/SKILL.md)
 
-## Upgrading
-
-To upgrade Remotion, related packages, compatible Mediabunny packages, and installed Remotion Agent Skills, load [Remotion Upgrade](remotion-upgrade/SKILL.md).
-
 ## React Markup Best Practices
 
 If you are writing Remotion React Markup, load [Remotion Markup Best Practices](remotion-markup/SKILL.md)
@@ -40,3 +36,7 @@ Use the [Remotion SaaS skill](remotion-saas/SKILL.md) for knowledge about Remoti
 ## Looking up Remotion APIs and documentation
 
 To find and read current Remotion documentation, load [Remotion Docs](remotion-docs/SKILL.md).
+
+## Upgrading
+
+To upgrade Remotion, related packages, compatible Mediabunny packages, and installed Remotion Agent Skills, load [Remotion Upgrade](remotion-upgrade/SKILL.md).

--- a/packages/skills/skills/remotion-best-practices/remotion-upgrade
+++ b/packages/skills/skills/remotion-best-practices/remotion-upgrade
@@ -1,0 +1,1 @@
+../remotion-upgrade

--- a/packages/skills/skills/remotion-upgrade/SKILL.md
+++ b/packages/skills/skills/remotion-upgrade/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: remotion-upgrade
+description: Upgrade Remotion, its related packages, compatible Mediabunny packages, and installed Remotion Agent Skills. Use when asked to upgrade or update a Remotion project.
+---
+
+# Upgrade Remotion
+
+1. Inspect the project manifests and lockfile to identify the package manager and workspaces. Preserve unrelated changes.
+2. Determine whether `@remotion/cli` is locally available. If it is, run:
+
+   ```bash
+   npx remotion upgrade
+   ```
+
+   Skip the manual package upgrade below.
+
+3. If `@remotion/cli` is not available, upgrade manually:
+   - Get the latest stable Remotion version with `npm view remotion version`.
+   - Find every installed `remotion` and `@remotion/*` dependency across the project and upgrade them all to that exact version. Preserve their dependency sections and the project's workspace or catalog conventions.
+   - Read the current [Mediabunny compatibility page](https://www.remotion.dev/docs/mediabunny/version) and determine the Mediabunny version compatible with the target Remotion version. Upgrade every installed `mediabunny` and `@mediabunny/*` package to the documented compatible version.
+   - Run the project's package manager to update its lockfile.
+4. Update the installed Remotion skills:
+
+   ```bash
+   npx remotion skills update
+   ```
+
+5. Review the manifest and lockfile diff. Ensure all Remotion packages use one version and all installed Mediabunny packages use the compatible version. If the CLI is available, run `npx remotion versions` as an additional check.
+
+The [Remotion releases](https://github.com/remotion-dev/remotion/releases) contain the changelog and may be useful for summarizing relevant changes after the upgrade.


### PR DESCRIPTION
## Summary

- add a public `/remotion-upgrade` skill for upgrading Remotion, Mediabunny, and installed Remotion skills
- expose the skill through the generated Agent Skills symlinks
- document the skill on the Agent Skills documentation page

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun render-cards.ts` in `packages/docs`
