### PR TITLE
`@remotion/studio`: Restore browser swipe navigation

### DIFF
--- a/packages/studio/src/helpers/inject-css.ts
+++ b/packages/studio/src/helpers/inject-css.ts
@@ -22,12 +22,10 @@ const makeDefaultGlobalCSS = () => {
 	    --remotion-cli-internals-blue: ${BLUE};
 	    --remotion-cli-internals-blue-hovered: ${BLUE_HOVERED};
 	    overscroll-behavior-y: none;
-	    overscroll-behavior-x: none;
 	  }
 
   body {
     overscroll-behavior-y: none;
-    overscroll-behavior-x: none;
     /* Override Chakra UI position: relative on body */
     position: static !important;
   }


### PR DESCRIPTION
## Summary

- allow horizontal browser overscroll in Remotion Studio
- restore the trackpad two-finger back and forward gestures
- continue suppressing vertical overscroll

## Testing

- `bun run build`
- `bun run stylecheck`
