### PR TITLE
`@remotion/studio`: Preserve value when deleting all keyframes

### DIFF
--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -158,6 +158,7 @@ export type KeyframeOperation =
 	| {
 			type: 'remove';
 			frame: number;
+			valueWhenLastKeyframeDeleted?: unknown;
 	  }
 	| {
 			type: 'settings';
@@ -1163,10 +1164,12 @@ const removeKeyframe = ({
 	expression,
 	frame,
 	videoConfigValues,
+	valueWhenLastKeyframeDeleted,
 }: {
 	expression: Expression;
 	frame: number;
 	videoConfigValues: VideoConfigIdentifierValues;
+	valueWhenLastKeyframeDeleted?: unknown;
 }): {expression: ExpressionKind; introduced: IntroducedKeyframeIdentifiers} => {
 	const existing = getInterpolationExpression(expression, videoConfigValues);
 	if (!existing) {
@@ -1186,7 +1189,10 @@ const removeKeyframe = ({
 
 	if (nextKeyframes.length === 0) {
 		return {
-			expression: existing.keyframes[keyframeIndex].output,
+			expression:
+				valueWhenLastKeyframeDeleted === undefined
+					? existing.keyframes[keyframeIndex].output
+					: parseValueExpression(valueWhenLastKeyframeDeleted),
 			introduced: noIntroducedIdentifiers,
 		};
 	}
@@ -1367,6 +1373,7 @@ const applyKeyframeOperation = ({
 		expression,
 		frame: operation.frame,
 		videoConfigValues,
+		valueWhenLastKeyframeDeleted: operation.valueWhenLastKeyframeDeleted,
 	});
 };
 

--- a/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
+++ b/packages/studio-server/src/codemods/update-keyframes/update-keyframes.ts
@@ -158,7 +158,7 @@ export type KeyframeOperation =
 	| {
 			type: 'remove';
 			frame: number;
-			valueWhenLastKeyframeDeleted?: unknown;
+			valueWhenLastKeyframeDeleted: unknown | null;
 	  }
 	| {
 			type: 'settings';
@@ -1169,7 +1169,7 @@ const removeKeyframe = ({
 	expression: Expression;
 	frame: number;
 	videoConfigValues: VideoConfigIdentifierValues;
-	valueWhenLastKeyframeDeleted?: unknown;
+	valueWhenLastKeyframeDeleted: unknown | null;
 }): {expression: ExpressionKind; introduced: IntroducedKeyframeIdentifiers} => {
 	const existing = getInterpolationExpression(expression, videoConfigValues);
 	if (!existing) {
@@ -1190,7 +1190,7 @@ const removeKeyframe = ({
 	if (nextKeyframes.length === 0) {
 		return {
 			expression:
-				valueWhenLastKeyframeDeleted === undefined
+				valueWhenLastKeyframeDeleted === null
 					? existing.keyframes[keyframeIndex].output
 					: parseValueExpression(valueWhenLastKeyframeDeleted),
 			introduced: noIntroducedIdentifiers,

--- a/packages/studio-server/src/preview-server/routes/delete-keyframes.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-keyframes.ts
@@ -196,6 +196,7 @@ export const deleteKeyframes = async ({
 					operation: {
 						type: 'remove',
 						frame: keyframe.frame,
+						valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
 					},
 				})),
 			});
@@ -235,6 +236,7 @@ export const deleteKeyframes = async ({
 					operation: {
 						type: 'remove',
 						frame: keyframe.frame,
+						valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
 					},
 				})),
 			});

--- a/packages/studio-server/src/preview-server/routes/delete-keyframes.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-keyframes.ts
@@ -196,7 +196,8 @@ export const deleteKeyframes = async ({
 					operation: {
 						type: 'remove',
 						frame: keyframe.frame,
-						valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
+						valueWhenLastKeyframeDeleted:
+							keyframe.valueWhenLastKeyframeDeleted ?? null,
 					},
 				})),
 			});
@@ -236,7 +237,8 @@ export const deleteKeyframes = async ({
 					operation: {
 						type: 'remove',
 						frame: keyframe.frame,
-						valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
+						valueWhenLastKeyframeDeleted:
+							keyframe.valueWhenLastKeyframeDeleted ?? null,
 					},
 				})),
 			});

--- a/packages/studio-server/src/test/delete-keyframes.test.ts
+++ b/packages/studio-server/src/test/delete-keyframes.test.ts
@@ -64,6 +64,15 @@ test('deleteKeyframes batches sequence and effect deletes into one undo entry', 
 					key: 'style.opacity',
 					frame: 0,
 					schema: NoReactInternals.sequenceSchema,
+					valueWhenLastKeyframeDeleted: 0.4,
+				},
+				{
+					fileName,
+					nodePath,
+					key: 'style.opacity',
+					frame: 10,
+					schema: NoReactInternals.sequenceSchema,
+					valueWhenLastKeyframeDeleted: 0.4,
 				},
 			],
 			effectKeyframes: [
@@ -72,8 +81,18 @@ test('deleteKeyframes batches sequence and effect deletes into one undo entry', 
 					sequenceNodePath: nodePath,
 					effectIndex: 0,
 					key: 'amount',
+					frame: 0,
+					schema: NoReactInternals.sequenceSchema,
+					valueWhenLastKeyframeDeleted: 0.6,
+				},
+				{
+					fileName,
+					sequenceNodePath: nodePath,
+					effectIndex: 0,
+					key: 'amount',
 					frame: 20,
 					schema: NoReactInternals.sequenceSchema,
+					valueWhenLastKeyframeDeleted: 0.6,
 				},
 			],
 			clientId: 'test-client',
@@ -82,10 +101,8 @@ test('deleteKeyframes batches sequence and effect deletes into one undo entry', 
 		});
 
 		const output = readFileSync(filePath, 'utf-8');
-		expect(output).toContain(
-			'style={{opacity: interpolate(frame, [10], [1])}}',
-		);
-		expect(output).toContain('amount: interpolate(frame, [0], [0.2])');
+		expect(output).toContain('style={{opacity: 0.4}}');
+		expect(output).toContain('amount: 0.6');
 		expect(getUndoStack()).toHaveLength(1);
 
 		expect(popUndo()).toEqual({success: true});

--- a/packages/studio-server/src/test/update-keyframes-imports.test.ts
+++ b/packages/studio-server/src/test/update-keyframes-imports.test.ts
@@ -240,7 +240,16 @@ export const Example: React.FC = () => {
 		videoConfigValues: null,
 		input,
 		nodePath: lineColumnToNodePath(input, getLine(input, 'opacity')),
-		updates: [{key: 'style.opacity', operation: {type: 'remove', frame: 50}}],
+		updates: [
+			{
+				key: 'style.opacity',
+				operation: {
+					type: 'remove',
+					frame: 50,
+					valueWhenLastKeyframeDeleted: null,
+				},
+			},
+		],
 	});
 
 	expect(serialized).not.toContain('useCurrentFrame');
@@ -507,7 +516,16 @@ export const Comp = () => {
 			getLine(input, '<HtmlInCanvas'),
 		),
 		effectIndex: 0,
-		updates: [{key: 'amount', operation: {type: 'remove', frame: 50}}],
+		updates: [
+			{
+				key: 'amount',
+				operation: {
+					type: 'remove',
+					frame: 50,
+					valueWhenLastKeyframeDeleted: null,
+				},
+			},
+		],
 	});
 	const after = (serialized.match(/const frame = useCurrentFrame/g) ?? [])
 		.length;

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -1233,7 +1233,11 @@ test('updateSequenceKeyframes keeps an interpolation when one keyframe remains',
 		updates: [
 			{
 				key: 'style.scale',
-				operation: {type: 'remove', frame: 0},
+				operation: {
+					type: 'remove',
+					frame: 0,
+					valueWhenLastKeyframeDeleted: null,
+				},
 			},
 		],
 	});
@@ -1262,7 +1266,11 @@ export const Example: React.FC = () => {
 		updates: [
 			{
 				key: 'style.scale',
-				operation: {type: 'remove', frame: 91},
+				operation: {
+					type: 'remove',
+					frame: 91,
+					valueWhenLastKeyframeDeleted: null,
+				},
 			},
 		],
 	});
@@ -1291,7 +1299,11 @@ export const Example: React.FC = () => {
 		updates: [
 			{
 				key: 'style.scale',
-				operation: {type: 'remove', frame: 38},
+				operation: {
+					type: 'remove',
+					frame: 38,
+					valueWhenLastKeyframeDeleted: null,
+				},
 			},
 		],
 	});
@@ -1448,7 +1460,11 @@ test('updateSequenceKeyframes converts the last keyframe to a static value', asy
 			updates: [
 				{
 					key: 'style.scale',
-					operation: {type: 'remove', frame: 12},
+					operation: {
+						type: 'remove',
+						frame: 12,
+						valueWhenLastKeyframeDeleted: null,
+					},
 				},
 			],
 		});
@@ -1504,7 +1520,11 @@ test('updateSequenceKeyframes keeps a color interpolation when one keyframe rema
 		updates: [
 			{
 				key: 'color',
-				operation: {type: 'remove', frame: 0},
+				operation: {
+					type: 'remove',
+					frame: 0,
+					valueWhenLastKeyframeDeleted: null,
+				},
 			},
 		],
 	});
@@ -1652,7 +1672,11 @@ test('updateSequenceKeyframes converts the last color keyframe to a static value
 			updates: [
 				{
 					key: 'color',
-					operation: {type: 'remove', frame: 15},
+					operation: {
+						type: 'remove',
+						frame: 15,
+						valueWhenLastKeyframeDeleted: null,
+					},
 				},
 			],
 		});
@@ -1686,7 +1710,11 @@ test('updateEffectKeyframes removes a keyframe from an effect prop interpolation
 		updates: [
 			{
 				key: 'amount',
-				operation: {type: 'remove', frame: 50},
+				operation: {
+					type: 'remove',
+					frame: 50,
+					valueWhenLastKeyframeDeleted: null,
+				},
 			},
 		],
 	});
@@ -1775,7 +1803,11 @@ test('updateEffectKeyframes keeps an effect prop interpolation with one keyframe
 		updates: [
 			{
 				key: 'amount',
-				operation: {type: 'remove', frame: 100},
+				operation: {
+					type: 'remove',
+					frame: 100,
+					valueWhenLastKeyframeDeleted: null,
+				},
 			},
 		],
 	});
@@ -1800,7 +1832,11 @@ test('updateEffectKeyframes converts the last effect keyframe to a static value'
 			updates: [
 				{
 					key: 'amount',
-					operation: {type: 'remove', frame: 40},
+					operation: {
+						type: 'remove',
+						frame: 40,
+						valueWhenLastKeyframeDeleted: null,
+					},
 				},
 			],
 		});

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -1470,6 +1470,32 @@ test('updateSequenceKeyframes converts the last keyframe to a static value', asy
 	});
 });
 
+test('updateSequenceKeyframes preserves the playhead value when all keyframes are removed', async () => {
+	for (const frames of [
+		[0, 100],
+		[100, 0],
+	]) {
+		const {output} = await updateSequenceKeyframes({
+			videoConfigValues: null,
+			input: sequenceInput,
+			nodePath: lineColumnToNodePath(
+				sequenceInput,
+				getLine(sequenceInput, 'scale'),
+			),
+			updates: frames.map((frame) => ({
+				key: 'style.scale',
+				operation: {
+					type: 'remove' as const,
+					frame,
+					valueWhenLastKeyframeDeleted: 3,
+				},
+			})),
+		});
+
+		expect(output).toContain('style={{scale: 3}}');
+	}
+});
+
 test('updateSequenceKeyframes keeps a color interpolation when one keyframe remains', async () => {
 	const {output, oldValueStrings} = await updateSequenceKeyframes({
 		videoConfigValues: null,

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -464,6 +464,7 @@ export type DeleteSequenceKeyframe = {
 	key: string;
 	frame: number;
 	schema: InteractivitySchema;
+	valueWhenLastKeyframeDeleted?: unknown;
 };
 
 export type MoveSequenceKeyframe = {
@@ -496,6 +497,7 @@ export type DeleteEffectKeyframe = {
 	key: string;
 	frame: number;
 	schema: InteractivitySchema;
+	valueWhenLastKeyframeDeleted?: unknown;
 };
 
 export type MoveEffectKeyframe = {

--- a/packages/studio-shared/src/optimistic-delete-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-delete-keyframe.ts
@@ -28,7 +28,7 @@ const removeKeyframeFromPropStatus = ({
 }: {
 	status: CanUpdateSequencePropStatus;
 	frame: number;
-	valueWhenLastKeyframeDeleted?: unknown;
+	valueWhenLastKeyframeDeleted: unknown | null;
 }): CanUpdateSequencePropStatus => {
 	if (status.status !== 'keyframed') {
 		return status;
@@ -44,7 +44,7 @@ const removeKeyframeFromPropStatus = ({
 		return {
 			status: 'static',
 			codeValue:
-				valueWhenLastKeyframeDeleted === undefined
+				valueWhenLastKeyframeDeleted === null
 					? status.keyframes[index].value
 					: valueWhenLastKeyframeDeleted,
 		};
@@ -96,7 +96,7 @@ export const optimisticDeleteSequenceKeyframe = ({
 			[fieldKey]: removeKeyframeFromPropStatus({
 				status,
 				frame,
-				valueWhenLastKeyframeDeleted,
+				valueWhenLastKeyframeDeleted: valueWhenLastKeyframeDeleted ?? null,
 			}),
 		},
 	};
@@ -166,7 +166,7 @@ export const optimisticDeleteEffectKeyframe = ({
 			[fieldKey]: removeKeyframeFromPropStatus({
 				status,
 				frame,
-				valueWhenLastKeyframeDeleted,
+				valueWhenLastKeyframeDeleted: valueWhenLastKeyframeDeleted ?? null,
 			}),
 		},
 	};

--- a/packages/studio-shared/src/optimistic-delete-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-delete-keyframe.ts
@@ -24,9 +24,11 @@ const getEasingIndexToRemove = ({
 const removeKeyframeFromPropStatus = ({
 	status,
 	frame,
+	valueWhenLastKeyframeDeleted,
 }: {
 	status: CanUpdateSequencePropStatus;
 	frame: number;
+	valueWhenLastKeyframeDeleted?: unknown;
 }): CanUpdateSequencePropStatus => {
 	if (status.status !== 'keyframed') {
 		return status;
@@ -41,7 +43,10 @@ const removeKeyframeFromPropStatus = ({
 	if (keyframes.length === 0) {
 		return {
 			status: 'static',
-			codeValue: status.keyframes[index].value,
+			codeValue:
+				valueWhenLastKeyframeDeleted === undefined
+					? status.keyframes[index].value
+					: valueWhenLastKeyframeDeleted,
 		};
 	}
 
@@ -68,10 +73,12 @@ export const optimisticDeleteSequenceKeyframe = ({
 	previous,
 	fieldKey,
 	frame,
+	valueWhenLastKeyframeDeleted,
 }: {
 	previous: CanUpdateSequencePropsResponse;
 	fieldKey: string;
 	frame: number;
+	valueWhenLastKeyframeDeleted?: unknown;
 }): CanUpdateSequencePropsResponse => {
 	if (!previous.canUpdate) {
 		return previous;
@@ -86,7 +93,11 @@ export const optimisticDeleteSequenceKeyframe = ({
 		...previous,
 		props: {
 			...previous.props,
-			[fieldKey]: removeKeyframeFromPropStatus({status, frame}),
+			[fieldKey]: removeKeyframeFromPropStatus({
+				status,
+				frame,
+				valueWhenLastKeyframeDeleted,
+			}),
 		},
 	};
 };
@@ -96,7 +107,11 @@ export const optimisticDeleteSequenceKeyframes = ({
 	keyframes,
 }: {
 	previous: CanUpdateSequencePropsResponse;
-	keyframes: {fieldKey: string; frame: number}[];
+	keyframes: {
+		fieldKey: string;
+		frame: number;
+		valueWhenLastKeyframeDeleted?: unknown;
+	}[];
 }): CanUpdateSequencePropsResponse => {
 	return keyframes.reduce(
 		(current, keyframe) =>
@@ -104,6 +119,7 @@ export const optimisticDeleteSequenceKeyframes = ({
 				previous: current,
 				fieldKey: keyframe.fieldKey,
 				frame: keyframe.frame,
+				valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
 			}),
 		previous,
 	);
@@ -114,11 +130,13 @@ export const optimisticDeleteEffectKeyframe = ({
 	effectIndex,
 	fieldKey,
 	frame,
+	valueWhenLastKeyframeDeleted,
 }: {
 	previous: CanUpdateSequencePropsResponse;
 	effectIndex: number;
 	fieldKey: string;
 	frame: number;
+	valueWhenLastKeyframeDeleted?: unknown;
 }): CanUpdateSequencePropsResponse => {
 	if (!previous.canUpdate) {
 		return previous;
@@ -145,7 +163,11 @@ export const optimisticDeleteEffectKeyframe = ({
 		...target,
 		props: {
 			...target.props,
-			[fieldKey]: removeKeyframeFromPropStatus({status, frame}),
+			[fieldKey]: removeKeyframeFromPropStatus({
+				status,
+				frame,
+				valueWhenLastKeyframeDeleted,
+			}),
 		},
 	};
 
@@ -163,7 +185,12 @@ export const optimisticDeleteEffectKeyframes = ({
 	keyframes,
 }: {
 	previous: CanUpdateSequencePropsResponse;
-	keyframes: {effectIndex: number; fieldKey: string; frame: number}[];
+	keyframes: {
+		effectIndex: number;
+		fieldKey: string;
+		frame: number;
+		valueWhenLastKeyframeDeleted?: unknown;
+	}[];
 }): CanUpdateSequencePropsResponse => {
 	return keyframes.reduce(
 		(current, keyframe) =>
@@ -172,6 +199,7 @@ export const optimisticDeleteEffectKeyframes = ({
 				effectIndex: keyframe.effectIndex,
 				fieldKey: keyframe.fieldKey,
 				frame: keyframe.frame,
+				valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
 			}),
 		previous,
 	);

--- a/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
@@ -215,6 +215,48 @@ test('optimisticDeleteSequenceKeyframes deletes multiple keyframes in one pass',
 	expect(status.easing).toEqual([]);
 });
 
+test('optimisticDeleteSequenceKeyframes uses the playhead value when deleting all keyframes', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {
+			width: {
+				status: 'keyframed',
+				interpolationFunction: 'interpolate',
+				keyframes: [
+					{frame: 0, value: 100},
+					{frame: 30, value: 200},
+				],
+				easing: [{type: 'linear'}],
+				clamping: {left: 'extend', right: 'extend'},
+				posterize: undefined,
+				output: undefined,
+			},
+		},
+		effects: [],
+	};
+
+	const updated = optimisticDeleteSequenceKeyframes({
+		previous,
+		keyframes: [
+			{
+				fieldKey: 'width',
+				frame: 0,
+				valueWhenLastKeyframeDeleted: 150,
+			},
+			{
+				fieldKey: 'width',
+				frame: 30,
+				valueWhenLastKeyframeDeleted: 150,
+			},
+		],
+	});
+
+	expect(updated.canUpdate && updated.props.width).toEqual({
+		status: 'static',
+		codeValue: 150,
+	});
+});
+
 test('optimisticDeleteEffectKeyframe removes the matching keyframe on the target effect', () => {
 	const previous: CanUpdateSequencePropsResponse = {
 		canUpdate: true,
@@ -385,4 +427,57 @@ test('optimisticDeleteEffectKeyframes deletes multiple keyframes in one pass', (
 
 	expect(status.keyframes).toEqual([{frame: 30, value: 0.5}]);
 	expect(status.easing).toEqual([]);
+});
+
+test('optimisticDeleteEffectKeyframes uses the playhead value when deleting all keyframes', () => {
+	const previous: CanUpdateSequencePropsResponse = {
+		canUpdate: true,
+		props: {},
+		effects: [
+			{
+				canUpdate: true,
+				effectIndex: 0,
+				callee: 'tint',
+				importPath: null,
+				props: {
+					amount: {
+						status: 'keyframed',
+						interpolationFunction: 'interpolate',
+						keyframes: [
+							{frame: 0, value: 0},
+							{frame: 30, value: 1},
+						],
+						easing: [{type: 'linear'}],
+						clamping: {left: 'extend', right: 'extend'},
+						posterize: undefined,
+						output: undefined,
+					},
+				},
+			},
+		],
+	};
+
+	const updated = optimisticDeleteEffectKeyframes({
+		previous,
+		keyframes: [
+			{
+				effectIndex: 0,
+				fieldKey: 'amount',
+				frame: 0,
+				valueWhenLastKeyframeDeleted: 0.5,
+			},
+			{
+				effectIndex: 0,
+				fieldKey: 'amount',
+				frame: 30,
+				valueWhenLastKeyframeDeleted: 0.5,
+			},
+		],
+	});
+
+	const effect = updated.canUpdate ? updated.effects[0] : null;
+	expect(effect?.canUpdate && effect.props.amount).toEqual({
+		status: 'static',
+		codeValue: 0.5,
+	});
 });

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -1012,6 +1012,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 								fieldKey: keyframeTarget.fieldKey,
 								sourceFrame,
 								schema: keyframeTarget.schema,
+								valueWhenLastKeyframeDeleted: null,
 							}),
 						);
 

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -890,6 +890,8 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 							setPropStatuses,
 							clientId,
 							confirm,
+							propStatuses,
+							timelinePosition: timelinePositionRef.current,
 						});
 						return deletePromise?.then((deleted) => {
 							if (!deleted) {

--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -83,6 +83,8 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 				setPropStatuses,
 				clientId,
 				confirm,
+				propStatuses,
+				timelinePosition: timelinePositionRef.current,
 			});
 
 			if (deletePromise !== null) {

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -355,6 +355,7 @@ const getDeleteChange = (
 		fieldKey: target.fieldKey,
 		sourceFrame: target.sourceFrame,
 		schema: target.schema,
+		valueWhenLastKeyframeDeleted: null,
 	};
 
 	if (target.effectIndex === null) {

--- a/packages/studio/src/components/Timeline/call-delete-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-delete-keyframe.ts
@@ -15,6 +15,7 @@ export type DeleteSequenceKeyframeChange = {
 	fieldKey: string;
 	sourceFrame: number;
 	schema: InteractivitySchema;
+	valueWhenLastKeyframeDeleted?: unknown;
 };
 
 export type DeleteEffectKeyframeChange = DeleteSequenceKeyframeChange & {
@@ -154,6 +155,7 @@ export const callDeleteKeyframes = ({
 				keyframes: keyframes.map((keyframe) => ({
 					fieldKey: keyframe.fieldKey,
 					frame: keyframe.sourceFrame,
+					valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
 				})),
 			}),
 		);
@@ -172,6 +174,7 @@ export const callDeleteKeyframes = ({
 					effectIndex: keyframe.effectIndex,
 					fieldKey: keyframe.fieldKey,
 					frame: keyframe.sourceFrame,
+					valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
 				})),
 			}),
 		);
@@ -184,6 +187,7 @@ export const callDeleteKeyframes = ({
 			key: keyframe.fieldKey,
 			frame: keyframe.sourceFrame,
 			schema: keyframe.schema,
+			valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
 		})),
 		effectKeyframes: effectKeyframes.map((keyframe) => ({
 			fileName: keyframe.fileName,
@@ -192,6 +196,7 @@ export const callDeleteKeyframes = ({
 			key: keyframe.fieldKey,
 			frame: keyframe.sourceFrame,
 			schema: keyframe.schema,
+			valueWhenLastKeyframeDeleted: keyframe.valueWhenLastKeyframeDeleted,
 		})),
 		clientId,
 	}).then(() => undefined);

--- a/packages/studio/src/components/Timeline/call-delete-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-delete-keyframe.ts
@@ -15,7 +15,7 @@ export type DeleteSequenceKeyframeChange = {
 	fieldKey: string;
 	sourceFrame: number;
 	schema: InteractivitySchema;
-	valueWhenLastKeyframeDeleted?: unknown;
+	valueWhenLastKeyframeDeleted: unknown | null;
 };
 
 export type DeleteEffectKeyframeChange = DeleteSequenceKeyframeChange & {

--- a/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
@@ -1,4 +1,10 @@
-import type {OverrideIdToNodePaths, TSequence} from 'remotion';
+import type {
+	CanUpdateSequencePropStatus,
+	OverrideIdToNodePaths,
+	PropStatuses,
+	TSequence,
+} from 'remotion';
+import {Internals} from 'remotion';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
 	callDeleteEffectKeyframe,
@@ -15,16 +21,40 @@ type SelectedKeyframeDeletion =
 	| ({type: 'sequence'} & DeleteSequenceKeyframeChange)
 	| ({type: 'effect'} & DeleteEffectKeyframeChange);
 
+const getValueWhenLastKeyframeDeleted = ({
+	propStatus,
+	playheadSourceFrame,
+}: {
+	propStatus: CanUpdateSequencePropStatus | null | undefined;
+	playheadSourceFrame: number | null;
+}): unknown => {
+	if (propStatus?.status !== 'keyframed' || playheadSourceFrame === null) {
+		return undefined;
+	}
+
+	return (
+		Internals.interpolateKeyframedStatus({
+			forceSpringAllowTail: null,
+			frame: playheadSourceFrame,
+			status: propStatus,
+		}) ?? undefined
+	);
+};
+
 const getSelectedKeyframeDeletion = ({
 	nodePathInfo,
 	frame,
 	sequences,
 	overrideIdsToNodePaths,
+	propStatuses,
+	timelinePosition,
 }: {
 	nodePathInfo: SequenceNodePathInfo;
 	frame: number;
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
+	propStatuses?: PropStatuses;
+	timelinePosition?: number;
 }): SelectedKeyframeDeletion | null => {
 	const field = parseKeyframeFieldFromNodePath(nodePathInfo.auxiliaryKeys);
 	if (field === null) {
@@ -42,6 +72,10 @@ const getSelectedKeyframeDeletion = ({
 	}
 
 	const sourceFrame = frame - (track?.keyframeDisplayOffset ?? 0);
+	const playheadSourceFrame =
+		timelinePosition === undefined
+			? null
+			: timelinePosition - (track?.keyframeDisplayOffset ?? 0);
 	const nodePath = nodePathInfo.sequenceSubscriptionKey;
 	const fileName = nodePath.absolutePath;
 
@@ -51,6 +85,22 @@ const getSelectedKeyframeDeletion = ({
 			return null;
 		}
 
+		const effectStatus = propStatuses
+			? Internals.getEffectPropStatusesCtx({
+					propStatuses,
+					nodePath,
+					effectIndex: field.effectIndex,
+				})
+			: null;
+		const effectPropStatus =
+			effectStatus?.type === 'can-update-effect'
+				? effectStatus.props[field.fieldKey]
+				: null;
+		const effectValueWhenLastKeyframeDeleted = getValueWhenLastKeyframeDeleted({
+			propStatus: effectPropStatus,
+			playheadSourceFrame,
+		});
+
 		return {
 			type: 'effect',
 			fileName,
@@ -59,8 +109,17 @@ const getSelectedKeyframeDeletion = ({
 			fieldKey: field.fieldKey,
 			sourceFrame,
 			schema: effect.schema,
+			valueWhenLastKeyframeDeleted: effectValueWhenLastKeyframeDeleted,
 		};
 	}
+
+	const sequencePropStatus = propStatuses
+		? Internals.getPropStatusesCtx(propStatuses, nodePath)?.[field.fieldKey]
+		: null;
+	const sequenceValueWhenLastKeyframeDeleted = getValueWhenLastKeyframeDeleted({
+		propStatus: sequencePropStatus,
+		playheadSourceFrame,
+	});
 
 	return {
 		type: 'sequence',
@@ -69,6 +128,7 @@ const getSelectedKeyframeDeletion = ({
 		fieldKey: field.fieldKey,
 		sourceFrame,
 		schema: sequence.controls.schema,
+		valueWhenLastKeyframeDeleted: sequenceValueWhenLastKeyframeDeleted,
 	};
 };
 
@@ -118,6 +178,8 @@ export const deleteSelectedKeyframes = ({
 	overrideIdsToNodePaths,
 	setPropStatuses,
 	clientId,
+	propStatuses,
+	timelinePosition,
 }: {
 	keyframes: {
 		nodePathInfo: SequenceNodePathInfo;
@@ -127,6 +189,8 @@ export const deleteSelectedKeyframes = ({
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
 	setPropStatuses: SetPropStatuses;
 	clientId: string;
+	propStatuses: PropStatuses;
+	timelinePosition: number;
 }): Promise<void> | null => {
 	const deletions = keyframes
 		.map((keyframe) =>
@@ -135,6 +199,8 @@ export const deleteSelectedKeyframes = ({
 				frame: keyframe.frame,
 				sequences,
 				overrideIdsToNodePaths,
+				propStatuses,
+				timelinePosition,
 			}),
 		)
 		.filter(

--- a/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
@@ -27,9 +27,9 @@ const getValueWhenLastKeyframeDeleted = ({
 }: {
 	propStatus: CanUpdateSequencePropStatus | null | undefined;
 	playheadSourceFrame: number | null;
-}): unknown => {
+}): unknown | null => {
 	if (propStatus?.status !== 'keyframed' || playheadSourceFrame === null) {
-		return undefined;
+		return null;
 	}
 
 	return (
@@ -37,7 +37,7 @@ const getValueWhenLastKeyframeDeleted = ({
 			forceSpringAllowTail: null,
 			frame: playheadSourceFrame,
 			status: propStatus,
-		}) ?? undefined
+		}) ?? null
 	);
 };
 
@@ -53,8 +53,8 @@ const getSelectedKeyframeDeletion = ({
 	frame: number;
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
-	propStatuses?: PropStatuses;
-	timelinePosition?: number;
+	propStatuses: PropStatuses | null;
+	timelinePosition: number | null;
 }): SelectedKeyframeDeletion | null => {
 	const field = parseKeyframeFieldFromNodePath(nodePathInfo.auxiliaryKeys);
 	if (field === null) {
@@ -73,7 +73,7 @@ const getSelectedKeyframeDeletion = ({
 
 	const sourceFrame = frame - (track?.keyframeDisplayOffset ?? 0);
 	const playheadSourceFrame =
-		timelinePosition === undefined
+		timelinePosition === null
 			? null
 			: timelinePosition - (track?.keyframeDisplayOffset ?? 0);
 	const nodePath = nodePathInfo.sequenceSubscriptionKey;
@@ -85,13 +85,14 @@ const getSelectedKeyframeDeletion = ({
 			return null;
 		}
 
-		const effectStatus = propStatuses
-			? Internals.getEffectPropStatusesCtx({
-					propStatuses,
-					nodePath,
-					effectIndex: field.effectIndex,
-				})
-			: null;
+		const effectStatus =
+			propStatuses !== null
+				? Internals.getEffectPropStatusesCtx({
+						propStatuses,
+						nodePath,
+						effectIndex: field.effectIndex,
+					})
+				: null;
 		const effectPropStatus =
 			effectStatus?.type === 'can-update-effect'
 				? effectStatus.props[field.fieldKey]
@@ -113,9 +114,10 @@ const getSelectedKeyframeDeletion = ({
 		};
 	}
 
-	const sequencePropStatus = propStatuses
-		? Internals.getPropStatusesCtx(propStatuses, nodePath)?.[field.fieldKey]
-		: null;
+	const sequencePropStatus =
+		propStatuses !== null
+			? Internals.getPropStatusesCtx(propStatuses, nodePath)?.[field.fieldKey]
+			: null;
 	const sequenceValueWhenLastKeyframeDeleted = getValueWhenLastKeyframeDeleted({
 		propStatus: sequencePropStatus,
 		playheadSourceFrame,
@@ -152,6 +154,8 @@ export const deleteSelectedKeyframe = ({
 		frame,
 		sequences,
 		overrideIdsToNodePaths,
+		propStatuses: null,
+		timelinePosition: null,
 	});
 	if (deletion === null) {
 		return null;

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -419,6 +419,8 @@ export const deleteSelectedTimelineItems = ({
 	setPropStatuses,
 	clientId,
 	confirm,
+	propStatuses,
+	timelinePosition,
 }: {
 	selections: readonly TimelineSelection[];
 	sequences: TSequence[];
@@ -426,6 +428,8 @@ export const deleteSelectedTimelineItems = ({
 	setPropStatuses: SetPropStatuses;
 	clientId: string;
 	confirm: ConfirmationDialogFunction;
+	propStatuses: PropStatuses;
+	timelinePosition: number;
 }): Promise<boolean> | null => {
 	const firstSelection = selections[0];
 	if (!firstSelection) {
@@ -447,6 +451,8 @@ export const deleteSelectedTimelineItems = ({
 			overrideIdsToNodePaths,
 			setPropStatuses,
 			clientId,
+			propStatuses,
+			timelinePosition,
 		});
 		return promise?.then(() => true) ?? null;
 	}

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -5855,6 +5855,7 @@ test('Deleting selected keyframes ignores selected easings', async () => {
 							key: 'opacity',
 							frame: 12,
 							schema,
+							valueWhenLastKeyframeDeleted: null,
 						},
 					],
 					effectKeyframes: [],

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -5628,6 +5628,8 @@ test('Deleting unsupported mixed timeline selection types returns null', () => {
 			setPropStatuses: () => undefined,
 			clientId: 'client',
 			confirm,
+			propStatuses: {},
+			timelinePosition: 0,
 		}),
 	).toBe(null);
 });
@@ -5837,6 +5839,8 @@ test('Deleting selected keyframes ignores selected easings', async () => {
 			setPropStatuses: () => undefined,
 			clientId: 'client',
 			confirm: () => Promise.resolve(true),
+			propStatuses: {},
+			timelinePosition: 0,
 		});
 
 		expect(result).toBe(true);
@@ -5851,6 +5855,107 @@ test('Deleting selected keyframes ignores selected easings', async () => {
 							key: 'opacity',
 							frame: 12,
 							schema,
+						},
+					],
+					effectKeyframes: [],
+					clientId: 'client',
+				},
+			},
+		]);
+	} finally {
+		globalThis.fetch = previousFetch;
+	}
+});
+
+test('Deleting all selected keyframes preserves the value at the playhead', async () => {
+	const schema = {
+		opacity: {type: 'number', default: 1, hiddenFromList: false},
+	} satisfies InteractivitySchema;
+	const opacityNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'opacity'],
+	);
+	const nodePath = opacityNodePathInfo.sequenceSubscriptionKey;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {
+				opacity: {
+					status: 'keyframed',
+					interpolationFunction: 'interpolate',
+					keyframes: [
+						{frame: 0, value: 0},
+						{frame: 10, value: 1},
+					],
+					easing: [{type: 'linear'}],
+					clamping: {left: 'extend', right: 'extend'},
+					posterize: undefined,
+					output: undefined,
+				},
+			},
+			effects: [],
+		},
+	} satisfies PropStatuses;
+	const fetchCalls: unknown[] = [];
+	const previousFetch = globalThis.fetch;
+	globalThis.fetch = ((input, init) => {
+		fetchCalls.push({
+			input,
+			body:
+				typeof init?.body === 'string'
+					? JSON.parse(init.body)
+					: (init?.body ?? null),
+		});
+
+		return Promise.resolve({
+			json: () => Promise.resolve({success: true, data: {}}),
+		} as Response);
+	}) as typeof fetch;
+
+	try {
+		const result = await deleteSelectedTimelineItems({
+			selections: [
+				{
+					type: 'keyframe',
+					nodePathInfo: opacityNodePathInfo,
+					frame: 0,
+				},
+				{
+					type: 'keyframe',
+					nodePathInfo: opacityNodePathInfo,
+					frame: 10,
+				},
+			],
+			sequences: [makeTimelineSequence({schema})],
+			overrideIdsToNodePaths: {override: nodePath},
+			setPropStatuses: () => undefined,
+			clientId: 'client',
+			confirm: () => Promise.resolve(true),
+			propStatuses,
+			timelinePosition: 5,
+		});
+
+		expect(result).toBe(true);
+		expect(fetchCalls).toEqual([
+			{
+				input: '/api/delete-keyframes',
+				body: {
+					sequenceKeyframes: [
+						{
+							fileName: '/project/src/Comp.tsx',
+							nodePath,
+							key: 'opacity',
+							frame: 0,
+							schema,
+							valueWhenLastKeyframeDeleted: 0.5,
+						},
+						{
+							fileName: '/project/src/Comp.tsx',
+							nodePath,
+							key: 'opacity',
+							frame: 10,
+							schema,
+							valueWhenLastKeyframeDeleted: 0.5,
 						},
 					],
 					effectKeyframes: [],


### PR DESCRIPTION
## Summary

- resolve the current keyframed value at the playhead before deleting selected keyframes
- use that value for optimistic state and source code when a property loses its final keyframe
- keep partial keyframe deletions unchanged and make full deletion independent of selection order

## Testing

- `bun test packages/studio-server/src/test/delete-keyframes.test.ts packages/studio-server/src/test/update-keyframes.test.ts packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes https://github.com/remotion-dev/remotion/issues/9291
