### PR TITLE
`@remotion/studio`: Refine connected composition navigation

### DIFF
--- a/packages/studio/src/components/InitialCompositionLoader.tsx
+++ b/packages/studio/src/components/InitialCompositionLoader.tsx
@@ -17,16 +17,24 @@ import {useStaticFiles} from './use-static-files';
 export const useSelectComposition = () => {
 	const {setCompositionFoldersExpanded} = useContext(FolderContext);
 	const {setCanvasContent} = useContext(Internals.CompositionSetters);
+	const setFrame = Internals.useTimelineSetFrame();
 	const isMobileLayout = useMobileLayout();
 	const {setSidebarCollapsedState} = useContext(SidebarContext);
 
 	return useCallback(
-		(c: _InternalTypes['AnyComposition'], push: boolean) => {
+		(
+			c: _InternalTypes['AnyComposition'],
+			push: boolean,
+			frame: number | null = null,
+		) => {
 			if (push) {
 				pushUrl(`/${c.id}`);
 			}
 
 			explorerSidebarTabs.current?.selectCompositionPanel();
+			if (frame !== null) {
+				setFrame((current) => ({...current, [c.id]: frame}));
+			}
 
 			setCanvasContent({type: 'composition', compositionId: c.id});
 
@@ -55,6 +63,7 @@ export const useSelectComposition = () => {
 			isMobileLayout,
 			setCanvasContent,
 			setCompositionFoldersExpanded,
+			setFrame,
 			setSidebarCollapsedState,
 		],
 	);

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useContext, useMemo, useRef} from 'react';
-import type {TSequence} from 'remotion';
+import type {_InternalTypes, TSequence} from 'remotion';
 import {Internals, useCurrentFrame} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {
@@ -13,6 +13,10 @@ import {
 	WHITE_ALPHA_50,
 } from '../../helpers/colors';
 import {formatFileLocation} from '../../helpers/format-file-location';
+import {
+	getConnectedCompositionFrame,
+	getSequenceDoubleClickAction,
+} from '../../helpers/get-sequence-double-click-action';
 import {
 	getTimelineSequenceLayout,
 	SEQUENCE_BORDER_WIDTH,
@@ -29,6 +33,7 @@ import {AudioWaveform} from '../AudioWaveform';
 import {callApi} from '../call-api';
 import {useConfirmationDialog} from '../ConfirmationDialog';
 import {ContextMenu} from '../ContextMenu';
+import {useSelectComposition} from '../InitialCompositionLoader';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {useSelectAsset} from '../use-select-asset';
 import {disableSequenceInteractivity} from './disable-sequence-interactivity';
@@ -38,6 +43,7 @@ import {LoopedTimelineIndicator} from './LoopedTimelineIndicators';
 import {getTimelineAssetLinkInfo} from './timeline-asset-link';
 import {TimelineImageInfo} from './TimelineImageInfo';
 import {
+	isTimelineSelectionModifierEvent,
 	shouldSelectTimelineRowOnPointerDown,
 	TIMELINE_MARQUEE_ITEM_ATTR,
 	useTimelineMarqueeSelectableItem,
@@ -57,9 +63,10 @@ import {useSequenceFreezeFrameMenuItem} from './use-sequence-freeze-frame-menu-i
 
 const TimelineSequenceFn: React.FC<{
 	readonly s: TSequence;
+	readonly connectedCompositions: readonly _InternalTypes['AnyComposition'][];
 	readonly nodePathInfo: SequenceNodePathInfo | null;
 	readonly sequenceFrameOffset: number;
-}> = ({s, nodePathInfo, sequenceFrameOffset}) => {
+}> = ({s, connectedCompositions, nodePathInfo, sequenceFrameOffset}) => {
 	const windowWidth = useContext(TimelineWidthContext);
 
 	if (windowWidth === null) {
@@ -70,6 +77,7 @@ const TimelineSequenceFn: React.FC<{
 		<TimelineSequenceInner
 			windowWidth={windowWidth}
 			s={s}
+			connectedCompositions={connectedCompositions}
 			nodePathInfo={nodePathInfo}
 			sequenceFrameOffset={sequenceFrameOffset}
 		/>
@@ -90,6 +98,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	readonly onMoveDragPointerDown: (
 		e: React.PointerEvent<HTMLDivElement>,
 	) => void;
+	readonly onDoubleClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }> = ({
 	s,
 	displayDurationInFrames,
@@ -102,6 +111,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	fromCanUpdate,
 	frozenFrame,
 	onMoveDragPointerDown,
+	onDoubleClick,
 }) => {
 	const ref = useRef<HTMLDivElement>(null);
 	const {onSelect, selectable, selected, selectionItem} =
@@ -166,6 +176,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 			style={actualStyle}
 			title={s.displayName}
 			onPointerDown={selectable ? onPointerDown : undefined}
+			onDoubleClick={onDoubleClick}
 		>
 			{premountWidth ? (
 				<div
@@ -231,10 +242,17 @@ const TimelineSequenceCurrentFrame: React.FC<{
 
 const TimelineSequenceInner: React.FC<{
 	readonly s: TSequence;
+	readonly connectedCompositions: readonly _InternalTypes['AnyComposition'][];
 	readonly windowWidth: number;
 	readonly nodePathInfo: SequenceNodePathInfo | null;
 	readonly sequenceFrameOffset: number;
-}> = ({s, windowWidth, nodePathInfo, sequenceFrameOffset}) => {
+}> = ({
+	s,
+	connectedCompositions,
+	windowWidth,
+	nodePathInfo,
+	sequenceFrameOffset,
+}) => {
 	// If a duration is 1, it is essentially a still and it should have width 0
 	// Some compositions may not be longer than their media duration,
 	// if that is the case, it needs to be asynchronously determined
@@ -286,6 +304,7 @@ const TimelineSequenceInner: React.FC<{
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const selectAsset = useSelectAsset();
+	const selectComposition = useSelectComposition();
 	const confirm = useConfirmationDialog();
 	const {onSelect, selectable} = useTimelineRowSelection(nodePathInfo);
 	const fileLocation = useMemo(
@@ -308,6 +327,50 @@ const TimelineSequenceInner: React.FC<{
 			showNotification((err as Error).message, 2000);
 		});
 	}, [canOpenInEditor, originalLocation]);
+	const onSequenceDoubleClick = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (isTimelineSelectionModifierEvent(e)) {
+				e.stopPropagation();
+				return;
+			}
+
+			const action = getSequenceDoubleClickAction({
+				button: e.button,
+				canOpenInEditor,
+				numberOfConnectedCompositions: connectedCompositions.length,
+			});
+			if (action === null) {
+				return;
+			}
+
+			e.stopPropagation();
+			if (action === 'open-connected-composition') {
+				selectComposition(
+					connectedCompositions[0],
+					true,
+					getConnectedCompositionFrame({
+						timelinePosition,
+						sequence: s,
+						sequenceFrameOffset,
+					}),
+				);
+				return;
+			}
+
+			openInEditor();
+		},
+		[
+			canOpenInEditor,
+			connectedCompositions,
+			openInEditor,
+			s,
+			selectComposition,
+			sequenceFrameOffset,
+			timelinePosition,
+		],
+	);
+	const canHandleSequenceDoubleClick =
+		connectedCompositions.length === 1 || canOpenInEditor;
 	const canDeleteFromSource = Boolean(nodePath && validatedLocation?.source);
 	const deleteDisabled =
 		!previewInteractive || !s.controls || !canDeleteFromSource;
@@ -552,6 +615,9 @@ const TimelineSequenceInner: React.FC<{
 			fromCanUpdate={fromCanUpdate}
 			frozenFrame={frozenFrame}
 			onMoveDragPointerDown={onMoveDragPointerDown}
+			onDoubleClick={
+				canHandleSequenceDoubleClick ? onSequenceDoubleClick : undefined
+			}
 		>
 			{s.type === 'audio' ? (
 				<AudioWaveform

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -16,7 +16,10 @@ import {
 	WHITE,
 } from '../../helpers/colors';
 import {formatFileLocation} from '../../helpers/format-file-location';
-import {getSequenceDoubleClickAction} from '../../helpers/get-sequence-double-click-action';
+import {
+	getConnectedCompositionFrame,
+	getSequenceDoubleClickAction,
+} from '../../helpers/get-sequence-double-click-action';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {getStudioKeyboardShortcutsEnabled} from '../../helpers/studio-runtime-config';
@@ -763,13 +766,29 @@ export const TimelineSequenceItem: React.FC<{
 
 			e.stopPropagation();
 			if (action === 'open-connected-composition') {
-				selectComposition(connectedCompositions[0], true);
+				selectComposition(
+					connectedCompositions[0],
+					true,
+					getConnectedCompositionFrame({
+						timelinePosition,
+						sequence,
+						sequenceFrameOffset,
+					}),
+				);
 				return;
 			}
 
 			openInEditor();
 		},
-		[canOpenInEditor, connectedCompositions, openInEditor, selectComposition],
+		[
+			canOpenInEditor,
+			connectedCompositions,
+			openInEditor,
+			selectComposition,
+			sequence,
+			sequenceFrameOffset,
+			timelinePosition,
+		],
 	);
 	const canHandleSequenceDoubleClick =
 		connectedCompositions.length === 1 || canOpenInEditor;

--- a/packages/studio/src/components/Timeline/TimelineTrack.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTrack.tsx
@@ -52,6 +52,7 @@ const TimelineTrackUnmemoized: React.FC<{
 				) : null}
 				<TimelineSequence
 					s={track.sequence}
+					connectedCompositions={track.connectedCompositions ?? []}
 					nodePathInfo={track.nodePathInfo}
 					sequenceFrameOffset={track.sequenceFrameOffset}
 				/>

--- a/packages/studio/src/helpers/get-sequence-double-click-action.ts
+++ b/packages/studio/src/helpers/get-sequence-double-click-action.ts
@@ -1,3 +1,5 @@
+import type {TSequence} from 'remotion';
+
 export type SequenceDoubleClickAction =
 	| 'open-connected-composition'
 	| 'open-in-editor';
@@ -20,4 +22,21 @@ export const getSequenceDoubleClickAction = ({
 	}
 
 	return canOpenInEditor ? 'open-in-editor' : null;
+};
+
+export const getConnectedCompositionFrame = ({
+	timelinePosition,
+	sequence,
+	sequenceFrameOffset,
+}: {
+	readonly timelinePosition: number;
+	readonly sequence: TSequence;
+	readonly sequenceFrameOffset: number;
+}): number | null => {
+	const relativeFrame = timelinePosition - sequence.from;
+	if (relativeFrame < 0 || relativeFrame >= sequence.duration) {
+		return null;
+	}
+
+	return sequence.frozenFrame ?? relativeFrame + sequenceFrameOffset;
 };

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -125,7 +125,10 @@ import {
 	getKeyframesForTimelineEasingDrag,
 	getTimelineSelectionsAfterEasingKeyframeDrag,
 } from '../components/Timeline/use-timeline-keyframe-drag';
-import {getSequenceDoubleClickAction} from '../helpers/get-sequence-double-click-action';
+import {
+	getConnectedCompositionFrame,
+	getSequenceDoubleClickAction,
+} from '../helpers/get-sequence-double-click-action';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {
 	loadEditorShowOutlinesOption,
@@ -2210,6 +2213,55 @@ test('Sequence double-click opens one connected composition before the editor', 
 			numberOfConnectedCompositions: 1,
 		}),
 	).toBeNull();
+});
+
+test('Connected composition double-click uses the visible sequence frame', () => {
+	const sequence = makeTimelineSequence({
+		schema: Internals.baseSchema,
+		from: 20,
+		duration: 40,
+	});
+
+	expect(
+		getConnectedCompositionFrame({
+			timelinePosition: 35,
+			sequence,
+			sequenceFrameOffset: 5,
+		}),
+	).toBe(20);
+	expect(
+		getConnectedCompositionFrame({
+			timelinePosition: 19,
+			sequence,
+			sequenceFrameOffset: 5,
+		}),
+	).toBeNull();
+	expect(
+		getConnectedCompositionFrame({
+			timelinePosition: 60,
+			sequence,
+			sequenceFrameOffset: 5,
+		}),
+	).toBeNull();
+});
+
+test('Connected composition double-click respects frozen frames', () => {
+	const sequence = {
+		...makeTimelineSequence({
+			schema: Internals.baseSchema,
+			from: 20,
+			duration: 40,
+		}),
+		frozenFrame: 12,
+	} satisfies TSequence;
+
+	expect(
+		getConnectedCompositionFrame({
+			timelinePosition: 35,
+			sequence,
+			sequenceFrameOffset: 5,
+		}),
+	).toBe(12);
 });
 
 test('Canvas outline hit targets render nested sequences above parents', () => {


### PR DESCRIPTION
## Summary

- seek to the visible nested frame when opening an active connected composition
- preserve the connected composition's previous frame when the sequence is inactive
- support the same double-click action on timeline layers as timeline list rows
- account for trimmed and frozen connected composition frames

## Verification

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bunx turbo run make --filter=@remotion/studio`
- `bun run build`
- `bun run stylecheck`

Closes #9294
