### PR TITLE
`remotion`: Keep interactive components visible with negative offsets

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -27,7 +27,6 @@ import type {AbsoluteFillLayout} from './Sequence.js';
 import {Sequence} from './Sequence.js';
 import {useDelayRender} from './use-delay-render.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
-import {useVideoConfig} from './use-video-config.js';
 import {withInteractivitySchema} from './with-interactivity-schema.js';
 
 // IDL: https://github.com/WICG/html-in-canvas#idl-changes
@@ -728,9 +727,6 @@ const HtmlInCanvasInner = forwardRef<
 		},
 		ref,
 	) => {
-		const {durationInFrames: videoDuration} = useVideoConfig();
-		const resolvedDuration = durationInFrames ?? videoDuration;
-
 		const memoizedEffectDefinitions = useMemoizedEffectDefinitions(effects);
 		const actualRef = useRef<HTMLCanvasElement | null>(null);
 		const setCanvasRef = useCallback(
@@ -747,7 +743,7 @@ const HtmlInCanvasInner = forwardRef<
 
 		return (
 			<Sequence
-				durationInFrames={resolvedDuration}
+				durationInFrames={durationInFrames}
 				name={name ?? '<HtmlInCanvas>'}
 				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/remotion/html-in-canvas"
 				controls={controls}

--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -273,8 +273,6 @@ const AnimatedImageInner = ({
 	readonly controls?: SequenceControls | undefined;
 	readonly ref?: React.Ref<HTMLCanvasElement>;
 }) => {
-	const {durationInFrames: videoDuration} = useVideoConfig();
-	const resolvedDuration = durationInFrames ?? videoDuration;
 	const actualRef = useRef<HTMLCanvasElement | null>(null);
 
 	const memoizedEffectDefinitions = useMemoizedEffectDefinitions(effects);
@@ -303,7 +301,7 @@ const AnimatedImageInner = ({
 	return (
 		<Sequence
 			layout="none"
-			durationInFrames={resolvedDuration}
+			durationInFrames={durationInFrames}
 			name="<AnimatedImage>"
 			_remotionInternalDocumentationLink="https://www.remotion.dev/docs/animatedimage"
 			controls={controls}

--- a/packages/core/src/test/html-in-canvas.test.tsx
+++ b/packages/core/src/test/html-in-canvas.test.tsx
@@ -161,11 +161,15 @@ const SequenceTestWrapper: React.FC<{
 	readonly onRegisterSequence: (sequence: TSequence) => void;
 	readonly isRendering?: boolean;
 	readonly isClientSideRendering?: boolean;
+	readonly compositionDurationInFrames?: number;
+	readonly currentFrame?: number;
 }> = ({
 	children,
 	onRegisterSequence,
 	isRendering = false,
 	isClientSideRendering = false,
+	compositionDurationInFrames,
+	currentFrame,
 }) => {
 	const registerSequence = useCallback(
 		(sequence: TSequence) => {
@@ -215,7 +219,10 @@ const SequenceTestWrapper: React.FC<{
 	);
 
 	return (
-		<WrapSequenceContext>
+		<WrapSequenceContext
+			compositionDurationInFrames={compositionDurationInFrames}
+			currentFrame={currentFrame}
+		>
 			<Internals.RemotionEnvironmentContext
 				value={{
 					isClientSideRendering,
@@ -240,6 +247,22 @@ const SequenceTestWrapper: React.FC<{
 		</WrapSequenceContext>
 	);
 };
+
+test('<HtmlInCanvas> remains visible with a negative offset', () => {
+	const {queryByText} = render(
+		<SequenceTestWrapper
+			compositionDurationInFrames={100}
+			currentFrame={75}
+			onRegisterSequence={() => undefined}
+		>
+			<HtmlInCanvas from={-100} width={120} height={80}>
+				<div>Still visible</div>
+			</HtmlInCanvas>
+		</SequenceTestWrapper>,
+	);
+
+	expect(queryByText('Still visible')).not.toBeNull();
+});
 
 test('<HtmlInCanvas> registers its canvas for outline selection', async () => {
 	const registeredSequences: TSequence[] = [];

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -34,6 +34,8 @@ type SequenceTestWrapperProps = {
 	readonly children: React.ReactNode;
 	readonly onRegisterSequence: (sequence: TSequence) => void;
 	readonly rerenderOnRegister?: boolean;
+	readonly compositionDurationInFrames?: number;
+	readonly currentFrame?: number;
 };
 
 type VisualModeOverrides = {
@@ -51,6 +53,8 @@ const SequenceTestWrapperWithVisualModeOverrides: React.FC<
 	onRegisterSequence,
 	rerenderOnRegister = false,
 	visualModeOverrides,
+	compositionDurationInFrames,
+	currentFrame,
 }) => {
 	const [, setTick] = useState(0);
 
@@ -109,7 +113,10 @@ const SequenceTestWrapperWithVisualModeOverrides: React.FC<
 	);
 
 	return (
-		<WrapSequenceContext>
+		<WrapSequenceContext
+			compositionDurationInFrames={compositionDurationInFrames}
+			currentFrame={currentFrame}
+		>
 			<Internals.RemotionEnvironmentContext
 				value={{
 					isRendering: false,
@@ -143,12 +150,16 @@ const SequenceTestWrapper: React.FC<SequenceTestWrapperProps> = ({
 	children,
 	onRegisterSequence,
 	rerenderOnRegister = false,
+	compositionDurationInFrames,
+	currentFrame,
 }) => {
 	return (
 		<SequenceTestWrapperWithVisualModeOverrides
 			onRegisterSequence={onRegisterSequence}
 			rerenderOnRegister={rerenderOnRegister}
 			visualModeOverrides={null}
+			compositionDurationInFrames={compositionDurationInFrames}
+			currentFrame={currentFrame}
 		>
 			{children}
 		</SequenceTestWrapperWithVisualModeOverrides>
@@ -482,6 +493,20 @@ test('AnimatedImage registers its canvas ref for the Studio outline', () => {
 
 	expect(refForOutline.current).toBeInstanceOf(HTMLCanvasElement);
 	expect(ref.current).toBe(refForOutline.current);
+});
+
+test('AnimatedImage remains visible with a negative offset', () => {
+	const {container} = render(
+		<SequenceTestWrapper
+			compositionDurationInFrames={100}
+			currentFrame={75}
+			onRegisterSequence={() => undefined}
+		>
+			<AnimatedImage from={-100} onError={() => undefined} src="test.gif" />
+		</SequenceTestWrapper>,
+	);
+
+	expect(container.querySelector('canvas')).not.toBeNull();
 });
 
 test('AnimatedImage forwards data and aria attributes to its canvas', () => {

--- a/packages/core/src/test/wrap-sequence-context.tsx
+++ b/packages/core/src/test/wrap-sequence-context.tsx
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React, {useContext, useMemo} from 'react';
 import {BufferingProvider} from '../buffering.js';
 import {CanUseRemotionHooksProvider} from '../CanUseRemotionHooks.js';
 import type {CompositionManagerContext} from '../CompositionManagerContext.js';
@@ -18,11 +18,13 @@ import {
 
 const Comp: React.FC = () => null;
 
-const mockCompositionContext: CompositionManagerContext = {
+const makeMockCompositionContext = (
+	durationInFrames: number,
+): CompositionManagerContext => ({
 	compositions: [
 		{
 			id: 'my-comp',
-			durationInFrames: 1000000,
+			durationInFrames,
 			component: Comp,
 			defaultProps: {},
 			folderName: null,
@@ -45,25 +47,17 @@ const mockCompositionContext: CompositionManagerContext = {
 		defaultProResProfile: null,
 		defaultSampleRate: null,
 		defaultVideoImageFormat: null,
-		durationInFrames: 1000000,
+		durationInFrames,
 		fps: 30,
 		height: 1080,
 		width: 1080,
 		props: {},
 	},
-};
+});
 
 const logContext: LoggingContextValue = {
 	logLevel: 'info',
 	mountTime: 0,
-};
-
-const mockTimelineContext: TimelineContextValue = {
-	frame: {},
-	playing: false,
-	rootId: 'test-root',
-	imperativePlaying: {current: false},
-	audioAndVideoTags: {current: []},
 };
 
 const mockPlaybackRateContext: PlaybackRateContextValue = {
@@ -75,7 +69,8 @@ const mockPlaybackRateContext: PlaybackRateContextValue = {
 
 const MaybeTimelineProvider: React.FC<{
 	readonly children: React.ReactNode;
-}> = ({children}) => {
+	readonly timelineContext: TimelineContextValue;
+}> = ({children, timelineContext}) => {
 	const existing = useContext(TimelineContext);
 	if (existing !== null) {
 		// eslint-disable-next-line react/jsx-no-useless-fragment
@@ -83,8 +78,8 @@ const MaybeTimelineProvider: React.FC<{
 	}
 
 	return (
-		<AbsoluteTimeContext.Provider value={mockTimelineContext}>
-			<TimelineContext.Provider value={mockTimelineContext}>
+		<AbsoluteTimeContext.Provider value={timelineContext}>
+			<TimelineContext.Provider value={timelineContext}>
 				{children}
 			</TimelineContext.Provider>
 		</AbsoluteTimeContext.Provider>
@@ -109,15 +104,32 @@ const MaybePlaybackRateProvider: React.FC<{
 
 export const WrapSequenceContext: React.FC<{
 	readonly children: React.ReactNode;
-}> = ({children}) => {
+	readonly compositionDurationInFrames?: number;
+	readonly currentFrame?: number;
+}> = ({children, compositionDurationInFrames = 1000000, currentFrame = 0}) => {
+	const compositionContext = useMemo(
+		() => makeMockCompositionContext(compositionDurationInFrames),
+		[compositionDurationInFrames],
+	);
+	const timelineContext = useMemo<TimelineContextValue>(
+		() => ({
+			frame: {'my-comp': currentFrame},
+			playing: false,
+			rootId: 'test-root',
+			imperativePlaying: {current: false},
+			audioAndVideoTags: {current: []},
+		}),
+		[currentFrame],
+	);
+
 	return (
 		<LogLevelContext.Provider value={logContext}>
 			<BufferingProvider>
 				<CanUseRemotionHooksProvider>
-					<MaybeTimelineProvider>
+					<MaybeTimelineProvider timelineContext={timelineContext}>
 						<MaybePlaybackRateProvider>
 							<SequenceManagerProvider>
-								<CompositionManager.Provider value={mockCompositionContext}>
+								<CompositionManager.Provider value={compositionContext}>
 									{children}
 								</CompositionManager.Provider>
 							</SequenceManagerProvider>

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -4,7 +4,6 @@ import {
 	Interactive,
 	Sequence,
 	useRemotionEnvironment,
-	useVideoConfig,
 	type EffectsProp,
 	type InteractiveBaseProps,
 	type InteractiveTransformProps,
@@ -65,8 +64,6 @@ const GifInner = ({
 	readonly ref?: React.Ref<HTMLCanvasElement>;
 }) => {
 	const env = useRemotionEnvironment();
-	const {durationInFrames: videoDuration} = useVideoConfig();
-	const resolvedDuration = durationInFrames ?? videoDuration;
 	const refForOutline = React.useRef<HTMLElement | null>(null);
 
 	const memoizedEffectDefinitions = useMemoizedEffectDefinitions(effects);
@@ -102,7 +99,7 @@ const GifInner = ({
 	return (
 		<Sequence
 			layout="none"
-			durationInFrames={resolvedDuration}
+			durationInFrames={durationInFrames}
 			name="<Gif>"
 			_remotionInternalDocumentationLink="https://www.remotion.dev/docs/gif/gif"
 			controls={controls}

--- a/packages/gif/src/test/Gif.test.tsx
+++ b/packages/gif/src/test/Gif.test.tsx
@@ -112,7 +112,8 @@ const logContext = {
 const SequenceRegistrationWrapper: React.FC<{
 	readonly children: React.ReactNode;
 	readonly onRegisterSequence: (sequence: RegisteredSequence) => void;
-}> = ({children, onRegisterSequence}) => {
+	readonly currentFrame?: number;
+}> = ({children, onRegisterSequence, currentFrame = 0}) => {
 	const registerSequence = useCallback(
 		(sequence: RegisteredSequence) => {
 			onRegisterSequence(sequence);
@@ -129,13 +130,19 @@ const SequenceRegistrationWrapper: React.FC<{
 			}) as React.ContextType<typeof Internals.SequenceManager>,
 		[registerSequence, unregisterSequence],
 	);
+	const currentTimelineContext = useMemo(
+		() => ({...timelineContext, frame: {comp: currentFrame}}),
+		[currentFrame],
+	);
 
 	return (
 		<Internals.LogLevelContext.Provider value={logContext}>
 			<Internals.BufferingProvider>
 				<Internals.CanUseRemotionHooksProvider>
-					<Internals.AbsoluteTimeContext.Provider value={timelineContext}>
-						<Internals.TimelineContext.Provider value={timelineContext}>
+					<Internals.AbsoluteTimeContext.Provider
+						value={currentTimelineContext}
+					>
+						<Internals.TimelineContext.Provider value={currentTimelineContext}>
 							<Internals.PlaybackRateContext.Provider
 								value={playbackRateContext}
 							>
@@ -206,6 +213,19 @@ test('<Gif> registers its canvas as the outline ref', async () => {
 	const refForOutline = registeredSequences[0]
 		.refForOutline as React.RefObject<HTMLCanvasElement | null>;
 	expect(ref.current).toBe(refForOutline.current);
+});
+
+test('<Gif> remains visible with a negative offset', () => {
+	const {container} = render(
+		<SequenceRegistrationWrapper
+			currentFrame={75}
+			onRegisterSequence={() => undefined}
+		>
+			<Gif from={-100} src="test.gif" />
+		</SequenceRegistrationWrapper>,
+	);
+
+	expect(container.querySelector('canvas')).not.toBeNull();
 });
 
 test('reuses a cached GIF without spawning a decode worker', async () => {


### PR DESCRIPTION
## Summary

- preserve omitted durations for `HtmlInCanvas`, fixing negatively offset shapes that use effects
- apply the same unbounded default to `AnimatedImage` and `Gif`
- add regression coverage for all three components at negative offsets

## Validation

- `bun test src/test/html-in-canvas.test.tsx src/test/sequence-register-once.test.tsx` in `packages/core`
- `bun test src/test/Gif.test.tsx` in `packages/gif`
- `bun run build`
- `bun run stylecheck`

Closes #9296
