### PR TITLE
`remotion`: Fix AnimatedImage playback rate

### DIFF
--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -29,6 +29,7 @@ import type {AnimatedImageCanvasRef} from './canvas';
 import {Canvas} from './canvas';
 import type {RemotionImageDecoder} from './decode-image.js';
 import {decodeImage} from './decode-image.js';
+import {getCurrentTime} from './get-current-time.js';
 import type {
 	AnimatedImageCanvasProps,
 	AnimatedImageProps,
@@ -112,7 +113,7 @@ const AnimatedImageContent = forwardRef<
 
 		const frame = useCurrentFrame();
 		const {fps} = useVideoConfig();
-		const currentTime = frame / playbackRate / fps;
+		const currentTime = getCurrentTime({frame, playbackRate, fps});
 		const currentTimeRef = useRef<number>(currentTime);
 		currentTimeRef.current = currentTime;
 		const requestInitKey = serializeRequestInit(requestInit);

--- a/packages/core/src/animated-image/get-current-time.ts
+++ b/packages/core/src/animated-image/get-current-time.ts
@@ -1,0 +1,11 @@
+export const getCurrentTime = ({
+	frame,
+	playbackRate,
+	fps,
+}: {
+	frame: number;
+	playbackRate: number;
+	fps: number;
+}) => {
+	return (frame * playbackRate) / fps;
+};

--- a/packages/core/src/test/animated-image-playback-rate.test.ts
+++ b/packages/core/src/test/animated-image-playback-rate.test.ts
@@ -1,0 +1,8 @@
+import {expect, test} from 'bun:test';
+import {getCurrentTime} from '../animated-image/get-current-time.js';
+
+test('calculates the current time using the playback rate', () => {
+	expect(getCurrentTime({frame: 30, playbackRate: 1, fps: 30})).toBe(1);
+	expect(getCurrentTime({frame: 30, playbackRate: 2, fps: 30})).toBe(2);
+	expect(getCurrentTime({frame: 30, playbackRate: 0.5, fps: 30})).toBe(0.5);
+});


### PR DESCRIPTION
## Summary

- Make `AnimatedImage` advance media time according to the standard playback-rate convention
- Add regression coverage for normal, faster, and slower playback rates

## Tests

- `bun run build`
- `bun run stylecheck`
- `cd packages/core && bun run test`

Closes https://github.com/remotion-dev/remotion/issues/9304
