### PR TITLE
`@remotion/studio`: Align matching assets on drop

### DIFF
--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1078,6 +1078,8 @@ export const Canvas: React.FC<{
 						files,
 						compositionFile,
 						compositionId: currentCompositionId,
+						destinationDimensions:
+							contentDimensions === 'none' ? null : contentDimensions,
 						dropPosition,
 					});
 				} else if (isAssetDragEvent(event)) {
@@ -1090,6 +1092,8 @@ export const Canvas: React.FC<{
 						assetPaths: [assetPath],
 						compositionFile,
 						compositionId: currentCompositionId,
+						destinationDimensions:
+							contentDimensions === 'none' ? null : contentDimensions,
 						dropPosition,
 					});
 				} else if (isSfxDragEvent(event)) {
@@ -1149,6 +1153,8 @@ export const Canvas: React.FC<{
 						url,
 						compositionFile,
 						compositionId: currentCompositionId,
+						destinationDimensions:
+							contentDimensions === 'none' ? null : contentDimensions,
 						dropPosition,
 					});
 				}

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -162,6 +162,7 @@ const TimelineContextMenuArea: React.FC<{
 				files,
 				compositionFile,
 				compositionId: currentCompositionId,
+				destinationDimensions: null,
 				dropPosition: null,
 			});
 		} finally {

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -305,6 +305,27 @@ export const getCompositionPositionForDrop = ({
 	});
 };
 
+export const getAssetPositionForDrop = ({
+	assetDimensions,
+	destinationDimensions,
+	dropPosition,
+}: {
+	assetDimensions: Dimensions | null;
+	destinationDimensions: Dimensions | null;
+	dropPosition: InsertElementDropPosition | null;
+}): InsertableCompositionElementPosition | null => {
+	if (
+		assetDimensions !== null &&
+		destinationDimensions !== null &&
+		assetDimensions.width === destinationDimensions.width &&
+		assetDimensions.height === destinationDimensions.height
+	) {
+		return null;
+	}
+
+	return getCenteredPosition({dimensions: assetDimensions, dropPosition});
+};
+
 const getComponentPropNumber = (props: ComponentProp[], name: string) => {
 	const prop = props.find((p) => p.name === name);
 	return typeof prop?.value === 'number' ? prop.value : null;
@@ -596,11 +617,13 @@ const downloadRemoteAsset = (
 export const importAssets = async ({
 	compositionFile,
 	compositionId,
+	destinationDimensions,
 	dropPosition,
 	files,
 }: {
 	compositionFile: string;
 	compositionId: string;
+	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
 	files: File[];
 }) => {
@@ -669,15 +692,17 @@ export const importAssets = async ({
 			}
 
 			const dimensions = await getFileDimensionsOrNull({file, fileType});
+			const resolvedDimensions = element.dimensions ?? dimensions;
 
 			const inserted = await insertAssetElement({
 				compositionFile,
 				compositionId,
 				element: {
 					...element,
-					dimensions: element.dimensions ?? dimensions,
-					position: getCenteredPosition({
-						dimensions,
+					dimensions: resolvedDimensions,
+					position: getAssetPositionForDrop({
+						assetDimensions: resolvedDimensions,
+						destinationDimensions,
 						dropPosition,
 					}),
 				},
@@ -707,11 +732,13 @@ export const importAssets = async ({
 export const importRemoteAsset = async ({
 	compositionFile,
 	compositionId,
+	destinationDimensions,
 	dropPosition,
 	url,
 }: {
 	compositionFile: string;
 	compositionId: string;
+	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
 	url: string;
 }) => {
@@ -732,8 +759,9 @@ export const importRemoteAsset = async ({
 			compositionId,
 			element: {
 				...element,
-				position: getCenteredPosition({
-					dimensions: element.dimensions,
+				position: getAssetPositionForDrop({
+					assetDimensions: element.dimensions,
+					destinationDimensions,
 					dropPosition,
 				}),
 			},
@@ -803,11 +831,13 @@ export const insertExistingAssets = async ({
 	assetPaths,
 	compositionFile,
 	compositionId,
+	destinationDimensions,
 	dropPosition,
 }: {
 	assetPaths: string[];
 	compositionFile: string;
 	compositionId: string;
+	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
 }) => {
 	if (assetPaths.length === 0) {
@@ -834,8 +864,9 @@ export const insertExistingAssets = async ({
 				element: {
 					...element,
 					dimensions,
-					position: getCenteredPosition({
-						dimensions,
+					position: getAssetPositionForDrop({
+						assetDimensions: dimensions,
+						destinationDimensions,
 						dropPosition,
 					}),
 				},

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from 'bun:test';
 import {
+	getAssetPositionForDrop,
 	getAssetElement,
 	getAssetElementForDroppedFile,
 	getAssetElementFromPath,
@@ -237,6 +238,26 @@ test('centers a composition with different destination dimensions', () => {
 	expect(
 		getCompositionPositionForDrop({
 			compositionDimensions: {width: 1280, height: 720},
+			destinationDimensions: {width: 1920, height: 1080},
+			dropPosition: {centerX: 400, centerY: 300},
+		}),
+	).toEqual({x: -240, y: -60});
+});
+
+test('aligns an asset with matching destination dimensions', () => {
+	expect(
+		getAssetPositionForDrop({
+			assetDimensions: {width: 1920, height: 1080},
+			destinationDimensions: {width: 1920, height: 1080},
+			dropPosition: {centerX: 400, centerY: 300},
+		}),
+	).toBe(null);
+});
+
+test('centers an asset with different destination dimensions', () => {
+	expect(
+		getAssetPositionForDrop({
+			assetDimensions: {width: 1280, height: 720},
 			destinationDimensions: {width: 1920, height: 1080},
 			dropPosition: {centerX: 400, centerY: 300},
 		}),


### PR DESCRIPTION
## Summary

- align dropped media assets to the composition origin when their dimensions match
- preserve pointer-centered placement for differently sized assets
- cover local files, existing assets, and downloaded remote assets

## Testing

- `bun test packages/studio/src/test/import-assets.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9245
