### PR TITLE
`remotion`: Preserve Sequence opacity while active

### DIFF
--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -612,7 +612,8 @@ const PremountedPostmountedSequenceRefForwardingFunction: React.ForwardRefRender
 	const style = useMemo(() => {
 		return {
 			...passedStyle,
-			opacity: premountingActive || postmountingActive ? 0 : 1,
+			opacity:
+				premountingActive || postmountingActive ? 0 : passedStyle?.opacity,
 			pointerEvents:
 				premountingActive || postmountingActive
 					? 'none'

--- a/packages/core/src/test/sequence-premounting.test.tsx
+++ b/packages/core/src/test/sequence-premounting.test.tsx
@@ -1,0 +1,72 @@
+import {afterEach, expect, test} from 'bun:test';
+import {cleanup, render} from '@testing-library/react';
+import type {ReactNode} from 'react';
+import {Internals} from '../internals.js';
+import {Sequence} from '../Sequence.js';
+import {WrapSequenceContext} from './wrap-sequence-context.js';
+
+afterEach(() => {
+	cleanup();
+});
+
+const NonRenderingEnvironment = ({
+	children,
+}: {
+	readonly children: ReactNode;
+}) => {
+	return (
+		<Internals.RemotionEnvironmentContext
+			value={{
+				isRendering: false,
+				isClientSideRendering: false,
+				isPlayer: true,
+				isStudio: false,
+				isReadOnlyStudio: false,
+			}}
+		>
+			{children}
+		</Internals.RemotionEnvironmentContext>
+	);
+};
+
+test('preserves the Sequence opacity while it is active', () => {
+	const {container} = render(
+		<WrapSequenceContext currentFrame={10}>
+			<NonRenderingEnvironment>
+				<Sequence
+					from={10}
+					durationInFrames={20}
+					premountFor={10}
+					style={{opacity: 0.5}}
+				>
+					Content
+				</Sequence>
+			</NonRenderingEnvironment>
+		</WrapSequenceContext>,
+	);
+
+	expect(container.firstElementChild?.getAttribute('style')).toContain(
+		'opacity: 0.5',
+	);
+});
+
+test('hides a Sequence while it is premounted', () => {
+	const {container} = render(
+		<WrapSequenceContext currentFrame={0}>
+			<NonRenderingEnvironment>
+				<Sequence
+					from={10}
+					durationInFrames={20}
+					premountFor={10}
+					style={{opacity: 0.5}}
+				>
+					Content
+				</Sequence>
+			</NonRenderingEnvironment>
+		</WrapSequenceContext>,
+	);
+
+	expect(container.firstElementChild?.getAttribute('style')).toContain(
+		'opacity: 0',
+	);
+});


### PR DESCRIPTION
## Summary

- preserve a `Sequence`'s configured opacity during its active frames
- continue forcing opacity to zero while the sequence is premounted or postmounted
- add regression tests for active and premounted states

## Tests

- `bun test src/test` in `packages/core`
- `bun run build`
- `bun run stylecheck`
