### PR TITLE
`@remotion/cli`: Fix Mediabunny extension upgrades

### DIFF
--- a/packages/cli/src/test/upgrade-protocols.test.ts
+++ b/packages/cli/src/test/upgrade-protocols.test.ts
@@ -7,7 +7,7 @@ import {
 	isCatalogProtocol,
 	updateCatalogEntry,
 } from '../catalog-utils';
-import {getPackagesToUpgrade} from '../upgrade';
+import {getPackagesToUpgrade, resolveExtraPackageVersions} from '../upgrade';
 
 let tmpDir: string;
 
@@ -143,6 +143,23 @@ test('includes Remotion and extra packages that only exist in pnpm catalog entri
 		{pkg: '@remotion/player', version: '4.0.462'},
 		{pkg: 'mediabunny', version: '1.50.7'},
 	]);
+});
+
+test('uses the Mediabunny version for extension packages', () => {
+	expect(
+		resolveExtraPackageVersions({
+			mediabunny: '1.50.8',
+			zod: '4.3.6',
+		}),
+	).toMatchObject({
+		mediabunny: '1.50.8',
+		'@mediabunny/ac3': '1.50.8',
+		'@mediabunny/mp3-encoder': '1.50.8',
+		'@mediabunny/aac-encoder': '1.50.8',
+		'@mediabunny/flac-encoder': '1.50.8',
+		'@mediabunny/prores': '1.50.8',
+		zod: '4.3.6',
+	});
 });
 
 test('end-to-end: updates catalog in bun-style package.json and preserves catalog: references in sub-packages', () => {

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -13,6 +13,22 @@ import {EXTRA_PACKAGES} from './extra-packages';
 import {listOfRemotionPackages} from './list-of-remotion-packages';
 import {Log} from './log';
 
+export const resolveExtraPackageVersions = (
+	dependencies: Record<string, string>,
+): Record<string, string> => {
+	const extraVersions = {...EXTRA_PACKAGES};
+
+	for (const pkg of Object.keys(EXTRA_PACKAGES)) {
+		if (dependencies[pkg]) {
+			extraVersions[pkg] = dependencies[pkg];
+		} else if (pkg.startsWith('@mediabunny/') && dependencies.mediabunny) {
+			extraVersions[pkg] = dependencies.mediabunny;
+		}
+	}
+
+	return extraVersions;
+};
+
 const getExtraPackageVersionsForRemotionVersion = (
 	remotionVersion: string,
 ): Record<string, string> => {
@@ -23,14 +39,7 @@ const getExtraPackageVersionsForRemotionVersion = (
 		);
 		const dependencies = JSON.parse(output) as Record<string, string>;
 
-		const extraVersions: Record<string, string> = {};
-		for (const pkg of Object.keys(EXTRA_PACKAGES)) {
-			if (dependencies[pkg]) {
-				extraVersions[pkg] = dependencies[pkg];
-			}
-		}
-
-		return extraVersions;
+		return resolveExtraPackageVersions(dependencies);
 	} catch {
 		// If we can't fetch the versions, return the default versions from EXTRA_PACKAGES
 		return EXTRA_PACKAGES;
@@ -81,7 +90,8 @@ export const getPackagesToUpgrade = ({
 
 	for (const pkg of allPackagesToUpgrade) {
 		const versionSpec = findVersionSpecifier(depsWithVersions, pkg);
-		const targetVersionForPkg = extraPackageVersions[pkg] ?? targetVersion;
+		const targetVersionForPkg =
+			extraPackageVersions[pkg] ?? EXTRA_PACKAGES[pkg] ?? targetVersion;
 
 		if (
 			(versionSpec && isCatalogProtocol(versionSpec)) ||


### PR DESCRIPTION
## Summary

- resolve Mediabunny extension packages from the target release's published `mediabunny` version
- keep catalog versions as a fallback instead of using the Remotion version
- cover ProRes, AC-3, and encoder extensions with a regression test

## Tests

- `bun test packages/cli/src/test/upgrade-protocols.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9311
