### PR TITLE
`@remotion/convert`: Seek when adjusting trim points

### DIFF
--- a/packages/convert/app/components/MediaPlayer.tsx
+++ b/packages/convert/app/components/MediaPlayer.tsx
@@ -131,6 +131,7 @@ export function VideoPlayer({
 }) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const playerRef = useRef<PlayerRef>(null);
+	const trimFrameToSeekRef = useRef<number | null>(null);
 	const videoSourceUrl = useVideoSourceUrl(source);
 
 	const playerFps = getPlayerFps(fps);
@@ -183,6 +184,16 @@ export function VideoPlayer({
 			current.removeEventListener('seeked', onFrameChange);
 		};
 	}, [onPlaybackTimeChange, playerFps, videoSourceUrl]);
+
+	useEffect(() => {
+		const frameToSeek = trimFrameToSeekRef.current;
+		if (frameToSeek === null) {
+			return;
+		}
+
+		trimFrameToSeekRef.current = null;
+		playerRef.current?.seekTo(frameToSeek);
+	}, [trimInFrame, trimOutFrame]);
 
 	return (
 		<div
@@ -253,7 +264,8 @@ export function VideoPlayer({
 					durationInFrames={durationInFrames}
 					inFrame={trimInFrame}
 					outFrame={trimOutFrame}
-					onTrim={(nextTrim) => {
+					onTrim={(nextTrim, seekToFrame) => {
+						trimFrameToSeekRef.current = seekToFrame;
 						setTrimInFrame(nextTrim.inFrame);
 						setTrimOutFrame(nextTrim.outFrame);
 					}}

--- a/packages/convert/app/components/player/filmstrip.tsx
+++ b/packages/convert/app/components/player/filmstrip.tsx
@@ -184,10 +184,13 @@ export const Filmstrip: React.FC<{
 	readonly durationInFrames: number;
 	readonly inFrame: number | null;
 	readonly outFrame: number | null;
-	readonly onTrim: (trim: {
-		inFrame: number | null;
-		outFrame: number | null;
-	}) => void;
+	readonly onTrim: (
+		trim: {
+			inFrame: number | null;
+			outFrame: number | null;
+		},
+		seekToFrame: number,
+	) => void;
 }> = ({
 	src,
 	durationInSeconds,
@@ -222,7 +225,10 @@ export const Filmstrip: React.FC<{
 		const maxInFrame = currentOutFrame - minimumFrameDistance;
 		const nextInFrame = clamp(frame, 0, maxInFrame);
 
-		onTrim({inFrame: nextInFrame === 0 ? null : nextInFrame, outFrame});
+		onTrim(
+			{inFrame: nextInFrame === 0 ? null : nextInFrame, outFrame},
+			nextInFrame,
+		);
 	};
 
 	const setOutFrameFromPointer = (clientX: number) => {
@@ -240,24 +246,33 @@ export const Filmstrip: React.FC<{
 		const minOutFrame = currentInFrame + minimumFrameDistance;
 		const nextOutFrame = clamp(frame, minOutFrame, durationInFrames - 1);
 
-		onTrim({
-			inFrame,
-			outFrame: nextOutFrame === durationInFrames - 1 ? null : nextOutFrame,
-		});
+		onTrim(
+			{
+				inFrame,
+				outFrame: nextOutFrame === durationInFrames - 1 ? null : nextOutFrame,
+			},
+			nextOutFrame,
+		);
 	};
 
 	const setInFrame = (frame: number) => {
-		onTrim({
-			inFrame: frame === 0 ? null : frame,
-			outFrame,
-		});
+		onTrim(
+			{
+				inFrame: frame === 0 ? null : frame,
+				outFrame,
+			},
+			frame,
+		);
 	};
 
 	const setOutFrame = (frame: number) => {
-		onTrim({
-			inFrame,
-			outFrame: frame === durationInFrames - 1 ? null : frame,
-		});
+		onTrim(
+			{
+				inFrame,
+				outFrame: frame === durationInFrames - 1 ? null : frame,
+			},
+			frame,
+		);
 	};
 
 	const moveInFrame = (delta: number) => {


### PR DESCRIPTION
## Summary

- seek the Convert preview to the start trim point while adjusting the start handle
- seek the preview to the end trim point while adjusting the end handle
- apply the same behavior to dragging, keyboard controls, and the plus/minus buttons

## Verification

- `bunx turbo run lint test --filter='@remotion/convert'`
- `bun run build`
- `bun run stylecheck`

Closes #9309
