### PR TITLE
`@remotion/studio`: Open existing render output

### DIFF
--- a/packages/studio/src/components/NewComposition/ValidationMessage.tsx
+++ b/packages/studio/src/components/NewComposition/ValidationMessage.tsx
@@ -50,7 +50,7 @@ const compactLabel: React.CSSProperties = {
 type ValidationMessageSize = 'default' | 'compact';
 
 export const ValidationMessage: React.FC<{
-	readonly message: string;
+	readonly message: React.ReactNode;
 	readonly align: 'flex-start' | 'flex-end';
 	readonly type: 'warning' | 'error';
 	readonly action?: React.ReactNode;

--- a/packages/studio/src/components/RenderModal/RenderModalOutputName.tsx
+++ b/packages/studio/src/components/RenderModal/RenderModalOutputName.tsx
@@ -1,8 +1,32 @@
-import React from 'react';
+import React, {useCallback} from 'react';
+import {WHITE} from '../../helpers/colors';
+import {getFileManagerName} from '../../helpers/get-file-manager-name';
+import {ExpandedFolderIconSolid} from '../../icons/folder';
+import type {RenderInlineAction} from '../InlineAction';
+import {InlineAction} from '../InlineAction';
 import {Column, Spacing} from '../layout';
 import {RemotionInput} from '../NewComposition/RemInput';
 import {ValidationMessage} from '../NewComposition/ValidationMessage';
+import {showNotification} from '../Notifications/NotificationCenter';
+import {openInFileExplorer} from '../RenderQueue/actions';
 import {label, optionRow, rightRow} from './layout';
+
+const existsMessageStyle: React.CSSProperties = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	minWidth: 0,
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	lineHeight: '18px',
+	color: WHITE,
+	whiteSpace: 'nowrap',
+};
+
+const openIconStyle: React.CSSProperties = {
+	width: 12,
+	height: 12,
+	flexShrink: 0,
+};
 
 type Props = {
 	readonly existence: boolean;
@@ -21,6 +45,20 @@ export const RenderModalOutputName = ({
 	validationMessage,
 	label: labelText,
 }: Props) => {
+	const openExistingOutput = useCallback(() => {
+		openInFileExplorer({directory: outName}).catch((err) => {
+			showNotification(`Could not open file: ${err.message}`, 2000);
+		});
+	}, [outName]);
+
+	const renderOpenIcon: RenderInlineAction = useCallback((color) => {
+		return <ExpandedFolderIconSolid style={openIconStyle} color={color} />;
+	}, []);
+
+	const fileManagerName = getFileManagerName(
+		window.remotion_fileSystemPlatform,
+	);
+
 	return (
 		<div style={optionRow}>
 			<Column>
@@ -50,7 +88,16 @@ export const RenderModalOutputName = ({
 							<Spacing y={1} block />
 							<ValidationMessage
 								align="flex-end"
-								message="Will be overwritten"
+								message={
+									<span style={existsMessageStyle}>
+										<InlineAction
+											onClick={openExistingOutput}
+											renderAction={renderOpenIcon}
+											title={`Open in ${fileManagerName}`}
+										/>
+										Exists, will be overwritten
+									</span>
+								}
 								type={'warning'}
 							/>
 						</>


### PR DESCRIPTION
## Summary

- indicate when a render output already exists
- add an inline action to reveal the existing output in the system file manager
- keep the nested Studio label styles explicit under the global CSS reset

## Verification

- `bun run build`
- `bun run stylecheck`

Closes #9241
