### PR TITLE
`@remotion/studio`: Show image metadata in asset inspector

### DIFF
--- a/packages/studio/src/components/CurrentAsset.tsx
+++ b/packages/studio/src/components/CurrentAsset.tsx
@@ -8,6 +8,7 @@ import {
 	renderHumanReadableAudioCodec,
 	renderHumanReadableVideoCodec,
 } from '../helpers/render-codec-label';
+import {useImageMetadata} from '../helpers/use-image-metadata';
 import type {MediaMetadata} from '../helpers/use-media-metadata';
 import {useMediaMetadata} from '../helpers/use-media-metadata';
 import {InlineEditableTitle} from './InlineEditableTitle';
@@ -31,6 +32,18 @@ export const getCurrentAssetMetadataSource = (assetName: string | null) => {
 
 	const fileType = getPreviewFileType(assetName);
 	return fileType === 'audio' || fileType === 'video'
+		? staticFile(assetName)
+		: null;
+};
+
+export const getCurrentAssetImageMetadataSource = (
+	assetName: string | null,
+) => {
+	if (!assetName) {
+		return null;
+	}
+
+	return getPreviewFileType(assetName) === 'image'
 		? staticFile(assetName)
 		: null;
 };
@@ -101,6 +114,8 @@ export const AssetInfo: React.FC<{
 
 	const src = getCurrentAssetMetadataSource(assetName);
 	const mediaMetadata = useMediaMetadata(src);
+	const imageSrc = getCurrentAssetImageMetadataSource(assetName);
+	const imageMetadata = useImageMetadata(imageSrc);
 	const canRename =
 		onAssetClick === undefined &&
 		connectionStatus === 'connected' &&
@@ -131,6 +146,9 @@ export const AssetInfo: React.FC<{
 		if (mediaMetadata.width !== null && mediaMetadata.height !== null) {
 			subtitleParts.push(`${mediaMetadata.width}x${mediaMetadata.height}`);
 		}
+	} else if (imageMetadata) {
+		subtitleParts.push(imageMetadata.format);
+		subtitleParts.push(`${imageMetadata.width}x${imageMetadata.height}`);
 	}
 
 	const mediaDetailLines = mediaMetadata

--- a/packages/studio/src/helpers/get-preview-file-type.ts
+++ b/packages/studio/src/helpers/get-preview-file-type.ts
@@ -13,7 +13,7 @@ export const getPreviewFileType = (fileName: string | null): AssetFileType => {
 
 	const audioExtensions = ['mp3', 'wav', 'ogg', 'aac'];
 	const videoExtensions = ['mp4', 'avi', 'mkv', 'mov', 'webm'];
-	const imageExtensions = ['jpg', 'jpeg', 'png', 'apng', 'gif', 'bmp'];
+	const imageExtensions = ['jpg', 'jpeg', 'png', 'apng', 'gif', 'bmp', 'webp'];
 
 	const fileExtension = fileName.split('.').pop()?.toLowerCase();
 	if (fileExtension === undefined) {

--- a/packages/studio/src/helpers/use-image-metadata.ts
+++ b/packages/studio/src/helpers/use-image-metadata.ts
@@ -1,0 +1,112 @@
+import {
+	detectFileType,
+	isImageFileType,
+	type ImageFileType,
+} from '@remotion/studio-shared';
+import {useEffect, useState} from 'react';
+
+export type ImageMetadata = {
+	readonly format: string;
+	readonly width: number;
+	readonly height: number;
+};
+
+const cache = new Map<string, ImageMetadata>();
+const pendingRequests = new Map<string, Promise<ImageMetadata | null>>();
+
+const formatImageType = (fileType: ImageFileType['type']) => {
+	if (fileType === 'webp') {
+		return 'WebP';
+	}
+
+	return fileType.toUpperCase();
+};
+
+export const getImageMetadataFromData = (
+	data: Uint8Array,
+): ImageMetadata | null => {
+	const fileType = detectFileType(data);
+
+	if (!isImageFileType(fileType) || fileType.dimensions === null) {
+		return null;
+	}
+
+	return {
+		format: formatImageType(fileType.type),
+		width: fileType.dimensions.width,
+		height: fileType.dimensions.height,
+	};
+};
+
+export const getImageMetadata = (
+	src: string,
+): Promise<ImageMetadata | null> => {
+	const cached = cache.get(src);
+
+	if (cached) {
+		return Promise.resolve(cached);
+	}
+
+	const pendingRequest = pendingRequests.get(src);
+
+	if (pendingRequest) {
+		return pendingRequest;
+	}
+
+	const request = fetch(src)
+		.then((response) => {
+			if (!response.ok) {
+				return null;
+			}
+
+			return response.arrayBuffer();
+		})
+		.then((data) => {
+			if (data === null) {
+				return null;
+			}
+
+			const metadata = getImageMetadataFromData(new Uint8Array(data));
+			if (metadata) {
+				cache.set(src, metadata);
+			}
+
+			return metadata;
+		})
+		.catch(() => null)
+		.finally(() => {
+			pendingRequests.delete(src);
+		});
+
+	pendingRequests.set(src, request);
+	return request;
+};
+
+export const useImageMetadata = (src: string | null): ImageMetadata | null => {
+	const [imageMetadata, setImageMetadata] = useState<ImageMetadata | null>(
+		src ? (cache.get(src) ?? null) : null,
+	);
+
+	useEffect(() => {
+		const cached = src ? (cache.get(src) ?? null) : null;
+		setImageMetadata(cached);
+
+		if (!src || cached) {
+			return;
+		}
+
+		let cancelled = false;
+
+		getImageMetadata(src).then((metadata) => {
+			if (!cancelled) {
+				setImageMetadata(metadata);
+			}
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [src]);
+
+	return imageMetadata;
+};

--- a/packages/studio/src/test/current-asset.test.ts
+++ b/packages/studio/src/test/current-asset.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
 import {
 	getCurrentAssetMediaDetailLines,
+	getCurrentAssetImageMetadataSource,
 	getCurrentAssetMetadataSource,
 } from '../components/CurrentAsset';
 import {
@@ -8,6 +9,17 @@ import {
 	getStaticFileRenameSelection,
 	validateStaticFileRename,
 } from '../components/NewComposition/use-rename-static-file';
+
+test('requests image metadata for image assets', () => {
+	expect(getCurrentAssetImageMetadataSource('1.jpg')).toBe('/1.jpg');
+	expect(getCurrentAssetImageMetadataSource('nested/file.png')).toBe(
+		'/nested/file.png',
+	);
+	expect(getCurrentAssetImageMetadataSource('animation.gif')).toBe(
+		'/animation.gif',
+	);
+	expect(getCurrentAssetImageMetadataSource('image.webp')).toBe('/image.webp');
+});
 
 test('does not request media metadata for image assets', () => {
 	expect(getCurrentAssetMetadataSource('1.jpg')).toBe(null);

--- a/packages/studio/src/test/image-metadata.test.ts
+++ b/packages/studio/src/test/image-metadata.test.ts
@@ -1,0 +1,19 @@
+import {expect, test} from 'bun:test';
+import {getImageMetadataFromData} from '../helpers/use-image-metadata';
+
+test('gets PNG format and dimensions', () => {
+	const png = new Uint8Array(24);
+	png.set([0x89, 0x50, 0x4e, 0x47, 13, 10, 26, 10], 0);
+	png.set([0, 0, 7, 128], 16);
+	png.set([0, 0, 4, 56], 20);
+
+	expect(getImageMetadataFromData(png)).toEqual({
+		format: 'PNG',
+		width: 1920,
+		height: 1080,
+	});
+});
+
+test('returns null for non-image data', () => {
+	expect(getImageMetadataFromData(new Uint8Array([1, 2, 3, 4]))).toBe(null);
+});


### PR DESCRIPTION
## Summary

- show image format and pixel dimensions in the Asset Inspector
- detect metadata from image bytes for PNG, APNG, JPEG, GIF, BMP, and WebP
- recognize WebP assets as image previews

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run formatting lint test --filter=@remotion/studio`

Closes #9259
