### PR TITLE
`@remotion/studio`: Reject invalid playback rate values

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -82,6 +82,24 @@ export const deriveInputDraggerDragStartValue = ({
 	return 0;
 };
 
+export const isInputDraggerValueInRange = ({
+	max,
+	min,
+	value,
+}: {
+	readonly max: React.InputHTMLAttributes<HTMLInputElement>['max'];
+	readonly min: React.InputHTMLAttributes<HTMLInputElement>['min'];
+	readonly value: number;
+}) => {
+	const numericMin = Number(min);
+	const numericMax = Number(max);
+
+	return (
+		(!Number.isFinite(numericMin) || value >= numericMin) &&
+		(!Number.isFinite(numericMax) || value <= numericMax)
+	);
+};
+
 const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 	HTMLButtonElement,
 	Props
@@ -170,11 +188,19 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 	const onInputChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
 		(e) => {
 			const parsed = Number(e.target.value);
-			if (e.target.value !== '' && !Number.isNaN(parsed)) {
+			if (
+				e.target.value !== '' &&
+				!Number.isNaN(parsed) &&
+				isInputDraggerValueInRange({
+					max: _max,
+					min: _min,
+					value: parsed,
+				})
+			) {
 				onValueChange(parsed);
 			}
 		},
-		[onValueChange],
+		[_max, _min, onValueChange],
 	);
 
 	const onBlur = useCallback(() => {

--- a/packages/studio/src/test/input-dragger.test.ts
+++ b/packages/studio/src/test/input-dragger.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'bun:test';
 import {
 	deriveInputDraggerDragStartValue,
 	deriveInputDraggerStep,
+	isInputDraggerValueInRange,
 } from '../components/NewComposition/InputDragger';
 
 test('deriveInputDraggerStep disables HTML step validation if snapping is disabled', () => {
@@ -45,4 +46,30 @@ test('deriveInputDraggerDragStartValue falls back to a finite start value', () =
 			value: 24,
 		}),
 	).toBe(24);
+});
+
+test('live input values must be within the configured range', () => {
+	expect(
+		isInputDraggerValueInRange({
+			max: Infinity,
+			min: 0.1,
+			value: 0,
+		}),
+	).toBe(false);
+
+	expect(
+		isInputDraggerValueInRange({
+			max: Infinity,
+			min: 0.1,
+			value: 0.1,
+		}),
+	).toBe(true);
+
+	expect(
+		isInputDraggerValueInRange({
+			max: 10,
+			min: -Infinity,
+			value: 11,
+		}),
+	).toBe(false);
 });


### PR DESCRIPTION
## Summary

- prevent out-of-range numeric inspector values from being applied during live text entry
- keep invalid values in the input so the browser can report the existing range validation
- add regression coverage for rejecting a playback rate of `0` when the minimum is `0.1`

## Tests

- `bun test packages/studio/src/test/input-dragger.test.ts`
- `bunx turbo run lint test --filter=@remotion/studio`
- `bun run build`
- `bun run stylecheck`

Closes #9310
