### PR TITLE
`remotion`: Remove text controls from SVG elements

### DIFF
--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -139,6 +139,10 @@ const makeRemotionComponentIdentity = ({
 const interactiveElementSchema = {
 	...baseSchema,
 	...transformSchema,
+} as const satisfies InteractivitySchema;
+
+const interactiveTextElementSchema = {
+	...interactiveElementSchema,
 	...textSchema,
 	...textContentSchema,
 } as const satisfies InteractivitySchema;
@@ -166,6 +170,7 @@ const withSchema = <S extends InteractivitySchema, Props extends object>(
 const makeInteractiveElement = <Tag extends InteractiveTag>(
 	tag: Tag,
 	displayName: string,
+	schema: InteractivitySchema,
 ): InteractiveElementComponent<Tag> => {
 	type ElementType = ElementForTag<Tag>;
 	type Props = InteractiveElementProps<Tag>;
@@ -231,13 +236,27 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 			packageName: 'remotion',
 			componentName: displayName.slice(1, -1),
 		}),
-		schema: interactiveElementSchema,
+		schema,
 		supportsEffects: false,
 	}) as InteractiveElementComponent<Tag>;
 
 	Wrapped.displayName = displayName;
 
 	return Wrapped;
+};
+
+const makeInteractiveTextElement = <Tag extends InteractiveTag>(
+	tag: Tag,
+	displayName: string,
+) => {
+	return makeInteractiveElement(tag, displayName, interactiveTextElementSchema);
+};
+
+const makeInteractiveNonTextElement = <Tag extends InteractiveTag>(
+	tag: Tag,
+	displayName: string,
+) => {
+	return makeInteractiveElement(tag, displayName, interactiveElementSchema);
 };
 
 /**
@@ -251,41 +270,41 @@ export const Interactive = {
 	sequenceSchema,
 	withSchema,
 	_internalMakeRemotionComponentIdentity: makeRemotionComponentIdentity,
-	A: makeInteractiveElement('a', '<Interactive.A>'),
-	Article: makeInteractiveElement('article', '<Interactive.Article>'),
-	Aside: makeInteractiveElement('aside', '<Interactive.Aside>'),
-	Button: makeInteractiveElement('button', '<Interactive.Button>'),
-	Circle: makeInteractiveElement('circle', '<Interactive.Circle>'),
-	Code: makeInteractiveElement('code', '<Interactive.Code>'),
-	Div: makeInteractiveElement('div', '<Interactive.Div>'),
-	Ellipse: makeInteractiveElement('ellipse', '<Interactive.Ellipse>'),
-	Em: makeInteractiveElement('em', '<Interactive.Em>'),
-	Footer: makeInteractiveElement('footer', '<Interactive.Footer>'),
-	G: makeInteractiveElement('g', '<Interactive.G>'),
-	H1: makeInteractiveElement('h1', '<Interactive.H1>'),
-	H2: makeInteractiveElement('h2', '<Interactive.H2>'),
-	H3: makeInteractiveElement('h3', '<Interactive.H3>'),
-	H4: makeInteractiveElement('h4', '<Interactive.H4>'),
-	H5: makeInteractiveElement('h5', '<Interactive.H5>'),
-	H6: makeInteractiveElement('h6', '<Interactive.H6>'),
-	Header: makeInteractiveElement('header', '<Interactive.Header>'),
-	Label: makeInteractiveElement('label', '<Interactive.Label>'),
-	Li: makeInteractiveElement('li', '<Interactive.Li>'),
-	Line: makeInteractiveElement('line', '<Interactive.Line>'),
-	Main: makeInteractiveElement('main', '<Interactive.Main>'),
-	Nav: makeInteractiveElement('nav', '<Interactive.Nav>'),
-	Ol: makeInteractiveElement('ol', '<Interactive.Ol>'),
-	P: makeInteractiveElement('p', '<Interactive.P>'),
-	Path: makeInteractiveElement('path', '<Interactive.Path>'),
-	Pre: makeInteractiveElement('pre', '<Interactive.Pre>'),
-	Rect: makeInteractiveElement('rect', '<Interactive.Rect>'),
-	Section: makeInteractiveElement('section', '<Interactive.Section>'),
-	Small: makeInteractiveElement('small', '<Interactive.Small>'),
-	Span: makeInteractiveElement('span', '<Interactive.Span>'),
-	Strong: makeInteractiveElement('strong', '<Interactive.Strong>'),
-	Svg: makeInteractiveElement('svg', '<Interactive.Svg>'),
-	Text: makeInteractiveElement('text', '<Interactive.Text>'),
-	Ul: makeInteractiveElement('ul', '<Interactive.Ul>'),
+	A: makeInteractiveTextElement('a', '<Interactive.A>'),
+	Article: makeInteractiveTextElement('article', '<Interactive.Article>'),
+	Aside: makeInteractiveTextElement('aside', '<Interactive.Aside>'),
+	Button: makeInteractiveTextElement('button', '<Interactive.Button>'),
+	Circle: makeInteractiveNonTextElement('circle', '<Interactive.Circle>'),
+	Code: makeInteractiveTextElement('code', '<Interactive.Code>'),
+	Div: makeInteractiveTextElement('div', '<Interactive.Div>'),
+	Ellipse: makeInteractiveNonTextElement('ellipse', '<Interactive.Ellipse>'),
+	Em: makeInteractiveTextElement('em', '<Interactive.Em>'),
+	Footer: makeInteractiveTextElement('footer', '<Interactive.Footer>'),
+	G: makeInteractiveNonTextElement('g', '<Interactive.G>'),
+	H1: makeInteractiveTextElement('h1', '<Interactive.H1>'),
+	H2: makeInteractiveTextElement('h2', '<Interactive.H2>'),
+	H3: makeInteractiveTextElement('h3', '<Interactive.H3>'),
+	H4: makeInteractiveTextElement('h4', '<Interactive.H4>'),
+	H5: makeInteractiveTextElement('h5', '<Interactive.H5>'),
+	H6: makeInteractiveTextElement('h6', '<Interactive.H6>'),
+	Header: makeInteractiveTextElement('header', '<Interactive.Header>'),
+	Label: makeInteractiveTextElement('label', '<Interactive.Label>'),
+	Li: makeInteractiveTextElement('li', '<Interactive.Li>'),
+	Line: makeInteractiveNonTextElement('line', '<Interactive.Line>'),
+	Main: makeInteractiveTextElement('main', '<Interactive.Main>'),
+	Nav: makeInteractiveTextElement('nav', '<Interactive.Nav>'),
+	Ol: makeInteractiveTextElement('ol', '<Interactive.Ol>'),
+	P: makeInteractiveTextElement('p', '<Interactive.P>'),
+	Path: makeInteractiveNonTextElement('path', '<Interactive.Path>'),
+	Pre: makeInteractiveTextElement('pre', '<Interactive.Pre>'),
+	Rect: makeInteractiveNonTextElement('rect', '<Interactive.Rect>'),
+	Section: makeInteractiveTextElement('section', '<Interactive.Section>'),
+	Small: makeInteractiveTextElement('small', '<Interactive.Small>'),
+	Span: makeInteractiveTextElement('span', '<Interactive.Span>'),
+	Strong: makeInteractiveTextElement('strong', '<Interactive.Strong>'),
+	Svg: makeInteractiveNonTextElement('svg', '<Interactive.Svg>'),
+	Text: makeInteractiveTextElement('text', '<Interactive.Text>'),
+	Ul: makeInteractiveTextElement('ul', '<Interactive.Ul>'),
 };
 
 export type InteractiveProps<Tag extends InteractiveTag> =

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -730,7 +730,15 @@ test('Interactive elements register their rendered element for Studio outlines',
 			<Interactive.Div ref={divRef}>Hello</Interactive.Div>
 			<Interactive.Span>World</Interactive.Span>
 			<Interactive.Svg viewBox="0 0 100 100">
+				<Interactive.Circle />
+				<Interactive.Ellipse />
+				<Interactive.G />
+				<Interactive.Line />
+				<Interactive.Path />
 				<Interactive.Rect width={100} height={100} />
+				<Interactive.Text x={50} y={50}>
+					Label
+				</Interactive.Text>
 			</Interactive.Svg>
 		</SequenceTestWrapper>,
 	);
@@ -738,10 +746,16 @@ test('Interactive elements register their rendered element for Studio outlines',
 	expect(
 		registeredSequences.map((sequence) => sequence.displayName).sort(),
 	).toEqual([
+		'<Interactive.Circle>',
 		'<Interactive.Div>',
+		'<Interactive.Ellipse>',
+		'<Interactive.G>',
+		'<Interactive.Line>',
+		'<Interactive.Path>',
 		'<Interactive.Rect>',
 		'<Interactive.Span>',
 		'<Interactive.Svg>',
+		'<Interactive.Text>',
 	]);
 
 	const getByName = (displayName: string) =>
@@ -761,6 +775,9 @@ test('Interactive elements register their rendered element for Studio outlines',
 	expect(getByName('<Interactive.Rect>')?.refForOutline?.current?.tagName).toBe(
 		'rect',
 	);
+	expect(getByName('<Interactive.Text>')?.refForOutline?.current?.tagName).toBe(
+		'text',
+	);
 	expect(getByName('<Interactive.Div>')?.documentationLink).toBe(
 		documentationLink,
 	);
@@ -771,6 +788,34 @@ test('Interactive elements register their rendered element for Studio outlines',
 		divRef.current,
 	);
 	expect(getByName('<Interactive.Div>')?.controls).not.toBe(null);
+
+	for (const displayName of [
+		'<Interactive.Div>',
+		'<Interactive.Span>',
+		'<Interactive.Text>',
+	]) {
+		expect(getByName(displayName)?.controls?.schema).toHaveProperty([
+			'style.fontSize',
+		]);
+		expect(getByName(displayName)?.controls?.schema).toHaveProperty('children');
+	}
+
+	for (const displayName of [
+		'<Interactive.Circle>',
+		'<Interactive.Ellipse>',
+		'<Interactive.G>',
+		'<Interactive.Line>',
+		'<Interactive.Path>',
+		'<Interactive.Rect>',
+		'<Interactive.Svg>',
+	]) {
+		expect(getByName(displayName)?.controls?.schema).not.toHaveProperty([
+			'style.fontSize',
+		]);
+		expect(getByName(displayName)?.controls?.schema).not.toHaveProperty(
+			'children',
+		);
+	}
 });
 
 test('Interactive elements inherit trimBefore from Sequence', () => {


### PR DESCRIPTION
## Summary

- separate text and non-text schemas for `Interactive.*` elements
- remove text style and content controls from SVG containers and shapes
- preserve text controls for HTML elements and `Interactive.Text`

## Test plan

- `cd packages/core && bun run test`
- `bun run build`
- `bun run stylecheck`

Closes #9327
