### PR TITLE
`@remotion/studio`: Add composition inspector actions

### DIFF
--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -21,6 +21,7 @@ import type {SegmentedControlItem} from '../SegmentedControl';
 import {SegmentedControl} from '../SegmentedControl';
 import {VisualControlsContent} from '../VisualControls/VisualControlsContent';
 import {
+	InspectorActionSection,
 	InspectorDefaultPropsWarnings,
 	InspectorInlineAction,
 	InspectorSectionDivider,
@@ -32,7 +33,6 @@ import {
 	compositionDefaultPropsSection,
 	compositionVisualControlsSection,
 	defaultPropsWarningContainer,
-	detailsContainer,
 	inspectorOverviewSection,
 	scrollableContainer,
 	sectionHeaderEnd,
@@ -45,16 +45,6 @@ import {useCompositionActions} from './use-composition-actions';
 const actionIconStyle: React.CSSProperties = {
 	height: 13,
 	width: 13,
-};
-
-const actionsContainer: React.CSSProperties = {
-	...detailsContainer,
-	paddingBottom: 6,
-	paddingTop: 6,
-};
-
-const actionButton: React.CSSProperties = {
-	width: '100%',
 };
 
 const CompositionActions: React.FC = () => {
@@ -72,35 +62,28 @@ const CompositionActions: React.FC = () => {
 	}
 
 	return (
-		<>
-			<InspectorSectionDivider />
-			<div style={actionsContainer}>
-				{canShowInsertSolid ? (
-					<InspectorInlineAction
-						disabled={!canInsertSolid}
-						onClick={insertSolid}
-						style={actionButton}
-						renderIcon={(color) => (
-							<Plus color={color} style={actionIconStyle} />
-						)}
-					>
-						Add Solid
-					</InspectorInlineAction>
-				) : null}
-				{canShowInsertAsset ? (
-					<InspectorInlineAction
-						disabled={!canInsertAsset}
-						onClick={insertAsset}
-						style={actionButton}
-						renderIcon={(color) => (
-							<FileIcon color={color} style={actionIconStyle} />
-						)}
-					>
-						Add asset
-					</InspectorInlineAction>
-				) : null}
-			</div>
-		</>
+		<InspectorActionSection>
+			{canShowInsertSolid ? (
+				<InspectorInlineAction
+					disabled={!canInsertSolid}
+					onClick={insertSolid}
+					renderIcon={(color) => <Plus color={color} style={actionIconStyle} />}
+				>
+					Add Solid
+				</InspectorInlineAction>
+			) : null}
+			{canShowInsertAsset ? (
+				<InspectorInlineAction
+					disabled={!canInsertAsset}
+					onClick={insertAsset}
+					renderIcon={(color) => (
+						<FileIcon color={color} style={actionIconStyle} />
+					)}
+				>
+					Add asset
+				</InspectorInlineAction>
+			) : null}
+		</InspectorActionSection>
 	);
 };
 

--- a/packages/studio/src/components/InspectorPanel/DefaultInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/DefaultInspector.tsx
@@ -2,6 +2,8 @@ import React, {useContext, useEffect, useMemo, useState} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
 import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
+import {FileIcon} from '../../icons/file';
+import {Plus} from '../../icons/plus';
 import {VisualControlsContext} from '../../visual-controls/VisualControls';
 import {CurrentAsset} from '../CurrentAsset';
 import {CurrentComposition} from '../CurrentComposition';
@@ -23,6 +25,7 @@ import {SegmentedControl} from '../SegmentedControl';
 import {VisualControlsContent} from '../VisualControls/VisualControlsContent';
 import {
 	InspectorDefaultPropsWarnings,
+	InspectorInlineAction,
 	InspectorSectionDivider,
 	InspectorSectionHeader,
 } from './common';
@@ -32,6 +35,7 @@ import {
 	container,
 	defaultPropsSection,
 	defaultPropsWarningContainer,
+	detailsContainer,
 	scrollableContainer,
 	sectionHeaderEnd,
 	sectionHeaderRow,
@@ -39,6 +43,69 @@ import {
 	sectionHeaderTitle,
 	visualControlsSection,
 } from './styles';
+import {useCompositionActions} from './use-composition-actions';
+
+const actionIconStyle: React.CSSProperties = {
+	height: 13,
+	width: 13,
+};
+
+const actionsContainer: React.CSSProperties = {
+	...detailsContainer,
+	paddingBottom: 6,
+	paddingTop: 6,
+};
+
+const actionButton: React.CSSProperties = {
+	width: '100%',
+};
+
+const CompositionActions: React.FC = () => {
+	const {
+		canInsertAsset,
+		canInsertSolid,
+		canShowInsertAsset,
+		canShowInsertSolid,
+		insertAsset,
+		insertSolid,
+	} = useCompositionActions();
+
+	if (!canShowInsertAsset && !canShowInsertSolid) {
+		return null;
+	}
+
+	return (
+		<>
+			<InspectorSectionDivider />
+			<div style={actionsContainer}>
+				{canShowInsertSolid ? (
+					<InspectorInlineAction
+						disabled={!canInsertSolid}
+						onClick={insertSolid}
+						style={actionButton}
+						renderIcon={(color) => (
+							<Plus color={color} style={actionIconStyle} />
+						)}
+					>
+						Add Solid
+					</InspectorInlineAction>
+				) : null}
+				{canShowInsertAsset ? (
+					<InspectorInlineAction
+						disabled={!canInsertAsset}
+						onClick={insertAsset}
+						style={actionButton}
+						renderIcon={(color) => (
+							<FileIcon color={color} style={actionIconStyle} />
+						)}
+					>
+						Add asset
+					</InspectorInlineAction>
+				) : null}
+			</div>
+		</>
+	);
+};
 
 export const DefaultInspector: React.FC<{
 	readonly composition: _InternalTypes['AnyComposition'] | null;
@@ -193,6 +260,7 @@ export const DefaultInspector: React.FC<{
 					</div>
 				</>
 			) : null}
+			<CompositionActions />
 		</div>
 	);
 };

--- a/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
@@ -24,6 +24,7 @@ import {
 	type EasingSelection,
 } from '../Timeline/update-selected-easing';
 import {
+	InspectorActionSection,
 	InspectorBackHeader,
 	InspectorInlineAction,
 	InspectorMessage,
@@ -33,11 +34,7 @@ import {getEasingSelectionFromCurrentKeyframes} from './easing-inspector-selecti
 import {KeyframeEasingNavigator} from './KeyframeEasingNavigator';
 import {KeyframeSettings} from './KeyframeSettings';
 import {SequenceInspectorSections} from './SequenceInspectorHeader';
-import {
-	detailsWithInlineAction,
-	sectionHeaderTitle,
-	selectedContainer,
-} from './styles';
+import {sectionHeaderTitle, selectedContainer} from './styles';
 import {useTrackForSelection} from './use-track-for-selection';
 
 type EasingInspectorDetails = {
@@ -334,20 +331,17 @@ export const EasingInspector: React.FC<{
 			<InspectorSectionDivider />
 			<KeyframeSettings update={easingUpdate} />
 			{canAddKeyframeAtPlayhead ? (
-				<>
-					<InspectorSectionDivider />
-					<div style={detailsWithInlineAction}>
-						<InspectorInlineAction
-							disabled={addKeyframeDisabled}
-							onClick={onAddKeyframeAtPlayhead}
-							renderIcon={(color) => (
-								<Plus color={color} style={addKeyframeIcon} />
-							)}
-						>
-							{`Add keyframe at ${addKeyframeTime}`}
-						</InspectorInlineAction>
-					</div>
-				</>
+				<InspectorActionSection>
+					<InspectorInlineAction
+						disabled={addKeyframeDisabled}
+						onClick={onAddKeyframeAtPlayhead}
+						renderIcon={(color) => (
+							<Plus color={color} style={addKeyframeIcon} />
+						)}
+					>
+						{`Add keyframe at ${addKeyframeTime}`}
+					</InspectorInlineAction>
+				</InspectorActionSection>
 			) : null}
 		</div>
 	);

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -19,6 +19,7 @@ import {
 } from '../Timeline/TimelineSelection';
 import {AlignmentControls} from './AlignmentControls';
 import {
+	InspectorActionSection,
 	InspectorInlineAction,
 	InspectorMessage,
 	InspectorSectionDivider,
@@ -32,22 +33,12 @@ import {
 	SequenceInspectorHeader,
 	useSequenceInspectorSourceLocation,
 } from './SequenceInspectorHeader';
-import {detailsContainer, selectedContainer} from './styles';
+import {selectedContainer} from './styles';
 import {useTrackForSelection} from './use-track-for-selection';
 
 const splitIconStyle: React.CSSProperties = {
 	height: 13,
 	width: 13,
-};
-
-const splitActionContainer: React.CSSProperties = {
-	...detailsContainer,
-	paddingBottom: 6,
-	paddingTop: 6,
-};
-
-const splitActionButton: React.CSSProperties = {
-	width: '100%',
 };
 
 const SplitSequenceAction: React.FC<{
@@ -90,21 +81,17 @@ const SplitSequenceAction: React.FC<{
 	}
 
 	return (
-		<>
-			<InspectorSectionDivider />
-			<div style={splitActionContainer}>
-				<InspectorInlineAction
-					disabled={false}
-					onClick={onSplit}
-					style={splitActionButton}
-					renderIcon={(color) => (
-						<ScissorsIcon style={splitIconStyle} color={color} />
-					)}
-				>
-					Split clip
-				</InspectorInlineAction>
-			</div>
-		</>
+		<InspectorActionSection>
+			<InspectorInlineAction
+				disabled={false}
+				onClick={onSplit}
+				renderIcon={(color) => (
+					<ScissorsIcon style={splitIconStyle} color={color} />
+				)}
+			>
+				Split clip
+			</InspectorInlineAction>
+		</InspectorActionSection>
 	);
 };
 

--- a/packages/studio/src/components/InspectorPanel/common.tsx
+++ b/packages/studio/src/components/InspectorPanel/common.tsx
@@ -10,6 +10,7 @@ import {
 	detailLabel,
 	detailRow,
 	detailValue,
+	inspectorActionSection,
 	inspectorSectionBody,
 	inspectorSectionDivider,
 	resolveLinkStyle,
@@ -24,6 +25,15 @@ export const InspectorSectionHeader: React.FC<{
 
 export const InspectorSectionDivider: React.FC = () => (
 	<div style={inspectorSectionDivider} />
+);
+
+export const InspectorActionSection: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => (
+	<>
+		<InspectorSectionDivider />
+		<div style={inspectorActionSection}>{children}</div>
+	</>
 );
 
 export const InspectorSection: React.FC<{

--- a/packages/studio/src/components/InspectorPanel/styles.ts
+++ b/packages/studio/src/components/InspectorPanel/styles.ts
@@ -192,6 +192,10 @@ export const detailsWithInlineAction: React.CSSProperties = {
 	paddingBottom: INSPECTOR_PANEL_HORIZONTAL_PADDING,
 };
 
+export const inspectorActionSection: React.CSSProperties = {
+	padding: '4px 0',
+};
+
 export const detailsBeforeInlineAction: React.CSSProperties = {
 	padding: `0 ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
 };

--- a/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
+++ b/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
@@ -1,0 +1,132 @@
+import {useCallback, useContext, useMemo, useState} from 'react';
+import {Internals} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
+import {useCachedCompositionComponentInfo} from '../../helpers/open-in-editor';
+import {callApi} from '../call-api';
+import {importAssets, pickFilesToImport} from '../import-assets';
+import {showNotification} from '../Notifications/NotificationCenter';
+import {useResolvedStack} from '../Timeline/use-resolved-stack';
+
+export const useCompositionActions = () => {
+	const {compositions, canvasContent} = useContext(
+		Internals.CompositionManager,
+	);
+	const videoConfig = Internals.useUnsafeVideoConfig();
+	const [isAddingSolid, setIsAddingSolid] = useState(false);
+	const [isAddingAsset, setIsAddingAsset] = useState(false);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const previewConnected = previewServerState.type === 'connected';
+	const previewInteractive = previewConnected && studioInteractivityEnabled;
+
+	const currentCompositionId =
+		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
+	const currentComposition = useMemo(() => {
+		if (currentCompositionId === null) {
+			return null;
+		}
+
+		return (
+			compositions.find(
+				(composition) => composition.id === currentCompositionId,
+			) ?? null
+		);
+	}, [compositions, currentCompositionId]);
+	const resolvedCompositionLocation = useResolvedStack(
+		currentComposition?.stack ?? null,
+	);
+	const compositionFile = resolvedCompositionLocation?.source ?? null;
+	const compositionComponentInfo = useCachedCompositionComponentInfo({
+		compositionFile,
+		compositionId: currentCompositionId,
+	});
+
+	const canShowInsertSolid =
+		previewInteractive &&
+		compositionComponentInfo?.canAddSequence === true &&
+		currentCompositionId !== null &&
+		compositionFile !== null &&
+		videoConfig !== null;
+	const canInsertSolid = canShowInsertSolid && !isAddingSolid;
+
+	const canShowInsertAsset =
+		previewInteractive &&
+		!window.remotion_isReadOnlyStudio &&
+		compositionComponentInfo?.canAddSequence === true &&
+		currentCompositionId !== null &&
+		compositionFile !== null;
+	const canInsertAsset = canShowInsertAsset && !isAddingAsset;
+
+	const insertSolid = useCallback(async () => {
+		if (
+			!canInsertSolid ||
+			currentCompositionId === null ||
+			compositionFile === null ||
+			videoConfig === null
+		) {
+			return;
+		}
+
+		setIsAddingSolid(true);
+		try {
+			const result = await callApi('/api/insert-jsx-element', {
+				compositionFile,
+				compositionId: currentCompositionId,
+				element: {
+					type: 'solid',
+					width: videoConfig.width,
+					height: videoConfig.height,
+					position: null,
+				},
+			});
+
+			if (result.success) {
+				showNotification('Added <Solid> to source file', 2000);
+				return;
+			}
+
+			showNotification(result.reason, 4000);
+		} catch (err) {
+			showNotification((err as Error).message, 4000);
+		} finally {
+			setIsAddingSolid(false);
+		}
+	}, [canInsertSolid, compositionFile, currentCompositionId, videoConfig]);
+
+	const insertAsset = useCallback(async () => {
+		if (
+			!canInsertAsset ||
+			currentCompositionId === null ||
+			compositionFile === null
+		) {
+			return;
+		}
+
+		const files = await pickFilesToImport();
+		if (files.length === 0) {
+			return;
+		}
+
+		setIsAddingAsset(true);
+		try {
+			await importAssets({
+				files,
+				compositionFile,
+				compositionId: currentCompositionId,
+				destinationDimensions: null,
+				dropPosition: null,
+			});
+		} finally {
+			setIsAddingAsset(false);
+		}
+	}, [canInsertAsset, compositionFile, currentCompositionId]);
+
+	return {
+		canInsertAsset,
+		canInsertSolid,
+		canShowInsertAsset,
+		canShowInsertSolid,
+		insertAsset,
+		insertSolid,
+	};
+};


### PR DESCRIPTION
## Summary

- add context-sensitive Add Solid and Add asset actions to the composition inspector
- only show each action when the current composition state supports it
- standardize Composition, Sequence, and Easing inspector action sections with dividers, no horizontal padding, and 4px vertical padding

## Testing

- `bun run build`
- `bun run stylecheck`
