### PR TITLE
docs: fix VPAT version label in remotion.pro accessibility statement

### DIFF
--- a/packages/docs/docs/license/accessibility-statement-remotion-pro.mdx
+++ b/packages/docs/docs/license/accessibility-statement-remotion-pro.mdx
@@ -21,7 +21,7 @@ Remotion Pro is currently **partially conformant** with both standards. "Partial
 
 Our most recent self-assessment scored **68% against RGAA 4.1.2** (46 criteria applicable, 50 conformant, 23 non-conformant).
 
-Download our detailed VPAT 2.5Rev: [PDF](https://www.remotion.pro/accessibility/vpat.pdf) · [Markdown](https://www.remotion.pro/accessibility/vpat.md). The full RGAA audit report is available on request at [hi@remotion.dev](mailto:hi@remotion.dev).
+Download our detailed VPAT 2.4 Rev: [PDF](https://www.remotion.pro/accessibility/vpat.pdf) · [Markdown](https://www.remotion.pro/accessibility/vpat.md). The full RGAA audit report is available on request at [hi@remotion.dev](mailto:hi@remotion.dev).
 
 ## Preparation of this statement
 


### PR DESCRIPTION
## Summary

Fixes a version label typo on `packages/docs/docs/license/accessibility-statement-remotion-pro.mdx`. The statement advertised the downloadable VPAT as **"VPAT 2.5Rev"**, but the actual document is **VPAT 2.4 Rev**.

## Evidence

Both source-of-truth artifacts in the `pro` repo agree on **2.4 Rev**:

- `pro/docs/a11y/records/VPAT.md` (line 5): `## VPAT 2.4 Rev — WCAG 2.1 Edition`
- `pro/scripts/generate-vpat-pdf.mjs` (line 25): sets the generated PDF's `Subject` metadata to `'VPAT 2.4 Rev — WCAG 2.1 Edition'`

The "2.5Rev" string only existed on the docs page. `git log -S "2.5Rev"` traces it back to #9238 (the PR that consolidated accessibility documentation under *License, Pricing and Compliance*), so it's a typo that crept in when the statement was moved — not a real version bump.

## Why only the docs page changes

The VPAT document and PDF generator live in the `pro` repo because the VPAT is an assessment of the **remotion.pro website specifically** (product/store pages, login, FAQ accordion, OpenStreetMap embed, etc.). Keeping the audit artifacts in the `pro` repo — next to the code they audit — is the arrangement codified in remotion-dev/pro#773, and moving them into the docs repo would split the evidence from the audited code and force a compliance folder structure into the docs repo that doesn't belong there. So the fix is to align the docs page with the real document, not the other way around.

See the follow-up comment on remotion-dev/pro#773 for the full rationale on why the VPAT files stay served from remotion.pro.

## Test plan

- [ ] Open the preview for `/docs/license/accessibility-statement-remotion-pro` and confirm the download sentence now reads "VPAT 2.4 Rev".
- [ ] Confirm both download links still resolve (`https://www.remotion.pro/accessibility/vpat.pdf` and `…/vpat.md`).

Made with [Cursor](https://cursor.com)