### PR TITLE
`@remotion/studio`: Add padding when fitting compositions

### DIFF
--- a/packages/core/src/use-current-scale.ts
+++ b/packages/core/src/use-current-scale.ts
@@ -24,8 +24,14 @@ export type CurrentScaleContextType =
 			canvasSize: Size;
 	  };
 
+type InternalCurrentScaleContextType =
+	| Extract<CurrentScaleContextType, {type: 'scale'}>
+	| (Extract<CurrentScaleContextType, {type: 'canvas-size'}> & {
+			canvasSizeForAuto: Size;
+	  });
+
 export const CurrentScaleContext =
-	React.createContext<CurrentScaleContextType | null>(null);
+	React.createContext<InternalCurrentScaleContextType | null>(null);
 
 type Options = {
 	dontThrowIfOutsideOfRemotion: boolean;
@@ -113,7 +119,7 @@ export const useCurrentScale = (options?: Options) => {
 	}
 
 	return calculateScale({
-		canvasSize: hasContext.canvasSize,
+		canvasSize: hasContext.canvasSizeForAuto,
 		compositionHeight: config.height,
 		compositionWidth: config.width,
 		previewSize: zoomContext.size.size,

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -47,6 +47,7 @@ import {
 	smoothenZoom,
 	unsmoothenZoom,
 } from '../helpers/smooth-zoom';
+import {calculateStudioScale} from '../helpers/studio-fit-padding';
 import {
 	areKeyboardShortcutsDisabled,
 	useKeybinding,
@@ -146,6 +147,31 @@ type WebKitGestureEvent = UIEvent & {
 	scale: number;
 	clientX: number;
 	clientY: number;
+};
+
+const calculateCanvasScale = ({
+	addFitPadding,
+	canvasSize,
+	compositionHeight,
+	compositionWidth,
+	previewSize,
+}: {
+	readonly addFitPadding: boolean;
+	readonly canvasSize: Size;
+	readonly compositionHeight: number;
+	readonly compositionWidth: number;
+	readonly previewSize: PreviewSize['size'];
+}) => {
+	const options = {
+		canvasSize,
+		compositionHeight,
+		compositionWidth,
+		previewSize,
+	};
+
+	return addFitPadding
+		? calculateStudioScale(options)
+		: Internals.calculateScale(options);
 };
 
 const isFileDragEvent = (event: DragEvent): boolean => {
@@ -256,12 +282,14 @@ const getSfxDragUrl = (event: DragEvent): string | null => {
 };
 
 const getDropPosition = ({
+	addFitPadding,
 	clientX,
 	clientY,
 	contentDimensions,
 	previewSize,
 	size,
 }: {
+	addFitPadding: boolean;
 	clientX: number;
 	clientY: number;
 	contentDimensions: {width: number; height: number} | 'none' | null;
@@ -272,7 +300,8 @@ const getDropPosition = ({
 		return null;
 	}
 
-	const scale = Internals.calculateScale({
+	const scale = calculateCanvasScale({
+		addFitPadding,
 		canvasSize: size,
 		compositionHeight: contentDimensions.height,
 		compositionWidth: contentDimensions.width,
@@ -407,6 +436,7 @@ export const Canvas: React.FC<{
 	}, [assetResolution, config, canvasContent]);
 
 	const isFit = previewSize.size === 'auto';
+	const addFitPadding = canvasContent.type === 'composition';
 
 	previewSnapshotRef.current = {
 		previewSize,
@@ -443,7 +473,8 @@ export const Canvas: React.FC<{
 			ev.preventDefault();
 
 			setSize((prevSize) => {
-				const scale = Internals.calculateScale({
+				const scale = calculateCanvasScale({
+					addFitPadding,
 					canvasSize: size,
 					compositionHeight: contentDimensions.height,
 					compositionWidth: contentDimensions.width,
@@ -457,6 +488,7 @@ export const Canvas: React.FC<{
 					const unsmoothened = unsmoothenZoom(added);
 
 					return applyZoomAroundFocalPoint({
+						addFitPadding,
 						canvasSize: size,
 						contentDimensions,
 						previewSizeBefore: prevSize,
@@ -490,7 +522,14 @@ export const Canvas: React.FC<{
 				};
 			});
 		},
-		[editorZoomGestures, contentDimensions, isFit, setSize, size],
+		[
+			addFitPadding,
+			editorZoomGestures,
+			contentDimensions,
+			isFit,
+			setSize,
+			size,
+		],
 	);
 
 	useEffect(() => {
@@ -532,7 +571,8 @@ export const Canvas: React.FC<{
 			e.preventDefault();
 			suppressWheelFromWebKitPinchRef.current = true;
 
-			const fitted = Internals.calculateScale({
+			const fitted = calculateCanvasScale({
+				addFitPadding,
 				canvasSize: canvasSz,
 				compositionHeight: cdim.height,
 				compositionWidth: cdim.width,
@@ -557,7 +597,8 @@ export const Canvas: React.FC<{
 			e.preventDefault();
 
 			setSize((prevSize) => {
-				const scale = Internals.calculateScale({
+				const scale = calculateCanvasScale({
+					addFitPadding,
 					canvasSize: canvasSz,
 					compositionHeight: dimensions.height,
 					compositionWidth: dimensions.width,
@@ -566,6 +607,7 @@ export const Canvas: React.FC<{
 				const oldNumeric = prevSize.size === 'auto' ? scale : prevSize.size;
 
 				return applyZoomAroundFocalPoint({
+					addFitPadding,
 					canvasSize: canvasSz,
 					contentDimensions: dimensions,
 					previewSizeBefore: prevSize,
@@ -596,7 +638,7 @@ export const Canvas: React.FC<{
 			current.removeEventListener('gestureend', onGestureEnd);
 			current.removeEventListener('gesturecancel', onGestureEnd);
 		};
-	}, [editorZoomGestures, setSize, supportsWebKitPinch]);
+	}, [addFitPadding, editorZoomGestures, setSize, supportsWebKitPinch]);
 
 	useEffect(() => {
 		const {current} = canvasRef;
@@ -628,7 +670,8 @@ export const Canvas: React.FC<{
 				return;
 			}
 
-			const fitted = Internals.calculateScale({
+			const fitted = calculateCanvasScale({
+				addFitPadding,
 				canvasSize: snap.canvasSize,
 				compositionHeight: snap.contentDimensions.height,
 				compositionWidth: snap.contentDimensions.width,
@@ -667,7 +710,8 @@ export const Canvas: React.FC<{
 					width: number;
 					height: number;
 				};
-				const scale = Internals.calculateScale({
+				const scale = calculateCanvasScale({
+					addFitPadding,
 					canvasSize: canvasSz,
 					compositionHeight: cdim.height,
 					compositionWidth: cdim.width,
@@ -676,6 +720,7 @@ export const Canvas: React.FC<{
 				const oldNumeric = prevSize.size === 'auto' ? scale : prevSize.size;
 
 				return applyZoomAroundFocalPoint({
+					addFitPadding,
 					canvasSize: canvasSz,
 					contentDimensions: cdim,
 					previewSizeBefore: prevSize,
@@ -704,7 +749,7 @@ export const Canvas: React.FC<{
 			current.removeEventListener('touchend', onTouchEnd);
 			current.removeEventListener('touchcancel', onTouchEnd);
 		};
-	}, [editorZoomGestures, setSize]);
+	}, [addFitPadding, editorZoomGestures, setSize]);
 
 	const onReset = useCallback(() => {
 		setSize(() => {
@@ -728,7 +773,8 @@ export const Canvas: React.FC<{
 		}
 
 		setSize((prevSize) => {
-			const scale = Internals.calculateScale({
+			const scale = calculateCanvasScale({
+				addFitPadding,
 				canvasSize: size,
 				compositionHeight: contentDimensions.height,
 				compositionWidth: contentDimensions.width,
@@ -742,7 +788,7 @@ export const Canvas: React.FC<{
 				size: Math.min(MAX_ZOOM, scale * 2),
 			};
 		});
-	}, [contentDimensions, setSize, size]);
+	}, [addFitPadding, contentDimensions, setSize, size]);
 
 	const onZoomOut = useCallback(() => {
 		if (!contentDimensions || contentDimensions === 'none') {
@@ -754,7 +800,8 @@ export const Canvas: React.FC<{
 		}
 
 		setSize((prevSize) => {
-			const scale = Internals.calculateScale({
+			const scale = calculateCanvasScale({
+				addFitPadding,
 				canvasSize: size,
 				compositionHeight: contentDimensions.height,
 				compositionWidth: contentDimensions.width,
@@ -768,7 +815,7 @@ export const Canvas: React.FC<{
 				size: Math.max(MIN_ZOOM, scale / 2),
 			};
 		});
-	}, [contentDimensions, setSize, size]);
+	}, [addFitPadding, contentDimensions, setSize, size]);
 
 	useEffect(() => {
 		const resetBinding = keybindings.registerKeybinding({
@@ -1091,6 +1138,7 @@ export const Canvas: React.FC<{
 			setIsAddingAsset(true);
 			try {
 				const dropPosition = getDropPosition({
+					addFitPadding,
 					clientX: event.clientX,
 					clientY: event.clientY,
 					contentDimensions,
@@ -1201,6 +1249,7 @@ export const Canvas: React.FC<{
 			}
 		},
 		[
+			addFitPadding,
 			canDropAssets,
 			cannotAddSequence,
 			chooseSvgImportMode,

--- a/packages/studio/src/components/Editor.tsx
+++ b/packages/studio/src/components/Editor.tsx
@@ -1,10 +1,9 @@
 import {PlayerInternals} from '@remotion/player';
 import React, {useCallback, useMemo, useState} from 'react';
-import type {CurrentScaleContextType} from 'remotion';
 import {Internals} from 'remotion';
 import {BACKGROUND} from '../helpers/colors';
 import {noop} from '../helpers/noop';
-import {getStudioPaddedCanvasSize} from '../helpers/studio-fit-padding';
+import {getStudioCurrentScaleContext} from '../helpers/studio-fit-padding';
 import {getStudioBufferStateDelayInMilliseconds} from '../helpers/studio-runtime-config';
 import {drawRef} from '../state/canvas-ref';
 import {ScaleLockProvider} from '../state/scale-lock';
@@ -55,15 +54,12 @@ export const Editor: React.FC<{
 		setDrawElement(node);
 	}, []);
 
-	const value: CurrentScaleContextType | null = useMemo(() => {
+	const value = useMemo(() => {
 		if (!size) {
 			return null;
 		}
 
-		return {
-			type: 'canvas-size',
-			canvasSize: getStudioPaddedCanvasSize(size).canvasSize,
-		};
+		return getStudioCurrentScaleContext(size);
 	}, [size]);
 
 	const MemoRoot = useMemo(() => {

--- a/packages/studio/src/components/Editor.tsx
+++ b/packages/studio/src/components/Editor.tsx
@@ -4,6 +4,7 @@ import type {CurrentScaleContextType} from 'remotion';
 import {Internals} from 'remotion';
 import {BACKGROUND} from '../helpers/colors';
 import {noop} from '../helpers/noop';
+import {getStudioPaddedCanvasSize} from '../helpers/studio-fit-padding';
 import {getStudioBufferStateDelayInMilliseconds} from '../helpers/studio-runtime-config';
 import {drawRef} from '../state/canvas-ref';
 import {ScaleLockProvider} from '../state/scale-lock';
@@ -61,7 +62,7 @@ export const Editor: React.FC<{
 
 		return {
 			type: 'canvas-size',
-			canvasSize: size,
+			canvasSize: getStudioPaddedCanvasSize(size).canvasSize,
 		};
 	}, [size]);
 

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -20,6 +20,7 @@ import {LIGHT_TEXT} from '../helpers/colors';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import type {Dimensions} from '../helpers/is-current-selected-still';
+import {calculateStudioCanvasTransformation} from '../helpers/studio-fit-padding';
 import {CheckerboardContext} from '../state/checkerboard';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from './Menu/is-menu-item';
 import {RenderPreview} from './RenderPreview';
@@ -157,13 +158,20 @@ const CompWhenItHasDimensions: React.FC<{
 			};
 		}
 
-		return PlayerInternals.calculateCanvasTransformation({
-			canvasSize,
-			compositionHeight: contentDimensions.height,
-			compositionWidth: contentDimensions.width,
-			previewSize: previewSize.size,
-		});
-	}, [canvasSize, contentDimensions, previewSize.size]);
+		return canvasContent.type === 'composition'
+			? calculateStudioCanvasTransformation({
+					canvasSize,
+					compositionHeight: contentDimensions.height,
+					compositionWidth: contentDimensions.width,
+					previewSize: previewSize.size,
+				})
+			: PlayerInternals.calculateCanvasTransformation({
+					canvasSize,
+					compositionHeight: contentDimensions.height,
+					compositionWidth: contentDimensions.width,
+					previewSize: previewSize.size,
+				});
+	}, [canvasContent.type, canvasSize, contentDimensions, previewSize.size]);
 
 	const outer: React.CSSProperties = useMemo(() => {
 		return {

--- a/packages/studio/src/helpers/get-effective-translation.ts
+++ b/packages/studio/src/helpers/get-effective-translation.ts
@@ -1,6 +1,7 @@
 import type {Size} from '@remotion/player';
 import {Internals, type PreviewSize, type Translation} from 'remotion';
 import {MAX_ZOOM, MIN_ZOOM} from './smooth-zoom';
+import {calculateStudioScale} from './studio-fit-padding';
 
 const getEffectiveXTranslation = ({
 	canvasSize,
@@ -121,6 +122,7 @@ export const getCenterPointWhileScrolling = ({
 };
 
 export const applyZoomAroundFocalPoint = ({
+	addFitPadding,
 	canvasSize,
 	contentDimensions,
 	previewSizeBefore,
@@ -129,6 +131,7 @@ export const applyZoomAroundFocalPoint = ({
 	clientX,
 	clientY,
 }: {
+	readonly addFitPadding: boolean;
 	readonly canvasSize: Size;
 	readonly contentDimensions: {width: number; height: number};
 	readonly previewSizeBefore: PreviewSize;
@@ -137,12 +140,19 @@ export const applyZoomAroundFocalPoint = ({
 	readonly clientX: number;
 	readonly clientY: number;
 }): PreviewSize => {
-	const scale = Internals.calculateScale({
-		canvasSize,
-		compositionHeight: contentDimensions.height,
-		compositionWidth: contentDimensions.width,
-		previewSize: previewSizeBefore.size,
-	});
+	const scale = addFitPadding
+		? calculateStudioScale({
+				canvasSize,
+				compositionHeight: contentDimensions.height,
+				compositionWidth: contentDimensions.width,
+				previewSize: previewSizeBefore.size,
+			})
+		: Internals.calculateScale({
+				canvasSize,
+				compositionHeight: contentDimensions.height,
+				compositionWidth: contentDimensions.width,
+				previewSize: previewSizeBefore.size,
+			});
 
 	const clampedNew = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, newNumericSize));
 

--- a/packages/studio/src/helpers/studio-fit-padding.ts
+++ b/packages/studio/src/helpers/studio-fit-padding.ts
@@ -1,0 +1,92 @@
+import type {Size} from '@remotion/player';
+import {PlayerInternals} from '@remotion/player';
+import type {PreviewSize} from 'remotion';
+import {Internals} from 'remotion';
+
+export const STUDIO_FIT_PADDING = 16;
+
+type CanvasSize = {
+	readonly width: number;
+	readonly height: number;
+};
+
+const getPadding = (length: number) => {
+	return Math.min(STUDIO_FIT_PADDING, Math.max(0, (length - 1) / 2));
+};
+
+export const getStudioPaddedCanvasSize = <T extends CanvasSize>(
+	canvasSize: T,
+) => {
+	const horizontalPadding = getPadding(canvasSize.width);
+	const verticalPadding = getPadding(canvasSize.height);
+
+	return {
+		canvasSize: {
+			...canvasSize,
+			width: canvasSize.width - horizontalPadding * 2,
+			height: canvasSize.height - verticalPadding * 2,
+		},
+		horizontalPadding,
+		verticalPadding,
+	};
+};
+
+export const calculateStudioScale = ({
+	canvasSize,
+	compositionHeight,
+	compositionWidth,
+	previewSize,
+}: {
+	readonly canvasSize: CanvasSize;
+	readonly compositionHeight: number;
+	readonly compositionWidth: number;
+	readonly previewSize: PreviewSize['size'];
+}) => {
+	const paddedCanvasSize = getStudioPaddedCanvasSize(canvasSize).canvasSize;
+
+	return Internals.calculateScale({
+		canvasSize: paddedCanvasSize,
+		compositionHeight,
+		compositionWidth,
+		previewSize,
+	});
+};
+
+export const calculateStudioCanvasTransformation = ({
+	canvasSize,
+	compositionHeight,
+	compositionWidth,
+	previewSize,
+}: {
+	readonly canvasSize: Size;
+	readonly compositionHeight: number;
+	readonly compositionWidth: number;
+	readonly previewSize: PreviewSize['size'];
+}) => {
+	if (previewSize !== 'auto') {
+		return PlayerInternals.calculateCanvasTransformation({
+			canvasSize,
+			compositionHeight,
+			compositionWidth,
+			previewSize,
+		});
+	}
+
+	const {
+		canvasSize: paddedCanvasSize,
+		horizontalPadding,
+		verticalPadding,
+	} = getStudioPaddedCanvasSize(canvasSize);
+	const transformation = PlayerInternals.calculateCanvasTransformation({
+		canvasSize: paddedCanvasSize,
+		compositionHeight,
+		compositionWidth,
+		previewSize,
+	});
+
+	return {
+		...transformation,
+		centerX: transformation.centerX + horizontalPadding,
+		centerY: transformation.centerY + verticalPadding,
+	};
+};

--- a/packages/studio/src/helpers/studio-fit-padding.ts
+++ b/packages/studio/src/helpers/studio-fit-padding.ts
@@ -31,6 +31,14 @@ export const getStudioPaddedCanvasSize = <T extends CanvasSize>(
 	};
 };
 
+export const getStudioCurrentScaleContext = (canvasSize: Size) => {
+	return {
+		type: 'canvas-size' as const,
+		canvasSize,
+		canvasSizeForAuto: getStudioPaddedCanvasSize(canvasSize).canvasSize,
+	};
+};
+
 export const calculateStudioScale = ({
 	canvasSize,
 	compositionHeight,

--- a/packages/studio/src/helpers/use-studio-canvas-dimensions.ts
+++ b/packages/studio/src/helpers/use-studio-canvas-dimensions.ts
@@ -1,9 +1,9 @@
 import type {Size} from '@remotion/player';
-import {PlayerInternals} from '@remotion/player';
 import {useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import type {AssetMetadata} from './get-asset-metadata';
 import type {Dimensions} from './is-current-selected-still';
+import {calculateStudioCanvasTransformation} from './studio-fit-padding';
 
 export const useStudioCanvasDimensions = ({
 	canvasSize,
@@ -32,7 +32,7 @@ export const useStudioCanvasDimensions = ({
 			};
 		}
 
-		return PlayerInternals.calculateCanvasTransformation({
+		return calculateStudioCanvasTransformation({
 			canvasSize,
 			compositionHeight: contentDimensions.height,
 			compositionWidth: contentDimensions.width,

--- a/packages/studio/src/test/studio-fit-padding.test.ts
+++ b/packages/studio/src/test/studio-fit-padding.test.ts
@@ -1,0 +1,70 @@
+import {expect, test} from 'bun:test';
+import type {Size} from '@remotion/player';
+import {
+	calculateStudioCanvasTransformation,
+	calculateStudioScale,
+	STUDIO_FIT_PADDING,
+} from '../helpers/studio-fit-padding';
+
+const makeCanvasSize = (width: number, height: number): Size => ({
+	width,
+	height,
+	left: 0,
+	top: 0,
+	windowSize: {width, height},
+	refresh: () => undefined,
+});
+
+test('adds a 16px horizontal gutter when fitting by width', () => {
+	const canvasSize = makeCanvasSize(1000, 600);
+	const transformation = calculateStudioCanvasTransformation({
+		canvasSize,
+		compositionHeight: 1080,
+		compositionWidth: 1920,
+		previewSize: 'auto',
+	});
+
+	expect(transformation.scale).toBeCloseTo((1000 - 32) / 1920);
+	expect(transformation.centerX).toBe(STUDIO_FIT_PADDING);
+	expect(transformation.centerY).toBeCloseTo(
+		(600 - 1080 * transformation.scale) / 2,
+	);
+});
+
+test('adds a 16px vertical gutter when fitting by height', () => {
+	const canvasSize = makeCanvasSize(1000, 500);
+	const transformation = calculateStudioCanvasTransformation({
+		canvasSize,
+		compositionHeight: 1080,
+		compositionWidth: 1920,
+		previewSize: 'auto',
+	});
+
+	expect(transformation.scale).toBeCloseTo((500 - 32) / 1080);
+	expect(transformation.centerX).toBeCloseTo(
+		(1000 - 1920 * transformation.scale) / 2,
+	);
+	expect(transformation.centerY).toBe(STUDIO_FIT_PADDING);
+});
+
+test('does not add padding to explicit zoom levels', () => {
+	const canvasSize = makeCanvasSize(1000, 600);
+	const transformation = calculateStudioCanvasTransformation({
+		canvasSize,
+		compositionHeight: 1080,
+		compositionWidth: 1920,
+		previewSize: 0.5,
+	});
+
+	expect(transformation.scale).toBe(0.5);
+	expect(transformation.centerX).toBe(20);
+	expect(transformation.centerY).toBe(30);
+	expect(
+		calculateStudioScale({
+			canvasSize,
+			compositionHeight: 1080,
+			compositionWidth: 1920,
+			previewSize: 0.5,
+		}),
+	).toBe(0.5);
+});

--- a/packages/studio/src/test/studio-fit-padding.test.ts
+++ b/packages/studio/src/test/studio-fit-padding.test.ts
@@ -3,6 +3,7 @@ import type {Size} from '@remotion/player';
 import {
 	calculateStudioCanvasTransformation,
 	calculateStudioScale,
+	getStudioCurrentScaleContext,
 	STUDIO_FIT_PADDING,
 } from '../helpers/studio-fit-padding';
 
@@ -67,4 +68,13 @@ test('does not add padding to explicit zoom levels', () => {
 			previewSize: 0.5,
 		}),
 	).toBe(0.5);
+});
+
+test('keeps the layout size separate from the auto-fit size', () => {
+	const canvasSize = makeCanvasSize(1000, 600);
+	const context = getStudioCurrentScaleContext(canvasSize);
+
+	expect(context.canvasSize).toBe(canvasSize);
+	expect(context.canvasSizeForAuto.width).toBe(1000 - 32);
+	expect(context.canvasSizeForAuto.height).toBe(600 - 32);
 });


### PR DESCRIPTION
## Summary

- leave a 16px screen-space gutter around compositions when Studio preview size is set to Fit
- keep assets and explicit zoom levels unchanged
- use the padded Fit scale consistently for zoom gestures, drops, rulers, guides, and `useCurrentScale()`

## Testing

- `bun test packages/studio/src/test/studio-fit-padding.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9337
