### PR TITLE
`@remotion/studio`: Fix nested sequence reordering

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineList.tsx
+++ b/packages/studio/src/components/Timeline/TimelineList.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {BACKGROUND} from '../../helpers/colors';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
+import {
+	nestTimelineTracks,
+	type NestedTimelineTrack,
+} from './nest-timeline-tracks';
 import {TimelineSequenceItem} from './TimelineSequenceItem';
 import {TimelineTimePadding} from './TimelineTimeIndicators';
 
@@ -9,28 +13,50 @@ const container: React.CSSProperties = {
 	background: BACKGROUND,
 };
 
+const TimelineListTrack: React.FC<{
+	readonly nestedTrack: NestedTimelineTrack<TrackWithHash>;
+}> = ({nestedTrack}) => {
+	const {track, children, siblingIndex} = nestedTrack;
+
+	return (
+		<div>
+			<TimelineSequenceItem
+				siblingIndex={siblingIndex}
+				connectedCompositions={track.connectedCompositions ?? []}
+				nestedDepth={track.depth}
+				sequence={track.sequence}
+				nodePathInfo={track.nodePathInfo}
+				keyframeDisplayOffset={track.keyframeDisplayOffset}
+				sequenceFrameOffset={track.sequenceFrameOffset}
+			>
+				{children.map((child) => (
+					<TimelineListTrack
+						key={child.track.sequence.id}
+						nestedTrack={child}
+					/>
+				))}
+			</TimelineSequenceItem>
+		</div>
+	);
+};
+
 export const TimelineList: React.FC<{
 	readonly timeline: TrackWithHash[];
 }> = ({timeline}) => {
+	const nestedTimeline = useMemo(
+		() => nestTimelineTracks(timeline),
+		[timeline],
+	);
+
 	return (
 		<div style={container}>
 			<TimelineTimePadding />
-			{timeline.map((track, trackIndex) => {
-				return (
-					<div key={track.sequence.id}>
-						<TimelineSequenceItem
-							key={track.sequence.id}
-							trackIndex={trackIndex}
-							connectedCompositions={track.connectedCompositions ?? []}
-							nestedDepth={track.depth}
-							sequence={track.sequence}
-							nodePathInfo={track.nodePathInfo}
-							keyframeDisplayOffset={track.keyframeDisplayOffset}
-							sequenceFrameOffset={track.sequenceFrameOffset}
-						/>
-					</div>
-				);
-			})}
+			{nestedTimeline.map((nestedTrack) => (
+				<TimelineListTrack
+					key={nestedTrack.track.sequence.id}
+					nestedTrack={nestedTrack}
+				/>
+			))}
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -99,7 +99,7 @@ const SEQUENCE_REORDER_MIME_TYPE = 'application/remotion-sequence-reorder';
 type SequenceReorderDragData = {
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly nodePathKey: string;
-	readonly trackIndex: number;
+	readonly siblingIndex: number;
 	readonly parentId: string | null;
 	readonly fileName: string;
 };
@@ -148,6 +148,16 @@ const sequenceReorderLineBase: React.CSSProperties = {
 	zIndex: 1,
 };
 
+const sequenceReorderAfterLineWrapper: React.CSSProperties = {
+	height: 0,
+	position: 'relative',
+};
+
+const sequenceReorderAfterLine: React.CSSProperties = {
+	...sequenceReorderLineBase,
+	top: -1,
+};
+
 const sequenceReorderRejectionStyle: React.CSSProperties = {
 	backgroundColor: BLACK_ALPHA_85,
 	border: BORDER_WHITE_ALPHA_20,
@@ -190,7 +200,7 @@ const getSequenceReorderDragData = (
 		const parsed = JSON.parse(value) as SequenceReorderDragData;
 		if (
 			typeof parsed.nodePathKey === 'string' &&
-			typeof parsed.trackIndex === 'number' &&
+			typeof parsed.siblingIndex === 'number' &&
 			(typeof parsed.parentId === 'string' || parsed.parentId === null) &&
 			typeof parsed.fileName === 'string' &&
 			parsed.nodePath &&
@@ -227,21 +237,23 @@ type SequenceDropTarget =
 	  };
 
 export const TimelineSequenceItem: React.FC<{
+	readonly children: React.ReactNode;
 	readonly sequence: TSequence;
 	readonly connectedCompositions: readonly _InternalTypes['AnyComposition'][];
 	readonly nestedDepth: number;
 	readonly nodePathInfo: SequenceNodePathInfo | null;
 	readonly keyframeDisplayOffset: number;
 	readonly sequenceFrameOffset: number;
-	readonly trackIndex: number;
+	readonly siblingIndex: number;
 }> = ({
+	children,
 	connectedCompositions,
 	nestedDepth,
 	sequence,
 	nodePathInfo,
 	keyframeDisplayOffset,
 	sequenceFrameOffset,
-	trackIndex,
+	siblingIndex,
 }) => {
 	const nodePath = nodePathInfo?.sequenceSubscriptionKey ?? null;
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
@@ -457,13 +469,13 @@ export const TimelineSequenceItem: React.FC<{
 
 			const rect = e.currentTarget.getBoundingClientRect();
 			const before = e.clientY < rect.top + rect.height / 2;
-			const insertionIndex = before ? trackIndex : trackIndex + 1;
+			const insertionIndex = before ? siblingIndex : siblingIndex + 1;
 			const toIndex = getDestinationIndex({
-				fromIndex: dragData.trackIndex,
+				fromIndex: dragData.siblingIndex,
 				insertionIndex,
 			});
 
-			if (toIndex === dragData.trackIndex) {
+			if (toIndex === dragData.siblingIndex) {
 				return {
 					type: 'invalid',
 					reason: 'This sequence is already in that position.',
@@ -481,7 +493,7 @@ export const TimelineSequenceItem: React.FC<{
 			nodePathInfo?.numberOfSequencesWithThisNodePath,
 			nodePathKey,
 			parentId,
-			trackIndex,
+			siblingIndex,
 			validatedLocation?.source,
 		],
 	);
@@ -501,7 +513,7 @@ export const TimelineSequenceItem: React.FC<{
 			const dragData = {
 				nodePath,
 				nodePathKey,
-				trackIndex,
+				siblingIndex,
 				parentId,
 				fileName: validatedLocation.source,
 			};
@@ -518,7 +530,7 @@ export const TimelineSequenceItem: React.FC<{
 			nodePath,
 			nodePathKey,
 			parentId,
-			trackIndex,
+			siblingIndex,
 			validatedLocation?.source,
 		],
 	);
@@ -989,13 +1001,13 @@ export const TimelineSequenceItem: React.FC<{
 		sequence.controls?.supportsEffects === true;
 
 	const sequenceReorderLineStyle = useMemo((): React.CSSProperties | null => {
-		if (!sequenceDropIndicator) {
+		if (sequenceDropIndicator !== 'before') {
 			return null;
 		}
 
 		return {
 			...sequenceReorderLineBase,
-			...(sequenceDropIndicator === 'before' ? {top: -1} : {bottom: -1}),
+			top: -1,
 		};
 	}, [sequenceDropIndicator]);
 
@@ -1184,6 +1196,12 @@ export const TimelineSequenceItem: React.FC<{
 					nestedDepth={nestedDepth}
 					keyframeDisplayOffset={keyframeDisplayOffset}
 				/>
+			) : null}
+			{children}
+			{sequenceDropIndicator === 'after' ? (
+				<div style={sequenceReorderAfterLineWrapper}>
+					<div style={sequenceReorderAfterLine} />
+				</div>
 			) : null}
 		</>
 	);

--- a/packages/studio/src/components/Timeline/nest-timeline-tracks.ts
+++ b/packages/studio/src/components/Timeline/nest-timeline-tracks.ts
@@ -1,0 +1,35 @@
+export type NestedTimelineTrack<T> = {
+	readonly track: T;
+	readonly siblingIndex: number;
+	readonly children: NestedTimelineTrack<T>[];
+};
+
+export const nestTimelineTracks = <T extends {readonly depth: number}>(
+	timeline: readonly T[],
+): NestedTimelineTrack<T>[] => {
+	const roots: NestedTimelineTrack<T>[] = [];
+	const stack: NestedTimelineTrack<T>[] = [];
+
+	for (let trackIndex = 0; trackIndex < timeline.length; trackIndex++) {
+		const track = timeline[trackIndex];
+		while (
+			stack.length > 0 &&
+			stack[stack.length - 1].track.depth >= track.depth
+		) {
+			stack.pop();
+		}
+
+		const parent = stack[stack.length - 1];
+		const siblings = parent ? parent.children : roots;
+		const nestedTrack: NestedTimelineTrack<T> = {
+			track,
+			siblingIndex: siblings.length,
+			children: [],
+		};
+		siblings.push(nestedTrack);
+
+		stack.push(nestedTrack);
+	}
+
+	return roots;
+};

--- a/packages/studio/src/test/nest-timeline-tracks.test.ts
+++ b/packages/studio/src/test/nest-timeline-tracks.test.ts
@@ -1,0 +1,49 @@
+import {expect, test} from 'bun:test';
+import {nestTimelineTracks} from '../components/Timeline/nest-timeline-tracks';
+
+test('groups nested tracks with their parent sequence', () => {
+	const nested = nestTimelineTracks([
+		{id: 'first-sequence', depth: 0},
+		{id: 'video', depth: 1},
+		{id: 'video-child', depth: 2},
+		{id: 'first-sequence-sibling', depth: 1},
+		{id: 'second-sequence', depth: 0},
+		{id: 'image', depth: 1},
+	]);
+
+	expect(nested).toEqual([
+		{
+			track: {id: 'first-sequence', depth: 0},
+			siblingIndex: 0,
+			children: [
+				{
+					track: {id: 'video', depth: 1},
+					siblingIndex: 0,
+					children: [
+						{
+							track: {id: 'video-child', depth: 2},
+							siblingIndex: 0,
+							children: [],
+						},
+					],
+				},
+				{
+					track: {id: 'first-sequence-sibling', depth: 1},
+					siblingIndex: 1,
+					children: [],
+				},
+			],
+		},
+		{
+			track: {id: 'second-sequence', depth: 0},
+			siblingIndex: 1,
+			children: [
+				{
+					track: {id: 'image', depth: 1},
+					siblingIndex: 0,
+					children: [],
+				},
+			],
+		},
+	]);
+});


### PR DESCRIPTION
## Summary

- group flattened timeline tracks by nesting depth
- render after-drop indicators below all descendants of the target sequence
- calculate reorder positions with sibling indices so nested tracks do not affect no-op detection

## Testing

- `bun run test` in `packages/studio`
- `bun run build`
- `bun run stylecheck`

Closes #9354
