### PR TITLE
`@remotion/studio`: Use CanvasImage for dropped images

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -313,7 +313,9 @@ const ImgContent: React.FC<ImgContentProps> = ({
 		isClientSideRendering,
 	});
 
-	// src gets set once we've loaded and decoded the image.
+	// `src` is assigned imperatively to this element in the layout effect above.
+	// The element may paint while `decode()` is pending; `delayRender()` only
+	// blocks frame rendering.
 	return (
 		<img
 			{...props}

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -1398,12 +1398,12 @@ const ensureStaticFileImport = (ast: File) => {
 	});
 };
 
-const ensureImgImport = (ast: File) => {
+const ensureCanvasImageImport = (ast: File) => {
 	return ensureOfficialNamedImport({
 		ast,
-		importedName: 'Img',
+		importedName: 'CanvasImage',
 		sourcePath: 'remotion',
-		label: '<Img>',
+		label: '<CanvasImage>',
 	});
 };
 
@@ -2202,7 +2202,7 @@ const createInsertableJsxElement = ({
 			element.srcType === 'remote' ? null : ensureStaticFileImport(ast);
 		let localName: string;
 		if (element.assetType === 'image') {
-			localName = ensureImgImport(ast);
+			localName = ensureCanvasImageImport(ast);
 		} else if (element.assetType === 'video') {
 			localName = ensureVideoImport(ast);
 		} else if (element.assetType === 'gif') {

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -181,7 +181,7 @@ const getElementLabel = (element: InsertableCompositionElement) => {
 
 	if (element.type === 'asset') {
 		if (element.assetType === 'image') {
-			return '<Img>';
+			return '<CanvasImage>';
 		}
 
 		if (element.assetType === 'video') {

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -876,7 +876,7 @@ test('converts and inserts SVG markup as an Interactive.Svg', async () => {
 	}
 });
 
-test('inserts an Img asset into the resolved composition component', async () => {
+test('inserts a CanvasImage asset into the resolved composition component', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {
 		await fs.writeFile(
@@ -921,9 +921,9 @@ test('inserts an Img asset into the resolved composition component', async () =>
 		});
 
 		expect(result.output).toContain(
-			"import { AbsoluteFill, staticFile, Img } from 'remotion';",
+			"import { AbsoluteFill, staticFile, CanvasImage } from 'remotion';",
 		);
-		expect(result.output).toContain('<Img');
+		expect(result.output).toContain('<CanvasImage');
 		expect(result.output).toContain("src={staticFile('image.png')}");
 		expect(result.output).toContain("position: 'absolute'");
 		expect(result.output).toContain('width: 800');
@@ -935,7 +935,7 @@ test('inserts an Img asset into the resolved composition component', async () =>
 	}
 });
 
-test('inserts an Img asset with a translate style', async () => {
+test('inserts a CanvasImage asset with a translate style', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {
 		await fs.writeFile(
@@ -982,6 +982,10 @@ test('inserts an Img asset with a translate style', async () => {
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
+		expect(result.output).toContain(
+			"import { AbsoluteFill, staticFile, CanvasImage } from 'remotion';",
+		);
+		expect(result.output).toContain('<CanvasImage');
 		expect(result.output).toContain("src={staticFile('image.png')}");
 		expect(result.output).toContain("translate: '100px 150px'");
 	} finally {

--- a/packages/studio/src/api/get-static-files.ts
+++ b/packages/studio/src/api/get-static-files.ts
@@ -45,7 +45,7 @@ export const getStaticFiles = (): StaticFile[] => {
 
 export type StaticFile = {
 	/**
-	 * A string that you can pass to the `src` attribute of an `<Audio>`, `<Img>`, `<Video>`, `<Html5Audio>`, `<Html5Video>` or `<OffthreadVideo>` element.
+	 * A string that you can pass to the `src` attribute of an `<Audio>`, `<CanvasImage>`, `<Img>`, `<Video>`, `<Html5Audio>`, `<Html5Video>` or `<OffthreadVideo>` element.
 	 */
 	src: string;
 	/**

--- a/packages/studio/src/components/SvgImportDialog.tsx
+++ b/packages/studio/src/components/SvgImportDialog.tsx
@@ -119,7 +119,7 @@ export const SvgImportDialog: React.FC<{
 					<Flex />
 					<Button onClick={onImage}>
 						Add to <code style={inlineCode}>public</code> and import as{' '}
-						<code style={inlineCode}>{'<Img>'}</code>
+						<code style={inlineCode}>{'<CanvasImage>'}</code>
 					</Button>
 					<Spacing x={1} />
 					<ModalButton onClick={onInline} autoFocus>

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -221,7 +221,7 @@ const getAssetLabel = (element: InsertableCompositionElement) => {
 	}
 
 	if (element.assetType === 'image') {
-		return '<Img>';
+		return '<CanvasImage>';
 	}
 
 	if (element.assetType === 'video') {

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -76,7 +76,7 @@ test('maps animated WebP file types to AnimatedImage assets', () => {
 	});
 });
 
-test('maps static WebP file types to Img assets', () => {
+test('maps static WebP file types to static image assets', () => {
 	expect(
 		getAssetElement({
 			fileType: {


### PR DESCRIPTION
## Summary

- generate `<CanvasImage>` for image assets inserted onto the Studio canvas
- update Studio labels and SVG import messaging to match the generated component
- correct the misleading `<Img>` decode comment and add regression coverage

## Testing

- `bun test packages/studio-server/src/test/resolve-composition-component.test.ts`
- `bun test packages/studio/src/test/import-assets.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9352
