### PR TITLE
`@remotion/studio-server`: Replace deprecated URL parser

### DIFF
--- a/packages/studio-server/src/preview-server/dev-middleware/middleware.ts
+++ b/packages/studio-server/src/preview-server/dev-middleware/middleware.ts
@@ -2,7 +2,6 @@ import type {ReadStream} from 'node:fs';
 import type {IncomingMessage, ServerResponse} from 'node:http';
 import path from 'node:path';
 import querystring from 'node:querystring';
-import {parse} from 'node:url';
 import {RenderInternals} from '@remotion/renderer';
 import {send, setHeaderForResponse} from './compatible-api';
 import {getPaths} from './get-paths';
@@ -35,7 +34,7 @@ const mem = (fn: Function, {cache = new Map()} = {}) => {
 	return memoized;
 };
 
-const memoizedParse = mem(parse);
+const memoizedParse = mem((url: string) => new URL(url, 'http://localhost'));
 
 function getFilenameFromUrl(
 	context: DevMiddlewareContext,
@@ -45,10 +44,13 @@ function getFilenameFromUrl(
 
 	let foundFilename;
 	let urlObject;
+	if (!url) {
+		return;
+	}
 
 	try {
 		// The `url` property of the `request` is contains only  `pathname`, `search` and `hash`
-		urlObject = memoizedParse(url, false, true);
+		urlObject = memoizedParse(url);
 	} catch {
 		return;
 	}
@@ -60,8 +62,6 @@ function getFilenameFromUrl(
 		try {
 			publicPathObject = memoizedParse(
 				publicPath !== 'auto' && publicPath ? publicPath : '/',
-				false,
-				true,
 			);
 		} catch {
 			continue;


### PR DESCRIPTION
## Summary

- replace the deprecated `node:url.parse()` calls in Studio's dev middleware with the WHATWG URL API
- resolve request and public-path URLs against a local base so relative URL handling is retained
- preserve the previous no-match behavior when the request URL is missing

## Testing

- `bun run build`
- `bun run stylecheck`
- `NODE_OPTIONS=--throw-deprecation bun run dev -- --port=32123` on Node.js 24.18.0
- `bun test src` in `packages/studio-server` (436 passed; 3 unrelated logging-format expectations failed)

Closes #9359
