### PR TITLE
`@remotion/studio`: Fix timeline pinch zoom anchoring

### DIFF
--- a/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
+++ b/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
@@ -306,45 +306,71 @@ export const viewportClientXToScrollContentX = ({
 	return clampedClientX + scrollEl.scrollLeft - rect.left;
 };
 
-export const zoomAndPreserveCursor = ({
-	oldZoom,
-	newZoom,
+export const getScrollLeftToKeepCursorInPlace = ({
+	anchorContentX,
+	oldScrollLeft,
+	oldTimelineWidth,
+	newTimelineWidth,
+}: {
+	anchorContentX: number;
+	oldScrollLeft: number;
+	oldTimelineWidth: number;
+	newTimelineWidth: number;
+}) => {
+	const oldUsableWidth = getUsableTimelineWidth(oldTimelineWidth);
+	const newUsableWidth = getUsableTimelineWidth(newTimelineWidth);
+	const clampedAnchorContentX = Math.min(
+		Math.max(anchorContentX, TIMELINE_PADDING),
+		TIMELINE_PADDING + oldUsableWidth,
+	);
+	const cursorX = clampedAnchorContentX - oldScrollLeft;
+	const anchorInUsableWidth = clampedAnchorContentX - TIMELINE_PADDING;
+	const newAnchorContentX =
+		TIMELINE_PADDING + (anchorInUsableWidth / oldUsableWidth) * newUsableWidth;
+
+	return newAnchorContentX - cursorX;
+};
+
+export const prepareToPreserveTimelineCursor = ({
 	currentFrame,
 	currentDurationInFrames,
 	anchorFrame,
 	anchorContentX,
 }: {
-	oldZoom: number;
-	newZoom: number;
 	currentFrame: number;
 	currentDurationInFrames: number;
 	anchorFrame: number | null;
 	/** Prefer this over `anchorFrame` when not null (subpixel-accurate anchor). */
 	anchorContentX: number | null;
 }) => {
-	const ratio = newZoom / oldZoom;
-	if (ratio === 1) {
-		return;
-	}
-
 	const {current} = scrollableRef;
 
 	if (!current) {
-		return;
+		return () => undefined;
 	}
 
-	const frameIncrement = getFrameIncrement(currentDurationInFrames);
+	const oldTimelineWidth = current.scrollWidth;
+	const oldScrollLeft = current.scrollLeft;
+	const frameIncrement = getFrameIncrementFromWidth(
+		currentDurationInFrames,
+		oldTimelineWidth,
+	);
 	const frameForScroll = anchorFrame ?? currentFrame;
 	const prevCursorPosition =
 		anchorContentX !== null
-			? Math.min(Math.max(anchorContentX, 0), current.scrollWidth)
+			? anchorContentX
 			: frameIncrement * frameForScroll + TIMELINE_PADDING;
 
-	const newCursorPosition =
-		ratio * (prevCursorPosition - TIMELINE_PADDING) + TIMELINE_PADDING;
+	return () => {
+		if (scrollableRef.current !== current) {
+			return;
+		}
 
-	current.scrollLeft += newCursorPosition - prevCursorPosition;
-	// Playhead position is synced in `TimelineSlider` `useLayoutEffect` using
-	// measured `sliderAreaRef.clientWidth` so it matches layout after zoom
-	// (avoids fighting React `style` with stale `timelineWidth` during pinch).
+		current.scrollLeft = getScrollLeftToKeepCursorInPlace({
+			anchorContentX: prevCursorPosition,
+			oldScrollLeft,
+			oldTimelineWidth,
+			newTimelineWidth: current.scrollWidth,
+		});
+	};
 };

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -4,7 +4,7 @@ import {
 	getCurrentDuration,
 	getCurrentFrame,
 } from '../components/Timeline/imperative-state';
-import {zoomAndPreserveCursor} from '../components/Timeline/timeline-scroll-logic';
+import {prepareToPreserveTimelineCursor} from '../components/Timeline/timeline-scroll-logic';
 import {getZoomFromLocalStorage} from '../components/ZoomPersistor';
 
 export const TIMELINE_MIN_ZOOM = 1;
@@ -42,6 +42,14 @@ export const TimelineZoomContext: React.FC<{
 			callback: (prevZoomLevel: number) => number,
 			options?: TimelineSetZoomOptions,
 		) => {
+			// Capture the old geometry before committing the new timeline width.
+			const preserveTimelineCursor = prepareToPreserveTimelineCursor({
+				currentDurationInFrames: getCurrentDuration(),
+				currentFrame: getCurrentFrame(),
+				anchorFrame: options?.anchorFrame ?? null,
+				anchorContentX: options?.anchorContentX ?? null,
+			});
+
 			flushSync(() => {
 				setZoomState((prevZoomMap) => {
 					const newZoomWithFloatingPointErrors = Math.min(
@@ -53,20 +61,13 @@ export const TimelineZoomContext: React.FC<{
 					);
 					const newZoom = Math.round(newZoomWithFloatingPointErrors * 10) / 10;
 
-					const anchorFrame = options?.anchorFrame ?? null;
-					const anchorContentX = options?.anchorContentX ?? null;
-
-					zoomAndPreserveCursor({
-						oldZoom: prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM,
-						newZoom,
-						currentDurationInFrames: getCurrentDuration(),
-						currentFrame: getCurrentFrame(),
-						anchorFrame,
-						anchorContentX,
-					});
 					return {...prevZoomMap, [compositionId]: newZoom};
 				});
 			});
+
+			// The new scroll range exists now, so the browser will not clamp the offset
+			// against the previous width.
+			preserveTimelineCursor();
 		},
 		[],
 	);

--- a/packages/studio/src/test/timeline-scroll-logic.test.ts
+++ b/packages/studio/src/test/timeline-scroll-logic.test.ts
@@ -2,7 +2,9 @@ import {expect, test} from 'bun:test';
 import {
 	getFrameFromX,
 	getFrameIncrementFromWidth,
+	getScrollLeftToKeepCursorInPlace,
 } from '../components/Timeline/timeline-scroll-logic';
+import {TIMELINE_PADDING} from '../helpers/timeline-layout';
 
 test('getFrameFromX handles collapsed timeline widths', () => {
 	expect(
@@ -17,4 +19,105 @@ test('getFrameFromX handles collapsed timeline widths', () => {
 
 test('getFrameIncrementFromWidth never returns a negative increment', () => {
 	expect(getFrameIncrementFromWidth(100, 0)).toBe(0.01);
+});
+
+test('keeps the same timeline position under the cursor after zooming', () => {
+	const oldTimelineWidth = 1000;
+	const newTimelineWidth = 2000;
+	const oldScrollLeft = 100;
+	const anchorContentX = 700;
+	const cursorX = anchorContentX - oldScrollLeft;
+	const oldUsableWidth = oldTimelineWidth - TIMELINE_PADDING * 2;
+	const newUsableWidth = newTimelineWidth - TIMELINE_PADDING * 2;
+	const oldTimelinePosition =
+		(anchorContentX - TIMELINE_PADDING) / oldUsableWidth;
+
+	const newScrollLeft = getScrollLeftToKeepCursorInPlace({
+		anchorContentX,
+		oldScrollLeft,
+		oldTimelineWidth,
+		newTimelineWidth,
+	});
+	const newAnchorContentX = newScrollLeft + cursorX;
+	const newTimelinePosition =
+		(newAnchorContentX - TIMELINE_PADDING) / newUsableWidth;
+
+	expect(newTimelinePosition).toBeCloseTo(oldTimelinePosition, 10);
+});
+
+test('accounts for the timeline Flexer when preserving the cursor', () => {
+	const fullTimelineWidth = 1200;
+	const flexValues = [0.15, 0.2, 0.5];
+
+	for (const flexValue of flexValues) {
+		const scrollableWidth = fullTimelineWidth * (1 - flexValue);
+		const oldTimelineWidth = scrollableWidth;
+		const newTimelineWidth = scrollableWidth * 2;
+		const anchorContentX = oldTimelineWidth * 0.75;
+		const newScrollLeft = getScrollLeftToKeepCursorInPlace({
+			anchorContentX,
+			oldScrollLeft: 0,
+			oldTimelineWidth,
+			newTimelineWidth,
+		});
+		const cursorX = anchorContentX;
+		const oldTimelinePosition =
+			(anchorContentX - TIMELINE_PADDING) /
+			(oldTimelineWidth - TIMELINE_PADDING * 2);
+		const newTimelinePosition =
+			(newScrollLeft + cursorX - TIMELINE_PADDING) /
+			(newTimelineWidth - TIMELINE_PADDING * 2);
+
+		expect(newTimelinePosition).toBeCloseTo(oldTimelinePosition, 10);
+	}
+});
+
+test('does not drift after zooming in and back out', () => {
+	const initialTimelineWidth = 1000;
+	const zoomedTimelineWidth = 2500;
+	const cursorX = 750;
+	const zoomedScrollLeft = getScrollLeftToKeepCursorInPlace({
+		anchorContentX: cursorX,
+		oldScrollLeft: 0,
+		oldTimelineWidth: initialTimelineWidth,
+		newTimelineWidth: zoomedTimelineWidth,
+	});
+	const restoredScrollLeft = getScrollLeftToKeepCursorInPlace({
+		anchorContentX: zoomedScrollLeft + cursorX,
+		oldScrollLeft: zoomedScrollLeft,
+		oldTimelineWidth: zoomedTimelineWidth,
+		newTimelineWidth: initialTimelineWidth,
+	});
+
+	expect(restoredScrollLeft).toBeCloseTo(0, 10);
+});
+
+test('the last frame contributes one frame width to the timeline', () => {
+	const durationInFrames = 100;
+	const oldTimelineWidth = 1000;
+	const newTimelineWidth = 2000;
+	const oldFrameIncrement = getFrameIncrementFromWidth(
+		durationInFrames,
+		oldTimelineWidth,
+	);
+	const newFrameIncrement = getFrameIncrementFromWidth(
+		durationInFrames,
+		newTimelineWidth,
+	);
+	const oldLastFrameX =
+		TIMELINE_PADDING + oldFrameIncrement * (durationInFrames - 1);
+	const newLastFrameX =
+		TIMELINE_PADDING + newFrameIncrement * (durationInFrames - 1);
+	const newScrollLeft = getScrollLeftToKeepCursorInPlace({
+		anchorContentX: oldLastFrameX,
+		oldScrollLeft: 0,
+		oldTimelineWidth,
+		newTimelineWidth,
+	});
+
+	expect(newScrollLeft + oldLastFrameX).toBeCloseTo(newLastFrameX, 10);
+	expect(newTimelineWidth - TIMELINE_PADDING - newLastFrameX).toBeCloseTo(
+		newFrameIncrement,
+		10,
+	);
 });


### PR DESCRIPTION
## Summary

- preserve the timeline position under the cursor after the zoomed layout is committed
- calculate cursor anchoring from the usable timeline width, excluding fixed padding
- cover different timeline Flexer widths, zoom round trips, and the last frame's width

## Testing

- `bun test packages/studio/src/test/timeline-scroll-logic.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9286
