### PR TITLE
Add video-shotcraft to resources

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -155,6 +155,7 @@ See the [Showcase](/showcase) for videos made with Remotion.
 ## Tooling
 
 - [VS Code extension](https://marketplace.visualstudio.com/items?itemName=KarelNagel.remotion-vscode)
+- [video-shotcraft](https://github.com/Vincentwei1021/video-shotcraft) - Agent skill for crafting cinematic product videos with 106 shot recipes, 161 motion previews, reusable components, SFX assets, and a production-ready template
 - [GIF Pull request previews](https://github.com/stoat-dev/example-remotion)
 - [Loading compositions remotely](https://github.com/musafiroon/remotion-remote-composition)
 


### PR DESCRIPTION
Adds video-shotcraft to the Tooling section of the Remotion resources page. It is an open-source agent skill for creating cinematic product videos with Remotion, including 106 shot recipes, 161 motion previews, reusable components, SFX assets, and a production-ready template. Validation: git diff --check.