### PR TITLE
`@remotion/studio-server`: Prevent parentheses around wrapped assets

### DIFF
--- a/packages/studio-server/src/codemods/recast-mods.ts
+++ b/packages/studio-server/src/codemods/recast-mods.ts
@@ -21,6 +21,7 @@ import type {RecastCodemod} from '@remotion/studio-shared';
 import * as recast from 'recast';
 import {applyVisualControl} from './apply-visual-control';
 import {deleteJsxElementAtPath} from './delete-jsx-node';
+import {stripParenthesizedExtra} from './strip-parenthesized-extra';
 
 export type Change = {
 	description: string;
@@ -209,27 +210,6 @@ const mapReturnStatement = (
 };
 
 const nullLiteral = (): NullLiteral => ({type: 'NullLiteral'});
-
-// When a node was originally parenthesized (e.g. the `<JSX/>` inside
-// `return (<JSX/>)`), Babel records `extra.parenthesized` on it. If we move
-// such a node into a JSXFragment without clearing that hint, recast prints
-// stray `(` / `)` characters around it as JSX text. Clear the hint so the
-// node prints cleanly in its new context.
-const stripParenthesizedExtra = <T extends {extra?: unknown}>(node: T): T => {
-	if (!node.extra) {
-		return node;
-	}
-
-	const {
-		parenthesized: _p,
-		parenStart: _ps,
-		...rest
-	} = node.extra as {
-		parenthesized?: boolean;
-		parenStart?: number;
-	};
-	return {...node, extra: rest};
-};
 
 const wrapInJsxFragment = (children: JSXFragment['children']): JSXFragment => ({
 	type: 'JSXFragment',

--- a/packages/studio-server/src/codemods/strip-parenthesized-extra.ts
+++ b/packages/studio-server/src/codemods/strip-parenthesized-extra.ts
@@ -1,0 +1,20 @@
+// When a node was originally parenthesized (e.g. the `<JSX/>` inside
+// `return (<JSX/>)`), Babel records `extra.parenthesized` on it. If we move
+// such a node into a new JSX parent without clearing that hint, recast prints
+// stray `(` / `)` characters around it as JSX text.
+export const stripParenthesizedExtra = <T extends object>(node: T): T => {
+	const {extra} = node as {extra?: unknown};
+	if (!extra) {
+		return node;
+	}
+
+	const {
+		parenthesized: _p,
+		parenStart: _ps,
+		...rest
+	} = extra as {
+		parenthesized?: boolean;
+		parenStart?: number;
+	};
+	return {...node, extra: rest};
+};

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -27,6 +27,7 @@ import * as recast from 'recast';
 import {NoReactInternals} from 'remotion/no-react';
 import {formatFileContent} from '../codemods/format-file-content';
 import {parseAst, serializeAst} from '../codemods/parse-ast';
+import {stripParenthesizedExtra} from '../codemods/strip-parenthesized-extra';
 import {parseValueExpression} from '../codemods/update-nested-prop';
 import {
 	ensureNamedImport,
@@ -1836,7 +1837,7 @@ const addElementToComponentRoot = ({
 			recast.types.builders.jsxClosingFragment(),
 			[
 				createSequenceWithChild({
-					child: rootNode,
+					child: stripParenthesizedExtra(rootNode),
 					sequenceLocalName: ensureSequenceImport(ast),
 				}),
 				element,

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -397,6 +397,57 @@ test('wraps a self-closing root in a Sequence before inserting', async () => {
 	}
 });
 
+test('removes parentheses when wrapping a self-closing root in a Sequence', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				"import {Video} from '@remotion/media';",
+				"import {staticFile} from 'remotion';",
+				'',
+				'export const MyComp: React.FC = () => {',
+				'\treturn (',
+				'\t\t<Video src={staticFile("background.mov")} />',
+				'\t);',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const result = await insertJsxElementIntoComposition({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+			element: {
+				type: 'asset',
+				assetType: 'image',
+				src: 'foreground.png',
+				srcType: 'static',
+				dimensions: {width: 1920, height: 1080},
+				position: null,
+			},
+			prettierConfigOverride: {singleQuote: true, useTabs: true},
+		});
+
+		expect(result.output).toContain('<Sequence>\n\t\t\t\t<Video');
+		expect(result.output).not.toContain('<Sequence>\n\t\t\t(');
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('canAddSequence=false for ThreeCanvas root element', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {


### PR DESCRIPTION
## Summary

- clear stale parenthesis metadata when moving a composition's root element into a generated Sequence
- share the existing AST cleanup helper between composition codemods and asset insertion
- add a regression test for inserting a second asset after a parenthesized, self-closing root

## Tests

- `bun test packages/studio-server/src/test/resolve-composition-component.test.ts`
- `bunx turbo run make lint --filter='@remotion/studio-server'`
- `bun run build`
- `bun run stylecheck`

Closes #9350
