### PR TITLE
`@remotion/studio`: Open assets in new window

### DIFF
--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -47,6 +47,7 @@ import {COMPACT_CONTROL_ROW_HEIGHT, Row, Spacing} from './layout';
 import {inlineCodeSnippet} from './Menu/styles';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
+import {getOpenInNewWindowMenuItem} from './open-in-new-window';
 import {openInFileExplorer} from './RenderQueue/actions';
 
 const iconStyle: React.CSSProperties = {
@@ -477,6 +478,11 @@ const AssetSelectorItem: React.FC<{
 
 	const contextMenu = useMemo((): ComboboxValue[] => {
 		return [
+			getOpenInNewWindowMenuItem(`/assets/${relativePath}`),
+			{
+				type: 'divider',
+				id: 'open-in-new-window-divider',
+			},
 			{
 				id: 'copy-asset-file-name',
 				keyHint: null,

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -28,7 +28,6 @@ import {
 	markCompositionSidebarScrollFromRowClick,
 	maybeScrollCompositionSidebarRowIntoView,
 } from '../helpers/sidebar-scroll-into-view';
-import {getUrlForRoute} from '../helpers/url-state';
 import {CollapsedFolderIcon, ExpandedFolderIcon} from '../icons/folder';
 import {ModalsContext} from '../state/modals';
 import {getCompositionMenuItems} from './composition-menu-items';
@@ -39,6 +38,7 @@ import {getFolderMenuItems} from './folder-menu-items';
 import {COMPACT_CONTROL_ROW_HEIGHT, Row, Spacing} from './layout';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
+import {getOpenInNewWindowMenuItem} from './open-in-new-window';
 import {applyCodemod} from './RenderQueue/actions';
 import {SidebarRenderButton} from './SidebarRenderButton';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
@@ -211,49 +211,7 @@ export const CompositionSelectorItem: React.FC<{
 			});
 
 			return [
-				{
-					id: 'open-in-new-window',
-					keyHint: null,
-					label: 'Open in new window',
-					leftItem: null,
-					onClick: () => {
-						const screen = window.screen as Screen & {
-							availLeft?: number;
-							availTop?: number;
-						};
-						const width = Math.min(1200, Math.floor(screen.availWidth * 0.8));
-						const height = Math.min(800, Math.floor(screen.availHeight * 0.8));
-						const displayLeft = screen.availLeft ?? 0;
-						const displayTop = screen.availTop ?? 0;
-						const left = Math.round(
-							Math.min(
-								Math.max(
-									window.screenX + (window.outerWidth - width) / 2,
-									displayLeft,
-								),
-								displayLeft + screen.availWidth - width,
-							),
-						);
-						const top = Math.round(
-							Math.min(
-								Math.max(
-									window.screenY + (window.outerHeight - height) / 2,
-									displayTop,
-								),
-								displayTop + screen.availHeight - height,
-							),
-						);
-						window.open(
-							getUrlForRoute(`/${item.composition.id}`),
-							'_blank',
-							`popup,width=${width},height=${height},left=${left},top=${top}`,
-						);
-					},
-					quickSwitcherLabel: null,
-					subMenu: null,
-					type: 'item',
-					value: 'open-in-new-window',
-				},
+				getOpenInNewWindowMenuItem(`/${item.composition.id}`),
 				{
 					type: 'divider',
 					id: 'open-in-new-window-divider',

--- a/packages/studio/src/components/open-in-new-window.ts
+++ b/packages/studio/src/components/open-in-new-window.ts
@@ -1,0 +1,48 @@
+import {getUrlForRoute} from '../helpers/url-state';
+import type {SelectionItem} from './NewComposition/ComboBox';
+
+export const getOpenInNewWindowMenuItem = (route: string): SelectionItem => {
+	return {
+		id: 'open-in-new-window',
+		keyHint: null,
+		label: 'Open in new window',
+		leftItem: null,
+		onClick: () => {
+			const screen = window.screen as Screen & {
+				availLeft?: number;
+				availTop?: number;
+			};
+			const width = Math.min(1200, Math.floor(screen.availWidth * 0.8));
+			const height = Math.min(800, Math.floor(screen.availHeight * 0.8));
+			const displayLeft = screen.availLeft ?? 0;
+			const displayTop = screen.availTop ?? 0;
+			const left = Math.round(
+				Math.min(
+					Math.max(
+						window.screenX + (window.outerWidth - width) / 2,
+						displayLeft,
+					),
+					displayLeft + screen.availWidth - width,
+				),
+			);
+			const top = Math.round(
+				Math.min(
+					Math.max(
+						window.screenY + (window.outerHeight - height) / 2,
+						displayTop,
+					),
+					displayTop + screen.availHeight - height,
+				),
+			);
+			window.open(
+				getUrlForRoute(route),
+				'_blank',
+				`popup,width=${width},height=${height},left=${left},top=${top}`,
+			);
+		},
+		quickSwitcherLabel: null,
+		subMenu: null,
+		type: 'item',
+		value: 'open-in-new-window',
+	};
+};

--- a/packages/studio/src/test/open-in-new-window.test.ts
+++ b/packages/studio/src/test/open-in-new-window.test.ts
@@ -1,0 +1,50 @@
+import {afterEach, expect, test} from 'bun:test';
+import {getOpenInNewWindowMenuItem} from '../components/open-in-new-window';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+	} else {
+		Reflect.deleteProperty(globalThis, 'window');
+	}
+});
+
+test('opens a Studio route in a centered popup', () => {
+	const openCalls: unknown[][] = [];
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			location: {pathname: '/'},
+			open: (...args: unknown[]) => openCalls.push(args),
+			outerHeight: 1000,
+			outerWidth: 1400,
+			remotion_isReadOnlyStudio: false,
+			screen: {
+				availHeight: 1080,
+				availLeft: 50,
+				availTop: 25,
+				availWidth: 1920,
+			},
+			screenX: 400,
+			screenY: 100,
+		},
+	});
+
+	const item = getOpenInNewWindowMenuItem('/assets/folder/image.png');
+	item.onClick(item.id, null);
+
+	expect(item.label).toBe('Open in new window');
+	expect(openCalls).toEqual([
+		[
+			'/assets/folder/image.png',
+			'_blank',
+			'popup,width=1200,height=800,left=500,top=200',
+		],
+	]);
+});


### PR DESCRIPTION
## Summary

- add an "Open in new window" action to asset selector context menus
- share the existing centered popup behavior between assets and compositions
- cover Studio route opening and popup positioning with a regression test

## Testing

- `bun test src` in `packages/studio` (452 tests passed)
- `bun run build`
- `bun run stylecheck`

Closes #9365
