### PR TITLE
`@remotion/web-renderer`: Fix HtmlInCanvas fallback rendering

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -8,7 +8,6 @@ import React, {
 	useRef,
 } from 'react';
 import type {SequenceControls} from './CompositionManager.js';
-import {delayRender} from './delay-render.js';
 import type {EffectsProp} from './effects/effect-types.js';
 import {runEffectChain} from './effects/run-effect-chain.js';
 import {useEffectChainState} from './effects/use-effect-chain-state.js';
@@ -372,7 +371,7 @@ const HtmlInCanvasContent = forwardRef<
 		const resolvedPixelDensity = resolveHtmlInCanvasPixelDensity(pixelDensity);
 		const canvasWidth = Math.ceil(width * resolvedPixelDensity);
 		const canvasHeight = Math.ceil(height * resolvedPixelDensity);
-		const {continueRender, cancelRender} = useDelayRender();
+		const {delayRender, continueRender, cancelRender} = useDelayRender();
 		const {isClientSideRendering, isRendering} = useRemotionEnvironment();
 		const canRetryMissingPaintRecord = !isRendering || isClientSideRendering;
 		const usesDirectLayoutCanvas =
@@ -579,6 +578,7 @@ const HtmlInCanvasContent = forwardRef<
 			chainState,
 			continueRender,
 			cancelRender,
+			delayRender,
 			resolvedPixelDensity,
 			canRetryMissingPaintRecord,
 		]);
@@ -659,7 +659,7 @@ const HtmlInCanvasContent = forwardRef<
 			return () => {
 				continueRender(handle);
 			};
-		}, [width, height, continueRender, canvasSizeKey]);
+		}, [width, height, continueRender, delayRender, canvasSizeKey]);
 
 		const innerStyle = useMemo(() => {
 			return {

--- a/packages/core/src/test/html-in-canvas.test.tsx
+++ b/packages/core/src/test/html-in-canvas.test.tsx
@@ -2,6 +2,7 @@ import {afterEach, expect, test} from 'bun:test';
 import {cleanup, render, waitFor} from '@testing-library/react';
 import React, {useCallback, useMemo} from 'react';
 import type {TSequence} from '../CompositionManager.js';
+import type {DelayRenderScope} from '../delay-render.js';
 import type {HtmlInCanvasOnPaintParams} from '../HtmlInCanvas.js';
 import {HtmlInCanvas} from '../HtmlInCanvas.js';
 import {Internals} from '../internals.js';
@@ -550,6 +551,54 @@ test('<HtmlInCanvas> lets onInit choose a WebGL2 context', async () => {
 	await waitFor(() => {
 		expect(gotWebGl2Context).toBe(true);
 		expect(paintCalled).toBe(true);
+	});
+});
+
+test('<HtmlInCanvas> uses the scoped delayRender handles', async () => {
+	const delayRenderScope: DelayRenderScope = {
+		remotion_attempt: 0,
+		remotion_delayRenderHandles: [],
+		remotion_delayRenderTimeouts: {},
+		remotion_puppeteerTimeout: 30_000,
+		remotion_renderReady: true,
+	};
+	let resolvePaint!: () => void;
+	const paintPromise = new Promise<void>((resolve) => {
+		resolvePaint = resolve;
+	});
+
+	const {container} = render(
+		<Internals.DelayRenderContextType.Provider value={delayRenderScope}>
+			<SequenceTestWrapper
+				isClientSideRendering
+				isRendering
+				onRegisterSequence={() => undefined}
+			>
+				<HtmlInCanvas width={50} height={50} onPaint={() => paintPromise}>
+					<div>Test</div>
+				</HtmlInCanvas>
+			</SequenceTestWrapper>
+		</Internals.DelayRenderContextType.Provider>,
+	);
+
+	await waitFor(() => {
+		expect(delayRenderScope.remotion_delayRenderHandles).toHaveLength(1);
+	});
+	expect(window.remotion_delayRenderHandles).toHaveLength(0);
+
+	const canvas = container.querySelector('canvas')!;
+	canvas.dispatchEvent(new Event('paint'));
+
+	await waitFor(() => {
+		expect(delayRenderScope.remotion_delayRenderHandles).toHaveLength(1);
+		expect(delayRenderScope.remotion_renderReady).toBe(false);
+	});
+	expect(window.remotion_delayRenderHandles).toHaveLength(0);
+
+	resolvePaint();
+	await waitFor(() => {
+		expect(delayRenderScope.remotion_delayRenderHandles).toHaveLength(0);
+		expect(delayRenderScope.remotion_renderReady).toBe(true);
 	});
 });
 

--- a/packages/docs/docs/client-side-rendering/limitations.mdx
+++ b/packages/docs/docs/client-side-rendering/limitations.mdx
@@ -118,7 +118,7 @@ The [`<Audio>`](/docs/media/audio) from `@remotion/media` is <a style={{color: '
 [`<ThreeCanvas>`](/docs/three-canvas) from [`@remotion/three`](/docs/three) is <a style={{color: 'green'}}>supported</a>.  
 [`<SkiaCanvas>`](/docs/skia/skia-canvas) from [`@remotion/skia`](/docs/skia) is <a style={{color: 'green'}}>supported</a>.  
 [`<AnimatedImage>`](/docs/animatedimage) is <a style={{color: 'green'}}>supported</a> when rendering in Chrome.  
-[`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) is <a style={{color: 'green'}}>supported</a> when the component itself is supported. Automatic [HTML-in-canvas capture](/docs/client-side-rendering/html-in-canvas) requires Chrome or Chromium `152.0.7944.0` or later; older browsers use the built-in DOM composer.<br />
+[`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) is <a style={{color: 'green'}}>supported</a> when the component itself is supported, including its [`onPaint`](/docs/remotion/html-in-canvas#onpaint) and [`onInit`](/docs/remotion/html-in-canvas#oninit) callbacks. Automatic [HTML-in-canvas capture](/docs/client-side-rendering/html-in-canvas) requires Chrome or Chromium `152.0.7944.0` or later; older browsers use the built-in DOM composer.<br />
 [`<OffthreadVideo>`](/docs/offthreadvideo) is <a style={{color: 'red'}}>not supported</a>.  
  → Use [`<Video>`](/docs/media/video) instead.  
 [`<Html5Video>`](/docs/html5-video) is <a style={{color: 'red'}}>not supported</a>.  

--- a/packages/web-renderer/src/create-scaffold.tsx
+++ b/packages/web-renderer/src/create-scaffold.tsx
@@ -189,6 +189,10 @@ export function createScaffold<Props extends Record<string, unknown>>({
 	div.style.backgroundColor = 'transparent';
 	div.style.width = `${width}px`;
 	div.style.height = `${height}px`;
+	// The wrapper's visibility would prevent Chromium from creating paint records
+	// for nested <HtmlInCanvas> elements. Override it on the composition root;
+	// the wrapper's negative z-index still keeps the scaffold behind the host app.
+	div.style.visibility = 'visible';
 
 	const scaffoldClassName = `remotion-scaffold-${Math.random().toString(36).substring(2, 15)}`;
 	div.className = scaffoldClassName;

--- a/packages/web-renderer/src/create-scaffold.tsx
+++ b/packages/web-renderer/src/create-scaffold.tsx
@@ -5,7 +5,11 @@ import type {Codec, DelayRenderScope, LogLevel, TRenderAsset} from 'remotion';
 import {Internals} from 'remotion';
 import type {$ZodObject} from 'zod/v4/core';
 import type {HtmlInCanvasContext} from './html-in-canvas';
-import {setupHtmlInCanvas, teardownHtmlInCanvas} from './html-in-canvas';
+import {
+	containsLayoutSubtreeCanvas,
+	setupHtmlInCanvas,
+	teardownHtmlInCanvas,
+} from './html-in-canvas';
 import type {TimeUpdaterRef} from './update-time';
 import {UpdateTime} from './update-time';
 
@@ -176,6 +180,9 @@ export function createScaffold<Props extends Record<string, unknown>>({
 	wrapper.style.inset = '0';
 	wrapper.style.overflow = 'hidden';
 	wrapper.style.visibility = 'hidden';
+	// A filter keeps visible layout subtrees transparent on screen without
+	// suppressing the paint records that CSS opacity:0 would remove.
+	wrapper.style.filter = 'opacity(0)';
 	wrapper.style.pointerEvents = 'none';
 	wrapper.style.zIndex = '-9999';
 
@@ -189,10 +196,6 @@ export function createScaffold<Props extends Record<string, unknown>>({
 	div.style.backgroundColor = 'transparent';
 	div.style.width = `${width}px`;
 	div.style.height = `${height}px`;
-	// The wrapper's visibility would prevent Chromium from creating paint records
-	// for nested <HtmlInCanvas> elements. Override it on the composition root;
-	// the wrapper's negative z-index still keeps the scaffold behind the host app.
-	div.style.visibility = 'visible';
 
 	const scaffoldClassName = `remotion-scaffold-${Math.random().toString(36).substring(2, 15)}`;
 	div.className = scaffoldClassName;
@@ -207,6 +210,23 @@ export function createScaffold<Props extends Record<string, unknown>>({
 	const htmlInCanvasContext = useHtmlInCanvas
 		? setupHtmlInCanvas({wrapper, div, width, height})
 		: null;
+	const updateFallbackScaffoldVisibility = () => {
+		if (htmlInCanvasContext) {
+			return;
+		}
+
+		// Chromium does not create paint records for a visibility:hidden subtree.
+		// Only expose the composition root when the DOM-composer fallback contains
+		// an <HtmlInCanvas>; keeping other scaffolds hidden avoids affecting canvas
+		// paint scheduling in compositions such as <ThreeCanvas>.
+		div.style.visibility = containsLayoutSubtreeCanvas(div) ? 'visible' : '';
+	};
+
+	const fallbackScaffoldObserver = htmlInCanvasContext
+		? null
+		: new MutationObserver(updateFallbackScaffoldVisibility);
+
+	fallbackScaffoldObserver?.observe(div, {childList: true, subtree: true});
 
 	const errorHolder: ErrorHolder = {error: null};
 
@@ -313,6 +333,7 @@ export function createScaffold<Props extends Record<string, unknown>>({
 			</Internals.MaxMediaCacheSizeContext.Provider>,
 		);
 	});
+	updateFallbackScaffoldVisibility();
 
 	return {
 		delayRenderScope,
@@ -320,6 +341,7 @@ export function createScaffold<Props extends Record<string, unknown>>({
 		errorHolder,
 		htmlInCanvasContext,
 		[Symbol.dispose]: () => {
+			fallbackScaffoldObserver?.disconnect();
 			root.unmount();
 			if (htmlInCanvasContext) {
 				teardownHtmlInCanvas({htmlInCanvasContext, wrapper, div});

--- a/packages/web-renderer/src/test/html-in-canvas.test.tsx
+++ b/packages/web-renderer/src/test/html-in-canvas.test.tsx
@@ -1,5 +1,6 @@
 import {Internals} from 'remotion';
 import {expect, test, vi} from 'vitest';
+import {createScaffold} from '../create-scaffold';
 import {
 	setForceDisableHtmlInCanvasForTesting,
 	supportsNativeHtmlInCanvas,
@@ -116,17 +117,50 @@ test('retries a transient missing nested paint record during a client-side rende
 	expect(simulatedMissingRecord).toBe(true);
 });
 
+test('keeps the DOM composer scaffold paintable', () => {
+	const scaffold = createScaffold({
+		Component: () => null,
+		audioEnabled: false,
+		defaultCodec: null,
+		defaultOutName: null,
+		delayRenderTimeoutInMilliseconds: 30_000,
+		durationInFrames: 1,
+		fps: 30,
+		height: 100,
+		id: 'html-in-canvas-scaffold-visibility',
+		initialFrame: 0,
+		logLevel: 'error',
+		mediaCacheSizeInBytes: null,
+		pixelDensity: 1,
+		resolvedProps: {},
+		schema: null,
+		useHtmlInCanvas: false,
+		videoEnabled: false,
+		width: 100,
+	});
+
+	try {
+		expect(getComputedStyle(scaffold.div.parentElement!).visibility).toBe(
+			'hidden',
+		);
+		expect(getComputedStyle(scaffold.div).visibility).toBe('visible');
+	} finally {
+		scaffold[Symbol.dispose]();
+	}
+});
+
 test('uses the DOM composer when native HTML-in-canvas does not support nesting', async () => {
-	if (!supportsNativeHtmlInCanvas() || (await supportsNestedHtmlInCanvas())) {
+	if (!supportsNativeHtmlInCanvas()) {
 		return;
 	}
 
+	setForceDisableHtmlInCanvasForTesting(true);
 	const warn = vi
 		.spyOn(Internals.Log, 'warn')
 		.mockImplementation(() => undefined);
 
 	try {
-		await renderStillOnWeb({
+		const result = await renderStillOnWeb({
 			composition: nestedHtmlInCanvas,
 			frame: 0,
 			inputProps: {},
@@ -142,7 +176,11 @@ test('uses the DOM composer when native HTML-in-canvas does not support nesting'
 				),
 			),
 		).toBe(false);
+
+		const blob = await result.blob({format: 'png'});
+		await testImage({blob, testId: 'nested-html-in-canvas'});
 	} finally {
+		setForceDisableHtmlInCanvasForTesting(false);
 		warn.mockRestore();
 	}
 });

--- a/packages/web-renderer/src/test/html-in-canvas.test.tsx
+++ b/packages/web-renderer/src/test/html-in-canvas.test.tsx
@@ -117,7 +117,7 @@ test('retries a transient missing nested paint record during a client-side rende
 	expect(simulatedMissingRecord).toBe(true);
 });
 
-test('keeps the DOM composer scaffold paintable', () => {
+test('keeps a scaffold without HTML-in-canvas hidden', () => {
 	const scaffold = createScaffold({
 		Component: () => null,
 		audioEnabled: false,
@@ -142,6 +142,54 @@ test('keeps the DOM composer scaffold paintable', () => {
 	try {
 		expect(getComputedStyle(scaffold.div.parentElement!).visibility).toBe(
 			'hidden',
+		);
+		expect(getComputedStyle(scaffold.div.parentElement!).filter).toBe(
+			'opacity(0)',
+		);
+		expect(getComputedStyle(scaffold.div).visibility).toBe('hidden');
+	} finally {
+		scaffold[Symbol.dispose]();
+	}
+});
+
+test('keeps the DOM composer scaffold paintable', () => {
+	const scaffold = createScaffold({
+		Component: () => (
+			<canvas
+				ref={(node) => {
+					if (node) {
+						(
+							node as HTMLCanvasElement & {layoutSubtree?: boolean}
+						).layoutSubtree = true;
+					}
+				}}
+			/>
+		),
+		audioEnabled: false,
+		defaultCodec: null,
+		defaultOutName: null,
+		delayRenderTimeoutInMilliseconds: 30_000,
+		durationInFrames: 1,
+		fps: 30,
+		height: 100,
+		id: 'html-in-canvas-scaffold-visibility',
+		initialFrame: 0,
+		logLevel: 'error',
+		mediaCacheSizeInBytes: null,
+		pixelDensity: 1,
+		resolvedProps: {},
+		schema: null,
+		useHtmlInCanvas: false,
+		videoEnabled: false,
+		width: 100,
+	});
+
+	try {
+		expect(getComputedStyle(scaffold.div.parentElement!).visibility).toBe(
+			'hidden',
+		);
+		expect(getComputedStyle(scaffold.div.parentElement!).filter).toBe(
+			'opacity(0)',
 		);
 		expect(getComputedStyle(scaffold.div).visibility).toBe('visible');
 	} finally {


### PR DESCRIPTION
## Summary

- register `<HtmlInCanvas>` paint and resize delay handles on the active `DelayRender` scope so `@remotion/web-renderer` waits for them
- keep the DOM-composer scaffold paintable while its outer wrapper remains hidden, allowing Chromium to create nested canvas paint records
- add scoped-handle, scaffold-visibility, and fallback-rendering regression coverage and clarify callback support in the docs

## Testing

- `bun test src/test` from `packages/core`
- `bunx vitest src/test/html-in-canvas.test.tsx --browser --run` from `packages/web-renderer`
- `bun run build`
- `bun run stylecheck`

## Notes

The full web-renderer browser suite recorded 611 passes and 21 skips, with one transient Chromium text screenshot mismatch. That test passed immediately when rerun in isolation across Chromium, Firefox, and WebKit.

Closes #9367
