### PR TITLE
`@remotion/cli`: Fix package manager spawning on Windows

### DIFF
--- a/packages/cli/src/add.ts
+++ b/packages/cli/src/add.ts
@@ -186,17 +186,23 @@ export const addCommand = async ({
 		stdio: RenderInternals.isEqualOrBelowLogLevel(logLevel, 'info')
 			? 'inherit'
 			: 'ignore',
+		...StudioServerInternals.getPackageManagerSpawnOptions(),
 	});
 
-	await new Promise<void>((resolve) => {
+	await new Promise<void>((resolve, reject) => {
+		task.on('error', (err) => {
+			reject(err);
+		});
 		task.on('close', (code) => {
 			if (code === 0) {
 				resolve();
 			} else if (RenderInternals.isEqualOrBelowLogLevel(logLevel, 'info')) {
-				throw new Error(`Failed to install packages, see logs above`);
+				reject(new Error(`Failed to install packages, see logs above`));
 			} else {
-				throw new Error(
-					`Failed to install packages, run with --log=info to see logs`,
+				reject(
+					new Error(
+						`Failed to install packages, run with --log=info to see logs`,
+					),
 				);
 			}
 		});

--- a/packages/studio-server/src/helpers/package-manager-spawn-options.ts
+++ b/packages/studio-server/src/helpers/package-manager-spawn-options.ts
@@ -1,0 +1,8 @@
+import type {SpawnOptionsWithoutStdio} from 'node:child_process';
+
+export const getPackageManagerSpawnOptions = (): Pick<
+	SpawnOptionsWithoutStdio,
+	'shell'
+> => {
+	return process.platform === 'win32' ? {shell: true} : {};
+};

--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -47,6 +47,7 @@ import {
 	getInstalledDependenciesWithVersions,
 } from './helpers/get-installed-dependencies';
 import {getInstallCommand} from './helpers/install-command';
+import {getPackageManagerSpawnOptions} from './helpers/package-manager-spawn-options';
 import {
 	getMaxTimelineTracks,
 	resetMaxTimelineTracks,
@@ -83,6 +84,7 @@ export const StudioServerInternals = {
 	getInstalledDependencies,
 	getInstalledDependenciesWithVersions,
 	getInstallCommand,
+	getPackageManagerSpawnOptions,
 	addCompletedClientRender,
 	getCompletedClientRenders,
 	removeCompletedClientRender,

--- a/packages/studio-server/src/preview-server/routes/install-dependency.ts
+++ b/packages/studio-server/src/preview-server/routes/install-dependency.ts
@@ -8,6 +8,7 @@ import {
 } from '@remotion/studio-shared';
 import {VERSION} from 'remotion/version';
 import {getInstallCommand} from '../../helpers/install-command';
+import {getPackageManagerSpawnOptions} from '../../helpers/package-manager-spawn-options';
 import type {ApiHandler} from '../api-types';
 import {getPackageManager, lockFilePaths} from '../get-package-manager';
 
@@ -74,7 +75,14 @@ export const handleInstallPackage: ApiHandler<
 	const time = Date.now();
 	try {
 		await new Promise<void>((resolve, reject) => {
-			const cmd = spawn(manager.manager, command, {});
+			const cmd = spawn(
+				manager.manager,
+				command,
+				getPackageManagerSpawnOptions(),
+			);
+			cmd.on('error', (err) => {
+				reject(err);
+			});
 			cmd.stdout.on('data', (d: Buffer) => {
 				const splitted = d.toString().trim().split('\n');
 				splitted.forEach((line) => {


### PR DESCRIPTION
## Summary
- Add shared package manager spawn options that use a shell on Windows so npm/pnpm/yarn/bun command shims can be resolved by child_process.spawn().
- Use the shared options for both the CLI add command and the Studio package installation route.
- Reject spawn errors instead of throwing inside async event handlers.

## Testing
- Ran git diff --check.
- Verified the failure mode in a Windows Remotion Studio project where Tools > Install package failed with spawn pnpm ENOENT.
- Verified the workaround in that project by installing @remotion/animation-utils from Studio in Chrome; the install completed successfully.

Note: I did not run the monorepo test suite locally because this clean upstream checkout does not have the Bun-based dependency environment installed.