### PR TITLE
`@remotion/studio`: Scale trimBefore drags by playback rate

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -67,6 +67,7 @@ export type TimelineSequenceLeftEdgeDragTarget = {
 	readonly initialFrom: number;
 	readonly initialTrimBefore: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly playbackRate: number;
 	readonly schema: InteractivitySchema;
 };
 
@@ -227,6 +228,28 @@ const isLeftEdgeDraggableSequence = (sequence: TSequence) => {
 	);
 };
 
+const playbackRateComponentIdentities = new Set([
+	'dev.remotion.gif.Gif',
+	'dev.remotion.media.Audio',
+	'dev.remotion.media.Video',
+	'dev.remotion.remotion.AnimatedImage',
+]);
+
+const getTrimBeforePlaybackRate = (sequence: TSequence) => {
+	const componentIdentity = sequence.controls?.componentIdentity;
+	if (
+		componentIdentity === null ||
+		componentIdentity === undefined ||
+		!playbackRateComponentIdentities.has(componentIdentity)
+	) {
+		return 1;
+	}
+
+	const runtimePlaybackRate =
+		sequence.controls?.currentRuntimeValueDotNotation.playbackRate;
+	return typeof runtimePlaybackRate === 'number' ? runtimePlaybackRate : 1;
+};
+
 const isFromDraggableSequence = (sequence: TSequence) => {
 	return (
 		!sequence.loopDisplay &&
@@ -247,12 +270,14 @@ export const getTimelineSequenceLeftEdgeDragDelta = ({
 	initialDuration,
 	initialTrimBefore,
 	deltaFrames,
+	playbackRate,
 }: {
 	readonly initialDuration: number;
 	readonly initialTrimBefore: number;
 	readonly deltaFrames: number;
+	readonly playbackRate: number;
 }) => {
-	const minDeltaFrames = 0 - initialTrimBefore;
+	const minDeltaFrames = 0 - initialTrimBefore / playbackRate;
 	const maxDeltaFrames = initialDuration - 1;
 
 	return Math.max(minDeltaFrames, Math.min(deltaFrames, maxDeltaFrames));
@@ -263,22 +288,25 @@ export const getTimelineSequenceLeftEdgeDragValues = ({
 	initialFrom,
 	initialTrimBefore,
 	deltaFrames,
+	playbackRate,
 }: {
 	readonly initialDuration: number;
 	readonly initialFrom: number;
 	readonly initialTrimBefore: number;
 	readonly deltaFrames: number;
+	readonly playbackRate: number;
 }) => {
 	const clampedDeltaFrames = getTimelineSequenceLeftEdgeDragDelta({
 		initialDuration,
 		initialTrimBefore,
 		deltaFrames,
+		playbackRate,
 	});
 
 	return {
 		durationInFrames: initialDuration - clampedDeltaFrames,
 		from: initialFrom + clampedDeltaFrames,
-		trimBefore: initialTrimBefore + clampedDeltaFrames,
+		trimBefore: initialTrimBefore + clampedDeltaFrames * playbackRate,
 	};
 };
 
@@ -295,6 +323,7 @@ export const getTimelineSequenceLeftEdgeDragChanges = ({
 			initialFrom: target.initialFrom,
 			initialTrimBefore: target.initialTrimBefore,
 			deltaFrames,
+			playbackRate: target.playbackRate,
 		});
 		const changes: SaveSequencePropChange[] = [];
 
@@ -627,6 +656,7 @@ export const getTimelineSequenceLeftEdgeDragTargets = ({
 						Math.max(0, originalSequence.startMediaFrom))
 					: (originalSequence.trimBefore ?? 0),
 				nodePath,
+				playbackRate: getTrimBeforePlaybackRate(originalSequence),
 				schema: controls.schema,
 			});
 		}
@@ -943,6 +973,7 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 					initialFrom: target.initialFrom,
 					initialTrimBefore: target.initialTrimBefore,
 					deltaFrames,
+					playbackRate: target.playbackRate,
 				});
 				latestRef.current.setDragOverrides(
 					target.nodePath,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -203,6 +203,8 @@ const makeTimelineSequence = ({
 	from = 0,
 	premountDisplay = null,
 	postmountDisplay = null,
+	componentIdentity = null,
+	currentRuntimeValueDotNotation = {},
 	startMediaFrom = 0,
 	type = 'sequence',
 	showInTimeline = true,
@@ -218,6 +220,8 @@ const makeTimelineSequence = ({
 	readonly from?: number;
 	readonly premountDisplay?: number | null;
 	readonly postmountDisplay?: number | null;
+	readonly componentIdentity?: string | null;
+	readonly currentRuntimeValueDotNotation?: Record<string, unknown>;
 	readonly startMediaFrom?: number;
 	readonly type?: TSequence['type'];
 	readonly showInTimeline?: boolean;
@@ -242,10 +246,10 @@ const makeTimelineSequence = ({
 		postmountDisplay,
 		controls: {
 			schema,
-			currentRuntimeValueDotNotation: {},
+			currentRuntimeValueDotNotation,
 			overrideId,
 			supportsEffects: true,
-			componentIdentity: null,
+			componentIdentity,
 			componentName: '<Sequence>',
 		},
 		refForOutline,
@@ -1717,6 +1721,7 @@ test('Timeline left edge drag clamps trimBefore to the visible range', () => {
 			initialFrom: 20,
 			initialTrimBefore: 2,
 			deltaFrames: 10,
+			playbackRate: 1,
 		}),
 	).toEqual({
 		durationInFrames: 1,
@@ -1729,10 +1734,71 @@ test('Timeline left edge drag clamps trimBefore to the visible range', () => {
 			initialFrom: 20,
 			initialTrimBefore: 2,
 			deltaFrames: -10,
+			playbackRate: 1,
 		}),
 	).toEqual({
 		durationInFrames: 6,
 		from: 18,
+		trimBefore: 0,
+	});
+});
+
+test('Timeline left edge drag scales media trimBefore by the runtime playbackRate', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const cases = [
+		{componentIdentity: 'dev.remotion.media.Video', type: 'video'},
+		{componentIdentity: 'dev.remotion.media.Audio', type: 'audio'},
+		{componentIdentity: 'dev.remotion.gif.Gif', type: 'sequence'},
+		{
+			componentIdentity: 'dev.remotion.remotion.AnimatedImage',
+			type: 'sequence',
+		},
+	] as const;
+
+	for (const [index, testCase] of cases.entries()) {
+		const nodePathInfo = makeNodePathInfo(['body', index], []);
+		const targets = getTimelineSequenceLeftEdgeDragTargets({
+			draggedNodePathInfo: nodePathInfo,
+			selectedItems: [{type: 'sequence', nodePathInfo}],
+			sequences: [
+				makeTimelineSequence({
+					schema,
+					componentIdentity: testCase.componentIdentity,
+					currentRuntimeValueDotNotation: {playbackRate: 2},
+					type: testCase.type,
+				}),
+			],
+			overrideIdsToNodePaths: {
+				override: nodePathInfo.sequenceSubscriptionKey,
+			},
+			propStatuses: makeLeftEdgePropStatuses(
+				[nodePathInfo.sequenceSubscriptionKey],
+				true,
+			),
+		});
+
+		expect(targets?.[0].playbackRate).toBe(2);
+		expect(
+			getTimelineSequenceLeftEdgeDragChanges({
+				targets: targets ?? [],
+				deltaFrames: 6,
+			}).find((change) => change.fieldKey === 'trimBefore')?.value,
+		).toBe(12);
+	}
+});
+
+test('Timeline left edge drag clamps scaled trimBefore at zero', () => {
+	expect(
+		getTimelineSequenceLeftEdgeDragValues({
+			initialDuration: 10,
+			initialFrom: 20,
+			initialTrimBefore: 8,
+			deltaFrames: -10,
+			playbackRate: 2,
+		}),
+	).toEqual({
+		durationInFrames: 14,
+		from: 16,
 		trimBefore: 0,
 	});
 });


### PR DESCRIPTION
## Summary

- scale interactive `trimBefore` changes by the media's runtime `playbackRate`
- support Video, Audio, Gif, and AnimatedImage timeline items
- clamp reverse trims so the scaled `trimBefore` value cannot become negative

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9397
