### PR TITLE
`@remotion/studio`: Remove easing paste notification

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -1120,21 +1120,12 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 							return;
 						}
 
-						return updatePromise
-							.then(() => {
-								showNotification(
-									easingSelections.length === 1
-										? 'Pasted easing'
-										: 'Pasted easing to selected segments',
-									2000,
-								);
-							})
-							.catch((err) => {
-								showNotification(
-									`Could not paste easing: ${(err as Error).message}`,
-									3000,
-								);
-							});
+						return updatePromise.catch((err) => {
+							showNotification(
+								`Could not paste easing: ${(err as Error).message}`,
+								3000,
+							);
+						});
 					}
 
 					const effectPropResult = parseEffectPropClipboardDataResult(text);


### PR DESCRIPTION
## Summary

- Keep successful easing pastes silent
- Preserve notifications for unsupported, invalid, and failed easing pastes

## Validation

- `bun test src` in `packages/studio`
- `bun run build`
- `bun run stylecheck`

Closes #9391
