### PR TITLE
`remotion`: Fix animated image decoder race

### DIFF
--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -140,6 +140,18 @@ const AnimatedImageContent = forwardRef<
 
 		useEffect(() => {
 			const controller = new AbortController();
+			let cancelled = false;
+			let continued = false;
+
+			const continueRenderOnce = () => {
+				if (continued) {
+					return;
+				}
+
+				continued = true;
+				continueRender(decodeHandle);
+			};
+
 			decodeImage({
 				resolvedSrc,
 				signal: controller.signal,
@@ -148,26 +160,37 @@ const AnimatedImageContent = forwardRef<
 				initialLoopBehavior,
 			})
 				.then((d) => {
+					if (cancelled) {
+						d.close();
+						return;
+					}
+
 					setImageDecoder(d);
-					continueRender(decodeHandle);
+					continueRenderOnce();
 				})
 				.catch((err) => {
+					if (cancelled) {
+						return;
+					}
+
 					if ((err as Error).name === 'AbortError') {
-						continueRender(decodeHandle);
+						continueRenderOnce();
 
 						return;
 					}
 
 					if (onError) {
 						onError?.(err as Error);
-						continueRender(decodeHandle);
+						continueRenderOnce();
 					} else {
 						cancelRender(err);
 					}
 				});
 
 			return () => {
+				cancelled = true;
 				controller.abort();
+				continueRenderOnce();
 			};
 		}, [
 			resolvedSrc,
@@ -177,6 +200,12 @@ const AnimatedImageContent = forwardRef<
 			initialLoopBehavior,
 			continueRender,
 		]);
+
+		useEffect(() => {
+			return () => {
+				imageDecoder?.close();
+			};
+		}, [imageDecoder]);
 
 		useLayoutEffect(() => {
 			if (!imageDecoder) {

--- a/packages/core/src/animated-image/decode-image.ts
+++ b/packages/core/src/animated-image/decode-image.ts
@@ -7,6 +7,7 @@ export type AnimatedImageCacheItem = {
 };
 
 export type RemotionImageDecoder = {
+	close: () => void;
 	getFrame: (
 		i: number,
 		loopBehavior: RemotionAnimatedImageLoopBehavior,
@@ -62,8 +63,9 @@ export const decodeImage = async ({
 		data: body,
 		type: res.headers.get('Content-Type') || 'image/gif',
 	});
-	await decoder.completed;
-	const {selectedTrack} = decoder.tracks;
+	const {tracks} = decoder;
+	await Promise.all([decoder.completed, tracks.ready]);
+	const {selectedTrack} = tracks;
 	if (!selectedTrack) {
 		throw new Error('No selected track');
 	}
@@ -216,6 +218,14 @@ export const decodeImage = async ({
 	};
 
 	return {
+		close: () => {
+			for (const item of cache) {
+				item.frame?.close();
+				item.frame = null;
+			}
+
+			decoder.close();
+		},
 		getFrame,
 		frameCount: selectedTrack.frameCount,
 	};


### PR DESCRIPTION
## Summary

- wait for animated image track metadata before accessing the selected track
- ignore decoder completion and errors after the component has unmounted
- close the decoder and cached video frames during cleanup

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run make test --filter=remotion`

Closes #9388
