### PR TITLE
`@remotion/web-renderer`: Use native HTML-in-canvas for compositions without nested layout canvases

### DIFF
--- a/packages/web-renderer/src/html-in-canvas.ts
+++ b/packages/web-renderer/src/html-in-canvas.ts
@@ -1,3 +1,5 @@
+import type {InternalState} from './internal-state';
+
 type Canvas2DWithDrawElement = CanvasRenderingContext2D & {
 	drawElementImage: (
 		element: Element | ElementImage,
@@ -24,7 +26,7 @@ export const setForceDisableHtmlInCanvasForTesting = (
 };
 
 export const supportsNativeHtmlInCanvas = (): boolean => {
-	if (typeof document === 'undefined') {
+	if (forceDisableHtmlInCanvasForTesting || typeof document === 'undefined') {
 		return false;
 	}
 
@@ -182,6 +184,7 @@ export const containsLayoutSubtreeCanvas = (element: HTMLElement): boolean => {
 export type HtmlInCanvasContext = {
 	layoutCanvas: HTMLCanvasWithLayoutSubtree;
 	ctx: Canvas2DWithDrawElement;
+	supportsNesting: () => Promise<boolean>;
 };
 
 /**
@@ -238,7 +241,11 @@ export const setupHtmlInCanvas = ({
 	layoutCanvas.appendChild(div);
 	wrapper.appendChild(layoutCanvas);
 
-	return {layoutCanvas, ctx: maybeCtx};
+	return {
+		layoutCanvas,
+		ctx: maybeCtx,
+		supportsNesting: supportsNestedHtmlInCanvas,
+	};
 };
 
 const waitForPaint = (
@@ -257,13 +264,14 @@ const waitForPaint = (
  * The caller is responsible for ensuring the frame content is ready (via
  * waitForReady) before calling this function.
  */
-export const drawWithHtmlInCanvas = async ({
+export const drawHtmlInCanvas = async ({
 	htmlInCanvasContext,
 	element,
 	scaledWidth,
 	scaledHeight,
 	waitForRenderReady,
 	useElementImage,
+	internalState,
 }: {
 	htmlInCanvasContext: HtmlInCanvasContext;
 	element: HTMLElement;
@@ -271,7 +279,8 @@ export const drawWithHtmlInCanvas = async ({
 	scaledHeight: number;
 	waitForRenderReady: () => Promise<void>;
 	useElementImage: boolean;
-}): Promise<OffscreenCanvasRenderingContext2D> => {
+	internalState: InternalState;
+}): Promise<CanvasRenderingContext2D> => {
 	const {ctx, layoutCanvas} = htmlInCanvasContext;
 
 	if (
@@ -282,6 +291,7 @@ export const drawWithHtmlInCanvas = async ({
 		layoutCanvas.height = scaledHeight;
 	}
 
+	const paintStartedAt = performance.now();
 	await waitForPaint(layoutCanvas);
 	// Each nested layout canvas needs one paint to run its async effect and a
 	// second paint to propagate the completed bitmap to its parent. One final
@@ -297,6 +307,9 @@ export const drawWithHtmlInCanvas = async ({
 		await waitForPaint(layoutCanvas);
 	}
 
+	const paintTime = performance.now() - paintStartedAt;
+
+	const drawStartedAt = performance.now();
 	ctx.reset();
 	if (useElementImage) {
 		if (typeof layoutCanvas.captureElementImage !== 'function') {
@@ -313,13 +326,56 @@ export const drawWithHtmlInCanvas = async ({
 		ctx.drawElementImage(element, 0, 0, scaledWidth, scaledHeight);
 	}
 
+	const drawTime = performance.now() - drawStartedAt;
+
+	internalState.addHtmlInCanvasTiming({
+		paintTime,
+		drawTime,
+		copyTime: 0,
+	});
+	return ctx;
+};
+
+export const drawWithHtmlInCanvas = async ({
+	htmlInCanvasContext,
+	element,
+	scaledWidth,
+	scaledHeight,
+	waitForRenderReady,
+	useElementImage,
+	internalState,
+}: {
+	htmlInCanvasContext: HtmlInCanvasContext;
+	element: HTMLElement;
+	scaledWidth: number;
+	scaledHeight: number;
+	waitForRenderReady: () => Promise<void>;
+	useElementImage: boolean;
+	internalState: InternalState;
+}): Promise<OffscreenCanvasRenderingContext2D> => {
+	await drawHtmlInCanvas({
+		htmlInCanvasContext,
+		element,
+		scaledWidth,
+		scaledHeight,
+		waitForRenderReady,
+		useElementImage,
+		internalState,
+	});
+
+	const copyStartedAt = performance.now();
 	const offscreen = new OffscreenCanvas(scaledWidth, scaledHeight);
 	const offCtx = offscreen.getContext('2d');
 	if (!offCtx) {
 		throw new Error('Could not get offscreen context');
 	}
 
-	offCtx.drawImage(layoutCanvas, 0, 0);
+	offCtx.drawImage(htmlInCanvasContext.layoutCanvas, 0, 0);
+	internalState.addHtmlInCanvasTiming({
+		paintTime: 0,
+		drawTime: 0,
+		copyTime: performance.now() - copyStartedAt,
+	});
 	return offCtx;
 };
 

--- a/packages/web-renderer/src/internal-state.ts
+++ b/packages/web-renderer/src/internal-state.ts
@@ -25,6 +25,9 @@ export const makeInternalState = () => {
 	let addSampleTime = 0;
 	let createFrameTime = 0;
 	let audioMixingTime = 0;
+	let htmlInCanvasPaintTime = 0;
+	let htmlInCanvasDrawTime = 0;
+	let htmlInCanvasCopyTime = 0;
 
 	const helperCanvasState: HelperCanvasState = {
 		current: null,
@@ -64,6 +67,22 @@ export const makeInternalState = () => {
 		getAudioMixingTime: () => audioMixingTime,
 		addAudioMixingTime: (time: number) => {
 			audioMixingTime += time;
+		},
+		getHtmlInCanvasPaintTime: () => htmlInCanvasPaintTime,
+		getHtmlInCanvasDrawTime: () => htmlInCanvasDrawTime,
+		getHtmlInCanvasCopyTime: () => htmlInCanvasCopyTime,
+		addHtmlInCanvasTiming: ({
+			paintTime,
+			drawTime,
+			copyTime,
+		}: {
+			paintTime: number;
+			drawTime: number;
+			copyTime: number;
+		}) => {
+			htmlInCanvasPaintTime += paintTime;
+			htmlInCanvasDrawTime += drawTime;
+			htmlInCanvasCopyTime += copyTime;
 		},
 	};
 };

--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -12,7 +12,7 @@ import {canUseWebFsWriter} from './can-use-webfs-target';
 import {createAudioSampleSource} from './create-audio-sample-source';
 import {checkForError, createScaffold} from './create-scaffold';
 import {getRealFrameRange, type FrameRange} from './frame-range';
-import {supportsNestedHtmlInCanvas} from './html-in-canvas';
+import {supportsNativeHtmlInCanvas} from './html-in-canvas';
 import type {InternalState} from './internal-state';
 import {makeInternalState} from './internal-state';
 import {
@@ -44,7 +44,10 @@ import type {CompositionCalculateMetadataOrExplicit} from './props-if-has-props'
 import {onlyOneRenderAtATimeQueue} from './render-operations-queue';
 import {resolveAudioCodec} from './resolve-audio-codec';
 import {sendUsageEvent} from './send-telemetry-event';
-import {createLayer, type HtmlInCanvasLayerOutcome} from './take-screenshot';
+import {
+	createMediaLayer,
+	type HtmlInCanvasLayerOutcome,
+} from './take-screenshot';
 import {createThrottledProgressCallback} from './throttle-progress';
 import {validateScale} from './validate-scale';
 import {validateVideoFrame, type OnFrameCallback} from './validate-video-frame';
@@ -153,6 +156,23 @@ type InternalRenderMediaOnWebOptions<
 > = MandatoryRenderMediaOnWebOptions<Schema, Props> &
 	OptionalRenderMediaOnWebOptions<Schema> &
 	InputPropsIfHasProps<Schema, Props>;
+
+const copyToOffscreenCanvas = (
+	canvas: HTMLCanvasElement | OffscreenCanvas,
+): OffscreenCanvas => {
+	if (canvas instanceof OffscreenCanvas) {
+		return canvas;
+	}
+
+	const offscreen = new OffscreenCanvas(canvas.width, canvas.height);
+	const context = offscreen.getContext('2d');
+	if (!context) {
+		throw new Error('Could not get context');
+	}
+
+	context.drawImage(canvas, 0, 0);
+	return offscreen;
+};
 
 // TODO: Validating inputs
 // TODO: Apply defaultCodec
@@ -311,7 +331,7 @@ const internalRenderMediaOnWeb = async <
 		return Promise.reject(new Error('renderMediaOnWeb() was cancelled'));
 	}
 
-	const useHtmlInCanvas = await supportsNestedHtmlInCanvas();
+	const useHtmlInCanvas = supportsNativeHtmlInCanvas();
 
 	using scaffold = createScaffold({
 		width: resolved.width,
@@ -506,16 +526,15 @@ const internalRenderMediaOnWeb = async <
 			);
 
 			let frameToEncode: VideoFrame | null = null;
-			let layerCanvas: OffscreenCanvas | null = null;
+			let layerCanvas: HTMLCanvasElement | OffscreenCanvas | null = null;
 
 			if (videoEnabled) {
 				const createFrameStart = performance.now();
-				const layer = await createLayer({
+				const layer = await createMediaLayer({
 					element: div,
 					scale,
 					logLevel,
 					internalState,
-					onlyBackgroundClipText: false,
 					cutout: new DOMRect(0, 0, resolved.width, resolved.height),
 					htmlInCanvasContext,
 					onHtmlInCanvasLayerOutcome: htmlInCanvasContext
@@ -579,7 +598,7 @@ const internalRenderMediaOnWeb = async <
 			const assets = collectAssets.current!.collectAssets();
 			if (onArtifact) {
 				await artifactsHandler.handle({
-					imageData: layerCanvas,
+					imageData: layerCanvas ? copyToOffscreenCanvas(layerCanvas) : null,
 					frame,
 					assets,
 					onArtifact,
@@ -640,7 +659,7 @@ const internalRenderMediaOnWeb = async <
 
 		Internals.Log.verbose(
 			{logLevel, tag: 'web-renderer'},
-			`Render timings: waitForReady=${internalState.getWaitForReadyTime().toFixed(2)}ms, createFrame=${internalState.getCreateFrameTime().toFixed(2)}ms, addSample=${internalState.getAddSampleTime().toFixed(2)}ms, audioMixing=${internalState.getAudioMixingTime().toFixed(2)}ms`,
+			`Render timings: waitForReady=${internalState.getWaitForReadyTime().toFixed(2)}ms, createFrame=${internalState.getCreateFrameTime().toFixed(2)}ms, addSample=${internalState.getAddSampleTime().toFixed(2)}ms, audioMixing=${internalState.getAudioMixingTime().toFixed(2)}ms, htmlInCanvasPaint=${internalState.getHtmlInCanvasPaintTime().toFixed(2)}ms, htmlInCanvasDraw=${internalState.getHtmlInCanvasDrawTime().toFixed(2)}ms, htmlInCanvasCopy=${internalState.getHtmlInCanvasCopyTime().toFixed(2)}ms`,
 		);
 
 		if (webFsTarget) {

--- a/packages/web-renderer/src/render-still-on-web.tsx
+++ b/packages/web-renderer/src/render-still-on-web.tsx
@@ -7,7 +7,7 @@ import type {$ZodObject} from 'zod/v4/core';
 import type {WebRendererOnArtifact} from './artifact';
 import {handleArtifacts} from './artifact';
 import {checkForError, createScaffold} from './create-scaffold';
-import {supportsNestedHtmlInCanvas} from './html-in-canvas';
+import {supportsNativeHtmlInCanvas} from './html-in-canvas';
 import {makeInternalState} from './internal-state';
 import type {CompositionCalculateMetadataOrExplicit} from './props-if-has-props';
 import type {InputPropsIfHasProps} from './render-media-on-web';
@@ -114,7 +114,7 @@ async function internalRenderStillOnWeb<
 		return Promise.reject(new Error('renderStillOnWeb() was cancelled'));
 	}
 
-	const useHtmlInCanvas = await supportsNestedHtmlInCanvas();
+	const useHtmlInCanvas = supportsNativeHtmlInCanvas();
 
 	using internalState = makeInternalState();
 

--- a/packages/web-renderer/src/take-screenshot.ts
+++ b/packages/web-renderer/src/take-screenshot.ts
@@ -4,6 +4,7 @@ import {compose} from './compose';
 import type {HtmlInCanvasContext} from './html-in-canvas';
 import {
 	containsLayoutSubtreeCanvas,
+	drawHtmlInCanvas,
 	drawWithHtmlInCanvas,
 } from './html-in-canvas';
 import type {InternalState} from './internal-state';
@@ -37,15 +38,19 @@ export const createLayer = async ({
 }) => {
 	const scaledWidth = Math.ceil(cutout.width * scale);
 	const scaledHeight = Math.ceil(cutout.height * scale);
+	const hasNestedHtmlInCanvas =
+		element instanceof HTMLElement && containsLayoutSubtreeCanvas(element);
+	const canUseNativeHtmlInCanvas =
+		!hasNestedHtmlInCanvas ||
+		(await htmlInCanvasContext?.supportsNesting()) === true;
 
 	if (
 		!onlyBackgroundClipText &&
 		element instanceof HTMLElement &&
 		htmlInCanvasContext &&
-		onHtmlInCanvasLayerOutcome
+		onHtmlInCanvasLayerOutcome &&
+		canUseNativeHtmlInCanvas
 	) {
-		const hasNestedHtmlInCanvas = containsLayoutSubtreeCanvas(element);
-
 		try {
 			const offCtx = await drawWithHtmlInCanvas({
 				htmlInCanvasContext,
@@ -54,6 +59,7 @@ export const createLayer = async ({
 				scaledHeight,
 				waitForRenderReady,
 				useElementImage: hasNestedHtmlInCanvas,
+				internalState,
 			});
 			onHtmlInCanvasLayerOutcome({native: true});
 			return offCtx;
@@ -91,4 +97,77 @@ export const createLayer = async ({
 	});
 
 	return context;
+};
+
+export const createMediaLayer = async ({
+	element,
+	scale,
+	logLevel,
+	internalState,
+	cutout,
+	htmlInCanvasContext,
+	onHtmlInCanvasLayerOutcome,
+	waitForPageResponsiveness,
+	waitForRenderReady,
+}: {
+	element: HTMLElement;
+	scale: number;
+	logLevel: LogLevel;
+	internalState: InternalState;
+	cutout: DOMRect;
+	htmlInCanvasContext: HtmlInCanvasContext | null;
+	onHtmlInCanvasLayerOutcome?: (outcome: HtmlInCanvasLayerOutcome) => void;
+	waitForPageResponsiveness: (() => Promise<void>) | null;
+	waitForRenderReady: () => Promise<void>;
+}): Promise<CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D> => {
+	const scaledWidth = Math.ceil(cutout.width * scale);
+	const scaledHeight = Math.ceil(cutout.height * scale);
+	const hasNestedHtmlInCanvas = containsLayoutSubtreeCanvas(element);
+	const canUseNativeHtmlInCanvas =
+		!hasNestedHtmlInCanvas ||
+		(await htmlInCanvasContext?.supportsNesting()) === true;
+
+	if (
+		htmlInCanvasContext &&
+		onHtmlInCanvasLayerOutcome &&
+		canUseNativeHtmlInCanvas
+	) {
+		try {
+			const context = await drawHtmlInCanvas({
+				htmlInCanvasContext,
+				element,
+				scaledWidth,
+				scaledHeight,
+				waitForRenderReady,
+				useElementImage: hasNestedHtmlInCanvas,
+				internalState,
+			});
+			onHtmlInCanvasLayerOutcome({native: true});
+			return context;
+		} catch (err) {
+			const detail = err instanceof Error ? err.message : JSON.stringify(err);
+			onHtmlInCanvasLayerOutcome({
+				native: false,
+				reason: `drawElementImage failed (${detail}); falling back to the built-in DOM composer.`,
+				shouldWarn: true,
+			});
+			Internals.Log.verbose(
+				{logLevel, tag: '@remotion/web-renderer'},
+				'HTML-in-canvas capture failed, falling back to software compose',
+				err,
+			);
+		}
+	}
+
+	return createLayer({
+		element,
+		scale,
+		logLevel,
+		internalState,
+		onlyBackgroundClipText: false,
+		cutout,
+		htmlInCanvasContext: null,
+		waitForPageResponsiveness,
+		waitForRenderReady,
+	});
 };

--- a/packages/web-renderer/src/test/html-in-canvas.test.tsx
+++ b/packages/web-renderer/src/test/html-in-canvas.test.tsx
@@ -1,4 +1,4 @@
-import {Internals} from 'remotion';
+import {AbsoluteFill, Internals} from 'remotion';
 import {expect, test, vi} from 'vitest';
 import {createScaffold} from '../create-scaffold';
 import {
@@ -13,6 +13,52 @@ import {nestedHtmlInCanvas} from './fixtures/nested-html-in-canvas';
 import {testImage} from './utils';
 
 setForceDisableHtmlInCanvasForTesting(false);
+
+test('uses native HTML-in-canvas for compositions without nested layout canvases', async () => {
+	if (!supportsNativeHtmlInCanvas()) {
+		return;
+	}
+
+	const warn = vi
+		.spyOn(Internals.Log, 'warn')
+		.mockImplementation(() => undefined);
+
+	try {
+		const result = await renderStillOnWeb({
+			composition: {
+				component: () => (
+					<AbsoluteFill style={{backgroundColor: 'rgb(255, 0, 0)'}} />
+				),
+				durationInFrames: 1,
+				fps: 30,
+				height: 100,
+				id: 'non-nested-html-in-canvas',
+				width: 100,
+			},
+			frame: 0,
+			inputProps: {},
+			licenseKey: 'free-license',
+		});
+		const canvas = await result.canvas();
+		const context = canvas.getContext('2d');
+		const pixel = context?.getImageData(50, 50, 1, 1).data;
+
+		expect(pixel?.[0]).toBeGreaterThan(250);
+		expect(pixel?.[1]).toBeLessThan(5);
+		expect(pixel?.[2]).toBeLessThan(5);
+		expect(
+			warn.mock.calls.some((call) =>
+				call.some(
+					(value) =>
+						typeof value === 'string' &&
+						value.includes('Using Chromium experimental HTML-in-canvas'),
+				),
+			),
+		).toBe(true);
+	} finally {
+		warn.mockRestore();
+	}
+});
 
 test('captures three nested HTML-in-canvas effect layers natively', async () => {
 	const supportsNesting = await supportsNestedHtmlInCanvas();


### PR DESCRIPTION
## Benchmarks

Measured in Chrome 150 with `--enable-features=CanvasDrawElement`, 1280×720 @ 30fps, 30 frames, `renderMediaOnWeb()`:

| Composition | Metric | DOM composer (before) | Native path (this PR) | Speedup |
|---|---|---|---|---|
| DOM-heavy (120 animated tiles + SVG) | frame capture (`createFrame`) | ~1,900 ms | **~50 ms** | **~38×** |
| Video + 48 animated DOM overlays | total render | ~910 ms | **~610 ms** | **~1.5×** |
| Video + 48 animated DOM overlays | frame capture (`createFrame`) | ~720 ms | **~435 ms** | **~1.7×** |

The capture speedup comes from using the browser's native `drawElementImage` rasterization instead of the software DOM composer for compositions that were previously excluded from it (see below). After this change, encoding becomes the dominant cost for DOM-heavy compositions rather than capture.

## Summary

- The native `drawElementImage` capture path was previously gated on `supportsNestedHtmlInCanvas()`, so browsers that support basic `drawElementImage` (`CanvasDrawElement`) but not nested layout-subtree capture (`CanvasDrawElementInSubtree`) fell back to the DOM composer for **every** composition — including ones with no nested layout canvases at all. Nesting support is now probed lazily per layer (`HtmlInCanvasContext.supportsNesting`), so plain-DOM compositions use the native path whenever basic `drawElementImage` is available.
- `renderMediaOnWeb()` now captures video frames directly from the layout canvas via the new `createMediaLayer()` instead of round-tripping each frame through an intermediate `OffscreenCanvas`, saving one full-frame copy per frame. On failure it falls back to the existing DOM composer path, preserving current behavior.
- Adds paint/draw/copy timing counters to the internal state; they are reported in the existing verbose "Render timings" log line to make future profiling easier.

## Test plan

- [x] New test: `uses native HTML-in-canvas for compositions without nested layout canvases` — renders a solid-color still, asserts pixel output and that the native-path warning fired (skips when `drawElementImage` is unavailable).
- [x] Full `@remotion/web-renderer` vitest suite passes on Chromium (74 files, 211 passed / 2 skipped), including the existing nested HTML-in-canvas and DOM-composer fallback screenshot tests.
- [x] `eslint` and `tsc` clean on changed files.

Note: the tests exercising the native path require Chrome with `--enable-features=CanvasDrawElement,CanvasDrawElementInSubtree`; they skip gracefully otherwise (same pattern as the existing nested tests). Happy to also add those flags to the Chromium instance in `vitest.config.ts` if you want them exercised in CI — left it out of this PR to keep CI behavior unchanged.