### PR TITLE
`@remotion/example-videos`: Retry media downloads in the flaky test

### DIFF
--- a/packages/example-videos/src/cached-example-media.ts
+++ b/packages/example-videos/src/cached-example-media.ts
@@ -38,7 +38,7 @@ const downloadFile = async (url: string, location: string) => {
 	const {$} = await import('bun');
 	console.log('Downloading', url);
 	console.time(`Download ${url}`);
-	await $`curl -f -o ${location} ${url}`;
+	await $`curl -f --retry 3 --retry-all-errors -o ${location} ${url}`;
 	console.timeEnd(`Download ${url}`);
 };
 


### PR DESCRIPTION
## Summary

- retry example media downloads up to three times
- include transient HTTP and network failures to reduce CI flakes

## Verification

- `bun run build`
- `bun run stylecheck`

Addresses #8375
