### PR TITLE
Fix two ways the Player's playback loop can stall permanently while isPlaying() stays true

### DIFF
--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -43,12 +43,14 @@ const useBufferManager = (
 	mountTime: number | null,
 ): BufferManager => {
 	const [blocks, setBlocks] = useState<Block[]>([]);
-	const [onBufferingCallbacks, setOnBufferingCallbacks] = useState<
-		OnBufferingCallback[]
-	>([]);
-	const [onResumeCallbacks, setOnResumeCallbacks] = useState<
-		OnBufferingCallback[]
-	>([]);
+	// Listener registries are refs, not state: `usePlayback` parks its loop
+	// during buffering and registers its resume listener from a rAF callback.
+	// With state, that registration only lands after the next React commit -
+	// if the last block unblocks before then, the resume dispatch reads the
+	// previous array, the listener is never called, and the playback loop
+	// stays parked forever (frame clock frozen while isPlaying() is true).
+	const onBufferingCallbacks = useRef<OnBufferingCallback[]>([]);
+	const onResumeCallbacks = useRef<OnBufferingCallback[]>([]);
 
 	const env = useRemotionEnvironment();
 	const rendering = env.isRendering;
@@ -89,11 +91,16 @@ const useBufferManager = (
 
 	const listenForBuffering: ListenForBuffering = useCallback(
 		(callback: OnBufferingCallback) => {
-			setOnBufferingCallbacks((c) => [...c, callback]);
+			onBufferingCallbacks.current = [
+				...onBufferingCallbacks.current,
+				callback,
+			];
 
 			return {
 				remove: () => {
-					setOnBufferingCallbacks((c) => c.filter((cb) => cb !== callback));
+					onBufferingCallbacks.current = onBufferingCallbacks.current.filter(
+						(cb) => cb !== callback,
+					);
 				},
 			};
 		},
@@ -102,11 +109,13 @@ const useBufferManager = (
 
 	const listenForResume: ListenForResume = useCallback(
 		(callback: OnResumeCallback) => {
-			setOnResumeCallbacks((c) => [...c, callback]);
+			onResumeCallbacks.current = [...onResumeCallbacks.current, callback];
 
 			return {
 				remove: () => {
-					setOnResumeCallbacks((c) => c.filter((cb) => cb !== callback));
+					onResumeCallbacks.current = onResumeCallbacks.current.filter(
+						(cb) => cb !== callback,
+					);
 				},
 			};
 		},
@@ -123,7 +132,7 @@ const useBufferManager = (
 		// not re-dispatch `waiting` to listeners.
 		if (blocks.length > 0 && !buffering.current) {
 			buffering.current = true;
-			onBufferingCallbacks.forEach((c) => c());
+			[...onBufferingCallbacks.current].forEach((c) => c());
 			playbackLogging({
 				logLevel,
 				message: 'Player is entering buffer state',
@@ -151,7 +160,7 @@ const useBufferManager = (
 			// dispatch `resume` to listeners.
 			if (blocks.length === 0 && buffering.current) {
 				buffering.current = false;
-				onResumeCallbacks.forEach((c) => c());
+				[...onResumeCallbacks.current].forEach((c) => c());
 				playbackLogging({
 					logLevel,
 					message: 'Player is exiting buffer state',

--- a/packages/core/src/test/buffering.test.tsx
+++ b/packages/core/src/test/buffering.test.tsx
@@ -103,3 +103,65 @@ test('a block added and removed within the same commit emits no events', () => {
 	expect(events).toEqual([]);
 	expect(manager!.buffering.current).toBe(false);
 });
+
+test('a listener registered while buffering ends still receives "resume"', () => {
+	// usePlayback() parks its loop during buffering and registers its resume
+	// listener from outside the React render cycle (a rAF callback). The
+	// registration must be visible to the resume dispatch of the very next
+	// commit - if it only lands one commit later, the resume is missed and the
+	// playback loop stays parked forever.
+	let registerOnNextCommit = false;
+	let resumed = false;
+
+	const LateRegistrar: React.FC<{generation: number}> = ({generation}) => {
+		const context = useContext(BufferingContextReact);
+
+		useLayoutEffect(() => {
+			if (registerOnNextCommit) {
+				registerOnNextCommit = false;
+				context!.listenForResume(() => {
+					resumed = true;
+				});
+			}
+		}, [context, generation]);
+
+		return null;
+	};
+
+	const renderWithGeneration = (generation: number) =>
+		render(
+			<RemotionEnvironmentContext.Provider value={previewEnvironment}>
+				<BufferingProvider>
+					<Harness />
+					<LateRegistrar generation={generation} />
+				</BufferingProvider>
+			</RemotionEnvironmentContext.Provider>,
+		);
+
+	const {rerender} = renderWithGeneration(1);
+
+	let block: {unblock: () => void} | null = null;
+	act(() => {
+		block = manager!.addBlock({id: 'scrub'});
+	});
+	expect(manager!.buffering.current).toBe(true);
+
+	// Register inside the same commit that empties the block list - the child's
+	// layout effect runs before the provider's dispatch effect, like the
+	// playback loop registering mid-transition.
+	registerOnNextCommit = true;
+	act(() => {
+		rerender(
+			<RemotionEnvironmentContext.Provider value={previewEnvironment}>
+				<BufferingProvider>
+					<Harness />
+					<LateRegistrar generation={2} />
+				</BufferingProvider>
+			</RemotionEnvironmentContext.Provider>,
+		);
+		block!.unblock();
+	});
+
+	expect(manager!.buffering.current).toBe(false);
+	expect(resumed).toBe(true);
+});

--- a/packages/core/src/test/buffering.test.tsx
+++ b/packages/core/src/test/buffering.test.tsx
@@ -113,7 +113,9 @@ test('a listener registered while buffering ends still receives "resume"', () =>
 	let registerOnNextCommit = false;
 	let resumed = false;
 
-	const LateRegistrar: React.FC<{generation: number}> = ({generation}) => {
+	const LateRegistrar: React.FC<{readonly generation: number}> = ({
+		generation,
+	}) => {
 		const context = useContext(BufferingContextReact);
 
 		useLayoutEffect(() => {

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -10,6 +10,8 @@ import {useIsBackgrounded} from './is-backgrounded.js';
 import {setGlobalTimeAnchor} from './set-global-time-anchor.js';
 import {usePlayer} from './use-player.js';
 
+const AUDIO_CONTEXT_RESUME_DEADLINE_MS = 500;
+
 const shouldForceAnchorChange = (newState: RemotionAudioContextState) => {
 	if (newState === 'suspended' || newState === 'running-to-suspended') {
 		return true;
@@ -239,15 +241,44 @@ export const usePlayback = ({
 			queueNextFrame();
 		};
 
+		// AudioContext.resume() promises can stay pending forever in Chromium
+		// when a suspend() lands while the resume is still in flight - which
+		// happens routinely when the user scrubs while playing, because each
+		// effect teardown calls suspend(). Waiting on such a promise without a
+		// deadline parks the playback loop permanently: isPlaying() stays true,
+		// the frame clock never advances, and only a seek or pause/play revives
+		// it. Bound the wait; past the deadline, keep ticking without audio and
+		// let audio rejoin once the context actually resumes.
+		let audioResumeBypass = false;
+
 		const queueNextFrame = () => {
+			if (hasBeenStopped) {
+				return;
+			}
+
 			const getIsResumingAudioContext =
 				sharedAudioContext?.getIsResumingAudioContext?.() ?? null;
-			if (getIsResumingAudioContext !== null && !muted) {
-				getIsResumingAudioContext.then(() => {
+			if (getIsResumingAudioContext !== null && !muted && !audioResumeBypass) {
+				let continued = false;
+				const continuePlayback = () => {
+					if (continued || hasBeenStopped) {
+						return;
+					}
+
+					continued = true;
 					startedTime = performance.now();
 					framesAdvanced = 0;
 					queueNextFrame();
+				};
+
+				getIsResumingAudioContext.then(() => {
+					audioResumeBypass = false;
+					continuePlayback();
 				});
+				setTimeout(() => {
+					audioResumeBypass = true;
+					continuePlayback();
+				}, AUDIO_CONTEXT_RESUME_DEADLINE_MS);
 
 				return;
 			}


### PR DESCRIPTION
## Symptom

Scrubbing a media-heavy composition while it plays can leave the Player in a state where video and audio elements keep running but the frame clock never advances again: getCurrentFrame() returns the same value forever, isPlaying() returns true, the buffering flag is false, and no waiting/resume events fire. Only a seek or a pause/play cycle revives it. In our editor this reproduced within a minute of scrubbing on most sessions.

We instrumented the playback loop in production builds and traced the stall to two independent causes in how usePlayback parks and resumes itself. Both fixes are small; each was verified against its own failure trace.

## Cause 1: resume listeners registered through React state can miss the resume

useBufferManager keeps its listener arrays in useState, so listenForResume() only takes effect after the next commit. usePlayback registers its resume listener from a rAF callback while buffering is active. If the last buffering block unblocks before that registration commits, the resume dispatch iterates the previous callback array, the listener never fires, and the loop stays parked with nothing left to wake it. The window is a full React commit, which rapid scrub-driven buffering churn hits often.

Fix: keep the listener registries in refs so registration is visible to the dispatch of the same commit. Dispatch iterates a snapshot, preserving the existing guarantee that a callback removing itself does not skip the next one. Added a regression test that registers a listener from a child layout effect inside the commit that empties the block list; it fails on the previous implementation and passes now.

## Cause 2: waiting on AudioContext.resume() with no deadline

queueNextFrame() awaits sharedAudioContext.getIsResumingAudioContext() before scheduling the next frame. In Chromium, a resume() promise can stay pending indefinitely when a suspend() lands while the resume is still in flight, and the loop's own teardown calls suspend() on every effect re-run. During scrubbing the playback effect restarts constantly, so an orphaned resume promise is easy to produce, and the loop then waits on it forever.

Fix: race the wait against a 500ms deadline. Past the deadline the loop resumes ticking without audio (the bypass is sticky per loop instance, so it does not re-park on the same pending promise once per frame) and audio rejoins when the promise settles. Also added a hasBeenStopped guard to queueNextFrame so a torn-down loop cannot keep re-parking from a late promise resolution.

## Notes for review

- The trace that isolated cause 2 looked like: loop-start -> park on getIsResumingAudioContext -> nothing, repeated across sessions; after the deadline was added without the sticky bypass, the loop re-parked on the same pending promise once per timeout, so the bypass flag is load-bearing.
- I could not find a practical way to unit-test cause 2 without mounting a full Player against a mocked shared audio context; suggestions welcome. Cause 1 has a test in packages/core/src/test/buffering.test.tsx.
- bun test src/test/buffering.test.tsx passes (4 tests), and bun run make succeeds in packages/core and packages/player.

Opening as a draft to hear whether you would rather handle the audio wait with cancellation on suspend() instead of a deadline.