### PR TITLE
`@remotion/studio`: Make pasting keyframes easier

### DIFF
--- a/packages/studio-shared/src/keyframe-clipboard-data.ts
+++ b/packages/studio-shared/src/keyframe-clipboard-data.ts
@@ -49,7 +49,7 @@ export type KeyframeClipboardData = {
 	readonly version: 1;
 	readonly remotionClipboard: 'keyframe';
 	readonly fieldType: KeyframeClipboardFieldType | null;
-	readonly field?: KeyframeClipboardField;
+	readonly field: KeyframeClipboardField | null;
 	readonly keyframes: readonly {
 		readonly frameOffset: number;
 		readonly value: unknown;
@@ -169,17 +169,12 @@ export const parseKeyframeClipboardDataResult = (
 			parsed.type !== 'keyframe' ||
 			!areValidKeyframes(parsed.keyframes) ||
 			easing === null ||
-			(Object.hasOwn(parsed, 'field') &&
-				!isKeyframeClipboardField(parsed.field)) ||
+			(parsed.field !== null && !isKeyframeClipboardField(parsed.field)) ||
 			(parsed.fieldType !== null &&
 				!isKeyframeClipboardFieldType(parsed.fieldType))
 		) {
 			return {status: 'invalid'};
 		}
-
-		const field = Object.hasOwn(parsed, 'field')
-			? {field: parsed.field as KeyframeClipboardField}
-			: {};
 
 		return {
 			status: 'valid',
@@ -188,7 +183,7 @@ export const parseKeyframeClipboardDataResult = (
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: parsed.fieldType,
-				...field,
+				field: parsed.field,
 				keyframes: parsed.keyframes,
 				easing,
 			},

--- a/packages/studio-shared/src/keyframe-clipboard-data.ts
+++ b/packages/studio-shared/src/keyframe-clipboard-data.ts
@@ -34,11 +34,22 @@ export type KeyframeClipboardFieldType = {
 		: never;
 }[keyof KeyframeClipboardFieldTypeSupport];
 
+export type KeyframeClipboardField =
+	| {
+			readonly type: 'sequence';
+			readonly fieldKey: string;
+	  }
+	| {
+			readonly type: 'effect';
+			readonly fieldKey: string;
+	  };
+
 export type KeyframeClipboardData = {
 	readonly type: 'keyframe';
 	readonly version: 1;
 	readonly remotionClipboard: 'keyframe';
 	readonly fieldType: KeyframeClipboardFieldType | null;
+	readonly field?: KeyframeClipboardField;
 	readonly keyframes: readonly {
 		readonly frameOffset: number;
 		readonly value: unknown;
@@ -107,6 +118,16 @@ const areValidKeyframes = (
 	return value[0]?.frameOffset === 0;
 };
 
+const isKeyframeClipboardField = (
+	value: unknown,
+): value is KeyframeClipboardField => {
+	return (
+		isRecord(value) &&
+		(value.type === 'sequence' || value.type === 'effect') &&
+		typeof value.fieldKey === 'string'
+	);
+};
+
 const parseEasings = ({
 	value,
 	keyframeCount,
@@ -148,11 +169,17 @@ export const parseKeyframeClipboardDataResult = (
 			parsed.type !== 'keyframe' ||
 			!areValidKeyframes(parsed.keyframes) ||
 			easing === null ||
+			(Object.hasOwn(parsed, 'field') &&
+				!isKeyframeClipboardField(parsed.field)) ||
 			(parsed.fieldType !== null &&
 				!isKeyframeClipboardFieldType(parsed.fieldType))
 		) {
 			return {status: 'invalid'};
 		}
+
+		const field = Object.hasOwn(parsed, 'field')
+			? {field: parsed.field as KeyframeClipboardField}
+			: {};
 
 		return {
 			status: 'valid',
@@ -161,6 +188,7 @@ export const parseKeyframeClipboardDataResult = (
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: parsed.fieldType,
+				...field,
 				keyframes: parsed.keyframes,
 				easing,
 			},

--- a/packages/studio-shared/src/test/keyframe-clipboard-data.test.ts
+++ b/packages/studio-shared/src/test/keyframe-clipboard-data.test.ts
@@ -12,6 +12,7 @@ test('parses keyframe clipboard data', () => {
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: 'number',
+				field: {type: 'sequence', fieldKey: 'style.opacity'},
 				keyframes: [
 					{frameOffset: 0, value: 0.5},
 					{frameOffset: 20, value: 1},
@@ -24,12 +25,29 @@ test('parses keyframe clipboard data', () => {
 		version: 1,
 		remotionClipboard: 'keyframe',
 		fieldType: 'number',
+		field: {type: 'sequence', fieldKey: 'style.opacity'},
 		keyframes: [
 			{frameOffset: 0, value: 0.5},
 			{frameOffset: 20, value: 1},
 		],
 		easing: [{type: 'linear'}],
 	});
+});
+
+test('rejects invalid keyframe clipboard field identities', () => {
+	expect(
+		parseKeyframeClipboardData(
+			JSON.stringify({
+				type: 'keyframe',
+				version: 1,
+				remotionClipboard: 'keyframe',
+				fieldType: 'number',
+				field: {type: 'sequence'},
+				keyframes: [{frameOffset: 0, value: 1}],
+				easing: [],
+			}),
+		),
+	).toBe(null);
 });
 
 test('allows keyframes without a schema field type', () => {

--- a/packages/studio-shared/src/test/keyframe-clipboard-data.test.ts
+++ b/packages/studio-shared/src/test/keyframe-clipboard-data.test.ts
@@ -48,6 +48,18 @@ test('rejects invalid keyframe clipboard field identities', () => {
 			}),
 		),
 	).toBe(null);
+	expect(
+		parseKeyframeClipboardData(
+			JSON.stringify({
+				type: 'keyframe',
+				version: 1,
+				remotionClipboard: 'keyframe',
+				fieldType: 'number',
+				keyframes: [{frameOffset: 0, value: 1}],
+				easing: [],
+			}),
+		),
+	).toBe(null);
 });
 
 test('allows keyframes without a schema field type', () => {
@@ -58,6 +70,7 @@ test('allows keyframes without a schema field type', () => {
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: null,
+				field: null,
 				keyframes: [{frameOffset: 0, value: '#ff0000'}],
 				easing: [],
 			}),
@@ -85,6 +98,7 @@ test('rejects invalid and unsupported keyframe clipboard data', () => {
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: 'array',
+				field: null,
 				keyframes: [{frameOffset: 0, value: []}],
 				easing: [],
 			}),
@@ -97,6 +111,7 @@ test('rejects invalid and unsupported keyframe clipboard data', () => {
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: 'number',
+				field: null,
 				keyframes: [
 					{frameOffset: 10, value: 1},
 					{frameOffset: 5, value: 2},
@@ -112,6 +127,7 @@ test('rejects invalid and unsupported keyframe clipboard data', () => {
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: 'number',
+				field: null,
 				keyframes: [
 					{frameOffset: 0, value: 1},
 					{frameOffset: 10, value: 2},

--- a/packages/studio/src/components/Timeline/keyframe-clipboard.ts
+++ b/packages/studio/src/components/Timeline/keyframe-clipboard.ts
@@ -399,7 +399,8 @@ export const getPasteKeyframeTarget = ({
 	const resolvedSelectedItems: readonly TimelineSelection[] =
 		selectedItems.length === 1 &&
 		selectedItems[0]?.type === 'sequence' &&
-		payload.field?.type === 'sequence'
+		payload.field !== null &&
+		payload.field.type === 'sequence'
 			? [
 					{
 						type: 'sequence-prop',

--- a/packages/studio/src/components/Timeline/keyframe-clipboard.ts
+++ b/packages/studio/src/components/Timeline/keyframe-clipboard.ts
@@ -308,6 +308,10 @@ export const getKeyframeClipboardDataFromSelections = ({
 		version: 1,
 		remotionClipboard: 'keyframe',
 		fieldType: firstResolved.fieldType,
+		field: {
+			type: firstResolved.identity.type,
+			fieldKey: firstResolved.identity.fieldKey,
+		},
 		keyframes: keyframes.map((keyframe) => {
 			return {
 				frameOffset: keyframe.frame - firstFrame,
@@ -392,12 +396,25 @@ export const getPasteKeyframeTarget = ({
 		return {type: 'none'};
 	}
 
-	const selection = selectedItems[0];
+	const resolvedSelectedItems: readonly TimelineSelection[] =
+		selectedItems.length === 1 &&
+		selectedItems[0]?.type === 'sequence' &&
+		payload.field?.type === 'sequence'
+			? [
+					{
+						type: 'sequence-prop',
+						nodePathInfo: selectedItems[0].nodePathInfo,
+						key: payload.field.fieldKey,
+					},
+				]
+			: selectedItems;
+
+	const selection = resolvedSelectedItems[0];
 	if (!selection || getKeyframeFieldIdentity(selection) === null) {
 		return {type: 'none'};
 	}
 
-	const resolvedFields = selectedItems.map((item) =>
+	const resolvedFields = resolvedSelectedItems.map((item) =>
 		resolveKeyframeField({
 			selection: item,
 			sequences,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -988,6 +988,7 @@ test('pasting keyframes targets one selected property at the playhead', () => {
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: 'number',
+				field: null,
 				keyframes: [
 					{frameOffset: 0, value: 0.4},
 					{frameOffset: 20, value: 0.8},
@@ -1059,6 +1060,7 @@ test('pasting keyframes replaces the destination range and preserves easing', ()
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: 'number',
+				field: null,
 				keyframes: [
 					{frameOffset: 0, value: 0.25},
 					{frameOffset: 20, value: 0.75},
@@ -1120,6 +1122,7 @@ test('pasting a keyframe rejects an incompatible property', () => {
 				version: 1,
 				remotionClipboard: 'keyframe',
 				fieldType: 'number',
+				field: null,
 				keyframes: [{frameOffset: 0, value: 0.4}],
 				easing: [],
 			},

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -847,11 +847,63 @@ test('copying selected keyframes preserves their frame deltas', () => {
 		version: 1,
 		remotionClipboard: 'keyframe',
 		fieldType: 'number',
+		field: {type: 'sequence', fieldKey: 'opacity'},
 		keyframes: [
 			{frameOffset: 0, value: 0.4},
 			{frameOffset: 20, value: 0.8},
 		],
 		easing: [{type: 'linear'}],
+	});
+});
+
+test('pasting keyframes onto a sequence targets the copied property', () => {
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const schema = {
+		'style.translate': {
+			type: 'translate',
+			default: 'none',
+		},
+	} satisfies InteractivitySchema;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {
+				'style.translate': {status: 'static', codeValue: 'none'},
+			},
+			effects: [],
+		},
+	} satisfies PropStatuses;
+
+	expect(
+		getPasteKeyframeTarget({
+			selectedItems: [{type: 'sequence', nodePathInfo}],
+			payload: {
+				type: 'keyframe',
+				version: 1,
+				remotionClipboard: 'keyframe',
+				fieldType: 'translate',
+				field: {type: 'sequence', fieldKey: 'style.translate'},
+				keyframes: [
+					{frameOffset: 0, value: '0px 0px'},
+					{frameOffset: 20, value: '100px 0px'},
+				],
+				easing: [{type: 'linear'}],
+			},
+			timelinePosition: 50,
+			sequences: [makeTimelineSequence({schema})],
+			overrideIdsToNodePaths: {override: nodePath},
+			propStatuses,
+		}),
+	).toMatchObject({
+		type: 'valid',
+		nodePath,
+		fieldKey: 'style.translate',
+		effectIndex: null,
+		keyframes: [
+			{sourceFrame: 50, value: '0px 0px'},
+			{sourceFrame: 70, value: '100px 0px'},
+		],
 	});
 });
 


### PR DESCRIPTION
## Summary

- include the copied property identity in keyframe clipboard data
- paste keyframes onto the matching property when a Sequence is selected
- preserve compatibility with clipboard payloads that do not contain property identity

## Testing

- `bun test packages/studio-shared/src/test/keyframe-clipboard-data.test.ts packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9392
