### PR TITLE
`@remotion/studio`: Replace asset URL when renaming

### DIFF
--- a/packages/studio/src/components/NewComposition/use-rename-static-file.ts
+++ b/packages/studio/src/components/NewComposition/use-rename-static-file.ts
@@ -1,7 +1,7 @@
 import {useCallback, useContext} from 'react';
 import {Internals, type StaticFile} from 'remotion';
 import {renameStaticFile} from '../../api/rename-static-file';
-import {pushUrl} from '../../helpers/url-state';
+import {replaceUrl} from '../../helpers/url-state';
 import {showNotification} from '../Notifications/NotificationCenter';
 
 export const getStaticFileParent = (relativePath: string) => {
@@ -116,7 +116,7 @@ export const useRenameStaticFile = ({
 					canvasContent.asset === relativePath
 				) {
 					setCanvasContent({type: 'asset', asset: newRelativePath});
-					pushUrl(`/assets/${newRelativePath}`);
+					replaceUrl(`/assets/${newRelativePath}`);
 				}
 
 				notification.replaceContent(`Renamed to ${newRelativePath}`, 2000);

--- a/packages/studio/src/helpers/url-state.ts
+++ b/packages/studio/src/helpers/url-state.ts
@@ -20,6 +20,10 @@ export const pushUrl = (url: string) => {
 	window.history.pushState({}, 'Studio', getUrlForRoute(url));
 };
 
+export const replaceUrl = (url: string) => {
+	window.history.replaceState({}, 'Studio', getUrlForRoute(url));
+};
+
 export const clearUrl = () => {
 	window.location.href = window.location.pathname;
 };

--- a/packages/studio/src/test/url-state.test.ts
+++ b/packages/studio/src/test/url-state.test.ts
@@ -1,0 +1,35 @@
+import {afterEach, expect, test} from 'bun:test';
+import {replaceUrl} from '../helpers/url-state';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+		return;
+	}
+
+	Reflect.deleteProperty(globalThis, 'window');
+});
+
+test('replaces the current Studio URL', () => {
+	const replaceStateCalls: unknown[][] = [];
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			history: {
+				replaceState: (...args: unknown[]) => replaceStateCalls.push(args),
+			},
+			location: {pathname: '/'},
+			remotion_isReadOnlyStudio: false,
+		},
+	});
+
+	replaceUrl('/assets/renamed.mp4');
+
+	expect(replaceStateCalls).toEqual([[{}, 'Studio', '/assets/renamed.mp4']]);
+});


### PR DESCRIPTION
## Summary

- replace the current asset URL after renaming instead of adding a history entry
- add focused coverage for the new route replacement helper

## Testing

- `bun test packages/studio/src`
- `bun run build`
- `bun run stylecheck`

Closes #9390
