### PR TITLE
`@remotion/media`: Play iPhone Live Photo videos

### DIFF
--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -478,7 +478,10 @@ export const audioIteratorManager = ({
 			onScheduled: (sourceDurationInSeconds) => {
 				bufferedDuration += sourceDurationInSeconds;
 				// Need to schedule a bit into the future to unblock the buffer state,
-				// otherwise we might be scheduling too late.
+				// otherwise we might be scheduling too late. This must be based on
+				// duration, not chunk count, because large PCM chunks can exceed the
+				// scheduling horizon before enough chunks are queued:
+				// https://github.com/remotion-dev/remotion/issues/9394
 				if (hasEnoughAudioToStartPlayback(bufferedDuration)) {
 					unblockPlayback();
 				}

--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -35,6 +35,12 @@ type ScheduleAudioNode = (
 	sourceDurationInSeconds: number,
 ) => ScheduleAudioNodeResult;
 
+export const MINIMUM_AUDIO_BUFFERING_TIME_SECONDS = 0.1;
+
+export const hasEnoughAudioToStartPlayback = (bufferedDuration: number) => {
+	return bufferedDuration >= MINIMUM_AUDIO_BUFFERING_TIME_SECONDS;
+};
+
 export type AudioIteratorAnchor = {
 	// The unlooped time in seconds at which the current iterator was started
 	unloopedStartInSeconds: number;
@@ -292,7 +298,7 @@ export const audioIteratorManager = ({
 		) => number | null;
 		playbackRate: number;
 		scheduleAudioNode: ScheduleAudioNode;
-		onScheduled: (mediaTimestamp: number) => void;
+		onScheduled: (sourceDurationInSeconds: number) => void;
 		onDone: () => void;
 		onDestroyed: () => void;
 		logLevel: LogLevel;
@@ -340,7 +346,7 @@ export const audioIteratorManager = ({
 					return;
 				}
 
-				onScheduled(result.value.timelineTimestamp);
+				onScheduled(result.value.sourceDurationInSeconds);
 				notifyNodeScheduled();
 
 				onAudioChunk({
@@ -452,7 +458,16 @@ export const audioIteratorManager = ({
 		audioIteratorsCreated++;
 		audioBufferIterator = iterator;
 
-		let chunksScheduled = 0;
+		let bufferedDuration = 0;
+		let hasUnblockedPlayback = false;
+		const unblockPlayback = () => {
+			if (hasUnblockedPlayback) {
+				return;
+			}
+
+			hasUnblockedPlayback = true;
+			delayHandle.unblock();
+		};
 
 		proceedScheduling({
 			iterator,
@@ -460,19 +475,19 @@ export const audioIteratorManager = ({
 			getTargetTime,
 			playbackRate,
 			scheduleAudioNode,
-			onScheduled: () => {
-				chunksScheduled++;
+			onScheduled: (sourceDurationInSeconds) => {
+				bufferedDuration += sourceDurationInSeconds;
 				// Need to schedule a bit into the future to unblock the buffer state,
 				// otherwise we might be scheduling too late.
-				if (chunksScheduled === 6) {
-					delayHandle.unblock();
+				if (hasEnoughAudioToStartPlayback(bufferedDuration)) {
+					unblockPlayback();
 				}
 			},
 			onDestroyed: () => {
-				delayHandle.unblock();
+				unblockPlayback();
 			},
 			onDone: () => {
-				delayHandle.unblock();
+				unblockPlayback();
 			},
 			logLevel,
 			currentTime: sharedAudioContext.audioContext.currentTime,

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -500,6 +500,8 @@ export class MediaPlayer {
 				this.videoIteratorManager?.seek({
 					newTime,
 					nonce,
+					fps: this.fps,
+					playbackRate: this.playbackRate,
 				}),
 				this.audioIteratorManager?.seek({
 					newTime,

--- a/packages/media/src/test/audio-iterator.test.ts
+++ b/packages/media/src/test/audio-iterator.test.ts
@@ -4,6 +4,7 @@ import {expect, test} from 'vitest';
 import {
 	anchorToContinuousTime,
 	audioIteratorManager,
+	hasEnoughAudioToStartPlayback,
 } from '../audio-iterator-manager';
 import {makeNonceManager} from '../nonce-manager';
 
@@ -163,6 +164,12 @@ test('anchor maps unlooped time using the local playback rate', () => {
 			playbackRate: 2,
 		}),
 	).toBe(8);
+});
+
+test('audio startup buffering is based on duration instead of chunk count', () => {
+	expect(hasEnoughAudioToStartPlayback(0.099)).toBe(false);
+	expect(hasEnoughAudioToStartPlayback(0.1)).toBe(true);
+	expect(hasEnoughAudioToStartPlayback(0.5)).toBe(true);
 });
 
 test('media player should work', async () => {

--- a/packages/media/src/test/audio-iterator.test.ts
+++ b/packages/media/src/test/audio-iterator.test.ts
@@ -9,6 +9,7 @@ import {
 import {makeNonceManager} from '../nonce-manager';
 
 const prepare = async (options?: {
+	src?: string;
 	fps?: number;
 	playbackRate?: number;
 	localPlaybackRate?: number;
@@ -19,6 +20,7 @@ const prepare = async (options?: {
 	loop?: boolean;
 }) => {
 	const {
+		src = 'https://remotion.media/video.mp4',
 		fps = 30,
 		playbackRate = 1,
 		localPlaybackRate = playbackRate,
@@ -29,7 +31,7 @@ const prepare = async (options?: {
 		loop = false,
 	} = options ?? {};
 	const input = new Input({
-		source: new UrlSource('https://remotion.media/video.mp4'),
+		source: new UrlSource(src),
 		formats: ALL_FORMATS,
 	});
 	const audioTrack = await input.getPrimaryAudioTrack();
@@ -52,11 +54,14 @@ const prepare = async (options?: {
 
 	const unscheduleAudioNode = () => {};
 	const audioSyncAnchor = {value: 0};
+	let playbackUnblocks = 0;
 
 	const manager = audioIteratorManager({
 		audioTrack,
 		delayPlaybackHandleIfNotPremounting: () => ({
-			unblock: () => {},
+			unblock: () => {
+				playbackUnblocks++;
+			},
 			[Symbol.dispose]: () => {},
 		}),
 		sharedAudioContext: {
@@ -141,6 +146,7 @@ const prepare = async (options?: {
 		scheduledStartOffsets,
 		seek,
 		audioContextCurrentTime,
+		getPlaybackUnblocks: () => playbackUnblocks,
 	};
 };
 
@@ -170,6 +176,21 @@ test('audio startup buffering is based on duration instead of chunk count', () =
 	expect(hasEnoughAudioToStartPlayback(0.099)).toBe(false);
 	expect(hasEnoughAudioToStartPlayback(0.1)).toBe(true);
 	expect(hasEnoughAudioToStartPlayback(0.5)).toBe(true);
+});
+
+test('PCM chunks unblock playback based on duration before six chunks or EOF', async () => {
+	const {manager, seek, scheduledChunks, getPlaybackUnblocks} = await prepare({
+		src: '/junk.wav',
+	});
+
+	seek({time: 0});
+	await manager.waitForNScheduledNodes(3);
+
+	expect(scheduledChunks).toEqual([
+		0, 0.046439909297052155, 0.09287981859410431,
+	]);
+	expect(getPlaybackUnblocks()).toBe(1);
+	manager.destroyIterator();
 });
 
 test('media player should work', async () => {

--- a/packages/media/src/test/variable-fps-issue-8303.test.ts
+++ b/packages/media/src/test/variable-fps-issue-8303.test.ts
@@ -37,7 +37,7 @@ test('variable FPS video can be sought forward one frame at a time', async () =>
 
 		for (let frame = 0; frame <= 210; frame++) {
 			const time = frame / FPS;
-			const result = await iterator.tryToSatisfySeek(time);
+			const result = await iterator.tryToSatisfySeek(time, true);
 			if (result.type !== 'satisfied') {
 				throw new Error(
 					`Expected seek to ${time.toFixed(3)}s to be satisfied, got ${result.reason}`,

--- a/packages/media/src/test/video-iterator-manager.test.ts
+++ b/packages/media/src/test/video-iterator-manager.test.ts
@@ -1,7 +1,50 @@
 import {ALL_FORMATS, Input, UrlSource} from 'mediabunny';
 import {expect, test} from 'vitest';
 import {makeNonceManager} from '../nonce-manager';
-import {videoIteratorManager} from '../video-iterator-manager';
+import {
+	isSequentialMediaTimeAdvance,
+	videoIteratorManager,
+} from '../video-iterator-manager';
+
+test('detects one timeline frame as a sequential media time advance', () => {
+	expect(
+		isSequentialMediaTimeAdvance({
+			previousTime: 0,
+			newTime: 1 / 30,
+			fps: 30,
+			playbackRate: 1,
+		}),
+	).toBe(true);
+
+	expect(
+		isSequentialMediaTimeAdvance({
+			previousTime: 0,
+			newTime: 2 / 30,
+			fps: 30,
+			playbackRate: 1,
+		}),
+	).toBe(false);
+});
+
+test('accounts for playback rate when detecting sequential advances', () => {
+	expect(
+		isSequentialMediaTimeAdvance({
+			previousTime: 1,
+			newTime: 1 + 2 / 30,
+			fps: 30,
+			playbackRate: 2,
+		}),
+	).toBe(true);
+
+	expect(
+		isSequentialMediaTimeAdvance({
+			previousTime: 1,
+			newTime: 0.9,
+			fps: 30,
+			playbackRate: 2,
+		}),
+	).toBe(false);
+});
 
 const prepare = async () => {
 	const input = new Input({
@@ -59,9 +102,24 @@ test('seek should not cause overlapping block/unblock cycles', async () => {
 
 	// Perform seeks that will trigger 'not-satisfied' (jumping around)
 	// These should NOT cause overlapping blocks
-	await manager.seek({newTime: 5, nonce: nonceManager.createAsyncOperation()});
-	await manager.seek({newTime: 0, nonce: nonceManager.createAsyncOperation()});
-	await manager.seek({newTime: 8, nonce: nonceManager.createAsyncOperation()});
+	await manager.seek({
+		newTime: 5,
+		nonce: nonceManager.createAsyncOperation(),
+		fps: 30,
+		playbackRate: 1,
+	});
+	await manager.seek({
+		newTime: 0,
+		nonce: nonceManager.createAsyncOperation(),
+		fps: 30,
+		playbackRate: 1,
+	});
+	await manager.seek({
+		newTime: 8,
+		nonce: nonceManager.createAsyncOperation(),
+		fps: 30,
+		playbackRate: 1,
+	});
 
 	// With the fix, max concurrent blocks should be 1
 	// Before the fix (fire-and-forget), it could be > 1
@@ -117,6 +175,8 @@ test('rapid sequential seeks should not cause overlapping blocks', async () => {
 		await manager.seek({
 			newTime: time,
 			nonce: nonceManager.createAsyncOperation(),
+			fps: 30,
+			playbackRate: 1,
 		});
 	}
 

--- a/packages/media/src/test/video-preview-iterator.test.ts
+++ b/packages/media/src/test/video-preview-iterator.test.ts
@@ -43,7 +43,7 @@ test('preview iterator uses next frame timestamp instead of reported duration', 
 	});
 
 	try {
-		const result = await iterator.tryToSatisfySeek(1.5);
+		const result = await iterator.tryToSatisfySeek(1.5, true);
 
 		if (result.type !== 'satisfied') {
 			throw new Error(`Expected seek to be satisfied, got ${result.reason}`);
@@ -91,10 +91,105 @@ test('preview iterator does not trust reported duration without a next timestamp
 	});
 
 	try {
-		const result = await iterator.tryToSatisfySeek(1.5);
+		const result = await iterator.tryToSatisfySeek(1.5, false);
 
 		expect(result.type).toBe('not-satisfied');
 		expect(pendingWaits).toBe(0);
+	} finally {
+		iterator.destroy();
+	}
+});
+
+test('preview iterator waits through high-FPS frames for a sequential timeline step', async () => {
+	const sourceFps = 240;
+	const timelineFps = 30;
+	let frameIndex = 0;
+	let pendingWaits = 0;
+
+	const iterator = await createVideoIterator(0, {
+		destroy: () => undefined,
+		makeIteratorOrUsePrewarmed: () => {
+			return {
+				closeIterator: () => Promise.resolve(),
+				next: () => {
+					const frame = makeFrame({
+						timestamp: frameIndex / sourceFps,
+						duration: 1 / sourceFps,
+					});
+					frameIndex++;
+
+					if (frameIndex === 1) {
+						return {type: 'ready' as const, frame};
+					}
+
+					return {
+						type: 'pending' as const,
+						wait: () => {
+							pendingWaits++;
+							return Promise.resolve(frame);
+						},
+					};
+				},
+			};
+		},
+		prewarmIteratorForLooping: () => undefined,
+	});
+
+	try {
+		const result = await iterator.tryToSatisfySeek(1 / timelineFps, true);
+
+		if (result.type !== 'satisfied') {
+			throw new Error(`Expected seek to be satisfied, got ${result.reason}`);
+		}
+
+		expect(result.frame.timestamp).toBe(8 / sourceFps);
+		expect(pendingWaits).toBe(9);
+	} finally {
+		iterator.destroy();
+	}
+});
+
+test('preview iterator supports frames longer than one timeline step', async () => {
+	let index = 0;
+	let pendingWaits = 0;
+	const frames = [
+		makeFrame({timestamp: 0, duration: 0.085}),
+		makeFrame({timestamp: 0.085, duration: 1 / 30}),
+	];
+
+	const iterator = await createVideoIterator(0, {
+		destroy: () => undefined,
+		makeIteratorOrUsePrewarmed: () => {
+			return {
+				closeIterator: () => Promise.resolve(),
+				next: () => {
+					const frame = frames[index++] ?? null;
+					if (index === 1) {
+						return {type: 'ready' as const, frame};
+					}
+
+					return {
+						type: 'pending' as const,
+						wait: () => {
+							pendingWaits++;
+							return Promise.resolve(frame);
+						},
+					};
+				},
+			};
+		},
+		prewarmIteratorForLooping: () => undefined,
+	});
+
+	try {
+		const result = await iterator.tryToSatisfySeek(0.075, true);
+
+		if (result.type !== 'satisfied') {
+			throw new Error(`Expected seek to be satisfied, got ${result.reason}`);
+		}
+
+		expect(result.frame.timestamp).toBe(0);
+		expect(pendingWaits).toBe(1);
 	} finally {
 		iterator.destroy();
 	}

--- a/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
+++ b/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
@@ -50,14 +50,20 @@ test('in preview, should properly buffer and draw frames', async (t) => {
 	await manager.seek({
 		newTime: 0.03,
 		nonce: nonceManager.createAsyncOperation(),
+		fps: 30,
+		playbackRate: 1,
 	});
 	await manager.seek({
 		newTime: 1,
 		nonce: nonceManager.createAsyncOperation(),
+		fps: 30,
+		playbackRate: 1,
 	});
 	await manager.seek({
 		newTime: 2,
 		nonce: nonceManager.createAsyncOperation(),
+		fps: 30,
+		playbackRate: 1,
 	});
 
 	const iteratorsCreated = manager.getVideoIteratorsCreated();
@@ -66,6 +72,8 @@ test('in preview, should properly buffer and draw frames', async (t) => {
 	await manager.seek({
 		newTime: 4.5,
 		nonce: nonceManager.createAsyncOperation(),
+		fps: 30,
+		playbackRate: 1,
 	});
 
 	const iteratorsCreated2 = manager.getVideoIteratorsCreated();

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -17,6 +17,28 @@ import {
 
 const {runEffectChain} = Internals;
 
+export const isSequentialMediaTimeAdvance = ({
+	previousTime,
+	newTime,
+	fps,
+	playbackRate,
+}: {
+	previousTime: number;
+	newTime: number;
+	fps: number;
+	playbackRate: number;
+}) => {
+	if (newTime < previousTime) {
+		return false;
+	}
+
+	const maximumSequentialAdvance = Math.abs(playbackRate) / fps;
+	return (
+		roundTo4Digits(newTime - previousTime) <=
+		roundTo4Digits(maximumSequentialAdvance)
+	);
+};
+
 export const videoIteratorManager = async ({
 	delayPlaybackHandleIfNotPremounting,
 	canvas,
@@ -177,7 +199,17 @@ export const videoIteratorManager = async ({
 		await drawFrame(iterator.initialFrame);
 	};
 
-	const seek = async ({newTime, nonce}: {newTime: number; nonce: Nonce}) => {
+	const seek = async ({
+		newTime,
+		nonce,
+		fps,
+		playbackRate,
+	}: {
+		newTime: number;
+		nonce: Nonce;
+		fps: number;
+		playbackRate: number;
+	}) => {
 		if (!videoFrameIterator) {
 			return;
 		}
@@ -189,6 +221,7 @@ export const videoIteratorManager = async ({
 			return;
 		}
 
+		const previousTime = currentSeek;
 		currentSeek = newTime;
 
 		if (getIsLooping()) {
@@ -200,8 +233,18 @@ export const videoIteratorManager = async ({
 			}
 		}
 
-		const videoSatisfyResult =
-			await videoFrameIterator.tryToSatisfySeek(newTime);
+		const allowWaitingForNextFrame =
+			previousTime !== null &&
+			isSequentialMediaTimeAdvance({
+				previousTime,
+				newTime,
+				fps,
+				playbackRate,
+			});
+		const videoSatisfyResult = await videoFrameIterator.tryToSatisfySeek(
+			newTime,
+			allowWaitingForNextFrame,
+		);
 
 		// Doing this before the staleness check, because
 		// frame might be better than what we currently have

--- a/packages/media/src/video/video-preview-iterator.ts
+++ b/packages/media/src/video/video-preview-iterator.ts
@@ -3,8 +3,6 @@ import {releaseStableFrame} from '../canvas-ahead-of-time';
 import {roundTo4Digits} from '../helpers/round-to-4-digits';
 import type {PrewarmedVideoIteratorCache} from '../prewarm-iterator-for-looping';
 
-const MAXIMUM_AWAITED_PEEK_DISTANCE_SECONDS = 0.05;
-
 export const createVideoIterator = async (
 	timeToSeek: number,
 	cache: PrewarmedVideoIteratorCache,
@@ -59,29 +57,14 @@ export const createVideoIterator = async (
 		};
 	};
 
-	const peek = async () => {
-		const peeked = peekIfReady();
-		if (peeked.type === 'ready') {
-			return peeked.frame;
-		}
-
-		return setPeekedFrame(await peeked.wait());
-	};
-
 	const getFrameEndTimestampFromPeek = (frame: WrappedCanvas | null) => {
 		return frame ? roundTo4Digits(frame.timestamp) : Infinity;
 	};
 
-	const getFrameEndTimestamp = async () => {
-		return getFrameEndTimestampFromPeek(await peek());
-	};
-
-	const getFrameEndTimestampIfCloseEnough = async ({
-		timestamp,
-		frameTimestamp,
+	const getFrameEndTimestamp = async ({
+		allowWaitingForNextFrame,
 	}: {
-		timestamp: number;
-		frameTimestamp: number;
+		allowWaitingForNextFrame: boolean;
 	}) => {
 		const peeked = peekIfReady();
 		if (peeked.type === 'ready') {
@@ -91,7 +74,7 @@ export const createVideoIterator = async (
 			};
 		}
 
-		if (timestamp - frameTimestamp > MAXIMUM_AWAITED_PEEK_DISTANCE_SECONDS) {
+		if (!allowWaitingForNextFrame) {
 			return {type: 'pending' as const};
 		}
 
@@ -158,6 +141,7 @@ export const createVideoIterator = async (
 
 	const tryToSatisfySeek = async (
 		time: number,
+		allowWaitingForNextFrame: boolean,
 	): Promise<
 		| {
 				type: 'not-satisfied';
@@ -191,9 +175,20 @@ export const createVideoIterator = async (
 				};
 			}
 
-			const frameEndTimestamp = await getFrameEndTimestamp();
+			const frameEndTimestamp = await getFrameEndTimestamp({
+				allowWaitingForNextFrame,
+			});
+			if (frameEndTimestamp.type === 'pending') {
+				return {
+					type: 'not-satisfied' as const,
+					reason: 'iterator did not have next frame ready',
+				};
+			}
 
-			if (frameTimestamp <= timestamp && frameEndTimestamp > timestamp) {
+			if (
+				frameTimestamp <= timestamp &&
+				frameEndTimestamp.timestamp > timestamp
+			) {
 				return {
 					type: 'satisfied' as const,
 					frame: lastReturnedFrame,
@@ -242,9 +237,8 @@ export const createVideoIterator = async (
 				}
 
 				const frameTimestamp = roundTo4Digits(frame.frame.timestamp);
-				const frameEndTimestamp = await getFrameEndTimestampIfCloseEnough({
-					frameTimestamp,
-					timestamp,
+				const frameEndTimestamp = await getFrameEndTimestamp({
+					allowWaitingForNextFrame,
 				});
 				if (frameEndTimestamp.type === 'pending') {
 					return {


### PR DESCRIPTION
## Summary

- replace the fixed 50ms next-frame wait threshold with a timeline-FPS-aware sequential advance check
- allow sequential playback to decode every source frame needed for one composition frame, including high-FPS media
- avoid waiting on unbuffered frames for discontinuous seeks
- base audio startup buffering on queued duration instead of chunk count, avoiding a deadlock with large PCM chunks
- cover 240fps media on a 30fps timeline and valid 85ms variable-duration frames

Closes #9394

## Tests

- `bun run test` in `packages/media`
- `bun run build`
- `bunx turbo run lint formatting --filter='@remotion/media'`
- verified the attached Live Photo plays in the local Remotion Studio
