### PR TITLE
`@remotion/docusaurus-plugin`: Support Twoslash in JavaScript snippets

### DIFF
--- a/packages/docusaurus-plugin/src/caching.test.ts
+++ b/packages/docusaurus-plugin/src/caching.test.ts
@@ -1,0 +1,20 @@
+import {expect, test} from 'bun:test';
+import {createHighlighter} from 'shiki';
+import {cachedTwoslashCall} from './caching';
+
+test('applies Twoslash transforms to JavaScript code blocks', async () => {
+	const highlighter = await createHighlighter({
+		themes: ['github-dark'],
+		langs: ['javascript'],
+	});
+	const html = cachedTwoslashCall(
+		['const hidden = false;', '// ---cut---', 'console.log(hidden);'].join(
+			'\n',
+		),
+		'javascript',
+		highlighter,
+	);
+
+	expect(html).not.toContain('---cut---');
+	expect(html).toContain('console');
+});

--- a/packages/docusaurus-plugin/src/caching.ts
+++ b/packages/docusaurus-plugin/src/caching.ts
@@ -18,6 +18,15 @@ import {
 let cachedTwoslasher: ReturnType<typeof createTwoslasher> | null = null;
 let cacheContext: ReturnType<typeof createTwoslashCacheContext> | null = null;
 
+const TWOSLASH_LANGUAGES = [
+	'ts',
+	'tsx',
+	'typescript',
+	'js',
+	'jsx',
+	'javascript',
+];
+
 function getTwoslasher() {
 	if (!cachedTwoslasher) {
 		cachedTwoslasher = createTwoslasher({
@@ -70,6 +79,7 @@ export const cachedTwoslashCall = (
 				twoslasher,
 				renderer: rendererClassic(),
 				explicitTrigger: TWOSLASH_EXPLICIT_TRIGGER,
+				langs: TWOSLASH_LANGUAGES,
 			}),
 		],
 	});

--- a/packages/docusaurus-plugin/src/twoslash-cache.ts
+++ b/packages/docusaurus-plugin/src/twoslash-cache.ts
@@ -15,7 +15,7 @@ import {
 } from 'fs';
 import {dirname, join, relative, resolve} from 'path';
 
-export const TWOSLASH_CACHE_SCHEMA_VERSION = 2;
+export const TWOSLASH_CACHE_SCHEMA_VERSION = 3;
 export const TWOSLASH_THEME = 'github-dark';
 export const TWOSLASH_EXPLICIT_TRIGGER = false;
 export const TWOSLASH_RENDERER = 'classic';


### PR DESCRIPTION
## Summary

- enable Twoslash transformations for JavaScript and JSX code fences
- invalidate cached code-block HTML generated without JavaScript Twoslash support
- add a regression test for `---cut---` in JavaScript snippets

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src` in `packages/docusaurus-plugin`

Closes #9372
