### PR TITLE
`@remotion/studio`: Increase translate drag sensitivity

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -26,6 +26,7 @@ type Props = InputHTMLAttributes<HTMLInputElement> & {
 	readonly small?: boolean;
 	readonly snapToStep?: boolean;
 	readonly dragDecimalPlaces?: number;
+	readonly dragSensitivity?: number;
 };
 
 export const inputDraggerContainerStyle: React.CSSProperties = {
@@ -110,6 +111,22 @@ export const isInputDraggerValueInRange = ({
 	);
 };
 
+export const deriveInputDraggerValueDiff = ({
+	dragSensitivity,
+	step,
+	xDistance,
+}: {
+	readonly dragSensitivity: number;
+	readonly step: number;
+	readonly xDistance: number;
+}) => {
+	return interpolate(
+		xDistance,
+		[-5, -4, 0, 4, 5],
+		[-step * dragSensitivity, 0, 0, 0, step * dragSensitivity],
+	);
+};
+
 const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 	HTMLButtonElement,
 	Props
@@ -128,6 +145,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 		small,
 		snapToStep = true,
 		dragDecimalPlaces,
+		dragSensitivity = 1,
 		...props
 	},
 	ref,
@@ -270,11 +288,11 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 					target.blur();
 				}
 
-				const diff = interpolate(
+				const diff = deriveInputDraggerValueDiff({
+					dragSensitivity,
+					step,
 					xDistance,
-					[-5, -4, 0, 4, 5],
-					[-step, 0, 0, 0, step],
-				);
+				});
 				const newValue = Math.min(max, Math.max(min, dragStartValue + diff));
 				const nextValue = snapToStep
 					? roundToStep(newValue, step)
@@ -315,6 +333,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 			onValueChangeEnd,
 			snapToStep,
 			dragDecimalPlaces,
+			dragSensitivity,
 		],
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTranslateField.tsx
@@ -23,6 +23,8 @@ const containerStyle: React.CSSProperties = {
 	gap: 4,
 };
 
+const translateDragSensitivity = 3;
+
 export const TimelineTranslateField: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly propStatus: CanUpdateSequencePropStatusStatic;
@@ -175,6 +177,7 @@ export const TimelineTranslateField: React.FC<{
 				rightAlign={false}
 				snapToStep={false}
 				dragDecimalPlaces={decimalPlaces}
+				dragSensitivity={translateDragSensitivity}
 			/>
 			<div style={{marginLeft: -6, marginRight: -6}} />
 			<InputDragger
@@ -193,6 +196,7 @@ export const TimelineTranslateField: React.FC<{
 				rightAlign={false}
 				snapToStep={false}
 				dragDecimalPlaces={decimalPlaces}
+				dragSensitivity={translateDragSensitivity}
 			/>
 		</span>
 	);

--- a/packages/studio/src/test/input-dragger.test.ts
+++ b/packages/studio/src/test/input-dragger.test.ts
@@ -2,8 +2,24 @@ import {expect, test} from 'bun:test';
 import {
 	deriveInputDraggerDragStartValue,
 	deriveInputDraggerStep,
+	deriveInputDraggerValueDiff,
 	isInputDraggerValueInRange,
 } from '../components/NewComposition/InputDragger';
+
+test('drag sensitivity scales the value change', () => {
+	const defaultDiff = deriveInputDraggerValueDiff({
+		dragSensitivity: 1,
+		step: 1,
+		xDistance: 10,
+	});
+	const sensitiveDiff = deriveInputDraggerValueDiff({
+		dragSensitivity: 3,
+		step: 1,
+		xDistance: 10,
+	});
+
+	expect(sensitiveDiff).toBe(defaultDiff * 3);
+});
 
 test('deriveInputDraggerStep disables HTML step validation if snapping is disabled', () => {
 	expect(


### PR DESCRIPTION
## Summary

- add an optional sensitivity multiplier to `InputDragger`
- make translate X and Y draggers three times more sensitive
- keep all other draggers and translate step/precision behavior unchanged
- add a regression test for sensitivity scaling

## Testing

- `bun test packages/studio/src/test/input-dragger.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9382
