### PR TITLE
Elements: Use real video references

### DIFF
--- a/packages/docs/elements/guidelines.mdx
+++ b/packages/docs/elements/guidelines.mdx
@@ -10,6 +10,14 @@ A Remotion Element should be a focused, reusable video building block that can b
 
 Use these guidelines when designing and reviewing an Element.
 
+## Use real videos as references
+
+Start with a visual technique observed in a published video, such as a YouTube video, TikTok, or Instagram Reel. Save a link and timestamp, and identify precisely what is worth turning into an Element.
+
+**Do not use web components, other Remotion libraries, or AI-generated ideas as the source of the concept.** They may help with implementation, but they do not demonstrate that a visual idea works in a real video.
+
+Treat references as evidence of a useful video-making need, not as designs to reproduce. Identify the role the technique plays—for example, emphasizing a phrase or introducing a speaker—then design an original Element for that role. Do not copy the source's visual treatment, branding, footage, or proprietary assets.
+
 ## Keep it focused
 
 An Element should demonstrate one visual idea, technique, or workflow. It should be useful in more than one Remotion project without becoming a complete, highly specific composition.


### PR DESCRIPTION
## Summary

- direct Element authors to start from techniques observed in published videos
- clarify that references should validate a video-making need, not provide a design to reproduce
- discourage using web components, other Remotion libraries, or AI-generated ideas as the source of a concept

## Verification

- `bunx oxfmt packages/docs/elements/guidelines.mdx --write`
- `bun run build`
- `bun run stylecheck`


## Preview

- [Element Guidelines](https://remotion-git-elements-real-video-references-remotion.vercel.app/elements/guidelines)
