### PR TITLE
`@remotion/studio`: Add connected composition context menus

### DIFF
--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -31,7 +31,7 @@ import {
 } from '../helpers/sidebar-scroll-into-view';
 import {CollapsedFolderIcon, ExpandedFolderIcon} from '../icons/folder';
 import {ModalsContext} from '../state/modals';
-import {getCompositionMenuItems} from './composition-menu-items';
+import {getCompositionContextMenuItems} from './composition-menu-items';
 import {CompositionContextButton} from './CompositionContextButton';
 import {CompositionOrStillIcon} from './CompositionOrStillIcon';
 import {ContextMenu} from './ContextMenu';
@@ -39,7 +39,6 @@ import {getFolderMenuItems} from './folder-menu-items';
 import {COMPACT_CONTROL_ROW_HEIGHT, Row, Spacing} from './layout';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
-import {getOpenInNewWindowMenuItem} from './open-in-new-window';
 import {applyCodemod} from './RenderQueue/actions';
 import {SidebarRenderButton} from './SidebarRenderButton';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
@@ -204,23 +203,15 @@ export const CompositionSelectorItem: React.FC<{
 
 	const contextMenu = useMemo((): ComboboxValue[] => {
 		if (item.type === 'composition') {
-			const compositionMenuItems = getCompositionMenuItems({
+			return getCompositionContextMenuItems({
 				closeMenu: noop,
 				composition: item.composition,
 				connectionStatus,
+				includeCompositionManagementItems: true,
 				resolvedLocation,
 				setSelectedModal,
 				readOnlyStudio: window.remotion_isReadOnlyStudio,
 			});
-
-			return [
-				getOpenInNewWindowMenuItem(`/${item.composition.id}`),
-				{
-					type: 'divider',
-					id: 'open-in-new-window-divider',
-				},
-				...compositionMenuItems,
-			];
 		}
 
 		return getFolderMenuItems({

--- a/packages/studio/src/components/InspectorPanel/ConnectedCompositionsSection.tsx
+++ b/packages/studio/src/components/InspectorPanel/ConnectedCompositionsSection.tsx
@@ -1,10 +1,16 @@
 import React, {useContext, useMemo} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {getConnectedCompositions} from '../../helpers/get-connected-compositions';
 import type {TrackWithHash} from '../../helpers/get-timeline-sequence-sort-key';
+import {noop} from '../../helpers/noop';
+import {ModalsContext} from '../../state/modals';
+import {getCompositionContextMenuItems} from '../composition-menu-items';
 import {CompositionOrStillIcon} from '../CompositionOrStillIcon';
+import {ContextMenu} from '../ContextMenu';
 import {useSelectComposition} from '../InitialCompositionLoader';
+import {useResolvedStack} from '../Timeline/use-resolved-stack';
 import {InspectorInlineAction} from './common';
 
 const compositionIconStyle: React.CSSProperties = {
@@ -16,6 +22,10 @@ const compositionListStyle: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'column',
 	padding: '6px 0',
+};
+
+const compositionContextMenuStyle: React.CSSProperties = {
+	width: '100%',
 };
 
 export const useConnectedCompositions = ({
@@ -37,26 +47,59 @@ export const useConnectedCompositions = ({
 export const ConnectedCompositionsSection: React.FC<{
 	readonly connectedCompositions: readonly _InternalTypes['AnyComposition'][];
 }> = ({connectedCompositions}) => {
-	const selectComposition = useSelectComposition();
-
 	return (
 		<div style={compositionListStyle}>
 			{connectedCompositions.map((composition) => (
-				<InspectorInlineAction
+				<ConnectedCompositionRow
 					key={composition.id}
-					disabled={false}
-					onClick={() => selectComposition(composition, true)}
-					renderIcon={(color) => (
-						<CompositionOrStillIcon
-							color={color}
-							composition={composition}
-							style={compositionIconStyle}
-						/>
-					)}
-				>
-					{composition.id}
-				</InspectorInlineAction>
+					composition={composition}
+				/>
 			))}
 		</div>
+	);
+};
+
+const ConnectedCompositionRow: React.FC<{
+	readonly composition: _InternalTypes['AnyComposition'];
+}> = ({composition}) => {
+	const selectComposition = useSelectComposition();
+	const {setSelectedModal} = useContext(ModalsContext);
+	const connectionStatus = useContext(StudioServerConnectionCtx)
+		.previewServerState.type;
+	const resolvedLocation = useResolvedStack(composition.stack);
+	const contextMenuItems = useMemo(
+		() =>
+			getCompositionContextMenuItems({
+				closeMenu: noop,
+				composition,
+				connectionStatus,
+				includeCompositionManagementItems: false,
+				readOnlyStudio: window.remotion_isReadOnlyStudio,
+				resolvedLocation,
+				setSelectedModal,
+			}),
+		[composition, connectionStatus, resolvedLocation, setSelectedModal],
+	);
+
+	return (
+		<ContextMenu
+			values={contextMenuItems}
+			onOpen={null}
+			style={compositionContextMenuStyle}
+		>
+			<InspectorInlineAction
+				disabled={false}
+				onClick={() => selectComposition(composition, true)}
+				renderIcon={(color) => (
+					<CompositionOrStillIcon
+						color={color}
+						composition={composition}
+						style={compositionIconStyle}
+					/>
+				)}
+			>
+				{composition.id}
+			</InspectorInlineAction>
+		</ContextMenu>
 	);
 };

--- a/packages/studio/src/components/composition-menu-items.ts
+++ b/packages/studio/src/components/composition-menu-items.ts
@@ -10,6 +10,7 @@ import type {PreviewServerConnectionState} from '../helpers/preview-server-event
 import type {ModalState} from '../state/modals';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
+import {getOpenInNewWindowMenuItem} from './open-in-new-window';
 
 export const getCompositionMenuItems = ({
 	composition,
@@ -18,6 +19,8 @@ export const getCompositionMenuItems = ({
 	setSelectedModal,
 	closeMenu,
 	readOnlyStudio,
+	includeNewCompositionItem,
+	includeCompositionManagementItems,
 }: {
 	composition: _InternalTypes['AnyComposition'] | null;
 	connectionStatus: PreviewServerConnectionState['type'];
@@ -25,6 +28,8 @@ export const getCompositionMenuItems = ({
 	setSelectedModal: (value: SetStateAction<ModalState | null>) => void;
 	closeMenu: () => void;
 	readOnlyStudio: boolean;
+	includeNewCompositionItem: boolean;
+	includeCompositionManagementItems: boolean;
 }): ComboboxValue[] => {
 	const editorName = window.remotion_editorName;
 	const fileLocation = formatFileLocation({
@@ -42,7 +47,7 @@ export const getCompositionMenuItems = ({
 			? {
 					id: 'show-in-editor',
 					keyHint: null,
-					label: `Show composition in ${editorName}`,
+					label: `Open composition in ${editorName}`,
 					leftItem: null,
 					onClick: async () => {
 						closeMenu();
@@ -56,11 +61,39 @@ export const getCompositionMenuItems = ({
 							showNotification((err as Error).message, 2000);
 						}
 					},
-					quickSwitcherLabel: `Show composition in ${editorName}`,
+					quickSwitcherLabel: `Open composition in ${editorName}`,
 					subMenu: null,
 					type: 'item' as const,
 					value: 'show-in-editor',
 					disabled: showInEditorDisabled,
+				}
+			: null,
+		editorName
+			? {
+					id: 'open-component-in-editor',
+					keyHint: null,
+					label: `Open component in ${editorName}`,
+					leftItem: null,
+					onClick: async () => {
+						closeMenu();
+						if (!composition || !resolvedLocation?.source) {
+							return;
+						}
+
+						try {
+							await openCompositionComponentInEditor({
+								compositionFile: resolvedLocation.source,
+								compositionId: composition.id,
+							});
+						} catch (err) {
+							showNotification((err as Error).message, 2000);
+						}
+					},
+					quickSwitcherLabel: `Open composition component in ${editorName}`,
+					subMenu: null,
+					type: 'item' as const,
+					value: 'open-component-in-editor',
+					disabled: openComponentInEditorDisabled,
 				}
 			: null,
 		{
@@ -92,128 +125,109 @@ export const getCompositionMenuItems = ({
 			value: 'copy-file-location',
 			disabled: copyFileLocationDisabled,
 		},
-		editorName
-			? {
-					id: 'open-component-in-editor',
-					keyHint: null,
-					label: `Show component in ${editorName}`,
-					leftItem: null,
-					onClick: async () => {
-						closeMenu();
-						if (!composition || !resolvedLocation?.source) {
-							return;
-						}
-
-						try {
-							await openCompositionComponentInEditor({
-								compositionFile: resolvedLocation.source,
-								compositionId: composition.id,
-							});
-						} catch (err) {
-							showNotification((err as Error).message, 2000);
-						}
-					},
-					quickSwitcherLabel: `Show composition component in ${editorName}`,
-					subMenu: null,
-					type: 'item' as const,
-					value: 'open-component-in-editor',
-					disabled: openComponentInEditorDisabled,
-				}
-			: null,
-		editorName || fileLocation
+		(editorName || fileLocation) &&
+		(includeNewCompositionItem || includeCompositionManagementItems)
 			? {
 					type: 'divider' as const,
 					id: 'show-in-editor-divider',
 				}
 			: null,
-		{
-			id: 'new',
-			keyHint: null,
-			label: `New...`,
-			leftItem: null,
-			onClick: () => {
-				closeMenu();
-				setSelectedModal({
-					type: 'new-comp',
-					folderName: null,
-					parentName: null,
-					stack: null,
-				});
-			},
-			quickSwitcherLabel: 'New composition...',
-			subMenu: null,
-			type: 'item' as const,
-			value: 'new',
-			disabled: readOnlyStudio,
-		},
-		{
-			id: 'rename',
-			keyHint: null,
-			label: `Rename...`,
-			leftItem: null,
-			onClick: () => {
-				if (!composition) {
-					return;
+		includeNewCompositionItem
+			? {
+					id: 'new',
+					keyHint: null,
+					label: `New...`,
+					leftItem: null,
+					onClick: () => {
+						closeMenu();
+						setSelectedModal({
+							type: 'new-comp',
+							folderName: null,
+							parentName: null,
+							stack: null,
+						});
+					},
+					quickSwitcherLabel: 'New composition...',
+					subMenu: null,
+					type: 'item' as const,
+					value: 'new',
+					disabled: readOnlyStudio,
 				}
+			: null,
+		includeCompositionManagementItems
+			? {
+					id: 'rename',
+					keyHint: null,
+					label: `Rename...`,
+					leftItem: null,
+					onClick: () => {
+						if (!composition) {
+							return;
+						}
 
-				closeMenu();
-				setSelectedModal({
-					type: 'rename-comp',
-					compositionId: composition.id,
-				});
-			},
-			quickSwitcherLabel: 'Rename composition...',
-			subMenu: null,
-			type: 'item' as const,
-			value: 'rename',
-			disabled: !composition || readOnlyStudio,
-		},
-		{
-			id: 'duplicate',
-			keyHint: null,
-			label: `Duplicate...`,
-			leftItem: null,
-			onClick: () => {
-				if (!composition) {
-					return;
+						closeMenu();
+						setSelectedModal({
+							type: 'rename-comp',
+							compositionId: composition.id,
+						});
+					},
+					quickSwitcherLabel: 'Rename composition...',
+					subMenu: null,
+					type: 'item' as const,
+					value: 'rename',
+					disabled: !composition || readOnlyStudio,
 				}
+			: null,
+		includeCompositionManagementItems
+			? {
+					id: 'duplicate',
+					keyHint: null,
+					label: `Duplicate...`,
+					leftItem: null,
+					onClick: () => {
+						if (!composition) {
+							return;
+						}
 
-				closeMenu();
-				setSelectedModal({
-					type: 'duplicate-comp',
-					compositionId: composition.id,
-					compositionType:
-						composition.durationInFrames === 1 ? 'still' : 'composition',
-				});
-			},
-			quickSwitcherLabel: 'Duplicate composition...',
-			subMenu: null,
-			type: 'item' as const,
-			value: 'duplicate',
-			disabled: !composition || readOnlyStudio,
-		},
-		{
-			id: 'delete',
-			keyHint: null,
-			label: `Delete...`,
-			leftItem: null,
-			onClick: () => {
-				if (!composition) {
-					return;
+						closeMenu();
+						setSelectedModal({
+							type: 'duplicate-comp',
+							compositionId: composition.id,
+							compositionType:
+								composition.durationInFrames === 1 ? 'still' : 'composition',
+						});
+					},
+					quickSwitcherLabel: 'Duplicate composition...',
+					subMenu: null,
+					type: 'item' as const,
+					value: 'duplicate',
+					disabled: !composition || readOnlyStudio,
 				}
+			: null,
+		includeCompositionManagementItems
+			? {
+					id: 'delete',
+					keyHint: null,
+					label: `Delete...`,
+					leftItem: null,
+					onClick: () => {
+						if (!composition) {
+							return;
+						}
 
-				closeMenu();
-				setSelectedModal({
-					type: 'delete-comp',
-					compositionId: composition.id,
-				});
-			},
-			quickSwitcherLabel: 'Delete composition...',
-			subMenu: null,
-			type: 'item' as const,
-			value: 'delete',
-			disabled: !composition || readOnlyStudio,
-		},
+						closeMenu();
+						setSelectedModal({
+							type: 'delete-comp',
+							compositionId: composition.id,
+						});
+					},
+					quickSwitcherLabel: 'Delete composition...',
+					subMenu: null,
+					type: 'item' as const,
+					value: 'delete',
+					disabled: !composition || readOnlyStudio,
+				}
+			: null,
 		{
 			type: 'divider' as const,
 			id: 'copy-id-divider',
@@ -248,4 +262,32 @@ export const getCompositionMenuItems = ({
 			disabled: !composition,
 		},
 	].filter(NoReactInternals.truthy);
+};
+
+export const getCompositionContextMenuItems = (
+	args: Omit<
+		Parameters<typeof getCompositionMenuItems>[0],
+		'includeNewCompositionItem' | 'includeCompositionManagementItems'
+	> & {
+		readonly includeCompositionManagementItems: boolean;
+	},
+): ComboboxValue[] => {
+	if (args.composition === null) {
+		return getCompositionMenuItems({
+			...args,
+			includeNewCompositionItem: false,
+		});
+	}
+
+	return [
+		getOpenInNewWindowMenuItem(`/${args.composition.id}`),
+		{
+			type: 'divider',
+			id: 'open-in-new-window-divider',
+		},
+		...getCompositionMenuItems({
+			...args,
+			includeNewCompositionItem: false,
+		}),
+	];
 };

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -776,6 +776,8 @@ export const useMenuStructure = (
 					closeMenu,
 					composition: currentComposition,
 					connectionStatus: type,
+					includeCompositionManagementItems: true,
+					includeNewCompositionItem: true,
 					resolvedLocation: resolvedCompositionLocation,
 					setSelectedModal,
 					readOnlyStudio,

--- a/packages/studio/src/test/composition-menu-items.test.ts
+++ b/packages/studio/src/test/composition-menu-items.test.ts
@@ -1,0 +1,124 @@
+import {afterEach, expect, test} from 'bun:test';
+import type {_InternalTypes} from 'remotion';
+import {
+	getCompositionContextMenuItems,
+	getCompositionMenuItems,
+} from '../components/composition-menu-items';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+	} else {
+		Reflect.deleteProperty(globalThis, 'window');
+	}
+});
+
+const installTestWindow = () => {
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			remotion_cwd: '/project',
+			remotion_editorName: null,
+		},
+	});
+};
+
+const installTestWindowWithEditor = () => {
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			remotion_cwd: '/project',
+			remotion_editorName: 'VS Code',
+		},
+	});
+};
+
+const composition = {
+	id: 'ConnectedComposition',
+	durationInFrames: 100,
+} as _InternalTypes['AnyComposition'];
+
+const commonArgs = {
+	closeMenu: () => undefined,
+	composition,
+	connectionStatus: 'connected' as const,
+	readOnlyStudio: false,
+	resolvedLocation: null,
+	setSelectedModal: () => undefined,
+};
+
+const ids = (items: ReturnType<typeof getCompositionMenuItems>) =>
+	items.map((item) => item.id);
+
+test('composition context menus do not include New', () => {
+	installTestWindow();
+
+	const items = getCompositionContextMenuItems({
+		...commonArgs,
+		includeCompositionManagementItems: true,
+	});
+
+	expect(ids(items)).not.toContain('new');
+	expect(ids(items)).toContain('rename');
+	expect(ids(items)).toContain('duplicate');
+	expect(ids(items)).toContain('delete');
+});
+
+test('connected composition context menus omit management actions', () => {
+	installTestWindow();
+
+	const items = getCompositionContextMenuItems({
+		...commonArgs,
+		includeCompositionManagementItems: false,
+	});
+
+	expect(ids(items)).toEqual([
+		'open-in-new-window',
+		'open-in-new-window-divider',
+		'copy-file-location',
+		'copy-id-divider',
+		'copy-id',
+	]);
+});
+
+test('the main composition menu still includes New', () => {
+	installTestWindow();
+
+	const items = getCompositionMenuItems({
+		...commonArgs,
+		includeCompositionManagementItems: true,
+		includeNewCompositionItem: true,
+	});
+
+	expect(ids(items)).toContain('new');
+});
+
+test('editor actions use Open labels and are adjacent', () => {
+	installTestWindowWithEditor();
+
+	const items = getCompositionContextMenuItems({
+		...commonArgs,
+		includeCompositionManagementItems: false,
+	});
+	const compositionIndex = items.findIndex(
+		(item) => item.id === 'show-in-editor',
+	);
+	const componentIndex = items.findIndex(
+		(item) => item.id === 'open-component-in-editor',
+	);
+
+	expect(componentIndex).toBe(compositionIndex + 1);
+	const compositionItem = items[compositionIndex];
+	const componentItem = items[componentIndex];
+	if (compositionItem.type !== 'item' || componentItem.type !== 'item') {
+		throw new Error('Expected editor actions');
+	}
+
+	expect(compositionItem.label).toBe('Open composition in VS Code');
+	expect(componentItem.label).toBe('Open component in VS Code');
+});


### PR DESCRIPTION
## Summary

- add composition context menus to connected composition and still rows in the Sequence inspector
- share context-menu construction with the composition selector
- simplify contextual actions and use adjacent “Open composition” / “Open component” labels
- cover the menu variants with focused tests

Closes #9264

## Validation

- `bun test packages/studio/src`
- `bun run build`
- `bun run stylecheck`
