### PR TITLE
`@remotion/gif`: Add direct premounting to Gif

### DIFF
--- a/packages/docs/docs/gif/gif.mdx
+++ b/packages/docs/docs/gif/gif.mdx
@@ -91,6 +91,24 @@ Callback that gets called once the GIF has loaded and finished processing. As it
 
 Allows to pass in custom CSS styles. You may not pass `width` and `height`, instead use the props `width` and `height` to set the size of the GIF.
 
+### `premountFor?`<AvailableFrom v="4.0.497" />
+
+Mounts the canvas for the specified number of frames before its `from` frame. The canvas carries `display: none` and is frozen at its first frame while premounted.
+
+Use this prop to let the GIF load, parse, and initialize its frame cache before it becomes visible. See [Premounting](/docs/player/premounting).
+
+### `postmountFor?`<AvailableFrom v="4.0.497" />
+
+Keeps the canvas mounted for the specified number of frames after its duration has ended. The canvas is invisible and frozen at its final frame while postmounted.
+
+### `styleWhilePremounted?`<AvailableFrom v="4.0.497" />
+
+CSS styles applied to the canvas while it is premounted. These styles override the default `display: none` and `pointer-events: none` styles.
+
+### `styleWhilePostmounted?`<AvailableFrom v="4.0.497" />
+
+CSS styles applied to the canvas while it is postmounted. These styles override the default `display: none` and `pointer-events: none` styles.
+
 ### `loopBehavior`<AvailableFrom v="3.3.4" />
 
 The looping behavior of the GIF. Can be one of these values:

--- a/packages/example/src/GifTest/index.tsx
+++ b/packages/example/src/GifTest/index.tsx
@@ -1,6 +1,6 @@
 import {Gif} from '@remotion/gif';
 import {useRef} from 'react';
-import {Sequence, staticFile, useVideoConfig} from 'remotion';
+import {staticFile, useVideoConfig} from 'remotion';
 
 const GifTest: React.FC = () => {
 	const {width, height} = useVideoConfig();
@@ -12,67 +12,62 @@ const GifTest: React.FC = () => {
 
 	return (
 		<div style={{flex: 1, backgroundColor: 'black'}}>
-			<Sequence durationInFrames={50}>
-				<Gif
-					ref={ref1}
-					playbackRate={4}
-					src={giphy}
-					width={width}
-					height={height}
-					fit="fill"
-					delayRenderTimeoutInMilliseconds={60000}
-				/>
-			</Sequence>
-
-			<Sequence from={50} durationInFrames={50}>
-				<Gif
-					ref={ref2}
-					src="https://media.giphy.com/media/xT0GqH01ZyKwd3aT3G/giphy.gif"
-					width={width}
-					height={height}
-					fit="cover"
-				/>
-			</Sequence>
-
-			<Sequence from={100} durationInFrames={50}>
-				<Gif
-					ref={ref3}
-					src="https://media.giphy.com/media/3o72F7YT6s0EMFI0Za/giphy.gif"
-					width={width}
-					height={height}
-					fit="contain"
-				/>
-			</Sequence>
-			<Sequence
+			<Gif
+				ref={ref1}
+				playbackRate={4}
+				src={giphy}
+				width={width}
+				height={height}
+				fit="fill"
+				delayRenderTimeoutInMilliseconds={60000}
+				durationInFrames={50}
+				trimBefore={28}
+				premountFor={30}
+				freeze={null}
+			/>
+			<Gif
+				ref={ref2}
+				src="https://media.giphy.com/media/xT0GqH01ZyKwd3aT3G/giphy.gif"
+				width={width}
+				height={height}
+				fit="cover"
+				from={50}
+				durationInFrames={50}
+			/>
+			<Gif
+				ref={ref3}
+				src="https://media.giphy.com/media/3o72F7YT6s0EMFI0Za/giphy.gif"
+				width={width}
+				height={height}
+				fit="contain"
+				from={100}
+				durationInFrames={50}
+			/>
+			<Gif
+				ref={ref4}
+				src={staticFile('disposal-type-3.gif')}
+				width={width}
+				height={height}
+				fit="fill"
 				from={150}
 				durationInFrames={50}
 				style={{
 					backgroundColor: 'white',
 				}}
-			>
-				<Gif
-					ref={ref4}
-					src={staticFile('disposal-type-3.gif')}
-					width={width}
-					height={height}
-					fit="fill"
-				/>
-			</Sequence>
-			<Sequence
+			/>
+			<Gif
+				ref={ref4}
+				src={staticFile('non-animated-interlaced.gif')}
+				width={width}
+				height={height}
+				fit="fill"
 				from={200}
 				durationInFrames={50}
 				style={{
 					backgroundColor: 'white',
 				}}
-			>
-				<Gif
-					ref={ref4}
-					src={staticFile('non-animated-interlaced.gif')}
-					width={width}
-					height={height}
-					fit="fill"
-				/>
-			</Sequence>
+				premountFor={15}
+			/>
 		</div>
 	);
 };

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import {
+	Freeze,
 	Internals,
 	Interactive,
 	Sequence,
 	useRemotionEnvironment,
 	type EffectsProp,
 	type InteractiveBaseProps,
+	type InteractivePremountProps,
 	type InteractiveTransformProps,
 	type SequenceControls,
 	type InteractivitySchema,
@@ -17,6 +19,7 @@ import type {RemotionGifProps} from './props';
 const {useMemoizedEffectDefinitions, useMemoizedEffects} = Internals;
 
 export type GifProps = InteractiveBaseProps &
+	InteractivePremountProps &
 	InteractiveTransformProps &
 	RemotionGifProps & {
 		readonly effects?: EffectsProp;
@@ -26,8 +29,10 @@ export type GifProps = InteractiveBaseProps &
  * @description Displays a GIF that synchronizes with Remotions useCurrentFrame().
  * @see [Documentation](https://remotion.dev/docs/gif)
  */
-const gifSchema = {
+export const gifSchema: InteractivitySchema = {
 	...Internals.baseSchema,
+	...Internals.premountSchema,
+	...Internals.premountStyleSchema,
 	playbackRate: {
 		type: 'number',
 		min: 0,
@@ -54,6 +59,11 @@ const GifInner = ({
 	delayRenderTimeoutInMilliseconds,
 	requestInit,
 	durationInFrames,
+	from,
+	premountFor,
+	postmountFor,
+	styleWhilePremounted,
+	styleWhilePostmounted,
 	style,
 	controls,
 	effects = [],
@@ -65,6 +75,24 @@ const GifInner = ({
 }) => {
 	const env = useRemotionEnvironment();
 	const refForOutline = React.useRef<HTMLElement | null>(null);
+	const {
+		effectivePostmountFor,
+		effectivePremountFor,
+		freezeFrame,
+		isPremountingOrPostmounting,
+		postmountingActive,
+		premountingActive,
+		premountingStyle,
+	} = Internals.usePremounting({
+		from: from ?? 0,
+		durationInFrames: durationInFrames ?? Infinity,
+		premountFor: premountFor ?? null,
+		postmountFor: postmountFor ?? null,
+		style: style ?? null,
+		styleWhilePremounted: styleWhilePremounted ?? null,
+		styleWhilePostmounted: styleWhilePostmounted ?? null,
+		hideWhilePremounted: 'display-none',
+	});
 
 	const memoizedEffectDefinitions = useMemoizedEffectDefinitions(effects);
 	const memoizedEffects = useMemoizedEffects({
@@ -86,7 +114,7 @@ const GifInner = ({
 		id,
 		delayRenderTimeoutInMilliseconds,
 		requestInit,
-		style,
+		style: premountingStyle ?? undefined,
 		effects: memoizedEffects,
 	};
 
@@ -97,18 +125,25 @@ const GifInner = ({
 	);
 
 	return (
-		<Sequence
-			layout="none"
-			durationInFrames={durationInFrames}
-			name="<Gif>"
-			_remotionInternalDocumentationLink="https://www.remotion.dev/docs/gif/gif"
-			controls={controls}
-			_remotionInternalEffects={memoizedEffectDefinitions}
-			{...sequenceProps}
-			outlineRef={refForOutline}
-		>
-			{inner}
-		</Sequence>
+		<Freeze frame={freezeFrame} active={isPremountingOrPostmounting}>
+			<Sequence
+				layout="none"
+				from={from ?? 0}
+				durationInFrames={durationInFrames ?? Infinity}
+				name="<Gif>"
+				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/gif/gif"
+				controls={controls}
+				_remotionInternalEffects={memoizedEffectDefinitions}
+				_remotionInternalPremountDisplay={effectivePremountFor || null}
+				_remotionInternalPostmountDisplay={effectivePostmountFor || null}
+				_remotionInternalIsPremounting={premountingActive}
+				_remotionInternalIsPostmounting={postmountingActive}
+				{...sequenceProps}
+				outlineRef={refForOutline}
+			>
+				{inner}
+			</Sequence>
+		</Freeze>
 	);
 };
 

--- a/packages/gif/src/test/Gif.test.tsx
+++ b/packages/gif/src/test/Gif.test.tsx
@@ -2,7 +2,7 @@ import {afterEach, beforeEach, expect, test} from 'bun:test';
 import {cleanup, render, waitFor} from '@testing-library/react';
 import React, {useCallback, useMemo} from 'react';
 import {Internals} from 'remotion';
-import {Gif} from '../Gif';
+import {Gif, gifSchema} from '../Gif';
 import {manuallyManagedGifCache} from '../gif-cache';
 import type {GifState} from '../props';
 import {getGifCacheKey} from '../request-init';
@@ -10,6 +10,8 @@ import {resolveGifSource} from '../resolve-gif-source';
 
 type RegisteredSequence = {
 	readonly refForOutline: React.RefObject<HTMLElement | null> | null;
+	readonly premountDisplay: number | null;
+	readonly postmountDisplay: number | null;
 };
 
 class MockWorker {
@@ -213,6 +215,120 @@ test('<Gif> registers its canvas as the outline ref', async () => {
 	const refForOutline = registeredSequences[0]
 		.refForOutline as React.RefObject<HTMLCanvasElement | null>;
 	expect(ref.current).toBe(refForOutline.current);
+});
+
+test('<Gif> exposes non-keyframable premounting schema fields', () => {
+	expect(gifSchema.premountFor).toMatchObject({keyframable: false});
+	expect(gifSchema.postmountFor).toMatchObject({keyframable: false});
+	expect(gifSchema.styleWhilePremounted.type).toBe('hidden');
+	expect(gifSchema.styleWhilePostmounted.type).toBe('hidden');
+});
+
+test('<Gif> hides the canvas while premounted and postmounted', () => {
+	const premounted = render(
+		<SequenceRegistrationWrapper
+			currentFrame={0}
+			onRegisterSequence={() => undefined}
+		>
+			<Gif
+				src="test.gif"
+				from={10}
+				durationInFrames={20}
+				premountFor={10}
+				style={{opacity: 0.5}}
+			/>
+		</SequenceRegistrationWrapper>,
+	);
+	const premountedStyle = premounted.container
+		.querySelector('canvas')
+		?.getAttribute('style');
+	expect(premountedStyle).toContain('display: none');
+	expect(premountedStyle).toContain('pointer-events: none');
+	expect(premountedStyle).toContain('opacity: 0.5');
+	premounted.unmount();
+
+	const postmounted = render(
+		<SequenceRegistrationWrapper
+			currentFrame={35}
+			onRegisterSequence={() => undefined}
+		>
+			<Gif src="test.gif" from={10} durationInFrames={20} postmountFor={10} />
+		</SequenceRegistrationWrapper>,
+	);
+	const postmountedStyle = postmounted.container
+		.querySelector('canvas')
+		?.getAttribute('style');
+	expect(postmountedStyle).toContain('display: none');
+	expect(postmountedStyle).toContain('pointer-events: none');
+});
+
+test('<Gif> allows overriding the premount and postmount styles', () => {
+	const premounted = render(
+		<SequenceRegistrationWrapper
+			currentFrame={0}
+			onRegisterSequence={() => undefined}
+		>
+			<Gif
+				src="test.gif"
+				from={10}
+				durationInFrames={20}
+				premountFor={10}
+				styleWhilePremounted={{display: 'block', opacity: 0.25}}
+			/>
+		</SequenceRegistrationWrapper>,
+	);
+	const premountedStyle = premounted.container
+		.querySelector('canvas')
+		?.getAttribute('style');
+	expect(premountedStyle).toContain('display: block');
+	expect(premountedStyle).toContain('opacity: 0.25');
+	premounted.unmount();
+
+	const postmounted = render(
+		<SequenceRegistrationWrapper
+			currentFrame={35}
+			onRegisterSequence={() => undefined}
+		>
+			<Gif
+				src="test.gif"
+				from={10}
+				durationInFrames={20}
+				postmountFor={10}
+				styleWhilePostmounted={{display: 'block', opacity: 0.75}}
+			/>
+		</SequenceRegistrationWrapper>,
+	);
+	const postmountedStyle = postmounted.container
+		.querySelector('canvas')
+		?.getAttribute('style');
+	expect(postmountedStyle).toContain('display: block');
+	expect(postmountedStyle).toContain('opacity: 0.75');
+});
+
+test('<Gif> registers premount and postmount ranges once', async () => {
+	const registeredSequences: RegisteredSequence[] = [];
+
+	render(
+		<SequenceRegistrationWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Gif
+				src="test.gif"
+				from={10}
+				durationInFrames={20}
+				premountFor={10}
+				postmountFor={5}
+			/>
+		</SequenceRegistrationWrapper>,
+	);
+
+	await waitFor(() => {
+		expect(registeredSequences).toHaveLength(1);
+	});
+	expect(registeredSequences[0].premountDisplay).toBe(10);
+	expect(registeredSequences[0].postmountDisplay).toBe(5);
 });
 
 test('<Gif> remains visible with a negative offset', () => {


### PR DESCRIPTION
## Summary

- add direct premounting and postmounting support to `<Gif>`
- hide and freeze GIF canvases outside their active range while exposing those ranges in Studio
- document the new props and cover schema, styles, and timeline registration

## Testing

- `bun test src/test/Gif.test.tsx` in `packages/gif`
- `bunx turbo run make lint --filter='@remotion/gif'`
- `bun run build`
- `bun run stylecheck`
- `bun render-cards.ts` in `packages/docs`

Closes #9335

Related to #9331

## Preview

- [`<Gif>` documentation](https://remotion-git-codex-add-gif-premounting-remotion.vercel.app/docs/gif/gif)
