### PR TITLE
`@remotion/transitions`: Add trimBefore to TransitionSeries.Sequence

### DIFF
--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -30,7 +30,7 @@ type SeriesSequenceProps = PropsWithChildren<
 		readonly className?: string;
 	} & Pick<
 		SequenceProps,
-		'layout' | 'name' | 'hidden' | 'showInTimeline' | 'freeze'
+		'layout' | 'name' | 'hidden' | 'showInTimeline' | 'freeze' | 'trimBefore'
 	> &
 		LayoutAndStyle
 >;
@@ -56,6 +56,7 @@ const seriesSequenceSchema = {
 	hidden: Interactive.sequenceSchema.hidden,
 	showInTimeline: Interactive.sequenceSchema.showInTimeline,
 	freeze: Interactive.baseSchema.freeze,
+	trimBefore: Interactive.sequenceSchema.trimBefore,
 	layout: Interactive.sequenceSchema.layout,
 } as const satisfies InteractivitySchema;
 

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -333,7 +333,7 @@ test('Series.Sequence registers with its own visual controls', () => {
 	]);
 });
 
-test('Series.Sequence duration overrides cascade to later sequences', async () => {
+test('Series.Sequence timing overrides cascade to later sequences', async () => {
 	const registeredSequences: TSequence[] = [];
 	const onRegisterSequence = (sequence: TSequence) => {
 		registeredSequences.push(sequence);
@@ -357,7 +357,7 @@ test('Series.Sequence duration overrides cascade to later sequences', async () =
 			}}
 		>
 			<Series>
-				<Series.Sequence name="First" durationInFrames={10}>
+				<Series.Sequence name="First" durationInFrames={10} trimBefore={2}>
 					First
 				</Series.Sequence>
 				<Series.Sequence name="Second" durationInFrames={20}>
@@ -391,7 +391,13 @@ test('Series.Sequence duration overrides cascade to later sequences', async () =
 		videoConfigValues: null,
 	};
 	const subscriptionKey = Internals.makeSequencePropsSubscriptionKey(nodePath);
-	const makeDurationOverride = (durationInFrames: number) => ({
+	const makeTimingOverride = ({
+		durationInFrames,
+		trimBefore,
+	}: {
+		durationInFrames: number;
+		trimBefore: number;
+	}) => ({
 		overrideIdToNodePathMappings: {
 			[firstSequenceControls.overrideId]: nodePath,
 		},
@@ -400,6 +406,7 @@ test('Series.Sequence duration overrides cascade to later sequences', async () =
 				canUpdate: true as const,
 				props: {
 					durationInFrames: {status: 'static' as const, codeValue: 10},
+					trimBefore: {status: 'static' as const, codeValue: 2},
 				},
 				effects: [],
 			},
@@ -407,30 +414,37 @@ test('Series.Sequence duration overrides cascade to later sequences', async () =
 		dragOverrides: {
 			[subscriptionKey]: {
 				durationInFrames: Internals.makeStaticDragOverride(durationInFrames),
+				trimBefore: Internals.makeStaticDragOverride(trimBefore),
 			},
 		},
 	});
 
 	registeredSequences.length = 0;
-	rendered.rerender(renderSeries(makeDurationOverride(15)));
+	rendered.rerender(
+		renderSeries(makeTimingOverride({durationInFrames: 7, trimBefore: 5})),
+	);
 	await waitFor(() => {
-		expect(
-			registeredSequences.find((sequence) => sequence.displayName === 'First')
-				?.duration,
-		).toBe(15);
+		const first = registeredSequences.find(
+			(sequence) => sequence.displayName === 'First',
+		);
+		expect(first?.duration).toBe(7);
+		expect(first?.trimBefore).toBe(5);
 		expect(
 			registeredSequences.find((sequence) => sequence.displayName === 'Second')
 				?.from,
-		).toBe(15);
+		).toBe(7);
 	});
 
 	registeredSequences.length = 0;
-	rendered.rerender(renderSeries(makeDurationOverride(18)));
+	rendered.rerender(
+		renderSeries(makeTimingOverride({durationInFrames: 18, trimBefore: 7})),
+	);
 	await waitFor(() => {
-		expect(
-			registeredSequences.find((sequence) => sequence.displayName === 'First')
-				?.duration,
-		).toBe(18);
+		const first = registeredSequences.find(
+			(sequence) => sequence.displayName === 'First',
+		);
+		expect(first?.duration).toBe(18);
+		expect(first?.trimBefore).toBe(7);
 		expect(
 			registeredSequences.find((sequence) => sequence.displayName === 'Second')
 				?.from,

--- a/packages/docs/docs/series.mdx
+++ b/packages/docs/docs/series.mdx
@@ -75,6 +75,10 @@ The offset does not apply to sequences that come before, but the sequences that 
 **Example 1**: Pass `10` to delay the sequence by 10 frames and create a blank space of 10 frames before it.  
 **Example 2**: Pass `-10` to start the sequence earlier and overlay the sequence on top of the previous one for 10 frames.
 
+### `trimBefore?`<AvailableFrom v="4.0.497" />
+
+Trims frames from the beginning without changing where the sequence starts. See [`trimBefore`](/docs/sequence#trimbefore) on [`<Sequence>`](/docs/sequence).
+
 ### `freeze?`<AvailableFrom v="4.0.476" />
 
 Freezes the children of the sequence at the specified frame. See [`freeze`](/docs/sequence#freeze) on [`<Sequence>`](/docs/sequence).

--- a/packages/docs/docs/transitions/transitionseries.mdx
+++ b/packages/docs/docs/transitions/transitionseries.mdx
@@ -91,6 +91,8 @@ The `<TransitionSeries>` component can only contain `<TransitionSeries.Sequence>
 
 Inherits the [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`className`](/docs/sequence#classname), [`style`](/docs/sequence#style), [`showInTimeline`](/docs/sequence#showintimeline), [`freeze`](/docs/sequence#freeze), [`premountFor`](/docs/sequence#premountfor), [`postmountFor`](/docs/sequence#postmountfor) and [`layout`](/docs/sequence#layout) props from [`<Sequence>`](/docs/sequence).
 
+The [`trimBefore`](/docs/sequence#trimbefore) prop is supported from <AvailableFrom v="4.0.497" inline />.
+
 As children, put the contents of your scene.
 
 ### `<TransitionSeries.Transition>`

--- a/packages/example/src/Issue8974TimelineInteractivity/index.tsx
+++ b/packages/example/src/Issue8974TimelineInteractivity/index.tsx
@@ -8,11 +8,14 @@ import {Series} from 'remotion';
 export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 	return (
 		<TransitionSeries name="Linked timeline TransitionSeries">
-			<TransitionSeries.Sequence name="Linked clip 01" durationInFrames={39}>
+			<TransitionSeries.Sequence
+				name="Linked clip 01"
+				durationInFrames={39}
+				trimBefore={0}
+			>
 				<Video
 					name="Linked video 01"
 					src="https://remotion.media/video.mp4"
-					trimBefore={0}
 					durationInFrames={39}
 				/>
 			</TransitionSeries.Sequence>
@@ -20,37 +23,37 @@ export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 				presentation={fade()}
 				timing={linearTiming({durationInFrames: 15})}
 			/>
-			<TransitionSeries.Sequence name="Linked clip 02" durationInFrames={84}>
-				<Video
-					name="Linked video 02"
-					src="https://remotion.media/video.webm"
-					trimBefore={8}
-				/>
+			<TransitionSeries.Sequence
+				name="Linked clip 02"
+				durationInFrames={84}
+				trimBefore={8}
+			>
+				<Video name="Linked video 02" src="https://remotion.media/video.webm" />
 			</TransitionSeries.Sequence>
-			<TransitionSeries.Sequence name="Linked clip 03" durationInFrames={43}>
-				<Video
-					name="Linked video 03"
-					src="https://remotion.media/video.mp4"
-					trimBefore={60}
-				/>
+			<TransitionSeries.Sequence
+				name="Linked clip 03"
+				durationInFrames={43}
+				trimBefore={60}
+			>
+				<Video name="Linked video 03" src="https://remotion.media/video.mp4" />
 			</TransitionSeries.Sequence>
 			<TransitionSeries.Transition
 				presentation={slide({direction: 'from-right'})}
 				timing={linearTiming({durationInFrames: 22})}
 			/>
-			<TransitionSeries.Sequence name="Linked clip 04" durationInFrames={36}>
-				<Video
-					name="Linked video 04"
-					src="https://remotion.media/video.webm"
-					trimBefore={80}
-				/>
+			<TransitionSeries.Sequence
+				name="Linked clip 04"
+				durationInFrames={36}
+				trimBefore={80}
+			>
+				<Video name="Linked video 04" src="https://remotion.media/video.webm" />
 			</TransitionSeries.Sequence>
-			<TransitionSeries.Sequence name="Linked clip 05" durationInFrames={45}>
-				<Video
-					name="Linked video 05"
-					src="https://remotion.media/video.mp4"
-					trimBefore={120}
-				/>
+			<TransitionSeries.Sequence
+				name="Linked clip 05"
+				durationInFrames={45}
+				trimBefore={120}
+			>
+				<Video name="Linked video 05" src="https://remotion.media/video.mp4" />
 			</TransitionSeries.Sequence>
 		</TransitionSeries>
 	);

--- a/packages/example/src/Issue8974TimelineInteractivity/index.tsx
+++ b/packages/example/src/Issue8974TimelineInteractivity/index.tsx
@@ -10,7 +10,7 @@ export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 		<TransitionSeries name="Linked timeline TransitionSeries">
 			<TransitionSeries.Sequence
 				name="Linked clip 01"
-				durationInFrames={39}
+				durationInFrames={44}
 				trimBefore={0}
 			>
 				<Video
@@ -23,17 +23,13 @@ export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 				presentation={fade()}
 				timing={linearTiming({durationInFrames: 15})}
 			/>
-			<TransitionSeries.Sequence
-				name="Linked clip 02"
-				durationInFrames={84}
-				trimBefore={8}
-			>
+			<TransitionSeries.Sequence name="Linked clip 02" durationInFrames={69}>
 				<Video name="Linked video 02" src="https://remotion.media/video.webm" />
 			</TransitionSeries.Sequence>
 			<TransitionSeries.Sequence
 				name="Linked clip 03"
 				durationInFrames={43}
-				trimBefore={60}
+				trimBefore={46}
 			>
 				<Video name="Linked video 03" src="https://remotion.media/video.mp4" />
 			</TransitionSeries.Sequence>
@@ -98,43 +94,58 @@ export const Issue8974IndependentVideosTimeline: React.FC = () => {
 export const Issue8974SeriesTimeline: React.FC = () => {
 	return (
 		<Series name="Linked timeline Series">
-			<Series.Sequence name="Linked clip 01" durationInFrames={78}>
+			<Series.Sequence
+				name="Linked clip 01"
+				durationInFrames={81}
+				trimBefore={0}
+			>
 				<Video
 					name="Linked video 01"
 					src="https://remotion.media/video.mp4"
-					trimBefore={0}
 					durationInFrames={78}
 				/>
 			</Series.Sequence>
-			<Series.Sequence name="Linked clip 02" durationInFrames={66}>
+			<Series.Sequence
+				name="Linked clip 02"
+				durationInFrames={66}
+				trimBefore={12}
+			>
 				<Video
 					name="Linked video 02"
 					src="https://remotion.media/video.webm"
-					trimBefore={12}
 					durationInFrames={66}
 				/>
 			</Series.Sequence>
-			<Series.Sequence name="Linked clip 03" durationInFrames={90}>
+			<Series.Sequence
+				name="Linked clip 03"
+				durationInFrames={90}
+				trimBefore={72}
+			>
 				<Video
 					name="Linked video 03"
 					src="https://remotion.media/video.mp4"
-					trimBefore={72}
 					durationInFrames={90}
 				/>
 			</Series.Sequence>
-			<Series.Sequence name="Linked clip 04" durationInFrames={72}>
+			<Series.Sequence
+				name="Linked clip 04"
+				durationInFrames={72}
+				trimBefore={58}
+			>
 				<Video
 					name="Linked video 04"
 					src="https://remotion.media/video.webm"
-					trimBefore={58}
 					durationInFrames={72}
 				/>
 			</Series.Sequence>
-			<Series.Sequence name="Linked clip 05" durationInFrames={60}>
+			<Series.Sequence
+				name="Linked clip 05"
+				durationInFrames={60}
+				trimBefore={180}
+			>
 				<Video
 					name="Linked video 05"
 					src="https://remotion.media/video.mp4"
-					trimBefore={180}
 					durationInFrames={60}
 				/>
 			</Series.Sequence>

--- a/packages/example/src/Issue8974TimelineInteractivity/index.tsx
+++ b/packages/example/src/Issue8974TimelineInteractivity/index.tsx
@@ -10,7 +10,7 @@ export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 		<TransitionSeries name="Linked timeline TransitionSeries">
 			<TransitionSeries.Sequence
 				name="Linked clip 01"
-				durationInFrames={44}
+				durationInFrames={39}
 				trimBefore={0}
 			>
 				<Video
@@ -23,13 +23,17 @@ export const Issue8974TransitionSeriesTimeline: React.FC = () => {
 				presentation={fade()}
 				timing={linearTiming({durationInFrames: 15})}
 			/>
-			<TransitionSeries.Sequence name="Linked clip 02" durationInFrames={69}>
+			<TransitionSeries.Sequence
+				name="Linked clip 02"
+				durationInFrames={84}
+				trimBefore={8}
+			>
 				<Video name="Linked video 02" src="https://remotion.media/video.webm" />
 			</TransitionSeries.Sequence>
 			<TransitionSeries.Sequence
 				name="Linked clip 03"
 				durationInFrames={43}
-				trimBefore={46}
+				trimBefore={60}
 			>
 				<Video name="Linked video 03" src="https://remotion.media/video.mp4" />
 			</TransitionSeries.Sequence>
@@ -96,7 +100,7 @@ export const Issue8974SeriesTimeline: React.FC = () => {
 		<Series name="Linked timeline Series">
 			<Series.Sequence
 				name="Linked clip 01"
-				durationInFrames={81}
+				durationInFrames={78}
 				trimBefore={0}
 			>
 				<Video

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -56,6 +56,8 @@ import {
 	TimelineSequenceLeftEdgeDragHandle,
 	TimelineSequenceRightEdgeDragHandle,
 	isTimelineSequenceDurationDraggable,
+	isTimelineSequenceLeftEdgeDraggable,
+	isTransitionSeriesSequence,
 	useTimelineSequenceFromDrag,
 } from './TimelineSequenceRightEdgeDragHandle';
 import {TimelineVideoInfo} from './TimelineVideoInfo';
@@ -296,6 +298,10 @@ const TimelineSequenceInner: React.FC<{
 	const fromCanUpdate = Boolean(
 		studioInteractivityEnabled &&
 		propStatusesForOverride?.from?.status === 'static',
+	);
+	const offsetCanUpdate = Boolean(
+		studioInteractivityEnabled &&
+		propStatusesForOverride?.offset?.status === 'static',
 	);
 	const trimBeforeCanUpdate = Boolean(
 		studioInteractivityEnabled &&
@@ -604,15 +610,10 @@ const TimelineSequenceInner: React.FC<{
 		validatedLocation !== null &&
 		durationCanUpdate;
 	const showLeftEdgeDragHandle =
-		(s.type === 'sequence' ||
-			s.type === 'image' ||
-			s.type === 'audio' ||
-			s.type === 'video') &&
-		!s.isInsideSeries &&
+		isTimelineSequenceLeftEdgeDraggable(s) &&
 		nodePath !== null &&
 		validatedLocation !== null &&
-		Boolean(s.controls) &&
-		fromCanUpdate &&
+		(isTransitionSeriesSequence(s) ? offsetCanUpdate : fromCanUpdate) &&
 		durationCanUpdate &&
 		trimBeforeCanUpdate;
 

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -299,10 +299,6 @@ const TimelineSequenceInner: React.FC<{
 		studioInteractivityEnabled &&
 		propStatusesForOverride?.from?.status === 'static',
 	);
-	const offsetCanUpdate = Boolean(
-		studioInteractivityEnabled &&
-		propStatusesForOverride?.offset?.status === 'static',
-	);
 	const trimBeforeCanUpdate = Boolean(
 		studioInteractivityEnabled &&
 		propStatusesForOverride?.trimBefore?.status === 'static',
@@ -613,7 +609,7 @@ const TimelineSequenceInner: React.FC<{
 		isTimelineSequenceLeftEdgeDraggable(s) &&
 		nodePath !== null &&
 		validatedLocation !== null &&
-		(isTransitionSeriesSequence(s) ? offsetCanUpdate : fromCanUpdate) &&
+		(isTransitionSeriesSequence(s) || fromCanUpdate) &&
 		durationCanUpdate &&
 		trimBeforeCanUpdate;
 

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -55,9 +55,9 @@ import {TimelineSequenceFrame} from './TimelineSequenceFrame';
 import {
 	TimelineSequenceLeftEdgeDragHandle,
 	TimelineSequenceRightEdgeDragHandle,
+	isCascadingSequence,
 	isTimelineSequenceDurationDraggable,
 	isTimelineSequenceLeftEdgeDraggable,
-	isTransitionSeriesSequence,
 	useTimelineSequenceFromDrag,
 } from './TimelineSequenceRightEdgeDragHandle';
 import {TimelineVideoInfo} from './TimelineVideoInfo';
@@ -609,7 +609,7 @@ const TimelineSequenceInner: React.FC<{
 		isTimelineSequenceLeftEdgeDraggable(s) &&
 		nodePath !== null &&
 		validatedLocation !== null &&
-		(isTransitionSeriesSequence(s) || fromCanUpdate) &&
+		(isCascadingSequence(s) || fromCanUpdate) &&
 		durationCanUpdate &&
 		trimBeforeCanUpdate;
 

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -68,6 +68,7 @@ export type TimelineSequenceLeftEdgeDragTarget = {
 	readonly initialTrimBefore: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly playbackRate: number;
+	readonly positionField: 'from' | 'offset';
 	readonly schema: InteractivitySchema;
 };
 
@@ -188,6 +189,19 @@ const canUpdateFrom = ({
 	return status === 'static';
 };
 
+const canUpdateOffset = ({
+	propStatuses,
+	nodePath,
+}: {
+	readonly propStatuses: PropStatuses;
+	readonly nodePath: SequencePropsSubscriptionKey;
+}) => {
+	const status = Internals.getPropStatusesCtx(propStatuses, nodePath)?.offset
+		?.status;
+
+	return status === 'static';
+};
+
 const canUpdateTrimBefore = ({
 	propStatuses,
 	nodePath,
@@ -201,10 +215,15 @@ const canUpdateTrimBefore = ({
 	return status === 'static';
 };
 
+export const isTransitionSeriesSequence = (sequence: TSequence) =>
+	sequence.controls?.componentIdentity ===
+	'dev.remotion.transitions.TransitionSeries.Sequence';
+
 export const isTimelineSequenceDurationDraggable = (sequence: TSequence) => {
-	const isInteractiveSeriesSequence =
+	const isInteractiveCascadingSequence =
 		sequence.controls?.componentIdentity ===
-		'dev.remotion.remotion.Series.Sequence';
+			'dev.remotion.remotion.Series.Sequence' ||
+		isTransitionSeriesSequence(sequence);
 
 	return (
 		(sequence.type === 'sequence' ||
@@ -212,14 +231,14 @@ export const isTimelineSequenceDurationDraggable = (sequence: TSequence) => {
 			sequence.type === 'audio' ||
 			sequence.type === 'video') &&
 		!sequence.loopDisplay &&
-		(!sequence.isInsideSeries || isInteractiveSeriesSequence) &&
+		(!sequence.isInsideSeries || isInteractiveCascadingSequence) &&
 		Boolean(sequence.controls)
 	);
 };
 
-const isLeftEdgeDraggableSequence = (sequence: TSequence) => {
+export const isTimelineSequenceLeftEdgeDraggable = (sequence: TSequence) => {
 	return (
-		!sequence.isInsideSeries &&
+		(!sequence.isInsideSeries || isTransitionSeriesSequence(sequence)) &&
 		Boolean(sequence.controls) &&
 		(sequence.type === 'sequence' ||
 			sequence.type === 'image' ||
@@ -331,7 +350,7 @@ export const getTimelineSequenceLeftEdgeDragChanges = ({
 			changes.push({
 				fileName: target.fileName,
 				nodePath: target.nodePath,
-				fieldKey: 'from',
+				fieldKey: target.positionField,
 				value: nextValues.from,
 				defaultValue: '0',
 				schema: target.schema,
@@ -624,7 +643,7 @@ export const getTimelineSequenceLeftEdgeDragTargets = ({
 			!track ||
 			!track.nodePathInfo ||
 			!originalSequence ||
-			!isLeftEdgeDraggableSequence(originalSequence)
+			!isTimelineSequenceLeftEdgeDraggable(originalSequence)
 		) {
 			return null;
 		}
@@ -632,8 +651,13 @@ export const getTimelineSequenceLeftEdgeDragTargets = ({
 		const nodePath = track.nodePathInfo.sequenceSubscriptionKey;
 		const trimsMedia =
 			originalSequence.type === 'audio' || originalSequence.type === 'video';
+		const positionField = isTransitionSeriesSequence(originalSequence)
+			? 'offset'
+			: 'from';
 		if (
-			!canUpdateFrom({propStatuses, nodePath}) ||
+			(positionField === 'from'
+				? !canUpdateFrom({propStatuses, nodePath})
+				: !canUpdateOffset({propStatuses, nodePath})) ||
 			!canUpdateDurationInFrames({propStatuses, nodePath}) ||
 			!canUpdateTrimBefore({propStatuses, nodePath})
 		) {
@@ -650,13 +674,19 @@ export const getTimelineSequenceLeftEdgeDragTargets = ({
 			targets.set(key, {
 				fileName: nodePath.absolutePath,
 				initialDuration: originalSequence.duration,
-				initialFrom: originalSequence.from,
+				initialFrom:
+					positionField === 'from'
+						? originalSequence.from
+						: typeof controls.currentRuntimeValueDotNotation.offset === 'number'
+							? controls.currentRuntimeValueDotNotation.offset
+							: 0,
 				initialTrimBefore: trimsMedia
 					? (originalSequence.trimBefore ??
 						Math.max(0, originalSequence.startMediaFrom))
 					: (originalSequence.trimBefore ?? 0),
 				nodePath,
 				playbackRate: getTrimBeforePlaybackRate(originalSequence),
+				positionField,
 				schema: controls.schema,
 			});
 		}
@@ -977,7 +1007,7 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 				});
 				latestRef.current.setDragOverrides(
 					target.nodePath,
-					'from',
+					target.positionField,
 					Internals.makeStaticDragOverride(nextValues.from),
 				);
 				latestRef.current.setDragOverrides(

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -209,6 +209,13 @@ export const isTransitionSeriesSequence = (sequence: TSequence) =>
 	sequence.controls?.componentIdentity ===
 	'dev.remotion.transitions.TransitionSeries.Sequence';
 
+const isSeriesSequence = (sequence: TSequence) =>
+	sequence.controls?.componentIdentity ===
+	'dev.remotion.remotion.Series.Sequence';
+
+const isCascadingSequence = (sequence: TSequence) =>
+	isSeriesSequence(sequence) || isTransitionSeriesSequence(sequence);
+
 const isTransitionSeriesTransition = (sequence: TSequence | undefined) =>
 	sequence?.controls?.componentIdentity ===
 	'dev.remotion.transitions.TransitionSeries.Transition';
@@ -251,10 +258,7 @@ const getMinimumSequenceDuration = ({
 };
 
 export const isTimelineSequenceDurationDraggable = (sequence: TSequence) => {
-	const isInteractiveCascadingSequence =
-		sequence.controls?.componentIdentity ===
-			'dev.remotion.remotion.Series.Sequence' ||
-		isTransitionSeriesSequence(sequence);
+	const isInteractiveCascadingSequence = isCascadingSequence(sequence);
 
 	return (
 		(sequence.type === 'sequence' ||
@@ -269,7 +273,7 @@ export const isTimelineSequenceDurationDraggable = (sequence: TSequence) => {
 
 export const isTimelineSequenceLeftEdgeDraggable = (sequence: TSequence) => {
 	return (
-		(!sequence.isInsideSeries || isTransitionSeriesSequence(sequence)) &&
+		(!sequence.isInsideSeries || isCascadingSequence(sequence)) &&
 		Boolean(sequence.controls) &&
 		(sequence.type === 'sequence' ||
 			sequence.type === 'image' ||
@@ -698,9 +702,7 @@ export const getTimelineSequenceLeftEdgeDragTargets = ({
 		const nodePath = track.nodePathInfo.sequenceSubscriptionKey;
 		const trimsMedia =
 			originalSequence.type === 'audio' || originalSequence.type === 'video';
-		const positionField = isTransitionSeriesSequence(originalSequence)
-			? null
-			: 'from';
+		const positionField = isCascadingSequence(originalSequence) ? null : 'from';
 		if (
 			(positionField === 'from' && !canUpdateFrom({propStatuses, nodePath})) ||
 			!canUpdateDurationInFrames({propStatuses, nodePath}) ||

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -68,7 +68,7 @@ export type TimelineSequenceLeftEdgeDragTarget = {
 	readonly initialTrimBefore: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly playbackRate: number;
-	readonly positionField: 'from' | 'offset';
+	readonly positionField: 'from' | null;
 	readonly schema: InteractivitySchema;
 };
 
@@ -184,19 +184,6 @@ const canUpdateFrom = ({
 	readonly nodePath: SequencePropsSubscriptionKey;
 }) => {
 	const status = Internals.getPropStatusesCtx(propStatuses, nodePath)?.from
-		?.status;
-
-	return status === 'static';
-};
-
-const canUpdateOffset = ({
-	propStatuses,
-	nodePath,
-}: {
-	readonly propStatuses: PropStatuses;
-	readonly nodePath: SequencePropsSubscriptionKey;
-}) => {
-	const status = Internals.getPropStatusesCtx(propStatuses, nodePath)?.offset
 		?.status;
 
 	return status === 'static';
@@ -346,7 +333,10 @@ export const getTimelineSequenceLeftEdgeDragChanges = ({
 		});
 		const changes: SaveSequencePropChange[] = [];
 
-		if (nextValues.from !== target.initialFrom) {
+		if (
+			target.positionField !== null &&
+			nextValues.from !== target.initialFrom
+		) {
 			changes.push({
 				fileName: target.fileName,
 				nodePath: target.nodePath,
@@ -652,12 +642,10 @@ export const getTimelineSequenceLeftEdgeDragTargets = ({
 		const trimsMedia =
 			originalSequence.type === 'audio' || originalSequence.type === 'video';
 		const positionField = isTransitionSeriesSequence(originalSequence)
-			? 'offset'
+			? null
 			: 'from';
 		if (
-			(positionField === 'from'
-				? !canUpdateFrom({propStatuses, nodePath})
-				: !canUpdateOffset({propStatuses, nodePath})) ||
+			(positionField === 'from' && !canUpdateFrom({propStatuses, nodePath})) ||
 			!canUpdateDurationInFrames({propStatuses, nodePath}) ||
 			!canUpdateTrimBefore({propStatuses, nodePath})
 		) {
@@ -674,12 +662,7 @@ export const getTimelineSequenceLeftEdgeDragTargets = ({
 			targets.set(key, {
 				fileName: nodePath.absolutePath,
 				initialDuration: originalSequence.duration,
-				initialFrom:
-					positionField === 'from'
-						? originalSequence.from
-						: typeof controls.currentRuntimeValueDotNotation.offset === 'number'
-							? controls.currentRuntimeValueDotNotation.offset
-							: 0,
+				initialFrom: positionField === 'from' ? originalSequence.from : 0,
 				initialTrimBefore: trimsMedia
 					? (originalSequence.trimBefore ??
 						Math.max(0, originalSequence.startMediaFrom))
@@ -1005,11 +988,14 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 					deltaFrames,
 					playbackRate: target.playbackRate,
 				});
-				latestRef.current.setDragOverrides(
-					target.nodePath,
-					target.positionField,
-					Internals.makeStaticDragOverride(nextValues.from),
-				);
+				if (target.positionField !== null) {
+					latestRef.current.setDragOverrides(
+						target.nodePath,
+						target.positionField,
+						Internals.makeStaticDragOverride(nextValues.from),
+					);
+				}
+
 				latestRef.current.setDragOverrides(
 					target.nodePath,
 					'durationInFrames',

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -213,7 +213,7 @@ const isSeriesSequence = (sequence: TSequence) =>
 	sequence.controls?.componentIdentity ===
 	'dev.remotion.remotion.Series.Sequence';
 
-const isCascadingSequence = (sequence: TSequence) =>
+export const isCascadingSequence = (sequence: TSequence) =>
 	isSeriesSequence(sequence) || isTransitionSeriesSequence(sequence);
 
 const isTransitionSeriesTransition = (sequence: TSequence | undefined) =>

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -23,6 +23,7 @@ import {calculateTimeline} from '../../helpers/calculate-timeline';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {TRANSPARENT} from '../../helpers/colors';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {sortItemsByNonceHistory} from '../../helpers/sort-by-nonce-history';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {
 	forceSpecificCursor,
@@ -57,6 +58,7 @@ const baseStyle: React.CSSProperties = {
 export type TimelineSequenceDurationDragTarget = {
 	readonly fileName: string;
 	readonly initialDuration: number;
+	readonly minimumDuration: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: InteractivitySchema;
 };
@@ -66,6 +68,7 @@ export type TimelineSequenceLeftEdgeDragTarget = {
 	readonly initialDuration: number;
 	readonly initialFrom: number;
 	readonly initialTrimBefore: number;
+	readonly minimumDuration: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly playbackRate: number;
 	readonly positionField: 'from' | null;
@@ -206,6 +209,47 @@ export const isTransitionSeriesSequence = (sequence: TSequence) =>
 	sequence.controls?.componentIdentity ===
 	'dev.remotion.transitions.TransitionSeries.Sequence';
 
+const isTransitionSeriesTransition = (sequence: TSequence | undefined) =>
+	sequence?.controls?.componentIdentity ===
+	'dev.remotion.transitions.TransitionSeries.Transition';
+
+const getMinimumSequenceDuration = ({
+	sequence,
+	sequences,
+}: {
+	readonly sequence: TSequence;
+	readonly sequences: TSequence[];
+}) => {
+	if (!isTransitionSeriesSequence(sequence)) {
+		return 1;
+	}
+
+	const siblings = sortItemsByNonceHistory(
+		sequences.filter(
+			(candidate) =>
+				candidate.parent === sequence.parent &&
+				candidate.rootId === sequence.rootId &&
+				(isTransitionSeriesSequence(candidate) ||
+					isTransitionSeriesTransition(candidate)),
+		),
+	);
+	const sequenceIndex = siblings.findIndex(
+		(candidate) => candidate.id === sequence.id,
+	);
+	if (sequenceIndex === -1) {
+		return 1;
+	}
+
+	const previous = siblings[sequenceIndex - 1];
+	const next = siblings[sequenceIndex + 1];
+
+	return Math.max(
+		1,
+		isTransitionSeriesTransition(previous) ? previous.duration : 1,
+		isTransitionSeriesTransition(next) ? next.duration : 1,
+	);
+};
+
 export const isTimelineSequenceDurationDraggable = (sequence: TSequence) => {
 	const isInteractiveCascadingSequence =
 		sequence.controls?.componentIdentity ===
@@ -267,24 +311,28 @@ const isFromDraggableSequence = (sequence: TSequence) => {
 export const getTimelineSequenceDurationDragValue = ({
 	initialDuration,
 	deltaFrames,
+	minimumDuration = 1,
 }: {
 	readonly initialDuration: number;
 	readonly deltaFrames: number;
-}) => Math.max(1, initialDuration + deltaFrames);
+	readonly minimumDuration?: number;
+}) => Math.max(minimumDuration, initialDuration + deltaFrames);
 
 export const getTimelineSequenceLeftEdgeDragDelta = ({
 	initialDuration,
 	initialTrimBefore,
 	deltaFrames,
 	playbackRate,
+	minimumDuration = 1,
 }: {
 	readonly initialDuration: number;
 	readonly initialTrimBefore: number;
 	readonly deltaFrames: number;
 	readonly playbackRate: number;
+	readonly minimumDuration?: number;
 }) => {
 	const minDeltaFrames = 0 - initialTrimBefore / playbackRate;
-	const maxDeltaFrames = initialDuration - 1;
+	const maxDeltaFrames = initialDuration - minimumDuration;
 
 	return Math.max(minDeltaFrames, Math.min(deltaFrames, maxDeltaFrames));
 };
@@ -295,18 +343,21 @@ export const getTimelineSequenceLeftEdgeDragValues = ({
 	initialTrimBefore,
 	deltaFrames,
 	playbackRate,
+	minimumDuration = 1,
 }: {
 	readonly initialDuration: number;
 	readonly initialFrom: number;
 	readonly initialTrimBefore: number;
 	readonly deltaFrames: number;
 	readonly playbackRate: number;
+	readonly minimumDuration?: number;
 }) => {
 	const clampedDeltaFrames = getTimelineSequenceLeftEdgeDragDelta({
 		initialDuration,
 		initialTrimBefore,
 		deltaFrames,
 		playbackRate,
+		minimumDuration,
 	});
 
 	return {
@@ -330,6 +381,7 @@ export const getTimelineSequenceLeftEdgeDragChanges = ({
 			initialTrimBefore: target.initialTrimBefore,
 			deltaFrames,
 			playbackRate: target.playbackRate,
+			minimumDuration: target.minimumDuration,
 		});
 		const changes: SaveSequencePropChange[] = [];
 
@@ -384,6 +436,7 @@ export const getTimelineSequenceDurationDragChanges = ({
 		const nextValue = getTimelineSequenceDurationDragValue({
 			initialDuration: target.initialDuration,
 			deltaFrames,
+			minimumDuration: target.minimumDuration,
 		});
 
 		if (nextValue === target.initialDuration) {
@@ -576,6 +629,10 @@ export const getTimelineSequenceDurationDragTargets = ({
 			targets.set(key, {
 				fileName: nodePath.absolutePath,
 				initialDuration: originalSequence.duration,
+				minimumDuration: getMinimumSequenceDuration({
+					sequence: originalSequence,
+					sequences,
+				}),
 				nodePath,
 				schema: controls.schema,
 			});
@@ -667,6 +724,10 @@ export const getTimelineSequenceLeftEdgeDragTargets = ({
 					? (originalSequence.trimBefore ??
 						Math.max(0, originalSequence.startMediaFrom))
 					: (originalSequence.trimBefore ?? 0),
+				minimumDuration: getMinimumSequenceDuration({
+					sequence: originalSequence,
+					sequences,
+				}),
 				nodePath,
 				playbackRate: getTrimBeforePlaybackRate(originalSequence),
 				positionField,
@@ -987,6 +1048,7 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 					initialTrimBefore: target.initialTrimBefore,
 					deltaFrames,
 					playbackRate: target.playbackRate,
+					minimumDuration: target.minimumDuration,
 				});
 				if (target.positionField !== null) {
 					latestRef.current.setDragOverrides(
@@ -1531,6 +1593,7 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 						getTimelineSequenceDurationDragValue({
 							initialDuration: target.initialDuration,
 							deltaFrames,
+							minimumDuration: target.minimumDuration,
 						}),
 					),
 				);

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1911,6 +1911,56 @@ test('TransitionSeries.Sequence left edge drag leaves its calculated position un
 	]);
 });
 
+test('Series.Sequence left edge drag leaves its calculated position unchanged', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const subscriptionKey = nodePathInfo.sequenceSubscriptionKey;
+	const targets = getTimelineSequenceLeftEdgeDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		selectedItems: [{type: 'sequence', nodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				componentIdentity: 'dev.remotion.remotion.Series.Sequence',
+				duration: 40,
+				from: 12,
+				isInsideSeries: true,
+				trimBefore: 3,
+			}),
+		],
+		overrideIdsToNodePaths: {
+			override: subscriptionKey,
+		},
+		propStatuses: {
+			[Internals.makeSequencePropsSubscriptionKey(subscriptionKey)]: {
+				canUpdate: true,
+				props: {
+					durationInFrames: {status: 'static', codeValue: 40},
+					trimBefore: {status: 'static', codeValue: 3},
+				},
+				effects: [],
+			},
+		},
+	});
+
+	expect(targets?.[0]).toMatchObject({
+		initialDuration: 40,
+		initialFrom: 0,
+		initialTrimBefore: 3,
+		minimumDuration: 1,
+		positionField: null,
+	});
+	expect(
+		getTimelineSequenceLeftEdgeDragChanges({
+			targets: targets ?? [],
+			deltaFrames: 6,
+		}).map((change) => [change.fieldKey, change.value]),
+	).toEqual([
+		['durationInFrames', 34],
+		['trimBefore', 9],
+	]);
+});
+
 test('Timeline left edge drag clamps trimBefore to the visible range', () => {
 	expect(
 		getTimelineSequenceLeftEdgeDragValues({

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1786,7 +1786,7 @@ test('Timeline left edge drag adjusts from, duration and trimBefore for selected
 	]);
 });
 
-test('TransitionSeries.Sequence left edge drag uses offset and preserves its right edge', () => {
+test('TransitionSeries.Sequence left edge drag leaves its calculated position unchanged', () => {
 	const schema = {} satisfies InteractivitySchema;
 	const nodePathInfo = makeNodePathInfo(['body', 0], []);
 	const subscriptionKey = nodePathInfo.sequenceSubscriptionKey;
@@ -1797,7 +1797,6 @@ test('TransitionSeries.Sequence left edge drag uses offset and preserves its rig
 			makeTimelineSequence({
 				schema,
 				componentIdentity: 'dev.remotion.transitions.TransitionSeries.Sequence',
-				currentRuntimeValueDotNotation: {offset: 2},
 				duration: 40,
 				from: 12,
 				isInsideSeries: true,
@@ -1812,7 +1811,6 @@ test('TransitionSeries.Sequence left edge drag uses offset and preserves its rig
 				canUpdate: true,
 				props: {
 					durationInFrames: {status: 'static', codeValue: 40},
-					offset: {status: 'static', codeValue: 2},
 					trimBefore: {status: 'static', codeValue: 3},
 				},
 				effects: [],
@@ -1822,9 +1820,9 @@ test('TransitionSeries.Sequence left edge drag uses offset and preserves its rig
 
 	expect(targets?.[0]).toMatchObject({
 		initialDuration: 40,
-		initialFrom: 2,
+		initialFrom: 0,
 		initialTrimBefore: 3,
-		positionField: 'offset',
+		positionField: null,
 	});
 	expect(
 		getTimelineSequenceLeftEdgeDragChanges({
@@ -1832,7 +1830,6 @@ test('TransitionSeries.Sequence left edge drag uses offset and preserves its rig
 			deltaFrames: 6,
 		}).map((change) => [change.fieldKey, change.value]),
 	).toEqual([
-		['offset', 8],
 		['durationInFrames', 34],
 		['trimBefore', 9],
 	]);

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1521,6 +1521,7 @@ test('Timeline duration drag supports interactive video clips', () => {
 		{
 			fileName: nodePathInfo.sequenceSubscriptionKey.absolutePath,
 			initialDuration: 78,
+			minimumDuration: 1,
 			nodePath: nodePathInfo.sequenceSubscriptionKey,
 			schema: Internals.baseSchema,
 		},
@@ -1570,6 +1571,81 @@ test('Timeline duration drag clamps each selected sequence to one frame', () => 
 			deltaFrames: -10,
 		}),
 	).toBe(10);
+});
+
+test('TransitionSeries.Sequence resize clamps to adjacent transition durations', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const nodePathInfo = makeNodePathInfo(['body', 2], []);
+	const transitionSeriesSequence = (
+		id: string,
+		duration: number,
+		overrideId: string,
+	) =>
+		makeTimelineSequence({
+			schema,
+			id,
+			overrideId,
+			duration,
+			componentIdentity: 'dev.remotion.transitions.TransitionSeries.Sequence',
+			isInsideSeries: true,
+		});
+	const transition = (id: string, duration: number) =>
+		makeTimelineSequence({
+			schema: {},
+			id,
+			duration,
+			componentIdentity: 'dev.remotion.transitions.TransitionSeries.Transition',
+			isInsideSeries: true,
+		});
+	const sequences = [
+		transitionSeriesSequence('first', 30, 'first'),
+		transition('previous-transition', 8),
+		transitionSeriesSequence('target', 40, 'target'),
+		transition('next-transition', 12),
+		transitionSeriesSequence('last', 30, 'last'),
+	];
+	const propStatuses = makeLeftEdgePropStatuses(
+		[nodePathInfo.sequenceSubscriptionKey],
+		true,
+	);
+	const overrideIdsToNodePaths = {
+		target: nodePathInfo.sequenceSubscriptionKey,
+	};
+	const selectedItems = [{type: 'sequence' as const, nodePathInfo}];
+	const durationTargets = getTimelineSequenceDurationDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		selectedItems,
+		sequences,
+		overrideIdsToNodePaths,
+		propStatuses,
+	});
+
+	expect(durationTargets?.[0].minimumDuration).toBe(12);
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: durationTargets ?? [],
+			deltaFrames: -100,
+		})[0].value,
+	).toBe(12);
+
+	const leftEdgeTargets = getTimelineSequenceLeftEdgeDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		selectedItems,
+		sequences,
+		overrideIdsToNodePaths,
+		propStatuses,
+	});
+
+	expect(leftEdgeTargets?.[0].minimumDuration).toBe(12);
+	expect(
+		getTimelineSequenceLeftEdgeDragChanges({
+			targets: leftEdgeTargets ?? [],
+			deltaFrames: 100,
+		}).map((change) => [change.fieldKey, change.value]),
+	).toEqual([
+		['durationInFrames', 12],
+		['trimBefore', 28],
+	]);
 });
 
 test('Timeline duration drag is blocked if one selected sequence cannot update duration', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -114,7 +114,9 @@ import {
 	getTimelineSequenceLeftEdgeDragChanges,
 	getTimelineSequenceLeftEdgeDragTargets,
 	getTimelineSequenceLeftEdgeDragValues,
+	isCascadingSequence,
 	isTimelineSequenceDurationDraggable,
+	isTimelineSequenceLeftEdgeDraggable,
 } from '../components/Timeline/TimelineSequenceRightEdgeDragHandle';
 import {
 	parsedTransformOriginToUv,
@@ -1543,6 +1545,8 @@ test('Timeline duration drag supports interactive cascading sequence rows', () =
 	} satisfies TSequence;
 
 	expect(isTimelineSequenceDurationDraggable(seriesSequence)).toBe(true);
+	expect(isCascadingSequence(seriesSequence)).toBe(true);
+	expect(isTimelineSequenceLeftEdgeDraggable(seriesSequence)).toBe(true);
 
 	const transitionSeriesSequence = {
 		...baseSequence,
@@ -1554,6 +1558,10 @@ test('Timeline duration drag supports interactive cascading sequence rows', () =
 	} satisfies TSequence;
 
 	expect(isTimelineSequenceDurationDraggable(transitionSeriesSequence)).toBe(
+		true,
+	);
+	expect(isCascadingSequence(transitionSeriesSequence)).toBe(true);
+	expect(isTimelineSequenceLeftEdgeDraggable(transitionSeriesSequence)).toBe(
 		true,
 	);
 });

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -205,7 +205,9 @@ const makeTimelineSequence = ({
 	postmountDisplay = null,
 	componentIdentity = null,
 	currentRuntimeValueDotNotation = {},
+	isInsideSeries = false,
 	startMediaFrom = 0,
+	trimBefore = null,
 	type = 'sequence',
 	showInTimeline = true,
 	singleChildComponent,
@@ -222,7 +224,9 @@ const makeTimelineSequence = ({
 	readonly postmountDisplay?: number | null;
 	readonly componentIdentity?: string | null;
 	readonly currentRuntimeValueDotNotation?: Record<string, unknown>;
+	readonly isInsideSeries?: boolean;
 	readonly startMediaFrom?: number;
+	readonly trimBefore?: number | null;
 	readonly type?: TSequence['type'];
 	readonly showInTimeline?: boolean;
 	readonly singleChildComponent?: unknown;
@@ -230,7 +234,7 @@ const makeTimelineSequence = ({
 	({
 		type,
 		from,
-		trimBefore: null,
+		trimBefore,
 		duration,
 		id,
 		displayName: id,
@@ -253,7 +257,7 @@ const makeTimelineSequence = ({
 			componentName: '<Sequence>',
 		},
 		refForOutline,
-		isInsideSeries: false,
+		isInsideSeries,
 		effects,
 		frozenFrame: null,
 		startMediaFrom,
@@ -1523,7 +1527,7 @@ test('Timeline duration drag supports interactive video clips', () => {
 	]);
 });
 
-test('Timeline duration drag supports interactive Series.Sequence rows', () => {
+test('Timeline duration drag supports interactive cascading sequence rows', () => {
 	const baseSequence = makeTimelineSequence({
 		schema: Internals.baseSchema,
 		duration: 78,
@@ -1538,6 +1542,19 @@ test('Timeline duration drag supports interactive Series.Sequence rows', () => {
 	} satisfies TSequence;
 
 	expect(isTimelineSequenceDurationDraggable(seriesSequence)).toBe(true);
+
+	const transitionSeriesSequence = {
+		...baseSequence,
+		isInsideSeries: true,
+		controls: {
+			...baseSequence.controls!,
+			componentIdentity: 'dev.remotion.transitions.TransitionSeries.Sequence',
+		},
+	} satisfies TSequence;
+
+	expect(isTimelineSequenceDurationDraggable(transitionSeriesSequence)).toBe(
+		true,
+	);
 });
 
 test('Timeline duration drag clamps each selected sequence to one frame', () => {
@@ -1766,6 +1783,58 @@ test('Timeline left edge drag adjusts from, duration and trimBefore for selected
 		['from', 16],
 		['durationInFrames', 9],
 		['trimBefore', 6],
+	]);
+});
+
+test('TransitionSeries.Sequence left edge drag uses offset and preserves its right edge', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const subscriptionKey = nodePathInfo.sequenceSubscriptionKey;
+	const targets = getTimelineSequenceLeftEdgeDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		selectedItems: [{type: 'sequence', nodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				componentIdentity: 'dev.remotion.transitions.TransitionSeries.Sequence',
+				currentRuntimeValueDotNotation: {offset: 2},
+				duration: 40,
+				from: 12,
+				isInsideSeries: true,
+				trimBefore: 3,
+			}),
+		],
+		overrideIdsToNodePaths: {
+			override: subscriptionKey,
+		},
+		propStatuses: {
+			[Internals.makeSequencePropsSubscriptionKey(subscriptionKey)]: {
+				canUpdate: true,
+				props: {
+					durationInFrames: {status: 'static', codeValue: 40},
+					offset: {status: 'static', codeValue: 2},
+					trimBefore: {status: 'static', codeValue: 3},
+				},
+				effects: [],
+			},
+		},
+	});
+
+	expect(targets?.[0]).toMatchObject({
+		initialDuration: 40,
+		initialFrom: 2,
+		initialTrimBefore: 3,
+		positionField: 'offset',
+	});
+	expect(
+		getTimelineSequenceLeftEdgeDragChanges({
+			targets: targets ?? [],
+			deltaFrames: 6,
+		}).map((change) => [change.fieldKey, change.value]),
+	).toEqual([
+		['offset', 8],
+		['durationInFrames', 34],
+		['trimBefore', 9],
 	]);
 });
 

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -131,7 +131,7 @@ type SeriesSequenceProps = PropsWithChildren<
 	} & LayoutBasedProps &
 		Pick<
 			SequencePropsWithoutDuration,
-			'name' | 'showInTimeline' | 'freeze' | 'hidden'
+			'name' | 'showInTimeline' | 'freeze' | 'hidden' | 'trimBefore'
 		>
 >;
 
@@ -152,6 +152,7 @@ const transitionSeriesSequenceSchema = {
 	hidden: Internals.sequenceSchema.hidden,
 	showInTimeline: Internals.sequenceSchema.showInTimeline,
 	freeze: Internals.freezeField,
+	trimBefore: Internals.sequenceSchema.trimBefore,
 	layout: Internals.sequenceSchema.layout,
 } as const satisfies InteractivitySchema;
 

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -148,7 +148,6 @@ type InternalSeriesSequenceProps = ResolvedSeriesSequenceProps & {
 
 const transitionSeriesSequenceSchema = {
 	durationInFrames: Internals.durationInFramesField,
-	offset: Internals.fromField,
 	name: Internals.sequenceSchema.name,
 	hidden: Internals.sequenceSchema.hidden,
 	showInTimeline: Internals.sequenceSchema.showInTimeline,

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -148,6 +148,7 @@ type InternalSeriesSequenceProps = ResolvedSeriesSequenceProps & {
 
 const transitionSeriesSequenceSchema = {
 	durationInFrames: Internals.durationInFramesField,
+	offset: Internals.fromField,
 	name: Internals.sequenceSchema.name,
 	hidden: Internals.sequenceSchema.hidden,
 	showInTimeline: Internals.sequenceSchema.showInTimeline,

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -37,7 +37,6 @@ const remotionEnvironment = {
 };
 
 const compositionManagerContext = makeMockCompositionManagerContext();
-const timelineContext = makeTimelineContext(0);
 const visualModeSetters = {
 	setDragOverrides: () => undefined,
 	clearDragOverrides: () => undefined,
@@ -48,12 +47,14 @@ const visualModeSetters = {
 
 const SequenceTestWrapper: React.FC<{
 	readonly children: React.ReactNode;
+	readonly frame?: number;
 	readonly onRegisterSequence: (sequence: RegisteredSequence) => void;
 	readonly overrideIdToNodePathMappings: OverrideIdToNodePaths;
 	readonly propStatuses: PropStatuses;
 	readonly dragOverrides: DragOverrides;
 }> = ({
 	children,
+	frame = 0,
 	onRegisterSequence,
 	overrideIdToNodePathMappings,
 	propStatuses,
@@ -102,7 +103,9 @@ const SequenceTestWrapper: React.FC<{
 				<Internals.CompositionManager.Provider
 					value={compositionManagerContext}
 				>
-					<Internals.TimelineContext.Provider value={timelineContext}>
+					<Internals.TimelineContext.Provider
+						value={makeTimelineContext(frame)}
+					>
 						<Internals.OverrideIdsToNodePathsGettersContext.Provider
 							value={overrideIdToNodePathContext}
 						>
@@ -289,6 +292,7 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 	}) => {
 		root.render(
 			<SequenceTestWrapper
+				frame={7}
 				onRegisterSequence={onRegisterSequence}
 				overrideIdToNodePathMappings={overrideIdToNodePathMappings}
 				propStatuses={propStatuses}
@@ -343,9 +347,11 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 	const subscriptionKey = Internals.makeSequencePropsSubscriptionKey(nodePath);
 	const makeTimingOverride = ({
 		durationInFrames,
+		offset,
 		trimBefore,
 	}: {
 		durationInFrames: number;
+		offset: number;
 		trimBefore: number;
 	}) => ({
 		overrideIdToNodePathMappings: {
@@ -356,6 +362,7 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 				canUpdate: true as const,
 				props: {
 					durationInFrames: {status: 'static' as const, codeValue: 10},
+					offset: {status: 'static' as const, codeValue: 0},
 					trimBefore: {status: 'static' as const, codeValue: 2},
 				},
 				effects: [],
@@ -364,38 +371,38 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 		dragOverrides: {
 			[subscriptionKey]: {
 				durationInFrames: Internals.makeStaticDragOverride(durationInFrames),
+				offset: Internals.makeStaticDragOverride(offset),
 				trimBefore: Internals.makeStaticDragOverride(trimBefore),
 			},
 		},
 	});
 
-	registeredSequences.length = 0;
 	renderTransitionSeries(
-		makeTimingOverride({durationInFrames: 15, trimBefore: 5}),
+		makeTimingOverride({durationInFrames: 7, offset: 3, trimBefore: 5}),
 	);
 	await new Promise((resolve) => setTimeout(resolve, 10));
 
-	const updatedFirstSequence = registeredSequences.find(
+	const updatedFirstSequence = registeredSequences.findLast(
 		(sequence) => sequence.getStack() === firstStack,
 	);
-	const updatedSecondSequence = registeredSequences.find(
+	const updatedSecondSequence = registeredSequences.findLast(
 		(sequence) => sequence.getStack() === secondStack,
 	);
-	const updatedTransition = registeredSequences.find(
+	const updatedTransition = registeredSequences.findLast(
 		(sequence) => sequence.getStack() === transitionStack,
 	);
 
-	expect(updatedFirstSequence?.duration).toBe(15);
+	expect(updatedFirstSequence?.duration).toBe(7);
 	expect(updatedFirstSequence?.trimBefore).toBe(5);
-	expect(updatedFirstSequence?.from).toBe(0);
-	expect(updatedTransition?.from).toBe(10);
+	expect(updatedFirstSequence?.from).toBe(3);
+	expect(updatedTransition?.from).toBe(5);
 	expect(updatedTransition?.duration).toBe(5);
 	expect(updatedSecondSequence?.duration).toBe(20);
-	expect(updatedSecondSequence?.from).toBe(10);
+	expect(updatedSecondSequence?.from).toBe(5);
 
 	registeredSequences.length = 0;
 	renderTransitionSeries(
-		makeTimingOverride({durationInFrames: 18, trimBefore: 7}),
+		makeTimingOverride({durationInFrames: 18, offset: 0, trimBefore: 7}),
 	);
 	await new Promise((resolve) => setTimeout(resolve, 10));
 

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -25,6 +25,7 @@ type RegisteredSequence = {
 	readonly controls: SequenceControls | null;
 	readonly duration: number;
 	readonly from: number;
+	readonly trimBefore: number | null;
 };
 
 const remotionEnvironment = {
@@ -150,6 +151,7 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 			>
 				<TransitionSeries.Sequence
 					durationInFrames={10}
+					trimBefore={4}
 					{...({stack: childSequenceStack} as {readonly stack: string})}
 				>
 					First
@@ -187,7 +189,9 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 				sequence.controls?.componentIdentity ===
 					'dev.remotion.transitions.TransitionSeries.Sequence' &&
 				sequence.controls.currentRuntimeValueDotNotation.durationInFrames ===
-					10,
+					10 &&
+				sequence.controls.currentRuntimeValueDotNotation.trimBefore === 4 &&
+				sequence.trimBefore === 4,
 		),
 	).toBe(true);
 });
@@ -263,7 +267,7 @@ test('TransitionSeries.Transition and Overlay register at their rendered timelin
 	expect((overlay?.from ?? 0) + (overlay?.duration ?? 0)).toBe(68);
 });
 
-test('TransitionSeries.Sequence duration overrides cascade to later sequences', async () => {
+test('TransitionSeries.Sequence timing overrides cascade to later sequences', async () => {
 	const registeredSequences: RegisteredSequence[] = [];
 	const div = document.createElement('div');
 	const root = createRoot(div);
@@ -293,6 +297,7 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 				<TransitionSeries>
 					<TransitionSeries.Sequence
 						durationInFrames={10}
+						trimBefore={2}
 						{...({stack: firstStack} as {readonly stack: string})}
 					>
 						First
@@ -336,7 +341,13 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 		videoConfigValues: null,
 	};
 	const subscriptionKey = Internals.makeSequencePropsSubscriptionKey(nodePath);
-	const makeDurationOverride = (durationInFrames: number) => ({
+	const makeTimingOverride = ({
+		durationInFrames,
+		trimBefore,
+	}: {
+		durationInFrames: number;
+		trimBefore: number;
+	}) => ({
 		overrideIdToNodePathMappings: {
 			[firstSequenceControls.overrideId]: nodePath,
 		},
@@ -345,6 +356,7 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 				canUpdate: true as const,
 				props: {
 					durationInFrames: {status: 'static' as const, codeValue: 10},
+					trimBefore: {status: 'static' as const, codeValue: 2},
 				},
 				effects: [],
 			},
@@ -352,12 +364,15 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 		dragOverrides: {
 			[subscriptionKey]: {
 				durationInFrames: Internals.makeStaticDragOverride(durationInFrames),
+				trimBefore: Internals.makeStaticDragOverride(trimBefore),
 			},
 		},
 	});
 
 	registeredSequences.length = 0;
-	renderTransitionSeries(makeDurationOverride(15));
+	renderTransitionSeries(
+		makeTimingOverride({durationInFrames: 15, trimBefore: 5}),
+	);
 	await new Promise((resolve) => setTimeout(resolve, 10));
 
 	const updatedFirstSequence = registeredSequences.find(
@@ -371,6 +386,7 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 	);
 
 	expect(updatedFirstSequence?.duration).toBe(15);
+	expect(updatedFirstSequence?.trimBefore).toBe(5);
 	expect(updatedFirstSequence?.from).toBe(0);
 	expect(updatedTransition?.from).toBe(10);
 	expect(updatedTransition?.duration).toBe(5);
@@ -378,7 +394,9 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 	expect(updatedSecondSequence?.from).toBe(10);
 
 	registeredSequences.length = 0;
-	renderTransitionSeries(makeDurationOverride(18));
+	renderTransitionSeries(
+		makeTimingOverride({durationInFrames: 18, trimBefore: 7}),
+	);
 	await new Promise((resolve) => setTimeout(resolve, 10));
 
 	const repeatedlyUpdatedFirstSequence = registeredSequences.find(
@@ -391,6 +409,7 @@ test('TransitionSeries.Sequence duration overrides cascade to later sequences', 
 		(sequence) => sequence.getStack() === transitionStack,
 	);
 	expect(repeatedlyUpdatedFirstSequence?.duration).toBe(18);
+	expect(repeatedlyUpdatedFirstSequence?.trimBefore).toBe(7);
 	expect(repeatedlyUpdatedTransition?.from).toBe(13);
 	expect(repeatedlyUpdatedSecondSequence?.from).toBe(13);
 

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -347,11 +347,9 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 	const subscriptionKey = Internals.makeSequencePropsSubscriptionKey(nodePath);
 	const makeTimingOverride = ({
 		durationInFrames,
-		offset,
 		trimBefore,
 	}: {
 		durationInFrames: number;
-		offset: number;
 		trimBefore: number;
 	}) => ({
 		overrideIdToNodePathMappings: {
@@ -362,7 +360,6 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 				canUpdate: true as const,
 				props: {
 					durationInFrames: {status: 'static' as const, codeValue: 10},
-					offset: {status: 'static' as const, codeValue: 0},
 					trimBefore: {status: 'static' as const, codeValue: 2},
 				},
 				effects: [],
@@ -371,14 +368,13 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 		dragOverrides: {
 			[subscriptionKey]: {
 				durationInFrames: Internals.makeStaticDragOverride(durationInFrames),
-				offset: Internals.makeStaticDragOverride(offset),
 				trimBefore: Internals.makeStaticDragOverride(trimBefore),
 			},
 		},
 	});
 
 	renderTransitionSeries(
-		makeTimingOverride({durationInFrames: 7, offset: 3, trimBefore: 5}),
+		makeTimingOverride({durationInFrames: 7, trimBefore: 5}),
 	);
 	await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -394,15 +390,15 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 
 	expect(updatedFirstSequence?.duration).toBe(7);
 	expect(updatedFirstSequence?.trimBefore).toBe(5);
-	expect(updatedFirstSequence?.from).toBe(3);
-	expect(updatedTransition?.from).toBe(5);
+	expect(updatedFirstSequence?.from).toBe(0);
+	expect(updatedTransition?.from).toBe(2);
 	expect(updatedTransition?.duration).toBe(5);
 	expect(updatedSecondSequence?.duration).toBe(20);
-	expect(updatedSecondSequence?.from).toBe(5);
+	expect(updatedSecondSequence?.from).toBe(2);
 
 	registeredSequences.length = 0;
 	renderTransitionSeries(
-		makeTimingOverride({durationInFrames: 18, offset: 0, trimBefore: 7}),
+		makeTimingOverride({durationInFrames: 18, trimBefore: 7}),
 	);
 	await new Promise((resolve) => setTimeout(resolve, 10));
 


### PR DESCRIPTION
## Summary

- add `trimBefore` to the public `TransitionSeries.Sequence` props
- add matching `trimBefore` support and left-edge ripple trimming to `Series.Sequence`
- show the left resize handle for `Series.Sequence` rows and align the video-editing example's trim ownership
- expose `trimBefore` through the component's Studio interactivity schema
- enable left-edge trimming by increasing `trimBefore` and shortening the sequence
- ripple transitions and following sequences left as the trimmed sequence becomes shorter
- clamp both resize handles to the longest adjacent transition so live edits stay valid
- document availability from Remotion 4.0.497

## Validation

- `bun test src` in `packages/transitions`
- `bun run build`
- `bun run stylecheck`
- manually dragged the left edge in the `video-editing-cascading` Studio composition

Closes #9140

## Preview

- [TransitionSeries documentation](https://remotion-git-codex-transition-series-trim-before-remotion.vercel.app/docs/transitions/transitionseries)
- [Series documentation](https://remotion-git-codex-transition-series-trim-before-remotion.vercel.app/docs/series)
