### PR TITLE
`@remotion/studio-server`: Focus existing Studio tab without reloading

### DIFF
--- a/packages/studio-server/src/better-opn/index.ts
+++ b/packages/studio-server/src/better-opn/index.ts
@@ -125,8 +125,35 @@ const normalizeURLToMatch = (target: string) => {
 	}
 };
 
-export const getFocusBrowserTabAppleScript = (
+const getBrowserArgs = (browserArgs: string | undefined) => {
+	if (browserArgs) {
+		return browserArgs.split(' ');
+	}
+
+	if (process.env.BROWSER_ARGS) {
+		return process.env.BROWSER_ARGS.split(' ');
+	}
+
+	return [];
+};
+
+const shouldTryOpenChromiumWithAppleScript = ({
+	browser,
+	args,
+}: {
+	browser: string | undefined;
+	args: string[];
+}) => {
+	return (
+		process.platform === 'darwin' &&
+		args.length === 0 &&
+		(!browser || browser === 'google chrome' || browser === 'chrome')
+	);
+};
+
+const getFocusBrowserTabAppleScriptWithCondition = (
 	chromiumBrowser: (typeof supportedChromiumBrowsers)[number],
+	condition: string,
 ) => {
 	return `
 property targetTabIndex: -1
@@ -159,7 +186,7 @@ on lookupTabWithUrl(lookupUrl)
         set theTabIndex to 0
         repeat with theTab in every tab of theWindow
           set theTabIndex to theTabIndex + 1
-          if (theTab's URL as string) is lookupUrl then
+          ${condition}
             set targetTabIndex to theTabIndex
             set targetWindow to theWindow
             set found to true
@@ -178,7 +205,34 @@ end lookupTabWithUrl
 `.trim();
 };
 
-export const focusBrowserTab = async ({url}: {url: string}) => {
+export const getFocusBrowserTabAppleScript = (
+	chromiumBrowser: (typeof supportedChromiumBrowsers)[number],
+) => {
+	return getFocusBrowserTabAppleScriptWithCondition(
+		chromiumBrowser,
+		"if (theTab's URL as string) is lookupUrl then",
+	);
+};
+
+export const getFocusBrowserTabByOriginAppleScript = (
+	chromiumBrowser: (typeof supportedChromiumBrowsers)[number],
+) => {
+	return getFocusBrowserTabAppleScriptWithCondition(
+		chromiumBrowser,
+		`set tabURL to theTab's URL as string
+          if tabURL is lookupUrl or tabURL starts with lookupUrl & "/" or tabURL starts with lookupUrl & "?" or tabURL starts with lookupUrl & "#" then`,
+	);
+};
+
+const focusBrowserTabWithAppleScript = async ({
+	url,
+	getAppleScript,
+}: {
+	url: string;
+	getAppleScript: (
+		browser: (typeof supportedChromiumBrowsers)[number],
+	) => string;
+}) => {
 	if (process.platform !== 'darwin') {
 		return false;
 	}
@@ -193,7 +247,7 @@ export const focusBrowserTab = async ({url}: {url: string}) => {
 	for (const chromiumBrowser of browsersToTry) {
 		try {
 			const result = await runAppleScript({
-				appleScript: getFocusBrowserTabAppleScript(chromiumBrowser),
+				appleScript: getAppleScript(chromiumBrowser),
 				args: [url],
 			});
 			if (result.trim() === 'true') {
@@ -209,6 +263,34 @@ export const focusBrowserTab = async ({url}: {url: string}) => {
 	return false;
 };
 
+export const focusBrowserTab = ({url}: {url: string}) => {
+	return focusBrowserTabWithAppleScript({
+		url,
+		getAppleScript: getFocusBrowserTabAppleScript,
+	});
+};
+
+export const focusBrowserTabByOrigin = ({
+	url,
+	browserFlag,
+	browserArgs,
+}: {
+	url: string;
+	browserFlag: string | undefined;
+	browserArgs: string | undefined;
+}) => {
+	const args = getBrowserArgs(browserArgs);
+	const browser = browserFlag ?? process.env.BROWSER;
+	if (!shouldTryOpenChromiumWithAppleScript({browser, args})) {
+		return false;
+	}
+
+	return focusBrowserTabWithAppleScript({
+		url: normalizeURLToMatch(url),
+		getAppleScript: getFocusBrowserTabByOriginAppleScript,
+	});
+};
+
 // Copy from
 // https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/openBrowser.js#L64
 const startBrowserProcess = async ({
@@ -222,12 +304,7 @@ const startBrowserProcess = async ({
 }) => {
 	const tryNewInstance = args.length > 0;
 
-	const shouldTryOpenChromiumWithAppleScript =
-		process.platform === 'darwin' &&
-		!tryNewInstance &&
-		(!browser || browser === 'google chrome' || browser === 'chrome');
-
-	if (shouldTryOpenChromiumWithAppleScript) {
+	if (shouldTryOpenChromiumWithAppleScript({browser, args})) {
 		let appleScriptDenied = false;
 
 		// Will use the first open browser found from list
@@ -355,18 +432,6 @@ const startBrowserProcess = async ({
 		newInstance: tryNewInstance,
 		wait: false,
 	});
-};
-
-const getBrowserArgs = (browserArgs: string | undefined) => {
-	if (browserArgs) {
-		return browserArgs.split(' ');
-	}
-
-	if (process.env.BROWSER_ARGS) {
-		return process.env.BROWSER_ARGS.split(' ');
-	}
-
-	return [];
 };
 
 export const openBrowser = ({

--- a/packages/studio-server/src/open-browser-shortcut.ts
+++ b/packages/studio-server/src/open-browser-shortcut.ts
@@ -1,6 +1,7 @@
 import * as readline from 'node:readline';
 import type {LogLevel} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
+import {focusBrowserTabByOrigin} from './better-opn';
 import {maybeOpenBrowser} from './maybe-open-browser';
 import {clearPrintPortMessageTimeout} from './preview-server/live-events';
 
@@ -53,38 +54,49 @@ export const registerOpenBrowserShortcut = ({
 		}
 	};
 
-	const openStudio = () => {
+	const openStudio = async () => {
 		if (isOpeningBrowser) {
 			return;
 		}
 
 		isOpeningBrowser = true;
 		clearPrintPortMessageTimeout();
-		maybeOpenBrowser({
-			browserArgs,
-			browserFlag,
-			shouldOpenBrowser: true,
-			url,
-			logLevel,
-		})
-			.then((result) => {
-				if (result.didOpenBrowser) {
-					RenderInternals.Log.info(
-						{indent: false, logLevel},
-						`Opened ${url} in browser`,
-					);
-				}
-			})
-			.catch((err) => {
-				RenderInternals.Log.error(
-					{indent: false, logLevel},
-					'Could not open browser:',
-					err,
-				);
-			})
-			.finally(() => {
-				isOpeningBrowser = false;
+		try {
+			const didFocus = await focusBrowserTabByOrigin({
+				url,
+				browserArgs,
+				browserFlag,
 			});
+			if (didFocus) {
+				RenderInternals.Log.info(
+					{indent: false, logLevel},
+					`Focused ${url} in browser`,
+				);
+				return;
+			}
+
+			const result = await maybeOpenBrowser({
+				browserArgs,
+				browserFlag,
+				shouldOpenBrowser: true,
+				url,
+				logLevel,
+			});
+			if (result.didOpenBrowser) {
+				RenderInternals.Log.info(
+					{indent: false, logLevel},
+					`Opened ${url} in browser`,
+				);
+			}
+		} catch (err) {
+			RenderInternals.Log.error(
+				{indent: false, logLevel},
+				'Could not open browser:',
+				err,
+			);
+		} finally {
+			isOpeningBrowser = false;
+		}
 	};
 
 	function onKeypress(_str: string, key: Key | undefined) {
@@ -98,7 +110,7 @@ export const registerOpenBrowserShortcut = ({
 			return;
 		}
 
-		openStudio();
+		openStudio().catch(() => undefined);
 	}
 
 	readline.emitKeypressEvents(process.stdin);

--- a/packages/studio-server/src/test/better-opn.test.ts
+++ b/packages/studio-server/src/test/better-opn.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'bun:test';
 import {
 	getChromiumBrowsersToTry,
 	getFocusBrowserTabAppleScript,
+	getFocusBrowserTabByOriginAppleScript,
 } from '../better-opn';
 
 test('matches running Chromium browsers by exact process name', () => {
@@ -34,6 +35,23 @@ test('focuses an exact existing tab without reloading or opening one', () => {
 
 	expect(appleScript).toContain('set targetURL to item 1 of argv');
 	expect(appleScript).toContain("if (theTab's URL as string) is lookupUrl");
+	expect(appleScript).toContain(
+		"set targetWindow's active tab index to targetTabIndex",
+	);
+	expect(appleScript).toContain('activate');
+	expect(appleScript).not.toContain('reload');
+	expect(appleScript).not.toContain('make new tab');
+	expect(appleScript).not.toContain('make new window');
+});
+
+test('focuses an existing tab on the same origin without reloading it', () => {
+	const appleScript = getFocusBrowserTabByOriginAppleScript('Google Chrome');
+
+	expect(appleScript).toContain('set targetURL to item 1 of argv');
+	expect(appleScript).toContain('tabURL is lookupUrl');
+	expect(appleScript).toContain('tabURL starts with lookupUrl & "/"');
+	expect(appleScript).toContain('tabURL starts with lookupUrl & "?"');
+	expect(appleScript).toContain('tabURL starts with lookupUrl & "#"');
 	expect(appleScript).toContain(
 		"set targetWindow's active tab index to targetTabIndex",
 	);


### PR DESCRIPTION
## Summary

- Focus an existing Studio tab when pressing `s` instead of reloading it
- Match composition-specific Studio URLs by origin
- Fall back to the existing browser-opening behavior when no tab can be focused

## Tests

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio-server/src/test/better-opn.test.ts`

Closes #9433
