### PR TITLE
Internal: Document site version compatibility contract

### DIFF
--- a/packages/renderer/src/set-props-and-env.ts
+++ b/packages/renderer/src/set-props-and-env.ts
@@ -282,6 +282,11 @@ const innerSetPropsAndEnv = async ({
 		timeoutInMilliseconds: actualTimeout,
 	});
 
+	// Increment this value when the generated bundle format or behavior changes
+	// in a backwards-incompatible way. It is not the Remotion package version and
+	// should not be bumped for every generated HTML change. Keep it synchronized
+	// with window.siteVersion in packages/studio-shared/src/studio-html.ts by
+	// incrementing both values.
 	const requiredVersion: typeof window.siteVersion = '11';
 
 	if (siteVersion !== requiredVersion) {

--- a/packages/studio-shared/src/studio-html.ts
+++ b/packages/studio-shared/src/studio-html.ts
@@ -153,6 +153,11 @@ export const studioHtml = ({
 		<script>window.remotion_packageManager = ${JSON.stringify(packageManager)}</script>
 		<script>window.remotion_publicFolderExists = ${JSON.stringify(publicFolderExists)};</script>
 		<script>
+				// Increment this value when the generated bundle format or behavior changes
+				// in a backwards-incompatible way. It is not the Remotion package version
+				// and should not be bumped for every generated HTML change.
+				// Keep it synchronized with requiredVersion in
+				// packages/renderer/src/set-props-and-env.ts by incrementing both values.
 				window.siteVersion = '11';
 				window.remotion_version = '${VERSION}';
 		</script>


### PR DESCRIPTION
## Summary

- document when backwards-incompatible bundle format or behavior changes require a site version increment
- cross-reference the emitted and required site versions so they are updated together
- clarify that the site version is separate from the Remotion package version and keep it unchanged at `11`

## Verification

- `bunx oxfmt packages/studio-shared/src/studio-html.ts packages/renderer/src/set-props-and-env.ts --write`
- `bun run build`
- `bun run stylecheck`
- `git diff --check`

Closes #9456
