### PR TITLE
`@remotion/lambda`: Match ETag calculation to multipart upload part size

### DIFF
--- a/packages/lambda/src/api/upload-dir.ts
+++ b/packages/lambda/src/api/upload-dir.ts
@@ -7,6 +7,7 @@ import {LambdaClientInternals} from '@remotion/lambda-client';
 import type {Privacy, UploadDirProgress} from '@remotion/serverless';
 import mimeTypes from 'mime-types';
 import {makeS3Key} from '../shared/make-s3-key';
+import {multipartUploadPartSize} from '../shared/multipart-upload-part-size';
 
 type FileInfo = {
 	name: string;
@@ -109,7 +110,7 @@ export const uploadDir = async ({
 		const parallelUploadsS3 = new Upload({
 			client,
 			queueSize: 2,
-			partSize: 40 * 1024 * 1024,
+			partSize: multipartUploadPartSize,
 			params: {
 				Key,
 				Bucket: bucket,

--- a/packages/lambda/src/shared/get-etag.ts
+++ b/packages/lambda/src/shared/get-etag.ts
@@ -1,7 +1,6 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
-
-const chunk = 1024 * 1024 * 5; // 5MB
+import {multipartUploadPartSize} from './multipart-upload-part-size';
 
 const md5 = (data: Buffer) =>
 	crypto
@@ -16,17 +15,17 @@ export const getEtagOfFile = (
 	const calc = async () => {
 		const size = await fs.promises.stat(filePath).then((s) => s.size);
 
-		if (size <= chunk) {
+		if (size <= multipartUploadPartSize) {
 			const buffer = await fs.promises.readFile(filePath);
 			return `"${md5(buffer)}"`;
 		}
 
 		const stream = fs.createReadStream(filePath, {
-			highWaterMark: chunk,
+			highWaterMark: multipartUploadPartSize,
 		});
 
 		const md5Chunks: string[] = [];
-		const chunksNumber = Math.ceil(size / chunk);
+		const chunksNumber = Math.ceil(size / multipartUploadPartSize);
 
 		return new Promise<string>((resolve, reject) => {
 			stream.on('data', (c) => {

--- a/packages/lambda/src/shared/multipart-upload-part-size.ts
+++ b/packages/lambda/src/shared/multipart-upload-part-size.ts
@@ -1,0 +1,1 @@
+export const multipartUploadPartSize = 40 * 1024 * 1024;

--- a/packages/lambda/src/test/unit/get-etag.test.ts
+++ b/packages/lambda/src/test/unit/get-etag.test.ts
@@ -1,0 +1,55 @@
+import {afterEach, expect, test} from 'bun:test';
+import {mkdtemp, rm, truncate, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import type {_Object} from '@aws-sdk/client-s3';
+import type {AwsProvider} from '@remotion/lambda-client';
+import type {FullClientSpecifics} from '@remotion/serverless';
+import {getEtagOfFile} from '../../shared/get-etag';
+import {getS3DiffOperations} from '../../shared/get-s3-operations';
+import {multipartUploadPartSize} from '../../shared/multipart-upload-part-size';
+import {readDirectory} from '../../shared/read-dir';
+
+let temporaryDirectory: string | null = null;
+
+afterEach(async () => {
+	if (temporaryDirectory) {
+		await rm(temporaryDirectory, {recursive: true});
+		temporaryDirectory = null;
+	}
+});
+
+const createZeroFilledFile = async (size: number) => {
+	temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'remotion-etag-'));
+	const file = path.join(temporaryDirectory, 'asset.bin');
+	await writeFile(file, '');
+	await truncate(file, size);
+	return file;
+};
+
+test('calculates a single-part ETag at the multipart part-size boundary', async () => {
+	const file = await createZeroFilledFile(multipartUploadPartSize);
+	const getEtag = getEtagOfFile(file, () => undefined);
+
+	expect(await getEtag()).toBe('"ec8bb3b24d5b0f1b5bdf8c8f0f541ee6"');
+});
+
+test('recognizes an unchanged file above the multipart part-size boundary', async () => {
+	await createZeroFilledFile(multipartUploadPartSize + 1);
+	const etag = '"60dc0dd5b9a5166cb9ea548998a4ccf4-2"';
+	const objects: _Object[] = [{Key: 'sites/test/asset.bin', ETag: etag}];
+
+	const operations = await getS3DiffOperations({
+		objects,
+		bundle: temporaryDirectory as string,
+		prefix: 'sites/test',
+		onProgress: () => undefined,
+		fullClientSpecifics: {readDirectory} as FullClientSpecifics<AwsProvider>,
+	});
+
+	expect(operations).toEqual({
+		toDelete: [],
+		toUpload: [],
+		existingCount: 1,
+	});
+});


### PR DESCRIPTION
## Summary

- share the 40 MiB multipart part size between S3 uploads and local ETag calculation
- add ETag coverage at the part-size boundary
- verify unchanged multipart files are skipped during incremental deployment

## Test plan

- `bun test src/test/unit/get-etag.test.ts` in `packages/lambda`
- `bunx turbo run lint test --filter='@remotion/lambda'`
- `bun run build`
- `bun run stylecheck`

Closes #9422
