### PR TITLE
`@remotion/transitions`: Fix HTML-in-canvas presentations

### DIFF
--- a/packages/docs/components/transitions/zoom-in-out-preview.tsx
+++ b/packages/docs/components/transitions/zoom-in-out-preview.tsx
@@ -1,7 +1,7 @@
 import {linearTiming, TransitionSeries} from '@remotion/transitions';
 import {zoomInOut} from '@remotion/transitions/zoom-in-out';
 import React from 'react';
-import {AbsoluteFill, Img} from 'remotion';
+import {AbsoluteFill} from 'remotion';
 
 const sceneStyle: React.CSSProperties = {
 	justifyContent: 'center',
@@ -10,14 +10,19 @@ const sceneStyle: React.CSSProperties = {
 	fontWeight: 900,
 	color: 'white',
 	fontSize: '40cqmin',
+	overflow: 'hidden',
 };
 
-const backgroundImageStyle: React.CSSProperties = {
-	position: 'absolute',
-	inset: 0,
-	width: '100%',
-	height: '100%',
-	objectFit: 'cover',
+const sceneAStyle: React.CSSProperties = {
+	...sceneStyle,
+	backgroundImage:
+		'radial-gradient(circle at 25% 25%, #63c7ff 0%, transparent 38%), linear-gradient(135deg, #087ecc, #032444)',
+};
+
+const sceneBStyle: React.CSSProperties = {
+	...sceneStyle,
+	backgroundImage:
+		'radial-gradient(circle at 75% 30%, #ffb0dc 0%, transparent 38%), linear-gradient(135deg, #d22a80, #4c0a42)',
 };
 
 const letterStyle: React.CSSProperties = {
@@ -27,13 +32,7 @@ const letterStyle: React.CSSProperties = {
 
 const SceneA: React.FC = () => {
 	return (
-		<AbsoluteFill style={sceneStyle}>
-			<Img
-				crossOrigin="anonymous"
-				src="https://remotion.media/transition-bg-blue.jpg"
-				style={backgroundImageStyle}
-				alt=""
-			/>
+		<AbsoluteFill style={sceneAStyle}>
 			<div style={letterStyle}>A</div>
 		</AbsoluteFill>
 	);
@@ -41,13 +40,7 @@ const SceneA: React.FC = () => {
 
 const SceneB: React.FC = () => {
 	return (
-		<AbsoluteFill style={sceneStyle}>
-			<Img
-				crossOrigin="anonymous"
-				src="https://remotion.media/transition-bg-pink.jpg"
-				style={backgroundImageStyle}
-				alt=""
-			/>
+		<AbsoluteFill style={sceneBStyle}>
 			<div style={letterStyle}>B</div>
 		</AbsoluteFill>
 	);

--- a/packages/docs/docs/transitions/make-html-in-canvas-presentation.mdx
+++ b/packages/docs/docs/transitions/make-html-in-canvas-presentation.mdx
@@ -81,7 +81,7 @@ const myShader: HtmlInCanvasShader<{}> = (canvas) => {
       gl.activeTexture(gl.TEXTURE0);
       gl.bindTexture(gl.TEXTURE_2D, prevTex);
       if (prevImage) {
-        gl.texElementImage2D(
+        gl.texImage2D(
           gl.TEXTURE_2D,
           0,
           gl.RGBA,
@@ -96,7 +96,7 @@ const myShader: HtmlInCanvasShader<{}> = (canvas) => {
       gl.activeTexture(gl.TEXTURE1);
       gl.bindTexture(gl.TEXTURE_2D, nextTex);
       if (nextImage) {
-        gl.texElementImage2D(
+        gl.texImage2D(
           gl.TEXTURE_2D,
           0,
           gl.RGBA,
@@ -193,7 +193,7 @@ const myShader: HtmlInCanvasShader<{}> = (canvas) => {
       gl.activeTexture(gl.TEXTURE0);
       gl.bindTexture(gl.TEXTURE_2D, prevTex);
       if (prevImage) {
-        gl.texElementImage2D(
+        gl.texImage2D(
           gl.TEXTURE_2D,
           0,
           gl.RGBA,
@@ -208,7 +208,7 @@ const myShader: HtmlInCanvasShader<{}> = (canvas) => {
       gl.activeTexture(gl.TEXTURE1);
       gl.bindTexture(gl.TEXTURE_2D, nextTex);
       if (nextImage) {
-        gl.texElementImage2D(
+        gl.texImage2D(
           gl.TEXTURE_2D,
           0,
           gl.RGBA,
@@ -260,11 +260,13 @@ Has the type [`HtmlInCanvasShaderDraw<Props>`](#htmlincanvasshaderdraw); the arg
 
 ##### `prevImage`
 
-[`ElementImage`](https://github.com/WICG/html-in-canvas#idl-changes)` | null` — the captured exiting scene. `null` while it has not yet rendered (e.g. at the very start).
+`OffscreenCanvas | null` — the rasterized exiting scene. `null` while it has not yet rendered (e.g. at the very start).
 
 ##### `nextImage`
 
-[`ElementImage`](https://github.com/WICG/html-in-canvas#idl-changes)` | null` — the captured entering scene. `null` after the entering scene has unmounted.
+`OffscreenCanvas | null` — the rasterized entering scene. `null` after the entering scene has unmounted.
+
+Upload these sources to WebGL textures using [`texImage2D()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D).
 
 ##### `width` / `height`
 

--- a/packages/docs/docs/transitions/presentations/custom-html-in-canvas.mdx
+++ b/packages/docs/docs/transitions/presentations/custom-html-in-canvas.mdx
@@ -19,7 +19,7 @@ Prefer CSS because it has wider browser support.
 
 ## Concept
 
-Remotion captures both scenes via [`captureElementImage()`](https://github.com/WICG/html-in-canvas#4-captureelementimage) and passes them to your shader as two [`ElementImage`](https://github.com/WICG/html-in-canvas#idl-changes) handles (`prevImage` and `nextImage`) along with the transition `time` (`0` → `1`). Your shader uploads them as textures via [`drawElementImage()`](https://github.com/WICG/html-in-canvas#2-drawelementimage-and-webglwebgpu-equivalents) (or its WebGL/WebGPU equivalents) and writes the blended result to an offscreen WebGL2 canvas, which Remotion then composites into the frame.
+Remotion rasterizes both scenes and passes them to your shader as two `OffscreenCanvas` sources (`prevImage` and `nextImage`) along with the transition `time` (`0` → `1`). Upload them as textures using [`texImage2D()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D) and write the blended result to the supplied offscreen WebGL2 canvas. Remotion composites that canvas into the frame.
 
 You implement a single function — [`HtmlInCanvasShader<Props>`](/docs/transitions/make-html-in-canvas-presentation#htmlincanvasshader) — and pass it to [`makeHtmlInCanvasPresentation()`](/docs/transitions/make-html-in-canvas-presentation) to get back a `TransitionPresentation` constructor.
 
@@ -78,7 +78,7 @@ export const myShader: HtmlInCanvasShader<MyShaderProps> = (canvas) => {
       // Release WebGL resources here
     },
     draw: ({prevImage, nextImage, width, height, time, passedProps}) => {
-      // Upload prevImage / nextImage to textures via gl.texElementImage2D
+      // Upload prevImage / nextImage to textures via gl.texImage2D
       // Set uniforms, draw the quad
     },
   };

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -216,18 +216,18 @@ type TypeChild<PresentationProps extends Record<string, unknown>> =
 	| string;
 
 export type DrawFunction = (
-	prevImage: ElementImage | null,
-	nextImage: ElementImage | null,
+	prevImage: OffscreenCanvas | null,
+	nextImage: OffscreenCanvas | null,
 	progress: number,
 ) => void;
 
-type ElementImageAndProgress = {
-	elementImage: ElementImage | null;
+type TransitionImageAndProgress = {
+	elementImage: OffscreenCanvas | null;
 	progress: number | null;
 	draw: DrawFunction | null;
 };
 
-type ImageMap = Record<number, ElementImageAndProgress>;
+type ImageMap = Record<number, TransitionImageAndProgress>;
 
 const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 	children,
@@ -273,7 +273,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 
 	const onNextElementImage = useCallback(
 		(
-			elementImage: ElementImage | null,
+			elementImage: OffscreenCanvas | null,
 			progress: number | null,
 			draw: DrawFunction | null,
 			index: number,
@@ -287,7 +287,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 
 	const onPrevElementImage = useCallback(
 		(
-			elementImage: ElementImage | null,
+			elementImage: OffscreenCanvas | null,
 			progress: number | null,
 			draw: DrawFunction | null,
 			index: number,

--- a/packages/transitions/src/html-in-canvas-presentation.tsx
+++ b/packages/transitions/src/html-in-canvas-presentation.tsx
@@ -34,6 +34,7 @@ export const HtmlInCanvasPresentation = <
 	}
 
 	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const outputCanvasRef = useRef<HTMLCanvasElement>(null);
 	const canvasSubtreeStyle: React.CSSProperties = useMemo(() => {
 		return {
 			width: '100%',
@@ -45,8 +46,24 @@ export const HtmlInCanvasPresentation = <
 			bottom: 0,
 		};
 	}, []);
+	const outputCanvasStyle: React.CSSProperties = useMemo(() => {
+		return {
+			width: '100%',
+			height: '100%',
+			position: 'absolute',
+			top: 0,
+			left: 0,
+			right: 0,
+			bottom: 0,
+			pointerEvents: 'none',
+		};
+	}, []);
 
-	const [offscreenCanvas] = useState(() => new OffscreenCanvas(1, 1));
+	const captureCanvasRef = useRef<OffscreenCanvas | null>(null);
+	const captureContextRef = useRef<OffscreenCanvasRenderingContext2D | null>(
+		null,
+	);
+	const [shaderCanvas] = useState(() => new OffscreenCanvas(1, 1));
 
 	const passedPropsRef = useRef(passedProps);
 	passedPropsRef.current = passedProps;
@@ -59,28 +76,56 @@ export const HtmlInCanvasPresentation = <
 	const effectsRef = useRef(memoizedEffects);
 	effectsRef.current = memoizedEffects;
 
-	const [instance] = useState(() => shader(offscreenCanvas));
+	const [instance] = useState(() => shader(shaderCanvas));
 
 	useLayoutEffect(() => {
+		const canvas = canvasRef.current;
+		if (!canvas) {
+			return () => {
+				instance.cleanup();
+			};
+		}
+
+		const captureCanvas = canvas.transferControlToOffscreen();
+		const captureContext = captureCanvas.getContext('2d');
+		if (!captureContext) {
+			throw new Error('Failed to create capture canvas context');
+		}
+
+		captureCanvasRef.current = captureCanvas;
+		captureContextRef.current = captureContext;
+
 		return () => {
 			instance.cleanup();
+			captureCanvasRef.current = null;
+			captureContextRef.current = null;
 		};
-	}, [offscreenCanvas, instance]);
+	}, [instance]);
 
 	const chainState = Internals.useEffectChainState();
 	const {delayRender, continueRender} = useDelayRender();
 
 	const draw: DrawFunction = useCallback(
 		async (prevImage, nextImage, progress) => {
-			if (!canvasRef.current) {
+			const outputCanvas = outputCanvasRef.current;
+			if (!outputCanvas) {
 				throw new Error('Canvas not found');
 			}
 
 			const handle = delayRender('onPaint');
+			const clearOutput = () => {
+				const context = outputCanvas.getContext('2d');
+				if (!context) {
+					throw new Error('Failed to create output canvas context');
+				}
+
+				context.clearRect(0, 0, outputCanvas.width, outputCanvas.height);
+			};
 
 			if (!prevImage && !nextImage) {
-				continueRender(handle);
 				instance.clear();
+				clearOutput();
+				continueRender(handle);
 				return;
 			}
 
@@ -88,13 +133,14 @@ export const HtmlInCanvasPresentation = <
 			const height = prevImage?.height ?? nextImage?.height ?? 0;
 
 			if (width === 0 || height === 0) {
-				continueRender(handle);
 				instance.clear();
+				clearOutput();
+				continueRender(handle);
 				return;
 			}
 
-			offscreenCanvas.width = width;
-			offscreenCanvas.height = height;
+			shaderCanvas.width = width;
+			shaderCanvas.height = height;
 
 			instance.draw({
 				prevImage,
@@ -107,15 +153,15 @@ export const HtmlInCanvasPresentation = <
 
 			await Internals.runEffectChain({
 				state: chainState.get(width, height)!,
-				source: offscreenCanvas,
+				source: shaderCanvas,
 				effects: effectsRef.current ?? [],
 				width,
 				height,
-				output: canvasRef.current,
+				output: outputCanvas,
 			});
 			continueRender(handle);
 		},
-		[chainState, instance, offscreenCanvas, continueRender, delayRender],
+		[chainState, continueRender, delayRender, instance, shaderCanvas],
 	);
 
 	const passThrough =
@@ -135,13 +181,22 @@ export const HtmlInCanvasPresentation = <
 
 		const onPaint = () => {
 			const firstChild = canvas.firstChild as HTMLElement;
+			const captureCanvas = captureCanvasRef.current;
+			const captureContext = captureContextRef.current;
 
-			if (!firstChild) {
+			if (!firstChild || !captureCanvas || !captureContext) {
 				return;
 			}
 
 			const elementImage = canvas.captureElementImage(firstChild);
-			onElementImage(elementImage, draw);
+			try {
+				captureContext.reset();
+				captureContext.drawElementImage(elementImage, 0, 0);
+			} finally {
+				elementImage.close();
+			}
+
+			onElementImage(captureCanvas, draw);
 		};
 
 		canvas.addEventListener('paint', onPaint);
@@ -186,10 +241,25 @@ export const HtmlInCanvasPresentation = <
 
 		// Size the canvas grid to match the device scale factor to prevent blurriness.
 		const observer = new ResizeObserver(([entry]) => {
-			canvas.width = entry.devicePixelContentBoxSize[0].inlineSize;
-			canvas.height = entry.devicePixelContentBoxSize[0].blockSize;
+			const outputCanvas = outputCanvasRef.current;
+			const captureCanvas = captureCanvasRef.current;
+			if (!outputCanvas || !captureCanvas) {
+				return;
+			}
+
+			const width = entry.devicePixelContentBoxSize[0].inlineSize;
+			const height = entry.devicePixelContentBoxSize[0].blockSize;
+			captureCanvas.width = width;
+			captureCanvas.height = height;
+			outputCanvas.width = width;
+			outputCanvas.height = height;
+			canvas.requestPaint?.();
 		});
 		observer.observe(canvas, {box: 'device-pixel-content-box'});
+
+		return () => {
+			observer.disconnect();
+		};
 	}, [passThrough]);
 
 	if (passThrough) {
@@ -201,13 +271,14 @@ export const HtmlInCanvasPresentation = <
 			<canvas ref={canvasRef} style={canvasSubtreeStyle}>
 				{children}
 			</canvas>
+			<canvas ref={outputCanvasRef} style={outputCanvasStyle} />
 		</AbsoluteFill>
 	);
 };
 
 export type HtmlInCanvasShaderDrawParams<Props> = {
-	prevImage: ElementImage | null;
-	nextImage: ElementImage | null;
+	prevImage: OffscreenCanvas | null;
+	nextImage: OffscreenCanvas | null;
 	width: number;
 	height: number;
 	time: number;

--- a/packages/transitions/src/presentations/book-flip.tsx
+++ b/packages/transitions/src/presentations/book-flip.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type BookFlipDirection =
 	| 'from-left'
@@ -295,14 +296,7 @@ export const bookFlipShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -310,14 +304,7 @@ export const bookFlipShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/cross-zoom.tsx
+++ b/packages/transitions/src/presentations/cross-zoom.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type CrossZoomProps = {
 	strength?: number;
@@ -231,14 +232,7 @@ export const crossZoomShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -246,14 +240,7 @@ export const crossZoomShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/crosswarp.tsx
+++ b/packages/transitions/src/presentations/crosswarp.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type CrosswarpProps = Record<string, never>;
 
@@ -182,14 +183,7 @@ export const crosswarpShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -197,14 +191,7 @@ export const crosswarpShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/dissolve.tsx
+++ b/packages/transitions/src/presentations/dissolve.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type DissolveProps = {
 	lineWidth?: number;
@@ -233,14 +234,7 @@ export const dissolveShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -248,14 +242,7 @@ export const dissolveShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/dreamy-zoom.tsx
+++ b/packages/transitions/src/presentations/dreamy-zoom.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type DreamyZoomProps = {
 	rotation?: number;
@@ -202,14 +203,7 @@ export const dreamyZoomShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -217,14 +211,7 @@ export const dreamyZoomShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/film-burn.tsx
+++ b/packages/transitions/src/presentations/film-burn.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type FilmBurnProps = {
 	seed?: number;
@@ -297,14 +298,7 @@ export const filmBurnShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -312,14 +306,7 @@ export const filmBurnShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/linear-blur.tsx
+++ b/packages/transitions/src/presentations/linear-blur.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type LinearBlurProps = {
 	intensity?: number;
@@ -197,14 +198,7 @@ export const linearBlurShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -212,14 +206,7 @@ export const linearBlurShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/ripple.tsx
+++ b/packages/transitions/src/presentations/ripple.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type RippleProps = {
 	amplitude?: number;
@@ -196,14 +197,7 @@ export const rippleShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -211,14 +205,7 @@ export const rippleShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/swap.tsx
+++ b/packages/transitions/src/presentations/swap.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type SwapProps = {
 	reflection?: number;
@@ -246,14 +247,7 @@ export const swapShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -261,14 +255,7 @@ export const swapShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/upload-element-image.ts
+++ b/packages/transitions/src/presentations/upload-element-image.ts
@@ -1,0 +1,13 @@
+export const uploadElementImage = (
+	gl: WebGL2RenderingContext,
+	elementImage: OffscreenCanvas,
+): void => {
+	gl.texImage2D(
+		gl.TEXTURE_2D,
+		0,
+		gl.RGBA,
+		gl.RGBA,
+		gl.UNSIGNED_BYTE,
+		elementImage,
+	);
+};

--- a/packages/transitions/src/presentations/zoom-blur.tsx
+++ b/packages/transitions/src/presentations/zoom-blur.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type ZoomBlurProps = {
 	rotation?: number;
@@ -216,14 +217,7 @@ export const zoomBlurShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -231,14 +225,7 @@ export const zoomBlurShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/presentations/zoom-in-out.tsx
+++ b/packages/transitions/src/presentations/zoom-in-out.tsx
@@ -1,5 +1,6 @@
 import type {HtmlInCanvasShader} from '../html-in-canvas-presentation';
 import {makeHtmlInCanvasPresentation} from '../html-in-canvas-presentation';
+import {uploadElementImage} from './upload-element-image';
 
 export type ZoomInOutProps = Record<string, never>;
 
@@ -178,14 +179,7 @@ export const zoomInOutShader = (
 		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, prevTex);
 		if (prevImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				prevImage,
-			);
+			uploadElementImage(gl, prevImage);
 		}
 
 		gl.uniform1i(uPrev, 0);
@@ -193,14 +187,7 @@ export const zoomInOutShader = (
 		gl.activeTexture(gl.TEXTURE1);
 		gl.bindTexture(gl.TEXTURE_2D, nextTex);
 		if (nextImage) {
-			gl.texElementImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				nextImage,
-			);
+			uploadElementImage(gl, nextImage);
 		}
 
 		gl.uniform1i(uNext, 1);

--- a/packages/transitions/src/test/upload-element-image.test.ts
+++ b/packages/transitions/src/test/upload-element-image.test.ts
@@ -1,0 +1,25 @@
+import {expect, test} from 'bun:test';
+import {uploadElementImage} from '../presentations/upload-element-image';
+
+const elementImage = {
+	width: 100,
+	height: 100,
+} as OffscreenCanvas;
+
+test('uploads the rasterized transition image', () => {
+	const calls: unknown[][] = [];
+	const gl = {
+		TEXTURE_2D: 1,
+		RGBA: 2,
+		UNSIGNED_BYTE: 3,
+		texImage2D(...args: unknown[]) {
+			calls.push(args);
+		},
+	} as unknown as WebGL2RenderingContext;
+
+	uploadElementImage(gl, elementImage);
+
+	expect(calls).toEqual([
+		[gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, elementImage],
+	]);
+});

--- a/packages/transitions/src/types.ts
+++ b/packages/transitions/src/types.ts
@@ -35,7 +35,7 @@ export type TransitionPresentationComponentProps<
 	presentationDirection: PresentationDirection;
 	passedProps: PresentationProps;
 	presentationDurationInFrames: number;
-	onElementImage: (elementImage: ElementImage, draw: DrawFunction) => void;
+	onElementImage: (elementImage: OffscreenCanvas, draw: DrawFunction) => void;
 	onUnmount: () => void;
 	bothEnteringAndExiting: boolean;
 };


### PR DESCRIPTION
## Summary

- adapt HTML-in-canvas presentations to Chromium's canvas-bound `ElementImage` behavior
- rasterize each scene through its matching `OffscreenCanvas` and upload it with `texImage2D`
- update the custom presentation docs and keep the Zoom In/Out preview origin-safe

## Testing

- `bun run build`
- `bun run stylecheck`
- `@remotion/transitions` tests
- still renders in Chrome 150 and Chrome Canary 152

## Preview

- [makeHtmlInCanvasPresentation()](https://remotion-git-codex-fix-html-in-canvas-presentations-remotion.vercel.app/docs/transitions/make-html-in-canvas-presentation)
- [Custom HTML-in-canvas presentations](https://remotion-git-codex-fix-html-in-canvas-presentations-remotion.vercel.app/docs/transitions/presentations/custom-html-in-canvas)

Closes #9459
