### PR TITLE
`@remotion/studio`: Batch selected outline keyframe edits

### DIFF
--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -92,7 +92,6 @@ import {
 } from './selected-outline-uv';
 import {
 	callAddKeyframes,
-	callAddSequenceKeyframe,
 	type AddSequenceKeyframeChange,
 } from './Timeline/call-add-keyframe';
 import {disableSequenceInteractivity} from './Timeline/disable-sequence-interactivity';
@@ -733,18 +732,12 @@ const SelectedOutlinePolygon: React.FC<{
 										: 'Move sequence back',
 							})
 						: Promise.resolve(),
-					...keyframedChanges.map((change) =>
-						callAddSequenceKeyframe({
-							fileName: change.fileName,
-							nodePath: change.nodePath,
-							fieldKey: change.fieldKey,
-							sourceFrame: change.sourceFrame,
-							value: change.value,
-							schema: change.schema,
-							setPropStatuses,
-							clientId: change.clientId,
-						}),
-					),
+					callAddKeyframes({
+						sequenceKeyframes: keyframedChanges,
+						effectKeyframes: [],
+						setPropStatuses,
+						clientId: drag.clientId,
+					}),
 				])
 					.catch((err) => {
 						showNotification(
@@ -1077,18 +1070,12 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 										: 'Scale sequence back',
 							})
 						: Promise.resolve(),
-					...keyframedChanges.map((change) =>
-						callAddSequenceKeyframe({
-							fileName: change.fileName,
-							nodePath: change.nodePath,
-							fieldKey: change.fieldKey,
-							sourceFrame: change.sourceFrame,
-							value: change.value,
-							schema: change.schema,
-							setPropStatuses,
-							clientId: change.clientId,
-						}),
-					),
+					callAddKeyframes({
+						sequenceKeyframes: keyframedChanges,
+						effectKeyframes: [],
+						setPropStatuses,
+						clientId: scaleDrag.clientId,
+					}),
 				])
 					.catch((err) => {
 						showNotification(
@@ -1410,18 +1397,12 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 										: 'Rotate sequence back',
 							})
 						: Promise.resolve(),
-					...keyframedChanges.map((change) =>
-						callAddSequenceKeyframe({
-							fileName: change.fileName,
-							nodePath: change.nodePath,
-							fieldKey: change.fieldKey,
-							sourceFrame: change.sourceFrame,
-							value: change.value,
-							schema: change.schema,
-							setPropStatuses,
-							clientId: change.clientId,
-						}),
-					),
+					callAddKeyframes({
+						sequenceKeyframes: keyframedChanges,
+						effectKeyframes: [],
+						setPropStatuses,
+						clientId: rotationDrag.clientId,
+					}),
 				])
 					.catch((err) => {
 						showNotification(

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -61,7 +61,7 @@ import {
 	SelectedOutlineUvHandleCircleLayer,
 	SelectedOutlineUvHandleConnectionLayer,
 } from './SelectedOutlineUvControls';
-import {callAddSequenceKeyframe} from './Timeline/call-add-keyframe';
+import {callAddKeyframes} from './Timeline/call-add-keyframe';
 import {getCurrentDuration, getCurrentFps} from './Timeline/imperative-state';
 import {saveSequenceProps} from './Timeline/save-sequence-prop';
 import {ensureFrameIsInViewport} from './Timeline/timeline-scroll-logic';
@@ -993,18 +993,12 @@ export const SelectedOutlineOverlay: React.FC<{
 								: 'Move sequence back',
 					})
 				: Promise.resolve(),
-			...keyframedChanges.map((change) =>
-				callAddSequenceKeyframe({
-					fileName: change.fileName,
-					nodePath: change.nodePath,
-					fieldKey: change.fieldKey,
-					sourceFrame: change.sourceFrame,
-					value: change.value,
-					schema: change.schema,
-					setPropStatuses,
-					clientId: change.clientId,
-				}),
-			),
+			callAddKeyframes({
+				sequenceKeyframes: keyframedChanges,
+				effectKeyframes: [],
+				setPropStatuses,
+				clientId: session.clientId,
+			}),
 		])
 			.catch((err) => {
 				showNotification(


### PR DESCRIPTION
## Summary

- batch keyframed position updates when moving multiple selected Studio items
- cover keyboard nudges and pointer move, scale, and rotate gestures
- record each keyframed multi-selection gesture as a single undo transaction

## Testing

- `bun test packages/studio-server/src/test/add-keyframes.test.ts packages/studio/src/test/timeline-selection.test.ts`
- `bunx turbo run make --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`

## Follow-ups

- #9467 tracks mixed static and keyframed canvas transactions
- #9468 tracks batched easing changes, including effect keyframes
- #9469 tracks batched effect-property resets

Closes #9380
