### PR TITLE
`@remotion/studio`: Allow dropping assets onto timeline

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -2347,7 +2347,7 @@ export const insertJsxElementIntoComposition = async ({
 				child: elementToInsert,
 				dimensions: sequenceWrapper.dimensions,
 				durationInFrames: sequenceWrapper.durationInFrames ?? null,
-				from: sequenceWrapper.from ?? null,
+				from: sequenceWrapper.from,
 				name: sequenceWrapper.name,
 				position: sequenceWrapper.position,
 				sequenceLocalName: ensureSequenceImport(ast),

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -7,8 +7,8 @@ import type {
 	ExportSpecifier,
 	File,
 	FunctionDeclaration,
-	ImportDefaultSpecifier,
 	ImportDeclaration,
+	ImportDefaultSpecifier,
 	ImportSpecifier,
 	JSXAttribute,
 	JSXElement,
@@ -930,11 +930,13 @@ const createSolidElement = ({
 
 const createComponentElement = ({
 	addPositionStyle,
+	from,
 	localName,
 	props,
 	position,
 }: {
 	addPositionStyle: boolean;
+	from: number | null;
 	localName: string;
 	props: ComponentProp[];
 	position: InsertableCompositionElementPosition | null;
@@ -944,6 +946,7 @@ const createComponentElement = ({
 			recast.types.builders.jsxIdentifier(localName),
 			[
 				...props.map(createComponentProp),
+				...(from === null ? [] : [createNumberAttribute('from', from)]),
 				...(addPositionStyle
 					? [createPositionAbsoluteStyleAttribute(position)]
 					: []),
@@ -1001,6 +1004,7 @@ const createSequenceWrappedElement = ({
 const createAssetElement = ({
 	addPositionStyle,
 	durationInFrames,
+	from,
 	localName,
 	staticFileLocalName,
 	src,
@@ -1009,6 +1013,7 @@ const createAssetElement = ({
 }: {
 	addPositionStyle: boolean;
 	durationInFrames: number | null;
+	from: number | null;
 	localName: string;
 	staticFileLocalName: string | null;
 	src: string;
@@ -1025,6 +1030,7 @@ const createAssetElement = ({
 				...(durationInFrames === null
 					? []
 					: [createNumberAttribute('durationInFrames', durationInFrames)]),
+				...(from === null ? [] : [createNumberAttribute('from', from)]),
 				...(addPositionStyle
 					? [createAssetStyleAttribute({dimensions, position})]
 					: []),
@@ -1037,10 +1043,12 @@ const createAssetElement = ({
 };
 
 const createSvgElement = async ({
+	from,
 	interactiveLocalName,
 	markup,
 	position,
 }: {
+	from: number | null;
 	interactiveLocalName: string;
 	markup: string;
 	position: InsertableCompositionElementPosition | null;
@@ -1048,6 +1056,10 @@ const createSvgElement = async ({
 	const svgElement = await svgMarkupToJsx(markup);
 	const attributes = svgElement.openingElement.attributes ?? [];
 	svgElement.openingElement.attributes = attributes;
+	if (from !== null) {
+		attributes.push(createNumberAttribute('from', from));
+	}
+
 	const styleAttribute = attributes.find(
 		(attribute) =>
 			attribute.type === 'JSXAttribute' &&
@@ -2138,12 +2150,14 @@ const createInsertableJsxElement = ({
 	ast,
 	destinationFileName,
 	element,
+	from,
 	remotionRoot,
 }: {
 	addPositionStyleToComponent: boolean;
 	ast: File;
 	destinationFileName: string;
 	element: InsertableCompositionElement;
+	from: number | null;
 	remotionRoot: string;
 }): Promise<namedTypes.JSXElement> | namedTypes.JSXElement => {
 	if (element.type === 'solid') {
@@ -2167,6 +2181,7 @@ const createInsertableJsxElement = ({
 
 		return createComponentElement({
 			addPositionStyle: addPositionStyleToComponent,
+			from,
 			localName: componentLocalName,
 			props: element.props,
 			position: element.position,
@@ -2175,6 +2190,7 @@ const createInsertableJsxElement = ({
 
 	if (element.type === 'svg') {
 		return createSvgElement({
+			from,
 			interactiveLocalName: ensureInteractiveImport(ast),
 			markup: element.markup,
 			position: element.position,
@@ -2229,10 +2245,14 @@ const createInsertableJsxElement = ({
 				addPositionStyleToComponent && element.assetType !== 'audio',
 			durationInFrames:
 				element.assetType === 'image' ? null : element.durationInFrames,
+			from,
 			localName,
 			staticFileLocalName,
 			src: element.src,
-			dimensions: element.dimensions,
+			dimensions:
+				element.assetType === 'image' && from !== null
+					? null
+					: element.dimensions,
 			position: element.position,
 		});
 	}
@@ -2302,14 +2322,14 @@ export const insertJsxElementIntoComposition = async ({
 					position: element.position,
 					from,
 				}
-			: from === null
+			: from === null ||
+				  element.type === 'asset' ||
+				  element.type === 'svg' ||
+				  element.type === 'component'
 				? wrapInSequence
 				: {
-						dimensions: element.type === 'asset' ? element.dimensions : null,
-						durationInFrames:
-							element.type === 'asset' && element.assetType !== 'image'
-								? element.durationInFrames
-								: null,
+						dimensions: null,
+						durationInFrames: null,
 						name: null,
 						position: element.position,
 						from,
@@ -2319,6 +2339,7 @@ export const insertJsxElementIntoComposition = async ({
 		ast,
 		destinationFileName: location.fileName,
 		element,
+		from,
 		remotionRoot,
 	});
 	const finalElementToInsert = sequenceWrapper

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -2265,7 +2265,7 @@ export const insertJsxElementIntoComposition = async ({
 	compositionFile,
 	compositionId,
 	element,
-	from = null,
+	from,
 	prettierConfigOverride,
 	wrapInSequence = null,
 }: {
@@ -2273,12 +2273,12 @@ export const insertJsxElementIntoComposition = async ({
 	compositionFile: string;
 	compositionId: string;
 	element: InsertableCompositionElement;
-	from?: number | null;
+	from: number | null;
 	prettierConfigOverride: Record<string, unknown> | null;
 	wrapInSequence?: {
 		dimensions: {width: number; height: number} | null;
 		durationInFrames?: number | null;
-		from?: number | null;
+		from: number | null;
 		name: string | null;
 		position: InsertableCompositionElementPosition | null;
 	} | null;

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -959,6 +959,7 @@ const createSequenceWrappedElement = ({
 	child,
 	dimensions,
 	durationInFrames,
+	from,
 	name,
 	position,
 	sequenceLocalName,
@@ -966,6 +967,7 @@ const createSequenceWrappedElement = ({
 	child: namedTypes.JSXElement;
 	dimensions: {width: number; height: number} | null;
 	durationInFrames: number | null;
+	from: number | null;
 	name: string | null;
 	position: InsertableCompositionElementPosition | null;
 	sequenceLocalName: string;
@@ -974,6 +976,7 @@ const createSequenceWrappedElement = ({
 		recast.types.builders.jsxOpeningElement(
 			recast.types.builders.jsxIdentifier(sequenceLocalName),
 			[
+				...(from === null ? [] : [createNumberAttribute('from', from)]),
 				...(name === null ? [] : [createStringAttribute('name', name)]),
 				...(dimensions !== null
 					? [
@@ -2242,6 +2245,7 @@ export const insertJsxElementIntoComposition = async ({
 	compositionFile,
 	compositionId,
 	element,
+	from = null,
 	prettierConfigOverride,
 	wrapInSequence = null,
 }: {
@@ -2249,10 +2253,12 @@ export const insertJsxElementIntoComposition = async ({
 	compositionFile: string;
 	compositionId: string;
 	element: InsertableCompositionElement;
+	from?: number | null;
 	prettierConfigOverride: Record<string, unknown> | null;
 	wrapInSequence?: {
 		dimensions: {width: number; height: number} | null;
 		durationInFrames?: number | null;
+		from?: number | null;
 		name: string | null;
 		position: InsertableCompositionElementPosition | null;
 	} | null;
@@ -2294,8 +2300,20 @@ export const insertJsxElementIntoComposition = async ({
 					durationInFrames: element.durationInFrames,
 					name: element.compositionId,
 					position: element.position,
+					from,
 				}
-			: wrapInSequence;
+			: from === null
+				? wrapInSequence
+				: {
+						dimensions: element.type === 'asset' ? element.dimensions : null,
+						durationInFrames:
+							element.type === 'asset' && element.assetType !== 'image'
+								? element.durationInFrames
+								: null,
+						name: null,
+						position: element.position,
+						from,
+					};
 	const elementToInsert = await createInsertableJsxElement({
 		addPositionStyleToComponent: sequenceWrapper === null,
 		ast,
@@ -2308,6 +2326,7 @@ export const insertJsxElementIntoComposition = async ({
 				child: elementToInsert,
 				dimensions: sequenceWrapper.dimensions,
 				durationInFrames: sequenceWrapper.durationInFrames ?? null,
+				from: sequenceWrapper.from ?? null,
 				name: sequenceWrapper.name,
 				position: sequenceWrapper.position,
 				sequenceLocalName: ensureSequenceImport(ast),

--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -114,7 +114,7 @@ export const insertElementHandler: ApiHandler<
 	InsertElementRequest,
 	InsertElementResponse
 > = ({
-	input: {compositionFile, compositionId, element, from = null, position},
+	input: {compositionFile, compositionId, element, from, position},
 	remotionRoot,
 	logLevel,
 }) =>
@@ -199,6 +199,7 @@ export const insertElementHandler: ApiHandler<
 					props: [],
 					position: null,
 				},
+				from: null,
 				prettierConfigOverride: null,
 				wrapInSequence: {
 					dimensions: element.dimensions,

--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -114,7 +114,7 @@ export const insertElementHandler: ApiHandler<
 	InsertElementRequest,
 	InsertElementResponse
 > = ({
-	input: {compositionFile, compositionId, element, position},
+	input: {compositionFile, compositionId, element, from = null, position},
 	remotionRoot,
 	logLevel,
 }) =>
@@ -122,6 +122,13 @@ export const insertElementHandler: ApiHandler<
 		try {
 			validateElement(element);
 			validatePosition(position);
+			if (
+				from !== null &&
+				(!Number.isInteger(from) || !Number.isFinite(from) || from < 0)
+			) {
+				throw new Error('from must be a non-negative integer');
+			}
+
 			const componentName = getElementComponentNameFromSourceCode(
 				element.sourceCode,
 			);
@@ -195,6 +202,7 @@ export const insertElementHandler: ApiHandler<
 				prettierConfigOverride: null,
 				wrapInSequence: {
 					dimensions: element.dimensions,
+					from,
 					name: element.displayName,
 					position,
 				},

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -220,7 +220,7 @@ export const insertJsxElementHandler: ApiHandler<
 	InsertJsxElementRequest,
 	InsertJsxElementResponse
 > = ({
-	input: {compositionFile, compositionId, element, from = null},
+	input: {compositionFile, compositionId, element, from},
 	remotionRoot,
 	logLevel,
 }) =>

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -220,13 +220,20 @@ export const insertJsxElementHandler: ApiHandler<
 	InsertJsxElementRequest,
 	InsertJsxElementResponse
 > = ({
-	input: {compositionFile, compositionId, element},
+	input: {compositionFile, compositionId, element, from = null},
 	remotionRoot,
 	logLevel,
 }) =>
 	withSourceFileWriteQueue(async () => {
 		try {
 			validateElement(element, remotionRoot);
+			if (
+				from !== null &&
+				(!Number.isInteger(from) || !Number.isFinite(from) || from < 0)
+			) {
+				throw new Error('from must be a non-negative integer');
+			}
+
 			const elementLabel = getElementLabel(element);
 
 			RenderInternals.Log.trace(
@@ -240,6 +247,7 @@ export const insertJsxElementHandler: ApiHandler<
 					compositionFile,
 					compositionId,
 					element,
+					from,
 					prettierConfigOverride: null,
 				});
 

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -929,7 +929,7 @@ test('converts and inserts SVG markup as an Interactive.Svg', async () => {
 	}
 });
 
-test('inserts a CanvasImage asset into the resolved composition component', async () => {
+test('inserts a CanvasImage asset at a timeline frame', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {
 		await fs.writeFile(
@@ -971,19 +971,22 @@ test('inserts a CanvasImage asset into the resolved composition component', asyn
 				durationInFrames: null,
 				position: null,
 			},
+			from: 42,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
 		expect(result.output).toContain(
-			"import { AbsoluteFill, staticFile, CanvasImage } from 'remotion';",
+			"import { AbsoluteFill, staticFile, CanvasImage, Sequence } from 'remotion';",
 		);
+		expect(result.output).toContain('<Sequence');
+		expect(result.output).toContain('from={42}');
+		expect(result.output).toContain('width={800}');
+		expect(result.output).toContain('height={600}');
 		expect(result.output).toContain('<CanvasImage');
 		expect(result.output).toContain("src={staticFile('image.png')}");
 		expect(result.output).toContain("position: 'absolute'");
-		expect(result.output).toContain('width: 800');
-		expect(result.output).toContain('height: 600');
-		expect(result.output).not.toContain('width={800}');
-		expect(result.output).not.toContain('height={600}');
+		expect(result.output).not.toContain('width: 800');
+		expect(result.output).not.toContain('height: 600');
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}
@@ -1538,6 +1541,7 @@ test('wraps a component in a dimensionless Sequence', async () => {
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 			wrapInSequence: {
 				dimensions: null,
+				from: 42,
 				name: 'Lower Third',
 				position: {x: 120, y: 80.5},
 			},
@@ -1550,6 +1554,7 @@ test('wraps a component in a dimensionless Sequence', async () => {
 			"import { LowerThird } from './lower-third.element';",
 		);
 		expect(result.output).toContain('<Sequence');
+		expect(result.output).toContain('from={42}');
 		expect(result.output).toContain('name="Lower Third"');
 		expect(result.output).toContain("translate: '120px 80.5px'");
 		expect(result.output).toContain('<LowerThird />');

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -908,6 +908,7 @@ test('converts and inserts SVG markup as an Interactive.Svg', async () => {
 					'<svg width="100" height="50" viewBox="0 0 100 50" style="opacity: 0.8"><path fill-rule="evenodd" stroke-width="2" d="M0 0h10v10z" /></svg>',
 				position: {x: 120.25, y: 80},
 			},
+			from: 42,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -915,6 +916,8 @@ test('converts and inserts SVG markup as an Interactive.Svg', async () => {
 			"import { AbsoluteFill, Interactive } from 'remotion';",
 		);
 		expect(result.output).toContain('<Interactive.Svg');
+		expect(result.output).toContain('from={42}');
+		expect(result.output).not.toContain('<Sequence');
 		expect(result.output).toContain('</Interactive.Svg>');
 		expect(result.output).toContain('width={100}');
 		expect(result.output).toContain('height={50}');
@@ -976,15 +979,15 @@ test('inserts a CanvasImage asset at a timeline frame', async () => {
 		});
 
 		expect(result.output).toContain(
-			"import { AbsoluteFill, staticFile, CanvasImage, Sequence } from 'remotion';",
+			"import { AbsoluteFill, staticFile, CanvasImage } from 'remotion';",
 		);
-		expect(result.output).toContain('<Sequence');
+		expect(result.output).not.toContain('<Sequence');
 		expect(result.output).toContain('from={42}');
-		expect(result.output).toContain('width={800}');
-		expect(result.output).toContain('height={600}');
 		expect(result.output).toContain('<CanvasImage');
 		expect(result.output).toContain("src={staticFile('image.png')}");
 		expect(result.output).toContain("position: 'absolute'");
+		expect(result.output).not.toContain('width={800}');
+		expect(result.output).not.toContain('height={600}');
 		expect(result.output).not.toContain('width: 800');
 		expect(result.output).not.toContain('height: 600');
 	} finally {
@@ -1093,6 +1096,7 @@ test('inserts an AnimatedImage asset into the resolved composition component', a
 				durationInFrames: 37.52,
 				position: null,
 			},
+			from: 42,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -1102,6 +1106,8 @@ test('inserts an AnimatedImage asset into the resolved composition component', a
 		expect(result.output).toContain('<AnimatedImage');
 		expect(result.output).toContain("src={staticFile('animated-png.png')}");
 		expect(result.output).toContain('durationInFrames={37.52}');
+		expect(result.output).toContain('from={42}');
+		expect(result.output).not.toContain('<Sequence');
 		expect(result.output).toContain('width: 320');
 		expect(result.output).toContain('height: 180');
 		expect(result.output).not.toContain('width={320}');
@@ -1153,6 +1159,7 @@ test('inserts a Video asset with its duration and CSS dimensions', async () => {
 				durationInFrames: 37.52,
 				position: null,
 			},
+			from: 42,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -1161,6 +1168,7 @@ test('inserts a Video asset with its duration and CSS dimensions', async () => {
 			"import { AbsoluteFill, staticFile } from 'remotion';",
 		);
 		expect(result.output).toContain('durationInFrames={37.52}');
+		expect(result.output).toContain('from={42}');
 		expect(result.output).toContain('<Video');
 		expect(result.output).toContain("src={staticFile('clip.mp4')}");
 		expect(result.output).toContain("position: 'absolute'");
@@ -1264,6 +1272,7 @@ test('inserts a Gif asset into the resolved composition component', async () => 
 				durationInFrames: 37.52,
 				position: null,
 			},
+			from: 42,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -1274,6 +1283,8 @@ test('inserts a Gif asset into the resolved composition component', async () => 
 		expect(result.output).toContain('<Gif');
 		expect(result.output).toContain("src={staticFile('animation.gif')}");
 		expect(result.output).toContain('durationInFrames={37.52}');
+		expect(result.output).toContain('from={42}');
+		expect(result.output).not.toContain('<Sequence');
 		expect(result.output).toContain('width: 320');
 		expect(result.output).toContain('height: 180');
 		expect(result.output).not.toContain('width={320}');
@@ -1322,6 +1333,7 @@ test('inserts an Audio asset into the resolved composition component', async () 
 				durationInFrames: 37.52,
 				position: null,
 			},
+			from: 42,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -1332,6 +1344,8 @@ test('inserts an Audio asset into the resolved composition component', async () 
 		expect(result.output).toContain('<Audio');
 		expect(result.output).toContain("src={staticFile('audio.mp3')}");
 		expect(result.output).toContain('durationInFrames={37.52}');
+		expect(result.output).toContain('from={42}');
+		expect(result.output).not.toContain('<Sequence');
 		expect(result.output).not.toContain("position: 'absolute'");
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
@@ -1484,6 +1498,7 @@ test('inserts a component into the resolved composition component', async () => 
 				],
 				position: null,
 			},
+			from: 42,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -1494,7 +1509,9 @@ test('inserts a component into the resolved composition component', async () => 
 		expect(result.output).toContain('fill="#0b84ff"');
 		expect(result.output).toContain('dataShapeIndex={1}');
 		expect(result.output).toContain('debug={false}');
+		expect(result.output).toContain('from={42}');
 		expect(result.output).toContain("position: 'absolute'");
+		expect(result.output).not.toContain('<Sequence');
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -381,6 +381,7 @@ test('wraps a self-closing root in a Sequence before inserting', async () => {
 				durationInFrames: null,
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -440,6 +441,7 @@ test('removes parentheses when wrapping a self-closing root in a Sequence', asyn
 				durationInFrames: null,
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -636,6 +638,7 @@ test('inserts a Solid into the resolved composition component', async () => {
 				height: 720,
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -692,6 +695,7 @@ test('inserts a Solid with a translate style', async () => {
 					y: 80.5,
 				},
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -741,6 +745,7 @@ test('rounds the translate style to one decimal place', async () => {
 					y: 50.1836012801557,
 				},
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -789,6 +794,7 @@ test('inserts an aliased Solid import if Solid is already defined', async () => 
 				height: 1080,
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -833,6 +839,7 @@ test('inserts a Solid into an empty component returning null', async () => {
 				height: 360,
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -864,6 +871,7 @@ test('inserts a Solid into an empty component returning null', async () => {
 				height: 180,
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 		expect(secondInsert.output.match(/<Solid/g)?.length).toBe(2);
@@ -1040,6 +1048,7 @@ test('inserts a CanvasImage asset with a translate style', async () => {
 					y: 150,
 				},
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -1222,6 +1231,7 @@ test('rejects inserting a Video asset if Video is already defined', async () => 
 					durationInFrames: null,
 					position: null,
 				},
+				from: null,
 				prettierConfigOverride: {singleQuote: true, useTabs: true},
 			}),
 		).rejects.toThrow('Cannot add <Video> because Video is already defined');
@@ -1391,6 +1401,7 @@ test('inserts a remote audio asset with a literal URL', async () => {
 				durationInFrames: null,
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -1448,6 +1459,7 @@ test('rejects inserting an Audio asset if Audio is already defined', async () =>
 					durationInFrames: null,
 					position: null,
 				},
+				from: null,
 				prettierConfigOverride: {singleQuote: true, useTabs: true},
 			}),
 		).rejects.toThrow('Cannot add <Audio> because Audio is already defined');
@@ -1555,6 +1567,7 @@ test('wraps a component in a dimensionless Sequence', async () => {
 				props: [],
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 			wrapInSequence: {
 				dimensions: null,
@@ -1643,6 +1656,7 @@ test('inserts a composition as a duration-aware Sequence', async () => {
 				}),
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -1725,6 +1739,7 @@ test('inserts a default-exported composition next to an existing namespace impor
 				serializedResolvedPropsWithCustomSchema: JSON.stringify({}),
 				position: null,
 			},
+			from: null,
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
@@ -1800,6 +1815,7 @@ test('rejects array payloads for resolved composition props', async () => {
 					]),
 					position: null,
 				},
+				from: null,
 				prettierConfigOverride: {singleQuote: true, useTabs: true},
 			}),
 		).rejects.toThrow('Resolved composition props must be an object');
@@ -1825,6 +1841,7 @@ test('rejects composition insertion requests that traverse out of the project ro
 					serializedResolvedPropsWithCustomSchema: JSON.stringify({}),
 					position: null,
 				},
+				from: null,
 			},
 			entryPoint: path.join(tempDir, 'Root.tsx'),
 			remotionRoot: tempDir,

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -774,6 +774,7 @@ export type InsertElementRequest = {
 	compositionFile: string;
 	compositionId: string;
 	element: ElementDragData['element'];
+	from?: number | null;
 	position: InsertableCompositionElementPosition | null;
 };
 

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -743,6 +743,7 @@ export type InsertJsxElementRequest = {
 	compositionFile: string;
 	compositionId: string;
 	element: InsertableCompositionElement;
+	from?: number | null;
 };
 
 export type InsertJsxElementResponse =

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -743,7 +743,7 @@ export type InsertJsxElementRequest = {
 	compositionFile: string;
 	compositionId: string;
 	element: InsertableCompositionElement;
-	from?: number | null;
+	from: number | null;
 };
 
 export type InsertJsxElementResponse =
@@ -774,7 +774,7 @@ export type InsertElementRequest = {
 	compositionFile: string;
 	compositionId: string;
 	element: ElementDragData['element'];
-	from?: number | null;
+	from: number | null;
 	position: InsertableCompositionElementPosition | null;
 };
 

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -914,6 +914,7 @@ export const Canvas: React.FC<{
 					compositionFile: activeElementInstallRequest.compositionFile,
 					compositionId: activeElementInstallRequest.compositionId,
 					dropPosition: null,
+					from: null,
 				});
 			}
 		};
@@ -1012,6 +1013,7 @@ export const Canvas: React.FC<{
 					dropPosition,
 					event,
 					fps: config.fps,
+					from: null,
 				});
 			} finally {
 				setIsAddingAsset(false);
@@ -1121,6 +1123,7 @@ export const Canvas: React.FC<{
 					destinationDimensions:
 						contentDimensions === 'none' ? null : contentDimensions,
 					dropPosition,
+					from: null,
 					svgImportMode,
 				});
 			} finally {

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1,18 +1,5 @@
 import type {Size} from '@remotion/player';
-import {
-	ASSET_DRAG_MIME_TYPE,
-	COMPONENT_DRAG_MIME_TYPE,
-	COMPOSITION_DRAG_MIME_TYPE,
-	ELEMENT_DRAG_MIME_TYPE,
-	parseAssetDragData,
-	parseComponentDragData,
-	parseCompositionDragData,
-	parseSfxDragData,
-	SFX_DRAG_MIME_TYPE,
-	type ComponentDragData,
-	type CompositionDragData,
-	type ElementInstallRequest,
-} from '@remotion/studio-shared';
+import type {ElementInstallRequest} from '@remotion/studio-shared';
 import React, {
 	useCallback,
 	useContext,
@@ -39,10 +26,6 @@ import {
 import {getMissingPackages} from '../helpers/install-required-package';
 import {useCachedCompositionComponentInfo} from '../helpers/open-in-editor';
 import {
-	getRemoteAssetUrlFromDataTransfer,
-	hasRemoteAssetDragData,
-} from '../helpers/remote-asset-drag';
-import {
 	MAX_ZOOM,
 	MIN_ZOOM,
 	smoothenZoom,
@@ -58,21 +41,17 @@ import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorZoomGesturesContext} from '../state/editor-zoom-gestures';
 import {callApi} from './call-api';
 import {useConfirmationDialog} from './ConfirmationDialog';
+import {isSupportedDropEvent} from './drop-handler-data';
 import EditorGuides from './EditorGuides';
 import {EditorRulers} from './EditorRuler';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
 import {getEffectDragData} from './effect-drag-and-drop';
-import {getElementDragData} from './element-drag-and-drop';
+import {handleDrop} from './handle-drop';
 import {
 	hasSvgFile,
 	importAssets,
 	importFigmaClipboard,
-	importRemoteAsset,
-	insertComponent,
-	insertComposition,
 	insertElement,
-	insertExistingAssets,
-	insertRemoteAudio,
 	insertSvgMarkup,
 	type InsertElementDropPosition,
 } from './import-assets';
@@ -174,113 +153,6 @@ const calculateCanvasScale = ({
 	return addFitPadding
 		? calculateStudioScale(options)
 		: Internals.calculateScale(options);
-};
-
-const isFileDragEvent = (event: DragEvent): boolean => {
-	return Array.from(event.dataTransfer?.types ?? []).includes('Files');
-};
-
-const isAssetDragEvent = (event: DragEvent): boolean => {
-	return Array.from(event.dataTransfer?.types ?? []).includes(
-		ASSET_DRAG_MIME_TYPE,
-	);
-};
-
-const isComponentDragEvent = (event: DragEvent): boolean => {
-	return Array.from(event.dataTransfer?.types ?? []).includes(
-		COMPONENT_DRAG_MIME_TYPE,
-	);
-};
-
-const isCompositionDragEvent = (event: DragEvent): boolean => {
-	return Array.from(event.dataTransfer?.types ?? []).includes(
-		COMPOSITION_DRAG_MIME_TYPE,
-	);
-};
-
-const isElementDragEvent = (event: DragEvent): boolean => {
-	return Array.from(event.dataTransfer?.types ?? []).includes(
-		ELEMENT_DRAG_MIME_TYPE,
-	);
-};
-
-const isSfxDragEvent = (event: DragEvent): boolean => {
-	return Array.from(event.dataTransfer?.types ?? []).includes(
-		SFX_DRAG_MIME_TYPE,
-	);
-};
-
-const isRemoteAssetDragEvent = (event: DragEvent): boolean => {
-	return (
-		!isFileDragEvent(event) &&
-		!isAssetDragEvent(event) &&
-		!isCompositionDragEvent(event) &&
-		!isComponentDragEvent(event) &&
-		!isElementDragEvent(event) &&
-		!isSfxDragEvent(event) &&
-		hasRemoteAssetDragData(event.dataTransfer)
-	);
-};
-
-const getAssetDragPath = (event: DragEvent): string | null => {
-	const value = event.dataTransfer?.getData(ASSET_DRAG_MIME_TYPE);
-	if (!value) {
-		return null;
-	}
-
-	return parseAssetDragData(value)?.assetPath ?? null;
-};
-
-const getCompositionDragData = (
-	event: DragEvent,
-): CompositionDragData | null => {
-	const value = event.dataTransfer?.getData(COMPOSITION_DRAG_MIME_TYPE);
-	if (!value) {
-		return null;
-	}
-
-	return parseCompositionDragData(value);
-};
-
-const getComponentDragData = (event: DragEvent): ComponentDragData | null => {
-	for (const type of [
-		COMPONENT_DRAG_MIME_TYPE,
-		'application/json',
-		'text/plain',
-	]) {
-		const value = event.dataTransfer?.getData(type);
-		if (!value) {
-			continue;
-		}
-
-		const parsed = parseComponentDragData(value);
-		if (parsed) {
-			return parsed;
-		}
-	}
-
-	return null;
-};
-
-const getSfxDragUrl = (event: DragEvent): string | null => {
-	const {dataTransfer} = event;
-	if (!dataTransfer) {
-		return null;
-	}
-
-	for (const type of [SFX_DRAG_MIME_TYPE, 'application/json', 'text/plain']) {
-		const value = dataTransfer.getData(type);
-		if (!value) {
-			continue;
-		}
-
-		const parsed = parseSfxDragData(value);
-		if (parsed) {
-			return parsed.sfx.url;
-		}
-	}
-
-	return null;
 };
 
 const getDropPosition = ({
@@ -1068,16 +940,7 @@ export const Canvas: React.FC<{
 
 	const onDragOver = useCallback(
 		(event: DragEvent) => {
-			if (
-				(!isFileDragEvent(event) &&
-					!isAssetDragEvent(event) &&
-					!isCompositionDragEvent(event) &&
-					!isComponentDragEvent(event) &&
-					!isElementDragEvent(event) &&
-					!isSfxDragEvent(event) &&
-					!isRemoteAssetDragEvent(event)) ||
-				!isDragEventInsideCanvas(event)
-			) {
+			if (!isSupportedDropEvent(event) || !isDragEventInsideCanvas(event)) {
 				return;
 			}
 
@@ -1095,16 +958,7 @@ export const Canvas: React.FC<{
 
 	const onDrop = useCallback(
 		async (event: DragEvent) => {
-			if (
-				(!isFileDragEvent(event) &&
-					!isAssetDragEvent(event) &&
-					!isCompositionDragEvent(event) &&
-					!isComponentDragEvent(event) &&
-					!isElementDragEvent(event) &&
-					!isSfxDragEvent(event) &&
-					!isRemoteAssetDragEvent(event)) ||
-				!isDragEventInsideCanvas(event)
-			) {
+			if (!isSupportedDropEvent(event) || !isDragEventInsideCanvas(event)) {
 				return;
 			}
 
@@ -1149,108 +1003,16 @@ export const Canvas: React.FC<{
 					size,
 				});
 
-				if (isFileDragEvent(event)) {
-					const files = Array.from(event.dataTransfer?.files ?? []);
-					if (files.length === 0) {
-						return;
-					}
-
-					const svgImportMode = hasSvgFile(files)
-						? await chooseSvgImportMode()
-						: 'image';
-					if (svgImportMode === null) {
-						return;
-					}
-
-					await importAssets({
-						files,
-						fps: config.fps,
-						compositionFile,
-						compositionId: currentCompositionId,
-						destinationDimensions:
-							contentDimensions === 'none' ? null : contentDimensions,
-						dropPosition,
-						svgImportMode,
-					});
-				} else if (isAssetDragEvent(event)) {
-					const assetPath = getAssetDragPath(event);
-					if (assetPath === null) {
-						return;
-					}
-
-					await insertExistingAssets({
-						assetPaths: [assetPath],
-						fps: config.fps,
-						compositionFile,
-						compositionId: currentCompositionId,
-						destinationDimensions:
-							contentDimensions === 'none' ? null : contentDimensions,
-						dropPosition,
-					});
-				} else if (isSfxDragEvent(event)) {
-					const url = getSfxDragUrl(event);
-					if (url === null) {
-						return;
-					}
-
-					await insertRemoteAudio({
-						url,
-						fps: config.fps,
-						compositionFile,
-						compositionId: currentCompositionId,
-					});
-				} else if (isCompositionDragEvent(event)) {
-					const compositionDragData = getCompositionDragData(event);
-					if (compositionDragData === null) {
-						return;
-					}
-
-					await insertComposition({
-						composition: compositionDragData,
-						compositionFile,
-						compositionId: currentCompositionId,
-						destinationDimensions:
-							contentDimensions === 'none' ? null : contentDimensions,
-						dropPosition,
-					});
-				} else {
-					const elementDragData = getElementDragData(event.dataTransfer);
-					if (elementDragData !== null) {
-						await insertElement({
-							element: elementDragData.element,
-							compositionFile,
-							compositionId: currentCompositionId,
-							dropPosition,
-						});
-						return;
-					}
-
-					const componentDragData = getComponentDragData(event);
-					if (componentDragData !== null) {
-						await insertComponent({
-							component: componentDragData.component,
-							compositionFile,
-							compositionId: currentCompositionId,
-							dropPosition,
-						});
-						return;
-					}
-
-					const url = getRemoteAssetUrlFromDataTransfer(event.dataTransfer);
-					if (url === null) {
-						return;
-					}
-
-					await importRemoteAsset({
-						url,
-						fps: config.fps,
-						compositionFile,
-						compositionId: currentCompositionId,
-						destinationDimensions:
-							contentDimensions === 'none' ? null : contentDimensions,
-						dropPosition,
-					});
-				}
+				await handleDrop({
+					chooseSvgImportMode,
+					compositionFile,
+					compositionId: currentCompositionId,
+					destinationDimensions:
+						contentDimensions === 'none' ? null : contentDimensions,
+					dropPosition,
+					event,
+					fps: config.fps,
+				});
 			} finally {
 				setIsAddingAsset(false);
 			}

--- a/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
+++ b/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
@@ -72,6 +72,7 @@ export const useCompositionActions = () => {
 			const result = await callApi('/api/insert-jsx-element', {
 				compositionFile,
 				compositionId: currentCompositionId,
+				from: null,
 				element: {
 					type: 'solid',
 					width: videoConfig.width,
@@ -117,6 +118,7 @@ export const useCompositionActions = () => {
 				compositionId: currentCompositionId,
 				destinationDimensions: null,
 				dropPosition: null,
+				from: null,
 				svgImportMode: 'image',
 			});
 		} finally {

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -21,6 +21,7 @@ import {SequencePropsObserver} from './SequencePropsObserver';
 import {shouldShowTrackInTimeline} from './should-show-track-in-timeline';
 import {shouldSubscribeToSequenceProps} from './should-subscribe-to-sequence-props';
 import {SubscribeToNodePaths} from './SubscribeToNodePaths';
+import {TimelineAssetDropFrameContext} from './timeline-asset-drop-context';
 import {timelineVerticalScroll} from './timeline-refs';
 import {TimelineDragHandler} from './TimelineDragHandler';
 import {TimelineHeightContainer} from './TimelineHeightContainer';
@@ -59,7 +60,7 @@ const noop = () => undefined;
 const TimelineContextMenuArea: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
-	useTimelineAssetDrop();
+	const assetDropFrame = useTimelineAssetDrop();
 	const {compositions, canvasContent} = useContext(
 		Internals.CompositionManager,
 	);
@@ -212,7 +213,9 @@ const TimelineContextMenuArea: React.FC<{
 			style={container}
 			className={'css-reset ' + VERTICAL_SCROLLBAR_CLASSNAME}
 		>
-			{children}
+			<TimelineAssetDropFrameContext.Provider value={assetDropFrame}>
+				{children}
+			</TimelineAssetDropFrameContext.Provider>
 		</ContextMenu>
 	);
 };

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -124,6 +124,7 @@ const TimelineContextMenuArea: React.FC<{
 			const result = await callApi('/api/insert-jsx-element', {
 				compositionFile,
 				compositionId: currentCompositionId,
+				from: null,
 				element: {
 					type: 'solid',
 					width: videoConfig.width,
@@ -169,6 +170,7 @@ const TimelineContextMenuArea: React.FC<{
 				compositionId: currentCompositionId,
 				destinationDimensions: null,
 				dropPosition: null,
+				from: null,
 				svgImportMode: 'image',
 			});
 		} finally {

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -43,6 +43,7 @@ import {
 import {TimelineTracks} from './TimelineTracks';
 import {TimelineWidthProvider} from './TimelineWidthProvider';
 import {useResolvedStack} from './use-resolved-stack';
+import {useTimelineAssetDrop} from './use-timeline-asset-drop';
 
 const container: React.CSSProperties = {
 	minHeight: '100%',
@@ -58,6 +59,7 @@ const noop = () => undefined;
 const TimelineContextMenuArea: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
+	useTimelineAssetDrop();
 	const {compositions, canvasContent} = useContext(
 		Internals.CompositionManager,
 	);

--- a/packages/studio/src/components/Timeline/TimelineAssetDropIndicator.tsx
+++ b/packages/studio/src/components/Timeline/TimelineAssetDropIndicator.tsx
@@ -1,0 +1,44 @@
+import React, {useContext} from 'react';
+import {Internals} from 'remotion';
+import {RULER_COLOR} from '../../helpers/colors';
+import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
+import {TimelineAssetDropFrameContext} from './timeline-asset-drop-context';
+import {sliderAreaRef} from './timeline-refs';
+import {TimelineWidthContext} from './TimelineWidthProvider';
+
+const indicator: React.CSSProperties = {
+	backgroundColor: RULER_COLOR,
+	bottom: 0,
+	pointerEvents: 'none',
+	position: 'absolute',
+	top: 0,
+	width: 1,
+	zIndex: 10,
+};
+
+export const TimelineAssetDropIndicator: React.FC = () => {
+	const frame = useContext(TimelineAssetDropFrameContext);
+	const timelineWidth = useContext(TimelineWidthContext);
+	const videoConfig = Internals.useUnsafeVideoConfig();
+
+	if (frame === null || timelineWidth === null || videoConfig === null) {
+		return null;
+	}
+
+	const width = sliderAreaRef.current?.clientWidth ?? timelineWidth;
+	const left = getXPositionOfItemInTimelineImperatively(
+		frame,
+		videoConfig.durationInFrames,
+		width,
+	);
+
+	return (
+		<div
+			data-timeline-asset-drop-indicator="true"
+			style={{
+				...indicator,
+				transform: `translateX(${left - 0.5}px)`,
+			}}
+		/>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelineScrollable.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScrollable.tsx
@@ -9,7 +9,6 @@ import {
 	TIMELINE_BACKGROUND,
 	useTimelineMarqueeSelection,
 } from './TimelineSelection';
-import {useTimelineAssetDrop} from './use-timeline-asset-drop';
 
 const outer: React.CSSProperties = {
 	width: '100%',
@@ -33,7 +32,6 @@ export const TimelineScrollable: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
 	const {marqueeRect, onPointerDownCapture} = useTimelineMarqueeSelection();
-	const {onAssetDragOver, onAssetDrop} = useTimelineAssetDrop();
 	const containerStyle: React.CSSProperties = useMemo(() => {
 		return {
 			width: '100%',
@@ -47,8 +45,6 @@ export const TimelineScrollable: React.FC<{
 			style={outer}
 			className={HORIZONTAL_SCROLLBAR_CLASSNAME}
 			onPointerDownCapture={onPointerDownCapture}
-			onDragOver={onAssetDragOver}
-			onDrop={onAssetDrop}
 		>
 			<div style={containerStyle}>{children}</div>
 			{marqueeRect === null ? null : (

--- a/packages/studio/src/components/Timeline/TimelineScrollable.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScrollable.tsx
@@ -9,6 +9,7 @@ import {
 	TIMELINE_BACKGROUND,
 	useTimelineMarqueeSelection,
 } from './TimelineSelection';
+import {useTimelineAssetDrop} from './use-timeline-asset-drop';
 
 const outer: React.CSSProperties = {
 	width: '100%',
@@ -32,6 +33,7 @@ export const TimelineScrollable: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
 	const {marqueeRect, onPointerDownCapture} = useTimelineMarqueeSelection();
+	const {onAssetDragOver, onAssetDrop} = useTimelineAssetDrop();
 	const containerStyle: React.CSSProperties = useMemo(() => {
 		return {
 			width: '100%',
@@ -45,6 +47,8 @@ export const TimelineScrollable: React.FC<{
 			style={outer}
 			className={HORIZONTAL_SCROLLBAR_CLASSNAME}
 			onPointerDownCapture={onPointerDownCapture}
+			onDragOver={onAssetDragOver}
+			onDrop={onAssetDrop}
 		>
 			<div style={containerStyle}>{children}</div>
 			{marqueeRect === null ? null : (

--- a/packages/studio/src/components/Timeline/TimelineScrollable.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScrollable.tsx
@@ -5,6 +5,7 @@ import {
 } from '../../helpers/colors';
 import {HORIZONTAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {scrollableRef} from './timeline-refs';
+import {TimelineAssetDropIndicator} from './TimelineAssetDropIndicator';
 import {
 	TIMELINE_BACKGROUND,
 	useTimelineMarqueeSelection,
@@ -42,11 +43,13 @@ export const TimelineScrollable: React.FC<{
 	return (
 		<div
 			ref={scrollableRef}
+			data-timeline-scrollable="true"
 			style={outer}
 			className={HORIZONTAL_SCROLLBAR_CLASSNAME}
 			onPointerDownCapture={onPointerDownCapture}
 		>
 			<div style={containerStyle}>{children}</div>
+			<TimelineAssetDropIndicator />
 			{marqueeRect === null ? null : (
 				<div
 					style={{

--- a/packages/studio/src/components/Timeline/timeline-asset-drop-context.ts
+++ b/packages/studio/src/components/Timeline/timeline-asset-drop-context.ts
@@ -1,0 +1,3 @@
+import {createContext} from 'react';
+
+export const TimelineAssetDropFrameContext = createContext<number | null>(null);

--- a/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
+++ b/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
@@ -288,6 +288,27 @@ export const getFrameFromX = ({
 	return frame;
 };
 
+export const getFrameFromTimelineDrop = ({
+	clientX,
+	durationInFrames,
+	scrollLeft,
+	timelineLeft,
+	timelineWidth,
+}: {
+	clientX: number;
+	durationInFrames: number;
+	scrollLeft: number;
+	timelineLeft: number;
+	timelineWidth: number;
+}) => {
+	return getFrameFromX({
+		clientX: clientX - timelineLeft + scrollLeft,
+		durationInFrames,
+		width: timelineWidth,
+		extrapolate: 'clamp',
+	});
+};
+
 /**
  * Horizontal position inside the scrollable timeline content (0 … scrollWidth)
  * for a viewport `clientX`, so pinch-anchoring matches the pointer (not a

--- a/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
@@ -2,13 +2,14 @@ import {
 	ASSET_DRAG_MIME_TYPE,
 	parseAssetDragData,
 } from '@remotion/studio-shared';
-import {useCallback, useContext, useMemo, useState} from 'react';
+import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {useCachedCompositionComponentInfo} from '../../helpers/open-in-editor';
 import {insertExistingAssets} from '../import-assets';
 import {showNotification} from '../Notifications/NotificationCenter';
+import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
 import {getFrameFromTimelineDrop} from './timeline-scroll-logic';
 import {useResolvedStack} from './use-resolved-stack';
 
@@ -16,11 +17,26 @@ const isAssetDrag = (dataTransfer: DataTransfer) => {
 	return Array.from(dataTransfer.types).includes(ASSET_DRAG_MIME_TYPE);
 };
 
+const isEventInsideElement = (event: DragEvent, element: HTMLElement) => {
+	if (event.target instanceof Node && element.contains(event.target)) {
+		return true;
+	}
+
+	const rect = element.getBoundingClientRect();
+	return (
+		event.clientX >= rect.left &&
+		event.clientX <= rect.right &&
+		event.clientY >= rect.top &&
+		event.clientY <= rect.bottom
+	);
+};
+
 export const useTimelineAssetDrop = () => {
 	const {canvasContent, compositions} = useContext(
 		Internals.CompositionManager,
 	);
 	const videoConfig = Internals.useUnsafeVideoConfig();
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
 
@@ -53,22 +69,36 @@ export const useTimelineAssetDrop = () => {
 		videoConfig !== null &&
 		!isAddingAsset;
 
-	const onAssetDragOver: React.DragEventHandler<HTMLDivElement> = useCallback(
-		(event) => {
-			if (!isAssetDrag(event.dataTransfer)) {
+	const onAssetDragOver = useCallback(
+		(event: DragEvent) => {
+			const timeline = timelineVerticalScroll.current;
+			const {dataTransfer} = event;
+			if (
+				timeline === null ||
+				dataTransfer === null ||
+				!isAssetDrag(dataTransfer) ||
+				!isEventInsideElement(event, timeline)
+			) {
 				return;
 			}
 
 			event.preventDefault();
 			event.stopPropagation();
-			event.dataTransfer.dropEffect = canInsertAsset ? 'copy' : 'none';
+			dataTransfer.dropEffect = canInsertAsset ? 'copy' : 'none';
 		},
 		[canInsertAsset],
 	);
 
-	const onAssetDrop: React.DragEventHandler<HTMLDivElement> = useCallback(
-		async (event) => {
-			if (!isAssetDrag(event.dataTransfer)) {
+	const onAssetDrop = useCallback(
+		async (event: DragEvent) => {
+			const timeline = timelineVerticalScroll.current;
+			const {dataTransfer} = event;
+			if (
+				timeline === null ||
+				dataTransfer === null ||
+				!isAssetDrag(dataTransfer) ||
+				!isEventInsideElement(event, timeline)
+			) {
 				return;
 			}
 
@@ -91,20 +121,23 @@ export const useTimelineAssetDrop = () => {
 			}
 
 			const dragData = parseAssetDragData(
-				event.dataTransfer.getData(ASSET_DRAG_MIME_TYPE),
+				dataTransfer.getData(ASSET_DRAG_MIME_TYPE),
 			);
 			if (dragData === null) {
 				return;
 			}
 
-			const timeline = event.currentTarget;
-			const frame = getFrameFromTimelineDrop({
-				clientX: event.clientX,
-				durationInFrames: videoConfig.durationInFrames,
-				scrollLeft: timeline.scrollLeft,
-				timelineLeft: timeline.getBoundingClientRect().left,
-				timelineWidth: timeline.scrollWidth,
-			});
+			const scrollable = scrollableRef.current;
+			const frame =
+				scrollable !== null && isEventInsideElement(event, scrollable)
+					? getFrameFromTimelineDrop({
+							clientX: event.clientX,
+							durationInFrames: videoConfig.durationInFrames,
+							scrollLeft: scrollable.scrollLeft,
+							timelineLeft: scrollable.getBoundingClientRect().left,
+							timelineWidth: scrollable.scrollWidth,
+						})
+					: timelinePosition;
 
 			setIsAddingAsset(true);
 			try {
@@ -126,9 +159,20 @@ export const useTimelineAssetDrop = () => {
 			compositionComponentInfo?.canAddSequence,
 			compositionFile,
 			currentCompositionId,
+			timelinePosition,
 			videoConfig,
 		],
 	);
 
-	return {onAssetDragOver, onAssetDrop};
+	useEffect(() => {
+		document.addEventListener('dragover', onAssetDragOver, {capture: true});
+		document.addEventListener('drop', onAssetDrop, {capture: true});
+
+		return () => {
+			document.removeEventListener('dragover', onAssetDragOver, {
+				capture: true,
+			});
+			document.removeEventListener('drop', onAssetDrop, {capture: true});
+		};
+	}, [onAssetDragOver, onAssetDrop]);
 };

--- a/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
@@ -1,21 +1,16 @@
-import {
-	ASSET_DRAG_MIME_TYPE,
-	parseAssetDragData,
-} from '@remotion/studio-shared';
 import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {useCachedCompositionComponentInfo} from '../../helpers/open-in-editor';
-import {insertExistingAssets} from '../import-assets';
+import {isSupportedDropEvent} from '../drop-handler-data';
+import {getEffectDragData} from '../effect-drag-and-drop';
+import {handleDrop} from '../handle-drop';
 import {showNotification} from '../Notifications/NotificationCenter';
+import {useSvgImportDialog} from '../SvgImportDialog';
 import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
 import {getFrameFromTimelineDrop} from './timeline-scroll-logic';
 import {useResolvedStack} from './use-resolved-stack';
-
-const isAssetDrag = (dataTransfer: DataTransfer) => {
-	return Array.from(dataTransfer.types).includes(ASSET_DRAG_MIME_TYPE);
-};
 
 const isEventInsideElement = (event: DragEvent, element: HTMLElement) => {
 	if (event.target instanceof Node && element.contains(event.target)) {
@@ -37,8 +32,10 @@ export const useTimelineAssetDrop = () => {
 	);
 	const videoConfig = Internals.useUnsafeVideoConfig();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const chooseSvgImportMode = useSvgImportDialog();
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
+	const [assetDropFrame, setAssetDropFrame] = useState<number | null>(null);
 
 	const currentCompositionId =
 		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
@@ -69,6 +66,26 @@ export const useTimelineAssetDrop = () => {
 		videoConfig !== null &&
 		!isAddingAsset;
 
+	const getDropFrame = useCallback(
+		(event: DragEvent) => {
+			if (videoConfig === null) {
+				return null;
+			}
+
+			const scrollable = scrollableRef.current;
+			return scrollable !== null && isEventInsideElement(event, scrollable)
+				? getFrameFromTimelineDrop({
+						clientX: event.clientX,
+						durationInFrames: videoConfig.durationInFrames,
+						scrollLeft: scrollable.scrollLeft,
+						timelineLeft: scrollable.getBoundingClientRect().left,
+						timelineWidth: scrollable.scrollWidth,
+					})
+				: timelinePosition;
+		},
+		[timelinePosition, videoConfig],
+	);
+
 	const onAssetDragOver = useCallback(
 		(event: DragEvent) => {
 			const timeline = timelineVerticalScroll.current;
@@ -76,29 +93,42 @@ export const useTimelineAssetDrop = () => {
 			if (
 				timeline === null ||
 				dataTransfer === null ||
-				!isAssetDrag(dataTransfer) ||
+				!isSupportedDropEvent(event) ||
 				!isEventInsideElement(event, timeline)
 			) {
+				setAssetDropFrame(null);
 				return;
 			}
 
 			event.preventDefault();
 			event.stopPropagation();
 			dataTransfer.dropEffect = canInsertAsset ? 'copy' : 'none';
+			const scrollable = scrollableRef.current;
+			const shouldShowDropFrame =
+				canInsertAsset &&
+				scrollable !== null &&
+				isEventInsideElement(event, scrollable);
+			setAssetDropFrame(shouldShowDropFrame ? getDropFrame(event) : null);
 		},
-		[canInsertAsset],
+		[canInsertAsset, getDropFrame],
 	);
 
 	const onAssetDrop = useCallback(
 		async (event: DragEvent) => {
+			setAssetDropFrame(null);
 			const timeline = timelineVerticalScroll.current;
 			const {dataTransfer} = event;
 			if (
 				timeline === null ||
 				dataTransfer === null ||
-				!isAssetDrag(dataTransfer) ||
+				!isSupportedDropEvent(event) ||
 				!isEventInsideElement(event, timeline)
 			) {
+				return;
+			}
+
+			if (getEffectDragData(dataTransfer) !== null) {
+				event.preventDefault();
 				return;
 			}
 
@@ -120,33 +150,26 @@ export const useTimelineAssetDrop = () => {
 				return;
 			}
 
-			const dragData = parseAssetDragData(
-				dataTransfer.getData(ASSET_DRAG_MIME_TYPE),
-			);
-			if (dragData === null) {
+			const frame = getDropFrame(event);
+			if (frame === null) {
 				return;
 			}
 
-			const scrollable = scrollableRef.current;
-			const frame =
-				scrollable !== null && isEventInsideElement(event, scrollable)
-					? getFrameFromTimelineDrop({
-							clientX: event.clientX,
-							durationInFrames: videoConfig.durationInFrames,
-							scrollLeft: scrollable.scrollLeft,
-							timelineLeft: scrollable.getBoundingClientRect().left,
-							timelineWidth: scrollable.scrollWidth,
-						})
-					: timelinePosition;
-
 			setIsAddingAsset(true);
 			try {
-				await insertExistingAssets({
-					assetPaths: [dragData.assetPath],
+				await handleDrop({
+					chooseSvgImportMode,
 					compositionFile,
 					compositionId: currentCompositionId,
-					destinationDimensions: null,
-					dropPosition: null,
+					destinationDimensions: {
+						height: videoConfig.height,
+						width: videoConfig.width,
+					},
+					dropPosition: {
+						centerX: videoConfig.width / 2,
+						centerY: videoConfig.height / 2,
+					},
+					event,
 					fps: videoConfig.fps,
 					from: frame,
 				});
@@ -156,23 +179,34 @@ export const useTimelineAssetDrop = () => {
 		},
 		[
 			canInsertAsset,
+			chooseSvgImportMode,
 			compositionComponentInfo?.canAddSequence,
 			compositionFile,
 			currentCompositionId,
-			timelinePosition,
+			getDropFrame,
 			videoConfig,
 		],
 	);
 
+	const clearAssetDropFrame = useCallback(() => {
+		setAssetDropFrame(null);
+	}, []);
+
 	useEffect(() => {
 		document.addEventListener('dragover', onAssetDragOver, {capture: true});
 		document.addEventListener('drop', onAssetDrop, {capture: true});
+		document.addEventListener('dragend', clearAssetDropFrame, {capture: true});
 
 		return () => {
 			document.removeEventListener('dragover', onAssetDragOver, {
 				capture: true,
 			});
 			document.removeEventListener('drop', onAssetDrop, {capture: true});
+			document.removeEventListener('dragend', clearAssetDropFrame, {
+				capture: true,
+			});
 		};
-	}, [onAssetDragOver, onAssetDrop]);
+	}, [clearAssetDropFrame, onAssetDragOver, onAssetDrop]);
+
+	return assetDropFrame;
 };

--- a/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
@@ -1,0 +1,134 @@
+import {
+	ASSET_DRAG_MIME_TYPE,
+	parseAssetDragData,
+} from '@remotion/studio-shared';
+import {useCallback, useContext, useMemo, useState} from 'react';
+import {Internals} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {studioInteractivityEnabled} from '../../helpers/interactivity-enabled';
+import {useCachedCompositionComponentInfo} from '../../helpers/open-in-editor';
+import {insertExistingAssets} from '../import-assets';
+import {showNotification} from '../Notifications/NotificationCenter';
+import {getFrameFromTimelineDrop} from './timeline-scroll-logic';
+import {useResolvedStack} from './use-resolved-stack';
+
+const isAssetDrag = (dataTransfer: DataTransfer) => {
+	return Array.from(dataTransfer.types).includes(ASSET_DRAG_MIME_TYPE);
+};
+
+export const useTimelineAssetDrop = () => {
+	const {canvasContent, compositions} = useContext(
+		Internals.CompositionManager,
+	);
+	const videoConfig = Internals.useUnsafeVideoConfig();
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const [isAddingAsset, setIsAddingAsset] = useState(false);
+
+	const currentCompositionId =
+		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
+	const currentComposition = useMemo(() => {
+		return (
+			compositions.find(
+				(composition) => composition.id === currentCompositionId,
+			) ?? null
+		);
+	}, [compositions, currentCompositionId]);
+	const resolvedCompositionLocation = useResolvedStack(
+		currentComposition?.stack ?? null,
+	);
+	const compositionFile = resolvedCompositionLocation?.source ?? null;
+	const compositionComponentInfo = useCachedCompositionComponentInfo({
+		compositionFile,
+		compositionId: currentCompositionId,
+	});
+
+	const previewInteractive =
+		previewServerState.type === 'connected' && studioInteractivityEnabled;
+	const canInsertAsset =
+		previewInteractive &&
+		!window.remotion_isReadOnlyStudio &&
+		compositionComponentInfo?.canAddSequence === true &&
+		currentCompositionId !== null &&
+		compositionFile !== null &&
+		videoConfig !== null &&
+		!isAddingAsset;
+
+	const onAssetDragOver: React.DragEventHandler<HTMLDivElement> = useCallback(
+		(event) => {
+			if (!isAssetDrag(event.dataTransfer)) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			event.dataTransfer.dropEffect = canInsertAsset ? 'copy' : 'none';
+		},
+		[canInsertAsset],
+	);
+
+	const onAssetDrop: React.DragEventHandler<HTMLDivElement> = useCallback(
+		async (event) => {
+			if (!isAssetDrag(event.dataTransfer)) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			if (
+				!canInsertAsset ||
+				currentCompositionId === null ||
+				compositionFile === null ||
+				videoConfig === null
+			) {
+				if (compositionComponentInfo?.canAddSequence === false) {
+					showNotification(
+						'Cannot insert items into this composition component',
+						3000,
+					);
+				}
+
+				return;
+			}
+
+			const dragData = parseAssetDragData(
+				event.dataTransfer.getData(ASSET_DRAG_MIME_TYPE),
+			);
+			if (dragData === null) {
+				return;
+			}
+
+			const timeline = event.currentTarget;
+			const frame = getFrameFromTimelineDrop({
+				clientX: event.clientX,
+				durationInFrames: videoConfig.durationInFrames,
+				scrollLeft: timeline.scrollLeft,
+				timelineLeft: timeline.getBoundingClientRect().left,
+				timelineWidth: timeline.scrollWidth,
+			});
+
+			setIsAddingAsset(true);
+			try {
+				await insertExistingAssets({
+					assetPaths: [dragData.assetPath],
+					compositionFile,
+					compositionId: currentCompositionId,
+					destinationDimensions: null,
+					dropPosition: null,
+					fps: videoConfig.fps,
+					from: frame,
+				});
+			} finally {
+				setIsAddingAsset(false);
+			}
+		},
+		[
+			canInsertAsset,
+			compositionComponentInfo?.canAddSequence,
+			compositionFile,
+			currentCompositionId,
+			videoConfig,
+		],
+	);
+
+	return {onAssetDragOver, onAssetDrop};
+};

--- a/packages/studio/src/components/drop-handler-data.ts
+++ b/packages/studio/src/components/drop-handler-data.ts
@@ -1,0 +1,135 @@
+import {
+	ASSET_DRAG_MIME_TYPE,
+	COMPONENT_DRAG_MIME_TYPE,
+	COMPOSITION_DRAG_MIME_TYPE,
+	ELEMENT_DRAG_MIME_TYPE,
+	parseAssetDragData,
+	parseComponentDragData,
+	parseCompositionDragData,
+	parseSfxDragData,
+	SFX_DRAG_MIME_TYPE,
+	type ComponentDragData,
+	type CompositionDragData,
+} from '@remotion/studio-shared';
+import {hasRemoteAssetDragData} from '../helpers/remote-asset-drag';
+
+export const isFileDragEvent = (event: DragEvent): boolean => {
+	return Array.from(event.dataTransfer?.types ?? []).includes('Files');
+};
+
+export const isAssetDragEvent = (event: DragEvent): boolean => {
+	return Array.from(event.dataTransfer?.types ?? []).includes(
+		ASSET_DRAG_MIME_TYPE,
+	);
+};
+
+export const isComponentDragEvent = (event: DragEvent): boolean => {
+	return Array.from(event.dataTransfer?.types ?? []).includes(
+		COMPONENT_DRAG_MIME_TYPE,
+	);
+};
+
+export const isCompositionDragEvent = (event: DragEvent): boolean => {
+	return Array.from(event.dataTransfer?.types ?? []).includes(
+		COMPOSITION_DRAG_MIME_TYPE,
+	);
+};
+
+export const isElementDragEvent = (event: DragEvent): boolean => {
+	return Array.from(event.dataTransfer?.types ?? []).includes(
+		ELEMENT_DRAG_MIME_TYPE,
+	);
+};
+
+export const isSfxDragEvent = (event: DragEvent): boolean => {
+	return Array.from(event.dataTransfer?.types ?? []).includes(
+		SFX_DRAG_MIME_TYPE,
+	);
+};
+
+export const isRemoteAssetDragEvent = (event: DragEvent): boolean => {
+	return (
+		!isFileDragEvent(event) &&
+		!isAssetDragEvent(event) &&
+		!isCompositionDragEvent(event) &&
+		!isComponentDragEvent(event) &&
+		!isElementDragEvent(event) &&
+		!isSfxDragEvent(event) &&
+		hasRemoteAssetDragData(event.dataTransfer)
+	);
+};
+
+export const isSupportedDropEvent = (event: DragEvent): boolean => {
+	return (
+		isFileDragEvent(event) ||
+		isAssetDragEvent(event) ||
+		isCompositionDragEvent(event) ||
+		isComponentDragEvent(event) ||
+		isElementDragEvent(event) ||
+		isSfxDragEvent(event) ||
+		isRemoteAssetDragEvent(event)
+	);
+};
+
+export const getAssetDragPath = (event: DragEvent): string | null => {
+	const value = event.dataTransfer?.getData(ASSET_DRAG_MIME_TYPE);
+	if (!value) {
+		return null;
+	}
+
+	return parseAssetDragData(value)?.assetPath ?? null;
+};
+
+export const getCompositionDragData = (
+	event: DragEvent,
+): CompositionDragData | null => {
+	const value = event.dataTransfer?.getData(COMPOSITION_DRAG_MIME_TYPE);
+	if (!value) {
+		return null;
+	}
+
+	return parseCompositionDragData(value);
+};
+
+export const getComponentDragData = (
+	event: DragEvent,
+): ComponentDragData | null => {
+	for (const type of [
+		COMPONENT_DRAG_MIME_TYPE,
+		'application/json',
+		'text/plain',
+	]) {
+		const value = event.dataTransfer?.getData(type);
+		if (!value) {
+			continue;
+		}
+
+		const parsed = parseComponentDragData(value);
+		if (parsed) {
+			return parsed;
+		}
+	}
+
+	return null;
+};
+
+export const getSfxDragUrl = (event: DragEvent): string | null => {
+	const {dataTransfer} = event;
+	if (!dataTransfer) {
+		return null;
+	}
+
+	for (const type of [SFX_DRAG_MIME_TYPE, 'application/json', 'text/plain']) {
+		const value = dataTransfer.getData(type);
+		if (!value) {
+			continue;
+		}
+
+		const parsed = parseSfxDragData(value);
+		if (parsed) {
+			return parsed.sfx.url;
+		}
+	}
+
+	return null;
+};

--- a/packages/studio/src/components/handle-drop.ts
+++ b/packages/studio/src/components/handle-drop.ts
@@ -1,0 +1,161 @@
+import type {Dimensions} from '../helpers/is-current-selected-still';
+import {getRemoteAssetUrlFromDataTransfer} from '../helpers/remote-asset-drag';
+import {
+	getAssetDragPath,
+	getComponentDragData,
+	getCompositionDragData,
+	getSfxDragUrl,
+	isAssetDragEvent,
+	isCompositionDragEvent,
+	isFileDragEvent,
+	isSfxDragEvent,
+} from './drop-handler-data';
+import {getElementDragData} from './element-drag-and-drop';
+import {
+	hasSvgFile,
+	importAssets,
+	importRemoteAsset,
+	insertComponent,
+	insertComposition,
+	insertElement,
+	insertExistingAssets,
+	insertRemoteAudio,
+	type InsertElementDropPosition,
+} from './import-assets';
+import type {SvgImportMode} from './SvgImportDialog';
+
+export const handleDrop = async ({
+	chooseSvgImportMode,
+	compositionFile,
+	compositionId,
+	destinationDimensions,
+	dropPosition,
+	event,
+	fps,
+	from = null,
+}: {
+	chooseSvgImportMode: () => Promise<SvgImportMode | null>;
+	compositionFile: string;
+	compositionId: string;
+	destinationDimensions: Dimensions | null;
+	dropPosition: InsertElementDropPosition | null;
+	event: DragEvent;
+	fps: number;
+	from?: number | null;
+}) => {
+	if (isFileDragEvent(event)) {
+		const files = Array.from(event.dataTransfer?.files ?? []);
+		if (files.length === 0) {
+			return;
+		}
+
+		const svgImportMode = hasSvgFile(files)
+			? await chooseSvgImportMode()
+			: 'image';
+		if (svgImportMode === null) {
+			return;
+		}
+
+		await importAssets({
+			compositionFile,
+			compositionId,
+			destinationDimensions,
+			dropPosition,
+			files,
+			fps,
+			from,
+			svgImportMode,
+		});
+		return;
+	}
+
+	if (isAssetDragEvent(event)) {
+		const assetPath = getAssetDragPath(event);
+		if (assetPath === null) {
+			return;
+		}
+
+		await insertExistingAssets({
+			assetPaths: [assetPath],
+			compositionFile,
+			compositionId,
+			destinationDimensions,
+			dropPosition,
+			fps,
+			from,
+		});
+		return;
+	}
+
+	if (isSfxDragEvent(event)) {
+		const sfxUrl = getSfxDragUrl(event);
+		if (sfxUrl === null) {
+			return;
+		}
+
+		await insertRemoteAudio({
+			compositionFile,
+			compositionId,
+			fps,
+			from,
+			url: sfxUrl,
+		});
+		return;
+	}
+
+	if (isCompositionDragEvent(event)) {
+		const composition = getCompositionDragData(event);
+		if (composition === null) {
+			return;
+		}
+
+		await insertComposition({
+			composition,
+			compositionFile,
+			compositionId,
+			destinationDimensions,
+			dropPosition,
+			from,
+		});
+		return;
+	}
+
+	const element = getElementDragData(event.dataTransfer);
+	if (element !== null) {
+		await insertElement({
+			compositionFile,
+			compositionId,
+			dropPosition,
+			element: element.element,
+			from,
+		});
+		return;
+	}
+
+	const component = getComponentDragData(event);
+	if (component !== null) {
+		await insertComponent({
+			component: component.component,
+			compositionFile,
+			compositionId,
+			dropPosition,
+			from,
+		});
+		return;
+	}
+
+	const remoteAssetUrl = getRemoteAssetUrlFromDataTransfer(event.dataTransfer);
+	if (remoteAssetUrl === null) {
+		return;
+	}
+
+	await importRemoteAsset({
+		compositionFile,
+		compositionId,
+		destinationDimensions,
+		dropPosition,
+		fps,
+		from,
+		url: remoteAssetUrl,
+	});
+};

--- a/packages/studio/src/components/handle-drop.ts
+++ b/packages/studio/src/components/handle-drop.ts
@@ -32,7 +32,7 @@ export const handleDrop = async ({
 	dropPosition,
 	event,
 	fps,
-	from = null,
+	from,
 }: {
 	chooseSvgImportMode: () => Promise<SvgImportMode | null>;
 	compositionFile: string;
@@ -41,7 +41,7 @@ export const handleDrop = async ({
 	dropPosition: InsertElementDropPosition | null;
 	event: DragEvent;
 	fps: number;
-	from?: number | null;
+	from: number | null;
 }) => {
 	if (isFileDragEvent(event)) {
 		const files = Array.from(event.dataTransfer?.files ?? []);

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -693,10 +693,12 @@ const insertCompositionElement = async ({
 	compositionFile,
 	compositionId,
 	element,
+	from = null,
 }: {
 	compositionFile: string;
 	compositionId: string;
 	element: InsertableCompositionElement;
+	from?: number | null;
 }) => {
 	const requiredPackage = getRequiredPackageForInsertableElement(element);
 	await installRequiredPackages(requiredPackage ? [requiredPackage] : []);
@@ -705,6 +707,7 @@ const insertCompositionElement = async ({
 		compositionFile,
 		compositionId,
 		element,
+		from,
 	});
 
 	if (!result.success) {
@@ -1098,6 +1101,7 @@ export const insertExistingAssets = async ({
 	destinationDimensions,
 	dropPosition,
 	fps,
+	from = null,
 }: {
 	assetPaths: string[];
 	compositionFile: string;
@@ -1105,6 +1109,7 @@ export const insertExistingAssets = async ({
 	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
 	fps: number;
+	from?: number | null;
 }) => {
 	if (assetPaths.length === 0) {
 		return;
@@ -1130,6 +1135,7 @@ export const insertExistingAssets = async ({
 			const inserted = await insertCompositionElement({
 				compositionFile,
 				compositionId,
+				from,
 				element: {
 					...element,
 					dimensions,

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -2,9 +2,9 @@ import {
 	detectFileType,
 	getRequiredPackageForInsertableElement,
 	isUrl,
-	type CompositionDragData,
 	type ComponentDragData,
 	type ComponentProp,
+	type CompositionDragData,
 	type DownloadRemoteAssetResponse,
 	type ElementDragData,
 	type FileType,
@@ -731,6 +731,7 @@ export const importAssets = async ({
 	dropPosition,
 	files,
 	fps,
+	from = null,
 	svgImportMode,
 }: {
 	compositionFile: string;
@@ -739,6 +740,7 @@ export const importAssets = async ({
 	dropPosition: InsertElementDropPosition | null;
 	files: File[];
 	fps: number;
+	from?: number | null;
 	svgImportMode: 'image' | 'inline';
 }) => {
 	if (files.length === 0) {
@@ -791,6 +793,7 @@ export const importAssets = async ({
 				const svgInserted = await insertCompositionElement({
 					compositionFile,
 					compositionId,
+					from,
 					element: {
 						type: 'svg',
 						markup: new TextDecoder().decode(contents),
@@ -840,6 +843,7 @@ export const importAssets = async ({
 			const inserted = await insertCompositionElement({
 				compositionFile,
 				compositionId,
+				from,
 				element: {
 					...element,
 					dimensions: resolvedDimensions,
@@ -980,6 +984,7 @@ export const importRemoteAsset = async ({
 	destinationDimensions,
 	dropPosition,
 	fps,
+	from = null,
 	url,
 }: {
 	compositionFile: string;
@@ -987,6 +992,7 @@ export const importRemoteAsset = async ({
 	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
 	fps: number;
+	from?: number | null;
 	url: string;
 }) => {
 	try {
@@ -1010,6 +1016,7 @@ export const importRemoteAsset = async ({
 		const inserted = await insertCompositionElement({
 			compositionFile,
 			compositionId,
+			from,
 			element: {
 				...element,
 				dimensions,
@@ -1046,11 +1053,13 @@ export const insertRemoteAudio = async ({
 	compositionFile,
 	compositionId,
 	fps,
+	from = null,
 	url,
 }: {
 	compositionFile: string;
 	compositionId: string;
 	fps: number;
+	from?: number | null;
 	url: string;
 }) => {
 	if (!isUrl(url)) {
@@ -1077,6 +1086,7 @@ export const insertRemoteAudio = async ({
 			compositionFile,
 			compositionId,
 			element,
+			from,
 		});
 
 		if (!inserted) {
@@ -1177,16 +1187,19 @@ export const insertComponent = async ({
 	compositionFile,
 	compositionId,
 	dropPosition,
+	from = null,
 }: {
 	component: ComponentDragData['component'];
 	compositionFile: string;
 	compositionId: string;
 	dropPosition: InsertElementDropPosition | null;
+	from?: number | null;
 }) => {
 	try {
 		const inserted = await insertCompositionElement({
 			compositionFile,
 			compositionId,
+			from,
 			element: {
 				type: 'component',
 				componentName: component.componentName,
@@ -1234,12 +1247,14 @@ export const insertComposition = async ({
 	compositionId,
 	destinationDimensions,
 	dropPosition,
+	from = null,
 }: {
 	composition: CompositionDragData;
 	compositionFile: string;
 	compositionId: string;
 	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
+	from?: number | null;
 }) => {
 	if (composition.compositionId === compositionId) {
 		showNotification('Cannot add a composition to itself', 3000);
@@ -1267,6 +1282,7 @@ export const insertComposition = async ({
 		const inserted = await insertCompositionElement({
 			compositionFile,
 			compositionId,
+			from,
 			element: {
 				type: 'composition',
 				compositionId: composition.compositionId,
@@ -1307,11 +1323,13 @@ export const insertElement = async ({
 	compositionId,
 	dropPosition,
 	element,
+	from = null,
 }: {
 	compositionFile: string;
 	compositionId: string;
 	dropPosition: InsertElementDropPosition | null;
 	element: ElementDragData['element'];
+	from?: number | null;
 }) => {
 	try {
 		await installRequiredPackages(element.dependencies);
@@ -1320,6 +1338,7 @@ export const insertElement = async ({
 			compositionFile,
 			compositionId,
 			element,
+			from,
 			position: getElementPositionForDrop({
 				dimensions: element.dimensions,
 				dropPosition,

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -693,12 +693,12 @@ const insertCompositionElement = async ({
 	compositionFile,
 	compositionId,
 	element,
-	from = null,
+	from,
 }: {
 	compositionFile: string;
 	compositionId: string;
 	element: InsertableCompositionElement;
-	from?: number | null;
+	from: number | null;
 }) => {
 	const requiredPackage = getRequiredPackageForInsertableElement(element);
 	await installRequiredPackages(requiredPackage ? [requiredPackage] : []);
@@ -731,7 +731,7 @@ export const importAssets = async ({
 	dropPosition,
 	files,
 	fps,
-	from = null,
+	from,
 	svgImportMode,
 }: {
 	compositionFile: string;
@@ -740,7 +740,7 @@ export const importAssets = async ({
 	dropPosition: InsertElementDropPosition | null;
 	files: File[];
 	fps: number;
-	from?: number | null;
+	from: number | null;
 	svgImportMode: 'image' | 'inline';
 }) => {
 	if (files.length === 0) {
@@ -954,6 +954,7 @@ export const insertSvgMarkup = async ({
 		const inserted = await insertCompositionElement({
 			compositionFile,
 			compositionId,
+			from: null,
 			element: {
 				type: 'svg',
 				markup,
@@ -984,7 +985,7 @@ export const importRemoteAsset = async ({
 	destinationDimensions,
 	dropPosition,
 	fps,
-	from = null,
+	from,
 	url,
 }: {
 	compositionFile: string;
@@ -992,7 +993,7 @@ export const importRemoteAsset = async ({
 	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
 	fps: number;
-	from?: number | null;
+	from: number | null;
 	url: string;
 }) => {
 	try {
@@ -1053,13 +1054,13 @@ export const insertRemoteAudio = async ({
 	compositionFile,
 	compositionId,
 	fps,
-	from = null,
+	from,
 	url,
 }: {
 	compositionFile: string;
 	compositionId: string;
 	fps: number;
-	from?: number | null;
+	from: number | null;
 	url: string;
 }) => {
 	if (!isUrl(url)) {
@@ -1111,7 +1112,7 @@ export const insertExistingAssets = async ({
 	destinationDimensions,
 	dropPosition,
 	fps,
-	from = null,
+	from,
 }: {
 	assetPaths: string[];
 	compositionFile: string;
@@ -1119,7 +1120,7 @@ export const insertExistingAssets = async ({
 	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
 	fps: number;
-	from?: number | null;
+	from: number | null;
 }) => {
 	if (assetPaths.length === 0) {
 		return;
@@ -1187,13 +1188,13 @@ export const insertComponent = async ({
 	compositionFile,
 	compositionId,
 	dropPosition,
-	from = null,
+	from,
 }: {
 	component: ComponentDragData['component'];
 	compositionFile: string;
 	compositionId: string;
 	dropPosition: InsertElementDropPosition | null;
-	from?: number | null;
+	from: number | null;
 }) => {
 	try {
 		const inserted = await insertCompositionElement({
@@ -1247,14 +1248,14 @@ export const insertComposition = async ({
 	compositionId,
 	destinationDimensions,
 	dropPosition,
-	from = null,
+	from,
 }: {
 	composition: CompositionDragData;
 	compositionFile: string;
 	compositionId: string;
 	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
-	from?: number | null;
+	from: number | null;
 }) => {
 	if (composition.compositionId === compositionId) {
 		showNotification('Cannot add a composition to itself', 3000);
@@ -1323,13 +1324,13 @@ export const insertElement = async ({
 	compositionId,
 	dropPosition,
 	element,
-	from = null,
+	from,
 }: {
 	compositionFile: string;
 	compositionId: string;
 	dropPosition: InsertElementDropPosition | null;
 	element: ElementDragData['element'];
-	from?: number | null;
+	from: number | null;
 }) => {
 	try {
 		await installRequiredPackages(element.dependencies);

--- a/packages/studio/src/test/timeline-scroll-logic.test.ts
+++ b/packages/studio/src/test/timeline-scroll-logic.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
 import {
 	getFrameFromX,
+	getFrameFromTimelineDrop,
 	getFrameIncrementFromWidth,
 	getScrollLeftToKeepCursorInPlace,
 } from '../components/Timeline/timeline-scroll-logic';
@@ -15,6 +16,18 @@ test('getFrameFromX handles collapsed timeline widths', () => {
 			width: 0,
 		}),
 	).toBe(0);
+});
+
+test('gets a timeline drop frame from viewport coordinates and scroll position', () => {
+	expect(
+		getFrameFromTimelineDrop({
+			clientX: 300,
+			durationInFrames: 100,
+			scrollLeft: 200,
+			timelineLeft: 100,
+			timelineWidth: 1000,
+		}),
+	).toBe(40);
 });
 
 test('getFrameIncrementFromWidth never returns a negative increment', () => {


### PR DESCRIPTION
## Summary

- allow dropping files, Studio assets, remote images, compositions, Elements, Shapes, and SFX onto the timeline
- share the Canvas drop dispatcher so Canvas and Timeline accept the same drag types
- insert at the hovered timeline frame and center visual items in the composition
- show a subtle ruler-colored placement indicator while hovering the timeline frame area
- pass timing directly to built-in interactive assets and Shapes, retaining `Sequence` wrappers only for compositions and Elements

## Test plan

- `bun test packages/studio/src/test/timeline-scroll-logic.test.ts packages/studio-server/src/test/resolve-composition-component.test.ts`
- local Studio drag-and-drop verification on the Canvas and both sides of the Timeline
- `bun run build`
- `bun run stylecheck`

Closes #9377
