### PR TITLE
`@remotion/lambda`: Validate full site names

### DIFF
--- a/packages/lambda/src/shared/validate-site-name.ts
+++ b/packages/lambda/src/shared/validate-site-name.ts
@@ -1,3 +1,5 @@
+const VALID_SITE_NAME_RE = /^[-0-9a-zA-Z!_.*'()]+$/;
+
 export const validateSiteName = (siteName: unknown) => {
 	if (typeof siteName === 'undefined') {
 		return;
@@ -5,15 +7,23 @@ export const validateSiteName = (siteName: unknown) => {
 
 	if (typeof siteName !== 'string') {
 		throw new TypeError(
-			`The 'projectName' argument must be a string if provided, but is ${JSON.stringify(
+			`The 'siteName' argument must be a string if provided, but is ${JSON.stringify(
 				siteName,
 			)}`,
 		);
 	}
 
-	if (!siteName.match(/([0-9a-zA-Z-!_.*'()]+)/g)) {
+	if (siteName === '.' || siteName === '..') {
 		throw new Error(
-			"The `siteName` must match the RegExp `/([0-9a-zA-Z-!_.*'()]+)/g`. You passed: " +
+			'The `siteName` must not be `.` or `..`. You passed: ' + siteName + '.',
+		);
+	}
+
+	if (!VALID_SITE_NAME_RE.test(siteName)) {
+		throw new Error(
+			'The `siteName` must match the RegExp `/' +
+				VALID_SITE_NAME_RE.source +
+				'/`. You passed: ' +
 				siteName +
 				'. Check for invalid characters.',
 		);

--- a/packages/lambda/src/test/unit/validate-site-name.test.ts
+++ b/packages/lambda/src/test/unit/validate-site-name.test.ts
@@ -1,0 +1,46 @@
+import {expect, test} from 'bun:test';
+import {validateSiteName} from '../../shared/validate-site-name';
+
+test('allows valid site names', () => {
+	expect(() => validateSiteName('mysite')).not.toThrow();
+	expect(() => validateSiteName('my-site_1.0')).not.toThrow();
+	expect(() => validateSiteName("it's-fine!")).not.toThrow();
+	expect(() => validateSiteName('a(b)c')).not.toThrow();
+	expect(() => validateSiteName('0.1.2')).not.toThrow();
+});
+
+test('rejects invalid characters', () => {
+	expect(() => validateSiteName('my@site')).toThrow();
+	expect(() => validateSiteName('a#b')).toThrow();
+	expect(() => validateSiteName('site name')).toThrow();
+	expect(() => validateSiteName('site/name')).toThrow();
+	expect(() => validateSiteName('site\\name')).toThrow();
+	expect(() => validateSiteName('site:name')).toThrow();
+});
+
+test('rejects dot segments and empty strings', () => {
+	expect(() => validateSiteName('.')).toThrow();
+	expect(() => validateSiteName('..')).toThrow();
+	expect(() => validateSiteName('')).toThrow();
+});
+
+test('rejects Unicode characters outside the allowlist', () => {
+	expect(() => validateSiteName('süte')).toThrow();
+	expect(() => validateSiteName('site\u00e9')).toThrow();
+});
+
+test('rejects substrings and suffixes that contain invalid characters', () => {
+	expect(() => validateSiteName('good/bad')).toThrow();
+	expect(() => validateSiteName('bad good')).toThrow();
+	expect(() => validateSiteName('prefix@suffix')).toThrow();
+});
+
+test('allows undefined', () => {
+	expect(() => validateSiteName(undefined)).not.toThrow();
+});
+
+test('throws a TypeError for non-string types', () => {
+	expect(() => validateSiteName(123)).toThrow(TypeError);
+	expect(() => validateSiteName(null)).toThrow(TypeError);
+	expect(() => validateSiteName({})).toThrow(TypeError);
+});


### PR DESCRIPTION
## Problem

`validateSiteName` in `@remotion/lambda` used `.match(/([0-9a-zA-Z-!_.*'()]+)/g)`, which only checks that the name contains at least one allowed character. Path separators (`/`), spaces, `@`, `#`, Unicode, and other characters could therefore reach deploy-time.

## Triage / Root cause

The regex is unanchored and has no start/end markers, and `.` / `..` dot segments were not explicitly rejected. The `TypeError` for non-string inputs also incorrectly referenced `projectName` instead of `siteName`.

## Fix

- Replace the unanchored match with `/^[0-9a-zA-Z-!_.*'()]+$/` and `.test()`.
- Explicitly reject `.` and `..` dot segments before the regex check.
- Correct the `TypeError` message to reference `siteName`.
- Add unit tests in `packages/lambda/src/test/unit/validate-site-name.test.ts` covering valid names, invalid characters, dot segments, substrings, and non-string inputs.

## Verification

- `bun run build` from root passed.
- `bun test packages/lambda/src/test/unit/validate-site-name.test.ts` passed.
- `bun run stylecheck` passed (only pre-existing warnings outside `lambda`).

## Notes / Risks

Closes #9424. This is a stricter validation, but the previous behavior was unintentionally permissive; all previously valid site names still pass.
