### PR TITLE
@remotion/renderer: Normalize paths before isPathInside check

### DIFF
--- a/packages/renderer/src/serve-handler/is-path-inside.ts
+++ b/packages/renderer/src/serve-handler/is-path-inside.ts
@@ -4,6 +4,11 @@ export const isPathInside = function (
 	thePath: string,
 	potentialParent: string,
 ) {
+	// Resolve . and .. segments before checking containment so that a path
+	// containing traversal components cannot be mistaken for a child path.
+	thePath = path.normalize(thePath);
+	potentialParent = path.normalize(potentialParent);
+
 	// For inside-directory checking, we want to allow trailing slashes, so normalize.
 	thePath = stripTrailingSep(thePath);
 	potentialParent = stripTrailingSep(potentialParent);

--- a/packages/renderer/src/test/is-path-inside.test.ts
+++ b/packages/renderer/src/test/is-path-inside.test.ts
@@ -1,0 +1,24 @@
+import {expect, test} from 'bun:test';
+import {isPathInside} from '../serve-handler/is-path-inside';
+
+test('allows child paths', () => {
+	expect(isPathInside('/foo/bar', '/foo')).toBe(true);
+	expect(isPathInside('/foo/bar/baz', '/foo')).toBe(true);
+	expect(isPathInside('/foo/', '/foo')).toBe(true);
+});
+
+test('rejects paths outside parent', () => {
+	expect(isPathInside('/bar', '/foo')).toBe(false);
+	expect(isPathInside('/foo/../bar', '/foo')).toBe(false);
+	expect(isPathInside('/foo/bar/../../../etc', '/foo')).toBe(false);
+});
+
+test('rejects sibling paths', () => {
+	expect(isPathInside('/foo/../bar', '/foo')).toBe(false);
+	expect(isPathInside('/foo/..', '/foo')).toBe(false);
+});
+
+test('handles trailing separators', () => {
+	expect(isPathInside('/foo/bar/', '/foo/')).toBe(true);
+	expect(isPathInside('/foo/../bar/', '/foo/')).toBe(false);
+});


### PR DESCRIPTION
## Problem

`isPathInside` did not resolve `.` or `..` segments before the prefix check. A path like `/foo/../bar` was accepted as inside `/foo` even though it resolves to `/bar`, which could bypass the path-traversal guard in the serve handler / preview server.

## Triage / Root cause

`path.relative` and the subsequent prefix checks operate on the literal string, not the resolved path. Relative segments therefore affected the outcome.

## Fix

- Call `path.normalize` on both the candidate path and the potential parent before comparing.
- Add unit tests in `packages/renderer/src/test/is-path-inside.test.ts` for child paths, traversal attempts, and trailing separators.

## Verification

- `bun test packages/renderer/src/test/is-path-inside.test.ts` passed.
- `bun run stylecheck` passed (only pre-existing warnings outside `renderer`).

## Notes / Risks

Security fix; no public API change. The function is used internally by the serve handler.
