### PR TITLE
`@remotion/studio`: Snap timeline tick labels to human-friendly intervals

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
@@ -42,6 +42,10 @@ const secondTick: React.CSSProperties = {
 const TICK_LABEL_FONT_SIZE = 12;
 const TICK_LABEL_MARGIN_LEFT = 8;
 const TICK_LABEL_MIN_GAP = 16;
+const MIN_SPACING_BETWEEN_FRAME_TICKS_PX = 5;
+const MIN_SPACING_BETWEEN_TIME_TICKS_PX = 16;
+const MIN_SPACING_BETWEEN_MEDIUM_FRAME_TICKS_PX = 24;
+const MIN_SPACING_BETWEEN_MEDIUM_TIME_TICKS_PX = 48;
 
 const tickLabel: React.CSSProperties = {
 	fontSize: TICK_LABEL_FONT_SIZE,
@@ -114,6 +118,128 @@ export const getNiceSecondInterval = (rawNthSecond: number): number => {
 	return Math.ceil(rawNthSecond / 3600) * 3600;
 };
 
+type TickInterval = {
+	readonly interval: number;
+	readonly unit: 'frames' | 'seconds';
+};
+
+export type TimelineTickScale = {
+	readonly labelEverySeconds: number;
+	readonly mediumTickEvery: TickInterval | null;
+	readonly minorTickEvery: TickInterval | null;
+};
+
+const getIntegerDivisors = (value: number): number[] => {
+	const lowerDivisors: number[] = [];
+	const upperDivisors: number[] = [];
+
+	for (let candidate = 1; candidate <= Math.sqrt(value); candidate++) {
+		if (value % candidate !== 0) {
+			continue;
+		}
+
+		lowerDivisors.push(candidate);
+		if (candidate !== value / candidate) {
+			upperDivisors.unshift(value / candidate);
+		}
+	}
+
+	return [...lowerDivisors, ...upperDivisors];
+};
+
+const getFrameIntervals = (fps: number): number[] => {
+	if (Number.isInteger(fps)) {
+		return getIntegerDivisors(fps);
+	}
+
+	return [1, 2, 5, 10, 15, 20, 30, 60].filter((interval) => interval < fps);
+};
+
+const getSecondIntervals = (labelEverySeconds: number): number[] => {
+	const hourlyIntervals = getIntegerDivisors(labelEverySeconds / 3600).map(
+		(hours) => hours * 3600,
+	);
+
+	return [...new Set([...NICE_SECOND_INTERVALS, ...hourlyIntervals])].sort(
+		(a, b) => a - b,
+	);
+};
+
+export const getTimelineTickScale = ({
+	fps,
+	frameInterval,
+	rawSecondMarkerEveryNth,
+}: {
+	readonly fps: number;
+	readonly frameInterval: number;
+	readonly rawSecondMarkerEveryNth: number;
+}): TimelineTickScale => {
+	const labelEverySeconds = getNiceSecondInterval(rawSecondMarkerEveryNth);
+	const frameIntervals = getFrameIntervals(fps);
+	const rawFrameInterval = MIN_SPACING_BETWEEN_FRAME_TICKS_PX / frameInterval;
+	const minorFrameInterval = frameIntervals.find(
+		(interval) => interval >= rawFrameInterval && interval < fps,
+	);
+
+	if (minorFrameInterval !== undefined) {
+		const rawMediumFrameInterval =
+			MIN_SPACING_BETWEEN_MEDIUM_FRAME_TICKS_PX / frameInterval;
+		const mediumFrameInterval = frameIntervals.find(
+			(interval) =>
+				interval >= rawMediumFrameInterval &&
+				interval < fps &&
+				interval % minorFrameInterval === 0,
+		);
+
+		return {
+			labelEverySeconds,
+			mediumTickEvery:
+				mediumFrameInterval === undefined
+					? null
+					: {interval: mediumFrameInterval, unit: 'frames'},
+			minorTickEvery: {interval: minorFrameInterval, unit: 'frames'},
+		};
+	}
+
+	const pixelsPerSecond = frameInterval * fps;
+	const secondIntervals = getSecondIntervals(labelEverySeconds);
+	const rawMinorSecondInterval =
+		MIN_SPACING_BETWEEN_TIME_TICKS_PX / pixelsPerSecond;
+	const minorSecondInterval = secondIntervals.find(
+		(interval) =>
+			interval >= rawMinorSecondInterval &&
+			interval < labelEverySeconds &&
+			labelEverySeconds % interval === 0,
+	);
+
+	if (minorSecondInterval === undefined) {
+		return {
+			labelEverySeconds,
+			mediumTickEvery: null,
+			minorTickEvery: null,
+		};
+	}
+
+	const rawMediumSecondInterval =
+		MIN_SPACING_BETWEEN_MEDIUM_TIME_TICKS_PX / pixelsPerSecond;
+	const mediumSecondInterval = secondIntervals.find(
+		(interval) =>
+			interval >= rawMediumSecondInterval &&
+			interval < labelEverySeconds &&
+			interval % minorSecondInterval === 0 &&
+			labelEverySeconds % interval === 0,
+	);
+
+	return {
+		labelEverySeconds,
+		mediumTickEvery:
+			mediumSecondInterval === undefined
+				? null
+				: {interval: mediumSecondInterval, unit: 'seconds'},
+		minorTickEvery: {interval: minorSecondInterval, unit: 'seconds'},
+	};
+};
+
 export const TimelineTimeIndicators: React.FC = () => {
 	const sliderTrack = useContext(TimelineWidthContext);
 	const video = Internals.useVideo();
@@ -178,7 +304,6 @@ const TimelineTimeIndicatorsInner: React.FC<{
 			windowWidth,
 		);
 
-		const MIN_SPACING_BETWEEN_TICKS_PX = 5;
 		const maxTickLabelWidth =
 			renderFrame(durationInFrames - 1, fps).length *
 			TICK_LABEL_FONT_SIZE *
@@ -189,14 +314,15 @@ const TimelineTimeIndicatorsInner: React.FC<{
 		const seconds = Math.floor(durationInFrames / fps);
 		const rawSecondMarkerEveryNth =
 			minSpacingBetweenTickLabelsPx / (frameInterval * fps);
-		const secondMarkerEveryNth = getNiceSecondInterval(rawSecondMarkerEveryNth);
-		const frameMarkerEveryNth = Math.ceil(
-			MIN_SPACING_BETWEEN_TICKS_PX / frameInterval,
-		);
+		const tickScale = getTimelineTickScale({
+			fps,
+			frameInterval,
+			rawSecondMarkerEveryNth,
+		});
 
-		// Big ticks showing for every second, stepping directly by the interval
+		// Labeled ticks use human-friendly time intervals.
 		const secondTicks: TimelineTick[] = [];
-		for (let index = 0; index < seconds; index += secondMarkerEveryNth) {
+		for (let index = 0; index < seconds; index += tickScale.labelEverySeconds) {
 			secondTicks.push({
 				frame: index * fps,
 				style: {
@@ -207,35 +333,65 @@ const TimelineTimeIndicatorsInner: React.FC<{
 			});
 		}
 
-		// Frame-level ticks, stepping directly by the interval
 		const hasSecondTick = new Set(secondTicks.map((t) => t.frame));
-		const frameTicks: TimelineTick[] = [];
-		for (
-			let index = 0;
-			index < durationInFrames;
-			index += frameMarkerEveryNth
-		) {
-			if (hasSecondTick.has(index)) {
-				continue;
-			}
+		const subdivisionTicks: TimelineTick[] = [];
+		const {minorTickEvery, mediumTickEvery} = tickScale;
 
-			frameTicks.push({
-				frame: index,
-				style: {
-					...tick,
-					left: frameInterval * index + TIMELINE_PADDING,
-					height:
-						index % fps === 0
-							? 10
-							: (index / frameMarkerEveryNth) % 2 === 0
+		if (minorTickEvery?.unit === 'frames') {
+			for (
+				let frame = 0;
+				frame < durationInFrames;
+				frame += minorTickEvery.interval
+			) {
+				if (hasSecondTick.has(frame)) {
+					continue;
+				}
+
+				subdivisionTicks.push({
+					frame,
+					style: {
+						...tick,
+						left: frameInterval * frame + TIMELINE_PADDING,
+						height:
+							(Number.isInteger(fps) && frame % fps === 0) ||
+							(mediumTickEvery?.unit === 'frames' &&
+								frame % mediumTickEvery.interval === 0)
 								? 5
 								: 2,
-				},
-				showTime: false,
-			});
+					},
+					showTime: false,
+				});
+			}
 		}
 
-		return [...secondTicks, ...frameTicks];
+		if (minorTickEvery?.unit === 'seconds') {
+			for (
+				let second = 0;
+				second < seconds;
+				second += minorTickEvery.interval
+			) {
+				const frame = second * fps;
+				if (hasSecondTick.has(frame)) {
+					continue;
+				}
+
+				subdivisionTicks.push({
+					frame,
+					style: {
+						...tick,
+						left: frameInterval * frame + TIMELINE_PADDING,
+						height:
+							mediumTickEvery?.unit === 'seconds' &&
+							second % mediumTickEvery.interval === 0
+								? 5
+								: 2,
+					},
+					showTime: false,
+				});
+			}
+		}
+
+		return [...secondTicks, ...subdivisionTicks];
 	}, [durationInFrames, fps, windowWidth]);
 
 	return (

--- a/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
@@ -86,6 +86,34 @@ type TimelineTick = {
 	showTime: boolean;
 };
 
+const NICE_SECOND_INTERVALS = [
+	1,
+	2,
+	5,
+	10,
+	15,
+	30,
+	60,
+	2 * 60,
+	3 * 60,
+	5 * 60,
+	10 * 60,
+	15 * 60,
+	20 * 60,
+	30 * 60,
+	60 * 60,
+];
+
+export const getNiceSecondInterval = (rawNthSecond: number): number => {
+	for (const n of NICE_SECOND_INTERVALS) {
+		if (n >= rawNthSecond) {
+			return n;
+		}
+	}
+
+	return Math.ceil(rawNthSecond / 3600) * 3600;
+};
+
 export const TimelineTimeIndicators: React.FC = () => {
 	const sliderTrack = useContext(TimelineWidthContext);
 	const video = Internals.useVideo();
@@ -159,55 +187,55 @@ const TimelineTimeIndicatorsInner: React.FC<{
 			TICK_LABEL_MARGIN_LEFT + maxTickLabelWidth + TICK_LABEL_MIN_GAP;
 
 		const seconds = Math.floor(durationInFrames / fps);
-		const secondMarkerEveryNth = Math.ceil(
-			minSpacingBetweenTickLabelsPx / (frameInterval * fps),
-		);
+		const rawSecondMarkerEveryNth =
+			minSpacingBetweenTickLabelsPx / (frameInterval * fps);
+		const secondMarkerEveryNth = getNiceSecondInterval(rawSecondMarkerEveryNth);
 		const frameMarkerEveryNth = Math.ceil(
 			MIN_SPACING_BETWEEN_TICKS_PX / frameInterval,
 		);
 
-		// Big ticks showing for every second
-		const secondTicks: TimelineTick[] = new Array(seconds)
-			.fill(true)
-			.map((_, index) => {
-				return {
-					frame: index * fps,
-					style: {
-						...secondTick,
-						left: frameInterval * index * fps + TIMELINE_PADDING,
-					},
-					showTime: index > 0,
-				};
-			})
-			.filter((_, idx) => idx % secondMarkerEveryNth === 0);
+		// Big ticks showing for every second, stepping directly by the interval
+		const secondTicks: TimelineTick[] = [];
+		for (let index = 0; index < seconds; index += secondMarkerEveryNth) {
+			secondTicks.push({
+				frame: index * fps,
+				style: {
+					...secondTick,
+					left: frameInterval * index * fps + TIMELINE_PADDING,
+				},
+				showTime: index > 0,
+			});
+		}
 
-		const frameTicks: TimelineTick[] = new Array(durationInFrames)
-			.fill(true)
-			.map((_, index) => {
-				return {
-					frame: index,
-					style: {
-						...tick,
-						left: frameInterval * index + TIMELINE_PADDING,
-						height:
-							index % fps === 0
-								? 10
-								: (index / frameMarkerEveryNth) % 2 === 0
-									? 5
-									: 2,
-					},
-					showTime: false,
-				};
-			})
-			.filter((_, idx) => idx % frameMarkerEveryNth === 0);
+		// Frame-level ticks, stepping directly by the interval
+		const hasSecondTick = new Set(secondTicks.map((t) => t.frame));
+		const frameTicks: TimelineTick[] = [];
+		for (
+			let index = 0;
+			index < durationInFrames;
+			index += frameMarkerEveryNth
+		) {
+			if (hasSecondTick.has(index)) {
+				continue;
+			}
 
-		// Merge and deduplicate ticks
-		const hasTicks: number[] = [];
-		return [...secondTicks, ...frameTicks].filter((t) => {
-			const alreadyUsed = hasTicks.find((ht) => ht === t.frame) !== undefined;
-			hasTicks.push(t.frame);
-			return !alreadyUsed;
-		});
+			frameTicks.push({
+				frame: index,
+				style: {
+					...tick,
+					left: frameInterval * index + TIMELINE_PADDING,
+					height:
+						index % fps === 0
+							? 10
+							: (index / frameMarkerEveryNth) % 2 === 0
+								? 5
+								: 2,
+				},
+				showTime: false,
+			});
+		}
+
+		return [...secondTicks, ...frameTicks];
 	}, [durationInFrames, fps, windowWidth]);
 
 	return (

--- a/packages/studio/src/test/timeline-nice-intervals.test.ts
+++ b/packages/studio/src/test/timeline-nice-intervals.test.ts
@@ -1,5 +1,8 @@
 import {expect, test} from 'bun:test';
-import {getNiceSecondInterval} from '../components/Timeline/TimelineTimeIndicators';
+import {
+	getNiceSecondInterval,
+	getTimelineTickScale,
+} from '../components/Timeline/TimelineTimeIndicators';
 
 test('getNiceSecondInterval snaps to exact nice values', () => {
 	expect(getNiceSecondInterval(1)).toBe(1);
@@ -44,4 +47,60 @@ test('getNiceSecondInterval handles values beyond 1 hour', () => {
 	expect(getNiceSecondInterval(4000)).toBe(7200);
 	expect(getNiceSecondInterval(7200)).toBe(7200);
 	expect(getNiceSecondInterval(10000)).toBe(10800);
+});
+
+test('uses individual frames when they have enough visual space', () => {
+	expect(
+		getTimelineTickScale({
+			fps: 30,
+			frameInterval: 15,
+			rawSecondMarkerEveryNth: 0.5,
+		}),
+	).toEqual({
+		labelEverySeconds: 1,
+		mediumTickEvery: {interval: 2, unit: 'frames'},
+		minorTickEvery: {interval: 1, unit: 'frames'},
+	});
+});
+
+test('uses frame intervals which divide a second while zoomed in', () => {
+	expect(
+		getTimelineTickScale({
+			fps: 30,
+			frameInterval: 3,
+			rawSecondMarkerEveryNth: 0.5,
+		}),
+	).toEqual({
+		labelEverySeconds: 1,
+		mediumTickEvery: {interval: 10, unit: 'frames'},
+		minorTickEvery: {interval: 2, unit: 'frames'},
+	});
+});
+
+test('uses clean time subdivisions for long compositions', () => {
+	expect(
+		getTimelineTickScale({
+			fps: 30,
+			frameInterval: 0.004541666666666667,
+			rawSecondMarkerEveryNth: 757,
+		}),
+	).toEqual({
+		labelEverySeconds: 900,
+		mediumTickEvery: null,
+		minorTickEvery: {interval: 180, unit: 'seconds'},
+	});
+});
+
+test('keeps a ten-hour composition sparse and aligned', () => {
+	expect(
+		getTimelineTickScale({
+			fps: 30,
+			frameInterval: 1 / 1080,
+			rawSecondMarkerEveryNth: 3708,
+		}),
+	).toEqual({
+		labelEverySeconds: 7200,
+		mediumTickEvery: {interval: 1800, unit: 'seconds'},
+		minorTickEvery: {interval: 600, unit: 'seconds'},
+	});
 });

--- a/packages/studio/src/test/timeline-nice-intervals.test.ts
+++ b/packages/studio/src/test/timeline-nice-intervals.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'bun:test';
+import {getNiceSecondInterval} from '../components/Timeline/TimelineTimeIndicators';
+
+test('getNiceSecondInterval snaps to exact nice values', () => {
+	expect(getNiceSecondInterval(1)).toBe(1);
+	expect(getNiceSecondInterval(2)).toBe(2);
+	expect(getNiceSecondInterval(5)).toBe(5);
+	expect(getNiceSecondInterval(10)).toBe(10);
+	expect(getNiceSecondInterval(15)).toBe(15);
+	expect(getNiceSecondInterval(30)).toBe(30);
+	expect(getNiceSecondInterval(60)).toBe(60);
+	expect(getNiceSecondInterval(300)).toBe(300);
+	expect(getNiceSecondInterval(600)).toBe(600);
+	expect(getNiceSecondInterval(3600)).toBe(3600);
+});
+
+test('getNiceSecondInterval rounds up to next nice value', () => {
+	expect(getNiceSecondInterval(0.5)).toBe(1);
+	expect(getNiceSecondInterval(1.5)).toBe(2);
+	expect(getNiceSecondInterval(3)).toBe(5);
+	expect(getNiceSecondInterval(7)).toBe(10);
+	expect(getNiceSecondInterval(12)).toBe(15);
+	expect(getNiceSecondInterval(20)).toBe(30);
+	expect(getNiceSecondInterval(45)).toBe(60);
+	expect(getNiceSecondInterval(90)).toBe(120);
+	expect(getNiceSecondInterval(150)).toBe(180);
+	expect(getNiceSecondInterval(250)).toBe(300);
+	expect(getNiceSecondInterval(500)).toBe(600);
+	expect(getNiceSecondInterval(700)).toBe(900);
+	expect(getNiceSecondInterval(1000)).toBe(1200);
+	expect(getNiceSecondInterval(1500)).toBe(1800);
+	expect(getNiceSecondInterval(2000)).toBe(3600);
+});
+
+test('getNiceSecondInterval handles the 108000-frame case', () => {
+	// 108000 frames at 30fps = 3600 seconds
+	// With ~932px width, rawNthSecond ≈ 326.16
+	// Should snap to 600 (10 minutes), not 327 (5min 27sec)
+	expect(getNiceSecondInterval(326.16)).toBe(600);
+});
+
+test('getNiceSecondInterval handles values beyond 1 hour', () => {
+	// Falls back to Math.ceil(raw / 3600) * 3600
+	expect(getNiceSecondInterval(4000)).toBe(7200);
+	expect(getNiceSecondInterval(7200)).toBe(7200);
+	expect(getNiceSecondInterval(10000)).toBe(10800);
+});


### PR DESCRIPTION
## Related Issue: #9395

### Summary
Fixes timeline tick labels showing at non-round intervals (e.g. `05:27.00`, `10:54.00`) for long compositions. Labels now land on clean time marks like `10:00.00`, `20:00.00`.
### Changes
- Added `getNiceSecondInterval()` that snaps raw second intervals to the next value from `[1, 2, 5, 10, 15, 30s, 1, 2, 3, 5, 10, 15, 20, 30, 60min]`
- Replaced `new Array(durationInFrames).fill().map().filter()` with direct `for` loops stepping by the interval
- Replaced linear `.find()` deduplication with a `Set` lookup
- Added 4 unit tests for the new snapping function
### Verification
- `bunx turbo run make --filter='@remotion/studio'` builds successfully
- All 957 studio tests pass (`cd packages/studio && bun test`)
- Tested with 108,000 frames / 30fps / ~933px: labels now show `10:00.00, 20:00.00, 30:00.00, 40:00.00, 50:00.00` instead of `05:27.00, 10:54.00, 16:21.00, 21:48.00, 27:15.00`

Fixes #9395