### PR TITLE
`@remotion/cloudrun`: Validate full site names

### DIFF
--- a/packages/cloudrun/src/shared/validate-site-name.ts
+++ b/packages/cloudrun/src/shared/validate-site-name.ts
@@ -1,3 +1,5 @@
+const VALID_SITE_NAME_RE = /^[-0-9a-zA-Z!_.*'()]+$/;
+
 export const validateSiteName = (siteName: unknown) => {
 	if (typeof siteName === 'undefined') {
 		return;
@@ -13,15 +15,15 @@ export const validateSiteName = (siteName: unknown) => {
 
 	if (siteName === '.' || siteName === '..') {
 		throw new Error(
-			"The `siteName` must match the RegExp `/^[0-9a-zA-Z-!_.*'()]+$/`. You passed: " +
-				siteName +
-				'. Check for invalid characters.',
+			'The `siteName` must not be `.` or `..`. You passed: ' + siteName + '.',
 		);
 	}
 
-	if (!/^[0-9a-zA-Z-!_.*'()]+$/.test(siteName)) {
+	if (!VALID_SITE_NAME_RE.test(siteName)) {
 		throw new Error(
-			"The `siteName` must match the RegExp `/^[0-9a-zA-Z-!_.*'()]+$/`. You passed: " +
+			'The `siteName` must match the RegExp `/' +
+				VALID_SITE_NAME_RE.source +
+				'/`. You passed: ' +
 				siteName +
 				'. Check for invalid characters.',
 		);

--- a/packages/cloudrun/src/shared/validate-site-name.ts
+++ b/packages/cloudrun/src/shared/validate-site-name.ts
@@ -5,15 +5,23 @@ export const validateSiteName = (siteName: unknown) => {
 
 	if (typeof siteName !== 'string') {
 		throw new TypeError(
-			`The 'projectName' argument must be a string if provided, but is ${JSON.stringify(
+			`The 'siteName' argument must be a string if provided, but is ${JSON.stringify(
 				siteName,
 			)}`,
 		);
 	}
 
-	if (!siteName.match(/([0-9a-zA-Z-!_.*'()]+)/g)) {
+	if (siteName === '.' || siteName === '..') {
 		throw new Error(
-			"The `siteName` must match the RegExp `/([0-9a-zA-Z-!_.*'()]+)/g`. You passed: " +
+			"The `siteName` must match the RegExp `/^[0-9a-zA-Z-!_.*'()]+$/`. You passed: " +
+				siteName +
+				'. Check for invalid characters.',
+		);
+	}
+
+	if (!/^[0-9a-zA-Z-!_.*'()]+$/.test(siteName)) {
+		throw new Error(
+			"The `siteName` must match the RegExp `/^[0-9a-zA-Z-!_.*'()]+$/`. You passed: " +
 				siteName +
 				'. Check for invalid characters.',
 		);

--- a/packages/cloudrun/src/test/validate-site-name.test.ts
+++ b/packages/cloudrun/src/test/validate-site-name.test.ts
@@ -14,8 +14,12 @@ test('rejects invalid characters', () => {
 });
 
 test('rejects dot segments and empty strings', () => {
-	expect(() => validateSiteName('.')).toThrow(/Check for invalid characters/);
-	expect(() => validateSiteName('..')).toThrow(/Check for invalid characters/);
+	expect(() => validateSiteName('.')).toThrow(
+		'The `siteName` must not be `.` or `..`.',
+	);
+	expect(() => validateSiteName('..')).toThrow(
+		'The `siteName` must not be `.` or `..`.',
+	);
 	expect(() => validateSiteName('')).toThrow(/Check for invalid characters/);
 });
 

--- a/packages/cloudrun/src/test/validate-site-name.test.ts
+++ b/packages/cloudrun/src/test/validate-site-name.test.ts
@@ -1,0 +1,34 @@
+import {expect, test} from 'bun:test';
+import {validateSiteName} from '../shared/validate-site-name';
+
+test('allows valid site names', () => {
+	expect(() => validateSiteName('my-site')).not.toThrow();
+	expect(() => validateSiteName('my_site.v1')).not.toThrow();
+	expect(() => validateSiteName("my-site-!'()*")).not.toThrow();
+});
+
+test('rejects invalid characters', () => {
+	expect(() => validateSiteName('my site')).toThrow(/Check for invalid characters/);
+	expect(() => validateSiteName('my@site')).toThrow(/Check for invalid characters/);
+	expect(() => validateSiteName('my#site')).toThrow(/Check for invalid characters/);
+});
+
+test('rejects dot segments and empty strings', () => {
+	expect(() => validateSiteName('.')).toThrow(/Check for invalid characters/);
+	expect(() => validateSiteName('..')).toThrow(/Check for invalid characters/);
+	expect(() => validateSiteName('')).toThrow(/Check for invalid characters/);
+});
+
+test('rejects substrings and suffixes that contain invalid characters', () => {
+	expect(() => validateSiteName('valid/name')).toThrow(/Check for invalid characters/);
+	expect(() => validateSiteName('valid name')).toThrow(/Check for invalid characters/);
+});
+
+test('allows undefined', () => {
+	expect(() => validateSiteName(undefined)).not.toThrow();
+});
+
+test('throws a TypeError for non-string types', () => {
+	expect(() => validateSiteName(123)).toThrow(TypeError);
+	expect(() => validateSiteName(null)).toThrow(TypeError);
+});


### PR DESCRIPTION
## Problem

`packages/cloudrun/src/shared/validate-site-name.ts` used the same unanchored regex as `@remotion/lambda` previously did: `.match(/([0-9a-zA-Z-!_.*'()]+)/g)`. Any name containing one allowed substring passed, so path separators, spaces, `@`, `#`, Unicode, and other characters could reach deploy-time in Cloud Run.

## Triage / Root cause

The regex is unanchored, dot segments (`.` / `..`) are not explicitly rejected, and the error message references the wrong (unanchored) regex.

## Fix

- Replace the unanchored match with `/^[0-9a-zA-Z-!_.*'()]+$/` and `.test()`.
- Explicitly reject `.` and `..` dot segments.
- Update the error message to reference the anchored regex.
- Add unit tests in `packages/cloudrun/src/test/validate-site-name.test.ts`.

## Verification

- `bun test packages/cloudrun/src/test/validate-site-name.test.ts` passed.
- `bunx tsgo -d` passed (type-check / build for the package).
- `bun run stylecheck` passed (only pre-existing warnings outside `cloudrun`).

## Notes / Risks

Follow-up to #9470 (same bug in the `lambda` package). The two validators now behave identically.
