### PR TITLE
`@remotion/studio-server`: Style opened browser label

### DIFF
--- a/packages/studio-server/src/open-browser-shortcut.ts
+++ b/packages/studio-server/src/open-browser-shortcut.ts
@@ -70,7 +70,7 @@ export const registerOpenBrowserShortcut = ({
 			if (didFocus) {
 				RenderInternals.Log.info(
 					{indent: false, logLevel},
-					`Focused ${url} in browser`,
+					RenderInternals.chalk.blue(`Opened ${url} in browser`),
 				);
 				return;
 			}
@@ -85,7 +85,7 @@ export const registerOpenBrowserShortcut = ({
 			if (result.didOpenBrowser) {
 				RenderInternals.Log.info(
 					{indent: false, logLevel},
-					`Opened ${url} in browser`,
+					RenderInternals.chalk.blue(`Opened ${url} in browser`),
 				);
 			}
 		} catch (err) {


### PR DESCRIPTION
## Summary

- label the browser shortcut action as "Opened" when an existing tab is focused
- render the browser action label in blue for both focus and open paths

## Testing

- `bun run build`
- `bun run stylecheck`
