### PR TITLE
`remotion`: Keep shared audio tags stable when enabling AudioContext

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -471,21 +471,23 @@ export const SharedAudioTagsContextProvider: React.FC<{
 	const audioContext = audioCtx?.audioContext ?? null;
 	const resume = audioCtx?.resume;
 
-	const refs = useMemo(() => {
+	const [refs] = useState(() => {
 		return new Array(numberOfAudioTags).fill(true).map((): Ref => {
 			const ref = createRef<HTMLAudioElement>();
 			return {
 				id: Math.random(),
 				ref,
-				mediaElementSourceNode: audioContext
-					? makeSharedElementSourceNode({
-							audioContext,
-							ref,
-						})
-					: null,
+				mediaElementSourceNode: makeSharedElementSourceNode({
+					audioContext,
+					ref,
+				}),
 			};
 		});
-	}, [audioContext, numberOfAudioTags]);
+	});
+
+	for (const {mediaElementSourceNode} of refs) {
+		mediaElementSourceNode?.setAudioContext(audioContext);
+	}
 
 	/**
 	 * Effects in React 18 fire twice, and we are looking for a way to only fire it once.
@@ -598,7 +600,9 @@ export const SharedAudioTagsContextProvider: React.FC<{
 			const cloned = [...takenAudios.current];
 			const index = refs.findIndex((r) => r.id === id);
 			if (index === -1) {
-				throw new TypeError('Error occured in ');
+				throw new TypeError(
+					`Unknown audio ref ${id}; refs: ${refs.map((r) => r.id).join(', ')}`,
+				);
 			}
 
 			cloned[index] = false;
@@ -749,12 +753,10 @@ export const useSharedAudio = ({
 
 		// numberOfSharedAudioTags is 0
 		const el = React.createRef<HTMLAudioElement>();
-		const mediaElementSourceNode = audioCtx?.audioContext
-			? makeSharedElementSourceNode({
-					audioContext: audioCtx.audioContext,
-					ref: el,
-				})
-			: null;
+		const mediaElementSourceNode = makeSharedElementSourceNode({
+			audioContext: audioCtx?.audioContext ?? null,
+			ref: el,
+		});
 
 		return {
 			el,
@@ -770,6 +772,7 @@ export const useSharedAudio = ({
 			},
 		};
 	});
+	elem.mediaElementSourceNode?.setAudioContext(audioCtx?.audioContext ?? null);
 
 	/**
 	 * Effects in React 18 fire twice, and we are looking for a way to only fire it once.

--- a/packages/core/src/audio/shared-element-source-node.ts
+++ b/packages/core/src/audio/shared-element-source-node.ts
@@ -2,23 +2,26 @@ export const makeSharedElementSourceNode = ({
 	audioContext,
 	ref,
 }: {
-	audioContext: AudioContext;
+	audioContext: AudioContext | null;
 	ref: React.RefObject<HTMLAudioElement | null>;
 }) => {
 	let connected: MediaElementAudioSourceNode | null = null;
 	let disposed = false;
+	let currentAudioContext = audioContext;
 
 	// We must allow this to cleanup and create a new one due to strict mode.
 	return {
+		setAudioContext: (newAudioContext: AudioContext | null) => {
+			currentAudioContext = newAudioContext;
+		},
 		attemptToConnect: () => {
 			if (disposed) {
 				throw new Error('SharedElementSourceNode has been disposed');
 			}
 
-			if (!connected && ref.current) {
-				const mediaElementSourceNode = audioContext.createMediaElementSource(
-					ref.current,
-				);
+			if (!connected && ref.current && currentAudioContext) {
+				const mediaElementSourceNode =
+					currentAudioContext.createMediaElementSource(ref.current);
 
 				connected = mediaElementSourceNode;
 			}

--- a/packages/core/src/test/shared-element-source-node.test.ts
+++ b/packages/core/src/test/shared-element-source-node.test.ts
@@ -1,0 +1,31 @@
+import {expect, test} from 'bun:test';
+import type React from 'react';
+import {makeSharedElementSourceNode} from '../audio/shared-element-source-node.js';
+
+test('connects once an AudioContext becomes available', () => {
+	const audioElement = {} as HTMLAudioElement;
+	const ref = {
+		current: audioElement,
+	} as React.RefObject<HTMLAudioElement>;
+	const createdFor: HTMLMediaElement[] = [];
+	const mediaElementSourceNode = {
+		disconnect: () => undefined,
+	} as MediaElementAudioSourceNode;
+	const audioContext = {
+		createMediaElementSource: (element: HTMLMediaElement) => {
+			createdFor.push(element);
+			return mediaElementSourceNode;
+		},
+	} as AudioContext;
+	const source = makeSharedElementSourceNode({
+		audioContext: null,
+		ref,
+	});
+
+	source.attemptToConnect();
+	source.setAudioContext(audioContext);
+	source.attemptToConnect();
+
+	expect(createdFor).toEqual([audioElement]);
+	expect(source.get()).toBe(mediaElementSourceNode);
+});

--- a/packages/player/src/test/index.test.ts
+++ b/packages/player/src/test/index.test.ts
@@ -16,12 +16,18 @@ test('It should throw an error if not being used inside a RemotionRoot', () => {
 	}).toThrow();
 });
 
+let createdAudioContexts = 0;
+
 class MockAudioContext {
 	public state = 'suspended' as AudioContextState;
 	public baseLatency = 0;
 	public outputLatency = 0;
 	public currentTime = 0;
 	public destination = {};
+
+	constructor() {
+		createdAudioContexts++;
+	}
 
 	addEventListener() {
 		return undefined;
@@ -76,8 +82,10 @@ const AudioComposition = () => {
 
 const PlayerWithMuteButton = ({
 	onError,
+	initiallyMuted = false,
 }: {
 	readonly onError: (error: Error) => void;
+	readonly initiallyMuted?: boolean;
 }) => {
 	const playerRef = useRef<PlayerRef>(null);
 
@@ -91,6 +99,7 @@ const PlayerWithMuteButton = ({
 			compositionWidth: 1920,
 			compositionHeight: 1080,
 			fps: 30,
+			initiallyMuted,
 			errorFallback: ({error}) => {
 				onError(error);
 				return null;
@@ -98,8 +107,14 @@ const PlayerWithMuteButton = ({
 		}),
 		React.createElement(
 			'button',
-			{type: 'button', onClick: () => playerRef.current?.mute()},
-			'Mute',
+			{
+				type: 'button',
+				onClick: () =>
+					initiallyMuted
+						? playerRef.current?.unmute()
+						: playerRef.current?.mute(),
+			},
+			initiallyMuted ? 'Unmute' : 'Mute',
 		),
 	);
 };
@@ -120,6 +135,33 @@ test('It does not crash when muting a Player with a mounted Html5Audio tag', () 
 			getByText('Mute').click();
 		});
 
+		expect(errors).toEqual([]);
+	} finally {
+		globalThis.AudioContext = originalAudioContext;
+	}
+});
+
+test('It does not crash when unmuting a Player with a mounted Html5Audio tag', () => {
+	const originalAudioContext = globalThis.AudioContext;
+	globalThis.AudioContext = MockAudioContext as unknown as typeof AudioContext;
+	const errors: Error[] = [];
+	createdAudioContexts = 0;
+
+	try {
+		const {getByText} = render(
+			React.createElement(PlayerWithMuteButton, {
+				initiallyMuted: true,
+				onError: (error) => errors.push(error),
+			}),
+		);
+
+		expect(createdAudioContexts).toBe(0);
+
+		act(() => {
+			getByText('Unmute').click();
+		});
+
+		expect(createdAudioContexts).toBe(1);
 		expect(errors).toEqual([]);
 	} finally {
 		globalThis.AudioContext = originalAudioContext;


### PR DESCRIPTION
## Summary

- keep shared audio tag refs stable when an `AudioContext` is created after mount
- bind each shared media element source lazily once the context becomes available
- cover initially-muted Players unmuting with a mounted `<Html5Audio>` while preserving deferred `AudioContext` creation
- improve the diagnostic for an unknown shared audio ref

## Tests

- `bun test src/test/shared-element-source-node.test.ts` in `packages/core`
- `bun test src/test/index.test.ts` in `packages/player`
- `bun run build`
- `bun run stylecheck`

Closes #9475
