### PR TITLE
`@remotion/studio`: Remove waveform error message

### DIFF
--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -46,17 +46,6 @@ const getContainerStyle = (height: number): React.CSSProperties => {
 	};
 };
 
-const errorMessage: React.CSSProperties = {
-	fontSize: 13,
-	paddingTop: 6,
-	paddingBottom: 6,
-	paddingLeft: 12,
-	paddingRight: 12,
-	alignSelf: 'flex-start',
-	maxWidth: 450,
-	opacity: 0.75,
-};
-
 const getWaveformErrorMessage = () => {
 	return new Error(
 		'No waveform available. The audio could not be decoded or may not support CORS.',
@@ -398,14 +387,7 @@ export const AudioWaveform: React.FC<{
 	}, [height, parsedVolume, shouldRenderVolumeOverlay, visualizationWidth]);
 
 	if (error) {
-		return (
-			<div style={getContainerStyle(height)}>
-				<div style={errorMessage}>
-					No waveform available. The audio could not be decoded or may not
-					support CORS.
-				</div>
-			</div>
-		);
+		return null;
 	}
 
 	if (!canUseWorkerPath && !peaks) {


### PR DESCRIPTION
## Summary

Stop rendering the waveform decoding error message in the Studio timeline.

## Verification

- `bun test src` in `packages/studio`
- `bun run build`
- `bun run stylecheck`

Closes https://github.com/remotion-dev/remotion/issues/9481
