### PR TITLE
`@remotion/cloudrun`: Set v5 maximum instances default

### DIFF
--- a/packages/cloudrun/src/shared/constants.ts
+++ b/packages/cloudrun/src/shared/constants.ts
@@ -1,3 +1,4 @@
+import {NoReactInternals} from 'remotion/no-react';
 import type {GcpRegion} from '../pricing/gcp-regions';
 
 export const DEFAULT_REGION: GcpRegion = 'us-east1';
@@ -19,5 +20,6 @@ export const DEFAULT_OUTPUT_PRIVACY: Privacy = 'public';
 
 export const DEFAULT_TIMEOUT = 300;
 export const DEFAULT_MIN_INSTANCES = 0;
-// TODO: In V5, Enable set this to 5
-export const DEFAULT_MAX_INSTANCES = 100;
+export const DEFAULT_MAX_INSTANCES = NoReactInternals.ENABLE_V5_BREAKING_CHANGES
+	? 5
+	: 100;

--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -87,6 +87,13 @@ This will add a miniscule cost to your renders technically, but will lead to mor
 `renderMediaOnLambda()`, `getRenderProgress()`, `renderStillOnLambda()`, `presignUrl()`, `getSites()` have been removed from `@remotion/lambda`.  
 They are now available in `@remotion/lambda/client`.
 
+## Cloud Run services use a lower maximum instance count
+
+The default [`maxInstances`](/docs/cloudrun/deployservice#maxinstances) for new Cloud Run services has been reduced from `100` to `5`.
+Some GCP accounts have lower Cloud Run quotas and rejected deployments using the previous default with an `Invalid value specified for cpu` error.
+
+**Required action**: If you want to keep the old scaling limit, set `maxInstances: 100` when using [`deployService()`](/docs/cloudrun/deployservice), or pass `--maxInstances=100` to the [Cloud Run CLI](/docs/cloudrun/cli/services/deploy).
+
 ## `bt709` is now the default color space
 
 The default [`colorSpace`](/docs/renderer/render-media#colorspace) is now `"bt709"` instead of `"default"` (which was equivalent to `"bt601"`).

--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -90,7 +90,7 @@ They are now available in `@remotion/lambda/client`.
 ## Cloud Run services use a lower maximum instance count
 
 The default [`maxInstances`](/docs/cloudrun/deployservice#maxinstances) for new Cloud Run services has been reduced from `100` to `5`.
-Some GCP accounts have lower Cloud Run quotas and rejected deployments using the previous default with an `Invalid value specified for cpu` error.
+On some GCP accounts, the previous default exceeded the available Cloud Run quota and caused deployments to fail with an `Invalid value specified for cpu` error.
 
 **Required action**: If you want to keep the old scaling limit, set `maxInstances: 100` when using [`deployService()`](/docs/cloudrun/deployservice), or pass `--maxInstances=100` to the [Cloud Run CLI](/docs/cloudrun/cli/services/deploy).
 


### PR DESCRIPTION
## Summary

- gate the Cloud Run maximum instance default on `ENABLE_V5_BREAKING_CHANGES`
- keep the v4 default at 100 instances
- switch the v5 default to 5 instances when the central flag is enabled
- document the new default, its quota-related rationale, and how to retain the old limit

## Validation

- `bunx oxfmt packages/cloudrun/src/shared/constants.ts --write`
- `bunx oxfmt packages/docs/docs/5-0-migration.mdx --write`
- `bun run build`
- `bun run stylecheck`
- `bun test packages/cloudrun/src`
- `bunx turbo run lint formatting --filter=docs --no-update-notifier`
- `bun run build-docs`
- `bun render-cards.ts`

## Preview

- [v5.0 Migration](https://remotion-git-codex-cloudrun-v5-max-instances-remotion.vercel.app/docs/5-0-migration)

Part of #3310.
Closes #9497.
