### PR TITLE
`@remotion/studio`: Fix multiple marquee selection

### DIFF
--- a/packages/cloudrun/tsconfig.json
+++ b/packages/cloudrun/tsconfig.json
@@ -5,6 +5,7 @@
 		"rootDir": "src"
 	},
 	"include": ["src"],
+	"exclude": ["src/test"],
 	"references": [
 		{"path": "../core"},
 		{"path": "../cli"},

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -560,6 +560,41 @@ export const getTimelineMarqueeSelection = ({
 	};
 };
 
+export const extendTimelineMarqueeSelection = ({
+	currentSelection,
+	marqueeSelection,
+}: {
+	readonly currentSelection: readonly TimelineSelection[];
+	readonly marqueeSelection: readonly TimelineSelection[];
+}): readonly TimelineSelection[] => {
+	if (marqueeSelection.length === 0) {
+		return currentSelection;
+	}
+
+	const marqueeKind = getTimelineMarqueeSelectionKind(marqueeSelection[0]);
+	if (marqueeKind === null) {
+		return marqueeSelection;
+	}
+
+	const selectedKeys = new Set(
+		currentSelection.map((item) => getTimelineSelectionKey(item)),
+	);
+	return [
+		...currentSelection.filter((item) =>
+			isTimelineSelectionCompatibleWithMarqueeKind(item, marqueeKind),
+		),
+		...marqueeSelection.filter((item) => {
+			const key = getTimelineSelectionKey(item);
+			if (selectedKeys.has(key)) {
+				return false;
+			}
+
+			selectedKeys.add(key);
+			return true;
+		}),
+	];
+};
+
 type TimelineSelectionContextValue = {
 	readonly canSelect: boolean;
 	readonly selectedItems: readonly TimelineSelection[];
@@ -1491,7 +1526,8 @@ export const useCurrentTimelineSelectionStateAsRef = () => {
 };
 
 export const useTimelineMarqueeSelection = () => {
-	const {canSelect, getMarqueeSelection, selectItems} = useTimelineSelection();
+	const {canSelect, getMarqueeSelection, selectedItems, selectItems} =
+		useTimelineSelection();
 	const {isHighestContext} = useZIndex();
 	const [marqueeRect, setMarqueeRect] = useState<TimelineMarqueeRect | null>(
 		null,
@@ -1507,7 +1543,7 @@ export const useTimelineMarqueeSelection = () => {
 				return;
 			}
 
-			if (event.shiftKey || event.metaKey || event.ctrlKey) {
+			if (event.shiftKey) {
 				return;
 			}
 
@@ -1548,6 +1584,8 @@ export const useTimelineMarqueeSelection = () => {
 
 			let hasDragged = false;
 			let lockedSelectionKind: TimelineMarqueeSelectionKind | null = null;
+			const extendSelection = event.metaKey || event.ctrlKey;
+			const selectionBeforeMarquee = selectedItems;
 
 			const cleanup = () => {
 				window.removeEventListener('pointermove', onPointerMove);
@@ -1586,7 +1624,14 @@ export const useTimelineMarqueeSelection = () => {
 				const nextSelection = getMarqueeSelection(rect, lockedSelectionKind);
 				lockedSelectionKind = nextSelection.lockedSelectionKind;
 				setMarqueeRect(rect);
-				selectItems(nextSelection.selectedItems);
+				selectItems(
+					extendSelection
+						? extendTimelineMarqueeSelection({
+								currentSelection: selectionBeforeMarquee,
+								marqueeSelection: nextSelection.selectedItems,
+							})
+						: nextSelection.selectedItems,
+				);
 			};
 
 			const onPointerMove = (moveEvent: PointerEvent) => {
@@ -1606,7 +1651,13 @@ export const useTimelineMarqueeSelection = () => {
 			window.addEventListener('pointerup', onPointerUp);
 			window.addEventListener('pointercancel', onPointerCancel);
 		},
-		[canSelect, getMarqueeSelection, isHighestContext, selectItems],
+		[
+			canSelect,
+			getMarqueeSelection,
+			isHighestContext,
+			selectedItems,
+			selectItems,
+		],
 	);
 
 	return {marqueeRect, onPointerDownCapture};

--- a/packages/studio/src/components/Timeline/should-clear-selection-on-pointer-down.ts
+++ b/packages/studio/src/components/Timeline/should-clear-selection-on-pointer-down.ts
@@ -19,9 +19,11 @@ const isSelectionClearBlocked = (target: EventTarget | null | undefined) => {
 
 export const shouldClearSelectionOnPointerDown = (event: {
 	readonly button: number;
+	readonly ctrlKey?: boolean;
+	readonly metaKey?: boolean;
 	readonly target?: EventTarget | null;
 }) => {
-	if (event.button !== 0) {
+	if (event.button !== 0 || event.metaKey || event.ctrlKey) {
 		return false;
 	}
 

--- a/packages/studio/src/components/Timeline/should-clear-selection-on-pointer-down.ts
+++ b/packages/studio/src/components/Timeline/should-clear-selection-on-pointer-down.ts
@@ -19,11 +19,11 @@ const isSelectionClearBlocked = (target: EventTarget | null | undefined) => {
 
 export const shouldClearSelectionOnPointerDown = (event: {
 	readonly button: number;
-	readonly ctrlKey?: boolean;
-	readonly metaKey?: boolean;
+	readonly ctrlKey: boolean | null;
+	readonly metaKey: boolean | null;
 	readonly target?: EventTarget | null;
 }) => {
-	if (event.button !== 0 || event.metaKey || event.ctrlKey) {
+	if (event.button !== 0 || event.metaKey === true || event.ctrlKey === true) {
 		return false;
 	}
 

--- a/packages/studio/src/test/clear-selection-on-pointer-down.test.ts
+++ b/packages/studio/src/test/clear-selection-on-pointer-down.test.ts
@@ -13,6 +13,21 @@ test('non-left pointer down does not clear Studio selection', () => {
 	expect(shouldClearSelectionOnPointerDown({button: 2})).toBe(false);
 });
 
+test('Cmd/Ctrl+pointer down does not clear Studio selection', () => {
+	expect(
+		shouldClearSelectionOnPointerDown({
+			button: 0,
+			metaKey: true,
+		}),
+	).toBe(false);
+	expect(
+		shouldClearSelectionOnPointerDown({
+			button: 0,
+			ctrlKey: true,
+		}),
+	).toBe(false);
+});
+
 test('pointer down from a selection-clear blocker does not clear Studio selection', () => {
 	const target = {
 		closest: (selector: string) => {

--- a/packages/studio/src/test/clear-selection-on-pointer-down.test.ts
+++ b/packages/studio/src/test/clear-selection-on-pointer-down.test.ts
@@ -5,18 +5,37 @@ import {
 } from '../components/Timeline/should-clear-selection-on-pointer-down';
 
 test('left pointer down clears Studio selection', () => {
-	expect(shouldClearSelectionOnPointerDown({button: 0})).toBe(true);
+	expect(
+		shouldClearSelectionOnPointerDown({
+			button: 0,
+			ctrlKey: null,
+			metaKey: null,
+		}),
+	).toBe(true);
 });
 
 test('non-left pointer down does not clear Studio selection', () => {
-	expect(shouldClearSelectionOnPointerDown({button: 1})).toBe(false);
-	expect(shouldClearSelectionOnPointerDown({button: 2})).toBe(false);
+	expect(
+		shouldClearSelectionOnPointerDown({
+			button: 1,
+			ctrlKey: null,
+			metaKey: null,
+		}),
+	).toBe(false);
+	expect(
+		shouldClearSelectionOnPointerDown({
+			button: 2,
+			ctrlKey: null,
+			metaKey: null,
+		}),
+	).toBe(false);
 });
 
 test('Cmd/Ctrl+pointer down does not clear Studio selection', () => {
 	expect(
 		shouldClearSelectionOnPointerDown({
 			button: 0,
+			ctrlKey: null,
 			metaKey: true,
 		}),
 	).toBe(false);
@@ -24,6 +43,7 @@ test('Cmd/Ctrl+pointer down does not clear Studio selection', () => {
 		shouldClearSelectionOnPointerDown({
 			button: 0,
 			ctrlKey: true,
+			metaKey: null,
 		}),
 	).toBe(false);
 });
@@ -40,6 +60,8 @@ test('pointer down from a selection-clear blocker does not clear Studio selectio
 	expect(
 		shouldClearSelectionOnPointerDown({
 			button: 0,
+			ctrlKey: null,
+			metaKey: null,
 			target: target as unknown as EventTarget,
 		}),
 	).toBe(false);

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -88,6 +88,7 @@ import {
 } from '../components/Timeline/TimelineClipboardKeybindings';
 import {getSelectedKeyframeControlNodePathInfos} from '../components/Timeline/TimelineKeyframeControls';
 import {
+	extendTimelineMarqueeSelection,
 	getAvailableTimelineSelectionState,
 	getClampedTimelineMarqueePoint,
 	getSelectableTimelineItems,
@@ -560,6 +561,68 @@ test('timeline marquee clears its item kind when no target is selected', () => {
 
 	expect(result.lockedSelectionKind).toBe(null);
 	expect(result.selectedItems).toEqual([]);
+});
+
+test('timeline marquee can extend a keyframe selection', () => {
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'style.opacity'],
+	);
+	const selectedKeyframe = {
+		type: 'keyframe' as const,
+		nodePathInfo,
+		frame: 10,
+	};
+	const newlySelectedKeyframe = {
+		type: 'keyframe' as const,
+		nodePathInfo,
+		frame: 20,
+	};
+
+	expect(
+		extendTimelineMarqueeSelection({
+			currentSelection: [selectedKeyframe],
+			marqueeSelection: [newlySelectedKeyframe],
+		}),
+	).toEqual([selectedKeyframe, newlySelectedKeyframe]);
+});
+
+test('extending a timeline marquee preserves the selection until it intersects an item', () => {
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'style.opacity'],
+	);
+	const selectedKeyframe = {
+		type: 'keyframe' as const,
+		nodePathInfo,
+		frame: 10,
+	};
+
+	expect(
+		extendTimelineMarqueeSelection({
+			currentSelection: [selectedKeyframe],
+			marqueeSelection: [],
+		}),
+	).toEqual([selectedKeyframe]);
+});
+
+test('extending a timeline marquee removes duplicate selections', () => {
+	const nodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'style.opacity'],
+	);
+	const selectedKeyframe = {
+		type: 'keyframe' as const,
+		nodePathInfo,
+		frame: 10,
+	};
+
+	expect(
+		extendTimelineMarqueeSelection({
+			currentSelection: [selectedKeyframe],
+			marqueeSelection: [selectedKeyframe],
+		}),
+	).toEqual([selectedKeyframe]);
 });
 
 test('keyframe diamond target resolution uses all selected prop rows when clicked row is selected', () => {


### PR DESCRIPTION
## Summary

- allow Cmd/Ctrl+marquee to extend the current keyframe and easing selection
- preserve the existing selection from pointer-down through the marquee drag
- avoid duplicate selections and add regression coverage

## Testing

- `bun test packages/studio/src/test/clear-selection-on-pointer-down.test.ts packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9379
