### PR TITLE
`remotion`: Support editing background colors

### DIFF
--- a/packages/brand/src/3DContext/Div3D.tsx
+++ b/packages/brand/src/3DContext/Div3D.tsx
@@ -129,6 +129,7 @@ const extrudeDivSchema = {
 	scaleY: scaleTransformField('Scale Y'),
 	scaleZ: scaleTransformField('Scale Z'),
 	...Interactive.transformSchema,
+	...Interactive.backgroundSchema,
 	...Interactive.borderSchema,
 } as const satisfies InteractivitySchema;
 

--- a/packages/brand/src/Compose/WhatIsRemotion.tsx
+++ b/packages/brand/src/Compose/WhatIsRemotion.tsx
@@ -43,6 +43,7 @@ const labelSchema = {
 	...Interactive.baseSchema,
 	...Interactive.transformSchema,
 	...Interactive.textSchema,
+	...Interactive.backgroundSchema,
 	...Interactive.borderSchema,
 	children: {
 		type: 'text-content',

--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -18,6 +18,7 @@ import {
 import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
 import type {InteractiveBaseProps} from './Interactive.js';
 import {
+	backgroundSchema,
 	baseSchema,
 	borderSchema,
 	transformSchema,
@@ -785,6 +786,7 @@ export const htmlInCanvasSchema = {
 		hiddenFromList: false,
 	},
 	...transformSchema,
+	...backgroundSchema,
 	...borderSchema,
 } as const satisfies InteractivitySchema;
 

--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -18,6 +18,7 @@ import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
 import {getCrossOriginValue} from './get-cross-origin-value.js';
 import type {InteractiveBaseProps} from './Interactive.js';
 import {
+	backgroundSchema,
 	baseSchema,
 	borderSchema,
 	transformSchema,
@@ -388,6 +389,7 @@ export const imgSchema = {
 	},
 	...baseSchema,
 	...transformSchema,
+	...backgroundSchema,
 	...borderSchema,
 } as const satisfies InteractivitySchema;
 

--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -5,6 +5,7 @@ import type {
 } from './CompositionManager.js';
 import {addSequenceStackTraces} from './enable-sequence-stack-traces.js';
 import {
+	backgroundSchema,
 	baseSchema,
 	borderSchema,
 	premountSchema,
@@ -142,8 +143,13 @@ const interactiveElementSchema = {
 	...transformSchema,
 } as const satisfies InteractivitySchema;
 
-const interactiveBorderElementSchema = {
+const interactiveBackgroundElementSchema = {
 	...interactiveElementSchema,
+	...backgroundSchema,
+} as const satisfies InteractivitySchema;
+
+const interactiveBorderElementSchema = {
+	...interactiveBackgroundElementSchema,
 	...borderSchema,
 } as const satisfies InteractivitySchema;
 
@@ -278,6 +284,7 @@ export const Interactive = {
 	baseSchema,
 	transformSchema,
 	textSchema,
+	backgroundSchema,
 	borderSchema,
 	premountSchema,
 	sequenceSchema,

--- a/packages/core/src/animated-image/AnimatedImage.tsx
+++ b/packages/core/src/animated-image/AnimatedImage.tsx
@@ -17,6 +17,7 @@ import {
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {Freeze} from '../freeze.js';
 import {
+	backgroundSchema,
 	baseSchema,
 	borderSchema,
 	premountSchema,
@@ -62,6 +63,7 @@ export const animatedImageSchema = {
 		keyframable: false,
 	},
 	...transformSchema,
+	...backgroundSchema,
 	...borderSchema,
 } as const satisfies InteractivitySchema;
 

--- a/packages/core/src/canvas-image/CanvasImage.tsx
+++ b/packages/core/src/canvas-image/CanvasImage.tsx
@@ -21,6 +21,7 @@ import {
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {Freeze} from '../freeze.js';
 import {
+	backgroundSchema,
 	baseSchema,
 	borderSchema,
 	premountSchema,
@@ -51,6 +52,7 @@ export const canvasImageSchema = {
 		},
 	},
 	...transformSchema,
+	...backgroundSchema,
 	...borderSchema,
 } as const satisfies InteractivitySchema;
 

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -11,6 +11,7 @@ import type {SequenceControls} from '../CompositionManager.js';
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import type {InteractiveBaseProps} from '../Interactive.js';
 import {
+	backgroundSchema,
 	baseSchema,
 	borderSchema,
 	transformSchema,
@@ -97,6 +98,7 @@ export const solidSchema = {
 		hiddenFromList: false,
 	},
 	...transformSchema,
+	...backgroundSchema,
 	...borderSchema,
 } as const satisfies InteractivitySchema;
 

--- a/packages/core/src/interactivity-schema.ts
+++ b/packages/core/src/interactivity-schema.ts
@@ -367,6 +367,15 @@ export const borderSchema = {
 	},
 } as const satisfies InteractivitySchema;
 
+export const backgroundSchema = {
+	'style.backgroundColor': {
+		type: 'color',
+		// `transparent` is the CSS initial value of background-color.
+		default: 'transparent',
+		description: 'Color',
+	},
+} as const satisfies InteractivitySchema;
+
 export const textContentSchema = {
 	children: {
 		type: 'text-content',
@@ -402,6 +411,7 @@ export const sequencePremountSchema = {
 
 export const sequenceStyleSchema = {
 	...transformSchema,
+	...backgroundSchema,
 	...borderSchema,
 	...sequencePremountSchema,
 } as const satisfies InteractivitySchema;

--- a/packages/core/src/test/find-props-to-delete.test.ts
+++ b/packages/core/src/test/find-props-to-delete.test.ts
@@ -39,6 +39,7 @@ test('find right values to delete when upgrading a discriminated union', () => {
 		'style.scale',
 		'style.rotate',
 		'style.opacity',
+		'style.backgroundColor',
 		'style.borderWidth',
 		'style.borderStyle',
 		'style.borderColor',

--- a/packages/core/src/test/with-interactivity-schema-helpers.test.ts
+++ b/packages/core/src/test/with-interactivity-schema-helpers.test.ts
@@ -12,6 +12,7 @@ import {htmlInCanvasSchema} from '../HtmlInCanvas.js';
 import {imgSchema} from '../Img.js';
 import {Interactive} from '../Interactive.js';
 import {
+	backgroundSchema,
 	baseSchema,
 	borderSchema,
 	extendSchemaWithSequenceName,
@@ -31,17 +32,18 @@ import {
 	selectActiveKeys,
 } from '../with-interactivity-schema.js';
 
-test('sequenceStyleSchema contains transform and premount fields', () => {
+test('sequenceStyleSchema contains visual style and premount fields', () => {
 	expect(Object.keys(sequenceStyleSchema).sort()).toEqual(
 		[
 			...Object.keys(transformSchema),
+			...Object.keys(backgroundSchema),
 			...Object.keys(borderSchema),
 			...Object.keys(sequencePremountSchema),
 		].sort(),
 	);
 });
 
-test('CSS box component schemas expose border controls', () => {
+test('CSS box component schemas expose background and border controls', () => {
 	for (const schema of [
 		sequenceStyleSchema,
 		imgSchema,
@@ -50,6 +52,7 @@ test('CSS box component schemas expose border controls', () => {
 		htmlInCanvasSchema,
 		solidSchema,
 	]) {
+		expect('style.backgroundColor' in schema).toBe(true);
 		expect('style.borderWidth' in schema).toBe(true);
 		expect('style.borderStyle' in schema).toBe(true);
 		expect('style.borderColor' in schema).toBe(true);
@@ -146,6 +149,7 @@ test('getFlatSchema(sequenceSchema) exposes every variant key', () => {
 			'style.rotate',
 			'style.transformOrigin',
 			'style.opacity',
+			'style.backgroundColor',
 			'style.borderWidth',
 			'style.borderStyle',
 			'style.borderColor',
@@ -354,6 +358,14 @@ test('borderSchema exposes the longhand border style fields', () => {
 	});
 });
 
+test('backgroundSchema exposes the background color style field', () => {
+	expect(Object.keys(backgroundSchema)).toEqual(['style.backgroundColor']);
+	expect(backgroundSchema['style.backgroundColor']).toMatchObject({
+		type: 'color',
+		default: 'transparent',
+	});
+});
+
 test('readValuesFromProps reads dot-notation keys via getNestedValue', () => {
 	const props = {
 		layout: 'absolute-fill',
@@ -418,6 +430,7 @@ test('selectActiveKeys exposes style.* keys when layout=absolute-fill', () => {
 			'style.rotate',
 			'style.transformOrigin',
 			'style.opacity',
+			'style.backgroundColor',
 			'style.borderWidth',
 			'style.borderStyle',
 			'style.borderColor',

--- a/packages/docs/docs/interactive.mdx
+++ b/packages/docs/docs/interactive.mdx
@@ -17,9 +17,7 @@ import {AbsoluteFill, Interactive} from 'remotion';
 export const MyComp: React.FC = () => {
   return (
     <AbsoluteFill>
-      <Interactive.Div style={{backgroundColor: 'white', padding: 24}}>
-        Hello World
-      </Interactive.Div>
+      <Interactive.Div style={{backgroundColor: 'white', padding: 24}}>Hello World</Interactive.Div>
     </AbsoluteFill>
   );
 };
@@ -102,6 +100,14 @@ Controls for text-related style props:
 
 Use it for components that accept a `style` prop and render text.
 
+### `Interactive.backgroundSchema`<AvailableFrom v="4.0.497" />
+
+A color control for `style.backgroundColor`.
+
+The `backgroundColor` longhand is used rather than the `background` shorthand so complex backgrounds such as gradients and images can remain untouched.
+
+Use it for components that accept a `style` prop and render a CSS background.
+
 ### `Interactive.borderSchema`<AvailableFrom v="4.0.497" />
 
 Controls for border-related style props:
@@ -124,7 +130,7 @@ Use it for components that forward these props to a `<Sequence>`.
 
 The schema used by [`<Sequence>`](/docs/sequence).
 
-It includes `Interactive.baseSchema` and a `layout` field. When `layout` is `"absolute-fill"`, the active fields include `Interactive.transformSchema` and `Interactive.premountSchema`.
+It includes `Interactive.baseSchema` and a `layout` field. When `layout` is `"absolute-fill"`, the active fields include `Interactive.transformSchema`, `Interactive.backgroundSchema`, `Interactive.borderSchema` and `Interactive.premountSchema`.
 
 ### `Interactive.withSchema()`<AvailableFrom v="4.0.479" />
 

--- a/packages/docs/docs/interactivity-schema.mdx
+++ b/packages/docs/docs/interactivity-schema.mdx
@@ -49,6 +49,12 @@ Text-related style props: `style.color`, `style.fontFamily`, `style.fontSize`, `
 
 `style.fontFamily` is available from <AvailableFrom v="4.0.486" inline />.
 
+### `Interactive.backgroundSchema`<AvailableFrom v="4.0.497" />
+
+A color control for `style.backgroundColor`.
+
+The `backgroundColor` longhand is used rather than the `background` shorthand so complex backgrounds such as gradients and images can remain untouched.
+
 ### `Interactive.borderSchema`<AvailableFrom v="4.0.497" />
 
 Border-related style props: `style.borderWidth`, `style.borderStyle` and `style.borderColor`.

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -43,6 +43,7 @@ export const gifSchema: InteractivitySchema = {
 		keyframable: false,
 	},
 	...Internals.transformSchema,
+	...Interactive.backgroundSchema,
 	...Interactive.borderSchema,
 } as const satisfies InteractivitySchema;
 

--- a/packages/gif/src/test/Gif.test.tsx
+++ b/packages/gif/src/test/Gif.test.tsx
@@ -14,7 +14,8 @@ type RegisteredSequence = {
 	readonly postmountDisplay: number | null;
 };
 
-test('Gif exposes border controls', () => {
+test('Gif exposes background and border controls', () => {
+	expect('style.backgroundColor' in gifSchema).toBe(true);
 	expect('style.borderWidth' in gifSchema).toBe(true);
 	expect('style.borderStyle' in gifSchema).toBe(true);
 	expect('style.borderColor' in gifSchema).toBe(true);

--- a/packages/light-leaks/src/LightLeak.tsx
+++ b/packages/light-leaks/src/LightLeak.tsx
@@ -252,6 +252,7 @@ export const lightLeakSchema: InteractivitySchema = {
 		hiddenFromList: false,
 	},
 	...Internals.transformSchema,
+	...Interactive.backgroundSchema,
 	...Interactive.borderSchema,
 	...Internals.premountSchema,
 } as const satisfies InteractivitySchema;

--- a/packages/light-leaks/src/test/light-leak-effect-params.test.ts
+++ b/packages/light-leaks/src/test/light-leak-effect-params.test.ts
@@ -2,7 +2,8 @@ import {expect, test} from 'bun:test';
 import {LightLeakInternals, lightLeak} from '../light-leak-internals.js';
 import {lightLeakSchema} from '../LightLeak.js';
 
-test('<LightLeak> exposes border controls', () => {
+test('<LightLeak> exposes background and border controls', () => {
+	expect('style.backgroundColor' in lightLeakSchema).toBe(true);
 	expect('style.borderWidth' in lightLeakSchema).toBe(true);
 	expect('style.borderStyle' in lightLeakSchema).toBe(true);
 	expect('style.borderColor' in lightLeakSchema).toBe(true);

--- a/packages/media/src/test/border-schema.test.ts
+++ b/packages/media/src/test/border-schema.test.ts
@@ -2,13 +2,15 @@ import {expect, test} from 'vitest';
 import {audioSchema} from '../audio/audio';
 import {videoSchema} from '../video/video';
 
-test('Video exposes border controls', () => {
+test('Video exposes background and border controls', () => {
+	expect('style.backgroundColor' in videoSchema).toBe(true);
 	expect('style.borderWidth' in videoSchema).toBe(true);
 	expect('style.borderStyle' in videoSchema).toBe(true);
 	expect('style.borderColor' in videoSchema).toBe(true);
 });
 
-test('Audio does not expose visual border controls', () => {
+test('Audio does not expose visual background or border controls', () => {
+	expect('style.backgroundColor' in audioSchema).toBe(false);
 	expect('style.borderWidth' in audioSchema).toBe(false);
 	expect('style.borderStyle' in audioSchema).toBe(false);
 	expect('style.borderColor' in audioSchema).toBe(false);

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -48,6 +48,7 @@ export const videoSchema: InteractivitySchema = {
 	muted: {type: 'boolean', default: false, description: 'Muted'},
 	loop: {type: 'boolean', default: false, description: 'Loop'},
 	...Internals.transformSchema,
+	...Interactive.backgroundSchema,
 	...Interactive.borderSchema,
 } as const satisfies InteractivitySchema;
 

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -109,6 +109,7 @@ const riveCanvasSchema = {
 		variants: riveAlignmentVariants,
 	},
 	...Internals.transformSchema,
+	...Interactive.backgroundSchema,
 	...Interactive.borderSchema,
 } as const satisfies InteractivitySchema;
 

--- a/packages/rough-notation/src/Annotation.tsx
+++ b/packages/rough-notation/src/Annotation.tsx
@@ -235,6 +235,7 @@ const sharedSchema = (defaultRoughness: number): InteractivitySchema => ({
 	...colorSchema,
 	...Interactive.textSchema,
 	...textContentSchema,
+	...Interactive.backgroundSchema,
 	...Interactive.borderSchema,
 });
 

--- a/packages/rough-notation/src/test/annotation-schema.test.ts
+++ b/packages/rough-notation/src/test/annotation-schema.test.ts
@@ -65,6 +65,7 @@ test('all named annotations expose text, font, border, and seed controls', () =>
 		expect(keys(schema)).toContain('style.fontWeight');
 		expect(keys(schema)).toContain('style.fontStyle');
 		expect(keys(schema)).toContain('style.letterSpacing');
+		expect(keys(schema)).toContain('style.backgroundColor');
 		expect(keys(schema)).toContain('style.borderWidth');
 		expect(keys(schema)).toContain('style.borderStyle');
 		expect(keys(schema)).toContain('style.borderColor');

--- a/packages/shapes/src/components/schema.ts
+++ b/packages/shapes/src/components/schema.ts
@@ -89,6 +89,7 @@ export const makeShapeSchema = (
 			description: 'Fill',
 		}),
 		...Internals.transformSchema,
+		...Interactive.backgroundSchema,
 		...Interactive.borderSchema,
 	};
 };

--- a/packages/shapes/src/test/effects.test.tsx
+++ b/packages/shapes/src/test/effects.test.tsx
@@ -117,6 +117,9 @@ mock.module('remotion', () => {
 			useMemoizedEffectDefinitions: mock(() => effectDefinitions),
 		},
 		Interactive: {
+			backgroundSchema: {
+				'style.backgroundColor': {},
+			},
 			borderSchema: {
 				'style.borderWidth': {},
 				'style.borderStyle': {},

--- a/packages/shapes/src/test/schema.test.ts
+++ b/packages/shapes/src/test/schema.test.ts
@@ -8,6 +8,7 @@ test('adds a fill control to shape schemas', () => {
 		default: '#0b84ff',
 		description: 'Fill',
 	});
+	expect('style.backgroundColor' in schema).toBe(true);
 	expect('style.borderWidth' in schema).toBe(true);
 	expect('style.borderStyle' in schema).toBe(true);
 	expect('style.borderColor' in schema).toBe(true);

--- a/packages/starburst/src/Starburst.tsx
+++ b/packages/starburst/src/Starburst.tsx
@@ -344,6 +344,7 @@ export const starburstSchema: InteractivitySchema = {
 		hiddenFromList: false,
 	},
 	...Internals.transformSchema,
+	...Interactive.backgroundSchema,
 	...Interactive.borderSchema,
 	...Internals.premountSchema,
 };

--- a/packages/starburst/src/test/starburst-effect-params.test.ts
+++ b/packages/starburst/src/test/starburst-effect-params.test.ts
@@ -97,7 +97,8 @@ test('<Starburst> exposes colors as an array control', () => {
 	});
 });
 
-test('<Starburst> exposes border controls', () => {
+test('<Starburst> exposes background and border controls', () => {
+	expect('style.backgroundColor' in starburstSchema).toBe(true);
 	expect('style.borderWidth' in starburstSchema).toBe(true);
 	expect('style.borderStyle' in starburstSchema).toBe(true);
 	expect('style.borderColor' in starburstSchema).toBe(true);

--- a/packages/studio-server/src/helpers/css-shorthand-properties.ts
+++ b/packages/studio-server/src/helpers/css-shorthand-properties.ts
@@ -1,3 +1,4 @@
+import {parseBackgroundShorthand} from './parse-background-shorthand';
 import {parseBorderShorthand} from './parse-border-shorthand';
 
 type ParsedCssShorthand = Readonly<Record<string, string | number>>;
@@ -22,7 +23,25 @@ const borderShorthand = {
 		borderSidePropertyRegex.test(propertyName),
 } as const satisfies CssShorthandProperty;
 
+const backgroundShorthand = {
+	parentKey: 'style',
+	shorthand: 'background',
+	longhands: [
+		'backgroundColor',
+		'backgroundImage',
+		'backgroundPosition',
+		'backgroundSize',
+		'backgroundRepeat',
+		'backgroundOrigin',
+		'backgroundClip',
+		'backgroundAttachment',
+	],
+	parse: parseBackgroundShorthand,
+	isUnsupportedProperty: () => false,
+} as const satisfies CssShorthandProperty;
+
 export const cssShorthandProperties = [
+	backgroundShorthand,
 	borderShorthand,
 ] as const satisfies readonly CssShorthandProperty[];
 
@@ -37,9 +56,7 @@ export const getCssShorthandForLonghand = ({
 		cssShorthandProperties.find(
 			(property) =>
 				property.parentKey === parentKey &&
-				property.longhands.includes(
-					longhand as (typeof property.longhands)[number],
-				),
+				(property.longhands as readonly string[]).includes(longhand),
 		) ?? null
 	);
 };

--- a/packages/studio-server/src/helpers/parse-background-shorthand.ts
+++ b/packages/studio-server/src/helpers/parse-background-shorthand.ts
@@ -1,0 +1,57 @@
+import {NoReactInternals} from 'remotion/no-react';
+
+export type ParsedBackgroundShorthand = {
+	backgroundAttachment: string;
+	backgroundClip: string;
+	backgroundColor: string;
+	backgroundImage: string;
+	backgroundOrigin: string;
+	backgroundPosition: string;
+	backgroundRepeat: string;
+	backgroundSize: string;
+};
+
+const CSS_WIDE_KEYWORDS = new Set([
+	'inherit',
+	'initial',
+	'revert',
+	'revert-layer',
+	'unset',
+]);
+
+const makeColorOnlyBackground = (
+	backgroundColor: string,
+): ParsedBackgroundShorthand => {
+	return {
+		backgroundColor,
+		backgroundImage: 'none',
+		backgroundPosition: '0% 0%',
+		backgroundSize: 'auto auto',
+		backgroundRepeat: 'repeat',
+		backgroundOrigin: 'padding-box',
+		backgroundClip: 'border-box',
+		backgroundAttachment: 'scroll',
+	};
+};
+
+export const parseBackgroundShorthand = (
+	value: string,
+): ParsedBackgroundShorthand | null => {
+	const trimmed = value.trim();
+	const lowerCaseValue = trimmed.toLowerCase();
+
+	if (trimmed === '' || CSS_WIDE_KEYWORDS.has(lowerCaseValue)) {
+		return null;
+	}
+
+	if (lowerCaseValue === 'none') {
+		return makeColorOnlyBackground('transparent');
+	}
+
+	try {
+		NoReactInternals.processColor(trimmed);
+		return makeColorOnlyBackground(trimmed);
+	} catch {
+		return null;
+	}
+};

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -288,6 +288,128 @@ export const Example = () => {
 	});
 });
 
+test('computeSequencePropsStatus should expand a color-only background shorthand', () => {
+	const input = `import {AbsoluteFill} from 'remotion';
+
+export const Example = () => {
+	return <AbsoluteFill style={{background: 'rgba(1, 2, 3, 0.5)'}} />;
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 4),
+		componentIdentity: null,
+		keys: ['style.backgroundColor'],
+		effects: [],
+		videoConfigValues: null,
+	});
+
+	expect(result.props['style.backgroundColor']).toEqual({
+		status: 'static',
+		codeValue: 'rgba(1, 2, 3, 0.5)',
+	});
+});
+
+test('computeSequencePropsStatus should treat complex and dynamic background shorthands as computed', () => {
+	const inputs = [
+		`import {AbsoluteFill} from 'remotion';
+
+export const Example = () => {
+	return <AbsoluteFill style={{background: 'linear-gradient(red, blue)'}} />;
+};
+`,
+		`import {AbsoluteFill} from 'remotion';
+
+export const Example = ({background}: {background: string}) => {
+	return <AbsoluteFill style={{background}} />;
+};
+`,
+	];
+
+	for (const input of inputs) {
+		const result = computeSequencePropsStatusFromContent({
+			fileContents: input,
+			nodePath: getNodePathFromContent(input, 4),
+			componentIdentity: null,
+			keys: ['style.backgroundColor'],
+			effects: [],
+			videoConfigValues: null,
+		});
+
+		expect(result.props['style.backgroundColor']).toEqual({
+			status: 'computed',
+		});
+	}
+});
+
+test('computeSequencePropsStatus should respect background property order', () => {
+	const input = `import {AbsoluteFill} from 'remotion';
+
+export const Example = () => {
+	return (
+		<>
+			<AbsoluteFill style={{backgroundColor: 'blue', background: 'red'}} />
+			<AbsoluteFill style={{background: 'red', backgroundColor: 'blue'}} />
+		</>
+	);
+};
+`;
+	const beforeShorthand = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 6),
+		componentIdentity: null,
+		keys: ['style.backgroundColor'],
+		effects: [],
+		videoConfigValues: null,
+	});
+	const afterShorthand = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 7),
+		componentIdentity: null,
+		keys: ['style.backgroundColor'],
+		effects: [],
+		videoConfigValues: null,
+	});
+
+	expect(beforeShorthand.props['style.backgroundColor']).toEqual({
+		status: 'static',
+		codeValue: 'red',
+	});
+	expect(afterShorthand.props['style.backgroundColor']).toEqual({
+		status: 'static',
+		codeValue: 'blue',
+	});
+});
+
+test('computeSequencePropsStatus should allow an independent background image', () => {
+	const input = `import {AbsoluteFill} from 'remotion';
+
+export const Example = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundImage: 'linear-gradient(red, blue)',
+				backgroundColor: 'black',
+			}}
+		/>
+	);
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 5),
+		componentIdentity: null,
+		keys: ['style.backgroundColor'],
+		effects: [],
+		videoConfigValues: null,
+	});
+
+	expect(result.props['style.backgroundColor']).toEqual({
+		status: 'static',
+		codeValue: 'black',
+	});
+});
+
 test('canUpdateSequenceProps should flag computed props', () => {
 	const filePath = path.join(__dirname, 'snapshots', 'light-leak-computed.tsx');
 	const result = computeSequencePropsStatus({

--- a/packages/studio-server/src/test/css-shorthand-properties.test.ts
+++ b/packages/studio-server/src/test/css-shorthand-properties.test.ts
@@ -29,11 +29,33 @@ test('registers border longhands and side-specific blockers', () => {
 	expect(border?.isUnsupportedProperty('borderRadius')).toBe(false);
 });
 
+test('registers the background color longhand', () => {
+	const background = getCssShorthandForLonghand({
+		parentKey: 'style',
+		longhand: 'backgroundColor',
+	});
+
+	expect(background?.shorthand).toBe('background');
+	expect(background?.longhands).toEqual([
+		'backgroundColor',
+		'backgroundImage',
+		'backgroundPosition',
+		'backgroundSize',
+		'backgroundRepeat',
+		'backgroundOrigin',
+		'backgroundClip',
+		'backgroundAttachment',
+	]);
+	expect(background?.isUnsupportedProperty('backgroundImage')).toBe(false);
+});
+
 test('selects shorthand migrations from dot-notation update keys', () => {
 	expect(
-		getCssShorthandsForUpdates(['style.opacity', 'style.borderColor']).map(
-			(property) => property.shorthand,
-		),
-	).toEqual(['border']);
+		getCssShorthandsForUpdates([
+			'style.opacity',
+			'style.backgroundColor',
+			'style.borderColor',
+		]).map((property) => property.shorthand),
+	).toEqual(['background', 'border']);
 	expect(getCssShorthandsForUpdates(['style.opacity'])).toEqual([]);
 });

--- a/packages/studio-server/src/test/discriminated-union-update.test.ts
+++ b/packages/studio-server/src/test/discriminated-union-update.test.ts
@@ -52,6 +52,7 @@ test('Should expose absolute-fill variant fields when active', () => {
 		'style.scale',
 		'style.rotate',
 		'style.opacity',
+		'style.backgroundColor',
 		'style.borderWidth',
 		'style.borderStyle',
 		'style.borderColor',

--- a/packages/studio-server/src/test/get-all-schema-keys.test.ts
+++ b/packages/studio-server/src/test/get-all-schema-keys.test.ts
@@ -19,6 +19,7 @@ test('getAllSchemaKeys returns every key across all enum variants', () => {
 			'style.rotate',
 			'style.transformOrigin',
 			'style.opacity',
+			'style.backgroundColor',
 			'style.borderWidth',
 			'style.borderStyle',
 			'style.borderColor',

--- a/packages/studio-server/src/test/parse-background-shorthand.test.ts
+++ b/packages/studio-server/src/test/parse-background-shorthand.test.ts
@@ -1,0 +1,55 @@
+import {expect, test} from 'bun:test';
+import {parseBackgroundShorthand} from '../helpers/parse-background-shorthand';
+
+test('parses color-only background shorthands', () => {
+	for (const backgroundColor of [
+		'red',
+		'#123456',
+		'rgba(1, 2, 3, 0.5)',
+		'hsla(120, 50%, 50%, 0.25)',
+		'transparent',
+	]) {
+		expect(parseBackgroundShorthand(backgroundColor)).toEqual({
+			backgroundColor,
+			backgroundImage: 'none',
+			backgroundPosition: '0% 0%',
+			backgroundSize: 'auto auto',
+			backgroundRepeat: 'repeat',
+			backgroundOrigin: 'padding-box',
+			backgroundClip: 'border-box',
+			backgroundAttachment: 'scroll',
+		});
+	}
+});
+
+test('maps a none background to a transparent color', () => {
+	expect(parseBackgroundShorthand('none')).toEqual({
+		backgroundColor: 'transparent',
+		backgroundImage: 'none',
+		backgroundPosition: '0% 0%',
+		backgroundSize: 'auto auto',
+		backgroundRepeat: 'repeat',
+		backgroundOrigin: 'padding-box',
+		backgroundClip: 'border-box',
+		backgroundAttachment: 'scroll',
+	});
+});
+
+test('rejects complex, dynamic and CSS-wide backgrounds', () => {
+	for (const background of [
+		'',
+		'initial',
+		'inherit',
+		'unset',
+		'revert',
+		'revert-layer',
+		'var(--background)',
+		'linear-gradient(red, blue)',
+		'url(image.png)',
+		'red url(image.png)',
+		'red no-repeat',
+		'red, blue',
+	]) {
+		expect(parseBackgroundShorthand(background)).toBe(null);
+	}
+});

--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -111,6 +111,50 @@ export const Example = () => {
 	expect(oldValueStrings).toEqual(['2']);
 });
 
+test('updateSequenceProps should migrate a color-only background shorthand', async () => {
+	const input = `import {AbsoluteFill} from 'remotion';
+
+export const Example = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundImage: 'url(image.png)',
+				background: 'rgba(10, 20, 30, 0.5)',
+				opacity: 0.5,
+			}}
+		/>
+	);
+};
+`;
+	const {output, oldValueStrings} = await updateSequenceProps({
+		videoConfigValues: null,
+		input,
+		nodePath: lineColumnToNodePath(input, 5),
+		updates: [
+			{
+				key: 'style.backgroundColor',
+				value: '#00ff00',
+				defaultValue: 'transparent',
+			},
+		],
+		schema: NoReactInternals.sequenceSchema,
+		prettierConfigOverride: null,
+	});
+
+	expect(output).not.toContain("background: 'rgba");
+	expect(output).toContain("backgroundColor: '#00ff00'");
+	expect(output).toContain("backgroundImage: 'url(image.png)'");
+	expect(output).toContain("backgroundImage: 'none'");
+	expect(output).toContain("backgroundPosition: '0% 0%'");
+	expect(output).toContain("backgroundSize: 'auto auto'");
+	expect(output).toContain("backgroundRepeat: 'repeat'");
+	expect(output).toContain("backgroundOrigin: 'padding-box'");
+	expect(output).toContain("backgroundClip: 'border-box'");
+	expect(output).toContain("backgroundAttachment: 'scroll'");
+	expect(output).toContain('opacity: 0.5');
+	expect(oldValueStrings).toEqual(['"rgba(10, 20, 30, 0.5)"']);
+});
+
 test('updateSequenceProps should update durationInFrames', async () => {
 	const {output, oldValueStrings} = await updateSequenceProps({
 		videoConfigValues: null,

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -45,6 +45,7 @@ export type SchemaFieldGroup =
 	| 'source'
 	| 'controls'
 	| 'transforms'
+	| 'background'
 	| 'border'
 	| 'text';
 
@@ -58,6 +59,7 @@ export const SCHEMA_FIELD_GROUPS = [
 	{id: 'controls', label: 'Controls'},
 	{id: 'transforms', label: 'Transform'},
 	{id: 'text', label: 'Text'},
+	{id: 'background', label: 'Background'},
 	{id: 'border', label: 'Border'},
 ] as const satisfies readonly SchemaFieldGroupInfo[];
 
@@ -83,6 +85,8 @@ const BORDER_FIELD_KEYS = new Set([
 	'style.borderColor',
 ]);
 
+const BACKGROUND_FIELD_KEYS = new Set(['style.backgroundColor']);
+
 const TEXT_FIELD_KEYS = new Set([
 	'children',
 	'style.color',
@@ -106,6 +110,10 @@ export const getSchemaFieldGroup = (key: string): SchemaFieldGroup => {
 
 	if (BORDER_FIELD_KEYS.has(key)) {
 		return 'border';
+	}
+
+	if (BACKGROUND_FIELD_KEYS.has(key)) {
+		return 'background';
 	}
 
 	if (TEXT_FIELD_KEYS.has(key)) {

--- a/packages/studio-shared/src/test/keyframe-interpolation-function.test.ts
+++ b/packages/studio-shared/src/test/keyframe-interpolation-function.test.ts
@@ -22,6 +22,15 @@ test('border longhand fields keyframe width and color, but not style', () => {
 	);
 });
 
+test('background color is keyframable', () => {
+	expect(
+		isSchemaFieldKeyframable({
+			schema: Interactive.backgroundSchema,
+			key: 'style.backgroundColor',
+		}),
+	).toBe(true);
+});
+
 test('known interpolation functions explicitly support easing', () => {
 	expect(canEditEasingForInterpolationFunction('interpolate')).toBe(true);
 	expect(canEditEasingForInterpolationFunction('interpolateColors')).toBe(true);

--- a/packages/studio-shared/src/test/schema-field-info.test.ts
+++ b/packages/studio-shared/src/test/schema-field-info.test.ts
@@ -199,6 +199,10 @@ test('getFieldsToShow sorts fields by inspector group order', () => {
 				default: 1,
 				hiddenFromList: false,
 			},
+			'style.backgroundColor': {
+				type: 'color',
+				default: 'transparent',
+			},
 			'style.borderWidth': {
 				type: 'number',
 				default: undefined,
@@ -253,6 +257,7 @@ test('getFieldsToShow sorts fields by inspector group order', () => {
 		'style.fontFamily',
 		'style.letterSpacing',
 		'style.textAlign',
+		'style.backgroundColor',
 		'style.borderWidth',
 		'style.borderStyle',
 		'style.borderColor',
@@ -269,6 +274,7 @@ test('getFieldsToShow sorts fields by inspector group order', () => {
 		'text',
 		'text',
 		'text',
+		'background',
 		'border',
 		'border',
 		'border',


### PR DESCRIPTION
## Summary

- add a reusable `backgroundSchema` for editable `style.backgroundColor` values
- expose background color controls on components that already support CSS box styling
- safely migrate color-only `background` shorthands while preserving their reset semantics
- group the field under **Background** in the Studio inspector and document the schema

## Tests

- `bun run build`
- `bun run stylecheck`
- affected package and shorthand migration tests

Closes #8804
