### PR TITLE
Docs: Better document `--disable-headless`

### DIFF
--- a/packages/docs/docs/chromium-flags.mdx
+++ b/packages/docs/docs/chromium-flags.mdx
@@ -71,23 +71,43 @@ Prior to `v3.3.39`, the option was called `Config.Puppeteer.setChromiumIgnoreCer
 
 <Options id="disable-headless" />
 
+Whether a window opens depends on the browser executable:
+
+| Browser executable                                                                               | Opens a window                                |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| Default Chrome Headless Shell                                                                    | No. Chrome Headless Shell has no headed mode. |
+| [Chrome for Testing](/docs/miscellaneous/chrome-headless-shell#using-chrome-for-testing-instead) | Yes.                                          |
+| Custom desktop Chrome or Chromium                                                                | Yes.                                          |
+| Custom Chrome Headless Shell                                                                     | No.                                           |
+
+On Linux, headed mode requires a running display server. It is not available on Remotion Lambda, Cloud Run or Vercel.
+
 ### Via Node.JS APIs
 
-In [`getCompositions()`](/docs/renderer/get-compositions), [`renderStill()`](/docs/renderer/render-still#headless), [`renderMedia()`](/docs/renderer/render-media#headless) and [`renderFrames()`](/docs/renderer/render-frames#headless), you can pass [`chromiumOptions.headless`](/docs/renderer/render-still#headless). You cannot set this option in Lambda.
+In [`getCompositions()`](/docs/renderer/get-compositions), [`renderStill()`](/docs/renderer/render-still#headless), [`renderMedia()`](/docs/renderer/render-media#headless) and [`renderFrames()`](/docs/renderer/render-frames#headless), pass [`chromiumOptions.headless: false`](/docs/renderer/render-still#headless).
+
+Also pass `chromeMode: 'chrome-for-testing'`, or provide a compatible desktop browser using `browserExecutable`.
 
 ### Via CLI flag
 
-Pass [`--disable-headless`](/docs/cli/render#--disable-headless) in one of the following commands: [`remotion compositions`](/docs/cli/compositions), [`remotion render`](/docs/cli/render), [`remotion still`](/docs/cli/still).
+Pass [`--disable-headless`](/docs/cli/render#--disable-headless) together with `--chrome-mode=chrome-for-testing`:
+
+```bash title="Render with a visible Chrome window"
+npx remotion render ... --chrome-mode=chrome-for-testing --disable-headless
+```
+
+The flag is supported by [`remotion compositions`](/docs/cli/compositions), [`remotion render`](/docs/cli/render) and [`remotion still`](/docs/cli/still). Alternatively, combine it with [`--browser-executable`](/docs/cli/render#--browser-executable) to use a custom desktop browser.
 
 ### Via config file
 
-Use [setChromiumHeadlessMode()](/docs/config#setchromiumheadlessmode).
+Use [setChromiumHeadlessMode()](/docs/config#setchromiumheadlessmode) and select Chrome for Testing:
 
-```tsx twoslash
+```tsx twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 
 // ---cut---
 
+Config.setChromeMode('chrome-for-testing');
 Config.setChromiumHeadlessMode(false);
 ```
 

--- a/packages/docs/docs/chromium-flags.mdx
+++ b/packages/docs/docs/chromium-flags.mdx
@@ -67,7 +67,7 @@ Config.setChromiumIgnoreCertificateErrors(true);
 Prior to `v3.3.39`, the option was called `Config.Puppeteer.setChromiumIgnoreCertificateErrors()`.
 :::
 
-## ~`--disable-headless`~
+## `--disable-headless`
 
 <Options id="disable-headless" />
 

--- a/packages/docs/docs/cli/benchmark.mdx
+++ b/packages/docs/docs/cli/benchmark.mdx
@@ -87,7 +87,7 @@ Inherited from [`npx remotion render`](/docs/cli/render#--disable-web-security)
 
 <Options id="dark-mode" />
 
-### ~`--disable-headless`~
+### `--disable-headless`
 
 <Options id="disable-headless" />
 

--- a/packages/docs/docs/cli/compositions.mdx
+++ b/packages/docs/docs/cli/compositions.mdx
@@ -69,7 +69,7 @@ Not to be confused with the [`--timeout` flag when deploying a Lambda function](
 
 <Options id="disable-web-security" />
 
-### ~`--disable-headless`~
+### `--disable-headless`
 
 <Options id="disable-headless" />
 

--- a/packages/docs/docs/cli/render.mdx
+++ b/packages/docs/docs/cli/render.mdx
@@ -212,7 +212,7 @@ Not to be confused with the [`--timeout` flag when deploying a Lambda function](
 
 <Options id="disable-web-security" />
 
-### ~`--disable-headless`~<AvailableFrom v="2.6.5" />
+### `--disable-headless`<AvailableFrom v="2.6.5" />
 
 <Options id="disable-headless" />
 

--- a/packages/docs/docs/cli/still.mdx
+++ b/packages/docs/docs/cli/still.mdx
@@ -100,7 +100,7 @@ Not to be confused with the [`--timeout` flag when deploying a Lambda function](
 
 <Options id="disable-web-security" />
 
-### ~`--disable-headless`~<AvailableFrom v="2.6.5" />
+### `--disable-headless`<AvailableFrom v="2.6.5" />
 
 <Options id="disable-headless" />
 

--- a/packages/docs/docs/lambda/cli/compositions.mdx
+++ b/packages/docs/docs/lambda/cli/compositions.mdx
@@ -108,7 +108,7 @@ This will most notably disable CORS in Chrome among other security features.
 
 <Options id="dark-mode" />
 
-### ~`--disable-headless`~
+### `--disable-headless`
 
 <Options id="disable-headless" />
 

--- a/packages/docs/docs/renderer/render-media.mdx
+++ b/packages/docs/docs/renderer/render-media.mdx
@@ -391,7 +391,7 @@ _boolean - default `false`_
 
 Results in invalid SSL certificates, such as self-signed ones, being ignored.
 
-#### ~`headless?`~
+#### `headless?`
 
 <Options id="disable-headless" />
 

--- a/packages/docs/docs/renderer/render-still.mdx
+++ b/packages/docs/docs/renderer/render-still.mdx
@@ -177,7 +177,7 @@ _boolean - default `false`_
 
 Results in invalid SSL certificates, such as self-signed ones, being ignored.
 
-#### ~`headless?`~
+#### `headless?`
 
 <Options id="disable-headless" />
 

--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -20,17 +20,6 @@ import type {optionsMap} from './options/options-map';
 
 type OpenGlRenderer = (typeof validOpenGlRenderers)[number];
 
-type OnlyV4Options =
-	typeof NoReactInternals.ENABLE_V5_BREAKING_CHANGES extends true
-		? {}
-		: {
-				/**
-				 * @deprecated - Will be removed in v5.
-				 * Chrome Headless shell does not allow disabling headless mode anymore.
-				 */
-				headless?: boolean;
-			};
-
 // ⚠️ When adding new options, also add them to the hash in lambda/get-browser-instance.ts!
 export type ChromiumOptions = {
 	ignoreCertificateErrors?: boolean;
@@ -39,7 +28,12 @@ export type ChromiumOptions = {
 	userAgent?: string | null;
 	enableMultiProcessOnLinux?: boolean;
 	darkMode?: boolean;
-} & OnlyV4Options;
+	/**
+	 * Opens a browser window if Chrome for Testing or a custom Chrome/Chromium
+	 * executable is used. Chrome Headless Shell always runs headlessly.
+	 */
+	headless?: boolean;
+};
 
 const featuresToEnable = (option?: OpenGlRenderer | null) => {
 	const renderer = option ?? DEFAULT_OPENGL_RENDERER;

--- a/packages/renderer/src/options/headless.tsx
+++ b/packages/renderer/src/options/headless.tsx
@@ -10,14 +10,11 @@ export const headlessOption = {
 	cliFlag,
 	description: () => (
 		<>
-			Deprecated - will be removed in 5.0.0. With the migration to{' '}
-			<a href="/docs/miscellaneous/chrome-headless-shell">
-				Chrome Headless Shell
-			</a>
-			, this option is not functional anymore.
-			<br />
-			<br /> If disabled, the render will open an actual Chrome window where you
-			can see the render happen. The default is headless mode.
+			If disabled, the render will open an actual Chrome window where you can
+			see the render happen. This requires{' '}
+			<a href="/docs/miscellaneous/chrome-headless-shell">Chrome for Testing</a>{' '}
+			or a custom Chrome or Chromium executable. Chrome Headless Shell always
+			runs headlessly. The default is headless mode.
 		</>
 	),
 	ssrName: 'headless',


### PR DESCRIPTION
## Summary

- keep `chromiumOptions.headless`, `Config.setChromiumHeadlessMode()`, and `--disable-headless` available in Remotion 5
- clarify that headed mode works with Chrome for Testing and custom full Chrome/Chromium binaries
- document that headed mode does not work with the default Chrome Headless Shell binary or serverless rendering environments

Context: #9488

## Validation

- `bun run build`
- `bun run formatting`
- `cd packages/docs && bun render-cards.ts`
- `bun run build-docs`
