### PR TITLE
`@remotion/studio`: Make timeline zoom logarithmic

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
@@ -1,7 +1,11 @@
 import {PlayerInternals} from '@remotion/player';
-import {createContext, useContext, useMemo} from 'react';
+import {createContext, useContext, useLayoutEffect, useMemo} from 'react';
 import {Internals} from 'remotion';
-import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
+import {
+	getMaxTimelineZoom,
+	TIMELINE_MIN_ZOOM,
+	TimelineZoomCtx,
+} from '../../state/timeline-zoom';
 import {scrollableRef, sliderAreaRef} from './timeline-refs';
 
 type TimelineWidthContextType = number | null;
@@ -16,22 +20,41 @@ export const TimelineWidthProvider: React.FC<{
 		triggerOnWindowResize: false,
 		shouldApplyCssTransforms: true,
 	});
-	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
+	const videoConfig = Internals.useUnsafeVideoConfig();
+	const {setMaxZoom, zoom: zoomMap} = useContext(TimelineZoomCtx);
 	const {canvasContent} = useContext(Internals.CompositionManager);
+	const timelineViewportWidth =
+		size?.width ?? scrollableRef.current?.clientWidth ?? null;
+	const compositionId =
+		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
+	const maxZoom =
+		videoConfig && timelineViewportWidth
+			? getMaxTimelineZoom({
+					durationInFrames: videoConfig.durationInFrames,
+					timelineViewportWidth,
+				})
+			: null;
+
+	useLayoutEffect(() => {
+		if (compositionId === null || maxZoom === null) {
+			return;
+		}
+
+		setMaxZoom(compositionId, maxZoom);
+	}, [compositionId, maxZoom, setMaxZoom]);
 
 	const width = useMemo(() => {
 		const zoom =
-			canvasContent?.type === 'composition'
-				? (zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM)
+			compositionId !== null
+				? (zoomMap[compositionId] ?? TIMELINE_MIN_ZOOM)
 				: TIMELINE_MIN_ZOOM;
 
-		const scrollableWidth = size?.width ?? scrollableRef.current?.clientWidth;
-		if (scrollableWidth === undefined) {
+		if (timelineViewportWidth === null) {
 			return sliderAreaRef.current?.clientWidth ?? null;
 		}
 
-		return scrollableWidth * zoom;
-	}, [canvasContent, size?.width, zoomMap]);
+		return timelineViewportWidth * zoom;
+	}, [compositionId, timelineViewportWidth, zoomMap]);
 
 	return (
 		<TimelineWidthContext.Provider value={width}>

--- a/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
@@ -4,11 +4,7 @@ import {BLACK, CURRENT_COLOR_LOWERCASE, WHITE} from '../../helpers/colors';
 import {useIsStill} from '../../helpers/is-current-selected-still';
 import {Minus} from '../../icons/minus';
 import {Plus} from '../../icons/plus';
-import {
-	TIMELINE_MAX_ZOOM,
-	TIMELINE_MIN_ZOOM,
-	TimelineZoomCtx,
-} from '../../state/timeline-zoom';
+import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
 import {ControlButton} from '../ControlButton';
 import {Spacing} from '../layout';
@@ -31,7 +27,11 @@ const iconStyle: React.CSSProperties = {
 
 export const TimelineZoomControls: React.FC = () => {
 	const {canvasContent} = useContext(Internals.CompositionManager);
-	const {setZoom, zoom: zoomMap} = useContext(TimelineZoomCtx);
+	const {
+		maxZoom: maxZoomMap,
+		setZoom,
+		zoom: zoomMap,
+	} = useContext(TimelineZoomCtx);
 	const {tabIndex} = useZIndex();
 
 	const onMinusClicked = useCallback(() => {
@@ -51,11 +51,10 @@ export const TimelineZoomControls: React.FC = () => {
 			return;
 		}
 
-		setZoom(
-			canvasContent.compositionId,
-			(z) => Math.min(TIMELINE_MAX_ZOOM, z + 0.2),
-			{anchorFrame: null, anchorContentX: null},
-		);
+		setZoom(canvasContent.compositionId, (z) => z + 0.2, {
+			anchorFrame: null,
+			anchorContentX: null,
+		});
 	}, [canvasContent, setZoom]);
 
 	const onChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
@@ -83,6 +82,7 @@ export const TimelineZoomControls: React.FC = () => {
 	}
 
 	const zoom = zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM;
+	const maxZoom = maxZoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM;
 
 	return (
 		<div style={container}>
@@ -104,7 +104,7 @@ export const TimelineZoomControls: React.FC = () => {
 				min={TIMELINE_MIN_ZOOM}
 				step={0.1}
 				value={zoom}
-				max={TIMELINE_MAX_ZOOM}
+				max={maxZoom}
 				onChange={onChange}
 				className="__remotion-timeline-slider"
 				tabIndex={tabIndex}
@@ -116,7 +116,7 @@ export const TimelineZoomControls: React.FC = () => {
 				title="Zoom in timeline"
 				role={'button'}
 				type="button"
-				disabled={TIMELINE_MAX_ZOOM === zoom}
+				disabled={maxZoom === zoom}
 			>
 				<Plus color={CURRENT_COLOR_LOWERCASE} style={iconStyle} />
 			</ControlButton>

--- a/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
@@ -4,7 +4,12 @@ import {BLACK, CURRENT_COLOR_LOWERCASE, WHITE} from '../../helpers/colors';
 import {useIsStill} from '../../helpers/is-current-selected-still';
 import {Minus} from '../../icons/minus';
 import {Plus} from '../../icons/plus';
-import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
+import {
+	getTimelineZoomFromSliderValue,
+	getTimelineZoomSliderValue,
+	TIMELINE_MIN_ZOOM,
+	TimelineZoomCtx,
+} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
 import {ControlButton} from '../ControlButton';
 import {Spacing} from '../layout';
@@ -25,6 +30,8 @@ const iconStyle: React.CSSProperties = {
 	width: 14,
 };
 
+const ZOOM_BUTTON_FACTOR = 1.2;
+
 export const TimelineZoomControls: React.FC = () => {
 	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {
@@ -33,17 +40,22 @@ export const TimelineZoomControls: React.FC = () => {
 		zoom: zoomMap,
 	} = useContext(TimelineZoomCtx);
 	const {tabIndex} = useZIndex();
+	const compositionId =
+		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
+	const maxZoom =
+		compositionId === null
+			? TIMELINE_MIN_ZOOM
+			: (maxZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM);
 
 	const onMinusClicked = useCallback(() => {
 		if (canvasContent === null || canvasContent.type !== 'composition') {
 			return;
 		}
 
-		setZoom(
-			canvasContent.compositionId,
-			(z) => Math.max(TIMELINE_MIN_ZOOM, z - 0.2),
-			{anchorFrame: null, anchorContentX: null},
-		);
+		setZoom(canvasContent.compositionId, (z) => z / ZOOM_BUTTON_FACTOR, {
+			anchorFrame: null,
+			anchorContentX: null,
+		});
 	}, [canvasContent, setZoom]);
 
 	const onPlusClicked = useCallback(() => {
@@ -51,7 +63,7 @@ export const TimelineZoomControls: React.FC = () => {
 			return;
 		}
 
-		setZoom(canvasContent.compositionId, (z) => z + 0.2, {
+		setZoom(canvasContent.compositionId, (z) => z * ZOOM_BUTTON_FACTOR, {
 			anchorFrame: null,
 			anchorContentX: null,
 		});
@@ -63,12 +75,20 @@ export const TimelineZoomControls: React.FC = () => {
 				return;
 			}
 
-			setZoom(canvasContent.compositionId, () => Number(e.target.value), {
-				anchorFrame: null,
-				anchorContentX: null,
-			});
+			setZoom(
+				canvasContent.compositionId,
+				() =>
+					getTimelineZoomFromSliderValue({
+						maxZoom,
+						sliderValue: Number(e.target.value),
+					}),
+				{
+					anchorFrame: null,
+					anchorContentX: null,
+				},
+			);
 		},
-		[canvasContent, setZoom],
+		[canvasContent, maxZoom, setZoom],
 	);
 
 	const isStill = useIsStill();
@@ -82,7 +102,7 @@ export const TimelineZoomControls: React.FC = () => {
 	}
 
 	const zoom = zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM;
-	const maxZoom = maxZoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM;
+	const sliderValue = getTimelineZoomSliderValue({maxZoom, zoom});
 
 	return (
 		<div style={container}>
@@ -101,13 +121,14 @@ export const TimelineZoomControls: React.FC = () => {
 				title={`Timeline zoom (${zoom}x)`}
 				alt={`Timeline zoom (${zoom}x)`}
 				type={'range'}
-				min={TIMELINE_MIN_ZOOM}
-				step={0.1}
-				value={zoom}
-				max={maxZoom}
+				min={0}
+				step={0.001}
+				value={sliderValue}
+				max={1}
 				onChange={onChange}
 				className="__remotion-timeline-slider"
 				tabIndex={tabIndex}
+				disabled={maxZoom === TIMELINE_MIN_ZOOM}
 			/>
 			<Spacing x={0.5} />
 			<ControlButton

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -17,6 +17,41 @@ import {TIMELINE_PADDING} from '../helpers/timeline-layout';
 export const TIMELINE_MIN_ZOOM = 1;
 const MINIMUM_FRAME_WIDTH = 20;
 
+export const getTimelineZoomSliderValue = ({
+	maxZoom,
+	zoom,
+}: {
+	maxZoom: number;
+	zoom: number;
+}) => {
+	if (maxZoom <= TIMELINE_MIN_ZOOM) {
+		return 0;
+	}
+
+	const clampedZoom = Math.min(maxZoom, Math.max(TIMELINE_MIN_ZOOM, zoom));
+	return (
+		Math.log(clampedZoom / TIMELINE_MIN_ZOOM) /
+		Math.log(maxZoom / TIMELINE_MIN_ZOOM)
+	);
+};
+
+export const getTimelineZoomFromSliderValue = ({
+	maxZoom,
+	sliderValue,
+}: {
+	maxZoom: number;
+	sliderValue: number;
+}) => {
+	if (maxZoom <= TIMELINE_MIN_ZOOM) {
+		return TIMELINE_MIN_ZOOM;
+	}
+
+	const clampedSliderValue = Math.min(1, Math.max(0, sliderValue));
+	return (
+		TIMELINE_MIN_ZOOM * (maxZoom / TIMELINE_MIN_ZOOM) ** clampedSliderValue
+	);
+};
+
 export const getMaxTimelineZoom = ({
 	durationInFrames,
 	timelineViewportWidth,

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -1,4 +1,10 @@
-import React, {createContext, useCallback, useMemo, useState} from 'react';
+import React, {
+	createContext,
+	useCallback,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {flushSync} from 'react-dom';
 import {
 	getCurrentDuration,
@@ -6,9 +12,28 @@ import {
 } from '../components/Timeline/imperative-state';
 import {prepareToPreserveTimelineCursor} from '../components/Timeline/timeline-scroll-logic';
 import {getZoomFromLocalStorage} from '../components/ZoomPersistor';
+import {TIMELINE_PADDING} from '../helpers/timeline-layout';
 
 export const TIMELINE_MIN_ZOOM = 1;
-export const TIMELINE_MAX_ZOOM = 5;
+const MINIMUM_FRAME_WIDTH = 20;
+
+export const getMaxTimelineZoom = ({
+	durationInFrames,
+	timelineViewportWidth,
+}: {
+	durationInFrames: number;
+	timelineViewportWidth: number;
+}) => {
+	if (durationInFrames <= 0 || timelineViewportWidth <= 0) {
+		return TIMELINE_MIN_ZOOM;
+	}
+
+	const zoom =
+		(durationInFrames * MINIMUM_FRAME_WIDTH + TIMELINE_PADDING * 2) /
+		timelineViewportWidth;
+
+	return Math.max(TIMELINE_MIN_ZOOM, Math.ceil(zoom * 10) / 10);
+};
 
 export type TimelineSetZoomOptions = {
 	anchorFrame: number | null;
@@ -17,6 +42,8 @@ export type TimelineSetZoomOptions = {
 
 export const TimelineZoomCtx = createContext<{
 	zoom: Record<string, number>;
+	maxZoom: Record<string, number>;
+	setMaxZoom: (compositionId: string, maxZoom: number) => void;
 	setZoom: (
 		compositionId: string,
 		prev: (prevZoom: number) => number,
@@ -24,6 +51,10 @@ export const TimelineZoomCtx = createContext<{
 	) => void;
 }>({
 	zoom: {},
+	maxZoom: {},
+	setMaxZoom: () => {
+		throw new Error('has no context');
+	},
 	setZoom: () => {
 		throw new Error('has no context');
 	},
@@ -34,6 +65,33 @@ export const TimelineZoomContext: React.FC<{
 }> = ({children}) => {
 	const [zoom, setZoomState] = useState<Record<string, number>>(() =>
 		getZoomFromLocalStorage(),
+	);
+	const [maxZoom, setMaxZoomState] = useState<Record<string, number>>({});
+	const maxZoomRef = useRef(maxZoom);
+	maxZoomRef.current = maxZoom;
+
+	const setMaxZoom = useCallback(
+		(compositionId: string, newMaxZoom: number) => {
+			setZoomState((previousZoom) => {
+				const zoomForComposition = previousZoom[compositionId];
+				if (
+					zoomForComposition === undefined ||
+					zoomForComposition <= newMaxZoom
+				) {
+					return previousZoom;
+				}
+
+				return {...previousZoom, [compositionId]: newMaxZoom};
+			});
+			setMaxZoomState((previousMaxZoom) => {
+				if (previousMaxZoom[compositionId] === newMaxZoom) {
+					return previousMaxZoom;
+				}
+
+				return {...previousMaxZoom, [compositionId]: newMaxZoom};
+			});
+		},
+		[],
 	);
 
 	const setZoom = useCallback(
@@ -52,12 +110,14 @@ export const TimelineZoomContext: React.FC<{
 
 			flushSync(() => {
 				setZoomState((prevZoomMap) => {
+					const maximumZoom = maxZoomRef.current[compositionId] ?? Infinity;
+					const previousZoom = Math.min(
+						maximumZoom,
+						prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM,
+					);
 					const newZoomWithFloatingPointErrors = Math.min(
-						TIMELINE_MAX_ZOOM,
-						Math.max(
-							TIMELINE_MIN_ZOOM,
-							callback(prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM),
-						),
+						maximumZoom,
+						Math.max(TIMELINE_MIN_ZOOM, callback(previousZoom)),
 					);
 					const newZoom = Math.round(newZoomWithFloatingPointErrors * 10) / 10;
 
@@ -73,11 +133,20 @@ export const TimelineZoomContext: React.FC<{
 	);
 
 	const value = useMemo(() => {
+		const constrainedZoom = Object.fromEntries(
+			Object.entries(zoom).map(([compositionId, zoomLevel]) => [
+				compositionId,
+				Math.min(zoomLevel, maxZoom[compositionId] ?? Infinity),
+			]),
+		);
+
 		return {
-			zoom,
+			zoom: constrainedZoom,
+			maxZoom,
+			setMaxZoom,
 			setZoom,
 		};
-	}, [zoom, setZoom]);
+	}, [maxZoom, setMaxZoom, setZoom, zoom]);
 
 	return (
 		<TimelineZoomCtx.Provider value={value}>

--- a/packages/studio/src/test/timeline-zoom.test.ts
+++ b/packages/studio/src/test/timeline-zoom.test.ts
@@ -1,0 +1,53 @@
+import {expect, test} from 'bun:test';
+import {getFrameIncrementFromWidth} from '../components/Timeline/timeline-scroll-logic';
+import {getMaxTimelineZoom, TIMELINE_MIN_ZOOM} from '../state/timeline-zoom';
+
+test('makes each frame at least 20 pixels wide at maximum zoom', () => {
+	const durationInFrames = 100;
+	const timelineViewportWidth = 1000;
+	const maxZoom = getMaxTimelineZoom({
+		durationInFrames,
+		timelineViewportWidth,
+	});
+
+	expect(maxZoom).toBe(2.1);
+	expect(
+		getFrameIncrementFromWidth(
+			durationInFrames,
+			timelineViewportWidth * maxZoom,
+		),
+	).toBeGreaterThanOrEqual(20);
+	expect(
+		getFrameIncrementFromWidth(
+			durationInFrames,
+			timelineViewportWidth * (maxZoom - 0.1),
+		),
+	).toBeLessThan(20);
+});
+
+test('supports maximum zoom levels above the old fixed limit', () => {
+	expect(
+		getMaxTimelineZoom({
+			durationInFrames: 1000,
+			timelineViewportWidth: 800,
+		}),
+	).toBe(25.1);
+});
+
+test('does not allow zooming out beyond the minimum zoom', () => {
+	expect(
+		getMaxTimelineZoom({
+			durationInFrames: 10,
+			timelineViewportWidth: 1000,
+		}),
+	).toBe(TIMELINE_MIN_ZOOM);
+});
+
+test('handles an unavailable timeline viewport', () => {
+	expect(
+		getMaxTimelineZoom({
+			durationInFrames: 100,
+			timelineViewportWidth: 0,
+		}),
+	).toBe(TIMELINE_MIN_ZOOM);
+});

--- a/packages/studio/src/test/timeline-zoom.test.ts
+++ b/packages/studio/src/test/timeline-zoom.test.ts
@@ -1,6 +1,38 @@
 import {expect, test} from 'bun:test';
 import {getFrameIncrementFromWidth} from '../components/Timeline/timeline-scroll-logic';
-import {getMaxTimelineZoom, TIMELINE_MIN_ZOOM} from '../state/timeline-zoom';
+import {
+	getMaxTimelineZoom,
+	getTimelineZoomFromSliderValue,
+	getTimelineZoomSliderValue,
+	TIMELINE_MIN_ZOOM,
+} from '../state/timeline-zoom';
+
+test('maps the timeline zoom slider logarithmically', () => {
+	expect(
+		getTimelineZoomFromSliderValue({
+			maxZoom: 100,
+			sliderValue: 0,
+		}),
+	).toBe(1);
+	expect(
+		getTimelineZoomFromSliderValue({
+			maxZoom: 100,
+			sliderValue: 0.5,
+		}),
+	).toBe(10);
+	expect(
+		getTimelineZoomFromSliderValue({
+			maxZoom: 100,
+			sliderValue: 1,
+		}),
+	).toBe(100);
+	expect(
+		getTimelineZoomSliderValue({
+			maxZoom: 100,
+			zoom: 10,
+		}),
+	).toBeCloseTo(0.5);
+});
 
 test('makes each frame at least 20 pixels wide at maximum zoom', () => {
 	const durationInFrames = 100;


### PR DESCRIPTION
## Summary

- derive the maximum timeline zoom from the composition duration and measured viewport width
- map the slider logarithmically and use proportional button steps so large zoom ranges remain usable
- keep zoom controls, gestures, rendering, and persisted zoom constrained to the dynamic maximum
- test the logarithmic mapping and that maximum zoom gives every frame at least 20 pixels

## Tests

- `bun test packages/studio/src`
- `bun run build`
- `bun run stylecheck`

Closes https://github.com/remotion-dev/remotion/issues/9511
