### PR TITLE
`@remotion/renderer`: Deprecate getVideoMetadata()

### DIFF
--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -76,7 +76,7 @@ Use `logLevel: "verbose"` instead.
 
 Use [Mediabunny to get video metadata](/docs/mediabunny/metadata) instead.
 
-**Required action**: Replace calls to `getVideoMetadata()` from `@remotion/renderer` with the Mediabunny method.
+**Required action**: Replace calls to `getVideoMetadata()` from `@remotion/renderer` with [getting metadata using Mediabunny](/docs/mediabunny/metadata).
 
 ## `diskSizeInMb` is now 10240 by default
 

--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -72,6 +72,12 @@ The default value of `overwrite` has been changed to `true` in `renderMediaOnLam
 The `shouldDumpIo` option has been be removed in 5.0.  
 Use `logLevel: "verbose"` instead.
 
+## `getVideoMetadata()` has been removed from `@remotion/renderer`
+
+Use [Mediabunny to get video metadata](/docs/mediabunny/metadata) instead.
+
+**Required action**: Replace calls to `getVideoMetadata()` from `@remotion/renderer` with the Mediabunny method.
+
 ## `diskSizeInMb` is now 10240 by default
 
 For Remotion Lambda, the default disk size is now 10240 MB.  

--- a/packages/docs/docs/renderer/get-video-metadata.mdx
+++ b/packages/docs/docs/renderer/get-video-metadata.mdx
@@ -5,11 +5,10 @@ title: getVideoMetadata()
 crumb: '@remotion/renderer'
 ---
 
-# getVideoMetadata()<AvailableFrom v="4.0.6" />
+# ~~getVideoMetadata()~~<AvailableFrom v="4.0.6" />
 
 :::note
-Deprecated.  
-Better solution: [Get metadata using Mediabunny](/docs/mediabunny/metadata)
+Deprecated in favor of [getting metadata using Mediabunny](/docs/mediabunny/metadata).
 :::
 
 :::note

--- a/packages/renderer/src/get-video-metadata.ts
+++ b/packages/renderer/src/get-video-metadata.ts
@@ -1,4 +1,5 @@
 import {resolve} from 'node:path';
+import {NoReactInternals} from 'remotion/no-react';
 import {startLongRunningCompositor} from './compositor/compositor';
 import type {VideoMetadata} from './compositor/payloads';
 import type {LogLevel} from './log-level';
@@ -6,12 +7,18 @@ import type {LogLevel} from './log-level';
 export {VideoMetadata} from './compositor/payloads';
 
 /**
- * @deprecated Use `parseMedia()` instead: https://www.remotion.dev/docs/media-parser/parse-media
+ * @deprecated Use Mediabunny instead: https://www.remotion.dev/docs/mediabunny/metadata
  */
 export const getVideoMetadata = async (
 	videoSource: string,
 	options?: {logLevel?: LogLevel; binariesDirectory?: string | null},
 ): Promise<VideoMetadata> => {
+	if (NoReactInternals.ENABLE_V5_BREAKING_CHANGES) {
+		throw new Error(
+			'getVideoMetadata() has been removed in Remotion 5. Use Mediabunny instead: https://www.remotion.dev/docs/mediabunny/metadata',
+		);
+	}
+
 	const compositor = startLongRunningCompositor({
 		maximumFrameCacheItemsInBytes: null,
 		logLevel: options?.logLevel ?? 'info',


### PR DESCRIPTION
## Summary

- deprecate `getVideoMetadata()` in favor of Mediabunny
- make the API throw a migration-focused error when v5 breaking changes are enabled
- document the removal in the v5 migration guide

## Validation

- `bun run build`
- `bun run stylecheck`
- production docs build with all Twoslash snippets
- renderer metadata and render-still tests

Closes #9496

## Preview

- [v5.0 migration guide](https://remotion-git-codex-deprecate-renderer-get-video-79bc9a-remotion.vercel.app/docs/5-0-migration)
- [`getVideoMetadata()` documentation](https://remotion-git-codex-deprecate-renderer-get-video-79bc9a-remotion.vercel.app/docs/renderer/get-video-metadata)
