### PR TITLE
`remotion`: Enable buffering defaults in v5

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -37,6 +37,7 @@ import {useBufferState} from './use-buffer-state.js';
 import {useDelayRender} from './use-delay-render.js';
 import {usePremounting} from './use-premounting.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
+import {resolveV5Default} from './v5-flag.js';
 import {withInteractivitySchema} from './with-interactivity-schema.js';
 
 function exponentialBackoff(errorCount: number): number {
@@ -548,6 +549,7 @@ const ImgInner: React.FC<
 	...props
 }) => {
 	const refForOutline = useRef<HTMLElement | null>(null);
+	const shouldPauseWhenLoading = resolveV5Default(pauseWhenLoading);
 
 	if (effects.length === 0) {
 		return (
@@ -573,7 +575,7 @@ const ImgInner: React.FC<
 				className={className}
 				style={style}
 				id={id}
-				pauseWhenLoading={pauseWhenLoading}
+				pauseWhenLoading={shouldPauseWhenLoading}
 				maxRetries={maxRetries}
 				delayRenderRetries={delayRenderRetries}
 				delayRenderTimeoutInMilliseconds={delayRenderTimeoutInMilliseconds}
@@ -608,7 +610,7 @@ const ImgInner: React.FC<
 			className={className}
 			style={style}
 			id={id}
-			pauseWhenLoading={pauseWhenLoading}
+			pauseWhenLoading={shouldPauseWhenLoading}
 			maxRetries={maxRetries}
 			delayRenderRetries={delayRenderRetries}
 			delayRenderTimeoutInMilliseconds={delayRenderTimeoutInMilliseconds}

--- a/packages/core/src/audio/html5-audio.tsx
+++ b/packages/core/src/audio/html5-audio.tsx
@@ -9,6 +9,7 @@ import {usePreload} from '../prefetch.js';
 import {Sequence} from '../Sequence.js';
 import {useRemotionEnvironment} from '../use-remotion-environment.js';
 import {useVideoConfig} from '../use-video-config.js';
+import {resolveV5Default} from '../v5-flag.js';
 import {validateMediaProps} from '../validate-media-props.js';
 import {
 	resolveTrimProps,
@@ -48,6 +49,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 	const {loop, freeze: _freeze, ...propsOtherThanLoop} = propsWithFreeze;
 	const {fps} = useVideoConfig();
 	const environment = useRemotionEnvironment();
+	const shouldPauseWhenBuffering = resolveV5Default(pauseWhenBuffering);
 
 	if (environment.isClientSideRendering) {
 		throw new Error(
@@ -163,7 +165,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 			>
 				<Html5Audio
 					_remotionInternalNeedsDurationCalculation={Boolean(loop)}
-					pauseWhenBuffering={pauseWhenBuffering ?? false}
+					pauseWhenBuffering={shouldPauseWhenBuffering}
 					{...otherProps}
 					ref={ref}
 				/>
@@ -205,8 +207,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 			ref={ref}
 			onNativeError={onError}
 			onDuration={onDuration}
-			// Proposal: Make this default to true in v5
-			pauseWhenBuffering={pauseWhenBuffering ?? false}
+			pauseWhenBuffering={shouldPauseWhenBuffering}
 			_remotionInternalNeedsDurationCalculation={Boolean(loop)}
 			showInTimeline={showInTimeline ?? true}
 		/>

--- a/packages/core/src/test/v5-flag.test.ts
+++ b/packages/core/src/test/v5-flag.test.ts
@@ -1,0 +1,8 @@
+import {expect, test} from 'bun:test';
+import {ENABLE_V5_BREAKING_CHANGES, resolveV5Default} from '../v5-flag.js';
+
+test('resolves a v5 default while preserving explicit values', () => {
+	expect(resolveV5Default(undefined)).toBe(ENABLE_V5_BREAKING_CHANGES);
+	expect(resolveV5Default(false)).toBe(false);
+	expect(resolveV5Default(true)).toBe(true);
+});

--- a/packages/core/src/v5-flag.ts
+++ b/packages/core/src/v5-flag.ts
@@ -1,1 +1,5 @@
 export const ENABLE_V5_BREAKING_CHANGES = false as const;
+
+export const resolveV5Default = (value: boolean | undefined): boolean => {
+	return value ?? ENABLE_V5_BREAKING_CHANGES;
+};

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -2,6 +2,7 @@ import React, {useCallback} from 'react';
 import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
 import {Sequence} from '../Sequence.js';
 import {useRemotionEnvironment} from '../use-remotion-environment.js';
+import {resolveV5Default} from '../v5-flag.js';
 import {validateMediaProps} from '../validate-media-props.js';
 import {
 	resolveTrimProps,
@@ -31,6 +32,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 		...otherProps
 	} = props;
 	const environment = useRemotionEnvironment();
+	const shouldPauseWhenBuffering = resolveV5Default(pauseWhenBuffering);
 
 	if (environment.isClientSideRendering) {
 		throw new Error(
@@ -70,7 +72,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 				name={name}
 			>
 				<InnerOffthreadVideo
-					pauseWhenBuffering={pauseWhenBuffering ?? false}
+					pauseWhenBuffering={shouldPauseWhenBuffering}
 					{...otherProps}
 					trimAfter={undefined}
 					name={undefined}
@@ -89,7 +91,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 	if (environment.isRendering) {
 		return (
 			<OffthreadVideoForRendering
-				pauseWhenBuffering={pauseWhenBuffering ?? false}
+				pauseWhenBuffering={shouldPauseWhenBuffering}
 				{...otherProps}
 				trimAfter={undefined}
 				name={undefined}
@@ -118,7 +120,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 			_remotionInternalStack={stack ?? null}
 			onDuration={onDuration}
 			onlyWarnForMediaSeekingError
-			pauseWhenBuffering={pauseWhenBuffering ?? false}
+			pauseWhenBuffering={shouldPauseWhenBuffering}
 			showInTimeline={showInTimeline ?? true}
 			onAutoPlayError={onAutoPlayError ?? undefined}
 			onVideoFrame={onVideoFrame ?? null}
@@ -187,7 +189,7 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 			onAutoPlayError={onAutoPlayError ?? null}
 			onError={onError}
 			onVideoFrame={onVideoFrame}
-			pauseWhenBuffering={pauseWhenBuffering ?? true}
+			pauseWhenBuffering={resolveV5Default(pauseWhenBuffering)}
 			playbackRate={playbackRate ?? 1}
 			preservePitch={preservePitch}
 			toneFrequency={toneFrequency ?? 1}

--- a/packages/core/src/video/html5-video.tsx
+++ b/packages/core/src/video/html5-video.tsx
@@ -8,6 +8,7 @@ import {usePreload} from '../prefetch.js';
 import {Sequence} from '../Sequence.js';
 import {useRemotionEnvironment} from '../use-remotion-environment.js';
 import {useVideoConfig} from '../use-video-config.js';
+import {resolveV5Default} from '../v5-flag.js';
 import {validateMediaProps} from '../validate-media-props.js';
 import {
 	resolveTrimProps,
@@ -45,6 +46,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 	const {loop, ...propsOtherThanLoop} = props;
 	const {fps} = useVideoConfig();
 	const environment = useRemotionEnvironment();
+	const shouldPauseWhenBuffering = resolveV5Default(pauseWhenBuffering);
 
 	if (environment.isClientSideRendering) {
 		throw new Error(
@@ -140,7 +142,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 				name={name}
 			>
 				<Html5Video
-					pauseWhenBuffering={pauseWhenBuffering ?? false}
+					pauseWhenBuffering={shouldPauseWhenBuffering}
 					onVideoFrame={onVideoFrame}
 					{...otherProps}
 					ref={ref}
@@ -176,8 +178,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			{...otherProps}
 			ref={ref}
 			onVideoFrame={onVideoFrame ?? null}
-			// Proposal: Make this default to true in v5
-			pauseWhenBuffering={pauseWhenBuffering ?? false}
+			pauseWhenBuffering={shouldPauseWhenBuffering}
 			onDuration={onDuration}
 			_remotionInternalStack={stack ?? null}
 			_remotionInternalNativeLoopPassed={

--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -123,6 +123,14 @@ This prevents black frames that were commonly seen when a `<Sequence>` containin
 
 **Required action**: If you don't want this behavior for a specific Sequence, opt out by passing [`premountFor={0}`](/docs/sequence#premountfor).
 
+## Media and images pause playback while loading
+
+[`<Html5Video>`](/docs/html5-video), [`<OffthreadVideo>`](/docs/offthreadvideo), and [`<Html5Audio>`](/docs/html5-audio) now set [`pauseWhenBuffering`](/docs/player/buffer-state) to `true` by default.
+[`<Img>`](/docs/img) now sets [`pauseWhenLoading`](/docs/img#pausewhenloading) to `true` by default.
+This prevents the Player from continuing while media or images are still loading.
+
+**Required action**: If you want to keep the old behavior, set `pauseWhenBuffering={false}` on video and audio components and `pauseWhenLoading={false}` on `<Img>` explicitly.
+
 ## License changes
 
 Remotion 5.0 has an updated license. View the [license](https://github.com/remotion-dev/remotion/blob/5-0-license/LICENSE.md) here or compare the [changes](https://github.com/remotion-dev/remotion/pull/3750).

--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -125,6 +125,8 @@ This prevents black frames that were commonly seen when a `<Sequence>` containin
 
 ## Media and images pause playback while loading
 
+[`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media) have paused playback while loading by default since they were introduced.
+
 [`<Html5Video>`](/docs/html5-video), [`<OffthreadVideo>`](/docs/offthreadvideo), and [`<Html5Audio>`](/docs/html5-audio) now set [`pauseWhenBuffering`](/docs/player/buffer-state) to `true` by default.
 [`<Img>`](/docs/img) now sets [`pauseWhenLoading`](/docs/img#pausewhenloading) to `true` by default.
 This prevents the Player from continuing while media or images are still loading.

--- a/packages/docs/docs/html5-audio.mdx
+++ b/packages/docs/docs/html5-audio.mdx
@@ -210,7 +210,7 @@ In the [Remotion Studio](/docs/terminology/studio) or in the [Remotion Player](/
 
 ### `pauseWhenBuffering?`<AvailableFrom v="4.0.111"/>
 
-If set to `true` and the audio is buffering, the Player will enter into the [native buffering state](/docs/player/buffer-state). The default is `false`, but will become `true` in Remotion 5.0.
+If set to `true` and the audio is buffering, the Player will enter into the [native buffering state](/docs/player/buffer-state). The default is `false` in Remotion 4.0 and `true` in Remotion 5.0.
 
 ### `showInTimeline?`<AvailableFrom v="4.0.122"/>
 

--- a/packages/docs/docs/html5-video.mdx
+++ b/packages/docs/docs/html5-video.mdx
@@ -271,7 +271,7 @@ Handle an error playing the video. From v3.3.89, if you pass an `onError` callba
 
 ### `pauseWhenBuffering?`<AvailableFrom v="4.0.100"/>
 
-If set to `true` and the video is loading, the Player will enter into the [native buffering state](/docs/player/buffer-state). The default is `false`, but will become `true` in Remotion 5.0.
+If set to `true` and the video is loading, the Player will enter into the [native buffering state](/docs/player/buffer-state). The default is `false` in Remotion 4.0 and `true` in Remotion 5.0.
 
 ### `showInTimeline?`<AvailableFrom v="4.0.122"/>
 

--- a/packages/docs/docs/img.mdx
+++ b/packages/docs/docs/img.mdx
@@ -99,7 +99,7 @@ An exponential backoff is being used, with 1000ms delay between the first and se
 
 ### `pauseWhenLoading?`<AvailableFrom v="4.0.111"/>
 
-If set to `true`, pause the Player when the image is loading. See: [Buffer state](/docs/player/buffer-state).
+If set to `true`, pause the Player when the image is loading. The default is `false` in Remotion 4.0 and `true` in Remotion 5.0. See: [Buffer state](/docs/player/buffer-state).
 
 ### `premountFor?`<AvailableFrom v="4.0.497" />
 

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -231,7 +231,7 @@ A `toneFrequency` of 0.5 would lower the pitch by half, and a `toneFrequency` of
 
 ### `pauseWhenBuffering?`<AvailableFrom v="4.0.111"/>
 
-If set to `true` and the video is loading, the Player will enter into the [native buffering state](/docs/player/buffer-state). The default is `false`, but will become `true` in Remotion 5.0.
+If set to `true` and the video is loading, the Player will enter into the [native buffering state](/docs/player/buffer-state). The default is `false` in Remotion 4.0 and `true` in Remotion 5.0.
 
 ### `toneMapped?`<AvailableFrom v="4.0.117" />
 


### PR DESCRIPTION
## Summary

- default `pauseWhenBuffering` to `true` for `<Html5Video>`, `<OffthreadVideo>`, and `<Html5Audio>` when the Remotion 5.0 breaking changes flag is enabled
- default `pauseWhenLoading` to `true` for `<Img>` behind the same flag
- document the new defaults and migration opt-outs

## Testing

- `bun run build`
- `bun run stylecheck`
- focused core tests with the v5 breaking changes flag disabled and enabled

Closes #9494

## Preview

- [v5.0 Migration](https://remotion-git-codex-v5-buffering-defaults-remotion.vercel.app/docs/5-0-migration)
- [`<Html5Video>`](https://remotion-git-codex-v5-buffering-defaults-remotion.vercel.app/docs/html5-video)
- [`<Html5Audio>`](https://remotion-git-codex-v5-buffering-defaults-remotion.vercel.app/docs/html5-audio)
- [`<Img>`](https://remotion-git-codex-v5-buffering-defaults-remotion.vercel.app/docs/img)
- [`<OffthreadVideo>`](https://remotion-git-codex-v5-buffering-defaults-remotion.vercel.app/docs/offthreadvideo)
