### PR TITLE
`@remotion/bundler`: Remove legacy positional signatures

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -77,7 +77,7 @@ export const getBundleStaticHash = (publicPath: string): string => {
 	);
 };
 
-export type MandatoryLegacyBundleOptions = {
+export type MandatoryBundleInternalsOptions = {
 	webpackOverride: WebpackOverrideFn;
 	outDir: string | null;
 	enableCaching: boolean;
@@ -99,8 +99,6 @@ export type MandatoryLegacyBundleOptions = {
 	symlinkPublicDir: boolean;
 };
 
-export type LegacyBundleOptions = Partial<MandatoryLegacyBundleOptions>;
-
 export const getConfig = ({
 	entryPoint,
 	outDir,
@@ -116,7 +114,7 @@ export const getConfig = ({
 	bufferStateDelayInMilliseconds: number | null;
 	maxTimelineTracks: number | null;
 	onProgress: (progress: number) => void;
-	options: MandatoryLegacyBundleOptions;
+	options: MandatoryBundleInternalsOptions;
 }) => {
 	const configArgs = {
 		entry: path.join(
@@ -151,7 +149,6 @@ export const getConfig = ({
 };
 
 type NewBundleOptions = {
-	entryPoint: string;
 	onProgress: (progress: number) => void;
 	ignoreRegisterRootWarning: boolean;
 	onDirectoryCreated: (dir: string) => void;
@@ -165,40 +162,29 @@ type NewBundleOptions = {
 type MandatoryBundleOptions = {
 	entryPoint: string;
 } & NewBundleOptions &
-	MandatoryLegacyBundleOptions;
+	MandatoryBundleInternalsOptions;
 
 export type BundleOptions = {
 	entryPoint: string;
 } & Partial<NewBundleOptions> &
-	LegacyBundleOptions;
+	Partial<MandatoryBundleInternalsOptions>;
 
-type Arguments =
-	| [options: BundleOptions]
-	| [
-			entryPoint: string,
-			onProgress?: (progress: number) => void,
-			options?: LegacyBundleOptions,
-	  ];
+const validateBundleOptions = (options: BundleOptions): BundleOptions => {
+	if (typeof options === 'string') {
+		throw new TypeError(
+			'bundle() no longer supports the legacy positional arguments. Pass an options object instead: bundle({entryPoint, onProgress, ...options}).',
+		);
+	}
 
-const convertArgumentsIntoOptions = (args: Arguments): BundleOptions => {
-	if ((args.length as number) === 0) {
+	if (!options) {
 		throw new TypeError('bundle() was called without arguments');
 	}
 
-	const firstArg = args[0];
-	if (typeof firstArg === 'string') {
-		return {
-			entryPoint: firstArg,
-			onProgress: args[1],
-			...(args[2] ?? {}),
-		};
-	}
-
-	if (typeof firstArg.entryPoint !== 'string') {
+	if (typeof options.entryPoint !== 'string') {
 		throw new TypeError('bundle() was called without the `entryPoint` option');
 	}
 
-	return firstArg;
+	return options;
 };
 
 const recursionLimit = 5;
@@ -451,8 +437,8 @@ export const internalBundle = async (
  * @description Bundles a Remotion project using Webpack and prepares it for rendering.
  * @see [Documentation](https://remotion.dev/docs/bundle)
  */
-export async function bundle(...args: Arguments): Promise<string> {
-	const actualArgs = convertArgumentsIntoOptions(args);
+export async function bundle(options: BundleOptions): Promise<string> {
+	const actualArgs = validateBundleOptions(options);
 	const result = await internalBundle({
 		bufferStateDelayInMilliseconds:
 			actualArgs.bufferStateDelayInMilliseconds ?? null,

--- a/packages/bundler/src/index.ts
+++ b/packages/bundler/src/index.ts
@@ -23,12 +23,7 @@ export const BundlerInternals = {
 };
 
 export type {GitSource} from '@remotion/studio-shared';
-export {
-	bundle,
-	BundleOptions,
-	LegacyBundleOptions,
-	MandatoryLegacyBundleOptions,
-} from './bundle';
+export {bundle, BundleOptions, MandatoryBundleInternalsOptions} from './bundle';
 export {WebpackConfiguration, WebpackOverrideFn} from './webpack-config';
 export {WatchIgnoreNextChangePlugin};
 export {webpack};

--- a/packages/bundler/src/test/validate-bundle.test.ts
+++ b/packages/bundler/src/test/validate-bundle.test.ts
@@ -9,4 +9,9 @@ test('Should reject bad bundle options', () => {
 	expect(() => bundle({})).toThrow(
 		/bundle\(\) was called without the `entryPoint` option/,
 	);
+
+	// @ts-expect-error
+	expect(() => bundle('src/index.ts')).toThrow(
+		'bundle() no longer supports the legacy positional arguments. Pass an options object instead: bundle({entryPoint, onProgress, ...options}).',
+	);
 });

--- a/packages/cli/src/setup-cache.ts
+++ b/packages/cli/src/setup-cache.ts
@@ -1,6 +1,6 @@
 import {existsSync} from 'fs';
 import path from 'path';
-import type {MandatoryLegacyBundleOptions} from '@remotion/bundler';
+import type {MandatoryBundleInternalsOptions} from '@remotion/bundler';
 import {BundlerInternals} from '@remotion/bundler';
 import type {LogLevel} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
@@ -206,7 +206,7 @@ export const bundleOnCli = async ({
 		updateProgress(false);
 	};
 
-	const options: MandatoryLegacyBundleOptions = {
+	const options: MandatoryBundleInternalsOptions = {
 		enableCaching: shouldCache,
 		webpackOverride: ConfigInternals.getWebpackOverrideFn() ?? ((f) => f),
 		rootDir: remotionRoot,

--- a/packages/docs/blog/2021-08-11-remotion-2-3.mdx
+++ b/packages/docs/blog/2021-08-11-remotion-2-3.mdx
@@ -62,7 +62,7 @@ npx remotion still --props='{"custom": "data"}'  my-comp out.png
 
 If you render using the Node.JS APIs, we have a new equivalent API for rendering stills as well.
 
-```ts twoslash
+```ts
 import {bundle} from '@remotion/bundler';
 import {getCompositions, renderStill} from '@remotion/renderer';
 

--- a/packages/docs/blog/2022-11-17-remotion-3-3.mdx
+++ b/packages/docs/blog/2022-11-17-remotion-3-3.mdx
@@ -207,7 +207,7 @@ Previously, the progress for rendering and encoding was reported individually. T
 
 Previously, [`bundle()`](/docs/bundle) accepted three arguments: `entryPoint`, `onProgress` and `options`.
 
-```ts twoslash title="Old bundle() signature"
+```ts title="Old bundle() signature"
 import {bundle} from '@remotion/bundler';
 
 bundle('./src/index.ts', (progress) => console.log(progress), {

--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -42,6 +42,20 @@ A common footgun was the render was not working as intended because the input pr
 
 **Required action**: Pass an empty object `{}` if you don't have any input props.
 
+## `bundle()` and `getCompositions()` now take an options object
+
+The legacy positional signatures of [`bundle()`](/docs/bundle) and [`getCompositions()`](/docs/renderer/get-compositions) have been removed.
+
+**Required action**: Move positional arguments into an options object:
+
+```diff title="Before and after"
+- bundle(entryPoint, onProgress, options)
++ bundle({entryPoint, onProgress, ...options})
+
+- getCompositions(serveUrl, options)
++ getCompositions({serveUrl, ...options})
+```
+
 ## `visualizeAudio()` yields different result
 
 [`optimizeFor: "speed"`](/docs/visualize-audio#optimizefor) is now the default. This will yield slightly different results.

--- a/packages/docs/docs/audio/exporting.mdx
+++ b/packages/docs/docs/audio/exporting.mdx
@@ -40,7 +40,9 @@ const compositionId = 'HelloWorld';
 // You only have to do this once, you can reuse the bundle.
 const entry = './src/index';
 console.log('Creating a Webpack bundle of the video');
-const bundleLocation = await bundle(path.resolve(entry), () => undefined, {
+const bundleLocation = await bundle({
+  entryPoint: path.resolve(entry),
+  onProgress: () => undefined,
   // If you have a Webpack override, make sure to add it here
   webpackOverride: (config) => config,
 });
@@ -52,7 +54,8 @@ const inputProps = {
 
 // Extract all the compositions you have defined in your project
 // from the webpack bundle.
-const comps = await getCompositions(bundleLocation, {
+const comps = await getCompositions({
+  serveUrl: bundleLocation,
   // You can pass custom input props that you can retrieve using getInputProps()
   // in the composition list. Use this if you want to dynamically set the duration or
   // dimensions of the video.
@@ -149,7 +152,9 @@ const compositionId = 'HelloWorld';
 // You only have to do this once, you can reuse the bundle.
 const entry = './src/index';
 console.log('Creating a Webpack bundle of the video');
-const bundleLocation = await bundle(path.resolve(entry), () => undefined, {
+const bundleLocation = await bundle({
+  entryPoint: path.resolve(entry),
+  onProgress: () => undefined,
   // If you have a Webpack override, make sure to add it here
   webpackOverride: (config) => config,
 });
@@ -161,7 +166,8 @@ const inputProps = {
 
 // Extract all the compositions you have defined in your project
 // from the webpack bundle.
-const comps = await getCompositions(bundleLocation, {
+const comps = await getCompositions({
+  serveUrl: bundleLocation,
   // You can pass custom input props that you can retrieve using getInputProps()
   // in the composition list. Use this if you want to dynamically set the duration or
   // dimensions of the video.

--- a/packages/docs/docs/bundle.mdx
+++ b/packages/docs/docs/bundle.mdx
@@ -108,35 +108,6 @@ Gets called when a symbolic link is detected in the `public/` directory. Since R
 
 Ignore an error that gets thrown if you pass an entry point file which does not contain `registerRoot`.
 
-## Legacy function signature
-
-Remotion versions earlier than v3.2.17 had the following function signature instead:
-
-```ts
-const bundle: (
-  entryPoint: string,
-  onProgress?: (progress: number) => void,
-  options?: {
-    webpackOverride?: WebpackOverrideFn;
-    outDir?: string;
-    enableCaching?: boolean;
-    publicPath?: string;
-    rootDir?: string;
-    publicDir?: string | null;
-  },
-) => Promise<string>;
-```
-
-Example:
-
-```ts
-await bundle('src/index.ts', () => console.log(progress * 100 + '% done'), {
-  webpackOverride,
-});
-```
-
-It is still supported in Remotion v3, but we encourage to migrate to the new function signature.
-
 ## Return value
 
 A promise which will resolve into a `string` specifying the output directory.

--- a/packages/docs/docs/player/player-integration.mdx
+++ b/packages/docs/docs/player/player-integration.mdx
@@ -197,7 +197,9 @@ In any Node.JS context, you can call [`bundle()`](/docs/bundle) to bundle your v
 import path from 'path';
 import {bundle} from '@remotion/bundler';
 
-const bundled = await bundle(path.join(process.cwd(), 'src', 'remotion', 'index.ts'));
+const bundled = await bundle({
+  entryPoint: path.join(process.cwd(), 'src', 'remotion', 'index.ts'),
+});
 ```
 
 See [Server-side rendering](/docs/ssr) for a full example.

--- a/packages/docs/docs/render-all.mdx
+++ b/packages/docs/docs/render-all.mdx
@@ -49,7 +49,10 @@ const bundled = await bundle({
   webpackOverride: (config) => config,
 });
 
-const compositions = await getCompositions(bundled);
+const compositions = await getCompositions({
+  serveUrl: bundled,
+  inputProps: {},
+});
 
 for (const composition of compositions) {
   console.log(`Rendering ${composition.id}...`);

--- a/packages/docs/docs/renderer/get-compositions.mdx
+++ b/packages/docs/docs/renderer/get-compositions.mdx
@@ -11,8 +11,6 @@ Gets a list of compositions defined in a Remotion project based on a [Remotion B
 
 For every compositions their [`calculateMetadata()`](/docs/composition#calculatemetadata) function is evaluated. If you just want to evaluate one composition that you want to render, use [`selectComposition()`](/docs/renderer/select-composition).
 
-The new signature, from [v4.0.497](https://github.com/remotion-dev/remotion/releases/v4.0.497) is:
-
 ```ts twoslash title="Example"
 import {bundle} from '@remotion/bundler';
 import {getCompositions} from '@remotion/renderer';
@@ -24,8 +22,6 @@ const compositions = await getCompositions({
   inputProps: {},
 });
 ```
-
-Use [the old signature](#legacy-function-signature) for versions below 4.0.496. It remains supported.
 
 ## Arguments
 
@@ -157,18 +153,6 @@ An absolute path overriding the `ffmpeg` executable to use.
 _removed in v4.0_
 
 An absolute path overriding the `ffprobe` executable to use.
-
-## Legacy function signature
-
-The positional function signature is also supported for backwards compatibility:
-
-```ts twoslash title="Legacy signature"
-import {getCompositions} from '@remotion/renderer';
-
-const compositions = await getCompositions('https://example.com', {
-  inputProps: {},
-});
-```
 
 ## Return value
 

--- a/packages/docs/docs/renderer/render-still.mdx
+++ b/packages/docs/docs/renderer/render-still.mdx
@@ -29,7 +29,8 @@ const serveUrl = await bundle({
   entryPoint: require.resolve('./src/index.ts'),
 });
 
-const comps = await getCompositions(serveUrl, {
+const comps = await getCompositions({
+  serveUrl,
   inputProps: {
     custom: 'data',
   },

--- a/packages/docs/render-cards.ts
+++ b/packages/docs/render-cards.ts
@@ -1,9 +1,9 @@
-import {bundle} from '@remotion/bundler';
-import {getCompositions, renderStill} from '@remotion/renderer';
 import {execSync} from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import {bundle} from '@remotion/bundler';
+import {getCompositions, renderStill} from '@remotion/renderer';
 import {readDir} from './get-pages.mjs';
 
 const data: {
@@ -176,7 +176,10 @@ const serveUrl = await bundle({
 	entryPoint: path.join(process.cwd(), './src/remotion/entry.ts'),
 	publicDir: path.join(process.cwd(), 'static'),
 });
-const compositions = await getCompositions(serveUrl);
+const compositions = await getCompositions({
+	serveUrl,
+	inputProps: {},
+});
 
 for (const composition of compositions.filter(
 	(c) => c.id.startsWith('expert') || c.id.startsWith('template'),

--- a/packages/docs/render-element-previews.ts
+++ b/packages/docs/render-element-previews.ts
@@ -89,7 +89,10 @@ const serveUrl = await bundle({
 	entryPoint: path.join(process.cwd(), 'src', 'remotion', 'entry.ts'),
 	publicDir: path.join(process.cwd(), 'static'),
 });
-const compositions = await getCompositions(serveUrl);
+const compositions = await getCompositions({
+	serveUrl,
+	inputProps: {},
+});
 const elementCompositions = compositions.filter((composition) =>
 	composition.id.startsWith('element-'),
 );

--- a/packages/example/render-all.ts
+++ b/packages/example/render-all.ts
@@ -8,7 +8,10 @@ const start = async () => {
 		webpackOverride,
 	});
 
-	const compositions = await getCompositions(bundled);
+	const compositions = await getCompositions({
+		serveUrl: bundled,
+		inputProps: {},
+	});
 
 	for (const composition of compositions) {
 		console.log(`Rendering ${composition.id}...`);

--- a/packages/it-tests/src/rendering/get-compositions.test.ts
+++ b/packages/it-tests/src/rendering/get-compositions.test.ts
@@ -11,4 +11,9 @@ test('getCompositions() should give a good error message if there is no composit
 	expect(() => getCompositions({})).toThrow(
 		'No serve URL or webpack bundle directory was passed to getCompositions().',
 	);
+
+	// @ts-expect-error
+	expect(() => getCompositions('https://example.com')).toThrow(
+		'getCompositions() no longer supports the legacy positional arguments. Pass an options object instead: getCompositions({serveUrl, ...options}).',
+	);
 });

--- a/packages/it-tests/src/ssr/render-frames.test.ts
+++ b/packages/it-tests/src/ssr/render-frames.test.ts
@@ -16,7 +16,8 @@ test(
 	'Legacy SSR way of rendering videos should still work',
 	async () => {
 		const puppeteerInstance = await openBrowser('chrome');
-		const compositions = await getCompositions(exampleBuild, {
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
 			puppeteerInstance,
 			inputProps: {},
 		});

--- a/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
+++ b/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
@@ -42,7 +42,10 @@ const getSampleRateFromFile = async (filePath: string): Promise<number> => {
 test(
 	'Render video with sampleRate 44100 should produce 44100 Hz audio',
 	async () => {
-		const compositions = await getCompositions(exampleBuild);
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
+			inputProps: {},
+		});
 		const comp = compositions.find((c) => c.id === 'audio-testing');
 
 		if (!comp) {
@@ -71,7 +74,10 @@ test(
 test(
 	'Render video with default sampleRate should produce 48000 Hz audio',
 	async () => {
-		const compositions = await getCompositions(exampleBuild);
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
+			inputProps: {},
+		});
 		const comp = compositions.find((c) => c.id === 'audio-testing');
 
 		if (!comp) {

--- a/packages/it-tests/src/ssr/render-media.test.ts
+++ b/packages/it-tests/src/ssr/render-media.test.ts
@@ -10,7 +10,8 @@ test(
 	'Render video with browser instance open',
 	async () => {
 		const puppeteerInstance = await openBrowser('chrome');
-		const compositions = await getCompositions(exampleBuild, {
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
 			puppeteerInstance,
 			inputProps: {},
 		});
@@ -42,7 +43,10 @@ test(
 );
 
 test('Render video with browser instance not open', async () => {
-	const compositions = await getCompositions(exampleBuild);
+	const compositions = await getCompositions({
+		serveUrl: exampleBuild,
+		inputProps: {},
+	});
 
 	const reactSvg = compositions.find((c) => c.id === 'react-svg');
 
@@ -109,7 +113,10 @@ test('should fail on invalid CRF', async () => {
 });
 
 test('Render video to a buffer', async () => {
-	const compositions = await getCompositions(exampleBuild);
+	const compositions = await getCompositions({
+		serveUrl: exampleBuild,
+		inputProps: {},
+	});
 
 	const reactSvg = compositions.find((c) => c.id === 'react-svg');
 

--- a/packages/it-tests/src/ssr/render-still.test.ts
+++ b/packages/it-tests/src/ssr/render-still.test.ts
@@ -46,7 +46,10 @@ test('Render video with browser instance open', async () => {
 test(
 	'Render still with browser instance not open and legacy webpack config',
 	async () => {
-		const compositions = await getCompositions(exampleBuild);
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
+			inputProps: {},
+		});
 
 		const reactSvg = compositions.find((c) => c.id === 'react-svg');
 

--- a/packages/lambda/src/test/mocks/mock-bundle-site.ts
+++ b/packages/lambda/src/test/mocks/mock-bundle-site.ts
@@ -1,30 +1,19 @@
 import type {bundle, BundleOptions} from '@remotion/bundler';
 
-const convertArgumentsIntoOptions = (
-	args: Parameters<typeof bundle>,
-): BundleOptions => {
-	if ((args.length as number) === 0) {
+const validateOptions = (options: BundleOptions): BundleOptions => {
+	if (!options) {
 		throw new TypeError('bundle() was called without arguments');
 	}
 
-	const firstArg = args[0];
-	if (typeof firstArg === 'string') {
-		return {
-			entryPoint: firstArg,
-			onProgress: args[1],
-			...(args[2] ?? {}),
-		};
-	}
-
-	if (typeof firstArg.entryPoint !== 'string') {
+	if (typeof options.entryPoint !== 'string') {
 		throw new TypeError('bundle() was called without the `entryPoint` option');
 	}
 
-	return firstArg;
+	return options;
 };
 
-export const mockBundleSite: typeof bundle = (...args) => {
-	const {entryPoint} = convertArgumentsIntoOptions(args);
+export const mockBundleSite: typeof bundle = (options) => {
+	const {entryPoint} = validateOptions(options);
 	if (entryPoint === 'first') {
 		return Promise.resolve('/path/to/bundle-1');
 	}

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -38,42 +38,15 @@ type InternalGetCompositionsOptions = {
 	onLog: OnLog;
 } & ToOptions<typeof optionsMap.getCompositions>;
 
-export type LegacyGetCompositionsOptions = RequiredInputPropsInV5 & {
+export type GetCompositionsOptions = RequiredInputPropsInV5 & {
 	envVariables?: Record<string, string>;
 	puppeteerInstance?: HeadlessBrowser;
 	onBrowserLog?: (log: BrowserLog) => void;
 	browserExecutable?: BrowserExecutable;
 	chromiumOptions?: ChromiumOptions;
 	port?: number | null;
-} & Partial<ToOptions<typeof optionsMap.getCompositions>>;
-
-export type GetCompositionsOptions = LegacyGetCompositionsOptions & {
 	serveUrl: string;
-};
-
-type GetCompositionsArguments =
-	| [options: GetCompositionsOptions]
-	| [serveUrlOrWebpackUrl: string, config?: LegacyGetCompositionsOptions];
-
-const convertGetCompositionsArgumentsToOptions = (
-	args: GetCompositionsArguments,
-): GetCompositionsOptions => {
-	if ((args.length as number) === 0) {
-		throw new Error(
-			'No serve URL or webpack bundle directory was passed to getCompositions().',
-		);
-	}
-
-	const firstArg = args[0];
-	if (typeof firstArg === 'string') {
-		return {
-			...(args[1] ?? {}),
-			serveUrl: firstArg,
-		};
-	}
-
-	return firstArg;
-};
+} & Partial<ToOptions<typeof optionsMap.getCompositions>>;
 
 type InnerGetCompositionsParams = {
 	serializedInputPropsWithCustomSchema: string;
@@ -309,9 +282,14 @@ export const internalGetCompositions = wrapWithErrorHandling(
  * @see [Documentation](https://www.remotion.dev/docs/renderer/get-compositions)
  */
 export const getCompositions = (
-	...args: GetCompositionsArguments
+	options: GetCompositionsOptions,
 ): Promise<VideoConfig[]> => {
-	const options = convertGetCompositionsArgumentsToOptions(args);
+	if (typeof options === 'string') {
+		throw new TypeError(
+			'getCompositions() no longer supports the legacy positional arguments. Pass an options object instead: getCompositions({serveUrl, ...options}).',
+		);
+	}
+
 	if (typeof options?.serveUrl !== 'string' || !options.serveUrl) {
 		throw new Error(
 			'No serve URL or webpack bundle directory was passed to getCompositions().',

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -90,11 +90,7 @@ export {extractAudio} from './extract-audio';
 export type {FfmpegOverrideFn} from './ffmpeg-override';
 export {FileExtension} from './file-extensions';
 export {FrameRange} from './frame-range';
-export {
-	GetCompositionsOptions,
-	getCompositions,
-	LegacyGetCompositionsOptions,
-} from './get-compositions';
+export {GetCompositionsOptions, getCompositions} from './get-compositions';
 export {SilentPart, getSilentParts} from './get-silent-parts';
 export {VideoMetadata, getVideoMetadata} from './get-video-metadata';
 export {

--- a/packages/template-skia/README.md
+++ b/packages/template-skia/README.md
@@ -42,7 +42,9 @@ npx remotion upgrade
 This template uses a [custom Webpack override](https://www.remotion.dev/docs/webpack). If you are using server-side rendering, you need to import `enableSkia` from `@remotion/skia/enable` and pass it to [`bundle()`](https://www.remotion.dev/docs/bundle) (if using SSR) and [`deploySite()`](https://www.remotion.dev/docs/lambda/deploysite) (if using Lambda):
 
 ```ts
-bundle(entry, () => undefined, {
+bundle({
+  entryPoint: entry,
+  onProgress: () => undefined,
   webpackOverride: (config) => enableSkia(config),
 });
 // or

--- a/packages/template-still/src/server/index.ts
+++ b/packages/template-still/src/server/index.ts
@@ -22,7 +22,9 @@ dotenv.config({ quiet: true });
 const app = express();
 const port = process.env.PORT || 8000;
 
-const webpackBundling = bundle(path.join(process.cwd(), "src/index.ts"));
+const webpackBundling = bundle({
+  entryPoint: path.join(process.cwd(), "src/index.ts"),
+});
 const tmpDir = fs.promises.mkdtemp(path.join(os.tmpdir(), "remotion-"));
 
 enum Params {


### PR DESCRIPTION
## Summary

- remove the legacy positional signatures from `bundle()` and `getCompositions()`
- throw actionable runtime errors when the removed signatures are used
- update internal callers, templates, tests, and documentation to use options objects

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/bundler/src/test/validate-bundle.test.ts packages/it-tests/src/rendering/get-compositions.test.ts`

Closes #9486

## Preview

- [Remotion 2.3 blog post](https://remotion-git-codex-remove-legacy-bundle-get-com-b533f3-remotion.vercel.app/blog/2-3)
- [Remotion 3.3 blog post](https://remotion-git-codex-remove-legacy-bundle-get-com-b533f3-remotion.vercel.app/blog/3-3)
- [v5.0 Migration](https://remotion-git-codex-remove-legacy-bundle-get-com-b533f3-remotion.vercel.app/docs/5-0-migration)
- [Exporting Audio](https://remotion-git-codex-remove-legacy-bundle-get-com-b533f3-remotion.vercel.app/docs/audio/exporting)
- [`bundle()`](https://remotion-git-codex-remove-legacy-bundle-get-com-b533f3-remotion.vercel.app/docs/bundle)
- [Player code sharing](https://remotion-git-codex-remove-legacy-bundle-get-com-b533f3-remotion.vercel.app/docs/player/integration)
- [Render all compositions](https://remotion-git-codex-remove-legacy-bundle-get-com-b533f3-remotion.vercel.app/docs/render-all)
- [`getCompositions()`](https://remotion-git-codex-remove-legacy-bundle-get-com-b533f3-remotion.vercel.app/docs/renderer/get-compositions)
- [`renderStill()`](https://remotion-git-codex-remove-legacy-bundle-get-com-b533f3-remotion.vercel.app/docs/renderer/render-still)
