### PR TITLE
`@remotion/studio`: Fix PreviewToolbar layout at small browser widths

### DIFF
--- a/packages/studio/src/components/ControlButton.tsx
+++ b/packages/studio/src/components/ControlButton.tsx
@@ -20,6 +20,7 @@ export const ControlButton = (
 			justifyContent: 'center',
 			width: CONTROL_BUTTON_SIZE,
 			height: CONTROL_BUTTON_SIZE,
+			flexShrink: 0,
 			background: 'none',
 			border: 'none',
 			padding: 0,

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -51,7 +51,7 @@ const container: React.CSSProperties = {
 const mobileContainer: React.CSSProperties = {
 	...container,
 	position: 'relative',
-	overflowY: 'auto',
+	overflowX: 'auto',
 	justifyContent: 'flex-start',
 };
 const scrollIndicatorLeft: React.CSSProperties = {
@@ -82,6 +82,14 @@ const sideContainer: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'row',
 	alignItems: 'center',
+};
+
+const mobileSideContainer: React.CSSProperties = {
+	height: 30,
+	display: 'flex',
+	flexDirection: 'row',
+	alignItems: 'center',
+	flexShrink: 0,
 };
 
 const padding: React.CSSProperties = {
@@ -277,7 +285,6 @@ export const PreviewToolbar: React.FC<{
 			<Flex />
 			{isMobileLayout && (
 				<>
-					<Flex />
 					<PreviewToolbarControl>
 						<SizeSelector />
 					</PreviewToolbarControl>
@@ -291,7 +298,7 @@ export const PreviewToolbar: React.FC<{
 					) : null}
 				</>
 			)}
-			<div style={sideContainer}>
+			<div style={isMobileLayout ? mobileSideContainer : sideContainer}>
 				<Flex />
 				{!isMobileLayout && <FpsCounter playbackSpeed={playbackRate} />}
 				<Spacing x={2} />


### PR DESCRIPTION
### Related Issue #9440

## Summary

Fixes the `PreviewToolbar` becoming visually broken (buttons squishing, items clipping, no scrollability) when the browser width is small.


## Changes

- **Fix overflow axis**: Changed `overflowY: 'auto'` → `overflowX: 'auto'` on the mobile toolbar container so items scroll horizontally instead of clipping
- **Responsive side container**: Replaced the hard-coded `width: 300` side container with an auto-sizing `mobileSideContainer` (`flexShrink: 0`, no fixed width) on mobile
- **Prevent button compression**: Added `flexShrink: 0` to `ControlButton` so 30×30 icon buttons don't shrink below their intended size
- **Remove redundant spacer**: Removed an extra `<Flex />` in the mobile layout that created odd gaps between controls

## Validation

-  `bunx turbo run lint --filter='@remotion/studio'` — 0 errors
-  `bunx turbo run make --filter='@remotion/studio'` — 21/21 tasks successful
-  `bun run stylecheck` — 240/240 tasks successful
-  Visually verified at 500px, 700px, 850px, and 1000px+ viewports — buttons maintain 30×30, horizontal scroll works, gradient indicators display correctly, desktop layout unchanged