### PR TITLE
Internal: Retry flaky render scale tests

### DIFF
--- a/packages/it-tests/src/rendering/render-scale.test.ts
+++ b/packages/it-tests/src/rendering/render-scale.test.ts
@@ -65,6 +65,7 @@ test(
 		expect(data).toContain('30 fps');
 	},
 	{
+		retry: 3,
 		timeout: 90000,
 	},
 );
@@ -116,6 +117,7 @@ test(
 		expect(data).toContain('30 fps');
 	},
 	{
+		retry: 3,
 		timeout: 30000,
 	},
 );


### PR DESCRIPTION
## Summary

- retry both render scale integration tests up to three times
- reduce macOS CI failures caused by intermittent headless browser startup timeouts

Related to #8375.

## Verification

- `bunx oxfmt packages/it-tests/src/rendering/render-scale.test.ts --write`
- `bun run build`
- `bun run stylecheck`
- `bunx tsc -p packages/it-tests/tsconfig.json --noEmit`

A targeted local test run could not complete because nested `execa('bun')` calls could not resolve the Bun executable in the local harness environment. It did confirm that Bun ran the configured retries.
