### PR TITLE
`@remotion/paths`: Return null beyond path length

### DIFF
--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -61,6 +61,13 @@ The values passed in there did not influence the calculation at all. Therefore w
 
 **Required action**: Remove the `from` and `to` options from your code.
 
+## Path sampling returns `null` beyond the end of a path
+
+[`getPointAtLength()`](/docs/paths/get-point-at-length) and [`getTangentAtLength()`](/docs/paths/get-tangent-at-length) now return `null` if the requested length is greater than the return value of [`getLength()`](/docs/paths/get-length).
+Previously, they returned the point or tangent at the end of the path.
+
+**Required action**: Handle the `null` return value or ensure that the requested length does not exceed the path length.
+
 ## `overwrite` is now `true` by default in `renderMediaOnLambda()`
 
 The default value of `overwrite` has been changed to `true` in `renderMediaOnLambda()`. This skips a check that the file already exists in the S3 bucket, which makes the render start faster.

--- a/packages/docs/docs/paths/get-point-at-length.mdx
+++ b/packages/docs/docs/paths/get-point-at-length.mdx
@@ -7,9 +7,9 @@ crumb: "@remotion/paths"
 _Part of the [`@remotion/paths`](/docs/paths) package._
 
 Gets the coordinates of a point which is on an SVG path.
-The first argument is an SVG path, the second one is the length at which the point should be sampled. It must be between `0` and the return value of [`getLength()`](/docs/paths/get-length).
+The first argument is an SVG path, the second one is the length at which the point should be sampled.
 
-An object containing `x` and `y` is returned if the path is valid:
+An object containing `x` and `y` is returned if the path is valid and the length is between `0` and the return value of [`getLength()`](/docs/paths/get-length):
 
 ```tsx twoslash
 import { getPointAtLength } from "@remotion/paths";
@@ -17,6 +17,8 @@ import { getPointAtLength } from "@remotion/paths";
 const point = getPointAtLength("M 0 0 L 100 0", 50);
 console.log(point); // { x: 50, y: 0 }
 ```
+
+From <AvailableFrom v="5.0.0" inline />, the function returns `null` if the requested length is greater than the length of the path. In Remotion 4.0, it returned the end point of the path. See the [migration guide](/docs/5-0-migration).
 
 The function will throw if the path is invalid:
 

--- a/packages/docs/docs/paths/get-tangent-at-length.mdx
+++ b/packages/docs/docs/paths/get-tangent-at-length.mdx
@@ -6,9 +6,9 @@ crumb: "@remotion/paths"
 
 _Part of the [`@remotion/paths`](/docs/paths) package._
 
-Gets tangent values `x` and `y` of a point which is on an SVG path. The first argument is an SVG path, the second one is the length at which the point should be sampled. It must be between 0 and the return value of [`getLength()`](/docs/paths/get-length).
+Gets tangent values `x` and `y` of a point which is on an SVG path. The first argument is an SVG path, the second one is the length at which the point should be sampled.
 
-Returns a point if the path is valid:
+Returns a point if the path is valid and the length is between `0` and the return value of [`getLength()`](/docs/paths/get-length):
 
 ```tsx twoslash
 import { getTangentAtLength } from "@remotion/paths";
@@ -16,6 +16,8 @@ import { getTangentAtLength } from "@remotion/paths";
 const tangent = getTangentAtLength("M 50 50 L 150 50", 50);
 console.log(tangent); // { x: 1, y: 0}
 ```
+
+From <AvailableFrom v="5.0.0" inline />, the function returns `null` if the requested length is greater than the length of the path. In Remotion 4.0, it returned the tangent at the end of the path. See the [migration guide](/docs/5-0-migration).
 
 The function will throw if the path is invalid:
 

--- a/packages/example/src/ReactSvg/Arc.tsx
+++ b/packages/example/src/ReactSvg/Arc.tsx
@@ -50,6 +50,10 @@ export const Arc: React.FC<{
 	const d = ellipseToPath(cx, cy);
 	const tangent = getTangentAtLength(d, (electronProgress % 1) * arcLength);
 	const pointAtLength = getPointAtLength(d, (electronProgress % 1) * arcLength);
+	if (!tangent || !pointAtLength) {
+		return null;
+	}
+
 	const move = (orig: number, x: number, y: number): number =>
 		orig + x * tangent.x + y * tangent.y;
 

--- a/packages/paths/src/get-point-at-length.ts
+++ b/packages/paths/src/get-point-at-length.ts
@@ -7,6 +7,10 @@ import {construct} from './helpers/construct';
  */
 export const getPointAtLength = (path: string, length: number) => {
 	const constructed = construct(path);
+	if (length > constructed.totalLength) {
+		return null;
+	}
+
 	const fractionPart = getInstructionIndexAtLengthFromConstructed(
 		constructed,
 		length,

--- a/packages/paths/src/get-tangent-at-length.ts
+++ b/packages/paths/src/get-tangent-at-length.ts
@@ -8,6 +8,9 @@ import {construct} from './helpers/construct';
 
 export const getTangentAtLength = (path: string, length: number) => {
 	const constructed = construct(path);
+	if (length > constructed.totalLength) {
+		return null;
+	}
 
 	const fractionPart = getInstructionIndexAtLengthFromConstructed(
 		constructed,

--- a/packages/paths/src/test/get-point-at-length.test.ts
+++ b/packages/paths/src/test/get-point-at-length.test.ts
@@ -8,6 +8,11 @@ test('Should be able to get parts of a path', () => {
 	expect(parts).toEqual({x: 50, y: 0});
 });
 
+test('Should return null if the length is longer than the path', () => {
+	expect(getPointAtLength('M 0 0 L 100 0', 100)).toEqual({x: 100, y: 0});
+	expect(getPointAtLength('M 0 0 L 100 0', 101)).toBeNull();
+});
+
 test('Another more complex point', () => {
 	const path = `M2 129
 		

--- a/packages/paths/src/test/get-tangent-at-length.test.ts
+++ b/packages/paths/src/test/get-tangent-at-length.test.ts
@@ -6,3 +6,8 @@ test('Should be able to get parts of a path', () => {
 
 	expect(parts).toEqual({x: 1, y: 0});
 });
+
+test('Should return null if the length is longer than the path', () => {
+	expect(getTangentAtLength('M 0 0 L 100 0', 100)).toEqual({x: 1, y: 0});
+	expect(getTangentAtLength('M 0 0 L 100 0', 101)).toBeNull();
+});


### PR DESCRIPTION
## Summary

- return `null` from `getPointAtLength()` and `getTangentAtLength()` when the requested length exceeds the path length
- preserve valid results at the exact end of the path and add regression tests
- document the Remotion 5.0 behavior and migration action

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src` in `packages/paths`

Closes #9484

## Preview

- [v5.0 Migration](https://remotion-git-codex-paths-null-beyond-length-remotion.vercel.app/docs/5-0-migration)
- [getPointAtLength()](https://remotion-git-codex-paths-null-beyond-length-remotion.vercel.app/docs/paths/get-point-at-length)
- [getTangentAtLength()](https://remotion-git-codex-paths-null-beyond-length-remotion.vercel.app/docs/paths/get-tangent-at-length)
