### PR TITLE
`docs`: Recommend Agent Skills in Editor Starter setup

### DIFF
--- a/packages/docs/docs/editor-starter/setup.mdx
+++ b/packages/docs/docs/editor-starter/setup.mdx
@@ -18,6 +18,15 @@ If you are starting a new project, you can stay in your repository and install d
 npm i
 ```
 
+If you use a coding agent, install the [Remotion Agent Skills](/docs/ai/skills):
+
+```bash
+npx remotion skills add
+```
+
+For Editor Starter projects, we recommend [`/remotion-saas`](/docs/ai/skills#remotion-saas) and [`/remotion-docs`](/docs/ai/skills#remotion-docs).
+Alternatively, use [`/remotion-best-practices`](/docs/ai/skills#remotion-best-practices), which encompasses all Remotion skills.
+
 Run the app using:
 
 ```


### PR DESCRIPTION
## Summary

- recommend installing Remotion Agent Skills after dependencies
- link the Editor Starter-specific and comprehensive skills

Closes #9525

## Tests

- `bun run build`
- `bun run stylecheck`
- `bun render-cards.ts` from `packages/docs`