### PR TITLE
`@remotion/renderer`: In Remotion 5.0, default to ANGLE with SwiftShader fallback

### DIFF
--- a/packages/core/src/v5-flag.ts
+++ b/packages/core/src/v5-flag.ts
@@ -1,1 +1,1 @@
-export const ENABLE_V5_BREAKING_CHANGES = false as const;
+export const ENABLE_V5_BREAKING_CHANGES = true as const;

--- a/packages/core/src/v5-flag.ts
+++ b/packages/core/src/v5-flag.ts
@@ -1,1 +1,1 @@
-export const ENABLE_V5_BREAKING_CHANGES = true as const;
+export const ENABLE_V5_BREAKING_CHANGES = false as const;

--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type {NoReactInternals} from 'remotion/no-react';
+import {NoReactInternals} from 'remotion/no-react';
 import type {Browser} from './browser';
 import type {HeadlessBrowser} from './browser/Browser';
 import {defaultBrowserDownloadProgress} from './browser/browser-download-progress-bar';
@@ -14,7 +14,7 @@ import {type LogLevel} from './log-level';
 import {Log} from './logger';
 import type {ChromeMode} from './options/chrome-mode';
 import type {validOpenGlRenderers} from './options/gl';
-import {DEFAULT_OPENGL_RENDERER, validateOpenGlRenderer} from './options/gl';
+import {getDefaultOpenGlRenderer, validateOpenGlRenderer} from './options/gl';
 import type {ToOptions} from './options/option';
 import type {optionsMap} from './options/options-map';
 
@@ -36,7 +36,10 @@ export type ChromiumOptions = {
 };
 
 const featuresToEnable = (option?: OpenGlRenderer | null) => {
-	const renderer = option ?? DEFAULT_OPENGL_RENDERER;
+	const renderer =
+		option === undefined
+			? getDefaultOpenGlRenderer(NoReactInternals.ENABLE_V5_BREAKING_CHANGES)
+			: option;
 
 	const enableAlways = [
 		'NetworkService',
@@ -55,8 +58,14 @@ const featuresToEnable = (option?: OpenGlRenderer | null) => {
 	return enableAlways;
 };
 
-const getOpenGlRenderer = (option?: OpenGlRenderer | null): string[] => {
-	const renderer = option ?? DEFAULT_OPENGL_RENDERER;
+export const getOpenGlRenderer = (
+	option: OpenGlRenderer | null | undefined,
+	enableV5BreakingChanges: boolean = NoReactInternals.ENABLE_V5_BREAKING_CHANGES,
+): string[] => {
+	const renderer =
+		option === undefined
+			? getDefaultOpenGlRenderer(enableV5BreakingChanges)
+			: option;
 	validateOpenGlRenderer(renderer);
 	if (renderer === 'swangle') {
 		return ['--use-gl=angle', '--use-angle=swiftshader'];
@@ -79,6 +88,15 @@ const getOpenGlRenderer = (option?: OpenGlRenderer | null): string[] => {
 
 	if (renderer === null) {
 		return [];
+	}
+
+	if (renderer === 'angle' && enableV5BreakingChanges) {
+		return [
+			'--use-gl=angle',
+			// Opt into Chromium's software WebGL fallback for GPU-less machines:
+			// https://chromium.googlesource.com/chromium/src/+/main/docs/gpu/swiftshader.md
+			'--enable-unsafe-swiftshader',
+		];
 	}
 
 	return [`--use-gl=${renderer}`];
@@ -142,7 +160,7 @@ export const internalOpenBrowser = async ({
 		chromeMode,
 	});
 
-	const customGlRenderer = getOpenGlRenderer(chromiumOptions.gl ?? null);
+	const customGlRenderer = getOpenGlRenderer(chromiumOptions.gl);
 	const enableMultiProcessOnLinux =
 		chromiumOptions.enableMultiProcessOnLinux ?? true;
 

--- a/packages/renderer/src/options/gl.tsx
+++ b/packages/renderer/src/options/gl.tsx
@@ -1,3 +1,4 @@
+import {NoReactInternals} from 'remotion/no-react';
 import type {AnyRemotionOption} from './option';
 
 export const validOpenGlRenderers = [
@@ -11,7 +12,15 @@ export const validOpenGlRenderers = [
 
 export type OpenGlRenderer = (typeof validOpenGlRenderers)[number];
 
-export const DEFAULT_OPENGL_RENDERER: OpenGlRenderer | null = null;
+export const getDefaultOpenGlRenderer = (
+	enableV5BreakingChanges: boolean,
+): OpenGlRenderer | null => {
+	return enableV5BreakingChanges ? 'angle' : null;
+};
+
+export const DEFAULT_OPENGL_RENDERER = getDefaultOpenGlRenderer(
+	NoReactInternals.ENABLE_V5_BREAKING_CHANGES,
+);
 
 let openGlRenderer: OpenGlRenderer | null = DEFAULT_OPENGL_RENDERER;
 
@@ -37,6 +46,13 @@ const AngleChangelog: React.FC = () => {
 					however it turns out to have a small memory leak that could crash long
 					Remotion renders.
 				</li>
+				{NoReactInternals.ENABLE_V5_BREAKING_CHANGES ? (
+					<li>
+						From Remotion v5.0, the default is <code>angle</code>. If no
+						compatible GPU is available, Chromium automatically falls back to
+						SwiftShader.
+					</li>
+				) : null}
 			</ul>
 		</details>
 	);
@@ -79,8 +95,16 @@ export const glOption = {
 					</li>
 				</ul>
 				<p>
-					The default is <code>null</code>, letting Chrome decide, except on
-					Lambda where the default is <code>{'"swangle"'}</code>
+					The default is{' '}
+					<code>
+						{DEFAULT_OPENGL_RENDERER === null
+							? 'null'
+							: `"${DEFAULT_OPENGL_RENDERER}"`}
+					</code>
+					{DEFAULT_OPENGL_RENDERER === null
+						? ', letting Chrome decide'
+						: ', with automatic fallback to SwiftShader if no compatible GPU is available'}
+					, except on Lambda where the default is <code>{'"swangle"'}</code>
 				</p>
 			</>
 		);

--- a/packages/renderer/src/test/open-gl-renderer.test.ts
+++ b/packages/renderer/src/test/open-gl-renderer.test.ts
@@ -1,0 +1,32 @@
+import {expect, test} from 'bun:test';
+import {getOpenGlRenderer} from '../open-browser';
+
+test('uses the Chrome default in v4', () => {
+	expect(getOpenGlRenderer(undefined, false)).toEqual([]);
+});
+
+test('uses ANGLE with automatic SwiftShader fallback in v5', () => {
+	expect(getOpenGlRenderer(undefined, true)).toEqual([
+		'--use-gl=angle',
+		'--enable-unsafe-swiftshader',
+	]);
+});
+
+test('keeps null as an explicit opt-out in v5', () => {
+	expect(getOpenGlRenderer(null, true)).toEqual([]);
+});
+
+test('enables automatic SwiftShader fallback for ANGLE in v5', () => {
+	expect(getOpenGlRenderer('angle', true)).toEqual([
+		'--use-gl=angle',
+		'--enable-unsafe-swiftshader',
+	]);
+	expect(getOpenGlRenderer('angle', false)).toEqual(['--use-gl=angle']);
+});
+
+test('does not change explicitly selected software rendering', () => {
+	expect(getOpenGlRenderer('swangle', true)).toEqual([
+		'--use-gl=angle',
+		'--use-angle=swiftshader',
+	]);
+});


### PR DESCRIPTION
## Summary

- Make `angle` the default OpenGL renderer when the Remotion 5 breaking-changes flag is enabled.
- Opt into Chromium's automatic SwiftShader fallback with `--enable-unsafe-swiftshader`.
- Preserve the Remotion 4 default and the explicit `gl: null` opt-out.
- Update the generated GL option description and add focused renderer tests.

## Verification

- `bun test packages/renderer/src/test/open-gl-renderer.test.ts`
- Local render without `--gl`
- Forced GPU-less Chrome A/B verification: WebGL unavailable without the opt-in and available through SwiftShader with the V5 flags
- Real AWS Lambda render without GL configuration
- Docker renders without GL configuration on Ubuntu 24, Ubuntu 22, and Debian, on both x86-64 and arm64
- Direct core build, lint, and formatting checks
- Renderer lint and formatting checks

The repository-wide `bun run build` and `bun run stylecheck` currently stop on pre-existing `@remotion/licensing` type errors involving the `apiKey` to `licenseKey` migration. The renderer standalone type build also reports existing option-type mismatches outside this change.

Closes #9498

Documentation follow-up: #9524
