### PR TITLE
`@remotion/cli`: Warn about unrecognized CLI flags

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,7 +48,6 @@ import {
 	validateVersionsBeforeCommand,
 	versionsCommand,
 } from './versions';
-import {warnAboutUnrecognizedCliFlags} from './warn-about-unrecognized-cli-flags';
 
 const {packageManagerOption, versionFlagOption} = BrowserSafeApis.options;
 
@@ -86,20 +85,6 @@ export const cli = async () => {
 	}
 
 	const isStudio = command === 'studio' || command === 'preview';
-
-	if (isStudio) {
-		warnAboutUnrecognizedCliFlags({
-			args: process.argv.slice(2),
-			command: 'studio',
-			logLevel,
-		});
-	} else if (command === 'render') {
-		warnAboutUnrecognizedCliFlags({
-			args: process.argv.slice(2),
-			command,
-			logLevel,
-		});
-	}
 
 	const errorSymbolicationLock = isStudio
 		? 0

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,6 +48,7 @@ import {
 	validateVersionsBeforeCommand,
 	versionsCommand,
 } from './versions';
+import {warnAboutUnrecognizedCliFlags} from './warn-about-unrecognized-cli-flags';
 
 const {packageManagerOption, versionFlagOption} = BrowserSafeApis.options;
 
@@ -85,6 +86,20 @@ export const cli = async () => {
 	}
 
 	const isStudio = command === 'studio' || command === 'preview';
+
+	if (isStudio) {
+		warnAboutUnrecognizedCliFlags({
+			args: process.argv.slice(2),
+			command: 'studio',
+			logLevel,
+		});
+	} else if (command === 'render') {
+		warnAboutUnrecognizedCliFlags({
+			args: process.argv.slice(2),
+			command,
+			logLevel,
+		});
+	}
 
 	const errorSymbolicationLock = isStudio
 		? 0

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -9,6 +9,7 @@ import {getCliOptions} from './get-cli-options';
 import {Log} from './log';
 import {parsedCli, quietFlagProvided} from './parsed-cli';
 import {renderVideoFlow} from './render-flows/render';
+import {warnAboutUnrecognizedCliFlags} from './warn-about-unrecognized-cli-flags';
 
 const {
 	x264Option,
@@ -69,6 +70,12 @@ export const render = async (
 	args: (string | number)[],
 	logLevel: LogLevel,
 ) => {
+	warnAboutUnrecognizedCliFlags({
+		args: process.argv.slice(2),
+		command: 'render',
+		logLevel,
+	});
+
 	const {
 		file,
 		remainingArgs,

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -18,6 +18,7 @@ import {
 	getRenderQueue,
 	removeJob,
 } from './render-queue/queue';
+import {warnAboutUnrecognizedCliFlags} from './warn-about-unrecognized-cli-flags';
 
 const {
 	binariesDirectoryOption,
@@ -44,6 +45,12 @@ export const studioCommand = async (
 	args: string[],
 	logLevel: LogLevel,
 ) => {
+	warnAboutUnrecognizedCliFlags({
+		args: process.argv.slice(2),
+		command: 'studio',
+		logLevel,
+	});
+
 	const {file, reason} = findEntryPoint({
 		args,
 		remotionRoot,

--- a/packages/cli/src/test/warn-about-unrecognized-cli-flags.test.ts
+++ b/packages/cli/src/test/warn-about-unrecognized-cli-flags.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, spyOn, test} from 'bun:test';
+import {Log} from '../log';
+import {
+	getUnrecognizedCliFlags,
+	warnAboutUnrecognizedCliFlags,
+} from '../warn-about-unrecognized-cli-flags';
+
+describe('warn about unrecognized CLI flags', () => {
+	test('allows flags recognized by render', () => {
+		expect(
+			getUnrecognizedCliFlags({
+				args: [
+					'render',
+					'src/index.ts',
+					'MyComp',
+					'out.mp4',
+					'--codec=h264',
+					'--quiet',
+					'--props',
+					'./props.json',
+				],
+				command: 'render',
+			}),
+		).toEqual([]);
+	});
+
+	test('allows flags recognized by Studio', () => {
+		expect(
+			getUnrecognizedCliFlags({
+				args: [
+					'studio',
+					'src/index.ts',
+					'--port',
+					'3001',
+					'--no-open',
+					'--concurrency=4',
+					'--codec=h264',
+					'--browser-executable=/path/to/browser',
+					'--bundle-cache',
+					'--output=out.mp4',
+					'--quiet',
+				],
+				command: 'studio',
+			}),
+		).toEqual([]);
+	});
+
+	test('returns typos and flags for another command', () => {
+		expect(
+			getUnrecognizedCliFlags({
+				args: [
+					'studio',
+					'--portt=3001',
+					'--overwrite',
+					'--height=1080',
+					'--separate-audio-to=audio.wav',
+				],
+				command: 'studio',
+			}),
+		).toEqual(['portt', 'overwrite', 'height', 'separate-audio-to']);
+	});
+
+	test('returns render flags which are parsed but unused', () => {
+		expect(
+			getUnrecognizedCliFlags({
+				args: ['render', '--browser=safari', '--force-new'],
+				command: 'render',
+			}),
+		).toEqual(['browser', 'force-new']);
+	});
+
+	test('warns that the flag will fail in the future', () => {
+		const warn = spyOn(Log, 'warn').mockImplementation(() => undefined);
+
+		warnAboutUnrecognizedCliFlags({
+			args: ['studio', '--width=1920'],
+			command: 'studio',
+			logLevel: 'info',
+		});
+
+		expect(warn).toHaveBeenCalledWith(
+			{indent: false, logLevel: 'info'},
+			'"--width" is not a valid flag for "npx remotion studio". This will fail in the future.',
+		);
+		warn.mockRestore();
+	});
+});

--- a/packages/cli/src/warn-about-unrecognized-cli-flags.ts
+++ b/packages/cli/src/warn-about-unrecognized-cli-flags.ts
@@ -1,0 +1,270 @@
+import type {LogLevel} from '@remotion/renderer';
+import {BrowserSafeApis} from '@remotion/renderer/client';
+import {Log} from './log';
+
+const {
+	askAIOption,
+	audioBitrateOption,
+	audioCodecOption,
+	audioLatencyHintOption,
+	beepOnFinishOption,
+	binariesDirectoryOption,
+	browserExecutableOption,
+	browserOption,
+	bundleCacheOption,
+	chromeModeOption,
+	colorSpaceOption,
+	concurrencyOption,
+	configOption,
+	crfOption,
+	darkModeOption,
+	delayRenderTimeoutInMillisecondsOption,
+	disableGitSourceOption,
+	disableWebSecurityOption,
+	disallowParallelEncodingOption,
+	enableCrossSiteIsolationOption,
+	enableMultiprocessOnLinuxOption,
+	encodingBufferSizeOption,
+	encodingMaxRateOption,
+	enforceAudioOption,
+	envFileOption,
+	everyNthFrameOption,
+	forSeamlessAacConcatenationOption,
+	forceNewStudioOption,
+	framesOption,
+	glOption,
+	gopSizeOption,
+	hardwareAccelerationOption,
+	headlessOption,
+	ignoreCertificateErrorsOption,
+	imageSequenceOption,
+	imageSequencePatternOption,
+	interactivityOption,
+	ipv4Option,
+	jpegQualityOption,
+	keyboardShortcutsOption,
+	licenseKeyOption,
+	logLevelOption,
+	mediaCacheSizeInBytesOption,
+	metadataOption,
+	mutedOption,
+	noOpenOption,
+	numberOfGifLoopsOption,
+	numberOfSharedAudioTagsOption,
+	offthreadVideoCacheSizeInBytesOption,
+	offthreadVideoThreadsOption,
+	overrideDurationOption,
+	overrideFpsOption,
+	overrideHeightOption,
+	overrideWidthOption,
+	overwriteOption,
+	pixelFormatOption,
+	portOption,
+	previewSampleRateOption,
+	propsOption,
+	proResProfileOption,
+	publicDirOption,
+	publicLicenseKeyOption,
+	publicPathOption,
+	reproOption,
+	rspackOption,
+	sampleRateOption,
+	scaleOption,
+	separateAudioOption,
+	stillFrameOption,
+	userAgentOption,
+	videoBitrateOption,
+	videoCodecOption,
+	videoImageFormatOption,
+	webpackPollOption,
+	x264Option,
+} = BrowserSafeApis.options;
+
+const commonFlags = [
+	configOption.cliFlag,
+	envFileOption.cliFlag,
+	licenseKeyOption.cliFlag,
+	logLevelOption.cliFlag,
+	propsOption.cliFlag,
+];
+
+const studioFlags = [
+	...commonFlags,
+	askAIOption.cliFlag,
+	audioBitrateOption.cliFlag,
+	audioCodecOption.cliFlag,
+	audioLatencyHintOption.cliFlag,
+	beepOnFinishOption.cliFlag,
+	binariesDirectoryOption.cliFlag,
+	'browser-args',
+	browserOption.cliFlag,
+	browserExecutableOption.cliFlag,
+	bundleCacheOption.cliFlag,
+	chromeModeOption.cliFlag,
+	colorSpaceOption.cliFlag,
+	concurrencyOption.cliFlag,
+	darkModeOption.cliFlag,
+	delayRenderTimeoutInMillisecondsOption.cliFlag,
+	disableGitSourceOption.cliFlag,
+	disableWebSecurityOption.cliFlag,
+	enableCrossSiteIsolationOption.cliFlag,
+	enableMultiprocessOnLinuxOption.cliFlag,
+	encodingBufferSizeOption.cliFlag,
+	encodingMaxRateOption.cliFlag,
+	enforceAudioOption.cliFlag,
+	everyNthFrameOption.cliFlag,
+	forSeamlessAacConcatenationOption.cliFlag,
+	forceNewStudioOption.cliFlag,
+	glOption.cliFlag,
+	gopSizeOption.cliFlag,
+	hardwareAccelerationOption.cliFlag,
+	headlessOption.cliFlag,
+	ignoreCertificateErrorsOption.cliFlag,
+	interactivityOption.cliFlag,
+	ipv4Option.cliFlag,
+	jpegQualityOption.cliFlag,
+	keyboardShortcutsOption.cliFlag,
+	mediaCacheSizeInBytesOption.cliFlag,
+	mutedOption.cliFlag,
+	noOpenOption.cliFlag,
+	numberOfGifLoopsOption.cliFlag,
+	numberOfSharedAudioTagsOption.cliFlag,
+	offthreadVideoCacheSizeInBytesOption.cliFlag,
+	offthreadVideoThreadsOption.cliFlag,
+	'output',
+	pixelFormatOption.cliFlag,
+	portOption.cliFlag,
+	previewSampleRateOption.cliFlag,
+	proResProfileOption.cliFlag,
+	publicDirOption.cliFlag,
+	publicLicenseKeyOption.cliFlag,
+	'q',
+	'quiet',
+	reproOption.cliFlag,
+	rspackOption.cliFlag,
+	sampleRateOption.cliFlag,
+	scaleOption.cliFlag,
+	userAgentOption.cliFlag,
+	videoBitrateOption.cliFlag,
+	videoCodecOption.cliFlag,
+	videoImageFormatOption.cliFlag,
+	webpackPollOption.cliFlag,
+	x264Option.cliFlag,
+];
+
+const renderFlags = [
+	...commonFlags,
+	askAIOption.cliFlag,
+	audioBitrateOption.cliFlag,
+	audioCodecOption.cliFlag,
+	audioLatencyHintOption.cliFlag,
+	binariesDirectoryOption.cliFlag,
+	browserExecutableOption.cliFlag,
+	bundleCacheOption.cliFlag,
+	chromeModeOption.cliFlag,
+	colorSpaceOption.cliFlag,
+	concurrencyOption.cliFlag,
+	crfOption.cliFlag,
+	darkModeOption.cliFlag,
+	delayRenderTimeoutInMillisecondsOption.cliFlag,
+	disableWebSecurityOption.cliFlag,
+	disallowParallelEncodingOption.cliFlag,
+	enableMultiprocessOnLinuxOption.cliFlag,
+	encodingBufferSizeOption.cliFlag,
+	encodingMaxRateOption.cliFlag,
+	enforceAudioOption.cliFlag,
+	everyNthFrameOption.cliFlag,
+	forSeamlessAacConcatenationOption.cliFlag,
+	framesOption.cliFlag,
+	glOption.cliFlag,
+	gopSizeOption.cliFlag,
+	hardwareAccelerationOption.cliFlag,
+	headlessOption.cliFlag,
+	ignoreCertificateErrorsOption.cliFlag,
+	imageSequenceOption.cliFlag,
+	imageSequencePatternOption.cliFlag,
+	jpegQualityOption.cliFlag,
+	keyboardShortcutsOption.cliFlag,
+	mediaCacheSizeInBytesOption.cliFlag,
+	metadataOption.cliFlag,
+	mutedOption.cliFlag,
+	numberOfGifLoopsOption.cliFlag,
+	offthreadVideoCacheSizeInBytesOption.cliFlag,
+	offthreadVideoThreadsOption.cliFlag,
+	'output',
+	overrideDurationOption.cliFlag,
+	overrideFpsOption.cliFlag,
+	overrideHeightOption.cliFlag,
+	overrideWidthOption.cliFlag,
+	overwriteOption.cliFlag,
+	pixelFormatOption.cliFlag,
+	portOption.cliFlag,
+	proResProfileOption.cliFlag,
+	publicDirOption.cliFlag,
+	publicPathOption.cliFlag,
+	'q',
+	'quiet',
+	reproOption.cliFlag,
+	rspackOption.cliFlag,
+	sampleRateOption.cliFlag,
+	scaleOption.cliFlag,
+	separateAudioOption.cliFlag,
+	stillFrameOption.cliFlag,
+	userAgentOption.cliFlag,
+	videoBitrateOption.cliFlag,
+	videoCodecOption.cliFlag,
+	videoImageFormatOption.cliFlag,
+	x264Option.cliFlag,
+];
+
+export type CommandWithRecognizedFlags = 'render' | 'studio';
+
+export const getUnrecognizedCliFlags = ({
+	args,
+	command,
+}: {
+	args: string[];
+	command: CommandWithRecognizedFlags;
+}) => {
+	const recognizedFlags = new Set<string>(
+		command === 'studio' ? studioFlags : renderFlags,
+	);
+	const passedFlags = new Set<string>();
+
+	for (const arg of args) {
+		if (arg === '--') {
+			break;
+		}
+
+		if (arg.startsWith('--') && arg.length > 2) {
+			const flag = arg.slice(2);
+			const equalsSign = flag.indexOf('=');
+			passedFlags.add(equalsSign === -1 ? flag : flag.slice(0, equalsSign));
+		} else if (/^-[a-zA-Z]/.test(arg)) {
+			const flag = arg.slice(1);
+			const equalsSign = flag.indexOf('=');
+			passedFlags.add(equalsSign === -1 ? flag : flag.slice(0, equalsSign));
+		}
+	}
+
+	return [...passedFlags].filter((flag) => !recognizedFlags.has(flag));
+};
+
+export const warnAboutUnrecognizedCliFlags = ({
+	args,
+	command,
+	logLevel,
+}: {
+	args: string[];
+	command: CommandWithRecognizedFlags;
+	logLevel: LogLevel;
+}) => {
+	const unrecognizedFlags = getUnrecognizedCliFlags({args, command});
+
+	for (const flag of unrecognizedFlags) {
+		Log.warn(
+			{indent: false, logLevel},
+			`"--${flag}" is not a valid flag for "npx remotion ${command}". This will fail in the future.`,
+		);
+	}
+};


### PR DESCRIPTION
## Summary

- warn when `remotion studio`, `remotion preview`, or `remotion render` receives a flag that the command does not recognize
- keep global and deferred Studio render flags in the recognized command-specific sets
- note that unsupported flags will become errors in the future

## Testing

- `bun test packages/cli/src/test/warn-about-unrecognized-cli-flags.test.ts`
- `bun run build`
- `bun run stylecheck`
