### PR TITLE
`@remotion/studio`: Respect trimBefore when freezing sequences

### DIFF
--- a/packages/studio/src/components/Timeline/use-sequence-freeze-frame-menu-item.ts
+++ b/packages/studio/src/components/Timeline/use-sequence-freeze-frame-menu-item.ts
@@ -11,6 +11,26 @@ export const shouldShowFreezeFrameMenuItem = (sequence: TSequence): boolean => {
 	return sequence.type !== 'audio';
 };
 
+export const calculateSequenceFreezeFrame = ({
+	sequence,
+	sequenceFrameOffset,
+	timelinePosition,
+}: {
+	readonly sequence: TSequence;
+	readonly sequenceFrameOffset: number;
+	readonly timelinePosition: number;
+}): number => {
+	const rawFreezeFrame = Math.round(
+		timelinePosition - sequence.from + sequenceFrameOffset,
+	);
+	const minFrame = sequenceFrameOffset;
+	const maxFrame = Number.isFinite(sequence.duration)
+		? Math.max(minFrame, sequence.duration + sequenceFrameOffset - 1)
+		: Infinity;
+
+	return Math.min(Math.max(minFrame, rawFreezeFrame), maxFrame);
+};
+
 export const useSequenceFreezeFrameMenuItem = ({
 	clientId,
 	nodePath,
@@ -57,13 +77,11 @@ export const useSequenceFreezeFrameMenuItem = ({
 			return;
 		}
 
-		const rawFreezeFrame = Math.round(
-			timelinePosition - sequence.from + sequenceFrameOffset,
-		);
-		const maxFrame = Number.isFinite(sequence.duration)
-			? Math.max(0, sequence.duration - 1)
-			: rawFreezeFrame;
-		const freezeFrame = Math.min(Math.max(0, rawFreezeFrame), maxFrame);
+		const freezeFrame = calculateSequenceFreezeFrame({
+			sequence,
+			sequenceFrameOffset,
+			timelinePosition,
+		});
 		const remove = isFrozen;
 
 		saveSequenceProps({
@@ -89,9 +107,7 @@ export const useSequenceFreezeFrameMenuItem = ({
 		clientId,
 		isFrozen,
 		nodePath,
-		sequence.controls,
-		sequence.duration,
-		sequence.from,
+		sequence,
 		sequenceFrameOffset,
 		setPropStatuses,
 		timelinePosition,

--- a/packages/studio/src/test/sequence-context-menu-items.test.ts
+++ b/packages/studio/src/test/sequence-context-menu-items.test.ts
@@ -2,6 +2,7 @@ import {afterEach, expect, test} from 'bun:test';
 import type {TSequence} from 'remotion';
 import type {ComboboxValue} from '../components/NewComposition/ComboBox';
 import {getSequenceContextMenuItems} from '../components/Timeline/get-sequence-context-menu-items';
+import {getTimelineMediaStartFrame} from '../components/Timeline/get-timeline-media-start-frame';
 import {
 	calculateSequenceFreezeFrame,
 	shouldShowFreezeFrameMenuItem,
@@ -202,4 +203,33 @@ test('sequence freeze frame accounts for trimBefore', () => {
 			timelinePosition: 119,
 		}),
 	).toBe(139);
+});
+
+test('video freeze preserves the media frame under the playhead at different playback rates', () => {
+	const mediaFrameAtSequenceZero = 5;
+	const playbackRate = 2;
+	const sequence = {
+		duration: 120,
+		from: 0,
+		mediaFrameAtSequenceZero,
+		playbackRate,
+		type: 'video',
+	} as Extract<TSequence, {type: 'video'}>;
+	const timelinePosition = 40;
+	const freezeFrame = calculateSequenceFreezeFrame({
+		sequence,
+		sequenceFrameOffset: 0,
+		timelinePosition,
+	});
+	const mediaFrameUnderPlayhead = getTimelineMediaStartFrame({
+		startMediaFrom: mediaFrameAtSequenceZero,
+		mediaFrameAtSequenceZero,
+		sequenceFrameOffset: timelinePosition,
+		playbackRate,
+	});
+	const mediaFrameAfterFreeze =
+		mediaFrameAtSequenceZero + freezeFrame * playbackRate;
+
+	expect(freezeFrame).toBe(timelinePosition);
+	expect(mediaFrameAfterFreeze).toBe(mediaFrameUnderPlayhead);
 });

--- a/packages/studio/src/test/sequence-context-menu-items.test.ts
+++ b/packages/studio/src/test/sequence-context-menu-items.test.ts
@@ -2,7 +2,10 @@ import {afterEach, expect, test} from 'bun:test';
 import type {TSequence} from 'remotion';
 import type {ComboboxValue} from '../components/NewComposition/ComboBox';
 import {getSequenceContextMenuItems} from '../components/Timeline/get-sequence-context-menu-items';
-import {shouldShowFreezeFrameMenuItem} from '../components/Timeline/use-sequence-freeze-frame-menu-item';
+import {
+	calculateSequenceFreezeFrame,
+	shouldShowFreezeFrameMenuItem,
+} from '../components/Timeline/use-sequence-freeze-frame-menu-item';
 
 const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
 	globalThis,
@@ -170,4 +173,33 @@ test('sequence freeze context menu item is hidden for audio', () => {
 	expect(shouldShowFreezeFrameMenuItem({type: 'sequence'} as TSequence)).toBe(
 		true,
 	);
+});
+
+test('sequence freeze frame accounts for trimBefore', () => {
+	const sequence = {
+		duration: 120,
+		from: 0,
+	} as TSequence;
+
+	expect(
+		calculateSequenceFreezeFrame({
+			sequence,
+			sequenceFrameOffset: 20,
+			timelinePosition: -10,
+		}),
+	).toBe(20);
+	expect(
+		calculateSequenceFreezeFrame({
+			sequence,
+			sequenceFrameOffset: 20,
+			timelinePosition: 0,
+		}),
+	).toBe(20);
+	expect(
+		calculateSequenceFreezeFrame({
+			sequence,
+			sequenceFrameOffset: 20,
+			timelinePosition: 119,
+		}),
+	).toBe(139);
 });


### PR DESCRIPTION
## Summary

- clamp Studio freeze frames to the sequence's visible local frame range
- preserve `trimBefore` offsets when freezing before or near the end of a sequence
- add regression coverage for trimmed sequence freeze-frame calculation

## Testing

- `bun test packages/studio/src`
- `bun run build`
- `bun run stylecheck`

Closes #9407
