### PR TITLE
`@remotion/studio`: Snap layers to timeline start

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -25,6 +25,7 @@ import {TRANSPARENT} from '../../helpers/colors';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {sortItemsByNonceHistory} from '../../helpers/sort-by-nonce-history';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
+import {EditorSnappingContext} from '../../state/editor-snapping';
 import {
 	forceSpecificCursor,
 	stopForcingSpecificCursor,
@@ -44,6 +45,7 @@ import {
 } from './TimelineSelection';
 
 const HANDLE_WIDTH = 6;
+export const timelineSequenceFromDragSnapThresholdPx = 10;
 
 const baseStyle: React.CSSProperties = {
 	position: 'absolute',
@@ -76,6 +78,7 @@ export type TimelineSequenceLeftEdgeDragTarget = {
 };
 
 export type TimelineSequenceFromDragTarget = {
+	readonly canSnapToTimelineStart: boolean;
 	readonly effectKeyframes: TimelineSequenceEffectKeyframeDragTarget[];
 	readonly fileName: string;
 	readonly initialFrom: number;
@@ -468,6 +471,53 @@ export const getTimelineSequenceFromDragValue = ({
 	readonly deltaFrames: number;
 }) => initialFrom + deltaFrames;
 
+export const getTimelineSequenceFromDragDelta = ({
+	deltaFrames,
+	pxPerFrame,
+	snappingEnabled,
+	targets,
+}: {
+	readonly deltaFrames: number;
+	readonly pxPerFrame: number;
+	readonly snappingEnabled: boolean;
+	readonly targets: readonly TimelineSequenceFromDragTarget[];
+}) => {
+	if (!snappingEnabled) {
+		return deltaFrames;
+	}
+
+	let closestSnap:
+		| {
+				readonly deltaFrames: number;
+				readonly distancePx: number;
+		  }
+		| undefined;
+	for (const target of targets) {
+		if (!target.canSnapToTimelineStart) {
+			continue;
+		}
+
+		const nextFrom = getTimelineSequenceFromDragValue({
+			initialFrom: target.initialFrom,
+			deltaFrames,
+		});
+		const distancePx = Math.abs(nextFrom * pxPerFrame);
+		if (
+			distancePx > timelineSequenceFromDragSnapThresholdPx ||
+			(closestSnap && closestSnap.distancePx <= distancePx)
+		) {
+			continue;
+		}
+
+		closestSnap = {
+			deltaFrames: -target.initialFrom,
+			distancePx,
+		};
+	}
+
+	return closestSnap?.deltaFrames ?? deltaFrames;
+};
+
 export const getTimelineSequenceFromDragChanges = ({
 	targets,
 	deltaFrames,
@@ -808,6 +858,7 @@ export const getTimelineSequenceFromDragTargets = ({
 					propStatuses,
 				});
 			targets.set(key, {
+				canSnapToTimelineStart: originalSequence.parent === null,
 				effectKeyframes,
 				fileName: nodePath.absolutePath,
 				initialFrom: originalSequence.from,
@@ -1152,6 +1203,7 @@ export const useTimelineSequenceFromDrag = ({
 	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
+	const {editorSnapping} = useContext(EditorSnappingContext);
 
 	const [dragging, setDragging] = useState(false);
 	const dragStateRef = useRef<{
@@ -1171,6 +1223,7 @@ export const useTimelineSequenceFromDrag = ({
 		clearEffectDragOverrides,
 		previewServerState,
 		overrideIdToNodePathMappings,
+		editorSnapping,
 	});
 	latestRef.current = {
 		nodePathInfo,
@@ -1181,6 +1234,7 @@ export const useTimelineSequenceFromDrag = ({
 		clearEffectDragOverrides,
 		previewServerState,
 		overrideIdToNodePathMappings,
+		editorSnapping,
 	};
 
 	const finishDrag = useCallback((commit: boolean) => {
@@ -1328,7 +1382,12 @@ export const useTimelineSequenceFromDrag = ({
 			}
 
 			const dx = e.clientX - dragState.initialClientX;
-			const deltaFrames = Math.round(dx / dragState.pxPerFrame);
+			const deltaFrames = getTimelineSequenceFromDragDelta({
+				deltaFrames: Math.round(dx / dragState.pxPerFrame),
+				pxPerFrame: dragState.pxPerFrame,
+				snappingEnabled: latestRef.current.editorSnapping,
+				targets: dragState.targets,
+			});
 			dragState.latestDeltaFrames = deltaFrames;
 			for (const target of dragState.targets) {
 				const nextFrom = getTimelineSequenceFromDragValue({

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -113,6 +113,7 @@ import {
 	getTimelineSequenceDurationDragTargets,
 	getTimelineSequenceDurationDragValue,
 	getTimelineSequenceFromDragChanges,
+	getTimelineSequenceFromDragDelta,
 	getTimelineSequenceFromDragKeyframeMoves,
 	getTimelineSequenceFromDragTargets,
 	getTimelineSequenceFromDragValue,
@@ -122,6 +123,7 @@ import {
 	isCascadingSequence,
 	isTimelineSequenceDurationDraggable,
 	isTimelineSequenceLeftEdgeDraggable,
+	timelineSequenceFromDragSnapThresholdPx,
 } from '../components/Timeline/TimelineSequenceRightEdgeDragHandle';
 import {
 	parsedTransformOriginToUv,
@@ -2407,6 +2409,66 @@ test('Timeline from drag supports negative offsets', () => {
 	).toBe(-6);
 });
 
+test('Timeline from drag snaps a root sequence to frame 0', () => {
+	const nodePath = makeNodePathInfo(['body', 0], []).sequenceSubscriptionKey;
+	const target = {
+		canSnapToTimelineStart: true,
+		effectKeyframes: [],
+		fileName: nodePath.absolutePath,
+		initialFrom: 8,
+		nodePath,
+		sequenceKeyframes: [],
+	};
+	const pxPerFrame = timelineSequenceFromDragSnapThresholdPx / 2;
+
+	expect(
+		getTimelineSequenceFromDragDelta({
+			deltaFrames: -6,
+			pxPerFrame,
+			snappingEnabled: true,
+			targets: [target],
+		}),
+	).toBe(-8);
+	expect(
+		getTimelineSequenceFromDragDelta({
+			deltaFrames: -6,
+			pxPerFrame,
+			snappingEnabled: false,
+			targets: [target],
+		}),
+	).toBe(-6);
+	expect(
+		getTimelineSequenceFromDragDelta({
+			deltaFrames: -5,
+			pxPerFrame,
+			snappingEnabled: true,
+			targets: [target],
+		}),
+	).toBe(-5);
+});
+
+test('Timeline from drag does not snap nested sequences to the timeline start', () => {
+	const nodePath = makeNodePathInfo(['body', 0], []).sequenceSubscriptionKey;
+
+	expect(
+		getTimelineSequenceFromDragDelta({
+			deltaFrames: -6,
+			pxPerFrame: timelineSequenceFromDragSnapThresholdPx / 2,
+			snappingEnabled: true,
+			targets: [
+				{
+					canSnapToTimelineStart: false,
+					effectKeyframes: [],
+					fileName: nodePath.absolutePath,
+					initialFrom: 8,
+					nodePath,
+					sequenceKeyframes: [],
+				},
+			],
+		}),
+	).toBe(-6);
+});
+
 test('Timeline from drag saves relative from for nested sequences', () => {
 	const schema = {} satisfies InteractivitySchema;
 	const childNodePathInfo = makeNodePathInfo(['body', 1], []);
@@ -2501,6 +2563,7 @@ test('Timeline from drag removes the prop at the default value', () => {
 	const [change] = getTimelineSequenceFromDragChanges({
 		targets: [
 			{
+				canSnapToTimelineStart: true,
 				effectKeyframes: [],
 				fileName: nodePathInfo.sequenceSubscriptionKey.absolutePath,
 				initialFrom: 5,


### PR DESCRIPTION
## Summary

- Snap root timeline layers to frame 0 when dragged within 10 pixels of the timeline start
- Respect the existing editor snapping toggle
- Keep nested sequence offsets unchanged and add no visual snap indicator

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9396
