### PR TITLE
`@remotion/studio`: Prevent timeline layer names from shrinking

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
@@ -44,6 +44,7 @@ export const TimelineSequenceName: React.FC<{
 			alignSelf: 'stretch',
 			...getTimelineSelectedLabelStyle(selected, false),
 			display: 'inline-flex',
+			flexShrink: 0,
 			fontFamily: 'inherit',
 			fontSize: 12,
 			lineHeight: 'normal',


### PR DESCRIPTION
## Summary

- Prevent the timeline layer name from shrinking when an asset filename is long
- Keep the asset filename as the flexible, ellipsized part of the row

Closes #9298

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
