### PR TITLE
`@remotion/studio`: Harden drag cleanup on unmount

### DIFF
--- a/packages/studio/src/components/ForceSpecificCursor.tsx
+++ b/packages/studio/src/components/ForceSpecificCursor.tsx
@@ -2,6 +2,12 @@ import React, {useMemo} from 'react';
 
 const ref = React.createRef<HTMLDivElement>();
 
+const removeAutomaticCleanupListeners = () => {
+	window.removeEventListener('pointerup', stopForcingSpecificCursor, true);
+	window.removeEventListener('pointercancel', stopForcingSpecificCursor, true);
+	window.removeEventListener('blur', stopForcingSpecificCursor, true);
+};
+
 export const forceSpecificCursor = (cursor: string): void => {
 	if (!ref.current) {
 		throw new Error('ForceSpecificCursor is not mounted');
@@ -9,11 +15,20 @@ export const forceSpecificCursor = (cursor: string): void => {
 
 	ref.current.style.cursor = cursor;
 	ref.current.style.pointerEvents = 'auto';
+
+	// The component which initiated the drag may unmount before it gets a chance
+	// to handle the end of the gesture. Keep this fallback independent from the
+	// initiator so the cursor overlay can never remain stuck.
+	window.addEventListener('pointerup', stopForcingSpecificCursor, true);
+	window.addEventListener('pointercancel', stopForcingSpecificCursor, true);
+	window.addEventListener('blur', stopForcingSpecificCursor, true);
 };
 
 export const stopForcingSpecificCursor = () => {
+	removeAutomaticCleanupListeners();
+
 	if (!ref.current) {
-		throw new Error('ForceSpecificCursor is not mounted');
+		return;
 	}
 
 	ref.current.style.cursor = '';

--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -304,25 +304,38 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 			};
 
 			window.addEventListener('mousemove', moveListener);
-			window.addEventListener(
-				'pointerup',
-				() => {
-					window.removeEventListener('mousemove', moveListener);
-					pointerDownRef.current = false;
-					setDragging(false);
-					stopForcingSpecificCursor();
-					if (lastDragValue !== null && onValueChangeEnd) {
-						onValueChangeEnd(lastDragValue);
-					}
+			const endDrag = (commit: boolean) => {
+				window.removeEventListener('mousemove', moveListener);
+				window.removeEventListener('pointerup', onPointerUp);
+				window.removeEventListener('pointercancel', onPointerCancel);
+				window.removeEventListener('blur', onWindowBlur);
+				pointerDownRef.current = false;
+				setDragging(false);
+				stopForcingSpecificCursor();
+				if (commit && lastDragValue !== null && onValueChangeEnd) {
+					onValueChangeEnd(lastDragValue);
+				}
 
-					setTimeout(() => {
-						setClickLock(false);
-					}, 2);
-				},
-				{
-					once: true,
-				},
-			);
+				setTimeout(() => {
+					setClickLock(false);
+				}, 2);
+			};
+
+			const onPointerUp = () => {
+				endDrag(true);
+			};
+
+			const onPointerCancel = () => {
+				endDrag(false);
+			};
+
+			const onWindowBlur = () => {
+				endDrag(false);
+			};
+
+			window.addEventListener('pointerup', onPointerUp);
+			window.addEventListener('pointercancel', onPointerCancel);
+			window.addEventListener('blur', onWindowBlur);
 		},
 		[
 			_step,

--- a/packages/studio/src/components/Splitter/SplitterHandle.tsx
+++ b/packages/studio/src/components/Splitter/SplitterHandle.tsx
@@ -89,6 +89,8 @@ export const SplitterHandle: React.FC<{
 				current.classList.remove('remotion-splitter-active');
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
+				window.removeEventListener('pointercancel', onPointerCancel);
+				window.removeEventListener('blur', onWindowBlur);
 				endDrag = null;
 				PlayerInternals.updateAllElementsSizes();
 			};
@@ -125,8 +127,18 @@ export const SplitterHandle: React.FC<{
 				endDrag?.();
 			};
 
+			const onPointerCancel = () => {
+				endDrag?.();
+			};
+
+			const onWindowBlur = () => {
+				endDrag?.();
+			};
+
 			window.addEventListener('pointermove', onPointerMove);
 			window.addEventListener('pointerup', onPointerUp);
+			window.addEventListener('pointercancel', onPointerCancel);
+			window.addEventListener('blur', onWindowBlur);
 		};
 
 		current.addEventListener('pointerdown', onPointerDown);

--- a/packages/studio/src/components/Timeline/TimelineInOutDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineInOutDragHandler.tsx
@@ -297,6 +297,15 @@ const TimelineInOutDragHandlerInner: React.FC = () => {
 		],
 	);
 
+	const onPointerCancelInOut = useCallback(() => {
+		document.body.style.userSelect = '';
+		document.body.style.webkitUserSelect = '';
+		stopForcingSpecificCursor();
+		setInOutDragging({
+			dragging: false,
+		});
+	}, []);
+
 	useEffect(() => {
 		if (inOutDragging.dragging === false) {
 			return;
@@ -304,11 +313,28 @@ const TimelineInOutDragHandlerInner: React.FC = () => {
 
 		window.addEventListener('pointermove', onPointerMoveInOut);
 		window.addEventListener('pointerup', onPointerUpInOut);
+		window.addEventListener('pointercancel', onPointerCancelInOut);
+		window.addEventListener('blur', onPointerCancelInOut);
 		return () => {
 			window.removeEventListener('pointermove', onPointerMoveInOut);
 			window.removeEventListener('pointerup', onPointerUpInOut);
+			window.removeEventListener('pointercancel', onPointerCancelInOut);
+			window.removeEventListener('blur', onPointerCancelInOut);
 		};
-	}, [inOutDragging.dragging, onPointerMoveInOut, onPointerUpInOut]);
+	}, [
+		inOutDragging.dragging,
+		onPointerCancelInOut,
+		onPointerMoveInOut,
+		onPointerUpInOut,
+	]);
+
+	useEffect(() => {
+		return () => {
+			document.body.style.userSelect = '';
+			document.body.style.webkitUserSelect = '';
+			stopForcingSpecificCursor();
+		};
+	}, []);
 
 	const inContextMenu = useMemo((): ComboboxValue[] => {
 		return [

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -964,15 +964,15 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 
 	const finishDrag = useCallback((commit: boolean) => {
 		const dragState = dragStateRef.current;
+		if (!dragState) {
+			return;
+		}
+
 		dragStateRef.current = null;
 		document.body.style.userSelect = '';
 		document.body.style.webkitUserSelect = '';
 		stopForcingSpecificCursor();
 		setDragging(false);
-
-		if (!dragState) {
-			return;
-		}
 
 		const {
 			setPropStatuses: latestSetPropStatuses,
@@ -1158,6 +1158,7 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 			window.removeEventListener('pointerup', onUp);
 			window.removeEventListener('pointercancel', onCancel);
 			window.removeEventListener('blur', onWindowBlur);
+			finishDrag(false);
 		};
 	}, [dragging, finishDrag]);
 
@@ -1239,14 +1240,14 @@ export const useTimelineSequenceFromDrag = ({
 
 	const finishDrag = useCallback((commit: boolean) => {
 		const dragState = dragStateRef.current;
+		if (!dragState) {
+			return;
+		}
+
 		dragStateRef.current = null;
 		document.body.style.userSelect = '';
 		document.body.style.webkitUserSelect = '';
 		setDragging(false);
-
-		if (!dragState) {
-			return;
-		}
 
 		const {
 			setPropStatuses: latestSetPropStatuses,
@@ -1462,6 +1463,7 @@ export const useTimelineSequenceFromDrag = ({
 			window.removeEventListener('pointerup', onUp);
 			window.removeEventListener('pointercancel', onCancel);
 			window.removeEventListener('blur', onWindowBlur);
+			finishDrag(false);
 		};
 	}, [dragging, finishDrag]);
 
@@ -1518,15 +1520,15 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 
 	const finishDrag = useCallback((commit: boolean) => {
 		const dragState = dragStateRef.current;
+		if (!dragState) {
+			return;
+		}
+
 		dragStateRef.current = null;
 		document.body.style.userSelect = '';
 		document.body.style.webkitUserSelect = '';
 		stopForcingSpecificCursor();
 		setDragging(false);
-
-		if (!dragState) {
-			return;
-		}
 
 		const {
 			setPropStatuses: latestSetPropStatuses,
@@ -1699,6 +1701,7 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 			window.removeEventListener('pointerup', onUp);
 			window.removeEventListener('pointercancel', onCancel);
 			window.removeEventListener('blur', onWindowBlur);
+			finishDrag(false);
 		};
 	}, [dragging, finishDrag]);
 


### PR DESCRIPTION
## Summary

- reset the forced Studio cursor from a lifecycle-independent pointer cleanup
- cancel drag sessions on pointer cancellation, window blur, and initiator unmount
- discard transient timeline overrides instead of committing cancelled drags

## Testing

- `bun test src` in `packages/studio` (499 tests)
- `bun run build`
- `bun run stylecheck`

Closes #9460
