### PR TITLE
@remotion/renderer: Clarify --disable-headless does not work on Windows

### DIFF
--- a/packages/renderer/src/options/headless.tsx
+++ b/packages/renderer/src/options/headless.tsx
@@ -16,8 +16,12 @@ export const headlessOption = {
 			</a>
 			, this option is not functional anymore.
 			<br />
-			<br /> If disabled, the render will open an actual Chrome window where you
-			can see the render happen. The default is headless mode.
+			<br /> If disabled, the render was intended to open an actual Chrome
+			window where you can see the render happen. The default is headless mode.
+			<br />
+			<br />
+			This option is known to not work on Windows and may cause the render
+			process to hang.
 		</>
 	),
 	ssrName: 'headless',


### PR DESCRIPTION
Closes #3332

The `--disable-headless` / `headless` option is already deprecated and documented as non-functional with Chrome Headless Shell, but the docs did not mention that it is also broken on Windows and can hang the render process. This change adds that note to the option description so it appears in the CLI help and the generated docs pages.

## Verification

- `bun run format` passed
- `bunx turbo run lint --filter=@remotion/renderer` passed
- `bunx turbo run formatting --filter=@remotion/renderer` passed
- `bun test src/test/boolean-option-precedence.test.ts` passed