### PR TITLE
`remotion`: Bump Zod to 4.4.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1797,7 +1797,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -1842,7 +1842,7 @@
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
         "twoslash-cdn": "0.3.1",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -1902,7 +1902,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -1921,7 +1921,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -1942,7 +1942,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -1968,7 +1968,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2008,7 +2008,7 @@
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
         "tailwind-merge": "3.0.1",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2048,7 +2048,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2126,7 +2126,7 @@
         "remotion": "workspace:*",
         "tailwind-merge": "3.4.0",
         "three": "0.178.0",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2168,7 +2168,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@elevenlabs/elevenlabs-js": "2.20.0",
@@ -2214,7 +2214,7 @@
         "tailwindcss": "4.2.0",
         "vite": "6.4.3",
         "vite-tsconfig-paths": "4.3.2",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@react-router/dev": "7.12.0",
@@ -2267,7 +2267,7 @@
         "remotion": "workspace:*",
         "tailwind-merge": "1.14.0",
         "tailwindcss-animate": "1.0.7",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2301,7 +2301,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2326,7 +2326,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2347,7 +2347,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2378,7 +2378,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2402,7 +2402,7 @@
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
         "three": "0.178.0",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2426,7 +2426,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@remotion/captions": "workspace:*",
@@ -2460,7 +2460,7 @@
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
         "tailwind-merge": "3.0.1",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2728,7 +2728,7 @@
     "sharp": "0.34.5",
     "three": "0.178.0",
     "vitest": "4.0.9",
-    "zod": "4.3.6",
+    "zod": "4.4.3",
   },
   "packages": {
     "@aashutoshrathi/word-wrap": ["@aashutoshrathi/word-wrap@1.2.6", "", {}, "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="],
@@ -8357,7 +8357,7 @@
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "5.0.2", "compress-commons": "6.0.2", "readable-stream": "4.7.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
@@ -10419,6 +10419,8 @@
 
     "astro/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
+    "astro/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "autoprefixer/browserslist": ["browserslist@4.25.0", "", { "dependencies": { "caniuse-lite": "1.0.30001724", "electron-to-chromium": "1.5.167", "node-releases": "2.0.19", "update-browserslist-db": "1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA=="],
 
     "autoprefixer/postcss": ["postcss@8.4.47", "", { "dependencies": { "nanoid": "3.3.11", "picocolors": "1.1.1", "source-map-js": "1.2.1" } }, "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ=="],
@@ -11098,8 +11100,6 @@
     "ofetch/ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
     "openai/@types/node": ["@types/node@18.14.6", "", {}, "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="],
-
-    "openai/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
 	},
 	"dependencies": {
 		"p-limit": "7.2.0",
-		"typescript": "5.9.3",
 		"turbo": "2.9.14",
+		"typescript": "5.9.3",
 		"@typescript/native-preview": "catalog:"
 	},
 	"packageManager": "bun@1.3.3",
@@ -116,7 +116,7 @@
 			"react-dom": "19.2.3",
 			"eslint": "9.19.0",
 			"prettier": "3.8.1",
-			"zod": "4.3.6",
+			"zod": "4.4.3",
 			"@types/react": "19.2.7",
 			"@types/react-dom": "19.2.3",
 			"@types/node": "20.12.14",

--- a/packages/cli/src/extra-packages.ts
+++ b/packages/cli/src/extra-packages.ts
@@ -5,7 +5,7 @@ export const EXTRA_PACKAGES: Record<string, string> = {
 	'@mediabunny/aac-encoder': '1.50.8',
 	'@mediabunny/flac-encoder': '1.50.8',
 	'@mediabunny/prores': '1.50.8',
-	zod: '4.3.6',
+	zod: '4.4.3',
 };
 
 export const EXTRA_PACKAGES_DOCS: Record<string, string> = {

--- a/packages/cli/src/test/catalog-utils.test.ts
+++ b/packages/cli/src/test/catalog-utils.test.ts
@@ -69,7 +69,7 @@ test('parsePnpmWorkspaceCatalog handles basic, quoted, scoped entries and stops 
 		'  - packages/*',
 		'catalog:',
 		'  react: ^18.3.1',
-		'  zod: 4.3.6',
+		'  zod: 4.4.3',
 		'  "react-dom": "^18.3.1"',
 		"  typescript: '5.8.3'",
 		'  "@remotion/core": 4.0.10',
@@ -81,7 +81,7 @@ test('parsePnpmWorkspaceCatalog handles basic, quoted, scoped entries and stops 
 
 	const result = parsePnpmWorkspaceCatalog(richContent);
 	expect(result.react).toBe('^18.3.1');
-	expect(result.zod).toBe('4.3.6');
+	expect(result.zod).toBe('4.4.3');
 	expect(result['react-dom']).toBe('^18.3.1');
 	expect(result.typescript).toBe('5.8.3');
 	expect(result['@remotion/core']).toBe('4.0.10');
@@ -100,7 +100,7 @@ test('bun-style monorepo: finds workspace root, catalog source, and reads entrie
 				packages: ['packages/*'],
 				catalog: {
 					react: '^19.0.0',
-					zod: '4.3.6',
+					zod: '4.4.3',
 				},
 			},
 		}),
@@ -124,7 +124,7 @@ test('bun-style monorepo: finds workspace root, catalog source, and reads entrie
 
 	expect(getCatalogEntries(tmpDir)).toEqual({
 		react: '^19.0.0',
-		zod: '4.3.6',
+		zod: '4.4.3',
 	});
 });
 
@@ -133,7 +133,7 @@ test('top-level catalog in package.json: finds catalog source and reads entries'
 		path.join(tmpDir, 'package.json'),
 		JSON.stringify({
 			name: 'my-monorepo',
-			catalog: {zod: '4.3.6'},
+			catalog: {zod: '4.4.3'},
 		}),
 	);
 
@@ -144,13 +144,13 @@ test('top-level catalog in package.json: finds catalog source and reads entries'
 		expect(source!.catalogKey).toBe('root');
 	}
 
-	expect(getCatalogEntries(tmpDir)).toEqual({zod: '4.3.6'});
+	expect(getCatalogEntries(tmpDir)).toEqual({zod: '4.4.3'});
 });
 
 test('pnpm monorepo: finds workspace root, catalog source, and reads entries', () => {
 	fs.writeFileSync(
 		path.join(tmpDir, 'pnpm-workspace.yaml'),
-		'packages:\n  - packages/*\ncatalog:\n  zod: 4.3.6\n  react: ^19.0.0\n',
+		'packages:\n  - packages/*\ncatalog:\n  zod: 4.4.3\n  react: ^19.0.0\n',
 	);
 
 	const subPkgDir = path.join(tmpDir, 'packages', 'my-app');
@@ -163,7 +163,7 @@ test('pnpm monorepo: finds workspace root, catalog source, and reads entries', (
 	expect(source!.type).toBe('pnpm-workspace');
 
 	expect(getCatalogEntries(tmpDir)).toEqual({
-		zod: '4.3.6',
+		zod: '4.4.3',
 		react: '^19.0.0',
 	});
 });
@@ -193,7 +193,7 @@ test('updating catalog entries in bun-style package.json', () => {
 					packages: ['packages/*'],
 					catalog: {
 						react: '^18.0.0',
-						zod: '4.3.6',
+						zod: '4.4.3',
 						mediabunny: '1.34.4',
 					},
 				},
@@ -245,7 +245,7 @@ test('updating catalog entries in top-level package.json catalog', () => {
 		JSON.stringify(
 			{
 				name: 'my-monorepo',
-				catalog: {zod: '4.3.6', mediabunny: '1.34.4'},
+				catalog: {zod: '4.4.3', mediabunny: '1.34.4'},
 			},
 			null,
 			'\t',
@@ -263,7 +263,7 @@ test('updating catalog entries in top-level package.json catalog', () => {
 
 	const updated = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
 	expect(updated.catalog.mediabunny).toBe('1.35.0');
-	expect(updated.catalog.zod).toBe('4.3.6');
+	expect(updated.catalog.zod).toBe('4.4.3');
 });
 
 test('updating catalog entries in pnpm-workspace.yaml', () => {
@@ -275,7 +275,7 @@ test('updating catalog entries in pnpm-workspace.yaml', () => {
 			'  - packages/*',
 			'catalog:',
 			'  react: ^18.3.1',
-			'  zod: 4.3.6',
+			'  zod: 4.4.3',
 			'  "react-dom": "^18.3.1"',
 			'  "@aws-sdk/client-s3": 3.986.0',
 			'catalogs:',

--- a/packages/cli/src/test/upgrade-protocols.test.ts
+++ b/packages/cli/src/test/upgrade-protocols.test.ts
@@ -133,7 +133,7 @@ test('includes Remotion and extra packages that only exist in pnpm catalog entri
 		targetVersion: '4.0.462',
 		extraPackageVersions: {
 			mediabunny: '1.50.7',
-			zod: '4.3.6',
+			zod: '4.4.3',
 		},
 	});
 
@@ -149,7 +149,7 @@ test('uses the Mediabunny version for extension packages', () => {
 	expect(
 		resolveExtraPackageVersions({
 			mediabunny: '1.50.8',
-			zod: '4.3.6',
+			zod: '4.4.3',
 		}),
 	).toMatchObject({
 		mediabunny: '1.50.8',
@@ -158,7 +158,7 @@ test('uses the Mediabunny version for extension packages', () => {
 		'@mediabunny/aac-encoder': '1.50.8',
 		'@mediabunny/flac-encoder': '1.50.8',
 		'@mediabunny/prores': '1.50.8',
-		zod: '4.3.6',
+		zod: '4.4.3',
 	});
 });
 
@@ -171,7 +171,7 @@ test('end-to-end: updates catalog in bun-style package.json and preserves catalo
 				workspaces: {
 					packages: ['packages/*'],
 					catalog: {
-						zod: '4.3.6',
+						zod: '4.4.3',
 						mediabunny: '1.34.4',
 						react: '19.2.3',
 					},
@@ -238,7 +238,7 @@ test('end-to-end: updates catalog in pnpm-workspace.yaml', () => {
 			'packages:',
 			'  - packages/*',
 			'catalog:',
-			'  zod: 4.3.6',
+			'  zod: 4.4.3',
 			'  mediabunny: 1.34.4',
 			'  react: ^19.0.0',
 			'',

--- a/packages/studio-shared/src/package-info.ts
+++ b/packages/studio-shared/src/package-info.ts
@@ -132,7 +132,7 @@ export const extraPackages: ExtraPackage[] = [
 	},
 	{
 		name: 'zod',
-		version: '4.3.6',
+		version: '4.4.3',
 		description: 'TypeScript-first schema validation',
 		docsUrl: 'https://zod.dev',
 	},

--- a/packages/studio/src/test/create-zod-values.test.ts
+++ b/packages/studio/src/test/create-zod-values.test.ts
@@ -72,8 +72,7 @@ test('Should be able to create a union', async () => {
 	expect(createZodValues(z.union([z.number(), z.string()]), z, zodTypes)).toBe(
 		0,
 	);
-	// In v4, z.union([]) throws during schema creation
-	expect(() => createZodValues(z.union([]) as never, z, zodTypes)).toThrow();
+	expect(createZodValues(z.union([]) as never, z, zodTypes)).toBeUndefined();
 });
 
 test('Zod literal', async () => {

--- a/packages/template-audiogram/package.json
+++ b/packages/template-audiogram/package.json
@@ -24,7 +24,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-code-hike/package.json
+++ b/packages/template-code-hike/package.json
@@ -17,7 +17,7 @@
     "remotion": "workspace:*",
     "twoslash-cdn": "0.3.1",
     "polished": "4.3.1",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-helloworld/package.json
+++ b/packages/template-helloworld/package.json
@@ -16,7 +16,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-javascript/package.json
+++ b/packages/template-javascript/package.json
@@ -15,7 +15,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-music-visualization/package.json
+++ b/packages/template-music-visualization/package.json
@@ -21,7 +21,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-next-app-tailwind/package.json
+++ b/packages/template-next-app-tailwind/package.json
@@ -31,7 +31,7 @@
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
     "tailwind-merge": "3.0.1",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.0",

--- a/packages/template-next-app/package.json
+++ b/packages/template-next-app/package.json
@@ -23,7 +23,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-next-pages/package.json
+++ b/packages/template-next-pages/package.json
@@ -23,7 +23,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.1.0",

--- a/packages/template-prompt-to-motion-graphics/package.json
+++ b/packages/template-prompt-to-motion-graphics/package.json
@@ -51,7 +51,7 @@
     "remotion": "workspace:*",
     "tailwind-merge": "3.4.0",
     "three": "0.178.0",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.1.0",

--- a/packages/template-prompt-to-video/package.json
+++ b/packages/template-prompt-to-video/package.json
@@ -21,7 +21,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@elevenlabs/elevenlabs-js": "2.20.0",

--- a/packages/template-react-router/package.json
+++ b/packages/template-react-router/package.json
@@ -37,7 +37,7 @@
     "@tailwindcss/vite": "4.2.0",
     "vite": "6.4.3",
     "vite-tsconfig-paths": "4.3.2",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@react-router/dev": "7.12.0",

--- a/packages/template-recorder/package.json
+++ b/packages/template-recorder/package.json
@@ -44,7 +44,7 @@
     "react-dom": "19.2.3",
     "tailwind-merge": "1.14.0",
     "tailwindcss-animate": "1.0.7",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-render-server/package.json
+++ b/packages/template-render-server/package.json
@@ -21,7 +21,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-skia/package.json
+++ b/packages/template-skia/package.json
@@ -19,7 +19,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-stargazer/package.json
+++ b/packages/template-stargazer/package.json
@@ -14,7 +14,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-still/package.json
+++ b/packages/template-still/package.json
@@ -32,7 +32,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-three/package.json
+++ b/packages/template-three/package.json
@@ -20,7 +20,7 @@
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
     "three": "0.178.0",
-    "zod": "4.3.6",
+    "zod": "4.4.3",
     "mediabunny": "1.50.8"
   },
   "devDependencies": {

--- a/packages/template-tiktok/package.json
+++ b/packages/template-tiktok/package.json
@@ -20,7 +20,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-vercel/package.json
+++ b/packages/template-vercel/package.json
@@ -29,7 +29,7 @@
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
     "tailwind-merge": "3.0.1",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.0",


### PR DESCRIPTION
## Summary

- bump the shared Zod version from 4.3.6 to 4.4.3
- update templates, CLI upgrade metadata, package metadata, and test fixtures
- account for Zod 4.4 allowing empty unions to be constructed

## Validation

- `bun test packages/studio/src/test/create-zod-values.test.ts packages/studio/src/test/extract-zod-enums.test.ts packages/cli/src/test/catalog-utils.test.ts packages/cli/src/test/upgrade-protocols.test.ts packages/core/src/test/with-interactivity-schema-helpers.test.ts`
- `bun run build`
- `bun run stylecheck`
