### PR TITLE
`@remotion/studio`: Disable resizing media without explicit duration

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -55,6 +55,7 @@ import {TimelineSequenceFrame} from './TimelineSequenceFrame';
 import {
 	TimelineSequenceLeftEdgeDragHandle,
 	TimelineSequenceRightEdgeDragHandle,
+	canResizeTimelineSequenceDuration,
 	isCascadingSequence,
 	isTimelineSequenceDurationDraggable,
 	isTimelineSequenceLeftEdgeDraggable,
@@ -294,6 +295,13 @@ const TimelineSequenceInner: React.FC<{
 	const durationCanUpdate = Boolean(
 		isStudioInteractivityEnabled() &&
 		propStatusesForOverride?.durationInFrames?.status === 'static',
+	);
+	const durationCanResize = Boolean(
+		isStudioInteractivityEnabled() &&
+		canResizeTimelineSequenceDuration({
+			sequence: s,
+			status: propStatusesForOverride?.durationInFrames,
+		}),
 	);
 	const fromCanUpdate = Boolean(
 		isStudioInteractivityEnabled() &&
@@ -604,7 +612,7 @@ const TimelineSequenceInner: React.FC<{
 		isTimelineSequenceDurationDraggable(s) &&
 		nodePath !== null &&
 		validatedLocation !== null &&
-		durationCanUpdate;
+		durationCanResize;
 	const showLeftEdgeDragHandle =
 		isTimelineSequenceLeftEdgeDraggable(s) &&
 		nodePath !== null &&

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -10,6 +10,7 @@ import React, {
 	useState,
 } from 'react';
 import type {
+	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusKeyframed,
 	OverrideIdToNodePaths,
 	PropStatuses,
@@ -272,6 +273,24 @@ export const isTimelineSequenceDurationDraggable = (sequence: TSequence) => {
 		(!sequence.isInsideSeries || isInteractiveCascadingSequence) &&
 		Boolean(sequence.controls)
 	);
+};
+
+export const canResizeTimelineSequenceDuration = ({
+	sequence,
+	status,
+}: {
+	readonly sequence: TSequence;
+	readonly status: CanUpdateSequencePropStatus | undefined;
+}) => {
+	if (status?.status !== 'static') {
+		return false;
+	}
+
+	if (sequence.type === 'audio' || sequence.type === 'video') {
+		return status.codeValue !== undefined;
+	}
+
+	return true;
 };
 
 export const isTimelineSequenceLeftEdgeDraggable = (sequence: TSequence) => {
@@ -669,7 +688,16 @@ export const getTimelineSequenceDurationDragTargets = ({
 		}
 
 		const nodePath = track.nodePathInfo.sequenceSubscriptionKey;
-		if (!canUpdateDurationInFrames({propStatuses, nodePath})) {
+		const durationStatus = Internals.getPropStatusesCtx(
+			propStatuses,
+			nodePath,
+		)?.durationInFrames;
+		if (
+			!canResizeTimelineSequenceDuration({
+				sequence: originalSequence,
+				status: durationStatus,
+			})
+		) {
 			return null;
 		}
 

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1599,6 +1599,37 @@ test('Timeline duration drag supports interactive video clips', () => {
 	]);
 });
 
+test('Timeline duration drag rejects media without an explicit duration', () => {
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const audio = makeTimelineSequence({
+		schema: Internals.baseSchema,
+		type: 'audio',
+		duration: 78,
+	});
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+
+	expect(isTimelineSequenceDurationDraggable(audio)).toBe(true);
+	expect(
+		getTimelineSequenceDurationDragTargets({
+			draggedNodePathInfo: nodePathInfo,
+			selectedItems: [{type: 'sequence', nodePathInfo}],
+			sequences: [audio],
+			overrideIdsToNodePaths: {
+				override: nodePath,
+			},
+			propStatuses: {
+				[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+					canUpdate: true,
+					props: {
+						durationInFrames: {status: 'static', codeValue: undefined},
+					},
+					effects: [],
+				},
+			},
+		}),
+	).toBe(null);
+});
+
 test('Timeline duration drag supports interactive cascading sequence rows', () => {
 	const baseSequence = makeTimelineSequence({
 		schema: Internals.baseSchema,


### PR DESCRIPTION
## Summary

- hide the right-edge resize handle for audio and video without an explicit `durationInFrames`
- reject duration drag targets for the same case to keep pointer handling consistent
- add regression coverage for audio with an omitted duration

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9268
