### PR TITLE
`@remotion/studio`: Let rulers cover the full canvas

### DIFF
--- a/packages/studio/src/components/EditorRuler/Ruler.tsx
+++ b/packages/studio/src/components/EditorRuler/Ruler.tsx
@@ -10,8 +10,8 @@ import {Internals} from 'remotion';
 import {BACKGROUND, RULER_COLOR} from '../../helpers/colors';
 import {getRulerGuideHighlight} from '../../helpers/editor-guide-selection';
 import {drawMarkingOnRulerCanvas} from '../../helpers/editor-ruler';
+import {getRulerCanvasSize} from '../../helpers/ruler-canvas-size';
 import {EditorShowGuidesContext} from '../../state/editor-guides';
-import {RULER_WIDTH} from '../../state/editor-rulers';
 import {forceSpecificCursor} from '../ForceSpecificCursor';
 import {PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR} from '../Timeline/should-clear-selection-on-pointer-down';
 import {useTimelineSelection} from '../Timeline/TimelineSelection';
@@ -75,8 +75,10 @@ const Ruler: React.FC<RulerProps> = ({
 		[draggingGuideId, guidesList, hoveredGuideId, selectedItems],
 	);
 
-	const rulerWidth = isVerticalRuler ? RULER_WIDTH : size.width - RULER_WIDTH;
-	const rulerHeight = isVerticalRuler ? size.height - RULER_WIDTH : RULER_WIDTH;
+	const {width: rulerWidth, height: rulerHeight} = getRulerCanvasSize({
+		orientation,
+		size,
+	});
 
 	useEffect(() => {
 		drawMarkingOnRulerCanvas({

--- a/packages/studio/src/helpers/ruler-canvas-size.ts
+++ b/packages/studio/src/helpers/ruler-canvas-size.ts
@@ -20,3 +20,23 @@ export const applyRulerInsetsToCanvasSize = ({
 		height: size.height - RULER_WIDTH,
 	};
 };
+
+export const getRulerCanvasSize = ({
+	orientation,
+	size,
+}: {
+	readonly orientation: 'horizontal' | 'vertical';
+	readonly size: Size;
+}) => {
+	if (orientation === 'vertical') {
+		return {
+			height: size.height,
+			width: RULER_WIDTH,
+		};
+	}
+
+	return {
+		height: RULER_WIDTH,
+		width: size.width,
+	};
+};

--- a/packages/studio/src/test/canvas-rulers.test.ts
+++ b/packages/studio/src/test/canvas-rulers.test.ts
@@ -9,12 +9,13 @@ Object.defineProperty(globalThis, 'localStorage', {
 });
 
 const getRulerModules = async () => {
-	const [{applyRulerInsetsToCanvasSize}, {RULER_WIDTH}] = await Promise.all([
-		import('../helpers/ruler-canvas-size'),
-		import('../state/editor-rulers'),
-	]);
+	const [{applyRulerInsetsToCanvasSize, getRulerCanvasSize}, {RULER_WIDTH}] =
+		await Promise.all([
+			import('../helpers/ruler-canvas-size'),
+			import('../state/editor-rulers'),
+		]);
 
-	return {applyRulerInsetsToCanvasSize, RULER_WIDTH};
+	return {applyRulerInsetsToCanvasSize, getRulerCanvasSize, RULER_WIDTH};
 };
 
 const size = {
@@ -47,4 +48,26 @@ test('canvas size is unchanged if rulers are hidden', async () => {
 	expect(applyRulerInsetsToCanvasSize({rulersAreVisible: false, size})).toBe(
 		size,
 	);
+});
+
+test('rulers cover the full inset canvas size', async () => {
+	const {applyRulerInsetsToCanvasSize, getRulerCanvasSize, RULER_WIDTH} =
+		await getRulerModules();
+	const insetSize = applyRulerInsetsToCanvasSize({
+		rulersAreVisible: true,
+		size,
+	});
+
+	expect(
+		getRulerCanvasSize({orientation: 'horizontal', size: insetSize}),
+	).toEqual({
+		height: RULER_WIDTH,
+		width: insetSize.width,
+	});
+	expect(
+		getRulerCanvasSize({orientation: 'vertical', size: insetSize}),
+	).toEqual({
+		height: insetSize.height,
+		width: RULER_WIDTH,
+	});
 });


### PR DESCRIPTION
## Summary

- let the horizontal and vertical Studio rulers cover the full inset canvas
- avoid applying the ruler width twice when sizing the ruler canvases
- add a regression test for both ruler orientations

## Testing

- `bun test packages/studio/src/test/canvas-rulers.test.ts`
- `bun run build`
- `bun run stylecheck`
- verified in Remotion Studio

Closes #9343
