### PR TITLE
`@remotion/studio`: Keep unselected keyframes visually unselected

### DIFF
--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -629,10 +629,12 @@ export const useTimelineKeyframeDrag = ({
 				}
 
 				setDraggedKeyframes(
-					targets.map((target) => ({
-						nodePathInfo: target.nodePathInfo,
-						frame: target.displayFrame + delta,
-					})),
+					shouldDragExistingSelection
+						? targets.map((target) => ({
+								nodePathInfo: target.nodePathInfo,
+								frame: target.displayFrame + delta,
+							}))
+						: [],
 				);
 				applyDragOverrides({
 					delta,


### PR DESCRIPTION
## Summary

- keep keyframes that start unselected visually unselected while dragging
- preserve the selected appearance when dragging an existing keyframe selection

## Testing

- `bun run build`
- `bun run stylecheck`
- verified in Remotion Studio

Closes https://github.com/remotion-dev/remotion/issues/9561
