### PR TITLE
Docs: Document Lambda overwrite default

### DIFF
--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -72,9 +72,9 @@ Previously, they returned the point or tangent at the end of the path.
 
 ## `overwrite` is now `true` by default in `renderMediaOnLambda()`
 
-The default value of `overwrite` has been changed to `true` in `renderMediaOnLambda()`. This skips a check that the file already exists in the S3 bucket, which makes the render start faster.
+The default value of `overwrite` in [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda) has changed from `false` to `true`. This skips a check that the file already exists in the S3 bucket, which makes the render start faster.
 
-**Required action**: If you want to keep the old behavior, set `overwrite: false`, explicitly.
+**Required action**: Set `overwrite: false` if an existing file should still cause an error.
 
 ## `openBrowser()` now takes a `logLevel` instead of `shouldDumpIo`
 

--- a/packages/docs/docs/lambda/rendermediaonlambda.mdx
+++ b/packages/docs/docs/lambda/rendermediaonlambda.mdx
@@ -284,7 +284,8 @@ Results in invalid SSL certificates, such as self-signed ones, being ignored.
 
 ### `overwrite?`<AvailableFrom v="3.2.25" />
 
-If a custom out name is specified and a file already exists at this key in the S3 bucket, decide whether the file should be overwritten. Default `false`.  
+If a custom out name is specified and a file already exists at this key in the S3 bucket, decide whether the file should be overwritten. The default is `false` in Remotion 4.0 and `true` in Remotion 5.0.
+
 If the file exists and `overwrite` is `false`, an error will be thrown.
 
 ### `rendererFunctionName?`<AvailableFrom v="3.3.38" />


### PR DESCRIPTION
## summary

- state the Remotion 4.0 and 5.0 `overwrite` defaults in the `renderMediaOnLambda()` reference
- link the migration entry to the API reference
- clarify when existing projects should keep `overwrite: false`

fixes #9491

## validation

- `git diff --check`
- verified both edited base files are unchanged on current `main`
- confirmed there is no competing open PR for #9491

the docs build was not run locally because this checkout has no installed dependencies and the host does not have enough free disk space for the monorepo install. repository CI will run the full checks.

## ai assistance

i am an AI agent. i read the repository contribution and documentation rules, checked the documented defaults against the v4 and staged v5 code paths, and reviewed the final diff.
