### PR TITLE
`@remotion/lambda`: Clean up generated site bundles

### DIFF
--- a/packages/lambda/src/api/deploy-site.ts
+++ b/packages/lambda/src/api/deploy-site.ts
@@ -78,7 +78,7 @@ const mandatoryDeploySite = async ({
 	}): DeploySiteOutput => {
 	let generatedBundleDir: string | null = null;
 
-	const result = await deploySiteWithBundle({
+	const deploymentOutcome = await deploySiteWithBundle({
 		bucketName,
 		region,
 		siteName,
@@ -90,7 +90,7 @@ const mandatoryDeploySite = async ({
 		fullClientSpecifics,
 		requestHandler,
 		getBundle: async () => {
-			generatedBundleDir = await fullClientSpecifics.bundleSite({
+			const bundleDir = await fullClientSpecifics.bundleSite({
 				publicPath: `/${getSitesKey(siteName)}/`,
 				bundlerOverride: options.bundlerOverride ?? ((f) => f),
 				rspackOverride: options.rspackOverride ?? ((f) => f),
@@ -104,7 +104,9 @@ const mandatoryDeploySite = async ({
 				gitSource,
 				bufferStateDelayInMilliseconds: null,
 				maxTimelineTracks: null,
-				onDirectoryCreated: () => undefined,
+				onDirectoryCreated: (directory) => {
+					generatedBundleDir = directory;
+				},
 				onPublicDirCopyProgress: () => undefined,
 				onSymlinkDetected: () => undefined,
 				outDir: null,
@@ -117,17 +119,47 @@ const mandatoryDeploySite = async ({
 				symlinkPublicDir: false,
 			});
 
-			return generatedBundleDir;
+			generatedBundleDir = bundleDir;
+			return bundleDir;
 		},
-	});
+	}).then(
+		(result) => ({type: 'success' as const, result}),
+		(error: unknown) => ({type: 'failure' as const, error}),
+	);
 
-	if (generatedBundleDir && fs.existsSync(generatedBundleDir)) {
-		fs.rmSync(generatedBundleDir, {
-			recursive: true,
-		});
+	const cleanupOutcome = (() => {
+		if (generatedBundleDir === null) {
+			return {type: 'success' as const};
+		}
+
+		try {
+			fs.rmSync(generatedBundleDir, {
+				force: true,
+				recursive: true,
+			});
+			return {type: 'success' as const};
+		} catch (error) {
+			return {type: 'failure' as const, error};
+		}
+	})();
+
+	if (deploymentOutcome.type === 'failure') {
+		if (cleanupOutcome.type === 'failure') {
+			throw new AggregateError(
+				[deploymentOutcome.error, cleanupOutcome.error],
+				'Deploying the site failed, and removing the generated bundle also failed.',
+				{cause: deploymentOutcome.error},
+			);
+		}
+
+		throw deploymentOutcome.error;
 	}
 
-	return result;
+	if (cleanupOutcome.type === 'failure') {
+		throw cleanupOutcome.error;
+	}
+
+	return deploymentOutcome.result;
 };
 
 export type InternalDeploySiteInput = MandatoryParameters &

--- a/packages/lambda/src/api/deploy-site.ts
+++ b/packages/lambda/src/api/deploy-site.ts
@@ -78,75 +78,79 @@ const mandatoryDeploySite = async ({
 	}): DeploySiteOutput => {
 	let generatedBundleDir: string | null = null;
 
-	const deploymentOutcome = await deploySiteWithBundle({
-		bucketName,
-		region,
-		siteName,
-		options,
-		privacy,
-		throwIfSiteExists,
-		providerSpecifics,
-		forcePathStyle,
-		fullClientSpecifics,
-		requestHandler,
-		getBundle: async () => {
-			const bundleDir = await fullClientSpecifics.bundleSite({
-				publicPath: `/${getSitesKey(siteName)}/`,
-				bundlerOverride: options.bundlerOverride ?? ((f) => f),
-				rspackOverride: options.rspackOverride ?? ((f) => f),
-				webpackOverride: options.webpackOverride ?? ((f) => f),
-				enableCaching: options.enableCaching ?? true,
-				publicDir: options.publicDir ?? null,
-				rootDir: options.rootDir ?? null,
-				ignoreRegisterRootWarning: options.ignoreRegisterRootWarning ?? false,
-				onProgress: options.onBundleProgress ?? (() => undefined),
-				entryPoint,
-				gitSource,
-				bufferStateDelayInMilliseconds: null,
-				maxTimelineTracks: null,
-				onDirectoryCreated: (directory) => {
-					generatedBundleDir = directory;
-				},
-				onPublicDirCopyProgress: () => undefined,
-				onSymlinkDetected: () => undefined,
-				outDir: null,
-				askAIEnabled: options.askAIEnabled ?? true,
-				interactivityEnabled: options.interactivityEnabled ?? true,
-				audioLatencyHint: null,
-				keyboardShortcutsEnabled: options.keyboardShortcutsEnabled ?? true,
-				renderDefaults: null,
-				rspack: options.rspack ?? false,
-				symlinkPublicDir: false,
-			});
+	let deploymentOutcome:
+		| {type: 'success'; result: Awaited<DeploySiteOutput>}
+		| {type: 'failure'; error: unknown};
 
-			generatedBundleDir = bundleDir;
-			return bundleDir;
-		},
-	}).then(
-		(result) => ({type: 'success' as const, result}),
-		(error: unknown) => ({type: 'failure' as const, error}),
-	);
+	try {
+		const result = await deploySiteWithBundle({
+			bucketName,
+			region,
+			siteName,
+			options,
+			privacy,
+			throwIfSiteExists,
+			providerSpecifics,
+			forcePathStyle,
+			fullClientSpecifics,
+			requestHandler,
+			getBundle: async () => {
+				const bundleDir = await fullClientSpecifics.bundleSite({
+					publicPath: `/${getSitesKey(siteName)}/`,
+					bundlerOverride: options.bundlerOverride ?? ((f) => f),
+					rspackOverride: options.rspackOverride ?? ((f) => f),
+					webpackOverride: options.webpackOverride ?? ((f) => f),
+					enableCaching: options.enableCaching ?? true,
+					publicDir: options.publicDir ?? null,
+					rootDir: options.rootDir ?? null,
+					ignoreRegisterRootWarning: options.ignoreRegisterRootWarning ?? false,
+					onProgress: options.onBundleProgress ?? (() => undefined),
+					entryPoint,
+					gitSource,
+					bufferStateDelayInMilliseconds: null,
+					maxTimelineTracks: null,
+					onDirectoryCreated: (directory) => {
+						generatedBundleDir = directory;
+					},
+					onPublicDirCopyProgress: () => undefined,
+					onSymlinkDetected: () => undefined,
+					outDir: null,
+					askAIEnabled: options.askAIEnabled ?? true,
+					interactivityEnabled: options.interactivityEnabled ?? true,
+					audioLatencyHint: null,
+					keyboardShortcutsEnabled: options.keyboardShortcutsEnabled ?? true,
+					renderDefaults: null,
+					rspack: options.rspack ?? false,
+					symlinkPublicDir: false,
+				});
 
-	const cleanupOutcome = (() => {
-		if (generatedBundleDir === null) {
-			return {type: 'success' as const};
-		}
+				generatedBundleDir = bundleDir;
+				return bundleDir;
+			},
+		});
+		deploymentOutcome = {type: 'success', result};
+	} catch (error) {
+		deploymentOutcome = {type: 'failure', error};
+	}
 
+	let cleanupFailed = false;
+	let cleanupError: unknown;
+	if (generatedBundleDir !== null) {
 		try {
 			fs.rmSync(generatedBundleDir, {
 				force: true,
 				recursive: true,
 			});
-			return {type: 'success' as const};
 		} catch (error) {
-			return {type: 'failure' as const, error};
+			cleanupFailed = true;
+			cleanupError = error;
 		}
-	})();
+	}
 
 	if (deploymentOutcome.type === 'failure') {
-		if (cleanupOutcome.type === 'failure') {
+		if (cleanupFailed) {
 			throw new AggregateError(
-				[deploymentOutcome.error, cleanupOutcome.error],
+				[deploymentOutcome.error, cleanupError],
 				'Deploying the site failed, and removing the generated bundle also failed.',
 				{cause: deploymentOutcome.error},
 			);
@@ -155,8 +159,8 @@ const mandatoryDeploySite = async ({
 		throw deploymentOutcome.error;
 	}
 
-	if (cleanupOutcome.type === 'failure') {
-		throw cleanupOutcome.error;
+	if (cleanupFailed) {
+		throw cleanupError;
 	}
 
 	return deploymentOutcome.result;

--- a/packages/lambda/src/api/upload-dir.ts
+++ b/packages/lambda/src/api/upload-dir.ts
@@ -8,6 +8,7 @@ import type {Privacy, UploadDirProgress} from '@remotion/serverless';
 import mimeTypes from 'mime-types';
 import {makeS3Key} from '../shared/make-s3-key';
 import {multipartUploadPartSize} from '../shared/multipart-upload-part-size';
+import {waitForPromisesToFinish} from '../shared/wait-for-promises-to-finish';
 
 type FileInfo = {
 	name: string;
@@ -141,14 +142,11 @@ export const uploadDir = async ({
 		}
 	};
 
-	const uploadAll = (async () => {
-		const uploads = files.map((filePath) =>
-			limit(async () => {
-				await uploadWithRetry(filePath);
-			}),
-		);
-		await Promise.all(uploads);
-	})();
+	const uploads = files.map((filePath) =>
+		limit(async () => {
+			await uploadWithRetry(filePath);
+		}),
+	);
 
 	const interval = setInterval(() => {
 		onProgress({
@@ -158,6 +156,10 @@ export const uploadDir = async ({
 			filesUploaded: files.filter((f) => progresses[f.name] === f.size).length,
 		});
 	}, 1000);
-	await uploadAll;
-	clearInterval(interval);
+
+	try {
+		await waitForPromisesToFinish(uploads);
+	} finally {
+		clearInterval(interval);
+	}
 };

--- a/packages/lambda/src/shared/deploy-site-with-bundle.ts
+++ b/packages/lambda/src/shared/deploy-site-with-bundle.ts
@@ -12,6 +12,7 @@ import type {
 import {validateBucketName, validatePrivacy} from '@remotion/serverless';
 import {getS3DiffOperations} from './get-s3-operations';
 import {validateSiteName} from './validate-site-name';
+import {waitForPromisesToFinish} from './wait-for-promises-to-finish';
 
 export type DeploySiteOutput = Promise<{
 	serveUrl: string;
@@ -87,18 +88,20 @@ export const deploySiteWithBundle: (
 
 	const subFolder = getSitesKey(siteName);
 
-	const [files, bundleDir] = await Promise.all([
-		providerSpecifics.listObjects({
-			bucketName,
-			expectedBucketOwner: accountId,
-			region,
-			// The `/` is important to not accidentally delete sites with the same name but containing a suffix.
-			prefix: `${subFolder}/`,
-			forcePathStyle,
-			requestHandler,
-		}),
-		getBundle(),
-	]);
+	const filesPromise = providerSpecifics.listObjects({
+		bucketName,
+		expectedBucketOwner: accountId,
+		region,
+		// The `/` is important to not accidentally delete sites with the same name but containing a suffix.
+		prefix: `${subFolder}/`,
+		forcePathStyle,
+		requestHandler,
+	});
+	const bundlePromise = getBundle();
+	const [files, bundleDir] = await waitForPromisesToFinish([
+		filesPromise,
+		bundlePromise,
+	] as const);
 
 	if (throwIfSiteExists && files.length > 0) {
 		throw new Error(
@@ -152,20 +155,20 @@ export const deploySiteWithBundle: (
 	await upload(indexHtmlToUpload);
 
 	const limit = LambdaClientInternals.pLimit(deleteConcurrency);
-	await Promise.all(
-		toDelete.map((d) => {
-			return limit(() => {
-				return providerSpecifics.deleteFile({
-					bucketName,
-					customCredentials: null,
-					key: d.Key as string,
-					region,
-					forcePathStyle,
-					requestHandler,
-				});
+	const deletePromises = toDelete.map((d) => {
+		return limit(() => {
+			return providerSpecifics.deleteFile({
+				bucketName,
+				customCredentials: null,
+				key: d.Key as string,
+				region,
+				forcePathStyle,
+				requestHandler,
 			});
-		}),
-	);
+		});
+	});
+
+	await waitForPromisesToFinish(deletePromises);
 
 	return {
 		serveUrl: LambdaClientInternals.makeS3ServeUrl({

--- a/packages/lambda/src/shared/wait-for-promises-to-finish.ts
+++ b/packages/lambda/src/shared/wait-for-promises-to-finish.ts
@@ -1,0 +1,12 @@
+export const waitForPromisesToFinish = async <
+	T extends readonly PromiseLike<unknown>[],
+>(
+	promises: T,
+) => {
+	try {
+		return await Promise.all(promises);
+	} catch (error) {
+		await Promise.allSettled(promises);
+		throw error;
+	}
+};

--- a/packages/lambda/src/test/integration/deploy-site.test.ts
+++ b/packages/lambda/src/test/integration/deploy-site.test.ts
@@ -1,4 +1,8 @@
-import {expect, test} from 'bun:test';
+import {afterEach, expect, spyOn, test} from 'bun:test';
+import fs, {existsSync, mkdtempSync, writeFileSync} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type {BundleOptions} from '@remotion/bundler';
 import {LambdaClientInternals} from '@remotion/lambda-client';
 import {internalGetOrCreateBucket} from '@remotion/serverless';
 import {internalDeleteSite} from '../../api/delete-site';
@@ -6,6 +10,93 @@ import {internalDeploySite} from '../../api/deploy-site';
 import {mockFullClientSpecifics} from '../mock-implementation';
 import {mockImplementation} from '../mocks/mock-implementation';
 import {getDirFiles} from '../mocks/upload-dir';
+
+const temporaryDirectories: string[] = [];
+
+const makeGeneratedBundle = () => {
+	const directory = mkdtempSync(
+		path.join(os.tmpdir(), 'remotion-generated-bundle-test-'),
+	);
+	temporaryDirectories.push(directory);
+	writeFileSync(path.join(directory, 'index.html'), '<html></html>');
+	writeFileSync(path.join(directory, 'bundle.js'), 'console.log("bundle")');
+	return directory;
+};
+
+const makeBucket = async () => {
+	const {bucketName} = await internalGetOrCreateBucket({
+		region: 'ap-northeast-1',
+		providerSpecifics: mockImplementation,
+		customCredentials: null,
+		enableFolderExpiry: false,
+		forcePathStyle: false,
+		skipPutAcl: false,
+		requestHandler: null,
+		logLevel: 'error',
+	});
+
+	return bucketName;
+};
+
+const makeBundleSite = ({
+	directory,
+	getBundle,
+	onStarted = () => undefined,
+}: {
+	directory: string;
+	getBundle: () => Promise<string>;
+	onStarted?: () => void;
+}): typeof mockFullClientSpecifics.bundleSite => {
+	return ((options: BundleOptions) => {
+		options.onDirectoryCreated?.(directory);
+		onStarted();
+		return getBundle();
+	}) as typeof mockFullClientSpecifics.bundleSite;
+};
+
+const deployGeneratedBundle = ({
+	bucketName,
+	fullClientSpecifics,
+	providerSpecifics = mockImplementation,
+	siteName,
+}: {
+	bucketName: string;
+	fullClientSpecifics: typeof mockFullClientSpecifics;
+	providerSpecifics?: typeof mockImplementation;
+	siteName: string;
+}) => {
+	return internalDeploySite({
+		bucketName,
+		entryPoint: 'entry-point',
+		region: 'ap-northeast-1',
+		siteName,
+		gitSource: null,
+		providerSpecifics,
+		indent: false,
+		logLevel: 'error',
+		options: {},
+		privacy: 'public',
+		throwIfSiteExists: false,
+		forcePathStyle: false,
+		fullClientSpecifics,
+		requestHandler: null,
+	});
+};
+
+const getRejection = <T>(promise: Promise<T>): Promise<unknown> => {
+	return promise.then(
+		() => {
+			throw new Error('Expected the promise to reject');
+		},
+		(error: unknown) => error,
+	);
+};
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		fs.rmSync(directory, {force: true, recursive: true});
+	}
+});
 
 test('Should throw on wrong prefix', async () => {
 	await expect(
@@ -401,4 +492,256 @@ test('Should not delete site with same prefix', async () => {
 			}),
 		].sort(),
 	);
+});
+
+test('Should remove a generated bundle after bundling fails', async () => {
+	const directory = makeGeneratedBundle();
+	const bucketName = await makeBucket();
+	const bundlingError = new Error('Bundling failed');
+	const fullClientSpecifics: typeof mockFullClientSpecifics = {
+		...mockFullClientSpecifics,
+		bundleSite: makeBundleSite({
+			directory,
+			getBundle: () => Promise.reject(bundlingError),
+		}),
+	};
+
+	const error = await getRejection(
+		deployGeneratedBundle({
+			bucketName,
+			fullClientSpecifics,
+			siteName: 'bundling-failure',
+		}),
+	);
+
+	expect(error).toBe(bundlingError);
+	expect(existsSync(directory)).toBe(false);
+});
+
+test('Should wait for bundling to finish after listing fails', async () => {
+	const directory = makeGeneratedBundle();
+	const bucketName = await makeBucket();
+	const listingError = new Error('Listing failed');
+	let resolveBundle: (directory: string) => void = () => undefined;
+	const bundlePromise = new Promise<string>((resolve) => {
+		resolveBundle = resolve;
+	});
+	let markBundleStarted: () => void = () => undefined;
+	const bundleStarted = new Promise<void>((resolve) => {
+		markBundleStarted = resolve;
+	});
+	const fullClientSpecifics: typeof mockFullClientSpecifics = {
+		...mockFullClientSpecifics,
+		bundleSite: makeBundleSite({
+			directory,
+			getBundle: () => bundlePromise,
+			onStarted: markBundleStarted,
+		}),
+	};
+	const providerSpecifics: typeof mockImplementation = {
+		...mockImplementation,
+		listObjects: () => Promise.reject(listingError),
+	};
+
+	let settled = false;
+	const observedDeployment = deployGeneratedBundle({
+		bucketName,
+		fullClientSpecifics,
+		providerSpecifics,
+		siteName: 'listing-failure',
+	}).then(
+		() => {
+			settled = true;
+			return null;
+		},
+		(reason: unknown) => {
+			settled = true;
+			return reason;
+		},
+	);
+
+	await bundleStarted;
+	await Promise.resolve();
+	expect(settled).toBe(false);
+	expect(existsSync(directory)).toBe(true);
+
+	resolveBundle(directory);
+	const error = await observedDeployment;
+	expect(error).toBe(listingError);
+	expect(existsSync(directory)).toBe(false);
+});
+
+test('Should remove a generated bundle after uploading fails', async () => {
+	const directory = makeGeneratedBundle();
+	const bucketName = await makeBucket();
+	const uploadError = new Error('Uploading failed');
+	const fullClientSpecifics: typeof mockFullClientSpecifics = {
+		...mockFullClientSpecifics,
+		bundleSite: makeBundleSite({
+			directory,
+			getBundle: () => Promise.resolve(directory),
+		}),
+		uploadDir: () => Promise.reject(uploadError),
+	};
+
+	const error = await getRejection(
+		deployGeneratedBundle({
+			bucketName,
+			fullClientSpecifics,
+			siteName: 'upload-failure',
+		}),
+	);
+
+	expect(error).toBe(uploadError);
+	expect(existsSync(directory)).toBe(false);
+});
+
+test('Should finish stale file deletions before removing the generated bundle', async () => {
+	const directory = makeGeneratedBundle();
+	const bucketName = await makeBucket();
+	const deletionError = new Error('Deleting failed');
+	let deleteCount = 0;
+	let bundleWasRemovedDuringDeletion = false;
+	const providerSpecifics: typeof mockImplementation = {
+		...mockImplementation,
+		listObjects: () => {
+			return Promise.resolve(
+				Array.from({length: 12}, (_, index) => ({
+					Key: `sites/deletion-failure/stale-${index}.js`,
+					ETag: 'stale-etag',
+					LastModified: new Date(0),
+					Size: 0,
+				})),
+			);
+		},
+		deleteFile: async () => {
+			deleteCount++;
+			if (!existsSync(directory)) {
+				bundleWasRemovedDuringDeletion = true;
+			}
+
+			if (deleteCount === 1) {
+				throw deletionError;
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			if (!existsSync(directory)) {
+				bundleWasRemovedDuringDeletion = true;
+			}
+		},
+	};
+	const fullClientSpecifics: typeof mockFullClientSpecifics = {
+		...mockFullClientSpecifics,
+		bundleSite: makeBundleSite({
+			directory,
+			getBundle: () => Promise.resolve(directory),
+		}),
+		uploadDir: () => Promise.resolve(),
+	};
+
+	const error = await getRejection(
+		deployGeneratedBundle({
+			bucketName,
+			fullClientSpecifics,
+			providerSpecifics,
+			siteName: 'deletion-failure',
+		}),
+	);
+
+	expect(error).toBe(deletionError);
+	expect(deleteCount).toBe(12);
+	expect(bundleWasRemovedDuringDeletion).toBe(false);
+	expect(existsSync(directory)).toBe(false);
+});
+
+test('Should remove a generated bundle after a successful deployment', async () => {
+	const directory = makeGeneratedBundle();
+	const bucketName = await makeBucket();
+	const fullClientSpecifics: typeof mockFullClientSpecifics = {
+		...mockFullClientSpecifics,
+		bundleSite: makeBundleSite({
+			directory,
+			getBundle: () => Promise.resolve(directory),
+		}),
+	};
+
+	const result = await deployGeneratedBundle({
+		bucketName,
+		fullClientSpecifics,
+		siteName: 'successful-cleanup',
+	});
+
+	expect(result.stats.uploadedFiles).toBe(2);
+	expect(existsSync(directory)).toBe(false);
+});
+
+test('Should report a cleanup failure after a successful deployment', async () => {
+	const directory = makeGeneratedBundle();
+	const bucketName = await makeBucket();
+	const cleanupError = new Error('Cleanup failed');
+	const fullClientSpecifics: typeof mockFullClientSpecifics = {
+		...mockFullClientSpecifics,
+		bundleSite: makeBundleSite({
+			directory,
+			getBundle: () => Promise.resolve(directory),
+		}),
+	};
+	const cleanupSpy = spyOn(fs, 'rmSync').mockImplementation(() => {
+		throw cleanupError;
+	});
+
+	let error: unknown;
+	try {
+		error = await getRejection(
+			deployGeneratedBundle({
+				bucketName,
+				fullClientSpecifics,
+				siteName: 'cleanup-failure',
+			}),
+		);
+	} finally {
+		cleanupSpy.mockRestore();
+	}
+
+	expect(error).toBe(cleanupError);
+	expect(existsSync(directory)).toBe(true);
+});
+
+test('Should retain deployment and cleanup errors if both fail', async () => {
+	const directory = makeGeneratedBundle();
+	const bucketName = await makeBucket();
+	const deploymentError = new Error('Deployment failed');
+	const cleanupError = new Error('Cleanup failed');
+	const fullClientSpecifics: typeof mockFullClientSpecifics = {
+		...mockFullClientSpecifics,
+		bundleSite: makeBundleSite({
+			directory,
+			getBundle: () => Promise.resolve(directory),
+		}),
+		uploadDir: () => Promise.reject(deploymentError),
+	};
+	const cleanupSpy = spyOn(fs, 'rmSync').mockImplementation(() => {
+		throw cleanupError;
+	});
+
+	let error: unknown;
+	try {
+		error = await getRejection(
+			deployGeneratedBundle({
+				bucketName,
+				fullClientSpecifics,
+				siteName: 'deployment-and-cleanup-failure',
+			}),
+		);
+	} finally {
+		cleanupSpy.mockRestore();
+	}
+
+	expect(error).toBeInstanceOf(AggregateError);
+	expect((error as AggregateError).errors).toEqual([
+		deploymentError,
+		cleanupError,
+	]);
+	expect((error as AggregateError).cause).toBe(deploymentError);
+	expect(existsSync(directory)).toBe(true);
 });

--- a/packages/lambda/src/test/unit/wait-for-promises-to-finish.test.ts
+++ b/packages/lambda/src/test/unit/wait-for-promises-to-finish.test.ts
@@ -1,0 +1,37 @@
+import {expect, test} from 'bun:test';
+import {waitForPromisesToFinish} from '../../shared/wait-for-promises-to-finish';
+
+test('waits for all promises before rethrowing the first error', async () => {
+	const firstError = new Error('First promise failed');
+	let resolvePending: () => void = () => undefined;
+	let pendingFinished = false;
+	const pendingPromise = new Promise<void>((resolve) => {
+		resolvePending = resolve;
+	}).then(() => {
+		pendingFinished = true;
+	});
+
+	let waitFinished = false;
+	const resultPromise = waitForPromisesToFinish([
+		Promise.reject(firstError),
+		pendingPromise,
+	]).then(
+		() => {
+			waitFinished = true;
+			return null;
+		},
+		(error: unknown) => {
+			waitFinished = true;
+			return error;
+		},
+	);
+
+	await Promise.resolve();
+	await Promise.resolve();
+	expect(waitFinished).toBe(false);
+	expect(pendingFinished).toBe(false);
+
+	resolvePending();
+	expect(await resultPromise).toBe(firstError);
+	expect(pendingFinished).toBe(true);
+});


### PR DESCRIPTION
## Summary

- capture internally generated `deploySite()` bundle directories as soon as the bundler creates them
- wait for concurrent listing, upload, and stale-file deletion work to settle before cleanup
- clean generated bundles on success and failure while preserving the original deployment error when cleanup also fails
- add coverage for bundling, listing, upload, deletion, and cleanup failures

## Why

`deploySite()` writes generated bundles to a directory under `os.tmpdir()`, but this only selects a conventional temporary location. Node.js does not automatically remove directories created there when an operation finishes, the process exits, or an error occurs.

Operating-system cleanup is platform-dependent and may happen only periodically, after a reboot, or not at all. Long-running deployment services, CI workers, and reused containers can therefore accumulate large Remotion bundles and eventually exhaust disk space. This change makes cleanup deterministic once all bundling and deployment work has settled, while leaving caller-owned bundle directories untouched.

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun test packages/lambda/src/test/unit`
- `bun test packages/lambda/src/test/unit/wait-for-promises-to-finish.test.ts packages/lambda/src/test/integration/deploy-site.test.ts packages/lambda/src/test/integration/deploy-site-from-bundle.test.ts`

Closes #9423
