### PR TITLE
`@remotion/rough-notation`: Fix transformed annotations

### DIFF
--- a/packages/rough-notation/src/Annotation.tsx
+++ b/packages/rough-notation/src/Annotation.tsx
@@ -415,7 +415,10 @@ const makeAnnotationComponent = ({
 				_remotionInternalDocumentationLink={`https://www.remotion.dev/docs/rough-notation/${documentationSlug}`}
 				outlineRef={outlineRef}
 			>
-				<span ref={outlineRef} style={{display: 'inline-block'}}>
+				<span
+					ref={outlineRef}
+					style={{display: 'inline-block', position: 'relative'}}
+				>
 					<annotation.Container>
 						{layer === 'behind' ? annotationElement : null}
 						<annotation.Tracker style={style}>{children}</annotation.Tracker>

--- a/packages/rough-notation/src/create-annotation.tsx
+++ b/packages/rough-notation/src/create-annotation.tsx
@@ -1,11 +1,11 @@
 import React, {
-	createContext,
 	createRef,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useState,
 } from 'react';
-import {continueRender, delayRender} from 'remotion';
+import {continueRender, delayRender, useCurrentFrame} from 'remotion';
 import {useElementSize} from './element-size';
 import {render} from './rough';
 import {
@@ -14,26 +14,6 @@ import {
 	type AnnotationConfig,
 	type RoughAnnotationOptions,
 } from './types';
-
-const AnnotationContext = createContext<{
-	readonly svgChildren: React.ReactElement[];
-	readonly setSvgChildren: React.Dispatch<
-		React.SetStateAction<React.ReactElement[]>
-	>;
-}>({
-	setSvgChildren: () => undefined,
-	svgChildren: [],
-});
-
-const MEASURER_SIZE = 100;
-
-const measurerSize: React.CSSProperties = {
-	height: MEASURER_SIZE,
-	width: MEASURER_SIZE,
-	position: 'fixed',
-	opacity: 0,
-	top: -10000,
-};
 
 type ChildrenProps = {
 	readonly children: React.ReactNode;
@@ -53,21 +33,8 @@ type AnnotationProps = Readonly<
 export const createAnnotation = () => {
 	const ref = createRef<HTMLSpanElement>();
 	const svgRef = createRef<SVGSVGElement>();
-	const measurer = createRef<HTMLDivElement>();
-
 	const Container: React.FC<ChildrenProps> = (props) => {
-		const [svgChildren, setSvgChildren] = useState<React.ReactElement[]>([]);
-
-		const value = useMemo(() => {
-			return {setSvgChildren, svgChildren};
-		}, [svgChildren]);
-
-		return (
-			<AnnotationContext.Provider value={value}>
-				{props.children}
-				<div ref={measurer} style={measurerSize} />
-			</AnnotationContext.Provider>
-		);
+		return props.children;
 	};
 
 	const Tracker: React.FC<TrackerProps> = ({children, style}) => {
@@ -99,9 +66,13 @@ export const createAnnotation = () => {
 		progress,
 		...config
 	}) => {
+		const frame = useCurrentFrame();
+		const parsedKey = JSON.stringify(resolveAnnotationConfig(config));
 		const parsed = useMemo(() => {
-			return resolveAnnotationConfig(config);
-		}, [config]);
+			return JSON.parse(parsedKey) as ReturnType<
+				typeof resolveAnnotationConfig
+			>;
+		}, [parsedKey]);
 		const roughJsOptions = useMemo(() => {
 			return resolveRoughOptions({
 				roughness,
@@ -135,22 +106,24 @@ export const createAnnotation = () => {
 			continueRender(initial);
 		}, [initial, size]);
 
-		const scale = measurer.current
-			? measurer.current.getBoundingClientRect().width / MEASURER_SIZE
-			: null;
+		const [svgChildren, setSvgChildren] = useState<React.ReactElement[]>([]);
 
-		const svgChildren =
-			ref.current && scale
-				? render({
-						config: parsed,
-						svg: svgRef.current as SVGSVGElement,
-						element: ref.current,
-						seed: seed ?? 1,
-						scale,
-						progress,
-						options: roughJsOptions,
-					})
-				: [];
+		useLayoutEffect(() => {
+			if (!ref.current || !svgRef.current) {
+				setSvgChildren([]);
+				return;
+			}
+
+			setSvgChildren(
+				render({
+					config: parsed,
+					element: ref.current,
+					seed: seed ?? 1,
+					progress,
+					options: roughJsOptions,
+				}),
+			);
+		}, [frame, parsed, progress, roughJsOptions, seed, size]);
 
 		return (
 			<svg

--- a/packages/rough-notation/src/rough.ts
+++ b/packages/rough-notation/src/rough.ts
@@ -6,49 +6,29 @@ import type {
 	RoughAnnotationOptions,
 } from './types';
 
-const svgRect = ({
-	svg,
-	element,
-	scale,
-}: {
-	readonly svg: SVGSVGElement;
-	readonly element: HTMLElement;
-	readonly scale: number;
-}): Rect => {
-	const rect1 = svg.getBoundingClientRect();
-	const rect2 = element.getBoundingClientRect();
-	const inverseScale = 1 / scale;
-
+export const getLocalRect = (element: HTMLElement): Rect => {
 	return {
-		x: (rect2.x - rect1.x) * inverseScale,
-		y: (rect2.y - rect1.y) * inverseScale,
-		w: rect2.width * inverseScale,
-		h: rect2.height * inverseScale,
+		x: element.offsetLeft,
+		y: element.offsetTop,
+		w: element.offsetWidth,
+		h: element.offsetHeight,
 	};
 };
 
 export const render = ({
-	svg,
 	seed,
 	element,
 	config,
-	scale,
 	progress,
 	options,
 }: {
-	readonly svg: SVGSVGElement;
 	readonly seed: number;
 	readonly element: HTMLElement;
 	readonly config: ResolvedAnnotationConfig;
-	readonly scale: number;
 	readonly progress: number;
 	readonly options: RoughAnnotationOptions;
 }): React.ReactElement[] => {
-	if (scale === 0) {
-		return [];
-	}
-
-	const rect = svgRect({svg, element, scale});
+	const rect = getLocalRect(element);
 	if (rect.w === 0 || rect.h === 0) {
 		return [];
 	}

--- a/packages/rough-notation/src/test/render-annotation.test.tsx
+++ b/packages/rough-notation/src/test/render-annotation.test.tsx
@@ -5,7 +5,22 @@ import {
 	getInstructions,
 	renderAnnotation,
 } from '../render-annotation';
+import {getLocalRect} from '../rough';
 import type {RoughAnnotationOptions} from '../types';
+
+test('annotation geometry uses local layout coordinates', () => {
+	const element = {
+		offsetHeight: 40,
+		offsetLeft: 12,
+		offsetTop: 8,
+		offsetWidth: 100,
+		getBoundingClientRect: () => {
+			throw new Error('Viewport coordinates should not be read');
+		},
+	} as unknown as HTMLElement;
+
+	expect(getLocalRect(element)).toEqual({x: 12, y: 8, w: 100, h: 40});
+});
 
 test('type none renders no annotation paths', () => {
 	const result = renderAnnotation({


### PR DESCRIPTION
## Summary

- measure annotation geometry after the current frame has been committed to the DOM
- generate annotation paths from local layout coordinates instead of viewport coordinates
- keep annotations on the same transform plane as their text while preventing concurrent render jitter
- add regression coverage ensuring viewport bounds are not used for annotation geometry

## Before

https://github.com/user-attachments/assets/2b603133-b377-4660-b7c4-7773e851a75d

## After

https://github.com/user-attachments/assets/2047086a-62ed-4658-aafb-82800e3e6d41

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun test packages/rough-notation/src/test`
- rendered the comparison composition with concurrency 5

Stacked on #9570.
