### PR TITLE
`@remotion/studio`: Prevent visibility toggle double clicks

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
+++ b/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
@@ -118,11 +118,19 @@ export const TimelineLayerEye: React.FC<{
 		}
 	}, [onInvoked]);
 
+	const onDoubleClick: React.MouseEventHandler<HTMLDivElement> = useCallback(
+		(e) => {
+			e.stopPropagation();
+		},
+		[],
+	);
+
 	return (
 		<div
 			style={timelineLayerIconContainer}
 			draggable={false}
 			onDragStart={onDragStart}
+			onDoubleClick={onDoubleClick}
 			onPointerEnter={onPointerEnter}
 			onPointerDown={onPointerDown}
 		>


### PR DESCRIPTION
## Summary

- prevent double-clicks on timeline visibility controls from reaching the row
- preserve click-and-drag visibility toggling across timeline tracks

## Checks

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`

Closes #9574
