### PR TITLE
Internal testbed: Enable experimental Rspack

### DIFF
--- a/packages/example/remotion.config.ts
+++ b/packages/example/remotion.config.ts
@@ -2,9 +2,11 @@ import {Config} from '@remotion/cli/config';
 import {webpackOverride} from './src/webpack-override.mjs';
 
 Config.setOverwriteOutput(true);
+Config.setExperimentalRspackEnabled(true);
 Config.overrideWebpackConfig(async (config) => {
 	await new Promise((resolve) => {
 		setTimeout(resolve, 10);
 	});
 	return webpackOverride(config);
 });
+Config.overrideRspackConfig(webpackOverride);


### PR DESCRIPTION
## Summary

- enable the experimental Rspack bundler in `packages/example`
- apply the existing testbed bundler override to Rspack so MDX, aliases, Tailwind, SCSS, and Skia continue to load

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx remotion compositions` from `packages/example`
