### PR TITLE
`@remotion/studio`: Clamp sidebar width

### DIFF
--- a/packages/studio/src/components/EditorContent.tsx
+++ b/packages/studio/src/components/EditorContent.tsx
@@ -63,6 +63,8 @@ export const EditorContent: React.FC<{
 			maxFlex={0.9}
 			minFlex={0.2}
 			defaultFlex={0.75}
+			maxFlexerSize={null}
+			maxAntiFlexerSize={null}
 		>
 			<SplitterElement sticky={null} type="flexer">
 				{children}

--- a/packages/studio/src/components/Splitter/SplitterContainer.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContainer.tsx
@@ -27,10 +27,21 @@ export const SplitterContainer: React.FC<{
 	readonly orientation: SplitterOrientation;
 	readonly maxFlex: number;
 	readonly minFlex: number;
+	readonly maxFlexerSize: number | null;
+	readonly maxAntiFlexerSize: number | null;
 	readonly id: string;
 	readonly defaultFlex: number;
 	readonly children: React.ReactNode;
-}> = ({orientation, children, defaultFlex, maxFlex, minFlex, id}) => {
+}> = ({
+	orientation,
+	children,
+	defaultFlex,
+	maxFlex,
+	minFlex,
+	maxFlexerSize,
+	maxAntiFlexerSize,
+	id,
+}) => {
 	const [initialTimelineFlex, persistFlex] = useTimelineFlex(id);
 	const [flexValue, setFlexValue] = useState(
 		initialTimelineFlex ?? defaultFlex,
@@ -49,6 +60,8 @@ export const SplitterContainer: React.FC<{
 			id,
 			maxFlex,
 			minFlex,
+			maxFlexerSize,
+			maxAntiFlexerSize,
 			defaultFlex,
 			persistFlex,
 		};
@@ -57,6 +70,8 @@ export const SplitterContainer: React.FC<{
 		flexValue,
 		id,
 		maxFlex,
+		maxFlexerSize,
+		maxAntiFlexerSize,
 		minFlex,
 		orientation,
 		persistFlex,

--- a/packages/studio/src/components/Splitter/SplitterContext.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContext.tsx
@@ -11,6 +11,8 @@ export type TSplitterContext = {
 	ref: React.RefObject<HTMLDivElement | null>;
 	maxFlex: number;
 	minFlex: number;
+	maxFlexerSize: number | null;
+	maxAntiFlexerSize: number | null;
 	defaultFlex: number;
 	id: string;
 	persistFlex: (value: number) => void;
@@ -31,6 +33,8 @@ export const SplitterContext = React.createContext<TSplitterContext>({
 	orientation: 'horizontal',
 	maxFlex: 1,
 	minFlex: 1,
+	maxFlexerSize: null,
+	maxAntiFlexerSize: null,
 	defaultFlex: 1,
 	id: '--',
 	persistFlex: () => undefined,

--- a/packages/studio/src/components/Splitter/SplitterElement.tsx
+++ b/packages/studio/src/components/Splitter/SplitterElement.tsx
@@ -9,6 +9,8 @@ export const SplitterElement: React.FC<{
 	readonly sticky: React.ReactNode | null;
 }> = ({children, type, sticky}) => {
 	const context = useContext(SplitterContext);
+	const maxSize =
+		type === 'flexer' ? context.maxFlexerSize : context.maxAntiFlexerSize;
 
 	const style: React.CSSProperties = useMemo(() => {
 		return {
@@ -19,8 +21,14 @@ export const SplitterElement: React.FC<{
 			position: 'relative',
 			overflow: 'hidden',
 			flexDirection: 'column',
+			maxWidth:
+				context.orientation === 'vertical' ? (maxSize ?? undefined) : undefined,
+			maxHeight:
+				context.orientation === 'horizontal'
+					? (maxSize ?? undefined)
+					: undefined,
 		};
-	}, [context.flexValue, type]);
+	}, [context.flexValue, context.orientation, maxSize, type]);
 
 	const stickStyle: React.CSSProperties = useMemo(() => {
 		return {

--- a/packages/studio/src/components/Splitter/SplitterHandle.tsx
+++ b/packages/studio/src/components/Splitter/SplitterHandle.tsx
@@ -53,7 +53,33 @@ export const SplitterHandle: React.FC<{
 			// value updates on every pointermove, so it must not be re-read live.
 			const dragContext = latest.current.context;
 			const start = {x: e.clientX, y: e.clientY};
-			const startFlex = dragContext.flexValue;
+			const {width: containerWidth, height: containerHeight} =
+				dragContext.ref.current?.getBoundingClientRect() ?? {
+					width: 0,
+					height: 0,
+				};
+			const availableSize =
+				(dragContext.orientation === 'vertical'
+					? containerWidth
+					: containerHeight) - SPLITTER_HANDLE_SIZE;
+			const minFlex =
+				dragContext.maxAntiFlexerSize === null || availableSize <= 0
+					? dragContext.minFlex
+					: Math.max(
+							dragContext.minFlex,
+							1 - dragContext.maxAntiFlexerSize / availableSize,
+						);
+			const maxFlex =
+				dragContext.maxFlexerSize === null || availableSize <= 0
+					? dragContext.maxFlex
+					: Math.min(
+							dragContext.maxFlex,
+							dragContext.maxFlexerSize / availableSize,
+						);
+			const startFlex = Math.min(
+				maxFlex,
+				Math.max(minFlex, dragContext.flexValue),
+			);
 
 			dragContext.isDragging.current = start;
 			forceSpecificCursor(
@@ -74,10 +100,7 @@ export const SplitterHandle: React.FC<{
 
 				const newFlex = startFlex + change;
 				if (clamp) {
-					return Math.min(
-						dragContext.maxFlex,
-						Math.max(dragContext.minFlex, newFlex),
-					);
+					return Math.min(maxFlex, Math.max(minFlex, newFlex));
 				}
 
 				return newFlex;

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -308,6 +308,8 @@ const TimelineInner: React.FC = () => {
 									id="names-to-timeline"
 									maxFlex={0.5}
 									minFlex={0.15}
+									maxFlexerSize={null}
+									maxAntiFlexerSize={null}
 								>
 									<SplitterElement
 										type="flexer"

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -31,6 +31,8 @@ const row: React.CSSProperties = {
 	minHeight: 0,
 };
 
+const MAX_SIDEBAR_WIDTH = 350;
+
 export const useResponsiveSidebarStatus = (): 'collapsed' | 'expanded' => {
 	const {sidebarCollapsedStateLeft} = useContext(SidebarContext);
 	const responsiveLeftStatus = useBreakpoint(1200) ? 'collapsed' : 'expanded';
@@ -111,6 +113,8 @@ const TopPanelInner: React.FC<{
 						minFlex={0.15}
 						maxFlex={0.4}
 						defaultFlex={0.2}
+						maxFlexerSize={MAX_SIDEBAR_WIDTH}
+						maxAntiFlexerSize={null}
 						id="sidebar-to-preview"
 						orientation="vertical"
 					>
@@ -136,6 +140,8 @@ const TopPanelInner: React.FC<{
 								minFlex={0.5}
 								maxFlex={0.8}
 								defaultFlex={0.7}
+								maxFlexerSize={null}
+								maxAntiFlexerSize={MAX_SIDEBAR_WIDTH}
 								id="canvas-to-right-sidebar"
 								orientation="vertical"
 							>


### PR DESCRIPTION
## Summary

- cap both Studio sidebars at 350px
- keep splitter drag behavior aligned with the visible pixel cap
- preserve the existing percentage-based sizing below the cap

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
- manually verified both sidebar caps and inward/outward dragging at a 1920px viewport

Closes #9583
