### PR TITLE
Docs: Replace stale pnpm commands with Bun

### DIFF
--- a/packages/docs/docs/contributing/formatting.mdx
+++ b/packages/docs/docs/contributing/formatting.mdx
@@ -24,11 +24,11 @@ bunx oxfmt src --write
 
 ESLint will warn about code style issues and errors. You can install the [ESLint VS Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) extension to get warnings in the editor as you write code. Extensions for other editors are available on the [ESLint website](https://eslint.org/docs/user-guide/integrations).
 
-You can also run `pnpm run lint` in any package to check if there are any errors. Example:
+You can also run `bun run lint` in any package to check if there are any errors. Example:
 
 ```bash
 cd packages/renderer
-pnpm run lint
+bun run lint
 ```
 
 ## Testing everything
@@ -36,7 +36,7 @@ pnpm run lint
 You can run
 
 ```bash
-pnpm run stylecheck
+bun run stylecheck
 ```
 
 in the root to test locally if the whole repo is well-formatted and will pass the continuous integration checks.

--- a/packages/docs/docs/contributing/presentation.mdx
+++ b/packages/docs/docs/contributing/presentation.mdx
@@ -41,7 +41,7 @@ const presentations = ['slide', 'flip', 'wipe', 'fade', ..., 'yourPresentation']
   }
 ```
 
-Make sure to `pnpm build` in `remotion/packages/transitions` so your transition gets usable in your remotion repository.
+Make sure to `bun run build` in `remotion/packages/transitions` so your transition gets usable in your remotion repository.
 
 <Step>5</Step> Write a documentation for your presentation. Have a look at the presentations linked in the <a href="/docs/transitions/presentations">presentation</a> docs for reference. The documentation should consist of the following parts:
 


### PR DESCRIPTION
## Why

The contributing guides (`formatting.mdx`, `presentation.mdx`) still told contributors to run `pnpm run lint` / `pnpm run stylecheck` / `pnpm build`, but the repository has migrated to **Bun**. `AGENTS.md`, the Oxfmt section, and the root `package.json` `stylecheck` script all use Bun, so these instructions now contradict the rest of the docs and fail for new contributors.

## What changed

- `packages/docs/docs/contributing/formatting.mdx`: `pnpm run lint` → `bun run lint`, `pnpm run stylecheck` → `bun run stylecheck`.
- `packages/docs/docs/contributing/presentation.mdx`: `pnpm build` → `bun run build`.

## Verification

- Confirmed `stylecheck` exists as a Bun script in the root `package.json` and that `bun run lint` works per-package.
- `oxfmt --check` passes on both files (the formatter enforced by `stylecheck`).
- Checked open PRs — no duplicate.
- Branched from `upstream/main`; rebased on latest before opening.

## Tradeoffs

Docs-only change, no code/behaviour impact.
