### PR TITLE
`@remotion/studio`: Support math in InputDragger

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -59,17 +59,165 @@ const roundToDecimalPlaces = (val: number, decimalPlaces: number) => {
 	return Object.is(rounded, -0) ? 0 : rounded;
 };
 
-const validNumberPattern =
-	/^[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:e[+-]?\d+)?$/i;
+export type InputDraggerExpressionResult =
+	| {
+			readonly status: 'valid';
+			readonly value: number;
+	  }
+	| {
+			readonly status: 'incomplete' | 'invalid';
+	  };
 
-export const parseInputDraggerNumber = (value: string) => {
-	const trimmedValue = value.trim();
-	if (!validNumberPattern.test(trimmedValue)) {
-		return null;
+const numberAtStartPattern = /^(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:e[+-]?\d+)?/i;
+
+export const parseInputDraggerExpression = (
+	input: string,
+): InputDraggerExpressionResult => {
+	let index = 0;
+
+	const invalid = (): InputDraggerExpressionResult => ({status: 'invalid'});
+	const incomplete = (): InputDraggerExpressionResult => ({
+		status: 'incomplete',
+	});
+
+	const skipWhitespace = () => {
+		while (index < input.length && /\s/.test(input[index])) {
+			index++;
+		}
+	};
+
+	const parsePrimary = (): InputDraggerExpressionResult => {
+		skipWhitespace();
+		if (index === input.length) {
+			return incomplete();
+		}
+
+		if (input[index] === '(') {
+			index++;
+			const expression = parseExpression();
+			if (expression.status !== 'valid') {
+				return expression;
+			}
+
+			skipWhitespace();
+			if (index === input.length) {
+				return incomplete();
+			}
+
+			if (input[index] !== ')') {
+				return invalid();
+			}
+
+			index++;
+			return expression;
+		}
+
+		const match = input.slice(index).match(numberAtStartPattern);
+		if (!match) {
+			return invalid();
+		}
+
+		index += match[0].length;
+		const rest = input.slice(index);
+		if (/^e[+-]?\s*$/i.test(rest)) {
+			return incomplete();
+		}
+
+		const value = Number(match[0]);
+		return Number.isFinite(value) ? {status: 'valid', value} : invalid();
+	};
+
+	const parseUnary = (): InputDraggerExpressionResult => {
+		skipWhitespace();
+		if (input[index] !== '+' && input[index] !== '-') {
+			return parsePrimary();
+		}
+
+		const operator = input[index];
+		index++;
+		const operand = parseUnary();
+		if (operand.status !== 'valid') {
+			return operand;
+		}
+
+		const value = operator === '-' ? -operand.value : operand.value;
+		return Number.isFinite(value) ? {status: 'valid', value} : invalid();
+	};
+
+	const parseTerm = (): InputDraggerExpressionResult => {
+		let left = parseUnary();
+		if (left.status !== 'valid') {
+			return left;
+		}
+
+		while (true) {
+			skipWhitespace();
+			const operator = input[index];
+			if (operator !== '*' && operator !== '/') {
+				return left;
+			}
+
+			index++;
+			const right = parseUnary();
+			if (right.status !== 'valid') {
+				return right;
+			}
+
+			if (operator === '/' && right.value === 0) {
+				return invalid();
+			}
+
+			const value: number =
+				operator === '*' ? left.value * right.value : left.value / right.value;
+			if (!Number.isFinite(value)) {
+				return invalid();
+			}
+
+			left = {status: 'valid', value};
+		}
+	};
+
+	const parseExpression = (): InputDraggerExpressionResult => {
+		let left = parseTerm();
+		if (left.status !== 'valid') {
+			return left;
+		}
+
+		while (true) {
+			skipWhitespace();
+			const operator = input[index];
+			if (operator !== '+' && operator !== '-') {
+				return left;
+			}
+
+			index++;
+			const right = parseTerm();
+			if (right.status !== 'valid') {
+				return right;
+			}
+
+			const value: number =
+				operator === '+' ? left.value + right.value : left.value - right.value;
+			if (!Number.isFinite(value)) {
+				return invalid();
+			}
+
+			left = {status: 'valid', value};
+		}
+	};
+
+	const result = parseExpression();
+	if (result.status !== 'valid') {
+		return result;
 	}
 
-	const parsed = Number(trimmedValue);
-	return Number.isFinite(parsed) ? parsed : null;
+	skipWhitespace();
+	return index === input.length ? result : invalid();
+};
+
+export const parseInputDraggerNumber = (value: string) => {
+	const result = parseInputDraggerExpression(value);
+	return result.status === 'valid' ? result.value : null;
 };
 
 const getFiniteAttribute = (

--- a/packages/studio/src/test/input-dragger.test.ts
+++ b/packages/studio/src/test/input-dragger.test.ts
@@ -6,6 +6,7 @@ import {
 	deriveInputDraggerValueDiff,
 	isInputDraggerValueAlignedToStep,
 	isInputDraggerValueInRange,
+	parseInputDraggerExpression,
 	parseInputDraggerNumber,
 	validateInputDraggerValue,
 } from '../components/NewComposition/InputDragger';
@@ -94,42 +95,71 @@ test('live input values must be within the configured range', () => {
 	).toBe(false);
 });
 
-test('text input values are parsed as finite decimal numbers', () => {
-	expect(parseInputDraggerNumber('-12.5')).toBe(-12.5);
-	expect(parseInputDraggerNumber('.5')).toBe(0.5);
-	expect(parseInputDraggerNumber('1e3')).toBe(1000);
-	expect(parseInputDraggerNumber(' 20 ')).toBe(20);
-	expect(parseInputDraggerNumber('')).toBeNull();
-	expect(parseInputDraggerNumber('Infinity')).toBeNull();
-	expect(parseInputDraggerNumber('0x10')).toBeNull();
-	expect(parseInputDraggerNumber('12px')).toBeNull();
+test('text input values support arithmetic expressions', () => {
+	const validExpressions = [
+		['30 * 60', 1800],
+		['2 + 3 * 4', 14],
+		['(2 + 3) * 4', 20],
+		['18 / 3 / 2', 3],
+		['-2 * -(3 + 1)', 8],
+		['+.5 + 1.5', 2],
+		['1e3 / 2E+1', 50],
+		[' 20 ', 20],
+	] as const;
+
+	for (const [expression, value] of validExpressions) {
+		expect(parseInputDraggerExpression(expression)).toEqual({
+			status: 'valid',
+			value,
+		});
+		expect(parseInputDraggerNumber(expression)).toBe(value);
+	}
+});
+
+test('incomplete expressions are distinguished from invalid expressions', () => {
+	const incompleteExpressions = ['', '30 *', '(2 + 3', '-', '1e', '1e+'];
+	for (const expression of incompleteExpressions) {
+		expect(parseInputDraggerExpression(expression)).toEqual({
+			status: 'incomplete',
+		});
+	}
+
+	const invalidExpressions = [
+		'Infinity',
+		'0x10',
+		'12px',
+		'2 + )',
+		'2 3',
+		'2 ** 3',
+		'1 / 0',
+		'1e309',
+	];
+	for (const expression of invalidExpressions) {
+		expect(parseInputDraggerExpression(expression)).toEqual({
+			status: 'invalid',
+		});
+		expect(parseInputDraggerNumber(expression)).toBeNull();
+	}
 });
 
 test('text input values retain range and step validation', () => {
-	expect(
-		validateInputDraggerValue({
-			max: 10,
-			min: 0,
-			step: 0.5,
-			value: '2.5',
-		}),
-	).toEqual({valid: true, value: 2.5});
-	expect(
-		validateInputDraggerValue({
-			max: 10,
-			min: 0,
-			step: 0.5,
-			value: '10.5',
-		}).valid,
-	).toBe(false);
-	expect(
-		validateInputDraggerValue({
-			max: 10,
-			min: 0,
-			step: 0.5,
-			value: '2.25',
-		}).valid,
-	).toBe(false);
+	const constrainedExpressions = [
+		['1 + 1.5', true],
+		['8 + 2.5', false],
+		['1.5 * 1.5', false],
+	] as const;
+
+	for (const [value, valid] of constrainedExpressions) {
+		expect(
+			validateInputDraggerValue({
+				max: 10,
+				min: 0,
+				step: 0.5,
+				value,
+			}).valid,
+		).toBe(valid);
+	}
+
 	expect(
 		validateInputDraggerValue({
 			max: Infinity,


### PR DESCRIPTION
## Summary

- evaluate `+`, `-`, `*`, and `/` expressions in `InputDragger` with normal precedence
- support unary signs, parentheses, decimals, and scientific notation without `eval()` or a parsing dependency
- preserve incomplete expressions while editing and reject malformed, non-finite, out-of-range, and step-misaligned results
- add table-driven coverage for valid, incomplete, invalid, range, and step cases

## Validation

- `bunx turbo run lint test --filter=@remotion/studio`
- `bun run build`
- `bun run stylecheck`

Closes #9389
