### PR TITLE
`remotion`: Add SVG paint controls to Interactive

### DIFF
--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -10,6 +10,8 @@ import {
 	borderSchema,
 	premountSchema,
 	sequenceSchema,
+	svgPaintSchema,
+	svgStrokeSchema,
 	textContentSchema,
 	textSchema,
 	transformSchema,
@@ -161,8 +163,24 @@ const interactiveTextElementSchema = {
 
 const interactiveSvgTextElementSchema = {
 	...interactiveElementSchema,
+	...svgPaintSchema,
 	...textSchema,
 	...textContentSchema,
+} as const satisfies InteractivitySchema;
+
+const interactiveSvgElementSchema = {
+	...interactiveElementSchema,
+	...svgPaintSchema,
+} as const satisfies InteractivitySchema;
+
+const interactiveSvgStrokeElementSchema = {
+	...interactiveElementSchema,
+	...svgStrokeSchema,
+} as const satisfies InteractivitySchema;
+
+const interactiveSvgRootElementSchema = {
+	...interactiveBorderElementSchema,
+	...svgPaintSchema,
 } as const satisfies InteractivitySchema;
 
 const setRef = <ElementType,>(
@@ -270,11 +288,22 @@ const makeInteractiveTextElement = <Tag extends InteractiveTag>(
 	return makeInteractiveElement(tag, displayName, interactiveTextElementSchema);
 };
 
-const makeInteractiveNonTextElement = <Tag extends InteractiveTag>(
+const makeInteractiveSvgElement = <Tag extends InteractiveSvgTag>(
 	tag: Tag,
 	displayName: string,
 ) => {
-	return makeInteractiveElement(tag, displayName, interactiveElementSchema);
+	return makeInteractiveElement(tag, displayName, interactiveSvgElementSchema);
+};
+
+const makeInteractiveSvgStrokeElement = <Tag extends InteractiveSvgTag>(
+	tag: Tag,
+	displayName: string,
+) => {
+	return makeInteractiveElement(
+		tag,
+		displayName,
+		interactiveSvgStrokeElementSchema,
+	);
 };
 
 /**
@@ -286,6 +315,8 @@ export const Interactive = {
 	textSchema,
 	backgroundSchema,
 	borderSchema,
+	svgPaintSchema,
+	svgStrokeSchema,
 	premountSchema,
 	sequenceSchema,
 	withSchema,
@@ -294,13 +325,13 @@ export const Interactive = {
 	Article: makeInteractiveTextElement('article', '<Interactive.Article>'),
 	Aside: makeInteractiveTextElement('aside', '<Interactive.Aside>'),
 	Button: makeInteractiveTextElement('button', '<Interactive.Button>'),
-	Circle: makeInteractiveNonTextElement('circle', '<Interactive.Circle>'),
+	Circle: makeInteractiveSvgElement('circle', '<Interactive.Circle>'),
 	Code: makeInteractiveTextElement('code', '<Interactive.Code>'),
 	Div: makeInteractiveTextElement('div', '<Interactive.Div>'),
-	Ellipse: makeInteractiveNonTextElement('ellipse', '<Interactive.Ellipse>'),
+	Ellipse: makeInteractiveSvgElement('ellipse', '<Interactive.Ellipse>'),
 	Em: makeInteractiveTextElement('em', '<Interactive.Em>'),
 	Footer: makeInteractiveTextElement('footer', '<Interactive.Footer>'),
-	G: makeInteractiveNonTextElement('g', '<Interactive.G>'),
+	G: makeInteractiveSvgElement('g', '<Interactive.G>'),
 	H1: makeInteractiveTextElement('h1', '<Interactive.H1>'),
 	H2: makeInteractiveTextElement('h2', '<Interactive.H2>'),
 	H3: makeInteractiveTextElement('h3', '<Interactive.H3>'),
@@ -310,14 +341,14 @@ export const Interactive = {
 	Header: makeInteractiveTextElement('header', '<Interactive.Header>'),
 	Label: makeInteractiveTextElement('label', '<Interactive.Label>'),
 	Li: makeInteractiveTextElement('li', '<Interactive.Li>'),
-	Line: makeInteractiveNonTextElement('line', '<Interactive.Line>'),
+	Line: makeInteractiveSvgStrokeElement('line', '<Interactive.Line>'),
 	Main: makeInteractiveTextElement('main', '<Interactive.Main>'),
 	Nav: makeInteractiveTextElement('nav', '<Interactive.Nav>'),
 	Ol: makeInteractiveTextElement('ol', '<Interactive.Ol>'),
 	P: makeInteractiveTextElement('p', '<Interactive.P>'),
-	Path: makeInteractiveNonTextElement('path', '<Interactive.Path>'),
+	Path: makeInteractiveSvgElement('path', '<Interactive.Path>'),
 	Pre: makeInteractiveTextElement('pre', '<Interactive.Pre>'),
-	Rect: makeInteractiveNonTextElement('rect', '<Interactive.Rect>'),
+	Rect: makeInteractiveSvgElement('rect', '<Interactive.Rect>'),
 	Section: makeInteractiveTextElement('section', '<Interactive.Section>'),
 	Small: makeInteractiveTextElement('small', '<Interactive.Small>'),
 	Span: makeInteractiveTextElement('span', '<Interactive.Span>'),
@@ -325,7 +356,7 @@ export const Interactive = {
 	Svg: makeInteractiveElement(
 		'svg',
 		'<Interactive.Svg>',
-		interactiveBorderElementSchema,
+		interactiveSvgRootElementSchema,
 	),
 	Text: makeInteractiveElement(
 		'text',

--- a/packages/core/src/interactivity-schema.ts
+++ b/packages/core/src/interactivity-schema.ts
@@ -376,6 +376,33 @@ export const backgroundSchema = {
 	},
 } as const satisfies InteractivitySchema;
 
+export const svgStrokeSchema = {
+	stroke: {
+		type: 'color',
+		// `none` is the SVG initial value of stroke.
+		default: 'none',
+		description: 'Stroke',
+	},
+	strokeWidth: {
+		type: 'number',
+		// `1` is the SVG initial value of stroke-width.
+		default: 1,
+		description: 'Stroke width',
+		min: 0,
+		step: 1,
+		hiddenFromList: false,
+	},
+} as const satisfies InteractivitySchema;
+
+export const svgPaintSchema = {
+	fill: {
+		type: 'color',
+		default: undefined,
+		description: 'Fill',
+	},
+	...svgStrokeSchema,
+} as const satisfies InteractivitySchema;
+
 export const textContentSchema = {
 	children: {
 		type: 'text-content',

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -1104,7 +1104,27 @@ test('Interactive elements register their rendered element for Studio outlines',
 		expect(getByName(displayName)?.controls?.schema).not.toHaveProperty(
 			'children',
 		);
+		expect(getByName(displayName)?.controls?.schema).toHaveProperty('stroke');
+		expect(getByName(displayName)?.controls?.schema).toHaveProperty(
+			'strokeWidth',
+		);
 	}
+
+	for (const displayName of [
+		'<Interactive.Circle>',
+		'<Interactive.Ellipse>',
+		'<Interactive.G>',
+		'<Interactive.Path>',
+		'<Interactive.Rect>',
+		'<Interactive.Svg>',
+		'<Interactive.Text>',
+	]) {
+		expect(getByName(displayName)?.controls?.schema).toHaveProperty('fill');
+	}
+
+	expect(getByName('<Interactive.Line>')?.controls?.schema).not.toHaveProperty(
+		'fill',
+	);
 });
 
 test('Interactive elements inherit trimBefore from Sequence', () => {

--- a/packages/core/src/test/with-interactivity-schema-helpers.test.ts
+++ b/packages/core/src/test/with-interactivity-schema-helpers.test.ts
@@ -21,6 +21,8 @@ import {
 	sequenceSchema,
 	sequenceSchemaWithoutFrom,
 	sequenceStyleSchema,
+	svgPaintSchema,
+	svgStrokeSchema,
 	textContentSchema,
 	textSchema,
 	transformSchema,
@@ -364,6 +366,44 @@ test('backgroundSchema exposes the background color style field', () => {
 		type: 'color',
 		default: 'transparent',
 	});
+});
+
+test('svgStrokeSchema exposes SVG stroke controls', () => {
+	expect(Object.keys(svgStrokeSchema)).toEqual(['stroke', 'strokeWidth']);
+	expect(svgStrokeSchema.stroke).toMatchObject({
+		type: 'color',
+		default: 'none',
+		description: 'Stroke',
+	});
+	expect(svgStrokeSchema.strokeWidth).toMatchObject({
+		type: 'number',
+		default: 1,
+		description: 'Stroke width',
+		min: 0,
+		step: 1,
+		hiddenFromList: false,
+	});
+	expect(Interactive.svgStrokeSchema).toBe(svgStrokeSchema);
+});
+
+test('svgPaintSchema exposes SVG fill and stroke fields', () => {
+	expect(Object.keys(svgPaintSchema)).toEqual([
+		'fill',
+		'stroke',
+		'strokeWidth',
+	]);
+	expect(svgPaintSchema.fill).toMatchObject({
+		type: 'color',
+		default: undefined,
+		description: 'Fill',
+	});
+	expect(svgPaintSchema.stroke).toMatchObject({
+		type: 'color',
+		default: 'none',
+		description: 'Stroke',
+	});
+	expect(svgPaintSchema.strokeWidth).toBe(svgStrokeSchema.strokeWidth);
+	expect(Interactive.svgPaintSchema).toBe(svgPaintSchema);
 });
 
 test('readValuesFromProps reads dot-notation keys via getNestedValue', () => {

--- a/packages/docs/docs/interactive.mdx
+++ b/packages/docs/docs/interactive.mdx
@@ -53,6 +53,15 @@ Available SVG elements:
 
 `Circle`, `Ellipse`, `G`, `Line`, `Path`, `Rect`, `Svg`, `Text`.
 
+All SVG elements expose controls for the `stroke` and `strokeWidth` props.
+Elements with a paintable interior also expose a color control for `fill`.
+On `Svg` and `G`, these controls set inherited paint defaults for descendants.
+Keep these values inline in JSX if the Studio should edit or keyframe them.
+The `strokeWidth` control defaults to SVG's initial value of `1`; resetting it
+removes the prop from the JSX.
+The `stroke` control defaults to `none`; resetting it also removes the prop and
+therefore removes the stroke.
+
 ## Schema helpers
 
 `Interactive` also exposes schema fragments for custom timeline components.
@@ -117,6 +126,18 @@ Controls for border-related style props:
 The longhand properties are used rather than the `border` shorthand, because React does not expand shorthands. This lets each control read its own value, and allows `style.borderWidth` and `style.borderColor` to be animated.
 
 Use it for components that accept a `style` prop and render a border.
+
+### `Interactive.svgPaintSchema`<AvailableFrom v="4.0.499" />
+
+Controls for the SVG `fill`, `stroke` and `strokeWidth` props.
+
+Use it for custom components that accept SVG paint props.
+
+### `Interactive.svgStrokeSchema`<AvailableFrom v="4.0.499" />
+
+Controls for the SVG `stroke` and `strokeWidth` props.
+
+Use it for custom components such as lines that do not have a paintable interior.
 
 ### `Interactive.premountSchema`<AvailableFrom v="4.0.479" />
 

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -287,6 +287,7 @@ import {
 	InteractiveSvgElements,
 } from './VisualModeTests/InteractiveComponents';
 import {Issue9170} from './VisualModeTests/Issue9170';
+import {SvgPaintSchema} from './VisualModeTests/SvgPaintSchema';
 import {VideoConfigExpressions} from './VisualModeTests/VideoConfigExpressions';
 import {VoiceVisualization} from './voice-visualization';
 import {WhisperWeb} from './WhisperWeb';
@@ -2758,6 +2759,14 @@ export const Index: React.FC = () => {
 				<Composition
 					id="interactive-svg-elements"
 					component={InteractiveSvgElements}
+					width={1080}
+					height={1080}
+					fps={30}
+					durationInFrames={90}
+				/>
+				<Composition
+					id="issue-9582-svg-paint-schema"
+					component={SvgPaintSchema}
 					width={1080}
 					height={1080}
 					fps={30}

--- a/packages/example/src/VisualModeTests/SvgPaintSchema.tsx
+++ b/packages/example/src/VisualModeTests/SvgPaintSchema.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import {
+	AbsoluteFill,
+	Interactive,
+	interpolate,
+	useCurrentFrame,
+} from 'remotion';
+
+export const SvgPaintSchema: React.FC = () => {
+	const frame = useCurrentFrame();
+	return (
+		<AbsoluteFill
+			style={{
+				alignItems: 'center',
+				backgroundColor: '#020617',
+				color: '#e2e8f0',
+				fontFamily: 'sans-serif',
+				justifyContent: 'center',
+			}}
+		>
+			<div
+				style={{
+					fontSize: 48,
+					fontWeight: 700,
+					marginBottom: 24,
+				}}
+			>
+				SVG paint and stroke width controls
+			</div>
+			<div
+				style={{
+					color: '#94a3b8',
+					fontSize: 24,
+					marginBottom: 32,
+				}}
+			>
+				Select a named SVG element and edit its paint or stroke width
+			</div>
+			<Interactive.Svg
+				name="SVG root"
+				width={880}
+				height={620}
+				viewBox="0 0 880 620"
+				fill="#38bdf8"
+				style={{
+					backgroundColor: '#0f172a',
+					borderRadius: 32,
+				}}
+			>
+				<path d="M70 90 L130 40 L190 90 L170 170 L90 170 Z" />
+				<Interactive.G
+					name="Group paint"
+					fill={'#7f7794'}
+					strokeWidth={interpolate(frame, [0], [1], {
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+					})}
+				>
+					<circle cx={330} cy={105} r={65} />
+					<path
+						d="M290 105 H370 M330 65 V145"
+						fill="none"
+						strokeLinecap="round"
+					/>
+				</Interactive.G>
+				<Interactive.Circle
+					name="Circle paint"
+					cx={540}
+					cy={105}
+					r={65}
+					fill="#fb7185"
+					stroke="#ffe4e6"
+					strokeWidth={10}
+				/>
+				<Interactive.Ellipse
+					name="Ellipse paint"
+					cx={750}
+					cy={105}
+					rx={85}
+					ry={55}
+					fill="#fbbf24"
+					stroke="#fef3c7"
+					strokeWidth={10}
+				/>
+				<Interactive.Rect
+					name="Rectangle paint"
+					x={65}
+					y={250}
+					width={190}
+					height={130}
+					rx={28}
+					fill="#34d399"
+					stroke="#d1fae5"
+					strokeWidth={42}
+				/>
+				<Interactive.Path
+					name="Path paint"
+					d="M325 360 C375 215 455 215 505 360 Z"
+					fill="#60a5fa"
+					stroke="#dbeafe"
+				/>
+				<Interactive.Line
+					name="Line paint"
+					x1={585}
+					y1={260}
+					x2={805}
+					y2={370}
+					stroke="#f472b6"
+					strokeWidth={24}
+					strokeLinecap="round"
+				/>
+				<Interactive.Text
+					name="Text paint"
+					x={440}
+					y={520}
+					fill="#f8fafc"
+					stroke="#7c3aed"
+					strokeWidth={2}
+					textAnchor="middle"
+					fontFamily="sans-serif"
+					fontSize={74}
+					fontWeight={800}
+				>
+					Editable SVG paint
+				</Interactive.Text>
+			</Interactive.Svg>
+		</AbsoluteFill>
+	);
+};

--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -236,6 +236,61 @@ test('updateSequenceProps should remove attribute when value equals default', as
 	expect(output.split('\n')[7]).toContain('hueShift={30}');
 });
 
+test('resetting strokeWidth removes the JSX attribute', async () => {
+	const input = `import {Interactive} from 'remotion';
+
+export const Example = () => {
+	return <Interactive.Line stroke="red" strokeWidth={10} />;
+};
+`;
+	const {output, oldValueStrings} = await updateSequenceProps({
+		videoConfigValues: null,
+		input,
+		nodePath: lineColumnToNodePath(input, 4),
+		updates: [{key: 'strokeWidth', value: 1, defaultValue: 1}],
+		schema: {
+			strokeWidth: {
+				type: 'number',
+				default: 1,
+				min: 0,
+				step: 1,
+				hiddenFromList: false,
+			},
+		},
+		prettierConfigOverride: null,
+	});
+
+	expect(oldValueStrings).toEqual(['10']);
+	expect(output).toContain('<Interactive.Line stroke="red" />');
+	expect(output).not.toContain('strokeWidth');
+});
+
+test('resetting stroke removes the JSX attribute', async () => {
+	const input = `import {Interactive} from 'remotion';
+
+export const Example = () => {
+	return <Interactive.Line stroke="red" />;
+};
+`;
+	const {output, oldValueStrings} = await updateSequenceProps({
+		videoConfigValues: null,
+		input,
+		nodePath: lineColumnToNodePath(input, 4),
+		updates: [{key: 'stroke', value: 'none', defaultValue: 'none'}],
+		schema: {
+			stroke: {
+				type: 'color',
+				default: 'none',
+			},
+		},
+		prettierConfigOverride: null,
+	});
+
+	expect(oldValueStrings).toEqual(['"red"']);
+	expect(output).toContain('<Interactive.Line />');
+	expect(output).not.toContain('stroke=');
+});
+
 test('updateSequenceProps should remove name when value is empty string default', async () => {
 	const input = `import {Sequence} from 'remotion';
 

--- a/packages/studio/src/components/Timeline/TimelineColorField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineColorField.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useMemo} from 'react';
 import type {CanUpdateSequencePropStatusStatic} from 'remotion';
-import {BLACK_HEX} from '../../helpers/colors';
+import {BLACK_HEX, BLUE, LIGHT_TEXT} from '../../helpers/colors';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -16,6 +16,22 @@ const containerStyle: React.CSSProperties = {
 
 const SWATCH_WIDTH = 20;
 const SWATCH_HEIGHT = 15;
+const DEFAULT_SET_COLOR = '#808080';
+
+const noneLabelStyle: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontSize: 12,
+};
+
+const setButtonStyle: React.CSSProperties = {
+	background: 'none',
+	border: 'none',
+	color: BLUE,
+	cursor: 'pointer',
+	fontSize: 12,
+	margin: 0,
+	padding: 0,
+};
 
 export const TimelineColorField: React.FC<{
 	readonly field: SchemaFieldInfo;
@@ -62,6 +78,22 @@ export const TimelineColorField: React.FC<{
 			marginLeft: 5,
 		};
 	}, []);
+
+	if (currentValue === 'none') {
+		return (
+			<span style={containerStyle}>
+				<span style={noneLabelStyle}>None</span>
+				<button
+					type="button"
+					style={setButtonStyle}
+					title={`Set ${field.description ?? field.key} to gray`}
+					onClick={() => onChangeComplete(DEFAULT_SET_COLOR)}
+				>
+					Set
+				</button>
+			</span>
+		);
+	}
 
 	return (
 		<span style={containerStyle}>

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -4818,6 +4818,51 @@ test('Backspace reset targets multiple selected sequence props', () => {
 	expect(resetTargets?.map((target) => target.value)).toEqual([1, '0deg']);
 });
 
+test('Backspace reset targets stroke with the SVG default', () => {
+	const schema = {
+		stroke: {type: 'color', default: 'none'},
+	} satisfies InteractivitySchema;
+	const strokeNodePathInfo = makeNodePathInfo(
+		['body', 0],
+		['controls', 'stroke'],
+	);
+	const nodePath = strokeNodePathInfo.sequenceSubscriptionKey;
+	const propStatuses = {
+		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+			canUpdate: true,
+			props: {
+				stroke: {status: 'static', codeValue: '#ff0000'},
+			},
+			effects: [],
+		},
+	} satisfies PropStatuses;
+
+	const resetTargets = getTimelinePropResetTargets({
+		selections: [
+			{
+				type: 'sequence-prop',
+				nodePathInfo: strokeNodePathInfo,
+				key: 'stroke',
+			},
+		],
+		sequences: [makeTimelineSequence({schema})],
+		overrideIdsToNodePaths: {override: nodePath},
+		propStatuses,
+	});
+
+	expect(resetTargets).toEqual([
+		{
+			type: 'sequence-prop',
+			fileName: '/project/src/Comp.tsx',
+			nodePath,
+			fieldKey: 'stroke',
+			value: 'none',
+			defaultValue: '"none"',
+			schema,
+		},
+	]);
+});
+
 test('Backspace reset targets selected keyframed sequence props', () => {
 	const schema = {
 		opacity: {type: 'number', default: 1, hiddenFromList: false},


### PR DESCRIPTION
## Summary

- add fill, stroke, and stroke width controls to relevant interactive SVG elements
- model SVG defaults so Backspace removes paint props cleanly
- improve the Inspector's no-paint state and add an example testbed

## Testing

- `bun run build`
- `bun run stylecheck`

Closes #9582

## Preview

- [Interactive documentation](https://remotion-git-codex-interactive-svg-paint-controls-remotion.vercel.app/docs/interactive)
