### PR TITLE
`@remotion/studio`: Prevent keyframes from overflowing timeline

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
@@ -4,6 +4,7 @@ import {LIGHT_TEXT} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
+import {isKeyframeInTimelineRange} from './get-keyframe-navigation';
 import {TimelineKeyframeDiamondIcon} from './TimelineKeyframeDiamondIcon';
 import {useTimelineKeyframeDragState} from './TimelineKeyframeDragState';
 import {
@@ -44,7 +45,10 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 		selected || isKeyframeDragging({nodePathInfo, frame});
 
 	const style = useMemo((): React.CSSProperties | null => {
-		if (timelineWidth === null) {
+		if (
+			timelineWidth === null ||
+			!isKeyframeInTimelineRange(frame, videoConfig.durationInFrames)
+		) {
 			return null;
 		}
 

--- a/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
@@ -11,6 +11,7 @@ import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sor
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {ContextMenuForTarget} from '../ContextMenu';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {getVisibleTimelineEasingSegment} from './get-timeline-easing-segments';
 import {
 	TIMELINE_MARQUEE_ITEM_ATTR,
 	useCurrentTimelineSelectionStateAsRef,
@@ -181,15 +182,24 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 			return null;
 		}
 
+		const visibleSegment = getVisibleTimelineEasingSegment({
+			fromFrame,
+			toFrame,
+			durationInFrames: videoConfig.durationInFrames,
+		});
+		if (visibleSegment === null) {
+			return null;
+		}
+
 		const fromLeft =
 			getXPositionOfItemInTimelineImperatively(
-				fromFrame,
+				visibleSegment.fromFrame,
 				videoConfig.durationInFrames,
 				timelineWidth,
 			) - TIMELINE_PADDING;
 		const toLeft =
 			getXPositionOfItemInTimelineImperatively(
-				toFrame,
+				visibleSegment.toFrame,
 				videoConfig.durationInFrames,
 				timelineWidth,
 			) - TIMELINE_PADDING;

--- a/packages/studio/src/components/Timeline/get-keyframe-navigation.ts
+++ b/packages/studio/src/components/Timeline/get-keyframe-navigation.ts
@@ -1,4 +1,4 @@
-const isKeyframeInTimelineRange = (
+export const isKeyframeInTimelineRange = (
 	frame: number,
 	durationInFrames: number,
 ): boolean => {

--- a/packages/studio/src/components/Timeline/get-timeline-easing-segments.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-easing-segments.ts
@@ -6,6 +6,28 @@ export type TimelineEasingSegment = {
 	readonly segmentIndex: number;
 };
 
+export const getVisibleTimelineEasingSegment = ({
+	fromFrame,
+	toFrame,
+	durationInFrames,
+}: {
+	readonly fromFrame: number;
+	readonly toFrame: number;
+	readonly durationInFrames: number;
+}): Pick<TimelineEasingSegment, 'fromFrame' | 'toFrame'> | null => {
+	const visibleFromFrame = Math.max(0, fromFrame);
+	const visibleToFrame = Math.min(durationInFrames - 1, toFrame);
+
+	if (visibleFromFrame >= visibleToFrame) {
+		return null;
+	}
+
+	return {
+		fromFrame: visibleFromFrame,
+		toFrame: visibleToFrame,
+	};
+};
+
 export const getTimelineEasingSegments = (
 	keyframes: ReturnType<typeof getTimelineKeyframes>,
 ): TimelineEasingSegment[] => {

--- a/packages/studio/src/test/timeline-keyframe-navigation.test.ts
+++ b/packages/studio/src/test/timeline-keyframe-navigation.test.ts
@@ -4,6 +4,7 @@ import {
 	getNextKeyframeDisplayFrame,
 	getPreviousKeyframeDisplayFrame,
 	hasKeyframeAtSourceFrame,
+	isKeyframeInTimelineRange,
 } from '../components/Timeline/get-keyframe-navigation';
 import {
 	shouldShowTimelineKeyframeControls,
@@ -63,6 +64,13 @@ test('keyframe navigation skips frames outside the timeline range', () => {
 	expect(getPreviousKeyframeDisplayFrame(offTimelineKeyframes, 120, 100)).toBe(
 		40,
 	);
+});
+
+test('keyframe timeline range excludes frames beyond the composition', () => {
+	expect(isKeyframeInTimelineRange(-1, 100)).toBe(false);
+	expect(isKeyframeInTimelineRange(0, 100)).toBe(true);
+	expect(isKeyframeInTimelineRange(99, 100)).toBe(true);
+	expect(isKeyframeInTimelineRange(100, 100)).toBe(false);
 });
 
 test('hasKeyframeAtSourceFrame checks source frame membership', () => {

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -8,7 +8,10 @@ import {Internals, type PropStatuses} from 'remotion';
 import {findTrackForNodePathInfo} from '../components/Timeline/find-track-for-node-path-info';
 import {getBoundedKeyframeDragDelta} from '../components/Timeline/get-bounded-keyframe-drag-delta';
 import {getNodeKeyframes} from '../components/Timeline/get-node-keyframes';
-import {getTimelineEasingSegments} from '../components/Timeline/get-timeline-easing-segments';
+import {
+	getTimelineEasingSegments,
+	getVisibleTimelineEasingSegment,
+} from '../components/Timeline/get-timeline-easing-segments';
 import {getTimelineKeyframes} from '../components/Timeline/get-timeline-keyframes';
 import {getTimelineKeyframeDragKey} from '../components/Timeline/TimelineKeyframeDragState';
 import {calculateTimeline} from '../helpers/calculate-timeline';
@@ -352,6 +355,30 @@ test('timeline easing segments connect adjacent display keyframes', () => {
 		{fromFrame: 30, toFrame: 60, segmentIndex: 0},
 		{fromFrame: 60, toFrame: 90, segmentIndex: 1},
 	]);
+});
+
+test('timeline easing segments are clipped to the composition timeline', () => {
+	expect(
+		getVisibleTimelineEasingSegment({
+			fromFrame: 80,
+			toFrame: 120,
+			durationInFrames: 100,
+		}),
+	).toEqual({fromFrame: 80, toFrame: 99});
+	expect(
+		getVisibleTimelineEasingSegment({
+			fromFrame: -20,
+			toFrame: 20,
+			durationInFrames: 100,
+		}),
+	).toEqual({fromFrame: 0, toFrame: 20});
+	expect(
+		getVisibleTimelineEasingSegment({
+			fromFrame: 100,
+			toFrame: 120,
+			durationInFrames: 100,
+		}),
+	).toBe(null);
 });
 
 test('bounded keyframe drag delta stays inside the composition timeline', () => {


### PR DESCRIPTION
## Summary

- hide keyframe diamonds that fall outside the composition timeline
- clip easing segments that cross the timeline boundaries
- add regression coverage for out-of-range keyframes and easing segments

## Tests

- `bun test packages/studio/src/test/timeline-keyframe-navigation.test.ts packages/studio/src/test/timeline-keyframes.test.ts`
- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`

Closes #9585
