### PR TITLE
Skills: Avoid composed easing functions

### DIFF
--- a/packages/skills/skills/remotion-maps/techniques/maptiler/assets/CountryLabel.tsx
+++ b/packages/skills/skills/remotion-maps/techniques/maptiler/assets/CountryLabel.tsx
@@ -13,7 +13,7 @@ export const CountryLabel: React.FC<{
 	const e = interpolate(reveal, [0, 1], [0, 1], {
 		extrapolateLeft: 'clamp',
 		extrapolateRight: 'clamp',
-		easing: Easing.bezier(1 / 3, 1, 2 / 3, 1),
+		easing: Easing.bezier(0.3333333333333333, 1, 0.6666666666666666, 1),
 	});
 	return (
 		<div

--- a/packages/skills/skills/remotion-maps/techniques/maptiler/assets/CountryLabel.tsx
+++ b/packages/skills/skills/remotion-maps/techniques/maptiler/assets/CountryLabel.tsx
@@ -13,7 +13,7 @@ export const CountryLabel: React.FC<{
 	const e = interpolate(reveal, [0, 1], [0, 1], {
 		extrapolateLeft: 'clamp',
 		extrapolateRight: 'clamp',
-		easing: Easing.out(Easing.cubic),
+		easing: Easing.bezier(1 / 3, 1, 2 / 3, 1),
 	});
 	return (
 		<div

--- a/packages/skills/skills/remotion-maps/techniques/maptiler/assets/RiverReveal.tsx
+++ b/packages/skills/skills/remotion-maps/techniques/maptiler/assets/RiverReveal.tsx
@@ -251,7 +251,7 @@ export const RiverReveal: React.FC = () => {
 		const reveal = interpolate(t, [RIVER_START, RIVER_END], [0, 1], {
 			extrapolateLeft: 'clamp',
 			extrapolateRight: 'clamp',
-			easing: Easing.inOut(Easing.cubic),
+			easing: Easing.bezier(0.645, 0.045, 0.355, 1),
 		});
 		const riverDrawnKm = lineKm * reveal;
 		(map.getSource('river') as any)?.setData(
@@ -296,7 +296,7 @@ export const RiverReveal: React.FC = () => {
 
 			// 1) border draws on (constant duration), settling to a darker shade — no electric head
 			const bp = interpolate(clamp01(lt / BORDER_S), [0, 1], [0, 1], {
-				easing: Easing.inOut(Easing.cubic),
+				easing: Easing.bezier(0.645, 0.045, 0.355, 1),
 			});
 			(map.getSource(`trail-${c}`) as any)?.setData(
 				bp <= 0 ? EMPTY : sliceBorder(d, 0, d.total * bp),
@@ -311,7 +311,7 @@ export const RiverReveal: React.FC = () => {
 				{
 					extrapolateLeft: 'clamp',
 					extrapolateRight: 'clamp',
-					easing: Easing.out(Easing.cubic),
+					easing: Easing.bezier(1 / 3, 1, 2 / 3, 1),
 				},
 			);
 			map.setPaintProperty(`fill-${c}`, 'fill-opacity', fp <= 0 ? 0 : fo);

--- a/packages/skills/skills/remotion-maps/techniques/maptiler/assets/RiverReveal.tsx
+++ b/packages/skills/skills/remotion-maps/techniques/maptiler/assets/RiverReveal.tsx
@@ -311,7 +311,7 @@ export const RiverReveal: React.FC = () => {
 				{
 					extrapolateLeft: 'clamp',
 					extrapolateRight: 'clamp',
-					easing: Easing.bezier(1 / 3, 1, 2 / 3, 1),
+					easing: Easing.bezier(0.3333333333333333, 1, 0.6666666666666666, 1),
 				},
 			);
 			map.setPaintProperty(`fill-${c}`, 'fill-opacity', fp <= 0 ? 0 : fo);

--- a/packages/skills/skills/remotion-maps/techniques/maptiler/references/map-explainer-architecture.md
+++ b/packages/skills/skills/remotion-maps/techniques/maptiler/references/map-explainer-architecture.md
@@ -81,7 +81,7 @@ const bp = interpolate(clamp01(lt / BORDER_S), [0,1], [0,1], { easing: Easing.be
 map.getSource(`trail-${c}`).setData(sliceBorder(DRAW[c], 0, DRAW[c].total * bp));   // COUNTRY_DARK line
 // 2) fill blooms in (opacity overshoots, then settles) after the border completes
 const fp = clamp01((lt - BORDER_S) / FILL_S);
-const fo = interpolate(fp, [0, 0.6, 1], [0, FILL_OPACITY * 1.25, FILL_OPACITY], { ...clamp, easing: Easing.bezier(1 / 3, 1, 2 / 3, 1) });
+const fo = interpolate(fp, [0, 0.6, 1], [0, FILL_OPACITY * 1.25, FILL_OPACITY], { ...clamp, easing: Easing.bezier(0.3333333333333333, 1, 0.6666666666666666, 1) });
 map.setPaintProperty(`fill-${c}`, "fill-opacity", fp <= 0 ? 0 : fo);
 // 3) label rises in after the fill
 const lp = clamp01((lt - BORDER_S - FILL_S) / LABEL_S);

--- a/packages/skills/skills/remotion-maps/techniques/maptiler/references/map-explainer-architecture.md
+++ b/packages/skills/skills/remotion-maps/techniques/maptiler/references/map-explainer-architecture.md
@@ -32,7 +32,7 @@ const RIVER_START = 0.3, RIVER_END = 8.0;            // river draws over this wi
 const BORDER_S = 2.5, FILL_S = 1.0, LABEL_S = 0.7;   // per-country sequence (constant durations)
 const trigger = (c) => RIVER_START + META[c].stop * (RIVER_END - RIVER_START);  // river-arrival time
 // beat length = max over c of (trigger(c) + BORDER_S + FILL_S + LABEL_S) + tail
-const reveal = interpolate(t, [RIVER_START, RIVER_END], [0,1], { ...clamp, easing: Easing.inOut(Easing.cubic) });
+const reveal = interpolate(t, [RIVER_START, RIVER_END], [0,1], { ...clamp, easing: Easing.bezier(0.645, 0.045, 0.355, 1) });
 ```
 
 **Constant durations matter:** drive the border draw by _time since trigger_, not a slice of the reveal —
@@ -77,11 +77,11 @@ of the country colour (the electricity is on the river, not here).
 ```ts
 const lt = t - trigger(c);                                   // local seconds since trigger
 // 1) complete source border draws on over a constant BORDER_S, multi-segment-safe
-const bp = interpolate(clamp01(lt / BORDER_S), [0,1], [0,1], { easing: Easing.inOut(Easing.cubic) });
+const bp = interpolate(clamp01(lt / BORDER_S), [0,1], [0,1], { easing: Easing.bezier(0.645, 0.045, 0.355, 1) });
 map.getSource(`trail-${c}`).setData(sliceBorder(DRAW[c], 0, DRAW[c].total * bp));   // COUNTRY_DARK line
 // 2) fill blooms in (opacity overshoots, then settles) after the border completes
 const fp = clamp01((lt - BORDER_S) / FILL_S);
-const fo = interpolate(fp, [0, 0.6, 1], [0, FILL_OPACITY * 1.25, FILL_OPACITY], { ...clamp, easing: Easing.out(Easing.cubic) });
+const fo = interpolate(fp, [0, 0.6, 1], [0, FILL_OPACITY * 1.25, FILL_OPACITY], { ...clamp, easing: Easing.bezier(1 / 3, 1, 2 / 3, 1) });
 map.setPaintProperty(`fill-${c}`, "fill-opacity", fp <= 0 ? 0 : fo);
 // 3) label rises in after the fill
 const lp = clamp01((lt - BORDER_S - FILL_S) / LABEL_S);

--- a/packages/skills/skills/remotion-markup/timing.md
+++ b/packages/skills/skills/remotion-markup/timing.md
@@ -94,20 +94,6 @@ const pop = interpolate(frame, [0, 30], [0, 1], {
 });
 ```
 
-## Studio-editable easing curves
-
-Use an explicit `Easing.bezier()` curve instead of composed presets such as `Easing.inOut(Easing.cubic)`. Explicit Bézier control points remain editable in Remotion Studio.
-
-```ts
-import { interpolate, Easing } from "remotion";
-
-const value1 = interpolate(frame, [0, 100], [0, 1], {
-  easing: Easing.bezier(0.645, 0.045, 0.355, 1),
-  extrapolateLeft: "clamp",
-  extrapolateRight: "clamp",
-});
-```
-
 The default easing is `Easing.linear`.
 
 ### Easing direction for enter/exit animations

--- a/packages/skills/skills/remotion-markup/timing.md
+++ b/packages/skills/skills/remotion-markup/timing.md
@@ -94,6 +94,20 @@ const pop = interpolate(frame, [0, 30], [0, 1], {
 });
 ```
 
+## Studio-editable easing curves
+
+Use an explicit `Easing.bezier()` curve instead of composed presets such as `Easing.inOut(Easing.cubic)`. Explicit Bézier control points remain editable in Remotion Studio.
+
+```ts
+import { interpolate, Easing } from "remotion";
+
+const value1 = interpolate(frame, [0, 100], [0, 1], {
+  easing: Easing.bezier(0.645, 0.045, 0.355, 1),
+  extrapolateLeft: "clamp",
+  extrapolateRight: "clamp",
+});
+```
+
 The default easing is `Easing.linear`.
 
 ### Easing direction for enter/exit animations


### PR DESCRIPTION
## Summary

- stop recommending composed `Easing.in()`, `Easing.out()`, and `Easing.inOut()` functions in public skills
- use explicit Bézier curves in the MapTiler examples so generated animations remain editable in Remotion Studio
- remove misleading guidance that presented an approximation as an equivalent curve

## Testing

- `bun run build`
- `bun run stylecheck`

Closes #9580
