### PR TITLE
`@remotion/timeline-utils`: Fix waveform playback rate display

### DIFF
--- a/packages/timeline-utils/src/audio-waveform/slice-waveform-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/slice-waveform-peaks.ts
@@ -25,8 +25,27 @@ export const sliceWaveformPeaks = ({
 		(startTimeInSeconds + durationInSeconds) * TARGET_SAMPLE_RATE,
 	);
 
-	return peaks.subarray(
-		Math.max(0, startPeakIndex),
-		Math.min(peaks.length, endPeakIndex),
-	);
+	if (!Number.isFinite(startPeakIndex) || !Number.isFinite(endPeakIndex)) {
+		return peaks.subarray(
+			Math.max(0, startPeakIndex),
+			Math.min(peaks.length, endPeakIndex),
+		);
+	}
+
+	if (startPeakIndex >= 0 && endPeakIndex <= peaks.length) {
+		return peaks.subarray(startPeakIndex, endPeakIndex);
+	}
+
+	const portion = new Float32Array(Math.max(0, endPeakIndex - startPeakIndex));
+	const sourceStart = Math.max(0, startPeakIndex);
+	const sourceEnd = Math.min(peaks.length, endPeakIndex);
+
+	if (sourceStart < sourceEnd) {
+		portion.set(
+			peaks.subarray(sourceStart, sourceEnd),
+			sourceStart - startPeakIndex,
+		);
+	}
+
+	return portion;
 };

--- a/packages/timeline-utils/src/test/slice-waveform-peaks.test.ts
+++ b/packages/timeline-utils/src/test/slice-waveform-peaks.test.ts
@@ -30,3 +30,53 @@ test('Should return an empty waveform unchanged', () => {
 
 	expect(sliced).toBe(peaks);
 });
+
+test('Should preserve silence after the waveform when playback is faster', () => {
+	const peaks = Float32Array.from({length: 100}, (_, i) => i + 1);
+
+	const sliced = sliceWaveformPeaks({
+		peaks,
+		startFrom: 0,
+		durationInFrames: 30,
+		fps: 30,
+		playbackRate: 2,
+	});
+
+	expect(Array.from(sliced)).toEqual([
+		...Array.from({length: 100}, (_, i) => i + 1),
+		...Array.from({length: 100}, () => 0),
+	]);
+});
+
+test('Should preserve silence before the waveform', () => {
+	const peaks = Float32Array.from({length: 100}, (_, i) => i + 1);
+
+	const sliced = sliceWaveformPeaks({
+		peaks,
+		startFrom: -15,
+		durationInFrames: 30,
+		fps: 30,
+		playbackRate: 1,
+	});
+
+	expect(Array.from(sliced)).toEqual([
+		...Array.from({length: 50}, () => 0),
+		...Array.from({length: 50}, (_, i) => i + 1),
+	]);
+});
+
+test('Should handle an infinite timeline duration', () => {
+	const peaks = Float32Array.from({length: 100}, (_, i) => i + 1);
+
+	const sliced = sliceWaveformPeaks({
+		peaks,
+		startFrom: 15,
+		durationInFrames: Infinity,
+		fps: 30,
+		playbackRate: 1,
+	});
+
+	expect(Array.from(sliced)).toEqual(
+		Array.from({length: 50}, (_, i) => i + 51),
+	);
+});


### PR DESCRIPTION
## Summary

- preserve the requested waveform time window when playback rate extends beyond the available audio peaks
- render out-of-range portions as silence instead of stretching the available waveform
- cover faster playback, leading silence, and infinite timeline durations with tests

## Verification

- `bun test packages/timeline-utils/src/test`
- `bun run build`
- `bun run stylecheck`

Closes #9557
