### PR TITLE
Docs: Update npx remotion versions example to current version

### DIFF
--- a/packages/docs/docs/cli/versions.mdx
+++ b/packages/docs/docs/cli/versions.mdx
@@ -18,7 +18,7 @@ npx remotion versions
 In the optimal case, your versions are aligned and the output of the command looks like this:
 
 ```
-On version: 3.0.19
+On version: 4.0.498
 - @remotion/bundler
 - @remotion/cli
 - @remotion/eslint-config


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Problem

`packages/docs/docs/cli/versions.mdx` still showed `On version: 3.0.19` in the example output for `npx remotion versions`, while the current Remotion version is `4.0.498` (per `packages/core/src/version.ts`). The stale output is confusing for users running the command.

## Triage / Root cause

The docs example was not updated when the project version advanced to `4.0.498`.

## Fix

Update the example output to `On version: 4.0.498`.

## Verification

- `bunx oxfmt packages/docs/docs/cli/versions.mdx --check` passed.
- The change is docs-only and touches no runtime code.

## Notes / Risks

Docs-only change; no runtime behavior.
