### PR TITLE
Docs: Remove duplicate --log section in benchmark CLI docs

### DIFF
--- a/packages/docs/docs/cli/benchmark.mdx
+++ b/packages/docs/docs/cli/benchmark.mdx
@@ -123,10 +123,6 @@ Inherited from [`npx remotion render`](/docs/cli/render#--port)
 
 Inherited from [`npx remotion render`](/docs/cli/render#--every-nth-frame)
 
-### `--log`
-
-Inherited from [`npx remotion render`](/docs/cli/render#--log)
-
 ### `--muted`
 
 Inherited from [`npx remotion render`](/docs/cli/render#--muted)


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Problem

`packages/docs/docs/cli/benchmark.mdx` documented the `--log` flag twice: once after `--disable-web-security` and again after `--every-nth-frame`. The duplicate section is redundant and confusing because the flag ordering no longer mirrors `npx remotion render`.

## Triage / Root cause

A copy-paste or merge artifact left the second `### `--log`` block at lines 126-128. It is identical to the first occurrence and interrupts the logical CLI option grouping.

## Fix

Remove the duplicate `### `--log`` section that appears between `--every-nth-frame` and `--muted`.

## Verification

- `bunx oxfmt packages/docs/docs/cli/benchmark.mdx --check` passed.
- `packages/docs` formatting check passed.
- The change is docs-only and touches no runtime code.

## Notes / Risks

Docs-only change; no runtime behavior.
