### PR TITLE
Docs: Replace stale pnpm commands with Bun

### DIFF
--- a/packages/docs/docs/contributing/formatting.mdx
+++ b/packages/docs/docs/contributing/formatting.mdx
@@ -24,11 +24,11 @@ bunx oxfmt src --write
 
 ESLint will warn about code style issues and errors. You can install the [ESLint VS Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) extension to get warnings in the editor as you write code. Extensions for other editors are available on the [ESLint website](https://eslint.org/docs/user-guide/integrations).
 
-You can also run `pnpm run lint` in any package to check if there are any errors. Example:
+You can also run `bun run lint` in any package to check if there are any errors. Example:
 
 ```bash
 cd packages/renderer
-pnpm run lint
+bun run lint
 ```
 
 ## Testing everything
@@ -36,7 +36,7 @@ pnpm run lint
 You can run
 
 ```bash
-pnpm run stylecheck
+bun run stylecheck
 ```
 
 in the root to test locally if the whole repo is well-formatted and will pass the continuous integration checks.

--- a/packages/docs/docs/contributing/presentation.mdx
+++ b/packages/docs/docs/contributing/presentation.mdx
@@ -41,7 +41,7 @@ const presentations = ['slide', 'flip', 'wipe', 'fade', ..., 'yourPresentation']
   }
 ```
 
-Make sure to `pnpm build` in `remotion/packages/transitions` so your transition gets usable in your remotion repository.
+Make sure to `bun run build` in `remotion/packages/transitions` so your transition gets usable in your remotion repository.
 
 <Step>5</Step> Write a documentation for your presentation. Have a look at the presentations linked in the <a href="/docs/transitions/presentations">presentation</a> docs for reference. The documentation should consist of the following parts:
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Problem

The contributing formatting and presentation guides still told contributors to run `pnpm lint`/`stylecheck`/`build` after the repo migrated to Bun.

## Triage / Root cause

The docs were not updated when the monorepo switched its package manager to Bun, so the commands are stale and will fail for new contributors.

## Fix

Update the commands to `bun run lint`, `bun run stylecheck`, and `bun run build` to match the current package manager and the existing `bunx oxfmt` examples.

## Verification

- `bunx oxfmt packages/docs/docs/contributing/formatting.mdx packages/docs/docs/contributing/presentation.mdx --check` passed.
- Confirmed the root `package.json` scripts are `lint`, `stylecheck`, and `build`.
- Preflight showed no duplicate open PRs and the stale `pnpm` commands are still present on `upstream/main`.

## Notes / Risks

Docs-only change; no runtime behavior.
