### PR TITLE
Skills: Fix dead Element Guidelines link

### DIFF
--- a/.agents/skills/publish-element/SKILL.md
+++ b/.agents/skills/publish-element/SKILL.md
@@ -5,7 +5,7 @@ description: Finalize a developed Remotion Element, add it to the docs gallery, 
 
 # Publish a Remotion Element
 
-The source of truth for design and quality criteria is the [Element Guidelines](../../../packages/docs/elements/guidelines.mdx). Read them completely before making changes. If this skill and the guidelines diverge on acceptance criteria, follow the guidelines.
+The source of truth for design and quality criteria is the [Element Guidelines](https://github.com/remotion-dev/remotion/blob/main/packages/docs/elements/guidelines.mdx). Read them completely before making changes. If this skill and the guidelines diverge on acceptance criteria, follow the guidelines.
 
 This skill owns the technical publication workflow. It starts with an Element scaffold created by the [`scaffold-element` skill](../scaffold-element/SKILL.md) and does not create the initial development scaffold.
 

--- a/.agents/skills/scaffold-element/SKILL.md
+++ b/.agents/skills/scaffold-element/SKILL.md
@@ -5,7 +5,7 @@ description: Scaffold a new Remotion Element with a correctly configured preview
 
 # Scaffold a Remotion Element
 
-The source of truth for design and quality criteria is the [Element Guidelines](../../../packages/docs/elements/guidelines.mdx). Read them completely before making changes. If this skill and the guidelines diverge on acceptance criteria, follow the guidelines.
+The source of truth for design and quality criteria is the [Element Guidelines](https://github.com/remotion-dev/remotion/blob/main/packages/docs/elements/guidelines.mdx). Read them completely before making changes. If this skill and the guidelines diverge on acceptance criteria, follow the guidelines.
 
 This skill owns the technical scaffolding workflow. Use the [`publish-element` skill](../publish-element/SKILL.md) when the Element is ready for the gallery.
 


### PR DESCRIPTION
## Summary

- replace the relative Element Guidelines links in the scaffold and publish skills
- use an absolute GitHub URL that remains valid outside the repository checkout

## Testing

- `bun run build`
- `bun run stylecheck`

Closes https://github.com/remotion-dev/remotion/issues/9597
