### PR TITLE
`@remotion/studio`: Move left sidebar toggle to the left

### DIFF
--- a/packages/studio/src/components/InlineAction.tsx
+++ b/packages/studio/src/components/InlineAction.tsx
@@ -14,6 +14,7 @@ export type InlineActionProps = {
 	readonly disabled?: boolean;
 	readonly renderAction: RenderInlineAction;
 	readonly title?: string;
+	readonly unhoveredColor?: string;
 };
 
 export const InlineAction = ({
@@ -21,6 +22,7 @@ export const InlineAction = ({
 	onClick,
 	disabled,
 	title,
+	unhoveredColor = LIGHT_TEXT,
 }: InlineActionProps) => {
 	const {tabIndex} = useZIndex();
 
@@ -61,7 +63,7 @@ export const InlineAction = ({
 			tabIndex={tabIndex}
 			title={title}
 		>
-			{renderAction(hovered ? WHITE : LIGHT_TEXT)}
+			{renderAction(hovered ? WHITE : unhoveredColor)}
 		</button>
 	);
 };

--- a/packages/studio/src/components/Menu/MenuItem.tsx
+++ b/packages/studio/src/components/Menu/MenuItem.tsx
@@ -2,7 +2,11 @@ import {PlayerInternals} from '@remotion/player';
 import type {SetStateAction} from 'react';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
-import {WHITE, getBackgroundFromHoverState} from '../../helpers/colors';
+import {
+	WHITE,
+	WHITE_ALPHA_80,
+	getBackgroundFromHoverState,
+} from '../../helpers/colors';
 import {HigherZIndex, useZIndex} from '../../state/z-index';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {MenuContent} from '../NewComposition/MenuContent';
@@ -12,7 +16,7 @@ import {menuContainerTowardsBottom, outerPortal} from './styles';
 
 const container: React.CSSProperties = {
 	fontSize: 13,
-	color: WHITE,
+	color: WHITE_ALPHA_80,
 	paddingLeft: 10,
 	paddingRight: 10,
 	cursor: 'default',
@@ -71,6 +75,7 @@ export const MenuItem: React.FC<{
 	const containerStyle = useMemo((): React.CSSProperties => {
 		return {
 			...container,
+			color: hovered || selected ? WHITE : WHITE_ALPHA_80,
 			backgroundColor: getBackgroundFromHoverState({
 				hovered,
 				selected,

--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -3,11 +3,11 @@ import React, {useCallback, useMemo, useState} from 'react';
 import {BACKGROUND, BORDER_BLACK, WHITE} from '../helpers/colors';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import {useMenuStructure} from '../helpers/use-menu-structure';
-import {Row, Spacing} from './layout';
+import {Row} from './layout';
 import type {MenuId} from './Menu/MenuItem';
 import {MenuItem} from './Menu/MenuItem';
 import {MenuBuildIndicator} from './MenuBuildIndicator';
-import {SidebarCollapserControls} from './SidebarCollapserControls';
+import {SidebarCollapserControl} from './SidebarCollapserControls';
 import {UndoRedoButtons} from './UndoRedoButtons';
 import {UpdateCheck} from './UpdateCheck';
 
@@ -23,7 +23,7 @@ const row: React.CSSProperties = {
 	fontSize: 13,
 	height: MENU_TOOLBAR_HEIGHT,
 	paddingLeft: 6,
-	paddingRight: 10,
+	paddingRight: 6,
 	backgroundColor: BACKGROUND,
 };
 
@@ -131,6 +131,7 @@ export const MenuToolbar: React.FC<{
 			onPointerDown={onPointerDown}
 		>
 			<div style={fixedWidthLeft}>
+				<SidebarCollapserControl side="left" />
 				{structure.map((s) => {
 					return (
 						<MenuItem
@@ -155,9 +156,8 @@ export const MenuToolbar: React.FC<{
 			<div style={flex} />
 			<div style={fixedWidthRight}>
 				{readOnlyStudio ? null : <UndoRedoButtons />}
-				<SidebarCollapserControls />
+				<SidebarCollapserControl side="right" />
 			</div>
-			<Spacing x={1} />
 		</Row>
 	);
 };

--- a/packages/studio/src/components/SidebarCollapserControls.tsx
+++ b/packages/studio/src/components/SidebarCollapserControls.tsx
@@ -4,6 +4,7 @@ import {
 	BORDER_CURRENT_COLOR,
 	CURRENT_COLOR,
 	TRANSPARENT,
+	WHITE_ALPHA_80,
 } from '../helpers/colors';
 import {
 	areKeyboardShortcutsDisabled,
@@ -24,7 +25,9 @@ const style: React.CSSProperties = {
 	position: 'relative',
 };
 
-export const SidebarCollapserControls: React.FC<{}> = () => {
+export const SidebarCollapserControl: React.FC<{
+	readonly side: 'left' | 'right';
+}> = ({side}) => {
 	const {setSidebarCollapsedState, sidebarCollapsedStateRight} =
 		useContext(SidebarContext);
 	const keybindings = useKeybinding();
@@ -103,15 +106,32 @@ export const SidebarCollapserControls: React.FC<{}> = () => {
 	]);
 
 	useEffect(() => {
-		const left = keybindings.registerKeybinding({
-			event: 'keydown',
-			key: 'b',
-			commandCtrlKey: true,
-			callback: toggleLeft,
-			preventDefault: true,
-			triggerIfInputFieldFocused: false,
-			keepRegisteredWhenNotHighestContext: false,
-		});
+		if (side === 'left') {
+			const left = keybindings.registerKeybinding({
+				event: 'keydown',
+				key: 'b',
+				commandCtrlKey: true,
+				callback: toggleLeft,
+				preventDefault: true,
+				triggerIfInputFieldFocused: false,
+				keepRegisteredWhenNotHighestContext: false,
+			});
+
+			const zen = keybindings.registerKeybinding({
+				event: 'keydown',
+				key: 'g',
+				commandCtrlKey: true,
+				callback: toggleBoth,
+				preventDefault: true,
+				triggerIfInputFieldFocused: false,
+				keepRegisteredWhenNotHighestContext: false,
+			});
+
+			return () => {
+				left.unregister();
+				zen.unregister();
+			};
+		}
 
 		const right = keybindings.registerKeybinding({
 			event: 'keydown',
@@ -123,22 +143,10 @@ export const SidebarCollapserControls: React.FC<{}> = () => {
 			keepRegisteredWhenNotHighestContext: false,
 		});
 
-		const zen = keybindings.registerKeybinding({
-			event: 'keydown',
-			key: 'g',
-			commandCtrlKey: true,
-			callback: toggleBoth,
-			preventDefault: true,
-			triggerIfInputFieldFocused: false,
-			keepRegisteredWhenNotHighestContext: false,
-		});
-
 		return () => {
-			left.unregister();
 			right.unregister();
-			zen.unregister();
 		};
-	}, [keybindings, toggleBoth, toggleLeft, toggleRight]);
+	}, [keybindings, side, toggleBoth, toggleLeft, toggleRight]);
 
 	const toggleLeftTooltip = areKeyboardShortcutsDisabled()
 		? 'Toggle Left Sidebar'
@@ -177,10 +185,21 @@ export const SidebarCollapserControls: React.FC<{}> = () => {
 		[colorStyle, rightIcon, toggleRightTooltip],
 	);
 
+	if (side === 'left') {
+		return (
+			<InlineAction
+				onClick={toggleLeft}
+				renderAction={toggleLeftAction}
+				unhoveredColor={WHITE_ALPHA_80}
+			/>
+		);
+	}
+
 	return (
-		<>
-			<InlineAction onClick={toggleLeft} renderAction={toggleLeftAction} />
-			<InlineAction onClick={toggleRight} renderAction={toggleRightAction} />
-		</>
+		<InlineAction
+			onClick={toggleRight}
+			renderAction={toggleRightAction}
+			unhoveredColor={WHITE_ALPHA_80}
+		/>
 	);
 };

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -30,7 +30,7 @@ import type {SidebarCollapsedState} from '../state/sidebar';
 import {SidebarContext} from '../state/sidebar';
 import {checkFullscreenSupport} from './check-fullscreen-support';
 import {StudioServerConnectionCtx} from './client-id';
-import {WHITE_HEX} from './colors';
+import {CURRENT_COLOR} from './colors';
 import {getFileManagerName} from './get-file-manager-name';
 import {getGitMenuItem} from './get-git-menu-item';
 import {useMobileLayout} from './mobile-layout';
@@ -47,6 +47,13 @@ const openExternal = (link: string) => {
 
 const rotate: React.CSSProperties = {
 	transform: `rotate(90deg)`,
+	color: 'inherit',
+};
+const iconContainer: React.CSSProperties = {
+	color: 'inherit',
+};
+const iconPath: React.CSSProperties = {
+	color: 'inherit',
 };
 const ICON_SIZE = 16;
 
@@ -309,7 +316,7 @@ export const useMenuStructure = (
 			{
 				id: 'remotion' as const,
 				label: (
-					<Row align="center" justify="center">
+					<Row align="center" justify="center" style={iconContainer}>
 						<svg
 							width={ICON_SIZE}
 							height={ICON_SIZE}
@@ -317,8 +324,9 @@ export const useMenuStructure = (
 							style={rotate}
 						>
 							<path
-								fill={WHITE_HEX}
-								stroke={WHITE_HEX}
+								fill={CURRENT_COLOR}
+								stroke={CURRENT_COLOR}
+								style={iconPath}
 								strokeWidth="100"
 								strokeLinejoin="round"
 								d="M 2 172 a 196 100 0 0 0 195 5 A 196 240 0 0 0 100 2.259 A 196 240 0 0 0 2 172 z"


### PR DESCRIPTION
## Summary

- move the left sidebar toggle to the left edge of the Studio toolbar
- keep the right sidebar toggle on the right with symmetric spacing
- align the Remotion icon, menu labels, and sidebar toggles with the project-name color
- preserve the existing sidebar keyboard shortcuts

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`

Closes #9604
