### PR TITLE
`@remotion/studio`: Make mobile sidebars floating

### DIFF
--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -4,14 +4,13 @@ import {BACKGROUND, BORDER_BLACK, WHITE} from '../helpers/colors';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import {useMenuStructure} from '../helpers/use-menu-structure';
 import {Row} from './layout';
+import {MENU_TOOLBAR_HEIGHT} from './menu-toolbar-height';
 import type {MenuId} from './Menu/MenuItem';
 import {MenuItem} from './Menu/MenuItem';
 import {MenuBuildIndicator} from './MenuBuildIndicator';
 import {SidebarCollapserControl} from './SidebarCollapserControls';
 import {UndoRedoButtons} from './UndoRedoButtons';
 import {UpdateCheck} from './UpdateCheck';
-
-export const MENU_TOOLBAR_HEIGHT = 30;
 
 const row: React.CSSProperties = {
 	alignItems: 'center',

--- a/packages/studio/src/components/MobilePanel.tsx
+++ b/packages/studio/src/components/MobilePanel.tsx
@@ -1,20 +1,28 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {BACKGROUND} from '../helpers/colors';
-import {useZIndex} from '../state/z-index';
+import {BACKGROUND, SHADOW_BLACK} from '../helpers/colors';
+import {HigherZIndex, useZIndex} from '../state/z-index';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 import {getPortal} from './Menu/portals';
 import {CancelIcon} from './NewComposition/CancelButton';
 
-const container: React.CSSProperties = {
+const overlay: React.CSSProperties = {
 	position: 'fixed',
 	top: 0,
 	left: 0,
 	width: '100%',
 	height: '100%',
+};
+
+const panel: React.CSSProperties = {
+	position: 'fixed',
+	top: 0,
+	width: 'min(350px, calc(100% - 50px))',
+	height: '100%',
 	padding: '0 0px 50px 0px',
 	background: BACKGROUND,
+	boxShadow: SHADOW_BLACK,
 };
 
 const buttonContainer: React.CSSProperties = {
@@ -39,22 +47,34 @@ const renderCloseIcon: RenderInlineAction = (color) => {
 export default function MobilePanel({
 	children,
 	onClose,
+	side,
 }: {
 	children: React.ReactNode;
 	onClose: () => void;
+	side: 'left' | 'right';
 }) {
 	const {currentZIndex} = useZIndex();
 
 	return ReactDOM.createPortal(
-		<div style={container}>
-			<div style={buttonContainer}>
-				<InlineAction
-					onClick={onClose}
-					renderAction={renderCloseIcon}
-					title="Close sidebar"
-				/>
-			</div>
-			{children}
+		<div style={overlay}>
+			<HigherZIndex onEscape={onClose} onOutsideClick={onClose}>
+				<div
+					style={{
+						...panel,
+						left: side === 'left' ? 0 : undefined,
+						right: side === 'right' ? 0 : undefined,
+					}}
+				>
+					<div style={buttonContainer}>
+						<InlineAction
+							onClick={onClose}
+							renderAction={renderCloseIcon}
+							title="Close sidebar"
+						/>
+					</div>
+					{children}
+				</div>
+			</HigherZIndex>
 		</div>,
 		getPortal(currentZIndex),
 	);

--- a/packages/studio/src/components/MobilePanel.tsx
+++ b/packages/studio/src/components/MobilePanel.tsx
@@ -18,7 +18,7 @@ const panel: React.CSSProperties = {
 	top: MENU_TOOLBAR_HEIGHT,
 	width: 'min(350px, calc(100% - 50px))',
 	height: `calc(100% - ${MENU_TOOLBAR_HEIGHT}px)`,
-	padding: '0 0px 50px 0px',
+	overflow: 'hidden',
 	background: BACKGROUND,
 	boxShadow: SHADOW_BLACK,
 };

--- a/packages/studio/src/components/MobilePanel.tsx
+++ b/packages/studio/src/components/MobilePanel.tsx
@@ -2,46 +2,25 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {BACKGROUND, SHADOW_BLACK} from '../helpers/colors';
 import {HigherZIndex, useZIndex} from '../state/z-index';
-import type {RenderInlineAction} from './InlineAction';
-import {InlineAction} from './InlineAction';
+import {MENU_TOOLBAR_HEIGHT} from './menu-toolbar-height';
 import {getPortal} from './Menu/portals';
-import {CancelIcon} from './NewComposition/CancelButton';
 
 const overlay: React.CSSProperties = {
 	position: 'fixed',
-	top: 0,
+	top: MENU_TOOLBAR_HEIGHT,
 	left: 0,
 	width: '100%',
-	height: '100%',
+	height: `calc(100% - ${MENU_TOOLBAR_HEIGHT}px)`,
 };
 
 const panel: React.CSSProperties = {
 	position: 'fixed',
-	top: 0,
+	top: MENU_TOOLBAR_HEIGHT,
 	width: 'min(350px, calc(100% - 50px))',
-	height: '100%',
+	height: `calc(100% - ${MENU_TOOLBAR_HEIGHT}px)`,
 	padding: '0 0px 50px 0px',
 	background: BACKGROUND,
 	boxShadow: SHADOW_BLACK,
-};
-
-const buttonContainer: React.CSSProperties = {
-	height: '40px',
-	width: '100%',
-	alignItems: 'center',
-	display: 'flex',
-	justifyContent: 'flex-end',
-	paddingRight: 8,
-};
-
-const button: React.CSSProperties = {
-	height: 16,
-	width: 16,
-	flexShrink: 0,
-};
-
-const renderCloseIcon: RenderInlineAction = (color) => {
-	return <CancelIcon style={{...button, color}} />;
 };
 
 export default function MobilePanel({
@@ -54,10 +33,25 @@ export default function MobilePanel({
 	side: 'left' | 'right';
 }) {
 	const {currentZIndex} = useZIndex();
+	const onOutsideClick = React.useCallback(
+		(target: Node) => {
+			const element = target instanceof Element ? target : null;
+			const toggleSelector = `[data-sidebar-toggle="${side}"]`;
+			if (
+				element?.closest(toggleSelector) ||
+				element?.closest('button')?.querySelector(toggleSelector)
+			) {
+				return;
+			}
+
+			onClose();
+		},
+		[onClose, side],
+	);
 
 	return ReactDOM.createPortal(
 		<div style={overlay}>
-			<HigherZIndex onEscape={onClose} onOutsideClick={onClose}>
+			<HigherZIndex onEscape={onClose} onOutsideClick={onOutsideClick}>
 				<div
 					style={{
 						...panel,
@@ -65,13 +59,6 @@ export default function MobilePanel({
 						right: side === 'right' ? 0 : undefined,
 					}}
 				>
-					<div style={buttonContainer}>
-						<InlineAction
-							onClick={onClose}
-							renderAction={renderCloseIcon}
-							title="Close sidebar"
-						/>
-					</div>
 					{children}
 				</div>
 			</HigherZIndex>

--- a/packages/studio/src/components/SidebarCollapserControls.tsx
+++ b/packages/studio/src/components/SidebarCollapserControls.tsx
@@ -166,7 +166,11 @@ export const SidebarCollapserControl: React.FC<{
 	const toggleLeftAction: RenderInlineAction = useCallback(
 		(color) => {
 			return (
-				<div style={colorStyle(color)} title={toggleLeftTooltip}>
+				<div
+					data-sidebar-toggle="left"
+					style={colorStyle(color)}
+					title={toggleLeftTooltip}
+				>
 					<div style={leftIcon(color)} />
 				</div>
 			);
@@ -177,7 +181,11 @@ export const SidebarCollapserControl: React.FC<{
 	const toggleRightAction: RenderInlineAction = useCallback(
 		(color) => {
 			return (
-				<div style={colorStyle(color)} title={toggleRightTooltip}>
+				<div
+					data-sidebar-toggle="right"
+					style={colorStyle(color)}
+					title={toggleRightTooltip}
+				>
 					<div style={rightIcon(color)} />
 				</div>
 			);

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -129,7 +129,7 @@ const TopPanelInner: React.FC<{
 								</SplitterElement>
 							)
 						) : null}
-						{actualStateLeft === 'expanded' ? (
+						{actualStateLeft === 'expanded' && !isMobileLayout ? (
 							<SplitterHandle
 								allowToCollapse="left"
 								onCollapse={onCollapseLeft}
@@ -150,7 +150,7 @@ const TopPanelInner: React.FC<{
 										<CanvasIfSizeIsAvailable />
 									</div>
 								</SplitterElement>
-								{actualStateRight === 'expanded' ? (
+								{actualStateRight === 'expanded' && !isMobileLayout ? (
 									<SplitterHandle
 										allowToCollapse="right"
 										onCollapse={onCollapseRight}

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -120,7 +120,7 @@ const TopPanelInner: React.FC<{
 					>
 						{actualStateLeft === 'expanded' ? (
 							isMobileLayout ? (
-								<MobilePanel onClose={onCollapseLeft}>
+								<MobilePanel onClose={onCollapseLeft} side="left">
 									<ExplorerPanel readOnlyStudio={readOnlyStudio} />
 								</MobilePanel>
 							) : (
@@ -158,7 +158,7 @@ const TopPanelInner: React.FC<{
 								) : null}
 								{actualStateRight === 'expanded' ? (
 									isMobileLayout ? (
-										<MobilePanel onClose={onCollapseRight}>
+										<MobilePanel onClose={onCollapseRight} side="right">
 											<OptionsPanel readOnlyStudio={readOnlyStudio} />
 										</MobilePanel>
 									) : (

--- a/packages/studio/src/components/menu-toolbar-height.ts
+++ b/packages/studio/src/components/menu-toolbar-height.ts
@@ -1,0 +1,1 @@
+export const MENU_TOOLBAR_HEIGHT = 30;

--- a/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
@@ -5,7 +5,7 @@ import React, {
 	useState,
 } from 'react';
 import {AbsoluteFill} from 'remotion';
-import {MENU_TOOLBAR_HEIGHT} from '../../components/MenuToolbar';
+import {MENU_TOOLBAR_HEIGHT} from '../../components/menu-toolbar-height';
 import {BACKGROUND_HEX, WHITE} from '../../helpers/colors';
 import {KeybindingContextProvider} from '../../state/keybindings';
 import {ErrorLoader} from './ErrorLoader';


### PR DESCRIPTION
## Summary

- render mobile Studio sidebars as floating drawers below the menu toolbar
- anchor each drawer to its corresponding viewport edge and cap its width
- keep the toolbar toggles accessible while a drawer is open
- remove the drawer close buttons while preserving outside-click and Escape dismissal

## Testing

- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`
- verified both drawers, their full toggle hit areas, and dismissal behavior at a 600×700 viewport

Closes #9606
