### PR TITLE
`@remotion/studio`: Refine Quick Switcher design

### DIFF
--- a/packages/studio/src/components/ModalContainer.tsx
+++ b/packages/studio/src/components/ModalContainer.tsx
@@ -43,7 +43,8 @@ export const ModalContainer: React.FC<{
 	readonly onOutsideClick: () => void;
 	readonly children: React.ReactNode;
 	readonly noZIndex?: boolean;
-}> = ({children, onEscape, onOutsideClick, noZIndex}) => {
+	readonly panelStyle?: React.CSSProperties;
+}> = ({children, onEscape, onOutsideClick, noZIndex, panelStyle}) => {
 	const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
 		// Prevent deselection of currently selected items
 		e.stopPropagation();
@@ -62,7 +63,7 @@ export const ModalContainer: React.FC<{
 				onOutsideClick={onOutsideClick}
 				onEscape={onEscape}
 			>
-				<div style={panel}>{children}</div>
+				<div style={{...panel, ...panelStyle}}>{children}</div>
 			</HigherZIndex>
 		</div>
 	);

--- a/packages/studio/src/components/NewComposition/DismissableModal.tsx
+++ b/packages/studio/src/components/NewComposition/DismissableModal.tsx
@@ -4,7 +4,8 @@ import {ModalContainer} from '../ModalContainer';
 
 export const DismissableModal: React.FC<{
 	readonly children: React.ReactNode;
-}> = ({children}) => {
+	readonly panelStyle?: React.CSSProperties;
+}> = ({children, panelStyle}) => {
 	const {setSelectedModal} = useContext(ModalsContext);
 
 	const onQuit = useCallback(() => {
@@ -12,7 +13,11 @@ export const DismissableModal: React.FC<{
 	}, [setSelectedModal]);
 
 	return (
-		<ModalContainer onOutsideClick={onQuit} onEscape={onQuit}>
+		<ModalContainer
+			onOutsideClick={onQuit}
+			onEscape={onQuit}
+			panelStyle={panelStyle}
+		>
 			{children}
 		</ModalContainer>
 	);

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -3,13 +3,18 @@ import {DismissableModal} from '../NewComposition/DismissableModal';
 import type {QuickSwitcherMode} from './NoResults';
 import {QuickSwitcherContent} from './QuickSwitcherContent';
 
+const panelStyle: React.CSSProperties = {
+	borderRadius: 6,
+	overflow: 'hidden',
+};
+
 const QuickSwitcher: React.FC<{
 	readonly initialMode: QuickSwitcherMode;
 	readonly invocationTimestamp: number;
 	readonly readOnlyStudio: boolean;
 }> = ({initialMode, invocationTimestamp, readOnlyStudio}) => {
 	return (
-		<DismissableModal>
+		<DismissableModal panelStyle={panelStyle}>
 			<QuickSwitcherContent
 				readOnlyStudio={readOnlyStudio}
 				invocationTimestamp={invocationTimestamp}

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -31,6 +31,7 @@ import {loopIndex} from './shared';
 
 const input: React.CSSProperties = {
 	width: '100%',
+	borderRadius: 4,
 };
 
 const modeSelector: React.CSSProperties = {

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
@@ -1,8 +1,9 @@
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {
 	LIGHT_TEXT,
+	TRANSPARENT,
 	WHITE,
-	getBackgroundFromHoverState,
+	WHITE_ALPHA_06,
 } from '../../helpers/colors';
 import {useKeybinding} from '../../helpers/use-keybinding';
 import {StillIcon} from '../../icons/still';
@@ -41,6 +42,10 @@ const container: React.CSSProperties = {
 	flexDirection: 'row',
 	alignItems: 'center',
 	cursor: 'pointer',
+	marginBottom: 1,
+	marginLeft: 4,
+	marginRight: 4,
+	borderRadius: 4,
 };
 
 const label: React.CSSProperties = {
@@ -54,8 +59,9 @@ const searchLabel: React.CSSProperties = {
 };
 
 const iconStyle: React.CSSProperties = {
-	width: 14,
-	height: 14,
+	width: 18,
+	height: 18,
+	flexShrink: 0,
 };
 
 const labelContainer: React.CSSProperties = {
@@ -117,10 +123,7 @@ export const QuickSwitcherResult: React.FC<{
 	const style = useMemo(() => {
 		return {
 			...container,
-			backgroundColor: getBackgroundFromHoverState({
-				hovered,
-				selected,
-			}),
+			backgroundColor: hovered || selected ? WHITE_ALPHA_06 : TRANSPARENT,
 		};
 	}, [hovered, selected]);
 
@@ -141,9 +144,15 @@ export const QuickSwitcherResult: React.FC<{
 		<div ref={ref} key={result.id} style={style} onClick={result.onSelected}>
 			{result.type === 'composition' ? (
 				result.compositionType === 'still' ? (
-					<StillIcon color={selected ? WHITE : LIGHT_TEXT} style={iconStyle} />
+					<StillIcon
+						color={selected || hovered ? WHITE : LIGHT_TEXT}
+						style={iconStyle}
+					/>
 				) : (
-					<FilmIcon color={selected ? WHITE : LIGHT_TEXT} style={iconStyle} />
+					<FilmIcon
+						color={selected || hovered ? WHITE : LIGHT_TEXT}
+						style={iconStyle}
+					/>
 				)
 			) : null}
 			<Spacing x={1} />

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
@@ -41,6 +41,7 @@ const container: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'row',
 	alignItems: 'center',
+	cursor: 'default',
 	marginBottom: 1,
 	marginLeft: 4,
 	marginRight: 4,

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
@@ -41,7 +41,6 @@ const container: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'row',
 	alignItems: 'center',
-	cursor: 'pointer',
 	marginBottom: 1,
 	marginLeft: 4,
 	marginRight: 4,


### PR DESCRIPTION
## Summary

- give Quick Switcher results the same spacing and rounded corners as composition selector items
- match the composition selector's hover and selected colors
- increase composition icons to the same size as composition selector icons

## Test plan

- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`

Closes #9613
