### PR TITLE
Docs: Fix renderMedia outputLocation example path

### DIFF
--- a/packages/docs/docs/renderer/render-media.mdx
+++ b/packages/docs/docs/renderer/render-media.mdx
@@ -13,7 +13,7 @@ Render a video or an audio programmatically.
 
 ```tsx twoslash title="render.mjs"
 const serveUrl = '/path/to/bundle';
-const outputLocation = '/path/to/frames';
+const outputLocation = '/path/to/video.mp4';
 
 import {renderMedia, selectComposition} from '@remotion/renderer';
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Problem

The `renderMedia()` intro example sets `outputLocation` to `'/path/to/frames'`, but the `outputLocation` argument docs on the same page state it **must be a file path (not a folder)**. With `codec: 'h264'`, a directory-style path is misleading.

Self-sourced (no linked issue).

## Triage / Root cause

The example at the top of `packages/docs/docs/renderer/render-media.mdx` predates or missed the file-path requirement documented at `### outputLocation?`.

## Fix

Change the example `outputLocation` from `'/path/to/frames'` to `'/path/to/video.mp4'`, consistent with the `h264` codec in the same snippet and with other docs (e.g. `combine-chunks.mdx`).

## Verification

- `bunx oxfmt packages/docs/docs/renderer/render-media.mdx --check` passed.
- Docs-only change; no runtime code touched.

## Notes / Risks

Docs-only. Similar `'/path/to/frames'` placeholders exist in other docs pages (`passing-props.mdx`, `hardware-acceleration.mdx`, etc.) but are out of scope for this focused PR.

Made with [Cursor](https://cursor.com)