### PR TITLE
Docs: Wire deploy-static SSR example outputLocation

### DIFF
--- a/packages/docs/docs/studio/deploy-static.mdx
+++ b/packages/docs/docs/studio/deploy-static.mdx
@@ -124,7 +124,7 @@ npx remotion render https://remotion-helloworld.vercel.app HelloWorld --props '{
 <TabItem value="ssr">
 
 ```tsx twoslash title="render.mjs"
-const outputLocation = '/path/to/frames';
+const outputLocation = '/path/to/video.mp4';
 
 import {renderMedia, selectComposition} from '@remotion/renderer';
 
@@ -145,6 +145,7 @@ await renderMedia({
   composition,
   serveUrl,
   codec: 'h264',
+  outputLocation,
   inputProps,
 });
 ```


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Problem

On the Studio **Deploy a static site** page, the SSR tab example declares `outputLocation = '/path/to/frames'` but never passes `outputLocation` into `renderMedia()`. Readers copying the snippet get no guidance on writing output to disk, and the placeholder path looks like a folder even though `outputLocation` must be a file path.

Self-sourced (no linked issue). Related context: #9616 fixes the same folder-style placeholder on `render-media.mdx`; this page has the additional unused-variable issue.

## Triage / Root cause

In `packages/docs/docs/studio/deploy-static.mdx`, the SSR `render.mjs` example sets `outputLocation` outside the `// ---cut---` block but omits it from the `renderMedia()` call. With `codec: 'h264'`, a file path such as `.mp4` is the correct placeholder.

## Fix

- Change the placeholder to `'/path/to/video.mp4'`.
- Pass `outputLocation` into the `renderMedia()` call so the example demonstrates saving to disk.

## Verification

- `bunx oxfmt packages/docs/docs/studio/deploy-static.mdx --check` passed.
- Docs-only change; no runtime code touched.

## Notes / Risks

Docs-only. Similar `'/path/to/frames'` placeholders remain on `passing-props.mdx` and `hardware-acceleration.mdx` — intentionally out of scope here to keep this PR focused.

Made with [Cursor](https://cursor.com)