### PR TITLE
`@remotion/studio`: Add composition metadata presets

### DIFF
--- a/packages/studio/src/components/InlineAction.tsx
+++ b/packages/studio/src/components/InlineAction.tsx
@@ -56,6 +56,7 @@ export const InlineAction = ({
 	return (
 		<button
 			type="button"
+			disabled={disabled}
 			onPointerEnter={onPointerEnter}
 			onPointerLeave={onPointerLeave}
 			onClick={onClick}

--- a/packages/studio/src/components/InlineDropdown.tsx
+++ b/packages/studio/src/components/InlineDropdown.tsx
@@ -1,6 +1,7 @@
 import {PlayerInternals} from '@remotion/player';
 import {useCallback, useMemo, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
+import {WHITE} from '../helpers/colors';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import {noop} from '../helpers/noop';
 import {HigherZIndex, useZIndex} from '../state/z-index';
@@ -30,6 +31,7 @@ type OpenState =
 
 export const InlineDropdown = ({
 	values,
+	unhoveredColor,
 	...props
 }: Omit<InlineActionProps, 'onClick'> & {
 	readonly values: ComboboxValue[];
@@ -118,7 +120,11 @@ export const InlineDropdown = ({
 	return (
 		<>
 			<div ref={ref}>
-				<InlineAction onClick={onClick} {...props} />
+				<InlineAction
+					onClick={onClick}
+					unhoveredColor={opened.type === 'open' ? WHITE : unhoveredColor}
+					{...props}
+				/>
 			</div>
 			{portalStyle
 				? ReactDOM.createPortal(

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -1,7 +1,7 @@
 import type {RecastCodemod} from '@remotion/studio-shared';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Internals} from 'remotion';
-import {WHITE_ALPHA_40} from '../../helpers/colors';
+import {WHITE_ALPHA_25, WHITE_ALPHA_40} from '../../helpers/colors';
 import {isCompositionStill} from '../../helpers/is-composition-still';
 import {resolvedStackToSymbolicated} from '../../helpers/resolved-stack-to-symbolicated';
 import {CaretDown} from '../../icons/caret';
@@ -138,7 +138,7 @@ const PresetDropdown: React.FC<{
 				disabled={disabled}
 				renderAction={renderAction}
 				title={title}
-				unhoveredColor={WHITE_ALPHA_40}
+				unhoveredColor={WHITE_ALPHA_25}
 				values={values}
 			/>
 		</div>

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -117,7 +117,8 @@ const PresetDropdown: React.FC<{
 	readonly disabled: boolean;
 	readonly title: string;
 	readonly values: ComboboxValue[];
-}> = ({disabled, title, values}) => {
+	readonly visible: boolean;
+}> = ({disabled, title, values, visible}) => {
 	const renderAction = useCallback((color: string) => {
 		return (
 			<span style={{...presetButtonIcon, color}}>
@@ -127,7 +128,12 @@ const PresetDropdown: React.FC<{
 	}, []);
 
 	return (
-		<div style={presetDropdownContainer}>
+		<div
+			style={{
+				...presetDropdownContainer,
+				visibility: visible ? 'visible' : 'hidden',
+			}}
+		>
 			<InlineDropdown
 				disabled={disabled}
 				renderAction={renderAction}
@@ -430,7 +436,7 @@ export const CompositionMetadata: React.FC<{
 	return (
 		<div style={compositionMetadataContainer}>
 			<InspectorDetailRow
-				label={
+				label={(hovered) => (
 					<div style={metadataLabelControls}>
 						<span style={metadataLabelText}>Dimensions</span>
 						{widthIsComputed || heightIsComputed ? null : (
@@ -442,10 +448,11 @@ export const CompositionMetadata: React.FC<{
 								}
 								title="Choose dimension preset"
 								values={dimensionPresetValues}
+								visible={hovered}
 							/>
 						)}
 					</div>
-				}
+				)}
 			>
 				<div style={dimensionsControls}>
 					<CompositionMetadataValue
@@ -469,7 +476,7 @@ export const CompositionMetadata: React.FC<{
 			{isStill ? null : (
 				<>
 					<InspectorDetailRow
-						label={
+						label={(hovered) => (
 							<div style={metadataLabelControls}>
 								<span style={metadataLabelText}>Frame rate</span>
 								{fpsIsComputed ? null : (
@@ -477,10 +484,11 @@ export const CompositionMetadata: React.FC<{
 										disabled={disabled || pendingValues.fps !== undefined}
 										title="Choose frame rate preset"
 										values={frameRatePresetValues}
+										visible={hovered}
 									/>
 								)}
 							</div>
-						}
+						)}
 					>
 						<div style={dimensionsControls}>
 							<CompositionMetadataValue

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -1,12 +1,12 @@
-import type {
-	RecastCodemod,
-	SymbolicatedStackFrame,
-} from '@remotion/studio-shared';
+import type {RecastCodemod} from '@remotion/studio-shared';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Internals} from 'remotion';
 import {WHITE_ALPHA_40} from '../../helpers/colors';
 import {isCompositionStill} from '../../helpers/is-composition-still';
 import {resolvedStackToSymbolicated} from '../../helpers/resolved-stack-to-symbolicated';
+import {CaretDown} from '../../icons/caret';
+import {InlineDropdown} from '../InlineDropdown';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {
 	InputDragger,
 	inputDraggerContainerStyle,
@@ -63,40 +63,59 @@ const dimensionsControls: React.CSSProperties = {
 	minWidth: 0,
 };
 
+const presetButtonIcon: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	height: 12,
+	justifyContent: 'center',
+	width: 12,
+};
+
+type CompositionMetadataValues = Partial<
+	Record<CompositionMetadataField, number>
+>;
+
+const dimensionPresets = [
+	{height: 720, label: 'HD landscape', width: 1280},
+	{height: 1080, label: 'Full HD landscape', width: 1920},
+	{height: 1280, label: 'HD portrait', width: 720},
+	{height: 1920, label: 'Full HD portrait', width: 1080},
+	{height: 1080, label: 'Square', width: 1080},
+] as const;
+
+const frameRatePresets = [23.976, 24, 25, 29.97, 30, 50, 60] as const;
+
+const PresetDropdown: React.FC<{
+	readonly disabled: boolean;
+	readonly title: string;
+	readonly values: ComboboxValue[];
+}> = ({disabled, title, values}) => {
+	const renderAction = useCallback((color: string) => {
+		return (
+			<span style={{...presetButtonIcon, color}}>
+				<CaretDown small />
+			</span>
+		);
+	}, []);
+
+	return (
+		<InlineDropdown
+			disabled={disabled}
+			renderAction={renderAction}
+			title={title}
+			values={values}
+		/>
+	);
+};
+
 const CompositionMetadataValue: React.FC<{
-	readonly compositionId: string;
 	readonly computed: boolean;
 	readonly disabled: boolean;
 	readonly field: CompositionMetadataField;
-	readonly onPendingValue: (
-		field: CompositionMetadataField,
-		value: PendingCompositionMetadataValue,
-	) => void;
-	readonly onPendingValueAccepted: (
-		field: CompositionMetadataField,
-		value: PendingCompositionMetadataValue,
-	) => void;
-	readonly onPendingValueFailed: (
-		field: CompositionMetadataField,
-		value: PendingCompositionMetadataValue,
-	) => void;
+	readonly onSave: (values: CompositionMetadataValues) => void;
 	readonly pendingValue: PendingCompositionMetadataValue | null;
-	readonly resolvedConfig: object;
-	readonly symbolicatedStack: SymbolicatedStackFrame | null;
 	readonly value: number;
-}> = ({
-	compositionId,
-	computed,
-	disabled,
-	field,
-	onPendingValue,
-	onPendingValueAccepted,
-	onPendingValueFailed,
-	pendingValue,
-	resolvedConfig,
-	symbolicatedStack,
-	value,
-}) => {
+}> = ({computed, disabled, field, onSave, pendingValue, value}) => {
 	const [dragValue, setDragValue] = useState<number | null>(null);
 
 	const save = useCallback(
@@ -106,67 +125,10 @@ const CompositionMetadataValue: React.FC<{
 				return;
 			}
 
-			if (symbolicatedStack === null) {
-				setDragValue(null);
-				showNotification(
-					'Could not determine where this composition is defined',
-					2000,
-				);
-				return;
-			}
-
-			const codemod: RecastCodemod = {
-				type: 'update-composition-metadata',
-				idToUpdate: compositionId,
-				newDurationInFrames: field === 'durationInFrames' ? newValue : null,
-				newFps: field === 'fps' ? newValue : null,
-				newHeight: field === 'height' ? newValue : null,
-				newWidth: field === 'width' ? newValue : null,
-			};
-			const optimisticValue: PendingCompositionMetadataValue = {
-				baseline: resolvedConfig,
-				status: 'saving',
-				value: newValue,
-			};
-			onPendingValue(field, optimisticValue);
 			setDragValue(null);
-			applyCodemod({
-				codemod,
-				dryRun: false,
-				signal: new AbortController().signal,
-				symbolicatedStack,
-			})
-				.then((result) => {
-					if (!result.success) {
-						onPendingValueFailed(field, optimisticValue);
-						showNotification(
-							`Could not update composition ${field}: ${result.reason}`,
-							2000,
-						);
-						return;
-					}
-
-					onPendingValueAccepted(field, optimisticValue);
-				})
-				.catch((error) => {
-					onPendingValueFailed(field, optimisticValue);
-					showNotification(
-						`Could not update composition ${field}: ${(error as Error).message}`,
-						2000,
-					);
-				});
+			onSave({[field]: newValue});
 		},
-		[
-			compositionId,
-			field,
-			onPendingValue,
-			onPendingValueAccepted,
-			onPendingValueFailed,
-			pendingValue?.value,
-			resolvedConfig,
-			symbolicatedStack,
-			value,
-		],
+		[field, onSave, pendingValue?.value, value],
 	);
 	const isFps = field === 'fps';
 	const formatValue = useCallback(
@@ -246,15 +208,6 @@ export const CompositionMetadata: React.FC<{
 		);
 	}, [resolvedConfig]);
 
-	const onPendingValue = useCallback(
-		(
-			field: CompositionMetadataField,
-			value: PendingCompositionMetadataValue,
-		) => {
-			setPendingValues((pending) => ({...pending, [field]: value}));
-		},
-		[],
-	);
 	const onPendingValueAccepted = useCallback(
 		(
 			field: CompositionMetadataField,
@@ -286,6 +239,111 @@ export const CompositionMetadata: React.FC<{
 		},
 		[],
 	);
+	const currentValues = useMemo(
+		(): Record<CompositionMetadataField, number> => ({
+			durationInFrames: video?.durationInFrames ?? 0,
+			fps: video?.fps ?? 0,
+			height: video?.height ?? 0,
+			width: video?.width ?? 0,
+		}),
+		[video],
+	);
+	const saveMetadata = useCallback(
+		(newValues: CompositionMetadataValues) => {
+			if (resolvedConfig === null) {
+				return;
+			}
+
+			const changedFields = (
+				Object.keys(newValues) as CompositionMetadataField[]
+			).filter(
+				(field) =>
+					newValues[field] !==
+					(pendingValues[field]?.value ?? currentValues[field]),
+			);
+
+			if (changedFields.length === 0) {
+				return;
+			}
+
+			if (symbolicatedStack === null) {
+				showNotification(
+					'Could not determine where this composition is defined',
+					2000,
+				);
+				return;
+			}
+
+			const optimisticValues = changedFields.reduce((values, field) => {
+				values[field] = {
+					baseline: resolvedConfig,
+					status: 'saving',
+					value: newValues[field] as number,
+				};
+				return values;
+			}, {} as PendingCompositionMetadata);
+			const codemod: RecastCodemod = {
+				type: 'update-composition-metadata',
+				idToUpdate: compositionId,
+				newDurationInFrames: newValues.durationInFrames ?? null,
+				newFps: newValues.fps ?? null,
+				newHeight: newValues.height ?? null,
+				newWidth: newValues.width ?? null,
+			};
+			setPendingValues((pending) => ({...pending, ...optimisticValues}));
+			applyCodemod({
+				codemod,
+				dryRun: false,
+				signal: new AbortController().signal,
+				symbolicatedStack,
+			})
+				.then((result) => {
+					if (!result.success) {
+						for (const field of changedFields) {
+							onPendingValueFailed(
+								field,
+								optimisticValues[field] as PendingCompositionMetadataValue,
+							);
+						}
+
+						showNotification(
+							`Could not update composition metadata: ${result.reason}`,
+							2000,
+						);
+						return;
+					}
+
+					for (const field of changedFields) {
+						onPendingValueAccepted(
+							field,
+							optimisticValues[field] as PendingCompositionMetadataValue,
+						);
+					}
+				})
+				.catch((error) => {
+					for (const field of changedFields) {
+						onPendingValueFailed(
+							field,
+							optimisticValues[field] as PendingCompositionMetadataValue,
+						);
+					}
+
+					showNotification(
+						`Could not update composition metadata: ${(error as Error).message}`,
+						2000,
+					);
+				});
+		},
+		[
+			compositionId,
+			currentValues,
+			onPendingValueAccepted,
+			onPendingValueFailed,
+			pendingValues,
+			resolvedConfig,
+			symbolicatedStack,
+		],
+	);
 
 	if (video === null || resolvedConfig === null) {
 		return null;
@@ -302,68 +360,98 @@ export const CompositionMetadata: React.FC<{
 	const durationIsComputed =
 		metadataSource?.durationInFrames === 'calculate-metadata';
 	const isStill = isCompositionStill(video);
+	const dimensionPresetValues = dimensionPresets.map(
+		(preset): ComboboxValue => ({
+			type: 'item',
+			id: `${preset.width}x${preset.height}`,
+			label: `${preset.label} (${preset.width} × ${preset.height})`,
+			value: `${preset.width}x${preset.height}`,
+			onClick: () => {
+				saveMetadata({height: preset.height, width: preset.width});
+			},
+			keyHint: null,
+			leftItem: null,
+			subMenu: null,
+			quickSwitcherLabel: null,
+		}),
+	);
+	const frameRatePresetValues = frameRatePresets.map(
+		(fps): ComboboxValue => ({
+			type: 'item',
+			id: String(fps),
+			label: `${fps} fps`,
+			value: fps,
+			onClick: () => {
+				saveMetadata({fps});
+			},
+			keyHint: null,
+			leftItem: null,
+			subMenu: null,
+			quickSwitcherLabel: null,
+		}),
+	);
 
 	return (
 		<div style={compositionMetadataContainer}>
 			<InspectorDetailRow label="Dimensions">
 				<div style={dimensionsControls}>
 					<CompositionMetadataValue
-						compositionId={compositionId}
 						computed={widthIsComputed}
 						disabled={disabled}
 						field="width"
-						onPendingValue={onPendingValue}
-						onPendingValueAccepted={onPendingValueAccepted}
-						onPendingValueFailed={onPendingValueFailed}
+						onSave={saveMetadata}
 						pendingValue={pendingValues.width ?? null}
-						resolvedConfig={resolvedConfig}
-						symbolicatedStack={symbolicatedStack}
 						value={video.width}
 					/>
 					<CompositionMetadataValue
-						compositionId={compositionId}
 						computed={heightIsComputed}
 						disabled={disabled}
 						field="height"
-						onPendingValue={onPendingValue}
-						onPendingValueAccepted={onPendingValueAccepted}
-						onPendingValueFailed={onPendingValueFailed}
+						onSave={saveMetadata}
 						pendingValue={pendingValues.height ?? null}
-						resolvedConfig={resolvedConfig}
-						symbolicatedStack={symbolicatedStack}
 						value={video.height}
 					/>
+					{widthIsComputed || heightIsComputed ? null : (
+						<PresetDropdown
+							disabled={
+								disabled ||
+								pendingValues.width !== undefined ||
+								pendingValues.height !== undefined
+							}
+							title="Choose dimension preset"
+							values={dimensionPresetValues}
+						/>
+					)}
 				</div>
 			</InspectorDetailRow>
 			{isStill ? null : (
 				<>
 					<InspectorDetailRow label="Frame rate">
-						<CompositionMetadataValue
-							compositionId={compositionId}
-							computed={fpsIsComputed}
-							disabled={disabled}
-							field="fps"
-							onPendingValue={onPendingValue}
-							onPendingValueAccepted={onPendingValueAccepted}
-							onPendingValueFailed={onPendingValueFailed}
-							pendingValue={pendingValues.fps ?? null}
-							resolvedConfig={resolvedConfig}
-							symbolicatedStack={symbolicatedStack}
-							value={video.fps}
-						/>
+						<div style={dimensionsControls}>
+							<CompositionMetadataValue
+								computed={fpsIsComputed}
+								disabled={disabled}
+								field="fps"
+								onSave={saveMetadata}
+								pendingValue={pendingValues.fps ?? null}
+								value={video.fps}
+							/>
+							{fpsIsComputed ? null : (
+								<PresetDropdown
+									disabled={disabled || pendingValues.fps !== undefined}
+									title="Choose frame rate preset"
+									values={frameRatePresetValues}
+								/>
+							)}
+						</div>
 					</InspectorDetailRow>
 					<InspectorDetailRow label="Duration">
 						<CompositionMetadataValue
-							compositionId={compositionId}
 							computed={durationIsComputed}
 							disabled={disabled}
 							field="durationInFrames"
-							onPendingValue={onPendingValue}
-							onPendingValueAccepted={onPendingValueAccepted}
-							onPendingValueFailed={onPendingValueFailed}
+							onSave={saveMetadata}
 							pendingValue={pendingValues.durationInFrames ?? null}
-							resolvedConfig={resolvedConfig}
-							symbolicatedStack={symbolicatedStack}
 							value={video.durationInFrames}
 						/>
 					</InspectorDetailRow>

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -104,10 +104,10 @@ type CompositionMetadataValues = Partial<
 >;
 
 const dimensionPresets = [
-	{height: 720, label: 'HD landscape', width: 1280},
-	{height: 1080, label: 'Full HD landscape', width: 1920},
-	{height: 1280, label: 'HD portrait', width: 720},
-	{height: 1920, label: 'Full HD portrait', width: 1080},
+	{height: 1080, label: 'Full HD', width: 1920},
+	{height: 1920, label: 'Full HD', width: 1080},
+	{height: 720, label: 'HD', width: 1280},
+	{height: 1280, label: 'HD', width: 720},
 	{height: 1080, label: 'Square', width: 1080},
 ] as const;
 
@@ -391,20 +391,25 @@ export const CompositionMetadata: React.FC<{
 	const durationIsComputed =
 		metadataSource?.durationInFrames === 'calculate-metadata';
 	const isStill = isCompositionStill(video);
-	const dimensionPresetValues = dimensionPresets.map(
-		(preset): ComboboxValue => ({
-			type: 'item',
-			id: `${preset.width}x${preset.height}`,
-			label: `${preset.label} (${preset.width} × ${preset.height})`,
-			value: `${preset.width}x${preset.height}`,
-			onClick: () => {
-				saveMetadata({height: preset.height, width: preset.width});
+	const dimensionPresetValues = dimensionPresets.flatMap(
+		(preset, index): ComboboxValue[] => [
+			...(index === 2 || index === 4
+				? [{type: 'divider' as const, id: `dimension-divider-${index}`}]
+				: []),
+			{
+				type: 'item',
+				id: `${preset.width}x${preset.height}`,
+				label: `${preset.width}x${preset.height} (${preset.label})`,
+				value: `${preset.width}x${preset.height}`,
+				onClick: () => {
+					saveMetadata({height: preset.height, width: preset.width});
+				},
+				keyHint: null,
+				leftItem: null,
+				subMenu: null,
+				quickSwitcherLabel: null,
 			},
-			keyHint: null,
-			leftItem: null,
-			subMenu: null,
-			quickSwitcherLabel: null,
-		}),
+		],
 	);
 	const frameRatePresetValues = frameRatePresets.map(
 		(fps): ComboboxValue => ({

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -65,10 +65,38 @@ const dimensionsControls: React.CSSProperties = {
 
 const presetButtonIcon: React.CSSProperties = {
 	alignItems: 'center',
+	color: 'inherit',
 	display: 'flex',
+	flexShrink: 0,
 	height: 12,
 	justifyContent: 'center',
 	width: 12,
+};
+
+const presetDropdownContainer: React.CSSProperties = {
+	display: 'flex',
+	flexShrink: 0,
+};
+
+const metadataLabelControls: React.CSSProperties = {
+	alignItems: 'center',
+	color: 'inherit',
+	display: 'flex',
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	lineHeight: '18px',
+	minWidth: 0,
+};
+
+const metadataLabelText: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	lineHeight: '18px',
+	minWidth: 0,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
 };
 
 type CompositionMetadataValues = Partial<
@@ -99,12 +127,15 @@ const PresetDropdown: React.FC<{
 	}, []);
 
 	return (
-		<InlineDropdown
-			disabled={disabled}
-			renderAction={renderAction}
-			title={title}
-			values={values}
-		/>
+		<div style={presetDropdownContainer}>
+			<InlineDropdown
+				disabled={disabled}
+				renderAction={renderAction}
+				title={title}
+				unhoveredColor={WHITE_ALPHA_40}
+				values={values}
+			/>
+		</div>
 	);
 };
 
@@ -393,7 +424,24 @@ export const CompositionMetadata: React.FC<{
 
 	return (
 		<div style={compositionMetadataContainer}>
-			<InspectorDetailRow label="Dimensions">
+			<InspectorDetailRow
+				label={
+					<div style={metadataLabelControls}>
+						<span style={metadataLabelText}>Dimensions</span>
+						{widthIsComputed || heightIsComputed ? null : (
+							<PresetDropdown
+								disabled={
+									disabled ||
+									pendingValues.width !== undefined ||
+									pendingValues.height !== undefined
+								}
+								title="Choose dimension preset"
+								values={dimensionPresetValues}
+							/>
+						)}
+					</div>
+				}
+			>
 				<div style={dimensionsControls}>
 					<CompositionMetadataValue
 						computed={widthIsComputed}
@@ -411,22 +459,24 @@ export const CompositionMetadata: React.FC<{
 						pendingValue={pendingValues.height ?? null}
 						value={video.height}
 					/>
-					{widthIsComputed || heightIsComputed ? null : (
-						<PresetDropdown
-							disabled={
-								disabled ||
-								pendingValues.width !== undefined ||
-								pendingValues.height !== undefined
-							}
-							title="Choose dimension preset"
-							values={dimensionPresetValues}
-						/>
-					)}
 				</div>
 			</InspectorDetailRow>
 			{isStill ? null : (
 				<>
-					<InspectorDetailRow label="Frame rate">
+					<InspectorDetailRow
+						label={
+							<div style={metadataLabelControls}>
+								<span style={metadataLabelText}>Frame rate</span>
+								{fpsIsComputed ? null : (
+									<PresetDropdown
+										disabled={disabled || pendingValues.fps !== undefined}
+										title="Choose frame rate preset"
+										values={frameRatePresetValues}
+									/>
+								)}
+							</div>
+						}
+					>
 						<div style={dimensionsControls}>
 							<CompositionMetadataValue
 								computed={fpsIsComputed}
@@ -436,13 +486,6 @@ export const CompositionMetadata: React.FC<{
 								pendingValue={pendingValues.fps ?? null}
 								value={video.fps}
 							/>
-							{fpsIsComputed ? null : (
-								<PresetDropdown
-									disabled={disabled || pendingValues.fps !== undefined}
-									title="Choose frame rate preset"
-									values={frameRatePresetValues}
-								/>
-							)}
 						</div>
 					</InspectorDetailRow>
 					<InspectorDetailRow label="Duration">

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -439,10 +439,9 @@ export const CompositionMetadata: React.FC<{
 				label={(hovered) => (
 					<div style={metadataLabelControls}>
 						<span style={metadataLabelText}>Dimensions</span>
-						{widthIsComputed || heightIsComputed ? null : (
+						{disabled || widthIsComputed || heightIsComputed ? null : (
 							<PresetDropdown
 								disabled={
-									disabled ||
 									pendingValues.width !== undefined ||
 									pendingValues.height !== undefined
 								}
@@ -479,9 +478,9 @@ export const CompositionMetadata: React.FC<{
 						label={(hovered) => (
 							<div style={metadataLabelControls}>
 								<span style={metadataLabelText}>Frame rate</span>
-								{fpsIsComputed ? null : (
+								{disabled || fpsIsComputed ? null : (
 									<PresetDropdown
-										disabled={disabled || pendingValues.fps !== undefined}
+										disabled={pendingValues.fps !== undefined}
 										title="Choose frame rate preset"
 										values={frameRatePresetValues}
 										visible={hovered}

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -1,7 +1,7 @@
 import type {RecastCodemod} from '@remotion/studio-shared';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Internals} from 'remotion';
-import {WHITE_ALPHA_25, WHITE_ALPHA_40} from '../../helpers/colors';
+import {WHITE_ALPHA_40} from '../../helpers/colors';
 import {isCompositionStill} from '../../helpers/is-composition-still';
 import {resolvedStackToSymbolicated} from '../../helpers/resolved-stack-to-symbolicated';
 import {CaretDown} from '../../icons/caret';
@@ -121,8 +121,8 @@ const PresetDropdown: React.FC<{
 }> = ({disabled, title, values, visible}) => {
 	const renderAction = useCallback((color: string) => {
 		return (
-			<span style={{...presetButtonIcon, color}}>
-				<CaretDown small />
+			<span style={presetButtonIcon}>
+				<CaretDown color={color} small />
 			</span>
 		);
 	}, []);
@@ -138,7 +138,6 @@ const PresetDropdown: React.FC<{
 				disabled={disabled}
 				renderAction={renderAction}
 				title={title}
-				unhoveredColor={WHITE_ALPHA_25}
 				values={values}
 			/>
 		</div>

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -84,6 +84,7 @@ const metadataLabelControls: React.CSSProperties = {
 	display: 'flex',
 	fontFamily: 'sans-serif',
 	fontSize: 13,
+	gap: 2,
 	lineHeight: '18px',
 	minWidth: 0,
 };

--- a/packages/studio/src/components/InspectorPanel/common.tsx
+++ b/packages/studio/src/components/InspectorPanel/common.tsx
@@ -98,14 +98,24 @@ export const InspectorMessage: React.FC<{
 }> = ({children}) => <div style={centeredMessage}>{children}</div>;
 
 export const InspectorDetailRow: React.FC<{
-	readonly label: React.ReactNode;
+	readonly label: React.ReactNode | ((hovered: boolean) => React.ReactNode);
 	readonly children: React.ReactNode;
-}> = ({label, children}) => (
-	<div style={detailRow}>
-		<div style={detailLabel}>{label}</div>
-		<div style={detailValue}>{children}</div>
-	</div>
-);
+}> = ({label, children}) => {
+	const [hovered, setHovered] = React.useState(false);
+
+	return (
+		<div
+			style={detailRow}
+			onPointerEnter={() => setHovered(true)}
+			onPointerLeave={() => setHovered(false)}
+		>
+			<div style={detailLabel}>
+				{typeof label === 'function' ? label(hovered) : label}
+			</div>
+			<div style={detailValue}>{children}</div>
+		</div>
+	);
+};
 
 const INLINE_LABEL_BUTTON_MARGIN = 4;
 

--- a/packages/studio/src/components/InspectorPanel/common.tsx
+++ b/packages/studio/src/components/InspectorPanel/common.tsx
@@ -98,7 +98,7 @@ export const InspectorMessage: React.FC<{
 }> = ({children}) => <div style={centeredMessage}>{children}</div>;
 
 export const InspectorDetailRow: React.FC<{
-	readonly label: string;
+	readonly label: React.ReactNode;
 	readonly children: React.ReactNode;
 }> = ({label, children}) => (
 	<div style={detailRow}>

--- a/packages/studio/src/icons/caret.tsx
+++ b/packages/studio/src/icons/caret.tsx
@@ -26,13 +26,14 @@ export const CaretRight = () => (
 	</svg>
 );
 
-export const CaretDown: React.FC<{readonly small?: boolean}> = ({
-	small = false,
-}) => {
+export const CaretDown: React.FC<{
+	readonly color?: string;
+	readonly small?: boolean;
+}> = ({color = CURRENT_COLOR, small = false}) => {
 	return (
 		<svg viewBox="0 0 320 512" style={small ? caretDownSmall : caretDown}>
 			<path
-				fill={CURRENT_COLOR}
+				fill={color}
 				d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
 			/>
 		</svg>


### PR DESCRIPTION
## Summary

- add dimension presets for HD, Full HD, portrait, landscape, and square compositions
- add presets for seven common frame rates
- apply paired dimension changes through a single codemod with optimistic inspector updates
- make disabled inline actions respect native button semantics

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test`
- verified both preset menus in Remotion Studio

Closes #9611
