### PR TITLE
`@remotion/web-renderer`: don't add silent AAC track for compositions without audio

### DIFF
--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -488,6 +488,13 @@ const internalRenderMediaOnWeb = async <
 			};
 		};
 
+		// If a composition never emits audio, no samples are sent to the AAC
+		// encoder - encoder priming would make the audio track longer than the
+		// video track and inflate the container duration (#7099). Silence is
+		// backfilled once the first real audio sample appears.
+		let hasEncounteredAudio = false;
+		let silentFramesBeforeFirstAudio = 0;
+
 		for (let frame = realFrameRange[0]; frame <= realFrameRange[1]; frame++) {
 			if (signal?.aborted) {
 				throw new Error('renderMediaOnWeb() was cancelled');
@@ -588,9 +595,24 @@ const internalRenderMediaOnWeb = async <
 
 			await waitForPageResponsiveness();
 
-			const audio = muted
-				? null
-				: onlyInlineAudio({assets, fps: resolved.fps, timestamp, sampleRate});
+			let audio: AudioData | null = null;
+			if (audioSampleSource) {
+				if (assets.some((a) => a.type === 'inline-audio')) {
+					hasEncounteredAudio = true;
+				}
+
+				if (hasEncounteredAudio) {
+					audio = onlyInlineAudio({
+						assets,
+						fps: resolved.fps,
+						timestamp,
+						sampleRate,
+					});
+				} else {
+					silentFramesBeforeFirstAudio++;
+				}
+			}
+
 			internalState.addAudioMixingTime(performance.now() - audioCombineStart);
 
 			await waitForPageResponsiveness();
@@ -607,6 +629,20 @@ const internalRenderMediaOnWeb = async <
 			}
 
 			if (audio && audioSampleSource) {
+				for (let i = 0; i < silentFramesBeforeFirstAudio; i++) {
+					const silence = onlyInlineAudio({
+						assets: [],
+						fps: resolved.fps,
+						timestamp: Math.round((i / resolved.fps) * 1_000_000),
+						sampleRate,
+					});
+					encodingPromises.push(
+						addAudioSample(silence, audioSampleSource.audioSampleSource),
+					);
+				}
+
+				silentFramesBeforeFirstAudio = 0;
+
 				encodingPromises.push(
 					addAudioSample(audio, audioSampleSource.audioSampleSource),
 				);

--- a/packages/web-renderer/src/test/audio.test.tsx
+++ b/packages/web-renderer/src/test/audio.test.tsx
@@ -1,6 +1,6 @@
 import {Audio, Video} from '@remotion/media';
 import {ALL_FORMATS, BlobSource, Input, type InputAudioTrack} from 'mediabunny';
-import {staticFile} from 'remotion';
+import {Sequence, staticFile} from 'remotion';
 import {expect, test} from 'vitest';
 import {renderMediaOnWeb} from '../render-media-on-web';
 import '../symbol-dispose';
@@ -264,6 +264,78 @@ test('should render audio at 44100 Hz when sampleRate is set', async (t) => {
 	const blob = await result.getBlob();
 	const track = await getAudioTrackFromBlob(blob);
 	expect(track.sampleRate).toBe(44100);
+});
+
+test('silent composition should not get an audio track that inflates the container duration', async () => {
+	const Component: React.FC = () => {
+		return null;
+	};
+
+	const durationInFrames = 10;
+	const fps = 30;
+
+	const result = await renderMediaOnWeb({
+		licenseKey: 'free-license',
+		composition: {
+			component: Component,
+			id: 'silent-no-audio-track-test',
+			width: 100,
+			height: 100,
+			fps,
+			durationInFrames,
+			calculateMetadata: null,
+		},
+		container: 'mp4',
+		outputTarget: 'arraybuffer',
+	});
+
+	const blob = await result.getBlob();
+	using input = new Input({
+		formats: ALL_FORMATS,
+		source: new BlobSource(blob),
+	});
+
+	const tracks = await input.getTracks();
+	expect(tracks.some((track) => track.isAudioTrack())).toBe(false);
+
+	const duration = await input.computeDuration();
+	expect(duration).toBeLessThanOrEqual(durationInFrames / fps);
+});
+
+test('audio starting after a silent lead-in should stay in sync', async () => {
+	const from = 5;
+
+	const Component: React.FC = () => {
+		return (
+			<Sequence from={from}>
+				<Audio src={staticFile('dialogue.wav')} />
+			</Sequence>
+		);
+	};
+
+	const result = await renderMediaOnWeb({
+		licenseKey: 'free-license',
+		composition: {
+			component: Component,
+			id: 'silent-lead-in-test',
+			width: 100,
+			height: 100,
+			fps: 30,
+			durationInFrames: 10,
+			calculateMetadata: null,
+		},
+		container: 'mp4',
+		outputTarget: 'arraybuffer',
+	});
+
+	const blob = await result.getBlob();
+	const track = await getAudioTrackFromBlob(blob);
+
+	const firstTimestamp = await track.getFirstTimestamp();
+	expect(firstTimestamp).toBe(0);
+
+	const duration = await track.computeDuration();
+	expect(duration).toBeGreaterThanOrEqual(10 / 30);
 });
 
 test('should render audio at default 48000 Hz when sampleRate is not set', async (t) => {


### PR DESCRIPTION
AAC encoder priming makes an all-silence audio track longer than the video track, inflating the MP4 container duration beyond durationInFrames / fps. Defer sending audio samples to the encoder until the first frame that actually contains inline audio, backfilling the preceding silence so audio stays in sync. Compositions that never emit audio no longer get an audio track.

Fixes #7099

<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->


## Problem

`renderMediaOnWeb()` registers an audio track whenever rendering is not muted and an audio codec is available, and `onlyInlineAudio()` produces an all-zero sample for every frame even when the composition contains no audio. AAC encoder priming then makes the silent audio track longer than the video track, so the MP4 container duration (max of track durations) exceeds `durationInFrames / fps`.

Repro on `main` (10 frames @ 30fps, no audio): container duration `0.3627s` with a silent AAC track, vs `0.3333s` expected.

## Fix

Defer sending audio samples to the encoder until the first frame that actually contains an `inline-audio` asset:

- Frames before the first audio asset only increment a `silentFramesBeforeFirstAudio` counter.
- When the first real audio appears, the preceding silence is backfilled (one sample per skipped frame, with the correct timestamps) before the current sample is added, so audio stays in sync.
- If the composition never emits audio, no samples reach the encoder and the output has no audio track; the container duration then matches the video track.

## Tradeoffs

- The audio track is still registered upfront (mediabunny requires `addAudioTrack()` before `output.start()`); it is finalized empty when no samples are added, which mediabunny drops from the output.
- Compositions where audio starts mid-way pay a one-time backfill of the leading silence at the frame where audio begins (same samples as before, just deferred).

## Tests

- New test: a silent composition produces no audio track and the container duration does not exceed `durationInFrames / fps` (fails on `main`, passes with this change).
- New test: audio starting after a silent lead-in (`<Sequence from={5}>`) still starts at timestamp 0 and covers the full composition duration.
- Verified with ffprobe/ffmpeg out-of-band: silent renders (full and frame-range) have zero excess duration; renders with audio keep an audible, full-length AAC track; mid-start audio has silent lead-in and correctly timed content.

Co-Authored-By: Aiden <aiden@weco.ai>
