### PR TITLE
Docs: Fix Spline package name typo in spline.mdx

### DIFF
--- a/packages/docs/docs/spline.mdx
+++ b/packages/docs/docs/spline.mdx
@@ -78,7 +78,7 @@ Your 3D model should look like this:
 
    ![Project Starter](../static/img/spline-guide/12_project_starter.png)
 
-2. Install the [`@splinetools/r3f-spline`](https://github.com/splinetool/r3f-spline) package:
+2. Install the [`@splinetool/r3f-spline`](https://github.com/splinetool/r3f-spline) package:
 
    ```shell
    npm install @splinetool/r3f-spline


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Problem

The Spline integration guide links to `@splinetools/r3f-spline` in the install step, but that scoped package does not exist on npm (`npm view @splinetools/r3f-spline` → 404). The correct package is `@splinetool/r3f-spline` (already used in the `npm install` command on the next line).

Self-sourced (no linked issue).

## Triage / Root cause

In `packages/docs/docs/spline.mdx` line 81, the markdown link text uses a typo (`splinetools` with an extra `s`). The shell snippet below already installs the correct package name.

## Fix

- Change the link text from `` `@splinetools/r3f-spline` `` to `` `@splinetool/r3f-spline` `` so the prose matches the install command and the real npm package.

## Verification

- Preflight passed against current `upstream/main` (bug marker present, no duplicate PRs).
- `bunx oxfmt packages/docs/docs/spline.mdx --check` passed.
- `npm view @splinetool/r3f-spline name` → `@splinetool/r3f-spline`.
- Docs-only change; no runtime code touched.

## Notes / Risks

Docs-only, one-character-scope fix in link text. No API or behavior change.

Made with [Cursor](https://cursor.com)