### PR TITLE
Docs: Fix duplicate word typos in documentation

### DIFF
--- a/packages/docs/docs/miscellaneous/linux-dependencies.mdx
+++ b/packages/docs/docs/miscellaneous/linux-dependencies.mdx
@@ -113,7 +113,7 @@ yum install -y \
 
 ## Alpine Linux
 
-Not supported due to to unsupported Libc symbols.
+Not supported due to unsupported Libc symbols.
 
 ## nixOS
 

--- a/packages/docs/docs/transitions/presentations/clock-wipe.mdx
+++ b/packages/docs/docs/transitions/presentations/clock-wipe.mdx
@@ -73,7 +73,7 @@ Should be set to the height of the video.
 
 ### `outerEnterStyle?`<AvailableFrom v="4.0.84"/>
 
-The style of the outer element when the scene is is entering.
+The style of the outer element when the scene is entering.
 
 ### `outerExitStyle?`<AvailableFrom v="4.0.84"/>
 

--- a/packages/docs/docs/transitions/presentations/fade.mdx
+++ b/packages/docs/docs/transitions/presentations/fade.mdx
@@ -60,7 +60,7 @@ An object which takes:
 
 ### `enterStyle?`<AvailableFrom v="4.0.84"/>
 
-The style of the container element when the scene is is entering.
+The style of the container element when the scene is entering.
 
 ### `exitStyle?`<AvailableFrom v="4.0.84"/>
 

--- a/packages/docs/docs/transitions/presentations/flip.mdx
+++ b/packages/docs/docs/transitions/presentations/flip.mdx
@@ -76,7 +76,7 @@ The CSS `perspective` of the flip animation. Defaults to `1000`.
 
 ### `outerEnterStyle?`<AvailableFrom v="4.0.84"/>
 
-The style of the outer element when the scene is is entering.
+The style of the outer element when the scene is entering.
 
 ### `outerExitStyle?`<AvailableFrom v="4.0.84"/>
 

--- a/packages/docs/docs/transitions/presentations/iris.mdx
+++ b/packages/docs/docs/transitions/presentations/iris.mdx
@@ -70,7 +70,7 @@ Should be set to the height of the video.
 
 ### `outerEnterStyle?`
 
-The style of the outer element when the scene is is entering.
+The style of the outer element when the scene is entering.
 
 ### `outerExitStyle?`
 

--- a/packages/docs/docs/transitions/presentations/slide.mdx
+++ b/packages/docs/docs/transitions/presentations/slide.mdx
@@ -70,7 +70,7 @@ const slideDirection: SlideDirection = "from-left";
 
 ### `enterStyle?`<AvailableFrom v="4.0.84"/>
 
-The style of the container when the scene is is entering.
+The style of the container when the scene is entering.
 
 ### `exitStyle?`<AvailableFrom v="4.0.84"/>
 

--- a/packages/docs/docs/transitions/presentations/wipe.mdx
+++ b/packages/docs/docs/transitions/presentations/wipe.mdx
@@ -70,7 +70,7 @@ const wipeDirection: WipeDirection = "from-left";
 
 ### `outerEnterStyle?`<AvailableFrom v="4.0.84"/>
 
-The style of the outer element when the scene is is entering.
+The style of the outer element when the scene is entering.
 
 ### `outerExitStyle?`<AvailableFrom v="4.0.84"/>
 


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## Problem

Seven documentation pages contain duplicated words in prose — six instances of "is is" in transition presentation docs (`outerEnterStyle` / `enterStyle` descriptions) and one "to to" in the Alpine Linux dependencies note. These read incorrectly in user-facing docs.

Self-sourced (no linked issue).

## Triage / Root cause

A targeted grep under `packages/docs` for `is is ` and `to to ` found seven MDX files with the same duplicated-word pattern. Each instance is a stray extra word in prose, not intentional wording.

## Fix

- Remove the extra duplicate word in:
  - `packages/docs/docs/transitions/presentations/clock-wipe.mdx`
  - `packages/docs/docs/transitions/presentations/fade.mdx`
  - `packages/docs/docs/transitions/presentations/flip.mdx`
  - `packages/docs/docs/transitions/presentations/iris.mdx`
  - `packages/docs/docs/transitions/presentations/slide.mdx`
  - `packages/docs/docs/transitions/presentations/wipe.mdx`
  - `packages/docs/docs/miscellaneous/linux-dependencies.mdx`

## Verification

- Preflight passed against current `upstream/main` (bug markers present on tip, no duplicate open PRs for this specific pattern).
- `bunx oxfmt --check` on all seven changed files passed.
- `rg 'when the scene is is|due to to unsupported' packages/docs/docs` returns no matches after the fix.
- Docs-only change; no runtime code touched.

## Notes / Risks

Docs-only typo cleanup across seven files; one logical change (duplicate-word removal). Complements #9624 (duplicate "the" typos) without overlapping files. No API or behavior change.

Made with [Cursor](https://cursor.com)