### PR TITLE
Docs: Update template READMEs to use remotion-dev org

### DIFF
--- a/packages/template-javascript/README.md
+++ b/packages/template-javascript/README.md
@@ -47,8 +47,8 @@ We provide help on our [Discord server](https://discord.gg/6VzzNDwUwV).
 
 ## Issues
 
-Found an issue with Remotion? [File an issue here](https://github.com/JonnyBurger/remotion/issues/new).
+Found an issue with Remotion? [File an issue here](https://github.com/remotion-dev/remotion/issues/new).
 
 ## License
 
-Note that for some entities a company license is needed. [Read the terms here](https://github.com/JonnyBurger/remotion/blob/main/LICENSE.md).
+Note that for some entities a company license is needed. [Read the terms here](https://github.com/remotion-dev/remotion/blob/main/LICENSE.md).

--- a/packages/template-three/README.md
+++ b/packages/template-three/README.md
@@ -4,13 +4,13 @@
     <img src="demo.gif" style="border-radius: 5px">
 </p>
 
-[This is a template repository, click "Use this template" to create a repository based off this template!](https://github.com/JonnyBurger/remotion-template-three/generate)
+[This is a template repository, click "Use this template" to create a repository based off this template!](https://github.com/remotion-dev/remotion-template-three/generate)
 
-This is a lightweight boilerplate for [Remotion](https://github.com/jonnyburger/remotion) with [React Three Fiber](https://github.com/pmndrs/react-three-fiber) and [@remotion/three](http://remotion.dev/docs/three) preinstalled.
+This is a lightweight boilerplate for [Remotion](https://github.com/remotion-dev/remotion) with [React Three Fiber](https://github.com/pmndrs/react-three-fiber) and [@remotion/three](https://remotion.dev/docs/three) preinstalled.
 
 - [Remotion documentation](https://remotion.dev)
 - [React Three Fiber documentation](https://docs.pmnd.rs/react-three-fiber)
-- [@remotion/three documentation](http://remotion.dev/docs/three)
+- [@remotion/three documentation](https://remotion.dev/docs/three)
 
 This example features a phone with a screen. You can easily switch out the video and change a series of parameters, like size, color, aspect ratio, corner radius etc. of the phone.
 
@@ -52,7 +52,7 @@ We provide help on our [Discord server](https://discord.gg/6VzzNDwUwV).
 
 ## Issues
 
-Found an issue with Remotion? [File an issue here](https://github.com/JonnyBurger/remotion/issues/new).
+Found an issue with Remotion? [File an issue here](https://github.com/remotion-dev/remotion/issues/new).
 
 ## License
 


### PR DESCRIPTION
Updates stale GitHub organization names and HTTP documentation links in two template READMEs.

- `packages/template-three/README.md`: replace `JonnyBurger` / `jonnyburger` references with `remotion-dev` and upgrade the `@remotion/three` doc link to HTTPS.
- `packages/template-javascript/README.md`: replace `JonnyBurger` references with `remotion-dev`.

No functional changes.