### PR TITLE
Docs: Update cloud GPU Docker guide to Node 22

### DIFF
--- a/packages/docs/docs/miscellaneous/cloud-gpu-docker.mdx
+++ b/packages/docs/docs/miscellaneous/cloud-gpu-docker.mdx
@@ -69,7 +69,7 @@ sudo systemctl restart docker
 <kbd>X</kbd> to save and quit. <br />
 
 ```bash title="Dockerfile"
-FROM node:20-bookworm
+FROM node:22-bookworm
 RUN apt-get update
 RUN apt-get install -y curl gnupg git
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

`packages/docs/docs/miscellaneous/cloud-gpu-docker.mdx` still instructs users to base their cloud GPU Dockerfile on `node:20-bookworm`, while the main Docker guide (`packages/docs/docs/docker.mdx`) was updated to `node:22-bookworm-slim` and its changelog notes the Node 22 LTS recommendation.

## Fix

Update line 72 of `cloud-gpu-docker.mdx` from `FROM node:20-bookworm` to `FROM node:22-bookworm`.

## Verification

- Ran `python3 ../scripts/preflight_ship.py --repo remotion-dev/remotion --local remotion --branch main --file packages/docs/docs/miscellaneous/cloud-gpu-docker.mdx --must-contain 'FROM node:20-bookworm' --must-not-contain 'FROM node:22-bookworm'` → **PREFLIGHT CLEAR**.
- `git show upstream/main:packages/docs/docs/miscellaneous/cloud-gpu-docker.mdx` confirmed the outdated image is still on upstream `main`.
- Confirmed `packages/docs/docs/docker.mdx` line 12 uses `FROM node:22-bookworm-slim` and line 245 notes the Node 22 update.

## Notes / Risks

None — single-line documentation change.