### PR TITLE
Internal: Stabilize registration range test in `@remotion/transitions`

### DIFF
--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -205,11 +205,20 @@ test('TransitionSeries.Transition and Overlay register at their rendered timelin
 	const root = createRoot(div);
 	const transitionStack = 'Error\n    at UserAuthoredTransition';
 	const overlayStack = 'Error\n    at UserAuthoredOverlay';
+	const pendingRegistrationStacks = new Set([transitionStack, overlayStack]);
+	let resolveRegistrations: () => void = () => undefined;
+	const registrations = new Promise<void>((resolve) => {
+		resolveRegistrations = resolve;
+	});
 
 	root.render(
 		<SequenceTestWrapper
 			onRegisterSequence={(sequence) => {
 				registeredSequences.push(sequence);
+				pendingRegistrationStacks.delete(sequence.getStack() ?? '');
+				if (pendingRegistrationStacks.size === 0) {
+					resolveRegistrations();
+				}
 			}}
 			overrideIdToNodePathMappings={{}}
 			propStatuses={{}}
@@ -240,7 +249,7 @@ test('TransitionSeries.Transition and Overlay register at their rendered timelin
 		</SequenceTestWrapper>,
 	);
 
-	await new Promise((resolve) => setTimeout(resolve, 10));
+	await registrations;
 
 	const transition = registeredSequences.find(
 		(sequence) => sequence.getStack() === transitionStack,


### PR DESCRIPTION
## Summary

- replace the fixed 10ms delay in the TransitionSeries registration range test
- wait for both transition and overlay registration callbacks before asserting timeline ranges
- avoid scheduler-dependent failures on slower CI runners

## Verification

- `bun test src/test/transition-series-stack.test.tsx --test-name-pattern "TransitionSeries.Transition and Overlay register at their rendered timeline ranges" --rerun-each 100` (from `packages/transitions`)
- `bunx turbo run test make --filter='@remotion/transitions' --no-update-notifier`
- `bun run build`
- `bun run stylecheck`
