### PR TITLE
`@remotion/studio`: Speed up timeline nonce-history sort

### DIFF
--- a/packages/studio/src/helpers/sort-by-nonce-history.ts
+++ b/packages/studio/src/helpers/sort-by-nonce-history.ts
@@ -38,6 +38,35 @@ export const compareNonceHistories = (
 	return aLatestEpoch - bLatestEpoch;
 };
 
+// Compare two histories, each pre-collapsed to parallel arrays of epochs and
+// nonces sorted by descending epoch, without rebuilding a Map per comparison.
+// Equivalent to getSharedEpochOrder: both find the newest shared epoch and
+// compare its nonces.
+const sharedEpochOrderFromSorted = (
+	aEpochs: number[],
+	aNonces: number[],
+	bEpochs: number[],
+	bNonces: number[],
+): number | null => {
+	let i = 0;
+	let j = 0;
+	while (i < aEpochs.length && j < bEpochs.length) {
+		const ae = aEpochs[i];
+		const be = bEpochs[j];
+		if (ae === be) {
+			return aNonces[i] - bNonces[j];
+		}
+
+		if (ae > be) {
+			i++;
+		} else {
+			j++;
+		}
+	}
+
+	return null;
+};
+
 export const sortItemsByNonceHistory: <T extends {nonce: NonceHistory}>(
 	items: T[],
 ) => T[] = (items) => {
@@ -46,47 +75,111 @@ export const sortItemsByNonceHistory: <T extends {nonce: NonceHistory}>(
 		return items.slice();
 	}
 
-	// Build a pairwise ordering matrix from shared epochs.
-	// order[i][j] < 0 means i before j, > 0 means j before i, null means no direct relationship.
-	const order: (number | null)[][] = Array.from({length: n}, () =>
-		Array(n).fill(null),
-	);
+	// Collapse each history once into epoch/nonce arrays sorted by descending
+	// epoch. `new Map(nonce)` keeps the last value per duplicated epoch, matching
+	// getSharedEpochOrder. This removes the per-pair Map/Set construction the
+	// pairwise loop below would otherwise repeat O(n^2) times.
+	const epochsOf: number[][] = new Array(n);
+	const noncesOf: number[][] = new Array(n);
+	for (let i = 0; i < n; i++) {
+		const map = new Map(items[i].nonce);
+		const epochs = [...map.keys()].sort((x, y) => y - x);
+		epochsOf[i] = epochs;
+		noncesOf[i] = epochs.map((e) => map.get(e)!);
+	}
+
+	// Pairwise "strictly before" relation, stored as bitsets: `before[i]` has
+	// bit j set when i must come before j, `known[i]` has bit j set when the
+	// pair (i, j) is directly determined by a shared epoch. Bitsets let the
+	// transitive closure below combine 32 relationships per word.
+	const words = (n + 31) >> 5;
+	const before = new Uint32Array(n * words);
+	const known = new Uint32Array(n * words);
+	// Direct comparison sign per ordered pair; only read where `known` is set.
+	const sign = new Int8Array(n * n);
 
 	for (let i = 0; i < n; i++) {
 		for (let j = i + 1; j < n; j++) {
-			const cmp = getSharedEpochOrder(items[i].nonce, items[j].nonce);
-			order[i][j] = cmp;
-			order[j][i] = cmp !== null ? -cmp : null;
+			const cmp = sharedEpochOrderFromSorted(
+				epochsOf[i],
+				noncesOf[i],
+				epochsOf[j],
+				noncesOf[j],
+			);
+			if (cmp === null) {
+				continue;
+			}
+
+			known[i * words + (j >> 5)] |= 1 << (j & 31);
+			known[j * words + (i >> 5)] |= 1 << (i & 31);
+			sign[i * n + j] = cmp < 0 ? -1 : cmp > 0 ? 1 : 0;
+			sign[j * n + i] = cmp < 0 ? 1 : cmp > 0 ? -1 : 0;
+			if (cmp < 0) {
+				before[i * words + (j >> 5)] |= 1 << (j & 31);
+			} else if (cmp > 0) {
+				before[j * words + (i >> 5)] |= 1 << (i & 31);
+			}
 		}
 	}
 
-	// Compute transitive closure: if i < j and j < k, then i < k.
+	// Transitive closure: if i < k and k < j, then i < j. This is the same
+	// Floyd-Warshall relation as before, but the inner sweep is bitwise
+	// (`before[k] & ~known[i]` finds all reachable j at once). A newly derived
+	// edge is marked known immediately so the first path decides an otherwise
+	// undetermined pair — preserving behavior on the inputs where the pairwise
+	// comparison is intentionally non-transitive.
 	for (let k = 0; k < n; k++) {
+		const kBase = k * words;
+		const kWord = k >> 5;
+		const kBit = 1 << (k & 31);
 		for (let i = 0; i < n; i++) {
-			for (let j = 0; j < n; j++) {
-				if (
-					order[i][j] === null &&
-					order[i][k] !== null &&
-					order[k][j] !== null &&
-					order[i][k]! < 0 &&
-					order[k][j]! < 0
-				) {
-					order[i][j] = -1;
-					order[j][i] = 1;
+			if (i === k) {
+				continue;
+			}
+
+			const iBase = i * words;
+			if ((before[iBase + kWord] & kBit) === 0) {
+				continue; // i is not before k, so k adds nothing for i
+			}
+
+			for (let w = 0; w < words; w++) {
+				const add = before[kBase + w] & ~known[iBase + w];
+				if (add === 0) {
+					continue;
+				}
+
+				before[iBase + w] |= add;
+				known[iBase + w] |= add;
+				// Set the mirror relationship (j after i) for each newly known pair.
+				let bits = add;
+				while (bits !== 0) {
+					const lowest = bits & -bits;
+					const j = (w << 5) + (31 - Math.clz32(lowest));
+					sign[i * n + j] = -1;
+					known[j * words + (i >> 5)] |= 1 << (i & 31);
+					sign[j * n + i] = 1;
+					bits ^= lowest;
 				}
 			}
 		}
 	}
 
-	// Sort using transitive order, falling back to lower latest epoch first.
 	const indexMap = new Map(items.map((item, i) => [item, i]));
 	const result = items.slice();
 	result.sort((a, b) => {
 		const ai = indexMap.get(a)!;
 		const bi = indexMap.get(b)!;
-		const transitiveOrder = order[ai][bi];
-		if (transitiveOrder !== null) {
-			return transitiveOrder;
+
+		if ((known[ai * words + (bi >> 5)] >> (bi & 31)) & 1) {
+			return sign[ai * n + bi];
+		}
+
+		if ((before[ai * words + (bi >> 5)] >> (bi & 31)) & 1) {
+			return -1;
+		}
+
+		if ((before[bi * words + (ai >> 5)] >> (ai & 31)) & 1) {
+			return 1;
 		}
 
 		// No transitive relationship — lower latest epoch first


### PR DESCRIPTION
## What

Speeds up `sortItemsByNonceHistory` in the Studio timeline (the sort that orders Sequences, Compositions and Folders by nonce history, added in #6797). The result and behavior are unchanged; only the internal algorithm is faster.

## Why

The current implementation builds a pairwise ordering matrix and then computes a transitive closure with a triple-nested loop over a boxed `(number | null)[][]` matrix — `O(n³)` with per-cell object access. For a large project this runs on every timeline re-sort and becomes visibly slow.

Directly measured, median wall-clock of one sort of mixed multi-epoch inputs (the case that actually exercises the closure):

| items | before | after |
| ---: | ---: | ---: |
| 200 | ~24 ms | ~1.5 ms |
| 500 | ~291 ms | ~10 ms |
| 1000 | ~2181 ms | ~58 ms |

Where it matters: for a typical timeline of a handful to a few dozen items this is sub-millisecond either way and users won't notice. The win shows up for large projects with hundreds of Sequences, Compositions and Folders, where the old `O(n³)` closure caused noticeable Studio lag whenever the list was re-sorted.

## How

Two changes, both behavior-preserving:

- The transitive closure now runs over `Uint32Array` bitsets instead of a boxed matrix, so its inner sweep combines 32 relationships per word (`before[k] & ~known[i]`). A newly derived edge is locked immediately, so the first path decides an otherwise-undetermined pair — this keeps the exact output on the inputs where the newest-shared-epoch comparison is intentionally non-transitive.
- The pairwise comparison no longer rebuilds a `Map` and a `Set` for every pair. Each history is collapsed once into epoch/nonce arrays sorted by descending epoch, and pairs are compared with a linear merge-scan. Once the closure is cheap, this per-pair setup is the larger remaining cost.

The public `compareNonceHistories` export is unchanged.

## Testing

- `bun test packages/studio/src/test/sort-by-nonce-history.test.ts` — 8/8 pass.
- Additionally validated against the previous implementation as an oracle over randomized inputs across the single-epoch, multi-epoch, duplicate-epoch, unsorted-history, tie-dense and duplicate-object cases, plus the handcrafted non-transitive and closure-chain fixtures; the emitted order matches on every case.
- Typecheck and `oxfmt` formatting clean on the touched file.

Supplementary autoresearch — a public record of the exploration behind this change (baseline and the variants measured, including one that was discarded because it changed behavior on cyclic inputs): https://dashboard.weco.ai/share/sSea_OsAHQq29q4g8HtD-PC96KLHxoqu
