### PR TITLE
Docs: Mark Cloud Run as unmaintained

### DIFF
--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -1305,30 +1305,6 @@ const sidebars: SidebarsConfig = {
 			],
 		},
 		{
-			type: 'category',
-			label: 'Cloud Run',
-			link: {
-				type: 'doc',
-				id: 'cloudrun',
-			},
-			items: [
-				'cloudrun',
-				'cloudrun/status',
-				'cloudrun/setup',
-				'cloudrun/permissions',
-				'cloudrun/generate-env',
-				'cloudrun/region-selection',
-				'cloudrun/checklist',
-				'cloudrun/instancecount',
-				'cloudrun/multiple-buckets',
-				'cloudrun/limits',
-				'cloudrun/light-client',
-				'cloudrun/upgrading',
-				'cloudrun/uninstall',
-			],
-		},
-
-		{
 			type: 'html',
 			value:
 				'<hr style="margin-top: 4px; margin-bottom: 4px; border-bottom: none"/>', // The HTML to be rendered
@@ -1700,6 +1676,30 @@ const sidebars: SidebarsConfig = {
 			value:
 				'<hr style="margin-top: 4px; margin-bottom: 4px; border-bottom: none"/>', // The HTML to be rendered
 			defaultStyle: true, // Use the default menu item styling
+		},
+		{
+			type: 'category',
+			label: 'Cloud Run',
+			className: 'unmaintained-item',
+			link: {
+				type: 'doc',
+				id: 'cloudrun',
+			},
+			items: [
+				'cloudrun',
+				'cloudrun/status',
+				'cloudrun/setup',
+				'cloudrun/permissions',
+				'cloudrun/generate-env',
+				'cloudrun/region-selection',
+				'cloudrun/checklist',
+				'cloudrun/instancecount',
+				'cloudrun/multiple-buckets',
+				'cloudrun/limits',
+				'cloudrun/light-client',
+				'cloudrun/upgrading',
+				'cloudrun/uninstall',
+			],
 		},
 		{
 			type: 'category',

--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -223,8 +223,9 @@ code {
 }
 
 .deprecated-item > div > a::after,
+.unmaintained-item > div > a::after,
+.unmaintained-item > a::after,
 .deprecated-item > a::after {
-	content: 'Deprecated';
 	font-size: 12px;
 	opacity: 0.4;
 	border: 1px solid;
@@ -235,6 +236,16 @@ code {
 	margin-left: 6px;
 	border-radius: 4px;
 	transform: none !important;
+}
+
+.deprecated-item > div > a::after,
+.deprecated-item > a::after {
+	content: 'Deprecated';
+}
+
+.unmaintained-item > div > a::after,
+.unmaintained-item > a::after {
+	content: 'Unmaintained';
 }
 
 .wip-item > div > a::after,


### PR DESCRIPTION
## Summary

- move Cloud Run to the legacy section at the bottom of the docs sidebar
- label Cloud Run as unmaintained while keeping the other entries deprecated

## Checks

- `bun run build`
- `bun run stylecheck`

Closes #9631
