### PR TITLE
`@remotion/studio`: Allow changing media sources

### DIFF
--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -152,6 +152,7 @@ export const GlobalKeybindings: React.FC = () => {
 							? 'assets'
 							: 'compositions',
 					invocationTimestamp: Date.now(),
+					assetSelection: null,
 				});
 			},
 			triggerIfInputFieldFocused: true,
@@ -203,6 +204,7 @@ export const GlobalKeybindings: React.FC = () => {
 					type: 'quick-switcher',
 					mode: 'docs',
 					invocationTimestamp: Date.now(),
+					assetSelection: null,
 				});
 			},
 			commandCtrlKey: false,

--- a/packages/studio/src/components/InspectorPanel/common.tsx
+++ b/packages/studio/src/components/InspectorPanel/common.tsx
@@ -198,6 +198,11 @@ const segmentedTrailingAction: React.CSSProperties = {
 	width: 28,
 };
 
+const hiddenSegmentedTrailingIcon: React.CSSProperties = {
+	...inlineLabelIcon,
+	opacity: 0,
+};
+
 export type InspectorInlineActionSegment = {
 	readonly disabled: boolean;
 	readonly onClick: React.MouseEventHandler<HTMLButtonElement>;
@@ -232,7 +237,6 @@ export const InspectorInlineAction: React.FC<InspectorInlineActionProps> = ({
 	variant = {type: 'single'},
 }) => {
 	const [hovered, setHovered] = React.useState(false);
-	const [trailingHovered, setTrailingHovered] = React.useState(false);
 	const color = hovered && !disabled ? WHITE : LIGHT_TEXT;
 	const isSegmented = variant.type === 'segmented';
 	const buttonStyle = React.useMemo(
@@ -263,12 +267,6 @@ export const InspectorInlineAction: React.FC<InspectorInlineActionProps> = ({
 	const onPointerLeave = React.useCallback(() => {
 		setHovered(false);
 	}, []);
-	const onTrailingPointerEnter = React.useCallback(() => {
-		setTrailingHovered(true);
-	}, []);
-	const onTrailingPointerLeave = React.useCallback(() => {
-		setTrailingHovered(false);
-	}, []);
 
 	const mainContent = (
 		<>
@@ -286,8 +284,8 @@ export const InspectorInlineAction: React.FC<InspectorInlineActionProps> = ({
 			style={buttonStyle}
 			title={title}
 			onClick={onClick}
-			onPointerEnter={disabled ? undefined : onPointerEnter}
-			onPointerLeave={onPointerLeave}
+			onPointerEnter={disabled || isSegmented ? undefined : onPointerEnter}
+			onPointerLeave={isSegmented ? undefined : onPointerLeave}
 		>
 			{mainContent}
 		</button>
@@ -299,13 +297,13 @@ export const InspectorInlineAction: React.FC<InspectorInlineActionProps> = ({
 
 	if (variant.type === 'segmented') {
 		const trailingColor =
-			trailingHovered && !variant.trailing.disabled ? WHITE : LIGHT_TEXT;
+			hovered && !variant.trailing.disabled ? WHITE : LIGHT_TEXT;
 		const trailingStyle: React.CSSProperties = {
 			...segmentedTrailingAction,
 			backgroundColor: variant.trailing.disabled
 				? TRANSPARENT
 				: getBackgroundFromHoverState({
-						hovered: trailingHovered,
+						hovered,
 						selected: false,
 					}),
 			height:
@@ -316,7 +314,11 @@ export const InspectorInlineAction: React.FC<InspectorInlineActionProps> = ({
 		};
 
 		return (
-			<div style={segmentedInlineAction}>
+			<div
+				style={segmentedInlineAction}
+				onPointerEnter={onPointerEnter}
+				onPointerLeave={onPointerLeave}
+			>
 				{mainAction}
 				<button
 					type="button"
@@ -324,12 +326,8 @@ export const InspectorInlineAction: React.FC<InspectorInlineActionProps> = ({
 					style={trailingStyle}
 					title={variant.trailing.title}
 					onClick={variant.trailing.onClick}
-					onPointerEnter={
-						variant.trailing.disabled ? undefined : onTrailingPointerEnter
-					}
-					onPointerLeave={onTrailingPointerLeave}
 				>
-					<span style={inlineLabelIcon}>
+					<span style={hovered ? inlineLabelIcon : hiddenSegmentedTrailingIcon}>
 						{variant.trailing.renderIcon(trailingColor)}
 					</span>
 				</button>

--- a/packages/studio/src/components/InspectorPanel/common.tsx
+++ b/packages/studio/src/components/InspectorPanel/common.tsx
@@ -170,15 +170,58 @@ const inlineLabelIcon: React.CSSProperties = {
 	width: 18,
 };
 
-export const InspectorInlineAction: React.FC<{
-	readonly children: React.ReactNode;
+const segmentedInlineAction: React.CSSProperties = {
+	display: 'flex',
+	gap: 1,
+	margin: `0 ${INLINE_LABEL_BUTTON_MARGIN}px`,
+	width: `calc(100% - ${INLINE_LABEL_BUTTON_MARGIN * 2}px)`,
+};
+
+const segmentedMainAction: React.CSSProperties = {
+	borderRadius: '4px 0 0 4px',
+	flex: 1,
+	margin: 0,
+	minWidth: 0,
+	width: 'auto',
+};
+
+const segmentedTrailingAction: React.CSSProperties = {
+	alignItems: 'center',
+	appearance: 'none',
+	border: 'none',
+	borderRadius: '0 4px 4px 0',
+	display: 'flex',
+	flex: '0 0 28px',
+	justifyContent: 'center',
+	margin: 0,
+	padding: 0,
+	width: 28,
+};
+
+export type InspectorInlineActionSegment = {
 	readonly disabled: boolean;
 	readonly onClick: React.MouseEventHandler<HTMLButtonElement>;
+	readonly renderIcon: (color: string) => React.ReactNode;
+	readonly title?: string;
+};
+
+export type InspectorInlineActionProps = {
+	readonly children: React.ReactNode;
+	readonly disabled: boolean;
+	readonly onClick: React.MouseEventHandler<HTMLButtonElement> | null;
 	readonly renderIcon?: (color: string) => React.ReactNode;
 	readonly size?: 'default' | 'compact';
 	readonly style?: React.CSSProperties;
 	readonly title?: string;
-}> = ({
+	readonly variant?:
+		| {readonly type: 'single'}
+		| {
+				readonly type: 'segmented';
+				readonly trailing: InspectorInlineActionSegment;
+		  };
+};
+
+export const InspectorInlineAction: React.FC<InspectorInlineActionProps> = ({
 	children,
 	disabled,
 	onClick,
@@ -186,9 +229,12 @@ export const InspectorInlineAction: React.FC<{
 	size = 'default',
 	style,
 	title,
+	variant = {type: 'single'},
 }) => {
 	const [hovered, setHovered] = React.useState(false);
+	const [trailingHovered, setTrailingHovered] = React.useState(false);
 	const color = hovered && !disabled ? WHITE : LIGHT_TEXT;
+	const isSegmented = variant.type === 'segmented';
 	const buttonStyle = React.useMemo(
 		(): React.CSSProperties => ({
 			...(disabled ? inlineLabelButtonDisabled : inlineLabelButton),
@@ -198,9 +244,10 @@ export const InspectorInlineAction: React.FC<{
 			}),
 			color,
 			...(size === 'compact' ? compactInlineLabelButton : null),
+			...(isSegmented ? segmentedMainAction : null),
 			...style,
 		}),
-		[color, disabled, hovered, size, style],
+		[color, disabled, hovered, isSegmented, size, style],
 	);
 	const textStyle = React.useMemo(
 		(): React.CSSProperties => ({
@@ -216,8 +263,22 @@ export const InspectorInlineAction: React.FC<{
 	const onPointerLeave = React.useCallback(() => {
 		setHovered(false);
 	}, []);
+	const onTrailingPointerEnter = React.useCallback(() => {
+		setTrailingHovered(true);
+	}, []);
+	const onTrailingPointerLeave = React.useCallback(() => {
+		setTrailingHovered(false);
+	}, []);
 
-	return (
+	const mainContent = (
+		<>
+			{renderIcon ? (
+				<span style={inlineLabelIcon}>{renderIcon(color)}</span>
+			) : null}
+			<span style={textStyle}>{children}</span>
+		</>
+	);
+	const mainAction = onClick ? (
 		<button
 			className="__remotion-inspector-inline-action"
 			type="button"
@@ -228,12 +289,55 @@ export const InspectorInlineAction: React.FC<{
 			onPointerEnter={disabled ? undefined : onPointerEnter}
 			onPointerLeave={onPointerLeave}
 		>
-			{renderIcon ? (
-				<span style={inlineLabelIcon}>{renderIcon(color)}</span>
-			) : null}
-			<span style={textStyle}>{children}</span>
+			{mainContent}
 		</button>
+	) : (
+		<div style={buttonStyle} title={title}>
+			{mainContent}
+		</div>
 	);
+
+	if (variant.type === 'segmented') {
+		const trailingColor =
+			trailingHovered && !variant.trailing.disabled ? WHITE : LIGHT_TEXT;
+		const trailingStyle: React.CSSProperties = {
+			...segmentedTrailingAction,
+			backgroundColor: variant.trailing.disabled
+				? TRANSPARENT
+				: getBackgroundFromHoverState({
+						hovered: trailingHovered,
+						selected: false,
+					}),
+			height:
+				size === 'compact'
+					? COMPACT_INLINE_ROW_HEIGHT
+					: COMPACT_CONTROL_ROW_HEIGHT,
+			opacity: variant.trailing.disabled ? 0.35 : 1,
+		};
+
+		return (
+			<div style={segmentedInlineAction}>
+				{mainAction}
+				<button
+					type="button"
+					disabled={variant.trailing.disabled}
+					style={trailingStyle}
+					title={variant.trailing.title}
+					onClick={variant.trailing.onClick}
+					onPointerEnter={
+						variant.trailing.disabled ? undefined : onTrailingPointerEnter
+					}
+					onPointerLeave={onTrailingPointerLeave}
+				>
+					<span style={inlineLabelIcon}>
+						{variant.trailing.renderIcon(trailingColor)}
+					</span>
+				</button>
+			</div>
+		);
+	}
+
+	return mainAction;
 };
 
 export const InspectorDefaultPropsWarnings: React.FC<{

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -26,7 +26,7 @@ import {
 	openTimelineAssetLink,
 	splitRemoteSourceForMiddleEllipsis,
 } from './Timeline/timeline-asset-link';
-import {AssetSelectionInitialQueryContext} from './Timeline/TimelineAssetField';
+import {AssetSelectionContext} from './Timeline/TimelineAssetField';
 import {TimelineExpandedRow} from './Timeline/TimelineExpandedRow';
 import {
 	INSPECTOR_TIMELINE_ROW_LAYOUT,
@@ -72,6 +72,13 @@ const assetSelectorIcon: React.CSSProperties = {
 	width: 18,
 };
 
+const localSourceAction: React.CSSProperties = {
+	margin: 0,
+	paddingLeft: INSPECTOR_PANEL_HORIZONTAL_PADDING,
+	paddingRight: 4,
+	width: '100%',
+};
+
 const remoteSourceLabel: React.CSSProperties = {
 	color: LIGHT_TEXT,
 	display: 'flex',
@@ -80,7 +87,7 @@ const remoteSourceLabel: React.CSSProperties = {
 	lineHeight: '18px',
 	minWidth: 0,
 	overflow: 'hidden',
-	padding: `6px ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
+	padding: `6px 4px 6px ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
 	whiteSpace: 'nowrap',
 };
 
@@ -246,6 +253,52 @@ export const InspectorSequenceSection: React.FC<{
 	const assetSelectionInitialQuery = getAssetSearchQueryForComponent(
 		sequence.controls.componentIdentity,
 	);
+	const sourceDisplay = useMemo(() => {
+		if (localAsset) {
+			return (
+				<InspectorInlineAction
+					disabled={false}
+					onClick={jumpToAsset}
+					renderIcon={(color) => (
+						<AssetFileIcon
+							color={color}
+							fileType={getPreviewFileType(localAsset.assetPath)}
+							style={assetSelectorIcon}
+						/>
+					)}
+					size="compact"
+					style={localSourceAction}
+					title={localAsset.assetPath}
+				>
+					{localAssetFileName}
+				</InspectorInlineAction>
+			);
+		}
+
+		if (remoteAsset && remoteSourceParts) {
+			return (
+				<div style={remoteSourceLabel} title={remoteAsset.href}>
+					<span style={remoteSourceLeading}>{remoteSourceParts.leading}</span>
+					<span style={remoteSourceTrailing}>{remoteSourceParts.trailing}</span>
+				</div>
+			);
+		}
+
+		return null;
+	}, [
+		jumpToAsset,
+		localAsset,
+		localAssetFileName,
+		remoteAsset,
+		remoteSourceParts,
+	]);
+	const assetSelectionContextValue = useMemo(
+		() => ({
+			initialQuery: assetSelectionInitialQuery,
+			sourceDisplay,
+		}),
+		[assetSelectionInitialQuery, sourceDisplay],
+	);
 
 	const getIsExpanded = useCallback(
 		(candidate: SequenceNodePathInfo) => {
@@ -382,41 +435,12 @@ export const InspectorSequenceSection: React.FC<{
 	}
 
 	return (
-		<AssetSelectionInitialQueryContext.Provider
-			value={assetSelectionInitialQuery}
-		>
+		<AssetSelectionContext.Provider value={assetSelectionContextValue}>
 			<div style={container}>
 				{controlRows.length > 0 ? (
 					<TimelineSelectionOrderProvider items={controlSelectableItems}>
 						{controlGroups.map((group) => (
 							<InspectorSection key={group.id} header={group.label}>
-								{group.id === 'source' && localAsset ? (
-									<InspectorInlineAction
-										disabled={false}
-										onClick={jumpToAsset}
-										renderIcon={(color) => (
-											<AssetFileIcon
-												color={color}
-												fileType={getPreviewFileType(localAsset.assetPath)}
-												style={assetSelectorIcon}
-											/>
-										)}
-										size="compact"
-										title={localAsset.assetPath}
-									>
-										{localAssetFileName}
-									</InspectorInlineAction>
-								) : null}
-								{group.id === 'source' && remoteAsset && remoteSourceParts ? (
-									<div style={remoteSourceLabel} title={remoteAsset.href}>
-										<span style={remoteSourceLeading}>
-											{remoteSourceParts.leading}
-										</span>
-										<span style={remoteSourceTrailing}>
-											{remoteSourceParts.trailing}
-										</span>
-									</div>
-								) : null}
 								{group.id === 'transforms' ? renderTransformControls() : null}
 								{group.rows.map(renderRow)}
 							</InspectorSection>
@@ -433,6 +457,6 @@ export const InspectorSequenceSection: React.FC<{
 					</InspectorSection>
 				) : null}
 			</div>
-		</AssetSelectionInitialQueryContext.Provider>
+		</AssetSelectionContext.Provider>
 	);
 };

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -19,12 +19,14 @@ import {InlineAction} from './InlineAction';
 import {InspectorInlineAction, InspectorSection} from './InspectorPanel/common';
 import {sectionHeaderRow, sectionHeaderTitle} from './InspectorPanel/styles';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from './InspectorPanelLayout';
+import {getAssetSearchQueryForComponent} from './QuickSwitcher/asset-search';
 import {
 	getTimelineAssetLinkInfo,
 	getTimelineAssetSrcFromSchema,
 	openTimelineAssetLink,
 	splitRemoteSourceForMiddleEllipsis,
 } from './Timeline/timeline-asset-link';
+import {AssetSelectionInitialQueryContext} from './Timeline/TimelineAssetField';
 import {TimelineExpandedRow} from './Timeline/TimelineExpandedRow';
 import {
 	INSPECTOR_TIMELINE_ROW_LAYOUT,
@@ -241,6 +243,9 @@ export const InspectorSequenceSection: React.FC<{
 	const localAssetFileName = localAsset
 		? (localAsset.assetPath.split('/').pop() ?? localAsset.assetPath)
 		: null;
+	const assetSelectionInitialQuery = getAssetSearchQueryForComponent(
+		sequence.controls.componentIdentity,
+	);
 
 	const getIsExpanded = useCallback(
 		(candidate: SequenceNodePathInfo) => {
@@ -292,12 +297,7 @@ export const InspectorSequenceSection: React.FC<{
 	}, [getIsExpanded, tree]);
 
 	const controlSelectableItems = useMemo(
-		() =>
-			getInspectorSelectableItems(
-				controlRows.filter(
-					({node}) => node.kind !== 'field' || node.field?.key !== 'src',
-				),
-			),
+		() => getInspectorSelectableItems(controlRows),
 		[controlRows],
 	);
 	const effectSelectableItems = useMemo(
@@ -382,53 +382,57 @@ export const InspectorSequenceSection: React.FC<{
 	}
 
 	return (
-		<div style={container}>
-			{controlRows.length > 0 ? (
-				<TimelineSelectionOrderProvider items={controlSelectableItems}>
-					{controlGroups.map((group) => (
-						<InspectorSection key={group.id} header={group.label}>
-							{group.id === 'source' && localAsset ? (
-								<InspectorInlineAction
-									disabled={false}
-									onClick={jumpToAsset}
-									renderIcon={(color) => (
-										<AssetFileIcon
-											color={color}
-											fileType={getPreviewFileType(localAsset.assetPath)}
-											style={assetSelectorIcon}
-										/>
-									)}
-									size="compact"
-									title={localAsset.assetPath}
-								>
-									{localAssetFileName}
-								</InspectorInlineAction>
-							) : null}
-							{group.id === 'source' && remoteAsset && remoteSourceParts ? (
-								<div style={remoteSourceLabel} title={remoteAsset.href}>
-									<span style={remoteSourceLeading}>
-										{remoteSourceParts.leading}
-									</span>
-									<span style={remoteSourceTrailing}>
-										{remoteSourceParts.trailing}
-									</span>
-								</div>
-							) : null}
-							{group.id === 'transforms' ? renderTransformControls() : null}
-							{group.id === 'source' ? null : group.rows.map(renderRow)}
-						</InspectorSection>
-					))}
-				</TimelineSelectionOrderProvider>
-			) : null}
-			{showEffectsSection ? (
-				<InspectorSection header={effectsHeader}>
-					{effectRows.length > 0 ? (
-						<TimelineSelectionOrderProvider items={effectSelectableItems}>
-							{effectRows.map(renderRow)}
-						</TimelineSelectionOrderProvider>
-					) : null}
-				</InspectorSection>
-			) : null}
-		</div>
+		<AssetSelectionInitialQueryContext.Provider
+			value={assetSelectionInitialQuery}
+		>
+			<div style={container}>
+				{controlRows.length > 0 ? (
+					<TimelineSelectionOrderProvider items={controlSelectableItems}>
+						{controlGroups.map((group) => (
+							<InspectorSection key={group.id} header={group.label}>
+								{group.id === 'source' && localAsset ? (
+									<InspectorInlineAction
+										disabled={false}
+										onClick={jumpToAsset}
+										renderIcon={(color) => (
+											<AssetFileIcon
+												color={color}
+												fileType={getPreviewFileType(localAsset.assetPath)}
+												style={assetSelectorIcon}
+											/>
+										)}
+										size="compact"
+										title={localAsset.assetPath}
+									>
+										{localAssetFileName}
+									</InspectorInlineAction>
+								) : null}
+								{group.id === 'source' && remoteAsset && remoteSourceParts ? (
+									<div style={remoteSourceLabel} title={remoteAsset.href}>
+										<span style={remoteSourceLeading}>
+											{remoteSourceParts.leading}
+										</span>
+										<span style={remoteSourceTrailing}>
+											{remoteSourceParts.trailing}
+										</span>
+									</div>
+								) : null}
+								{group.id === 'transforms' ? renderTransformControls() : null}
+								{group.rows.map(renderRow)}
+							</InspectorSection>
+						))}
+					</TimelineSelectionOrderProvider>
+				) : null}
+				{showEffectsSection ? (
+					<InspectorSection header={effectsHeader}>
+						{effectRows.length > 0 ? (
+							<TimelineSelectionOrderProvider items={effectSelectableItems}>
+								{effectRows.map(renderRow)}
+							</TimelineSelectionOrderProvider>
+						) : null}
+					</InspectorSection>
+				) : null}
+			</div>
+		</AssetSelectionInitialQueryContext.Provider>
 	);
 };

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -25,7 +25,10 @@ import {
 	openTimelineAssetLink,
 	splitRemoteSourceForMiddleEllipsis,
 } from './Timeline/timeline-asset-link';
-import {AssetSelectionContext} from './Timeline/TimelineAssetField';
+import {
+	AssetSelectionContext,
+	type InspectorSourceAction,
+} from './Timeline/TimelineAssetField';
 import {TimelineExpandedRow} from './Timeline/TimelineExpandedRow';
 import {
 	INSPECTOR_TIMELINE_ROW_LAYOUT,
@@ -222,75 +225,61 @@ export const InspectorSequenceSection: React.FC<{
 	const {setSelectedModal} = useContext(ModalsContext);
 	const selectAsset = useSelectAsset();
 	const mediaSrc = getTimelineAssetSrcFromSchema(sequence.controls);
-	const assetLinkInfo = useMemo(
-		() => (mediaSrc ? getTimelineAssetLinkInfo(mediaSrc) : null),
-		[mediaSrc],
-	);
-	const localAsset = assetLinkInfo?.kind === 'local' ? assetLinkInfo : null;
-	const remoteAsset = assetLinkInfo?.kind === 'remote' ? assetLinkInfo : null;
-	const remoteSourceParts = useMemo(
-		() =>
-			remoteAsset ? splitRemoteSourceForMiddleEllipsis(remoteAsset.href) : null,
-		[remoteAsset],
-	);
-	const jumpToAsset = useCallback(() => {
-		if (localAsset) {
-			openTimelineAssetLink(localAsset, selectAsset);
-		}
-	}, [localAsset, selectAsset]);
-	const localAssetFileName = localAsset
-		? (localAsset.assetPath.split('/').pop() ?? localAsset.assetPath)
-		: null;
 	const assetSelectionInitialQuery = getAssetSearchQueryForComponent(
 		sequence.controls.componentIdentity,
 	);
-	const sourceAction = useMemo(() => {
-		if (localAsset) {
-			return {
-				children: localAssetFileName,
-				disabled: false,
-				onClick: jumpToAsset,
-				renderIcon: (color: string) => (
-					<AssetFileIcon
-						color={color}
-						fileType={getPreviewFileType(localAsset.assetPath)}
-						style={assetSelectorIcon}
-					/>
-				),
-				title: localAsset.assetPath,
-			};
-		}
+	const getSourceAction = useCallback(
+		(src: string): InspectorSourceAction | null => {
+			const linkInfo = getTimelineAssetLinkInfo(src);
+			if (linkInfo?.kind === 'local') {
+				const fileName =
+					linkInfo.assetPath.split('/').pop() ?? linkInfo.assetPath;
 
-		if (remoteAsset && remoteSourceParts) {
-			return {
-				children: (
-					<span style={remoteSourcePartsContainer}>
-						<span style={remoteSourceLeading}>{remoteSourceParts.leading}</span>
-						<span style={remoteSourceTrailing}>
-							{remoteSourceParts.trailing}
+				return {
+					children: fileName,
+					disabled: false,
+					onClick: () => openTimelineAssetLink(linkInfo, selectAsset),
+					renderIcon: (color: string) => (
+						<AssetFileIcon
+							color={color}
+							fileType={getPreviewFileType(linkInfo.assetPath)}
+							style={assetSelectorIcon}
+						/>
+					),
+					title: linkInfo.assetPath,
+				};
+			}
+
+			if (linkInfo?.kind === 'remote') {
+				const parts = splitRemoteSourceForMiddleEllipsis(linkInfo.href);
+
+				return {
+					children: (
+						<span style={remoteSourcePartsContainer}>
+							<span style={remoteSourceLeading}>{parts.leading}</span>
+							<span style={remoteSourceTrailing}>{parts.trailing}</span>
 						</span>
-					</span>
-				),
-				disabled: false,
-				onClick: null,
-				title: remoteAsset.href,
-			};
-		}
+					),
+					disabled: false,
+					onClick: null,
+					title: linkInfo.href,
+				};
+			}
 
-		return null;
-	}, [
-		jumpToAsset,
-		localAsset,
-		localAssetFileName,
-		remoteAsset,
-		remoteSourceParts,
-	]);
+			return null;
+		},
+		[selectAsset],
+	);
+	const sourceAction = useMemo(() => {
+		return mediaSrc ? getSourceAction(mediaSrc) : null;
+	}, [getSourceAction, mediaSrc]);
 	const assetSelectionContextValue = useMemo(
 		() => ({
+			getSourceAction,
 			initialQuery: assetSelectionInitialQuery,
 			sourceAction,
 		}),
-		[assetSelectionInitialQuery, sourceAction],
+		[assetSelectionInitialQuery, getSourceAction, sourceAction],
 	);
 
 	const getIsExpanded = useCallback(

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -16,9 +16,8 @@ import {Plus} from '../icons/plus';
 import {ModalsContext} from '../state/modals';
 import {AssetFileIcon} from './AssetFileIcon';
 import {InlineAction} from './InlineAction';
-import {InspectorInlineAction, InspectorSection} from './InspectorPanel/common';
+import {InspectorSection} from './InspectorPanel/common';
 import {sectionHeaderRow, sectionHeaderTitle} from './InspectorPanel/styles';
-import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from './InspectorPanelLayout';
 import {getAssetSearchQueryForComponent} from './QuickSwitcher/asset-search';
 import {
 	getTimelineAssetLinkInfo,
@@ -72,22 +71,14 @@ const assetSelectorIcon: React.CSSProperties = {
 	width: 18,
 };
 
-const localSourceAction: React.CSSProperties = {
-	margin: 0,
-	paddingLeft: INSPECTOR_PANEL_HORIZONTAL_PADDING,
-	paddingRight: 4,
-	width: '100%',
-};
-
-const remoteSourceLabel: React.CSSProperties = {
-	color: LIGHT_TEXT,
+const remoteSourcePartsContainer: React.CSSProperties = {
+	color: 'inherit',
 	display: 'flex',
 	fontFamily: 'Arial, Helvetica, sans-serif',
 	fontSize: 12,
 	lineHeight: '18px',
 	minWidth: 0,
 	overflow: 'hidden',
-	padding: `6px 4px 6px ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
 	whiteSpace: 'nowrap',
 };
 
@@ -253,35 +244,37 @@ export const InspectorSequenceSection: React.FC<{
 	const assetSelectionInitialQuery = getAssetSearchQueryForComponent(
 		sequence.controls.componentIdentity,
 	);
-	const sourceDisplay = useMemo(() => {
+	const sourceAction = useMemo(() => {
 		if (localAsset) {
-			return (
-				<InspectorInlineAction
-					disabled={false}
-					onClick={jumpToAsset}
-					renderIcon={(color) => (
-						<AssetFileIcon
-							color={color}
-							fileType={getPreviewFileType(localAsset.assetPath)}
-							style={assetSelectorIcon}
-						/>
-					)}
-					size="compact"
-					style={localSourceAction}
-					title={localAsset.assetPath}
-				>
-					{localAssetFileName}
-				</InspectorInlineAction>
-			);
+			return {
+				children: localAssetFileName,
+				disabled: false,
+				onClick: jumpToAsset,
+				renderIcon: (color: string) => (
+					<AssetFileIcon
+						color={color}
+						fileType={getPreviewFileType(localAsset.assetPath)}
+						style={assetSelectorIcon}
+					/>
+				),
+				title: localAsset.assetPath,
+			};
 		}
 
 		if (remoteAsset && remoteSourceParts) {
-			return (
-				<div style={remoteSourceLabel} title={remoteAsset.href}>
-					<span style={remoteSourceLeading}>{remoteSourceParts.leading}</span>
-					<span style={remoteSourceTrailing}>{remoteSourceParts.trailing}</span>
-				</div>
-			);
+			return {
+				children: (
+					<span style={remoteSourcePartsContainer}>
+						<span style={remoteSourceLeading}>{remoteSourceParts.leading}</span>
+						<span style={remoteSourceTrailing}>
+							{remoteSourceParts.trailing}
+						</span>
+					</span>
+				),
+				disabled: false,
+				onClick: null,
+				title: remoteAsset.href,
+			};
 		}
 
 		return null;
@@ -295,9 +288,9 @@ export const InspectorSequenceSection: React.FC<{
 	const assetSelectionContextValue = useMemo(
 		() => ({
 			initialQuery: assetSelectionInitialQuery,
-			sourceDisplay,
+			sourceAction,
 		}),
-		[assetSelectionInitialQuery, sourceDisplay],
+		[assetSelectionInitialQuery, sourceAction],
 	);
 
 	const getIsExpanded = useCallback(

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -22,7 +22,6 @@ import {getAssetSearchQueryForComponent} from './QuickSwitcher/asset-search';
 import {
 	getTimelineAssetLinkInfo,
 	getTimelineAssetSrcFromSchema,
-	openTimelineAssetLink,
 	splitRemoteSourceForMiddleEllipsis,
 } from './Timeline/timeline-asset-link';
 import {AssetSelectionContext} from './Timeline/TimelineAssetField';
@@ -37,7 +36,6 @@ import {
 	type TimelineSelection,
 } from './Timeline/TimelineSelection';
 import {useTimelineExpandedTree} from './Timeline/use-timeline-expanded-tree';
-import {useSelectAsset} from './use-select-asset';
 
 const container: React.CSSProperties = {
 	color: WHITE,
@@ -185,6 +183,14 @@ export const getInspectorSelectableItems = (
 	rows: readonly FlatTreeRow[],
 ): TimelineSelection[] => {
 	return rows.flatMap(({node}): TimelineSelection[] => {
+		if (
+			node.kind === 'field' &&
+			node.field?.typeName === 'asset' &&
+			node.field.key === 'src'
+		) {
+			return [];
+		}
+
 		const selection = getTimelineSelectionFromNodePathInfo(node.nodePathInfo);
 		return selection ? [selection] : [];
 	});
@@ -220,7 +226,6 @@ export const InspectorSequenceSection: React.FC<{
 	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {setSelectedModal} = useContext(ModalsContext);
-	const selectAsset = useSelectAsset();
 	const mediaSrc = getTimelineAssetSrcFromSchema(sequence.controls);
 	const assetLinkInfo = useMemo(
 		() => (mediaSrc ? getTimelineAssetLinkInfo(mediaSrc) : null),
@@ -233,11 +238,6 @@ export const InspectorSequenceSection: React.FC<{
 			remoteAsset ? splitRemoteSourceForMiddleEllipsis(remoteAsset.href) : null,
 		[remoteAsset],
 	);
-	const jumpToAsset = useCallback(() => {
-		if (localAsset) {
-			openTimelineAssetLink(localAsset, selectAsset);
-		}
-	}, [localAsset, selectAsset]);
 	const localAssetFileName = localAsset
 		? (localAsset.assetPath.split('/').pop() ?? localAsset.assetPath)
 		: null;
@@ -249,7 +249,7 @@ export const InspectorSequenceSection: React.FC<{
 			return {
 				children: localAssetFileName,
 				disabled: false,
-				onClick: jumpToAsset,
+				onClick: null,
 				renderIcon: (color: string) => (
 					<AssetFileIcon
 						color={color}
@@ -278,13 +278,7 @@ export const InspectorSequenceSection: React.FC<{
 		}
 
 		return null;
-	}, [
-		jumpToAsset,
-		localAsset,
-		localAssetFileName,
-		remoteAsset,
-		remoteSourceParts,
-	]);
+	}, [localAsset, localAssetFileName, remoteAsset, remoteSourceParts]);
 	const assetSelectionContextValue = useMemo(
 		() => ({
 			initialQuery: assetSelectionInitialQuery,

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -22,6 +22,7 @@ import {getAssetSearchQueryForComponent} from './QuickSwitcher/asset-search';
 import {
 	getTimelineAssetLinkInfo,
 	getTimelineAssetSrcFromSchema,
+	openTimelineAssetLink,
 	splitRemoteSourceForMiddleEllipsis,
 } from './Timeline/timeline-asset-link';
 import {AssetSelectionContext} from './Timeline/TimelineAssetField';
@@ -36,6 +37,7 @@ import {
 	type TimelineSelection,
 } from './Timeline/TimelineSelection';
 import {useTimelineExpandedTree} from './Timeline/use-timeline-expanded-tree';
+import {useSelectAsset} from './use-select-asset';
 
 const container: React.CSSProperties = {
 	color: WHITE,
@@ -183,14 +185,6 @@ export const getInspectorSelectableItems = (
 	rows: readonly FlatTreeRow[],
 ): TimelineSelection[] => {
 	return rows.flatMap(({node}): TimelineSelection[] => {
-		if (
-			node.kind === 'field' &&
-			node.field?.typeName === 'asset' &&
-			node.field.key === 'src'
-		) {
-			return [];
-		}
-
 		const selection = getTimelineSelectionFromNodePathInfo(node.nodePathInfo);
 		return selection ? [selection] : [];
 	});
@@ -226,6 +220,7 @@ export const InspectorSequenceSection: React.FC<{
 	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {setSelectedModal} = useContext(ModalsContext);
+	const selectAsset = useSelectAsset();
 	const mediaSrc = getTimelineAssetSrcFromSchema(sequence.controls);
 	const assetLinkInfo = useMemo(
 		() => (mediaSrc ? getTimelineAssetLinkInfo(mediaSrc) : null),
@@ -238,6 +233,11 @@ export const InspectorSequenceSection: React.FC<{
 			remoteAsset ? splitRemoteSourceForMiddleEllipsis(remoteAsset.href) : null,
 		[remoteAsset],
 	);
+	const jumpToAsset = useCallback(() => {
+		if (localAsset) {
+			openTimelineAssetLink(localAsset, selectAsset);
+		}
+	}, [localAsset, selectAsset]);
 	const localAssetFileName = localAsset
 		? (localAsset.assetPath.split('/').pop() ?? localAsset.assetPath)
 		: null;
@@ -249,7 +249,7 @@ export const InspectorSequenceSection: React.FC<{
 			return {
 				children: localAssetFileName,
 				disabled: false,
-				onClick: null,
+				onClick: jumpToAsset,
 				renderIcon: (color: string) => (
 					<AssetFileIcon
 						color={color}
@@ -278,7 +278,13 @@ export const InspectorSequenceSection: React.FC<{
 		}
 
 		return null;
-	}, [localAsset, localAssetFileName, remoteAsset, remoteSourceParts]);
+	}, [
+		jumpToAsset,
+		localAsset,
+		localAssetFileName,
+		remoteAsset,
+		remoteSourceParts,
+	]);
 	const assetSelectionContextValue = useMemo(
 		() => ({
 			initialQuery: assetSelectionInitialQuery,
@@ -337,7 +343,12 @@ export const InspectorSequenceSection: React.FC<{
 	}, [getIsExpanded, tree]);
 
 	const controlSelectableItems = useMemo(
-		() => getInspectorSelectableItems(controlRows),
+		() =>
+			getInspectorSelectableItems(
+				controlRows.filter(
+					({node}) => node.kind !== 'field' || node.field?.key !== 'src',
+				),
+			),
 		[controlRows],
 	);
 	const effectSelectableItems = useMemo(

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -180,6 +180,7 @@ export const Modals: React.FC<{
 					readOnlyStudio={readOnlyStudio}
 					invocationTimestamp={modalContextType.invocationTimestamp}
 					initialMode={modalContextType.mode}
+					assetSelection={modalContextType.assetSelection ?? null}
 				/>
 			)}
 			{modalContextType && modalContextType.type === 'add-effect' && (

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -180,7 +180,7 @@ export const Modals: React.FC<{
 					readOnlyStudio={readOnlyStudio}
 					invocationTimestamp={modalContextType.invocationTimestamp}
 					initialMode={modalContextType.mode}
-					assetSelection={modalContextType.assetSelection ?? null}
+					assetSelection={modalContextType.assetSelection}
 				/>
 			)}
 			{modalContextType && modalContextType.type === 'add-effect' && (

--- a/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
+++ b/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
@@ -42,6 +42,7 @@ export const ExplorerQuickSwitcherTrigger: React.FC<{
 			type: 'quick-switcher',
 			mode,
 			invocationTimestamp: Date.now(),
+			assetSelection: null,
 		});
 	}, [mode, setSelectedModal]);
 

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type {StaticFile} from '../../api/get-static-files';
 import {DismissableModal} from '../NewComposition/DismissableModal';
 import type {QuickSwitcherMode} from './NoResults';
 import {QuickSwitcherContent} from './QuickSwitcherContent';
@@ -12,13 +13,18 @@ const QuickSwitcher: React.FC<{
 	readonly initialMode: QuickSwitcherMode;
 	readonly invocationTimestamp: number;
 	readonly readOnlyStudio: boolean;
-}> = ({initialMode, invocationTimestamp, readOnlyStudio}) => {
+	readonly assetSelection: {
+		readonly initialQuery: string;
+		readonly onSelected: (asset: StaticFile) => void;
+	} | null;
+}> = ({initialMode, invocationTimestamp, readOnlyStudio, assetSelection}) => {
 	return (
 		<DismissableModal panelStyle={panelStyle}>
 			<QuickSwitcherContent
 				readOnlyStudio={readOnlyStudio}
 				invocationTimestamp={invocationTimestamp}
 				initialMode={initialMode}
+				assetSelection={assetSelection}
 			/>
 		</DismissableModal>
 	);

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -79,6 +79,11 @@ const content: React.CSSProperties = {
 	alignItems: 'center',
 };
 
+const contentWithoutModeSelector: React.CSSProperties = {
+	...content,
+	paddingTop: 16,
+};
+
 const stripQuery = (query: string) => {
 	if (query.startsWith('$') || query.startsWith('>') || query.startsWith('?')) {
 		return query.substring(1).trim();
@@ -464,7 +469,7 @@ export const QuickSwitcherContent: React.FC<{
 					</button>
 				</div>
 			)}
-			<div style={content}>
+			<div style={assetSelection ? contentWithoutModeSelector : content}>
 				<RemotionInput
 					ref={inputRef}
 					type="text"

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -7,6 +7,7 @@ import React, {
 	useState,
 } from 'react';
 import {Internals} from 'remotion';
+import type {StaticFile} from '../../api/get-static-files';
 import {LIGHT_TEXT, WHITE} from '../../helpers/colors';
 import {getPreviewFileType} from '../../helpers/get-preview-file-type';
 import {isCompositionStill} from '../../helpers/is-composition-still';
@@ -136,22 +137,26 @@ export const QuickSwitcherContent: React.FC<{
 	readonly initialMode: QuickSwitcherMode;
 	readonly invocationTimestamp: number;
 	readonly readOnlyStudio: boolean;
-}> = ({initialMode, invocationTimestamp, readOnlyStudio}) => {
+	readonly assetSelection: {
+		readonly initialQuery: string;
+		readonly onSelected: (asset: StaticFile) => void;
+	} | null;
+}> = ({initialMode, invocationTimestamp, readOnlyStudio, assetSelection}) => {
 	const {compositions} = useContext(Internals.CompositionManager);
 	const staticFiles = useStaticFiles();
 	const [state, setState] = useState(() => {
 		return {
-			query: mapModeToQuery(initialMode),
+			query: assetSelection?.initialQuery ?? mapModeToQuery(initialMode),
 			selectedIndex: 0,
 		};
 	});
 
 	useEffect(() => {
 		setState({
-			query: mapModeToQuery(initialMode),
+			query: assetSelection?.initialQuery ?? mapModeToQuery(initialMode),
 			selectedIndex: 0,
 		});
-	}, [initialMode, invocationTimestamp]);
+	}, [assetSelection, initialMode, invocationTimestamp]);
 
 	const inputRef = useRef<HTMLInputElement>(null);
 	const selectComposition = useSelectComposition();
@@ -165,7 +170,9 @@ export const QuickSwitcherContent: React.FC<{
 
 	const keybindings = useKeybinding();
 
-	const mode: QuickSwitcherMode = mapQueryToMode(state.query);
+	const mode: QuickSwitcherMode = assetSelection
+		? 'assets'
+		: mapQueryToMode(state.query);
 
 	const actualQuery = useMemo(() => {
 		return stripQuery(state.query);
@@ -205,8 +212,13 @@ export const QuickSwitcherContent: React.FC<{
 						type: 'asset',
 						fileType: getPreviewFileType(asset.name),
 						onSelected: () => {
-							selectAsset(asset.name);
-							pushUrl(`/assets/${asset.name}`);
+							if (assetSelection) {
+								assetSelection.onSelected(asset);
+							} else {
+								selectAsset(asset.name);
+								pushUrl(`/assets/${asset.name}`);
+							}
+
 							setSelectedModal(null);
 						},
 					};
@@ -245,6 +257,7 @@ export const QuickSwitcherContent: React.FC<{
 		menuActions,
 		docResults,
 		assetSearch,
+		assetSelection,
 		selectAsset,
 		selectComposition,
 		setSelectedModal,
@@ -416,39 +429,41 @@ export const QuickSwitcherContent: React.FC<{
 
 	return (
 		<div style={container}>
-			<div style={modeSelector}>
-				<button
-					onClick={onCompositionsSelected}
-					style={mode === 'compositions' ? modeActive : modeInactive}
-					type="button"
-				>
-					Compositions
-				</button>
-				<Spacing x={1} />
-				<button
-					onClick={onAssetsSelected}
-					style={mode === 'assets' ? modeActive : modeInactive}
-					type="button"
-				>
-					Assets
-				</button>
-				<Spacing x={1} />
-				<button
-					onClick={onActionsSelected}
-					style={mode === 'commands' ? modeActive : modeInactive}
-					type="button"
-				>
-					Actions
-				</button>
-				<Spacing x={1} />
-				<button
-					onClick={onDocSearchSelected}
-					style={mode === 'docs' ? modeActive : modeInactive}
-					type="button"
-				>
-					Documentation
-				</button>
-			</div>
+			{assetSelection ? null : (
+				<div style={modeSelector}>
+					<button
+						onClick={onCompositionsSelected}
+						style={mode === 'compositions' ? modeActive : modeInactive}
+						type="button"
+					>
+						Compositions
+					</button>
+					<Spacing x={1} />
+					<button
+						onClick={onAssetsSelected}
+						style={mode === 'assets' ? modeActive : modeInactive}
+						type="button"
+					>
+						Assets
+					</button>
+					<Spacing x={1} />
+					<button
+						onClick={onActionsSelected}
+						style={mode === 'commands' ? modeActive : modeInactive}
+						type="button"
+					>
+						Actions
+					</button>
+					<Spacing x={1} />
+					<button
+						onClick={onDocSearchSelected}
+						style={mode === 'docs' ? modeActive : modeInactive}
+						type="button"
+					>
+						Documentation
+					</button>
+				</div>
+			)}
 			<div style={content}>
 				<RemotionInput
 					ref={inputRef}

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -151,14 +151,20 @@ export const QuickSwitcherContent: React.FC<{
 	const staticFiles = useStaticFiles();
 	const [state, setState] = useState(() => {
 		return {
-			query: assetSelection?.initialQuery ?? mapModeToQuery(initialMode),
+			query:
+				assetSelection === null
+					? mapModeToQuery(initialMode)
+					: assetSelection.initialQuery,
 			selectedIndex: 0,
 		};
 	});
 
 	useEffect(() => {
 		setState({
-			query: assetSelection?.initialQuery ?? mapModeToQuery(initialMode),
+			query:
+				assetSelection === null
+					? mapModeToQuery(initialMode)
+					: assetSelection.initialQuery,
 			selectedIndex: 0,
 		});
 	}, [assetSelection, initialMode, invocationTimestamp]);
@@ -175,9 +181,8 @@ export const QuickSwitcherContent: React.FC<{
 
 	const keybindings = useKeybinding();
 
-	const mode: QuickSwitcherMode = assetSelection
-		? 'assets'
-		: mapQueryToMode(state.query);
+	const mode: QuickSwitcherMode =
+		assetSelection !== null ? 'assets' : mapQueryToMode(state.query);
 
 	const actualQuery = useMemo(() => {
 		return stripQuery(state.query);
@@ -217,7 +222,7 @@ export const QuickSwitcherContent: React.FC<{
 						type: 'asset',
 						fileType: getPreviewFileType(asset.name),
 						onSelected: () => {
-							if (assetSelection) {
+							if (assetSelection !== null) {
 								assetSelection.onSelected(asset);
 							} else {
 								selectAsset(asset.name);
@@ -434,7 +439,7 @@ export const QuickSwitcherContent: React.FC<{
 
 	return (
 		<div style={container}>
-			{assetSelection ? null : (
+			{assetSelection === null && (
 				<div style={modeSelector}>
 					<button
 						onClick={onCompositionsSelected}
@@ -469,7 +474,9 @@ export const QuickSwitcherContent: React.FC<{
 					</button>
 				</div>
 			)}
-			<div style={assetSelection ? contentWithoutModeSelector : content}>
+			<div
+				style={assetSelection === null ? content : contentWithoutModeSelector}
+			>
 				<RemotionInput
 					ref={inputRef}
 					type="text"

--- a/packages/studio/src/components/QuickSwitcher/asset-search.ts
+++ b/packages/studio/src/components/QuickSwitcher/asset-search.ts
@@ -55,5 +55,5 @@ export const getAssetSearchQueryForComponent = (
 	}
 
 	const assetType = componentAssetTypes[componentIdentity];
-	return assetType ? `type:${assetType}` : '';
+	return assetType ? `type:${assetType} ` : '';
 };

--- a/packages/studio/src/components/QuickSwitcher/asset-search.ts
+++ b/packages/studio/src/components/QuickSwitcher/asset-search.ts
@@ -1,5 +1,8 @@
 import type {StaticFile} from '../../api/get-static-files';
-import {getPreviewFileType} from '../../helpers/get-preview-file-type';
+import {
+	getPreviewFileType,
+	type AssetFileType,
+} from '../../helpers/get-preview-file-type';
 
 const typeFilterRegex = /(^|\s)type:([^\s]+)/gi;
 
@@ -35,4 +38,22 @@ export const filterAssetsByType = ({
 		}),
 		query: queryWithoutTypeFilters,
 	};
+};
+
+const componentAssetTypes: Record<string, AssetFileType> = {
+	'dev.remotion.media.Audio': 'audio',
+	'dev.remotion.media.Video': 'video',
+	'dev.remotion.remotion.AnimatedImage': 'image',
+	'dev.remotion.remotion.Img': 'image',
+};
+
+export const getAssetSearchQueryForComponent = (
+	componentIdentity: string | null,
+): string => {
+	if (componentIdentity === null) {
+		return '';
+	}
+
+	const assetType = componentAssetTypes[componentIdentity];
+	return assetType ? `type:${assetType}` : '';
 };

--- a/packages/studio/src/components/Timeline/TimelineAssetField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineAssetField.tsx
@@ -1,4 +1,4 @@
-import React, {createContext, useCallback, useContext} from 'react';
+import React, {createContext, useCallback, useContext, useMemo} from 'react';
 import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import type {
@@ -20,12 +20,16 @@ const penIcon: React.CSSProperties = {
 	width: 14,
 };
 
+export type InspectorSourceAction = Omit<InspectorInlineActionProps, 'variant'>;
+
 type AssetSelectionContextValue = {
 	readonly initialQuery: string;
-	readonly sourceAction: Omit<InspectorInlineActionProps, 'variant'> | null;
+	readonly getSourceAction: (src: string) => InspectorSourceAction | null;
+	readonly sourceAction: InspectorSourceAction | null;
 };
 
 export const AssetSelectionContext = createContext<AssetSelectionContextValue>({
+	getSourceAction: () => null,
 	initialQuery: '',
 	sourceAction: null,
 });
@@ -48,6 +52,7 @@ type TimelineAssetFieldProps = {
 
 export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
 	field,
+	effectiveValue,
 	propStatus,
 	onSave,
 	onDragValueChange,
@@ -58,8 +63,18 @@ export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
 	}
 
 	const {setSelectedModal} = useContext(ModalsContext);
-	const {initialQuery, sourceAction} = useContext(AssetSelectionContext);
-	const inlineSourceAction = field.key === 'src' ? sourceAction : null;
+	const {getSourceAction, initialQuery, sourceAction} = useContext(
+		AssetSelectionContext,
+	);
+	const inlineSourceAction = useMemo(() => {
+		if (field.key !== 'src') {
+			return null;
+		}
+
+		return typeof effectiveValue === 'string'
+			? getSourceAction(effectiveValue)
+			: sourceAction;
+	}, [effectiveValue, field.key, getSourceAction, sourceAction]);
 
 	const onSelect = useCallback(
 		(assetName: string, previewValue: string) => {

--- a/packages/studio/src/components/Timeline/TimelineAssetField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineAssetField.tsx
@@ -6,14 +6,37 @@ import type {
 	TimelineFieldOnDragValueChange,
 	TimelineFieldOnSave,
 } from '../../helpers/timeline-layout';
+import {PenIcon} from '../../icons/pen';
 import {ModalsContext} from '../../state/modals';
-import {Button} from '../Button';
+import {InlineAction} from '../InlineAction';
 
-const buttonStyle: React.CSSProperties = {
-	marginLeft: 8,
+const assetFieldRow: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	flex: 1,
+	minWidth: 0,
 };
 
-export const AssetSelectionInitialQueryContext = createContext('');
+const sourceDisplayContainer: React.CSSProperties = {
+	flex: 1,
+	minWidth: 0,
+};
+
+const penIcon: React.CSSProperties = {
+	display: 'block',
+	height: 14,
+	width: 14,
+};
+
+type AssetSelectionContextValue = {
+	readonly initialQuery: string;
+	readonly sourceDisplay: React.ReactNode;
+};
+
+export const AssetSelectionContext = createContext<AssetSelectionContextValue>({
+	initialQuery: '',
+	sourceDisplay: null,
+});
 
 export const toFileToken = (name: string) => {
 	return `${NoReactInternals.FILE_TOKEN}${name
@@ -43,7 +66,8 @@ export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
 	}
 
 	const {setSelectedModal} = useContext(ModalsContext);
-	const initialQuery = useContext(AssetSelectionInitialQueryContext);
+	const {initialQuery, sourceDisplay} = useContext(AssetSelectionContext);
+	const inlineSourceDisplay = field.key === 'src' ? sourceDisplay : null;
 
 	const onSelect = useCallback(
 		(assetName: string, previewValue: string) => {
@@ -72,15 +96,23 @@ export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
 		});
 	}, [initialQuery, onSelect, setSelectedModal]);
 
-	return (
-		<Button
+	const action = (
+		<InlineAction
 			onClick={openAssetSelection}
 			disabled={window.remotion_isReadOnlyStudio}
-			size="condensed"
-			style={buttonStyle}
 			title="Change source"
-		>
-			Change
-		</Button>
+			renderAction={(color) => <PenIcon color={color} style={penIcon} />}
+		/>
+	);
+
+	if (inlineSourceDisplay === null) {
+		return action;
+	}
+
+	return (
+		<div style={assetFieldRow}>
+			<div style={sourceDisplayContainer}>{inlineSourceDisplay}</div>
+			{action}
+		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineAssetField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineAssetField.tsx
@@ -9,18 +9,10 @@ import type {
 import {PenIcon} from '../../icons/pen';
 import {ModalsContext} from '../../state/modals';
 import {InlineAction} from '../InlineAction';
-
-const assetFieldRow: React.CSSProperties = {
-	alignItems: 'center',
-	display: 'flex',
-	flex: 1,
-	minWidth: 0,
-};
-
-const sourceDisplayContainer: React.CSSProperties = {
-	flex: 1,
-	minWidth: 0,
-};
+import {
+	InspectorInlineAction,
+	type InspectorInlineActionProps,
+} from '../InspectorPanel/common';
 
 const penIcon: React.CSSProperties = {
 	display: 'block',
@@ -30,12 +22,12 @@ const penIcon: React.CSSProperties = {
 
 type AssetSelectionContextValue = {
 	readonly initialQuery: string;
-	readonly sourceDisplay: React.ReactNode;
+	readonly sourceAction: Omit<InspectorInlineActionProps, 'variant'> | null;
 };
 
 export const AssetSelectionContext = createContext<AssetSelectionContextValue>({
 	initialQuery: '',
-	sourceDisplay: null,
+	sourceAction: null,
 });
 
 export const toFileToken = (name: string) => {
@@ -66,8 +58,8 @@ export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
 	}
 
 	const {setSelectedModal} = useContext(ModalsContext);
-	const {initialQuery, sourceDisplay} = useContext(AssetSelectionContext);
-	const inlineSourceDisplay = field.key === 'src' ? sourceDisplay : null;
+	const {initialQuery, sourceAction} = useContext(AssetSelectionContext);
+	const inlineSourceAction = field.key === 'src' ? sourceAction : null;
 
 	const onSelect = useCallback(
 		(assetName: string, previewValue: string) => {
@@ -105,14 +97,23 @@ export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
 		/>
 	);
 
-	if (inlineSourceDisplay === null) {
+	if (inlineSourceAction === null) {
 		return action;
 	}
 
 	return (
-		<div style={assetFieldRow}>
-			<div style={sourceDisplayContainer}>{inlineSourceDisplay}</div>
-			{action}
-		</div>
+		<InspectorInlineAction
+			{...inlineSourceAction}
+			size="compact"
+			variant={{
+				type: 'segmented',
+				trailing: {
+					disabled: window.remotion_isReadOnlyStudio,
+					onClick: openAssetSelection,
+					renderIcon: (color) => <PenIcon color={color} style={penIcon} />,
+					title: 'Change source',
+				},
+			}}
+		/>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineAssetField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineAssetField.tsx
@@ -1,45 +1,25 @@
-import React, {useCallback, useMemo} from 'react';
+import React, {createContext, useCallback, useContext} from 'react';
 import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
-import {writeStaticFile} from '../../api/write-static-file';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
 	TimelineFieldOnSave,
 } from '../../helpers/timeline-layout';
-import {Checkmark} from '../../icons/Checkmark';
-import {pickFilesToImport} from '../import-assets';
-import type {ComboboxValue} from '../NewComposition/ComboBox';
-import {Combobox} from '../NewComposition/ComboBox';
-import {showNotification} from '../Notifications/NotificationCenter';
-import {useStaticFiles} from '../use-static-files';
+import {ModalsContext} from '../../state/modals';
+import {Button} from '../Button';
 
-const comboboxStyle: React.CSSProperties = {
+const buttonStyle: React.CSSProperties = {
 	marginLeft: 8,
-	maxWidth: 180,
 };
 
-const remoteAssetStyle: React.CSSProperties = {
-	display: 'inline-block',
-	marginLeft: 8,
-	maxWidth: 180,
-	overflow: 'hidden',
-	textOverflow: 'ellipsis',
-	verticalAlign: 'middle',
-	whiteSpace: 'nowrap',
-};
+export const AssetSelectionInitialQueryContext = createContext('');
 
-const toFileToken = (name: string) => {
+export const toFileToken = (name: string) => {
 	return `${NoReactInternals.FILE_TOKEN}${name
 		.split('/')
 		.map(encodeURIComponent)
 		.join('/')}`;
-};
-
-const toStaticFileUrl = (fileToken: string) => {
-	return `${window.remotion_staticBase}/${fileToken.slice(
-		NoReactInternals.FILE_TOKEN.length,
-	)}`;
 };
 
 type TimelineAssetFieldProps = {
@@ -51,24 +31,23 @@ type TimelineAssetFieldProps = {
 	readonly onDragEnd: () => void;
 };
 
-export const isStaticFileAssetValue = (value: unknown): value is string => {
-	return (
-		typeof value === 'string' && value.startsWith(NoReactInternals.FILE_TOKEN)
-	);
-};
-
-const TimelineStaticFileAssetField: React.FC<TimelineAssetFieldProps> = ({
+export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
+	field,
 	propStatus,
-	effectiveValue,
 	onSave,
 	onDragValueChange,
 	onDragEnd,
 }) => {
-	const staticFiles = useStaticFiles();
-	const current = String(effectiveValue ?? '');
+	if (field.fieldSchema.type !== 'asset') {
+		throw new Error('TimelineAssetField rendered for non-asset field');
+	}
+
+	const {setSelectedModal} = useContext(ModalsContext);
+	const initialQuery = useContext(AssetSelectionInitialQueryContext);
 
 	const onSelect = useCallback(
-		(sourceValue: string, previewValue: string) => {
+		(assetName: string, previewValue: string) => {
+			const sourceValue = toFileToken(assetName);
 			if (sourceValue === propStatus.codeValue) {
 				return;
 			}
@@ -81,107 +60,27 @@ const TimelineStaticFileAssetField: React.FC<TimelineAssetFieldProps> = ({
 		[propStatus.codeValue, onDragValueChange, onSave, onDragEnd],
 	);
 
-	const upload = useCallback(async () => {
-		const [file] = await pickFilesToImport({multiple: false});
-		if (!file) {
-			return;
-		}
-
-		const existing = staticFiles.find(
-			(candidate) => candidate.name === file.name,
-		);
-		if (existing && existing.sizeInBytes !== file.size) {
-			showNotification(
-				`File with name ${file.name} already exists and is different`,
-				4000,
-			);
-			return;
-		}
-
-		try {
-			if (!existing) {
-				await writeStaticFile({
-					contents: await file.arrayBuffer(),
-					filePath: file.name,
-				});
-			}
-
-			const fileToken = toFileToken(file.name);
-			onSelect(fileToken, toStaticFileUrl(fileToken));
-			if (!existing) {
-				showNotification(`Created ${file.name} in public folder`, 3000);
-			}
-		} catch (error) {
-			showNotification(
-				`Could not upload asset: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-				4000,
-			);
-		}
-	}, [onSelect, staticFiles]);
-
-	const items = useMemo<ComboboxValue[]>(() => {
-		const publicFileItems = staticFiles.map((file): ComboboxValue => {
-			const fileToken = toFileToken(file.name);
-			return {
-				type: 'item',
-				id: fileToken,
-				value: fileToken,
-				label: file.name,
-				onClick: () => onSelect(fileToken, file.src),
-				keyHint: null,
-				leftItem: fileToken === current ? <Checkmark /> : null,
-				subMenu: null,
-				quickSwitcherLabel: null,
-			};
-		});
-		return [
-			...publicFileItems,
-			{type: 'divider', id: 'upload-asset-divider'},
-			{
-				type: 'item',
-				id: 'upload-asset',
-				value: 'upload-asset',
-				label: 'Upload…',
-				onClick: () => {
-					upload().catch(() => undefined);
-				},
-				keyHint: null,
-				leftItem: null,
-				subMenu: null,
-				quickSwitcherLabel: null,
-				disabled: window.remotion_isReadOnlyStudio,
+	const openAssetSelection = useCallback(() => {
+		setSelectedModal({
+			type: 'quick-switcher',
+			mode: 'assets',
+			invocationTimestamp: Date.now(),
+			assetSelection: {
+				initialQuery,
+				onSelected: (asset) => onSelect(asset.name, asset.src),
 			},
-		];
-	}, [current, onSelect, staticFiles, upload]);
+		});
+	}, [initialQuery, onSelect, setSelectedModal]);
 
 	return (
-		<Combobox
-			size="small"
-			title={current}
-			selectedId={current}
-			values={items}
-			style={comboboxStyle}
-		/>
+		<Button
+			onClick={openAssetSelection}
+			disabled={window.remotion_isReadOnlyStudio}
+			size="condensed"
+			style={buttonStyle}
+			title="Change source"
+		>
+			Change
+		</Button>
 	);
-};
-
-export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = (
-	props,
-) => {
-	if (props.field.fieldSchema.type !== 'asset') {
-		throw new Error('TimelineAssetField rendered for non-asset field');
-	}
-
-	if (!isStaticFileAssetValue(props.effectiveValue)) {
-		const remote = String(props.effectiveValue ?? '');
-		return (
-			<span style={remoteAssetStyle} title={remote}>
-				{remote}
-			</span>
-		);
-	}
-
-	return <TimelineStaticFileAssetField {...props} />;
 };

--- a/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
@@ -1,18 +1,10 @@
-import React, {useContext} from 'react';
+import React from 'react';
 import type {SchemaFieldInfo} from '../../helpers/timeline-layout';
 import {
 	timelineFieldValueColumnStyle,
 	timelineStackedFieldContentStyle,
 } from './timeline-field-row-layout';
-import {AssetSelectionContext} from './TimelineAssetField';
 import {TimelineFieldLabel} from './TimelineFieldLabel';
-
-const assetSourceRowStyle: React.CSSProperties = {
-	alignItems: 'center',
-	display: 'flex',
-	flex: 1,
-	minWidth: 0,
-};
 
 export const TimelineFieldRowContent: React.FC<{
 	readonly field: SchemaFieldInfo;
@@ -20,15 +12,6 @@ export const TimelineFieldRowContent: React.FC<{
 	readonly selected: boolean;
 	readonly children: React.ReactNode;
 }> = ({field, rowDepth, selected, children}) => {
-	const {sourceAction} = useContext(AssetSelectionContext);
-	if (
-		field.typeName === 'asset' &&
-		field.key === 'src' &&
-		sourceAction !== null
-	) {
-		return <div style={assetSourceRowStyle}>{children}</div>;
-	}
-
 	const label = (
 		<TimelineFieldLabel
 			rowDepth={rowDepth}

--- a/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
@@ -20,11 +20,11 @@ export const TimelineFieldRowContent: React.FC<{
 	readonly selected: boolean;
 	readonly children: React.ReactNode;
 }> = ({field, rowDepth, selected, children}) => {
-	const {sourceDisplay} = useContext(AssetSelectionContext);
+	const {sourceAction} = useContext(AssetSelectionContext);
 	if (
 		field.typeName === 'asset' &&
 		field.key === 'src' &&
-		sourceDisplay !== null
+		sourceAction !== null
 	) {
 		return <div style={assetSourceRowStyle}>{children}</div>;
 	}

--- a/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import type {SchemaFieldInfo} from '../../helpers/timeline-layout';
 import {
 	timelineFieldValueColumnStyle,
 	timelineStackedFieldContentStyle,
 } from './timeline-field-row-layout';
+import {AssetSelectionContext} from './TimelineAssetField';
 import {TimelineFieldLabel} from './TimelineFieldLabel';
+
+const assetSourceRowStyle: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	flex: 1,
+	minWidth: 0,
+};
 
 export const TimelineFieldRowContent: React.FC<{
 	readonly field: SchemaFieldInfo;
@@ -12,6 +20,15 @@ export const TimelineFieldRowContent: React.FC<{
 	readonly selected: boolean;
 	readonly children: React.ReactNode;
 }> = ({field, rowDepth, selected, children}) => {
+	const {sourceDisplay} = useContext(AssetSelectionContext);
+	if (
+		field.typeName === 'asset' &&
+		field.key === 'src' &&
+		sourceDisplay !== null
+	) {
+		return <div style={assetSourceRowStyle}>{children}</div>;
+	}
+
 	const label = (
 		<TimelineFieldLabel
 			rowDepth={rowDepth}

--- a/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePrimitiveFieldValue.tsx
@@ -27,6 +27,13 @@ const inlineWrapper: React.CSSProperties = {
 	fontSize: 12,
 };
 
+const assetInlineWrapper: React.CSSProperties = {
+	...inlineWrapper,
+	display: 'flex',
+	flex: 1,
+	minWidth: 0,
+};
+
 export type TimelinePrimitiveFieldInfo = Omit<
 	SchemaFieldInfo,
 	'fieldSchema' | 'typeName'
@@ -230,7 +237,7 @@ export const TimelinePrimitiveFieldValue: React.FC<{
 
 	if (field.typeName === 'asset') {
 		return (
-			<span style={inlineWrapper}>
+			<span style={assetInlineWrapper}>
 				<TimelineAssetField
 					effectiveValue={effectiveValue}
 					field={field}

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -21,6 +21,7 @@ import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {callAddSequenceKeyframe} from './call-add-keyframe';
 import {getAnimationItemSelectionForSourceFrame} from './get-animation-item-selection-for-frame';
 import {saveSequenceProps} from './save-sequence-prop';
+import {AssetSelectionContext} from './TimelineAssetField';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineFieldRowContent} from './TimelineFieldRowContent';
 import {
@@ -42,6 +43,11 @@ import {
 import {canEditEasingForInterpolationFunction} from './update-selected-easing';
 
 const fieldRowBase: React.CSSProperties = {};
+
+const inlineSourceFieldRow: React.CSSProperties = {
+	alignItems: 'stretch',
+	display: 'flex',
+};
 
 const isKeyframedStatus = (
 	status: CanUpdateSequencePropStatus,
@@ -307,6 +313,7 @@ export const TimelineSequencePropItem: React.FC<{
 	);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {sourceAction} = useContext(AssetSelectionContext);
 	const selection = useTimelineRowSelection(nodePathInfo);
 	const {selectItems} = useTimelineSelection();
 	const setFrame = Internals.useTimelineSetFrame();
@@ -558,6 +565,24 @@ export const TimelineSequencePropItem: React.FC<{
 	) : (
 		<TimelineNonEditableStatus propStatus={propStatus} />
 	);
+
+	if (
+		field.typeName === 'asset' &&
+		field.key === 'src' &&
+		sourceAction !== null
+	) {
+		return (
+			<div style={{...inlineSourceFieldRow, ...style}}>
+				<TimelineFieldRowContent
+					field={field}
+					rowDepth={rowDepth}
+					selected={false}
+				>
+					{fieldValue}
+				</TimelineFieldRowContent>
+			</div>
+		);
+	}
 
 	const row = (
 		<TimelineRowChrome

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -21,7 +21,6 @@ import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {callAddSequenceKeyframe} from './call-add-keyframe';
 import {getAnimationItemSelectionForSourceFrame} from './get-animation-item-selection-for-frame';
 import {saveSequenceProps} from './save-sequence-prop';
-import {AssetSelectionContext} from './TimelineAssetField';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineFieldRowContent} from './TimelineFieldRowContent';
 import {
@@ -47,6 +46,8 @@ const fieldRowBase: React.CSSProperties = {};
 const inlineSourceFieldRow: React.CSSProperties = {
 	alignItems: 'stretch',
 	display: 'flex',
+	minWidth: 0,
+	width: '100%',
 };
 
 const isKeyframedStatus = (
@@ -313,7 +314,6 @@ export const TimelineSequencePropItem: React.FC<{
 	);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
-	const {sourceAction} = useContext(AssetSelectionContext);
 	const selection = useTimelineRowSelection(nodePathInfo);
 	const {selectItems} = useTimelineSelection();
 	const setFrame = Internals.useTimelineSetFrame();
@@ -566,22 +566,8 @@ export const TimelineSequencePropItem: React.FC<{
 		<TimelineNonEditableStatus propStatus={propStatus} />
 	);
 
-	if (
-		field.typeName === 'asset' &&
-		field.key === 'src' &&
-		sourceAction !== null
-	) {
-		return (
-			<div style={{...inlineSourceFieldRow, ...style}}>
-				<TimelineFieldRowContent
-					field={field}
-					rowDepth={rowDepth}
-					selected={false}
-				>
-					{fieldValue}
-				</TimelineFieldRowContent>
-			</div>
-		);
+	if (field.typeName === 'asset' && field.key === 'src') {
+		return <div style={{...inlineSourceFieldRow, ...style}}>{fieldValue}</div>;
 	}
 
 	const row = (

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -17,6 +17,7 @@ import type {
 	TimelineFieldOnSave,
 } from '../../helpers/timeline-layout';
 import {ContextMenu} from '../ContextMenu';
+import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {callAddSequenceKeyframe} from './call-add-keyframe';
 import {getAnimationItemSelectionForSourceFrame} from './get-animation-item-selection-for-frame';
@@ -48,6 +49,11 @@ const inlineSourceFieldRow: React.CSSProperties = {
 	display: 'flex',
 	minWidth: 0,
 	width: '100%',
+};
+
+const computedSourceFieldRow: React.CSSProperties = {
+	boxSizing: 'border-box',
+	paddingInline: INSPECTOR_PANEL_HORIZONTAL_PADDING,
 };
 
 const isKeyframedStatus = (
@@ -567,7 +573,17 @@ export const TimelineSequencePropItem: React.FC<{
 	);
 
 	if (field.typeName === 'asset' && field.key === 'src') {
-		return <div style={{...inlineSourceFieldRow, ...style}}>{fieldValue}</div>;
+		return (
+			<div
+				style={{
+					...inlineSourceFieldRow,
+					...(propStatus.status === 'computed' ? computedSourceFieldRow : null),
+					...style,
+				}}
+			>
+				{fieldValue}
+			</div>
+		);
 	}
 
 	const row = (

--- a/packages/studio/src/components/Timeline/timeline-asset-link.ts
+++ b/packages/studio/src/components/Timeline/timeline-asset-link.ts
@@ -1,5 +1,6 @@
 import {getAssetSchemaKeys} from '@remotion/studio-shared';
 import type {SequenceControls} from 'remotion';
+import {NoReactInternals} from 'remotion/no-react';
 import {pushUrl} from '../../helpers/url-state';
 
 type LinkInfo =
@@ -48,6 +49,22 @@ export const getTimelineAssetSrcFromSchema = (
 };
 
 export const getTimelineAssetLinkInfo = (src: string): LinkInfo => {
+	if (src.startsWith(NoReactInternals.FILE_TOKEN)) {
+		const encodedAssetPath = src.slice(NoReactInternals.FILE_TOKEN.length);
+		let assetPath = encodedAssetPath;
+		try {
+			assetPath = encodedAssetPath.split('/').map(decodeURIComponent).join('/');
+		} catch {
+			// Keep the encoded path if it contains an invalid escape sequence.
+		}
+
+		return {
+			kind: 'local',
+			assetPath,
+			title: assetPath,
+		};
+	}
+
 	const staticBase =
 		typeof window === 'undefined' ? null : window.remotion_staticBase;
 

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -689,6 +689,7 @@ export const useMenuStructure = (
 								type: 'quick-switcher',
 								mode: 'compositions',
 								invocationTimestamp: Date.now(),
+								assetSelection: null,
 							});
 						},
 						type: 'item' as const,
@@ -872,6 +873,7 @@ export const useMenuStructure = (
 								type: 'quick-switcher',
 								mode: 'docs',
 								invocationTimestamp: Date.now(),
+								assetSelection: null,
 							});
 						},
 						keyHint: '?',

--- a/packages/studio/src/icons/pen.tsx
+++ b/packages/studio/src/icons/pen.tsx
@@ -1,0 +1,17 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+export const PenIcon: React.FC<
+	SVGProps<SVGSVGElement> & {
+		readonly color: string;
+	}
+> = ({color, ...props}) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
+			<path
+				fill={color}
+				d="M18.7 2.3a1 1 0 0 0-1.4 0L5.2 14.4a1 1 0 0 0-.26.46l-1.4 4.95a.5.5 0 0 0 .62.62l4.95-1.4a1 1 0 0 0 .46-.26L21.7 6.7a1 1 0 0 0 0-1.4l-3-3Zm-10.33 14.9-2.4.68.68-2.4L15.5 6.62l1.73 1.73-8.86 8.85Zm10.28-10.27L16.92 5.2 18 4.12l1.73 1.73-1.08 1.08Z"
+			/>
+		</svg>
+	);
+};

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -24,6 +24,7 @@ import type {
 import type React from 'react';
 import {createContext} from 'react';
 import type {SequencePropsSubscriptionKey, _InternalTypes} from 'remotion';
+import type {StaticFile} from '../api/get-static-files';
 import type {CompType} from '../components/NewComposition/DuplicateComposition';
 import type {QuickSwitcherMode} from '../components/QuickSwitcher/NoResults';
 import type {RenderType} from '../components/RenderModal/RenderModalAdvanced';
@@ -201,6 +202,10 @@ export type ModalState =
 			type: 'quick-switcher';
 			mode: QuickSwitcherMode;
 			invocationTimestamp: number;
+			assetSelection?: {
+				initialQuery: string;
+				onSelected: (asset: StaticFile) => void;
+			};
 	  }
 	| AddEffectModalState
 	| ConfirmationDialogState

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -202,10 +202,10 @@ export type ModalState =
 			type: 'quick-switcher';
 			mode: QuickSwitcherMode;
 			invocationTimestamp: number;
-			assetSelection?: {
+			assetSelection: {
 				initialQuery: string;
 				onSelected: (asset: StaticFile) => void;
-			};
+			} | null;
 	  }
 	| AddEffectModalState
 	| ConfirmationDialogState

--- a/packages/studio/src/test/quick-switcher-asset-search.test.ts
+++ b/packages/studio/src/test/quick-switcher-asset-search.test.ts
@@ -1,6 +1,9 @@
 import {expect, test} from 'bun:test';
 import type {StaticFile} from '../api/get-static-files';
-import {filterAssetsByType} from '../components/QuickSwitcher/asset-search';
+import {
+	filterAssetsByType,
+	getAssetSearchQueryForComponent,
+} from '../components/QuickSwitcher/asset-search';
 
 const assets: StaticFile[] = [
 	{
@@ -56,4 +59,21 @@ test('returns no assets for an unknown asset type', () => {
 
 	expect(result.query).toBe('');
 	expect(result.assets).toEqual([]);
+});
+
+test('gets an asset type query for interactive media components', () => {
+	expect(getAssetSearchQueryForComponent('dev.remotion.media.Video')).toBe(
+		'type:video',
+	);
+	expect(getAssetSearchQueryForComponent('dev.remotion.media.Audio')).toBe(
+		'type:audio',
+	);
+	expect(getAssetSearchQueryForComponent('dev.remotion.remotion.Img')).toBe(
+		'type:image',
+	);
+	expect(
+		getAssetSearchQueryForComponent('dev.remotion.remotion.AnimatedImage'),
+	).toBe('type:image');
+	expect(getAssetSearchQueryForComponent('com.example.Custom')).toBe('');
+	expect(getAssetSearchQueryForComponent(null)).toBe('');
 });

--- a/packages/studio/src/test/quick-switcher-asset-search.test.ts
+++ b/packages/studio/src/test/quick-switcher-asset-search.test.ts
@@ -63,17 +63,17 @@ test('returns no assets for an unknown asset type', () => {
 
 test('gets an asset type query for interactive media components', () => {
 	expect(getAssetSearchQueryForComponent('dev.remotion.media.Video')).toBe(
-		'type:video',
+		'type:video ',
 	);
 	expect(getAssetSearchQueryForComponent('dev.remotion.media.Audio')).toBe(
-		'type:audio',
+		'type:audio ',
 	);
 	expect(getAssetSearchQueryForComponent('dev.remotion.remotion.Img')).toBe(
-		'type:image',
+		'type:image ',
 	);
 	expect(
 		getAssetSearchQueryForComponent('dev.remotion.remotion.AnimatedImage'),
-	).toBe('type:image');
+	).toBe('type:image ');
 	expect(getAssetSearchQueryForComponent('com.example.Custom')).toBe('');
 	expect(getAssetSearchQueryForComponent(null)).toBe('');
 });

--- a/packages/studio/src/test/timeline-video-info.test.ts
+++ b/packages/studio/src/test/timeline-video-info.test.ts
@@ -256,6 +256,16 @@ test('asset selections serialize to staticFile source tokens', () => {
 	);
 });
 
+test('timeline asset links resolve staticFile source tokens', () => {
+	expect(
+		getTimelineAssetLinkInfo('remotion-file:folder%20name/video%20%231.mp4'),
+	).toEqual({
+		kind: 'local',
+		assetPath: 'folder name/video #1.mp4',
+		title: 'folder name/video #1.mp4',
+	});
+});
+
 test('timeline local asset links select the asset and push the asset route', () => {
 	const pushedUrls: (string | URL | null | undefined)[] = [];
 	installTestWindow({

--- a/packages/studio/src/test/timeline-video-info.test.ts
+++ b/packages/studio/src/test/timeline-video-info.test.ts
@@ -10,7 +10,7 @@ import {
 	splitRemoteSourceForMiddleEllipsis,
 } from '../components/Timeline/timeline-asset-link';
 import {getTimelineVideoFilmstripTimes} from '../components/Timeline/timeline-video-filmstrip-times';
-import {isStaticFileAssetValue} from '../components/Timeline/TimelineAssetField';
+import {toFileToken} from '../components/Timeline/TimelineAssetField';
 import {isVideoWithLastFrameHold} from '../helpers/is-video-with-last-frame-hold';
 
 type TestWindow = Pick<
@@ -249,11 +249,11 @@ test('inspector ignores runtime src values without a src asset schema', () => {
 	expect(getTimelineAssetSrcFromSchema(null)).toBeNull();
 });
 
-test('only staticFile asset values use the asset picker', () => {
-	expect(isStaticFileAssetValue('remotion-file:video.mp4')).toBe(true);
-	expect(isStaticFileAssetValue('https://example.com/video.mp4')).toBe(false);
-	expect(isStaticFileAssetValue('/video.mp4')).toBe(false);
-	expect(isStaticFileAssetValue(undefined)).toBe(false);
+test('asset selections serialize to staticFile source tokens', () => {
+	expect(toFileToken('video.mp4')).toBe('remotion-file:video.mp4');
+	expect(toFileToken('folder name/video #1.mp4')).toBe(
+		'remotion-file:folder%20name/video%20%231.mp4',
+	);
 });
 
 test('timeline local asset links select the asset and push the asset route', () => {


### PR DESCRIPTION
## Summary

- add a Change action for interactive media sources in the Studio inspector
- open the asset quick switcher in a replacement-only mode with component-specific type filters
- save selected public assets back to source as `staticFile()` values

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
- verified the Video source replacement flow in the local Studio

Closes #8626
