### PR TITLE
`@remotion/lambda-ruby`: Bump Bundler version

### DIFF
--- a/packages/lambda-ruby/Gemfile.lock
+++ b/packages/lambda-ruby/Gemfile.lock
@@ -26,4 +26,4 @@ DEPENDENCIES
   logger (= 1.6.1)
 
 BUNDLED WITH
-   2.1.4
+   2.6.9


### PR DESCRIPTION
## Summary

- bump the Lambda Ruby lockfile from Bundler 2.1.4 to 2.6.9
- allow Ruby 3.3 to select a compatible Bundler version without an environment override

## Test plan

- `bundle install` in `packages/lambda-ruby` with Ruby 3.3.8 and no `BUNDLER_VERSION` override
- `bun test src/monorepo` in `packages/it-tests`
- `bun run build`
- `bun run stylecheck`

Closes #9589
