### PR TITLE
`@remotion/studio`: Move layout controls into own section

### DIFF
--- a/packages/studio-server/src/test/discriminated-union-update.test.ts
+++ b/packages/studio-server/src/test/discriminated-union-update.test.ts
@@ -45,8 +45,6 @@ test('Should expose absolute-fill variant fields when active', () => {
 		getDragOverrides: () => ({}),
 	});
 	expect(schemaFields?.map((s) => s.key)).toEqual([
-		'layout',
-		'premountFor',
 		'style.transformOrigin',
 		'style.translate',
 		'style.scale',
@@ -60,6 +58,8 @@ test('Should expose absolute-fill variant fields when active', () => {
 		'cropRight',
 		'cropTop',
 		'cropBottom',
+		'layout',
+		'premountFor',
 	]);
 });
 

--- a/packages/studio-shared/src/schema-field-info.ts
+++ b/packages/studio-shared/src/schema-field-info.ts
@@ -48,7 +48,8 @@ export type SchemaFieldGroup =
 	| 'background'
 	| 'border'
 	| 'crop'
-	| 'text';
+	| 'text'
+	| 'layout';
 
 export type SchemaFieldGroupInfo = {
 	readonly id: SchemaFieldGroup;
@@ -63,6 +64,7 @@ export const SCHEMA_FIELD_GROUPS = [
 	{id: 'background', label: 'Background'},
 	{id: 'border', label: 'Border'},
 	{id: 'crop', label: 'Crop'},
+	{id: 'layout', label: 'Layout'},
 ] as const satisfies readonly SchemaFieldGroupInfo[];
 
 const schemaFieldGroupOrder = SCHEMA_FIELD_GROUPS.reduce(
@@ -96,6 +98,8 @@ const BORDER_FIELD_KEYS = new Set([
 
 const BACKGROUND_FIELD_KEYS = new Set(['style.backgroundColor']);
 
+const LAYOUT_FIELD_KEYS = new Set(['layout', 'premountFor']);
+
 const TEXT_FIELD_KEYS = new Set([
 	'children',
 	'style.color',
@@ -127,6 +131,10 @@ export const getSchemaFieldGroup = (key: string): SchemaFieldGroup => {
 
 	if (BACKGROUND_FIELD_KEYS.has(key)) {
 		return 'background';
+	}
+
+	if (LAYOUT_FIELD_KEYS.has(key)) {
+		return 'layout';
 	}
 
 	if (TEXT_FIELD_KEYS.has(key)) {

--- a/packages/studio-shared/src/test/schema-field-info.test.ts
+++ b/packages/studio-shared/src/test/schema-field-info.test.ts
@@ -231,6 +231,19 @@ test('getFieldsToShow sorts fields by inspector group order', () => {
 				default: 1,
 				hiddenFromList: false,
 			},
+			layout: {
+				type: 'enum',
+				default: 'absolute-fill',
+				variants: {
+					'absolute-fill': {},
+					none: {},
+				},
+			},
+			premountFor: {
+				type: 'number',
+				default: 0,
+				hiddenFromList: false,
+			},
 			'style.letterSpacing': {
 				type: 'number',
 				default: undefined,
@@ -268,6 +281,8 @@ test('getFieldsToShow sorts fields by inspector group order', () => {
 		'style.borderStyle',
 		'style.borderColor',
 		'cropLeft',
+		'layout',
+		'premountFor',
 	]);
 	expect(fields?.map((field) => field.group)).toEqual([
 		'source',
@@ -286,6 +301,8 @@ test('getFieldsToShow sorts fields by inspector group order', () => {
 		'border',
 		'border',
 		'crop',
+		'layout',
+		'layout',
 	]);
 });
 
@@ -293,6 +310,13 @@ test('groups Sequence crop controls into the Crop inspector section', () => {
 	expect(
 		['cropLeft', 'cropRight', 'cropTop', 'cropBottom'].map(getSchemaFieldGroup),
 	).toEqual(['crop', 'crop', 'crop', 'crop']);
+});
+
+test('groups Sequence layout controls into the final Layout inspector section', () => {
+	expect(['layout', 'premountFor'].map(getSchemaFieldGroup)).toEqual([
+		'layout',
+		'layout',
+	]);
 });
 
 test('getFieldsToShow does not reserve extra height for text content fields', () => {

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -348,6 +348,10 @@ export const InspectorSequenceSection: React.FC<{
 		() => getInspectorControlGroups(controlRows),
 		[controlRows],
 	);
+	const layoutGroup = controlGroups.find((group) => group.id === 'layout');
+	const controlGroupsWithoutLayout = controlGroups.filter(
+		(group) => group.id !== 'layout',
+	);
 
 	const {schema} = sequence.controls;
 	const showEffectsSection =
@@ -426,7 +430,7 @@ export const InspectorSequenceSection: React.FC<{
 			<div style={container}>
 				{controlRows.length > 0 ? (
 					<TimelineSelectionOrderProvider items={controlSelectableItems}>
-						{controlGroups.map((group) => (
+						{controlGroupsWithoutLayout.map((group) => (
 							<InspectorSection key={group.id} header={group.label}>
 								{group.id === 'transforms' ? renderTransformControls() : null}
 								{group.rows.map(renderRow)}
@@ -442,6 +446,13 @@ export const InspectorSequenceSection: React.FC<{
 							</TimelineSelectionOrderProvider>
 						) : null}
 					</InspectorSection>
+				) : null}
+				{layoutGroup ? (
+					<TimelineSelectionOrderProvider items={controlSelectableItems}>
+						<InspectorSection header={layoutGroup.label}>
+							{layoutGroup.rows.map(renderRow)}
+						</InspectorSection>
+					</TimelineSelectionOrderProvider>
 				) : null}
 			</div>
 		</AssetSelectionContext.Provider>


### PR DESCRIPTION
## Summary

- Add a dedicated Layout group for the Sequence Inspector
- Move the `layout` and `premountFor` controls into it
- Keep Layout as the final property section, after Effects

## Testing

- `bun test packages/studio-shared/src/test/schema-field-info.test.ts`
- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`

Closes #9681
