### PR TITLE
Docs: Deprecate @remotion/light-leaks in documentation

### DIFF
--- a/packages/docs/docs/light-leaks/index.mdx
+++ b/packages/docs/docs/light-leaks/index.mdx
@@ -7,6 +7,10 @@ title: '@remotion/light-leaks'
 
 # @remotion/light-leaks<AvailableFrom v="4.0.415" />
 
+:::warning Deprecated
+`@remotion/light-leaks` is deprecated and will no longer be published starting with Remotion 5.0. The `lightLeak()` effect will move to `@remotion/effects`. The `<LightLeak>` component will not be moved to `@remotion/effects`.
+:::
+
 Light leak effects for Remotion videos.
 
 import {TableOfContents} from './table-of-contents';

--- a/packages/docs/docs/light-leaks/light-leak-effect.mdx
+++ b/packages/docs/docs/light-leaks/light-leak-effect.mdx
@@ -8,6 +8,10 @@ crumb: '@remotion/light-leaks'
 
 # lightLeak()<AvailableFrom v="4.0.468" />
 
+:::warning Deprecated
+`@remotion/light-leaks` is deprecated and will no longer be published starting with Remotion 5.0. The `lightLeak()` effect will move to `@remotion/effects`.
+:::
+
 _Part of the [`@remotion/light-leaks`](/docs/light-leaks/api) package._
 
 Applies a WebGL2-based light leak effect to canvas-based components such as [`<Video>`](/docs/media/video), [`<CanvasImage>`](/docs/canvasimage) and [`<Solid>`](/docs/solid).

--- a/packages/docs/docs/light-leaks/light-leak.mdx
+++ b/packages/docs/docs/light-leaks/light-leak.mdx
@@ -6,6 +6,10 @@ crumb: '@remotion/light-leaks'
 
 # &lt;LightLeak&gt;<AvailableFrom v="4.0.415" />
 
+:::warning Deprecated
+`@remotion/light-leaks` is deprecated and will no longer be published starting with Remotion 5.0. The `lightLeak()` effect will move to `@remotion/effects`. The `<LightLeak>` component will not be moved to `@remotion/effects`.
+:::
+
 Renders a WebGL-based light leak effect.  
 The effect reveals during the first half of the duration and retracts during the second half.  
 Is a [`<Sequence>`](/docs/sequence) component under the hood and accepts it's props.


### PR DESCRIPTION
## Problem

Maintainer issue #9666 asks for Remotion 5.0 deprecation notices on the legacy `@remotion/light-leaks` documentation. The matching `@remotion/starburst` notices already landed in #9677; the light-leaks API pages still had no warning.

## Triage / Root cause

`packages/docs/docs/light-leaks/index.mdx`, `light-leak.mdx`, and `light-leak-effect.mdx` were missing the `:::warning Deprecated` blocks that the starburst package pages received during the effects migration.

## Fix

- Add deprecation notices to the `@remotion/light-leaks` package index, `<LightLeak>`, and `lightLeak()` pages.
- Mirror the starburst wording: package stops publishing in v5, `lightLeak()` will move to `@remotion/effects`, and `<LightLeak>` will not move.
- Leave the existing 4.x examples intact for users still on the legacy package.

## Verification

- `bun run formatting` in `packages/docs` — passed.
- Pre-commit docs format hook — passed on commit.
- Full monorepo `bun run stylecheck` fails locally on a pre-existing `@remotion/starburst#make` TS2307 (`@remotion/effects/starburst` resolution) unrelated to this docs-only diff; CI on prior docs PRs has been green.

## Notes / Risks

- The `@remotion/effects` light-leak API page does not exist yet (#9665); notices say the effect *will move* to `@remotion/effects` rather than linking a non-existent page. A follow-up can add the link after the code migration lands.
- Complements open #9627 (cloud GPU Docker Node 22); separate file/scope.

Closes #9666

Made with [Cursor](https://cursor.com)