### PR TITLE
`@remotion/studio`: Clip overflowing timeline keyframes

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -12,6 +12,7 @@ import {
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
 const row: React.CSSProperties = {
+	overflow: 'hidden',
 	position: 'relative',
 };
 


### PR DESCRIPTION
## Summary

- clip keyframes and easing curves that extend beyond the composition timeline
- keep out-of-range keyframes in the rendering data while hiding only their overflowing visuals

## Verification

- reproduced and verified the fix in the `switzerland-map` composition
- `bun run build`
- `bun run stylecheck`
- `bun test src` in `packages/studio` (524 tests)

Closes #9585
